### PR TITLE
Expands mouse functionality.

### DIFF
--- a/code/io/mouse.cpp
+++ b/code/io/mouse.cpp
@@ -344,6 +344,7 @@ int mouse_down(int btn)
 	int tmp;
 	if ( !mouse_inited ) return 0;
 
+	// Bail if not a button or wheel direction
 	if ((btn < LOWEST_MOUSE_BUTTON) || (btn > HIGHEST_MOUSE_WHEEL)) return 0;
 
 
@@ -372,6 +373,7 @@ float mouse_down_time(int btn)
 	float tmp;
 	if ( !mouse_inited ) return 0.0f;
 
+	// Bail if not a button or wheel direction
 	if ( (btn < LOWEST_MOUSE_BUTTON) || (btn > HIGHEST_MOUSE_WHEEL)) return 0.0f;
 
 	SDL_LockMutex( mouse_lock );

--- a/code/io/mouse.cpp
+++ b/code/io/mouse.cpp
@@ -534,7 +534,7 @@ void mousewheel_motion(int x, int y) {
 		mouse_flags |= MOUSE_WHEEL_DOWN;
 		mouse_flags &= ~MOUSE_WHEEL_UP;
 	} else {
-		mouse_flags &= (~MOUSE_WHEEL_UP & ~MOUSE_WHEEL_DOWN);
+		mouse_flags &= ~(MOUSE_WHEEL_UP | MOUSE_WHEEL_DOWN);
 	}
 
 	if (Mouse_wheel_x > 0) {
@@ -546,7 +546,7 @@ void mousewheel_motion(int x, int y) {
 		mouse_flags |= MOUSE_WHEEL_LEFT;
 		mouse_flags &= ~MOUSE_WHEEL_RIGHT;
 	} else {
-		mouse_flags &= (~MOUSE_WHEEL_RIGHT & ~MOUSE_WHEEL_LEFT);
+		mouse_flags &= ~(MOUSE_WHEEL_RIGHT | MOUSE_WHEEL_LEFT);
 	}
 }
 
@@ -567,10 +567,10 @@ void mousewheel_decay(int btn) {
 	}
 
 	if (Mouse_wheel_x == 0) {
-		mouse_flags &= (~MOUSE_WHEEL_UP & ~MOUSE_WHEEL_DOWN);
+		mouse_flags &= ~(MOUSE_WHEEL_UP | MOUSE_WHEEL_DOWN);
 	}
 	if (Mouse_wheel_y == 0) {
-		mouse_flags &= (~MOUSE_WHEEL_RIGHT & ~MOUSE_WHEEL_LEFT);
+		mouse_flags &= ~(MOUSE_WHEEL_RIGHT | MOUSE_WHEEL_LEFT);
 	}
 }
 

--- a/code/io/mouse.h
+++ b/code/io/mouse.h
@@ -38,22 +38,39 @@ extern void mouse_get_real_pos(int *mx, int *my);
 
 extern void mouse_set_pos(int xpos,int ypos);
 
-#define MOUSE_LEFT_BUTTON		(1<<0)
-#define MOUSE_RIGHT_BUTTON		(1<<1)
-#define MOUSE_MIDDLE_BUTTON	(1<<2)
+#define MOUSE_LEFT_BUTTON   (1<<0)
+#define MOUSE_RIGHT_BUTTON  (1<<1)
+#define MOUSE_MIDDLE_BUTTON (1<<2)
+#define MOUSE_X1_BUTTON     (1<<3)
+#define MOUSE_X2_BUTTON     (1<<4)
+#define MOUSE_WHEEL_UP      (1<<5)  // Wheel is treated like a pair of buttons, but they don't have a down nor up count
+#define MOUSE_WHEEL_DOWN    (1<<6)
+#define MOUSE_WHEEL_LEFT    (1<<7)
+#define MOUSE_WHEEL_RIGHT   (1<<8)
 
-#define MOUSE_NUM_BUTTONS		3
+#define MOUSE_NUM_BUTTONS		9
 
 // keep the following two #defines up to date with the #defines above
-#define LOWEST_MOUSE_BUTTON	(1<<0)
-#define HIGHEST_MOUSE_BUTTON	(1<<2)
+#define LOWEST_MOUSE_BUTTON     MOUSE_LEFT_BUTTON
+#define HIGHEST_MOUSE_BUTTON    MOUSE_X2_BUTTON
 
-// Returns the number of times button n went from up to down since last call
+#define LOWEST_MOUSE_WHEEL      MOUSE_WHEEL_UP
+#define HIGHEST_MOUSE_WHEEL     MOUSE_WHEEL_RIGHT
+
+/**
+ * @brief Returns the number of times button n went from up to down since last call
+ */
 int mouse_down_count(int n, int reset_count = 1);
-// Returns the number of times button n went from down to up since last call
+
+/**
+ * @brief Returns the number of times button n went from down to up since last call
+ */
 int mouse_up_count(int n);
 
-extern void mouse_flush();
+/**
+ * @brief Flushes the mouse's states clean. Called whenever it gains/loses focus
+ */
+void mouse_flush();
 
 int mouse_down(int btn);			// returns 1 if mouse button btn is down, 0 otherwise
 float mouse_down_time(int btn);	// returns the fraction of time btn has been down since last call
@@ -65,6 +82,11 @@ void mouse_reset_deltas();
 void mouse_get_delta(int *dx = NULL, int *dy = NULL, int *dz = NULL);
 
 void mouse_event(int x, int y, int dx, int dy);
+
+/**
+ * Called when there is motion on the mouse wheel(s). Supports 2 axes
+ */
+void mousewheel_motion(int x, int y);
 
 // portable routines to get and set the mouse position, relative
 // to current window

--- a/code/io/mouse.h
+++ b/code/io/mouse.h
@@ -50,7 +50,9 @@ extern void mouse_set_pos(int xpos,int ypos);
 
 #define MOUSE_NUM_BUTTONS		9
 
-// keep the following two #defines up to date with the #defines above
+// keep the following #defines up to date with the #defines above
+// These mouse_button defines are a quick check to verify the input button is a mouse button
+// Likewise, the mouse_wheel defines quickly check against the mousewheel directions
 #define LOWEST_MOUSE_BUTTON     MOUSE_LEFT_BUTTON
 #define HIGHEST_MOUSE_BUTTON    MOUSE_X2_BUTTON
 

--- a/code/osapi/osapi.cpp
+++ b/code/osapi/osapi.cpp
@@ -420,6 +420,10 @@ void os_poll()
 		case SDL_MOUSEMOTION:
 			mouse_event(event.motion.x, event.motion.y, event.motion.xrel, event.motion.yrel);
 			break;
+
+		case SDL_MOUSEWHEEL:
+			mousewheel_motion(event.wheel.x, event.wheel.y);
+			break;
 		}
 	}
 }


### PR DESCRIPTION
Adds support for the X and Y mousewheels, and X1 and X2 buttons. These currently take up the same mappings as joy buttons 4 through 9.

Of particular note is how the mousewheels reset to neutral, since the SDL API allows for values different from -1, 0, or 1, it's theoretically possible to end up thrashing from UP to DOWN between calls, for example.

 In practice this might not be the case, and if so the mousewheel_motion function could be simplified and mousewheel_decay could be replaced by a simpler "mousewheel_x = 0"