### PR TITLE
Abstract toolchain capabilities

### DIFF
--- a/code/ai/aiturret.cpp
+++ b/code/ai/aiturret.cpp
@@ -1377,7 +1377,7 @@ void turret_ai_update_aim(ai_info *aip, object *En_Objp, ship_subsys *ss)
  */
 int aifft_rotate_turret(ship *shipp, int parent_objnum, ship_subsys *ss, object *objp, object *lep, vec3d *predicted_enemy_pos, vec3d *gvec)
 {
-	int ret_val __attribute__((__unused__)) = 0; // to be used in future, see comment @ end of function
+	int ret_val __UNUSED = 0; // to be used in future, see comment @ end of function
 
 	if (ss->turret_enemy_objnum != -1) {
 		model_subsystem *tp = ss->system_info;

--- a/code/freespace2/freespace.cpp
+++ b/code/freespace2/freespace.cpp
@@ -1265,7 +1265,7 @@ void game_loading_callback_close()
 	// Make sure bar shows all the way over.
 	game_loading_callback(COUNT_ESTIMATE);
 	
-	int real_count __attribute__((__unused__)) = game_busy_callback( NULL );
+	int real_count __UNUSED = game_busy_callback( NULL );
  	Mouse_hidden = 0;
 
 	Game_loading_callback_inited = 0;
@@ -1429,7 +1429,7 @@ int game_start_mission()
 {
 	mprintf(( "=================== STARTING LEVEL LOAD ==================\n" ));
 
-	int s1 __attribute__((__unused__)) = timer_get_milliseconds();
+	int s1 __UNUSED = timer_get_milliseconds();
 
 	// clear post processing settings
 	gr_post_process_set_defaults();
@@ -1486,7 +1486,7 @@ int game_start_mission()
 
 	bm_print_bitmaps();
 
-	int e1 __attribute__((__unused__)) = timer_get_milliseconds();
+	int e1 __UNUSED = timer_get_milliseconds();
 
 	mprintf(("Level load took %f seconds.\n", (e1 - s1) / 1000.0f ));
 
@@ -1745,7 +1745,7 @@ char full_path[1024];
  */
 void game_init()
 {
-	int s1 __attribute__((__unused__)), e1 __attribute__((__unused__));
+	int s1 __UNUSED, e1 __UNUSED;
 	const char *ptr;
 	char whee[MAX_PATH_LEN];
 

--- a/code/fs2netd/fs2netd_client.cpp
+++ b/code/fs2netd/fs2netd_client.cpp
@@ -737,7 +737,7 @@ static void fs2netd_handle_messages()
 
 			case PCKT_SLIST_REPLY: {
 				int numServers = 0;
-				int svr_flags __attribute__((__unused__)); // gcc [-Wunused-but-set-variable] doesn't like MACROs
+				int svr_flags __UNUSED; // gcc [-Wunused-but-set-variable] doesn't like MACROs
 				ushort svr_port;
 				char svr_ip[16];
 				active_game ag;

--- a/code/fs2netd/tcp_client.cpp
+++ b/code/fs2netd/tcp_client.cpp
@@ -218,7 +218,7 @@ int FS2NetD_GetPlayerData(const char *player_name, player *pl, bool can_create, 
 		uint rc_total = 0;
 		ubyte reply_type = 0;
 		int si_index = 0;
-		ushort bogus __attribute__((unused));
+		ushort bogus __UNUSED;
 		ushort num_type_kills = 0, num_medals = 0;
 		char ship_name[NAME_LENGTH];
 		int idx;
@@ -489,8 +489,8 @@ int FS2NetD_Login(const char *username, const char *password, bool do_send)
 		int rc;
 		uint rc_total = 0;
 		ubyte login_status = 0;
-		int sid __attribute__((unused));
-		short pilots __attribute__((unused));
+		int sid __UNUSED;
+		short pilots __UNUSED;
 
 		do {
 			rc = FS2NetD_GetData(buffer+rc_total, sizeof(buffer)-rc_total);

--- a/code/globalincs/toolchain.h
+++ b/code/globalincs/toolchain.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) Volition, Inc. 1999.  All rights reserved.
+ *
+ * All source code herein is the property of Volition, Inc. You may not sell
+ * or otherwise commercially exploit the source or things you created based on
+ * the source.
+ */
+
+/**
+ * @file
+ *
+ * @brief Macros to abstract compiler capabilities for various toolchains
+ */
+
+#ifndef _TOOLCHAIN_H
+#define _TOOLCHAIN_H
+
+#if defined(DOXYGEN)
+#	include "globalincs/toolchain/doxygen.h"
+#elif defined(__MINGW32__)
+#	include "globalincs/toolchain/mingw.h"
+#elif defined(__clang__)
+#	include "globalincs/toolchain/clang.h"
+#elif defined(__GNUC__)
+#	include "globalincs/toolchain/gcc.h"
+#elif defined(_MSC_VER)
+#	include "globalincs/toolchain/msvc.h"
+#else
+#	error "Unknown toolchain detected!\n"           \
+		"Currently supported toolchains include:\n" \
+		"\tMingW, Clang, GCC, MSVC\n"               \
+		"Update toolchain.h to add support for additional toolchains.\n"
+#endif
+
+#endif /* _TOOLCHAIN_H */

--- a/code/globalincs/toolchain/clang.h
+++ b/code/globalincs/toolchain/clang.h
@@ -41,13 +41,13 @@
 #	define Assertion(expr, msg, ...)                                      \
 		do {                                                              \
 			if (!(expr)) {                                                \
-				WinAssert(#espr, __FILE__, __LINE__, msg, ##_VA_ARGS__);  \
+				WinAssert(#expr, __FILE__, __LINE__, msg, ##__VA_ARGS__); \
 			}                                                             \
 		} while (0)
 #endif
 
 /* C++11 Standard Detection */
-#if !defined(HAVE_CX11)
+#if !defined(HAVE_CXX11)
 	/*
 	 * Clang does not seem to have a feature check for 'is_trivial'.
 	 * Assume it will be covered by one of the following checks ...

--- a/code/globalincs/toolchain/clang.h
+++ b/code/globalincs/toolchain/clang.h
@@ -21,6 +21,7 @@
 #define SCP_FORMAT_STRING_ARGS(x,y)  __attribute__((format(printf, x, y)))
 
 #define __UNUSED __attribute__((__unused__))
+#define __ALIGNED(x)  __attribute__((__aligned__(x)))
 
 #ifdef NO_RESTRICT_USE
 #	define RESTRICT

--- a/code/globalincs/toolchain/clang.h
+++ b/code/globalincs/toolchain/clang.h
@@ -20,6 +20,8 @@
 #define SCP_FORMAT_STRING
 #define SCP_FORMAT_STRING_ARGS(x,y)  __attribute__((format(printf, x, y)))
 
+#define __UNUSED __attribute__((__unused__))
+
 #ifdef NO_RESTRICT_USE
 #	define RESTRICT
 #else

--- a/code/globalincs/toolchain/clang.h
+++ b/code/globalincs/toolchain/clang.h
@@ -61,3 +61,6 @@
 #define PTRDIFF_T_ARG "%zd"
 
 #define NOEXCEPT  noexcept
+
+#define likely(x)    __builtin_expect((long) !!(x), 1L)
+#define unlikely(x)  __builtin_expect((long) !!(x), 0L)

--- a/code/globalincs/toolchain/clang.h
+++ b/code/globalincs/toolchain/clang.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) Volition, Inc. 1999.  All rights reserved.
+ *
+ * All source code herein is the property of Volition, Inc. You may not sell
+ * or otherwise commercially exploit the source or things you created based on
+ * the source.
+ */
+
+/**
+ * @file
+ *
+ * @brief Macros to abstract compiler capabilities for the Clang toolchain
+ *
+ * @internal
+ * This file should never be included directly; instead, one should
+ * include toolchain.h which will pull in the file appropriate to
+ * the detected toolchain.
+ */
+
+#define SCP_FORMAT_STRING
+#define SCP_FORMAT_STRING_ARGS(x,y)  __attribute__((format(printf, x, y)))
+
+#ifdef NO_RESTRICT_USE
+#	define RESTRICT
+#else
+#	define RESTRICT  restrict
+#endif
+
+#define ASSUME(x)
+
+#if defined(NDEBUG)
+#	define Assertion(expr, msg, ...)  do { } while (0)
+#else
+/*
+ * NOTE: Assertion() can only use its proper functionality in compilers
+ * that support variadic macros.
+ */
+#	define Assertion(expr, msg, ...)                                      \
+		do {                                                              \
+			if (!(expr)) {                                                \
+				WinAssert(#espr, __FILE__, __LINE__, msg, ##_VA_ARGS__);  \
+			}                                                             \
+		} while (0)
+#endif
+
+/* C++11 Standard Detection */
+#if !defined(HAVE_CX11)
+	/*
+	 * Clang does not seem to have a feature check for 'is_trivial'.
+	 * Assume it will be covered by one of the following checks ...
+	 * http://clang.llvm.org/docs/LanguageExtensions.html#feature_check
+	 */
+#	if __has_feature(cxx_static_assert) && __has_feature(cxx_auto_type)
+#		define HAVE_CXX11
+#	endif
+#endif
+
+#define SIZE_T_ARG    "%zu"
+#define PTRDIFF_T_ARG "%zd"
+
+#define NOEXCEPT  noexcept

--- a/code/globalincs/toolchain/doxygen.h
+++ b/code/globalincs/toolchain/doxygen.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) Volition, Inc. 1999.  All rights reserved.
+ *
+ * All source code herein is the property of Volition, Inc. You may not sell
+ * or otherwise commercially exploit the source or things you created based on
+ * the source.
+ */
+
+/**
+ * @file
+ *
+ * @brief Macros to abstract compiler capabilities (for doxygen use only)
+ */
+
+/**
+ * @brief Identifies a printf-style format string
+ */
+#define SCP_FORMAT_STRING
+
+/**
+ * @brief Specify which arguments are involved in printf-style string formatting
+ *
+ * @details Expands to a compiler specific attribute which specify where the
+ *          format arguments are located. Parameters are 1-based which also
+ *          includes the 'this' parameter at position 1 for class methods.
+ *
+ * @param formatArg Location of format string argument in the argument list
+ * @param varArgs Location where the variable arguments begin
+ */
+#define SCP_FORMAT_STRING_ARGS(formatArg,varArgs)
+
+/**
+ * @brief Format specifier for a @c size_t argument
+ *
+ * Due to different runtimes using different format specifier for these types
+ * it's necessary to hide these changes behind a macro. Use this in place of %zu
+ */
+#define SIZE_T_ARG    "%zu"
+
+/**
+ * @brief Format specifier for a @c ptrdiff_t argument
+ *
+ * Due to different runtimes using different format specifier for these types
+ * it's necessary to hide these changes behind a macro. Use this in place of %zd
+ */
+#define PTRDIFF_T_ARG "%zd"

--- a/code/globalincs/toolchain/gcc.h
+++ b/code/globalincs/toolchain/gcc.h
@@ -41,15 +41,15 @@
 #	define Assertion(expr, msg, ...)                                      \
 		do {                                                              \
 			if (!(expr)) {                                                \
-				WinAssert(#espr, __FILE__, __LINE__, msg, ##_VA_ARGS__);  \
+				WinAssert(#expr, __FILE__, __LINE__, msg, ##__VA_ARGS__); \
 			}                                                             \
 		} while (0)
 #endif
 
 /* C++11 Standard Detection */
-#if !defined(HAVE_CX11)
+#if !defined(HAVE_CXX11)
 	/*
-	 * For GCC with autotools, see AX_CXX_comPiLE_STDCXX_11 macro in the
+	 * For GCC with autotools, see AX_CXX_COMPiLE_STDCXX_11 macro in the
 	 * file "configure.ac". This sets HAVE_CXX11 & -std=c++0x or -std=c++11
 	 * as appropriate.
 	 *

--- a/code/globalincs/toolchain/gcc.h
+++ b/code/globalincs/toolchain/gcc.h
@@ -21,6 +21,7 @@
 #define SCP_FORMAT_STRING_ARGS(x,y)  __attribute__((format(printf, x, y)))
 
 #define __UNUSED __attribute__((__unused__))
+#define __ALIGNED(x)  __attribute__((__aligned__(x)))
 
 #ifdef NO_RESTRICT_USE
 #   define RESTRICT

--- a/code/globalincs/toolchain/gcc.h
+++ b/code/globalincs/toolchain/gcc.h
@@ -60,3 +60,6 @@
 #define PTRDIFF_T_ARG "%zd"
 
 #define NOEXCEPT  noexcept
+
+#define likely(x)    __builtin_expect((long) !!(x), 1L)
+#define unlikely(x)  __builtin_expect((long) !!(x), 0L)

--- a/code/globalincs/toolchain/gcc.h
+++ b/code/globalincs/toolchain/gcc.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) Volition, Inc. 1999.  All rights reserved.
+ *
+ * All source code herein is the property of Volition, Inc. You may not sell
+ * or otherwise commercially exploit the source or things you created based on
+ * the source.
+ */
+
+/**
+ * @file
+ *
+ * @brief Macros to abstract compiler capabilities for the GCC toolchain
+ *
+ * @internal
+ * This file should never be included directly; instead, one should
+ * include toolchain.h which will pull in the file appropriate to
+ * the detected toolchain.
+ */
+
+#define SCP_FORMAT_STRING
+#define SCP_FORMAT_STRING_ARGS(x,y)  __attribute__((format(printf, x, y)))
+
+#ifdef NO_RESTRICT_USE
+#   define RESTRICT
+#else
+#   define RESTRICT  restrict
+#endif
+
+#define ASSUME(x)
+
+#if defined(NDEBUG)
+#	define Assertion(expr, msg, ...)  do {} while (0)
+#else
+/*
+ * NOTE: Assertion() can only use its proper functionality in compilers
+ * that support variadic macros.
+ */
+#	define Assertion(expr, msg, ...)                                      \
+		do {                                                              \
+			if (!(expr)) {                                                \
+				WinAssert(#espr, __FILE__, __LINE__, msg, ##_VA_ARGS__);  \
+			}                                                             \
+		} while (0)
+#endif
+
+/* C++11 Standard Detection */
+#if !defined(HAVE_CX11)
+	/*
+	 * For GCC with autotools, see AX_CXX_comPiLE_STDCXX_11 macro in the
+	 * file "configure.ac". This sets HAVE_CXX11 & -std=c++0x or -std=c++11
+	 * as appropriate.
+	 *
+	 * TODO: Is anything else required here?
+	 */
+#endif
+
+#define SIZE_T_ARG    "%zu"
+#define PTRDIFF_T_ARG "%zd"
+
+#define NOEXCEPT  noexcept

--- a/code/globalincs/toolchain/gcc.h
+++ b/code/globalincs/toolchain/gcc.h
@@ -20,6 +20,8 @@
 #define SCP_FORMAT_STRING
 #define SCP_FORMAT_STRING_ARGS(x,y)  __attribute__((format(printf, x, y)))
 
+#define __UNUSED __attribute__((__unused__))
+
 #ifdef NO_RESTRICT_USE
 #   define RESTRICT
 #else

--- a/code/globalincs/toolchain/mingw.h
+++ b/code/globalincs/toolchain/mingw.h
@@ -55,3 +55,6 @@
 #define PTRDIFF_T_ARG "%zd"
 
 #define NOEXCEPT  noexcept
+
+#define likely(x)    __builtin_expect((long) !!(x), 1L)
+#define unlikely(x)  __builtin_expect((long) !!(x), 0L)

--- a/code/globalincs/toolchain/mingw.h
+++ b/code/globalincs/toolchain/mingw.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) Volition, Inc. 1999.  All rights reserved.
+ *
+ * All source code herein is the property of Volition, Inc. You may not sell
+ * or otherwise commercially exploit the source or things you created based on
+ * the source.
+ */
+
+/**
+ * @file
+ *
+ * @brief Macros to abstract compiler capabilities for the Mingw toolchain
+ *
+ * @internal
+ * This file should never be included directly; instead, one should
+ * include toolchain.h which will pull in the file appropriate to
+ * the detected toolchain.
+ */
+
+#define SCP_FORMAT_STRING
+#define SCP_FORMAT_STRING_ARGS(x,y)  __attribute__((format(printf, x, y)))
+
+#ifdef NO_RESTRICT_USE
+#   define RESTRICT
+#else
+#   define RESTRICT  restrict
+#endif
+
+#define ASSUME(x)
+
+#if defined(NDEBUG)
+#	define Assertion(expr, msg, ...)  do {} while (0)
+#else
+/*
+ * NOTE: Assertion() can only use its proper functionality in compilers
+ * that support variadic macros.
+ */
+#	define Assertion(expr, msg, ...)                                      \
+		do {                                                              \
+			if (!(expr)) {                                                \
+				WinAssert(#espr, __FILE__, __LINE__, msg, ##_VA_ARGS__);  \
+			}                                                             \
+		} while (0)
+#endif
+
+/* C++11 Standard Detection */
+#if !defined(HAVE_CX11)
+	/* TODO */
+#endif
+
+
+#define SIZE_T_ARG    "%zu"
+#define PTRDIFF_T_ARG "%zd"
+
+#define NOEXCEPT  noexcept

--- a/code/globalincs/toolchain/mingw.h
+++ b/code/globalincs/toolchain/mingw.h
@@ -21,6 +21,7 @@
 #define SCP_FORMAT_STRING_ARGS(x,y)  __attribute__((format(printf, x, y)))
 
 #define __UNUSED __attribute__((__unused__))
+#define __ALIGNED(x)  __attribute__((__aligned__(x)))
 
 #ifdef NO_RESTRICT_USE
 #   define RESTRICT

--- a/code/globalincs/toolchain/mingw.h
+++ b/code/globalincs/toolchain/mingw.h
@@ -41,13 +41,13 @@
 #	define Assertion(expr, msg, ...)                                      \
 		do {                                                              \
 			if (!(expr)) {                                                \
-				WinAssert(#espr, __FILE__, __LINE__, msg, ##_VA_ARGS__);  \
+				WinAssert(#expr, __FILE__, __LINE__, msg, ##__VA_ARGS__); \
 			}                                                             \
 		} while (0)
 #endif
 
 /* C++11 Standard Detection */
-#if !defined(HAVE_CX11)
+#if !defined(HAVE_CXX11)
 	/* TODO */
 #endif
 

--- a/code/globalincs/toolchain/mingw.h
+++ b/code/globalincs/toolchain/mingw.h
@@ -20,6 +20,8 @@
 #define SCP_FORMAT_STRING
 #define SCP_FORMAT_STRING_ARGS(x,y)  __attribute__((format(printf, x, y)))
 
+#define __UNUSED __attribute__((__unused__))
+
 #ifdef NO_RESTRICT_USE
 #   define RESTRICT
 #else

--- a/code/globalincs/toolchain/msvc.h
+++ b/code/globalincs/toolchain/msvc.h
@@ -23,6 +23,7 @@
 #define SCP_FORMAT_STRING_ARGS(x,y)
 
 #define __attribute__(x)
+#define __UNUSED
 
 #ifdef NO_RESTRICT_USE
 #   define RESTRICT

--- a/code/globalincs/toolchain/msvc.h
+++ b/code/globalincs/toolchain/msvc.h
@@ -79,3 +79,6 @@
 #else
 #	define NOEXCEPT  noexcept
 #endif
+
+#define likely(x)
+#define unlikely(x)

--- a/code/globalincs/toolchain/msvc.h
+++ b/code/globalincs/toolchain/msvc.h
@@ -51,7 +51,7 @@
 #		define Assertion(expr, msg, ...)                                    \
 			do {                                                            \
 				if (!(expr)) {                                              \
-					WinAssert(#expr, __FILE__, __LINE__, msg, _VA_ARGS__);  \
+					WinAssert(#expr, __FILE__, __LINE__, msg, __VA_ARGS__); \
 				}                                                           \
 			} while (0)
 #	else                 /* Older MSVC compilers */
@@ -64,7 +64,7 @@
 #endif
 
 /* C++11 Standard Detection */
-#if !defined(HAVE_CX11)
+#if !defined(HAVE_CXX11)
 	/* Use the Visual Studio version to detect C++11 support */
 #	if _MSC_VER >= 1600
 #		define HAVE_CXX11

--- a/code/globalincs/toolchain/msvc.h
+++ b/code/globalincs/toolchain/msvc.h
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) Volition, Inc. 1999.  All rights reserved.
+ *
+ * All source code herein is the property of Volition, Inc. You may not sell
+ * or otherwise commercially exploit the source or things you created based on
+ * the source.
+ */
+
+/**
+ * @file
+ *
+ * @brief Macros to abstract compiler capabilities for the MSVC toolchain
+ *
+ * @internal
+ * This file should never be included directly; instead, one should
+ * include toolchain.h which will pull in the file appropriate to
+ * the detected toolchain.
+ */
+
+#include <sal.h>
+
+#define SCP_FORMAT_STRING            _Printf_format_string_
+#define SCP_FORMAT_STRING_ARGS(x,y)
+
+#define __attribute__(x)
+
+#ifdef NO_RESTRICT_USE
+#   define RESTRICT
+#elif _MSC_VER >= 1400
+#   define RESTRICT  __restrict
+#else
+#   define RESTRICT
+#endif
+
+#define ASSUME(x)
+
+#if defined(NDEBUG)
+#	if _MSC_VER >= 1400  /* MSVC 2005 or newer */
+#		define Assertion(expr, msg, ...)  do { ASSUME(expr); } while (0)
+#	else
+#		define Assertion(expr, msg)  do {} while (0)
+#	endif
+#else
+	/*
+	 * NOTE: Assertion() can only use its proper functionality in compilers
+	 * that support variadic macros.
+	 */
+#	if _MSC_VER >= 1400  /* MSVC 2005 or newer */
+#		define Assertion(expr, msg, ...)                                    \
+			do {                                                            \
+				if (!(expr)) {                                              \
+					WinAssert(#expr, __FILE__, __LINE__, msg, _VA_ARGS__);  \
+				}                                                           \
+			} while (0)
+#	else                 /* Older MSVC compilers */
+#		define Assertion(expr, msg)                        \
+			do {                                           \
+				if (!(expr)) {                             \
+					WinAssert(#expr, __FILE__, __LINE__);  \
+			} while (0)
+#	endif
+#endif
+
+/* C++11 Standard Detection */
+#if !defined(HAVE_CX11)
+	/* Use the Visual Studio version to detect C++11 support */
+#	if _MSC_VER >= 1600
+#		define HAVE_CXX11
+#	endif
+#endif
+
+#define PTRDIFF_T_ARG "%Iu"
+#define SIZE_T_ARG    "%Id"
+
+/* The 'noexcept' keyword is not defined in versions before VS 2015. */
+#if _MSC_VER < 1900
+#	define NOEXCEPT
+#else
+#	define NOEXCEPT  noexcept
+#endif

--- a/code/globalincs/toolchain/msvc.h
+++ b/code/globalincs/toolchain/msvc.h
@@ -24,6 +24,7 @@
 
 #define __attribute__(x)
 #define __UNUSED
+#define __ALIGNED(x)  __declspec(align(x))
 
 #ifdef NO_RESTRICT_USE
 #   define RESTRICT

--- a/code/pilotfile/csg.cpp
+++ b/code/pilotfile/csg.cpp
@@ -1111,7 +1111,7 @@ void pilotfile::csg_read_settings()
 
 	if (csg_ver < 3) {
 		// detail
-		int dummy  __attribute__((__unused__)) = cfread_int(cfp);
+		int dummy  __UNUSED = cfread_int(cfp);
 		dummy = cfread_int(cfp);
 		dummy = cfread_int(cfp);
 		dummy = cfread_int(cfp);
@@ -1152,7 +1152,7 @@ void pilotfile::csg_write_settings()
 void pilotfile::csg_read_controls()
 {
 	int idx, list_size;
-	short id1, id2, id3 __attribute__((__unused__));
+	short id1, id2, id3 __UNUSED;
 
 	list_size = (int)cfread_ushort(cfp);
 

--- a/code/pilotfile/plr.cpp
+++ b/code/pilotfile/plr.cpp
@@ -600,7 +600,7 @@ void pilotfile::plr_write_stats_multi()
 void pilotfile::plr_read_controls()
 {
 	int idx, list_size, list_axis;
-	short id1, id2, id3 __attribute__((__unused__));
+	short id1, id2, id3 __UNUSED;
 	int axi, inv;
 
 	list_size = (int)cfread_ushort(cfp);

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -7547,7 +7547,7 @@ void ship_subsystems_delete(ship *shipp)
 void ship_delete( object * obj )
 {
 	ship	*shipp;
-	int	num, objnum __attribute__((__unused__));
+	int	num, objnum __UNUSED;
 
 	num = obj->instance;
 	Assert( num >= 0);
@@ -16377,7 +16377,7 @@ void ship_page_in()
 
 	// Page in all the ship classes that are used on this level
 	int num_ship_types_used = 0;
-	int test_id __attribute__((__unused__)) = -1;
+	int test_id __UNUSED = -1;
 
 	memset( fireball_used, 0, sizeof(int) * MAX_FIREBALL_TYPES );
 

--- a/code/sound/rtvoice.cpp
+++ b/code/sound/rtvoice.cpp
@@ -278,7 +278,7 @@ int rtvoice_start_recording( void (*user_callback)(), int callback_time )
 // NOTE: function converts voice data into compressed format
 void rtvoice_get_data(unsigned char **outbuf, int *size, double *gain)
 {
-	int max_size __attribute__((__unused__)), raw_size;
+	int max_size __UNUSED, raw_size;
 	max_size = dscap_max_buffersize();
 
 	*outbuf=NULL;

--- a/code/weapon/shockwave.cpp
+++ b/code/weapon/shockwave.cpp
@@ -800,7 +800,7 @@ void shockwave_page_in()
 		} else if (Shockwave_info[i].model_id >= 0) {
 			// for a model we have to run model_load() on it again to make sure
 			// that it's ref_count is sane for this mission
-			int idx __attribute__((__unused__)) = model_load( Shockwave_info[i].filename, 0, NULL );
+			int idx __UNUSED = model_load( Shockwave_info[i].filename, 0, NULL );
 			Assert( idx == Shockwave_info[i].model_id );
 
 			model_page_in_textures( Shockwave_info[i].model_id );


### PR DESCRIPTION
An attempt to abstract toolchain capabilities to make it easier to add support for new ones, as well as maintain existing ones.

I may be wrong, but from what I gathered, the following toolchains were supported: MSVC, GCC, Clang and MingW.  If others are desired, the infrastructure makes it fairly straight forward to add new ones.  The proposed new file toolchain.h includes the compiler specific header appropriate to the detected toolchain.

Thus far, I have only tested this on an x86-64 linux platform with GCC.