### PR TITLE
Fix color table parsing.

### DIFF
--- a/code/globalincs/alphacolors.cpp
+++ b/code/globalincs/alphacolors.cpp
@@ -311,6 +311,7 @@ void parse_colors(const char *filename)
 				"$Light Pink:",
 				"$Yellow:",
 				"$Bright Yellow:",
+				"$Orange:",
 				"$UI Light Green:",
 				"$UI Green:",
 				"$UI Light Pink:",


### PR DESCRIPTION
Accidentally forgot one array in PR #633, causing a crash if a color table is actually present.

Really should refactor this code again to get rid of this redundant array.