### PR TITLE
Make beam-create actually call sexp_beam_floating_fire().

### DIFF
--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -24271,6 +24271,11 @@ int eval_sexp(int cur_node, int referenced_node)
 				sexp_val = SEXP_TRUE;
 				break;
 
+			case OP_BEAM_FLOATING_FIRE:
+				sexp_beam_floating_fire(node);
+				sexp_val = SEXP_TRUE;
+				break;
+
 			case OP_IS_TAGGED:
 				sexp_val = sexp_is_tagged(node);
 				break;


### PR DESCRIPTION
Somehow, this got missed during the creation of the pull request, and I guess nobody (not even me) actually tried using it since then.