### PR TITLE
[3.7.4] Stop joystick hat binds being triggered spuriously

### DIFF
--- a/code/controlconfig/controlsconfig.cpp
+++ b/code/controlconfig/controlsconfig.cpp
@@ -2257,7 +2257,8 @@ int check_control_used(int id, int key)
 		return 0;
 	}
 
-	if ((Control_config[id].key_id == key) || joy_down_count(Control_config[id].joy_id, 1) || mouse_down_count(1 << Control_config[id].joy_id)) {
+	if ((Control_config[id].key_id == key) || joy_down_count(Control_config[id].joy_id, 1) ||
+			((Control_config[id].joy_id >= 0) && (Control_config[id].joy_id < MOUSE_NUM_BUTTONS) && mouse_down_count(1 << Control_config[id].joy_id))) {
 		//mprintf(("Key used %d", key));
 		control_used(id);
 		return 1;


### PR DESCRIPTION
There was a bug in the controls code that meant trigger type controls
bound to a joystick hat could be triggered by unrelated mouse button
presses. i.e. bind "hat-back" to cycle secondary weapons and secondary
banks would change when you fired with left mouse button.

Root cause is left bitshifting by 32 or more, which is implementation
defined and at least on Linux/GCC resulted in the above behaviour.