### PR TITLE
handle mod subfolders on unix

### DIFF
--- a/code/cmdline/cmdline.cpp
+++ b/code/cmdline/cmdline.cpp
@@ -1038,12 +1038,12 @@ char *cmdline_parm::str()
 
 #ifdef SCP_UNIX
 // for case sensitive filesystems (e.g. Linux/BSD) perform case-insensitive dir matches
-void unix_handle_modlist(char **modlist, int *len)
+static void unix_handle_modlist(char **modlist, int *len)
 {
 	DIR *dp;
 	dirent *dirp;
-	char *cur_pos, *temp;
-	char cur_dir[CF_MAX_PATHNAME_LENGTH], delim[] = ",";
+	char *cur_pos;
+	char cur_dir[CF_MAX_PATHNAME_LENGTH];
 	SCP_vector<SCP_string> temp_modlist;
 	size_t total_len = 0;
 
@@ -1051,7 +1051,7 @@ void unix_handle_modlist(char **modlist, int *len)
 		Error(LOCATION, "Can't get current working directory -- %d", errno );
 	}
 
-	for (cur_pos = strtok(*modlist, delim); cur_pos != NULL; cur_pos = strtok(NULL, delim))
+	for (cur_pos = strtok(*modlist, ","); cur_pos != NULL; cur_pos = strtok(NULL, ","))
 	{
 		if ((dp = opendir(cur_dir)) == NULL) {
 			Error(LOCATION, "Can't open directory '%s' -- %d", cur_dir, errno );
@@ -1072,12 +1072,11 @@ void unix_handle_modlist(char **modlist, int *len)
 	SCP_vector<SCP_string>::iterator ii, end = temp_modlist.end();
 	for (ii = temp_modlist.begin(); ii != end; ++ii) {
 		strcat_s(new_modlist, total_len+1, ii->c_str());
-		strcat_s(new_modlist, total_len+1, ","); // replace later with NUL
+		strcat_s(new_modlist, total_len+1, ",");
 	}
 
-	temp = *modlist;
+	delete [] (*modlist);
 	*modlist = new_modlist;
-	delete [] temp;
 	*len = total_len;
 }
 #endif /* SCP_UNIX */

--- a/code/cmdline/cmdline.cpp
+++ b/code/cmdline/cmdline.cpp
@@ -1036,6 +1036,52 @@ char *cmdline_parm::str()
 	return args;
 }
 
+#ifdef SCP_UNIX
+// for case sensitive filesystems (e.g. Linux/BSD) perform case-insensitive dir matches
+void unix_handle_modlist(char **modlist, int *len)
+{
+	DIR *dp;
+	dirent *dirp;
+	char *cur_pos, *temp;
+	char cur_dir[CF_MAX_PATHNAME_LENGTH], delim[] = ",";
+	SCP_vector<SCP_string> temp_modlist;
+	size_t total_len = 0;
+
+	if ( !_getcwd(cur_dir, CF_MAX_PATHNAME_LENGTH ) ) {
+		Error(LOCATION, "Can't get current working directory -- %d", errno );
+	}
+
+	for (cur_pos = strtok(*modlist, delim); cur_pos != NULL; cur_pos = strtok(NULL, delim))
+	{
+		if ((dp = opendir(cur_dir)) == NULL) {
+			Error(LOCATION, "Can't open directory '%s' -- %d", cur_dir, errno );
+		}
+
+		while ((dirp = readdir(dp)) != NULL) {
+			if (!stricmp(dirp->d_name, cur_pos)) {
+				temp_modlist.push_back(dirp->d_name);
+				total_len += (strlen(dirp->d_name) + 1);
+			}
+		}
+		(void)closedir(dp);
+	}
+
+	// create new char[] to replace modlist
+	char *new_modlist = new char[total_len+1];
+	memset( new_modlist, 0, total_len + 1 );
+	SCP_vector<SCP_string>::iterator ii, end = temp_modlist.end();
+	for (ii = temp_modlist.begin(); ii != end; ++ii) {
+		strcat_s(new_modlist, total_len+1, ii->c_str());
+		strcat_s(new_modlist, total_len+1, ","); // replace later with NUL
+	}
+
+	temp = *modlist;
+	*modlist = new_modlist;
+	delete [] temp;
+	*len = total_len;
+}
+#endif /* SCP_UNIX */
+
 // external entry point into this modules
 
 bool SetCmdlineParams()
@@ -1318,47 +1364,7 @@ bool SetCmdlineParams()
 		strcpy_s(modlist, len+2, Cmdline_mod);
 
 #ifdef SCP_UNIX
-		// for case sensitive filesystems (e.g. Linux/BSD) perform case-insensitive dir matches
-		DIR *dp;
-		dirent *dirp;
-		char *cur_pos, *temp;
-		char cur_dir[CF_MAX_PATHNAME_LENGTH], delim[] = ",";
-		SCP_vector<SCP_string> temp_modlist;
-		size_t total_len = 0;
-
-		if ( !_getcwd(cur_dir, CF_MAX_PATHNAME_LENGTH ) ) {
-			Error(LOCATION, "Can't get current working directory -- %d", errno );
-		}
-
-		for (cur_pos = strtok(modlist, delim); cur_pos != NULL; cur_pos = strtok(NULL, delim))
-		{
-			if ((dp = opendir(cur_dir)) == NULL) {
-				Error(LOCATION, "Can't open directory '%s' -- %d", cur_dir, errno );
-			}
-
-			while ((dirp = readdir(dp)) != NULL) {
-				if (!stricmp(dirp->d_name, cur_pos)) {
-					temp_modlist.push_back(dirp->d_name);
-					total_len += (strlen(dirp->d_name) + 1);
-				}
-			}
-			(void)closedir(dp);
-		}
-
-		// create new char[] to replace modlist
-		char *new_modlist = new char[total_len+1];
-		memset( new_modlist, 0, total_len + 1 );
-		SCP_vector<SCP_string>::iterator ii, end = temp_modlist.end();
-		for (ii = temp_modlist.begin(); ii != end; ++ii) {
-			strcat_s(new_modlist, total_len+1, ii->c_str());
-			strcat_s(new_modlist, total_len+1, ","); // replace later with NUL
-		}
-
-		// make the rest of the function unaware that anything happened here
-		temp = modlist;
-		modlist = new_modlist;
-		delete [] temp;
-		len = total_len;
+		unix_handle_modlist(&modlist, &len);
 #endif
 
 		// null terminate each individual

--- a/code/cmdline/cmdline.cpp
+++ b/code/cmdline/cmdline.cpp
@@ -1062,11 +1062,13 @@ static char *unix_get_single_dir_name(const char *dir, const char *parent)
 
 // Returns the name of the directory "parent/dir" as seen by the filesystem.
 // Recurses when dir contains a slash.
+// Backslashes are treated as slashes for compatibility with mod.inis that
+// are written for Windows.
 static char *unix_get_dir_name(const char *dir, const char *parent)
 {
 	// find end of first directory name
 	const char *pos = dir;
-	for ( ; *pos != '\0' && *pos != '/'; pos++)
+	for ( ; *pos != '\0' && *pos != '/' && *pos != '\\'; pos++)
 		;
 
 	if (*pos == '\0') {

--- a/code/mission/missioncampaign.cpp
+++ b/code/mission/missioncampaign.cpp
@@ -629,9 +629,20 @@ int mission_campaign_load( char *filename, player *pl, int load_savefile, bool r
 				cm->num_variables = 0;
 			}
 
-			cm->goals = NULL;
-			cm->events = NULL;
-			cm->variables = NULL;
+			// it's possible to have data already loaded from the pilotfile
+			// if so free it to avoid memory leaks
+			if (cm->goals != nullptr) {
+				vm_free(cm->goals);
+				cm->goals = nullptr;
+			}
+			if (cm->events != nullptr) {
+				vm_free(cm->events);
+				cm->events = nullptr;
+			}
+			if (cm->variables != nullptr) {
+				vm_free(cm->variables);
+				cm->variables = nullptr;
+			}
 
 			Campaign.num_missions++;
 		}


### PR DESCRIPTION
Mod paths given using the -mod cmdline parameter currently cannot contain subfolders on unix.
This is stopping me putting all mods in a "mods" folder and the writing e.g
    -mod mods/fsport-mediavps_2014,mods/fsport,mods/MediaVPs_2014

This patchset allows mod subfolders and also backslashes instead of slashes for compatibility with mod.inis that are written for Windows.

The following modlist then works:
    -mod Mods/fsport-MediaVPs_2014,mods\fsport,mods\mediavps_2014
with the following directory structure
main folder
--- mods
------ fsport
------ fsport-mediavps_2014
------ MediaVPs_2014

Note that I wrote most of this code while taking part in a sleep deprivation experiment so I would appreciate a thorough review.

Edit: don't know how that one commit slipped in, nor how to remove it...