### PR TITLE
Revert "Fix for Coverity 1093600: Negative array index read"

### DIFF
--- a/code/hud/hudsquadmsg.cpp
+++ b/code/hud/hudsquadmsg.cpp
@@ -1383,10 +1383,11 @@ int hud_squadmsg_send_wing_command( int wingnum, int command, int send_message, 
 
 		target_shipname = NULL;
 		target_team = -1;
-
-		if ( Objects[ainfo->target_objnum].type == OBJ_SHIP ) {
-			target_shipname = Ships[Objects[ainfo->target_objnum].instance].ship_name;		// I think this is right
-			target_team = Ships[Objects[ainfo->target_objnum].instance].team;
+		if ( ainfo->target_objnum != -1) {
+			if ( Objects[ainfo->target_objnum].type == OBJ_SHIP ) {
+				target_shipname = Ships[Objects[ainfo->target_objnum].instance].ship_name;		// I think this is right
+				target_team = Ships[Objects[ainfo->target_objnum].instance].team;
+			}
 		}
 
 		Assert ( ainfo->shipnum != -1 );


### PR DESCRIPTION
This reverts commit 2aa569c1e762413112717fde5405e3bb0b96d210.

As discussed in #386 hud_squadmsg_is_target_order_valid actually doesn't properly catch cases where the target_objnum may be -1.