### PR TITLE
Fix various issues with wings in the Lua interface

### DIFF
--- a/code/parse/lua.cpp
+++ b/code/parse/lua.cpp
@@ -8797,7 +8797,7 @@ ADE_FUNC(isValid, l_Message, NULL, "Checks if the message handle is valid", "boo
 //**********HANDLE: Wing
 ade_obj<int> l_Wing("wing", "Wing handle");
 
-ADE_INDEXER(l_Wing, "number Index", "Array of ships in the wing", "ship", "Ship handle, or invalid ship handle if index is invawing handle is invalid")
+ADE_INDEXER(l_Wing, "number Index", "Array of ships in the wing", "ship", "Ship handle, or invalid ship handle if index is invalid or wing handle is invalid")
 {
 	int wdx;
 	int sdx;
@@ -8805,7 +8805,7 @@ ADE_INDEXER(l_Wing, "number Index", "Array of ships in the wing", "ship", "Ship 
 	if(!ade_get_args(L, "oi|o", l_Wing.Get(&wdx), &sdx, l_Ship.GetPtr(&ndx)))
 		return ade_set_error(L, "o", l_Ship.Set(object_h()));
 
-	if(sdx < 1 || sdx > Wings[wdx].current_count) {
+	if(wdx < 0 || wdx >= Num_wings || sdx < 1 || sdx > Wings[wdx].current_count) {
 		return ade_set_error(L, "o", l_Ship.Set(object_h()));
 	}
 
@@ -8819,11 +8819,11 @@ ADE_INDEXER(l_Wing, "number Index", "Array of ships in the wing", "ship", "Ship 
 	return ade_set_args(L, "o", l_Ship.Set(object_h(&Objects[Ships[Wings[wdx].ship_index[sdx]].objnum])));
 }
 
-ADE_FUNC(__len, l_Wing, NULL, "Gets the number of ships in the wing", "number", "Number of ships in wing")
+ADE_FUNC(__len, l_Wing, NULL, "Gets the number of ships in the wing", "number", "Number of ships in wing, or 0 if invalid handle")
 {
 	int wdx;
-	if(!ade_get_args(L, "o", l_Wing.Get(&wdx)))
-		return ade_set_error(L, "i", NULL);
+	if(!ade_get_args(L, "o", l_Wing.Get(&wdx)) || wdx < 0 || wdx >= Num_wings)
+		return ade_set_error(L, "i", 0);
 
 	return ade_set_args(L, "i", Wings[wdx].current_count);
 }
@@ -8832,7 +8832,7 @@ ADE_VIRTVAR(Name, l_Wing, "string", "Name of Wing", "string", "Wing name, or emp
 {
 	int wdx;
 	char *s = NULL;
-	if ( !ade_get_args(L, "o|s", l_Wing.Get(&wdx), &s) )
+	if ( !ade_get_args(L, "o|s", l_Wing.Get(&wdx), &s) || wdx < 0 || wdx >= Num_wings )
 		return ade_set_error(L, "s", "");
 
 	if(ADE_SETTING_VAR && s != NULL) {

--- a/code/parse/lua.cpp
+++ b/code/parse/lua.cpp
@@ -3232,7 +3232,7 @@ ADE_VIRTVAR(Name, l_Shiptype, "string", "Ship type name", "string", "Ship type n
 	if(!ade_get_args(L, "o|s", l_Shiptype.Get(&idx), &s))
 		return ade_set_error(L, "s", "");
 
-	if(idx < 0 || idx > (int)Ship_types.size())
+	if(idx < 0 || idx >= (int)Ship_types.size())
 		return ade_set_error(L, "s", "");
 
 	if(ADE_SETTING_VAR && s != NULL) {
@@ -3913,7 +3913,7 @@ ADE_FUNC(__tostring, l_Weaponclass, NULL, "Weapon class name", "string", "Weapon
 	if(!ade_get_args(L, "o|s", l_Weaponclass.Get(&idx), &s))
 		return ade_set_error(L, "s", "");
 
-	if(idx < 0 || idx > Num_weapon_types)
+	if(idx < 0 || idx >= Num_weapon_types)
 		return ade_set_error(L, "s", "");
 
 	return ade_set_args(L, "s", Weapon_info[idx].name);
@@ -3925,10 +3925,10 @@ ADE_FUNC(__eq, l_Weaponclass, "weaponclass, weaponclass", "Checks if the two cla
 	if(!ade_get_args(L, "oo", l_Weaponclass.Get(&idx1), l_Weaponclass.Get(&idx2)))
 		return ade_set_error(L, "b", false);
 
-	if(idx1 < 0 || idx1 > Num_weapon_types)
+	if(idx1 < 0 || idx1 >= Num_weapon_types)
 		return ade_set_error(L, "b", false);
 
-	if(idx2 < 0 || idx2 > Num_weapon_types)
+	if(idx2 < 0 || idx2 >= Num_weapon_types)
 		return ade_set_error(L, "b", false);
 
 	return ade_set_args(L, "b", idx1 == idx2);
@@ -3942,7 +3942,7 @@ ADE_VIRTVAR(Name, l_Weaponclass, "string", "Weapon class name", "string", "Weapo
 	if(!ade_get_args(L, "o|s", l_Weaponclass.Get(&idx), &s))
 		return ade_set_error(L, "s", "");
 
-	if(idx < 0 || idx > Num_weapon_types)
+	if(idx < 0 || idx >= Num_weapon_types)
 		return ade_set_error(L, "s", "");
 
 	if(ADE_SETTING_VAR && s != NULL) {
@@ -3959,7 +3959,7 @@ ADE_VIRTVAR(Title, l_Weaponclass, "string", "Weapon class title", "string", "Wea
 	if(!ade_get_args(L, "o|s", l_Weaponclass.Get(&idx), &s))
 		return ade_set_error(L, "s", "");
 
-	if(idx < 0 || idx > Num_weapon_types)
+	if(idx < 0 || idx >= Num_weapon_types)
 		return ade_set_error(L, "s", "");
 
 	if(ADE_SETTING_VAR && s != NULL) {
@@ -4004,7 +4004,7 @@ ADE_VIRTVAR(TechTitle, l_Weaponclass, "string", "Weapon class tech title", "stri
 	if(!ade_get_args(L, "o|s", l_Weaponclass.Get(&idx), &s))
 		return ade_set_error(L, "s", "");
 
-	if(idx < 0 || idx > Num_weapon_types)
+	if(idx < 0 || idx >= Num_weapon_types)
 		return ade_set_error(L, "s", "");
 
 	if(ADE_SETTING_VAR && s != NULL) {
@@ -4021,7 +4021,7 @@ ADE_VIRTVAR(TechAnimationFilename, l_Weaponclass, "string", "Weapon class animat
 	if(!ade_get_args(L, "o|s", l_Weaponclass.Get(&idx), &s))
 		return ade_set_error(L, "s", "");
 
-	if(idx < 0 || idx > Num_weapon_types)
+	if(idx < 0 || idx >= Num_weapon_types)
 		return ade_set_error(L, "s", "");
 
 	if(ADE_SETTING_VAR && s != NULL) {
@@ -4066,7 +4066,7 @@ ADE_VIRTVAR(Model, l_Weaponclass, "model", "Model", "model", "Weapon class model
 	if(!ade_get_args(L, "o|o", l_Weaponclass.Get(&weapon_info_idx), l_Model.GetPtr(&mdl)))
 		return ade_set_error(L, "o", l_Model.Set(-1));
 
-	if(weapon_info_idx < 0 || weapon_info_idx > Num_weapon_types)
+	if(weapon_info_idx < 0 || weapon_info_idx >= Num_weapon_types)
 		return ade_set_error(L, "o", l_Model.Set(-1));
 
 	weapon_info *wip = &Weapon_info[weapon_info_idx];
@@ -4087,7 +4087,7 @@ ADE_VIRTVAR(ArmorFactor, l_Weaponclass, "number", "Amount of weapon damage appli
 	if(!ade_get_args(L, "o|f", l_Weaponclass.Get(&idx), &f))
 		return ade_set_error(L, "f", 0.0f);
 
-	if(idx < 0 || idx > Num_weapon_types)
+	if(idx < 0 || idx >= Num_weapon_types)
 		return ade_set_error(L, "f", 0.0f);
 
 	if(ADE_SETTING_VAR) {
@@ -4104,7 +4104,7 @@ ADE_VIRTVAR(Damage, l_Weaponclass, "number", "Amount of damage that weapon deals
 	if(!ade_get_args(L, "o|f", l_Weaponclass.Get(&idx), &f))
 		return ade_set_error(L, "f", 0.0f);
 
-	if(idx < 0 || idx > Num_weapon_types)
+	if(idx < 0 || idx >= Num_weapon_types)
 		return ade_set_error(L, "f", 0.0f);
 
 	if(ADE_SETTING_VAR) {
@@ -4121,7 +4121,7 @@ ADE_VIRTVAR(FireWait, l_Weaponclass, "number", "Weapon fire wait (cooldown time)
 	if(!ade_get_args(L, "o|f", l_Weaponclass.Get(&idx), &f))
 		return ade_set_error(L, "f", 0.0f);
 
-	if(idx < 0 || idx > Num_weapon_types)
+	if(idx < 0 || idx >= Num_weapon_types)
 		return ade_set_error(L, "f", 0.0f);
 
 	if(ADE_SETTING_VAR) {
@@ -4138,7 +4138,7 @@ ADE_VIRTVAR(FreeFlightTime, l_Weaponclass, "number", "The time the weapon will f
 	if(!ade_get_args(L, "o|f", l_Weaponclass.Get(&idx), &f))
 		return ade_set_error(L, "f", 0.0f);
 
-	if(idx < 0 || idx > Num_weapon_types)
+	if(idx < 0 || idx >= Num_weapon_types)
 		return ade_set_error(L, "f", 0.0f);
 
 	if(ADE_SETTING_VAR) {
@@ -4155,7 +4155,7 @@ ADE_VIRTVAR(LifeMax, l_Weaponclass, "number", "Life of weapon in seconds", "numb
 	if(!ade_get_args(L, "o|f", l_Weaponclass.Get(&idx), &f))
 		return ade_set_error(L, "f", 0.0f);
 
-	if(idx < 0 || idx > Num_weapon_types)
+	if(idx < 0 || idx >= Num_weapon_types)
 		return ade_set_error(L, "f", 0.0f);
 
 	if(ADE_SETTING_VAR) {
@@ -4172,7 +4172,7 @@ ADE_VIRTVAR(Range, l_Weaponclass, "number", "Range of weapon in meters", "number
 	if(!ade_get_args(L, "o|f", l_Weaponclass.Get(&idx), &f))
 		return ade_set_error(L, "f", 0.0f);
 
-	if(idx < 0 || idx > Num_weapon_types)
+	if(idx < 0 || idx >= Num_weapon_types)
 		return ade_set_error(L, "f", 0.0f);
 
 	if(ADE_SETTING_VAR) {
@@ -4189,7 +4189,7 @@ ADE_VIRTVAR(Mass, l_Weaponclass, "number", "Weapon mass", "number", "Weapon mass
 	if(!ade_get_args(L, "o|f", l_Weaponclass.Get(&idx), &f))
 		return ade_set_error(L, "f", 0.0f);
 
-	if(idx < 0 || idx > Num_weapon_types)
+	if(idx < 0 || idx >= Num_weapon_types)
 		return ade_set_error(L, "f", 0.0f);
 
 	if(ADE_SETTING_VAR) {
@@ -4206,7 +4206,7 @@ ADE_VIRTVAR(ShieldFactor, l_Weaponclass, "number", "Amount of weapon damage appl
 	if(!ade_get_args(L, "o|f", l_Weaponclass.Get(&idx), &f))
 		return ade_set_error(L, "f", 0.0f);
 
-	if(idx < 0 || idx > Num_weapon_types)
+	if(idx < 0 || idx >= Num_weapon_types)
 		return ade_set_error(L, "f", 0.0f);
 
 	if(ADE_SETTING_VAR) {
@@ -4223,7 +4223,7 @@ ADE_VIRTVAR(SubsystemFactor, l_Weaponclass, "number", "Amount of weapon damage a
 	if(!ade_get_args(L, "o|f", l_Weaponclass.Get(&idx), &f))
 		return ade_set_error(L, "f", 0.0f);
 
-	if(idx < 0 || idx > Num_weapon_types)
+	if(idx < 0 || idx >= Num_weapon_types)
 		return ade_set_error(L, "f", 0.0f);
 
 	if(ADE_SETTING_VAR) {
@@ -4240,7 +4240,7 @@ ADE_VIRTVAR(TargetLOD, l_Weaponclass, "number", "LOD used for weapon model in th
 	if(!ade_get_args(L, "o|i", l_Weaponclass.Get(&idx), &lod))
 		return ade_set_error(L, "i", 0);
 
-	if(idx < 0 || idx > Num_weapon_types)
+	if(idx < 0 || idx >= Num_weapon_types)
 		return ade_set_error(L, "i", 0);
 
 	if(ADE_SETTING_VAR) {
@@ -4257,7 +4257,7 @@ ADE_VIRTVAR(Speed, l_Weaponclass, "number", "Weapon max speed, aka $Velocity in 
 	if(!ade_get_args(L, "o|f", l_Weaponclass.Get(&idx), &spd))
 		return ade_set_error(L, "f", 0.0f);
 
-	if(idx < 0 || idx > Num_weapon_types)
+	if(idx < 0 || idx >= Num_weapon_types)
 		return ade_set_error(L, "f", 0.0f);
 
 	if(ADE_SETTING_VAR) {
@@ -4274,7 +4274,7 @@ ADE_VIRTVAR(Bomb, l_Weaponclass, "boolean", "Is weapon class flagged as bomb", "
 	if(!ade_get_args(L, "o|b", l_Weaponclass.Get(&idx), &newVal))
 		return ADE_RETURN_FALSE;
 
-	if(idx < 0 || idx > Num_weapon_types)
+	if(idx < 0 || idx >= Num_weapon_types)
 		return ADE_RETURN_FALSE;
 	
 	weapon_info *info = &Weapon_info[idx];
@@ -4305,7 +4305,7 @@ ADE_VIRTVAR(CargoSize, l_Weaponclass, "number", "The cargo size of this weapon c
 	if(!ade_get_args(L, "o|f", l_Weaponclass.Get(&idx), &newVal))
 		return ade_set_args(L, "f", -1.0f);
 
-	if(idx < 0 || idx > Num_weapon_types)
+	if(idx < 0 || idx >= Num_weapon_types)
 		return ade_set_args(L, "f", -1.0f);
 	
 	weapon_info *info = &Weapon_info[idx];
@@ -8214,7 +8214,7 @@ struct sound_entry_h
 
 	bool IsValid()
 	{
-		if (idx < 0 || idx > (int) Snds.size())
+		if (idx < 0 || idx >= (int) Snds.size())
 			return false;
 
 		return true;
@@ -8819,7 +8819,7 @@ ADE_INDEXER(l_Wing, "number Index", "Array of ships in the wing", "ship", "Ship 
 	return ade_set_args(L, "o", l_Ship.Set(object_h(&Objects[Ships[Wings[wdx].ship_index[sdx]].objnum])));
 }
 
-ADE_FUNC(__len, l_Wing, NULL, "Number of wings in mission", "number", "Number of wings in mission")
+ADE_FUNC(__len, l_Wing, NULL, "Gets the number of ships in the wing", "number", "Number of ships in wing")
 {
 	int wdx;
 	if(!ade_get_args(L, "o", l_Wing.Get(&wdx)))

--- a/code/parse/lua.cpp
+++ b/code/parse/lua.cpp
@@ -8842,6 +8842,18 @@ ADE_VIRTVAR(Name, l_Wing, "string", "Name of Wing", "string", "Wing name, or emp
 	return ade_set_args(L, "s", Wings[wdx].name);
 }
 
+ADE_FUNC(isValid, l_Wing, NULL, "Detects whether handle is valid", "boolean", "true if valid, false if handle is invalid, nil if a syntax/type error occurs")
+{
+	int idx;
+	if(!ade_get_args(L, "o", l_Wing.Get(&idx)))
+		return ADE_RETURN_NIL;
+
+	if (idx < 0 || idx >= Num_wings)
+		return ADE_RETURN_FALSE;
+
+	return ADE_RETURN_TRUE;
+}
+
 //**********HANDLE: Ship
 ade_obj<object_h> l_Ship("ship", "Ship handle", &l_Object);
 

--- a/code/parse/lua.cpp
+++ b/code/parse/lua.cpp
@@ -14895,7 +14895,8 @@ ADE_INDEXER(l_Mission_Wings, "number Index/string WingName", "Wings in the missi
 	if(!ade_get_args(L, "*s", &name))
 		return ade_set_error(L, "o", l_Wing.Set(-1));
 
-	int idx = wing_name_lookup(name);
+	//MageKing17 - Make the count-ignoring version of the lookup and leave checking if the wing has any ships to the scripter
+	int idx = wing_lookup(name);
 	
 	if(idx < 0)
 	{


### PR DESCRIPTION
After a lot of trial and error involving a simultaneously very-reproduceable and yet hard-to-track-down crash in the new Blue Planet release, I found that the problem is ultimately due to some inconsistencies in the Lua interface (ultimately leading to an uncaught negative index array access). This PR fixes the issue several times over. Firstly, looking up a wing by name no longer returns an invalid wing handle if the wing doesn't currently have any ships in the mission. Secondly, invalid wing handles can now be checked for with a new `isValid()` function. Thirdly, indexing an invalid wing handle will now produce an invalid ship handle instead of performing an out-of-bounds array access. Lastly, there's a cleanup commit (004fdae) to just fix a couple of other issues I happened to see while I was mucking around in Lua.cpp; not strictly related to wings (except the documentation part), but I didn't really feel like making a whole separate PR for it.