### PR TITLE
Disable unused function warnings in release mode

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -274,7 +274,7 @@ if test "$fs2_debug" = "yes" ; then
 else
 	AC_DEFINE([NDEBUG])
 	D_CFLAGS="$D_CFLAGS -O2 -Wall -funroll-loops"
-	D_CFLAGS="$D_CFLAGS -Wno-write-strings -Wno-unused-variable"
+	D_CFLAGS="$D_CFLAGS -Wno-write-strings -Wno-unused-variable -Wno-unused-function"
 	
 	AC_C_COMPILE_FLAGS([-Wno-unused-but-set-variable])
 	


### PR DESCRIPTION
If a function is only used in an `Assert` then the CI build will fail for release builds.