### PR TITLE
Fixes and enhancements for detail boxes and spheres

### DIFF
--- a/code/model/modelinterp.cpp
+++ b/code/model/modelinterp.cpp
@@ -4715,12 +4715,20 @@ void model_render_children_buffers_DEPRECATED(polymodel *pm, int mn, int detail_
 
 	// if using detail boxes or spheres, check that we are valid for the range
 	if ( !(Interp_flags & MR_FULL_DETAIL) && model->use_render_box ) {
-		vec3d box_min, box_max;
+		vec3d box_min, box_max, offset;
+
+		if (model->use_render_box_offset) {
+			model_find_submodel_offset(&offset, pm->id, mn);
+			vm_vec_sub(&offset, &vmd_zero_vector, &offset);
+			vm_vec_add2(&offset, &model->render_box_offset);
+		} else {
+			offset = vmd_zero_vector;
+		}
 
 		vm_vec_copy_scale(&box_min, &model->render_box_min, Interp_box_scale);
 		vm_vec_copy_scale(&box_max, &model->render_box_max, Interp_box_scale);
 
-		if ( (-model->use_render_box + in_box(&box_min, &box_max, &model->offset, &View_position)) )
+		if ( (-model->use_render_box + in_box(&box_min, &box_max, &offset, &View_position)) )
 			return;
 	}
 	if ( !(Interp_flags & MR_FULL_DETAIL) && model->use_render_sphere ) {
@@ -4817,12 +4825,20 @@ void model_render_buffers_DEPRECATED(polymodel *pm, int mn, int render, bool is_
 
 	// if using detail boxes or spheres, check that we are valid for the range
 	if ( !is_child && !(Interp_flags & MR_FULL_DETAIL) && model->use_render_box ) {
-		vec3d box_min, box_max;
+		vec3d box_min, box_max, offset;
+
+		if (model->use_render_box_offset) {
+			model_find_submodel_offset(&offset, pm->id, mn);
+			vm_vec_sub(&offset, &vmd_zero_vector, &offset);
+			vm_vec_add2(&offset, &model->render_box_offset);
+		} else {
+			offset = vmd_zero_vector;
+		}
 
 		vm_vec_copy_scale(&box_min, &model->render_box_min, Interp_box_scale);
 		vm_vec_copy_scale(&box_max, &model->render_box_max, Interp_box_scale);
 
-		if ( (-model->use_render_box + in_box(&box_min, &box_max, &model->offset, &View_position)) )
+		if ( (-model->use_render_box + in_box(&box_min, &box_max, &offset, &View_position)) )
 			return;
 	}
 	if ( !is_child && !(Interp_flags & MR_FULL_DETAIL) && model->use_render_sphere ) {

--- a/code/model/modelinterp.cpp
+++ b/code/model/modelinterp.cpp
@@ -4728,10 +4728,13 @@ void model_render_children_buffers_DEPRECATED(polymodel *pm, int mn, int detail_
 
 		// TODO: doesn't consider submodel rotations yet -zookeeper
 		vec3d offset;
-		if (model->use_render_sphere_offset)
-			offset = model->render_sphere_offset;
-		else
+		if (model->use_render_sphere_offset) {
 			model_find_submodel_offset(&offset, pm->id, mn);
+			vm_vec_sub(&offset, &vmd_zero_vector, &offset);
+			vm_vec_add2(&offset, &model->render_sphere_offset);
+		} else {
+			offset = vmd_zero_vector;
+		}
 
 		if ( (-model->use_render_sphere + in_sphere(&offset, radius, &View_position)) )
 			return;
@@ -4827,10 +4830,13 @@ void model_render_buffers_DEPRECATED(polymodel *pm, int mn, int render, bool is_
 
 		// TODO: doesn't consider submodel rotations yet -zookeeper
 		vec3d offset;
-		if (model->use_render_sphere_offset)
-			offset = model->render_sphere_offset;
-		else
+		if (model->use_render_sphere_offset) {
 			model_find_submodel_offset(&offset, pm->id, mn);
+			vm_vec_sub(&offset, &vmd_zero_vector, &offset);
+			vm_vec_add2(&offset, &model->render_sphere_offset);
+		} else {
+			offset = vmd_zero_vector;
+		}
 
 		if ( (-model->use_render_sphere + in_sphere(&offset, radius, &View_position)) )
 			return;

--- a/code/model/modelread.cpp
+++ b/code/model/modelread.cpp
@@ -1315,6 +1315,18 @@ int read_model_file(polymodel * pm, char *filename, int n_subsystems, model_subs
 					while (*p == ' ') p++;
 					pm->submodel[n].use_render_box = atoi(p);
 
+					if ( (p = strstr(props, "$box_offset:")) != NULL ) {
+						p += 12;
+						while (*p == ' ') p++;
+						pm->submodel[n].render_box_offset.xyz.x = (float)strtod(p, (char **)NULL);
+						while (*p != ',') p++;
+						pm->submodel[n].render_box_offset.xyz.y = (float)strtod(++p, (char **)NULL);
+						while (*p != ',') p++;
+						pm->submodel[n].render_box_offset.xyz.z = (float)strtod(++p, (char **)NULL);
+
+						pm->submodel[n].use_render_box_offset = true;
+					}
+
 					if ( (p = strstr(props, "$box_min:")) != NULL ) {
 						p += 9;
 						while (*p == ' ') p++;

--- a/code/model/modelread.cpp
+++ b/code/model/modelread.cpp
@@ -1361,6 +1361,8 @@ int read_model_file(polymodel * pm, char *filename, int n_subsystems, model_subs
 						pm->submodel[n].render_sphere_offset.xyz.y = (float)strtod(++p, (char **)NULL);
 						while (*p != ',') p++;
 						pm->submodel[n].render_sphere_offset.xyz.z = (float)strtod(++p, (char **)NULL);
+
+						pm->submodel[n].use_render_sphere_offset = true;
 					} else {
 						pm->submodel[n].render_sphere_offset = vmd_zero_vector;
 					}

--- a/code/model/modelrender.cpp
+++ b/code/model/modelrender.cpp
@@ -1586,12 +1586,18 @@ bool model_render_check_detail_box(vec3d *view_pos, polymodel *pm, int submodel_
 	float box_scale = model_render_determine_box_scale();
 
 	if ( !( flags & MR_FULL_DETAIL ) && model->use_render_box ) {
-		vec3d box_min, box_max;
+		vec3d box_min, box_max, offset;
+
+		if (model->use_render_box_offset) {
+			offset = model->render_box_offset;
+		} else {
+			model_find_submodel_offset(&offset, pm->id, submodel_num);
+		}
 
 		vm_vec_copy_scale(&box_min, &model->render_box_min, box_scale);
 		vm_vec_copy_scale(&box_max, &model->render_box_max, box_scale);
 
-		if ( (-model->use_render_box + in_box(&box_min, &box_max, &model->offset, view_pos)) ) {
+		if ( (-model->use_render_box + in_box(&box_min, &box_max, &offset, view_pos)) ) {
 			return false;
 		}
 	}

--- a/code/model/modelrender.cpp
+++ b/code/model/modelrender.cpp
@@ -1594,8 +1594,6 @@ bool model_render_check_detail_box(vec3d *view_pos, polymodel *pm, int submodel_
 		if ( (-model->use_render_box + in_box(&box_min, &box_max, &model->offset, view_pos)) ) {
 			return false;
 		}
-
-		return true;
 	}
 
 	if ( !(flags & MR_FULL_DETAIL) && model->use_render_sphere ) {
@@ -1609,8 +1607,6 @@ bool model_render_check_detail_box(vec3d *view_pos, polymodel *pm, int submodel_
 		if ( (-model->use_render_sphere + in_sphere(&offset, sphere_radius, view_pos)) ) {
 			return false;
 		}
-
-		return true;
 	}
 
 	return true;

--- a/code/model/modelrender.cpp
+++ b/code/model/modelrender.cpp
@@ -1601,8 +1601,12 @@ bool model_render_check_detail_box(vec3d *view_pos, polymodel *pm, int submodel_
 
 		// TODO: doesn't consider submodel rotations yet -zookeeper
 		vec3d offset;
-		model_find_submodel_offset(&offset, pm->id, submodel_num);
-		vm_vec_add2(&offset, &model->render_sphere_offset);
+
+		if (model->use_render_sphere_offset) {
+			offset = model->render_sphere_offset;
+		} else {
+			model_find_submodel_offset(&offset, pm->id, submodel_num);
+		}
 
 		if ( (-model->use_render_sphere + in_sphere(&offset, sphere_radius, view_pos)) ) {
 			return false;


### PR DESCRIPTION
See commit messages.

A part of the implementation of $box_offset and $offset (the added bsp_info variables) was actually accidentally committed a long time ago in r10135.

The problems in the box/sphere calculations were partly small regressions in the new rendering code and partly my own mistakes in the original code.