### PR TITLE
Improve alignment of color struct

### DIFF
--- a/code/graphics/2d.h
+++ b/code/graphics/2d.h
@@ -94,15 +94,15 @@ typedef struct shader {
 // gr_get_colors after calling gr_set_colors_fast.
 typedef struct color {
 	uint		screen_sig;
+	int		is_alphacolor;
+	int		alphacolor;
+	int		magic;
 	ubyte		red;
 	ubyte		green;
 	ubyte		blue;
 	ubyte		alpha;
 	ubyte		ac_type;							// The type of alphacolor.  See AC_TYPE_??? defines
-	int		is_alphacolor;
 	ubyte		raw8;
-	int		alphacolor;
-	int		magic;		
 } color;
 
 // Used by the team coloring code


### PR DESCRIPTION
The memory usage of the color struct can be optimised via reordering elements, which improves alignment and removes unnecessary padding bytes.

The attached patch reduces `sizeof(color)` from 28 bytes -> 24 bytes. 

That is a c.14% memory saving for any arrays which use the `color` struct.