### PR TITLE
Stop calling popup() during gr_init().

### DIFF
--- a/code/graphics/gropenglextension.cpp
+++ b/code/graphics/gropenglextension.cpp
@@ -434,9 +434,6 @@ void opengl_extensions_init()
 	if ( !(Is_Extension_Enabled(OGL_EXT_GEOMETRY_SHADER4) && Is_Extension_Enabled(OGL_EXT_TEXTURE_ARRAY) && Is_Extension_Enabled(OGL_ARB_DRAW_ELEMENTS_BASE_VERTEX)) ) {
 		Cmdline_shadow_quality = 0;
 		mprintf(("  No hardware support for shadow mapping. Shadows will be disabled. \n"));
-#ifdef NDEBUG
-		popup(0, 1, POPUP_OK, "No hardware support for shadow mapping. Shadows will be disabled.\n");
-#endif
 	}
 
 	if ( !Cmdline_noglsl && Is_Extension_Enabled(OGL_ARB_SHADER_OBJECTS) && Is_Extension_Enabled(OGL_ARB_FRAGMENT_SHADER)
@@ -463,9 +460,6 @@ void opengl_extensions_init()
 		else if (ver < 110) {
 			Use_GLSL = 0;
 			mprintf(("  OpenGL Shading Language version %s is not sufficient to use GLSL mode in FSO. Defaulting to fixed-function renderer.\n", glGetString(GL_SHADING_LANGUAGE_VERSION_ARB) ));
-#ifdef NDEBUG
-			popup(PF_USE_AFFIRMATIVE_ICON, 1, POPUP_OK, "GLSL support not available on this GPU. Disabling shader support and defaulting to fixed-function rendering.\n");
-#endif
 		}
 	}
 


### PR DESCRIPTION
While investigating issue #345, it was discovered that `popup()` is getting called during `gr_init()` (and since this is before `gamesnd_parse_soundstbl()` gets called, the eventual call to `gamesnd_play_iface()` results in reading invalid memory). Given that this is basically relying on a feature in the middle of the function initializing it, and given that both lines are preceded by `mprintf()` calls saying basically the same thing, it seems the best solution is to just remove the troublesome lines altogether.