### PR TITLE
Math refactoring

### DIFF
--- a/code/math/floating.h
+++ b/code/math/floating.h
@@ -37,10 +37,10 @@ float frand_range(float min, float max);
 #define fl_tan(fl) tanf(fl)
 
 // convert a measurement in degrees to radians
-#define fl_radians(fl)	((float)((fl * PI)/180.0f))
+#define fl_radians(fl)	((float)((fl) * (PI / 180.0f)))
 
 // convert a measurement in radians to degrees
-#define fl_degrees(fl)	((float)((fl * 180.0f)/PI))
+#define fl_degrees(fl)	((float)((fl) * (180.0f / PI)))
 
 // use this instead of:
 // for:  (int)floor(x+0.5f) use fl_round_2048(x)

--- a/code/math/spline.cpp
+++ b/code/math/spline.cpp
@@ -26,18 +26,28 @@
 // SPLINE FUNCTIONS
 //
 
-// integer factorial. =o
-int bez_fact(int n)
+static float bez_fact_lookup[13] = {
+	1.0f,          // 0!
+	1.0f,          // 1!
+	2.0f,          // 2!
+	6.0f,          // 3!
+	24.0f,         // 4!
+	120.0f,        // 5!
+	720.0f,        // 6!
+	5040.0f,       // 7!
+	40320.0f,      // 8!
+	362880.0f,     // 9!
+	3628800.0f,    // 10!
+	39916800.0f,   // 11!
+	479001600.0f,  // 12!
+};
+
+// Limited Factorial
+static float bez_fact(int n)
 {
-	int idx;
-	int product = 1;
+	Assert((n >= 0) && (n <= 12));
 
-	// do eet
-	for(idx=1; idx<=n; idx++){
-		product *= idx;
-	}
-
-	return product;
+	return bez_fact_lookup[n];
 }
 
 // bez constructor
@@ -74,7 +84,7 @@ void bez_spline::bez_set_points(int _num_pts, vec3d *_pts[MAX_BEZ_PTS])
 }
 
 // blend function
-#define COMB(_n, _k)		( (float)bez_fact(_n) / (float)(bez_fact(_k) * bez_fact(_n - _k)) )
+#define COMB(_n, _k)		(bez_fact(_n) / (bez_fact(_k) * bez_fact(_n - _k)))
 float bez_spline::BEZ(int k, int n, float u)
 {
 	float a = (float)COMB(n, k);


### PR DESCRIPTION
3 minor refactors to the math code.

1. Rejiggerring the parentheses in macros fl_degrees and fl_radians() allows the compiler to precalculate the radians-to-degrees ratio so that a runtime division operation can be avoided.

2. Using a table to lookup factorials cuts down on the generated code.  In the previous implementation, the compiler (GCC 4.6.3) was both unrolling the loop and inlining the generated code.  The lookup table is only valid for 0! -> 12! as that was the valid range in the previous implementation.

3. Simplifies the solution to the quadratic equation in fvi.cpp by solving "A*x*x + 2*B*x + C = 0" instead of "A*x*x + B*x + C = 0".  This cuts down on the number of required multiplications.  (Commit message has the math to back it up).