### PR TITLE
Fix Closeup_Pos and Closeup_Zoom

### DIFF
--- a/code/missionui/missionscreencommon.cpp
+++ b/code/missionui/missionscreencommon.cpp
@@ -1527,7 +1527,7 @@ int restore_wss_data(ubyte *block)
 	return offset;
 }
 
-void draw_model_icon(int model_id, int flags, float closeup_zoom, int x, int y, int w, int h, ship_info *sip, int resize_mode, vec3d closeup_pos)
+void draw_model_icon(int model_id, int flags, float closeup_zoom, int x, int y, int w, int h, ship_info *sip, int resize_mode, vec3d *closeup_pos)
 {
 	matrix	object_orient	= IDENTITY_MATRIX;
 	angles rot_angles = {0.0f,0.0f,0.0f};
@@ -1587,7 +1587,7 @@ void draw_model_icon(int model_id, int flags, float closeup_zoom, int x, int y, 
 			bs = &pm->submodel[0];
 		}
 
-		vec3d weap_closeup = closeup_pos;
+		vec3d weap_closeup = *closeup_pos;
 		float y_closeup;
 		float tm_zoom = closeup_zoom;
 

--- a/code/missionui/missionscreencommon.cpp
+++ b/code/missionui/missionscreencommon.cpp
@@ -1527,7 +1527,7 @@ int restore_wss_data(ubyte *block)
 	return offset;
 }
 
-void draw_model_icon(int model_id, int flags, float closeup_zoom, int x, int y, int w, int h, ship_info *sip, int resize_mode)
+void draw_model_icon(int model_id, int flags, float closeup_zoom, int x, int y, int w, int h, ship_info *sip, int resize_mode, vec3d closeup_pos)
 {
 	matrix	object_orient	= IDENTITY_MATRIX;
 	angles rot_angles = {0.0f,0.0f,0.0f};
@@ -1587,9 +1587,9 @@ void draw_model_icon(int model_id, int flags, float closeup_zoom, int x, int y, 
 			bs = &pm->submodel[0];
 		}
 
-		vec3d weap_closeup = Weapon_info->closeup_pos;
+		vec3d weap_closeup = closeup_pos;
 		float y_closeup;
-		float tm_zoom = Weapon_info->closeup_zoom;
+		float tm_zoom = closeup_zoom;
 
 		//Find the center of teh submodel
 		weap_closeup.xyz.x = -(bs->min.xyz.z + (bs->max.xyz.z - bs->min.xyz.z)/2.0f);

--- a/code/missionui/missionscreencommon.h
+++ b/code/missionui/missionscreencommon.h
@@ -205,7 +205,7 @@ int store_wss_data(ubyte *block, int max_size, int sound,int player_index);
 int restore_wss_data(ubyte *block);
 
 class ship_info;
-void draw_model_icon(int model_id, int flags, float closeup_zoom, int x1, int x2, int y1, int y2, ship_info* sip = NULL, int resize_mode = GR_RESIZE_FULL, vec3d closeup_pos = vmd_zero_vector);
+void draw_model_icon(int model_id, int flags, float closeup_zoom, int x1, int x2, int y1, int y2, ship_info* sip = NULL, int resize_mode = GR_RESIZE_FULL, vec3d *closeup_pos = &vmd_zero_vector);
 void draw_model_rotating(model_render_params *render_info, int model_id, int x1, int y1, int x2, int y2, float *rotation_buffer, vec3d *closeup_pos=NULL, float closeup_zoom = .65f, float rev_rate = REVOLUTION_RATE, int flags = MR_AUTOCENTER | MR_NO_FOGGING, int resize_mode=GR_RESIZE_FULL, int effect = 2);
 
 void common_set_team_pointers(int team);

--- a/code/missionui/missionscreencommon.h
+++ b/code/missionui/missionscreencommon.h
@@ -205,7 +205,7 @@ int store_wss_data(ubyte *block, int max_size, int sound,int player_index);
 int restore_wss_data(ubyte *block);
 
 class ship_info;
-void draw_model_icon(int model_id, int flags, float closeup_zoom, int x1, int x2, int y1, int y2, ship_info* sip=NULL, int resize_mode=GR_RESIZE_FULL);
+void draw_model_icon(int model_id, int flags, float closeup_zoom, int x1, int x2, int y1, int y2, ship_info* sip = NULL, int resize_mode = GR_RESIZE_FULL, vec3d closeup_pos = vmd_zero_vector);
 void draw_model_rotating(model_render_params *render_info, int model_id, int x1, int y1, int x2, int y2, float *rotation_buffer, vec3d *closeup_pos=NULL, float closeup_zoom = .65f, float rev_rate = REVOLUTION_RATE, int flags = MR_AUTOCENTER | MR_NO_FOGGING, int resize_mode=GR_RESIZE_FULL, int effect = 2);
 
 void common_set_team_pointers(int team);

--- a/code/missionui/missionweaponchoice.cpp
+++ b/code/missionui/missionweaponchoice.cpp
@@ -2748,7 +2748,7 @@ void weapon_select_do(float frametime)
 				if(icon->model_index != -1)
 				{
 					//Draw the model
-					draw_model_icon(icon->model_index, MR_NO_FOGGING | MR_NO_LIGHTING, wip->closeup_zoom / 2.5f, sx, sy, w, h, NULL, GR_RESIZE_MENU, wip->closeup_pos);
+					draw_model_icon(icon->model_index, MR_NO_FOGGING | MR_NO_LIGHTING, wip->closeup_zoom / 2.5f, sx, sy, w, h, NULL, GR_RESIZE_MENU, &wip->closeup_pos);
 				}
 				else if(icon->laser_bmap != -1)
 				{

--- a/code/missionui/missionweaponchoice.cpp
+++ b/code/missionui/missionweaponchoice.cpp
@@ -2692,15 +2692,13 @@ void weapon_select_do(float frametime)
 			gr_screen.res == 0 ? 202 : 332,
 			gr_screen.res == 0 ? 185 : 260,
 			&WeapSelectScreenWeapRot,
-			&Weapon_info->closeup_pos,
-			Weapon_info->closeup_zoom * 0.65f,
+			&wip->closeup_pos,
+			wip->closeup_zoom * 0.65f,
 			REVOLUTION_RATE,
 			MR_IS_MISSILE | MR_AUTOCENTER | MR_NO_FOGGING,
 			GR_RESIZE_MENU,
 			wip->selection_effect);
-	}
-
-	else if ( Weapon_anim_class != -1 && ( Selected_wl_class == Weapon_anim_class )) {
+	} else if ( Weapon_anim_class != -1 && ( Selected_wl_class == Weapon_anim_class )) {
 		Assert(Selected_wl_class >= 0 && Selected_wl_class < MAX_WEAPON_TYPES );
 		if ( Weapon_anim_class != Selected_wl_class )
 			start_weapon_animation(Selected_wl_class);
@@ -2736,14 +2734,13 @@ void weapon_select_do(float frametime)
 		if ( Wl_icons[Carried_wl_icon.weapon_class].can_use > 0)
 		{
 			wl_icon_info *icon = &Wl_icons[Carried_wl_icon.weapon_class];
+			weapon_info *wip = &Weapon_info[Carried_wl_icon.weapon_class];
 			if(icon->icon_bmaps[WEAPON_ICON_FRAME_SELECTED] != -1)
 			{
 				gr_set_color_fast(&Color_blue);
 				gr_set_bitmap(icon->icon_bmaps[WEAPON_ICON_FRAME_SELECTED]);
 				gr_bitmap(sx, sy, GR_RESIZE_MENU);
-			}
-			else
-			{
+			} else {
 				gr_set_color_fast(&Icon_colors[ICON_FRAME_SELECTED]);
 				int w = 56;
 				int h = 24;
@@ -2751,7 +2748,7 @@ void weapon_select_do(float frametime)
 				if(icon->model_index != -1)
 				{
 					//Draw the model
-					draw_model_icon(icon->model_index, MR_NO_FOGGING | MR_NO_LIGHTING, Weapon_info->closeup_zoom / 2.5f, sx, sy, w, h, NULL, GR_RESIZE_MENU);
+					draw_model_icon(icon->model_index, MR_NO_FOGGING | MR_NO_LIGHTING, wip->closeup_zoom / 2.5f, sx, sy, w, h, NULL, GR_RESIZE_MENU, wip->closeup_pos);
 				}
 				else if(icon->laser_bmap != -1)
 				{
@@ -2760,9 +2757,7 @@ void weapon_select_do(float frametime)
 					gr_set_bitmap(icon->laser_bmap);
 					gr_bitmap(0, 0, GR_RESIZE_MENU);
 					gr_reset_clip();
-				}
-				else
-				{
+				} else {
 					//Draw the weapon name, crappy last-ditch effort to not crash.
 					int half_x, half_y;
 					char *print_name = (Weapon_info[Carried_wl_icon.weapon_class].alt_name[0]) ? Weapon_info[Carried_wl_icon.weapon_class].alt_name : Weapon_info[Carried_wl_icon.weapon_class].name;


### PR DESCRIPTION
The draw_model_rotating() and draw_model_icon() functions were receiving
the whole Weapon_Info array (Weapon_Info->variable) instead of a single weapon_info object (wip->variable in this case).

These have been replaced with proper pointer(s).