### PR TITLE
Added a $Model Icon Direction ship table entry for overriding the ang…

### DIFF
--- a/code/missionui/missionscreencommon.cpp
+++ b/code/missionui/missionscreencommon.cpp
@@ -1513,6 +1513,11 @@ void draw_model_icon(int model_id, int flags, float closeup_zoom, int x, int y, 
 		//Assume it's a weapon
 		rot_angles.h = -(PI_2);
 	}
+	else if(sip->model_icon_angles.p != 0.0f || sip->model_icon_angles.b != 0.0f || sip->model_icon_angles.h != 0.0f)
+	{
+		// If non-zero model_icon_angles exists, always use that
+		rot_angles = sip->model_icon_angles;
+	}
 	else if(sip->flags & SIF_SMALL_SHIP)
 	{
 		rot_angles.p = -(PI_2);

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -2726,6 +2726,32 @@ int parse_ship_values(ship_info* sip, bool first_time, bool replace)
 		stuff_string(sip->icon_filename, F_NAME, MAX_FILENAME_LEN);
 	}
 
+	if ( optional_string("$Model Icon Direction:") ) {
+		char str[NAME_LENGTH];
+		stuff_string(str, F_NAME, NAME_LENGTH);
+
+		angles model_icon_angles = {0.0f,0.0f,0.0f};
+
+		if (!stricmp(str, "top")) {
+			model_icon_angles.p = -PI_2;
+		} else if (!stricmp(str, "bottom")) {
+			model_icon_angles.p = -PI_2;
+			model_icon_angles.b = 2 * PI_2;
+		} else if (!stricmp(str, "front")) {
+			model_icon_angles.h = 2 * PI_2;
+		} else if (!stricmp(str, "back")) {
+			model_icon_angles.h = 4 * PI_2;
+		} else if (!stricmp(str, "left")) {
+			model_icon_angles.h = -PI_2;
+		} else if (!stricmp(str, "right")) {
+			model_icon_angles.h = PI_2;
+		} else {
+			Warning(LOCATION, "Unrecognized value \"%s\" passed to $Model Icon Direction, ignoring...", str);
+		}
+
+		sip->model_icon_angles = model_icon_angles;
+	}
+
 	// read in filename for animation that is used in ship selection
 	if ( optional_string("$Ship_anim:") ) {
 		stuff_string(sip->anim_filename, F_NAME, MAX_FILENAME_LEN);

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -1325,6 +1325,7 @@ public:
 
 	ubyte	shield_icon_index;				// index to locate ship-specific animation frames for the shield on HUD
 	char	icon_filename[MAX_FILENAME_LEN];	// filename for icon that is displayed in ship selection
+	angles	model_icon_angles;					// angle from which the model icon should be rendered (if not 0,0,0)
 	char	anim_filename[MAX_FILENAME_LEN];	// filename for animation that plays in ship selection
 	char	overhead_filename[MAX_FILENAME_LEN];	// filename for animation that plays weapons loadout
 	int 	selection_effect;


### PR DESCRIPTION
…le from which ship icons are rendered from.

By default the code chooses the angle based on ship flags and max speed, which sometimes is completely different from what you want. This allows you to choose the angle from one of the six cardinal directions.