### PR TITLE
Fix for Coverity 1093555: Negative array index read

### DIFF
--- a/code/network/multiutil.cpp
+++ b/code/network/multiutil.cpp
@@ -1599,6 +1599,12 @@ void multi_create_standalone_object()
 
 	vm_vec_zero(&v);
 	objnum = observer_create(&m,&v);
+
+	if (objnum < 0) {
+		Error(LOCATION, "Failed to create standalone observer object! Please investigate!");
+		return;
+	}
+
 	Player_obj = &Objects[objnum];
 	obj_set_flags(Player_obj, Player_obj->flags & (~OF_COLLIDES) );
 	//obj_set_flags(Player_obj, Player_obj->flags | OF_SHOULD_BE_DEAD);


### PR DESCRIPTION
A memory location at a negative offset from the beginning of the array will be read, resulting in incorrect values.
In multi_create_standalone_object(): Negative value used to index an array in a read operation

observer_create() will only fail in exceptional circumstances so a showing an error dialog should be acceptable