### PR TITLE
Make VS 2013 and 2015 use the copy of gc.exe like 2010 does.

### DIFF
--- a/projects/MSVC_2013/code.vcxproj
+++ b/projects/MSVC_2013/code.vcxproj
@@ -1070,21 +1070,21 @@
   </ItemGroup>
   <ItemGroup>
     <CustomBuild Include="..\..\code\sound\phrases.xml">
-      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">gc /O "$(IntDir)voicer\%(Filename).cfg" /H "$(IntDir)voicer\grammar.h" "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">"%(RootDir)%(Directory)gc" /O "$(IntDir)voicer\%(Filename).cfg" /H "$(IntDir)voicer\grammar.h" "%(RootDir)%(Directory)%(Filename)"</Command>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(IntDir)voicer\%(Filename).cfg;$(IntDir)voicer\grammar.h;%(Outputs)</Outputs>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Debug AVX|Win32'">gc /O "$(IntDir)voicer\%(Filename).cfg" /H "$(IntDir)voicer\grammar.h" "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug AVX|Win32'">"%(RootDir)%(Directory)gc" /O "$(IntDir)voicer\%(Filename).cfg" /H "$(IntDir)voicer\grammar.h" "%(RootDir)%(Directory)%(Filename)"</Command>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug AVX|Win32'">$(IntDir)voicer\%(Filename).cfg;$(IntDir)voicer\grammar.h;%(Outputs)</Outputs>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Debug SSE|Win32'">gc /O "$(IntDir)voicer\%(Filename).cfg" /H "$(IntDir)voicer\grammar.h" "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug SSE|Win32'">"%(RootDir)%(Directory)gc" /O "$(IntDir)voicer\%(Filename).cfg" /H "$(IntDir)voicer\grammar.h" "%(RootDir)%(Directory)%(Filename)"</Command>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug SSE|Win32'">$(IntDir)voicer\%(Filename).cfg;$(IntDir)voicer\grammar.h;%(Outputs)</Outputs>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Debug SSE2|Win32'">gc /O "$(IntDir)voicer\%(Filename).cfg" /H "$(IntDir)voicer\grammar.h" "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug SSE2|Win32'">"%(RootDir)%(Directory)gc" /O "$(IntDir)voicer\%(Filename).cfg" /H "$(IntDir)voicer\grammar.h" "%(RootDir)%(Directory)%(Filename)"</Command>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug SSE2|Win32'">$(IntDir)voicer\%(Filename).cfg;$(IntDir)voicer\grammar.h;%(Outputs)</Outputs>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">gc /O "$(IntDir)voicer\%(Filename).cfg" /H "$(IntDir)voicer\grammar.h" "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">"%(RootDir)%(Directory)gc" /O "$(IntDir)voicer\%(Filename).cfg" /H "$(IntDir)voicer\grammar.h" "%(RootDir)%(Directory)%(Filename)"</Command>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(IntDir)voicer\%(Filename).cfg;$(IntDir)voicer\grammar.h;%(Outputs)</Outputs>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Release AVX|Win32'">gc /O "$(IntDir)voicer\%(Filename).cfg" /H "$(IntDir)voicer\grammar.h" "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release AVX|Win32'">"%(RootDir)%(Directory)gc" /O "$(IntDir)voicer\%(Filename).cfg" /H "$(IntDir)voicer\grammar.h" "%(RootDir)%(Directory)%(Filename)"</Command>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Release AVX|Win32'">$(IntDir)voicer\%(Filename).cfg;$(IntDir)voicer\grammar.h;%(Outputs)</Outputs>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Release SSE|Win32'">gc /O "$(IntDir)voicer\%(Filename).cfg" /H "$(IntDir)voicer\grammar.h" "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release SSE|Win32'">"%(RootDir)%(Directory)gc" /O "$(IntDir)voicer\%(Filename).cfg" /H "$(IntDir)voicer\grammar.h" "%(RootDir)%(Directory)%(Filename)"</Command>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Release SSE|Win32'">$(IntDir)voicer\%(Filename).cfg;$(IntDir)voicer\grammar.h;%(Outputs)</Outputs>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Release SSE2|Win32'">gc /O "$(IntDir)voicer\%(Filename).cfg" /H "$(IntDir)voicer\grammar.h" "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release SSE2|Win32'">"%(RootDir)%(Directory)gc" /O "$(IntDir)voicer\%(Filename).cfg" /H "$(IntDir)voicer\grammar.h" "%(RootDir)%(Directory)%(Filename)"</Command>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Release SSE2|Win32'">$(IntDir)voicer\%(Filename).cfg;$(IntDir)voicer\grammar.h;%(Outputs)</Outputs>
     </CustomBuild>
   </ItemGroup>

--- a/projects/MSVC_2015/code.vcxproj
+++ b/projects/MSVC_2015/code.vcxproj
@@ -1070,21 +1070,21 @@
   </ItemGroup>
   <ItemGroup>
     <CustomBuild Include="..\..\code\sound\phrases.xml">
-      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">gc /O "$(IntDir)voicer\%(Filename).cfg" /H "$(IntDir)voicer\grammar.h" "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">"%(RootDir)%(Directory)gc" /O "$(IntDir)voicer\%(Filename).cfg" /H "$(IntDir)voicer\grammar.h" "%(RootDir)%(Directory)%(Filename)"</Command>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(IntDir)voicer\%(Filename).cfg;$(IntDir)voicer\grammar.h;%(Outputs)</Outputs>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Debug AVX|Win32'">gc /O "$(IntDir)voicer\%(Filename).cfg" /H "$(IntDir)voicer\grammar.h" "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug AVX|Win32'">"%(RootDir)%(Directory)gc" /O "$(IntDir)voicer\%(Filename).cfg" /H "$(IntDir)voicer\grammar.h" "%(RootDir)%(Directory)%(Filename)"</Command>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug AVX|Win32'">$(IntDir)voicer\%(Filename).cfg;$(IntDir)voicer\grammar.h;%(Outputs)</Outputs>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Debug SSE|Win32'">gc /O "$(IntDir)voicer\%(Filename).cfg" /H "$(IntDir)voicer\grammar.h" "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug SSE|Win32'">"%(RootDir)%(Directory)gc" /O "$(IntDir)voicer\%(Filename).cfg" /H "$(IntDir)voicer\grammar.h" "%(RootDir)%(Directory)%(Filename)"</Command>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug SSE|Win32'">$(IntDir)voicer\%(Filename).cfg;$(IntDir)voicer\grammar.h;%(Outputs)</Outputs>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Debug SSE2|Win32'">gc /O "$(IntDir)voicer\%(Filename).cfg" /H "$(IntDir)voicer\grammar.h" "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug SSE2|Win32'">"%(RootDir)%(Directory)gc" /O "$(IntDir)voicer\%(Filename).cfg" /H "$(IntDir)voicer\grammar.h" "%(RootDir)%(Directory)%(Filename)"</Command>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug SSE2|Win32'">$(IntDir)voicer\%(Filename).cfg;$(IntDir)voicer\grammar.h;%(Outputs)</Outputs>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">gc /O "$(IntDir)voicer\%(Filename).cfg" /H "$(IntDir)voicer\grammar.h" "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">"%(RootDir)%(Directory)gc" /O "$(IntDir)voicer\%(Filename).cfg" /H "$(IntDir)voicer\grammar.h" "%(RootDir)%(Directory)%(Filename)"</Command>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(IntDir)voicer\%(Filename).cfg;$(IntDir)voicer\grammar.h;%(Outputs)</Outputs>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Release AVX|Win32'">gc /O "$(IntDir)voicer\%(Filename).cfg" /H "$(IntDir)voicer\grammar.h" "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release AVX|Win32'">"%(RootDir)%(Directory)gc" /O "$(IntDir)voicer\%(Filename).cfg" /H "$(IntDir)voicer\grammar.h" "%(RootDir)%(Directory)%(Filename)"</Command>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Release AVX|Win32'">$(IntDir)voicer\%(Filename).cfg;$(IntDir)voicer\grammar.h;%(Outputs)</Outputs>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Release SSE|Win32'">gc /O "$(IntDir)voicer\%(Filename).cfg" /H "$(IntDir)voicer\grammar.h" "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release SSE|Win32'">"%(RootDir)%(Directory)gc" /O "$(IntDir)voicer\%(Filename).cfg" /H "$(IntDir)voicer\grammar.h" "%(RootDir)%(Directory)%(Filename)"</Command>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Release SSE|Win32'">$(IntDir)voicer\%(Filename).cfg;$(IntDir)voicer\grammar.h;%(Outputs)</Outputs>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Release SSE2|Win32'">gc /O "$(IntDir)voicer\%(Filename).cfg" /H "$(IntDir)voicer\grammar.h" "%(RootDir)%(Directory)%(Filename)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release SSE2|Win32'">"%(RootDir)%(Directory)gc" /O "$(IntDir)voicer\%(Filename).cfg" /H "$(IntDir)voicer\grammar.h" "%(RootDir)%(Directory)%(Filename)"</Command>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Release SSE2|Win32'">$(IntDir)voicer\%(Filename).cfg;$(IntDir)voicer\grammar.h;%(Outputs)</Outputs>
     </CustomBuild>
   </ItemGroup>


### PR DESCRIPTION
Recent update to VS 2015 Community Edition appears to have removed gc.exe for some reason; the safest thing to do would seem to be to go back to using the copy of it we were already keeping around for VS 2010 Express.