### PR TITLE
mjn.mixael's request for per-mission briefing backgrounds

### DIFF
--- a/code/fred2/missionsave.cpp
+++ b/code/fred2/missionsave.cpp
@@ -883,6 +883,20 @@ int CFred_mission_save::save_briefing()
 		required_string_fred("$start_briefing");
 		parse_comments();
 
+		// Goober5000's briefing background stuff (c.f. Phreak's loading screen stuff)
+		if (Format_fs2_open != FSO_FORMAT_RETAIL)
+		{
+			if (strlen(Briefings[nb].background[GR_640]) > 0)
+			{
+				fout("\n$background_640: %s", Briefings[nb].background[GR_640]);
+			}
+
+			if (strlen(Briefings[nb].background[GR_1024]) > 0)
+			{
+				fout("\n$background_1024: %s", Briefings[nb].background[GR_1024]);
+			}
+		}
+
 		Assert(Briefings[nb].num_stages <= MAX_BRIEF_STAGES);
 		required_string_fred("$num_stages:");
 		parse_comments();

--- a/code/mission/missionbriefcommon.h
+++ b/code/mission/missionbriefcommon.h
@@ -183,10 +183,13 @@ class briefing
 public:
 	int			num_stages;
 	brief_stage	stages[MAX_BRIEF_STAGES];
+	char		background[GR_NUM_RESOLUTIONS][MAX_FILENAME_LEN];
 
 	briefing()
 		: num_stages(0)
-	{}
+	{
+		memset(background, GR_NUM_RESOLUTIONS * MAX_FILENAME_LEN * sizeof(char), 0);
+	}
 };
 
 class debriefing

--- a/code/missionui/missionbrief.cpp
+++ b/code/missionui/missionbrief.cpp
@@ -739,10 +739,22 @@ void brief_load_bitmaps()
 //
 void brief_ui_init()
 {
-	if(Game_mode & GM_MULTIPLAYER) {
-		Brief_background_bitmap = bm_load(Brief_multi_filename[gr_screen.res]);
-	} else {
-		Brief_background_bitmap = bm_load(Brief_filename[gr_screen.res]);	
+	Brief_background_bitmap = -1;
+
+	if (*Briefing->background[gr_screen.res]) {
+		Brief_background_bitmap = bm_load(Briefing->background[gr_screen.res]);
+		if (Brief_background_bitmap < 0) {
+			mprintf(("Failed to load custom briefing bitmap %s!\n", Briefing->background[gr_screen.res]));
+		}
+	}
+
+	// if special background failed to load, or if no special background was supplied, load the standard bitmap
+	if (Brief_background_bitmap < 0) {
+		if (Game_mode & GM_MULTIPLAYER) {
+			Brief_background_bitmap = bm_load(Brief_multi_filename[gr_screen.res]);
+		} else {
+			Brief_background_bitmap = bm_load(Brief_filename[gr_screen.res]);
+		}
 	}
 
 	if ( Num_brief_stages <= 0 ){


### PR DESCRIPTION
see http://www.hard-light.net/forums/index.php?topic=90337.0

No FRED support - just add the appropriate text lines in the mission file using a text editor.  However, FRED will still load/save the mission file properly, preserving the mission background lines if they exist.