### PR TITLE
Wrap some unused functions in a diagnostic protection pragma

### DIFF
--- a/code/math/fvi.cpp
+++ b/code/math/fvi.cpp
@@ -18,7 +18,7 @@
 #define	UNINITIALIZED_VALUE	-1234567.8f
 #define WARN_DIST	1.0
 
-static void accurate_square_root( float A, float B, float C, float discriminant, float *root1, float *root2 );
+static void accurate_square_root( float A, float B, float C, float discriminant, float *root1, float *root2 ) __UNUSED;
 
 static float matrix_determinant_from_vectors(const vec3d *v1, const vec3d *v2, const vec3d *v3)
 {

--- a/code/math/vecmat.cpp
+++ b/code/math/vecmat.cpp
@@ -29,6 +29,8 @@ matrix vmd_identity_matrix = IDENTITY_MATRIX;
 
 #define	UNINITIALIZED_VALUE	-12345678.9f
 
+static void rotate_z ( matrix *m, float theta ) __UNUSED;
+
 bool vm_vec_equal(const vec4 &self, const vec4 &other)
 {
 	return fl_equal(self.a1d[0], other.a1d[0]) && fl_equal(self.a1d[1], other.a1d[1]) && fl_equal(self.a1d[2], other.a1d[2]) && fl_equal(self.a1d[3], other.a1d[3]);

--- a/configure.ac
+++ b/configure.ac
@@ -251,7 +251,7 @@ fi
 
 if test "$fs2_debug" = "yes" ; then
 	AC_DEFINE([_DEBUG])
-	D_CFLAGS="$D_CFLAGS -O0 -g -Wall -Wextra -Wno-unused-parameter -Wno-unused-function -Wno-write-strings -Wshadow -funroll-loops"
+	D_CFLAGS="$D_CFLAGS -O0 -g -Wall -Wextra -Wno-unused-parameter -Wno-write-strings -Wshadow -funroll-loops"
 	D_LDFLAGS="$D_LDFLAGS -g"
 
 	if test "$fs2_fred" = "yes" ; then
@@ -262,7 +262,7 @@ if test "$fs2_debug" = "yes" ; then
 else
 	AC_DEFINE([NDEBUG])
 	D_CFLAGS="$D_CFLAGS -O2 -Wall -funroll-loops"
-	D_CFLAGS="$D_CFLAGS -Wno-unused-function -Wno-write-strings -Wno-unused-variable"
+	D_CFLAGS="$D_CFLAGS -Wno-write-strings -Wno-unused-variable"
 	
 	AC_C_COMPILE_FLAGS([-Wno-unused-but-set-variable])
 	


### PR DESCRIPTION
Should work on GCC, tested and works on Xcode's clang.  clang isn't reporting any more unused functions, so GCC on Linux probably won't either, and I've removed that hider in the configure.ac.  If any more show up, we can probably determine whether to remove or protect them in a similar manner.  We could also do the same for unused parameters, unused variables, etc, but I'll leave that for another audit.  Would fix the remaining issues in #292.