### PR TITLE
Refactor bm_set_render_target() return type to bool, thereby removing a TODO

### DIFF
--- a/code/bmpman/bmpman.cpp
+++ b/code/bmpman/bmpman.cpp
@@ -2488,7 +2488,7 @@ void bm_set_low_mem(int mode) {
 	Bm_low_mem = mode;
 }
 
-int bm_set_render_target(int handle, int face) {
+bool bm_set_render_target(int handle, int face) {
 	int n = handle % MAX_BITMAPS;
 
 	if (n >= 0) {
@@ -2497,7 +2497,7 @@ int bm_set_render_target(int handle, int face) {
 		if ((bm_bitmaps[n].type != BM_TYPE_RENDER_TARGET_STATIC) && (bm_bitmaps[n].type != BM_TYPE_RENDER_TARGET_DYNAMIC)) {
 			// odds are that someone passed a normal texture created with bm_load()
 			mprintf(("Trying to set invalid bitmap (slot: %i, handle: %i) as render target!\n", n, handle));
-			return 0;
+			return false;
 		}
 	}
 
@@ -2562,10 +2562,10 @@ int bm_set_render_target(int handle, int face) {
 			opengl_setup_viewport();
 		}
 
-		return 1;
+		return true;
 	}
 
-	return 0;
+	return false;
 }
 
 int bm_unload(int handle, int clear_render_targets, bool nodebug) {

--- a/code/bmpman/bmpman.h
+++ b/code/bmpman/bmpman.h
@@ -651,12 +651,10 @@ int bm_is_render_target(int handle);
 /**
  * @brief (GR function) Calls gr_bm_set_render target for the given bitmap indexed by handle
  *
- * @returns 1 if successful, or
- * @returns 0 if unsuccessful
- *
- * @todo retval should be a bool
+ * @returns true if successful, or
+ * @returns false if unsuccessful
  */
-int bm_set_render_target(int handle, int face = -1);
+bool bm_set_render_target(int handle, int face = -1);
 
 /**
  * @brief Loads and parses an .EFF

--- a/code/parse/lua.cpp
+++ b/code/parse/lua.cpp
@@ -13262,9 +13262,7 @@ ADE_FUNC(setTarget, l_Graphics, "[texture Texture]",
 	int idx = -1;
 	ade_get_args(L, "|o", l_Texture.Get(&idx));
 
-	int i = bm_set_render_target(idx, 0);
-
-	return ade_set_args(L, "b", i ? true : false);
+	return ade_set_args(L, "b", bm_set_render_target(idx, 0));
 }
 
 ADE_FUNC(setCamera, l_Graphics, "[camera handle Camera]", "Sets current camera, or resets camera if none specified", "boolean", "true if successful, false or nil otherwise")


### PR DESCRIPTION
A very simple refactor patch, which addresses a TODO comment in the code/documentation.