### PR TITLE
Allow aspect missiles to die when have lost lock

### DIFF
--- a/code/weapon/weapon.h
+++ b/code/weapon/weapon.h
@@ -124,6 +124,7 @@ extern int Num_weapon_subtypes;
 #define WIF3_AOE_ELECTRONICS			(1 << 7)	// Apply electronics effect across the weapon's entire area of effect instead of just on the impacted ship -MageKing17
 #define WIF3_APPLY_RECOIL				(1 << 8)	// Apply recoil using weapon and ship info
 #define WIF3_DONT_SPAWN_IF_SHOT			(1 << 9)	// Prevent shot down parent weapons from spawning children (DahBlount)
+#define WIF3_DIE_ON_LOST_LOCK			(1 << 10)	// WIF_LOCKED_HOMING missiles will die if they lose their lock
 
 #define	WIF_HOMING					(WIF_HOMING_HEAT | WIF_HOMING_ASPECT | WIF_HOMING_JAVELIN)
 #define WIF_LOCKED_HOMING           (WIF_HOMING_ASPECT | WIF_HOMING_JAVELIN)

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -687,6 +687,14 @@ void parse_wi_flags(weapon_info *weaponp, int wi_flags, int wi_flags2, int wi_fl
 			weaponp->wi_flags3 |= WIF3_APPLY_RECOIL;
 		else if (!stricmp(NOX("don't spawn if shot"), weapon_strings[i]))
 			weaponp->wi_flags3 |= WIF3_DONT_SPAWN_IF_SHOT;
+		else if (!stricmp(NOX("die on lost lock"), weapon_strings[i])) {
+			if (!(weaponp->wi_flags & WIF_LOCKED_HOMING)) {
+				Warning(LOCATION, "\"die on lost lock\" may only be used for Homing Type ASPECT/JAVELIN!");
+			}
+			else {
+				weaponp->wi_flags3 |= WIF3_DIE_ON_LOST_LOCK;
+			}
+		}
 		else
 			Warning(LOCATION, "Bogus string in weapon flags: %s\n", weapon_strings[i]);
 	}
@@ -4241,13 +4249,20 @@ void weapon_home(object *obj, int num, float frame_time)
 	// Goober5000 - this has been fixed back to more closely follow the original logic.  Remember, the retail code
 	// had 0.5 second of free flight time, the first half of which was spent ramping up to full speed.
 	if ((hobjp == &obj_used_list) || ( f2fl(Missiontime - wp->creation_time) < (wip->free_flight_time / 2) )) {
-		//	If this is a heat seeking homing missile and [free-flight-time] has elapsed since firing
-		//	and we don't have a target (else we wouldn't be inside the IF), find a new target.
-        if ((wip->wi_flags & WIF_HOMING_HEAT) &&
-            (f2fl(Missiontime - wp->creation_time) > wip->free_flight_time))
-        {
-            find_homing_object(obj, num);
-        }
+		if (f2fl(Missiontime - wp->creation_time) > wip->free_flight_time) {
+			// If this is a heat seeking homing missile and [free-flight-time] has elapsed since firing
+			// and we don't have a target (else we wouldn't be inside the IF), find a new target.
+			if (wip->wi_flags & WIF_HOMING_HEAT) {
+				find_homing_object(obj, num);
+			}
+			// modders may want aspect homing missiles to die if they lose their target
+			else if (wip->wi_flags & WIF_LOCKED_HOMING && wip->wi_flags3 & WIF3_DIE_ON_LOST_LOCK) {
+				if (wp->lifeleft > 0.5f) {
+					wp->lifeleft = frand_range(0.1f, 0.5f); // randomise a bit to avoid multiple missiles detonating in one frame
+				}
+				return;
+			}
+		}
 		else if (MULTIPLAYER_MASTER && (wip->wi_flags & WIF_LOCKED_HOMING) && (wp->weapon_flags & WF_HOMING_UPDATE_NEEDED)) {
 			wp->weapon_flags &= ~WF_HOMING_UPDATE_NEEDED; 
 			send_homing_weapon_info(num);
@@ -4344,6 +4359,8 @@ void weapon_home(object *obj, int num, float frame_time)
 			wp->homing_object = &obj_used_list;
 			return;
 	}
+
+	// TODO maybe add flag to allow WF_LOCKED_HOMING to lose target when target is dead
 
 	switch (hobjp->type) {
 	case OBJ_NONE:


### PR DESCRIPTION
Note that aspect missiles don't lose lock when their target dies, I'll
see about adding that later