### PR TITLE
small optimization of shadow checks

### DIFF
--- a/code/freespace2/freespace.cpp
+++ b/code/freespace2/freespace.cpp
@@ -752,7 +752,9 @@ void game_sunspot_process(float frametime)
 
 			// check
 			for(idx=0; idx<n_lights; idx++)	{
-				if ( (ls_on && !ls_force_off) || !shipfx_eye_in_shadow( &Eye_position, Viewer_obj, idx ) )	{
+				bool in_shadow = shipfx_eye_in_shadow(&Eye_position, Viewer_obj, idx);
+
+				if ( (ls_on && !ls_force_off) || !in_shadow )	{
 					vec3d light_dir;				
 					light_get_global_dir(&light_dir, idx);
 
@@ -762,10 +764,10 @@ void game_sunspot_process(float frametime)
 						Sun_spot_goal += (float)pow(dot,85.0f);
 					}
 				}
-			if (!shipfx_eye_in_shadow( &Eye_position, Viewer_obj, idx ) )	{
-			// draw the glow for this sun
-			stars_draw_sun_glow(idx);				
-			}
+				if ( !in_shadow )	{
+					// draw the glow for this sun
+					stars_draw_sun_glow(idx);				
+				}
 			}
 
 			Sun_drew = 0;


### PR DESCRIPTION
While working on #389, I noticed that `shipfx_eye_in_shadow()` is called 2n times, where n is the number of light sources in the mission.  Since this function is expensive, let's only call it n times.