### PR TITLE
Deprecate +Min Damage and +Max Damage, add +Attenuation Damage:

### DIFF
--- a/code/object/collideshipweapon.cpp
+++ b/code/object/collideshipweapon.cpp
@@ -74,11 +74,9 @@ void ship_weapon_do_hit_stuff(object *pship_obj, object *weapon_obj, vec3d *worl
 	// Apply hit & damage & stuff to weapon
 	weapon_hit(weapon_obj, pship_obj,  world_hitpos, quadrant_num);
 
-	if (wip->damage_time != 0.0f && wp->lifeleft <= wip->damage_time) {
-		if (wip->min_damage != 0.0f) {
-			damage = (((wip->damage - wip->min_damage) * (wp->lifeleft / wip->damage_time)) + wip->min_damage);
-		} else if (wip->max_damage != 0.0f) {
-			damage = (((wip->damage - wip->max_damage) * (wp->lifeleft / wip->damage_time)) + wip->max_damage);
+	if (wip->damage_time >= 0.0f && wp->lifeleft <= wip->damage_time) {
+		if (wip->atten_damage >= 0.0f) {
+			damage = (((wip->damage - wip->atten_damage) * (wp->lifeleft / wip->damage_time)) + wip->atten_damage);
 		} else {
 			damage = wip->damage * (wp->lifeleft / wip->damage_time);
 		}

--- a/code/weapon/weapon.h
+++ b/code/weapon/weapon.h
@@ -361,8 +361,7 @@ typedef struct weapon_info {
 
 	float	damage;								//	damage of weapon (for missile, damage within inner radius)
 	float	damage_time;						// point in the lifetime of the weapon at which damage starts to attenuate. This applies to non-beam primaries. (DahBlount)
-	float	min_damage;							// lowest damage the weapon can deal. (DahBlount)
-	float	max_damage;							// highest damage the weapon can deal. (DahBlount)
+	float	atten_damage;							// The damage to attenuate to. (DahBlount)
 
 	shockwave_create_info shockwave;
 	shockwave_create_info dinky_shockwave;

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -884,9 +884,8 @@ void init_weapon_entry(int weap_info_index)
 	wip->max_delay = 0.0f;
 	wip->min_delay = 0.0f;
 	wip->damage = 0.0f;
-	wip->damage_time = 0.0f;
-	wip->min_damage = 0.0f;
-	wip->max_damage = 0.0f;
+	wip->damage_time = -1.0f;
+	wip->atten_damage = -1.0f;
 
 	wip->damage_type_idx = -1;
 	wip->damage_type_idx_sav = -1;
@@ -1425,24 +1424,11 @@ int parse_weapon(int subtype, bool replace, const char *filename)
 	// Attenuation of non-beam primary weapon damage
 	if(optional_string("$Damage Time:")) {
 		stuff_float(&wip->damage_time);
-		if(optional_string("+Min Damage:")){
-			stuff_float(&wip->min_damage);
-			if (wip->min_damage > wip->damage && wip->min_damage != 0.0f) {
-				Warning(LOCATION, "Min Damage is greater than Damage, resetting to zero.");
-				wip->min_damage = 0.0f;
-			}
-		}
-		if(optional_string("+Max Damage:")) {
-			stuff_float(&wip->max_damage);
-			if (wip->max_damage < wip->damage && wip->max_damage != 0.0f) {
-				Warning(LOCATION, "Max Damage is less than Damage, resetting to zero.");
-				wip->max_damage = 0.0f;
-			}
-		}
-		if(wip->min_damage != 0.0f && wip->max_damage != 0.0f) {
-			Warning(LOCATION, "Both Min Damage and Max Damage are set to values greater than zero, resetting both to zero.");
-			wip->min_damage = 0.0f;
-			wip->max_damage = 0.0f;
+		if(optional_string("+Attenuation Damage:")){
+			stuff_float(&wip->atten_damage);
+		} else if (optional_string_either("+Min Damage:", "+Max Damage:")) {
+			Warning(LOCATION, "+Min Damage: and +Max Damage: in %s are deprecated, please change to +Attenuation Damage:.", wip->name);
+			stuff_float(&wip->atten_damage);
 		}
 	}
 	


### PR DESCRIPTION
This deprecates +Min Damage and +Max Damage, as having two variables for what is effectively the same case and algorithm is not the most ideal situation.

Retested with current mods and retail to ensure compatibility, nothing to report on that front.