### PR TITLE
Sparky hi fallback fix

### DIFF
--- a/code/graphics/2d.cpp
+++ b/code/graphics/2d.cpp
@@ -770,6 +770,15 @@ void gr_screen_resize(int width, int height)
 	}
 }
 
+int gr_get_resolution_class(int width, int height)
+{
+	if ((width >= GR_1024_THRESHOLD_WIDTH) && (height >= GR_1024_THRESHOLD_HEIGHT)) {
+		return GR_1024;
+	} else {
+		return GR_640;
+	}
+}
+
 static bool gr_init_sub(int mode, int width, int height, int depth, float center_aspect_ratio)
 {
 	int res = GR_1024;
@@ -800,11 +809,7 @@ static bool gr_init_sub(int mode, int width, int height, int depth, float center
 	gr_screen.save_center_offset_x = gr_screen.center_offset_x = (width - gr_screen.center_w) / 2;
 	gr_screen.save_center_offset_y = gr_screen.center_offset_y = (height - gr_screen.center_h) / 2;
 
-	if ( (gr_screen.center_w >= GR_1024_THRESHOLD_WIDTH) && (gr_screen.center_h >= GR_1024_THRESHOLD_HEIGHT) ) {
-		res = GR_1024;
-	} else {
-		res = GR_640;
-	}
+	res = gr_get_resolution_class(gr_screen.center_w, gr_screen.center_h);
 
 	if (Fred_running) {
 		gr_screen.custom_size = false;
@@ -979,19 +984,21 @@ bool gr_init(int d_mode, int d_width, int d_height, int d_depth)
 		depth = d_depth;
 	}
 
-	// check for hi-res interface files so that we can verify our width/height is correct
-	bool has_sparky_hi = (cf_exists_full("2_ChoosePilot-m.pcx", CF_TYPE_ANY) && cf_exists_full("2_TechShipData-m.pcx", CF_TYPE_ANY));
+	if (gr_get_resolution_class(width, height) != GR_640) {
+		// check for hi-res interface files so that we can verify our width/height is correct
+		bool has_sparky_hi = (cf_exists_full("2_ChoosePilot-m.pcx", CF_TYPE_ANY) && cf_exists_full("2_TechShipData-m.pcx", CF_TYPE_ANY));
 
-	// if we don't have it then fall back to 640x480 mode instead
-	if ( !has_sparky_hi ) {
-		if ( (width == 1024) && (height == 768) ) {
-			width = 640;
-			height = 480;
-			center_aspect_ratio = -1.0f;
-		} else {
-			width = 800;
-			height = 600;
-			center_aspect_ratio = -1.0f;
+		// if we don't have it then fall back to 640x480 mode instead
+		if ( !has_sparky_hi ) {
+			if ( (width == 1024) && (height == 768) ) {
+				width = 640;
+				height = 480;
+				center_aspect_ratio = -1.0f;
+			} else {
+				width = 800;
+				height = 600;
+				center_aspect_ratio = -1.0f;
+			}
 		}
 	}
 

--- a/code/graphics/2d.h
+++ b/code/graphics/2d.h
@@ -686,6 +686,7 @@ extern const char *Resolution_prefixes[GR_NUM_RESOLUTIONS];
 
 extern bool gr_init(int d_mode = GR_DEFAULT, int d_width = GR_DEFAULT, int d_height = GR_DEFAULT, int d_depth = GR_DEFAULT);
 extern void gr_screen_resize(int width, int height);
+extern int gr_get_resolution_class(int width, int height);
 
 // Call this when your app ends.
 extern void gr_close();

--- a/code/menuui/mainhallmenu.cpp
+++ b/code/menuui/mainhallmenu.cpp
@@ -534,11 +534,7 @@ void main_hall_init(const SCP_string &main_hall_name)
 
 	// get the default value for tooltip padding if necessary
 	if (Main_hall->tooltip_padding == -1) {
-		if (Main_hall_bitmap_w >= GR_1024_THRESHOLD_WIDTH && Main_hall_bitmap_h >= GR_1024_THRESHOLD_HEIGHT) {
-			Main_hall->tooltip_padding = Main_hall_default_tooltip_padding[GR_1024];
-		} else {
-			Main_hall->tooltip_padding = Main_hall_default_tooltip_padding[GR_640];
-		}
+		Main_hall->tooltip_padding = Main_hall_default_tooltip_padding[gr_get_resolution_class(Main_hall_bitmap_w, Main_hall_bitmap_h)];
 	}
 
 	// In case we're re-entering the mainhall


### PR DESCRIPTION
As you might know, if sparky_hi_fs2.vp is missing, FSO changes the resolution to 640x480 if it was 1024x768 originally, and to 800x600 in other cases. However, this is incorrectly being done to *all* resolutions instead of just those that use high-resolution graphics (1024x600 and above). The effect of this is that low resolutions like 720x576 and even 640x480(!) are changed to 800x600 in this situation.

The changes in this pull request fix this problem.