### PR TITLE
Fix Mantis 2997: Make +Bitmap a required table item if a weapon trail has been set.

### DIFF
--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -1855,7 +1855,7 @@ int parse_weapon(int subtype, bool replace)
 			ti->stamp = fl2i(1000.0f*ti->max_life)/(NUM_TRAIL_SECTIONS+1);
 		}
 
-		if ( optional_string("+Bitmap:") ) {
+		if ( required_string("+Bitmap:") ) {
 			stuff_string(fname, F_NAME, NAME_LENGTH);
 			generic_bitmap_init(&ti->texture, fname);
 		}


### PR DESCRIPTION
See http://scp.indiegames.us/mantis/view.php?id=2997
