### PR TITLE
Fix mission screen grid by changing the drawing of the lines.

### DIFF
--- a/code/missionui/missionscreencommon.cpp
+++ b/code/missionui/missionscreencommon.cpp
@@ -1726,8 +1726,6 @@ void draw_model_rotating(model_render_params *render_info, int model_id, int x1,
 		float size = pm->rad*0.7f;
 		float start_scale = MIN(time,0.5f)*2.5f;
 		float offset = size*0.5f*MIN(MAX(time-3.0f,0.0f),0.6f)*1.66667f;
-		if ( (time < 1.5f) && (time >= 0.5f) )  // Clip the grid if were in phase 1
-			render_info->set_clip_plane(plane_point,wire_normal);
 
 		g3_start_instance_angles(&vmd_zero_vector,&view_angles);
 
@@ -1754,6 +1752,10 @@ void draw_model_rotating(model_render_params *render_info, int model_id, int x1,
 			gr_set_color(0,200,0);
 			g3_start_instance_angles(&vmd_zero_vector,&view_angles);
 
+			if (time < 1.5f) {
+				stop.xyz.z = -clip;
+			}
+
 			for (i = -3; i < 4; i++) {
 				start.xyz.x = stop.xyz.x = size*0.333f*i;
 				g3_draw_htl_line(&start,&stop);
@@ -1762,8 +1764,10 @@ void draw_model_rotating(model_render_params *render_info, int model_id, int x1,
 			start.xyz.x = size;
 			stop.xyz.x = -size;
 
-			for (i = -3; i < 4; i++) {
+			for (i = 3; i > -4; i--) {
 				start.xyz.z = stop.xyz.z = size*0.333f*i+offset*0.5f;
+				if ((time < 1.5f) && (start.xyz.z <= -clip))
+					break;
 				g3_draw_htl_line(&start,&stop);
 			}
 


### PR DESCRIPTION
Instead of using the clipping plane, simply don't draw the grid below the scanline. Fixes issue #347.