### PR TITLE
Share fire direction turret flag

### DIFF
--- a/code/ai/aiturret.cpp
+++ b/code/ai/aiturret.cpp
@@ -1342,7 +1342,7 @@ void ship_get_global_turret_gun_info(object *objp, ship_subsys *ssp, vec3d *gpos
 
 		model_instance_find_world_point(&tmp_pos, &avg, tp->model_num, Ships[objp->instance].model_instance_num, tp->turret_gun_sobj, &objp->orient, &objp->pos);
 
-		if (targetp == NULL) {
+		if (targetp == nullptr) {
 			object *lep = &Objects[ssp->turret_enemy_objnum];
 
 			int best_weapon_tidx = turret_select_best_weapon(ssp, lep);
@@ -1355,7 +1355,7 @@ void ship_get_global_turret_gun_info(object *objp, ship_subsys *ssp, vec3d *gpos
 
 			float weapon_system_strength = ship_get_subsystem_strength(&Ships[ssp->parent_objnum], SUBSYSTEM_WEAPONS);
 
-			if ((ssp->targeted_subsys != NULL) && !(ssp->flags & SSF_NO_SS_TARGETING)) {
+			if ((ssp->targeted_subsys != nullptr) && !(ssp->flags & SSF_NO_SS_TARGETING)) {
 				if (ssp->turret_enemy_objnum != -1) {
 					vm_vec_unrotate(&enemy_point, &ssp->targeted_subsys->system_info->pnt, &Objects[ssp->turret_enemy_objnum].orient);
 					vm_vec_add2(&enemy_point, &ssp->last_aim_enemy_pos);

--- a/code/ai/aiturret.cpp
+++ b/code/ai/aiturret.cpp
@@ -1334,9 +1334,57 @@ void ship_get_global_turret_gun_info(object *objp, ship_subsys *ssp, vec3d *gpos
 	//model_find_world_point(gpos, gun_pos, tp->model_num, tp->turret_gun_sobj, &objp->orient, &objp->pos );
 	model_instance_find_world_point(gpos, gun_pos, tp->model_num, Ships[objp->instance].model_instance_num, tp->turret_gun_sobj, &objp->orient, &objp->pos);
 
-	if (use_angles)
-		model_instance_find_world_dir(gvec, &tp->turret_norm, tp->model_num, Ships[objp->instance].model_instance_num, tp->turret_gun_sobj, &objp->orient, &objp->pos );
-	else {
+	if (use_angles) {
+		model_instance_find_world_dir(gvec, &tp->turret_norm, tp->model_num, Ships[objp->instance].model_instance_num, tp->turret_gun_sobj, &objp->orient, &objp->pos);
+	} else if (tp->flags2 & MSS_FLAG2_SHARE_FIRE_DIRECTION) {
+		vec3d shared_dir, avg, tmp_pos, tmp_target, enemy_point;
+		vm_vec_avg_n(&avg, tp->turret_num_firing_points, tp->turret_firing_point);
+
+		model_instance_find_world_point(&tmp_pos, &avg, tp->model_num, Ships[objp->instance].model_instance_num, tp->turret_gun_sobj, &objp->orient, &objp->pos);
+
+		if (targetp == NULL) {
+			object *lep = &Objects[ssp->turret_enemy_objnum];
+
+			int best_weapon_tidx = turret_select_best_weapon(ssp, lep);
+
+			//This turret doesn't have any good weapons
+			if (best_weapon_tidx < 0)
+				return;
+
+			weapon_info *wip = get_turret_weapon_wip(&ssp->weapons, best_weapon_tidx);
+
+			float weapon_system_strength = ship_get_subsystem_strength(&Ships[ssp->parent_objnum], SUBSYSTEM_WEAPONS);
+
+			if ((ssp->targeted_subsys != NULL) && !(ssp->flags & SSF_NO_SS_TARGETING)) {
+				if (ssp->turret_enemy_objnum != -1) {
+					vm_vec_unrotate(&enemy_point, &ssp->targeted_subsys->system_info->pnt, &Objects[ssp->turret_enemy_objnum].orient);
+					vm_vec_add2(&enemy_point, &ssp->last_aim_enemy_pos);
+				}
+			} else {
+				if ((lep->type == OBJ_SHIP) && (Ship_info[Ships[lep->instance].ship_info_index].flags & (SIF_BIG_SHIP | SIF_HUGE_SHIP))) {
+					ai_big_pick_attack_point_turret(lep, ssp, &tmp_pos, &tp->turret_norm, &enemy_point, tp->turret_fov, MIN(wip->max_speed * wip->lifetime, wip->weapon_range));
+				}
+				else {
+					enemy_point = ssp->last_aim_enemy_pos;
+				}
+			}
+
+			vec3d target_moving_direction = ssp->last_aim_enemy_vel;
+
+			//Try to guess where the enemy will be, and store that spot in predicted_enemy_pos
+			if (The_mission.ai_profile->flags & AIPF_USE_ADDITIVE_WEAPON_VELOCITY) {
+				vm_vec_scale_sub2(&target_moving_direction, &objp->phys_info.vel, wip->vel_inherit_amount);
+			}
+
+			set_predicted_enemy_pos_turret(&tmp_target, &tmp_pos, objp, &enemy_point, &target_moving_direction, wip->max_speed, ssp->turret_time_enemy_in_range * (weapon_system_strength + 1.0f) / 2.0f);
+		} else {
+			tmp_target = *targetp;
+		}
+
+		vm_vec_normalized_dir(&shared_dir, &tmp_target, &tmp_pos);
+
+		model_instance_find_world_dir(gvec, &shared_dir, tp->model_num, Ships[objp->instance].model_instance_num, tp->turret_gun_sobj, &objp->orient, &objp->pos);
+	} else {
 		//vector	gun_pos2;
 		//vm_vec_add(&gun_pos2, gpos, gun_pos);
 		vm_vec_normalized_dir(gvec, targetp, gpos);

--- a/code/model/model.h
+++ b/code/model/model.h
@@ -142,6 +142,7 @@ typedef struct polymodel_instance {
 #define MSS_FLAG2_TURRET_USE_AMMO				 (1 << 5)	// enables ammo consumption for turrets (DahBlount)
 #define MSS_FLAG2_AUTOREPAIR_IF_DISABLED		 (1 << 6)	// Allows the subsystem to repair itself even if disabled (MageKing17)
 #define MSS_FLAG2_NO_AUTOREPAIR_IF_DISABLED		 (1 << 7)	// Inversion of the previous; disallows this particular subsystem if the ship-wide flag is set (MageKing17)
+#define MSS_FLAG2_SHARE_FIRE_DIRECTION			 (1 << 8)	// (DahBlount) Whenever the turret fires, make all firing points fire in the same direction.
 
 #define NUM_SUBSYSTEM_FLAGS			33
 

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -259,6 +259,7 @@ flag_def_list Subsystem_flags[] = {
 	{ "turret use ammo",		MSS_FLAG2_TURRET_USE_AMMO, 1},
 	{ "autorepair if disabled",	MSS_FLAG2_AUTOREPAIR_IF_DISABLED, 1},
 	{ "don't autorepair if disabled", MSS_FLAG2_NO_AUTOREPAIR_IF_DISABLED, 1},
+	{ "share fire direction", MSS_FLAG2_SHARE_FIRE_DIRECTION, 1 }
 };
 
 const int Num_subsystem_flags = sizeof(Subsystem_flags)/sizeof(flag_def_list);

--- a/code/weapon/beam.cpp
+++ b/code/weapon/beam.cpp
@@ -2201,8 +2201,12 @@ void beam_aim(beam *b)
 		if (!(b->flags & BF_IS_FIGHTER_BEAM))
 			b->subsys->turret_next_fire_pos = b->firingpoint;
 
-		// where the shot is originating from (b->last_start gets filled in)
-		beam_get_global_turret_gun_info(b->objp, b->subsys, &b->last_start, &temp, 1, &p2, (b->flags & BF_IS_FIGHTER_BEAM) > 0);
+		if (b->subsys->system_info->flags2 & MSS_FLAG2_SHARE_FIRE_DIRECTION) {
+			beam_get_global_turret_gun_info(b->objp, b->subsys, &b->last_start, &temp, 0, NULL, (b->flags & BF_IS_FIGHTER_BEAM) > 0);
+		} else {
+			// where the shot is originating from (b->last_start gets filled in)
+			beam_get_global_turret_gun_info(b->objp, b->subsys, &b->last_start, &temp, 1, &p2, (b->flags & BF_IS_FIGHTER_BEAM) > 0);
+		}
 
 		b->subsys->turret_next_fire_pos = temp_int;
 	}
@@ -2214,7 +2218,13 @@ void beam_aim(beam *b)
 		if(b->target_subsys != NULL){
 			vm_vec_unrotate(&b->last_shot, &b->target_subsys->system_info->pnt, &b->target->orient);
 			vm_vec_add2(&b->last_shot, &b->target->pos);
-			vm_vec_sub(&temp, &b->last_shot, &b->last_start);
+
+			if ((b->subsys != NULL) && (b->subsys->system_info->flags2 & MSS_FLAG2_SHARE_FIRE_DIRECTION)) {
+				float dist = vm_vec_dist(&b->last_shot,&b->last_start);
+				vm_vec_scale(&temp, dist);
+			} else {
+				vm_vec_sub(&temp, &b->last_shot, &b->last_start);
+			}
 
 			vm_vec_scale_add(&b->last_shot, &b->last_start, &temp, 2.0f);
 			break;
@@ -2222,29 +2232,57 @@ void beam_aim(beam *b)
 
 		// if we're shooting at a big ship - shoot directly at the model
 		if((b->target != NULL) && (b->target->type == OBJ_SHIP) && (Ship_info[Ships[b->target->instance].ship_info_index].flags & (SIF_BIG_SHIP | SIF_HUGE_SHIP))){
-			// rotate into world coords
-			vm_vec_unrotate(&temp, &b->binfo.dir_a, &b->target->orient);
-			vm_vec_add2(&temp, &b->target->pos);
+			if ((b->subsys != NULL) && (b->subsys->system_info->flags2 & MSS_FLAG2_SHARE_FIRE_DIRECTION)) {
+				vec3d pnt;
+				vm_vec_unrotate(&pnt, &b->binfo.dir_a, &b->target->orient);
+				vm_vec_add2(&pnt, &b->target->pos);
 
-			// get the shot point
-			vm_vec_sub(&p2, &temp, &b->last_start);
+				float dist = vm_vec_dist(&pnt, &b->last_start);
+				vm_vec_scale(&temp, dist);
+				p2 = temp;
+			} else {
+				// rotate into world coords
+				vm_vec_unrotate(&temp, &b->binfo.dir_a, &b->target->orient);
+				vm_vec_add2(&temp, &b->target->pos);
+
+				// get the shot point
+				vm_vec_sub(&p2, &temp, &b->last_start);
+			}
 			vm_vec_scale_add(&b->last_shot, &b->last_start, &p2, 2.0f);
 			break;
 		}
 
 		// point at the center of the target...
 		if (b->flags & BF_TARGETING_COORDS) {
-			b->last_shot = b->target_pos1;
+			if ((b->subsys != NULL) && (b->subsys->system_info->flags2 & MSS_FLAG2_SHARE_FIRE_DIRECTION)) {
+				beam_get_global_turret_gun_info(b->objp, b->subsys, &b->last_start, &temp, 0, &b->target_pos1, (b->flags & BF_IS_FIGHTER_BEAM) > 0);
+				float dist = vm_vec_dist(&b->target_pos1, &b->last_start);
+				vm_vec_scale_add(&b->last_shot, &b->last_start, &temp, dist);
+			} else {
+				b->last_shot = b->target_pos1;
+			}
 		} else {
-			b->last_shot = b->target->pos;
+			if ((b->subsys != NULL) && (b->subsys->system_info->flags2 & MSS_FLAG2_SHARE_FIRE_DIRECTION)) {
+				beam_get_global_turret_gun_info(b->objp, b->subsys, &b->last_start, &temp, 0, &b->target->pos, (b->flags & BF_IS_FIGHTER_BEAM) > 0);
+				float dist = vm_vec_dist(&b->target->pos, &b->last_start);
+				vm_vec_scale_add(&b->last_shot, &b->last_start, &temp, dist);
+			} else {
+				b->last_shot = b->target->pos;
+			}
 			// ...then jitter based on shot_aim (requires target)
 			beam_jitter_aim(b, b->binfo.shot_aim[0]);
 		}
 		break;
 
 	case BEAM_TYPE_B:
-		// set the shot point
-		vm_vec_scale_add(&b->last_shot, &b->last_start, &b->binfo.dir_a, b->range);
+		if ((b->subsys != NULL) && (b->subsys->system_info->flags2 & MSS_FLAG2_SHARE_FIRE_DIRECTION)) {
+			vm_vec_scale(&b->binfo.dir_a, b->range);
+			beam_get_global_turret_gun_info(b->objp, b->subsys, &b->last_start, &temp, 0, &b->binfo.dir_a, (b->flags & BF_IS_FIGHTER_BEAM) > 0);
+			vm_vec_add(&b->last_shot, &b->last_start, &temp);
+		} else {
+			// set the shot point
+			vm_vec_scale_add(&b->last_shot, &b->last_start, &b->binfo.dir_a, b->range);
+		}
 		Assert(is_valid_vec(&b->last_shot));
 		break;
 
@@ -2259,9 +2297,21 @@ void beam_aim(beam *b)
 	case BEAM_TYPE_D:
 		// point at the center of the target...
 		if (b->flags & BF_TARGETING_COORDS) {
-			b->last_shot = b->target_pos1;
+			if ((b->subsys != NULL) && (b->subsys->system_info->flags2 & MSS_FLAG2_SHARE_FIRE_DIRECTION)) {
+				beam_get_global_turret_gun_info(b->objp, b->subsys, &b->last_start, &temp, 0, &b->target_pos1, (b->flags & BF_IS_FIGHTER_BEAM) > 0);
+				float dist = vm_vec_dist(&b->target_pos1, &b->last_start);
+				vm_vec_scale_add(&b->last_shot, &b->last_start, &temp, dist);
+			} else {
+				b->last_shot = b->target_pos1;
+			}
 		} else {
-			b->last_shot = b->target->pos;
+			if ((b->subsys != NULL) && (b->subsys->system_info->flags2 & MSS_FLAG2_SHARE_FIRE_DIRECTION)) {
+				beam_get_global_turret_gun_info(b->objp, b->subsys, &b->last_start, &temp, 0, &b->target->pos, (b->flags & BF_IS_FIGHTER_BEAM) > 0);
+				float dist = vm_vec_dist(&b->target->pos, &b->last_start);
+				vm_vec_scale_add(&b->last_shot, &b->last_start, &temp, dist);
+			} else {
+				b->last_shot = b->target->pos;
+			}
 			// ...then jitter based on shot_aim (requires target)
 			beam_jitter_aim(b, b->binfo.shot_aim[b->shot_index]);
 		}

--- a/code/weapon/beam.cpp
+++ b/code/weapon/beam.cpp
@@ -2195,17 +2195,17 @@ void beam_aim(beam *b)
 		}
 	}
 
-	if (b->subsys != NULL && b->type != BEAM_TYPE_C) {	// Type C beams don't use this information.
+	if (b->subsys != nullptr && b->type != BEAM_TYPE_C) {	// Type C beams don't use this information.
 		int temp_int = b->subsys->turret_next_fire_pos;
 
 		if (!(b->flags & BF_IS_FIGHTER_BEAM))
 			b->subsys->turret_next_fire_pos = b->firingpoint;
 
 		if (b->subsys->system_info->flags2 & MSS_FLAG2_SHARE_FIRE_DIRECTION) {
-			beam_get_global_turret_gun_info(b->objp, b->subsys, &b->last_start, &temp, 0, NULL, (b->flags & BF_IS_FIGHTER_BEAM) > 0);
+			beam_get_global_turret_gun_info(b->objp, b->subsys, &b->last_start, &temp, 0, nullptr, (b->flags & BF_IS_FIGHTER_BEAM) != 0);
 		} else {
 			// where the shot is originating from (b->last_start gets filled in)
-			beam_get_global_turret_gun_info(b->objp, b->subsys, &b->last_start, &temp, 1, &p2, (b->flags & BF_IS_FIGHTER_BEAM) > 0);
+			beam_get_global_turret_gun_info(b->objp, b->subsys, &b->last_start, &temp, 1, &p2, (b->flags & BF_IS_FIGHTER_BEAM) != 0);
 		}
 
 		b->subsys->turret_next_fire_pos = temp_int;
@@ -2215,11 +2215,11 @@ void beam_aim(beam *b)
 	switch(b->type){
 	case BEAM_TYPE_A:
 		// if we're targeting a subsystem - shoot directly at it
-		if(b->target_subsys != NULL){
+		if(b->target_subsys != nullptr){
 			vm_vec_unrotate(&b->last_shot, &b->target_subsys->system_info->pnt, &b->target->orient);
 			vm_vec_add2(&b->last_shot, &b->target->pos);
 
-			if ((b->subsys != NULL) && (b->subsys->system_info->flags2 & MSS_FLAG2_SHARE_FIRE_DIRECTION)) {
+			if ((b->subsys != nullptr) && (b->subsys->system_info->flags2 & MSS_FLAG2_SHARE_FIRE_DIRECTION)) {
 				float dist = vm_vec_dist(&b->last_shot,&b->last_start);
 				vm_vec_scale(&temp, dist);
 			} else {
@@ -2231,8 +2231,8 @@ void beam_aim(beam *b)
 		}
 
 		// if we're shooting at a big ship - shoot directly at the model
-		if((b->target != NULL) && (b->target->type == OBJ_SHIP) && (Ship_info[Ships[b->target->instance].ship_info_index].flags & (SIF_BIG_SHIP | SIF_HUGE_SHIP))){
-			if ((b->subsys != NULL) && (b->subsys->system_info->flags2 & MSS_FLAG2_SHARE_FIRE_DIRECTION)) {
+		if((b->target != nullptr) && (b->target->type == OBJ_SHIP) && (Ship_info[Ships[b->target->instance].ship_info_index].flags & (SIF_BIG_SHIP | SIF_HUGE_SHIP))){
+			if ((b->subsys != nullptr) && (b->subsys->system_info->flags2 & MSS_FLAG2_SHARE_FIRE_DIRECTION)) {
 				vec3d pnt;
 				vm_vec_unrotate(&pnt, &b->binfo.dir_a, &b->target->orient);
 				vm_vec_add2(&pnt, &b->target->pos);
@@ -2254,16 +2254,16 @@ void beam_aim(beam *b)
 
 		// point at the center of the target...
 		if (b->flags & BF_TARGETING_COORDS) {
-			if ((b->subsys != NULL) && (b->subsys->system_info->flags2 & MSS_FLAG2_SHARE_FIRE_DIRECTION)) {
-				beam_get_global_turret_gun_info(b->objp, b->subsys, &b->last_start, &temp, 0, &b->target_pos1, (b->flags & BF_IS_FIGHTER_BEAM) > 0);
+			if ((b->subsys != nullptr) && (b->subsys->system_info->flags2 & MSS_FLAG2_SHARE_FIRE_DIRECTION)) {
+				beam_get_global_turret_gun_info(b->objp, b->subsys, &b->last_start, &temp, 0, &b->target_pos1, (b->flags & BF_IS_FIGHTER_BEAM) != 0);
 				float dist = vm_vec_dist(&b->target_pos1, &b->last_start);
 				vm_vec_scale_add(&b->last_shot, &b->last_start, &temp, dist);
 			} else {
 				b->last_shot = b->target_pos1;
 			}
 		} else {
-			if ((b->subsys != NULL) && (b->subsys->system_info->flags2 & MSS_FLAG2_SHARE_FIRE_DIRECTION)) {
-				beam_get_global_turret_gun_info(b->objp, b->subsys, &b->last_start, &temp, 0, &b->target->pos, (b->flags & BF_IS_FIGHTER_BEAM) > 0);
+			if ((b->subsys != nullptr) && (b->subsys->system_info->flags2 & MSS_FLAG2_SHARE_FIRE_DIRECTION)) {
+				beam_get_global_turret_gun_info(b->objp, b->subsys, &b->last_start, &temp, 0, &b->target->pos, (b->flags & BF_IS_FIGHTER_BEAM) != 0);
 				float dist = vm_vec_dist(&b->target->pos, &b->last_start);
 				vm_vec_scale_add(&b->last_shot, &b->last_start, &temp, dist);
 			} else {
@@ -2275,9 +2275,9 @@ void beam_aim(beam *b)
 		break;
 
 	case BEAM_TYPE_B:
-		if ((b->subsys != NULL) && (b->subsys->system_info->flags2 & MSS_FLAG2_SHARE_FIRE_DIRECTION)) {
+		if ((b->subsys != nullptr) && (b->subsys->system_info->flags2 & MSS_FLAG2_SHARE_FIRE_DIRECTION)) {
 			vm_vec_scale(&b->binfo.dir_a, b->range);
-			beam_get_global_turret_gun_info(b->objp, b->subsys, &b->last_start, &temp, 0, &b->binfo.dir_a, (b->flags & BF_IS_FIGHTER_BEAM) > 0);
+			beam_get_global_turret_gun_info(b->objp, b->subsys, &b->last_start, &temp, 0, &b->binfo.dir_a, (b->flags & BF_IS_FIGHTER_BEAM) != 0);
 			vm_vec_add(&b->last_shot, &b->last_start, &temp);
 		} else {
 			// set the shot point
@@ -2297,16 +2297,16 @@ void beam_aim(beam *b)
 	case BEAM_TYPE_D:
 		// point at the center of the target...
 		if (b->flags & BF_TARGETING_COORDS) {
-			if ((b->subsys != NULL) && (b->subsys->system_info->flags2 & MSS_FLAG2_SHARE_FIRE_DIRECTION)) {
-				beam_get_global_turret_gun_info(b->objp, b->subsys, &b->last_start, &temp, 0, &b->target_pos1, (b->flags & BF_IS_FIGHTER_BEAM) > 0);
+			if ((b->subsys != nullptr) && (b->subsys->system_info->flags2 & MSS_FLAG2_SHARE_FIRE_DIRECTION)) {
+				beam_get_global_turret_gun_info(b->objp, b->subsys, &b->last_start, &temp, 0, &b->target_pos1, (b->flags & BF_IS_FIGHTER_BEAM) != 0);
 				float dist = vm_vec_dist(&b->target_pos1, &b->last_start);
 				vm_vec_scale_add(&b->last_shot, &b->last_start, &temp, dist);
 			} else {
 				b->last_shot = b->target_pos1;
 			}
 		} else {
-			if ((b->subsys != NULL) && (b->subsys->system_info->flags2 & MSS_FLAG2_SHARE_FIRE_DIRECTION)) {
-				beam_get_global_turret_gun_info(b->objp, b->subsys, &b->last_start, &temp, 0, &b->target->pos, (b->flags & BF_IS_FIGHTER_BEAM) > 0);
+			if ((b->subsys != nullptr) && (b->subsys->system_info->flags2 & MSS_FLAG2_SHARE_FIRE_DIRECTION)) {
+				beam_get_global_turret_gun_info(b->objp, b->subsys, &b->last_start, &temp, 0, &b->target->pos, (b->flags & BF_IS_FIGHTER_BEAM) != 0);
 				float dist = vm_vec_dist(&b->target->pos, &b->last_start);
 				vm_vec_scale_add(&b->last_shot, &b->last_start, &temp, dist);
 			} else {


### PR DESCRIPTION
This adds the "share fire direction" subsystem flag. Normally, each firing point on a turret will target a different spot  on a ship (unless they're firing at a subsystem or given firing coordinates), this flag prevents that from occurring, forcing a firing direction instead of a firing at a point.
<a href="http://imgur.com/AJvsJcz"><img src="http://i.imgur.com/AJvsJcz.png" title="source: imgur.com" /></a>