### PR TITLE
Only process events that belong to the main window

### DIFF
--- a/code/io/key.cpp
+++ b/code/io/key.cpp
@@ -91,6 +91,10 @@ namespace
 {
 	bool key_down_event_handler(const SDL_Event& e)
 	{
+		if (!os::events::isWindowEvent(e, os_get_window())) {
+			return false;
+		}
+
 		if (SDLtoFS2[e.key.keysym.scancode]) {
 			key_mark(SDLtoFS2[e.key.keysym.scancode], 1, 0);
 
@@ -102,6 +106,10 @@ namespace
 
 	bool key_up_event_handler(const SDL_Event& e)
 	{
+		if (!os::events::isWindowEvent(e, os_get_window())) {
+			return false;
+		}
+
 		if (SDLtoFS2[e.key.keysym.scancode]) {
 			key_mark(SDLtoFS2[e.key.keysym.scancode], 0, 0);
 

--- a/code/io/mouse.cpp
+++ b/code/io/mouse.cpp
@@ -61,6 +61,10 @@ namespace
 {
 	bool mouse_key_event_handler(const SDL_Event& e)
 	{
+		if (!os::events::isWindowEvent(e, os_get_window())) {
+			return false;
+		}
+
 		if (e.button.button == SDL_BUTTON_LEFT)
 			mouse_mark_button(MOUSE_LEFT_BUTTON, e.button.state);
 		else if (e.button.button == SDL_BUTTON_MIDDLE)
@@ -73,6 +77,10 @@ namespace
 
 	bool mouse_motion_event_handler(const SDL_Event& e)
 	{
+		if (!os::events::isWindowEvent(e, os_get_window())) {
+			return false;
+		}
+
 		mouse_event(e.motion.x, e.motion.y, e.motion.xrel, e.motion.yrel);
 
 		return true;
@@ -80,6 +88,10 @@ namespace
 
 	bool mouse_wheel_event_handler(const SDL_Event& e)
 	{
+		if (!os::events::isWindowEvent(e, os_get_window())) {
+			return false;
+		}
+
 #if SDL_VERSION_ATLEAST(2, 0, 4)
 		mousewheel_motion(e.wheel.x, e.wheel.y, e.wheel.direction == SDL_MOUSEWHEEL_FLIPPED);
 #else

--- a/code/osapi/osapi.cpp
+++ b/code/osapi/osapi.cpp
@@ -57,7 +57,7 @@ namespace
 	bool fAppActive = false;
 	bool window_event_handler(const SDL_Event& e)
 	{
-		if (e.window.windowID == SDL_GetWindowID(os_get_window())) {
+		if (os::events::isWindowEvent(e, os_get_window())) {
 			switch (e.window.event) {
 			case SDL_WINDOWEVENT_MINIMIZED:
 			case SDL_WINDOWEVENT_FOCUS_LOST:
@@ -495,6 +495,33 @@ namespace os
 			}
 
 			return false;
+		}
+
+		bool isWindowEvent(const SDL_Event& e, SDL_Window* window)
+		{
+			auto mainId = SDL_GetWindowID(window);
+			switch(e.type)
+			{
+			case SDL_WINDOWEVENT:
+				return mainId == e.window.windowID;
+			case SDL_KEYDOWN:
+			case SDL_KEYUP:
+				return mainId == e.key.windowID;
+			case SDL_TEXTEDITING:
+				return mainId == e.edit.windowID;
+			case SDL_TEXTINPUT:
+				return mainId == e.text.windowID;
+			case SDL_MOUSEMOTION:
+				return mainId == e.motion.windowID;
+			case SDL_MOUSEBUTTONDOWN:
+			case SDL_MOUSEBUTTONUP:
+				return mainId == e.button.windowID;
+			case SDL_MOUSEWHEEL:
+				return mainId == e.wheel.windowID;
+			default:
+				// Event doesn't have a window ID
+				return true;
+			}
 		}
 	}
 }

--- a/code/osapi/osapi.h
+++ b/code/osapi/osapi.h
@@ -140,6 +140,15 @@ namespace os
 		 */
 		bool removeEventListener(ListenerIdentifier identifier);
 
+		/**
+		* @brief Checks if the event belongs to a window
+		* This can be used to handle multiple windows correctly and only handle the events
+		* that belong to a specific window.
+		*
+		* @param e The event that should be checked
+		* @param window The window the event should belong to
+		* @return @c true if the event belongs to the window, @c false otherwise
+		*/
 		bool isWindowEvent(const SDL_Event& e, SDL_Window* window);
 	}
 }

--- a/code/osapi/osapi.h
+++ b/code/osapi/osapi.h
@@ -139,6 +139,8 @@ namespace os
 		 * @return @c true if the event handler was removed, @c false otherwise
 		 */
 		bool removeEventListener(ListenerIdentifier identifier);
+
+		bool isWindowEvent(const SDL_Event& e, SDL_Window* window);
 	}
 }
 


### PR DESCRIPTION
SDL2 support multiple windows and differentiates the events for the
individual windows using the windowID field in the events. These changes
check if that window ID belongs to our main window and ignores any
events that don't belong to it. This allows to add another window
without screwing up the rest of FSO with its input.