### PR TITLE
Prevent "no collide" objects from colliding during warp sequence

### DIFF
--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -13410,7 +13410,7 @@ void ai_warp_out(object *objp)
 			aip->submode_start_time = Missiontime;
 
 			// maybe recalculate collision pairs.
-			if (ship_get_warpout_speed(objp) > ship_get_max_speed(shipp)) {
+			if ((objp->flags & OF_COLLIDES) && (ship_get_warpout_speed(objp) > ship_get_max_speed(shipp))) {
 				// recalculate collision pairs
 				OBJ_RECALC_PAIRS(objp);	
 			}


### PR DESCRIPTION
OBJ_RECALC_PAIRS unsets then sets the OF_COLLIDES flag, so when a ship
with "no collide" set on it warps out, the flag is essentially ignored
and the ship can collide during the warp sequence.