### PR TITLE
Look_at reimplementation

### DIFF
--- a/code/model/model.h
+++ b/code/model/model.h
@@ -35,7 +35,6 @@ extern int model_render_flags_size;
 #define MOVEMENT_TYPE_ROT_SPECIAL		2	// for turrets only
 #define MOVEMENT_TYPE_TRIGGERED			3	// triggered rotation
 #define MOVEMENT_TYPE_INTRINSIC_ROTATE	4	// intrinsic (non-subsystem-based) rotation
-#define MOVEMENT_TYPE_LOOK_AT			5	// the subobject is always looking at a 'look at' subobject, as best it can - Bobboau
 
 
 // DA 11/13/98 Reordered to account for difference between max and game
@@ -305,11 +304,10 @@ public:
 		num_arcs(0), outline_buffer(NULL), n_verts_outline(0), render_sphere_radius(0.0f), use_render_box(0), use_render_box_offset(false),
 		use_render_sphere(0), use_render_sphere_offset(false), gun_rotation(false), no_collisions(false),
 		nocollide_this_only(false), collide_invisible(false), force_turret_normal(false), attach_thrusters(false), dumb_turn_rate(0.0f),
-		look_at_num(-1)
+		look_at_submodel(-1)
 	{
 		name[0] = 0;
 		lod_name[0] = 0;
-		look_at[0] = 0;
 
 		offset = geometric_center = min = max = render_box_min = render_box_max = render_box_offset = render_sphere_offset = vmd_zero_vector;
 		orientation = vmd_identity_matrix;
@@ -393,10 +391,9 @@ public:
 	bool	force_turret_normal;	//Wanderer: Sets the turret uvec to override any input of for turret normal.
 	char	lod_name[MAX_NAME_LEN];	//FUBAR:  Name to be used for LOD naming comparison to preserve compatibility with older tables.  Only used on LOD0 
 	bool	attach_thrusters;		//zookeeper: If set and this submodel or any of its parents rotates, also rotates associated thrusters.
+
 	float	dumb_turn_rate;			//Bobboau
-	//int	look_at;				//Bobboau
-	int		look_at_num;			//VA - number of the submodel to be looked at by this submodel (-1 if none)
-	char	look_at[MAX_NAME_LEN];	//VA - name of submodel to be looked at by this submodel
+	int		look_at_submodel;		//VA - number of the submodel to be looked at by this submodel (-1 if none)
 };
 
 void parse_triggersint(int &n_trig, queued_animation **triggers, char *props);
@@ -1365,8 +1362,6 @@ void model_set_replacement_textures(int *replacement_textures);
 
 void model_setup_cloak(vec3d *shift, int full_cloak, int alpha);
 void model_finish_cloak(int full_cloak);
-
-void model_do_look_at(int model_num); //Bobboau
 
 void model_do_intrinsic_rotations(int model_instance_num = -1);
 

--- a/code/model/model.h
+++ b/code/model/model.h
@@ -304,7 +304,7 @@ public:
 		num_arcs(0), outline_buffer(NULL), n_verts_outline(0), render_sphere_radius(0.0f), use_render_box(0), use_render_box_offset(false),
 		use_render_sphere(0), use_render_sphere_offset(false), gun_rotation(false), no_collisions(false),
 		nocollide_this_only(false), collide_invisible(false), force_turret_normal(false), attach_thrusters(false), dumb_turn_rate(0.0f),
-		look_at_submodel(-1)
+		look_at_submodel(-1), look_at_offset(-1.0f)
 	{
 		name[0] = 0;
 		lod_name[0] = 0;
@@ -394,6 +394,7 @@ public:
 
 	float	dumb_turn_rate;			//Bobboau
 	int		look_at_submodel;		//VA - number of the submodel to be looked at by this submodel (-1 if none)
+	float	look_at_offset;			//angle in radians that the submodel should be turned from its initial orientation to be considered "looking at" something (-1 if set on first eval)
 };
 
 void parse_triggersint(int &n_trig, queued_animation **triggers, char *props);

--- a/code/model/modelread.cpp
+++ b/code/model/modelread.cpp
@@ -2315,12 +2315,12 @@ int read_model_file(polymodel * pm, char *filename, int n_subsystems, model_subs
 
 	// Now that we've processed all the chunks, resolve the look_at submodels if we have any
 	if (!look_at_submodel_names.empty()) {
-		for (int i = 0; i < pm->n_models; i++) {
+		for (i = 0; i < pm->n_models; i++) {
 			if (pm->submodel[i].look_at_submodel >= 0) {
 				const char *submodel_name = look_at_submodel_names[pm->submodel[i].look_at_submodel].c_str();
 
 				// search for this submodel name among all submodels
-				for (int j = 0; j < pm->n_models; j++) {
+				for (j = 0; j < pm->n_models; j++) {
 					if (!strcmp(submodel_name, pm->submodel[j].name)) {
 						nprintf(("Model", "NOTE: Matched %s %s $look_at: target %s with subobject id %d\n", pm->filename, pm->submodel[i].name, submodel_name, j));
 
@@ -3592,17 +3592,25 @@ void submodel_look_at(int model_num, int model_instance_num, int submodel_num, s
 	// TODO: these angles aren't quite right, plus having three separate calculations is brittle
 
 	// calculate the angle we need to point to
-	float angle;
+	float angle, y, x;
 	if (sm->movement_axis == MOVEMENT_AXIS_X)
-		angle = atan2(local_target_vec.xyz.z, local_target_vec.xyz.y);
+	{
+		y = local_target_vec.xyz.y;
+		x = local_target_vec.xyz.z;
+	}
 	else if (sm->movement_axis == MOVEMENT_AXIS_Y)
-		angle = atan2(local_target_vec.xyz.x, local_target_vec.xyz.z);
+	{
+		y = local_target_vec.xyz.z;
+		x = local_target_vec.xyz.x;
+	}
 	else if (sm->movement_axis == MOVEMENT_AXIS_Z)
-		angle = atan2(local_target_vec.xyz.y, local_target_vec.xyz.x);
+	{
+		y = local_target_vec.xyz.y;
+		x = local_target_vec.xyz.x;
+	}
 	else
 		return;
-
-
+	angle = atan2(y, x);
 
 
 	// need to test this whole function with the praetor rotated in various orientations, just to make sure all the rotations came out correct

--- a/code/model/modelread.cpp
+++ b/code/model/modelread.cpp
@@ -1284,15 +1284,24 @@ int read_model_file(polymodel * pm, char *filename, int n_subsystems, model_subs
 				if ((p = strstr(props, "$look_at_offset")) != NULL) {
 					float offset = (float)atof(p + 16);
 
-					// check range
+					// sanity
+					if (offset >= -PI2 || offset <= PI2) {
+						mprintf(("Submodel '%s' of model '%s' has a very small look_at_offset.  Did you enter radians instead of degrees?", pm->submodel[n].name, pm->filename));
+					}
+
+					// model property is specified in degrees, so convert it
+					offset = fl_radians(offset);
+
+					// check range (the angle is now in radians)
 					if (offset < -PI2 || offset > PI2) {
-						Warning(LOCATION, "Submodel '%s' of model '%s' has a look_at_offset that is outside the range of -2PI to 2PI!", pm->submodel[n].name, pm->filename);
+						Warning(LOCATION, "Submodel '%s' of model '%s' has a look_at_offset that is outside the range of -360 to 360!", pm->submodel[n].name, pm->filename);
 						offset = -1.0f;
 					}
 					// make the angle positive, since negative angles will be set at first look_at call
 					else if (offset < 0.0f) {
 						offset += PI2;
 					}
+
 					pm->submodel[n].look_at_offset = offset;
 				} else {
 					pm->submodel[n].look_at_offset = -1.0f;
@@ -3575,17 +3584,17 @@ void submodel_look_at(int model_num, int model_instance_num, int submodel_num, s
 	if (sm->movement_axis == MOVEMENT_AXIS_X)
 	{
 		vm_vec_make(&local_axis_vec, 1.0f, 0.0f, 0.0f);
-		vm_vec_make(&local_zero_vec, 0.0f, 0.0f, -1.0f);
+		vm_vec_make(&local_zero_vec, 0.0f, 0.0f, 1.0f);
 	}
 	else if (sm->movement_axis == MOVEMENT_AXIS_Y)
 	{
 		vm_vec_make(&local_axis_vec, 0.0f, 1.0f, 0.0f);
-		vm_vec_make(&local_zero_vec, 1.0f, 0.0f, 0.0f);
+		vm_vec_make(&local_zero_vec, 0.0f, 0.0f, 1.0f);
 	}
 	else if (sm->movement_axis == MOVEMENT_AXIS_Z)
 	{
 		vm_vec_make(&local_axis_vec, 0.0f, 0.0f, 1.0f);
-		vm_vec_make(&local_zero_vec, 1.0f, 0.0f, 0.0f);
+		vm_vec_make(&local_zero_vec, 0.0f, 1.0f, 0.0f);
 	}
 	else
 		return;

--- a/code/model/modelread.cpp
+++ b/code/model/modelread.cpp
@@ -2321,7 +2321,7 @@ int read_model_file(polymodel * pm, char *filename, int n_subsystems, model_subs
 
 				// search for this submodel name among all submodels
 				for (j = 0; j < pm->n_models; j++) {
-					if (!strcmp(submodel_name, pm->submodel[j].name)) {
+					if (!stricmp(submodel_name, pm->submodel[j].name)) {
 						nprintf(("Model", "NOTE: Matched %s %s $look_at: target %s with subobject id %d\n", pm->filename, pm->submodel[i].name, submodel_name, j));
 
 						// set the correct submodel reference, and set the char* to null as a found-flag

--- a/code/model/modelread.cpp
+++ b/code/model/modelread.cpp
@@ -3587,18 +3587,17 @@ void submodel_look_at(int model_num, int model_instance_num, int submodel_num, s
 	// rotate it back to the submodel's reference frame
 	vm_vec_rotate(&local_target_vec, &target_vec, &submodel_orient);
 
-	// TODO: these angles aren't quite right, plus having three separate calculations is brittle
-
 	// calculate the angle we need to point to
+	// Since FreeSpace uses pitch/bank/heading (Tait–Bryan angles), we use the left-hand rule.  Positive angles are counter-clockwise when looking in the positive axis direction.
 	float angle, y, x;
 	if (sm->movement_axis == MOVEMENT_AXIS_X)
 	{
 		y = local_target_vec.xyz.y;
-		x = local_target_vec.xyz.z;
+		x = -local_target_vec.xyz.z;
 	}
 	else if (sm->movement_axis == MOVEMENT_AXIS_Y)
 	{
-		y = local_target_vec.xyz.z;
+		y = -local_target_vec.xyz.z;
 		x = local_target_vec.xyz.x;
 	}
 	else if (sm->movement_axis == MOVEMENT_AXIS_Z)
@@ -3611,11 +3610,10 @@ void submodel_look_at(int model_num, int model_instance_num, int submodel_num, s
 	angle = atan2(y, x);
 
 
-	// need to test this whole function with the praetor rotated in various orientations, just to make sure all the rotations came out correct
 
+
+	// TODO: these angles aren't quite right, plus having three separate calculations is brittle
 	// also need to remove ez_debug
-
-
 
 	// ensure the angle is in the proper range (see submodel_rotate)
 	while (angle > PI2)
@@ -3656,7 +3654,6 @@ void submodel_look_at(int model_num, int model_instance_num, int submodel_num, s
 	// (try to avoid a one-frame dramatic spike in the turn rate if the angle passes 0.0 or PI2)
 	if (abs(angle - prev_angle) < PI)
 		sii->cur_turn_rate = sii->desired_turn_rate = (angle - prev_angle) / flFrametime;
-
 
 	/*
 

--- a/code/model/modelread.cpp
+++ b/code/model/modelread.cpp
@@ -3618,7 +3618,6 @@ void submodel_look_at(int model_num, int model_instance_num, int submodel_num, s
 	float angle = atan2(det, dot);
 
 	// apply an offset to the angle, since the direction we look at may be different than the default orientation!
-
 	// if we have not specified an offset in the POF, assume that the very first time we call submodel_look_at, the submodel is pointing in the correct direction
 	if (sm->look_at_offset < 0.0f)
 	{
@@ -3630,7 +3629,6 @@ void submodel_look_at(int model_num, int model_instance_num, int submodel_num, s
 		while (sm->look_at_offset < 0.0f)
 			sm->look_at_offset += PI2;
 	}
-
 	angle += sm->look_at_offset;
 
 	// ensure the angle is in the proper range (see submodel_rotate)

--- a/code/model/modelread.cpp
+++ b/code/model/modelread.cpp
@@ -3562,8 +3562,8 @@ void submodel_look_at(int model_num, int model_instance_num, int submodel_num, s
 	vec3d temp, local_axis_vec, submodel_axis_vec, submodel_pos, target_submodel_pos, nearest_point, target_vec, local_target_vec;
 
 	// find the origin of this submodel and its target
-	find_submodel_instance_point_orient(&submodel_pos, &submodel_orient, model_num, model_instance_num, submodel_num, &vmd_zero_vector, &vmd_identity_matrix);
-	find_submodel_instance_point(&target_submodel_pos, model_num, model_instance_num, sm->look_at_submodel);
+	find_submodel_instance_point_orient(&submodel_pos, &submodel_orient, model_instance_num, submodel_num, &vmd_zero_vector, &vmd_identity_matrix);
+	find_submodel_instance_point(&target_submodel_pos, model_instance_num, sm->look_at_submodel);
 
 	// figure out which axis this submodel rotates on, rotated in the model's reference frame
 	if (sm->movement_axis == MOVEMENT_AXIS_X)

--- a/code/object/collideshipship.cpp
+++ b/code/object/collideshipship.cpp
@@ -621,11 +621,12 @@ void calculate_ship_ship_collision_physics(collision_info_struct *ship_ship_hit_
 				axis = vmd_x_vector;
 			} else if ( pm->submodel[ship_ship_hit_info->submodel_num].movement_axis == MOVEMENT_AXIS_Y ) {
 				axis = vmd_y_vector;
-			} else if ( pm->submodel[ship_ship_hit_info->submodel_num].movement_axis == MOVEMENT_AXIS_Z ) {
-				axis = vmd_z_vector;
 			} else {
-				// must be one of these axes or submodel_rot_hit is incorrectly set
-				Int3();
+				if ( pm->submodel[ship_ship_hit_info->submodel_num].movement_axis != MOVEMENT_AXIS_Z ) {
+					// must be one of these axes or submodel_rot_hit is incorrectly set
+					Warning(LOCATION, "Model %s submodel %d has an invalid movement axis!", pm->filename, ship_ship_hit_info->submodel_num);
+				}
+				axis = vmd_z_vector;
 			}
 
 			// get world rotational velocity of rotating submodel


### PR DESCRIPTION
NOTE: This isn't quite ready to be merged yet!  See comments below.

This PR re-implements the look_at feature, which originally was a brute-force iteration down the submodel hierarchy, just like dumb_rotation.  The look_at code now properly uses the `model_instance` code developed by Swifty to integrate into the rest of the collision and rendering code.

A look-at rotation is a type of intrinsic_rotation, just like dumb-rotations. The same code handles both; the only difference is whether submodel_rotate or submodel_look_at is called to apply the actual movement.

The previous look_at parsing code has been optimized by performing the name-to-submodel resolution when the model is actually parsed, instead of when the first look-at rotation is called.  This avoids the need to store a name in the submodel struct and also avoids cluttering the look_at function.

A few functions - `model_instance_find_obj_dir`, `find_submodel_instance_point`, and `find_submodel_instance_point_orient` - have been tweaked to allow them to be called for any model with a model_instance, not just ship models.

This PR is essentially bookkeeping, except for the submodel_look_at method.  Bobboau's previous code has a few flaws - it doesn't work with the new model_instance code, it only accounts for rotation in one level of the submodel hierarchy, it makes an unnecessary detour out to world coordinates - so it can't be used as-is.  Unfortunately, it's also almost entirely inscrutable, with one- or two-letter variables and no comments. :-/  So it was necessary to rewrite the rotation calculation code.

Currently, the rotation code has a few bugs that need to be worked out before committing (assistance with the finer points of vector math is appreciated).  The rotation has to work properly for all three axes, and it also has to work for all ranges of angles.  Currently, only the X axis can be tested with the Praetor model, and currently the door struts flip 180 degrees in the process of opening.

The praetor test mod has been updated since the dumb-rotation PR.  It can be downloaded here:
http://scp.indiegames.us/temp/praetor.zip
