### PR TITLE
Fix shader compilation on Mesa OpenGL drivers

### DIFF
--- a/code/cmdline/cmdline.cpp
+++ b/code/cmdline/cmdline.cpp
@@ -479,6 +479,7 @@ cmdline_parm reparse_mainhall_arg("-reparse_mainhall", NULL, AT_NONE); //Cmdline
 cmdline_parm frame_profile_arg("-profile_frame_time", NULL, AT_NONE); //Cmdline_frame_profile
 cmdline_parm frame_profile_write_file("-profile_write_file", NULL, AT_NONE); // Cmdline_profile_write_file
 cmdline_parm no_unfocused_pause_arg("-no_unfocused_pause", NULL, AT_NONE); //Cmdline_no_unfocus_pause
+cmdline_parm opengl_workaround_override("-opengl_driver_override", NULL, AT_STRING); // Cmdline_opengl_workaround_override
 
 char *Cmdline_start_mission = NULL;
 int Cmdline_old_collision_sys = 0;
@@ -506,6 +507,7 @@ int Cmdline_reparse_mainhall = 0;
 bool Cmdline_frame_profile = false;
 bool Cmdline_profile_write_file = false;
 bool Cmdline_no_unfocus_pause = false;
+char* Cmdline_opengl_workaround_override = nullptr;
 
 // Other
 cmdline_parm get_flags_arg("-get_flags", "Output the launcher flags file", AT_NONE);
@@ -1706,6 +1708,11 @@ bool SetCmdlineParams()
 	if (no_unfocused_pause_arg.found())
 	{
 		Cmdline_no_unfocus_pause = true;
+	}
+
+	if (opengl_workaround_override.found())
+	{
+		Cmdline_opengl_workaround_override = opengl_workaround_override.str();
 	}
 
 	//Deprecated flags - CommanderDJ

--- a/code/cmdline/cmdline.h
+++ b/code/cmdline/cmdline.h
@@ -161,5 +161,6 @@ extern int Cmdline_reparse_mainhall;
 extern bool Cmdline_frame_profile;
 extern bool Cmdline_profile_write_file;
 extern bool Cmdline_no_unfocus_pause;
+extern char* Cmdline_opengl_workaround_override;
 
 #endif

--- a/code/graphics/gropengl.cpp
+++ b/code/graphics/gropengl.cpp
@@ -1959,6 +1959,11 @@ static void gr_opengl_initialize_workarounds()
 	{
 		GL_enabled_workarounds[OGL_NO_SHADER_VERSION].enabled = true;
 	}
+	
+	if (!stricmp(vendor, "NVIDIA Corporation"))
+	{
+		GL_enabled_workarounds[OGL_NO_SHADER_VERSION].enabled = true;
+	}
 
 	if (Cmdline_opengl_workaround_override != nullptr)
 	{

--- a/code/graphics/gropengl.cpp
+++ b/code/graphics/gropengl.cpp
@@ -1,6 +1,6 @@
 
 
-
+#include <iterator>
 
 
 #include "bmpman/bmpman.h"
@@ -1976,13 +1976,14 @@ static void gr_opengl_initialize_workarounds()
 
 			if (!overrideName.empty())
 			{
-				for (auto& workaround : GL_enabled_workarounds)
+				auto endIter = std::end(GL_enabled_workarounds);
+				for (auto iter = std::begin(GL_enabled_workarounds); iter != endIter; iter = std::next(iter))
 				{
-					if (overrideName == workaround.name)
+					if (overrideName == iter->name)
 					{
 						// Flip the enabled state
-						workaround.enabled = !workaround.enabled;
-						mprintf(("    \"%s\" is now %s\n", workaround.name, workaround.enabled ? "enabled" : "disabled"));
+						iter->enabled = !iter->enabled;
+						mprintf(("    \"%s\" is now %s\n", iter->name, iter->enabled ? "enabled" : "disabled"));
 						break;
 					}
 				}

--- a/code/graphics/gropengl.cpp
+++ b/code/graphics/gropengl.cpp
@@ -1945,6 +1945,11 @@ void opengl_setup_function_pointers()
 
 static void gr_opengl_initialize_workarounds()
 {
+	auto vendor = reinterpret_cast<const char*>(glGetString(GL_VENDOR));
+	if (!stricmp(vendor, "ATI Technologies Inc."))
+	{
+		GL_enabled_workarounds[OGL_NO_SHADER_VERSION] = true;
+	}
 }
 
 bool gr_opengl_init()

--- a/code/graphics/gropengl.cpp
+++ b/code/graphics/gropengl.cpp
@@ -110,6 +110,7 @@ static int GL_minimized = 0;
 
 static GLenum GL_read_format = GL_BGRA;
 
+static bool GL_enabled_workarounds[OGL_MAX_WORKAROUNDS] = {false};
 
 void opengl_go_fullscreen()
 {
@@ -1942,6 +1943,9 @@ void opengl_setup_function_pointers()
 	// *****************************************************************************
 }
 
+static void gr_opengl_initialize_workarounds()
+{
+}
 
 bool gr_opengl_init()
 {
@@ -1990,6 +1994,8 @@ bool gr_opengl_init()
 
 	// initialize the extensions and make sure we aren't missing something that we need
 	opengl_extensions_init();
+
+	gr_opengl_initialize_workarounds();
 
 	// setup the lighting stuff that will get used later
 	opengl_light_init();
@@ -2096,6 +2102,15 @@ bool gr_opengl_init()
         GL_read_format = GL_RGBA;
 
 	return true;
+}
+
+bool opengl_use_workaround(ogl_driver_workaround workaround)
+{
+	int index = static_cast<int>(workaround);
+
+	Assertion(index >= 0 && index < static_cast<int>(OGL_MAX_WORKAROUNDS), "Invalid OpenGL driver workaround index!");
+
+	return GL_enabled_workarounds[index];
 }
 
 DCF(ogl_minimize, "Minimizes opengl")

--- a/code/graphics/gropengl.cpp
+++ b/code/graphics/gropengl.cpp
@@ -1960,6 +1960,40 @@ static void gr_opengl_initialize_workarounds()
 		GL_enabled_workarounds[OGL_NO_SHADER_VERSION].enabled = true;
 	}
 
+	if (Cmdline_opengl_workaround_override != nullptr)
+	{
+		const char* name_begin = Cmdline_opengl_workaround_override;
+		mprintf(("  Using workaround overrides:\n"));
+
+		const char* name_end;
+		do
+		{
+			name_end = strchr(name_begin, ';');
+
+			size_t subsLen = name_end == nullptr ? strlen(name_begin) : static_cast<size_t>(std::distance(name_begin, name_end));
+
+			SCP_string overrideName(name_begin, subsLen);
+
+			if (!overrideName.empty())
+			{
+				for (auto& workaround : GL_enabled_workarounds)
+				{
+					if (overrideName == workaround.name)
+					{
+						// Flip the enabled state
+						workaround.enabled = !workaround.enabled;
+						mprintf(("    \"%s\" is now %s\n", workaround.name, workaround.enabled ? "enabled" : "disabled"));
+						break;
+					}
+				}
+			}
+
+			name_begin = name_end;
+			// Skip the ;
+			std::advance(name_begin, 1);
+		} while(name_end != nullptr);
+	}
+
 #ifndef NDEBUG
 	// Dump a statistic to the log
 	mprintf(("  Using OpenGL driver workarounds:\n"));

--- a/code/graphics/gropengl.h
+++ b/code/graphics/gropengl.h
@@ -656,6 +656,15 @@ bool gr_opengl_init();
 void gr_opengl_cleanup(int minimize=1);
 int opengl_check_for_errors(char *err_at = NULL);
 
+enum ogl_driver_workaround
+{
+	OGL_NO_SHADER_VERSION = 0,
+
+	OGL_MAX_WORKAROUNDS
+};
+
+bool opengl_use_workaround(ogl_driver_workaround workaround);
+
 #ifndef NDEBUG
 #define GL_CHECK_FOR_ERRORS(s)	opengl_check_for_errors((s))
 #else

--- a/code/graphics/gropenglshader.cpp
+++ b/code/graphics/gropenglshader.cpp
@@ -305,10 +305,11 @@ static char *opengl_load_shader(shader_type type_id, char *filename, int flags)
 {
 	SCP_string sflags;
 
-#ifdef __APPLE__
-    sflags += "#version 120\n";
-#endif
-    
+	if (!opengl_use_workaround(OGL_NO_SHADER_VERSION))
+	{
+		sflags += "#version 120\n";
+	}
+
 	if (Use_GLSL >= 4) {
 		sflags += "#define SHADER_MODEL 4\n";
 	}


### PR DESCRIPTION
FSO is currently unusable on Mesa OpenGL drivers because they actually implement the standard properly and generate an error when GLSL language features are used that are not supported by the specified version. FSO current doesn't specify the required GLSL version in the shaders because there are some buggy drivers that don't like it.

To fix both issues I introduced a driver workaround mechanism that checks the opengl vendor or renderer strings and possible sets the workaround flags so the driver can still be supported.

Currently no vendor is detected so I need some people to test this version and report if there are vendors that don't work with `#version` in the shader.