### PR TITLE
Fix Mantis #3173.

### DIFF
--- a/code/weapon/beam.cpp
+++ b/code/weapon/beam.cpp
@@ -2996,11 +2996,6 @@ void beam_handle_collisions(beam *b)
             r_coll[r_coll_count].c_stamp = timestamp(fl2i(delay_time));
 		}
 
-		// if no damage - don't even indicate it has been hit
-		if(wi->damage <= 0){
-			do_damage = 0;
-		}
-
 		// increment collision count
 		r_coll_count++;		
 
@@ -3140,7 +3135,7 @@ void beam_handle_collisions(beam *b)
 			}
 		}
 
-		if(!physics_paused){
+		if(do_damage && !physics_paused){
 
 			switch(Objects[target].type){
 			case OBJ_DEBRIS:
@@ -3475,6 +3470,9 @@ float beam_get_ship_damage(beam *b, object *objp)
 
 	weapon_info *wip = &Weapon_info[b->weapon_info_index];
 
+	if (wip->damage <= 0)
+		return 0.0f;	// Not much point in calculating the attenuation if the beam doesn't hurt in the first place.
+
 	float attenuation = 1.0f;
 
 	if ((b->damage_threshold >= 0.0f) && (b->damage_threshold < 1.0f)) {
@@ -3493,7 +3491,7 @@ float beam_get_ship_damage(beam *b, object *objp)
 		damage = The_mission.ai_profile->beam_friendly_damage_cap[Game_skill_level] * attenuation;
 	} else {
 		// normal damage
-		damage = Weapon_info[b->weapon_info_index].damage * attenuation;
+		damage = wip->damage * attenuation;
 	}
 
 	return damage;


### PR DESCRIPTION
So in PR #294, I made 0-damage beams call the damage-applying code so they could be used to TAG things. The way I did this was I removed the `do_damage` check from the conditional before the switch block that handles beams damaging things.

This was a horrible mistake.

`do_damage` was set to 0 if a beam dealt `<= 0` damage, but before that, it would only be set to 1 if the damage timestamp had elapsed. Removing the `do_damage` check caused damaging beams to deal damage every frame, which obviously will cause a substantial damage increase (well, unless your framerate was so low that beams would deal less than their full damage anyway).

This commit restores the `do_damage` check, and simply avoids setting `do_damage` to 0 if the beam isn't a damaging one (the `<= 0` check is moved to `beam_get_ship_damage()` instead, so we can skip the attenuation calculation if we're not going to deal damage in the first place).

([Mantis link](http://scp.indiegames.us/mantis/view.php?id=3173))