### PR TITLE
Ignore all OS events when loading a mission

### DIFF
--- a/code/freespace2/freespace.cpp
+++ b/code/freespace2/freespace.cpp
@@ -1219,6 +1219,8 @@ void game_loading_callback(int count)
 	}
 #endif	// !NDEBUG
 
+	os_ignore_events();
+
 	if (do_flip)
 		gr_flip();
 }

--- a/code/osapi/osapi.h
+++ b/code/osapi/osapi.h
@@ -65,6 +65,11 @@ void os_set_window(SDL_Window* new_handle);
 
 // process management --------------------------------------------------------------
 
+/**
+ * @brief Removes all pending events and ignores them
+ */
+void os_ignore_events();
+
 // call to process windows messages. only does something in non THREADED mode
 void os_poll();
 


### PR DESCRIPTION
This should fix the "Application unresponsive" errors.

This is a resubmit of #510.