### PR TITLE
Change warning from too many ship/weapon classes to an error.

### DIFF
--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -402,8 +402,6 @@ static int Ship_cargo_check_timer;
 
 static int Thrust_anim_inited = 0;
 
-bool warning_too_many_ship_classes = false;
-
 int ship_get_subobj_model_num(ship_info* sip, char* subobj_name);
 
 SCP_vector<ship_effect> Ship_effects;
@@ -1743,15 +1741,7 @@ int parse_ship(const char *filename, bool replace)
 		
 		//Check if there are too many ship classes
 		if(Ship_info.size() >= MAX_SHIP_CLASSES) {
-			if (!warning_too_many_ship_classes) {
-				Warning(LOCATION, "Too many ship classes before '%s'; maximum is %d, so only the first " SIZE_T_ARG " will be used\nPlease check also the debug log as it may contain other ship classes which are over the limit", buf, MAX_SHIP_CLASSES, Ship_info.size());
-				warning_too_many_ship_classes = true;
-			} else {
-				mprintf(("Warning: Too many ship classes before '%s'\n", buf));
-			}
-			
-			skip_to_start_of_string_either("$Name:", "#End");
-			return -1;
+			Error(LOCATION, "Too many ship classes before '%s'; maximum is %d.\n", buf, MAX_SHIP_CLASSES);
 		}
 
 		//Init vars

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -1183,15 +1183,7 @@ int parse_weapon(int subtype, bool replace, const char *filename)
 		}
 
 		if(Num_weapon_types >= MAX_WEAPON_TYPES) {
-			Warning(LOCATION, "Too many weapon classes before '%s'; maximum is %d, so only the first %d will be used", fname, MAX_WEAPON_TYPES, Num_weapon_types);
-			
-			//Skip the rest of the ships in non-modular tables, since we can't add them.
-			if(!replace) {
-				if ( !skip_to_start_of_string_either("$Name:", "#End")) {
-					Int3();
-				}
-			}
-			return -1;
+			Error(LOCATION, "Too many weapon classes before '%s'; maximum is %d.\n", fname, MAX_WEAPON_TYPES);
 		}
 
 		wip = &Weapon_info[Num_weapon_types];


### PR DESCRIPTION
If a modular table broke the weapons limit, it would warn about too many weapon classes, and then not actually skip the entry, because of the `if(!replace)` conditional around it, resulting in nonsensical parsing errors. Rather than just fix this error, it was suggested on IRC (by The_E) that these problems should instead cause immediate errors. Upon reflection, this makes more sense: if the mod exceeds the limits, there's little point in loading it anyway and having things be missing.

Hopefully, eventually, these limits will be removed altogether, but until then, exceeding them should not just be a dismissible warning.