### PR TITLE
Avoid setting flags when using the share fire direction flag

### DIFF
--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -6471,10 +6471,10 @@ int subsys_set(int objnum, int ignore_subsys_info)
 			Warning (LOCATION, "\"fixed firingpoint\" flag used with turret which has less weapons defined for it than it has firingpoints\nsubsystem '%s' on ship type '%s'.\nsome of the firingpoints will be left unused\n", model_system->subobj_name, sinfo->name );
 		}
 
-        if ((ship_system->system_info->flags2 & MSS_FLAG2_SHARE_FIRE_DIRECTION) && !(ship_system->system_info->flags & MSS_FLAG_TURRET_SALVO))
+        if ((ship_system->system_info->flags2 & MSS_FLAG2_SHARE_FIRE_DIRECTION) && (!(ship_system->system_info->flags & MSS_FLAG_TURRET_SALVO) || !(ship_system->system_info->flags & MSS_FLAG_USE_MULTIPLE_GUNS)))
         {
-            Warning(LOCATION, "\"share fire direction\" flag used with turret which does not have the \"salvo mode\" flag set\nsubsystem '%s' on ship type '%s'.\nsetting the \"salvo mode\" flag\n", model_system->subobj_name, sinfo->name);
-            ship_system->system_info->flags |= MSS_FLAG_TURRET_SALVO;
+            Warning(LOCATION, "\"share fire direction\" flag used with turret which does not have the \"salvo mode\" or \"use multiple guns\" flag set\nsubsystem '%s' on ship type '%s'.\n\"share fire direction\" flag is ignored\n", model_system->subobj_name, sinfo->name);
+			ship_system->system_info->flags &= (~MSS_FLAG2_SHARE_FIRE_DIRECTION);
         }
 
 		for (k=0; k<ship_system->weapons.num_secondary_banks; k++) {


### PR DESCRIPTION
Originally, "share fire dir" forced the "salvo mode" flag. This
interfered with the "use multiple guns" flag. In order to avoid this, I
instead made "share fire dir" get unset if either "salvo mode" or "use multiple
guns" is not found, as those are the only two flags that, coupled with
"share fire dir", give the desired results.