### PR TITLE
Fix for Coverity 1093530: Negative array index read

### DIFF
--- a/code/mission/missionmessage.cpp
+++ b/code/mission/missionmessage.cpp
@@ -1534,6 +1534,9 @@ void message_queue_process()
 
 	//	Don't play death scream unless a small ship.
 	if ( q->builtin_type == MESSAGE_WINGMAN_SCREAM ) {
+		if (Message_shipnum < 0) {
+			goto all_done;
+		}
 		if (!((Ship_info[Ships[Message_shipnum].ship_info_index].flags & SIF_SMALL_SHIP) || (Ships[Message_shipnum].flags2 & SF2_ALWAYS_DEATH_SCREAM)) ) {
 			goto all_done;
 		}


### PR DESCRIPTION
A memory location at a negative offset from the beginning of the array will be read, resulting in incorrect values.
In message_queue_process(): Negative value used to index an array in a read operation