### PR TITLE
refactor of dumb_rotation to intrinsic_rotation

### DIFF
--- a/code/asteroid/asteroid.cpp
+++ b/code/asteroid/asteroid.cpp
@@ -331,7 +331,7 @@ object *asteroid_create(asteroid_field *asfieldp, int asteroid_type, int asteroi
 	asp->objnum = objnum;
 	asp->model_instance_num = -1;
 
-	if (model_get(asip->model_num[asteroid_subtype])->flags & PM_FLAG_HAS_DUMB_ROTATE) {
+	if (model_get(asip->model_num[asteroid_subtype])->flags & PM_FLAG_HAS_INTRINSIC_ROTATE) {
 		asp->model_instance_num = model_create_instance(false, asip->model_num[asteroid_subtype]);
 	}
 

--- a/code/model/model.h
+++ b/code/model/model.h
@@ -33,9 +33,9 @@ extern int model_render_flags_size;
 #define MOVEMENT_TYPE_POS				0
 #define MOVEMENT_TYPE_ROT				1
 #define MOVEMENT_TYPE_ROT_SPECIAL		2	// for turrets only
-#define MOVEMENT_TYPE_TRIGGERED			3	//triggered rotation
-#define MOVEMENT_TYPE_LOOK_AT			4	// the subobject is always looking at a 'look at' subobject, as best it can - Bobboau
-#define MOVEMENT_TYPE_DUMB_ROTATE		5
+#define MOVEMENT_TYPE_TRIGGERED			3	// triggered rotation
+#define MOVEMENT_TYPE_INTRINSIC_ROTATE	4	// intrinsic (non-subsystem-based) rotation
+#define MOVEMENT_TYPE_LOOK_AT			5	// the subobject is always looking at a 'look at' subobject, as best it can - Bobboau
 
 
 // DA 11/13/98 Reordered to account for difference between max and game
@@ -617,11 +617,11 @@ typedef struct insignia {
 	vec3d norm[MAX_INS_VECS]	;					//normal of the insignia-Bobboau
 } insignia;
 
-#define PM_FLAG_ALLOW_TILING		(1<<0)					// Allow texture tiling
-#define PM_FLAG_AUTOCEN				(1<<1)					// contains autocentering info	
-#define PM_FLAG_TRANS_BUFFER		(1<<2)					// render transparency buffer
-#define PM_FLAG_BATCHED				(1<<3)					// this model can be batch rendered
-#define PM_FLAG_HAS_DUMB_ROTATE		(1<<4)					// whether this model has a dumb-rotate submodel somewhere
+#define PM_FLAG_ALLOW_TILING			(1<<0)					// Allow texture tiling
+#define PM_FLAG_AUTOCEN					(1<<1)					// contains autocentering info	
+#define PM_FLAG_TRANS_BUFFER			(1<<2)					// render transparency buffer
+#define PM_FLAG_BATCHED					(1<<3)					// this model can be batch rendered
+#define PM_FLAG_HAS_INTRINSIC_ROTATE	(1<<4)					// whether this model has an intrinsic rotation submodel somewhere
 
 // Goober5000
 class texture_info
@@ -1058,7 +1058,6 @@ extern void model_set_instance(int model_num, int sub_model_num, submodel_instan
 extern void model_set_instance_techroom(int model_num, int sub_model_num, float angle_1, float angle_2);
 
 void model_update_instance(int model_instance_num, int sub_model_num, submodel_instance_info *sii, int flags);
-void model_instance_dumb_rotation(int model_instance_num);
 
 // Adds an electrical arcing effect to a submodel
 void model_add_arc(int model_num, int sub_model_num, vec3d *v1, vec3d *v2, int arc_type);
@@ -1370,7 +1369,7 @@ void model_finish_cloak(int full_cloak);
 
 void model_do_look_at(int model_num); //Bobboau
 
-void model_do_dumb_rotations(int model_instance_num = -1);
+void model_do_intrinsic_rotations(int model_instance_num = -1);
 
 int model_should_render_engine_glow(int objnum, int bank_obj);
 

--- a/code/model/modelrender.cpp
+++ b/code/model/modelrender.cpp
@@ -2731,13 +2731,13 @@ void model_render_queue(model_render_params *interp, draw_list *scene, int model
 			shipp = &Ships[objp->instance];
 			pmi = model_get_instance(shipp->model_instance_num);
 		}
-		else if (pm->flags & PM_FLAG_HAS_DUMB_ROTATE) {
+		else if (pm->flags & PM_FLAG_HAS_INTRINSIC_ROTATE) {
 			if (objp->type == OBJ_ASTEROID)
 				pmi = model_get_instance(Asteroids[objp->instance].model_instance_num);
 			else if (objp->type == OBJ_WEAPON)
 				pmi = model_get_instance(Weapons[objp->instance].model_instance_num);
 			else
-				Warning(LOCATION, "Unsupported object type %d for rendering dumb-rotate submodels!", objp->type);
+				Warning(LOCATION, "Unsupported object type %d for rendering intrinsic-rotate submodels!", objp->type);
 		}
 	}
 

--- a/code/object/object.cpp
+++ b/code/object/object.cpp
@@ -1454,10 +1454,10 @@ void obj_move_all(float frametime)
 		Script_system.RemHookVars(2, "User", "Target");
 	}
 
-	// Now that we've moved all the objects, move all the models that use dumb-rotate.  We do that here because we already handled the
+	// Now that we've moved all the objects, move all the models that use intrinsic rotations.  We do that here because we already handled the
 	// ship models in obj_move_all_post, and this is more or less conceptually close enough to move the rest.  (Originally all models
-	// were dumb-rotated here, but there are collision-related reasons for ship rotations to happen where they do, even dumb ones.)
-	model_do_dumb_rotations();
+	// were intrinsic-rotated here, but for sequencing reasons, intrinsic ship rotations must happen along with regular ship rotations.)
+	model_do_intrinsic_rotations();
 
 	//	After all objects have been moved, move all docked objects.
 	objp = GET_FIRST(&obj_used_list);

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -13109,8 +13109,8 @@ void ship_model_update_instance(object *objp)
 		}
 	}
 
-	// Handle dumb rotations for this ship
-	model_do_dumb_rotations(model_instance_num);
+	// Handle intrinsic rotations for this ship
+	model_do_intrinsic_rotations(model_instance_num);
 
 	// preprocess subobject orientations for collision detection
 	model_collide_preprocess(&objp->orient, model_instance_num);

--- a/code/ship/shipfx.cpp
+++ b/code/ship/shipfx.cpp
@@ -72,6 +72,8 @@ void shipfx_remove_submodel_ship_sparks(ship *shipp, int submodel_num)
 	}
 }
 
+void model_get_rotating_submodel_axis(vec3d *model_axis, vec3d *world_axis, int modelnum, int submodel_num, object *obj);
+
 /**
  * Check if subsystem has live debris and create
  *
@@ -103,13 +105,12 @@ void shipfx_subsystem_maybe_create_live_debris(object *ship_objp, ship *ship_p, 
 	vec3d model_axis, world_axis, rotvel, world_axis_pt;
 	matrix m_rot;	// rotation for debris orient about axis
 
-	if(pm->submodel[submodel_num].movement_type == MOVEMENT_TYPE_ROT) {
+	if (pm->submodel[submodel_num].movement_type == MOVEMENT_TYPE_ROT || pm->submodel[submodel_num].movement_type == MOVEMENT_TYPE_INTRINSIC_ROTATE) {
 		if ( !sii->axis_set ) {
 			model_init_submodel_axis_pt(sii, pm->id, submodel_num);
 		}
 
 		// get the rotvel
-		void model_get_rotating_submodel_axis(vec3d *model_axis, vec3d *world_axis, int modelnum, int submodel_num, object *obj);
 		model_get_rotating_submodel_axis(&model_axis, &world_axis, pm->id, submodel_num, ship_objp);
 		vm_vec_copy_scale(&rotvel, &world_axis, sii->cur_turn_rate);
 

--- a/code/starfield/starfield.cpp
+++ b/code/starfield/starfield.cpp
@@ -2197,7 +2197,7 @@ void stars_set_background_model(char *model_name, char *texture_name, int flags)
 	if (Nmodel_num >= 0) {
 		model_page_in_textures(Nmodel_num);
 
-		if (model_get(Nmodel_num)->flags & PM_FLAG_HAS_DUMB_ROTATE) {
+		if (model_get(Nmodel_num)->flags & PM_FLAG_HAS_INTRINSIC_ROTATE) {
 			Nmodel_instance_num = model_create_instance(false, Nmodel_num);
 		}
 	}

--- a/code/weapon/weapon.h
+++ b/code/weapon/weapon.h
@@ -163,7 +163,7 @@ extern int Num_weapon_subtypes;
 typedef struct weapon {
 	int		weapon_info_index;			// index into weapon_info array
 	int		objnum;							// object number for this weapon
-	int		model_instance_num;				// model instance number, if we have any dumb-rotating submodels
+	int		model_instance_num;				// model instance number, if we have any intrinsic-rotating submodels
 	int		team;								// The team of the ship that fired this
 	int		species;							// The species of the ship that fired thisz
 	float		lifeleft;						// life left on this weapon	

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -5497,8 +5497,8 @@ int weapon_create( vec3d * pos, matrix * porient, int weapon_type, int parent_ob
 
 		objp->radius = model_get_radius(wip->model_num);
 
-		// if we dumb-rotate, make sure we have a model instance
-		if (model_get(wip->model_num)->flags & PM_FLAG_HAS_DUMB_ROTATE) {
+		// if we intrinsic-rotate, make sure we have a model instance
+		if (model_get(wip->model_num)->flags & PM_FLAG_HAS_INTRINSIC_ROTATE) {
 			wp->model_instance_num = model_create_instance(false, wip->model_num);
 		}
 	} else if ( wip->render_type == WRT_LASER ) {


### PR DESCRIPTION
This is a renaming of the Dumb_rotation infrastructure, which is now called Intrinsic_rotation.  Intrinsic rotations are automatically applied to submodels without the need for an associated subsystem.  Dumb rotations are now a type of intrinsic rotation, and look_at rotations will be added in a future PR.  The same code will handle both; the only difference is in how the intrinsic rotation is calculated.  (In the case of dumb-rotation, it is calculated the same way as normal rotation; in the case of look-at, it will be calculated using submodel_look_at.)

This PR was created at @asarium's request in the comments on #530.