### PR TITLE
Fix mantis 2940

### DIFF
--- a/code/playerman/managepilot.cpp
+++ b/code/playerman/managepilot.cpp
@@ -432,7 +432,11 @@ void player::reset()
 	memset(&ci, 0, sizeof(control_info));
 
 	stats.init();
-	Pilot.reset_stats();
+	// only reset Pilotfile stats if we're resetting Player
+	// remember: multi has many Players...
+	if (Player == this) {
+		Pilot.reset_stats();
+	}
 
 	friendly_hits = 0;
 	friendly_damage = 0.0f;


### PR DESCRIPTION
Only reset pilotfile stats when the local Player is reset.

See here for more info: http://scp.indiegames.us/mantis/view.php?id=2940
