### PR TITLE
Adds the ability for subsystems to repair themselves when disabled.

### DIFF
--- a/code/model/model.h
+++ b/code/model/model.h
@@ -140,6 +140,7 @@ typedef struct polymodel_instance {
 #define MSS_FLAG2_COLLIDE_SUBMODEL				 (1 << 3)	// subsystem takes damage only from hits which impact the associated submodel
 #define MSS_FLAG2_DESTROYED_ROTATION			 (1 << 4)   // allows subobjects to continue to rotate even if they have been destroyed
 #define MSS_FLAG2_TURRET_USE_AMMO				 (1 << 5)	// enables ammo consumption for turrets (DahBlount)
+#define MSS_FLAG2_AUTOREPAIR_IF_DISABLED		 (1 << 6)	// Allows the subsystem to repair itself even if disabled (MageKing17)
 
 #define NUM_SUBSYSTEM_FLAGS			33
 

--- a/code/model/model.h
+++ b/code/model/model.h
@@ -141,6 +141,7 @@ typedef struct polymodel_instance {
 #define MSS_FLAG2_DESTROYED_ROTATION			 (1 << 4)   // allows subobjects to continue to rotate even if they have been destroyed
 #define MSS_FLAG2_TURRET_USE_AMMO				 (1 << 5)	// enables ammo consumption for turrets (DahBlount)
 #define MSS_FLAG2_AUTOREPAIR_IF_DISABLED		 (1 << 6)	// Allows the subsystem to repair itself even if disabled (MageKing17)
+#define MSS_FLAG2_NO_AUTOREPAIR_IF_DISABLED		 (1 << 7)	// Inversion of the previous; disallows this particular subsystem if the ship-wide flag is set (MageKing17)
 
 #define NUM_SUBSYSTEM_FLAGS			33
 

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -8790,8 +8790,18 @@ void ship_auto_repair_frame(int shipnum, float frametime)
 		if ( ssp->current_hits < ssp->max_hits ) {
 
 			// only repair those subsystems which are not destroyed
-			if ( (ssp->max_hits <= 0) || ((ssp->current_hits <= 0) && !(((sip->flags2 & SIF2_SUBSYS_REPAIR_WHEN_DISABLED) && !(ssp->flags & SSF_NO_AUTOREPAIR_IF_DISABLED)) || (ssp->flags & SSF_AUTOREPAIR_IF_DISABLED))) )
+			if ( ssp->max_hits <= 0 )
 				continue;
+
+			if ( ssp->current_hits <= 0 ) {
+				if (sip->flags2 & SIF2_SUBSYS_REPAIR_WHEN_DISABLED) {
+					if (ssp->flags & SSF_NO_AUTOREPAIR_IF_DISABLED) {
+						continue;
+					}
+				} else if (!(ssp->flags & SSF_AUTOREPAIR_IF_DISABLED)) {
+					continue;
+				}
+			}
 
 			// do incremental repair on the subsystem
 			// check for overflow of current_hits

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -258,6 +258,7 @@ flag_def_list Subsystem_flags[] = {
 	{ "allow destroyed rotation",	MSS_FLAG2_DESTROYED_ROTATION, 1},
 	{ "turret use ammo",		MSS_FLAG2_TURRET_USE_AMMO, 1},
 	{ "autorepair if disabled",	MSS_FLAG2_AUTOREPAIR_IF_DISABLED, 1},
+	{ "don't autorepair if disabled", MSS_FLAG2_NO_AUTOREPAIR_IF_DISABLED, 1},
 };
 
 const int Num_subsystem_flags = sizeof(Subsystem_flags)/sizeof(flag_def_list);
@@ -4336,6 +4337,15 @@ int parse_ship_values(ship_info* sip, const bool is_template, const bool first_t
 				sp->flags |= MSS_FLAG_USE_MULTIPLE_GUNS;
 			}
 
+			if ((sp->flags2 & MSS_FLAG2_AUTOREPAIR_IF_DISABLED) && (sp->flags2 & MSS_FLAG2_NO_AUTOREPAIR_IF_DISABLED)) {
+				Warning(LOCATION, "\"autorepair if disabled\" flag used with \"don't autorepair if disabled\" flag on a subsystem on %s '%s'.\nWhichever flag would be default behavior anyway for this ship has been removed.\n", info_type_name, sip->name);
+				if (sip->flags2 & SIF2_SUBSYS_REPAIR_WHEN_DISABLED){
+					sp->flags2 &= ~MSS_FLAG2_AUTOREPAIR_IF_DISABLED;
+				} else {
+					sp->flags2 &= ~MSS_FLAG2_NO_AUTOREPAIR_IF_DISABLED;
+				}
+			}
+
 			if (old_flags) {
 				mprintf(("Use of deprecated subsystem syntax.  Please use the $Flags: field for subsystem flags.\n\n" \
 				"At least one of the following tags was used on %s '%s', subsystem %s:\n" \
@@ -6311,6 +6321,8 @@ int subsys_set(int objnum, int ignore_subsys_info)
 			ship_system->flags |= SSF_NO_DISAPPEAR;
 		if (model_system->flags2 & MSS_FLAG2_AUTOREPAIR_IF_DISABLED)
 			ship_system->flags |= SSF_AUTOREPAIR_IF_DISABLED;
+		if (model_system->flags2 & MSS_FLAG2_NO_AUTOREPAIR_IF_DISABLED)
+			ship_system->flags |= SSF_NO_AUTOREPAIR_IF_DISABLED;
 
 		ship_system->turn_rate = model_system->turn_rate;
 
@@ -8778,7 +8790,7 @@ void ship_auto_repair_frame(int shipnum, float frametime)
 		if ( ssp->current_hits < ssp->max_hits ) {
 
 			// only repair those subsystems which are not destroyed
-			if ( (ssp->max_hits <= 0) || ((ssp->current_hits <= 0) && !((sip->flags2 & SIF2_SUBSYS_REPAIR_WHEN_DISABLED) || (ssp->flags & SSF_AUTOREPAIR_IF_DISABLED))) )
+			if ( (ssp->max_hits <= 0) || ((ssp->current_hits <= 0) && !(((sip->flags2 & SIF2_SUBSYS_REPAIR_WHEN_DISABLED) && !(ssp->flags & SSF_NO_AUTOREPAIR_IF_DISABLED)) || (ssp->flags & SSF_AUTOREPAIR_IF_DISABLED))) )
 				continue;
 
 			// do incremental repair on the subsystem

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -294,6 +294,7 @@ typedef struct cockpit_display_info {
 #define SSF_NO_AGGREGATE		(1 << 12)		// exclude this subsystem from the aggregate subsystem-info tracking - Goober5000
 #define SSF_PLAY_SOUND_FOR_PLAYER	( 1 << 13)	// If this subsystem is a turret on a player ship, play firing sounds - The E 
 #define SSF_NO_DISAPPEAR		( 1 << 14)		// prevents submodel from disappearing when subsys destroyed
+#define SSF_AUTOREPAIR_IF_DISABLED	(1 << 15)	// Allows the subsystem to repair itself even when disabled - MageKing17
 
 
 // Wanderer 
@@ -931,6 +932,7 @@ extern int ship_find_exited_ship_by_signature( int signature);
 #define SIF2_AUTO_SPREAD_SHIELDS			(1 << 16)	// zookeeper - auto spread shields
 #define SIF2_DRAW_WEAPON_MODELS				(1 << 17)	// the ship draws weapon models of any sort (used to be a boolean)
 #define SIF2_MODEL_POINT_SHIELDS			(1 << 18)	// zookeeper - uses model-defined shield points instead of quadrants
+#define SIF2_SUBSYS_REPAIR_WHEN_DISABLED	(1 << 19)	// MageKing17 - Subsystems auto-repair themselves even when disabled.
 
 #define	SIF_DEFAULT_VALUE		0
 #define SIF2_DEFAULT_VALUE		0

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -295,6 +295,7 @@ typedef struct cockpit_display_info {
 #define SSF_PLAY_SOUND_FOR_PLAYER	( 1 << 13)	// If this subsystem is a turret on a player ship, play firing sounds - The E 
 #define SSF_NO_DISAPPEAR		( 1 << 14)		// prevents submodel from disappearing when subsys destroyed
 #define SSF_AUTOREPAIR_IF_DISABLED	(1 << 15)	// Allows the subsystem to repair itself even when disabled - MageKing17
+#define SSF_NO_AUTOREPAIR_IF_DISABLED (1 << 16) // Inversion of the above; allow a specific subsystem not to repair itself after being disabled if the ship has the "repair disabled subsystems" flag - MageKing17
 
 
 // Wanderer 


### PR DESCRIPTION
Can either be set for individual subsystems via the "autorepair if disabled" flag, or set for an entire ship via the "repair disabled subsystems" flag. It will, by necessity, only have an effect if the ship's "$Subsystem Repair Rate:" is a positive number.

Some things that I'm considering adding:
- [x] A "don't autorepair this subsystem" flag to act as the inverse of "autorepair if disabled", so you don't have to add the latter flag to every single subsystem except the one you want not to autorepair.
- ~~[ ] A (per-subsystem-configurable?) delay before a disabled subsystem repairs itself, so that autorepair capability doesn't mean a ship can't be temporarily disarmed/disabled.~~