### PR TITLE
Only enable team glow colors if team color texture mask has an alpha channel.

### DIFF
--- a/code/globalincs/def_files.cpp
+++ b/code/globalincs/def_files.cpp
@@ -1467,7 +1467,7 @@ char* Default_main_vertex_shader =
 "	gl_ClipVertex = (gl_ModelViewMatrix * orient * vertex);\n"
 "}";
 
-char *Default_main_fragment_shader = 
+char *Default_main_fragment_shader =
 "#extension GL_EXT_texture_array : enable\n"
 "#ifdef FLAG_LIGHT\n"
 "uniform int n_lights;\n"
@@ -1510,6 +1510,7 @@ char *Default_main_fragment_shader =
 "#ifdef FLAG_TEAMCOLOR\n"
 "uniform vec3 base_color;\n"
 "uniform vec3 stripe_color;\n"
+"uniform bool team_glow_enabled;\n"
 "vec2 teamMask = vec2(0.0, 0.0);\n"
 "#endif\n"
 "#ifdef FLAG_MISC_MAP\n"
@@ -1793,7 +1794,7 @@ char *Default_main_fragment_shader =
 " #ifdef FLAG_MISC_MAP\n"
 "  #ifdef FLAG_TEAMCOLOR\n"
 "	float glowColorLuminance = dot(glowColor, vec3(0.299, 0.587, 0.114));\n"
-"	glowColor = mix((base * teamMask.b) + (stripe * teamMask.a), glowColor, clamp(glowColorLuminance - teamMask.b - teamMask.a, 0.0, 1.0));\n"
+"	glowColor = team_glow_enabled ? mix((base * teamMask.b) + (stripe * teamMask.a), glowColor, clamp(glowColorLuminance - teamMask.b - teamMask.a, 0.0, 1.0)) : glowColor;\n"
 "  #endif\n"
 " #endif\n"
 "   baseColor.rgb += glowColor * GLOW_MAP_INTENSITY;\n"

--- a/code/graphics/gropenglshader.cpp
+++ b/code/graphics/gropenglshader.cpp
@@ -125,7 +125,7 @@ static opengl_shader_variant_t GL_shader_variants[] = {
 		"Utility mapping" },
 	
 	{ SDR_TYPE_MODEL, false, SDR_FLAG_MODEL_TEAMCOLOR, "FLAG_TEAMCOLOR", 
-		2, { "stripe_color", "base_color" }, 0, { NULL }, 
+		3, { "stripe_color", "base_color", "team_glow_enabled" }, 0, { NULL }, 
 		"Team Colors" },
 	
 	{ SDR_TYPE_MODEL, false, SDR_FLAG_MODEL_DEFERRED, "FLAG_DEFERRED", 

--- a/code/graphics/gropengltnl.cpp
+++ b/code/graphics/gropengltnl.cpp
@@ -2183,7 +2183,7 @@ void opengl_tnl_set_material(int flags, uint shader_flags, int tmap_type)
 	// Team colors are passed to the shader here, but the shader needs to handle their application.
 	// By default, this is handled through the r and g channels of the misc map, but this can be changed
 	// in the shader; test versions of this used the normal map r and b channels
-	if ( shader_flags & SDR_FLAG_MODEL_TEAMCOLOR ) {
+	if ( (shader_flags & SDR_FLAG_MODEL_TEAMCOLOR) && (shader_flags & SDR_FLAG_MODEL_MISC_MAP) ) {
 		vec3d stripe_color;
 		vec3d base_color;
 
@@ -2197,6 +2197,12 @@ void opengl_tnl_set_material(int flags, uint shader_flags, int tmap_type)
 
 		GL_state.Uniform.setUniform3f("stripe_color", stripe_color);
 		GL_state.Uniform.setUniform3f("base_color", base_color);
+
+		if ( bm_has_alpha_channel(MISCMAP) ) {
+			GL_state.Uniform.setUniformi("team_glow_enabled", 1);
+		} else {
+			GL_state.Uniform.setUniformi("team_glow_enabled", 0);
+		}
 	}
 
 	if ( shader_flags & SDR_FLAG_MODEL_THRUSTER ) {


### PR DESCRIPTION
Fixes an issue with team glows still being displayed on certain texture formats that only have three color channels.