### PR TITLE
Proposed fix for #248

### DIFF
--- a/code/cmdline/cmdline.cpp
+++ b/code/cmdline/cmdline.cpp
@@ -696,6 +696,12 @@ void os_parse_parms(int argc, char *argv[])
 
 	for (int i = 0; i < argc; i++)
 	{
+		// On mac this gets passed if the application was launched by double-clicking in the finder
+		if (i == 1 && strncmp(argv[1], "-psn", 4) == 0)
+		{
+			continue;
+		}
+
 		for (parmp = GET_FIRST(&Parm_list); parmp != END_OF_LIST(&Parm_list); parmp = GET_NEXT(parmp)) {
 			if (!stricmp(parmp->name, argv[i]))
 			{


### PR DESCRIPTION
This should match what was done in `SDLMain.c` with SDL 1.2.

This isn't hidden behind a `#ifdef APPLE_APP` to keep behavior consistent across platforms.