### PR TITLE
Make new registry configurable on commandline

### DIFF
--- a/code/cmdline/cmdline.cpp
+++ b/code/cmdline/cmdline.cpp
@@ -197,6 +197,9 @@ Flag exe_params[] =
 	{ "-no_batching",		"Disable batched model rendering",			true,	0,					EASY_DEFAULT,		"Troubleshoot", "", },
 	{ "-no_geo_effects",	"Disable geometry shader for effects",		true,	0,					EASY_DEFAULT,		"Troubleshoot", "", },
 	{ "-set_cpu_affinity",	"Sets processor affinity to config value",	true,	0,					EASY_DEFAULT,		"Troubleshoot", "", },
+#ifdef WIN32
+	{ "-fix_registry",	"Use a different registry path",			true,		0,					EASY_DEFAULT,		"Troubleshoot", "", },
+#endif
 
 	{ "-ingame_join",		"Allow in-game joining",					true,	0,					EASY_DEFAULT,		"Experimental",	"http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-ingame_join", },
 	{ "-voicer",			"Enable voice recognition",					true,	0,					EASY_DEFAULT,		"Experimental",	"http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-voicer", },
@@ -427,6 +430,9 @@ cmdline_parm old_collision_system("-old_collision", NULL, AT_NONE); // Cmdline_o
 cmdline_parm gl_finish ("-gl_finish", NULL, AT_NONE);
 cmdline_parm no_geo_sdr_effects("-no_geo_effects", NULL, AT_NONE);
 cmdline_parm set_cpu_affinity("-set_cpu_affinity", NULL, AT_NONE);
+#ifdef WIN32
+cmdline_parm fix_registry("-fix_registry", NULL, AT_NONE);
+#endif
 
 int Cmdline_load_all_weapons = 0;
 int Cmdline_nohtl = 0;
@@ -444,6 +450,9 @@ char* Cmdline_keyboard_layout = NULL;
 bool Cmdline_gl_finish = false;
 bool Cmdline_no_geo_sdr_effects = false;
 bool Cmdline_set_cpu_affinity = false;
+#ifdef WIN32
+bool Cmdline_alternate_registry_path = false;
+#endif
 
 // Developer/Testing related
 cmdline_parm start_mission_arg("-start_mission", "Skip mainhall and run this mission", AT_STRING);	// Cmdline_start_mission
@@ -1616,6 +1625,12 @@ bool SetCmdlineParams()
 	{
 		Cmdline_set_cpu_affinity = true;
 	}
+
+#ifdef WIN32
+	if (fix_registry.found()) {
+		Cmdline_alternate_registry_path = true;
+	}
+#endif
 
 	if ( snd_preload_arg.found() )
 	{

--- a/code/cmdline/cmdline.h
+++ b/code/cmdline/cmdline.h
@@ -135,6 +135,9 @@ extern char* Cmdline_keyboard_layout;
 extern bool Cmdline_gl_finish;
 extern bool Cmdline_no_geo_sdr_effects;
 extern bool Cmdline_set_cpu_affinity;
+#ifdef WIN32
+extern bool Cmdline_alternate_registry_path;
+#endif
 
 // Developer/Testing related
 extern char *Cmdline_start_mission;

--- a/code/osapi/osregistry.cpp
+++ b/code/osapi/osregistry.cpp
@@ -111,6 +111,17 @@ bool needsWOW64()
 
 HKEY get_registry_keyname(char* out_keyname, const char* section)
 {
+	if (!Cmdline_alternate_registry_path) {
+		// Use the original registry path, sometimes breaks for no reason which can be fixed by the code below
+		if (section) {
+			sprintf(out_keyname, "Software\\%s\\%s\\%s", szCompanyName, szAppName, section);
+		}
+		else {
+			sprintf(out_keyname, "Software\\%s\\%s", szCompanyName, szAppName);
+		}
+		return HKEY_LOCAL_MACHINE;
+	}
+
 	// Every compiler from Visual Studio 2008 onward should have support for UAC
 #if _MSC_VER >= 1400
 	if (userSIDValid)


### PR DESCRIPTION
The new registry handling also breaks the settings for some people so I added a commandline option which selects which path is used.

This issue should be added to the "Known issues" section of the release post so users know how to fix this issue.