### PR TITLE
Fix a small bug in multi_oo_send_control_info().

### DIFF
--- a/code/network/multi_obj.cpp
+++ b/code/network/multi_obj.cpp
@@ -1442,7 +1442,7 @@ void multi_oo_send_control_info()
 	int packet_size = 0;
 
 	// if I'm dying or my object type is not a ship, bail here
-	if((Player_obj != NULL) && (Player_ship->flags & SF_DYING)){
+	if((Player_obj != NULL) || (Player_ship->flags & SF_DYING)){
 		return;
 	}	
 	


### PR DESCRIPTION
Fix a bug in multi_oo_send_control_info() where the code used a && but the
comment and intended semantics are clearly ||.