### PR TITLE
Change timestamp integer handling again

### DIFF
--- a/code/freespace2/freespace.cpp
+++ b/code/freespace2/freespace.cpp
@@ -4871,7 +4871,9 @@ void game_set_frametime(int state)
 	Last_frame_timestamp = timestamp();
 
 	flFrametime = f2fl(Frametime);
-	timestamp_inc(Frametime);
+	
+	auto frametime_ms = f2i(fixmul(Frametime, F1_0 * TIMESTAMP_FREQUENCY));
+	timestamp_inc(frametime_ms);
 
 	// wrap overall frametime if needed
 	if ( FrametimeOverall > (INT_MAX - F1_0) )

--- a/code/io/timer.cpp
+++ b/code/io/timer.cpp
@@ -214,10 +214,9 @@ void timestamp_reset()
 // something like 1 minute (6000).
 #define MAX_TIME (INT_MAX/2)
 
-void timestamp_inc(fix frametime)
+void timestamp_inc(int frametime_ms)
 {
-	auto frametime_ms = fixmul(frametime, F1_0 * TIMESTAMP_FREQUENCY);
-	timestamp_ticker += f2i(frametime_ms);
+	timestamp_ticker += frametime_ms;
 
 	if ( timestamp_ticker > MAX_TIME )	{
 		timestamp_ticker = 2;		// Roll!

--- a/code/io/timer.h
+++ b/code/io/timer.h
@@ -73,7 +73,7 @@ extern int timestamp_ticker;
 extern void timestamp_reset();
 
 // Call this once every frame with the frametime.
-extern void timestamp_inc(fix frametime);
+extern void timestamp_inc(int frametime_ms);
 
 // To do timing, call this with the interval you
 // want to check.  Then, pass this to timestamp_elapsed

--- a/code/menuui/credits.cpp
+++ b/code/menuui/credits.cpp
@@ -803,7 +803,7 @@ void credits_do_frame(float frametime)
 
 	Credits_frametime = temp_time - Credits_last_time;
 	Credits_last_time = temp_time;
-	timestamp_inc(Credits_frametime / 1000.0f);
+	timestamp_inc(Credits_frametime);
 
 	float fl_frametime = i2fl(Credits_frametime) / 1000.f;
 	if (keyd_pressed[KEY_LSHIFT]) {


### PR DESCRIPTION
As noted by @MageKing17 in #522 there was another instance where `timestamp_inc` was used.

I realized that it would make more sense to pass milliseconds to `timestamp_inc` instead of the `fix` frametime in seconds so I changed the function to accept milliseconds and moved the code to convert fix to milliseconds into freespace.cpp.