### PR TITLE
Various cleanup related to weapon objects.

### DIFF
--- a/code/debris/debris.cpp
+++ b/code/debris/debris.cpp
@@ -779,8 +779,8 @@ int debris_check_collision(object *pdebris, object *other_obj, vec3d *hitpos, co
 		}
 
 		weapon *wp = &Weapons[other_obj->instance];
-		wp->collisionOccured = true;
-		memcpy(&wp->collisionInfo, &mc, sizeof(mc_info));
+		wp->collisionInfo = new mc_info;	// The weapon will free this memory later
+		memcpy(wp->collisionInfo, &mc, sizeof(mc_info));
 
 		return mc.num_hits;
 	}

--- a/code/object/collideshipweapon.cpp
+++ b/code/object/collideshipweapon.cpp
@@ -410,8 +410,8 @@ int ship_weapon_check_collision(object *ship_objp, object *weapon_objp, float ti
 
 	if ( valid_hit_occurred )
 	{
-		wp->collisionOccured = true;
-		memcpy(&wp->collisionInfo, &mc, sizeof(mc_info));
+		wp->collisionInfo = new mc_info;	// The weapon will free this memory later
+		memcpy(wp->collisionInfo, &mc, sizeof(mc_info));
 
 		Script_system.SetHookObjects(4, "Ship", ship_objp, "Weapon", weapon_objp, "Self",ship_objp, "Object", weapon_objp);
 		bool ship_override = Script_system.IsConditionOverride(CHA_COLLIDEWEAPON, ship_objp);

--- a/code/object/collideweaponweapon.cpp
+++ b/code/object/collideweaponweapon.cpp
@@ -150,16 +150,20 @@ int collide_weapon_weapon( obj_pair * pair )
 			// single player and multiplayer masters evaluate the scoring and kill stuff
 			if (!MULTIPLAYER_CLIENT) {
 
-				//Save damage for bomb so we can do scoring once it's destroyed. -Halleck
+				// If bomb was destroyed, do scoring
 				if (wipA->wi_flags & WIF_BOMB) {
-					scoring_add_damage_to_weapon(A, B, wipB->damage);
 					//Update stats. -Halleck
 					scoring_eval_hit(A, B, 0);
+					if (wpA->weapon_flags & WF_DESTROYED_BY_WEAPON) {
+						scoring_eval_kill_on_weapon(A, B);
+					}
 				}
 				if (wipB->wi_flags & WIF_BOMB) {
-					scoring_add_damage_to_weapon(B, A, wipA->damage);
 					//Update stats. -Halleck
 					scoring_eval_hit(B, A, 0);
+					if (wpB->weapon_flags & WF_DESTROYED_BY_WEAPON) {
+						scoring_eval_kill_on_weapon(B, A);
+					}
 				}
 			}
 		}

--- a/code/object/collideweaponweapon.cpp
+++ b/code/object/collideweaponweapon.cpp
@@ -102,10 +102,10 @@ int collide_weapon_weapon( obj_pair * pair )
 			if (wipA->weapon_hitpoints > 0) {
 				if (wipB->weapon_hitpoints > 0) {		//	Two bombs collide, detonate both.
 					if ((wipA->wi_flags & WIF_BOMB) && (wipB->wi_flags & WIF_BOMB)) {
-						Weapons[A->instance].lifeleft = 0.01f;
-						Weapons[B->instance].lifeleft = 0.01f;
-						Weapons[A->instance].weapon_flags |= WF_DESTROYED_BY_WEAPON;
-						Weapons[B->instance].weapon_flags |= WF_DESTROYED_BY_WEAPON;
+						wpA->lifeleft = 0.01f;
+						wpB->lifeleft = 0.01f;
+						wpA->weapon_flags |= WF_DESTROYED_BY_WEAPON;
+						wpB->weapon_flags |= WF_DESTROYED_BY_WEAPON;
 					} else {
 						A->hull_strength -= bDamage;
 						B->hull_strength -= aDamage;
@@ -120,30 +120,30 @@ int collide_weapon_weapon( obj_pair * pair )
 						}
 						
 						if (A->hull_strength < 0.0f) {
-							Weapons[A->instance].lifeleft = 0.01f;
-							Weapons[A->instance].weapon_flags |= WF_DESTROYED_BY_WEAPON;
+							wpA->lifeleft = 0.01f;
+							wpA->weapon_flags |= WF_DESTROYED_BY_WEAPON;
 						}
 						if (B->hull_strength < 0.0f) {
-							Weapons[B->instance].lifeleft = 0.01f;
-							Weapons[B->instance].weapon_flags |= WF_DESTROYED_BY_WEAPON;
+							wpB->lifeleft = 0.01f;
+							wpB->weapon_flags |= WF_DESTROYED_BY_WEAPON;
 						}
 					}
 				} else {
 					A->hull_strength -= bDamage;
-					Weapons[B->instance].lifeleft = 0.01f;
-					Weapons[B->instance].weapon_flags |= WF_DESTROYED_BY_WEAPON;
+					wpB->lifeleft = 0.01f;
+					wpB->weapon_flags |= WF_DESTROYED_BY_WEAPON;
 					if (A->hull_strength < 0.0f) {
-						Weapons[A->instance].lifeleft = 0.01f;
-						Weapons[A->instance].weapon_flags |= WF_DESTROYED_BY_WEAPON;
+						wpA->lifeleft = 0.01f;
+						wpA->weapon_flags |= WF_DESTROYED_BY_WEAPON;
 					}
 				}
 			} else if (wipB->weapon_hitpoints > 0) {
 				B->hull_strength -= aDamage;
-				Weapons[A->instance].lifeleft = 0.01f;
-				Weapons[A->instance].weapon_flags |= WF_DESTROYED_BY_WEAPON;
+				wpA->lifeleft = 0.01f;
+				wpA->weapon_flags |= WF_DESTROYED_BY_WEAPON;
 				if (B->hull_strength < 0.0f) {
-					Weapons[B->instance].lifeleft = 0.01f;
-					Weapons[B->instance].weapon_flags |= WF_DESTROYED_BY_WEAPON;
+					wpB->lifeleft = 0.01f;
+					wpB->weapon_flags |= WF_DESTROYED_BY_WEAPON;
 				}
 			}
 
@@ -169,7 +169,7 @@ int collide_weapon_weapon( obj_pair * pair )
 			Script_system.SetHookObjects(4, "Weapon", A, "WeaponB", B, "Self",A, "Object", B);
 			Script_system.RunCondition(CHA_COLLIDEWEAPON, '\0', NULL, A, wpA->weapon_info_index);
 		}
-		if((b_override && !a_override) || (!b_override && !a_override))
+		else
 		{
 			//Should be reversed
 			Script_system.SetHookObjects(4, "Weapon", B, "WeaponB", A, "Self",B, "Object", A);

--- a/code/parse/lua.cpp
+++ b/code/parse/lua.cpp
@@ -10966,8 +10966,8 @@ ADE_FUNC(getCollisionInformation, l_Weapon, NULL, "Returns the collision informa
 
 	weapon *wp = &Weapons[oh->objp->instance];
 	
-	if (wp->collisionOccured)
-		return ade_set_args(L, "o", l_ColInfo.Set(mc_info_h(new mc_info(wp->collisionInfo))));
+	if (wp->collisionInfo != nullptr)
+		return ade_set_args(L, "o", l_ColInfo.Set(mc_info_h(new mc_info(*(wp->collisionInfo)))));
 	else
 		return ade_set_args(L, "o", l_ColInfo.Set(mc_info_h()));
 }

--- a/code/stats/scoring.cpp
+++ b/code/stats/scoring.cpp
@@ -856,25 +856,11 @@ int scoring_eval_kill(object *ship_objp)
 
 //evaluate a kill on a weapon, right now this is only called on bombs. -Halleck
 int scoring_eval_kill_on_weapon(object *weapon_obj, object *other_obj) {
-	float max_damage_pct;		// the pct% of total damage the max damage object did
-	int max_damage_index;		// the index into the dying ship's damage_ship[] array corresponding the greatest amount of damage
 	int killer_sig;				// signature of the guy getting credit for the kill (or -1 if none)
-	int idx,net_player_num;
+	int net_player_num;
 	player *plr;					// pointer to a player struct if it was a player who got the kill
 	net_player *net_plr = NULL;
-	net_player *dead_plr = NULL;
-	float scoring_scale_by_damage = 1;	// percentage to scale the killer's score by if we score based on the amount of damage caused
 	int kill_score; 
-
-	weapon *dead_wp;						// the weapon that was killed
-	weapon_info *dead_wip;				// info on the weapon that was killed
-
-	if((weapon_obj->instance < 0) || (weapon_obj->instance >= MAX_WEAPONS)){
-		return -1;
-	}
-    
-	dead_wp = &Weapons[weapon_obj->instance]; //assign the dead weapon
-	dead_wip = &Weapon_info[dead_wp->weapon_info_index];
 
 	// multiplayer clients bail here
 	if(MULTIPLAYER_CLIENT){
@@ -882,57 +868,26 @@ int scoring_eval_kill_on_weapon(object *weapon_obj, object *other_obj) {
 	}
 
 	// we don't evaluate kills on anything except weapons
-	if(weapon_obj->type != OBJ_WEAPON){
-		return -1;	
+	// also make sure there was a killer, and that it was a ship
+	if((weapon_obj->type != OBJ_WEAPON) || (weapon_obj->instance < 0) || (weapon_obj->instance >= MAX_WEAPONS)
+			|| (other_obj == nullptr) || (other_obj->type != OBJ_WEAPON) || (other_obj->instance < 0) || (other_obj->instance >= MAX_WEAPONS)
+			|| (other_obj->parent == -1) || (Objects[other_obj->parent].type != OBJ_SHIP)) {
+		return -1;
 	}
+    
+	weapon *dead_wp = &Weapons[weapon_obj->instance];	// the weapon that was killed
+	weapon_info *dead_wip = &Weapon_info[dead_wp->weapon_info_index];	// info on the weapon that was killed
 
 	// we don't evaluate kills on anything except bombs, currently. -Halleck
 	if(!(dead_wip->wi_flags & WIF_BOMB))  {
 		return -1;
 	}
 
-	// clear out invalid damager ships
-	for(idx=0; idx<MAX_DAMAGE_SLOTS; idx++){
-		if((dead_wp->damage_ship_id[idx] >= 0) && (ship_get_by_signature(dead_wp->damage_ship_id[idx]) < 0)){
-			dead_wp->damage_ship[idx] = 0.0f;
-			dead_wp->damage_ship_id[idx] = -1;
-		}
-	}
-			
-	// determine which object did the most damage to the dying object, and how much damage that was
-	max_damage_index = -1;
-	for(idx=0;idx<MAX_DAMAGE_SLOTS;idx++){
-		// bogus ship
-		if(dead_wp->damage_ship_id[idx] < 0){
-			continue;
-		}
+	// set killer_sig for this weapon to the signature of the guy who gets credit for the kill
+	killer_sig = Objects[other_obj->parent].signature;
 
-		// if this slot did more damage then the next highest slot
-		if((max_damage_index == -1) || (dead_wp->damage_ship[idx] > dead_wp->damage_ship[max_damage_index])){
-			max_damage_index = idx;
-		}			
-	}
-	
-	// doh
-	if((max_damage_index < 0) || (max_damage_index >= MAX_DAMAGE_SLOTS)){
-		return -1;
-	}
-
-	// the pct of total damage applied to this ship
-	max_damage_pct = dead_wp->damage_ship[max_damage_index] / dead_wp->total_damage_received;
-    
-	CLAMP(max_damage_pct, 0.0f, 1.0f);
-
-	// only evaluate if the max damage % is high enough to record a kill and it was done by a valid object
-	if((max_damage_pct >= Kill_percentage) && (dead_wp->damage_ship_id[max_damage_index] >= 0)){
-		// set killer_sig for this ship to the signature of the guy who gets credit for the kill
-		killer_sig = dead_wp->damage_ship_id[max_damage_index];
-
-		// set the scale value if we only award 100% score for 100% damage
-		if (The_mission.ai_profile->flags & AIPF_KILL_SCORING_SCALES_WITH_DAMAGE) {
-			scoring_scale_by_damage = max_damage_pct;
-		}
-
+	// only evaluate if the kill was done by a valid object
+	if(killer_sig >= 0) {
 		// null this out for now
 		plr = NULL;
 		net_plr = NULL;
@@ -950,22 +905,16 @@ int scoring_eval_kill_on_weapon(object *weapon_obj, object *other_obj) {
 			if(Objects[Player->objnum].signature == killer_sig){
 				plr = Player;
 			}
-		}		
+		}
 
 		// if we found a valid player, evaluate some kill details
 		if(plr != NULL){
-			//int si_index;
-
 			// bogus
 			if((plr->objnum < 0) || (plr->objnum >= MAX_OBJECTS)){
 				return -1;
-			}			
+			}
 
-			// get the ship info index of the ship type of this kill.  we need to take ship
-			// copies into account here.
-			//si_index = dead_wp->weapon_info_index;
-
-			// if he killed a guy on his own team increment his bonehead kills
+			// if he killed a bomb on his own team increment his bonehead kills
 			if((Ships[Objects[plr->objnum].instance].team == dead_wp->team) && !MULTI_DOGFIGHT ){
 				if (!(The_mission.flags & MISSION_FLAG_NO_TRAITOR)) {
 					plr->stats.m_bonehead_kills++;
@@ -984,15 +933,15 @@ int scoring_eval_kill_on_weapon(object *weapon_obj, object *other_obj) {
 					// don't add a kill for dogfight kills on non-players
 				} else {
 
-					// bombs don't scale with difficulty at the moment. If we change this we want to *scoring_get_scale_factor() too
-					kill_score = (int)(dead_wip->score * scoring_scale_by_damage);
+					// bombs don't scale with difficulty at the moment. If we change this we want to *scoring_get_scale_factor()
+					kill_score = dead_wip->score;
 
 					plr->stats.m_score += kill_score;  					
 					hud_gauge_popup_start(HUD_KILLS_GAUGE);
 
 #ifdef SCORING_DEBUG
 					char kill_score_text[1024] = "";
-					sprintf(kill_score_text, "SCORING : %s killed a ship worth %i points and gets %i pts for the kill", plr->callsign, dead_wip->score, kill_score);	
+					sprintf(kill_score_text, "SCORING : %s killed a bomb worth %i points and gets %i pts for the kill", plr->callsign, dead_wip->score, kill_score);	
 					if (MULTIPLAYER_MASTER) {
 						send_game_chat_packet(Net_player, kill_score_text, MULTI_MSG_ALL);
 					}
@@ -1003,100 +952,30 @@ int scoring_eval_kill_on_weapon(object *weapon_obj, object *other_obj) {
 					// multiplayer
 					if(net_plr != NULL){
 						multi_team_maybe_add_score(dead_wip->score , net_plr->p_info.team);
-
-						// award teammates % of score value for big ship kills
-						// not in dogfight tho
-						// and not if there is no assist threshold (as otherwise assists could get higher scores than kills)
-						/* Below is N/A. -Halleck
-						if (!(Netgame.type_flags & NG_TYPE_DOGFIGHT) && (Ship_info[dead_wp->ship_info_index].flags & (SIF_BIG_SHIP | SIF_HUGE_SHIP))) {
-							for (idx=0; idx<MAX_PLAYERS; idx++) {
-								if (MULTI_CONNECTED(Net_players[idx]) && (Net_players[idx].p_info.team == net_plr->p_info.team) && (&Net_players[idx] != net_plr)) {
-									assist_score = (int)(dead_wip->score * The_mission.ai_profile->assist_award_percentage_scale[Game_skill_level]);
-									Net_players[idx].m_player->stats.m_score += assist_score;
-
-#ifdef SCORING_DEBUG
-									// DEBUG CODE TO TEST NEW SCORING
-									char score_text[1024] = "";
-									sprintf(score_text, "SCORING : All team mates get %d pts for helping kill the capship", assist_score);
-									send_game_chat_packet(Net_player, score_text, MULTI_MSG_ALL);
-									HUD_printf(score_text);
-									mprintf((score_text));
-#endif
-								}
-							}
-						}
-						*/
-
-						// death message
-						if((Net_player != NULL) && (Net_player->flags & NETINFO_FLAG_AM_MASTER) && (net_plr != NULL) && (dead_plr != NULL) && (net_plr->m_player != NULL) && (dead_plr->m_player != NULL)){
-							char dead_text[1024] = "";
-
-							sprintf(dead_text, "%s gets the kill for %s", net_plr->m_player->callsign, dead_plr->m_player->callsign);							
-							send_game_chat_packet(Net_player, dead_text, MULTI_MSG_ALL, NULL, NULL, 2);
-							HUD_printf(dead_text);
-						}
 					}
 				}
 			}
-				
-			// increment his all-encompassing kills
-			/*Not really a kill. -Halleck
-			plr->stats.m_kills[si_index]++;
-			plr->stats.m_kill_count++;			
-			
-			// update everyone on this guy's kills if this is multiplayer
-			if(MULTIPLAYER_MASTER && (net_player_num != -1)){
-				// send appropriate stats
-				if(Netgame.type_flags & NG_TYPE_DOGFIGHT){
-					// evaluate dogfight kills
-					multi_df_eval_kill(&Net_players[net_player_num], weapon_obj);
-
-					// update stats
-					send_player_stats_block_packet(&Net_players[net_player_num], STATS_DOGFIGHT_KILLS);
-				} else {
-					send_player_stats_block_packet(&Net_players[net_player_num], STATS_MISSION_KILLS);
-				}				
-			}
-			*/
 		}
-	} else {
-		// set killer_sig for this ship to -1, indicating no one got the kill for it
-		killer_sig = -1;
-	}		
-		
-	// pass in the guy who got the credit for the kill (if any), so that he doesn't also
-	// get credit for an assist
-	/* TODO: ADD ASSIST CALC BACK IN. -Halleck
-	scoring_eval_assists(dead_wp,killer_sig, is_enemy_player);	
-	*/
+	}
 
 #ifdef SCORING_DEBUG
 
 	if (Game_mode & GM_MULTIPLAYER) {
-		char buf[256];
-		sprintf(Scoring_debug_text, "SCORING : %s killed.\nDamage by ship:\n\n", dead_wip->name);
+		sprintf(Scoring_debug_text, "SCORING : %s killed.\nKilled by player:\n", dead_wip->name);
 
-		// show damage done by player
-		for (int i=0; i<MAX_DAMAGE_SLOTS; i++) {
-			int net_player_num = multi_find_player_by_signature(dead_wp->damage_ship_id[i]);
-			if (net_player_num != -1) {
-				plr = Net_players[net_player_num].m_player;
-				sprintf(buf, "%s: %f", plr->callsign, dead_wp->damage_ship[i]);
+		int net_player_num = multi_find_player_by_signature(killer_sig);
+		if (net_player_num != -1) {
+			plr = Net_players[net_player_num].m_player;
+			char buf[256];
+			sprintf(buf, "    %s\n", plr->callsign);
 
-				if (dead_wp->damage_ship_id[i] == killer_sig ) {
-					strcat_s(buf, "  KILLER\n");
-				} else {
-					strcat_s(buf, "\n");
-				}
-
-				strcat_s(Scoring_debug_text, buf);	
-			}
+			strcat_s(Scoring_debug_text, buf);
 		}
 		mprintf ((Scoring_debug_text)); 
 	}
 #endif
 
-	return max_damage_index; 
+	return killer_sig; 
 }
 
 // kill_id is the object signature of the guy who got the credit for the kill (may be -1, if no one got it)
@@ -1345,102 +1224,6 @@ void scoring_eval_hit(object *hit_obj, object *other_obj,int from_blast)
 			}
 		}
 	}
-}
-
-// STATS damage, assists recording stuff
-void scoring_add_damage_to_weapon(object *weapon_obj,object *other_obj,float damage)
-{
-	int found_slot, signature;
-	int lowest_index,idx;
-	object *use_obj;
-	weapon *wp;
-
-	// multiplayer clients bail here
-	if(MULTIPLAYER_CLIENT){
-		return;
-	}
-
-	// if we have no other object, bail
-	if(other_obj == NULL){
-		return;
-	}	
-
-	// for player kill/assist evaluation, we have to know exactly how much damage really mattered. For example, if
-	// a ship had 1 hit point left, and the player hit it with a nuke, it doesn't matter that it did 10,000,000 
-	// points of damage, only that 1 point would count
-	float actual_damage = 0.0f;
-	
-	// other_obj might not always be the parent of other_obj (in the case of debug code for sure).  See
-	// if the other_obj has a parent, and if so, use the parent.  If no parent, see if other_obj is a ship
-	// and if so, use that ship.
-	if ( other_obj->parent != -1 ){		
-		use_obj = &Objects[other_obj->parent];
-		signature = use_obj->signature;
-	} else {
-		signature = other_obj->signature;
-		use_obj = other_obj;
-	}
-	
-	// don't count damage done to a ship by himself
-	if(use_obj == weapon_obj){
-		return;
-	}
-
-	// get a pointer to the ship and add the actual amount of damage done to it
-	// get the ship object, and determine the _actual_ amount of damage done
-	wp = &Weapons[weapon_obj->instance];
-	// see comments at beginning of function
-	if(weapon_obj->hull_strength < 0.0f){
-		actual_damage = damage + weapon_obj->hull_strength;
-	} else {
-		actual_damage = damage;
-	}
-	if(actual_damage < 0.0f){
-		actual_damage = 0.0f;
-	}
-	wp->total_damage_received += actual_damage;
-
-	// go through and clear out all old damagers
-	for(idx=0; idx<MAX_DAMAGE_SLOTS; idx++){
-		if((wp->damage_ship_id[idx] >= 0) && (ship_get_by_signature(wp->damage_ship_id[idx]) < 0)){
-			wp->damage_ship_id[idx] = -1;
-			wp->damage_ship[idx] = 0;
-		}
-	}
-
-	// only evaluate possible kill/assist numbers if the hitting object (use_obj) is a piloted ship (ie, ignore asteroids, etc)
-	// don't store damage a ship may do to himself
-	if((weapon_obj->type == OBJ_WEAPON) && (use_obj->type == OBJ_SHIP)){
-		found_slot = 0;
-		// try and find an open slot
-		for(idx=0;idx<MAX_DAMAGE_SLOTS;idx++){
-			// if this ship object doesn't exist anymore, use the slot
-			if((wp->damage_ship_id[idx] == -1) || (ship_get_by_signature(wp->damage_ship_id[idx]) < 0) || (wp->damage_ship_id[idx] == signature) ){
-				found_slot = 1;
-				break;
-			}
-		}
-
-		// if not found (implying all slots are taken), then find the slot with the lowest damage % and use that
-		if(!found_slot){
-			lowest_index = 0;
-			for(idx=0;idx<MAX_DAMAGE_SLOTS;idx++){
-				if(wp->damage_ship[idx] < wp->damage_ship[lowest_index]){
-				   lowest_index = idx;
-				}
-			}
-		} else {
-			lowest_index = idx;
-		}
-
-		// fill in the slot damage and damager-index
-		if(found_slot){
-			wp->damage_ship[lowest_index] += actual_damage;								
-		} else {
-			wp->damage_ship[lowest_index] = actual_damage;
-		}
-		wp->damage_ship_id[lowest_index] = signature;
-	}	
 }
 
 // get a scaling factor for adding/subtracting from mission score

--- a/code/stats/scoring.h
+++ b/code/stats/scoring.h
@@ -145,7 +145,6 @@ void scoring_do_accept( scoring_struct *score );
 void scoring_check_medal(scoring_struct *sc);
 
 void scoring_add_damage(object *ship_obj,object *other_obj,float damage);
-void scoring_add_damage_to_weapon(object *weapon_obj,object *other_obj,float damage);
 int scoring_eval_kill(object *ship_obj);
 int scoring_eval_kill_on_weapon(object *weapon_obj, object *other_obj);
 void scoring_eval_assists(ship *sp,int killer_sig, bool enemy_player = false);

--- a/code/weapon/weapon.h
+++ b/code/weapon/weapon.h
@@ -227,8 +227,7 @@ typedef struct weapon {
 	float launch_speed;			// the initial forward speed (can vary due to additive velocity or acceleration)
 								// currently only gets set when weapon_info->acceleration_time is used
 
-	bool collisionOccured;
-	mc_info collisionInfo; // The last collision of this weapon or NULL if it had none
+	mc_info* collisionInfo; // The last collision of this weapon or NULL if it had none
 	//Scoring stuff
 	float total_damage_received;        // total damage received (for scoring purposes)
 	float damage_ship[MAX_WEP_DAMAGE_SLOTS];    // damage applied from each player

--- a/code/weapon/weapon.h
+++ b/code/weapon/weapon.h
@@ -228,10 +228,6 @@ typedef struct weapon {
 								// currently only gets set when weapon_info->acceleration_time is used
 
 	mc_info* collisionInfo; // The last collision of this weapon or NULL if it had none
-	//Scoring stuff
-	float total_damage_received;        // total damage received (for scoring purposes)
-	float damage_ship[MAX_WEP_DAMAGE_SLOTS];    // damage applied from each player
-	int   damage_ship_id[MAX_WEP_DAMAGE_SLOTS]; // signature of the damager (corresponds to each entry in damage_ship)
 
 	int hud_in_flight_snd_sig;					// Signature of the sound played while the weapon is in flight
 } weapon;

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -3669,6 +3669,11 @@ void weapon_delete(object *obj)
 		wp->cmeasure_ignore_list = nullptr;
 	}
 
+	if (wp->collisionInfo != nullptr) {
+		delete wp->collisionInfo;
+		wp->collisionInfo = nullptr;
+	}
+
 	wp->objnum = -1;
 	Num_weapons--;
 	Assert(Num_weapons >= 0);
@@ -5453,7 +5458,7 @@ int weapon_create( vec3d * pos, matrix * porient, int weapon_type, int parent_ob
 	wp->alpha_current = -1.0f;
 	wp->alpha_backward = 0;
 
-	wp->collisionOccured = false;
+	wp->collisionInfo = nullptr;
 	wp->hud_in_flight_snd_sig = -1;
 
 	Num_weapons++;

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -5463,14 +5463,6 @@ int weapon_create( vec3d * pos, matrix * porient, int weapon_type, int parent_ob
 
 	Num_weapons++;
 
-	// reset the damage record fields (for scoring purposes)
-	wp->total_damage_received = 0.0f;
-	for(int i=0;i<MAX_WEP_DAMAGE_SLOTS;i++)
-	{
-		wp->damage_ship[i] = 0.0f;
-		wp->damage_ship_id[i] = -1;
-	}
-
 	if (Weapons_inherit_parent_collision_group) {
 		Objects[objnum].collision_group_id = Objects[parent_objnum].collision_group_id;
 	}
@@ -6206,14 +6198,6 @@ void weapon_hit( object * weapon_obj, object * other_obj, vec3d * hitpos, int qu
 		if (aip->hitter_objnum == objnum) {
 			aip->hitter_objnum = -1;
         }
-	}
-
-	// single player and multiplayer masters evaluate the scoring and kill stuff
-	if (!MULTIPLAYER_CLIENT) {
-		//If this is a bomb, set it up for scoring. -Halleck
-		if (wip->wi_flags & WIF_BOMB) {
-			scoring_eval_kill_on_weapon(weapon_obj, other_obj);
-		}
 	}
 
 	weapon_obj->flags |= OF_SHOULD_BE_DEAD;


### PR DESCRIPTION
These commits attempt to reduce the memory footprint of projectiles. The first changes `collisionInfo` from an `mc_info` object to a pointer to one. The second does some simplification of the code handling weapon/weapon collisions. The third simplifies weapon scoring and gets rid of scoring data from the `weapon` struct.