### PR TITLE
Add benchmark command line option

### DIFF
--- a/code/cmdline/cmdline.cpp
+++ b/code/cmdline/cmdline.cpp
@@ -1771,7 +1771,7 @@ bool SetCmdlineParams()
 	
 	if (benchmark_mode_arg.found())
 	{
-		Cmdline_benchmark_mode = 1;
+		Cmdline_benchmark_mode = true;
 	}
 
 	//Deprecated flags - CommanderDJ

--- a/code/cmdline/cmdline.cpp
+++ b/code/cmdline/cmdline.cpp
@@ -231,6 +231,7 @@ Flag exe_params[] =
 	{ "-profile_frame_time", "Profile engine subsystems",				true,	0,					EASY_DEFAULT,		"Dev Tool",		"http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-profile_frame_timings", },
 	{ "-profile_write_file", "Write profiling information to file",		true,	0,					EASY_DEFAULT,		"Dev Tool",		"http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-profile_write_file", },
 	{ "-no_unfocused_pause","Don't pause if the window isn't focused",	true,	0,					EASY_DEFAULT,		"Dev Tool",		"http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-no_unfocused_pause", },
+	{ "-benchmark_mode",	"Puts the game into benchmark mode",		true,	0,					EASY_DEFAULT,		"Dev Tool",		"http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-benchmark_mode", },
 };
 
 // forward declaration
@@ -479,6 +480,8 @@ cmdline_parm reparse_mainhall_arg("-reparse_mainhall", NULL, AT_NONE); //Cmdline
 cmdline_parm frame_profile_arg("-profile_frame_time", NULL, AT_NONE); //Cmdline_frame_profile
 cmdline_parm frame_profile_write_file("-profile_write_file", NULL, AT_NONE); // Cmdline_profile_write_file
 cmdline_parm no_unfocused_pause_arg("-no_unfocused_pause", NULL, AT_NONE); //Cmdline_no_unfocus_pause
+cmdline_parm benchmark_mode_arg("-benchmark_mode", NULL, AT_NONE); //Cmdline_benchmark_mode
+
 
 char *Cmdline_start_mission = NULL;
 int Cmdline_old_collision_sys = 0;
@@ -506,6 +509,7 @@ int Cmdline_reparse_mainhall = 0;
 bool Cmdline_frame_profile = false;
 bool Cmdline_profile_write_file = false;
 bool Cmdline_no_unfocus_pause = false;
+bool Cmdline_benchmark_mode = false;
 
 // Other
 cmdline_parm get_flags_arg("-get_flags", "Output the launcher flags file", AT_NONE);
@@ -1763,6 +1767,11 @@ bool SetCmdlineParams()
 	if (no_unfocused_pause_arg.found())
 	{
 		Cmdline_no_unfocus_pause = true;
+	}
+	
+	if (benchmark_mode_arg.found())
+	{
+		Cmdline_benchmark_mode = 1;
 	}
 
 	//Deprecated flags - CommanderDJ

--- a/code/cmdline/cmdline.h
+++ b/code/cmdline/cmdline.h
@@ -161,5 +161,6 @@ extern int Cmdline_reparse_mainhall;
 extern bool Cmdline_frame_profile;
 extern bool Cmdline_profile_write_file;
 extern bool Cmdline_no_unfocus_pause;
+extern bool Cmdline_benchmark_mode;
 
 #endif

--- a/code/freespace2/freespace.cpp
+++ b/code/freespace2/freespace.cpp
@@ -5764,6 +5764,10 @@ void game_leave_state( int old_state, int new_state )
 				snd_aav_init();
 
 				freespace_stop_mission();
+				
+				if (Cmdline_benchmark_mode) {
+					gameseq_post_event( GS_EVENT_QUIT_GAME );
+				}
 			}
 			break;
 

--- a/code/menuui/playermenu.cpp
+++ b/code/menuui/playermenu.cpp
@@ -334,8 +334,8 @@ void player_select_init()
 	} else { // otherwise go to the single player mode by default
 		player_select_init_player_stuff(PLAYER_SELECT_MODE_SINGLE);
 	}
-	
-	if (Cmdline_benchmark_mode) {
+
+	if (Cmdline_benchmark_mode || ((Player_select_num_pilots == 1) && Player_select_input_mode)) {
 		// When benchmarking, just accept automatically
 		Player_select_autoaccept = 1;
 	}

--- a/code/menuui/playermenu.cpp
+++ b/code/menuui/playermenu.cpp
@@ -334,8 +334,9 @@ void player_select_init()
 	} else { // otherwise go to the single player mode by default
 		player_select_init_player_stuff(PLAYER_SELECT_MODE_SINGLE);
 	}
-
-	if ( (Player_select_num_pilots == 1) && Player_select_input_mode ) {
+	
+	if (Cmdline_benchmark_mode) {
+		// When benchmarking, just accept automatically
 		Player_select_autoaccept = 1;
 	}
 }


### PR DESCRIPTION
That option will make performance tests much easier.

The option causes the initial pilot selection to immediately accept the current pilot without further user interaction.

For starting a mission `-start_mission` can be used which will immediately run a mission until it is complete. This works best with cutscenes because no user interaction is required.

When the end of the mission is reached the benchmark option will automatically quit the game and an external script can collect the framerate results generated by the profiling subsystem.