### PR TITLE
Replace Sleep with os_sleep

### DIFF
--- a/code/freespace2/freespace.cpp
+++ b/code/freespace2/freespace.cpp
@@ -4808,7 +4808,7 @@ void game_set_frametime(int state)
 		if (Frametime < cap) {
 			thistime = cap - Frametime;
 //  			mprintf(("Sleeping for %6.3f seconds.\n", f2fl(thistime)));
-			Sleep( DWORD(f2fl(thistime) * 1000.0f) );
+			os_sleep(static_cast<int>(f2fl(thistime) * 1000.0f));
 			Frametime = cap;
 			thistime = timer_get_fixed_seconds();
 		}
@@ -4818,7 +4818,7 @@ void game_set_frametime(int state)
 		(f2fl(Frametime) < ((float)1.0/(float)Multi_options_g.std_framecap))){
 
 		frame_cap_diff = ((float)1.0/(float)Multi_options_g.std_framecap) - f2fl(Frametime);		
-		Sleep((DWORD)(frame_cap_diff*1000)); 				
+		os_sleep(static_cast<int>(frame_cap_diff*1000)); 				
 		
 		thistime += fl2f((frame_cap_diff));		
 

--- a/code/fs2netd/fs2netd_client.cpp
+++ b/code/fs2netd/fs2netd_client.cpp
@@ -33,6 +33,7 @@
 #include "cfile/cfilesystem.h"
 #include "network/multimsgs.h"
 #include "mod_table/mod_table.h"
+#include "osapi/osapi.h"
 
 #ifndef WIN32
 #include <cstdio>
@@ -184,12 +185,12 @@ void fs2netd_reset_connection()
 	fs2netd_reset_state();
 
 	// wait a little to allow for the port to clear
-	Sleep(500);
+	os_sleep(500);
 
 	// try to reinit the server connection
 	fs2netd_login();
 
-	Sleep(250);
+	os_sleep(250);
 
 	if ( reset_gameserver && fs2netd_is_online() ) {
 		fs2netd_gameserver_start();
@@ -210,14 +211,14 @@ void fs2netd_disconnect()
 
 	fs2netd_reset_state();
 
-	Sleep(500);
+	os_sleep(500);
 }
 
 static int fs2netd_connect_do()
 {
 	int retval = FS2NetD_ConnectToServer(Multi_options_g.game_tracker_ip, Multi_options_g.tracker_port);
 
-	Sleep(5);
+	os_sleep(5);
 
 	switch (retval) {
 		// connection failed
@@ -396,7 +397,7 @@ bool fs2netd_login()
 			popup(PF_USE_AFFIRMATIVE_ICON, 1, POPUP_OK, XSTR("Failed to connect to FS2NetD server!", 1578));
 		} else {
 			std_gen_set_text("Connect FAILED!", 1);
-			Sleep(2000);
+			os_sleep(2000);
 			std_destroy_gen_dialog();
 		}
 
@@ -511,7 +512,7 @@ bool fs2netd_login()
 		popup(PF_USE_AFFIRMATIVE_ICON, 1, POPUP_OK, error_str);
 	} else if ( Is_standalone && std_gen_is_active() && strlen(std_error_str) ) {
 		std_gen_set_text(std_error_str, 1);
-		Sleep(2000);
+		os_sleep(2000);
 	}
 
 	if (retval) {
@@ -630,7 +631,7 @@ static void fs2netd_handle_messages()
 
 		bytes_read += read_size;
 
-		Sleep(20);
+		os_sleep(20);
 	}
 
 	if ( (bytes_read == 0) || (bytes_read < BASE_PACKET_SIZE) ) {

--- a/code/fs2netd/tcp_client.cpp
+++ b/code/fs2netd/tcp_client.cpp
@@ -24,6 +24,7 @@
 #include "ship/ship.h"
 #include "io/timer.h"
 #include "globalincs/pstypes.h"
+#include "osapi/osapi.h"
 
 #include <iostream>
 #include <string>
@@ -63,7 +64,7 @@ int FS2NetD_CheckSingleMission(const char *m_name, uint crc32, bool do_send)
 
 			rc_total += rc;
 
-			Sleep(20);
+			os_sleep(20);
 		} while ( FS2NetD_DataReady() && (rc_total < (int)sizeof(buffer)) );
 
 		if (rc < BASE_PACKET_SIZE) {
@@ -165,7 +166,7 @@ int FS2NetD_SendPlayerData(const char *player_name, player *pl, bool do_send)
 
 			rc_total += rc;
 
-			Sleep(20);
+			os_sleep(20);
 		} while ( FS2NetD_DataReady() && (rc_total < (int)sizeof(buffer)) );
 
 		if (rc < BASE_PACKET_SIZE) {
@@ -231,7 +232,7 @@ int FS2NetD_GetPlayerData(const char *player_name, player *pl, bool can_create, 
 
 			rc_total += rc;
 
-			Sleep(20);
+			os_sleep(20);
 		} while ( FS2NetD_DataReady() && (rc_total < (int)sizeof(buffer)) );
 
 		if (rc < BASE_PACKET_SIZE) {
@@ -260,7 +261,7 @@ int FS2NetD_GetPlayerData(const char *player_name, player *pl, bool can_create, 
 				rc_total += rc;
 			}
 
-			Sleep(20);
+			os_sleep(20);
 		}
 
 		PXO_GET_DATA( reply_type );
@@ -343,7 +344,7 @@ int FS2NetD_GetBanList(SCP_vector<SCP_string> &mask_list, bool do_send)
 
 			rc_total += rc;
 
-			Sleep(20);
+			os_sleep(20);
 		} while ( FS2NetD_DataReady() && (rc_total < (int)sizeof(buffer)) );
 
 		if (rc < BASE_PACKET_SIZE) {
@@ -372,7 +373,7 @@ int FS2NetD_GetBanList(SCP_vector<SCP_string> &mask_list, bool do_send)
 				rc_total += rc;
 			}
 
-			Sleep(20);
+			os_sleep(20);
 		}
 
 		PXO_GET_INT( num_files );
@@ -417,7 +418,7 @@ int FS2NetD_GetMissionsList(SCP_vector<file_record> &m_list, bool do_send)
 
 			rc_total += rc;
 
-			Sleep(20);
+			os_sleep(20);
 		} while ( FS2NetD_DataReady() && (rc_total < (int)sizeof(buffer)) );
 
 		if (rc < BASE_PACKET_SIZE) {
@@ -446,7 +447,7 @@ int FS2NetD_GetMissionsList(SCP_vector<file_record> &m_list, bool do_send)
 				rc_total += rc;
 			}
 
-			Sleep(20);
+			os_sleep(20);
 		}
 
 		PXO_GET_INT( num_files );
@@ -500,7 +501,7 @@ int FS2NetD_Login(const char *username, const char *password, bool do_send)
 
 			rc_total += rc;
 
-			Sleep(20);
+			os_sleep(20);
 		} while ( FS2NetD_DataReady() && (rc_total < (int)sizeof(buffer)) );
 
 		if (rc < BASE_PACKET_SIZE) {
@@ -721,7 +722,7 @@ int FS2NetD_ValidateTableList(bool do_send)
 
 			rc_total += rc;
 
-			Sleep(20);
+			os_sleep(20);
 		} while ( FS2NetD_DataReady() && (rc_total < (int)sizeof(buffer)) );
 
 		if (rc < BASE_PACKET_SIZE) {
@@ -746,7 +747,7 @@ int FS2NetD_ValidateTableList(bool do_send)
 				rc_total += rc;
 			}
 
-			Sleep(20);
+			os_sleep(20);
 		}
 
 		PXO_GET_USHORT( num_tables );

--- a/code/graphics/2d.cpp
+++ b/code/graphics/2d.cpp
@@ -931,7 +931,7 @@ void gr_force_windowed()
 	}
 
 	if ( Os_debugger_running ) {
-		Sleep(1000);
+		os_sleep(1000);
 	}
 }
 

--- a/code/inetfile/cftp.cpp
+++ b/code/inetfile/cftp.cpp
@@ -29,6 +29,7 @@
 #define WSAGetLastError()  (errno)
 #endif
 
+#include "osapi/osapi.h"
 #include "inetfile/cftp.h"
 
 
@@ -498,7 +499,7 @@ uint CFtpGet::ReadFTPServerReply()
 			strcat_s(recv_buffer,chunk);
 		}
 		
-		Sleep(1);	
+		os_sleep(1);	
 	}while(igotcrlf==0);
 					
 	if(recv_buffer[3] == '-')
@@ -538,7 +539,7 @@ uint CFtpGet::ReadDataChannel()
 			fwrite(sDataBuffer,nBytesRecv,1,LOCALFILE);
     	}
 
-		Sleep(1);
+		os_sleep(1);
 	}while (nBytesRecv > 0);
 	fclose(LOCALFILE);							
 	// Close the file and check for error returns.
@@ -577,6 +578,6 @@ void CFtpGet::FlushControlChannel()
 	{
 		recv(m_ControlSock,flushbuff,1,0);
 
-		Sleep(1);
+		os_sleep(1);
 	}
 }

--- a/code/inetfile/chttpget.cpp
+++ b/code/inetfile/chttpget.cpp
@@ -35,6 +35,7 @@
 #include <ctype.h>
 #include <errno.h>
 
+#include "osapi/osapi.h"
 #include "inetfile/inetgetfile.h"
 #include "inetfile/chttpget.h"
 
@@ -63,7 +64,7 @@ int HTTPObjThread( void *obj )
 void ChttpGet::AbortGet()
 {
 	m_Aborting = true;
-	while(!m_Aborted) Sleep(50); //Wait for the thread to end
+	while(!m_Aborted) os_sleep(50); //Wait for the thread to end
 }
 
 ChttpGet::ChttpGet(char *URL,char *localfile,char *proxyip,unsigned short proxyport)
@@ -272,7 +273,7 @@ if (!p) return;
 
 				}
 
-				Sleep(1);
+				os_sleep(1);
 			}while(!idataready);
 		ReadDataChannel();
 		return;
@@ -313,7 +314,7 @@ int ChttpGet::ConnectSocket()
 			}
 			rcode = http_Asyncgethostbyname(&ip,NW_AGHBN_READ,m_szHost);
 
-			Sleep(1);
+			os_sleep(1);
 		}while(rcode==0);
 	}
 	
@@ -357,7 +358,7 @@ int ChttpGet::ConnectSocket()
 				}
 				rcode = http_Asyncgethostbyname(&ip,NW_AGHBN_READ,m_ProxyIP);
 
-				Sleep(1);
+				os_sleep(1);
 			}while(rcode==0);
 			
 			
@@ -416,7 +417,7 @@ int ChttpGet::ConnectSocket()
 				break;
 			}
 
-			Sleep(1);
+			os_sleep(1);
 		}
 	}
 
@@ -460,7 +461,7 @@ char *ChttpGet::GetHTTPLine()
 				gotdata = true;
 			}
 
-			Sleep(1);
+			os_sleep(1);
 		}while(!gotdata);
 		
 		if(chunk[0]==0x0d)
@@ -486,7 +487,7 @@ char *ChttpGet::GetHTTPLine()
 					gotdata = true;
 				}
 
-				Sleep(1);
+				os_sleep(1);
 			}while(!gotdata);
 			igotcrlf = 1;	
 		}
@@ -495,7 +496,7 @@ char *ChttpGet::GetHTTPLine()
 			strcat_s(recv_buffer,chunk);
 		}
 		
-		Sleep(1);
+		os_sleep(1);
 	}while(igotcrlf==0);
 	return recv_buffer;	
 }
@@ -553,7 +554,7 @@ uint ChttpGet::ReadDataChannel()
 			fwrite(sDataBuffer, nBytesRecv, 1, LOCALFILE);
     	}
 		
-		Sleep(1);
+		os_sleep(1);
 	} while (nBytesRecv > 0);
 
 	fclose(LOCALFILE);	

--- a/code/network/multi.cpp
+++ b/code/network/multi.cpp
@@ -1595,7 +1595,7 @@ void standalone_main_init()
 void standalone_main_do()
 {
  
-   Sleep(10);  // since nothing will really be going on here, we can afford to give some time
+   os_sleep(10);  // since nothing will really be going on here, we can afford to give some time
                // back to the operating system.
 
 	// kind of a do-nothing spin state.

--- a/code/network/multi_pause.cpp
+++ b/code/network/multi_pause.cpp
@@ -26,6 +26,7 @@
 #include "network/multi.h"
 #include "globalincs/alphacolors.h"
 #include "io/timer.h"
+#include "osapi/osapi.h"
 
 
 
@@ -440,7 +441,7 @@ void multi_pause_do()
 	}
 	// standalone pretty much does nothing here
 	else {
-		Sleep(1);
+		os_sleep(1);
 	}
 }
 

--- a/code/network/stand_gui-unix.cpp
+++ b/code/network/stand_gui-unix.cpp
@@ -175,6 +175,7 @@ std::string base64_decode(std::string const& encoded_string) {
 #include "playerman/player.h"
 #include "mission/missiongoals.h"
 #include "ship/ship.h"
+#include "osapi/osapi.h"
 
 #include "network/multi.h"
 #include "network/multiutil.h"
@@ -410,7 +411,7 @@ json_t* serverPut(ResourceContext *context) {
         // update fs2netd with the info
         if (MULTI_IS_TRACKER_GAME) {
             fs2netd_gameserver_disconnect();
-            Sleep(50);
+            os_sleep(50);
             fs2netd_gameserver_start();
         }
     }
@@ -898,7 +899,7 @@ void std_connect_set_gamename(char *name)
 		// update fs2netd
 		if (MULTI_IS_TRACKER_GAME) {
 			fs2netd_gameserver_disconnect();
-			Sleep(50);
+			os_sleep(50);
 			fs2netd_gameserver_start();
 		}
 	}

--- a/code/network/stand_gui.cpp
+++ b/code/network/stand_gui.cpp
@@ -36,6 +36,7 @@
 #include "ship/ship.h"
 #include "cfile/cfile.h"
 #include "fs2netd/fs2netd_client.h"
+#include "osapi/osapi.h"
 
 #include <string>
 
@@ -388,7 +389,7 @@ void std_connect_set_gamename(char *name)
 		// update fs2netd
 		if (MULTI_IS_TRACKER_GAME) {
 			fs2netd_gameserver_disconnect();
-			Sleep(50);
+			os_sleep(50);
 			fs2netd_gameserver_start();
 		}
 	}
@@ -428,7 +429,7 @@ void std_connect_handle_name_change()
 		// update fs2netd with the info
 		if (MULTI_IS_TRACKER_GAME) {
 			fs2netd_gameserver_disconnect();
-			Sleep(50);
+			os_sleep(50);
 			fs2netd_gameserver_start();
 		}
 	}

--- a/code/windows_stub/config.h
+++ b/code/windows_stub/config.h
@@ -287,7 +287,6 @@ char *strnset( char *string, int fill, size_t count);
 #define _hypot(x, y)  hypot(x, y)
 
 int MulDiv(int number, int numerator, int denominator);
-void Sleep(int mili);
 
 struct POINT {
 	int x, y;

--- a/code/windows_stub/stubs.cpp
+++ b/code/windows_stub/stubs.cpp
@@ -76,21 +76,6 @@ int filelength(int fd)
 	return buf.st_size;
 }
 
-// non-blocking process pause
-void Sleep(int mili)
-{
-#ifdef __APPLE__
-	// ewwww, I hate this!!  SDL_Delay() is causing issues for us though and this
-	// basically matches Apple examples of the same thing.  Same as SDL_Delay() but
-	// we aren't hitting up the system for anything during the process
-	uint then = SDL_GetTicks() + mili;
-
-	while (then > SDL_GetTicks());
-#else
-	SDL_Delay(mili);
-#endif
-}
-
 extern void os_deinit();
 // fatal assertion error
 void WinAssert(char * text, char *filename, int line)


### PR DESCRIPTION
The `Sleep` WinAPI function was emulated on linux but we now have `os_sleep` so I replaced all remaining usages of `Sleep` with that function.

This also merges the latest changes from master into antipodes.