### PR TITLE
[Antipodes] Make the joystick system use GUIDs to identify the joysticks

### DIFF
--- a/code/cmdline/cmdline.cpp
+++ b/code/cmdline/cmdline.cpp
@@ -93,9 +93,20 @@ enum
 	EASY_DEFAULT_MEM = EASY_DEFAULT | EASY_MEM_OFF
 };
 
-#define BUILD_CAP_OPENAL	(1<<0)
-#define BUILD_CAP_NO_D3D	(1<<1)
-#define BUILD_CAP_NEW_SND	(1<<2)
+enum class BuildCaps
+{
+	OPENAL = (1<<0),
+	NO_D3D = (1<<1),
+	NEW_SND = (1<<2),
+	SDL_BUILD = (1<<3)
+};
+
+// Convenience function to enable |= operator for BuildCaps enum
+ubyte& operator|=(ubyte& in, BuildCaps cap)
+{
+	in |= static_cast<ubyte>(cap);
+	return in;
+}
 
 #define PARSE_COMMAND_LINE_STRING	"-parse_cmdline_only"
 
@@ -1117,9 +1128,10 @@ bool SetCmdlineParams()
 			ubyte build_caps = 0;
 			
 			/* portej05 defined this always */
-			build_caps |= BUILD_CAP_OPENAL;
-			build_caps |= BUILD_CAP_NO_D3D;
-			build_caps |= BUILD_CAP_NEW_SND;
+			build_caps |= BuildCaps::OPENAL;
+			build_caps |= BuildCaps::NO_D3D;
+			build_caps |= BuildCaps::NEW_SND;
+			build_caps |= BuildCaps::SDL_BUILD;
 			
 			
 			fwrite(&build_caps, 1, 1, fp);

--- a/code/cmdline/cmdline.cpp
+++ b/code/cmdline/cmdline.cpp
@@ -93,20 +93,13 @@ enum
 	EASY_DEFAULT_MEM = EASY_DEFAULT | EASY_MEM_OFF
 };
 
-enum class BuildCaps
+enum BuildCaps
 {
-	OPENAL = (1<<0),
-	NO_D3D = (1<<1),
-	NEW_SND = (1<<2),
-	SDL_BUILD = (1<<3)
+	BUILD_CAPS_OPENAL = (1<<0),
+	BUILD_CAPS_NO_D3D = (1<<1),
+	BUILD_CAPS_NEW_SND = (1<<2),
+	BUILD_CAPS_SDL = (1<<3)
 };
-
-// Convenience function to enable |= operator for BuildCaps enum
-ubyte& operator|=(ubyte& in, BuildCaps cap)
-{
-	in |= static_cast<ubyte>(cap);
-	return in;
-}
 
 #define PARSE_COMMAND_LINE_STRING	"-parse_cmdline_only"
 
@@ -1128,10 +1121,10 @@ bool SetCmdlineParams()
 			ubyte build_caps = 0;
 			
 			/* portej05 defined this always */
-			build_caps |= BuildCaps::OPENAL;
-			build_caps |= BuildCaps::NO_D3D;
-			build_caps |= BuildCaps::NEW_SND;
-			build_caps |= BuildCaps::SDL_BUILD;
+			build_caps |= BUILD_CAPS_OPENAL;
+			build_caps |= BUILD_CAPS_NO_D3D;
+			build_caps |= BUILD_CAPS_NEW_SND;
+			build_caps |= BUILD_CAPS_SDL;
 			
 			
 			fwrite(&build_caps, 1, 1, fp);

--- a/code/io/joy.h
+++ b/code/io/joy.h
@@ -12,6 +12,9 @@
 #ifndef __JOY_H__
 #define __JOY_H__
 
+#include "globalincs/pstypes.h"
+#include "SDL_joystick.h"
+
 #define JOY_NUM_BUTTONS		32
 #define JOY_NUM_HAT_POS		4
 #define JOY_TOTAL_BUTTONS	(JOY_NUM_BUTTONS + JOY_NUM_HAT_POS)
@@ -52,5 +55,7 @@ void joy_get_delta(int *dx, int *dy);
 int joy_get_scaled_reading(int raw, int axn);
 int joy_get_unscaled_reading(int raw, int axn);
 void joy_close();
+void joy_device_changed(int state, int device);
+SDL_Joystick* joy_get_device();
 
 #endif	/* __JOY_H__ */

--- a/code/io/joy_ff-sdl.cpp
+++ b/code/io/joy_ff-sdl.cpp
@@ -14,6 +14,7 @@
 #include "math/vecmat.h"
 #include "osapi/osregistry.h"
 #include "io/joy_ff.h"
+#include "io/joy.h"
 #include "osapi/osapi.h"
 
 #include "SDL_haptic.h"
@@ -22,8 +23,6 @@
 #ifndef SDL_INIT_HAPTIC
 #define SDL_INIT_HAPTIC		0x00001000
 #endif
-
-extern SDL_Joystick *sdljoy;
 
 static int Joy_ff_enabled = 0;
 static SDL_Haptic *haptic = NULL;
@@ -71,13 +70,13 @@ int joy_ff_init()
 		return -1;
 	}
 
-	if ( !SDL_JoystickIsHaptic(sdljoy) ) {
+	if (!SDL_JoystickIsHaptic(joy_get_device())) {
 		mprintf(("    ERROR: Joystick does not have haptic capabilities\n"));
 		SDL_QuitSubSystem(SDL_INIT_HAPTIC);
 		return -1;
 	}
 
-	haptic = SDL_HapticOpenFromJoystick(sdljoy);
+	haptic = SDL_HapticOpenFromJoystick(joy_get_device());
 
 	if (haptic == NULL) {
 		mprintf(("    ERROR: Unable to open haptic joystick\n"));

--- a/code/osapi/osapi.cpp
+++ b/code/osapi/osapi.cpp
@@ -413,6 +413,10 @@ void os_poll()
 			}
 			break;
 		
+		case SDL_JOYDEVICEADDED:
+		case SDL_JOYDEVICEREMOVED:
+			joy_device_changed(event.jdevice.type, event.jdevice.which);
+			break;
 		case SDL_MOUSEMOTION:
 			mouse_event(event.motion.x, event.motion.y, event.motion.xrel, event.motion.yrel);
 			break;


### PR DESCRIPTION
The config value `CurrentJoystickGUID` will be read to determine what joystick is selected, if that value isn't present the old `CurrentJoystick` value will be read.
To let launchers know that this build uses SDL I added a new build flag, older launchers can still use `CurrentJoystick` to set the selected joystick but the GUID value will override the old config value.

This also adds support for removing and reconnecting a device while FSO is running which wasn't possible before.