### PR TITLE
Allow model rendering code to use polymodel_instance. 

### DIFF
--- a/code/model/model.h
+++ b/code/model/model.h
@@ -827,7 +827,7 @@ void model_instance_free_all();
 // Loads a model from disk and returns the model number it loaded into.
 int model_load(char *filename, int n_subsystems, model_subsystem *subsystems, int ferror = 1, int duplicate = 0);
 
-int model_create_instance(int model_num, int submodel_num = -1);
+int model_create_instance(int model_num);
 void model_delete_instance(int model_instance_num);
 
 // Goober5000
@@ -1040,7 +1040,7 @@ extern void model_instance_find_world_dir(vec3d * out_dir, vec3d *in_dir,int mod
 // Clears all the submodel instances stored in a model to their defaults.
 extern void model_clear_instance(int model_num);
 
-void model_clear_submodel_instance( submodel_instance *sm_instance );
+void model_clear_submodel_instance( submodel_instance *sm_instance, bsp_info *sm );
 void model_clear_submodel_instances( int model_instance_num );
 
 // Sets rotating submodel turn info to that stored in model
@@ -1053,7 +1053,7 @@ extern void model_clear_instance_info(submodel_instance_info * sii);
 extern void model_set_instance(int model_num, int sub_model_num, submodel_instance_info * sii, int flags = 0 );
 extern void model_set_instance_techroom(int model_num, int sub_model_num, float angle_1, float angle_2 );
 
-void model_update_instance(int model_instance_num, int sub_model_num, submodel_instance_info *sii);
+void model_update_instance(int model_instance_num, int sub_model_num, submodel_instance_info *sii, int flags);
 void model_instance_dumb_rotation(int model_instance_num);
 
 // Adds an electrical arcing effect to a submodel

--- a/code/model/modelread.cpp
+++ b/code/model/modelread.cpp
@@ -4555,7 +4555,6 @@ void model_clear_submodel_instance( submodel_instance *sm_instance, bsp_info *sm
 
 	sm_instance->blown_off = sm->is_damaged ? true : false;
 
-	sm_instance->blown_off = false;
 	sm_instance->collision_checked = false;
 }
 

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -13051,11 +13051,11 @@ void ship_model_update_instance(object *objp)
 		}
 
 		if ( psub->subobj_num >= 0 )	{
-			model_update_instance(model_instance_num, psub->subobj_num, &pss->submodel_info_1 );
+			model_update_instance(model_instance_num, psub->subobj_num, &pss->submodel_info_1, pss->flags );
 		}
 
 		if ( (psub->subobj_num != psub->turret_gun_sobj) && (psub->turret_gun_sobj >= 0) )		{
-			model_update_instance(model_instance_num, psub->turret_gun_sobj, &pss->submodel_info_2 );
+			model_update_instance(model_instance_num, psub->turret_gun_sobj, &pss->submodel_info_2, pss->flags );
 		}
 	}
 
@@ -18993,8 +18993,6 @@ void ship_render(object* obj, draw_list* scene)
 		}
 	}
 
-	ship_model_start(obj);
-
 	// Only render electrical arcs if within 500m of the eye (for a 10m piece)
 	if ( vm_vec_dist_quick( &obj->pos, &Eye_position ) < obj->radius*50.0f && !Rendering_to_shadow_map ) {
 		for ( int i = 0; i < MAX_SHIP_ARCS; i++ )	{
@@ -19018,8 +19016,6 @@ void ship_render(object* obj, draw_list* scene)
 		} else if(shipp->flags & SF_DEPART_WARP) {
 			shipp->warpout_effect->warpShipRender();
 		}
-
-		ship_model_stop(obj);
 
 		return;
 	}
@@ -19092,8 +19088,6 @@ void ship_render(object* obj, draw_list* scene)
 
 		model_render_queue(&render_info, scene, sip->model_num, &obj->orient, &obj->pos);
 	}
-
-	ship_model_stop(obj);
 
 	if (shipp->shield_hits && !Rendering_to_shadow_map) {
 		create_shield_explosion_all(obj);


### PR DESCRIPTION
Removes the reliance on ship_model_start/stop for rendering models. Also fix a bunch of oversights involving blown off models in the polymodel_instance code.