### PR TITLE
Fix memory leak in bm_load_animation

### DIFF
--- a/code/bmpman/bmpman.cpp
+++ b/code/bmpman/bmpman.cpp
@@ -1241,6 +1241,9 @@ int bm_load_animation(const char *real_filename, int *nframes, int *fps, int *ke
 			}
 			//some retail anis have their keyframes reversed
 			key = MAX(the_anim.keys[0].frame_num, the_anim.keys[1].frame_num);
+			
+			vm_free(the_anim.keys);
+			the_anim.keys = nullptr;
 		}
 	} else {
 		return -1;


### PR DESCRIPTION
This was reported in #381. I'm pretty sure that the allocated memory is only used temporarily and cleaning it up at the end of the block doesn't cause any side effects.