### PR TITLE
Add 'make cppcheck' command line option.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -41,6 +41,8 @@ EXTRA_PROGRAMS = cfilearchiver cfileextractor
 ## Begin utilitites
 ##
 
+CPPSOURCES=$(wildcard code/*/*.cpp code/*/*.h)
+
 # cfilearchiver -- to create VPs
 cfilearchiver_SOURCES =	\
 	code/cfilearchiver/cfilearchiver.cpp
@@ -55,6 +57,11 @@ tools: cfilearchiver cfileextractor
 # cleaning
 clean-tools:
 	-test -z "$(EXTRA_PROGRAMS)" || rm -f $(EXTRA_PROGRAMS)
+
+## cppcheck    : check for many code issues
+cppcheck: ${CPPSOURCES}
+	cppcheck ${CPPSOURCES} --enable=all --platform=unix64 \
+	--std=c99 --inline-suppr --quiet
 
 ##
 ## End utilitites


### PR DESCRIPTION
New Makefile feature which runs the [cppcheck](http://cppcheck.sourceforge.net/) tool over the source code.

Cppcheck is a static analysis tool for C/C++ code. Unlike C/C++ compilers and many other analysis tools it does not detect syntax errors in the code. Cppcheck primarily detects the types of bugs that the compilers normally do not detect. The goal is to detect only real errors in the code (i.e. have zero false positives).

Command line invocation is:
```
make cppcheck
```