### PR TITLE
Use generic architecture for Travis CI

### DIFF
--- a/ci/travis/before_script.sh
+++ b/ci/travis/before_script.sh
@@ -3,7 +3,7 @@
 if [ "$TRAVIS_OS_NAME" = "linux" ]; then
     # Due to a bug in gcc the array bounds check isn't working correctly
     # This can be removed when gcc is updated
-    AUTOGEN_CONFIG="CXXFLAGS=-Wno-array-bounds --enable-fatal-warnings"
+    AUTOGEN_CONFIG="CXXFLAGS=-Wno-array-bounds --enable-fatal-warnings --enable-generic-architecture"
     
     if [ "$CONFIGURATION" = "Debug" ]; then
         AUTOGEN_CONFIG="$AUTOGEN_CONFIG --enable-debug"


### PR DESCRIPTION
using `-march=native` causes some issues with the outdated GCC Travis CI is currently using. By using the generic architecture we can work around this issue.