### PR TITLE
Fix for Mantis 3045: gr.drawImage()'s UV arguments aren't working properly

### DIFF
--- a/code/graphics/tmapper.h
+++ b/code/graphics/tmapper.h
@@ -109,11 +109,11 @@ struct bitmap_2d_list{
 //from 0,0 in the upper left to 1,1 in the lowwer right
 //out of range values are valid
 struct texture_rect_list{
-	texture_rect_list(float X=0, float Y=0, float W=1.0f, float H=1.0f):x(X),y(Y),w(W),h(H){}
-	float x;
-	float y;
-	float w;
-	float h;
+	texture_rect_list(float u0In=0.0f, float v0In=0.0f, float u1In=1.0f, float v1In=1.0f):u0(u0In),v0(v0In),u1(u1In),v1(v1In){}
+	float u0;
+	float v0;
+	float u1;
+	float v1;
 };
 
 struct bitmap_rect_list{

--- a/code/render/3ddraw.cpp
+++ b/code/render/3ddraw.cpp
@@ -1909,8 +1909,8 @@ int g3_draw_2d_poly_bitmap_rect_list(bitmap_rect_list* b_list, int n_bm, uint ad
 		V->screen.xyw.x = (float)b->x;
 		V->screen.xyw.y = (float)b->y;	
 		V->screen.xyw.w = 0.0f;
-		V->texture_position.u = (float)t->x;
-		V->texture_position.v = (float)t->y;
+		V->texture_position.u = (float)t->u0;
+		V->texture_position.v = (float)t->v0;
 		V->flags = PF_PROJECTED;
 		V->codes = 0;
 
@@ -1918,8 +1918,8 @@ int g3_draw_2d_poly_bitmap_rect_list(bitmap_rect_list* b_list, int n_bm, uint ad
 		V->screen.xyw.x = (float)(b->x + b->w);
 		V->screen.xyw.y = (float)b->y;	
 		V->screen.xyw.w = 0.0f;
-		V->texture_position.u = (float)(t->x + t->w);
-		V->texture_position.v = (float)t->y;
+		V->texture_position.u = (float)t->u1;
+		V->texture_position.v = (float)t->v0;
 		V->flags = PF_PROJECTED;
 		V->codes = 0;
 
@@ -1927,8 +1927,8 @@ int g3_draw_2d_poly_bitmap_rect_list(bitmap_rect_list* b_list, int n_bm, uint ad
 		V->screen.xyw.x = (float)(b->x + b->w);
 		V->screen.xyw.y = (float)(b->y + b->h);	
 		V->screen.xyw.w = 0.0f;
-		V->texture_position.u = (float)(t->x + t->w);
-		V->texture_position.v = (float)(t->y + t->h);
+		V->texture_position.u = (float)t->u1;
+		V->texture_position.v = (float)t->v1;
 		V->flags = PF_PROJECTED;
 		V->codes = 0;
 	
@@ -1937,8 +1937,8 @@ int g3_draw_2d_poly_bitmap_rect_list(bitmap_rect_list* b_list, int n_bm, uint ad
 		V->screen.xyw.x = (float)b->x;
 		V->screen.xyw.y = (float)b->y;	
 		V->screen.xyw.w = 0.0f;
-		V->texture_position.u = (float)t->x;
-		V->texture_position.v = (float)t->y;
+		V->texture_position.u = (float)t->u0;
+		V->texture_position.v = (float)t->v0;
 		V->flags = PF_PROJECTED;
 		V->codes = 0;
 
@@ -1946,8 +1946,8 @@ int g3_draw_2d_poly_bitmap_rect_list(bitmap_rect_list* b_list, int n_bm, uint ad
 		V->screen.xyw.x = (float)(b->x + b->w);
 		V->screen.xyw.y = (float)(b->y + b->h);	
 		V->screen.xyw.w = 0.0f;
-		V->texture_position.u = (float)(t->x + t->w);
-		V->texture_position.v = (float)(t->y + t->h);
+		V->texture_position.u = (float)t->u1;
+		V->texture_position.v = (float)t->v1;
 		V->flags = PF_PROJECTED;
 		V->codes = 0;
 
@@ -1955,8 +1955,8 @@ int g3_draw_2d_poly_bitmap_rect_list(bitmap_rect_list* b_list, int n_bm, uint ad
 		V->screen.xyw.x = (float)b->x;
 		V->screen.xyw.y = (float)(b->y + b->h);	
 		V->screen.xyw.w = 0.0f;
-		V->texture_position.u = (float)t->x;
-		V->texture_position.v = (float)(t->y + t->h);
+		V->texture_position.u = (float)t->u0;
+		V->texture_position.v = (float)t->v1;
 		V->flags = PF_PROJECTED;
 		V->codes = 0;	
 	}


### PR DESCRIPTION
The g3_draw_2d_poly_bitmap_rect_list was for some reason doing more than necessary which meant that users couldn't flip an image, only crop it although that feature wasn't used anywhere.
