### PR TITLE
Hud scale limit (part 2)

### DIFF
--- a/code/hud/hudparse.cpp
+++ b/code/hud/hudparse.cpp
@@ -1107,7 +1107,7 @@ void adjust_base_res(int *base_res, int *force_scaling_above_res, bool scaling =
 	// no scaling is set and current res is between base res and "force scaling above res"
 	// Avoid HUD blurring caused solely by rounding errors
 	if ((!scaling && gr_screen.center_w >= base_res[0] && gr_screen.center_h >= base_res[1] &&
-+			(gr_screen.center_w <= force_scaling_above_res[0] || gr_screen.center_h <= force_scaling_above_res[1])) ||
+			(gr_screen.center_w <= force_scaling_above_res[0] || gr_screen.center_h <= force_scaling_above_res[1])) ||
 			(gr_screen.center_w >= base_res[0] && gr_screen.center_h == base_res[1]) ||
 			(gr_screen.center_w == base_res[0] && gr_screen.center_h >= base_res[1])) {
 		base_res[0] = gr_screen.center_w;
@@ -1117,8 +1117,12 @@ void adjust_base_res(int *base_res, int *force_scaling_above_res, bool scaling =
 
 	if (!scaling && force_scaling_above_res[0] > base_res[0] && force_scaling_above_res[1] > base_res[1] &&
 			gr_screen.center_w > force_scaling_above_res[0] && gr_screen.center_h > force_scaling_above_res[1]) {
-		base_res[0] = force_scaling_above_res[0];
-		base_res[1] = force_scaling_above_res[1];
+		if (force_scaling_above_res[0] > 0) {
+			base_res[0] = force_scaling_above_res[0];
+		}
+		if (force_scaling_above_res[1] > 0) {
+			base_res[1] = force_scaling_above_res[1];
+		}
 	}
 
 	float aspect_quotient = ((float)gr_screen.center_w / (float)gr_screen.center_h) / ((float)base_res[0] / (float)base_res[1]);
@@ -1154,13 +1158,6 @@ T* gauge_load_common(gauge_settings* settings, T* preAllocated = NULL)
 	int display_size[2] = {0, 0};
 	int display_offset[2] = {0, 0};
 	int canvas_size[2] = {0, 0};
-
-	if(settings->force_scaling_above_res[0] <= 0) {
-		settings->force_scaling_above_res[0] = INT_MAX;
-	}
-	if(settings->force_scaling_above_res[1] <= 0) {
-		settings->force_scaling_above_res[1] = INT_MAX;
-	}
 
 	if(check_base_res(settings->base_res)) {
 		if (settings->set_position) {


### PR DESCRIPTION
This PR fixes a bug that prevents the new "Force Scaling Above" parameter from working properly under certain conditions. It also removes an erroneous plus sign that somehow found its way into #500.

(The first change mentioned here also addresses m!m's concern about `force_scaling_above_res` being changed from -1 to `INT_MAX` at one point in the code.)