### PR TITLE
Resolve CID 1204285: Division by Zero

### DIFF
--- a/code/ui/slider2.cpp
+++ b/code/ui/slider2.cpp
@@ -263,7 +263,11 @@ void UI_SLIDER2::set_currentItem(int _currentItem) {
 		}
 	}	
 	
-	currentPosition = fl2i(((float)currentItem/(float)numberItems) * (float)numberPositions);	
+	if (numberItems > 0) {
+		currentPosition = fl2i(((float)currentItem/(float)numberItems) * (float)numberPositions);
+	} else {
+		currentPosition = 0;
+	}
 
 cpSafety: // helps fix math problem on x86_64
 	if (currentPosition > numberItems)


### PR DESCRIPTION
It's probably not possible to reach this line when numberItems = 0, since we've never had problems, but it's good programming practice to add the check, anyway. We can just make currentPosition = 0 when numberItems = 0.