### PR TITLE
Made it possible to name control presets, and made controls config displ...

### DIFF
--- a/code/controlconfig/controlsconfig.cpp
+++ b/code/controlconfig/controlsconfig.cpp
@@ -2107,6 +2107,45 @@ void control_config_do_frame(float frametime)
 		List_buttons[i++].disable();
 	}
 
+	// If multiple controls presets are provided, display which one is in use
+	if (Control_config_presets.size() > 1) {
+		SCP_string preset_str;
+		int matching_preset = -1;
+
+		for (i=0; i<(int)Control_config_presets.size(); i++) {
+			bool this_preset_matches = true;
+			config_item *this_preset = Control_config_presets[i];
+
+			for (int j=0; j<CCFG_MAX; j++) {
+				if (!Control_config[j].disabled && Control_config[j].key_id != this_preset[j].key_default) {
+					this_preset_matches = false;
+					break;
+				}
+			}
+
+			if (this_preset_matches) {
+				matching_preset = i;
+				break;
+			}
+		}
+
+		if (matching_preset >= 0) {
+			sprintf(preset_str, "Controls: %s", Control_config_preset_names[matching_preset].c_str());
+		} else {
+			sprintf(preset_str, "Controls: custom");
+			
+		}
+
+		gr_get_string_size(&w, NULL, preset_str.c_str());
+		gr_set_color_fast(&Color_text_normal);
+
+		if (gr_screen.res == GR_640) {
+			gr_string(16, (24 - font_height) / 2, preset_str.c_str(), GR_RESIZE_MENU);
+		} else {
+			gr_string(24, (40 - font_height) / 2, preset_str.c_str(), GR_RESIZE_MENU);
+		}
+	}
+
 	// blit help overlay if active
 	help_overlay_maybe_blit(Control_config_overlay_id, gr_screen.res);
 

--- a/code/controlconfig/controlsconfig.h
+++ b/code/controlconfig/controlsconfig.h
@@ -292,6 +292,7 @@ extern int Control_config_overlay_id;
 
 extern config_item Control_config[];		//!< Stores the keyboard configuration
 extern SCP_vector<config_item*> Control_config_presets; // tabled control presets; pointers to config_item arrays
+extern SCP_vector<SCP_string> Control_config_preset_names; // names for Control_config_presets (identical order of items)
 extern char **Scan_code_text;
 extern char **Joy_button_text;
 

--- a/code/controlconfig/controlsconfigcommon.cpp
+++ b/code/controlconfig/controlsconfigcommon.cpp
@@ -404,6 +404,7 @@ char **Scan_code_text = Scan_code_text_english;
 char **Joy_button_text = Joy_button_text_english;
 
 SCP_vector<config_item*> Control_config_presets;
+SCP_vector<SCP_string> Control_config_preset_names;
 
 void set_modifier_status()
 {
@@ -810,6 +811,14 @@ void control_config_common_load_overrides()
 		config_item *cfg_preset = new config_item[CCFG_MAX + 1];
 		std::copy(Control_config, Control_config + CCFG_MAX + 1, cfg_preset);
 		Control_config_presets.push_back(cfg_preset);
+
+		SCP_string preset_name;
+		if (optional_string("$Name:")) {
+			stuff_string_line(preset_name);
+		} else {
+			preset_name = "<unnamed preset>";
+		}
+		Control_config_preset_names.push_back(preset_name);
 
 		while (required_string_either("#End","$Bind Name:")) {
 			const int iBufferLength = 64;


### PR DESCRIPTION
...ay the current preset's name if there are multiple to choose from.

Usage in controlconfigdefaults.tbl:

#ControlConfigOverride
$Name: WASD

; ... all the usual stuff

#End

#ControlConfigOverride
$Name: Keyboard only

; ... all the usual stuff

#End