### PR TITLE
Added a +Minimum Weapon Span auto spread shield option to control the…

### DIFF
--- a/code/object/collideshipweapon.cpp
+++ b/code/object/collideshipweapon.cpp
@@ -210,15 +210,16 @@ int ship_weapon_check_collision(object *ship_objp, object *weapon_objp, float ti
 			// The weapon is not allowed to impact the shield before it reaches this point
 			vec3d shield_ignored_until = weapon_objp->last_pos;
 
+			float min_weapon_span = sip->auto_shield_spread_min_span;
 			float weapon_flown_for = vm_vec_dist(&wp->start_pos, &weapon_objp->last_pos);
 
 			// If weapon hasn't yet flown a distance greater than the maximum ignore
 			// range, then some part of the currently checked range needs to be
 			// ignored
-			if (weapon_flown_for < sip->auto_shield_spread) {
+			if (weapon_flown_for < min_weapon_span) {
 				vm_vec_sub(&shield_ignored_until, &weapon_end_pos, &wp->start_pos);
 				vm_vec_normalize(&shield_ignored_until);
-				vm_vec_scale(&shield_ignored_until, sip->auto_shield_spread);
+				vm_vec_scale(&shield_ignored_until, min_weapon_span);
 				vm_vec_add2(&shield_ignored_until, &wp->start_pos);
 			}
 
@@ -253,7 +254,7 @@ int ship_weapon_check_collision(object *ship_objp, object *weapon_objp, float ti
 			// If no collision with the model found in the ignore range, only
 			// then do we check for sphereline collisions with the model during the
 			// non-ignored range
-			if (!shield_collision && weapon_flown_for + this_range > sip->auto_shield_spread) {
+			if (!shield_collision && weapon_flown_for + this_range > min_weapon_span) {
 				mc_shield.p0 = &shield_ignored_until;
 
 				mc_shield.p1 = &weapon_end_pos;

--- a/code/object/collideshipweapon.cpp
+++ b/code/object/collideshipweapon.cpp
@@ -210,8 +210,14 @@ int ship_weapon_check_collision(object *ship_objp, object *weapon_objp, float ti
 			// The weapon is not allowed to impact the shield before it reaches this point
 			vec3d shield_ignored_until = weapon_objp->last_pos;
 
-			float min_weapon_span = sip->auto_shield_spread_min_span;
 			float weapon_flown_for = vm_vec_dist(&wp->start_pos, &weapon_objp->last_pos);
+			float min_weapon_span;
+
+			if (sip->auto_shield_spread_min_span >= 0.0f) {
+				min_weapon_span = sip->auto_shield_spread_min_span;
+			} else {
+				min_weapon_span = sip->auto_shield_spread;
+			}
 
 			// If weapon hasn't yet flown a distance greater than the maximum ignore
 			// range, then some part of the currently checked range needs to be

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -873,6 +873,7 @@ void init_ship_entry(ship_info *sip)
 	sip->auto_shield_spread = 0.0f;
 	sip->auto_shield_spread_bypass = false;
 	sip->auto_shield_spread_from_lod = -1;
+	sip->auto_shield_spread_min_span = -1.0f;
 
 	for (i = 0; i < 4; i++)
 	{
@@ -2316,6 +2317,11 @@ int parse_ship_values(ship_info* sip, bool first_time, bool replace)
 
 		if(optional_string("+Auto Spread:")) {
 			stuff_float(&sip->auto_shield_spread);
+		}
+		if(optional_string("+Minimum Weapon Span:")) {
+			stuff_float(&sip->auto_shield_spread_min_span);
+		} else if (first_time) {
+			sip->auto_shield_spread_min_span = sip->auto_shield_spread;
 		}
 		if(optional_string("+Allow Bypass:")) {
 			stuff_boolean(&sip->auto_shield_spread_bypass);

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -2320,8 +2320,6 @@ int parse_ship_values(ship_info* sip, bool first_time, bool replace)
 		}
 		if(optional_string("+Minimum Weapon Span:")) {
 			stuff_float(&sip->auto_shield_spread_min_span);
-		} else if (first_time) {
-			sip->auto_shield_spread_min_span = sip->auto_shield_spread;
 		}
 		if(optional_string("+Allow Bypass:")) {
 			stuff_boolean(&sip->auto_shield_spread_bypass);

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -1306,6 +1306,7 @@ public:
 	float	auto_shield_spread;
 	bool	auto_shield_spread_bypass;
 	int		auto_shield_spread_from_lod;
+	float	auto_shield_spread_min_span;	// Minimum distance weapons must travel until allowed to collide with the shield
 
 	int		shield_point_augment_ctrls[4];	// Re-mapping of shield augmentation controls for model point shields
 


### PR DESCRIPTION
… minimum distance weapons must have traveled before being allowed to hit the shield.

Overrides the default which equals to the shield thickness.