### PR TITLE
Create "don't spawn if shot" flag

### DIFF
--- a/code/weapon/weapon.h
+++ b/code/weapon/weapon.h
@@ -123,6 +123,7 @@ extern int Num_weapon_subtypes;
 #define WIF3_FIGHTER_INTERCEPTABLE		(1 << 6)	// (like WIF_BOMB), without forcing it to be tagetable -MageKing17
 #define WIF3_AOE_ELECTRONICS			(1 << 7)	// Apply electronics effect across the weapon's entire area of effect instead of just on the impacted ship -MageKing17
 #define WIF3_APPLY_RECOIL				(1 << 8)	// Apply recoil using weapon and ship info
+#define WIF3_DONT_SPAWN_IF_SHOT			(1 << 9)	// Prevent shot down parent weapons from spawning children (DahBlount)
 
 #define	WIF_HOMING					(WIF_HOMING_HEAT | WIF_HOMING_ASPECT | WIF_HOMING_JAVELIN)
 #define WIF_LOCKED_HOMING           (WIF_HOMING_ASPECT | WIF_HOMING_JAVELIN)

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -685,6 +685,8 @@ void parse_wi_flags(weapon_info *weaponp, int wi_flags, int wi_flags2, int wi_fl
 			weaponp->wi_flags3 |= WIF3_FIGHTER_INTERCEPTABLE;
 		else if (!stricmp(NOX("apply recoil"), weapon_strings[i]))
 			weaponp->wi_flags3 |= WIF3_APPLY_RECOIL;
+		else if (!stricmp(NOX("don't spawn if shot"), weapon_strings[i]))
+			weaponp->wi_flags3 |= WIF3_DONT_SPAWN_IF_SHOT;
 		else
 			Warning(LOCATION, "Bogus string in weapon flags: %s\n", weapon_strings[i]);
 	}
@@ -6359,7 +6361,9 @@ void weapon_hit( object * weapon_obj, object * other_obj, vec3d * hitpos, int qu
 
 	// spawn weapons - note the change from FS 1 multiplayer.
 	if (wip->wi_flags & WIF_SPAWN){
-		spawn_child_weapons(weapon_obj);
+		if (!((wip->wi_flags3 & WIF3_DONT_SPAWN_IF_SHOT) && (sw_flag == SW_WEAPON_KILL))){			// prevent spawning of children if shot down and the dont spawn if shot flag is set (DahBlount)
+			spawn_child_weapons(weapon_obj);
+		}
 	}	
 }
 


### PR DESCRIPTION
This flag prevents submunitions from being created if a parent weapon is
shot down.

Requested by IronBeer.