### PR TITLE
Fix mantis 3056

### DIFF
--- a/code/missionui/redalert.cpp
+++ b/code/missionui/redalert.cpp
@@ -460,7 +460,7 @@ void red_alert_store_weapons(red_alert_ship_status *ras, ship_weapon *swp)
 	}
 
 	// edited to accommodate ballistics - Goober5000
-	for (i = 0; i < MAX_SHIP_PRIMARY_BANKS; i++) {
+	for (i = 0; i < swp->num_primary_banks; i++) {
 		weapons.index = swp->primary_bank_weapons[i];
 
 		if (weapons.index < 0) {
@@ -481,7 +481,7 @@ void red_alert_store_weapons(red_alert_ship_status *ras, ship_weapon *swp)
 		ras->primary_weapons.push_back( weapons );
 	}
 
-	for (i = 0; i < MAX_SHIP_SECONDARY_BANKS; i++) {
+	for (i = 0; i < swp->num_secondary_banks; i++) {
 		weapons.index = swp->secondary_bank_weapons[i];
 
 		if (weapons.index < 0) {


### PR DESCRIPTION
In redalert loadout, only store the current number of banks in use by
ships, not all banks where the weapon idx is -1

(note if testing - restarting a campaign from the campaign room DOES NOT reset red-alert data (yes it's another bug) you'll need to manually delete your .csg otherwise that old redalert data will just hang around)
