### PR TITLE
Refactor mission saving to avoid duplicate code.

### DIFF
--- a/code/fred2/missionsave.cpp
+++ b/code/fred2/missionsave.cpp
@@ -96,30 +96,20 @@ void CFred_mission_save::convert_special_tags_to_retail()
 	}
 }
 
-int CFred_mission_save::save_mission_file(char *pathname)
+void CFred_mission_save::save_mission_internal(const char *pathname)
 {
-	char backup_name[256], savepath[MAX_PATH_LEN], *p;
 	CTime t;
 
 	t = CTime::GetCurrentTime();
 	strcpy_s(The_mission.modified, t.Format("%x at %X"));
 
-	strcpy_s(savepath, "");
-	p = strrchr(pathname, '\\');
-	if ( p ) {
-		*p = '\0';
-		strcpy_s(savepath, pathname);
-		*p = '\\';
-		strcat_s(savepath, "\\");
-	}
-	strcat_s(savepath, "saving.xxx");
-
 	reset_parse();
 	fred_parse_flag = 0;
-	fp = cfopen(savepath, "wt", CFILE_NORMAL);
+	fp = cfopen(pathname, "wt", CFILE_NORMAL, CF_TYPE_MISSIONS);
 	if (!fp)	{
 		nprintf(("Error", "Can't open mission file to save.\n"));
-		return -1;
+		err = -1;
+		return;
 	}	
 
 	// Goober5000
@@ -174,10 +164,27 @@ int CFred_mission_save::save_mission_file(char *pathname)
 	}
 
 	cfclose(fp);
-	if (err) {
+	if (err)
 		mprintf(("Mission saving error code #%d\n", err));
+}
 
-	} else {
+int CFred_mission_save::save_mission_file(char *pathname)
+{
+	char backup_name[256], savepath[MAX_PATH_LEN], *p;
+
+	strcpy_s(savepath, "");
+	p = strrchr(pathname, '\\');
+	if ( p ) {
+		*p = '\0';
+		strcpy_s(savepath, pathname);
+		*p = '\\';
+		strcat_s(savepath, "\\");
+	}
+	strcat_s(savepath, "saving.xxx");
+
+	save_mission_internal(savepath);
+
+	if (!err) {
 		strcpy_s(backup_name, pathname);
 		if (backup_name[strlen(backup_name) - 4] == '.')
 			backup_name[strlen(backup_name) - 4] = 0;
@@ -196,10 +203,6 @@ int CFred_mission_save::autosave_mission_file(char *pathname)
 {
 	char backup_name[256], name2[256];
 	int i, len;
-	CTime t;
-	
-	t = CTime::GetCurrentTime();
-	strcpy_s(The_mission.modified, t.Format("%x at %X"));
 
 	len = strlen(pathname);
 	strcpy_s(backup_name, pathname);
@@ -213,68 +216,8 @@ int CFred_mission_save::autosave_mission_file(char *pathname)
 	}
 	
 	strcpy(backup_name + len, ".001");
-	reset_parse();
-	fred_parse_flag = 0;
-	fp = cfopen(backup_name, "wt", CFILE_NORMAL, CF_TYPE_MISSIONS);
-	if (!fp)	{
-		nprintf(("Error", "Can't open mission file to save.\n"));
-		return -1;
-	}
 
-	// Goober5000
-	convert_special_tags_to_retail();
-
-	if (save_mission_info())
-		err = -2;
-	else if (save_plot_info())
-		err = -3;
-	else if (save_variables())
-		err = -3;
-//	else if (save_briefing_info())
-//		err = -4;
-	else if (save_fiction())
-		err = -3;
-	else if (save_cutscenes())
-		err = -4;
-	else if (save_cmd_briefs())
-		err = -4;
-	else if (save_briefing())
-		err = -4;
-	else if (save_debriefing())
-		err = -5;
-	else if (save_players())
-		err = -6;
-	else if (save_objects())
-		err = -7;
-	else if (save_wings())
-		err = -8;
-	else if (save_events())
-		err = -9;
-	else if (save_goals())
-		err = -10;
-	else if (save_waypoints())
-		err = -11;
-	else if (save_messages())
-		err = -12;
-	else if (save_reinforcements())
-		err = -13;
-	else if (save_bitmaps())
-		err = -14;
-	else if (save_asteroid_fields())
-		err = -15;
-	else if (save_music())
-		err = -16;
-	else {
-		required_string_fred("#End");
-		parse_comments(2);
-		token_found = NULL;
-		parse_comments();
-		fout("\n");
-	}
-
-	cfclose(fp);
-	if (err)
-		mprintf(("Mission saving error code #%d\n", err));
+	save_mission_internal(backup_name);
 
 	return err;
 }

--- a/code/fred2/missionsave.h
+++ b/code/fred2/missionsave.h
@@ -61,6 +61,8 @@ private:
 	void convert_special_tags_to_retail(SCP_string &text);
 	void convert_special_tags_to_retail();
 
+	void save_mission_internal(const char *pathname);
+
 public:
 	void save_turret_info(ship_subsys *ptr, int ship);
 	int save_bitmaps();


### PR DESCRIPTION
Makes `save_mission_file()` and `autosave_mission_file()` delegate to a new `save_mission_internal()` function. Tested and works with both manual and automatic saves.

As an aside, this fixes a slight inconsistency between manual and automatic saving (which inspired this refactor in the first place): when the order of `save_fiction()` and `save_cutscenes()` was swapped (in r10886 a.k.a. d6e0a73), `autosave_mission_file()` wasn't also changed, so autosaves of missions with "#Cutscenes" sections can't actually be loaded.