### PR TITLE
Makes vsprintf() stop chopping off the last character. Fixes issue #298.

### DIFF
--- a/code/parse/parselo.cpp
+++ b/code/parse/parselo.cpp
@@ -3796,7 +3796,7 @@ void vsprintf(SCP_string &dest, const char *format, va_list ap)
 	}
 
 	dest.resize(static_cast<size_t>(needed_length));
-	vsnprintf(&dest[0], dest.size(), format, ap);
+	vsnprintf(&dest[0], dest.size() + 1, format, ap);
 }
 
 void sprintf(SCP_string &dest, const char *format, ...)


### PR DESCRIPTION
Also fixes saving missions in FRED, since it uses the same function.