### PR TITLE
Use the correct type for high resolution timers

### DIFF
--- a/code/globalincs/profiling.cpp
+++ b/code/globalincs/profiling.cpp
@@ -36,8 +36,8 @@
 SCP_vector<profile_sample> samples;
 SCP_vector<profile_sample_history> history;
 
-uint start_profile_time = 0;
-uint end_profile_time = 0;
+std::uint64_t start_profile_time = 0;
+std::uint64_t end_profile_time = 0;
 
 SCP_string profile_output;
 std::ofstream profiling_file;
@@ -145,7 +145,7 @@ void profile_end(const char* name)
 			if ( !strcmp(samples[i].name.c_str(), name) && samples[i].parent == child_of ) {
 				int inner = 0;
 				int parent = -1;
-				uint end_time = timer_get_high_res_microseconds();
+				std::uint64_t end_time = timer_get_high_res_microseconds();
 				samples[i].open_profiles--;
 
 				// count all parents and find the immediate parent

--- a/code/globalincs/systemvars.h
+++ b/code/globalincs/systemvars.h
@@ -15,6 +15,8 @@
 #include "globalincs/pstypes.h"
 #include "math.h"
 
+#include <cstdint>
+
 #define	GM_MULTIPLAYER					(1 << 0)
 #define	GM_NORMAL						(1 << 1)
 #define	GM_DEAD_DIED					(1 << 2)				//	Died, waiting to blow up.
@@ -201,9 +203,9 @@ typedef struct profile_sample {
 	int open_profiles;
 	//char name[256];
 	SCP_string name;
-	uint start_time;	// in microseconds
-	uint accumulator;
-	uint children_sample_time;
+	std::uint64_t start_time;	// in microseconds
+	std::uint64_t accumulator;
+	std::uint64_t children_sample_time;
 	uint num_parents;
 	uint num_children;
 	int parent;
@@ -216,9 +218,9 @@ typedef struct profile_sample_history {
 	float avg;
 	float min;
 	float max;
-	uint avg_micro_sec;
-	uint min_micro_sec;
-	uint max_micro_sec;
+	std::uint64_t avg_micro_sec;
+	std::uint64_t min_micro_sec;
+	std::uint64_t max_micro_sec;
 } profile_sample_history;
 
 extern SCP_string profile_output;

--- a/code/io/timer.cpp
+++ b/code/io/timer.cpp
@@ -103,7 +103,7 @@ int timer_get_microseconds()
 	return timer_get() * 1000;
 }
 
-uint timer_get_high_res_microseconds()
+std::uint64_t timer_get_high_res_microseconds()
 {
 	if ( !Timer_inited ) {
 		Int3();
@@ -112,7 +112,7 @@ uint timer_get_high_res_microseconds()
 
 	Uint64 elapsed = SDL_GetPerformanceCounter();
 
-	return (uint)(elapsed * MICROSECONDS_PER_SECOND / Timer_perf_counter_freq);
+	return elapsed * MICROSECONDS_PER_SECOND / Timer_perf_counter_freq;
 }
 
 // 0 means invalid,

--- a/code/io/timer.h
+++ b/code/io/timer.h
@@ -14,6 +14,8 @@
 
 #include "globalincs/pstypes.h"
 
+#include <cstdint>
+
 //==========================================================================
 // This installs the timer services and interrupts at the rate specified by
 // count_val.  If 'function' isn't 0, the function pointed to by function will
@@ -44,7 +46,7 @@ extern fix timer_get_fixed_secondsX();		// Assume interrupts already disabled
 extern fix timer_get_approx_seconds();		// Returns time since program started... accurate to 1/120th of a second
 extern int timer_get_milliseconds();		//
 extern int timer_get_microseconds();
-extern uint timer_get_high_res_microseconds();
+extern std::uint64_t timer_get_high_res_microseconds();
 extern int timer_get_seconds();				// seconds since program started... not accurate, but good for long
 											//     runtimes with second-based timeouts
 


### PR DESCRIPTION
@MageKing17 discovered that the timer value can overflow because our code uses 32 bit integers while SDL supplied 64 bit integers.