### PR TITLE
fix VPATH builds

### DIFF
--- a/code/Makefile.am
+++ b/code/Makefile.am
@@ -185,7 +185,7 @@ EXTRA_DIST =	\
 
 # D_ variants are defaults and should always be used
 # FS2_ variants are for game building and wxFRED
-AM_CXXFLAGS = @D_CFLAGS@ @FS2_CXXFLAGS@ -I../mongoose
+AM_CXXFLAGS = @D_CFLAGS@ @FS2_CXXFLAGS@ -I./$(VPATH)/../mongoose
 AM_LDFLAGS = @D_LDFLAGS@ @FS2_LDFLAGS@
 
 if BUILD_WXFRED


### PR DESCRIPTION
I'm quite sure that this is correct, but I'd still be reassured if some Linux users check that it doesn't break their build.

https://www.gnu.org/software/automake/manual/html_node/VPATH-Builds.html

VPATH builds were broken because mongoose.h was not found.
Makefile.am stated that it should be found in ../mongoose, which is
incorrect for VPATH builds. The search path should be relative to the
source tree ( i.e. $(VPATH) ).

Example:
mkdir -p build/debug
cd build/debug
../../autogen.sh
../../configure --enable-debug
make

The search path would then be (relative to the source tree)
build/mongoose, not ./mongoose as it should.

Fix this by changing ../mongoose to ./$(VPATH)/../mongoose.

In the previous example, $(VPATH) is ../../../code, so the search path
is now correctly ./../../../code/../mongoose.

For in-tree builds, the path was previously ../mongoose. It is now
.//../mongoose, which is equivalent.

edit: typo