### PR TITLE
Fix indentation warnings

### DIFF
--- a/code/cmdline/cmdline.cpp
+++ b/code/cmdline/cmdline.cpp
@@ -1568,8 +1568,8 @@ bool SetCmdlineParams()
 	if ( ship_choice_3d_arg.found() )
 		Cmdline_ship_choice_3d = 1;
 
-    if ( weapon_choice_3d_arg.found() )
-        Cmdline_weapon_choice_3d = 1;
+	if ( weapon_choice_3d_arg.found() )
+		Cmdline_weapon_choice_3d = 1;
 
 	if ( show_mem_usage_arg.found() )
 		Cmdline_show_mem_usage = 1;

--- a/code/inetfile/chttpget.cpp
+++ b/code/inetfile/chttpget.cpp
@@ -240,7 +240,7 @@ void ChttpGet::WorkerThread()
 	sprintf(szCommand,"GET %s%s HTTP/1.1\nAccept: */*\nAccept-Encoding: deflate\nHost: %s\n\n\n",m_ProxyEnabled?"":"/",m_ProxyEnabled?m_URL:m_szDir,m_szHost);
 	send(m_DataSock,szCommand,strlen(szCommand),0);
 	p = GetHTTPLine();
-if (!p) return;
+	if (!p) return;
 	if(strnicmp("HTTP/",p,5)==0)
 	{
 		char *pcode;

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -4579,7 +4579,7 @@ void parse_wing(mission *pm)
 		for ( sexp = CDR(wing_goals); sexp != -1; sexp = CDR(sexp) )
 			ai_add_wing_goal_sexp(sexp, AIG_TYPE_EVENT_WING, wingnum);  // used by Fred
 
-			free_sexp2(wing_goals);  // free up sexp nodes for reuse, since they aren't needed anymore.
+		free_sexp2(wing_goals);  // free up sexp nodes for reuse, since they aren't needed anymore.
 	}
 
 	// set the wing number for all ships in the wing


### PR DESCRIPTION
GCC 6 warns about misleading indentation because it counts tabs as 8
spaces. The rest of the code uses tabs, these lines use 4 spaces.
Replace spaces with tabs.

Whitespace changes only.