### PR TITLE
Fix remaining gcc/clang warnings

### DIFF
--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -14107,7 +14107,7 @@ void ai_frame(int objnum)
 	}
 
 	if ((En_objp != NULL) && (En_objp->pos.xyz.x == Pl_objp->pos.xyz.x) && (En_objp->pos.xyz.y == Pl_objp->pos.xyz.y) && (En_objp->pos.xyz.z == Pl_objp->pos.xyz.z)) {
-		mprintf(("Warning: Object and its enemy have same position.  Object #%i\n", OBJ_INDEX(Pl_objp)));
+		mprintf(("Warning: Object and its enemy have same position.  Object #" PTRDIFF_T_ARG "\n", OBJ_INDEX(Pl_objp)));
 		En_objp = NULL;
 	}
 

--- a/code/asteroid/asteroid.cpp
+++ b/code/asteroid/asteroid.cpp
@@ -2008,7 +2008,7 @@ void asteroid_parse_tbl()
 			Error(LOCATION,
 				"Found %d asteroids/debris when %d expected\n\n"
 				"<Number expected> = <Number of species> * %d + %d generic asteroids\n"
-				"%d = %d*%d + %d\n\n"
+				"%d = " SIZE_T_ARG "*%d + %d\n\n"
 #ifdef NDEBUG
 				"Run a debug build to see a list of all parsed asteroids\n",
 #else

--- a/code/bmpman/bmpman.cpp
+++ b/code/bmpman/bmpman.cpp
@@ -806,8 +806,8 @@ bool bm_has_alpha_channel(int handle) {
 void bm_init() {
 	int i;
 
-	mprintf(("Size of bitmap info = %d KB\n", sizeof(bm_bitmaps) / 1024));
-	mprintf(("Size of bitmap extra info = %d bytes\n", sizeof(bm_extra_info)));
+	mprintf(("Size of bitmap info = "SIZE_T_ARG" KB\n", sizeof(bm_bitmaps) / 1024));
+	mprintf(("Size of bitmap extra info = "SIZE_T_ARG" bytes\n", sizeof(bm_extra_info)));
 
 	if (!bm_inited) {
 		bm_inited = 1;

--- a/code/bmpman/bmpman.cpp
+++ b/code/bmpman/bmpman.cpp
@@ -806,8 +806,8 @@ bool bm_has_alpha_channel(int handle) {
 void bm_init() {
 	int i;
 
-	mprintf(("Size of bitmap info = "SIZE_T_ARG" KB\n", sizeof(bm_bitmaps) / 1024));
-	mprintf(("Size of bitmap extra info = "SIZE_T_ARG" bytes\n", sizeof(bm_extra_info)));
+	mprintf(("Size of bitmap info = " SIZE_T_ARG " KB\n", sizeof(bm_bitmaps) / 1024));
+	mprintf(("Size of bitmap extra info = " SIZE_T_ARG " bytes\n", sizeof(bm_extra_info)));
 
 	if (!bm_inited) {
 		bm_inited = 1;

--- a/code/camera/camera.cpp
+++ b/code/camera/camera.cpp
@@ -80,7 +80,7 @@ void camera::reset()
 
 void camera::set_name(char *in_name)
 {
-	if(name != NULL)
+	if(in_name != NULL)
 		strncpy(name, in_name, NAME_LENGTH-1);
 }
 

--- a/code/controlconfig/controlsconfig.cpp
+++ b/code/controlconfig/controlsconfig.cpp
@@ -393,22 +393,7 @@ int control_config_detect_axis()
 
 void control_config_conflict_check()
 {
-	int i, j, shift = -1, alt = -1;
-
-	for (i=0; i<CCFG_MAX; i++) {
-		Conflicts[i].key = Conflicts[i].joy = -1;
-		switch (Control_config[i].key_id) {
-			case KEY_LSHIFT:
-			case KEY_RSHIFT:
-				shift = i;
-				break;
-
-			case KEY_LALT:
-			case KEY_RALT:
-				alt = i;
-				break;
-		}
-	}
+	int i, j;
 
 	for (i=0; i<NUM_TABS; i++) {
 		Conflicts_tabs[i] = 0;
@@ -468,15 +453,12 @@ void control_config_conflict_check()
 // do list setup required prior to rendering and checking for the controls listing.  Called when list changes
 void control_config_list_prepare()
 {
-	int j, k, y, z;
+	int j, y, z;
 	int font_height = gr_get_font_height();
 
 	Num_cc_lines = y = z = 0;
 	while (z < CCFG_MAX) {
 		if (Control_config[z].tab == Tab && !Control_config[z].disabled) {
-			k = Control_config[z].key_id;
-			j = Control_config[z].joy_id;
-
 			if (Control_config[z].hasXSTR) {
 				Cc_lines[Num_cc_lines].label = XSTR(Control_config[z].text, CONTROL_CONFIG_XSTR + z);
 			} else {

--- a/code/controlconfig/controlsconfig.cpp
+++ b/code/controlconfig/controlsconfig.cpp
@@ -394,6 +394,10 @@ int control_config_detect_axis()
 void control_config_conflict_check()
 {
 	int i, j;
+	
+	for (i=0; i<CCFG_MAX; i++) {
+		Conflicts[i].key = Conflicts[i].joy = -1;
+	}
 
 	for (i=0; i<NUM_TABS; i++) {
 		Conflicts_tabs[i] = 0;

--- a/code/cutscene/decoder16.cpp
+++ b/code/cutscene/decoder16.cpp
@@ -15,7 +15,7 @@ static void genLoopkupTable();
 
 void decodeFrame16(ubyte *pFrame, ubyte *pMap, int mapRemain, unsigned char *pData, int dataRemain)
 {
-	ubyte *pOrig, *pOffData, *pEnd, op;
+	ubyte *pOrig, *pOffData, op;
 	ushort offset;
 	int length = 0, i, j, xb, yb;
 
@@ -32,7 +32,6 @@ void decodeFrame16(ubyte *pFrame, ubyte *pMap, int mapRemain, unsigned char *pDa
 	offset = pData[0]|(pData[1]<<8);
 
 	pOffData = pData + offset;
-	pEnd = pData + offset;
 
 	pData += 2;
 
@@ -55,7 +54,8 @@ void decodeFrame16(ubyte *pFrame, ubyte *pMap, int mapRemain, unsigned char *pDa
 	}
 
 	if ((length-(pData-pOrig)) != 0) {
-		nprintf(("MVE", "DEBUG: junk left over: %d,%d,%d\n", (pData-pOrig), length, (length-(pData-pOrig))));
+		nprintf(("MVE", "DEBUG: junk left over: " PTRDIFF_T_ARG ",%d," PTRDIFF_T_ARG "\n",
+			(pData-pOrig), length, (length-(pData-pOrig))));
 	}
 }
 

--- a/code/cutscene/mveplayer.cpp
+++ b/code/cutscene/mveplayer.cpp
@@ -228,7 +228,7 @@ void mve_audio_createbuf(ubyte minor, ubyte *data)
 		return;
 	}
 
-	int flags, desired_buffer, sample_rate;
+	int flags, sample_rate;
 
 	mas = (mve_audio_t *) vm_malloc ( sizeof(mve_audio_t) );
 	memset(mas, 0, sizeof(mve_audio_t));
@@ -237,7 +237,6 @@ void mve_audio_createbuf(ubyte minor, ubyte *data)
 
 	flags = mve_get_ushort(data + 2);
 	sample_rate = mve_get_ushort(data + 4);
-	desired_buffer = mve_get_int(data + 6);
 
 	mas->channels = (flags & 0x0001) ? 2 : 1;
 	mas->bitsize = (flags & 0x0002) ? 16 : 8;
@@ -419,15 +418,9 @@ int mve_video_createbuf(ubyte minor, ubyte *data)
 	}
 
 	short w, h;
-	short count, truecolor;
+	short truecolor;
 	w = mve_get_short(data);
 	h = mve_get_short(data+2);
-
-	if (minor > 0) {
-		count = mve_get_short(data+4);
-	} else {
-		count = 1;
-	}
 
 	if (minor > 1) {
 		truecolor = mve_get_short(data+6);
@@ -725,18 +718,9 @@ void mve_video_codemap(ubyte *data, int len)
 
 void mve_video_data(ubyte *data, int len)
 {
-	short nFrameHot, nFrameCold;
-	short nXoffset, nYoffset;
-	short nXsize, nYsize;
 	ushort nFlags;
 	ubyte *temp;
 
-	nFrameHot = mve_get_short(data);
-	nFrameCold = mve_get_short(data+2);
-	nXoffset = mve_get_short(data+4);
-	nYoffset = mve_get_short(data+6);
-	nXsize = mve_get_short(data+8);
-	nYsize = mve_get_short(data+10);
 	nFlags = mve_get_ushort(data+12);
 
 	if (nFlags & 1) {

--- a/code/ddsutils/ddsutils.cpp
+++ b/code/ddsutils/ddsutils.cpp
@@ -36,7 +36,7 @@ int dds_read_header(const char *filename, CFILE *img_cfp, int *width, int *heigh
 	int retval = DDS_ERROR_NONE;
 	int ct = DDS_UNCOMPRESSED;
 	int bits = 0;
-	int i, trash, is_cubemap = 0;
+	int i, is_cubemap = 0;
 	int d_width = 0, d_height = 0, d_depth = 0, d_size = 0;
 
 
@@ -80,7 +80,7 @@ int dds_read_header(const char *filename, CFILE *img_cfp, int *width, int *heigh
 
 	// skip over the crap we don't care about
 	for (i = 0; i < 11; i++)
-		trash = cfread_uint(ddsfile);
+		cfread_uint(ddsfile);
 
 	dds_header.ddpfPixelFormat.dwSize				= cfread_uint(ddsfile);
 	dds_header.ddpfPixelFormat.dwFlags				= cfread_uint(ddsfile);

--- a/code/debugconsole/consoleparse.cpp
+++ b/code/debugconsole/consoleparse.cpp
@@ -1065,7 +1065,7 @@ void dc_stuff_float(float *f)
 	value_d = dc_parse_double(token.c_str(), DCT_FLOAT);	// Parse and convert
 	
 	// Stuff value if within bounds
-	if ((abs(value_d) < FLT_MAX) && (abs(value_d) > FLT_MIN)) {
+	if ((std::abs(value_d) < FLT_MAX) && (std::abs(value_d) > FLT_MIN)) {
 		*f = static_cast<float>(value_d);
 	} else {
 		throw errParse(token.c_str(), DCT_FLOAT);

--- a/code/fs2netd/tcp_client.cpp
+++ b/code/fs2netd/tcp_client.cpp
@@ -218,7 +218,8 @@ int FS2NetD_GetPlayerData(const char *player_name, player *pl, bool can_create, 
 		uint rc_total = 0;
 		ubyte reply_type = 0;
 		int si_index = 0;
-		ushort bogus, num_type_kills = 0, num_medals = 0;
+        ushort bogus __attribute__((unused));
+		ushort num_type_kills = 0, num_medals = 0;
 		char ship_name[NAME_LENGTH];
 		int idx;
 
@@ -488,8 +489,8 @@ int FS2NetD_Login(const char *username, const char *password, bool do_send)
 		int rc;
 		uint rc_total = 0;
 		ubyte login_status = 0;
-		int sid;
-		short pilots;
+		int sid __attribute__((unused));
+		short pilots __attribute__((unused));
 
 		do {
 			rc = FS2NetD_GetData(buffer+rc_total, sizeof(buffer)-rc_total);
@@ -832,4 +833,3 @@ void FS2NetD_CheckDuplicateLogin()
 
 	delete [] ids;
 }
-

--- a/code/fs2netd/tcp_client.cpp
+++ b/code/fs2netd/tcp_client.cpp
@@ -218,7 +218,7 @@ int FS2NetD_GetPlayerData(const char *player_name, player *pl, bool can_create, 
 		uint rc_total = 0;
 		ubyte reply_type = 0;
 		int si_index = 0;
-        ushort bogus __attribute__((unused));
+		ushort bogus __attribute__((unused));
 		ushort num_type_kills = 0, num_medals = 0;
 		char ship_name[NAME_LENGTH];
 		int idx;

--- a/code/gamesnd/gamesnd.cpp
+++ b/code/gamesnd/gamesnd.cpp
@@ -761,7 +761,7 @@ void parse_gamesnd_new(game_snd* gs, bool no_create)
 		int temp_limit;
 		stuff_int(&temp_limit);
 
-		if ((temp_limit > 0) && (temp_limit <= SND_ENHANCED_MAX_LIMIT))
+		if ((temp_limit > 0) && (static_cast<uint>(temp_limit) <= SND_ENHANCED_MAX_LIMIT))
 		{
 			gs->enhanced_sound_data.limit = (unsigned int)temp_limit;
 		}

--- a/code/gamesnd/gamesnd.cpp
+++ b/code/gamesnd/gamesnd.cpp
@@ -425,7 +425,8 @@ void parse_sound_core(const char* tag, int *idx_dest, const char* object_name, c
 	if((*idx_dest) < -1 || (*idx_dest) >= (int)size_to_check)
 	{
 		(*idx_dest) = -1;
-		Warning(LOCATION, "%s sound index out of range on '%s'. Must be between 0 and %d. Forcing to -1 (Nonexistent sound).\n", tag, object_name, size_to_check);
+		Warning(LOCATION, "%s sound index out of range on '%s'. Must be between 0 and " SIZE_T_ARG ". Forcing to -1 (Nonexistent sound).\n",
+			tag, object_name, size_to_check);
 	}
 }
 
@@ -494,7 +495,7 @@ void parse_sound_list(const char* tag, SCP_vector<int>& destination, const char*
 		//if we're using the old format, double check the size)
 		if(!(flags & PARSE_SOUND_SCP_SOUND_LIST) && (destination.size() != (unsigned)check))
 		{
-			mprintf(("%s in '%s' has %i entries. This does not match entered size of %i.", tag, object_name, destination.size(), check));
+			mprintf(("%s in '%s' has " SIZE_T_ARG " entries. This does not match entered size of %i.", tag, object_name, destination.size(), check));
 		}
 	}
 }

--- a/code/globalincs/pstypes.h
+++ b/code/globalincs/pstypes.h
@@ -711,6 +711,16 @@ public:
 #include "globalincs/vmallocator.h"
 #include "globalincs/safe_strings.h"
 
+// Macros for portable printf argument specification
+#ifdef _MSC_VER
+#define SIZE_T_ARG "%Iu"
+#define PTRDIFF_T_ARG "%Id"
+#else
+	// Asume C99 compatibility for everyone else
+#define SIZE_T_ARG "%zu"
+#define PTRDIFF_T_ARG "%zd"
+#endif
+
 // c++11 standard detection
 // for GCC with autotools, see AX_CXX_COMPILE_STDCXX_11 macro in configure.ac
 // this sets HAVE_CXX11 & -std=c++0x or -std=c++11 appropriately

--- a/code/globalincs/pstypes.h
+++ b/code/globalincs/pstypes.h
@@ -712,7 +712,21 @@ public:
 #include "globalincs/safe_strings.h"
 
 // Macros for portable printf argument specification
-#ifdef _MSC_VER
+#ifdef DOXYGEN
+// Special section for doxygen
+/**
+ * @brief Format specifier for a @c size_t argument
+ * Due to different runtimes using different format specifier for these types
+ * it's necessary to hide these changes behind a macro. Use this in place of %zu
+ */
+#define SIZE_T_ARG
+/**
+ * @brief Format specifier for a @c ptrdiff_t argument
+ * Due to different runtimes using different format specifier for these types
+ * it's necessary to hide these changes behind a macro. Use this in place of %zd
+ */
+#define PTRDIFF_T_ARG
+#elif defined(_MSC_VER)
 #define SIZE_T_ARG "%Iu"
 #define PTRDIFF_T_ARG "%Id"
 #else

--- a/code/globalincs/safe_strings.h
+++ b/code/globalincs/safe_strings.h
@@ -37,7 +37,7 @@ typedef int errno_t;
 #ifndef SAFESTRINGS_TEST_APP
 
 #	ifndef __safe_strings_error_handler
-#		define __safe_strings_error_handler( val ) Error(file, line,"%s: String error. Please Report.\nTrying to put into %d byte buffer:\n%s", #val, sizeInBytes,strSource)
+#		define __safe_strings_error_handler( val ) Error(file, line,"%s: String error. Please Report.\nTrying to put into " SIZE_T_ARG " byte buffer:\n%s", #val, sizeInBytes,strSource)
 #	endif
 
 #else

--- a/code/graphics/grbatch.cpp
+++ b/code/graphics/grbatch.cpp
@@ -631,7 +631,7 @@ void geometry_shader_batcher::draw_bitmap(vertex *position, int orient, float ra
 		vm_vec_scale_add(&PNT, &PNT, &fvec, depth);
 
 	particle_pnt new_particle;
-	vec3d up = {0.0f, 1.0f, 0.0f};
+	vec3d up = {{0.0f, 1.0f, 0.0f}};
 
 	new_particle.position = position->world;
 	new_particle.size = rad;

--- a/code/graphics/grbatch.cpp
+++ b/code/graphics/grbatch.cpp
@@ -631,7 +631,7 @@ void geometry_shader_batcher::draw_bitmap(vertex *position, int orient, float ra
 		vm_vec_scale_add(&PNT, &PNT, &fvec, depth);
 
 	particle_pnt new_particle;
-	vec3d up = {{0.0f, 1.0f, 0.0f}};
+	vec3d up = {{{0.0f, 1.0f, 0.0f}}};
 
 	new_particle.position = position->world;
 	new_particle.size = rad;

--- a/code/graphics/gropengltnl.cpp
+++ b/code/graphics/gropengltnl.cpp
@@ -2019,13 +2019,6 @@ void opengl_tnl_set_material(int flags, uint shader_flags, int tmap_type)
 			vm_vec_unrotate(&pos, &G3_user_clip_point, &Eye_matrix);
 			vm_vec_add2(&pos, &Eye_position);
 
-			vec4 clip_plane_equation;
-
-			clip_plane_equation.a1d[0] = normal.a1d[0];
-			clip_plane_equation.a1d[1] = normal.a1d[1];
-			clip_plane_equation.a1d[2] = normal.a1d[2];
-			clip_plane_equation.a1d[3] = vm_vec_mag(&pos);
-
 			matrix4 model_matrix;
 			memset( &model_matrix, 0, sizeof(model_matrix) );
 

--- a/code/graphics/grstub.cpp
+++ b/code/graphics/grstub.cpp
@@ -196,7 +196,6 @@ void gr_stub_free_screen(int id)
 
 void gr_stub_get_region(int front, int w, int h, ubyte *data)
 {
-	data = NULL;
 }
 
 void gr_stub_gradient(int x1,int y1,int x2,int y2, int resize_mode)

--- a/code/hud/hudshield.cpp
+++ b/code/hud/hudshield.cpp
@@ -562,8 +562,8 @@ void hud_shield_quadrant_hit(object *objp, int quadrant)
 		return;
 	}
 
-	Assertion(shi->shield_hit_timers.size() > 0, "Shield hit info object for object '%s' has a size %d shield_hit_timers; get a coder!\n", Ships[objp->instance].ship_name, shi->shield_hit_timers.size());
-	Assertion(shi->hull_hit_index < (int) shi->shield_hit_timers.size(), "Shield hit info object for object '%s' has a hull_hit_index of %d (should be between 0 and %d); get a coder!\n", Ships[objp->instance].ship_name, shi->hull_hit_index, shi->shield_hit_timers.size() - 1);
+	Assertion(shi->shield_hit_timers.size() > 0, "Shield hit info object for object '%s' has a size " SIZE_T_ARG " shield_hit_timers; get a coder!\n", Ships[objp->instance].ship_name, shi->shield_hit_timers.size());
+	Assertion(shi->hull_hit_index < (int) shi->shield_hit_timers.size(), "Shield hit info object for object '%s' has a hull_hit_index of %d (should be between 0 and " SIZE_T_ARG "); get a coder!\n", Ships[objp->instance].ship_name, shi->hull_hit_index, shi->shield_hit_timers.size() - 1);
 
 	if ( quadrant >= 0 ) {
 		if ( !(Ship_info[Ships[objp->instance].ship_info_index].flags2 & SIF2_MODEL_POINT_SHIELDS) )

--- a/code/io/keycontrol.cpp
+++ b/code/io/keycontrol.cpp
@@ -116,7 +116,7 @@ factor_table::~factor_table() {}
 
 size_t factor_table::getNext(size_t n, size_t current)
 {
-	Assertion(n >= 1, "factor_table::getNext() called with %d, when only natural numbers make sense; get a coder!\n", n);
+	Assertion(n >= 1, "factor_table::getNext() called with " SIZE_T_ARG ", when only natural numbers make sense; get a coder!\n", n);
 
 	// Resize lookup table if the value is greater than the current size
 	if (n > _lookup.size())

--- a/code/lab/wmcgui.h
+++ b/code/lab/wmcgui.h
@@ -130,7 +130,7 @@ public:
 
 	//--GET FUNCTIONS
 	int GetImageHandle(int ID=CIE_HANDLE_N){return Handles[ID].Image;}
-	ubyte GetColorHandle(int ColorID, int ID=CIE_HANDLE_N){if(this==NULL){return 0;}else{return Handles[ID].Colors[ColorID];}}
+	ubyte GetColorHandle(int ColorID, int ID=CIE_HANDLE_N){return Handles[ID].Colors[ColorID];}
 	//Copies the coordinates to the given location if coordinates are set.
 	int GetCoords(int *x, int *y);
 };

--- a/code/lighting/lighting.cpp
+++ b/code/lighting/lighting.cpp
@@ -252,8 +252,8 @@ void light_add_directional( vec3d *dir, float intensity, float r, float g, float
 
 void light_add_point( vec3d * pos, float r1, float r2, float intensity, float r, float g, float b, int light_ignore_objnum, float spec_r, float spec_g, float spec_b, bool specular  )
 {
-	Assertion( r1 > 0.0f, "Invalid radius r1 specified for light: %d. Radius must be > 0.0f. Examine stack trace to determine culprit.\n", r1 );
-	Assertion( r2 > 0.0f, "Invalid radius r2 specified for light: %d. Radius must be > 0.0f. Examine stack trace to determine culprit.\n", r2 );
+	Assertion( r1 > 0.0f, "Invalid radius r1 specified for light: %f. Radius must be > 0.0f. Examine stack trace to determine culprit.\n", r1 );
+	Assertion( r2 > 0.0f, "Invalid radius r2 specified for light: %f. Radius must be > 0.0f. Examine stack trace to determine culprit.\n", r2 );
 
 	if (r1 < 0.0001f || r2 < 0.0001f)
 		return;
@@ -1051,8 +1051,8 @@ void light_apply_rgb( ubyte *param_r, ubyte *param_g, ubyte *param_b, vec3d *pos
 
 void light_add_cone( vec3d * pos, vec3d * dir, float angle, float inner_angle, bool dual_cone, float r1, float r2, float intensity, float r, float g, float b, int light_ignore_objnum, float spec_r, float spec_g, float spec_b, bool specular )
 {
-	Assertion( r1 > 0.0f, "Invalid radius r1 specified for light: %d. Radius must be > 0.0f. Examine stack trace to determine culprit.\n", r1 );
-	Assertion( r2 > 0.0f, "Invalid radius r2 specified for light: %d. Radius must be > 0.0f. Examine stack trace to determine culprit.\n", r2 );
+	Assertion( r1 > 0.0f, "Invalid radius r1 specified for light: %f. Radius must be > 0.0f. Examine stack trace to determine culprit.\n", r1 );
+	Assertion( r2 > 0.0f, "Invalid radius r2 specified for light: %f. Radius must be > 0.0f. Examine stack trace to determine culprit.\n", r2 );
 
 	if (r1 < 0.0001f || r2 < 0.0001f)
 		return;

--- a/code/math/vecmat.cpp
+++ b/code/math/vecmat.cpp
@@ -1384,7 +1384,7 @@ float vm_vec_dot_to_point(const vec3d *dir, const vec3d *p1, const vec3d *p2)
 //	Result returned in q.
 void compute_point_on_plane(vec3d *q, const plane *planep, const vec3d *p)
 {
-	float	k, tv;
+	float	k;
 	vec3d	normal;
 
 	normal.xyz.x = planep->A;
@@ -1395,7 +1395,7 @@ void compute_point_on_plane(vec3d *q, const plane *planep, const vec3d *p)
 
 	vm_vec_scale_add(q, p, &normal, -k);
 
-	tv = planep->A * q->xyz.x + planep->B * q->xyz.y + planep->C * q->xyz.z + planep->D;
+	// tv = planep->A * q->xyz.x + planep->B * q->xyz.y + planep->C * q->xyz.z + planep->D;
 }
 
 
@@ -2599,4 +2599,3 @@ void vm_vec_boxscale(vec2d *vec, float scale)
 	vec->x *= ratio;
 	vec->y *= ratio;
 }
-

--- a/code/math/vecmat.cpp
+++ b/code/math/vecmat.cpp
@@ -1394,8 +1394,6 @@ void compute_point_on_plane(vec3d *q, const plane *planep, const vec3d *p)
 	k = (planep->D + vm_vec_dot(&normal, p)) / vm_vec_dot(&normal, &normal);
 
 	vm_vec_scale_add(q, p, &normal, -k);
-
-	// tv = planep->A * q->xyz.x + planep->B * q->xyz.y + planep->C * q->xyz.z + planep->D;
 }
 
 

--- a/code/menuui/credits.cpp
+++ b/code/menuui/credits.cpp
@@ -382,10 +382,10 @@ void credits_parse_table(const char* filename)
 				numLines = split_str(line.c_str(), Credits_text_coords[gr_screen.res][2], charNum, lines, -1);
 
 				// Make sure that we have valid data
-				Assertion(lines.size() == (size_t)numLines, "split_str reported %d lines but vector contains %d entries!", numLines, lines.size());
+				Assertion(lines.size() == (size_t)numLines, "split_str reported %d lines but vector contains " SIZE_T_ARG " entries!", numLines, lines.size());
 
 				Assertion(lines.size() <= charNum.size(),
-					"Something has gone wrong while splitting strings. Got %d lines but only %d chacter lengths.",
+					"Something has gone wrong while splitting strings. Got " SIZE_T_ARG " lines but only " SIZE_T_ARG " chacter lengths.",
 					lines.size(), charNum.size());
 
 				// Now add all splitted lines to the credit text and append a newline to the end

--- a/code/menuui/mainhallmenu.cpp
+++ b/code/menuui/mainhallmenu.cpp
@@ -2154,7 +2154,7 @@ void parse_main_hall_table(const char* filename)
 					if (temp_scp_string.size() > MAIN_HALL_MAX_CHEAT_LEN) {
 						// Since the value is longer than the cheat buffer it will never match.
 
-						Warning(LOCATION, "The value '%s' for '+Cheat String:' is too long! It can be at most %d characters long.", temp_scp_string.size(), MAIN_HALL_MAX_CHEAT_LEN);
+						Warning(LOCATION, "The value '%s' for '+Cheat String:' is too long! It can be at most %d characters long.", temp_scp_string.c_str(), MAIN_HALL_MAX_CHEAT_LEN);
 					}
 
 					required_string("+Anim To Change:");

--- a/code/mission/missionbriefcommon.cpp
+++ b/code/mission/missionbriefcommon.cpp
@@ -292,7 +292,7 @@ void brief_parse_icon_tbl()
 		while (required_string_either("#End", "$Name:"))
 		{
 			if (Briefing_icon_info.size() >= max_icons) {
-				Warning(LOCATION, "Too many icons in icons.tbl; only the first %d will be used", max_icons);
+				Warning(LOCATION, "Too many icons in icons.tbl; only the first " SIZE_T_ARG " will be used", max_icons);
 				skip_to_start_of_string("#End");
 				break;
 			}

--- a/code/mission/missionmessage.cpp
+++ b/code/mission/missionmessage.cpp
@@ -2032,16 +2032,16 @@ void message_send_builtin_to_player( int type, ship *shipp, int priority, int ti
 	}
 
 	if (best_match == BUILTIN_MATCHES_PERSONA_EXCLUDED) {
-		mprintf(("MESSAGING", "Couldn't find builtin message %s for persona %d with a none excluded mood\n", Builtin_messages[type].name, persona_index ));
-		mprintf(("MESSAGING", "using an excluded message for this persona\n"));
+		nprintf(("MESSAGING", "Couldn't find builtin message %s for persona %d with a none excluded mood\n", Builtin_messages[type].name, persona_index ));
+		nprintf(("MESSAGING", "using an excluded message for this persona\n"));
 	}else if (best_match == BUILTIN_MATCHES_SPECIES) {
-		mprintf(("MESSAGING", "Couldn't find builtin message %s for persona %d\n", Builtin_messages[type].name, persona_index ));
-		mprintf(("MESSAGING", "using a message for any persona of that species\n"));
+		nprintf(("MESSAGING", "Couldn't find builtin message %s for persona %d\n", Builtin_messages[type].name, persona_index ));
+		nprintf(("MESSAGING", "using a message for any persona of that species\n"));
 	} else if (best_match == BUILTIN_MATCHES_TYPE) {
-		mprintf(("MESSAGING", "Couldn't find builtin message %s for persona %d\n", Builtin_messages[type].name, persona_index ));
-		mprintf(("MESSAGING", "looking for message for any persona of any species\n"));
+		nprintf(("MESSAGING", "Couldn't find builtin message %s for persona %d\n", Builtin_messages[type].name, persona_index ));
+		nprintf(("MESSAGING", "looking for message for any persona of any species\n"));
 	} else if (best_match < 0) {
-		mprintf(("MESSAGING", "Couldn't find any builtin message of type %d\n", type ));
+		nprintf(("MESSAGING", "Couldn't find any builtin message of type %d\n", type ));
 		Int3();
 		return; 
 	}

--- a/code/missionui/missiondebrief.cpp
+++ b/code/missionui/missiondebrief.cpp
@@ -887,7 +887,7 @@ int debrief_find_persona_index()
 {
 	int i, j;
 
-	if ((Campaign.current_mission >= 0) && (Campaign.missions[Campaign.current_mission].name) && (Campaign.filename))
+	if ((Campaign.current_mission >= 0) && (Campaign.missions[Campaign.current_mission].name))
 	{
 		// Goober5000 - first see if the campaign supplied a persona index
 		// (0 means use the Volition default)

--- a/code/model/modelcollide.cpp
+++ b/code/model/modelcollide.cpp
@@ -1134,7 +1134,7 @@ void mc_check_subobj( int mn )
 				if (Mc->lod > 0 && sm->num_details > 0) {
 					bsp_info *lod_sm = sm;
 
-					for (int i = Mc->lod - 1; i >= 0; i--) {
+					for (i = Mc->lod - 1; i >= 0; i--) {
 						if (sm->details[i] != -1) {
 							lod_sm = &Mc_pm->submodel[sm->details[i]];
 

--- a/code/model/modelread.cpp
+++ b/code/model/modelread.cpp
@@ -5521,7 +5521,7 @@ void parse_glowpoint_table(const char *filename)
 					}
 					else
 					{
-						nprintf(("Model", "Glowpoint preset %s nebula texture num is %d\n", gpo, gpo.glow_neb_bitmap));
+						nprintf(("Model", "Glowpoint preset %s nebula texture num is %d\n", gpo.name, gpo.glow_neb_bitmap));
 					}
 				}
 				else {

--- a/code/model/modelread.cpp
+++ b/code/model/modelread.cpp
@@ -5598,7 +5598,7 @@ void parse_glowpoint_table(const char *filename)
 
 					if (optional_string("$Cone angle:")) {
 						stuff_float(&gpo.cone_angle);
-						gpo.cone_inner_angle = cos((gpo.cone_angle - (gpo.cone_angle < 20.0f) ? gpo.cone_angle*0.5f : 20.0f) / 180.0f * PI);
+						gpo.cone_inner_angle = cos((gpo.cone_angle - ((gpo.cone_angle < 20.0f) ? gpo.cone_angle*0.5f : 20.0f)) / 180.0f * PI);
 						gpo.cone_angle = cos(gpo.cone_angle / 180.0f * PI);
 					}
 

--- a/code/network/chat_api.cpp
+++ b/code/network/chat_api.cpp
@@ -654,7 +654,6 @@ char * ParseIRCMessage(char *Line, int iMode)
 
 	static char szResponse[MAXLOCALSTRING] = "";
 
-	int iNickLen;
 	int iPrefixLen = 0;	// JAS: Get rid of optimized warning
 
 	szRemLine[MAXLOCALSTRING-1] = '\0';
@@ -695,7 +694,6 @@ char * ParseIRCMessage(char *Line, int iMode)
 			strncpy(szNick,szPrefix,31);
          szNick[31]=0;
 		}
-		iNickLen=strlen(szNick);
 		iPrefixLen=strlen(szPrefix);
 	}
 	else if(iMode==MSG_LOCAL)
@@ -703,7 +701,6 @@ char * ParseIRCMessage(char *Line, int iMode)
 		strncpy(szRemLine, Line, sizeof(szRemLine)-1);
 		strncpy(szNick, Nick_name, sizeof(szNick)-1);
 		strncpy(szPrefix, Nick_name, sizeof(szPrefix)-1);
-		iNickLen=-2;
 		iPrefixLen=-2;
 	}
 	//Next is the command

--- a/code/network/multi_options.cpp
+++ b/code/network/multi_options.cpp
@@ -206,10 +206,10 @@ void multi_options_read_config()
 							mprintf(("ERROR: Invalid or out of range webapi_server_port '%s' specified in multi.cfg, must be integer between 1024 and %i.\n", tok, USHRT_MAX));
 						}
 						else if(result < 1024) {
-							mprintf(("ERROR: webapi_server_port '%d' in multi.cfg is too low, must be between 1024 and %d.\n", result, static_cast<int>(USHRT_MAX)));
+							mprintf(("ERROR: webapi_server_port '%ld' in multi.cfg is too low, must be between 1024 and %d.\n", result, USHRT_MAX));
 						}
 						else {
-							mprintf(("Using webapi_server_port '%d' from multi.cfg.\n", result));
+							mprintf(("Using webapi_server_port '%ld' from multi.cfg.\n", result));
 							Multi_options_g.webapiPort = (ushort) result;
 						}
 					}

--- a/code/network/multi_options.cpp
+++ b/code/network/multi_options.cpp
@@ -206,7 +206,7 @@ void multi_options_read_config()
 							mprintf(("ERROR: Invalid or out of range webapi_server_port '%s' specified in multi.cfg, must be integer between 1024 and %i.\n", tok, USHRT_MAX));
 						}
 						else if(result < 1024) {
-							mprintf(("ERROR: webapi_server_port '%d' in multi.cfg is too low, must be between 1024 and %i.\n", result, USHRT_MAX));
+							mprintf(("ERROR: webapi_server_port '%d' in multi.cfg is too low, must be between 1024 and %d.\n", result, static_cast<int>(USHRT_MAX)));
 						}
 						else {
 							mprintf(("Using webapi_server_port '%d' from multi.cfg.\n", result));

--- a/code/network/multiutil.cpp
+++ b/code/network/multiutil.cpp
@@ -2352,16 +2352,12 @@ void multi_file_xfer_notify(int handle)
 {
 	char *filename;
 	int len,idx;
-	int force_dir;
 	int cf_type;
 	int is_mission = 0;	
 
 	// get the filename of the file we are receiving
 	filename = NULL;
 	filename = multi_xfer_get_filename(handle);
-
-	// get the directory the file is forced into
-	force_dir = multi_xfer_get_force_dir(handle);
 		
 	// something is messed up
 	if(filename == NULL){

--- a/code/object/collideshipweapon.cpp
+++ b/code/object/collideshipweapon.cpp
@@ -451,7 +451,7 @@ int ship_weapon_check_collision(object *ship_objp, object *weapon_objp, float ti
 				if (!(shipp->flags2 & SF2_DONT_COLLIDE_INVIS)) {
 					wp->lifeleft = 0.001f;
 					if (ship_objp == Player_obj)
-						nprintf(("Jim", "Frame %i: Weapon %i set to detonate, dist = %7.3f.\n", Framecount, OBJ_INDEX(weapon_objp), dist));
+						nprintf(("Jim", "Frame %i: Weapon " PTRDIFF_T_ARG " set to detonate, dist = %7.3f.\n", Framecount, OBJ_INDEX(weapon_objp), dist));
 					valid_hit_occurred = 1;
 				}
 			}

--- a/code/object/object.cpp
+++ b/code/object/object.cpp
@@ -1546,7 +1546,7 @@ void obj_render_DEPRECATED(object *obj)
 		switch( obj->type )	{
 		case OBJ_NONE:
 			#ifndef NDEBUG
-			mprintf(( "ERROR!!!! Bogus obj %d is rendering!\n", obj-Objects ));
+			mprintf(( "ERROR!!!! Bogus obj " PTRDIFF_T_ARG " is rendering!\n", obj-Objects ));
 			Int3();
 			#endif
 			break;
@@ -1636,7 +1636,7 @@ void obj_queue_render(object* obj, draw_list* scene)
 	switch ( obj->type ) {
 	case OBJ_NONE:
 #ifndef NDEBUG
-		mprintf(( "ERROR!!!! Bogus obj %d is rendering!\n", obj-Objects ));
+		mprintf(( "ERROR!!!! Bogus obj " PTRDIFF_T_ARG " is rendering!\n", obj-Objects ));
 		Int3();
 #endif
 		break;

--- a/code/object/object.h
+++ b/code/object/object.h
@@ -182,7 +182,7 @@ struct object_h {
 	object *objp;
 	int sig;
 
-	bool IsValid(){return (this != NULL && objp != NULL && objp->signature == sig);}
+	bool IsValid(){return (objp != NULL && objp->signature == sig);}
 	object_h(object *in){objp=in; if(objp!=NULL){sig=in->signature;}}
 	object_h(){objp=NULL;sig=-1;}
 };

--- a/code/parse/lua.cpp
+++ b/code/parse/lua.cpp
@@ -16646,7 +16646,7 @@ int ade_table_entry::SetTable(lua_State *L, int p_amt_ldx, int p_mtb_ldx)
 		}
 		else
 		{
-			LuaError(L, "ade_table_entry::SetTable - Could not set data for '%s' (%d)", GetName(), ADE_INDEX(this));
+			LuaError(L, "ade_table_entry::SetTable - Could not set data for '%s' (" PTRDIFF_T_ARG ")", GetName(), ADE_INDEX(this));
 		}
 
 		if(data_ldx != INT_MAX)
@@ -16694,7 +16694,7 @@ int ade_table_entry::SetTable(lua_State *L, int p_amt_ldx, int p_mtb_ldx)
 					//so we can always find out what it is for debugging
 					lua_pushstring(L, GetName());
 					if(lua_setupvalue(L, data_ldx, 1) == NULL) {
-						LuaError(L, "ade_table_entry::SetTable - Could not set upvalue for '%s' (%d)", GetName(), ADE_INDEX(this));
+						LuaError(L, "ade_table_entry::SetTable - Could not set upvalue for '%s' (" PTRDIFF_T_ARG ")", GetName(), ADE_INDEX(this));
 					}
 				}
 
@@ -16714,7 +16714,7 @@ int ade_table_entry::SetTable(lua_State *L, int p_amt_ldx, int p_mtb_ldx)
 			}
 			else
 			{
-				LuaError(L, "ade_table_entry::SetTable - Could not instance '%s' (%d)", GetName(), ADE_INDEX(this));
+				LuaError(L, "ade_table_entry::SetTable - Could not instance '%s' (" PTRDIFF_T_ARG ")", GetName(), ADE_INDEX(this));
 			}
 		}
 	}

--- a/code/parse/lua.cpp
+++ b/code/parse/lua.cpp
@@ -882,7 +882,7 @@ struct enum_h {
 	enum_h(){index=-1; is_constant=false;}
 	enum_h(int n_index){index=n_index; is_constant=false;}
 
-	bool IsValid(){return (this != NULL && index > -1 && index < ENUM_NEXT_INDEX);}
+	bool IsValid(){return (index > -1 && index < ENUM_NEXT_INDEX);}
 };
 ade_obj<enum_h> l_Enum("enumeration", "Enumeration object");
 
@@ -1424,7 +1424,7 @@ public:
 	gameevent_h(){edx=-1;}
 	gameevent_h(int n_event){edx=n_event;}
 
-	bool IsValid(){return (this != NULL && edx > -1 && edx < Num_gs_event_text);}
+	bool IsValid(){return (edx > -1 && edx < Num_gs_event_text);}
 
 	int Get(){return edx;}
 };
@@ -1472,7 +1472,7 @@ public:
 	gamestate_h(){sdx=-1;}
 	gamestate_h(int n_state){sdx=n_state;}
 
-	bool IsValid(){return (this != NULL && sdx > -1 && sdx < Num_gs_state_text);}
+	bool IsValid(){return (sdx > -1 && sdx < Num_gs_state_text);}
 
 	int Get(){return sdx;}
 };
@@ -1638,7 +1638,7 @@ public:
 	}
 
 	bool IsValid(){
-		return (this != NULL && model != NULL && mid > -1 && model_get(mid) == model);
+		return (model != NULL && mid > -1 && model_get(mid) == model);
 	}
 
 	model_h(int n_modelnum) {
@@ -1715,7 +1715,7 @@ struct thrusterbank_h
 
 	bool isValid()
 	{
-		return this != NULL && bank != NULL;
+		return bank != NULL;
 	}
 };
 
@@ -1745,7 +1745,7 @@ struct glowpoint_h
 
 	bool isValid()
 	{
-		return (this != NULL && point != NULL);
+		return point != NULL;
 	}
 
 };
@@ -6323,7 +6323,7 @@ struct waypointlist_h
 		}
 	}
 	bool IsValid() {
-		return (this != NULL && wlp != NULL && !strcmp(wlp->get_name(), name));
+		return (wlp != NULL && !strcmp(wlp->get_name(), name));
 	}
 };
 
@@ -11730,7 +11730,7 @@ public:
 
 	bool isValid()
 	{
-		if (this != NULL && part != NULL && part->signature != 0 && part->signature == this->sig)
+		if (part != NULL && part->signature != 0 && part->signature == this->sig)
 			return true;
 		else
 			return false;

--- a/code/parse/parselo.cpp
+++ b/code/parse/parselo.cpp
@@ -937,7 +937,7 @@ void copy_text_until(char *outstr, char *instr, char *endstr, int max_chars)
 		outstr[foundstr - instr] = 0;
 
 	} else {
-		nprintf(("Error", "Error.  Too much text (%i chars, %i allowed) before %s\n",
+		nprintf(("Error", "Error.  Too much text (" SIZE_T_ARG " chars, %i allowed) before %s\n",
 			foundstr - instr - strlen(endstr), max_chars, endstr));
 
         throw parse::ParseException("Too much text found");
@@ -3808,7 +3808,7 @@ void vsprintf(SCP_string &dest, const char *format, va_list ap)
 			++p;
 			if (!*p || (buf_src_len >= MAX_BUF-1))
 			{
-				Warning(LOCATION, "Could not find a sprintf specifier within %d characters for format '%s', pos %d!", MAX_BUF-1, format, (p - format));
+				Warning(LOCATION, "Could not find a sprintf specifier within %d characters for format '%s', pos " SIZE_T_ARG "!", MAX_BUF-1, format, (p - format));
 
 				// unsafe to continue handling this va_list
 				dest += buf_src;

--- a/code/pilotfile/csg.cpp
+++ b/code/pilotfile/csg.cpp
@@ -1555,7 +1555,7 @@ bool pilotfile::save_savefile()
 	// assertion before writing so that we don't corrupt the .csg by asserting halfway through writing
 	// assertion should also prevent loss of major campaign progress
 	// i.e. lose one mission, not several missions worth (in theory)
-	Assertion(Red_alert_wingman_status.size() <= MAX_SHIPS, "Invalid number of Red_alert_wingman_status entries: %u\n", Red_alert_wingman_status.size());
+	Assertion(Red_alert_wingman_status.size() <= MAX_SHIPS, "Invalid number of Red_alert_wingman_status entries: " SIZE_T_ARG "\n", Red_alert_wingman_status.size());
 
 	// open it, hopefully...
 	cfp = cfopen((char*)filename.c_str(), "wb", CFILE_NORMAL, CF_TYPE_PLAYERS);

--- a/code/pilotfile/pilotfile.cpp
+++ b/code/pilotfile/pilotfile.cpp
@@ -280,7 +280,7 @@ void pilotfile::update_stats_backout(scoring_struct *stats, bool training)
 
 			for (idx = 0; idx < list_size; idx++) {
 				if ( p_stats->ship_kills[idx].name.compare(Ship_info[i].name) == 0 ) {
-					j = i;
+					j = idx;
 					break;
 				}
 			}
@@ -288,7 +288,7 @@ void pilotfile::update_stats_backout(scoring_struct *stats, bool training)
 			if (j >= 0) {
 				p_stats->ship_kills[j].val -= stats->m_okKills[i];
 			} else {
-				Assertion(false, "Ship kills of '%s' not found, should have been added by pilotfile::update_stats.", stats->m_okKills[i]);
+				Assertion(false, "Ship kills of '%s' not found, should have been added by pilotfile::update_stats.", Ship_info[i].name);
 			}
 		}
 	}

--- a/code/pilotfile/plr.cpp
+++ b/code/pilotfile/plr.cpp
@@ -909,7 +909,7 @@ bool pilotfile::load_player(const char *callsign, player *_p)
 
 		if (offset_pos) {
 			cfseek(cfp, offset_pos, CF_SEEK_CUR);
-			mprintf(("PLR => WARNING: Advancing to the next section. %i bytes were skipped!\n", offset_pos));
+			mprintf(("PLR => WARNING: Advancing to the next section. " SIZE_T_ARG " bytes were skipped!\n", offset_pos));
 		}
 	}
 
@@ -1121,4 +1121,3 @@ bool pilotfile::verify(const char *fname, int *rank, char *valid_language)
 
 	return true;
 }
-

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -17646,7 +17646,8 @@ void ArmorType::ParseData()
 		{
 			if(adt.Calculations.size() != adt.Arguments.size())
 			{
-				Warning(LOCATION, "Armor '%s', damage type %d: Armor has a different number of calculation types than arguments (%d, %d)", Name, DamageTypes.size(), adt.Calculations.size(), adt.Arguments.size());
+				Warning(LOCATION, "Armor '%s', damage type " SIZE_T_ARG ": Armor has a different number of calculation types than arguments (" SIZE_T_ARG ", " SIZE_T_ARG ")",
+						Name, DamageTypes.size(), adt.Calculations.size(), adt.Arguments.size());
 			}
 			DamageTypes.push_back(adt);
 		}

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -3110,7 +3110,7 @@ int parse_ship_values(ship_info* sip, bool first_time, bool replace)
 			SCP_string name, banks;
 			size_t seppos;
 			seppos = token->find_first_of(':');
-			if(seppos == -1) {
+			if(seppos == SCP_string::npos) {
 				Warning(LOCATION, "Couldn't find ':' seperator in Glowpoint override for ship %s ignoring token", sip->name);
 				continue;
 			}
@@ -3135,7 +3135,7 @@ int parse_ship_values(ship_info* sip, bool first_time, bool replace)
 				
 				size_t fromtopos;
 				fromtopos = banktoken.find_first_of('-');
-				if(fromtopos != -1) {
+				if(fromtopos != SCP_string::npos) {
 					SCP_string from, to;
 					int ifrom, ito;
 					from = banktoken.substr(0, fromtopos);

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -14388,7 +14388,8 @@ float ship_quadrant_shield_strength(object *hit_objp, vec3d *hitpos)
 	}
 
 	if(hit_objp->shield_quadrant[quadrant_num] > max_quadrant)
-		mprintf((LOCATION, "Warning: \"%s\" has shield quadrant strength of %f out of %f\n", Ships[hit_objp->instance].ship_name, hit_objp->shield_quadrant[quadrant_num], max_quadrant));
+		mprintf(("Warning: \"%s\" has shield quadrant strength of %f out of %f\n",
+				Ships[hit_objp->instance].ship_name, hit_objp->shield_quadrant[quadrant_num], max_quadrant));
 
 	return hit_objp->shield_quadrant[quadrant_num]/max_quadrant;
 }

--- a/code/sound/ds.cpp
+++ b/code/sound/ds.cpp
@@ -1012,7 +1012,7 @@ void ds_init_channels()
 	try {
 		Channels = new channel[MAX_CHANNELS];
 	} catch (std::bad_alloc) {
-		Error(LOCATION, "Unable to allocate %d bytes for %d audio channels.", sizeof(channel) * MAX_CHANNELS, MAX_CHANNELS);
+		Error(LOCATION, "Unable to allocate " SIZE_T_ARG " bytes for %d audio channels.", sizeof(channel) * MAX_CHANNELS, MAX_CHANNELS);
 	}
 }
 
@@ -2639,4 +2639,3 @@ int ds_get_sound_id(int channel_id)
 
 	return Channels[channel_id].snd_id;
 }
-

--- a/code/species_defs/species_defs.cpp
+++ b/code/species_defs/species_defs.cpp
@@ -326,7 +326,7 @@ void parse_species_tbl(const char *filename)
 					species->awacs_multiplier = 1.0f;
 
 				// let them know
-				Warning(LOCATION, "$AwacsMultiplier not specified for species %s in species_defs.tbl!  Defaulting to %.2d.\n", species->species_name, species->awacs_multiplier);
+				Warning(LOCATION, "$AwacsMultiplier not specified for species %s in species_defs.tbl!  Defaulting to %.2f.\n", species->species_name, species->awacs_multiplier);
 			}
 
 			// Goober5000 - countermeasure type

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -1528,7 +1528,7 @@ int parse_weapon(int subtype, bool replace, const char *filename)
 			Warning(LOCATION, "Lifetime max for weapon '%s' cannot be less than 0. Setting to 0.\n", wip->name);
 		} else if (wip->life_max < wip->life_min) {
 			wip->life_max = wip->life_min + 0.1f;
-			Warning(LOCATION, "Lifetime max for weapon '%s' cannot be less than its Lifetime Min (%d) value. Setting to %d.\n", wip->name, wip->life_min, wip->life_max);
+			Warning(LOCATION, "Lifetime max for weapon '%s' cannot be less than its Lifetime Min (%f) value. Setting to %f.\n", wip->name, wip->life_min, wip->life_max);
 		} else {
 			wip->lifetime = (wip->life_min+wip->life_max)*0.5f;
 		}
@@ -1537,7 +1537,7 @@ int parse_weapon(int subtype, bool replace, const char *filename)
 	if(wip->life_min >= 0.0f && wip->life_max < 0.0f) {
 		wip->lifetime = wip->life_min;
 		wip->life_min = -1.0f;
-		Warning(LOCATION, "Lifetime min, but not lifetime max, specified for weapon %s. Assuming static lifetime of %.2f seconds.\n", wip->lifetime);
+		Warning(LOCATION, "Lifetime min, but not lifetime max, specified for weapon %s. Assuming static lifetime of %.2f seconds.\n", wip->name, wip->lifetime);
 	}
 
 	if(optional_string("$Lifetime:")) {
@@ -2809,7 +2809,7 @@ int parse_weapon(int subtype, bool replace, const char *filename)
 				size_t current_size = wip->num_substitution_patterns;
 				size_t desired_size = current_size*period;
 				if (desired_size > MAX_SUBSTITUTION_PATTERNS) {
-					Warning(LOCATION, "The period is too large for the number of substitution patterns!  desired size=%d, max size=%d", desired_size, MAX_SUBSTITUTION_PATTERNS);
+					Warning(LOCATION, "The period is too large for the number of substitution patterns!  desired size=" SIZE_T_ARG ", max size=%d", desired_size, MAX_SUBSTITUTION_PATTERNS);
 				}
 				else {
 					wip->num_substitution_patterns = desired_size;
@@ -7422,7 +7422,7 @@ void validate_SSM_entries()
 		wip = &Weapon_info[wi];
 		nprintf(("parse", "Starting validation of '%s' [wip->name is '%s'], currently has an SSM_index of %d.\n", it->c_str(), wip->name, wip->SSM_index));
 		if (wip->SSM_index < -1 || wip->SSM_index >= static_cast<int>(Ssm_info.size())) {
-			Warning(LOCATION, "Invalid SSM index '%d' (should be 0-%d) in specification for %s (%s:line %d).\n", wip->SSM_index, Ssm_info.size() - 1, it->c_str(), dat->filename.c_str(), dat->linenum);
+			Warning(LOCATION, "Invalid SSM index '%d' (should be 0-" SIZE_T_ARG ") in specification for %s (%s:line %d).\n", wip->SSM_index, Ssm_info.size() - 1, it->c_str(), dat->filename.c_str(), dat->linenum);
 			wip->SSM_index = -1;
 		}
 		nprintf(("parse", "Validation complete, SSM-index is %d.\n", wip->SSM_index));

--- a/code/windows_stub/stubs.cpp
+++ b/code/windows_stub/stubs.cpp
@@ -174,7 +174,7 @@ void WarningEx( char *filename, int line, const char *format, ... )
 		va_start(args, format);
 		vsprintf(msg, format, args);
 		va_end(args);
-		Warning(filename, line, msg);
+		Warning(filename, line, "%s", msg);
 	}
 #endif
 }

--- a/configure.ac
+++ b/configure.ac
@@ -234,7 +234,10 @@ if test "$fs2_debug" = "yes" ; then
 else
 	AC_DEFINE([NDEBUG])
 	D_CFLAGS="$D_CFLAGS -O2 -Wall -funroll-loops"
-	D_CFLAGS="$D_CLFAGS -Wno-unused-function -Wno-unused-but-set-variable -Wno-write-strings -Wno-unused-variable"
+	D_CFLAGS="$D_CLFAGS -Wno-unused-function -Wno-write-strings -Wno-unused-variable"
+	
+	AC_C_COMPILE_FLAGS([-Wno-unused-but-set-variable])
+	
 	D_LDFLAGS="$D_LDFLAGS "
 
 	if test "$fs2_fred" = "yes" ; then

--- a/configure.ac
+++ b/configure.ac
@@ -223,7 +223,7 @@ fi
 
 if test "$fs2_debug" = "yes" ; then
 	AC_DEFINE([_DEBUG])
-	D_CFLAGS="$D_CFLAGS -O0 -g -Wall -Wextra -Wno-unused-parameter -Wno-write-strings -Wshadow -funroll-loops"
+	D_CFLAGS="$D_CFLAGS -O0 -g -Wall -Wextra -Wno-unused-parameter -Wno-unused-function -Wno-write-strings -Wshadow -funroll-loops"
 	D_LDFLAGS="$D_LDFLAGS -g"
 
 	if test "$fs2_fred" = "yes" ; then
@@ -233,7 +233,7 @@ if test "$fs2_debug" = "yes" ; then
 	fi
 else
 	AC_DEFINE([NDEBUG])
-	D_CFLAGS="$D_CFLAGS -O2 -Wall -Wno-write-strings -funroll-loops"
+	D_CFLAGS="$D_CFLAGS -O2 -Wall -Wno-unused-function -Wno-write-strings -funroll-loops"
 	D_LDFLAGS="$D_LDFLAGS "
 
 	if test "$fs2_fred" = "yes" ; then

--- a/configure.ac
+++ b/configure.ac
@@ -233,7 +233,8 @@ if test "$fs2_debug" = "yes" ; then
 	fi
 else
 	AC_DEFINE([NDEBUG])
-	D_CFLAGS="$D_CFLAGS -O2 -Wall -Wno-unused-function -Wno-write-strings -funroll-loops"
+	D_CFLAGS="$D_CFLAGS -O2 -Wall -funroll-loops"
+	D_CFLAGS="$D_CLFAGS -Wno-unused-function -Wno-unused-but-set-variable -Wno-write-strings -Wno-unused-variable"
 	D_LDFLAGS="$D_LDFLAGS "
 
 	if test "$fs2_fred" = "yes" ; then

--- a/m4/ac_cxx_compile_flags.m4
+++ b/m4/ac_cxx_compile_flags.m4
@@ -1,0 +1,15 @@
+AC_DEFUN([AC_C_COMPILE_FLAGS],[
+NEW_CFLAGS="$D_CFLAGS"
+for ac_flag in $1
+do
+ AC_MSG_CHECKING(whether compiler supports $ac_flag)
+ D_CFLAGS="$NEW_CFLAGS $ac_flag"
+ AC_TRY_COMPILE(,[
+  void f() {};
+ ],[
+  NEW_CFLAGS="$D_CFLAGS"
+  AC_MSG_RESULT(yes)
+ ],AC_MSG_RESULT(no))
+done
+D_CFLAGS="$NEW_CFLAGS"
+])


### PR DESCRIPTION
For compatibility with Visual studio we need to use a macro to specify `size_t` sized format arguments. C99 says `%zu` should be used but Visual Studio only supports `%Iu`. To solve this issue I added the `PTRDIFF_T_ARG ` and `SIZE_T_ARG` macros for specifying the respective argument types.