### PR TITLE
Sound index tweak

### DIFF
--- a/code/hud/hudartillery.cpp
+++ b/code/hud/hudartillery.cpp
@@ -74,7 +74,7 @@ void parse_ssm(const char *filename)
 			// name
 			stuff_string(s.name, F_NAME, NAME_LENGTH);
 			if (*s.name == 0) {
-				sprintf_s(s.name, "SSM " SIZE_T_ARG, Ssm_info.size());
+				sprintf(s.name, "SSM " SIZE_T_ARG, Ssm_info.size());
 				Warning(LOCATION, "SSM entries must have a name!  Assigning \"%s\"\n", s.name);
 			}
 

--- a/code/hud/hudartillery.cpp
+++ b/code/hud/hudartillery.cpp
@@ -75,7 +75,7 @@ void parse_ssm(const char *filename)
 			stuff_string(s.name, F_NAME, NAME_LENGTH);
 			if (*s.name == 0) {
 				sprintf(s.name, "SSM " SIZE_T_ARG, Ssm_info.size());
-				Warning(LOCATION, "SSM entries must have a name!  Assigning \"%s\"\n", s.name);
+				mprintf(("Found an SSM entry without a name.  Assigning \"%s\".\n", s.name));
 			}
 
 			// stuff data

--- a/code/hud/hudartillery.cpp
+++ b/code/hud/hudartillery.cpp
@@ -151,6 +151,7 @@ void parse_ssm(const char *filename)
 				stuff_string(s.message, F_NAME, NAME_LENGTH);
 				s.use_custom_message = true;
 			}
+			s.sound_index = -1;
 			parse_sound("+Alarm Sound:", &s.sound_index, s.name);
 
 			// see if we have a valid weapon

--- a/code/hud/hudartillery.cpp
+++ b/code/hud/hudartillery.cpp
@@ -102,7 +102,7 @@ void parse_ssm(const char *filename)
 				s.warp_time = 4.0f;
 			}
 			s.max_radius = -1.0f;
-			if ((use_min = required_string_either("+Radius:", "+Min Radius:")))
+			if ((use_min = required_string_either("+Radius:", "+Min Radius:")) != 0)
 				required_string("+Min Radius:");
 			else
 				required_string("+Radius:");


### PR DESCRIPTION
This began as a single line, s.sound_index = -1 on line 171.  Then I added parenthesis because PR #291 did not remove the warning in VS 2013.  Then I auto-generated the SSM name since Scroll was using an old-format SSM.tbl that didn't supply a name and as a result thought all of its no-name SSMs were duplicate entries.  Then I decided to clean up the code a bit due to the discussion in PR #289.