### PR TITLE
joy_asynch - Enables SDL's event handling for joystick axes

### DIFF
--- a/code/io/joy-sdl.cpp
+++ b/code/io/joy-sdl.cpp
@@ -138,9 +138,9 @@ namespace
 			// Fake a calibration
 			if (joy_num_sticks > 0) {
 				for (int i = 0; i<JOY_NUM_AXES; i++) {
-					joystick.axis_center[i] = 32768;
-					joystick.axis_min[i] = 0;
-					joystick.axis_max[i] = 65536;
+					joystick.axis_center[i] = JOY_AXIS_CENTER;
+					joystick.axis_min[i] = JOY_AXIS_MIN;
+					joystick.axis_max[i] = JOY_AXIS_MAX;
 				}
 			}
 		}
@@ -240,7 +240,7 @@ void joy_flush()
 	}
 
 	for (i = 0; i < JOY_NUM_AXES; i++) {
-		joy_axes[i] = 32768;
+		joy_axes[i] = JOY_AXIS_CENTER;
 	}
 }
 
@@ -500,7 +500,7 @@ void joy_event(SDL_JoystickID id, uint8_t axis_id, int16_t value)
 		return;
 	}
 
-	joy_axes[axis_id] = value + 32768;
+	joy_axes[axis_id] = value + JOY_AXIS_CENTER;
 }
 
 SDL_Joystick* joy_get_device()
@@ -624,7 +624,7 @@ int joystick_read_raw_axis(int num_axes, int *axis)
 	if (!Joy_inited || sdljoy == nullptr) {
 		// fake a return value so that controlconfig doesn't get freaky with no joystick
 		for (i = 0; i < num_axes; i++) {
-			axis[i] = 32768;
+			axis[i] = JOY_AXIS_CENTER;
 		}
 
 		return 0;
@@ -636,7 +636,7 @@ int joystick_read_raw_axis(int num_axes, int *axis)
 		if (i < joy_num_axes) {
 			axis[i] = joy_axes[i];
 		} else {
-			axis[i] = 32768;
+			axis[i] = JOY_AXIS_CENTER;
 		}
 	}
 	

--- a/code/io/joy-sdl.cpp
+++ b/code/io/joy-sdl.cpp
@@ -500,7 +500,7 @@ void joy_event(SDL_JoystickID id, uint8_t axis_id, int16_t value)
 		return;
 	}
 
-	joy_axes[axis_id] = value;
+	joy_axes[axis_id] = value + 32768;
 }
 
 SDL_Joystick* joy_get_device()

--- a/code/io/joy-sdl.cpp
+++ b/code/io/joy-sdl.cpp
@@ -621,12 +621,12 @@ int joystick_read_raw_axis(int num_axes, int *axis)
 {
 	int i;
 	
-	if (!Joy_inited || sdljoy == nullptr) {
-		// fake a return value so that controlconfig doesn't get freaky with no joystick
-		for (i = 0; i < num_axes; i++) {
-			axis[i] = JOY_AXIS_CENTER;
-		}
+	for (i = 0; i < num_axes; i++) {
+		axis[i] = JOY_AXIS_CENTER;
+	}
 
+	if (!Joy_inited || sdljoy == nullptr) {
+		// no stick available, bail
 		return 0;
 	}
 
@@ -635,8 +635,6 @@ int joystick_read_raw_axis(int num_axes, int *axis)
 	for (i = 0; i < num_axes; i++) {
 		if (i < joy_num_axes) {
 			axis[i] = joy_axes[i];
-		} else {
-			axis[i] = JOY_AXIS_CENTER;
 		}
 	}
 	

--- a/code/io/joy-unix.cpp
+++ b/code/io/joy-unix.cpp
@@ -163,7 +163,7 @@ void joy_event(SDL_JoystickID id, uint8_t axis_id, int16_t value) {
 		return;
 	}
 
-	joy_axes[axis_id] = value;
+	joy_axes[axis_id] = value + 32768;
 }
 
 void joy_flush()

--- a/code/io/joy-unix.cpp
+++ b/code/io/joy-unix.cpp
@@ -48,6 +48,7 @@ int JOYSTICKID1 = 0; 	// DDOI - temporary
 static SDL_Joystick *sdljoy;
 
 joy_button_info joy_buttons[JOY_TOTAL_BUTTONS];
+int joy_axes[JOY_NUM_AXES];
 
 
 void joy_close()
@@ -149,6 +150,22 @@ float joy_down_time(int btn)
 	return rval;
 }
 
+void joy_event(SDL_JoystickID id, uint8_t axis_id, int16_t value) {
+	Assertion((id >= 0), "Invalid joystick id passed during SDL_JOYAXISMOTION event.\n");
+
+	// z64: This'll later be updated to handle multiple controllers. For now, just bail if it isn't our current controller
+	if (id != currentJoystickID) {
+		return;
+	}
+
+	if (axis_id >= JOY_NUM_AXES) {
+		// whoops, can't support this axis
+		return;
+	}
+
+	joy_axes[axis_id] = value;
+}
+
 void joy_flush()
 {
 	int                     i;
@@ -165,6 +182,10 @@ void joy_flush()
 		bi->up_count = 0;
 		bi->down_time = 0;
 		bi->last_down_check = timer_get_milliseconds();
+	}
+
+	for (i = 0; i < JOY_NUM_AXES; i++) {
+		joy_axes[i] = 32768;
 	}
 }
 
@@ -563,7 +584,7 @@ int joystick_read_raw_axis(int num_axes, int *axis)
 
 	for (i = 0; i < num_axes; i++) {
 		if (i < joy_num_axes) {
-			axis[i] = SDL_JoystickGetAxis(sdljoy, i) + 32768;
+			axis[i] = joy_axes[i];
 		} else {
 			axis[i] = 32768;
 		}

--- a/code/io/joy.h
+++ b/code/io/joy.h
@@ -58,4 +58,15 @@ void joy_close();
 void joy_device_changed(int state, int device);
 SDL_Joystick* joy_get_device();
 
+/**
+ * @brief Called asychronously when the OS detects a change on any monitored joystick axis
+ *
+ * @param[in] id      The joystick instance index
+ * @param[in] axis_id The id of the axis that changed
+ * @param[in] value   The new value of the axis
+ */
+void joy_event(SDL_JoystickID id, uint8_t axis_id, int16_t value);
+
+
+
 #endif	/* __JOY_H__ */

--- a/code/io/joy.h
+++ b/code/io/joy.h
@@ -15,6 +15,8 @@
 #include "globalincs/pstypes.h"
 #include "SDL_joystick.h"
 
+#include <climits>
+
 #define JOY_NUM_BUTTONS		32
 #define JOY_NUM_HAT_POS		4
 #define JOY_TOTAL_BUTTONS	(JOY_NUM_BUTTONS + JOY_NUM_HAT_POS)
@@ -29,7 +31,7 @@
 
 const int JOY_AXIS_MIN = 0;
 const int JOY_AXIS_CENTER = -SHRT_MIN;
-const int JOY_AXIS_MAX = (SHRT_MAX - SHRT_MIN) + 1; // +1, since this is always checked to be less. ex: if (x < JOY_AXIS_MAX) {du_stoof();}
+const int JOY_AXIS_MAX = USHRT_MAX + 1; // 1 since this is always checked to be less. ex: if (x < JOY_AXIS_MAX) {du_stoof();}
 
 typedef struct Joy_info {
 	int axis_valid[JOY_NUM_AXES];   // (bool) 0 if invalid axis, 1 if valid

--- a/code/io/joy.h
+++ b/code/io/joy.h
@@ -27,11 +27,15 @@
 
 #define JOY_AXIS_UNDEFINED		-10000
 
+const int JOY_AXIS_MIN = 0;
+const int JOY_AXIS_CENTER = -SHRT_MIN;
+const int JOY_AXIS_MAX = (SHRT_MAX - SHRT_MIN) + 1; // +1, since this is always checked to be less. ex: if (x < JOY_AXIS_MAX) {du_stoof();}
+
 typedef struct Joy_info {
-	int	axis_valid[JOY_NUM_AXES];
-	int	axis_min[JOY_NUM_AXES];
-	int	axis_center[JOY_NUM_AXES];
-	int	axis_max[JOY_NUM_AXES];
+	int axis_valid[JOY_NUM_AXES];   // (bool) 0 if invalid axis, 1 if valid
+	int axis_min[JOY_NUM_AXES];     // minimum value of each axis (default is JOY_AXIS_MIN)
+	int axis_center[JOY_NUM_AXES];  // center value of each axis (default is JOY_AXIS_CENTER)
+	int axis_max[JOY_NUM_AXES];     // maximum value of each axis (default is JOY_AXIS_MAX)
 } Joy_info;
 
 extern int Joy_sensitivity;

--- a/code/osapi/osapi.cpp
+++ b/code/osapi/osapi.cpp
@@ -404,6 +404,10 @@ void os_poll()
 
 			break;
 
+		case SDL_JOYAXISMOTION:
+			joy_event(event.jaxis.which, event.jaxis.axis, event.jaxis.value);
+			break;
+
 		case SDL_JOYHATMOTION:
 			joy_set_hat_state(event.jhat.value);
 			break;


### PR DESCRIPTION
Previously, when a joystick event happened that was related to axis movement, it would be ignored by the os_poll(). Button presses from joystick events were still processed, however.

This PR changes the axis polling system to be asynchronous of frame time, simplifying the joy_read functions to just read from a buffer instead of polling the joystick per frame. This should hopefully be the "fastestest" we can get with SDL when concerning analog inputs.