### PR TITLE
Fixes numerous SEXPs accessing the wrong nodes.

### DIFF
--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -17790,6 +17790,7 @@ void sexp_turret_set_target_order(int node)
 		}
 
 		oindex++;
+		node = CDR(node);
 	}
 }
 void sexp_turret_set_direction_preference(int node)
@@ -17807,7 +17808,9 @@ void sexp_turret_set_direction_preference(int node)
 	}
 
 	//store direction preference
-	int dirpref = eval_num(CDR(node));
+	node = CDR(node);
+	int dirpref = eval_num(node);
+	node = CDR(node);
 
 	//Set range
 	while(node != -1){
@@ -17849,7 +17852,9 @@ void sexp_turret_set_rate_of_fire(int node)
 	}
 
 	//store rof
-	float rof = (float)eval_num(CDR(node));
+	node = CDR(node);
+	float rof = (float)eval_num(node);
+	node = CDR(node);
 
 	//Set rof
 	while(node != -1){
@@ -17886,7 +17891,9 @@ void sexp_turret_set_optimum_range(int node)
 	}
 
 	//store range
-	float range = (float)eval_num(CDR(node));
+	node = CDR(node);
+	float range = (float)eval_num(node);
+	node = CDR(node);
 
 	//Set range
 	while(node != -1){
@@ -17995,6 +18002,7 @@ void sexp_ship_turret_target_order(int node)
 		}
 
 		oindex++;
+		node = CDR(node);
 	}
 
 	turret = GET_FIRST(&Ships[sindex].subsys_list);
@@ -18028,6 +18036,8 @@ int sexp_get_turret_primary_ammo(int node)
 		return 0;
 	}
 
+	node = CDR(node);
+
 	turret = ship_get_subsys(&Ships[sindex], CTEXT(node));
 	if (turret == NULL) {
 		return 0;
@@ -18038,7 +18048,9 @@ int sexp_get_turret_primary_ammo(int node)
 
 	swp = &turret->weapons;
 
-	check = eval_num(CDR(node));
+	node = CDR(node);
+
+	check = eval_num(node);
 	if (check < 0) {
 		return 0;
 	}
@@ -18079,14 +18091,19 @@ void sexp_set_turret_primary_ammo(int node)
 		return;
 	}
 
+	node = CDR(node);
+
 	// Get the turret
-	turret = ship_get_subsys(&Ships[sindex], CTEXT(node));
+	char *subsys = CTEXT(node);
+	turret = ship_get_subsys(&Ships[sindex], subsys);
 	if (turret == NULL) {
 		return;
 	}
 
+	node = CDR(node);
+
 	// Get the bank to set the number on
-	requested_bank = eval_num(CDR(node));
+	requested_bank = eval_num(node);
 	if (requested_bank < 0)
 	{
 		return;
@@ -18094,7 +18111,7 @@ void sexp_set_turret_primary_ammo(int node)
 
 	//  Get the number of weapons requested	
 	node = CDR(node);
-	requested_weapons = eval_num(CDR(node));
+	requested_weapons = eval_num(node);
 	if (requested_weapons < 0)
 	{
 		return;
@@ -18103,7 +18120,6 @@ void sexp_set_turret_primary_ammo(int node)
 	set_turret_primary_ammo(turret, requested_bank, requested_weapons);
 
 	// Multiplayer call back
-	char *subsys = CTEXT(node);
 	multi_start_callback();
 	multi_send_int(sindex);
 	multi_send_string(subsys);
@@ -18175,6 +18191,8 @@ int sexp_get_turret_secondary_ammo(int node)
 		return 0;
 	}
 
+	node = CDR(node);
+
 	turret = ship_get_subsys(&Ships[sindex], CTEXT(node));
 	if (turret == NULL) {
 		return 0;
@@ -18185,7 +18203,9 @@ int sexp_get_turret_secondary_ammo(int node)
 
 	swp = &turret->weapons;
 
-	check = eval_num(CDR(node));
+	node = CDR(node);
+
+	check = eval_num(node);
 	if (check < 0) {
 		return 0;
 	}
@@ -18218,22 +18238,29 @@ void sexp_set_turret_secondary_ammo(int node)
 		return;
 	}
 
+	node = CDR(node);
+
 	// Get the turret
-	turret = ship_get_subsys(&Ships[sindex], CTEXT(node));
+	char *subsys = CTEXT(node);
+	turret = ship_get_subsys(&Ships[sindex], subsys);
 	if (turret == NULL) {
 		return;
 	}
 
+	node = CDR(node);
+
 	// Get the bank to set the number on
-	requested_bank = eval_num(CDR(node));
+	requested_bank = eval_num(node);
 	if (requested_bank < 0)
 	{
 		return;
 	}
 
-	//  Get the number of weapons requested	
+	//  Get the number of weapons requested
+
 	node = CDR(node);
-	requested_weapons = eval_num(CDR(node));
+
+	requested_weapons = eval_num(node);
 	if (requested_weapons < 0)
 	{
 		return;
@@ -18242,7 +18269,6 @@ void sexp_set_turret_secondary_ammo(int node)
 	set_turret_secondary_ammo(turret, requested_bank, requested_weapons);
 
 	// Multiplayer call back
-	char *subsys = CTEXT(node);
 	multi_start_callback();
 	multi_send_int(sindex);
 	multi_send_string(subsys);


### PR DESCRIPTION
Affected SEXPs include `turret-set-target-order`, `turret-set-direction-preference`, `turret-set-rate-of-fire`, `turret-set-optimum-range`, `ship-turret-target-order`, `turret-get-primary-ammo`, `turret-set-primary-ammo`, `turret-get-secondary-ammo`, and `turret-set-secondary-ammo`.

It's worth noting that while `turret-set-direction-preference`, `turret-set-rate-of-fire`, and `turret-set-optimum-range` were wrong, they were wrong in a way that wouldn't actually affect the outcome most of the time (thanks to the `if(turret == NULL)` checks simply skipping invalid subsystem names).