### PR TITLE
Fix Coverity 1298255: Uninitialized scalar var

### DIFF
--- a/code/model/modelinterp.cpp
+++ b/code/model/modelinterp.cpp
@@ -2579,8 +2579,8 @@ void model_render_thrusters(polymodel *pm, int objnum, ship *shipp, matrix *orie
 					pe.max_rad = gpt->radius * tp->max_rad;
 					// How close they stick to that normal 0=on normal, 1=180, 2=360 degree
 					pe.normal_variance = tp->variance;
-					pe.min_life = 0.0;
-					pe.max_life = 1.0;
+					pe.min_life = 0.0f;
+					pe.max_life = 1.0f;
 
 					particle_emit( &pe, PARTICLE_BITMAP, tp->thruster_bitmap.first_frame);
 				}

--- a/code/model/modelrender.cpp
+++ b/code/model/modelrender.cpp
@@ -2475,6 +2475,8 @@ void model_queue_render_thrusters(model_render_params *interp, polymodel *pm, in
 					pe.max_rad = gpt->radius * tp->max_rad;
 					// How close they stick to that normal 0=on normal, 1=180, 2=360 degree
 					pe.normal_variance = tp->variance;
+					pe.min_life = 0.0f;
+					pe.max_life = 1.0f;
 
 					particle_emit( &pe, PARTICLE_BITMAP, tp->thruster_bitmap.first_frame);
 				}


### PR DESCRIPTION
Copy particle min/max life values from modelinterp
Also avoid double->float conversion