### PR TITLE
Add player minimum speed feature

### DIFF
--- a/code/playerman/playercontrol.cpp
+++ b/code/playerman/playercontrol.cpp
@@ -581,6 +581,16 @@ void read_keyboard_controls( control_info * ci, float frame_time, physics_info *
 			override_analog_throttle = 1;
 		}
 
+		// allow a minimum speed to be set for the player ship (only)
+		if ( Player_ship != nullptr && Player_ship->ship_info_index >= 0 ) {
+			float z_min = Ship_info[Player_ship->ship_info_index].min_vel.xyz.z;
+			if (z_min > 0.0f && pi->speed <= z_min) {
+				ci->forward = MAX(ci->forward, 0.0f);
+				ci->forward_cruise_percent = MAX(ci->forward_cruise_percent, z_min / Ship_info[Player_ship->ship_info_index].max_vel.xyz.z * 100.0f);
+				override_analog_throttle = 1;
+			}
+		}
+
 		// AL 12-29-97: If afterburner key is down, player should have full forward thrust (even if afterburners run out)
 		if ( check_control(AFTERBURNER) ) {
 			ci->forward = 1.0f;

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -1194,6 +1194,7 @@ public:
 	float		rotdamp;								// rotational drag
 	float		delta_bank_const;
 	vec3d	max_vel;								//	max velocity of the ship in the linear directions -- read from ships.tbl
+	vec3d	min_vel;								//	min velocity of the ship in the linear directions -- read from ships.tbl
 	vec3d	max_rotvel;							// maximum rotational velocity
 	vec3d	rotation_time;						// time to rotate in x/y/z dimension traveling at max rotvel
 	float		srotation_time;					//	scalar, computed at runtime as (rotation_time.x + rotation_time.y)/2


### PR DESCRIPTION
Allows the players ship to have a minimum speed set. If the ships speed
drops below this (per ship) value, the throttle is increased to the
minimum.
For ships that are gliding, their engines will be reactivated when the
ships overall velocity falls below the minimum speed.
Currently only sets a minimum Z speed, Y & X are ignored.

See #604 