### PR TITLE
Fix for #625

### DIFF
--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -1293,14 +1293,21 @@ void parse_fiction(mission *pm)
 			if (optional_string("$Formula:"))
 				stage.formula = get_sexp_main();
 
-			// now, store this stage
-			Fiction_viewer_stages.push_back(stage);
-
-			// see if this is the stage we want to display, then display it
-			if (!Fred_running && !fiction_viewer_loaded && is_sexp_true(stage.formula))
+			if (strlen(stage.story_filename) > 0)
 			{
-				fiction_viewer_load(Fiction_viewer_stages.size() - 1);
-				fiction_viewer_loaded = true;
+				// now, store this stage
+				Fiction_viewer_stages.push_back(stage);
+
+				// see if this is the stage we want to display, then display it
+				if (!Fred_running && !fiction_viewer_loaded && is_sexp_true(stage.formula))
+				{
+					fiction_viewer_load(Fiction_viewer_stages.size() - 1);
+					fiction_viewer_loaded = true;
+				}
+			}
+			else
+			{
+				error_display(0, "Fiction viewer story filename may not be empty!");
 			}
 		}
 	}

--- a/code/parse/parselo.cpp
+++ b/code/parse/parselo.cpp
@@ -1245,8 +1245,8 @@ void stuff_string(char *outstr, int type, int len, char *terminators)
 	if (type == F_FILESPEC) {
 		// Make sure that the passed string looks like a good filename
 		if (strlen(read_str) == 0) {
-			// Empty file name is not valid!
-			error_display(1, "A file name was expected but no name was supplied!\n");
+			// Empty file name is probably not valid!
+			error_display(0, "A file name was expected but no name was supplied! This is probably a mistake.");
 		}
 	}
 


### PR DESCRIPTION
The warning in the parsing code has been replaced with a log message so if a file name is missing there will be some indication that something is probably wrong.

This also adds validation for the fiction viewer filename to make sure that a non-empty file name is specified in the mission.