### PR TITLE
Fix directory creation for nested mod folders.

### DIFF
--- a/code/cfile/cfilesystem.cpp
+++ b/code/cfile/cfilesystem.cpp
@@ -359,6 +359,16 @@ void cf_build_pack_list( cf_root *root )
 	vm_free(temp_roots_sort);
 }
 
+static char normalize_directory_separator(char in)
+{
+	if (in == '/')
+	{
+		return DIR_SEPARATOR_CHAR;
+	}
+
+	return in;
+}
+
 static void cf_add_mod_roots(const char* rootDirectory)
 {
 	if (Cmdline_mod)
@@ -379,6 +389,9 @@ static void cf_add_mod_roots(const char* rootDirectory)
 			if (rootPath.size() + 1 >= CF_MAX_PATHNAME_LENGTH) {
 				Error(LOCATION, "The length of mod directory path '%s' exceeds the maximum of %d!\n", rootPath.c_str(), CF_MAX_PATHNAME_LENGTH);
 			}
+
+			// normalize the path to the native path format
+			std::transform(rootPath.begin(), rootPath.end(), rootPath.begin(), normalize_directory_separator);
 
 			cf_root* root = cf_create_root();
 


### PR DESCRIPTION
The launcher passes the mod folders as relative paths using `/` as the
directory separator. That path is copied into the `cf_root` path and when
`cf_create_directory` tries to create the directory, `mkdir_recursive` can't
handle the `/` in the path and tries to create two path elements at once
which is not supported by `mkdir`.

These changes fix that by converting mod paths to the native format
(from the / format, so it's a No-op on Unix) before using it in
`cf_create_root()`.