### PR TITLE
Directional beam glows

### DIFF
--- a/code/weapon/beam.cpp
+++ b/code/weapon/beam.cpp
@@ -1424,46 +1424,136 @@ void beam_render_muzzle_glow(beam *b)
 	if (alpha <= 0.0f)
 		return;
 
-	// draw the bitmap
-	if (Cmdline_nohtl)
-		g3_rotate_vertex(&pt, &b->last_start);
-	else
-		g3_transfer_vertex(&pt, &b->last_start);
+	if (bwi->directional_glow == true){
+		vertex h1[4];
+		vertex *verts[4] = { &h1[0], &h1[1], &h1[2], &h1[3] };
+		vec3d fvec, top1, top2, bottom1, bottom2, sub1, sub2, start, end;
+
+		vm_vec_sub(&fvec, &b->last_shot, &b->last_start);
+		vm_vec_normalize_quick(&fvec);
+
+		vm_vec_copy_scale(&sub1, &fvec, rad);
+		vm_vec_sub(&start, &b->last_start, &sub1);
+		vm_vec_copy_scale(&sub2, &fvec, bwi->glow_length);
+		vm_vec_add(&end, &start, &sub2);
+
+		int cull = gr_set_cull(0);
+
+		beam_calc_facing_pts(&top1, &bottom1, &fvec, &start, rad, 1.0f);
+		beam_calc_facing_pts(&top2, &bottom2, &fvec, &end, rad, 1.0f);
+
+		if (Cmdline_nohtl) {
+			g3_rotate_vertex(verts[0], &bottom1);
+			g3_rotate_vertex(verts[1], &bottom2);
+			g3_rotate_vertex(verts[2], &top2);
+			g3_rotate_vertex(verts[3], &top1);
+		}
+		else {
+			g3_transfer_vertex(verts[0], &bottom1);
+			g3_transfer_vertex(verts[1], &bottom2);
+			g3_transfer_vertex(verts[2], &top2);
+			g3_transfer_vertex(verts[3], &top1);
+		}
+
+		for (int idx = 0; idx < 4; idx++) {
+			g3_project_vertex(verts[idx]);
+		}
+
+		verts[0]->texture_position.u = 1.0f;
+		verts[0]->texture_position.v = 0.0f;
+		verts[1]->texture_position.u = 0.0f;
+		verts[1]->texture_position.v = 0.0f;
+		verts[2]->texture_position.u = 0.0f;
+		verts[2]->texture_position.v = 1.0f;
+		verts[3]->texture_position.u = 1.0f;
+		verts[3]->texture_position.v = 1.0f;
+
+		verts[0]->r = 255;
+		verts[1]->r = 255;
+		verts[2]->r = 255;
+		verts[3]->r = 255;
+		verts[0]->g = 255;
+		verts[1]->g = 255;
+		verts[2]->g = 255;
+		verts[3]->g = 255;
+		verts[0]->b = 255;
+		verts[1]->b = 255;
+		verts[2]->b = 255;
+		verts[3]->b = 255;
+		verts[0]->a = 255;
+		verts[1]->a = 255;
+		verts[2]->a = 255;
+		verts[3]->a = 255;
+
+		int framenum = 0;
+
+		if (bwi->beam_glow.num_frames > 1) {
+			b->beam_glow_frame += flFrametime;
+
+			// Sanity checks
+			if (b->beam_glow_frame < 0.0f)
+				b->beam_glow_frame = 0.0f;
+			else if (b->beam_glow_frame > 100.0f)
+				b->beam_glow_frame = 0.0f;
+
+			while (b->beam_glow_frame > bwi->beam_glow.total_time)
+				b->beam_glow_frame -= bwi->beam_glow.total_time;
+
+			framenum = fl2i((b->beam_glow_frame * bwi->beam_glow.num_frames) / bwi->beam_glow.total_time);
+
+			CLAMP(framenum, 0, bwi->beam_glow.num_frames - 1);
+		}
+
+		gr_set_bitmap(bwi->beam_glow.first_frame + framenum, GR_ALPHABLEND_FILTER, GR_BITBLT_MODE_NORMAL, alpha * pct);
+
+		// draw a poly
+		g3_draw_poly(4, verts, TMAP_FLAG_TEXTURED | TMAP_FLAG_CORRECT | TMAP_HTL_3D_UNLIT);
+
+		gr_set_cull(cull);
+
+	} else {
+
+		// draw the bitmap
+		if (Cmdline_nohtl)
+			g3_rotate_vertex(&pt, &b->last_start);
+		else
+			g3_transfer_vertex(&pt, &b->last_start);
 
 
-	int framenum = 0;
+		int framenum = 0;
 
-	if (bwi->beam_glow.num_frames > 1) {
-		b->beam_glow_frame += flFrametime;
+		if (bwi->beam_glow.num_frames > 1) {
+			b->beam_glow_frame += flFrametime;
 
-		// Sanity checks
-		if (b->beam_glow_frame < 0.0f)
-			b->beam_glow_frame = 0.0f;
-		else if (b->beam_glow_frame > 100.0f)
-			b->beam_glow_frame = 0.0f;
+			// Sanity checks
+			if (b->beam_glow_frame < 0.0f)
+				b->beam_glow_frame = 0.0f;
+			else if (b->beam_glow_frame > 100.0f)
+				b->beam_glow_frame = 0.0f;
 
-		while (b->beam_glow_frame > bwi->beam_glow.total_time)
-			b->beam_glow_frame -= bwi->beam_glow.total_time;
+			while (b->beam_glow_frame > bwi->beam_glow.total_time)
+				b->beam_glow_frame -= bwi->beam_glow.total_time;
 
-		framenum = fl2i( (b->beam_glow_frame * bwi->beam_glow.num_frames) / bwi->beam_glow.total_time );
+			framenum = fl2i((b->beam_glow_frame * bwi->beam_glow.num_frames) / bwi->beam_glow.total_time);
 
-		CLAMP(framenum, 0, bwi->beam_glow.num_frames-1);
+			CLAMP(framenum, 0, bwi->beam_glow.num_frames - 1);
+		}
+
+		gr_set_bitmap(bwi->beam_glow.first_frame + framenum, GR_ALPHABLEND_FILTER, GR_BITBLT_MODE_NORMAL, alpha * pct);
+
+		// draw 1 bitmap
+		g3_draw_bitmap(&pt, 0, rad, tmap_flags);
+
+		// maybe draw more
+		if (pct > 0.3f)
+			g3_draw_bitmap(&pt, 0, rad * 0.75f, tmap_flags, rad * 0.25f);
+
+		if (pct > 0.5f)
+			g3_draw_bitmap(&pt, 0, rad * 0.45f, tmap_flags, rad * 0.55f);
+
+		if (pct > 0.7f)
+			g3_draw_bitmap(&pt, 0, rad * 0.25f, tmap_flags, rad * 0.75f);
 	}
-
-	gr_set_bitmap(bwi->beam_glow.first_frame + framenum, GR_ALPHABLEND_FILTER, GR_BITBLT_MODE_NORMAL, alpha * pct);
-
-	// draw 1 bitmap
-	g3_draw_bitmap(&pt, 0, rad, tmap_flags);
-	
-	// maybe draw more
-	if (pct > 0.3f)
-		g3_draw_bitmap(&pt, 0, rad * 0.75f, tmap_flags, rad * 0.25f);
-
-	if (pct > 0.5f)
-		g3_draw_bitmap(&pt, 0, rad * 0.45f, tmap_flags, rad * 0.55f);
-
-	if (pct > 0.7f)
-		g3_draw_bitmap(&pt, 0, rad * 0.25f, tmap_flags, rad * 0.75f);
 }
 
 // render all beam weapons

--- a/code/weapon/weapon.h
+++ b/code/weapon/weapon.h
@@ -264,6 +264,8 @@ typedef struct beam_weapon_info {
 	int beam_warmdown_sound;			// warmdown sound
 	int beam_num_sections;				// the # of visible "sections" on the beam
 	generic_anim beam_glow;				// muzzle glow bitmap
+	float glow_length;					// (DahBlount) determines the length the muzzle glow when using a directional glow
+	bool directional_glow;				// (DahBlount) makes the muzzle glow render to a poly that is oriented along the direction of fire
 	int beam_shots;						// # of shots the beam takes
 	float beam_shrink_factor;			// what percentage of total beam lifetime when the beam starts shrinking
 	float beam_shrink_pct;				// what percent/second the beam shrinks at

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -1028,6 +1028,8 @@ void init_weapon_entry(int weap_info_index)
 	wip->b_info.beam_warmup_sound = -1;
 	wip->b_info.beam_warmdown_sound = -1;
 	wip->b_info.beam_num_sections = 0;
+	wip->b_info.glow_length = 0;
+	wip->b_info.directional_glow = false;
 	wip->b_info.beam_shots = 1;
 	wip->b_info.beam_shrink_factor = 0.0f;
 	wip->b_info.beam_shrink_pct = 0.0f;
@@ -2281,6 +2283,11 @@ int parse_weapon(int subtype, bool replace, const char *filename)
 		if (optional_string("+Muzzleglow:") ) {
 			stuff_string(fname, F_NAME, NAME_LENGTH);
 			generic_anim_init(&wip->b_info.beam_glow, fname);
+		}
+
+		if (optional_string("+Directional Glow:")) {
+			stuff_float(&wip->b_info.glow_length);
+			wip->b_info.directional_glow = true;
 		}
 
 		// # of shots (only used for type D beams)


### PR DESCRIPTION
Directional Beam Glows, unlike conventional Muzzle Glows, are rendered to a project poly made of 4 vertices and oriented around the firing point.

Example of it in action: http://i.imgur.com/t0DMeHx.png

While not very noticeable initially, it is especially useful for AAA beams that have a very short life and need a bursty appearance.

This works using +Directional Glow: float, which sets a length value in meters for the glow, and the +Radius is used as the height.