### PR TITLE
Turret Ammo Implementation

### DIFF
--- a/code/ai/aiturret.cpp
+++ b/code/ai/aiturret.cpp
@@ -1881,7 +1881,15 @@ bool turret_fire_weapon(int weapon_num, ship_subsys *turret, int parent_objnum, 
 			swp = &turret->weapons;
 			int bank_to_fire = swp->current_secondary_bank;
 			if ((turret->system_info->flags2 & MSS_FLAG2_TURRET_USE_AMMO) && (swp->secondary_bank_ammo[bank_to_fire] < 0)) {
-				return false;
+				if (!(turret->system_info->flags & MSS_FLAG_USE_MULTIPLE_GUNS)) {
+					swp->current_secondary_bank++;
+					if (swp->current_secondary_bank >= swp->num_secondary_banks) {
+						swp->current_secondary_bank = 0;
+					}
+					return false;
+				} else {
+					return false;
+				}
 			} else {
 				turret_swarm_set_up_info(parent_objnum, turret, wip, turret->turret_next_fire_pos);
 
@@ -1925,6 +1933,12 @@ bool turret_fire_weapon(int weapon_num, ship_subsys *turret, int parent_objnum, 
 
 						if (swp->primary_bank_ammo[bank_to_fire] >= 0) {
 							swp->primary_bank_ammo[bank_to_fire] -= points;
+						} else if (!(turret->system_info->flags & MSS_FLAG_USE_MULTIPLE_GUNS) && (swp->primary_bank_ammo[bank_to_fire] < 0)) {
+							swp->current_primary_bank++;
+							if (swp->current_primary_bank >= swp->num_primary_banks) {
+								swp->current_primary_bank = 0;
+							}
+							return false;
 						} else {
 							return false;
 						}
@@ -1954,6 +1968,12 @@ bool turret_fire_weapon(int weapon_num, ship_subsys *turret, int parent_objnum, 
 
 							if (swp->secondary_bank_ammo[bank_to_fire] >= 0) {
 								swp->secondary_bank_ammo[bank_to_fire]--;
+							} else if (!(turret->system_info->flags & MSS_FLAG_USE_MULTIPLE_GUNS) && (swp->secondary_bank_ammo[bank_to_fire] < 0)) {
+								swp->current_secondary_bank++;
+								if (swp->current_secondary_bank >= swp->num_secondary_banks) {
+									swp->current_secondary_bank = 0;
+								}
+								return false;
 							} else {
 								return false;
 							}

--- a/code/ai/aiturret.cpp
+++ b/code/ai/aiturret.cpp
@@ -1877,14 +1877,89 @@ bool turret_fire_weapon(int weapon_num, ship_subsys *turret, int parent_objnum, 
 		}
 		// don't fire swam, but set up swarm info instead
 		else if ((wip->wi_flags & WIF_SWARM) || (wip->wi_flags & WIF_CORKSCREW)) {
-			turret_swarm_set_up_info(parent_objnum, turret, wip, turret->turret_next_fire_pos);
+			ship_weapon *swp;
+			swp = &turret->weapons;
+			int bank_to_fire = swp->current_secondary_bank;
+			if ((turret->system_info->flags2 & MSS_FLAG2_TURRET_USE_AMMO) && (swp->secondary_bank_ammo[bank_to_fire] < 0)) {
+				return false;
+			} else {
+				turret_swarm_set_up_info(parent_objnum, turret, wip, turret->turret_next_fire_pos);
 
-			turret->flags |= SSF_HAS_FIRED;	//set fired flag for scripting -nike
-			return true;
+				turret->flags |= SSF_HAS_FIRED;	//set fired flag for scripting -nike
+				return true;
+			}
 		}
 		// now do anything else
 		else {
 			for (int i = 0; i < wip->shots; i++) {
+				if (turret->system_info->flags2 & MSS_FLAG2_TURRET_USE_AMMO) {
+					ship_weapon *swp;
+					swp = &turret->weapons;
+					int bank_to_fire, num_slots = turret->system_info->turret_num_firing_points;
+					if (wip->subtype == WP_LASER) {
+						int points;
+						if (swp->num_primary_banks <= 0) {
+							return false;
+						}
+
+						if (swp->current_primary_bank < 0){
+							return false;
+						}
+
+						int	num_primary_banks = swp->num_primary_banks;
+
+						Assert(num_primary_banks > 0);
+						if (num_primary_banks < 1){
+							return false;
+						}
+
+						for (int j = 0; j < num_primary_banks; i++) {
+							bank_to_fire = (swp->current_primary_bank + i) % swp->num_primary_banks;
+						}
+
+						if (turret->system_info->flags & MSS_FLAG_TURRET_SALVO) {
+							points = num_slots;
+						} else {
+							points = 1;
+						}
+
+						if (swp->primary_bank_ammo[bank_to_fire] >= 0) {
+							swp->primary_bank_ammo[bank_to_fire] -= points;
+						} else {
+							return false;
+						}
+					}
+					else if (wip->subtype == WP_MISSILE) {
+						if (swp->num_secondary_banks <= 0) {
+							return false;
+						}
+
+						if (swp->current_secondary_bank < 0){
+							return false;
+						}
+
+						bank_to_fire = swp->current_secondary_bank;
+
+						int start_slot, end_slot;
+
+						start_slot = swp->secondary_next_slot[bank_to_fire];
+						end_slot = start_slot;
+
+						for (int j = start_slot; j <= end_slot; i++) {
+							swp->secondary_next_slot[bank_to_fire]++;
+
+							if (swp->secondary_next_slot[bank_to_fire] > (num_slots - 1)){
+								swp->secondary_next_slot[bank_to_fire] = 0;
+							}
+
+							if (swp->secondary_bank_ammo[bank_to_fire] >= 0) {
+								swp->secondary_bank_ammo[bank_to_fire]--;
+							} else {
+								return false;
+							}
+						}
+					}
+				}
 				// zookeeper - Firepoints should cycle normally between shots, 
 				// so we need to get the position info separately for each shot
 				ship_get_global_turret_gun_info(&Objects[parent_objnum], turret, turret_pos, turret_fvec, 1, NULL);

--- a/code/model/model.h
+++ b/code/model/model.h
@@ -139,6 +139,7 @@ typedef struct polymodel_instance {
 #define MSS_FLAG2_NO_DISAPPEAR					 (1 << 2)	// Submodel won't disappear when subsystem destroyed
 #define MSS_FLAG2_COLLIDE_SUBMODEL				 (1 << 3)	// subsystem takes damage only from hits which impact the associated submodel
 #define MSS_FLAG2_DESTROYED_ROTATION			 (1 << 4)   // allows subobjects to continue to rotate even if they have been destroyed
+#define MSS_FLAG2_TURRET_USE_AMMO				 (1 << 5)	// enables ammo consumption for turrets (DahBlount)
 
 #define NUM_SUBSYSTEM_FLAGS			33
 

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -25399,6 +25399,14 @@ void multi_sexp_eval()
 				multi_sexp_script_eval_multi();
 				break;
 
+			case OP_TURRET_SET_PRIMARY_AMMO:
+				multi_sexp_set_turret_primary_ammo();
+				break;
+
+			case OP_TURRET_SET_SECONDARY_AMMO:
+				multi_sexp_set_turret_secondary_ammo();
+				break;
+
 			// bad sexp in the packet
 			default: 
 				// probably just a version error where the host supports a SEXP but a client does not

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -18068,6 +18068,29 @@ void sexp_set_turret_primary_ammo(int node)
 	}
 
 	set_turret_primary_ammo(turret, requested_bank, requested_weapons);
+
+	// Multiplayer call back
+	char *subsys = CTEXT(node);
+	multi_start_callback();
+	multi_send_int(sindex);
+	multi_send_string(subsys);
+	multi_send_int(requested_bank);
+	multi_send_int(requested_weapons);
+	multi_end_callback();
+}
+
+void multi_sexp_set_turret_primary_ammo()
+{
+	int sindex, requested_bank, requested_weapons;
+	char *subsys;
+	multi_get_int(sindex);
+	multi_get_string(subsys);
+	multi_get_int(requested_bank);
+	multi_get_int(requested_weapons);
+
+	ship_subsys *turret = ship_get_subsys(&Ships[sindex], subsys);
+
+	set_turret_primary_ammo(turret, requested_bank, requested_weapons);
 }
 
 // DahBlount - Helper function for setting turret primary ammo
@@ -18182,6 +18205,29 @@ void sexp_set_turret_secondary_ammo(int node)
 	{
 		return;
 	}
+
+	set_turret_secondary_ammo(turret, requested_bank, requested_weapons);
+
+	// Multiplayer call back
+	char *subsys = CTEXT(node);
+	multi_start_callback();
+	multi_send_int(sindex);
+	multi_send_string(subsys);
+	multi_send_int(requested_bank);
+	multi_send_int(requested_weapons);
+	multi_end_callback();
+}
+
+void multi_sexp_set_turret_secondary_ammo()
+{
+	int sindex, requested_bank, requested_weapons;
+	char *subsys;
+	multi_get_int(sindex);
+	multi_get_string(subsys);
+	multi_get_int(requested_bank);
+	multi_get_int(requested_weapons);
+
+	ship_subsys *turret = ship_get_subsys(&Ships[sindex], subsys);
 
 	set_turret_secondary_ammo(turret, requested_bank, requested_weapons);
 }

--- a/code/parse/sexp.h
+++ b/code/parse/sexp.h
@@ -384,7 +384,9 @@ class waypoint_list;
 #define OP_IS_IN_BOX					    (0x004c | OP_CATEGORY_STATUS | OP_NONCAMPAIGN_FLAG)	// Sushi
 #define OP_IS_IN_MISSION					(0x004d | OP_CATEGORY_STATUS | OP_NONCAMPAIGN_FLAG)	// Goober5000
 #define OP_ARE_SHIP_FLAGS_SET				(0x004e | OP_CATEGORY_STATUS | OP_NONCAMPAIGN_FLAG) // Karajorma
+#define OP_TURRET_GET_PRIMARY_AMMO			(0x004f | OP_CATEGORY_STATUS | OP_NONCAMPAIGN_FLAG)	// DahBlount, part of the turret ammo code
 
+#define OP_TURRET_GET_SECONDARY_AMMO		(0x0050 | OP_CATEGORY_STATUS | OP_NONCAMPAIGN_FLAG)	// DahBlount, part of the turret ammo code
 
 // conditional sexpressions
 #define OP_WHEN								(0x0000 | OP_CATEGORY_CONDITIONAL)
@@ -728,6 +730,8 @@ class waypoint_list;
 #define OP_PAUSE_SOUND_FROM_FILE			(0x0029 | OP_CATEGORY_CHANGE2 | OP_NONCAMPAIGN_FLAG)	// Goober5000
 #define OP_SCRIPT_EVAL_BLOCK				(0x002a | OP_CATEGORY_CHANGE2 | OP_NONCAMPAIGN_FLAG) // niffiwan
 #define OP_BEAM_FLOATING_FIRE				(0x002b | OP_CATEGORY_CHANGE2 | OP_NONCAMPAIGN_FLAG)	// MageKing17
+#define OP_TURRET_SET_PRIMARY_AMMO			(0x002c | OP_CATEGORY_CHANGE2 | OP_NONCAMPAIGN_FLAG)	// DahBlount, part of the turret ammo changes
+#define OP_TURRET_SET_SECONDARY_AMMO		(0x002d | OP_CATEGORY_CHANGE2 | OP_NONCAMPAIGN_FLAG)	// DahBlount, part of the turret ammo changes
 
 // defined for AI goals
 #define OP_AI_CHASE							(0x0000 | OP_CATEGORY_AI | OP_NONCAMPAIGN_FLAG)
@@ -1178,6 +1182,9 @@ bool has_special_explosion_block_index(ship *shipp, int *index);
 void set_primary_ammo (int ship_index, int requested_bank, int requested_ammo, int rearm_limit=-1, bool update=true);
 void set_secondary_ammo (int ship_index, int requested_bank, int requested_ammo, int rearm_limit=-1, bool update=true);
 
+// DahBlount - Similar to Karajorma's functions, but for turrets
+void set_turret_primary_ammo(ship_subsys *turret, int requested_bank, int requested_ammo, bool update = true);
+void set_turret_secondary_ammo(ship_subsys *turret, int requested_bank, int requested_ammo, bool update = true);
 
 // menu and category stuff
 extern int get_sexp_id(char *sexp_name);

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -257,7 +257,8 @@ flag_def_list Subsystem_flags[] = {
 	{ "only target if can fire",    MSS_FLAG2_TURRET_ONLY_TARGET_IF_CAN_FIRE, 1},
 	{ "no disappear",			MSS_FLAG2_NO_DISAPPEAR, 1},
 	{ "collide submodel",		MSS_FLAG2_COLLIDE_SUBMODEL, 1},
-	{ "allow destroyed rotation",	MSS_FLAG2_DESTROYED_ROTATION, 1}
+	{ "allow destroyed rotation",	MSS_FLAG2_DESTROYED_ROTATION, 1},
+	{ "turret use ammo",		MSS_FLAG2_TURRET_USE_AMMO, 1}
 };
 
 const int Num_subsystem_flags = sizeof(Subsystem_flags)/sizeof(flag_def_list);

--- a/code/weapon/swarm.cpp
+++ b/code/weapon/swarm.cpp
@@ -484,7 +484,6 @@ void turret_swarm_set_up_info(int parent_objnum, ship_subsys *turret, weapon_inf
 	// increment ship tsi counter
 	shipp->num_turret_swarm_info++;
 
-
     // *Unnecessary check, now done on startup   -Et1
     /*
 
@@ -494,12 +493,23 @@ void turret_swarm_set_up_info(int parent_objnum, ship_subsys *turret, weapon_inf
 #endif
 
     */
+
+	ship_weapon *swp = &turret->weapons;
+	int bank_fired = swp->current_secondary_bank;
+
 	// initialize tsi
 	tsi->weapon_class = WEAPON_INFO_INDEX(wip);
-	if (wip->wi_flags & WIF_SWARM)
+	if (wip->wi_flags & WIF_SWARM) {
 		tsi->num_to_launch = wip->swarm_count;
-	else
+		if (turret->system_info->flags2 & MSS_FLAG2_TURRET_USE_AMMO) {
+			swp->secondary_bank_ammo[bank_fired] -= wip->swarm_count;
+		}
+	} else {
 		tsi->num_to_launch = wip->cs_num_fired;
+		if (turret->system_info->flags2 & MSS_FLAG2_TURRET_USE_AMMO) {
+			swp->secondary_bank_ammo[bank_fired] -= wip->cs_num_fired;
+		}
+	}
 	tsi->parent_objnum = parent_objnum;
 	tsi->parent_sig    = parent_obj->signature;
 	tsi->target_objnum = turret->turret_enemy_objnum;


### PR DESCRIPTION
This creates the foundation of turret ammo through the "turret use ammo" subsystem flag. Turret ammo works in the same manner as ship ammo, where the ammo is equal to bank capacity divided by the cargo size of the weapon. This was tested using the Blue Planet: War in Heaven mod.
Test case: UEFg Narayana turrets 19 through 21, all of which contain Apocalypse torpedos with a $Cargo Size: of 2.5, were changed to use ammo with a $SBank Capacity of 20, resulting in a total ammo capacity of 8 torpedos. The Narayana was ordered to attack a GTCv Diomedes; it fired 8 torpedos each from turrets 19 through 21 before stopping. The mission was left to proceed for an additional 2 minutes, in which time the Narayana did not fire any more torpedos. Note: The Apocalypse takes 20 seconds to fire each 4 torpedo burst.
Conclusion: Success