### PR TITLE
Added a $Max Shield Recharge ship table entry for limiting how full t…

### DIFF
--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -1838,6 +1838,7 @@ int parse_create_object_sub(p_object *p_objp)
 
 	shipp->ship_max_shield_strength = p_objp->ship_max_shield_strength;
 	shipp->ship_max_hull_strength =  p_objp->ship_max_hull_strength;
+	shipp->max_shield_recharge = p_objp->max_shield_recharge;
 
 	// Goober5000 - ugh, this is really stupid having to do this here; if the
 	// ship creation code was better organized this wouldn't be necessary
@@ -2250,7 +2251,7 @@ int parse_create_object_sub(p_object *p_objp)
 		Objects[objnum].hull_strength = p_objp->initial_hull * shipp->ship_max_hull_strength / 100.0f;
 		for (iLoop = 0; iLoop<Objects[objnum].n_quadrants; iLoop++)
 		{
-			Objects[objnum].shield_quadrant[iLoop] = (float) (p_objp->initial_shields * get_max_shield_quad(&Objects[objnum]) / 100.0f);
+			Objects[objnum].shield_quadrant[iLoop] = (float) (shipp->max_shield_recharge * p_objp->initial_shields * get_max_shield_quad(&Objects[objnum]) / 100.0f);
 		}
 
 		// initial velocities now do not apply to ships which warp in after mission starts
@@ -3110,6 +3111,7 @@ int parse_object(mission *pm, int flag, p_object *p_objp)
 	}
 
 	Assert(p_objp->ship_max_hull_strength > 0.0f);	// Goober5000: div-0 check (not shield because we might not have one)
+	p_objp->max_shield_recharge = Ship_info[p_objp->ship_class].max_shield_recharge;
 
 
 	// if the kamikaze flag is set, we should have the next flag
@@ -7558,6 +7560,7 @@ void mission_bring_in_support_ship( object *requester_objp )
 	// set support ship hitpoints
 	pobj->ship_max_hull_strength = Ship_info[i].max_hull_strength;
 	pobj->ship_max_shield_strength = Ship_info[i].max_shield_strength;
+	pobj->max_shield_recharge = Ship_info[i].max_shield_recharge;
 
 	pobj->team = requester_shipp->team;
 

--- a/code/mission/missionparse.h
+++ b/code/mission/missionparse.h
@@ -424,6 +424,8 @@ public:
 	float ship_max_hull_strength;			// Needed to deal with special hitpoints
 	float ship_max_shield_strength;
 
+	float max_shield_recharge;
+
 	// Goober5000
 	SCP_vector<texture_replace> replacement_textures;
 

--- a/code/object/objectshield.cpp
+++ b/code/object/objectshield.cpp
@@ -49,10 +49,19 @@ void shield_add_strength(object *objp, float delta)
 	if (delta == 0.0f)
 		return;
 
-	
+	float shield_str = shield_get_strength(objp);
+	float shield_recharge_limit = Ships[objp->instance].ship_max_shield_strength * Ships[objp->instance].max_shield_recharge;
+
+	if (shield_str >= shield_recharge_limit)
+		return;
+
 	if (!(Ai_info[Ships[objp->instance].ai_index].ai_profile_flags & AIPF_SMART_SHIELD_MANAGEMENT)
 		|| delta <= 0.0f) //SUSHI: We don't want smart shield management for negative delta
 	{
+		// set the limit for the shield recharge
+		if ((delta > 0.0f) && ((shield_str + delta) > shield_recharge_limit))
+			delta = shield_recharge_limit - shield_str;
+
 		for (int i = 0; i < objp->n_quadrants; i++)
 			shield_add_quad(objp, i, delta / objp->n_quadrants);
 	}
@@ -81,7 +90,11 @@ void shield_add_strength(object *objp, float delta)
 			// all quads are at full strength
 			if (weakest >= section_max)
 				break;
-		
+
+			// set the limit for the shield recharge
+			if ((delta > 0.0f) && ((shield_str + delta) > shield_recharge_limit))
+				delta = shield_recharge_limit - shield_str;
+
 			// throw all possible shield power at this quadrant
 			// if there's any left over then apply it to the next weakest on the next pass
 			float xfer_amount;

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -16555,6 +16555,7 @@ void parse_copy_damage(p_object *target_pobjp, ship *source_shipp)
 	// ...and shields
 	target_pobjp->ship_max_shield_strength = source_shipp->ship_max_shield_strength;
 	target_pobjp->initial_shields = fl2i(get_shield_pct(source_objp) * 100.0f);
+	target_pobjp->max_shield_recharge = source_shipp->max_shield_recharge;
 
 
 	// search through all subsystems on source ship and map them onto target ship

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -867,6 +867,8 @@ void init_ship_entry(ship_info *sip)
 	sip->max_hull_strength = 100.0f;
 	sip->max_shield_strength = 0.0f;
 
+	sip->max_shield_recharge = 1.0f;
+
 	sip->auto_shield_spread = 0.0f;
 	sip->auto_shield_spread_bypass = false;
 	sip->auto_shield_spread_from_lod = -1;
@@ -2369,6 +2371,11 @@ int parse_ship_values(ship_info* sip, bool first_time, bool replace)
 
 		if ( VALID_FNAME(fname) )
 			sip->shield_impact_explosion_anim = Weapon_explosions.Load(fname);
+	}
+
+	if(optional_string("$Max Shield Recharge:")){
+		stuff_float(&sip->max_shield_recharge);
+		CLAMP(sip->max_shield_recharge, 0.0f, 1.0f);
 	}
 
 	// The next five fields are used for the ETS
@@ -5129,12 +5136,14 @@ void ship_set(int ship_index, int objnum, int ship_type)
 	}
 	objp->hull_strength = shipp->ship_max_hull_strength;
 
+	shipp->max_shield_recharge = sip->max_shield_recharge;
+
 	if (Fred_running) {
 		shipp->ship_max_shield_strength = 100.0f;
 		objp->shield_quadrant[0] = 100.0f;
 	} else {
 		shipp->ship_max_shield_strength = sip->max_shield_strength;
-		shield_set_strength(objp, shipp->ship_max_shield_strength);
+		shield_set_strength(objp, shipp->ship_max_shield_strength * shipp->max_shield_recharge);
 	}
 
 	if (sip->flags2 & SIF2_MODEL_POINT_SHIELDS) {
@@ -9300,6 +9309,8 @@ void change_ship_type(int n, int ship_type, int by_sexp)
 		objp->hull_strength = hull_pct * sp->ship_max_hull_strength;
 	}
 
+	sp->max_shield_recharge = sip->max_shield_recharge;
+
 	// set the correct shield strength
 	if (Fred_running) {
 		if (sp->ship_max_shield_strength)
@@ -12740,7 +12751,7 @@ float ship_calculate_rearm_duration( object *objp )
 
 	//find out time to repair shields
 	if(sip->sup_shield_repair_rate > 0.0f)
-		shield_rep_time = (sp->ship_max_shield_strength - shield_get_strength(objp)) / (sp->ship_max_shield_strength * sip->sup_shield_repair_rate);
+		shield_rep_time = ((sp->ship_max_shield_strength * sp->max_shield_recharge) - shield_get_strength(objp)) / (sp->max_shield_recharge * sp->ship_max_shield_strength * sip->sup_shield_repair_rate);
 	
 	max_hull_repair = sp->ship_max_hull_strength * (The_mission.support_ships.max_hull_repair_val * 0.01f);
 	if ((The_mission.flags & MISSION_FLAG_SUPPORT_REPAIRS_HULL) && (max_hull_repair > objp->hull_strength) && (sip->sup_hull_repair_rate > 0.0f))
@@ -12876,7 +12887,7 @@ int ship_do_rearm_frame( object *objp, float frametime )
 	if ( !(objp->flags & OF_NO_SHIELDS) )
 	{
 		shield_str = shield_get_strength(objp);
-		if ( shield_str < shipp->ship_max_shield_strength ) {
+		if ( shield_str < (shipp->ship_max_shield_strength * shipp->max_shield_recharge) ) {
 			if ( objp == Player_obj ) {
 				player_maybe_start_repair_sound();
 			}

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -592,6 +592,8 @@ public:
 	float ship_max_shield_strength;
 	float ship_max_hull_strength;
 
+	float max_shield_recharge;
+
 	int ship_guardian_threshold;	// Goober5000 - now also determines whether ship is guardian'd
 
 
@@ -1305,6 +1307,8 @@ public:
 	int		auto_shield_spread_from_lod;
 
 	int		shield_point_augment_ctrls[4];	// Re-mapping of shield augmentation controls for model point shields
+
+	float	max_shield_recharge;
 
 	float	hull_repair_rate;				//How much of the hull is repaired every second
 	float	subsys_repair_rate;		//How fast 


### PR DESCRIPTION
…he shields may recharge.

The main intended use being that by setting a recharge limit (<1.0), you can still move energy between shield segments even if the shields are fully charged. For example with 2 shield segments and $Max Shield Recharge: 0.5, the max total energy will be half of what it would be normally, allowing either segment to be augmented further (at the expense of the other) even when the shields are full.