### PR TITLE
fix the $dumb_rotate turn rate calculation to align with regular $rotate

### DIFF
--- a/code/model/modelread.cpp
+++ b/code/model/modelread.cpp
@@ -1267,7 +1267,12 @@ int read_model_file(polymodel * pm, char *filename, int n_subsystems, model_subs
 					pm->submodel[n].movement_type = MOVEMENT_TYPE_INTRINSIC_ROTATE;
 					pm->flags |= PM_FLAG_HAS_INTRINSIC_ROTATE;
 
-					pm->submodel[n].dumb_turn_rate = (float)atof(p + 13);
+					// calculate turn rate from turn time, the same way as regular $rotate
+					char buf[64];
+					get_user_prop_value(p + 13, buf);
+					float turn_time = (float)atof(buf);
+
+					pm->submodel[n].dumb_turn_rate = PI2 / turn_time;
 				} else {
 					pm->submodel[n].dumb_turn_rate = 0.0f;
 				}


### PR DESCRIPTION
This is a small change in the code, but it fixes a significant bug.

The rotation turn rate for regular rotating submodels, specified using the $rotate property in the POF, is calculated using the time, in seconds, to complete one rotation.  Unfortunately,  the $dumb_rotate property was originally coded to use the property as the actual turn rate.  Thus, a subsystem that takes 5 seconds to complete one rotation would be interpreted at rotating at 5 radians per second if converted to use dumb_rotate.  (This is about .8 rotations/second rather than .2 rotations/second.)

This led to strange mismatches in the turn rate, but this was probably not examined closely due to all the other problems with $dumb_rotate and $look_at.  Now that the $dumb_rotation refactor has been completed and will be in 3.7.4, the turn rate calculation should be fixed at the same time.