### PR TITLE
Add "Right-Align Ship Names:" option to HudGaugeEscort.

### DIFF
--- a/code/graphics/font.cpp
+++ b/code/graphics/font.cpp
@@ -43,9 +43,9 @@ font *Current_font = NULL;
  * @param str		string to crop.  Modifies this string directly
  * @param max_str	max characters allowed in str
  * @param max_width number of pixels to limit string to (less than or equal to).
- * @return			Returns same pointer passed in for str.
+ * @return			Returns the width of the string as given by gr_get_string_size().
  */
-char *gr_force_fit_string(char *str, int max_str, int max_width)
+int gr_force_fit_string(char *str, int max_str, int max_width)
 {
 	int w;
 
@@ -65,7 +65,7 @@ char *gr_force_fit_string(char *str, int max_str, int max_width)
 		}
 	}
 
-	return str;
+	return w;
 }
 
 /**

--- a/code/graphics/font.h
+++ b/code/graphics/font.h
@@ -73,7 +73,7 @@ extern int gr_get_fontnum(const char *filename);
 extern void gr_set_font(int fontnum);
 
 void gr_print_timestamp(int x, int y, fix timestamp, int resize_mode);
-char *gr_force_fit_string(char *str, int max_str, int max_width);
+int gr_force_fit_string(char *str, int max_str, int max_width);
 void gr_font_init();
 void gr_font_close();
 

--- a/code/hud/hudescort.cpp
+++ b/code/hud/hudescort.cpp
@@ -202,6 +202,11 @@ void HudGaugeEscort::initShipNameMaxWidth(int w)
 	ship_name_max_width = w;
 }
 
+void HudGaugeEscort::initRightAlignNames(bool align)
+{
+	right_align_names = align;
+}
+
 void HudGaugeEscort::initBitmaps(char *fname_top, char *fname_middle, char *fname_bottom)
 {
 	Escort_gauges[0].first_frame = bm_load_animation(fname_top, &Escort_gauges[0].num_frames);
@@ -368,10 +373,14 @@ void HudGaugeEscort::renderIcon(int x, int y, int index)
 
 	// print out ship name
 	strcpy_s(buf, sp->ship_name);
-	gr_force_fit_string(buf, 255, ship_name_max_width);	
     end_string_at_first_hash_symbol(buf);
-	
-	renderString( x + ship_name_offsets[0], y + ship_name_offsets[1], EG_ESCORT1 + index, buf);	
+	const int w = gr_force_fit_string(buf, 255, ship_name_max_width);
+
+	if (right_align_names) {
+		renderString( x + ship_name_offsets[0] + ship_name_max_width - w, y + ship_name_offsets[1], EG_ESCORT1 + index, buf);
+	} else {
+		renderString( x + ship_name_offsets[0], y + ship_name_offsets[1], EG_ESCORT1 + index, buf);
+	}
 
 	// show ship integrity
 	hud_get_target_strength(objp, &shields, &integrity);

--- a/code/hud/hudescort.h
+++ b/code/hud/hudescort.h
@@ -52,6 +52,7 @@ protected:
 	int ship_integrity_offsets[2];			// Offset of the Ship Hull column
 	int ship_status_offsets[2];				// Offset of the Ship Status column
 	int ship_name_max_width;			// max width of ship name entries
+	bool right_align_names;				// whether or not to right-align ship names
 public:
 	HudGaugeEscort();
 	void initBitmaps(char *fname_top, char *fname_middle, char *fname_bottom);
@@ -65,6 +66,7 @@ public:
 	void initShipIntegrityOffsets(int x, int y);
 	void initShipStatusOffsets(int x, int y);
 	void initShipNameMaxWidth(int w);
+	void initRightAlignNames(bool align);
 	int setGaugeColorEscort(int index, int team);
 	virtual void render(float frametime);
 	void pageIn();

--- a/code/hud/hudparse.cpp
+++ b/code/hud/hudparse.cpp
@@ -1702,6 +1702,7 @@ void load_gauge_escort_view(int base_w, int base_h, int hud_font, bool scale_gau
 	int ship_name_max_w = 100;
 	int ship_integrity_offsets[2];
 	int ship_status_offsets[2];
+	bool right_align_names = false;
 	char header_text[MAX_FILENAME_LEN] = "";
 	char fname_top[MAX_FILENAME_LEN] = "escort1";
 	char fname_middle[MAX_FILENAME_LEN] = "escort2";
@@ -1784,6 +1785,10 @@ void load_gauge_escort_view(int base_w, int base_h, int hud_font, bool scale_gau
 		stuff_int(&ship_name_max_w);
 	}
 
+	if ( optional_string("Right-Align Ship Names:") ) {
+		stuff_boolean(&right_align_names);
+	}
+
 	if (header_text[0] == '\0') {
 		strcpy_s(header_text, XSTR("monitoring", 285));
 	}
@@ -1799,6 +1804,7 @@ void load_gauge_escort_view(int base_w, int base_h, int hud_font, bool scale_gau
 	hud_gauge->initShipNameOffsets(ship_name_offsets[0], ship_name_offsets[1]);
 	hud_gauge->initShipStatusOffsets(ship_status_offsets[0], ship_status_offsets[1]);
 	hud_gauge->initShipNameMaxWidth(ship_name_max_w);
+	hud_gauge->initRightAlignNames(right_align_names);
 
 	if(ship_idx->at(0) >= 0) {
 		for (SCP_vector<int>::iterator ship_index = ship_idx->begin(); ship_index != ship_idx->end(); ++ship_index) {


### PR DESCRIPTION
It allows the escort gauge to render with ship names right-aligned, as the name would suggest. Inability to retrieve the width from `gr_force_fit_string()` (requiring another `gr_get_string_size()` call) is slightly inefficient, but performance impact is probably negligible.

Requested by ShivanHunter.