### PR TITLE
Avoid application is not responding messages

### DIFF
--- a/code/freespace2/freespace.cpp
+++ b/code/freespace2/freespace.cpp
@@ -1233,6 +1233,8 @@ void game_loading_callback(int count)
 	}
 #endif	// !NDEBUG
 
+	os_poll();
+
 	if (do_flip)
 		gr_flip();
 }


### PR DESCRIPTION
It's still possible that FSO will be unresponsive when loading large models but as soon as `game_busy` is called that will be resolved.