### PR TITLE
Add automatic shield equalization

### DIFF
--- a/code/controlconfig/controlsconfig.h
+++ b/code/controlconfig/controlsconfig.h
@@ -270,6 +270,11 @@ enum IoActionId  {
 	//!< ----------------------------
 	CYCLE_PRIMARY_WEAPON_SEQUENCE					=118,	//!< cycle num primaries to fire at once
 
+	//!< @n
+	//!< Auto-balance shields
+	//!< ----------------------
+	TOGGLE_AUTO_SHIELD_EQUALIZE						=119,	//!< toggle automatic shield equalization
+
 	/*!
 	 * This must always be below the last defined item
 	 */

--- a/code/controlconfig/controlsconfigcommon.cpp
+++ b/code/controlconfig/controlsconfigcommon.cpp
@@ -192,6 +192,7 @@ config_item Control_config[CCFG_MAX + 1] = {
 	{ KEY_ALTED |               KEY_N,              -1, COMPUTER_TAB, false, "Cycle Nav Points",                       CC_TYPE_TRIGGER,    -1, -1, 0, false, false },
 	{ KEY_ALTED |               KEY_G,              -1, SHIP_TAB,     false, "Toggle Gliding",                         CC_TYPE_TRIGGER,    -1, -1, 0, false, false },
 	{                           KEY_O,              -1, WEAPON_TAB,   false, "Cycle Primary Weapon Firing Rate",       CC_TYPE_TRIGGER,    -1, -1, 0, false, false },
+	{ KEY_ALTED |               KEY_Q,              -1, COMPUTER_TAB, false, "Toggle Auto Equalize Shields",           CC_TYPE_TRIGGER,    -1, -1, 0, false, false },
 	{                           -1,                 -1, -1,           false, "",                                       CC_TYPE_TRIGGER,    -1, -1, 0, false, false }
 };
 

--- a/code/io/keycontrol.cpp
+++ b/code/io/keycontrol.cpp
@@ -330,7 +330,9 @@ int Normal_key_set[] = {
 	NAV_CYCLE,
 
 	TOGGLE_GLIDING,
-	CYCLE_PRIMARY_WEAPON_SEQUENCE
+	CYCLE_PRIMARY_WEAPON_SEQUENCE,
+
+	TOGGLE_AUTO_SHIELD_EQUALIZE,
 };
 
 int Dead_key_set[] = {
@@ -394,6 +396,7 @@ int Critical_key_set[] = {
 	SHIELD_XFER_RIGHT,			
 	XFER_SHIELD,			
 	XFER_LASER,			
+	TOGGLE_AUTO_SHIELD_EQUALIZE,
 };
 
 int Non_critical_key_set[] = {
@@ -465,7 +468,9 @@ int Non_critical_key_set[] = {
 	AUTO_PILOT_TOGGLE,
 	NAV_CYCLE,
 	TOGGLE_GLIDING,
-	CYCLE_PRIMARY_WEAPON_SEQUENCE
+	CYCLE_PRIMARY_WEAPON_SEQUENCE,
+
+	TOGGLE_AUTO_SHIELD_EQUALIZE,
 };
 
 int Ignored_keys[CCFG_MAX];
@@ -2311,11 +2316,6 @@ int button_function(int n)
 		case CYCLE_PREV_PRIMARY:	// cycle to previous primary weapon
 		case CYCLE_SECONDARY:		// cycle to next secondary weapon
 		case CYCLE_NUM_MISSLES:		// cycle number of missiles fired from secondary bank
-		case SHIELD_EQUALIZE:		// equalize shield energy to all quadrants
-		case SHIELD_XFER_TOP:		// transfer shield energy to front
-		case SHIELD_XFER_BOTTOM:	// transfer shield energy to rear
-		case SHIELD_XFER_LEFT:		// transfer shield energy to left
-		case SHIELD_XFER_RIGHT:		// transfer shield energy to right
 		case XFER_SHIELD:			// transfer energy to shield from weapons
 		case XFER_LASER:			// transfer energy to weapons from shield
 			return button_function_critical(n);
@@ -2334,6 +2334,18 @@ int button_function(int n)
 			}
 			return 1;
 			break;
+
+		case SHIELD_EQUALIZE:		// equalize shield energy to all quadrants
+			Player->flags &= ~PLAYER_FLAGS_AUTO_SHIELD_EQUALIZE_OVERRIDE;
+			return button_function_critical(n);
+
+		case SHIELD_XFER_TOP:		// transfer shield energy to front
+		case SHIELD_XFER_BOTTOM:	// transfer shield energy to rear
+		case SHIELD_XFER_LEFT:		// transfer shield energy to left
+		case SHIELD_XFER_RIGHT:		// transfer shield energy to right
+			Player->flags |= PLAYER_FLAGS_AUTO_SHIELD_EQUALIZE_OVERRIDE;
+			return button_function_critical(n);
+
 	}
 
 	/**
@@ -2521,6 +2533,7 @@ int button_function(int n)
 			if (!Sel_NextNav())
 				gamesnd_play_iface(SND_GENERAL_FAIL);
 			break;
+
 		default:
 			keyHasBeenUsed = FALSE;
 			break;
@@ -2810,6 +2823,17 @@ int button_function(int n)
 
 		case TARGET_NEXT_ESCORT_SHIP:
 			hud_escort_target_next();
+			break;
+
+		case TOGGLE_AUTO_SHIELD_EQUALIZE:
+			Players[Player_num].flags ^= PLAYER_FLAGS_AUTO_SHIELD_EQUALIZE;
+			if (Players[Player_num].flags & PLAYER_FLAGS_AUTO_SHIELD_EQUALIZE) {
+				Players[Player_num].flags &= ~PLAYER_FLAGS_AUTO_SHIELD_EQUALIZE_OVERRIDE;
+				button_function(SHIELD_EQUALIZE);
+				HUD_printf(XSTR("Auto shield equalization activated", 1638));
+			} else {
+				HUD_printf(XSTR("Auto shield equalization deactivated", 1639));
+			}
 			break;
 
 		default:

--- a/code/io/keycontrol.h
+++ b/code/io/keycontrol.h
@@ -39,5 +39,6 @@ void process_set_of_keys(int key, int count, int *list);
 void game_process_pause_key();
 void button_strip_noncritical_keys(button_info *bi);
 
+extern int button_function(int n);
 
 #endif

--- a/code/localization/localize.cpp
+++ b/code/localization/localize.cpp
@@ -58,7 +58,7 @@ int Lcl_english = 1;
 // the english version (in the code) to a foreign version (in the table).  Thus, if you
 // add a new string to the code, you must assign it a new index.  Use the number below for
 // that index and increase the number below by one.
-#define XSTR_SIZE	1638
+#define XSTR_SIZE	1640
 
 
 // struct to allow for strings.tbl-determined x offset

--- a/code/mission/missiontraining.cpp
+++ b/code/mission/missiontraining.cpp
@@ -363,8 +363,11 @@ void training_mission_init()
 	
 	// only clear player flags if this is actually a training mission
 	if ( The_mission.game_type & MISSION_TYPE_TRAINING ) {
-		Player->flags &= ~(PLAYER_FLAGS_MATCH_TARGET | PLAYER_FLAGS_MSG_MODE | PLAYER_FLAGS_AUTO_TARGETING | PLAYER_FLAGS_AUTO_MATCH_SPEED | PLAYER_FLAGS_LINK_PRIMARY | PLAYER_FLAGS_LINK_SECONDARY );
+		Player->flags &= ~(PLAYER_FLAGS_MATCH_TARGET | PLAYER_FLAGS_MSG_MODE | PLAYER_FLAGS_AUTO_TARGETING | PLAYER_FLAGS_AUTO_MATCH_SPEED | PLAYER_FLAGS_LINK_PRIMARY | PLAYER_FLAGS_LINK_SECONDARY | PLAYER_FLAGS_AUTO_SHIELD_EQUALIZE );
 	}
+
+	// never start with auto shield equalization on but overridden
+	Player->flags &= ~PLAYER_FLAGS_AUTO_SHIELD_EQUALIZE_OVERRIDE;
 }
 
 void training_mission_page_in()

--- a/code/parse/lua.cpp
+++ b/code/parse/lua.cpp
@@ -873,6 +873,7 @@ flag_def_list plr_commands[] = {
 	{	"AUTO_PILOT_TOGGLE",					AUTO_PILOT_TOGGLE,						3	},
 	{	"NAV_CYCLE",							NAV_CYCLE,								3	},
 	{	"TOGGLE_GLIDING",						TOGGLE_GLIDING,							3	},
+	{	"TOGGLE_AUTO_SHIELD_EQUALIZE",			TOGGLE_AUTO_SHIELD_EQUALIZE,			3	},
 };
 
 int num_plr_commands = sizeof(plr_commands)/sizeof(flag_def_list);

--- a/code/playerman/player.h
+++ b/code/playerman/player.h
@@ -52,6 +52,8 @@ struct campaign_info;
 #define PLAYER_FLAGS_KILLED_SELF_UNKNOWN			(1<<16)		// player died by his own hand
 #define PLAYER_FLAGS_KILLED_SELF_MISSILES			(1<<17)		// player died by his own missile
 #define PLAYER_FLAGS_KILLED_SELF_SHOCKWAVE		(1<<18)		// player died by his own shockwave
+#define PLAYER_FLAGS_AUTO_SHIELD_EQUALIZE		(1<<19)		// is auto shield equalization on?
+#define PLAYER_FLAGS_AUTO_SHIELD_EQUALIZE_OVERRIDE	(1<<20)	// is auto shield equalization overridden by manual control?
 
 #define PLAYER_KILLED_SELF						( PLAYER_FLAGS_KILLED_SELF_MISSILES | PLAYER_FLAGS_KILLED_SELF_SHOCKWAVE )
 

--- a/code/playerman/playercontrol.cpp
+++ b/code/playerman/playercontrol.cpp
@@ -1163,6 +1163,10 @@ void player_save_target_and_weapon_link_prefs()
 			Player->flags &= ~PLAYER_FLAGS_LINK_SECONDARY;
 		}
 	}
+
+	if ( Player->flags & PLAYER_FLAGS_AUTO_SHIELD_EQUALIZE ) {
+		Player->save_flags |= PLAYER_FLAGS_AUTO_SHIELD_EQUALIZE;
+	}
 }
 
 /**

--- a/code/ship/shiphit.cpp
+++ b/code/ship/shiphit.cpp
@@ -46,6 +46,7 @@
 #include "parse/parselo.h"
 #include "object/objectsnd.h"
 #include "mod_table/mod_table.h"
+#include "io/keycontrol.h"
 
 //#pragma optimize("", off)
 //#pragma auto_inline(off)
@@ -2114,6 +2115,10 @@ static void ship_do_damage(object *ship_objp, object *other_obj, vec3d *hitpos, 
 			if (piercing_pct > 0.0f) {
 				damage += (piercing_pct * pre_shield);
 				subsystem_damage += (piercing_pct * pre_shield_ss);
+			}
+
+			if (((Player->flags & (PLAYER_FLAGS_AUTO_SHIELD_EQUALIZE | PLAYER_FLAGS_AUTO_SHIELD_EQUALIZE_OVERRIDE)) == PLAYER_FLAGS_AUTO_SHIELD_EQUALIZE) && (ship_objp == Player_obj)) {
+				button_function(SHIELD_EQUALIZE);
 			}
 		}
 


### PR DESCRIPTION
Automatic shield equalization is an optional feature that is toggled by
pressing Alt-Q (this key combination is remappable). When enabled,
damage to shields triggers shield equalization. Automatic shield
equalization can be temporarily overriden by manually adjusting shield
distribution; to re-enable automatic shield equalization, manually
equalize your shields.

Automatic shield equalization is subject to the same 2% power penalty
per equalization (max 1/second) as manual shield equalization; it is
therefore functionally equivalent to mashing Q as fast as possible.