### PR TITLE
Deprecate -nohtl and -brief_lighting.

### DIFF
--- a/code/cmdline/cmdline.cpp
+++ b/code/cmdline/cmdline.cpp
@@ -175,7 +175,6 @@ Flag exe_params[] =
 	{ "-clientdamage",		"",											false,	0,					EASY_DEFAULT,		"Multiplayer",	"http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-clientdamage", },
 	{ "-mpnoreturn",		"Disable flight deck option",				true,	0,					EASY_DEFAULT,		"Multiplayer",	"http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-mpnoreturn", },
 
-	{ "-nohtl",				"Software mode (very slow)",				true,	0,					EASY_DEFAULT,		"Troubleshoot",	"http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-nohtl", },
 	{ "-no_set_gamma",		"Disable setting of gamma",					true,	0,					EASY_DEFAULT,		"Troubleshoot",	"http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-no_set_gamma", },
 	{ "-nomovies",			"Disable video playback",					true,	0,					EASY_DEFAULT,		"Troubleshoot",	"http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-nomovies", },
 	{ "-noparseerrors",		"Disable parsing errors",					true,	0,					EASY_DEFAULT,		"Troubleshoot",	"http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-noparseerrors", },
@@ -203,7 +202,6 @@ Flag exe_params[] =
 
 	{ "-ingame_join",		"Allow in-game joining",					true,	0,					EASY_DEFAULT,		"Experimental",	"http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-ingame_join", },
 	{ "-voicer",			"Enable voice recognition",					true,	0,					EASY_DEFAULT,		"Experimental",	"http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-voicer", },
-	{ "-brief_lighting",	"Enable lighting on briefing models",		true,	0,					EASY_DEFAULT,		"Experimental",	"http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-brief_lighting", },
 
 	{ "-fps",				"Show frames per second on HUD",			false,	0,					EASY_DEFAULT,		"Dev Tool",		"http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-fps", },
 	{ "-pos",				"Show position of camera",					false,	0,					EASY_DEFAULT,		"Dev Tool",		"http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-pos", },
@@ -310,7 +308,6 @@ cmdline_parm fxaa_arg("-fxaa", NULL, AT_NONE);
 cmdline_parm fxaa_preset_arg("-fxaa_preset", "FXAA quality (0-9), requires -post_process and -fxaa", AT_INT);
 cmdline_parm fb_explosions_arg("-fb_explosions", NULL, AT_NONE);
 cmdline_parm flightshaftsoff_arg("-nolightshafts", NULL, AT_NONE);
-cmdline_parm brieflighting_arg("-brief_lighting", NULL, AT_NONE);
 cmdline_parm no_batching("-no_batching", NULL, AT_NONE);
 cmdline_parm shadow_quality_arg("-shadow_quality", NULL, AT_INT);
 cmdline_parm enable_shadows_arg("-enable_shadows", NULL, AT_NONE);
@@ -340,7 +337,6 @@ extern int Fxaa_preset_last_frame;
 bool Cmdline_fb_explosions = 0;
 bool Cmdline_no_batching = false;
 extern bool ls_force_off;
-bool Cmdline_brief_lighting = 0;
 int Cmdline_shadow_quality = 0;
 int Cmdline_no_deferred_lighting = 0;
 
@@ -413,7 +409,6 @@ int Cmdline_objupd = 3;		// client object updates on LAN by default
 
 // Troubleshooting
 cmdline_parm loadallweapons_arg("-loadallweps", NULL, AT_NONE);	// Cmdline_load_all_weapons
-cmdline_parm htl_arg("-nohtl", NULL, AT_NONE);				// Cmdline_nohtl  -- don't use HT&L
 cmdline_parm nomovies_arg("-nomovies", NULL, AT_NONE);		// Cmdline_nomovies  -- Allows video streaming
 cmdline_parm no_set_gamma_arg("-no_set_gamma", NULL, AT_NONE);	// Cmdline_no_set_gamma
 cmdline_parm no_vbo_arg("-novbo", NULL, AT_NONE);			// Cmdline_novbo
@@ -435,7 +430,6 @@ cmdline_parm fix_registry("-fix_registry", NULL, AT_NONE);
 #endif
 
 int Cmdline_load_all_weapons = 0;
-int Cmdline_nohtl = 0;
 int Cmdline_nomovies = 0;
 int Cmdline_no_set_gamma = 0;
 int Cmdline_novbo = 0; // turn off OGL VBO support, troubleshooting
@@ -525,6 +519,8 @@ cmdline_parm deprecated_normal_arg("-normal", "Deprecated", AT_NONE);
 cmdline_parm deprecated_env_arg("-env", "Deprecated", AT_NONE);
 cmdline_parm deprecated_tbp_arg("-tbp", "Deprecated", AT_NONE);
 cmdline_parm deprecated_jpgtga_arg("-jpgtga", "Deprecated", AT_NONE);
+cmdline_parm deprecated_htl_arg("-nohtl", "Deprecated", AT_NONE);
+cmdline_parm deprecated_brieflighting_arg("-brief_lighting", "Deprecated", AT_NONE);
 
 int Cmdline_deprecated_spec = 0;
 int Cmdline_deprecated_glow = 0;
@@ -532,6 +528,8 @@ int Cmdline_deprecated_normal = 0;
 int Cmdline_deprecated_env = 0;
 int Cmdline_deprecated_tbp = 0;
 int Cmdline_deprecated_jpgtga = 0;
+int Cmdline_deprecated_nohtl = 0;
+bool Cmdline_deprecated_brief_lighting = 0;
 
 #ifndef NDEBUG
 // NOTE: this assumes that os_init() has already been called but isn't a fatal error if it hasn't
@@ -586,6 +584,16 @@ void cmdline_debug_print_cmdline()
 	if(Cmdline_deprecated_jpgtga == 1)
 	{
 		mprintf(("Deprecated flag '-jpgtga' found. Please remove from your cmdline.\n"));
+	}
+
+	if(Cmdline_deprecated_nohtl == 1)
+	{
+		mprintf(("Deprecated flag '-nohtl' found. Please remove from your cmdline.\n"));
+	}
+
+	if(Cmdline_deprecated_brief_lighting == 1)
+	{
+		mprintf(("Deprecated flag '-brief_lighting' found. Please remove from your cmdline.\n"));
 	}
 }
 #endif
@@ -1511,11 +1519,6 @@ bool SetCmdlineParams()
 		Cmdline_spec = 0;
 	}
 
-	if ( htl_arg.found() ) 
-	{
-		Cmdline_nohtl = 1;
-	}
-
 	if( no_set_gamma_arg.found() )
 	{
 		Cmdline_no_set_gamma = 1;
@@ -1715,11 +1718,6 @@ bool SetCmdlineParams()
 		Cmdline_no_batching = true;
 	}
 
-	if ( brieflighting_arg.found() )
-	{
-		Cmdline_brief_lighting = 1;
-	}
-
 	if ( postprocess_arg.found() )
 	{
 		Cmdline_postprocess = 1;
@@ -1804,6 +1802,16 @@ bool SetCmdlineParams()
 	if( deprecated_jpgtga_arg.found() )
 	{
 		Cmdline_deprecated_jpgtga = 1;
+	}
+
+	if ( deprecated_htl_arg.found() ) 
+	{
+		Cmdline_deprecated_nohtl = 1;
+	}
+
+	if ( deprecated_brieflighting_arg.found() )
+	{
+		Cmdline_deprecated_brief_lighting = 1;
 	}
 
 	return true; 

--- a/code/cmdline/cmdline.h
+++ b/code/cmdline/cmdline.h
@@ -119,7 +119,6 @@ extern int Cmdline_objupd;
 
 // Troubleshooting
 extern int Cmdline_load_all_weapons;
-extern int Cmdline_nohtl;
 extern int Cmdline_nomovies;	// WMC Toggles movie playing support
 extern int Cmdline_no_set_gamma;
 extern int Cmdline_novbo;

--- a/code/fireball/fireballs.cpp
+++ b/code/fireball/fireballs.cpp
@@ -395,11 +395,7 @@ void fireball_render_DEPRECATED(object * obj)
 		gr_fog_set(GR_FOGMODE_NONE, 0, 0, 0);
 	}
 
-	if(Cmdline_nohtl) {
-		g3_rotate_vertex(&p, &obj->pos );
-	}else{
-		g3_transfer_vertex(&p, &obj->pos);
-	}
+	g3_transfer_vertex(&p, &obj->pos);
 
 	switch( fb->fireball_render_type )	{
 
@@ -1052,11 +1048,7 @@ void fireball_render(object* obj, draw_list *scene)
 	if ( Fireballs[num].current_bitmap < 0 )
 		return;
 	
-	if ( Cmdline_nohtl ) {
-		g3_rotate_vertex(&p, &obj->pos );
-	} else {
-		g3_transfer_vertex(&p, &obj->pos);
-	}
+	g3_transfer_vertex(&p, &obj->pos);
 
 	switch ( fb->fireball_render_type )	{
 

--- a/code/fireball/warpineffect.cpp
+++ b/code/fireball/warpineffect.cpp
@@ -112,11 +112,7 @@ void warpin_render(object *obj, matrix *orient, vec3d *pos, int texture_bitmap_n
 			vecs[4] = center;
 			verts[4].texture_position.u = 0.5f; verts[4].texture_position.v = 0.5f; 
 
-			if (Cmdline_nohtl) {
-				g3_rotate_vertex( &verts[4], &vecs[4] );
-			} else {
-				g3_transfer_vertex( &verts[4], &vecs[4] );
-			}
+			g3_transfer_vertex( &verts[4], &vecs[4] );
 
 			float alpha = (The_mission.flags & MISSION_FLAG_FULLNEB) ? (1.0f - neb2_get_fog_intensity(obj)) : 1.0f;
 			gr_set_bitmap( Warp_glow_bitmap, GR_ALPHABLEND_FILTER, GR_BITBLT_MODE_NORMAL, alpha );
@@ -177,19 +173,11 @@ void warpin_render(object *obj, matrix *orient, vec3d *pos, int texture_bitmap_n
 		verts[4].texture_position.u = 0.5f;
 		verts[4].texture_position.v = 0.5f; 
 
-		if (Cmdline_nohtl) {
-			g3_rotate_vertex( &verts[0], &vecs[0] );
-			g3_rotate_vertex( &verts[1], &vecs[1] );
-			g3_rotate_vertex( &verts[2], &vecs[2] );
-			g3_rotate_vertex( &verts[3], &vecs[3] );
-			g3_rotate_vertex( &verts[4], &vecs[4] );
-		} else {
-			g3_transfer_vertex( &verts[0], &vecs[0] );
-			g3_transfer_vertex( &verts[1], &vecs[1] );
-			g3_transfer_vertex( &verts[2], &vecs[2] );
-			g3_transfer_vertex( &verts[3], &vecs[3] );
-			g3_transfer_vertex( &verts[4], &vecs[4] );
-		}
+		g3_transfer_vertex( &verts[0], &vecs[0] );
+		g3_transfer_vertex( &verts[1], &vecs[1] );
+		g3_transfer_vertex( &verts[2], &vecs[2] );
+		g3_transfer_vertex( &verts[3], &vecs[3] );
+		g3_transfer_vertex( &verts[4], &vecs[4] );
 
 		int cull = gr_set_cull(0); // fixes rendering problem in D3D - taylor
 		draw_face( &verts[0], &verts[4], &verts[1] );
@@ -262,11 +250,7 @@ void warpin_queue_render(draw_list *scene, object *obj, matrix *orient, vec3d *p
 			vecs[4] = center;
 			verts[4].texture_position.u = 0.5f; verts[4].texture_position.v = 0.5f; 
 
-			if (Cmdline_nohtl) {
-				g3_rotate_vertex( &verts[4], &vecs[4] );
-			} else {
-				g3_transfer_vertex( &verts[4], &vecs[4] );
-			}
+			g3_transfer_vertex( &verts[4], &vecs[4] );
 
 			float alpha = (The_mission.flags & MISSION_FLAG_FULLNEB) ? (1.0f - neb2_get_fog_intensity(obj)) : 1.0f;
 
@@ -329,19 +313,11 @@ void warpin_queue_render(draw_list *scene, object *obj, matrix *orient, vec3d *p
 		verts[4].texture_position.u = 0.5f;
 		verts[4].texture_position.v = 0.5f; 
 
-		if (Cmdline_nohtl) {
-			g3_rotate_vertex( &verts[0], &vecs[0] );
-			g3_rotate_vertex( &verts[1], &vecs[1] );
-			g3_rotate_vertex( &verts[2], &vecs[2] );
-			g3_rotate_vertex( &verts[3], &vecs[3] );
-			g3_rotate_vertex( &verts[4], &vecs[4] );
-		} else {
-			g3_transfer_vertex( &verts[0], &vecs[0] );
-			g3_transfer_vertex( &verts[1], &vecs[1] );
-			g3_transfer_vertex( &verts[2], &vecs[2] );
-			g3_transfer_vertex( &verts[3], &vecs[3] );
-			g3_transfer_vertex( &verts[4], &vecs[4] );
-		}
+		g3_transfer_vertex( &verts[0], &vecs[0] );
+		g3_transfer_vertex( &verts[1], &vecs[1] );
+		g3_transfer_vertex( &verts[2], &vecs[2] );
+		g3_transfer_vertex( &verts[3], &vecs[3] );
+		g3_transfer_vertex( &verts[4], &vecs[4] );
 
 		warpin_batch_draw_face( texture_bitmap_num, &verts[0], &verts[4], &verts[1] );
 		warpin_batch_draw_face( texture_bitmap_num, &verts[1], &verts[4], &verts[2] );

--- a/code/fred2/fredrender.cpp
+++ b/code/fred2/fredrender.cpp
@@ -612,30 +612,7 @@ void display_active_ship_subsystem()
 				// get subsys name
 				strcpy_s(buf, Render_subsys.cur_subsys->system_info->subobj_name);
 	
-				if (Cmdline_nohtl)
-				{
-					// get bounding box
-					if ( get_subsys_bounding_rect(objp, Render_subsys.cur_subsys, &x1, &x2, &y1, &y2) )
-					{
-	
-						// set color
-						gr_set_color(255, 32, 32);
-	
-						// draw box
-						gr_line(x1, y1, x1, y2);  gr_line(x1-1, y1, x1-1, y2);
-						gr_line(x1, y2, x2, y2);  gr_line(x1, y2+1, x2, y2+1);
-						gr_line(x2, y2, x2, y1);  gr_line(x2+1, y2, x2+1, y1);
-						gr_line(x2, y1, x1, y1);  gr_line(x2, y1-1, x1, y1-1);
-
-						// draw text
-						gr_set_color_fast(&colour_white);
-						gr_string_win( (x1+x2)/2,  y2 + 10, buf);
-					}
-				}
-				else
-				{		
-					fredhtl_render_subsystem_bounding_box(&Render_subsys);
-				}
+				fredhtl_render_subsystem_bounding_box(&Render_subsys);
 			}
 			else
 			{
@@ -660,19 +637,11 @@ void render_models(void)
 	}
 
 	bool f=false;
-	if (Cmdline_nohtl)
-	{
-		obj_render_all(render_one_model_nohtl,&f);
-	}
-	else
-	{
-		fred_enable_htl();
+	fred_enable_htl();
 		
-		obj_render_all(render_one_model_htl,&f);
+	obj_render_all(render_one_model_htl,&f);
 
-		fred_disable_htl();
-
-	}
+	fred_disable_htl();
 
 	if (Briefing_dialog)
 	{
@@ -1389,11 +1358,8 @@ void fred_render_grid(grid *gridp)
 {
 	int	i, ncols, nrows;
 
-	if (!Cmdline_nohtl)
-	{
-		fred_enable_htl();
-		gr_zbuffer_set(0);
-	}	
+	fred_enable_htl();
+	gr_zbuffer_set(0);
 	
 	if ( !Fred_grid_colors_inited )	{
 		Fred_grid_colors_inited = 1;
@@ -1419,14 +1385,12 @@ void fred_render_grid(grid *gridp)
 	//	Draw the column lines.
 	for (i=0; i<=ncols; i++)
 	{
-		if (Cmdline_nohtl) rpd_line(&gridp->gpoints1[i], &gridp->gpoints2[i]);
-		else g3_draw_htl_line(&gridp->gpoints1[i], &gridp->gpoints2[i]);
+		g3_draw_htl_line(&gridp->gpoints1[i], &gridp->gpoints2[i]);
 	}
 	//	Draw the row lines.
 	for (i=0; i<=nrows; i++)
 	{
-		if (Cmdline_nohtl) rpd_line(&gridp->gpoints3[i], &gridp->gpoints4[i]);
-		else g3_draw_htl_line(&gridp->gpoints3[i], &gridp->gpoints4[i]);
+		g3_draw_htl_line(&gridp->gpoints3[i], &gridp->gpoints4[i]);
 	}
 
 	ncols = gridp->ncols / 2;
@@ -1440,21 +1404,16 @@ void fred_render_grid(grid *gridp)
 	
 	for (i=0; i<=ncols; i++)
 	{
-		if (Cmdline_nohtl) rpd_line(&gridp->gpoints5[i], &gridp->gpoints6[i]);
-		else g3_draw_htl_line(&gridp->gpoints5[i], &gridp->gpoints6[i]);
+		g3_draw_htl_line(&gridp->gpoints5[i], &gridp->gpoints6[i]);
 	}
 
 	for (i=0; i<=nrows; i++)
 	{
-		if (Cmdline_nohtl) rpd_line(&gridp->gpoints7[i], &gridp->gpoints8[i]);
-		else g3_draw_htl_line(&gridp->gpoints7[i], &gridp->gpoints8[i]);
+		g3_draw_htl_line(&gridp->gpoints7[i], &gridp->gpoints8[i]);
 	}
 
-	if (!Cmdline_nohtl)
-	{
-		fred_disable_htl();
-		gr_zbuffer_set(1);
-	}
+	fred_disable_htl();
+	gr_zbuffer_set(1);
 }
 
 void render_frame()

--- a/code/fred2/management.cpp
+++ b/code/fred2/management.cpp
@@ -332,26 +332,6 @@ bool fred_init()
 	//HWND hwndApp = window->GetSafeHwnd();
 	//os_set_window((uint) hwndApp);
 
-	/*
-	int result = MessageBox(NULL, 
-		"Welcome to OGL Fred2_open. Do you want to run in htl? "
-		"Its faster on any system and runs in full detail but is still buggy.", 
-		"Question", MB_ICONQUESTION | MB_YESNOCANCEL);
-
-	if(result == IDCANCEL) return false;
-
-	Cmdline_nohtl = result != IDYES;
-	*/
-
-	/* - HTL is now on by default so the warning is redundant - Karajorma
-	if (Cmdline_nohtl)
-	{
-		MessageBox(NULL, "You are not running in HTL mode for FRED.  Although HTL mode isn't required, there may be some crashes"
-						 " when trying to render the new high polygon models.  To enable HTL mode, create a shortcut to FRED, right-click into properties"
-						 " and add \"-fredhtl\" to the end of the string in the \"target\" box.", "FRED2", MB_ICONWARNING | MB_OK);
-	}
-	*/
-
 	snd_init();
 
 	// Not ready for this yet

--- a/code/freespace2/freespace.cpp
+++ b/code/freespace2/freespace.cpp
@@ -3192,10 +3192,6 @@ void setup_environment_mapping(camid cid)
 	float old_zoom = View_zoom, new_zoom = 1.0f;//0.925f;
 	int i = 0;
 
-
-	if (Cmdline_nohtl)
-		return;
-
 	if(!cid.isValid())
 		return;
 
@@ -3730,10 +3726,8 @@ void game_render_frame( camid cid )
 	neb2_render_setup(cid);
 
 #ifndef DYN_CLIP_DIST
-	if (!Cmdline_nohtl) {
-		gr_set_proj_matrix(Proj_fov, gr_screen.clip_aspect, Min_draw_distance, Max_draw_distance);
-		gr_set_view_matrix(&Eye_position, &Eye_matrix);
-	}
+	gr_set_proj_matrix(Proj_fov, gr_screen.clip_aspect, Min_draw_distance, Max_draw_distance);
+	gr_set_view_matrix(&Eye_position, &Eye_matrix);
 #endif
 
 	if ( Game_subspace_effect )	{
@@ -3751,13 +3745,10 @@ void game_render_frame( camid cid )
 	PROFILE("Particles", particle_render_all());					// render particles after everything else.	
 	
 #ifdef DYN_CLIP_DIST
-	if(!Cmdline_nohtl)
-	{
-		gr_end_proj_matrix();
-		gr_end_view_matrix();
-		gr_set_proj_matrix(Proj_fov, gr_screen.clip_aspect, Min_draw_distance, Max_draw_distance);
-		gr_set_view_matrix(&Eye_position, &Eye_matrix);
-	}
+	gr_end_proj_matrix();
+	gr_end_view_matrix();
+	gr_set_proj_matrix(Proj_fov, gr_screen.clip_aspect, Min_draw_distance, Max_draw_distance);
+	gr_set_view_matrix(&Eye_position, &Eye_matrix);
 #endif
 
 	beam_render_all();						// render all beam weapons
@@ -3799,11 +3790,8 @@ void game_render_frame( camid cid )
 	snd_spew_debug_info();
 #endif
 
-	if(!Cmdline_nohtl)
-	{
-		gr_end_proj_matrix();
-		gr_end_view_matrix();
-	}
+	gr_end_proj_matrix();
+	gr_end_view_matrix();
 
 	//Draw viewer cockpit
 	if(Viewer_obj != NULL && Viewer_mode != VM_TOPDOWN && Ship_info[Ships[Viewer_obj->instance].ship_info_index].cockpit_model_num > 0)
@@ -3812,16 +3800,15 @@ void game_render_frame( camid cid )
 		ship_render_cockpit(Viewer_obj);
 	}
 
-	if (!Cmdline_nohtl) {
-		gr_set_proj_matrix(Proj_fov, gr_screen.clip_aspect, Min_draw_distance, Max_draw_distance);
-		gr_set_view_matrix(&Eye_position, &Eye_matrix);
+	gr_set_proj_matrix(Proj_fov, gr_screen.clip_aspect, Min_draw_distance, Max_draw_distance);
+	gr_set_view_matrix(&Eye_position, &Eye_matrix);
 
-		// Do the sunspot
-		game_sunspot_process(flFrametime);
+	// Do the sunspot
+	game_sunspot_process(flFrametime);
 
-		gr_end_proj_matrix();
-		gr_end_view_matrix();
-	}
+	gr_end_proj_matrix();
+	gr_end_view_matrix();
+
 	Shadow_override = false;
 	//================ END OF 3D RENDERING STUFF ====================
 
@@ -7988,9 +7975,6 @@ void get_version_string(char *str, int max_size)
 			strcat_s( str, max_size, " OpenGL" );
 			break;
 	}
-
-	if (Cmdline_nohtl)
-		strcat_s( str, max_size, " non-HT&L" );
 
 	// if a custom identifier exists, put it at the very end
 	#ifdef FS_VERSION_IDENT

--- a/code/graphics/gropengl.cpp
+++ b/code/graphics/gropengl.cpp
@@ -662,12 +662,6 @@ void gr_opengl_fog_set(int fog_mode, int r, int g, int b, float fog_near, float 
   	if (OGL_fogmode == 3) {
 		glFogf(GL_FOG_DISTANCE_MODE_NV, GL_EYE_RADIAL_NV);
 		glFogf(GL_FOG_COORDINATE_SOURCE, GL_FRAGMENT_DEPTH);
-	}
-	// Um.. this is not the correct way to fog in software, probably doesn't matter though
-	else if ( (OGL_fogmode == 2) && Cmdline_nohtl ) {
-		glFogf(GL_FOG_COORDINATE_SOURCE_EXT, GL_FOG_COORDINATE_EXT);
-		fog_near *= fog_near;		// it's faster this way
-		fog_far *= fog_far;
 	} else {
 		glFogf(GL_FOG_COORDINATE_SOURCE, GL_FRAGMENT_DEPTH);
 	}
@@ -1670,10 +1664,6 @@ int opengl_init_display_device()
 
 void opengl_setup_function_pointers()
 {
-	// *****************************************************************************
-	// NOTE: All function pointers here should have a Cmdline_nohtl check at the top
-	//       if they shouldn't be run in non-HTL mode, Don't keep separate entries.
-
 	gr_screen.gf_flip				= gr_opengl_flip;
 	gr_screen.gf_set_clip			= gr_opengl_set_clip;
 	gr_screen.gf_reset_clip			= gr_opengl_reset_clip;
@@ -1833,10 +1823,6 @@ void opengl_setup_function_pointers()
 	gr_screen.gf_clear_states	= gr_opengl_clear_states;
 
 	gr_screen.gf_set_team_color		= gr_opengl_set_team_color;
-
-	// NOTE: All function pointers here should have a Cmdline_nohtl check at the top
-	//       if they shouldn't be run in non-HTL mode, Don't keep separate entries.
-	// *****************************************************************************
 }
 
 

--- a/code/graphics/gropengldraw.cpp
+++ b/code/graphics/gropengldraw.cpp
@@ -761,10 +761,6 @@ void gr_opengl_line(int x1,int y1,int x2,int y2, int resize_mode)
 
 void gr_opengl_line_htl(const vec3d *start, const vec3d *end)
 {
-	if (Cmdline_nohtl) {
-		return;
-	}
-
 	gr_zbuffer_type zbuffer_state = (gr_zbuffering) ? ZBUFFER_TYPE_FULL : ZBUFFER_TYPE_NONE;
 	GL_state.SetTextureSource(TEXTURE_SOURCE_NONE);
 	GL_state.SetZbufferType(zbuffer_state);
@@ -1597,7 +1593,7 @@ void opengl_tmapper_internal3d(int nv, vertex **verts, uint flags)
 
 void gr_opengl_tmapper(int nverts, vertex **verts, uint flags)
 {
-	if ( !Cmdline_nohtl && (flags & TMAP_HTL_3D_UNLIT) ) {
+	if ( flags & TMAP_HTL_3D_UNLIT) {
 		opengl_tmapper_internal3d(nverts, verts, flags);
 	} else {
 		opengl_tmapper_internal(nverts, verts, flags);
@@ -1849,7 +1845,7 @@ void gr_opengl_render_effect(int nverts, vertex *verts, float *radius_list, uint
 
 void gr_opengl_render(int nverts, vertex *verts, uint flags)
 {
-	if ( !Cmdline_nohtl && (flags & TMAP_HTL_3D_UNLIT) ) {
+	if ( flags & TMAP_HTL_3D_UNLIT) {
 		opengl_render_internal3d(nverts, verts, flags);
 	} else {
 		opengl_render_internal(nverts, verts, flags);
@@ -2294,10 +2290,6 @@ void gr_opengl_bitmap_ex(int x, int y, int w, int h, int sx, int sy, int resize_
 
 void gr_opengl_sphere_htl(float rad)
 {
-	if (Cmdline_nohtl) {
-		return;
-	}
-
 	GLUquadricObj *quad = NULL;
 
 	// FIXME: before this is used in anything other than FRED2 we need to make this creation/deletion
@@ -2422,10 +2414,6 @@ void gr_opengl_deferred_light_sphere_init(int rings, int segments) // Generate a
 
 void gr_opengl_draw_deferred_light_sphere(vec3d *position, float rad, bool clearStencil = true)
 {
-	if (Cmdline_nohtl) {
-		return;
-	}
-
 	g3_start_instance_matrix(position, &vmd_identity_matrix, true);
 
 	GL_state.Uniform.setUniform3f("scale", rad, rad, rad);
@@ -2554,10 +2542,6 @@ void gr_opengl_deferred_light_cylinder_init(int segments) // Generate a VBO of a
 
 void gr_opengl_draw_deferred_light_cylinder(vec3d *position,matrix *orient, float rad, float length, bool clearStencil = true)
 {
-	if (Cmdline_nohtl) {
-		return;
-	}
-
 	g3_start_instance_matrix(position, orient, true);
 
 	GL_state.Uniform.setUniform3f("scale", rad, rad, length);
@@ -2578,9 +2562,6 @@ void gr_opengl_draw_deferred_light_cylinder(vec3d *position,matrix *orient, floa
 
 void gr_opengl_draw_line_list(const colored_vector *lines, int num)
 {
-	if (Cmdline_nohtl) {
-		return;
-	}
 }
 extern int opengl_check_framebuffer();
 void opengl_setup_scene_textures()

--- a/code/graphics/gropenglextension.cpp
+++ b/code/graphics/gropenglextension.cpp
@@ -413,7 +413,7 @@ void opengl_extensions_init()
 	//int use_base_vertex = Is_Extension_Enabled(OGL_ARB_DRAW_ELEMENTS_BASE_VERTEX);
 
 	//allow VBOs to be used
-	if ( !Cmdline_nohtl && !Cmdline_novbo && Is_Extension_Enabled(OGL_ARB_VERTEX_BUFFER_OBJECT) ) {
+	if ( !Cmdline_novbo && Is_Extension_Enabled(OGL_ARB_VERTEX_BUFFER_OBJECT) ) {
 		Use_VBOs = 1;
 	}
 

--- a/code/graphics/gropengllight.cpp
+++ b/code/graphics/gropengllight.cpp
@@ -354,9 +354,6 @@ void gr_opengl_destroy_light(int idx)
 
 void gr_opengl_set_light(light *fs_light)
 {
-	if (Cmdline_nohtl)
-		return;
-
 	if (Num_active_gl_lights >= MAX_LIGHTS)
 		return;
 
@@ -383,7 +380,7 @@ void gr_opengl_center_alpha(int type)
 
 void gr_opengl_set_center_alpha(int type)
 {
-	if (!type || Cmdline_nohtl)
+	if (!type)
 		return;
 
 	if(Num_active_gl_lights == MAX_LIGHTS)
@@ -459,9 +456,6 @@ void gr_opengl_set_light_factor(float factor)
 void gr_opengl_reset_lighting()
 {
 	int i;
-
-	if (Cmdline_nohtl)
-		return;
 
 //	memset( opengl_lights, 0, sizeof(opengl_light) * MAX_LIGHTS );
 
@@ -583,10 +577,6 @@ void opengl_default_light_settings(int ambient, int emission, int specular)
 
 void gr_opengl_set_lighting(bool set, bool state)
 {
-	if (Cmdline_nohtl) {
-		return;
-	}
-
 	lighting_is_enabled = set;
 
 	opengl_default_light_settings();

--- a/code/graphics/gropengltexture.cpp
+++ b/code/graphics/gropengltexture.cpp
@@ -1157,9 +1157,6 @@ int gr_opengl_preload(int bitmap_num, int is_aabitmap)
 static int GL_texture_panning_enabled = 0;
 void gr_opengl_set_texture_panning(float u, float v, bool enable)
 {
-	if (Cmdline_nohtl)
-		return;
-
 	GLint current_matrix;
 
 	if (enable) {

--- a/code/graphics/gropengltnl.cpp
+++ b/code/graphics/gropengltnl.cpp
@@ -343,10 +343,6 @@ static void opengl_gen_buffer(opengl_vertex_buffer *vbp)
 
 int gr_opengl_create_buffer()
 {
-	if (Cmdline_nohtl) {
-		return -1;
-	}
-
 	opengl_vertex_buffer vbuffer;
 
 	GL_vertex_buffers.push_back( vbuffer );
@@ -357,10 +353,6 @@ int gr_opengl_create_buffer()
 
 bool gr_opengl_config_buffer(const int buffer_id, vertex_buffer *vb, bool update_ibuffer_only)
 {
-	if (Cmdline_nohtl) {
-		return false;
-	}
-
 	if (buffer_id < 0) {
 		return false;
 	}
@@ -434,10 +426,6 @@ bool gr_opengl_config_buffer(const int buffer_id, vertex_buffer *vb, bool update
 
 bool gr_opengl_pack_buffer(const int buffer_id, vertex_buffer *vb)
 {
-	if (Cmdline_nohtl) {
-		return false;
-	}
-
 	if (buffer_id < 0) {
 		return false;
 	}
@@ -552,10 +540,6 @@ bool gr_opengl_pack_buffer(const int buffer_id, vertex_buffer *vb)
 
 void gr_opengl_set_buffer(int idx)
 {
-	if (Cmdline_nohtl) {
-		return;
-	}
-
 	g_vbp = NULL;
 
 	if (idx < 0) {
@@ -578,10 +562,6 @@ void gr_opengl_set_buffer(int idx)
 
 void gr_opengl_destroy_buffer(int idx)
 {
-	if (Cmdline_nohtl) {
-		return;
-	}
-
 	if (idx < 0) {
 		return;
 	}
@@ -1487,10 +1467,6 @@ void gr_opengl_render_stream_buffer(int buffer_handle, int offset, int n_verts, 
 
 void gr_opengl_start_instance_matrix(const vec3d *offset, const matrix *rotation)
 {
-	if (Cmdline_nohtl) {
-		return;
-	}
-
 	Assert( GL_htl_projection_matrix_set );
 	Assert( GL_htl_view_matrix_set );
 
@@ -1522,9 +1498,6 @@ void gr_opengl_start_instance_matrix(const vec3d *offset, const matrix *rotation
 
 void gr_opengl_start_instance_angles(const vec3d *pos, const angles *rotation)
 {
-	if (Cmdline_nohtl)
-		return;
-
 	Assert(GL_htl_projection_matrix_set);
 	Assert(GL_htl_view_matrix_set);
 
@@ -1536,9 +1509,6 @@ void gr_opengl_start_instance_angles(const vec3d *pos, const angles *rotation)
 
 void gr_opengl_end_instance_matrix()
 {
-	if (Cmdline_nohtl)
-		return;
-
 	Assert(GL_htl_projection_matrix_set);
 	Assert(GL_htl_view_matrix_set);
 
@@ -1550,10 +1520,6 @@ void gr_opengl_end_instance_matrix()
 // the projection matrix; fov, aspect ratio, near, far
 void gr_opengl_set_projection_matrix(float fov, float aspect, float z_near, float z_far)
 {
-	if (Cmdline_nohtl) {
-		return;
-	}
-
 	GL_CHECK_FOR_ERRORS("start of set_projection_matrix()()");
 	
 	if (GL_rendering_to_texture) {
@@ -1586,10 +1552,6 @@ void gr_opengl_set_projection_matrix(float fov, float aspect, float z_near, floa
 
 void gr_opengl_end_projection_matrix()
 {
-	if (Cmdline_nohtl) {
-		return;
-	}
-
 	GL_CHECK_FOR_ERRORS("start of end_projection_matrix()");
 
 	glViewport(0, 0, gr_screen.max_w, gr_screen.max_h);
@@ -1613,9 +1575,6 @@ void gr_opengl_end_projection_matrix()
 
 void gr_opengl_set_view_matrix(const vec3d *pos, const matrix *orient)
 {
-	if (Cmdline_nohtl)
-		return;
-
 	Assert(GL_htl_projection_matrix_set);
 	Assert(GL_modelview_matrix_depth == 1);
 
@@ -1726,9 +1685,6 @@ void gr_opengl_set_view_matrix(const vec3d *pos, const matrix *orient)
 
 void gr_opengl_end_view_matrix()
 {
-	if (Cmdline_nohtl)
-		return;
-
 	Assert(GL_modelview_matrix_depth == 2);
 
 	glPopMatrix();
@@ -1743,10 +1699,6 @@ void gr_opengl_end_view_matrix()
 // TODO: this probably needs to accept values
 void gr_opengl_set_2d_matrix(/*int x, int y, int w, int h*/)
 {
-	if (Cmdline_nohtl) {
-		return;
-	}
-
 	// don't bother with this if we aren't even going to need it
 	if ( !GL_htl_projection_matrix_set ) {
 		return;
@@ -1789,9 +1741,6 @@ void gr_opengl_set_2d_matrix(/*int x, int y, int w, int h*/)
 // ends a previously set 2d view and projection matrix
 void gr_opengl_end_2d_matrix()
 {
-	if (Cmdline_nohtl)
-		return;
-
 	if (!GL_htl_2d_matrix_set)
 		return;
 
@@ -1839,10 +1788,6 @@ void gr_opengl_pop_scale_matrix()
 
 void gr_opengl_end_clip_plane()
 {
-	if (Cmdline_nohtl) {
-		return;
-	}
-
 	if ( is_minimum_GLSL_version() ) {
 		return;
 	}
@@ -1852,10 +1797,6 @@ void gr_opengl_end_clip_plane()
 
 void gr_opengl_start_clip_plane()
 {
-	if (Cmdline_nohtl) {
-		return;
-	}
-
 	if ( is_minimum_GLSL_version() ) {
 		// bail since we're gonna clip in the shader
 		return;

--- a/code/graphics/shadows.cpp
+++ b/code/graphics/shadows.cpp
@@ -396,7 +396,7 @@ void shadows_render_all(float fov, matrix *eye_orient, vec3d *eye_pos)
 
 	light *lp = *(Static_light.begin());
 
-	if( Cmdline_nohtl || !Cmdline_shadow_quality || !lp ) {
+	if( !Cmdline_shadow_quality || !lp ) {
 		return;
 	}
 

--- a/code/hud/hudshield.cpp
+++ b/code/hud/hudshield.cpp
@@ -169,7 +169,6 @@ int hud_shield_maybe_flash(int gauge, int target_index, int shield_offset)
 	return flashed;
 }
 
-extern int Cmdline_nohtl;
 bool shield_ani_warning_displayed_already = false;
 
 // called at beginning of level to page in all ship icons
@@ -674,10 +673,8 @@ void HudGaugeShield::showShields(object *objp, int mode)
 			g3_set_view_matrix( &finger_vec, &vmd_identity_matrix, 1.0f);
 		}*/
 
-		if (!Cmdline_nohtl) {
-			gr_set_proj_matrix(0.5f*Proj_fov, gr_screen.clip_aspect, Min_draw_distance, Max_draw_distance);
-			gr_set_view_matrix(&Eye_position, &Eye_matrix);
-		}
+		gr_set_proj_matrix(0.5f*Proj_fov, gr_screen.clip_aspect, Min_draw_distance, Max_draw_distance);
+		gr_set_view_matrix(&Eye_position, &Eye_matrix);
 
 		//We're ready to show stuff
 		//if(!digitus_improbus)
@@ -706,11 +703,8 @@ void HudGaugeShield::showShields(object *objp, int mode)
 		}*/
 
 		//We're done
-		if(!Cmdline_nohtl)
-		{
-			gr_end_view_matrix();
-			gr_end_proj_matrix();
-		}
+		gr_end_view_matrix();
+		gr_end_proj_matrix();
 		if(g3_yourself)
 			g3_end_frame();
 		hud_save_restore_camera_data(0);

--- a/code/hud/hudtarget.cpp
+++ b/code/hud/hudtarget.cpp
@@ -7126,10 +7126,8 @@ void HudGaugeHardpoints::render(float frametime)
 
 	g3_set_view_matrix( &sip->closeup_pos, &vmd_identity_matrix, sip->closeup_zoom*1.5f);
 
-	if (!Cmdline_nohtl) {
-		gr_set_proj_matrix(Proj_fov, gr_screen.clip_aspect, Min_draw_distance, Max_draw_distance);
-		gr_set_view_matrix(&Eye_position, &Eye_matrix);
-	}
+	gr_set_proj_matrix(Proj_fov, gr_screen.clip_aspect, Min_draw_distance, Max_draw_distance);
+	gr_set_view_matrix(&Eye_position, &Eye_matrix);
 
 	setGaugeColor();
 
@@ -7280,11 +7278,8 @@ void HudGaugeHardpoints::render(float frametime)
 	}
 	
 	//We're done
-	if(!Cmdline_nohtl)
-	{
-		gr_end_view_matrix();
-		gr_end_proj_matrix();
-	}
+	gr_end_view_matrix();
+	gr_end_proj_matrix();
 	if(g3_yourself)
 		g3_end_frame();
 

--- a/code/hud/hudtargetbox.cpp
+++ b/code/hud/hudtargetbox.cpp
@@ -516,11 +516,8 @@ void HudGaugeTargetBox::renderTargetSetup(vec3d *camera_eye, matrix *camera_orie
 
 	setClip(position[0] + Viewport_offsets[0], position[1] + Viewport_offsets[1], Viewport_w, Viewport_h);
 
-	if (!Cmdline_nohtl) {
-		gr_set_proj_matrix(Proj_fov, gr_screen.clip_aspect, Min_draw_distance, Max_draw_distance);
-		gr_set_view_matrix(&Eye_position, &Eye_matrix);
-	}
-
+	gr_set_proj_matrix(Proj_fov, gr_screen.clip_aspect, Min_draw_distance, Max_draw_distance);
+	gr_set_view_matrix(&Eye_position, &Eye_matrix);
 }
 
 extern bool Interp_desaturate;
@@ -586,8 +583,7 @@ void HudGaugeTargetBox::renderTargetShip(object *target_objp)
 					render_info.set_team_color(target_shipp->team_name, target_shipp->secondary_team_name, target_shipp->team_change_timestamp, target_shipp->team_change_time);
 				}
 
-				flags = (Cmdline_nohtl) ? MR_SHOW_OUTLINE : MR_SHOW_OUTLINE_HTL;
-				flags |= MR_NO_POLYS | MR_NO_LIGHTING | MR_NO_TEXTURING;
+				flags = MR_SHOW_OUTLINE_HTL | MR_NO_POLYS | MR_NO_LIGHTING | MR_NO_TEXTURING;
 
 				break;
 			case 2:
@@ -737,8 +733,7 @@ void HudGaugeTargetBox::renderTargetDebris(object *target_objp)
 			case 1:
 				render_info.set_color(255, 255, 255);
 
-				flags = (Cmdline_nohtl) ? MR_SHOW_OUTLINE : MR_SHOW_OUTLINE_HTL;
-				flags |= MR_NO_POLYS | MR_NO_LIGHTING | MR_NO_TEXTURING;
+				flags = MR_SHOW_OUTLINE_HTL | MR_NO_POLYS | MR_NO_LIGHTING | MR_NO_TEXTURING;
 
 				break;
 			case 2:
@@ -902,8 +897,7 @@ void HudGaugeTargetBox::renderTargetWeapon(object *target_objp)
 				case 1:
 					render_info.set_color(*iff_get_color_by_team_and_object(target_team, Player_ship->team, 0, target_objp));
 
-					flags = (Cmdline_nohtl) ? MR_SHOW_OUTLINE : MR_SHOW_OUTLINE_HTL;
-					flags |= MR_NO_POLYS | MR_NO_LIGHTING | MR_NO_TEXTURING;
+					flags = MR_SHOW_OUTLINE_HTL | MR_NO_POLYS | MR_NO_LIGHTING | MR_NO_TEXTURING;
 
 					break;
 				case 2:
@@ -933,8 +927,7 @@ void HudGaugeTargetBox::renderTargetWeapon(object *target_objp)
 						render_info.set_team_color(homing_shipp->team_name, homing_shipp->secondary_team_name, homing_shipp->team_change_timestamp, homing_shipp->team_change_time);
 					}
 
-					flags = (Cmdline_nohtl) ? MR_SHOW_OUTLINE : MR_SHOW_OUTLINE_HTL;
-					flags |= MR_NO_POLYS | MR_NO_LIGHTING | MR_NO_TEXTURING;
+					flags = MR_SHOW_OUTLINE_HTL | MR_NO_POLYS | MR_NO_LIGHTING | MR_NO_TEXTURING;
 
 					break;
 				case 2:
@@ -1108,8 +1101,7 @@ void HudGaugeTargetBox::renderTargetAsteroid(object *target_objp)
 				else
 					render_info.set_color(64,64,0);
 
-				flags = (Cmdline_nohtl) ? MR_SHOW_OUTLINE : MR_SHOW_OUTLINE_HTL;
-				flags |= MR_NO_POLYS | MR_NO_LIGHTING | MR_NO_TEXTURING;
+				flags = MR_SHOW_OUTLINE_HTL | MR_NO_POLYS | MR_NO_LIGHTING | MR_NO_TEXTURING;
 
 				break;
 			case 2:
@@ -1327,10 +1319,8 @@ int HudGaugeTargetBox::maybeFlashElement(int index, int flash_fast)
 
 void HudGaugeTargetBox::renderTargetClose()
 {
-	if (!Cmdline_nohtl) {
-		gr_end_view_matrix();
-		gr_end_proj_matrix();
-	}
+	gr_end_view_matrix();
+	gr_end_proj_matrix();
 
 	g3_end_frame();
 	hud_save_restore_camera_data(0);

--- a/code/lab/lab.cpp
+++ b/code/lab/lab.cpp
@@ -833,10 +833,8 @@ void labviewer_render_model(float frametime)
 	if (Lab_viewer_flags & LAB_FLAG_SHOW_DEBRIS) {
 		polymodel *pm = model_get(Lab_model_num);
 
-		if (!Cmdline_nohtl) {
-			gr_set_proj_matrix(Proj_fov, gr_screen.clip_aspect, 1.0f, Max_draw_distance);
-			gr_set_view_matrix(&Eye_position, &Eye_matrix);
-		}
+		gr_set_proj_matrix(Proj_fov, gr_screen.clip_aspect, 1.0f, Max_draw_distance);
+		gr_set_view_matrix(&Eye_position, &Eye_matrix);
 
 		for (i = 0; i < pm->num_debris_objects; i++) {
 			vec3d world_point = ZERO_VECTOR;
@@ -966,10 +964,8 @@ void labviewer_render_model(float frametime)
 			shadows_end_render();
 		}
 
-		if (!Cmdline_nohtl) {
-			gr_set_proj_matrix(Proj_fov, gr_screen.clip_aspect, 1.0f, Max_draw_distance);
-			gr_set_view_matrix(&Eye_position, &Eye_matrix);
-		}
+		gr_set_proj_matrix(Proj_fov, gr_screen.clip_aspect, 1.0f, Max_draw_distance);
+		gr_set_view_matrix(&Eye_position, &Eye_matrix);
 
 		gr_opengl_deferred_lighting_begin();
 
@@ -1051,10 +1047,8 @@ void labviewer_render_model(float frametime)
 	batch_render_all();
 	gr_copy_effect_texture();
 	batch_render_distortion_map_bitmaps();
-	if ( !Cmdline_nohtl ) {
-		gr_end_view_matrix();
-		gr_end_proj_matrix();
-	}
+	gr_end_view_matrix();
+	gr_end_proj_matrix();
 
 	g3_end_frame();
 }
@@ -1138,10 +1132,8 @@ void labviewer_render_bitmap(float frametime)
 
 	g3_set_view_matrix(&Lab_viewer_pos, &vmd_identity_matrix, Lab_viewer_zoom * 1.3f);
 
-	if ( !Cmdline_nohtl ) {
-		gr_set_proj_matrix(Proj_fov, gr_screen.clip_aspect, 1.0f, Max_draw_distance);
-		gr_set_view_matrix(&Eye_position, &Eye_matrix);
-	}
+	gr_set_proj_matrix(Proj_fov, gr_screen.clip_aspect, 1.0f, Max_draw_distance);
+	gr_set_view_matrix(&Eye_position, &Eye_matrix);
 
 
 	// draw the primary laser bitmap
@@ -1215,10 +1207,8 @@ void labviewer_render_bitmap(float frametime)
 
 	// clean up and move on ...
 
-	if ( !Cmdline_nohtl ) {
-		gr_end_view_matrix();
-		gr_end_proj_matrix();
-	}
+	gr_end_view_matrix();
+	gr_end_proj_matrix();
 
 	g3_end_frame();
 }
@@ -1917,7 +1907,7 @@ void labviewer_make_render_options_window(Button *caller)
 	ADD_RENDER_BOOL("No Team Colors", Teamcolor_override);
 	ADD_RENDER_BOOL("No Glow Points", Glowpoint_override);
 	// model flags
-	ADD_RENDER_FLAG("Wireframe", Lab_model_flags, ((Cmdline_nohtl) ? MR_SHOW_OUTLINE | MR_NO_POLYS | MR_NO_TEXTURING : MR_SHOW_OUTLINE_HTL | MR_NO_POLYS | MR_NO_TEXTURING) );
+	ADD_RENDER_FLAG("Wireframe", Lab_model_flags, MR_SHOW_OUTLINE_HTL | MR_NO_POLYS | MR_NO_TEXTURING);
 	ADD_RENDER_FLAG("Transparent", Lab_model_flags, MR_ALL_XPARENT);
 	ADD_RENDER_FLAG("No Lighting", Lab_model_flags, MR_NO_LIGHTING);
 	ADD_RENDER_FLAG("No Z-Buffer", Lab_model_flags, MR_NO_ZBUFFER);

--- a/code/lighting/lighting.cpp
+++ b/code/lighting/lighting.cpp
@@ -27,7 +27,6 @@
 
 light Lights[MAX_LIGHTS];
 int Num_lights=0;
-extern int Cmdline_nohtl;
 
 static light *Relevent_lights[MAX_LIGHTS][MAX_LIGHT_LEVELS];
 static int Num_relevent_lights[MAX_LIGHT_LEVELS];

--- a/code/menuui/techmenu.cpp
+++ b/code/menuui/techmenu.cpp
@@ -253,9 +253,6 @@ void tech_scroll_list_up();
 void tech_scroll_list_down();
 
 
-//stuff for ht&l, vars and such
-extern int Cmdline_nohtl;
-
 ////////////////////////////////////////////////////
 // like, functions and stuff
 
@@ -576,10 +573,8 @@ void techroom_ships_render(float frametime)
 		gr_set_clip(Tech_ship_display_coords[gr_screen.res][SHIP_X_COORD], Tech_ship_display_coords[gr_screen.res][SHIP_Y_COORD], Tech_ship_display_coords[gr_screen.res][SHIP_W_COORD], Tech_ship_display_coords[gr_screen.res][SHIP_H_COORD], GR_RESIZE_MENU);
     }
 	
-	if (!Cmdline_nohtl) {
-		gr_set_proj_matrix(Proj_fov, gr_screen.clip_aspect, Min_draw_distance, Max_draw_distance);
-		gr_set_view_matrix(&Eye_position, &Eye_matrix);
-	}
+	gr_set_proj_matrix(Proj_fov, gr_screen.clip_aspect, Min_draw_distance, Max_draw_distance);
+	gr_set_view_matrix(&Eye_position, &Eye_matrix);
 
 	uint render_flags = MR_AUTOCENTER;
 
@@ -594,11 +589,8 @@ void techroom_ships_render(float frametime)
 
 	batch_render_all();
 
-	if (!Cmdline_nohtl)
-	{
-		gr_end_view_matrix();
-		gr_end_proj_matrix();
-	}
+	gr_end_view_matrix();
+	gr_end_proj_matrix();
 
 	g3_end_frame();
 

--- a/code/missionui/missionbrief.cpp
+++ b/code/missionui/missionbrief.cpp
@@ -300,11 +300,6 @@ int Brief_max_line_width[GR_NUM_RESOLUTIONS] = {
 	MAX_BRIEF_LINE_W_640, MAX_BRIEF_LINE_W_1024
 };
 
-//stuff for ht&l. vars and such
-extern int Cmdline_nohtl;
-extern bool Cmdline_brief_lighting;
-
-
 // --------------------------------------------------------------------------------------
 // Forward declarations
 // --------------------------------------------------------------------------------------
@@ -1048,22 +1043,18 @@ void brief_render_closeup(int ship_class, float frametime)
 	g3_set_view_matrix(&Closeup_cam_pos, &view_orient, Closeup_zoom);
 
 
-	if (!Cmdline_nohtl) {
-		gr_set_proj_matrix(Proj_fov, gr_screen.clip_aspect, Min_draw_distance, Max_draw_distance);
-		gr_set_view_matrix(&Eye_position, &Eye_matrix);
-	}
+	gr_set_proj_matrix(Proj_fov, gr_screen.clip_aspect, Min_draw_distance, Max_draw_distance);
+	gr_set_view_matrix(&Eye_position, &Eye_matrix);
 	
-	if (Cmdline_brief_lighting) {
-		// the following is copied from menuui/techmenu.cpp ... it works heehee :D  - delt.
-		// lighting for techroom
-		light_reset();
-		vec3d light_dir = vmd_zero_vector;
-		light_dir.xyz.y = 1.0f;
-		light_add_directional(&light_dir, 0.85f, 1.0f, 1.0f, 1.0f);
-		light_rotate_all();
-		// lighting for techroom
-		Glowpoint_use_depth_buffer = false;
-	}
+	// the following is copied from menuui/techmenu.cpp ... it works heehee :D  - delt.
+	// lighting for techroom
+	light_reset();
+	vec3d light_dir = vmd_zero_vector;
+	light_dir.xyz.y = 1.0f;
+	light_add_directional(&light_dir, 0.85f, 1.0f, 1.0f, 1.0f);
+	light_rotate_all();
+	// lighting for techroom
+	Glowpoint_use_depth_buffer = false;
 
 	model_clear_instance( Closeup_icon->modelnum );
 
@@ -1080,10 +1071,8 @@ void brief_render_closeup(int ship_class, float frametime)
 	if ( Closeup_icon->type == ICON_JUMP_NODE) {
 		render_info.set_color(HUD_color_red, HUD_color_green, HUD_color_blue);
 		render_info.set_flags(MR_NO_LIGHTING | MR_AUTOCENTER | MR_NO_POLYS | MR_SHOW_OUTLINE_HTL | MR_NO_TEXTURING);
-	} else if (Cmdline_brief_lighting) {
-		render_info.set_flags(MR_AUTOCENTER);
 	} else {
-		render_info.set_flags(MR_NO_LIGHTING | MR_AUTOCENTER);
+		render_info.set_flags(MR_AUTOCENTER);
 	}
 
 	model_render_immediate( &render_info, Closeup_icon->modelnum, &Closeup_orient, &Closeup_pos );
@@ -1092,11 +1081,8 @@ void brief_render_closeup(int ship_class, float frametime)
 		The_mission.flags |= MISSION_FLAG_FULLNEB;
 	}
 
-	if (!Cmdline_nohtl)
-	{
-		gr_end_view_matrix();
-		gr_end_proj_matrix();
-	}
+	gr_end_view_matrix();
+	gr_end_proj_matrix();
 
 	g3_end_frame();
 

--- a/code/missionui/missionscreencommon.cpp
+++ b/code/missionui/missionscreencommon.cpp
@@ -1565,9 +1565,7 @@ void draw_model_icon(int model_id, int flags, float closeup_zoom, int x, int y, 
 	{
 		g3_set_view_matrix( &sip->closeup_pos, &vmd_identity_matrix, zoom);
 
-		if (!Cmdline_nohtl) {
-			gr_set_proj_matrix(0.5f*Proj_fov, gr_screen.clip_aspect, Min_draw_distance, Max_draw_distance);
-		}
+		gr_set_proj_matrix(0.5f*Proj_fov, gr_screen.clip_aspect, Min_draw_distance, Max_draw_distance);
 	}
 	else
 	{
@@ -1608,17 +1606,13 @@ void draw_model_icon(int model_id, int flags, float closeup_zoom, int x, int y, 
 		}
 		g3_set_view_matrix( &weap_closeup, &vmd_identity_matrix, tm_zoom);
 
-		if (!Cmdline_nohtl) {
-			gr_set_proj_matrix(0.5f*Proj_fov, gr_screen.clip_aspect, 0.05f, 1000.0f);
-		}
+		gr_set_proj_matrix(0.5f*Proj_fov, gr_screen.clip_aspect, 0.05f, 1000.0f);
 	}
 
 	model_render_params render_info;
 	render_info.set_detail_level_lock(0);
 
-	if (!Cmdline_nohtl)	{
-		gr_set_view_matrix(&Eye_position, &Eye_matrix);
-	}
+	gr_set_view_matrix(&Eye_position, &Eye_matrix);
 
 	if(!(flags & MR_NO_LIGHTING))
 	{
@@ -1638,12 +1632,8 @@ void draw_model_icon(int model_id, int flags, float closeup_zoom, int x, int y, 
 	model_render_immediate(&render_info, model_id, &object_orient, &vmd_zero_vector);
 	Glowpoint_override = false;
 
-	if (!Cmdline_nohtl) 
-	{
-		gr_end_view_matrix();
-		gr_end_proj_matrix();
-	}
-
+	gr_end_view_matrix();
+	gr_end_proj_matrix();
 
 	g3_end_frame();
 	gr_reset_clip();

--- a/code/missionui/missionshipchoice.cpp
+++ b/code/missionui/missionshipchoice.cpp
@@ -297,7 +297,6 @@ static int				Num_mask_regions;
 
 //stuff for ht&l. vars and such
 extern float View_zoom, Canv_h2, Canv_w2;
-extern int Cmdline_nohtl;
 
 //////////////////////////////////////////////////////
 // Drag and Drop variables

--- a/code/missionui/missionweaponchoice.cpp
+++ b/code/missionui/missionweaponchoice.cpp
@@ -905,10 +905,8 @@ void wl_render_overhead_view(float frametime)
 				gr_set_clip(Wl_overhead_coords[gr_screen.res][0], Wl_overhead_coords[gr_screen.res][1], gr_screen.res == 0 ? 291 : 467, gr_screen.res == 0 ? 226 : 362, GR_RESIZE_MENU);
 			}
 			
-			if (!Cmdline_nohtl) {
-				gr_set_proj_matrix(Proj_fov, gr_screen.clip_aspect, Min_draw_distance, Max_draw_distance);
-				gr_set_view_matrix(&Eye_position, &Eye_matrix);
-			}
+			gr_set_proj_matrix(Proj_fov, gr_screen.clip_aspect, Min_draw_distance, Max_draw_distance);
+			gr_set_view_matrix(&Eye_position, &Eye_matrix);
 
 			render_info.set_flags(MR_AUTOCENTER | MR_NO_FOGGING);
 
@@ -1051,11 +1049,8 @@ void wl_render_overhead_view(float frametime)
 			}
 
 			//Cleanup
-			if (!Cmdline_nohtl) 
-			{
-				gr_end_view_matrix();
-				gr_end_proj_matrix();
-			}
+			gr_end_view_matrix();
+			gr_end_proj_matrix();
 
 			g3_end_frame();
 			

--- a/code/model/modelinterp.cpp
+++ b/code/model/modelinterp.cpp
@@ -634,24 +634,17 @@ void model_interp_defpoints(ubyte * p, polymodel *pm, bsp_info *sm)
 
 		for (n=0; n<nverts; n++ )	{	
 
-			if(!Cmdline_nohtl) {
-				if(GEOMETRY_NOISE!=0.0f){
-					GEOMETRY_NOISE = model_radius / 50;
+			if(GEOMETRY_NOISE!=0.0f){
+				GEOMETRY_NOISE = model_radius / 50;
 
-					Interp_verts[n] = src;	
-					point.xyz.x = src->xyz.x + frand_range(GEOMETRY_NOISE,-GEOMETRY_NOISE);
-					point.xyz.y = src->xyz.y + frand_range(GEOMETRY_NOISE,-GEOMETRY_NOISE);
-					point.xyz.z = src->xyz.z + frand_range(GEOMETRY_NOISE,-GEOMETRY_NOISE);
-							
-					g3_rotate_vertex(dest, &point);
-				}else{
-					Interp_verts[n] = src;	
-					g3_rotate_vertex(dest, src);
-				}
-			}
-			else {
-				Interp_verts[n] = src; 	 	 
-
+				Interp_verts[n] = src;	
+				point.xyz.x = src->xyz.x + frand_range(GEOMETRY_NOISE,-GEOMETRY_NOISE);
+				point.xyz.y = src->xyz.y + frand_range(GEOMETRY_NOISE,-GEOMETRY_NOISE);
+				point.xyz.z = src->xyz.z + frand_range(GEOMETRY_NOISE,-GEOMETRY_NOISE);
+						
+				g3_rotate_vertex(dest, &point);
+			}else{
+				Interp_verts[n] = src;	
 				g3_rotate_vertex(dest, src);
 			}
 
@@ -852,30 +845,28 @@ void model_interp_tmappoly(ubyte * p,polymodel * pm)
 
 	model_allocate_interp_data(max_n_verts, max_n_norms, nv);
 
-	if ( !Cmdline_nohtl ) {
-		if (Interp_warp_bitmap < 0) {
-			if (!g3_check_normal_facing(vp(p+20),vp(p+8)) && !(Interp_flags & MR_NO_CULL)){
-				if(!splodeing) return;
-			}
+	if (Interp_warp_bitmap < 0) {
+		if (!g3_check_normal_facing(vp(p+20),vp(p+8)) && !(Interp_flags & MR_NO_CULL)){
+			if(!splodeing) return;
 		}
+	}
 
-		if(splodeing){
-			float salpha = 1.0f - splode_level;
-			for (i=0;i<nv;i++){
-				Interp_list[i] = &Interp_splode_points[verts[i].vertnum];
-				Interp_list[i]->texture_position.u = verts[i].u*2;
-				Interp_list[i]->texture_position.v = verts[i].v*2;
-				Interp_list[i]->r = (unsigned char)(255*salpha);
-				Interp_list[i]->g = (unsigned char)(250*salpha);
-				Interp_list[i]->b = (unsigned char)(200*salpha);
-				model_interp_edge_alpha(&Interp_list[i]->r, &Interp_list[i]->g, &Interp_list[i]->b, Interp_verts[verts[i].vertnum], Interp_norms[verts[i].normnum], salpha, false);
-			}
-			cull = gr_set_cull(0);
-			gr_set_bitmap( splodeingtexture, GR_ALPHABLEND_FILTER, GR_BITBLT_MODE_NORMAL, salpha );
-			g3_draw_poly( nv, Interp_list,  TMAP_FLAG_TEXTURED|TMAP_FLAG_GOURAUD);
-			gr_set_cull(cull);
-			return;
+	if(splodeing){
+		float salpha = 1.0f - splode_level;
+		for (i=0;i<nv;i++){
+			Interp_list[i] = &Interp_splode_points[verts[i].vertnum];
+			Interp_list[i]->texture_position.u = verts[i].u*2;
+			Interp_list[i]->texture_position.v = verts[i].v*2;
+			Interp_list[i]->r = (unsigned char)(255*salpha);
+			Interp_list[i]->g = (unsigned char)(250*salpha);
+			Interp_list[i]->b = (unsigned char)(200*salpha);
+			model_interp_edge_alpha(&Interp_list[i]->r, &Interp_list[i]->g, &Interp_list[i]->b, Interp_verts[verts[i].vertnum], Interp_norms[verts[i].normnum], salpha, false);
 		}
+		cull = gr_set_cull(0);
+		gr_set_bitmap( splodeingtexture, GR_ALPHABLEND_FILTER, GR_BITBLT_MODE_NORMAL, salpha );
+		g3_draw_poly( nv, Interp_list,  TMAP_FLAG_TEXTURED|TMAP_FLAG_GOURAUD);
+		gr_set_cull(cull);
+		return;
 	}
 
 	for (i=0;i<nv;i++)	{
@@ -1872,15 +1863,9 @@ void model_render_insignias(polymodel *pm, int detail_level, int bitmap_num)
 			vm_vec_add(&t2, &pm->ins[idx].vecs[i2], &pm->ins[idx].offset);
 			vm_vec_add(&t3, &pm->ins[idx].vecs[i3], &pm->ins[idx].offset);
 
-			if(Cmdline_nohtl){
-				g3_rotate_vertex(&vecs[0], &t1);
-				g3_rotate_vertex(&vecs[1], &t2);
-				g3_rotate_vertex(&vecs[2], &t3);
-			}else{
-				g3_transfer_vertex(&vecs[0], &t1);
-				g3_transfer_vertex(&vecs[1], &t2);
-				g3_transfer_vertex(&vecs[2], &t3);
-			}
+			g3_transfer_vertex(&vecs[0], &t1);
+			g3_transfer_vertex(&vecs[1], &t2);
+			g3_transfer_vertex(&vecs[2], &t3);
 
 			// setup texture coords
 			vecs[0].texture_position.u = pm->ins[idx].u[s_idx][0];
@@ -1892,12 +1877,10 @@ void model_render_insignias(polymodel *pm, int detail_level, int bitmap_num)
 			vecs[2].texture_position.u = pm->ins[idx].u[s_idx][2];
 			vecs[2].texture_position.v = pm->ins[idx].v[s_idx][2];
 
-			if (!Cmdline_nohtl) {
-				light_apply_rgb( &vecs[0].r, &vecs[0].g, &vecs[0].b, &pm->ins[idx].vecs[i1], &pm->ins[idx].norm[i1], 1.5f );
-				light_apply_rgb( &vecs[1].r, &vecs[1].g, &vecs[1].b, &pm->ins[idx].vecs[i2], &pm->ins[idx].norm[i2], 1.5f );
-				light_apply_rgb( &vecs[2].r, &vecs[2].g, &vecs[2].b, &pm->ins[idx].vecs[i3], &pm->ins[idx].norm[i3], 1.5f );
-				tmap_flags |= (TMAP_FLAG_RGB | TMAP_FLAG_GOURAUD);
-			}
+			light_apply_rgb( &vecs[0].r, &vecs[0].g, &vecs[0].b, &pm->ins[idx].vecs[i1], &pm->ins[idx].norm[i1], 1.5f );
+			light_apply_rgb( &vecs[1].r, &vecs[1].g, &vecs[1].b, &pm->ins[idx].vecs[i2], &pm->ins[idx].norm[i2], 1.5f );
+			light_apply_rgb( &vecs[2].r, &vecs[2].g, &vecs[2].b, &pm->ins[idx].vecs[i3], &pm->ins[idx].norm[i3], 1.5f );
+			tmap_flags |= (TMAP_FLAG_RGB | TMAP_FLAG_GOURAUD);
 
 			// draw the polygon
 			g3_draw_poly(3, vlist, tmap_flags);
@@ -2442,11 +2425,7 @@ void model_render_thrusters(polymodel *pm, int objnum, ship *shipp, matrix *orie
 			float w = gpt->radius * (scale + Interp_thrust_glow_noise * NOISE_SCALE);
 
 			// these lines are used by the tertiary glows, thus we will need to project this all of the time
-			if (Cmdline_nohtl) {
-				g3_rotate_vertex( &p, &world_pnt );
-			} else {
-				g3_transfer_vertex( &p, &world_pnt );
-			}
+			g3_transfer_vertex( &p, &world_pnt );
 
 			// start primary thruster glows
 			if ( (Interp_thrust_glow_bitmap >= 0) && (d > 0.0f) ) {
@@ -2732,11 +2711,7 @@ void model_render_glow_points_DEPRECATED(polymodel *pm, ship *shipp, matrix *ori
 								if (Interp_tmap_flags & TMAP_FLAG_PIXEL_FOG)
 									gr_fog_set(GR_FOGMODE_NONE, 0, 0, 0);
 	
-								if (!Cmdline_nohtl) {
-									g3_transfer_vertex(&p, &world_pnt);
-								} else {
-									g3_rotate_vertex(&p, &world_pnt);
-								}
+								g3_transfer_vertex(&p, &world_pnt);
 
 								p.r = p.g = p.b = p.a = (ubyte)(255.0f * MAX(d,0.0f));
 								
@@ -2845,23 +2820,10 @@ void model_render_glow_points_DEPRECATED(polymodel *pm, ship *shipp, matrix *ori
 							moldel_calc_facing_pts(&top1, &bottom1, &fvec, &loc_offset, gpt->radius, 1.0f, &View_position);
 							moldel_calc_facing_pts(&top2, &bottom2, &fvec, &loc_norm, gpt->radius, 1.0f, &View_position);
 
-							int idx = 0;
-
-							if (Cmdline_nohtl) {
-								g3_rotate_vertex(&verts[0], &bottom1);
-								g3_rotate_vertex(&verts[1], &bottom2);
-								g3_rotate_vertex(&verts[2], &top2);
-								g3_rotate_vertex(&verts[3], &top1);
-
-								for (idx = 0; idx < 4; idx++) {
-									g3_project_vertex(&verts[idx]);
-								}
-							} else {
-								g3_transfer_vertex(&verts[0], &bottom1);
-								g3_transfer_vertex(&verts[1], &bottom2);
-								g3_transfer_vertex(&verts[2], &top2);
-								g3_transfer_vertex(&verts[3], &top1);
-							}
+							g3_transfer_vertex(&verts[0], &bottom1);
+							g3_transfer_vertex(&verts[1], &bottom2);
+							g3_transfer_vertex(&verts[2], &top2);
+							g3_transfer_vertex(&verts[3], &top1);
 
 							verts[0].texture_position.u = 0.0f;
 							verts[0].texture_position.v = 0.0f;
@@ -2991,7 +2953,7 @@ void model_really_render(int model_num, matrix *orient, vec3d * pos, uint flags,
 	}
 
 	bool is_outlines_only = (flags & MR_DEPRECATED_NO_POLYS) && ((flags & MR_DEPRECATED_SHOW_OUTLINE_PRESET) || (flags & MR_DEPRECATED_SHOW_OUTLINE));
-	bool is_outlines_only_htl = !Cmdline_nohtl && (flags & MR_DEPRECATED_NO_POLYS) && (flags & MR_DEPRECATED_SHOW_OUTLINE_HTL);
+	bool is_outlines_only_htl = (flags & MR_DEPRECATED_NO_POLYS) && (flags & MR_DEPRECATED_SHOW_OUTLINE_HTL);
 	bool use_api = !is_outlines_only_htl || (gr_screen.mode == GR_OPENGL);
 
 	g3_start_instance_matrix(pos, orient, use_api);
@@ -3186,15 +3148,13 @@ void model_really_render(int model_num, matrix *orient, vec3d * pos, uint flags,
 	if ( !(Interp_flags & MR_DEPRECATED_NO_LIGHTING) )	{
 		light_rotate_all();
  
-		if ( !Cmdline_nohtl ) {
-			light_set_all_relevent();
-		}
+		light_set_all_relevent();
 	}
-	if ( !(Interp_flags & MR_DEPRECATED_NO_LIGHTING) && (is_outlines_only_htl || (!Cmdline_nohtl && !is_outlines_only)) ) {
+	if ( !(Interp_flags & MR_DEPRECATED_NO_LIGHTING) && (is_outlines_only_htl || (!is_outlines_only)) ) {
 		opengl_change_active_lights(0); // Set up OpenGl lighting;
 	}
 
-	if (is_outlines_only_htl || (!Cmdline_nohtl && !is_outlines_only)) {
+	if (is_outlines_only_htl || (!is_outlines_only)) {
 		gr_set_buffer(pm->vertex_buffer_id);
 	}
 
@@ -3207,7 +3167,7 @@ void model_really_render(int model_num, matrix *orient, vec3d * pos, uint flags,
 	while( i >= 0 )	{
 		if ( !pm->submodel[i].is_thruster ) {
 			// When in htl mode render with htl method unless its a jump node
-			if (is_outlines_only_htl || (!Cmdline_nohtl && !is_outlines_only)) {
+			if (is_outlines_only_htl || (!is_outlines_only)) {
 				model_render_children_buffers_DEPRECATED( pm, i, Interp_detail_level, render );
 			} else {
 				model_interp_subcall( pm, i, Interp_detail_level );
@@ -3226,7 +3186,7 @@ void model_really_render(int model_num, matrix *orient, vec3d * pos, uint flags,
 	//*************************** draw the hull of the ship *********************************************
 
 	// When in htl mode render with htl method unless its a jump node
-	if (is_outlines_only_htl || (!Cmdline_nohtl && !is_outlines_only)) {
+	if (is_outlines_only_htl || (!is_outlines_only)) {
 		model_render_buffers_DEPRECATED(pm, pm->detail[Interp_detail_level], render);
 	} else {
 		model_interp_subcall(pm, pm->detail[Interp_detail_level], Interp_detail_level);
@@ -3239,7 +3199,7 @@ void model_really_render(int model_num, matrix *orient, vec3d * pos, uint flags,
 		while( i >= 0 ) {
 			if (pm->submodel[i].is_thruster) {
 				// When in htl mode render with htl method unless its a jump node
-				if (is_outlines_only_htl || (!Cmdline_nohtl && !is_outlines_only)) {
+				if (is_outlines_only_htl || (!is_outlines_only)) {
 					model_render_children_buffers_DEPRECATED( pm, i, Interp_detail_level, render );
 				} else {
 					model_interp_subcall( pm, i, Interp_detail_level );
@@ -3252,7 +3212,7 @@ void model_really_render(int model_num, matrix *orient, vec3d * pos, uint flags,
 	if ( !Interp_no_flush ) {
 		gr_clear_states();
 
-		if (is_outlines_only_htl || (!Cmdline_nohtl && !is_outlines_only)) {
+		if (is_outlines_only_htl || (!is_outlines_only)) {
 			gr_set_buffer(-1);
 		}
 	}
@@ -3281,7 +3241,7 @@ void model_really_render(int model_num, matrix *orient, vec3d * pos, uint flags,
 	// render model insignias
 	gr_zbias(1);
 
-	if (!Cmdline_nohtl)	gr_set_texture_panning(0.0, 0.0, false);
+	gr_set_texture_panning(0.0, 0.0, false);
 
 	gr_zbuffer_set(GR_ZBUFF_READ);
 	if(!(Interp_flags & MR_DEPRECATED_NO_TEXTURING))
@@ -3300,13 +3260,11 @@ void model_really_render(int model_num, matrix *orient, vec3d * pos, uint flags,
  	}	
 
  	if ( Interp_flags & MR_DEPRECATED_SHOW_PATHS ){
- 		if (Cmdline_nohtl) model_draw_paths(model_num, Interp_flags);
- 		else model_draw_paths_htl(model_num, Interp_flags);
+ 		model_draw_paths_htl(model_num, Interp_flags);
  	}
 
  	if (Interp_flags & MR_DEPRECATED_BAY_PATHS ){
- 		if (Cmdline_nohtl) model_draw_bay_paths(model_num);
- 		else model_draw_bay_paths_htl(model_num);
+ 		model_draw_bay_paths_htl(model_num);
  	}
 
 	if ( (Interp_flags & MR_DEPRECATED_AUTOCENTER) && (set_autocen) ) {
@@ -3384,7 +3342,7 @@ void submodel_render_DEPRECATED(int model_num, int submodel_num, matrix *orient,
 // 	if ( Interp_flags & MR_ANIMATED_SHADER )
 // 		Interp_tmap_flags |= TMAP_ANIMATED_SHADER;
 
-	bool is_outlines_only_htl = !Cmdline_nohtl && (flags & MR_NO_POLYS) && (flags & MR_SHOW_OUTLINE_HTL);
+	bool is_outlines_only_htl = (flags & MR_NO_POLYS) && (flags & MR_SHOW_OUTLINE_HTL);
 
 	//set to true since D3d and OGL need the api matrices set
 	g3_start_instance_matrix(pos, orient, true);
@@ -3431,9 +3389,7 @@ void submodel_render_DEPRECATED(int model_num, int submodel_num, matrix *orient,
 
 		light_rotate_all();
 
-		if (!Cmdline_nohtl) {
-			light_set_all_relevent();
-		}
+		light_set_all_relevent();
 
 		gr_set_lighting(true, true);
 	}
@@ -3451,34 +3407,29 @@ void submodel_render_DEPRECATED(int model_num, int submodel_num, matrix *orient,
 	// fixes disappearing HUD in OGL - taylor
 	int cull = gr_set_cull(1);
 
-	if (!Cmdline_nohtl) {
+	// RT - Put this here to fog debris
+	if(Interp_tmap_flags & TMAP_FLAG_PIXEL_FOG)
+	{
+		float fog_near, fog_far;
+		object *obj = NULL;
+		
+		if (objnum >= 0)
+			obj = &Objects[objnum];
 
-		// RT - Put this here to fog debris
-		if(Interp_tmap_flags & TMAP_FLAG_PIXEL_FOG)
-		{
-			float fog_near, fog_far;
-			object *obj = NULL;
-			
-			if (objnum >= 0)
-				obj = &Objects[objnum];
-
-			neb2_get_adjusted_fog_values(&fog_near, &fog_far, obj);
-			unsigned char r, g, b;
-			neb2_get_fog_color(&r, &g, &b);
-			gr_fog_set(GR_FOGMODE_FOG, r, g, b, fog_near, fog_far);
-		}
-		if(Rendering_to_shadow_map)
-			gr_zbias(-1024);
-		else
-			gr_zbias(0);
-		gr_set_buffer(pm->vertex_buffer_id);
-
-		model_render_buffers_DEPRECATED(pm, submodel_num, render);
-
-		gr_set_buffer(-1);
-	} else {
-		model_interp_sub( pm->submodel[submodel_num].bsp_data, pm, &pm->submodel[submodel_num], 0 );
+		neb2_get_adjusted_fog_values(&fog_near, &fog_far, obj);
+		unsigned char r, g, b;
+		neb2_get_fog_color(&r, &g, &b);
+		gr_fog_set(GR_FOGMODE_FOG, r, g, b, fog_near, fog_far);
 	}
+	if(Rendering_to_shadow_map)
+		gr_zbias(-1024);
+	else
+		gr_zbias(0);
+	gr_set_buffer(pm->vertex_buffer_id);
+
+	model_render_buffers_DEPRECATED(pm, submodel_num, render);
+
+	gr_set_buffer(-1);
 
 	if ( !(Interp_flags & MR_NO_LIGHTING) ) {
 		gr_set_lighting(false, false);

--- a/code/model/modelread.cpp
+++ b/code/model/modelread.cpp
@@ -59,7 +59,6 @@ SCP_vector<polymodel_instance*> Polygon_model_instances;
 SCP_vector<bsp_collision_tree> Bsp_collision_tree_list;
 
 static int model_initted = 0;
-extern int Cmdline_nohtl;
 
 #ifndef NDEBUG
 CFILE *ss_fp = NULL;			// file pointer used to dump subsystem information
@@ -263,9 +262,7 @@ void model_unload(int modelnum, int force)
 
 	if (pm->submodel) {
 		for (i = 0; i < pm->n_models; i++) {
-			if ( !Cmdline_nohtl ) {
-				pm->submodel[i].buffer.clear();
-			}
+			pm->submodel[i].buffer.clear();
 
 			if ( pm->submodel[i].bsp_data )	{
 				vm_free(pm->submodel[i].bsp_data);
@@ -279,9 +276,7 @@ void model_unload(int modelnum, int force)
 		delete[] pm->submodel;
 	}
 
-	if ( !Cmdline_nohtl ) {
-		gr_destroy_buffer(pm->vertex_buffer_id);
-	}
+	gr_destroy_buffer(pm->vertex_buffer_id);
 
 	if ( pm->xc ) {
 		vm_free(pm->xc);
@@ -850,7 +845,7 @@ void create_family_tree(polymodel *obj)
 
 void create_vertex_buffer(polymodel *pm)
 {
-	if (Cmdline_nohtl || Is_standalone) {
+	if (Is_standalone) {
 		return;
 	}
 

--- a/code/model/modelrender.cpp
+++ b/code/model/modelrender.cpp
@@ -1760,7 +1760,7 @@ void submodel_render_queue(model_render_params *render_info, draw_list *scene, i
 		scene->set_animated_timer(render_info->get_animated_effect_timer());
 	}
 
-	bool is_outlines_only_htl = !Cmdline_nohtl && (flags & MR_NO_POLYS) && (flags & MR_SHOW_OUTLINE_HTL);
+	bool is_outlines_only_htl = (flags & MR_NO_POLYS) && (flags & MR_SHOW_OUTLINE_HTL);
 
 	//set to true since D3d and OGL need the api matrices set
 	scene->push_transform(pos, orient);
@@ -1934,11 +1934,7 @@ void model_render_glowpoint(int point_num, vec3d *pos, matrix *orient, glow_poin
 					w *= 1.5;	//make it bigger in a nebula
 				}
 				
-				if (!Cmdline_nohtl) {
-					g3_transfer_vertex(&p, &world_pnt);
-				} else {
-					g3_rotate_vertex(&p, &world_pnt);
-				}
+				g3_transfer_vertex(&p, &world_pnt);
 
 				p.r = p.g = p.b = p.a = (ubyte)(255.0f * MAX(d,0.0f));
 
@@ -2056,23 +2052,10 @@ void model_render_glowpoint(int point_num, vec3d *pos, matrix *orient, glow_poin
 			moldel_calc_facing_pts(&top1, &bottom1, &fvec, &loc_offset, gpt->radius, 1.0f, &View_position);
 			moldel_calc_facing_pts(&top2, &bottom2, &fvec, &loc_norm, gpt->radius, 1.0f, &View_position);
 
-			int idx = 0;
-
-			if ( Cmdline_nohtl ) {
-				g3_rotate_vertex(&verts[0], &bottom1);
-				g3_rotate_vertex(&verts[1], &bottom2);
-				g3_rotate_vertex(&verts[2], &top2);
-				g3_rotate_vertex(&verts[3], &top1);
-
-				for ( idx = 0; idx < 4; idx++ ) {
-					g3_project_vertex(&verts[idx]);
-				}
-			} else {
-				g3_transfer_vertex(&verts[0], &bottom1);
-				g3_transfer_vertex(&verts[1], &bottom2);
-				g3_transfer_vertex(&verts[2], &top2);
-				g3_transfer_vertex(&verts[3], &top1);
-			}
+			g3_transfer_vertex(&verts[0], &bottom1);
+			g3_transfer_vertex(&verts[1], &bottom2);
+			g3_transfer_vertex(&verts[2], &top2);
+			g3_transfer_vertex(&verts[3], &top1);
 
 			verts[0].texture_position.u = 0.0f;
 			verts[0].texture_position.v = 0.0f;
@@ -2424,11 +2407,7 @@ void model_queue_render_thrusters(model_render_params *interp, polymodel *pm, in
 			float w = gpt->radius * (scale + thruster_info.glow_noise * NOISE_SCALE);
 
 			// these lines are used by the tertiary glows, thus we will need to project this all of the time
-			if (Cmdline_nohtl) {
-				g3_rotate_vertex( &p, &world_pnt );
-			} else {
-				g3_transfer_vertex( &p, &world_pnt );
-			}
+			g3_transfer_vertex( &p, &world_pnt );
 
 			// start primary thruster glows
 			if ( (thruster_info.primary_glow_bitmap >= 0) && (d > 0.0f) ) {
@@ -2668,13 +2647,11 @@ void model_render_debug(int model_num, matrix *orient, vec3d * pos, uint flags, 
 	}	
 
 	if ( debug_flags & MR_DEBUG_PATHS ) {
-		if ( Cmdline_nohtl ) model_draw_paths(model_num, flags);
-		else model_draw_paths_htl(model_num, flags);
+		model_draw_paths_htl(model_num, flags);
 	}
 
 	if ( debug_flags & MR_DEBUG_BAY_PATHS ) {
-		if ( Cmdline_nohtl ) model_draw_bay_paths(model_num);
-		else model_draw_bay_paths_htl(model_num);
+		model_draw_bay_paths_htl(model_num);
 	}
 
 	if ( (flags & MR_AUTOCENTER) && (set_autocen) ) {
@@ -2829,7 +2806,7 @@ void model_render_queue(model_render_params *interp, draw_list *scene, int model
 	}
 
 	bool is_outlines_only = (model_flags & MR_NO_POLYS) && ((model_flags & MR_SHOW_OUTLINE_PRESET) || (model_flags & MR_SHOW_OUTLINE));
-	bool is_outlines_only_htl = !Cmdline_nohtl && (model_flags & MR_NO_POLYS) && (model_flags & MR_SHOW_OUTLINE_HTL);
+	bool is_outlines_only_htl = (model_flags & MR_NO_POLYS) && (model_flags & MR_SHOW_OUTLINE_HTL);
 
 	scene->push_transform(pos, orient);
 
@@ -2903,7 +2880,7 @@ void model_render_queue(model_render_params *interp, draw_list *scene, int model
 		scene->set_lighting(false);
 	}
 	
-	if (is_outlines_only_htl || (!Cmdline_nohtl && !is_outlines_only)) {
+	if (is_outlines_only_htl || (!is_outlines_only)) {
 		scene->set_buffer(pm->vertex_buffer_id);
 	}
 

--- a/code/nebula/neb.cpp
+++ b/code/nebula/neb.cpp
@@ -351,7 +351,7 @@ void neb2_post_level_init()
 		return;
 	}
 
-	if ( (Cmdline_nohtl) && (The_mission.flags & MISSION_FLAG_FULLNEB) ) {
+	if (The_mission.flags & MISSION_FLAG_FULLNEB) {
 		// by default we'll use pof rendering
 		Neb2_render_mode = NEB2_RENDER_POF;
 		stars_set_background_model(BACKGROUND_MODEL_FILENAME, Neb2_texture_name);
@@ -1082,10 +1082,9 @@ void neb2_render_player()
 				// set the bitmap and render
 				gr_set_bitmap(Neb2_cubes[idx1][idx2][idx3].bmap, GR_ALPHABLEND_FILTER, GR_BITBLT_MODE_NORMAL, (alpha + Neb2_cubes[idx1][idx2][idx3].flash));
 
-				if (!Cmdline_nohtl) gr_set_lighting(false, false); {
-					gr_fog_set(GR_FOGMODE_NONE, 0, 0, 0);
-					g3_draw_rotated_bitmap(&p, fl_radians(Neb2_cubes[idx1][idx2][idx3].rot), Nd->prad, TMAP_FLAG_TEXTURED);
-				}
+				gr_set_lighting(false, false);
+				gr_fog_set(GR_FOGMODE_NONE, 0, 0, 0);
+				g3_draw_rotated_bitmap(&p, fl_radians(Neb2_cubes[idx1][idx2][idx3].rot), Nd->prad, TMAP_FLAG_TEXTURED);
 			} 
 		}
 	}
@@ -1590,9 +1589,7 @@ DCF(neb2_mode, "Switches nebula render modes")
 		break;
 
 		case NEB2_RENDER_HTL:
-			if (!Cmdline_nohtl) {
-				Neb2_render_mode = NEB2_RENDER_HTL;
-			}
+			Neb2_render_mode = NEB2_RENDER_HTL;
 		break;
 	}
 }

--- a/code/nebula/neblightning.cpp
+++ b/code/nebula/neblightning.cpp
@@ -23,8 +23,6 @@
 #include "render/3d.h"
 #include "weapon/emp.h"
 
-extern int Cmdline_nohtl;
-
 // ------------------------------------------------------------------------------------------------------
 // NEBULA LIGHTNING DEFINES/VARS
 //
@@ -970,20 +968,11 @@ void nebl_generate_section(bolt_type *bi, float width, l_node *a, l_node *b, l_s
 			Nebl_flash_y += tempv.screen.xyw.y;
 			Nebl_flash_count++;
 		}
-
-		if (Cmdline_nohtl) {
-			memcpy(&c->vex[idx], &tempv, sizeof(vertex));
-		}
 	}
 	// calculate the glow points		
 	nebl_calc_facing_pts_smart(&glow_a, &glow_b, &dir_normal, &a->pos, pinch_a ? 0.5f : width * 6.0f, Nebl_type->b_add);
-	if (Cmdline_nohtl) {
-		g3_rotate_vertex(&c->glow_vex[0], &glow_a);
-		g3_rotate_vertex(&c->glow_vex[1], &glow_b);
-	} else {
-		g3_transfer_vertex(&c->glow_vex[0], &glow_a);
-		g3_transfer_vertex(&c->glow_vex[1], &glow_b);
-	}
+	g3_transfer_vertex(&c->glow_vex[0], &glow_a);
+	g3_transfer_vertex(&c->glow_vex[1], &glow_b);
 
 	// maybe do a cap
 	if(cap != NULL){		
@@ -1008,21 +997,12 @@ void nebl_generate_section(bolt_type *bi, float width, l_node *a, l_node *b, l_s
 				Nebl_flash_y += tempv.screen.xyw.y;
 				Nebl_flash_count++;
 			}
-
-			if (Cmdline_nohtl) {
-				memcpy(&cap->vex[idx], &tempv, sizeof(vertex));
-			}
 		}
 		
 		// calculate the glow points		
 		nebl_calc_facing_pts_smart(&glow_a, &glow_b, &dir_normal, &b->pos, pinch_b ? 0.5f : width * 6.0f, bi->b_add);
-		if (Cmdline_nohtl) {
-			g3_rotate_vertex(&cap->glow_vex[0], &glow_a);
-			g3_rotate_vertex(&cap->glow_vex[1], &glow_b);
-		} else {
-			g3_transfer_vertex(&cap->glow_vex[0], &glow_a);
-			g3_transfer_vertex(&cap->glow_vex[1], &glow_b);
-		}
+		g3_transfer_vertex(&cap->glow_vex[0], &glow_a);
+		g3_transfer_vertex(&cap->glow_vex[1], &glow_b);
 	}
 }
 

--- a/code/object/objectsort.cpp
+++ b/code/object/objectsort.cpp
@@ -167,7 +167,6 @@ inline bool obj_render_is_model(object *obj)
 
 // Sorts all the objects by Z and renders them
 extern int Fred_active;
-extern int Cmdline_nohtl;
 extern int Interp_no_flush;
 void obj_render_all(void (*render_function)(object *objp), bool *draw_viewer_last )
 {
@@ -228,16 +227,13 @@ void obj_render_all(void (*render_function)(object *objp), bool *draw_viewer_las
 	std::sort(Sorted_objects.begin(), Sorted_objects.end());
 
 #ifdef DYN_CLIP_DIST
-	if (!Cmdline_nohtl)
-	{
-		if(closest_obj < Min_draw_distance)
-			closest_obj = Min_draw_distance;
-		if(farthest_obj > Max_draw_distance)
-			farthest_obj = Max_draw_distance;
+	if(closest_obj < Min_draw_distance)
+		closest_obj = Min_draw_distance;
+	if(farthest_obj > Max_draw_distance)
+		farthest_obj = Max_draw_distance;
 
-		gr_set_proj_matrix(Proj_fov, gr_screen.clip_aspect, closest_obj, farthest_obj);
-		gr_set_view_matrix(&Eye_position, &Eye_matrix);
-	}
+	gr_set_proj_matrix(Proj_fov, gr_screen.clip_aspect, closest_obj, farthest_obj);
+	gr_set_view_matrix(&Eye_position, &Eye_matrix);
 #endif
 
 	gr_zbuffer_set( GR_ZBUFF_FULL );	

--- a/code/particle/particle.cpp
+++ b/code/particle/particle.cpp
@@ -408,8 +408,7 @@ void particle_render_all()
 				continue;
 			}
 
-			if (!Cmdline_nohtl)
-				g3_transfer_vertex(&pos, &p_pos);
+			g3_transfer_vertex(&pos, &p_pos);
 		}
 
 		// figure out which frame we should be using

--- a/code/radar/radarorb.cpp
+++ b/code/radar/radarorb.cpp
@@ -34,8 +34,6 @@ extern rcol Radar_color_rgb[MAX_RADAR_COLORS][MAX_RADAR_LEVELS];
 
 extern int radar_target_id_flags;
 
-extern int Cmdline_nohtl;
-
 vec3d orb_ring_yz[NUM_ORB_RING_SLICES];
 vec3d orb_ring_xy[NUM_ORB_RING_SLICES];
 vec3d orb_ring_xz[NUM_ORB_RING_SLICES];
@@ -190,14 +188,7 @@ void HudGaugeRadarOrb::blipDrawDistorted(blip *b, vec3d *pos)
 	vm_vec_random_cone(&out,pos,distortion_angle);
 	vm_vec_scale(&out,dist);
 
-    if (Cmdline_nohtl)
-    {
-	    drawContact(&out,b->rad);
-    }
-    else
-    {
-        drawContactHtl(&out,b->rad);
-    }
+    drawContactHtl(&out,b->rad);
 }
 
 // blip is for a target immune to sensors, so cause to flicker in/out with mild distortion
@@ -236,14 +227,7 @@ void HudGaugeRadarOrb::blipDrawFlicker(blip *b, vec3d *pos)
 	vm_vec_random_cone(&out,pos,distortion_angle);
 	vm_vec_scale(&out,dist);
 
-	if (Cmdline_nohtl)
-    {
-	    drawContact(&out,b->rad);
-    }
-    else
-    {
-        drawContactHtl(&out,b->rad);
-    }
+    drawContactHtl(&out,b->rad);
 }
 
 // Draw all the active radar blips
@@ -295,11 +279,7 @@ void HudGaugeRadarOrb::drawBlips(int blip_type, int bright, int distort)
 		}
 		else
 		{
-            if (Cmdline_nohtl)
-            {
-               drawContact(&pos,b->rad);
-            }
-            else if (b->radar_image_2d >= 0 || b->radar_color_image_2d >= 0)
+            if (b->radar_image_2d >= 0 || b->radar_color_image_2d >= 0)
 			{
 				drawContactImage(&pos, b->rad, b->radar_image_2d, b->radar_color_image_2d, b->radar_projection_size);
 			}
@@ -497,17 +477,8 @@ void HudGaugeRadarOrb::render(float frametime)
 	blitGauge();
 	drawRange();
 
-    if (Cmdline_nohtl)
-    {
-        setupView();
-        drawOutlines();
-    }
-    else
-    {
-        setupViewHtl();
-        drawOutlinesHtl();
-    }
-	
+    setupViewHtl();
+    drawOutlinesHtl();
 
 	if ( timestamp_elapsed(Radar_static_next) ) {
 		Radar_static_playing ^= 1;
@@ -539,14 +510,7 @@ void HudGaugeRadarOrb::render(float frametime)
 		}
 	}
 	
-    if (Cmdline_nohtl)
-    {
-	    doneDrawing();
-    }
-    else
-    {
-        doneDrawingHtl();
-    }
+    doneDrawingHtl();
 
 	if(g3_yourself)
 		g3_end_frame();

--- a/code/render/3ddraw.cpp
+++ b/code/render/3ddraw.cpp
@@ -112,7 +112,7 @@ free_points:
 int g3_draw_line(vertex *p0, vertex *p1)
 {
 #ifdef FRED_OGL_COMMENT_OUT_FOR_NOW
-	if(Fred_running && !Cmdline_nohtl)
+	if(Fred_running)
 	{
   		gr_aaline( p0, p1 );
 		return 0;
@@ -212,30 +212,12 @@ int g3_draw_poly(int nv, vertex **pointlist, uint tmap_flags)
 
 	Assert( G3_count == 1 );
 
-	if(!Cmdline_nohtl && (tmap_flags & TMAP_HTL_3D_UNLIT)) {
+	if(tmap_flags & TMAP_HTL_3D_UNLIT) {
 		gr_tmapper( nv, pointlist, tmap_flags );
 		return 0;
 	}
 	//don't clip in HT&L mode, the card does it for us
-	if(!Cmdline_nohtl && (tmap_flags & TMAP_FLAG_TRISTRIP)) {
-		gr_tmapper( nv, pointlist, tmap_flags );
-		return 0;
-	}
-	if(Cmdline_nohtl && (tmap_flags & TMAP_FLAG_TRISTRIP)){
-		bool starting = true;
-		int offset = 0;
-		for (i=0;i<nv;i++){
-			if (!(pointlist[i]->flags&PF_PROJECTED))g3_project_vertex(pointlist[i]);
-			if (pointlist[i]->flags&PF_OVERFLOW){
-				if(starting)
-					offset++;
-				nv--;
-			}else
-				starting = false;
-			if(nv<3)return 1;
-		}
-		if(nv<3)return 1;
-		pointlist += offset;
+	if(tmap_flags & TMAP_FLAG_TRISTRIP) {
 		gr_tmapper( nv, pointlist, tmap_flags );
 		return 0;
 	}
@@ -386,7 +368,7 @@ int g3_draw_poly_constant_sw(int nv, vertex **pointlist, uint tmap_flags, float 
 
 	Assert( G3_count == 1 );
 
-	if(!Cmdline_nohtl && (tmap_flags & TMAP_HTL_3D_UNLIT)) {
+	if(tmap_flags & TMAP_HTL_3D_UNLIT) {
 		gr_tmapper( nv, pointlist, tmap_flags );
 		return 0;
 	}
@@ -648,7 +630,7 @@ int g3_draw_bitmap_3d_volume(vertex *pnt, int orient, float rad, uint tmap_flags
 // Orient
 int g3_draw_bitmap(vertex *pnt, int orient, float rad, uint tmap_flags, float depth)
 {
-	if ( !Cmdline_nohtl && (tmap_flags & TMAP_HTL_3D_UNLIT) ) {
+	if (tmap_flags & TMAP_HTL_3D_UNLIT) {
 		return g3_draw_bitmap_3d(pnt, orient, rad, tmap_flags, depth);
 	}
 
@@ -843,7 +825,7 @@ int g3_draw_rotated_bitmap_3d(vertex *pnt,float angle, float rad,uint tmap_flags
 //returns 1 if off screen, 0 if drew
 int g3_draw_rotated_bitmap(vertex *pnt,float angle, float rad,uint tmap_flags, float depth)
 {
-	if(!Cmdline_nohtl && (tmap_flags & TMAP_HTL_3D_UNLIT)) {
+	if(tmap_flags & TMAP_HTL_3D_UNLIT) {
 		return g3_draw_rotated_bitmap_3d(pnt, angle, rad, tmap_flags, depth);
 	}
 	vertex v[4];
@@ -1295,10 +1277,7 @@ int g3_draw_rod(const vec3d *p0, float width1, const vec3d *p1, float width2, ve
 		if ( verts )	{
 			pts[i] = verts[i];
 		}
-		if(Cmdline_nohtl)
-			g3_rotate_vertex( &pts[i], &vecs[i] );
-		else
-			g3_transfer_vertex( &pts[i], &vecs[i] );
+		g3_transfer_vertex( &pts[i], &vecs[i] );
 	}
 	ptlist[0]->texture_position.u = 0.0f;
 	ptlist[0]->texture_position.v = 0.0f;
@@ -1373,13 +1352,8 @@ int g3_draw_rod(int num_points, const vec3d *pvecs, float width, uint tmap_flags
 		ptlist[nv] = &pts[nv];
 		ptlist[nv+1] = &pts[nv+1];
 
-		if (Cmdline_nohtl) {
-			g3_rotate_vertex( &pts[nv], &vecs[0] );
-			g3_rotate_vertex( &pts[nv+1], &vecs[1] );
-		} else {
-			g3_transfer_vertex( &pts[nv], &vecs[0] );
-			g3_transfer_vertex( &pts[nv+1], &vecs[1] );
-		}
+		g3_transfer_vertex( &pts[nv], &vecs[0] );
+		g3_transfer_vertex( &pts[nv+1], &vecs[1] );
 
 		ptlist[nv]->texture_position.u = 1.0f;
 		ptlist[nv]->texture_position.v = i2fl(i);
@@ -1974,19 +1948,11 @@ int g3_draw_2d_poly_bitmap_rect_list(bitmap_rect_list* b_list, int n_bm, uint ad
 
 void g3_draw_htl_line(const vec3d *start, const vec3d *end)
 {
-	if (Cmdline_nohtl) {
-		return;
-	}
-
 	gr_line_htl(start, end);
 }
 
 void g3_draw_htl_sphere(const vec3d* position, float radius)
 {
-	if (Cmdline_nohtl) {
-		return;
-	}
-
 	g3_start_instance_matrix(position, &vmd_identity_matrix, true);
 
 	gr_sphere_htl(radius);

--- a/code/render/3dlaser.cpp
+++ b/code/render/3dlaser.cpp
@@ -119,7 +119,7 @@ float g3_draw_laser(const vec3d *headp, float head_width, const vec3d *tailp, fl
 		return 0.0f;
 	}
 
-	if ( !Cmdline_nohtl && (tmap_flags & TMAP_HTL_3D_UNLIT) ) {
+	if (tmap_flags & TMAP_HTL_3D_UNLIT) {
 		return g3_draw_laser_htl(headp, head_width, tailp, tail_width, 255,255,255, tmap_flags | TMAP_HTL_3D_UNLIT);
 	}
 
@@ -269,7 +269,7 @@ float g3_draw_laser_rgb(const vec3d *headp, float head_width, const vec3d *tailp
 	if (!Lasers){
 		return 0.0f;
 	}
-	if((!Cmdline_nohtl)  && tmap_flags & TMAP_HTL_3D_UNLIT){
+	if(tmap_flags & TMAP_HTL_3D_UNLIT) {
 		return g3_draw_laser_htl(headp, head_width, tailp, tail_width, r, g, b, tmap_flags | TMAP_HTL_3D_UNLIT);
 	}
 	float headx, heady, headr, tailx, taily, tailr;

--- a/code/render/3dsetup.cpp
+++ b/code/render/3dsetup.cpp
@@ -58,7 +58,6 @@ int instance_depth = 0;
 
 int G3_count = 0;
 int G3_frame_count = 0;
-extern int Cmdline_nohtl;
 
 /**
  * Check if in frame
@@ -98,7 +97,7 @@ void g3_start_frame_func(int zbuffer_flag, const char *filename, int lineno)
 	//compute aspect ratio for this canvas
 	s = aspect*(float)Canvas_height/(float)Canvas_width;
 
-	if ( !Cmdline_nohtl || (s <= 0.0f) ) {		//scale x
+	if (s <= 0.0f) {		//scale x
 		Window_scale.xyz.x = s;
 		Window_scale.xyz.y = 1.0f;
 	}
@@ -199,23 +198,10 @@ void scale_matrix(void)
 
 	Matrix_scale = Window_scale;
 
-	float s = 1.0f;
+	float s = 1.0f / tanf(Proj_fov * 0.5f);
 
-	if (Cmdline_nohtl) {
-		if (View_zoom <= 1.0f) { 		//zoom in by scaling z
-			Matrix_scale.xyz.z =  Matrix_scale.xyz.z*View_zoom;
-		} else {			//zoom out by scaling x&y
-			s = 1.0f / View_zoom;
-
-			Matrix_scale.xyz.x *= s;
-			Matrix_scale.xyz.y *= s;
-		}
-	} else {
-		s = 1.0f / tanf(Proj_fov * 0.5f);
-
-		Matrix_scale.xyz.x *= s;
-		Matrix_scale.xyz.y *= s;
-	}
+	Matrix_scale.xyz.x *= s;
+	Matrix_scale.xyz.y *= s;
 
 	//now scale matrix elements
 
@@ -303,7 +289,7 @@ void g3_start_instance_matrix(const vec3d *pos, const matrix *orient, bool set_a
 
 	vm_matrix_x_matrix(&Light_matrix,&saved_orient, orient);
 
-	if(!Cmdline_nohtl && set_api)
+	if(set_api)
 		gr_start_instance_matrix(pos, orient);
 
 }
@@ -329,8 +315,7 @@ void g3_start_instance_angles(const vec3d *pos, const angles *orient)
 
 	g3_start_instance_matrix(pos,&tm, false);
 
-	if(!Cmdline_nohtl)
-		gr_start_angles_instance_matrix(pos, orient);
+	gr_start_angles_instance_matrix(pos, orient);
 
 }
 
@@ -353,7 +338,7 @@ void g3_done_instance(bool use_api)
 	Object_matrix = instance_stack[instance_depth].om;
 	Object_position = instance_stack[instance_depth].op;
 
-	if (!Cmdline_nohtl && use_api)
+	if (use_api)
 		gr_end_instance_matrix();
 }
 
@@ -389,11 +374,9 @@ void g3_start_user_clip_plane(const vec3d *plane_point, const vec3d *plane_norma
 	}
 
 	G3_user_clip = 1;
-	if(!Cmdline_nohtl) {
-		G3_user_clip_normal = *plane_normal;
-		G3_user_clip_point = *plane_point;
-		gr_start_clip();
-	}
+	G3_user_clip_normal = *plane_normal;
+	G3_user_clip_point = *plane_point;
+	gr_start_clip();
 	vm_vec_rotate(&G3_user_clip_normal, plane_normal, &Eye_matrix );
 	vm_vec_normalize(&G3_user_clip_normal);
 
@@ -408,9 +391,7 @@ void g3_start_user_clip_plane(const vec3d *plane_point, const vec3d *plane_norma
 void g3_stop_user_clip_plane()
 {
 	G3_user_clip = 0;
-	if(!Cmdline_nohtl) {
-		gr_end_clip();
-	}
+	gr_end_clip();
 }
 
 /**

--- a/code/ship/shield.cpp
+++ b/code/ship/shield.cpp
@@ -251,8 +251,6 @@ void free_global_tri_records(int shnum)
 	}
 }
 
-extern int Cmdline_nohtl;
-
 void render_low_detail_shield_bitmap(gshield_tri *trip, matrix *orient, vec3d *pos, ubyte r, ubyte g, ubyte b)
 {
 	int		j;
@@ -267,8 +265,7 @@ void render_low_detail_shield_bitmap(gshield_tri *trip, matrix *orient, vec3d *p
 		vm_vec_add2(&pnt, pos);
 
 		// Pnt is now the x,y,z world coordinates of this vert.
-		if(!Cmdline_nohtl) g3_transfer_vertex(&verts[j], &pnt);
-		else g3_rotate_vertex(&verts[j], &pnt);
+		g3_transfer_vertex(&verts[j], &pnt);
 		verts[j].texture_position.u = trip->verts[j].u;
 		verts[j].texture_position.v = trip->verts[j].v;
 	}	
@@ -335,8 +332,7 @@ void render_shield_triangle(gshield_tri *trip, matrix *orient, vec3d *pos, ubyte
 		// Pnt is now the x,y,z world coordinates of this vert.
 		// For this example, I am just drawing a sphere at that point.
 
-	 	if (!Cmdline_nohtl) g3_transfer_vertex(&points[j],&pnt);
-	 	else g3_rotate_vertex(&points[j], &pnt);
+	 	g3_transfer_vertex(&points[j],&pnt);
 			
 		points[j].texture_position.u = trip->verts[j].u;
 		points[j].texture_position.v = trip->verts[j].v;
@@ -359,8 +355,7 @@ void render_shield_triangle(gshield_tri *trip, matrix *orient, vec3d *pos, ubyte
 	Poly_count++;
 	vm_vec_perp(&norm,&verts[0]->world,&verts[1]->world,&verts[2]->world);
 
-	int flags=TMAP_FLAG_TEXTURED | TMAP_FLAG_RGB | TMAP_FLAG_GOURAUD;
-	if (!Cmdline_nohtl) flags |= TMAP_HTL_3D_UNLIT | TMAP_FLAG_EMISSIVE;
+	int flags = TMAP_FLAG_TEXTURED | TMAP_FLAG_RGB | TMAP_FLAG_GOURAUD | TMAP_HTL_3D_UNLIT | TMAP_FLAG_EMISSIVE;
 
 	if ( vm_vec_dot(&norm,&verts[1]->world ) >= 0.0 )	{
 		vertex	*vertlist[3];

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -104,8 +104,6 @@ extern bool splodeing;
 extern float splode_level;
 extern int splodeingtexture;
 
-extern int Cmdline_nohtl;
-
 extern void fs2netd_add_table_validation(const char *tblname);
 
 #define SHIP_REPAIR_SUBSYSTEM_RATE	0.01f
@@ -7320,11 +7318,8 @@ void ship_render_cockpit(object *objp)
 	vec3d pos = vmd_zero_vector;
 
 	vm_vec_unrotate(&pos, &sip->cockpit_offset, &eye_ori);
-	if (!Cmdline_nohtl)
-	{
-		gr_set_proj_matrix(Proj_fov, gr_screen.clip_aspect, 0.02f, 10.0f*pm->rad);
-		gr_set_view_matrix(&vmd_zero_vector, &Eye_matrix);
-	}
+	gr_set_proj_matrix(Proj_fov, gr_screen.clip_aspect, 0.02f, 10.0f*pm->rad);
+	gr_set_view_matrix(&vmd_zero_vector, &Eye_matrix);
 
 	//Deal with the model
 	model_clear_instance(sip->cockpit_model_num);
@@ -7336,11 +7331,8 @@ void ship_render_cockpit(object *objp)
 
 	model_render_immediate(&render_info, sip->cockpit_model_num, &eye_ori, &pos);
 
-	if (!Cmdline_nohtl) 
-	{
-		gr_end_view_matrix();
-		gr_end_proj_matrix();
-	}
+	gr_end_view_matrix();
+	gr_end_proj_matrix();
 
 	hud_save_restore_camera_data(0);
 }

--- a/code/ship/shipfx.cpp
+++ b/code/ship/shipfx.cpp
@@ -4127,15 +4127,10 @@ int WE_BSG::warpShipRender()
 		if(shockwave_frame < shockwave_nframes)
 		{
 			vertex p;
-			extern int Cmdline_nohtl;
             
             memset(&p, 0, sizeof(p));
             
-			if(Cmdline_nohtl) {
-				g3_rotate_vertex(&p, &pos );
-			}else{
-				g3_transfer_vertex(&p, &pos);
-			}
+			g3_transfer_vertex(&p, &pos);
 
 			batch_add_bitmap(shockwave + shockwave_frame, TMAP_FLAG_TEXTURED | TMAP_HTL_3D_UNLIT | TMAP_FLAG_SOFT_QUAD | TMAP_FLAG_EMISSIVE, &p, 0, shockwave_radius, 1.0f);
 		}

--- a/code/ship/shiphit.cpp
+++ b/code/ship/shiphit.cpp
@@ -2465,8 +2465,6 @@ void ship_apply_local_damage(object *ship_objp, object *other_obj, vec3d *hitpos
 	}
 }
 
-extern int Cmdline_nohtl;
-
 // This gets called to apply damage when a damaging force hits a ship, but at no 
 // point in particular.  Like from a shockwave.   This routine will see if the
 // shield got hit and if so, apply damage to it.
@@ -2495,13 +2493,6 @@ void ship_apply_global_damage(object *ship_objp, object *other_obj, vec3d *force
 
 		// shield_quad = quadrant facing the force_center
 		shield_quad = get_quadrant(&local_hitpos, ship_objp);
-
-		// world_hitpos use force_center for shockwave
-		// Goober5000 check for NULL
-		if (Cmdline_nohtl && (other_obj != NULL) && (other_obj->type == OBJ_SHOCKWAVE) && (Ship_info[Ships[ship_objp->instance].ship_info_index].flags & SIF_HUGE_SHIP))
-		{
-			world_hitpos = *force_center;
-		}
 
 		// Do damage on local point		
 		ship_do_damage(ship_objp, other_obj, &world_hitpos, damage, shield_quad, -1 );

--- a/code/starfield/starfield.cpp
+++ b/code/starfield/starfield.cpp
@@ -1236,9 +1236,7 @@ void stars_draw_bitmaps(int show_bitmaps)
 	if ( !Detail.planets_suns )
 		return;
 
-	if ( !Cmdline_nohtl ) {
-		gr_start_instance_matrix(&Eye_position, &vmd_identity_matrix);
-	}
+	gr_start_instance_matrix(&Eye_position, &vmd_identity_matrix);
 
 	// turn off culling
 	int cull = gr_set_cull(0);
@@ -1289,8 +1287,7 @@ void stars_draw_bitmaps(int show_bitmaps)
 	// restore zbuffer
 	gr_zbuffer_set(saved_zbuffer_mode);
 
-	if ( !Cmdline_nohtl )
-		gr_end_instance_matrix();
+	gr_end_instance_matrix();
 }
 
 extern int Interp_subspace;
@@ -1435,13 +1432,11 @@ void subspace_render()
 	render_info.set_alpha(1.0f);
 	render_info.set_flags(render_flags);
 
-	if (!Cmdline_nohtl)
-		gr_set_texture_panning(Interp_subspace_offset_v, Interp_subspace_offset_u, true);
+	gr_set_texture_panning(Interp_subspace_offset_v, Interp_subspace_offset_u, true);
 
 	model_render_immediate( &render_info, Subspace_model_outer, &tmp, &Eye_position);	//MR_NO_CORRECT|MR_SHOW_OUTLINE
 
-	if (!Cmdline_nohtl)
-		gr_set_texture_panning(0, 0, false);
+	gr_set_texture_panning(0, 0, false);
 
 	Interp_subspace = 1;
 	Interp_subspace_offset_u = 1.0f - subspace_offset_u_inner;
@@ -1455,13 +1450,11 @@ void subspace_render()
 	render_info.set_alpha(1.0f);
 	render_info.set_flags(render_flags);
 
-	if (!Cmdline_nohtl)
-		gr_set_texture_panning(Interp_subspace_offset_v, Interp_subspace_offset_u, true);
+	gr_set_texture_panning(Interp_subspace_offset_v, Interp_subspace_offset_u, true);
 
 	model_render_immediate( &render_info, Subspace_model_inner, &tmp, &Eye_position );	//MR_NO_CORRECT|MR_SHOW_OUTLINE
 
-	if (!Cmdline_nohtl)
-		gr_set_texture_panning(0, 0, false);
+	gr_set_texture_panning(0, 0, false);
 
 	//Render subspace glows here and not as thrusters - Valathil 
 	vec3d glow_pos;
@@ -2518,7 +2511,7 @@ void stars_set_nebula(bool activate)
 		The_mission.flags |= MISSION_FLAG_FULLNEB;
 		Toggle_text_alpha = TOGGLE_TEXT_NEBULA_ALPHA;
 		HUD_contrast = 1;
-		if(Cmdline_nohtl || Fred_running) {
+		if(Fred_running) {
 			Neb2_render_mode = NEB2_RENDER_POF;
 			stars_set_background_model(BACKGROUND_MODEL_FILENAME, Neb2_texture_name);
 			stars_set_background_orientation();

--- a/code/weapon/beam.cpp
+++ b/code/weapon/beam.cpp
@@ -39,7 +39,6 @@
 #include "weapon/beam.h"
 #include "weapon/weapon.h"
 
-extern int Cmdline_nohtl;
 // ------------------------------------------------------------------------------------------------
 // BEAM WEAPON DEFINES/VARS
 //
@@ -1191,17 +1190,10 @@ void beam_render(beam *b, float u_offset)
 		beam_calc_facing_pts(&top1, &bottom1, &fvec, &b->last_start, bwsi->width * scale * b->shrink, bwsi->z_add);	
 		beam_calc_facing_pts(&top2, &bottom2, &fvec, &b->last_shot, bwsi->width * scale * scale * b->shrink, bwsi->z_add);
 
-		if (Cmdline_nohtl) {
-			g3_rotate_vertex(verts[0], &bottom1); 
-			g3_rotate_vertex(verts[1], &bottom2);	
-			g3_rotate_vertex(verts[2], &top2); 
-			g3_rotate_vertex(verts[3], &top1);
-		} else {
-			g3_transfer_vertex(verts[0], &bottom1); 
-			g3_transfer_vertex(verts[1], &bottom2);	
-			g3_transfer_vertex(verts[2], &top2); 
-			g3_transfer_vertex(verts[3], &top1);
-		}
+		g3_transfer_vertex(verts[0], &bottom1); 
+		g3_transfer_vertex(verts[1], &bottom2);	
+		g3_transfer_vertex(verts[2], &top2); 
+		g3_transfer_vertex(verts[3], &top1);
 
 		P_VERTICES();						
 		STUFF_VERTICES();		// stuff the beam with creamy goodness (texture coords)
@@ -1429,18 +1421,10 @@ void beam_render_muzzle_glow(beam *b)
 		beam_calc_facing_pts(&top1, &bottom1, &fvec, &start, rad, 1.0f);
 		beam_calc_facing_pts(&top2, &bottom2, &fvec, &end, rad, 1.0f);
 
-		if (Cmdline_nohtl) {
-			g3_rotate_vertex(verts[0], &bottom1);
-			g3_rotate_vertex(verts[1], &bottom2);
-			g3_rotate_vertex(verts[2], &top2);
-			g3_rotate_vertex(verts[3], &top1);
-		}
-		else {
-			g3_transfer_vertex(verts[0], &bottom1);
-			g3_transfer_vertex(verts[1], &bottom2);
-			g3_transfer_vertex(verts[2], &top2);
-			g3_transfer_vertex(verts[3], &top1);
-		}
+		g3_transfer_vertex(verts[0], &bottom1);
+		g3_transfer_vertex(verts[1], &bottom2);
+		g3_transfer_vertex(verts[2], &top2);
+		g3_transfer_vertex(verts[3], &top1);
 
 		for (int idx = 0; idx < 4; idx++) {
 			g3_project_vertex(verts[idx]);
@@ -1490,10 +1474,7 @@ void beam_render_muzzle_glow(beam *b)
 	} else {
 
 		// draw the bitmap
-		if (Cmdline_nohtl)
-			g3_rotate_vertex(&pt, &b->last_start);
-		else
-			g3_transfer_vertex(&pt, &b->last_start);
+		g3_transfer_vertex(&pt, &b->last_start);
 
 
 		int framenum = 0;

--- a/code/weapon/shockwave.cpp
+++ b/code/weapon/shockwave.cpp
@@ -44,7 +44,6 @@ int Shockwave_inited = 0;
 // Externals
 // -----------------------------------------------------------
 extern int Show_area_effect;
-extern int Cmdline_nohtl;
 extern int Cmdline_enable_3d_shockwave;
 extern bool Cmdline_fb_explosions;
 
@@ -409,11 +408,7 @@ void shockwave_render_DEPRECATED(object *objp)
 			);
 		}
 	}else{
-		if (!Cmdline_nohtl) {
-			g3_transfer_vertex(&p, &sw->pos);
-		} else {
-			g3_rotate_vertex(&p, &sw->pos);
-		}
+		g3_transfer_vertex(&p, &sw->pos);
 		if(Cmdline_fb_explosions)
 		{
 			distortion_add_bitmap_rotated(
@@ -481,11 +476,7 @@ void shockwave_render(object *objp, draw_list *scene)
 				);
 		}
 	} else {
-		if (!Cmdline_nohtl) {
-			g3_transfer_vertex(&p, &sw->pos);
-		} else {
-			g3_rotate_vertex(&p, &sw->pos);
-		}
+		g3_transfer_vertex(&p, &sw->pos);
 
 		if ( Cmdline_fb_explosions ) {
 			distortion_add_bitmap_rotated(

--- a/code/weapon/trails.cpp
+++ b/code/weapon/trails.cpp
@@ -115,8 +115,6 @@ int trail_is_on_ship(trail *trailp, ship *shipp)
 
 // Render the trail behind a missile.
 // Basically a queue of points that face the viewer
-extern int Cmdline_nohtl;
-
 static vertex *Trail_v_list = NULL;
 static int Trail_verts_allocated = 0;
 
@@ -244,14 +242,8 @@ void trail_add_batch(trail * trailp)
 
 		trail_calc_facing_pts(&topv, &botv, fvec, &trailp->pos[n], w);
 
-		if (!Cmdline_nohtl) {
-			g3_transfer_vertex(&top, &topv);
-			g3_transfer_vertex(&bot, &botv);
-		}
-		else {
-			g3_rotate_vertex(&top, &topv);
-			g3_rotate_vertex(&bot, &botv);
-		}
+		g3_transfer_vertex(&top, &topv);
+		g3_transfer_vertex(&bot, &botv);
 
 		top.r = top.g = top.b = l;
 		bot.r = bot.g = bot.b = l;
@@ -272,10 +264,7 @@ void trail_add_batch(trail * trailp)
 
 				vertex center_vert = vertex();
 
-				if (!Cmdline_nohtl)
-					g3_transfer_vertex(&center_vert, &centerv);
-				else
-					g3_rotate_vertex(&center_vert, &centerv);
+				g3_transfer_vertex(&center_vert, &centerv);
 
 				center_vert.texture_position.u = U + 1.0f;
 				center_vert.texture_position.v = 0.5f;
@@ -403,13 +392,8 @@ void trail_render( trail * trailp )
 
 		trail_calc_facing_pts( &topv, &botv, fvec, &trailp->pos[n], w );
 
-		if ( !Cmdline_nohtl ) {
-			g3_transfer_vertex( &top, &topv );
-			g3_transfer_vertex( &bot, &botv );
-		} else {
-			g3_rotate_vertex( &top, &topv );
-			g3_rotate_vertex( &bot, &botv );
-		}
+		g3_transfer_vertex( &top, &topv );
+		g3_transfer_vertex( &bot, &botv );
 
 		top.a = bot.a = l;	
 
@@ -420,10 +404,7 @@ void trail_render( trail * trailp )
 				// Last one...
 				vm_vec_avg( &centerv, &topv, &botv );
 
-				if ( !Cmdline_nohtl )
-					g3_transfer_vertex( &Trail_v_list[nv+2], &centerv );
-				else
-					g3_rotate_vertex( &Trail_v_list[nv+2], &centerv );
+				g3_transfer_vertex( &Trail_v_list[nv+2], &centerv );
 
 				Trail_v_list[nv].a = l;	
 


### PR DESCRIPTION
`-nohtl` hasn't worked for years, and `-brief_lighting` was always supposed to be a temporary flag before making the behavior always on.

My one point of uncertainty would be commit c2716d4ee879e22671971d6be5a165d21bccef4b; removing `Cmdline_nohtl` means removing that code entirely, but I'm not sure why it was originally present or why it broke in HTL mode.