### PR TITLE
Per-mission UI backgrounds

### DIFF
--- a/code/fred2/FictionViewerDlg.cpp
+++ b/code/fred2/FictionViewerDlg.cpp
@@ -63,6 +63,7 @@ BOOL FictionViewerDlg::OnInitDialog()
 	m_story_file = _T(fiction_file());
 	m_font_file = _T(fiction_font());
 	m_voice_file = _T(fiction_voice());
+	m_fiction_ui = fiction_ui_index();
 	m_fiction_music = Mission_music[SCORE_FICTION_VIEWER] + 1;
 
 	CDialog::OnInitDialog();
@@ -76,7 +77,7 @@ void FictionViewerDlg::OnOK()
 
 	// load it up
 	fiction_viewer_reset();
-	fiction_viewer_load((const char *)(LPCSTR)m_story_file, (const char *)(LPCSTR)m_font_file, (const char *)(LPCSTR)m_voice_file);
+	fiction_viewer_load((const char *)(LPCSTR)m_story_file, (const char *)(LPCSTR)m_font_file, (const char *)(LPCSTR)m_voice_file, m_fiction_ui);
 
 	// set music
 	Mission_music[SCORE_FICTION_VIEWER] = m_fiction_music - 1;

--- a/code/fred2/FictionViewerDlg.cpp
+++ b/code/fred2/FictionViewerDlg.cpp
@@ -60,10 +60,12 @@ BOOL FictionViewerDlg::OnInitDialog()
 	}
 
 	// init variables
+	m_fiction_background_640 = _T(fiction_background(GR_640));
+	m_fiction_background_1024 = _T(fiction_background(GR_1024));
+	m_fiction_ui = fiction_ui_index();
 	m_story_file = _T(fiction_file());
 	m_font_file = _T(fiction_font());
 	m_voice_file = _T(fiction_voice());
-	m_fiction_ui = fiction_ui_index();
 	m_fiction_music = Mission_music[SCORE_FICTION_VIEWER] + 1;
 
 	CDialog::OnInitDialog();
@@ -77,7 +79,7 @@ void FictionViewerDlg::OnOK()
 
 	// load it up
 	fiction_viewer_reset();
-	fiction_viewer_load((const char *)(LPCSTR)m_story_file, (const char *)(LPCSTR)m_font_file, (const char *)(LPCSTR)m_voice_file, m_fiction_ui);
+	fiction_viewer_load((const char *)(LPCSTR)m_fiction_background_640, (const char *)(LPCSTR)m_fiction_background_1024, m_fiction_ui, (const char *)(LPCSTR)m_story_file, (const char *)(LPCSTR)m_font_file, (const char *)(LPCSTR)m_voice_file);
 
 	// set music
 	Mission_music[SCORE_FICTION_VIEWER] = m_fiction_music - 1;

--- a/code/fred2/FictionViewerDlg.h
+++ b/code/fred2/FictionViewerDlg.h
@@ -25,6 +25,7 @@ public:
 	CString	m_story_file;
 	CString	m_font_file;
 	CString m_voice_file;
+	int		m_fiction_ui;
 	int		m_fiction_music;
 	//}}AFX_DATA
 

--- a/code/fred2/FictionViewerDlg.h
+++ b/code/fred2/FictionViewerDlg.h
@@ -22,10 +22,12 @@ public:
 // Dialog Data
 	//{{AFX_DATA(FictionViewerDlg)
 	enum { IDD = IDD_FICTION_VIEWER };
+	CString	m_fiction_background_640;
+	CString	m_fiction_background_1024;
+	int		m_fiction_ui;
 	CString	m_story_file;
 	CString	m_font_file;
 	CString m_voice_file;
-	int		m_fiction_ui;
 	int		m_fiction_music;
 	//}}AFX_DATA
 

--- a/code/fred2/missionsave.cpp
+++ b/code/fred2/missionsave.cpp
@@ -807,6 +807,17 @@ int CFred_mission_save::save_fiction()
 			}
 			else
 				optional_string_fred("$Voice:");
+
+			// save UI
+			const char *ui_name = fiction_ui_name();
+			if (ui_name)
+			{
+				if (optional_string_fred("$UI:"))
+					parse_comments();
+				else
+					fout("\n$UI:");
+				fout(" %s", ui_name);
+			}
 		}
 		else
 		{

--- a/code/fred2/missionsave.cpp
+++ b/code/fred2/missionsave.cpp
@@ -830,6 +830,30 @@ int CFred_mission_save::save_cmd_brief()
 	if (The_mission.game_type & MISSION_TYPE_MULTI)
 		return err;  // no command briefings allowed in multiplayer missions.
 
+		// Yarn's command briefing background stuff, based on Goober5000's briefing background stuff
+		if (Format_fs2_open != FSO_FORMAT_RETAIL)
+		{
+			bool background_written = false;
+
+			if (strlen(Cur_cmd_brief->background[GR_640]) > 0)
+			{
+				if (!background_written) {
+					fout("\n");
+				}
+				fout("\n$Background 640: %s", Cur_cmd_brief->background[GR_640]);
+				background_written = true;
+			}
+
+			if (strlen(Cur_cmd_brief->background[GR_1024]) > 0)
+			{
+				if (!background_written) {
+					fout("\n");
+				}
+				fout("\n$Background 1024: %s", Cur_cmd_brief->background[GR_1024]);
+				background_written = true;
+			}
+		}
+
 	for (stage=0; stage<Cur_cmd_brief->num_stages; stage++) {
 		required_string_fred("$Stage Text:");
 		parse_comments(2);

--- a/code/fred2/missionsave.cpp
+++ b/code/fred2/missionsave.cpp
@@ -1118,21 +1118,21 @@ int CFred_mission_save::save_debriefing()
 		{
 			bool background_written = false;
 
-			if (strlen(Debriefing[j].background[GR_640]) > 0)
+			if (strlen(Debriefing->background[GR_640]) > 0)
 			{
 				if (!background_written) {
 					fout("\n");
 				}
-				fout("\n$Background 640: %s", Debriefing[j].background[GR_640]);
+				fout("\n$Background 640: %s", Debriefing->background[GR_640]);
 				background_written = true;
 			}
 
-			if (strlen(Debriefing[j].background[GR_1024]) > 0)
+			if (strlen(Debriefing->background[GR_1024]) > 0)
 			{
 				if (!background_written) {
 					fout("\n");
 				}
-				fout("\n$Background 1024: %s", Debriefing[j].background[GR_1024]);
+				fout("\n$Background 1024: %s", Debriefing->background[GR_1024]);
 				background_written = true;
 			}
 		}

--- a/code/fred2/missionsave.cpp
+++ b/code/fred2/missionsave.cpp
@@ -767,6 +767,20 @@ int CFred_mission_save::save_fiction()
 
 			fout("\n");
 
+			// save background
+			save_custom_bitmap("$Background 640:", "$Background 1024:", fiction_background(GR_640), fiction_background(GR_1024));
+
+			// save UI
+			const char *ui_name = fiction_ui_name();
+			if (ui_name)
+			{
+				if (optional_string_fred("$UI:"))
+					parse_comments();
+				else
+					fout("\n$UI:");
+				fout(" %s", ui_name);
+			}
+
 			// save file
 			required_string_fred("$File:");
 			parse_comments();
@@ -795,17 +809,6 @@ int CFred_mission_save::save_fiction()
 			}
 			else
 				optional_string_fred("$Voice:");
-
-			// save UI
-			const char *ui_name = fiction_ui_name();
-			if (ui_name)
-			{
-				if (optional_string_fred("$UI:"))
-					parse_comments();
-				else
-					fout("\n$UI:");
-				fout(" %s", ui_name);
-			}
 		}
 		else
 		{

--- a/code/fred2/missionsave.cpp
+++ b/code/fred2/missionsave.cpp
@@ -1089,6 +1089,30 @@ int CFred_mission_save::save_debriefing()
 		required_string_fred("#Debriefing_info");
 		parse_comments(2);
 
+		// Yarn's debriefing background stuff, based on Goober5000's briefing background stuff
+		if (Format_fs2_open != FSO_FORMAT_RETAIL)
+		{
+			bool background_written = false;
+
+			if (strlen(Debriefing[j].background[GR_640]) > 0)
+			{
+				if (!background_written) {
+					fout("\n");
+				}
+				fout("\n$Background 640: %s", Debriefing[j].background[GR_640]);
+				background_written = true;
+			}
+
+			if (strlen(Debriefing[j].background[GR_1024]) > 0)
+			{
+				if (!background_written) {
+					fout("\n");
+				}
+				fout("\n$Background 1024: %s", Debriefing[j].background[GR_1024]);
+				background_written = true;
+			}
+		}
+
 		required_string_fred("$Num stages:");
 		parse_comments(2);
 		fout(" %d", Debriefing->num_stages);

--- a/code/fred2/missionsave.cpp
+++ b/code/fred2/missionsave.cpp
@@ -895,6 +895,16 @@ int CFred_mission_save::save_briefing()
 			{
 				fout("\n$background_1024: %s", Briefings[nb].background[GR_1024]);
 			}
+			
+			if (strlen(Briefings[nb].ship_select_background[GR_640]) > 0)
+			{
+				fout("\n$ship_select_background_640: %s", Briefings[nb].ship_select_background[GR_640]);
+			}
+
+			if (strlen(Briefings[nb].ship_select_background[GR_1024]) > 0)
+			{
+				fout("\n$ship_select_background_1024: %s", Briefings[nb].ship_select_background[GR_1024]);
+			}
 		}
 
 		Assert(Briefings[nb].num_stages <= MAX_BRIEF_STAGES);

--- a/code/fred2/missionsave.cpp
+++ b/code/fred2/missionsave.cpp
@@ -888,12 +888,12 @@ int CFred_mission_save::save_briefing()
 		{
 			if (strlen(Briefings[nb].background[GR_640]) > 0)
 			{
-				fout("\n$background_640: %s", Briefings[nb].background[GR_640]);
+				fout("\n$briefing_background_640: %s", Briefings[nb].background[GR_640]);
 			}
 
 			if (strlen(Briefings[nb].background[GR_1024]) > 0)
 			{
-				fout("\n$background_1024: %s", Briefings[nb].background[GR_1024]);
+				fout("\n$briefing_background_1024: %s", Briefings[nb].background[GR_1024]);
 			}
 			
 			if (strlen(Briefings[nb].ship_select_background[GR_640]) > 0)

--- a/code/fred2/missionsave.cpp
+++ b/code/fred2/missionsave.cpp
@@ -535,19 +535,7 @@ int CFred_mission_save::save_mission_info()
 		}
 	}
 
-	// Phreak's loading screen stuff
-	if (Format_fs2_open != FSO_FORMAT_RETAIL) //-V581
-	{
-		if (strlen(The_mission.loading_screen[GR_640]) > 0) //-V805
-		{
-			fout("\n\n$Load Screen 640:\t%s",The_mission.loading_screen[GR_640]);
-		}
-
-		if (strlen(The_mission.loading_screen[GR_1024]) > 0) //-V805
-		{
-			fout("\n$Load Screen 1024:\t%s",The_mission.loading_screen[GR_1024]);
-		}
-	}
+	save_custom_bitmap("$Load Screen 640:", "$Load Screen 1024:", The_mission.loading_screen[GR_640], The_mission.loading_screen[GR_1024], 1);
 
 	// Phreak's skybox stuff
 	if (strlen(The_mission.skybox_model) > 0) //-V805
@@ -841,29 +829,7 @@ int CFred_mission_save::save_cmd_brief()
 	if (The_mission.game_type & MISSION_TYPE_MULTI)
 		return err;  // no command briefings allowed in multiplayer missions.
 
-		// Yarn's command briefing background stuff, based on Goober5000's briefing background stuff
-		if (Format_fs2_open != FSO_FORMAT_RETAIL)
-		{
-			bool background_written = false;
-
-			if (strlen(Cur_cmd_brief->background[GR_640]) > 0)
-			{
-				if (!background_written) {
-					fout("\n");
-				}
-				fout("\n$Background 640: %s", Cur_cmd_brief->background[GR_640]);
-				background_written = true;
-			}
-
-			if (strlen(Cur_cmd_brief->background[GR_1024]) > 0)
-			{
-				if (!background_written) {
-					fout("\n");
-				}
-				fout("\n$Background 1024: %s", Cur_cmd_brief->background[GR_1024]);
-				background_written = true;
-			}
-		}
+	save_custom_bitmap("$Background 640:", "$Background 1024:", Cur_cmd_brief->background[GR_640], Cur_cmd_brief->background[GR_1024], 1);
 
 	for (stage=0; stage<Cur_cmd_brief->num_stages; stage++) {
 		required_string_fred("$Stage Text:");
@@ -918,39 +884,9 @@ int CFred_mission_save::save_briefing()
 		required_string_fred("$start_briefing");
 		parse_comments();
 
-		// Goober5000's briefing background stuff (c.f. Phreak's loading screen stuff)
-		if (Format_fs2_open != FSO_FORMAT_RETAIL)
-		{
-			if (strlen(Briefings[nb].background[GR_640]) > 0)
-			{
-				fout("\n$briefing_background_640: %s", Briefings[nb].background[GR_640]);
-			}
-
-			if (strlen(Briefings[nb].background[GR_1024]) > 0)
-			{
-				fout("\n$briefing_background_1024: %s", Briefings[nb].background[GR_1024]);
-			}
-			
-			if (strlen(Briefings[nb].ship_select_background[GR_640]) > 0)
-			{
-				fout("\n$ship_select_background_640: %s", Briefings[nb].ship_select_background[GR_640]);
-			}
-
-			if (strlen(Briefings[nb].ship_select_background[GR_1024]) > 0)
-			{
-				fout("\n$ship_select_background_1024: %s", Briefings[nb].ship_select_background[GR_1024]);
-			}
-			
-			if (strlen(Briefings[nb].weapon_select_background[GR_640]) > 0)
-			{
-				fout("\n$weapon_select_background_640: %s", Briefings[nb].weapon_select_background[GR_640]);
-			}
-
-			if (strlen(Briefings[nb].weapon_select_background[GR_1024]) > 0)
-			{
-				fout("\n$weapon_select_background_1024: %s", Briefings[nb].weapon_select_background[GR_1024]);
-			}
-		}
+		save_custom_bitmap("$briefing_background_640:", "$briefing_background_1024:", Briefings[nb].background[GR_640], Briefings[nb].background[GR_1024]);
+		save_custom_bitmap("$ship_select_background_640:", "$ship_select_background_1024:", Briefings[nb].ship_select_background[GR_640], Briefings[nb].ship_select_background[GR_1024]);
+		save_custom_bitmap("$weapon_select_background_640:", "$weapon_select_background_1024:", Briefings[nb].weapon_select_background[GR_640], Briefings[nb].weapon_select_background[GR_1024]);
 
 		Assert(Briefings[nb].num_stages <= MAX_BRIEF_STAGES);
 		required_string_fred("$num_stages:");
@@ -1124,29 +1060,7 @@ int CFred_mission_save::save_debriefing()
 		required_string_fred("#Debriefing_info");
 		parse_comments(2);
 
-		// Yarn's debriefing background stuff, based on Goober5000's briefing background stuff
-		if (Format_fs2_open != FSO_FORMAT_RETAIL)
-		{
-			bool background_written = false;
-
-			if (strlen(Debriefing->background[GR_640]) > 0)
-			{
-				if (!background_written) {
-					fout("\n");
-				}
-				fout("\n$Background 640: %s", Debriefing->background[GR_640]);
-				background_written = true;
-			}
-
-			if (strlen(Debriefing->background[GR_1024]) > 0)
-			{
-				if (!background_written) {
-					fout("\n");
-				}
-				fout("\n$Background 1024: %s", Debriefing->background[GR_1024]);
-				background_written = true;
-			}
-		}
+		save_custom_bitmap("$Background 640:", "$Background 1024:", Debriefing->background[GR_640], Debriefing->background[GR_1024], 1);
 
 		required_string_fred("$Num stages:");
 		parse_comments(2);
@@ -3974,6 +3888,28 @@ int CFred_mission_save::save_music()
 	fso_comment_pop(true);
 
 	return err;
+}
+
+void CFred_mission_save::save_custom_bitmap(const char *expected_string_640, const char *expected_string_1024, const char *string_field_640, const char *string_field_1024, int blank_lines)
+{
+	if (Format_fs2_open != FSO_FORMAT_RETAIL)
+	{
+		if ((*string_field_640 != '\0') || (*string_field_1024 != '\0'))
+		{
+			while (blank_lines-- > 0)
+				fout("\n");
+		}
+
+		if (*string_field_640 != '\0')
+		{
+			fout("\n%s %s", expected_string_640, string_field_640);
+		}
+
+		if (*string_field_1024 != '\0')
+		{
+			fout("\n%s %s", expected_string_1024, string_field_1024);
+		}
+	}
 }
 
 void CFred_mission_save::save_turret_info(ship_subsys *ptr, int ship)

--- a/code/fred2/missionsave.cpp
+++ b/code/fred2/missionsave.cpp
@@ -905,6 +905,16 @@ int CFred_mission_save::save_briefing()
 			{
 				fout("\n$ship_select_background_1024: %s", Briefings[nb].ship_select_background[GR_1024]);
 			}
+			
+			if (strlen(Briefings[nb].weapon_select_background[GR_640]) > 0)
+			{
+				fout("\n$weapon_select_background_640: %s", Briefings[nb].weapon_select_background[GR_640]);
+			}
+
+			if (strlen(Briefings[nb].weapon_select_background[GR_1024]) > 0)
+			{
+				fout("\n$weapon_select_background_1024: %s", Briefings[nb].weapon_select_background[GR_1024]);
+			}
 		}
 
 		Assert(Briefings[nb].num_stages <= MAX_BRIEF_STAGES);

--- a/code/fred2/missionsave.h
+++ b/code/fred2/missionsave.h
@@ -56,6 +56,8 @@ private:
 	int save_music();
 	void save_campaign_sexp(int node, int link);
 	void save_single_dock_instance(ship *shipp, dock_instance *dock_ptr);
+	
+	void save_custom_bitmap(const char *expected_string_640, const char *expected_string_1024, const char *string_field_640, const char *string_field_1024, int blank_lines = 0);
 
 	void convert_special_tags_to_retail(char *text, int max_len);
 	void convert_special_tags_to_retail(SCP_string &text);

--- a/code/mission/missionbriefcommon.h
+++ b/code/mission/missionbriefcommon.h
@@ -185,6 +185,7 @@ public:
 	brief_stage	stages[MAX_BRIEF_STAGES];
 	char		background[GR_NUM_RESOLUTIONS][MAX_FILENAME_LEN];
 	char		ship_select_background[GR_NUM_RESOLUTIONS][MAX_FILENAME_LEN];
+	char		weapon_select_background[GR_NUM_RESOLUTIONS][MAX_FILENAME_LEN];
 
 	briefing()
 		: num_stages(0)

--- a/code/mission/missionbriefcommon.h
+++ b/code/mission/missionbriefcommon.h
@@ -199,6 +199,7 @@ class debriefing
 public:
 	int				num_stages;
 	debrief_stage	stages[MAX_DEBRIEF_STAGES];
+	char			background[GR_NUM_RESOLUTIONS][MAX_FILENAME_LEN];
 
 	debriefing()
 		: num_stages(0)

--- a/code/mission/missionbriefcommon.h
+++ b/code/mission/missionbriefcommon.h
@@ -184,6 +184,7 @@ public:
 	int			num_stages;
 	brief_stage	stages[MAX_BRIEF_STAGES];
 	char		background[GR_NUM_RESOLUTIONS][MAX_FILENAME_LEN];
+	char		ship_select_background[GR_NUM_RESOLUTIONS][MAX_FILENAME_LEN];
 
 	briefing()
 		: num_stages(0)

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -1358,6 +1358,7 @@ void parse_briefing(mission *pm, int flags)
 		// Goober5000 - use the same code as for mission loading screens
 		parse_custom_bitmap("$background_640:", "$background_1024:", bp->background[GR_640], bp->background[GR_1024]);
 		parse_custom_bitmap("$ship_select_background_640:", "$ship_select_background_1024:", bp->ship_select_background[GR_640], bp->ship_select_background[GR_1024]);
+		parse_custom_bitmap("$weapon_select_background_640:", "$weapon_select_background_1024:", bp->weapon_select_background[GR_640], bp->weapon_select_background[GR_1024]);
 
 		required_string("$num_stages:");
 		stuff_int(&bp->num_stages);

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -1262,15 +1262,32 @@ done_briefing_music:
  */
 void parse_fiction(mission *pm)
 {
+	char background_640[MAX_FILENAME_LEN];
+	char background_1024[MAX_FILENAME_LEN];
+	int ui_index = -1;
 	char filename[MAX_FILENAME_LEN];
 	char font_filename[MAX_FILENAME_LEN];
 	char voice_filename[MAX_FILENAME_LEN];
-	int ui_index = -1;
 
 	fiction_viewer_reset();
 
 	if (!optional_string("#Fiction Viewer"))
 		return;
+
+	parse_custom_bitmap("$Background 640:", "$Background 1024:", background_640, background_1024);
+
+	if (optional_string("$UI:")) {
+		char ui_name[NAME_LENGTH];
+		stuff_string(ui_name, F_NAME, NAME_LENGTH);
+		ui_index = fiction_viewer_ui_name_to_index(ui_name);
+		if (ui_index < 0)
+		{
+			Warning(LOCATION, "Unrecognized fiction viewer UI: %s", ui_name);
+		}
+	}
+	if (!Fred_running && ui_index < 0) {
+		ui_index = Default_fiction_viewer_ui;
+	}
 
 	required_string("$File:");
 	stuff_string(filename, F_FILESPEC, MAX_FILENAME_LEN);
@@ -1287,20 +1304,7 @@ void parse_fiction(mission *pm)
 		strcpy_s(voice_filename, "");
 	}
 
-	if (optional_string("$UI:")) {
-		char ui_name[NAME_LENGTH];
-		stuff_string(ui_name, F_NAME, NAME_LENGTH);
-		ui_index = fiction_viewer_ui_name_to_index(ui_name);
-		if (ui_index < 0)
-		{
-			Warning(LOCATION, "Unrecognized fiction viewer UI: %s", ui_name);
-		}
-	}
-	if (!Fred_running && ui_index < 0) {
-		ui_index = Default_fiction_viewer_ui;
-	}
-
-	fiction_viewer_load(filename, font_filename, voice_filename, ui_index);
+	fiction_viewer_load(background_640, background_1024, ui_index, filename, font_filename, voice_filename);
 }
 
 /**

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -1356,7 +1356,7 @@ void parse_briefing(mission *pm, int flags)
 		required_string("$start_briefing");
 
 		// Goober5000 - use the same code as for mission loading screens
-		parse_custom_bitmap("$background_640:", "$background_1024:", bp->background[GR_640], bp->background[GR_1024]);
+		parse_custom_bitmap("$briefing_background_640:", "$briefing_background_1024:", bp->background[GR_640], bp->background[GR_1024]);
 		parse_custom_bitmap("$ship_select_background_640:", "$ship_select_background_1024:", bp->ship_select_background[GR_640], bp->ship_select_background[GR_1024]);
 		parse_custom_bitmap("$weapon_select_background_640:", "$weapon_select_background_1024:", bp->weapon_select_background[GR_640], bp->weapon_select_background[GR_1024]);
 

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -50,6 +50,7 @@
 #include "missionui/fictionviewer.h"
 #include "missionui/missioncmdbrief.h"
 #include "missionui/redalert.h"
+#include "mod_table/mod_table.h"
 #include "nebula/neb.h"
 #include "nebula/neblightning.h"
 #include "network/multi.h"
@@ -1264,6 +1265,7 @@ void parse_fiction(mission *pm)
 	char filename[MAX_FILENAME_LEN];
 	char font_filename[MAX_FILENAME_LEN];
 	char voice_filename[MAX_FILENAME_LEN];
+	int ui_index = -1;
 
 	fiction_viewer_reset();
 
@@ -1285,7 +1287,20 @@ void parse_fiction(mission *pm)
 		strcpy_s(voice_filename, "");
 	}
 
-	fiction_viewer_load(filename, font_filename, voice_filename);
+	if (optional_string("$UI:")) {
+		char ui_name[NAME_LENGTH];
+		stuff_string(ui_name, F_NAME, NAME_LENGTH);
+		ui_index = fiction_viewer_ui_name_to_index(ui_name);
+		if (ui_index < 0)
+		{
+			Warning(LOCATION, "Unrecognized fiction viewer UI: %s", ui_name);
+		}
+	}
+	if (!Fred_running && ui_index < 0) {
+		ui_index = Default_fiction_viewer_ui;
+	}
+
+	fiction_viewer_load(filename, font_filename, voice_filename, ui_index);
 }
 
 /**

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -1572,6 +1572,9 @@ void parse_debriefing_new(mission *pm)
 
 		db = &Debriefings[nt];
 
+		// Yarn - use the same code as for mission loading screens
+		parse_custom_bitmap("$Background 640:", "$Background 1024:", db->background[GR_640], db->background[GR_1024]);
+
 		required_string("$Num stages:");
 		stuff_int(&db->num_stages);
 		Assert(db->num_stages <= MAX_DEBRIEF_STAGES);

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -1299,6 +1299,10 @@ void parse_cmd_brief(mission *pm)
 	stage = 0;
 
 	required_string("#Command Briefing");
+
+	// Yarn - use the same code as for mission loading screens
+	parse_custom_bitmap("$Background 640:", "$Background 1024:", Cur_cmd_brief->background[GR_640], Cur_cmd_brief->background[GR_1024]);
+
 	while (optional_string("$Stage Text:")) {
 		Assert(stage < CMD_BRIEF_STAGES_MAX);
 		stuff_string(Cur_cmd_brief->stage[stage].text, F_MULTITEXT, NULL);

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -1357,6 +1357,7 @@ void parse_briefing(mission *pm, int flags)
 
 		// Goober5000 - use the same code as for mission loading screens
 		parse_custom_bitmap("$background_640:", "$background_1024:", bp->background[GR_640], bp->background[GR_1024]);
+		parse_custom_bitmap("$ship_select_background_640:", "$ship_select_background_1024:", bp->ship_select_background[GR_640], bp->ship_select_background[GR_1024]);
 
 		required_string("$num_stages:");
 		stuff_int(&bp->num_stages);

--- a/code/missionui/fictionviewer.h
+++ b/code/missionui/fictionviewer.h
@@ -19,8 +19,11 @@ int mission_has_fiction();
 const char *fiction_file();
 const char *fiction_font();
 const char *fiction_voice();
+int fiction_ui_index();
+const char *fiction_ui_name();
+int fiction_viewer_ui_name_to_index(char *ui_name);
 void fiction_viewer_reset();
-void fiction_viewer_load(const char *filename, const char *font_filename, const char* voice_filename);
+void fiction_viewer_load(const char *filename, const char *font_filename, const char* voice_filename, int ui_index);
 
 void fiction_viewer_pause();
 void fiction_viewer_unpause();

--- a/code/missionui/fictionviewer.h
+++ b/code/missionui/fictionviewer.h
@@ -16,14 +16,15 @@ void fiction_viewer_do_frame(float frametime);
 
 // fiction stuff
 int mission_has_fiction();
-const char *fiction_file();
-const char *fiction_font();
-const char *fiction_voice();
+const char *fiction_background(int res);
 int fiction_ui_index();
 const char *fiction_ui_name();
 int fiction_viewer_ui_name_to_index(char *ui_name);
+const char *fiction_file();
+const char *fiction_font();
+const char *fiction_voice();
 void fiction_viewer_reset();
-void fiction_viewer_load(const char *filename, const char *font_filename, const char* voice_filename, int ui_index);
+void fiction_viewer_load(const char *background_640, const char *background_1024, int ui_index, const char *filename, const char *font_filename, const char* voice_filename);
 
 void fiction_viewer_pause();
 void fiction_viewer_unpause();

--- a/code/missionui/missionbrief.cpp
+++ b/code/missionui/missionbrief.cpp
@@ -739,23 +739,7 @@ void brief_load_bitmaps()
 //
 void brief_ui_init()
 {
-	Brief_background_bitmap = -1;
-
-	if (*Briefing->background[gr_screen.res]) {
-		Brief_background_bitmap = bm_load(Briefing->background[gr_screen.res]);
-		if (Brief_background_bitmap < 0) {
-			mprintf(("Failed to load custom briefing bitmap %s!\n", Briefing->background[gr_screen.res]));
-		}
-	}
-
-	// if special background failed to load, or if no special background was supplied, load the standard bitmap
-	if (Brief_background_bitmap < 0) {
-		if (Game_mode & GM_MULTIPLAYER) {
-			Brief_background_bitmap = bm_load(Brief_multi_filename[gr_screen.res]);
-		} else {
-			Brief_background_bitmap = bm_load(Brief_filename[gr_screen.res]);
-		}
-	}
+	Brief_background_bitmap = mission_ui_background_load(Briefing->background[gr_screen.res], Brief_filename[gr_screen.res], Brief_multi_filename[gr_screen.res]);
 
 	if ( Num_brief_stages <= 0 ){
 		return;

--- a/code/missionui/missioncmdbrief.cpp
+++ b/code/missionui/missioncmdbrief.cpp
@@ -563,13 +563,26 @@ void cmd_brief_init(int team)
 	gr_flip();
 	Mouse_hidden--;
 
-	// first determine which layout to use
-	Uses_scroll_buttons = 1;	// assume true
-	Cmd_brief_background_bitmap = bm_load(Cmd_brief_fname[Uses_scroll_buttons][gr_screen.res]);	// try to load extra one first
-	if (Cmd_brief_background_bitmap < 0)	// failed to load
-	{
-		Uses_scroll_buttons = 0;	// nope, sorry
-		Cmd_brief_background_bitmap = bm_load(Cmd_brief_fname[Uses_scroll_buttons][gr_screen.res]);
+	Cmd_brief_background_bitmap = -1;
+
+	if (*Cur_cmd_brief->background[gr_screen.res]) {
+		Uses_scroll_buttons = 1;	// always true for custom backgrounds
+		Cmd_brief_background_bitmap = bm_load(Cur_cmd_brief->background[gr_screen.res]);
+		if (Cmd_brief_background_bitmap < 0) {
+			mprintf(("Failed to load custom briefing bitmap %s!\n", Cur_cmd_brief->background[gr_screen.res]));
+		}
+	}
+
+	// if special background failed to load, or if no special background was supplied, load the standard bitmap
+	if (Cmd_brief_background_bitmap < 0) {
+		// first determine which layout to use
+		Uses_scroll_buttons = 1;	// assume true
+		Cmd_brief_background_bitmap = bm_load(Cmd_brief_fname[Uses_scroll_buttons][gr_screen.res]);	// try to load extra one first
+		if (Cmd_brief_background_bitmap < 0)	// failed to load
+		{
+			Uses_scroll_buttons = 0;	// nope, sorry
+			Cmd_brief_background_bitmap = bm_load(Cmd_brief_fname[Uses_scroll_buttons][gr_screen.res]);
+		}
 	}
 
 	Ui_window.create(0, 0, gr_screen.max_w_unscaled, gr_screen.max_h_unscaled, 0);

--- a/code/missionui/missioncmdbrief.cpp
+++ b/code/missionui/missioncmdbrief.cpp
@@ -563,26 +563,13 @@ void cmd_brief_init(int team)
 	gr_flip();
 	Mouse_hidden--;
 
-	Cmd_brief_background_bitmap = -1;
-
-	if (*Cur_cmd_brief->background[gr_screen.res]) {
-		Uses_scroll_buttons = 1;	// always true for custom backgrounds
-		Cmd_brief_background_bitmap = bm_load(Cur_cmd_brief->background[gr_screen.res]);
-		if (Cmd_brief_background_bitmap < 0) {
-			mprintf(("Failed to load custom briefing bitmap %s!\n", Cur_cmd_brief->background[gr_screen.res]));
-		}
-	}
-
-	// if special background failed to load, or if no special background was supplied, load the standard bitmap
-	if (Cmd_brief_background_bitmap < 0) {
-		// first determine which layout to use
-		Uses_scroll_buttons = 1;	// assume true
-		Cmd_brief_background_bitmap = bm_load(Cmd_brief_fname[Uses_scroll_buttons][gr_screen.res]);	// try to load extra one first
-		if (Cmd_brief_background_bitmap < 0)	// failed to load
-		{
-			Uses_scroll_buttons = 0;	// nope, sorry
-			Cmd_brief_background_bitmap = bm_load(Cmd_brief_fname[Uses_scroll_buttons][gr_screen.res]);
-		}
+	// first determine which layout to use
+	Uses_scroll_buttons = 1;	// assume true
+	Cmd_brief_background_bitmap = mission_ui_background_load(Cur_cmd_brief->background[gr_screen.res], Cmd_brief_fname[Uses_scroll_buttons][gr_screen.res]);	// try to load extra one first
+	if (Cmd_brief_background_bitmap < 0)	// failed to load
+	{
+		Uses_scroll_buttons = 0;	// nope, sorry
+		Cmd_brief_background_bitmap = mission_ui_background_load(NULL, Cmd_brief_fname[Uses_scroll_buttons][gr_screen.res]);
 	}
 
 	Ui_window.create(0, 0, gr_screen.max_w_unscaled, gr_screen.max_h_unscaled, 0);

--- a/code/missionui/missioncmdbrief.h
+++ b/code/missionui/missioncmdbrief.h
@@ -31,6 +31,7 @@ struct cmd_brief_stage {
 struct cmd_brief {
 	int num_stages;
 	cmd_brief_stage stage[CMD_BRIEF_STAGES_MAX];
+	char background[GR_NUM_RESOLUTIONS][MAX_FILENAME_LEN];
 };
 
 extern cmd_brief Cmd_briefs[MAX_TVT_TEAMS];

--- a/code/missionui/missiondebrief.cpp
+++ b/code/missionui/missiondebrief.cpp
@@ -860,34 +860,18 @@ void debrief_ui_init()
 	Debrief_overlay_id = help_overlay_get_index(DEBRIEFING_OVERLAY);
 	help_overlay_set_state(Debrief_overlay_id,gr_screen.res,0);
 
-	Background_bitmap = -1;
-
-	if ( *Debriefing->background[gr_screen.res] ) {
-		Background_bitmap = bm_load(Debriefing->background[gr_screen.res]);
-		if ( Background_bitmap < 0 ) {
-			mprintf(("Failed to load custom debriefing bitmap %s!\n", Debriefing->background[gr_screen.res]));
-		}
-	}
-
 	if ( Game_mode & GM_MULTIPLAYER ) {
 		// close down any old instances of the chatbox
 		chatbox_close();
 
 		// create the new one
 		chatbox_create();
-		// if special background failed to load, or if no special background was supplied, load the standard bitmap
-		if ( Background_bitmap < 0 ) {
-			Background_bitmap = bm_load(Debrief_multi_name[gr_screen.res]);
-		}
 		List_region.create(&Debrief_ui_window, "", Debrief_list_coords[gr_screen.res][0], Debrief_list_coords[gr_screen.res][1], Debrief_list_coords[gr_screen.res][2], Debrief_list_coords[gr_screen.res][3], 0, 1);
 		List_region.hide();
 
-	} else {
-		// if special background failed to load, or if no special background was supplied, load the standard bitmap
-		if ( Background_bitmap < 0 ) {
-			Background_bitmap = bm_load(Debrief_single_name[gr_screen.res]);
-		}
 	}
+
+	Background_bitmap = mission_ui_background_load(Debriefing->background[gr_screen.res], Debrief_single_name[gr_screen.res], Debrief_multi_name[gr_screen.res]);
 
 	if ( Background_bitmap < 0 ) {
 		Warning(LOCATION, "Could not load the background bitmap for debrief screen");

--- a/code/missionui/missiondebrief.cpp
+++ b/code/missionui/missiondebrief.cpp
@@ -860,18 +860,33 @@ void debrief_ui_init()
 	Debrief_overlay_id = help_overlay_get_index(DEBRIEFING_OVERLAY);
 	help_overlay_set_state(Debrief_overlay_id,gr_screen.res,0);
 
+	Background_bitmap = -1;
+
+	if ( *Debriefing->background[gr_screen.res] ) {
+		Background_bitmap = bm_load(Debriefing->background[gr_screen.res]);
+		if ( Background_bitmap < 0 ) {
+			mprintf(("Failed to load custom debriefing bitmap %s!\n", Debriefing->background[gr_screen.res]));
+		}
+	}
+
 	if ( Game_mode & GM_MULTIPLAYER ) {
 		// close down any old instances of the chatbox
 		chatbox_close();
 
 		// create the new one
 		chatbox_create();
-		Background_bitmap = bm_load(Debrief_multi_name[gr_screen.res]);
+		// if special background failed to load, or if no special background was supplied, load the standard bitmap
+		if ( Background_bitmap < 0 ) {
+			Background_bitmap = bm_load(Debrief_multi_name[gr_screen.res]);
+		}
 		List_region.create(&Debrief_ui_window, "", Debrief_list_coords[gr_screen.res][0], Debrief_list_coords[gr_screen.res][1], Debrief_list_coords[gr_screen.res][2], Debrief_list_coords[gr_screen.res][3], 0, 1);
 		List_region.hide();
 
 	} else {
-		Background_bitmap = bm_load(Debrief_single_name[gr_screen.res]);
+		// if special background failed to load, or if no special background was supplied, load the standard bitmap
+		if ( Background_bitmap < 0 ) {
+			Background_bitmap = bm_load(Debrief_single_name[gr_screen.res]);
+		}
 	}
 
 	if ( Background_bitmap < 0 ) {

--- a/code/missionui/missionscreencommon.cpp
+++ b/code/missionui/missionscreencommon.cpp
@@ -280,6 +280,31 @@ void common_buttons_init(UI_WINDOW *ui_window)
 	}
 }
 
+// Try to load background bitmaps as appropriate
+int mission_ui_background_load(const char *custom_background, const char *single_background, const char *multi_background)
+{
+	int background_bitmap = -1;
+
+	if (custom_background && (*custom_background != '\0'))
+	{
+		background_bitmap = bm_load(custom_background);
+		if (background_bitmap < 0)
+			mprintf(("Failed to load custom background bitmap %s!\n", custom_background));
+	}
+
+	// if special background failed to load, or if no special background was supplied, load the standard bitmap
+	if (background_bitmap < 0)
+	{
+		if (multi_background && (Game_mode & GM_MULTIPLAYER))
+			background_bitmap = bm_load(multi_background);
+		else
+			background_bitmap = bm_load(single_background);
+	}
+
+	// return what we've got
+	return background_bitmap;
+}
+
 void set_active_ui(UI_WINDOW *ui_window)
 {
 	Active_ui_window = ui_window;

--- a/code/missionui/missionscreencommon.h
+++ b/code/missionui/missionscreencommon.h
@@ -88,6 +88,8 @@ void	common_redraw_pressed_buttons();
 void  common_maybe_clear_focus();
 void ship_select_common_init();
 
+int mission_ui_background_load(const char *custom_background, const char *single_background, const char *multi_background = NULL);
+
 void common_set_interface_palette(char *filename = NULL);		// set the interface palette
 void common_free_interface_palette();		// restore game palette
 

--- a/code/missionui/missionshipchoice.cpp
+++ b/code/missionui/missionshipchoice.cpp
@@ -739,7 +739,19 @@ void ship_select_init()
 	ship_select_buttons_init();
 
 	// init ship selection background bitmap
-	Ship_select_background_bitmap = bm_load(Ship_select_background_fname[gr_screen.res]);
+	Ship_select_background_bitmap = -1;
+
+	if (Briefing && *Briefing->ship_select_background[gr_screen.res]) {
+		Ship_select_background_bitmap = bm_load(Briefing->ship_select_background[gr_screen.res]);
+		if (Ship_select_background_bitmap < 0) {
+			mprintf(("Failed to load custom ship select bitmap %s!\n", Briefing->ship_select_background[gr_screen.res]));
+		}
+	}
+
+	// if special background failed to load, or if no special background was supplied, load the standard bitmap
+	if (Ship_select_background_bitmap < 0) {
+		Ship_select_background_bitmap = bm_load(Ship_select_background_fname[gr_screen.res]);
+	}
 
 	// init ship selection ship model rendering window
 	start_ship_animation( Selected_ss_class );

--- a/code/missionui/missionshipchoice.cpp
+++ b/code/missionui/missionshipchoice.cpp
@@ -739,19 +739,7 @@ void ship_select_init()
 	ship_select_buttons_init();
 
 	// init ship selection background bitmap
-	Ship_select_background_bitmap = -1;
-
-	if (Briefing && *Briefing->ship_select_background[gr_screen.res]) {
-		Ship_select_background_bitmap = bm_load(Briefing->ship_select_background[gr_screen.res]);
-		if (Ship_select_background_bitmap < 0) {
-			mprintf(("Failed to load custom ship select bitmap %s!\n", Briefing->ship_select_background[gr_screen.res]));
-		}
-	}
-
-	// if special background failed to load, or if no special background was supplied, load the standard bitmap
-	if (Ship_select_background_bitmap < 0) {
-		Ship_select_background_bitmap = bm_load(Ship_select_background_fname[gr_screen.res]);
-	}
+	Ship_select_background_bitmap = mission_ui_background_load(Briefing->ship_select_background[gr_screen.res], Ship_select_background_fname[gr_screen.res]);
 
 	// init ship selection ship model rendering window
 	start_ship_animation( Selected_ss_class );

--- a/code/missionui/missionweaponchoice.cpp
+++ b/code/missionui/missionweaponchoice.cpp
@@ -1996,14 +1996,27 @@ void weapon_select_init()
 	common_select_init();
 
 
-	// Goober5000
-	// first determine which layout to use
-	Uses_apply_all_button = 1;	// assume true
-	Weapon_select_background_bitmap = bm_load((Game_mode & GM_MULTIPLAYER) ? Weapon_select_multi_background_fname[Uses_apply_all_button][gr_screen.res] : Weapon_select_background_fname[Uses_apply_all_button][gr_screen.res]);
-	if (Weapon_select_background_bitmap < 0)	// failed to load
-	{
-		Uses_apply_all_button = 0;	// nope, sorry
+	Weapon_select_background_bitmap = -1;
+
+	if (Briefing && *Briefing->weapon_select_background[gr_screen.res]) {
+		Uses_apply_all_button = 1;	// always true for custom backgrounds
+		Weapon_select_background_bitmap = bm_load(Briefing->weapon_select_background[gr_screen.res]);
+		if (Weapon_select_background_bitmap < 0) {
+			mprintf(("Failed to load custom weapon select bitmap %s!\n", Briefing->weapon_select_background[gr_screen.res]));
+		}
+	}
+
+	// if special background failed to load, or if no special background was supplied, load the standard bitmap
+	if (Weapon_select_background_bitmap < 0) {
+		// Goober5000
+		// first determine which layout to use
+		Uses_apply_all_button = 1;	// assume true
 		Weapon_select_background_bitmap = bm_load((Game_mode & GM_MULTIPLAYER) ? Weapon_select_multi_background_fname[Uses_apply_all_button][gr_screen.res] : Weapon_select_background_fname[Uses_apply_all_button][gr_screen.res]);
+		if (Weapon_select_background_bitmap < 0)	// failed to load
+		{
+			Uses_apply_all_button = 0;	// nope, sorry
+			Weapon_select_background_bitmap = bm_load((Game_mode & GM_MULTIPLAYER) ? Weapon_select_multi_background_fname[Uses_apply_all_button][gr_screen.res] : Weapon_select_background_fname[Uses_apply_all_button][gr_screen.res]);
+		}
 	}
 
 

--- a/code/missionui/missionweaponchoice.cpp
+++ b/code/missionui/missionweaponchoice.cpp
@@ -1996,27 +1996,14 @@ void weapon_select_init()
 	common_select_init();
 
 
-	Weapon_select_background_bitmap = -1;
-
-	if (Briefing && *Briefing->weapon_select_background[gr_screen.res]) {
-		Uses_apply_all_button = 1;	// always true for custom backgrounds
-		Weapon_select_background_bitmap = bm_load(Briefing->weapon_select_background[gr_screen.res]);
-		if (Weapon_select_background_bitmap < 0) {
-			mprintf(("Failed to load custom weapon select bitmap %s!\n", Briefing->weapon_select_background[gr_screen.res]));
-		}
-	}
-
-	// if special background failed to load, or if no special background was supplied, load the standard bitmap
-	if (Weapon_select_background_bitmap < 0) {
-		// Goober5000
-		// first determine which layout to use
-		Uses_apply_all_button = 1;	// assume true
-		Weapon_select_background_bitmap = bm_load((Game_mode & GM_MULTIPLAYER) ? Weapon_select_multi_background_fname[Uses_apply_all_button][gr_screen.res] : Weapon_select_background_fname[Uses_apply_all_button][gr_screen.res]);
-		if (Weapon_select_background_bitmap < 0)	// failed to load
-		{
-			Uses_apply_all_button = 0;	// nope, sorry
-			Weapon_select_background_bitmap = bm_load((Game_mode & GM_MULTIPLAYER) ? Weapon_select_multi_background_fname[Uses_apply_all_button][gr_screen.res] : Weapon_select_background_fname[Uses_apply_all_button][gr_screen.res]);
-		}
+	// Goober5000
+	// first determine which layout to use
+	Uses_apply_all_button = 1;	// assume true
+	Weapon_select_background_bitmap = mission_ui_background_load(Briefing->weapon_select_background[gr_screen.res], Weapon_select_background_fname[Uses_apply_all_button][gr_screen.res], Weapon_select_multi_background_fname[Uses_apply_all_button][gr_screen.res]);
+	if (Weapon_select_background_bitmap < 0)	// failed to load
+	{
+		Uses_apply_all_button = 0;	// nope, sorry
+		Weapon_select_background_bitmap = mission_ui_background_load(NULL, Weapon_select_background_fname[Uses_apply_all_button][gr_screen.res], Weapon_select_multi_background_fname[Uses_apply_all_button][gr_screen.res]);
 	}
 
 

--- a/code/missionui/redalert.cpp
+++ b/code/missionui/redalert.cpp
@@ -328,24 +328,13 @@ void red_alert_init()
 	// hud_anim_load(&Flash_anim);
 
 	Red_alert_voice = -1;
-	Background_bitmap = -1;
 
 	if ( !Briefing ) {
 		Briefing = &Briefings[0];			
 	}
 
 	// load in background image and flashing red alert animation
-	if (*Briefing->background[gr_screen.res]) {
-		Background_bitmap = bm_load(Briefing->background[gr_screen.res]);
-		if (Background_bitmap < 0) {
-			mprintf(("Failed to load custom briefing bitmap %s!\n", Briefing->background[gr_screen.res]));
-		}
-	}
-
-	// if special background failed to load, or if no special background was supplied, load the standard bitmap
-	if (Background_bitmap < 0) {
-		Background_bitmap = bm_load(Red_alert_fname[gr_screen.res]);
-	}
+	Background_bitmap = mission_ui_background_load(Briefing->background[gr_screen.res], Red_alert_fname[gr_screen.res]);
 
 	if ( Briefing->num_stages > 0 ) {
 		brief_color_text_init(Briefing->stages[0].text.c_str(), Ra_brief_text_wnd_coords[gr_screen.res][RA_W_COORD], default_redalert_briefing_color, 0);

--- a/code/missionui/redalert.cpp
+++ b/code/missionui/redalert.cpp
@@ -323,17 +323,28 @@ void red_alert_init()
 
 	// set up red alert hotkeys
 	Buttons[gr_screen.res][RA_CONTINUE].button.set_hotkey(KEY_CTRLED | KEY_ENTER);
-
-	// load in background image and flashing red alert animation
-	Background_bitmap = bm_load(Red_alert_fname[gr_screen.res]);
 	
 	// hud_anim_init(&Flash_anim, Ra_flash_coords[gr_screen.res][RA_X_COORD], Ra_flash_coords[gr_screen.res][RA_Y_COORD], NOX("AlertFlash"));
 	// hud_anim_load(&Flash_anim);
 
 	Red_alert_voice = -1;
+	Background_bitmap = -1;
 
 	if ( !Briefing ) {
 		Briefing = &Briefings[0];			
+	}
+
+	// load in background image and flashing red alert animation
+	if (*Briefing->background[gr_screen.res]) {
+		Background_bitmap = bm_load(Briefing->background[gr_screen.res]);
+		if (Background_bitmap < 0) {
+			mprintf(("Failed to load custom briefing bitmap %s!\n", Briefing->background[gr_screen.res]));
+		}
+	}
+
+	// if special background failed to load, or if no special background was supplied, load the standard bitmap
+	if (Background_bitmap < 0) {
+		Background_bitmap = bm_load(Red_alert_fname[gr_screen.res]);
 	}
 
 	if ( Briefing->num_stages > 0 ) {

--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -9,6 +9,7 @@
 #include "localization/localize.h"
 #include "mission/missioncampaign.h"
 #include "mission/missionmessage.h"
+#include "missionui/fictionviewer.h"
 #include "mod_table/mod_table.h"
 #include "parse/parselo.h"
 #include "sound/sound.h"
@@ -21,6 +22,7 @@ bool Cutscene_camera_displays_hud = false;
 bool Alternate_chaining_behavior = false;
 int Default_ship_select_effect = 2;
 int Default_weapon_select_effect = 2;
+int Default_fiction_viewer_ui = -1;
 bool Enable_external_shaders = false;
 int Default_detail_level = 3; // "very high" seems a reasonable default in 2012 -zookeeper
 bool Full_color_head_anis = false;
@@ -283,6 +285,20 @@ void parse_mod_table(const char *filename)
 			}
 			else {
 				mprintf(("Game Settings Table: Beams will ignore Damage Factors (retail behavior)\n"));
+			}
+		}
+
+		if (optional_string("$Default fiction viewer UI:")) {
+			char ui_name[NAME_LENGTH];
+			stuff_string(ui_name, F_NAME, NAME_LENGTH);
+			if (!stricmp(ui_name, "auto"))
+				Default_fiction_viewer_ui = -1;
+			else {
+				int ui_index = fiction_viewer_ui_name_to_index(ui_name);
+				if (ui_index >= 0)
+					Default_fiction_viewer_ui = ui_index;
+				else
+					Warning(LOCATION, "Unrecognized fiction viewer UI: %s", ui_name);
 			}
 		}
 

--- a/code/mod_table/mod_table.h
+++ b/code/mod_table/mod_table.h
@@ -17,6 +17,7 @@ extern bool Cutscene_camera_displays_hud;
 extern bool Alternate_chaining_behavior;
 extern int Default_ship_select_effect;
 extern int Default_weapon_select_effect;
+extern int Default_fiction_viewer_ui;
 extern bool Enable_external_shaders;
 extern int Default_detail_level;
 extern bool Full_color_head_anis;

--- a/code/network/multiteamselect.cpp
+++ b/code/network/multiteamselect.cpp
@@ -1154,19 +1154,7 @@ void multi_ts_init_graphics()
 	Multi_ts_window.set_mask_bmap(Multi_ts_bitmap_mask_fname[gr_screen.res]);
 
 	// load the background bitmap
-	Multi_ts_bitmap = -1;
-
-	if(Briefing && *Briefing->ship_select_background[gr_screen.res]) {
-		Multi_ts_bitmap = bm_load(Briefing->ship_select_background[gr_screen.res]);
-		if (Multi_ts_bitmap < 0) {
-			mprintf(("Failed to load custom ship select bitmap %s!\n", Briefing->ship_select_background[gr_screen.res]));
-		}
-	}
-
-	// if special background failed to load, or if no special background was supplied, load the standard bitmap
-	if(Multi_ts_bitmap < 0) {
-		Multi_ts_bitmap = bm_load(Multi_ts_bitmap_fname[gr_screen.res]);
-	}
+	Multi_ts_bitmap = mission_ui_background_load(Briefing->ship_select_background[gr_screen.res], Multi_ts_bitmap_fname[gr_screen.res]);
 
 	if(Multi_ts_bitmap < 0){
 		// we failed to load the bitmap - this is very bad

--- a/code/network/multiteamselect.cpp
+++ b/code/network/multiteamselect.cpp
@@ -1154,7 +1154,20 @@ void multi_ts_init_graphics()
 	Multi_ts_window.set_mask_bmap(Multi_ts_bitmap_mask_fname[gr_screen.res]);
 
 	// load the background bitmap
-	Multi_ts_bitmap = bm_load(Multi_ts_bitmap_fname[gr_screen.res]);
+	Multi_ts_bitmap = -1;
+
+	if(Briefing && *Briefing->ship_select_background[gr_screen.res]) {
+		Multi_ts_bitmap = bm_load(Briefing->ship_select_background[gr_screen.res]);
+		if (Multi_ts_bitmap < 0) {
+			mprintf(("Failed to load custom ship select bitmap %s!\n", Briefing->ship_select_background[gr_screen.res]));
+		}
+	}
+
+	// if special background failed to load, or if no special background was supplied, load the standard bitmap
+	if(Multi_ts_bitmap < 0) {
+		Multi_ts_bitmap = bm_load(Multi_ts_bitmap_fname[gr_screen.res]);
+	}
+
 	if(Multi_ts_bitmap < 0){
 		// we failed to load the bitmap - this is very bad
 		Int3();


### PR DESCRIPTION
This code expands on Goober's earlier code for per-mission briefing backgrounds to also allow the ship selection, weapon selection, debriefing, command briefing, and fiction viewer screens to use custom backgrounds. It also allows the fiction viewer UI to be explicitly specified in mission files and game_settings.tbl. Details on using these features are in this post: http://www.hard-light.net/forums/index.php?topic=90337.msg1795797#msg1795797