### PR TITLE
Fixed the $On Ship Arrive hook code as per issue #334 and PR #333

### DIFF
--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -2370,6 +2370,30 @@ int parse_create_object_sub(p_object *p_objp)
 		}
 	}
 
+	if (Game_mode & GM_IN_MISSION) {
+		int anchor_objnum = -1;
+		if (p_objp->arrival_anchor >= 0) {
+			int shipnum = ship_name_lookup(Parse_names[p_objp->arrival_anchor]);
+
+			// Hopefully we found the ship
+			if (shipnum >= 0) {
+				anchor_objnum = Ships[shipnum].objnum;
+			}
+			// This shouldn't happen, but can if the FREDder was illogical
+			else {
+				Warning(LOCATION, "Arriving ship '%s' refers to an arrival anchor '%s' which does not exist!", p_objp->name, Parse_names[p_objp->arrival_anchor]);
+			}
+		}
+
+		if (anchor_objnum >= 0)
+			Script_system.SetHookObjects(2, "Ship", &Objects[objnum], "Parent", &Objects[anchor_objnum]);
+		else
+			Script_system.SetHookObjects(2, "Ship", &Objects[objnum], "Parent", NULL);
+
+		Script_system.RunCondition(CHA_ONSHIPARRIVE, 0, NULL, &Objects[objnum]);
+		Script_system.RemHookVars(2, "Ship", "Parent");
+	}
+
 	return objnum;
 }
 
@@ -4217,24 +4241,6 @@ int parse_wing_create_ships( wing *wingp, int num_to_create, int force, int spec
 
 		// possibly change the location where these ships arrive based on the wings arrival location
 		mission_set_wing_arrival_location( wingp, num_create_save );
-
-		for (it = 0; it < wingp->current_count; it++ ) {
-			int shipobjnum = Ships[wingp->ship_index[it]].objnum;
-			int anchor_objnum = -1;
-
-			if (wingp->arrival_anchor >= 0) {
-				int parentshipnum = ship_name_lookup(Parse_names[wingp->arrival_anchor]);
-				anchor_objnum = Ships[parentshipnum].objnum;
-			}
-
-			if (anchor_objnum >= 0)
-				Script_system.SetHookObjects(2, "Ship", &Objects[shipobjnum], "Parent", &Objects[anchor_objnum]);
-			else
-				Script_system.SetHookObjects(2, "Ship", &Objects[shipobjnum], "Parent", NULL);
-
-			Script_system.RunCondition(CHA_ONSHIPARRIVE, 0, NULL, &Objects[shipobjnum]);
-			Script_system.RemHookVars(2, "Ship", "Parent");
-		}
 
 		// if in multiplayer (and I am the host) and in the mission, send a wing create command to all
 		// other players
@@ -6683,24 +6689,6 @@ void mission_maybe_make_ship_arrive(p_object *p_objp)
 		mission_parse_support_arrived(objnum);
 	else
 		list_remove(&Ship_arrival_list, p_objp);
-
-	int anchor_objnum = -1;
-	if (p_objp->arrival_anchor >= 0) {
-		int shipnum = ship_name_lookup(Parse_names[p_objp->arrival_anchor]);
-
-		// This shouldn't be happening
-		Assertion(shipnum >= 0 && shipnum < MAX_SHIPS, "Arriving ship '%s' does not exist!", Parse_names[p_objp->arrival_anchor]);
-
-		anchor_objnum = Ships[shipnum].objnum;
-	}
-
-	if (anchor_objnum >= 0)
-		Script_system.SetHookObjects(2, "Ship", &Objects[objnum], "Parent", &Objects[anchor_objnum]);
-	else
-		Script_system.SetHookObjects(2, "Ship", &Objects[objnum], "Parent", NULL);
-
-	Script_system.RunCondition(CHA_ONSHIPARRIVE, 0, NULL, &Objects[objnum]);
-	Script_system.RemHookVars(2, "Ship", "Parent");
 }
 
 // Goober5000


### PR DESCRIPTION
This includes Goober's change from PR #333.

Notes: the reason for the added (Game_mode & GM_IN_MISSION) check is to prevent all ship creation during mission load from triggering the hook, and only limit it to in-mission arrivals. This is likely the original reasoning for why the code was where it was.