### PR TITLE
Add jumpToMission LUA function and a jump to hub function

### DIFF
--- a/code/mission/missioncampaign.cpp
+++ b/code/mission/missioncampaign.cpp
@@ -1866,7 +1866,7 @@ void mission_campaign_exit_loop()
  * all previous missions marked skipped
  * this relies on correct mission ordering in the campaign file
  */
-void mission_campaign_jump_to_mission(char *name)
+void mission_campaign_jump_to_mission(char *name, bool no_skip)
 {
 	int i = 0, mission_num = -1;
 	char dest_name[64], *p;
@@ -1886,10 +1886,10 @@ void mission_campaign_jump_to_mission(char *name)
 		if ((Campaign.missions[i].name != NULL) && !stricmp(Campaign.missions[i].name, dest_name)) {
 			mission_num = i;
 			break;
-		} else {
+		} else if (!no_skip) {
 			Campaign.missions[i].flags |= CMISSION_FLAG_SKIPPED;
 			Campaign.num_missions_completed = i;
-		}
+		}	
 	}
 
 	if (mission_num < 0) {
@@ -1898,10 +1898,11 @@ void mission_campaign_jump_to_mission(char *name)
 		mission_campaign_savefile_delete(Campaign.filename);
 		mission_campaign_load(Campaign.filename);
 	} else {
-		for (i = 0; i < MAX_SHIP_CLASSES; i++) {
+		for (SCP_vector<ship_info>::iterator it = Ship_info.begin(); it != Ship_info.end(); it++) {
+			i = static_cast<int>(std::distance(Ship_info.begin(), it));
 			Campaign.ships_allowed[i] = 1;
 		}
-		for (i = 0; i < MAX_WEAPON_TYPES; i++) {
+		for (i = 0; i < Num_weapon_types; i++) {
 			Campaign.weapons_allowed[i] = 1;
 		}
 

--- a/code/mission/missioncampaign.h
+++ b/code/mission/missioncampaign.h
@@ -265,7 +265,7 @@ void mission_campaign_skip_to_next(int start_game = 1);
 void mission_campaign_exit_loop();
 
 // jump to specified mission
-void mission_campaign_jump_to_mission(char *name);
+void mission_campaign_jump_to_mission(char *name, bool no_skip = false);
 
 // stuff for the end of the campaign of the single player game
 void mission_campaign_end_init();

--- a/code/parse/lua.cpp
+++ b/code/parse/lua.cpp
@@ -14870,6 +14870,19 @@ ADE_FUNC(getPrevMissionFilename, l_Campaign, NULL, "Gets previous mission filena
 	return ade_set_args(L, "s", Campaign.missions[Campaign.prev_mission].name);
 }
 
+// DahBlount - This jumps to a mission, the reason it accepts a boolean value is so that players can return to campaign maps
+ADE_FUNC(jumpToMission, l_Campaign, "string filename, [boolean hub]", "Jumps to a mission based on the filename. Optionally, the player can be sent to a hub mission without setting missions to skipped.", "boolean", "Jumps to a mission, or returns nil.")
+{
+	char *filename = NULL;;
+	bool hub = false;
+	if (!ade_get_args(L, "s|b", &filename, &hub))
+		return ADE_RETURN_NIL;
+
+	mission_campaign_jump_to_mission(filename, hub);
+
+	return ADE_RETURN_TRUE;
+}
+
 // TODO: add a proper indexer type that returns a handle
 // something like ca.Mission[filename/index]
 


### PR DESCRIPTION
The purpose of this function is to provide modders the capability to jump to a mission using LUA scripts. There is an optional argument for jumping to a hub mission, a good example is the JAD campaign map.