### PR TITLE
remove obsolete const_casts

### DIFF
--- a/code/fred2/missionsave.cpp
+++ b/code/fred2/missionsave.cpp
@@ -2975,7 +2975,7 @@ int CFred_mission_save::fout_version(char *format, ...)
 		str_scp.append(fso_ver_comment.back().c_str());
 		str_scp.append(" ");
 
-		cfputs(const_cast<char*>(str_scp.c_str()), fp);
+		cfputs(str_scp.c_str(), fp);
 
 		str_scp = "";
 	}
@@ -3002,7 +3002,7 @@ int CFred_mission_save::fout_version(char *format, ...)
 					if (first_line) {
 						first_line = false;
 					} else {
-						cfputs(const_cast<char*>(fso_ver_comment.back().c_str()), fp);
+						cfputs(fso_ver_comment.back().c_str(), fp);
 						cfputs(" ", fp);
 					}
 
@@ -3014,7 +3014,7 @@ int CFred_mission_save::fout_version(char *format, ...)
 					if (first_line) {
 						first_line = false;
 					} else {
-						cfputs(const_cast<char*>(fso_ver_comment.back().c_str()), fp);
+						cfputs(fso_ver_comment.back().c_str(), fp);
 						cfputs(" ", fp);
 					}
 
@@ -3028,7 +3028,7 @@ int CFred_mission_save::fout_version(char *format, ...)
 
 			// be sure to account for any ending elements too
 			if ( strlen(str_p) ) {
-				cfputs(const_cast<char*>(fso_ver_comment.back().c_str()), fp);
+				cfputs(fso_ver_comment.back().c_str(), fp);
 				cfputs(" ", fp);
 				cfputs(str_p, fp);
 			}
@@ -3057,7 +3057,7 @@ int CFred_mission_save::fout(char *format, ...)
 	vsprintf(str, format, args);
 	va_end(args);
 
-	cfputs(const_cast<char*>(str.c_str()), fp);
+	cfputs(str.c_str(), fp);
 	return 0;
 }
 
@@ -3122,7 +3122,7 @@ int CFred_mission_save::fout_ext(char *pre_str, char *format, ...)
 					if (first_line) {
 						first_line = false;
 					} else {
-						cfputs(const_cast<char*>(fso_ver_comment.back().c_str()), fp);
+						cfputs(fso_ver_comment.back().c_str(), fp);
 						cfputs(" ", fp);
 					}
 
@@ -3134,7 +3134,7 @@ int CFred_mission_save::fout_ext(char *pre_str, char *format, ...)
 					if (first_line) {
 						first_line = false;
 					} else {
-						cfputs(const_cast<char*>(fso_ver_comment.back().c_str()), fp);
+						cfputs(fso_ver_comment.back().c_str(), fp);
 						cfputs(" ", fp);
 					}
 
@@ -3148,7 +3148,7 @@ int CFred_mission_save::fout_ext(char *pre_str, char *format, ...)
 
 			// be sure to account for any ending elements too
 			if ( strlen(str_p) ) {
-				cfputs(const_cast<char*>(fso_ver_comment.back().c_str()), fp);
+				cfputs(fso_ver_comment.back().c_str(), fp);
 				cfputs(" ", fp);
 				cfputs(str_p, fp);
 			}

--- a/code/fred2/voiceactingmanager.cpp
+++ b/code/fred2/voiceactingmanager.cpp
@@ -718,7 +718,7 @@ int VoiceActingManager::fout(char *format, ...)
 	vsprintf(str, format, args);
 	va_end(args);
 
-	cfputs(const_cast<char*>(str.c_str()), fp);
+	cfputs(str.c_str(), fp);
 	return 0;
 }
 

--- a/code/fs2netd/fs2netd_client.cpp
+++ b/code/fs2netd/fs2netd_client.cpp
@@ -1207,7 +1207,7 @@ void fs2netd_update_ban_list()
 
 		if (banlist_cfg != NULL) {
 			for (SCP_vector<SCP_string>::iterator bl = FS2NetD_ban_list.begin(); bl != FS2NetD_ban_list.end(); ++bl) {
-				cfputs( const_cast<char*>(bl->c_str()), banlist_cfg );
+				cfputs( bl->c_str(), banlist_cfg );
 			}
 
 			cfclose(banlist_cfg);

--- a/code/gamesnd/gamesnd.cpp
+++ b/code/gamesnd/gamesnd.cpp
@@ -831,7 +831,7 @@ bool gamesnd_parse_line(game_snd *gs, const char *tag, SCP_vector<game_snd> *loo
 {
 	Assertion(gs != NULL, "Invalid game_snd pointer passed to gamesnd_parse_line!");
 
-	required_string(const_cast<char*>(tag));
+	required_string(tag);
 
 	bool no_create = false;
 

--- a/code/hud/hudshield.cpp
+++ b/code/hud/hudshield.cpp
@@ -187,7 +187,7 @@ void hud_ship_icon_page_in(ship_info *sip)
 	sgp = &Shield_gauges.at(sip->shield_icon_index);
 
 	if ( sgp->first_frame == -1 ) {
-		sgp->first_frame = bm_load_animation(const_cast<char*>(Hud_shield_filenames.at(sip->shield_icon_index).c_str()), &sgp->num_frames);
+		sgp->first_frame = bm_load_animation(Hud_shield_filenames.at(sip->shield_icon_index).c_str(), &sgp->num_frames);
 		if ( sgp->first_frame == -1 ) {
 			Warning(LOCATION, "Could not load in the HUD shield ani: %s\n", Hud_shield_filenames.at(sip->shield_icon_index).c_str());
 			return;
@@ -625,7 +625,7 @@ void HudGaugeShield::showShields(object *objp, int mode)
 		sgp = &Shield_gauges.at(sip->shield_icon_index);
 
 		if ( (sgp->first_frame == -1) && (sip->shield_icon_index < Hud_shield_filenames.size()) ) {
-			sgp->first_frame = bm_load_animation(const_cast<char*>(Hud_shield_filenames.at(sip->shield_icon_index).c_str()), &sgp->num_frames);
+			sgp->first_frame = bm_load_animation(Hud_shield_filenames.at(sip->shield_icon_index).c_str(), &sgp->num_frames);
 			if (sgp->first_frame == -1) {
 				if (!shield_ani_warning_displayed_already) {
 					shield_ani_warning_displayed_already = true;

--- a/code/hud/hudtarget.cpp
+++ b/code/hud/hudtarget.cpp
@@ -1390,7 +1390,7 @@ static object* select_next_target_by_distance( const bool targeting_from_closest
 			if ( diff > 0.0f ) {
 				if ( diff < ( current_distance - nearest_distance ) ) {
 					nearest_distance = new_distance;
-					nearest_object_ptr = const_cast<object *>(prospective_victim_ptr);
+					nearest_object_ptr = prospective_victim_ptr;
 				}
 			}
 		}

--- a/code/mission/missioncampaign.cpp
+++ b/code/mission/missioncampaign.cpp
@@ -880,7 +880,7 @@ void mission_campaign_delete_all_savefiles( char *pilot_name )
 	// be.  I have to save any file filters
 	filter_save = Get_file_list_filter;
 	Get_file_list_filter = NULL;
-	num_files = cf_get_file_list(names, dir_type, const_cast<char *>(file_spec));
+	num_files = cf_get_file_list(names, dir_type, file_spec);
 	Get_file_list_filter = filter_save;
 
 	for (i=0; i<num_files; i++) {

--- a/code/pilotfile/csg_convert.cpp
+++ b/code/pilotfile/csg_convert.cpp
@@ -1173,7 +1173,7 @@ bool pilotfile_convert::csg_convert(const char *fname, bool inferno)
 
 	filename.reserve(200);
 
-	cf_create_default_path_string(filename, CF_TYPE_SINGLE_PLAYERS, (inferno) ? const_cast<char*>("inferno") : NULL);
+	cf_create_default_path_string(filename, CF_TYPE_SINGLE_PLAYERS, (inferno) ? "inferno" : NULL);
 
 	if (inferno) {
 		filename.append(DIR_SEPARATOR_STR);
@@ -1184,7 +1184,7 @@ bool pilotfile_convert::csg_convert(const char *fname, bool inferno)
 
 	mprintf(("    CS2 => Converting '%s'...\n", filename.c_str()));
 
-	cfp = cfopen(const_cast<char*>(filename.c_str()), "rb", CFILE_NORMAL);
+	cfp = cfopen(filename.c_str(), "rb", CFILE_NORMAL);
 
 	if ( !cfp ) {
 		mprintf(("    CS2 => Unable to open '%s' for import!\n", fname));
@@ -1214,7 +1214,7 @@ bool pilotfile_convert::csg_convert(const char *fname, bool inferno)
 	filename.assign(fname);
 	filename.append(".csg");
 
-	cfp = cfopen(const_cast<char*>(filename.c_str()), "wb", CFILE_NORMAL, CF_TYPE_PLAYERS);
+	cfp = cfopen(filename.c_str(), "wb", CFILE_NORMAL, CF_TYPE_PLAYERS);
 
 	if ( !cfp ) {
 		mprintf(("    CSG => Unable to open '%s' for export!\n", fname));

--- a/code/pilotfile/pilotfile_convert.cpp
+++ b/code/pilotfile/pilotfile_convert.cpp
@@ -135,7 +135,7 @@ void convert_pilot_files()
 				Get_file_list_child = "inferno";
 			}
 
-			cf_get_file_list(savefiles, CF_TYPE_SINGLE_PLAYERS, const_cast<char*>(wildcard.c_str()));
+			cf_get_file_list(savefiles, CF_TYPE_SINGLE_PLAYERS, wildcard.c_str());
 
 			for (j = 0; j < savefiles.size(); j++) {
 				pcon->csg_convert(savefiles[j].c_str(), inferno);

--- a/code/pilotfile/plr_convert.cpp
+++ b/code/pilotfile/plr_convert.cpp
@@ -861,7 +861,7 @@ bool pilotfile_convert::plr_convert(const char *fname, bool inferno)
 
 	filename.reserve(200);
 
-	cf_create_default_path_string(filename, CF_TYPE_SINGLE_PLAYERS, (inferno) ? const_cast<char*>("inferno") : NULL);
+	cf_create_default_path_string(filename, CF_TYPE_SINGLE_PLAYERS, (inferno) ? "inferno" : NULL);
 
 	if (inferno) {
 		filename.append(DIR_SEPARATOR_STR);
@@ -872,7 +872,7 @@ bool pilotfile_convert::plr_convert(const char *fname, bool inferno)
 
 	mprintf(("  PL2 => Converting '%s'...\n", filename.c_str()));
 
-	cfp = cfopen(const_cast<char*>(filename.c_str()), "rb", CFILE_NORMAL);
+	cfp = cfopen(filename.c_str(), "rb", CFILE_NORMAL);
 
 	if ( !cfp ) {
 		mprintf(("  PL2 => Unable to open '%s' for import!\n", fname));
@@ -896,7 +896,7 @@ bool pilotfile_convert::plr_convert(const char *fname, bool inferno)
 	filename.assign(fname);
 	filename.append(".plr");
 
-	cfp = cfopen(const_cast<char*>(filename.c_str()), "wb", CFILE_NORMAL, CF_TYPE_PLAYERS);
+	cfp = cfopen(filename.c_str(), "wb", CFILE_NORMAL, CF_TYPE_PLAYERS);
 
 	if ( !cfp ) {
 		mprintf(("  PLR => Unable to open '%s' for export!\n", fname));

--- a/code/playerman/playercontrol.cpp
+++ b/code/playerman/playercontrol.cpp
@@ -1796,7 +1796,7 @@ void player_show_death_message()
 	color col;
 	gr_init_color(&col, 255, 0, 0);
 	// display the message
-	HUD_fixed_printf(30.0f, col, const_cast<char *>(msg.c_str()));
+	HUD_fixed_printf(30.0f, col, msg.c_str());
 }
 
 void player_set_next_all_alone_msg_timestamp()


### PR DESCRIPTION
Speaking of const_cast, many of them are no longer needed now that there are more const-correct functions in the codebase.  Applying this PR brings the total number of const_casts down to 5.