### PR TITLE
Improve linux stacktraces

### DIFF
--- a/code/windows_stub/stubs.cpp
+++ b/code/windows_stub/stubs.cpp
@@ -22,7 +22,9 @@
 #endif
 
 #ifdef __linux__
+// Hopefully both these headers are available...
 #include <execinfo.h>
+#include <cxxabi.h>
 #endif
 
 #include "cmdline/cmdline.h"
@@ -78,23 +80,83 @@ int filelength(int fd)
 SCP_string dump_stacktrace()
 {
 #ifdef __linux__
-	const int SIZE = 1024;
-	SCP_stringstream stackstream;
-	char **symbols;
-	int i, numstrings;
-	void *addresses[SIZE];
-
-	numstrings = backtrace(addresses, SIZE);
-	symbols = backtrace_symbols(addresses, numstrings);
-
-	if(symbols != NULL)
+	// The following is adapted from here: https://panthema.net/2008/0901-stacktrace-demangled/
+	const int ADDR_SIZE = 64;
+	void *addresses[ADDR_SIZE];
+	
+	auto numstrings = backtrace(addresses, ADDR_SIZE);
+	
+	if (numstrings == 0)
 	{
-		for(i = 0; i < numstrings; i++)
+		return "No stacktrace available (possibly corrupt)";
+	}
+	
+	auto symbollist = backtrace_symbols(addresses, numstrings);
+	
+	if (symbollist == nullptr)
+	{
+		return "No stacktrace available (possibly corrupt)";
+	}
+	
+	// Demangle c++ function names to a more readable format using the ABI functions
+	// TODO: Maybe add configure time checks to check if the required features are available
+	SCP_stringstream stackstream;
+	
+	size_t funcnamesize = 256;
+	char* funcname = reinterpret_cast<char*>(malloc(funcnamesize));
+	
+	// iterate over the returned symbol lines. skip the first, it is the
+	// address of this function.
+	for (int i = 1; i < numstrings; i++)
+	{
+		char *begin_name = 0, *begin_offset = 0, *end_offset = 0;
+
+		// find parentheses and +address offset surrounding the mangled name:
+		// ./module(function+0x15c) [0x8048a6d]
+		for (char *p = symbollist[i]; *p; ++p)
 		{
-			stackstream << symbols[i] << "\n";
+			if (*p == '(')
+				begin_name = p;
+			else if (*p == '+')
+				begin_offset = p;
+			else if (*p == ')' && begin_offset) {
+				end_offset = p;
+				break;
+			}
+		}
+
+		if (begin_name && begin_offset && end_offset && begin_name < begin_offset)
+		{
+			*begin_name++ = '\0';
+			*begin_offset++ = '\0';
+			*end_offset = '\0';
+
+			// mangled name is now in [begin_name, begin_offset) and caller
+			// offset in [begin_offset, end_offset). now apply
+			// __cxa_demangle():
+
+			int status;
+			char* ret = abi::__cxa_demangle(begin_name, funcname, &funcnamesize, &status);
+			
+			if (status == 0) {
+				funcname = ret; // use possibly realloc()-ed string
+				stackstream << "  " << symbollist[i] << " : " << funcname << "+" << begin_offset << "\n";
+			}
+			else {
+				// demangling failed. Output function name as a C function with
+				// no arguments.
+				stackstream << "  " << symbollist[i] << " : " << begin_name << "()+" << begin_offset << "\n";
+			}
+		}
+		else
+		{
+			// couldn't parse the line? print the whole line.
+			stackstream << "  " << symbollist[i] << "\n";
 		}
 	}
-	free(symbols);
+
+	free(funcname);
+	free(symbollist);
 
 	return stackstream.str();
 #else


### PR DESCRIPTION
The new version of `dump_stacktrace` uses abi::__cxa_demangle to determine the real name of a C++ function instead of printing the mangled name to the stacktrace.