### PR TITLE
Fix Coverity 1298268: Division by float zero

### DIFF
--- a/code/model/modelinterp.cpp
+++ b/code/model/modelinterp.cpp
@@ -5162,7 +5162,9 @@ bool model_get_team_color( team_color *clr, const SCP_string &team, const SCP_st
 			}
 
 			team_color end = Team_Colors[secondaryteam];
-			float time_remaining = (f2fl(Missiontime - timestamp) * 1000)/fadetime;
+			float time_remaining = 0.0f;
+			if (fadetime != 0) // avoid potential div-by-zero
+				time_remaining = (f2fl(Missiontime - timestamp) * 1000)/fadetime;
 			CLAMP(time_remaining, 0.0f, 1.0f);
 			model_mix_two_team_colors(&temp_color, &start, &end, time_remaining);
 


### PR DESCRIPTION
The div-by-zero won't be triggered by this code because the
secondaryteam is "none". Play it safe and protect the div anyway