### PR TITLE
Use the Core rather than older Extension form of GL_SHADING_LANGUAGE_VERSION

### DIFF
--- a/code/graphics/gropengl.cpp
+++ b/code/graphics/gropengl.cpp
@@ -2082,7 +2082,7 @@ bool gr_opengl_init()
 	mprintf(( "  Using %s texture filter.\n", (GL_mipmap_filter) ? NOX("trilinear") : NOX("bilinear") ));
 
 	if (Use_GLSL) {
-		mprintf(( "  OpenGL Shader Version: %s\n", glGetString(GL_SHADING_LANGUAGE_VERSION_ARB) ));
+		mprintf(( "  OpenGL Shader Version: %s\n", glGetString(GL_SHADING_LANGUAGE_VERSION) ));
 	}
 
 

--- a/code/graphics/gropenglextension.cpp
+++ b/code/graphics/gropenglextension.cpp
@@ -439,7 +439,7 @@ void opengl_extensions_init()
 	if ( !Cmdline_noglsl && Is_Extension_Enabled(OGL_ARB_SHADER_OBJECTS) && Is_Extension_Enabled(OGL_ARB_FRAGMENT_SHADER)
 			&& Is_Extension_Enabled(OGL_ARB_VERTEX_SHADER) ) {
 		int ver = 0, major = 0, minor = 0;
-		const char *glsl_ver = (const char*)glGetString(GL_SHADING_LANGUAGE_VERSION_ARB);
+		const char *glsl_ver = (const char*)glGetString(GL_SHADING_LANGUAGE_VERSION);
 
 		sscanf(glsl_ver, "%d.%d", &major, &minor);
 		ver = (major * 100) + minor;
@@ -459,7 +459,7 @@ void opengl_extensions_init()
 		// we require GLSL 1.20 or higher
 		else if (ver < 110) {
 			Use_GLSL = 0;
-			mprintf(("  OpenGL Shading Language version %s is not sufficient to use GLSL mode in FSO. Defaulting to fixed-function renderer.\n", glGetString(GL_SHADING_LANGUAGE_VERSION_ARB) ));
+			mprintf(("  OpenGL Shading Language version %s is not sufficient to use GLSL mode in FSO. Defaulting to fixed-function renderer.\n", glGetString(GL_SHADING_LANGUAGE_VERSION) ));
 		}
 	}
 


### PR DESCRIPTION
Our present approach queries `glGetString()` with `GL_SHADING_LANGUAGE_VERSION_ARB`, which is not guaranteed to be present in future releases.

Refer OpenGL specifications: https://www.opengl.org/sdk/docs/man/html/glGetString.xhtml

Tested on the following OpenGL drivers:
* Mesa open source (Intel i965)
* Apple