### PR TITLE
Fix antipodes on OS X

### DIFF
--- a/code/cmdline/cmdline.cpp
+++ b/code/cmdline/cmdline.cpp
@@ -696,8 +696,8 @@ void os_parse_parms(int argc, char *argv[])
 
 	for (int i = 0; i < argc; i++)
 	{
-		// On mac this gets passed if the application was launched by double-clicking in the finder
-		if (i == 1 && strncmp(argv[1], "-psn", 4) == 0)
+		// On OS X this gets passed if the application was launched by double-clicking in the Finder
+		if (i == 1 && strncmp(argv[i], "-psn", 4) == 0)
 		{
 			continue;
 		}
@@ -727,8 +727,14 @@ void os_validate_parms(int argc, char *argv[])
 	{
 		token = argv[i];
 
+		// On OS X this gets passed if the application was launched by double-clicking in the Finder
+		if (i == 1 && strncmp(token, "-psn", 4) == 0) {
+			continue;
+		}
+
 		if (token[0] == '-') {
 			parm_found = 0;
+
 			for (parmp = GET_FIRST(&Parm_list); parmp != END_OF_LIST(&Parm_list); parmp = GET_NEXT(parmp)) {
 				if (!stricmp(parmp->name, token)) {
 					parm_found = 1;

--- a/code/freespace2/freespace.cpp
+++ b/code/freespace2/freespace.cpp
@@ -8748,6 +8748,10 @@ int actual_main(int argc, char *argv[])
 	// Finder sets the working directory to the root of the drive so we have to get a little creative
 	// to find out where on the disk we should be running from for CFILE's sake.
 	strncpy(full_path, *argv, 1024);
+
+	char *path_name = SDL_GetBasePath();
+	SetCurrentDirectory(path_name);
+	SDL_free(path_name);
 #endif
 
 	// create user's directory	

--- a/code/freespace2/freespace.cpp
+++ b/code/freespace2/freespace.cpp
@@ -1735,10 +1735,6 @@ DCF(gamma,"Sets and saves Gamma Factor")
 	os_config_write_string( NULL, NOX("Gamma"), tmp_gamma_string );
 }
 
-#ifdef APPLE_APP
-char full_path[1024];
-#endif
-
 #ifdef FS2_VOICER
 // This is really awful but thank the guys of X11 for naming something "Window"
 #	include "SDL_syswm.h" // For SDL_SysWMinfo
@@ -8747,8 +8743,6 @@ int actual_main(int argc, char *argv[])
 #ifdef APPLE_APP
 	// Finder sets the working directory to the root of the drive so we have to get a little creative
 	// to find out where on the disk we should be running from for CFILE's sake.
-	strncpy(full_path, *argv, 1024);
-
 	char *path_name = SDL_GetBasePath();
 	SetCurrentDirectory(path_name);
 	SDL_free(path_name);

--- a/projects/Xcode4/Info.plist
+++ b/projects/Xcode4/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>SDL_FILESYSTEM_BASE_DIR_TYPE</key>
+	<string>parent</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>English</string>
 	<key>CFBundleExecutable</key>


### PR DESCRIPTION
*This is a PR to antipodes branch*

Resolves:
* Issue #248, and
* the lack of a working directory being set with SDL2-based middleware, which only affects fs2open when run from Finder (i.e. double clicking on .app bundle).

Specifically for the second resolved problem, with SDL1-based middleware `projects/Xcode4/SDLMain.m` used to set the working directory via `setupWorkingDirectory()`. This function is no longer present with SDL2. Accordingly, unless run from the Terminal a working directory is not set.

This leads to a number of problems on OS X with antipodes, not least of which is `cfile_init()` fails which leads to an early `exit(1)`.

Although we use `SDL_GetBasePath()` to set the working directory (not always strictly true), this limitation was already present on OS X with the SDL1-based middleware.