### PR TITLE
Fix a couple FRED warnings.

### DIFF
--- a/code/fred2/asteroideditordlg.cpp
+++ b/code/fred2/asteroideditordlg.cpp
@@ -440,7 +440,7 @@ void asteroid_editor::update_init()
 	for (k = 0; k < MAX_ACTIVE_DEBRIS_TYPES; k++)
 	{
 		box_index = ((CComboBox*)GetDlgItem(Dlg_id[k]))->AddString("None");
-		((CComboBox*)GetDlgItem(Dlg_id[k]))->SetItemData(box_index, -1);
+		((CComboBox*)GetDlgItem(Dlg_id[k]))->SetItemData(box_index, static_cast<DWORD_PTR>(-1));
 	}
 
 	// now add each kind of debris to each box

--- a/code/fred2/initialstatus.cpp
+++ b/code/fred2/initialstatus.cpp
@@ -848,7 +848,7 @@ void initial_status::list_dockees(int dock_types)
 
 	// add "nothing"
 	z = cboDockees->AddString("Nothing");
-	cboDockees->SetItemData(z, -1);
+	cboDockees->SetItemData(z, static_cast<DWORD_PTR>(-1));
 
 	// add ships
 	for (object *objp = GET_FIRST(&obj_used_list); objp != END_OF_LIST(&obj_used_list); objp = GET_NEXT(objp))


### PR DESCRIPTION
Change a couple instances of setting a DWORD_PTR to -1 by explicitly casting it to a DWORD_PTR.

As odd as this looks, Microsoft actually *expects* people to cast the item data, and at least one example on the MSDN itself uses -1.