### PR TITLE
[3.7.4] Make ship templates default first_time to true, like ship classes.

### DIFF
--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -1790,7 +1790,7 @@ int parse_ship_template()
 	char buf[SHIP_MULTITEXT_LENGTH];
 	ship_info *sip;
 	int rtn = 0;
-	bool first_time = false;
+	bool first_time = true;
 
 	required_string("$Template:");
 	stuff_string(buf, F_NAME, SHIP_MULTITEXT_LENGTH);


### PR DESCRIPTION
Otherwise, the first_time code never gets evaluated for template-based ships and you never get engine glows from species. Fixes issue #594.

Backport of PR #596.