### PR TITLE
Remove duplicate fclose() call (fix Coverity defect 1360951)

### DIFF
--- a/code/inetfile/cftp.cpp
+++ b/code/inetfile/cftp.cpp
@@ -190,8 +190,6 @@ CFtpGet::~CFtpGet()
 		SDL_WaitThread(thread_id, NULL);
     
 	fclose(LOCALFILE);
-    
-	fclose(LOCALFILE);
 
 	if(m_ListenSock != INVALID_SOCKET)
 	{


### PR DESCRIPTION
It looks like this was added to trunk (a0f31e6), synced with antipodes (4952b70), and then one of the antipodes merges (7e77b5a) wound up combining both additions.