### PR TITLE
Scope fixes for hudlock.cpp

### DIFF
--- a/code/hud/hudlock.cpp
+++ b/code/hud/hudlock.cpp
@@ -35,7 +35,6 @@
 vec3d lock_world_pos;
 
 static float Lock_start_dist;
-static int Rotate_time_id = 1;	// timer id for controlling how often to rotate triangles around lock indicator
 
 int Missile_track_loop = -1;
 int Missile_lock_loop = -1;
@@ -68,9 +67,6 @@ int Lock_gauge_half_h[GR_NUM_RESOLUTIONS] = {
 	25
 };
 
-int Lock_gauge_loaded = 0;
-int Lock_gauge_draw = 0;
-int Lock_gauge_draw_stamp = -1;
 #define LOCK_GAUGE_BLINK_RATE			5			// blinks/sec
 
 int Lockspin_half_w[NUM_HUD_RETICLE_STYLES][GR_NUM_RESOLUTIONS] = {
@@ -107,17 +103,11 @@ void hud_init_missile_lock()
 
 	Player_ai->last_secondary_index = -1;
 
-	Rotate_time_id = 1;
+	HudGaugeLock *gauge = static_cast<HudGaugeLock*>(hud_get_gauge("Lock indicator"));
 
-	// Load in the frames need for the lead indicator
-	//if (!Lock_gauge_loaded) {
-	//Commented out due to changes in HUD loading behaviour. These checks are no longer needed at this point.
-
-		Lock_gauge_loaded = 1;
-		
-		Lock_gauge_draw_stamp = -1;
-		Lock_gauge_draw = 0;
-	//}
+	gauge->Rotate_time_id = 1;
+	gauge->Lock_gauge_draw_stamp = -1;
+	gauge->Lock_gauge_draw = 0;
 }
 
 void hud_draw_diamond(int x, int y, int width, int height)
@@ -321,11 +311,12 @@ void hud_lock_reset(float lock_time_scale)
 	Player->locking_subsys_parent=-1;
 	hud_stop_looped_locking_sounds();
 
-	Lock_gauge_draw_stamp = -1;
-	Lock_gauge_draw = 0;
+	HudGaugeLock *gauge = static_cast<HudGaugeLock*>(hud_get_gauge("Lock indicator"));
+
+	gauge->Lock_gauge_draw_stamp = -1;
+	gauge->Lock_gauge_draw = 0;
 
 	// reset the lock anim time elapsed
-	HudGaugeLock *gauge = static_cast<HudGaugeLock*>(hud_get_gauge("Lock indicator"));
 	gauge->Lock_anim.time_elapsed = 0.0f;
 }
 

--- a/code/hud/hudlock.cpp
+++ b/code/hud/hudlock.cpp
@@ -325,7 +325,8 @@ void hud_lock_reset(float lock_time_scale)
 	Lock_gauge_draw = 0;
 
 	// reset the lock anim time elapsed
-//	Lock_anim.time_elapsed = 0.0f;
+	HudGaugeLock *gauge = static_cast<HudGaugeLock*>(hud_get_gauge("Lock indicator"));
+	gauge->Lock_anim.time_elapsed = 0.0f;
 }
 
 // Determine if the locking code has a point to track

--- a/code/hud/hudlock.cpp
+++ b/code/hud/hudlock.cpp
@@ -719,7 +719,11 @@ void HudGaugeLock::renderLockTriangles(int center_x, int center_y, float frameti
 			// maybe draw the anim
 			Lock_gauge.time_elapsed = 0.0f;			
 			if(Lock_gauge_draw){
-				hud_anim_render(&Lock_anim, frametime, 1, 0, 1);
+				if ( loop_locked_anim ) {
+					hud_anim_render(&Lock_anim, frametime, 1, 1, 0);
+				} else {
+					hud_anim_render(&Lock_anim, frametime, 1, 0, 1);
+				}
 			}
 		}
 	}

--- a/code/hud/hudlock.h
+++ b/code/hud/hudlock.h
@@ -25,6 +25,8 @@ void hud_lock_reset(float lock_time_scale=1.0f);
 
 class HudGaugeLock: public HudGauge
 {
+	friend void hud_lock_reset(float lock_time_scale);
+
 protected:
 	hud_anim Lock_gauge;
 	hud_anim Lock_anim;

--- a/code/hud/hudlock.h
+++ b/code/hud/hudlock.h
@@ -25,6 +25,7 @@ void hud_lock_reset(float lock_time_scale=1.0f);
 
 class HudGaugeLock: public HudGauge
 {
+	friend void hud_init_missile_lock();
 	friend void hud_lock_reset(float lock_time_scale);
 
 protected:


### PR DESCRIPTION
Whoever converted hudlock.cpp to use the new hud gauge code didn't fully sync the class-scoped functions and the global-scoped functions.  `Lock_anim` was moved to a protected field of `HudGaugeLock`, but the global `Lock_anim` was left in place.  This caused the global variable to be left "orphaned" without references.  It was removed in commit 8a728238390a14f4e98077d464128305f9948cb0.

This led to issue #456 by the ever-observant @Yarn366.  This current commit is my naive attempt to fix it.  (Please don't merge it as it doesn't actually work yet.  Default hud gauges don't have names, and so `hud_get_gauge` returns null.  Is there a preferred way to get a gauge like this?)

It should be mentioned that `Lock_anim` is not the only shadowed global variable here.  There are also `Lock_gauge_draw`, `Lock_gauge_draw_stamp`, and `Rotate_time_id`.