### PR TITLE
Use high-performance GPU by default.

### DIFF
--- a/code/freespace2/freespace.cpp
+++ b/code/freespace2/freespace.cpp
@@ -167,7 +167,13 @@
 
 extern int Om_tracker_flag; // needed for FS2OpenPXO config
 
-
+#ifdef WIN32
+// According to AMD and NV, these _should_ force their drivers into high-performance mode
+extern "C" {
+	_declspec(dllexport) DWORD NvOptimusEnablement = 0x00000001;
+	__declspec(dllexport) int AmdPowerXpressRequestHighPerformance = 1;
+}
+#endif
 
 #ifdef NDEBUG
 #ifdef FRED

--- a/code/freespace2/freespace.cpp
+++ b/code/freespace2/freespace.cpp
@@ -170,7 +170,7 @@ extern int Om_tracker_flag; // needed for FS2OpenPXO config
 #ifdef WIN32
 // According to AMD and NV, these _should_ force their drivers into high-performance mode
 extern "C" {
-	_declspec(dllexport) DWORD NvOptimusEnablement = 0x00000001;
+	__declspec(dllexport) DWORD NvOptimusEnablement = 0x00000001;
 	__declspec(dllexport) int AmdPowerXpressRequestHighPerformance = 1;
 }
 #endif


### PR DESCRIPTION
According to AMD and NV, these _should_ force their drivers into high-performance mode