### PR TITLE
for model vertices, use the entire range of RAND_MAX, not the range divided by 32

### DIFF
--- a/code/model/modelinterp.cpp
+++ b/code/model/modelinterp.cpp
@@ -3603,8 +3603,22 @@ void submodel_get_two_random_points(int model_num, int submodel_num, vec3d *v1, 
 		return;
 	}
 
-	int vn1 = (myrand()>>5) % nv;
-	int vn2 = (myrand()>>5) % nv;
+#ifndef NDEBUG
+	if (RAND_MAX < nv)
+	{
+		static int submodel_get_two_random_points_warned = false;
+		if (!submodel_get_two_random_points_warned)
+		{
+			polymodel *pm = model_get(model_num);
+			Warning(LOCATION, "RAND_MAX is only %d, but submodel %d for model %s has %d vertices!  Explosions will not propagate through the entire model!", RAND_MAX, submodel_num, pm->filename, nv);
+			submodel_get_two_random_points_warned = true;
+		}
+	}
+#endif
+
+	Assert(nv > 0);	// Goober5000 - to avoid div-0 error
+	int vn1 = myrand() % nv;
+	int vn2 = myrand() % nv;
 
 	*v1 = *Interp_verts[vn1];
 	*v2 = *Interp_verts[vn2];
@@ -3641,9 +3655,22 @@ void submodel_get_two_random_points_better(int model_num, int submodel_num, vec3
 			return;
 		}
 
+#ifndef NDEBUG
+		if (RAND_MAX < nv)
+		{
+			static int submodel_get_two_random_points_warned = false;
+			if (!submodel_get_two_random_points_warned)
+			{
+				polymodel *pm = model_get(model_num);
+				Warning(LOCATION, "RAND_MAX is only %d, but submodel %d for model %s has %d vertices!  Explosions will not propagate through the entire model!", RAND_MAX, submodel_num, pm->filename, nv);
+				submodel_get_two_random_points_warned = true;
+			}
+		}
+#endif
+
 		Assert(nv > 0);	// Goober5000 - to avoid div-0 error
-		int vn1 = (myrand()>>5) % nv;
-		int vn2 = (myrand()>>5) % nv;
+		int vn1 = myrand() % nv;
+		int vn2 = myrand() % nv;
 
 		*v1 = tree->point_list[vn1];
 		*v2 = tree->point_list[vn2];

--- a/code/model/modelinterp.cpp
+++ b/code/model/modelinterp.cpp
@@ -3610,13 +3610,12 @@ void submodel_get_two_random_points(int model_num, int submodel_num, vec3d *v1, 
 		if (!submodel_get_two_random_points_warned)
 		{
 			polymodel *pm = model_get(model_num);
-			Warning(LOCATION, "RAND_MAX is only %d, but submodel %d for model %s has %d vertices!  Explosions will not propagate through the entire model!", RAND_MAX, submodel_num, pm->filename, nv);
+			Warning(LOCATION, "RAND_MAX is only %d, but submodel %d for model %s has %d vertices!  Explosions will not propagate through the entire model!\n", RAND_MAX, submodel_num, pm->filename, nv);
 			submodel_get_two_random_points_warned = true;
 		}
 	}
 #endif
 
-	Assert(nv > 0);	// Goober5000 - to avoid div-0 error
 	int vn1 = myrand() % nv;
 	int vn2 = myrand() % nv;
 
@@ -3661,14 +3660,12 @@ void submodel_get_two_random_points_better(int model_num, int submodel_num, vec3
 			static int submodel_get_two_random_points_warned = false;
 			if (!submodel_get_two_random_points_warned)
 			{
-				polymodel *pm = model_get(model_num);
-				Warning(LOCATION, "RAND_MAX is only %d, but submodel %d for model %s has %d vertices!  Explosions will not propagate through the entire model!", RAND_MAX, submodel_num, pm->filename, nv);
+				Warning(LOCATION, "RAND_MAX is only %d, but submodel %d for model %s has %d vertices!  Explosions will not propagate through the entire model!\n", RAND_MAX, submodel_num, pm->filename, nv);
 				submodel_get_two_random_points_warned = true;
 			}
 		}
 #endif
 
-		Assert(nv > 0);	// Goober5000 - to avoid div-0 error
 		int vn1 = myrand() % nv;
 		int vn2 = myrand() % nv;
 


### PR DESCRIPTION
When explosions or sparks or electrical arcs or debris are created, the code will choose some random vertices on the detail[0] submodel.  However, for some reason, it doesn't use the entire range of RAND_MAX.  It divides by 2^5 first.  Since RAND_MAX is usually 32767, this results in a range of 0..1023.  And since most capships these days have more than 1024 vertices, explosions etc. will only be generated on the first 1024 vertices of the model.

I first noticed this problem with Scroll's GTCa Warlock, but The Dagger confirmed that it was a problem with another Inferno model.  A third large model did not have the problem, but its first 1024 vertices were distributed throughout the ship.

The division by 2^5 dates all the way back to the retail code.  I can only speculate that it was meant to make the division faster by restricting its range.  I wonder how many retail models had more than 1024 vertices.

I also added some extra debugging code in case anyone ever decides to add a really huge model with more than 32767 vertices.  We'll need to use rand32 in that case.