### PR TITLE
Upload the MacOSX build log to pastebin if the build fails

### DIFF
--- a/ci/travis/install.sh
+++ b/ci/travis/install.sh
@@ -6,5 +6,5 @@ if [ "$TRAVIS_OS_NAME" = "linux" ]; then
     # Nothing to do here
     :
 elif [ "$TRAVIS_OS_NAME" = "osx" ]; then
-    gem install xcpretty
+    gem install xcpretty thefox-pastebin
 fi

--- a/ci/travis/script.sh
+++ b/ci/travis/script.sh
@@ -6,5 +6,11 @@ if [ "$TRAVIS_OS_NAME" = "linux" ]; then
     make -j 4
 elif [ "$TRAVIS_OS_NAME" = "osx" ]; then
     cd projects/Xcode
-    xcodebuild ARCHS=$MACOSX_ARCH ONLY_ACTIVE_ARCH=NO -configuration "$CONFIGURATION" | xcpretty -c && exit ${PIPESTATUS[0]}
+    
+    xcodebuild ARCHS=$MACOSX_ARCH ONLY_ACTIVE_ARCH=NO -project FS2_Open.xcodeproj -configuration "$CONFIGURATION" clean build | tee release.log | xcpretty
+    XCODE_RET=${PIPESTATUS[0]}
+    if [ "$XCODE_RET" -ne "0" ]; then
+        pastebin -e 1d -f release.log
+        exit $XCODE_RET
+    fi
 fi


### PR DESCRIPTION
xcpretty does not show all errors so for some cases we still need the full build log. These changes will upload that build to pastebin if the build fails.