### PR TITLE
Fix Mantis #3139.

### DIFF
--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -7142,11 +7142,8 @@ void ship_blow_up_area_apply_blast( object *exp_objp)
 	}
 
 	if ( shockwave_speed > 0 ) {
-		shockwave_create_info sci;
-		shockwave_create_info_init(&sci);
+		shockwave_create_info sci = sip->shockwave;
 
-		strcpy_s(sci.name, sip->shockwave.name);
-		strcpy_s(sci.pof_name, sip->shockwave.pof_name);
 		sci.inner_rad = inner_rad;
 		sci.outer_rad = outer_rad;
 		sci.blast = max_blast;


### PR DESCRIPTION
This makes ship explosion shockwaves use the tabled damage type. The code was creating a new shockwave_create_info object, initializing it, and then only copying some of the attributes of the ship's "shockwave" shockwave_create_info member (not including damage type). It makes more sense to use copy-assignment and then specifically override the attributes that should be overridden.