### PR TITLE
Get rid of AppVeyor version number.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 3.7.3.{build}
+version: 1.0.0.{build}
 shallow_clone: true
 environment:
   matrix:


### PR DESCRIPTION
FSO hasn't been on 3.7.3 for a while, now.