### PR TITLE
Add *.VC.db and *.VC.VC.opendb to .gitignore file.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,8 @@ ipch/
 [Dd]ebug*/
 [Rr]elease*/
 Ankh.NoLoad
+*.VC.db
+*.VC.VC.opendb
 
 #MonoDevelop
 *.pidb


### PR DESCRIPTION
These are created by VS 2015 (as of update 2) and should be ignored like other local Visual Studio files. `*.VC.db` is a new format for the IntelliSense database (replacing `*.sdf` used by previous versions), and `*.VC.VC.opendb` is a lockfile indicating the database is in use.