### PR TITLE
Fiction viewer conditional support

### DIFF
--- a/code/fred2/FictionViewerDlg.cpp
+++ b/code/fred2/FictionViewerDlg.cpp
@@ -59,13 +59,27 @@ BOOL FictionViewerDlg::OnInitDialog()
 		box->AddString(Spooled_music[i].name);		
 	}
 
-	// init variables
-	m_fiction_background_640 = _T(fiction_background(GR_640));
-	m_fiction_background_1024 = _T(fiction_background(GR_1024));
-	m_fiction_ui = fiction_ui_index();
-	m_story_file = _T(fiction_file());
-	m_font_file = _T(fiction_font());
-	m_voice_file = _T(fiction_voice());
+	// make sure we have at least one stage
+	if (Fiction_viewer_stages.empty())
+	{
+		fiction_viewer_stage stage;
+		memset(&stage, 0, sizeof(fiction_viewer_stage));
+		stage.formula = Locked_sexp_true;
+
+		Fiction_viewer_stages.push_back(stage);
+	}
+	else if (Fiction_viewer_stages.size() > 1)
+	{
+		MessageBox("You have multiple fiction viewer stages defined for this mission.  At present, FRED will only allow you to edit the first stage.");
+	}
+
+	// init fields based on first fiction viewer stage
+	fiction_viewer_stage *stagep = &Fiction_viewer_stages.at(0);
+	m_story_file = _T(stagep->story_filename);
+	m_font_file = _T(stagep->font_filename);
+	m_voice_file = _T(stagep->voice_filename);
+
+	// music is managed through the mission
 	m_fiction_music = Mission_music[SCORE_FICTION_VIEWER] + 1;
 
 	CDialog::OnInitDialog();
@@ -77,9 +91,15 @@ void FictionViewerDlg::OnOK()
 {
 	UpdateData(TRUE);
 
-	// load it up
-	fiction_viewer_reset();
-	fiction_viewer_load((const char *)(LPCSTR)m_fiction_background_640, (const char *)(LPCSTR)m_fiction_background_1024, m_fiction_ui, (const char *)(LPCSTR)m_story_file, (const char *)(LPCSTR)m_font_file, (const char *)(LPCSTR)m_voice_file);
+	// store the fields in the data structure
+	fiction_viewer_stage *stagep = &Fiction_viewer_stages.at(0);
+	strcpy_s(stagep->story_filename, (LPCSTR)m_story_file);
+	strcpy_s(stagep->font_filename, (LPCSTR)m_font_file);
+	strcpy_s(stagep->voice_filename, (LPCSTR)m_voice_file);
+
+	// if we don't have a story file, remove this stage (stage 0)
+	if (strlen(stagep->story_filename) == 0)
+		Fiction_viewer_stages.erase(Fiction_viewer_stages.begin());
 
 	// set music
 	Mission_music[SCORE_FICTION_VIEWER] = m_fiction_music - 1;
@@ -117,6 +137,8 @@ void FictionViewerDlg::OnClose()
 
 int FictionViewerDlg::query_modified()
 {
-	return strcmp(m_story_file, fiction_file()) || strcmp(m_font_file, fiction_font()) || 
-		strcmp(m_voice_file, fiction_voice()) || m_fiction_music != (Mission_music[SCORE_FICTION_VIEWER] + 1);
+	fiction_viewer_stage *stagep = &Fiction_viewer_stages.at(0);
+
+	return strcmp(m_story_file, stagep->story_filename) || strcmp(m_font_file, stagep->font_filename) ||
+		strcmp(m_voice_file, stagep->voice_filename) || m_fiction_music != (Mission_music[SCORE_FICTION_VIEWER] + 1);
 }

--- a/code/fred2/missionsave.cpp
+++ b/code/fred2/missionsave.cpp
@@ -761,54 +761,74 @@ int CFred_mission_save::save_fiction()
 		if (Format_fs2_open != FSO_FORMAT_RETAIL)
 		{
 			if (optional_string_fred("#Fiction Viewer"))
-				parse_comments();
+				parse_comments(2);
 			else
 				fout("\n\n#Fiction Viewer");
 
-			fout("\n");
-
-			// save background
-			save_custom_bitmap("$Background 640:", "$Background 1024:", fiction_background(GR_640), fiction_background(GR_1024));
-
-			// save UI
-			const char *ui_name = fiction_ui_name();
-			if (ui_name)
+			// we have multiple stages now, so save them all
+			for (SCP_vector<fiction_viewer_stage>::iterator stage = Fiction_viewer_stages.begin(); stage != Fiction_viewer_stages.end(); ++stage)
 			{
-				if (optional_string_fred("$UI:"))
-					parse_comments();
-				else
-					fout("\n$UI:");
-				fout(" %s", ui_name);
-			}
+				fout("\n");
 
-			// save file
-			required_string_fred("$File:");
-			parse_comments();
-			fout(" %s", fiction_file());
+				// save file
+				required_string_fred("$File:");
+				parse_comments();
+				fout(" %s", stage->story_filename);
 
-			// save font
-			if (strlen(fiction_font()) > 0) //-V805
-			{
-				if (optional_string_fred("$Font:"))
-					parse_comments();
+				// save font
+				if (strlen(stage->font_filename) > 0) //-V805
+				{
+					if (optional_string_fred("$Font:"))
+						parse_comments();
+					else
+						fout("\n$Font:");
+					fout(" %s", stage->font_filename);
+				}
 				else
-					fout("\n$Font:");
-				fout(" %s", fiction_font());
-			}
-			else
-				optional_string_fred("$Font:");
+					optional_string_fred("$Font:");
 
-			// save voice
-			if (strlen(fiction_voice()) > 0) //-V805
-			{
-				if (optional_string_fred("$Voice:"))
-					parse_comments();
+				// save voice
+				if (strlen(stage->voice_filename) > 0) //-V805
+				{
+					if (optional_string_fred("$Voice:"))
+						parse_comments();
+					else
+						fout("\n$Voice:");
+					fout(" %s", stage->voice_filename);
+				}
 				else
-					fout("\n$Voice:");
-				fout(" %s", fiction_voice());
+					optional_string_fred("$Voice:");
+
+				// save UI
+				if (strlen(stage->ui_name) > 0)
+				{
+					if (optional_string_fred("$UI:"))
+						parse_comments();
+					else
+						fout("\n$UI:");
+					fout(" %s", stage->ui_name);
+				}
+				else
+					optional_string_fred("$UI:");
+
+				// save background
+				save_custom_bitmap("$Background 640:", "$Background 1024:", stage->background[GR_640], stage->background[GR_1024]);
+
+				// save sexp formula if we have one
+				if (stage->formula >= 0 && stage->formula != Locked_sexp_true)
+				{
+					SCP_string sexp_out;
+					convert_sexp_to_string(sexp_out, stage->formula, SEXP_SAVE_MODE);
+
+					if (optional_string_fred("$Formula:"))
+						parse_comments();
+					else
+						fout("\n$Formula:");
+					fout(" %s", sexp_out.c_str());
+				}
+				else
+					optional_string_fred("$Formula:");
 			}
-			else
-				optional_string_fred("$Voice:");
 		}
 		else
 		{

--- a/code/graphics/font.cpp
+++ b/code/graphics/font.cpp
@@ -551,7 +551,7 @@ int gr_get_current_fontnum()
 	}
 }
 
-int gr_get_fontnum(char *filename)
+int gr_get_fontnum(const char *filename)
 {
 	int i;
 	for(i = 0; i < Num_fonts; i++)

--- a/code/graphics/font.h
+++ b/code/graphics/font.h
@@ -69,7 +69,7 @@ extern font *Current_font;
 // extern definitions for basic font functions
 extern void gr_stuff_first_font(char *first_font, size_t first_font_size);
 extern int gr_get_current_fontnum();
-extern int gr_get_fontnum(char *filename);
+extern int gr_get_fontnum(const char *filename);
 extern void gr_set_font(int fontnum);
 
 void gr_print_timestamp(int x, int y, fix timestamp, int resize_mode);

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -1298,7 +1298,7 @@ void parse_fiction(mission *pm)
 			// see if this is the stage we want to display, then display it
 			if (!Fred_running && !fiction_viewer_loaded && is_sexp_true(stage.formula))
 			{
-				fiction_viewer_load(&Fiction_viewer_stages.back());
+				fiction_viewer_load(Fiction_viewer_stages.size() - 1);
 				fiction_viewer_loaded = true;
 			}
 		}

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -1262,49 +1262,47 @@ done_briefing_music:
  */
 void parse_fiction(mission *pm)
 {
-	char background_640[MAX_FILENAME_LEN];
-	char background_1024[MAX_FILENAME_LEN];
-	int ui_index = -1;
-	char filename[MAX_FILENAME_LEN];
-	char font_filename[MAX_FILENAME_LEN];
-	char voice_filename[MAX_FILENAME_LEN];
-
 	fiction_viewer_reset();
 
-	if (!optional_string("#Fiction Viewer"))
-		return;
+	if (optional_string("#Fiction Viewer"))
+	{
+		bool fiction_viewer_loaded = false;
 
-	parse_custom_bitmap("$Background 640:", "$Background 1024:", background_640, background_1024);
-
-	if (optional_string("$UI:")) {
-		char ui_name[NAME_LENGTH];
-		stuff_string(ui_name, F_NAME, NAME_LENGTH);
-		ui_index = fiction_viewer_ui_name_to_index(ui_name);
-		if (ui_index < 0)
+		while (check_for_string("$File:"))
 		{
-			Warning(LOCATION, "Unrecognized fiction viewer UI: %s", ui_name);
+			fiction_viewer_stage stage;
+			memset(&stage, 0, sizeof(fiction_viewer_stage));
+			stage.formula = Locked_sexp_true;
+
+			required_string("$File:");
+			stuff_string(stage.story_filename, F_FILESPEC, MAX_FILENAME_LEN);
+
+			if (optional_string("$Font:"))
+				stuff_string(stage.font_filename, F_FILESPEC, MAX_FILENAME_LEN);
+
+			if (optional_string("$Voice:"))
+				stuff_string(stage.voice_filename, F_FILESPEC, MAX_FILENAME_LEN);
+
+			if (optional_string("$UI:"))
+				stuff_string(stage.ui_name, F_NAME, NAME_LENGTH);
+
+			parse_custom_bitmap("$Background 640:", "$Background 1024:", stage.background[GR_640], stage.background[GR_1024]);
+
+			// get the sexp if we have one
+			if (optional_string("$Formula:"))
+				stage.formula = get_sexp_main();
+
+			// now, store this stage
+			Fiction_viewer_stages.push_back(stage);
+
+			// see if this is the stage we want to display, then display it
+			if (!Fred_running && !fiction_viewer_loaded && is_sexp_true(stage.formula))
+			{
+				fiction_viewer_load(&Fiction_viewer_stages.back());
+				fiction_viewer_loaded = true;
+			}
 		}
 	}
-	if (!Fred_running && ui_index < 0) {
-		ui_index = Default_fiction_viewer_ui;
-	}
-
-	required_string("$File:");
-	stuff_string(filename, F_FILESPEC, MAX_FILENAME_LEN);
-
-	if (optional_string("$Font:")) {
-		stuff_string(font_filename, F_FILESPEC, MAX_FILENAME_LEN);
-	} else {
-		strcpy_s(font_filename, "");
-	}
-
-	if (optional_string("$Voice:")) {
-		stuff_string(voice_filename, F_FILESPEC, MAX_FILENAME_LEN);
-	} else {
-		strcpy_s(voice_filename, "");
-	}
-
-	fiction_viewer_load(background_640, background_1024, ui_index, filename, font_filename, voice_filename);
 }
 
 /**

--- a/code/missionui/fictionviewer.cpp
+++ b/code/missionui/fictionviewer.cpp
@@ -533,7 +533,7 @@ void fiction_viewer_load(int stage)
 	// just to be sure
 	if (Fiction_viewer_text != nullptr)
 	{
-		Assertion(Fiction_viewer_text != nullptr, "Fiction viewer text should be a null pointer, but instead is '%s'. Trace out and fix!\n", Fiction_viewer_text);
+		Assertion(Fiction_viewer_text == nullptr, "Fiction viewer text should be a null pointer, but instead is '%s'. Trace out and fix!\n", Fiction_viewer_text);
 		return;
 	}
 

--- a/code/missionui/fictionviewer.cpp
+++ b/code/missionui/fictionviewer.cpp
@@ -167,7 +167,7 @@ static int Fiction_viewer_inited = 0;
 static int Fiction_viewer_old_fontnum = -1;
 static int Fiction_viewer_fontnum = -1;
 
-static char *Fiction_viewer_text = NULL;
+static char *Fiction_viewer_text = nullptr;
 static int Fiction_viewer_voice = -1;
 
 static int Fiction_viewer_ui = -1;
@@ -489,7 +489,7 @@ bool mission_has_fiction()
 	if (Fred_running)
 		return !Fiction_viewer_stages.empty();
 	else
-		return (Fiction_viewer_text != NULL);
+		return (Fiction_viewer_text != nullptr);
 }
 
 int fiction_viewer_ui_name_to_index(const char *ui_name)
@@ -508,9 +508,9 @@ int fiction_viewer_ui_name_to_index(const char *ui_name)
 
 void fiction_viewer_reset()
 {
-	if (Fiction_viewer_text != NULL)
+	if (Fiction_viewer_text != nullptr)
 		vm_free(Fiction_viewer_text);
-	Fiction_viewer_text = NULL;
+	Fiction_viewer_text = nullptr;
 
 	Fiction_viewer_stages.clear();
 	Fiction_viewer_active_stage = -1;
@@ -531,9 +531,9 @@ void fiction_viewer_load(int stage)
 	Assertion(stage >= 0 && static_cast<size_t>(stage) < Fiction_viewer_stages.size(), "stage parameter must be in range of Fiction_viewer_stages!");
 
 	// just to be sure
-	if (Fiction_viewer_text != NULL)
+	if (Fiction_viewer_text != nullptr)
 	{
-		Error(LOCATION, "Fiction viewer text should be NULL here!  Trace out and fix!");
+		Assertion(Fiction_viewer_text != nullptr, "Fiction viewer text should be a null pointer, but instead is '%s'. Trace out and fix!\n", Fiction_viewer_text);
 		return;
 	}
 

--- a/code/missionui/fictionviewer.cpp
+++ b/code/missionui/fictionviewer.cpp
@@ -154,7 +154,7 @@ int Fiction_viewer_slider_coordinates[NUM_FVW_SETTINGS][GR_NUM_RESOLUTIONS][4] =
 };
 
 SCP_vector<fiction_viewer_stage> Fiction_viewer_stages;
-const fiction_viewer_stage *Fiction_viewer_active_stage = NULL;
+int Fiction_viewer_active_stage = -1;
 
 static int Top_fiction_viewer_text_line = 0;
 static int Fiction_viewer_text_max_lines = 0;
@@ -273,7 +273,7 @@ void fiction_viewer_init()
 		return;
 
 	// no stage loaded?
-	if (Fiction_viewer_active_stage == NULL)
+	if (Fiction_viewer_active_stage < 0)
 		return;
 
 	// no fiction document?
@@ -285,11 +285,11 @@ void fiction_viewer_init()
 
 	Fiction_viewer_bitmap = -1;
 
-	if (*Fiction_viewer_active_stage->background[gr_screen.res] != '\0')
+	if (Fiction_viewer_stages[Fiction_viewer_active_stage].background[gr_screen.res] != '\0')
 	{
-		Fiction_viewer_bitmap = bm_load(Fiction_viewer_active_stage->background[gr_screen.res]);
+		Fiction_viewer_bitmap = bm_load(Fiction_viewer_stages[Fiction_viewer_active_stage].background[gr_screen.res]);
 		if (Fiction_viewer_bitmap < 0)
-			mprintf(("Failed to load custom background bitmap %s!\n", Fiction_viewer_active_stage->background[gr_screen.res]));
+			mprintf(("Failed to load custom background bitmap %s!\n", Fiction_viewer_stages[Fiction_viewer_active_stage].background[gr_screen.res]));
 		else if (Fiction_viewer_ui < 0)
 			Fiction_viewer_ui = 0;
 	}
@@ -513,7 +513,7 @@ void fiction_viewer_reset()
 	Fiction_viewer_text = NULL;
 
 	Fiction_viewer_stages.clear();
-	Fiction_viewer_active_stage = NULL;
+	Fiction_viewer_active_stage = -1;
 
 	Fiction_viewer_ui = -1;
 
@@ -526,8 +526,10 @@ void fiction_viewer_reset()
 	}
 }
 
-void fiction_viewer_load(const fiction_viewer_stage *stagep)
+void fiction_viewer_load(int stage)
 {
+	Assertion(stage >= 0 && static_cast<size_t>(stage) < Fiction_viewer_stages.size(), "stage parameter must be in range of Fiction_viewer_stages!");
+
 	// just to be sure
 	if (Fiction_viewer_text != NULL)
 	{
@@ -535,7 +537,8 @@ void fiction_viewer_load(const fiction_viewer_stage *stagep)
 		return;
 	}
 
-	Fiction_viewer_active_stage = stagep;
+	Fiction_viewer_active_stage = stage;
+	fiction_viewer_stage *stagep = &Fiction_viewer_stages[stage];
 
 	// load the ui index
 	Fiction_viewer_ui = Default_fiction_viewer_ui;

--- a/code/missionui/fictionviewer.cpp
+++ b/code/missionui/fictionviewer.cpp
@@ -285,7 +285,7 @@ void fiction_viewer_init()
 
 	Fiction_viewer_bitmap = -1;
 
-	if (Fiction_viewer_stages[Fiction_viewer_active_stage].background[gr_screen.res] != '\0')
+	if (*Fiction_viewer_stages[Fiction_viewer_active_stage].background[gr_screen.res] != '\0')
 	{
 		Fiction_viewer_bitmap = bm_load(Fiction_viewer_stages[Fiction_viewer_active_stage].background[gr_screen.res]);
 		if (Fiction_viewer_bitmap < 0)

--- a/code/missionui/fictionviewer.cpp
+++ b/code/missionui/fictionviewer.cpp
@@ -17,6 +17,7 @@
 #include "missionui/missioncmdbrief.h"
 #include "missionui/missionscreencommon.h"
 #include "missionui/redalert.h"
+#include "mod_table/mod_table.h"
 #include "sound/audiostr.h"
 
 
@@ -152,8 +153,11 @@ int Fiction_viewer_slider_coordinates[NUM_FVW_SETTINGS][GR_NUM_RESOLUTIONS][4] =
 	}
 };
 
-int Top_fiction_viewer_text_line = 0;
-int Fiction_viewer_text_max_lines = 0;
+SCP_vector<fiction_viewer_stage> Fiction_viewer_stages;
+const fiction_viewer_stage *Fiction_viewer_active_stage = NULL;
+
+static int Top_fiction_viewer_text_line = 0;
+static int Fiction_viewer_text_max_lines = 0;
 
 static UI_WINDOW Fiction_viewer_window;
 static UI_SLIDER2 Fiction_viewer_slider;
@@ -163,10 +167,6 @@ static int Fiction_viewer_inited = 0;
 static int Fiction_viewer_old_fontnum = -1;
 static int Fiction_viewer_fontnum = -1;
 
-static char Fiction_viewer_background[GR_NUM_RESOLUTIONS][MAX_FILENAME_LEN];
-static char Fiction_viewer_filename[MAX_FILENAME_LEN];
-static char Fiction_viewer_font_filename[MAX_FILENAME_LEN];
-static char Fiction_viewer_voice_filename[MAX_FILENAME_LEN];
 static char *Fiction_viewer_text = NULL;
 static int Fiction_viewer_voice = -1;
 
@@ -272,7 +272,11 @@ void fiction_viewer_init()
 	if (Fiction_viewer_inited)
 		return;
 
-	// no fiction viewer?
+	// no stage loaded?
+	if (Fiction_viewer_active_stage == NULL)
+		return;
+
+	// no fiction document?
 	if (!mission_has_fiction())
 		return;
 
@@ -281,11 +285,11 @@ void fiction_viewer_init()
 
 	Fiction_viewer_bitmap = -1;
 
-	if (*Fiction_viewer_background[gr_screen.res] != '\0')
+	if (*Fiction_viewer_active_stage->background[gr_screen.res] != '\0')
 	{
-		Fiction_viewer_bitmap = bm_load(Fiction_viewer_background[gr_screen.res]);
+		Fiction_viewer_bitmap = bm_load(Fiction_viewer_active_stage->background[gr_screen.res]);
 		if (Fiction_viewer_bitmap < 0)
-			mprintf(("Failed to load custom background bitmap %s!\n", Fiction_viewer_background[gr_screen.res]));
+			mprintf(("Failed to load custom background bitmap %s!\n", Fiction_viewer_active_stage->background[gr_screen.res]));
 		else if (Fiction_viewer_ui < 0)
 			Fiction_viewer_ui = 0;
 	}
@@ -480,37 +484,15 @@ void fiction_viewer_unpause()
 	}
 }
 
-int mission_has_fiction()
+bool mission_has_fiction()
 {
 	if (Fred_running)
-		return *Fiction_viewer_filename != 0;
+		return !Fiction_viewer_stages.empty();
 	else
 		return (Fiction_viewer_text != NULL);
 }
 
-const char *fiction_background(int res)
-{
-	return Fiction_viewer_background[res];
-}
-
-int fiction_ui_index()
-{
-	return Fiction_viewer_ui;
-}
-
-const char *fiction_ui_name()
-{
-	if (Fiction_viewer_ui >= 0 && Fiction_viewer_ui < NUM_FVW_SETTINGS)
-	{
-		return Fiction_viewer_ui_names[Fiction_viewer_ui];
-	}
-	else
-	{
-		return NULL;
-	}
-}
-
-int fiction_viewer_ui_name_to_index(char *ui_name)
+int fiction_viewer_ui_name_to_index(const char *ui_name)
 {
 	int i;
 	for (i = 0; i < NUM_FVW_SETTINGS; i++)
@@ -524,32 +506,16 @@ int fiction_viewer_ui_name_to_index(char *ui_name)
 	return -1;
 }
 
-const char *fiction_file()
-{
-	return Fiction_viewer_filename;
-}
-
-const char *fiction_font()
-{
-	return Fiction_viewer_font_filename;
-}
-
-const char *fiction_voice()
-{
-	return Fiction_viewer_voice_filename;
-}
-
 void fiction_viewer_reset()
 {
 	if (Fiction_viewer_text != NULL)
 		vm_free(Fiction_viewer_text);
 	Fiction_viewer_text = NULL;
 
-	Fiction_viewer_ui = -1;
+	Fiction_viewer_stages.clear();
+	Fiction_viewer_active_stage = NULL;
 
-	*Fiction_viewer_filename = 0;
-	*Fiction_viewer_font_filename = 0;
-	*Fiction_viewer_voice_filename = 0;
+	Fiction_viewer_ui = -1;
 
 	Top_fiction_viewer_text_line = 0;
 
@@ -560,55 +526,43 @@ void fiction_viewer_reset()
 	}
 }
 
-void fiction_viewer_load(const char *background_640, const char *background_1024, int ui_index, const char *filename, const char *font_filename, const char *voice_filename)
+void fiction_viewer_load(const fiction_viewer_stage *stagep)
 {
-	int file_length;
-	Assertion(filename, "Invalid fictionviewer filename pointer given!");
-	Assertion(font_filename, "Invalid fictionviewer font filename pointer given!");
-	Assertion(voice_filename, "Invalid fictionviewer voice filename pointer given!");
-
 	// just to be sure
 	if (Fiction_viewer_text != NULL)
 	{
-		Int3();
-		fiction_viewer_reset();
+		Error(LOCATION, "Fiction viewer text should be NULL here!  Trace out and fix!");
+		return;
 	}
 
-	// save the ui index
-	Fiction_viewer_ui = ui_index;
+	Fiction_viewer_active_stage = stagep;
 
-	// save our filenames
-	strcpy_s(Fiction_viewer_background[GR_640], background_640);
-	strcpy_s(Fiction_viewer_background[GR_1024], background_1024);
-	strcpy_s(Fiction_viewer_filename, filename);
-	strcpy_s(Fiction_viewer_font_filename, font_filename);
-	strcpy_s(Fiction_viewer_voice_filename, voice_filename);
+	// load the ui index
+	Fiction_viewer_ui = Default_fiction_viewer_ui;
+	if (*stagep->ui_name)
+	{
+		int ui_index = fiction_viewer_ui_name_to_index(stagep->ui_name);
+		if (ui_index >= 0)
+			Fiction_viewer_ui = ui_index;
+		else
+			Warning(LOCATION, "Unrecognized fiction viewer UI: %s", stagep->ui_name);
+	}
 
 	// see if we have a matching font
-	Fiction_viewer_fontnum = gr_get_fontnum(Fiction_viewer_font_filename);
-	if (Fiction_viewer_fontnum < 0 && !Fred_running)
-		strcpy_s(Fiction_viewer_font_filename, "");
+	Fiction_viewer_fontnum = gr_get_fontnum(stagep->font_filename);
 
-	Fiction_viewer_voice = audiostream_open(Fiction_viewer_voice_filename, ASF_VOICE);
-	if (Fiction_viewer_voice < 0 && !Fred_running)
-		strcpy_s(Fiction_viewer_voice_filename, "");
-
-	if (!strlen(filename))
-		return;
+	Fiction_viewer_voice = audiostream_open(stagep->voice_filename, ASF_VOICE);
 
 	// load up the text
-	CFILE *fp = cfopen(filename, "rb", CFILE_NORMAL, CF_TYPE_FICTION);
+	CFILE *fp = cfopen(stagep->story_filename, "rb", CFILE_NORMAL, CF_TYPE_FICTION);
 	if (fp == NULL)
 	{
-		Warning(LOCATION, "Unable to load fiction file '%s'.", filename);
-		return;
+		Warning(LOCATION, "Unable to load story file '%s'.", stagep->story_filename);
 	}
-
-	// we don't need to copy the text in Fred
-	if (!Fred_running)
+	else
 	{
 		// allocate space
-		file_length = cfilelength(fp);
+		int file_length = cfilelength(fp);
 		Fiction_viewer_text = (char *) vm_malloc(file_length + 1);
 		Fiction_viewer_text[file_length] = '\0';
 

--- a/code/missionui/fictionviewer.h
+++ b/code/missionui/fictionviewer.h
@@ -9,22 +9,36 @@
 #ifndef __FICTION_VIEWER_H__
 #define __FICTION_VIEWER_H__
 
+#include "globalincs/globals.h"
+#include "globalincs/pstypes.h"
+#include "graphics/2d.h"
+
+
+// since we may now have multiple possible fiction stages, activated by a formula
+typedef struct fiction_viewer_stage {
+	char story_filename[MAX_FILENAME_LEN];
+	char font_filename[MAX_FILENAME_LEN];
+	char voice_filename[MAX_FILENAME_LEN];
+
+	char ui_name[NAME_LENGTH];
+	char background[GR_NUM_RESOLUTIONS][MAX_FILENAME_LEN];
+
+	int formula;
+} fiction_viewer_stage;
+
+extern SCP_vector<fiction_viewer_stage> Fiction_viewer_stages;
+
+
 // management stuff
 void fiction_viewer_init();
 void fiction_viewer_close();
 void fiction_viewer_do_frame(float frametime);
 
 // fiction stuff
-int mission_has_fiction();
-const char *fiction_background(int res);
-int fiction_ui_index();
-const char *fiction_ui_name();
-int fiction_viewer_ui_name_to_index(char *ui_name);
-const char *fiction_file();
-const char *fiction_font();
-const char *fiction_voice();
+bool mission_has_fiction();
+int fiction_viewer_ui_name_to_index(const char *ui_name);
 void fiction_viewer_reset();
-void fiction_viewer_load(const char *background_640, const char *background_1024, int ui_index, const char *filename, const char *font_filename, const char* voice_filename);
+void fiction_viewer_load(const fiction_viewer_stage *stage);
 
 void fiction_viewer_pause();
 void fiction_viewer_unpause();

--- a/code/missionui/fictionviewer.h
+++ b/code/missionui/fictionviewer.h
@@ -38,7 +38,7 @@ void fiction_viewer_do_frame(float frametime);
 bool mission_has_fiction();
 int fiction_viewer_ui_name_to_index(const char *ui_name);
 void fiction_viewer_reset();
-void fiction_viewer_load(const fiction_viewer_stage *stage);
+void fiction_viewer_load(int stage);
 
 void fiction_viewer_pause();
 void fiction_viewer_unpause();

--- a/code/sound/audiostr.cpp
+++ b/code/sound/audiostr.cpp
@@ -1711,7 +1711,7 @@ void audiostream_close()
 //	
 // returns:	success => handle to identify streaming sound
 //				failure => -1
-int audiostream_open( char *filename, int type )
+int audiostream_open( const char *filename, int type )
 {
 	int i, rc;
 	char fname[MAX_FILENAME_LEN];

--- a/code/sound/audiostr.h
+++ b/code/sound/audiostr.h
@@ -57,7 +57,7 @@ void audiostream_init();
 void audiostream_close();
 
 // Opens a wave file but doesn't play it.
-int audiostream_open( char * filename, int type );
+int audiostream_open( const char * filename, int type );
 
 // Closes the opened wave file.  This doesn't have to be
 // called between songs, because when you open the next


### PR DESCRIPTION
Per Battuta's request in HPC, this adds support for multiple fiction viewer stages per mission.  Only one stage will be displayed when the mission loads, but the associated conditional sexp will determine which of the several stages will be displayed.

FRED support consists of just loading and saving; the addition of sexp tree GUI support would require a bit more coding work.

Note that this PR rearranges the new fields for the fiction viewer that Yarn added in #353.  This was necessary because the required field $File must appear first so that the parser can determine the number of stages on the fly.