### PR TITLE
Fix for Coverity 1093515: Negative array index read

### DIFF
--- a/code/network/multi_options.cpp
+++ b/code/network/multi_options.cpp
@@ -585,6 +585,11 @@ void multi_options_process_packet(unsigned char *data, header *hinfo)
 	// find out who is sending this data	
 	player_index = find_player_id(hinfo->id);
 
+	if (player_index < 0) {
+		nprintf(("Network", "Received packet from unknown player!\n"));
+		return;
+	}
+
 	// get the packet code
 	GET_DATA(code);
 	switch(code){


### PR DESCRIPTION
A memory location at a negative offset from the beginning of the array will be read, resulting in incorrect values.
In multi_options_process_packet(unsigned char *, header *): Negative value used to index an array in a read operation