### PR TITLE
Eliminate sorting of draw calls for skyboxes for correctness.

### DIFF
--- a/code/model/modelrender.cpp
+++ b/code/model/modelrender.cpp
@@ -841,9 +841,11 @@ void draw_list::init()
 	TransformBufferHandler.reset();
 }
 
-void draw_list::init_render()
+void draw_list::init_render(bool sort)
 {
-	sort_draws();
+	if ( sort ) {
+		sort_draws();
+	}
 
 	TransformBufferHandler.submit_buffer_data();
 }
@@ -2623,7 +2625,7 @@ void model_render_debug(int model_num, matrix *orient, vec3d * pos, uint flags, 
 	gr_zbuffer_set(save_gr_zbuffering_mode);
 }
 
-void model_render_immediate(model_render_params *render_info, int model_num, matrix *orient, vec3d * pos, int render)
+void model_render_immediate(model_render_params *render_info, int model_num, matrix *orient, vec3d * pos, int render, bool sort)
 {
 	draw_list model_list;
 
@@ -2631,7 +2633,7 @@ void model_render_immediate(model_render_params *render_info, int model_num, mat
 
 	model_render_queue(render_info, &model_list, model_num, orient, pos);
 
-	model_list.init_render();
+	model_list.init_render(sort);
 
 	switch ( render ) {
 	case MODEL_RENDER_OPAQUE:

--- a/code/model/modelrender.h
+++ b/code/model/modelrender.h
@@ -379,7 +379,7 @@ public:
 	void set_light_filter(int objnum, vec3d *pos, float rad);
 	void set_light_factor(float factor);
 
-	void init_render();
+	void init_render(bool sort = true);
 	void render_all(int depth_mode = -1);
 	void reset();
 };
@@ -393,7 +393,7 @@ public:
 };
 
 //void model_immediate_render(int model_num, matrix *orient, vec3d * pos, uint flags = MR_NORMAL, int objnum = -1, int lighting_skip = -1, int *replacement_textures = NULL);
-void model_render_immediate(model_render_params *render_info, int model_num, matrix *orient, vec3d * pos, int render = MODEL_RENDER_ALL);
+void model_render_immediate(model_render_params *render_info, int model_num, matrix *orient, vec3d * pos, int render = MODEL_RENDER_ALL, bool sort = true);
 void model_render_queue(model_render_params *render_info, draw_list* scene, int model_num, matrix *orient, vec3d *pos);
 //void model_queue_render(DrawList* scene, int model_num, int model_instance_num, matrix *orient, vec3d *pos, uint flags, int objnum, int *replacement_textures, const bool is_skybox = false);
 //void submodel_immediate_render(int model_num, int submodel_num, matrix *orient, vec3d * pos, uint flags = MR_NORMAL, int objnum = -1, int *replacement_textures = NULL);

--- a/code/starfield/starfield.cpp
+++ b/code/starfield/starfield.cpp
@@ -2165,7 +2165,7 @@ void stars_draw_background()
 	render_info.set_alpha(1.0f);
 	render_info.set_flags(Nmodel_flags | MR_SKYBOX);
 
-	model_render_immediate(&render_info, Nmodel_num, &Nmodel_orient, &Eye_position, MODEL_RENDER_ALL);
+	model_render_immediate(&render_info, Nmodel_num, &Nmodel_orient, &Eye_position, MODEL_RENDER_ALL, false);
 }
 
 // call this to set a specific model as the background model


### PR DESCRIPTION
I noticed the Saturn rings in the Diaspora mission Shadow Walking were not being occluded by the planet's surface. My draw call sorting system was causing that issue. So, I wrote a simple fix to disable sorting when drawing skyboxes.