### PR TITLE
Don't compare NULL with integer

### DIFF
--- a/code/sound/audiostr.cpp
+++ b/code/sound/audiostr.cpp
@@ -294,7 +294,7 @@ protected:
 // constructor
 void Timer::constructor(void)
 {
-	m_nIDTimer = NULL;
+	m_nIDTimer = 0;
 }
 
 
@@ -303,7 +303,7 @@ void Timer::destructor(void)
 {
 	if (m_nIDTimer) {
 		SDL_RemoveTimer(m_nIDTimer);
-		m_nIDTimer = NULL;
+		m_nIDTimer = 0;
 	}
 }
 
@@ -321,7 +321,7 @@ bool Timer::Create (uint nPeriod, uint nRes, ptr_u dwUser, TIMERCALLBACK pfnCall
 	m_dwUser = dwUser;
 	m_pfnCallback = pfnCallback;
 
-	if ((m_nIDTimer = SDL_AddTimer(m_nPeriod, TimeProc, (void*)this)) == NULL) {
+	if ((m_nIDTimer = SDL_AddTimer(m_nPeriod, TimeProc, (void*)this)) == 0) {
 	  bRtn = false;
 	}
 
@@ -346,7 +346,7 @@ uint Timer::TimeProc(uint interval, void *dwUser)
 		return interval;
     } else {
 		SDL_RemoveTimer(ptimer->m_nIDTimer);
-		ptimer->m_nIDTimer = NULL;
+		ptimer->m_nIDTimer = 0;
 		return 0;
     }
 }

--- a/code/sound/rtvoice.cpp
+++ b/code/sound/rtvoice.cpp
@@ -94,7 +94,7 @@ Uint32 CALLBACK TimeProc(Uint32 interval, void *param)
 {
 	if ( !Rtv_callback ) {
 		SDL_RemoveTimer(Rtv_record_timer_id);
-		Rtv_record_timer_id = NULL;
+		Rtv_record_timer_id = 0;
 
 		return 0;
 	}
@@ -106,7 +106,7 @@ Uint32 CALLBACK TimeProc(Uint32 interval, void *param)
 		return interval;
 	} else {
 		SDL_RemoveTimer(Rtv_record_timer_id);
-		Rtv_record_timer_id = NULL;
+		Rtv_record_timer_id = 0;
 
 		return 0;
 	}
@@ -195,11 +195,10 @@ void rtvoice_stop_recording()
 	if ( Rtv_record_timer_id ) {
 #ifndef _WIN32
 		SDL_RemoveTimer(Rtv_record_timer_id);
-		Rtv_record_timer_id = NULL;
 #else
 		timeKillEvent(Rtv_record_timer_id);
-		Rtv_record_timer_id = 0;
 #endif
+		Rtv_record_timer_id = 0;
 	}
 
 	Rtv_recording=0;

--- a/code/windows_stub/config.h
+++ b/code/windows_stub/config.h
@@ -6,9 +6,11 @@
 #define _CONFIG_H
 
 
-#if !defined BYTE_ORDER
+#ifndef BYTE_ORDER
 #include "SDL_endian.h"
+#endif
 
+#ifndef BYTE_ORDER
 #define LITTLE_ENDIAN 1234
 #define BIG_ENDIAN    4321
 


### PR DESCRIPTION
As noted in #236, `NULL` was being compared with an integer value (`SDL_TimerID`) which caused issues on FreeBSD.