### PR TITLE
Improve CursorManager

### DIFF
--- a/code/cutscene/movie.cpp
+++ b/code/cutscene/movie.cpp
@@ -101,6 +101,7 @@ bool movie_play(char *name)
 	}
 
 	// clear the screen and hide the mouse cursor
+	io::mouse::CursorManager::get()->pushStatus();
 	io::mouse::CursorManager::get()->showCursor(false);
 	gr_reset_clip();
 	gr_set_color(255, 255, 255);
@@ -127,7 +128,7 @@ bool movie_play(char *name)
 		} else {
 			// uh-oh, movie is invalid... Abory, Retry, Fail?
 			mprintf(("MOVIE ERROR: Found invalid movie! (%s)\n", name));
-			io::mouse::CursorManager::get()->showCursor(true);	// show the mouse cursor!
+			io::mouse::CursorManager::get()->popStatus();
 			return false;
 		}
 	} else if (rc == MOVIE_MVE) {
@@ -144,13 +145,13 @@ bool movie_play(char *name)
 		} else {
 			// uh-oh, movie is invalid... Abory, Retry, Fail?
 			mprintf(("MOVIE ERROR: Found invalid movie! (%s)\n", name));
-			io::mouse::CursorManager::get()->showCursor(true);	// show the mouse cursor!
+			io::mouse::CursorManager::get()->popStatus();
 			return false;
 		}
 	}
 
 	// show the mouse cursor again
-	io::mouse::CursorManager::get()->showCursor(true);
+	io::mouse::CursorManager::get()->popStatus();
 
 	return true;
 }

--- a/code/freespace2/freespace.cpp
+++ b/code/freespace2/freespace.cpp
@@ -5760,6 +5760,7 @@ void game_leave_state( int old_state, int new_state )
 					gameseq_post_event( GS_EVENT_QUIT_GAME );
 				}
 			}
+			io::mouse::CursorManager::get()->showCursor(true);
 			break;
 
 		case GS_STATE_TECH_MENU:
@@ -6309,6 +6310,8 @@ void mouse_force_pos(int x, int y);
 			// clear multiplayer button info			i
 			extern button_info Multi_ship_status_bi;
 			memset(&Multi_ship_status_bi, 0, sizeof(button_info));
+			
+			io::mouse::CursorManager::get()->showCursor(false, true);
 			break;
 
 		case GS_STATE_HUD_CONFIG:

--- a/code/io/cursor.cpp
+++ b/code/io/cursor.cpp
@@ -168,7 +168,7 @@ namespace io
 
 		CursorManager::CursorManager() : mCurrentCursor(nullptr)
 		{
-			mStatusStack.push_back(std::make_tuple(true, false));
+			mStatusStack.push_back(std::make_pair(true, false));
 		}
 
 		CursorManager::~CursorManager()
@@ -236,7 +236,7 @@ namespace io
 		void CursorManager::showCursor(bool show, bool grab)
 		{
 			auto current = mStatusStack.back();
-			if (show == std::get<0>(current) && grab == std::get<1>(current))
+			if (show == current.first && grab == current.second)
 			{
 				// Don't bother calling anithing if it's not going to change anything
 				return;
@@ -244,7 +244,7 @@ namespace io
 
 			changeMouseStatus(show, grab);
 
-			mStatusStack.back() = std::make_tuple(show, grab);
+			mStatusStack.back() = std::make_pair(show, grab);
 		}
 			
 		void CursorManager::pushStatus()
@@ -253,7 +253,7 @@ namespace io
 			mStatusStack.push_back(mStatusStack.back());
 		}
 		
-		std::tuple<bool, bool> CursorManager::popStatus()
+		std::pair<bool, bool> CursorManager::popStatus()
 		{
 			Assertion(mStatusStack.size() > 1, "Can't pop the last status!");
 			
@@ -262,7 +262,7 @@ namespace io
 			mStatusStack.pop_back();
 			
 			auto newState = mStatusStack.back();
-			changeMouseStatus(std::get<0>(newState), std::get<1>(newState));
+			changeMouseStatus(newState.first, newState.second);
 			
 			return current;
 		}

--- a/code/io/cursor.h
+++ b/code/io/cursor.h
@@ -98,7 +98,7 @@ namespace io
 
 			Cursor* mCurrentCursor; //!< The current cursor
 
-			SCP_vector<std::tuple<bool, bool>> mStatusStack; //!< Contains the stack of saved mouse statuses
+			SCP_vector<std::pair<bool, bool>> mStatusStack; //!< Contains the stack of saved mouse statuses
 
 			/**
 			 * @brief Default constructor
@@ -151,7 +151,7 @@ namespace io
 			 * @brief Specifies if the cursor is shown
 			 * @return @c true if shown ,@c false otherwise
 			 */
-			bool isCursorShown() { return std::get<0>(mStatusStack.back()); }
+			bool isCursorShown() { return mStatusStack.back().first; }
 
 			/**
 			 * @brief Gets the current cursor
@@ -168,7 +168,7 @@ namespace io
 			 * @brief Removes the top status from the stack and restores the previous
 			 * @returns The removed state
 			 */
-			std::tuple<bool, bool> popStatus();
+			std::pair<bool, bool> popStatus();
 
 		public:
 			/**

--- a/code/io/cursor.h
+++ b/code/io/cursor.h
@@ -8,6 +8,8 @@
 #include "globalincs/pstypes.h"
 #include "cmdline/cmdline.h"
 
+#include <memory>
+
 namespace io
 {
 	namespace mouse
@@ -27,12 +29,21 @@ namespace io
 			int mBeginTimeStamp; //! The timestamp when the animation was started, unused when not animated
 			float mAnimationLength; //! The length (in seconds) of the animation
 			size_t mLastFrame; //! The last frame which was set
+			
+			Cursor(const Cursor&); // Not implemented
+			Cursor& operator=(const Cursor&); // Not implemented
 		public:
 			/**
 			 * @brief Default constructor
 			 */
-			Cursor() : mFps(-1.0f), mBeginTimeStamp(-1), mLastFrame(static_cast<size_t>(-1)) {}
+			Cursor() : mFps(-1.0f), mBeginTimeStamp(-1), mAnimationLength(-1.f), mLastFrame(static_cast<size_t>(-1)) {}
 
+			Cursor(Cursor&& other);
+			
+			Cursor& operator=(Cursor&& other);
+
+			~Cursor();
+			
 			/**
 			 * @brief Adds an animation frame
 			 *
@@ -58,11 +69,6 @@ namespace io
 			 * @brief Called to set the correct frame
 			 */
 			void setCurrentFrame();
-
-			/**
-			 * Releases all SDL handles
-			 */
-			void releaseResources();
 		};
 
 		/**
@@ -73,7 +79,7 @@ namespace io
 		private:
 			static CursorManager* mSingleton; //! The singleton manager
 
-			SCP_vector<Cursor*> mLoadedCursors; //! A list of loaded cursors
+			SCP_vector<std::unique_ptr<Cursor>> mLoadedCursors; //! A list of loaded cursors
 
 			Cursor* mCurrentCursor; //! The current cursor
 

--- a/code/io/cursor.h
+++ b/code/io/cursor.h
@@ -83,8 +83,7 @@ namespace io
 
 			Cursor* mCurrentCursor; //! The current cursor
 
-			bool mCursorShown; //! @c true of cursor is shown or @c false if not
-			bool mMouseGrabbed; //! @c true if the mouse is grabbed, @c false if not
+			SCP_vector<std::tuple<bool, bool>> mStatusStack;
 
 			/**
 			 * @brief Default constructor
@@ -138,13 +137,17 @@ namespace io
 			 * @brief Specifies if the cursor is shown
 			 * @return @c true if shown ,@c false otherwise
 			 */
-			bool isCursorShown() { return mCursorShown; }
+			bool isCursorShown() { return std::get<0>(mStatusStack.back()); }
 
 			/**
 			 * @brief Gets the current cursor
 			 * @return The current cursor instance
 			 */
 			Cursor* getCurrentCursor() { return mCurrentCursor; }
+			
+			void pushStatus();
+			
+			std::tuple<bool, bool> popStatus();
 
 		public:
 			/**

--- a/code/io/cursor.h
+++ b/code/io/cursor.h
@@ -22,13 +22,13 @@ namespace io
 		class Cursor
 		{
 		private:
-			SCP_vector<SDL_Cursor*> mAnimationFrames; //! The individual frames
+			SCP_vector<SDL_Cursor*> mAnimationFrames; //!< The individual frames
 
-			float mFps; //! The FPS of the animation, unused if only one frame
+			float mFps; //!< The FPS of the animation, unused if only one frame
 
-			int mBeginTimeStamp; //! The timestamp when the animation was started, unused when not animated
-			float mAnimationLength; //! The length (in seconds) of the animation
-			size_t mLastFrame; //! The last frame which was set
+			int mBeginTimeStamp; //!< The timestamp when the animation was started, unused when not animated
+			float mAnimationLength; //!< The length (in seconds) of the animation
+			size_t mLastFrame; //!< The last frame which was set
 			
 			Cursor(const Cursor&); // Not implemented
 			Cursor& operator=(const Cursor&); // Not implemented
@@ -38,10 +38,25 @@ namespace io
 			 */
 			Cursor() : mFps(-1.0f), mBeginTimeStamp(-1), mAnimationLength(-1.f), mLastFrame(static_cast<size_t>(-1)) {}
 
+			/**
+			 * @brief Move constructor
+			 *
+			 * Transfers SDL resources to this newly constructed object
+			 */
 			Cursor(Cursor&& other);
 			
+			/**
+			 * @brief Move operator
+			 *
+			 * Transfers SDL resources to this object
+			 */
 			Cursor& operator=(Cursor&& other);
 
+			/**
+			 * @brief Cursor destructor
+			 *
+			 * Frees the allocated SDL cursors
+			 */
 			~Cursor();
 			
 			/**
@@ -77,24 +92,23 @@ namespace io
 		class CursorManager
 		{
 		private:
-			static CursorManager* mSingleton; //! The singleton manager
+			static CursorManager* mSingleton; //!< The singleton manager
 
-			SCP_vector<std::unique_ptr<Cursor>> mLoadedCursors; //! A list of loaded cursors
+			SCP_vector<std::unique_ptr<Cursor>> mLoadedCursors; //!< A list of loaded cursors
 
-			Cursor* mCurrentCursor; //! The current cursor
+			Cursor* mCurrentCursor; //!< The current cursor
 
-			SCP_vector<std::tuple<bool, bool>> mStatusStack;
+			SCP_vector<std::tuple<bool, bool>> mStatusStack; //!< Contains the stack of saved mouse statuses
 
 			/**
 			 * @brief Default constructor
 			 *
-			 * This class should not be instantiated outside from this module
+			 * @note This class should not be instantiated outside from this module
 			 */
 			CursorManager();
 		public:
-
 			/**
-			 * Releases the cursor resources
+			 * @brief Releases the cursor resources
 			 */
 			~CursorManager();
 
@@ -145,8 +159,15 @@ namespace io
 			 */
 			Cursor* getCurrentCursor() { return mCurrentCursor; }
 			
+			/**
+			 * @brief Pushes the current status onto the stack as a new entry
+			 */
 			void pushStatus();
 			
+			/**
+			 * @brief Removes the top status from the stack and restores the previous
+			 * @returns The removed state
+			 */
 			std::tuple<bool, bool> popStatus();
 
 		public:

--- a/code/missionui/missionpause.cpp
+++ b/code/missionui/missionpause.cpp
@@ -117,6 +117,9 @@ void pause_init()
 	Pause_win.create(0, 0, gr_screen.max_w_unscaled, gr_screen.max_h_unscaled, 0);	
 
 	Pause_background_bitmap = bm_load(Pause_bmp_name[gr_screen.res]);
+	
+	io::mouse::CursorManager::get()->pushStatus();
+	io::mouse::CursorManager::get()->showCursor(true);
 
 	Paused = 1;
 }
@@ -260,6 +263,8 @@ void pause_close()
 
 	Pause_win.destroy();		
 	game_flush();
+	
+	io::mouse::CursorManager::get()->popStatus();
 
 	// unpause all the music
 	audiostream_unpause_all();		

--- a/code/parse/lua.cpp
+++ b/code/parse/lua.cpp
@@ -12636,29 +12636,28 @@ ADE_FUNC(isMouseButtonDown, l_Mouse, "{MOUSE_*_BUTTON enumeration}, [..., ...]",
 	return ade_set_args(L, "b", rtn);
 }
 
-ADE_FUNC(setCursorImage, l_Mouse, "Image filename, [LOCK or UNLOCK]", "Sets mouse cursor image, and allows you to lock/unlock the image. (A locked cursor may only be changed with the unlock parameter)", NULL, NULL)
+ADE_FUNC(setCursorImage, l_Mouse, "Image filename, [LOCK or UNLOCK]", "Sets mouse cursor image, and allows you to lock/unlock the image. (A locked cursor may only be changed with the unlock parameter)", "boolean", "true if successful, false otherwise")
 {
 	using namespace io::mouse;
 
 	if(!mouse_inited || !Gr_inited)
-		return ADE_RETURN_NIL;
+		return ade_set_error(L, "b", false);
 
 	char *s = NULL;
 	enum_h *u = NULL; // This isn't used anymore
 
 	if(!ade_get_args(L, "s|o", &s, l_Enum.GetPtr(&u)))
-		return ADE_RETURN_NIL;
+		return ade_set_error(L, "b", false);
 
 	Cursor* cursor = CursorManager::get()->loadCursor(s);
 
 	if (cursor == NULL)
 	{
-		LuaError(L, "Failed to load cursor %s!", s);
-		return ADE_RETURN_NIL;
+		return ade_set_error(L, "b", false);
 	}
 
 	CursorManager::get()->setCurrentCursor(cursor);
-	return ADE_RETURN_NIL;
+	return ade_set_args(L, "b", true);
 }
 
 ADE_FUNC(setCursorHidden, l_Mouse, "True to hide mouse, false to show it", "Shows or hides mouse cursor", NULL, NULL)

--- a/code/parse/lua.cpp
+++ b/code/parse/lua.cpp
@@ -12636,7 +12636,7 @@ ADE_FUNC(isMouseButtonDown, l_Mouse, "{MOUSE_*_BUTTON enumeration}, [..., ...]",
 	return ade_set_args(L, "b", rtn);
 }
 
-ADE_FUNC(setCursorImage, l_Mouse, "Image filename, [LOCK or UNLOCK]", "Sets mouse cursor image, and allows you to lock/unlock the image. (A locked cursor may only be changed with the unlock parameter)", "boolean", "true if successful, false otherwise")
+ADE_FUNC(setCursorImage, l_Mouse, "Image filename", "Sets mouse cursor image, and allows you to lock/unlock the image. (A locked cursor may only be changed with the unlock parameter)", "boolean", "true if successful, false otherwise")
 {
 	using namespace io::mouse;
 

--- a/code/parse/lua.cpp
+++ b/code/parse/lua.cpp
@@ -12661,13 +12661,13 @@ ADE_FUNC(setCursorImage, l_Mouse, "Image filename", "Sets mouse cursor image, an
 }
 
 ADE_FUNC(setCursorHidden, l_Mouse, "boolean hide[, boolean grab]", "Hides the cursor when <i>hide</i> is true, otherwise shows it. <i>grab</i> determines if "
-				"the mouse will be restricted to the window. Set this to true when hiding the cursor while in game.", NULL, NULL)
+				"the mouse will be restricted to the window. Set this to true when hiding the cursor while in game. By default grab will be true when we are in the game play state, false otherwise.", NULL, NULL)
 {
 	if(!mouse_inited)
 		return ADE_RETURN_NIL;
 
 	bool b = false;
-	bool grab = false;
+	bool grab = gameseq_get_state() == GS_STATE_GAME_PLAY;
 	ade_get_args(L, "b|b", &b, &grab);
 
 	io::mouse::CursorManager::get()->showCursor(!b, grab);

--- a/code/parse/lua.cpp
+++ b/code/parse/lua.cpp
@@ -12660,15 +12660,17 @@ ADE_FUNC(setCursorImage, l_Mouse, "Image filename", "Sets mouse cursor image, an
 	return ade_set_args(L, "b", true);
 }
 
-ADE_FUNC(setCursorHidden, l_Mouse, "True to hide mouse, false to show it", "Shows or hides mouse cursor", NULL, NULL)
+ADE_FUNC(setCursorHidden, l_Mouse, "boolean hide[, boolean grab]", "Hides the cursor when <i>hide</i> is true, otherwise shows it. <i>grab</i> determines if "
+				"the mouse will be restricted to the window. Set this to true when hiding the cursor while in game.", NULL, NULL)
 {
 	if(!mouse_inited)
 		return ADE_RETURN_NIL;
 
 	bool b = false;
-	ade_get_args(L, "b", &b);
+	bool grab = false;
+	ade_get_args(L, "b|b", &b, &grab);
 
-	io::mouse::CursorManager::get()->showCursor(!b);
+	io::mouse::CursorManager::get()->showCursor(!b, grab);
 
 	return ADE_RETURN_NIL;
 }

--- a/code/popup/popup.cpp
+++ b/code/popup/popup.cpp
@@ -1023,10 +1023,14 @@ int popup(int flags, int nchoices, ... )
 	
 	gamesnd_play_iface(SND_POPUP_APPEAR); 	// play sound when popup appears
 
+	io::mouse::CursorManager::get()->pushStatus();
 	io::mouse::CursorManager::get()->showCursor(true);
 	Popup_is_active = 1;
 
 	choice = popup_do( &Popup_info, flags );
+	
+	io::mouse::CursorManager::get()->popStatus();
+	
 	switch(choice) {
 	case POPUP_ABORT:
 		return -1;
@@ -1076,10 +1080,14 @@ int popup_till_condition(int (*condition)(), ...)
 
 	gamesnd_play_iface(SND_POPUP_APPEAR); 	// play sound when popup appears
 
+	io::mouse::CursorManager::get()->pushStatus();
 	io::mouse::CursorManager::get()->showCursor(true);
 	Popup_is_active = 1;
 
 	choice = popup_do_with_condition( &Popup_info, flags, condition );
+	
+	io::mouse::CursorManager::get()->popStatus();
+	
 	switch(choice) {
 	case POPUP_ABORT:
 		return 0;

--- a/code/popup/popupdead.cpp
+++ b/code/popup/popupdead.cpp
@@ -237,6 +237,9 @@ void popupdead_start()
 		b->hide();
 	}
 	
+	io::mouse::CursorManager::get()->pushStatus();
+	io::mouse::CursorManager::get()->showCursor(true);
+	
 	Popupdead_default_choice = 0;
 	Popupdead_choice = -1;
 	Popupdead_active = 1;
@@ -528,6 +531,8 @@ void popupdead_close()
 	gamesnd_play_iface(SND_POPUP_DISAPPEAR);
 	Popupdead_window.destroy();
 	game_flush();
+	
+	io::mouse::CursorManager::get()->popStatus();
 
 	Popupdead_active = 0;
 	Popupdead_skip_active = 0;


### PR DESCRIPTION
The `CursorManager` has a few issues because the transition from drawing the cursor ourself to letting it be drawn by the OS introduced some inconsistencies.
These changes should improve that behavior by no longer setting the cursor state every frame and instead doing that only when in the relevant code. This should also fix #436 which was broken before because the mouse state the script sets was overwritten immediately.

This also introduces a means to save a stack of mouse states. This can be used if some user interface requires mouse interaction but the previous state is not clear.