### PR TITLE
Fix new[] vs delete mismatch

### DIFF
--- a/code/controlconfig/controlsconfigcommon.cpp
+++ b/code/controlconfig/controlsconfigcommon.cpp
@@ -617,7 +617,7 @@ void control_config_common_close()
 {
 	// only need to worry control presets for now
 	for (auto ii = Control_config_presets.cbegin(); ii != Control_config_presets.cend(); ++ii) {
-		delete * ii;
+		delete[] * ii;
 	}
 }
 


### PR DESCRIPTION
Found by address sanitiser

My mistake from commit 253d8a7e >.>

````
=================================================================
==5464== ERROR: AddressSanitizer: alloc-dealloc-mismatch (operator new [] vs operator delete) on 0x606000008080
    #0 0x7f6c7fe2d9da in operator delete(void*) ??:?
    #1 0x54c851 in control_config_common_close() /home/mememe/src/fs2open.github.com.niffiwan/code/controlconfig/controlsconfigcommon.cpp:620 (discriminator 3)
    #2 0x423207 in game_shutdown() /home/mememe/src/fs2open.github.com.niffiwan/code/freespace2/freespace.cpp:7337
    #3 0x422b0d in game_main(char*) /home/mememe/src/fs2open.github.com.niffiwan/code/freespace2/freespace.cpp:7080
    #4 0x422f52 in main /home/mememe/src/fs2open.github.com.niffiwan/code/freespace2/freespace.cpp:7209
    #5 0x7f6c7d24cec4 in __libc_start_main /build/eglibc-3GlaMS/eglibc-2.19/csu/libc-start.c:287
0x606000008080 is located 0 bytes inside of 3840-byte region [0x606000008080,0x606000008f80)
allocated by thread T0 here:
    #0 0x7f6c7fe2d88a in operator new[](unsigned long) ??:?
    #1 0x551778 in control_config_common_load_overrides() /home/mememe/src/fs2open.github.com.niffiwan/code/controlconfig/controlsconfigcommon.cpp:821
    #2 0x54c751 in control_config_common_init() /home/mememe/src/fs2open.github.com.niffiwan/code/controlconfig/controlsconfigcommon.cpp:597
    #3 0x4129ff in game_init() /home/mememe/src/fs2open.github.com.niffiwan/code/freespace2/freespace.cpp:1978
    #4 0x4229f4 in game_main(char*) /home/mememe/src/fs2open.github.com.niffiwan/code/freespace2/freespace.cpp:7017
    #5 0x422f52 in main /home/mememe/src/fs2open.github.com.niffiwan/code/freespace2/freespace.cpp:7209
    #6 0x7f6c7d24cec4 in __libc_start_main /build/eglibc-3GlaMS/eglibc-2.19/csu/libc-start.c:287
==5464== HINT: if you don't care about these warnings you may set ASAN_OPTIONS=alloc_dealloc_mismatch=0
==5464== ABORTING
````