### PR TITLE
Revert a part of f6e2f1d2 / r11129 which causes collision problems in…

### DIFF
--- a/code/model/modelcollide.cpp
+++ b/code/model/modelcollide.cpp
@@ -1078,19 +1078,18 @@ void mc_check_subobj( int mn )
 		return;
 	}
 
-	// quickly bail if we aren't inside the full model bbox
-	if ( !mc_ray_boundingbox(&Mc_pm->mins, &Mc_pm->maxs, &Mc_p0, &Mc_direction, NULL) ) {
-		return;
-	}
-
-	// If we are checking the root submodel, then we might want
-	// to check the shield at this point
-	if (Mc->flags & MC_CHECK_SHIELD) {
-		if ( (Mc_pm->detail[0] == mn) && (Mc_pm->shield.ntris > 0) ) {
-			mc_check_shield();
+	if (Mc_pm->detail[0] == mn)	{
+		// Quickly bail if we aren't inside the full model bbox
+		if (!mc_ray_boundingbox( &Mc_pm->mins, &Mc_pm->maxs, &Mc_p0, &Mc_direction, NULL))	{
+			return;
 		}
 
-		return;
+		// If we are checking the root submodel, then we might want to check	
+		// the shield at this point
+		if ((Mc->flags & MC_CHECK_SHIELD) && (Mc_pm->shield.ntris > 0 )) {
+			mc_check_shield();
+			return;
+		}
 	}
 
 	if (!(Mc->flags & MC_CHECK_MODEL)) {


### PR DESCRIPTION
… some corner cases.

Namely, it breaks for at least submodels which have their centerpoint far away from the actual mesh, such as is the case for one of my hangar doors (which opens by a small amount of rotation, hence why the centerpoint is far away from the mesh itself). The bbox and/or radius of the submodel aren't to blame.

I can't say definitively why the code breaks, but making that mc_ray_boundingbox check again be performed only on detail[0] fixes the issues. As a wild guess I think the breakage might occur when the center of the whole model is closer to the would-be collision than the centerpoint of the submodel that's being checked.

Re-instanting the detail[0] condition does seem sensible from a performance point of view too, because otherwise you end up performing the same whole-model bbox sanity check per every submodel, whereas it shouldn't be necessary for anything else than detail[0]; collision detection always (?) starts from detail[0], and if that bbox check for detail[0] fails, the code further up the chain won't be checking other submodels anyway.