### PR TITLE
Adds Persona flag "$Allow substitution of missing messages:"

### DIFF
--- a/code/mission/missionmessage.cpp
+++ b/code/mission/missionmessage.cpp
@@ -295,12 +295,7 @@ void persona_parse()
 	}
 
 	if (optional_string("$Allow substitution of missing messages:")) {
-		bool Allow_substitution;
-		stuff_boolean(&Allow_substitution);
-
-		if (Allow_substitution) {
-			Personas[Num_personas].substitute_missing_messages = Allow_substitution;
-		}
+		stuff_boolean(&Personas[Num_personas].substitute_missing_messages);
 	}
 	else 
 	{
@@ -2076,8 +2071,7 @@ void message_send_builtin_to_player( int type, ship *shipp, int priority, int ti
 			break;
 		case -1:
 		default:
-			nprintf(("MESSAGING", "Couldn't find any builtin message of type %d\n", type));
-			Int3();
+			Error(LOCATION, "Couldn't find any builtin message of type %d\n", type);
 			return;
 	}
 

--- a/code/mission/missionmessage.cpp
+++ b/code/mission/missionmessage.cpp
@@ -294,6 +294,19 @@ void persona_parse()
 			WarningEx(LOCATION, "Unknown species in messages.tbl -- %s\n", cstrtemp );
 	}
 
+	if (optional_string("$Allow substitution of missing messages:")) {
+		bool Allow_substitution;
+		stuff_boolean(&Allow_substitution);
+
+		if (Allow_substitution) {
+			Personas[Num_personas].substitute_missing_messages = Allow_substitution;
+		}
+	}
+	else 
+	{
+		Personas[Num_personas].substitute_missing_messages = true;
+	}
+
 	Num_personas++;
 }
 
@@ -2033,20 +2046,41 @@ void message_send_builtin_to_player( int type, ship *shipp, int priority, int ti
 		}
 	}
 
-	if (best_match == BUILTIN_MATCHES_PERSONA_EXCLUDED) {
-		nprintf(("MESSAGING", "Couldn't find builtin message %s for persona %d with a none excluded mood\n", Builtin_messages[type].name, persona_index ));
-		nprintf(("MESSAGING", "using an excluded message for this persona\n"));
-	}else if (best_match == BUILTIN_MATCHES_SPECIES) {
-		nprintf(("MESSAGING", "Couldn't find builtin message %s for persona %d\n", Builtin_messages[type].name, persona_index ));
-		nprintf(("MESSAGING", "using a message for any persona of that species\n"));
-	} else if (best_match == BUILTIN_MATCHES_TYPE) {
-		nprintf(("MESSAGING", "Couldn't find builtin message %s for persona %d\n", Builtin_messages[type].name, persona_index ));
-		nprintf(("MESSAGING", "looking for message for any persona of any species\n"));
-	} else if (best_match < 0) {
-		nprintf(("MESSAGING", "Couldn't find any builtin message of type %d\n", type ));
-		Int3();
-		return; 
+	switch (best_match) {
+		case BUILTIN_MATCHES_PERSONA_EXCLUDED:
+			nprintf(("MESSAGING", "Couldn't find builtin message %s for persona %d with a none excluded mood\n", Builtin_messages[type].name, persona_index));
+			if (!Personas[persona_index].substitute_missing_messages) {
+				nprintf(("MESSAGING", "Persona does not allow substitution, skipping message."));
+				return;
+			}
+			else
+				nprintf(("MESSAGING", "using an excluded message for this persona\n"));
+			break;
+		case BUILTIN_MATCHES_SPECIES:
+			nprintf(("MESSAGING", "Couldn't find builtin message %s for persona %d\n", Builtin_messages[type].name, persona_index));
+			if (!Personas[persona_index].substitute_missing_messages) {
+				nprintf(("MESSAGING", "Persona does not allow substitution, skipping message."));
+				return;
+			}
+			else
+				nprintf(("MESSAGING", "using a message for any persona of that species\n"));
+			break;
+		case BUILTIN_MATCHES_TYPE:
+			nprintf(("MESSAGING", "Couldn't find builtin message %s for persona %d\n", Builtin_messages[type].name, persona_index));
+			if (!Personas[persona_index].substitute_missing_messages) {
+				nprintf(("MESSAGING", "Persona does not allow substitution, skipping message."));
+				return;
+			}
+			else
+				nprintf(("MESSAGING", "looking for message for any persona of any species\n"));
+			break;
+		case -1:
+		default:
+			nprintf(("MESSAGING", "Couldn't find any builtin message of type %d\n", type));
+			Int3();
+			return;
 	}
+
 	
 	// since we may have multiple builtins we need to pick one at random
 	random_selection = (int)(rand32() % num_matching_builtins) + 1; 

--- a/code/mission/missionmessage.h
+++ b/code/mission/missionmessage.h
@@ -180,6 +180,7 @@ typedef struct persona_s {
 	char	name[NAME_LENGTH];
 	int	flags;
 	int species;
+	bool substitute_missing_messages;
 } Persona;
 
 extern Persona *Personas;


### PR DESCRIPTION
Currently, builtin messages can default to other messages from the same persona, or even other messages from other personas if they do not define a particular message. This is breaking the mood in mods where certain messages are excluded on purpose. This PR therefore introduces a persona flag to control this behaviour.