### PR TITLE
Remove alpha channel check in opengl_aabitmap_ex_internal 

### DIFF
--- a/code/graphics/gropengldraw.cpp
+++ b/code/graphics/gropengldraw.cpp
@@ -241,7 +241,7 @@ void opengl_aabitmap_ex_internal(int x, int y, int w, int h, int sx, int sy, int
 
 	GLboolean cull_face = GL_state.CullFace(GL_FALSE);
 
-	opengl_shader_set_passthrough(true, bm_has_alpha_channel(gr_screen.current_bitmap) ? false : true);
+	opengl_shader_set_passthrough(true, true);
 
 	opengl_draw_textured_quad(x1,y1,u0,v0, x2,y2,u1,v1);
 


### PR DESCRIPTION
This check shouldn't have been in opengl_aabitmap_ex_internal in the first place but I thought it was needed to fix an earlier bug Axem reported. It looks like it ended up causing https://github.com/scp-fs2open/fs2open.github.com/issues/650. 