### PR TITLE
Change SCP_hash_map to SCP_unordered_map

### DIFF
--- a/code/globalincs/vmallocator.h
+++ b/code/globalincs/vmallocator.h
@@ -9,33 +9,7 @@
 #include <string>
 #include <queue>
 #include <deque>
-
-#if defined __GNUC__
-#define GCC_VERSION (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__)
-#if GCC_VERSION >= 40300
-#include <tr1/unordered_map>
-#define SCP_hash_map std::tr1::unordered_map
-#elif GCC_VERSION < 40300 || __clang__
-#include <ext/hash_map>
-#define SCP_hash_map __gnu_cxx::hash_map
-#endif // GCC_VERSION || __clang__
-#endif // __GNUC__
-
-#if ! defined __GNUC__
-	#if defined(_MSC_VER)
-		#if _MSC_VER < 1900
-			#include <hash_map>
-			#if _MSC_VER < 1400
-			#define SCP_hash_map std::hash_map
-			#else
-			#define SCP_hash_map stdext::hash_map
-			#endif
-		#else
-			#include <unordered_map>
-			#define SCP_hash_map std::unordered_map
-		#endif
-	#endif
-#endif // ! defined __GNUC__
+#include <unordered_map>
 
 template< typename T >
 class SCP_vector : public std::vector< T, std::allocator< T > > { };
@@ -58,6 +32,9 @@ class SCP_queue : public std::queue< T, std::deque< T, std::allocator< T > > > {
 
 template< typename T >
 class SCP_deque : public std::deque< T, std::allocator< T > > { };
+
+template< typename Key, typename T, typename Hash = std::hash<Key>, typename KeyEqual = std::equal_to<Key> >
+class SCP_unordered_map : public std::unordered_map< Key, T, Hash, KeyEqual, std::allocator< std::pair<const Key, T> > > { };
 
 
 #endif // _VMALLOCATOR_H_INCLUDED_

--- a/code/missionui/redalert.cpp
+++ b/code/missionui/redalert.cpp
@@ -822,8 +822,8 @@ void red_alert_bash_wingman_status()
 	SCP_vector<red_alert_ship_status>::iterator rasii;
 	SCP_vector<p_object>::iterator poii;
 
-	SCP_hash_map<int, int> Wing_pobjects_deleted;
-	SCP_hash_map<int, int>::iterator ii;
+	SCP_unordered_map<int, int> Wing_pobjects_deleted;
+	SCP_unordered_map<int, int>::iterator ii;
 
 	if ( !(Game_mode & GM_CAMPAIGN_MODE) ) {
 		return;

--- a/code/model/modelinterp.cpp
+++ b/code/model/modelinterp.cpp
@@ -2030,7 +2030,7 @@ void model_render_DEPRECATED(int model_num, matrix *orient, vec3d * pos, uint fl
 
 	glow_point_bank_override *gpo = NULL;
 	bool override_all = false;
-	SCP_hash_map<int, void*>::iterator gpoi;
+	SCP_unordered_map<int, void*>::iterator gpoi;
 	ship_info *sip = NULL;
 	ship *shipp = NULL;
 	
@@ -2039,7 +2039,7 @@ void model_render_DEPRECATED(int model_num, matrix *orient, vec3d * pos, uint fl
 		{
 			shipp = &Ships[Objects[objnum].instance];
 			sip = &Ship_info[shipp->ship_info_index];
-			SCP_hash_map<int, void*>::iterator gpoi = sip->glowpoint_bank_override_map.find(-1);
+			SCP_unordered_map<int, void*>::iterator gpoi = sip->glowpoint_bank_override_map.find(-1);
 		
 			if(gpoi != sip->glowpoint_bank_override_map.end()) {
 				override_all = true;
@@ -2602,13 +2602,13 @@ void model_render_glow_points_DEPRECATED(polymodel *pm, ship *shipp, matrix *ori
 	
 	glow_point_bank_override *gpo = NULL;
 	bool override_all = false;
-	SCP_hash_map<int, void*>::iterator gpoi;
+	SCP_unordered_map<int, void*>::iterator gpoi;
 	ship_info *sip = NULL;
 
 	if(shipp)
 	{
 		sip = &Ship_info[shipp->ship_info_index];
-		SCP_hash_map<int, void*>::iterator gpoi = sip->glowpoint_bank_override_map.find(-1);
+		SCP_unordered_map<int, void*>::iterator gpoi = sip->glowpoint_bank_override_map.find(-1);
 		
 		if(gpoi != sip->glowpoint_bank_override_map.end()) {
 			override_all = true;

--- a/code/model/modelrender.cpp
+++ b/code/model/modelrender.cpp
@@ -2031,7 +2031,7 @@ void model_render_set_glow_points(polymodel *pm, int objnum)
 	int time = timestamp();
 	glow_point_bank_override *gpo = NULL;
 	bool override_all = false;
-	SCP_hash_map<int, void*>::iterator gpoi;
+	SCP_unordered_map<int, void*>::iterator gpoi;
 	ship_info *sip = NULL;
 	ship *shipp = NULL;
 
@@ -2045,7 +2045,7 @@ void model_render_set_glow_points(polymodel *pm, int objnum)
 		if ( objp != NULL && objp->type == OBJ_SHIP ) {
 			shipp = &Ships[Objects[objnum].instance];
 			sip = &Ship_info[shipp->ship_info_index];
-			SCP_hash_map<int, void*>::iterator gpoi = sip->glowpoint_bank_override_map.find(-1);
+			SCP_unordered_map<int, void*>::iterator gpoi = sip->glowpoint_bank_override_map.find(-1);
 
 			if (gpoi != sip->glowpoint_bank_override_map.end()) {
 				override_all = true;
@@ -2099,12 +2099,12 @@ void model_render_glow_points(polymodel *pm, ship *shipp, matrix *orient, vec3d 
 
 	glow_point_bank_override *gpo = NULL;
 	bool override_all = false;
-	SCP_hash_map<int, void*>::iterator gpoi;
+	SCP_unordered_map<int, void*>::iterator gpoi;
 	ship_info *sip = NULL;
 
 	if ( shipp ) {
 		sip = &Ship_info[shipp->ship_info_index];
-		SCP_hash_map<int, void*>::iterator gpoi = sip->glowpoint_bank_override_map.find(-1);
+		SCP_unordered_map<int, void*>::iterator gpoi = sip->glowpoint_bank_override_map.find(-1);
 
 		if(gpoi != sip->glowpoint_bank_override_map.end()) {
 			override_all = true;

--- a/code/object/objcollide.cpp
+++ b/code/object/objcollide.cpp
@@ -60,7 +60,7 @@ public:
 	{}
 };
 
-SCP_hash_map<uint, collider_pair> Collision_cached_pairs;
+SCP_unordered_map<uint, collider_pair> Collision_cached_pairs;
 
 struct checkobject;
 extern checkobject CheckObjects[MAX_OBJECTS];
@@ -1064,7 +1064,7 @@ int collide_remove_weapons( )
 			opp = opp->next;
 		}
 	} else {
-		SCP_hash_map<uint, collider_pair>::iterator it;
+		SCP_unordered_map<uint, collider_pair>::iterator it;
 		collider_pair *pair_obj;
 
 		for ( it = Collision_cached_pairs.begin(); it != Collision_cached_pairs.end(); ++it ) {
@@ -1205,7 +1205,7 @@ void obj_reset_colliders()
 
 void obj_collide_retime_cached_pairs(int checkdly)
 {
-	SCP_hash_map<uint, collider_pair>::iterator it;
+	SCP_unordered_map<uint, collider_pair>::iterator it;
 
 	for ( it = Collision_cached_pairs.begin(); it != Collision_cached_pairs.end(); ++it ) {
 		it->second.next_check_time = timestamp(checkdly);

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -1437,7 +1437,7 @@ public:
 
 	SCP_map<SCP_string, path_metadata> pathMetadata;
 
-	SCP_hash_map<int, void*> glowpoint_bank_override_map;
+	SCP_unordered_map<int, void*> glowpoint_bank_override_map;
 };
 
 extern int Num_wings;


### PR DESCRIPTION
Also uses std::unordered_map on every platform now to fix warnings on Mac as the stdext hash maps are deprecated there.
This depends on #50 to be merged in order to cleanly compile on Linux.