### PR TITLE
Fix Assertion when running in standalone mode

### DIFF
--- a/code/bmpman/bmpman.cpp
+++ b/code/bmpman/bmpman.cpp
@@ -1399,8 +1399,6 @@ static int bm_load_image_data(const char *filename, int handle, int bitmapnum, i
 	bitmap_entry *be = &bm_bitmaps[bitmapnum];
 	bitmap *bmp = &be->bm;
 
-	Assert(!Is_standalone);
-
 	if (bmp->true_bpp > bpp)
 		true_bpp = bmp->true_bpp;
 	else


### PR DESCRIPTION
The Assertion which was triggered was carried over from the OpenGL code
but the stub code was using pretty much the same code so removing the
Assertion seems like the correct way to solve this.

Fix for issue #726.