### PR TITLE
Increased filename limit to 256 from 32

### DIFF
--- a/code/globalincs/globals.h
+++ b/code/globalincs/globals.h
@@ -28,7 +28,7 @@
 #define MISSION_DESC_LENGTH		512
 
 // from player.h
-#define CALLSIGN_LEN					28		//	shortened from 32 to allow .plr to be attached without exceeding MAX_FILENAME_LEN
+#define CALLSIGN_LEN					252		//	shortened from 32 to allow .plr to be attached without exceeding MAX_FILENAME_LEN; bumped to 252
 #define SHORT_CALLSIGN_PIXEL_W	80		// max width of short_callsign[] in pixels
 
 #define MAX_IFFS		10

--- a/code/globalincs/pstypes.h
+++ b/code/globalincs/pstypes.h
@@ -396,7 +396,7 @@ extern int Fred_running;  // Is Fred running, or FreeSpace?
 #include "math/floating.h"
 
 // Some constants for stuff
-#define MAX_FILENAME_LEN	32		// Length for filenames, ie "title.pcx"
+#define MAX_FILENAME_LEN	256		// Length for filenames, ie "title.pcx"
 #define MAX_PATH_LEN		256		// Length for pathnames, ie "c:\bitmaps\title.pcx"
 
 // contants and defined for byteswapping routines (useful for mac)


### PR DESCRIPTION
I've reforked my branch with no unwanted commit history, and remade the commit from scratch. In order to keep in line with the modern operating systems such as Windows 10, the limitation of the maximum filename limit was increased to 256, so does the callsign (from 28 to 252).