### PR TITLE
Fix ping calculations in server list.

### DIFF
--- a/code/math/floating.h
+++ b/code/math/floating.h
@@ -35,8 +35,7 @@ float frand_range(float min, float max);
 #define flceil(fl) (int)ceil(fl)
 #define flfloor(fl) (int)floor(fl)
 #define f2fl(fx) ((float)(fx)/65536.0f)
-// more precise version of f2fl(), to double instead of float
-#define f2fld(fx) (((double)(fx))/65536.0)
+#define f2d(fx) (((double)(fx))/65536.0)
 #define fl2f(fl) (int)((fl)*65536.0f)
 #define fl_tan(fl) tanf(fl)
 

--- a/code/math/floating.h
+++ b/code/math/floating.h
@@ -35,6 +35,8 @@ float frand_range(float min, float max);
 #define flceil(fl) (int)ceil(fl)
 #define flfloor(fl) (int)floor(fl)
 #define f2fl(fx) ((float)(fx)/65536.0f)
+// more precise version of f2fl(), to double instead of float
+#define f2fld(fx) (((double)(fx))/65536.0)
 #define fl2f(fl) (int)((fl)*65536.0f)
 #define fl_tan(fl) tanf(fl)
 

--- a/code/network/multi_ping.cpp
+++ b/code/network/multi_ping.cpp
@@ -88,8 +88,8 @@ void multi_ping_eval_pong(ping_struct *ps, fix pong_time)
 	ping_sum = 0L;
 	for(idx=0;idx<ps->num_pings;idx++){
 		ping_sum += ps->ping_times[idx];
-	}// jg18 - IMO the slight loss of precision from the integer divide is better than the loss from premature double conversion
-	ps->ping_avg = (int)f2fld(1000L * ping_sum / (fix)ps->num_pings);
+	}
+	ps->ping_avg = (int)(f2fld(1000L * ping_sum) / (double)ps->num_pings);
 }
 
 // start a ping - call this when sending a ping packet

--- a/code/network/multi_ping.cpp
+++ b/code/network/multi_ping.cpp
@@ -89,7 +89,7 @@ void multi_ping_eval_pong(ping_struct *ps, fix pong_time)
 	for(idx=0;idx<ps->num_pings;idx++){
 		ping_sum += ps->ping_times[idx];
 	}
-	ps->ping_avg = (int)(f2fld(1000L * ping_sum) / (double)ps->num_pings);
+	ps->ping_avg = (int)(f2d(1000L * ping_sum) / (double)ps->num_pings);
 }
 
 // start a ping - call this when sending a ping packet

--- a/code/network/multi_ping.h
+++ b/code/network/multi_ping.h
@@ -24,8 +24,8 @@ struct net_player;
 #define MAX_PINGS					10
 
 typedef struct ping_struct {
-	float ping_start;										// time the current ping was sent out, or -1 if none
-	float ping_times[MAX_PINGS];						// ping times for calculating the average
+	fix ping_start;										// time the current ping was sent out, or -1 if none. using fix for higher precision
+	fix ping_times[MAX_PINGS];						// ping times for calculating the average, using precision of timer_get_fixed_seconds()
 	int num_pings;											// # of pings in the ping_times array
 	int ping_add;											// where to add the next ping
 
@@ -47,7 +47,7 @@ void multi_ping_reset(ping_struct *ps);
 void multi_ping_start(ping_struct *ps);
 
 // evaluate a pong return on the given struct
-void multi_ping_eval_pong(ping_struct *ps);
+void multi_ping_eval_pong(ping_struct *ps, fix pong_time);
 
 // send a ping to a specific player
 void multi_ping_send(net_player *p);

--- a/code/network/multimsgs.cpp
+++ b/code/network/multimsgs.cpp
@@ -3502,7 +3502,7 @@ void process_pong_packet(ubyte *data, header *hinfo)
 		p = &Net_players[lookup]; 
 
 		// evaluate the ping
-		multi_ping_eval_pong(&Net_players[lookup].s_info.ping);
+		multi_ping_eval_pong(&Net_players[lookup].s_info.ping, timer_get_fixed_seconds());
 			
 		// put in calls to any functions which may want to know about the ping times from 
 		// this guy

--- a/code/network/multiui.cpp
+++ b/code/network/multiui.cpp
@@ -1566,7 +1566,7 @@ void multi_join_eval_pong(net_addr *addr, fix pong_time)
 	if(moveup != NULL){
 		do {				
 			if(psnet_same(&moveup->server_addr,addr)){
-				multi_ping_eval_pong(&moveup->ping);
+				multi_ping_eval_pong(&moveup->ping, pong_time);
 				
 				break;
 			} else {


### PR DESCRIPTION
Fix calculations of server ping in in-game server list. Minimize floating
point calculations, using double instead of float, avoid calling timer
twice when receiving pong, and capture pong time more precisely.

Note that fix is just a typedef for long. It is the return type of timer_get_fixed_seconds().