### PR TITLE
Voice recognition cleanup based on Mantis #2373 patch.

### DIFF
--- a/code/sound/phrases.xml
+++ b/code/sound/phrases.xml
@@ -1,36 +1,46 @@
-<GRAMMAR>
+<GRAMMAR LANGID="0809">
 	<DEFINE>
-		<ID NAME="VID_Counter"			VAL="80"/>
-		<ID NAME="VID_DestroyTarget"	VAL="10"/>
-		<ID NAME="VID_DisableTarget"	VAL="11"/>
-		<ID NAME="VID_DisarmTarget"		VAL="12"/>
-		<ID NAME="VID_DestroySubsys"	VAL="13"/>
-		<ID NAME="VID_ProtectTarget"	VAL="14"/>
-		<ID NAME="VID_IgnoreTarget"		VAL="15"/>
-		<ID NAME="VID_FormWing"			VAL="16"/>
-		<ID NAME="VID_CoverMe"			VAL="17"/>
-		<ID NAME="VID_EngageEnemy"		VAL="18"/>
-		<ID NAME="VID_Depart"			VAL="19"/>
-		<ID NAME="VID_Action"			VAL="250"/>
-		<ID NAME="VID_WingName"			VAL="251"/>
-		<ID NAME="VID_TopMenu"			VAL="252"/>
-		<ID NAME="VID_ShipName"			VAL="253"/>
-		<ID NAME="VID_Number"			VAL="254"/>
-		<ID NAME="VID_Ships"			VAL="50"/>
-		<ID NAME="VID_Wings"			VAL="51"/>
-		<ID NAME="VID_AllFighters"		VAL="52"/>
-		<ID NAME="VID_AllWings"			VAL="53"/>
-		<ID NAME="VID_Reinforcements"	VAL="54"/>
-		<ID NAME="VID_SupportShip"		VAL="55"/>
-		<ID NAME="VID_AbortSupport"		VAL="56"/>
-		<ID NAME="VID_Cancel"			VAL="57"/>
-		<ID NAME="VID_Command"			VAL="58"/>
-		<ID NAME="VID_More"				VAL="59"/>
-		<ID NAME="VID_shields"			VAL="100"/>
-		<ID NAME="VID_targeting"		VAL="101"/>
-		<ID NAME="VID_power"			VAL="102"/>
-		<ID NAME="VID_speed"			VAL="103"/>
-		<ID name="VID_other"			VAL="104"/>
+		<ID NAME="VID_Counter"         VAL="80"/>
+ 
+		<ID NAME="VID_DestroyTarget"   VAL="10"/>
+		<ID NAME="VID_DisableTarget"   VAL="11"/>
+		<ID NAME="VID_DisarmTarget"    VAL="12"/>
+
+		<ID NAME="VID_DestroySubsys"   VAL="13"/>
+
+		<ID NAME="VID_ProtectTarget"   VAL="14"/>
+		<ID NAME="VID_IgnoreTarget"    VAL="15"/>
+		<ID NAME="VID_FormWing"	       VAL="16"/>
+		<ID NAME="VID_CoverMe"         VAL="17"/>
+		<ID NAME="VID_EngageEnemy"     VAL="18"/>
+		<ID NAME="VID_Depart"          VAL="19"/>
+
+		<ID NAME="VID_Action"          VAL="250"/>
+
+		<ID NAME="VID_WingName"        VAL="251"/>
+		<ID NAME="VID_TopMenu"         VAL="252"/>
+		<ID NAME="VID_ShipName"        VAL="253"/>
+		<ID NAME="VID_Number"          VAL="254"/>
+
+		<ID NAME="VID_Ships"       VAL="50"/>
+		<ID NAME="VID_Wings"       VAL="51"/>
+		<ID NAME="VID_AllFighters" VAL="52"/>
+		<ID NAME="VID_AllWings"    VAL="53"/>
+
+		<ID NAME="VID_Reinforcements" VAL="54"/>
+
+		<ID NAME="VID_SupportShip"  VAL="55"/>
+		<ID NAME="VID_AbortSupport" VAL="56"/>
+
+		<ID NAME="VID_Cancel"  VAL="57"/>
+		<ID NAME="VID_Command" VAL="58"/>
+		<ID NAME="VID_More"    VAL="59"/>
+		
+		<ID NAME="VID_shields" VAL="100"/>
+		<ID NAME="VID_targeting" VAL="101" />
+		<ID NAME="VID_power" VAL="102" />
+		<ID NAME="VID_speed" VAL="103" />
+		<ID name="VID_other" VAL="104" />
 	</DEFINE>
 
 	<RULE ID="VID_WingName" TOPLEVEL="ACTIVE">
@@ -79,16 +89,16 @@
 
 	<RULE ID="VID_Action" TOPLEVEL="ACTIVE">
 		<L PROPID="VID_Action">
-			<P VAL="VID_DestroyTarget">Destroy my target</P>
-			<P VAL="VID_DisableTarget">Disable my target</P>
-			<P VAL="VID_DisarmTarget">Disarm my target</P>
-			<P VAL="VID_DestroySubsys">Destroy subsystem</P>
-			<P VAL="VID_ProtectTarget">Protect my target</P>
-			<P VAL="VID_IgnoreTarget">Ignore my target</P>
+			<P VAL="VID_DestroyTarget">Destroy <O><O>my</O> target</O></P>
+			<P VAL="VID_DisableTarget">Disable <O><O>my</O> target</O></P>
+			<P VAL="VID_DisarmTarget">Disarm <O><O>my</O> target</O></P>
+			<P VAL="VID_DestroySubsys">Destroy <O>that</O> subsystem</P>
+			<P VAL="VID_ProtectTarget">Protect <O><O>my</O> target</O></P>
+			<P VAL="VID_IgnoreTarget">Ignore <O><O>my</O> target</O></P>
 			<P VAL="VID_FormWing">Form on my wing</P>
 			<P VAL="VID_CoverMe">Cover me</P>
 			<P VAL="VID_EngageEnemy">Engage the Enemy</P>
-			<P VAL="VID_EngageEnemy">Attack</P>
+			<P VAL="VID_EngageEnemy">Attack <O>anything</O></P>
 			<P VAL="VID_Depart">Depart</P>
 		</L>
 	</RULE>
@@ -124,28 +134,29 @@
 		<L PROPID="VID_targeting">
 			<P VAL="0">Target next</P>
 			<P VAL="1">Target previous</P>
-			<P VAL="2">Target hostile</P>
+			<P VAL="2">Target <O>next</O> hostile</P>
 			<P VAL="3">Target previous hostile</P>
 			<P VAL="4">Auto target</P>
-			<P VAL="5">Target Friendly</P>
+			<P VAL="5">Target <O>next</O> Friendly</P>
 			<P VAL="6">Target previous friendly</P>
 			<P VAL="7">Target sight</P>
 			<P VAL="8">Targets attacker</P>
 			<P VAL="9">Target sender</P>
 			<P VAL="10">Stop targeting</P>
+			<P VAL="10">Clear target</P>
 			<P VAL="11">Target sight subsystem</P>
-			<P VAL="12">Target next subsystem</P>
+			<P VAL="12">Target <O>next</O> subsystem</P>
 			<P VAL="13">Target previous subsystem</P>
 			<P VAL="14">Stop targeting subsystems</P>
 			<P val="50">Target closest attacker</P>
-			<P VAL="88">Target next escort</P>
+			<P VAL="88">Target <O>next</O> escort</P>
 			<P VAL="89">Target closest repair ship</P>
-			<P VAL="90">Target next uninspected</P>
+			<P VAL="90">Target <O>next</O> uninspected</P>
 			<P VAL="91">Target previous uninspected</P>
 			<P VAL="92">Target newest</P>
-			<P VAL="93">Target next turret</P>
+			<P VAL="93">Target <O>next</O> turret</P>
 			<P VAL="94">Target previous turret</P>
-			<P VAL="95">Target next bomb</P>
+			<P VAL="95">Target <O>next</O> bomb</P>
 			<P VAL="96">Target previous bomb</P>
 		</L>
 	</RULE>
@@ -153,7 +164,7 @@
 	<RULE ID="VID_speed" TOPLEVEL="ACTIVE">
 		<L PROPID="VID_speed">
 			<P VAL="15">Match speed</P>
-			<P VAL="16">Auto match</P>
+			<P VAL="16">Auto <O>match</O> speed</P>
 		</L>
 	</RULE>
 

--- a/code/sound/voicerec.cpp
+++ b/code/sound/voicerec.cpp
@@ -37,14 +37,16 @@
 CComPtr<ISpRecoGrammar>         p_grammarObject; // Pointer to our grammar object
 CComPtr<ISpRecoContext>         p_recogContext;  // Pointer to our recognition context
 CComPtr<ISpRecognizer>			p_recogEngine;   // Pointer to our recognition engine instance
+CComPtr<ISpAudio>				cpAudio;         // Pointer for Audio Input Device
 
 const bool DEBUG_ON = false;
 
 extern int button_function(int n);
 extern void hud_squadmsg_msg_all_fighters();
 extern void hud_squadmsg_shortcut( int command );
+extern bool hud_squadmsg_ship_valid(ship *shipp, object *objp = nullptr);
+extern int hud_squadmsg_wing_valid(wing *wingp);
 
-//extern void hud_squadmsg_ship_command();
 extern int Msg_instance;;
 extern int Msg_shortcut_command;
 extern int Squad_msg_mode;
@@ -72,18 +74,19 @@ void doVid_Action(int action)
 
 		if(Msg_instance == MESSAGE_ALL_FIGHTERS || Squad_msg_mode == SM_MODE_ALL_FIGHTERS )
 		{
-			//	nprintf(("warning", "VOICER hud_squadmsg_send_to_all_fighters\n"));
 			hud_squadmsg_send_to_all_fighters(Msg_shortcut_command);
 		}
 		else if(Squad_msg_mode == SM_MODE_SHIP_COMMAND)
 		{
-			//	nprintf(("warning", "VOICER msg ship %d\n", Msg_instance));
-			hud_squadmsg_send_ship_command( Msg_instance, Msg_shortcut_command, 1 );
+			// skip if player cannot order this ship
+			if (hud_squadmsg_ship_valid(&Ships[Msg_instance]))
+				hud_squadmsg_send_ship_command( Msg_instance, Msg_shortcut_command, 1 );
 		}
 		else if(Squad_msg_mode == SM_MODE_WING_COMMAND)
 		{
-			//	nprintf(("warning", "VOICER msg wing %d\n", Msg_instance));
-			hud_squadmsg_send_wing_command( Msg_instance, Msg_shortcut_command, 1 );
+			// skip if player cannot order this wing
+			if (hud_squadmsg_wing_valid(&Wings[Msg_instance]))
+				hud_squadmsg_send_wing_command( Msg_instance, Msg_shortcut_command, 1 );
 		}
 		else if(Squad_msg_mode == SM_MODE_REINFORCEMENTS )
 		{
@@ -113,7 +116,6 @@ void doVid_Action(int action)
 bool VOICEREC_init(HWND hWnd, int event_id, int grammar_id, int command_resource)
 {
 	HRESULT hr = S_OK;
-	CComPtr<ISpAudio> cpAudio;
 
 	while (true)
 	{
@@ -171,7 +173,7 @@ bool VOICEREC_init(HWND hWnd, int event_id, int grammar_id, int command_resource
 												SPLO_STATIC);
 			if (FAILED(hr))
 			{
-				MessageBox(hWnd,"Failed to load resource\n","Error",MB_OK);
+				MessageBox(hWnd,"Failed to load resource SRGRAMMAR\n","Error",MB_OK);
 				break;
 			}
 		}
@@ -212,6 +214,10 @@ bool VOICEREC_init(HWND hWnd, int event_id, int grammar_id, int command_resource
 
 void VOICEREC_deinit()
 {
+	if ( cpAudio )
+	{
+		cpAudio.Release();
+	}
 	// Release grammar, if loaded
 	if ( p_grammarObject )
 	{
@@ -289,7 +295,7 @@ void VOICEREC_execute_command(ISpPhrase *pPhrase, HWND hWnd)
 
 			mprintf(( "recognized speech : %s \n", szText ));
 			mprintf(( "speech Rule.ulId : %d \n", pElements->Rule.ulId ));
-			//MessageBoxW(NULL,pwszText,NULL,MB_OK);
+			mprintf(( "confidence: %f \n", pElements->pProperties->SREngineConfidence));
 
 			::CoTaskMemFree(pwszText);
 		}
@@ -340,7 +346,8 @@ void VOICEREC_execute_command(ISpPhrase *pPhrase, HWND hWnd)
 						hud_squadmsg_toggle();
 					}
 
-					hud_squadmsg_do_mode(SM_MODE_WING_COMMAND);
+					if (hud_squadmsg_wing_valid(&Wings[Msg_instance]))
+						hud_squadmsg_do_mode(SM_MODE_WING_COMMAND);
 				}
 				else
 				{
@@ -361,7 +368,8 @@ void VOICEREC_execute_command(ISpPhrase *pPhrase, HWND hWnd)
 						hud_squadmsg_toggle();
 					}
 
-					hud_squadmsg_do_mode(SM_MODE_SHIP_COMMAND);
+					if (hud_squadmsg_ship_valid(&Ships[Msg_instance]))
+						hud_squadmsg_do_mode(SM_MODE_SHIP_COMMAND);
 
 				}
 
@@ -414,17 +422,11 @@ void VOICEREC_execute_command(ISpPhrase *pPhrase, HWND hWnd)
 
 					case VID_AllFighters:
 					case VID_AllWings:
-					//	Msg_instance = MESSAGE_ALL_FIGHTERS;
-					//	Squad_msg_mode == SM_MODE_ALL_FIGHTERS
 						hud_squadmsg_msg_all_fighters();
+						// can have the action to perform spoken directly afterwards
 						if (pElements->pProperties->pFirstChild) {
 							doVid_Action(pElements->pProperties->pFirstChild->vValue.ulVal);
 						}
-
-					//	if(Msg_shortcut_command == -1)
-					//	{
-					//		hud_squadmsg_do_mode( SM_MODE_ALL_FIGHTERS );
-					//	}
 						break;
 
 					case VID_Reinforcements:
@@ -445,10 +447,10 @@ void VOICEREC_execute_command(ISpPhrase *pPhrase, HWND hWnd)
 
 				break;
 			}
+			// phrases for transferring shield energy to different locations
 			case VID_shields:
 			{
 				int action = pElements->pProperties->vValue.ulVal;
-				mprintf(("Shield Transfer %d \n", action));
 
 				switch(action)
 				{
@@ -462,27 +464,22 @@ void VOICEREC_execute_command(ISpPhrase *pPhrase, HWND hWnd)
 
 				break;
 			}
+			// basic cheat, phrase as a value equivalent to the defines in ControlConfig/ControlsConfig.h
+			// it just calls the button_function with this value
 			case VID_speed:
 			case VID_targeting:
 			case VID_other:
 			{
 				int action = pElements->pProperties->vValue.ulVal;
-				mprintf(("Targeting/speed %d \n", action));
 
 				if (action > -1)
 				{
 					button_function( action );
 				}
 				break;
-				/*
-				switch(action)
-				{
-					case 0: button_function( TARGET_NEXT ); break;
-						cas
-				}
-				break;
-				*/
 			}
+			// nearly the same as the previous except it has some extra entries for
+			// maximising/minimising energy
 			case VID_power:
 			{
 				int action = pElements->pProperties->vValue.ulVal;
@@ -492,8 +489,8 @@ void VOICEREC_execute_command(ISpPhrase *pPhrase, HWND hWnd)
 					button_function( action );
 				}
 				else
-					// this is for the max engines etc.
 				{
+					// this is for the max engines etc.
 					for (int i=1; i<7; i++)
 					{
 						button_function( action - 132 );
@@ -501,17 +498,6 @@ void VOICEREC_execute_command(ISpPhrase *pPhrase, HWND hWnd)
 				}
 				break;
 			}
-	
-	
-	/*
-
-
-	hud_squadmsg_do_mode( SM_MODE_SHIP_COMMAND );				// and move to a new mode
-	hud_squadmsg_do_mode( SM_MODE_WING_COMMAND );				// and move to a new mode
-hud_squadmsg_do_mode( SM_MODE_SHIP_COMMAND );
-
-*/
-
 		}
 		// Free the pElements memory which was allocated for us
 		::CoTaskMemFree(pElements);


### PR DESCRIPTION
* Frees `cpAudio` pointer in `VOICEREC_deinit()`
* Validates that the ship/wing can actually take orders, and validates that it can take the specific order in question before trying to send it.
* Reports the confidence of the voice match if `DEBUG_ON` is set.
* Various commenting changes based on the patch.

Not included: using confidence to discard voice matches that fall below a certain confidence level. I haven't noticed a tendency towards spurious matches, and I didn't want to introduce this without additional data, especially when it might cause problems for people with different accents (and ESPECIALLY without a setting to tweak the threshold value, which the original patch did not have; it was hardcoded at 90%).

[Mantis link](http://scp.indiegames.us/mantis/view.php?id=2373)