### PR TITLE
Add unified dialog handling

### DIFF
--- a/code/Makefile.am
+++ b/code/Makefile.am
@@ -593,6 +593,8 @@ FS2_SOURCES =	\
 	object/waypoint.h	\
 	observer/observer.cpp	\
 	observer/observer.h	\
+	osapi/dialogs.cpp	\
+	osapi/dialogs.h	\
 	osapi/osapi.cpp	\
 	osapi/osapi.h	\
 	osapi/outwnd.cpp	\

--- a/code/globalincs/pstypes.h
+++ b/code/globalincs/pstypes.h
@@ -220,13 +220,7 @@ typedef struct coord2d {
 	int x,y;
 } coord2d;
 
-//This are defined in MainWin.c
-extern void _cdecl WinAssert(char * text,char *filename, int line);
-void _cdecl WinAssert(char * text, char * filename, int linenum, const char * format, ... );
-extern void LuaError(struct lua_State *L, char *format=NULL, ...);
-extern void _cdecl Error( const char * filename, int line, const char * format, ... );
-extern void _cdecl Warning( char * filename, int line, const char * format, ... );
-extern void _cdecl WarningEx( char *filename, int line, const char *format, ... );
+#include "osapi/dialogs.h"
 
 extern int Global_warning_count;
 extern int Global_error_count;
@@ -276,10 +270,9 @@ extern int Global_error_count;
 #		endif
 #	endif
 #else
-	void gr_activate(int);
 #	define Assert(expr) do {\
 		if (!(expr)) {\
-			WinAssert(#expr,__FILE__,__LINE__);\
+			os::dialogs::AssertMessage(#expr,__FILE__,__LINE__);\
 		}\
 		ASSUME( expr );\
 	} while (0)
@@ -288,21 +281,21 @@ extern int Global_error_count;
 #	ifndef _MSC_VER   // non MS compilers
 #		define Assertion(expr, msg, ...) do {\
 			if (!(expr)) {\
-				WinAssert(#expr,__FILE__,__LINE__, msg , ##__VA_ARGS__ );\
+				os::dialogs::AssertMessage(#expr,__FILE__,__LINE__, msg , ##__VA_ARGS__ );\
 			}\
 		} while (0)
 #	else
 #		if _MSC_VER >= 1400	// VC 2005 or greater
 #			define Assertion(expr, msg, ...) do {\
 				if (!(expr)) {\
-					WinAssert(#expr,__FILE__,__LINE__, msg, __VA_ARGS__ );\
+					os::dialogs::AssertMessage(#expr,__FILE__,__LINE__, msg, __VA_ARGS__ );\
 				}\
 				ASSUME(expr);\
 			} while (0)
 #		else // older MSVC compilers
 #			define Assertion(expr, msg) do {\
 				if (!(expr)) {\
-					WinAssert(#expr,__FILE__,__LINE__);\
+					os::dialogs::AssertMessage(#expr,__FILE__,__LINE__);\
 				}\
 			} while (0)
 #		endif
@@ -628,6 +621,9 @@ public:
 
 #include "globalincs/vmallocator.h"
 #include "globalincs/safe_strings.h"
+
+// Function to generate a stacktrace
+SCP_string dump_stacktrace();
 
 // c++11 standard detection
 // for GCC with autotools, see AX_CXX_COMPILE_STDCXX_11 macro in configure.ac

--- a/code/globalincs/vmallocator.h
+++ b/code/globalincs/vmallocator.h
@@ -10,6 +10,7 @@
 #include <queue>
 #include <deque>
 #include <unordered_map>
+#include <sstream>
 
 template< typename T >
 class SCP_vector : public std::vector< T, std::allocator< T > > { };

--- a/code/globalincs/windebug.cpp
+++ b/code/globalincs/windebug.cpp
@@ -1,11 +1,11 @@
 /*
  * Copyright (C) Volition, Inc. 1999.  All rights reserved.
  *
- * All source code herein is the property of Volition, Inc. You may not sell 
- * or otherwise commercially exploit the source or things you created based on the 
+ * All source code herein is the property of Volition, Inc. You may not sell
+ * or otherwise commercially exploit the source or things you created based on the
  * source.
  *
-*/ 
+*/
 
 // Nothing in this module should be externalized!!!
 //XSTR:OFF
@@ -16,6 +16,7 @@
 #include <windows.h>
 #include <windowsx.h>
 #include <stdio.h>
+#include <iomanip>
 
 #ifdef _MSC_VER
 #	include <crtdbg.h>
@@ -41,13 +42,6 @@
 
 extern void gr_activate(int active);
 
-bool Messagebox_active = false;
-
-int Global_warning_count = 0;
-int Global_error_count = 0;
-
-const int Messagebox_lines = 30;
-
 #ifndef _ASSERT
   #ifndef _DEBUG
     #define _ASSERT(expr) ((void)0)
@@ -63,124 +57,11 @@ const char *clean_filename( const char *name)
 	// Move p to point to first letter of EXE filename
 	while( (*p!='\\') && (*p!='/') && (*p!=':') && (p>= name) )
 		p--;
-	p++;	
+	p++;
 
-	return p;	
-}		   
-
-#if defined( SHOW_CALL_STACK )
-static bool Dump_to_log = true; 
-
-class DumpBuffer
-{
-public :
-	enum { BUFFER_SIZE = 32000 } ;
-	DumpBuffer() ;
-	void Clear() ;
-	void Printf( const char* format, ... ) ;
-	void SetWindowText( HWND hWnd ) const ;
-	char buffer[ BUFFER_SIZE ] ;
-
-	void Append(const char* text);
-	void Truncate(size_t size);
-	void TruncateLines(int num_allowed_lines);
-	size_t Size() const;
-private :
-	char* current ;
-} ;
-
-
-
-DumpBuffer :: DumpBuffer()
-{
-	Clear() ;
+	return p;
 }
 
-
-void DumpBuffer :: Clear()
-{
-	current = buffer ;
-}
-
-
-void DumpBuffer :: Append(const char* text)
-{
-	strcat_s(buffer, text);
-}
-
-
-void DumpBuffer :: Truncate(size_t size)
-{
-	if (size >= strlen(buffer))
-		return;
-
-	buffer[size] = 0;
-}
-
-
-// adapted from parselo
-void DumpBuffer :: TruncateLines(int num_allowed_lines)
-{
-	Assert(num_allowed_lines > 0);
-	char *find_from = buffer;
-	char *lastch = find_from + strlen(buffer) - 6;
-
-	while (find_from < lastch)
-	{
-		if (num_allowed_lines <= 0)
-		{
-			*find_from = 0;
-			strcat_s(buffer, "[...]");
-			break;
-		}
-
-		char *p = strchr(find_from, '\n');
-		if (p == NULL)
-			break;
-
-		num_allowed_lines--;
-		find_from = p + 1;
-	}
-}
-
-
-size_t DumpBuffer :: Size() const
-{
-	return strlen(buffer);
-}
-
-
-void DumpBuffer :: Printf( const char* format, ... )
-{
-	va_list argPtr ;
-	int pos = current - buffer;
-	int max = BUFFER_SIZE - pos;
-
-	// protect against obvious buffer overflow
-	if (pos >= BUFFER_SIZE)
-		return;
-
-	va_start( argPtr, format ) ;
-	vsnprintf( current, max-1, format, argPtr ) ;
-	va_end( argPtr ) ;
-
-	current[max-1] = '\0';
-	current += strlen(current);
-}
-
-
-void DumpBuffer :: SetWindowText( HWND hWnd ) const
-{
-	SendMessage( hWnd, WM_SETTEXT, 0, (LPARAM)buffer ) ;
-}
-
-/* Needed by LUA printf */
-// This ought to be local to VerboseAssert, but it
-// causes problems in Visual C++ (in the CRTL init phase)
-static DumpBuffer dumpBuffer;
-const char* Separator = "------------------------------------------------------------------\n" ;
-
-#endif
 
 /* MSVC2005+ callstack support
  */
@@ -211,7 +92,7 @@ public:
 		entry.symbol = symbol;
 		m_stackFrames.push_back( entry );
 	}
-	
+
 	virtual void OnError( const char* error )
 	{
 		/* No error handling here! */
@@ -246,8 +127,7 @@ class PE_Debug
     PE_Debug() ;
     ~PE_Debug() ;
     void ClearReport() ;
-    int DumpDebugInfo( DumpBuffer& dumpBuffer, const BYTE* caller, HINSTANCE hInstance ) ;
-    void Display() ;
+    int DumpDebugInfo( std::ostream& dumpBuffer, const BYTE* caller, HINSTANCE hInstance ) ;
   private :
     // Report data
     enum { MAX_MODULENAME_LEN = 512, VA_MAX_FILENAME_LEN = 256 } ;
@@ -268,8 +148,8 @@ class PE_Debug
     void ClearDebugPtrs() ;
     void MapFileInMemory( const char* module ) ;
     void FindDebugInfo() ;
-    void DumpSymbolInfo( DumpBuffer& dumpBuffer, DWORD relativeAddress ) ;
-    void DumpLineNumber( DumpBuffer& dumpBuffer, DWORD relativeAddress ) ;
+    void DumpSymbolInfo( std::ostream& dumpBuffer, DWORD relativeAddress ) ;
+    void DumpLineNumber(std::ostream& dumpBuffer, DWORD relativeAddress ) ;
     PIMAGE_COFF_SYMBOLS_HEADER GetDebugHeader() ;
     PIMAGE_SECTION_HEADER SectionHeaderFromName( const char* name ) ;
     const char* GetSymbolName( PIMAGE_SYMBOL sym ) ;
@@ -335,7 +215,7 @@ void PE_Debug :: ClearFileCache()
   }
 
 
-void PE_Debug :: DumpLineNumber( DumpBuffer& dumpBuffer, DWORD relativeAddress )
+void PE_Debug :: DumpLineNumber(std::ostream& dumpBuffer, DWORD relativeAddress )
   {
   PIMAGE_LINENUMBER line = BasedPtr( PIMAGE_LINENUMBER, COFFDebugInfo,
                                      COFFDebugInfo->LvaToFirstLinenumber ) ;
@@ -358,13 +238,8 @@ void PE_Debug :: DumpLineNumber( DumpBuffer& dumpBuffer, DWORD relativeAddress )
     line++ ;
     }
   if( lineNum != none ) {
-    dumpBuffer.Printf( "  line %d\r\n", lineNum ) ;
-	if (Dump_to_log) {
-		mprintf(( "  line %d\r\n", lineNum )) ;
-	}
-  }	
-//  else
-//  dumpBuffer.Printf( "  line <unknown>\r\n" ) ;
+	  dumpBuffer << "  line " << lineNum << "\n";
+  }
   }
 
 
@@ -427,15 +302,15 @@ void Add_Symbol( int section, int offset, const char *name, char *module )
 	}
 
 	MemSymbol * sym = &Symbols[Num_symbols++];
-	
+
 	sym->section = section;
 	sym->offset = offset;
 	sym->size = -1;
-	
-	strcpy_s( sym->name, name );	
-	strcat_s( sym->name, "(" );	
-	strcat_s( sym->name, module );	
-	strcat_s( sym->name, ")" );	
+
+	strcpy_s( sym->name, name );
+	strcat_s( sym->name, "(" );
+	strcat_s( sym->name, module );
+	strcat_s( sym->name, ")" );
 
 }
 
@@ -476,7 +351,7 @@ void DumpSymbols()
 	int i;
 
 	insertion_sort( Symbols, Num_symbols, sizeof(MemSymbol), Sym_compare );
-	
+
 	for (i=0;i<Num_symbols; i++ )	{
 		MemSymbol * sym1 = &Symbols[i];
 		MemSymbol * sym2 = &Symbols[i+1];
@@ -503,14 +378,14 @@ void DumpSymbols()
 	}
 
 	fclose(fp);
-	
+
 	vm_free( Symbols );
 	Symbols = NULL;
 	_asm int 3
 }
 #endif
 
-void PE_Debug::DumpSymbolInfo( DumpBuffer& dumpBuffer, DWORD relativeAddress )
+void PE_Debug::DumpSymbolInfo(std::ostream& dumpBuffer, DWORD relativeAddress )
 {
 	// Variables to keep track of function symbols
 	PIMAGE_SYMBOL currentSym = COFFSymbolTable ;
@@ -571,7 +446,7 @@ void PE_Debug::DumpSymbolInfo( DumpBuffer& dumpBuffer, DWORD relativeAddress )
 					// Move p to point to first letter of EXE filename
 					while( (*p!='\\') && (*p!='/') && (*p!=':') )
 						p--;
-					p++;	
+					p++;
 					if ( strlen(p) < 1 ) {
 						strcpy_s( pretty_module, "<unknown>" );
 					} else {
@@ -595,32 +470,26 @@ void PE_Debug::DumpSymbolInfo( DumpBuffer& dumpBuffer, DWORD relativeAddress )
 	#ifdef DUMPRAM
 	DumpSymbols();
 	#endif
-	
+
 	// dump symbolic info if found
 	if ( fileSymbol )	{
 		const char* auxSym = (const char*)(fileSymbol + 1) ;
 
 		if( strcmpi( latestFile, auxSym ) )	{
 			strcpy_s( latestFile, auxSym ) ;
-			//JAS      dumpBuffer.Printf( "  file: %s\r\n", auxSym ) ;    
+			//JAS      dumpBuffer.Printf( "  file: %s\r\n", auxSym ) ;
 		}
 	} else {
 		latestFile[ 0 ] = 0 ;
-		//JAS    dumpBuffer.Printf( "  file: unknown\r\n" ) ;    
+		//JAS    dumpBuffer.Printf( "  file: unknown\r\n" ) ;
 	}
-	
+
 	if ( fnSymbol )	{
 		char tmp_name[1024];
 		unmangle(tmp_name, GetSymbolName( fnSymbol ) );
-		dumpBuffer.Printf( "    %s()", tmp_name ) ;
-		if (Dump_to_log) {
-			mprintf(("    %s()", tmp_name )) ;
-		}
+		dumpBuffer << "    " << tmp_name << "()";
 	} else {
-		dumpBuffer.Printf( "    <unknown>" ) ;
-		if (Dump_to_log) {		
-			mprintf(("    <unknown>" )) ;
-		}
+		dumpBuffer << "    <unknown>";
 	}
 }
 
@@ -708,11 +577,11 @@ void PE_Debug :: FindDebugInfo()
         COFFDebugInfo = GetDebugHeader() ;
         // Get a pointer to the symbol table and retrieve the number of symbols
         if( NT_Header->FileHeader.PointerToSymbolTable )
-          COFFSymbolTable = 
+          COFFSymbolTable =
             BasedPtr( PIMAGE_SYMBOL, fileBase, NT_Header->FileHeader.PointerToSymbolTable ) ;
         COFFSymbolCount = NT_Header->FileHeader.NumberOfSymbols ;
         // The string table starts right after the symbol table
-        stringTable = (const char*)(COFFSymbolTable + COFFSymbolCount) ; 
+        stringTable = (const char*)(COFFSymbolTable + COFFSymbolCount) ;
         }
       }
     }
@@ -738,7 +607,7 @@ void PE_Debug :: MapFileInMemory( const char* module )
   }
 
 
-int PE_Debug::DumpDebugInfo( DumpBuffer& dumpBuffer, const BYTE* caller, HINSTANCE hInstance )
+int PE_Debug::DumpDebugInfo(std::ostream& dumpBuffer, const BYTE* caller, HINSTANCE hInstance )
 {
 	// Avoid to open, map and looking for debug header/symbol table
 	// by caching the latest and comparing the actual module with
@@ -761,7 +630,7 @@ int PE_Debug::DumpDebugInfo( DumpBuffer& dumpBuffer, const BYTE* caller, HINSTAN
 	// Move p to point to first letter of EXE filename
 	while( (*p!='\\') && (*p!='/') && (*p!=':') )
 		p--;
-	p++;	
+	p++;
 	if ( strlen(p) < 1 ) {
 		strcpy_s( pretty_module, "<unknown>" );
 	} else {
@@ -781,10 +650,8 @@ int PE_Debug::DumpDebugInfo( DumpBuffer& dumpBuffer, const BYTE* caller, HINSTAN
 			} else {
 				//dumpBuffer.Printf( "Call stack is unavailable, because there is\r\nno COFF debugging info in this module.\r\n" ) ;
 				//JAS dumpBuffer.Printf( "  no debug information\r\n" ) ;
-				dumpBuffer.Printf( "    %s %08x()\r\n", pretty_module, caller ) ;
-				if (Dump_to_log) {
-					mprintf(("    %s %08x()\r\n", pretty_module, caller )) ;
-				}
+				dumpBuffer << "    " << pretty_module << " " << std::setprecision(8)
+					<< std::hex << (void*)caller << std::resetiosflags(std::ios::showbase) << "()\n";
 				return 0;
 			}
 		} catch( ... )	{
@@ -792,25 +659,19 @@ int PE_Debug::DumpDebugInfo( DumpBuffer& dumpBuffer, const BYTE* caller, HINSTAN
 			return 0;
       }
 	} else	{
-		dumpBuffer.Printf( "    %s %08x()\r\n", pretty_module, caller ) ;
-		if (Dump_to_log) {
-			mprintf(( "    %s %08x()\r\n", pretty_module, caller )) ;
-		}
+		dumpBuffer << "    " << pretty_module << " " << std::setprecision(8) <<
+			std::hex << (void*)caller << std::resetiosflags(std::ios::showbase) << "()\n";
 		//JAS dumpBuffer.Printf( "  module not accessible\r\n" ) ;
 		//JAS dumpBuffer.Printf( "    address: %8X\r\n", caller ) ;
 		return 0;
 	}
 
 	Int3();
-
 }
 
-void DumpCallsStack( DumpBuffer& dumpBuffer )
+void DumpCallsStack( std::ostream& dumpBuffer )
 {
 	static PE_Debug PE_debug ;
-
-	dumpBuffer.Printf( "\r\nCall stack:\r\n" ) ;
-	dumpBuffer.Printf( Separator ) ;
 
 	// The structure of the stack frames is the following:
 	// EBP -> parent stack frame EBP
@@ -827,7 +688,7 @@ void DumpCallsStack( DumpBuffer& dumpBuffer )
 
 	do	{
 		depth++;
-		if ( depth > 16 ) 
+		if ( depth > 16 )
 			break;
 
 		if ( (parentEBP & 3) || IsBadReadPtr((DWORD*)parentEBP, sizeof(DWORD)) )	{
@@ -864,545 +725,30 @@ void DumpCallsStack( DumpBuffer& dumpBuffer )
 		}
 	}  while( TRUE ) ;
 
-
-	dumpBuffer.Printf( Separator ) ;
 	PE_debug.ClearReport() ;  // Prepare for future calls
 }
 
 #endif	//SHOW_CALL_STACK
 
-
-char AssertText1[2048];
-char AssertText2[1024];
-
-uint flags = MB_SYSTEMMODAL|MB_SETFOREGROUND;
-//uint flags = MB_SYSTEMMODAL;
-
-extern void gr_force_windowed();
-
-void dump_text_to_clipboard( const char *text )
+SCP_string dump_stacktrace()
 {
-	int len = strlen(text)+1024;
-
-	HGLOBAL h_text = GlobalAlloc(GMEM_MOVEABLE | GMEM_DDESHARE, len );
-	if ( !h_text ) return;
-	char *ptr = (char *)GlobalLock(h_text);
-	if ( !ptr ) return;
-
-	// copy then, if you find any \n's without \r's, then add in the \r.
-	char last_char = 0;
-	while( *text )	{
-		if ( (*text == '\n') && (last_char != '\r') )	{
-			*ptr++ = '\r';
-		}
-		last_char = *text;
-		*ptr++ = last_char;
-		text++;
-	}
-	*ptr++ = 0;
-	GlobalUnlock(h_text);
-	OpenClipboard(NULL);
-	EmptyClipboard();
-	SetClipboardData(CF_TEXT, h_text);
-	CloseClipboard();
-}
-
-
-void _cdecl WinAssert(char * text, char * filename, int linenum )
-{
-	int val;
-
-	// this stuff migt be really useful for solving bug reports and user errors. We should output it! 
-	mprintf(("ASSERTION: \"%s\" at %s:%d\n", text, strrchr(filename, '\\')+1, linenum ));
-
-#ifdef Allow_NoWarn
-	if (Cmdline_nowarn) {
-		return;
-	}
-#endif
-
-	Messagebox_active = true;
-
-	gr_activate(0);
-
-	filename = strrchr(filename, '\\')+1;
-	sprintf( AssertText1, "Assert: %s\r\nFile: %s\r\nLine: %d\r\n", text, filename, linenum );
 
 #if defined( SHOW_CALL_STACK ) && defined( PDB_DEBUGGING )
 	/* Dump the callstack */
 	SCP_DebugCallStack callStack;
-	SCP_DumpStack( dynamic_cast< SCP_IDumpHandler* >( &callStack ) );
-	
-	/* Format the string */
-	SCP_string assertString( AssertText1 );
-	assertString += "\n";
-	assertString += callStack.DumpToString( );
-	
-	/* Copy to the clipboard */
-	dump_text_to_clipboard( assertString.c_str( ) );
+	SCP_DumpStack(dynamic_cast< SCP_IDumpHandler* >(&callStack));
 
-	// truncate text
-	truncate_message_lines(assertString, Messagebox_lines);
-
-	assertString += "\n[ This info is in the clipboard so you can paste it somewhere now ]\n";
-	assertString += "\n\nUse Ok to break into Debugger, Cancel to exit.\n";
-	val = MessageBox( NULL, assertString.c_str( ), "Assertion Failed!", MB_OKCANCEL | flags );
-
+	return callStack.DumpToString();
 #elif defined( SHOW_CALL_STACK )
-	dumpBuffer.Clear();
-	dumpBuffer.Printf( AssertText1 );
-	dumpBuffer.Printf( "\r\n" );
-	DumpCallsStack( dumpBuffer ) ;  
-	dump_text_to_clipboard(dumpBuffer.buffer);
+	SCP_stringstream stream;
 
-	// truncate text
-	dumpBuffer.TruncateLines(Messagebox_lines);
+	DumpCallsStack(stream);
 
-	dumpBuffer.Printf( "\r\n[ This info is in the clipboard so you can paste it somewhere now ]\r\n" );
-	dumpBuffer.Printf( "\r\n\r\nUse Ok to break into Debugger, Cancel to exit.\r\n");
-
-	val = MessageBox(NULL, dumpBuffer.buffer, "Assertion Failed!", MB_OKCANCEL|flags );
+	return stream.str();
 #else
-	val = MessageBox(NULL, AssertText1, "Assertion Failed!", MB_OKCANCEL|flags );
-#endif
-
-	if (val == IDCANCEL)
-		exit(1);
-
-	Int3();
-
-	gr_activate(1);
-
-	Messagebox_active = false;
-}
-
-void _cdecl WinAssert(char * text, char * filename, int linenum, const char * format, ... )
-{
-	int val;
-	va_list args;
-
-	memset( AssertText1, 0, sizeof(AssertText1) );
-	memset( AssertText2, 0, sizeof(AssertText2) );
-
-	va_start(args, format);
-	vsnprintf(AssertText2, sizeof(AssertText2)-1, format, args);
-	va_end(args);
-
-	// this stuff migt be really useful for solving bug reports and user errors. We should output it! 
-	mprintf(("ASSERTION: \"%s\" at %s:%d\n %s\n", text, strrchr(filename, '\\')+1, linenum, AssertText2 ));
-
-#ifdef Allow_NoWarn
-	if (Cmdline_nowarn) {
-		return;
-	}
-#endif
-
-	Messagebox_active = true;
-
-	gr_activate(0);
-
-	filename = strrchr(filename, '\\')+1;
-	snprintf( AssertText1, sizeof(AssertText1)-1, "Assert: %s\r\nFile: %s\r\nLine: %d\r\n%s\r\n", text, filename, linenum, AssertText2 );
-
-#if defined( SHOW_CALL_STACK ) && defined( PDB_DEBUGGING )
-	/* Dump the callstack */
-	SCP_DebugCallStack callStack;
-	SCP_DumpStack( dynamic_cast< SCP_IDumpHandler* >( &callStack ) );
-	
-	/* Format the string */
-	SCP_string assertString( AssertText1 );
-	assertString += "\n";
-	assertString += callStack.DumpToString( );
-	
-	/* Copy to the clipboard */
-	dump_text_to_clipboard( assertString.c_str( ) );
-
-	// truncate text
-	truncate_message_lines(assertString, Messagebox_lines);
-
-	assertString += "\n[ This info is in the clipboard so you can paste it somewhere now ]\n";
-	assertString += "\n\nUse Ok to break into Debugger, Cancel to exit.\n";
-	val = MessageBox( NULL, assertString.c_str( ), "Assertion Failed!", MB_OKCANCEL | flags );
-
-#elif defined ( SHOW_CALL_STACK	)
-	dumpBuffer.Clear();
-	dumpBuffer.Printf( AssertText1 );
-	dumpBuffer.Printf( "\r\n" );
-	DumpCallsStack( dumpBuffer ) ;  
-	dump_text_to_clipboard(dumpBuffer.buffer);
-
-	// truncate text
-	dumpBuffer.TruncateLines(Messagebox_lines);
-
-	dumpBuffer.Printf( "\r\n[ This info is in the clipboard so you can paste it somewhere now ]\r\n" );
-	dumpBuffer.Printf( "\r\n\r\nUse Ok to break into Debugger, Cancel to exit.\r\n");
-
-	val = MessageBox(NULL, dumpBuffer.buffer, "Assertion Failed!", MB_OKCANCEL|flags );
-#else
-	val = MessageBox(NULL, AssertText1, "Assertion Failed!", MB_OKCANCEL|flags );
-#endif
-
-	if (val == IDCANCEL)
-		exit(1);
-
-	Int3();
-
-	gr_activate(1);
-
-	Messagebox_active = false;
-}
-
-void LuaDebugPrint(lua_Debug &ar)
-{
-	dumpBuffer.Printf( "Name:\t\t%s\r\n",  ar.name);
-	dumpBuffer.Printf( "Name of:\t%s\r\n",  ar.namewhat);
-	dumpBuffer.Printf( "Function type:\t%s\r\n",  ar.what);
-	dumpBuffer.Printf( "Defined on:\t%d\r\n",  ar.linedefined);
-	dumpBuffer.Printf( "Upvalues:\t%d\r\n",  ar.nups);
-	dumpBuffer.Printf( "\r\n" );
-	dumpBuffer.Printf( "Source:\t\t%s\r\n",  ar.source);
-	dumpBuffer.Printf( "Short source:\t%s\r\n",  ar.short_src);
-	dumpBuffer.Printf( "Current line:\t%d\r\n",  ar.currentline);
-	dumpBuffer.Printf( "- Function line:\t%d\r\n", (ar.linedefined ? (1 + ar.currentline - ar.linedefined) : 0));
-}
-
-extern lua_Debug Ade_debug_info;
-extern char debug_stack[4][32];
-void LuaError(struct lua_State *L, char *format, ...)
-{
-	int val;
-
-	Messagebox_active = true;
-
-	gr_activate(0);
-
-	dumpBuffer.Clear();
-	//WMC - if format is set to NULL, assume this is acting as an
-	//error handler for Lua.
-	if(format == NULL)
-	{
-		dumpBuffer.Printf("LUA ERROR: %s", lua_tostring(L, -1));
-		lua_pop(L, -1);
-	}
-	else
-	{
-		va_list args;
-
-		memset(AssertText1, 0, sizeof(AssertText1));
-		memset(AssertText2, 0, sizeof(AssertText2));
-
-		va_start(args, format);
-		vsnprintf(AssertText1, sizeof(AssertText1)-1, format,args);
-		va_end(args);
-
-		dumpBuffer.Printf(AssertText1);
-	}
-
-	dumpBuffer.Printf( "\r\n" );
-	dumpBuffer.Printf( "\r\n" );
-
-	//WMC - This is virtually worthless.
-/*
-	dumpBuffer.Printf(Separator);
-	dumpBuffer.Printf( "LUA Debug:" );
-	dumpBuffer.Printf( "\r\n" );
-	dumpBuffer.Printf(Separator);
-
-	lua_Debug ar;
-	if(lua_getstack(L, 0, &ar))
-	{
-		lua_getinfo(L, "nSlu", &ar);
-		LuaDebugPrint(ar);
-	}
-	else
-	{
-		dumpBuffer.Printf("(No stack debug info)\r\n");
-	}
-*/
-//	TEST CODE
-
-	dumpBuffer.Printf(Separator);
-	dumpBuffer.Printf( "ADE Debug:" );
-	dumpBuffer.Printf( "\r\n" );
-	dumpBuffer.Printf(Separator);
-	LuaDebugPrint(Ade_debug_info);
-	dumpBuffer.Printf(Separator);
-
-	dumpBuffer.Printf( "\r\n" );
-	dumpBuffer.Printf( "\r\n" );
-
-	AssertText2[0] = '\0';
-	dumpBuffer.Printf(Separator);
-	
-	// Get the stack via the debug.traceback() function
-	lua_getglobal(L, LUA_DBLIBNAME);
-
-	if (!lua_isnil(L, -1))
-	{
-		dumpBuffer.Printf( "\r\n" );
-		lua_getfield(L, -1, "traceback");
-		lua_remove(L, -2);
-
-		if (lua_pcall(L, 0, 1, 0) != 0)
-			dumpBuffer.Printf("Error while retrieving stack: %s", lua_tostring(L, -1));
-		else
-			dumpBuffer.Printf(lua_tostring(L, -1));
-
-		lua_pop(L, 1);
-	}
-	else
-	{
-		// If the debug library is nil then fall back to the default debug stack
-		dumpBuffer.Printf("LUA Stack:\r\n");
-		int i;
-		for (i = 0; i < 4; i++) {
-			if (debug_stack[i][0] != '\0')
-				dumpBuffer.Printf("\t%s\r\n", debug_stack[i]);
-		}
-	}
-	dumpBuffer.Printf( "\r\n" );
-
-	dumpBuffer.Printf(Separator);
-	ade_stackdump(L, AssertText2);
-	dumpBuffer.Printf( AssertText2 );
-	dumpBuffer.Printf( "\r\n" );
-	dumpBuffer.Printf(Separator);
-
-	dump_text_to_clipboard(dumpBuffer.buffer);
-
-	// truncate text
-	dumpBuffer.TruncateLines(Messagebox_lines);
-
-	dumpBuffer.Printf( "\r\n[ This info is in the clipboard so you can paste it somewhere now ]\r\n" );
-	dumpBuffer.Printf( "\r\n\r\nUse Yes to break into Debugger, No to continue.\r\nand Cancel to Quit");
-
-	val = MessageBox(NULL, dumpBuffer.buffer, "Error!", flags|MB_YESNOCANCEL );
-
-	if (val == IDCANCEL ) {
-		exit(1);
-	} else if(val == IDYES) {
-		Int3();
-	}
-
-	gr_activate(1);
-
-	Messagebox_active = false;
-}
-
-void _cdecl Error( const char * filename, int line, const char * format, ... )
-{
-	Global_error_count++;
-
-	int val;
-	va_list args;
-
-	memset( AssertText1, 0, sizeof(AssertText1) );
-	memset( AssertText2, 0, sizeof(AssertText2) );
-
-	va_start(args, format);
-	vsnprintf(AssertText1, sizeof(AssertText1)-1, format, args);
-	va_end(args);
-
-	filename = strrchr(filename, '\\')+1;
-	snprintf(AssertText2, sizeof(AssertText2)-1, "Error: %s\r\nFile: %s\r\nLine: %d\r\n", AssertText1, filename, line);
-	mprintf(("ERROR: %s\r\nFile: %s\r\nLine: %d\r\n", AssertText1, filename, line));
-
-	Messagebox_active = true;
-
-	gr_activate(0);
-
-#if defined( SHOW_CALL_STACK ) && defined( PDB_DEBUGGING )
-	/* Dump the callstack */
-	SCP_DebugCallStack callStack;
-	SCP_DumpStack( dynamic_cast< SCP_IDumpHandler* >( &callStack ) );
-	
-	/* Format the string */
-	SCP_string assertString( AssertText1 );
-	assertString += "\n";
-	assertString += callStack.DumpToString( );
-	
-	/* Copy to the clipboard */
-	dump_text_to_clipboard( assertString.c_str( ) );
-
-	// truncate text
-	truncate_message_lines(assertString, Messagebox_lines);
-
-	assertString += "\n[ This info is in the clipboard so you can paste it somewhere now ]\n";
-	assertString += "\n\nUse Ok to break into Debugger, Cancel to exit.\n";
-	val = MessageBox( NULL, assertString.c_str( ), "Error!", flags | MB_DEFBUTTON2 | MB_OKCANCEL );
-
-#elif defined( SHOW_CALL_STACK )
-	dumpBuffer.Clear();
-	dumpBuffer.Printf( AssertText2 );
-	dumpBuffer.Printf( "\r\n" );
-	DumpCallsStack( dumpBuffer ) ;  
-	dump_text_to_clipboard(dumpBuffer.buffer);
-
-	// truncate text
-	dumpBuffer.TruncateLines(Messagebox_lines);
-
-	dumpBuffer.Printf( "\r\n[ This info is in the clipboard so you can paste it somewhere now ]\r\n" );
-	dumpBuffer.Printf( "\r\n\r\nUse Ok to break into Debugger, Cancel exits.\r\n");
-
-	val = MessageBox(NULL, dumpBuffer.buffer, "Error!", flags | MB_DEFBUTTON2 | MB_OKCANCEL );
-#else
-	strcat_s(AssertText2,"\r\n\r\nUse Ok to break into Debugger, Cancel exits.\r\n");
-
-	val = MessageBox(NULL, AssertText2, "Error!", flags | MB_DEFBUTTON2 | MB_OKCANCEL );
-#endif
-
-	switch (val)
-	{
-		case IDCANCEL:
-			exit(1);
-
-		default:
-			Int3();
-			break;
-	}
-
-	gr_activate(1);
-
-	Messagebox_active = false;
-}
-
-void _cdecl WarningEx( char *filename, int line, const char *format, ... )
-{
-#ifndef NDEBUG
-	if (Cmdline_extra_warn) {
-		char msg[sizeof(AssertText1)];
-		va_list args;
-
-		memset(msg, 0, sizeof(msg));
-
-		va_start(args, format);
-		vsnprintf(msg, sizeof(msg)-1, format, args);
-		va_end(args);
-
-		Warning(filename, line, msg);
-	}
+	return "No stacktrace available!";
 #endif
 }
-
-void _cdecl Warning( char *filename, int line, const char *format, ... )
-{
-	Global_warning_count++;
-
-#ifndef NDEBUG
-	va_list args;
-	int result;
-	int i;
-	int slen = 0;
-
-	// output to the debug log before anything else (so that we have a complete record)
-
-	memset( AssertText1, 0, sizeof(AssertText1) );
-	memset( AssertText2, 0, sizeof(AssertText2) );
-
-	va_start(args, format);
-	vsnprintf(AssertText1, sizeof(AssertText1) - 1, format, args);
-	va_end(args);
-
-	slen = strlen(AssertText1);
-
-	// strip out the newline char so the output looks better
-	for (i = 0; i < slen; i++){
-		if (AssertText1[i] == (char)0x0a) {
-			AssertText2[i] = ' ';
-		} else {
-			AssertText2[i] = AssertText1[i];
-		}
-	}
-
-	// kill off extra white space at end
-	if (AssertText2[slen-1] == (char)0x20) {
-		AssertText2[slen-1] = '\0';
-	} else {
-		// just being careful
-		AssertText2[slen] = '\0';
-	}
-
-	mprintf(("WARNING: \"%s\" at %s:%d\n", AssertText2, strrchr(filename, '\\')+1, line));
-
-	// now go for the additional popup window, if we want it ...
-#ifdef Allow_NoWarn
-	if (Cmdline_nowarn) {
-		return;
-	}
-#endif
-
-	filename = strrchr(filename, '\\')+1;
-	sprintf(AssertText2, "Warning: %s\r\nFile: %s\r\nLine: %d\r\n", AssertText1, filename, line );
-
-	Messagebox_active = true;
-
-	gr_activate(0);
-
-#if defined( SHOW_CALL_STACK ) && defined( PDB_DEBUGGING )
-	/* Dump the callstack */
-	SCP_DebugCallStack callStack;
-	SCP_DumpStack( dynamic_cast< SCP_IDumpHandler* >( &callStack ) );
-	
-	/* Format the string */
-	SCP_string assertString( AssertText1 );
-	assertString += "\n";
-	assertString += callStack.DumpToString( );
-	
-	/* Copy to the clipboard */
-	dump_text_to_clipboard( assertString.c_str( ) );
-
-	// truncate text
-	truncate_message_lines(assertString, Messagebox_lines);
-
-	assertString += "\n[ This info is in the clipboard so you can paste it somewhere now ]\n";
-	assertString += "\n\nUse Yes to break into Debugger, No to continue.\nand Cancel to Quit\n";
-	result = MessageBox( NULL, assertString.c_str( ), "Warning!", MB_YESNOCANCEL | MB_DEFBUTTON2 | MB_ICONWARNING | flags );
-
-#elif defined ( SHOW_CALL_STACK	)
-	//we don't want to dump the call stack for every single warning
-	Dump_to_log = false; 
-
-	dumpBuffer.Clear();
-	dumpBuffer.Printf( AssertText2 );
-	dumpBuffer.Printf( "\r\n" );
-	DumpCallsStack( dumpBuffer ) ;  
-	dump_text_to_clipboard(dumpBuffer.buffer);
-
-	// truncate text
-	dumpBuffer.TruncateLines(Messagebox_lines);
-
-	dumpBuffer.Printf( "\r\n[ This info is in the clipboard so you can paste it somewhere now ]\r\n" );
-	dumpBuffer.Printf("\r\n\r\nUse Yes to break into Debugger, No to continue.\r\nand Cancel to Quit");
-
-	result = MessageBox((HWND)os_get_window(), dumpBuffer.buffer, "Warning!", MB_YESNOCANCEL | MB_DEFBUTTON2 | MB_ICONWARNING | flags );
-
-	Dump_to_log = true; 
-
-#else
-	strcat_s(AssertText2,"\r\n\r\nUse Yes to break into Debugger, No to continue.\r\nand Cancel to Quit");
-	result = MessageBox((HWND)os_get_window(), AssertText2, "Warning!", MB_YESNOCANCEL | MB_DEFBUTTON2 | MB_ICONWARNING | flags );
-#endif
-
-	switch (result)
-	{
-		case IDYES:
-			Int3();
-			break;
-
-		case IDNO:
-			break;
-
-		case IDCANCEL:
-			exit(1);
-	}
-
-	gr_activate(1);
-
-	Messagebox_active = false;
-#endif // !NDEBUG
-}
-
-
 
 //================= memory stuff
 /*
@@ -1415,7 +761,7 @@ char *format_mem( DWORD num )
 	} else 	{
 		sprintf( tmp_mem, "%.3f MB", (float)(num/1024)/(1024.0f)  );
 	}
-	return tmp_mem;	
+	return tmp_mem;
 }
 */
 
@@ -1430,14 +776,14 @@ void getmem()
 
 	ms.dwLength = sizeof(MEMORYSTATUS);
 	GlobalMemoryStatus(&ms);
-	
+
 	printf( "Percent of memory in use: %d%%\n", ms.dwMemoryLoad );
-	printf( "Bytes of physical memory:	%s\n", format_mem(ms.dwTotalPhys) );     
-	printf( "Free physical memory bytes:	%s\n", format_mem(ms.dwAvailPhys) );     //  
-	printf( "Bytes of paging file:	%s\n", format_mem(ms.dwTotalPageFile) ); // bytes of paging file 
-	printf( "Free bytes of paging file:	%s\n", format_mem(ms.dwAvailPageFile) ); // free bytes of paging file 
-	printf( "User bytes of address space:	%s\n", format_mem(ms.dwTotalVirtual) );  //  
-	printf( "Free user bytes:	%s\n", format_mem(ms.dwAvailVirtual) );  // free user bytes 
+	printf( "Bytes of physical memory:	%s\n", format_mem(ms.dwTotalPhys) );
+	printf( "Free physical memory bytes:	%s\n", format_mem(ms.dwAvailPhys) );     //
+	printf( "Bytes of paging file:	%s\n", format_mem(ms.dwTotalPageFile) ); // bytes of paging file
+	printf( "Free bytes of paging file:	%s\n", format_mem(ms.dwAvailPageFile) ); // free bytes of paging file
+	printf( "User bytes of address space:	%s\n", format_mem(ms.dwTotalVirtual) );  //
+	printf( "Free user bytes:	%s\n", format_mem(ms.dwAvailVirtual) );  // free user bytes
 
 
 	// Get the instance handle of the module where caller belongs to
@@ -1505,12 +851,12 @@ int __cdecl MyAllocHook(
 	if ( nAllocType == 3 )	{
 		_CrtMemBlockHeader *phd = pHdr(pvData);
 		nSize = phd->nDataSize;
-	} 
+	}
 
 //	mprintf(( "Total RAM = %d\n", TotalRam ));
 
    mprintf(( "Memory operation in %s, line %d: %s a %d-byte '%s' block (# %ld)\n",
-            szFileName, nLine, operation[nAllocType], nSize, 
+            szFileName, nLine, operation[nAllocType], nSize,
             blockType[nBlockUse], lRequest ));
    if ( pvData != NULL )
       mprintf(( " at %X", pvData ));
@@ -1523,7 +869,7 @@ int __cdecl MyAllocHook(
 #endif  // #if 0
 
 
- 
+
 void windebug_memwatch_init()
 {
 	//_CrtSetAllocHook(MyAllocHook);
@@ -1551,7 +897,7 @@ int vm_init(int min_heap_size)
 #ifdef _REPORT_MEM_LEAKS
 const int MAX_MEM_POINTERS = 50000;
 
-typedef struct 
+typedef struct
 {
 	char  filename[33];
 	int   size;
@@ -1584,11 +930,11 @@ int memblockinfo_sort_compare( const void *arg1, const void *arg2 )
 
 	if (mbi1->size > mbi2->size)
 		return -1;
-		
+
 	if (mbi1->size < mbi2->size)
 		return 1;
-		
-	return 0; 
+
+	return 0;
 }
 
 void memblockinfo_sort()
@@ -1615,15 +961,15 @@ void register_malloc( int size, char *filename, int line, void *ptr)
 
 		// Get current flag
 		int tmpFlag = _CrtSetDbgFlag( _CRTDBG_REPORT_FLAG );
-		
+
 		// Turn on leak-checking bit
 		tmpFlag |= _CRTDBG_LEAK_CHECK_DF;
-		
+
 		// Set flag to the new value
 		_CrtSetDbgFlag( tmpFlag );
 
 #ifdef _REPORT_MEM_LEAKS
-		ZeroMemory(mem_ptr_list, MAX_MEM_POINTERS * sizeof(MemPtrInfo)); 
+		ZeroMemory(mem_ptr_list, MAX_MEM_POINTERS * sizeof(MemPtrInfo));
 #endif
 	}
 
@@ -1692,7 +1038,7 @@ void memblockinfo_output_memleak()
 {
 	if(!Cmdline_show_mem_usage)	return;
 
-	if(TotalRam == 0) 
+	if(TotalRam == 0)
 		return;
 
 	if(TotalRam < 0) {
@@ -1736,7 +1082,7 @@ void unregister_malloc(char *filename, int size, void *ptr)
 {
 	// calculate magic numbers
 	int magic1, magic2, len;
-	
+
 	char *temp = strrchr(filename, '\\');
 	if(temp)
 		filename = temp + 1;
@@ -1914,7 +1260,7 @@ void *_vm_realloc( void *ptr, int size, int quiet )
 		Error(LOCATION, "Out of memory.  Try closing down other applications, increasing your\n"
 			"virtual memory size, or installing more physical RAM.\n");
 	}
-#ifndef	NDEBUG 
+#ifndef	NDEBUG
 	TotalRam += size;
 
 	// register this allocation

--- a/code/osapi/dialogs.cpp
+++ b/code/osapi/dialogs.cpp
@@ -1,0 +1,439 @@
+
+#include "osapi/dialogs.h"
+#include "osapi/osapi.h"
+#include "parse/parselo.h"
+#include "parse/lua.h"
+#include "cmdline/cmdline.h"
+#include "graphics/2d.h"
+
+#include <SDL_messagebox.h>
+#include <SDL_clipboard.h>
+
+#include <string>
+#include <algorithm>
+
+namespace
+{
+	const char* Separator = "------------------------------------------------------------------\n";
+
+	const int Messagebox_lines = 30;
+	
+	template<typename Stream>
+	void LuaDebugPrint(Stream& stream, lua_Debug &ar)
+	{
+		if (ar.name == nullptr)
+		{
+			// Invalid lua_Debug struct
+			return;
+		}
+
+		stream << "Name:\t\t" << ar.name << "\n";
+		stream << "Name of:\t" << ar.namewhat << "\n";
+		stream << "Function type:\t" << ar.what << "\n";
+		stream << "Defined on:\t" << ar.linedefined << "\n";
+		stream << "Upvalues:\t" << ar.nups << "\n";
+		stream << "\n";
+		stream << "Source:\t\t" << ar.source << "\n";
+		stream << "Short source:\t" << ar.short_src << "\n";
+		stream << "Current line:\t" << ar.currentline << "\n";
+		stream << "- Function line:\t" << (ar.linedefined ? (1 + ar.currentline - ar.linedefined) : 0) << "\n";
+	}
+
+	SCP_string truncateLines(SCP_stringstream& s, int maxLines)
+	{
+		SCP_stringstream outStream;
+		s.seekp(0, std::ios::beg);
+
+		for (SCP_string line; std::getline(s, line);)
+		{
+			outStream << line << "\n";
+
+			--maxLines;
+
+			if (maxLines <= 0)
+			{
+				outStream << "[...]";
+				break;
+			}
+		}
+
+		return outStream.str();
+	}
+
+	const char* clean_filename(const char* filename)
+	{
+		auto separator = strrchr(filename, DIR_SEPARATOR_CHAR);
+		if (separator != nullptr)
+		{
+			filename = separator + 1;
+		}
+
+		return filename;
+	}
+
+	char replaceNewline(char in)
+	{
+		if (in == '\n')
+			return ' ';
+
+		return in;
+	}
+
+	void set_clipboard_text(const char* text)
+	{
+		// Make sure video is enabled
+		if (!SDL_InitSubSystem(SDL_INIT_VIDEO))
+		{
+			SDL_SetClipboardText(text);
+		}
+	}
+}
+
+int Global_warning_count = 0;
+int Global_error_count = 0;
+
+extern lua_Debug Ade_debug_info;
+
+namespace os
+{
+	namespace dialogs
+	{
+		void AssertMessage(const char * text, const char * filename, int linenum, const char * format, ...)
+		{
+			// We only want to display the file name
+			filename = clean_filename(filename);
+
+			SCP_stringstream msgStream;
+			msgStream << "Assert: \"" << text << "\"\n";
+			msgStream << "File: " << filename << "\n";
+			msgStream << "Line: " << linenum << "\n";
+			
+			if (format != nullptr)
+			{
+				SCP_string buffer;
+				va_list args;
+
+				va_start(args, format);
+				vsprintf(buffer, format, args);
+				va_end(args);
+
+				msgStream << buffer << "\n";
+				mprintf(("ASSERTION: \"%s\" at %s:%d\n %s\n", text, filename, linenum, buffer.c_str()));
+			}
+			else
+			{
+				// No additional message
+				mprintf(("ASSERTION: \"%s\" at %s:%d\n", text, filename, linenum));
+			}
+
+#ifdef Allow_NoWarn
+			if (Cmdline_nowarn) {
+				return;
+			}
+#endif
+
+			msgStream << "\n";
+			msgStream << dump_stacktrace();
+
+			SCP_string messageText = msgStream.str();
+			set_clipboard_text(messageText.c_str());
+
+			messageText = truncateLines(msgStream, Messagebox_lines);
+			messageText += "\n[ This info is in the clipboard so you can paste it somewhere now ]\n";
+			messageText += "\n\nUse Debug to break into Debugger, Exit will close the application.\n";
+
+			Error(messageText.c_str());
+		}
+
+		void LuaError(lua_State * L, const char * format, ...)
+		{
+			SCP_stringstream msgStream;
+			
+			//WMC - if format is set to NULL, assume this is acting as an
+			//error handler for Lua.
+			if (format == NULL)
+			{
+				msgStream << "LUA ERROR: " << lua_tostring(L, -1);
+				lua_pop(L, -1);
+			}
+			else
+			{
+				SCP_string formatText;
+
+				va_list args;
+				va_start(args, format);
+				vsprintf(formatText, format, args);
+				va_end(args);
+
+				msgStream << formatText;
+			}
+
+			msgStream << "\n";
+			msgStream << "\n";
+
+			msgStream << Separator;
+			msgStream << "ADE Debug:";
+			msgStream << "\n";
+
+			msgStream << Separator;
+			LuaDebugPrint(msgStream, Ade_debug_info);
+			msgStream << Separator;
+
+			msgStream << "\n";
+			msgStream << "\n";
+
+			msgStream << Separator;
+
+			// Get the stack via the debug.traceback() function
+			lua_getglobal(L, LUA_DBLIBNAME);
+
+			if (!lua_isnil(L, -1))
+			{
+				msgStream << "\n";
+				lua_getfield(L, -1, "traceback");
+				lua_remove(L, -2);
+
+				if (lua_pcall(L, 0, 1, 0) != 0)
+					msgStream << "Error while retrieving stack: " << lua_tostring(L, -1);
+				else
+					msgStream << lua_tostring(L, -1);
+
+				lua_pop(L, 1);
+			}
+			msgStream << "\n";
+
+			msgStream << Separator;
+
+			char stackText[1024];
+			stackText[0] = '\0';
+			ade_stackdump(L, stackText);
+			msgStream << stackText;
+			msgStream << "\n";
+			msgStream << Separator;
+
+			set_clipboard_text(msgStream.str().c_str());
+
+			// truncate text
+			auto truncatedText = truncateLines(msgStream, Messagebox_lines);
+
+			SCP_stringstream boxTextStream;
+			boxTextStream << truncatedText << "\n";
+
+			boxTextStream << "\n[ This info is in the clipboard so you can paste it somewhere now ]\n";
+
+			auto boxText = boxTextStream.str();
+			const SDL_MessageBoxButtonData buttons[] = {
+				{ SDL_MESSAGEBOX_BUTTON_RETURNKEY_DEFAULT, 2, "Exit" },
+				{ SDL_MESSAGEBOX_BUTTON_ESCAPEKEY_DEFAULT, 1, "Continue" },
+				{ /* .flags, .buttonid, .text */        0, 0, "Debug" },
+			};
+
+			SDL_MessageBoxData boxData;
+			memset(&boxData, 0, sizeof(boxData));
+
+			boxData.buttons = buttons;
+			boxData.numbuttons = 3;
+			boxData.colorScheme = nullptr;
+			boxData.flags = SDL_MESSAGEBOX_ERROR;
+			boxData.message = boxText.c_str();
+			boxData.title = "Error!";
+			boxData.window = os_get_window();
+
+			gr_activate(0);
+
+			int buttonId;
+			if (SDL_ShowMessageBox(&boxData, &buttonId) < 0)
+			{
+				// Call failed
+				buttonId = 1; // No action
+			}
+
+			switch (buttonId)
+			{
+			case 2:
+				exit(1);
+
+			case 0:
+				Int3();
+				break;
+
+			default:
+				break;
+			}
+
+			gr_activate(1);
+		}
+
+		void Error(const char * filename, int line, const char * format, ...)
+		{
+			SCP_string formatText;
+			filename = clean_filename(filename);
+
+			va_list args;
+			va_start(args, format);
+			vsprintf(formatText, format, args);
+			va_end(args);
+
+			SCP_stringstream messageStream;
+			messageStream << "Error: " << formatText << "\n";
+			messageStream << "File: " << filename << "\n";
+			messageStream << "Line: " << line << "\n";
+
+			SCP_string fullText = messageStream.str();
+			mprintf(("%s\n", fullText.c_str()));
+
+			messageStream << "\n";
+			messageStream << dump_stacktrace();
+			
+			fullText = messageStream.str();
+			set_clipboard_text(fullText.c_str());
+
+			fullText = truncateLines(messageStream, Messagebox_lines);
+
+			fullText += "\n[ This info is in the clipboard so you can paste it somewhere now ]\n";
+			fullText += "\n\nUse Debug to break into Debugger, Exit will close the application.\n";
+
+			Error(fullText.c_str());
+		}
+
+		void Error(const char* text)
+		{
+			const SDL_MessageBoxButtonData buttons[] = {
+				{ SDL_MESSAGEBOX_BUTTON_RETURNKEY_DEFAULT, 1, "Exit" },
+				{ /* .flags, .buttonid, .text */        0, 0, "Debug" },
+			};
+
+			SDL_MessageBoxData boxData;
+			memset(&boxData, 0, sizeof(boxData));
+
+			boxData.buttons = buttons;
+			boxData.numbuttons = 2;
+			boxData.colorScheme = nullptr;
+			boxData.flags = SDL_MESSAGEBOX_ERROR;
+			boxData.message = text;
+			boxData.title = "Error!";
+			boxData.window = os_get_window();
+
+			gr_activate(0);
+
+			int buttonId;
+			if (SDL_ShowMessageBox(&boxData, &buttonId) < 0)
+			{
+				// Call failed
+				exit(1);
+			}
+
+			switch (buttonId)
+			{
+			case 1:
+				exit(1);
+
+			default:
+				Int3();
+				break;
+			}
+			gr_activate(1);
+		}
+
+		void Warning(const char* filename, int line, const char* format, ...)
+		{
+			Global_warning_count++;
+
+#ifndef NDEBUG
+			filename = clean_filename(filename);
+
+			// output to the debug log before anything else (so that we have a complete record)
+
+			SCP_string formatMessage;
+			va_list args;
+			va_start(args, format);
+			vsprintf(formatMessage, format, args);
+			va_end(args);
+
+
+			SCP_string printfString = formatMessage;
+			std::transform(printfString.begin(), printfString.end(), printfString.begin(), replaceNewline);
+
+			mprintf(("WARNING: \"%s\" at %s:%d\n", printfString.c_str(), filename, line));
+
+			// now go for the additional popup window, if we want it ...
+#ifdef Allow_NoWarn
+			if (Cmdline_nowarn) {
+				return;
+			}
+#endif
+
+			SCP_stringstream boxMsgStream;
+			boxMsgStream << "Warning: " << formatMessage << "\n";
+			boxMsgStream << "File: " << filename << "\n";
+			boxMsgStream << "Line: " << line << "\n";
+
+			boxMsgStream << "\n";
+			boxMsgStream << dump_stacktrace();
+
+			set_clipboard_text(boxMsgStream.str().c_str());
+
+			SCP_string boxMessage = truncateLines(boxMsgStream, Messagebox_lines);
+			boxMessage += "\n[ This info is in the clipboard so you can paste it somewhere now ]\n";
+			boxMessage += "\n\nUse Debug to break into Debugger\n";
+
+			const SDL_MessageBoxButtonData buttons[] = {
+				{ SDL_MESSAGEBOX_BUTTON_ESCAPEKEY_DEFAULT, 2, "Exit" },
+				{ SDL_MESSAGEBOX_BUTTON_RETURNKEY_DEFAULT, 1, "Continue" },
+				{ /* .flags, .buttonid, .text */        0, 0, "Debug" },
+			};
+
+			SDL_MessageBoxData boxData;
+			memset(&boxData, 0, sizeof(boxData));
+
+			boxData.buttons = buttons;
+			boxData.numbuttons = 3;
+			boxData.colorScheme = nullptr;
+			boxData.flags = SDL_MESSAGEBOX_WARNING;
+			boxData.message = boxMessage.c_str();
+			boxData.title = "Warning!";
+			boxData.window = os_get_window();
+
+			gr_activate(0);
+
+			int buttonId;
+			if (SDL_ShowMessageBox(&boxData, &buttonId) < 0)
+			{
+				// Call failed
+				exit(1);
+			}
+
+			switch (buttonId)
+			{
+			case 2:
+				exit(1);
+
+			case 0:
+				Int3();
+				break;
+
+			default:
+				break;
+			}
+
+			gr_activate(1);
+#endif // !NDEBUG
+		}
+
+		void WarningEx(const char* filename, int line, const char* format, ...)
+		{
+#ifndef NDEBUG
+			if (Cmdline_extra_warn) {
+				SCP_string msg;
+				va_list args;
+
+				va_start(args, format);
+				vsprintf(msg, format, args);
+				va_end(args);
+
+				Warning(filename, line, "%s", msg.c_str());
+			}
+#endif
+		}
+	}
+}

--- a/code/osapi/dialogs.h
+++ b/code/osapi/dialogs.h
@@ -1,0 +1,82 @@
+
+#ifndef _OSAPI_DIALOGS_H
+#define _OSAPI_DIALOGS_H
+#pragma once
+
+#include "globalincs/pstypes.h"
+
+struct lua_State;
+
+namespace os
+{
+	namespace dialogs
+	{
+		/**
+		 * @brief Displays an assert message.
+		 * @note Used by Assert() and Assertion() to display an error message, should not be used directly
+		 *
+		 * @param text The text to display
+		 * @param filename The source code filename where this function was called
+		 * @param linenum The source code line number where this function was called
+		 * @param format An optional message to display in addition to the specified text
+		 */
+		void AssertMessage(const char* text, const char* filename, int linenum,
+				const char* format = nullptr, ...);
+
+		/**
+		 * @brief Shows a lua error.
+		 * This captures the current state of the given lua_State and displays a dialog describing the error.
+		 * If @c format is @c nullptr this function pops a string from the top of the lua stack and uses that as the error message.
+		 * @param L The lua_State to capture the state of
+		 * @param format The error message to display, may be @c nullptr
+		 */
+		void LuaError(lua_State *L, const char *format = nullptr, ...);
+
+		/**
+		 * @brief Shows an error dialog.
+		 * Only use this function if the program is in an unrecoverable state because of invalid user data, programming errors should
+		 * be handled with Assert() and Assertion(). This function usually doesn't return as the generated error is considered fatal.
+		 *
+		 * @param filename The source code filename where this function was called
+		 * @param line The source code line number where this function was called
+		 * @param format The error message to display (a format string)
+		 */
+		void Error(const char* filename, int line, const char* format, ...);
+
+		/**
+		 * @brief Shows an error dialog.
+		 * This is a more general version of Error(const char*,int,const char*,...) that only displays the dialog.
+		 *
+		 * @param text The text to display
+		 */
+		void Error(const char* text);
+
+		/**
+		 * @brief Shows a warning dialog.
+		 * A warning should be generated if a recoverable user data error was detected. This function is only enabled in debug builds.
+		 *
+		 * @param filename The source code filename where this function was called
+		 * @param line The source code line number where this function was called
+		 * @param format The message to display
+		 */
+		void Warning(const char* filename, int line, const char* format, ...);
+
+		/**
+		 * @brief Shows an extra warning.
+		 * Same as Warning(const char*,int,const char*) but only Cmdline_extra_warn is set to @c 1.
+		 *
+		 * @param filename The source code filename where this function was called
+		 * @param line The source code line number where this function was called
+		 * @param format The message to display
+		 */
+		void WarningEx(const char* filename, int line, const char* format, ...);
+	}
+}
+
+// Make these available in the global namespace for compatibility
+using os::dialogs::LuaError;
+using os::dialogs::Error;
+using os::dialogs::Warning;
+using os::dialogs::WarningEx;
+
+#endif // _OSAPI_DIALOGS_H

--- a/code/osapi/osapi.cpp
+++ b/code/osapi/osapi.cpp
@@ -29,14 +29,13 @@
 #include "graphics/2d.h"
 #include "cmdline/cmdline.h"
 
-#ifdef __linux__
-#include <execinfo.h>
-#endif
 
 #define THREADED	// to use the proper set of macros
 #include "osapi/osapi.h"
 
 #include "SDL_syswm.h"
+
+#include <SDL_assert.h>
 
 
 // used to be a THREADED define but only use multiple process threads if this is defined
@@ -437,38 +436,10 @@ void debug_int3(char *file, int line)
 
 	gr_activate(0);
 
-	
+	mprintf(("%s\n", dump_stacktrace().c_str()));
+
 #ifndef NDEBUG
-	// Try to get a backtrace on linux
-
-#	ifdef WIN32
-#		if defined(_MSC_VER) && _MSC_VER >= 1400
-	__debugbreak( );
-#		elif defined(_MSC_VER)
-	_asm int 3;
-#		elif defined __GNUC__
-	asm("int $3");
-#		else
-#			error debug_int3: unknown compiler
-#		endif
-#	elif defined(__linux__)
-#	define SIZE 1024
-	char **symbols;
-	int i, numstrings;
-	void *buffer[SIZE];
-
-	numstrings = backtrace(buffer, SIZE);
-	symbols = backtrace_symbols(buffer, numstrings);
-
-	if(symbols != NULL)
-	{
-		for(i = 0; i < numstrings; i++)
-		{
-			mprintf(("%s\n", symbols[i]));
-		}
-	}
-	free(symbols);
-#	endif
+	SDL_TriggerBreakpoint();
 #endif
 
 	gr_activate(1);

--- a/code/osapi/osapi.h
+++ b/code/osapi/osapi.h
@@ -13,6 +13,7 @@
 
 #include "globalincs/pstypes.h"
 #include "osapi/osregistry.h"
+#include "osapi/dialogs.h"
 
 // --------------------------------------------------------------------------------------------------
 // OSAPI DEFINES/VARS

--- a/code/parse/scripting.cpp
+++ b/code/parse/scripting.cpp
@@ -15,6 +15,7 @@
 #include "controlconfig/controlsconfig.h"
 #include "freespace2/freespace.h"
 #include "weapon/beam.h"
+#include "osapi/osapi.h"
 
 //tehe. Declare the main event
 script_state Script_system("FS2_Open Scripting");

--- a/code/windows_stub/stubs.cpp
+++ b/code/windows_stub/stubs.cpp
@@ -21,6 +21,10 @@
 #include <malloc.h>
 #endif
 
+#ifdef __linux__
+#include <execinfo.h>
+#endif
+
 #include "cmdline/cmdline.h"
 #include "debugconsole/console.h"
 #include "globalincs/pstypes.h"
@@ -28,9 +32,6 @@
 
 bool env_enabled = false;
 bool cell_enabled = false;
-
-int Global_warning_count = 0;
-int Global_error_count = 0;
 
 #define MAX_BUF_SIZE	1024
 static char buffer[MAX_BUF_SIZE], buffer_tmp[MAX_BUF_SIZE];
@@ -76,236 +77,33 @@ int filelength(int fd)
 	return buf.st_size;
 }
 
-extern void os_deinit();
-// fatal assertion error
-void WinAssert(char * text, char *filename, int line)
+
+SCP_string dump_stacktrace()
 {
-	fprintf(stderr, "ASSERTION FAILED: \"%s\" at %s:%d\n", text, filename, line);
+#ifdef __linux__
+	const int SIZE = 1024;
+	SCP_stringstream stackstream;
+	char **symbols;
+	int i, numstrings;
+	void *buffer[SIZE];
 
-	// this stuff migt be really useful for solving bug reports and user errors. We should output it! 
-	mprintf(("ASSERTION: \"%s\" at %s:%d\n", text, strrchr(filename, '/')+1, line ));
+	numstrings = backtrace(buffer, SIZE);
+	symbols = backtrace_symbols(buffer, numstrings);
 
-#ifdef Allow_NoWarn
-	if (Cmdline_nowarn) {
-		return;
-	}
-#endif
-
-	// we have to call os_deinit() before abort() so we make sure that SDL gets
-	// closed out and we don't lose video/input control
-	os_deinit();
-
-	abort();
-}
-
-// fatal assertion error
-void WinAssert(char * text, char *filename, int line, const char * format, ... )
-{
-	// Karajorma - Nicked the code from the Warning function below
-	va_list args;
-	int i;
-	int slen = 0;
-
-	memset( buffer, 0, sizeof(buffer) );
-	memset( buffer_tmp, 0, sizeof(buffer_tmp) );
-
-	va_start(args, format);
-	vsnprintf(buffer_tmp, sizeof(buffer_tmp) - 1, format, args);
-	va_end(args);
-
-	slen = strlen(buffer_tmp);
-
-	// strip out the newline char so the output looks better
-	for (i = 0; i < slen; i++){
-		if (buffer_tmp[i] == (char)0x0a) {
-			buffer[i] = ' ';
-		} else {
-			buffer[i] = buffer_tmp[i];
+	if(symbols != NULL)
+	{
+		for(i = 0; i < numstrings; i++)
+		{
+			stackstream << symbols[i] << "\n";
 		}
 	}
+	free(symbols);
 
-	// kill off extra white space at end
-	if (buffer[slen-1] == (char)0x20) {
-		buffer[slen-1] = '\0';
-	} else {
-		// just being careful
-		buffer[slen] = '\0';
-	}
-
-	fprintf(stderr, "ASSERTION FAILED: \"%s\" at %s:%d  %s\n", text, filename, line, buffer);
-
-	// this stuff migt be really useful for solving bug reports and user errors. We should output it! 
-	mprintf(("ASSERTION: \"%s\" at %s:%d  %s\n", text, strrchr(filename, '/')+1, line, buffer ));
-
-#ifdef Allow_NoWarn
-	if (Cmdline_nowarn) {
-		return;
-	}
-#endif
-
-	// we have to call os_deinit() before abort() so we make sure that SDL gets
-	// closed out and we don't lose video/input control
-	os_deinit();
-
-	abort();
-}
-
-void WarningEx( char *filename, int line, const char *format, ... )
-{
-#ifndef NDEBUG
-	if (Cmdline_extra_warn) {
-		char msg[2 * MAX_BUF_SIZE];
-		va_list args;
-		va_start(args, format);
-		vsprintf(msg, format, args);
-		va_end(args);
-		Warning(filename, line, msg);
-	}
-#endif
-}
-
-// standard warning message
-void Warning( char * filename, int line, const char * format, ... )
-{
-	Global_warning_count++;
-
-#ifndef NDEBUG
-	va_list args;
-	int i;
-	int slen = 0;
-
-	memset( buffer, 0, sizeof(buffer) );
-	memset( buffer_tmp, 0, sizeof(buffer_tmp) );
-
-	va_start(args, format);
-	vsnprintf(buffer_tmp, sizeof(buffer_tmp) - 1, format, args);
-	va_end(args);
-
-	slen = strlen(buffer_tmp);
-
-	// strip out the newline char so the output looks better
-	for (i = 0; i < slen; i++){
-		if (buffer_tmp[i] == (char)0x0a) {
-			buffer[i] = ' ';
-		} else {
-			buffer[i] = buffer_tmp[i];
-		}
-	}
-
-	// kill off extra white space at end
-	if (buffer[slen-1] == (char)0x20) {
-		buffer[slen-1] = '\0';
-	} else {
-		// just being careful
-		buffer[slen] = '\0';
-	}
-
-	mprintf(("WARNING: \"%s\" at %s:%d\n", buffer, strrchr(filename, '/')+1, line));
-
-	// Order UP!!
-	fprintf(stderr, "WARNING: \"%s\" at %s:%d\n", buffer, filename, line);
-#endif
-}
-
-// fatal error message
-void Error( const char * filename, int line, const char * format, ... )
-{
-	Global_error_count++;
-
-	va_list args;
-#ifndef APPLE_APP
-	int i;
-	int slen = 0;
-#endif
-
-	memset( buffer, 0, sizeof(buffer) );
-	memset( buffer_tmp, 0, sizeof(buffer_tmp) );
-
-	va_start(args, format);
-	vsnprintf(buffer_tmp, sizeof(buffer_tmp) - 1, format, args);
-	va_end(args);
-
-	mprintf(("ERROR: %s\nFile: %s\nLine: %d\n", buffer_tmp, filename, line));
-
-#if defined(APPLE_APP)
-	CFStringRef AsMessage;
-	char AsText[1024];
-	CFOptionFlags result;
-
-	snprintf(AsText, 1024, "Error: %s\n\nFile: %s\nLine %d\n", buffer_tmp, filename, line);
-	AsMessage = CFStringCreateWithCString(NULL, AsText, kCFStringEncodingASCII);
-
-	CFUserNotificationDisplayAlert(0, kCFUserNotificationStopAlertLevel, NULL, NULL, NULL, CFSTR("Error!"), AsMessage, CFSTR("Exit"), NULL, NULL, &result);
+	return stackstream.str();
 #else
-	slen = strlen(buffer_tmp);
-
-	// strip out the newline char so the output looks better
-	for (i = 0; i < slen; i++){
-		if (buffer_tmp[i] == (char)0x0a) {
-			buffer[i] = ' ';
-		} else {
-			buffer[i] = buffer_tmp[i];
-		}
-	}
-
-	// kill off extra white space at end
-	if (buffer[slen-1] == (char)0x20) {
-		buffer[slen-1] = '\0';
-	} else {
-		// just being careful
-		buffer[slen] = '\0';
-	}
-
-	// Order UP!!
-	fprintf(stderr, "ERROR: \"%s\" at %s:%d\n", buffer, filename, line);
+	return "No stacktrace available";
 #endif
-
-	exit(EXIT_FAILURE);
 }
-
-extern lua_Debug Ade_debug_info;
-void LuaError(struct lua_State *L, char *format, ...)
-{
-	va_list args;
-	memset( &buffer, 0, sizeof(buffer) );
-
-	if (format == NULL) {
-		// make sure to cap to a sane string size
-		snprintf( buffer, sizeof(buffer) - 1, "%s", lua_tostring(L, -1) );
-		lua_pop(L, -1);
-	} else {
-		va_start(args, format);
-		vsnprintf(buffer, sizeof(buffer) - 1, format, args);
-		va_end(args);
-	}
-
-	// Order UP!!
-	fprintf(stderr, "LUA ERROR: \"%s\"\n", buffer);
-	fprintf(stderr, "\n");
-
-	fprintf(stderr, "------------------------------------------------------------------\n");
-	fprintf(stderr, "ADE Debug:\n");
-	fprintf(stderr, "\n");
-	fprintf(stderr, "Name:  %s\n",  Ade_debug_info.name);
-	fprintf(stderr, "Name of:  %s\n",  Ade_debug_info.namewhat);
-	fprintf(stderr, "Function type:  %s\n",  Ade_debug_info.what);
-	fprintf(stderr, "Defined on:  %d\n",  Ade_debug_info.linedefined);
-	fprintf(stderr, "Upvalues:  %d\n",  Ade_debug_info.nups);
-	fprintf(stderr, "\n" );
-	fprintf(stderr, "Source:  %s\n",  Ade_debug_info.source);
-	fprintf(stderr, "Short source:  %s\n",  Ade_debug_info.short_src);
-	fprintf(stderr, "Current line:  %d\n",  Ade_debug_info.currentline);
-	
-	fprintf(stderr, "------------------------------------------------------------------\n");
-	fprintf(stderr, "LUA Stack:\n");
-	fprintf(stderr, "\n");
-	ade_stackdump(L, buffer);
-	fprintf(stderr, "%s\n", buffer);
-	fprintf(stderr, "\n");
-
-	exit(EXIT_FAILURE);
-}
-
 
 HMMIO mmioOpen(LPSTR szFilename, LPMMIOINFO lpmmioinfo, DWORD dwOpenFlags)
 {
@@ -367,9 +165,9 @@ char *clean_filename(char *name)
 	while( (p > name) && (*p != '\\') && (*p != '/') && (*p != ':') )
 		p--;
 
-	p++;	
+	p++;
 
-	return p;	
+	return p;
 }
 
 // high precision timer
@@ -380,7 +178,7 @@ bool QueryPerformanceCounter(LARGE_INTEGER *pcount)
 	gettimeofday(&timer_now, NULL);
 
 	pcount->QuadPart = (longlong)timer_now.tv_usec;
-	
+
 	return 1;
 }
 

--- a/projects/MSVC_2015/code.vcxproj
+++ b/projects/MSVC_2015/code.vcxproj
@@ -663,6 +663,7 @@
     <ClCompile Include="..\..\code\object\parseobjectdock.cpp" />
     <ClCompile Include="..\..\code\object\waypoint.cpp" />
     <ClCompile Include="..\..\code\Observer\observer.cpp" />
+    <ClCompile Include="..\..\code\osapi\dialogs.cpp" />
     <ClCompile Include="..\..\code\osapi\osapi.cpp" />
     <ClCompile Include="..\..\code\osapi\osregistry.cpp" />
     <ClCompile Include="..\..\code\osapi\osregistry_unix.cpp" />
@@ -951,6 +952,7 @@
     <ClInclude Include="..\..\code\object\parseobjectdock.h" />
     <ClInclude Include="..\..\code\object\waypoint.h" />
     <ClInclude Include="..\..\code\Observer\observer.h" />
+    <ClInclude Include="..\..\code\osapi\dialogs.h" />
     <ClInclude Include="..\..\code\osapi\monopub.h" />
     <ClInclude Include="..\..\code\osapi\osapi.h" />
     <ClInclude Include="..\..\code\osapi\osregistry.h" />

--- a/projects/MSVC_2015/code.vcxproj.filters
+++ b/projects/MSVC_2015/code.vcxproj.filters
@@ -291,10 +291,10 @@
     <ClCompile Include="..\..\code\debugconsole\console.cpp">
       <Filter>DebugConsole</Filter>
     </ClCompile>
-	<ClCompile Include="..\..\code\debugconsole\consolecmds.cpp">
+    <ClCompile Include="..\..\code\debugconsole\consolecmds.cpp">
       <Filter>DebugConsole</Filter>
     </ClCompile>
-	<ClCompile Include="..\..\code\debugconsole\consoleparse.cpp">
+    <ClCompile Include="..\..\code\debugconsole\consoleparse.cpp">
       <Filter>DebugConsole</Filter>
     </ClCompile>
     <ClCompile Include="..\..\code\fireball\fireballs.cpp">
@@ -1068,6 +1068,9 @@
     <ClCompile Include="..\..\code\graphics\shadows.cpp">
       <Filter>Graphics</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\code\osapi\dialogs.cpp">
+      <Filter>OsApi</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\code\ai\ai.h">
@@ -1136,10 +1139,10 @@
     <ClInclude Include="..\..\code\Debris\debris.h">
       <Filter>Debris</Filter>
     </ClInclude>
-	<ClInclude Include="..\..\code\debugconsole\console.h">
+    <ClInclude Include="..\..\code\debugconsole\console.h">
       <Filter>DebugConsole</Filter>
     </ClInclude>
-	<ClInclude Include="..\..\code\debugconsole\consoleparse.h">
+    <ClInclude Include="..\..\code\debugconsole\consoleparse.h">
       <Filter>DebugConsole</Filter>
     </ClInclude>
     <ClInclude Include="..\..\code\DirectX\vasync.h">
@@ -1882,6 +1885,9 @@
     </ClInclude>
     <ClInclude Include="..\..\code\graphics\shadows.h">
       <Filter>Graphics</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\code\osapi\dialogs.h">
+      <Filter>OsApi</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
This unifies the way the engine handles warning and error dialog by using the functions supplied by SDL without having to use platform specific functions.

Tested on Linux and Windows (VS 2015).