### PR TITLE
Countermeasures can be proccesed at a set interval

### DIFF
--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -35,6 +35,7 @@ bool Red_alert_applies_to_delayed_ships = false;
 bool Beams_use_damage_factors = false;
 float Generic_pain_flash_factor = 1.0f;
 float Shield_pain_flash_factor = 0.0f;
+int Countermeasure_processing_interval = 0;
 
 
 void parse_mod_table(const char *filename)
@@ -299,6 +300,16 @@ void parse_mod_table(const char *filename)
 					Default_fiction_viewer_ui = ui_index;
 				else
 					Warning(LOCATION, "Unrecognized fiction viewer UI: %s", ui_name);
+			}
+		}
+
+		if (optional_string("$Countermeasure Processing Interval:")) {
+			stuff_int(&Countermeasure_processing_interval);
+			if (Countermeasure_processing_interval != 0) {
+				mprintf(("Game Settings Table: Countermeasures will attempt to decoy missiles every %i milliseconds\n", Countermeasure_processing_interval));
+			}
+			else {
+				mprintf(("Game Settings Table: Countermeasures will attempt to decoy missiles for 2 frames after any countermeasure is launched (retail behavior)\n"));
 			}
 		}
 

--- a/code/mod_table/mod_table.h
+++ b/code/mod_table/mod_table.h
@@ -30,5 +30,6 @@ extern bool Red_alert_applies_to_delayed_ships;
 extern bool Beams_use_damage_factors;
 extern float Generic_pain_flash_factor;
 extern float Shield_pain_flash_factor;
+extern int Countermeasure_processing_interval;
 
 void mod_table_init();

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -4125,13 +4125,26 @@ void find_homing_object_cmeasures()
 {
 	object	*weapon_objp;
 
-	if (Cmeasures_homing_check == 0)
-		return;
+	if (Countermeasure_processing_interval != 0) {
+		static fix cm_last_processed = timestamp(Countermeasure_processing_interval);
+		if (!timestamp_elapsed(cm_last_processed)) {
+			return;
+		}
+		else {
+			cm_last_processed = timestamp(Countermeasure_processing_interval);
+			nprintf(("CounterMeasures", "Proccesing countermeasures @ frame: %i\n", Framecount));
+		}
+	}
+	else {
+		// this is retail behaviour
+		if (Cmeasures_homing_check == 0)
+			return;
 
-	if (Cmeasures_homing_check <= 0)
-		Cmeasures_homing_check = 1;
+		if (Cmeasures_homing_check <= 0)
+			Cmeasures_homing_check = 1;
 
-	Cmeasures_homing_check--;
+		Cmeasures_homing_check--;
+	}
 
 	for (weapon_objp = GET_FIRST(&obj_used_list); weapon_objp != END_OF_LIST(&obj_used_list); weapon_objp = GET_NEXT(weapon_objp) ) {
 		if (weapon_objp->type == OBJ_WEAPON) {


### PR DESCRIPTION
Retail processed countermeasures for two frames after any
countermeasure was fired. This allows them to be processed at a modder
changable interval. 500 or 1000 seems like a decent interval, but feel
free to try others out.

game_settings.tbl
    $Countermeasure Processing Interval: 1000

Note that this may make countermeasures overpowered unless you take
other steps to reduce their effect since each countermeasure will get
multiple chances to decoy any given missile

The AI may also respond unpredictably to this change, they might seem
to get a lot better at avoiding missiles.