### PR TITLE
cfclose() will hit an assertion if we try to close a null pointer

### DIFF
--- a/code/missionui/fictionviewer.cpp
+++ b/code/missionui/fictionviewer.cpp
@@ -571,8 +571,8 @@ void fiction_viewer_load(int stage)
 
 		// copy all the text
 		cfread(Fiction_viewer_text, file_length, 1, fp);
-	}
 
-	// we're done, close it out
-	cfclose(fp);
+		// we're done, close it out
+		cfclose(fp);
+	}
 }


### PR DESCRIPTION
Quick bugfix PR.