### PR TITLE
Fixes missing destroyed submodels from the polymodel_instance rendering commit.

### DIFF
--- a/code/model/modelread.cpp
+++ b/code/model/modelread.cpp
@@ -4607,11 +4607,11 @@ void model_set_instance(int model_num, int sub_model_num, submodel_instance_info
 	if (flags & SSF_NO_DISAPPEAR) {
 		// If the submodel is to not disappear when the subsystem is destroyed, we simply
 		// make the submodel act as its own replacement as well
-		sm->my_replacement = sub_model_num;
+		sm->blown_off = 0;
+	} else {
+		// Set the "blown out" flags
+		sm->blown_off = sii->blown_off;
 	}
-
-	// Set the "blown out" flags	
-	sm->blown_off = sii->blown_off;
 
 	if ( (sm->blown_off) && (!(flags & SSF_NO_REPLACE)) )	{
 		if ( sm->my_replacement > -1 )	{

--- a/code/model/modelread.cpp
+++ b/code/model/modelread.cpp
@@ -4605,8 +4605,6 @@ void model_set_instance(int model_num, int sub_model_num, submodel_instance_info
 	bsp_info *sm = &pm->submodel[sub_model_num];
 
 	if (flags & SSF_NO_DISAPPEAR) {
-		// If the submodel is to not disappear when the subsystem is destroyed, we simply
-		// make the submodel act as its own replacement as well
 		sm->blown_off = 0;
 	} else {
 		// Set the "blown out" flags

--- a/code/model/modelrender.cpp
+++ b/code/model/modelrender.cpp
@@ -1411,7 +1411,11 @@ void model_render_children_buffers(draw_list* scene, model_render_params* interp
 		smi = &pmi->submodel[mn];
 	}
 
-	if ( (smi != NULL && smi->blown_off) || model->blown_off ) {
+	if ( smi != NULL ) {
+		if ( smi->blown_off ) {
+			return;
+		}
+	} else if ( model->blown_off ) {
 		return;
 	}
 


### PR DESCRIPTION
Should fix https://github.com/scp-fs2open/fs2open.github.com/issues/489. Does a minor change to `model_set_instance` so we don't irrevocably alter `bsp_info::my_replacement` whenever `SSF_NO_DISAPPEAR` is on while still offering the same functionality; whatever `model_load()` reads in should be expected to be preserved.