### PR TITLE
accept lua51 as pkg-config name for Lua

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -470,14 +470,12 @@ D_CFLAGS=$D_CFLAGS" $PNG_CFLAGS"
 FS2_LIBS=$FS2_LIBS" $PNG_LIBS"
 
 dnl LUA
-## Checking for lua.pc and if that fails lua5.1.pc
-PKG_CHECK_MODULES(
-	[LUA],
-	[lua >= 5.1.3 lua < 5.2],
-	[], ## do nothing special
-	[PKG_CHECK_MODULES([LUA], [lua5.1 >= 5.1.3 lua5.1 < 5.2], [], [
-        PKG_CHECK_MODULES([LUA], [lua-5.1 >= 5.1.3 lua-5.1 < 5.2], [])
-    ])])
+## Checking for lua.pc and if that fails other possible names
+PKG_CHECK_MODULES([LUA], [lua >= 5.1.3 lua < 5.2], [], [
+	PKG_CHECK_MODULES([LUA], [lua5.1 >= 5.1.3 lua5.1 < 5.2], [], [
+	PKG_CHECK_MODULES([LUA], [lua-5.1 >= 5.1.3 lua-5.1 < 5.2], [], [
+	PKG_CHECK_MODULES([LUA], [lua51 >= 5.1.3 lua51 < 5.2], [])
+	])])])
 D_CFLAGS=$D_CFLAGS" $LUA_CFLAGS"
 FS2_LIBS=$FS2_LIBS" $LUA_LIBS"
 


### PR DESCRIPTION
Build was failing at least on Arch Linux, which installs Lua 5.1 pkg-config file as lua51.pc.

Changed formatting slightly, but that can be undone if you don't like it.