### PR TITLE
Allow countermeasures to pulse at regular intervals instead of globally.

### DIFF
--- a/code/weapon/weapon.h
+++ b/code/weapon/weapon.h
@@ -110,6 +110,7 @@ typedef struct weapon {
 	vec3d	big_attack_point;				//	Target-relative location of attack point.
 
 	SCP_vector<int>* cmeasure_ignore_list;
+	int		cmeasure_timer;
 
 	// corkscrew info (taken out for now)
 	short	cscrew_index;						// corkscrew info index
@@ -407,6 +408,7 @@ typedef struct weapon_info {
 	float cm_effective_rad;
 	float cm_detonation_rad;
 	bool  cm_kill_single;       // should the countermeasure kill just the single decoyed missile within CMEASURE_DETONATE_DISTANCE?
+	int   cmeasure_timer_interval;	// how many milliseconds between pulses
 
     // *
                
@@ -576,7 +578,7 @@ int	weapon_area_calc_damage(object *objp, vec3d *pos, float inner_rad, float out
 
 void	missile_obj_list_rebuild();	// called by save/restore code only
 missile_obj *missile_obj_return_address(int index);
-void find_homing_object_cmeasures();
+void find_homing_object_cmeasures(const SCP_vector<object*> &cmeasure_list);
 
 // THE FOLLOWING FUNCTION IS IN SHIP.CPP!!!!
 // JAS - figure out which thruster bitmap will get rendered next


### PR DESCRIPTION
Adds a new "+Pulse Interval:" countermeasure field that enables the new behavior; all countermeasures that don't have this field defined still use the old behavior of the global frame counter.

This changes countermeasure logic quite a bit, but I attempted to mitigate performance implications by re-using an existing traversal of the object list in order to build the list of active countermeasures each frame. If any countermeasures are actively pulsing in a frame, the object list is traversed again, looking for homing weapons. Each homing weapon then goes through the active countermeasure list and checks to see if it got decoyed. Most of this central logic is unchanged from the old behavior, although no longer separated into two functions, and it should be more efficient since it's using a prepared list of active countermeasures instead of traversing the object list looking for countermeasures for every homing missile (which are themselves found by traversing the object list).

This is the much-anticipated, long-awaited replacement for PR #441. I did my best to keep the impact as minimal as possible, but it could really use some stress testing in missile-and-countermeasure-rich environments.
