### PR TITLE
Fixed a bug with the next/prev subsystem targeting keys not working i…

### DIFF
--- a/code/hud/hudtarget.cpp
+++ b/code/hud/hudtarget.cpp
@@ -1095,7 +1095,7 @@ void hud_target_subobject_common(int next_flag)
 	target_shipp = &Ships[Objects[Player_ai->target_objnum].instance];
 
 	if (!Player_ai->targeted_subsys) {
-		start = GET_FIRST(&target_shipp->subsys_list);
+		start = END_OF_LIST(&target_shipp->subsys_list);
 	} else {
 		start = Player_ai->targeted_subsys;
 	}


### PR DESCRIPTION
…f the target only has one subsystem.

Here's a rather lengthy conversation about what's going on with the linked list: https://gist.github.com/ln-zookeeper/1fa2ae3323ea8e437c2d

Someone may or may not want to switch or tweak the list implementation to something which doesn't have the unintuitive quirk which necessitates a fix like this.