### PR TITLE
Makes FRED call glowpoint_init().

### DIFF
--- a/code/fred2/management.cpp
+++ b/code/fred2/management.cpp
@@ -409,6 +409,7 @@ bool fred_init()
 	armor_init();
 	weapon_init();
 	parse_medal_tbl();			// get medal names for sexpression usage
+	glowpoint_init();
 	ship_init();
 	parse_init();
 	techroom_intel_init();


### PR DESCRIPTION
Avoids a constant stream of warnings when using "$Glowpoint overrides:".