### PR TITLE
Fix for Mantis 3115

### DIFF
--- a/code/model/model.h
+++ b/code/model/model.h
@@ -619,6 +619,7 @@ typedef struct insignia {
 #define PM_FLAG_AUTOCEN				(1<<1)					// contains autocentering info	
 #define PM_FLAG_TRANS_BUFFER		(1<<2)					// render transparency buffer
 #define PM_FLAG_BATCHED				(1<<3)					// this model can be batch rendered
+#define PM_FLAGS_HAS_LOOK_AT		(1<<4)					// this model has a submodel that does look_at
 
 // Goober5000
 class texture_info

--- a/code/model/modelinterp.cpp
+++ b/code/model/modelinterp.cpp
@@ -2011,6 +2011,10 @@ void model_render_DEPRECATED(int model_num, matrix *orient, vec3d * pos, uint fl
 
 	polymodel *pm = model_get(model_num);
 
+	if (pm->flags & PM_FLAGS_HAS_LOOK_AT) {
+		model_do_look_at(model_num);
+	}
+
 	model_do_dumb_rotation(model_num);
 
 	if (flags & MR_FORCE_CLAMP)

--- a/code/model/modelread.cpp
+++ b/code/model/modelread.cpp
@@ -1216,19 +1216,12 @@ int read_model_file(polymodel * pm, char *filename, int n_subsystems, model_subs
 					}
 				}
 
-				// Sets can_move on submodels which are of a rotating type or which have such a parent somewhere down the hierarchy
-				if ( (pm->submodel[n].movement_type != MOVEMENT_TYPE_NONE)
-					|| strstr(props, "$triggered:") || strstr(props, "$rotate") || strstr(props, "$dumb_rotate:") || strstr(props, "$gun_rotation:") || strstr(props, "$gun_rotation") ) {
-					pm->submodel[n].can_move = true;
-				} else if (pm->submodel[n].parent > -1 && pm->submodel[pm->submodel[n].parent].can_move) {
-					pm->submodel[n].can_move = true;
-				}
-
 				if ( ( p = strstr(props, "$look_at:")) != NULL ) {
 					pm->submodel[n].movement_type = MOVEMENT_TYPE_LOOK_AT;
 					get_user_prop_value(p+9, pm->submodel[n].look_at);
 					pm->submodel[n].look_at_num = -2; // Set this to -2 to mark it as something we need to work out the correct subobject number for later, after all subobjects have been processed
 					
+					pm->flags |= PM_FLAGS_HAS_LOOK_AT;
 				} else {
 					pm->submodel[n].look_at_num = -1; // No look_at
 				}
@@ -1238,6 +1231,14 @@ int read_model_file(polymodel * pm, char *filename, int n_subsystems, model_subs
 					pm->submodel[n].dumb_turn_rate = (float)atof(p+13);
 				} else {
 					pm->submodel[n].dumb_turn_rate = 0.0f;
+				}
+
+				// Sets can_move on submodels which are of a rotating type or which have such a parent somewhere down the hierarchy
+				if ( (pm->submodel[n].movement_type != MOVEMENT_TYPE_NONE)
+					|| strstr(props, "$triggered:") || strstr(props, "$rotate") || strstr(props, "$gun_rotation:") || strstr(props, "$gun_rotation") ) {
+					pm->submodel[n].can_move = true;
+				} else if (pm->submodel[n].parent > -1 && pm->submodel[pm->submodel[n].parent].can_move) {
+					pm->submodel[n].can_move = true;
 				}
 
 				if ( pm->submodel[n].name[0] == '\0' ) {
@@ -3481,7 +3482,7 @@ void submodel_look_at(polymodel *pm, int mn)
 		}
 
 		if (sm->look_at_num == -2) {
-			Warning( LOCATION, "Invalid submodel name given in $look_at: property in model file <%s>. (%s looking for %s)\n", pm->filename, pm->submodel->name, sm->look_at );
+			Warning( LOCATION, "Invalid submodel name given in $look_at: property in model file <%s>. (%s looking for %s)\n", pm->filename, sm->name, sm->look_at );
 			sm->look_at_num = -1; // Set to -1 to not break stuff
 		}
 	}

--- a/code/model/modelrender.cpp
+++ b/code/model/modelrender.cpp
@@ -2670,6 +2670,10 @@ void model_render_queue(model_render_params *interp, draw_list *scene, int model
 	const int model_flags = interp->get_model_flags();
 
 	polymodel *pm = model_get(model_num);
+	
+	if (pm->flags & PM_FLAGS_HAS_LOOK_AT) {
+		model_do_look_at(model_num);
+	}
 		
 	model_do_dumb_rotation(model_num);
 


### PR DESCRIPTION
This is based on the patch uploaded by MageKing17 and adds a polymodel flag that indicates that a model uses look_at

This is currently untested as I can't create a mission containing the test model (no FRED on linux).