### PR TITLE
Fix for Coverity 1107329

### DIFF
--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -6014,6 +6014,11 @@ int check_ok_to_fire(int objnum, int target_objnum, weapon_info *wip)
 			}
 		}
 	}
+	else
+	{
+		// We have no valid target object, we should not fire at it...
+		return 0;
+	}
 
 	return 1;
 }


### PR DESCRIPTION
I'm not sure if it's ok to return false in `check_ok_to_fire` but it seems to be logical if we have no target object.
