### PR TITLE
[Antipodes] Pick a better default resolution

### DIFF
--- a/code/freespace2/freespace.cpp
+++ b/code/freespace2/freespace.cpp
@@ -1879,15 +1879,6 @@ void game_init()
 
 	if ( gr_init() == false ) {
 		SCP_Messagebox(MESSAGEBOX_ERROR, "Error intializing graphics!");
-#if defined(SCP_UNIX)
-		// the default entry should have been created already if it didn't exist, so if we're here then
-		// the current value is invalid and we need to replace it
-		os_config_write_string(NULL, NOX("VideocardFs2open"), NOX("OGL -(1024x768)x16 bit"));
-
-		// courtesy
-		fprintf(stderr, "The default video entry is now in place.  Please try running the game again...\n");
-		fprintf(stderr, "(edit ~/.fs2_open/fs2_open.ini to change from default resolution)\n");
-#endif
 		exit(1);
 		return;
 	}

--- a/code/graphics/2d.cpp
+++ b/code/graphics/2d.cpp
@@ -833,6 +833,21 @@ bool gr_init(int d_mode, int d_width, int d_height, int d_depth)
 		depth = d_depth;
 	}
 
+	// check for hi-res interface files so that we can verify our width/height is correct
+	bool has_sparky_hi = (cf_exists_full("2_ChoosePilot-m.pcx", CF_TYPE_ANY) && cf_exists_full("2_TechShipData-m.pcx", CF_TYPE_ANY));
+
+	// if we don't have it then fall back to 640x480 mode instead
+	if (!has_sparky_hi) {
+		if ((width == 1024) && (height == 768)) {
+			width = 640;
+			height = 480;
+		}
+		else {
+			width = 800;
+			height = 600;
+		}
+	}
+
 	// if we are in standalone mode then just use special defaults
 	if (Is_standalone) {
 		mode = GR_STUB;

--- a/code/graphics/2d.cpp
+++ b/code/graphics/2d.cpp
@@ -36,6 +36,7 @@
 #include "graphics/gropengldraw.h"
 #include "debugconsole/console.h"
 #include "io/timer.h"
+#include "parse/parselo.h"
 
 #if ( SDL_VERSION_ATLEAST(1, 2, 7) )
 #include "SDL_cpuinfo.h"
@@ -757,15 +758,53 @@ bool gr_init(int d_mode, int d_width, int d_height, int d_depth)
 
 	// if we don't have a config string then construct one, using OpenGL 1024x768 32-bit as the default
 	if (ptr == NULL) {
-		ptr = Default_video_settings;
-	}
+		// If we don't have a display mode, use SDL to get default settings
+		// We need to initialize SDL to do this
 
-	Assert( ptr != NULL );
+		if (SDL_InitSubSystem(SDL_INIT_VIDEO) == 0)
+		{
+			SDL_DisplayMode mode;
+			if (SDL_GetDesktopDisplayMode(0, &mode) == 0)
+			{
+				width = mode.w;
+				height = mode.h;
+				int sdlBits = SDL_BITSPERPIXEL(mode.format);
 
-	// NOTE: The "ptr+5" is to skip over the initial "????-" in the video string.
-	//       If the format of that string changes you'll have to change this too!!!
-	if ( sscanf(ptr+5, "(%dx%d)x%d ", &width, &height, &depth) != 3 ) {
-		Error(LOCATION, "Can't understand 'VideocardFs2open' config entry!");
+				if (SDL_ISPIXELFORMAT_ALPHA(mode.format))
+				{
+					depth = sdlBits;
+				}
+				else
+				{
+					// Fix a few values
+					if (sdlBits == 24)
+					{
+						depth = 32;
+					}
+					else if (sdlBits == 15)
+					{
+						depth = 16;
+					}
+					else
+					{
+						depth = sdlBits;
+					}
+				}
+
+				SCP_string videomode;
+				sprintf(videomode, "OGL -(%dx%d)x%d bit", width, height, depth);
+
+				os_config_write_string(NULL, NOX("VideocardFs2open"), videomode.c_str());
+			}
+		}
+	} else {
+		Assert(ptr != NULL);
+
+		// NOTE: The "ptr+5" is to skip over the initial "????-" in the video string.
+		//       If the format of that string changes you'll have to change this too!!!
+		if (sscanf(ptr + 5, "(%dx%d)x%d ", &width, &height, &depth) != 3) {
+			Error(LOCATION, "Can't understand 'VideocardFs2open' config entry!");
+		}
 	}
 
 	if (Cmdline_res != NULL) {
@@ -797,18 +836,7 @@ bool gr_init(int d_mode, int d_width, int d_height, int d_depth)
 
 	// check for hi-res interface files so that we can verify our width/height is correct
 	bool has_sparky_hi = (cf_exists_full("2_ChoosePilot-m.pcx", CF_TYPE_ANY) && cf_exists_full("2_TechShipData-m.pcx", CF_TYPE_ANY));
-
-	// if we don't have it then fall back to 640x480 mode instead
-	if ( !has_sparky_hi ) {
-		if ( (width == 1024) && (height == 768) ) {
-			width = 640;
-			height = 480;
-		} else {
-			width = 800;
-			height = 600;
-		}
-	}
-
+	
 	// if we are in standalone mode then just use special defaults
 	if (Is_standalone) {
 		mode = GR_STUB;

--- a/code/graphics/2d.cpp
+++ b/code/graphics/2d.cpp
@@ -732,7 +732,6 @@ bool gr_init(int d_mode, int d_width, int d_height, int d_depth)
 {
 	int width = 1024, height = 768, depth = 32, mode = GR_OPENGL;
 	const char *ptr = NULL;
-	const char *Default_video_settings = "OGL -(1024x768)x32 bit";
 
 	if ( !Gr_inited ) {
 		atexit(gr_close);
@@ -834,9 +833,6 @@ bool gr_init(int d_mode, int d_width, int d_height, int d_depth)
 		depth = d_depth;
 	}
 
-	// check for hi-res interface files so that we can verify our width/height is correct
-	bool has_sparky_hi = (cf_exists_full("2_ChoosePilot-m.pcx", CF_TYPE_ANY) && cf_exists_full("2_TechShipData-m.pcx", CF_TYPE_ANY));
-	
 	// if we are in standalone mode then just use special defaults
 	if (Is_standalone) {
 		mode = GR_STUB;

--- a/code/osapi/osapi.cpp
+++ b/code/osapi/osapi.cpp
@@ -195,10 +195,6 @@ const char *detect_home(void)
 // for the app name, which is where registry keys are stored.
 void os_init(const char * wclass, const char * title, const char *app_name, const char *version_string )
 {
-	// create default ini entries for the user
-	if (os_config_read_string(NULL, NOX("VideocardFs2open"), NULL) == NULL)
-		os_config_write_string(NULL, NOX("VideocardFs2open"), NOX("OGL -(640x480)x16 bit"));
-
 	os_init_registry_stuff(Osreg_company_name, title, version_string);
 
 	strcpy_s( szWinTitle, title );


### PR DESCRIPTION
Instead of defaulting the resolution to 1024x768 FSO should now pick the desktop resolution as the initial video card configuration.

There is also a fix that disables defaulting to 800x600 when launching from a directory without the required interface art to trigger high resolutions.