### PR TITLE
Allow apng's to not be cached

### DIFF
--- a/code/graphics/generic.cpp
+++ b/code/graphics/generic.cpp
@@ -154,7 +154,7 @@ int generic_anim_load(generic_anim *ga)
 	return 0;
 }
 
-int generic_anim_stream(generic_anim *ga)
+int generic_anim_stream(generic_anim *ga, const bool cache)
 {
 	CFILE *img_cfp = NULL;
 	int anim_fps = 0;
@@ -220,7 +220,7 @@ int generic_anim_stream(generic_anim *ga)
 	else if (ga->type == BM_TYPE_PNG) {
 		if (ga->png.anim == nullptr) {
 			try {
-				ga->png.anim = new apng::apng_ani(ga->filename);
+				ga->png.anim = new apng::apng_ani(ga->filename, cache);
 			}
 			catch (const apng::ApngException& e) {
 				mprintf(("Failed to load apng: %s\n", e.what() ));
@@ -231,7 +231,8 @@ int generic_anim_stream(generic_anim *ga)
 			nprintf(("apng", "apng read OK (%ix%i@%i) duration (%f)\n", ga->png.anim->w, ga->png.anim->h,
 					ga->png.anim->bpp, ga->png.anim->anim_time));
 		}
-		ga->png.anim->current_frame = 0;
+		ga->png.anim->goto_start();
+		ga->current_frame = 0;
 		ga->png.previous_frame_time = 0.0f;
 		ga->num_frames = ga->png.anim->nframes;
 		ga->height = ga->png.anim->h;
@@ -624,8 +625,8 @@ void generic_anim_render_variable_frame_delay(generic_anim* ga, float frametime,
 				else {
 					// loop back to start
 					ga->png.previous_frame_time = 0.0f;
-					ga->png.anim->current_frame = 0;
 					ga->current_frame = 0;
+					ga->png.anim->goto_start();
 				}
 				ga->done_playing = 1;
 			}

--- a/code/graphics/generic.h
+++ b/code/graphics/generic.h
@@ -85,7 +85,7 @@ void generic_anim_init(generic_anim *ga, const char *filename);
 void generic_anim_init(generic_anim *ga, const SCP_string& filename);
 void generic_bitmap_init(generic_bitmap *gb, const char *filename = NULL);
 int generic_anim_load(generic_anim *ga);
-int generic_anim_stream(generic_anim *ga);
+int generic_anim_stream(generic_anim *ga, const bool cache = true);
 int generic_bitmap_load(generic_bitmap *gb);
 void generic_anim_unload(generic_anim *ga);
 void generic_anim_render(generic_anim *ga, float frametime, int x, int y, bool menu = false, const generic_extras *ge = nullptr);

--- a/code/mission/missionmessage.cpp
+++ b/code/mission/missionmessage.cpp
@@ -1250,7 +1250,7 @@ void message_play_anim( message_q *q )
 	if(!Full_color_head_anis)
 			anim_info->anim_data.use_hud_color = true;
 
-	if ( generic_anim_stream(&anim_info->anim_data) < 0 ) {
+	if ( generic_anim_stream(&anim_info->anim_data, false) < 0 ) {
 		nprintf (("messaging", "Cannot load message avi %s.  Will not play.\n", ani_name));
 		m->avi_info.index = -1;			// if cannot load the avi -- set this index to -1 to avoid trying to load multiple times
 	}

--- a/code/parse/lua.cpp
+++ b/code/parse/lua.cpp
@@ -3524,7 +3524,7 @@ ADE_FUNC(isValid, l_streaminganim, NULL, "Detects whether handle is valid", "boo
 	return sah->IsValid();
 }
 
-ADE_FUNC(preload, l_streaminganim, NULL, "Load all apng animations into memory", "boolean", "true if preload was successful, nil if a syntax/type error occurs")
+ADE_FUNC(preload, l_streaminganim, NULL, "Load all apng animations into memory, enabling apng frame cache if not already enabled", "boolean", "true if preload was successful, nil if a syntax/type error occurs")
 {
 	streaminganim_h* sah;
 	if(!ade_get_args(L, "o", l_streaminganim.GetPtr(&sah)))
@@ -14283,17 +14283,18 @@ ADE_FUNC(getStringWidth, l_Graphics, "string String", "Gets string width", "numb
 	return ade_set_args(L, "i", w);
 }
 
-ADE_FUNC(loadStreamingAnim, l_Graphics, "string Filename, [boolean loop, boolean reverse, boolean pause]",
-		 "Plays a streaming animation, returning its handle. The optional booleans can also be set via the handles virtvars<br>"
+ADE_FUNC(loadStreamingAnim, l_Graphics, "string Filename, [boolean loop, boolean reverse, boolean pause, boolean cache]",
+		 "Plays a streaming animation, returning its handle. The optional booleans (except cache) can also be set via the handles virtvars<br>"
+		 "cache is best set to false when loading animations that are only intended to play once, e.g. headz<br>"
 		 "Remember to call the unload() function when you're finished using the animation to free up memory.",
 		 "streaminganim",
 		 "Streaming animation handle, or invalid handle if animation couldn't be loaded")
 {
 	char *s;
 	int rc = -1;
-	bool loop = false, reverse = false, pause = false;
+	bool loop = false, reverse = false, pause = false, cache = true;
 
-	if(!ade_get_args(L, "s|bbb", &s, &loop, &reverse, &pause))
+	if(!ade_get_args(L, "s|bbbb", &s, &loop, &reverse, &pause, &cache))
 		return ADE_RETURN_NIL;
 
 	streaminganim_h sah(s);
@@ -14306,7 +14307,7 @@ ADE_FUNC(loadStreamingAnim, l_Graphics, "string Filename, [boolean loop, boolean
 	if (pause == true) {
 		sah.ga.direction |= GENERIC_ANIM_DIRECTION_PAUSED;
 	}
-	rc = generic_anim_stream(&sah.ga);
+	rc = generic_anim_stream(&sah.ga, cache);
 
 	if(rc < 0)
 		return ade_set_args(L, "o", l_streaminganim.Set(sah)); // this object should be "invalid", matches loadTexture behaviour

--- a/code/pngutils/pngutils.h
+++ b/code/pngutils/pngutils.h
@@ -42,7 +42,7 @@ public:
 	uint       plays;
 	float      anim_time;
 
-	apng_ani(const char* filename);
+	apng_ani(const char* filenamen, bool cache = true);
 	~apng_ani();
 
 	int    load_header();
@@ -76,7 +76,7 @@ private:
 	uint                    _max_chunk_size;
 	ushort                  _delay_num, _delay_den;
 	ubyte                   _dispose_op, _blend_op;
-	bool                    _reading, _got_acTL, _got_IDAT;
+	bool                    _reading, _got_acTL, _got_IDAT, _cache;
 
 	uint _read_chunk(_chunk_s& chunk);
 	void _process_chunk();


### PR DESCRIPTION
Main use case is headanis where only one is played at a time and
caching the frames merely increases memory use & fragmentation, leading
to malloc errors with heavy apng use