### PR TITLE
Fix/292 warnings part b

### DIFF
--- a/code/freespace2/freespace.cpp
+++ b/code/freespace2/freespace.cpp
@@ -4795,7 +4795,7 @@ void game_set_frametime(int state)
 		fix frame_speed = F1_0 / Debug_dump_frames;
 
 		if (Frametime > frame_speed ){
-			nprintf(("warning","slow frame: %x\n",Frametime));
+			nprintf(("warning","slow frame: %x\n",(int)Frametime));
 		} else {			
 			do {
 				thistime = timer_get_fixed_seconds();

--- a/code/pcxutils/pcxutils.cpp
+++ b/code/pcxutils/pcxutils.cpp
@@ -410,8 +410,8 @@ int pcx_encode_line(ubyte *inBuff, int inLen, FILE * fp)
 	ubyte this_ptr, last;
 
 	int srcIndex, i;
-	register int total;
-	register ubyte runCount; 	// max single runlength is 63
+	int total;
+	ubyte runCount; 	// max single runlength is 63
 	total = 0;
 	last = *(inBuff);
 	runCount = 1;


### PR DESCRIPTION
Fixes two of the warnings I saw in master in Xcode/Clang.  The cast is the one I'm less certain of but in IRC it was suggested that this should be safe enough.  Changing the specifier alone just bounces the warning between 64bit and 32bit builds as fix is a different type on each platform.