### PR TITLE
Always use high resolution timers

### DIFF
--- a/code/cutscene/mveplayer.cpp
+++ b/code/cutscene/mveplayer.cpp
@@ -126,7 +126,7 @@ static void mve_timer_start(void)
 		timer_expire.tv_usec -= nsec * 1000000;
 	}
 #else
-	timer_expire = timer_get_microseconds();
+	timer_expire = static_cast<int>(timer_get_high_res_microseconds());
 	timer_expire += micro_frame_delay;
 #endif
 
@@ -181,7 +181,7 @@ end:
 #else
 	int tv, ts, ts2;
 
-	tv = timer_get_microseconds();
+	tv = static_cast<int>(timer_get_high_res_microseconds());
 
 	if (tv > timer_expire) {
 		goto end;

--- a/code/cutscene/mveplayer.cpp
+++ b/code/cutscene/mveplayer.cpp
@@ -31,11 +31,7 @@ static int mve_playing;
 // timer variables
 static int micro_frame_delay = 0;
 static int timer_started = 0;
-#ifdef SCP_UNIX
-static struct timeval timer_expire = { 0, 0 };
-#else
 static int timer_expire;
-#endif
 
 // audio variables
 #define MVE_AUDIO_BUFFERS 64  // total buffers to interact with stream
@@ -113,22 +109,8 @@ int mve_timer_create(ubyte *data)
 
 static void mve_timer_start(void)
 {
-#ifdef SCP_UNIX
-	int nsec = 0;
-
-	gettimeofday(&timer_expire, NULL);
-
-	timer_expire.tv_usec += micro_frame_delay;
-
-	if (timer_expire.tv_usec > 1000000) {
-		nsec = timer_expire.tv_usec / 1000000;
-		timer_expire.tv_sec += nsec;
-		timer_expire.tv_usec -= nsec * 1000000;
-	}
-#else
-	timer_expire = static_cast<int>(timer_get_high_res_microseconds());
+	timer_expire = static_cast<int>(timer_get_microseconds());
 	timer_expire += micro_frame_delay;
-#endif
 
 	timer_started = 1;
 }
@@ -139,49 +121,9 @@ static int mve_do_timer_wait(void)
 		return 0;
 	}
 
-#ifdef SCP_UNIX
-	int nsec = 0;
-	struct timespec ts, tsRem;
-	struct timeval tv;
-
-	gettimeofday(&tv, NULL);
-
-	if (tv.tv_sec > timer_expire.tv_sec) {
-		goto end;
-	}
-
-	if ( (tv.tv_sec == timer_expire.tv_sec) && (tv.tv_usec >= timer_expire.tv_usec) ) {
-		goto end;
-	}
-
-	ts.tv_sec = timer_expire.tv_sec - tv.tv_sec;
-	ts.tv_nsec = 1000 * (timer_expire.tv_usec - tv.tv_usec);
-
-	if (ts.tv_nsec < 0) {
-		ts.tv_nsec += 1000000000UL;
-		--ts.tv_sec;
-	}
-
-	if ( (nanosleep(&ts, &tsRem) == -1) && (errno == EINTR) ) {
-		// so we got an error that was a signal interupt, try to sleep again with remainder of time
-		if ( (nanosleep(&tsRem, NULL) == -1) && (errno == EINTR) ) {
-			mprintf(("MVE: Timer error! Aborting movie playback!\n"));
-			return 1;
-		}
-	}
-
-end:
-	timer_expire.tv_usec += micro_frame_delay;
-
-	if (timer_expire.tv_usec > 1000000) {
-		nsec = timer_expire.tv_usec / 1000000;
-		timer_expire.tv_sec += nsec;
-		timer_expire.tv_usec -= nsec * 1000000;
-	}
-#else
 	int tv, ts, ts2;
 
-	tv = static_cast<int>(timer_get_high_res_microseconds());
+	tv = static_cast<int>(timer_get_microseconds());
 
 	if (tv > timer_expire) {
 		goto end;
@@ -189,23 +131,17 @@ end:
 
 	ts = timer_expire - tv;
 	ts2 = ts/1000;
-	Sleep(ts2);
+	os_sleep(ts2);
 
 end:
 	timer_expire += micro_frame_delay;
-#endif
 
 	return 0;
 }
 
 static void mve_timer_stop()
 {
-#ifdef SCP_UNIX
-	timer_expire.tv_sec = 0;
-	timer_expire.tv_usec = 0;
-#else
 	timer_expire = 0;
-#endif
 	timer_started = 0;
 }
 

--- a/code/cutscene/oggplayer.cpp
+++ b/code/cutscene/oggplayer.cpp
@@ -55,11 +55,7 @@ static int buffer_handle = -1;
 
 static int timer_started = 0;
 static longlong base_time = -1;
-#ifdef SCP_UNIX
-static struct timeval timer_expire = { 0, 0 };
-#else
 static int timer_expire;
-#endif
 
 static int audio_inited = 0;
 static int audio_buffer_tail = 0;
@@ -129,22 +125,8 @@ static double OGG_get_time()
 
 static void OGG_timer_init()
 {
-#if SCP_UNIX
-	int nsec = 0;
-
-	gettimeofday(&timer_expire, NULL);
-
-	timer_expire.tv_usec += (int)((videobuf_time - OGG_get_time()) * 1000000.0);
-
-	if (timer_expire.tv_usec > 1000000) {
-		nsec = timer_expire.tv_usec / 1000000;
-		timer_expire.tv_sec += nsec;
-		timer_expire.tv_usec -= nsec * 1000000;
-	}
-#else
-	timer_expire = static_cast<int>(timer_get_high_res_microseconds());
+	timer_expire = static_cast<int>(timer_get_microseconds());
 	timer_expire += (int)((videobuf_time - OGG_get_time()) * 1000000.0);
-#endif
 
 	timer_started = 1;
 }
@@ -154,47 +136,9 @@ static void OGG_timer_do_wait()
 	if (!timer_started)
 		OGG_timer_init();
 
-#if SCP_UNIX
-	int nsec = 0;
-	struct timespec ts, tsRem;
-	struct timeval tv;
-
-	gettimeofday(&tv, NULL);
-
-	if (tv.tv_sec > timer_expire.tv_sec)
-		goto end;
-
-	if ( (tv.tv_sec == timer_expire.tv_sec) && (tv.tv_usec >= timer_expire.tv_usec) )
-		goto end;
-
-	ts.tv_sec = timer_expire.tv_sec - tv.tv_sec;
-	ts.tv_nsec = 1000 * (timer_expire.tv_usec - tv.tv_usec);
-
-	if (ts.tv_nsec < 0) {
-		ts.tv_nsec += 1000000000UL;
-		--ts.tv_sec;
-	}
-
-	if ( (nanosleep(&ts, &tsRem) == -1) && (errno == EINTR) ) {
-		// so we got an error that was a signal interupt, try to sleep again with remainder of time
-		if ( (nanosleep(&tsRem, NULL) == -1) && (errno == EINTR) ) {
-			mprintf(("MVE: Timer error! Aborting movie playback!\n"));
-			return;
-		}
-	}
-
-end:
-    timer_expire.tv_usec += (int)((videobuf_time - OGG_get_time()) * 1000000.0);
-
-    if (timer_expire.tv_usec > 1000000) {
-        nsec = timer_expire.tv_usec / 1000000;
-        timer_expire.tv_sec += nsec;
-        timer_expire.tv_usec -= nsec * 1000000;
-    }
-#else
 	int tv, ts, ts2;
 
-	tv = static_cast<int>(timer_get_high_res_microseconds());
+	tv = static_cast<int>(timer_get_microseconds());
 
 	if (tv > timer_expire)
 		goto end;
@@ -203,11 +147,10 @@ end:
 
 	ts2 = ts/1000;
 
-	Sleep(ts2);
+	os_sleep(ts2);
 
 end:
 	timer_expire += (int)((videobuf_time - OGG_get_time()) * 1000000.0);
-#endif
 }
 
 //

--- a/code/cutscene/oggplayer.cpp
+++ b/code/cutscene/oggplayer.cpp
@@ -142,7 +142,7 @@ static void OGG_timer_init()
 		timer_expire.tv_usec -= nsec * 1000000;
 	}
 #else
-	timer_expire = timer_get_microseconds();
+	timer_expire = static_cast<int>(timer_get_high_res_microseconds());
 	timer_expire += (int)((videobuf_time - OGG_get_time()) * 1000000.0);
 #endif
 
@@ -194,7 +194,7 @@ end:
 #else
 	int tv, ts, ts2;
 
-	tv = timer_get_microseconds();
+	tv = static_cast<int>(timer_get_high_res_microseconds());
 
 	if (tv > timer_expire)
 		goto end;

--- a/code/globalincs/profiling.cpp
+++ b/code/globalincs/profiling.cpp
@@ -158,7 +158,7 @@ void profile_begin(const char* name)
 		data.tid = get_tid();
 
 		data.enter = true;
-		data.time = timer_get_high_res_microseconds();
+		data.time = timer_get_microseconds();
 
 		json_profile_data.push_back(data);
 	}
@@ -225,7 +225,7 @@ void profile_end(const char* name)
 		data.tid = get_tid();
 
 		data.enter = false;
-		data.time = timer_get_high_res_microseconds();
+		data.time = timer_get_microseconds();
 
 		json_profile_data.push_back(data);
 	}

--- a/code/globalincs/profiling.cpp
+++ b/code/globalincs/profiling.cpp
@@ -106,7 +106,7 @@ static std::mutex json_mutex;
  */
 void profile_init()
 {
-	start_profile_time = timer_get_high_res_microseconds();
+	start_profile_time = timer_get_microseconds();
 
 	if (Cmdline_profile_write_file)
 	{
@@ -184,7 +184,7 @@ void profile_begin(const char* name)
 				// found the profile sample
 				samples[i].open_profiles++;
 				samples[i].profile_instances++;
-				samples[i].start_time = timer_get_high_res_microseconds();
+				samples[i].start_time = timer_get_microseconds();
 				Assert(samples[i].open_profiles == 1); // max 1 open at once
 				return;
 			}
@@ -197,7 +197,7 @@ void profile_begin(const char* name)
 		new_sample.open_profiles = 1;
 		new_sample.profile_instances = 1;
 		new_sample.accumulator = 0;
-		new_sample.start_time = timer_get_high_res_microseconds();
+		new_sample.start_time = timer_get_microseconds();
 		new_sample.children_sample_time = 0;
 		new_sample.num_children = 0;
 		new_sample.parent = parent;
@@ -246,7 +246,7 @@ void profile_end(const char* name)
 			if ( !strcmp(samples[i].name.c_str(), name) && samples[i].parent == child_of ) {
 				int inner = 0;
 				int parent = -1;
-				std::uint64_t end_time = timer_get_high_res_microseconds();
+				std::uint64_t end_time = timer_get_microseconds();
 				samples[i].open_profiles--;
 
 				// count all parents and find the immediate parent
@@ -297,7 +297,7 @@ void profile_end(const char* name)
 void profile_dump_output()
 {
 	if (Cmdline_frame_profile) {
-		end_profile_time = timer_get_high_res_microseconds();
+		end_profile_time = timer_get_microseconds();
 
 		if (Cmdline_profile_write_file)
 		{
@@ -351,7 +351,7 @@ void profile_dump_output()
 		}
 
 		samples.clear();
-		start_profile_time = timer_get_high_res_microseconds();
+		start_profile_time = timer_get_microseconds();
 	}
 }
 

--- a/code/io/timer.cpp
+++ b/code/io/timer.cpp
@@ -43,7 +43,7 @@ void timer_init()
 
 		atexit(timer_close);
 
-		high_res_begin = timer_get_high_res_microseconds();
+		high_res_begin = timer_get_microseconds();
 	}
 }
 
@@ -54,7 +54,7 @@ fix timer_get_fixed_seconds()
 		return 0;
 	}
 
-	auto time = timer_get_high_res_microseconds() - high_res_begin;
+	auto time = timer_get_microseconds() - high_res_begin;
 	time *= 65536;
 
 	return (fix)(time / MICROSECONDS_PER_SECOND);
@@ -77,7 +77,7 @@ int timer_get_seconds()
 		return 0;
 	}
 
-	return (int) (timer_get_high_res_microseconds() / MICROSECONDS_PER_SECOND);
+	return (int) (timer_get_microseconds() / MICROSECONDS_PER_SECOND);
 }
 
 int timer_get_milliseconds()
@@ -87,20 +87,10 @@ int timer_get_milliseconds()
 		return 0;
 	}
 
-	return (int) (timer_get_high_res_microseconds() / 1000);
+	return (int) (timer_get_microseconds() / 1000);
 }
 
-int timer_get_microseconds()
-{
-	if (!Timer_inited) {
-		Int3();					// Make sure you call timer_init before anything that uses timer functions!
-		return 0;
-	}
-
-	return (int) timer_get_high_res_microseconds();
-}
-
-std::uint64_t timer_get_high_res_microseconds()
+std::uint64_t timer_get_microseconds()
 {
 	if ( !Timer_inited ) {
 		Int3();

--- a/code/io/timer.cpp
+++ b/code/io/timer.cpp
@@ -116,7 +116,7 @@ std::uint64_t timer_get_high_res_microseconds()
 // 0 means invalid,
 // 1 means always return true
 // 2 and above actually check the time
-int timestamp_ticker = 2;
+std::uint64_t timestamp_ticker = 2;
 
 void timestamp_reset()
 {
@@ -129,9 +129,13 @@ void timestamp_reset()
 // something like 1 minute (6000).
 #define MAX_TIME (INT_MAX/2)
 
-void timestamp_inc(int frametime_ms)
+void timestamp_inc(fix frametime)
 {
-	timestamp_ticker += frametime_ms;
+	// Compute the microseconds, assumes that a fix uses the lower 16 bit for storing the fractional part
+	auto delta = (std::uint64_t)frametime;
+	delta = delta * (MICROSECONDS_PER_SECOND / 65536);
+
+	timestamp_ticker += delta;
 
 	if ( timestamp_ticker > MAX_TIME )	{
 		timestamp_ticker = 2;		// Roll!
@@ -143,15 +147,22 @@ void timestamp_inc(int frametime_ms)
 	}
 }
 
-int timestamp(int delta_ms )
-{
+static int timestamp_ms() {
+	if (timestamp_ticker <= 2) {
+		// These are special values, don't adjust them
+		return (int)timestamp_ticker;
+	}
+	return (int)(timestamp_ticker / 1000);
+}
+
+int timestamp(int delta_ms ) {
 	int t2;
 	if (delta_ms < 0 ) return 0;
 	if (delta_ms == 0 ) return 1;
-	t2 = timestamp_ticker + delta_ms;
+	t2 = timestamp_ms() + delta_ms;
 	if ( t2 > MAX_TIME )	{
 		// wrap!!!
-		t2 = delta_ms - (MAX_TIME-timestamp_ticker);
+		t2 = delta_ms - (MAX_TIME-timestamp_ms());
 	}
 	if (t2 < 2 ) t2 = 2;	// hack??
 	return t2;
@@ -159,13 +170,12 @@ int timestamp(int delta_ms )
 
 //	Returns milliseconds until timestamp will elapse.
 //	Negative value gives milliseconds ago that timestamp elapsed.
-int timestamp_until(int stamp)
-{
+int timestamp_until(int stamp) {
 	// JAS: FIX
 	// HACK!! This doesn't handle rollover!
 	// (Will it ever happen?)
 	
-	return stamp - timestamp_ticker;
+	return stamp - timestamp_ms();
 
 /*
 	uint	delta;
@@ -184,22 +194,37 @@ int timestamp_until(int stamp)
 
 // alternate timestamp functions.  The way these work is you call xtimestamp() to get the
 // current counter value, and then call
-int timestamp()
-{
-	return timestamp_ticker;
+int timestamp() {
+	return timestamp_ms();
 }
 
-int timestamp_has_time_elapsed(int stamp, int time)
-{
+int timestamp_has_time_elapsed(int stamp, int time) {
 	int t;
 
 	if (time <= 0)
 		return 1;
 
 	t = stamp + time;
-	if (t <= timestamp_ticker)
+	if (t <= timestamp_ms())
 		return 1;  // if we are unlucky enough to have it wrap on us, this will assume time has elapsed.
 
 	return 0;
+}
+bool timestamp_elapsed(int stamp) {
+	if (stamp == 0) {
+		return false;
+	}
+
+	return timestamp_ms() >= stamp;
+}
+bool timestamp_elapsed_safe(int a, int b) {
+	if (a == 0) {
+		return true;
+	}
+
+	return timestamp_ms() >= a || timestamp_ms() < (a - b + 100);
+}
+void timestamp_set_value(int value) {
+	timestamp_ticker = (std::uint64_t) value * 1000;
 }
 

--- a/code/io/timer.h
+++ b/code/io/timer.h
@@ -43,7 +43,7 @@ extern fix timer_get_fixed_seconds();		// Rolls about every 9 hours...
 extern fix timer_get_fixed_secondsX();		// Assume interrupts already disabled
 extern fix timer_get_approx_seconds();		// Returns time since program started... accurate to 1/120th of a second
 extern int timer_get_milliseconds();		//
-extern std::uint64_t timer_get_high_res_microseconds();
+extern std::uint64_t timer_get_microseconds();
 extern int timer_get_seconds();				// seconds since program started... not accurate, but good for long
 											//     runtimes with second-based timeouts
 

--- a/code/io/timer.h
+++ b/code/io/timer.h
@@ -43,7 +43,6 @@ extern fix timer_get_fixed_seconds();		// Rolls about every 9 hours...
 extern fix timer_get_fixed_secondsX();		// Assume interrupts already disabled
 extern fix timer_get_approx_seconds();		// Returns time since program started... accurate to 1/120th of a second
 extern int timer_get_milliseconds();		//
-extern int timer_get_microseconds();
 extern std::uint64_t timer_get_high_res_microseconds();
 extern int timer_get_seconds();				// seconds since program started... not accurate, but good for long
 											//     runtimes with second-based timeouts

--- a/code/io/timer.h
+++ b/code/io/timer.h
@@ -54,10 +54,6 @@ extern int timer_get_seconds();				// seconds since program started... not accur
 //=================================================================
 //=================================================================
 
-// NEVER USE THIS DIRECTLY!!! IF YOU REALLY NEED IT, THEN:
-// call timestamp(0) and use TIMESTAMP_FREQUENCY to scale it.
-extern int timestamp_ticker;	
-
 // You shouldn't use the output of timestamp() directly, 
 // but if you have to, use the TIMESTAMP_FREQUENCY to 
 // scale it correctly.
@@ -68,7 +64,16 @@ extern int timestamp_ticker;
 extern void timestamp_reset();
 
 // Call this once every frame with the frametime.
-extern void timestamp_inc(int frametime_ms);
+extern void timestamp_inc(fix frametime);
+
+/**
+ * @brief Sets the value of the internal timestamp ticker
+ *
+ * @warning This function may only be used in special cases! Only use if you are absolutely certain that you need it.
+ *
+ * @param value The new value of the ticker
+ */
+void timestamp_set_value(int value);
 
 // To do timing, call this with the interval you
 // want to check.  Then, pass this to timestamp_elapsed
@@ -90,7 +95,9 @@ int timestamp();
 
 // gets a timestamp randomly between a and b milliseconds in
 // the future.
-#define timestamp_rand(a,b) timestamp((myrand()%((b)-(a)+1))+(a))
+inline int timestamp_rand(int a, int b) {
+	return timestamp(myrand() % (b - a + 1) + a);
+}
 
 // Example that makes a ship fire in 1/2 second
 
@@ -100,9 +107,11 @@ int timestamp();
 // if (fire && timestamp_elapsed(ship->next_fire))
 //   fire_laser();
 
-#define timestamp_elapsed( stamp ) ( (stamp!=0) ? (timestamp_ticker >= (stamp) ? 1 : 0) : 0 )
+bool timestamp_elapsed( int stamp );
 
-#define timestamp_valid(stamp) ((stamp==0) ? 0 : 1 )
+inline bool timestamp_valid(int stamp) {
+	return stamp != 0;
+}
 
 //	Returns millliseconds until timestamp will elapse.
 int timestamp_until(int stamp);
@@ -112,7 +121,7 @@ int timestamp_until(int stamp);
 int timestamp_has_time_elapsed(int stamp, int time);
 
 // safer version of timestamp
-#define timestamp_elapsed_safe(_a, _b)		( (_a != 0) ? (((timestamp_ticker >= (_a)) || (timestamp_ticker < (_a - (_b + 100)))) ? 1 : 0) : 1 )
+bool timestamp_elapsed_safe(int a, int b);
 
 
 #endif

--- a/code/menuui/credits.cpp
+++ b/code/menuui/credits.cpp
@@ -816,7 +816,7 @@ void credits_do_frame(float frametime)
 
 	Credits_frametime = temp_time - Credits_last_time;
 	Credits_last_time = temp_time;
-	timestamp_inc(Credits_frametime);
+	timestamp_inc(i2f(Credits_frametime) / TIMESTAMP_FREQUENCY);
 
 	float fl_frametime = i2fl(Credits_frametime) / 1000.f;
 	if (keyd_pressed[KEY_LSHIFT]) {

--- a/code/network/multi_obj.cpp
+++ b/code/network/multi_obj.cpp
@@ -1630,7 +1630,7 @@ void multi_oo_server_process()
 	for(idx=0;idx<MAX_PLAYERS;idx++){
 		if(MULTI_CONNECTED(Net_players[idx]) && !MULTI_SERVER(Net_players[idx])){
 			// if his timestamp is -1 or has expired, reset it and zero his rate byte count
-			if((Net_players[idx].s_info.rate_stamp == -1) || timestamp_elapsed_safe(Net_players[idx].s_info.rate_stamp, OO_MAX_TIMESTAMP) || (abs(timestamp_ticker - Net_players[idx].s_info.rate_stamp) >= (int)(1000.0f / (float)OO_gran)) ){
+			if((Net_players[idx].s_info.rate_stamp == -1) || timestamp_elapsed_safe(Net_players[idx].s_info.rate_stamp, OO_MAX_TIMESTAMP) || (abs(timestamp() - Net_players[idx].s_info.rate_stamp) >= (int)(1000.0f / (float)OO_gran)) ){
 				Net_players[idx].s_info.rate_stamp = timestamp( (int)(1000.0f / (float)OO_gran) );
 				Net_players[idx].s_info.rate_bytes = 0;
 			}

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -4581,8 +4581,7 @@ void game_stop_time()
 		#endif
 
 		// Stop the timer_tick stuff...
-		// Normally, you should never access 'timestamp_ticker', consider this a low-level routine
-		saved_timestamp_ticker = timestamp_ticker;
+		saved_timestamp_ticker = timestamp();
 	}
 	timer_paused++;
 
@@ -4615,7 +4614,7 @@ void game_start_time()
 		// Restore the timer_tick stuff...
 		// Normally, you should never access 'timestamp_ticker', consider this a low-level routine
 		Assert( saved_timestamp_ticker > -1 );		// Called out of order, get JAS
-		timestamp_ticker = saved_timestamp_ticker;
+		timestamp_set_value(saved_timestamp_ticker);
 		saved_timestamp_ticker = -1;
 	}
 
@@ -4751,9 +4750,8 @@ void game_set_frametime(int state)
 	Last_frame_timestamp = timestamp();
 
 	flFrametime = f2fl(Frametime);
-	
-	auto frametime_ms = f2i(fixmul(Frametime, F1_0 * TIMESTAMP_FREQUENCY));
-	timestamp_inc(frametime_ms);
+
+	timestamp_inc(Frametime);
 
 	// wrap overall frametime if needed
 	if ( FrametimeOverall > (INT_MAX - F1_0) )


### PR DESCRIPTION
Currently the timer system uses `SDL_GetTick()` for keeping track of frametimes but that uses millisecond precision. `timer_get_fixed_seconds` converts that into a `fix` (aka 1/65536 of a second) which means that ~6 bits of information are completely useless. These changes always use the high precision timer which allows to get timer values with microsecond precision and that allows to use the remaining 6 bits of information in the `fix`.

I wanted to fix the timer issues at high framerates with this but it doesn't seem like that has changed with these changes. I decided to submit this anyway because it should improve the frametime computation a bit. 