### PR TITLE
Enhance an Assert to help track down how issue 187 could happen

### DIFF
--- a/code/network/multimsgs.cpp
+++ b/code/network/multimsgs.cpp
@@ -6035,7 +6035,10 @@ void process_post_sync_data_packet(ubyte *data, header *hinfo)
 		objp = multi_get_network_object(net_sig);
 
 		// make sure we found a ship
-		Assert((objp != NULL) && (objp->type == OBJ_SHIP));
+		Assertion(objp != NULL, "idx: %d, ship_count: %d, sinfo_index: %u, ts_index: %u, net_sig: %u",
+			idx, ship_count, sinfo_index, ts_index, net_sig);
+		Assertion(objp->type == OBJ_SHIP, "type: %d, idx: %d, ship_count: %d, sinfo_index: %u, ts_index: %u, net_sig: %u",
+			objp->type, idx, ship_count, sinfo_index, ts_index, net_sig);
 
 		// set the ship to be the right class
 		change_ship_type(objp->instance,(int)sinfo_index);


### PR DESCRIPTION
The Assert in #482  will now be split into both tests, with hopefully some more helpful information to see what might have happened.  Will ultimately have to see this happen again in production to attempt to resolve the actual issue.  Reproduction steps would be ideal but we don't know how this instance occurred.

As I don't know how to actually hit this assert, making sure that the tokenization is correct for the given variable types before it is actually encountered is probably the most import part of this PR.  I believe the ints and chars should be %d and the unsigned bytes and shorts should be %u but some double checking on that would be appreciated.