### PR TITLE
Allow ships to arrive from hangars on player ships

### DIFF
--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -6669,8 +6669,7 @@ int mission_did_ship_arrive(p_object *objp)
 			Assert( objp->arrival_anchor >= 0 );
 			name = Parse_names[objp->arrival_anchor];
 	
-			// see if ship is in mission.  If not, then we can assume it was destroyed or departed since
-			// it is not on the arrival list (as shown by above if statement).
+			// see if ship is in mission.
 			shipnum = ship_name_lookup( name );
 			if ( shipnum == -1 ) {
 				// see if ship is yet to arrive.  If so, then return -1 so we can evaluate again later.

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -3959,8 +3959,7 @@ int parse_wing_create_ships( wing *wingp, int num_to_create, int force, int spec
 			Assert( wingp->arrival_anchor >= 0 );
 			name = Parse_names[wingp->arrival_anchor];
 
-			// see if ship is in mission.  If not, then we can assume it was destroyed or departed since
-			// it is not on the arrival list (as shown by above if statement).
+			// see if ship is in mission.
 			shipnum = ship_name_lookup( name );
 			if ( shipnum == -1 ) {
 				int num_remaining;

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -6396,7 +6396,10 @@ int mission_parse_get_multi_mission_info( const char *filename )
 }
 
 /**
- * Return the parse object on the ship arrival list associated with the given name
+ * Returns the parse object on the ship arrival list associated with the given name.
+ * Returns NULL if the object is not on the Arrival list, or if the object is a player
+ * ship that is already in game (Player ships never get removed from the arrival list
+ * in order to make respawns in multiplayer work).
  */
 p_object *mission_parse_get_arrival_ship(const char *name)
 {
@@ -6409,6 +6412,7 @@ p_object *mission_parse_get_arrival_ship(const char *name)
 	{
 		if (!stricmp(p_objp->name, name)) 
 		{
+			//If this is a player ship, and the ship is currently in-game, return NULL
 			if (p_objp->flags & P_OF_PLAYER_START && ship_name_lookup(name) != -1)
 				return NULL;
 			return p_objp;	// still on the arrival list
@@ -6419,16 +6423,24 @@ p_object *mission_parse_get_arrival_ship(const char *name)
 }
 
 /**
- * Return the parse object on the ship arrival list associated with the given signature
- */
+* Returns the parse object on the ship arrival list associated with the given net signature.
+* Returns NULL if the object is not on the Arrival list, or if the object is a player
+* ship that is already in game (Player ships never get removed from the arrival list
+* in order to make respawns in multiplayer work).
+*/
 p_object *mission_parse_get_arrival_ship(ushort net_signature)
 {
 	p_object *p_objp;
 
 	for (p_objp = GET_FIRST(&Ship_arrival_list); p_objp !=END_OF_LIST(&Ship_arrival_list); p_objp = GET_NEXT(p_objp))
 	{
-		if (p_objp->net_signature == net_signature)
+		if (p_objp->net_signature == net_signature) 
+		{
+			//If this is a player ship, and the ship is currently in-game, return NULL
+			if (p_objp->flags & P_OF_PLAYER_START && ship_name_lookup(p_objp->name) != -1)
+				return NULL;
 			return p_objp;	// still on the arrival list
+		}
 	}
 
 	return NULL;

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -4154,7 +4154,7 @@ int parse_wing_create_ships( wing *wingp, int num_to_create, int force, int spec
 
 		// keep any player ship on the parse object list -- used for respawns
 		// 5/8/98 -- MWA -- don't remove ships from the list when you are ingame joining
-		if (!(p_objp->flags & P_OF_PLAYER_START && Game_mode & GM_MULTIPLAYER))
+		if (!(p_objp->flags & P_OF_PLAYER_START))
 		{
 			if ((Game_mode & GM_NORMAL) || !(Net_player->flags & NETINFO_FLAG_INGAME_JOIN))
 			{
@@ -6408,7 +6408,11 @@ p_object *mission_parse_get_arrival_ship(const char *name)
 	for (p_objp = GET_FIRST(&Ship_arrival_list); p_objp != END_OF_LIST(&Ship_arrival_list); p_objp = GET_NEXT(p_objp))
 	{
 		if (!stricmp(p_objp->name, name)) 
+		{
+			if (p_objp->flags & P_OF_PLAYER_START && ship_name_lookup(name) != -1)
+				return NULL;
 			return p_objp;	// still on the arrival list
+		}
 	}
 
 	return NULL;

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -6396,10 +6396,14 @@ int mission_parse_get_multi_mission_info( const char *filename )
 }
 
 /**
- * Returns the parse object on the ship arrival list associated with the given name.
- * Returns NULL if the object is not on the Arrival list, or if the object is a player
- * ship that is already in game (Player ships never get removed from the arrival list
- * in order to make respawns in multiplayer work).
+ * \brief				Returns the parse object on the ship arrival list associated with the given name.
+ * \param[in] name		The name of the object
+ * \returns				The parse object, or NULL if:
+ *						\li No object with the given name is on the arrival list
+ *						\li The object is a player ship and currently in-game
+ * \remarks				This function is used to determine whether a ship has arrived. Ships on the arrival list
+ *						are considered to not be in the game; In order to make respawns work in multiplayer,
+ *						player ships (those marked with the P_OF_PLAYER_START flag) are never removed from it.
  */
 p_object *mission_parse_get_arrival_ship(const char *name)
 {
@@ -6412,7 +6416,7 @@ p_object *mission_parse_get_arrival_ship(const char *name)
 	{
 		if (!stricmp(p_objp->name, name)) 
 		{
-			//If this is a player ship, and the ship is currently in-game, return NULL
+			//If this is a player ship and the ship is currently in-game, return NULL
 			if (p_objp->flags & P_OF_PLAYER_START && ship_name_lookup(name) != -1)
 				return NULL;
 			return p_objp;	// still on the arrival list
@@ -6423,11 +6427,15 @@ p_object *mission_parse_get_arrival_ship(const char *name)
 }
 
 /**
-* Returns the parse object on the ship arrival list associated with the given net signature.
-* Returns NULL if the object is not on the Arrival list, or if the object is a player
-* ship that is already in game (Player ships never get removed from the arrival list
-* in order to make respawns in multiplayer work).
-*/
+ * \brief					Returns the parse object on the ship arrival list associated with the given net signature.
+ * \param[in] net_signature	The net signature of the object
+ * \returns					The parse object, or NULL if:
+ *								\li No object with the given signature is on the arrival list
+ *								\li The object is a player ship and currently in-game
+ * \remarks					This function is used to determine whether a ship has arrived. Ships on the arrival list
+ *							are considered to not be in the game; In order to make respawns work in multiplayer,
+ *							player ships (those marked with the P_OF_PLAYER_START flag) are never removed from it.
+ */
 p_object *mission_parse_get_arrival_ship(ushort net_signature)
 {
 	p_object *p_objp;
@@ -6436,7 +6444,7 @@ p_object *mission_parse_get_arrival_ship(ushort net_signature)
 	{
 		if (p_objp->net_signature == net_signature) 
 		{
-			//If this is a player ship, and the ship is currently in-game, return NULL
+			//If this is a player ship and the ship is currently in-game, return NULL
 			if (p_objp->flags & P_OF_PLAYER_START && ship_name_lookup(p_objp->name) != -1)
 				return NULL;
 			return p_objp;	// still on the arrival list

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -4154,7 +4154,7 @@ int parse_wing_create_ships( wing *wingp, int num_to_create, int force, int spec
 
 		// keep any player ship on the parse object list -- used for respawns
 		// 5/8/98 -- MWA -- don't remove ships from the list when you are ingame joining
-		if (!(p_objp->flags & P_OF_PLAYER_START))
+		if (!(p_objp->flags & P_OF_PLAYER_START && Game_mode & GM_MULTIPLAYER))
 		{
 			if ((Game_mode & GM_NORMAL) || !(Net_player->flags & NETINFO_FLAG_INGAME_JOIN))
 			{

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -3911,13 +3911,13 @@ int find_wing_name(char *name)
 }
 
 /**
-* \brief						Tries to create a wing of ships
-* \param[inout]	wingp			Pointer to the wing structure of the wing to be created
-* \param[in] num_to_create		Number of ships to create
-* \param[in] force				If set to 1, the wing will be created regardless of whether or not the arrival conditions
+* @brief						Tries to create a wing of ships
+* @param[inout]	wingp			Pointer to the wing structure of the wing to be created
+* @param[in] num_to_create		Number of ships to create
+* @param[in] force				If set to 1, the wing will be created regardless of whether or not the arrival conditions
 *								have been met yet.
-* \param[in] specific_instance	Set this to create a specific ship from this wing
-* \returns						Number of ships created
+* @param[in] specific_instance	Set this to create a specific ship from this wing
+* @returns						Number of ships created
 */
 int parse_wing_create_ships( wing *wingp, int num_to_create, int force, int specific_instance )
 {
@@ -6405,10 +6405,10 @@ int mission_parse_get_multi_mission_info( const char *filename )
 }
 
 /**
- * \brief				Returns the parse object on the ship arrival list associated with the given name.
- * \param[in] name		The name of the object
- * \returns				The parse object, or NULL if no object with the given name is on the arrival list
- * \remarks				This function is used to determine whether a ship has arrived. Ships on the arrival list
+ * @brief				Returns the parse object on the ship arrival list associated with the given name.
+ * @param[in] name		The name of the object
+ * @returns				The parse object, or NULL if no object with the given name is on the arrival list
+ * @remarks				This function is used to determine whether a ship has arrived. Ships on the arrival list
  *						are considered to not be in the game; In order to make respawns work in multiplayer,
  *						player ships (those marked with the P_OF_PLAYER_START flag) are never removed from it.
  */
@@ -6431,10 +6431,10 @@ p_object *mission_parse_get_arrival_ship(const char *name)
 }
 
 /**
- * \brief					Returns the parse object on the ship arrival list associated with the given net signature.
- * \param[in] net_signature	The net signature of the object
- * \returns					The parse object, or NULL if no object with the given signature is on the arrival list
- * \remarks					This function is used to determine whether a ship has arrived. Ships on the arrival list
+ * @brief					Returns the parse object on the ship arrival list associated with the given net signature.
+ * @param[in] net_signature	The net signature of the object
+ * @returns					The parse object, or NULL if no object with the given signature is on the arrival list
+ * @remarks					This function is used to determine whether a ship has arrived. Ships on the arrival list
  *							are considered to not be in the game; In order to make respawns work in multiplayer,
  *							player ships (those marked with the P_OF_PLAYER_START flag) are never removed from it.
  */

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -3974,9 +3974,8 @@ int parse_wing_create_ships( wing *wingp, int num_to_create, int force, int spec
 				// set the gone flag
 				wingp->flags |= WF_WING_GONE;
 
-				// if the current wave is zero, it never existed
-				if (wingp->current_wave == 0)
-					wingp->flags |= WF_NEVER_EXISTED;
+				// Let's mark this wing as never having existed too, for good measure
+				wingp->flags |= WF_NEVER_EXISTED;
 
 				// mark the number of waves and number of ships destroyed equal to the last wave and the number
 				// of ships yet to arrive

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -3910,7 +3910,15 @@ int find_wing_name(char *name)
 	return -1;
 }
 
-// function to create ships in the wing that need to be created
+/**
+* \brief						Tries to create a wing of ships
+* \param[inout]	wingp			Pointer to the wing structure of the wing to be created
+* \param[in] num_to_create		Number of ships to create
+* \param[in] force				If set to 1, the wing will be created regardless of whether or not the arrival conditions
+*								have been met yet.
+* \param[in] specific_instance	Set this to create a specific ship from this wing
+* \returns						Number of ships created
+*/
 int parse_wing_create_ships( wing *wingp, int num_to_create, int force, int specific_instance )
 {
 	int wingnum, objnum, num_create_save;
@@ -3951,15 +3959,16 @@ int parse_wing_create_ships( wing *wingp, int num_to_create, int force, int spec
 			Assert( wingp->arrival_anchor >= 0 );
 			name = Parse_names[wingp->arrival_anchor];
 
-			// see if ship is yet to arrive.  If so, then return -1 so we can evaluate again later.
-			if ( mission_parse_get_arrival_ship( name ) )
-				return 0;
-
 			// see if ship is in mission.  If not, then we can assume it was destroyed or departed since
 			// it is not on the arrival list (as shown by above if statement).
 			shipnum = ship_name_lookup( name );
 			if ( shipnum == -1 ) {
 				int num_remaining;
+
+				// see if ship is yet to arrive.  If so, then return 0 so we can evaluate again later.
+				if (mission_parse_get_arrival_ship(name))
+					return 0;
+
 				// since this wing cannot arrive from this place, we need to mark the wing as destroyed and
 				// set the wing variables appropriately.  Good for directives.
 
@@ -3967,7 +3976,8 @@ int parse_wing_create_ships( wing *wingp, int num_to_create, int force, int spec
 				wingp->flags |= WF_WING_GONE;
 
 				// if the current wave is zero, it never existed
-				wingp->flags |= WF_NEVER_EXISTED;
+				if (wingp->current_wave == 0)
+					wingp->flags |= WF_NEVER_EXISTED;
 
 				// mark the number of waves and number of ships destroyed equal to the last wave and the number
 				// of ships yet to arrive
@@ -6398,9 +6408,7 @@ int mission_parse_get_multi_mission_info( const char *filename )
 /**
  * \brief				Returns the parse object on the ship arrival list associated with the given name.
  * \param[in] name		The name of the object
- * \returns				The parse object, or NULL if:
- *						\li No object with the given name is on the arrival list
- *						\li The object is a player ship and currently in-game
+ * \returns				The parse object, or NULL if no object with the given name is on the arrival list
  * \remarks				This function is used to determine whether a ship has arrived. Ships on the arrival list
  *						are considered to not be in the game; In order to make respawns work in multiplayer,
  *						player ships (those marked with the P_OF_PLAYER_START flag) are never removed from it.
@@ -6416,9 +6424,6 @@ p_object *mission_parse_get_arrival_ship(const char *name)
 	{
 		if (!stricmp(p_objp->name, name)) 
 		{
-			//If this is a player ship and the ship is currently in-game, return NULL
-			if (p_objp->flags & P_OF_PLAYER_START && ship_name_lookup(name) != -1)
-				return NULL;
 			return p_objp;	// still on the arrival list
 		}
 	}
@@ -6429,9 +6434,7 @@ p_object *mission_parse_get_arrival_ship(const char *name)
 /**
  * \brief					Returns the parse object on the ship arrival list associated with the given net signature.
  * \param[in] net_signature	The net signature of the object
- * \returns					The parse object, or NULL if:
- *								\li No object with the given signature is on the arrival list
- *								\li The object is a player ship and currently in-game
+ * \returns					The parse object, or NULL if no object with the given signature is on the arrival list
  * \remarks					This function is used to determine whether a ship has arrived. Ships on the arrival list
  *							are considered to not be in the game; In order to make respawns work in multiplayer,
  *							player ships (those marked with the P_OF_PLAYER_START flag) are never removed from it.
@@ -6444,9 +6447,6 @@ p_object *mission_parse_get_arrival_ship(ushort net_signature)
 	{
 		if (p_objp->net_signature == net_signature) 
 		{
-			//If this is a player ship and the ship is currently in-game, return NULL
-			if (p_objp->flags & P_OF_PLAYER_START && ship_name_lookup(p_objp->name) != -1)
-				return NULL;
 			return p_objp;	// still on the arrival list
 		}
 	}
@@ -6669,14 +6669,14 @@ int mission_did_ship_arrive(p_object *objp)
 			Assert( objp->arrival_anchor >= 0 );
 			name = Parse_names[objp->arrival_anchor];
 	
-			// see if ship is yet to arrive.  If so, then return -1 so we can evaluate again later.
-			if ( mission_parse_get_arrival_ship( name ) )
-				return -1;
-
 			// see if ship is in mission.  If not, then we can assume it was destroyed or departed since
 			// it is not on the arrival list (as shown by above if statement).
 			shipnum = ship_name_lookup( name );
 			if ( shipnum == -1 ) {
+				// see if ship is yet to arrive.  If so, then return -1 so we can evaluate again later.
+				if (mission_parse_get_arrival_ship(name))
+					return -1;
+
 				mission_parse_mark_non_arrival(objp);	// Goober5000
 				WarningEx(LOCATION, "Warning: Ship %s cannot arrive from docking bay of destroyed or departed %s.\n", objp->name, name);
 				return -1;


### PR DESCRIPTION
A longstanding issue for capship command missions has been that hangars on player ships don't work. The reason for this was that the engine kept the player ship in the Arrival_List; according to the :V: comments, this was done to allow respawns in multiplayer.
I've amended the check so that the player ship gets treated correctly in singleplayer.