### PR TITLE
Fix several problems with change_ship_type()

### DIFF
--- a/code/globalincs/pstypes.h
+++ b/code/globalincs/pstypes.h
@@ -82,6 +82,11 @@ typedef struct vec4 {
 	};
 } vec4;
 
+// sometimes, you just need some integers
+typedef struct ivec3 {
+	int x, y, z;
+} ivec3;
+
 /** Represents a point in 3d space.
 
 Note: this is a struct, not a class, so no member functions. */

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -10026,13 +10026,82 @@ void change_ship_type(int n, int ship_type, int by_sexp)
 	if (sp->ship_info_index == ship_type)
 		return;
 
+	int objnum = sp->objnum;
+
 	swp = &sp->weapons;
 	sip = &(Ship_info[ship_type]);
 	sip_orig = &Ship_info[sp->ship_info_index];
-	objp = &Objects[sp->objnum];
+	objp = &Objects[objnum];
 	p_objp = mission_parse_get_parse_object(sp->ship_name);
 	ph_inf = objp->phys_info;
 
+	// MageKing17 - See if any AIs are doing anything with subsystems of this ship (targeting, goal to destroy)
+	// keep track of those subsystems and transfer the target/goal if the subsystem still exists, delete otherwise
+
+	SCP_list<int> target_matches;	// tells us to check this Ai_info index during subsystem traversal
+
+	SCP_list<ivec3> subsystem_matches;	// Ai_info index, goal index (or -1 for targeted), subsystem index
+	// not having a subsystem index at first is why we have the target_matches list:
+	// while traversing the subsystem list, a match can be compared directly to the
+	// subsystem object, and its index added to subsystem_matches.
+
+	SCP_list<weapon*> homing_matches;	// any missiles locked on to a subsystem from this ship
+
+	SCP_list<std::pair<weapon*, int>> homing_subsystem_matches;	// When homing_matches find matches, they put them here
+
+	SCP_list<weapon*> weapon_turret_matches;	// projectiles that were fired from turrets on this ship
+
+	SCP_list<std::pair<weapon*, int>> weapon_turret_subsystem_matches;
+
+	SCP_list<int> last_targeted_matches;
+
+	SCP_list<std::pair<int, int>> last_targeted_subsystem_matches;
+
+	if (!(Fred_running) && (Game_mode & GM_IN_MISSION)) {	// Doing this effort only makes sense in the middle of a mission.
+		// Delete ship sparks if the model changed
+		if (sip_orig->model_num != sip->model_num) {
+			memset(sp->sparks, 0, MAX_SHIP_HITS * sizeof(ship_spark));
+			sp->num_hits = 0;
+		}
+
+		for (i = 0; i < MAX_AI_INFO; i++) {
+			if (Ai_info[i].shipnum > -1) {
+				if (Ai_info[i].targeted_subsys && Ai_info[i].targeted_subsys->parent_objnum == objnum) {
+					target_matches.push_back(i);
+				}
+				ai_goal* goals = Ai_info[i].goals;
+				for (int j = 0; j < MAX_AI_GOALS; j++) {
+					// POSSIBLE OPTIMIZATION: goals[0] should be the active goal, so we might be able to reuse target_subsys_parent for that instead of doing ship_name_lookup()
+					if (goals[j].ai_mode == AI_GOAL_DESTROY_SUBSYSTEM && !(goals[j].flags & AIGF_SUBSYS_NEEDS_FIXUP)) {	// If the subsystem name hasn't been parsed yet, we're fine.
+						int sindex = ship_name_lookup(goals[j].target_name);
+						if (sindex > -1 && Ships[sindex].objnum == objnum) {
+							ivec3 temp = {i, j, goals[j].ai_submode};
+							subsystem_matches.push_back(std::move(temp));
+						}
+					}
+				}
+			}
+		}
+
+		for (i = 0; i < MAX_WEAPONS; i++) {
+			if (Weapons[i].objnum == -1) {
+				continue;
+			}
+			weapon* wp = &Weapons[i];
+			if (wp->homing_subsys && wp->homing_subsys->parent_objnum == objnum) {
+				homing_matches.push_back(wp);
+			}
+			if (wp->turret_subsys && wp->turret_subsys->parent_objnum == objnum) {
+				weapon_turret_matches.push_back(wp);
+			}
+		}
+
+		for (i = 0; i < MAX_PLAYERS; i++) {
+			if (sp->last_targeted_subobject[i]) {
+				last_targeted_matches.push_back(i);
+			}
+		}
+	}
 
 	// Goober5000 - we can't copy the ship object because the tree of structs contains at least
 	// one class without a copy constructor.  So let's just save the information we need.
@@ -10089,6 +10158,74 @@ void change_ship_type(int n, int ship_type, int by_sexp)
 			break;
 		}
 
+		// MageKing17 - Update subsystem pointers if changing classes mid-mission
+		if (!(Fred_running) && (Game_mode & GM_IN_MISSION)) {
+			// If any of our AI info objects targeting a subsystem on this ship are targeting this specific
+			// subsystem, add them to the subsystem_matches vector and remove them from our "to be checked" list.
+			{
+				auto it = target_matches.begin();
+				while (it != target_matches.end()) {
+					ai_info* aip = &Ai_info[*it];
+					if (aip->targeted_subsys == ss) {
+						ivec3 temp = {*it, -1, num_saved_subsystems};	// -1 for the "goal" index means targeted, not actually a goal
+						subsystem_matches.push_back(std::move(temp));
+						aip->targeted_subsys = NULL;	// Clear this so that aip->last_subsys_target won't point to a subsystem from the old list later
+						aip->targeted_subsys_parent = -1;
+						auto erasor = it;
+						++it;
+						target_matches.erase(erasor);
+					} else {
+						++it;
+					}
+				}
+			}
+
+			// Fix any weapons homing in on this subsystem.
+			{
+				auto it = homing_matches.begin();
+				while (it != homing_matches.end()) {
+					if ((*it)->homing_subsys == ss) {
+						homing_subsystem_matches.push_back(std::make_pair(*it, num_saved_subsystems));
+						auto erasor = it;
+						++it;
+						homing_matches.erase(erasor);
+					} else {
+						++it;
+					}
+				}
+			}
+
+			// Fix any projectiles fired from this subsystem.
+			{
+				auto it = weapon_turret_matches.begin();
+				while (it != weapon_turret_matches.end()) {
+					if ((*it)->turret_subsys == ss) {
+						weapon_turret_subsystem_matches.push_back(std::make_pair(*it, num_saved_subsystems));
+						auto erasor = it;
+						++it;
+						weapon_turret_matches.erase(erasor);
+					} else {
+						++it;
+					}
+				}
+			}
+
+			// Fix any subsystems in last_targeted_matches[].
+			{
+				auto it = last_targeted_matches.begin();
+				while (it != last_targeted_matches.end()) {
+					if (sp->last_targeted_subobject[*it] == ss) {
+						last_targeted_subsystem_matches.push_back(std::make_pair(*it, num_saved_subsystems));
+						auto erasor = it;
+						++it;
+						last_targeted_matches.erase(erasor);
+					} else {
+						++it;
+					}
+				}
+			}
+		}
+
 		// save subsys information
 		subsys_names[num_saved_subsystems] = new char[NAME_LENGTH];
 		strcpy(subsys_names[num_saved_subsystems], ss->system_info->subobj_name);
@@ -10105,6 +10242,10 @@ void change_ship_type(int n, int ship_type, int by_sexp)
 		num_saved_subsystems++;
 		ss = GET_NEXT(ss);
 	}
+	Assertion(target_matches.empty(), "Failed to find matches for every currently-targeted subsystem on ship %s in change_ship_type(); get a coder!\n", sp->ship_name);
+	Assertion(homing_matches.empty(), "Failed to find matches for every subsystem being homed in on ship %s in change_ship_type(); get a coder!\n", sp->ship_name);
+	Assertion(weapon_turret_matches.empty(), "Failed to find matches for every turret a projectile was fired from on ship %s in change_ship_type(); get a coder!\n", sp->ship_name);
+	Assertion(last_targeted_matches.empty(), "Somehow failed to find every subsystem a player was previously targeting on ship %s in change_ship_type(); get a coder!\n", sp->ship_name);
 
 	// point to new ship data
 	ship_model_change(n, ship_type);
@@ -10180,6 +10321,7 @@ void change_ship_type(int n, int ship_type, int by_sexp)
 
 	// Goober5000 - restore the subsystem percentages
 	ss = GET_FIRST(&sp->subsys_list);
+	int ss_index = 0;
 	while ( ss != END_OF_LIST(&sp->subsys_list) )
 	{
 		for (i = 0; i < num_saved_subsystems; i++)
@@ -10187,13 +10329,115 @@ void change_ship_type(int n, int ship_type, int by_sexp)
 			if (!subsystem_stricmp(ss->system_info->subobj_name, subsys_names[i]))
 			{
 				ss->current_hits = ss->max_hits * subsys_pcts[i];
+
+				// MageKing17 - Every AI doing something with this subsystem must transfer to the new one.
+				{
+					auto it = subsystem_matches.begin();
+					while (it != subsystem_matches.end()) {
+						if (it->z == i) {	// the subsystem is a match
+							int goalnum = it->y;
+							ai_info* aip = &Ai_info[it->x];
+							if (goalnum == -1) {
+								set_targeted_subsys(aip, ss, n);
+							} else {
+								aip->goals[goalnum].ai_submode = ss_index;
+							}
+							auto erasor = it;
+							++it;
+							subsystem_matches.erase(erasor);
+						} else {
+							++it;
+						}
+					}
+				}
+
+				// also weapons homing in on this subsystem
+				{
+					auto it = homing_subsystem_matches.begin();
+					while (it != homing_subsystem_matches.end()) {
+						if (it->second == i) {	// the subsystem is a match
+							it->first->homing_subsys = ss;
+							auto erasor = it;
+							++it;
+							homing_subsystem_matches.erase(erasor);
+						} else {
+							++it;
+						}
+					}
+				}
+
+				// also weapons fired from this subsystem
+				{
+					auto it = weapon_turret_subsystem_matches.begin();
+					while (it != weapon_turret_subsystem_matches.end()) {
+						if (it->second == i) {
+							it->first->turret_subsys = ss;
+							auto erasor = it;
+							++it;
+							weapon_turret_subsystem_matches.erase(erasor);
+						} else {
+							++it;
+						}
+					}
+				}
+
+				// and finally, fix previously-targeted subsystems
+				{
+					auto it = last_targeted_subsystem_matches.begin();
+					while (it != last_targeted_subsystem_matches.end()) {
+						if (it->second == i) {	// the subsystem is a match
+							sp->last_targeted_subobject[it->first] = ss;
+							auto erasor = it;
+							++it;
+							last_targeted_subsystem_matches.erase(erasor);
+						} else {
+							++it;
+						}
+					}
+				}
+
 				break;
 			}
 		}
 
+		ss_index++;
 		ss = GET_NEXT(ss);
 	}
 	ship_recalc_subsys_strength(sp);
+
+	for (auto cit = subsystem_matches.cbegin(); cit != subsystem_matches.cend(); ++cit) {
+		int goalnum = cit->y;
+		ai_info* aip = &Ai_info[cit->x];
+		if (goalnum == -1) {
+			if (aip == Player_ai) {
+				hud_cease_subsystem_targeting(0);
+			} else {
+				set_targeted_subsys(aip, nullptr, -1);
+			}
+		} else {
+			ai_remove_ship_goal(aip, goalnum);
+		}
+	}
+
+	subsystem_matches.clear();	// We don't need these anymore, so may as well clear them now.
+
+	for (auto cit = homing_subsystem_matches.cbegin(); cit != homing_subsystem_matches.cend(); ++cit) {
+		cit->first->homing_subsys = nullptr;
+	}
+
+	homing_subsystem_matches.clear();
+
+	for (auto cit = weapon_turret_subsystem_matches.cbegin(); cit != weapon_turret_subsystem_matches.cend(); ++cit) {
+		cit->first->turret_subsys = nullptr;
+	}
+
+	weapon_turret_subsystem_matches.clear();
+
+	for (auto cit = last_targeted_subsystem_matches.cbegin(); cit != last_targeted_subsystem_matches.cend(); ++cit) {
+		sp->last_targeted_subobject[cit->first] = nullptr;
+	}
+
+	last_targeted_subsystem_matches.clear();
 
 	// now free the memory
 	for (i = 0; i < sip_orig->n_subsystems; i++)


### PR DESCRIPTION
This was a bit of a doozy.

If the player's current target changes ship class with `change_ship_type()`, `Player_ai->targeted_subsys` will still be pointing to the old subsystem list; this could cause problems (specifically out-of-bounds array accesses) when trying to e.g. look up nonexistant submodels. Similar problems occur with any other AIs targeting a subsystem on the ship in question. In order to fix this, several changes were made.

Firstly, `change_ship_type()` will now go through every `Ai_info[]` object looking for ones targeting a subsystem of the ship changing classes, or with an `AI_GOAL_DESTROY_SUBSYSTEM` goal for the ship changing classes, and convert them all to the new subsystem (if there's a match) or remove the target/goal (if there isn't), reusing the existing subsystem comparison logic (for transferring damage). Near the end, there's a `Player_ai` comparison to call `hud_cease_subsystem_targeting(0)` if necessary.

Additionally, `change_ship_type()` will also look through `Missile_obj_list` looking for anything that might be homing in on a subsystem on the ship changing types; these are handled similarly to targeted subsystems, including clearing the weapon's `homing_subsys` attribute if a matching subsystem isn't found.

Lastly, `change_ship_type()` will now kill ship sparks if the model number has changed (trying to transfer sparks to matching submodels would be a herculean task and probably fail most of the time anyway, with similarly-named subobjects with different shapes so the coordinates wouldn't make sense anyway).

This problem was reported by DefCynodont119; see [here](http://www.hard-light.net/forums/index.php?topic=91799.msg1822290#msg1822290) for some of the discussion.