### PR TITLE
*-argument sexp short-circuiting

### DIFF
--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -8969,11 +8969,16 @@ int eval_for_counter(int arg_handler_node, int condition_node)
 	for (i = counter_start; ((counter_step > 0) ? i <= counter_stop : i >= counter_stop); i += counter_step)
 	{
 		sprintf(buf, "%d", i);
-		argument_vector.push_back(strdup(buf));
+		argument_vector.push_back(vm_strdup(buf));
 	}
 
 	// test the whole argument vector
 	num_valid_arguments = test_argument_vector_for_condition(argument_vector, true, condition_node, &num_true, &num_false, &num_known_true, &num_known_false);
+
+	while (!argument_vector.empty()) {
+		vm_free(argument_vector.back());
+		argument_vector.pop_back();
+	}
 
 	// use the sexp_or algorithm
 	if (num_known_true || num_true)

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -22480,7 +22480,13 @@ int eval_sexp(int cur_node, int referenced_node)
 			add_to_event_log_buffer(get_operator_index(cur_node), SEXP_KNOWN_FALSE);
 		}
 		return SEXP_FALSE;
-	}		
+	}
+	else if (Sexp_nodes[cur_node].value == SEXP_NAN_FOREVER) {
+		if (Log_event) {
+			add_to_event_log_buffer(get_operator_index(cur_node), SEXP_NAN_FOREVER);
+		}
+		return SEXP_FALSE;
+	}
 
 	if (Sexp_nodes[cur_node].first != -1) {
 		node = CAR(cur_node);


### PR DESCRIPTION
Allows *-argument SEXPs to short-circuit by allowing the *-of SEXPs to short-circuit with SEXP_KNOWN_FALSE. See Mantis 3136.