### PR TITLE
Fix object recycling errors

### DIFF
--- a/code/debris/debris.cpp
+++ b/code/debris/debris.cpp
@@ -563,6 +563,7 @@ object *debris_create(object *source_obj, int model_num, int submodel_num, vec3d
 	db->is_hull = hull_flag;
 	db->source_objnum = parent_objnum;
 	db->source_sig = source_obj->signature;
+	db->damage_type_idx = shipp->debris_damage_type_idx;
 	db->ship_info_index = shipp->ship_info_index;
 	db->team = shipp->team;
 	db->fire_timeout = 0;	// if not changed, timestamp_elapsed() will return false

--- a/code/debris/debris.h
+++ b/code/debris/debris.h
@@ -25,6 +25,7 @@ typedef struct debris {
 	int		flags;					// See DEBRIS_??? defines
 	int		source_objnum;		// What object this came from
 	int		source_sig;			// Signature of the source object
+	int		damage_type_idx;	// Damage type of this debris
 	int		ship_info_index;	// Ship info index of the ship type debris came from
 	int		team;					// Team of the ship where the debris came from
 	int		objnum;				// What object this is linked to

--- a/code/object/objcollide.cpp
+++ b/code/object/objcollide.cpp
@@ -389,7 +389,7 @@ void obj_add_pair( object *A, object *B, int check_time, int add_to_end )
 			}
 
 			// for nonplayer ships, only create collision pair if close enough
-			if ( (B->parent >= 0) && !(Objects[B->parent].flags & OF_PLAYER_SHIP) && (vm_vec_dist(&B->pos, &A->pos) < (4.0f*A->radius + 200.0f)) )
+			if ( (B->parent >= 0) && !((Objects[B->parent].signature == B->parent_sig) && (Objects[B->parent].flags & OF_PLAYER_SHIP)) && (vm_vec_dist(&B->pos, &A->pos) < (4.0f*A->radius + 200.0f)) )
 				return;
 		}
 	}
@@ -398,6 +398,7 @@ void obj_add_pair( object *A, object *B, int check_time, int add_to_end )
 	if (check_collision == collide_ship_weapon) {
 		// weapon is B
 		if ( (B->parent >= 0)
+			&& (Objects[B->parent].signature == B->parent_sig)
 			&& !(Objects[B->parent].flags & OF_PLAYER_SHIP)
 			&& (Ships[Objects[B->parent].instance].team == Ships[A->instance].team) 
 			&& (Ship_info[Ships[A->instance].ship_info_index].flags & SIF_SMALL_SHIP) 
@@ -1620,7 +1621,7 @@ void obj_collide_pair(object *A, object *B)
 				}
 
 				// for nonplayer ships, only create collision pair if close enough
-				if ( (B->parent >= 0) && !(Objects[B->parent].flags & OF_PLAYER_SHIP) && (vm_vec_dist(&B->pos, &A->pos) < (4.0f*A->radius + 200.0f)) ) {
+				if ( (B->parent >= 0) && !((Objects[B->parent].signature == B->parent_sig) && (Objects[B->parent].flags & OF_PLAYER_SHIP)) && (vm_vec_dist(&B->pos, &A->pos) < (4.0f*A->radius + 200.0f)) ) {
 					collision_info->next_check_time = -1;
 					return;
 				}
@@ -1631,6 +1632,7 @@ void obj_collide_pair(object *A, object *B)
 		if (check_collision == collide_ship_weapon) {
 			// weapon is B
 			if ( (B->parent >= 0)
+				&& (Objects[B->parent].signature == B->parent_sig)
 				&& !(Objects[B->parent].flags & OF_PLAYER_SHIP)
 				&& (Ships[Objects[B->parent].instance].team == Ships[A->instance].team) 
 				&& (Ship_info[Ships[A->instance].ship_info_index].flags & SIF_SMALL_SHIP) 

--- a/code/ship/shiphit.cpp
+++ b/code/ship/shiphit.cpp
@@ -978,6 +978,7 @@ void ship_hit_music(object *ship_objp, object *other_obj)
 	Assert(other_obj);	// Goober5000
 
 	ship* ship_p = &Ships[ship_objp->instance];
+	object *parent;
 
 	// Switch to battle track when a ship is hit by fire 
 	//
@@ -990,6 +991,9 @@ void ship_hit_music(object *ship_objp, object *other_obj)
 	int attackee_team, attacker_team;
 
 	attackee_team = Ships[ship_objp->instance].team;
+
+	// avoid uninitialized value by matching them
+	attacker_team = attackee_team;
 
 	switch ( other_obj->type )
 	{
@@ -1004,7 +1008,9 @@ void ship_hit_music(object *ship_objp, object *other_obj)
 
 		case OBJ_WEAPON:
 			// parent of weapon is object num of ship that fired it
-			attacker_team = Ships[Objects[other_obj->parent].instance].team;	
+			parent = &Objects[other_obj->parent];
+			if (parent->signature == other_obj->parent_sig)
+				attacker_team = Ships[parent->instance].team;
 			break;
 
 		default:

--- a/code/ship/shiphit.cpp
+++ b/code/ship/shiphit.cpp
@@ -609,7 +609,7 @@ float do_subobj_hit_stuff(object *ship_objp, object *other_obj, vec3d *hitpos, i
 		} else if(other_obj->type == OBJ_ASTEROID) {
 			dmg_type_idx = Asteroid_info[Asteroids[other_obj->instance].asteroid_type].damage_type_idx;
 		} else if(other_obj->type == OBJ_DEBRIS) {
-			dmg_type_idx = Ships[Objects[Debris[other_obj->instance].source_objnum].instance].debris_damage_type_idx;
+			dmg_type_idx = Debris[other_obj->instance].damage_type_idx;
 		} else if(other_obj->type == OBJ_SHIP) {
 			dmg_type_idx = Ships[other_obj->instance].collision_damage_type_idx;
 		}
@@ -2058,7 +2058,7 @@ static void ship_do_damage(object *ship_objp, object *other_obj, vec3d *hitpos, 
 			} else if(other_obj_is_asteroid) {
 				dmg_type_idx = Asteroid_info[Asteroids[other_obj->instance].asteroid_type].damage_type_idx;
 			} else if(other_obj_is_debris) {
-				dmg_type_idx = Ships[Objects[Debris[other_obj->instance].source_objnum].instance].debris_damage_type_idx;
+				dmg_type_idx = Debris[other_obj->instance].damage_type_idx;
 			} else if(other_obj_is_ship) {
 				dmg_type_idx = Ships[other_obj->instance].collision_damage_type_idx;
 			}
@@ -2136,7 +2136,7 @@ static void ship_do_damage(object *ship_objp, object *other_obj, vec3d *hitpos, 
 			} else if(other_obj_is_asteroid) {
 				dmg_type_idx = Asteroid_info[Asteroids[other_obj->instance].asteroid_type].damage_type_idx;
 			} else if(other_obj_is_debris) {
-				dmg_type_idx = Ships[Objects[Debris[other_obj->instance].source_objnum].instance].debris_damage_type_idx;
+				dmg_type_idx = Debris[other_obj->instance].damage_type_idx;
 			} else if(other_obj_is_ship) {
 				dmg_type_idx = Ships[other_obj->instance].collision_damage_type_idx;
 			}


### PR DESCRIPTION
Three problems related to recycled object slots:
  - First (a5b705b), if piece of debris collided with a ship after its parent object got recycled and the slot used for something else, shiphit.cpp would still try to treat it as a ship instance and get the `debris_damage_type_idx` for that ship. If that instance number happened to be a valid ship, FSO would at least not crash; otherwise, out-of-bounds array access means undefined behavior. Could avoid with a signature check, but it seemed safer to just store the damage type on the debris itself.
  - Second (37a98b8), objcollide.cpp would sometimes make checks on an weapon's parent without verifying that the parent was still occupying that object slot with a `parent_sig` check. Again, sometimes the instance number would be beyond `MAX_SHIPS` and cause undefined behavior (like a crash).
  - Third (1159e66), a similar problem with checking a projectile's parent for purposes of combat music.