### PR TITLE
Check IS_VEC_NULL(&wp->homing_pos) for det_radius and arm_radius.

### DIFF
--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -4641,7 +4641,7 @@ void weapon_process_pre( object *obj, float frame_time)
 	{
 		if((wp->homing_object != &obj_used_list) && (wp->homing_object->type != 0))
 		{
-			if(vm_vec_dist(&wp->homing_pos, &obj->pos) <= wip->det_radius)
+			if(!IS_VEC_NULL(&wp->homing_pos) && vm_vec_dist(&wp->homing_pos, &obj->pos) <= wip->det_radius)
 			{
 				weapon_detonate(obj);
 			}
@@ -6174,7 +6174,7 @@ bool weapon_armed(weapon *wp, bool hit_target)
 		if(wip->arm_radius && (!hit_target)) {
 			if(wp->homing_object == &obj_used_list)
 				return false;
-			if(vm_vec_dist(&wobj->pos, &wp->homing_pos) > wip->arm_radius)
+			if(IS_VEC_NULL(&wp->homing_pos) || vm_vec_dist(&wobj->pos, &wp->homing_pos) > wip->arm_radius)
 				return false;
 		}
 	}


### PR DESCRIPTION
"$Detonation Radius:" and "$Arm radius:" would both rely on `wp->homing_pos` being set if `wp->homing_object` was; however, during free flight time, `wp->homing_pos` remains uninitialized (a null vector). As a result, their `vm_vec_dist()` calls would be comparing with the distance from the mission origin (coordinates 0,0,0) instead of the actual location of whatever they were homing in on. In the case of detonation radius, this would result in instant detonation on launch if you fired within `det_radius` of the mission origin. In the case of arm radius, this would result in the weapon being armed during free flight if launched within the `arm_radius` of the origin (and yes, you could theoretically experience the effects of both of these bugs simultaneously).

Theoretically, this solution is still less than ideal (a target sitting exactly on the mission origin could cause wonkiness), but it's consistent with the `IS_VEC_NULL()` checks elsewhere in weapons.cpp. A "proper" solution would basically require rewriting the entire homing code... which, obviously, if somebody would like to volunteer for, I wouldn't stop you ;). In the meantime, firing a homing weapon at a target sitting on the mission origin is even less likely than firing a weapon with one of the affected attributes within a certain distance of the mission origin, which was already pretty uncommon (it took a weapon with an abnormally large detonation radius of 1 kilometer to even realize this bug existed).