### PR TITLE
Profiling support for mission events and scripts

### DIFF
--- a/code/graphics/2d.cpp
+++ b/code/graphics/2d.cpp
@@ -2116,12 +2116,14 @@ void gr_flip()
 	// m!m avoid running CHA_ONFRAME when the "Quit mission" popup is shown. See mantis 2446 for reference
 	if (!quit_mission_popup_shown)
 	{
+		profile_begin("LUA On Frame");
 		//WMC - Evaluate global hook if not override.
 		Script_system.RunBytecode(Script_globalhook);
 		//WMC - Do conditional hooks. Yippee!
 		Script_system.RunCondition(CHA_ONFRAME);
 		//WMC - Do scripting reset stuff
 		Script_system.EndFrame();
+		profile_end("LUA On Frame");
 	}
 
 	gr_screen.gf_flip();

--- a/code/mission/missiongoals.cpp
+++ b/code/mission/missiongoals.cpp
@@ -1044,7 +1044,7 @@ void mission_eval_goals()
 			}
 
 			// if we get here, then the timestamp on the event has popped -- we should reevaluate
-			mission_process_event(i);
+			PROFILE("Repeating events", mission_process_event(i));
 		}
 	}
 	
@@ -1078,7 +1078,7 @@ void mission_eval_goals()
 			// we will evaluate repeatable events at the top of the file so we can get
 			// the exact interval that the designer asked for.
 			if ( !timestamp_valid( Mission_events[i].timestamp) ){
-				mission_process_event( i );
+				PROFILE("Nonrepeating events", mission_process_event( i ));
 			}
 		}
 	}


### PR DESCRIPTION
While testing out Her Finest Hour for the BP:WiH rerelease, we found that under certain very common conditions event evaluation could spike to take up several hundred milliseconds. In order to find the cause, I added these profile points, I think they will come in handy for everyone.