### PR TITLE
Restore SIF2_NO_LIGHTING functionality for ship_render().

### DIFF
--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -19093,6 +19093,10 @@ void ship_render(object* obj, draw_list* scene)
 		}
 	}
 
+	if ( sip->flags2 & SIF2_NO_LIGHTING ) {
+		render_flags |= MR_NO_LIGHTING;
+	}
+
 	if ( Rendering_to_shadow_map ) {
 		render_flags = MR_NO_TEXTURING | MR_NO_LIGHTING;
 	}


### PR DESCRIPTION
This should fix https://github.com/scp-fs2open/fs2open.github.com/issues/237 where ships assigned with with SIF2_NO_LIGHTING still have directional lighting applied.