### PR TITLE
Remove do_damage check before calling hit functions in beam collisions.

### DIFF
--- a/code/weapon/beam.cpp
+++ b/code/weapon/beam.cpp
@@ -3136,7 +3136,7 @@ void beam_handle_collisions(beam *b)
 			}
 		}
 
-		if(do_damage && !physics_paused){
+		if(!physics_paused){
 
 			switch(Objects[target].type){
 			case OBJ_DEBRIS:

--- a/code/weapon/beam.cpp
+++ b/code/weapon/beam.cpp
@@ -1387,7 +1387,7 @@ void beam_render_muzzle_glow(beam *b)
 {
 	vertex pt;
 	weapon_info *wip = &Weapon_info[b->weapon_info_index];
-	beam_weapon_info *bwi = &Weapon_info[b->weapon_info_index].b_info;
+	beam_weapon_info *bwi = &wip->b_info;
 	float rad, pct, rand_val;
 	int tmap_flags = TMAP_FLAG_TEXTURED | TMAP_HTL_3D_UNLIT;
 	pt.flags = 0;    // avoid potential read of uninit var
@@ -3141,7 +3141,7 @@ void beam_handle_collisions(beam *b)
 			switch(Objects[target].type){
 			case OBJ_DEBRIS:
 				// hit the debris - the debris hit code takes care of checking for MULTIPLAYER_CLIENT, etc
-				debris_hit(&Objects[target], &Objects[b->objnum], &b->f_collisions[idx].cinfo.hit_point_world, Weapon_info[b->weapon_info_index].damage);
+				debris_hit(&Objects[target], &Objects[b->objnum], &b->f_collisions[idx].cinfo.hit_point_world, wi->damage);
 				break;
 
 			case OBJ_WEAPON:
@@ -3160,7 +3160,7 @@ void beam_handle_collisions(beam *b)
 								}
 							}
 
-							float damage = Weapon_info[b->weapon_info_index].damage * attenuation;
+							float damage = wi->damage * attenuation;
 
 							trgt->hull_strength -= damage;
 
@@ -3188,7 +3188,7 @@ void beam_handle_collisions(beam *b)
 			case OBJ_ASTEROID:
 				// hit the asteroid
 				if (!(Game_mode & GM_MULTIPLAYER) || MULTIPLAYER_MASTER) {
-					asteroid_hit(&Objects[target], &Objects[b->objnum], &b->f_collisions[idx].cinfo.hit_point_world, Weapon_info[b->weapon_info_index].damage);
+					asteroid_hit(&Objects[target], &Objects[b->objnum], &b->f_collisions[idx].cinfo.hit_point_world, wi->damage);
 				}
 				break;
 			case OBJ_SHIP:	


### PR DESCRIPTION
This should allow 0-damage beams to be used to apply TAG effects.

On the flip side, it could have some unexpected consequences with existing mods that use 0-damage beams for anything (sudden appearance of impact sparks, for instance). Theoretically it could also cause problems if somebody had a 0-damage beam with TAG data that they were relying on not TAGing things for some reason, but that seems exceedingly unlikely.

There's also a minor cleanup commit that I noticed as I was poking around beam.cpp.