### PR TITLE
Weapon Damage Decay

### DIFF
--- a/code/object/collideshipweapon.cpp
+++ b/code/object/collideshipweapon.cpp
@@ -75,7 +75,15 @@ void ship_weapon_do_hit_stuff(object *ship_obj, object *weapon_obj, vec3d *world
 	// Apply hit & damage & stuff to weapon
 	weapon_hit(weapon_obj, ship_obj,  world_hitpos, quadrant_num);
 
-	damage = wip->damage;
+	if (wip->damage_time != 0.0f && wp->lifeleft <= wip->damage_time) {
+		if (wip->min_damage != 0.0f) {
+			damage = (((wip->damage - wip->min_damage) * (wp->lifeleft / wip->damage_time)) + wip->min_damage);
+		} else {
+			damage = wip->damage * (wp->lifeleft / wip->damage_time);
+		}
+	} else {
+		damage = wip->damage;
+	}
 
 	// deterine whack whack
 	float		blast = wip->mass;

--- a/code/object/collideshipweapon.cpp
+++ b/code/object/collideshipweapon.cpp
@@ -78,6 +78,8 @@ void ship_weapon_do_hit_stuff(object *ship_obj, object *weapon_obj, vec3d *world
 	if (wip->damage_time != 0.0f && wp->lifeleft <= wip->damage_time) {
 		if (wip->min_damage != 0.0f) {
 			damage = (((wip->damage - wip->min_damage) * (wp->lifeleft / wip->damage_time)) + wip->min_damage);
+		} else if (wip->max_damage != 0.0f) {
+			damage = (((wip->damage - wip->max_damage) * (wp->lifeleft / wip->damage_time)) + wip->max_damage);
 		} else {
 			damage = wip->damage * (wp->lifeleft / wip->damage_time);
 		}

--- a/code/weapon/weapon.h
+++ b/code/weapon/weapon.h
@@ -356,6 +356,8 @@ typedef struct weapon_info {
 	float min_delay;							// min time to delay a shot	(DahBlount)
 
 	float	damage;								//	damage of weapon (for missile, damage within inner radius)
+	float	damage_time;						// point in the lifetime of the weapon at which damage starts to attenuate. This applies to non-beam primaries. (DahBlount)
+	float	min_damage;							// lowest damage the weapon can deal. (DahBlount)
 
 	shockwave_create_info shockwave;
 	shockwave_create_info dinky_shockwave;

--- a/code/weapon/weapon.h
+++ b/code/weapon/weapon.h
@@ -358,6 +358,7 @@ typedef struct weapon_info {
 	float	damage;								//	damage of weapon (for missile, damage within inner radius)
 	float	damage_time;						// point in the lifetime of the weapon at which damage starts to attenuate. This applies to non-beam primaries. (DahBlount)
 	float	min_damage;							// lowest damage the weapon can deal. (DahBlount)
+	float	max_damage;							// highest damage the weapon can deal. (DahBlount)
 
 	shockwave_create_info shockwave;
 	shockwave_create_info dinky_shockwave;

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -1423,6 +1423,22 @@ int parse_weapon(int subtype, bool replace, const char *filename)
 		if(optional_string("+Min Damage:")){
 			stuff_float(&wip->min_damage);
 		}
+		if(wip->min_damage > wip->damage) {
+			Warning(LOCATION, "Min Damage is greater than Damage, resetting to zero.");
+			wip->min_damage = 0.0f;
+		}
+		if(optional_string("+Max Damage:")) {
+			stuff_float(&wip->max_damage);
+		}
+		if(wip->max_damage < wip->damage) {
+			Warning(LOCATION, "Max Damage is less than Damage, resetting to zero.");
+			wip->max_damage = 0.0f;
+		}
+		if(wip->min_damage != 0.0f && wip->max_damage != 0.0f) {
+			Warning(LOCATION, "Both Min Damage and Max Damage are set to values greater than zero, resetting both to zero.");
+			wip->min_damage = 0.0f;
+			wip->max_damage = 0.0f;
+		}
 	}
 	
 	if(optional_string("$Damage Type:")) {
@@ -1527,6 +1543,10 @@ int parse_weapon(int subtype, bool replace, const char *filename)
 			Warning(LOCATION, "Lifetime min or max specified, but $Lifetime was also specified; min or max will be used.");
 		}
 		stuff_float(&wip->lifetime);
+		if (wip->damage_time > wip->lifetime) {
+			Warning(LOCATION, "Lifetime is lower than Damage Time, setting Damage Time to be one half the value of Lifetime.");
+			wip->damage_time = 0.5f * wip->lifetime;
+		}
 	}
 
 	if(optional_string("$Energy Consumed:")) {

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -882,6 +882,8 @@ void init_weapon_entry(int weap_info_index)
 	wip->max_delay = 0.0f;
 	wip->min_delay = 0.0f;
 	wip->damage = 0.0f;
+	wip->damage_time = 0.0f;
+	wip->min_damage = 0.0f;
 	
 	wip->damage_type_idx = -1;
 	wip->damage_type_idx_sav = -1;
@@ -1412,6 +1414,14 @@ int parse_weapon(int subtype, bool replace, const char *filename)
 		//do this automagically
 		if(first_time) {
 			wip->shockwave.damage = wip->damage;
+		}
+	}
+
+	// Attenuation of non-beam primary weapon damage
+	if(optional_string("$Damage Time:")) {
+		stuff_float(&wip->damage_time);
+		if(optional_string("+Min Damage:")){
+			stuff_float(&wip->min_damage);
 		}
 	}
 	


### PR DESCRIPTION
This allows non-beam primary weapons to have attenuating damage.

$Damage Time:, Time at which damage attenuation starts. (when life left = damage time)
+Min Damage:, The minimum amount of damage that can ever be done assuming attenuation is taking place. Defaults to 0.0.
+Max Damage:, The maximum amount of damage that can ever be done assuming attenuation is taking place. Defaults to 0.0.

+Min Damage: and +Max Damage: cannot be used at the same time.

Test case:
Enemy: SF Mara
Weapon Velocity: 750 m/s
Lifetime: 4 seconds'
Max Range: 3000 meters
Damage time: 2 seconds, attenuation starts at 1500 meters
Damage: 25 -> 10 at max range

Shields removed entirely. ~13% damage taken by Mara at 1400 meters
~9% damage taken at 2000 meters.
~5% damage taken at 2900 meters. Single bolts were used each time and each distance was tested 3 times.

This should work for secondaries as well. (Not that missiles should have attenuating damage in the first place)