### PR TITLE
Fix for tab key on barracks screen

### DIFF
--- a/code/menuui/barracks.cpp
+++ b/code/menuui/barracks.cpp
@@ -1508,8 +1508,15 @@ void barracks_do_frame(float frametime)
 				}
 
 				if (Player_sel_mode == PLAYER_SELECT_MODE_SINGLE) {
+					Cur_pilot->flags |= PLAYER_FLAGS_IS_MULTI;
+					Pilot.save_player(Cur_pilot);
 					barracks_init_player_stuff(PLAYER_SELECT_MODE_MULTI);
 				} else {
+					// make sure we don't carry over the multi flag
+					if (Cur_pilot->flags & PLAYER_FLAGS_IS_MULTI) {
+						Cur_pilot->flags &= ~PLAYER_FLAGS_IS_MULTI;
+					}
+					Pilot.save_player(Cur_pilot);
 					barracks_init_player_stuff(PLAYER_SELECT_MODE_SINGLE);
 				}
 

--- a/code/menuui/barracks.cpp
+++ b/code/menuui/barracks.cpp
@@ -1513,9 +1513,7 @@ void barracks_do_frame(float frametime)
 					barracks_init_player_stuff(PLAYER_SELECT_MODE_MULTI);
 				} else {
 					// make sure we don't carry over the multi flag
-					if (Cur_pilot->flags & PLAYER_FLAGS_IS_MULTI) {
-						Cur_pilot->flags &= ~PLAYER_FLAGS_IS_MULTI;
-					}
+					Cur_pilot->flags &= ~PLAYER_FLAGS_IS_MULTI;
 					Pilot.save_player(Cur_pilot);
 					barracks_init_player_stuff(PLAYER_SELECT_MODE_SINGLE);
 				}


### PR DESCRIPTION
This fixes a bug where pressing the tab key (as opposed to clicking the single and multi buttons) on the barracks screen doesn't really switch between single player and multiplayer, even though the screen appears to reflect the change.