### PR TITLE
Fix support subsystem repair rate (for real this time).

### DIFF
--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -13686,14 +13686,12 @@ int ship_do_rearm_frame( object *objp, float frametime )
 	}
 
 	// figure out repairs for subsystems
-	if(repair_allocated > 0) {
-		if(sip->sup_subsys_repair_rate == 0.0f)
-			repair_allocated = 0.0f;
-		else if(sip->sup_hull_repair_rate == 0.0f)
-			repair_allocated = shipp->ship_max_hull_strength * frametime * sip->sup_subsys_repair_rate;
-		else if(!(sip->sup_hull_repair_rate == sip->sup_subsys_repair_rate))
-			repair_allocated = repair_allocated * sip->sup_subsys_repair_rate / sip->sup_hull_repair_rate;
-	}
+	if(sip->sup_subsys_repair_rate == 0.0f)
+		repair_allocated = 0.0f;
+	else if(sip->sup_hull_repair_rate == 0.0f)
+		repair_allocated = shipp->ship_max_hull_strength * frametime * sip->sup_subsys_repair_rate;
+	else if(!(sip->sup_hull_repair_rate == sip->sup_subsys_repair_rate))
+		repair_allocated = repair_allocated * sip->sup_subsys_repair_rate / sip->sup_hull_repair_rate;
 
 	// check the subsystems of the ship.
 	subsys_all_ok = 1;


### PR DESCRIPTION
PR #445 was unfortunately incomplete; it fixed the time estimate for repairs, but not the actual repair part. I think I've identified which piece of code was preventing the actual repairs from working. This `repair_allocated > 0` conditional is actively preventing the `sip->sup_hull_repair_rate == 0.0f` branch from executing (so `repair_allocated` remains 0 and subsystems can't actually repair).