### PR TITLE
[fix/cid_1204285_divide_by_zero] Fix CID 1204285: Division by zero

### DIFF
--- a/code/ui/slider2.cpp
+++ b/code/ui/slider2.cpp
@@ -263,7 +263,11 @@ void UI_SLIDER2::set_currentItem(int _currentItem) {
 		}
 	}	
 	
-	currentPosition = fl2i(((float)currentItem/(float)numberItems) * (float)numberPositions);	
+	if (numberItems > 0) {
+		currentPosition = fl2i(((float)currentItem/(float)numberItems) * (float)numberPositions);
+	} else {
+		currentPosition = 0;
+	}
 
 cpSafety: // helps fix math problem on x86_64
 	if (currentPosition > numberItems)


### PR DESCRIPTION
 in set_currentItem().  From FSCyborg's PR #221.