### PR TITLE
Fix Coverity 1298257: Uninitialized scalar var

### DIFF
--- a/code/model/modelrender.cpp
+++ b/code/model/modelrender.cpp
@@ -493,18 +493,11 @@ void draw_list::add_buffer_draw(vertex_buffer *buffer, int texi, uint tmap_flags
 	draw_data.texi = texi;
 	draw_data.flags = tmap_flags;
 
-	draw_data.clr = gr_screen.current_color;
 	draw_data.alpha = Current_alpha;
 	draw_data.blend_filter = Current_blend_filter;
 	draw_data.depth_mode = Current_depth_mode;
 
 	if ( tmap_flags & TMAP_FLAG_BATCH_TRANSFORMS ) {
- 		draw_data.transformation = transform();
- 
-  		draw_data.scale.xyz.x = 1.0f;
-  		draw_data.scale.xyz.y = 1.0f;
-  		draw_data.scale.xyz.z = 1.0f;
-
 		draw_data.transform_buffer_offset = TransformBufferHandler.get_buffer_offset();
 	} else {
 		draw_data.transformation = Current_transform;

--- a/code/model/modelrender.h
+++ b/code/model/modelrender.h
@@ -259,7 +259,7 @@ struct queued_buffer_draw
 		alpha(0.0f),
 		depth_mode(GR_ZBUFF_FULL),
 		transformation(),
-		scale{1.0f,1.0f,1.0f},
+		scale{ { {1.0f,1.0f,1.0f} } },
 		buffer(NULL),
 		texi(0),
 		flags(0),

--- a/code/model/modelrender.h
+++ b/code/model/modelrender.h
@@ -250,17 +250,22 @@ struct queued_buffer_draw
 
 	float thrust_scale;
 
-	queued_buffer_draw()
-	{
-		depth_mode = GR_ZBUFF_FULL;
-
-		texture_maps[TM_BASE_TYPE]		= -1;
-		texture_maps[TM_GLOW_TYPE]		= -1;
-		texture_maps[TM_HEIGHT_TYPE]	= -1;
-		texture_maps[TM_MISC_TYPE]		= -1;
-		texture_maps[TM_NORMAL_TYPE]	= -1;
-		texture_maps[TM_SPECULAR_TYPE]	= -1;
-	}
+	queued_buffer_draw():
+		render_state_handle(0),
+		texture_maps{-1,-1,-1,-1,-1,-1},
+		transform_buffer_offset(0),
+		clr(gr_screen.current_color),
+		blend_filter(0),
+		alpha(0.0f),
+		depth_mode(GR_ZBUFF_FULL),
+		transformation(),
+		scale{1.0f,1.0f,1.0f},
+		buffer(NULL),
+		texi(0),
+		flags(0),
+		sdr_flags(0),
+		thrust_scale(0.0f)
+	{}
 };
 
 struct outline_draw


### PR DESCRIPTION
Add all struct members to constructor (esp thrust_scale which was read
uninitialised). Remove some var sets that the constructor now sets as
defaults. Also fixes 1298248