### PR TITLE
Removes the beam flash impact from appearing when viewing from the hit object's cockpit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -272,3 +272,4 @@ xcuserdata
 #
 documentation/doxygen/*
 !documentation/doxygen/.gitkeep
+/code/sound

--- a/.gitignore
+++ b/.gitignore
@@ -272,4 +272,3 @@ xcuserdata
 #
 documentation/doxygen/*
 !documentation/doxygen/.gitkeep
-/code/sound

--- a/code/weapon/beam.cpp
+++ b/code/weapon/beam.cpp
@@ -2959,6 +2959,10 @@ void beam_handle_collisions(beam *b)
 			}
 		}
 
+		//Don't draw effects if we're in the cockpit of the hit ship
+		if (Viewer_obj == &Objects[target])
+			draw_effects = 0;
+
 		// add lighting
 		if(Use_GLSL < 2)
 			beam_add_light(b, target, 2, &b->f_collisions[idx].cinfo.hit_point_world);


### PR DESCRIPTION
Started a discussion about this here: http://www.hard-light.net/forums/index.php?topic=90329.msg1793720#msg1793720

The three people that replied seemed to like the idea of just never drawing it, but I could make it more complicated if people desire. ;)