### PR TITLE
Bad reference removal

### DIFF
--- a/projects/Eclipse/Freespace2/.project
+++ b/projects/Eclipse/Freespace2/.project
@@ -2982,11 +2982,6 @@
 			<locationURI>PARENT-3-PROJECT_LOC/code/observer/observer.h</locationURI>
 		</link>
 		<link>
-			<name>code/osapi/monopub.h</name>
-			<type>1</type>
-			<locationURI>PARENT-3-PROJECT_LOC/code/osapi/monopub.h</locationURI>
-		</link>
-		<link>
 			<name>code/osapi/osapi.h</name>
 			<type>1</type>
 			<locationURI>PARENT-3-PROJECT_LOC/code/osapi/osapi.h</locationURI>

--- a/projects/MSVC_2010/code.vcxproj
+++ b/projects/MSVC_2010/code.vcxproj
@@ -815,7 +815,6 @@
     <ClInclude Include="..\..\code\object\waypoint.h" />
     <ClInclude Include="..\..\code\Observer\observer.h" />
     <ClInclude Include="..\..\code\osapi\dialogs.h" />
-    <ClInclude Include="..\..\code\osapi\monopub.h" />
     <ClInclude Include="..\..\code\osapi\osapi.h" />
     <ClInclude Include="..\..\code\osapi\osregistry.h" />
     <ClInclude Include="..\..\code\osapi\outwnd.h" />

--- a/projects/MSVC_2013/code.vcxproj
+++ b/projects/MSVC_2013/code.vcxproj
@@ -948,7 +948,6 @@
     <ClInclude Include="..\..\code\object\waypoint.h" />
     <ClInclude Include="..\..\code\Observer\observer.h" />
     <ClInclude Include="..\..\code\osapi\dialogs.h" />
-    <ClInclude Include="..\..\code\osapi\monopub.h" />
     <ClInclude Include="..\..\code\osapi\osapi.h" />
     <ClInclude Include="..\..\code\osapi\osregistry.h" />
     <ClInclude Include="..\..\code\osapi\outwnd.h" />

--- a/projects/MSVC_2015/code.vcxproj
+++ b/projects/MSVC_2015/code.vcxproj
@@ -948,7 +948,6 @@
     <ClInclude Include="..\..\code\object\waypoint.h" />
     <ClInclude Include="..\..\code\Observer\observer.h" />
     <ClInclude Include="..\..\code\osapi\dialogs.h" />
-    <ClInclude Include="..\..\code\osapi\monopub.h" />
     <ClInclude Include="..\..\code\osapi\osapi.h" />
     <ClInclude Include="..\..\code\osapi\osregistry.h" />
     <ClInclude Include="..\..\code\osapi\outwnd.h" />

--- a/projects/codeblocks/code/code.cbp
+++ b/projects/codeblocks/code/code.cbp
@@ -1211,9 +1211,6 @@
 		<Unit filename="../../../code/observer/observer.h">
 			<Option virtualFolder="observer/" />
 		</Unit>
-		<Unit filename="../../../code/osapi/monopub.h">
-			<Option virtualFolder="osapi/" />
-		</Unit>
 		<Unit filename="../../../code/osapi/osapi.h">
 			<Option virtualFolder="osapi/" />
 		</Unit>


### PR DESCRIPTION
Removes references to monopub.h (removed in the AP merge) from the project files that still reference it