### PR TITLE
Replaces a reference to MAX_SHIP_CLASSES with Ship_info.size().

### DIFF
--- a/code/fred2/management.cpp
+++ b/code/fred2/management.cpp
@@ -885,7 +885,7 @@ void clear_mission()
 	// of ships for all teams
 	for (i=0; i<MAX_TVT_TEAMS; i++) {
 		count = 0;
-		for ( j = 0; j < MAX_SHIP_CLASSES; j++ ) {
+		for ( j = 0; j < static_cast<int>(Ship_info.size()); j++ ) {
 			if (Ship_info[j].flags & SIF_DEFAULT_PLAYER_SHIP) {
 				Team_data[i].ship_list[count] = j;
 				strcpy_s(Team_data[i].ship_list_variables[count], "");


### PR DESCRIPTION
This would cause FRED to treat essentially unspecified pieces of memory as ship classes and then see if this nonsense class had the `SIF_DEFAULT_PLAYER_SHIP` flag set... and if so, put it in the default list of available ships. With a debug build (where the memory past the end of `Ship_info` is all identical for quite a ways), this could result in the default, empty mission saving as 60 megabytes.