### PR TITLE
APNG support

### DIFF
--- a/code/asteroid/asteroid.cpp
+++ b/code/asteroid/asteroid.cpp
@@ -2031,7 +2031,7 @@ void asteroid_parse_tbl()
 
 		if (VALID_FNAME(impact_ani_file)) {
 			int num_frames;
-			Asteroid_impact_explosion_ani = bm_load_animation(impact_ani_file, &num_frames, NULL, NULL, 1);
+			Asteroid_impact_explosion_ani = bm_load_animation(impact_ani_file, &num_frames, nullptr, nullptr, nullptr, true);
 		}
 
 		required_string("$Impact Explosion Radius:");

--- a/code/bmpman/bm_internal.h
+++ b/code/bmpman/bm_internal.h
@@ -36,6 +36,10 @@ union bm_extra_info {
 			BM_TYPE type;                         //!< type for individual images
 			char  filename[MAX_FILENAME_LEN];   //!< filename for individual images
 		} eff;
+		struct {
+			bool  is_apng;      //!< Is this animation an APNG?
+			float frame_delay;  //!< cumulative frame delay
+		} apng;
 	} ani;
 
 	struct {
@@ -90,6 +94,7 @@ extern bitmap_entry bm_bitmaps[MAX_BITMAPS];
 void bm_lock_ani( int handle, int bitmapnum, bitmap_entry *be, bitmap *bmp, ubyte bpp, ubyte flags );
 void bm_lock_dds( int handle, int bitmapnum, bitmap_entry *be, bitmap *bmp, ubyte bpp, ubyte flags );
 void bm_lock_png( int handle, int bitmapnum, bitmap_entry *be, bitmap *bmp, ubyte bpp, ubyte flags );
+void bm_lock_apng( int handle, int bitmapnum, bitmap_entry *be, bitmap *bmp, ubyte bpp, ubyte flags );
 void bm_lock_jpg( int handle, int bitmapnum, bitmap_entry *be, bitmap *bmp, ubyte bpp, ubyte flags );
 void bm_lock_pcx( int handle, int bitmapnum, bitmap_entry *be, bitmap *bmp, ubyte bpp, ubyte flags );
 void bm_lock_tga( int handle, int bitmapnum, bitmap_entry *be, bitmap *bmp, ubyte bpp, ubyte flags );

--- a/code/bmpman/bm_internal.h
+++ b/code/bmpman/bm_internal.h
@@ -29,6 +29,7 @@ union bm_extra_info {
 		int first_frame;    //!< used for animations -- points to index of first frame
 		int num_frames;     //!< used for animations -- number of frames in the animation
 		int keyframe;       //!< used for animations -- keyframe info
+		float total_time;   //!< used for animations -- total animation time (not always derived from num_frames/fps)
 		ubyte fps;          //!< used for animations -- frames per second
 
 		struct {

--- a/code/bmpman/bmpman.cpp
+++ b/code/bmpman/bmpman.cpp
@@ -1492,7 +1492,7 @@ static int bm_load_image_data(const char *filename, int handle, int bitmapnum, u
 int bm_load_animation(const char *real_filename, int *nframes, int *fps, int *keyframe, float *total_time, bool can_drop_frames, int dir_type) {
 	int	i, n;
 	anim	the_anim;
-	CFILE	*img_cfp = NULL;
+	CFILE	*img_cfp = nullptr;
 	char filename[MAX_FILENAME_LEN];
 	int reduced = 0;
 	int anim_fps = 0, anim_frames = 0, key = 0;
@@ -1584,6 +1584,8 @@ int bm_load_animation(const char *real_filename, int *nframes, int *fps, int *ke
 	// we only check for -5 here since the filename should already have the extension on it, and it must have passed the previous check
 	if (strlen(filename) > MAX_FILENAME_LEN - 5) {
 		Warning(LOCATION, "Passed filename, '%s', is too long to support an extension and frames!!\n\nMaximum length for an ANI/EFF/APNG, minus the extension, is %i characters.\n", filename, MAX_FILENAME_LEN - 10);
+		if (img_cfp != nullptr)
+			cfclose(img_cfp);
 		return -1;
 	}
 
@@ -1591,6 +1593,8 @@ int bm_load_animation(const char *real_filename, int *nframes, int *fps, int *ke
 	if (type == BM_TYPE_EFF) {
 		if (!bm_load_and_parse_eff(filename, dir_type, &anim_frames, &anim_fps, &key, &eff_type)) {
 			mprintf(("BMPMAN: Error reading EFF\n"));
+			if (img_cfp != nullptr)
+				cfclose(img_cfp);
 			return -1;
 		} else {
 			mprintf(("BMPMAN: Found EFF (%s) with %d frames at %d fps.\n", filename, anim_frames, anim_fps));
@@ -1653,11 +1657,15 @@ int bm_load_animation(const char *real_filename, int *nframes, int *fps, int *ke
 		}
 		catch (const apng::ApngException& e) {
 			Warning(LOCATION, "Failed to load apng: %s", e.what());
+			if (img_cfp != nullptr)
+				cfclose(img_cfp);
 			return -1;
 		}
 	}
 	else {
 		Warning(LOCATION, "Unsupported image type: %i", type);
+		if (img_cfp != nullptr)
+			cfclose(img_cfp);
 		return -1;
 	}
 
@@ -1675,7 +1683,7 @@ int bm_load_animation(const char *real_filename, int *nframes, int *fps, int *ke
 	n = find_block_of(anim_frames);
 
 	if (n < 0) {
-		if (img_cfp != NULL)
+		if (img_cfp != nullptr)
 			cfclose(img_cfp);
 
 		return -1;
@@ -1696,7 +1704,7 @@ int bm_load_animation(const char *real_filename, int *nframes, int *fps, int *ke
 				if (i == 0) {
 					Warning(LOCATION, "EFF: No frame images were found.  EFF, %s, is invalid.\n", filename);
 
-					if (img_cfp != NULL)
+					if (img_cfp != nullptr)
 						cfclose(img_cfp);
 
 					return -1;

--- a/code/bmpman/bmpman.cpp
+++ b/code/bmpman/bmpman.cpp
@@ -69,8 +69,8 @@ const BM_TYPE bm_type_list[] = { BM_TYPE_DDS, BM_TYPE_TGA, BM_TYPE_PNG, BM_TYPE_
 const char *bm_ext_list[] = { ".dds", ".tga", ".png", ".jpg", ".pcx" };
 const int BM_NUM_TYPES = sizeof(bm_type_list) / sizeof(bm_type_list[0]);
 
-const BM_TYPE bm_ani_type_list[] = { BM_TYPE_EFF, BM_TYPE_ANI };
-const char *bm_ani_ext_list[] = { ".eff", ".ani" };
+const BM_TYPE bm_ani_type_list[] = { BM_TYPE_EFF, BM_TYPE_ANI, BM_TYPE_PNG };
+const char *bm_ani_ext_list[] = { ".eff", ".ani", ".png" };
 const int BM_ANI_NUM_TYPES = sizeof(bm_ani_type_list) / sizeof(bm_ani_type_list[0]);
 
 void(*bm_set_components)(ubyte *pixel, ubyte *r, ubyte *g, ubyte *b, ubyte *a) = NULL;

--- a/code/bmpman/bmpman.cpp
+++ b/code/bmpman/bmpman.cpp
@@ -1561,6 +1561,9 @@ int bm_load_animation(const char *real_filename, int *nframes, int *fps, int *ke
 			if (keyframe)
 				*keyframe = bm_bitmaps[n].info.ani.keyframe;
 
+			if (total_time != nullptr)
+				*total_time = bm_bitmaps[n].info.ani.total_time;
+
 			return handle;
 		}
 
@@ -1720,6 +1723,7 @@ int bm_load_animation(const char *real_filename, int *nframes, int *fps, int *ke
 		bm_bitmaps[n + i].info.ani.num_frames = anim_frames;
 		bm_bitmaps[n + i].info.ani.fps = (ubyte)anim_fps;
 		bm_bitmaps[n + i].info.ani.keyframe = key;
+		bm_bitmaps[n + i].info.ani.total_time = anim_total_time;
 		bm_bitmaps[n + i].bm.w = (short)anim_width;
 		bm_bitmaps[n + i].bm.rowsize = (short)anim_width;
 		bm_bitmaps[n + i].bm.h = (short)anim_height;

--- a/code/bmpman/bmpman.cpp
+++ b/code/bmpman/bmpman.cpp
@@ -71,6 +71,9 @@ const char *bm_ext_list[] = { ".dds", ".tga", ".png", ".jpg", ".pcx" };
 const int BM_NUM_TYPES = sizeof(bm_type_list) / sizeof(bm_type_list[0]);
 
 const BM_TYPE bm_ani_type_list[] = { BM_TYPE_EFF, BM_TYPE_ANI, BM_TYPE_PNG };
+// NOTE: it would be better to have apng files use the .apng extension
+// However there's lots of assumptions throughout the codebase that file extensions are only
+// three chars long. If this is ever changed the the .apng extension could be used
 const char *bm_ani_ext_list[] = { ".eff", ".ani", ".png" };
 const int BM_ANI_NUM_TYPES = sizeof(bm_ani_type_list) / sizeof(bm_ani_type_list[0]);
 

--- a/code/bmpman/bmpman.cpp
+++ b/code/bmpman/bmpman.cpp
@@ -1385,7 +1385,6 @@ bool bm_load_and_parse_eff(const char *filename, int dir_type, int *nframes, int
 	return true;
 }
 
-
 /**
 * Lock an image files data into memory
 */
@@ -1493,7 +1492,7 @@ static int bm_load_image_data(const char *filename, int handle, int bitmapnum, u
 	return 0;
 }
 
-int bm_load_animation(const char *real_filename, int *nframes, int *fps, int *keyframe, int can_drop_frames, int dir_type) {
+int bm_load_animation(const char *real_filename, int *nframes, int *fps, int *keyframe, float *total_time, bool can_drop_frames, int dir_type) {
 	int	i, n;
 	anim	the_anim;
 	CFILE	*img_cfp = NULL;
@@ -1654,7 +1653,7 @@ int bm_load_animation(const char *real_filename, int *nframes, int *fps, int *ke
 		return -1;
 	}
 
-	if ((can_drop_frames) && (type == BM_TYPE_ANI)) {
+	if ((can_drop_frames == true) && (type == BM_TYPE_ANI)) {
 		if (Bm_low_mem == 1) {
 			reduced = 1;
 			anim_frames = (anim_frames + 1) / 2;
@@ -1797,7 +1796,7 @@ int bm_load_either(const char *filename, int *nframes, int *fps, int *keyframe, 
 		*nframes = 0;
 	if (fps != NULL)
 		*fps = 0;
-	int tidx = bm_load_animation(filename, nframes, fps, keyframe, can_drop_frames, dir_type);
+	int tidx = bm_load_animation(filename, nframes, fps, keyframe, nullptr, can_drop_frames, dir_type);
 	if (tidx == -1) {
 		tidx = bm_load(filename);
 		if (tidx != -1 && nframes != NULL)

--- a/code/bmpman/bmpman.cpp
+++ b/code/bmpman/bmpman.cpp
@@ -1659,7 +1659,7 @@ int bm_load_animation(const char *real_filename, int *nframes, int *fps, int *ke
 			img_size = the_apng.imgsize();
 		}
 		catch (const apng::ApngException& e) {
-			Warning(LOCATION, "Failed to load apng: %s", e.what());
+			mprintf(("Failed to load apng: %s\n", e.what() ));
 			if (img_cfp != nullptr)
 				cfclose(img_cfp);
 			return -1;

--- a/code/bmpman/bmpman.cpp
+++ b/code/bmpman/bmpman.cpp
@@ -1799,7 +1799,7 @@ int bm_load_duplicate(const char *filename) {
 	return ret;
 }
 
-int bm_load_either(const char *filename, int *nframes, int *fps, int *keyframe, int can_drop_frames, int dir_type) {
+int bm_load_either(const char *filename, int *nframes, int *fps, int *keyframe, bool can_drop_frames, int dir_type) {
 	if (nframes != NULL)
 		*nframes = 0;
 	if (fps != NULL)

--- a/code/bmpman/bmpman.h
+++ b/code/bmpman/bmpman.h
@@ -299,7 +299,7 @@ int bm_release(int handle, int clear_render_targets = 0);
  * @returns The bm number of the first bitmap in the sequence if successful, or
  * @returns A negative value if unsuccessful
  */
-int bm_load_animation(const char *filename, int *nframes = NULL, int *fps = NULL, int *keyframe = NULL, int can_drop_frames = 0, int dir_type = CF_TYPE_ANY);
+int bm_load_animation(const char *filename, int *nframes = nullptr, int *fps = nullptr, int *keyframe = nullptr, float *total_time = nullptr, bool can_drop_frames = 0, int dir_type = CF_TYPE_ANY);
 
 /**
  * @brief Loads either animation (bm_load_animation) or still image (bm_load)

--- a/code/bmpman/bmpman.h
+++ b/code/bmpman/bmpman.h
@@ -671,4 +671,16 @@ bool bm_set_render_target(int handle, int face = -1);
  */
 bool bm_load_and_parse_eff(const char *filename, int dir_type, int *nframes, int *nfps, int *key, BM_TYPE *type);
 
+/**
+ * @brief Calculates & returns the current frame of an animation
+ *
+ * @param[in] frame1_handle  Handle of the animation
+ * @param[in] elapsed_time   Time in seconds since the animation started playing
+ * @param[in] loop           (optional) specifies if the animation should loop, default is false which causes animation to hold on the last frame
+ * @param[in] divisor        (optional) if greater than zero, elapsed time will be divided by this value i.e. allows a ratio of percentage complete to be used to determine the frame
+ *
+ * @returns current frame of the animation (range is zero to the number of frames minus one)
+ */
+int bm_get_anim_frame(const int frame1_handle, float elapsed_time, const bool loop = false, const float divisor = 0.0f);
+
 #endif

--- a/code/bmpman/bmpman.h
+++ b/code/bmpman/bmpman.h
@@ -314,7 +314,7 @@ int bm_load_animation(const char *filename, int *nframes = nullptr, int *fps = n
  * @returns The bm number of the first bitmap in the sequence if successful, or
  * @returns A negative value if unsuccessful
  */
-int bm_load_either(const char *filename, int *nframes = NULL, int *fps = NULL, int *keyframe = NULL, int can_drop_frames = 0, int dir_type = CF_TYPE_ANY);
+int bm_load_either(const char *filename, int *nframes = NULL, int *fps = NULL, int *keyframe = NULL, bool can_drop_frames = false, int dir_type = CF_TYPE_ANY);
 
 /**
  * @brief Locks down the bitmap indexed by bitmapnum.

--- a/code/bmpman/bmpman.h
+++ b/code/bmpman/bmpman.h
@@ -681,6 +681,6 @@ bool bm_load_and_parse_eff(const char *filename, int dir_type, int *nframes, int
  *
  * @returns current frame of the animation (range is zero to the number of frames minus one)
  */
-int bm_get_anim_frame(const int frame1_handle, float elapsed_time, const bool loop = false, const float divisor = 0.0f);
+int bm_get_anim_frame(const int frame1_handle, float elapsed_time, const float divisor = 0.0f, const bool loop = false);
 
 #endif

--- a/code/bmpman/bmpman.h
+++ b/code/bmpman/bmpman.h
@@ -677,7 +677,7 @@ bool bm_load_and_parse_eff(const char *filename, int dir_type, int *nframes, int
  * @param[in] frame1_handle  Handle of the animation
  * @param[in] elapsed_time   Time in seconds since the animation started playing
  * @param[in] loop           (optional) specifies if the animation should loop, default is false which causes animation to hold on the last frame
- * @param[in] divisor        (optional) if greater than zero, elapsed time will be divided by this value i.e. allows a ratio of percentage complete to be used to determine the frame
+ * @param[in] divisor        (optional) if greater than zero, elapsed time will be divided by this value i.e. allows "percentage complete" to be used to determine the frame instead of the animations total time derived from fps * frames
  *
  * @returns current frame of the animation (range is zero to the number of frames minus one)
  */

--- a/code/fireball/fireballs.cpp
+++ b/code/fireball/fireballs.cpp
@@ -517,8 +517,8 @@ void fireball_set_framenum(int num)
 			fb->current_bitmap = fl->bitmap_id + framenum;
 		}
 	} else {
-		framenum = bm_get_anim_frame(fl->bitmap_id, fb->time_elapsed, fb->total_time);
 		// ignore setting of OF_SHOULD_BE_DEAD, see fireball_process_post
+		framenum = bm_get_anim_frame(fl->bitmap_id, fb->time_elapsed, fb->total_time);
 		fb->current_bitmap = fl->bitmap_id + framenum;
 	}
 }

--- a/code/fireball/fireballs.cpp
+++ b/code/fireball/fireballs.cpp
@@ -323,7 +323,7 @@ void fireball_load_data()
 			if ( (i == FIREBALL_WARP) && (idx > MAX_WARP_LOD) )
 				continue;
 
-			fd->lod[idx].bitmap_id	= bm_load_animation( fd->lod[idx].filename, &fd->lod[idx].num_frames, &fd->lod[idx].fps, NULL, 1 );
+			fd->lod[idx].bitmap_id	= bm_load_animation( fd->lod[idx].filename, &fd->lod[idx].num_frames, &fd->lod[idx].fps, nullptr, nullptr, true );
 			if ( fd->lod[idx].bitmap_id < 0 ) {
 				Error(LOCATION, "Could not load %s anim file\n", fd->lod[idx].filename);
 			}

--- a/code/fireball/fireballs.cpp
+++ b/code/fireball/fireballs.cpp
@@ -507,13 +507,7 @@ void fireball_set_framenum(int num)
 	}
 
 	if ( fb->fireball_render_type == FIREBALL_WARP_EFFECT )	{
-		float total_time = i2fl(fl->num_frames) / fl->fps;	// in seconds
-
-		framenum = fl2i(fb->time_elapsed * fl->num_frames / total_time + 0.5);
-
-		if ( framenum < 0 ) framenum = 0;
-
-		framenum = framenum % fl->num_frames;
+		framenum = bm_get_anim_frame(fl->bitmap_id, fb->time_elapsed, 0.0f, true);
 
 		if ( fb->orient )	{
 			// warp out effect plays backwards
@@ -523,16 +517,8 @@ void fireball_set_framenum(int num)
 			fb->current_bitmap = fl->bitmap_id + framenum;
 		}
 	} else {
-
-		framenum = fl2i(fb->time_elapsed / fb->total_time * fl->num_frames + 0.5);
-
-		// ensure we don't go past the number of frames of animation
-		if ( framenum > (fl->num_frames-1) ) {
-			framenum = (fl->num_frames-1);
-			Objects[fb->objnum].flags |= OF_SHOULD_BE_DEAD;
-		}
-
-		if ( framenum < 0 ) framenum = 0;
+		framenum = bm_get_anim_frame(fl->bitmap_id, fb->time_elapsed, fb->total_time);
+		// ignore setting of OF_SHOULD_BE_DEAD, see fireball_process_post
 		fb->current_bitmap = fl->bitmap_id + framenum;
 	}
 }

--- a/code/fred2/campaigneditordlg.cpp
+++ b/code/fred2/campaigneditordlg.cpp
@@ -817,7 +817,8 @@ void campaign_editor::OnBrowseLoopAni()
 
 	// switch directories
 	pushed_dir = cfile_push_chdir(CF_TYPE_INTERFACE);
-	CFileDialog dlg(TRUE, "ani", NULL, OFN_HIDEREADONLY | OFN_FILEMUSTEXIST | OFN_NOCHANGEDIR, "Ani Files (*.ani)|*.ani");
+	CFileDialog dlg(TRUE, "ani", NULL, OFN_HIDEREADONLY | OFN_FILEMUSTEXIST | OFN_NOCHANGEDIR,
+		"Ani Files (*.ani)|*.ani|Eff File (*.eff)|*.eff|APNG Files (*.png)|*.png|All Anims (*.ani, *.eff, *.png)|*.ani;*.eff;*.png");
 
 	if (dlg.DoModal() == IDOK) {
 		m_branch_brief_anim = dlg.GetFileName();

--- a/code/fred2/cmdbrief.cpp
+++ b/code/fred2/cmdbrief.cpp
@@ -275,7 +275,7 @@ void cmd_brief_dlg::OnBrowseAni()
 	UpdateData(TRUE);
 	z = cfile_push_chdir(CF_TYPE_INTERFACE);
 	CFileDialog dlg(TRUE, "ani", NULL, OFN_HIDEREADONLY | OFN_FILEMUSTEXIST | OFN_NOCHANGEDIR,
-		"Ani Files (*.ani)|*.ani|Avi Files (*.avi)|*.avi|Both (*.ani, *.avi)|*.ani;*.avi||");
+		"Ani Files (*.ani)|*.ani|Eff Files (*.eff)|*.eff|APNG Files (*.png)|*.png|All Anims (*.ani, ,*.eff, *.png)|*.ani;*.eff;*.png|");
 
 	if (dlg.DoModal() == IDOK) {
 		m_ani_filename = dlg.GetFileName();

--- a/code/fred2/eventeditor.cpp
+++ b/code/fred2/eventeditor.cpp
@@ -1350,7 +1350,7 @@ void event_editor::OnBrowseAvi()
 
 	z = cfile_push_chdir(CF_TYPE_INTERFACE);
 	CFileDialog dlg(TRUE, "ani", m_avi_filename, OFN_HIDEREADONLY | OFN_FILEMUSTEXIST | OFN_NOCHANGEDIR,
-		"Ani Files (*.ani)|*.ani|Eff Files (*.eff)|*.eff|Avi Files (*.avi)|*.avi|Both (*.ani, *.avi)|*.ani;*.avi||");
+		"Ani Files (*.ani)|*.ani|Eff Files (*.eff)|*.eff|APNG Files (*.png)|*.png|All Anims (*.ani, *.eff, *.png)|*.ani;*.eff;*.png|");
 
 	if (dlg.DoModal() == IDOK) {
 		m_avi_filename = dlg.GetFileName();

--- a/code/fred2/messageeditordlg.cpp
+++ b/code/fred2/messageeditordlg.cpp
@@ -538,7 +538,7 @@ void CMessageEditorDlg::OnBrowseAvi()
 
 	UpdateData(TRUE);
 	CFileDialog dlg(TRUE, "ani", m_avi_filename, OFN_HIDEREADONLY | OFN_FILEMUSTEXIST | OFN_NOCHANGEDIR,
-		"Ani Files (*.ani)|*.ani|Avi Files (*.avi)|*.avi|Both (*.ani, *.avi)|*.ani;*.avi||");
+		"Ani Files (*.ani)|*.ani|Eff Files (*.eff)|*.eff|APNG Files (*.png)|*.png|All Anims (*.ani, *.eff, *.png)|*.ani;*.eff;*.png||");
 
 	if (dlg.DoModal() == IDOK)
 	{

--- a/code/fred2/shiptexturesdlg.cpp
+++ b/code/fred2/shiptexturesdlg.cpp
@@ -85,7 +85,7 @@ void CShipTexturesDlg::OnOK()
 				// if PCX not found, look for ANI
 				if (temp_bmp < 0)
 				{					
-					temp_bmp = bm_load_animation(new_texture_name[i],  &temp_frames, &temp_fps, NULL, 1);
+					temp_bmp = bm_load_animation(new_texture_name[i],  &temp_frames, &temp_fps, nullptr, nullptr, nullptr, true);
 				}
 
 				// check if loaded

--- a/code/freespace2/freespace.cpp
+++ b/code/freespace2/freespace.cpp
@@ -7398,6 +7398,7 @@ typedef struct animating_obj
 	int	first_frame;
 	int	num_frames;
 	int	current_frame;
+	float duration;
 	float elapsed_time;
 } animating_obj;
 
@@ -7414,6 +7415,7 @@ void init_animating_pointer()
 	Animating_mouse.first_frame	= -1;
 	Animating_mouse.num_frames		= 0;
 	Animating_mouse.current_frame	= -1;
+	Animating_mouse.duration = 0.0f;
 	Animating_mouse.elapsed_time	= 0.0f;
 }
 
@@ -7426,7 +7428,6 @@ void init_animating_pointer()
 // 
 void load_animating_pointer(char *filename)
 {
-	int				fps;
 	animating_obj *am;
 
 	init_animating_pointer();
@@ -7434,7 +7435,7 @@ void load_animating_pointer(char *filename)
 	mprintf(("loading animated cursor \"%s\"\n", filename));
 
 	am = &Animating_mouse;
-	am->first_frame = bm_load_animation(filename, &am->num_frames, &fps);
+	am->first_frame = bm_load_animation(filename, &am->num_frames, nullptr, nullptr, &am->duration);
 	if ( am->first_frame == -1 ) 
 		Error(LOCATION, "Could not load animation %s for the mouse pointer\n", filename);
 	am->current_frame = 0;
@@ -7470,15 +7471,14 @@ void unload_animating_pointer()
 // draw the correct frame of the game mouse... called from game_maybe_draw_mouse()
 void game_render_mouse(float frametime)
 {
-	int				mx, my;
 	animating_obj	*am;
 
 	// if animating cursor exists, play the next frame
 	am = &Animating_mouse;
 	if ( am->first_frame != -1 ) {
-		mouse_get_pos(&mx, &my);
 		am->elapsed_time += frametime;
 		am->current_frame = bm_get_anim_frame(am->first_frame, am->elapsed_time, 0.0f, true);
+		am->elapsed_time = fmod(am->elapsed_time, am->duration); // avoid loss of precision & overflow issues
 		gr_set_cursor_bitmap(am->first_frame + am->current_frame);
 	}
 }

--- a/code/freespace2/freespace.cpp
+++ b/code/freespace2/freespace.cpp
@@ -1138,7 +1138,7 @@ void game_loading_callback(int count)
 	int do_flip = 0;
 
 	mprintf(("bm_get_anim_frameA: count (%i) COUNT_ESTIMATE (%i)\n", count, COUNT_ESTIMATE));
-	int new_framenum = bm_get_anim_frame(Game_loading_ani.first_frame, static_cast<float>(count), false, static_cast<float>(COUNT_ESTIMATE));
+	int new_framenum = bm_get_anim_frame(Game_loading_ani.first_frame, static_cast<float>(count), static_cast<float>(COUNT_ESTIMATE));
 
 	//make sure we always run forwards - graphical hack
 	if(new_framenum > framenum)
@@ -7395,7 +7395,6 @@ typedef struct animating_obj
 	int	first_frame;
 	int	num_frames;
 	int	current_frame;
-	float time;
 	float elapsed_time;
 } animating_obj;
 
@@ -7412,7 +7411,6 @@ void init_animating_pointer()
 	Animating_mouse.first_frame	= -1;
 	Animating_mouse.num_frames		= 0;
 	Animating_mouse.current_frame	= -1;
-	Animating_mouse.time				= 0.0f;
 	Animating_mouse.elapsed_time	= 0.0f;
 }
 
@@ -7437,7 +7435,6 @@ void load_animating_pointer(char *filename)
 	if ( am->first_frame == -1 ) 
 		Error(LOCATION, "Could not load animation %s for the mouse pointer\n", filename);
 	am->current_frame = 0;
-	am->time = am->num_frames / i2fl(fps);
 }
 
 // ----------------------------------------------------------------------------
@@ -7478,11 +7475,7 @@ void game_render_mouse(float frametime)
 	if ( am->first_frame != -1 ) {
 		mouse_get_pos(&mx, &my);
 		am->elapsed_time += frametime;
-		am->current_frame = fl2i( ( am->elapsed_time / am->time ) * (am->num_frames-1) );
-		if ( am->current_frame >= am->num_frames ) {
-			am->current_frame = 0;
-			am->elapsed_time = 0.0f;
-		}
+		am->current_frame = bm_get_anim_frame(am->first_frame, am->elapsed_time, 0.0f, true);
 		gr_set_cursor_bitmap(am->first_frame + am->current_frame);
 	}
 }

--- a/code/freespace2/freespace.cpp
+++ b/code/freespace2/freespace.cpp
@@ -1137,8 +1137,11 @@ void game_loading_callback(int count)
 
 	int do_flip = 0;
 
-	mprintf(("bm_get_anim_frameA: count (%i) COUNT_ESTIMATE (%i)\n", count, COUNT_ESTIMATE));
 	int new_framenum = bm_get_anim_frame(Game_loading_ani.first_frame, static_cast<float>(count), static_cast<float>(COUNT_ESTIMATE));
+	// retail incremented the frame number by one, essentially skipping the 1st frame except for single-frame anims
+	if (Game_loading_ani.num_frames > 1 && new_framenum < Game_loading_ani.num_frames-1) {
+		new_framenum++;
+	}
 
 	//make sure we always run forwards - graphical hack
 	if(new_framenum > framenum)

--- a/code/freespace2/freespace.cpp
+++ b/code/freespace2/freespace.cpp
@@ -1130,7 +1130,6 @@ static int framenum;
  */
 void game_loading_callback(int count)
 {	
-	int new_framenum;
 	game_do_networking();
 
 	Assert( Game_loading_callback_inited==1 );
@@ -1138,12 +1137,9 @@ void game_loading_callback(int count)
 
 	int do_flip = 0;
 
-	new_framenum = ((Game_loading_ani.num_frames*count) / COUNT_ESTIMATE)+1;
-	if ( new_framenum > Game_loading_ani.num_frames-1 )	{
-		new_framenum = Game_loading_ani.num_frames-1;
-	} else if ( new_framenum < 0 )	{
-		new_framenum = 0;
-	}
+	mprintf(("bm_get_anim_frameA: count (%i) COUNT_ESTIMATE (%i)\n", count, COUNT_ESTIMATE));
+	int new_framenum = bm_get_anim_frame(Game_loading_ani.first_frame, static_cast<float>(count), false, static_cast<float>(COUNT_ESTIMATE));
+
 	//make sure we always run forwards - graphical hack
 	if(new_framenum > framenum)
 		framenum = new_framenum;

--- a/code/graphics/generic.cpp
+++ b/code/graphics/generic.cpp
@@ -223,7 +223,7 @@ int generic_anim_stream(generic_anim *ga)
 				ga->png.anim = new apng::apng_ani(ga->filename);
 			}
 			catch (const apng::ApngException& e) {
-				Warning(LOCATION, "Failed to load apng: %s", e.what());
+				mprintf(("Failed to load apng: %s\n", e.what() ));
 				delete ga->png.anim;
 				ga->png.anim = nullptr;
 				return -1;

--- a/code/graphics/generic.cpp
+++ b/code/graphics/generic.cpp
@@ -332,7 +332,7 @@ void generic_anim_unload(generic_anim *ga)
 			if(ga->type == BM_TYPE_PNG) {
 				if(ga->bitmap_id >= 0)
 					bm_release(ga->bitmap_id);
-				if (ga->png.anim)
+				if (ga->png.anim != nullptr)
 					delete ga->png.anim;
 			}
 		}

--- a/code/graphics/generic.cpp
+++ b/code/graphics/generic.cpp
@@ -148,6 +148,7 @@ int generic_anim_load(generic_anim *ga)
 	if (ga->first_frame < 0)
 		return -1;
 
+	// TODO handle APNGs having a different total_time calc
 	Assert(fps != 0);
 	ga->total_time = ga->num_frames / (float)fps;
 	ga->done_playing = 0;

--- a/code/graphics/generic.h
+++ b/code/graphics/generic.h
@@ -58,6 +58,25 @@ typedef struct generic_bitmap {
 	int bitmap_id;
 } generic_bitmap;
 
+/*
+ * @brief helper class to reduce params passed to generic_anim_render
+ */
+class generic_extras {
+public:
+	int width, height;
+	float u0, v0, u1, v1;
+	float alpha;
+	bool draw;
+
+	generic_extras()
+		: width(0), height(0)
+		, u0(0.0f), v0(0.0f)
+		, u1(1.0f), v1(1.0f)
+		, alpha(1.0f)
+		, draw(true)
+	{}
+};
+
 bool generic_bitmap_exists(const char *filename);
 bool generic_anim_exists(const char *filename);
 int generic_anim_init_and_stream(generic_anim *ga, const char *anim_filename, BM_TYPE bg_type, bool attempt_hi_res);
@@ -69,6 +88,6 @@ int generic_anim_load(generic_anim *ga);
 int generic_anim_stream(generic_anim *ga);
 int generic_bitmap_load(generic_bitmap *gb);
 void generic_anim_unload(generic_anim *ga);
-void generic_anim_render(generic_anim *ga, float frametime, int x, int y, bool menu = false);
+void generic_anim_render(generic_anim *ga, float frametime, int x, int y, bool menu = false, const generic_extras *ge = nullptr);
 
 #endif

--- a/code/graphics/generic.h
+++ b/code/graphics/generic.h
@@ -7,6 +7,7 @@
 #include "bmpman/bmpman.h"
 #include "cfile/cfile.h"
 #include "globalincs/pstypes.h"
+#include "pngutils/pngutils.h"
 
 #define GENERIC_ANIM_DIRECTION_FORWARDS		0
 #define GENERIC_ANIM_DIRECTION_BACKWARDS	1
@@ -37,6 +38,10 @@ typedef struct generic_anim {
 		struct {
 			int next_frame;
 		} eff;
+		struct {
+			apng::apng_ani* anim;
+			float previous_frame_time;
+		} png;
 	};
 	ubyte type;
 	unsigned char streaming;

--- a/code/graphics/gropenglbmpman.cpp
+++ b/code/graphics/gropenglbmpman.cpp
@@ -98,6 +98,7 @@ extern void bm_clean_slot(int n);
 
 extern bool opengl_texture_slot_valid(int n, int handle);
 
+
 void gr_opengl_bm_save_render_target(int n)
 {
 	Assert( (n >= 0) && (n < MAX_BITMAPS) );

--- a/code/hud/hud.cpp
+++ b/code/hud/hud.cpp
@@ -2215,6 +2215,7 @@ int hud_anim_load(hud_anim *ha)
 
 /**
  * @brief Render out a frame of the targetbox static animation, based on how much time has elapsed 
+ * @note targetbox static was not implemented by :v:, but this is also used for briefing icons & hud lock icons
  *
  * @param ha			Pointer to ::hud_anim info
  * @param frametime		Seconds elapsed since last frame
@@ -2224,6 +2225,8 @@ int hud_anim_load(hud_anim *ha)
  * @param reverse		Play animation in reverse (default 0)
  * @param resize_mode		Resize for non-standard resolutions
  * @param mirror		Mirror along y-axis so icon points left instead of right
+ *
+ * @returns  1 on success, 0 on failure
  */
 int hud_anim_render(hud_anim *ha, float frametime, int draw_alpha, int loop, int hold_last, int reverse, int resize_mode, bool mirror)
 {
@@ -2235,11 +2238,21 @@ int hud_anim_render(hud_anim *ha, float frametime, int draw_alpha, int loop, int
 	}
 
 	ha->time_elapsed += frametime;
+	if ( ha->time_elapsed > ha->total_time && loop != 0 && hold_last == 0) {
+		return 0;
+	}
+
+	framenum = bm_get_anim_frame(ha->first_frame, ha->time_elapsed, ha->total_time, static_cast<bool>(loop));
+	if (reverse) {
+		framenum = (ha->num_frames-1) - framenum;
+	}
+#if 0
 	if ( ha->time_elapsed > ha->total_time ) {
 		if ( loop ) {
 			ha->time_elapsed = 0.0f;
 		} else {
 			if ( !hold_last ) {
+				// anim ended, not looping, not holding last == abort!
 				return 0;
 			}
 		}
@@ -2255,6 +2268,7 @@ int hud_anim_render(hud_anim *ha, float frametime, int draw_alpha, int loop, int
 		framenum = 0;
 	if ( framenum >= ha->num_frames )
 		framenum = ha->num_frames-1;
+#endif
 
 	// Blit the bitmap for this frame
 	if(emp_should_blit_gauge()){

--- a/code/hud/hud.cpp
+++ b/code/hud/hud.cpp
@@ -2238,37 +2238,15 @@ int hud_anim_render(hud_anim *ha, float frametime, int draw_alpha, int loop, int
 	}
 
 	ha->time_elapsed += frametime;
-	if ( ha->time_elapsed > ha->total_time && loop != 0 && hold_last == 0) {
+	if ( ha->time_elapsed > ha->total_time && loop == 0 && hold_last == 0) {
 		return 0;
 	}
 
-	framenum = bm_get_anim_frame(ha->first_frame, ha->time_elapsed, ha->total_time, static_cast<bool>(loop));
+	// Note; total_time for hum_anim is derived only from the fps, no need to pass it here
+	framenum = bm_get_anim_frame(ha->first_frame, ha->time_elapsed, 0.0f, static_cast<bool>(loop));
 	if (reverse) {
 		framenum = (ha->num_frames-1) - framenum;
 	}
-#if 0
-	if ( ha->time_elapsed > ha->total_time ) {
-		if ( loop ) {
-			ha->time_elapsed = 0.0f;
-		} else {
-			if ( !hold_last ) {
-				// anim ended, not looping, not holding last == abort!
-				return 0;
-			}
-		}
-	}
-
-	// Draw the correct frame of animation
-	framenum = fl2i( (ha->time_elapsed * ha->num_frames) / ha->total_time );
-	if (reverse) {
-		framenum = (ha->num_frames-1) - framenum;
-	}
-
-	if ( framenum < 0 )
-		framenum = 0;
-	if ( framenum >= ha->num_frames )
-		framenum = ha->num_frames-1;
-#endif
 
 	// Blit the bitmap for this frame
 	if(emp_should_blit_gauge()){

--- a/code/hud/hud.cpp
+++ b/code/hud/hud.cpp
@@ -2214,8 +2214,8 @@ int hud_anim_load(hud_anim *ha)
 }
 
 /**
- * @brief Render out a frame of the targetbox static animation, based on how much time has elapsed 
- * @note targetbox static was not implemented by :v:, but this is also used for briefing icons & hud lock icons
+ * @brief Render out a frame of a hud or briefing animation, based on how much time has elapsed
+ * @note targetbox static was not implemented by :v:, also used for briefing icons & hud lock icons
  *
  * @param ha			Pointer to ::hud_anim info
  * @param frametime		Seconds elapsed since last frame
@@ -2242,7 +2242,7 @@ int hud_anim_render(hud_anim *ha, float frametime, int draw_alpha, int loop, int
 		return 0;
 	}
 
-	// Note; total_time for hum_anim is derived only from the fps, no need to pass it here
+	// Note; total_time for hud_anim is derived only from the fps, no need to pass it in
 	framenum = bm_get_anim_frame(ha->first_frame, ha->time_elapsed, 0.0f, static_cast<bool>(loop));
 	if (reverse) {
 		framenum = (ha->num_frames-1) - framenum;

--- a/code/lab/lab.cpp
+++ b/code/lab/lab.cpp
@@ -607,20 +607,7 @@ void labviewer_add_model_thrusters(model_render_params *render_info, ship_info *
 	if (flame_anim->first_frame >= 0) {
 		thruster_frame += flFrametime * rate;
 
-		// Sanity checks
-		if (thruster_frame < 0.0f) {
-			thruster_frame = 0.0f;
-		} else if (thruster_frame > 100.0f) {
-			thruster_frame = 0.0f;
-		}
-
-		while (thruster_frame > flame_anim->total_time) {
-			thruster_frame -= flame_anim->total_time;
-		}
-
-		framenum = fl2i( (thruster_frame * flame_anim->num_frames) / flame_anim->total_time );
-
-		CLAMP(framenum, 0, flame_anim->num_frames-1);
+		framenum = bm_get_anim_frame(flame_anim->first_frame, thruster_frame / flame_anim->total_time, true);
 
 		// Get the bitmap for this frame
 		thruster_bitmap = flame_anim->first_frame + framenum;
@@ -634,20 +621,7 @@ void labviewer_add_model_thrusters(model_render_params *render_info, ship_info *
 	if (glow_anim->first_frame >= 0) {
 		thruster_glow_frame += flFrametime * rate;
 
-		// Sanity checks
-		if (thruster_glow_frame < 0.0f) {
-			thruster_glow_frame = 0.0f;
-		} else if (thruster_glow_frame > 100.0f) {
-			thruster_glow_frame = 0.0f;
-		}
-
-		while (thruster_glow_frame > glow_anim->total_time) {
-			thruster_glow_frame -= glow_anim->total_time;
-		}
-
-		framenum = fl2i( (thruster_glow_frame * glow_anim->num_frames) / glow_anim->total_time );
-
-		CLAMP(framenum, 0, glow_anim->num_frames-1);
+		framenum = bm_get_anim_frame(glow_anim->first_frame, thruster_glow_frame / glow_anim->total_time);
 
 		// Get the bitmap for this frame
 		thruster_glow_bitmap = glow_anim->first_frame;	// + framenum;

--- a/code/lab/lab.cpp
+++ b/code/lab/lab.cpp
@@ -607,7 +607,7 @@ void labviewer_add_model_thrusters(model_render_params *render_info, ship_info *
 	if (flame_anim->first_frame >= 0) {
 		thruster_frame += flFrametime * rate;
 
-		framenum = bm_get_anim_frame(flame_anim->first_frame, thruster_frame / flame_anim->total_time, true);
+		framenum = bm_get_anim_frame(flame_anim->first_frame, thruster_frame, flame_anim->total_time, true);
 
 		// Get the bitmap for this frame
 		thruster_bitmap = flame_anim->first_frame + framenum;
@@ -621,7 +621,7 @@ void labviewer_add_model_thrusters(model_render_params *render_info, ship_info *
 	if (glow_anim->first_frame >= 0) {
 		thruster_glow_frame += flFrametime * rate;
 
-		framenum = bm_get_anim_frame(glow_anim->first_frame, thruster_glow_frame / glow_anim->total_time);
+		framenum = bm_get_anim_frame(glow_anim->first_frame, thruster_glow_frame, glow_anim->total_time, true);
 
 		// Get the bitmap for this frame
 		thruster_glow_bitmap = glow_anim->first_frame;	// + framenum;
@@ -1149,20 +1149,7 @@ void labviewer_render_bitmap(float frametime)
 	if (wip->laser_bitmap.num_frames > 1) {
 		current_frame += frametime;
 
-		// Sanity checks
-		if (current_frame < 0.0f) {
-			current_frame = 0.0f;
-		} else if (current_frame > 100.0f) {
-			current_frame = 0.0f;
-		}
-
-		while (current_frame > wip->laser_bitmap.total_time) {
-			current_frame -= wip->laser_bitmap.total_time;
-		}
-
-		framenum = fl2i( (current_frame * wip->laser_bitmap.num_frames) / wip->laser_bitmap.total_time );
-
-		CLAMP(framenum, 0, wip->laser_bitmap.num_frames-1);
+		framenum = bm_get_anim_frame(wip->laser_bitmap.first_frame, current_frame, wip->laser_bitmap.total_time, true);
 	}
 
 	vec3d headp;

--- a/code/menuui/mainhallmenu.cpp
+++ b/code/menuui/mainhallmenu.cpp
@@ -692,6 +692,8 @@ void main_hall_do(float frametime)
 		for (int c_idx = 0; c_idx < (int) Main_hall->cheat.size(); c_idx++) {
 			cheat_anim_found = false;
 
+			// TODO change way cheat anims are loaded to work with apngs
+			// maybe load both cheat & normal, advance frames in lockstep, display which one you want
 			if(Main_hall_cheat.find(Main_hall->cheat.at(c_idx)) != SCP_string::npos) {
 				cheat_found = true;
 				// switch animations

--- a/code/missionui/missionweaponchoice.cpp
+++ b/code/missionui/missionweaponchoice.cpp
@@ -779,12 +779,12 @@ void wl_render_overhead_view(float frametime)
 				if (gr_screen.res == GR_640)
 				{
 					// lo-res
-					wl_ship->overhead_bitmap = bm_load_animation(sip->overhead_filename, NULL, NULL, 0, CF_TYPE_INTERFACE);
+					wl_ship->overhead_bitmap = bm_load_animation(sip->overhead_filename, nullptr, nullptr, nullptr, nullptr, false, CF_TYPE_INTERFACE);
 				} else {
 					// high-res
 					char filename[NAME_LENGTH+2] = "2_";
 					strcat_s(filename, sip->overhead_filename);
-					wl_ship->overhead_bitmap = bm_load_animation(sip->overhead_filename, NULL, NULL, 0, CF_TYPE_INTERFACE);
+					wl_ship->overhead_bitmap = bm_load_animation(sip->overhead_filename, nullptr, nullptr, nullptr, nullptr, false, CF_TYPE_INTERFACE);
 				}
 
 				// load the bitmap
@@ -1265,7 +1265,7 @@ void wl_load_icons(int weapon_class)
 
 	if(!Cmdline_weapon_choice_3d || (wip->render_type == WRT_LASER && !strlen(wip->tech_model)))
 	{
-		first_frame = bm_load_animation(Weapon_info[weapon_class].icon_filename, &num_frames, NULL, 0, CF_TYPE_INTERFACE);
+		first_frame = bm_load_animation(Weapon_info[weapon_class].icon_filename, &num_frames, nullptr, nullptr, nullptr, false, CF_TYPE_INTERFACE);
 
 		for ( i = 0; (i < num_frames) && (i < NUM_ICON_FRAMES); i++ ) {
 			icon->icon_bmaps[i] = first_frame+i;

--- a/code/model/modelinterp.cpp
+++ b/code/model/modelinterp.cpp
@@ -5288,7 +5288,7 @@ int texture_info::LoadTexture(char *filename, char *dbg_name = "<UNKNOWN>")
 		mprintf(("Generated texture name %s is too long. Skipping...\n", filename));
 		return -1;
 	}
-	this->original_texture = bm_load_either(filename, NULL, NULL, NULL, 1, CF_TYPE_MAPS);
+	this->original_texture = bm_load_either(filename, NULL, NULL, NULL, true, CF_TYPE_MAPS);
 	if(this->original_texture < 0)
 		nprintf(("Maps", "For \"%s\" I couldn't find %s.ani\n", dbg_name, filename));
 	this->ResetTexture();

--- a/code/model/modelinterp.cpp
+++ b/code/model/modelinterp.cpp
@@ -992,7 +992,7 @@ void model_interp_tmappoly(ubyte * p,polymodel * pm)
 						if ( !(Interp_flags & MR_NO_GLOWMAPS) && (tglow->GetTexture() >= 0) ) {
 							// shockwaves are special, their current frame has to come out of the shockwave code to get the timing correct
 							if ( (Interp_objnum >= 0) && (Objects[Interp_objnum].type == OBJ_SHOCKWAVE) && (tglow->GetNumFrames() > 1) ) {
-								GLOWMAP = tglow->GetTexture() + shockwave_get_framenum(Objects[Interp_objnum].instance, tglow->GetNumFrames());
+								GLOWMAP = tglow->GetTexture() + shockwave_get_framenum(Objects[Interp_objnum].instance, tglow->GetTexture());
 							} else {
 								GLOWMAP = model_interp_get_texture(tglow, Interp_base_frametime);
 							}
@@ -4966,7 +4966,7 @@ void model_render_buffers_DEPRECATED(polymodel *pm, int mn, int render, bool is_
 				} else if (tglow->GetTexture() >= 0) {
 					// shockwaves are special, their current frame has to come out of the shockwave code to get the timing correct
 					if ( (Interp_objnum >= 0) && (Objects[Interp_objnum].type == OBJ_SHOCKWAVE) && (tglow->GetNumFrames() > 1) ) {
-						GLOWMAP = tglow->GetTexture() + shockwave_get_framenum(Objects[Interp_objnum].instance, tglow->GetNumFrames());
+						GLOWMAP = tglow->GetTexture() + shockwave_get_framenum(Objects[Interp_objnum].instance, tglow->GetTexture());
 					} else {
 						GLOWMAP = model_interp_get_texture(tglow, Interp_base_frametime);
 					}

--- a/code/model/modelrender.cpp
+++ b/code/model/modelrender.cpp
@@ -1294,7 +1294,7 @@ void model_render_buffers(draw_list* scene, model_render_params* interp, vertex_
 				} else if (tglow->GetTexture() >= 0) {
 					// shockwaves are special, their current frame has to come out of the shockwave code to get the timing correct
 					if ( (obj_num >= 0) && (Objects[obj_num].type == OBJ_SHOCKWAVE) && (tglow->GetNumFrames() > 1) ) {
-						texture_maps[TM_GLOW_TYPE] = tglow->GetTexture() + shockwave_get_framenum(Objects[obj_num].instance, tglow->GetNumFrames());
+						texture_maps[TM_GLOW_TYPE] = tglow->GetTexture() + shockwave_get_framenum(Objects[obj_num].instance, tglow->GetTexture());
 					} else {
 						texture_maps[TM_GLOW_TYPE] = model_interp_get_texture(tglow, base_frametime);
 					}

--- a/code/nebula/neb.cpp
+++ b/code/nebula/neb.cpp
@@ -20,7 +20,6 @@
 #include "object/object.h"
 #include "parse/parselo.h"
 #include "pcxutils/pcxutils.h"
-#include "pngutils/pngutils.h"
 #include "render/3d.h"
 #include "ship/ship.h"
 #include "starfield/starfield.h"

--- a/code/parse/lua.cpp
+++ b/code/parse/lua.cpp
@@ -3367,6 +3367,21 @@ public:
 
 ade_obj<streaminganim_h> l_streaminganim("streaminganim", "Streaming Animation handle");
 
+ADE_FUNC(__gc, l_streaminganim, NULL, "Auto-deletes streaming animation", NULL, NULL)
+{
+	// NOTE: very similar to the l_streaminganim ADE_FUNC unload
+	streaminganim_h* sah;
+
+	if(!ade_get_args(L, "o", l_streaminganim.GetPtr(&sah)))
+		return ADE_RETURN_NIL;
+
+	// don't bother to check if valid before unloading
+	// generic_anim_unload has safety checks
+	generic_anim_unload(&sah->ga);
+
+	return ADE_RETURN_NIL;
+}
+
 ADE_VIRTVAR(Loop, l_streaminganim, "[boolean loop]", "Make the streaming animation loop.", "boolean", "Is the animation looping, or nil if anim invalid")
 {
 	streaminganim_h* sah;

--- a/code/parse/lua.cpp
+++ b/code/parse/lua.cpp
@@ -3544,7 +3544,7 @@ ADE_FUNC(getFrame, l_Texture, "number Elapsed time (secs), [boolean Loop]",
 		return ADE_RETURN_NIL;
 
 	frame = bm_get_anim_frame(idx, elapsed_time, 0.0f, loop);
-	frame++;  // C++ -> LUA
+	frame++;  // C++ to LUA array idx
 
 	return ade_set_args(L, "i", frame);
 }

--- a/code/parse/lua.cpp
+++ b/code/parse/lua.cpp
@@ -3526,6 +3526,33 @@ ADE_FUNC(getFramesLeft, l_Texture, NULL, "Gets number of frames left, from handl
 	return ade_set_args(L, "i", num);
 }
 
+ADE_FUNC(getFrame, l_Texture, "number Elapsed time (secs), [boolean Loop]",
+		 "Get the frame number from the elapsed time of the animation"
+		 "The 1st argument is the time that has elapsed since the animation started"
+		 "If 2nd argument is set to true, the animation is expected to loop when the elapsed time exceeds the duration of a single playback",
+		 "integer",
+		 "Frame number")
+{
+	int idx, frame = 0;
+	float elapsed_time;
+	bool loop = false;
+
+	if (!ade_get_args(L, "of|b", l_Texture.Get(&idx), &elapsed_time, &loop))
+		return ADE_RETURN_NIL;
+
+	if (!bm_is_valid(idx))
+		return ADE_RETURN_NIL;
+
+	bitmap_entry *be = &bm_bitmaps[idx];
+	if (be->info.ani.num_frames < 2)
+		return ADE_RETURN_NIL;
+
+	frame = bm_get_anim_frame(idx, elapsed_time, loop);
+	frame++;  // C++ -> LUA
+
+	return ade_set_args(L, "i", frame);
+}
+
 //**********OBJECT: vector
 //WMC - see matrix for ade_obj def
 

--- a/code/parse/lua.cpp
+++ b/code/parse/lua.cpp
@@ -14064,7 +14064,7 @@ ADE_FUNC(loadTexture, l_Graphics, "string Filename, [boolean LoadIfAnimation, bo
 		return ade_set_error(L, "o", l_Texture.Set(-1));
 
 	if(b == true) {
-		idx = bm_load_animation(s, nullptr, nullptr, nullptr, d ? 1 : 0);
+		idx = bm_load_animation(s, nullptr, nullptr, nullptr, nullptr, d);
 	}
 	if(idx < 0) {
 		idx = bm_load(s);

--- a/code/parse/lua.cpp
+++ b/code/parse/lua.cpp
@@ -12,6 +12,7 @@
 #include "globalincs/linklist.h"
 #include "graphics/2d.h"
 #include "graphics/font.h"
+#include "graphics/generic.h"
 #include "graphics/gropenglpostprocessing.h"
 #include "hud/hudbrackets.h"
 #include "hud/hudconfig.h"
@@ -3345,6 +3346,256 @@ ADE_FUNC(isValid, l_Team, NULL, "Detects whether handle is valid", "boolean", "t
 
 	if(idx < 0 || idx >= Num_iffs)
 		return ADE_RETURN_FALSE;
+
+	return ADE_RETURN_TRUE;
+}
+
+//**********HANDLE: streamingAnimation
+
+class streaminganim_h {
+public:
+	generic_anim ga;
+
+	bool IsValid() {
+		return (ga.num_frames > 0);
+	}
+	streaminganim_h (const char* filename)
+	{
+		generic_anim_init(&ga, filename);
+	}
+};
+
+ade_obj<streaminganim_h> l_streaminganim("streaminganim", "Streaming Animation handle");
+
+ADE_VIRTVAR(Loop, l_streaminganim, "[boolean loop]", "Make the streaming animation loop.", "boolean", "Is the animation looping, or nil if anim invalid")
+{
+	streaminganim_h* sah;
+	bool loop = false;
+
+	if(!ade_get_args(L, "o|b", l_streaminganim.GetPtr(&sah), &loop))
+		return ADE_RETURN_NIL;
+
+	if(!sah->IsValid())
+		return ADE_RETURN_NIL;
+
+	if (ADE_SETTING_VAR) {
+		if (loop == false)
+			sah->ga.direction |= GENERIC_ANIM_DIRECTION_NOLOOP;
+		else
+			sah->ga.direction &= ~GENERIC_ANIM_DIRECTION_NOLOOP;
+	}
+
+	return ((sah->ga.direction & GENERIC_ANIM_DIRECTION_NOLOOP) == false ? ADE_RETURN_TRUE : ADE_RETURN_FALSE);
+}
+
+ADE_VIRTVAR(Pause, l_streaminganim, "[boolean pause]", "Pause the streaming animation.", "boolean", "Is the animation paused, or nil if anim invalid")
+{
+	streaminganim_h* sah;
+	bool pause = false;
+
+	if(!ade_get_args(L, "o|b", l_streaminganim.GetPtr(&sah), &pause))
+		return ADE_RETURN_NIL;
+
+	if(!sah->IsValid())
+		return ADE_RETURN_NIL;
+
+	if (ADE_SETTING_VAR) {
+		if (pause == true)
+			sah->ga.direction |= GENERIC_ANIM_DIRECTION_PAUSED;
+		else
+			sah->ga.direction &= ~GENERIC_ANIM_DIRECTION_PAUSED;
+	}
+
+	return ((sah->ga.direction & GENERIC_ANIM_DIRECTION_PAUSED) ? ADE_RETURN_TRUE : ADE_RETURN_FALSE);
+}
+
+ADE_VIRTVAR(Reverse, l_streaminganim, "[boolean reverse]", "Make the streaming animation play in reverse.", "boolean", "Is the animation playing in reverse, or nil if anim invalid")
+{
+	streaminganim_h* sah;
+	bool reverse = false;
+
+	if(!ade_get_args(L, "o|b", l_streaminganim.GetPtr(&sah), &reverse))
+		return ADE_RETURN_NIL;
+
+	if(!sah->IsValid())
+		return ADE_RETURN_NIL;
+
+	if (ADE_SETTING_VAR) {
+		if (reverse == true)
+			sah->ga.direction |= GENERIC_ANIM_DIRECTION_BACKWARDS;
+		else
+			sah->ga.direction &= ~GENERIC_ANIM_DIRECTION_BACKWARDS;
+	}
+
+	return ((sah->ga.direction & GENERIC_ANIM_DIRECTION_BACKWARDS) ? ADE_RETURN_TRUE : ADE_RETURN_FALSE);
+}
+
+ADE_FUNC(getFilename, l_streaminganim, NULL, "Get the filename of the animation", "string", "Filename or nil if invalid")
+{
+	streaminganim_h* sah;
+
+	if (!ade_get_args(L, "o", l_streaminganim.GetPtr(&sah)))
+		return ADE_RETURN_NIL;
+
+	if(!sah->IsValid())
+		return ADE_RETURN_NIL;
+
+	return ade_set_args(L, "s", sah->ga.filename);
+}
+
+ADE_FUNC(getFrameCount, l_streaminganim, NULL, "Get the number of frames in the animation.", "integer", "Total number of frames")
+{
+	streaminganim_h* sah;
+
+	if (!ade_get_args(L, "o", l_streaminganim.GetPtr(&sah)))
+		return ADE_RETURN_NIL;
+
+	if(!sah->IsValid())
+		return ADE_RETURN_NIL;
+
+	return ade_set_args(L, "i", sah->ga.num_frames);
+}
+
+ADE_FUNC(getFrameIndex, l_streaminganim, NULL, "Get the current frame index of the animation", "integer", "Current frame index")
+{
+	streaminganim_h* sah;
+
+	if (!ade_get_args(L, "o", l_streaminganim.GetPtr(&sah)))
+		return ADE_RETURN_NIL;
+
+	if(!sah->IsValid())
+		return ADE_RETURN_NIL;
+
+	int cframe = sah->ga.current_frame;
+	if (cframe < 0 || cframe >= sah->ga.num_frames) {
+		return ADE_RETURN_NIL;
+	}
+
+	return ade_set_args(L, "i", ++cframe); // C++ to LUA array index
+}
+
+ADE_FUNC(getHeight, l_streaminganim, NULL, "Get the height of the animation in pixels", "integer", "Height or nil if invalid")
+{
+	streaminganim_h* sah;
+
+	if (!ade_get_args(L, "o", l_streaminganim.GetPtr(&sah)))
+		return ADE_RETURN_NIL;
+
+	if(!sah->IsValid())
+		return ADE_RETURN_NIL;
+
+	return ade_set_args(L, "i", sah->ga.height);
+}
+
+ADE_FUNC(getWidth, l_streaminganim, NULL, "Get the width of the animation in pixels", "integer", "Width or nil if invalid")
+{
+	streaminganim_h* sah;
+
+	if (!ade_get_args(L, "o", l_streaminganim.GetPtr(&sah)))
+		return ADE_RETURN_NIL;
+
+	if(!sah->IsValid())
+		return ADE_RETURN_NIL;
+
+	return ade_set_args(L, "i", sah->ga.width);
+}
+
+ADE_FUNC(isValid, l_streaminganim, NULL, "Detects whether handle is valid", "boolean", "true if valid, false if handle is invalid, nil if a syntax/type error occurs")
+{
+	streaminganim_h* sah;
+	if(!ade_get_args(L, "o", l_streaminganim.GetPtr(&sah)))
+		return ADE_RETURN_NIL;
+
+	return sah->IsValid();
+}
+
+ADE_FUNC(preload, l_streaminganim, NULL, "Load all apng animations into memory", "boolean", "true if preload was successful, nil if a syntax/type error occurs")
+{
+	streaminganim_h* sah;
+	if(!ade_get_args(L, "o", l_streaminganim.GetPtr(&sah)))
+		return ADE_RETURN_NIL;
+
+	if (sah->ga.type != BM_TYPE_PNG)
+		return ADE_RETURN_NIL;
+
+	sah->ga.png.anim->preload();
+
+	return ADE_RETURN_TRUE;
+}
+
+ADE_FUNC(process, l_streaminganim, "[int x1, int y1, int x2, int y2, float u0, float v0, float u1, float v1, float alpha, boolean draw]",
+		"Processes a streaming animation, including selecting the correct frame & drawing it.",
+		"boolean", "True if processing was successful, otherwise nil")
+{
+	streaminganim_h* sah;
+	generic_extras ge;
+	int x1 = 0, y1 = 0;
+	int x2 = INT_MAX, y2 = INT_MAX;
+
+	if(!ade_get_args(L, "o|iiiifffffb", l_streaminganim.GetPtr(&sah),
+				&x1, &y1, &x2, &y2,
+				&ge.u0, &ge.v0, &ge.u1, &ge.v1, &ge.alpha,
+				&ge.draw))
+		return ADE_RETURN_NIL;
+
+	if(!sah->IsValid())
+		return ADE_RETURN_NIL;
+
+	ge.width = sah->ga.width;
+	ge.height = sah->ga.height;
+	if (x2 != INT_MAX) ge.width = x2-x1;
+	if (y2 != INT_MAX) ge.height = y2-y1;
+
+	// note; generic_anim_render will default to GR_RESIZE_NONE when ge is provided
+	generic_anim_render(&sah->ga, flFrametime, x1, y1, false, &ge);
+
+	return ADE_RETURN_TRUE;
+}
+
+ADE_FUNC(reset, l_streaminganim, "[none]", "Reset a streaming animation back to its 1st frame", "boolean", "True if successful, otherwise nil")
+{
+	streaminganim_h* sah;
+
+	if(!ade_get_args(L, "o", l_streaminganim.GetPtr(&sah)))
+		return ADE_RETURN_NIL;
+
+	sah->ga.png.anim->goto_start();
+	sah->ga.current_frame = 0;
+	sah->ga.anim_time = 0.0f;
+	sah->ga.png.previous_frame_time = 0.0f;
+
+	return ADE_RETURN_TRUE;
+}
+
+ADE_FUNC(timeLeft, l_streaminganim, NULL, "Get the amount of time left in the animation, in seconds", "float", "Time left in secs or nil if invalid")
+{
+	streaminganim_h* sah;
+
+	if (!ade_get_args(L, "o", l_streaminganim.GetPtr(&sah)))
+		return ADE_RETURN_NIL;
+
+	if(!sah->IsValid())
+		return ADE_RETURN_NIL;
+
+	float timeLeft = 0.0f;
+	if ((sah->ga.direction & GENERIC_ANIM_DIRECTION_BACKWARDS) == true)
+		timeLeft = sah->ga.anim_time;
+	else
+		timeLeft = sah->ga.total_time - sah->ga.anim_time;
+
+	return ade_set_args(L, "f", timeLeft);
+}
+
+ADE_FUNC(unload, l_streaminganim, NULL, "Unloads a streaming animation from memory", NULL, NULL)
+{
+	streaminganim_h* sah;
+
+	if(!ade_get_args(L, "o", l_streaminganim.GetPtr(&sah)))
+		return ADE_RETURN_NIL;
+
+	// don't bother to check if valid before unloading
+	// generic_anim_unload has safety checks
+	generic_anim_unload(&sah->ga);
 
 	return ADE_RETURN_TRUE;
 }
@@ -14015,6 +14266,37 @@ ADE_FUNC(getStringWidth, l_Graphics, "string String", "Gets string width", "numb
 	gr_get_string_size(&w, NULL, s);
 	
 	return ade_set_args(L, "i", w);
+}
+
+ADE_FUNC(loadStreamingAnim, l_Graphics, "string Filename, [boolean loop, boolean reverse, boolean pause]",
+		 "Plays a streaming animation, returning its handle. The optional booleans can also be set via the handles virtvars<br>"
+		 "Remember to call the unload() function when you're finished using the animation to free up memory.",
+		 "streaminganim",
+		 "Streaming animation handle, or invalid handle if animation couldn't be loaded")
+{
+	char *s;
+	int rc = -1;
+	bool loop = false, reverse = false, pause = false;
+
+	if(!ade_get_args(L, "s|bbb", &s, &loop, &reverse, &pause))
+		return ADE_RETURN_NIL;
+
+	streaminganim_h sah(s);
+	if (loop == false) {
+		sah.ga.direction |= GENERIC_ANIM_DIRECTION_NOLOOP;
+	}
+	if (reverse == true) {
+		sah.ga.direction |= GENERIC_ANIM_DIRECTION_BACKWARDS;
+	}
+	if (pause == true) {
+		sah.ga.direction |= GENERIC_ANIM_DIRECTION_PAUSED;
+	}
+	rc = generic_anim_stream(&sah.ga);
+
+	if(rc < 0)
+		return ade_set_args(L, "o", l_streaminganim.Set(sah)); // this object should be "invalid", matches loadTexture behaviour
+
+	return ade_set_args(L, "o", l_streaminganim.Set(sah));
 }
 
 ADE_FUNC(createTexture, l_Graphics, "[number Width=512, number Height=512, enumeration Type=TEXTURE_DYNAMIC]",

--- a/code/parse/lua.cpp
+++ b/code/parse/lua.cpp
@@ -3543,11 +3543,7 @@ ADE_FUNC(getFrame, l_Texture, "number Elapsed time (secs), [boolean Loop]",
 	if (!bm_is_valid(idx))
 		return ADE_RETURN_NIL;
 
-	bitmap_entry *be = &bm_bitmaps[idx];
-	if (be->info.ani.num_frames < 2)
-		return ADE_RETURN_NIL;
-
-	frame = bm_get_anim_frame(idx, elapsed_time, loop);
+	frame = bm_get_anim_frame(idx, elapsed_time, 0.0f, loop);
 	frame++;  // C++ -> LUA
 
 	return ade_set_args(L, "i", frame);
@@ -14068,7 +14064,7 @@ ADE_FUNC(loadTexture, l_Graphics, "string Filename, [boolean LoadIfAnimation, bo
 		return ade_set_error(L, "o", l_Texture.Set(-1));
 
 	if(b == true) {
-		idx = bm_load_animation(s, NULL, NULL, NULL, d ? 1 : 0);
+		idx = bm_load_animation(s, nullptr, nullptr, nullptr, d ? 1 : 0);
 	}
 	if(idx < 0) {
 		idx = bm_load(s);

--- a/code/parse/lua.cpp
+++ b/code/parse/lua.cpp
@@ -14060,16 +14060,18 @@ ADE_FUNC(loadTexture, l_Graphics, "string Filename, [boolean LoadIfAnimation, bo
 		 "Texture handle, or invalid texture handle if texture couldn't be loaded")
 {
 	char *s;
-	int idx;
+	int idx=-1;
 	bool b=false;
 	bool d=false;
 
 	if(!ade_get_args(L, "s|bb", &s, &b, &d))
 		return ade_set_error(L, "o", l_Texture.Set(-1));
 
-	idx = bm_load(s);
-	if(idx < 0 && b) {
+	if(b == true) {
 		idx = bm_load_animation(s, NULL, NULL, NULL, d ? 1 : 0);
+	}
+	if(idx < 0) {
+		idx = bm_load(s);
 	}
 
 	if(idx < 0)

--- a/code/parse/lua.cpp
+++ b/code/parse/lua.cpp
@@ -3527,8 +3527,8 @@ ADE_FUNC(getFramesLeft, l_Texture, NULL, "Gets number of frames left, from handl
 }
 
 ADE_FUNC(getFrame, l_Texture, "number Elapsed time (secs), [boolean Loop]",
-		 "Get the frame number from the elapsed time of the animation"
-		 "The 1st argument is the time that has elapsed since the animation started"
+		 "Get the frame number from the elapsed time of the animation<br>"
+		 "The 1st argument is the time that has elapsed since the animation started<br>"
 		 "If 2nd argument is set to true, the animation is expected to loop when the elapsed time exceeds the duration of a single playback",
 		 "integer",
 		 "Frame number")

--- a/code/particle/particle.cpp
+++ b/code/particle/particle.cpp
@@ -346,7 +346,6 @@ static float get_current_alpha(vec3d *pos)
 void particle_render_all()
 {
 	ubyte flags;
-	float pct_complete;
 	float alpha;
 	vertex pos;
 	vec3d ts, te, temp;
@@ -413,14 +412,9 @@ void particle_render_all()
 				g3_transfer_vertex(&pos, &p_pos);
 		}
 
-		// pct complete for the particle
-		pct_complete = part->age / part->max_life;
-
 		// figure out which frame we should be using
 		if (part->nframes > 1) {
-			framenum = fl2i(pct_complete * part->nframes + 0.5);
-			CLAMP(framenum, 0, part->nframes-1);
-
+			framenum = bm_get_anim_frame(part->optional_data, part->age, part->max_life);
 			cur_frame = part->reverse ? (part->nframes - framenum - 1) : framenum;
 		} else {
 			cur_frame = 0;

--- a/code/particle/particle.cpp
+++ b/code/particle/particle.cpp
@@ -56,17 +56,17 @@ void particle_init()
 
 	// FIRE!!!
 	if ( Anim_bitmap_id_fire == -1 )	{
-		Anim_bitmap_id_fire = bm_load_animation( "particleexp01", &Anim_num_frames_fire, &fps, NULL, 0 );
+		Anim_bitmap_id_fire = bm_load_animation( "particleexp01", &Anim_num_frames_fire, &fps );
 	}
 
 	// Cough, cough
 	if ( Anim_bitmap_id_smoke == -1 )	{
-		Anim_bitmap_id_smoke = bm_load_animation( "particlesmoke01", &Anim_num_frames_smoke, &fps, NULL, 0 );
+		Anim_bitmap_id_smoke = bm_load_animation( "particlesmoke01", &Anim_num_frames_smoke, &fps );
 	}
 
 	// wheeze
 	if ( Anim_bitmap_id_smoke2 == -1 )	{
-		Anim_bitmap_id_smoke2 = bm_load_animation( "particlesmoke02", &Anim_num_frames_smoke2, &fps, NULL, 0 );
+		Anim_bitmap_id_smoke2 = bm_load_animation( "particlesmoke02", &Anim_num_frames_smoke2, &fps );
 	}
 
 	// grab a vertex buffer object

--- a/code/pngutils/pngutils.cpp
+++ b/code/pngutils/pngutils.cpp
@@ -683,6 +683,11 @@ int apng_ani::load_header()
 		_apng_failed("couldn't seek to 1st fcTL offset");
 	}
 
+	// sanity check
+	if (anim_time <= 0.0f) {
+		_apng_failed("animation duration <= 0.0f, bad data?");
+	}
+
 	return PNG_ERROR_NONE;
 }
 
@@ -696,7 +701,7 @@ void apng_ani::_apng_failed(const char* msg)
 	nframes = 0;
 	current_frame = 0;
 	plays = 0;
-	anim_time = 0.0;
+	anim_time = 0.0f;
 
 	SCP_string error_msg = "(file ";
 	error_msg += _filename;
@@ -707,6 +712,7 @@ void apng_ani::_apng_failed(const char* msg)
 
 /*
  * @brief ctor
+ *
  * @note loads apng header data
  */
 apng_ani::apng_ani(const char* filename)
@@ -716,7 +722,7 @@ apng_ani::apng_ani(const char* filename)
 	, nframes(0)
 	, current_frame(0)
 	, plays(0)
-	, anim_time(0.0)
+	, anim_time(0.0f)
 	, _filename(filename)
 	, _pngp(nullptr)
 	, _infop(nullptr)

--- a/code/pngutils/pngutils.cpp
+++ b/code/pngutils/pngutils.cpp
@@ -698,7 +698,7 @@ int apng_ani::load_header()
 void apng_ani::_cleanup_resources()
 {
 	png_destroy_read_struct(&_pngp, &_infop, nullptr);
-	cfclose(_cfp);
+	if (_cfp != nullptr) cfclose(_cfp);
 }
 
 /*

--- a/code/pngutils/pngutils.cpp
+++ b/code/pngutils/pngutils.cpp
@@ -246,12 +246,12 @@ int png_read_bitmap(const char *real_filename, ubyte *image_data, ubyte *bpp, in
 
 namespace apng {
 
-const int id_IHDR = 0x52444849; // PNG header
-const int id_acTL = 0x4C546361; // Animation control chunk
-const int id_fcTL = 0x4C546366; // Frame control chunk
-const int id_IDAT = 0x54414449; // first frame and/or default image
-const int id_fdAT = 0x54416466; // Frame data chunk
-const int id_IEND = 0x444E4549; // end/footer chunk
+const uint id_IHDR = 0x52444849; // PNG header
+const uint id_acTL = 0x4C546361; // Animation control chunk
+const uint id_fcTL = 0x4C546366; // Frame control chunk
+const uint id_IDAT = 0x54414449; // first frame and/or default image
+const uint id_fdAT = 0x54416466; // Frame data chunk
+const uint id_IEND = 0x444E4549; // end/footer chunk
 
 // Protect against large PNGs. See Mozilla's bug #251381 for more info.
 const unsigned long cMaxPNGSize = 1000000UL;

--- a/code/pngutils/pngutils.cpp
+++ b/code/pngutils/pngutils.cpp
@@ -465,7 +465,9 @@ void apng_ani::_process_chunk()
 		_dispose_op = _chunk.data[32];
 		_blend_op = _chunk.data[33];
 
-		//Warning(LOCATION, "dop: %u bop: %u", _dispose_op, _blend_op);
+		// TODO if the caller wants to know; warn if the delay is not the same for all frames
+		// e.g. for stuff which doesn't exactly play like an animation; like loading screens
+		// (and possibly other stuff I haven't checked out yet)
 
 		if (_reading &&
 				(_framew > cMaxPNGSize || _frameh > cMaxPNGSize
@@ -599,6 +601,15 @@ void apng_ani::next_frame()
 		frame = _frames.at(current_frame++);
 	}
 }
+
+/*
+ * @brief return image size in bytes
+ */
+size_t apng_ani::imgsize()
+{
+	return _image_size;
+}
+
 
 /*
  * @brief Get info about the apng

--- a/code/pngutils/pngutils.cpp
+++ b/code/pngutils/pngutils.cpp
@@ -456,7 +456,6 @@ void apng_ani::_process_chunk()
 		}
 
 		// handle frame finish in next_frame
-
 		_framew = png_get_uint_32(&_chunk.data[12]);
 		_frameh = png_get_uint_32(&_chunk.data[16]);
 		_x_offset = png_get_uint_32(&_chunk.data[20]);
@@ -472,6 +471,11 @@ void apng_ani::_process_chunk()
 				|| _x_offset + _framew > w || _y_offset + _frameh > h
 				|| _dispose_op > 2 || _blend_op > 1)) {
 			_apng_failed("invalid apng fcTL data");
+		}
+
+		// according to spec...
+		if (current_frame == 0 && _dispose_op == 2) {
+			_dispose_op = 1;
 		}
 
 		if (_delay_den == 0) _delay_den = 100; // APNG spec

--- a/code/pngutils/pngutils.cpp
+++ b/code/pngutils/pngutils.cpp
@@ -692,6 +692,16 @@ int apng_ani::load_header()
 }
 
 /*
+ * @brief cleanup resources
+ *
+ */
+void apng_ani::_cleanup_resources()
+{
+	png_destroy_read_struct(&_pngp, &_infop, nullptr);
+	cfclose(_cfp);
+}
+
+/*
  * @brief something went badly wrong, throw an exception
  *
  * @param [in] msg  text to display about the error
@@ -702,6 +712,7 @@ void apng_ani::_apng_failed(const char* msg)
 	current_frame = 0;
 	plays = 0;
 	anim_time = 0.0f;
+	_cleanup_resources();
 
 	SCP_string error_msg = "(file ";
 	error_msg += _filename;
@@ -749,8 +760,7 @@ apng_ani::apng_ani(const char* filename)
 
 apng_ani::~apng_ani()
 {
-	png_destroy_read_struct(&_pngp, &_infop, nullptr);
-	cfclose(_cfp);
+	_cleanup_resources();
 }
 
 } // end namespace apng

--- a/code/pngutils/pngutils.cpp
+++ b/code/pngutils/pngutils.cpp
@@ -6,12 +6,13 @@
 #include "globalincs/pstypes.h"
 #include "graphics/2d.h"
 #include "palman/palman.h"
-#include "png.h"
 #include "pngutils/pngutils.h"
 
 CFILE *png_file = NULL;
 
-//copy/pasted from libpng
+/*
+ * @brief copy/pasted from libpng
+ */
 void png_scp_read_data(png_structp png_ptr, png_bytep data, png_size_t length)
 {
 	png_size_t check;
@@ -26,15 +27,17 @@ void png_scp_read_data(png_structp png_ptr, png_bytep data, png_size_t length)
 		png_error(png_ptr, "Read Error");
 }
 
-// Reads header information from the PNG file into the bitmap pointer
-//
-// filename - name of the PNG bitmap file
-// w - (output) width of the bitmap
-// h - (output) height of the bitmap
-// bpp - (output) bits per pixel of the bitmap
-//
-// returns - PNG_ERROR_NONE if successful, otherwise error code
-//
+/*
+ * @brief Reads header information from the PNG file into the bitmap pointer
+ *
+ * @param [in]  filename  name of the PNG bitmap file
+ * @param [out] w         width of the bitmap
+ * @param [out] h         height of the bitmap
+ * @param [out] bpp       bits per pixel of the bitmap
+ * @param [out] palette
+ *
+ * @retval PNG_ERROR_NONE if successful, otherwise error code
+ */
 int png_read_header(const char *real_filename, CFILE *img_cfp, int *w, int *h, int *bpp, ubyte *palette)
 {
 	char filename[MAX_FILENAME_LEN];
@@ -43,8 +46,6 @@ int png_read_header(const char *real_filename, CFILE *img_cfp, int *w, int *h, i
 
 	png_file = NULL;
 
-	//mprintf(("png_read_header: %s\n", real_filename));
-
 	if (img_cfp == NULL) {
 		strcpy_s( filename, real_filename );
 
@@ -52,7 +53,6 @@ int png_read_header(const char *real_filename, CFILE *img_cfp, int *w, int *h, i
 
 		if ( p )
 			*p = 0;
-
 		strcat_s( filename, ".png" );
 
 		png_file = cfopen( filename , "rb" );
@@ -123,13 +123,17 @@ int png_read_header(const char *real_filename, CFILE *img_cfp, int *w, int *h, i
 	return PNG_ERROR_NONE;
 }
 
-// Loads a PNG image
-//
-// filename - name of the targa file to load
-// image_data - allocated storage for the bitmap
-//
-// returns - true if succesful, false otherwise
-//
+/*
+ * Loads a PNG image
+ *
+ * @param [in]  real_filename  name of the png file to load
+ * @param [out] image_data     allocated storage for the bitmap
+ * @param [in]  bpp
+ * @param [in]  dest_size
+ * @param [in]  cf_type
+ *
+ * @retval true if succesful, false otherwise
+ */
 int png_read_bitmap(const char *real_filename, ubyte *image_data, ubyte *bpp, int dest_size, int cf_type)
 {
 	char filename[MAX_FILENAME_LEN];
@@ -206,3 +210,530 @@ int png_read_bitmap(const char *real_filename, ubyte *image_data, ubyte *bpp, in
 
 	return PNG_ERROR_NONE;
 }
+
+/*
+ * APNG related code
+ * Refer https://wiki.mozilla.org/APNG_Specification
+ *
+ * Original Copyright (c) 2014 Max Stepin
+ * maxst at users.sourceforge.net
+ * http://sourceforge.net/projects/apng/files/libpng/examples/
+ * and
+ * https://github.com/apngasm/apngasm/commit/92e409b8b9182b4442b0d9ab6dac0ed90c4e3ffd
+ * with hints gleaned from
+ * https://bugs.webkit.org/attachment.cgi?id=248547&action=diff
+ *
+ * zlib license
+ * ------------
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty.  In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ */
+
+namespace apng {
+
+const int id_IHDR = 0x52444849; // PNG header
+const int id_acTL = 0x4C546361; // Animation control chunk
+const int id_fcTL = 0x4C546366; // Frame control chunk
+const int id_IDAT = 0x54414449; // first frame and/or default image
+const int id_fdAT = 0x54416466; // Frame data chunk
+const int id_IEND = 0x444E4549; // end/footer chunk
+
+// Protect against large PNGs. See Mozilla's bug #251381 for more info.
+const unsigned long cMaxPNGSize = 1000000UL;
+
+/*
+ * @brief test if character is a valid png chunk type character
+ * @note refer to http://www.w3.org/TR/PNG/#5Chunk-layout
+ */
+static inline bool not_chunk(ubyte c)
+{
+	return c < 65 || c > 122 || (c > 90 && c < 97);
+}
+
+/*
+ * @brief shim for libpng info/IHDR chunk callback
+ */
+static void info_callback(png_structp png_ptr, png_infop info_ptr)
+{
+	static_cast<apng_ani*>(png_get_progressive_ptr(png_ptr))->info_callback();
+}
+
+/*
+ * @brief shim for libpng row callback
+ */
+static void row_callback(png_structp png_ptr, png_bytep new_row, png_uint_32 row_num, int pass)
+{
+	static_cast<apng_ani*>(png_get_progressive_ptr(png_ptr))->row_callback(new_row, row_num);
+}
+
+/*
+ * @brief compose new frame from previous frame & currently-processing frames raw data
+ * @note assumes png data has 4 bytes
+ */
+void apng_ani::_compose_frame()
+{
+	int u, v, al;
+
+	// our libpng transformations should ensure 4 bytes per pixel by this point
+	Assertion(bpp == 32, "apng frame composition assumes 4 bytes of data per pixel, get a coder!");
+	for (uint j = 0; j < _frameh; j++) {
+		ubyte* sp = _frame_raw.rows[j];
+		ubyte* dp = frame.rows[j + _y_offset] + _x_offset * 4;
+
+		if (_blend_op == 0) {
+			// blend operation 0 (APNG_BLEND_OP_SOURCE) means ignore destination
+			memcpy(dp, sp, _framew * 4);
+		}
+		else {
+			for (uint i = 0; i < _framew; i++, sp += 4, dp += 4) {
+				if (sp[3] == 255) {
+					// if source is not transparent at all, just copy it
+					memcpy(dp, sp, 4);
+				}
+				else {
+					if (sp[3] != 0) {
+						if (dp[3] != 0) {
+							u = sp[3] * 255;
+							v = (255 - sp[3]) * dp[3];
+							al = u + v;
+							dp[0] = (sp[0] * u + dp[0] * v) / al;
+							dp[1] = (sp[1] * u + dp[1] * v) / al;
+							dp[2] = (sp[2] * u + dp[2] * v) / al;
+							dp[3] = al / 255;
+						}
+						else {
+							memcpy(dp, sp, 4);
+						}
+					}
+					// if source is transparent, ignore it
+				}
+			}
+		}
+	}
+}
+
+/*
+ * @brief start processing apng frame
+ * @note uses libpng calls, treats apng data as discrete png images
+ */
+int apng_ani::_processing_start()
+{
+	static ubyte png_sig[8] = {137, 80, 78, 71, 13, 10, 26, 10};
+
+	_pngp = png_create_read_struct(PNG_LIBPNG_VER_STRING, nullptr, nullptr, nullptr);
+	_infop = png_create_info_struct(_pngp);
+	if (_pngp == nullptr || _infop == nullptr) {
+		return 1;
+	}
+
+	if (setjmp(png_jmpbuf(_pngp))) {
+		png_destroy_read_struct(&_pngp, &_infop, 0);
+		return 1;
+	}
+
+	png_set_crc_action(_pngp, PNG_CRC_QUIET_USE, PNG_CRC_QUIET_USE);
+	png_set_progressive_read_fn(_pngp, this, apng::info_callback, apng::row_callback, nullptr);
+
+	png_process_data(_pngp, _infop, png_sig, 8);
+	memcpy(&_chunk_IHDR.data[8], &_chunk.data[12], 8); // use frame width & height from fcTL
+	png_process_data(_pngp, _infop, &_chunk_IHDR.data[0], _chunk_IHDR.size);
+
+	for (size_t i = 0; i < _info_chunks.size(); ++i) {
+		// this processes chunks like tRNS / PLTE / etc
+		png_process_data(_pngp, _infop, &_info_chunks.at(i).data[0], _info_chunks.at(i).size);
+	}
+
+	return 0;
+}
+
+/*
+ * @brief process apng data chunks
+ * @note uses libpng calls, treats apng data as discrete png images
+ */
+void apng_ani::_processing_data(ubyte* data, uint size)
+{
+	png_process_data(_pngp, _infop, data, size);
+}
+
+/*
+ * @brief finish processing apng frame
+ * @note uses libpng calls, treats apng data as discrete png images
+ */
+int apng_ani::_processing_finish()
+{
+	static ubyte end_sig[12] = {0, 0, 0, 0, 73, 69, 78, 68, 174, 66, 96, 130};
+
+	if (_pngp == nullptr || _infop == nullptr) {
+		return 1;
+	}
+
+	if (setjmp(png_jmpbuf(_pngp))) {
+		png_destroy_read_struct(&_pngp, &_infop, 0);
+		return 1;
+	}
+
+	png_process_data(_pngp, _infop, end_sig, 12);
+	png_destroy_read_struct(&_pngp, &_infop, 0);
+
+	return 0;
+}
+
+/*
+ * @brief process IHDR data
+ * @note not called until the IDAT chunk starts processing
+ */
+void apng_ani::info_callback()
+{
+	png_set_expand(_pngp);
+	png_set_strip_16(_pngp);
+	png_set_gray_to_rgb(_pngp); // what about 'non-colour' headanis?
+	png_set_add_alpha(_pngp, 0xff, PNG_FILLER_AFTER); // doesn't affect images that already have alpha channel
+	png_set_interlace_handling(_pngp);
+	png_set_bgr(_pngp);
+
+	png_read_update_info(_pngp, _infop);
+}
+
+/*
+ * @brief process each row of data provided by libpng
+ * @note callback from libpng
+ *
+ * @param [in] new_row  pointer to start of next row of data
+ * @param [in] row_num  number of row in image
+ */
+void apng_ani::row_callback(png_bytep new_row, png_uint_32 row_num)
+{
+	png_progressive_combine_row(_pngp, _frame_raw.rows.at(row_num), new_row);
+}
+
+
+/*
+ * @brief manually process a single chunk of apng data
+ */
+void apng_ani::_process_chunk()
+{
+	_id = _read_chunk(_chunk);
+
+	if (_id == id_acTL && !_got_IDAT && !_got_acTL) {
+		// animation control chunk
+		if (!_reading) {
+			return;
+		}
+		nframes = png_get_uint_32(&_chunk.data[8]);
+		plays = png_get_uint_32(&_chunk.data[12]);
+
+		if (!nframes || nframes > PNG_UINT_31_MAX || plays > PNG_UINT_31_MAX) {
+			_apng_failed("invalid apng acTL data");
+		}
+
+		_got_acTL = true;
+		_frames.reserve(nframes);
+		_frame_offsets.reserve(nframes+1); // extra 1 is for EOF offset
+	}
+	else if (_id == id_fcTL && (!_got_IDAT || _got_acTL)) {
+		// frame control chunk
+		if (_reading) {
+			uint sequence_num = png_get_uint_32(&_chunk.data[8]);
+			if (sequence_num != _sequence_num++) {
+				_apng_failed("invalid apng fcTL sequence number");
+			}
+		}
+
+		// handle frame finish in next_frame
+
+		_framew = png_get_uint_32(&_chunk.data[12]);
+		_frameh = png_get_uint_32(&_chunk.data[16]);
+		_x_offset = png_get_uint_32(&_chunk.data[20]);
+		_y_offset = png_get_uint_32(&_chunk.data[24]);
+		_delay_num = png_get_uint_16(&_chunk.data[28]);
+		_delay_den = png_get_uint_16(&_chunk.data[30]);
+		_dispose_op = _chunk.data[32];
+		_blend_op = _chunk.data[33];
+
+		//Warning(LOCATION, "dop: %u bop: %u", _dispose_op, _blend_op);
+
+		if (_reading &&
+				(_framew > cMaxPNGSize || _frameh > cMaxPNGSize
+				|| _x_offset > cMaxPNGSize || _y_offset > cMaxPNGSize
+				|| _x_offset + _framew > w || _y_offset + _frameh > h
+				|| _dispose_op > 2 || _blend_op > 1)) {
+			_apng_failed("invalid apng fcTL data");
+		}
+
+		if (_delay_den == 0) _delay_den = 100; // APNG spec
+		if (_delay_num == 0) _delay_num = 1;   // arbitrary lower bound
+		float frame_delay = static_cast<float>(_delay_num)/static_cast<float>(_delay_den);
+		frame.delay = frame_delay;
+
+		if (_reading) {
+			anim_time+= frame_delay;
+			_frame_offsets.push_back(_offset);
+		}
+		else {
+			if (_got_IDAT && _processing_start()) {
+				_apng_failed("couldn't start fdat apng frame");
+			}
+		}
+	}
+	else if (_id == id_IDAT) {
+		_got_IDAT = true;
+		_processing_data(&_chunk.data[0], _chunk.size);
+	}
+	else if (_id == id_fdAT && _got_acTL) {
+		if (_reading) {
+			uint sequence_num = png_get_uint_32(&_chunk.data[8]);
+			if (sequence_num != _sequence_num++) {
+				_apng_failed("invalid apng fdAT sequence number");
+			}
+		}
+
+		if (_reading) {
+			return;
+		}
+
+		png_save_uint_32(&_chunk.data[4], _chunk.size - 16);
+		memcpy(&_chunk.data[8], "IDAT", 4);
+		_processing_data(&_chunk.data[4], _chunk.size - 4);
+	}
+	else if (_id == id_IEND) {
+		return;
+	}
+	else if (not_chunk(_chunk.data[4]) || not_chunk(_chunk.data[5]) ||
+			not_chunk(_chunk.data[6]) || not_chunk(_chunk.data[7])) {
+		_apng_failed("unknown chunk ID found");
+	}
+	else if (!_got_IDAT) {
+		_processing_data(&_chunk.data[0], _chunk.size);
+		_info_chunks.push_back(_chunk);
+	}
+}
+
+unsigned int apng_ani::_read_chunk(_chunk_s& chunk)
+{
+	chunk.data.resize(4);
+	_offset = cftell(_cfp);
+	if (cfread(&chunk.data[0], 4, 1, _cfp) == 1) {
+		chunk.size = png_get_uint_32(&chunk.data[0]) + 12;
+		chunk.data.resize(chunk.size);
+		if (cfread(&chunk.data[4], chunk.size-4, 1, _cfp) == 1) {
+			return *(uint*)(&chunk.data[4]);
+		}
+	}
+	return 0;
+}
+
+/*
+ * @brief get previous apng frame
+ * @note due to apng format, this can only play backwards from the furthest forward frame reached
+ */
+void apng_ani::prev_frame()
+{
+	_reading = false;
+	if (current_frame > 0) {
+		frame = _frames.at(--current_frame);
+		nprintf(("apng", "apng prev_frame; (%03lu) (%03i)\n", _frames.size(), current_frame));
+	}
+}
+
+
+/*
+ * @brief get next apng frame
+ */
+void apng_ani::next_frame()
+{
+	_reading = false;
+	// setup new frame (if frame doesn't already exist)
+	if (_frames.size() <= (current_frame)) {
+		if (current_frame > 0) {
+			if (_dispose_op == 1) {
+				// clear to fully transparent black
+				frame.data.assign(_image_size, 0);
+			}
+			else if (_dispose_op == 2) {
+				// revert to previous
+				frame.data = _frame_next.data;
+			}
+			// default is to leave frame alone
+		}
+
+		while (cftell(_cfp) < _frame_offsets.at(current_frame+1)) {
+			_process_chunk();
+		}
+
+		nprintf(("apng", "apng next_frame; new (%03lu) (%03i) (%u) (%u) %03u|%03u %03u|%03u (%02lu) (%04f)\n",
+				_frames.size(), current_frame, _dispose_op, _blend_op,
+				_framew, _x_offset, _frameh, _y_offset,
+				_frame_offsets.size(), frame.delay));
+
+		if (_got_IDAT && _processing_finish()) {
+			_apng_failed("couldn't finish fdat apng frame");
+		}
+
+		if (_dispose_op == 2) {
+			 // revert to previous; so save for later
+			 _frame_next.data = frame.data;
+		}
+		_compose_frame();
+		_frames.push_back(frame);
+	}
+	else {
+		nprintf(("apng", "apng next_frame; used old (%03lu) (%03i)\n", _frames.size(), current_frame));
+	}
+
+	if (current_frame < nframes-1) {
+		frame = _frames.at(current_frame++);
+	}
+}
+
+/*
+ * @brief Get info about the apng
+ * @note Also validates the apng & sets it up to have frames read
+ *
+ * @retval PNG_ERROR_NONE (0), otherwise will raise exception
+ */
+int apng_ani::load_header()
+{
+	char filename[MAX_FILENAME_LEN];
+
+	strcpy_s(filename, _filename.c_str());
+	char *p = strchr( filename, '.' );
+	if ( p != nullptr ) *p = 0;
+	strcat_s( filename, ".png" );
+
+	_cfp = cfopen( filename , "rb" );
+
+	if ( _cfp == nullptr) {
+		_apng_failed("couldn't open filename");
+	}
+
+	_reading = true;
+
+	ubyte sig[8];
+	if (cfread(sig, 8, 1, _cfp) != 1)  {
+		_apng_failed("cfread of png signature failed");
+	}
+	if (png_sig_cmp(sig, 0, 8) != 0) {
+		_apng_failed("file has invalid png signature");
+	}
+
+	_id = _read_chunk(_chunk_IHDR);
+
+	if (_id != id_IHDR || _chunk_IHDR.size != 25) {
+		_apng_failed("failed to read IHDR chunk");
+	}
+
+	w = png_get_uint_32(&_chunk_IHDR.data[8]);
+	h = png_get_uint_32(&_chunk_IHDR.data[12]);
+	_row_len = w * 4;
+	bpp = 32;  // we'll force all our frames to use this
+
+	// setup frames & keep bm_create happy
+	_image_size = _row_len * h;
+	frame.data.reserve(_image_size); // alloc only once
+	frame.data.assign(_image_size, 0); // all transparent black per spec
+	frame.rows.resize(h);
+	_frame_raw.data.resize(_image_size);
+	_frame_raw.rows.resize(h);
+	_frame_next.data.resize(_image_size);
+	_frame_next.rows.resize(h);
+	for (uint i = 0; i < h; ++i) {
+		frame.rows.at(i) =       &frame.data.at(i * _row_len);
+		_frame_raw.rows.at(i) =  &_frame_raw.data.at(i * _row_len);
+		_frame_next.rows.at(i) = &_frame_next.data.at(i * _row_len);
+	}
+
+	// read all data
+	while (!cfeof(_cfp)) {
+		_process_chunk();
+	}
+
+	// should be at EOF; attach to _frame_offsets to make next_frame code simpler
+	Assertion(cfeof(_cfp) != 0, "apng not at EOF, get a coder!");
+	_frame_offsets.push_back(cftell(_cfp));
+
+	// reset _cfp so it can be used for next frame
+	_reading = false;
+	if (cfseek(_cfp, _frame_offsets.at(0), CF_SEEK_SET) != 0) {
+		_apng_failed("couldn't seek to 1st fcTL offset");
+	}
+
+	return PNG_ERROR_NONE;
+}
+
+/*
+ * @brief something went badly wrong, throw an exception
+ *
+ * @param [in] msg  text to display about the error
+ */
+void apng_ani::_apng_failed(const char* msg)
+{
+	nframes = 0;
+	current_frame = 0;
+	plays = 0;
+	anim_time = 0.0;
+
+	SCP_string error_msg = "(file ";
+	error_msg += _filename;
+	error_msg += ") ";
+	error_msg += msg;
+	throw ApngException(error_msg.c_str());
+}
+
+/*
+ * @brief ctor
+ * @note loads apng header data
+ */
+apng_ani::apng_ani(const char* filename)
+	: w(0)
+	, h(0)
+	, bpp(0)
+	, nframes(0)
+	, current_frame(0)
+	, plays(0)
+	, anim_time(0.0)
+	, _filename(filename)
+	, _pngp(nullptr)
+	, _infop(nullptr)
+	, _cfp(nullptr)
+	, _offset(0)
+	, _sequence_num(0)
+	, _id(0)
+	, _row_len(0)
+	, _image_size(0)
+	, _framew(0)
+	, _frameh(0)
+	, _x_offset(0)
+	, _y_offset(0)
+	, _delay_num(1)
+	, _delay_den(100)
+	, _dispose_op(0)
+	, _blend_op(0)
+	, _reading(true)
+	, _got_acTL(false)
+	, _got_IDAT(false)
+{
+	load_header();
+}
+
+apng_ani::~apng_ani()
+{
+	png_destroy_read_struct(&_pngp, &_infop, nullptr);
+	cfclose(_cfp);
+}
+
+} // end namespace apng

--- a/code/pngutils/pngutils.cpp
+++ b/code/pngutils/pngutils.cpp
@@ -465,10 +465,6 @@ void apng_ani::_process_chunk()
 		_dispose_op = _chunk.data[32];
 		_blend_op = _chunk.data[33];
 
-		// TODO if the caller wants to know; warn if the delay is not the same for all frames
-		// e.g. for stuff which doesn't exactly play like an animation; like loading screens
-		// (and possibly other stuff I haven't checked out yet)
-
 		if (_reading &&
 				(_framew > cMaxPNGSize || _frameh > cMaxPNGSize
 				|| _x_offset > cMaxPNGSize || _y_offset > cMaxPNGSize
@@ -677,15 +673,19 @@ int apng_ani::load_header()
 	Assertion(cfeof(_cfp) != 0, "apng not at EOF, get a coder!");
 	_frame_offsets.push_back(cftell(_cfp));
 
+	// sanity checks
+	if (anim_time <= 0.0f) {
+		_apng_failed("animation duration <= 0.0f, bad data?");
+	}
+
+	if (nframes < 1) {
+		_apng_failed("animation didn't have any frames, is this a static png?");
+	}
+
 	// reset _cfp so it can be used for next frame
 	_reading = false;
 	if (cfseek(_cfp, _frame_offsets.at(0), CF_SEEK_SET) != 0) {
 		_apng_failed("couldn't seek to 1st fcTL offset");
-	}
-
-	// sanity check
-	if (anim_time <= 0.0f) {
-		_apng_failed("animation duration <= 0.0f, bad data?");
 	}
 
 	return PNG_ERROR_NONE;

--- a/code/pngutils/pngutils.cpp
+++ b/code/pngutils/pngutils.cpp
@@ -544,6 +544,19 @@ unsigned int apng_ani::_read_chunk(_chunk_s& chunk)
 }
 
 /*
+ * @brief preload/cache the anim frames
+ * @note useful for preloading without having to load the apng into bmpman slots
+ */
+void apng_ani::preload()
+{
+	_reading = false;
+	while (current_frame < nframes) {
+		next_frame();
+	}
+	current_frame = 0;
+}
+
+/*
  * @brief get previous apng frame
  * @note due to apng format, this can only play backwards from the furthest forward frame reached
  */
@@ -621,6 +634,15 @@ void apng_ani::next_frame()
 size_t apng_ani::imgsize()
 {
 	return _image_size;
+}
+
+
+/*
+ * @brief send animation to its 1st frame
+ */
+void apng_ani::goto_start()
+{
+	current_frame = 0;
 }
 
 

--- a/code/pngutils/pngutils.h
+++ b/code/pngutils/pngutils.h
@@ -82,6 +82,7 @@ private:
 	int  _processing_finish();
 	void _apng_failed(const char* msg);
 	void _compose_frame();
+	void _cleanup_resources();
 };
 
 class ApngException : public std::runtime_error

--- a/code/pngutils/pngutils.h
+++ b/code/pngutils/pngutils.h
@@ -20,6 +20,11 @@ extern int png_read_bitmap(const char *real_filename, ubyte *image_data, ubyte *
 
 namespace apng {
 
+/*
+ * @brief read apngs and provide access to their frames
+ *
+ * @note would prefer to use C++11 "Non-static data member initializers" however MSVC 2013 is the 1st version that supports them and we currently need to support 2010
+ */
 class apng_ani {
 public:
 	struct apng_frame {

--- a/code/pngutils/pngutils.h
+++ b/code/pngutils/pngutils.h
@@ -71,6 +71,7 @@ private:
 	uint                    _row_len, _image_size;
 	uint                    _framew, _frameh;
 	uint                    _x_offset, _y_offset;
+	uint                    _max_chunk_size;
 	ushort                  _delay_num, _delay_den;
 	ubyte                   _dispose_op, _blend_op;
 	bool                    _reading, _got_acTL, _got_IDAT;

--- a/code/pngutils/pngutils.h
+++ b/code/pngutils/pngutils.h
@@ -46,8 +46,10 @@ public:
 	~apng_ani();
 
 	int    load_header();
+	void   goto_start();
 	void   next_frame();
 	void   prev_frame();
+	void   preload();
 	void   info_callback();
 	void   row_callback(png_bytep new_row, png_uint_32 row_num);
 	size_t imgsize();

--- a/code/pngutils/pngutils.h
+++ b/code/pngutils/pngutils.h
@@ -39,11 +39,13 @@ public:
 
 	apng_ani(const char* filename);
 	~apng_ani();
-	int  load_header();
-	void next_frame();
-	void prev_frame(); // TODO create this
-	void info_callback();
-	void row_callback(png_bytep new_row, png_uint_32 row_num);
+
+	int    load_header();
+	void   next_frame();
+	void   prev_frame();
+	void   info_callback();
+	void   row_callback(png_bytep new_row, png_uint_32 row_num);
+	size_t imgsize();
 
 private:
 	struct _chunk_s {

--- a/code/pngutils/pngutils.h
+++ b/code/pngutils/pngutils.h
@@ -1,8 +1,14 @@
 #ifndef _PNGUTILS_H
 #define _PNGUTILS_H
 
+// see comments in (1.2) pngconf.h on Linux
+// libpng wants to check that the version of setjmp it uses is the same as the
+// one that FSO uses; and it is
+#define PNG_SKIP_SETJMP_CHECK
+
 #include "cfile/cfile.h"
 #include "globalincs/pstypes.h"
+#include "png.h"
 
 #define PNG_ERROR_INVALID		-1
 #define PNG_ERROR_NONE 			0
@@ -11,5 +17,73 @@
 // reading
 extern int png_read_header(const char *real_filename, CFILE *img_cfp = NULL, int *w = 0, int *h = 0, int *bpp = 0, ubyte *palette = NULL);
 extern int png_read_bitmap(const char *real_filename, ubyte *image_data, ubyte *bpp, int dest_size, int cf_type = CF_TYPE_ANY);
+
+namespace apng {
+
+class apng_ani {
+public:
+	struct apng_frame {
+		SCP_vector<ubyte>  data;
+		SCP_vector<ubyte*> rows;
+		float              delay;
+	};
+
+	apng_frame frame;
+	uint       w;
+	uint       h;
+	uint       bpp;
+	uint       nframes;
+	uint       current_frame;
+	uint       plays;
+	float      anim_time;
+
+	apng_ani(const char* filename);
+	~apng_ani();
+	int  load_header();
+	void next_frame();
+	void prev_frame(); // TODO create this
+	void info_callback();
+	void row_callback(png_bytep new_row, png_uint_32 row_num);
+
+private:
+	struct _chunk_s {
+		uint              size;
+		SCP_vector<ubyte> data;
+	};
+	SCP_vector<apng_frame>  _frames;
+	SCP_vector<int>         _frame_offsets;
+	SCP_vector<_chunk_s>    _info_chunks;
+	SCP_string              _filename;
+	apng_frame              _frame_next, _frame_raw;
+	_chunk_s                _chunk_IHDR, _chunk;
+	png_structp             _pngp;
+	png_infop               _infop;
+	CFILE*                  _cfp;
+	size_t                  _offset;
+	uint                    _sequence_num, _id;
+	uint                    _row_len, _image_size;
+	uint                    _framew, _frameh;
+	uint                    _x_offset, _y_offset;
+	ushort                  _delay_num, _delay_den;
+	ubyte                   _dispose_op, _blend_op;
+	bool                    _reading, _got_acTL, _got_IDAT;
+
+	uint _read_chunk(_chunk_s& chunk);
+	void _process_chunk();
+	int  _processing_start();
+	void _processing_data(ubyte* data, uint size);
+	int  _processing_finish();
+	void _apng_failed(const char* msg);
+	void _compose_frame();
+};
+
+class ApngException : public std::runtime_error
+{
+	public:
+		ApngException(const std::string& msg) : std::runtime_error(msg) {}
+		~ApngException() throw() {}
+};
+
+}
 
 #endif // _PNGUTILS_H

--- a/code/ship/shield.cpp
+++ b/code/ship/shield.cpp
@@ -100,7 +100,7 @@ void load_shield_hit_bitmap()
     {
         if (Species_info[i].shield_anim.filename[0] != '\0')
         {
-		    Species_info[i].shield_anim.first_frame = bm_load_animation(Species_info[i].shield_anim.filename, &Species_info[i].shield_anim.num_frames, NULL, NULL, 1);
+		    Species_info[i].shield_anim.first_frame = bm_load_animation(Species_info[i].shield_anim.filename, &Species_info[i].shield_anim.num_frames, nullptr, nullptr, nullptr, true);
 			// TODO probable asset issue should be an Error, not an Assertion
 		    Assertion((Species_info[i].shield_anim.first_frame >= 0), "Error while loading shield hit ani: %s for species: %s\n", Species_info[i].shield_anim.filename, Species_info[i].species_name);
         }

--- a/code/ship/shield.cpp
+++ b/code/ship/shield.cpp
@@ -101,6 +101,7 @@ void load_shield_hit_bitmap()
         if (Species_info[i].shield_anim.filename[0] != '\0')
         {
 		    Species_info[i].shield_anim.first_frame = bm_load_animation(Species_info[i].shield_anim.filename, &Species_info[i].shield_anim.num_frames, NULL, NULL, 1);
+			// TODO probable asset issue should be an Error, not an Assertion
 		    Assertion((Species_info[i].shield_anim.first_frame >= 0), "Error while loading shield hit ani: %s for species: %s\n", Species_info[i].shield_anim.filename, Species_info[i].species_name);
         }
 	}
@@ -455,6 +456,8 @@ void render_shield(int shield_num)
 			frame_num = 0;
 		}
 		bitmap_id = sa->first_frame + frame_num;
+
+		mprintf(("render_shield frames: %02i of %02i (%f|%i)\n", frame_num, sa->num_frames, sa->total_time, Missiontime - Shield_hits[shield_num].start_time));
 
 		float alpha = 0.9999f;
 		if(The_mission.flags & MISSION_FLAG_FULLNEB){

--- a/code/ship/shield.cpp
+++ b/code/ship/shield.cpp
@@ -101,7 +101,6 @@ void load_shield_hit_bitmap()
         if (Species_info[i].shield_anim.filename[0] != '\0')
         {
 		    Species_info[i].shield_anim.first_frame = bm_load_animation(Species_info[i].shield_anim.filename, &Species_info[i].shield_anim.num_frames, nullptr, nullptr, nullptr, true);
-			// TODO probable asset issue should be an Error, not an Assertion
 		    Assertion((Species_info[i].shield_anim.first_frame >= 0), "Error while loading shield hit ani: %s for species: %s\n", Species_info[i].shield_anim.filename, Species_info[i].species_name);
         }
 	}

--- a/code/ship/shield.cpp
+++ b/code/ship/shield.cpp
@@ -448,16 +448,8 @@ void render_shield(int shield_num)
 	// don't try to draw if we don't have an ani
 	if ( sa->first_frame >= 0 )
 	{
-		frame_num = fl2i( f2fl(Missiontime - Shield_hits[shield_num].start_time) / f2fl(SHIELD_HIT_DURATION) * sa->num_frames );
-		if ( frame_num >= sa->num_frames )	{
-			frame_num = sa->num_frames - 1;
-		} else if ( frame_num < 0 )	{
-			mprintf(( "HEY! Missiontime went backwards! (Shield.cpp)\n" ));
-			frame_num = 0;
-		}
+		frame_num = bm_get_anim_frame(sa->first_frame, f2fl(Missiontime - Shield_hits[shield_num].start_time), f2fl(SHIELD_HIT_DURATION));
 		bitmap_id = sa->first_frame + frame_num;
-
-		mprintf(("render_shield frames: %02i of %02i (%f|%i)\n", frame_num, sa->num_frames, sa->total_time, Missiontime - Shield_hits[shield_num].start_time));
 
 		float alpha = 0.9999f;
 		if(The_mission.flags & MISSION_FLAG_FULLNEB){

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -6950,7 +6950,7 @@ void ship_render_DEPRECATED(object * obj)
 
 							int bmap_frame = mtp->tex_id;
 							if(mtp->tex_nframes > 0)
-								bmap_frame += (int)(((float)(timestamp() - shipp->thrusters_start[i]) / 1000.0f) * (float)mtp->tex_fps) % mtp->tex_nframes;
+								bmap_frame += bm_get_anim_frame(mtp->tex_id, i2fl(timestamp() - shipp->thrusters_start[i]) / 1000.0f, 0.0f, true);
 
 							man_thruster_renderer *mtr = man_thruster_get_slot(bmap_frame);
 							mtr->man_batcher.add_allocate(1);
@@ -18797,7 +18797,7 @@ void ship_render_batch_thrusters(object *obj)
 
 				int bmap_frame = mtp->tex_id;
 				if(mtp->tex_nframes > 0)
-					bmap_frame += (int)(((float)(timestamp() - shipp->thrusters_start[i]) / 1000.0f) * (float)mtp->tex_fps) % mtp->tex_nframes;
+					bmap_frame += bm_get_anim_frame(mtp->tex_id, i2fl(timestamp() - shipp->thrusters_start[i]) / 1000.0f, 0.0f, true);
 
 				man_thruster_renderer *mtr = man_thruster_get_slot(bmap_frame);
 				mtr->man_batcher.add_allocate(1);

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -8684,16 +8684,7 @@ void ship_do_weapon_thruster_frame( weapon *weaponp, object *objp, float frameti
 	if (flame_anim->first_frame >= 0) {
 		weaponp->thruster_frame += frametime * rate;
 
-		// Sanity checks
-		if ( weaponp->thruster_frame < 0.0f )	weaponp->thruster_frame = 0.0f;
-		if ( weaponp->thruster_frame > 100.0f ) weaponp->thruster_frame = 0.0f;
-
-		while ( weaponp->thruster_frame > flame_anim->total_time )	{
-			weaponp->thruster_frame -= flame_anim->total_time;
-		}
-		framenum = fl2i( (weaponp->thruster_frame*flame_anim->num_frames) / flame_anim->total_time );
-		if ( framenum < 0 ) framenum = 0;
-		if ( framenum >= flame_anim->num_frames ) framenum = flame_anim->num_frames-1;
+		framenum = bm_get_anim_frame(flame_anim->first_frame, weaponp->thruster_frame, flame_anim->total_time, true);
 	
 		// Get the bitmap for this frame
 		weaponp->thruster_bitmap = flame_anim->first_frame + framenum;
@@ -8706,16 +8697,7 @@ void ship_do_weapon_thruster_frame( weapon *weaponp, object *objp, float frameti
 	if (glow_anim->first_frame >= 0) {
 		weaponp->thruster_glow_frame += frametime * rate;
 
-		// Sanity checks
-		if ( weaponp->thruster_glow_frame < 0.0f )	weaponp->thruster_glow_frame = 0.0f;
-		if ( weaponp->thruster_glow_frame > 100.0f ) weaponp->thruster_glow_frame = 0.0f;
-
-		while ( weaponp->thruster_glow_frame > glow_anim->total_time )	{
-			weaponp->thruster_glow_frame -= glow_anim->total_time;
-		}
-		framenum = fl2i( (weaponp->thruster_glow_frame*glow_anim->num_frames) / glow_anim->total_time );
-		if ( framenum < 0 ) framenum = 0;
-		if ( framenum >= glow_anim->num_frames ) framenum = glow_anim->num_frames-1;
+		framenum = bm_get_anim_frame(glow_anim->first_frame, weaponp->thruster_glow_frame, glow_anim->total_time, true);
 	
 		// Get the bitmap for this frame
 		weaponp->thruster_glow_bitmap = glow_anim->first_frame;	// + framenum;

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -3817,7 +3817,7 @@ int parse_ship_values(ship_info* sip, const bool is_template, const bool first_t
 		{
 			stuff_string(name_tmp, F_NAME, sizeof(name_tmp));
 			int tex_fps=0, tex_nframes=0, tex_id=-1;;
-			tex_id = bm_load_animation(name_tmp, &tex_nframes, &tex_fps, NULL, 1);
+			tex_id = bm_load_animation(name_tmp, &tex_nframes, &tex_fps, nullptr, nullptr, true);
 			if(tex_id < 0)
 				tex_id = bm_load(name_tmp);
 			if(tex_id >= 0)

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -8611,19 +8611,7 @@ void ship_do_thruster_frame( ship *shipp, object *objp, float frametime )
 	if (flame_anim->first_frame >= 0) {
 		shipp->thruster_frame += frametime * rate;
 
-		// Sanity checks
-		if (shipp->thruster_frame < 0.0f) {
-			shipp->thruster_frame = 0.0f;
-		} else if (shipp->thruster_frame > 100.0f) {
-			shipp->thruster_frame = 0.0f;
-		}
-
-		while (shipp->thruster_frame > flame_anim->total_time) {
-			shipp->thruster_frame -= flame_anim->total_time;
-		}
-
-		framenum = fl2i( (shipp->thruster_frame * flame_anim->num_frames) / flame_anim->total_time );
-		CLAMP(framenum, 0, (flame_anim->num_frames - 1));
+		framenum = bm_get_anim_frame(flame_anim->first_frame, shipp->thruster_frame / flame_anim->total_time, true);
 
 		// Get the bitmap for this frame
 		shipp->thruster_bitmap = flame_anim->first_frame + framenum;
@@ -8636,19 +8624,7 @@ void ship_do_thruster_frame( ship *shipp, object *objp, float frametime )
 	if (glow_anim->first_frame >= 0) {
 		shipp->thruster_glow_frame += frametime * rate;
 
-		// Sanity checks
-		if (shipp->thruster_glow_frame < 0.0f) {
-			shipp->thruster_glow_frame = 0.0f;
-		} else if (shipp->thruster_glow_frame > 100.0f) {
-			shipp->thruster_glow_frame = 0.0f;
-		}
-
-		while (shipp->thruster_glow_frame > glow_anim->total_time) {
-			shipp->thruster_glow_frame -= glow_anim->total_time;
-		}
-
-		framenum = fl2i( (shipp->thruster_glow_frame*glow_anim->num_frames) / glow_anim->total_time );
-		CLAMP(framenum, 0, (glow_anim->num_frames - 1));
+		framenum = bm_get_anim_frame(glow_anim->first_frame, shipp->thruster_glow_frame / glow_anim->total_time);
 
 		// Get the bitmap for this frame
 		shipp->thruster_glow_bitmap = glow_anim->first_frame;	// + framenum;

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -8611,7 +8611,7 @@ void ship_do_thruster_frame( ship *shipp, object *objp, float frametime )
 	if (flame_anim->first_frame >= 0) {
 		shipp->thruster_frame += frametime * rate;
 
-		framenum = bm_get_anim_frame(flame_anim->first_frame, shipp->thruster_frame / flame_anim->total_time, true);
+		framenum = bm_get_anim_frame(flame_anim->first_frame, shipp->thruster_frame, flame_anim->total_time, true);
 
 		// Get the bitmap for this frame
 		shipp->thruster_bitmap = flame_anim->first_frame + framenum;
@@ -8624,7 +8624,7 @@ void ship_do_thruster_frame( ship *shipp, object *objp, float frametime )
 	if (glow_anim->first_frame >= 0) {
 		shipp->thruster_glow_frame += frametime * rate;
 
-		framenum = bm_get_anim_frame(glow_anim->first_frame, shipp->thruster_glow_frame / glow_anim->total_time);
+		framenum = bm_get_anim_frame(glow_anim->first_frame, shipp->thruster_glow_frame, glow_anim->total_time, true);
 
 		// Get the bitmap for this frame
 		shipp->thruster_glow_bitmap = glow_anim->first_frame;	// + framenum;

--- a/code/ship/shipfx.cpp
+++ b/code/ship/shipfx.cpp
@@ -3834,7 +3834,7 @@ WE_BSG::WE_BSG(object *n_objp, int n_direction)
 	if(strlen(tmp_name))
 	{
 		//Load anim
-		anim = bm_load_either(tmp_name, &anim_nframes, &anim_fps, NULL, 1);
+		anim = bm_load_either(tmp_name, &anim_nframes, &anim_fps, NULL, true);
 		if(anim > -1)
 		{
 			anim_total_time = fl2i(((float)anim_nframes / (float)anim_fps) * 1000.0f);
@@ -3844,7 +3844,7 @@ WE_BSG::WE_BSG(object *n_objp, int n_direction)
 		strncat(tmp_name, "-shockwave", MAX_FILENAME_LEN-1);
 
 		//Load shockwave
-		shockwave = bm_load_either(tmp_name, &shockwave_nframes, &shockwave_fps, NULL, 1);
+		shockwave = bm_load_either(tmp_name, &shockwave_nframes, &shockwave_fps, NULL, true);
 		if(shockwave > -1)
 		{
 			shockwave_total_time = fl2i(((float)shockwave_nframes / (float)shockwave_fps) * 1000.0f);
@@ -4210,9 +4210,9 @@ WE_Homeworld::WE_Homeworld(object *n_objp, int n_direction)
 
 	//Anim
 	if(direction == WD_WARP_IN)
-		anim = bm_load_either(sip->warpin_anim, &anim_nframes, &anim_fps, NULL, 1);
+		anim = bm_load_either(sip->warpin_anim, &anim_nframes, &anim_fps, NULL, true);
 	else if(direction == WD_WARP_OUT)
-		anim = bm_load_either(sip->warpout_anim, &anim_nframes, &anim_fps, NULL, 1);
+		anim = bm_load_either(sip->warpout_anim, &anim_nframes, &anim_fps, NULL, true);
 	else
 		anim = -1;
 

--- a/code/starfield/starfield.cpp
+++ b/code/starfield/starfield.cpp
@@ -200,7 +200,7 @@ void stars_load_debris_vclips(debris_vclip *vclips)
 	}
 
 	for (i = 0; i < MAX_DEBRIS_VCLIPS; i++) {
-		vclips[i].bm = bm_load_animation( vclips[i].name, &vclips[i].nframes, NULL, NULL, 1 );
+		vclips[i].bm = bm_load_animation( vclips[i].name, &vclips[i].nframes, nullptr, nullptr, nullptr, true );
 
 		if ( vclips[i].bm < 0 ) {
 			// try loading it as a single bitmap
@@ -614,7 +614,7 @@ void stars_load_all_bitmaps()
 
 			// maybe didn't load a static image so try for an animated one
 			if (sb->bitmap_id < 0) {
-				sb->bitmap_id = bm_load_animation(sb->filename, &sb->n_frames, &sb->fps, NULL, 1);
+				sb->bitmap_id = bm_load_animation(sb->filename, &sb->n_frames, &sb->fps, nullptr, nullptr, true);
 
 				if (sb->bitmap_id < 0) {
 					mprintf(("Unable to load starfield bitmap: '%s'!\n", sb->filename));
@@ -636,7 +636,7 @@ void stars_load_all_bitmaps()
 
 			// maybe didn't load a static image so try for an animated one
 			if (sb->bitmap_id < 0) {
-				sb->bitmap_id = bm_load_animation(sb->filename, &sb->n_frames, &sb->fps, NULL, 1);
+				sb->bitmap_id = bm_load_animation(sb->filename, &sb->n_frames, &sb->fps, nullptr, nullptr, true);
 
 				if (sb->bitmap_id < 0) {
 					Warning(LOCATION, "Unable to load sun bitmap: '%s'!\n", sb->filename);
@@ -650,7 +650,7 @@ void stars_load_all_bitmaps()
 
 			// maybe didn't load a static image so try for an animated one
 			if (sb->glow_bitmap < 0) {
-				sb->glow_bitmap = bm_load_animation(sb->glow_filename, &sb->glow_n_frames, &sb->glow_fps, NULL, 1);
+				sb->glow_bitmap = bm_load_animation(sb->glow_filename, &sb->glow_n_frames, &sb->glow_fps, nullptr, nullptr, true);
 
 				if (sb->glow_bitmap < 0) {
 					Warning(LOCATION, "Unable to load sun glow bitmap: '%s'!\n", sb->glow_filename);
@@ -1962,7 +1962,7 @@ void stars_page_in()
 
 				// maybe didn't load a static image so try for an animated one
 				if (sb->bitmap_id < 0) {
-					sb->bitmap_id = bm_load_animation(sb->filename, &sb->n_frames, &sb->fps, NULL, 1);
+					sb->bitmap_id = bm_load_animation(sb->filename, &sb->n_frames, &sb->fps, nullptr, nullptr, true);
 
 					if (sb->bitmap_id < 0) {
 						Warning(LOCATION, "Unable to load starfield bitmap: '%s'!\n", sb->filename);
@@ -1994,7 +1994,7 @@ void stars_page_in()
 
 				// maybe didn't load a static image so try for an animated one
 				if (sb->bitmap_id < 0) {
-					sb->bitmap_id = bm_load_animation(sb->filename, &sb->n_frames, &sb->fps, NULL, 1);
+					sb->bitmap_id = bm_load_animation(sb->filename, &sb->n_frames, &sb->fps, nullptr, nullptr, true);
 
 					if (sb->bitmap_id < 0) {
 						Warning(LOCATION, "Unable to load sun bitmap: '%s'!\n", sb->filename);
@@ -2008,7 +2008,7 @@ void stars_page_in()
 
 				// maybe didn't load a static image so try for an animated one
 				if (sb->glow_bitmap < 0) {
-					sb->glow_bitmap = bm_load_animation(sb->glow_filename, &sb->glow_n_frames, &sb->glow_fps, NULL, 1);
+					sb->glow_bitmap = bm_load_animation(sb->glow_filename, &sb->glow_n_frames, &sb->glow_fps, nullptr, nullptr, true);
 
 					if (sb->glow_bitmap < 0) {
 						Warning(LOCATION, "Unable to load sun glow bitmap: '%s'!\n", sb->glow_filename);
@@ -2058,7 +2058,7 @@ void stars_page_in()
 
 			// maybe didn't load a static image so try for an animated one
 			if (sb->bitmap_id < 0) {
-				sb->bitmap_id = bm_load_animation(sb->filename, &sb->n_frames, &sb->fps, NULL, 1);
+				sb->bitmap_id = bm_load_animation(sb->filename, &sb->n_frames, &sb->fps, nullptr, nullptr, true);
 
 				if (sb->bitmap_id < 0) {
 					Warning(LOCATION, "Unable to load starfield bitmap: '%s'!\n", sb->filename);
@@ -2094,7 +2094,7 @@ void stars_page_in()
 
 			// maybe didn't load a static image so try for an animated one
 			if (sb->bitmap_id < 0) {
-				sb->bitmap_id = bm_load_animation(sb->filename, &sb->n_frames, &sb->fps, NULL, 1);
+				sb->bitmap_id = bm_load_animation(sb->filename, &sb->n_frames, &sb->fps, nullptr, nullptr, true);
 
 				if (sb->bitmap_id < 0) {
 					Warning(LOCATION, "Unable to load sun bitmap: '%s'!\n", sb->filename);
@@ -2108,7 +2108,7 @@ void stars_page_in()
 
 			// maybe didn't load a static image so try for an animated one
 			if (sb->glow_bitmap < 0) {
-				sb->glow_bitmap = bm_load_animation(sb->glow_filename, &sb->glow_n_frames, &sb->glow_fps, NULL, 1);
+				sb->glow_bitmap = bm_load_animation(sb->glow_filename, &sb->glow_n_frames, &sb->glow_fps, nullptr, nullptr, true);
 
 				if (sb->glow_bitmap < 0) {
 					Warning(LOCATION, "Unable to load sun glow bitmap: '%s'!\n", sb->glow_filename);
@@ -2285,7 +2285,7 @@ int stars_add_sun_entry(starfield_list_entry *sun_ptr)
 
 			// maybe didn't load a static image so try for an animated one
 		if (Sun_bitmaps[idx].bitmap_id < 0) {
-			Sun_bitmaps[idx].bitmap_id = bm_load_animation(Sun_bitmaps[idx].filename, &Sun_bitmaps[idx].n_frames, &Sun_bitmaps[idx].fps, NULL, 1);
+			Sun_bitmaps[idx].bitmap_id = bm_load_animation(Sun_bitmaps[idx].filename, &Sun_bitmaps[idx].n_frames, &Sun_bitmaps[idx].fps, nullptr, nullptr, true);
 
 			if (Sun_bitmaps[idx].bitmap_id < 0) {
 				// failed
@@ -2299,7 +2299,7 @@ int stars_add_sun_entry(starfield_list_entry *sun_ptr)
 
 			// maybe didn't load a static image so try for an animated one
 			if (Sun_bitmaps[idx].glow_bitmap < 0) {
-				Sun_bitmaps[idx].glow_bitmap = bm_load_animation(Sun_bitmaps[idx].glow_filename, &Sun_bitmaps[idx].glow_n_frames, &Sun_bitmaps[idx].glow_fps, NULL, 1);
+				Sun_bitmaps[idx].glow_bitmap = bm_load_animation(Sun_bitmaps[idx].glow_filename, &Sun_bitmaps[idx].glow_n_frames, &Sun_bitmaps[idx].glow_fps, nullptr, nullptr, true);
 
 				if (Sun_bitmaps[idx].glow_bitmap < 0) {
 					Warning(LOCATION, "Unable to load sun glow bitmap: '%s'!\n", Sun_bitmaps[idx].glow_filename);
@@ -2375,7 +2375,7 @@ int stars_add_bitmap_entry(starfield_list_entry *sle)
 
 		// maybe didn't load a static image so try for an animated one
 		if (Starfield_bitmaps[idx].bitmap_id < 0) {
-			Starfield_bitmaps[idx].bitmap_id = bm_load_animation(Starfield_bitmaps[idx].filename, &Starfield_bitmaps[idx].n_frames, &Starfield_bitmaps[idx].fps, NULL, 1);
+			Starfield_bitmaps[idx].bitmap_id = bm_load_animation(Starfield_bitmaps[idx].filename, &Starfield_bitmaps[idx].n_frames, &Starfield_bitmaps[idx].fps, nullptr, nullptr, true);
 
 			if (Starfield_bitmaps[idx].bitmap_id < 0) {
 				// failed

--- a/code/ui/inputbox.cpp
+++ b/code/ui/inputbox.cpp
@@ -270,16 +270,9 @@ void UI_INPUTBOX::draw()
 				ui_vline(1, h1, text_x + tw + 5);
 			} else {
 				// draw animating cursor
-				int time_delta = timer_get_milliseconds() - cursor_elapsed_time;
-
-				if ( (time_delta / 1000.0f) > (1.0f / cursor_fps) ) {
-					// advance frame
-					cursor_elapsed_time += time_delta;
-					cursor_current_frame++;
-					if (cursor_current_frame >= cursor_nframes) {
-						cursor_current_frame = 0;
-					}
-				}
+				// new method is simpler and should give the same results unless the target device is super slow
+				// i.e. can't render an interface frame in less than the anim frame delays (retail 15 fps == 66.67 msec)
+				cursor_current_frame = bm_get_anim_frame(cursor_first_frame, i2fl(timer_get_milliseconds()) / 1000.0f, 0.0f, true);
 
 				// draw current frame
 				gr_set_bitmap(cursor_first_frame + cursor_current_frame);

--- a/code/weapon/beam.cpp
+++ b/code/weapon/beam.cpp
@@ -1249,18 +1249,7 @@ void beam_render(beam *b, float u_offset)
 		if (bwsi->texture.num_frames > 1) {
 			b->beam_section_frame[s_idx] += flFrametime;
 
-			// Sanity checks
-			if (b->beam_section_frame[s_idx] < 0.0f)
-				b->beam_section_frame[s_idx] = 0.0f;
-			if (b->beam_section_frame[s_idx] > 100.0f)
-				b->beam_section_frame[s_idx] = 0.0f;
-
-			while (b->beam_section_frame[s_idx] > bwsi->texture.total_time)
-				b->beam_section_frame[s_idx] -= bwsi->texture.total_time;
-
-			framenum = fl2i( (b->beam_section_frame[s_idx] * bwsi->texture.num_frames) / bwsi->texture.total_time );
-
-			CLAMP(framenum, 0, bwsi->texture.num_frames-1);
+			framenum = bm_get_anim_frame(bwsi->texture.first_frame, b->beam_section_frame[s_idx], bwsi->texture.total_time, true);
 		}
 
 		gr_set_bitmap(bwsi->texture.first_frame + framenum, GR_ALPHABLEND_FILTER, GR_BITBLT_MODE_NORMAL, 0.9999f);
@@ -1488,18 +1477,7 @@ void beam_render_muzzle_glow(beam *b)
 		if (bwi->beam_glow.num_frames > 1) {
 			b->beam_glow_frame += flFrametime;
 
-			// Sanity checks
-			if (b->beam_glow_frame < 0.0f)
-				b->beam_glow_frame = 0.0f;
-			else if (b->beam_glow_frame > 100.0f)
-				b->beam_glow_frame = 0.0f;
-
-			while (b->beam_glow_frame > bwi->beam_glow.total_time)
-				b->beam_glow_frame -= bwi->beam_glow.total_time;
-
-			framenum = fl2i((b->beam_glow_frame * bwi->beam_glow.num_frames) / bwi->beam_glow.total_time);
-
-			CLAMP(framenum, 0, bwi->beam_glow.num_frames - 1);
+			framenum = bm_get_anim_frame(bwi->beam_glow.first_frame, b->beam_glow_frame, bwi->beam_glow.total_time, true);
 		}
 
 		gr_set_bitmap(bwi->beam_glow.first_frame + framenum, GR_ALPHABLEND_FILTER, GR_BITBLT_MODE_NORMAL, alpha * pct);
@@ -1523,18 +1501,7 @@ void beam_render_muzzle_glow(beam *b)
 		if (bwi->beam_glow.num_frames > 1) {
 			b->beam_glow_frame += flFrametime;
 
-			// Sanity checks
-			if (b->beam_glow_frame < 0.0f)
-				b->beam_glow_frame = 0.0f;
-			else if (b->beam_glow_frame > 100.0f)
-				b->beam_glow_frame = 0.0f;
-
-			while (b->beam_glow_frame > bwi->beam_glow.total_time)
-				b->beam_glow_frame -= bwi->beam_glow.total_time;
-
-			framenum = fl2i((b->beam_glow_frame * bwi->beam_glow.num_frames) / bwi->beam_glow.total_time);
-
-			CLAMP(framenum, 0, bwi->beam_glow.num_frames - 1);
+			framenum = bm_get_anim_frame(bwi->beam_glow.first_frame, b->beam_glow_frame, bwi->beam_glow.total_time, true);
 		}
 
 		gr_set_bitmap(bwi->beam_glow.first_frame + framenum, GR_ALPHABLEND_FILTER, GR_BITBLT_MODE_NORMAL, alpha * pct);

--- a/code/weapon/muzzleflash.cpp
+++ b/code/weapon/muzzleflash.cpp
@@ -189,7 +189,7 @@ void mflash_page_in(bool load_all)
 		int original_idx = 1;
 		for ( idx = 0; idx < Mflash_info[i].blobs.size(); ) {
 			mflash_blob_info* mfbip = &Mflash_info[i].blobs[idx];
-			mfbip->anim_id = bm_load_either(mfbip->name, &num_frames, &fps, NULL, 1);
+			mfbip->anim_id = bm_load_either(mfbip->name, &num_frames, &fps, NULL, true);
 			if ( mfbip->anim_id >= 0 ) {
 				bm_page_in_xparent_texture( mfbip->anim_id );
 				++idx;

--- a/code/weapon/shockwave.cpp
+++ b/code/weapon/shockwave.cpp
@@ -554,7 +554,7 @@ int shockwave_load(char *s_name, bool shock_3D)
 			return -1;
 		}
 	} else {
-		si->bitmap_id = bm_load_animation( si->filename, &si->num_frames, &si->fps, NULL, 1 );
+		si->bitmap_id = bm_load_animation( si->filename, &si->num_frames, &si->fps, nullptr, nullptr, true );
 
 		if ( si->bitmap_id < 0 ) {
 			Shockwave_info.pop_back();

--- a/code/weapon/shockwave.cpp
+++ b/code/weapon/shockwave.cpp
@@ -203,7 +203,7 @@ void shockwave_set_framenum(int index)
 }
 
 /**
- * Given a shockwave index and the animation id/handle return what the current frame # should be
+ * Given a shockwave index and the animation id/handle return what the current frame num should be
  *
  * @note for direct use with 3d shockwaves & indirect use with 2d shockwaves
  */

--- a/code/weapon/shockwave.cpp
+++ b/code/weapon/shockwave.cpp
@@ -199,38 +199,27 @@ void shockwave_set_framenum(int index)
 	if (si->bitmap_id < 0)
 		return;
 
-	sw->current_bitmap = si->bitmap_id + shockwave_get_framenum(index, si->num_frames);
+	sw->current_bitmap = si->bitmap_id + shockwave_get_framenum(index, si->bitmap_id);
 }
 
 /**
- * Given a shockwave index and the number of frames in an animation return what
- * the current frame # should be  (for use with 3d shockwaves)
+ * Given a shockwave index and the animation id/handle return what the current frame # should be
+ *
+ * @note for direct use with 3d shockwaves & indirect use with 2d shockwaves
  */
-int shockwave_get_framenum(int index, int num_frames)
+int shockwave_get_framenum(const int sw_idx, const int ani_id)
 {
-	int				framenum;
 	shockwave		*sw;
 
-	if ( (index < 0) || (index >= MAX_SHOCKWAVES) ) {
+	if ( (sw_idx < 0) || (sw_idx >= MAX_SHOCKWAVES) ) {
 		Int3();
 		return 0;
 	}
 
-	sw = &Shockwaves[index];
+	sw = &Shockwaves[sw_idx];
 
-	framenum = fl2i(sw->time_elapsed / sw->total_time * num_frames + 0.5);
-
-	// ensure we don't go past the number of frames of animation
-	if ( framenum > (num_frames-1) ) {
-		framenum = (num_frames-1);
-		Objects[sw->objnum].flags |= OF_SHOULD_BE_DEAD;
-	}
-
-	if ( framenum < 0 ) {
-		framenum = 0;
-	}
-
-	return framenum;
+	// ignore setting of OF_SHOULD_BE_DEAD, handled by shockwave_move
+	return bm_get_anim_frame(ani_id, sw->time_elapsed, sw->total_time);
 }
 
 /**
@@ -411,7 +400,7 @@ void shockwave_render_DEPRECATED(object *objp)
 			g3_transfer_vertex(&p, &sw->pos);
 				
 			distortion_add_bitmap_rotated(
-				Shockwave_info[1].bitmap_id+shockwave_get_framenum(objp->instance, 94), 
+				Shockwave_info[1].bitmap_id+shockwave_get_framenum(objp->instance, Shockwave_info[1].bitmap_id),
 				TMAP_FLAG_TEXTURED | TMAP_HTL_3D_UNLIT | TMAP_FLAG_SOFT_QUAD | TMAP_FLAG_DISTORTION, 
 				&p, 
 				fl_radians(sw->rot_angles.p), 
@@ -483,7 +472,7 @@ void shockwave_render(object *objp, draw_list *scene)
 			g3_transfer_vertex(&p, &sw->pos);
 
 			distortion_add_bitmap_rotated(
-				Shockwave_info[1].bitmap_id+shockwave_get_framenum(objp->instance, 94), 
+				Shockwave_info[1].bitmap_id+shockwave_get_framenum(objp->instance, Shockwave_info[1].bitmap_id),
 				TMAP_FLAG_TEXTURED | TMAP_HTL_3D_UNLIT | TMAP_FLAG_SOFT_QUAD | TMAP_FLAG_DISTORTION, 
 				&p, 
 				fl_radians(sw->rot_angles.p), 

--- a/code/weapon/shockwave.cpp
+++ b/code/weapon/shockwave.cpp
@@ -187,7 +187,6 @@ void shockwave_delete_all()
  */
 void shockwave_set_framenum(int index)
 {
-	int				framenum;
 	shockwave		*sw;
 	shockwave_info	*si;
 
@@ -200,19 +199,7 @@ void shockwave_set_framenum(int index)
 	if (si->bitmap_id < 0)
 		return;
 
-	framenum = fl2i(sw->time_elapsed / sw->total_time * si->num_frames + 0.5);
-
-	// ensure we don't go past the number of frames of animation
-	if ( framenum > (si->num_frames-1) ) {
-		framenum = (si->num_frames-1);
-		Objects[sw->objnum].flags |= OF_SHOULD_BE_DEAD;
-	}
-
-	if ( framenum < 0 ) {
-		framenum = 0;
-	}
-
-	sw->current_bitmap = si->bitmap_id + framenum;
+	sw->current_bitmap = si->bitmap_id + shockwave_get_framenum(index, si->num_frames);
 }
 
 /**

--- a/code/weapon/shockwave.h
+++ b/code/weapon/shockwave.h
@@ -103,7 +103,7 @@ float shockwave_get_min_radius(int index);
 float shockwave_get_max_radius(int index);
 float shockwave_get_damage(int index);
 int   shockwave_get_damage_type_idx(int index);
-int   shockwave_get_framenum(int index, int num_frames);
+int   shockwave_get_framenum(const int index, const int ani_id);
 int   shockwave_get_flags(int index);
 
 #endif /* __SHOCKWAVE_H__ */

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -194,7 +194,7 @@ int weapon_explosions::Load(char *filename, int expected_lods)
 	new_wei.lod_count = 1;
 
 	strcpy_s(new_wei.lod[0].filename, filename);
-	new_wei.lod[0].bitmap_id = bm_load_animation(filename, &new_wei.lod[0].num_frames, &new_wei.lod[0].fps, NULL, 1);
+	new_wei.lod[0].bitmap_id = bm_load_animation(filename, &new_wei.lod[0].num_frames, &new_wei.lod[0].fps, nullptr, nullptr, true);
 
 	if (new_wei.lod[0].bitmap_id < 0) {
 		Warning(LOCATION, "Weapon explosion '%s' does not have an LOD0 anim!", filename);
@@ -208,7 +208,7 @@ int weapon_explosions::Load(char *filename, int expected_lods)
 		for (idx = 1; idx < expected_lods; idx++) {
 			sprintf(name_tmp, "%s_%d", filename, idx);
 
-			bitmap_id = bm_load_animation(name_tmp, &nframes, &nfps, NULL, 1);
+			bitmap_id = bm_load_animation(name_tmp, &nframes, &nfps, nullptr, nullptr, true);
 
 			if (bitmap_id > 0) {
 				strcpy_s(new_wei.lod[idx].filename, name_tmp);

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -3676,18 +3676,7 @@ void weapon_render_DEPRECATED(object *obj)
 				if (wip->laser_bitmap.num_frames > 1) {
 					wp->laser_bitmap_frame += flFrametime;
 
-					// Sanity checks
-					if (wp->laser_bitmap_frame < 0.0f)
-						wp->laser_bitmap_frame = 0.0f;
-					if (wp->laser_bitmap_frame > 100.0f)
-						wp->laser_bitmap_frame = 0.0f;
-
-					while (wp->laser_bitmap_frame > wip->laser_bitmap.total_time)
-						wp->laser_bitmap_frame -= wip->laser_bitmap.total_time;
-
-					framenum = fl2i( (wp->laser_bitmap_frame * wip->laser_bitmap.num_frames) / wip->laser_bitmap.total_time );
-
-					CLAMP(framenum, 0, wip->laser_bitmap.num_frames-1);
+					framenum = bm_get_anim_frame(wip->laser_bitmap.first_frame, wp->laser_bitmap_frame, wip->laser_bitmap.total_time, true);
 				}
 
 				if (wip->wi_flags2 & WIF2_TRANSPARENT)
@@ -7318,18 +7307,7 @@ void weapon_render(object* obj, draw_list *scene)
 				if (wip->laser_bitmap.num_frames > 1) {
 					wp->laser_bitmap_frame += flFrametime;
 
-					// Sanity checks
-					if (wp->laser_bitmap_frame < 0.0f)
-						wp->laser_bitmap_frame = 0.0f;
-					if (wp->laser_bitmap_frame > 100.0f)
-						wp->laser_bitmap_frame = 0.0f;
-
-					while (wp->laser_bitmap_frame > wip->laser_bitmap.total_time)
-						wp->laser_bitmap_frame -= wip->laser_bitmap.total_time;
-
-					framenum = fl2i( (wp->laser_bitmap_frame * wip->laser_bitmap.num_frames) / wip->laser_bitmap.total_time );
-
-					CLAMP(framenum, 0, wip->laser_bitmap.num_frames-1);
+					framenum = bm_get_anim_frame(wip->laser_bitmap.first_frame, wp->laser_bitmap_frame, wip->laser_bitmap.total_time, true);
 				}
 
 				if (wip->wi_flags2 & WIF2_TRANSPARENT)


### PR DESCRIPTION
Adds apng animation support for all places in FSO where you'd want them (and probably a few places you wouldn't!)

Most "desirable" use cases are:
- Command Brief Anims
- Intel Anims (techroom)
- Loading Screen Anim
- HUD Head Anims
- Mainhall animations

And the advantages that APNG brings over ani/eff's:
- 24bit colour palette
- 8 bit transparency
- a single file which should be smaller than the equivalent number of PNG frames or ANI file