### PR TITLE
properly close the fiction viewer when returning to the main menu

### DIFF
--- a/code/freespace2/freespace.cpp
+++ b/code/freespace2/freespace.cpp
@@ -5966,6 +5966,10 @@ void game_leave_state( int old_state, int new_state )
 
 		case GS_STATE_FICTION_VIEWER:
 			fiction_viewer_close();
+			common_select_close();
+			if (new_state == GS_STATE_MAIN_MENU) {
+				freespace_stop_mission();
+			}
 			break;
 
 		case GS_STATE_LAB:


### PR DESCRIPTION
Thanks to Yarn for noticing this issue in #412.  When comparing the fiction viewer state with the other pre-mission states (GS_STATE_CMD_BRIEF, GS_STATE_RED_ALERT, etc.) in that same function, the fix becomes evident.