### PR TITLE
Fix possible out of bounds array access

### DIFF
--- a/code/parse/lua.cpp
+++ b/code/parse/lua.cpp
@@ -12438,7 +12438,7 @@ int l_cf_get_path_id(char* n_path)
 
 	//Remove trailing slashes
 	i = path_len -1;
-	while(buf[i] == '\\' || buf[i] == '/')
+	while(i >= 0 && (buf[i] == '\\' || buf[i] == '/'))
 		buf[i--] = '\0';
 
 	//Remove leading slashes


### PR DESCRIPTION
If the input string is "/", then buf[-1] would get accessed and in rare cases also modified.