### PR TITLE
Fix memory leak from Control_config_presets

### DIFF
--- a/code/controlconfig/controlsconfig.h
+++ b/code/controlconfig/controlsconfig.h
@@ -297,6 +297,7 @@ extern char **Scan_code_text;
 extern char **Joy_button_text;
 
 void control_config_common_init();			//!< initialize common control config stuff - call at game startup after localization has been initialized
+void control_config_common_close();			//!< close common control config stuff - call at game shutdown
 
 void control_config_init();
 void control_config_do_frame(float frametime);

--- a/code/controlconfig/controlsconfigcommon.cpp
+++ b/code/controlconfig/controlsconfigcommon.cpp
@@ -610,6 +610,16 @@ void control_config_common_init()
 	}
 }
 
+/*
+ * @brief close any common control config stuff, called at game_shutdown()
+ */
+void control_config_common_close()
+{
+	// only need to worry control presets for now
+	for (auto ii = Control_config_presets.cbegin(); ii != Control_config_presets.cend(); ++ii) {
+		delete * ii;
+	}
+}
 
 
 #include <map>

--- a/code/freespace2/freespace.cpp
+++ b/code/freespace2/freespace.cpp
@@ -7437,6 +7437,7 @@ void game_shutdown(void)
 	// free left over memory from table parsing
 	player_tips_close();
 
+	control_config_common_close();
 	joy_close();
 
 	audiostream_close();


### PR DESCRIPTION
Another one from #381, not very serious since the config presets are needed until game close anyway.