### PR TITLE
const-correctness inspired by #392, because why not be masochistic

### DIFF
--- a/code/graphics/2d.h
+++ b/code/graphics/2d.h
@@ -416,7 +416,7 @@ typedef struct screen {
 	void (*gf_flip)();
 
 	// Sets the current palette
-	void (*gf_set_palette)(ubyte * new_pal, int restrict_alphacolor);
+	void (*gf_set_palette)(const ubyte *new_pal, int restrict_alphacolor);
 
 	// Fade the screen in/out
 	void (*gf_fade_in)(int instantaneous);
@@ -565,7 +565,7 @@ typedef struct screen {
 	int (*gf_bm_make_render_target)(int n, int *width, int *height, ubyte *bpp, int *mm_lvl, int flags );
 	int (*gf_bm_set_render_target)(int n, int face);
 
-	void (*gf_translate_texture_matrix)(int unit, vec3d *shift);
+	void (*gf_translate_texture_matrix)(int unit, const vec3d *shift);
 	void (*gf_push_texture_matrix)(int unit);
 	void (*gf_pop_texture_matrix)(int unit);
 
@@ -593,14 +593,14 @@ typedef struct screen {
  	void (*gf_set_proj_matrix)(float, float, float, float);
   	void (*gf_end_proj_matrix)();
 	//the view matrix
- 	void (*gf_set_view_matrix)(vec3d *, matrix*);
+ 	void (*gf_set_view_matrix)(const vec3d*, const matrix*);
   	void (*gf_end_view_matrix)();
 	//object scaleing
-	void (*gf_push_scale_matrix)(vec3d *);
+	void (*gf_push_scale_matrix)(const vec3d*);
  	void (*gf_pop_scale_matrix)();
 	//object position and orientation
-	void (*gf_start_instance_matrix)(vec3d *, matrix*);
-	void (*gf_start_angles_instance_matrix)(vec3d *, angles*);
+	void (*gf_start_instance_matrix)(const vec3d*, const matrix*);
+	void (*gf_start_angles_instance_matrix)(const vec3d*, const angles*);
 	void (*gf_end_instance_matrix)();
 
 	int	 (*gf_make_light)(light*, int, int );
@@ -640,11 +640,11 @@ typedef struct screen {
 	void (*gf_set_fill_mode)(int);
 	void (*gf_set_texture_panning)(float u, float v, bool enable);
 
-	void (*gf_draw_line_list)(colored_vector*lines, int num);
+	void (*gf_draw_line_list)(const colored_vector *lines, int num);
 
 	void (*gf_set_line_width)(float width);
 
-	void (*gf_line_htl)(vec3d *start, vec3d* end);
+	void (*gf_line_htl)(const vec3d *start, const vec3d *end);
 	void (*gf_sphere_htl)(float rad);
 
 	int (*gf_maybe_create_shader)(shader_type type, unsigned int flags);
@@ -653,12 +653,12 @@ typedef struct screen {
 
 	void (*gf_clear_states)();
 
-	void (*gf_set_team_color)(team_color *colors);
+	void (*gf_set_team_color)(const team_color *colors);
 
-	void (*gf_update_texture)(int bitmap_handle, int bpp, ubyte* data, int width, int height);
+	void (*gf_update_texture)(int bitmap_handle, int bpp, const ubyte* data, int width, int height);
 	void (*gf_get_bitmap_from_texture)(void* data_out, int bitmap_num);
 
-	void (*gf_shadow_map_start)(matrix4 *shadow_view_matrix, matrix *light_matrix);
+	void (*gf_shadow_map_start)(const matrix4 *shadow_view_matrix, const matrix *light_matrix);
 	void (*gf_shadow_map_end)();
 } screen;
 
@@ -1034,7 +1034,7 @@ void gr_bitmap_list(bitmap_rect_list* list, int n_bm, int resize_mode);
 
 // texture update functions
 ubyte* gr_opengl_get_texture_update_pointer(int bitmap_handle);
-void gr_opengl_update_texture(int bitmap_handle, int bpp, ubyte* data, int width, int height);
+void gr_opengl_update_texture(int bitmap_handle, int bpp, const ubyte* data, int width, int height);
 
 // special function for drawing polylines. this function is specifically intended for
 // polylines where each section is no more than 90 degrees away from a previous section.

--- a/code/graphics/gropengl.cpp
+++ b/code/graphics/gropengl.cpp
@@ -477,7 +477,7 @@ void gr_opengl_reset_clip()
 	GL_state.ScissorTest(GL_FALSE);
 }
 
-void gr_opengl_set_palette(ubyte *new_palette, int is_alphacolor)
+void gr_opengl_set_palette(const ubyte *new_palette, int is_alphacolor)
 {
 }
 
@@ -1304,7 +1304,7 @@ void gr_opengl_pop_texture_matrix(int unit)
 	glMatrixMode(current_matrix);
 }
 
-void gr_opengl_translate_texture_matrix(int unit, vec3d *shift)
+void gr_opengl_translate_texture_matrix(int unit, const vec3d *shift)
 {
 	GLint current_matrix;
 

--- a/code/graphics/gropengldraw.cpp
+++ b/code/graphics/gropengldraw.cpp
@@ -751,7 +751,7 @@ void gr_opengl_line(int x1,int y1,int x2,int y2, int resize_mode)
 	gr_opengl_end_2d_matrix();
 }
 
-void gr_opengl_line_htl(vec3d *start, vec3d *end)
+void gr_opengl_line_htl(const vec3d *start, const vec3d *end)
 {
 	if (Cmdline_nohtl) {
 		return;
@@ -2535,7 +2535,7 @@ void gr_opengl_draw_deferred_light_cylinder(vec3d *position,matrix *orient, floa
 	g3_done_instance(true);
 }
 
-void gr_opengl_draw_line_list(colored_vector *lines, int num)
+void gr_opengl_draw_line_list(const colored_vector *lines, int num)
 {
 	if (Cmdline_nohtl) {
 		return;

--- a/code/graphics/gropengldraw.h
+++ b/code/graphics/gropengldraw.h
@@ -42,16 +42,16 @@ void gr_opengl_update_distortion();
 void opengl_set_spec_mapping(int tmap_type, float *u_scale, float *v_scale, int stage = 0);
 void opengl_reset_spec_mapping();
 
-void gr_opengl_line_htl(vec3d *start, vec3d *end);
+void gr_opengl_line_htl(const vec3d *start, const vec3d *end);
 void gr_opengl_sphere_htl(float rad);
 void gr_opengl_deferred_light_sphere_init(int rings, int segments);
-void gr_opengl_draw_deferred_light_sphere(vec3d *position, float rad, bool clearStencil);
+void gr_opengl_draw_deferred_light_sphere(const vec3d *position, float rad, bool clearStencil);
 void gr_opengl_deferred_light_cylinder_init(int segments);
-void gr_opengl_draw_deferred_light_cylinder(vec3d *position,matrix *orient, float rad, float length, bool clearStencil);
+void gr_opengl_draw_deferred_light_cylinder(const vec3d *position, const matrix *orient, float rad, float length, bool clearStencil);
 
-void gr_opengl_draw_line_list(colored_vector *lines, int num);
+void gr_opengl_draw_line_list(const colored_vector *lines, int num);
 
-void gr_opengl_shadow_map_start(matrix4 *shadow_view_matrix, matrix *light_orient);
+void gr_opengl_shadow_map_start(const matrix4 *shadow_view_matrix, const matrix *light_orient);
 void gr_opengl_shadow_map_end();
 
 void opengl_setup_scene_textures();

--- a/code/graphics/gropengltexture.cpp
+++ b/code/graphics/gropengltexture.cpp
@@ -1429,7 +1429,7 @@ size_t opengl_export_render_target( int slot, int width, int height, int alpha, 
 	return (size_t)m_offset;
 }
 
-void gr_opengl_update_texture(int bitmap_handle, int bpp, ubyte* data, int width, int height)
+void gr_opengl_update_texture(int bitmap_handle, int bpp, const ubyte* data, int width, int height)
 {
 	GLenum texFormat, glFormat;
 	int n = bm_get_cache_slot (bitmap_handle, 1);

--- a/code/graphics/gropengltnl.cpp
+++ b/code/graphics/gropengltnl.cpp
@@ -716,7 +716,7 @@ void mix_two_team_colors(team_color* dest, team_color* a, team_color* b, float m
 	dest->stripe.b = a->stripe.b * (1.0f - mix_factor) + b->stripe.b * mix_factor;
 }
 
-void gr_opengl_set_team_color(team_color *colors)
+void gr_opengl_set_team_color(const team_color *colors)
 {
 	if ( colors == NULL ) {
 		Using_Team_Color = false;
@@ -1479,7 +1479,7 @@ void gr_opengl_render_stream_buffer(int buffer_handle, int offset, int n_verts, 
 	GL_CHECK_FOR_ERRORS("end of render3d()");
 }
 
-void gr_opengl_start_instance_matrix(vec3d *offset, matrix *rotation)
+void gr_opengl_start_instance_matrix(const vec3d *offset, const matrix *rotation)
 {
 	if (Cmdline_nohtl) {
 		return;
@@ -1514,7 +1514,7 @@ void gr_opengl_start_instance_matrix(vec3d *offset, matrix *rotation)
 	GL_modelview_matrix_depth++;
 }
 
-void gr_opengl_start_instance_angles(vec3d *pos, angles *rotation)
+void gr_opengl_start_instance_angles(const vec3d *pos, const angles *rotation)
 {
 	if (Cmdline_nohtl)
 		return;
@@ -1605,7 +1605,7 @@ void gr_opengl_end_projection_matrix()
 	GL_htl_projection_matrix_set = 0;
 }
 
-void gr_opengl_set_view_matrix(vec3d *pos, matrix *orient)
+void gr_opengl_set_view_matrix(const vec3d *pos, const matrix *orient)
 {
 	if (Cmdline_nohtl)
 		return;
@@ -1807,7 +1807,7 @@ void gr_opengl_end_2d_matrix()
 
 static bool GL_scale_matrix_set = false;
 
-void gr_opengl_push_scale_matrix(vec3d *scale_factor)
+void gr_opengl_push_scale_matrix(const vec3d *scale_factor)
 {
 	if ( (scale_factor->xyz.x == 1) && (scale_factor->xyz.y == 1) && (scale_factor->xyz.z == 1) )
 		return;
@@ -1938,7 +1938,7 @@ void gr_opengl_set_state_block(int handle)
 extern bool Glowpoint_override;
 bool Glowpoint_override_save;
 
-void gr_opengl_shadow_map_start(matrix4 *shadow_view_matrix, matrix *light_orient)
+void gr_opengl_shadow_map_start(const matrix4 *shadow_view_matrix, const matrix *light_orient)
 {
 	if(!Cmdline_shadow_quality)
 		return;

--- a/code/graphics/gropengltnl.h
+++ b/code/graphics/gropengltnl.h
@@ -31,16 +31,16 @@ extern float shadow_middist;
 extern float shadow_fardist;
 extern bool Rendering_to_shadow_map;
 
-void gr_opengl_start_instance_matrix(vec3d *offset, matrix *rotation);
-void gr_opengl_start_instance_angles(vec3d *pos, angles *rotation);
+void gr_opengl_start_instance_matrix(const vec3d *offset, const matrix *rotation);
+void gr_opengl_start_instance_angles(const vec3d *pos, const angles *rotation);
 void gr_opengl_end_instance_matrix();
 void gr_opengl_set_projection_matrix(float fov, float aspect, float z_near, float z_far);
 void gr_opengl_end_projection_matrix();
-void gr_opengl_set_view_matrix(vec3d *pos, matrix *orient);
+void gr_opengl_set_view_matrix(const vec3d *pos, const matrix *orient);
 void gr_opengl_end_view_matrix();
 void gr_opengl_set_2d_matrix(/*int x, int y, int w, int h*/);
 void gr_opengl_end_2d_matrix();
-void gr_opengl_push_scale_matrix(vec3d *scale_factor);
+void gr_opengl_push_scale_matrix(const vec3d *scale_factor);
 void gr_opengl_pop_scale_matrix();
 
 void gr_opengl_start_clip_plane();
@@ -68,7 +68,7 @@ int gr_opengl_end_state_block();
 void gr_opengl_set_state_block(int);
 
 void gr_opengl_set_thrust_scale(float scale = -1.0f);
-void gr_opengl_set_team_color(team_color *colors);
+void gr_opengl_set_team_color(const team_color *colors);
 
 void opengl_tnl_shutdown();
 

--- a/code/graphics/grstub.cpp
+++ b/code/graphics/grstub.cpp
@@ -230,7 +230,7 @@ void gr_stub_print_screen(const char *filename)
 {
 }
 
-void gr_stub_push_scale_matrix(vec3d *scale_factor)
+void gr_stub_push_scale_matrix(const vec3d *scale_factor)
 {
 }
 
@@ -332,7 +332,7 @@ void gr_stub_set_light(light *light)
 {
 }
 
-void gr_stub_set_palette(ubyte *new_palette, int is_alphacolor)
+void gr_stub_set_palette(const ubyte *new_palette, int is_alphacolor)
 {
 }
 
@@ -348,7 +348,7 @@ void gr_stub_set_texture_addressing(int mode)
 {
 }
 
-void gr_stub_set_view_matrix(vec3d *pos, matrix* orient)
+void gr_stub_set_view_matrix(const vec3d *pos, const matrix* orient)
 {
 }
 
@@ -356,15 +356,15 @@ void gr_stub_start_clip_plane()
 {
 }
 
-void gr_stub_start_instance_angles(vec3d *pos, angles* rotation)
+void gr_stub_start_instance_angles(const vec3d *pos, const angles *rotation)
 {
 }
 
-void gr_stub_start_instance_matrix(vec3d *offset, matrix* rotation)
+void gr_stub_start_instance_matrix(const vec3d *offset, const matrix *rotation)
 {
 }
 
-void gr_stub_string( int sx, int sy, const char *s, int resize_mode = GR_RESIZE_NONE)
+void gr_stub_string(int sx, int sy, const char *s, int resize_mode = GR_RESIZE_NONE)
 {
 }
 
@@ -388,7 +388,7 @@ void gr_stub_render_effect( int nverts, vertex *verts, float *radius_list, uint 
 {
 }
 
-void gr_stub_translate_texture_matrix(int unit, vec3d *shift)
+void gr_stub_translate_texture_matrix(int unit, const vec3d *shift)
 {
 }
 
@@ -496,7 +496,7 @@ void gr_stub_set_line_width(float width)
 {
 }
 
-void gr_stub_draw_htl_line(vec3d *start, vec3d* end)
+void gr_stub_draw_htl_line(const vec3d *start, const vec3d *end)
 {
 }
 
@@ -504,7 +504,7 @@ void gr_stub_draw_htl_sphere(float rad)
 {
 }
 
-void gr_stub_draw_line_list(colored_vector *lines, int num)
+void gr_stub_draw_line_list(const colored_vector *lines, int num)
 {
 }
 
@@ -512,7 +512,7 @@ void gr_stub_clear_states()
 {
 }
 
-void gr_stub_update_texture(int bitmap_handle, int bpp, ubyte* data, int width, int height)
+void gr_stub_update_texture(int bitmap_handle, int bpp, const ubyte *data, int width, int height)
 {
 }
 
@@ -741,10 +741,10 @@ void gr_stub_set_animated_effect(int effect, float timer)
 
 }
 
-void gr_stub_set_team_color(team_color *colors) {
+void gr_stub_set_team_color(const team_color *colors) {
 }
 
-void gr_stub_shadow_map_start(matrix4 *shadow_view_matrix, matrix* light_matrix)
+void gr_stub_shadow_map_start(const matrix4 *shadow_view_matrix, const matrix* light_matrix)
 {
 }
 

--- a/code/io/keycontrol.cpp
+++ b/code/io/keycontrol.cpp
@@ -623,7 +623,7 @@ extern void snd_stop_any_sound();
 
 extern vec3d Eye_position;
 extern matrix Eye_matrix;
-extern void g3_set_view_matrix(vec3d *view_pos,matrix *view_matrix,float zoom);
+extern void g3_set_view_matrix(const vec3d *view_pos, const matrix *view_matrix, float zoom);
 
 extern int Show_cpu;
 

--- a/code/missionui/missionscreencommon.cpp
+++ b/code/missionui/missionscreencommon.cpp
@@ -1527,7 +1527,7 @@ int restore_wss_data(ubyte *block)
 	return offset;
 }
 
-void draw_model_icon(int model_id, int flags, float closeup_zoom, int x, int y, int w, int h, ship_info *sip, int resize_mode, vec3d *closeup_pos)
+void draw_model_icon(int model_id, int flags, float closeup_zoom, int x, int y, int w, int h, const ship_info *sip, int resize_mode, const vec3d *closeup_pos)
 {
 	matrix	object_orient	= IDENTITY_MATRIX;
 	angles rot_angles = {0.0f,0.0f,0.0f};

--- a/code/missionui/missionscreencommon.h
+++ b/code/missionui/missionscreencommon.h
@@ -205,7 +205,7 @@ int store_wss_data(ubyte *block, int max_size, int sound,int player_index);
 int restore_wss_data(ubyte *block);
 
 class ship_info;
-void draw_model_icon(int model_id, int flags, float closeup_zoom, int x1, int x2, int y1, int y2, ship_info* sip = NULL, int resize_mode = GR_RESIZE_FULL, vec3d *closeup_pos = &vmd_zero_vector);
+void draw_model_icon(int model_id, int flags, float closeup_zoom, int x1, int x2, int y1, int y2, const ship_info* sip = NULL, int resize_mode = GR_RESIZE_FULL, const vec3d *closeup_pos = &vmd_zero_vector);
 void draw_model_rotating(model_render_params *render_info, int model_id, int x1, int y1, int x2, int y2, float *rotation_buffer, vec3d *closeup_pos=NULL, float closeup_zoom = .65f, float rev_rate = REVOLUTION_RATE, int flags = MR_AUTOCENTER | MR_NO_FOGGING, int resize_mode=GR_RESIZE_FULL, int effect = 2);
 
 void common_set_team_pointers(int team);

--- a/code/model/modelinterp.cpp
+++ b/code/model/modelinterp.cpp
@@ -1472,7 +1472,7 @@ static const int MAX_ARC_SEGMENT_POINTS = 50;
 int Num_arc_segment_points = 0;
 vec3d Arc_segment_points[MAX_ARC_SEGMENT_POINTS];
 
-extern int g3_draw_rod(int num_points, vec3d *vecs, float width, uint tmap_flags);
+extern int g3_draw_rod(int num_points, const vec3d *vecs, float width, uint tmap_flags);
 
 void interp_render_arc_segment( vec3d *v1, vec3d *v2, int depth )
 {

--- a/code/render/3d.h
+++ b/code/render/3d.h
@@ -41,13 +41,13 @@
 /**
  * Use the g3_start_frame macro instead of calling this directly.
  */
-extern void g3_start_frame_func(int zbuffer_flag, char * filename, int lineno);
+extern void g3_start_frame_func(int zbuffer_flag, const char *filename, int lineno);
 
 /**
  * End the frame
  */
 #define g3_end_frame() g3_end_frame_func( __FILE__, __LINE__ )
-extern void g3_end_frame_func(char *filename, int lineno);
+extern void g3_end_frame_func(const char *filename, int lineno);
 
 /**
  * Currently in frame?
@@ -57,7 +57,7 @@ extern int g3_in_frame();
 /**
  * Set view from x,y,z & p,b,h, zoom.  Must call one of g3_set_view_*()
  */
-void g3_set_view_angles(vec3d *view_pos,angles *view_orient,float zoom);
+void g3_set_view_angles(const vec3d *view_pos, const angles *view_orient, float zoom);
 
 /**
  * Set view from camera
@@ -67,7 +67,7 @@ void g3_set_view(camera *cam);
 /**
  * Set view from x,y,z, viewer matrix, and zoom.  Must call one of g3_set_view_*()
  */
-void g3_set_view_matrix(vec3d *view_pos,matrix *view_matrix,float zoom);
+void g3_set_view_matrix(const vec3d *view_pos, const matrix *view_matrix, float zoom);
 
 // Never set these!
 extern matrix		View_matrix;		// The matrix to convert local coordinates to screen
@@ -103,12 +103,12 @@ int g3_compute_sky_polygon(float *points_2d,vec3d *vecs);
 /**
  * Instance at specified point with specified orientation
  */
-void g3_start_instance_matrix(vec3d *pos,matrix *orient, bool set_api = true);
+void g3_start_instance_matrix(const vec3d *pos, const matrix *orient, bool set_api = true);
 
 /**
  * Instance at specified point with specified orientation
  */
-void g3_start_instance_angles(vec3d *pos,angles *orient);
+void g3_start_instance_angles(const vec3d *pos, const angles *orient);
 
 /**
  * Pops the old context
@@ -138,27 +138,27 @@ void g3_get_view_vectors(vec3d *forward,vec3d *up,vec3d *right);
  *
  * Takes the unrotated surface normal of the plane, and a point on it.  The normal need not be normalized
  */
-int g3_check_normal_facing(vec3d *v,vec3d *norm);
+int g3_check_normal_facing(const vec3d *v, const vec3d *norm);
 
 /**
  * Returns codes_and & codes_or of a list of points numbers
  */
-ccodes g3_check_codes(int nv,vertex **pointlist);
+ccodes g3_check_codes(int nv, vertex **pointlist);
 
 /**
  * Rotates a point. returns codes.  does not check if already rotated
  */
-ubyte g3_rotate_vertex(vertex *dest,vec3d *src);
+ubyte g3_rotate_vertex(vertex *dest, const vec3d *src);
 
 /**
  * Same as above, only ignores the current instancing
  */
-ubyte g3_rotate_vertex_popped(vertex *dest,vec3d *src);
+ubyte g3_rotate_vertex_popped(vertex *dest, const vec3d *src);
 
 /**
  * Use this for stars, etc
  */
-ubyte g3_rotate_faraway_vertex(vertex *dest,vec3d *src);
+ubyte g3_rotate_faraway_vertex(vertex *dest, const vec3d *src);
 
 /**
  * Projects a point
@@ -168,24 +168,24 @@ int g3_project_vertex(vertex *point);
 /**
  * Projects a vector
  */
-ubyte g3_project_vector(vec3d *p, float *sx, float *sy );
+ubyte g3_project_vector(const vec3d *p, float *sx, float *sy );
 
 /**
  * Rotates a point.  
  * @return Returns codes.
  */
-ubyte g3_rotate_vector(vec3d *dest,vec3d *src);
+ubyte g3_rotate_vector(vec3d *dest, const vec3d *src);
 
 /**
  * Codes a vector.  
  * @return Returns the codes of a point.
  */
-ubyte g3_code_vector(vec3d * p);
+ubyte g3_code_vector(const vec3d * p);
 
 /**
  * Calculate the depth of a point - returns the z coord of the rotated point
  */
-float g3_calc_point_depth(vec3d *pnt);
+float g3_calc_point_depth(const vec3d *pnt);
 
 /**
  * From a 2d point, compute the vector through that point
@@ -217,10 +217,10 @@ ubyte g3_add_delta_vec(vertex *dest,vertex *src,vec3d *deltav);
  * Set TMAP_FLAG_TEXTURED in the tmap_flags to texture map it with current texture.
  * @return Returns 1 if off screen, 0 if drawn
  */
-int g3_draw_poly(int nv,vertex **pointlist,uint tmap_flags);
+int g3_draw_poly(int nv, vertex **pointlist,uint tmap_flags);
 
-int g3_draw_polygon(vec3d *pos, matrix *ori, float width, float height, int tmap_flags = TMAP_FLAG_TEXTURED);
-int g3_draw_polygon(vec3d *pos, vec3d *norm, float width, float height, int tmap_flags = TMAP_FLAG_TEXTURED);
+int g3_draw_polygon(const vec3d *pos, const matrix *ori, float width, float height, int tmap_flags = TMAP_FLAG_TEXTURED);
+int g3_draw_polygon(const vec3d *pos, const vec3d *norm, float width, float height, int tmap_flags = TMAP_FLAG_TEXTURED);
 
 /**
  * Draw a polygon.  
@@ -231,7 +231,7 @@ int g3_draw_polygon(vec3d *pos, vec3d *norm, float width, float height, int tmap
  * Set TMAP_FLAG_TEXTURED in the tmap_flags to texture map it with current texture.
  * @return Returns 1 if off screen, 0 if drawn
  */
-int g3_draw_poly_constant_sw(int nv,vertex **pointlist,uint tmap_flags, float constant_sw);
+int g3_draw_poly_constant_sw(int nv, vertex **pointlist, uint tmap_flags, float constant_sw);
 
 /**
  * Like g3_draw_poly(), but checks to see if facing.  
@@ -243,7 +243,7 @@ int g3_draw_poly_constant_sw(int nv,vertex **pointlist,uint tmap_flags, float co
  * Set TMAP_FLAG_TEXTURED in the tmap_flags to texture map it with current texture.
  * @return Returns -1 if not facing, 1 if off screen, 0 if drawn
  */
-int g3_draw_poly_if_facing(int nv,vertex **pointlist,uint tmap_flags,vec3d *norm,vec3d *pnt);
+int g3_draw_poly_if_facing(int nv, vertex **pointlist, uint tmap_flags, const vec3d *norm, const vec3d *pnt);
 
 /**
  * Draws a line.
@@ -251,14 +251,14 @@ int g3_draw_poly_if_facing(int nv,vertex **pointlist,uint tmap_flags,vec3d *norm
  * @param p0 First point
  * @param p1 Second point
  */
-int g3_draw_line(vertex *p0,vertex *p1);
+int g3_draw_line(vertex *p0, vertex *p1);
 
 /**
  * Draws a polygon always facing the viewer.
  * Compute the corners of a rod.  fills in vertbuf.
  * Verts has any needs uv's or l's or can be NULL if none needed.
  */
-int g3_draw_rod(vec3d *p0,float width1,vec3d *p1,float width2, vertex * verts, uint tmap_flags);
+int g3_draw_rod(const vec3d *p0, float width1, const vec3d *p1, float width2, vertex *verts, uint tmap_flags);
 
 /**
  * Draws a bitmap with the specified 3d width & height
@@ -270,7 +270,7 @@ int g3_draw_rod(vec3d *p0,float width1,vec3d *p1,float width2, vertex * verts, u
  * orient flips the bitmap in some way.  Pass 0 for normal or else pass a 
  * random nuber between 0 and 7, inclusive.
  */
-int g3_draw_bitmap(vertex *pos,int orient, float radius, uint tmap_flags, float depth = 0.0f);
+int g3_draw_bitmap(vertex *pos, int orient, float radius, uint tmap_flags, float depth = 0.0f);
 
 /**
  * Get bitmap dims onscreen as if g3_draw_bitmap() had been called
@@ -281,39 +281,39 @@ int g3_get_bitmap_dims(int bitmap, vertex *pos, float radius, int *x, int *y, in
  * Draw a sortof sphere - i.e., the 2d radius is proportional to the 3d
  * radius, but not to the distance from the eye.  Uses the current 2d color.
  */
-int g3_draw_sphere(vertex *pnt,float rad);
+int g3_draw_sphere(vertex *pnt, float rad);
 
 /**
  * Same as g3_draw_sphere, but you pass a vector and this rotates
  * and projects it and then call g3_draw_sphere.
  */
-int g3_draw_sphere_ez(vec3d *pnt,float rad);
+int g3_draw_sphere_ez(const vec3d *pnt, float rad);
 
 /**
  * Draw a laser shaped 3d looking thing.
  *
  * If max_len is > 1.0, then this caps the length to be no longer than max_len pixels
  */
-float g3_draw_laser(vec3d *headp, float head_width, vec3d *tailp, float tail_width, uint tmap_flags = TMAP_FLAG_TEXTURED, float max_len = 0.0f );
+float g3_draw_laser(const vec3d *headp, float head_width, const vec3d *tailp, float tail_width, uint tmap_flags = TMAP_FLAG_TEXTURED, float max_len = 0.0f );
 
 /**
  * Draw a laser shaped 3d looking thing using vertex coloring (useful for things like colored laser glows)
  *
  * If max_len is > 1.0, then this caps the length to be no longer than max_len pixels
  */
-float g3_draw_laser_rgb(vec3d *headp, float head_width, vec3d *tailp, float tail_width, int r, int g, int b, uint tmap_flags = TMAP_FLAG_TEXTURED | TMAP_FLAG_RGB, float max_len = 0.0f );
+float g3_draw_laser_rgb(const vec3d *headp, float head_width, const vec3d *tailp, float tail_width, int r, int g, int b, uint tmap_flags = TMAP_FLAG_TEXTURED | TMAP_FLAG_RGB, float max_len = 0.0f );
 
 /**
  * Draw a bitmap that is always facing, but rotates.
  *
  * If bitmap is not square, rad will be the 3d size of the smallest dimension.
  */
-int g3_draw_rotated_bitmap(vertex *pnt,float angle, float radius, uint tmap_flags, float depth = 0.0f);
+int g3_draw_rotated_bitmap(vertex *pnt, float angle, float radius, uint tmap_flags, float depth = 0.0f);
 
 /**
  * Draw a perspective bitmap based on angles and radius
  */
-int g3_draw_perspective_bitmap(angles *a, float scale_x, float scale_y, int div_x, int div_y, uint tmap_flags);
+int g3_draw_perspective_bitmap(const angles *a, float scale_x, float scale_y, int div_x, int div_y, uint tmap_flags);
 
 /**
  * Draw a 2D shield icon w/ 6 points
@@ -347,14 +347,14 @@ int g3_draw_2d_poly_bitmap(float x, float y, float w, float h, uint additional_t
  * clipped on or off by the plane, and will slow each clipped polygon by
  * not much more than any other clipping we do.
  */
-void g3_start_user_clip_plane( vec3d *plane_point, vec3d *plane_normal );
+void g3_start_user_clip_plane(const vec3d *plane_point, const vec3d *plane_normal);
 
 /**
  * Stops arbritary plane clipping
  */
 void g3_stop_user_clip_plane();
 
-ubyte g3_transfer_vertex(vertex *dest, vec3d *src);
+ubyte g3_transfer_vertex(vertex *dest, const vec3d *src);
 
 int g3_draw_2d_poly_bitmap_list(bitmap_2d_list* b_list, int n_bm, uint additional_tmap_flags);
 int g3_draw_2d_poly_bitmap_rect_list(bitmap_rect_list* b_list, int n_bm, uint additional_tmap_flags);
@@ -362,12 +362,12 @@ int g3_draw_2d_poly_bitmap_rect_list(bitmap_rect_list* b_list, int n_bm, uint ad
 /**
  * Draw a line in HTL mode without having to go through the rotate/project stuff
  */
-void g3_draw_htl_line(vec3d *start, vec3d *end);
+void g3_draw_htl_line(const vec3d *start, const vec3d *end);
 
 /**
  * Draw a sphere mode without having to go through the rotate/project stuff
  */
-void g3_draw_htl_sphere(vec3d *position, float radius);
+void g3_draw_htl_sphere(const vec3d *position, float radius);
 
 /**
  * Flash ball
@@ -389,13 +389,20 @@ class flash_ball{
 	void defpoint(int off, ubyte *bsp_data);
 
 public:
-	flash_ball(int number, float min_ray_width, float max_ray_width = 0, vec3d* dir = &vmd_zero_vector, vec3d*pcenter = &vmd_zero_vector, float outer = PI2, float inner = 0.0f, ubyte max_r = 255, ubyte max_g = 255, ubyte max_b = 255, ubyte min_r = 255, ubyte min_g = 255, ubyte min_b = 255)
+	flash_ball(int number, float min_ray_width, float max_ray_width = 0, const vec3d* dir = &vmd_zero_vector, const vec3d* pcenter = &vmd_zero_vector, float outer = PI2, float inner = 0.0f, ubyte max_r = 255, ubyte max_g = 255, ubyte max_b = 255, ubyte min_r = 255, ubyte min_g = 255, ubyte min_b = 255)
 		:ray(NULL),n_rays(0)
-		{initialize(number, min_ray_width, max_ray_width , dir , pcenter , outer , inner , max_r , max_g , max_b , min_r , min_g ,min_b);}
-	~flash_ball(){if(ray)vm_free(ray);}
+	{
+			initialize(number, min_ray_width, max_ray_width, dir, pcenter, outer, inner, max_r, max_g, max_b, min_r, min_g, min_b);
+	}
 
-	void initialize(int number, float min_ray_width, float max_ray_width = 0, vec3d* dir = &vmd_zero_vector, vec3d*pcenter = &vmd_zero_vector, float outer = PI2, float inner = 0.0f, ubyte max_r = 255, ubyte max_g = 255, ubyte max_b = 255, ubyte min_r = 255, ubyte min_g = 255, ubyte min_b = 255);
-	void initialize(ubyte *bsp_data, float min_ray_width, float max_ray_width = 0, vec3d* dir = &vmd_zero_vector, vec3d*pcenter = &vmd_zero_vector, float outer = PI2, float inner = 0.0f, ubyte max_r = 255, ubyte max_g = 255, ubyte max_b = 255, ubyte min_r = 255, ubyte min_g = 255, ubyte min_b = 255);
+	~flash_ball()
+	{
+		if (ray)
+			vm_free(ray);
+	}
+
+	void initialize(int number, float min_ray_width, float max_ray_width = 0, const vec3d* dir = &vmd_zero_vector, const vec3d* pcenter = &vmd_zero_vector, float outer = PI2, float inner = 0.0f, ubyte max_r = 255, ubyte max_g = 255, ubyte max_b = 255, ubyte min_r = 255, ubyte min_g = 255, ubyte min_b = 255);
+	void initialize(ubyte *bsp_data, float min_ray_width, float max_ray_width = 0, const vec3d* dir = &vmd_zero_vector, const vec3d* pcenter = &vmd_zero_vector, float outer = PI2, float inner = 0.0f, ubyte max_r = 255, ubyte max_g = 255, ubyte max_b = 255, ubyte min_r = 255, ubyte min_g = 255, ubyte min_b = 255);
 	void render(float rad, float intinsity, float life);
 	void render(int texture, float rad, float intinsity, float life);
 };

--- a/code/render/3ddraw.cpp
+++ b/code/render/3ddraw.cpp
@@ -1978,7 +1978,7 @@ void g3_draw_htl_line(const vec3d *start, const vec3d *end)
 		return;
 	}
 
-	gr_line_htl(const_cast<vec3d*>(start), const_cast<vec3d*>(end));
+	gr_line_htl(start, end);
 }
 
 void g3_draw_htl_sphere(const vec3d* position, float radius)

--- a/code/render/3ddraw.cpp
+++ b/code/render/3ddraw.cpp
@@ -68,11 +68,11 @@ static void g3_allocate_vbufs(int nv)
 /**
  * Deal with a clipped line
  */
-int must_clip_line(vertex *p0,vertex *p1,ubyte codes_or, uint flags)
+int must_clip_line(vertex *p0, vertex *p1, ubyte codes_or, uint flags)
 {
 	int ret = 0;
 	
-	clip_line(&p0,&p1,codes_or, flags);
+	clip_line(&p0, &p1, codes_or, flags);
 	
 	if (p0->codes & p1->codes) goto free_points;
 
@@ -109,7 +109,7 @@ free_points:
 /**
  * Draws a line. takes two points.  returns true if drew
  */
-int g3_draw_line(vertex *p0,vertex *p1)
+int g3_draw_line(vertex *p0, vertex *p1)
 {
 #ifdef FRED_OGL_COMMENT_OUT_FOR_NOW
 	if(Fred_running && !Cmdline_nohtl)
@@ -152,7 +152,7 @@ int g3_draw_line(vertex *p0,vertex *p1)
 
 //returns true if a plane is facing the viewer. takes the unrotated surface
 //normal of the plane, and a point on it.  The normal need not be normalized
-int g3_check_normal_facing(vec3d *v,vec3d *norm)
+int g3_check_normal_facing(const vec3d *v, const vec3d *norm)
 {
 	vec3d tempv;
 
@@ -163,7 +163,7 @@ int g3_check_normal_facing(vec3d *v,vec3d *norm)
 	return (vm_vec_dot(&tempv,norm) > 0.0f);
 }
 
-int do_facing_check(vec3d *norm,vertex **vertlist,vec3d *p)
+int do_facing_check(const vec3d *norm, vertex **vertlist, const vec3d *p)
 {
 	Assert( G3_count == 1 );
 
@@ -191,7 +191,7 @@ int do_facing_check(vec3d *norm,vertex **vertlist,vec3d *p)
 //is passed, this function works like g3_check_normal_facing() plus
 //g3_draw_poly().
 //returns -1 if not facing, 1 if off screen, 0 if drew
-int g3_draw_poly_if_facing(int nv,vertex **pointlist,uint tmap_flags,vec3d *norm,vec3d *pnt)
+int g3_draw_poly_if_facing(int nv, vertex **pointlist, uint tmap_flags, const vec3d *norm, const vec3d *pnt)
 {
 	Assert( G3_count == 1 );
 
@@ -204,7 +204,7 @@ int g3_draw_poly_if_facing(int nv,vertex **pointlist,uint tmap_flags,vec3d *norm
 //draw a polygon.
 //Set TMAP_FLAG_TEXTURED in the tmap_flags to texture map it with current texture.
 //returns 1 if off screen, 0 if drew
-int g3_draw_poly(int nv,vertex **pointlist,uint tmap_flags)
+int g3_draw_poly(int nv, vertex **pointlist, uint tmap_flags)
 {
 	int i;
 	vertex **bufptr;
@@ -307,7 +307,7 @@ free_points:
 	return 0;	//say it drew
 }
 
-int g3_draw_polygon(vec3d *pos, matrix *ori, float width, float height, int tmap_flags)
+int g3_draw_polygon(const vec3d *pos, const matrix *ori, float width, float height, int tmap_flags)
 {
 	//idiot-proof
 	if(width == 0 || height == 0)
@@ -366,7 +366,7 @@ int g3_draw_polygon(vec3d *pos, matrix *ori, float width, float height, int tmap
 	return 0;
 }
 
-int g3_draw_polygon(vec3d *pos, vec3d *norm, float width, float height, int tmap_flags)
+int g3_draw_polygon(const vec3d *pos, const vec3d *norm, float width, float height, int tmap_flags)
 {
 	matrix m;
 	vm_vector_2_matrix(&m, norm, NULL, NULL);
@@ -378,7 +378,7 @@ int g3_draw_polygon(vec3d *pos, vec3d *norm, float width, float height, int tmap
 // for all vertexes.  Needs to be done after clipping to get them all.
 //Set TMAP_FLAG_TEXTURED in the tmap_flags to texture map it with current texture.
 //returns 1 if off screen, 0 if drew
-int g3_draw_poly_constant_sw(int nv,vertex **pointlist,uint tmap_flags, float constant_sw)
+int g3_draw_poly_constant_sw(int nv, vertex **pointlist, uint tmap_flags, float constant_sw)
 {
 	int i;
 	vertex **bufptr;
@@ -472,7 +472,7 @@ free_points:
 
 //draw a sortof sphere - i.e., the 2d radius is proportional to the 3d
 //radius, but not to the distance from the eye
-int g3_draw_sphere(vertex *pnt,float rad)
+int g3_draw_sphere(vertex *pnt, float rad)
 {
 	Assert( G3_count == 1 );
 
@@ -495,14 +495,14 @@ int g3_draw_sphere(vertex *pnt,float rad)
 	return 0;
 }
 
-int g3_draw_sphere_ez(vec3d *pnt,float rad)
+int g3_draw_sphere_ez(const vec3d *pnt, float rad)
 {
 	vertex pt;
 	ubyte flags;
 
 	Assert( G3_count == 1 );
 
-	flags = g3_rotate_vertex(&pt,pnt);
+	flags = g3_rotate_vertex(&pt, pnt);
 
 	if (flags == 0) {
 
@@ -1259,7 +1259,7 @@ void g3_draw_horizon_line()
 // Draws a polygon always facing the viewer.
 // compute the corners of a rod.  fills in vertbuf.
 // Verts has any needs uv's or l's or can be NULL if none needed.
-int g3_draw_rod(vec3d *p0,float width1,vec3d *p1,float width2, vertex * verts, uint tmap_flags)
+int g3_draw_rod(const vec3d *p0, float width1, const vec3d *p1, float width2, vertex *verts, uint tmap_flags)
 {
 	vec3d uvec, fvec, rvec, center;
 
@@ -1332,7 +1332,7 @@ int g3_draw_rod(vec3d *p0,float width1,vec3d *p1,float width2, vertex * verts, u
 }
 
 #define MAX_ROD_VECS	100
-int g3_draw_rod(int num_points, vec3d *pvecs, float width, uint tmap_flags)
+int g3_draw_rod(int num_points, const vec3d *pvecs, float width, uint tmap_flags)
 {
 	vec3d uvec, fvec, rvec;
 	vec3d vecs[2];
@@ -1431,7 +1431,7 @@ void stars_project_2d_onto_sphere( vec3d *pnt, float rho, float phi, float theta
 // draw a perspective bitmap based on angles and radius
 float p_phi = 10.0f;
 float p_theta = 10.0f;
-int g3_draw_perspective_bitmap(angles *a, float scale_x, float scale_y, int div_x, int div_y, uint tmap_flags)
+int g3_draw_perspective_bitmap(const angles *a, float scale_x, float scale_y, int div_x, int div_y, uint tmap_flags)
 {
 	vec3d s_points[MAX_PERSPECTIVE_DIVISIONS+1][MAX_PERSPECTIVE_DIVISIONS+1];
 	vec3d t_points[MAX_PERSPECTIVE_DIVISIONS+1][MAX_PERSPECTIVE_DIVISIONS+1];
@@ -1467,10 +1467,9 @@ int g3_draw_perspective_bitmap(angles *a, float scale_x, float scale_y, int div_
 	vm_angles_2_matrix(&m_bank, &bank_first);
 
 	// convert angles to matrix
-	float b_save = a->b;
-	a->b = 0.0f;
-	vm_angles_2_matrix(&m, a);
-	a->b = b_save;	
+	angles a_temp = *a;
+	a_temp.b = 0.0f;
+	vm_angles_2_matrix(&m, &a_temp);
 
 	// generate the bitmap points	
 	for(idx=0; idx<=div_x; idx++){
@@ -1973,16 +1972,16 @@ int g3_draw_2d_poly_bitmap_rect_list(bitmap_rect_list* b_list, int n_bm, uint ad
 	return ret;
 }
 
-void g3_draw_htl_line(vec3d *start, vec3d *end)
+void g3_draw_htl_line(const vec3d *start, const vec3d *end)
 {
 	if (Cmdline_nohtl) {
 		return;
 	}
 
-	gr_line_htl(start,end);
+	gr_line_htl(const_cast<vec3d*>(start), const_cast<vec3d*>(end));
 }
 
-void g3_draw_htl_sphere(vec3d* position, float radius)
+void g3_draw_htl_sphere(const vec3d* position, float radius)
 {
 	if (Cmdline_nohtl) {
 		return;
@@ -1998,7 +1997,7 @@ void g3_draw_htl_sphere(vec3d* position, float radius)
 //++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++//
 //flash ball stuff
 
-void flash_ball::initialize(int number, float min_ray_width, float max_ray_width, vec3d* dir, vec3d*pcenter, float outer, float inner, ubyte max_r, ubyte max_g, ubyte max_b, ubyte min_r, ubyte min_g, ubyte min_b)
+void flash_ball::initialize(int number, float min_ray_width, float max_ray_width, const vec3d* dir, const vec3d* pcenter, float outer, float inner, ubyte max_r, ubyte max_g, ubyte max_b, ubyte min_r, ubyte min_g, ubyte min_b)
 {
 	if(number < 1)
 		return;
@@ -2134,7 +2133,7 @@ void flash_ball::parse_bsp(int offset, ubyte *bsp_data){
 }
 
 
-void flash_ball::initialize(ubyte *bsp_data, float min_ray_width, float max_ray_width, vec3d* dir , vec3d*pcenter , float outer , float inner , ubyte max_r , ubyte max_g , ubyte max_b , ubyte min_r , ubyte min_g , ubyte min_b )
+void flash_ball::initialize(ubyte *bsp_data, float min_ray_width, float max_ray_width, const vec3d* dir, const vec3d* pcenter, float outer, float inner, ubyte max_r, ubyte max_g, ubyte max_b, ubyte min_r, ubyte min_g, ubyte min_b)
 {
 	center = *pcenter;
 	vm_vec_negate(&center);

--- a/code/render/3dinternal.h
+++ b/code/render/3dinternal.h
@@ -36,6 +36,6 @@ extern vec3d G3_user_clip_normal;
 extern vec3d G3_user_clip_point;
 
 // Returns TRUE if point is behind user plane
-extern int g3_point_behind_user_plane( vec3d *pnt );
+extern int g3_point_behind_user_plane( const vec3d *pnt );
 
 #endif

--- a/code/render/3dlaser.cpp
+++ b/code/render/3dlaser.cpp
@@ -21,7 +21,7 @@
 int Lasers = 1;
 DCF_BOOL( lasers, Lasers )
 
-float g3_draw_laser_htl(vec3d *p0,float width1,vec3d *p1,float width2, int r, int g, int b, uint tmap_flags)
+float g3_draw_laser_htl(const vec3d *p0, float width1, const vec3d *p1, float width2, int r, int g, int b, uint tmap_flags)
 {
 	width1 *= 0.5f;
 	width2 *= 0.5f;
@@ -113,7 +113,7 @@ float g3_draw_laser_htl(vec3d *p0,float width1,vec3d *p1,float width2, int r, in
 // and a bitmap with gr_set_bitmap.  If it is very far away, it draws the laser
 // as flat-shaded using current color, else textured using current texture.
 // If max_len is > 1.0, then this caps the length to be no longer than max_len pixels.
-float g3_draw_laser(vec3d *headp, float head_width, vec3d *tailp, float tail_width, uint tmap_flags, float max_len )
+float g3_draw_laser(const vec3d *headp, float head_width, const vec3d *tailp, float tail_width, uint tmap_flags, float max_len )
 {
 	if (!Lasers) {
 		return 0.0f;
@@ -264,13 +264,13 @@ float g3_draw_laser(vec3d *headp, float head_width, vec3d *tailp, float tail_wid
 
 // Draw a laser shaped 3d looking thing using vertex coloring (useful for things like colored laser glows)
 // If max_len is > 1.0, then this caps the length to be no longer than max_len pixels
-float g3_draw_laser_rgb(vec3d *headp, float head_width, vec3d *tailp, float tail_width, int r, int g, int b, uint tmap_flags, float max_len )
+float g3_draw_laser_rgb(const vec3d *headp, float head_width, const vec3d *tailp, float tail_width, int r, int g, int b, uint tmap_flags, float max_len )
 {
 	if (!Lasers){
 		return 0.0f;
 	}
 	if((!Cmdline_nohtl)  && tmap_flags & TMAP_HTL_3D_UNLIT){
-		return g3_draw_laser_htl(headp,head_width,tailp,tail_width,r,g,b,tmap_flags | TMAP_HTL_3D_UNLIT);
+		return g3_draw_laser_htl(headp, head_width, tailp, tail_width, r, g, b, tmap_flags | TMAP_HTL_3D_UNLIT);
 	}
 	float headx, heady, headr, tailx, taily, tailr;
 	vertex pt1, pt2;

--- a/code/render/3dmath.cpp
+++ b/code/render/3dmath.cpp
@@ -18,7 +18,7 @@
 /**
  * Codes a vector.  Returns the codes of a point.
  */
-ubyte g3_code_vector(vec3d * p)
+ubyte g3_code_vector(const vec3d *p)
 {
 	ubyte cc=0;
 
@@ -81,7 +81,7 @@ ubyte g3_code_vertex(vertex *p)
 
 }
 
-ubyte g3_transfer_vertex(vertex *dest,vec3d *src)
+ubyte g3_transfer_vertex(vertex *dest, const vec3d *src)
 {
 	dest->world = *src;
 
@@ -94,7 +94,7 @@ ubyte g3_transfer_vertex(vertex *dest,vec3d *src)
 
 MONITOR( NumRotations )
 
-ubyte g3_rotate_vertex(vertex *dest,vec3d *src)
+ubyte g3_rotate_vertex(vertex *dest, const vec3d *src)
 {
 #if 0
 	vec3d tempv;
@@ -153,7 +153,7 @@ ubyte g3_rotate_vertex(vertex *dest,vec3d *src)
 }	
 
 
-ubyte g3_rotate_faraway_vertex(vertex *dest,vec3d *src)
+ubyte g3_rotate_faraway_vertex(vertex *dest, const vec3d *src)
 {	
 	Assert( G3_count == 1 );
 
@@ -168,7 +168,7 @@ ubyte g3_rotate_faraway_vertex(vertex *dest,vec3d *src)
 /**
  * Rotates a point. returns codes.  does not check if already rotated
  */
-ubyte g3_rotate_vector(vec3d *dest,vec3d *src)
+ubyte g3_rotate_vector(vec3d *dest, const vec3d *src)
 {
 	vec3d tempv;
 
@@ -181,7 +181,7 @@ ubyte g3_rotate_vector(vec3d *dest,vec3d *src)
 	return g3_code_vector(dest);
 }	
 		
-ubyte g3_project_vector(vec3d *p, float *sx, float *sy )
+ubyte g3_project_vector(const vec3d *p, float *sx, float *sy )
 {
 	float w;
 
@@ -228,7 +228,7 @@ int g3_project_vertex(vertex *p)
 /**
  * From a 2d point, compute the vector through that point
  */
-void g3_point_to_vec(vec3d *v,int sx,int sy)
+void g3_point_to_vec(vec3d *v, int sx, int sy)
 {
 	vec3d	tempv;
 
@@ -251,7 +251,7 @@ void g3_point_to_vec(vec3d *v,int sx,int sy)
  * This can be called outside of a g3_start_frame/g3_end_frame
  * pair as long g3_start_frame was previously called.
  */
-void g3_point_to_vec_delayed(vec3d *v,int sx,int sy)
+void g3_point_to_vec_delayed(vec3d *v, int sx, int sy)
 {
 	vec3d	tempv;
 
@@ -266,7 +266,7 @@ void g3_point_to_vec_delayed(vec3d *v,int sx,int sy)
 	vm_vec_unrotate(v, &tempv, &Unscaled_matrix);
 }
 
-vec3d *g3_rotate_delta_vec(vec3d *dest,vec3d *src)
+vec3d *g3_rotate_delta_vec(vec3d *dest, const vec3d *src)
 {
 	Assert( G3_count == 1 );
 	return vm_vec_rotate(dest,src,&View_matrix);
@@ -275,7 +275,7 @@ vec3d *g3_rotate_delta_vec(vec3d *dest,vec3d *src)
 /**
  * Calculate the depth of a point - returns the z coord of the rotated point
  */
-float g3_calc_point_depth(vec3d *pnt)
+float g3_calc_point_depth(const vec3d *pnt)
 {
 	float q;
 

--- a/code/render/3dsetup.cpp
+++ b/code/render/3dsetup.cpp
@@ -304,7 +304,7 @@ void g3_start_instance_matrix(const vec3d *pos, const matrix *orient, bool set_a
 	vm_matrix_x_matrix(&Light_matrix,&saved_orient, orient);
 
 	if(!Cmdline_nohtl && set_api)
-		gr_start_instance_matrix(const_cast<vec3d*>(pos), const_cast<matrix*>(orient));
+		gr_start_instance_matrix(pos, orient);
 
 }
 
@@ -330,7 +330,7 @@ void g3_start_instance_angles(const vec3d *pos, const angles *orient)
 	g3_start_instance_matrix(pos,&tm, false);
 
 	if(!Cmdline_nohtl)
-		gr_start_angles_instance_matrix(const_cast<vec3d*>(pos), const_cast<angles*>(orient));
+		gr_start_angles_instance_matrix(pos, orient);
 
 }
 

--- a/code/render/3dsetup.cpp
+++ b/code/render/3dsetup.cpp
@@ -72,7 +72,7 @@ int g3_in_frame()
  * Start the frame
  * Pass true for zbuffer_flag to turn on zbuffering
  */
-void g3_start_frame_func(int zbuffer_flag, char * filename, int lineno)
+void g3_start_frame_func(int zbuffer_flag, const char *filename, int lineno)
 {
 	float s;
 	int width, height;
@@ -123,7 +123,7 @@ void g3_start_frame_func(int zbuffer_flag, char * filename, int lineno)
 /**
  * This doesn't do anything, but is here for completeness
  */
-void g3_end_frame_func(char *filename, int lineno)
+void g3_end_frame_func(const char *filename, int lineno)
 {
 	G3_count--;
 	Assert( G3_count == 0 );
@@ -149,7 +149,7 @@ void g3_set_view(camera *cam)
 /**
  * Set view from x,y,z, viewer matrix, and zoom.  Must call one of g3_set_view_*()
  */
-void g3_set_view_matrix(vec3d *view_pos,matrix *view_matrix,float zoom)
+void g3_set_view_matrix(const vec3d *view_pos, const matrix *view_matrix, float zoom)
 {
 	Assert( G3_count == 1 );
 
@@ -179,7 +179,7 @@ void g3_set_view_matrix(vec3d *view_pos,matrix *view_matrix,float zoom)
 /**
  * Set view from x,y,z & p,b,h, zoom.  Must call one of g3_set_view_*()
  */
-void g3_set_view_angles(vec3d *view_pos,angles *view_orient,float zoom)
+void g3_set_view_angles(const vec3d *view_pos, const angles *view_orient, float zoom)
 {
 	matrix tmp;
 
@@ -225,7 +225,7 @@ void scale_matrix(void)
 
 }
 
-ubyte g3_rotate_vertex_popped(vertex *dest,vec3d *src)
+ubyte g3_rotate_vertex_popped(vertex *dest, const vec3d *src)
 {
 	vec3d tempv;
 
@@ -246,7 +246,7 @@ ubyte g3_rotate_vertex_popped(vertex *dest,vec3d *src)
  * if matrix==NULL, don't modify matrix.  This will be like doing an offset   
  * if pos==NULL, no position change
  */
-void g3_start_instance_matrix(vec3d *pos,matrix *orient, bool set_api)
+void g3_start_instance_matrix(const vec3d *pos, const matrix *orient, bool set_api)
 {
 	vec3d tempv;
 	matrix tempm,tempm2;
@@ -304,7 +304,7 @@ void g3_start_instance_matrix(vec3d *pos,matrix *orient, bool set_api)
 	vm_matrix_x_matrix(&Light_matrix,&saved_orient, orient);
 
 	if(!Cmdline_nohtl && set_api)
-		gr_start_instance_matrix(pos,orient);
+		gr_start_instance_matrix(const_cast<vec3d*>(pos), const_cast<matrix*>(orient));
 
 }
 
@@ -314,7 +314,7 @@ void g3_start_instance_matrix(vec3d *pos,matrix *orient, bool set_api)
  *
  * If angles==NULL, don't modify matrix.  This will be like doing an offset
  */
-void g3_start_instance_angles(vec3d *pos,angles *orient)
+void g3_start_instance_angles(const vec3d *pos, const angles *orient)
 {
 	matrix tm;
 
@@ -329,7 +329,8 @@ void g3_start_instance_angles(vec3d *pos,angles *orient)
 
 	g3_start_instance_matrix(pos,&tm, false);
 
-	if(!Cmdline_nohtl)gr_start_angles_instance_matrix(pos, orient);
+	if(!Cmdline_nohtl)
+		gr_start_angles_instance_matrix(const_cast<vec3d*>(pos), const_cast<angles*>(orient));
 
 }
 
@@ -377,7 +378,7 @@ vec3d G3_user_clip_point;
  * clipped on or off by the plane, and will slow each clipped polygon by
  * not much more than any other clipping we do.
  */
-void g3_start_user_clip_plane( vec3d *plane_point, vec3d *plane_normal )
+void g3_start_user_clip_plane(const vec3d *plane_point, const vec3d *plane_normal )
 {
 	float mag = vm_vec_mag( plane_normal );
 	if ( (mag < 0.1f) || (mag > 1.5f ) )	{
@@ -415,7 +416,7 @@ void g3_stop_user_clip_plane()
 /**
  * Returns TRUE if point is behind user plane
  */
-int g3_point_behind_user_plane( vec3d *pnt )
+int g3_point_behind_user_plane( const vec3d *pnt )
 {
 	if ( G3_user_clip ) {
 		vec3d tmp;

--- a/code/starfield/starfield.cpp
+++ b/code/starfield/starfield.cpp
@@ -296,10 +296,9 @@ static void starfield_create_bitmap_buffer(const int si_idx)
 	vm_angles_2_matrix(&m_bank, &bank_first);
 
 	// convert angles to matrix
-	float b_save = a->b;
-	a->b = 0.0f;
-	vm_angles_2_matrix(&m, a);
-	a->b = b_save;
+	angles a_temp = *a;
+	a_temp.b = 0.0f;
+	vm_angles_2_matrix(&m, &a_temp);
 
 	// generate the bitmap points
 	for(idx=0; idx<=div_x; idx++) {


### PR DESCRIPTION
After comments on #392, I decided to see about making `g3_set_view_matrix` (and other functions in 3d.h) const-correct.  This actually wasn't as bad as it could have been, owing mostly to the surprising fact that vertexes are often modified as they are drawn and so can't be const.  This isn't limited to clipping polygons, it also has to do with projecting and truncating lines.  Anyway, this diff is the result.

I did have to use `const_cast` in just a few places where the g3_ API calls the gr_ API.  Also, I removed two ugly instances of an `angles` struct being modified, used as a temporary variable for a calculation, then restored to its original value.

And yes, this PR adds `const` to the two parameters in `draw_model_icon` that I wanted to be const.