### PR TITLE
Reduce bmpslot usage by headz

### DIFF
--- a/code/graphics/generic.cpp
+++ b/code/graphics/generic.cpp
@@ -335,6 +335,11 @@ void generic_render_eff_stream(generic_anim *ga)
 				gr_update_texture(ga->bitmap_id, bpp, (ubyte*)next_frame_bmp->data, ga->width, ga->height);
 			bm_unlock(ga->eff.next_frame);
 			bm_unload(ga->eff.next_frame, 0, true);
+			if (ga->current_frame == ga->num_frames-1)
+			{
+				snprintf(frame_name, MAX_FILENAME_LEN, "%s_0001", ga->filename);
+				bm_reload(ga->eff.next_frame, frame_name);
+			}
 		}
 	#ifdef TIMER
 		mprintf(("end: %d\n", timer_get_fixed_seconds() - start_time));

--- a/code/mission/missionmessage.cpp
+++ b/code/mission/missionmessage.cpp
@@ -316,7 +316,8 @@ int add_avi( char *avi_name )
 	strcpy_s( extra.name, avi_name );
 	strcpy_s( extra.anim_data.filename, avi_name);
 	extra.num = -1;
-	generic_anim_load(&extra.anim_data);
+	generic_anim_load(&extra.anim_data);   // load only to validate the anim
+	generic_anim_unload(&extra.anim_data); // unload to not waste bmpman slots
 	Message_avis.push_back(extra); 
 	Num_message_avis++;
 	return ((int)Message_avis.size() - 1);


### PR DESCRIPTION
As headani's (both ANI & EFF) are streamed there's no need to have
the anim data in bmpman, the streaming code does that with only two
slots, rather than one slot per ani frame
Also fix a "leak" in the streaming code use of bmpman slots. i.e. each
time a message was played another slot would be used & not released