### PR TITLE
Minor trig cleanup

### DIFF
--- a/code/asteroid/asteroid.cpp
+++ b/code/asteroid/asteroid.cpp
@@ -1566,8 +1566,8 @@ void asteroid_maybe_break_up(object *pasteroid_obj)
 						float r = sqrt(1.0f - y*y);
 						float phi = i * inc;
 
-						dir_vec.xyz.x = cos(phi)*r;
-						dir_vec.xyz.y = sin(phi)*r;
+						dir_vec.xyz.x = cosf(phi)*r;
+						dir_vec.xyz.y = sinf(phi)*r;
 						dir_vec.xyz.z = y;
 
 						// Randomize the direction a bit

--- a/code/camera/camera.cpp
+++ b/code/camera/camera.cpp
@@ -515,8 +515,8 @@ void warp_camera::do_frame(float in_frametime)
 
 		float tmp_angle = frand()*PI2;
 	
-		tmp.xyz.x = 22.0f * (float)sin(tmp_angle);
-		tmp.xyz.y = -22.0f * (float)cos(tmp_angle);
+		tmp.xyz.x = 22.0f * sinf(tmp_angle);
+		tmp.xyz.y = -22.0f * cosf(tmp_angle);
 
 		this->set_velocity( &tmp, 0 );
 	}

--- a/code/globalincs/pstypes.h
+++ b/code/globalincs/pstypes.h
@@ -308,8 +308,6 @@ const float PI_2		= (PI/2.0f);
 const int RAND_MAX_2	= (RAND_MAX/2);
 const float RAND_MAX_1f	= (1.0f / RAND_MAX);
 
-#define ANG_TO_RAD(x)	((x)*PI/180)
-
 
 extern int Fred_running;  // Is Fred running, or FreeSpace?
 

--- a/code/graphics/gropengldraw.cpp
+++ b/code/graphics/gropengldraw.cpp
@@ -1050,8 +1050,8 @@ void gr_opengl_arc(int xc, int yc, float r, float angle_start, float angle_end, 
 	float s = sinf(theta);
 	float t;
 
-	float x1 = cosf(ANG_TO_RAD(angle_start));
-	float y1 = sinf(ANG_TO_RAD(angle_start));
+	float x1 = cosf(fl_radians(angle_start));
+	float y1 = sinf(fl_radians(angle_start));
 	float x2 = x1;
 	float y2 = y1;
 

--- a/code/graphics/gropenglpostprocessing.cpp
+++ b/code/graphics/gropenglpostprocessing.cpp
@@ -288,8 +288,8 @@ void gr_opengl_post_process_end()
 			if((dot=vm_vec_dot( &light_dir, &Eye_matrix.vec.fvec )) > 0.7f)
 			{
 				
-				x = asin(vm_vec_dot( &light_dir, &Eye_matrix.vec.rvec ))/PI*1.5f+0.5f; //cant get the coordinates right but this works for the limited glare fov
-				y = asin(vm_vec_dot( &light_dir, &Eye_matrix.vec.uvec ))/PI*1.5f*gr_screen.clip_aspect+0.5f;
+				x = asinf(vm_vec_dot( &light_dir, &Eye_matrix.vec.rvec ))/PI*1.5f+0.5f; //cant get the coordinates right but this works for the limited glare fov
+				y = asinf(vm_vec_dot( &light_dir, &Eye_matrix.vec.uvec ))/PI*1.5f*gr_screen.clip_aspect+0.5f;
 				GL_state.Uniform.setUniform2f( "sun_pos", x, y);
 				GL_state.Uniform.setUniformi( "scene", 0);
 				GL_state.Uniform.setUniformi( "cockpit", 1);

--- a/code/graphics/shadows.cpp
+++ b/code/graphics/shadows.cpp
@@ -61,10 +61,10 @@ void shadows_construct_light_proj(light_frustum_info *shadow_data)
 void shadows_debug_show_frustum(matrix* orient, vec3d *pos, float fov, float aspect, float z_near, float z_far)
 {
 	// find the widths and heights of the near plane and far plane to determine the points of this frustum
-	float near_height = (float)tan((double)fov * 0.5) * z_near;
+	float near_height = tanf(fov * 0.5f) * z_near;
 	float near_width = near_height * aspect;
 
-	float far_height = (float)tan((double)fov * 0.5) * z_far;
+	float far_height = tanf(fov * 0.5f) * z_far;
 	float far_width = far_height * aspect;
 
 	vec3d up_scale = ZERO_VECTOR;
@@ -190,10 +190,10 @@ void shadows_debug_show_frustum(matrix* orient, vec3d *pos, float fov, float asp
 void shadows_construct_light_frustum(light_frustum_info *shadow_data, matrix *light_matrix, matrix *orient, vec3d *pos, float fov, float aspect, float z_near, float z_far)
 {
 	// find the widths and heights of the near plane and far plane to determine the points of this frustum
-	float near_height = (float)tan((double)fov * 0.5) * z_near;
+	float near_height = tanf(fov * 0.5f) * z_near;
 	float near_width = near_height * aspect;
 
-	float far_height = (float)tan((double)fov * 0.5f) * z_far;
+	float far_height = tanf(fov * 0.5f) * z_far;
 	float far_width = far_height * aspect;
 
 	vec3d up_scale = ZERO_VECTOR;

--- a/code/hud/hudlock.cpp
+++ b/code/hud/hudlock.cpp
@@ -649,16 +649,16 @@ void HudGaugeLock::renderLockTrianglesOld(int center_x, int center_y, int radius
 		// draw the orbiting triangles
 
 		//ang = atan2(target_point.y,target_point.x);
-		xpos = center_x + (float)cos(ang)*(radius + Lock_triangle_height + 2);
-		ypos = center_y - (float)sin(ang)*(radius + Lock_triangle_height + 2);
+		xpos = center_x + cosf(ang)*(radius + Lock_triangle_height + 2);
+		ypos = center_y - sinf(ang)*(radius + Lock_triangle_height + 2);
 			
-		x3 = xpos - Lock_triangle_base * (float)sin(-ang);
-		y3 = ypos + Lock_triangle_base * (float)cos(-ang);
-		x4 = xpos + Lock_triangle_base * (float)sin(-ang);
-		y4 = ypos - Lock_triangle_base * (float)cos(-ang);
+		x3 = xpos - Lock_triangle_base * sinf(-ang);
+		y3 = ypos + Lock_triangle_base * cosf(-ang);
+		x4 = xpos + Lock_triangle_base * sinf(-ang);
+		y4 = ypos - Lock_triangle_base * cosf(-ang);
 
-		xpos = xpos - Lock_triangle_base * (float)cos(ang);
-		ypos = ypos + Lock_triangle_base * (float)sin(ang);
+		xpos = xpos - Lock_triangle_base * cosf(ang);
+		ypos = ypos + Lock_triangle_base * sinf(ang);
 
 		hud_tri(x3, y3, xpos, ypos, x4, y4);
 	} // end for

--- a/code/hud/hudlock.cpp
+++ b/code/hud/hudlock.cpp
@@ -652,10 +652,10 @@ void HudGaugeLock::renderLockTrianglesOld(int center_x, int center_y, int radius
 		xpos = center_x + cosf(ang)*(radius + Lock_triangle_height + 2);
 		ypos = center_y - sinf(ang)*(radius + Lock_triangle_height + 2);
 			
-		x3 = xpos - Lock_triangle_base * sinf(-ang);
-		y3 = ypos + Lock_triangle_base * cosf(-ang);
-		x4 = xpos + Lock_triangle_base * sinf(-ang);
-		y4 = ypos - Lock_triangle_base * cosf(-ang);
+		x3 = xpos + Lock_triangle_base * sinf(ang);
+		y3 = ypos + Lock_triangle_base * cosf(ang);
+		x4 = xpos - Lock_triangle_base * sinf(ang);
+		y4 = ypos - Lock_triangle_base * cosf(ang);
 
 		xpos = xpos - Lock_triangle_base * cosf(ang);
 		ypos = ypos + Lock_triangle_base * sinf(ang);

--- a/code/hud/hudtarget.cpp
+++ b/code/hud/hudtarget.cpp
@@ -2772,8 +2772,8 @@ void HudGaugeOrientationTee::renderOrientation(object *from_objp, object *to_obj
 		dot_product *= PI_2; //(range is now -PI/2 => PI/2)
 	}
 
-	y1 = (float)sin(dot_product) * (Radius - T_OFFSET_FROM_CIRCLE);
-	x1 = (float)cos(dot_product) * (Radius - T_OFFSET_FROM_CIRCLE);
+	y1 = sinf(dot_product) * (Radius - T_OFFSET_FROM_CIRCLE);
+	x1 = cosf(dot_product) * (Radius - T_OFFSET_FROM_CIRCLE);
 
 	y1 += position[1];
 	x1 += position[0];
@@ -2781,8 +2781,8 @@ void HudGaugeOrientationTee::renderOrientation(object *from_objp, object *to_obj
 	x1 += HUD_offset_x;
 	y1 += HUD_offset_y;
 
-	y2 = (float)sin(dot_product) * (Radius - T_OFFSET_FROM_CIRCLE - T_LENGTH);
-	x2 = (float)cos(dot_product) * (Radius - T_OFFSET_FROM_CIRCLE - T_LENGTH);
+	y2 = sinf(dot_product) * (Radius - T_OFFSET_FROM_CIRCLE - T_LENGTH);
+	x2 = cosf(dot_product) * (Radius - T_OFFSET_FROM_CIRCLE - T_LENGTH);
 
 	y2 += position[1];
 	x2 += position[0];
@@ -2790,10 +2790,10 @@ void HudGaugeOrientationTee::renderOrientation(object *from_objp, object *to_obj
 	x2 += HUD_offset_x;
 	y2 += HUD_offset_y;
 
-	x3 = x1 - T_BASE_LENGTH * (float)sin(dot_product);
-	y3 = y1 + T_BASE_LENGTH * (float)cos(dot_product);
-	x4 = x1 + T_BASE_LENGTH * (float)sin(dot_product);
-	y4 = y1 - T_BASE_LENGTH * (float)cos(dot_product);
+	x3 = x1 - T_BASE_LENGTH * sinf(dot_product);
+	y3 = y1 + T_BASE_LENGTH * cosf(dot_product);
+	x4 = x1 + T_BASE_LENGTH * sinf(dot_product);
+	y4 = y1 - T_BASE_LENGTH * cosf(dot_product);
 
 	// HACK! Should be antialiased!
 	renderLine(fl2i(x3),fl2i(y3),fl2i(x4),fl2i(y4));	// bottom of T
@@ -2935,8 +2935,8 @@ void HudGaugeReticleTriangle::renderTriangleMissileTail(float ang, float xpos, f
 
 	float max_tail_len=20.0f;
 
-	sin_ang=(float)sin(ang);
-	cos_ang=(float)cos(ang);
+	sin_ang=sinf(ang);
+	cos_ang=cosf(ang);
 
 	if ( cur_dist < Min_warning_missile_dist ) {
 		tail_len = 0.0f;
@@ -3040,8 +3040,8 @@ void HudGaugeReticleTriangle::renderTriangle(vec3d *hostile_pos, int aspect_flag
 	unsize( &hostile_vertex.world.xyz.x, &hostile_vertex.world.xyz.y );
 
 	ang = atan2_safe(hostile_vertex.world.xyz.y,hostile_vertex.world.xyz.x);
-	sin_ang=(float)sin(ang);
-	cos_ang=(float)cos(ang);
+	sin_ang=sinf(ang);
+	cos_ang=cosf(ang);
 	
 	if ( draw_inside ) {
 		xpos = position[0] + cos_ang*(Radius-7);

--- a/code/lab/lab.cpp
+++ b/code/lab/lab.cpp
@@ -835,8 +835,8 @@ void labviewer_render_model(float frametime)
 	int mx, my;
 	mouse_get_pos( &mx, &my );
 	light_dir.xyz.y = 0.0000001f;
-	light_dir.xyz.x = sin(my/150.0f);
-	light_dir.xyz.z = cos(my/150.0f);
+	light_dir.xyz.x = sinf(my/150.0f);
+	light_dir.xyz.z = cosf(my/150.0f);
 	vm_vec_normalize(&light_dir);
 	vm_vec_scale(&light_dir, mx*10.1f);
 	light_add_point(&light_dir,1,mx*10.2f+0.1f, 0.5f, 1.0f, 1.0f, 1.0f,-1);

--- a/code/math/vecmat.cpp
+++ b/code/math/vecmat.cpp
@@ -62,7 +62,7 @@ bool vm_matrix_equal(const matrix4 &self, const matrix4 &other)
 // -----------------------------------------------------------
 // atan2_safe()
 //
-// Wrapper around atan2() that used atan() to calculate angle.  Safe
+// Wrapper around atan2() that used atanf() to calculate angle.  Safe
 // for optimized builds.  Handles special cases when x == 0.
 //
 float atan2_safe(float y, float x)
@@ -81,7 +81,7 @@ float atan2_safe(float y, float x)
 		return ang;
 	}
 	
-	ang = (float)atan(y/x);
+	ang = atanf(y/x);
 	if ( x < 0.0f ){
 		ang += PI;
 	}
@@ -1075,7 +1075,7 @@ angles *vm_extract_angles_matrix_alternate(angles *a, const matrix *m)
 	} else if (sp >= 1.0f) {
 		a->p = PI_2;	// pi/2
 	} else {
-		a->p = asin(sp);
+		a->p = asinf(sp);
 	}
 
 	// Check for the Gimbal lock case, giving a slight tolerance

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -6552,7 +6552,7 @@ int mission_set_arrival_location(int anchor, int location, int dist, int objnum,
 			// cool function by MK to give a reasonable random vector "in front" of a ship
 			// rvec and uvec are the right and up vectors.
 			// If these are not available, this would be an expensive method.
-			x = (float)cos(fl_radians(45.0f));
+			x = cosf(fl_radians(45.0f));
 			if ( Game_mode & GM_NORMAL ) {
 				r1 = rand() < RAND_MAX_2 ? -1 : 1;
 				r2 = rand() < RAND_MAX_2 ? -1 : 1;

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -6552,7 +6552,7 @@ int mission_set_arrival_location(int anchor, int location, int dist, int objnum,
 			// cool function by MK to give a reasonable random vector "in front" of a ship
 			// rvec and uvec are the right and up vectors.
 			// If these are not available, this would be an expensive method.
-			x = (float)cos(ANG_TO_RAD(45));
+			x = (float)cos(fl_radians(45.0f));
 			if ( Game_mode & GM_NORMAL ) {
 				r1 = rand() < RAND_MAX_2 ? -1 : 1;
 				r2 = rand() < RAND_MAX_2 ? -1 : 1;

--- a/code/model/modelinterp.cpp
+++ b/code/model/modelinterp.cpp
@@ -1927,8 +1927,8 @@ int model_get_rotated_bitmap_points(vertex *pnt,float angle, float rad, vertex *
 
 	Assert( G3_count == 1 );
 		
-	sa = (float)sin(angle);
-	ca = (float)cos(angle);
+	sa = sinf(angle);
+	ca = cosf(angle);
 
 	float width, height;
 

--- a/code/model/modelread.cpp
+++ b/code/model/modelread.cpp
@@ -577,7 +577,7 @@ static void set_subsystem_info(int model_num, model_subsystem *subsystemp, char 
 		else
 			strcpy_s(buf,"180");
 		angle = fl_radians(atoi(buf))/2.0f;
-		subsystemp->turret_fov = (float)cos(angle);
+		subsystemp->turret_fov = cosf(angle);
 		subsystemp->turret_num_firing_points = 0;
 
 		if ( (p = strstr(props, "$crewspot")) != NULL) {
@@ -3667,9 +3667,9 @@ void submodel_look_at(polymodel *pm, int mn)
 	vm_vec_cross(&c, &l, &mp);
 	float dot=vm_vec_dot(&l,&mp);
 	if (dot>=0.0f) {
-		*a = asin(c.a1d[axis]);
+		*a = asinf(c.a1d[axis]);
 	} else {
-		*a = PI-asin(c.a1d[axis]);
+		*a = PI-asinf(c.a1d[axis]);
 	}
 
 	if (*a > PI2 ) {
@@ -3961,7 +3961,7 @@ int model_rotate_gun(int model_num, model_subsystem *turret, matrix *orient, ang
 //	vm_extract_angles_vector(&desired_angles, &of_dst);
 	
 	if (reset == false) {
-		desired_angles.p = (float)acos(of_dst.xyz.z);
+		desired_angles.p = acosf(of_dst.xyz.z);
 		desired_angles.h = PI - atan2_safe(of_dst.xyz.x, of_dst.xyz.y);
 		desired_angles.b = 0.0f;
 	} else {
@@ -5717,8 +5717,8 @@ void parse_glowpoint_table(const char *filename)
 
 					if (optional_string("$Cone angle:")) {
 						stuff_float(&gpo.cone_angle);
-						gpo.cone_inner_angle = cos((gpo.cone_angle - ((gpo.cone_angle < 20.0f) ? gpo.cone_angle*0.5f : 20.0f)) / 180.0f * PI);
-						gpo.cone_angle = cos(gpo.cone_angle / 180.0f * PI);
+						gpo.cone_inner_angle = cosf((gpo.cone_angle - ((gpo.cone_angle < 20.0f) ? gpo.cone_angle*0.5f : 20.0f)) / 180.0f * PI);
+						gpo.cone_angle = cosf(gpo.cone_angle / 180.0f * PI);
 					}
 
 					required_string("$Cone direction:");

--- a/code/model/modelread.cpp
+++ b/code/model/modelread.cpp
@@ -576,7 +576,7 @@ static void set_subsystem_info(int model_num, model_subsystem *subsystemp, char 
 			get_user_prop_value(p+4, buf);			// get the value of the fov
 		else
 			strcpy_s(buf,"180");
-		angle = ANG_TO_RAD(atoi(buf))/2.0f;
+		angle = fl_radians(atoi(buf))/2.0f;
 		subsystemp->turret_fov = (float)cos(angle);
 		subsystemp->turret_num_firing_points = 0;
 

--- a/code/network/multimsgs.cpp
+++ b/code/network/multimsgs.cpp
@@ -7994,7 +7994,7 @@ void process_beam_fired_packet(ubyte *data, header *hinfo)
 		shipp->beam_sys_info.model_num = Ship_info[shipp->ship_info_index].model_num;
 		shipp->beam_sys_info.turret_gun_sobj = pm->detail[0];
 		shipp->beam_sys_info.turret_num_firing_points = 1;
-		shipp->beam_sys_info.turret_fov = (float)cos((field_of_fire != 0.0f) ? field_of_fire : 180);
+		shipp->beam_sys_info.turret_fov = cosf((field_of_fire != 0.0f) ? field_of_fire : 180);
 		shipp->beam_sys_info.pnt = fire_info.targeting_laser_offset;
 		shipp->beam_sys_info.turret_firing_point[0] = fire_info.targeting_laser_offset;
 

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -15351,7 +15351,7 @@ int sexp_facing(int node)
 	vm_vec_normalize(&v2);
 
 	a1 = vm_vec_dot(&v1, &v2);
-	a2 = (float) cos(fl_radians(angle));
+	a2 = cosf(fl_radians(angle));
 	if (a1 >= a2){
 		return SEXP_TRUE;
 	}
@@ -15411,7 +15411,7 @@ int sexp_is_facing(int node)
 	vm_vec_normalize(&v2);
 
 	a1 = vm_vec_dot(&v1, &v2);
-	a2 = (float) cos(fl_radians(angle));
+	a2 = cosf(fl_radians(angle));
 	if (a1 >= a2){
 		return SEXP_TRUE;
 	}
@@ -15447,7 +15447,7 @@ int sexp_facing2(int node)
 	vm_vec_sub(&v2, wp_list->get_waypoints().front().get_pos(), &Player_obj->pos);
 	vm_vec_normalize(&v2);
 	a1 = vm_vec_dot(&v1, &v2);
-	a2 = (float) cos(fl_radians(atof(CTEXT(CDR(node)))));
+	a2 = cosf(fl_radians(atof(CTEXT(CDR(node)))));
 	if (a1 >= a2){
 		return SEXP_TRUE;
 	}

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -15351,7 +15351,7 @@ int sexp_facing(int node)
 	vm_vec_normalize(&v2);
 
 	a1 = vm_vec_dot(&v1, &v2);
-	a2 = (float) cos(ANG_TO_RAD(angle));
+	a2 = (float) cos(fl_radians(angle));
 	if (a1 >= a2){
 		return SEXP_TRUE;
 	}
@@ -15411,7 +15411,7 @@ int sexp_is_facing(int node)
 	vm_vec_normalize(&v2);
 
 	a1 = vm_vec_dot(&v1, &v2);
-	a2 = (float) cos(ANG_TO_RAD(angle));
+	a2 = (float) cos(fl_radians(angle));
 	if (a1 >= a2){
 		return SEXP_TRUE;
 	}
@@ -15447,7 +15447,7 @@ int sexp_facing2(int node)
 	vm_vec_sub(&v2, wp_list->get_waypoints().front().get_pos(), &Player_obj->pos);
 	vm_vec_normalize(&v2);
 	a1 = vm_vec_dot(&v1, &v2);
-	a2 = (float) cos(ANG_TO_RAD(atof(CTEXT(CDR(node)))));
+	a2 = (float) cos(fl_radians(atof(CTEXT(CDR(node)))));
 	if (a1 >= a2){
 		return SEXP_TRUE;
 	}

--- a/code/radar/radar.cpp
+++ b/code/radar/radar.cpp
@@ -367,7 +367,7 @@ void HudGaugeRadarStd::plotBlip(blip *b, int *x, int *y)
 	if (b->dist < pos->xyz.z) {
 		rscale = 0.0f;
 	} else {
-		rscale = (float) acos(pos->xyz.z / b->dist) / PI;		//2.0f;	 
+		rscale = (float) acosf(pos->xyz.z / b->dist) / PI;		//2.0f;	 
 	}
 
 	zdist = fl_sqrt((pos->xyz.x * pos->xyz.x) + (pos->xyz.y * pos->xyz.y));

--- a/code/radar/radarorb.cpp
+++ b/code/radar/radarorb.cpp
@@ -59,8 +59,8 @@ HudGaugeRadar(HUD_OBJECT_RADAR_ORB, 255, 255, 255)
 	
     for (i=0; i < NUM_ORB_RING_SLICES; i++)
     {
-        s=(float)sin(float(i*PI2)/NUM_ORB_RING_SLICES);
-        c=(float)cos(float(i*PI2)/NUM_ORB_RING_SLICES);
+        s=sinf(float(i*PI2)/NUM_ORB_RING_SLICES);
+        c=cosf(float(i*PI2)/NUM_ORB_RING_SLICES);
 
         orb_ring_xy[i].xyz.x = c;
         orb_ring_xy[i].xyz.y = s;
@@ -412,7 +412,7 @@ int HudGaugeRadarOrb::calcAlpha(vec3d* pt)
     vm_vec_normalize(&new_pt);
 
     float dot = vm_vec_dot(&fvec, &new_pt);
-    float angle = fabs(acos(dot));
+    float angle = fabs(acosf(dot));
     int alpha = int(angle*192.0f/PI);
     
     return alpha;

--- a/code/render/3ddraw.cpp
+++ b/code/render/3ddraw.cpp
@@ -861,8 +861,8 @@ int g3_draw_rotated_bitmap(vertex *pnt,float angle, float rad,uint tmap_flags, f
 	else if ( angle > PI2 )
 		angle -= PI2;
 			
-	sa = (float)sin(angle);
-	ca = (float)cos(angle);
+	sa = sinf(angle);
+	ca = cosf(angle);
 
 	float width, height;
 
@@ -1084,8 +1084,8 @@ float g3_draw_rotated_bitmap_area(vertex *pnt,float angle, float rad,uint tmap_f
 		angle -= PI2;
 	}
 			
-	sa = (float)sin(angle);
-	ca = (float)cos(angle);
+	sa = sinf(angle);
+	ca = cosf(angle);
 
 	float width, height;
 
@@ -1420,12 +1420,12 @@ void stars_project_2d_onto_sphere( vec3d *pnt, float rho, float phi, float theta
 {		
 	float a = PI * phi;
 	float b = PI2 * theta;
-	float sin_a = (float)sin(a);	
+	float sin_a = sinf(a);	
 
 	// coords
-	pnt->xyz.z = rho * sin_a * (float)cos(b);
-	pnt->xyz.y = rho * sin_a * (float)sin(b);
-	pnt->xyz.x = rho * (float)cos(a);
+	pnt->xyz.z = rho * sin_a * cosf(b);
+	pnt->xyz.y = rho * sin_a * sinf(b);
+	pnt->xyz.x = rho * cosf(a);
 }
 
 // draw a perspective bitmap based on angles and radius

--- a/code/render/3dlaser.cpp
+++ b/code/render/3dlaser.cpp
@@ -215,8 +215,8 @@ float g3_draw_laser(const vec3d *headp, float head_width, const vec3d *tailp, fl
 
 	float sa, ca;
 
-	sa = (float)sin(a);
-	ca = (float)cos(a);
+	sa = sinf(a);
+	ca = cosf(a);
 
 	vertex v[4];
 	vertex *vertlist[4] = { &v[3], &v[2], &v[1], &v[0] };
@@ -364,8 +364,8 @@ float g3_draw_laser_rgb(const vec3d *headp, float head_width, const vec3d *tailp
 
 	float sa, ca;
 
-	sa = (float)sin(a);
-	ca = (float)cos(a);
+	sa = sinf(a);
+	ca = cosf(a);
 
 	vertex v[4];
 	vertex *vertlist[4] = { &v[3], &v[2], &v[1], &v[0] };

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -2524,17 +2524,17 @@ int parse_ship_values(ship_info* sip, const bool is_template, const bool first_t
 		if(optional_string("+Landing Max Angle:")) {
 			float degrees;
 			stuff_float(&degrees);
-			sip->collision_physics.landing_max_angle = cos(fl_radians(90.0f - degrees));
+			sip->collision_physics.landing_max_angle = cosf(fl_radians(90.0f - degrees));
 		}
 		if(optional_string("+Landing Min Angle:")) {
 			float degrees;
 			stuff_float(&degrees);
-			sip->collision_physics.landing_min_angle = cos(fl_radians(90.0f - degrees));
+			sip->collision_physics.landing_min_angle = cosf(fl_radians(90.0f - degrees));
 		}
 		if(optional_string("+Landing Max Rotate Angle:")) {
 			float degrees;
 			stuff_float(&degrees);
-			sip->collision_physics.landing_max_rot_angle = cos(fl_radians(90.0f - degrees));
+			sip->collision_physics.landing_max_rot_angle = cosf(fl_radians(90.0f - degrees));
 		}
 		if(optional_string("+Reorient Max Forward Vel:")) {
 			stuff_float(&sip->collision_physics.reorient_max_z);
@@ -2552,17 +2552,17 @@ int parse_ship_values(ship_info* sip, const bool is_template, const bool first_t
 		if(optional_string("+Reorient Max Angle:")) {
 			float degrees;
 			stuff_float(&degrees);
-			sip->collision_physics.reorient_max_angle = cos(fl_radians(90.0f - degrees));
+			sip->collision_physics.reorient_max_angle = cosf(fl_radians(90.0f - degrees));
 		}
 		if(optional_string("+Reorient Min Angle:")) {
 			float degrees;
 			stuff_float(&degrees);
-			sip->collision_physics.reorient_min_angle = cos(fl_radians(90.0f - degrees));
+			sip->collision_physics.reorient_min_angle = cosf(fl_radians(90.0f - degrees));
 		}
 		if(optional_string("+Reorient Max Rotate Angle:")) {
 			float degrees;
 			stuff_float(&degrees);
-			sip->collision_physics.reorient_max_rot_angle = cos(fl_radians(90.0f - degrees));
+			sip->collision_physics.reorient_max_rot_angle = cosf(fl_radians(90.0f - degrees));
 		}
 		if(optional_string("+Reorient Speed Mult:")) {
 			stuff_float(&sip->collision_physics.reorient_mult);
@@ -2570,7 +2570,7 @@ int parse_ship_values(ship_info* sip, const bool is_template, const bool first_t
 		if(optional_string("+Landing Rest Angle:")) {
 			float degrees;
 			stuff_float(&degrees);
-			sip->collision_physics.landing_rest_angle = cos(fl_radians(90.0f - degrees));
+			sip->collision_physics.landing_rest_angle = cosf(fl_radians(90.0f - degrees));
 		}
 		parse_sound("+Landing Sound:", &sip->collision_physics.landing_sound_idx, sip->name);
 	}
@@ -4202,7 +4202,7 @@ int parse_ship_values(ship_info* sip, const bool is_template, const bool first_t
 				stuff_int(&value);
 				CAP(value, 0, 90);
 				float angle = fl_radians(90 - value);
-				sp->turret_max_fov = (float)cos(angle);
+				sp->turret_max_fov = cosf(angle);
 			}
 
 			if(optional_string("$Turret Base FOV:")) {
@@ -4210,7 +4210,7 @@ int parse_ship_values(ship_info* sip, const bool is_template, const bool first_t
 				stuff_int(&value);
 				CAP(value, 0, 359);
 				float angle = fl_radians(value)/2.0f;
-				sp->turret_y_fov = (float)cos(angle);
+				sp->turret_y_fov = cosf(angle);
 				turret_has_base_fov = true;
 			}
 
@@ -11111,7 +11111,7 @@ int ship_fire_primary(object * obj, int stream_weapons, int force)
 				shipp->beam_sys_info.model_num = sip->model_num;
 				shipp->beam_sys_info.turret_gun_sobj = pm->detail[0];
 				shipp->beam_sys_info.turret_num_firing_points = 1;  // dummy turret info is used per firepoint
-				shipp->beam_sys_info.turret_fov = (float)cos((winfo_p->field_of_fire != 0.0f)?winfo_p->field_of_fire:180);
+				shipp->beam_sys_info.turret_fov = cosf((winfo_p->field_of_fire != 0.0f)?winfo_p->field_of_fire:180);
 
 				shipp->fighter_beam_turret_data.disruption_timestamp = timestamp(0);
 				shipp->fighter_beam_turret_data.turret_next_fire_pos = 0;

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -2524,17 +2524,17 @@ int parse_ship_values(ship_info* sip, const bool is_template, const bool first_t
 		if(optional_string("+Landing Max Angle:")) {
 			float degrees;
 			stuff_float(&degrees);
-			sip->collision_physics.landing_max_angle = cos(ANG_TO_RAD(90 - degrees));
+			sip->collision_physics.landing_max_angle = cos(fl_radians(90.0f - degrees));
 		}
 		if(optional_string("+Landing Min Angle:")) {
 			float degrees;
 			stuff_float(&degrees);
-			sip->collision_physics.landing_min_angle = cos(ANG_TO_RAD(90 - degrees));
+			sip->collision_physics.landing_min_angle = cos(fl_radians(90.0f - degrees));
 		}
 		if(optional_string("+Landing Max Rotate Angle:")) {
 			float degrees;
 			stuff_float(&degrees);
-			sip->collision_physics.landing_max_rot_angle = cos(ANG_TO_RAD(90 - degrees));
+			sip->collision_physics.landing_max_rot_angle = cos(fl_radians(90.0f - degrees));
 		}
 		if(optional_string("+Reorient Max Forward Vel:")) {
 			stuff_float(&sip->collision_physics.reorient_max_z);
@@ -2552,17 +2552,17 @@ int parse_ship_values(ship_info* sip, const bool is_template, const bool first_t
 		if(optional_string("+Reorient Max Angle:")) {
 			float degrees;
 			stuff_float(&degrees);
-			sip->collision_physics.reorient_max_angle = cos(ANG_TO_RAD(90 - degrees));
+			sip->collision_physics.reorient_max_angle = cos(fl_radians(90.0f - degrees));
 		}
 		if(optional_string("+Reorient Min Angle:")) {
 			float degrees;
 			stuff_float(&degrees);
-			sip->collision_physics.reorient_min_angle = cos(ANG_TO_RAD(90 - degrees));
+			sip->collision_physics.reorient_min_angle = cos(fl_radians(90.0f - degrees));
 		}
 		if(optional_string("+Reorient Max Rotate Angle:")) {
 			float degrees;
 			stuff_float(&degrees);
-			sip->collision_physics.reorient_max_rot_angle = cos(ANG_TO_RAD(90 - degrees));
+			sip->collision_physics.reorient_max_rot_angle = cos(fl_radians(90.0f - degrees));
 		}
 		if(optional_string("+Reorient Speed Mult:")) {
 			stuff_float(&sip->collision_physics.reorient_mult);
@@ -2570,7 +2570,7 @@ int parse_ship_values(ship_info* sip, const bool is_template, const bool first_t
 		if(optional_string("+Landing Rest Angle:")) {
 			float degrees;
 			stuff_float(&degrees);
-			sip->collision_physics.landing_rest_angle = cos(ANG_TO_RAD(90 - degrees));
+			sip->collision_physics.landing_rest_angle = cos(fl_radians(90.0f - degrees));
 		}
 		parse_sound("+Landing Sound:", &sip->collision_physics.landing_sound_idx, sip->name);
 	}
@@ -4201,7 +4201,7 @@ int parse_ship_values(ship_info* sip, const bool is_template, const bool first_t
 				int value;
 				stuff_int(&value);
 				CAP(value, 0, 90);
-				float angle = ANG_TO_RAD((float) (90 - value));
+				float angle = fl_radians(90 - value);
 				sp->turret_max_fov = (float)cos(angle);
 			}
 
@@ -4209,7 +4209,7 @@ int parse_ship_values(ship_info* sip, const bool is_template, const bool first_t
 				int value;
 				stuff_int(&value);
 				CAP(value, 0, 359);
-				float angle = ANG_TO_RAD((float) value)/2.0f;
+				float angle = fl_radians(value)/2.0f;
 				sp->turret_y_fov = (float)cos(angle);
 				turret_has_base_fov = true;
 			}

--- a/code/ship/shipfx.cpp
+++ b/code/ship/shipfx.cpp
@@ -3041,7 +3041,7 @@ void engine_wash_ship_process(ship *shipp)
 							vm_vec_normalize(&apex_to_ship);
 
 							// check if inside cone angle
-							if (vm_vec_dot(&apex_to_ship, &world_thruster_norm) > cos(half_angle)) {
+							if (vm_vec_dot(&apex_to_ship, &world_thruster_norm) > cosf(half_angle)) {
 								vm_vec_cross(&temp, &world_thruster_norm, &thruster_to_ship);
 								vm_vec_scale_add2(&shipp->wash_rot_axis, &temp, dot_to_ship / dist_sqr);
 								ship_intensity += (1.0f - dist_sqr / (max_wash_dist*max_wash_dist));

--- a/code/starfield/nebula.cpp
+++ b/code/starfield/nebula.cpp
@@ -60,8 +60,8 @@ void project_2d_onto_sphere( vec3d *pnt, float u, float v )
 	a = PI * (2.0f * u - 1.0f );
 	z = 2.0f * v - 1.0f;	
 	s = scale_factor * fl_sqrt( 1.0f - z*z );
-	x = s * (float)cos(a);
-	y = s * (float)sin(a);
+	x = s * cosf(a);
+	y = s * sinf(a);
 	pnt->xyz.x = x;
 	pnt->xyz.y = y;
 	pnt->xyz.z = z;

--- a/code/starfield/nebula.cpp
+++ b/code/starfield/nebula.cpp
@@ -134,9 +134,9 @@ void nebula_init( const char *filename, int pitch, int bank, int heading )
 {
 	angles a;
 
-	a.p = ANG_TO_RAD((float) pitch);
-	a.b = ANG_TO_RAD((float) bank);
-	a.h = ANG_TO_RAD((float) heading);
+	a.p = fl_radians(pitch);
+	a.b = fl_radians(bank);
+	a.h = fl_radians(heading);
 	nebula_init(filename, &a);
 }
 

--- a/code/weapon/beam.cpp
+++ b/code/weapon/beam.cpp
@@ -3411,7 +3411,7 @@ float beam_get_cone_dot(beam *b)
 	case BEAM_TYPE_D:
 	case BEAM_TYPE_E:
 		// even though these beams don't move, return a _very_ small value
-		return (float)cos(fl_radians(50.5f));
+		return cosf(fl_radians(50.5f));
 		
 	case BEAM_TYPE_B:
 		return vm_vec_dot(&b->binfo.dir_a, &b->binfo.dir_b);

--- a/code/weapon/swarm.cpp
+++ b/code/weapon/swarm.cpp
@@ -18,7 +18,7 @@
 
 
 
-#define SWARM_DIST_OFFSET			2.0		// distance swarm missile should vary from original path
+#define SWARM_DIST_OFFSET			2.0f		// distance swarm missile should vary from original path
 #define SWARM_CONE_LENGTH			10000.0f	// used to pick a target point far in the distance
 #define SWARM_CHANGE_DIR_TIME		400		// time to force change in direction of swarm missile
 #define SWARM_ANGLE_CHANGE			(4*PI/180)			// in rad
@@ -243,9 +243,9 @@ void swarm_update_direction(object *objp, float frametime)
 			missile_speed = pi->speed;
 			missile_dist	= missile_speed * swarmp->change_time/1000.0f;
 			if ( missile_dist < SWARM_DIST_OFFSET ) {
-				missile_dist=i2fl(SWARM_DIST_OFFSET);
+				missile_dist = SWARM_DIST_OFFSET;
 			}
-			swarmp->angle_offset = (float)(asin(SWARM_DIST_OFFSET / missile_dist));
+			swarmp->angle_offset = asinf(SWARM_DIST_OFFSET / missile_dist);
 			Assert(!_isnan(swarmp->angle_offset) );
 		}
 
@@ -264,9 +264,9 @@ void swarm_update_direction(object *objp, float frametime)
 			missile_speed = pi->speed;
 			missile_dist = missile_speed * swarmp->change_time/1000.0f;
 			if ( missile_dist < SWARM_DIST_OFFSET ) {
-				missile_dist = i2fl(SWARM_DIST_OFFSET);
+				missile_dist = SWARM_DIST_OFFSET;
 			}
-			swarmp->angle_offset = (float)(asin(SWARM_DIST_OFFSET / missile_dist));
+			swarmp->angle_offset = asinf(SWARM_DIST_OFFSET / missile_dist);
 			Assert(!_isnan(swarmp->angle_offset) );
 		}
 
@@ -280,7 +280,7 @@ void swarm_update_direction(object *objp, float frametime)
 			goto swarm_new_target_calced;
 		}
 
-		radius = (float)tan(swarmp->angle_offset) * target_dist;
+		radius = tanf(swarmp->angle_offset) * target_dist;
 		vec3d rvec_component, uvec_component;
 
 		swarmp->change_count++;

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -1615,7 +1615,7 @@ int parse_weapon(int subtype, bool replace, const char *filename)
 
 			if(optional_string("+View Cone:")) {
 				stuff_float(&view_cone_angle);
-				wip->fov = (float)cos((float)(ANG_TO_RAD(view_cone_angle/2.0f)));
+				wip->fov = (float)cos(fl_radians(view_cone_angle * 0.5f));
 			}
 
 			if (optional_string("+Seeker Strength:"))
@@ -1656,7 +1656,7 @@ int parse_weapon(int subtype, bool replace, const char *filename)
 			if(optional_string("+View Cone:")) {
 				float	view_cone_angle;
 				stuff_float(&view_cone_angle);
-				wip->fov = (float)cos((float)(ANG_TO_RAD(view_cone_angle/2.0f)));
+				wip->fov = (float)cos(fl_radians(view_cone_angle * 0.5f));
 			}
 
 			if(optional_string("+Min Lock Time:")) {			// minimum time (in seconds) to achieve lock

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -1615,7 +1615,7 @@ int parse_weapon(int subtype, bool replace, const char *filename)
 
 			if(optional_string("+View Cone:")) {
 				stuff_float(&view_cone_angle);
-				wip->fov = (float)cos(fl_radians(view_cone_angle * 0.5f));
+				wip->fov = cosf(fl_radians(view_cone_angle * 0.5f));
 			}
 
 			if (optional_string("+Seeker Strength:"))


### PR DESCRIPTION
These proposed changes are based on observations in the executable built for Ubuntu 15.04 using the GCC 5.2 compiler. Although I have not checked this against other compilers, I don't expect these proposed changes to have a negative impact with them.

When invoking the standard trig functions (sin, cos, tan, asin, acos, and atan), unless the single precision form (sinf, cosf, tanf, asinf, acosf, atanf) were explicitly used, the compiler would generate code to convert the parameter to a double precision float (using cvtss2sd), call the slower double precision version of the trig function and then convert the result back from double precision back to single precision (using cvtsd2ss).  This seemed like unnecessary overhead.

In the third patch (hud: Simplify HudGaugeLock ....), I happened to notice that employing a simple trig identity allowed the compiler to generate one call to sincosf() instead of two.