### PR TITLE
Shivan Hunter's requested HUD table features

### DIFF
--- a/code/hud/hudparse.cpp
+++ b/code/hud/hudparse.cpp
@@ -2611,9 +2611,11 @@ void load_gauge_extra_target_data(int base_w, int base_h, int hud_font, bool sca
 	float origin[2] = {0.0, 1.0};
 	int offset[2];
 	int dock_offsets[2];
+	int dock_max_w;
 	int time_offsets[2];
 	int bracket_offsets[2];
 	int order_offsets[2];
+	int order_max_w;
 	char fname[MAX_FILENAME_LEN] = "targetview3";
 
 	if(gr_screen.res == GR_640) {
@@ -2642,6 +2644,9 @@ void load_gauge_extra_target_data(int base_w, int base_h, int hud_font, bool sca
 	order_offsets[0] = 8;
 	order_offsets[1] = 0;
 
+	dock_max_w = 173;
+	order_max_w = 162;
+
 	HudGaugeExtraTargetData* hud_gauge = gauge_load_common<HudGaugeExtraTargetData>(base_w, base_h, hud_font, scale_gauge, ship_idx, use_clr, origin[0], origin[1], offset[0], offset[1]);
 
 	if(optional_string("Filename:")) {
@@ -2653,8 +2658,14 @@ void load_gauge_extra_target_data(int base_w, int base_h, int hud_font, bool sca
 	if(optional_string("Dock Offsets:")) {
 		stuff_int_list(dock_offsets, 2);
 	}
+	if(optional_string("Dock Max Width:")) {
+		stuff_int(&dock_max_w);
+	}
 	if(optional_string("Order Offsets:")) {
 		stuff_int_list(order_offsets, 2);
+	}
+	if(optional_string("Order Max Width:")) {
+		stuff_int(&order_max_w);
 	}
 	if(optional_string("Time Offsets:")) {
 		stuff_int_list(time_offsets, 2);
@@ -2663,7 +2674,9 @@ void load_gauge_extra_target_data(int base_w, int base_h, int hud_font, bool sca
 	hud_gauge->initBitmaps(fname);
 	hud_gauge->initBracketOffsets(bracket_offsets[0], bracket_offsets[1]);
 	hud_gauge->initDockOffsets(dock_offsets[0], dock_offsets[1]);
+	hud_gauge->initDockMaxWidth(dock_max_w);
 	hud_gauge->initOrderOffsets(order_offsets[0], order_offsets[1]);
+	hud_gauge->initOrderMaxWidth(order_max_w);
 	hud_gauge->initTimeOffsets(time_offsets[0], time_offsets[1]);
 
 	if(ship_idx->at(0) >= 0) {

--- a/code/hud/hudparse.cpp
+++ b/code/hud/hudparse.cpp
@@ -2755,6 +2755,12 @@ void load_gauge_radar_std(int base_w, int base_h, int hud_font, bool scale_gauge
 	if(optional_string("Filename:")) {
 		stuff_string(fname, F_NAME, MAX_FILENAME_LEN);
 	}
+	if(optional_string("Radar Center Offsets:")) {
+		stuff_float_list(Radar_center_offsets, 2);
+	}
+	if(optional_string("Radar Size:")) {
+		stuff_int_list(Radar_radius, 2);
+	}
 	if(optional_string("Infinity Distance Offsets:")) {
 		stuff_int_list(Radar_dist_offsets[2], 2);
 	}
@@ -2857,6 +2863,12 @@ void load_gauge_radar_orb(int base_w, int base_h, int hud_font, bool scale_gauge
 
 	if(optional_string("Filename:")) {
 		stuff_string(fname, F_NAME, MAX_FILENAME_LEN);
+	}
+	if(optional_string("Radar Center Offsets:")) {
+		stuff_float_list(Radar_center_offsets, 2);
+	}
+	if(optional_string("Radar Size:")) {
+		stuff_int_list(Radar_radius, 2);
 	}
 	if(optional_string("Infinity Distance Offsets:")) {
 		stuff_int_list(Radar_dist_offsets[2], 2);

--- a/code/hud/hudparse.cpp
+++ b/code/hud/hudparse.cpp
@@ -3986,6 +3986,7 @@ void load_gauge_wingman_status(int base_w, int base_h, int hud_font, bool scale_
 	float origin[2] = {1.0, 0.0};
 	int offset[2];
 	int header_offsets[2];
+	bool fixed_header_position;
 	int left_frame_end_x;
 	
 	int single_wing_offsets[2];
@@ -4011,6 +4012,7 @@ void load_gauge_wingman_status(int base_w, int base_h, int hud_font, bool scale_
 
 	header_offsets[0] = 2;
 	header_offsets[1] = 2;
+	fixed_header_position = false;
 	left_frame_end_x = 71;
 	
 	single_wing_offsets[0] = 28;
@@ -4053,6 +4055,9 @@ void load_gauge_wingman_status(int base_w, int base_h, int hud_font, bool scale_
 	}
 	if(optional_string("Header Offsets:")) {
 		stuff_int_list(header_offsets, 2);
+	}
+	if(optional_string("Fixed Header Position:")) {
+		stuff_boolean(&fixed_header_position);
 	}
 	if(optional_string("Left Background Width:")) {
 		stuff_int(&left_frame_end_x);
@@ -4098,6 +4103,7 @@ void load_gauge_wingman_status(int base_w, int base_h, int hud_font, bool scale_
 
 	hud_gauge->initBitmaps(fname_left, fname_middle, fname_right, fname_dots);
 	hud_gauge->initHeaderOffsets(header_offsets[0], header_offsets[1]);
+	hud_gauge->initFixedHeaderPosition(fixed_header_position);
 	hud_gauge->initLeftFrameEndX(left_frame_end_x);
 	hud_gauge->initMultipleWingOffsets(multiple_wing_offsets[0], multiple_wing_offsets[1]);
 	hud_gauge->initSingleWingOffsets(single_wing_offsets[0], single_wing_offsets[1]);

--- a/code/hud/hudtargetbox.cpp
+++ b/code/hud/hudtargetbox.cpp
@@ -1379,6 +1379,11 @@ void HudGaugeExtraTargetData::initDockOffsets(int x, int y)
 	dock_offsets[1] = y;
 }
 
+void HudGaugeExtraTargetData::initDockMaxWidth(int width)
+{
+	dock_max_w = width;
+}
+
 void HudGaugeExtraTargetData::initTimeOffsets(int x, int y)
 {
 	time_offsets[0] = x;
@@ -1389,6 +1394,11 @@ void HudGaugeExtraTargetData::initOrderOffsets(int x, int y)
 {
 	order_offsets[0] = x;
 	order_offsets[1] = y;
+}
+
+void HudGaugeExtraTargetData::initOrderMaxWidth(int width)
+{
+	order_max_w = width;
 }
 
 void HudGaugeExtraTargetData::initBitmaps(char *fname)
@@ -1442,7 +1452,7 @@ void HudGaugeExtraTargetData::render(float frametime)
 		if ( ((Player_ship->team == target_shipp->team) || ((Iff_info[target_shipp->team].flags & IFFF_ORDERS_SHOWN) && !(Iff_info[target_shipp->team].flags & IFFF_ORDERS_HIDDEN)) ) && !(ship_get_SIF(target_shipp) & SIF_NOT_FLYABLE) ) {
 			extra_data_shown=1;
 			if ( ship_return_orders(outstr, target_shipp) ) {
-				gr_force_fit_string(outstr, 255, 162);
+				gr_force_fit_string(outstr, 255, order_max_w);
 				has_orders = 1;
 			} else {
 				strcpy_s(outstr, XSTR( "no orders", 337));
@@ -1484,7 +1494,7 @@ void HudGaugeExtraTargetData::render(float frametime)
 			sprintf(outstr, XSTR("Docked: %d objects", 1623), dock_count);
 		}
 
-		gr_force_fit_string(outstr, 255, 173);
+		gr_force_fit_string(outstr, 255, dock_max_w);
 		maybeFlashDock();
 			
 		renderString(position[0] + dock_offsets[0], position[1] + dock_offsets[1], EG_TBOX_EXTRA3, outstr);			

--- a/code/hud/hudtargetbox.h
+++ b/code/hud/hudtargetbox.h
@@ -135,15 +135,19 @@ class HudGaugeExtraTargetData: public HudGauge // HUD_TARGET_MONITOR_EXTRA_DATA
 
 	int bracket_offsets[2]; // Targetbox_coords[gr_screen.res][TBOX_EXTRA]
 	int dock_offsets[2]; // Targetbox_coords[gr_screen.res][TBOX_EXTRA_DOCK]
+	int dock_max_w;
 	int time_offsets[2]; // Targetbox_coords[gr_screen.res][TBOX_EXTRA_TIME]
 	int order_offsets[2]; // Targetbox_coords[gr_screen.res][TBOX_EXTRA_ORDERS]
+	int order_max_w;
 public:
 	HudGaugeExtraTargetData();
 	void initBitmaps(char *fname);
 	void initBracketOffsets(int x, int y);
 	void initDockOffsets(int x, int y);
+	void initDockMaxWidth(int width);
 	void initTimeOffsets(int x, int y);
 	void initOrderOffsets(int x, int y);
+	void initOrderMaxWidth(int width);
 	void updateFrame();
 	void render(float frametime);
 	void initialize();

--- a/code/hud/hudwingmanstatus.cpp
+++ b/code/hud/hudwingmanstatus.cpp
@@ -219,6 +219,11 @@ void HudGaugeWingmanStatus::initHeaderOffsets(int x, int y)
 	header_offsets[1] = y;
 }
 
+void HudGaugeWingmanStatus::initFixedHeaderPosition(bool fixed)
+{
+	fixed_header_position = fixed;
+}
+
 void HudGaugeWingmanStatus::initLeftFrameEndX(int x)
 {
 	left_frame_end_x = x;
@@ -317,7 +322,7 @@ void HudGaugeWingmanStatus::initGrowMode(int mode) {
 
 void HudGaugeWingmanStatus::renderBackground(int num_wings_to_draw)
 {
-	int sx, sy, bitmap;
+	int sx, sy, header_x, header_y, bitmap;
 
 	if((num_wings_to_draw < 1) || (num_wings_to_draw > 5)){
 		Int3();
@@ -343,7 +348,14 @@ void HudGaugeWingmanStatus::renderBackground(int num_wings_to_draw)
 	actual_origin[1] = sy;
 
 	// write "wingmen" on gauge
-	renderString(sx+header_offsets[0], sy+header_offsets[1], XSTR( "wingmen", 352));
+	if (fixed_header_position) {
+		header_x = position[0] + header_offsets[0];
+		header_y = position[1] + header_offsets[1];
+	} else {
+		header_x = sx + header_offsets[0];
+		header_y = sy + header_offsets[1];
+	}
+	renderString(header_x, header_y, XSTR( "wingmen", 352));
 
 	// bring us to the end of the left portion so we can draw the last or middle bits depending on how many wings we have to draw
 	if ( grow_mode == GROW_DOWN ) {

--- a/code/hud/hudwingmanstatus.h
+++ b/code/hud/hudwingmanstatus.h
@@ -39,6 +39,7 @@ protected:
 	hud_frames Wingman_status_dots;
 
 	int header_offsets[2];
+	bool fixed_header_position;
 	int left_frame_end_x;
 	int right_frame_start_offset;
 	
@@ -59,6 +60,7 @@ public:
 	HudGaugeWingmanStatus();
 	void initBitmaps(char *fname_left, char *fname_middle, char *fname_right, char *fname_dots);
 	void initHeaderOffsets(int x, int y);
+	void initFixedHeaderPosition(bool fixed);
 	void initLeftFrameEndX(int x);
 	void initSingleWingOffsets(int x, int y);
 	void initMultipleWingOffsets(int x, int y);


### PR DESCRIPTION
This PR implements the HUD table features that Shivan Hunter requested in [this thread](http://www.hard-light.net/forums/index.php?topic=90978.0). Here are the new options:

* Wingman Status
  * Fixed Header Position: If set to true, then the header text stays in its normal position, even if more than two wings are displayed. Should be placed after "Header Offsets:".
* Extra Target Data
  * Dock Max Width: Sets the maximum width of the docking status. Should be placed after "Dock Offsets:".
  * Order Max Width: Sets the maximum width of the current order. Should be placed after "Order Offsets:".
  * The ETA line is never truncated, so there is no "Time Max Width:".
* Radar (2D and 3D)
  * Radar Center Offsets: Sets the position of the center of the radar. Unlike many other parameters, this one takes floating-point values, but the values are still in pixels. Should be placed after "Filename:".
  * Radar Size: Sets the size of the radar. Should be placed after "Radar Center Offsets:".