### PR TITLE
Fix for the PBR shader compilation error on Mac

### DIFF
--- a/code/graphics/gropenglshader.cpp
+++ b/code/graphics/gropenglshader.cpp
@@ -313,6 +313,7 @@ static SCP_string get_shader_header(shader_type type_id, int flags) {
 
 #ifdef __APPLE__
 	sflags << "#version 120\n";
+    sflags << "#extension GL_ARB_shader_texture_lod : enable\n";
 	sflags << "#define APPLE\n";
 #endif
 


### PR DESCRIPTION
OpenGL 2.1 spec doesn't support texture LOD lookups in the fragment shader unless we use GL_ARB_shader_texture_lod. Should allow PBR to work on Mac now.