### PR TITLE
Fix CapsLock discrepancy on Unix-based systems.

### DIFF
--- a/code/osapi/osapi_unix.cpp
+++ b/code/osapi/osapi_unix.cpp
@@ -192,9 +192,12 @@ DWORD unix_process(DWORD lparam)
 					Gr_screen_mode_switch = 0;
 					break;
 				}*/
-
 				if (SDLtoFS2[event.key.keysym.sym]) {
-					key_mark( SDLtoFS2[event.key.keysym.sym], 0, 0 );
+					if (SDLtoFS2[event.key.keysym.sym] == KEY_CAPSLOCK) {
+						key_mark( SDLtoFS2[event.key.keysym.sym], 1, 0 );
+					} else {
+						key_mark( SDLtoFS2[event.key.keysym.sym], 0, 0 );
+					}
 				}
 				break;
 

--- a/code/osapi/osapi_unix.cpp
+++ b/code/osapi/osapi_unix.cpp
@@ -158,6 +158,7 @@ DWORD unix_process(DWORD lparam)
 	SDL_Event event;
 
 	while( SDL_PollEvent(&event) ) {
+		int pressedKey = 0;
 		switch(event.type) {
 			case SDL_ACTIVEEVENT:
 				if( (event.active.state & SDL_APPACTIVE) || (event.active.state & SDL_APPINPUTFOCUS) ) {
@@ -182,8 +183,10 @@ DWORD unix_process(DWORD lparam)
 					break;
 				}*/
 
-				if( SDLtoFS2[event.key.keysym.sym] ) {
-					key_mark( SDLtoFS2[event.key.keysym.sym], 1, 0 );
+				pressedKey = SDLtoFS2[event.key.keysym.sym];
+
+				if( pressedKey ) {
+					key_mark( pressedKey, 1, 0 );
 				}
 				break;
 
@@ -192,11 +195,14 @@ DWORD unix_process(DWORD lparam)
 					Gr_screen_mode_switch = 0;
 					break;
 				}*/
-				if (SDLtoFS2[event.key.keysym.sym]) {
-					if (SDLtoFS2[event.key.keysym.sym] == KEY_CAPSLOCK) {
-						key_mark( SDLtoFS2[event.key.keysym.sym], 1, 0 );
+
+				pressedKey = SDLtoFS2[event.key.keysym.sym];
+
+				if (pressedKey) {
+					if (pressedKey == KEY_CAPSLOCK) {
+						key_mark( pressedKey, 1, 0 );
 					} else {
-						key_mark( SDLtoFS2[event.key.keysym.sym], 0, 0 );
+						key_mark( pressedKey, 0, 0 );
 					}
 				}
 				break;


### PR DESCRIPTION
Since I'm a wingnut, I use CapsLock to turn glide mode on and off. On Unix-based systems, pressing CapsLock would only toggle glide mode if it wasn't already turned on.