### PR TITLE
Use -march=native for linux builds

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -88,6 +88,13 @@ AC_ARG_ENABLE(fatal-warnings,
 		[fs2_fatal_warnings=no],
 )
 
+AC_ARG_ENABLE(generic-architecture,
+	AC_HELP_STRING([--enable-generic-architecture],
+		[Only use generic architecture optimizations]),
+		[fs2_generic_architecture=$enableval],
+		[fs2_generic_architecture=no],
+)
+
 AC_ARG_WITH(static-ogg,
 	AC_HELP_STRING([--with-static-ogg=DIR],
 		[Link staticly with OGG, Vorbis and Theora libs from this directory]),
@@ -128,14 +135,28 @@ case "$target" in
 		# linux
 		echo "Using 64-bit Unix defines (for $host_os)"
 		fs2_os_linux="yes"
-		D_CFLAGS="$D_CFLAGS -m64 -mtune=generic -msse -msse2 -pipe"
+
+		if test "$fs2_generic_architecture" = "yes" ; then
+			D_CFLAGS="$D_CFLAGS -m64 -mtune=generic -mfpmath=sse -msse -msse2"
+		else
+			D_CFLAGS="$D_CFLAGS -march=native"
+		fi
+
+		D_CFLAGS="$D_CFLAGS -pipe"
 		D_CFLAGS="$D_CFLAGS -DLUA_USE_LINUX"
 		;;
 	*-*-linux*)
 		# linux
 		echo "Using Unix defines (for $host_os)"
 		fs2_os_linux="yes"
-		D_CFLAGS="$D_CFLAGS -mtune=generic -mfpmath=sse -msse -msse2 -pipe"
+
+		if test "$fs2_generic_architecture" = "yes" ; then
+			D_CFLAGS="$D_CFLAGS -mtune=generic -mfpmath=sse -msse -msse2"
+		else
+			D_CFLAGS="$D_CFLAGS -march=native"
+		fi
+
+		D_CFLAGS="$D_CFLAGS -pipe"
 		D_CFLAGS="$D_CFLAGS -DLUA_USE_LINUX"
 		;;
 	*-*-darwin*)


### PR DESCRIPTION
That should let the compiler make a few more optimizations for the current system (release builds would probably need to override this to ensure that the executables run on other systems).
I did some profiling with the different versions:

![image](https://cloud.githubusercontent.com/assets/1013983/11002488/5044de0a-84ad-11e5-95c5-040257a81070.png)

Both times I ran the Icarus cutscene of Blue Planet 2. The graph doesn't really show any big difference but it's better to let the compiler use what it can.