### PR TITLE
Cleanup/shield refactor

### DIFF
--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -12238,31 +12238,7 @@ void ai_chase_circle(object *objp)
  */
 void ai_transfer_shield(object *objp, int quadrant_num)
 {
-	int	i;
-	float	transfer_amount;
-	float	transfer_delta;
-	float	max_quadrant_strength;
-
-	max_quadrant_strength = get_max_shield_quad(objp);
-
-	transfer_amount = 0.0f;
-	transfer_delta = (SHIELD_BALANCE_RATE/2) * max_quadrant_strength;
-
-	if (objp->shield_quadrant[quadrant_num] + (objp->n_quadrants-1)*transfer_delta > max_quadrant_strength)
-		transfer_delta = (max_quadrant_strength - objp->shield_quadrant[quadrant_num])/(objp->n_quadrants-1);
-
-	for (i=0; i<objp->n_quadrants; i++)
-		if (i != quadrant_num) {
-			if (objp->shield_quadrant[i] >= transfer_delta) {
-				objp->shield_quadrant[i] -= transfer_delta;
-				transfer_amount += transfer_delta;
-			} else {
-				transfer_amount += objp->shield_quadrant[i];
-				objp->shield_quadrant[i] = 0.0f;
-			}
-		}
-
-	objp->shield_quadrant[quadrant_num] += transfer_amount;
+	shield_transfer(objp, quadrant_num, (SHIELD_BALANCE_RATE / 2));
 }
 
 void ai_balance_shield(object *objp)

--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -12267,41 +12267,7 @@ void ai_transfer_shield(object *objp, int quadrant_num)
 
 void ai_balance_shield(object *objp)
 {
-	int	i;
-	float	shield_strength_avg;
-	float	delta;
-
-	// if we are already at the max shield strength then just bail now
-	if ( shield_get_strength(objp) >= shield_get_max_strength(objp) )
-		return;
-
-
-	shield_strength_avg = shield_get_strength(objp)/objp->n_quadrants;
-
-	delta = SHIELD_BALANCE_RATE * shield_strength_avg;
-
-	for (i=0; i<objp->n_quadrants; i++) {
-		if (objp->shield_quadrant[i] < shield_strength_avg) {
-			// only do it the retail way if using smart shields (since that's a bigger thing) - taylor
-			if (Ai_info[Ships[objp->instance].ai_index].ai_profile_flags[AI::Profile_Flags::Smart_shield_management])
-				shield_add_strength(objp, delta);
-			else
-				objp->shield_quadrant[i] += delta/objp->n_quadrants;
-
-			if (objp->shield_quadrant[i] > shield_strength_avg)
-				objp->shield_quadrant[i] = shield_strength_avg;
-
-		} else {
-			// only do it the retail way if using smart shields (since that's a bigger thing) - taylor
-			if (Ai_info[Ships[objp->instance].ai_index].ai_profile_flags[AI::Profile_Flags::Smart_shield_management])
-				shield_add_strength(objp, -delta);
-			else
-				objp->shield_quadrant[i] -= delta/objp->n_quadrants;
-
-			if (objp->shield_quadrant[i] < shield_strength_avg)
-				objp->shield_quadrant[i] = shield_strength_avg;
-		}
-	}
+	shield_balance(objp, SHIELD_BALANCE_RATE, 0.0f);
 }
 
 //	Manage the shield for this ship.

--- a/code/hud/hudshield.cpp
+++ b/code/hud/hudshield.cpp
@@ -354,7 +354,7 @@ void hud_shield_show_mini(object *objp, int x_force, int y_force, int x_hull_off
 
 	// draw the four quadrants
 	// Draw shield quadrants at one of NUM_SHIELD_LEVELS
-	max_shield = get_max_shield_quad(objp);
+	max_shield = shield_get_max_quad(objp);
 
 	for ( i = 0; i < objp->n_quadrants; i++ ) {
 
@@ -650,7 +650,7 @@ void HudGaugeShield::showShields(object *objp, int mode)
 	// draw the quadrants
 	//
 	// Draw shield quadrants at one of NUM_SHIELD_LEVELS
-	max_shield = get_max_shield_quad(objp);
+	max_shield = shield_get_max_quad(objp);
 
 	coord2d shield_icon_coords[6];
 
@@ -939,7 +939,7 @@ void HudGaugeShieldMini::showMiniShields(object *objp)
 
 	// draw the four quadrants
 	// Draw shield quadrants at one of NUM_SHIELD_LEVELS
-	max_shield = get_max_shield_quad(objp);
+	max_shield = shield_get_max_quad(objp);
 
 	for ( i = 0; i < objp->n_quadrants; i++ ) {
 

--- a/code/hud/hudshield.cpp
+++ b/code/hud/hudshield.cpp
@@ -208,8 +208,6 @@ void hud_ship_icon_page_in(ship_info *sip)
 void hud_shield_equalize(object *objp, player *pl)
 {
 	float penalty;
-	int idx;
-	int all_equal;
 
 	Assert(objp != NULL);
 	if (objp == NULL)

--- a/code/hud/hudshield.cpp
+++ b/code/hud/hudshield.cpp
@@ -207,7 +207,7 @@ void hud_ship_icon_page_in(ship_info *sip)
 //
 void hud_shield_equalize(object *objp, player *pl)
 {
-	float strength;
+	float penalty;
 	int idx;
 	int all_equal;
 
@@ -227,31 +227,18 @@ void hud_shield_equalize(object *objp, player *pl)
 	if (objp->flags[Object::Object_Flags::No_shields])
 		return;
 
-	// are all quadrants equal?
-	all_equal = 1;
-	for (idx = 0; idx < objp->n_quadrants - 1; idx++) {
-		if (objp->shield_quadrant[idx] != objp->shield_quadrant[idx + 1]) {
-			all_equal = 0;
-			break;
-		}
-	}
-
-	if (all_equal)
-		return;
-
-	strength = shield_get_strength(objp);
-	if (strength == 0.0f)
-		return;
-
 	// maybe impose a 2% penalty - server side and single player only
 	if (!MULTIPLAYER_CLIENT && ((pl->shield_penalty_stamp < 0) || timestamp_elapsed_safe(pl->shield_penalty_stamp, 1000)) ) {
-		strength *= 0.98f;
+		penalty = 0.02f;
 
 		// reset the penalty timestamp
 		pl->shield_penalty_stamp = timestamp(1000);
+
+	} else {
+		penalty = 0.0f;
 	}
-			
-	shield_set_strength(objp, strength);					
+
+	shield_balance(objp, 1, penalty);
 
 	// beep
 	if (objp == Player_obj) {

--- a/code/hud/hudshield.cpp
+++ b/code/hud/hudshield.cpp
@@ -263,60 +263,7 @@ void hud_shield_equalize(object *objp, player *pl)
 //
 void hud_augment_shield_quadrant(object *objp, int direction)
 {
-	Assert(objp->type == OBJ_SHIP);
-
-	ship *shipp = &Ships[objp->instance];
-	ship_info *sip = &Ship_info[shipp->ship_info_index];
-	float	xfer_amount, energy_avail, percent_to_take, delta;
-	float	max_quadrant_val;
-	int	i;
-
-	if (sip->flags[Ship::Info_Flags::Model_point_shields]) {
-		direction = sip->shield_point_augment_ctrls[direction];
-
-		// The re-mapped direction can be -1 if this direction cannot be augmented
-		if (direction < 0)
-			return;
-	}
-
-	Assert(direction >= 0 && direction < objp->n_quadrants);
-	
-	xfer_amount = shield_get_max_strength(objp, true) * SHIELD_TRANSFER_PERCENT;  // xfer amounts are unaffected by $Max Shield Recharge
-	max_quadrant_val = get_max_shield_quad(objp);
-
-	if ( (objp->shield_quadrant[direction] + xfer_amount) > max_quadrant_val )
-		xfer_amount = max_quadrant_val - objp->shield_quadrant[direction];
-
-	Assert(xfer_amount >= 0);
-	if ( xfer_amount == 0 ) {
-		// TODO: provide a feedback sound
-		return;
-	}
-	else {
-		snd_play( &Snds[SND_SHIELD_XFER_OK] );
-	}
-
-	energy_avail = 0.0f;
-	for ( i = 0; i < objp->n_quadrants; i++ ) {
-		if ( i == direction )
-			continue;
-		energy_avail += objp->shield_quadrant[i];
-	}
-
-	percent_to_take = xfer_amount/energy_avail;
-	if ( percent_to_take > 1.0f )
-		percent_to_take = 1.0f;
-
-	for ( i = 0; i < objp->n_quadrants; i++ ) {
-		if ( i == direction )
-			continue;
-		delta = percent_to_take * objp->shield_quadrant[i];
-		objp->shield_quadrant[i] -= delta;
-		Assert(objp->shield_quadrant[i] >= 0 );
-		objp->shield_quadrant[direction] += delta;
-		if ( objp->shield_quadrant[direction] > max_quadrant_val )
-			objp->shield_quadrant[direction] = max_quadrant_val;
-	}
+	shield_transfer(objp, direction, SHIELD_TRANSFER_PERCENT);
 }
 
 // Try to find a match between filename and the names inside

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -2308,7 +2308,7 @@ int parse_create_object_sub(p_object *p_objp)
 		Objects[objnum].hull_strength = p_objp->initial_hull * shipp->ship_max_hull_strength / 100.0f;
 		for (iLoop = 0; iLoop<Objects[objnum].n_quadrants; iLoop++)
 		{
-			Objects[objnum].shield_quadrant[iLoop] = (float) (shipp->max_shield_recharge * p_objp->initial_shields * get_max_shield_quad(&Objects[objnum]) / 100.0f);
+			Objects[objnum].shield_quadrant[iLoop] = (float) (shipp->max_shield_recharge * p_objp->initial_shields * shield_get_max_quad(&Objects[objnum]) / 100.0f);
 		}
 
 		// initial velocities now do not apply to ships which warp in after mission starts

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -59,6 +59,7 @@
 #include "network/multimsgs.h"
 #include "network/multiutil.h"
 #include "object/parseobjectdock.h"
+#include "object/objectshield.h"
 #include "object/waypoint.h"
 #include "parse/generic_log.h"
 #include "parse/parselo.h"

--- a/code/network/multi_obj.cpp
+++ b/code/network/multi_obj.cpp
@@ -22,6 +22,7 @@
 #include "network/multi_rate.h"
 #include "network/multi.h"
 #include "object/object.h"
+#include "object/objectshield.h"
 #include "ship/ship.h"
 #include "playerman/player.h"
 #include "math/spline.h"

--- a/code/network/multi_obj.cpp
+++ b/code/network/multi_obj.cpp
@@ -452,7 +452,7 @@ int multi_oo_pack_data(net_player *pl, object *objp, ubyte oo_flags, ubyte *data
 		PACK_PERCENT(temp);				
 		multi_rate_add(NET_PLAYER_NUM(pl), "hul", 1);	
 
-		float quad = get_max_shield_quad(objp);
+		float quad = shield_get_max_quad(objp);
 
 		for (int i = 0; i < objp->n_quadrants; i++) {
 			temp = (objp->shield_quadrant[i] / quad);
@@ -858,7 +858,7 @@ int multi_oo_unpack_data(net_player *pl, ubyte *data)
 		UNPACK_PERCENT(fpct);
 		pobjp->hull_strength = fpct * Ships[pobjp->instance].ship_max_hull_strength;		
 
-		float quad = get_max_shield_quad(pobjp);
+		float quad = shield_get_max_quad(pobjp);
 
 		for (int i = 0; i < pobjp->n_quadrants; i++) {
 			UNPACK_PERCENT(fpct);

--- a/code/network/multimsgs.cpp
+++ b/code/network/multimsgs.cpp
@@ -7010,7 +7010,7 @@ void send_client_update_packet(net_player *pl)
 		n_quadrants = (ubyte)objp->n_quadrants;
 		ADD_DATA( n_quadrants );
 		for (i = 0; i < n_quadrants; i++ ) {
-			percent = (ubyte)(objp->shield_quadrant[i] / get_max_shield_quad(objp) * 100.0f);
+			percent = (ubyte)(objp->shield_quadrant[i] / shield_get_max_quad(objp) * 100.0f);
 
 			ADD_DATA( percent );
 		}
@@ -7134,7 +7134,7 @@ void process_client_update_packet(ubyte *data, header *hinfo)
 
 			for ( i = 0; i < n_quadrants; i++ ) {
 				if (i < objp->n_quadrants) {
-					fl_val = (shield_percent[i] * get_max_shield_quad(objp) / 100.0f);
+					fl_val = (shield_percent[i] * shield_get_max_quad(objp) / 100.0f);
 					objp->shield_quadrant[i] = fl_val;
 				}
 			}

--- a/code/network/multimsgs.cpp
+++ b/code/network/multimsgs.cpp
@@ -46,6 +46,7 @@
 #include "asteroid/asteroid.h"
 #include "network/multi_pmsg.h"
 #include "object/object.h"
+#include "object/objectshield.h"
 #include "ship/ship.h"
 #include "weapon/weapon.h"
 #include "hud/hudreticle.h"

--- a/code/object/collideshipweapon.cpp
+++ b/code/object/collideshipweapon.cpp
@@ -186,7 +186,7 @@ int ship_weapon_check_collision(object *ship_objp, object *weapon_objp, float ti
 	//
 	//	Note: This code is obviously stupid. We want to add the shield point if there is shield to hit, but:
 	//		1. We want the size/color of the hit effect to indicate shield damage done.  (i.e., for already-weak shield, smaller effect)
-	//		2. Currently (8/9/97), apply_damage_to_shield() passes lefer damage to hull, which might not make sense.  If
+	//		2. Currently (8/9/97), shield_apply_damage() passes lefer damage to hull, which might not make sense.  If
 	//			wouldn't have collided with hull, shouldn't do damage.  Once this is fixed, the code below needs to cast the
 	//			vector through to the hull if there is leftover damage.
 	//

--- a/code/object/object.cpp
+++ b/code/object/object.cpp
@@ -266,17 +266,6 @@ int free_object_slots(int num_used)
 }
 
 // Goober5000
-float get_max_shield_quad(object *objp)
-{
-	Assert(objp);
-	if(objp->type != OBJ_SHIP) {
-		return 0.0f;
-	}
-
-	return Ships[objp->instance].ship_max_shield_strength / objp->n_quadrants; // max segment strength is unaffected by $Max Shield Recharge
-}
-
-// Goober5000
 float get_hull_pct(object *objp)
 {
 	Assert(objp);

--- a/code/object/object.h
+++ b/code/object/object.h
@@ -269,7 +269,7 @@ void obj_init_all_ships_physics();
 float get_hull_pct(object *objp);
 float get_sim_hull_pct(object *objp);
 float get_shield_pct(object *objp);
-float get_max_shield_quad(object *objp);
+float shield_get_max_quad(object *objp);
 
 // returns the average 3-space position of all ships.  useful to find "center" of battle (sort of)
 void obj_get_average_ship_pos(vec3d *pos);

--- a/code/object/object.h
+++ b/code/object/object.h
@@ -269,7 +269,6 @@ void obj_init_all_ships_physics();
 float get_hull_pct(object *objp);
 float get_sim_hull_pct(object *objp);
 float get_shield_pct(object *objp);
-float shield_get_max_quad(object *objp);
 
 // returns the average 3-space position of all ships.  useful to find "center" of battle (sort of)
 void obj_get_average_ship_pos(vec3d *pos);

--- a/code/object/objectshield.cpp
+++ b/code/object/objectshield.cpp
@@ -18,7 +18,7 @@
 #include <limits.h>
 
 // Private variables
-static double factor = 1.0 / (log(50.0) - log(1.0));	// Factor used in Goober5000's scale_quad
+static const float shield_scale_factor = static_cast<float>(1.0 / (log(50.0) - log(1.0)));	// Factor used in Goober5000's scale_quad
 
 // Private Function Declarations
 /**
@@ -42,7 +42,7 @@ float scale_quad(float generator_fraction, float quad_strength) {
 	// -----------------
 	//  ln(50) - ln(1)
 	//
-	float effective_strength = quad_strength * ((float)log(generator_fraction) * (float)factor);
+	float effective_strength = quad_strength * (static_cast<float>(log(generator_fraction)) * shield_scale_factor);
 
 	// ensure not negative, which may happen if the shield gets below 1 percent
 	// (since we're dealing with logs)

--- a/code/object/objectshield.cpp
+++ b/code/object/objectshield.cpp
@@ -168,6 +168,37 @@ float shield_apply_damage(object *objp, int quadrant_num, float damage) {
 	}
 }
 
+void shield_balance(object *objp, float balance_rate) {
+	float shield_hp;
+	float shield_hp_avg;
+
+	if (objp->flags[Object::Object_Flags::No_shields]) {
+		// No shields, bail
+		return;
+	}
+
+	shield_hp = shield_get_strength(objp);
+	if (shield_hp == 0.0f) {
+		// Shields are down, bail
+		return;
+	}
+
+	Assert(balance_rate > 0.0f);
+	Assert(balance_rate <= 1.0f);
+
+	shield_hp_avg = shield_hp / objp->n_quadrants;
+	for (int i = 0; i < objp->n_quadrants; ++i) {
+		if (abs(objp->shield_quadrant[i] - shield_hp_avg) < 0.01f) {
+			// Very close, so clamp
+			objp->shield_quadrant[i] = shield_hp_avg;
+
+		} else {
+			// Else, smoothly balance towards target
+			objp->shield_quadrant[i] += balance_rate * (shield_hp_avg - objp->shield_quadrant[i]);
+		}
+	}
+}
+
 float shield_get_max_quad(object *objp) {
 	return shield_get_max_strength(objp, true) / objp->n_quadrants;
 }

--- a/code/object/objectshield.cpp
+++ b/code/object/objectshield.cpp
@@ -53,6 +53,8 @@ float scale_quad(float generator_fraction, float quad_strength) {
 }
 
 void shield_add_quad(object *objp, int quadrant_num, float delta) {
+	Assert(objp);
+
 	// if we aren't going to change anything anyway then just bail
 	if (delta == 0.0f)
 		return;
@@ -76,6 +78,8 @@ void shield_add_quad(object *objp, int quadrant_num, float delta) {
 }
 
 void shield_add_strength(object *objp, float delta) {
+	Assert(objp);
+
 	// if we aren't going to change anything anyway then just bail
 	if (delta == 0.0f)
 		return;
@@ -143,6 +147,8 @@ void shield_add_strength(object *objp, float delta) {
 float shield_apply_damage(object *objp, int quadrant_num, float damage) {
 	float remaining_damage;
 
+	Assert(objp);
+
 	// multiplayer clients bail here if nodamage
 	// if(MULTIPLAYER_CLIENT && (Netgame.debug_flags & NETD_FLAG_CLIENT_NODAMAGE)){
 	if (MULTIPLAYER_CLIENT)
@@ -169,6 +175,7 @@ float shield_apply_damage(object *objp, int quadrant_num, float damage) {
 }
 
 void shield_balance(object *objp, float rate, float penalty) {
+	Assert(objp);
 	if (objp->flags[Object::Object_Flags::No_shields]) {
 		// No shields, bail
 		return;
@@ -218,10 +225,21 @@ void shield_balance(object *objp, float rate, float penalty) {
 }
 
 float shield_get_max_quad(object *objp) {
+	Assert(objp);
+
+	if (objp->type != OBJ_SHIP) {
+		return 0.0f;
+	}
+
 	return shield_get_max_strength(objp, true) / objp->n_quadrants;
 }
 
 float shield_get_max_strength(object *objp, bool no_msr) {
+	Assert(objp);
+
+	if (objp->type != OBJ_SHIP && objp->type != OBJ_START)
+		return 0.0f;
+
 	if (no_msr == true)
 		return Ships[objp->instance].ship_max_shield_strength;
 	else
@@ -229,6 +247,8 @@ float shield_get_max_strength(object *objp, bool no_msr) {
 }
 
 float shield_get_quad(object *objp, int quadrant_num) {
+	Assert(objp);
+
 	// no shield system, no strength!
 	if (objp->flags[Object::Object_Flags::No_shields])
 		return 0.0f;
@@ -287,6 +307,8 @@ float shield_get_quad(object *objp, int quadrant_num) {
 
 float shield_get_strength(object *objp)
 {
+	Assert(objp);
+
 	// no shield system, no strength!
 	if (objp->flags[Object::Object_Flags::No_shields])
 		return 0.0f;
@@ -301,6 +323,8 @@ float shield_get_strength(object *objp)
 }
 
 int shield_is_up(object *objp, int quadrant_num) {
+	Assert(objp);
+
 	if ((quadrant_num >= 0) && (quadrant_num < objp->n_quadrants)) {
 		// Just check one quadrant
 		float quad = shield_get_quad(objp, quadrant_num);
@@ -319,6 +343,8 @@ int shield_is_up(object *objp, int quadrant_num) {
 }
 
 void shield_set_max_strength(object *objp, float newmax) {
+	Assert(objp);
+
 	if (objp->type != OBJ_SHIP)
 		return;
 
@@ -326,6 +352,8 @@ void shield_set_max_strength(object *objp, float newmax) {
 }
 
 void shield_set_quad(object *objp, int quadrant_num, float strength) {
+	Assert(objp);
+
 	// check array bounds
 	Assert(quadrant_num >= 0 && quadrant_num < objp->n_quadrants);
 	if (quadrant_num < 0 || quadrant_num >= objp->n_quadrants)
@@ -343,13 +371,16 @@ void shield_set_quad(object *objp, int quadrant_num, float strength) {
 
 void shield_set_strength(object *objp, float strength)
 {
-	int	i;
+	int i;
+
+	Assert(objp);
 
 	for (i = 0; i < objp->n_quadrants; i++)
 		shield_set_quad(objp, i, strength / objp->n_quadrants);
 }
 
 void shield_transfer(object *objp, int quadrant, float rate) {
+	Assert(objp);
 	Assert(objp->type == OBJ_SHIP);
 
 	ship *shipp = &Ships[objp->instance];

--- a/code/object/objectshield.cpp
+++ b/code/object/objectshield.cpp
@@ -213,7 +213,7 @@ void shield_balance(object *objp, float rate, float penalty) {
 	shield_hp_avg *= 1 - penalty;
 
 	for (int i = 0; i < objp->n_quadrants; ++i) {
-		if (abs(objp->shield_quadrant[i] - shield_hp_avg) < 0.01f) {
+		if (fabsf(objp->shield_quadrant[i] - shield_hp_avg) < 0.01f) {
 			// Very close, so clamp
 			objp->shield_quadrant[i] = shield_hp_avg;
 

--- a/code/object/objectshield.h
+++ b/code/object/objectshield.h
@@ -19,18 +19,34 @@
 #define	RIGHT_QUAD	0
 
 /**
-* @brief Balances/Equalizes the shield
-*
-* @param[in] balance_rate The rate to balance the shield (0 < x <= 1)
-* @param[in] penalty      Percent of the shield energy to lose during the balance (0 < x <= 1)
-*
-* @author z64555
-*
-* @details Each quadrant is observed to exponentially approach the average shield HP. We don't have to worry about
-*   the shield gaining energy from somewhere, since: The sum of each shield_hp_avg - shield_quadrant[i] is 0.
-*   Applying a balance rate is legal since it's equivalent to applying the rate to the entire sum, which is still 0.
-*/
-void shield_balance(object *objp, float balance_rate, float penalty);
+ * @brief Balances/Equalizes the shield
+ *
+ * @param[in] balance_rate The rate to balance the shield (0 < x <= 1)
+ * @param[in] penalty      Percent of the shield energy to lose during the balance (0 < x <= 1)
+ *
+ * @author z64555
+ *
+ * @details Each quadrant is observed to exponentially approach the average shield HP, weaker quadrants quickly fill
+ *   up while stronger quadrants fille up slower. We don't have to worry about the shield gaining energy from
+ *   somewhere, since the sum of each (shield_hp_avg - shield_quadrant[i]) is 0.
+ *   Applying a balance rate is legal since it's equivalent to applying the rate to the entire sum, which is still 0.
+ *
+ * @TODO Verify operation with model point shields
+ */
+void shield_balance(object *objp, float rate, float penalty);
+
+/**
+ * @brief Transfers energy to the given quadrant from the other quadrants
+ *
+ * @param[in] quadrant Index of the quadrant to Xfer to
+ * @param[in] rate     Percent rate to increase the target quadrant
+ *
+ * @author z64555, zookeeper
+ *
+ * @details The transfer sips a percentage of each quadrant, taking more energy from stronger quadrants and less from
+ *   weaker ones.
+ */
+void shield_transfer(object *objp, int quadrant, float rate);
 
 /**
  * @brief Gets the shield strength (in HP) of the given object

--- a/code/object/objectshield.h
+++ b/code/object/objectshield.h
@@ -21,13 +21,16 @@
 /**
 * @brief Balances/Equalizes the shield
 *
+* @param[in] balance_rate The rate to balance the shield (0 < x <= 1)
+* @param[in] penalty      Percent of the shield energy to lose during the balance (0 < x <= 1)
+*
 * @author z64555
 *
 * @details Each quadrant is observed to exponentially approach the average shield HP. We don't have to worry about
 *   the shield gaining energy from somewhere, since: The sum of each shield_hp_avg - shield_quadrant[i] is 0.
 *   Applying a balance rate is legal since it's equivalent to applying the rate to the entire sum, which is still 0.
 */
-void shield_balance(object *objp, float balance_rate);
+void shield_balance(object *objp, float balance_rate, float penalty);
 
 /**
  * @brief Gets the shield strength (in HP) of the given object

--- a/code/object/objectshield.h
+++ b/code/object/objectshield.h
@@ -18,18 +18,109 @@
 #define	LEFT_QUAD	3
 #define	RIGHT_QUAD	0
 
+/**
+* @brief Balances/Equalizes the shield
+*
+* @author z64555
+*
+* @details Each quadrant is observed to exponentially approach the average shield HP. We don't have to worry about
+*   the shield gaining energy from somewhere, since: The sum of each shield_hp_avg - shield_quadrant[i] is 0.
+*   Applying a balance rate is legal since it's equivalent to applying the rate to the entire sum, which is still 0.
+*/
+void shield_balance(object *objp, float balance_rate);
+
+/**
+ * @brief Gets the shield strength (in HP) of the given object
+ */
 float shield_get_strength(object *objp);
+
+/**
+ * @brief Sets the shield strength (in HP) of the given object.
+ * @note All quadrants are set to an equal strength
+ */
 void shield_set_strength(object *objp, float strength);
+
+/**
+ * @brief Adds the given delta to the given object's shield.
+ *
+ * @param[in] delta HP to add (or subtract if negative) to the object's shield
+ */
 void shield_add_strength(object *objp, float delta);
+
+/**
+ * @brief Gets the strength (in HP) of a shield quadrant/sector
+ *
+ * @param[in] quadrant_num Index of the quadrant/sector to check.
+ *
+ * @author Goober5000
+ */
 float shield_get_quad(object *objp, int quadrant_num);
+
+/**
+ * @brief Sets the strength (in HP) of a shield quadrant/sector
+ *
+ * @param[in] quadrant_num Index of the quadrant/sector to set.
+ * @param[in] strength HP to set
+ *
+ * @author Goober5000
+ */
 void shield_set_quad(object *objp, int quadrant_num, float strength);
+
+/**
+ * @brief Sets the strength (in HP) of a shield quadrant/sector
+ *
+ * @param[in] quadrant_num Index of the quadrant/sector to set.
+ * @param[in] strength HP to add (or subtract if negative) to the quadrant/sector
+ *
+ * @author Goober5000
+ */
 void shield_add_quad(object *objp, int quadrant_num, float strength);
 
+/**
+ * @brief Gets the max shield HP of the given object
+ *
+ * @note $Max Shield Recharge is not intended to affect max strength of individual shield segments
+ *
+ * @author Goober5000
+ */
 float shield_get_max_strength(object *objp, bool no_msr = false);
+
+/**
+ * @brief Sets the max shield HP of the given object. Use this to init or override a ship's default shield HP
+ */
 void shield_set_max_strength(object *objp, float newmax);
+
+/**
+ * @brief Gets the max shield HP that a quadrant/sector may have
+ *
+ * @author Goober5000
+ */
 float shield_get_max_quad(object *objp);
 
+/**
+ * @brief Applies damage to the given shield quandrant/sector of the given object.
+ *
+ * @returns Any remaining damage after being absorbed by the shield.
+ *
+ * @details Basically:
+ *   if (Damage > Quadrant HP) {
+ *     Quadrant HP = 0;
+ *     return Damage - Quadrant HP;
+ *   } else {
+ *     Quadrant HP -= Damage;
+ *     return 0.0f;
+ *   }
+ */
 float shield_apply_damage(object *objp, int quadrant, float damage);
+
+/**
+ * @brief Checks if the given quadrant is stronger than 10%
+ *
+ * @param[in] quadrant_num Quadrant index to check. If -1, then check if the entire shield is stronger than 10%
+ *
+ * @returns true If the quadrant (or shield) is stronger than 10%, or
+ * @returns false otherwise
+ */
 int shield_is_up(object *objp, int quadrant_num);
 
 #endif //_OBJECTSHIELD_H

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -15597,7 +15597,7 @@ int sexp_shield_quad_low(int node)
 	if(!(sip->is_small_ship())){
 		return SEXP_FALSE;
 	}
-	max_quad = get_max_shield_quad(objp);	
+	max_quad = shield_get_max_quad(objp);	
 
 	// shield pct
 	check = (float)eval_num(CDR(node));
@@ -19999,7 +19999,7 @@ int shield_quad_near_max(int quadnum)
 		remaining += Player_obj->shield_quadrant[i];
 	}
 
-	if ((remaining < 2.0f) || (Player_obj->shield_quadrant[quadnum] > get_max_shield_quad(Player_obj) - 5.0f)) {
+	if ((remaining < 2.0f) || (Player_obj->shield_quadrant[quadnum] > shield_get_max_quad(Player_obj) - 5.0f)) {
 		return SEXP_TRUE;
 	} else {
 		return SEXP_FALSE;
@@ -20081,8 +20081,8 @@ int process_special_sexps(int index)
 
 			apply_damage_to_shield(Player_obj, FRONT_QUAD, -flFrametime*200.0f);
 
-			if (Player_obj->shield_quadrant[FRONT_QUAD] > get_max_shield_quad(Player_obj))
-			Player_obj->shield_quadrant[FRONT_QUAD] = get_max_shield_quad(Player_obj);
+			if (Player_obj->shield_quadrant[FRONT_QUAD] > shield_get_max_quad(Player_obj))
+			Player_obj->shield_quadrant[FRONT_QUAD] = shield_get_max_quad(Player_obj);
 
 			if (Player_obj->shield_quadrant[FRONT_QUAD] > Player_obj->shield_quadrant[(FRONT_QUAD+1)%DEFAULT_SHIELD_SECTIONS] - 2.0f)
 				return SEXP_TRUE;

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -20051,7 +20051,7 @@ int process_special_sexps(int index)
 
 	case 3:	//	Player ship suffering shield damage on front.
 		if (!(Ship_info[Player_ship->ship_info_index].flags[Ship::Info_Flags::Model_point_shields])) {
-			apply_damage_to_shield(Player_obj, FRONT_QUAD, 10.0f);
+			shield_apply_damage(Player_obj, FRONT_QUAD, 10.0f);
 			hud_shield_quadrant_hit(Player_obj, FRONT_QUAD);
 			return SEXP_TRUE;
 		} else {
@@ -20063,7 +20063,7 @@ int process_special_sexps(int index)
 	case 4:	//	Player ship suffering much damage.
 		if (!(Ship_info[Player_ship->ship_info_index].flags[Ship::Info_Flags::Model_point_shields])) {
 			nprintf(("AI", "Frame %i\n", Framecount));
-			apply_damage_to_shield(Player_obj, FRONT_QUAD, 10.0f);
+			shield_apply_damage(Player_obj, FRONT_QUAD, 10.0f);
 			hud_shield_quadrant_hit(Player_obj, FRONT_QUAD);
 			if (Player_obj->shield_quadrant[FRONT_QUAD] < 2.0f)
 				return SEXP_TRUE;
@@ -20079,7 +20079,7 @@ int process_special_sexps(int index)
 		if (!(Ship_info[Player_ship->ship_info_index].flags[Ship::Info_Flags::Model_point_shields])) {
 			nprintf(("AI", "Frame %i, recharged to %7.3f\n", Framecount, Player_obj->shield_quadrant[FRONT_QUAD]));
 
-			apply_damage_to_shield(Player_obj, FRONT_QUAD, -flFrametime*200.0f);
+			shield_apply_damage(Player_obj, FRONT_QUAD, -flFrametime*200.0f);
 
 			if (Player_obj->shield_quadrant[FRONT_QUAD] > shield_get_max_quad(Player_obj))
 			Player_obj->shield_quadrant[FRONT_QUAD] = shield_get_max_quad(Player_obj);

--- a/code/ship/shield.cpp
+++ b/code/ship/shield.cpp
@@ -679,40 +679,6 @@ void copy_shield_to_globals( int objnum, shield_info *shieldp, matrix *hit_orien
 
 
 /**
- * Return absolute amount of damage not applied.
- *
- * This is the version that works on a quadrant basis.
- */
-float apply_damage_to_shield(object *objp, int quadrant, float damage)
-{
-	ai_info	*aip;
-
-	// multiplayer clients bail here
-	if(MULTIPLAYER_CLIENT){
-		return damage;
-	}
-
-	if ( (quadrant < 0)  || (quadrant >= objp->n_quadrants) ) return damage;	
-	
-	Assert(objp->type == OBJ_SHIP);
-	aip = &Ai_info[Ships[objp->instance].ai_index];
-	aip->last_hit_quadrant = quadrant;
-
-	objp->shield_quadrant[quadrant] -= damage;
-
-	if (objp->shield_quadrant[quadrant] < 0.0f) {
-		float	remaining_damage;
-
-		remaining_damage = -objp->shield_quadrant[quadrant];
-		objp->shield_quadrant[quadrant] = 0.0f;
-		return remaining_damage;
-	} else {
-		return 0.0f;
-	}
-		
-}
-
-/**
  * This function needs to be called by big ships which have shields. It should be able to be modified to deal with
  * the large polygons we use for their shield meshes - unknownplayer
  *

--- a/code/ship/shield.cpp
+++ b/code/ship/shield.cpp
@@ -1009,7 +1009,7 @@ int ship_is_shield_up( object *obj, int quadrant )
 {
 	if ( (quadrant >= 0) && (quadrant < obj->n_quadrants))	{
 		// Just check one quadrant
-		if (obj->shield_quadrant[quadrant] > MAX(2.0f, 0.1f * get_max_shield_quad(obj)))	{
+		if (obj->shield_quadrant[quadrant] > MAX(2.0f, 0.1f * shield_get_max_quad(obj)))	{
 			return 1;
 		}
 	} else {

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -14811,7 +14811,7 @@ float ship_quadrant_shield_strength(object *hit_objp, vec3d *hitpos)
 	if ( quadrant_num < 0 )
 		quadrant_num = 0;
 
-	max_quadrant = get_max_shield_quad(hit_objp);
+	max_quadrant = shield_get_max_quad(hit_objp);
 	if ( max_quadrant <= 0 ) {
 		return 0.0f;
 	}

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -1451,7 +1451,6 @@ extern void shield_hit_close();
 
 void ship_draw_shield( object *objp);
 
-float apply_damage_to_shield(object *objp, int quadrant, float damage);
 float compute_shield_strength(object *objp);
 
 // Returns true if the shield presents any opposition to something 

--- a/code/ship/shiphit.cpp
+++ b/code/ship/shiphit.cpp
@@ -2091,7 +2091,7 @@ static void ship_do_damage(object *ship_objp, object *other_obj, vec3d *hitpos, 
 				damage *= difficulty_scale_factor;
 			}
 
-			damage = apply_damage_to_shield(ship_objp, quadrant, damage);
+			damage = shield_apply_damage(ship_objp, quadrant, damage);
 
 			if (damage > 0.0f) {
 				subsystem_damage *= (damage / pre_shield);


### PR DESCRIPTION
Combines shield management code from AI and Player sources into objectshield.cpp, which should provide consistent behavior between the two. At the very least, it reduces the number of places to maintain.

The balancing routine was generalized so that both AI and Players can use them, in their own form. Shield Equalization is just a balance with a rate of 100%.

The quadrant augment/transfer routine is a lightly modified flavor of the one zookeeper recently made for his model-point shields, namely to allow different rates to be plugged in.
