### PR TITLE
Fixes call-ssm-strike resulting in a Warning about a null vec3d.

### DIFF
--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -22586,9 +22586,11 @@ void sexp_call_ssm_strike(int node) {
 		if (ship_num >= 0) {
 			int obj_num = Ships[ship_num].objnum;
 			object *target_ship = &Objects[obj_num];
-			vec3d *start = &target_ship->pos; 
+			vec3d start = target_ship->pos;
 
-			ssm_create(target_ship, start, ssm_index, NULL, calling_team);
+			vm_vec_scale_add(&start, &start, &target_ship->orient.vec.fvec, -1);
+
+			ssm_create(target_ship, &start, ssm_index, NULL, calling_team);
 		}
 	}
 }


### PR DESCRIPTION
`ssm_create()` subtracts the start coordinates from the position of the target, and then normalizes that. Since call-ssm-strike was using the position of the target as the start coordinates, this was obviously resulting in normalizing a null vec3d, generating the spurious warning. This just makes call-ssm-strike use a point immediately behind the target's position (using the target's orientation) as the starting coordinate, thereby avoiding the warning.