### PR TITLE
Fix for Mantis #3158: prevent narrowing that breaks compilation in stricter compilers 

### DIFF
--- a/code/network/multi_voice.cpp
+++ b/code/network/multi_voice.cpp
@@ -106,7 +106,7 @@ int Multi_voice_stamps[MULTI_VOICE_MAX_STREAMS];
 
 // the token index of a voice stream is set to one of these values, or the index of the player who has the token
 #define MULTI_VOICE_TOKEN_INDEX_FREE				-1					// the token (and the stream are free)
-#define MULTI_VOICE_TOKEN_INDEX_RELEASED			0xDEADBEAD		// the token has been released but the stream is still active
+#define MULTI_VOICE_TOKEN_INDEX_RELEASED			0xBEAD		// the token has been released but the stream is still active
 
 typedef struct voice_stream {		
 	int token_status;															// status of the token (player index if a player has it) or one of the above defines


### PR DESCRIPTION
When used with 0xDEADBEAD, MULTI_VOICE_TOKEN_INDEX_RELEASED gets used in a case statement comparing it to token_status, which can't fit the number as an int. This was enough to fix compilation on FreeBSD with clang 3.4.1 which is pickier about narrowing and treats it as an error.  0xBEAD instead of 0xDEADBEAD should semantically get the point across but fit within the int, and doesn't change the size of the token_stream struct.