### PR TITLE
Fix infinite trigger count not interacting correctly with "+Interval:"

### DIFF
--- a/code/mission/missiongoals.cpp
+++ b/code/mission/missiongoals.cpp
@@ -978,10 +978,11 @@ void mission_process_event( int event )
 	}
 
 	// decrement the trigger count.  When at 0, set the repeat count to 0 so we don't eval this function anymore
-	if (result && (Mission_events[event].trigger_count > 0) && (Mission_events[event].flags & MEF_USING_TRIGGER_COUNT) ) {
-		Mission_events[event].trigger_count--;
+	if (result && (Mission_events[event].trigger_count != 0) && (Mission_events[event].flags & MEF_USING_TRIGGER_COUNT) ) {
+		if (Mission_events[event].trigger_count > 0)
+			Mission_events[event].trigger_count--;
 		if (Mission_events[event].trigger_count == 0) {
-			 Mission_events[event].repeat_count = 0; 
+			 Mission_events[event].repeat_count = 0;
 		}
 		else {
 			bump_timestamp = true;
@@ -1008,7 +1009,7 @@ void mission_process_event( int event )
 		}
 		// Set the timestamp for the next check on this event unless we only have a trigger count and no repeat count and 
 		// this event didn't trigger this frame. 
-		else if (bump_timestamp || (!( Mission_events[event].repeat_count == -1 && Mission_events[event].trigger_count > 0 ))) {
+		else if (bump_timestamp || (!((Mission_events[event].repeat_count == -1) && (Mission_events[event].flags & MEF_USING_TRIGGER_COUNT) && (Mission_events[event].trigger_count != 0)))) {
 			// set the timestamp to time out 'interval' seconds in the future.  
 			Mission_events[event].timestamp = timestamp( Mission_events[event].interval * 1000 );
 		}


### PR DESCRIPTION
There's an undocumented feature whereby negative trigger counts are treated as infinite. However, since it doesn't use the bump_timestamp system of positive trigger counts, it'll behave more like an infinite repeat count (e.g. with "+Interval: 5" it will only check every 5 seconds instead of becoming active again after 5 seconds have passed). This just makes negative values set bump_timestamp and excludes them from resetting the timestamp if the event didn't trigger that frame (checking MEF_USING_TRIGGER_COUNT so that the other behavior is still possible if you set a negative repeat_count and don't specify a trigger_count).

(As an addendum, FRED makes it somewhat more difficult to use negative repeat and trigger counts because it doesn't allow typing non-digit characters; you can still paste in a "-", but FRED will display e.g. 4294967295 instead of -1, even though it will save -1 in the mission file. This PR just fixes FSO's interaction with infinite trigger counts, not FRED's interface issues with them.)