### PR TITLE
LUA access to campaign next & prev mission (requested by Axem)

### DIFF
--- a/code/parse/lua.cpp
+++ b/code/parse/lua.cpp
@@ -14402,7 +14402,7 @@ ADE_FUNC(getNextMissionFilename, l_Campaign, NULL, "Gets next mission filename",
 	return ade_set_args(L, "s", Campaign.missions[Campaign.next_mission].name);
 }
 
-ADE_FUNC(getPrevMissionFilename, l_Campaign, NULL, "Gets previous mission filename", "string", "Previous mission filename, or nil if the next mission is invalid")
+ADE_FUNC(getPrevMissionFilename, l_Campaign, NULL, "Gets previous mission filename", "string", "Previous mission filename, or nil if the previous mission is invalid")
 {
 	if (Campaign.prev_mission < 0 || Campaign.prev_mission >= MAX_CAMPAIGN_MISSIONS) {
 		return ADE_RETURN_NIL;
@@ -14410,18 +14410,8 @@ ADE_FUNC(getPrevMissionFilename, l_Campaign, NULL, "Gets previous mission filena
 	return ade_set_args(L, "s", Campaign.missions[Campaign.prev_mission].name);
 }
 
-ADE_FUNC(getAnyMissionFilename, l_Campaign, "mission index", "Gets the specified mission filename", "string", "Next mission filename, or nil if input was invalid")
-{
-	int idx;
-	if (!ade_get_args(L, "i", &idx)) {
-		return ADE_RETURN_NIL;
-	}
-
-	if (idx < 0 || idx >= MAX_CAMPAIGN_MISSIONS) {
-		return ADE_RETURN_NIL;
-	}
-	return ade_set_args(L, "s", Campaign.missions[idx].name);
-}
+// TODO: add a proper indexer type that returns a handle
+// something like ca.Mission[filename/index]
 
 //****SUBLIBRARY: Mission/Wings
 ade_lib l_Mission_Wings("Wings", &l_Mission, NULL, NULL);


### PR DESCRIPTION
This is pretty simple, two new LUA functions in a new library to provide access to the next/prev campaign mission filenames. Associated with the Journal/System Viewer.

These will return valid values in more states than mn.getMissionFilename() (in fact the only times it won't work are when there's no campaigns available at all, of if the campaign has ended)
