### PR TITLE
Fix for Mantis 3096

### DIFF
--- a/code/fred2/fredrender.cpp
+++ b/code/fred2/fredrender.cpp
@@ -140,8 +140,7 @@ color colour_yellow;
 
 void fred_enable_htl()
 {
-	if (!Briefing_dialog) gr_set_proj_matrix( (4.0f/9.0f) * PI * FRED_DEFAULT_HTL_FOV,  gr_screen.aspect*(float)gr_screen.clip_width/(float)gr_screen.clip_height, 1.0f, FRED_DEAFULT_HTL_DRAW_DIST);
-	if (Briefing_dialog) gr_set_proj_matrix( Briefing_window_FOV,  gr_screen.aspect*(float)gr_screen.clip_width/(float)gr_screen.clip_height, 1.0f, FRED_DEAFULT_HTL_DRAW_DIST);
+	gr_set_proj_matrix((4.0f/9.0f) * PI * (Briefing_dialog ? Briefing_window_FOV : FRED_DEFAULT_HTL_FOV),  gr_screen.aspect*(float)gr_screen.clip_width/(float)gr_screen.clip_height, 1.0f, FRED_DEAFULT_HTL_DRAW_DIST);
 	gr_set_view_matrix(&Eye_position, &Eye_matrix);
 }
 
@@ -1504,11 +1503,7 @@ void render_frame()
 	gr_set_font(FONT1);
 	light_reset();
 
-	if (Briefing_dialog) {
-		g3_set_view_matrix(&eye_pos, &eye_orient, Briefing_window_FOV);
-	} else {
-		g3_set_view_matrix(&eye_pos, &eye_orient, 0.5f);
-	}
+	g3_set_view_matrix(&eye_pos, &eye_orient, (Briefing_dialog ? Briefing_window_FOV : FRED_DEFAULT_HTL_FOV));
 	Viewer_pos = eye_pos;  // for starfield code
 	
 	fred_enable_htl();
@@ -1613,11 +1608,7 @@ void render_frame()
 		gr_set_clip(0, 0, True_rw, True_rh);
 
 	g3_start_frame(0);	 // ** Accounted for
-	if (Briefing_dialog) {
-		g3_set_view_matrix(&eye_pos, &eye_orient, Briefing_window_FOV);
-	} else {
-		g3_set_view_matrix(&eye_pos, &eye_orient, 0.5f);
-	}
+	g3_set_view_matrix(&eye_pos, &eye_orient, (Briefing_dialog ? Briefing_window_FOV : FRED_DEFAULT_HTL_FOV));
 }
 
 void game_do_frame()


### PR DESCRIPTION
This fixes the bug described in [Mantis 3096](http://scp.indiegames.us/mantis/view.php?id=3096) by doing these things:

* Applying the pi*(4/9) correction to the briefing view, as is already done to the main view
* Always using the FRED_DEFAULT_HTL_FOV value for the main view's FOV rather than a mix of FRED_DEFAULT_HTL_FOV and 0.5