### PR TITLE
fix a memset typo identified by Echelon9

### DIFF
--- a/code/mission/missionbriefcommon.h
+++ b/code/mission/missionbriefcommon.h
@@ -190,7 +190,7 @@ public:
 	briefing()
 		: num_stages(0)
 	{
-		memset(background, GR_NUM_RESOLUTIONS * MAX_FILENAME_LEN * sizeof(char), 0);
+		memset(background, 0, GR_NUM_RESOLUTIONS * MAX_FILENAME_LEN * sizeof(char));
 	}
 };
 


### PR DESCRIPTION
Addresses his comment here:
https://github.com/scp-fs2open/fs2open.github.com/commit/05d4e44c97100486fa68328fbfc89be68bed9a04#commitcomment-13593222

I did a regex search through the codebase and fortunately there are no other instances of 0 being the last argument instead of the middle one.