### PR TITLE
convert qsort to std::sort

### DIFF
--- a/code/cfile/cfilesystem.cpp
+++ b/code/cfile/cfilesystem.cpp
@@ -14,6 +14,7 @@
 #include <stdio.h>
 #include <errno.h>
 #include <sstream>
+#include <algorithm>
 
 #ifdef _WIN32
 #include <io.h>

--- a/code/cfile/cfilesystem.cpp
+++ b/code/cfile/cfilesystem.cpp
@@ -218,19 +218,15 @@ int cf_get_packfile_count(cf_root *root)
 }
 
 // packfile sort function
-int cf_packfile_sort_func(const void *elem1, const void *elem2)
+bool cf_packfile_sort_func(const cf_root_sort &r1, const cf_root_sort &r2)
 {
-	cf_root_sort *r1, *r2;
-	r1 = (cf_root_sort*)elem1;
-	r2 = (cf_root_sort*)elem2;
-
 	// if the 2 directory types are the same, do a string compare
-	if(r1->cf_type == r2->cf_type){
-		return stricmp(r1->path, r2->path);
+	if (r1.cf_type == r2.cf_type) {
+		return (stricmp(r1.path, r2.path) < 0);
 	}
 
 	// otherwise return them in order of CF_TYPE_* precedence
-	return (r1->cf_type < r2->cf_type) ? -1 : 1;
+	return (r1.cf_type < r2.cf_type);
 }
 
 // Go through a root and look for pack files
@@ -339,7 +335,7 @@ void cf_build_pack_list( cf_root *root )
 	Assert(root_index == temp_root_count);
 
 	// sort the roots
-	qsort(temp_roots_sort, temp_root_count, sizeof(cf_root_sort), cf_packfile_sort_func);
+	std::sort(temp_roots_sort, temp_roots_sort + temp_root_count, cf_packfile_sort_func);
 
 	// now insert them all into the real root list properly
 	cf_root *new_root;

--- a/code/graphics/gropengllight.cpp
+++ b/code/graphics/gropengllight.cpp
@@ -14,6 +14,8 @@
 #include <windows.h>
 #endif
 
+#include <algorithm>
+
 #include "cmdline/cmdline.h"
 #include "globalincs/pstypes.h"
 #include <globalincs/systemvars.h>

--- a/code/graphics/gropengllight.cpp
+++ b/code/graphics/gropengllight.cpp
@@ -16,6 +16,7 @@
 
 #include "cmdline/cmdline.h"
 #include "globalincs/pstypes.h"
+#include <globalincs/systemvars.h>
 #include "graphics/2d.h"
 #include "graphics/gropenglextension.h"
 #include "graphics/gropengllight.h"
@@ -180,51 +181,45 @@ void opengl_set_light(int light_num, opengl_light *ltp)
 	glLightf(GL_LIGHT0+light_num, GL_SPOT_CUTOFF, ltp->SpotCutOff);
 }
 
-#include <globalincs/systemvars.h>
-int opengl_sort_active_lights(const void *a, const void *b)
+bool opengl_sort_active_lights(const opengl_light &la, const opengl_light &lb)
 {
-	opengl_light *la, *lb;
-
-	la = (opengl_light *) a;
-	lb = (opengl_light *) b;
-
 	// directional lights always go first
-	if ( (la->type != LT_DIRECTIONAL) && (lb->type == LT_DIRECTIONAL) )
-		return 1;
-	else if ( (la->type == LT_DIRECTIONAL) && (lb->type != LT_DIRECTIONAL) )
-		return -1;
+	if ( (la.type != LT_DIRECTIONAL) && (lb.type == LT_DIRECTIONAL) )
+		return false;
+	else if ( (la.type == LT_DIRECTIONAL) && (lb.type != LT_DIRECTIONAL) )
+		return true;
 
 	// tube lights go next, they are generally large and intense
-	if ( (la->type != LT_TUBE) && (lb->type == LT_TUBE) )
-		return 1;
-	else if ( (la->type == LT_TUBE) && (lb->type != LT_TUBE) )
-		return -1;
+	if ( (la.type != LT_TUBE) && (lb.type == LT_TUBE) )
+		return false;
+	else if ( (la.type == LT_TUBE) && (lb.type != LT_TUBE) )
+		return true;
 
 	// everything else is sorted by linear atten (light size)
 	// NOTE: smaller atten is larger light radius!
-	if ( la->LinearAtten > lb->LinearAtten )
-		return 1;
-	else if ( la->LinearAtten < lb->LinearAtten )
-		return -1;
+	if ( la.LinearAtten > lb.LinearAtten )
+		return false;
+	else if ( la.LinearAtten < lb.LinearAtten )
+		return true;
 
 	// as one extra check, if we're still here, go with overall brightness of light
 
-	float la_value = la->Diffuse[0] + la->Diffuse[1] + la->Diffuse[2];
-	float lb_value = lb->Diffuse[0] + lb->Diffuse[1] + lb->Diffuse[2];
+	float la_value = la.Diffuse[0] + la.Diffuse[1] + la.Diffuse[2];
+	float lb_value = lb.Diffuse[0] + lb.Diffuse[1] + lb.Diffuse[2];
 
 	if ( la_value < lb_value )
-		return 1;
+		return false;
 	else if ( la_value > lb_value )
-		return -1;
+		return true;
 
 	// the two are equal
-	return 0;
+	return false;
 }
 
 void opengl_pre_render_init_lights()
 {
 	// sort the lights to try and get the most visible lights on the first pass
-	qsort(opengl_lights, Num_active_gl_lights, sizeof(opengl_light), opengl_sort_active_lights);
+	std::sort(opengl_lights, opengl_lights + Num_active_gl_lights, opengl_sort_active_lights);
 }
 
 static GLdouble eyex, eyey, eyez;

--- a/code/network/multi_obj.cpp
+++ b/code/network/multi_obj.cpp
@@ -157,22 +157,17 @@ int OO_update_index = -1;							// index into OO_update_records for displaying u
 object *OO_player_obj;
 int OO_sort = 1;
 
-int multi_oo_sort_func(const void *ship1, const void *ship2)
+bool multi_oo_sort_func(const short &index1, const short &index2)
 {
 	object *obj1, *obj2;
-	short index1, index2;
 	float dist1, dist2;
 	float dot1, dot2;
 	vec3d v1, v2;
 	vec3d vn1, vn2;
 
-	// get the 2 indices
-	memcpy(&index1, ship1, sizeof(short));
-	memcpy(&index2, ship2, sizeof(short));
-
 	// if the indices are bogus, or the objnums are bogus, return ">"
 	if((index1 < 0) || (index2 < 0) || (Ships[index1].objnum < 0) || (Ships[index2].objnum < 0)){
-		return 1;
+		return false;
 	}
 
 	// get the 2 objects
@@ -189,13 +184,13 @@ int multi_oo_sort_func(const void *ship1, const void *ship2)
 
 	// objects in front take precedence
 	if((dot1 < 0.0f) && (dot2 >= 0.0f)){
-		return 1;
+		return false;
 	} else if((dot2 < 0.0f) && (dot1 >= 0.0f)){
-		return -1;
+		return true;
 	}
 
 	// otherwise go by distance
-	return (dist1 <= dist2) ? -1 : 1;
+	return (dist1 < dist2);
 }
 
 // build the list of ship indices to use when updating for this player
@@ -261,10 +256,10 @@ void multi_oo_build_ship_list(net_player *pl)
 		}
 	}
 
-	// maybe qsort the thing here
+	// maybe sort the thing here
 	OO_player_obj = player_obj;
-	if(OO_sort){
-		qsort(OO_ship_index, ship_index, sizeof(short), multi_oo_sort_func);
+	if (OO_sort) {
+		std::sort(OO_ship_index, OO_ship_index + ship_index, multi_oo_sort_func);
 	}
 }
 

--- a/code/network/multi_obj.cpp
+++ b/code/network/multi_obj.cpp
@@ -8,7 +8,7 @@
 */
 
 
-#include <algortihm>
+#include <algorithm>
 
 #include "network/multi_obj.h"
 #include "globalincs/globals.h"

--- a/code/network/multi_obj.cpp
+++ b/code/network/multi_obj.cpp
@@ -8,6 +8,8 @@
 */
 
 
+#include <algortihm>
+
 #include "network/multi_obj.h"
 #include "globalincs/globals.h"
 #include "freespace2/freespace.h"

--- a/code/network/psnet2.cpp
+++ b/code/network/psnet2.cpp
@@ -32,6 +32,7 @@
 #endif
 #include <stdio.h>
 #include <limits.h>
+#include <algorithm>
 
 #include "globalincs/pstypes.h"
 #include "network/psnet2.h"

--- a/code/network/psnet2.cpp
+++ b/code/network/psnet2.cpp
@@ -1112,21 +1112,6 @@ int psnet_is_valid_ip_string( char *ip_string, int allow_port )
 // PSNET 2 RELIABLE SOCKET FUNCTIONS
 //
 
-/**
- * Compare 2 pings
- */
-int psnet_rel_ping_compare( const void *arg1, const void *arg2 )
-{
-	float *ping1 = (float *)arg1;
-	float *ping2 = (float *)arg2;
-	
-	if(*ping1==*ping2) return 0;
-	else if(*ping1>*ping2) return 1;
-	else if(*ping1<*ping2) return -1;
-
-	return 0;
-}
-
 void psnet_rel_send_ack(SOCKADDR *raddr, unsigned int sig, ubyte link_type, float time_sent)
 {
 	int ret, sig_tmp;
@@ -1587,7 +1572,7 @@ void psnet_rel_work()
 						sort_ping[a] = rsocket->pings[a];
 					}
 
-					qsort(sort_ping ,MAX_PING_HISTORY, sizeof(float), psnet_rel_ping_compare);
+					std::sort(sort_ping, sort_ping + MAX_PING_HISTORY);
 					rsocket->mean_ping = ((sort_ping[MAX_PING_HISTORY/2]+sort_ping[(MAX_PING_HISTORY/2)+1]))/2;					
 				}
 				rsocket->ping_pos++;

--- a/code/ship/shiphit.cpp
+++ b/code/ship/shiphit.cpp
@@ -10,6 +10,8 @@
 
 
 
+#include <algorithm>
+
 #include "asteroid/asteroid.h"
 #include "debris/debris.h"
 #include "fireball/fireballs.h"

--- a/code/ship/shiphit.cpp
+++ b/code/ship/shiphit.cpp
@@ -1079,20 +1079,13 @@ int get_max_sparks(object* ship_objp)
 }
 
 
-// helper function to qsort, sorting spark pairs by distance
-int spark_compare( const void *elem1, const void *elem2 )
+// helper function to std::sort, sorting spark pairs by distance
+int spark_compare(const spark_pair &pair1, const spark_pair &pair2)
 {
-	spark_pair *pair1 = (spark_pair *) elem1;
-	spark_pair *pair2 = (spark_pair *) elem2;
+	Assert(pair1.dist >= 0);
+	Assert(pair2.dist >= 0);
 
-	Assert(pair1->dist >= 0);
-	Assert(pair2->dist >= 0);
-
-	if ( pair1->dist <  pair2->dist ) {
-		return -1;
-	} else {
-		return 1;
-	}
+	return (pair1.dist < pair2.dist);
 }
 
 // for big ships, when all spark slots are filled, make intelligent choice of one to be recycled
@@ -1166,7 +1159,7 @@ int choose_next_spark(object *ship_objp, vec3d *hitpos)
 	Assert(count == num_spark_pairs);
 
 	// sort pairs
-	qsort(spark_pairs, count, sizeof(spark_pair), spark_compare);
+	std::sort(spark_pairs, spark_pairs + count, spark_compare);
 	//mprintf(("Min spark pair dist %.1f\n", spark_pairs[0].dist));
 
 	// look through the first few sorted pairs, counting number of indices of closest pair

--- a/code/weapon/beam.cpp
+++ b/code/weapon/beam.cpp
@@ -10,6 +10,8 @@
 
 
 
+#include <algorithm>
+
 #include "asteroid/asteroid.h"
 #include "cmdline/cmdline.h"
 #include "debris/debris.h"

--- a/code/weapon/beam.cpp
+++ b/code/weapon/beam.cpp
@@ -216,9 +216,6 @@ void beam_start_warmdown(beam *b);
 // add a collision to the beam for this frame (to be evaluated later)
 void beam_add_collision(beam *b, object *hit_object, mc_info *cinfo, int quad = -1, int exit_flag = 0);
 
-// sort collisions for the frame
-int beam_sort_collisions_func(const void *e1, const void *e2);
-
 // get the width of the widest section of the beam
 float beam_get_widest(beam *b);
 
@@ -2896,12 +2893,9 @@ void beam_add_collision(beam *b, object *hit_object, mc_info *cinfo, int quadran
 }
 
 // sort collisions for the frame
-int beam_sort_collisions_func(const void *e1, const void *e2)
+bool beam_sort_collisions_func(const beam_collision &b1, const beam_collision &b2)
 {
-	beam_collision *b1 = (beam_collision*)e1;
-	beam_collision *b2 = (beam_collision*)e2;
-
-	return b1->cinfo.hit_dist < b2->cinfo.hit_dist ? -1 : 1;
+	return (b1.cinfo.hit_dist < b2.cinfo.hit_dist);
 }
 
 // handle a hit on a specific object
@@ -2929,7 +2923,7 @@ void beam_handle_collisions(beam *b)
 	widest = beam_get_widest(b);
 
 	// the first thing we need to do is sort the collisions, from closest to farthest
-	qsort(b->f_collisions, b->f_collision_count, sizeof(beam_collision), beam_sort_collisions_func);
+	std::sort(b->f_collisions, b->f_collisions + b->f_collision_count, beam_sort_collisions_func);
 
 	// now apply all collisions until we reach a ship which "stops" the beam or we reach the end of the list
 	for(idx=0; idx<b->f_collision_count; idx++){	


### PR DESCRIPTION
My sources indicate that std::sort can often be substantially faster than qsort, since qsort invokes a function for every comparison whereas std::sort can inline the comparison.  Additionally, qsort makes no guarantees about performance, whereas std::sort is specified to have minimum n\*log(n) performance.  (In fairness, most implementations of qsort also have n\*log(n) performance, at least in the average case.  NB: qsort is not required to use the quicksort algorithm.)

Incidentally, @asarium may suspect that I'm biased against C++ due to conversations like #384, so hopefully this PR will serve as evidence otherwise. ;)