### PR TITLE
Add the osapi/dialog files to the other VS projects.

### DIFF
--- a/projects/MSVC_2010/code.vcxproj
+++ b/projects/MSVC_2010/code.vcxproj
@@ -527,6 +527,7 @@
     <ClCompile Include="..\..\code\object\parseobjectdock.cpp" />
     <ClCompile Include="..\..\code\object\waypoint.cpp" />
     <ClCompile Include="..\..\code\Observer\observer.cpp" />
+    <ClCompile Include="..\..\code\osapi\dialogs.cpp" />
     <ClCompile Include="..\..\code\osapi\osapi.cpp" />
     <ClCompile Include="..\..\code\osapi\osregistry.cpp" />
     <ClCompile Include="..\..\code\osapi\osregistry_unix.cpp" />
@@ -815,6 +816,7 @@
     <ClInclude Include="..\..\code\object\parseobjectdock.h" />
     <ClInclude Include="..\..\code\object\waypoint.h" />
     <ClInclude Include="..\..\code\Observer\observer.h" />
+    <ClInclude Include="..\..\code\osapi\dialogs.h" />
     <ClInclude Include="..\..\code\osapi\monopub.h" />
     <ClInclude Include="..\..\code\osapi\osapi.h" />
     <ClInclude Include="..\..\code\osapi\osregistry.h" />

--- a/projects/MSVC_2010/code.vcxproj.filters
+++ b/projects/MSVC_2010/code.vcxproj.filters
@@ -1068,6 +1068,9 @@
     <ClCompile Include="..\..\code\io\cursor.cpp">
       <Filter>Io</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\code\osapi\dialogs.cpp">
+      <Filter>OsApi</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\code\ai\ai.h">
@@ -1882,6 +1885,9 @@
     </ClInclude>
     <ClInclude Include="..\..\code\io\cursor.h">
       <Filter>Io</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\code\osapi\dialogs.h">
+      <Filter>OsApi</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/projects/MSVC_2012/code.vcxproj
+++ b/projects/MSVC_2012/code.vcxproj
@@ -656,6 +656,7 @@
     <ClCompile Include="..\..\code\object\parseobjectdock.cpp" />
     <ClCompile Include="..\..\code\object\waypoint.cpp" />
     <ClCompile Include="..\..\code\Observer\observer.cpp" />
+    <ClCompile Include="..\..\code\osapi\dialogs.cpp" />
     <ClCompile Include="..\..\code\osapi\osapi.cpp" />
     <ClCompile Include="..\..\code\osapi\osregistry.cpp" />
     <ClCompile Include="..\..\code\osapi\osregistry_unix.cpp" />
@@ -944,6 +945,7 @@
     <ClInclude Include="..\..\code\object\parseobjectdock.h" />
     <ClInclude Include="..\..\code\object\waypoint.h" />
     <ClInclude Include="..\..\code\Observer\observer.h" />
+    <ClInclude Include="..\..\code\osapi\dialogs.h" />
     <ClInclude Include="..\..\code\osapi\monopub.h" />
     <ClInclude Include="..\..\code\osapi\osapi.h" />
     <ClInclude Include="..\..\code\osapi\osregistry.h" />

--- a/projects/MSVC_2012/code.vcxproj.filters
+++ b/projects/MSVC_2012/code.vcxproj.filters
@@ -1068,6 +1068,9 @@
     <ClCompile Include="..\..\code\model\modelrender.cpp">
       <Filter>Model</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\code\osapi\dialogs.cpp">
+      <Filter>OsApi</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\code\ai\ai.h">
@@ -1882,6 +1885,9 @@
     </ClInclude>
     <ClInclude Include="..\..\code\model\modelrender.h">
       <Filter>Model</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\code\osapi\dialogs.h">
+      <Filter>OsApi</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/projects/MSVC_2013/code.vcxproj
+++ b/projects/MSVC_2013/code.vcxproj
@@ -663,6 +663,7 @@
     <ClCompile Include="..\..\code\object\parseobjectdock.cpp" />
     <ClCompile Include="..\..\code\object\waypoint.cpp" />
     <ClCompile Include="..\..\code\Observer\observer.cpp" />
+    <ClCompile Include="..\..\code\osapi\dialogs.cpp" />
     <ClCompile Include="..\..\code\osapi\osapi.cpp" />
     <ClCompile Include="..\..\code\osapi\osregistry.cpp" />
     <ClCompile Include="..\..\code\osapi\osregistry_unix.cpp" />
@@ -951,6 +952,7 @@
     <ClInclude Include="..\..\code\object\parseobjectdock.h" />
     <ClInclude Include="..\..\code\object\waypoint.h" />
     <ClInclude Include="..\..\code\Observer\observer.h" />
+    <ClInclude Include="..\..\code\osapi\dialogs.h" />
     <ClInclude Include="..\..\code\osapi\monopub.h" />
     <ClInclude Include="..\..\code\osapi\osapi.h" />
     <ClInclude Include="..\..\code\osapi\osregistry.h" />

--- a/projects/MSVC_2013/code.vcxproj.filters
+++ b/projects/MSVC_2013/code.vcxproj.filters
@@ -291,10 +291,10 @@
     <ClCompile Include="..\..\code\debugconsole\console.cpp">
       <Filter>DebugConsole</Filter>
     </ClCompile>
-	<ClCompile Include="..\..\code\debugconsole\consolecmds.cpp">
+    <ClCompile Include="..\..\code\debugconsole\consolecmds.cpp">
       <Filter>DebugConsole</Filter>
     </ClCompile>
-	<ClCompile Include="..\..\code\debugconsole\consoleparse.cpp">
+    <ClCompile Include="..\..\code\debugconsole\consoleparse.cpp">
       <Filter>DebugConsole</Filter>
     </ClCompile>
     <ClCompile Include="..\..\code\fireball\fireballs.cpp">
@@ -1068,6 +1068,9 @@
     <ClCompile Include="..\..\code\graphics\shadows.cpp">
       <Filter>Graphics</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\code\osapi\dialogs.cpp">
+      <Filter>OsApi</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\code\ai\ai.h">
@@ -1136,10 +1139,10 @@
     <ClInclude Include="..\..\code\Debris\debris.h">
       <Filter>Debris</Filter>
     </ClInclude>
-	<ClInclude Include="..\..\code\debugconsole\console.h">
+    <ClInclude Include="..\..\code\debugconsole\console.h">
       <Filter>DebugConsole</Filter>
     </ClInclude>
-	<ClInclude Include="..\..\code\debugconsole\consoleparse.h">
+    <ClInclude Include="..\..\code\debugconsole\consoleparse.h">
       <Filter>DebugConsole</Filter>
     </ClInclude>
     <ClInclude Include="..\..\code\DirectX\vasync.h">
@@ -1882,6 +1885,9 @@
     </ClInclude>
     <ClInclude Include="..\..\code\graphics\shadows.h">
       <Filter>Graphics</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\code\osapi\dialogs.h">
+      <Filter>OsApi</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Looks like a lot of changes but this is already mostly accomplished in master.  Fixes the file structures according to how the latest VS versions want the files to look like.  Proper line endings, etc.  'git diff -w' indicates a very clean set of functional changes, the rest is just whitespace.  These changes were mostly already made in master though, we may want to consider not merging this until master is merged into antipodes and then fixing the project files in antipodes to be a clean diff against master.