### PR TITLE
Workaround for freezing when exiting abnormally

### DIFF
--- a/code/graphics/2d.cpp
+++ b/code/graphics/2d.cpp
@@ -641,7 +641,7 @@ void gr_close()
 
 	switch (gr_screen.mode) {
 		case GR_OPENGL:
-			gr_opengl_cleanup();
+			gr_opengl_cleanup(true);
 			break;
 	
 		case GR_STUB:
@@ -904,7 +904,7 @@ bool gr_init(int d_mode, int d_width, int d_height, int d_depth)
 	if (Gr_inited) {
 		switch (gr_screen.mode) {
 			case GR_OPENGL:
-				gr_opengl_cleanup();
+				gr_opengl_cleanup(false);
 				break;
 			
 			case GR_STUB:

--- a/code/graphics/gropengl.cpp
+++ b/code/graphics/gropengl.cpp
@@ -450,13 +450,13 @@ void gr_opengl_print_screen(const char *filename)
 	}
 }
 
-void gr_opengl_cleanup(int minimize)
+void gr_opengl_cleanup(bool closing, int minimize)
 {
 	if ( !GL_initted ) {
 		return;
 	}
 
-	if ( !Fred_running ) {
+	if ( !closing && !Fred_running ) {
 		gr_reset_clip();
 		gr_clear();
 		gr_flip();
@@ -1560,7 +1560,7 @@ bool gr_opengl_init()
 		atexit(opengl_close);
 
 	if (GL_initted) {
-		gr_opengl_cleanup();
+		gr_opengl_cleanup(false);
 		GL_initted = false;
 	}
 

--- a/code/graphics/gropengl.h
+++ b/code/graphics/gropengl.h
@@ -651,7 +651,7 @@ typedef void (APIENTRYP PFNGLMULTIDRAWELEMENTSBASEVERTEXPROC) (GLenum mode, cons
 const ubyte GL_zero_3ub[3] = { 0, 0, 0 };
 
 bool gr_opengl_init();
-void gr_opengl_cleanup(int minimize=1);
+void gr_opengl_cleanup(bool closing, int minimize=1);
 int opengl_check_for_errors(char *err_at = NULL);
 
 #ifndef NDEBUG


### PR DESCRIPTION
When using the Linux AMD proprietary driver FSO gets stuck when trying to swap buffers when performing an abnormal shutdown (e.g. when exiting via a dialog). This skips the gr_flip calls when we are going to close as it doesn't matter anyway.