### PR TITLE
Fix Visual Studio warnings

### DIFF
--- a/ci/travis/before_script.sh
+++ b/ci/travis/before_script.sh
@@ -5,12 +5,14 @@ set -e
 if [ "$TRAVIS_OS_NAME" = "linux" ]; then
     # Due to a bug in gcc the array bounds check isn't working correctly
     # This can be removed when gcc is updated
-    AUTOGEN_CONFIG="CXXFLAGS=-Wno-array-bounds --enable-fatal-warnings --enable-generic-architecture"
+    AUTOGEN_CONFIG="--enable-fatal-warnings --enable-generic-architecture"
+	CXXFLAGS="-Wno-array-bounds -Wno-unknown-pragmas"
     
     if [ "$CONFIGURATION" = "Debug" ]; then
         AUTOGEN_CONFIG="$AUTOGEN_CONFIG --enable-debug"
     fi
     
+	export CXXFLAGS
     ./autogen.sh $AUTOGEN_CONFIG
 elif [ "$TRAVIS_OS_NAME" = "osx" ]; then
     cd projects/Xcode

--- a/code/bmpman/bm_internal.h
+++ b/code/bmpman/bm_internal.h
@@ -92,14 +92,14 @@ struct bitmap_entry {
 extern bitmap_entry bm_bitmaps[MAX_BITMAPS];
 
 // image specific lock functions
-void bm_lock_ani( int handle, int bitmapnum, bitmap_entry *be, bitmap *bmp, ubyte bpp, ubyte flags );
-void bm_lock_dds( int handle, int bitmapnum, bitmap_entry *be, bitmap *bmp, ubyte bpp, ubyte flags );
-void bm_lock_png( int handle, int bitmapnum, bitmap_entry *be, bitmap *bmp, ubyte bpp, ubyte flags );
-void bm_lock_apng( int handle, int bitmapnum, bitmap_entry *be, bitmap *bmp, ubyte bpp, ubyte flags );
-void bm_lock_jpg( int handle, int bitmapnum, bitmap_entry *be, bitmap *bmp, ubyte bpp, ubyte flags );
-void bm_lock_pcx( int handle, int bitmapnum, bitmap_entry *be, bitmap *bmp, ubyte bpp, ubyte flags );
-void bm_lock_tga( int handle, int bitmapnum, bitmap_entry *be, bitmap *bmp, ubyte bpp, ubyte flags );
-void bm_lock_user( int handle, int bitmapnum, bitmap_entry *be, bitmap *bmp, ubyte bpp, ubyte flags );
+void bm_lock_ani( int handle, int bitmapnum, bitmap_entry *be, bitmap *bmp, int bpp, ubyte flags );
+void bm_lock_dds( int handle, int bitmapnum, bitmap_entry *be, bitmap *bmp, int bpp, ubyte flags );
+void bm_lock_png( int handle, int bitmapnum, bitmap_entry *be, bitmap *bmp, int bpp, ubyte flags );
+void bm_lock_apng( int handle, int bitmapnum, bitmap_entry *be, bitmap *bmp, int bpp, ubyte flags );
+void bm_lock_jpg( int handle, int bitmapnum, bitmap_entry *be, bitmap *bmp, int bpp, ubyte flags );
+void bm_lock_pcx( int handle, int bitmapnum, bitmap_entry *be, bitmap *bmp, int bpp, ubyte flags );
+void bm_lock_tga( int handle, int bitmapnum, bitmap_entry *be, bitmap *bmp, int bpp, ubyte flags );
+void bm_lock_user( int handle, int bitmapnum, bitmap_entry *be, bitmap *bmp, int bpp, ubyte flags );
 
 
 #endif // __BM_INTERNAL_H__

--- a/code/bmpman/bmpman.cpp
+++ b/code/bmpman/bmpman.cpp
@@ -1391,10 +1391,10 @@ bool bm_load_and_parse_eff(const char *filename, int dir_type, int *nframes, int
 /**
 * Lock an image files data into memory
 */
-static int bm_load_image_data(const char *filename, int handle, int bitmapnum, ubyte bpp, ubyte flags, bool nodebug)
+static int bm_load_image_data(const char *filename, int handle, int bitmapnum, int bpp, ubyte flags, bool nodebug)
 {
 	BM_TYPE c_type = BM_TYPE_NONE;
-	ubyte true_bpp;
+	int true_bpp;
 
 	bitmap_entry *be = &bm_bitmaps[bitmapnum];
 	bitmap *bmp = &be->bm;
@@ -1888,7 +1888,7 @@ int bm_load_sub_slow(const char *real_filename, const int num_ext, const char **
 	return -1;
 }
 
-bitmap * bm_lock(int handle, ubyte bpp, ubyte flags, bool nodebug) {
+bitmap * bm_lock(int handle, int bpp, ubyte flags, bool nodebug) {
 	bitmap			*bmp;
 	bitmap_entry	*be;
 
@@ -1994,7 +1994,7 @@ bitmap * bm_lock(int handle, ubyte bpp, ubyte flags, bool nodebug) {
 	return bmp;
 }
 
-void bm_lock_ani(int handle, int bitmapnum, bitmap_entry *be, bitmap *bmp, ubyte bpp, ubyte flags) {
+void bm_lock_ani(int handle, int bitmapnum, bitmap_entry *be, bitmap *bmp, int bpp, ubyte flags) {
 	anim				*the_anim;
 	anim_instance	*the_anim_instance;
 	bitmap			*bm;
@@ -2115,7 +2115,7 @@ void bm_lock_ani(int handle, int bitmapnum, bitmap_entry *be, bitmap *bmp, ubyte
 }
 
 
-void bm_lock_apng(int handle, int bitmapnum, bitmap_entry *be, bitmap *bmp, ubyte bpp, ubyte flags) {
+void bm_lock_apng(int handle, int bitmapnum, bitmap_entry *be, bitmap *bmp, int bpp, ubyte flags) {
 
 	int first_frame = be->info.ani.first_frame;
 	int nframes = bm_bitmaps[first_frame].info.ani.num_frames;
@@ -2163,7 +2163,7 @@ void bm_lock_apng(int handle, int bitmapnum, bitmap_entry *be, bitmap *bmp, ubyt
 }
 
 
-void bm_lock_dds(int handle, int bitmapnum, bitmap_entry *be, bitmap *bmp, ubyte bpp, ubyte flags) {
+void bm_lock_dds(int handle, int bitmapnum, bitmap_entry *be, bitmap *bmp, int bpp, ubyte flags) {
 	ubyte *data = NULL;
 	int error;
 	ubyte dds_bpp = 0;
@@ -2225,7 +2225,7 @@ void bm_lock_dds(int handle, int bitmapnum, bitmap_entry *be, bitmap *bmp, ubyte
 #endif
 }
 
-void bm_lock_jpg(int handle, int bitmapnum, bitmap_entry *be, bitmap *bmp, ubyte bpp, ubyte flags) {
+void bm_lock_jpg(int handle, int bitmapnum, bitmap_entry *be, bitmap *bmp, int bpp, ubyte flags) {
 	ubyte *data = NULL;
 	int d_size = 0;
 	int jpg_error = JPEG_ERROR_INVALID;
@@ -2267,7 +2267,7 @@ void bm_lock_jpg(int handle, int bitmapnum, bitmap_entry *be, bitmap *bmp, ubyte
 #endif
 }
 
-void bm_lock_pcx(int handle, int bitmapnum, bitmap_entry *be, bitmap *bmp, ubyte bpp, ubyte flags) {
+void bm_lock_pcx(int handle, int bitmapnum, bitmap_entry *be, bitmap *bmp, int bpp, ubyte flags) {
 	ubyte *data;
 	int pcx_error;
 	char filename[MAX_FILENAME_LEN];
@@ -2310,7 +2310,7 @@ void bm_lock_pcx(int handle, int bitmapnum, bitmap_entry *be, bitmap *bmp, ubyte
 	bm_convert_format(bmp, flags);
 }
 
-void bm_lock_png(int handle, int bitmapnum, bitmap_entry *be, bitmap *bmp, ubyte bpp, ubyte flags) {
+void bm_lock_png(int handle, int bitmapnum, bitmap_entry *be, bitmap *bmp, int bpp, ubyte flags) {
 	ubyte *data = NULL;
 	//assume 32 bit - libpng should expand everything
 	int d_size;
@@ -2353,7 +2353,7 @@ void bm_lock_png(int handle, int bitmapnum, bitmap_entry *be, bitmap *bmp, ubyte
 #endif
 }
 
-void bm_lock_tga(int handle, int bitmapnum, bitmap_entry *be, bitmap *bmp, ubyte bpp, ubyte flags) {
+void bm_lock_tga(int handle, int bitmapnum, bitmap_entry *be, bitmap *bmp, int bpp, ubyte flags) {
 	ubyte *data = NULL;
 	int d_size, byte_size;
 	char filename[MAX_FILENAME_LEN];
@@ -2409,7 +2409,7 @@ void bm_lock_tga(int handle, int bitmapnum, bitmap_entry *be, bitmap *bmp, ubyte
 	bm_convert_format(bmp, flags);
 }
 
-void bm_lock_user(int handle, int bitmapnum, bitmap_entry *be, bitmap *bmp, ubyte bpp, ubyte flags) {
+void bm_lock_user(int handle, int bitmapnum, bitmap_entry *be, bitmap *bmp, int bpp, ubyte flags) {
 	// Unload any existing data
 	bm_free_data(bitmapnum);
 
@@ -2455,7 +2455,7 @@ int bm_make_render_target(int width, int height, int flags) {
 	int mm_lvl = 0;
 	// final w and h may be different from passed width and height
 	int w = width, h = height;
-	ubyte bpp = 32;
+	int bpp = 32;
 	int size = 0;
 
 	if (!bm_inited)
@@ -2502,8 +2502,8 @@ int bm_make_render_target(int width, int height, int flags) {
 	bm_bitmaps[n].bm.w = (short)w;
 	bm_bitmaps[n].bm.h = (short)h;
 	bm_bitmaps[n].bm.rowsize = (short)w;
-	bm_bitmaps[n].bm.bpp = (ubyte)bpp;
-	bm_bitmaps[n].bm.true_bpp = (ubyte)bpp;
+	bm_bitmaps[n].bm.bpp = bpp;
+	bm_bitmaps[n].bm.true_bpp = bpp;
 	bm_bitmaps[n].bm.flags = (ubyte)flags;
 	bm_bitmaps[n].bm.data = 0;
 	bm_bitmaps[n].bm.palette = NULL;

--- a/code/bmpman/bmpman.h
+++ b/code/bmpman/bmpman.h
@@ -103,8 +103,8 @@ struct bitmap
 	short	w;          //!< Width, in number of pixels
 	short	h;          //!< Height, in number of pixels
 	short	rowsize;    //!< What you need to add to go to next row
-	ubyte	bpp;        //!< Requested bitdepth of each pixel. ( 7, 8, 15, 16, 24, 32)
-	ubyte	true_bpp;   //!< The image's actual bitdepth
+	int	bpp;        //!< Requested bitdepth of each pixel. ( 7, 8, 15, 16, 24, 32)
+	int	true_bpp;   //!< The image's actual bitdepth
 	ubyte	flags;      //!< Various texture type flags. @see BMPMAN_CONSTANTS
 	ptr_u	data;       //!< Pointer to data, or maybe offset into VRAM.
 	ubyte *palette;     /**< @brief   Pointer to this bitmap's palette (if it has one).
@@ -335,7 +335,7 @@ int bm_load_either(const char *filename, int *nframes = NULL, int *fps = NULL, i
  * @returns A pointer to the bitmap that's valid until bm_unlock is called if successful, or
  * @returns NULL if unsuccessful
  */
-bitmap* bm_lock(int handle, ubyte bpp, ubyte flags, bool nodebug = false);
+bitmap* bm_lock(int handle, int bpp, ubyte flags, bool nodebug = false);
 
 /**
  * @brief Returns a unique signiature for the bitmap indexed by handle

--- a/code/globalincs/alphacolors.cpp
+++ b/code/globalincs/alphacolors.cpp
@@ -376,7 +376,7 @@ void parse_everything_else(const char *filename)
 
 			while (required_string_either("#End", "$Team Name:")) {
 				required_string("$Team Name:"); // required to move the parse pointer forward
-				team_color temp_color;
+				team_color temp_color = {};
 
 				char temp2[NAME_LENGTH];
 				stuff_string(temp2, F_NAME, NAME_LENGTH);

--- a/code/globalincs/alphacolors.cpp
+++ b/code/globalincs/alphacolors.cpp
@@ -376,7 +376,8 @@ void parse_everything_else(const char *filename)
 
 			while (required_string_either("#End", "$Team Name:")) {
 				required_string("$Team Name:"); // required to move the parse pointer forward
-				team_color temp_color = {};
+				team_color temp_color;
+				memset(&temp_color, 0, sizeof(temp_color));
 
 				char temp2[NAME_LENGTH];
 				stuff_string(temp2, F_NAME, NAME_LENGTH);

--- a/code/globalincs/mspdb_callstack.cpp
+++ b/code/globalincs/mspdb_callstack.cpp
@@ -10,7 +10,12 @@
 
 /* Windows */
 #include <windows.h>
+
+// Stupid Microsoft is not able to fix a simple compile warning: https://connect.microsoft.com/VisualStudio/feedback/details/888527/warnings-on-dbghelp-h
+#pragma warning(push)
+#pragma warning(disable: 4091) // ignored on left of '' when no variable is declared
 #include <dbghelp.h>
+#pragma warning(pop)
 
 /* SCP */
 #include "globalincs/pstypes.h"
@@ -100,7 +105,7 @@ BOOL SCP_mspdbcs_ResolveSymbol( HANDLE hProcess, UINT_PTR dwAddress, SCP_mspdbcs
 
 			if ( siSymbol.dwOffset != 0 )
 			{
-				sprintf_s( szWithOffset, SCP_MSPDBCS_MAX_SYMBOL_LENGTH, "%s + %d bytes", pszSymbol, siSymbol.dwOffset );
+				sprintf_s( szWithOffset, SCP_MSPDBCS_MAX_SYMBOL_LENGTH, "%s + %lld bytes", pszSymbol, siSymbol.dwOffset );
 				szWithOffset[ SCP_MSPDBCS_MAX_SYMBOL_LENGTH - 1 ] = '\0'; /* Because sprintf doesn't guarantee NULL terminating */
 				pszSymbol = szWithOffset;
 			}

--- a/code/globalincs/profiling.cpp
+++ b/code/globalincs/profiling.cpp
@@ -208,9 +208,9 @@ void profile_dump_output()
 		profile_output += "----------------------------------------\n";
 
 		for(int i = 0; i < (int)samples.size(); i++) {
-			uint sample_time;
+			uint64_t sample_time;
 			float percent_time, avg_time, min_time, max_time;
-			uint avg_micro_seconds, min_micro_seconds, max_micro_seconds; 
+			uint64_t avg_micro_seconds, min_micro_seconds, max_micro_seconds; 
 
 			Assert(samples[i].open_profiles == 0);
 
@@ -260,7 +260,7 @@ void profile_dump_output()
  * @param name The globally unique name for this profile (see profile_begin()/profile_end())
  * @param percent How much time the profiled section took to execute (as a percentage of overall frametime)
  */
-void store_profile_in_history(SCP_string &name, float percent, uint time)
+void store_profile_in_history(SCP_string &name, float percent, uint64_t time)
 {
 	float old_ratio;
 	float new_ratio = 0.8f * f2fl(Frametime);
@@ -323,7 +323,7 @@ void store_profile_in_history(SCP_string &name, float percent, uint time)
  * @param min Pointer to a float in which the minimum value will be stored (or 0.0 if no value has been saved)
  * @param max Pointer to a float in which the maximum value will be stored (or 0.0 if no value has been saved)
  */
-void get_profile_from_history(SCP_string &name, float* avg, float* min, float* max, uint *avg_micro_sec, uint *min_micro_sec, uint *max_micro_sec)
+void get_profile_from_history(SCP_string &name, float* avg, float* min, float* max, uint64_t *avg_micro_sec, uint64_t *min_micro_sec, uint64_t *max_micro_sec)
 {
 	for ( int i = 0; i < (int)history.size(); i++ ) {
 		if ( history[i].name == name ) {

--- a/code/globalincs/systemvars.h
+++ b/code/globalincs/systemvars.h
@@ -243,8 +243,8 @@ void profile_begin(const char* name);
 void profile_begin(SCP_string &output_handle, const char* name);
 void profile_end(const char* name);
 void profile_dump_output();
-void store_profile_in_history(SCP_string &name, float percent, uint time);
-void get_profile_from_history(SCP_string &name, float* avg, float* min, float* max, uint *avg_micro_sec, uint *min_micro_sec, uint *max_micro_sec);
+void store_profile_in_history(SCP_string &name, float percent, uint64_t time);
+void get_profile_from_history(SCP_string &name, float* avg, float* min, float* max, uint64_t *avg_micro_sec, uint64_t *min_micro_sec, uint64_t *max_micro_sec);
 
 class profile_auto
 {

--- a/code/graphics/2d.h
+++ b/code/graphics/2d.h
@@ -538,7 +538,7 @@ typedef struct screen {
 	void (*gf_bm_page_in_start)();
 	bool (*gf_bm_data)(int n, bitmap* bm);
 
-	int (*gf_bm_make_render_target)(int n, int *width, int *height, ubyte *bpp, int *mm_lvl, int flags );
+	int (*gf_bm_make_render_target)(int n, int *width, int *height, int *bpp, int *mm_lvl, int flags );
 	int (*gf_bm_set_render_target)(int n, int face);
 
 	void (*gf_translate_texture_matrix)(int unit, const vec3d *shift);

--- a/code/graphics/generic.cpp
+++ b/code/graphics/generic.cpp
@@ -499,7 +499,7 @@ void generic_render_png_stream(generic_anim* ga)
 	}
 
 	bm_lock(ga->bitmap_id, ga->png.anim->bpp, BMP_TEX_NONCOMP, true);  // lock in 32 bpp for png
-	ubyte bpp = ga->png.anim->bpp;
+	int bpp = ga->png.anim->bpp;
 	if (ga->use_hud_color) {
 		bpp = 8;
 	}

--- a/code/graphics/gropenglbmpman.cpp
+++ b/code/graphics/gropenglbmpman.cpp
@@ -118,7 +118,7 @@ void gr_opengl_bm_save_render_target(int n)
 	}
 }
 
-int gr_opengl_bm_make_render_target(int n, int *width, int *height, ubyte *bpp, int *mm_lvl, int flags)
+int gr_opengl_bm_make_render_target(int n, int *width, int *height, int *bpp, int *mm_lvl, int flags)
 {
 	Assert( (n >= 0) && (n < MAX_BITMAPS) );
 

--- a/code/graphics/gropenglbmpman.h
+++ b/code/graphics/gropenglbmpman.h
@@ -31,7 +31,7 @@ void gr_opengl_bm_page_in_start();
 bool gr_opengl_bm_data(int n, bitmap* bm);
 
 void gr_opengl_bm_save_render_target(int slot);
-int gr_opengl_bm_make_render_target(int n, int *width, int *height, ubyte *bpp, int *mm_lvl, int flags);
+int gr_opengl_bm_make_render_target(int n, int *width, int *height, int *bpp, int *mm_lvl, int flags);
 int gr_opengl_bm_set_render_target(int n, int face);
 
 #endif // _OGL_BMPMAN_H

--- a/code/graphics/gropengltexture.cpp
+++ b/code/graphics/gropengltexture.cpp
@@ -372,7 +372,7 @@ int opengl_create_texture_sub(int bitmap_handle, int bitmap_type, int bmap_w, in
 	GLenum texFormat = GL_UNSIGNED_SHORT_1_5_5_5_REV;
 	GLenum glFormat = GL_BGRA;
 	GLint intFormat = GL_RGBA;
-	ubyte saved_bpp = 0;
+	int saved_bpp = 0;
 	int mipmap_w = 0, mipmap_h = 0;
 	int dsize = 0, doffset = 0, block_size = 0;
 	int i,j,k;
@@ -1639,7 +1639,7 @@ int opengl_set_render_target( int slot, int face, int is_static )
 	return 1;
 }
 
-int opengl_make_render_target( int handle, int slot, int *w, int *h, ubyte *bpp, int *mm_lvl, int flags )
+int opengl_make_render_target( int handle, int slot, int *w, int *h, int *bpp, int *mm_lvl, int flags )
 {
 	Assert( !GL_rendering_to_texture );
 

--- a/code/graphics/gropengltexture.h
+++ b/code/graphics/gropengltexture.h
@@ -24,8 +24,8 @@ typedef struct tcache_slot_opengl {
 	int	bitmap_handle;
 	int	size;
 	ushort w, h;
-	ubyte bpp;
-	ubyte mipmap_levels;
+	int bpp;
+	int mipmap_levels;
 
 	tcache_slot_opengl() :
 		texture_id(0), texture_target(GL_TEXTURE_2D), wrap_mode(GL_REPEAT),
@@ -73,7 +73,7 @@ void opengl_set_modulate_tex_env();
 void opengl_preload_init();
 GLfloat opengl_get_max_anisotropy();
 void opengl_kill_render_target(int slot);
-int opengl_make_render_target(int handle, int slot, int *w, int *h, ubyte *bpp, int *mm_lvl, int flags);
+int opengl_make_render_target(int handle, int slot, int *w, int *h, int *bpp, int *mm_lvl, int flags);
 int opengl_set_render_target(int slot, int face = -1, int is_static = 0);
 void gr_opengl_get_bitmap_from_texture(void* data_out, int bitmap_num);
 int opengl_get_texture(GLenum target, GLenum pixel_format, GLenum data_format, int num_mipmaps, int width, int height, int bytes_per_pixel, void* image_data, int offset);

--- a/code/graphics/grstub.cpp
+++ b/code/graphics/grstub.cpp
@@ -479,7 +479,7 @@ void gr_stub_get_bitmap_from_texture(void* data_out, int bitmap_num)
 
 }
 
-int gr_stub_bm_make_render_target(int n, int *width, int *height, ubyte *bpp, int *mm_lvl, int flags)
+int gr_stub_bm_make_render_target(int n, int *width, int *height, int *bpp, int *mm_lvl, int flags)
 {
 	return 0;
 }

--- a/code/hud/hud.cpp
+++ b/code/hud/hud.cpp
@@ -2243,7 +2243,7 @@ int hud_anim_render(hud_anim *ha, float frametime, int draw_alpha, int loop, int
 	}
 
 	// Note; total_time for hud_anim is derived only from the fps, no need to pass it in
-	framenum = bm_get_anim_frame(ha->first_frame, ha->time_elapsed, 0.0f, static_cast<bool>(loop));
+	framenum = bm_get_anim_frame(ha->first_frame, ha->time_elapsed, 0.0f, loop != 0);
 	if (reverse) {
 		framenum = (ha->num_frames-1) - framenum;
 	}

--- a/code/jpgutils/jpgutils.cpp
+++ b/code/jpgutils/jpgutils.cpp
@@ -16,6 +16,7 @@
 #include "jpeglib.h"
 
 #undef LOCAL // fix from a jpeg header, pstypes.h will define it again
+#undef HAVE_STDDEF_H // fix a warning where jpeg and SDL headers collide
 
 #include "globalincs/pstypes.h"
 #include "jpgutils/jpgutils.h"

--- a/code/lab/wmcgui.cpp
+++ b/code/lab/wmcgui.cpp
@@ -2668,7 +2668,7 @@ int Slider::DoRefreshSize()
 
 int Slider::GetSliderOffset()
 {
-	return SliderScale * (BarCoords[2] - BarCoords[0] - SliderWidth) + BarCoords[0];
+	return fl2i(SliderScale * (BarCoords[2] - BarCoords[0] - SliderWidth) + BarCoords[0]);
 }
 
 float Slider::GetSliderPos(int x)
@@ -2714,7 +2714,7 @@ void Slider::DoDraw(float frametime)
 
 	draw_open_rect(BarCoords[0], BarCoords[1], BarCoords[2], BarCoords[3], false);
 
-	float sliderX = GetSliderOffset();
+	auto sliderX = GetSliderOffset();
 
 	gr_set_shader(&SliderShade);
 	gr_opengl_shade(sliderX, BarCoords[1], sliderX + SliderWidth, BarCoords[3], false);

--- a/code/math/fvi.cpp
+++ b/code/math/fvi.cpp
@@ -1079,6 +1079,8 @@ void fvi_closest_line_line(const vec3d *x0, const vec3d *vx, const vec3d *y0, co
 }
 
 // --------------------------------------------------------------------------------------------------------------------
+#pragma warning(push)
+#pragma warning(disable: 4505) // Unused local function
 static void accurate_square_root( float A, float B, float C, float discriminant, float *root1, float *root2 )
 {
 	float root = fl_sqrt(discriminant);
@@ -1091,6 +1093,7 @@ static void accurate_square_root( float A, float B, float C, float discriminant,
 		*root2 = 2.0f*C / (-B + root);
 	}
 }
+#pragma warning(pop)
 
 /**
  * Project point on bounding box

--- a/code/math/vecmat.cpp
+++ b/code/math/vecmat.cpp
@@ -1583,6 +1583,8 @@ void vm_quaternion_rotate(matrix *M, float theta, const vec3d *u)
 //		inputs:	m			=>		point to resultant rotation matrix
 //				angle		=>		rotation angle about z axis (in radians)
 //
+#pragma warning(push)
+#pragma warning(disable: 4505) // Unused local function
 static void rotate_z ( matrix *m, float theta )
 {
 	m->vec.rvec.xyz.x = cosf (theta);
@@ -1597,6 +1599,7 @@ static void rotate_z ( matrix *m, float theta )
 	m->vec.fvec.xyz.y = 0.0f;
 	m->vec.fvec.xyz.z = 1.0f;
 }
+#pragma warning(pop)
 
 
 // --------------------------------------------------------------------------------------

--- a/code/osapi/osregistry.cpp
+++ b/code/osapi/osregistry.cpp
@@ -19,7 +19,11 @@
 
 #ifdef WIN32
 #include <Windows.h>
+// Stupid Microsoft is not able to fix a simple compile warning: https://connect.microsoft.com/VisualStudio/feedback/details/1342304/level-1-compiler-warnings-in-windows-sdk-shipped-with-visual-studio
+#pragma warning(push)
+#pragma warning(disable: 4091) // ignored on left of '' when no variable is declared
 #include <Shlobj.h>
+#pragma warning(pop)
 #include <Sddl.h>
 #endif
 

--- a/code/parse/parselo.cpp
+++ b/code/parse/parselo.cpp
@@ -694,7 +694,6 @@ int required_string_either(char *str1, char *str2)
 	nprintf(("Error", "Error: Unable to find either required token [%s] or [%s]\n", str1, str2));
 	Warning(LOCATION, "Error: Unable to find either required token [%s] or [%s]\n", str1, str2);
 	throw parse::ParseException("Required string not found");
-	return -1;	// Dead code, but some compilers still complain about it
 }
 
 /**

--- a/code/pngutils/pngutils.cpp
+++ b/code/pngutils/pngutils.cpp
@@ -134,7 +134,7 @@ int png_read_header(const char *real_filename, CFILE *img_cfp, int *w, int *h, i
  *
  * @retval true if succesful, false otherwise
  */
-int png_read_bitmap(const char *real_filename, ubyte *image_data, ubyte *bpp, int dest_size, int cf_type)
+int png_read_bitmap(const char *real_filename, ubyte *image_data, int *bpp, int dest_size, int cf_type)
 {
 	char filename[MAX_FILENAME_LEN];
 	png_infop info_ptr;
@@ -311,10 +311,10 @@ void apng_ani::_compose_frame()
 							u = sp[3] * 255;
 							v = (255 - sp[3]) * dp[3];
 							al = u + v;
-							dp[0] = (sp[0] * u + dp[0] * v) / al;
-							dp[1] = (sp[1] * u + dp[1] * v) / al;
-							dp[2] = (sp[2] * u + dp[2] * v) / al;
-							dp[3] = al / 255;
+							dp[0] = static_cast<ubyte>((sp[0] * u + dp[0] * v) / al);
+							dp[1] = static_cast<ubyte>((sp[1] * u + dp[1] * v) / al);
+							dp[2] = static_cast<ubyte>((sp[2] * u + dp[2] * v) / al);
+							dp[3] = static_cast<ubyte>(al / 255);
 						}
 						else {
 							// destination is transparent, overwrite it

--- a/code/pngutils/pngutils.h
+++ b/code/pngutils/pngutils.h
@@ -15,8 +15,8 @@
 #define PNG_ERROR_READING		1
 
 // reading
-extern int png_read_header(const char *real_filename, CFILE *img_cfp = NULL, int *w = 0, int *h = 0, int *bpp = 0, ubyte *palette = NULL);
-extern int png_read_bitmap(const char *real_filename, ubyte *image_data, ubyte *bpp, int dest_size, int cf_type = CF_TYPE_ANY);
+extern int png_read_header(const char *real_filename, CFILE *img_cfp = NULL, int *w = nullptr, int *h = nullptr, int *bpp = nullptr, ubyte *palette = nullptr);
+extern int png_read_bitmap(const char *real_filename, ubyte *image_data, int *bpp, int dest_size, int cf_type = CF_TYPE_ANY);
 
 namespace apng {
 
@@ -36,7 +36,7 @@ public:
 	apng_frame frame;
 	uint       w;
 	uint       h;
-	uint       bpp;
+	int       bpp;
 	uint       nframes;
 	uint       current_frame;
 	uint       plays;

--- a/code/sound/speech.cpp
+++ b/code/sound/speech.cpp
@@ -39,6 +39,14 @@
 	#pragma error( "ERROR: Unknown platform, speech (FS2_SPEECH) is not supported" )
 #endif	//_WIN32
 
+#pragma warning(push)
+#pragma warning(disable: 4995)
+// Visual Studio complains that some functions are deprecated so this fixes that
+#include <cstring>
+#include <cwchar>
+#include <cstdio>
+#pragma warning(pop)
+
 #include "globalincs/pstypes.h"
 #include "speech.h"
 

--- a/code/sound/voicerec.cpp
+++ b/code/sound/voicerec.cpp
@@ -19,6 +19,13 @@
 #include "stdafx.h"
 #endif	//LAUNCHER
 
+#pragma warning(push)
+#pragma warning(disable: 4995)
+// Visual Studio complains that some functions are deprecated so this fixes that
+#include <cstring>
+#include <cwchar>
+#include <cstdio>
+#pragma warning(pop)
 
 
 #include <sphelper.h>                           // Contains definitions of SAPI functions


### PR DESCRIPTION
The only major change is that all bpp variables in bmpman have been converted into ints. Before it was a mix of ubyte and int.