### PR TITLE
Resolve CID 1093395 - Unnecessary sanity check

### DIFF
--- a/code/palman/palman.cpp
+++ b/code/palman/palman.cpp
@@ -546,7 +546,6 @@ ubyte *palette_get_blend_table(float alpha)
 		if ( alpha <= blend_table_factors[i] )	
 			break;
 	} 
-	if ( i<0 ) i = 0;
 	if ( i>NUM_BLEND_TABLES-1 ) i = NUM_BLEND_TABLES-1;
 
 	return &palette_blend_table[i*256*256];


### PR DESCRIPTION
Pretty sure this is just a paranoid check.  If it's negative it should get changed to at least 2 in the following line.  Let me know if I have any misconceptions.