### PR TITLE
Some cleanup for vecmat

### DIFF
--- a/code/ai/aibig.cpp
+++ b/code/ai/aibig.cpp
@@ -1239,7 +1239,7 @@ int ai_big_strafe_maybe_retreat(float dist, vec3d *target_pos)
 	float dist_to_target, dist_normal_to_target, time_to_target;
 	dist_to_target = vm_vec_mag_quick(&vec_to_target);
 	if (vm_vec_mag_quick(&aip->big_attack_surface_normal) > 0.9) {
-		dist_normal_to_target = -vm_vec_dotprod(&vec_to_target, &aip->big_attack_surface_normal);
+		dist_normal_to_target = -vm_vec_dot(&vec_to_target, &aip->big_attack_surface_normal);
 	} else {
 		dist_normal_to_target = 0.2f * vm_vec_mag_quick(&vec_to_target);
 	}

--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -9261,7 +9261,7 @@ float dock_orient_and_approach(object *docker_objp, int docker_index, object *do
 			vec3d origin_docker_point, adjusted_docker_point, v_offset;
 
 			// find out the rotation matrix that will get us from the old to the new rotation
-			vm_copy_transpose_matrix(&temp, &docker_objp->orient);
+			vm_copy_transpose(&temp, &docker_objp->orient);
 			vm_matrix_x_matrix(&m_offset, &temp, &dom);
 
 			// now find out the new docker point after being adjusted for the new orientation

--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -1539,8 +1539,8 @@ float turn_towards_tangent(object *objp, vec3d *point, float radius)
 	vec3d	v2g;
 
 	vm_vec_normalized_dir(&vec_to_point, point, &objp->pos);
-	vm_vec_crossprod(&up_vec, &vec_to_point, &objp->orient.vec.fvec);
-	vm_vec_crossprod(&perp_vec, &vec_to_point, &up_vec);
+	vm_vec_cross(&up_vec, &vec_to_point, &objp->orient.vec.fvec);
+	vm_vec_cross(&perp_vec, &vec_to_point, &up_vec);
 
 	vm_vec_scale_add(&perp_point, point, &vec_to_point, -radius);
 	if (vm_vec_dot(&objp->orient.vec.fvec, &perp_vec) > 0.0f) {
@@ -1574,7 +1574,7 @@ float turn_toward_tangent_with_axis(object *objp, object *center_objp, float rad
 	Assert( (vm_vec_dot(&r_vec, &center_objp->orient.vec.fvec) < 0.0001));
 
 	// get theta vec - perp to r_vec and z_vec
-	vm_vec_crossprod(&theta_vec, &center_objp->orient.vec.fvec, &r_vec);
+	vm_vec_cross(&theta_vec, &center_objp->orient.vec.fvec, &r_vec);
 
 #ifndef NDEBUG
 	float mag;
@@ -1583,7 +1583,7 @@ float turn_toward_tangent_with_axis(object *objp, object *center_objp, float rad
 #endif
 
 	vec3d temp;
-	vm_vec_crossprod(&temp, &r_vec, &theta_vec);
+	vm_vec_cross(&temp, &r_vec, &theta_vec);
 
 #ifndef NDEBUG
 	float dot;
@@ -1613,17 +1613,17 @@ void get_tangent_point(vec3d *goal_point, object *objp, vec3d *point, float radi
 	vec3d	up_vec, perp_vec;
 
 	vm_vec_normalized_dir(&vec_to_point, point, &objp->pos);
-	vm_vec_crossprod(&up_vec, &vec_to_point, &objp->orient.vec.fvec);
+	vm_vec_cross(&up_vec, &vec_to_point, &objp->orient.vec.fvec);
 	
 	while (IS_VEC_NULL(&up_vec)) {
 		vec3d	rnd_vec;
 
 		vm_vec_rand_vec_quick(&rnd_vec);
 		vm_vec_add2(&rnd_vec, &objp->orient.vec.fvec);
-		vm_vec_crossprod(&up_vec, &vec_to_point, &rnd_vec);
+		vm_vec_cross(&up_vec, &vec_to_point, &rnd_vec);
 	}
 
-	vm_vec_crossprod(&perp_vec, &vec_to_point, &up_vec);
+	vm_vec_cross(&perp_vec, &vec_to_point, &up_vec);
 	vm_vec_normalize(&perp_vec);
 
 	vm_vec_scale_add(&perp_point, point, &vec_to_point, -radius);
@@ -2966,8 +2966,8 @@ int maybe_avoid_player(object *objp, vec3d *goal_pos)
 		} else {
 			vec3d	tvec1;
 			vm_vec_normalize(&avoid_vec);
-			vm_vec_crossprod(&tvec1, &n_vec_to_goal, &avoid_vec);
-			vm_vec_crossprod(&avoid_vec, &tvec1, &n_vec_to_player);
+			vm_vec_cross(&tvec1, &n_vec_to_goal, &avoid_vec);
+			vm_vec_cross(&avoid_vec, &tvec1, &n_vec_to_player);
 		}
 
 		//	Now, avoid_vec is a vector perpendicular to the vector to the player and the direction *objp
@@ -7144,10 +7144,10 @@ void ai_stealth_sweep()
 	}
 
 	// get "right" vector for box
-	vm_vec_crossprod(&right, &aip->stealth_velocity, &vmd_y_vector);
+	vm_vec_cross(&right, &aip->stealth_velocity, &vmd_y_vector);
 
 	if ( vm_vec_mag_quick(&right) < 0.01 ) {
-		vm_vec_crossprod(&right, &aip->stealth_velocity, &vmd_z_vector);
+		vm_vec_cross(&right, &aip->stealth_velocity, &vmd_z_vector);
 	}
 
 	vm_vec_normalize_quick(&right);
@@ -7156,7 +7156,7 @@ void ai_stealth_sweep()
 	vm_vec_copy_normalize_quick(&forward, &aip->stealth_velocity);
 
 	// get "up" for box
-	vm_vec_crossprod(&up, &forward, &right);
+	vm_vec_cross(&up, &forward, &right);
 	
 	// lost far away ahead (do box)
 	switch(aip->submode_parm0) {
@@ -9837,7 +9837,7 @@ void ai_big_guard()
 
 		// get position relative to cylinder of guard_objp		
 		extended_z = get_cylinder_points(Pl_objp, guard_objp, &axis_pt, &r_vec, &radius);
-		vm_vec_crossprod(&theta_vec, &guard_objp->orient.vec.fvec, &r_vec);
+		vm_vec_cross(&theta_vec, &guard_objp->orient.vec.fvec, &r_vec);
 
 		// half ships circle each way
 		if (objval > 0.5f) {

--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -8996,7 +8996,7 @@ void set_goal_dock_orient(matrix *dom, vec3d *docker_p0, vec3d *docker_p1, vec3d
 
 	//	Pre-multiply the orientation of the source object (docker_orient) by the transpose
 	//	of the docking bay's orientation, ie unrotate the source object's matrix.
-	vm_transpose_matrix(&m2);
+	vm_transpose(&m2);
 	vm_matrix_x_matrix(dom, &m3, &m2);
 }
 

--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -980,7 +980,7 @@ int ai_is_stealth_visible(object *viewer_objp, object *stealth_objp)
 	if ( !ship_is_visible_by_team(stealth_objp, &Ships[viewer_objp->instance]) ) {
 		vm_vec_sub(&vec_to_stealth, &stealth_objp->pos, &viewer_objp->pos);
 		dist_to_stealth = vm_vec_mag_quick(&vec_to_stealth);
-		dot_to_stealth = vm_vec_dotprod(&viewer_objp->orient.vec.fvec, &vec_to_stealth) / dist_to_stealth;
+		dot_to_stealth = vm_vec_dot(&viewer_objp->orient.vec.fvec, &vec_to_stealth) / dist_to_stealth;
 
 		// get max dist at which stealth is visible
 		max_stealth_dist = get_skill_stealth_dist_scaler() * STEALTH_MAX_VIEW_DIST;
@@ -1563,7 +1563,7 @@ float turn_toward_tangent_with_axis(object *objp, object *center_objp, float rad
 
 	// find closest z of center objp
 	vm_vec_sub(&sph_r_vec, &objp->pos, &center_objp->pos);
-	center_obj_z = vm_vec_dotprod(&sph_r_vec, &center_objp->orient.vec.fvec);
+	center_obj_z = vm_vec_dot(&sph_r_vec, &center_objp->orient.vec.fvec);
 
 	// find pt on axis with closest z
 	vm_vec_scale_add(&center_vec, &center_objp->pos, &center_objp->orient.vec.fvec, center_obj_z);
@@ -1571,7 +1571,7 @@ float turn_toward_tangent_with_axis(object *objp, object *center_objp, float rad
 	// get r_vec
 	vm_vec_sub(&r_vec, &objp->pos, &center_vec);
 
-	Assert( (vm_vec_dotprod(&r_vec, &center_objp->orient.vec.fvec) < 0.0001));
+	Assert( (vm_vec_dot(&r_vec, &center_objp->orient.vec.fvec) < 0.0001));
 
 	// get theta vec - perp to r_vec and z_vec
 	vm_vec_crossprod(&theta_vec, &center_objp->orient.vec.fvec, &r_vec);
@@ -1587,7 +1587,7 @@ float turn_toward_tangent_with_axis(object *objp, object *center_objp, float rad
 
 #ifndef NDEBUG
 	float dot;
-	dot = vm_vec_dotprod(&temp, &center_objp->orient.vec.fvec);
+	dot = vm_vec_dot(&temp, &center_objp->orient.vec.fvec);
 	Assert( dot >0.9999 && dot < 1.0001);
 #endif
 
@@ -6496,7 +6496,7 @@ void set_predicted_enemy_pos(vec3d *predicted_enemy_pos, object *pobjp, vec3d *e
 		vec3d temp;
 		vm_vec_sub(&temp, enemy_pos, &pobjp->pos);
 		vm_vec_normalize_quick(&temp);
-		float dot = vm_vec_dotprod(&temp, &pobjp->orient.vec.fvec);
+		float dot = vm_vec_dot(&temp, &pobjp->orient.vec.fvec);
 		float st_err = 3.0f * (1.4f - dot) * (1.0f + dist / (get_skill_stealth_dist_scaler() * STEALTH_MAX_VIEW_DIST)) * (1 - aip->ai_accuracy);
 		scale += st_err;
 	}
@@ -7056,7 +7056,7 @@ void ai_stealth_find()
 	// if dist is near max and dot is close to 1, accel, afterburn
 	vm_vec_sub(&vec_to_enemy, &new_pos, &Pl_objp->pos);
 	dist_to_enemy = vm_vec_normalize_quick(&vec_to_enemy);
-	dot_to_enemy = vm_vec_dotprod(&vec_to_enemy, &Pl_objp->orient.vec.fvec);
+	dot_to_enemy = vm_vec_dot(&vec_to_enemy, &Pl_objp->orient.vec.fvec);
 
 	// if i think i should see him ahead and i don't, set goal pos and turn around, but only if I haven't seen him for a while
 	if ( (delta_time > 800) && (aip->submode_parm0 == SM_SF_AHEAD) && (dot_to_enemy > .94) && (dist_to_enemy < get_skill_stealth_dist_scaler()*STEALTH_MAX_VIEW_DIST + 50) ) {
@@ -7065,7 +7065,7 @@ void ai_stealth_find()
 		aip->submode_parm0 = SM_SF_BEHIND;
 		vm_vec_sub(&vec_to_enemy, &new_pos, &Pl_objp->pos);
 		dist_to_enemy = vm_vec_normalize_quick(&vec_to_enemy);
-		dot_to_enemy = vm_vec_dotprod(&vec_to_enemy, &Pl_objp->orient.vec.fvec);
+		dot_to_enemy = vm_vec_dot(&vec_to_enemy, &Pl_objp->orient.vec.fvec);
 	}
 
 	if ( (dist_to_enemy > get_skill_stealth_dist_scaler()*STEALTH_MAX_VIEW_DIST) && (dot_to_enemy > 0.94f) ) {		// 20 degree half angle
@@ -7095,7 +7095,7 @@ void ai_stealth_find()
 		ai_turn_towards_vector(&new_pos, Pl_objp, flFrametime, sip->srotation_time, NULL, NULL, 0.0f, 0);
 	}
 
-	dot_from_enemy = -vm_vec_dotprod(&vec_to_enemy, &En_objp->orient.vec.fvec);
+	dot_from_enemy = -vm_vec_dot(&vec_to_enemy, &En_objp->orient.vec.fvec);
 
 	attack_set_accel(aip, sip, dist_to_enemy, dot_to_enemy, dot_from_enemy);
 }
@@ -7226,7 +7226,7 @@ void ai_stealth_sweep()
 	if (dist_to_goal < 100) {
 		vec3d vec_to_goal;
 		vm_vec_normalized_dir(&vec_to_goal, &goal_pt, &Pl_objp->pos);
-		dot = vm_vec_dotprod(&vec_to_goal, &Pl_objp->orient.vec.fvec);
+		dot = vm_vec_dot(&vec_to_goal, &Pl_objp->orient.vec.fvec);
 	}
 
 	accelerate_ship(aip, 0.8f*dot);
@@ -7872,7 +7872,7 @@ void ai_chase_big_get_separations(object *attack_objp, object *target_objp, vec3
 	vm_vec_sub(&vec_to_target, &attack_objp->pos, &target_objp->pos);
 
 	// find the distance between centers along forward direction of ships
-	perp_dist = vm_vec_dotprod(&vec_to_target, &target_objp->orient.vec.fvec);
+	perp_dist = vm_vec_dot(&vec_to_target, &target_objp->orient.vec.fvec);
 
 	// subtract off perp component to get "horizontal" separation vector between cylinders [ASSUMING parallel]
 	vm_vec_scale_add(horz_vec_to_target, &vec_to_target, &target_objp->orient.vec.fvec, -perp_dist);
@@ -7903,7 +7903,7 @@ void ai_chase_big_parallel_set_goal(vec3d *goal_pos, object *attack_objp, object
 	r_target = MAX(temp, r_target);
 
 	// are we opposing (only when other ship is not moving)
-	opposing = ( vm_vec_dotprod(&attack_objp->orient.vec.fvec, &target_objp->orient.vec.fvec) < 0 );
+	opposing = ( vm_vec_dot(&attack_objp->orient.vec.fvec, &target_objp->orient.vec.fvec) < 0 );
 
 	ai_chase_big_get_separations(attack_objp, target_objp, &horz_vec_to_target, &optimal_separation, &separation);
 
@@ -7921,7 +7921,7 @@ void ai_chase_big_parallel_set_goal(vec3d *goal_pos, object *attack_objp, object
 	// find the distance between centers along forward direction of ships
 	vec3d vec_to_target;
 	vm_vec_sub(&vec_to_target, &target_objp->pos, &attack_objp->pos);
-	float perp_dist = vm_vec_dotprod(&vec_to_target, &target_objp->orient.vec.fvec);
+	float perp_dist = vm_vec_dot(&vec_to_target, &target_objp->orient.vec.fvec);
 
 	float match_accel = 0.0f;
 	float length_scale = attack_objp->radius;
@@ -8071,7 +8071,7 @@ void ai_cruiser_chase()
 				// moving
 				if (moving) {
 					// if within 90 degrees of en forward, go into parallel, otherwise circle
-					if ( vm_vec_dotprod(&En_objp->orient.vec.fvec, &Pl_objp->orient.vec.fvec) > 0 ) {
+					if ( vm_vec_dot(&En_objp->orient.vec.fvec, &Pl_objp->orient.vec.fvec) > 0 ) {
 						aip->submode = SM_BIG_PARALLEL;
 						aip->submode_start_time = Missiontime;
 					}
@@ -8091,9 +8091,9 @@ void ai_cruiser_chase()
 				vec3d temp;
 				float desired_sep, cur_sep;
 				// we're behind the enemy ship
-				if (vm_vec_dotprod(&vec_to_enemy, &En_objp->orient.vec.fvec) > 0) {
+				if (vm_vec_dot(&vec_to_enemy, &En_objp->orient.vec.fvec) > 0) {
 					// and we're turning toward the enemy
-					if (vm_vec_dotprod(&En_objp->orient.vec.fvec, &Pl_objp->orient.vec.fvec) > 0) {
+					if (vm_vec_dot(&En_objp->orient.vec.fvec, &Pl_objp->orient.vec.fvec) > 0) {
 						// get separation
 						ai_chase_big_get_separations(Pl_objp, En_objp, &temp, &desired_sep, &cur_sep);
 						// and the separation is > 0.9 desired
@@ -8108,9 +8108,9 @@ void ai_cruiser_chase()
 				vec3d temp;
 				float desired_sep, cur_sep;
 				// we're behind the enemy ship
-				if (vm_vec_dotprod(&vec_to_enemy, &En_objp->orient.vec.fvec) > 0) {
+				if (vm_vec_dot(&vec_to_enemy, &En_objp->orient.vec.fvec) > 0) {
 					// and we're turning toward the enemy
-					if (vm_vec_dotprod(&En_objp->orient.vec.fvec, &Pl_objp->orient.vec.fvec) > 0) {
+					if (vm_vec_dot(&En_objp->orient.vec.fvec, &Pl_objp->orient.vec.fvec) > 0) {
 						// get separation
 						ai_chase_big_get_separations(Pl_objp, En_objp, &temp, &desired_sep, &cur_sep);
 						// and the separation is > 0.9 desired
@@ -8123,7 +8123,7 @@ void ai_cruiser_chase()
 				// in front of ship
 				else {
 					// and we're turning toward the enemy
-					if (vm_vec_dotprod(&En_objp->orient.vec.fvec, &Pl_objp->orient.vec.fvec) < 0) {
+					if (vm_vec_dot(&En_objp->orient.vec.fvec, &Pl_objp->orient.vec.fvec) < 0) {
 						// get separation
 						ai_chase_big_get_separations(Pl_objp, En_objp, &temp, &desired_sep, &cur_sep);
 						// and the separation is > 0.9 desired
@@ -8138,7 +8138,7 @@ void ai_cruiser_chase()
 
 		case SM_BIG_PARALLEL:
 			// we're opposing
-			if ( vm_vec_dotprod(&Pl_objp->orient.vec.fvec, &En_objp->orient.vec.fvec) < 0 ) {
+			if ( vm_vec_dot(&Pl_objp->orient.vec.fvec, &En_objp->orient.vec.fvec) < 0 ) {
 				// and the other ship is moving
 				if (moving) {
 					// and we no longer overlap
@@ -9801,7 +9801,7 @@ float get_cylinder_points(object *other_objp, object *cyl_objp, vec3d *axis_pt, 
 	// get point on axis and on cylinder
 	// extended_cylinder_z is along extended cylinder
 	// cylinder_z is capped within cylinder
-	float extended_cylinder_z = vm_vec_dotprod(&r_sph, &cyl_objp->orient.vec.fvec);
+	float extended_cylinder_z = vm_vec_dot(&r_sph, &cyl_objp->orient.vec.fvec);
 
 	// get pt on axis of extended cylinder
 	vm_vec_scale_add(axis_pt, &cyl_objp->pos, &cyl_objp->orient.vec.fvec, extended_cylinder_z);
@@ -13662,7 +13662,7 @@ int aas_1(object *objp, ai_info *aip, vec3d *safe_pos)
 			vec3d vec_from_exp;
 			float dir = 1.0f;
 			vm_vec_sub(&vec_from_exp, &objp->pos, &expected_pos);
-			float dot = vm_vec_dotprod(&vec_from_exp, &weapon_objp->orient.vec.fvec);
+			float dot = vm_vec_dot(&vec_from_exp, &weapon_objp->orient.vec.fvec);
 			if (dot > -30) {
 				// if we're already on the other side of the explosion, don't try to fly behind it
 				dir = -1.0f;

--- a/code/debris/debris.cpp
+++ b/code/debris/debris.cpp
@@ -703,7 +703,7 @@ object *debris_create(object *source_obj, int model_num, int submodel_num, vec3d
 	// displacement fromt the center of the parent object to the center of the debris piece
 	vec3d world_rotvel, vel_from_rotvel;
 	vm_vec_unrotate ( &world_rotvel, &source_obj->phys_info.rotvel, &source_obj->orient );
-	vm_vec_crossprod ( &vel_from_rotvel, &world_rotvel, &to_center );
+	vm_vec_cross ( &vel_from_rotvel, &world_rotvel, &to_center );
 	vm_vec_scale ( &vel_from_rotvel, DEBRIS_ROTVEL_SCALE);
 
 	vm_vec_add (&obj->phys_info.vel, &radial_vel, &source_obj->phys_info.vel);

--- a/code/fred2/fredrender.cpp
+++ b/code/fred2/fredrender.cpp
@@ -1374,11 +1374,11 @@ void process_controls(vec3d *pos, matrix *orient, float frametime, int key, int 
 
 		vm_angles_2_matrix(&rotmat, &rotangs);
 		if (rotangs.h && Universal_heading)
-			vm_transpose_matrix(orient);
+			vm_transpose(orient);
 		vm_matrix_x_matrix(&newmat, orient, &rotmat);
 		*orient = newmat;
 		if (rotangs.h && Universal_heading)
-			vm_transpose_matrix(orient);
+			vm_transpose(orient);
 	}
 }
 

--- a/code/fred2/fredrender.cpp
+++ b/code/fred2/fredrender.cpp
@@ -1141,7 +1141,7 @@ void draw_orient_sphere(object *obj, int r, int g, int b)
 
 	if ((obj->type != OBJ_WAYPOINT) && (obj->type != OBJ_POINT))
 	{
-		flag = (vm_vec_dotprod(&eye_orient.vec.fvec, &obj->orient.vec.fvec) < 0.0f);
+		flag = (vm_vec_dot(&eye_orient.vec.fvec, &obj->orient.vec.fvec) < 0.0f);
 		v1 = v2 = obj->pos;
 		vm_vec_scale_add2(&v1, &obj->orient.vec.fvec, size);
 		vm_vec_scale_add2(&v2, &obj->orient.vec.fvec, size * 1.5f);
@@ -1177,7 +1177,7 @@ void draw_orient_sphere2(int col, object *obj, int r, int g, int b)
 
 	if ((obj->type != OBJ_WAYPOINT) && (obj->type != OBJ_POINT))
 	{
-		flag = (vm_vec_dotprod(&eye_orient.vec.fvec, &obj->orient.vec.fvec) < 0.0f);
+		flag = (vm_vec_dot(&eye_orient.vec.fvec, &obj->orient.vec.fvec) < 0.0f);
 
 		v1 = v2 = obj->pos;
 		vm_vec_scale_add2(&v1, &obj->orient.vec.fvec, size);
@@ -2036,7 +2036,7 @@ void render_compass(void)
 
 	v.xyz.x = 1.0f;
 	v.xyz.y = v.xyz.z = 0.0f;
-	if (vm_vec_dotprod(&eye, &v) < 0.0f)
+	if (vm_vec_dot(&eye, &v) < 0.0f)
 		gr_set_color(159, 20, 20);
 	else
 		gr_set_color(255, 32, 32);
@@ -2044,7 +2044,7 @@ void render_compass(void)
 
 	v.xyz.y = 1.0f;
 	v.xyz.x = v.xyz.z = 0.0f;
-	if (vm_vec_dotprod(&eye, &v) < 0.0f)
+	if (vm_vec_dot(&eye, &v) < 0.0f)
 		gr_set_color(20, 159, 20);
 	else
 		gr_set_color(32, 255, 32);
@@ -2052,7 +2052,7 @@ void render_compass(void)
 
 	v.xyz.z = 1.0f;
 	v.xyz.x = v.xyz.y = 0.0f;
-	if (vm_vec_dotprod(&eye, &v) < 0.0f)
+	if (vm_vec_dot(&eye, &v) < 0.0f)
 		gr_set_color(20, 20, 159);
 	else
 		gr_set_color(32, 32, 255);

--- a/code/fred2/fredrender.cpp
+++ b/code/fred2/fredrender.cpp
@@ -1668,7 +1668,7 @@ void game_do_frame()
 					leader = &Objects[cur_object_index];
 					leader_old_pos = leader->pos;  // save original position
 					leader_orient = leader->orient;			// save original orientation
-					vm_copy_transpose_matrix(&leader_transpose, &leader_orient);
+					vm_copy_transpose(&leader_transpose, &leader_orient);
 
 					process_controls(&leader->pos, &leader->orient, f2fl(Frametime), key);
 					vm_vec_sub(&delta_pos, &leader->pos, &leader_old_pos);  // get position change
@@ -1685,7 +1685,7 @@ void game_do_frame()
 
 								// change rotation matrix to rotate in opposite direction.  This rotation
 								// matrix is what the leader ship has rotated by.
-								vm_copy_transpose_matrix(&rot_trans, &view_physics.last_rotmat);
+								vm_copy_transpose(&rot_trans, &view_physics.last_rotmat);
 
 								// get point relative to our point of rotation (make POR the origin).  Since
 								// only the leader has been moved yet, and not the objects, we have to use

--- a/code/fred2/fredview.cpp
+++ b/code/fred2/fredview.cpp
@@ -773,7 +773,7 @@ int drag_rotate_objects()
 
 	leader = &Objects[cur_object_index];
 	leader_orient = leader->orient;			// save original orientation
-	vm_copy_transpose_matrix(&leader_transpose, &leader_orient);
+	vm_copy_transpose(&leader_transpose, &leader_orient);
 
 	vm_angles_2_matrix(&rotmat, &a);
 	vm_matrix_x_matrix(&newmat, &leader->orient, &rotmat);
@@ -789,7 +789,7 @@ int drag_rotate_objects()
 
 				// change rotation matrix to rotate in opposite direction.  This rotation
 				// matrix is what the leader ship has rotated by.
-				vm_copy_transpose_matrix(&rot_trans, &rotmat);
+				vm_copy_transpose(&rot_trans, &rotmat);
 
 				// get point relative to our point of rotation (make POR the origin).
 				vm_vec_sub(&tmpv1, &objp->pos, &leader->pos);

--- a/code/graphics/2d.cpp
+++ b/code/graphics/2d.cpp
@@ -1852,15 +1852,15 @@ void poly_list::calculate_tangent()
 		vm_vec_normalize_safe(t2);
 
 		// compute handedness (for all 3 verts)
-		vm_vec_crossprod(&cross, &norm[i], &tangent);
+		vm_vec_cross(&cross, &norm[i], &tangent);
 		scale = vm_vec_dot(&cross, &binormal);
 		tsb[i].scaler = (scale < 0.0f) ? -1.0f : 1.0f;
 
-		vm_vec_crossprod(&cross, &norm[i+1], &tangent);
+		vm_vec_cross(&cross, &norm[i+1], &tangent);
 		scale = vm_vec_dot(&cross, &binormal);
 		tsb[i+1].scaler = (scale < 0.0f) ? -1.0f : 1.0f;
 
-		vm_vec_crossprod(&cross, &norm[i+2], &tangent);
+		vm_vec_cross(&cross, &norm[i+2], &tangent);
 		scale = vm_vec_dot(&cross, &binormal);
 		tsb[i+2].scaler = (scale < 0.0f) ? -1.0f : 1.0f;
 	}

--- a/code/graphics/grbatch.cpp
+++ b/code/graphics/grbatch.cpp
@@ -173,11 +173,11 @@ void geometry_batcher::draw_bitmap(vertex *pnt, int orient, float rad, float dep
 	uvec = View_matrix.vec.uvec;
 
 	// make a right vector from the f and up vector, this r vec is exactly what we want, so...
-	vm_vec_crossprod(&rvec, &View_matrix.vec.fvec, &uvec);
+	vm_vec_cross(&rvec, &View_matrix.vec.fvec, &uvec);
 	vm_vec_normalize_safe(&rvec);
 
 	// fix the u vec with it
-	vm_vec_crossprod(&uvec, &View_matrix.vec.fvec, &rvec);
+	vm_vec_cross(&uvec, &View_matrix.vec.fvec, &rvec);
 
 	// move the center of the sprite based on the depth parameter
 	if ( depth != 0.0f )
@@ -284,9 +284,9 @@ void geometry_batcher::draw_bitmap(vertex *pnt, float rad, float angle, float de
 
 	vm_rot_point_around_line(&uvec, &View_matrix.vec.uvec, angle, &vmd_zero_vector, &View_matrix.vec.fvec);
 
-	vm_vec_crossprod(&rvec, &View_matrix.vec.fvec, &uvec);
+	vm_vec_cross(&rvec, &View_matrix.vec.fvec, &uvec);
 	vm_vec_normalize_safe(&rvec);
-	vm_vec_crossprod(&uvec, &View_matrix.vec.fvec, &rvec);
+	vm_vec_cross(&uvec, &View_matrix.vec.fvec, &rvec);
 
 	vm_vec_scale_add(&PNT, &PNT, &fvec, depth);
 	vm_vec_scale_add(&p[0], &PNT, &rvec, rad);
@@ -373,13 +373,13 @@ void geometry_batcher::draw_beam(vec3d *start, vec3d *end, float width, float in
 	vm_vec_sub(&evec, &View_position, start);
 	vm_vec_normalize_safe(&evec);
 
-	vm_vec_crossprod(&uvecs, &fvec, &evec);
+	vm_vec_cross(&uvecs, &fvec, &evec);
 	vm_vec_normalize_safe(&uvecs);
 
 	vm_vec_sub(&evec, &View_position, end);
 	vm_vec_normalize_safe(&evec);
 
-	vm_vec_crossprod(&uvece, &fvec, &evec);
+	vm_vec_cross(&uvece, &fvec, &evec);
 	vm_vec_normalize_safe(&uvece);
 
 
@@ -441,13 +441,13 @@ float geometry_batcher::draw_laser(vec3d *p0, float width1, vec3d *p1, float wid
 	vm_vec_normalize(&reye);
 
 	// compute the up vector
-	vm_vec_crossprod(&uvec, &fvec, &reye);
+	vm_vec_cross(&uvec, &fvec, &reye);
 	vm_vec_normalize_safe(&uvec);
 	// ... the forward vector
-	vm_vec_crossprod(&fvec, &uvec, &reye);
+	vm_vec_cross(&fvec, &uvec, &reye);
 	vm_vec_normalize_safe(&fvec);
 	// now recompute right vector, in case it wasn't entirely perpendiclar
-	vm_vec_crossprod(&rvec, &uvec, &fvec);
+	vm_vec_cross(&rvec, &uvec, &fvec);
 
 	// Now have uvec, which is up vector and rvec which is the normal
 	// of the face.

--- a/code/hud/hudreticle.cpp
+++ b/code/hud/hudreticle.cpp
@@ -328,7 +328,7 @@ void HudGaugeReticle::getFirepointStatus() {
 
 						matrix eye_orient, player_transpose;
 
-						vm_copy_transpose_matrix(&player_transpose, &Objects[Player->objnum].orient);
+						vm_copy_transpose(&player_transpose, &Objects[Player->objnum].orient);
 						vm_matrix_x_matrix(&eye_orient, &player_transpose, &Eye_matrix);
 						vm_vec_rotate(&fpfromeye, &pm->gun_banks[i].pnt[j], &eye_orient);
 

--- a/code/hud/hudtarget.cpp
+++ b/code/hud/hudtarget.cpp
@@ -1792,7 +1792,7 @@ void hud_target_live_turret(int next_flag, int auto_advance, int only_player_tar
 					
 					if (!auto_advance && get_closest_turret && !only_player_target) {
 						// if within 3 degrees and not previous subsys, use subsys in front
-						dot = vm_vec_dotprod(&vec_to_subsys, &Player_obj->orient.vec.fvec);
+						dot = vm_vec_dot(&vec_to_subsys, &Player_obj->orient.vec.fvec);
 						if ((dot > 0.9986) && facing) {
 							use_straight_ahead_turret = TRUE;
 							break;
@@ -2760,9 +2760,9 @@ void HudGaugeOrientationTee::renderOrientation(object *from_objp, object *to_obj
 	// 0 - vectors are perpendicular
 	// 1 - vectors are collinear and in the same direction (target is facing player)
 	// -1 - vectors are collinear and in the opposite direction (target is facing away from player)
-	dot_product = vm_vec_dotprod(&from_orientp->vec.fvec, &target_to_obj);
+	dot_product = vm_vec_dot(&from_orientp->vec.fvec, &target_to_obj);
 
-	if (vm_vec_dotprod(&from_orientp->vec.rvec, &target_to_obj) >= 0) {
+	if (vm_vec_dot(&from_orientp->vec.rvec, &target_to_obj) >= 0) {
 		if (dot_product >= 0){
 			dot_product = -PI_2*dot_product + PI;
 		} else {

--- a/code/math/fvi.cpp
+++ b/code/math/fvi.cpp
@@ -42,7 +42,7 @@ static float matrix_determinant_from_vectors(const vec3d *v1, const vec3d *v2, c
 void fvi_two_lines_in_3space(const vec3d *p1, const vec3d *v1, const vec3d *p2, const vec3d *v2, float *s, float *t)
 {
 	vec3d cross,delta;
-	vm_vec_crossprod(&cross, v1, v2);
+	vm_vec_cross(&cross, v1, v2);
 	vm_vec_sub(&delta, p2, p1);
 
 	float denominator = vm_vec_mag_squared(&cross);
@@ -589,7 +589,7 @@ int fvi_sphere_perp_edge(vec3d *intersect_point, const vec3d *sphere_center_star
 
 	vm_vec_copy_normalize( &x_hat, &edge_velocity );
 	vm_vec_copy_normalize( &y_hat, sphere_velocity );
-	vm_vec_crossprod( &z_hat, &x_hat, &y_hat );
+	vm_vec_cross( &z_hat, &x_hat, &y_hat );
 	max_edge_parameter = vm_vec_mag( &edge_velocity );
 
 	vec3d temp;
@@ -1068,9 +1068,9 @@ void fvi_closest_line_line(const vec3d *x0, const vec3d *vx, const vec3d *y0, co
 
 	vm_vec_sub(&delta_l, y0, x0);
 
-	vm_vec_crossprod(&vx_cross_vy, vx, vy);
-	vm_vec_crossprod(&delta_l_cross_vx, &delta_l, vx);
-	vm_vec_crossprod(&delta_l_cross_vy, &delta_l, vy);
+	vm_vec_cross(&vx_cross_vy, vx, vy);
+	vm_vec_cross(&delta_l_cross_vx, &delta_l, vx);
+	vm_vec_cross(&delta_l_cross_vy, &delta_l, vy);
 
 	denominator = vm_vec_mag_squared(&vx_cross_vy);
 

--- a/code/math/fvi.cpp
+++ b/code/math/fvi.cpp
@@ -520,9 +520,9 @@ int fvi_sphere_plane(vec3d *intersect_point, const vec3d *sphere_center_start, c
 	float t1, t2;
 
 	// find the time and position of the ray-plane intersection
-	D = -vm_vec_dotprod( plane_normal, plane_point );
-	xs0_dot_norm = vm_vec_dotprod( plane_normal, sphere_center_start );
-	vs_dot_norm  = vm_vec_dotprod( plane_normal, sphere_velocity);
+	D = -vm_vec_dot( plane_normal, plane_point );
+	xs0_dot_norm = vm_vec_dot( plane_normal, sphere_center_start );
+	vs_dot_norm  = vm_vec_dot( plane_normal, sphere_velocity);
 
 	// protect against divide by zero
 	if (fl_abs(vs_dot_norm) > 1e-30) {
@@ -606,9 +606,9 @@ int fvi_sphere_perp_edge(vec3d *intersect_point, const vec3d *sphere_center_star
 	vm_project_point_onto_plane(&Xs_proj, sphere_center_start, &z_hat, &V0);
 
 	vec3d plane_coord;
-	plane_coord.xyz.x = vm_vec_dotprod(&Xs_proj, &x_hat);
-	plane_coord.xyz.y = vm_vec_dotprod(&Xe_proj, &y_hat);
-	plane_coord.xyz.z = vm_vec_dotprod(&Xe_proj, &z_hat);
+	plane_coord.xyz.x = vm_vec_dot(&Xs_proj, &x_hat);
+	plane_coord.xyz.y = vm_vec_dot(&Xe_proj, &y_hat);
+	plane_coord.xyz.z = vm_vec_dot(&Xe_proj, &z_hat);
 
 	// determime the position on the edge line
 	vm_vec_copy_scale( intersect_point, &x_hat, plane_coord.xyz.x );
@@ -620,7 +620,7 @@ int fvi_sphere_perp_edge(vec3d *intersect_point, const vec3d *sphere_center_star
 	vec3d temp_vec;
 
 	vm_vec_sub( &temp_vec, intersect_point, &V0 );
-	edge_parameter = vm_vec_dotprod( &temp_vec, &x_hat );
+	edge_parameter = vm_vec_dot( &temp_vec, &x_hat );
 
 	if ( edge_parameter < 0 || edge_parameter > max_edge_parameter ) {
 		return 0;
@@ -647,7 +647,7 @@ static int check_sphere_point(const vec3d *point, const vec3d *sphere_start, con
 	vm_vec_sub( &delta_x, sphere_start, point );
 	delta_x_sqr = vm_vec_mag_squared( &delta_x );
 	vs_sqr = vm_vec_mag_squared( sphere_vel );
-	delta_x_dot_vs = vm_vec_dotprod( &delta_x, sphere_vel );
+	delta_x_dot_vs = vm_vec_dot( &delta_x, sphere_vel );
 
 	float discriminant = delta_x_dot_vs*delta_x_dot_vs - vs_sqr*(delta_x_sqr - radius*radius);
 	if (discriminant < 0) {
@@ -726,10 +726,10 @@ int fvi_polyedge_sphereline(vec3d *hit_point, const vec3d *xs0, const vec3d *vs,
 		// First find the closest intersection between the edge_line and the sphere_line.
 		vm_vec_sub(&delta_x, xs0, &v0);
 
-		delta_x_dot_ve = vm_vec_dotprod(&delta_x, &ve);
-		delta_x_dot_vs = vm_vec_dotprod(&delta_x, vs);
+		delta_x_dot_ve = vm_vec_dot(&delta_x, &ve);
+		delta_x_dot_vs = vm_vec_dot(&delta_x, vs);
 		delta_x_sqr = vm_vec_mag_squared(&delta_x);
-		ve_dot_vs = vm_vec_dotprod(&ve, vs);
+		ve_dot_vs = vm_vec_dot(&ve, vs);
 		ve_sqr = vm_vec_mag_squared(&ve);
 
 		/*
@@ -858,7 +858,7 @@ TryVertex:
 		// try V1 
 		vm_vec_sub( &delta_x, xs0, &v1 );
 		delta_x_sqr = vm_vec_mag_squared( &delta_x );
-		delta_x_dot_vs = vm_vec_dotprod( &delta_x, vs );
+		delta_x_dot_vs = vm_vec_dot( &delta_x, vs );
 		int v1_hit;
 
 		B = delta_x_dot_vs;
@@ -939,7 +939,7 @@ void fvi_closest_point_on_line_segment(vec3d *closest_point, const vec3d *fixed_
 
 	vm_vec_sub(&line_velocity, line_point2, line_point1);
 	vm_vec_sub(&delta_x, line_point1, fixed_point);
-	t = -vm_vec_dotprod(&delta_x, &line_velocity) / vm_vec_mag_squared(&line_velocity);
+	t = -vm_vec_dot(&delta_x, &line_velocity) / vm_vec_mag_squared(&line_velocity);
 
 	// Constrain t to be in range [0,1]
 	if (t < 0) {
@@ -992,7 +992,7 @@ int fvi_check_sphere_sphere(const vec3d *x_p0, const vec3d *x_p1, const vec3d *x
 	vm_vec_add2(&delta_v, x_p0);
 	vm_vec_sub2(&delta_v, x_p1);
 
-	delta_x_dot_delta_v = vm_vec_dotprod(&delta_x, &delta_v);
+	delta_x_dot_delta_v = vm_vec_dot(&delta_x, &delta_v);
 	delta_v_sqr = vm_vec_mag_squared(&delta_v);
 
 	discriminant = delta_x_dot_delta_v*delta_x_dot_delta_v - delta_v_sqr*(delta_x_sqr - separation*separation);
@@ -1074,8 +1074,8 @@ void fvi_closest_line_line(const vec3d *x0, const vec3d *vx, const vec3d *y0, co
 
 	denominator = vm_vec_mag_squared(&vx_cross_vy);
 
-	*x_time = vm_vec_dotprod(&delta_l_cross_vy, &vx_cross_vy) / denominator; 
-	*y_time = vm_vec_dotprod(&delta_l_cross_vx, &vx_cross_vy) / denominator; 
+	*x_time = vm_vec_dot(&delta_l_cross_vy, &vx_cross_vy) / denominator; 
+	*y_time = vm_vec_dot(&delta_l_cross_vx, &vx_cross_vy) / denominator; 
 }
 
 // --------------------------------------------------------------------------------------------------------------------

--- a/code/math/vecmat.cpp
+++ b/code/math/vecmat.cpp
@@ -967,7 +967,7 @@ vec3d *vm_vec_rotate(vec3d *dest, const vec3d *src, const matrix *m)
 //returns ptr to dest vector
 //dest CANNOT equal source
 // This is a faster replacement for this common code sequence:
-//    vm_copy_transpose_matrix(&tempm,src_matrix);
+//    vm_copy_transpose(&tempm,src_matrix);
 //    vm_vec_rotate(dst_vec,src_vect,&tempm);
 // Replace with:
 //    vm_vec_unrotate(dst_vec,src_vect, src_matrix)
@@ -1003,7 +1003,7 @@ matrix *vm_transpose(matrix *m)
 
 //copy and transpose a matrix. returns ptr to matrix
 //dest CANNOT equal source. use vm_transpose() if this is the case
-matrix *vm_copy_transpose_matrix(matrix *dest, const matrix *src)
+matrix *vm_copy_transpose(matrix *dest, const matrix *src)
 {
 	Assert(dest != src);
 
@@ -1890,7 +1890,7 @@ void vm_matrix_interpolate(const matrix *goal_orient, const matrix *curr_orient,
 
 	//	FIND ROTATION NEEDED FOR GOAL
 	// goal_orient = R curr_orient,  so R = goal_orient curr_orient^-1
-	vm_copy_transpose_matrix(&Mtemp1, curr_orient);				// Mtemp1 = curr ^-1
+	vm_copy_transpose(&Mtemp1, curr_orient);				// Mtemp1 = curr ^-1
 	vm_matrix_x_matrix(&rot_matrix, &Mtemp1, goal_orient);	// R = goal * Mtemp1
 	vm_orthogonalize_matrix(&rot_matrix);
 	vm_matrix_to_rot_axis_and_angle(&rot_matrix, &theta, &rot_axis);		// determines angle and rotation axis from curr to goal
@@ -2032,7 +2032,7 @@ void get_camera_limits(const matrix *start_camera, const matrix *end_camera, flo
 	vec3d angle;
 
 	// determine the necessary rotation matrix
-	vm_copy_transpose_matrix(&temp, start_camera);
+	vm_copy_transpose(&temp, start_camera);
 	vm_matrix_x_matrix(&rot_matrix, &temp, end_camera);
 	vm_orthogonalize_matrix(&rot_matrix);
 
@@ -2402,7 +2402,7 @@ void vm_estimate_next_orientation(const matrix *last_orient, const matrix *curre
 
 	matrix Mtemp;
 	matrix Rot_matrix;
-	vm_copy_transpose_matrix(&Mtemp, last_orient);				// Mtemp = (L)^-1
+	vm_copy_transpose(&Mtemp, last_orient);				// Mtemp = (L)^-1
 	vm_matrix_x_matrix(&Rot_matrix, &Mtemp, current_orient);	// R = C Mtemp1
 	vm_matrix_x_matrix(next_orient, current_orient, &Rot_matrix);
 }

--- a/code/math/vecmat.cpp
+++ b/code/math/vecmat.cpp
@@ -990,7 +990,7 @@ vec3d *vm_vec_unrotate(vec3d *dest, const vec3d *src, const matrix *m)
 }
 
 //transpose a matrix in place. returns ptr to matrix
-matrix *vm_transpose_matrix(matrix *m)
+matrix *vm_transpose(matrix *m)
 {
 	float t;
 
@@ -1002,7 +1002,7 @@ matrix *vm_transpose_matrix(matrix *m)
 }
 
 //copy and transpose a matrix. returns ptr to matrix
-//dest CANNOT equal source. use vm_transpose_matrix() if this is the case
+//dest CANNOT equal source. use vm_transpose() if this is the case
 matrix *vm_copy_transpose_matrix(matrix *dest, const matrix *src)
 {
 	Assert(dest != src);

--- a/code/math/vecmat.cpp
+++ b/code/math/vecmat.cpp
@@ -97,7 +97,7 @@ float vm_vec_projection_parallel(vec3d *component, const vec3d *src, const vec3d
 	float mag;
 	Assert( vm_vec_mag(unit_vec) > 0.999f  &&  vm_vec_mag(unit_vec) < 1.001f );
 
-	mag = vm_vec_dotprod(src, unit_vec);
+	mag = vm_vec_dot(src, unit_vec);
 	vm_vec_copy_scale(component, unit_vec, mag);
 	return mag;
 }
@@ -112,7 +112,7 @@ void vm_vec_projection_onto_plane(vec3d *projection, const vec3d *src, const vec
 	float mag;
 	Assert( vm_vec_mag(unit_normal) > 0.999f  &&  vm_vec_mag(unit_normal) < 1.001f );
 
-	mag = vm_vec_dotprod(src, unit_normal);
+	mag = vm_vec_dot(src, unit_normal);
 	*projection = *src;
 	vm_vec_scale_add2(projection, unit_normal, -mag);
 }
@@ -129,8 +129,8 @@ void vm_project_point_onto_plane(vec3d *new_point, const vec3d *point, const vec
 	float dist;
 	Assert( vm_vec_mag(plane_normal) > 0.999f  &&  vm_vec_mag(plane_normal) < 1.001f );
 
-	D = -vm_vec_dotprod(plane_point, plane_normal);
-	dist = vm_vec_dotprod(point, plane_normal) + D;
+	D = -vm_vec_dot(plane_point, plane_normal);
+	dist = vm_vec_dot(point, plane_normal) + D;
 
 	*new_point = *point;
 	vm_vec_scale_add2(new_point, plane_normal, -dist);
@@ -328,7 +328,7 @@ void vm_vec_scale2(vec3d *dest, float n, float d)
 
 //returns dot product of 2 vectors
 #ifndef _INLINE_VECMAT
-float vm_vec_dotprod(const vec3d *v0, const vec3d *v1)
+float vm_vec_dot(const vec3d *v0, const vec3d *v1)
 {
 	return (v1->xyz.x*v0->xyz.x)+(v1->xyz.y*v0->xyz.y)+(v1->xyz.z*v0->xyz.z);
 }
@@ -734,7 +734,7 @@ float vm_vec_delta_ang_norm(const vec3d *v0, const vec3d *v1, const vec3d *fvec)
 
 	if (fvec) {
 		vm_vec_cross(&t,v0,v1);
-		if ( vm_vec_dotprod(&t,fvec) < 0.0 )	{
+		if ( vm_vec_dot(&t,fvec) < 0.0 )	{
 			a = -a;
 		}
 	}
@@ -2103,7 +2103,7 @@ void vm_forward_interpolate(const vec3d *goal_f, const matrix *orient, const vec
 	if (t > 1.0f)
 		t = 1.0f;
 
-	z_dotprod = vm_vec_dotprod( &orient->vec.fvec, goal_f );
+	z_dotprod = vm_vec_dot( &orient->vec.fvec, goal_f );
 
 	if ( t < SMALLER_NUM )  {
 		if ( z_dotprod > 0.0f )
@@ -2540,7 +2540,7 @@ int vm_vec_dist_to_line(const vec3d *p, const vec3d *l0, const vec3d *l1, vec3d 
 	b_mag = vm_vec_copy_normalize(&c, &b);	
 
 	// calculate component
-	comp = vm_vec_dotprod(&a, &b) / b_mag;
+	comp = vm_vec_dot(&a, &b) / b_mag;
 
 	// stuff nearest
 	vm_vec_scale_add(nearest, l0, &c, comp);
@@ -2580,7 +2580,7 @@ void vm_vec_dist_squared_to_line(const vec3d *p, const vec3d *l0, const vec3d *l
 	b_mag = vm_vec_copy_normalize(&c, &b);	
 
 	// calculate component
-	comp = vm_vec_dotprod(&a, &b) / b_mag;
+	comp = vm_vec_dot(&a, &b) / b_mag;
 
 	// stuff nearest
 	vm_vec_scale_add(nearest, l0, &c, comp);

--- a/code/math/vecmat.cpp
+++ b/code/math/vecmat.cpp
@@ -664,7 +664,7 @@ vec3d *vm_vec_normal(vec3d *dest, const vec3d *p0, const vec3d *p1, const vec3d 
 //product of the magnitudes of the two source vectors.  This means it is
 //quite easy for this routine to overflow and underflow.  Be careful that
 //your inputs are ok.
-vec3d *vm_vec_crossprod(vec3d *dest, const vec3d *src0, const vec3d *src1)
+vec3d *vm_vec_cross(vec3d *dest, const vec3d *src0, const vec3d *src1)
 {
 	dest->xyz.x = (src0->xyz.y * src1->xyz.z) - (src0->xyz.z * src1->xyz.y);
 	dest->xyz.y = (src0->xyz.z * src1->xyz.x) - (src0->xyz.x * src1->xyz.z);
@@ -697,7 +697,7 @@ vec3d *vm_vec_perp(vec3d *dest, const vec3d *p0, const vec3d *p1,const vec3d *p2
 	vm_vec_sub(&t0,p1,p0);
 	vm_vec_sub(&t1,p2,p1);
 
-	return vm_vec_crossprod(dest,&t0,&t1);
+	return vm_vec_cross(dest,&t0,&t1);
 }
 
 
@@ -859,7 +859,7 @@ void vm_vector_2_matrix_gen_vectors(matrix *m)
 
 		vm_vec_normalize(xvec);
 
-		vm_vec_crossprod(yvec,zvec,xvec);
+		vm_vec_cross(yvec,zvec,xvec);
 
 	}
 }
@@ -886,25 +886,25 @@ matrix *vm_vector_2_matrix(matrix *m, const vec3d *fvec, const vec3d *uvec, cons
 		else {                      //use right vec
 			vm_vec_copy_normalize(xvec,rvec);
 
-			vm_vec_crossprod(yvec,zvec,xvec);
+			vm_vec_cross(yvec,zvec,xvec);
 
 			//normalize new perpendicular vector
 			vm_vec_normalize(yvec);
 
 			//now recompute right vector, in case it wasn't entirely perpendiclar
-			vm_vec_crossprod(xvec,yvec,zvec);
+			vm_vec_cross(xvec,yvec,zvec);
 		}
 	}
 	else {      //use up vec
 		vm_vec_copy_normalize(yvec,uvec);
 
-		vm_vec_crossprod(xvec,yvec,zvec);
+		vm_vec_cross(xvec,yvec,zvec);
 
 		//normalize new perpendicular vector
 		vm_vec_normalize(xvec);
 
 		//now recompute up vector, in case it wasn't entirely perpendiclar
-		vm_vec_crossprod(yvec,zvec,xvec);
+		vm_vec_cross(yvec,zvec,xvec);
 	}
 	return m;
 }
@@ -925,23 +925,23 @@ matrix *vm_vector_2_matrix_norm(matrix *m, const vec3d *fvec, const vec3d *uvec,
 			vm_vector_2_matrix_gen_vectors(m);
 		}
 		else {                      //use right vec
-			vm_vec_crossprod(yvec,zvec,xvec);
+			vm_vec_cross(yvec,zvec,xvec);
 
 			//normalize new perpendicular vector
 			vm_vec_normalize(yvec);
 
 			//now recompute right vector, in case it wasn't entirely perpendiclar
-			vm_vec_crossprod(xvec,yvec,zvec);
+			vm_vec_cross(xvec,yvec,zvec);
 		}
 	}
 	else {      //use up vec
-		vm_vec_crossprod(xvec,yvec,zvec);
+		vm_vec_cross(xvec,yvec,zvec);
 
 		//normalize new perpendicular vector
 		vm_vec_normalize(xvec);
 
 		//now recompute up vector, in case it wasn't entirely perpendiclar
-		vm_vec_crossprod(yvec,zvec,xvec);
+		vm_vec_cross(yvec,zvec,xvec);
 	}
 	return m;
 }
@@ -1284,7 +1284,7 @@ void vm_orthogonalize_matrix(matrix *m_src)
 				vm_vec_make(&m->vec.uvec, 0.0f, 1.0f, 0.0f);
 
 		} else {  // use the right vector to figure up vector
-			vm_vec_crossprod(&m->vec.uvec, &m->vec.fvec, &m_src->vec.rvec);
+			vm_vec_cross(&m->vec.uvec, &m->vec.fvec, &m_src->vec.rvec);
 			vm_vec_normalize(&m->vec.uvec);
 		}
 
@@ -1293,13 +1293,13 @@ void vm_orthogonalize_matrix(matrix *m_src)
 	}
 
 	// use forward and up vectors as good vectors to calculate right vector
-	vm_vec_crossprod(&m->vec.rvec, &m->vec.uvec, &m->vec.fvec);
+	vm_vec_cross(&m->vec.rvec, &m->vec.uvec, &m->vec.fvec);
 		
 	//normalize new perpendicular vector
 	vm_vec_normalize(&m->vec.rvec);
 
 	//now recompute up vector, in case it wasn't entirely perpendicular
-	vm_vec_crossprod(&m->vec.uvec, &m->vec.fvec, &m->vec.rvec);
+	vm_vec_cross(&m->vec.uvec, &m->vec.fvec, &m->vec.rvec);
 	*m_src = tempm;
 }
 
@@ -1314,7 +1314,7 @@ void vm_fix_matrix(matrix *m)
 	rmag = vm_vec_mag(&m->vec.rvec);
 	if (fmag <= 0.0f) {
 		if ((umag > 0.0f) && (rmag > 0.0f) && !vm_test_parallel(&m->vec.uvec, &m->vec.rvec)) {
-			vm_vec_crossprod(&m->vec.fvec, &m->vec.uvec, &m->vec.rvec);
+			vm_vec_cross(&m->vec.fvec, &m->vec.uvec, &m->vec.rvec);
 			vm_vec_normalize(&m->vec.fvec);
 
 		} else if (umag > 0.0f) {
@@ -1337,7 +1337,7 @@ void vm_fix_matrix(matrix *m)
 				vm_vec_make(&m->vec.uvec, 0.0f, 1.0f, 0.0f);
 
 		} else {  // use the right vector to figure up vector
-			vm_vec_crossprod(&m->vec.uvec, &m->vec.fvec, &m->vec.rvec);
+			vm_vec_cross(&m->vec.uvec, &m->vec.fvec, &m->vec.rvec);
 			vm_vec_normalize(&m->vec.uvec);
 		}
 
@@ -1346,13 +1346,13 @@ void vm_fix_matrix(matrix *m)
 
 	// we now have both valid and normalized forward and up vectors
 
-	vm_vec_crossprod(&m->vec.rvec, &m->vec.uvec, &m->vec.fvec);
+	vm_vec_cross(&m->vec.rvec, &m->vec.uvec, &m->vec.fvec);
 		
 	//normalize new perpendicular vector
 	vm_vec_normalize(&m->vec.rvec);
 
 	//now recompute up vector, in case it wasn't entirely perpendiclar
-	vm_vec_crossprod(&m->vec.uvec, &m->vec.fvec, &m->vec.rvec);
+	vm_vec_cross(&m->vec.uvec, &m->vec.fvec, &m->vec.rvec);
 }
 
 //Rotates the orient matrix by the angles in tangles and then
@@ -2097,7 +2097,7 @@ void vm_forward_interpolate(const vec3d *goal_f, const matrix *orient, const vec
 	// FIND ROTATION NEEDED FOR GOAL
 	// rotation vector is (current fvec)  orient->vec.fvec x goal_f
 	// magnitude = asin ( magnitude of crossprod )
-	vm_vec_crossprod( &rot_axis, &orient->vec.fvec, goal_f );
+	vm_vec_cross( &rot_axis, &orient->vec.fvec, goal_f );
 
 	float t = vm_vec_mag(&rot_axis);
 	if (t > 1.0f)
@@ -2426,7 +2426,7 @@ void vm_vec_interp_constant(vec3d *out, const vec3d *v0, const vec3d *v1, float 
 	float total_ang;
 
 	// get the cross-product of the 2 vectors
-	vm_vec_crossprod(&cross, v0, v1);
+	vm_vec_cross(&cross, v0, v1);
 	vm_vec_normalize(&cross);
 
 	// get the total angle between the 2 vectors

--- a/code/math/vecmat.h
+++ b/code/math/vecmat.h
@@ -281,11 +281,10 @@ float vm_vec_normalized_dir_quick(vec3d *dest, const vec3d *end, const vec3d *st
 
 ////returns dot product of two vectors
 #ifdef _INLINE_VECMAT
-#define vm_vec_dotprod( v0, v1 ) (((v1)->xyz.x*(v0)->xyz.x)+((v1)->xyz.y*(v0)->xyz.y)+((v1)->xyz.z*(v0)->xyz.z))
+#define vm_vec_dot( v0, v1 ) (((v1)->xyz.x*(v0)->xyz.x)+((v1)->xyz.y*(v0)->xyz.y)+((v1)->xyz.z*(v0)->xyz.z))
 #define vm_vec_dot( v0, v1 ) (((v1)->xyz.x*(v0)->xyz.x)+((v1)->xyz.y*(v0)->xyz.y)+((v1)->xyz.z*(v0)->xyz.z))
 #else
-float vm_vec_dotprod(const vec3d *v0, const vec3d *v1);
-#define vm_vec_dot vm_vec_dotprod
+float vm_vec_dot(const vec3d *v0, const vec3d *v1);
 #endif
 
 #ifdef _INLINE_VECMAT

--- a/code/math/vecmat.h
+++ b/code/math/vecmat.h
@@ -360,11 +360,10 @@ vec3d *vm_vec_rotate(vec3d *dest, const vec3d *src, const matrix *m);
 vec3d *vm_vec_unrotate(vec3d *dest, const vec3d *src, const matrix *m);
 
 //transpose a matrix in place. returns ptr to matrix
-matrix *vm_transpose_matrix(matrix *m);
-#define vm_transpose(m) vm_transpose_matrix(m)
+matrix *vm_transpose(matrix *m);
 
 //copy and transpose a matrix. returns ptr to matrix
-//dest CANNOT equal source. use vm_transpose_matrix() if this is the case
+//dest CANNOT equal source. use vm_transpose() if this is the case
 matrix *vm_copy_transpose_matrix(matrix *dest, const matrix *src);
 #define vm_copy_transpose(dest,src) vm_copy_transpose_matrix((dest),(src))
 

--- a/code/math/vecmat.h
+++ b/code/math/vecmat.h
@@ -295,8 +295,7 @@ float vm_vec_dot3(float x, float y, float z, vec3d *v);
 
 //computes cross product of two vectors. returns ptr to dest
 //dest CANNOT equal either source
-vec3d *vm_vec_crossprod(vec3d *dest, const vec3d *src0, const vec3d *src1);
-#define vm_vec_cross vm_vec_crossprod
+vec3d *vm_vec_cross(vec3d *dest, const vec3d *src0, const vec3d *src1);
 
 // test if 2 vectors are parallel or not.
 int vm_test_parallel(const vec3d *src0, const vec3d *src1);

--- a/code/math/vecmat.h
+++ b/code/math/vecmat.h
@@ -349,7 +349,7 @@ vec3d *vm_vec_rotate(vec3d *dest, const vec3d *src, const matrix *m);
 //returns ptr to dest vector
 //dest CANNOT equal source
 // This is a faster replacement for this common code sequence:
-//    vm_copy_transpose_matrix(&tempm,src_matrix);
+//    vm_copy_transpose(&tempm,src_matrix);
 //    vm_vec_rotate(dst_vec,src_vect,&tempm);
 // Replace with:
 //    vm_vec_unrotate(dst_vec,src_vect, src_matrix)
@@ -364,8 +364,8 @@ matrix *vm_transpose(matrix *m);
 
 //copy and transpose a matrix. returns ptr to matrix
 //dest CANNOT equal source. use vm_transpose() if this is the case
-matrix *vm_copy_transpose_matrix(matrix *dest, const matrix *src);
-#define vm_copy_transpose(dest,src) vm_copy_transpose_matrix((dest),(src))
+matrix *vm_copy_transpose(matrix *dest, const matrix *src);
+#define vm_copy_transpose(dest,src) vm_copy_transpose((dest),(src))
 
 //mulitply 2 matrices, fill in dest.  returns ptr to dest
 //dest CANNOT equal either source

--- a/code/math/vecmat.h
+++ b/code/math/vecmat.h
@@ -365,7 +365,6 @@ matrix *vm_transpose(matrix *m);
 //copy and transpose a matrix. returns ptr to matrix
 //dest CANNOT equal source. use vm_transpose() if this is the case
 matrix *vm_copy_transpose(matrix *dest, const matrix *src);
-#define vm_copy_transpose(dest,src) vm_copy_transpose((dest),(src))
 
 //mulitply 2 matrices, fill in dest.  returns ptr to dest
 //dest CANNOT equal either source

--- a/code/model/modelcollide.cpp
+++ b/code/model/modelcollide.cpp
@@ -1206,7 +1206,7 @@ NoHit:
 					vm_rotate_matrix_by_angles(&rotation_matrix, &angs);
 
 					matrix inv_orientation;
-					vm_copy_transpose_matrix(&inv_orientation, &csm->orientation);
+					vm_copy_transpose(&inv_orientation, &csm->orientation);
 
 					vm_matrix_x_matrix(&tm, &rotation_matrix, &inv_orientation);
 				}
@@ -1376,7 +1376,7 @@ void model_collide_preprocess_subobj(vec3d *pos, matrix *orient, polymodel *pm, 
 			vm_rotate_matrix_by_angles(&rotation_matrix, &angs);
 
 			matrix inv_orientation;
-			vm_copy_transpose_matrix(&inv_orientation, &csm->orientation);
+			vm_copy_transpose(&inv_orientation, &csm->orientation);
 
 			vm_matrix_x_matrix(&tm, &rotation_matrix, &inv_orientation);
 		}

--- a/code/model/modelcollide.cpp
+++ b/code/model/modelcollide.cpp
@@ -277,7 +277,7 @@ static void mc_check_sphereline_face( int nv, vec3d ** verts, vec3d * plane_pnt,
 				//mprintf(("Estimated radius error: Estimate %f, actual %f Mc->radius\n", temp_dist, Mc->radius));
 			}
 			vm_vec_sub( &temp_dir, &hit_point, &temp_sphere );
-			// Assert( vm_vec_dotprod( &temp_dir, &Mc_direction ) > 0 );
+			// Assert( vm_vec_dot( &temp_dir, &Mc_direction ) > 0 );
 			*/
 		}
 	}
@@ -305,7 +305,7 @@ static void mc_check_sphereline_face( int nv, vec3d ** verts, vec3d * plane_pnt,
 				//mprintf(("Estimated radius error: Estimate %f, actual %f Mc->radius\n", temp_dist, Mc->radius));
 			}
 			vm_vec_sub( &temp_dir, &hit_point, &temp_sphere );
-//			Assert( vm_vec_dotprod( &temp_dir, &Mc_direction ) > 0 );
+//			Assert( vm_vec_dot( &temp_dir, &Mc_direction ) > 0 );
 			*/
 
 			if ( (Mc->num_hits==0) || (sphere_time < Mc->hit_dist) ) {

--- a/code/model/modelinterp.cpp
+++ b/code/model/modelinterp.cpp
@@ -2239,7 +2239,7 @@ void moldel_calc_facing_pts( vec3d *top, vec3d *bot, vec3d *fvec, vec3d *pos, fl
 	vm_vec_sub( &rvec, Eyeposition, &temp );
 	vm_vec_normalize( &rvec );	
 
-	vm_vec_crossprod(&uvec,fvec,&rvec);
+	vm_vec_cross(&uvec,fvec,&rvec);
 	vm_vec_normalize(&uvec);
 
 	vm_vec_scale_add( top, &temp, &uvec, w/2.0f );

--- a/code/model/modelinterp.cpp
+++ b/code/model/modelinterp.cpp
@@ -1628,7 +1628,7 @@ void model_interp_subcall(polymodel * pm, int mn, int detail_level)
 	vm_rotate_matrix_by_angles(&rotation_matrix, &pm->submodel[mn].angs);
 
 	matrix inv_orientation;
-	vm_copy_transpose_matrix(&inv_orientation, &pm->submodel[mn].orientation);
+	vm_copy_transpose(&inv_orientation, &pm->submodel[mn].orientation);
 
 	matrix submodel_matrix;
 	vm_matrix_x_matrix(&submodel_matrix, &rotation_matrix, &inv_orientation);
@@ -4771,7 +4771,7 @@ void model_render_children_buffers_DEPRECATED(polymodel *pm, int mn, int detail_
 	vm_rotate_matrix_by_angles(&rotation_matrix, &ang);
 
 	matrix inv_orientation;
-	vm_copy_transpose_matrix(&inv_orientation, &model->orientation);
+	vm_copy_transpose(&inv_orientation, &model->orientation);
 
 	matrix submodel_matrix;
 	vm_matrix_x_matrix(&submodel_matrix, &rotation_matrix, &inv_orientation);

--- a/code/model/modelread.cpp
+++ b/code/model/modelread.cpp
@@ -1725,7 +1725,7 @@ int read_model_file(polymodel * pm, char *filename, int n_subsystems, model_subs
 
 						vec3d diff;
 						vm_vec_normalized_dir(&diff, &bay->pnt[0], &bay->pnt[1]);
-						float dot = vm_vec_dotprod(&diff, &bay->norm[0]);
+						float dot = vm_vec_dot(&diff, &bay->norm[0]);
 						if(fl_abs(dot) > 0.99f) {
 							Warning(LOCATION, "Model '%s', docking port '%s' has docking slot positions that lie on the same axis as the docking normal.  This will cause a NULL VEC crash when docked to another ship.  A new docking normal will be generated.", filename, bay->name);
 
@@ -3538,7 +3538,7 @@ void submodel_look_at(polymodel *pm, int mn)
 
 	vec3d c;
 	vm_vec_crossprod(&c, &l, &mp);
-	float dot=vm_vec_dotprod(&l,&mp);
+	float dot=vm_vec_dot(&l,&mp);
 	if (dot>=0.0f) {
 		*a = asin(c.a1d[axis]);
 	} else {

--- a/code/model/modelread.cpp
+++ b/code/model/modelread.cpp
@@ -1472,8 +1472,8 @@ int read_model_file(polymodel * pm, char *filename, int n_subsystems, model_subs
 						vm_vec_normalize(&orient->vec.uvec);
 						vm_vec_normalize(&orient->vec.fvec);
 
-						vm_vec_crossprod(&orient->vec.rvec, &orient->vec.uvec, &orient->vec.fvec);
-						vm_vec_crossprod(&orient->vec.fvec, &orient->vec.rvec, &orient->vec.uvec);
+						vm_vec_cross(&orient->vec.rvec, &orient->vec.uvec, &orient->vec.fvec);
+						vm_vec_cross(&orient->vec.fvec, &orient->vec.rvec, &orient->vec.uvec);
 
 						vm_vec_normalize(&orient->vec.fvec);
 						vm_vec_normalize(&orient->vec.rvec);
@@ -3537,7 +3537,7 @@ void submodel_look_at(polymodel *pm, int mn)
 	vm_vec_normalize(&l);
 
 	vec3d c;
-	vm_vec_crossprod(&c, &l, &mp);
+	vm_vec_cross(&c, &l, &mp);
 	float dot=vm_vec_dot(&l,&mp);
 	if (dot>=0.0f) {
 		*a = asin(c.a1d[axis]);

--- a/code/model/modelread.cpp
+++ b/code/model/modelread.cpp
@@ -3235,7 +3235,7 @@ void model_find_obj_dir(vec3d *w_vec, vec3d *m_vec, object *pship_obj, int sub_m
 		vm_rotate_matrix_by_angles(&rotation_matrix, &pm->submodel[mn].angs);
 
 		matrix inv_orientation;
-		vm_copy_transpose_matrix(&inv_orientation, &pm->submodel[mn].orientation);
+		vm_copy_transpose(&inv_orientation, &pm->submodel[mn].orientation);
 
 		vm_matrix_x_matrix(&m, &rotation_matrix, &inv_orientation);
 
@@ -3271,7 +3271,7 @@ void model_instance_find_obj_dir(vec3d *w_vec, vec3d *m_vec, object *pship_obj, 
 		vm_rotate_matrix_by_angles(&rotation_matrix, &pmi->submodel[mn].angs);
 
 		matrix inv_orientation;
-		vm_copy_transpose_matrix(&inv_orientation, &pm->submodel[mn].orientation);
+		vm_copy_transpose(&inv_orientation, &pm->submodel[mn].orientation);
 
 		vm_matrix_x_matrix(&m, &rotation_matrix, &inv_orientation);
 
@@ -3307,7 +3307,7 @@ void model_rot_sub_into_obj(vec3d * outpnt, vec3d *mpnt,polymodel *pm, int sub_m
 		vm_rotate_matrix_by_angles(&rotation_matrix, &pm->submodel[mn].angs);
  
 		matrix inv_orientation;
-		vm_copy_transpose_matrix(&inv_orientation, &pm->submodel[mn].orientation);
+		vm_copy_transpose(&inv_orientation, &pm->submodel[mn].orientation);
 
 		vm_matrix_x_matrix(&m, &rotation_matrix, &inv_orientation);
 
@@ -3933,7 +3933,7 @@ void make_submodel_world_matrix(polymodel *pm, int sn, vec3d*v){
 	vm_angles_2_matrix(&a, &pm->submodel[sn].angs);
 	if (!IS_MAT_NULL(&pm->submodel[sn].orientation)) {
 		matrix inv, f;
-		vm_copy_transpose_matrix(&inv, &pm->submodel[sn].orientation);
+		vm_copy_transpose(&inv, &pm->submodel[sn].orientation);
 		vm_matrix_x_matrix(&f, &a, &inv);
 		vm_matrix_x_matrix(&a, &pm->submodel[sn].orientation, &f);
 	}
@@ -3983,7 +3983,7 @@ void model_find_world_point(vec3d * outpnt, vec3d *mpnt,int model_num,int sub_mo
 		vm_rotate_matrix_by_angles(&rotation_matrix, &pm->submodel[mn].angs);
 
 		matrix inv_orientation;
-		vm_copy_transpose_matrix(&inv_orientation, &pm->submodel[mn].orientation);
+		vm_copy_transpose(&inv_orientation, &pm->submodel[mn].orientation);
 
 		vm_matrix_x_matrix(&m, &rotation_matrix, &inv_orientation);
 
@@ -4020,7 +4020,7 @@ void model_instance_find_world_point(vec3d * outpnt, vec3d *mpnt, int model_num,
 		vm_rotate_matrix_by_angles(&rotation_matrix, &pmi->submodel[mn].angs);
 
 		matrix inv_orientation;
-		vm_copy_transpose_matrix(&inv_orientation, &pm->submodel[mn].orientation);
+		vm_copy_transpose(&inv_orientation, &pm->submodel[mn].orientation);
 
 		vm_matrix_x_matrix(&m, &rotation_matrix, &inv_orientation);
 
@@ -4072,7 +4072,7 @@ void world_find_model_point(vec3d *out, vec3d *world_pt, polymodel *pm, int subm
 	vm_rotate_matrix_by_angles(&rotation_matrix, &pm->submodel[submodel_num].angs);
 
 	matrix inv_orientation;
-	vm_copy_transpose_matrix(&inv_orientation, &pm->submodel[submodel_num].orientation);
+	vm_copy_transpose(&inv_orientation, &pm->submodel[submodel_num].orientation);
 
 	vm_matrix_x_matrix(&m, &rotation_matrix, &inv_orientation);
 
@@ -4105,7 +4105,7 @@ void world_find_model_instance_point(vec3d *out, vec3d *world_pt, polymodel *pm,
 	vm_rotate_matrix_by_angles(&rotation_matrix, &pmi->submodel[submodel_num].angs);
 
 	matrix inv_orientation;
-	vm_copy_transpose_matrix(&inv_orientation, &pm->submodel[submodel_num].orientation);
+	vm_copy_transpose(&inv_orientation, &pm->submodel[submodel_num].orientation);
 
 	vm_matrix_x_matrix(&m, &rotation_matrix, &inv_orientation);
 
@@ -4140,7 +4140,7 @@ void find_submodel_instance_point(vec3d *outpnt, object *pship_obj, int submodel
 			rotation_matrix = pm->submodel[parent_mn].orientation;
 			vm_rotate_matrix_by_angles(&rotation_matrix, &pmi->submodel[parent_mn].angs);
 
-			vm_copy_transpose_matrix(&inv_orientation, &pm->submodel[parent_mn].orientation);
+			vm_copy_transpose(&inv_orientation, &pm->submodel[parent_mn].orientation);
 
 			vm_matrix_x_matrix(&submodel_instance_matrix, &rotation_matrix, &inv_orientation);
 
@@ -4187,7 +4187,7 @@ void find_submodel_instance_point_normal(vec3d *outpnt, vec3d *outnorm, object *
 			rotation_matrix = pm->submodel[submodel_num].orientation;
 			vm_rotate_matrix_by_angles(&rotation_matrix, &pmi->submodel[submodel_num].angs);
 
-			vm_copy_transpose_matrix(&inv_orientation, &pm->submodel[submodel_num].orientation);
+			vm_copy_transpose(&inv_orientation, &pm->submodel[submodel_num].orientation);
 
 			vm_matrix_x_matrix(&submodel_instance_matrix, &rotation_matrix, &inv_orientation);
 
@@ -4205,7 +4205,7 @@ void find_submodel_instance_point_normal(vec3d *outpnt, vec3d *outnorm, object *
 		rotation_matrix = pm->submodel[parent_model_num].orientation;
 		vm_rotate_matrix_by_angles(&rotation_matrix, &pmi->submodel[parent_model_num].angs);
 
-		vm_copy_transpose_matrix(&inv_orientation, &pm->submodel[parent_model_num].orientation);
+		vm_copy_transpose(&inv_orientation, &pm->submodel[parent_model_num].orientation);
 
 		vm_matrix_x_matrix(&submodel_instance_matrix, &rotation_matrix, &inv_orientation);
 
@@ -4257,7 +4257,7 @@ void find_submodel_instance_point_orient(vec3d *outpnt, matrix *outorient, objec
 			rotation_matrix = pm->submodel[submodel_num].orientation;
 			vm_rotate_matrix_by_angles(&rotation_matrix, &pmi->submodel[submodel_num].angs);
 
-			vm_copy_transpose_matrix(&inv_orientation, &pm->submodel[submodel_num].orientation);
+			vm_copy_transpose(&inv_orientation, &pm->submodel[submodel_num].orientation);
 
 			vm_matrix_x_matrix(&submodel_instance_matrix, &rotation_matrix, &inv_orientation);
 
@@ -4275,7 +4275,7 @@ void find_submodel_instance_point_orient(vec3d *outpnt, matrix *outorient, objec
 		rotation_matrix = pm->submodel[parent_model_num].orientation;
 		vm_rotate_matrix_by_angles(&rotation_matrix, &pmi->submodel[parent_model_num].angs);
 
-		vm_copy_transpose_matrix(&inv_orientation, &pm->submodel[parent_model_num].orientation);
+		vm_copy_transpose(&inv_orientation, &pm->submodel[parent_model_num].orientation);
 
 		vm_matrix_x_matrix(&submodel_instance_matrix, &rotation_matrix, &inv_orientation);
 
@@ -4431,7 +4431,7 @@ void model_find_world_dir(vec3d * out_dir, vec3d *in_dir,int model_num, int sub_
 		vm_rotate_matrix_by_angles(&rotation_matrix, &pm->submodel[mn].angs);
 
 		matrix inv_orientation;
-		vm_copy_transpose_matrix(&inv_orientation, &pm->submodel[mn].orientation);
+		vm_copy_transpose(&inv_orientation, &pm->submodel[mn].orientation);
 
 		vm_matrix_x_matrix(&m, &rotation_matrix, &inv_orientation);
 
@@ -4468,7 +4468,7 @@ void model_instance_find_world_dir(vec3d * out_dir, vec3d *in_dir,int model_num,
 		vm_rotate_matrix_by_angles(&rotation_matrix, &pmi->submodel[mn].angs);
 
 		matrix inv_orientation;
-		vm_copy_transpose_matrix(&inv_orientation, &pm->submodel[mn].orientation);
+		vm_copy_transpose(&inv_orientation, &pm->submodel[mn].orientation);
 
 		vm_matrix_x_matrix(&m, &rotation_matrix, &inv_orientation);
 

--- a/code/model/modelrender.cpp
+++ b/code/model/modelrender.cpp
@@ -1450,7 +1450,7 @@ void model_render_children_buffers(draw_list* scene, model_render_params* interp
 	vm_rotate_matrix_by_angles(&rotation_matrix, &ang);
 
 	matrix inv_orientation;
-	vm_copy_transpose_matrix(&inv_orientation, &model->orientation);
+	vm_copy_transpose(&inv_orientation, &model->orientation);
 
 	matrix submodel_matrix;
 	vm_matrix_x_matrix(&submodel_matrix, &rotation_matrix, &inv_orientation);
@@ -2530,7 +2530,7 @@ void model_render_debug_children(polymodel *pm, int mn, int detail_level, uint d
 	vm_rotate_matrix_by_angles(&rotation_matrix, &ang);
 
 	matrix inv_orientation;
-	vm_copy_transpose_matrix(&inv_orientation, &model->orientation);
+	vm_copy_transpose(&inv_orientation, &model->orientation);
 
 	matrix submodel_matrix;
 	vm_matrix_x_matrix(&submodel_matrix, &rotation_matrix, &inv_orientation);

--- a/code/nebula/neblightning.cpp
+++ b/code/nebula/neblightning.cpp
@@ -854,7 +854,7 @@ void nebl_calc_facing_pts_smart( vec3d *top, vec3d *bot, vec3d *fvec, vec3d *pos
 	vm_vec_sub( &rvec, &Eye_position, &temp );
 	vm_vec_normalize( &rvec );	
 
-	vm_vec_crossprod(&uvec,fvec,&rvec);
+	vm_vec_cross(&uvec,fvec,&rvec);
 	vm_vec_normalize(&uvec);
 
 	vm_vec_scale_add( top, &temp, &uvec, w/2.0f );

--- a/code/network/multi_obj.cpp
+++ b/code/network/multi_obj.cpp
@@ -181,8 +181,8 @@ bool multi_oo_sort_func(const short &index1, const short &index2)
 	dist1 = vm_vec_copy_normalize(&vn1, &v1);
 	vm_vec_sub(&v2, &OO_player_obj->pos, &obj2->pos);
 	dist2 = vm_vec_copy_normalize(&vn2, &v2);
-	dot1 = vm_vec_dotprod(&OO_player_obj->orient.vec.fvec, &vn1);
-	dot2 = vm_vec_dotprod(&OO_player_obj->orient.vec.fvec, &vn2);
+	dot1 = vm_vec_dot(&OO_player_obj->orient.vec.fvec, &vn1);
+	dot2 = vm_vec_dot(&OO_player_obj->orient.vec.fvec, &vn2);
 
 	// objects in front take precedence
 	if((dot1 < 0.0f) && (dot2 >= 0.0f)){
@@ -1984,7 +1984,7 @@ void multi_oo_calc_interp_splines(int ship_index, vec3d *cur_pos, matrix *cur_or
 	if(!IS_VEC_NULL_SQ_SAFE(&v_norm) && !IS_VEC_NULL_SQ_SAFE(&v_dir)){
 		vm_vec_normalize(&v_dir);
 		vm_vec_normalize(&v_norm);	
-		if(vm_vec_dotprod(&v_dir, &v_norm) < 0.0f){
+		if(vm_vec_dot(&v_dir, &v_norm) < 0.0f){
 			*new_pos = *cur_pos;
 		}
 	}

--- a/code/object/collideshipship.cpp
+++ b/code/object/collideshipship.cpp
@@ -419,7 +419,7 @@ int ship_ship_check_collision(collision_info_struct *ship_ship_hit_info, vec3d *
 					float mass_sum = light_obj->phys_info.mass + heavy_obj->phys_info.mass;
 
 					// get comp of rel_vel perp to h_to_l_vec;
-					float mag = vm_vec_dotprod(&h_to_l_vec, &rel_vel_h) / vm_vec_mag_squared(&h_to_l_vec);
+					float mag = vm_vec_dot(&h_to_l_vec, &rel_vel_h) / vm_vec_mag_squared(&h_to_l_vec);
 					vm_vec_scale_add(&perp_rel_vel, &rel_vel_h, &h_to_l_vec, -mag);
 					vm_vec_normalize(&perp_rel_vel);
 
@@ -656,7 +656,7 @@ void calculate_ship_ship_collision_physics(collision_info_struct *ship_ship_hit_
 	// Add in effect of rotating submodel
 	vm_vec_sub2(&v_rel_m, &local_vel_from_submodel);
 
-	v_rel_normal_m = vm_vec_dotprod(&v_rel_m, &ship_ship_hit_info->collision_normal);// if less than zero, colliding contact taking place
+	v_rel_normal_m = vm_vec_dot(&v_rel_m, &ship_ship_hit_info->collision_normal);// if less than zero, colliding contact taking place
 																									// (v_slow - v_fast) dot (n_fast)
 
 	if (v_rel_normal_m > 0) {
@@ -728,7 +728,7 @@ void calculate_ship_ship_collision_physics(collision_info_struct *ship_ship_hit_
 		float rotation_factor = (heavy->type == OBJ_SHIP) ? heavy_sip->collision_physics.rotation_factor : COLLISION_ROTATION_FACTOR;
 		vm_vec_scale(&delta_rotvel_heavy, rotation_factor);		// hack decrease rotation (delta_rotvel)
 		vm_vec_crossprod(&delta_vel_from_delta_rotvel_heavy, &delta_rotvel_heavy , &ship_ship_hit_info->r_heavy);
-		heavy_denom = vm_vec_dotprod(&delta_vel_from_delta_rotvel_heavy, &ship_ship_hit_info->collision_normal);
+		heavy_denom = vm_vec_dot(&delta_vel_from_delta_rotvel_heavy, &ship_ship_hit_info->collision_normal);
 		if (heavy_denom < 0) {
 			// sanity check
 			heavy_denom = 0.0f;
@@ -752,7 +752,7 @@ void calculate_ship_ship_collision_physics(collision_info_struct *ship_ship_hit_
 		float rotation_factor = (lighter->type == OBJ_SHIP) ? light_sip->collision_physics.rotation_factor : COLLISION_ROTATION_FACTOR;
 		vm_vec_scale(&delta_rotvel_light, rotation_factor);		// hack decrease rotation (delta_rotvel)
 		vm_vec_crossprod(&delta_vel_from_delta_rotvel_light, &delta_rotvel_light, &ship_ship_hit_info->r_light);
-		light_denom = vm_vec_dotprod(&delta_vel_from_delta_rotvel_light, &ship_ship_hit_info->collision_normal);
+		light_denom = vm_vec_dot(&delta_vel_from_delta_rotvel_light, &ship_ship_hit_info->collision_normal);
 		if (light_denom < 0) {
 			// sanity check
 			light_denom = 0.0f;
@@ -1038,11 +1038,11 @@ void maybe_push_little_ship_from_fast_big_ship(object *big_obj, object *small_ob
 				// get perp vec
 				vec3d temp, perp;
 				vm_vec_sub(&temp, &small_obj->pos, &big_obj->pos);
-				vm_vec_scale_add(&perp, &temp, &big_obj->orient.vec.fvec, -vm_vec_dotprod(&temp, &big_obj->orient.vec.fvec));
+				vm_vec_scale_add(&perp, &temp, &big_obj->orient.vec.fvec, -vm_vec_dot(&temp, &big_obj->orient.vec.fvec));
 				vm_vec_normalize_quick(&perp);
 
 				// don't drive into sfc we just collided with
-				if (vm_vec_dotprod(&perp, normal) < 0) {
+				if (vm_vec_dot(&perp, normal) < 0) {
 					vm_vec_negate(&perp);
 				}
 
@@ -1357,7 +1357,7 @@ void collect_ship_ship_physics_info(object *heavier_obj, object *lighter_obj, mc
 	}
 
 	// r dot n may not be negative if hit by moving model parts.
-	float dot = vm_vec_dotprod( r_light, &ship_ship_hit_info->collision_normal );
+	float dot = vm_vec_dot( r_light, &ship_ship_hit_info->collision_normal );
 	if ( dot > 0 )
 	{
 		nprintf(("Physics", "Framecount: %i r dot normal %f > 0\n", Framecount, dot));

--- a/code/object/collideshipship.cpp
+++ b/code/object/collideshipship.cpp
@@ -859,7 +859,7 @@ void get_I_inv (matrix* I_inv, matrix* I_inv_body, matrix* orient)
 	// which is equivalent to rotating in the opposite direction (or transpose)
 
 	vm_matrix_x_matrix(&Mtemp1, I_inv_body, orient);
-	vm_copy_transpose_matrix(&Mtemp2, orient);
+	vm_copy_transpose(&Mtemp2, orient);
 	vm_matrix_x_matrix(I_inv, &Mtemp2, &Mtemp1);
 }
 

--- a/code/object/collideshipship.cpp
+++ b/code/object/collideshipship.cpp
@@ -583,7 +583,7 @@ void calculate_ship_ship_collision_physics(collision_info_struct *ship_ship_hit_
 	} else {
 		// take account the effective velocity from rotation
 		vm_vec_unrotate(&world_rotvel_heavy_m, &heavy->phys_info.rotvel, &heavy->orient);	// heavy's world rotvel before collision
-		vm_vec_crossprod(&vel_from_rotvel_heavy_m, &world_rotvel_heavy_m, &ship_ship_hit_info->r_heavy);	// heavy's velocity from rotvel before collision
+		vm_vec_cross(&vel_from_rotvel_heavy_m, &world_rotvel_heavy_m, &ship_ship_hit_info->r_heavy);	// heavy's velocity from rotvel before collision
 		vel_heavy_m = vel_from_rotvel_heavy_m;
 	}
 
@@ -638,7 +638,7 @@ void calculate_ship_ship_collision_physics(collision_info_struct *ship_ship_hit_
 		vm_vec_unrotate(&temp, &pm->submodel[ship_ship_hit_info->submodel_num].sii->pt_on_axis, &heavy->orient);
 		vm_vec_sub(&r_rot, &ship_ship_hit_info->hit_pos, &temp);
 
-		vm_vec_crossprod(&local_vel_from_submodel, &omega, &r_rot);
+		vm_vec_cross(&local_vel_from_submodel, &omega, &r_rot);
 
 		if (set_model) {
 			ship_model_stop(heavy);
@@ -649,7 +649,7 @@ void calculate_ship_ship_collision_physics(collision_info_struct *ship_ship_hit_
 	}
 
 	vm_vec_unrotate(&world_rotvel_light_m, &lighter->phys_info.rotvel, &lighter->orient);		// light's world rotvel before collision
-	vm_vec_crossprod(&vel_from_rotvel_light_m, &world_rotvel_light_m, &ship_ship_hit_info->r_light);	// light's velocity from rotvel before collision
+	vm_vec_cross(&vel_from_rotvel_light_m, &world_rotvel_light_m, &ship_ship_hit_info->r_light);	// light's velocity from rotvel before collision
 	vm_vec_add(&vel_light_m, &vel_from_rotvel_light_m, &ship_ship_hit_info->light_rel_vel);
 	vm_vec_sub(&v_rel_m, &vel_light_m, &vel_heavy_m);
 
@@ -722,12 +722,12 @@ void calculate_ship_ship_collision_physics(collision_info_struct *ship_ship_hit_
 		vm_vec_zero( &delta_rotvel_heavy );
 		heavy_denom = 1.0f / heavy->phys_info.mass;
 	} else {
-		vm_vec_crossprod(&rotational_impulse_heavy, &ship_ship_hit_info->r_heavy, &impulse);
+		vm_vec_cross(&rotational_impulse_heavy, &ship_ship_hit_info->r_heavy, &impulse);
 		get_I_inv(&heavy_I_inv, &heavy->phys_info.I_body_inv, &heavy->orient);
 		vm_vec_rotate(&delta_rotvel_heavy, &rotational_impulse_heavy, &heavy_I_inv);
 		float rotation_factor = (heavy->type == OBJ_SHIP) ? heavy_sip->collision_physics.rotation_factor : COLLISION_ROTATION_FACTOR;
 		vm_vec_scale(&delta_rotvel_heavy, rotation_factor);		// hack decrease rotation (delta_rotvel)
-		vm_vec_crossprod(&delta_vel_from_delta_rotvel_heavy, &delta_rotvel_heavy , &ship_ship_hit_info->r_heavy);
+		vm_vec_cross(&delta_vel_from_delta_rotvel_heavy, &delta_rotvel_heavy , &ship_ship_hit_info->r_heavy);
 		heavy_denom = vm_vec_dot(&delta_vel_from_delta_rotvel_heavy, &ship_ship_hit_info->collision_normal);
 		if (heavy_denom < 0) {
 			// sanity check
@@ -746,12 +746,12 @@ void calculate_ship_ship_collision_physics(collision_info_struct *ship_ship_hit_
 		vm_vec_zero( &delta_rotvel_light );
 		light_denom = 1.0f / lighter->phys_info.mass;
 	} else {
-		vm_vec_crossprod(&rotational_impulse_light, &ship_ship_hit_info->r_light, &impulse);
+		vm_vec_cross(&rotational_impulse_light, &ship_ship_hit_info->r_light, &impulse);
 		get_I_inv(&light_I_inv, &lighter->phys_info.I_body_inv, &lighter->orient);
 		vm_vec_rotate(&delta_rotvel_light, &rotational_impulse_light, &light_I_inv);
 		float rotation_factor = (lighter->type == OBJ_SHIP) ? light_sip->collision_physics.rotation_factor : COLLISION_ROTATION_FACTOR;
 		vm_vec_scale(&delta_rotvel_light, rotation_factor);		// hack decrease rotation (delta_rotvel)
-		vm_vec_crossprod(&delta_vel_from_delta_rotvel_light, &delta_rotvel_light, &ship_ship_hit_info->r_light);
+		vm_vec_cross(&delta_vel_from_delta_rotvel_light, &delta_rotvel_light, &ship_ship_hit_info->r_light);
 		light_denom = vm_vec_dot(&delta_vel_from_delta_rotvel_light, &ship_ship_hit_info->collision_normal);
 		if (light_denom < 0) {
 			// sanity check

--- a/code/object/collideshipweapon.cpp
+++ b/code/object/collideshipweapon.cpp
@@ -557,7 +557,7 @@ int check_inside_radius_for_big_ships( object *ship, object *weapon_obj, obj_pai
 	ship_speed_at_exit_sphere = estimate_ship_speed_upper_limit( ship, time_to_exit_sphere );
 	// update estimated time to exit sphere
 	time_to_exit_sphere = (ship->radius + vm_vec_dist(&ship->pos, &weapon_obj->pos)) / (weapon_obj->phys_info.max_vel.xyz.z - ship_speed_at_exit_sphere);
-	vm_vec_scale_add( &error_vel, &ship->phys_info.vel, &weapon_obj->orient.vec.fvec, -vm_vec_dotprod(&ship->phys_info.vel, &weapon_obj->orient.vec.fvec) );
+	vm_vec_scale_add( &error_vel, &ship->phys_info.vel, &weapon_obj->orient.vec.fvec, -vm_vec_dot(&ship->phys_info.vel, &weapon_obj->orient.vec.fvec) );
 	error_vel_mag = vm_vec_mag_quick( &error_vel );
 	error_vel_mag += 0.5f * (ship->phys_info.max_vel.xyz.z - error_vel_mag)*(time_to_exit_sphere/ship->phys_info.forward_accel_time_const);
 	// error_vel_mag is now average velocity over period

--- a/code/object/objcollide.cpp
+++ b/code/object/objcollide.cpp
@@ -824,7 +824,7 @@ int weapon_will_never_hit( object *obj_weapon, object *other, obj_pair * current
 			laser_vel = obj_weapon->phys_info.vel;
 			// vm_vec_copy_scale( &laser_vel, &weapon->orient.vec.fvec, max_vel_weapon );
 			delta_t = (other->radius + 10.0f) / max_vel_other;		// time to get from center to radius of other obj
-			delta_x_dot_vl = vm_vec_dotprod( &delta_x, &laser_vel );
+			delta_x_dot_vl = vm_vec_dot( &delta_x, &laser_vel );
 
 			a = max_vel_weapon*max_vel_weapon - max_vel_other*max_vel_other;
 			b = 2.0f * (delta_x_dot_vl - max_vel_other*max_vel_other*delta_t);

--- a/code/object/objectsnd.cpp
+++ b/code/object/objectsnd.cpp
@@ -321,8 +321,8 @@ int obj_snd_get_freq(int source_freq, object* source, object* observor, vec3d *s
 	vm_vec_normalized_dir(&v_os, source_pos, &observor->pos);
 	vm_vec_normalized_dir(&v_so, &observor->pos, source_pos);
 	
-	vo = vm_vec_dotprod(&v_os, &observor->phys_info.vel);
-	vs = vm_vec_dotprod(&v_so, &source->phys_info.vel);
+	vo = vm_vec_dot(&v_os, &observor->phys_info.vel);
+	vs = vm_vec_dot(&v_so, &source->phys_info.vel);
 
 	freq = source_freq * ( (SPEED_SOUND + vo) / (SPEED_SOUND - vs) );
 	return fl2i(freq);

--- a/code/parse/lua.cpp
+++ b/code/parse/lua.cpp
@@ -3719,7 +3719,7 @@ ADE_FUNC(getDotProduct, l_Vector, "vector OtherVector", "Returns dot product of 
 	if(!ade_get_args(L, "oo", l_Vector.GetPtr(&v3a), l_Vector.GetPtr(&v3b)))
 		return ade_set_error(L, "f", 0.0f);
 
-	return ade_set_args(L, "f", vm_vec_dotprod(v3a, v3b));
+	return ade_set_args(L, "f", vm_vec_dot(v3a, v3b));
 }
 
 ADE_FUNC(getCrossProduct, l_Vector, "vector OtherVector", "Returns cross product of vector object with vector argument", "vector", "Cross product, or null vector if a handle is invalid")

--- a/code/parse/lua.cpp
+++ b/code/parse/lua.cpp
@@ -3729,7 +3729,7 @@ ADE_FUNC(getCrossProduct, l_Vector, "vector OtherVector", "Returns cross product
 		return ade_set_error(L, "o", l_Vector.Set(vmd_zero_vector));
 
 	vec3d v3r;
-	vm_vec_crossprod(&v3r, v3a, v3b);
+	vm_vec_cross(&v3r, v3a, v3b);
 
 	return ade_set_args(L, "o",l_Vector.Set(v3r));
 }

--- a/code/parse/lua.cpp
+++ b/code/parse/lua.cpp
@@ -461,7 +461,7 @@ ADE_FUNC(getTranspose, l_Matrix, NULL, "Returns a transpose version of the speci
 		return ade_set_error(L, "o", l_Matrix.Set(matrix_h()));
 
 	matrix final = *mh->GetMatrix();
-	vm_transpose_matrix(&final);
+	vm_transpose(&final);
 
 	return ade_set_args(L, "o", l_Matrix.Set(matrix_h(&final)));
 }

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -5634,7 +5634,7 @@ int sexp_special_warp_dist( int n)
 	}
 
 	// check if within 45 degree half-angle cone of facing 
-	float dot = fl_abs(vm_vec_dotprod(&warp_objp->orient.vec.fvec, &ship_objp->orient.vec.fvec));
+	float dot = fl_abs(vm_vec_dot(&warp_objp->orient.vec.fvec, &ship_objp->orient.vec.fvec));
 	if (dot < 0.707f) {
 		return SEXP_NAN;
 	}
@@ -15350,7 +15350,7 @@ int sexp_facing(int node)
 	vm_vec_sub(&v2, &Objects[target_shipp->objnum].pos, &Player_obj->pos);
 	vm_vec_normalize(&v2);
 
-	a1 = vm_vec_dotprod(&v1, &v2);
+	a1 = vm_vec_dot(&v1, &v2);
 	a2 = (float) cos(ANG_TO_RAD(angle));
 	if (a1 >= a2){
 		return SEXP_TRUE;
@@ -15410,7 +15410,7 @@ int sexp_is_facing(int node)
 	vm_vec_sub(&v2, &target_objp->pos, &origin_objp->pos);
 	vm_vec_normalize(&v2);
 
-	a1 = vm_vec_dotprod(&v1, &v2);
+	a1 = vm_vec_dot(&v1, &v2);
 	a2 = (float) cos(ANG_TO_RAD(angle));
 	if (a1 >= a2){
 		return SEXP_TRUE;
@@ -15446,7 +15446,7 @@ int sexp_facing2(int node)
 
 	vm_vec_sub(&v2, wp_list->get_waypoints().front().get_pos(), &Player_obj->pos);
 	vm_vec_normalize(&v2);
-	a1 = vm_vec_dotprod(&v1, &v2);
+	a1 = vm_vec_dot(&v1, &v2);
 	a2 = (float) cos(ANG_TO_RAD(atof(CTEXT(CDR(node)))));
 	if (a1 >= a2){
 		return SEXP_TRUE;

--- a/code/physics/physics.cpp
+++ b/code/physics/physics.cpp
@@ -500,7 +500,7 @@ void physics_read_flying_controls( matrix * orient, physics_info * pi, control_i
 
 		ship_get_eye(&tmp_vec, &eyemat, Player_obj, false);
 
-		vm_copy_transpose_matrix(&tmp_mat, &Player_obj->orient);
+		vm_copy_transpose(&tmp_mat, &Player_obj->orient);
 		vm_matrix_x_matrix(&rotvelmat, &tmp_mat, &eyemat);
 
 		vm_vec_rotate(&new_rotvel, &pi->max_rotvel, &rotvelmat);

--- a/code/physics/physics.cpp
+++ b/code/physics/physics.cpp
@@ -786,7 +786,7 @@ void physics_apply_whack(vec3d *impulse, vec3d *pos, physics_info *pi, matrix *o
 	// calculate the torque on the body based on the point on the
 	// object that was hit and the momentum being applied to the object
 
-	vm_vec_crossprod(&torque, pos, impulse);
+	vm_vec_cross(&torque, pos, impulse);
 	vm_vec_rotate ( &local_torque, &torque, orient );
 
 	vec3d delta_rotvel;
@@ -947,7 +947,7 @@ void physics_apply_shock(vec3d *direction_vec, float pressure, physics_info *pi,
 	else								// normal > 0, hits the left face
 		vm_vec_copy_scale( &impact_vec, &orient->vec.rvec, min->xyz.x * pressure * area.xyz.x * -normal.xyz.x * sin.xyz.x / pi->mass );
 
-	vm_vec_crossprod( &temp_torque, &impact_vec, direction_vec );
+	vm_vec_cross( &temp_torque, &impact_vec, direction_vec );
 	vm_vec_add2( &torque, &temp_torque );
 
 	// find torque due to forces on the up/down face
@@ -956,7 +956,7 @@ void physics_apply_shock(vec3d *direction_vec, float pressure, physics_info *pi,
 	else
 		vm_vec_copy_scale( &impact_vec, &orient->vec.uvec, min->xyz.y * pressure * area.xyz.y * -normal.xyz.y * sin.xyz.y / pi->mass );
 
-	vm_vec_crossprod( &temp_torque, &impact_vec, direction_vec );
+	vm_vec_cross( &temp_torque, &impact_vec, direction_vec );
 	vm_vec_add2( &torque, &temp_torque );
 
 	// find torque due to forces on the forward/backward face
@@ -965,7 +965,7 @@ void physics_apply_shock(vec3d *direction_vec, float pressure, physics_info *pi,
 	else
 		vm_vec_copy_scale( &impact_vec, &orient->vec.fvec, min->xyz.z * pressure * area.xyz.z * -normal.xyz.z * sin.xyz.z / pi->mass );
 
-	vm_vec_crossprod( &temp_torque, &impact_vec, direction_vec );
+	vm_vec_cross( &temp_torque, &impact_vec, direction_vec );
 	vm_vec_add2( &torque, &temp_torque );
 
 	// compute delta rotvel, scale according to blast and radius

--- a/code/physics/physics.cpp
+++ b/code/physics/physics.cpp
@@ -922,9 +922,9 @@ void physics_apply_shock(vec3d *direction_vec, float pressure, physics_info *pi,
 	area.xyz.y = (max->xyz.x - min->xyz.x) * (max->xyz.z - min->xyz.z);
 	area.xyz.z = (max->xyz.x - min->xyz.x) * (max->xyz.y - min->xyz.y);
 
-	normal.xyz.x = vm_vec_dotprod( direction_vec, &orient->vec.rvec );
-	normal.xyz.y = vm_vec_dotprod( direction_vec, &orient->vec.uvec );
-	normal.xyz.z = vm_vec_dotprod( direction_vec, &orient->vec.fvec );
+	normal.xyz.x = vm_vec_dot( direction_vec, &orient->vec.rvec );
+	normal.xyz.y = vm_vec_dot( direction_vec, &orient->vec.uvec );
+	normal.xyz.z = vm_vec_dot( direction_vec, &orient->vec.fvec );
 
 	sin.xyz.x = fl_sqrt( fl_abs(1.0f - normal.xyz.x*normal.xyz.x) );
 	sin.xyz.y = fl_sqrt( fl_abs(1.0f - normal.xyz.y*normal.xyz.y) );

--- a/code/radar/radarorb.cpp
+++ b/code/radar/radarorb.cpp
@@ -411,7 +411,7 @@ int HudGaugeRadarOrb::calcAlpha(vec3d* pt)
     vm_vec_unrotate(&new_pt, pt, &Player_obj->orient);
     vm_vec_normalize(&new_pt);
 
-    float dot = vm_vec_dotprod(&fvec, &new_pt);
+    float dot = vm_vec_dot(&fvec, &new_pt);
     float angle = fabs(acos(dot));
     int alpha = int(angle*192.0f/PI);
     

--- a/code/render/3ddraw.cpp
+++ b/code/render/3ddraw.cpp
@@ -806,7 +806,7 @@ int g3_draw_rotated_bitmap_3d(vertex *pnt,float angle, float rad,uint tmap_flags
 	vm_rot_point_around_line(&uvec, &View_matrix.vec.uvec, angle, &vmd_zero_vector, &View_matrix.vec.fvec);
 	vm_vec_normalize(&uvec);
 
-	vm_vec_crossprod(&rvec, &View_matrix.vec.fvec, &uvec);
+	vm_vec_cross(&rvec, &View_matrix.vec.fvec, &uvec);
 	vm_vec_normalize(&rvec);
 
 	vertex *ptlist[4] = { &P[3], &P[2], &P[1], &P[0] };	
@@ -946,7 +946,7 @@ int g3_draw_rotated_bitmap(vertex *pnt,float angle, float rad,uint tmap_flags, f
 	b.xyz.y = _r->world.xyz.y - _p->world.xyz.y;\
 	b.xyz.z = 0.0f;\
 	\
-	vm_vec_crossprod(&cross, &a, &b);\
+	vm_vec_cross(&cross, &a, &b);\
 	total_area += vm_vec_mag(&cross) * 0.5f;\
 } while(0);
 
@@ -1270,13 +1270,13 @@ int g3_draw_rod(const vec3d *p0, float width1, const vec3d *p1, float width2, ve
 	vm_vec_sub( &rvec, &Eye_position, &center );
 	vm_vec_normalize( &rvec );
 
-	vm_vec_crossprod(&uvec,&fvec,&rvec);
+	vm_vec_cross(&uvec,&fvec,&rvec);
 			
 	//normalize new perpendicular vector
 	vm_vec_normalize(&uvec);
 	 
 	//now recompute right vector, in case it wasn't entirely perpendiclar
-	vm_vec_crossprod(&rvec,&uvec,&fvec);
+	vm_vec_cross(&rvec,&uvec,&fvec);
 
 	// Now have uvec, which is up vector and rvec which is the normal
 	// of the face.
@@ -1360,7 +1360,7 @@ int g3_draw_rod(int num_points, const vec3d *pvecs, float width, uint tmap_flags
 		vm_vec_sub(&rvec, &pvecs[first], &pvecs[second]);
 		vm_vec_normalize_safe(&rvec);
 
-		vm_vec_crossprod(&uvec, &rvec, &fvec);
+		vm_vec_cross(&uvec, &rvec, &fvec);
 
 		vm_vec_scale_add(&vecs[0], &pvecs[i], &uvec, width * 0.5f);
 		vm_vec_scale_add(&vecs[1], &pvecs[i], &uvec, -width * 0.5f);

--- a/code/render/3dlaser.cpp
+++ b/code/render/3dlaser.cpp
@@ -49,13 +49,13 @@ float g3_draw_laser_htl(const vec3d *p0, float width1, const vec3d *p1, float wi
 	}
 	// code intended to prevent possible null vector normalize issue - end
 
-	vm_vec_crossprod(&uvec,&fvec,&reye);
+	vm_vec_cross(&uvec,&fvec,&reye);
 	vm_vec_normalize(&uvec);
-	vm_vec_crossprod(&fvec,&uvec,&reye);
+	vm_vec_cross(&fvec,&uvec,&reye);
 	vm_vec_normalize(&fvec);
 	 
 	//now recompute right vector, in case it wasn't entirely perpendiclar
-	vm_vec_crossprod(&rvec,&uvec,&fvec);
+	vm_vec_cross(&rvec,&uvec,&fvec);
 
 	// Now have uvec, which is up vector and rvec which is the normal
 	// of the face.

--- a/code/render/3dsetup.cpp
+++ b/code/render/3dsetup.cpp
@@ -283,7 +283,7 @@ void g3_start_instance_matrix(const vec3d *pos, const matrix *orient, bool set_a
 	}
 
 	//step 3: rotate object matrix through view_matrix (vm = ob * vm)
-	vm_copy_transpose_matrix(&tempm2,orient);
+	vm_copy_transpose(&tempm2,orient);
 
 	vm_matrix_x_matrix(&tempm,&tempm2,&View_matrix);
 	View_matrix = tempm;

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -8158,7 +8158,7 @@ void ship_dying_frame(object *objp, int ship_num)
 			if ( timestamp_elapsed(shipp->next_fireball)) {
 				vec3d rand_vec, outpnt; // [0-.7 rad] in plane
 				vm_vec_rand_vec_quick(&rand_vec);
-				float scale = -vm_vec_dotprod(&objp->orient.vec.fvec, &rand_vec) * (0.9f + 0.2f * frand());
+				float scale = -vm_vec_dot(&objp->orient.vec.fvec, &rand_vec) * (0.9f + 0.2f * frand());
 				vm_vec_scale_add2(&rand_vec, &objp->orient.vec.fvec, scale);
 				vm_vec_normalize_quick(&rand_vec);
 				scale = objp->radius * frand() * 0.717f;

--- a/code/ship/shipfx.cpp
+++ b/code/ship/shipfx.cpp
@@ -157,7 +157,7 @@ void shipfx_subsystem_maybe_create_live_debris(object *ship_objp, ship *ship_p, 
 			// get radial velocity of debris
 			vec3d delta_x, radial_vel;
 			vm_vec_sub(&delta_x, &end_world_pos, &world_axis_pt);
-			vm_vec_crossprod(&radial_vel, &rotvel, &delta_x);
+			vm_vec_cross(&radial_vel, &rotvel, &delta_x);
 
 			if (Ship_info[ship_p->ship_info_index].flags & SIF_KNOSSOS_DEVICE) {
 				// set velocity to cross center of knossos device
@@ -1803,8 +1803,8 @@ static void split_ship_init( ship* shipp, split_ship* split_shipp )
 	vec3d temp_rotvel = parent_ship_obj->phys_info.rotvel;
 	temp_rotvel.xyz.z = 0.0f;
 	vec3d vel_from_rotvel;
-	vm_vec_crossprod(&vel_from_rotvel, &temp_rotvel, &split_shipp->front_ship.local_pivot);
-	vm_vec_crossprod(&vel_from_rotvel, &temp_rotvel, &split_shipp->back_ship.local_pivot);
+	vm_vec_cross(&vel_from_rotvel, &temp_rotvel, &split_shipp->front_ship.local_pivot);
+	vm_vec_cross(&vel_from_rotvel, &temp_rotvel, &split_shipp->back_ship.local_pivot);
 
 	// set up velocity and make initial fireballs and particles
 	split_shipp->front_ship.phys_info.vel = parent_ship_obj->phys_info.vel;
@@ -1888,7 +1888,7 @@ static void half_ship_render_ship_and_debris(clip_ship* half_ship,ship *shipp)
 						debris_obj->orient = half_ship->orient;
 						
 						vm_vec_sub(&center_to_debris, &tmp, &half_ship->local_pivot);
-						vm_vec_crossprod(&debris_vel, &center_to_debris, &half_ship->phys_info.rotvel);
+						vm_vec_cross(&debris_vel, &center_to_debris, &half_ship->phys_info.rotvel);
 						vm_vec_add2(&debris_vel, &half_ship->phys_info.vel);
 						vm_vec_copy_normalize(&radial_vel, &center_to_debris);
 						float radial_mag = 10.0f + 30.0f*frand();
@@ -1988,7 +1988,7 @@ void shipfx_queue_render_ship_halves_and_debris(draw_list *scene, clip_ship* hal
 						debris_obj->orient = half_ship->orient;
 
 						vm_vec_sub(&center_to_debris, &tmp, &half_ship->local_pivot);
-						vm_vec_crossprod(&debris_vel, &center_to_debris, &half_ship->phys_info.rotvel);
+						vm_vec_cross(&debris_vel, &center_to_debris, &half_ship->phys_info.rotvel);
 						vm_vec_add2(&debris_vel, &half_ship->phys_info.vel);
 						vm_vec_copy_normalize(&radial_vel, &center_to_debris);
 						float radial_mag = 10.0f + 30.0f*frand();
@@ -3035,7 +3035,7 @@ void engine_wash_ship_process(ship *shipp)
 
 						// check if inside the sphere
 						if ( dist_sqr < ((radius_mult * radius_mult) * (bank->points[j].radius * bank->points[j].radius)) ) {
-							vm_vec_crossprod(&temp, &world_thruster_norm, &thruster_to_ship);
+							vm_vec_cross(&temp, &world_thruster_norm, &thruster_to_ship);
 							vm_vec_scale_add2(&shipp->wash_rot_axis, &temp, dot_to_ship / dist_sqr);
 							ship_intensity += (1.0f - dist_sqr / (max_wash_dist*max_wash_dist));
 							if (!do_damage) {
@@ -3052,7 +3052,7 @@ void engine_wash_ship_process(ship *shipp)
 
 							// check if inside cone angle
 							if (vm_vec_dot(&apex_to_ship, &world_thruster_norm) > cos(half_angle)) {
-								vm_vec_crossprod(&temp, &world_thruster_norm, &thruster_to_ship);
+								vm_vec_cross(&temp, &world_thruster_norm, &thruster_to_ship);
 								vm_vec_scale_add2(&shipp->wash_rot_axis, &temp, dot_to_ship / dist_sqr);
 								ship_intensity += (1.0f - dist_sqr / (max_wash_dist*max_wash_dist));
 								if (!do_damage) {

--- a/code/ship/shipfx.cpp
+++ b/code/ship/shipfx.cpp
@@ -672,7 +672,7 @@ int compute_special_warpout_stuff(object *objp, float *speed, float *warp_time, 
 	// get facing normal from knossos
 	vm_vec_sub(&vec_to_knossos, &sp_objp->pos, &center_pos);
 	facing_normal = sp_objp->orient.vec.fvec;
-	if (vm_vec_dotprod(&vec_to_knossos, &sp_objp->orient.vec.fvec) > 0) {
+	if (vm_vec_dot(&vec_to_knossos, &sp_objp->orient.vec.fvec) > 0) {
 		vm_vec_negate(&facing_normal);
 	}
 
@@ -694,7 +694,7 @@ int compute_special_warpout_stuff(object *objp, float *speed, float *warp_time, 
 		max_warpout_angle = 0.866f;	// 30 degree half-angle cone for BIG or HUGE
 	}
 
-	if (-vm_vec_dotprod(&objp->orient.vec.fvec, &facing_normal) < max_warpout_angle) {	// within allowed angle
+	if (-vm_vec_dot(&objp->orient.vec.fvec, &facing_normal) < max_warpout_angle) {	// within allowed angle
 		Int3();
 		mprintf(("special warpout angle exceeded\n"));
 		return -1;
@@ -3023,7 +3023,7 @@ void engine_wash_ship_process(ship *shipp)
 				vm_vec_sub(&thruster_to_ship, &objp->pos, &world_thruster_pos);
 
 				// check if on back side of thruster
-				dot_to_ship = vm_vec_dotprod(&thruster_to_ship, &world_thruster_norm);
+				dot_to_ship = vm_vec_dot(&thruster_to_ship, &world_thruster_norm);
 				if (dot_to_ship > 0) {
 
 					// get max wash distance
@@ -3051,7 +3051,7 @@ void engine_wash_ship_process(ship *shipp)
 							vm_vec_normalize(&apex_to_ship);
 
 							// check if inside cone angle
-							if (vm_vec_dotprod(&apex_to_ship, &world_thruster_norm) > cos(half_angle)) {
+							if (vm_vec_dot(&apex_to_ship, &world_thruster_norm) > cos(half_angle)) {
 								vm_vec_crossprod(&temp, &world_thruster_norm, &thruster_to_ship);
 								vm_vec_scale_add2(&shipp->wash_rot_axis, &temp, dot_to_ship / dist_sqr);
 								ship_intensity += (1.0f - dist_sqr / (max_wash_dist*max_wash_dist));

--- a/code/ship/shiphit.cpp
+++ b/code/ship/shiphit.cpp
@@ -158,7 +158,7 @@ void do_subobj_destroyed_stuff( ship *ship_p, ship_subsys *subsys, vec3d* hitpos
 				}
 
 				vec3d fb_vel;
-				vm_vec_crossprod(&fb_vel, &objp->phys_info.rotvel, &center_to_subsys);
+				vm_vec_cross(&fb_vel, &objp->phys_info.rotvel, &center_to_subsys);
 				vm_vec_add2(&fb_vel, &objp->phys_info.vel);
 
 				int fireball_type = fireball_ship_explosion_type(sip);

--- a/code/ship/shiphit.cpp
+++ b/code/ship/shiphit.cpp
@@ -146,7 +146,7 @@ void do_subobj_destroyed_stuff( ship *ship_p, ship_subsys *subsys, vec3d* hitpos
 				} else {
 					// make other fireballs at random positions, but try to keep on the surface
 					vm_vec_rand_vec_quick(&rand_vec);
-					float dot = vm_vec_dotprod(&center_to_subsys, &rand_vec);
+					float dot = vm_vec_dot(&center_to_subsys, &rand_vec);
 					vm_vec_scale_add2(&rand_vec, &center_to_subsys, -dot/vm_vec_mag_squared(&center_to_subsys));
 					vm_vec_scale_add(&temp_vec, &g_subobj_pos, &rand_vec, 0.5f*psub->radius);
 				}
@@ -1249,9 +1249,9 @@ void ship_hit_create_sparks(object *ship_objp, vec3d *hitpos, int submodel_num)
 		vm_vec_sub(&diff, hitpos, &temp_zero);
 
 		// find displacement from submodel origin in submodel RF
-		shipp->sparks[n].pos.xyz.x = vm_vec_dotprod(&diff, &temp_x);
-		shipp->sparks[n].pos.xyz.y = vm_vec_dotprod(&diff, &temp_y);
-		shipp->sparks[n].pos.xyz.z = vm_vec_dotprod(&diff, &temp_z);
+		shipp->sparks[n].pos.xyz.x = vm_vec_dot(&diff, &temp_x);
+		shipp->sparks[n].pos.xyz.y = vm_vec_dot(&diff, &temp_y);
+		shipp->sparks[n].pos.xyz.z = vm_vec_dot(&diff, &temp_z);
 		shipp->sparks[n].submodel_num = submodel_num;
 		shipp->sparks[n].end_time = timestamp(-1);
 	} else {

--- a/code/weapon/beam.cpp
+++ b/code/weapon/beam.cpp
@@ -2939,7 +2939,7 @@ int beam_collide_early_out(object *a, object *b)
 	vm_vec_normalize_quick(&dot_test);
 	vm_vec_normalize_quick(&dot_test2);
 	// cull_dist == DIST SQUARED FOO!
-	if((vm_vec_dotprod(&dot_test, &dot_test2) < cull_dot) && (vm_vec_mag_squared(&dist_test) > cull_dist)){
+	if((vm_vec_dot(&dot_test, &dot_test2) < cull_dot) && (vm_vec_mag_squared(&dist_test) > cull_dist)){
 		return 1;
 	}
 	
@@ -3366,7 +3366,7 @@ float beam_get_cone_dot(beam *b)
 		return (float)cos(fl_radians(50.5f));
 		
 	case BEAM_TYPE_B:
-		return vm_vec_dotprod(&b->binfo.dir_a, &b->binfo.dir_b);
+		return vm_vec_dot(&b->binfo.dir_a, &b->binfo.dir_b);
 
 	default:
 		Int3();
@@ -3449,7 +3449,7 @@ int beam_ok_to_fire(beam *b)
 		} else {
 			vec3d turret_dir, turret_pos, temp;
 			beam_get_global_turret_gun_info(b->objp, b->subsys, &turret_pos, &turret_dir, 1, &temp, (b->flags & BF_IS_FIGHTER_BEAM) > 0);
-			if (vm_vec_dotprod(&aim_dir, &turret_dir) < b->subsys->system_info->turret_fov) {
+			if (vm_vec_dot(&aim_dir, &turret_dir) < b->subsys->system_info->turret_fov) {
 				nprintf(("BEAM", "BEAM : powering beam down because of FOV condition!\n"));
 				return 0;
 			}

--- a/code/weapon/beam.cpp
+++ b/code/weapon/beam.cpp
@@ -1612,7 +1612,7 @@ void beam_calc_facing_pts( vec3d *top, vec3d *bot, vec3d *fvec, vec3d *pos, floa
 	vm_vec_sub( &rvec, &Eye_position, &temp );
 	vm_vec_normalize( &rvec );	
 
-	vm_vec_crossprod(&uvec,fvec,&rvec);
+	vm_vec_cross(&uvec,fvec,&rvec);
 	// VECMAT-ERROR: NULL VEC3D (value of, fvec == rvec)
 	vm_vec_normalize_safe(&uvec);
 

--- a/code/weapon/trails.cpp
+++ b/code/weapon/trails.cpp
@@ -89,7 +89,7 @@ void trail_calc_facing_pts( vec3d *top, vec3d *bot, vec3d *fvec, vec3d *pos, flo
 	if (!IS_VEC_NULL(&rvec))
 		vm_vec_normalize( &rvec );
 
-	vm_vec_crossprod(&uvec,fvec,&rvec);
+	vm_vec_cross(&uvec,fvec,&rvec);
 	if (!IS_VEC_NULL(&uvec))
 		vm_vec_normalize(&uvec);
 


### PR DESCRIPTION
For some inexplicable reason, several vecmat functions were declared twice, once as normal and then again with a #define with a shorter name. This is completely unnecessary.