### PR TITLE
Travis CI: Switch to container infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,22 @@
 language: cpp
-sudo: true
-env:
-    global:
-     # The next declaration is the encrypted COVERITY_SCAN_TOKEN, created
-     #   via the "travis encrypt" command using the project repo's public key
-     - secure: "C3wF967ZeliwwP1vC12EMIBOaC568n26Z/cPnwzn317ve59DWH3YSfPZVgvt08GzmaXITGGsJvPB+qxfGoKvQzYE4O1B73q81RpUe5pB3IhF+ThQ91VfQZIRJR5xEGJaLINUlHTTZGX5jxlkVO9wAcauVj/s3b8sQ3dvUZauPvk="
+sudo: false
 addons:
+    apt:
+        packages:
+            - libopenal-dev
+            - libogg-dev
+            - libvorbis-dev
+            - build-essential
+            - automake
+            - autoconf
+            - libsdl1.2-dev
+            - libtheora-dev
+            - libreadline6-dev
+            - libpng12-dev
+            - libjpeg62-dev
+            - liblua5.1-0-dev
+            - libjansson-dev
+            - libtool
     coverity_scan:
         project:
             name: "scp-fs2open/fs2open.github.com"
@@ -15,6 +26,11 @@ addons:
         build_command:   "make -j2"
         # must match TRAVIS_BRANCH check below
         branch_pattern: coverity_scan
+env:
+    global:
+     # The next declaration is the encrypted COVERITY_SCAN_TOKEN, created
+     #   via the "travis encrypt" command using the project repo's public key
+     - secure: "C3wF967ZeliwwP1vC12EMIBOaC568n26Z/cPnwzn317ve59DWH3YSfPZVgvt08GzmaXITGGsJvPB+qxfGoKvQzYE4O1B73q81RpUe5pB3IhF+ThQ91VfQZIRJR5xEGJaLINUlHTTZGX5jxlkVO9wAcauVj/s3b8sQ3dvUZauPvk="
 matrix:
     include:
         # note that gcc needs to be 1st for Coverity

--- a/ci/travis/before_install.sh
+++ b/ci/travis/before_install.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env sh
 
 if [ "$TRAVIS_OS_NAME" = "linux" ]; then
-    sudo apt-get update -qq
+    # Nothing to do here
+    :
 elif [ "$TRAVIS_OS_NAME" = "osx" ]; then
     # Nothing to do here
     :

--- a/ci/travis/install.sh
+++ b/ci/travis/install.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env sh
 
 if [ "$TRAVIS_OS_NAME" = "linux" ]; then
-    sudo apt-get install libopenal-dev libogg-dev libvorbis-dev build-essential automake1.10 autoconf libsdl1.2-dev libtheora-dev libreadline6-dev libpng12-dev libjpeg62-dev liblua5.1-0-dev libjansson-dev libtool
+    # Nothing to do here
+    :
 elif [ "$TRAVIS_OS_NAME" = "osx" ]; then
     gem install xcpretty
 fi

--- a/ci/travis/script.sh
+++ b/ci/travis/script.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env sh
 
 if [ "$TRAVIS_OS_NAME" = "linux" ]; then
-    make -j 2
+    make -j 4
 elif [ "$TRAVIS_OS_NAME" = "osx" ]; then
     cd projects/Xcode4
     xcodebuild ARCHS=$MACOSX_ARCH ONLY_ACTIVE_ARCH=NO -configuration "$CONFIGURATION" | xcpretty -c


### PR DESCRIPTION
Now that all APT packages are supported we can switch to the container based infrastructure. It should be faster and provide more features for future usage (e.g. caching).