### PR TITLE
Make script_state::UnloadImages() call bm_release instead of bm_unload.

### DIFF
--- a/code/parse/scripting.cpp
+++ b/code/parse/scripting.cpp
@@ -839,7 +839,7 @@ void script_state::UnloadImages()
 {
 	for(int i = 0; i < (int)ScriptImages.size(); i++)
 	{
-		bm_unload(ScriptImages[i].handle);
+		bm_release(ScriptImages[i].handle);
 	}
 
 	ScriptImages.clear();


### PR DESCRIPTION
Should result in reduced BMPMAN slot usage with certain scripts as `bm_unload()` unloads the image data but holds on to the slot, while `bm_release()` releases the slot.