### PR TITLE
Fix/refactor gr cursor interface

### DIFF
--- a/code/freespace2/freespace.cpp
+++ b/code/freespace2/freespace.cpp
@@ -7564,7 +7564,7 @@ void unload_animating_pointer()
 		Assert( (am->first_frame+i) >= 0 );
 
 		// if we are the current cursor then reset to avoid gr_close() issues - taylor
-		gr_unset_cursor_bitmap(am->first_frame + i);
+		g_Cursor.unloadHandle(am->first_frame + i);
 	}
 
 	// this will release all of the frames at once
@@ -7592,7 +7592,7 @@ void game_render_mouse(float frametime)
 			am->current_frame = 0;
 			am->elapsed_time = 0.0f;
 		}
-		gr_set_cursor_bitmap(am->first_frame + am->current_frame);
+		g_Cursor.setHandle(am->first_frame + am->current_frame);
 	}
 }
 

--- a/code/graphics/2d.cpp
+++ b/code/graphics/2d.cpp
@@ -49,6 +49,8 @@ const char *Resolution_prefixes[GR_NUM_RESOLUTIONS] = { "", "2_" };
 
 screen gr_screen;
 
+CCursor g_Cursor;
+
 color_gun Gr_red, Gr_green, Gr_blue, Gr_alpha;
 color_gun Gr_t_red, Gr_t_green, Gr_t_blue, Gr_t_alpha;
 color_gun Gr_ta_red, Gr_ta_green, Gr_ta_blue, Gr_ta_alpha;
@@ -59,9 +61,6 @@ ubyte Gr_original_palette[768];		// The palette
 ubyte Gr_current_palette[768];
 char Gr_current_palette_name[128] = NOX("none");
 
-// cursor stuff
-int Gr_cursor_handle = -1;
-size_t Gr_cursor_size = 32;	// default w/h
 
 int Web_cursor_bitmap = -1;
 
@@ -1053,22 +1052,8 @@ bool gr_init(int d_mode, int d_width, int d_height, int d_depth)
 
 	bm_init();
 
-	if ( !bm_is_valid(gr_get_cursor_bitmap()) ) {
-		int w, h;
-
-		Gr_cursor_handle = bm_load( "cursor" );
-
-		if ( bm_is_valid(gr_get_cursor_bitmap()) ) {
-			// get cursor size, so that we can be sure to account for the full thing
-			// in later cursor hiding code
-			bm_get_info(gr_get_cursor_bitmap(), &w, &h);
-			Gr_cursor_size = MAX(w, h);
-
-			if (gr_get_cursor_size() <= 0) {
-				Int3();
-			}
-		}
-	}
+	if ( !bm_is_valid(g_Cursor.getHandle()) )
+		g_Cursor.setHandle( bm_load( "cursor" ) );
 
 	// load the web pointer cursor bitmap
 	if (Web_cursor_bitmap < 0) {
@@ -1227,17 +1212,37 @@ void gr_set_shader(shader *shade)
 	}
 }
 
+// ****************************************************************************
+// CCursor class
+// ****************************************************************************
+
+/**
+ * Destructor
+ */
+CCursor::~CCursor(void)
+{
+	if (bm_is_valid(_cursor_handle)) {
+		bm_unload(_cursor_handle);
+		_cursor_handle = -1;
+		_cursor_size = 0;
+	}	
+}
+
 /**
  * Set the bitmap for the mouse pointer.  This is called by the animating mouse
  * pointer code.
  *
- * The lock parameter just locks basically disables the next call of this function that doesn't
- * have an unlock feature.  If adding in more cursor-changing situations, be aware of
- * unexpected results. You have been warned.
+ * @param n 	Handle to bitmap
+ * @param lock	See CCursor::cursor_status. Default value is GR_CURSOR_UNKNOWN
  *
- * @todo investigate memory leak of original Gr_cursor_handle bitmap when this is called
+ * The lock parameter just locks basically disables the next call of this 
+ * function that doesn't have an unlock feature.  If adding in more 
+ * cursor-changing situations, be aware of unexpected results. 
+ * You have been warned.
+ *
+ * @todo investigate original _cursor_handle memory leak  when this is called
  */
-void gr_set_cursor_bitmap(int n, int lock)
+void CCursor::setHandle(int n, cursor_status lock)
 {
 	int w, h;
 	static int locked = 0;
@@ -1245,27 +1250,28 @@ void gr_set_cursor_bitmap(int n, int lock)
 	if ( !locked || (lock == GR_CURSOR_UNLOCK) ) {
 		// if we are changing the cursor to something different
 		// then unload the previous cursor's data - taylor
-		if ( bm_is_valid(gr_get_cursor_bitmap()) && (gr_get_cursor_bitmap() != n) ) {
-			// be sure to avoid changing a cursor which is simply another frame
-			if ( (GL_cursor_nframes < 2) || ((n - gr_get_cursor_bitmap()) >= GL_cursor_nframes) ) {
-				gr_unset_cursor_bitmap(gr_get_cursor_bitmap());
+		if ( bm_is_valid(getHandle()) && (getHandle() != n) ) {
+			// Avoid changing cursor which is simply another frame
+			if ( (GL_cursor_nframes < 2) || 
+			     ((n - getHandle()) >= GL_cursor_nframes) ) {
+				unloadHandle(getHandle());
 			}
 		}
 
-		if (n != gr_get_cursor_bitmap()) {
-			// get cursor size, so that we can be sure to account for the full thing
-			// in later cursor hiding code
+		if (n != getHandle()) {
+			// get cursor size, so that we can account for the 
+			// full thing in later cursor hiding code
 			bm_get_info(n, &w, &h, NULL, &GL_cursor_nframes);
 			Assert( GL_cursor_nframes > 0 );
 
-			Gr_cursor_size = MAX(w, h);
+			_cursor_size = MAX(w, h);
 
-			if (gr_get_cursor_size() <= 0) {
+			if (getCursorSize() <= 0) {
 				Int3();
 			}
 		}
 
-		Gr_cursor_handle = n;
+		_cursor_handle = n;
 	} else {
 		locked = 0;
 	}
@@ -1275,36 +1281,44 @@ void gr_set_cursor_bitmap(int n, int lock)
 	}
 }
 
-void gr_unset_cursor_bitmap(int n)
+/**
+ * Unloads resources held by a cursor bitmap and resets CCursor object
+ *
+ * @param n Handle to bitmap
+ */
+void CCursor::unloadHandle(int n)
 {
-	if (n < 0) {
+	if (!bm_is_valid(n))
 		return;
-	}
 
-	if (gr_get_cursor_bitmap() == n) {
-		bm_unload(gr_get_cursor_bitmap());
-		Gr_cursor_handle = -1;
+	if (getHandle() == n) {
+		bm_unload(getHandle());
+		_cursor_handle = -1;
+		_cursor_size = 0;
 	}
 }
 
 /**
- * Retrieves the current bitmap
- * Used in UI_GADGET to save/restore current cursor state
+ * Retrieves the current bitmap handle
+ *
+ * @return Current cursor bitmap handle
  */
-int gr_get_cursor_bitmap()
+int CCursor::getHandle() const
 {
-	return Gr_cursor_handle;
+	return _cursor_handle;
 }
 
 /**
  * Retrieves the current bitmap size
  *
- * @return Current bitmap size in width or height (assumed square)
+ * @return Current cursor bitmap size in width or height (assumed square)
  */
-size_t gr_get_cursor_size()
+size_t CCursor::getCursorSize() const
 {
-	return Gr_cursor_size;
+	return _cursor_size;
 }
+
+// ****************************************************************************
 
 // new bitmap functions
 void gr_bitmap(int _x, int _y, int resize_mode)

--- a/code/graphics/2d.cpp
+++ b/code/graphics/2d.cpp
@@ -1288,14 +1288,12 @@ void CCursor::setHandle(int n, cursor_status lock)
  */
 void CCursor::unloadHandle(int n)
 {
-	if (!bm_is_valid(n))
+	if (!bm_is_valid(n) || !(getHandle() == n))
 		return;
 
-	if (getHandle() == n) {
-		bm_unload(getHandle());
-		_cursor_handle = -1;
-		_cursor_size = 0;
-	}
+	bm_unload(getHandle());
+	_cursor_handle = -1;
+	_cursor_size = 0;
 }
 
 /**

--- a/code/graphics/2d.cpp
+++ b/code/graphics/2d.cpp
@@ -1052,15 +1052,15 @@ bool gr_init(int d_mode, int d_width, int d_height, int d_depth)
 
 	bm_init();
 
-	if (Gr_cursor < 0) {
+	if (gr_get_cursor_bitmap() < 0) {
 		int w, h;
 
 		Gr_cursor = bm_load( "cursor" );
 
-		if (Gr_cursor >= 0) {
+		if (gr_get_cursor_bitmap() >= 0) {
 			// get cursor size, so that we can be sure to account for the full thing
 			// in later cursor hiding code
-			bm_get_info(Gr_cursor, &w, &h);
+			bm_get_info(gr_get_cursor_bitmap(), &w, &h);
 			Gr_cursor_size = MAX(w, h);
 
 			if (Gr_cursor_size <= 0) {
@@ -1245,14 +1245,14 @@ void gr_set_cursor_bitmap(int n, int lock)
 	if ( !locked || (lock == GR_CURSOR_UNLOCK) ) {
 		// if we are changing the cursor to something different
 		// then unload the previous cursor's data - taylor
-		if ( (Gr_cursor >= 0) && (Gr_cursor != n) ) {
+		if ( (gr_get_cursor_bitmap() >= 0) && (gr_get_cursor_bitmap() != n) ) {
 			// be sure to avoid changing a cursor which is simply another frame
-			if ( (GL_cursor_nframes < 2) || ((n - Gr_cursor) >= GL_cursor_nframes) ) {
-				gr_unset_cursor_bitmap(Gr_cursor);
+			if ( (GL_cursor_nframes < 2) || ((n - gr_get_cursor_bitmap()) >= GL_cursor_nframes) ) {
+				gr_unset_cursor_bitmap(gr_get_cursor_bitmap());
 			}
 		}
 
-		if (n != Gr_cursor) {
+		if (n != gr_get_cursor_bitmap()) {
 			// get cursor size, so that we can be sure to account for the full thing
 			// in later cursor hiding code
 			bm_get_info(n, &w, &h, NULL, &GL_cursor_nframes);
@@ -1282,8 +1282,8 @@ void gr_unset_cursor_bitmap(int n)
 		return;
 	}
 
-	if (Gr_cursor == n) {
-		bm_unload(Gr_cursor);
+	if (gr_get_cursor_bitmap() == n) {
+		bm_unload(gr_get_cursor_bitmap());
 		Gr_cursor = -1;
 	}
 }

--- a/code/graphics/2d.cpp
+++ b/code/graphics/2d.cpp
@@ -60,7 +60,7 @@ ubyte Gr_current_palette[768];
 char Gr_current_palette_name[128] = NOX("none");
 
 // cursor stuff
-int Gr_cursor = -1;
+int Gr_cursor_handle = -1;
 int Web_cursor_bitmap = -1;
 size_t Gr_cursor_size = 32;	// default w/h
 
@@ -1055,7 +1055,7 @@ bool gr_init(int d_mode, int d_width, int d_height, int d_depth)
 	if ( !bm_is_valid(gr_get_cursor_bitmap()) ) {
 		int w, h;
 
-		Gr_cursor = bm_load( "cursor" );
+		Gr_cursor_handle = bm_load( "cursor" );
 
 		if ( bm_is_valid(gr_get_cursor_bitmap()) ) {
 			// get cursor size, so that we can be sure to account for the full thing
@@ -1234,7 +1234,7 @@ void gr_set_shader(shader *shade)
  * have an unlock feature.  If adding in more cursor-changing situations, be aware of
  * unexpected results. You have been warned.
  *
- * @todo investigate memory leak of original Gr_cursor bitmap when this is called
+ * @todo investigate memory leak of original Gr_cursor_handle bitmap when this is called
  */
 void gr_set_cursor_bitmap(int n, int lock)
 {
@@ -1264,7 +1264,7 @@ void gr_set_cursor_bitmap(int n, int lock)
 			}
 		}
 
-		Gr_cursor = n;
+		Gr_cursor_handle = n;
 	} else {
 		locked = 0;
 	}
@@ -1282,7 +1282,7 @@ void gr_unset_cursor_bitmap(int n)
 
 	if (gr_get_cursor_bitmap() == n) {
 		bm_unload(gr_get_cursor_bitmap());
-		Gr_cursor = -1;
+		Gr_cursor_handle = -1;
 	}
 }
 
@@ -1292,7 +1292,7 @@ void gr_unset_cursor_bitmap(int n)
  */
 int gr_get_cursor_bitmap()
 {
-	return Gr_cursor;
+	return Gr_cursor_handle;
 }
 
 /**

--- a/code/graphics/2d.cpp
+++ b/code/graphics/2d.cpp
@@ -61,8 +61,9 @@ char Gr_current_palette_name[128] = NOX("none");
 
 // cursor stuff
 int Gr_cursor_handle = -1;
-int Web_cursor_bitmap = -1;
 size_t Gr_cursor_size = 32;	// default w/h
+
+int Web_cursor_bitmap = -1;
 
 int Gr_inited = 0;
 

--- a/code/graphics/2d.cpp
+++ b/code/graphics/2d.cpp
@@ -62,7 +62,7 @@ char Gr_current_palette_name[128] = NOX("none");
 // cursor stuff
 int Gr_cursor = -1;
 int Web_cursor_bitmap = -1;
-int Gr_cursor_size = 32;	// default w/h
+size_t Gr_cursor_size = 32;	// default w/h
 
 int Gr_inited = 0;
 
@@ -1063,9 +1063,8 @@ bool gr_init(int d_mode, int d_width, int d_height, int d_depth)
 			bm_get_info(gr_get_cursor_bitmap(), &w, &h);
 			Gr_cursor_size = MAX(w, h);
 
-			if (Gr_cursor_size <= 0) {
+			if (gr_get_cursor_size() <= 0) {
 				Int3();
-				Gr_cursor_size = 32;
 			}
 		}
 	}
@@ -1260,9 +1259,8 @@ void gr_set_cursor_bitmap(int n, int lock)
 
 			Gr_cursor_size = MAX(w, h);
 
-			if (Gr_cursor_size <= 0) {
+			if (gr_get_cursor_size() <= 0) {
 				Int3();
-				Gr_cursor_size = 32;
 			}
 		}
 
@@ -1295,6 +1293,16 @@ void gr_unset_cursor_bitmap(int n)
 int gr_get_cursor_bitmap()
 {
 	return Gr_cursor;
+}
+
+/**
+ * Retrieves the current bitmap size
+ *
+ * @return Current bitmap size in width or height (assumed square)
+ */
+size_t gr_get_cursor_size()
+{
+	return Gr_cursor_size;
 }
 
 // new bitmap functions

--- a/code/graphics/2d.cpp
+++ b/code/graphics/2d.cpp
@@ -1052,12 +1052,12 @@ bool gr_init(int d_mode, int d_width, int d_height, int d_depth)
 
 	bm_init();
 
-	if (gr_get_cursor_bitmap() < 0) {
+	if ( !bm_is_valid(gr_get_cursor_bitmap()) ) {
 		int w, h;
 
 		Gr_cursor = bm_load( "cursor" );
 
-		if (gr_get_cursor_bitmap() >= 0) {
+		if ( bm_is_valid(gr_get_cursor_bitmap()) ) {
 			// get cursor size, so that we can be sure to account for the full thing
 			// in later cursor hiding code
 			bm_get_info(gr_get_cursor_bitmap(), &w, &h);
@@ -1245,7 +1245,7 @@ void gr_set_cursor_bitmap(int n, int lock)
 	if ( !locked || (lock == GR_CURSOR_UNLOCK) ) {
 		// if we are changing the cursor to something different
 		// then unload the previous cursor's data - taylor
-		if ( (gr_get_cursor_bitmap() >= 0) && (gr_get_cursor_bitmap() != n) ) {
+		if ( bm_is_valid(gr_get_cursor_bitmap()) && (gr_get_cursor_bitmap() != n) ) {
 			// be sure to avoid changing a cursor which is simply another frame
 			if ( (GL_cursor_nframes < 2) || ((n - gr_get_cursor_bitmap()) >= GL_cursor_nframes) ) {
 				gr_unset_cursor_bitmap(gr_get_cursor_bitmap());

--- a/code/graphics/2d.h
+++ b/code/graphics/2d.h
@@ -742,13 +742,29 @@ extern void gr_set_palette(const char *name, ubyte *palette, int restrict_to_128
 void gr_get_string_size_win(int *w, int *h, const char *text);
 void gr_string_win(int x, int y, const char *s );
 
-// set the mouse pointer to a specific bitmap, used for animating cursors
-#define GR_CURSOR_LOCK		1
-#define GR_CURSOR_UNLOCK	2
-void gr_set_cursor_bitmap(int n, int lock = 0);
-void gr_unset_cursor_bitmap(int n);
-int gr_get_cursor_bitmap();
-size_t gr_get_cursor_size();
+class CCursor
+{
+public:
+	enum cursor_status 
+	{
+		GR_CURSOR_UNKNOWN = 0,		
+		GR_CURSOR_LOCK,
+		GR_CURSOR_UNLOCK
+	};
+
+	CCursor	 () : _cursor_handle(-1), _cursor_size(0) {}
+	~CCursor (void);
+	void 	setHandle(int n, cursor_status lock = GR_CURSOR_UNKNOWN);
+	void 	unloadHandle(int n);
+	int 	getHandle() const;
+	size_t 	getCursorSize() const;
+
+private:
+	int 	_cursor_handle;
+	size_t 	_cursor_size;
+};
+
+extern CCursor g_Cursor;
 
 extern int Web_cursor_bitmap;
 

--- a/code/graphics/2d.h
+++ b/code/graphics/2d.h
@@ -748,6 +748,8 @@ void gr_string_win(int x, int y, const char *s );
 void gr_set_cursor_bitmap(int n, int lock = 0);
 void gr_unset_cursor_bitmap(int n);
 int gr_get_cursor_bitmap();
+size_t gr_get_cursor_size();
+
 extern int Web_cursor_bitmap;
 
 // Called by OS when application gets/looses focus

--- a/code/graphics/grinternal.h
+++ b/code/graphics/grinternal.h
@@ -16,7 +16,6 @@
 #include "globalincs/pstypes.h" // IAM_64BIT
 #include "globalincs/globals.h" // just in case pstypes.h messed up
 
-extern int Gr_cursor;
 extern int Gr_cursor_size;
 
 extern ubyte Gr_original_palette[768];		// The palette 

--- a/code/graphics/grinternal.h
+++ b/code/graphics/grinternal.h
@@ -16,8 +16,6 @@
 #include "globalincs/pstypes.h" // IAM_64BIT
 #include "globalincs/globals.h" // just in case pstypes.h messed up
 
-extern int Gr_cursor_size;
-
 extern ubyte Gr_original_palette[768];		// The palette 
 extern ubyte Gr_current_palette[768];
 

--- a/code/graphics/gropengl.cpp
+++ b/code/graphics/gropengl.cpp
@@ -344,7 +344,7 @@ void gr_opengl_flip()
 
 	//	opengl_save_mouse_area(mx, my, Gr_cursor_size, Gr_cursor_size);
 
-		if (gr_get_cursor_bitmap() != -1 && bm_is_valid(gr_get_cursor_bitmap())) {
+		if (bm_is_valid(gr_get_cursor_bitmap())) {
 			gr_set_bitmap(gr_get_cursor_bitmap());
 			gr_bitmap( mx, my, GR_RESIZE_NONE);
 		}

--- a/code/graphics/gropengl.cpp
+++ b/code/graphics/gropengl.cpp
@@ -344,8 +344,8 @@ void gr_opengl_flip()
 
 	//	opengl_save_mouse_area(mx, my, Gr_cursor_size, Gr_cursor_size);
 
-		if (Gr_cursor != -1 && bm_is_valid(Gr_cursor)) {
-			gr_set_bitmap(Gr_cursor);
+		if (gr_get_cursor_bitmap() != -1 && bm_is_valid(gr_get_cursor_bitmap())) {
+			gr_set_bitmap(gr_get_cursor_bitmap());
 			gr_bitmap( mx, my, GR_RESIZE_NONE);
 		}
 	}

--- a/code/graphics/gropengl.cpp
+++ b/code/graphics/gropengl.cpp
@@ -342,7 +342,7 @@ void gr_opengl_flip()
 		gr_reset_clip();
 		mouse_get_pos( &mx, &my );
 
-	//	opengl_save_mouse_area(mx, my, Gr_cursor_size, Gr_cursor_size);
+	//	opengl_save_mouse_area(mx, my, gr_get_cursor_size(), gr_get_cursor_size());
 
 		if (bm_is_valid(gr_get_cursor_bitmap())) {
 			gr_set_bitmap(gr_get_cursor_bitmap());
@@ -936,13 +936,13 @@ void opengl_save_mouse_area(int x, int y, int w, int h)
 	GL_CHECK_FOR_ERRORS("start of save_mouse_area()");
 
 	// lazy - taylor
-	cursor_size = (Gr_cursor_size * Gr_cursor_size);
+	cursor_size = (gr_get_cursor_size() * gr_get_cursor_size());
 
 	// no reason to be bigger than the cursor, should never be smaller
-	if (w != Gr_cursor_size)
-		w = Gr_cursor_size;
-	if (h != Gr_cursor_size)
-		h = Gr_cursor_size;
+	if (w != gr_get_cursor_size())
+		w = gr_get_cursor_size();
+	if (h != gr_get_cursor_size())
+		h = gr_get_cursor_size();
 
 	GL_mouse_saved_x1 = x;
 	GL_mouse_saved_y1 = y;
@@ -1033,7 +1033,7 @@ int gr_opengl_save_screen()
 		pixels = (GLubyte*)vglMapBufferARB(GL_PIXEL_PACK_BUFFER_ARB, GL_READ_ONLY);
 
 		width_times_pixel = (gr_screen.max_w * 4);
-		mouse_times_pixel = (Gr_cursor_size * 4);
+		mouse_times_pixel = (gr_get_cursor_size() * 4);
 
 		sptr = (ubyte *)pixels;
 		dptr = (ubyte *)&GL_saved_screen[gr_screen.max_w * gr_screen.max_h * 4];
@@ -1055,7 +1055,7 @@ int gr_opengl_save_screen()
 			sptr = (ubyte *)pixels;
 			dptr = (ubyte *)&GL_saved_screen[(GL_mouse_saved_x1 + GL_mouse_saved_y2 * gr_screen.max_w) * 4];
 
-			for (i = 0; i < Gr_cursor_size; i++) {
+			for (i = 0; i < gr_get_cursor_size(); i++) {
 				memcpy(dptr, sptr, mouse_times_pixel);
 				sptr += mouse_times_pixel;
 				dptr -= width_times_pixel;
@@ -1089,7 +1089,7 @@ int gr_opengl_save_screen()
 		dptr = (ubyte *)GL_saved_screen;
 
 		width_times_pixel = (gr_screen.max_w * 4);
-		mouse_times_pixel = (Gr_cursor_size * 4);
+		mouse_times_pixel = (gr_get_cursor_size() * 4);
 
 		for (i = 0; i < gr_screen.max_h; i++) {
 			sptr -= width_times_pixel;
@@ -1103,7 +1103,7 @@ int gr_opengl_save_screen()
 			sptr = (ubyte *)GL_saved_mouse_data;
 			dptr = (ubyte *)&GL_saved_screen[(GL_mouse_saved_x1 + GL_mouse_saved_y2 * gr_screen.max_w) * 4];
 
-			for (i = 0; i < Gr_cursor_size; i++) {
+			for (i = 0; i < gr_get_cursor_size(); i++) {
 				memcpy(dptr, sptr, mouse_times_pixel);
 				sptr += mouse_times_pixel;
 				dptr -= width_times_pixel;

--- a/code/graphics/gropengl.cpp
+++ b/code/graphics/gropengl.cpp
@@ -338,8 +338,8 @@ void gr_opengl_flip()
 		gr_reset_clip();
 		mouse_get_pos( &mx, &my );
 
-		if (bm_is_valid(gr_get_cursor_bitmap())) {
-			gr_set_bitmap(gr_get_cursor_bitmap());
+		if (bm_is_valid( g_Cursor.getHandle()) ) {
+			gr_set_bitmap( g_Cursor.getHandle() );
 			gr_bitmap( mx, my, GR_RESIZE_NONE);
 		}
 	}
@@ -969,7 +969,7 @@ int gr_opengl_save_screen()
 		pixels = (GLubyte*)vglMapBufferARB(GL_PIXEL_PACK_BUFFER_ARB, GL_READ_ONLY);
 
 		width_times_pixel = (gr_screen.max_w * 4);
-		mouse_times_pixel = (gr_get_cursor_size() * 4);
+		mouse_times_pixel = (g_Cursor.getCursorSize() * 4);
 
 		sptr = (ubyte *)pixels;
 		dptr = (ubyte *)&GL_saved_screen[gr_screen.max_w * gr_screen.max_h * 4];
@@ -991,7 +991,7 @@ int gr_opengl_save_screen()
 			sptr = (ubyte *)pixels;
 			dptr = (ubyte *)&GL_saved_screen[(GL_mouse_saved_x1 + GL_mouse_saved_y2 * gr_screen.max_w) * 4];
 
-			for (i = 0; i < (int)gr_get_cursor_size(); i++) {
+			for (i = 0; i < (int)g_Cursor.getCursorSize(); i++) {
 				memcpy(dptr, sptr, mouse_times_pixel);
 				sptr += mouse_times_pixel;
 				dptr -= width_times_pixel;
@@ -1025,7 +1025,7 @@ int gr_opengl_save_screen()
 		dptr = (ubyte *)GL_saved_screen;
 
 		width_times_pixel = (gr_screen.max_w * 4);
-		mouse_times_pixel = (gr_get_cursor_size() * 4);
+		mouse_times_pixel = (g_Cursor.getCursorSize() * 4);
 
 		for (i = 0; i < gr_screen.max_h; i++) {
 			sptr -= width_times_pixel;
@@ -1039,7 +1039,7 @@ int gr_opengl_save_screen()
 			sptr = (ubyte *)GL_saved_mouse_data;
 			dptr = (ubyte *)&GL_saved_screen[(GL_mouse_saved_x1 + GL_mouse_saved_y2 * gr_screen.max_w) * 4];
 
-			for (i = 0; i < (int)gr_get_cursor_size(); i++) {
+			for (i = 0; i < g_Cursor.getCursorSize(); i++) {
 				memcpy(dptr, sptr, mouse_times_pixel);
 				sptr += mouse_times_pixel;
 				dptr -= width_times_pixel;

--- a/code/graphics/gropengl.cpp
+++ b/code/graphics/gropengl.cpp
@@ -991,7 +991,7 @@ int gr_opengl_save_screen()
 			sptr = (ubyte *)pixels;
 			dptr = (ubyte *)&GL_saved_screen[(GL_mouse_saved_x1 + GL_mouse_saved_y2 * gr_screen.max_w) * 4];
 
-			for (i = 0; i < gr_get_cursor_size(); i++) {
+			for (i = 0; i < (int)gr_get_cursor_size(); i++) {
 				memcpy(dptr, sptr, mouse_times_pixel);
 				sptr += mouse_times_pixel;
 				dptr -= width_times_pixel;
@@ -1039,7 +1039,7 @@ int gr_opengl_save_screen()
 			sptr = (ubyte *)GL_saved_mouse_data;
 			dptr = (ubyte *)&GL_saved_screen[(GL_mouse_saved_x1 + GL_mouse_saved_y2 * gr_screen.max_w) * 4];
 
-			for (i = 0; i < gr_get_cursor_size(); i++) {
+			for (i = 0; i < (int)gr_get_cursor_size(); i++) {
 				memcpy(dptr, sptr, mouse_times_pixel);
 				sptr += mouse_times_pixel;
 				dptr -= width_times_pixel;

--- a/code/parse/lua.cpp
+++ b/code/parse/lua.cpp
@@ -12627,16 +12627,16 @@ ADE_FUNC(setCursorImage, l_Mouse, "Image filename, [LOCK or UNLOCK]", "Sets mous
 	if(!ade_get_args(L, "s|o", &s, l_Enum.GetPtr(&u)))
 		return ADE_RETURN_NIL;
 
-	int ul = 0;
+	CCursor::cursor_status ul = CCursor::GR_CURSOR_UNKNOWN;
 	if(u != NULL)
 	{
 		if(u->index == LE_LOCK)
-			ul = GR_CURSOR_LOCK;
+			ul = CCursor::GR_CURSOR_LOCK;
 		else if(u->index == LE_UNLOCK)
-			ul = GR_CURSOR_UNLOCK;
+			ul = CCursor::GR_CURSOR_UNLOCK;
 	}
 
-	gr_set_cursor_bitmap(bm_load(s), ul);
+	g_Cursor.setHandle(bm_load(s), ul);
 
 	return ADE_RETURN_NIL;
 }

--- a/code/ui/button.cpp
+++ b/code/ui/button.cpp
@@ -436,8 +436,8 @@ void UI_BUTTON::maybe_show_custom_cursor()
 	// set the mouseover cursor 
 	if (is_mouse_on()) {
 		if ((custom_cursor_bmap >= 0) && (previous_cursor_bmap < 0)) {
-			previous_cursor_bmap = gr_get_cursor_bitmap();
-			gr_set_cursor_bitmap(custom_cursor_bmap, GR_CURSOR_LOCK);			// set and lock
+			previous_cursor_bmap = g_Cursor.getHandle();
+			g_Cursor.setHandle(custom_cursor_bmap, CCursor::GR_CURSOR_LOCK);
 		}
 	}
 }
@@ -445,7 +445,7 @@ void UI_BUTTON::maybe_show_custom_cursor()
 void UI_BUTTON::restore_previous_cursor()
 {
 	if (previous_cursor_bmap >= 0) {
-		gr_set_cursor_bitmap(previous_cursor_bmap, GR_CURSOR_UNLOCK);		// restore and unlock
+		g_Cursor.setHandle(previous_cursor_bmap, CCursor::GR_CURSOR_UNLOCK);
 		previous_cursor_bmap = -1;
 	}
 }


### PR DESCRIPTION
Refactor of the `gr_cursor_*` interface into a clean class `CCursor` and associated enum.
* This refactor has enable optimisation of the code and improved readability. 
* Confirmed working with test runs through valgrind and gdb single step debugging.
* No visible issues in game.
* Fully doxygen documented.

Potential to move the Web_cursor_bitmap to this CCursor class in future.