### PR TITLE
EFF subdirectories

### DIFF
--- a/code/bmpman/bm_internal.h
+++ b/code/bmpman/bm_internal.h
@@ -36,6 +36,7 @@ union bm_extra_info {
 			// stuff for static animations
 			BM_TYPE type;                         //!< type for individual images
 			char  filename[MAX_FILENAME_LEN];   //!< filename for individual images
+			bool in_subdir;                     //!< Whether frames are in their own subdirectory
 		} eff;
 		struct {
 			bool  is_apng;      //!< Is this animation an APNG?

--- a/code/bmpman/bmpman.h
+++ b/code/bmpman/bmpman.h
@@ -676,15 +676,16 @@ bool bm_set_render_target(int handle, int face = -1);
  *
  * @param[in]  filename The filename of the .EFF
  * @param[in]  dir_type
- * @param[out] nframes (optional) If given, is set to the number of frames this .EFF has
- * @param[out] nfps    (optional) If given, is set to the fps of this .EFF
- * @param[out] key     (optional) If given, is set to the keyframe index of this .EFF
- * @param[out] type    (optional) If given, is set to the BM_TYPE of the .EFF
+ * @param[out] nframes   (optional) If given, is set to the number of frames this .EFF has
+ * @param[out] nfps      (optional) If given, is set to the fps of this .EFF
+ * @param[out] key       (optional) If given, is set to the keyframe index of this .EFF
+ * @param[out] type      (optional) If given, is set to the BM_TYPE of the .EFF
+ * @param[out] in_subdir (optional) If given, is set to true if the frames of this .EFF are in a subdir
  *
  * @returns true If successful
  * @returns false If not successful
  */
-bool bm_load_and_parse_eff(const char *filename, int dir_type, int *nframes, int *nfps, int *key, BM_TYPE *type);
+bool bm_load_and_parse_eff(const char *filename, int dir_type, int *nframes, int *nfps, int *key, BM_TYPE *type, bool *in_subdir);
 
 /**
  * @brief Calculates & returns the current frame of an animation

--- a/code/cfile/cfile.h
+++ b/code/cfile/cfile.h
@@ -78,8 +78,9 @@ typedef struct {
 #define CF_TYPE_INTEL_ANIMS			34
 #define CF_TYPE_SCRIPTS				35
 #define CF_TYPE_FICTION				36
+#define CF_TYPE_TEMP_SUBDIR_LOOKUP	37
 
-#define CF_MAX_PATH_TYPES			37			// Can be as high as you'd like //DTP; yeah but beware alot of things uses CF_MAX_PATH_TYPES
+#define CF_MAX_PATH_TYPES			38			// Can be as high as you'd like //DTP; yeah but beware alot of things uses CF_MAX_PATH_TYPES
 
 
 // TRUE if type is specified and valid
@@ -129,6 +130,10 @@ char *cf_add_ext(const char *filename, const char *ext);
 // return CF_TYPE (directory location type) of a CFILE you called cfopen() successfully on.
 int cf_get_dir_type(CFILE *cfile);
 
+/**
+ * @brief Stuffs Pathtypes with an additional path leading to a subdir of the same name as the given file (minus file extension)
+*/
+bool cf_set_temp_subdir_pathtype(const char *filename);
 
 // Opens the file.  If no path is given, use the extension to look into the
 // default path.  If mode is NULL, delete the file.  

--- a/code/cfile/cfilesystem.cpp
+++ b/code/cfile/cfilesystem.cpp
@@ -725,6 +725,12 @@ void cf_search_root_pack(int root_index)
 					strcat_s( search_path, DIR_SEPARATOR_STR );
 				}
 				strcat_s( search_path, find.filename );
+
+				// If this directory is a subdir containing for example .eff frames,
+				// then those files won't be found (below) by just checking all the
+				// standard paths, so we temporarily add this directory to Pathtypes
+				vm_free(Pathtypes[CF_TYPE_TEMP_SUBDIR_LOOKUP].path);
+				Pathtypes[CF_TYPE_TEMP_SUBDIR_LOOKUP].path = vm_strdup(search_path);
 			}
 
 			//mprintf(( "Current dir = '%s'\n", search_path ));
@@ -911,6 +917,7 @@ int cf_find_file_location( const char *filespec, int pathtype, int max_out, char
 			case CF_TYPE_MULTI_CACHE:
 			case CF_TYPE_MISSIONS:
 			case CF_TYPE_CACHE:
+			case CF_TYPE_TEMP_SUBDIR_LOOKUP:
 				cfs_slow_search = 1;
 				break;
  

--- a/code/graphics/generic.cpp
+++ b/code/graphics/generic.cpp
@@ -242,13 +242,19 @@ int generic_anim_stream(generic_anim *ga, const bool cache)
 		ga->bitmap_id = bm_create(ga->png.anim->bpp, ga->width, ga->height, ga->buffer, 0);
 	}
 	else {
+		bool in_subdir;
 		bpp = 32;
 		if(ga->use_hud_color)
 			bpp = 8;
-		bm_load_and_parse_eff(ga->filename, CF_TYPE_ANY, &ga->num_frames, &anim_fps, &ga->keyframe, 0);
+		bm_load_and_parse_eff(ga->filename, CF_TYPE_ANY, &ga->num_frames, &anim_fps, &ga->keyframe, 0, &in_subdir);
 		char *p = strrchr( ga->filename, '.' );
 		if ( p )
 			*p = 0;
+
+		if (in_subdir) {
+			cf_set_temp_subdir_pathtype(ga->filename);
+		}
+
 		char frame_name[MAX_FILENAME_LEN];
 		snprintf(frame_name, MAX_FILENAME_LEN, "%s_0000", ga->filename);
 		ga->bitmap_id = bm_load(frame_name);


### PR DESCRIPTION
This allows animation frames of eff animations to be located in a subdirectory. This is useful for de-cluttering the effects directory in particular.

Usage and limitations as per http://www.hard-light.net/forums/index.php?topic=88139.0

Before merging, this needs testing in different mod environments: VP's, multiple mods, replacing anims from retail or other mods, and so on. I've pretty much only tested this in a development setting, as in a single mod as a bare directory, no VP's.

Notes:

I'm not sure about the original rationale behind the changes to the bm_unlock()/bm_unload() calls in bmpman.cpp; I'm sure they were intended as bugfixes, but I don't recall the specifics. I included them now because they've been like this in FotG for a long time without problems, but I'll have to split those into a separate commit or remove entirely before merging.
