### PR TITLE
Changed bitmap_lookup to use ubyte instead of floats.

### DIFF
--- a/code/bmpman/bmpman.cpp
+++ b/code/bmpman/bmpman.cpp
@@ -123,7 +123,7 @@ bitmap_lookup::bitmap_lookup(int bitmap_num):
 	Width = be->bm.w;
 	Height = be->bm.h;
 
-	Bitmap_data = (float*)vm_malloc(Width * Height * Num_channels * sizeof(float));
+	Bitmap_data = (ubyte*)vm_malloc(Width * Height * Num_channels * sizeof(ubyte));
 
 	gr_get_bitmap_from_texture((void*)Bitmap_data, bitmap_num);
 }
@@ -156,7 +156,7 @@ float bitmap_lookup::get_channel_red(float u, float v)
 	int x = fl2i(map_texture_address(u) * (Width-1));
 	int y = fl2i(map_texture_address(v) * (Height-1));
 
-	return Bitmap_data[(y*Width + x)*Num_channels];
+	return i2fl(Bitmap_data[(y*Width + x)*Num_channels]) / 255.0f;
 }
 
 float bitmap_lookup::get_channel_green(float u, float v)
@@ -169,7 +169,7 @@ float bitmap_lookup::get_channel_green(float u, float v)
 	int x = fl2i(map_texture_address(u) * (Width-1));
 	int y = fl2i(map_texture_address(v) * (Height-1));
 
-	return Bitmap_data[(y*Width + x)*Num_channels + 1];
+	return i2fl(Bitmap_data[(y*Width + x)*Num_channels + 1]) / 255.0f;
 }
 
 float bitmap_lookup::get_channel_blue(float u, float v)
@@ -179,7 +179,7 @@ float bitmap_lookup::get_channel_blue(float u, float v)
 	int x = fl2i(map_texture_address(u) * (Width-1));
 	int y = fl2i(map_texture_address(v) * (Height-1));
 
-	return Bitmap_data[(y*Width + x)*Num_channels + 2];
+	return i2fl(Bitmap_data[(y*Width + x)*Num_channels + 2]) / 255.0f;
 }
 
 float bitmap_lookup::get_channel_alpha(float u, float v)
@@ -189,7 +189,7 @@ float bitmap_lookup::get_channel_alpha(float u, float v)
 	int x = fl2i(map_texture_address(u) * (Width-1));
 	int y = fl2i(map_texture_address(v) * (Height-1));
 
-	return Bitmap_data[(y*Width + x)*Num_channels + 3];
+	return i2fl(Bitmap_data[(y*Width + x)*Num_channels + 3]) / 255.0f;
 }
 
 /**

--- a/code/bmpman/bmpman.h
+++ b/code/bmpman/bmpman.h
@@ -175,7 +175,7 @@ void *bm_malloc(int handle, int size);
 void bm_update_memory_used(int n, int size);
 
 class bitmap_lookup {
-	float *Bitmap_data;
+	ubyte *Bitmap_data;
 
 	int Width;
 	int Height;

--- a/code/graphics/gropengltexture.cpp
+++ b/code/graphics/gropengltexture.cpp
@@ -1318,12 +1318,12 @@ void gr_opengl_get_bitmap_from_texture(void* data_out, int bitmap_num)
 	tcache_slot_opengl *ts = &Textures[n];
 	
 	GLenum pixel_format = GL_RGB;
-	GLenum data_format = GL_FLOAT;
-	int bytes_per_pixel = 3 * sizeof(float);
+	GLenum data_format = GL_UNSIGNED_BYTE;
+	int bytes_per_pixel = 3 * sizeof(ubyte);
 
 	if ( bm_has_alpha_channel(bitmap_num) ) {
 		pixel_format = GL_RGBA;
-		bytes_per_pixel = 4 * sizeof(float);
+		bytes_per_pixel = 4 * sizeof(ubyte);
 	}
 
 	opengl_get_texture(ts->texture_target, pixel_format, data_format, 1, ts->w, ts->h, bytes_per_pixel, data_out, 0);


### PR DESCRIPTION
This should speed up load times by about half when scanning a model for transparent triangles. Not quite back to original load times, but it's a start.