### PR TITLE
Hopefully fix FRED and turret ammo.

### DIFF
--- a/code/fred2/weaponeditordlg.cpp
+++ b/code/fred2/weaponeditordlg.cpp
@@ -87,7 +87,11 @@ void WeaponEditorDlg::DoDataExchange(CDataExchange* pDX)
 	if (pDX->m_bSaveAndValidate) {
 		GetDlgItem(IDC_AMMO1)->GetWindowText(str);
 		if (save_number((char *) (LPCSTR) str, &m_ammo1)) {
-			m_ammo_max1 = (m_missile1 <= 0) ? 0 : get_max_ammo_count_for_bank(m_ship_class, 0, m_missile1 + First_secondary_index - 1);
+			if (m_missile1 <= 0) {
+				m_ammo_max1 = 0;
+			} else {
+				m_ammo_max1 = (m_cur_item == 0) ? get_max_ammo_count_for_bank(m_ship_class, 0, m_missile1 + First_secondary_index - 1) : get_max_ammo_count_for_turret_bank(cur_weapon, 0, m_missile1 + First_secondary_index - 1);
+			}
 			if (m_ammo1 < 0)
 				m_ammo1 = 0;
 			if (m_ammo1 > m_ammo_max1)
@@ -96,7 +100,11 @@ void WeaponEditorDlg::DoDataExchange(CDataExchange* pDX)
 
 		GetDlgItem(IDC_AMMO2)->GetWindowText(str);
 		if (save_number((char *) (LPCSTR) str, &m_ammo2)) {
-			m_ammo_max2 = (m_missile2 <= 0) ? 0 : get_max_ammo_count_for_bank(m_ship_class, 1, m_missile2 + First_secondary_index - 1);
+			if (m_missile2 <= 0) {
+				m_ammo_max2 = 0;
+			} else {
+				m_ammo_max2 = (m_cur_item == 0) ? get_max_ammo_count_for_bank(m_ship_class, 1, m_missile2 + First_secondary_index - 1) : get_max_ammo_count_for_turret_bank(cur_weapon, 1, m_missile2 + First_secondary_index - 1);
+			}
 			if (m_ammo2 < 0)
 				m_ammo2 = 0;
 			if (m_ammo2 > m_ammo_max2)
@@ -105,7 +113,11 @@ void WeaponEditorDlg::DoDataExchange(CDataExchange* pDX)
 
 		GetDlgItem(IDC_AMMO3)->GetWindowText(str);
 		if (save_number((char *) (LPCSTR) str, &m_ammo3)) {
-			m_ammo_max3 = (m_missile3 <= 0) ? 0 : get_max_ammo_count_for_bank(m_ship_class, 2, m_missile3 + First_secondary_index - 1);
+			if (m_missile3 <= 0) {
+				m_ammo_max3 = 0;
+			} else {
+				m_ammo_max3 = (m_cur_item == 0) ? get_max_ammo_count_for_bank(m_ship_class, 2, m_missile3 + First_secondary_index - 1) : get_max_ammo_count_for_turret_bank(cur_weapon, 2, m_missile3 + First_secondary_index - 1);
+			}
 			if (m_ammo3 < 0)
 				m_ammo3 = 0;
 			if (m_ammo3 > m_ammo_max3)
@@ -114,7 +126,11 @@ void WeaponEditorDlg::DoDataExchange(CDataExchange* pDX)
 
 		GetDlgItem(IDC_AMMO4)->GetWindowText(str);
 		if (save_number((char *) (LPCSTR) str, &m_ammo4)) {
-			m_ammo_max4 = (m_missile4 <= 0) ? 0 : get_max_ammo_count_for_bank(m_ship_class, 3, m_missile4 + First_secondary_index - 1);
+			if (m_missile4 <= 0) {
+				m_ammo_max4 = 0;
+			} else {
+				m_ammo_max4 = (m_cur_item == 0) ? get_max_ammo_count_for_bank(m_ship_class, 3, m_missile4 + First_secondary_index - 1) : get_max_ammo_count_for_turret_bank(cur_weapon, 3, m_missile4 + First_secondary_index - 1);
+			}
 			if (m_ammo4 < 0)
 				m_ammo4 = 0;
 			if (m_ammo4 > m_ammo_max4)
@@ -403,7 +419,11 @@ void WeaponEditorDlg::change_selection()
 	if (cur_weapon->num_secondary_banks > 0) {
 		m_missile1 = cur_weapon->secondary_bank_weapons[0] + 1;
 		if (m_missile1 > 0) {
-			m_ammo_max1 = get_max_ammo_count_for_bank(m_ship_class, 0, m_missile1 - 1);
+			if (m_cur_item == 0) {
+				m_ammo_max1 = get_max_ammo_count_for_bank(m_ship_class, 0, m_missile1 - 1);
+			} else {
+				m_ammo_max1 = get_max_ammo_count_for_turret_bank(cur_weapon, 0, m_missile1 - 1);
+			}
 			if (cur_weapon->secondary_bank_ammo[0] != BLANK_FIELD)
 				m_ammo1 = cur_weapon->secondary_bank_ammo[0] * m_ammo_max1 / 100;
 			m_missile1 -= First_secondary_index;
@@ -422,7 +442,11 @@ void WeaponEditorDlg::change_selection()
 	if (cur_weapon->num_secondary_banks > 1) {
 		m_missile2 = cur_weapon->secondary_bank_weapons[1] + 1;
 		if (m_missile2 > 0) {
-			m_ammo_max2 = get_max_ammo_count_for_bank(m_ship_class, 1, m_missile2 - 1);
+			if (m_cur_item == 0) {
+				m_ammo_max2 = get_max_ammo_count_for_bank(m_ship_class, 1, m_missile2 - 1);
+			} else {
+				m_ammo_max2 = get_max_ammo_count_for_turret_bank(cur_weapon, 1, m_missile2 - 1);
+			}
 			if (cur_weapon->secondary_bank_ammo[1] != BLANK_FIELD)
 				m_ammo2 = cur_weapon->secondary_bank_ammo[1] * m_ammo_max2 / 100;
 			m_missile2 -= First_secondary_index;
@@ -441,7 +465,11 @@ void WeaponEditorDlg::change_selection()
 	if (cur_weapon->num_secondary_banks > 2) {
 		m_missile3 = cur_weapon->secondary_bank_weapons[2] + 1;
 		if (m_missile3 > 0) {
-			m_ammo_max3 = get_max_ammo_count_for_bank(m_ship_class, 2, m_missile3 - 1);
+			if (m_cur_item == 0) {
+				m_ammo_max3 = get_max_ammo_count_for_bank(m_ship_class, 2, m_missile3 - 1);
+			} else {
+				m_ammo_max3 = get_max_ammo_count_for_turret_bank(cur_weapon, 2, m_missile2 - 1);
+			}
 			if (cur_weapon->secondary_bank_ammo[2] != BLANK_FIELD)
 				m_ammo3 = cur_weapon->secondary_bank_ammo[2] * m_ammo_max3 / 100;
 			m_missile3 -= First_secondary_index;
@@ -460,7 +488,11 @@ void WeaponEditorDlg::change_selection()
 	if (cur_weapon->num_secondary_banks > 3) {
 		m_missile4 = cur_weapon->secondary_bank_weapons[3] + 1;
 		if (m_missile4 > 0) {
-			m_ammo_max4 = get_max_ammo_count_for_bank(m_ship_class, 3, m_missile4 - 1);
+			if (m_cur_item == 0) {
+				m_ammo_max4 = get_max_ammo_count_for_bank(m_ship_class, 3, m_missile4 - 1);
+			} else {
+				m_ammo_max4 = get_max_ammo_count_for_turret_bank(cur_weapon, 3, m_missile4 - 1);
+			}
 			if (cur_weapon->secondary_bank_ammo[3] != BLANK_FIELD)
 				m_ammo4 = cur_weapon->secondary_bank_ammo[3] * m_ammo_max4 / 100;
 			m_missile4 -= First_secondary_index;
@@ -553,7 +585,11 @@ void WeaponEditorDlg::OnSelchangeMissile1()
 {
 	UpdateData(TRUE);
 	UpdateData(TRUE);
-	m_ammo_max1 = get_max_ammo_count_for_bank(m_ship_class, 0, m_missile1 + First_secondary_index - 1);
+	if (m_cur_item == 0) {
+		m_ammo_max1 = get_max_ammo_count_for_bank(m_ship_class, 0, m_missile1 + First_secondary_index - 1);
+	} else {
+		m_ammo_max1 = get_max_ammo_count_for_turret_bank(cur_weapon, 0, m_missile1 + First_secondary_index - 1);
+	}
 	m_ammo1 = m_ammo_max1 ? (m_ammo_max1) : 0;
 	change_selection();
 }
@@ -562,7 +598,11 @@ void WeaponEditorDlg::OnSelchangeMissile2()
 {
 	UpdateData(TRUE);
 	UpdateData(TRUE);
-	m_ammo_max2 = get_max_ammo_count_for_bank(m_ship_class, 0, m_missile2 + First_secondary_index - 1);
+	if (m_cur_item == 0) {
+		m_ammo_max2 = get_max_ammo_count_for_bank(m_ship_class, 1, m_missile2 + First_secondary_index - 1);
+	} else {
+		m_ammo_max2 = get_max_ammo_count_for_turret_bank(cur_weapon, 1, m_missile2 + First_secondary_index - 1);
+	}
 	m_ammo2 = m_ammo_max2 ? (m_ammo_max2) : 0;
 	change_selection();
 }
@@ -571,7 +611,11 @@ void WeaponEditorDlg::OnSelchangeMissile3()
 {
 	UpdateData(TRUE);
 	UpdateData(TRUE);
-	m_ammo_max3 = get_max_ammo_count_for_bank(m_ship_class, 0, m_missile3 + First_secondary_index - 1);
+	if (m_cur_item == 0) {
+		m_ammo_max3 = get_max_ammo_count_for_bank(m_ship_class, 2, m_missile3 + First_secondary_index - 1);
+	} else {
+		m_ammo_max3 = get_max_ammo_count_for_turret_bank(cur_weapon, 2, m_missile3 + First_secondary_index - 1);
+	}
 	m_ammo3 = m_ammo_max3 ? (m_ammo_max3) : 0;
 	change_selection();
 }
@@ -580,7 +624,11 @@ void WeaponEditorDlg::OnSelchangeMissile4()
 {
 	UpdateData(TRUE);
 	UpdateData(TRUE);
-	m_ammo_max4 = get_max_ammo_count_for_bank(m_ship_class, 0, m_missile4 + First_secondary_index - 1);
+	if (m_cur_item == 0) {
+		m_ammo_max4 = get_max_ammo_count_for_bank(m_ship_class, 3, m_missile4 + First_secondary_index - 1);
+	} else {
+		m_ammo_max4 = get_max_ammo_count_for_turret_bank(cur_weapon, 3, m_missile4 + First_secondary_index - 1);
+	}
 	m_ammo4 = m_ammo_max4 ? (m_ammo_max4) : 0;
 	change_selection();
 }

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -2210,12 +2210,28 @@ int parse_create_object_sub(p_object *p_objp)
 
 				// Goober5000
 				for (j = 0; j < MAX_SHIP_PRIMARY_BANKS; j++)
-					ptr->weapons.primary_bank_ammo[j] = sssp->primary_ammo[j];
+				{
+					if (Fred_running) {
+						ptr->weapons.primary_bank_ammo[j] = sssp->primary_ammo[j];
+					} else {
+						Assert(Weapon_info[ptr->weapons.primary_bank_weapons[j]].cargo_size > 0.0f);
 
-				// AL 3-5-98:  This is correct for FRED, but not for FreeSpace... but is this even used?
-				//					As far as I know, turrets cannot run out of ammo
+						int capacity = fl2i(sssp->primary_ammo[j]/100.0f * ptr->weapons.primary_bank_capacity[j] + 0.5f);
+						ptr->weapons.primary_bank_ammo[j] = fl2i(capacity / Weapon_info[ptr->weapons.primary_bank_weapons[j]].cargo_size + 0.5f);
+					}
+				}
+
 				for (j = 0; j < MAX_SHIP_SECONDARY_BANKS; j++)
-					ptr->weapons.secondary_bank_ammo[j] = sssp->secondary_ammo[j];
+				{
+					if (Fred_running) {
+						ptr->weapons.secondary_bank_ammo[j] = sssp->secondary_ammo[j];
+					} else {
+						Assert(Weapon_info[ptr->weapons.secondary_bank_weapons[j]].cargo_size > 0.0f);
+
+						int capacity = fl2i(sssp->secondary_ammo[j]/100.0f * ptr->weapons.secondary_bank_capacity[j] + 0.5f);
+						ptr->weapons.secondary_bank_ammo[j] = fl2i(capacity / Weapon_info[ptr->weapons.secondary_bank_weapons[j]].cargo_size + 0.5f);
+					}
+				}
 
 				ptr->subsys_cargo_name = sssp->subsys_cargo_name;
 

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -5710,7 +5710,7 @@ int subsys_set(int objnum, int ignore_subsys_info)
 
 		for (k=0; k<MAX_SHIP_SECONDARY_BANKS; k++) {
 			float weapon_size = Weapon_info[ship_system->weapons.secondary_bank_weapons[k]].cargo_size;
-			Assertion( weapon_size > 0.0f, "Cargo size for secondary weapon %s is invalid, must be greater than 0.\n", Weapon_info[sip->secondary_bank_weapons[i]].name );
+			Assertion( weapon_size > 0.0f, "Cargo size for secondary weapon %s is invalid, must be greater than 0.\n", Weapon_info[ship_system->weapons.secondary_bank_weapons[i]].name );
 			ship_system->weapons.secondary_bank_ammo[k] = (Fred_running ? 100 : ship_system->weapons.secondary_bank_capacity[k] / weapon_size + 0.5f);
 
 			ship_system->weapons.secondary_next_slot[k] = 0;
@@ -5720,7 +5720,7 @@ int subsys_set(int objnum, int ignore_subsys_info)
 		for (k=0; k<MAX_SHIP_PRIMARY_BANKS; k++)
 		{
 			float weapon_size = Weapon_info[ship_system->weapons.primary_bank_weapons[k]].cargo_size;
-			Assertion( weapon_size > 0.0f, "Cargo size for secondary weapon %s is invalid, must be greater than 0.\n", Weapon_info[sip->secondary_bank_weapons[i]].name );
+			Assertion( weapon_size > 0.0f, "Cargo size for secondary weapon %s is invalid, must be greater than 0.\n", Weapon_info[ship_system->weapons.primary_bank_weapons[i]].name );
 			ship_system->weapons.primary_bank_ammo[k] = (Fred_running ? 100 : ship_system->weapons.primary_bank_capacity[k] / weapon_size + 0.5f);
 		}
 

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -5709,7 +5709,7 @@ int subsys_set(int objnum, int ignore_subsys_info)
 
 
 		for (k=0; k<MAX_SHIP_SECONDARY_BANKS; k++) {
-			float weapon_size = Weapon_info[ship_system->weapons.secondary_bank_weapons[i]].cargo_size;
+			float weapon_size = Weapon_info[ship_system->weapons.secondary_bank_weapons[k]].cargo_size;
 			Assertion( weapon_size > 0.0f, "Cargo size for secondary weapon %s is invalid, must be greater than 0.\n", Weapon_info[sip->secondary_bank_weapons[i]].name );
 			ship_system->weapons.secondary_bank_ammo[k] = (Fred_running ? 100 : ship_system->weapons.secondary_bank_capacity[k] / weapon_size + 0.5f);
 
@@ -5719,7 +5719,7 @@ int subsys_set(int objnum, int ignore_subsys_info)
 		// Goober5000
 		for (k=0; k<MAX_SHIP_PRIMARY_BANKS; k++)
 		{
-			float weapon_size = Weapon_info[ship_system->weapons.primary_bank_weapons[i]].cargo_size;
+			float weapon_size = Weapon_info[ship_system->weapons.primary_bank_weapons[k]].cargo_size;
 			Assertion( weapon_size > 0.0f, "Cargo size for secondary weapon %s is invalid, must be greater than 0.\n", Weapon_info[sip->secondary_bank_weapons[i]].name );
 			ship_system->weapons.primary_bank_ammo[k] = (Fred_running ? 100 : ship_system->weapons.primary_bank_capacity[k] / weapon_size + 0.5f);
 		}

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -5710,7 +5710,7 @@ int subsys_set(int objnum, int ignore_subsys_info)
 
 		for (k=0; k<MAX_SHIP_SECONDARY_BANKS; k++) {
 			float weapon_size = Weapon_info[ship_system->weapons.secondary_bank_weapons[k]].cargo_size;
-			Assertion( weapon_size > 0.0f, "Cargo size for secondary weapon %s is invalid, must be greater than 0.\n", Weapon_info[ship_system->weapons.secondary_bank_weapons[i]].name );
+			Assertion( weapon_size > 0.0f, "Cargo size for secondary weapon %s is invalid, must be greater than 0.\n", Weapon_info[ship_system->weapons.secondary_bank_weapons[k]].name );
 			ship_system->weapons.secondary_bank_ammo[k] = (Fred_running ? 100 : ship_system->weapons.secondary_bank_capacity[k] / weapon_size + 0.5f);
 
 			ship_system->weapons.secondary_next_slot[k] = 0;
@@ -5720,7 +5720,7 @@ int subsys_set(int objnum, int ignore_subsys_info)
 		for (k=0; k<MAX_SHIP_PRIMARY_BANKS; k++)
 		{
 			float weapon_size = Weapon_info[ship_system->weapons.primary_bank_weapons[k]].cargo_size;
-			Assertion( weapon_size > 0.0f, "Cargo size for secondary weapon %s is invalid, must be greater than 0.\n", Weapon_info[ship_system->weapons.primary_bank_weapons[i]].name );
+			Assertion( weapon_size > 0.0f, "Cargo size for secondary weapon %s is invalid, must be greater than 0.\n", Weapon_info[ship_system->weapons.primary_bank_weapons[k]].name );
 			ship_system->weapons.primary_bank_ammo[k] = (Fred_running ? 100 : ship_system->weapons.primary_bank_capacity[k] / weapon_size + 0.5f);
 		}
 

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -15594,13 +15594,36 @@ int get_max_ammo_count_for_bank(int ship_class, int bank, int ammo_type)
 {
 	float capacity, size;
 
+	Assertion(ship_class < Num_ship_classes, "Invalid ship_class of %d is >= Num_ship_classes (%d); get a coder!\n", ship_class, Num_ship_classes);
+	Assertion(bank < MAX_SHIP_SECONDARY_BANKS, "Invalid secondary bank of %d (max is %d); get a coder!\n", bank, MAX_SHIP_SECONDARY_BANKS - 1);
+	Assertion(ammo_type < Num_weapon_types, "Invalid ammo_type of %d is >= Num_weapon_types (%d); get a coder!\n", ammo_type, Num_weapon_types);
+
 	if (ship_class < 0 || bank < 0 || ammo_type < 0) {
 		return 0;
 	} else {
-	capacity = (float) Ship_info[ship_class].secondary_bank_ammo_capacity[bank];
-	size = (float) Weapon_info[ammo_type].cargo_size;
-	return (int) (capacity / size);
+		capacity = (float) Ship_info[ship_class].secondary_bank_ammo_capacity[bank];
+		size = (float) Weapon_info[ammo_type].cargo_size;
+		return (int) (capacity / size);
+	}
 }
+
+/**
+ * The same as above, but for a specific turret's bank.
+ */
+int get_max_ammo_count_for_turret_bank(ship_weapon *swp, int bank, int ammo_type)
+{
+	float capacity, size;
+
+	Assertion(bank < MAX_SHIP_SECONDARY_BANKS, "Invalid secondary bank of %d (max is %d); get a coder!\n", bank, MAX_SHIP_SECONDARY_BANKS - 1);
+	Assertion(ammo_type < Num_weapon_types, "Invalid ammo_type of %d is >= Num_weapon_types (%d); get a coder!\n", ammo_type, Num_weapon_types);
+
+	if (!swp || bank < 0 || ammo_type < 0) {
+		return 0;
+	} else {
+		capacity = (float) swp->secondary_bank_capacity[bank];
+		size = (float) Weapon_info[ammo_type].cargo_size;
+		return (int) (capacity / size);
+	}
 }
 
 /**

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -5709,7 +5709,9 @@ int subsys_set(int objnum, int ignore_subsys_info)
 
 
 		for (k=0; k<MAX_SHIP_SECONDARY_BANKS; k++) {
-			ship_system->weapons.secondary_bank_ammo[k] = (Fred_running ? 100 : ship_system->weapons.secondary_bank_capacity[k]);
+			float weapon_size = Weapon_info[ship_system->weapons.secondary_bank_weapons[i]].cargo_size;
+			Assertion( weapon_size > 0.0f, "Cargo size for secondary weapon %s is invalid, must be greater than 0.\n", Weapon_info[sip->secondary_bank_weapons[i]].name );
+			ship_system->weapons.secondary_bank_ammo[k] = (Fred_running ? 100 : ship_system->weapons.secondary_bank_capacity[k] / weapon_size + 0.5f);
 
 			ship_system->weapons.secondary_next_slot[k] = 0;
 		}
@@ -5717,7 +5719,9 @@ int subsys_set(int objnum, int ignore_subsys_info)
 		// Goober5000
 		for (k=0; k<MAX_SHIP_PRIMARY_BANKS; k++)
 		{
-			ship_system->weapons.primary_bank_ammo[k] = (Fred_running ? 100 : ship_system->weapons.primary_bank_capacity[k]);
+			float weapon_size = Weapon_info[ship_system->weapons.primary_bank_weapons[i]].cargo_size;
+			Assertion( weapon_size > 0.0f, "Cargo size for secondary weapon %s is invalid, must be greater than 0.\n", Weapon_info[sip->secondary_bank_weapons[i]].name );
+			ship_system->weapons.primary_bank_ammo[k] = (Fred_running ? 100 : ship_system->weapons.primary_bank_capacity[k] / weapon_size + 0.5f);
 		}
 
 		ship_system->weapons.last_fired_weapon_index = -1;

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -1827,6 +1827,7 @@ int primary_out_of_ammo(ship_weapon *swp, int bank);
 int get_max_ammo_count_for_primary_bank(int ship_class, int bank, int ammo_type);
 
 int get_max_ammo_count_for_bank(int ship_class, int bank, int ammo_type);
+int get_max_ammo_count_for_turret_bank(ship_weapon *swp, int bank, int ammo_type);
 
 int is_support_allowed(object *objp, bool do_simple_check = false);
 


### PR DESCRIPTION
Adds a get_max_ammo_count_for_turret_bank() function that the weapon editor can use for turrets instead of trying to hack the behavior into get_max_ammo_count_for_bank somehow. Adjusts weaponeditordlg.cpp to use it, and also fixes missionparse.cpp so that ammo values get correctly converted from a percentage to the number of actual missiles (but only when FRED isn't running).