### PR TITLE
Make beams and warps bright again

### DIFF
--- a/code/fireball/warpineffect.cpp
+++ b/code/fireball/warpineffect.cpp
@@ -61,7 +61,7 @@ void warpin_batch_draw_face( int texture, vertex *v1, vertex *v2, vertex *v3 )
 		vertlist[2] = *v3;
 	}
 
-	batch_add_tri(texture, TMAP_FLAG_TEXTURED | TMAP_HTL_3D_UNLIT, vertlist, 1.0f);
+	batch_add_tri(texture, TMAP_FLAG_TEXTURED | TMAP_HTL_3D_UNLIT | TMAP_FLAG_EMISSIVE, vertlist, 1.0f);
 }
 
 void warpin_render(object *obj, matrix *orient, vec3d *pos, int texture_bitmap_num, float radius, float life_percent, float max_radius, int warp_3d)

--- a/code/graphics/gropengldraw.cpp
+++ b/code/graphics/gropengldraw.cpp
@@ -1408,7 +1408,7 @@ void opengl_draw_primitive(int nv, vertex **verts, uint flags, float u_scale, fl
 	float color_scale = 1.0f;
 
 	if ( High_dynamic_range && flags & TMAP_FLAG_EMISSIVE ) {
-		color_scale = 1.5f;
+		color_scale = 2.0f;
 	}
 
 	opengl_shader_set_passthrough(textured, false, color_scale);
@@ -1567,7 +1567,7 @@ void opengl_tmapper_internal3d(int nv, vertex **verts, uint flags)
 
 	float color_scale = 1.0f;
 	if ( High_dynamic_range && flags & TMAP_FLAG_EMISSIVE ) {
-		color_scale = 1.5f;
+		color_scale = 2.0f;
 	}
 
 	GL_state.Array.BindArrayBuffer(0);
@@ -1740,7 +1740,7 @@ void opengl_render_internal3d(int nverts, vertex *verts, uint flags)
 
 	float color_scale = 1.0f;
 	if ( High_dynamic_range && flags & TMAP_FLAG_EMISSIVE ) {
-		color_scale = 1.5f;
+		color_scale = 2.0f;
 	}
 
 	vert_def.add_vertex_component(vertex_format_data::POSITION3, sizeof(vertex), &verts[0].world.xyz.x);

--- a/code/model/modelrender.cpp
+++ b/code/model/modelrender.cpp
@@ -1290,6 +1290,11 @@ void model_render_buffers(draw_list* scene, model_render_params* interp, vertex_
 		if (forced_texture != -2) {
 			texture_maps[TM_BASE_TYPE] = forced_texture;
 			alpha = forced_alpha;
+
+			if (interp->get_warp_bitmap() >= 0) {
+				texture_maps[TM_GLOW_TYPE] = forced_texture;
+			}
+			
 		} else if ( !no_texturing ) {
 			// pick the texture, animating it if necessary
 			if ( (replacement_textures != NULL) && (replacement_textures[rt_begin_index + TM_BASE_TYPE] == REPLACE_WITH_INVISIBLE) ) {


### PR DESCRIPTION
Adds TMAP_FLAG_EMISSIVE for the 2D warp effect, and ups the scaling applied to textures with that flag from 1.5 to 2.0 to better approximate the brightness beams used to have.

Also sets a glow texture for the 3D warp effect.