### PR TITLE
Fix the output Fred SSE target name.

### DIFF
--- a/projects/MSVC_2013/Fred2.vcxproj
+++ b/projects/MSVC_2013/Fred2.vcxproj
@@ -175,7 +175,7 @@
     <TargetName Condition="'$(Configuration)|$(Platform)'=='Debug SSE2|Win32'">fred2_open_3_7_3_SSE2-DEBUG</TargetName>
     <TargetName Condition="'$(Configuration)|$(Platform)'=='Debug AVX|Win32'">fred2_open_3_7_3_AVX-DEBUG</TargetName>
     <TargetName Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">fred2_open_3_7_3</TargetName>
-    <TargetName Condition="'$(Configuration)|$(Platform)'=='Release SSE|Win32'">fred2_open_3_7_3_SSE2</TargetName>
+    <TargetName Condition="'$(Configuration)|$(Platform)'=='Release SSE|Win32'">fred2_open_3_7_3_SSE</TargetName>
     <TargetName Condition="'$(Configuration)|$(Platform)'=='Release SSE2|Win32'">fred2_open_3_7_3_SSE2</TargetName>
     <TargetName Condition="'$(Configuration)|$(Platform)'=='Release AVX|Win32'">fred2_open_3_7_3_AVX</TargetName>
   </PropertyGroup>


### PR DESCRIPTION
Edited in VS2013 which fixed the file's line endings to CRLF.  Logically only a one character deletion in the file.