### PR TITLE
Make model_really_render()'s depth check use View_position instead of…

### DIFF
--- a/code/model/modelinterp.cpp
+++ b/code/model/modelinterp.cpp
@@ -2824,7 +2824,7 @@ void model_really_render(int model_num, matrix *orient, vec3d * pos, uint flags,
 	Assert( pm->n_detail_levels < MAX_MODEL_DETAIL_LEVELS );
 
 	vec3d closest_pos;
-	float depth = model_find_closest_point( &closest_pos, model_num, -1, orient, pos, &Eye_position );
+	float depth = model_find_closest_point( &closest_pos, model_num, -1, orient, pos, &View_position );
 
 	if ( !(Interp_flags & MR_LOCK_DETAIL) ) {
 		#if MAX_DETAIL_LEVEL != 4


### PR DESCRIPTION
… Eye_position.

View_position is modified by g3_start_instance_matrix()/g3_done_instance(). Eye_position is not. As a result, this depth check was basically comparing the distance from a small distance away from the center of the mission to the absolute coordinates of the camera, instead of their relative distances.

Now, I am far from an expert on FSO's graphics code, so I'm not sure if this is the correct fix, or maybe Eye_position should be being modified by g3_start_instance_matrix()/g3_done_instance() as well. I'm not really clear on what the difference between the two variables is supposed to be, for that matter. All I know is that making this change fixed external stores vanishing at a certain distance from the center of the mission, without any new issues *seeming* to pop up.