### PR TITLE
Make modular ship tables not reset to species countermeasures.

### DIFF
--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -3432,7 +3432,7 @@ int parse_ship_values(ship_info* sip, const bool is_template, const bool first_t
 		} else {
 			sip->cmeasure_type = res;
 		}
-	} else if (Species_info[sip->species].cmeasure_index >= 0) {
+	} else if (first_time && Species_info[sip->species].cmeasure_index >= 0) {
 		sip->cmeasure_type = Species_info[sip->species].cmeasure_index;
 	}
 


### PR DESCRIPTION
If a modular ship table modifies a ship entry without specifying a `$Countermeasure type:` entry, and the species has a `$Countermeasure type:` entry, FSO would reset the ship's countermeasure type to match the species default, even if we weren't defining the class for the first time. This just adds a `first_time` check to the else branch to avoid that.