### PR TITLE
Fix a couple force feedback issues.

### DIFF
--- a/code/io/joy_ff-sdl.cpp
+++ b/code/io/joy_ff-sdl.cpp
@@ -87,7 +87,10 @@ int joy_ff_init()
 	}
 #endif
 	
-	haptic = SDL_HapticOpenFromJoystick(joy_get_device());
+	// This should be how we do it, but it's currently bugged in SDL so it fails to re-enumerate haptic axes.
+	//haptic = SDL_HapticOpenFromJoystick(joy_get_device());
+
+	haptic = SDL_HapticOpen(0);
 
 	if (haptic == NULL) {
 		mprintf(("    ERROR: Unable to open haptic joystick: %s\n", SDL_GetError()));

--- a/code/io/joy_ff-sdl.cpp
+++ b/code/io/joy_ff-sdl.cpp
@@ -323,7 +323,7 @@ static int joy_ff_create_effects()
 	// pDock
 	memset(&pDock, 0, sizeof(haptic_effect_t));
 
-	pDock.eff.type = SDL_HAPTIC_LEFTRIGHT; //SDL_HAPTIC_SQUARE;
+	pDock.eff.type = SDL_HAPTIC_SINE; //SDL_HAPTIC_SQUARE;
 	pDock.eff.periodic.direction.type = SDL_HAPTIC_POLAR;
 	pDock.eff.periodic.direction.dir[0] = 9000;
 	pDock.eff.periodic.length = 125;


### PR DESCRIPTION
So, this makes force feedback work. It's not an ideal solution (uses the first haptic device SDL sees rather than matching the currently-selected joystick), but it's better than not working at all, which is where we are until [SDL fixes this bug](https://bugzilla.libsdl.org/show_bug.cgi?id=3021). As @asarium noted on IRC, "I doubt many people have more than one haptic device so for most people it should work fine." For more detail, see the description for commit 19b5ee9 (and the previously-linked SDL bug).

The other commit fixes the docking effect, which I noticed was malformed while I was working on the other issue. With both of these commits, the force feedback code no longer generates any errors in my debug log, and I get force feedback in-game.