### PR TITLE
* remove an incorrect comment (the *= multiplies the variable by the …

### DIFF
--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -1999,11 +1999,6 @@ void evaluate_object_as_nearest_objnum(eval_nearest_objnum *eno)
 					}
 
 					if (eno->trial_objp->flags & OF_PLAYER_SHIP){
-						// Goober5000: oh dear, it looks like this was originally meant to scale
-						// the distance according to skill, but as it is, the effect appears negligible.
-						// I could fix it with parentheses, but we all know how quickly AI pilots
-						// die usually, so the overall effect would probably be worse.  So I left
-						// this unchanged.
 						dist *= 1.0f + (NUM_SKILL_LEVELS - Game_skill_level - 1)/NUM_SKILL_LEVELS;	//	Favor attacking non-players based on skill level.
 					}
 


### PR DESCRIPTION
…entire RHS; it doesn't multiply and then add)

I added this comment many years ago, thinking I was clarifying a small bit of code, when really it was just a case of reading too fast.  The original code is correct; my comment was erroneous.