### PR TITLE
Cpp11 support for GCC

### DIFF
--- a/code/globalincs/fsmemory.cpp
+++ b/code/globalincs/fsmemory.cpp
@@ -3,7 +3,11 @@
 
 
 // throw
+#ifdef HAVE_CXX11
+void * operator new (size_t size)
+#else
 void * operator new (size_t size) throw (std::bad_alloc)
+#endif // CPP11_STD
 {
 	void *p = vm_malloc_q(size);
 
@@ -19,7 +23,11 @@ void operator delete (void *p) throw()
 	vm_free(p);
 }
 
+#ifdef HAVE_CXX11
+void * operator new [] (size_t size)
+#else
 void * operator new [] (size_t size) throw (std::bad_alloc)
+#endif // CPP11_STD
 {
 	void *p = vm_malloc_q(size);
 

--- a/code/globalincs/fsmemory.h
+++ b/code/globalincs/fsmemory.h
@@ -4,6 +4,25 @@
 
 #include <new>
 
+#ifdef HAVE_CXX11
+// throw
+extern void * operator new (size_t size);
+
+extern void operator delete (void *p) throw();
+
+extern void * operator new [] (size_t size);
+
+extern void operator delete [] (void *p) throw();
+
+// no-throw
+extern void * operator new (size_t size, const std::nothrow_t&) throw();
+
+extern void operator delete (void *p, const std::nothrow_t&) throw();
+
+extern void * operator new [] (size_t size, const std::nothrow_t&) throw();
+
+extern void operator delete [] (void *p, const std::nothrow_t&) throw();
+#else
 // throw
 extern void * operator new (size_t size) throw (std::bad_alloc);
 
@@ -21,5 +40,6 @@ extern void operator delete (void *p, const std::nothrow_t&) throw();
 extern void * operator new [] (size_t size, const std::nothrow_t&) throw();
 
 extern void operator delete [] (void *p, const std::nothrow_t&) throw();
+#endif
 
 #endif	// _FSMEMORY_H

--- a/code/globalincs/pstypes.h
+++ b/code/globalincs/pstypes.h
@@ -22,6 +22,15 @@
 #define IAM_64BIT 1
 #endif
 
+// C++11 support detection
+// autotools (gcc) uses a feature test to set HAVE_CXX11
+// Use the visual studio version to detect C++11 support
+#if _MSC_VER >= 1600
+#	define HAVE_CXX11
+#endif
+// TODO: add clang c+11 detection/support
+// TODO: sort out cmake/gcc
+
 #include "windows_stub/config.h"
 
 // value to represent an uninitialized state in any int or uint

--- a/code/globalincs/pstypes.h
+++ b/code/globalincs/pstypes.h
@@ -22,14 +22,6 @@
 #define IAM_64BIT 1
 #endif
 
-// C++11 support detection
-// autotools (gcc) uses a feature test to set HAVE_CXX11
-// Use the visual studio version to detect C++11 support
-#if _MSC_VER >= 1600
-#	define HAVE_CXX11
-#endif
-// TODO: add clang c+11 detection/support
-// TODO: sort out cmake/gcc
 
 #include "windows_stub/config.h"
 
@@ -797,6 +789,22 @@ public:
 // c++11 standard detection
 // for GCC with autotools, see AX_CXX_COMPILE_STDCXX_11 macro in configure.ac
 // this sets HAVE_CXX11 & -std=c++0x or -std=c++11 appropriately
+
+// Use the visual studio version to detect C++11 support
+#if _MSC_VER >= 1600
+#	define HAVE_CXX11
+#endif
+// clang doesn't seem to have a feature check for is_trivial
+// oh well, assume it'll be covered by one of the other two checks...
+// http://clang.llvm.org/docs/LanguageExtensions.html#feature_check
+#if defined(__clang__)
+	#if __has_feature(cxx_static_assert)
+		#if __has_feature(cxx_auto_type)
+			#define HAVE_CXX11
+		#endif // __has_feature(cxx_auto_type)
+	#endif // __has_feature(cxx_static_assert)
+#endif // defined(__clang__)
+// TODO: sort out cmake/gcc
 
 // DEBUG compile time catch for dangerous uses of memset/memcpy/memmove
 // would prefer std::is_trivially_copyable but it's not supported by gcc yet

--- a/code/globalincs/pstypes.h
+++ b/code/globalincs/pstypes.h
@@ -785,5 +785,9 @@ public:
 #include "globalincs/vmallocator.h"
 #include "globalincs/safe_strings.h"
 
+// c++11 standard detection
+// for GCC with autotools, see AX_CXX_COMPILE_STDCXX_11 macro in configure.ac
+// this sets HAVE_CXX11 & -std=c++0x or -std=c++11 appropriately
+
 
 #endif		// PS_TYPES_H

--- a/code/globalincs/pstypes.h
+++ b/code/globalincs/pstypes.h
@@ -823,17 +823,17 @@ public:
 	#define memset memset_if_trivial_else_error
 
 	template<typename T>
-	void *memset_if_trivial_else_error(T *data, int ch, size_t count)
+	void *memset_if_trivial_else_error(T *memset_data, int ch, size_t count)
 	{
 		static_assert(std::is_trivial<T>::value, "memset on non-trivial object");
-		return ptr_memset(data, ch, count);
+		return ptr_memset(memset_data, ch, count);
 	}
 
 	// assume memset on a void* is "safe"
 	// only used in cutscene/mveplayer.cpp:mve_video_createbuf()
-	inline void *memset_if_trivial_else_error(void *data, int ch, size_t count)
+	inline void *memset_if_trivial_else_error(void *memset_data, int ch, size_t count)
 	{
-		return ptr_memset(data, ch, count);
+		return ptr_memset(memset_data, ch, count);
 	}
 
 	// MEMCPY!
@@ -841,11 +841,11 @@ public:
 	#define memcpy memcpy_if_trivial_else_error
 
 	template<typename T, typename U>
-	void *memcpy_if_trivial_else_error(T *dest, U *src, size_t count)
+	void *memcpy_if_trivial_else_error(T *memcpy_dest, U *src, size_t count)
 	{
 		static_assert(std::is_trivial<T>::value, "memcpy on non-trivial object T");
 		static_assert(std::is_trivial<U>::value, "memcpy on non-trivial object U");
-		return ptr_memcpy(dest, src, count);
+		return ptr_memcpy(memcpy_dest, src, count);
 	}
 
 	// assume memcpy with void* is "safe"
@@ -857,28 +857,28 @@ public:
 	//
 	// probably should setup a static_assert on insertion_sort as well
 	template<typename U>
-	void *memcpy_if_trivial_else_error(void *dest, U *src, size_t count)
+	void *memcpy_if_trivial_else_error(void *memcpy_dest, U *memcpy_src, size_t count)
 	{
 		static_assert(std::is_trivial<U>::value, "memcpy on non-trivial object U");
-		return ptr_memcpy(dest, src, count);
+		return ptr_memcpy(memcpy_dest, memcpy_src, count);
 	}
 
 	template<typename T>
-	void *memcpy_if_trivial_else_error(T *dest, void *src, size_t count)
+	void *memcpy_if_trivial_else_error(T *memcpy_dest, void *memcpy_src, size_t count)
 	{
 		static_assert(std::is_trivial<T>::value, "memcpy on non-trivial object T");
-		return ptr_memcpy(dest, src, count);
+		return ptr_memcpy(memcpy_dest, memcpy_src, count);
 	}
 	template<typename T>
-	void *memcpy_if_trivial_else_error(T *dest, const void *src, size_t count)
+	void *memcpy_if_trivial_else_error(T *memcpy_dest, const void *memcpy_src, size_t count)
 	{
 		static_assert(std::is_trivial<T>::value, "memcpy on non-trivial object T");
-		return ptr_memcpy(dest, src, count);
+		return ptr_memcpy(memcpy_dest, memcpy_src, count);
 	}
 
-	inline void *memcpy_if_trivial_else_error(void *dest, void *src, size_t count)
+	inline void *memcpy_if_trivial_else_error(void *memcpy_dest, void *memcpy_src, size_t count)
 	{
-		return ptr_memcpy(dest, src, count);
+		return ptr_memcpy(memcpy_dest, memcpy_src, count);
 	}
 
 	// MEMMOVE!
@@ -886,11 +886,11 @@ public:
 	#define memmove memmove_if_trivial_else_error
 
 	template<typename T, typename U>
-	void *memmove_if_trivial_else_error(T *dest, U *src, size_t count)
+	void *memmove_if_trivial_else_error(T *memmove_dest, U *memmove_src, size_t count)
 	{
 		static_assert(std::is_trivial<T>::value, "memmove on non-trivial object T");
 		static_assert(std::is_trivial<U>::value, "memmove on non-trivial object U");
-		return ptr_memmove(dest, src, count);
+		return ptr_memmove(memmove_dest, memmove_src, count);
 	}
 	#endif // HAVE_CXX11
 #endif // NDEBUG

--- a/code/globalincs/pstypes.h
+++ b/code/globalincs/pstypes.h
@@ -863,6 +863,18 @@ public:
 	{
 		return ptr_memcpy(dest, src, count);
 	}
+
+	// MEMMOVE!
+	const auto ptr_memmove = std::memmove;
+	#define memmove memmove_if_trivial_else_error
+
+	template<typename T, typename U>
+	void *memmove_if_trivial_else_error(T *dest, U *src, size_t count)
+	{
+		static_assert(std::is_trivial<T>::value, "memmove on non-trivial object T");
+		static_assert(std::is_trivial<U>::value, "memmove on non-trivial object U");
+		return ptr_memmove(dest, src, count);
+	}
 	#endif // HAVE_CXX11
 #endif // NDEBUG
 

--- a/code/globalincs/pstypes.h
+++ b/code/globalincs/pstypes.h
@@ -818,6 +818,51 @@ public:
 	{
 		return ptr_memset(data, ch, count);
 	}
+
+	// MEMCPY!
+	const auto ptr_memcpy = std::memcpy;
+	#define memcpy memcpy_if_trivial_else_error
+
+	template<typename T, typename U>
+	void *memcpy_if_trivial_else_error(T *dest, U *src, size_t count)
+	{
+		static_assert(std::is_trivial<T>::value, "memcpy on non-trivial object T");
+		static_assert(std::is_trivial<U>::value, "memcpy on non-trivial object U");
+		return ptr_memcpy(dest, src, count);
+	}
+
+	// assume memcpy with void* is "safe"
+	// used in:
+	//   globalincs/systemvars.cpp:insertion_sort()
+	//   network/chat_api.cpp:AddChatCommandToQueue()
+	//   network/multi_obj.cpp:multi_oo_sort_func()
+	//   parse/lua.cpp:ade_get_args() && ade_set_args()
+	//
+	// probably should setup a static_assert on insertion_sort as well
+	template<typename U>
+	void *memcpy_if_trivial_else_error(void *dest, U *src, size_t count)
+	{
+		static_assert(std::is_trivial<U>::value, "memcpy on non-trivial object U");
+		return ptr_memcpy(dest, src, count);
+	}
+
+	template<typename T>
+	void *memcpy_if_trivial_else_error(T *dest, void *src, size_t count)
+	{
+		static_assert(std::is_trivial<T>::value, "memcpy on non-trivial object T");
+		return ptr_memcpy(dest, src, count);
+	}
+	template<typename T>
+	void *memcpy_if_trivial_else_error(T *dest, const void *src, size_t count)
+	{
+		static_assert(std::is_trivial<T>::value, "memcpy on non-trivial object T");
+		return ptr_memcpy(dest, src, count);
+	}
+
+	inline void *memcpy_if_trivial_else_error(void *dest, void *src, size_t count)
+	{
+		return ptr_memcpy(dest, src, count);
+	}
 	#endif // HAVE_CXX11
 #endif // NDEBUG
 

--- a/code/osapi/outwnd_unix.cpp
+++ b/code/osapi/outwnd_unix.cpp
@@ -35,7 +35,8 @@ void outwnd_print(const char *id = NULL, const char *temp = NULL);
 bool outwnd_inited = false;
 ubyte Outwnd_no_filter_file = 0;		// 0 = .cfg file found, 1 = not found and warning not printed yet, 2 = not found and warning printed
 
-struct outwnd_filter_struct {
+class outwnd_filter_struct {
+public:
 	char name[NAME_LENGTH];
 	bool enabled;
 
@@ -75,22 +76,16 @@ void load_filter_info(void)
 	if (!fp) {
 		Outwnd_no_filter_file = 1;
 
-		memset( &new_filter, 0, sizeof(outwnd_filter_struct) );
 		strcpy_s( new_filter.name, "error" );
 		new_filter.enabled = true;
-
 		OutwndFilter.push_back( new_filter );
 
-		memset( &new_filter, 0, sizeof(outwnd_filter_struct) );
 		strcpy_s( new_filter.name, "general" );
 		new_filter.enabled = true;
-
 		OutwndFilter.push_back( new_filter );
 
-		memset( &new_filter, 0, sizeof(outwnd_filter_struct) );
 		strcpy_s( new_filter.name, "warning" );
 		new_filter.enabled = true;
-
 		OutwndFilter.push_back( new_filter );
 
 		return;
@@ -99,7 +94,6 @@ void load_filter_info(void)
 	Outwnd_no_filter_file = 0;
 
 	while ( fgets(inbuf, NAME_LENGTH+3, fp) ) {
-		memset( &new_filter, 0, sizeof(outwnd_filter_struct) );
 
 		if (*inbuf == '+')
 			new_filter.enabled = true;

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -29003,7 +29003,7 @@ sexp_help_struct Sexp_help[] = {
 		"If no input coordinates are specified, the coordinate returned is the coordinate of the object (or object's "
 		"subsystem) itself.  Takes 1 to 5 arguments...\r\n"
 		"\t1: The name of a ship, wing, or waypoint.\r\n"
-		"\t2: A ship subsystem (or \""SEXP_NONE_STRING"\" if the first argument is not a ship - optional).\r\n"
+		"\t2: A ship subsystem (or \"" SEXP_NONE_STRING "\" if the first argument is not a ship - optional).\r\n"
 		"\t3: The relative X coordinate (optional).\r\n"
 		"\t4: The relative Y coordinate (optional).\r\n"
 		"\t5: The relative Z coordinate (optional).\r\n" },
@@ -29015,7 +29015,7 @@ sexp_help_struct Sexp_help[] = {
 		"If no input coordinates are specified, the coordinate returned is the coordinate of the object (or object's "
 		"subsystem) itself.  Takes 1 to 5 arguments...\r\n"
 		"\t1: The name of a ship, wing, or waypoint.\r\n"
-		"\t2: A ship subsystem (or \""SEXP_NONE_STRING"\" if the first argument is not a ship - optional).\r\n"
+		"\t2: A ship subsystem (or \"" SEXP_NONE_STRING "\" if the first argument is not a ship - optional).\r\n"
 		"\t3: The relative X coordinate (optional).\r\n"
 		"\t4: The relative Y coordinate (optional).\r\n"
 		"\t5: The relative Z coordinate (optional).\r\n" },
@@ -29027,7 +29027,7 @@ sexp_help_struct Sexp_help[] = {
 		"If no input coordinates are specified, the coordinate returned is the coordinate of the object (or object's "
 		"subsystem) itself.  Takes 1 to 5 arguments...\r\n"
 		"\t1: The name of a ship, wing, or waypoint.\r\n"
-		"\t2: A ship subsystem (or \""SEXP_NONE_STRING"\" if the first argument is not a ship - optional).\r\n"
+		"\t2: A ship subsystem (or \"" SEXP_NONE_STRING "\" if the first argument is not a ship - optional).\r\n"
 		"\t3: The relative X coordinate (optional).\r\n"
 		"\t4: The relative Y coordinate (optional).\r\n"
 		"\t5: The relative Z coordinate (optional).\r\n" },

--- a/code/windows_stub/config.h
+++ b/code/windows_stub/config.h
@@ -64,8 +64,8 @@
 
 
 // don't verbose stub funtions unless we're debugging
-#define STUB_FUNCTION nprintf(( "Warning", "STUB: %s in "__FILE__" at line %d, thread %d\n", __FUNCTION__, __LINE__, getpid() ))
-#define DEBUGME(d1) nprintf(( "Warning", "DEBUGME: %s in "__FILE__" at line %d, msg \"%s\", thread %d\n", __FUNCTION__, __LINE__, d1, getpid() ))
+#define STUB_FUNCTION nprintf(( "Warning", "STUB: %s in " __FILE__ " at line %d, thread %d\n", __FUNCTION__, __LINE__, getpid() ))
+#define DEBUGME(d1) nprintf(( "Warning", "DEBUGME: %s in " __FILE__ " at line %d, msg \"%s\", thread %d\n", __FUNCTION__, __LINE__, d1, getpid() ))
 
 
 #define _cdecl

--- a/configure.ac
+++ b/configure.ac
@@ -39,6 +39,8 @@ AC_SUBST(LDFLAGS)
 
 PKG_PROG_PKG_CONFIG()
 
+dnl lets see if we support c++11
+AX_CXX_COMPILE_STDCXX_11([noext], [optional])
 
 dnl The configuration options
 dnl -------------------------

--- a/m4/ax_cxx_compile_stdcxx_11.m4
+++ b/m4/ax_cxx_compile_stdcxx_11.m4
@@ -1,0 +1,133 @@
+# ============================================================================
+#  http://www.gnu.org/software/autoconf-archive/ax_cxx_compile_stdcxx_11.html
+# ============================================================================
+#
+# SYNOPSIS
+#
+#   AX_CXX_COMPILE_STDCXX_11([ext|noext],[mandatory|optional])
+#
+# DESCRIPTION
+#
+#   Check for baseline language coverage in the compiler for the C++11
+#   standard; if necessary, add switches to CXXFLAGS to enable support.
+#
+#   The first argument, if specified, indicates whether you insist on an
+#   extended mode (e.g. -std=gnu++11) or a strict conformance mode (e.g.
+#   -std=c++11).  If neither is specified, you get whatever works, with
+#   preference for an extended mode.
+#
+#   The second argument, if specified 'mandatory' or if left unspecified,
+#   indicates that baseline C++11 support is required and that the macro
+#   should error out if no mode with that support is found.  If specified
+#   'optional', then configuration proceeds regardless, after defining
+#   HAVE_CXX11 if and only if a supporting mode is found.
+#
+# LICENSE
+#
+#   Copyright (c) 2008 Benjamin Kosnik <bkoz@redhat.com>
+#   Copyright (c) 2012 Zack Weinberg <zackw@panix.com>
+#   Copyright (c) 2013 Roy Stogner <roystgnr@ices.utexas.edu>
+#
+#   Copying and distribution of this file, with or without modification, are
+#   permitted in any medium without royalty provided the copyright notice
+#   and this notice are preserved. This file is offered as-is, without any
+#   warranty.
+
+#serial 3
+
+m4_define([_AX_CXX_COMPILE_STDCXX_11_testbody], [
+  template <typename T>
+    struct check
+    {
+      static_assert(sizeof(int) <= sizeof(T), "not big enough");
+    };
+
+    typedef check<check<bool>> right_angle_brackets;
+
+    int a;
+    decltype(a) b;
+
+    typedef check<int> check_type;
+    check_type c;
+    check_type&& cr = static_cast<check_type&&>(c);
+
+    auto d = a;
+])
+
+AC_DEFUN([AX_CXX_COMPILE_STDCXX_11], [dnl
+  m4_if([$1], [], [],
+        [$1], [ext], [],
+        [$1], [noext], [],
+        [m4_fatal([invalid argument `$1' to AX_CXX_COMPILE_STDCXX_11])])dnl
+  m4_if([$2], [], [ax_cxx_compile_cxx11_required=true],
+        [$2], [mandatory], [ax_cxx_compile_cxx11_required=true],
+        [$2], [optional], [ax_cxx_compile_cxx11_required=false],
+        [m4_fatal([invalid second argument `$2' to AX_CXX_COMPILE_STDCXX_11])])dnl
+  AC_LANG_PUSH([C++])dnl
+  ac_success=no
+  AC_CACHE_CHECK(whether $CXX supports C++11 features by default,
+  ax_cv_cxx_compile_cxx11,
+  [AC_COMPILE_IFELSE([AC_LANG_SOURCE([_AX_CXX_COMPILE_STDCXX_11_testbody])],
+    [ax_cv_cxx_compile_cxx11=yes],
+    [ax_cv_cxx_compile_cxx11=no])])
+  if test x$ax_cv_cxx_compile_cxx11 = xyes; then
+    ac_success=yes
+  fi
+
+  m4_if([$1], [noext], [], [dnl
+  if test x$ac_success = xno; then
+    for switch in -std=gnu++11 -std=gnu++0x; do
+      cachevar=AS_TR_SH([ax_cv_cxx_compile_cxx11_$switch])
+      AC_CACHE_CHECK(whether $CXX supports C++11 features with $switch,
+                     $cachevar,
+        [ac_save_CXXFLAGS="$CXXFLAGS"
+         CXXFLAGS="$CXXFLAGS $switch"
+         AC_COMPILE_IFELSE([AC_LANG_SOURCE([_AX_CXX_COMPILE_STDCXX_11_testbody])],
+          [eval $cachevar=yes],
+          [eval $cachevar=no])
+         CXXFLAGS="$ac_save_CXXFLAGS"])
+      if eval test x\$$cachevar = xyes; then
+        CXXFLAGS="$CXXFLAGS $switch"
+        ac_success=yes
+        break
+      fi
+    done
+  fi])
+
+  m4_if([$1], [ext], [], [dnl
+  if test x$ac_success = xno; then
+    for switch in -std=c++11 -std=c++0x; do
+      cachevar=AS_TR_SH([ax_cv_cxx_compile_cxx11_$switch])
+      AC_CACHE_CHECK(whether $CXX supports C++11 features with $switch,
+                     $cachevar,
+        [ac_save_CXXFLAGS="$CXXFLAGS"
+         CXXFLAGS="$CXXFLAGS $switch"
+         AC_COMPILE_IFELSE([AC_LANG_SOURCE([_AX_CXX_COMPILE_STDCXX_11_testbody])],
+          [eval $cachevar=yes],
+          [eval $cachevar=no])
+         CXXFLAGS="$ac_save_CXXFLAGS"])
+      if eval test x\$$cachevar = xyes; then
+        CXXFLAGS="$CXXFLAGS $switch"
+        ac_success=yes
+        break
+      fi
+    done
+  fi])
+  AC_LANG_POP([C++])
+  if test x$ax_cxx_compile_cxx11_required = xtrue; then
+    if test x$ac_success = xno; then
+      AC_MSG_ERROR([*** A compiler with support for C++11 language features is required.])
+    fi
+  else
+    if test x$ac_success = xno; then
+      HAVE_CXX11=0
+      AC_MSG_NOTICE([No compiler with C++11 support was found])
+    else
+      HAVE_CXX11=1
+      AC_DEFINE(HAVE_CXX11,1,
+                [define if the compiler supports basic C++11 syntax])
+    fi
+
+    AC_SUBST(HAVE_CXX11)
+  fi
+])


### PR DESCRIPTION
Also adds compile time checks for dangerous uses of memcpy/memmove/memset, i.e. on non POD classes/structs