### PR TITLE
Fix memory leaks in generic_anim_stream

### DIFF
--- a/code/graphics/generic.cpp
+++ b/code/graphics/generic.cpp
@@ -194,8 +194,12 @@ int generic_anim_stream(generic_anim *ga)
 		bpp = ANI_BPP_CHECK;
 		if(ga->use_hud_color)
 			bpp = 8;
-		ga->ani.animation = anim_load(ga->filename, CF_TYPE_ANY, 0);
-		ga->ani.instance = init_anim_instance(ga->ani.animation, bpp);
+		if (ga->ani.animation == nullptr) {
+			ga->ani.animation = anim_load(ga->filename, CF_TYPE_ANY, 0);
+		}
+		if (ga->ani.instance == nullptr) {
+			ga->ani.instance = init_anim_instance(ga->ani.animation, bpp);
+		}
 
 	#ifndef NDEBUG
 		// for debug of ANI sizes

--- a/code/mission/missionmessage.cpp
+++ b/code/mission/missionmessage.cpp
@@ -312,9 +312,8 @@ int add_avi( char *avi_name )
 	}
 
 	// would have returned if a slot existed.
-	generic_anim_init( &extra.anim_data );
+	generic_anim_init( &extra.anim_data, avi_name );
 	strcpy_s( extra.name, avi_name );
-	strcpy_s( extra.anim_data.filename, avi_name);
 	extra.num = -1;
 	generic_anim_load(&extra.anim_data);   // load only to validate the anim
 	generic_anim_unload(&extra.anim_data); // unload to not waste bmpman slots
@@ -1234,10 +1233,12 @@ void message_play_anim( message_q *q )
 
 	// if there is something already here that's not this same file then go ahead a let go of it - taylor
 	if ( !strstr(anim_info->anim_data.filename, ani_name) ) {
+		nprintf(("Messaging", "clearing headani data due to name mismatch: (%s) (%s)\n",
+					anim_info->anim_data.filename, ani_name));
 		message_mission_free_avi( m->avi_info.index );
 	}
 
-	generic_anim_init(&anim_info->anim_data, ani_name);
+	strcpy_s( anim_info->anim_data.filename, ani_name );
 	if(!Full_color_head_anis)
 			anim_info->anim_data.use_hud_color = true;
 


### PR DESCRIPTION
Tested with a mission that repeatedly plays command head animations running through valgrind. Confirmed that report in #381 has been removed.