### PR TITLE
Fix for crash in events editor

### DIFF
--- a/code/sound/audiostr.cpp
+++ b/code/sound/audiostr.cpp
@@ -466,11 +466,10 @@ bool WaveFile::Open(char *pszFilename, bool keep_ext)
 	// ... otherwise we just find the best match
 	else {
 		rc = cf_find_file_location_ext(filename, NUM_AUDIO_EXT, audio_ext_list, CF_TYPE_ANY, sizeof(fullpath) - 1, fullpath, &FileSize, &FileOffset);
-	}
 
-	if (rc < 0) {
-		goto OPEN_ERROR;
-	} else {
+		if (rc < 0)
+			goto OPEN_ERROR;
+
 		// set proper filename for later use (assumes that it doesn't already have an extension)
 		strcat_s( filename, audio_ext_list[rc] );
 	}


### PR DESCRIPTION
There is a bug in the events editor that crashes FRED when the user tries to play a sound file whose file name has at least 28 characters and has the extension ".wav" or ".ogg". This is caused by the game trying to add another extension to the name, potentially resulting in a string that's longer than the maximum of 31 characters. The change in this PR fixes this bug (hopefully without breaking anything else).