### PR TITLE
Fix writing to undefined memory in multiplayer SEXP code for turret a…

### DIFF
--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -18082,7 +18082,7 @@ void sexp_set_turret_primary_ammo(int node)
 void multi_sexp_set_turret_primary_ammo()
 {
 	int sindex, requested_bank, requested_weapons;
-	char *subsys;
+	char subsys[TOKEN_LENGTH];
 	multi_get_int(sindex);
 	multi_get_string(subsys);
 	multi_get_int(requested_bank);
@@ -18221,7 +18221,7 @@ void sexp_set_turret_secondary_ammo(int node)
 void multi_sexp_set_turret_secondary_ammo()
 {
 	int sindex, requested_bank, requested_weapons;
-	char *subsys;
+	char subsys[TOKEN_LENGTH];
 	multi_get_int(sindex);
 	multi_get_string(subsys);
 	multi_get_int(requested_bank);


### PR DESCRIPTION
…mmo.

`multi_sexp_set_turret_primary_ammo()` and `multi_sexp_set_turret_secondary_ammo()` were using an uninitialized pointer instead of an uninitialized array, like every other instance of `multi_get_string()`. This is just begging to write to invalid memory.