### PR TITLE
Fix Coverity 1298258: Uninitialized scalar var

### DIFF
--- a/code/graphics/grbatch.cpp
+++ b/code/graphics/grbatch.cpp
@@ -898,7 +898,7 @@ int batch_add_polygon(int texture, int tmap_flags, vec3d *pos, matrix *orient, f
 
 	const int NUM_VERTICES = 4;
 	vec3d p[NUM_VERTICES] = { ZERO_VECTOR };
-	vertex v[NUM_VERTICES];
+	vertex v[NUM_VERTICES] = { vertex() };
 
 	p[0].xyz.x = width;
 	p[0].xyz.y = height;

--- a/code/model/modelinterp.cpp
+++ b/code/model/modelinterp.cpp
@@ -1307,7 +1307,7 @@ void model_draw_paths( int model_num, uint flags )
 			// For this example, I am just drawing a sphere at that
 			// point.
 			{
-				vertex tmp;
+				vertex tmp = vertex();
 				g3_rotate_vertex(&tmp,&pnt);
 
 				if ( pm->paths[i].verts[j].nturrets > 0 ){
@@ -1815,7 +1815,7 @@ void model_render_shields( polymodel * pm, uint flags )
 {
 	int i, j;
 	shield_tri *tri;
-	vertex pnt0, tmp, prev_pnt;
+	vertex pnt0, prev_pnt, tmp = vertex();
 
 	if ( flags & MR_SHOW_OUTLINE_PRESET )	{
 		return;

--- a/code/weapon/trails.cpp
+++ b/code/weapon/trails.cpp
@@ -270,7 +270,7 @@ void trail_add_batch(trail * trailp)
 				// Last one...
 				vm_vec_avg(&centerv, &topv, &botv);
 
-				vertex center_vert;
+				vertex center_vert = vertex();
 
 				if (!Cmdline_nohtl)
 					g3_transfer_vertex(&center_vert, &centerv);


### PR DESCRIPTION
Also fixes 1298256, 1298254, 1298253

For vertex vars use default value-initialisation to zero the struct
http://en.cppreference.com/w/cpp/language/value_initialization

Note that parts of vertex don't seem used in relevant codepaths, e.g.
the colours. A zero init approach should be safer should code change in
future.