### PR TITLE
Resolve numerous format string issues

### DIFF
--- a/code/asteroid/asteroid.cpp
+++ b/code/asteroid/asteroid.cpp
@@ -1955,7 +1955,7 @@ void asteroid_parse_tbl()
 				SCP_string msg("Ignoring extra asteroid/debris '");
 				msg.append(new_asteroid.name);
 				msg.append("'\n");
-				Warning(LOCATION, msg.c_str());
+				Warning(LOCATION, "%s", msg.c_str());
 				parsed_asteroids.push_back(msg);
 #endif
 			}

--- a/code/asteroid/asteroid.cpp
+++ b/code/asteroid/asteroid.cpp
@@ -2002,7 +2002,7 @@ void asteroid_parse_tbl()
 				iter != parsed_asteroids.end(); ++iter)
 			{
 				mprintf(("Asteroid.tbl as parsed:\n"));
-				mprintf((iter->c_str()));
+				mprintf(("%s", iter->c_str()));
 			}
 #endif
 			Error(LOCATION,

--- a/code/lab/wmcgui.cpp
+++ b/code/lab/wmcgui.cpp
@@ -168,7 +168,7 @@ void GUISystem::ParseClassInfo(char* filename)
 	}
 	catch (const parse::ParseException& e)
 	{
-		mprintf(("WMCGUI: Unable to parse '%s'!  Error code = %s.\n", filename, e.what()));
+		mprintf(("WMCGUI: Unable to parse '%s'!  Error message = %s.\n", filename, e.what()));
 		return;
 	}
 }

--- a/code/mission/missionbriefcommon.cpp
+++ b/code/mission/missionbriefcommon.cpp
@@ -340,7 +340,7 @@ void brief_parse_icon_tbl()
 				errormsg += "\n";
 			}
 
-			Error(LOCATION, errormsg.c_str());
+			Error(LOCATION, "%s", errormsg.c_str());
 		}
 	}
 	catch (const parse::ParseException& e)

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -5705,11 +5705,11 @@ void post_process_mission()
 				sprintf(error_msg, "%s.\n\nIn sexpression: %s\n(Error appears to be: %s)", sexp_error_message(result), sexp_str.c_str(), Sexp_nodes[bad_node].text);
 
 				if (!Fred_running) {
-					nprintf(("Error", error_msg.c_str()));
-					Error(LOCATION, error_msg.c_str());
+					nprintf(("Error", "%s", error_msg.c_str()));
+					Error(LOCATION, "%s", error_msg.c_str());
 				} else {
-					nprintf(("Warning", error_msg.c_str()));
-					Warning(LOCATION, error_msg.c_str());
+					nprintf(("Warning", "%s", error_msg.c_str()));
+					Warning(LOCATION, "%s", error_msg.c_str());
 				}
 			}
 		}

--- a/code/model/modelread.cpp
+++ b/code/model/modelread.cpp
@@ -5655,7 +5655,7 @@ void parse_glowpoint_table(const char *filename)
 		}
 		required_string("#End");
 	} catch (const parse::ParseException& e) {
-		mprintf(("Unable to parse '%s'!  Error code = %d.\n", filename, e.what()));
+		mprintf(("Unable to parse '%s'!  Error code = %s.\n", filename, e.what()));
 		return;
 	}
 }

--- a/code/model/modelread.cpp
+++ b/code/model/modelread.cpp
@@ -5655,7 +5655,7 @@ void parse_glowpoint_table(const char *filename)
 		}
 		required_string("#End");
 	} catch (const parse::ParseException& e) {
-		mprintf(("Unable to parse '%s'!  Error code = %s.\n", filename, e.what()));
+		mprintf(("Unable to parse '%s'!  Error message = %s.\n", filename, e.what()));
 		return;
 	}
 }

--- a/code/network/multi_ingame.cpp
+++ b/code/network/multi_ingame.cpp
@@ -1027,7 +1027,7 @@ void process_ingame_ships_packet( ubyte *data, header *hinfo )
 		}
 		if(p_objp == NULL){
 			Int3();
-			nprintf(("Network", "Couldn't find ship %s in either arrival list or in mission"));
+			nprintf(("Network", "Couldn't find ship %s in either arrival list or in mission", ship_name));
 			multi_quit_game(PROMPT_NONE, MULTI_END_NOTIFY_NONE, MULTI_END_ERROR_INGAME_BOGUS);
 			return;
 		}

--- a/code/network/multi_sexp.cpp
+++ b/code/network/multi_sexp.cpp
@@ -819,6 +819,6 @@ bool multi_get_ushort(ushort &value)
 void multi_discard_remaining_callback_data()
 {
 	if (!multi_sexp_discard_operator()) {
-		Warning(LOCATION, "Attempt to discard remaining data failed! Callback for operator lacks proper termination. Entire packet may be corrupt. Discarding remaining packet");
+		Warning(LOCATION, "Attempt to discard remaining data failed! Callback lacks proper termination. Entire packet may be corrupt. Discarding remaining packet");
 	}
 }

--- a/code/network/multi_sexp.cpp
+++ b/code/network/multi_sexp.cpp
@@ -819,6 +819,6 @@ bool multi_get_ushort(ushort &value)
 void multi_discard_remaining_callback_data()
 {
 	if (!multi_sexp_discard_operator()) {
-		Warning(LOCATION, "Attempt to discard remaining data failed! Callback for operator %d lacks proper termination. Entire packet may be corrupt. Discarding remaining packet"); 
+		Warning(LOCATION, "Attempt to discard remaining data failed! Callback for operator lacks proper termination. Entire packet may be corrupt. Discarding remaining packet");
 	}
 }

--- a/code/network/multimsgs.cpp
+++ b/code/network/multimsgs.cpp
@@ -2751,7 +2751,7 @@ void process_wing_create_packet( ubyte *data, header *hinfo )
 
 	// do a sanity check on the wing to be sure that we are actually working on a valid wing
 	if ( (index < 0) || (index >= Num_wings) || (Wings[index].num_waves == -1) ) {
-		nprintf(("Network", "invalid index %d for wing create packet\n"));
+		nprintf(("Network", "Invalid index %d for wing create packet\n", index));
 		return;
 	}
 	if ( (num_to_create <= 0) || (num_to_create > Wings[index].wave_count) ) {

--- a/code/object/collideshipship.cpp
+++ b/code/object/collideshipship.cpp
@@ -1360,7 +1360,7 @@ void collect_ship_ship_physics_info(object *heavier_obj, object *lighter_obj, mc
 	float dot = vm_vec_dotprod( r_light, &ship_ship_hit_info->collision_normal );
 	if ( dot > 0 )
 	{
-		nprintf(("Physics", "Framecount: %i r dot normal  > 0\n", Framecount, dot));
+		nprintf(("Physics", "Framecount: %i r dot normal %f > 0\n", Framecount, dot));
 	}
 
 	vm_vec_zero(heavy_collide_cm_pos);

--- a/code/object/waypoint.cpp
+++ b/code/object/waypoint.cpp
@@ -375,7 +375,7 @@ void waypoint_add_list(const char *name, SCP_vector<vec3d> &vec_list)
 
 	if (find_matching_waypoint_list(name) != NULL)
 	{
-		Warning(LOCATION, "Waypoint list '%s' already exists in this mission!  Not adding the new list...");
+		Warning(LOCATION, "Waypoint list '%s' already exists in this mission!  Not adding the new list...", name);
 		return;
 	}
 

--- a/code/parse/scripting.cpp
+++ b/code/parse/scripting.cpp
@@ -701,7 +701,7 @@ void script_state::SetHookVar(char *name, char format, void *data)
 		}
 		else
 		{
-			LuaError(LuaState, "Could not get HookVariable library to set hook variable '%s' - get a coder", name);
+			LuaError(LuaState, "Could not get HookVariable library to set hook variable '%s'", name);
 			if(data_ldx)
 				lua_pop(LuaState, 1);
 		}
@@ -739,7 +739,7 @@ bool script_state::GetHookVar(char *name, char format, void *data)
 		}
 		else
 		{
-			LuaError(LuaState, "Could not get HookVariable library to get hook variable '%' - get a coder", name);
+			LuaError(LuaState, "Could not get HookVariable library to get hook variable '%s'", name);
 		}
 	}
 

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -7603,7 +7603,7 @@ int sexp_percent_ships_arrive_depart_destroy_disarm_disable(int n, int what)
 				if ( mission_log_get_time(LOG_SHIP_ARRIVED, name, NULL, NULL) )
 					count++;
 			} else
-				Error("Invalid status check '%d' for ship '%s' in sexp_percent_ships_depart_destroy_disarm_disable", what, name);
+				Error(LOCATION, "Invalid status check '%d' for ship '%s' in sexp_percent_ships_depart_destroy_disarm_disable", what, name);
 
 		}
 	}

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -4587,7 +4587,7 @@ int sexp_number_compare(int n, int op)
 				break;
 
 			default:
-				Warning(LOCATION, "Unhandled comparison case!  Operator = ", op);
+				Warning(LOCATION, "Unhandled comparison case!  Operator = %d", op);
 				break;
 		}
 	}

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -20531,10 +20531,10 @@ void sexp_debug(int node)
 
 	//send the message
 	#ifndef NDEBUG
-		Warning(LOCATION, temp_buf);
+		Warning(LOCATION, "%s", temp_buf);
     #else	
 	if (!no_release_message) {	
-		Warning(LOCATION, temp_buf);
+		Warning(LOCATION, "%s", temp_buf);
 	}
 	#endif
 }

--- a/code/pilotfile/csg_convert.cpp
+++ b/code/pilotfile/csg_convert.cpp
@@ -1187,7 +1187,7 @@ bool pilotfile_convert::csg_convert(const char *fname, bool inferno)
 	cfp = cfopen(const_cast<char*>(filename.c_str()), "rb", CFILE_NORMAL);
 
 	if ( !cfp ) {
-		mprintf(("    CS2 => Unable to open for import!\n", fname));
+		mprintf(("    CS2 => Unable to open '%s' for import!\n", fname));
 		delete csg;
 		csg = NULL;
 
@@ -1217,7 +1217,7 @@ bool pilotfile_convert::csg_convert(const char *fname, bool inferno)
 	cfp = cfopen(const_cast<char*>(filename.c_str()), "wb", CFILE_NORMAL, CF_TYPE_PLAYERS);
 
 	if ( !cfp ) {
-		mprintf(("    CSG => Unable to open for export!\n", fname));
+		mprintf(("    CSG => Unable to open '%s' for export!\n", fname));
 		return false;
 	}
 

--- a/code/pilotfile/plr_convert.cpp
+++ b/code/pilotfile/plr_convert.cpp
@@ -875,7 +875,7 @@ bool pilotfile_convert::plr_convert(const char *fname, bool inferno)
 	cfp = cfopen(const_cast<char*>(filename.c_str()), "rb", CFILE_NORMAL);
 
 	if ( !cfp ) {
-		mprintf(("  PL2 => Unable to open for import!\n", fname));
+		mprintf(("  PL2 => Unable to open '%s' for import!\n", fname));
 		return false;
 	}
 
@@ -899,7 +899,7 @@ bool pilotfile_convert::plr_convert(const char *fname, bool inferno)
 	cfp = cfopen(const_cast<char*>(filename.c_str()), "wb", CFILE_NORMAL, CF_TYPE_PLAYERS);
 
 	if ( !cfp ) {
-		mprintf(("  PLR => Unable to open for export!\n", fname));
+		mprintf(("  PLR => Unable to open '%s' for export!\n", fname));
 		return false;
 	}
 

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -5176,7 +5176,7 @@ void ship_set(int ship_index, int objnum, int ship_type)
 		if (Fred_running) 
 			MessageBox(NULL, err_msg, "Error", MB_OK);
 		else
-			Error(LOCATION, err_msg);
+			Error(LOCATION, "%s", err_msg);
 	}
 
 	ets_init_ship(objp);	// init ship fields that are used for the ETS

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -2429,7 +2429,7 @@ int parse_ship_values(ship_info* sip, bool first_time, bool replace)
 		stuff_float(&sip->max_hull_strength);
 		if (sip->max_hull_strength < 0.0f)
 		{
-			Warning(LOCATION, "Max hull strength on ship %s cannot be less than 0.  Defaulting to 100.\n", sip->name, sip->max_hull_strength);
+			Warning(LOCATION, "Max hull strength on ship %s cannot be less than 0.  Defaulting to 100.\n", sip->name);
 			sip->max_hull_strength = 100.0f;
 		}
 	}


### PR DESCRIPTION
Resolves a number of format string-related warnings reported by GCC 4.9, now properly exposed.

Some locations miss variables, some locations have too many variables. Some locations lack format string specifiers.