### PR TITLE
Fix scripting function ad.playMusic

### DIFF
--- a/code/parse/lua.cpp
+++ b/code/parse/lua.cpp
@@ -12063,7 +12063,7 @@ ADE_FUNC(playMusic, l_Audio, "string Filename, [float volume = 1.0, bool looping
 	char *s;
 	float volume = 1.0f;
 	bool loop = true;
-	if(!ade_get_args(L, "s|fb", &s, &volume))
+	if (!ade_get_args(L, "s|fb", &s, &volume, &loop))
 		return ade_set_error(L, "i", -1);
 
 	int ah = audiostream_open(s, ASF_MENUMUSIC);


### PR DESCRIPTION
The `loop` variable wasn't specified in the `ade_get_args` call.