### PR TITLE
Fix mantis 2929

### DIFF
--- a/code/menuui/barracks.cpp
+++ b/code/menuui/barracks.cpp
@@ -909,12 +909,6 @@ void barracks_init_player_stuff(int mode)
 	// determine if we should be looking for single or multiplayers at the outset
 	Player_sel_mode = mode;
 	
-	// get the list of pilots based upon whether we're in single or multiplayer mode
-	Num_pilots = 0;
-	Get_file_list_filter = barracks_pilot_filter;
-
-	Num_pilots = cf_get_file_list_preallocated(MAX_PILOTS, Pilots_arr, Pilots, CF_TYPE_PLAYERS, NOX("*.plr"), CF_SORT_TIME);
-
 	// single player specific stuff
 	if (mode == PLAYER_SELECT_MODE_SINGLE) {
 		Game_mode &= ~GM_MULTIPLAYER;
@@ -939,6 +933,13 @@ void barracks_init_player_stuff(int mode)
 		Buttons[gr_screen.res][B_SQUAD_NEXT_BUTTON].button.enable();
 		Buttons[gr_screen.res][B_SQUAD_NEXT_BUTTON].button.unhide();			
 	}
+
+	// get the list of pilots based upon whether we're in single or multiplayer mode
+	// moved down here so pilotfile::verify knows which Game_mode to get ranks for
+	Num_pilots = 0;
+	Get_file_list_filter = barracks_pilot_filter;
+
+	Num_pilots = cf_get_file_list_preallocated(MAX_PILOTS, Pilots_arr, Pilots, CF_TYPE_PLAYERS, NOX("*.plr"), CF_SORT_TIME);
 
 	int ranks[MAX_PILOTS];
 

--- a/code/pilotfile/csg.cpp
+++ b/code/pilotfile/csg.cpp
@@ -30,6 +30,11 @@ void pilotfile::csg_read_flags()
 {
 	// tips?
 	p->tips = (int)cfread_ubyte(cfp);
+
+	// avoid having to read everything to get the rank
+	if (csg_ver >= 4) {
+		p->stats.rank = cfread_int(cfp);
+	}
 }
 
 void pilotfile::csg_write_flags()
@@ -38,6 +43,9 @@ void pilotfile::csg_write_flags()
 
 	// tips
 	cfwrite_ubyte((ubyte)p->tips, cfp);
+
+	// avoid having to read everything to get the rank
+	cfwrite_int(p->stats.rank, cfp);
 
 	endSection();
 }
@@ -1561,6 +1569,93 @@ bool pilotfile::save_savefile()
 	// Done!
 	mprintf(("CSG => Saving complete!\n"));
 
+	csg_close();
+
+	return true;
+}
+
+/*
+ * get_csg_rank: this function is called from plr.cpp & is
+ * tightly linked with pilotfile::verify()
+ */
+bool pilotfile::get_csg_rank(int *rank)
+{
+	player t_csg;
+
+	// set player ptr first thing
+	p = &t_csg;
+
+	// filename has already been set
+	cfp = cfopen((char*)filename.c_str(), "rb", CFILE_NORMAL, CF_TYPE_PLAYERS);
+
+	if ( !cfp ) {
+		mprintf(("CSG => Unable to open '%s'!\n", filename.c_str()));
+		return false;
+	}
+
+	unsigned int csg_id = cfread_uint(cfp);
+
+	if (csg_id != CSG_FILE_ID) {
+		mprintf(("CSG => Invalid header id for '%s'!\n", filename.c_str()));
+		csg_close();
+		return false;
+	}
+
+	// version, now used
+	csg_ver = cfread_ubyte(cfp);
+
+	mprintf(("CSG => Get Rank from '%s' with version %d...\n", filename.c_str(), (int)csg_ver));
+
+	// the point of all this: read in the CSG contents
+	while ( !m_have_flags && !cfeof(cfp) ) {
+		ushort section_id = cfread_ushort(cfp);
+		uint section_size = cfread_uint(cfp);
+
+		size_t start_pos = cftell(cfp);
+		size_t offset_pos;
+
+		// safety, to help protect against long reads
+		cf_set_max_read_len(cfp, section_size);
+
+		try {
+			switch (section_id) {
+				case Section::Flags:
+					mprintf(("CSG => Parsing:  Flags...\n"));
+					m_have_flags = true;
+					csg_read_flags();
+					break;
+
+				default:
+					break;
+			}
+		} catch (cfile::max_read_length &msg) {
+			// read to max section size, move to next section, discarding
+			// extra/unknown data
+			mprintf(("CSG => (0x%04x) %s\n", section_id, msg.what()));
+		} catch (const char *err) {
+			mprintf(("CSG => ERROR: %s\n", err));
+			csg_close();
+			return false;
+		}
+
+		// reset safety catch
+		cf_set_max_read_len(cfp, 0);
+
+		// skip to next section (if not already there)
+		offset_pos = (start_pos + section_size) - cftell(cfp);
+
+		if (offset_pos) {
+			mprintf(("CSG => Warning: (0x%04x) Short read, information may have been lost!\n", section_id));
+			cfseek(cfp, offset_pos, CF_SEEK_CUR);
+		}
+	}
+
+	// this is what we came for...
+	*rank = p->stats.rank;
+
+	mprintf(("CSG => Get Rank complete!\n"));
+
+	// cleanup & return
 	csg_close();
 
 	return true;

--- a/code/pilotfile/csg_convert.cpp
+++ b/code/pilotfile/csg_convert.cpp
@@ -686,6 +686,9 @@ void pilotfile_convert::csg_export_flags()
 	// tips
 	cfwrite_ubyte((ubyte)plr->tips, cfp);
 
+	// special rank
+	cfwrite_int(csg->stats.rank, cfp);
+
 	endSection();
 }
 

--- a/code/pilotfile/pilotfile.h
+++ b/code/pilotfile/pilotfile.h
@@ -23,7 +23,8 @@ static const ubyte PLR_VERSION = 1;
 //   1 - re-add recent missions
 //   2 - separate single/multi squad name & pic
 //   3 - remove separate detail settings for campaigns
-static const ubyte CSG_VERSION = 3;
+//   4 - save rank to flags for quick access
+static const ubyte CSG_VERSION = 4;
 
 
 class pilotfile {
@@ -212,6 +213,10 @@ class pilotfile {
 		void csg_write_controls();
 		void csg_write_cutscenes();
 		void csg_write_lastmissions();
+
+		// similar to PLR verify, except we only want the rank
+		bool get_csg_rank(int *rank);
+
 };
 
 extern pilotfile Pilot;

--- a/code/pilotfile/plr.cpp
+++ b/code/pilotfile/plr.cpp
@@ -33,6 +33,8 @@ void pilotfile::plr_read_flags()
 	p->auto_advance = cfread_int(cfp);
 
 	// special rank setting (to avoid having to read all stats on verify)
+	// will be the multi rank
+	// if there's a valid CSG, this will be overwritten
 	p->stats.rank = cfread_int(cfp);
 
 	if (version > 0) 
@@ -61,7 +63,8 @@ void pilotfile::plr_write_flags()
 	cfwrite_int(p->auto_advance, cfp);
 
 	// special rank setting (to avoid having to read all stats on verify)
-	cfwrite_int(p->stats.rank, cfp);
+	// should be multi only from now on
+	cfwrite_int(multi_stats.rank, cfp);
 
 	// What game mode we were in last on this pilot
 	cfwrite_int(p->player_was_multi, cfp);
@@ -1026,7 +1029,7 @@ bool pilotfile::verify(const char *fname, int *rank)
 	mprintf(("PLR => Verifying '%s' with version %d...\n", filename.c_str(), (int)plr_ver));
 
 	// the point of all this: read in the PLR contents
-	while ( !m_have_flags && !cfeof(cfp) ) {
+	while ( !(m_have_flags && m_have_info) && !cfeof(cfp) ) {
 		ushort section_id = cfread_ushort(cfp);
 		uint section_size = cfread_uint(cfp);
 
@@ -1041,6 +1044,14 @@ bool pilotfile::verify(const char *fname, int *rank)
 					mprintf(("PLR => Parsing:  Flags...\n"));
 					m_have_flags = true;
 					plr_read_flags();
+					break;
+
+				// now reading the Info section to get the campaign
+				// and be able to lookup the campaign rank
+				case Section::Info:
+					mprintf(("PLR => Parsing:  Info...\n"));
+					m_have_info = true;
+					plr_read_info();
 					break;
 
 				default:
@@ -1068,14 +1079,30 @@ bool pilotfile::verify(const char *fname, int *rank)
 		}
 	}
 
+	// need to cleanup early to ensure everything is OK for use in the CSG next
+	// also means we can't use *p from now on, use t_plr instead for a few vars
+	plr_close();
+
 	if (rank) {
-		*rank = p->stats.rank;
+		// maybe get the rank from the CSG
+		if ( !(Game_mode & GM_MULTIPLAYER) ) {
+			// build the csg filename
+			// since filename/fname was validated above, perform less safety checks here
+			filename = fname;
+			filename = filename.replace(filename.find_last_of('.')+1,filename.npos, t_plr.current_campaign);
+			filename.append(".csg");
+
+			if (!this->get_csg_rank(rank)) {
+				// if we failed to get the csg rank, default to multi rank
+				*rank = t_plr.stats.rank;
+			}
+		} else {
+			// if the CSG isn't valid, or for multi, use this rank
+			*rank = t_plr.stats.rank;
+		}
 	}
 
 	mprintf(("PLR => Verifying complete!\n"));
-
-	// cleanup and return
-	plr_close();
 
 	return true;
 }


### PR DESCRIPTION
Save shortcut rank to the csg flags & bump csg version
Add function to read the csg rank during pilotfile::verify()
Reorder 'find pilots' call so that Game_mode is valid for verify

Mantis here: http://scp.indiegames.us/mantis/view.php?id=2929
