### PR TITLE
Log OpenAL info for selected device.

### DIFF
--- a/code/sound/ds.cpp
+++ b/code/sound/ds.cpp
@@ -1106,6 +1106,13 @@ int ds_init()
 
 	alcMakeContextCurrent(ds_sound_context);
 
+	alcGetError(ds_sound_device);
+
+	mprintf(("  OpenAL Vendor     : %s\n", alGetString(AL_VENDOR)));
+	mprintf(("  OpenAL Renderer   : %s\n", alGetString(AL_RENDERER)));
+	mprintf(("  OpenAL Version    : %s\n", alGetString(AL_VERSION)));
+	mprintf(("\n"));
+
 	// we need to clear out all errors before moving on
 	alcGetError(NULL);
 	alGetError();

--- a/code/sound/openal.cpp
+++ b/code/sound/openal.cpp
@@ -381,11 +381,6 @@ bool openal_init_device(SCP_string *playback, SCP_string *capture)
 
 	alcGetError(device);
 
-	mprintf(( "  OpenAL Vendor     : %s\n", alGetString( AL_VENDOR ) ));
-	mprintf(( "  OpenAL Renderer   : %s\n", alGetString( AL_RENDERER ) ));
-	mprintf(( "  OpenAL Version    : %s\n", alGetString( AL_VERSION ) ));
-	mprintf(( "\n" ));
-
 	// close default device
 	alcMakeContextCurrent(NULL);
 	alcDestroyContext(context);


### PR DESCRIPTION
Fix the issue pointed out by Yarn where the OpenAL info for the default
device was being logged instead of the info for the selected
device. http://www.hard-light.net/forums/index.php?topic=90070.0.