### PR TITLE
Actually fix the `cargo_size` check for turrets.

### DIFF
--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -2209,7 +2209,7 @@ int parse_create_object_sub(p_object *p_objp)
 						ptr->weapons.secondary_bank_weapons[j] = sssp->secondary_banks[j];
 
 				// Goober5000
-				for (j = 0; j < MAX_SHIP_PRIMARY_BANKS; j++)
+				for (j = 0; j < ptr->weapons.num_primary_banks; j++)
 				{
 					if (Fred_running) {
 						ptr->weapons.primary_bank_ammo[j] = sssp->primary_ammo[j];
@@ -2221,7 +2221,7 @@ int parse_create_object_sub(p_object *p_objp)
 					}
 				}
 
-				for (j = 0; j < MAX_SHIP_SECONDARY_BANKS; j++)
+				for (j = 0; j < ptr->weapons.num_secondary_banks; j++)
 				{
 					if (Fred_running) {
 						ptr->weapons.secondary_bank_ammo[j] = sssp->secondary_ammo[j];

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -2213,7 +2213,7 @@ int parse_create_object_sub(p_object *p_objp)
 				{
 					if (Fred_running) {
 						ptr->weapons.primary_bank_ammo[j] = sssp->primary_ammo[j];
-					} else {
+					} else if (Weapon_info[ptr->weapons.primary_bank_weapons[j]].wi_flags2 & WIF2_BALLISTIC) {
 						Assert(Weapon_info[ptr->weapons.primary_bank_weapons[j]].cargo_size > 0.0f);
 
 						int capacity = fl2i(sssp->primary_ammo[j]/100.0f * ptr->weapons.primary_bank_capacity[j] + 0.5f);

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -5708,21 +5708,21 @@ int subsys_set(int objnum, int ignore_subsys_info)
 		}
 
 
-		for (k=0; k<MAX_SHIP_SECONDARY_BANKS; k++) {
+		for (k=0; k<ship_system->weapons.num_secondary_banks; k++) {
 			float weapon_size = Weapon_info[ship_system->weapons.secondary_bank_weapons[k]].cargo_size;
 			Assertion( weapon_size > 0.0f, "Cargo size for secondary weapon %s is invalid, must be greater than 0.\n", Weapon_info[ship_system->weapons.secondary_bank_weapons[k]].name );
-			ship_system->weapons.secondary_bank_ammo[k] = (Fred_running ? 100 : ship_system->weapons.secondary_bank_capacity[k] / weapon_size + 0.5f);
+			ship_system->weapons.secondary_bank_ammo[k] = (Fred_running ? 100 : fl2i(ship_system->weapons.secondary_bank_capacity[k] / weapon_size + 0.5f));
 
 			ship_system->weapons.secondary_next_slot[k] = 0;
 		}
 
 		// Goober5000
-		for (k=0; k<MAX_SHIP_PRIMARY_BANKS; k++)
+		for (k=0; k<ship_system->weapons.num_primary_banks; k++)
 		{
 			float weapon_size = Weapon_info[ship_system->weapons.primary_bank_weapons[k]].cargo_size;
 
 			if (weapon_size > 0.0f) {	// Non-ballistic primaries are supposed to have a cargo_size of 0
-				ship_system->weapons.primary_bank_ammo[k] = (Fred_running ? 100 : ship_system->weapons.primary_bank_capacity[k] / weapon_size + 0.5f);
+				ship_system->weapons.primary_bank_ammo[k] = (Fred_running ? 100 : fl2i(ship_system->weapons.primary_bank_capacity[k] / weapon_size + 0.5f));
 			}
 		}
 


### PR DESCRIPTION
So it turns out it actually was the secondary code triggering the Assertion, because `ship_system->weapons.secondary_bank_weapons[]` was full of 0s. Subach HL-7 is weapon type 0, and obviously doesn't have a `cargo_size`. I see no reason to iterate through `MAX_SHIP_PRIMARY_BANKS`/`MAX_SHIP_SECONDARY_BANKS` if there aren't that many banks being used anyway.