### PR TITLE
Remove unused graphics functions

### DIFF
--- a/code/graphics/2d.cpp
+++ b/code/graphics/2d.cpp
@@ -702,14 +702,10 @@ void gr_set_palette_internal( const char *name, ubyte * palette, int restrict_fo
 	}
 
 	if ( Gr_inited ) {
-		if (gr_screen.gf_set_palette) {
-			(*gr_screen.gf_set_palette)(Gr_current_palette, restrict_font_to_128 );
-
-			// Since the palette set code might shuffle the palette,
-			// reload it into the source palette
-			if ( palette ) {
-				memmove( palette, Gr_current_palette, 768 );
-			}
+		// Since the palette set code might shuffle the palette,		
+		// reload it into the source palette		
+		if (palette) {
+			memmove(palette, Gr_current_palette, 768);
 		}
 
 		// Update Palette Manager tables

--- a/code/graphics/2d.h
+++ b/code/graphics/2d.h
@@ -408,9 +408,6 @@ typedef struct screen {
 	//switch onscreen, offscreen
 	void (*gf_flip)();
 
-	// Sets the current palette
-	void (*gf_set_palette)(const ubyte *new_pal, int restrict_alphacolor);
-	
 	// Flash the screen
 	void (*gf_flash)( int r, int g, int b );
 	void (*gf_flash_alpha)(int r, int g, int b, int a);
@@ -503,12 +500,7 @@ typedef struct screen {
 	
 	// Sets the gamma
 	void (*gf_set_gamma)(float gamma);
-
-	// Lock/unlock the screen
-	// Returns non-zero if sucessful (memory pointer)
-	uint (*gf_lock)();
-	void (*gf_unlock)();
-
+	
 	// grab a region of the screen. assumes data is large enough
 	void (*gf_get_region)(int front, int w, int h, ubyte *data);
 

--- a/code/graphics/gropengl.cpp
+++ b/code/graphics/gropengl.cpp
@@ -473,10 +473,6 @@ void gr_opengl_reset_clip()
 	GL_state.ScissorTest(GL_FALSE);
 }
 
-void gr_opengl_set_palette(const ubyte *new_palette, int is_alphacolor)
-{
-}
-
 void gr_opengl_print_screen(const char *filename)
 {
 	char tmp[MAX_PATH_LEN];
@@ -1691,7 +1687,6 @@ void opengl_setup_function_pointers()
 
 	gr_screen.gf_gradient			= gr_opengl_gradient;
 
-	gr_screen.gf_set_palette		= gr_opengl_set_palette;
 	gr_screen.gf_print_screen		= gr_opengl_print_screen;
 
 	gr_screen.gf_flash				= gr_opengl_flash;

--- a/code/graphics/grstub.cpp
+++ b/code/graphics/grstub.cpp
@@ -312,10 +312,6 @@ void gr_stub_set_light(light *light)
 {
 }
 
-void gr_stub_set_palette(const ubyte *new_palette, int is_alphacolor)
-{
-}
-
 void gr_stub_set_projection_matrix(float fov, float aspect, float z_near, float z_far)
 {
 }
@@ -588,7 +584,6 @@ bool gr_stub_init()
 
 	gr_screen.gf_gradient			= gr_stub_gradient;
 
-	gr_screen.gf_set_palette		= gr_stub_set_palette;
 	gr_screen.gf_print_screen		= gr_stub_print_screen;
 
 	gr_screen.gf_flash				= gr_stub_flash;


### PR DESCRIPTION
`gf_set_palette` was a no-op for all graphics APIs so I just removed it.