### PR TITLE
Upped MAX_SHIP_CLASSES to 500

### DIFF
--- a/code/globalincs/globals.h
+++ b/code/globalincs/globals.h
@@ -45,7 +45,7 @@
 // ****************************************************************
 #define MAX_SHIP_CLASSES_MULTI	130
 
-#define MAX_SHIP_CLASSES		250
+#define MAX_SHIP_CLASSES		500
 
 #define MAX_WINGS				75
 


### PR DESCRIPTION
Because apparently, this is a thing we will need to have in Blue Planet.

Yes, I know it's better to remove the limit completely, which I am working on. But until that's finished, we need this to continue work.