### PR TITLE
one small bugfix, one small comment tweak

### DIFF
--- a/code/hud/hudlock.cpp
+++ b/code/hud/hudlock.cpp
@@ -253,9 +253,9 @@ void HudGaugeLock::render(float frametime)
 		}
 	}
 
+	// show locked indicator
 	Lock_gauge.sx = sx - Lock_gauge_half_w;
 	Lock_gauge.sy = sy - Lock_gauge_half_h;
-
 	if (Player_ai->current_target_is_locked) {
 		hud_anim_render(&Lock_gauge, 0.0f, 1);
 	} else {

--- a/code/model/modelread.cpp
+++ b/code/model/modelread.cpp
@@ -352,6 +352,10 @@ void model_instance_free_all()
 		}
 	}
 
+	// clear skybox model instance if we have one; it is not an object and therefore has no <object>_delete function which would remove the instance
+	extern int Nmodel_instance_num;
+	Nmodel_instance_num = -1;
+
 	Polygon_model_instances.clear();
 }
 


### PR DESCRIPTION
This fixes a bug where, when the skybox is changed after loading a new mission, it tries to delete its model instance which was already deleted in model_instance_free_all.  Setting the instance reference to -1 when the instance is freed fixes this.  (This is something that would typically be handled by the object_delete function, as it is for ship_delete, asteroid_delete, and weapon_delete, but there is no such equivalent for skyboxes.)

Since this is such a small PR, I decided to also include a stash where I restored a comment that was inadvertently deleted by Swifty's hud_lock variable scope fix PR.