### PR TITLE
Use SDL_GetPrefPath to determine config directory

### DIFF
--- a/code/cfile/cfile.cpp
+++ b/code/cfile/cfile.cpp
@@ -36,8 +36,9 @@
 
 
 char Cfile_root_dir[CFILE_ROOT_DIRECTORY_LEN] = "";
-#ifdef SCP_UNIX
 char Cfile_user_dir[CFILE_ROOT_DIRECTORY_LEN] = "";
+#ifdef SCP_UNIX
+char Cfile_user_dir_legacy[CFILE_ROOT_DIRECTORY_LEN] = "";
 #endif
 
 // During cfile_init, verify that Pathtypes[n].index == n for each item
@@ -208,8 +209,12 @@ int cfile_init(const char *exe_dir, const char *cdrom_dir)
 
 		// set root directory
 		strncpy(Cfile_root_dir, buf, CFILE_ROOT_DIRECTORY_LEN-1);
+		strncpy(Cfile_user_dir, os_get_config_path().c_str(), CFILE_ROOT_DIRECTORY_LEN-1);
+		
 #ifdef SCP_UNIX
-		snprintf(Cfile_user_dir, CFILE_ROOT_DIRECTORY_LEN-1, "%s/%s/", detect_home(), Osreg_user_dir);
+		// Initialize path of old pilot files
+		extern const char* Osreg_user_dir_legacy;
+		snprintf(Cfile_user_dir_legacy, CFILE_ROOT_DIRECTORY_LEN-1, "%s/%s/", getenv("HOME"), Osreg_user_dir_legacy);
 #endif
 
 		for ( i = 0; i < MAX_CFILE_BLOCKS; i++ ) {

--- a/code/cfile/cfile.h
+++ b/code/cfile/cfile.h
@@ -109,8 +109,9 @@ extern const char *Get_file_list_child;
 // cfile directory. valid after cfile_init() returns successfully
 #define CFILE_ROOT_DIRECTORY_LEN			256
 extern char Cfile_root_dir[CFILE_ROOT_DIRECTORY_LEN];
-#ifdef SCP_UNIX
 extern char Cfile_user_dir[CFILE_ROOT_DIRECTORY_LEN];
+#ifdef SCP_UNIX
+extern char Cfile_user_dir_legacy[CFILE_ROOT_DIRECTORY_LEN];
 #endif
 
 //================= LOW-LEVEL FUNCTIONS ==================

--- a/code/cfile/cfilesystem.cpp
+++ b/code/cfile/cfilesystem.cpp
@@ -37,7 +37,7 @@
 #include "cmdline/cmdline.h"
 #include "globalincs/pstypes.h"
 #include "localization/localize.h"
-
+#include "osapi/osapi.h"
 
 #define CF_ROOTTYPE_PATH 0
 #define CF_ROOTTYPE_PACK 1
@@ -94,7 +94,6 @@ typedef struct cf_file_block {
 
 static uint Num_files = 0;
 static cf_file_block  *File_blocks[CF_MAX_FILE_BLOCKS];
-
 
 // Return a pointer to to file 'index'.
 cf_file *cf_get_file(int index)
@@ -360,6 +359,36 @@ void cf_build_pack_list( cf_root *root )
 	vm_free(temp_roots_sort);
 }
 
+static void cf_add_mod_roots(const char* rootDirectory)
+{
+	if (Cmdline_mod)
+	{
+		for (const char* cur_pos=Cmdline_mod; strlen(cur_pos) != 0; cur_pos+= (strlen(cur_pos)+1))
+		{
+			SCP_stringstream ss;
+			ss << rootDirectory;
+
+			if (rootDirectory[strlen(rootDirectory) - 1] != DIR_SEPARATOR_CHAR)
+			{
+				ss << DIR_SEPARATOR_CHAR;
+			}
+
+			ss << cur_pos << DIR_SEPARATOR_STR;
+
+			SCP_string rootPath = ss.str();
+			if (rootPath.size() + 1 >= CF_MAX_PATHNAME_LENGTH) {
+				Error(LOCATION, "The length of mod directory path '%s' exceeds the maximum of %d!\n", rootPath.c_str(), CF_MAX_PATHNAME_LENGTH);
+			}
+
+			cf_root* root = cf_create_root();
+
+			strncpy(root->path, rootPath.c_str(),  CF_MAX_PATHNAME_LENGTH-1);
+
+			root->roottype = CF_ROOTTYPE_PATH;
+			cf_build_pack_list(root);
+		}
+	}
+}
 
 void cf_build_root_list(const char *cdrom_dir)
 {
@@ -367,40 +396,11 @@ void cf_build_root_list(const char *cdrom_dir)
 	Num_path_roots = 0;
 
 	cf_root	*root;
-	char str_temp[CF_MAX_PATHNAME_LENGTH], *cur_pos;
 	int path_len;
 
-#ifdef SCP_UNIX
 	// =========================================================================
 	// now look for mods under the users HOME directory to use before system ones
-	if (Cmdline_mod) {
-		for (cur_pos=Cmdline_mod; strlen(cur_pos) != 0; cur_pos+= (strlen(cur_pos)+1))
-		{
-			memset(str_temp, 0, CF_MAX_PATHNAME_LENGTH);
-			strncpy(str_temp, cur_pos, CF_MAX_PATHNAME_LENGTH-1);
-
-			strncat(str_temp, DIR_SEPARATOR_STR, (CF_MAX_PATHNAME_LENGTH - strlen(str_temp) - 1));
-
-			// truncated string check
-			if ( (strlen(Cfile_user_dir) + strlen(str_temp) + 1) >= CF_MAX_PATHNAME_LENGTH ) {
-				Error(LOCATION, "Home directory plus mod directory exceeds CF_MAX_PATHNAME_LENGTH\n");
-			}
-
-			root = cf_create_root();
-
-			strncpy( root->path, Cfile_user_dir, CF_MAX_PATHNAME_LENGTH-1 );
-
-			// do we already have a slash? as in the case of a root directory install
-			if ( (strlen(root->path) < (CF_MAX_PATHNAME_LENGTH-1)) && (root->path[strlen(root->path)-1] != DIR_SEPARATOR_CHAR) ) {
-				strcat_s(root->path, DIR_SEPARATOR_STR);		// put trailing backslash on for easier path construction
-			}
-
-			strncat(root->path, str_temp, (CF_MAX_PATHNAME_LENGTH - strlen(root->path) - 1));
-
-			root->roottype = CF_ROOTTYPE_PATH;
-			cf_build_pack_list(root);
-		}
-	}
+	cf_add_mod_roots(Cfile_user_dir);
 	// =========================================================================
 
 	// =========================================================================
@@ -421,46 +421,37 @@ void cf_build_root_list(const char *cdrom_dir)
 	// Next, check any VP files under the current directory.
 	cf_build_pack_list(root);
 	// =========================================================================
-#endif
 
-	if(Cmdline_mod) {
-		// stackable Mod support -- Kazan
-		for (cur_pos=Cmdline_mod; *cur_pos != '\0'; cur_pos+= (strlen(cur_pos)+1))
-		{
-			memset(str_temp, 0, CF_MAX_PATHNAME_LENGTH);
-			strncpy(str_temp, cur_pos, CF_MAX_PATHNAME_LENGTH-1);
+	// =========================================================================
+#ifdef SCP_UNIX
+	// For compatibility with old installations we need to also add the legacy path as a root
+	cf_add_mod_roots(Cfile_user_dir_legacy);
+	
+	root = cf_create_root();
+	strncpy( root->path, Cfile_user_dir_legacy, CF_MAX_PATHNAME_LENGTH-1 );
 
-			strncat(str_temp, DIR_SEPARATOR_STR, (CF_MAX_PATHNAME_LENGTH - strlen(str_temp) - 1));
-			root = cf_create_root();
-
-			if ( !_getcwd(root->path, CF_MAX_PATHNAME_LENGTH ) ) {
-				Error(LOCATION, "Can't get current working directory -- %d", errno );
-			}
-
-			// truncated string check
-			if ( (strlen(root->path) + strlen(str_temp) + 1) >= CF_MAX_PATHNAME_LENGTH ) {
-				Error(LOCATION, "Installed path plus mod directory exceeds CF_MAX_PATHNAME_LENGTH\n");
-			}
-
-			path_len = strlen(root->path);
-
-			// do we already have a slash? as in the case of a root directory install
-			if ( (path_len < (CF_MAX_PATHNAME_LENGTH-1)) && (root->path[path_len-1] != DIR_SEPARATOR_CHAR) ) {
-				strcat_s(root->path, DIR_SEPARATOR_STR);		// put trailing backslash on for easier path construction
-				path_len++;
-			}
-
-			strncat(root->path, str_temp, (CF_MAX_PATHNAME_LENGTH - path_len - 1));
-			root->roottype = CF_ROOTTYPE_PATH;
-			cf_build_pack_list(root);
-		}
+	// do we already have a slash? as in the case of a root directory install
+	if( (strlen(root->path) < (CF_MAX_PATHNAME_LENGTH-1)) && (root->path[strlen(root->path)-1] != DIR_SEPARATOR_CHAR) ) {
+		strcat_s(root->path, DIR_SEPARATOR_STR);		// put trailing backslash on for easier path construction
 	}
+	root->roottype = CF_ROOTTYPE_PATH;
+
+	// Next, check any VP files under the current directory.
+	cf_build_pack_list(root);
+#endif
+	// =========================================================================
+
+	char working_directory[CF_MAX_PATHNAME_LENGTH];
+	
+	if ( !_getcwd(working_directory, CF_MAX_PATHNAME_LENGTH ) ) {
+		Error(LOCATION, "Can't get current working directory -- %d", errno );
+	}
+	
+	cf_add_mod_roots(working_directory);
 
 	root = cf_create_root();
 	
-	if ( !_getcwd(root->path, CF_MAX_PATHNAME_LENGTH ) ) {
-		Error(LOCATION, "Can't get current working directory -- %d", errno );
-	}
+	strcpy_s(root->path, working_directory);
 
 	path_len = strlen(root->path);
 
@@ -2128,18 +2119,11 @@ int cf_create_default_path_string( SCP_string &path, int pathtype, const char *f
 void cfile_spew_pack_file_crcs()
 {
 	int i;
-	char out_path[CFILE_ROOT_DIRECTORY_LEN+MAX_FILENAME_LEN];
 	char datetime[45];
 	uint chksum = 0;
 	time_t my_time;
 	
-#ifdef SCP_UNIX
-	sprintf(out_path, "%s%svp_crcs.txt", Cfile_user_dir, DIR_SEPARATOR_STR);
-#else
-	sprintf(out_path, "%s%svp_crcs.txt", Cfile_root_dir, DIR_SEPARATOR_STR);
-#endif
-
-	FILE *out = fopen(out_path, "w");
+	FILE *out = fopen(os_get_config_path("vp_crcs.txt").c_str(), "w");
 
 	if (out == NULL) {
 		Int3();

--- a/code/freespace2/freespace.cpp
+++ b/code/freespace2/freespace.cpp
@@ -8730,8 +8730,6 @@ int actual_main(int argc, char *argv[])
 
 	SCP_mspdbcs_Initialise();
 #else
-	char userdir[MAX_PATH];
-
 #ifdef APPLE_APP
 	// Finder sets the working directory to the root of the drive so we have to get a little creative
 	// to find out where on the disk we should be running from for CFILE's sake.
@@ -8741,8 +8739,7 @@ int actual_main(int argc, char *argv[])
 #endif
 
 	// create user's directory	
-	snprintf(userdir, MAX_PATH - 1, "%s/%s/", detect_home(), Osreg_user_dir);
-	_mkdir(userdir);
+	_mkdir(os_get_config_path().c_str());
 #endif
 
 #if defined(GAME_ERRORLOG_TXT) && defined(_MSC_VER)

--- a/code/graphics/gropengl.cpp
+++ b/code/graphics/gropengl.cpp
@@ -358,19 +358,9 @@ void gr_opengl_print_screen(const char *filename)
 	GLuint pbo = 0;
 
 	// save to a "screenshots" directory and tack on the filename
-#ifdef SCP_UNIX
-	snprintf( tmp, MAX_PATH_LEN-1, "%s/%s/screenshots/%s.tga", detect_home(), Osreg_user_dir, filename);
-	_mkdir( tmp );
-#else
-	_getcwd( tmp, MAX_PATH_LEN-1 );
-	strcat_s( tmp, "\\screenshots\\" );
-	_mkdir( tmp );
+	snprintf(tmp, MAX_PATH_LEN-1, "screenshots/%s.tga", filename);
 
-	strcat_s( tmp, filename );
-	strcat_s( tmp, ".tga" );
-#endif
-
-	FILE *fout = fopen(tmp, "wb");
+	FILE *fout = fopen(os_get_config_path(tmp).c_str(), "wb");
 
 	if (fout == NULL) {
 		return;

--- a/code/osapi/osapi.h
+++ b/code/osapi/osapi.h
@@ -28,9 +28,6 @@ extern int Os_debugger_running;
 
 // initialization/shutdown functions -----------------------------------------------
 
-// detect the home/base/writable directory to use
-extern const char *detect_home(void);
-
 // If app_name is NULL or ommited, then TITLE is used
 // for the app name, which is where registry keys are stored.
 void os_init(const char * wclass, const char * title, const char *app_name=NULL, const char *version_string=NULL );
@@ -68,5 +65,13 @@ void os_suspend();
 // resume message processing
 void os_resume(); 
 
+/**
+ * @brief Gets a path to a configuration file
+ * A relative path to the wanted file or directory. Directories should be separated with '/'
+ * @param subpath The path of the wanted file or directory, may be emtpy to get the config directory
+ * 
+ * @returns The path to the specified config path
+ */
+SCP_string os_get_config_path(const SCP_string& subpath = "");
 
 #endif // _OSAPI_H

--- a/code/osapi/osregistry.h
+++ b/code/osapi/osregistry.h
@@ -22,9 +22,6 @@ extern const char *Osreg_company_name;
 extern const char *Osreg_class_name;
 extern const char *Osreg_app_name;
 extern const char *Osreg_title;
-#ifdef SCP_UNIX
-extern const char *Osreg_user_dir;
-#endif
 
 
 // ------------------------------------------------------------------------------------------------------------
@@ -66,4 +63,3 @@ unsigned int  os_config_read_uint( const char *section, const char *name, unsign
 const char * os_config_read_string_ex( const char *keyname, const char *name, const char *default_value );
 
 #endif
-

--- a/code/osapi/outwnd.cpp
+++ b/code/osapi/outwnd.cpp
@@ -55,13 +55,9 @@ void load_filter_info(void)
 	outwnd_filter_loaded = 1;
 
 	memset( pathname, 0, sizeof(pathname) );
-#ifdef WIN32
-	snprintf( pathname, MAX_PATH_LEN, "%s\\%s\\%s", detect_home(), Pathtypes[CF_TYPE_DATA].path, NOX("debug_filter.cfg") );
-#else
-	snprintf( pathname, MAX_PATH_LEN, "%s/%s/%s/%s", detect_home(), Osreg_user_dir, Pathtypes[CF_TYPE_DATA].path, NOX("debug_filter.cfg") );
-#endif
+	snprintf( pathname, MAX_PATH_LEN, "%s/%s", Pathtypes[CF_TYPE_DATA].path, NOX("debug_filter.cfg") );
 
-	fp = fopen(pathname, "rt");
+	fp = fopen(os_get_config_path(pathname).c_str(), "rt");
 
 	if (!fp) {
 		Outwnd_no_filter_file = 1;
@@ -129,13 +125,9 @@ void save_filter_info(void)
 
 
 	memset( pathname, 0, sizeof(pathname) );
-#ifdef WIN32
-	snprintf( pathname, MAX_PATH_LEN, "%s\\%s\\%s", detect_home(), Pathtypes[CF_TYPE_DATA].path, NOX("debug_filter.cfg") );
-#else
-	snprintf( pathname, MAX_PATH_LEN, "%s/%s/%s/%s", detect_home(), Osreg_user_dir, Pathtypes[CF_TYPE_DATA].path, NOX("debug_filter.cfg") );
-#endif
+	snprintf( pathname, MAX_PATH_LEN, "%s/%s", Pathtypes[CF_TYPE_DATA].path, NOX("debug_filter.cfg") );
 
-	fp = fopen(pathname, "wt");
+	fp = fopen(os_get_config_path(pathname).c_str(), "wt");
 
 	if (fp) {
 		for (uint i = 0; i < OutwndFilter.size(); i++)
@@ -247,13 +239,9 @@ void outwnd_init()
 		}
 
 		memset( pathname, 0, sizeof(pathname) );
-#ifdef WIN32
-		snprintf(pathname, MAX_PATH_LEN-1, "%s\\%s\\%s", detect_home(), Pathtypes[CF_TYPE_DATA].path, FreeSpace_logfilename);
-#else
-		snprintf(pathname, MAX_PATH_LEN, "%s/%s/%s/%s", detect_home(), Osreg_user_dir, Pathtypes[CF_TYPE_DATA].path, FreeSpace_logfilename);
-#endif
+		snprintf( pathname, MAX_PATH_LEN, "%s/%s", Pathtypes[CF_TYPE_DATA].path, FreeSpace_logfilename);
 
-		Log_fp = fopen(pathname, "wb");
+		Log_fp = fopen(os_get_config_path(pathname).c_str(), "wb");
 
 		if (Log_fp == NULL) {
 			outwnd_printf("Error", "Error opening %s\n", pathname);


### PR DESCRIPTION
This tried to stay compatible with current installs as much as possible but for pilot files that isn't possible without rather substantial rewrites of the cfile system. Instead the launcher will handle copying the files from the old location.
These changes also will use the config directory for all writing operations on Windows similar to how Unix is currently handled.

This is currently not finished but it is ready for preliminary code review and testing. Remaining things to do:
- [x] wxLauncher compatibility (in work)
  - [x] Configuration files saved in correct directory based on selected build
  - [x] Player files copied to new directory
- [ ] Windows compatibility

EDIT: Remaining things should now be finished.