### PR TITLE
Passing value 2.0 to asin() leads to implementation-defined result

### DIFF
--- a/code/weapon/swarm.cpp
+++ b/code/weapon/swarm.cpp
@@ -263,10 +263,10 @@ void swarm_update_direction(object *objp, float frametime)
 
 			missile_speed = pi->speed;
 			missile_dist = missile_speed * swarmp->change_time/1000.0f;
-			if (missile_dist == 0.0f) // Just in case of div by zero, which can happen with local SSMs
-				swarmp->angle_offset = (float)asin(SWARM_DIST_OFFSET);
-			else
-				swarmp->angle_offset = (float)(asin(SWARM_DIST_OFFSET / missile_dist));
+			if ( missile_dist < SWARM_DIST_OFFSET ) {
+				missile_dist = i2fl(SWARM_DIST_OFFSET);
+			}
+			swarmp->angle_offset = (float)(asin(SWARM_DIST_OFFSET / missile_dist));
 			Assert(!_isnan(swarmp->angle_offset) );
 		}
 


### PR DESCRIPTION
Fix issue #196.