### PR TITLE
Ap cleanup/controls

### DIFF
--- a/code/controlconfig/controlsconfig.cpp
+++ b/code/controlconfig/controlsconfig.cpp
@@ -436,17 +436,15 @@ int control_config_detect_axis()
 	}
 
 	if ( (axis == -1) && Use_mouse_to_fly ) {
-		mouse_get_delta( &dx, &dy, &dz );
+		mouse_get_delta( &dx, &dy);
 
 		if ( (dx > fudge) || (dx < -fudge) ) {
 			axis = 0;
 		} else if ( (dy > fudge) || (dy < -fudge) ) {
 			axis = 1;
-		} else if ( (dz > fudge) || (dz < -fudge) ) {
-			axis = 2;
 		}
 	}
-		
+
 	return axis;
 }
 

--- a/code/controlconfig/controlsconfig.cpp
+++ b/code/controlconfig/controlsconfig.cpp
@@ -519,8 +519,9 @@ static void control_config_do_search();
  * @brief Handles a conflict.
  *
  * @details Actually does nothing at the moment...
+ * @note Commented out for the moment to remove gcc compiler warning about dead code. Might be used later once z64's Controls Code Overhaul (TM) gets done
  */
-static int control_config_handle_conflict();
+//static int control_config_handle_conflict();
 
 /**
  * @brief Sets up the control_config list.
@@ -2072,9 +2073,12 @@ static void control_config_do_search() {
 	gamesnd_play_iface(SND_USER_SELECT);
 }
 
+/**
+ * commented out until this actually does something
 static int control_config_handle_conflict() {
 	return 0;
 }
+*/
 
 void control_config_init() {
 	int i;

--- a/code/controlconfig/controlsconfig.cpp
+++ b/code/controlconfig/controlsconfig.cpp
@@ -11,7 +11,6 @@
 
 #include "controlconfig/controlsconfig.h"
 #include "debugconsole/console.h"
-#include "freespace2/freespace.h"
 #include "gamehelp/contexthelp.h"
 #include "gamesequence/gamesequence.h"
 #include "gamesnd/gamesnd.h"
@@ -30,6 +29,7 @@
 #include "ui/ui.h"
 #include "ui/uidefs.h"
 
+#include <freespace.h>
 
 #ifndef NDEBUG
 #include "hud/hud.h"

--- a/code/controlconfig/controlsconfig.cpp
+++ b/code/controlconfig/controlsconfig.cpp
@@ -1,18 +1,17 @@
 /*
  * Copyright (C) Volition, Inc. 1999.  All rights reserved.
  *
- * All source code herein is the property of Volition, Inc. You may not sell 
- * or otherwise commercially exploit the source or things you created based on the 
+ * All source code herein is the property of Volition, Inc. You may not sell
+ * or otherwise commercially exploit the source or things you created based on the
  * source.
  *
-*/ 
-
+ */
 
 
 
 #include "controlconfig/controlsconfig.h"
 #include "debugconsole/console.h"
-#include "freespace.h"
+#include "freespace2/freespace.h"
 #include "gamehelp/contexthelp.h"
 #include "gamesequence/gamesequence.h"
 #include "gamesnd/gamesnd.h"
@@ -38,218 +37,231 @@
 
 
 
-#define NUM_SYSTEM_KEYS			14
-#define NUM_BUTTONS				19
-#define NUM_TABS				4
+#define NUM_SYSTEM_KEYS     14  // System_keys.size()
+#define NUM_BUTTONS         19  // Number of UI buttons on the controls config menu
+#define NUM_TABS             4  // Number of control catagory tabs
 
 // coordinate indicies
-#define CONTROL_X_COORD 0
-#define CONTROL_Y_COORD 1
-#define CONTROL_W_COORD 2
-#define CONTROL_H_COORD 3
+#define CONTROL_X_COORD 0   // X pixel coordinate (Leftmost)
+#define CONTROL_Y_COORD 1   // Y pixel coordinate (Topmost)
+#define CONTROL_W_COORD 2   // Width, in pixels
+#define CONTROL_H_COORD 3   // Height, in pixels
 
+// Filenames of the conflict box background
 char* Conflict_background_bitmap_fname[GR_NUM_RESOLUTIONS] = {
-	"ControlConfig",		// GR_640
-	"2_ControlConfig"		// GR_1024
+	"ControlConfig",        // GR_640
+	"2_ControlConfig"       // GR_1024
 };
 
+// Filenames of the conflict box background's mask
 char* Conflict_background_bitmap_mask_fname[GR_NUM_RESOLUTIONS] = {
-	"ControlConfig-m",		// GR_640
-	"2_ControlConfig-m"		// GR_1024
+	"ControlConfig-m",      // GR_640
+	"2_ControlConfig-m"     // GR_1024
 };
 
-// control list area
+// Control list draw area
 int Control_list_coords[GR_NUM_RESOLUTIONS][4] = {
 	{
-		32, 58, 198, 259	// GR_640
+		32, 58, 198, 259    // GR_640
 	},
 	{
-		32, 94, 904, 424	// GR_1024
+		32, 94, 904, 424    // GR_1024
 	}
 };
 
-// width of the control name section of the list
+// Width of the control name column
 int Control_list_ctrl_w[GR_NUM_RESOLUTIONS] = {
-	350,	// GR_640
-	600		// GR_1024
+	350,    // GR_640
+	600     // GR_1024
 };
 
-// x start position of the binding area section of the list
+// X start position of the binding area column
 int Control_list_key_x[GR_NUM_RESOLUTIONS] = {
-	397,	// GR_640
-	712		// GR_1024
+	397,    // GR_640
+	712     // GR_1024
 };
 
-// width of the binding area section of the list
+// Width of the binding area column
 int Control_list_key_w[GR_NUM_RESOLUTIONS] = {
-	198,	// GR_640
-	230		// GR_1024
+	198,    // GR_640
+	230     // GR_1024
 };
 
-// display the "more..." text under the control list
+// Coords of the "more..." label at the bottom of the visible list
 int Control_more_coords[GR_NUM_RESOLUTIONS][2] = {
 	{
-		320, 326			// GR_640
+		320, 326    // GR_640
 	},
 	{
-		500, 542			// GR_1024
+		500, 542    // GR_1024
 	}
 };
 
-// area to display "conflicts with..." text
+// Draw area of the "conflicts with..." label
 int Conflict_wnd_coords[GR_NUM_RESOLUTIONS][4] = {
 	{
-		32, 313, 250, 32	// GR_640
+		32, 313, 250, 32    // GR_640
 	},
 	{
-		48, 508, 354, 46	// GR_1024
+		48, 508, 354, 46    // GR_1024
 	}
 };
 
-// conflict warning anim coords
+// Coords of the conflict warning anim
 int Conflict_warning_coords[GR_NUM_RESOLUTIONS][2] = {
 	{
-		-1, 420			// GR_640
+		-1, 420     // GR_640
 	},
 	{
-		-1, 669			// GR_1024
+		-1, 669     // GR_1024
 	}
 };
 
-// for flashing the conflict text
-#define CONFLICT_FLASH_TIME	250
-int Conflict_stamp = -1;
-int Conflict_bright = 0;
+// Conflict text flasher registers
+#define CONFLICT_FLASH_TIME 250     // Period of the flash, in ms
+int Conflict_stamp  = -1;           // Timestamp of when to toggle the text brightness
+int Conflict_bright =  0;           // Bool. false is normal, true is bright
 
-#define LIST_BUTTONS_MAX	42
-#define JOY_AXIS			0x80000
+#define LIST_BUTTONS_MAX         42     // Maximum number of button hotspots for the config list
+#define JOY_AXIS            0x80000     // Mask applied to axis number to distiguish it from keys, buttons
 
-static int Num_cc_lines;
-static struct {
-	const char *label;
-	int cc_index;  // index into Control_config of item
-	int y;  // Y coordinate of line
-	int kx, kw, jx, jw;  // x start and width of keyboard and joystick bound text
+static int Num_cc_lines;    // Number of lines on the current selected tab. Is refereshed each time a tab is loaded
+
+static struct
+{
+	const char *label;  // Human readable label of the control
+	int cc_index;       // index into Control_config of item
+	int y;              // Y coordinate of line
+	int kx, kw;         // x start and width of keyboard bound text
+	int jx, jw;         // x start and width of joystick bound text
 } Cc_lines[CCFG_MAX];
 
 // struct to hold backup config_item elements so we can undo them
-struct config_item_undo {
-	int size;
-	int *index;  // array (size) of Control_config indices of replaced elements
-	config_item *list;  // array (size) of original elements
-	int reset_to_preset; // if >=0, then we ignore the above list and simply reset to the given preset instead
-	config_item_undo *next;
+struct config_item_undo
+{
+	int size;               // number of replaced mappings in the undo block
+	int reset_to_preset;    // if >=0, then we ignore the ref'd list and simply reset to the given preset instead
+	int *index;             // array[size] of Control_config indices of replaced elements
+	config_item *list;      // array of original elements
+	config_item_undo *next; // ptr to the next item in the list, or NULL if the tail
 };
 
+// Backup of the current control mappings, in case the user decides to cancel w/o saving any changes
 config_item Control_config_backup[CCFG_MAX];
 
+// Joystick axis mapping (hardcoded to be same as defaults at init)
 int Axis_map_to[] = { JOY_X_AXIS, JOY_Y_AXIS, JOY_RX_AXIS, -1, -1 };
+
+// Joystick default axis mapping
 int Axis_map_to_defaults[] = { JOY_X_AXIS, JOY_Y_AXIS, JOY_RX_AXIS, -1, -1 };
 
-// all this stuff is localized/externalized
-#define NUM_AXIS_TEXT			6
-#define NUM_MOUSE_TEXT			5
-#define NUM_MOUSE_AXIS_TEXT		2
-#define NUM_INVERT_TEXT			2	
+// all this stuff should really use relevent headers...
+#define NUM_AXIS_TEXT           6   // Joy_axis_text.size()
+#define NUM_MOUSE_TEXT          5   // Mouse_button_text.size()
+#define NUM_MOUSE_AXIS_TEXT     2   // Mouse_axis_text.size()
+#define NUM_INVERT_TEXT         2   // Invert_text.size()
 char *Joy_axis_action_text[NUM_JOY_AXIS_ACTIONS];
 char *Joy_axis_text[NUM_AXIS_TEXT];
 char *Mouse_button_text[NUM_MOUSE_TEXT];
 char *Mouse_axis_text[NUM_MOUSE_AXIS_TEXT];
 char *Invert_text[NUM_INVERT_TEXT];
 
+// Array of keys considered as "system keys," which are (currently) not user configurable and hardcoded to specific functions
 ubyte System_keys[NUM_SYSTEM_KEYS] = {
 	KEY_ESC, KEY_F1, KEY_F2, KEY_F3, KEY_F4, KEY_F5, KEY_F6, KEY_F7, KEY_F8, KEY_F9, KEY_F10,
 	KEY_F11, KEY_F12, KEY_PRINT_SCRN
 };
 
-int Control_check_count = 0;
+int Control_check_count = 0;    // Debugging variable used to check how many controls have been checked within a frame
 
-static int Tab;  // which tab we are currently in
-static int Binding_mode = 0;  // are we waiting for a key to bind it?
-static int Bind_time = 0;
-static int Search_mode = 0;  // are we waiting for a key to bind it?
-static int Last_key = -1;
-static int Selected_line = 0;  // line that is currently selected for binding
+static int Tab;                 // which tab we are currently in
+static int Binding_mode = 0;    // are we waiting for a key to bind it?
+static int Bind_time = 0;       // Timestamp of when we started a bind operation.
+static int Search_mode = 0;     // are we waiting for a key to bind it?
+static int Last_key = -1;       // Keymask of the last pressed key's modifiers, or -1
+static int Selected_line = 0;   // line that is currently selected for binding
 static int Selected_item = -1;  // -1 = none, 0 = key, 1 = button
-static int Scroll_offset;
-static int Axis_override = -1;
-static int Background_bitmap;
-static int Conflicts_tabs[NUM_TABS];
-static UI_BUTTON List_buttons[LIST_BUTTONS_MAX];  // buttons for each line of text in list
+static int Scroll_offset;       // Line number of the topmost visible line. Is changed on each scroll operation
+static int Axis_override = -1;  // Axis index to bind to a control (used in do_frame() and do_bind())
+static int Background_bitmap;   // BMPMAN index of the menu's current background.
+
+static int Conflicts_tabs[NUM_TABS];                // Which tabs have assignment conflicts
+static UI_BUTTON List_buttons[LIST_BUTTONS_MAX];    // buttons for each line of text in list
 static UI_WINDOW Ui_window;
-static unsigned int Defaults_cycle_pos; // the controls preset that was last selected
+static unsigned int Defaults_cycle_pos;             // the controls preset that was last selected
 
 int Control_config_overlay_id;
 
-static struct {
+static struct
+{
 	int key;  // index of other control in conflict with this one
 	int joy;  // index of other control in conflict with this one
 } Conflicts[CCFG_MAX];
 
 int Conflicts_axes[NUM_JOY_AXIS_ACTIONS];
 
-#define TARGET_TAB				0
-#define SHIP_TAB				1
-#define WEAPON_TAB				2
-#define COMPUTER_TAB			3
-#define SCROLL_UP_BUTTON		4
-#define SCROLL_DOWN_BUTTON		5
-#define ALT_TOGGLE				6
-#define SHIFT_TOGGLE			7
-#define INVERT_AXIS				8
-#define CANCEL_BUTTON			9
-#define UNDO_BUTTON				10
-#define RESET_BUTTON			11
-#define SEARCH_MODE				12
-#define BIND_BUTTON				13
-#define HELP_BUTTON				14
-#define ACCEPT_BUTTON			15
-#define CLEAR_OTHER_BUTTON		16
-#define CLEAR_ALL_BUTTON		17
-#define CLEAR_BUTTON			18
+#define TARGET_TAB               0
+#define SHIP_TAB                 1
+#define WEAPON_TAB               2
+#define COMPUTER_TAB             3
+#define SCROLL_UP_BUTTON         4
+#define SCROLL_DOWN_BUTTON       5
+#define ALT_TOGGLE               6
+#define SHIFT_TOGGLE             7
+#define INVERT_AXIS              8
+#define CANCEL_BUTTON            9
+#define UNDO_BUTTON             10
+#define RESET_BUTTON            11
+#define SEARCH_MODE             12
+#define BIND_BUTTON             13
+#define HELP_BUTTON             14
+#define ACCEPT_BUTTON           15
+#define CLEAR_OTHER_BUTTON      16
+#define CLEAR_ALL_BUTTON        17
+#define CLEAR_BUTTON            18
 
 ui_button_info CC_Buttons[GR_NUM_RESOLUTIONS][NUM_BUTTONS] = {
 	{ // GR_640
-		ui_button_info("CCB_00",	32,	348,	17,	384,	0),	// target tab
-		ui_button_info("CCB_01",	101,	348,	103,	384,	1),	// ship tab
-		ui_button_info("CCB_02",	173,	352,	154,	384,	2),	// weapon tab
-		ui_button_info("CCB_03",	242,	347,	244,	384,	3),	// computer/misc tab
-		ui_button_info("CCB_04",	614,	73,	-1,	-1,	4),	// scroll up
-		ui_button_info("CCB_05",	614,	296,	-1,	-1,	5),	// scroll down
-		ui_button_info("CCB_06",	17,	452,	12,	440,	6),	// alt toggle
-		ui_button_info("CCB_07",	56,	452,	50,	440,	7),	// shift toggle
-		ui_button_info("CCB_09",	162,	452,	155,	440,	9),	// invert
-		ui_button_info("CCB_10",	404,	1,		397,	45,	10),	// cancel
-		ui_button_info("CCB_11",	582,	347,	586,	386,	11),	// undo
-		ui_button_info("CCB_12",	576,	1,		578,	45,	12),	// default
-		ui_button_info("CCB_13",	457,	4,		453,	45,	13),	// search
-		ui_button_info("CCB_14",	516,	4,		519,	45,	14),	// bind
-		ui_button_info("CCB_15",	540,	428,	500,	440,	15),	// help
-		ui_button_info("CCB_16",	574,	432,	571,	412,	16),	// accept
-		ui_button_info("CCB_18",	420,	346,	417,	386,	18),	// clear other 
-		ui_button_info("CCB_19",	476,	346,	474,	386,	19),	// clear all
-		ui_button_info("CCB_20",	524,	346,	529,	386,	20),	// clear button
+		ui_button_info("CCB_00",  32, 348, 17,  384,  0),   // target tab
+		ui_button_info("CCB_01", 101, 348, 103, 384,  1),   // ship tab
+		ui_button_info("CCB_02", 173, 352, 154, 384,  2),   // weapon tab
+		ui_button_info("CCB_03", 242, 347, 244, 384,  3),   // computer/misc tab
+		ui_button_info("CCB_04", 614,  73,  -1,  -1,  4),   // scroll up
+		ui_button_info("CCB_05", 614, 296,  -1,  -1,  5),   // scroll down
+		ui_button_info("CCB_06",  17, 452,  12, 440,  6),   // alt toggle
+		ui_button_info("CCB_07",  56, 452,  50, 440,  7),   // shift toggle
+		ui_button_info("CCB_09", 162, 452, 155, 440,  9),   // invert
+		ui_button_info("CCB_10", 404,   1, 397,  45, 10),   // cancel
+		ui_button_info("CCB_11", 582, 347, 586, 386, 11),   // undo
+		ui_button_info("CCB_12", 576,   1, 578,  45, 12),   // default
+		ui_button_info("CCB_13", 457,   4, 453,  45, 13),   // search
+		ui_button_info("CCB_14", 516,   4, 519,  45, 14),   // bind
+		ui_button_info("CCB_15", 540, 428, 500, 440, 15),   // help
+		ui_button_info("CCB_16", 574, 432, 571, 412, 16),   // accept
+		ui_button_info("CCB_18", 420, 346, 417, 386, 18),   // clear other 
+		ui_button_info("CCB_19", 476, 346, 474, 386, 19),   // clear all
+		ui_button_info("CCB_20", 524, 346, 529, 386, 20),   // clear button
 	},
 	{ // GR_1024
-		ui_button_info("2_CCB_00",	51,	557,	27,	615,	0),	// target tab
-		ui_button_info("2_CCB_01",	162,	557,	166,	615,	1),	// ship tab
-		ui_button_info("2_CCB_02",	277,	563,	246,	615,	2),	// weapon tab
-		ui_button_info("2_CCB_03",	388,	555,	391,	615,	3),	// computer/misc tab
-		ui_button_info("2_CCB_04",	982,	117,	-1,	-1,	4),	// scroll up
-		ui_button_info("2_CCB_05",	982,	474,	-1,	-1,	5),	// scroll down
-		ui_button_info("2_CCB_06",	28,	723,	24,	704,	6),	// alt toggle
-		ui_button_info("2_CCB_07",	89,	723,	80,	704,	7),	// shift toggle
-		ui_button_info("2_CCB_09",	260,	723,	249,	704,	9),	// invert
-		ui_button_info("2_CCB_10",	646,	2,		635,	71,	10),	// cancel
-		ui_button_info("2_CCB_11",	932,	555,	938,	619,	11),	// undo
-		ui_button_info("2_CCB_12",	921,	1,		923,	71,	12),	// default
-		ui_button_info("2_CCB_13",	732,	6,		726,	71,	13),	// search
-		ui_button_info("2_CCB_14",	825,	6,		831,	71,	14),	// bind
-		ui_button_info("2_CCB_15",	864,	685,	800,	704,	15),	// help
-		ui_button_info("2_CCB_16",	919,	692,	914,	660,	16),	// accept
-		ui_button_info("2_CCB_18",	672,	553,	668,	619,	18),	// clear other 
-		ui_button_info("2_CCB_19",	761,	553,	749,	619,	19),	// clear all
-		ui_button_info("2_CCB_20",	838,	553,	846,	619,	20),	// clear button
+		ui_button_info("2_CCB_00",  51, 557,  27, 615,  0), // target tab
+		ui_button_info("2_CCB_01", 162, 557, 166, 615,  1), // ship tab
+		ui_button_info("2_CCB_02", 277, 563, 246, 615,  2), // weapon tab
+		ui_button_info("2_CCB_03", 388, 555, 391, 615,  3), // computer/misc tab
+		ui_button_info("2_CCB_04", 982, 117,  -1,  -1,  4), // scroll up
+		ui_button_info("2_CCB_05", 982, 474,  -1,  -1,  5), // scroll down
+		ui_button_info("2_CCB_06",  28, 723,  24, 704,  6), // alt toggle
+		ui_button_info("2_CCB_07",  89, 723,  80, 704,  7), // shift toggle
+		ui_button_info("2_CCB_09", 260, 723, 249, 704,  9), // invert
+		ui_button_info("2_CCB_10", 646,   2, 635,  71, 10), // cancel
+		ui_button_info("2_CCB_11", 932, 555, 938, 619, 11), // undo
+		ui_button_info("2_CCB_12", 921,   1, 923,  71, 12), // default
+		ui_button_info("2_CCB_13", 732,   6, 726,  71, 13), // search
+		ui_button_info("2_CCB_14", 825,   6, 831,  71, 14), // bind
+		ui_button_info("2_CCB_15", 864, 685, 800, 704, 15), // help
+		ui_button_info("2_CCB_16", 919, 692, 914, 660, 16), // accept
+		ui_button_info("2_CCB_18", 672, 553, 668, 619, 18), // clear other 
+		ui_button_info("2_CCB_19", 761, 553, 749, 619, 19), // clear all
+		ui_button_info("2_CCB_20", 838, 553, 846, 619, 20), // clear button
 	}
 };
 
@@ -257,48 +269,48 @@ ui_button_info CC_Buttons[GR_NUM_RESOLUTIONS][NUM_BUTTONS] = {
 #define CC_NUM_TEXT		20
 UI_XSTR CC_text[GR_NUM_RESOLUTIONS][CC_NUM_TEXT] = {
 	{ // GR_640
-		{ "Targeting",		1340,		17,	384,	UI_XSTR_COLOR_GREEN, -1, &CC_Buttons[0][TARGET_TAB].button },
-		{ "Ship",			1341,		103,	384,	UI_XSTR_COLOR_GREEN, -1, &CC_Buttons[0][SHIP_TAB].button },
-		{ "Weapons",		1065,		154,	384,	UI_XSTR_COLOR_GREEN, -1, &CC_Buttons[0][WEAPON_TAB].button },
-		{ "Misc",			1411,		244,	384,	UI_XSTR_COLOR_GREEN, -1, &CC_Buttons[0][COMPUTER_TAB].button },		
-		{ "Alt",				1510,		12,	440,	UI_XSTR_COLOR_GREEN, -1, &CC_Buttons[0][ALT_TOGGLE].button },
-		{ "Shift",			1511,		50,	440,	UI_XSTR_COLOR_GREEN, -1, &CC_Buttons[0][SHIFT_TOGGLE].button },
-		{ "Invert",			1342,		155,	440,	UI_XSTR_COLOR_GREEN, -1, &CC_Buttons[0][INVERT_AXIS].button },
-		{ "Cancel",			641,		397,	45,	UI_XSTR_COLOR_PINK, -1, &CC_Buttons[0][CANCEL_BUTTON].button },
-		{ "Undo",			1343,		586,	386,	UI_XSTR_COLOR_GREEN, -1, &CC_Buttons[0][UNDO_BUTTON].button },
-		{ "Defaults",		1344,		568,	45,	UI_XSTR_COLOR_GREEN, -1, &CC_Buttons[0][RESET_BUTTON].button },
-		{ "Search",			1345,		453,	45,	UI_XSTR_COLOR_GREEN, -1, &CC_Buttons[0][SEARCH_MODE].button },
-		{ "Bind",			1346,		519,	45,	UI_XSTR_COLOR_PINK, -1, &CC_Buttons[0][BIND_BUTTON].button },
-		{ "Help",			928,		500,	440,	UI_XSTR_COLOR_GREEN, -1, &CC_Buttons[0][HELP_BUTTON].button },
-		{ "Accept",			1035,		571,	412,	UI_XSTR_COLOR_PINK, -1, &CC_Buttons[0][ACCEPT_BUTTON].button },
-		{ "Clear",			1347,		417,	386,	UI_XSTR_COLOR_GREEN, -1, &CC_Buttons[0][CLEAR_OTHER_BUTTON].button },
-		{ "Conflict",		1348,		406,	396,	UI_XSTR_COLOR_GREEN, -1, &CC_Buttons[0][CLEAR_OTHER_BUTTON].button },
-		{ "Clear",			1413,		474,	386,	UI_XSTR_COLOR_GREEN, -1, &CC_Buttons[0][CLEAR_ALL_BUTTON].button },
-		{ "All",				1349,		483,	396,	UI_XSTR_COLOR_GREEN, -1, &CC_Buttons[0][CLEAR_ALL_BUTTON].button },
-		{ "Clear",			1414,		529,	388,	UI_XSTR_COLOR_PINK, -1, &CC_Buttons[0][CLEAR_BUTTON].button },
-		{ "Selected",		1350,		517,	396,	UI_XSTR_COLOR_PINK, -1, &CC_Buttons[0][CLEAR_BUTTON].button },
+		{ "Targeting", 1340,  17, 384, UI_XSTR_COLOR_GREEN, -1, &CC_Buttons[0][TARGET_TAB].button },
+		{ "Ship",      1341, 103, 384, UI_XSTR_COLOR_GREEN, -1, &CC_Buttons[0][SHIP_TAB].button },
+		{ "Weapons",   1065, 154, 384, UI_XSTR_COLOR_GREEN, -1, &CC_Buttons[0][WEAPON_TAB].button },
+		{ "Misc",      1411, 244, 384, UI_XSTR_COLOR_GREEN, -1, &CC_Buttons[0][COMPUTER_TAB].button },
+		{ "Alt",       1510,  12, 440, UI_XSTR_COLOR_GREEN, -1, &CC_Buttons[0][ALT_TOGGLE].button },
+		{ "Shift",     1511,  50, 440, UI_XSTR_COLOR_GREEN, -1, &CC_Buttons[0][SHIFT_TOGGLE].button },
+		{ "Invert",    1342, 155, 440, UI_XSTR_COLOR_GREEN, -1, &CC_Buttons[0][INVERT_AXIS].button },
+		{ "Cancel",     641, 397,  45, UI_XSTR_COLOR_PINK,  -1, &CC_Buttons[0][CANCEL_BUTTON].button },
+		{ "Undo",      1343, 586, 386, UI_XSTR_COLOR_GREEN, -1, &CC_Buttons[0][UNDO_BUTTON].button },
+		{ "Defaults",  1344, 568,  45, UI_XSTR_COLOR_GREEN, -1, &CC_Buttons[0][RESET_BUTTON].button },
+		{ "Search",    1345, 453,  45, UI_XSTR_COLOR_GREEN, -1, &CC_Buttons[0][SEARCH_MODE].button },
+		{ "Bind",      1346, 519,  45, UI_XSTR_COLOR_PINK,  -1, &CC_Buttons[0][BIND_BUTTON].button },
+		{ "Help",       928, 500, 440, UI_XSTR_COLOR_GREEN, -1, &CC_Buttons[0][HELP_BUTTON].button },
+		{ "Accept",    1035, 571, 412, UI_XSTR_COLOR_PINK,  -1, &CC_Buttons[0][ACCEPT_BUTTON].button },
+		{ "Clear",     1347, 417, 386, UI_XSTR_COLOR_GREEN, -1, &CC_Buttons[0][CLEAR_OTHER_BUTTON].button },
+		{ "Conflict",  1348, 406, 396, UI_XSTR_COLOR_GREEN, -1, &CC_Buttons[0][CLEAR_OTHER_BUTTON].button },
+		{ "Clear",     1413, 474, 386, UI_XSTR_COLOR_GREEN, -1, &CC_Buttons[0][CLEAR_ALL_BUTTON].button },
+		{ "All",       1349, 483, 396, UI_XSTR_COLOR_GREEN, -1, &CC_Buttons[0][CLEAR_ALL_BUTTON].button },
+		{ "Clear",     1414, 529, 388, UI_XSTR_COLOR_PINK,  -1, &CC_Buttons[0][CLEAR_BUTTON].button },
+		{ "Selected",  1350, 517, 396, UI_XSTR_COLOR_PINK,  -1, &CC_Buttons[0][CLEAR_BUTTON].button },
 	},
 	{ // GR_1024
-		{ "Targeting",		1340,		47,	615,	UI_XSTR_COLOR_GREEN, -1, &CC_Buttons[1][TARGET_TAB].button },
-		{ "Ship",			1341,		176,	615,	UI_XSTR_COLOR_GREEN, -1, &CC_Buttons[1][SHIP_TAB].button },
-		{ "Weapons",		1065,		266,	615,	UI_XSTR_COLOR_GREEN, -1, &CC_Buttons[1][WEAPON_TAB].button },
-		{ "Misc",			1411,		401,	615,	UI_XSTR_COLOR_GREEN, -1, &CC_Buttons[1][COMPUTER_TAB].button },		
-		{ "Alt",				1510,		29,	704,	UI_XSTR_COLOR_GREEN, -1, &CC_Buttons[1][ALT_TOGGLE].button },
-		{ "Shift",			1511,		85,	704,	UI_XSTR_COLOR_GREEN, -1, &CC_Buttons[1][SHIFT_TOGGLE].button },
-		{ "Invert",			1342,		254,	704,	UI_XSTR_COLOR_GREEN, -1, &CC_Buttons[1][INVERT_AXIS].button },
-		{ "Cancel",			641,		655,	71,	UI_XSTR_COLOR_PINK, -1, &CC_Buttons[1][CANCEL_BUTTON].button },
-		{ "Undo",			1343,		938,	619,	UI_XSTR_COLOR_GREEN, -1, &CC_Buttons[1][UNDO_BUTTON].button },
-		{ "Defaults",		1344,		923,	71,	UI_XSTR_COLOR_GREEN, -1, &CC_Buttons[1][RESET_BUTTON].button },
-		{ "Search",			1345,		746,	71,	UI_XSTR_COLOR_GREEN, -1, &CC_Buttons[1][SEARCH_MODE].button },
-		{ "Bind",			1346,		846,	71,	UI_XSTR_COLOR_PINK, -1, &CC_Buttons[1][BIND_BUTTON].button },
-		{ "Help",			928,		800,	704,	UI_XSTR_COLOR_GREEN, -1, &CC_Buttons[1][HELP_BUTTON].button },
-		{ "Accept",			1035,		914,	660,	UI_XSTR_COLOR_PINK, -1, &CC_Buttons[1][ACCEPT_BUTTON].button },
-		{ "Clear",			1347,		683,	619,	UI_XSTR_COLOR_GREEN, -1, &CC_Buttons[1][CLEAR_OTHER_BUTTON].button },
-		{ "Conflict",		1348,		666,	634,	UI_XSTR_COLOR_GREEN, -1, &CC_Buttons[1][CLEAR_OTHER_BUTTON].button },
-		{ "Clear",			1413,		759,	619,	UI_XSTR_COLOR_GREEN, -1, &CC_Buttons[1][CLEAR_ALL_BUTTON].button },
-		{ "All",				1349,		772,	634,	UI_XSTR_COLOR_GREEN, -1, &CC_Buttons[1][CLEAR_ALL_BUTTON].button },
-		{ "Clear",			1414,		871,	619,	UI_XSTR_COLOR_PINK, -1, &CC_Buttons[1][CLEAR_BUTTON].button },
-		{ "Selected",		1350,		852,	634,	UI_XSTR_COLOR_PINK, -1, &CC_Buttons[1][CLEAR_BUTTON].button },
+		{ "Targeting", 1340,  47, 615, UI_XSTR_COLOR_GREEN, -1, &CC_Buttons[1][TARGET_TAB].button },
+		{ "Ship",      1341, 176, 615, UI_XSTR_COLOR_GREEN, -1, &CC_Buttons[1][SHIP_TAB].button },
+		{ "Weapons",   1065, 266, 615, UI_XSTR_COLOR_GREEN, -1, &CC_Buttons[1][WEAPON_TAB].button },
+		{ "Misc",      1411, 401, 615, UI_XSTR_COLOR_GREEN, -1, &CC_Buttons[1][COMPUTER_TAB].button },
+		{ "Alt",       1510,  29, 704, UI_XSTR_COLOR_GREEN, -1, &CC_Buttons[1][ALT_TOGGLE].button },
+		{ "Shift",     1511,  85, 704, UI_XSTR_COLOR_GREEN, -1, &CC_Buttons[1][SHIFT_TOGGLE].button },
+		{ "Invert",    1342, 254, 704, UI_XSTR_COLOR_GREEN, -1, &CC_Buttons[1][INVERT_AXIS].button },
+		{ "Cancel",     641, 655,  71, UI_XSTR_COLOR_PINK,  -1, &CC_Buttons[1][CANCEL_BUTTON].button },
+		{ "Undo",      1343, 938, 619, UI_XSTR_COLOR_GREEN, -1, &CC_Buttons[1][UNDO_BUTTON].button },
+		{ "Defaults",  1344, 923,  71, UI_XSTR_COLOR_GREEN, -1, &CC_Buttons[1][RESET_BUTTON].button },
+		{ "Search",    1345, 746,  71, UI_XSTR_COLOR_GREEN, -1, &CC_Buttons[1][SEARCH_MODE].button },
+		{ "Bind",      1346, 846,  71, UI_XSTR_COLOR_PINK,  -1, &CC_Buttons[1][BIND_BUTTON].button },
+		{ "Help",       928, 800, 704, UI_XSTR_COLOR_GREEN, -1, &CC_Buttons[1][HELP_BUTTON].button },
+		{ "Accept",    1035, 914, 660, UI_XSTR_COLOR_PINK,  -1, &CC_Buttons[1][ACCEPT_BUTTON].button },
+		{ "Clear",     1347, 683, 619, UI_XSTR_COLOR_GREEN, -1, &CC_Buttons[1][CLEAR_OTHER_BUTTON].button },
+		{ "Conflict",  1348, 666, 634, UI_XSTR_COLOR_GREEN, -1, &CC_Buttons[1][CLEAR_OTHER_BUTTON].button },
+		{ "Clear",     1413, 759, 619, UI_XSTR_COLOR_GREEN, -1, &CC_Buttons[1][CLEAR_ALL_BUTTON].button },
+		{ "All",       1349, 772, 634, UI_XSTR_COLOR_GREEN, -1, &CC_Buttons[1][CLEAR_ALL_BUTTON].button },
+		{ "Clear",     1414, 871, 619, UI_XSTR_COLOR_PINK,  -1, &CC_Buttons[1][CLEAR_BUTTON].button },
+		{ "Selected",  1350, 852, 634, UI_XSTR_COLOR_PINK,  -1, &CC_Buttons[1][CLEAR_BUTTON].button },
 	}
 };
 
@@ -355,6 +367,2212 @@ DCF_BOOL(show_controls_info, Show_controls_info);
 #endif
 
 static int Axes_origin[JOY_NUM_AXES];
+
+extern Joy_info joystick;
+
+int Last_frame_timestamp;
+// --------------------------------------------------------------------------------------------------------------------
+// Inherited/Friended methods
+// --------------------------------------------------------------------------------------------------------------------
+
+// --------------------------------------------------------------------------------------------------------------------
+// Declaration of protected functions.
+// --------------------------------------------------------------------------------------------------------------------
+
+
+// --------------------------------------------------------------------------------------------------------------------
+// Declaration of private functions(declared as static type func(type param);)
+// --------------------------------------------------------------------------------------------------------------------
+/**
+ * @brief Checks if the given line in the Controls Config screen is visible.
+ *
+ * @param[in] n The controls config line to check
+ *
+ * @returns 1 If the line is visible, or
+ * @returns 0 otherwise
+ */
+static int cc_line_query_visible(int n);
+
+/**
+ * @brief Checks if the given control is being used, and if so, marks it as such
+ *
+ * @param[in] id  Index of the control to check
+ * @param[in] key Index of the key to check. If -1, checks the last key that was checked
+ *
+ * @details The given control is marked as used by control_used() if:
+ *   - The passed key is assigned to the control, or
+ *   - Either the joystick or mouse buttons assigned to the control is active
+ */
+static int check_control_used(int id, int key);
+
+/**
+ * @brief Handler for when the "Accept" button is pressed
+ *
+ * @returns  0  If it's OK to continue, or
+ * @returns -1  If a assignment conflict was found
+ */
+static int control_config_accept();
+
+/**
+ * @brief Gets the default control axis mapping for the given joystick/mouse axis.
+ *
+ * @param[in] axis The joystick/mouse axis to check
+ *
+ * @returns The default Joy_axis_index assignment
+ */
+static int control_config_axis_default(int axis);
+
+/**
+ * @brief Binds the given joystick/mouse axis to a control
+ *
+ * @param[in] i    The Joy_axis_index of the control to bind to
+ * @param[in] axis The axis joystick/mouse index to bind
+ *
+ * @details Also pushes an undo block
+ */
+static void control_config_bind_axis(int i, int axis);
+
+/**
+ * @brief Binds the given joystick/mouse button to a control
+ *
+ * @param[in] i   Index to the control in Control_config
+ * @param[in] joy The button id from the joystick/mouse
+ *
+ * @details Also pushes an undo block
+ */
+static void control_config_bind_joy(int i, int joy);
+
+/**
+ * @brief Binds the given key to a control
+ *
+ * @param[in] i   Index to the control in Control_config
+ * @param[in] key The key to bind
+ *
+ * @details Also pushes an undo block
+ */
+static void control_config_bind_key(int i, int key);
+
+/**
+ * @brief Handler for when a UI button was pressed.
+ *
+ * @param[in] n Index of the UI button
+ */
+static void control_config_button_pressed(int n);
+
+/**
+ * @brief Wipes out all bindings and saves an undo block per binding that was actually cleared
+ *
+ * @returns  0 If successful, or
+ * @returns -1 otherwise
+ */
+static int control_config_clear_all();
+
+/**
+ * @brief Wipes out all bindings that is not the currently selected one and saves an undo block per cleared binding
+ *
+ * @returns  0 If successful, or
+ * @returns -1 Otherwise
+ */
+static int control_config_clear_other();
+
+/**
+ * @brief Checks for bind conflicts, and stores them in the appropriate Conflicts arrays
+ */
+static void control_config_conflict_check();
+
+/**
+ * @brief Checks the joystick and mouse for movement, and selects the axis with the greatest delta
+ *
+ * @returns The axis id of the detected axis, or -1 if none found
+ */
+static int control_config_detect_axis();
+
+/**
+ * @brief Resets the reference point used by control_config_detect_axis.
+ */
+static void control_config_detect_axis_reset();
+
+/**
+ * @brief Does the housekeeping after a sucessful bind
+ */
+static void control_config_do_bind();
+
+/**
+ * @brief Handler for the Cancel button
+ */
+static void control_config_do_cancel(int fail = 0);
+
+/**
+ * @brief Resets all controls to defaults or preset
+ *
+ * @returns 0 If successful, or
+ * @returns -1 otherwise
+ */
+static int control_config_do_reset();
+
+/**
+ * @brief Housekeeping for the search function
+ */
+static void control_config_do_search();
+
+/**
+ * @brief Handles a conflict.
+ *
+ * @details Actually does nothing at the moment...
+ */
+static int control_config_handle_conflict();
+
+/**
+ * @brief Sets up the control_config list.
+ *
+ * @details Required prior to rendering and checking for the controls listing.  Called when list changes
+ */
+static void control_config_list_prepare();
+
+/**
+ * @brief Unbinds the controllers assigned to the ccfg referenced by Selected_item
+ */
+static int control_config_remove_binding();
+
+/**
+ * @brief Saves the given axis in an undo block
+ */
+static void control_config_save_axis_undo(int axis);
+
+/**
+ * @brief Handler called to scroll down the active controls config list by 1 line
+ */
+static void control_config_scroll_line_down();
+
+/**
+ * @brief Handler called to scroll up the active controls config list by 1 line
+ */
+static void control_config_scroll_line_up();
+
+/**
+ * @brief Handler called to page down the active controls config list
+ */
+static void control_config_scroll_screen_down();
+
+/**
+ * @brief Handler called to page up the active controls config list
+ */
+static void control_config_scroll_screen_up();
+
+/**
+ * @brief Toggles inversion for the selected axis
+ */
+static void control_config_toggle_invert();
+
+/**
+ * @brief Toggles the Shift/Ctrl/Alt modifier (which is given as a bitfield) for the selected key 
+ */
+static void control_config_toggle_modifier(int bit);
+
+/**
+ * @brief If the given cstring is "@conflict", check tabs for a conflict and return a "Conflict!" string
+ */
+static const char *control_config_tooltip_handler(const char *str);
+
+/**
+ * @brief Undos the last control config assignment
+ */
+static int control_config_undo_last();
+
+/**
+ * @brief Frees an undo block from the list
+ */
+static void free_undo_block();
+
+/**
+ * @brief Allocates the required space for one undo block and places it in the beginning of the linked list (top of a stack).
+ *
+ * @returns A pointer to this newly allocated block
+ */
+static config_item_undo *get_undo_block(int size);
+
+
+// --------------------------------------------------------------------------------------------------------------------
+// Definition of all functions, in alphabetical order
+// --------------------------------------------------------------------------------------------------------------------
+static int cc_line_query_visible(int n) {
+	int y;
+
+	if ((n < 0) || (n >= Num_cc_lines)) {
+		return 0;
+	}
+
+	y = Cc_lines[n].y - Cc_lines[Scroll_offset].y;
+	if ((y < 0) || (y + gr_get_font_height() > Control_list_coords[gr_screen.res][CONTROL_H_COORD])) {
+		return 0;
+	}
+
+	return 1;
+}
+
+int check_control(int id, int key) {
+	if (check_control_used(id, key)) {
+		if (Ignored_keys[id]) {
+			if (Ignored_keys[id] > 0) {
+				Ignored_keys[id]--;
+			}
+			return 0;
+		}
+		return 1;
+	}
+
+	if (Control_config[id].continuous_ongoing) {
+		// If we reach this point, then it means this is a continuous control
+		// which has just been released
+
+		Script_system.SetHookVar("Action", 's', Control_config[id].text);
+		Script_system.RunCondition(CHA_ONACTIONSTOPPED, '\0', NULL, NULL, id);
+		Script_system.RemHookVar("Action");
+
+		Control_config[id].continuous_ongoing = false;
+	}
+
+	return 0;
+}
+
+float check_control_timef(int id) {
+	float t1, t2;
+
+	// if type isn't continuous, we shouldn't be using this function, cause it won't work.
+	Assert(Control_config[id].type == CC_TYPE_CONTINUOUS);
+
+	// first, see if control actually used (makes sure modifiers match as well)
+	if (!check_control(id)) {
+		Control_config[id].continuous_ongoing = false;
+
+		return 0.0f;
+	}
+
+	t1 = key_down_timef(Control_config[id].key_id);
+	if (t1) {
+		control_used(id);
+	}
+
+	t2 = joy_down_time(Control_config[id].joy_id);
+	if (t2) {
+		control_used(id);
+	}
+
+	if (t1 + t2) {
+		// We want to set this to true only after visiting control_used() (above)
+		// to allow it to tell the difference between an ongoing continuous action
+		// started before and a continuous action being started right now.
+		Control_config[id].continuous_ongoing = true;
+
+		return t1 + t2;
+	}
+
+	return 1.0f;
+}
+
+static int check_control_used(int id, int key) {
+	int z, mask;
+	static int last_key = 0;
+
+	Control_check_count++;
+	if (key < 0) {
+		key = last_key;
+	}
+
+	last_key = key;
+
+	// if we're in multiplayer text enter (for chat) mode, check to see if we should ignore controls
+	if ((Game_mode & GM_MULTIPLAYER) && multi_ignore_controls()) {
+		return 0;
+	}
+
+	if (Control_config[id].disabled)
+		return 0;
+
+	if (Control_config[id].type == CC_TYPE_CONTINUOUS) {
+		if (joy_down(Control_config[id].joy_id) || joy_down_count(Control_config[id].joy_id, 1)) {
+			control_used(id);
+			return 1;
+		}
+
+		if ((Control_config[id].joy_id >= 0) && (Control_config[id].joy_id < MOUSE_NUM_BUTTONS)) {
+			if (mouse_down(1 << Control_config[id].joy_id) || mouse_down_count(1 << Control_config[id].joy_id)) {
+				control_used(id);
+				return 1;
+			}
+		}
+
+		// check what current modifiers are pressed
+		mask = 0;
+		if (keyd_pressed[KEY_LSHIFT] || key_down_count(KEY_LSHIFT) || keyd_pressed[KEY_RSHIFT] || key_down_count(KEY_RSHIFT)) {
+			mask |= KEY_SHIFTED;
+		}
+
+		if (keyd_pressed[KEY_LALT] || key_down_count(KEY_LALT) || keyd_pressed[KEY_RALT] || key_down_count(KEY_RALT)) {
+			mask |= KEY_ALTED;
+		}
+
+		z = Control_config[id].key_id;
+		if (z >= 0) {
+			if ((z != KEY_LALT) && (z != KEY_RALT) && (z != KEY_LSHIFT) && (z != KEY_RSHIFT)) {
+				// if current modifiers don't match action's modifiers, don't register control active.
+				if ((z & (KEY_SHIFTED | KEY_ALTED)) != mask) {
+					return 0;
+				}
+			}
+
+			z &= KEY_MASK;
+
+			if (keyd_pressed[z] || key_down_count(z)) {
+				control_used(id);
+				return 1;
+			}
+		}
+
+		return 0;
+	}
+
+	if ((Control_config[id].key_id == key) || joy_down_count(Control_config[id].joy_id, 1) || mouse_down_count(1 << Control_config[id].joy_id)) {
+		//mprintf(("Key used %d", key));
+		control_used(id);
+		return 1;
+	}
+
+	return 0;
+}
+
+void clear_key_binding(short key) {
+	int i;
+
+	for (i = 0; i < CCFG_MAX; i++) {
+		if (Control_config[i].key_id == key) {
+			Control_config[i].key_id = -1;
+		}
+	}
+}
+
+void control_check_indicate() {
+#ifndef NDEBUG
+	if (Show_controls_info) {
+		gr_set_color_fast(&HUD_color_debug);
+		gr_printf_no_resize(gr_screen.center_offset_x + gr_screen.center_w - 154, gr_screen.center_offset_y + 5, NOX("Ctrls checked: %d"), Control_check_count);
+	}
+#endif
+
+	Control_check_count = 0;
+}
+
+static int control_config_accept() {
+	int i;
+
+	for (i = 0; i < NUM_TABS; i++) {
+		if (Conflicts_tabs[i]) {
+			break;
+		}
+	}
+
+	if (i < NUM_TABS) {
+		gamesnd_play_iface(SND_GENERAL_FAIL);
+		return -1;
+	}
+
+	hud_squadmsg_save_keys();  // rebuild map for saving/restoring keys in squadmsg mode
+	gameseq_post_event(GS_EVENT_PREVIOUS_STATE);
+	gamesnd_play_iface(SND_COMMIT_PRESSED);
+	return 0;
+}
+
+static int control_config_axis_default(int axis) {
+	Assert(axis >= 0);
+
+	if (axis > 1) {
+		if (Axis_map_to_defaults[axis] < 0) {
+			return -1;
+		}
+
+		if (!joystick.axis_valid[Axis_map_to_defaults[axis]]) {
+			return -1;
+		}
+	}
+
+	return Axis_map_to_defaults[axis];
+}
+
+static void control_config_bind_axis(int i, int axis) {
+	control_config_save_axis_undo(i);
+	Axis_map_to[i] = axis;
+}
+
+static void control_config_bind_joy(int i, int joy) {
+	config_item_undo *ptr;
+
+	ptr = get_undo_block(1);
+	ptr->index[0] = i;
+	ptr->list[0] = Control_config[i];
+	Control_config[i].joy_id = (short) joy;
+}
+
+static void control_config_bind_key(int i, int key) {
+	config_item_undo *ptr;
+
+	ptr = get_undo_block(1);
+	ptr->index[0] = i;
+	ptr->list[0] = Control_config[i];
+	Control_config[i].key_id = (short) key;
+}
+
+static void control_config_button_pressed(int n) {
+	switch (n) {
+	case TARGET_TAB:
+	case SHIP_TAB:
+	case WEAPON_TAB:
+	case COMPUTER_TAB:
+		Tab = n;
+		Scroll_offset = Selected_line = 0;
+		control_config_list_prepare();
+		gamesnd_play_iface(SND_SCREEN_MODE_PRESSED);
+		break;
+
+	case BIND_BUTTON:
+		control_config_do_bind();
+		break;
+
+	case SEARCH_MODE:
+		control_config_do_search();
+		break;
+
+	case SHIFT_TOGGLE:
+		control_config_toggle_modifier(KEY_SHIFTED);
+		gamesnd_play_iface(SND_USER_SELECT);
+		break;
+
+	case ALT_TOGGLE:
+		control_config_toggle_modifier(KEY_ALTED);
+		gamesnd_play_iface(SND_USER_SELECT);
+		break;
+
+	case INVERT_AXIS:
+		control_config_toggle_invert();
+		gamesnd_play_iface(SND_USER_SELECT);
+		break;
+
+	case SCROLL_UP_BUTTON:
+		control_config_scroll_screen_up();
+		break;
+
+	case SCROLL_DOWN_BUTTON:
+		control_config_scroll_screen_down();
+		break;
+
+	case ACCEPT_BUTTON:
+		control_config_accept();
+		break;
+
+	case CLEAR_BUTTON:
+		control_config_remove_binding();
+		break;
+
+	case HELP_BUTTON:
+		launch_context_help();
+		gamesnd_play_iface(SND_HELP_PRESSED);
+		break;
+
+	case RESET_BUTTON:
+		control_config_do_reset();
+		break;
+
+	case UNDO_BUTTON:
+		control_config_undo_last();
+		break;
+
+	case CANCEL_BUTTON:
+		control_config_do_cancel();
+		break;
+
+	case CLEAR_OTHER_BUTTON:
+		control_config_clear_other();
+		break;
+
+	case CLEAR_ALL_BUTTON:
+		control_config_clear_all();
+		break;
+	}
+}
+
+void control_config_cancel_exit() {
+	int i;
+
+	for (i = 0; i < CCFG_MAX; i++) {
+		Control_config[i] = Control_config_backup[i];
+	}
+
+	gameseq_post_event(GS_EVENT_PREVIOUS_STATE);
+}
+
+void control_config_clear() {
+	int i;
+
+	// Reset keyboard defaults
+	for (i = 0; i < CCFG_MAX; i++) {
+		Control_config[i].key_id = Control_config[i].joy_id = -1;
+	}
+}
+
+static int control_config_clear_all() {
+	int i, j, total = 0;
+	config_item_undo *ptr;
+
+	// first, determine how many bindings need to be changed
+	for (i = 0; i < CCFG_MAX; i++) {
+		if ((Control_config[i].key_id >= 0) || (Control_config[i].joy_id >= 0)) {
+			total++;
+		}
+	}
+
+	if (!total) {
+		gamesnd_play_iface(SND_GENERAL_FAIL);
+		return -1;
+	}
+
+	// now, back up the old bindings so we can undo if we want to
+	ptr = get_undo_block(total);
+	for (i = j = 0; i < CCFG_MAX; i++) {
+		if ((Control_config[i].key_id >= 0) || (Control_config[i].joy_id >= 0)) {
+			ptr->index[j] = i;
+			ptr->list[j] = Control_config[i];
+			j++;
+		}
+	}
+
+	Assert(j == total);
+	for (i = 0; i < CCFG_MAX; i++) {
+		Control_config[i].key_id = Control_config[i].joy_id = -1;
+	}
+
+	control_config_conflict_check();
+	control_config_list_prepare();
+	gamesnd_play_iface(SND_RESET_PRESSED);
+	return 0;
+}
+
+static int control_config_clear_other() {
+	int z, i, j, total = 0;
+	config_item_undo *ptr;
+
+	if (Selected_line < 0) {
+		gamesnd_play_iface(SND_GENERAL_FAIL);
+		return -1;
+	}
+
+	z = Cc_lines[Selected_line].cc_index;
+	if (z & JOY_AXIS) {
+		config_item item;
+
+		z &= ~JOY_AXIS;
+		if (Axis_map_to[z] < 0) {
+			gamesnd_play_iface(SND_GENERAL_FAIL);
+			return -1;
+		}
+
+		for (i = 0; i < NUM_JOY_AXIS_ACTIONS; i++) {
+			if ((Axis_map_to[i] == Axis_map_to[z]) && (i != z)) {
+				total++;
+			}
+		}
+
+		if (!total) {
+			gamesnd_play_iface(SND_GENERAL_FAIL);
+			return -1;
+		}
+
+		ptr = get_undo_block(total);
+		for (i = j = 0; i < NUM_JOY_AXIS_ACTIONS; i++) {
+			if ((Axis_map_to[i] == Axis_map_to[z]) && (i != z)) {
+				memset(&item, 0, sizeof(config_item));
+
+				item.joy_id = (short) Axis_map_to[i];
+				item.used = Invert_axis[i];
+
+				ptr->index[j] = i | JOY_AXIS;
+				ptr->list[j] = item;
+				j++;
+
+				Axis_map_to[i] = -1;
+			}
+		}
+		control_config_conflict_check();
+		control_config_list_prepare();
+		gamesnd_play_iface(SND_USER_SELECT);
+		return 0;
+	}
+
+	for (i = 0; i < CCFG_MAX; i++) {
+		if ((Control_config[i].key_id == Control_config[z].key_id) || (Control_config[i].joy_id == Control_config[z].joy_id)) {
+			if (i != z) {
+				total++;
+			}
+		}
+	}
+	if (!total) {
+		gamesnd_play_iface(SND_GENERAL_FAIL);
+		return -1;
+	}
+
+	if ((Control_config[z].joy_id < 0) && (Control_config[z].key_id < 0)) {
+		gamesnd_play_iface(SND_GENERAL_FAIL);
+		return -1;
+	}
+
+	// now, back up the old bindings so we can undo if we want to
+	ptr = get_undo_block(total);
+	for (i = j = 0; i < CCFG_MAX; i++) {
+		if ((Control_config[i].key_id == Control_config[z].key_id) || (Control_config[i].joy_id == Control_config[z].joy_id)) {
+			if (i != z) {
+				ptr->index[j] = i;
+				ptr->list[j] = Control_config[i];
+				j++;
+
+				if (Control_config[i].key_id == Control_config[z].key_id) {
+					Control_config[i].key_id = (short) -1;
+				}
+
+				if (Control_config[i].joy_id == Control_config[z].joy_id) {
+					Control_config[i].joy_id = (short) -1;
+				}
+			}
+		}
+	}
+	control_config_conflict_check();
+	control_config_list_prepare();
+	gamesnd_play_iface(SND_USER_SELECT);
+	return 0;
+}
+
+void control_config_close() {
+	int idx;
+
+	while (Config_item_undo) {
+		free_undo_block();
+	}
+
+	if (Background_bitmap) {
+		bm_release(Background_bitmap);
+	}
+
+	Ui_window.destroy();
+	common_free_interface_palette();		// restore game palette
+	hud_squadmsg_save_keys();				// rebuild map for saving/restoring keys in squadmsg mode
+	game_flush();
+
+	if (Game_mode & GM_MULTIPLAYER) {
+		Pilot.save_player();
+	} else {
+		Pilot.save_savefile();
+	}
+
+	// free strings	
+	for (idx = 0; idx < NUM_JOY_AXIS_ACTIONS; idx++) {
+		if (Joy_axis_action_text[idx] != NULL) {
+			vm_free(Joy_axis_action_text[idx]);
+			Joy_axis_action_text[idx] = NULL;
+		}
+	}
+	for (idx = 0; idx < NUM_AXIS_TEXT; idx++) {
+		if (Joy_axis_text[idx] != NULL) {
+			vm_free(Joy_axis_text[idx]);
+			Joy_axis_text[idx] = NULL;
+		}
+	}
+	for (idx = 0; idx < NUM_MOUSE_TEXT; idx++) {
+		if (Mouse_button_text[idx] != NULL) {
+			vm_free(Mouse_button_text[idx]);
+			Mouse_button_text[idx] = NULL;
+		}
+	}
+	for (idx = 0; idx < NUM_MOUSE_AXIS_TEXT; idx++) {
+		if (Mouse_axis_text[idx] != NULL) {
+			vm_free(Mouse_axis_text[idx]);
+			Mouse_axis_text[idx] = NULL;
+		}
+	}
+	for (idx = 0; idx < NUM_INVERT_TEXT; idx++) {
+		if (Invert_text[idx] != NULL) {
+			vm_free(Invert_text[idx]);
+			Invert_text[idx] = NULL;
+		}
+	}
+}
+
+void control_config_clear_used_status() {
+	int i;
+
+	for (i = 0; i < CCFG_MAX; i++) {
+		Control_config[i].used = 0;
+	}
+}
+
+static void control_config_conflict_check() {
+	int i, j;
+
+	for (i = 0; i < CCFG_MAX; i++) {
+		Conflicts[i].key = Conflicts[i].joy = -1;
+	}
+
+	for (i = 0; i < NUM_TABS; i++) {
+		Conflicts_tabs[i] = 0;
+	}
+
+	for (i = 0; i < CCFG_MAX - 1; i++) {
+		for (j = i + 1; j < CCFG_MAX; j++) {
+			if ((Control_config[i].key_id >= 0) && (Control_config[i].key_id == Control_config[j].key_id)) {
+				// If one of the conflicting keys is disabled, then this silently clears
+				// the disabled key to prevent the conflict; a conflict is recorded only
+				// if both keys are enabled
+
+				if (Control_config[i].disabled)
+					Control_config[i].key_id = (short) -1;
+				else if (Control_config[j].disabled)
+					Control_config[j].key_id = (short) -1;
+				else {
+					Conflicts[i].key = j;
+					Conflicts[j].key = i;
+					Conflicts_tabs[Control_config[i].tab] = 1;
+					Conflicts_tabs[Control_config[j].tab] = 1;
+				}
+			}
+
+			if ((Control_config[i].joy_id >= 0) && (Control_config[i].joy_id == Control_config[j].joy_id)) {
+				// Same as above
+
+				if (Control_config[i].disabled)
+					Control_config[i].joy_id = (short) -1;
+				else if (Control_config[j].disabled)
+					Control_config[j].joy_id = (short) -1;
+				else {
+					Conflicts[i].joy = j;
+					Conflicts[j].joy = i;
+					Conflicts_tabs[Control_config[i].tab] = 1;
+					Conflicts_tabs[Control_config[j].tab] = 1;
+				}
+			}
+		}
+	}
+
+	for (i = 0; i < NUM_JOY_AXIS_ACTIONS; i++) {
+		Conflicts_axes[i] = -1;
+	}
+
+	for (i = 0; i < NUM_JOY_AXIS_ACTIONS - 1; i++) {
+		for (j = i + 1; j < NUM_JOY_AXIS_ACTIONS; j++) {
+			if ((Axis_map_to[i] >= 0) && (Axis_map_to[i] == Axis_map_to[j])) {
+				Conflicts_axes[i] = j;
+				Conflicts_axes[j] = i;
+				Conflicts_tabs[SHIP_TAB] = 1;
+			}
+		}
+	}
+}
+
+static int control_config_detect_axis() {
+	int i, d, axis = -1, delta = 16384;
+	int axes_values[JOY_NUM_AXES];
+	int dx, dy, fudge = 7;
+
+	joystick_read_raw_axis(JOY_NUM_AXES, axes_values);
+	for (i = 0; i < JOY_NUM_AXES; i++) {
+		d = abs(axes_values[i] - Axes_origin[i]);
+		if (d > delta) {
+			axis = i;
+			delta = d;
+		}
+	}
+
+	if ((axis == -1) && Use_mouse_to_fly) {
+		mouse_get_delta(&dx, &dy);
+
+		if ((dx > fudge) || (dx < -fudge)) {
+			axis = 0;
+		} else if ((dy > fudge) || (dy < -fudge)) {
+			axis = 1;
+		}
+	}
+
+	return axis;
+}
+
+static void control_config_detect_axis_reset() {
+	joystick_read_raw_axis(JOY_NUM_AXES, Axes_origin);
+}
+
+static void control_config_do_bind() {
+	int i;
+
+	game_flush();
+	//	if ((Selected_line < 0) || (Cc_lines[Selected_line].cc_index & JOY_AXIS)) {
+	if (Selected_line < 0) {
+		gamesnd_play_iface(SND_GENERAL_FAIL);
+		return;
+	}
+
+	for (i = 0; i < NUM_BUTTONS; i++) {
+		if (i != CANCEL_BUTTON) {
+			CC_Buttons[gr_screen.res][i].button.reset_status();
+			CC_Buttons[gr_screen.res][i].button.disable();
+		}
+	}
+	CC_Buttons[gr_screen.res][CANCEL_BUTTON].button.enable();
+	CC_Buttons[gr_screen.res][CANCEL_BUTTON].button.set_hotkey(KEY_ESC);
+
+	for (i = 0; i < JOY_TOTAL_BUTTONS; i++) {
+		joy_down_count(i, 1);  // clear checking status of all joystick buttons
+	}
+
+	control_config_detect_axis_reset();
+
+	Binding_mode = 1;
+	Bind_time = timer_get_milliseconds();
+	Search_mode = 0;
+	Last_key = -1;
+	Axis_override = -1;
+	gamesnd_play_iface(SND_USER_SELECT);
+}
+
+static void control_config_do_cancel(int fail) {
+	int i;
+
+	game_flush();
+
+	for (i = 0; i < NUM_BUTTONS; i++) {
+		if ((i != CANCEL_BUTTON) && (i != INVERT_AXIS)) {
+			CC_Buttons[gr_screen.res][i].button.enable();
+		}
+	}
+
+	CC_Buttons[gr_screen.res][CANCEL_BUTTON].button.reset_status();
+	CC_Buttons[gr_screen.res][CANCEL_BUTTON].button.disable();
+	CC_Buttons[gr_screen.res][CANCEL_BUTTON].button.set_hotkey(-1);
+	CC_Buttons[gr_screen.res][BIND_BUTTON].button.reset_status();
+	CC_Buttons[gr_screen.res][SEARCH_MODE].button.reset_status();
+
+	Binding_mode = Search_mode = 0;
+	if (fail) {
+		gamesnd_play_iface(SND_GENERAL_FAIL);
+	} else {
+		gamesnd_play_iface(SND_USER_SELECT);
+	}
+}
+
+void control_config_do_frame(float frametime) {
+	const char *str;
+	char buf[256];
+	int i, j, k, w, x, y, z, line, conflict;
+	int font_height = gr_get_font_height();
+	int select_tease_line = -1;  // line mouse is down on, but won't be selected until button released
+	static float timer = 0.0f;
+	color *c;
+	static int bound_timestamp = 0;
+	static char bound_string[40];
+
+	timer += frametime;
+
+	if (Binding_mode) {
+		if (Cc_lines[Selected_line].cc_index & JOY_AXIS) {
+			int bind = 0;
+
+			z = Cc_lines[Selected_line].cc_index & ~JOY_AXIS;
+			i = control_config_detect_axis();
+			if (i >= 0) {
+				Axis_override = i;
+				bind = 1;
+			}
+
+			k = game_poll();
+			Ui_window.use_hack_to_get_around_stupid_problem_flag = 1;
+			Ui_window.process(0);
+
+			if (k == KEY_ESC) {
+				strcpy_s(bound_string, XSTR("Canceled", 206));
+				bound_timestamp = timestamp(2500);
+				control_config_do_cancel();
+
+			} else {
+				if (k == KEY_ENTER) {
+					bind = 1;
+				}
+
+				for (i = 0; i < JOY_TOTAL_BUTTONS; i++) {
+					if (joy_down_count(i, 1)) {
+						bind = 1;
+					}
+				}
+
+				if (bind) {
+					if (Axis_override >= 0) {
+						control_config_bind_axis(z, Axis_override);
+						strcpy_s(bound_string, Joy_axis_text[Axis_override]);
+						gr_force_fit_string(bound_string, 39, Conflict_wnd_coords[gr_screen.res][CONTROL_W_COORD]);
+						bound_timestamp = timestamp(2500);
+						control_config_conflict_check();
+						control_config_list_prepare();
+						control_config_do_cancel();
+
+					} else {
+						control_config_do_cancel(1);
+					}
+				}
+			}
+
+		} else {
+			if (help_overlay_active(Control_config_overlay_id)) {
+				CC_Buttons[gr_screen.res][HELP_BUTTON].button.reset_status();
+				Ui_window.set_ignore_gadgets(1);
+			}
+
+			k = game_poll();
+			Ui_window.use_hack_to_get_around_stupid_problem_flag = 1;
+			Ui_window.process(0);
+
+			if ((k > 0) || B1_JUST_RELEASED) {
+				if (help_overlay_active(Control_config_overlay_id)) {
+					help_overlay_set_state(Control_config_overlay_id, gr_screen.res, 0);
+					Ui_window.set_ignore_gadgets(0);
+					k = 0;
+				}
+			}
+
+			if (!help_overlay_active(Control_config_overlay_id)) {
+				Ui_window.set_ignore_gadgets(0);
+			}
+
+			if (k == KEY_ESC) {
+				strcpy_s(bound_string, XSTR("Canceled", 206));
+				bound_timestamp = timestamp(2500);
+				control_config_do_cancel();
+
+			} else {
+				switch (k & KEY_MASK) {
+				case KEY_LSHIFT:
+				case KEY_RSHIFT:
+				case KEY_LALT:
+				case KEY_RALT:
+					Last_key = k & KEY_MASK;
+					k = 0;
+					break;
+				}
+
+				if (Cc_lines[Selected_line].cc_index == BANK_WHEN_PRESSED || Cc_lines[Selected_line].cc_index == GLIDE_WHEN_PRESSED) {
+					if ((Last_key >= 0) && (k <= 0) && !keyd_pressed[Last_key]) {
+						k = Last_key;
+					}
+				}
+
+				if ((k > 0) && !Config_allowed[k & KEY_MASK]) {
+					popup(PF_USE_AFFIRMATIVE_ICON, 1, POPUP_OK, XSTR("That is a non-bindable key.  Please try again.", 207));
+					k = 0;
+				}
+
+				k &= (KEY_MASK | KEY_SHIFTED | KEY_ALTED);
+				if (k > 0) {
+					z = Cc_lines[Selected_line].cc_index;
+					Assert(!(z & JOY_AXIS));
+					control_config_bind_key(z, k);
+
+					strcpy_s(bound_string, textify_scancode(k));
+					gr_force_fit_string(bound_string, 39, Conflict_wnd_coords[gr_screen.res][CONTROL_W_COORD]);
+					bound_timestamp = timestamp(2500);
+					control_config_conflict_check();
+					control_config_list_prepare();
+					control_config_do_cancel();
+				}
+
+				for (i = 0; i < JOY_TOTAL_BUTTONS; i++) {
+					if (joy_down_count(i, 1)) {
+						z = Cc_lines[Selected_line].cc_index;
+						Assert(!(z & JOY_AXIS));
+						control_config_bind_joy(z, i);
+
+						strcpy_s(bound_string, Joy_button_text[i]);
+						gr_force_fit_string(bound_string, 39, Conflict_wnd_coords[gr_screen.res][CONTROL_W_COORD]);
+						bound_timestamp = timestamp(2500);
+						control_config_conflict_check();
+						control_config_list_prepare();
+						control_config_do_cancel();
+						break;
+					}
+				}
+
+				if (Bind_time + 375 < timer_get_milliseconds()) {
+					for (i = 0; i < NUM_BUTTONS; i++) {
+						if ((CC_Buttons[gr_screen.res][i].button.is_mouse_on()) && (CC_Buttons[gr_screen.res][i].button.enabled())) {
+							break;
+						}
+					}
+
+					if (i == NUM_BUTTONS) {  // no buttons pressed
+						for (i = 0; i < MOUSE_NUM_BUTTONS; i++) {
+							if (mouse_down(1 << i)) {
+								z = Cc_lines[Selected_line].cc_index;
+								Assert(!(z & JOY_AXIS));
+								control_config_bind_joy(z, i);
+
+								strcpy_s(bound_string, Joy_button_text[i]);
+								gr_force_fit_string(bound_string, 39, Conflict_wnd_coords[gr_screen.res][CONTROL_W_COORD]);
+								bound_timestamp = timestamp(2500);
+								control_config_conflict_check();
+								control_config_list_prepare();
+								control_config_do_cancel();
+								for (j = 0; j < NUM_BUTTONS; j++) {
+									CC_Buttons[gr_screen.res][j].button.reset();
+								}
+
+								break;
+							}
+						}
+					}
+				}
+			}
+		}
+
+	} else if (Search_mode) {
+		if (help_overlay_active(Control_config_overlay_id)) {
+			CC_Buttons[gr_screen.res][HELP_BUTTON].button.reset_status();
+			Ui_window.set_ignore_gadgets(1);
+		}
+
+		k = game_poll();
+		Ui_window.use_hack_to_get_around_stupid_problem_flag = 1;
+		Ui_window.process(0);
+
+		if ((k > 0) || B1_JUST_RELEASED) {
+			if (help_overlay_active(Control_config_overlay_id)) {
+				help_overlay_set_state(Control_config_overlay_id, gr_screen.res, 0);
+				Ui_window.set_ignore_gadgets(0);
+				k = 0;
+			}
+		}
+
+		if (!help_overlay_active(Control_config_overlay_id)) {
+			Ui_window.set_ignore_gadgets(0);
+		}
+
+		if (k == KEY_ESC) {
+			control_config_do_cancel();
+
+		} else {
+			if ((k > 0) && !Config_allowed[k & KEY_MASK]) {
+				k = 0;
+			}
+
+			k &= (KEY_MASK | KEY_SHIFTED | KEY_ALTED);
+			z = -1;
+			if (k > 0) {
+				for (i = 0; i < CCFG_MAX; i++) {
+					if (Control_config[i].key_id == k) {
+						z = i;
+						break;
+					}
+				}
+			}
+
+			for (i = 0; i < JOY_TOTAL_BUTTONS; i++) {
+				if (joy_down_count(i, 1)) {
+					j = i;
+					for (i = 0; i < CCFG_MAX; i++) { //-V535
+						if (Control_config[i].joy_id == j) {
+							z = i;
+							break;
+						}
+					}
+					break;
+				}
+			}
+
+			// check if not on enabled button
+			for (j = 0; j < NUM_BUTTONS; j++) {
+				if ((CC_Buttons[gr_screen.res][j].button.is_mouse_on()) && (CC_Buttons[gr_screen.res][j].button.enabled())) {
+					break;
+				}
+			}
+
+			if (j == NUM_BUTTONS) {  // no buttons pressed
+				for (j = 0; j < MOUSE_NUM_BUTTONS; j++) {
+					if (mouse_down(1 << j)) {
+						for (i = 0; i < CCFG_MAX; i++) {
+							if (Control_config[i].joy_id == j) {
+								z = i;
+								for (size_t buttonid = 0; buttonid < NUM_BUTTONS; buttonid++) {
+									CC_Buttons[gr_screen.res][buttonid].button.reset();
+								}
+								break;
+							}
+						}
+						break;
+					}
+				}
+			}
+
+			if (z >= 0) {
+				Tab = Control_config[z].tab;
+				control_config_list_prepare();
+				Selected_line = Scroll_offset = 0;
+				for (i = 0; i < Num_cc_lines; i++) {
+					if (Cc_lines[i].cc_index == z) {
+						Selected_line = i;
+						break;
+					}
+				}
+				while (!cc_line_query_visible(Selected_line)) {
+					Scroll_offset++;
+					Assert(Scroll_offset < Num_cc_lines);
+				}
+			}
+		}
+
+	} else {
+		z = Cc_lines[Selected_line].cc_index & JOY_AXIS;
+		CC_Buttons[gr_screen.res][ALT_TOGGLE].button.enable(!z);
+		CC_Buttons[gr_screen.res][SHIFT_TOGGLE].button.enable(!z);
+		CC_Buttons[gr_screen.res][INVERT_AXIS].button.enable(z);
+
+		if (!z) {
+			z = Cc_lines[Selected_line].cc_index;
+			k = Control_config[z].key_id;
+			if ((k == KEY_LALT) || (k == KEY_RALT) || (k == KEY_LSHIFT) || (k == KEY_RSHIFT)) {
+				CC_Buttons[gr_screen.res][ALT_TOGGLE].button.enable(0);
+				CC_Buttons[gr_screen.res][SHIFT_TOGGLE].button.enable(0);
+			}
+		}
+
+		CC_Buttons[gr_screen.res][UNDO_BUTTON].button.enable(Config_item_undo != NULL);
+
+		if (help_overlay_active(Control_config_overlay_id)) {
+			CC_Buttons[gr_screen.res][HELP_BUTTON].button.reset_status();
+			Ui_window.set_ignore_gadgets(1);
+		}
+
+		k = Ui_window.process();
+
+		if ((k > 0) || B1_JUST_RELEASED) {
+			if (help_overlay_active(Control_config_overlay_id)) {
+				help_overlay_set_state(Control_config_overlay_id, gr_screen.res, 0);
+				Ui_window.set_ignore_gadgets(0);
+				k = 0;
+			}
+		}
+
+		if (!help_overlay_active(Control_config_overlay_id)) {
+			Ui_window.set_ignore_gadgets(0);
+		}
+
+		switch (k) {
+		case KEY_DOWN:  // select next line
+			control_config_scroll_line_down();
+			break;
+
+		case KEY_UP:  // select previous line
+			control_config_scroll_line_up();
+			break;
+
+		case KEY_SHIFTED | KEY_TAB:  // activate previous tab
+			Tab--;
+			if (Tab < 0) {
+				Tab = NUM_TABS - 1;
+			}
+
+			Scroll_offset = Selected_line = 0;
+			control_config_list_prepare();
+			gamesnd_play_iface(SND_SCREEN_MODE_PRESSED);
+			break;
+
+		case KEY_TAB:  // activate next tab
+			Tab++;
+			if (Tab >= NUM_TABS) {
+				Tab = 0;
+			}
+
+			Scroll_offset = Selected_line = 0;
+			control_config_list_prepare();
+			gamesnd_play_iface(SND_SCREEN_MODE_PRESSED);
+			break;
+
+		case KEY_LEFT:
+			Selected_item--;
+			if (Selected_item == -2) {
+				Selected_item = 1;
+				if (Cc_lines[Selected_line].jw < 1) {
+					Selected_item = 0;
+					if (Cc_lines[Selected_line].kw < 1) {
+						Selected_item = -1;
+					}
+				}
+			}
+
+			gamesnd_play_iface(SND_SCROLL);
+			break;
+
+		case KEY_RIGHT:
+			Selected_item++;
+			if ((Selected_item == 1) && (Cc_lines[Selected_line].jw < 1)) {
+				Selected_item = -1;
+			} else if (!Selected_item && (Cc_lines[Selected_line].kw < 1)) {
+				Selected_item = -1;
+			} else if (Selected_item > 1) {
+				Selected_item = -1;
+			}
+			gamesnd_play_iface(SND_SCROLL);
+			break;
+
+		case KEY_BACKSP:  // undo
+			control_config_undo_last();
+			break;
+
+		case KEY_ESC:
+			control_config_cancel_exit();
+			break;
+		}	// end switch
+	}
+
+	for (i = 0; i < NUM_BUTTONS; i++) {
+		if (CC_Buttons[gr_screen.res][i].button.pressed()) {
+			control_config_button_pressed(i);
+		}
+	}
+
+	for (i = 0; i < LIST_BUTTONS_MAX; i++) {
+		if (List_buttons[i].is_mouse_on()) {
+			select_tease_line = i + Scroll_offset;
+		}
+
+		if (List_buttons[i].pressed()) {
+			Selected_line = i + Scroll_offset;
+			Selected_item = -1;
+			List_buttons[i].get_mouse_pos(&x, &y);
+			if ((x >= Cc_lines[Selected_line].kx) && (x < Cc_lines[Selected_line].kx + Cc_lines[Selected_line].kw)) {
+				Selected_item = 0;
+			}
+
+			if ((x >= Cc_lines[Selected_line].jx) && (x < Cc_lines[Selected_line].jx + Cc_lines[Selected_line].jw)) {
+				Selected_item = 1;
+			}
+
+			gamesnd_play_iface(SND_USER_SELECT);
+		}
+
+		if (List_buttons[i].double_clicked()) {
+			control_config_do_bind();
+		}
+	}
+
+	GR_MAYBE_CLEAR_RES(Background_bitmap);
+	if (Background_bitmap >= 0) {
+		gr_set_bitmap(Background_bitmap);
+		gr_bitmap(0, 0, GR_RESIZE_MENU);
+	}
+
+	// highlight tab with conflict
+	Ui_window.draw();
+	for (i = z = 0; i < NUM_TABS; i++) {
+		if (Conflicts_tabs[i]) {
+			CC_Buttons[gr_screen.res][i].button.draw_forced(4);
+			z++;
+		}
+	}
+
+	if (z) {
+		// maybe switch from bright to normal
+		if ((Conflict_stamp == -1) || timestamp_elapsed(Conflict_stamp)) {
+			Conflict_bright = !Conflict_bright;
+
+			Conflict_stamp = timestamp(CONFLICT_FLASH_TIME);
+		}
+
+		// set color and font
+		gr_set_font(FONT2);
+		if (Conflict_bright) {
+			gr_set_color_fast(&Color_bright_red);
+		} else {
+			gr_set_color_fast(&Color_red);
+		}
+
+		// setup the conflict string
+		char conflict_str[512] = "";
+		strncpy(conflict_str, XSTR("Conflict!", 205), 511);
+		int sw, sh;
+		gr_get_string_size(&sw, &sh, conflict_str);
+
+		gr_string((gr_screen.max_w / 2) - (sw / 2), Conflict_warning_coords[gr_screen.res][1], conflict_str, GR_RESIZE_MENU);
+
+		gr_set_font(FONT1);
+	} else {
+		// might as well always reset the conflict stamp
+		Conflict_stamp = -1;
+	}
+
+	for (i = 0; i < NUM_TABS; i++) {
+		if (CC_Buttons[gr_screen.res][i].button.button_down()) {
+			break;
+		}
+	}
+
+	if (i == NUM_TABS) {
+		CC_Buttons[gr_screen.res][Tab].button.draw_forced(2);
+	}
+
+	if (Search_mode) {
+		CC_Buttons[gr_screen.res][SEARCH_MODE].button.draw_forced(2);
+	}
+
+	if (Selected_line >= 0) {
+		z = Cc_lines[Selected_line].cc_index;
+		if (z & JOY_AXIS) {
+			if (Invert_axis[z & ~JOY_AXIS]) {
+				CC_Buttons[gr_screen.res][INVERT_AXIS].button.draw_forced(2);
+			}
+
+		} else {
+			z = Control_config[z].key_id;
+			if (z >= 0) {
+				if (z & KEY_SHIFTED) {
+					CC_Buttons[gr_screen.res][SHIFT_TOGGLE].button.draw_forced(2);
+				}
+				if (z & KEY_ALTED) {
+					CC_Buttons[gr_screen.res][ALT_TOGGLE].button.draw_forced(2);
+				}
+			}
+		}
+	}
+
+	if (Binding_mode) {
+		CC_Buttons[gr_screen.res][BIND_BUTTON].button.draw_forced(2);
+	}
+
+	z = Cc_lines[Selected_line].cc_index;
+	x = Conflict_wnd_coords[gr_screen.res][CONTROL_X_COORD] + Conflict_wnd_coords[gr_screen.res][CONTROL_W_COORD] / 2;
+	y = Conflict_wnd_coords[gr_screen.res][CONTROL_Y_COORD] + Conflict_wnd_coords[gr_screen.res][CONTROL_H_COORD] / 2;
+	if (Binding_mode) {
+		int t;
+
+		t = (int) (timer * 3);
+		if (t % 2) {
+			gr_set_color_fast(&Color_text_normal);
+			gr_get_string_size(&w, NULL, XSTR("?", 208));
+			gr_printf_menu(x - w / 2, y - font_height / 2, XSTR("?", 208));
+		}
+
+	} else if (!(z & JOY_AXIS) && ((Conflicts[z].key >= 0) || (Conflicts[z].joy >= 0))) {
+		i = Conflicts[z].key;
+		if (i < 0) {
+			i = Conflicts[z].joy;
+		}
+
+		gr_set_color_fast(&Color_text_normal);
+		str = XSTR("Control conflicts with:", 209);
+		gr_get_string_size(&w, NULL, str);
+		gr_printf_menu(x - w / 2, y - font_height, str);
+
+		if (Control_config[i].hasXSTR) {
+			strcpy_s(buf, XSTR(Control_config[i].text, CONTROL_CONFIG_XSTR + i));
+		} else {
+			strcpy_s(buf, Control_config[i].text);
+		}
+
+		gr_force_fit_string(buf, 255, Conflict_wnd_coords[gr_screen.res][CONTROL_W_COORD]);
+		gr_get_string_size(&w, NULL, buf);
+		gr_printf_menu(x - w / 2, y, buf);
+
+	} else if (*bound_string) {
+		gr_set_color_fast(&Color_text_normal);
+		gr_get_string_size(&w, NULL, bound_string);
+		gr_printf_menu(x - w / 2, y - font_height / 2, bound_string);
+		if (timestamp_elapsed(bound_timestamp)) {
+			*bound_string = 0;
+		}
+	}
+
+	if (Cc_lines[Num_cc_lines - 1].y + font_height > Cc_lines[Scroll_offset].y + Control_list_coords[gr_screen.res][CONTROL_H_COORD]) {
+		gr_set_color_fast(&Color_white);
+		gr_printf_menu(Control_more_coords[gr_screen.res][CONTROL_X_COORD], Control_more_coords[gr_screen.res][CONTROL_Y_COORD], XSTR("More...", 210));
+	}
+
+	conflict = 0;
+	line = Scroll_offset;
+	while (cc_line_query_visible(line)) {
+		z = Cc_lines[line].cc_index;
+		y = Control_list_coords[gr_screen.res][CONTROL_Y_COORD] + Cc_lines[line].y - Cc_lines[Scroll_offset].y;
+
+		List_buttons[line - Scroll_offset].update_dimensions(Control_list_coords[gr_screen.res][CONTROL_X_COORD], y, Control_list_coords[gr_screen.res][CONTROL_W_COORD], font_height);
+		List_buttons[line - Scroll_offset].enable(!Binding_mode);
+
+		Cc_lines[line].kw = Cc_lines[line].jw = 0;
+
+		if (line == Selected_line) {
+			c = &Color_text_selected;
+		} else if (line == select_tease_line) {
+			c = &Color_text_subselected;
+		} else {
+			c = &Color_text_normal;
+		}
+
+		gr_set_color_fast(c);
+		if (Cc_lines[line].label) {
+			strcpy_s(buf, Cc_lines[line].label);
+			gr_force_fit_string(buf, 255, Control_list_ctrl_w[gr_screen.res]);
+			gr_printf_menu(Control_list_coords[gr_screen.res][CONTROL_X_COORD], y, buf);
+		}
+
+		if (!(z & JOY_AXIS)) {
+			k = Control_config[z].key_id;
+			j = Control_config[z].joy_id;
+			x = Control_list_key_x[gr_screen.res];
+			*buf = 0;
+
+			if ((k < 0) && (j < 0)) {
+				gr_set_color_fast(&Color_grey);
+				gr_printf_menu(x, y, XSTR("None", 211));
+
+			} else {
+				if (k >= 0) {
+					strcpy_s(buf, textify_scancode(k));
+					if (Conflicts[z].key >= 0) {
+						if (c == &Color_text_normal)
+							gr_set_color_fast(&Color_text_error);
+						else {
+							gr_set_color_fast(&Color_text_error_hi);
+							conflict++;
+						}
+
+					} else if (Selected_item == 1) {
+						gr_set_color_fast(&Color_text_normal);
+
+					} else {
+						gr_set_color_fast(c);
+					}
+
+					gr_printf_menu(x, y, buf);
+
+					Cc_lines[line].kx = x - Control_list_coords[gr_screen.res][CONTROL_X_COORD];
+					gr_get_string_size(&w, NULL, buf);
+					Cc_lines[line].kw = w;
+					x += w;
+
+					if (j >= 0) {
+						gr_set_color_fast(&Color_text_normal);
+						gr_printf_menu(x, y, XSTR(", ", 212));
+						gr_get_string_size(&w, NULL, XSTR(", ", 212));
+						x += w;
+					}
+				}
+
+				if (j >= 0) {
+					strcpy_s(buf, Joy_button_text[j]);
+					if (Conflicts[z].joy >= 0) {
+						if (c == &Color_text_normal) {
+							gr_set_color_fast(&Color_text_error);
+						} else {
+							gr_set_color_fast(&Color_text_error_hi);
+							conflict++;
+						}
+
+					} else if (!Selected_item) {
+						gr_set_color_fast(&Color_text_normal);
+
+					} else {
+						gr_set_color_fast(c);
+					}
+
+					gr_force_fit_string(buf, 255, Control_list_key_w[gr_screen.res] + Control_list_key_x[gr_screen.res] - x);
+					gr_printf_menu(x, y, buf);
+
+					Cc_lines[line].jx = x - Control_list_coords[gr_screen.res][CONTROL_X_COORD];
+					gr_get_string_size(&Cc_lines[line].jw, NULL, buf);
+				}
+			}
+
+		} else {
+			x = Control_list_key_x[gr_screen.res];
+			j = Axis_map_to[z & ~JOY_AXIS];
+			if (Binding_mode && (line == Selected_line)) {
+				j = Axis_override;
+			}
+
+			if (j < 0) {
+				gr_set_color_fast(&Color_grey);
+				gr_printf_menu(x, y, XSTR("None", 211));
+
+			} else {
+				if (Conflicts_axes[z & ~JOY_AXIS] >= 0) {
+					if (c == &Color_text_normal) {
+						gr_set_color_fast(&Color_text_error);
+
+					} else {
+						gr_set_color_fast(&Color_text_error_hi);
+						conflict++;
+					}
+
+				} else if (!Selected_item) {
+					gr_set_color_fast(&Color_text_normal);
+
+				} else {
+					gr_set_color_fast(c);
+				}
+
+				gr_string(x, y, Joy_axis_text[j], GR_RESIZE_MENU);
+			}
+		}
+
+		line++;
+	}
+
+	CC_Buttons[gr_screen.res][CLEAR_OTHER_BUTTON].button.enable(conflict);
+
+	i = line - Scroll_offset;
+	while (i < LIST_BUTTONS_MAX) {
+		List_buttons[i++].disable();
+	}
+
+	// If multiple controls presets are provided, display which one is in use
+	if (Control_config_presets.size() > 1) {
+		SCP_string preset_str;
+		int matching_preset = -1;
+
+		for (i = 0; i < (int) Control_config_presets.size(); i++) {
+			bool this_preset_matches = true;
+			config_item *this_preset = Control_config_presets[i];
+
+			for (j = 0; j < CCFG_MAX; j++) {
+				if (!Control_config[j].disabled && Control_config[j].key_id != this_preset[j].key_default) {
+					this_preset_matches = false;
+					break;
+				}
+			}
+
+			if (this_preset_matches) {
+				matching_preset = i;
+				break;
+			}
+		}
+
+		if (matching_preset >= 0) {
+			sprintf(preset_str, "Controls: %s", Control_config_preset_names[matching_preset].c_str());
+		} else {
+			sprintf(preset_str, "Controls: custom");
+
+		}
+
+		gr_get_string_size(&w, NULL, preset_str.c_str());
+		gr_set_color_fast(&Color_text_normal);
+
+		if (gr_screen.res == GR_640) {
+			gr_string(16, (24 - font_height) / 2, preset_str.c_str(), GR_RESIZE_MENU);
+		} else {
+			gr_string(24, (40 - font_height) / 2, preset_str.c_str(), GR_RESIZE_MENU);
+		}
+	}
+
+	// blit help overlay if active
+	help_overlay_maybe_blit(Control_config_overlay_id, gr_screen.res);
+
+	gr_flip();
+}
+
+static int control_config_do_reset() {
+	int i, j, total = 0;
+	config_item_undo *ptr;
+	config_item item;
+	config_item *preset;
+	bool cycling_presets = false;
+
+	// If there are presets, then we'll cycle to the next preset and reset to that
+	if (Control_config_presets.size() >= 1) {
+		cycling_presets = true;
+
+		if (++Defaults_cycle_pos >= Control_config_presets.size())
+			Defaults_cycle_pos = 0;
+
+		preset = Control_config_presets[Defaults_cycle_pos];
+	} else {
+		// If there are no presets, then we'll always reset to the hardcoded defaults
+		preset = Control_config;
+	}
+
+	// first, determine how many bindings need to be changed
+	for (i = 0; i < CCFG_MAX; i++) {
+		if ((Control_config[i].key_id != preset[i].key_default) || (Control_config[i].joy_id != preset[i].joy_default)) {
+			total++;
+		}
+	}
+
+	for (i = 0; i < NUM_JOY_AXIS_ACTIONS; i++) {
+		if ((Axis_map_to[i] != control_config_axis_default(i)) || (Invert_axis[i] != Invert_axis_defaults[i])) {
+			total++;
+		}
+	}
+
+	if (!total && !cycling_presets) {
+		gamesnd_play_iface(SND_GENERAL_FAIL);
+		return -1;
+	}
+
+	// now, back up the old bindings so we can undo if we want to
+	ptr = get_undo_block(total);
+	for (i = j = 0; i < CCFG_MAX; i++) {
+		if ((Control_config[i].key_id != preset[i].key_default) || (Control_config[i].joy_id != preset[i].joy_default)) {
+			ptr->index[j] = i;
+			ptr->list[j] = Control_config[i];
+			j++;
+		}
+	}
+
+	for (i = 0; i < NUM_JOY_AXIS_ACTIONS; i++) {
+		if ((Axis_map_to[i] != control_config_axis_default(i)) || (Invert_axis[i] != Invert_axis_defaults[i])) {
+			memset(&item, 0, sizeof(config_item));
+
+			item.joy_id = (short) Axis_map_to[i];
+			item.used = Invert_axis[i];
+
+			ptr->index[j] = i | JOY_AXIS;
+			ptr->list[j] = item;
+			j++;
+		}
+	}
+
+	Assert(j == total);
+
+	if (cycling_presets)
+		control_config_reset_defaults(Defaults_cycle_pos);
+	else
+		control_config_reset_defaults();
+
+	control_config_conflict_check();
+	control_config_list_prepare();
+	gamesnd_play_iface(SND_RESET_PRESSED);
+	return 0;
+}
+
+static void control_config_do_search() {
+	int i;
+
+	for (i = 0; i < NUM_BUTTONS; i++) {
+		if (i != CANCEL_BUTTON) {
+			CC_Buttons[gr_screen.res][i].button.reset_status();
+			CC_Buttons[gr_screen.res][i].button.disable();
+		}
+	}
+
+	CC_Buttons[gr_screen.res][CANCEL_BUTTON].button.enable();
+	CC_Buttons[gr_screen.res][CANCEL_BUTTON].button.set_hotkey(KEY_ESC);
+
+	for (i = 0; i < JOY_TOTAL_BUTTONS; i++) {
+		joy_down_count(i, 1);  // clear checking status of all joystick buttons
+	}
+
+	Binding_mode = 0;
+	Search_mode = 1;
+	Last_key = -1;
+	gamesnd_play_iface(SND_USER_SELECT);
+}
+
+static int control_config_handle_conflict() {
+	return 0;
+}
+
+void control_config_init() {
+	int i;
+	ui_button_info *b;
+
+	// make backup of all controls
+	for (i = 0; i < CCFG_MAX; i++) {
+		Control_config_backup[i] = Control_config[i];
+	}
+
+	Defaults_cycle_pos = 0;
+
+	common_set_interface_palette(NOX("ControlConfigPalette"));  // set the interface palette
+	Ui_window.create(0, 0, gr_screen.max_w_unscaled, gr_screen.max_h_unscaled, 0);
+	Ui_window.set_mask_bmap(Conflict_background_bitmap_mask_fname[gr_screen.res]);
+	Ui_window.tooltip_handler = control_config_tooltip_handler;
+
+	// load in help overlay bitmap	
+	Control_config_overlay_id = help_overlay_get_index(CONTROL_CONFIG_OVERLAY);
+	help_overlay_set_state(Control_config_overlay_id, gr_screen.res, 0);
+
+	// reset conflict flashing
+	Conflict_stamp = -1;
+
+	for (i = 0; i < NUM_BUTTONS; i++) {
+		b = &CC_Buttons[gr_screen.res][i];
+
+		if (b->hotspot < 0) {  // temporary
+			b->button.create(&Ui_window, NOX("Clear other"), b->x, b->y, 150, 30, 0, 1);  // temporary
+			b->button.set_highlight_action(common_play_highlight_sound);
+			continue;
+		}
+
+		b->button.create(&Ui_window, "", b->x, b->y, 60, 30, ((i == SCROLL_UP_BUTTON) || (i == SCROLL_DOWN_BUTTON)), 1);
+
+		// set up callback for when a mouse first goes over a button
+		b->button.set_highlight_action(common_play_highlight_sound);
+		if (i < 4) {
+			b->button.set_bmaps(b->filename, 5, 1);		// a bit of a hack here, but buttons 0-3 need 4 frames loaded
+		} else {
+			b->button.set_bmaps(b->filename);
+		}
+		b->button.link_hotspot(b->hotspot);
+	}
+
+	// create all text
+	for (i = 0; i < CC_NUM_TEXT; i++) {
+		Ui_window.add_XSTR(&CC_text[gr_screen.res][i]);
+	}
+
+	for (i = 0; i < LIST_BUTTONS_MAX; i++) {
+		List_buttons[i].create(&Ui_window, "", 0, 0, 60, 30, 0, 1);
+		List_buttons[i].hide();
+		List_buttons[i].disable();
+	}
+
+	// set up hotkeys for buttons so we draw the correct animation frame when a key is pressed
+	CC_Buttons[gr_screen.res][SCROLL_UP_BUTTON].button.set_hotkey(KEY_PAGEUP);
+	CC_Buttons[gr_screen.res][SCROLL_DOWN_BUTTON].button.set_hotkey(KEY_PAGEDOWN);
+	CC_Buttons[gr_screen.res][BIND_BUTTON].button.set_hotkey(KEY_ENTER);
+	CC_Buttons[gr_screen.res][CLEAR_OTHER_BUTTON].button.set_hotkey(KEY_CTRLED | KEY_DELETE);
+	CC_Buttons[gr_screen.res][UNDO_BUTTON].button.set_hotkey(KEY_CTRLED | KEY_Z);
+	CC_Buttons[gr_screen.res][CLEAR_BUTTON].button.set_hotkey(KEY_DELETE);
+	CC_Buttons[gr_screen.res][ACCEPT_BUTTON].button.set_hotkey(KEY_CTRLED | KEY_ENTER);
+	CC_Buttons[gr_screen.res][HELP_BUTTON].button.set_hotkey(KEY_F1);
+	CC_Buttons[gr_screen.res][RESET_BUTTON].button.set_hotkey(KEY_CTRLED | KEY_R);
+	CC_Buttons[gr_screen.res][INVERT_AXIS].button.set_hotkey(KEY_I);
+
+	CC_Buttons[gr_screen.res][CANCEL_BUTTON].button.disable();
+	CC_Buttons[gr_screen.res][CLEAR_OTHER_BUTTON].button.disable();
+
+	Background_bitmap = bm_load(Conflict_background_bitmap_fname[gr_screen.res]);
+
+	Scroll_offset = Selected_line = 0;
+	Config_item_undo = NULL;
+	control_config_conflict_check();
+
+	// setup strings					
+	Joy_axis_action_text[0] = vm_strdup(XSTR("Turn (Yaw) Axis", 1016));
+	Joy_axis_action_text[1] = vm_strdup(XSTR("Pitch Axis", 1017));
+	Joy_axis_action_text[2] = vm_strdup(XSTR("Bank Axis", 1018));
+	Joy_axis_action_text[3] = vm_strdup(XSTR("Absolute Throttle Axis", 1019));
+	Joy_axis_action_text[4] = vm_strdup(XSTR("Relative Throttle Axis", 1020));
+	Joy_axis_text[0] = vm_strdup(XSTR("Joystick/Mouse X Axis", 1021));
+	Joy_axis_text[1] = vm_strdup(XSTR("Joystick/Mouse Y Axis", 1022));
+	Joy_axis_text[2] = vm_strdup(XSTR("Joystick Z Axis", 1023));
+	Joy_axis_text[3] = vm_strdup(XSTR("Joystick rX Axis", 1024));
+	Joy_axis_text[4] = vm_strdup(XSTR("Joystick rY Axis", 1025));
+	Joy_axis_text[5] = vm_strdup(XSTR("Joystick rZ Axis", 1026));
+	Mouse_button_text[0] = vm_strdup("");
+	Mouse_button_text[1] = vm_strdup(XSTR("Left Button", 1027));
+	Mouse_button_text[2] = vm_strdup(XSTR("Right Button", 1028));
+	Mouse_button_text[3] = vm_strdup(XSTR("Mid Button", 1029));
+	Mouse_button_text[4] = vm_strdup("");
+	Mouse_axis_text[0] = vm_strdup(XSTR("L/R", 1030));
+	Mouse_axis_text[1] = vm_strdup(XSTR("U/B", 1031));
+	Invert_text[0] = vm_strdup(XSTR("N", 1032));
+	Invert_text[1] = vm_strdup(XSTR("Y", 1033));
+
+	control_config_list_prepare();
+}
+
+static void control_config_list_prepare() {
+	int j, y, z;
+	int font_height = gr_get_font_height();
+
+	Num_cc_lines = y = z = 0;
+	while (z < CCFG_MAX) {
+		if (Control_config[z].tab == Tab && !Control_config[z].disabled) {
+			if (Control_config[z].hasXSTR) {
+				Cc_lines[Num_cc_lines].label = XSTR(Control_config[z].text, CONTROL_CONFIG_XSTR + z);
+			} else {
+				Cc_lines[Num_cc_lines].label = Control_config[z].text;
+			}
+
+			Cc_lines[Num_cc_lines].cc_index = z;
+			Cc_lines[Num_cc_lines++].y = y;
+			y += font_height + 2;
+		}
+
+		z++;
+	}
+
+	if (Tab == SHIP_TAB) {
+		for (j = 0; j < NUM_JOY_AXIS_ACTIONS; j++) {
+			Cc_lines[Num_cc_lines].label = Joy_axis_action_text[j];
+			Cc_lines[Num_cc_lines].cc_index = j | JOY_AXIS;
+			Cc_lines[Num_cc_lines++].y = y;
+			y += font_height + 2;
+		}
+	}
+}
+
+static int control_config_remove_binding() {
+	int z;
+	config_item_undo *ptr;
+
+	if (Selected_line < 0) {
+		gamesnd_play_iface(SND_GENERAL_FAIL);
+		return -1;
+	}
+
+	z = Cc_lines[Selected_line].cc_index;
+	if (z & JOY_AXIS) {
+		z &= ~JOY_AXIS;
+		if (Axis_map_to[z] < 0) {
+			gamesnd_play_iface(SND_GENERAL_FAIL);
+			return -1;
+		}
+
+		control_config_save_axis_undo(z);
+		Axis_map_to[z] = -1;
+		control_config_conflict_check();
+		control_config_list_prepare();
+		gamesnd_play_iface(SND_USER_SELECT);
+		Selected_item = -1;
+		return 0;
+	}
+
+	if ((Control_config[z].joy_id < 0) && (Control_config[z].key_id < 0)) {
+		gamesnd_play_iface(SND_GENERAL_FAIL);
+		return -1;
+	}
+
+	ptr = get_undo_block(1);
+	ptr->index[0] = z;
+	ptr->list[0] = Control_config[z];
+
+	if (Selected_item && (Control_config[z].joy_id >= 0)) {  // if not just key selected (which would be 0)
+		Control_config[z].joy_id = (short) -1;
+	}
+
+	if ((Selected_item != 1) && (Control_config[z].key_id >= 0)) {  // if not just joy button selected (1)
+		Control_config[z].key_id = (short) -1;
+	}
+
+	control_config_conflict_check();
+	control_config_list_prepare();
+	gamesnd_play_iface(SND_USER_SELECT);
+	Selected_item = -1;
+	return 0;
+}
+
+void control_config_reset_defaults(int presetnum) {
+	int i;
+	config_item *preset;
+
+	if (presetnum >= 0)
+		preset = Control_config_presets[presetnum];
+	else
+		preset = Control_config;
+
+	// Reset keyboard defaults
+	for (i = 0; i < CCFG_MAX; i++) {
+		// Note that key_default and joy_default are NOT overwritten here;
+		// they should retain the values of the first preset because
+		// for example the key-pressed SEXP works off the defaults of the first preset
+		Control_config[i].key_id = preset[i].key_default;
+		Control_config[i].joy_id = preset[i].joy_default;
+		Control_config[i].tab = preset[i].tab;
+		Control_config[i].hasXSTR = preset[i].hasXSTR;
+		Control_config[i].type = preset[i].type;
+		Control_config[i].disabled = preset[i].disabled;
+	}
+
+	for (i = 0; i < NUM_JOY_AXIS_ACTIONS; i++) {
+		Axis_map_to[i] = control_config_axis_default(i);
+		Invert_axis[i] = Invert_axis_defaults[i];
+	}
+}
+
+static void control_config_save_axis_undo(int axis) {
+	config_item_undo *ptr;
+	config_item item;
+
+	memset(&item, 0, sizeof(config_item));
+
+	item.joy_id = (short) Axis_map_to[axis];
+	item.used = Invert_axis[axis];
+
+	ptr = get_undo_block(1);
+	ptr->index[0] = axis | JOY_AXIS;
+	ptr->list[0] = item;
+}
+
+static void control_config_scroll_line_down() {
+	if (Selected_line < Num_cc_lines - 1) {
+		Selected_line++;
+		Assert(Selected_line > Scroll_offset);
+		while (!cc_line_query_visible(Selected_line)) {
+			Scroll_offset++;
+		}
+
+		Selected_item = -1;
+		gamesnd_play_iface(SND_SCROLL);
+
+	} else {
+		gamesnd_play_iface(SND_GENERAL_FAIL);
+	}
+}
+
+static void control_config_scroll_line_up() {
+	if (Selected_line) {
+		Selected_line--;
+		if (Selected_line < Scroll_offset) {
+			Scroll_offset = Selected_line;
+		}
+
+		Selected_item = -1;
+		gamesnd_play_iface(SND_SCROLL);
+
+	} else {
+		gamesnd_play_iface(SND_GENERAL_FAIL);
+	}
+}
+
+static void control_config_scroll_screen_down() {
+	if (Cc_lines[Num_cc_lines - 1].y + gr_get_font_height() > Cc_lines[Scroll_offset].y + Control_list_coords[gr_screen.res][CONTROL_H_COORD]) {
+		Scroll_offset++;
+		while (!cc_line_query_visible(Selected_line)) {
+			Selected_line++;
+			Assert(Selected_line < Num_cc_lines);
+		}
+
+		Selected_item = -1;
+		gamesnd_play_iface(SND_SCROLL);
+
+	} else {
+		gamesnd_play_iface(SND_GENERAL_FAIL);
+	}
+}
+
+static void control_config_scroll_screen_up() {
+	if (Scroll_offset) {
+		Scroll_offset--;
+		Assert(Selected_line > Scroll_offset);
+		while (!cc_line_query_visible(Selected_line)) {
+			Selected_line--;
+		}
+
+		Selected_item = -1;
+		gamesnd_play_iface(SND_SCROLL);
+
+	} else {
+		gamesnd_play_iface(SND_GENERAL_FAIL);
+	}
+}
+
+static void control_config_toggle_invert() {
+	int z;
+
+	z = Cc_lines[Selected_line].cc_index;
+	Assert(z & JOY_AXIS);
+	z &= ~JOY_AXIS;
+	control_config_save_axis_undo(z);
+	Invert_axis[z] = !Invert_axis[z];
+}
+
+static void control_config_toggle_modifier(int bit) {
+	int k, z;
+
+	z = Cc_lines[Selected_line].cc_index;
+	Assert(!(z & JOY_AXIS));
+	k = Control_config[z].key_id;
+	if (k < 0) {
+		gamesnd_play_iface(SND_GENERAL_FAIL);
+		return;
+	}
+
+	control_config_bind_key(z, k ^ bit);
+	control_config_conflict_check();
+	gamesnd_play_iface(SND_USER_SELECT);
+}
+
+static const char *control_config_tooltip_handler(const char *str) {
+	int i;
+
+	if (!stricmp(str, NOX("@conflict"))) {
+		for (i = 0; i < NUM_TABS; i++) {
+			if (Conflicts_tabs[i]) {
+				return XSTR("Conflict!", 205);
+			}
+		}
+	}
+
+	return NULL;
+}
+
+static int control_config_undo_last() {
+	int i, z, tab;
+
+	if (!Config_item_undo) {
+		gamesnd_play_iface(SND_GENERAL_FAIL);
+		return -1;
+	}
+
+	if (Config_item_undo->reset_to_preset > -1) {
+		control_config_reset_defaults(Config_item_undo->reset_to_preset);
+	} else {
+		if (Config_item_undo->index[0] & JOY_AXIS) {
+			tab = SHIP_TAB;
+		} else {
+			tab = Control_config[Config_item_undo->index[0]].tab;
+		}
+
+		for (i = 1; i < Config_item_undo->size; i++) {
+			if (Config_item_undo->index[i] & JOY_AXIS) {
+				if (tab != SHIP_TAB) {
+					tab = -1;
+				}
+
+			} else {
+				if (Control_config[Config_item_undo->index[i]].tab != tab) {
+					tab = -1;
+				}
+			}
+		}
+
+		if (tab >= 0) {
+			Tab = tab;
+		}
+
+		for (i = 0; i < Config_item_undo->size; i++) {
+			z = Config_item_undo->index[i];
+			if (z & JOY_AXIS) {
+				config_item *ptr;
+
+				z &= ~JOY_AXIS;
+				ptr = &Config_item_undo->list[i];
+				Axis_map_to[z] = ptr->joy_id;
+				Invert_axis[z] = ptr->used;
+
+			} else {
+				Control_config[z] = Config_item_undo->list[i];
+			}
+		}
+	}
+
+	free_undo_block();
+	control_config_conflict_check();
+	control_config_list_prepare();
+	gamesnd_play_iface(SND_USER_SELECT);
+	return 0;
+}
+
+void control_get_axes_readings(int *h, int *p, int *b, int *ta, int *tr) {
+	int axes_values[JOY_NUM_AXES];
+
+	joystick_read_raw_axis(JOY_NUM_AXES, axes_values);
+
+	//	joy_get_scaled_reading will return a value represents the joystick pos from -1 to +1 (fixed point)
+	*h = 0;
+	if (Axis_map_to[0] >= 0) {
+		*h = joy_get_scaled_reading(axes_values[Axis_map_to[0]], Axis_map_to[0]);
+	}
+
+	*p = 0;
+	if (Axis_map_to[1] >= 0) {
+		*p = joy_get_scaled_reading(axes_values[Axis_map_to[1]], Axis_map_to[1]);
+	}
+
+	*b = 0;
+	if (Axis_map_to[2] >= 0) {
+		*b = joy_get_scaled_reading(axes_values[Axis_map_to[2]], Axis_map_to[2]);
+	}
+
+	*ta = 0;
+	if (Axis_map_to[3] >= 0) {
+		*ta = joy_get_unscaled_reading(axes_values[Axis_map_to[3]], Axis_map_to[3]);
+	}
+
+	*tr = 0;
+	if (Axis_map_to[4] >= 0) {
+		*tr = joy_get_scaled_reading(axes_values[Axis_map_to[4]], Axis_map_to[4]);
+	}
+
+	if (Invert_axis[0]) {
+		*h = -(*h);
+	}
+	if (Invert_axis[1]) {
+		*p = -(*p);
+	}
+	if (Invert_axis[2]) {
+		*b = -(*b);
+	}
+	if (Invert_axis[3]) {
+		*ta = F1_0 - *ta;
+	}
+	if (Invert_axis[4]) {
+		*tr = -(*tr);
+	}
+
+	return;
+}
+
+void control_used(int id) {
+	// if we have set this key to be ignored, ignore it
+	if (Ignored_keys[id]) {
+		return;
+	}
+
+	// This check needs to be done because the control code might call this function more than once per frame,
+	// and we don't want to run the hooks more than once per frame
+	if (Control_config[id].used < Last_frame_timestamp) {
+		if (!Control_config[id].continuous_ongoing) {
+			Script_system.SetHookVar("Action", 's', Control_config[id].text);
+			Script_system.RunCondition(CHA_ONACTION, '\0', NULL, NULL, id);
+			Script_system.RemHookVar("Action");
+
+			if (Control_config[id].type == CC_TYPE_CONTINUOUS)
+				Control_config[id].continuous_ongoing = true;
+		}
+
+		Control_config[id].used = timestamp();
+	}
+}
+
+static void free_undo_block() {
+	config_item_undo *ptr;
+
+	ptr = Config_item_undo;
+	if (!ptr) {
+		return;
+	}
+
+	Config_item_undo = ptr->next;
+	if (ptr->size) {
+		vm_free(ptr->list);
+		vm_free(ptr->index);
+	}
+
+	vm_free(ptr);
+}
+
+static config_item_undo *get_undo_block(int size) {
+	config_item_undo *ptr;
+
+	ptr = (config_item_undo *) vm_malloc(sizeof(config_item_undo));
+	Assert(ptr);
+	ptr->next = Config_item_undo;
+	Config_item_undo = ptr;
+
+	ptr->size = size;
+	if (size) {
+		ptr->index = (int *) vm_malloc(sizeof(int) * size);
+		Assert(ptr->index);
+		ptr->list = (config_item *) vm_malloc(sizeof(config_item) * size);
+		Assert(ptr->list);
+
+	} else {
+		ptr->index = NULL;
+		ptr->list = NULL;
+	}
+
+	ptr->reset_to_preset = -1;
+
+	return ptr;
+}
 
 static int joy_get_unscaled_reading(int raw, int axn)
 {
@@ -415,2039 +2633,3 @@ int joy_get_scaled_reading(int raw)
 	return x;
 }
 
-void control_config_detect_axis_reset()
-{
-	joystick_read_raw_axis(JOY_NUM_AXES, Axes_origin);
-}
-
-int control_config_detect_axis()
-{
-	int i, d, axis = -1, delta = 16384;
-	int axes_values[JOY_NUM_AXES];
-	int dx, dy, dz, fudge = 7;
-
-	joystick_read_raw_axis(JOY_NUM_AXES, axes_values);
-	for (i=0; i<JOY_NUM_AXES; i++) {
-		d = abs(axes_values[i] - Axes_origin[i]);
-		if (d > delta) {
-			axis = i;
-			delta = d;
-		}
-	}
-
-	if ( (axis == -1) && Use_mouse_to_fly ) {
-		mouse_get_delta( &dx, &dy);
-
-		if ( (dx > fudge) || (dx < -fudge) ) {
-			axis = 0;
-		} else if ( (dy > fudge) || (dy < -fudge) ) {
-			axis = 1;
-		}
-	}
-
-	return axis;
-}
-
-void control_config_conflict_check()
-{
-	int i, j;
-	
-	for (i=0; i<CCFG_MAX; i++) {
-		Conflicts[i].key = Conflicts[i].joy = -1;
-	}
-
-	for (i=0; i<NUM_TABS; i++) {
-		Conflicts_tabs[i] = 0;
-	}
-
-	for (i=0; i<CCFG_MAX-1; i++) {
-		for (j=i+1; j<CCFG_MAX; j++) {
-			if ((Control_config[i].key_id >= 0) && (Control_config[i].key_id == Control_config[j].key_id)) {
-				// If one of the conflicting keys is disabled, then this silently clears
-				// the disabled key to prevent the conflict; a conflict is recorded only
-				// if both keys are enabled
-
-				if (Control_config[i].disabled)
-					Control_config[i].key_id = (short) -1;
-				else if (Control_config[j].disabled)
-					Control_config[j].key_id = (short) -1;
-				else {
-					Conflicts[i].key = j;
-					Conflicts[j].key = i;
-					Conflicts_tabs[ Control_config[i].tab ] = 1;
-					Conflicts_tabs[ Control_config[j].tab ] = 1;
-				}
-			}
-
-			if ((Control_config[i].joy_id >= 0) && (Control_config[i].joy_id == Control_config[j].joy_id)) {
-				// Same as above
-
-				if (Control_config[i].disabled)
-					Control_config[i].joy_id = (short) -1;
-				else if (Control_config[j].disabled)
-					Control_config[j].joy_id = (short) -1;
-				else {
-					Conflicts[i].joy = j;
-					Conflicts[j].joy = i;
-					Conflicts_tabs[ Control_config[i].tab ] = 1;
-					Conflicts_tabs[ Control_config[j].tab ] = 1;
-				}
-			}
-		}
-	}
-
-	for (i=0; i<NUM_JOY_AXIS_ACTIONS; i++) {
-		Conflicts_axes[i] = -1;
-	}
-
-	for (i=0; i<NUM_JOY_AXIS_ACTIONS-1; i++) {
-		for (j=i+1; j<NUM_JOY_AXIS_ACTIONS; j++) {
-			if ((Axis_map_to[i] >= 0) && (Axis_map_to[i] == Axis_map_to[j])) {
-				Conflicts_axes[i] = j;
-				Conflicts_axes[j] = i;
-				Conflicts_tabs[SHIP_TAB] = 1;
- 			}
-		}
-	}
-}
-
-// do list setup required prior to rendering and checking for the controls listing.  Called when list changes
-void control_config_list_prepare()
-{
-	int j, y, z;
-	int font_height = gr_get_font_height();
-
-	Num_cc_lines = y = z = 0;
-	while (z < CCFG_MAX) {
-		if (Control_config[z].tab == Tab && !Control_config[z].disabled) {
-			if (Control_config[z].hasXSTR) {
-				Cc_lines[Num_cc_lines].label = XSTR(Control_config[z].text, CONTROL_CONFIG_XSTR + z);
-			} else {
-				Cc_lines[Num_cc_lines].label = Control_config[z].text;
-			}
-
-			Cc_lines[Num_cc_lines].cc_index = z;
-			Cc_lines[Num_cc_lines++].y = y;
-			y += font_height + 2;
-		}
-
-		z++;
-	}
-
-	if (Tab == SHIP_TAB) {
-		for (j=0; j<NUM_JOY_AXIS_ACTIONS; j++) {
-			Cc_lines[Num_cc_lines].label = Joy_axis_action_text[j];
-			Cc_lines[Num_cc_lines].cc_index = j | JOY_AXIS;
-			Cc_lines[Num_cc_lines++].y = y;
-			y += font_height + 2;
-		}
-	}
-}
-
-int cc_line_query_visible(int n)
-{
-	int y;
-
-	if ((n < 0) || (n >= Num_cc_lines)) {
-		return 0;
-	}
-	
-	y = Cc_lines[n].y - Cc_lines[Scroll_offset].y;
-	if ((y < 0) || (y + gr_get_font_height() > Control_list_coords[gr_screen.res][CONTROL_H_COORD])){
-		return 0;
-	}
-
-	return 1;
-}
-
-// allocates the required space for one undo block and put it in the beginning of the linked list (top of a stack).
-// Returns a pointer to this newly allocated block
-config_item_undo *get_undo_block(int size)
-{
-	config_item_undo *ptr;
-
-	ptr = (config_item_undo *) vm_malloc( sizeof(config_item_undo) );
-	Assert(ptr);
-	ptr->next = Config_item_undo;
-	Config_item_undo = ptr;
-
-	ptr->size = size;
-	if (size) {
-		ptr->index = (int *) vm_malloc( sizeof(int) * size );
-		Assert(ptr->index);
-		ptr->list = (config_item *) vm_malloc( sizeof(config_item) * size );
-		Assert(ptr->list);
-
-	} else {
-		ptr->index = NULL;
-		ptr->list = NULL;
-	}
-
-	ptr->reset_to_preset = -1;
-
-	return ptr;
-}
-
-// frees one undo block.  The first one in the list (top of the stack) to be precise.
-void free_undo_block()
-{
-	config_item_undo *ptr;
-
-	ptr = Config_item_undo;
-	if (!ptr) {
-		return;
-	}
-
-	Config_item_undo = ptr->next;
-	if (ptr->size) {
-		vm_free(ptr->list);
-		vm_free(ptr->index);
-	}
-
-	vm_free(ptr);
-}
-
-// undo the most recent binding changes
-int control_config_undo_last()
-{
-	int i, z, tab;
-
-	if (!Config_item_undo) {
-		gamesnd_play_iface(SND_GENERAL_FAIL);
-		return -1;
-	}
-
-	if (Config_item_undo->reset_to_preset > -1) {
-		control_config_reset_defaults(Config_item_undo->reset_to_preset);
-	} else {
-		if (Config_item_undo->index[0] & JOY_AXIS) {
-			tab = SHIP_TAB;
-		} else {
-			tab = Control_config[Config_item_undo->index[0]].tab;
-		}
-
-		for (i=1; i<Config_item_undo->size; i++) {
-			if (Config_item_undo->index[i] & JOY_AXIS) {
-				if (tab != SHIP_TAB) {
-					tab = -1;
-				}
-
-			} else {
-				if (Control_config[Config_item_undo->index[i]].tab != tab) {
-					tab = -1;
-				}
-			}
-		}
-
-		if (tab >= 0) {
-			Tab = tab;
-		}
-
-		for (i=0; i<Config_item_undo->size; i++) {
-			z = Config_item_undo->index[i];
-			if (z & JOY_AXIS) {
-				config_item *ptr;
-
-				z &= ~JOY_AXIS;
-				ptr = &Config_item_undo->list[i];
-				Axis_map_to[z] = ptr->joy_id;
-				Invert_axis[z] = ptr->used;
-
-			} else {
-				Control_config[z] = Config_item_undo->list[i];
-			}
-		}
-	}
-
-	free_undo_block();
-	control_config_conflict_check();
-	control_config_list_prepare();
-	gamesnd_play_iface(SND_USER_SELECT);
-	return 0;
-}
-
-void control_config_save_axis_undo(int axis)
-{
-	config_item_undo *ptr;
-	config_item item;
-
-	memset( &item, 0, sizeof(config_item) );
-
-	item.joy_id = (short) Axis_map_to[axis];
-	item.used = Invert_axis[axis];
-
-	ptr = get_undo_block(1);
-	ptr->index[0] = axis | JOY_AXIS;
-	ptr->list[0] = item;
-}
-
-void control_config_bind_key(int i, int key)
-{
-	config_item_undo *ptr;
-
-	ptr = get_undo_block(1);
-	ptr->index[0] = i;
-	ptr->list[0] = Control_config[i];
-	Control_config[i].key_id = (short) key;
-}
-
-void control_config_bind_joy(int i, int joy)
-{
-	config_item_undo *ptr;
-
-	ptr = get_undo_block(1);
-	ptr->index[0] = i;
-	ptr->list[0] = Control_config[i];
-	Control_config[i].joy_id = (short) joy;
-}
-
-void control_config_bind_axis(int i, int axis)
-{
-	control_config_save_axis_undo(i);
-	Axis_map_to[i] = axis;
-}
-
-int control_config_remove_binding()
-{
-	int z;
-	config_item_undo *ptr;
-
-	if (Selected_line < 0) {
-		gamesnd_play_iface(SND_GENERAL_FAIL);
-		return -1;
-	}
-
-	z = Cc_lines[Selected_line].cc_index;
-	if (z & JOY_AXIS) {
-		z &= ~JOY_AXIS;
-		if (Axis_map_to[z] < 0) {
-			gamesnd_play_iface(SND_GENERAL_FAIL);
-			return -1;
-		}
-
-		control_config_save_axis_undo(z);
-		Axis_map_to[z] = -1;
-		control_config_conflict_check();
-		control_config_list_prepare();
-		gamesnd_play_iface(SND_USER_SELECT);
-		Selected_item = -1;
-		return 0;
-	}
-
-	if ((Control_config[z].joy_id < 0) && (Control_config[z].key_id < 0)) {
-		gamesnd_play_iface(SND_GENERAL_FAIL);
-		return -1;
-	}
-
-	ptr = get_undo_block(1);
-	ptr->index[0] = z;
-	ptr->list[0] = Control_config[z];
-
-	if (Selected_item && (Control_config[z].joy_id >= 0)) {  // if not just key selected (which would be 0)
-		Control_config[z].joy_id = (short) -1;
-	}
-
-	if ((Selected_item != 1) && (Control_config[z].key_id >= 0)) {  // if not just joy button selected (1)
-		Control_config[z].key_id = (short) -1;
-	}
-
-	control_config_conflict_check();
-	control_config_list_prepare();
-	gamesnd_play_iface(SND_USER_SELECT);
-	Selected_item = -1;
-	return 0;
-}
-
-int control_config_clear_other()
-{
-	int z, i, j, total = 0;
-	config_item_undo *ptr;
-
-	if (Selected_line < 0) {
-		gamesnd_play_iface(SND_GENERAL_FAIL);
-		return -1;
-	}
-
-	z = Cc_lines[Selected_line].cc_index;
-	if (z & JOY_AXIS) {
-		config_item item;
-
-		z &= ~JOY_AXIS;
-		if (Axis_map_to[z] < 0) {
-			gamesnd_play_iface(SND_GENERAL_FAIL);
-			return -1;
-		}
-
-		for (i=0; i<NUM_JOY_AXIS_ACTIONS; i++) {
-			if ((Axis_map_to[i] == Axis_map_to[z]) && (i != z)) {
-				total++;
-			}
-		}
-
-		if (!total) {
-			gamesnd_play_iface(SND_GENERAL_FAIL);
-			return -1;
-		}
-
-		ptr = get_undo_block(total);
-		for (i=j=0; i<NUM_JOY_AXIS_ACTIONS; i++) {
-			if ((Axis_map_to[i] == Axis_map_to[z]) && (i != z)) {
-				memset( &item, 0, sizeof(config_item) );
-
-				item.joy_id = (short) Axis_map_to[i];
-				item.used = Invert_axis[i];
-
-				ptr->index[j] = i | JOY_AXIS;
-				ptr->list[j] = item;
-				j++;
-
-				Axis_map_to[i] = -1;
-			}
-		}
-		control_config_conflict_check();
-		control_config_list_prepare();
-		gamesnd_play_iface(SND_USER_SELECT);
-		return 0;
-	}
-
-	for (i=0; i<CCFG_MAX; i++) {
-		if ( (Control_config[i].key_id == Control_config[z].key_id) || (Control_config[i].joy_id == Control_config[z].joy_id) ) {
-			if (i != z) {
-				total++;
-			}
-		}
-	}
-	if (!total) {
-		gamesnd_play_iface(SND_GENERAL_FAIL);
-		return -1;
-	}
-
-	if ((Control_config[z].joy_id < 0) && (Control_config[z].key_id < 0)) {
-		gamesnd_play_iface(SND_GENERAL_FAIL);
-		return -1;
-	}
-
-	// now, back up the old bindings so we can undo if we want to
-	ptr = get_undo_block(total);
-	for (i=j=0; i<CCFG_MAX; i++) {
-		if ( (Control_config[i].key_id == Control_config[z].key_id) || (Control_config[i].joy_id == Control_config[z].joy_id) ) {
-			if (i != z) {
-				ptr->index[j] = i;
-				ptr->list[j] = Control_config[i];
-				j++;
-
-				if (Control_config[i].key_id == Control_config[z].key_id) {
-					Control_config[i].key_id = (short) -1;
-				}
-
-				if (Control_config[i].joy_id == Control_config[z].joy_id) {
-					Control_config[i].joy_id = (short) -1;
-				}
-			}
-		}
-	}
-	control_config_conflict_check();
-	control_config_list_prepare();
-	gamesnd_play_iface(SND_USER_SELECT);
-	return 0;
-}
-
-int control_config_clear_all()
-{
-	int i, j, total = 0;
-	config_item_undo *ptr;
-
-	// first, determine how many bindings need to be changed
-	for (i=0; i<CCFG_MAX; i++) {
-		if ((Control_config[i].key_id >= 0) || (Control_config[i].joy_id >= 0)) {
-			total++;
-		}
-	}
-
-	if (!total) {
-		gamesnd_play_iface(SND_GENERAL_FAIL);
-		return -1;
-	}
-
-	// now, back up the old bindings so we can undo if we want to
-	ptr = get_undo_block(total);
-	for (i=j=0; i<CCFG_MAX; i++) {
-		if ((Control_config[i].key_id >= 0) || (Control_config[i].joy_id >= 0)) {
-			ptr->index[j] = i;
-			ptr->list[j] = Control_config[i];
-			j++;
-		}
-	}
-
-	Assert(j == total);
-	for (i=0; i<CCFG_MAX; i++) {
-		Control_config[i].key_id = Control_config[i].joy_id = -1;
-	}
-
-	control_config_conflict_check();
-	control_config_list_prepare();
-	gamesnd_play_iface(SND_RESET_PRESSED);
-	return 0;
-}
-
-int control_config_axis_default(int axis)
-{
-	Assert(axis >= 0);
-
-	if ( axis > 1 ) {
-		if (Axis_map_to_defaults[axis] < 0) {
-			return -1;
-		}
-
-		auto joystick = io::joystick::getCurrentJoystick();
-		if (Axis_map_to_defaults[axis] >= 0 && Axis_map_to_defaults[axis] < joystick->numAxes()) {
-			return -1;
-		}
-	}
-
-	return Axis_map_to_defaults[axis];
-}
-
-int control_config_do_reset()
-{
-	int i, j, total = 0;
-	config_item_undo *ptr;
-	config_item item;
-	config_item *preset;
-	bool cycling_presets = false;
-	
-	// If there are presets, then we'll cycle to the next preset and reset to that
-	if (Control_config_presets.size() >= 1) {
-		cycling_presets = true;
-		
-		if (++Defaults_cycle_pos >= Control_config_presets.size())
-			Defaults_cycle_pos = 0;
-		
-		preset = Control_config_presets[Defaults_cycle_pos];
-	} else {
-		// If there are no presets, then we'll always reset to the hardcoded defaults
-		preset = Control_config;
-	}
-	
-	// first, determine how many bindings need to be changed
-	for (i=0; i<CCFG_MAX; i++) {
-		if ((Control_config[i].key_id != preset[i].key_default) || (Control_config[i].joy_id != preset[i].joy_default)) {
-			total++;
-		}
-	}
-
-	for (i=0; i<NUM_JOY_AXIS_ACTIONS; i++) {
-		if ((Axis_map_to[i] != control_config_axis_default(i)) || (Invert_axis[i] != Invert_axis_defaults[i])) {
-			total++;
-		}
-	}
-
-	if (!total && !cycling_presets) {
-		gamesnd_play_iface(SND_GENERAL_FAIL);
-		return -1;
-	}
-
-	// now, back up the old bindings so we can undo if we want to
-	ptr = get_undo_block(total);
-	for (i=j=0; i<CCFG_MAX; i++) {
-		if ((Control_config[i].key_id != preset[i].key_default) || (Control_config[i].joy_id != preset[i].joy_default)) {
-			ptr->index[j] = i;
-			ptr->list[j] = Control_config[i];
-			j++;
-		}
-	}
-
-	for (i=0; i<NUM_JOY_AXIS_ACTIONS; i++) {
-		if ((Axis_map_to[i] != control_config_axis_default(i)) || (Invert_axis[i] != Invert_axis_defaults[i])) {
-			memset( &item, 0, sizeof(config_item) );
-
-			item.joy_id = (short) Axis_map_to[i];
-			item.used = Invert_axis[i];
-
-			ptr->index[j] = i | JOY_AXIS;
-			ptr->list[j] = item;
-			j++;
-		}
-	}
-
-	Assert(j == total);
-
-	if (cycling_presets)
-		control_config_reset_defaults(Defaults_cycle_pos);
-	else
-		control_config_reset_defaults();
-
-	control_config_conflict_check();
-	control_config_list_prepare();
-	gamesnd_play_iface(SND_RESET_PRESSED);
-	return 0;
-}
-
-// This sets all the controls to the default values in the given preset
-// If no preset is given, the hardcoded defaults of Control_config are used
-void control_config_reset_defaults(int presetnum)
-{
-	int i;
-	config_item *preset;
-
-	if (presetnum >= 0)
-		preset = Control_config_presets[presetnum];
-	else
-		preset = Control_config;
-
-	// Reset keyboard defaults
-	for (i=0; i<CCFG_MAX; i++) {
-		// Note that key_default and joy_default are NOT overwritten here;
-		// they should retain the values of the first preset because
-		// for example the key-pressed SEXP works off the defaults of the first preset
-		Control_config[i].key_id = preset[i].key_default;
-		Control_config[i].joy_id = preset[i].joy_default;
-		Control_config[i].tab = preset[i].tab;
-		Control_config[i].hasXSTR = preset[i].hasXSTR;
-		Control_config[i].type = preset[i].type;
-		Control_config[i].disabled = preset[i].disabled;
-	}
-
-	for (i=0; i<NUM_JOY_AXIS_ACTIONS; i++) {
-		Axis_map_to[i] = control_config_axis_default(i);
-		Invert_axis[i] = Invert_axis_defaults[i];
-	}
-}
-
-void control_config_scroll_screen_up()
-{
-	if (Scroll_offset) {
-		Scroll_offset--;
-		Assert(Selected_line > Scroll_offset);
-		while (!cc_line_query_visible(Selected_line)) {
-			Selected_line--;
-		}
-
-		Selected_item = -1;
-		gamesnd_play_iface(SND_SCROLL);
-
-	} else {
-		gamesnd_play_iface(SND_GENERAL_FAIL);
-	}
-}
-
-void control_config_scroll_line_up()
-{
-	if (Selected_line) {
-		Selected_line--;
-		if (Selected_line < Scroll_offset) {
-			Scroll_offset = Selected_line;
-		}
-
-		Selected_item = -1;
-		gamesnd_play_iface(SND_SCROLL);
-
-	} else {
-		gamesnd_play_iface(SND_GENERAL_FAIL);
-	}
-}
-
-void control_config_scroll_screen_down()
-{
-	if (Cc_lines[Num_cc_lines - 1].y + gr_get_font_height() > Cc_lines[Scroll_offset].y + Control_list_coords[gr_screen.res][CONTROL_H_COORD]) {
-		Scroll_offset++;
-		while (!cc_line_query_visible(Selected_line)) {
-			Selected_line++;
-			Assert(Selected_line < Num_cc_lines);
-		}
-
-		Selected_item = -1;
-		gamesnd_play_iface(SND_SCROLL);
-
-	} else {
-		gamesnd_play_iface(SND_GENERAL_FAIL);
-	}
-}
-
-void control_config_scroll_line_down()
-{
-	if (Selected_line < Num_cc_lines - 1) {
-		Selected_line++;
-		Assert(Selected_line > Scroll_offset);
-		while (!cc_line_query_visible(Selected_line)) {
-			Scroll_offset++;
-		}
-
-		Selected_item = -1;
-		gamesnd_play_iface(SND_SCROLL);
-
-	} else {
-		gamesnd_play_iface(SND_GENERAL_FAIL);
-	}
-}
-
-void control_config_toggle_modifier(int bit)
-{
-	int k, z;
-
-	z = Cc_lines[Selected_line].cc_index;
-	Assert(!(z & JOY_AXIS));
-	k = Control_config[z].key_id;
-	if (k < 0) {
-		gamesnd_play_iface(SND_GENERAL_FAIL);
-		return;
-	}
-
-	control_config_bind_key(z, k ^ bit);
-	control_config_conflict_check();
-	gamesnd_play_iface(SND_USER_SELECT);
-}
-
-void control_config_toggle_invert()
-{
-	int z;
-
-	z = Cc_lines[Selected_line].cc_index;
-	Assert(z & JOY_AXIS);
-	z &= ~JOY_AXIS;
-	control_config_save_axis_undo(z);
-	Invert_axis[z] = !Invert_axis[z];
-}
-
-void control_config_do_bind()
-{
-	int i;
-
-	game_flush();
-//	if ((Selected_line < 0) || (Cc_lines[Selected_line].cc_index & JOY_AXIS)) {
-	if (Selected_line < 0) {
-		gamesnd_play_iface(SND_GENERAL_FAIL);
-		return;
-	}
-
-	for (i=0; i<NUM_BUTTONS; i++) {
-		if (i != CANCEL_BUTTON) {
-			CC_Buttons[gr_screen.res][i].button.reset_status();
-			CC_Buttons[gr_screen.res][i].button.disable();
-		}
-	}
-	CC_Buttons[gr_screen.res][CANCEL_BUTTON].button.enable();
-	CC_Buttons[gr_screen.res][CANCEL_BUTTON].button.set_hotkey(KEY_ESC);
-
-	for (i=0; i<JOY_TOTAL_BUTTONS; i++){
-		joy_down_count(i, 1);  // clear checking status of all joystick buttons
-	}
-
-	control_config_detect_axis_reset();
-
-	Binding_mode = 1;
-	Bind_time = timer_get_milliseconds();
-	Search_mode = 0;
-	Last_key = -1;
-	Axis_override = -1;
-	gamesnd_play_iface(SND_USER_SELECT);
-}
-
-void control_config_do_search()
-{
-	int i;
-
-	for (i=0; i<NUM_BUTTONS; i++){
-		if (i != CANCEL_BUTTON) {
-			CC_Buttons[gr_screen.res][i].button.reset_status();
-			CC_Buttons[gr_screen.res][i].button.disable();
-		}
-	}
-
-	CC_Buttons[gr_screen.res][CANCEL_BUTTON].button.enable();
-	CC_Buttons[gr_screen.res][CANCEL_BUTTON].button.set_hotkey(KEY_ESC);
-
-	for (i=0; i<JOY_TOTAL_BUTTONS; i++){
-		joy_down_count(i, 1);  // clear checking status of all joystick buttons
-	}
-
-	Binding_mode = 0;
-	Search_mode = 1;
-	Last_key = -1;
-	gamesnd_play_iface(SND_USER_SELECT);
-}
-
-void control_config_do_cancel(int fail = 0)
-{
-	int i;
-
-	game_flush();
-
-	for (i=0; i<NUM_BUTTONS; i++){
-		if ( (i != CANCEL_BUTTON) && (i != INVERT_AXIS) ){
-			CC_Buttons[gr_screen.res][i].button.enable();
-		}
-	}
-
-	CC_Buttons[gr_screen.res][CANCEL_BUTTON].button.reset_status();
-	CC_Buttons[gr_screen.res][CANCEL_BUTTON].button.disable();
-	CC_Buttons[gr_screen.res][CANCEL_BUTTON].button.set_hotkey(-1);
-	CC_Buttons[gr_screen.res][BIND_BUTTON].button.reset_status();
-	CC_Buttons[gr_screen.res][SEARCH_MODE].button.reset_status();
-
-	Binding_mode = Search_mode = 0;
-	if (fail){
-		gamesnd_play_iface(SND_GENERAL_FAIL);
-	} else {
-		gamesnd_play_iface(SND_USER_SELECT);
-	}
-}
-
-int control_config_accept()
-{
-	int i;
-
-	for (i=0; i<NUM_TABS; i++) {
-		if (Conflicts_tabs[i]) {
-			break;
-		}
-	}
-
-	if (i < NUM_TABS) {
-		gamesnd_play_iface(SND_GENERAL_FAIL);
-		return -1;
-	}
-
-	hud_squadmsg_save_keys();  // rebuild map for saving/restoring keys in squadmsg mode
-	gameseq_post_event(GS_EVENT_PREVIOUS_STATE);
-	gamesnd_play_iface(SND_COMMIT_PRESSED);
-	return 0;
-}
-
-void control_config_cancel_exit()
-{
-	int i;
-
-	for (i=0; i<CCFG_MAX; i++) {
-		Control_config[i] = Control_config_backup[i];
-	}
-
-	gameseq_post_event(GS_EVENT_PREVIOUS_STATE);
-}
-
-void control_config_button_pressed(int n)
-{
-	switch (n) {
-		case TARGET_TAB:
-		case SHIP_TAB:
-		case WEAPON_TAB:
-		case COMPUTER_TAB:
-			Tab = n;
-			Scroll_offset = Selected_line = 0;
-			control_config_list_prepare();
-			gamesnd_play_iface(SND_SCREEN_MODE_PRESSED);
-			break;
-
-		case BIND_BUTTON:
-			control_config_do_bind();
-			break;
-
-		case SEARCH_MODE:
-			control_config_do_search();
-			break;
-
-		case SHIFT_TOGGLE:
-			control_config_toggle_modifier(KEY_SHIFTED);
-			gamesnd_play_iface(SND_USER_SELECT);
-			break;
-
-		case ALT_TOGGLE:
-			control_config_toggle_modifier(KEY_ALTED);
-			gamesnd_play_iface(SND_USER_SELECT);
-			break;
-
-		case INVERT_AXIS:
-			control_config_toggle_invert();
-			gamesnd_play_iface(SND_USER_SELECT);
-			break;
-
-		case SCROLL_UP_BUTTON:
-			control_config_scroll_screen_up();
-			break;
-
-		case SCROLL_DOWN_BUTTON:
-			control_config_scroll_screen_down();
-			break;
-
-		case ACCEPT_BUTTON:
-			control_config_accept();
-			break;
-
-		case CLEAR_BUTTON:
-			control_config_remove_binding();
-			break;
-
-		case HELP_BUTTON:
-			launch_context_help();
-			gamesnd_play_iface(SND_HELP_PRESSED);
-			break;
-
-		case RESET_BUTTON:
-			control_config_do_reset();
-			break;
-
-		case UNDO_BUTTON:
-			control_config_undo_last();
-			break;
-
-		case CANCEL_BUTTON:
-			control_config_do_cancel();
-			break;
-
-		case CLEAR_OTHER_BUTTON:
-			control_config_clear_other();
-			break;
-
-		case CLEAR_ALL_BUTTON:
-			control_config_clear_all();
-			break;		
-	}
-}
-
-const char *control_config_tooltip_handler(const char *str)
-{
-	int i;
-
-	if (!stricmp(str, NOX("@conflict"))) {
-		for (i=0; i<NUM_TABS; i++) {
-			if (Conflicts_tabs[i]) {
-				return XSTR( "Conflict!", 205);
-			}
-		}
-	}
-
-	return NULL;
-}
-
-void control_config_init()
-{
-	int i;
-	ui_button_info *b;
-
-	// make backup of all controls
-	for (i=0; i<CCFG_MAX; i++) {
-		Control_config_backup[i] = Control_config[i];
-	}
-
-	Defaults_cycle_pos = 0;
-
-	common_set_interface_palette(NOX("ControlConfigPalette"));  // set the interface palette
-	Ui_window.create(0, 0, gr_screen.max_w_unscaled, gr_screen.max_h_unscaled, 0);
-	Ui_window.set_mask_bmap(Conflict_background_bitmap_mask_fname[gr_screen.res]);
-	Ui_window.tooltip_handler = control_config_tooltip_handler;
-
-	// load in help overlay bitmap	
-	Control_config_overlay_id = help_overlay_get_index(CONTROL_CONFIG_OVERLAY);
-	help_overlay_set_state(Control_config_overlay_id,gr_screen.res,0);
-
-	// reset conflict flashing
-	Conflict_stamp = -1;
-
-	for (i=0; i<NUM_BUTTONS; i++) {
-		b = &CC_Buttons[gr_screen.res][i];
-
-		if (b->hotspot < 0) {  // temporary
-			b->button.create(&Ui_window, NOX("Clear other"), b->x, b->y, 150, 30, 0, 1);  // temporary
-			b->button.set_highlight_action(common_play_highlight_sound);
-			continue;
-		}
-
-		b->button.create(&Ui_window, "", b->x, b->y, 60, 30, ((i == SCROLL_UP_BUTTON) || (i == SCROLL_DOWN_BUTTON)), 1);
-
-		// set up callback for when a mouse first goes over a button
-		b->button.set_highlight_action(common_play_highlight_sound);		
-		if (i<4) {
-			b->button.set_bmaps(b->filename, 5, 1);		// a bit of a hack here, but buttons 0-3 need 4 frames loaded
-		} else {
-			b->button.set_bmaps(b->filename);
-		}
-		b->button.link_hotspot(b->hotspot);
-	}	
-
-	// create all text
-	for(i=0; i<CC_NUM_TEXT; i++){
-		Ui_window.add_XSTR(&CC_text[gr_screen.res][i]);
-	}
-
-	for (i=0; i<LIST_BUTTONS_MAX; i++) {
-		List_buttons[i].create(&Ui_window, "", 0, 0, 60, 30, 0, 1);
-		List_buttons[i].hide();
-		List_buttons[i].disable();
-	}
-
-	// set up hotkeys for buttons so we draw the correct animation frame when a key is pressed
-	CC_Buttons[gr_screen.res][SCROLL_UP_BUTTON].button.set_hotkey(KEY_PAGEUP);
-	CC_Buttons[gr_screen.res][SCROLL_DOWN_BUTTON].button.set_hotkey(KEY_PAGEDOWN);
-	CC_Buttons[gr_screen.res][BIND_BUTTON].button.set_hotkey(KEY_ENTER);
-	CC_Buttons[gr_screen.res][CLEAR_OTHER_BUTTON].button.set_hotkey(KEY_CTRLED | KEY_DELETE);
-	CC_Buttons[gr_screen.res][UNDO_BUTTON].button.set_hotkey(KEY_CTRLED | KEY_Z);
-	CC_Buttons[gr_screen.res][CLEAR_BUTTON].button.set_hotkey(KEY_DELETE);
-	CC_Buttons[gr_screen.res][ACCEPT_BUTTON].button.set_hotkey(KEY_CTRLED | KEY_ENTER);
-	CC_Buttons[gr_screen.res][HELP_BUTTON].button.set_hotkey(KEY_F1);
-	CC_Buttons[gr_screen.res][RESET_BUTTON].button.set_hotkey(KEY_CTRLED | KEY_R);
-	CC_Buttons[gr_screen.res][INVERT_AXIS].button.set_hotkey(KEY_I);
-
-	CC_Buttons[gr_screen.res][CANCEL_BUTTON].button.disable();
-	CC_Buttons[gr_screen.res][CLEAR_OTHER_BUTTON].button.disable();
-
-	Background_bitmap = bm_load(Conflict_background_bitmap_fname[gr_screen.res]);	
-
-	Scroll_offset = Selected_line = 0;
-	Config_item_undo = NULL;
-	control_config_conflict_check();
-
-	// setup strings					
-	Joy_axis_action_text[0] = vm_strdup(XSTR("Turn (Yaw) Axis", 1016));
-	Joy_axis_action_text[1] = vm_strdup(XSTR("Pitch Axis", 1017));
-	Joy_axis_action_text[2] = vm_strdup(XSTR("Bank Axis", 1018));
-	Joy_axis_action_text[3] = vm_strdup(XSTR("Absolute Throttle Axis", 1019));
-	Joy_axis_action_text[4] = vm_strdup(XSTR("Relative Throttle Axis", 1020));
-	Joy_axis_text[0] = vm_strdup(XSTR("Joystick/Mouse X Axis", 1021));
-	Joy_axis_text[1] = vm_strdup(XSTR("Joystick/Mouse Y Axis", 1022));
-	Joy_axis_text[2] = vm_strdup(XSTR("Joystick Z Axis", 1023));
-	Joy_axis_text[3] = vm_strdup(XSTR("Joystick rX Axis", 1024));
-	Joy_axis_text[4] = vm_strdup(XSTR("Joystick rY Axis", 1025));
-	Joy_axis_text[5] = vm_strdup(XSTR("Joystick rZ Axis", 1026));
-	Mouse_button_text[0] = vm_strdup("");
-	Mouse_button_text[1] = vm_strdup(XSTR("Left Button", 1027));
-	Mouse_button_text[2] = vm_strdup(XSTR("Right Button", 1028));
-	Mouse_button_text[3] = vm_strdup(XSTR("Mid Button", 1029));
-	Mouse_button_text[4] = vm_strdup("");
-	Mouse_axis_text[0] = vm_strdup(XSTR("L/R", 1030));
-	Mouse_axis_text[1] = vm_strdup(XSTR("U/B", 1031));
-	Invert_text[0] = vm_strdup(XSTR("N", 1032));
-	Invert_text[1] = vm_strdup(XSTR("Y", 1033));
-
-	control_config_list_prepare();
-}
-
-void control_config_close()
-{
-	int idx;
-	
-	while (Config_item_undo){
-		free_undo_block();
-	}
-	
-	if (Background_bitmap){
-		bm_release(Background_bitmap);
-	}
-
-	Ui_window.destroy();
-	common_free_interface_palette();		// restore game palette
-	hud_squadmsg_save_keys();				// rebuild map for saving/restoring keys in squadmsg mode
-	game_flush();
-
-	if (Game_mode & GM_MULTIPLAYER) {
-		Pilot.save_player();
-	} else {
-		Pilot.save_savefile();
-	}
-
-	// free strings	
-	for(idx=0; idx<NUM_JOY_AXIS_ACTIONS; idx++){
-		if(Joy_axis_action_text[idx] != NULL){
-			vm_free(Joy_axis_action_text[idx]);
-			Joy_axis_action_text[idx] = NULL;
-		}
-	}
-	for(idx=0; idx<NUM_AXIS_TEXT; idx++){
-		if(Joy_axis_text[idx] != NULL){
-			vm_free(Joy_axis_text[idx]);
-			Joy_axis_text[idx] = NULL;
-		}
-	}
-	for(idx=0; idx<NUM_MOUSE_TEXT; idx++){
-		if(Mouse_button_text[idx] != NULL){
-			vm_free(Mouse_button_text[idx]);
-			Mouse_button_text[idx] = NULL;
-		}
-	}
-	for(idx=0; idx<NUM_MOUSE_AXIS_TEXT; idx++){
-		if(Mouse_axis_text[idx] != NULL){
-			vm_free(Mouse_axis_text[idx]);
-			Mouse_axis_text[idx] = NULL;
-		}
-	}
-	for(idx=0; idx<NUM_INVERT_TEXT; idx++){
-		if(Invert_text[idx] != NULL){
-			vm_free(Invert_text[idx]);
-			Invert_text[idx] = NULL;
-		}
-	}
-}
-
-void control_config_do_frame(float frametime)
-{
-	const char *str;
-	char buf[256];
-	int i, j, k, w, x, y, z, line, conflict;
-	int font_height = gr_get_font_height();
-	int select_tease_line = -1;  // line mouse is down on, but won't be selected until button released
-	static float timer = 0.0f;
-	color *c;
-	static int bound_timestamp = 0;
-	static char bound_string[40];
-	
-	timer += frametime;
-
-	if (Binding_mode) {
-		if (Cc_lines[Selected_line].cc_index & JOY_AXIS) {
-			int bind = 0;
-
-			z = Cc_lines[Selected_line].cc_index & ~JOY_AXIS;
-			i = control_config_detect_axis();
-			if (i >= 0) {
-				Axis_override = i;
-				bind = 1;
-			}
-
-			k = game_poll();
-			Ui_window.use_hack_to_get_around_stupid_problem_flag = 1;
-			Ui_window.process(0);
-
-			if (k == KEY_ESC) {
-				strcpy_s(bound_string, XSTR( "Canceled", 206));
-				bound_timestamp = timestamp(2500);
-				control_config_do_cancel();
-
-			} else {
-				if (k == KEY_ENTER) {
-					bind = 1;
-				}
-
-				for (i=0; i<JOY_TOTAL_BUTTONS; i++) {
-					if (joy_down_count(i, 1)) {
-						bind = 1;
-					}
-				}
-
-				if (bind) {
-					if (Axis_override >= 0) {
-						control_config_bind_axis(z, Axis_override);
-						strcpy_s(bound_string, Joy_axis_text[Axis_override]);
-						font::force_fit_string(bound_string, 39, Conflict_wnd_coords[gr_screen.res][CONTROL_W_COORD]);
-						bound_timestamp = timestamp(2500);
-						control_config_conflict_check();
-						control_config_list_prepare();
-						control_config_do_cancel();
-
-					} else {
-						control_config_do_cancel(1);
-					}
-				}
-			}
-
-		} else {
-			if (help_overlay_active(Control_config_overlay_id)) {
-				CC_Buttons[gr_screen.res][HELP_BUTTON].button.reset_status();
-				Ui_window.set_ignore_gadgets(1);
-			}
-
-			k = game_poll();
-			Ui_window.use_hack_to_get_around_stupid_problem_flag = 1;
-			Ui_window.process(0);
-
-			if ( (k > 0) || B1_JUST_RELEASED ) {
-				if (help_overlay_active(Control_config_overlay_id)) {
-					help_overlay_set_state(Control_config_overlay_id, gr_screen.res, 0);
-					Ui_window.set_ignore_gadgets(0);
-					k = 0;
-				}
-			}
-
-			if ( !help_overlay_active(Control_config_overlay_id) ) {
-				Ui_window.set_ignore_gadgets(0);
-			}
-
-			if (k == KEY_ESC) {
-				strcpy_s(bound_string, XSTR( "Canceled", 206));
-				bound_timestamp = timestamp(2500);
-				control_config_do_cancel();
-
-			} else {
-				switch (k & KEY_MASK) {
-					case KEY_LSHIFT:
-					case KEY_RSHIFT:
-					case KEY_LALT:
-					case KEY_RALT:
-						Last_key = k & KEY_MASK;
-						k = 0;
-						break;
-				}
-
-				if (Cc_lines[Selected_line].cc_index == BANK_WHEN_PRESSED || Cc_lines[Selected_line].cc_index == GLIDE_WHEN_PRESSED) {
-					if ( (Last_key >= 0) && (k <= 0) && !keyd_pressed[Last_key] ) {
-						k = Last_key;
-					}
-				}
-
-				if ((k > 0) && !Config_allowed[k & KEY_MASK]) {
-					popup(PF_USE_AFFIRMATIVE_ICON, 1, POPUP_OK, XSTR( "That is a non-bindable key.  Please try again.", 207));
-					k = 0;
-				}
-
-				k &= (KEY_MASK | KEY_SHIFTED | KEY_ALTED);
-				if (k > 0) {
-					z = Cc_lines[Selected_line].cc_index;
-					Assert(!(z & JOY_AXIS));
-					control_config_bind_key(z, k);
-
-					strcpy_s(bound_string, textify_scancode(k));
-					font::force_fit_string(bound_string, 39, Conflict_wnd_coords[gr_screen.res][CONTROL_W_COORD]);
-					bound_timestamp = timestamp(2500);
-					control_config_conflict_check();
-					control_config_list_prepare();
-					control_config_do_cancel();
-				}
-
-				for (i=0; i<JOY_TOTAL_BUTTONS; i++) {
-					if (joy_down_count(i, 1)) {
-						z = Cc_lines[Selected_line].cc_index;
-						Assert(!(z & JOY_AXIS));
-						control_config_bind_joy(z, i);
-
-						strcpy_s(bound_string, Joy_button_text[i]);
-						font::force_fit_string(bound_string, 39, Conflict_wnd_coords[gr_screen.res][CONTROL_W_COORD]);
-						bound_timestamp = timestamp(2500);
-						control_config_conflict_check();
-						control_config_list_prepare();
-						control_config_do_cancel();
-						break;
-					}
-				}
-
-				if (Bind_time + 375 < timer_get_milliseconds()) {
-					for (i=0; i<NUM_BUTTONS; i++){
-						if ( (CC_Buttons[gr_screen.res][i].button.is_mouse_on()) && (CC_Buttons[gr_screen.res][i].button.enabled()) ){
-							break;
-						}
-					}
-
-					if (i == NUM_BUTTONS) {  // no buttons pressed
-						for (i=0; i<MOUSE_NUM_BUTTONS; i++) {
-							if (mouse_down(1 << i)) {
-								z = Cc_lines[Selected_line].cc_index;
-								Assert(!(z & JOY_AXIS));
-								control_config_bind_joy(z, i);
-
-								strcpy_s(bound_string, Joy_button_text[i]);
-								font::force_fit_string(bound_string, 39, Conflict_wnd_coords[gr_screen.res][CONTROL_W_COORD]);
-								bound_timestamp = timestamp(2500);
-								control_config_conflict_check();
-								control_config_list_prepare();
-								control_config_do_cancel();
-								for (j=0; j<NUM_BUTTONS; j++){
-									CC_Buttons[gr_screen.res][j].button.reset();
-								}
-
-								break;
-							}
-						}
-					}
-				}
-			}
-		}
-
-	} else if (Search_mode) {
-		if (help_overlay_active(Control_config_overlay_id)) {
-			CC_Buttons[gr_screen.res][HELP_BUTTON].button.reset_status();
-			Ui_window.set_ignore_gadgets(1);
-		}
-
-		k = game_poll();
-		Ui_window.use_hack_to_get_around_stupid_problem_flag = 1;
-		Ui_window.process(0);
-
-		if ( (k > 0) || B1_JUST_RELEASED ) {
-			if ( help_overlay_active(Control_config_overlay_id) ) {
-				help_overlay_set_state(Control_config_overlay_id, gr_screen.res, 0);
-				Ui_window.set_ignore_gadgets(0);
-				k = 0;
-			}
-		}
-
-		if ( !help_overlay_active(Control_config_overlay_id) ) {
-			Ui_window.set_ignore_gadgets(0);
-		}
-
-		if (k == KEY_ESC) {
-			control_config_do_cancel();
-
-		} else {
-			if ((k > 0) && !Config_allowed[k & KEY_MASK]) {
-				k = 0;
-			}
-
-			k &= (KEY_MASK | KEY_SHIFTED | KEY_ALTED);
-			z = -1;
-			if (k > 0) {
-				for (i=0; i<CCFG_MAX; i++) {
-					if (Control_config[i].key_id == k) {
-						z = i;
-						break;
-					}
-				}
-			}
-
-			for (i=0; i<JOY_TOTAL_BUTTONS; i++) {
-				if (joy_down_count(i, 1)) {
-					j = i;
-					for (i=0; i<CCFG_MAX; i++) { //-V535
-						if (Control_config[i].joy_id == j) {
-							z = i;
-							break;
-						}
-					}
-					break;
-				}
-			}
-
-			// check if not on enabled button
-			for (j=0; j<NUM_BUTTONS; j++){
-				if ( (CC_Buttons[gr_screen.res][j].button.is_mouse_on()) && (CC_Buttons[gr_screen.res][j].button.enabled()) ){
-					break;
-				}
-			}
-
-			if (j == NUM_BUTTONS) {  // no buttons pressed
-				for (j=0; j<MOUSE_NUM_BUTTONS; j++) {
-					if (mouse_down(1 << j)) {
-						for (i=0; i<CCFG_MAX; i++) {
-							if (Control_config[i].joy_id == j) {
-								z = i;
-								for (size_t buttonid=0; buttonid<NUM_BUTTONS; buttonid++){
-									CC_Buttons[gr_screen.res][buttonid].button.reset();
-								}
-								break;
-							}
-						}
-						break;
-					}
-				}
-			}
-
-			if (z >= 0) {
-				Tab = Control_config[z].tab;
-				control_config_list_prepare();
-				Selected_line = Scroll_offset = 0;
-				for (i=0; i<Num_cc_lines; i++) {
-					if (Cc_lines[i].cc_index == z) {
-						Selected_line = i;
-						break;
-					}
-				}
-				while (!cc_line_query_visible(Selected_line)) {
-					Scroll_offset++;
-					Assert(Scroll_offset < Num_cc_lines);
-				}
-			}
-		}
-
-	} else {
-		z = Cc_lines[Selected_line].cc_index & JOY_AXIS;
-		CC_Buttons[gr_screen.res][ALT_TOGGLE].button.enable(!z);
-		CC_Buttons[gr_screen.res][SHIFT_TOGGLE].button.enable(!z);
-		CC_Buttons[gr_screen.res][INVERT_AXIS].button.enable(z);
-
-		if (!z) {
-			z = Cc_lines[Selected_line].cc_index;
-			k = Control_config[z].key_id;
-			if ( (k == KEY_LALT) || (k == KEY_RALT) || (k == KEY_LSHIFT) || (k == KEY_RSHIFT) ) {
-				CC_Buttons[gr_screen.res][ALT_TOGGLE].button.enable(0);
-				CC_Buttons[gr_screen.res][SHIFT_TOGGLE].button.enable(0);
-			}
-		}
-
-		CC_Buttons[gr_screen.res][UNDO_BUTTON].button.enable(Config_item_undo != NULL);
-
-		if ( help_overlay_active(Control_config_overlay_id) ) {
-			CC_Buttons[gr_screen.res][HELP_BUTTON].button.reset_status();
-			Ui_window.set_ignore_gadgets(1);
-		}
-
-		k = Ui_window.process();
-
-		if ( (k > 0) || B1_JUST_RELEASED ) {
-			if ( help_overlay_active(Control_config_overlay_id) ) {
-				help_overlay_set_state(Control_config_overlay_id, gr_screen.res, 0);
-				Ui_window.set_ignore_gadgets(0);
-				k = 0;
-			}
-		}
-
-		if ( !help_overlay_active(Control_config_overlay_id) ) {
-			Ui_window.set_ignore_gadgets(0);
-		}
-
-		switch (k) {
-			case KEY_DOWN:  // select next line
-				control_config_scroll_line_down();
-				break;
-
-			case KEY_UP:  // select previous line
-				control_config_scroll_line_up();
-				break;
-
-			case KEY_SHIFTED | KEY_TAB:  // activate previous tab
-				Tab--;
-				if (Tab < 0) {
-					Tab = NUM_TABS - 1;
-				}
-
-				Scroll_offset = Selected_line = 0;
-				control_config_list_prepare();
-				gamesnd_play_iface(SND_SCREEN_MODE_PRESSED);
-				break;
-
-			case KEY_TAB:  // activate next tab
-				Tab++;
-				if (Tab >= NUM_TABS) {
-					Tab = 0;
-				}
-
-				Scroll_offset = Selected_line = 0;
-				control_config_list_prepare();
-				gamesnd_play_iface(SND_SCREEN_MODE_PRESSED);
-				break;
-
-			case KEY_LEFT:
-				Selected_item--;
-				if (Selected_item == -2) {
-					Selected_item = 1;
-					if (Cc_lines[Selected_line].jw < 1) {
-						Selected_item = 0;
-						if (Cc_lines[Selected_line].kw < 1) {
-							Selected_item = -1;
-						}
-					}
-				}
-
-				gamesnd_play_iface(SND_SCROLL);
-				break;
-
-			case KEY_RIGHT:
-				Selected_item++;
-				if ((Selected_item == 1) && (Cc_lines[Selected_line].jw < 1)) {
-					Selected_item = -1;
-				} else if (!Selected_item && (Cc_lines[Selected_line].kw < 1)) {
-					Selected_item = -1;
-				} else if (Selected_item > 1) {
-					Selected_item = -1;
-				}
-				gamesnd_play_iface(SND_SCROLL);
-				break;
-
-			case KEY_BACKSP:  // undo
-				control_config_undo_last();
-				break;
-
-			case KEY_ESC:
-				control_config_cancel_exit();
-				break;
-		}	// end switch
-	}
-
-	for (i=0; i<NUM_BUTTONS; i++){
-		if (CC_Buttons[gr_screen.res][i].button.pressed()){
-			control_config_button_pressed(i);
-		}
-	}
-
-	for (i=0; i<LIST_BUTTONS_MAX; i++) {
-		if (List_buttons[i].is_mouse_on()) {
-			select_tease_line = i + Scroll_offset;
-		}
-	
-		if (List_buttons[i].pressed()) {
-			Selected_line = i + Scroll_offset;
-			Selected_item = -1;
-			List_buttons[i].get_mouse_pos(&x, &y);
-			if ((x >= Cc_lines[Selected_line].kx) && (x < Cc_lines[Selected_line].kx + Cc_lines[Selected_line].kw)) {
-				Selected_item = 0;
-			}
-
-			if ((x >= Cc_lines[Selected_line].jx) && (x < Cc_lines[Selected_line].jx + Cc_lines[Selected_line].jw)) {
-				Selected_item = 1;
-			}
-
-			gamesnd_play_iface(SND_USER_SELECT);
-		}
-
-		if (List_buttons[i].double_clicked()) {
-			control_config_do_bind();
-		}
-	}
-
-	GR_MAYBE_CLEAR_RES(Background_bitmap);
-	if (Background_bitmap >= 0) {
-		gr_set_bitmap(Background_bitmap);
-		gr_bitmap(0, 0, GR_RESIZE_MENU);
-	} 
-
-	// highlight tab with conflict
-	Ui_window.draw();
-	for (i=z=0; i<NUM_TABS; i++) {
-		if (Conflicts_tabs[i]) {
-			CC_Buttons[gr_screen.res][i].button.draw_forced(4);
-			z++;
-		}
-	}
-
-	if (z) {
-		// maybe switch from bright to normal
-		if((Conflict_stamp == -1) || timestamp_elapsed(Conflict_stamp)){
-			Conflict_bright = !Conflict_bright;
-
-			Conflict_stamp = timestamp(CONFLICT_FLASH_TIME);
-		}
-
-		// set color and font
-		font::set_font(font::FONT2);
-		if(Conflict_bright){
-			gr_set_color_fast(&Color_bright_red);
-		} else {
-			gr_set_color_fast(&Color_red);
-		}
-
-		// setup the conflict string
-		char conflict_str[512] = "";
-		strncpy(conflict_str, XSTR("Conflict!", 205), 511);
-		int sw, sh;
-		gr_get_string_size(&sw, &sh, conflict_str);
-
-		gr_string((gr_screen.max_w / 2) - (sw / 2), Conflict_warning_coords[gr_screen.res][1], conflict_str, GR_RESIZE_MENU);
-
-		font::set_font(font::FONT1);
-	} else {
-		// might as well always reset the conflict stamp
-		Conflict_stamp = -1;
-	}
-
-	for (i=0; i<NUM_TABS; i++) {
-		if (CC_Buttons[gr_screen.res][i].button.button_down()) {
-			break;
-		}
-	}
-
-	if (i == NUM_TABS) {
-		CC_Buttons[gr_screen.res][Tab].button.draw_forced(2);
-	}
-
-	if (Search_mode) {
-		CC_Buttons[gr_screen.res][SEARCH_MODE].button.draw_forced(2);
-	}
-
-	if (Selected_line >= 0) {
-		z = Cc_lines[Selected_line].cc_index;
-		if (z & JOY_AXIS) {
-			if (Invert_axis[z & ~JOY_AXIS]) {
-				CC_Buttons[gr_screen.res][INVERT_AXIS].button.draw_forced(2);
-			}
-
-		} else {
-			z = Control_config[z].key_id;
-			if (z >= 0) {
-				if (z & KEY_SHIFTED) {
-					CC_Buttons[gr_screen.res][SHIFT_TOGGLE].button.draw_forced(2);
-				}
-				if (z & KEY_ALTED) {
-					CC_Buttons[gr_screen.res][ALT_TOGGLE].button.draw_forced(2);
-				}
-			}
-		}
-	}
-
-	if (Binding_mode) {
-		CC_Buttons[gr_screen.res][BIND_BUTTON].button.draw_forced(2);
-	}
-
-	z = Cc_lines[Selected_line].cc_index;
-	x = Conflict_wnd_coords[gr_screen.res][CONTROL_X_COORD] + Conflict_wnd_coords[gr_screen.res][CONTROL_W_COORD] / 2;
-	y = Conflict_wnd_coords[gr_screen.res][CONTROL_Y_COORD] + Conflict_wnd_coords[gr_screen.res][CONTROL_H_COORD] / 2;
-	if (Binding_mode) {
-		int t;
-
-		t = (int) (timer * 3);
-		if (t % 2) {
-			gr_set_color_fast(&Color_text_normal);
-			gr_get_string_size(&w, NULL, XSTR( "?", 208));
-			gr_printf_menu(x - w / 2, y - font_height / 2, XSTR( "?", 208));
-		}
-
-	} else if (!(z & JOY_AXIS) && ((Conflicts[z].key >= 0) || (Conflicts[z].joy >= 0))) {
-		i = Conflicts[z].key;
-		if (i < 0) {
-			i = Conflicts[z].joy;
-		}
-
-		gr_set_color_fast(&Color_text_normal);
-		str = XSTR( "Control conflicts with:", 209);
-		gr_get_string_size(&w, NULL, str);
-		gr_printf_menu(x - w / 2, y - font_height, str);
-
-		if (Control_config[i].hasXSTR) {
-			strcpy_s(buf, XSTR(Control_config[i].text, CONTROL_CONFIG_XSTR + i));
-		} else {
-			strcpy_s(buf, Control_config[i].text);
-		}
-
-		font::force_fit_string(buf, 255, Conflict_wnd_coords[gr_screen.res][CONTROL_W_COORD]);
-		gr_get_string_size(&w, NULL, buf);
-		gr_printf_menu(x - w / 2, y, buf);
-
-	} else if (*bound_string) {
-		gr_set_color_fast(&Color_text_normal);
-		gr_get_string_size(&w, NULL, bound_string);
-		gr_printf_menu(x - w / 2, y - font_height / 2, bound_string);
-		if (timestamp_elapsed(bound_timestamp)) {
-			*bound_string = 0;
-		}
-	}
-
-	if (Cc_lines[Num_cc_lines - 1].y + font_height > Cc_lines[Scroll_offset].y + Control_list_coords[gr_screen.res][CONTROL_H_COORD]) {
-		gr_set_color_fast(&Color_white);
-		gr_printf_menu(Control_more_coords[gr_screen.res][CONTROL_X_COORD], Control_more_coords[gr_screen.res][CONTROL_Y_COORD], XSTR( "More...", 210));
-	}
-
-	conflict = 0;
-	line = Scroll_offset;
-	while (cc_line_query_visible(line)) {
-		z = Cc_lines[line].cc_index;
-		y = Control_list_coords[gr_screen.res][CONTROL_Y_COORD] + Cc_lines[line].y - Cc_lines[Scroll_offset].y;
-
-		List_buttons[line - Scroll_offset].update_dimensions(Control_list_coords[gr_screen.res][CONTROL_X_COORD], y, Control_list_coords[gr_screen.res][CONTROL_W_COORD], font_height);
-		List_buttons[line - Scroll_offset].enable(!Binding_mode);
-
-		Cc_lines[line].kw = Cc_lines[line].jw = 0;
-
-		if (line == Selected_line){
-			c = &Color_text_selected;
-		} else if (line == select_tease_line) {
-			c = &Color_text_subselected;
-		} else {
-			c = &Color_text_normal;
-		}
-
-		gr_set_color_fast(c);
-		if (Cc_lines[line].label) {
-			strcpy_s(buf, Cc_lines[line].label);
-			font::force_fit_string(buf, 255, Control_list_ctrl_w[gr_screen.res]);
-			gr_printf_menu(Control_list_coords[gr_screen.res][CONTROL_X_COORD], y, buf);
-		}
-
-		if (!(z & JOY_AXIS)) {
-			k = Control_config[z].key_id;
-			j = Control_config[z].joy_id;
-			x = Control_list_key_x[gr_screen.res];
-			*buf = 0;
-
-			if ((k < 0) && (j < 0)) {
-				gr_set_color_fast(&Color_grey);
-				gr_printf_menu(x, y, XSTR( "None", 211));
-
-			} else {
-				if (k >= 0) {
-					strcpy_s(buf, textify_scancode(k));
-					if (Conflicts[z].key >= 0) {
-						if (c == &Color_text_normal)
-							gr_set_color_fast(&Color_text_error);
-						else {
-							gr_set_color_fast(&Color_text_error_hi);
-							conflict++;
-						}
-
-					} else if (Selected_item == 1) {
-						gr_set_color_fast(&Color_text_normal);
-
-					} else {
-						gr_set_color_fast(c);
-					}
-
-					gr_printf_menu(x, y, buf);
-
-					Cc_lines[line].kx = x - Control_list_coords[gr_screen.res][CONTROL_X_COORD];
-					gr_get_string_size(&w, NULL, buf);
-					Cc_lines[line].kw = w;
-					x += w;
-
-					if (j >= 0) {
-						gr_set_color_fast(&Color_text_normal);
-						gr_printf_menu(x, y, XSTR( ", ", 212));
-						gr_get_string_size(&w, NULL, XSTR( ", ", 212));
-						x += w;
-					}
-				}
-
-				if (j >= 0) {
-					strcpy_s(buf, Joy_button_text[j]);
-					if (Conflicts[z].joy >= 0) {
-						if (c == &Color_text_normal) {
-							gr_set_color_fast(&Color_text_error);
-						} else {
-							gr_set_color_fast(&Color_text_error_hi);
-							conflict++;
-						}
-
-					} else if (!Selected_item) {
-						gr_set_color_fast(&Color_text_normal);
-
-					} else {
-						gr_set_color_fast(c);
-					}
-
-					font::force_fit_string(buf, 255, Control_list_key_w[gr_screen.res] + Control_list_key_x[gr_screen.res] - x);
-					gr_printf_menu(x, y, buf);
-
-					Cc_lines[line].jx = x - Control_list_coords[gr_screen.res][CONTROL_X_COORD];
-					gr_get_string_size(&Cc_lines[line].jw, NULL, buf);
-				}
-			}
-
-		} else {
-			x = Control_list_key_x[gr_screen.res];
-			j = Axis_map_to[z & ~JOY_AXIS];
-			if (Binding_mode && (line == Selected_line)) {
-				j = Axis_override;
-			}
-
-			if (j < 0) {
-				gr_set_color_fast(&Color_grey);
-				gr_printf_menu(x, y, XSTR( "None", 211));
-
-			} else {
-				if (Conflicts_axes[z & ~JOY_AXIS] >= 0) {
-					if (c == &Color_text_normal) {
-						gr_set_color_fast(&Color_text_error);
-
-					} else {
-						gr_set_color_fast(&Color_text_error_hi);
-						conflict++;
-					}
-
-				} else if (!Selected_item) {
-					gr_set_color_fast(&Color_text_normal);
-
-				} else {
-					gr_set_color_fast(c);
-				}
-
-				gr_string(x, y, Joy_axis_text[j], GR_RESIZE_MENU);
-			}
-		}
-
-		line++;
-	}
-
-	CC_Buttons[gr_screen.res][CLEAR_OTHER_BUTTON].button.enable(conflict);
-
-	i = line - Scroll_offset;
-	while (i < LIST_BUTTONS_MAX) {
-		List_buttons[i++].disable();
-	}
-
-	// If multiple controls presets are provided, display which one is in use
-	if (Control_config_presets.size() > 1) {
-		SCP_string preset_str;
-		int matching_preset = -1;
-
-		for (i=0; i<(int)Control_config_presets.size(); i++) {
-			bool this_preset_matches = true;
-			config_item *this_preset = Control_config_presets[i];
-
-			for (j=0; j<CCFG_MAX; j++) {
-				if (!Control_config[j].disabled && Control_config[j].key_id != this_preset[j].key_default) {
-					this_preset_matches = false;
-					break;
-				}
-			}
-
-			if (this_preset_matches) {
-				matching_preset = i;
-				break;
-			}
-		}
-
-		if (matching_preset >= 0) {
-			sprintf(preset_str, "Controls: %s", Control_config_preset_names[matching_preset].c_str());
-		} else {
-			sprintf(preset_str, "Controls: custom");
-			
-		}
-
-		gr_get_string_size(&w, NULL, preset_str.c_str());
-		gr_set_color_fast(&Color_text_normal);
-
-		if (gr_screen.res == GR_640) {
-			gr_string(16, (24 - font_height) / 2, preset_str.c_str(), GR_RESIZE_MENU);
-		} else {
-			gr_string(24, (40 - font_height) / 2, preset_str.c_str(), GR_RESIZE_MENU);
-		}
-	}
-
-	// blit help overlay if active
-	help_overlay_maybe_blit(Control_config_overlay_id, gr_screen.res);
-
-	gr_flip();
-}
-
-void clear_key_binding(short key)
-{
-	int i;
-
-	for (i=0; i<CCFG_MAX; i++) {
-		if (Control_config[i].key_id == key) {
-			Control_config[i].key_id = -1;
-		}
-	}
-}
-
-float check_control_timef(int id)
-{
-	float t1, t2;
-
-	// if type isn't continuous, we shouldn't be using this function, cause it won't work.
-	Assert(Control_config[id].type == CC_TYPE_CONTINUOUS);
-
-	// first, see if control actually used (makes sure modifiers match as well)
-	if (!check_control(id)) {
-		Control_config[id].continuous_ongoing = false;
-
-		return 0.0f;
-	}
-
-	t1 = key_down_timef(Control_config[id].key_id);
-	if (t1) {
-		control_used(id);
-	}
-
-	t2 = joy_down_time(Control_config[id].joy_id);
-	if (t2) {
-		control_used(id);
-	}
-
-	if (t1 + t2) {
-		// We want to set this to true only after visiting control_used() (above)
-		// to allow it to tell the difference between an ongoing continuous action
-		// started before and a continuous action being started right now.
-		Control_config[id].continuous_ongoing = true;
-
-		return t1 + t2;
-	}
-
-	return 1.0f;
-}
-
-void control_check_indicate()
-{
-#ifndef NDEBUG
-	if (Show_controls_info) {
-		gr_set_color_fast(&HUD_color_debug);
-		gr_printf_no_resize(gr_screen.center_offset_x + gr_screen.center_w - 154, gr_screen.center_offset_y + 5, NOX("Ctrls checked: %d"), Control_check_count);
-	}
-#endif
-
-	Control_check_count = 0;
-}
-
-int check_control_used(int id, int key)
-{
-	int z, mask;
-	static int last_key = 0;
-
-	Control_check_count++;
-	if (key < 0) {
-		key = last_key;
-	}
-
-	last_key = key;
-
-	// if we're in multiplayer text enter (for chat) mode, check to see if we should ignore controls
-	if ((Game_mode & GM_MULTIPLAYER) && multi_ignore_controls()){
-		return 0;
-	}
-
-	if (Control_config[id].disabled)
-		return 0;
-
-	if (Control_config[id].type == CC_TYPE_CONTINUOUS) {
-		if (joy_down(Control_config[id].joy_id) || joy_down_count(Control_config[id].joy_id, 1)) {
-			control_used(id);
-			return 1;
-		}
-
-		if ((Control_config[id].joy_id >= 0) && (Control_config[id].joy_id < MOUSE_NUM_BUTTONS)) {
-			if (mouse_down(1 << Control_config[id].joy_id) || mouse_down_count(1 << Control_config[id].joy_id)) {
-				control_used(id);
-				return 1;
-			}
-		}
-
-		// check what current modifiers are pressed
-		mask = 0;
-		if (keyd_pressed[KEY_LSHIFT] || key_down_count(KEY_LSHIFT) || keyd_pressed[KEY_RSHIFT] || key_down_count(KEY_RSHIFT)) {
-			mask |= KEY_SHIFTED;
-		}
-
-		if (keyd_pressed[KEY_LALT] || key_down_count(KEY_LALT) || keyd_pressed[KEY_RALT] || key_down_count(KEY_RALT)) {
-			mask |= KEY_ALTED;
-		}
-
-		z = Control_config[id].key_id;
-		if (z >= 0) {
-			if ( (z != KEY_LALT) && (z != KEY_RALT) && (z != KEY_LSHIFT) && (z != KEY_RSHIFT) ) {
-				// if current modifiers don't match action's modifiers, don't register control active.
-				if ((z & (KEY_SHIFTED | KEY_ALTED)) != mask) {
-					return 0;
-				}
-			}
-
-			z &= KEY_MASK;
-
-			if (keyd_pressed[z] || key_down_count(z)) {
-				control_used(id);
-				return 1;
-			}
-		}
-
-		return 0;
-	}
-
-	if ((Control_config[id].key_id == key) || joy_down_count(Control_config[id].joy_id, 1) ||
-			((Control_config[id].joy_id >= 0) && (Control_config[id].joy_id < MOUSE_NUM_BUTTONS) && mouse_down_count(1 << Control_config[id].joy_id))) {
-		//mprintf(("Key used %d", key));
-		control_used(id);
-		return 1;
-	}
-
-	return 0;
-}
-
-/**
-* Wrapper for check_control_used. Allows the game to ignore the key if told to do so by the ignore-key SEXP.
-*/
-int check_control(int id, int key) 
-{
-	if (check_control_used(id, key)) {
-		if (Ignored_keys[id]) {
-			if (Ignored_keys[id] > 0) {
-				Ignored_keys[id]--;
-			}
-			return 0;
-		}
-		return 1;
-	}
-
-	if (Control_config[id].continuous_ongoing) {
-		// If we reach this point, then it means this is a continuous control
-		// which has just been released
-
-		Script_system.SetHookVar("Action", 's', Control_config[id].text);
-		Script_system.RunCondition(CHA_ONACTIONSTOPPED, '\0', NULL, NULL, id);
-		Script_system.RemHookVar("Action");
-
-		Control_config[id].continuous_ongoing = false;
-	}
-
-	return 0;
-}
-
-// get heading, pitch, bank, throttle abs. and throttle rel. values.
-void control_get_axes_readings(int *h, int *p, int *b, int *ta, int *tr)
-{
-	int axes_values[JOY_NUM_AXES];
-
-	joystick_read_raw_axis(JOY_NUM_AXES, axes_values);
-
-	//	joy_get_scaled_reading will return a value represents the joystick pos from -1 to +1 (fixed point)
-	*h = 0;
-	if (Axis_map_to[0] >= 0) {
-		*h = joy_get_scaled_reading(axes_values[Axis_map_to[0]]);
-	}
-
-	*p = 0;
-	if (Axis_map_to[1] >= 0) {
-		*p = joy_get_scaled_reading(axes_values[Axis_map_to[1]]);
-	}
-
-	*b = 0;
-	if (Axis_map_to[2] >= 0) {
-		*b = joy_get_scaled_reading(axes_values[Axis_map_to[2]]);
-	}
-
-	*ta = 0;
-	if (Axis_map_to[3] >= 0) {
-		*ta = joy_get_unscaled_reading(axes_values[Axis_map_to[3]], Axis_map_to[3]);
-	}
-
-	*tr = 0;
-	if (Axis_map_to[4] >= 0) {
-		*tr = joy_get_scaled_reading(axes_values[Axis_map_to[4]]);
-	}
-
-	if (Invert_axis[0]) {
-		*h = -(*h);
-	}
-	if (Invert_axis[1]) {
-		*p = -(*p);
-	}
-	if (Invert_axis[2]) {
-		*b = -(*b);
-	}
-	if (Invert_axis[3]) {
-		*ta = F1_0 - *ta;
-	}
-	if (Invert_axis[4]) {
-		*tr = -(*tr);
-	}
-
-	return;
-}
-
-int Last_frame_timestamp;
-void control_used(int id)
-{
-	// if we have set this key to be ignored, ignore it
-	if (Ignored_keys[id]) {
-		return;
-	}
-
-	// This check needs to be done because the control code might call this function more than once per frame,
-	// and we don't want to run the hooks more than once per frame
-	if (Control_config[id].used < Last_frame_timestamp) {
-		if (!Control_config[id].continuous_ongoing) {
-			Script_system.SetHookVar("Action", 's', Control_config[id].text);
-			Script_system.RunCondition(CHA_ONACTION, '\0', NULL, NULL, id);
-			Script_system.RemHookVar("Action");
-
-			if (Control_config[id].type == CC_TYPE_CONTINUOUS)
-				Control_config[id].continuous_ongoing = true;
-		}
-
-		Control_config[id].used = timestamp();
-	}
-}
-
-void control_config_clear_used_status()
-{
-	int i;
-
-	for (i=0; i<CCFG_MAX; i++) {
-		Control_config[i].used = 0;
-	}
-}
-
-void control_config_clear()
-{
-	int i;
-
-	// Reset keyboard defaults
-	for (i=0; i<CCFG_MAX; i++) {
-		Control_config[i].key_id = Control_config[i].joy_id = -1;
-	}
-}
-
-int control_config_handle_conflict()
-{
-	return 0;
-}

--- a/code/controlconfig/controlsconfig.h
+++ b/code/controlconfig/controlsconfig.h
@@ -28,7 +28,6 @@ enum Joy_axis_index {
 	JOY_RZ_AXIS
 };
 
-
 /*!
  * These are used to index a corresponding (analog) action, namely controlling the orientation angles and throttle.
  */
@@ -45,8 +44,6 @@ enum Joy_axis_action_index {
 	NUM_JOY_AXIS_ACTIONS			//!< The total number of actions an axis may map to
 };
 
-
-
 /*!
  * Control Configuration Types. Namely differ in how the control is activated
  */
@@ -54,23 +51,6 @@ enum CC_type {
 	CC_TYPE_TRIGGER			=0,		//!< A normal, one-shot type control that is activated when a key is or button is pressed
 	CC_TYPE_CONTINUOUS				//!< A continous control that is activated as long as the key or button is held down
 };
-
-/*!
- * Control configuration item type.
- */
-typedef struct config_item {
-	short key_default;		//!< default key bound to action
-	short joy_default;		//!< default joystick button bound to action
-	char tab;				//!< what tab (category) it belongs in
-	bool hasXSTR;			//!< whether we should translate this with an XSTR
-	char *text;				//!< describes the action in the config screen
-	char type;				//!< manner control should be checked in
-	short key_id;			//!< actual key bound to action
-	short joy_id;			//!< joystick button bound to action
-	int used;				//!< has control been used yet in mission?  If so, this is the timestamp
-	bool disabled;			//!< whether this action should be available at all
-	bool continuous_ongoing;//!< whether this action is a continuous one and is currently ongoing
-} config_item;
 
 /*!
  * All available actions
@@ -276,6 +256,23 @@ enum IoActionId  {
 	CCFG_MAX                                  //!<  The total number of defined control actions (or last define + 1)
 };
 
+/*!
+ * Control configuration item type.
+ */
+typedef struct config_item {
+	short key_default;          //!< default key bound to action
+	short joy_default;          //!< default joystick button bound to action
+	char tab;                   //!< what tab (category) it belongs in
+	bool hasXSTR;               //!< whether we should translate this with an XSTR
+	char *text;                 //!< describes the action in the config screen
+	char type;                  //!< manner control should be checked in
+	short key_id;               //!< actual key bound to action
+	short joy_id;               //!< joystick button bound to action
+	int used;                   //!< has control been used yet in mission?  If so, this is the timestamp
+	bool disabled;              //!< whether this action should be available at all
+	bool continuous_ongoing;	//!< whether this action is a continuous one and is currently ongoing
+} config_item;
+
 extern int Failed_key_index;
 extern int Invert_heading;
 extern int Invert_pitch;
@@ -293,32 +290,114 @@ extern int Joy_sensitivity;
 
 extern int Control_config_overlay_id;
 
-extern config_item Control_config[];		//!< Stores the keyboard configuration
-extern SCP_vector<config_item*> Control_config_presets; // tabled control presets; pointers to config_item arrays
-extern SCP_vector<SCP_string> Control_config_preset_names; // names for Control_config_presets (identical order of items)
-extern char **Scan_code_text;
-extern char **Joy_button_text;
+extern config_item Control_config[];                        //!< Stores the keyboard configuration
+extern SCP_vector<config_item*> Control_config_presets;     //!< tabled control presets; pointers to config_item arrays
+extern SCP_vector<SCP_string> Control_config_preset_names;  //!< names for Control_config_presets (identical order of items)
+extern char **Scan_code_text;   //!< (Localization) Pointer to char[] containing key scancode names
+extern char **Joy_button_text;  //!< (Localization) Pointer to char[] containing mouse/joystick button names
 
-void control_config_common_init();			//!< initialize common control config stuff - call at game startup after localization has been initialized
-void control_config_common_close();			//!< close common control config stuff - call at game shutdown
+/*!
+ * @brief Initialize common control config stuff
+ *
+ * @details Called at game startup after localization has been initialized
+ */
+void control_config_common_init();
 
+/*!
+ * @brief Close common control config stuff
+ *
+ * @details Called at game shutdown
+ */
+void control_config_common_close();
+
+/*!
+ * @brief Initialize stuff needed for the control config menu
+ */
 void control_config_init();
+
+/*!
+ * @brief Does a frame on the control config menu
+ */
 void control_config_do_frame(float frametime);
+
+/*!
+ * @brief Called when the control config menu closes
+ */
 void control_config_close();
 
+/*!
+ * @brief Restores the Control_config mappings and exits the menu
+ */
 void control_config_cancel_exit();
 
+/*!
+ * @brief Sets all the controls to the default values in the given preset
+ *
+ * @details If no preset is given, the hardcoded defaults of Control_config are used
+ */
 void control_config_reset_defaults(int presetnum=-1);
+
+/*!
+ * @brief translates the given keycode to a corresponding action
+ *
+ * @param[in] key Pointer to the keycode to translate
+ * @param[in] find_override If true, return the index of the action bound to this key.
+ *                          If false, return the index of the action defaulting to this key
+ */
 int translate_key_to_index(const char *key, bool find_override=true);
+
+/*!
+ * @brief Given the system default key 'key', return the current key that is bound to that function.
+ *
+ * @details Both are 'key' and the return value are descriptive strings that can be displayed directly to the user.
+ *    If 'key' isn't a real key, is not normally bound to anything, or there is no key currently bound to the
+ *  function, NULL is returned.
+ */
 char *translate_key(char *key);
+
+/*!
+ * @brief translates a key code into human-readable format. (Some localization provided)
+ */
 char *textify_scancode(int code);
+
+/*!
+ * @brief Used for CC_TYPE_CONTINOUS actions, checks how long this action has been activated by all controllers
+ */
 float check_control_timef(int id);
+
+/*!
+ * @brief Wrapper for check_control_used. Allows the game to ignore the key if told to do so by the ignore-key SEXP.
+ */
 int check_control(int id, int key = -1);
+
+/*!
+ * @brief Gets heading, pitch, bank, throttle abs. and throttle rel. values.
+ */
 void control_get_axes_readings(int *h, int *p, int *b, int *ta, int *tr);
+
+/*!
+ * Marks a control (indexed by id) as being used/activated, unless explicitly ignored (by a SEXP or script)
+ */
 void control_used(int id);
+
+/*!
+ * Clears all mapped keys and buttons
+ */
 void control_config_clear();
+
+/*!
+ * Unbinds the given key from all controls
+ */
 void clear_key_binding(short key);
+
+/*!
+ * @brief DEBUG: Draws a text string indicating the number of checked controls
+ */
 void control_check_indicate();
+
+/*!
+ * @brief Clears the config_item::used member on all controls
+ */
 void control_config_clear_used_status();
 
 int joy_get_scaled_reading(int raw);

--- a/code/controlconfig/controlsconfig.h
+++ b/code/controlconfig/controlsconfig.h
@@ -274,12 +274,6 @@ typedef struct config_item {
 } config_item;
 
 extern int Failed_key_index;
-extern int Invert_heading;
-extern int Invert_pitch;
-extern int Invert_roll;
-extern int Invert_thrust;
-extern int Disable_axis2;
-extern int Disable_axis3;
 
 extern int Axis_map_to[];
 extern int Invert_axis[];

--- a/code/controlconfig/controlsconfigcommon.cpp
+++ b/code/controlconfig/controlsconfigcommon.cpp
@@ -7,9 +7,6 @@
  *
 */ 
 
-#include <stdio.h>
-#include <stdarg.h>
-
 #include "cfile/cfile.h"
 #include "controlconfig/controlsconfig.h"
 #include "def_files/def_files.h"
@@ -19,30 +16,31 @@
 #include "localization/localize.h"
 #include "parse/parselo.h"
 
+#include <cstdio>
+#include <cstdarg>
+#include <map>
+#include <string>
+
+
 // z64: These enumerations MUST equal to those in controlsconfig.cpp...
 // z64: Really need a better way than this.
-enum CC_tab {
-	TARGET_TAB			=0,
-	SHIP_TAB			=1,
-	WEAPON_TAB			=2,
-	COMPUTER_TAB		=3
+enum CC_tab
+{
+	TARGET_TAB   = 0,
+	SHIP_TAB     = 1,
+	WEAPON_TAB   = 2,
+	COMPUTER_TAB = 3
 };
 
 int Failed_key_index;
 
-// Joystick configuration
+int Axis_enabled[JOY_NUM_AXES]          = { 1, 1, 1, 0, 0, 0 };
+int Axis_enabled_defaults[JOY_NUM_AXES] = { 1, 1, 1, 0, 0, 0 };
+int Invert_axis[JOY_NUM_AXES]           = { 0, 0, 0, 0, 0, 0 };
+int Invert_axis_defaults[JOY_NUM_AXES]  = { 0, 0, 0, 0, 0, 0 }
+
 int Joy_dead_zone_size = 10;
 int Joy_sensitivity = 9;
-
-// assume control keys are used as modifiers until we find out 
-int Shift_is_modifier;
-int Ctrl_is_modifier;
-int Alt_is_modifier;
-
-int Axis_enabled[JOY_NUM_AXES] = { 1, 1, 1, 0, 0, 0 };
-int Axis_enabled_defaults[JOY_NUM_AXES] = { 1, 1, 1, 0, 0, 0 };
-int Invert_axis[JOY_NUM_AXES] = { 0, 0, 0, 0, 0, 0 };
-int Invert_axis_defaults[JOY_NUM_AXES] = { 0, 0, 0, 0, 0, 0 };
 
 //! arrays which hold the key mappings.  The array index represents a key-independent action.
 //! please use SPACES for aligning the fields of this array
@@ -199,6 +197,8 @@ config_item Control_config[CCFG_MAX + 1] = {
 	{                           -1,                 -1, -1,           false, "",                                       CC_TYPE_TRIGGER,    -1, -1, 0, false, false }
 };
 
+//!	This is the text that is displayed on the screen for the keys a player selects (second column labels)
+// Just forget about trying to format these arrays to any particular style for the moment. :ugh:
 char *Scan_code_text_german[] = {
 	"",				"Esc",				"1",				"2",				"3",				"4",				"5",				"6",
 	"7",				"8",				"9",				"0",				"Akzent '",				"Eszett",				"R\x81""cktaste",		"Tab",
@@ -352,7 +352,6 @@ char *Joy_button_text_polish[] = {
 	"Przyc.31",	"Przyc.32",	"Hat Ty\xB3",		"Hat Prz\xF3\x64",	"Hat Lewo",		"Hat Prawo"
 };
 
-//!	This is the text that is displayed on the screen for the keys a player selects
 char *Scan_code_text_english[] = {
 	"",				"Esc",			"1",				"2",				"3",				"4",				"5",				"6",
 	"7",				"8",				"9",				"0",				"-",				"=",				"Backspace",	"Tab",
@@ -410,202 +409,75 @@ char **Joy_button_text = Joy_button_text_english;
 SCP_vector<config_item*> Control_config_presets;
 SCP_vector<SCP_string> Control_config_preset_names;
 
-void set_modifier_status()
+SCP_map<SCP_string, int> mKeyNameToVal;
+SCP_map<SCP_string, CC_type> mCCTypeNameToVal;
+SCP_map<SCP_string, char> mCCTabNameToVal;
+
+// --------------------------------------------------------------------------------------------------------------------
+// Inherited/Friended methods
+// --------------------------------------------------------------------------------------------------------------------
+
+// --------------------------------------------------------------------------------------------------------------------
+// Declaration of protected functions.
+// --------------------------------------------------------------------------------------------------------------------
+
+
+// --------------------------------------------------------------------------------------------------------------------
+// Declaration of private functions(declared as static type func(type param);)
+// --------------------------------------------------------------------------------------------------------------------
+/**
+ * @brief Parses controlconfigdefault.tbl, and overrides the default control configuration for each valid entry in the .tbl
+ */
+static void control_config_common_load_overrides();
+
+/**
+ * @brief Helper function to LoadEnumsIntoMaps(), Loads the Keyboard definitions/enumerations into mKeyNameToVal
+ */
+static void LoadEnumsIntoKeyMap();
+
+/**
+ * @brief Helper for LoadEnumsIntoMaps(), loads the CC_TYPE defines's into mCCTabNameToVal
+ */
+static void LoadEnumsIntoCCTypeMap();
+
+/**
+ * @brief Helper for LoadEnumsIntoMaps(), loads the CC_tab enum's into mCCTabNameToVal
+ */
+static void LoadEnumsIntoCCTabMap();
+
+/**
+ * @brief Loads the various control config maps to allow the parsing functions to map string tokens into enum's.
+ *
+ * @details The string tokens in the controlconfigdefaults.tbl match directly to their names in the C++ code, such as
+ *   "KEY_5" in the .tbl mapping to the #define KEY_5 value
+ */
+static void LoadEnumsIntoMaps();
+
+// --------------------------------------------------------------------------------------------------------------------
+// Definition of all functions, in alphabetical order
+// --------------------------------------------------------------------------------------------------------------------
+void control_config_common_close()
 {
-	int i;
-
-	Alt_is_modifier = 0;
-	Shift_is_modifier = 0;
-	Ctrl_is_modifier = 0;
-
-	for (i=0; i<CCFG_MAX; i++) {
-		if (Control_config[i].key_id < 0)
-			continue;
-
-		if (Control_config[i].key_id & KEY_ALTED)
-			Alt_is_modifier = 1;
-
-		if (Control_config[i].key_id & KEY_SHIFTED)
-			Shift_is_modifier = 1;
-
-		if (Control_config[i].key_id & KEY_CTRLED) {
-			Assert(0);  // get Alan
-			Ctrl_is_modifier = 1;
-		}
+	// only need to worry control presets for now
+	for (auto ii = Control_config_presets.cbegin(); ii != Control_config_presets.cend(); ++ii) {
+		delete * ii;
 	}
 }
 
-// If find_override is set to true, then this returns the index of the action
-// which has been bound to the given key. Otherwise, the index of the action
-// which has the given key as its default key will be returned.
-int translate_key_to_index(const char *key, bool find_override)
-{
-	int i, index = -1, alt = 0, shift = 0, max_scan_codes;
-
-	max_scan_codes = sizeof(Scan_code_text_english) / sizeof(char *);
-
-	// look for modifiers
-	Assert(key);
-	if (!strnicmp(key, "Alt", 3)) {
-		alt = 1;
-		key += 3;
-		if (*key)
-			key++;
-	}
-
-	if (!strnicmp(key, "Shift", 5)) {
-		shift = 1;
-		key += 5;
-		if (*key)
-			key++;
-	}
-
-	// look up index for default key
-	if (*key) {
-		for (i=0; i<max_scan_codes; i++)
-			if (!stricmp(key, Scan_code_text_english[i])) {
-				index = i;
-				break;
-			}
-
-		if (i == max_scan_codes)
-			return -1;
-
-		if (shift)
-			index |= KEY_SHIFTED;
-		if (alt)
-			index |= KEY_ALTED;
-
-		// convert scancode to Control_config index
-		if (find_override) {
-			for (i=0; i<CCFG_MAX; i++) {
-				if (!Control_config[i].disabled && Control_config[i].key_id == index) {
-					index = i;
-					break;
-				}
-			}
-		} else {
-			for (i=0; i<CCFG_MAX; i++) {
-				if (!Control_config[i].disabled && Control_config[i].key_default == index) {
-					index = i;
-					break;
-				}
-			}
-		}
-
-		if (i == CCFG_MAX)
-			return -1;
-
-		return index;
-	}
-
-	return -1;
-}
-
-/*! Given the system default key 'key', return the current key that is bound to that function.
-* Both are 'key' and the return value are descriptive strings that can be displayed
-* directly to the user.  If 'key' isn't a real key, is not normally bound to anything,
-* or there is no key currently bound to the function, NULL is returned.
-*/
-char *translate_key(char *key)
-{
-	int index = -1, key_code = -1, joy_code = -1;
-	char *key_text = NULL;
-	char *joy_text = NULL;
-
-	static char text[40] = {"None"};
-
-	index = translate_key_to_index(key, false);
-	if (index < 0) {
-		return NULL;
-	}
-
-	key_code = Control_config[index].key_id;
-	joy_code = Control_config[index].joy_id;
-
-	Failed_key_index = index;
-
-	if (key_code >= 0) {
-		key_text = textify_scancode(key_code);
-	}
-
-	if (joy_code >= 0) {
-		joy_text = Joy_button_text[joy_code];
-	}
-
-	// both key and joystick button are mapped to this control
-	if ((key_code >= 0 ) && (joy_code >= 0) ) {
-		strcpy_s(text, key_text);
-		strcat_s(text, " or ");
-		strcat_s(text, joy_text);
-	}
-	// if we only have one
-	else if (key_code >= 0 ) {
-		strcpy_s(text, key_text);
-	}
-	else if (joy_code >= 0) {
-		strcpy_s(text, joy_text);
-	}
-	else {
-		strcpy_s(text, "None");
-	}
-
-	return text;
-}
-
-char *textify_scancode(int code)
-{
-	static char text[40];
-
-	if (code < 0)
-		return "None";
-
-	int keycode = code & KEY_MASK;
-
-	*text = 0;
-	if (code & KEY_ALTED && !(keycode == KEY_LALT || keycode == KEY_RALT)) {
-		if(Lcl_gr){		
-			strcat_s(text, "Alt-");
-		} else if(Lcl_fr){		
-			strcat_s(text, "Alt-");
-		} else {		
-			strcat_s(text, "Alt-");
-		}		
-	}
-
-	if (code & KEY_SHIFTED && !(keycode == KEY_LSHIFT || keycode == KEY_RSHIFT)) {		
-		if(Lcl_gr){
-			strcat_s(text, "Shift-");
-		} else if(Lcl_fr){		
-			strcat_s(text, "Maj.-");
-		} else {		
-			strcat_s(text, "Shift-");
-		}
-	}
-
-	strcat_s(text, Scan_code_text[keycode]);
-	return text;
-}
-//XSTR:ON
-
-void control_config_common_load_overrides();
-
-// initialize common control config stuff - call at game startup after localization has been initialized
-void control_config_common_init()
-{
-	for (int i=0; i<CCFG_MAX; i++) {
+void control_config_common_init() {
+	for (int i = 0; i<CCFG_MAX; i++) {
 		Control_config[i].disabled = false;
 		Control_config[i].continuous_ongoing = false;
 	}
 
 	control_config_common_load_overrides();
-	if(Lcl_gr){
+	if (Lcl_gr) {
 		Scan_code_text = Scan_code_text_german;
 		Joy_button_text = Joy_button_text_german;
-	} else if(Lcl_fr){
+	} else if (Lcl_fr) {
 		Scan_code_text = Scan_code_text_french;
 		Joy_button_text = Joy_button_text_french;
-	} else if(Lcl_pl){
+	} else if (Lcl_pl) {
 		Scan_code_text = Scan_code_text_polish;
 		Joy_button_text = Joy_button_text_polish;
 	} else {
@@ -614,27 +486,148 @@ void control_config_common_init()
 	}
 }
 
-/*
- * @brief close any common control config stuff, called at game_shutdown()
- */
-void control_config_common_close()
-{
-	// only need to worry control presets for now
-	for (auto ii = Control_config_presets.cbegin(); ii != Control_config_presets.cend(); ++ii) {
-		delete[] * ii;
+void control_config_common_load_overrides() {
+	LoadEnumsIntoMaps();
+
+	if (cf_exists_full("controlconfigdefaults.tbl", CF_TYPE_TABLES)) {
+		read_file_text("controlconfigdefaults.tbl", CF_TYPE_TABLES);
+	} else {
+		read_file_text_from_array(defaults_get_file("controlconfigdefaults.tbl"));
+	}
+
+	reset_parse();
+
+	// start parsing
+	// TODO: Split this out into more helps. Too many tabs!
+	while (optional_string("#ControlConfigOverride")) {
+		config_item *cfg_preset = new config_item[CCFG_MAX + 1];
+		std::copy(Control_config, Control_config + CCFG_MAX + 1, cfg_preset);
+		Control_config_presets.push_back(cfg_preset);
+
+		SCP_string preset_name;
+		if (optional_string("$Name:")) {
+			stuff_string_line(preset_name);
+		} else {
+			preset_name = "<unnamed preset>";
+		}
+		Control_config_preset_names.push_back(preset_name);
+
+		while (required_string_either("#End", "$Bind Name:")) {
+			const int iBufferLength = 64;
+			char szTempBuffer[iBufferLength];
+
+			required_string("$Bind Name:");
+			stuff_string(szTempBuffer, F_NAME, iBufferLength);
+
+			const size_t cCntrlAryLength = sizeof(Control_config) / sizeof(Control_config[0]);
+			for (size_t i = 0; i < cCntrlAryLength; ++i) {
+				config_item& r_ccConfig = cfg_preset[i];
+
+				if (!strcmp(szTempBuffer, r_ccConfig.text)) {
+					/**
+					* short key_default;
+					* short joy_default;
+					* char tab;
+					* bool hasXSTR;
+					* char type;
+					*/
+
+					int iTemp;
+
+					if (optional_string("$Key Default:")) {
+						if (optional_string("NONE")) {
+							r_ccConfig.key_default = (short) -1;
+						} else {
+							stuff_string(szTempBuffer, F_NAME, iBufferLength);
+							r_ccConfig.key_default = (short) mKeyNameToVal[szTempBuffer];
+						}
+					}
+
+					if (optional_string("$Joy Default:")) {
+						stuff_int(&iTemp);
+						r_ccConfig.joy_default = (short) iTemp;
+					}
+
+					if (optional_string("$Key Mod Shift:")) {
+						stuff_int(&iTemp);
+						r_ccConfig.key_default |= (iTemp == 1) ? KEY_SHIFTED : 0;
+					}
+
+					if (optional_string("$Key Mod Alt:")) {
+						stuff_int(&iTemp);
+						r_ccConfig.key_default |= (iTemp == 1) ? KEY_ALTED : 0;
+					}
+
+					if (optional_string("$Key Mod Ctrl:")) {
+						stuff_int(&iTemp);
+						r_ccConfig.key_default |= (iTemp == 1) ? KEY_CTRLED : 0;
+					}
+
+					if (optional_string("$Category:")) {
+						stuff_string(szTempBuffer, F_NAME, iBufferLength);
+						r_ccConfig.tab = (char) mCCTabNameToVal[szTempBuffer];
+					}
+
+					if (optional_string("$Has XStr:")) {
+						stuff_int(&iTemp);
+						r_ccConfig.hasXSTR = (iTemp == 1);
+					}
+
+					if (optional_string("$Type:")) {
+						stuff_string(szTempBuffer, F_NAME, iBufferLength);
+						r_ccConfig.type = (char) mCCTypeNameToVal[szTempBuffer];
+					}
+
+					if (optional_string("+Disable")) {
+						r_ccConfig.disabled = true;
+					}
+					if (optional_string("$Disable:")) {
+						stuff_boolean(&r_ccConfig.disabled);
+					}
+
+					// Nerf the buffer now.
+					szTempBuffer[0] = '\0';
+				} else if ((i + 1) == cCntrlAryLength) {
+					error_display(1, "Bind Name not found: %s\n", szTempBuffer);
+					advance_to_eoln(NULL);
+					ignore_white_space();
+					return;
+				}
+			}
+		}
+
+		required_string("#End");
+	}
+
+	// Overwrite the control config with the first preset that was found
+	if (Control_config_presets.size() > 0) {
+		std::copy(Control_config_presets[0], Control_config_presets[0] + CCFG_MAX + 1, Control_config);
 	}
 }
 
+void LoadEnumsIntoCCTabMap() {
+	// Dirty macro hack :D
+#define ADD_ENUM_TO_CCTAB_MAP(Enum) mCCTabNameToVal[#Enum] = (Enum);
 
-#include <map>
-#include <string>
-SCP_map<SCP_string, int> mKeyNameToVal;
-SCP_map<SCP_string, CC_type> mCCTypeNameToVal;
-SCP_map<SCP_string, char> mCCTabNameToVal;
+	ADD_ENUM_TO_CCTAB_MAP(TARGET_TAB)
+		ADD_ENUM_TO_CCTAB_MAP(SHIP_TAB)
+		ADD_ENUM_TO_CCTAB_MAP(WEAPON_TAB)
+		ADD_ENUM_TO_CCTAB_MAP(COMPUTER_TAB)
 
-/*! Helper function to LoadEnumsIntoMaps(), Loads the Keyboard definitions/enumerations into mKeyNameToVal
-*/
-void LoadEnumsIntoKeyMap(void) {
+#undef ADD_ENUM_TO_CCTAB_MAP
+}
+
+void LoadEnumsIntoCCTypeMap() {
+	// Dirty macro hack :D
+#define ADD_ENUM_TO_CCTYPE_MAP(Enum) mCCTypeNameToVal[#Enum] = (Enum);
+
+	ADD_ENUM_TO_CCTYPE_MAP(CC_TYPE_TRIGGER)
+		ADD_ENUM_TO_CCTYPE_MAP(CC_TYPE_CONTINUOUS)
+
+#undef ADD_ENUM_TO_CCTYPE_MAP
+}
+
+void LoadEnumsIntoKeyMap() {
 	// Dirty macro hack :D
 #define ADD_ENUM_TO_KEY_MAP(Enum) mKeyNameToVal[#Enum] = (Enum);
 
@@ -768,161 +761,147 @@ void LoadEnumsIntoKeyMap(void) {
 #undef ADD_ENUM_TO_KEY_MAP
 }
 
-/*! Helper function to LoadEnumsIntoMaps(), Loads the Control Types enumerations into mCCTypeNameToVal
- */
-void LoadEnumsIntoCCTypeMap(void) {
-	// Dirty macro hack :D
-#define ADD_ENUM_TO_CCTYPE_MAP(Enum) mCCTypeNameToVal[#Enum] = (Enum);
-
-	ADD_ENUM_TO_CCTYPE_MAP(CC_TYPE_TRIGGER)
-		ADD_ENUM_TO_CCTYPE_MAP(CC_TYPE_CONTINUOUS)
-
-#undef ADD_ENUM_TO_CCTYPE_MAP
-}
-
-/*! Helper function to LoadEnumsIntoMaps(), Loads the Control Tabs enumerations into mCCTabNameToVal
- */
-void LoadEnumsIntoCCTabMap(void) {
-	// Dirty macro hack :D
-#define ADD_ENUM_TO_CCTAB_MAP(Enum) mCCTabNameToVal[#Enum] = (Enum);
-
-	ADD_ENUM_TO_CCTAB_MAP(TARGET_TAB)
-	ADD_ENUM_TO_CCTAB_MAP(SHIP_TAB)
-	ADD_ENUM_TO_CCTAB_MAP(WEAPON_TAB)
-	ADD_ENUM_TO_CCTAB_MAP(COMPUTER_TAB)
-
-#undef ADD_ENUM_TO_CCTAB_MAP
-}
-
-/*! Loads the various control configuration maps to allow the parsing functions to appropriately map string tokns to
-* their associated enumerations. The string tokens in the controlconfigdefaults.tbl match directly to their names in
-* the C++ code, such as "KEY_5" in the .tbl mapping to the #define KEY_5 value
-*/
 void LoadEnumsIntoMaps() {
 	LoadEnumsIntoKeyMap();
 	LoadEnumsIntoCCTypeMap();
 	LoadEnumsIntoCCTabMap();
 }
 
-/**
- * @brief Parses controlconfigdefault.tbl, and overrides the default control configuration for each valid entry in the .tbl
- */
-void control_config_common_load_overrides()
-{
-	LoadEnumsIntoMaps();
+char *textify_scancode(int code) {
+	static char text[40];
 
-	if (cf_exists_full("controlconfigdefaults.tbl", CF_TYPE_TABLES)) {
-		read_file_text("controlconfigdefaults.tbl", CF_TYPE_TABLES);
-	} else {
-		read_file_text_from_default(defaults_get_file("controlconfigdefaults.tbl"));
+	if (code < 0)
+		return "None";
+
+	int keycode = code & KEY_MASK;
+
+	*text = 0;
+	if (code & KEY_ALTED && !(keycode == KEY_LALT || keycode == KEY_RALT)) {
+		if (Lcl_gr) {
+			strcat_s(text, "Alt-");
+		} else if (Lcl_fr) {
+			strcat_s(text, "Alt-");
+		} else {
+			strcat_s(text, "Alt-");
+		}
 	}
 
-	reset_parse();
-
-	// start parsing
-	// TODO: Split this out into more helps. Too many tabs!
-	while(optional_string("#ControlConfigOverride")) {
-		config_item *cfg_preset = new config_item[CCFG_MAX + 1];
-		std::copy(Control_config, Control_config + CCFG_MAX + 1, cfg_preset);
-		Control_config_presets.push_back(cfg_preset);
-
-		SCP_string preset_name;
-		if (optional_string("$Name:")) {
-			stuff_string_line(preset_name);
+	if (code & KEY_SHIFTED && !(keycode == KEY_LSHIFT || keycode == KEY_RSHIFT)) {
+		if (Lcl_gr) {
+			strcat_s(text, "Shift-");
+		} else if (Lcl_fr) {
+			strcat_s(text, "Maj.-");
 		} else {
-			preset_name = "<unnamed preset>";
+			strcat_s(text, "Shift-");
 		}
-		Control_config_preset_names.push_back(preset_name);
+	}
 
-		while (required_string_either("#End","$Bind Name:")) {
-			const int iBufferLength = 64;
-			char szTempBuffer[iBufferLength];
+	strcat_s(text, Scan_code_text[keycode]);
+	return text;
+}
 
-			required_string("$Bind Name:");
-			stuff_string(szTempBuffer, F_NAME, iBufferLength);
+char *translate_key(char *key) {
+	int index = -1, key_code = -1, joy_code = -1;
+	char *key_text = NULL;
+	char *joy_text = NULL;
 
-			const size_t cCntrlAryLength = sizeof(Control_config) / sizeof(Control_config[0]);
-			for (size_t i = 0; i < cCntrlAryLength; ++i) {
-				config_item& r_ccConfig = cfg_preset[i];
+	static char text[40] = { "None" };
 
-				if (!strcmp(szTempBuffer, r_ccConfig.text)) {
-					/**
-					* short key_default;
-					* short joy_default;
-					* char tab;
-					* bool hasXSTR;
-					* char type;
-					*/
+	index = translate_key_to_index(key, false);
+	if (index < 0) {
+		return NULL;
+	}
 
-					int iTemp;
+	key_code = Control_config[index].key_id;
+	joy_code = Control_config[index].joy_id;
 
-					if (optional_string("$Key Default:")) {
-						if (optional_string("NONE")) {
-							r_ccConfig.key_default = (short)-1;
-						} else {
-							stuff_string(szTempBuffer, F_NAME, iBufferLength);
-							r_ccConfig.key_default = (short)mKeyNameToVal[szTempBuffer];
-						}
-					}
+	Failed_key_index = index;
 
-					if (optional_string("$Joy Default:")) {
-						stuff_int(&iTemp);
-						r_ccConfig.joy_default = (short)iTemp;
-					}
+	if (key_code >= 0) {
+		key_text = textify_scancode(key_code);
+	}
 
-					if (optional_string("$Key Mod Shift:")) {
-						stuff_int(&iTemp);
-						r_ccConfig.key_default |= (iTemp == 1) ? KEY_SHIFTED : 0;
-					}
+	if (joy_code >= 0) {
+		joy_text = Joy_button_text[joy_code];
+	}
 
-					if (optional_string("$Key Mod Alt:")) {
-						stuff_int(&iTemp);
-						r_ccConfig.key_default |= (iTemp == 1) ? KEY_ALTED : 0;
-					}
+	// both key and joystick button are mapped to this control
+	if ((key_code >= 0) && (joy_code >= 0)) {
+		strcpy_s(text, key_text);
+		strcat_s(text, " or ");
+		strcat_s(text, joy_text);
+	}
+	// if we only have one
+	else if (key_code >= 0) {
+		strcpy_s(text, key_text);
+	} else if (joy_code >= 0) {
+		strcpy_s(text, joy_text);
+	} else {
+		strcpy_s(text, "None");
+	}
 
-					if (optional_string("$Key Mod Ctrl:")) {
-						stuff_int(&iTemp);
-						r_ccConfig.key_default |= (iTemp == 1) ? KEY_CTRLED : 0;
-					}
+	return text;
+}
 
-					if (optional_string("$Category:")) {
-						stuff_string(szTempBuffer, F_NAME, iBufferLength);
-						r_ccConfig.tab = (char)mCCTabNameToVal[szTempBuffer];
-					}
+int translate_key_to_index(const char *key, bool find_override) {
+	int i, index = -1, alt = 0, shift = 0, max_scan_codes;
 
-					if (optional_string("$Has XStr:")) {
-						stuff_int(&iTemp);
-						r_ccConfig.hasXSTR = (iTemp == 1);
-					}
+	max_scan_codes = sizeof(Scan_code_text_english) / sizeof(char *);
 
-					if (optional_string("$Type:")) {
-						stuff_string(szTempBuffer, F_NAME, iBufferLength);
-						r_ccConfig.type = (char)mCCTypeNameToVal[szTempBuffer];
-					}
+	// look for modifiers
+	Assert(key);
+	if (!strnicmp(key, "Alt", 3)) {
+		alt = 1;
+		key += 3;
+		if (*key)
+			key++;
+	}
 
-					if (optional_string("+Disable")) {
-						r_ccConfig.disabled = true;
-					}
-					if (optional_string("$Disable:")) {
-						stuff_boolean(&r_ccConfig.disabled);
-					}
-					
-					// Nerf the buffer now.
-					szTempBuffer[0] = '\0';
-				} else if ((i + 1) == cCntrlAryLength) {
-					error_display(1, "Bind Name not found: %s\n", szTempBuffer);
-					advance_to_eoln(NULL);
-					ignore_white_space();
-					return;
+	if (!strnicmp(key, "Shift", 5)) {
+		shift = 1;
+		key += 5;
+		if (*key)
+			key++;
+	}
+
+	// look up index for default key
+	if (*key) {
+		for (i = 0; i<max_scan_codes; i++)
+			if (!stricmp(key, Scan_code_text_english[i])) {
+				index = i;
+				break;
+			}
+
+		if (i == max_scan_codes)
+			return -1;
+
+		if (shift)
+			index |= KEY_SHIFTED;
+		if (alt)
+			index |= KEY_ALTED;
+
+		// convert scancode to Control_config index
+		if (find_override) {
+			for (i = 0; i<CCFG_MAX; i++) {
+				if (!Control_config[i].disabled && Control_config[i].key_id == index) {
+					index = i;
+					break;
+				}
+			}
+		} else {
+			for (i = 0; i<CCFG_MAX; i++) {
+				if (!Control_config[i].disabled && Control_config[i].key_default == index) {
+					index = i;
+					break;
 				}
 			}
 		}
 
-		required_string("#End");
+		if (i == CCFG_MAX)
+			return -1;
+
+		return index;
 	}
-	
-	// Overwrite the control config with the first preset that was found
-	if (Control_config_presets.size() > 0) {
-		std::copy(Control_config_presets[0], Control_config_presets[0] + CCFG_MAX + 1, Control_config);
-	}
+
+	return -1;
 }

--- a/code/io/joy_ff.h
+++ b/code/io/joy_ff.h
@@ -1,3 +1,5 @@
+#ifndef __JOY_FF_H__
+#define __JOY_FF_H__
 /*
  * Copyright (C) Volition, Inc. 1999.  All rights reserved.
  *
@@ -9,28 +11,112 @@
 
 
 
-#ifndef __JOY_FF_H__
-#define __JOY_FF_H__
-
 #include "globalincs/pstypes.h"
 
+/**
+ * @brief Inits haptic feedback
+ *
+ * @returns  0 if successful, or
+ * @returns  0 if Haptic Feedback is disabled (and can't init), or
+ * @returns -1 if an error occurred
+ */
 int joy_ff_init();
+
+/**
+ * @brief De-init's haptic feedback
+ */
 void joy_ff_shutdown();
+
+/**
+ * @brief Stops any currently playing haptic effects
+ */
 void joy_ff_stop_effects();
+
+/**
+ * @brief Pre-mission init
+ */
 void joy_ff_mission_init(vec3d v);
+
+/**
+ * @brief Unimplemented (TODO)
+ */
 void joy_reacquire_ff();
+
+/**
+ * @brief Unimplmented (TODO)
+ */
 void joy_unacquire_ff();
+
+/**
+ * @brief Play a vector effect with the given scaler
+ *
+ * @param[in] v Vector in
+ * @param[in] scaler Scale up or down the effect
+ */
 void joy_ff_play_vector_effect(vec3d *v, float scaler);
+
+/**
+ * @brief Play an effect with the given x, y as its origin (left/right, up/down)
+ */
 void joy_ff_play_dir_effect(float x, float y);
+
+/**
+ * @brief Play an effect of a primary weapon shooting
+ *
+ * @param[in] gain Strength of the buzz
+ */
 void joy_ff_play_primary_shoot(int gain);
+
+/**
+ * @brief Play an effect of a secondary weapon shooting
+ *
+ * @param[in] gain Strength of the buzz
+ */
 void joy_ff_play_secondary_shoot(int gain);
+
+/**
+ * @brief Adjust the handling force with the given speed
+ *
+ * @param[in] speed The current speed (non-negative scalar of velocity) of the craft.
+ *   Higher speeds generally mean tighter handling
+ */
 void joy_ff_adjust_handling(int speed);
+
+/**
+ * @brief Play a "docked" haptic effect
+ */
 void joy_ff_docked();
+
+/**
+ * @brief Play a "reload" (from the support ship) haptic effect
+ */
 void joy_ff_play_reload_effect();
+
+/**
+ * @brief Start playing an "afterburner" haptic effect
+ */
 void joy_ff_afterburn_on();
+
+/**
+ * @brief Stop playing afterburner effects
+ */
 void joy_ff_afterburn_off();
+
+/**
+ * @brief Play the "explode" haptic effect
+ */
 void joy_ff_explode();
+
+/**
+ * @brief Play the "Fly By" haptic effect
+ *
+ * @param[in] mag Strength of the effect
+ */
 void joy_ff_fly_by(int mag);
+
+/**
+ * @brief Play the "deathroll" haptic effect
+ */
 void joy_ff_deathroll();
 
 #endif

--- a/code/io/key.cpp
+++ b/code/io/key.cpp
@@ -8,17 +8,19 @@
 */ 
 
 
-#include "SDL.h"
 
+#include "io/key.h"
+
+#include "cmdline/cmdline.h"
 #include "controlconfig/controlsconfig.h" //For textify scancode
 #include "globalincs/pstypes.h"
 #include "graphics/2d.h"
-#include "io/key.h"
-#include "math/fix.h"
 #include "io/timer.h"
 #include "localization/localize.h"
+#include "math/fix.h"
 #include "parse/scripting.h"
-#include "cmdline/cmdline.h"
+
+#include "SDL.h"
 
 #define THREADED	// to use the proper set of macros
 #include "osapi/osapi.h"
@@ -27,37 +29,24 @@
 #define KEY_BUFFER_SIZE 16
 
 //-------- Variable accessed by outside functions ---------
-ubyte				keyd_buffer_type;		// 0=No buffer, 1=buffer ASCII, 2=buffer scans
-ubyte				keyd_repeat;
-uint				keyd_last_pressed;
-uint				keyd_last_released;
-ubyte				keyd_pressed[NUM_KEYS];
-int				keyd_time_when_last_pressed;
+ubyte   keyd_buffer_type;       // 0=No buffer, 1=buffer ASCII, 2=buffer scans
+ubyte   keyd_repeat;
+uint    keyd_last_pressed;
+uint    keyd_last_released;
+ubyte   keyd_pressed[NUM_KEYS];
+int     keyd_time_when_last_pressed;
 
-typedef struct keyboard	{
-	ushort			keybuffer[KEY_BUFFER_SIZE];
-	uint				time_pressed[KEY_BUFFER_SIZE];
-	uint				TimeKeyWentDown[NUM_KEYS];
-	uint				TimeKeyHeldDown[NUM_KEYS];
-	uint				TimeKeyDownChecked[NUM_KEYS];
-	uint				NumDowns[NUM_KEYS];
-	uint				NumUps[NUM_KEYS];
-	int				down_check[NUM_KEYS];  // nonzero if has been pressed yet this mission
-	uint				keyhead, keytail;
+typedef struct keyboard {
+	ushort  keybuffer[KEY_BUFFER_SIZE];
+	uint    time_pressed[KEY_BUFFER_SIZE];
+	uint    TimeKeyWentDown[NUM_KEYS];
+	uint    TimeKeyHeldDown[NUM_KEYS];
+	uint    TimeKeyDownChecked[NUM_KEYS];
+	uint    NumDowns[NUM_KEYS];
+	uint    NumUps[NUM_KEYS];
+	int     down_check[NUM_KEYS];       // nonzero if has been pressed yet this mission
+	uint    keyhead, keytail;
 } keyboard;
-
-keyboard key_data;
-
-int key_inited = 0;
-
-SDL_mutex* key_lock;
-
-//int Backspace_debug=1;	// global flag that will enable/disable the backspace key from stopping execution
-								// This flag was created since the backspace key is also used to correct mistakes
-								// when typing in your pilots callsign.  This global flag is checked before execution
-								// is stopped.
-
-SCP_map<int, int> SDLtoFS2;
 
 int ascii_table[128] = 
 { 255, 255, '1', '2', '3', '4', '5', '6', '7', '8', '9', '0', '-', '=',255,255,
@@ -81,12 +70,20 @@ int shifted_ascii_table[128] =
   255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,
   255,255,255,255,255,255,255,255 };
 
-static int Key_numlock_was_on = 0;	// Flag to indicate whether NumLock is on at start
+keyboard key_data;
 
+int key_inited = 0;     //!< Bool to check if the keyboard is initialized
+
+SDL_mutex* key_lock;    //!< Mutex used when reading from the keyboard
+
+SCP_map<int, int> SDLtoFS2;     //!< Used by the osapi to map the SDL scancodes into ye olde FS2 scancodes
+
+static int Key_numlock_was_on = 0;  //!< Flag to indicate whether NumLock is on at start
 
 int Cheats_enabled = 0;
 int Key_normal_game = 0;
 
+int Current_key_down = 0;   //!< [WMC] Added so scripting can get at keys.
 namespace
 {
 	bool key_down_event_handler(const SDL_Event& e)
@@ -120,8 +117,66 @@ namespace
 	}
 }
 
-void FillSDLArray ()
-{
+
+/**
+ * @brief Returns the next key in the key buffer.
+ *
+ * @param[in] n Key index 
+ *
+ * @returns The next key index, or
+ * @returns 0, if n is negative
+ *
+ * @details Essentially, { return (n+1) % KEY_BUFFER_SIZE; }.
+ */
+static int add_one(int n);
+
+/**
+ * @brief Inits the SDLtoFS2 map
+ */
+static void FillSDLArray();
+
+/**
+ * @brief De-inits the keyboard
+ */
+static void key_close();
+
+/**
+ * @brief Returns how long the last key was held down
+ *
+ * @note [:V:] This is currently (July 17, 1996) bogus because our timing is not accurate.
+ */
+static int key_inkey_time(uint * time);
+
+/**
+ * @brief Checks if the numlock is on
+ *
+ * @returns nonzero if the numlock is on, or
+ * @returns 0 otherwise
+ */
+static int key_numlock_is_on();
+
+/**
+ * @brief Turns off the numlock
+ *
+ * @note Unimplemented (TODO)
+ */
+static void key_turn_off_numlock();
+
+/**
+* @brief Turns on the numlock
+*
+* @note Unimplemented (TODO)
+*/
+static void key_turn_on_numlock();
+
+
+static int add_one(int n) {
+	n++;
+	if (n >= KEY_BUFFER_SIZE) n = 0;
+	return n;
+}
+
+static void FillSDLArray() {
 	SDLtoFS2[SDL_SCANCODE_0] = KEY_0;
 	SDLtoFS2[SDL_SCANCODE_1] = KEY_1;
 	SDLtoFS2[SDL_SCANCODE_2] = KEY_2;
@@ -242,212 +297,139 @@ void FillSDLArray ()
 	//	SDLtoFS2[SDL_SCANCODE_BREAK] = KEY_BREAK;
 }
 
-int key_numlock_is_on()
+int key_check(int key)
 {
-	const Uint8 *state = SDL_GetKeyboardState(NULL);
-
-	return state[SDL_SCANCODE_NUMLOCKCLEAR];
+	return key_data.down_check[key];
 }
 
-void key_turn_off_numlock()
-{
+int key_checkch() {
+	int is_one_waiting = 0;
 
+	if (!key_inited) return 0;
+
+	SDL_LockMutex(key_lock);
+
+	if (key_data.keytail != key_data.keyhead) {
+		is_one_waiting = 1;
+	}
+
+	SDL_UnlockMutex(key_lock);
+
+	return is_one_waiting;
 }
 
-void key_turn_on_numlock()
+static void key_close()
 {
+	if ( !key_inited ) return;
 
+	if ( Key_numlock_was_on ) {
+		key_turn_on_numlock();
+		Key_numlock_was_on = 0;
+	}
+
+	key_inited = 0;
+
+	SDL_DestroyMutex( key_lock );
 }
 
-//	Convert a BIOS scancode to ASCII.
-//	If scancode >= 127, returns 255, meaning there is no corresponding ASCII code.
-//	Uses ascii_table and shifted_ascii_table to translate scancode to ASCII.
-int key_to_ascii(int keycode )
-{
-	int shifted;
+int key_down_count(int scancode) {
+	int n;
 
-	if ( !key_inited ) return 255;
+	if (!key_inited) return 0;
+	if ((scancode<0) || (scancode >= NUM_KEYS)) return 0;
 
-	shifted = keycode & KEY_SHIFTED;
-	keycode &= 0xFF;
+	SDL_LockMutex(key_lock);
 
-	if ( keycode>=127 )
-		return 255;
+	n = key_data.NumDowns[scancode];
+	key_data.NumDowns[scancode] = 0;
 
-	if (shifted)
-		return shifted_ascii_table[keycode];
-	else
-		return ascii_table[keycode];
+	SDL_UnlockMutex(key_lock);
+
+	return n;
 }
 
-//	Flush the keyboard buffer.
-//	Clear the keyboard array (keyd_pressed).
-void key_flush()
-{
+float key_down_timef(uint scancode) {
+	uint time_down, time;
+	uint delta_time;
+
+	if (!key_inited) {
+		return 0.0f;
+	}
+
+	if (scancode >= NUM_KEYS) {
+		return 0.0f;
+	}
+
+	SDL_LockMutex(key_lock);
+
+	time = timer_get_milliseconds();
+	delta_time = time - key_data.TimeKeyDownChecked[scancode];
+	key_data.TimeKeyDownChecked[scancode] = time;
+
+	if (delta_time <= 1) {
+		key_data.TimeKeyWentDown[scancode] = time;
+		if (keyd_pressed[scancode]) {
+			SDL_UnlockMutex(key_lock);
+			return 1.0f;
+		} else {
+			SDL_UnlockMutex(key_lock);
+			return 0.0f;
+		}
+	}
+
+	if (!keyd_pressed[scancode]) {
+		time_down = key_data.TimeKeyHeldDown[scancode];
+		key_data.TimeKeyHeldDown[scancode] = 0;
+	} else {
+		time_down = time - key_data.TimeKeyWentDown[scancode];
+		key_data.TimeKeyWentDown[scancode] = time;
+	}
+
+	SDL_UnlockMutex(key_lock);
+
+	return i2fl(time_down) / i2fl(delta_time);
+}
+
+void key_flush() {
 	int i;
 	uint CurTime;
 
-	if ( !key_inited ) return;
+	if (!key_inited) return;
 
-	SDL_LockMutex( key_lock );	
+	SDL_LockMutex(key_lock);
 
 	key_data.keyhead = key_data.keytail = 0;
 
 	//Clear the keyboard buffer
-	for (i=0; i<KEY_BUFFER_SIZE; i++ )	{
+	for (i = 0; i<KEY_BUFFER_SIZE; i++) {
 		key_data.keybuffer[i] = 0;
 		key_data.time_pressed[i] = 0;
 	}
-	
+
 	//Clear the keyboard array
 
 	CurTime = timer_get_milliseconds();
 
 
-	for (i=0; i<NUM_KEYS; i++ )	{
+	for (i = 0; i<NUM_KEYS; i++) {
 		keyd_pressed[i] = 0;
 		key_data.TimeKeyDownChecked[i] = CurTime;
 		key_data.TimeKeyWentDown[i] = CurTime;
 		key_data.TimeKeyHeldDown[i] = 0;
-		key_data.NumDowns[i]=0;
-		key_data.NumUps[i]=0;
+		key_data.NumDowns[i] = 0;
+		key_data.NumUps[i] = 0;
 	}
 
-	SDL_UnlockMutex( key_lock );	
+	SDL_UnlockMutex(key_lock);
 }
 
-//	A nifty function which performs the function:
-//		n = (n+1) % KEY_BUFFER_SIZE
-//	(assuming positive values of n).
-int add_one( int n )
-{
-	n++;
-	if ( n >= KEY_BUFFER_SIZE ) n=0;
-	return n;
-}
-
-// Returns 1 if character waiting... 0 otherwise
-int key_checkch()
-{
-	int is_one_waiting = 0;
-
-	if ( !key_inited ) return 0;
-
-	SDL_LockMutex( key_lock );	
-
-	if (key_data.keytail != key_data.keyhead){
-		is_one_waiting = 1;
-	}
-
-	SDL_UnlockMutex( key_lock );		
-
-	return is_one_waiting;
-}
-
-//	Return key scancode if a key has been pressed,
-//	else return 0.
-//	Reads keys out of the key buffer and updates keyhead.
-
-//WMC - Added so scripting can get at keys.
-int Current_key_down = 0;
-int key_inkey()
-{
-	int key = 0;
-
-	if ( !key_inited ) return 0;
-
-	SDL_LockMutex( key_lock );	
-
-	if (key_data.keytail!=key_data.keyhead)	{
-		key = key_data.keybuffer[key_data.keyhead];
-		key_data.keyhead = add_one(key_data.keyhead);
-	}
-
-	SDL_UnlockMutex( key_lock );	
-
-	Current_key_down = key;
-
-	return key;
-}
-
-//	Unget a key.  Puts it back in the input queue.
-void key_outkey(int key)
-{
-	int	bufp;
-
-	if ( !key_inited ) return;
-
-	SDL_LockMutex( key_lock );		
-
-	bufp = key_data.keytail+1;
-
-	if (bufp >= KEY_BUFFER_SIZE){
-		bufp = 0;
-	}
-
-	key_data.keybuffer[key_data.keytail] = (unsigned short)key;
-
-	key_data.keytail = bufp;
-
-	SDL_UnlockMutex( key_lock );		
-}
-
-
-
-//	Return amount of time last key was held down.
-//	This is currently (July 17, 1996) bogus because our timing is
-//	not accurate.
-int key_inkey_time(uint * time)
-{
-	int key = 0;
-
-	if ( !key_inited ) {
-		*time = 0;
-		return 0;
-	}
-	
-	SDL_LockMutex( key_lock );		
-
-	if (key_data.keytail!=key_data.keyhead)	{
-		key = key_data.keybuffer[key_data.keyhead];
-		*time = key_data.time_pressed[key_data.keyhead];
-		key_data.keyhead = add_one(key_data.keyhead);
-	}
-
-	SDL_UnlockMutex( key_lock );		
-
-	return key;
-}
-
-
-//	Returns scancode of last key pressed, if any (returns 0 if no key pressed)
-//	but does not update keyhead pointer.
-int key_peekkey()
-{
-	int key = 0;
-
-	if ( !key_inited ) return 0;
-
-	SDL_LockMutex( key_lock );		
-
-	if (key_data.keytail!=key_data.keyhead)	{
-		key = key_data.keybuffer[key_data.keyhead];
-	}
-	SDL_UnlockMutex( key_lock );		
-
-	return key;
-}
-
-// If not installed, uses BIOS and returns getch();
-//	Else returns pending key (or waits for one if none waiting).
-int key_getch()
-{
-	int dummy=0;
+int key_getch() {
+	int dummy = 0;
 	int in;
 
-	if ( !key_inited ) return 0;
-	
-	while (!key_checkch()){
+	if (!key_inited) return 0;
+
+	while (!key_checkch()) {
 		os_poll();
 
 		dummy++;
@@ -457,22 +439,20 @@ int key_getch()
 	return in;
 }
 
-//	Set global shift_status with modifier results (shift, ctrl, alt).
-uint key_get_shift_status()
-{
+uint key_get_shift_status() {
 	unsigned int shift_status = 0;
 
-	if ( !key_inited ) return 0;
+	if (!key_inited) return 0;
 
-	SDL_LockMutex( key_lock );		
+	SDL_LockMutex(key_lock);
 
-	if ( keyd_pressed[KEY_LSHIFT] || keyd_pressed[KEY_RSHIFT] )
+	if (keyd_pressed[KEY_LSHIFT] || keyd_pressed[KEY_RSHIFT])
 		shift_status |= KEY_SHIFTED;
 
-	if ( keyd_pressed[KEY_LALT] || keyd_pressed[KEY_RALT] )
+	if (keyd_pressed[KEY_LALT] || keyd_pressed[KEY_RALT])
 		shift_status |= KEY_ALTED;
 
-	if ( keyd_pressed[KEY_LCTRL] || keyd_pressed[KEY_RCTRL] )
+	if (keyd_pressed[KEY_LCTRL] || keyd_pressed[KEY_RCTRL])
 		shift_status |= KEY_CTRLED;
 
 #ifndef NDEBUG
@@ -487,249 +467,15 @@ uint key_get_shift_status()
 		}
 	}
 #endif
-	SDL_UnlockMutex( key_lock );		
+	SDL_UnlockMutex(key_lock);
 
 	return shift_status;
 }
 
-//	Returns amount of time key (specified by "code") has been down since last call.
-//	Returns float, unlike key_down_time() which returns a fix.
-float key_down_timef(uint scancode)	
-{
-	uint time_down, time;
-	uint delta_time;
+void key_got_focus() {
+	if (!key_inited) return;
 
-	if ( !key_inited ) {
-		return 0.0f;
-	}
-
-	if (scancode >= NUM_KEYS) {
-		return 0.0f;
-	}
-
-	SDL_LockMutex( key_lock );		
-
-	time = timer_get_milliseconds();
-	delta_time = time - key_data.TimeKeyDownChecked[scancode];
-	key_data.TimeKeyDownChecked[scancode] = time;
-
-	if ( delta_time <= 1 ) {
-		key_data.TimeKeyWentDown[scancode] = time;
-		if (keyd_pressed[scancode])	{
-			SDL_UnlockMutex( key_lock );		
-			return 1.0f;
-		} else	{
-			SDL_UnlockMutex( key_lock );		
-			return 0.0f;
-		}
-	}
-
-	if ( !keyd_pressed[scancode] )	{
-		time_down = key_data.TimeKeyHeldDown[scancode];
-		key_data.TimeKeyHeldDown[scancode] = 0;
-	} else	{
-		time_down =  time - key_data.TimeKeyWentDown[scancode];
-		key_data.TimeKeyWentDown[scancode] = time;
-	}
-
-	SDL_UnlockMutex( key_lock );		
-
-	return i2fl(time_down) / i2fl(delta_time);
-}
-
-// Returns number of times key has went from up to down since last call.
-int key_down_count(int scancode)	
-{
-	int n;
-
-	if ( !key_inited ) return 0;
-	if ((scancode<0)|| (scancode>=NUM_KEYS)) return 0;
-
-	SDL_LockMutex( key_lock );		
-
-	n = key_data.NumDowns[scancode];
-	key_data.NumDowns[scancode] = 0;
-
-	SDL_UnlockMutex( key_lock );		
-
-	return n;
-}
-
-
-// Returns number of times key has went from down to up since last call.
-int key_up_count(int scancode)	
-{
-	int n;
-
-	if ( !key_inited ) return 0;
-	if ((scancode<0)|| (scancode>=NUM_KEYS)) return 0;
-
-	SDL_LockMutex( key_lock );		
-
-	n = key_data.NumUps[scancode];
-	key_data.NumUps[scancode] = 0;
-
-	SDL_UnlockMutex( key_lock );		
-
-	return n;
-}
-
-int key_check(int key)
-{
-	return key_data.down_check[key];
-}
-
-//	Add a key up or down code to the key buffer.  state=1 -> down, state=0 -> up
-// latency => time difference in ms between when key was actually pressed and now
-//void key_mark( uint code, int state )
-void key_mark( uint code, int state, uint latency )
-{
-	uint scancode, breakbit, temp, event_time;
-	ushort keycode;	
-
-	if ( !key_inited ) return;
-
-	SDL_LockMutex( key_lock );		
-
-	// If running in the UK, need to translate their wacky slash scancode to ours
-	if ( code == KEY_SLASH_UK ) {
-		code = KEY_SLASH;
-	}
-
-	Assert( code < NUM_KEYS );
-
-	event_time = timer_get_milliseconds() - latency;
-	// event_time = timeGetTime() - latency;
-
-	// Read in scancode
-	scancode = code & (NUM_KEYS-1);
-	breakbit = !state;
-	
-	if (breakbit) {
-		// Key going up
-		keyd_last_released = scancode;
-		keyd_pressed[scancode] = 0;
-		key_data.NumUps[scancode]++;
-
-		// What is the point of this code?  "temp" is never used!
-		temp = 0;
-		temp |= keyd_pressed[KEY_LSHIFT] || keyd_pressed[KEY_RSHIFT];
-		temp |= keyd_pressed[KEY_LALT] || keyd_pressed[KEY_RALT];
-		temp |= keyd_pressed[KEY_LCTRL] || keyd_pressed[KEY_RCTRL];
-		temp |= keyd_pressed[KEY_DEBUG_KEY];
-	
-		if (event_time < key_data.TimeKeyWentDown[scancode]) {
-			key_data.TimeKeyHeldDown[scancode] = 0;
-		} else {
-			key_data.TimeKeyHeldDown[scancode] += event_time - key_data.TimeKeyWentDown[scancode];
-		}
-
-		Current_key_down = scancode;
-		if ( keyd_pressed[KEY_LSHIFT] || keyd_pressed[KEY_RSHIFT] ) {
-			Current_key_down |= KEY_SHIFTED;
-		}
-
-		if ( keyd_pressed[KEY_LALT] || keyd_pressed[KEY_RALT] ) {
-			Current_key_down |= KEY_ALTED;
-		}
-
-		if ( keyd_pressed[KEY_LCTRL] || keyd_pressed[KEY_RCTRL] ) {
-			Current_key_down |= KEY_CTRLED;
-		}
-
-		Script_system.SetHookVar("Key", 's', textify_scancode(Current_key_down));
-		Script_system.RunCondition(CHA_KEYRELEASED);
-		Script_system.RemHookVar("Key");
-	} else {
-		// Key going down
-		keyd_last_pressed = scancode;
-		keyd_time_when_last_pressed = event_time;
-		if (!keyd_pressed[scancode]) {
-			// First time down
-			key_data.TimeKeyWentDown[scancode] = event_time;
-			keyd_pressed[scancode] = 1;
-			key_data.NumDowns[scancode]++;
-			key_data.down_check[scancode]++;
-
-			//WMC - For scripting
-			Current_key_down = scancode;
-			if ( keyd_pressed[KEY_LSHIFT] || keyd_pressed[KEY_RSHIFT] ) {
-				Current_key_down |= KEY_SHIFTED;
-			}
-
-			if ( keyd_pressed[KEY_LALT] || keyd_pressed[KEY_RALT] ) {
-				Current_key_down |= KEY_ALTED;
-			}
-
-			if ( keyd_pressed[KEY_LCTRL] || keyd_pressed[KEY_RCTRL] ) {
-				Current_key_down |= KEY_CTRLED;
-			}
-
-			Script_system.SetHookVar("Key", 's', textify_scancode(Current_key_down));
-			Script_system.RunCondition(CHA_KEYPRESSED);
-			Script_system.RemHookVar("Key");
-		} else if (!keyd_repeat) {
-			// Don't buffer repeating key if repeat mode is off
-			scancode = 0xAA;		
-		} 
-
-		if ( scancode!=0xAA ) {
-			keycode = (unsigned short)scancode;
-
-			if ( keyd_pressed[KEY_LSHIFT] || keyd_pressed[KEY_RSHIFT] ) {
-				keycode |= KEY_SHIFTED;
-			}
-
-			if ( keyd_pressed[KEY_LALT] || keyd_pressed[KEY_RALT] ) {
-				keycode |= KEY_ALTED;
-			}
-
-			if ( keyd_pressed[KEY_LCTRL] || keyd_pressed[KEY_RCTRL] ) {
-				keycode |= KEY_CTRLED;
-			}
-
-#ifndef NDEBUG
-			if ( keyd_pressed[KEY_DEBUG_KEY] ) {
-				keycode |= KEY_DEBUGGED;
-			}
-#else
-			if ( keyd_pressed[KEY_DEBUG_KEY] ) {
-				mprintf(("Cheats_enabled = %i, Key_normal_game = %i\n", Cheats_enabled, Key_normal_game));
-				if (Cheats_enabled && Key_normal_game) {
-					keycode |= KEY_DEBUGGED1;
-				}
-			}
-
-#endif
-
-			if ( keycode ) {
-				temp = key_data.keytail+1;
-				if ( temp >= KEY_BUFFER_SIZE ) temp=0;
-
-				if (temp!=key_data.keyhead) {
-					key_data.keybuffer[key_data.keytail] = keycode;
-					key_data.time_pressed[key_data.keytail] = keyd_time_when_last_pressed;
-					key_data.keytail = temp;
-				}
-			}
-		}
-	}
-
-	SDL_UnlockMutex( key_lock );
-}
-
-void key_close()
-{
-	if ( !key_inited ) return;
-
-	if ( Key_numlock_was_on ) {
-		key_turn_on_numlock();
-		Key_numlock_was_on = 0;
-	}
-
-	key_inited = 0;
-
-	SDL_DestroyMutex( key_lock );
+	key_flush();
 }
 
 void key_init()
@@ -756,7 +502,47 @@ void key_init()
 	os::events::addEventListener(SDL_KEYDOWN, os::events::DEFAULT_LISTENER_WEIGHT, key_down_event_handler);
 	os::events::addEventListener(SDL_KEYUP, os::events::DEFAULT_LISTENER_WEIGHT, key_up_event_handler);
 
-	atexit(key_close);
+	atexit(key_close)
+}
+
+int key_inkey() {
+	int key = 0;
+
+	if (!key_inited) return 0;
+
+	SDL_LockMutex(key_lock);
+
+	if (key_data.keytail != key_data.keyhead) {
+		key = key_data.keybuffer[key_data.keyhead];
+		key_data.keyhead = add_one(key_data.keyhead);
+	}
+
+	SDL_UnlockMutex(key_lock);
+
+	Current_key_down = key;
+
+	return key;
+}
+
+static int key_inkey_time(uint * time) {
+	int key = 0;
+
+	if (!key_inited) {
+		*time = 0;
+		return 0;
+	}
+
+	SDL_LockMutex(key_lock);
+
+	if (key_data.keytail != key_data.keyhead) {
+		key = key_data.keybuffer[key_data.keyhead];
+		*time = key_data.time_pressed[key_data.keyhead];
+		key_data.keyhead = add_one(key_data.keyhead);
+	}
+
+	SDL_UnlockMutex(key_lock);
+
+	return key;
 }
 
 void key_level_init()
@@ -774,9 +560,219 @@ void key_lost_focus()
 	key_flush();	
 }
 
-void key_got_focus()
-{
-	if ( !key_inited ) return;
-	
-	key_flush();	
+void key_mark(uint code, int state, uint latency) {
+	uint scancode, breakbit, temp, event_time;
+	ushort keycode;
+
+	if (!key_inited) return;
+
+	SDL_LockMutex(key_lock);
+
+	// If running in the UK, need to translate their wacky slash scancode to ours
+	if (code == KEY_SLASH_UK) {
+		code = KEY_SLASH;
+	}
+
+	Assert(code < NUM_KEYS);
+
+	event_time = timer_get_milliseconds() - latency;
+	// event_time = timeGetTime() - latency;
+
+	// Read in scancode
+	scancode = code & (NUM_KEYS - 1);
+	breakbit = !state;
+
+	if (breakbit) {
+		// Key going up
+		keyd_last_released = scancode;
+		keyd_pressed[scancode] = 0;
+		key_data.NumUps[scancode]++;
+
+		// What is the point of this code?  "temp" is never used!
+		temp = 0;
+		temp |= keyd_pressed[KEY_LSHIFT] || keyd_pressed[KEY_RSHIFT];
+		temp |= keyd_pressed[KEY_LALT] || keyd_pressed[KEY_RALT];
+		temp |= keyd_pressed[KEY_LCTRL] || keyd_pressed[KEY_RCTRL];
+		temp |= keyd_pressed[KEY_DEBUG_KEY];
+
+		if (event_time < key_data.TimeKeyWentDown[scancode]) {
+			key_data.TimeKeyHeldDown[scancode] = 0;
+		} else {
+			key_data.TimeKeyHeldDown[scancode] += event_time - key_data.TimeKeyWentDown[scancode];
+		}
+
+		Current_key_down = scancode;
+		if (keyd_pressed[KEY_LSHIFT] || keyd_pressed[KEY_RSHIFT]) {
+			Current_key_down |= KEY_SHIFTED;
+		}
+
+		if (keyd_pressed[KEY_LALT] || keyd_pressed[KEY_RALT]) {
+			Current_key_down |= KEY_ALTED;
+		}
+
+		if (keyd_pressed[KEY_LCTRL] || keyd_pressed[KEY_RCTRL]) {
+			Current_key_down |= KEY_CTRLED;
+		}
+
+		Script_system.SetHookVar("Key", 's', textify_scancode(Current_key_down));
+		Script_system.RunCondition(CHA_KEYRELEASED);
+		Script_system.RemHookVar("Key");
+	} else {
+		// Key going down
+		keyd_last_pressed = scancode;
+		keyd_time_when_last_pressed = event_time;
+		if (!keyd_pressed[scancode]) {
+			// First time down
+			key_data.TimeKeyWentDown[scancode] = event_time;
+			keyd_pressed[scancode] = 1;
+			key_data.NumDowns[scancode]++;
+			key_data.down_check[scancode]++;
+
+			//WMC - For scripting
+			Current_key_down = scancode;
+			if (keyd_pressed[KEY_LSHIFT] || keyd_pressed[KEY_RSHIFT]) {
+				Current_key_down |= KEY_SHIFTED;
+			}
+
+			if (keyd_pressed[KEY_LALT] || keyd_pressed[KEY_RALT]) {
+				Current_key_down |= KEY_ALTED;
+			}
+
+			if (keyd_pressed[KEY_LCTRL] || keyd_pressed[KEY_RCTRL]) {
+				Current_key_down |= KEY_CTRLED;
+			}
+
+			Script_system.SetHookVar("Key", 's', textify_scancode(Current_key_down));
+			Script_system.RunCondition(CHA_KEYPRESSED);
+			Script_system.RemHookVar("Key");
+		} else if (!keyd_repeat) {
+			// Don't buffer repeating key if repeat mode is off
+			scancode = 0xAA;
+		}
+
+		if (scancode != 0xAA) {
+			keycode = (unsigned short)scancode;
+
+			if (keyd_pressed[KEY_LSHIFT] || keyd_pressed[KEY_RSHIFT]) {
+				keycode |= KEY_SHIFTED;
+			}
+
+			if (keyd_pressed[KEY_LALT] || keyd_pressed[KEY_RALT]) {
+				keycode |= KEY_ALTED;
+			}
+
+			if (keyd_pressed[KEY_LCTRL] || keyd_pressed[KEY_RCTRL]) {
+				keycode |= KEY_CTRLED;
+			}
+
+#ifndef NDEBUG
+			if (keyd_pressed[KEY_DEBUG_KEY]) {
+				keycode |= KEY_DEBUGGED;
+			}
+#else
+			if (keyd_pressed[KEY_DEBUG_KEY]) {
+				mprintf(("Cheats_enabled = %i, Key_normal_game = %i\n", Cheats_enabled, Key_normal_game));
+				if (Cheats_enabled && Key_normal_game) {
+					keycode |= KEY_DEBUGGED1;
+				}
+			}
+
+#endif
+
+			if (keycode) {
+				temp = key_data.keytail + 1;
+				if (temp >= KEY_BUFFER_SIZE) temp = 0;
+
+				if (temp != key_data.keyhead) {
+					key_data.keybuffer[key_data.keytail] = keycode;
+					key_data.time_pressed[key_data.keytail] = keyd_time_when_last_pressed;
+					key_data.keytail = temp;
+				}
+			}
+		}
+	}
+
+	SDL_UnlockMutex(key_lock);
+}
+
+static int key_numlock_is_on() {
+	const Uint8 *state = SDL_GetKeyboardState(NULL);
+
+	return state[SDL_SCANCODE_NUMLOCKCLEAR];
+}
+
+void key_outkey(int key) {
+	int	bufp;
+
+	if (!key_inited) return;
+
+	SDL_LockMutex(key_lock);
+
+	bufp = key_data.keytail + 1;
+
+	if (bufp >= KEY_BUFFER_SIZE) {
+		bufp = 0;
+	}
+
+	key_data.keybuffer[key_data.keytail] = (unsigned short)key;
+
+	key_data.keytail = bufp;
+
+	SDL_UnlockMutex(key_lock);
+}
+
+int key_peekkey() {
+	int key = 0;
+
+	if (!key_inited) return 0;
+
+	SDL_LockMutex(key_lock);
+
+	if (key_data.keytail != key_data.keyhead) {
+		key = key_data.keybuffer[key_data.keyhead];
+	}
+	SDL_UnlockMutex(key_lock);
+
+	return key;
+}
+
+int key_to_ascii(int keycode) {
+	int shifted;
+
+	if (!key_inited) return 255;
+
+	shifted = keycode & KEY_SHIFTED;
+	keycode &= 0xFF;
+
+	if (keycode >= 127)
+		return 255;
+
+	if (shifted)
+		return shifted_ascii_table[keycode];
+	else
+		return ascii_table[keycode];
+}
+
+static void key_turn_off_numlock() {
+
+}
+
+static void key_turn_on_numlock() {
+
+}
+
+int key_up_count(int scancode) {
+	int n;
+
+	if (!key_inited) return 0;
+	if ((scancode<0) || (scancode >= NUM_KEYS)) return 0;
+
+	SDL_LockMutex(key_lock);
+
+	n = key_data.NumUps[scancode];
+	key_data.NumUps[scancode] = 0;
+
+	SDL_UnlockMutex(key_lock);
+
+	return n;
 }

--- a/code/io/key.cpp
+++ b/code/io/key.cpp
@@ -138,25 +138,6 @@ static void FillSDLArray();
  */
 static void key_close();
 
-/**
- * @brief Returns how long the last key was held down
- *
- * @note [:V:] This is currently (July 17, 1996) bogus because our timing is not accurate.
- * @note [z64555] May be used in the future
- */
-static int key_inkey_time(uint * time);
-
-/**
- * @brief Checks if the numlock is on
- *
- * @returns nonzero if the numlock is on, or
- * @returns 0 otherwise
- *
- * @note [z64555] May be used in the future
- */
-static int key_numlock_is_on();
-
-
 static int add_one(int n) {
 	n++;
 	if (n >= KEY_BUFFER_SIZE) n = 0;
@@ -506,27 +487,6 @@ int key_inkey() {
 	return key;
 }
 
-static int key_inkey_time(uint * time) {
-	int key = 0;
-
-	if (!key_inited) {
-		*time = 0;
-		return 0;
-	}
-
-	SDL_LockMutex(key_lock);
-
-	if (key_data.keytail != key_data.keyhead) {
-		key = key_data.keybuffer[key_data.keyhead];
-		*time = key_data.time_pressed[key_data.keyhead];
-		key_data.keyhead = add_one(key_data.keyhead);
-	}
-
-	SDL_UnlockMutex(key_lock);
-
-	return key;
-}
-
 void key_level_init()
 {
 	int i;
@@ -677,11 +637,14 @@ void key_mark(uint code, int state, uint latency) {
 	SDL_UnlockMutex(key_lock);
 }
 
+// [z64555] Commented out until we have a use for it
+/*
 static int key_numlock_is_on() {
 	const Uint8 *state = SDL_GetKeyboardState(NULL);
 
 	return state[SDL_SCANCODE_NUMLOCKCLEAR];
 }
+*/
 
 void key_outkey(int key) {
 	int	bufp;

--- a/code/io/key.cpp
+++ b/code/io/key.cpp
@@ -78,8 +78,6 @@ SDL_mutex* key_lock;    //!< Mutex used when reading from the keyboard
 
 SCP_map<int, int> SDLtoFS2;     //!< Used by the osapi to map the SDL scancodes into ye olde FS2 scancodes
 
-static int Key_numlock_was_on = 0;  //!< Flag to indicate whether NumLock is on at start
-
 int Cheats_enabled = 0;
 int Key_normal_game = 0;
 
@@ -307,11 +305,6 @@ int key_checkch() {
 static void key_close()
 {
 	if ( !key_inited ) return;
-
-	if ( Key_numlock_was_on ) {
-		key_turn_on_numlock();
-		Key_numlock_was_on = 0;
-	}
 
 	key_inited = 0;
 

--- a/code/io/key.cpp
+++ b/code/io/key.cpp
@@ -142,6 +142,7 @@ static void key_close();
  * @brief Returns how long the last key was held down
  *
  * @note [:V:] This is currently (July 17, 1996) bogus because our timing is not accurate.
+ * @note [z64555] May be used in the future
  */
 static int key_inkey_time(uint * time);
 
@@ -150,6 +151,8 @@ static int key_inkey_time(uint * time);
  *
  * @returns nonzero if the numlock is on, or
  * @returns 0 otherwise
+ *
+ * @note [z64555] May be used in the future
  */
 static int key_numlock_is_on();
 

--- a/code/io/key.cpp
+++ b/code/io/key.cpp
@@ -155,20 +155,6 @@ static int key_inkey_time(uint * time);
  */
 static int key_numlock_is_on();
 
-/**
- * @brief Turns off the numlock
- *
- * @note Unimplemented (TODO)
- */
-static void key_turn_off_numlock();
-
-/**
-* @brief Turns on the numlock
-*
-* @note Unimplemented (TODO)
-*/
-static void key_turn_on_numlock();
-
 
 static int add_one(int n) {
 	n++;
@@ -751,14 +737,6 @@ int key_to_ascii(int keycode) {
 		return shifted_ascii_table[keycode];
 	else
 		return ascii_table[keycode];
-}
-
-static void key_turn_off_numlock() {
-
-}
-
-static void key_turn_on_numlock() {
-
 }
 
 int key_up_count(int scancode) {

--- a/code/io/key.h
+++ b/code/io/key.h
@@ -261,4 +261,14 @@ int key_check(int key);
  */
 void key_outkey(int key);
 
+/**
+* @brief Checks if the numlock is on
+*
+* @returns nonzero if the numlock is on, or
+* @returns 0 otherwise
+*
+* @note [z64555] Commented out until we have a use for it
+*/
+//int key_numlock_is_on();
+
 #endif

--- a/code/io/key.h
+++ b/code/io/key.h
@@ -1,3 +1,5 @@
+#ifndef _KEY_H
+#define _KEY_H
 /*
  * Copyright (C) Volition, Inc. 1999.  All rights reserved.
  *
@@ -9,55 +11,7 @@
 
 
 
-#ifndef _KEY_H
-#define _KEY_H
-
-/*
-#ifdef __cplusplus
-extern "C" {
-#endif
-*/
-
 #include "globalincs/pstypes.h"
-
-#define NUM_KEYS 256
-
-extern int shifted_ascii_table[];
-extern int ascii_table[];
-
-extern ubyte keyd_pressed[NUM_KEYS];
-
-// O/S level hooks...
-void key_init();
-void key_level_init();
-void key_lost_focus();
-void key_got_focus();
-void key_mark( uint code, int state, uint latency );
-int key_getch();
-int key_peekkey();
-void key_flush();
-
-// Routines/data you can access:
-//NOT USED! extern fix key_down_time( uint code );
-float key_down_timef( uint code );
-
-int key_to_ascii(int keycode );
-int key_inkey();
-
-// global flag that will enable/disable the backspace key from stopping execution
-//extern int Backspace_debug;
-
-uint key_get_shift_status();
-int key_down_count(int scancode);
-int key_up_count(int scancode);
-int key_checkch();
-int key_check(int key);
-
-//	Put "key" back in the input buffer.
-void key_outkey(int key);
-
-extern int Cheats_enabled;
-extern int Key_normal_game;
 
 #define KEY_SHIFTED     0x1000
 #define KEY_ALTED       0x2000
@@ -65,8 +19,6 @@ extern int Key_normal_game;
 #define KEY_DEBUGGED    0x8000
 #define KEY_DEBUGGED1   0x0800	// Cheat bit in release version of game.
 #define KEY_MASK        0x00FF
-
-#define KEY_DEBUG_KEY   0x29	// KEY_LAPOSTRO (shifted = tilde, near upper-left of keyboard)
 
 #define KEY_0           0x0B
 #define KEY_1           0x02
@@ -119,7 +71,7 @@ extern int Key_normal_game;
 #define KEY_RBRACKET    0x1B
 
 #define KEY_RAPOSTRO    0x28
-#define KEY_LAPOSTRO    0x29
+#define KEY_LAPOSTRO    0x29	// (shifted = tilde, near upper-left of keyboard)
 
 #define KEY_ESC         0x01
 #define KEY_ENTER       0x1C
@@ -173,7 +125,7 @@ extern int Key_normal_game;
 #define KEY_INSERT      0xD2
 #define KEY_HOME        0xC7
 #define KEY_PAGEUP      0xC9
-#define KEY_DELETE      0xd3
+#define KEY_DELETE      0xD3
 #define KEY_END         0xCF
 #define KEY_PAGEDOWN    0xD1
 #define KEY_UP          0xC8
@@ -183,12 +135,130 @@ extern int Key_normal_game;
 
 #define KEY_PRINT_SCRN  0xB7
 #define KEY_PAUSE       0x45	//DOS: 0x61
-#define KEY_BREAK       0xc6
+#define KEY_BREAK       0xC6
 
-/*
-#ifdef __cplusplus
-}
-#endif
-*/
+#define KEY_DEBUG_KEY   KEY_LAPOSTRO
+
+#define NUM_KEYS 256
+
+
+extern int ascii_table[];           //!< Table of printable ascii characters (lowercase)
+extern int shifted_ascii_table[];   //!< Table of printable ascii characters (uppercase)
+
+extern ubyte keyd_pressed[NUM_KEYS];    //!< State of all keys. 1 = closed, 0 = open
+
+extern int Cheats_enabled;      //!< Nonzero if cheats are eneabled
+extern int Key_normal_game;     //!< If this is a normal game, then this is (Game_mode & GM_NORMAL), otherwise is 0
+
+
+// ----------------------------------------------------------------------------
+// O/S level hooks...
+// ----------------------------------------------------------------------------
+/**
+ * @brief Initialize the keyboard
+ */
+void key_init();
+
+/**
+ * @brief Pre-mission key init
+ */
+void key_level_init();
+
+/**
+ * @brief (FRED) Keyboard handler when FRED losses focus
+ */
+void key_lost_focus();
+
+/**
+ * @brief (FRED) Keyboard handler when FRED regains focus
+ */
+void key_got_focus();
+
+/**
+ * @brief Mark a key as down or up.
+ *
+ * @param[in] code    The key to mark.
+ * @param[in] state   State of the key. 1 = down, 0 = up.
+ * @param[in] latency Time, in ms, between when key was actually pressed and now
+ */
+void key_mark( uint code, int state, uint latency );
+
+/**
+ * @brief Get a character, waiting for input.
+ *
+ * @details Yes, this function will wait until eternity or until a key is pressed. Whichever is sooner.
+ */
+int key_getch();
+
+/**
+ * @brief Returns scancode of last key pressed, if any (returns 0 if no key pressed)
+ * but does not update keyhead pointer.
+ */
+int key_peekkey();
+
+/**
+ * @brief Flush the keyboard buffer and clear the keyboard array
+ */
+void key_flush();
+
+
+// ----------------------------------------------------------------------------
+// Routines/data you can access:
+// ----------------------------------------------------------------------------
+/**
+ * @brief Returns amount of time key (specified by "code") has been down since last call.
+ *
+ * @param[in] code The key to check
+ */
+float key_down_timef( uint code );
+
+/**
+ * @brief Converts a BIOS scancode to ASCII.
+ *
+ * @param[in] keycode Key to convert
+ *
+ * @details If scancode >= 127, returns 255, meaning there is no corresponding ASCII code.
+ *  Uses ascii_table and shifted_ascii_table to translate scancode to ASCII.
+ */
+int key_to_ascii(int keycode );
+
+/**
+ * @brief Gets a key from the input queue.
+ *
+ * @returns A keycode of the first key in the queue
+ */
+int key_inkey();
+
+/**
+ * @brief Gets the status of shift keys (Shift, Alt, Ctrl, and the Debug keys)
+ *
+ * @returns bitmask of any active shift keys
+ */
+uint key_get_shift_status();
+
+/**
+ * @brief  Returns number of times key has went from up to down since last call.
+ */
+int key_down_count(int scancode);
+
+/**
+ * @brief Returns number of times key has went from down to up since last call.
+ */
+int key_up_count(int scancode);
+
+/**
+ * @brief Returns 1 if character waiting, 0 otherwise
+ */
+int key_checkch();
+
+/**
+ * @brief Checks if the key has been processed
+ */
+int key_check(int key);
+
+/**
+ * @brief Unget a key.  Puts it back in the input queue.
+ */
+void key_outkey(int key);
 
 #endif

--- a/code/io/keycontrol.cpp
+++ b/code/io/keycontrol.cpp
@@ -7,58 +7,56 @@
  *
 */ 
 
-
-
-
-#include "globalincs/pstypes.h"
-#include "globalincs/globals.h"
-#include "globalincs/linklist.h"
-#include "io/key.h"
-#include "io/joy.h"
-#include "io/timer.h"
-#include "ship/ship.h"
-#include "playerman/player.h"
-#include "weapon/weapon.h"
-#include "hud/hud.h"
-#include "gamesequence/gamesequence.h"
-#include "mission/missiongoals.h"
-#include "hud/hudets.h"
-#include "gamesnd/gamesnd.h"
-#include "hud/hudsquadmsg.h"
-#include "gamesnd/eventmusic.h"
-#include "freespace.h"
-#include "mission/missionhotkey.h"
-#include "hud/hudescort.h"
-#include "hud/hudshield.h"
-#include "io/keycontrol.h"
-#include "ship/shiphit.h"
-#include "ship/shipfx.h"
-#include "mission/missionlog.h"
-#include "hud/hudtargetbox.h"
-#include "popup/popup.h"
-#include "object/objcollide.h"
-#include "object/object.h"
-#include "hud/hudconfig.h"
-#include "hud/hudmessage.h"
-#include "network/multi_pmsg.h"
-#include "starfield/supernova.h"
-#include "mission/missionmessage.h"
-#include "menuui/mainhallmenu.h"
-#include "missionui/missionpause.h"
-#include "hud/hudgauges.h"
-#include "freespace.h"	//For time compression stuff
-#include "species_defs/species_defs.h"
 #include "asteroid/asteroid.h"
-#include "iff_defs/iff_defs.h"
-#include "network/multi.h"
-#include "network/multiutil.h"
-#include "network/multimsgs.h"
-#include "network/multi_pause.h"
-#include "network/multi_observer.h"
-#include "network/multi_endgame.h"
 #include "autopilot/autopilot.h"
 #include "cmdline/cmdline.h"
+#include "freespace2/freespace.h"	//For time compression stuff
+#include "freespace2/freespace.h"
+#include "gamesequence/gamesequence.h"
+#include "gamesnd/eventmusic.h"
+#include "gamesnd/gamesnd.h"
+#include "globalincs/globals.h"
+#include "globalincs/linklist.h"
+#include "globalincs/pstypes.h"
+#include "hud/hud.h"
+#include "hud/hudconfig.h"
+#include "hud/hudescort.h"
+#include "hud/hudets.h"
+#include "hud/hudgauges.h"
+#include "hud/hudmessage.h"
+#include "hud/hudshield.h"
+#include "hud/hudsquadmsg.h"
+#include "hud/hudtargetbox.h"
+#include "iff_defs/iff_defs.h"
+#include "io/joy.h"
+#include "io/key.h"
+#include "io/timer.h"
+#include "menuui/mainhallmenu.h"
+#include "mission/missiongoals.h"
+#include "mission/missionhotkey.h"
+#include "mission/missionlog.h"
+#include "mission/missionmessage.h"
+#include "missionui/missionpause.h"
+#include "network/multi.h"
+#include "network/multimsgs.h"
+#include "network/multiutil.h"
+#include "network/multi_endgame.h"
+#include "network/multi_observer.h"
+#include "network/multi_pause.h"
+#include "network/multi_pmsg.h"
+#include "object/objcollide.h"
+#include "object/object.h"
 #include "object/objectshield.h"
+#include "playerman/player.h"
+#include "popup/popup.h"
+#include "ship/ship.h"
+#include "ship/shipfx.h"
+#include "ship/shiphit.h"
+#include "species_defs/species_defs.h"
+#include "starfield/supernova.h"
+#include "weapon/weapon.h"
+
+#include "io/keycontrol.h"
 
 /**
 * Natural number factor lookup class.
@@ -180,6 +178,8 @@ factor_table ftables;
 #define MAX_TIME_MULTIPLIER		64
 #define MAX_TIME_DIVIDER		4
 
+// --------------------------------------------------------
+// Cheats!!!!1!1
 #define CHEAT_BUFFER_LEN	17
 char CheatBuffer[CHEAT_BUFFER_LEN+1];
 
@@ -209,16 +209,8 @@ static struct Cheat cheatsTable[] = {
 
 #define CHEATS_TABLE_LEN	6
 
-int Tool_enabled = 0;
-bool Perspective_locked=false;
-bool quit_mission_popup_shown = false;
-
-extern int AI_watch_object;
-extern int Countermeasures_enabled;
-
-extern float do_subobj_hit_stuff(object *ship_obj, object *other_obj, vec3d *hitpos, int submodel_num, float damage, bool *hull_should_apply_armor);
-
-extern void mission_goal_mark_all_true( int type );
+// End Cheats
+// --------------------------------------------------------
 
 int Normal_key_set[] = {
 	TARGET_NEXT,
@@ -375,47 +367,47 @@ int Dead_key_set[] = {
 	TIME_SLOW_DOWN
 };
 
-int Critical_key_set[] = {	
-	CYCLE_NEXT_PRIMARY,		
-	CYCLE_PREV_PRIMARY,				
-	CYCLE_SECONDARY,			
-	CYCLE_NUM_MISSLES,			
-	INCREASE_WEAPON,			
-	DECREASE_WEAPON,	
-	INCREASE_SHIELD,			
-	DECREASE_SHIELD,			
-	INCREASE_ENGINE,			
-	DECREASE_ENGINE,			
+int Critical_key_set[] = {
+	CYCLE_NEXT_PRIMARY,
+	CYCLE_PREV_PRIMARY,
+	CYCLE_SECONDARY,
+	CYCLE_NUM_MISSLES,
+	INCREASE_WEAPON,
+	DECREASE_WEAPON,
+	INCREASE_SHIELD,
+	DECREASE_SHIELD,
+	INCREASE_ENGINE,
+	DECREASE_ENGINE,
 	ETS_EQUALIZE,
-	SHIELD_EQUALIZE,			
-	SHIELD_XFER_TOP,			
-	SHIELD_XFER_BOTTOM,			
-	SHIELD_XFER_LEFT,			
-	SHIELD_XFER_RIGHT,			
-	XFER_SHIELD,			
-	XFER_LASER,			
+	SHIELD_EQUALIZE,
+	SHIELD_XFER_TOP,
+	SHIELD_XFER_BOTTOM,
+	SHIELD_XFER_LEFT,
+	SHIELD_XFER_RIGHT,
+	XFER_SHIELD,
+	XFER_LASER,
 };
 
 int Non_critical_key_set[] = {
-	MATCH_TARGET_SPEED,			
-	TOGGLE_AUTO_MATCH_TARGET_SPEED,			
-	TARGET_NEXT,	
-	TARGET_PREV,			
-	TARGET_NEXT_CLOSEST_HOSTILE,			
-	TARGET_PREV_CLOSEST_HOSTILE,			
-	TOGGLE_AUTO_TARGETING,			
-	TARGET_NEXT_CLOSEST_FRIENDLY,			
-	TARGET_PREV_CLOSEST_FRIENDLY,			
-	TARGET_SHIP_IN_RETICLE,			
+	MATCH_TARGET_SPEED,
+	TOGGLE_AUTO_MATCH_TARGET_SPEED,
+	TARGET_NEXT,
+	TARGET_PREV,
+	TARGET_NEXT_CLOSEST_HOSTILE,
+	TARGET_PREV_CLOSEST_HOSTILE,
+	TOGGLE_AUTO_TARGETING,
+	TARGET_NEXT_CLOSEST_FRIENDLY,
+	TARGET_PREV_CLOSEST_FRIENDLY,
+	TARGET_SHIP_IN_RETICLE,
 	TARGET_LAST_TRANMISSION_SENDER,
-	TARGET_CLOSEST_REPAIR_SHIP,			
-	TARGET_CLOSEST_SHIP_ATTACKING_TARGET,			
-	STOP_TARGETING_SHIP,			
-	TARGET_CLOSEST_SHIP_ATTACKING_SELF,			
-	TARGET_TARGETS_TARGET,			
-	TARGET_SUBOBJECT_IN_RETICLE,			
-	TARGET_PREV_SUBOBJECT,			
-	TARGET_NEXT_SUBOBJECT,			
+	TARGET_CLOSEST_REPAIR_SHIP,
+	TARGET_CLOSEST_SHIP_ATTACKING_TARGET,
+	STOP_TARGETING_SHIP,
+	TARGET_CLOSEST_SHIP_ATTACKING_SELF,
+	TARGET_TARGETS_TARGET,
+	TARGET_SUBOBJECT_IN_RETICLE,
+	TARGET_PREV_SUBOBJECT,
+	TARGET_NEXT_SUBOBJECT,
 	STOP_TARGETING_SUBSYSTEM,
 	TARGET_NEXT_BOMB,
 	TARGET_PREV_BOMB,
@@ -468,1267 +460,791 @@ int Non_critical_key_set[] = {
 	CYCLE_PRIMARY_WEAPON_SEQUENCE
 };
 
-int Ignored_keys[CCFG_MAX];
 
-// set sizes of the key sets automatically
-int Normal_key_set_size = sizeof(Normal_key_set) / sizeof(int);
-int Dead_key_set_size = sizeof(Dead_key_set) / sizeof(int);
-int Critical_key_set_size = sizeof(Critical_key_set) / sizeof(int);
-int Non_critical_key_set_size = sizeof(Non_critical_key_set) / sizeof(int);
+// Inherited members
+extern int AI_watch_object;
 
-// --------------------------------------------------------------
-// routine to process keys used only for debugging
-// --------------------------------------------------------------
+extern int Countermeasures_enabled;
 
-void debug_cycle_player_ship(int delta)
-{
-	if ( Player_obj == NULL )
-		return;
-
-	int si_index = Ships[Player_obj->instance].ship_info_index;
-	int sanity = 0;
-	ship_info	*sip;
-	while ( TRUE ) {
-		si_index += delta;
-		if ( si_index >= static_cast<int>(Ship_info.size()) ){
-			si_index = 0;
-		}
-		if ( si_index < 0 ){
-			si_index = static_cast<int>(Ship_info.size() - 1);
-		}
-		sip = &Ship_info[si_index];
-		if ( sip->flags & SIF_PLAYER_SHIP ){
-			break;
-		}
-
-		// just in case
-		sanity++;
-		if ( sanity >= static_cast<int>(Ship_info.size()) ){
-			break;
-		}
-	}
-
-	change_ship_type(Player_obj->instance, si_index);
-	HUD_sourced_printf(HUD_SOURCE_HIDDEN, XSTR( "Player ship changed to %s", 0), Ship_info[si_index].name);			
-}
-
-/**
- * Cycle targeted ship to next ship in that species
- * @param delta Increment
- */
-void debug_cycle_targeted_ship(int delta)
-{
-	object		*objp;
-	ship_info	*sip;
-	int			si_index, species;
-	char			name[NAME_LENGTH];
-
-	if ( Player_ai->target_objnum == -1 )
-		return;
-
-	objp = &Objects[Player_ai->target_objnum];
-	if ( objp->type != OBJ_SHIP )
-		return;
-
-	si_index = Ships[objp->instance].ship_info_index;
-	Assert(si_index != -1 );
-	species = Ship_info[si_index].species;
-
-	int sanity = 0;
-
-	while ( TRUE ) {
-		si_index += delta;
-		if ( si_index >= static_cast<int>(Ship_info.size()) )
-			si_index = 0;
-		if ( si_index < 0 )
-			si_index = static_cast<int>(Ship_info.size() - 1);
-
-	
-		sip = &Ship_info[si_index];
-	
-		// if it has test in the name, jump over it
-		strcpy_s(name, sip->name);
-		_strlwr(name);
-		if ( strstr(name,NOX("test")) != NULL )
-			continue;
-
-		if ( sip->species == species && (sip->flags & (SIF_FIGHTER | SIF_BOMBER | SIF_TRANSPORT) ) )
-			break;
-
-		// just in case
-		sanity++;
-		if ( sanity >= static_cast<int>(Ship_info.size()) )
-			break;
-	}
-
-	change_ship_type(objp->instance, si_index);
-	HUD_sourced_printf(HUD_SOURCE_HIDDEN, XSTR( "Changed player target to %s", 1), Ship_info[si_index].name);			
-}
-
-void debug_max_secondary_weapons(object *objp)
-{
-	int index;
-	ship *shipp = &Ships[objp->instance];
-	ship_info *sip = &Ship_info[shipp->ship_info_index];
-	ship_weapon *swp = &shipp->weapons;
-
-	for ( index = 0; index < MAX_SHIP_SECONDARY_BANKS; index++ )
-	{
-		swp->secondary_bank_ammo[index] = sip->secondary_bank_ammo_capacity[index];
-	}
-}
-
-void debug_max_primary_weapons(object *objp)	// Goober5000
-{
-	Assert(objp);	// Goober5000
-
-	int index;
-	ship *shipp = &Ships[objp->instance];
-	ship_info *sip = &Ship_info[shipp->ship_info_index];
-	ship_weapon *swp = &shipp->weapons;
-	weapon_info *wip;
-
-	if (sip->flags & SIF_BALLISTIC_PRIMARIES)
-	{
-		for ( index = 0; index < MAX_SHIP_PRIMARY_BANKS; index++ )
-		{
-			wip = &Weapon_info[swp->primary_bank_weapons[index]];
-			if (wip->wi_flags2 & WIF2_BALLISTIC)
-			{
-				float capacity, size;
-				capacity = (float) sip->primary_bank_ammo_capacity[index];
-				size = (float) wip->cargo_size;
-				swp->primary_bank_ammo[index] = fl2i((capacity / size)+0.5f);
-			}
-		}
-	}
-}
-
-void debug_change_song(int delta)
-{
-	char buf[256];
-	if ( event_music_next_soundtrack(delta) != -1 ) {
-		event_music_get_soundtrack_name(buf);
-		HUD_sourced_printf(HUD_SOURCE_HIDDEN, XSTR( "Soundtrack changed to: %s", 2), buf);
-
-	} else {
-		HUD_sourced_printf(HUD_SOURCE_HIDDEN, XSTR( "Event music is not playing", 3));
-	}
-}
-
-extern void hud_target_asteroid();
 extern int Framerate_delay;
-
-extern void snd_stop_any_sound();
 
 extern vec3d Eye_position;
 extern matrix Eye_matrix;
-extern void g3_set_view_matrix(const vec3d *view_pos, const matrix *view_matrix, float zoom);
 
 extern int Show_cpu;
 
-int get_prev_weapon_looped(int current_weapon, int subtype)
-{
-	int i, new_index;
 
-	for (i = 1; i < Num_weapon_types; i++)
-	{
-		new_index = (Num_weapon_types + current_weapon - i) % Num_weapon_types;
+// Public members
+int Ignored_keys[CCFG_MAX];
 
-		if(Weapon_info[new_index].subtype == subtype)
-		{
-			return new_index;
-		}
-	}
+bool Perspective_locked = false;
+bool quit_mission_popup_shown = false;
 
-	return current_weapon;
-}
+int Normal_key_set_size = sizeof(Normal_key_set) / sizeof(int);
+int Dead_key_set_size = sizeof(Dead_key_set) / sizeof(int);
 
-int get_next_weapon_looped(int current_weapon, int subtype)
-{
-	int i, new_index;
 
-	for (i = 1; i < Num_weapon_types; i++)
-	{
-		new_index = (current_weapon + i) % Num_weapon_types;
+// Private members
+int Tool_enabled = 0;
 
-		if(Weapon_info[new_index].subtype == subtype)
-		{
-			return new_index;
-		}
-	}
+int Critical_key_set_size = sizeof(Critical_key_set) / sizeof(int);
+int Non_critical_key_set_size = sizeof(Non_critical_key_set) / sizeof(int);
 
-	return current_weapon;
-}
 
-void process_debug_keys(int k)
-{
-	// Kazan -- NO CHEATS IN MULTI
-	if (Game_mode & GM_MULTIPLAYER)
-	{
-		Cheats_enabled = 0;
-		return;
-	}
+// Inherited/Friended/Referenced methods
+extern void hud_target_asteroid();
 
-	switch (k) {
-		case KEY_DEBUGGED + KEY_Q:
-		case KEY_DEBUGGED1 + KEY_Q:
-			Snapshot_all_events = true;
-			break;
+extern void g3_set_view_matrix(const vec3d *view_pos, const matrix *view_matrix, float zoom);
 
-		case KEY_DEBUGGED + KEY_H:
-			hud_target_toggle_hidden_from_sensors();
-			break;
+extern void snd_stop_any_sound();
 
-		case KEY_DEBUGGED + KEY_F: 
-			extern int wacky_scheme;
-			if(wacky_scheme == 3){
-				wacky_scheme = 0;
-			} else {
-				wacky_scheme++;
-			}
-			break;
-		
-		case KEY_DEBUGGED + KEY_ALTED + KEY_F:
-			Framerate_delay += 10;
-			HUD_printf(XSTR( "Framerate delay increased to %i milliseconds per frame.", 4), Framerate_delay);
-			break;
+extern float do_subobj_hit_stuff(object *ship_obj, object *other_obj, vec3d *hitpos, int submodel_num, float damage, bool *hull_should_apply_armor);
 
-		case KEY_DEBUGGED + KEY_ALTED + KEY_SHIFTED + KEY_F:
-			Framerate_delay -= 10;
-			if (Framerate_delay < 0)
-				Framerate_delay = 0;
+extern void mission_goal_mark_all_true(int type);
 
-			HUD_printf(XSTR( "Framerate delay decreased to %i milliseconds per frame.", 5), Framerate_delay);
-			break;
-
-		case KEY_DEBUGGED + KEY_X:
-		case KEY_DEBUGGED1 + KEY_X:
-			HUD_printf("Cloaking has been disabled, thank you for playing fs2_open, %s", Player->callsign);
-			break;
-
-		case KEY_DEBUGGED + KEY_C:
-		case KEY_DEBUGGED1 + KEY_C:
-			if(Player_obj->flags & OF_COLLIDES){
-				obj_set_flags(Player_obj, Player_obj->flags & ~(OF_COLLIDES));
-				HUD_sourced_printf(HUD_SOURCE_HIDDEN, "Player no longer collides");
-			} else {
-				obj_set_flags(Player_obj, Player_obj->flags | OF_COLLIDES);
-				HUD_sourced_printf(HUD_SOURCE_HIDDEN, "Player collides");
-			}
-			break;
-
-		case KEY_DEBUGGED + KEY_SHIFTED + KEY_C:
-		case KEY_DEBUGGED1 + KEY_SHIFTED + KEY_C:
-			Countermeasures_enabled = !Countermeasures_enabled;
-			HUD_printf(XSTR( "Countermeasure firing: %s", 6), Countermeasures_enabled ? XSTR( "ENABLED", 7) : XSTR( "DISABLED", 8));
-			break;
-
-// Goober5000: this should only be compiled in debug builds, since it crashes release
-#ifndef NDEBUG
-		case KEY_DEBUGGED + KEY_E:
-			gameseq_post_event(GS_EVENT_EVENT_DEBUG);
-			break;
-#endif
-
-		// Goober5000: handle time dilation in cheat section
-		case KEY_DEBUGGED + KEY_SHIFTED + KEY_COMMA:
-		case KEY_DEBUGGED1 + KEY_SHIFTED + KEY_COMMA:
-			if ( Game_mode & GM_NORMAL ) {
-				if ( Game_time_compression > (F1_0/MAX_TIME_DIVIDER) ) {
-					change_time_compression(0.5);
-				} else {
-					gamesnd_play_error_beep();
-				}
-			} else {
-				gamesnd_play_error_beep();
-			}
-			break;
-
-		// Goober5000: handle as normal here
-		case KEY_DEBUGGED + KEY_SHIFTED + KEY_PERIOD:
-		case KEY_DEBUGGED1 + KEY_SHIFTED + KEY_PERIOD:
-			if ( Game_mode & GM_NORMAL ) {
-				if ( Game_time_compression < (F1_0*MAX_TIME_MULTIPLIER) ) {
-					change_time_compression(2);
-				} else {
-					gamesnd_play_error_beep();
-				}
-			} else {
-				gamesnd_play_error_beep();
-			}
-			break;
-
-		//	Kill! the currently targeted ship.
-		case KEY_DEBUGGED + KEY_K:
-		case KEY_DEBUGGED1 + KEY_K:
-			if (Player_ai->target_objnum != -1) {
-				object	*objp = &Objects[Player_ai->target_objnum];
-
-				switch (objp->type) {
-				case OBJ_SHIP:
-					
-					// remove guardian flag -- kazan
-					Ships[objp->instance].ship_guardian_threshold = 0;
-					
-					ship_apply_local_damage( objp, Player_obj, &objp->pos, 100000.0f, MISS_SHIELDS, CREATE_SPARKS);
-					ship_apply_local_damage( objp, Player_obj, &objp->pos, 1.0f, MISS_SHIELDS, CREATE_SPARKS);
-					break;
-				case OBJ_WEAPON:
-					Weapons[objp->instance].lifeleft = 0.01f;
-					break;
-				}
-			}
-
-			break;
-		
-		// play the next mission message
-		case KEY_DEBUGGED + KEY_V:		
-			extern int Message_debug_index;
-			extern int Num_messages_playing;
-			// stop any other messages
-			if(Num_messages_playing){
-				message_kill_all(1);
-			}
-
-			// next message
-			if(Message_debug_index >= Num_messages - 1){
-				Message_debug_index = Num_builtin_messages;
-			} else {
-				Message_debug_index++;
-			}
-			
-			// play the message
-			message_send_unique_to_player( Messages[Message_debug_index].name, Message_waves[Messages[Message_debug_index].wave_info.index].name, MESSAGE_SOURCE_SPECIAL, MESSAGE_PRIORITY_HIGH, 0, 0 );			
-			if (Messages[Message_debug_index].avi_info.index == -1) {
-				HUD_printf("No anim set for message \"%s\"; None will play!", Messages[Message_debug_index].name);
-			}
-			break;
-
-		// play the previous mission message
-		case KEY_DEBUGGED + KEY_SHIFTED + KEY_V:
-			extern int Message_debug_index;
-			extern int Num_messages_playing;
-			// stop any other messages
-			if(Num_messages_playing){
-				message_kill_all(1);
-			}
-
-			// go maybe go down one
-			if(Message_debug_index == Num_builtin_messages - 1){
-				Message_debug_index = Num_builtin_messages;
-			} else if(Message_debug_index > Num_builtin_messages){
-				Message_debug_index--;
-			}
-			
-			// play the message
-			message_send_unique_to_player( Messages[Message_debug_index].name, Message_waves[Messages[Message_debug_index].wave_info.index].name, MESSAGE_SOURCE_SPECIAL, MESSAGE_PRIORITY_HIGH, 0, 0 );
-			if (Messages[Message_debug_index].avi_info.index == -1) {
-				HUD_printf("No avi associated with this message; None will play!");
-			}
-			break;
-
-		// reset to the beginning of mission messages
-		case KEY_DEBUGGED + KEY_ALTED + KEY_V:
-			extern int Message_debug_index;
-			Message_debug_index = Num_builtin_messages - 1;
-			HUD_printf("Resetting to first mission message");
-			break;
-
-		//	Kill! the currently targeted ship.
-		case KEY_DEBUGGED + KEY_ALTED + KEY_SHIFTED + KEY_K:
-		case KEY_DEBUGGED1 + KEY_ALTED + KEY_SHIFTED + KEY_K:
-			if (Player_ai->target_objnum != -1) {
-				object	*objp = &Objects[Player_ai->target_objnum];
-
-				if (objp->type == OBJ_SHIP) {
-					ship_apply_local_damage( objp, Player_obj, &objp->pos, Ships[objp->instance].ship_max_hull_strength * 0.1f + 10.0f, MISS_SHIELDS, CREATE_SPARKS);
-				}
-			}
-			break;
-
-			//	Kill the currently targeted subsystem.
-		case KEY_DEBUGGED + KEY_SHIFTED + KEY_K:
-		case KEY_DEBUGGED1 + KEY_SHIFTED + KEY_K:
-			if ((Player_ai->target_objnum != -1) && (Player_ai->targeted_subsys != NULL)) {
-				object	*objp = &Objects[Player_ai->target_objnum];
-				if ( objp->type == OBJ_SHIP ) {
-					ship		*sp = &Ships[objp->instance];
-					vec3d	g_subobj_pos;
-
-					get_subsystem_world_pos(objp, Player_ai->targeted_subsys, &g_subobj_pos);
-
-					do_subobj_hit_stuff(objp, Player_obj, &g_subobj_pos, Player_ai->targeted_subsys->system_info->subobj_num, (float) -Player_ai->targeted_subsys->system_info->type, NULL); //100.0f);
-
-					if ( sp->subsys_info[SUBSYSTEM_ENGINE].aggregate_current_hits <= 0.0f ) {
-						mission_log_add_entry(LOG_SHIP_DISABLED, sp->ship_name, NULL );
-						sp->flags |= SF_DISABLED;				// add the disabled flag
-					}
-
-					if ( sp->subsys_info[SUBSYSTEM_TURRET].aggregate_current_hits <= 0.0f ) {
-						mission_log_add_entry(LOG_SHIP_DISARMED, sp->ship_name, NULL );
-					}
-				}
-			}
-			break;
-
-		case KEY_DEBUGGED + KEY_ALTED + KEY_K:
-		case KEY_DEBUGGED1 + KEY_ALTED + KEY_K:
-			{
-				float	shield, integrity;
-				vec3d	pos, randvec;
-
-				vm_vec_rand_vec_quick(&randvec);
-				vm_vec_scale_add(&pos, &Player_obj->pos, &randvec, Player_obj->radius);
-			ship_apply_local_damage(Player_obj, Player_obj, &pos, 25.0f, MISS_SHIELDS, CREATE_SPARKS);
-			hud_get_target_strength(Player_obj, &shield, &integrity);
-			HUD_sourced_printf(HUD_SOURCE_HIDDEN, XSTR( "You knocked yourself down to %7.3f percent hull.\n", 9), 100.0f * integrity);
-			break;
-			}
-			
-		//	Whack down the player's shield and hull by a little more than 50%
-		//	Select next object to be viewed by AI.
-		case KEY_DEBUGGED + KEY_I:
-		case KEY_DEBUGGED1 + KEY_I:
-			Player_obj->flags ^= OF_INVULNERABLE;
-			HUD_sourced_printf(HUD_SOURCE_HIDDEN, XSTR( "You are %s", 10), Player_obj->flags & OF_INVULNERABLE ? XSTR( "now INVULNERABLE!", 11) : XSTR( "no longer invulnerable...", 12));
-			break;
-
-		case KEY_DEBUGGED + KEY_SHIFTED + KEY_I:
-		case KEY_DEBUGGED1 + KEY_SHIFTED + KEY_I:
-			if (Player_ai->target_objnum != -1) {
-				object	*objp = &Objects[Player_ai->target_objnum];
-
-				objp->flags ^= OF_INVULNERABLE;
-				HUD_sourced_printf(HUD_SOURCE_HIDDEN, XSTR( "Player's target [%s] is %s", 13), Ships[objp->instance].ship_name, objp->flags & OF_INVULNERABLE ? XSTR( "now INVULNERABLE!", 11) : XSTR( "no longer invulnerable...", 12));
-			}
-			break;
-
-		case KEY_DEBUGGED + KEY_N:
-			AI_watch_object++;
-			HUD_sourced_printf(HUD_SOURCE_HIDDEN, XSTR( "Spewing debug info about object #%d", 14), AI_watch_object);
-			break;
-
-		case KEY_DEBUGGED + KEY_O:
-		case KEY_DEBUGGED1 + KEY_O:
-			toggle_player_object();
-			break;				
-
-		case KEY_DEBUGGED + KEY_SHIFTED + KEY_O:
-			extern int Debug_octant;
-			if(Debug_octant == 7){
-				Debug_octant = -1;
-			} else {
-				Debug_octant++;
-			}
-			nprintf(("General", "Debug_octant == %d\n", Debug_octant));
-			break;
-
-		case KEY_DEBUGGED + KEY_P:
-			supernova_start(20);
-			break;
-
-		case KEY_DEBUGGED + KEY_W:
-		case KEY_DEBUGGED1 + KEY_W:
-		case KEY_DEBUGGED + KEY_SHIFTED + KEY_W:
-		case KEY_DEBUGGED1 + KEY_SHIFTED + KEY_W:
-			// temp code for testing purposes, toggles weapon energy cheat
-			Weapon_energy_cheat = !Weapon_energy_cheat;
-			if (Weapon_energy_cheat) {
-				if (k & KEY_SHIFTED)
-					HUD_sourced_printf(HUD_SOURCE_HIDDEN, XSTR( "Weapon energy and missile count will always be at full ALL SHIPS!", 15));
-				else
-					HUD_sourced_printf(HUD_SOURCE_HIDDEN, XSTR( "Weapon energy and missile count will always be at full for player", 16));
-
-				debug_max_secondary_weapons(Player_obj);
-				debug_max_primary_weapons(Player_obj);
-				if (k & KEY_SHIFTED) {
-					object	*objp;
-
-					for ( objp = GET_FIRST(&obj_used_list); objp !=END_OF_LIST(&obj_used_list); objp = GET_NEXT(objp) )
-						if (objp->type == OBJ_SHIP) {
-							debug_max_secondary_weapons(objp);
-							debug_max_primary_weapons(objp);
-						}
-				}
-
-			} else
-				HUD_sourced_printf(HUD_SOURCE_HIDDEN, XSTR( "Normal weapon energy system / missile count restored", 17));
-
-			break;
-
-		case KEY_DEBUGGED + KEY_G:
-		case KEY_DEBUGGED1 + KEY_G:
-			mission_goal_mark_all_true( PRIMARY_GOAL );
-			break;
-
-		case KEY_DEBUGGED + KEY_G + KEY_SHIFTED:
-		case KEY_DEBUGGED1 + KEY_G + KEY_SHIFTED:
-			mission_goal_mark_all_true( SECONDARY_GOAL );
-			break;
-
-		case KEY_DEBUGGED + KEY_G + KEY_ALTED:
-		case KEY_DEBUGGED1 + KEY_G + KEY_ALTED:
-			mission_goal_mark_all_true( BONUS_GOAL );
-			break;
-
-		case KEY_DEBUGGED + KEY_9: {
-		case KEY_DEBUGGED1 + KEY_9:
-			ship* shipp;
-			
-			shipp = &Ships[Player_obj->instance];
-			int *weap = &shipp->weapons.secondary_bank_weapons[shipp->weapons.current_secondary_bank];
-			*weap = get_next_weapon_looped(*weap, WP_MISSILE);
-
-			HUD_sourced_printf(HUD_SOURCE_HIDDEN, XSTR( "Secondary Weapon forced to %s", 18), Weapon_info[*weap].name);
-			break;
-		}
-
-			
-		case KEY_DEBUGGED + KEY_SHIFTED + KEY_9: {
-		case KEY_DEBUGGED1 + KEY_SHIFTED + KEY_9:
-			ship* shipp;
-
-			shipp = &Ships[Player_obj->instance];
-			int *weap = &shipp->weapons.secondary_bank_weapons[shipp->weapons.current_secondary_bank];
-			*weap = get_prev_weapon_looped(*weap, WP_MISSILE);
-
-			HUD_sourced_printf(HUD_SOURCE_HIDDEN, XSTR( "Secondary Weapon forced to %s", 18), Weapon_info[*weap].name);
-			break;
-		}
-		
-		case KEY_DEBUGGED + KEY_U: {
-		case KEY_DEBUGGED1 + KEY_U:
-			// launch asteroid
-			object *asteroid_create(asteroid_field *asfieldp, int asteroid_type, int subtype);
-			object *objp = asteroid_create(&Asteroid_field, 0, 0);
-			if(objp == NULL) {
-				break;
-			}			
-			vec3d vel;
-			vm_vec_copy_scale(&vel, &Player_obj->orient.vec.fvec, 50.0f);
-			objp->phys_info.vel = vel;
-			objp->phys_info.desired_vel = vel;
-			objp->pos = Player_obj->pos;
-			HUD_sourced_printf(HUD_SOURCE_HIDDEN, XSTR( "Asteroid launched", 1595));
-			break;
-		}
-
-		case KEY_DEBUGGED + KEY_0: {
-		case KEY_DEBUGGED1 + KEY_0:
-			ship* shipp;
-
-			shipp = &Ships[Player_obj->instance];
-			int *weap = &shipp->weapons.primary_bank_weapons[shipp->weapons.current_primary_bank];
-			*weap = get_next_weapon_looped(*weap, WP_LASER);
-			
-			HUD_sourced_printf(HUD_SOURCE_HIDDEN, XSTR( "Primary Weapon forced to %s", 19), Weapon_info[*weap].name);
-			break;
-		}
-
-		case KEY_DEBUGGED + KEY_SHIFTED + KEY_0: {
-		case KEY_DEBUGGED1 + KEY_SHIFTED + KEY_0:
-			ship* shipp;
-
-			shipp = &Ships[Player_obj->instance];
-			int *weap = &shipp->weapons.primary_bank_weapons[shipp->weapons.current_primary_bank];
-			*weap = get_prev_weapon_looped(*weap, WP_LASER);
-		
-			HUD_sourced_printf(HUD_SOURCE_HIDDEN, XSTR( "Primary Weapon forced to %s", 19), Weapon_info[*weap].name);
-			break;
-		}
-
-		case KEY_DEBUGGED + KEY_J: {
-			int new_pattern = event_music_return_current_pattern();
-
-			new_pattern++;
-			if ( new_pattern >= MAX_PATTERNS )
-				new_pattern = 0;
-
-			event_music_change_pattern(new_pattern);
-			break;
-		}
-
-		case KEY_DEBUGGED + KEY_M: {
-			if ( Event_music_enabled ) {
-				event_music_disable();
-				HUD_sourced_printf(HUD_SOURCE_HIDDEN, XSTR( "Event music disabled", 20));
-
-			} else {
-				event_music_enable();
-				HUD_sourced_printf(HUD_SOURCE_HIDDEN, XSTR( "Event music enabled", 21));
-			}
-
-			break;
-		}
-
-		case KEY_DEBUGGED + KEY_R:
-		case KEY_DEBUGGED1 + KEY_R:
-		{
-			// rearm the target, if we have one
-			object *obj_to_rearm = (Player_ai->target_objnum >= 0) ? &Objects[Player_ai->target_objnum] : Player_obj;
-
-			if (is_support_allowed(obj_to_rearm))
-			{
-				HUD_sourced_printf(HUD_SOURCE_HIDDEN, XSTR("Issuing rearm request for %s", -1), Ships[obj_to_rearm->instance].ship_name);
-				ai_issue_rearm_request(obj_to_rearm);
-			}
-			else
-			{
-				HUD_sourced_printf(HUD_SOURCE_HIDDEN, XSTR("Cannot issue rearm request for %s", -1), Ships[obj_to_rearm->instance].ship_name);
-			}
-
-			break;
-		}
-
-		case KEY_DEBUGGED + KEY_SHIFTED + KEY_UP:
-			Game_detail_level++;
-			HUD_printf( XSTR( "Detail level set to %+d\n", 22), Game_detail_level );
-			break;
-
-		case KEY_DEBUGGED + KEY_SHIFTED + KEY_DOWN:
-			Game_detail_level--;
-			HUD_printf( XSTR( "Detail level set to %+d\n", 22), Game_detail_level );
-			break;
-
-#ifndef NDEBUG
-		case KEY_DEBUGGED + KEY_SHIFTED + KEY_T:	{
-			extern int Test_begin;
-
-			if ( Test_begin == 1 )
-				break;
-
-			Test_begin = 1;
-			HUD_sourced_printf(HUD_SOURCE_HIDDEN, XSTR( "Frame Rate test started", 23));
-
-			break;
-		}
-#endif
-		case KEY_DEBUGGED + KEY_A:	{
-
-			HUD_printf("frame rate currently is %0.2 FPS", 1/flFrametime);
-
-			break;
-		}
-
-
-		case KEY_DEBUGGED + KEY_D:
-			extern int OO_update_index;			
-
-			if(MULTIPLAYER_MASTER){
-				do {
-					OO_update_index++;
-				} while((OO_update_index < (MAX_PLAYERS-1)) && !MULTI_CONNECTED(Net_players[OO_update_index]));
-				if(OO_update_index >= MAX_PLAYERS-1){
-					OO_update_index = -1;
-				}			
-			} else {
-				if(OO_update_index < 0){
-					OO_update_index = MY_NET_PLAYER_NUM;
-				} else {
-					OO_update_index = -1;
-				}
-			}
-			break;
-
-		// change player ship to next flyable type
-		case KEY_DEBUGGED + KEY_RIGHT:
-			debug_cycle_player_ship(1);
-			break;
-
-		// change player ship to previous flyable ship
-		case KEY_DEBUGGED + KEY_LEFT:
-			debug_cycle_player_ship(-1);
-			break;
-		
-		// cycle target to ship
-		case KEY_DEBUGGED + KEY_SHIFTED + KEY_RIGHT:
-			debug_cycle_targeted_ship(1);
-			break;
-
-		// cycle target to previous ship
-		case KEY_DEBUGGED + KEY_SHIFTED + KEY_LEFT:
-			debug_cycle_targeted_ship(-1);
-			break;
-
-		// change species of the targeted ship
-		case KEY_DEBUGGED + KEY_S: {
-			if ( Player_ai->target_objnum < 0 )
-				break;
-
-			object		*objp;
-			ship_info	*sip;
-
-			objp = &Objects[Player_ai->target_objnum];
-			if ( objp->type != OBJ_SHIP )
-				return;
-
-			sip = &Ship_info[Ships[objp->instance].ship_info_index];
-			sip->species++;
-
-			if (sip->species >= (int)Species_info.size())
-				sip->species = 0;
-
-			HUD_sourced_printf(HUD_SOURCE_HIDDEN, XSTR( "Species of target changed to: %s", 24), Species_info[sip->species].species_name);
-			break;
-		}
-			
-		case KEY_DEBUGGED + KEY_SHIFTED + KEY_S:
-			game_increase_skill_level();
-			HUD_sourced_printf(HUD_SOURCE_HIDDEN, XSTR( "Skill level set to %s.", 25), Skill_level_names(Game_skill_level));
-			break;
-					
-		case KEY_DEBUGGED + KEY_T: {
-			char buf[256];
-			event_music_get_info(buf);
-			HUD_sourced_printf(HUD_SOURCE_HIDDEN, buf);
-			break;
-		}
-
-		case KEY_DEBUGGED + KEY_UP:
-		case KEY_DEBUGGED1 + KEY_UP:
-			debug_change_song(1);
-			break;
-
-		case KEY_DEBUGGED + KEY_DOWN:
-		case KEY_DEBUGGED1 + KEY_DOWN:
-			debug_change_song(-1);
-			break;
-
-		case KEY_PADMINUS: {
-			int init_flag = 0;
-
-			if ( keyd_pressed[KEY_1] )	{
-				init_flag = 1;
-				HUD_color_red -= 4;
-			} 
-
-			if ( keyd_pressed[KEY_2] )	{
-				init_flag = 1;
-				HUD_color_green -= 4;
-			} 
-
-			if ( keyd_pressed[KEY_3] )	{
-				init_flag = 1;
-				HUD_color_blue -= 4;
-			} 
-
-			if (init_flag)
-				HUD_init_colors();
-
-			break;
-		}
-		
-		case KEY_DEBUGGED + KEY_Y:
-			extern int tst;
-			tst = 2;
-			break;
-
-		case KEY_PADPLUS: {
-			int init_flag = 0;
-
-			if ( keyd_pressed[KEY_1] )	{
-				init_flag = 1;
-				HUD_color_red += 4;
-			} 
-
-			if ( keyd_pressed[KEY_2] )	{
-				init_flag = 1;
-				HUD_color_green += 4;
-			} 
-
-			if ( keyd_pressed[KEY_3] )	{
-				init_flag = 1;
-				HUD_color_blue += 4;
-			} 
-
-			if (init_flag)
-				HUD_init_colors();
-
-			break;
-		}
-		case KEY_DEBUGGED + KEY_ALTED + KEY_EQUAL:
-		case KEY_DEBUGGED1 + KEY_ALTED + KEY_EQUAL:
-			{
-			camera *cam = Main_camera.getCamera();
-			if(cam == NULL)
-			{
-				HUD_sourced_printf(HUD_SOURCE_HIDDEN, "Couldn't get camera FOV");
-				break;
-			}
-			cam->set_fov(cam->get_fov() + 0.1f);
-			HUD_sourced_printf(HUD_SOURCE_HIDDEN, "Camera fov raised to %0.2f" , cam->get_fov());
-			}
-			break;
-
-		case KEY_DEBUGGED + KEY_ALTED + KEY_MINUS:
-		case KEY_DEBUGGED1 + KEY_ALTED + KEY_MINUS:
-			{
-			camera *cam = Main_camera.getCamera();
-			if(cam == NULL)
-			{
-				HUD_sourced_printf(HUD_SOURCE_HIDDEN, "Couldn't get camera FOV");
-				break;
-			}
-			cam->set_fov(cam->get_fov() - 0.1f);
-			HUD_sourced_printf(HUD_SOURCE_HIDDEN, "Camera fov lowered to %0.2f" , cam->get_fov());
-			}
-			break;
-		case KEY_DEBUGGED + KEY_Z:
-		case KEY_DEBUGGED1 + KEY_Z:
-			{
-				Show_cpu = !Show_cpu;
-			}
-			break;
-
-	}	// end switch
-}
-
-void ppsk_hotkeys(int k)
-{
-	// use k to check for keys that can have Shift,Ctrl,Alt,Del status
-	int hotkey_set;
-
-#ifndef NDEBUG
-	k &= ~KEY_DEBUGGED;			// since hitting F11 will set this bit
-#endif
-
-	switch (k) {
-		case KEY_F5:
-		case KEY_F6:
-		case KEY_F7:
-		case KEY_F8:
-		case KEY_F9:
-		case KEY_F10:
-		case KEY_F11:
-		case KEY_F12:
-			hotkey_set = mission_hotkey_get_set_num(k);
-			if ( !(Players[Player_num].flags & PLAYER_FLAGS_MSG_MODE) )
-				hud_target_hotkey_select( hotkey_set );
-			else
-				hud_squadmsg_hotkey_select( hotkey_set );
-
-			break;
-
-		case KEY_F5 + KEY_SHIFTED:
-		case KEY_F6 + KEY_SHIFTED:
-		case KEY_F7 + KEY_SHIFTED:
-		case KEY_F8 + KEY_SHIFTED:
-		case KEY_F9 + KEY_SHIFTED:
-		case KEY_F10 + KEY_SHIFTED:
-		case KEY_F11 + KEY_SHIFTED:
-		case KEY_F12 + KEY_SHIFTED:
-			hotkey_set = mission_hotkey_get_set_num(k&(~KEY_SHIFTED));
-			mprintf(("Adding to set %d\n", hotkey_set+1));
-			if ( Player_ai->target_objnum == -1)
-				HUD_sourced_printf(HUD_SOURCE_HIDDEN, XSTR( "No target to add/remove from set %d.", 26), hotkey_set+1);
-			else  {
-				hud_target_hotkey_add_remove( hotkey_set, &Objects[Player_ai->target_objnum], HOTKEY_USER_ADDED);
-				HUD_sourced_printf(HUD_SOURCE_HIDDEN, XSTR( "%s added to set %d. (F%d)", 27), Ships[Objects[Player_ai->target_objnum].instance].ship_name, hotkey_set, 4+hotkey_set+1);
-			}
-
-			break;
-
-		case KEY_F5 + KEY_SHIFTED + KEY_ALTED:
-		case KEY_F6 + KEY_SHIFTED + KEY_ALTED:
-		case KEY_F7 + KEY_SHIFTED + KEY_ALTED:
-		case KEY_F8 + KEY_SHIFTED + KEY_ALTED:
-		case KEY_F9 + KEY_SHIFTED + KEY_ALTED:
-		case KEY_F10 + KEY_SHIFTED + KEY_ALTED:
-		case KEY_F11 + KEY_SHIFTED + KEY_ALTED:
-		case KEY_F12 + KEY_SHIFTED + KEY_ALTED:
-			hotkey_set = mission_hotkey_get_set_num(k & (~(KEY_SHIFTED+KEY_ALTED)));
-			hud_target_hotkey_clear( hotkey_set );
-			break;
-
-		case KEY_SHIFTED + KEY_MINUS:
-			if ( HUD_color_alpha > HUD_COLOR_ALPHA_USER_MIN )	{
-				HUD_color_alpha--;
-				HUD_init_colors();
-			}
-			break;
-
-		case KEY_SHIFTED + KEY_EQUAL:
-			if ( HUD_color_alpha < HUD_COLOR_ALPHA_USER_MAX ) {
-				HUD_color_alpha++;
-				HUD_init_colors();
-			}
-			break;
-	}	// end switch
-}
+// --------------------------------------------------------------------------------------------------------------------
+// Declaration of private functions(declared as static type func(type param);)
+// --------------------------------------------------------------------------------------------------------------------
+/**
+ * @brief Handler for when player hits 'ESC' during the game
+ */
+void game_do_end_mission_popup();
 
 /**
- * Check keypress 'key' against a set of valid controls and mark the match in the
- * player's button info bitfield.  Also checks joystick controls in the set.
+ * @brief Processes cheat codes
+ */
+void game_process_cheats(int k);
+
+/**
+ * @brief Processes all keys pressed since last frame
+ */
+void game_process_keys();
+
+/**
+ * @brief Gets the index of the next weapon type. Loops around
+ */
+int get_next_weapon_looped(int current_weapon, int subtype);
+
+/**
+ * @brief Gets the index of the previous weapon type. Loops around
+ */
+int get_prev_weapon_looped(int current_weapon, int subtype);
+
+/**
+ * @brief Execute function corresponding to action n
  *
- * @param key Scancode (plus modifiers).
- * @param count Total size of the list
- * @param list List of ::Control_config struct action indices to check for
+ * @param[in] n IoActionId
+ *
+ * @returns 1 when an action was taken, or
+ * @returns 0 otherwise
  */
-void process_set_of_keys(int key, int count, int *list)
-{
-	int i;
-
-	for (i=0; i<count; i++)
-		if (check_control(list[i], key))
-			button_info_set(&Player->bi, list[i]);
-}
+int button_function(int n);
 
 /**
- * Routine to process keys used for player ship stuff (*not* ship movement).
+ * @brief Execute a critical function corresponding to action n
+ *
+ * @param[in] n IoActionId
+ * @param[in] p Pointer to the netplayer this function should be processed for. If Null, process for the player on
+ *   this machine
+ *
+ * @returns 1 if an action was taken, or
+ * @returns 0 otherwise
  */
-void process_player_ship_keys(int k)
-{
-	int masked_k;
+int button_function_critical(int n, net_player *p = NULL);
 
-	masked_k = k & ~KEY_CTRLED;	// take out CTRL modifier only	
+/**
+ * @brief Execute function corresponding to action n, if it doesn't affect demo playback
+ *
+ * @param[in] n IoActionId
+ *
+ * @returns 1 when an action was taken, or
+ * @returns 0 otherwise
+ */
+int button_function_demo_valid(int n);
 
-	// moved this line to beginning of function since hotkeys now encompass
-	// F5 - F12.  We can return after using F11 as a hotkey.
-	ppsk_hotkeys(masked_k);
-	if (keyd_pressed[KEY_DEBUG_KEY]){
-		return;
-	}
 
-	// if we're in supernova mode. do nothing
-	if(Player->control_mode == PCM_SUPERNOVA){
-		return;
-	}
+/**
+ * @brief Returns true if the given action is a targeting control
+ */
+bool key_is_targeting(int n);
 
-	// pass the key to the squadmate messaging code.  If the messaging code took the key, then return
-	// from here immediately since we don't want to do further key processing.
-	if ( hud_squadmsg_read_key(k) )
-		return;
+/**
+ * @brief If the given key is a hotkey, do the corresponding action
+ *
+ * @param[in] k The key to check
+ *
+ * @details Pre-Process Special Key? This is called within process_player_ship_keys before it checks the other actions
+ *   for a match
+ */
+void ppsk_hotkeys(int k);
 
-	if ( Player->control_mode == PCM_NORMAL )	{
-		//	The following things are not legal to do while dead.
-		if ( !(Game_mode & GM_DEAD) ) {
-			process_set_of_keys(masked_k, Normal_key_set_size, Normal_key_set);
-		} else	{
-			process_set_of_keys(masked_k, Dead_key_set_size, Dead_key_set);
+/**
+ * @brief If the given key is tied to a hardcoded debug action, do the corresponding action
+ *
+ * @param[in] k The key to check
+ */
+void process_debug_keys(int k);
+
+/**
+ * @brief If the given keys is used for player ship stuff (*not* ship movement), do the corresponding action
+ *
+ * @param[in] k The key to check
+ */
+void process_player_ship_keys(int k);
+
+/**
+ * @brief DEBUG: Changes the currently playing soundtrack. Maybe.
+ *
+ * @param[in] delta Not used
+ */
+void debug_change_song(int delta);
+
+/**
+ * @brief DEBUG: Cycle the player's ship to the next ship in its species
+ *
+ * @param[in] delta Number of ships to skip. Ex: +1 uses the next ship, -1 uses previous, +2 uses the 2nd next, etc.
+ */
+void debug_cycle_player_ship(int delta);
+
+/**
+ * @brief DEBUG: Cycle the targeted ship to the next ship in its species
+ *
+ * @param[in] delta Number of ships to skip. Ex: +1 uses the next ship, -1 uses previous, +2 uses the 2nd next, etc.
+ */
+void debug_cycle_targeted_ship(int delta);
+
+/**
+ * @brief DEBUG: Refills ammo for ballistic primaries for the given obj
+ *
+ * @param[in] delta
+ */
+void debug_max_primary_weapons(object *objp);
+
+/**
+ * @brief DEBUG: Refills secondary ammo for the given obj
+ *
+ * @param[in] delta
+ */
+void debug_max_secondary_weapons(object *objp);
+
+
+// --------------------------------------------------------------------------------------------------------------------
+// Definition of all functions, in alphabetical order
+// --------------------------------------------------------------------------------------------------------------------
+int button_function(int n) {
+	Assert(n >= 0);
+
+	if (Control_config[n].disabled)
+		return 0;
+
+	// check if the button has been set to be ignored by a SEXP
+	if (Ignored_keys[n]) {
+		if (Ignored_keys[n] > 0) {
+			Ignored_keys[n]--;
 		}
-		if (lua_game_control & LGC_B_POLL_ALL) {
-			// first clear all
-			button_info_clear(&Player->lua_bi_full);
+		return 0;
+	}
 
-			// then check the keys.
-			int i;
-			for(i = 0; i < CCFG_MAX; i++) {
-				if (check_control(i, masked_k))
-					button_info_set(&Player->lua_bi_full, i);
+	//	No keys, not even targeting keys, when player in death roll.  He can press keys after he blows up.
+	if (Game_mode & GM_DEAD_DIED) {
+		return 0;
+	}
+
+	// Goober5000 - if the ship doesn't have subspace drive, jump key doesn't work: so test and exit early
+	if (Player_ship->flags2 & SF2_NO_SUBSPACE_DRIVE) {
+		switch (n) {
+		case END_MISSION:
+			control_used(n);	// set the timestamp for when we used the control, in case we need it
+			return 1;			// pretend we took the action: if we return 0, strange stuff may happen
+		}
+	}
+
+	// Goober5000 - if we have primitive sensors, some keys don't work: so test and exit early
+	if (Player_ship->flags2 & SF2_PRIMITIVE_SENSORS) {
+		switch (n) {
+		case MATCH_TARGET_SPEED:
+		case TOGGLE_AUTO_MATCH_TARGET_SPEED:
+		case TOGGLE_AUTO_TARGETING:
+		case TARGET_NEXT:
+		case TARGET_PREV:
+		case TARGET_NEXT_CLOSEST_HOSTILE:
+		case TARGET_PREV_CLOSEST_HOSTILE:
+		case TARGET_NEXT_CLOSEST_FRIENDLY:
+		case TARGET_PREV_CLOSEST_FRIENDLY:
+		case TARGET_SHIP_IN_RETICLE:
+		case TARGET_LAST_TRANMISSION_SENDER:
+		case TARGET_CLOSEST_REPAIR_SHIP:
+		case TARGET_CLOSEST_SHIP_ATTACKING_TARGET:
+		case STOP_TARGETING_SHIP:
+		case TARGET_CLOSEST_SHIP_ATTACKING_SELF:
+		case TARGET_TARGETS_TARGET:
+		case TARGET_SUBOBJECT_IN_RETICLE:
+		case TARGET_NEXT_SUBOBJECT:
+		case TARGET_PREV_SUBOBJECT:
+		case STOP_TARGETING_SUBSYSTEM:
+		case TARGET_NEXT_BOMB:
+		case TARGET_PREV_BOMB:
+		case TARGET_NEXT_UNINSPECTED_CARGO:
+		case TARGET_PREV_UNINSPECTED_CARGO:
+		case TARGET_NEWEST_SHIP:
+		case TARGET_NEXT_LIVE_TURRET:
+		case TARGET_PREV_LIVE_TURRET:
+		case TARGET_NEXT_ESCORT_SHIP:
+			control_used(n);	// set the timestamp for when we used the control, in case we need it
+			return 1;			// pretend we took the action: if we return 0, strange stuff may happen
+		}
+	}
+
+	switch (n) {
+		// following are not handled here, but we need to bypass the Int3()
+	case LAUNCH_COUNTERMEASURE:
+	case VIEW_SLEW:
+	case VIEW_TRACK_TARGET:
+	case ONE_THIRD_THROTTLE:
+	case TWO_THIRDS_THROTTLE:
+	case MINUS_5_PERCENT_THROTTLE:
+	case PLUS_5_PERCENT_THROTTLE:
+	case ZERO_THROTTLE:
+	case MAX_THROTTLE:
+	case TOGGLE_GLIDING:
+	case GLIDE_WHEN_PRESSED:
+		return 0;
+	}
+
+	/**
+	* This switch handles the critical buttons
+	*
+	* button_function_critical is also called from network
+	*/
+	switch (n) {
+	case CYCLE_PRIMARY_WEAPON_SEQUENCE:
+	case CYCLE_NEXT_PRIMARY:	// cycle to next primary weapon
+	case CYCLE_PREV_PRIMARY:	// cycle to previous primary weapon
+	case CYCLE_SECONDARY:		// cycle to next secondary weapon
+	case CYCLE_NUM_MISSLES:		// cycle number of missiles fired from secondary bank
+	case SHIELD_EQUALIZE:		// equalize shield energy to all quadrants
+	case SHIELD_XFER_TOP:		// transfer shield energy to front
+	case SHIELD_XFER_BOTTOM:	// transfer shield energy to rear
+	case SHIELD_XFER_LEFT:		// transfer shield energy to left
+	case SHIELD_XFER_RIGHT:		// transfer shield energy to right
+	case XFER_SHIELD:			// transfer energy to shield from weapons
+	case XFER_LASER:			// transfer energy to weapons from shield
+		return button_function_critical(n);
+		break;
+
+	case INCREASE_WEAPON:		// increase weapon recharge rate
+	case DECREASE_WEAPON:		// decrease weapon recharge rate
+	case INCREASE_SHIELD:		// increase shield recharge rate
+	case DECREASE_SHIELD:		// decrease shield recharge rate
+	case INCREASE_ENGINE:		// increase energy to engines
+	case DECREASE_ENGINE:		// decrease energy to engines
+	case ETS_EQUALIZE:
+		if ((Player_ship->flags2 & SF2_NO_ETS) == 0) {
+			hud_gauge_popup_start(HUD_ETS_GAUGE);
+			return button_function_critical(n);
+		}
+		return 1;
+		break;
+	}
+
+	/**
+	* Assume the switches below will catch the key, if not, set to FALSE in default
+	*
+	* Below, you must not use return in cases,
+	* else the check for invalid keys will fail
+	*/
+	int keyHasBeenUsed = TRUE;
+
+	switch (n) {
+		// message all netplayers button
+	case MULTI_MESSAGE_ALL:
+		multi_msg_key_down(MULTI_MSG_ALL);
+		break;
+
+		// message all friendlies button
+	case MULTI_MESSAGE_FRIENDLY:
+		multi_msg_key_down(MULTI_MSG_FRIENDLY);
+		break;
+
+		// message all hostiles button
+	case MULTI_MESSAGE_HOSTILE:
+		multi_msg_key_down(MULTI_MSG_HOSTILE);
+		break;
+
+		// message targeted ship (if player)
+	case MULTI_MESSAGE_TARGET:
+		multi_msg_key_down(MULTI_MSG_TARGET);
+		break;
+
+		// undefined in multiplayer for clients right now
+		// toggle auto-match target speed
+	case TOGGLE_AUTO_MATCH_TARGET_SPEED:
+		// multiplayer observers can't match target speed
+		if ((Game_mode & GM_MULTIPLAYER) && (Net_player != NULL) && ((Net_player->flags & NETINFO_FLAG_OBSERVER) || (Player_obj->type == OBJ_OBSERVER))) {
+			break;
+		}
+
+		Player->flags ^= PLAYER_FLAGS_AUTO_MATCH_SPEED;
+		control_used(TOGGLE_AUTO_MATCH_TARGET_SPEED);
+		hud_gauge_popup_start(HUD_AUTO_SPEED);
+		if (Players[Player_num].flags & PLAYER_FLAGS_AUTO_MATCH_SPEED) {
+			snd_play(&Snds[SND_SHIELD_XFER_OK], 1.0f);
+			if (!(Player->flags & PLAYER_FLAGS_MATCH_TARGET)) {
+				player_match_target_speed();
+			}
+		} else {
+			snd_play(&Snds[SND_SHIELD_XFER_OK], 1.0f);
+			player_match_target_speed();
+		}
+		break;
+
+	case TARGET_NEXT_UNINSPECTED_CARGO:
+		hud_target_uninspected_object(1);
+		break;
+
+	case TARGET_PREV_UNINSPECTED_CARGO:
+		hud_target_uninspected_object(0);
+		break;
+
+	case TARGET_NEWEST_SHIP:
+		hud_target_newest_ship();
+		break;
+
+	case TARGET_NEXT_LIVE_TURRET:
+		hud_target_live_turret(1);
+		break;
+
+	case TARGET_PREV_LIVE_TURRET:
+		hud_target_live_turret(0);
+		break;
+
+		// end the mission
+	case END_MISSION:
+		// in multiplayer, all end mission requests should go through the server
+		if (Game_mode & GM_MULTIPLAYER) {
+			multi_handle_end_mission_request();
+			break;
+		}
+
+		control_used(END_MISSION);
+
+		if (collide_predict_large_ship(Player_obj, 200.0f)
+			|| (Ship_info[Ships[Player_obj->instance].ship_info_index].warpout_type == WT_HYPERSPACE
+			&& collide_predict_large_ship(Player_obj, 100000.0f))) {
+			gamesnd_play_iface(SND_GENERAL_FAIL);
+			HUD_printf(XSTR("** WARNING ** Collision danger.  Subspace drive not activated.", 39));
+		} else if (!ship_engine_ok_to_warp(Player_ship)) {
+			gamesnd_play_iface(SND_GENERAL_FAIL);
+			HUD_printf(XSTR("Engine failure.  Cannot engage subspace drive.", 40));
+		} else if (!ship_navigation_ok_to_warp(Player_ship)) {
+			gamesnd_play_iface(SND_GENERAL_FAIL);
+			HUD_printf(XSTR("Navigation failure.  Cannot engage subspace drive.", 1596));
+		} else if ((Player_obj != NULL) && object_get_gliding(Player_obj)) {
+			gamesnd_play_iface(SND_GENERAL_FAIL);
+			HUD_printf(XSTR("Cannot engage subspace drive while gliding.", 1597));
+		} else {
+			gameseq_post_event(GS_EVENT_PLAYER_WARPOUT_START);
+		}
+		break;
+
+	case ADD_REMOVE_ESCORT:
+		if (Player_ai->target_objnum >= 0) {
+			control_used(ADD_REMOVE_ESCORT);
+			hud_add_remove_ship_escort(Player_ai->target_objnum);
+		}
+		break;
+
+		// if i'm an observer, zoom to my targeted object
+	case MULTI_OBSERVER_ZOOM_TO:
+		multi_obs_zoom_to_target();
+		break;
+
+		// toggle between high and low HUD contrast
+	case TOGGLE_HUD_CONTRAST:
+		gamesnd_play_iface(SND_USER_SELECT);
+		hud_toggle_contrast();
+		break;
+
+		// toggle network info
+	case MULTI_TOGGLE_NETINFO:
+		extern int Multi_display_netinfo;
+		Multi_display_netinfo = !Multi_display_netinfo;
+		break;
+
+		// self destruct (multiplayer only)
+	case MULTI_SELF_DESTRUCT:
+		if (!(Game_mode & GM_MULTIPLAYER)) {
+			break;
+		}
+
+		// bogus netplayer
+		if ((Net_player == NULL) || (Net_player->m_player == NULL)) {
+			break;
+		}
+
+		// blow myself up, if I'm the server
+		if (Net_player->flags & NETINFO_FLAG_AM_MASTER) {
+			if ((Net_player->m_player->objnum >= 0) &&
+				(Net_player->m_player->objnum < MAX_OBJECTS) &&
+				(Objects[Net_player->m_player->objnum].type == OBJ_SHIP) &&
+				(Objects[Net_player->m_player->objnum].instance >= 0) &&
+				(Objects[Net_player->m_player->objnum].instance < MAX_SHIPS)) {
+
+				ship_self_destruct(&Objects[Net_player->m_player->objnum]);
+			}
+		} else { // otherwise send a packet to the server
+			send_self_destruct_packet();
+		}
+		break;
+
+	case TOGGLE_HUD:
+		gamesnd_play_iface(SND_USER_SELECT);
+		hud_toggle_draw();
+		break;
+
+	case HUD_TARGETBOX_TOGGLE_WIREFRAME:
+		if (!Lock_targetbox_mode) {
+			gamesnd_play_iface(SND_USER_SELECT);
+			hud_targetbox_switch_wireframe_mode();
+		} else {
+			gamesnd_play_iface(SND_GENERAL_FAIL);
+		}
+		break;
+
+		// Autopilot key control
+	case AUTO_PILOT_TOGGLE:
+		if (!(The_mission.flags & MISSION_FLAG_DEACTIVATE_AP)) {
+			if (AutoPilotEngaged) {
+				if (Cmdline_autopilot_interruptable == 1) //allow WCS to disable autopilot interrupt via commandline
+					EndAutoPilot();
+			} else {
+				if (!StartAutopilot())
+					gamesnd_play_iface(SND_GENERAL_FAIL);
 			}
 		}
-	} else {
+		break;
 
+	case NAV_CYCLE:
+		if (!Sel_NextNav())
+			gamesnd_play_iface(SND_GENERAL_FAIL);
+		break;
+	default:
+		keyHasBeenUsed = FALSE;
+		break;
 	}
-}
 
-/**
- * Handler for when player hits 'ESC' during the game
- */
-void game_do_end_mission_popup()
-{
-	int	pf_flags, choice;
+	/**
+	* The key has been handled, return early before the timestamp is set
+	*/
+	if (keyHasBeenUsed) {
+		return 1;
+	}
 
-	// do the multiplayer version of this
-	if(Game_mode & GM_MULTIPLAYER){
-		multi_quit_game(PROMPT_ALL);
-	} else {
-		// single player version....
-		// do housekeeping things.
-		game_stop_time();
-		game_stop_looped_sounds();
-		snd_stop_all();
+	/**
+	* 	Update the last used timestamp of this key
+	*/
+	control_used(n);
 
-		quit_mission_popup_shown = true;
-
-		pf_flags = PF_BODY_BIG | PF_USE_AFFIRMATIVE_ICON | PF_USE_NEGATIVE_ICON;
-		choice = popup(pf_flags, 3, POPUP_NO, XSTR( "&Yes, Quit", 28), XSTR( "Yes, &Restart", 29), XSTR( "Do you really want to end the mission?", 30));
-
-		switch (choice) {
-		case 1:
-			gameseq_post_event(GS_EVENT_END_GAME);
+	if (hud_sensors_ok(Player_ship)) {
+		keyHasBeenUsed = TRUE;
+		switch (n) {
+			// target next
+		case TARGET_NEXT:
+			hud_target_next();
 			break;
 
-		case 2:
-			gameseq_post_event(GS_EVENT_ENTER_GAME);
+			// target previous
+		case TARGET_PREV:
+			hud_target_prev();
+			break;
+
+			// target the next hostile target
+		case TARGET_NEXT_CLOSEST_HOSTILE:
+			hud_target_next_list();
+			break;
+
+			// target the previous closest hostile
+		case TARGET_PREV_CLOSEST_HOSTILE:
+			hud_target_next_list(1, 0);
+			break;
+
+			// target the next friendly ship
+		case TARGET_NEXT_CLOSEST_FRIENDLY:
+			hud_target_next_list(0);
+			break;
+
+			// target the closest friendly ship
+		case TARGET_PREV_CLOSEST_FRIENDLY:
+			hud_target_next_list(0, 0);
+			break;
+
+			// target ship closest to center of reticle
+		case TARGET_SHIP_IN_RETICLE:
+			hud_target_in_reticle_new();
+			break;
+
+		case TARGET_LAST_TRANMISSION_SENDER:
+			hud_target_last_transmit();
+			break;
+
+			// target the closest ship attacking current target
+		case TARGET_CLOSEST_SHIP_ATTACKING_TARGET:
+			if (Player_ai->target_objnum < 0) {
+				snd_play(&Snds[SND_TARGET_FAIL]);
+				break;
+			}
+
+			hud_target_closest(iff_get_attacker_mask(obj_team(&Objects[Player_ai->target_objnum])), Player_ai->target_objnum);
+			break;
+
+			// target closest ship that is attacking player
+		case TARGET_CLOSEST_SHIP_ATTACKING_SELF:
+			hud_target_next_list(1, 0, iff_get_attacker_mask(Player_ship->team), OBJ_INDEX(Player_obj), TRUE, 0, 1);
+			break;
+
+			// target your target's target
+		case TARGET_TARGETS_TARGET:
+			hud_target_targets_target();
+			break;
+
+			// target ships subsystem in reticle
+		case TARGET_SUBOBJECT_IN_RETICLE:
+			hud_target_subsystem_in_reticle();
+			break;
+
+		case TARGET_PREV_SUBOBJECT:
+			hud_target_prev_subobject();
+			break;
+
+			// target next subsystem on current target
+		case TARGET_NEXT_SUBOBJECT:
+			hud_target_next_subobject();
 			break;
 
 		default:
-			break;  // do nothing
+			keyHasBeenUsed = FALSE;
+			break;
+		};
+		if (keyHasBeenUsed) {
+			return 1;
 		}
-		quit_mission_popup_shown = false;
-
-		game_start_time();
-		game_flush();
-	}
-}
-
-/**
- * Handle pause keypress
- */
-void game_process_pause_key()
-{
-	// special processing for multiplayer
-	if (Game_mode & GM_MULTIPLAYER) {							
-		if(Multi_pause_status){
-			multi_pause_request(0);
-		} else {
-			multi_pause_request(1);
-		}		
 	} else {
-		gameseq_post_event( GS_EVENT_PAUSE_GAME );
-	}
-}
-
-/**
- * Process cheat codes
- */
-void game_process_cheats(int k)
-{
-	size_t i;
-
-	if ( k == 0 ){
-		return;
+		//if sensors are gone, and the passed key is one of the targeting keys, we need to exit here before we hit the Int3() later in this function
+		if (key_is_targeting(n)) {
+			return 1;
+		}
 	}
 
-	// no cheats in multiplayer, ever
-	if(Game_mode & GM_MULTIPLAYER){
-		Cheats_enabled = 0;
-		return;
-	}
+	keyHasBeenUsed = TRUE;
+	switch (n) {
+		// undefined in multiplayer for clients right now
+		// match target speed
+	case MATCH_TARGET_SPEED:
+		// If player is auto-matching, break auto-match speed
+		if (Player->flags & PLAYER_FLAGS_AUTO_MATCH_SPEED) {
+			Player->flags &= ~PLAYER_FLAGS_AUTO_MATCH_SPEED;
+		}
+		player_match_target_speed();
+		break;
 
-	for (i = 0; i < CHEAT_BUFFER_LEN; i++){
-		CheatBuffer[i]=CheatBuffer[i+1];
-	}
+		// toggle auto-targeting
+	case TOGGLE_AUTO_TARGETING:
+		hud_gauge_popup_start(HUD_AUTO_TARGET);
+		Players[Player_num].flags ^= PLAYER_FLAGS_AUTO_TARGETING;
+		if (Players[Player_num].flags & PLAYER_FLAGS_AUTO_TARGETING) {
+			if (hud_sensors_ok(Player_ship)) {
+				hud_target_closest(iff_get_attackee_mask(Player_ship->team), -1, FALSE, TRUE);
+				snd_play(&Snds[SND_SHIELD_XFER_OK], 1.0f);
+				//HUD_sourced_printf(HUD_SOURCE_HIDDEN, XSTR( "Auto targeting activated", -1));
+			} else {
+				Players[Player_num].flags ^= PLAYER_FLAGS_AUTO_TARGETING;
+			}
+		} else {
+			snd_play(&Snds[SND_SHIELD_XFER_OK], 1.0f);
+			//HUD_sourced_printf(HUD_SOURCE_HIDDEN, XSTR( "Auto targeting deactivated", -1));
+		}
+		break;
 
-	CheatBuffer[CHEAT_BUFFER_LEN - 1] = (char)key_to_ascii(k);
-	
-	cheatCode detectedCheatCode = CHEAT_CODE_NONE;
+		// target the closest repair ship
+	case TARGET_CLOSEST_REPAIR_SHIP:
+		// AL: Try to find the closest repair ship coming to repair the player... if no support
+		//		 ships are coming to rearm the player, just try for the closest repair ship
+		if (hud_target_closest_repair_ship(OBJ_INDEX(Player_obj)) == 0) {
+			if (hud_target_closest_repair_ship() == 0) {
+				snd_play(&Snds[SND_TARGET_FAIL]);
+			}
+		}
+		break;
 
-	for(i=0; i < CHEATS_TABLE_LEN; i++) {
-		Cheat cheat = cheatsTable[i];
+		// stop targeting ship
+	case STOP_TARGETING_SHIP:
+		hud_cease_targeting();
+		break;
 
-		if(!strncmp(cheat.data, CheatBuffer, CHEAT_BUFFER_LEN)){
-			detectedCheatCode = cheat.code;
+		// stop targeting subsystems on ship
+	case STOP_TARGETING_SUBSYSTEM:
+		hud_cease_subsystem_targeting();
+		break;
+
+	case TARGET_NEXT_BOMB:
+		hud_target_missile(Player_obj, 1);
+		break;
+
+	case TARGET_PREV_BOMB:
+		hud_target_missile(Player_obj, 0);
+		break;
+
+		// wingman message: attack current target
+	case ATTACK_MESSAGE:
+		hud_squadmsg_shortcut(ATTACK_TARGET_ITEM);
+		break;
+
+		// wingman message: disarm current target
+	case DISARM_MESSAGE:
+		hud_squadmsg_shortcut(DISARM_TARGET_ITEM);
+		break;
+
+		// wingman message: disable current target
+	case DISABLE_MESSAGE:
+		hud_squadmsg_shortcut(DISABLE_TARGET_ITEM);
+		break;
+
+		// wingman message: disable current target
+	case ATTACK_SUBSYSTEM_MESSAGE:
+		hud_squadmsg_shortcut(DISABLE_SUBSYSTEM_ITEM);
+		break;
+
+		// wingman message: capture current target
+	case CAPTURE_MESSAGE:
+		hud_squadmsg_shortcut(CAPTURE_TARGET_ITEM);
+		break;
+
+		// wingman message: engage enemy
+	case ENGAGE_MESSAGE:
+		hud_squadmsg_shortcut(ENGAGE_ENEMY_ITEM);
+		break;
+
+		// wingman message: form on my wing
+	case FORM_MESSAGE:
+		hud_squadmsg_shortcut(FORMATION_ITEM);
+		break;
+
+		// wingman message: protect current target
+	case PROTECT_MESSAGE:
+		hud_squadmsg_shortcut(PROTECT_TARGET_ITEM);
+		break;
+
+		// wingman message: cover me
+	case COVER_MESSAGE:
+		hud_squadmsg_shortcut(COVER_ME_ITEM);
+		break;
+
+		// wingman message: warp out
+	case WARP_MESSAGE:
+		hud_squadmsg_shortcut(DEPART_ITEM);
+		break;
+
+	case IGNORE_MESSAGE:
+		hud_squadmsg_shortcut(IGNORE_TARGET_ITEM);
+		break;
+
+		// rearm message
+	case REARM_MESSAGE:
+		hud_squadmsg_rearm_shortcut();
+		break;
+
+		// cycle to next radar range
+	case RADAR_RANGE_CYCLE:
+		HUD_config.rp_dist++;
+		if (HUD_config.rp_dist >= RR_MAX_RANGES)
+			HUD_config.rp_dist = 0;
+
+		HUD_sourced_printf(HUD_SOURCE_HIDDEN, XSTR("Radar range set to %s", 38), Radar_range_text(HUD_config.rp_dist));
+		break;
+
+		// toggle the squadmate messaging menu
+	case SQUADMSG_MENU:
+		hud_squadmsg_toggle();				// leave the details to the messaging code!!!
+		break;
+
+		// show the mission goals screen
+	case SHOW_GOALS:
+		gameseq_post_event(GS_EVENT_SHOW_GOALS);
+		break;
+
+		// end the mission
+	case END_MISSION:
+		// in multiplayer, all end mission requests should go through the server
+		if (Game_mode & GM_MULTIPLAYER) {
+			multi_handle_end_mission_request();
 			break;
 		}
-	}
 
-	if(detectedCheatCode == CHEAT_CODE_FREESPACE){
-		Cheats_enabled = 1;
+		control_used(END_MISSION);
 
-		// cheating allows the changing of weapons so we have to grab anything
-		// that we don't already have loaded, just in case
-		extern void weapons_page_in_cheats();
-		weapons_page_in_cheats();
-
-		HUD_printf("Cheats enabled");
-	}
-	if(detectedCheatCode == CHEAT_CODE_FISH){
-		// only enable in the Vasudan main hall
-		if ((gameseq_get_state() == GS_STATE_MAIN_MENU) && main_hall_is_vasudan()) {
-			extern void fishtank_start();
-			fishtank_start();
+		if (collide_predict_large_ship(Player_obj, 200.0f)
+			|| (Ship_info[Ships[Player_obj->instance].ship_info_index].warpout_type == WT_HYPERSPACE
+			&& collide_predict_large_ship(Player_obj, 100000.0f))) {
+			gamesnd_play_iface(SND_GENERAL_FAIL);
+			HUD_printf(XSTR("** WARNING ** Collision danger.  Subspace drive not activated.", 39));
+		} else if (!ship_engine_ok_to_warp(Player_ship)) {
+			gamesnd_play_iface(SND_GENERAL_FAIL);
+			HUD_printf(XSTR("Engine failure.  Cannot engage subspace drive.", 40));
+		} else if (!ship_navigation_ok_to_warp(Player_ship)) {
+			gamesnd_play_iface(SND_GENERAL_FAIL);
+			HUD_printf(XSTR("Navigation failure.  Cannot engage subspace drive.", 1572));
+		} else if (Player_obj != NULL && object_get_gliding(Player_obj)) {
+			gamesnd_play_iface(SND_GENERAL_FAIL);
+			HUD_printf(XSTR("Cannot engage subspace drive while gliding.", 1573));
+		} else {
+			gameseq_post_event(GS_EVENT_PLAYER_WARPOUT_START);
 		}
-	}
-	if(detectedCheatCode == CHEAT_CODE_HEADZ){
-		// only enable in the Vasudan main hall
-		if ((gameseq_get_state() == GS_STATE_MAIN_MENU) && main_hall_is_vasudan()) {
-			main_hall_vasudan_funny();
+		break;
+
+	case ADD_REMOVE_ESCORT:
+		if (Player_ai->target_objnum >= 0) {
+			control_used(ADD_REMOVE_ESCORT);
+			hud_add_remove_ship_escort(Player_ai->target_objnum);
 		}
+		break;
+
+	case ESCORT_CLEAR:
+		hud_escort_clear_all(true);
+		break;
+
+	case TARGET_NEXT_ESCORT_SHIP:
+		hud_escort_target_next();
+		break;
+
+	default:
+		keyHasBeenUsed = FALSE;
+		break;
+	};
+	if (keyHasBeenUsed) {
+		return 1;
 	}
-	if(detectedCheatCode ==  CHEAT_CODE_SKIP && (gameseq_get_state() == GS_STATE_MAIN_MENU)){
-		extern void main_hall_campaign_cheat();
-		main_hall_campaign_cheat();
-	}
-	if(detectedCheatCode == CHEAT_CODE_TOOLED && (Game_mode & GM_IN_MISSION)){
-		Tool_enabled = 1;
-		HUD_printf("Prepare to be taken to school");
-	}
-	if(detectedCheatCode == CHEAT_CODE_PIRATE && (Game_mode & GM_IN_MISSION) && (Player_obj != NULL)){
-		extern void prevent_spawning_collision(object *new_obj);
-		ship_subsys *ptr;
-		char name[NAME_LENGTH];
-		int ship_idx, ship_class; 
 
-		// if not found, then don't create it :(
-		ship_class = ship_info_lookup("Volition Bravos");
-		if (ship_class < 0)
-			return;
+	/**
+	* All keys should have been handled above, if not panic
+	*/
+	mprintf(("Unknown key %d at %s:%u\n", n, __FILE__, __LINE__));
+	Int3();
 
-		HUD_printf(NOX("Walk the plank"));
-
-		vec3d pos = Player_obj->pos;
-		matrix orient = Player_obj->orient;
-		pos.xyz.x += frand_range(-700.0f, 700.0f);
-		pos.xyz.y += frand_range(-700.0f, 700.0f);
-		pos.xyz.z += frand_range(-700.0f, 700.0f);
-
-		int objnum = ship_create(&orient, &pos, ship_class);
-		if (objnum < 0)
-			return;
-
-		ship *shipp = &Ships[Objects[objnum].instance];
-		shipp->ship_name[0] = '\0';
-		shipp->orders_accepted = (1<<NUM_COMM_ORDER_ITEMS)-1;
-
-		// Goober5000 - stolen from support ship creation
-		// create a name for the ship.  use "Volition Bravos #".  look for collisions until one isn't found anymore
-		ship_idx = 1;
-		do {
-			sprintf(name, NOX("Volition Bravos %d"), ship_idx);
-			if ( (ship_name_lookup(name) == -1) && (ship_find_exited_ship_by_name(name) == -1) )
-			{
-				strcpy_s(shipp->ship_name, name);
-				break;
-			}
-
-			ship_idx++;
-		} while(1);
-
-		shipp->flags |= SF_ESCORT;
-		shipp->escort_priority = 1000 - ship_idx;
-
-		// now make sure we're not colliding with anyone
-		prevent_spawning_collision(&Objects[objnum]);
-			
-		// Goober5000 - beam free
-		for (ptr = GET_FIRST(&shipp->subsys_list); ptr != END_OF_LIST(&shipp->subsys_list); ptr = GET_NEXT(ptr))
-		{
-			// mark all turrets as beam free
-			if (ptr->system_info->type == SUBSYSTEM_TURRET)
-			{
-				ptr->weapons.flags |= SW_FLAG_BEAM_FREE;
-				ptr->turret_next_fire_stamp = timestamp((int) frand_range(50.0f, 4000.0f));
-			}
-		}
-				
-		// warpin
-		shipfx_warpin_start(&Objects[objnum]);
-	}
+	return 1;
 }
 
-void game_process_keys()
-{
-	int k;
-
-	button_info_clear(&Player->bi);	// clear out the button info struct for the player
-    do
-	{		
-		k = game_poll();
-
-		if ( Game_mode & GM_DEAD_BLEW_UP ) {
-			continue;
-		}
-
-		game_process_cheats( k );
-		process_player_ship_keys(k);
-		process_debug_keys(k);
-		
-		switch (k) {
-			case 0:
-				// No key
-				break;
-			
-			case KEY_ESC:
-				if ( Player->control_mode != PCM_NORMAL )	{
-					if ( Player->control_mode == PCM_WARPOUT_STAGE1 )	{
-						gameseq_post_event( GS_EVENT_PLAYER_WARPOUT_STOP );
-					} else {
-						// too late to abort warp out!
-					}
-				} else {
-					// let the ESC key break out of messaging mode
-					if ( Players[Player_num].flags & PLAYER_FLAGS_MSG_MODE ) {
-						hud_squadmsg_toggle();
-						break;
-					}
-
-					//If topdown view in non-2D mission, go back to cockpit view.
-					if ( (Viewer_mode & VM_TOPDOWN) && !(The_mission.flags & MISSION_FLAG_2D_MISSION) && !(Perspective_locked) ) {
-						Viewer_mode &= ~VM_TOPDOWN;
-						break;
-					}
-
-					// if in external view or chase view, go back to cockpit view
-					if ( (Viewer_mode & (VM_EXTERNAL|VM_CHASE|VM_OTHER_SHIP)) && !(Perspective_locked) ) {
-						Viewer_mode &= ~(VM_EXTERNAL|VM_CHASE|VM_OTHER_SHIP);
-						break;
-					}
-
-					if (!(Game_mode & GM_DEAD_DIED))
-						game_do_end_mission_popup();
-
-				}
-				break;
-
-			case KEY_Y:								
-				break;
-
-			case KEY_N:
-				break;
-
-			case KEY_DEBUGGED | KEY_PAUSE:
-				gameseq_post_event( GS_EVENT_DEBUG_PAUSE_GAME );
-				break;
-
-			case KEY_ALTED + KEY_PAUSE:
-				if( Game_mode & GM_DEAD_BLEW_UP || 
-					Game_mode & GM_DEAD_DIED) {
-					break;
-				}
-
-				pause_set_type(PAUSE_TYPE_VIEWER);
-				game_process_pause_key();
-				break;
-			case KEY_PAUSE:
-				if( Game_mode & GM_DEAD_BLEW_UP || 
-					Game_mode & GM_DEAD_DIED) {
-					break;
-				}
-
-				pause_set_type(PAUSE_TYPE_NORMAL);
-				game_process_pause_key();
-				break;
-
-		} // end switch
-	}
-	while (k);
-
-	// lua button command override goes here!!
-	if (lua_game_control & LGC_B_OVERRIDE) {
-		button_info temp = Player->bi;
-		Player->bi = Player->lua_bi;
-		Player->lua_bi = temp;
-	} else if (lua_game_control & LGC_B_ADDITIVE) {
-		// add the lua commands to current commands 
-		int i;
-		for (i=0; i<NUM_BUTTON_FIELDS; i++)
-			Player->bi.status[i] |= Player->lua_bi.status[i];
-		Player->lua_bi = Player->bi;		
-	} else {
-		// just copy over the values
-		Player->lua_bi = Player->bi;
-	}
-	// there.. wasnt that bad hack was it?
-
-	button_info_do(&Player->bi);	// call functions based on status of button_info bit vectors
-}
-
-int button_function_critical(int n, net_player *p = NULL)
-{
+int button_function_critical(int n, net_player *p) {
 	object *objp;
 	player *pl;
 	net_player *npl;
 	int at_self;    // flag indicating the object is local (for hud messages, etc)
 
 	Assert(n >= 0);
-   
+
 	// multiplayer clients should leave critical button bits alone and pass them to the server instead
 	if (MULTIPLAYER_CLIENT) {
 		// if this flag is set, we should apply the button itself (came from the server)
-		if (!Multi_button_info_ok){
+		if (!Multi_button_info_ok) {
 			return 0;
 		}
 	}
@@ -1740,11 +1256,11 @@ int button_function_critical(int n, net_player *p = NULL)
 		objp = Player_obj;
 		pl = Player;
 
-		if(Game_mode & GM_MULTIPLAYER){
+		if (Game_mode & GM_MULTIPLAYER) {
 			npl = Net_player;
 
 			// if we're the server in multiplayer and we're an observer, don't process our own critical button functions
-			if((Net_player->flags & NETINFO_FLAG_AM_MASTER) && (Net_player->flags & NETINFO_FLAG_OBSERVER)){
+			if ((Net_player->flags & NETINFO_FLAG_AM_MASTER) && (Net_player->flags & NETINFO_FLAG_OBSERVER)) {
 				return 0;
 			}
 		}
@@ -1756,327 +1272,318 @@ int button_function_critical(int n, net_player *p = NULL)
 		npl = p;
 		at_self = 0;
 
-		if ( NETPLAYER_IS_DEAD(npl) || (Ships[Objects[pl->objnum].instance].flags & SF_DYING) )
+		if (NETPLAYER_IS_DEAD(npl) || (Ships[Objects[pl->objnum].instance].flags & SF_DYING))
 			return 0;
 	}
-	
+
 	switch (n) {
 		// cycle num primaries to fire at once
-		case CYCLE_PRIMARY_WEAPON_SEQUENCE:
-			{
-				int count;
-				ship * shipp = &Ships[objp->instance];
-				ship_weapon *swp = &shipp->weapons;
-				ship_info *sip = &Ship_info[shipp->ship_info_index];
-				if (sip->flags2 & SIF2_DYN_PRIMARY_LINKING) {
-					polymodel *pm = model_get( sip->model_num );
-					count = ftables.getNext( pm->gun_banks[ swp->current_primary_bank ].num_slots, swp->primary_bank_slot_count[ swp->current_primary_bank ] );
-					swp->primary_bank_slot_count[ swp->current_primary_bank ] = count;
-					shipp->last_fired_point[ swp->current_primary_bank ] += count - ( shipp->last_fired_point[ swp->current_primary_bank ] % count);
-					shipp->last_fired_point[ swp->current_primary_bank ] -= 1;
-					shipp->last_fired_point[ swp->current_primary_bank ] %= swp->primary_bank_slot_count[ swp->current_primary_bank ];
-				}
-			}
-			break;
+	case CYCLE_PRIMARY_WEAPON_SEQUENCE:
+	{
+		int count;
+		ship * shipp = &Ships[objp->instance];
+		ship_weapon *swp = &shipp->weapons;
+		ship_info *sip = &Ship_info[shipp->ship_info_index];
+		if (sip->flags2 & SIF2_DYN_PRIMARY_LINKING) {
+			polymodel *pm = model_get(sip->model_num);
+			count = ftables.getNext(pm->gun_banks[swp->current_primary_bank].num_slots, swp->primary_bank_slot_count[swp->current_primary_bank]);
+			swp->primary_bank_slot_count[swp->current_primary_bank] = count;
+			shipp->last_fired_point[swp->current_primary_bank] += count - (shipp->last_fired_point[swp->current_primary_bank] % count);
+			shipp->last_fired_point[swp->current_primary_bank] -= 1;
+			shipp->last_fired_point[swp->current_primary_bank] %= swp->primary_bank_slot_count[swp->current_primary_bank];
+		}
+	}
+	break;
 
-		// cycle to next primary weapon
-		case CYCLE_NEXT_PRIMARY:
-			if (at_self) {
-				control_used(CYCLE_NEXT_PRIMARY);
-			}
-
-			hud_gauge_popup_start(HUD_WEAPONS_GAUGE);
-			if (ship_select_next_primary(objp, CYCLE_PRIMARY_NEXT)) {
-				ship* shipp = &Ships[objp->instance];
-				if ( timestamp_elapsed(shipp->weapons.next_primary_fire_stamp[shipp->weapons.current_primary_bank]) ) {
-					shipp->weapons.next_primary_fire_stamp[shipp->weapons.current_primary_bank] = timestamp(250);	//	1/4 second delay until can fire
-				}
-
-				// multiplayer server should maintain bank/link status here
-				if ( MULTIPLAYER_MASTER ) {
-					Assert(npl != NULL);
-					multi_server_update_player_weapons(npl,shipp);										
-				}
-			}			
-			break;
-
-		// cycle to previous primary weapon
-		case CYCLE_PREV_PRIMARY:
-			if (at_self) {
-				control_used(CYCLE_PREV_PRIMARY);
-			}
-
-			hud_gauge_popup_start(HUD_WEAPONS_GAUGE);
-			if (ship_select_next_primary(objp, CYCLE_PRIMARY_PREV)) {
-				ship* shipp = &Ships[objp->instance];
-				if ( timestamp_elapsed(shipp->weapons.next_primary_fire_stamp[shipp->weapons.current_primary_bank]) ) {
-					shipp->weapons.next_primary_fire_stamp[shipp->weapons.current_primary_bank] = timestamp(250);	//	1/4 second delay until can fire
-				}
-
-				// multiplayer server should maintain bank/link status here
-				if ( MULTIPLAYER_MASTER ) {
-					Assert(npl != NULL);
-					multi_server_update_player_weapons(npl,shipp);										
-				}
-			}			
-			break;
-
-		// cycle to next secondary weapon
-		case CYCLE_SECONDARY:
-			if(at_self)
-				control_used(CYCLE_SECONDARY);
-			
-			hud_gauge_popup_start(HUD_WEAPONS_GAUGE);
-			if (ship_select_next_secondary(objp)) {
-				ship* shipp = &Ships[objp->instance];
-				if ( timestamp_elapsed(shipp->weapons.next_secondary_fire_stamp[shipp->weapons.current_secondary_bank]) ) {
-					shipp->weapons.next_secondary_fire_stamp[shipp->weapons.current_secondary_bank] = timestamp(250);	//	1/4 second delay until can fire
-				}
-
-				// multiplayer server should maintain bank/link status here
-				if( MULTIPLAYER_MASTER ){
-					Assert(npl != NULL);
-					multi_server_update_player_weapons(npl,shipp);										
-				}					
-			}			
-			break;
-
-		// cycle number of missiles
-		case CYCLE_NUM_MISSLES: {
-			if(at_self)
-				control_used(CYCLE_NUM_MISSLES);
-
-			if ( objp == Player_obj ) {
-				if ( Player_ship->weapons.num_secondary_banks <= 0 ) {
-					HUD_sourced_printf(HUD_SOURCE_HIDDEN, XSTR( "This ship has no secondary weapons", 33));
-					gamesnd_play_iface(SND_GENERAL_FAIL);
-					break;
-				}
-			}
-
-			polymodel *pm = model_get(Ship_info[Ships[objp->instance].ship_info_index].model_num);
-
-			int firepoints = pm->missile_banks[Ships[objp->instance].weapons.current_secondary_bank].num_slots;
-
-			if ( Ships[objp->instance].flags & SF_SECONDARY_DUAL_FIRE || firepoints < 2) {		
-				Ships[objp->instance].flags &= ~SF_SECONDARY_DUAL_FIRE;
-				if(at_self) {
-					HUD_sourced_printf(HUD_SOURCE_HIDDEN, XSTR( "Secondary weapon set to normal fire mode", 34));
-					snd_play( &Snds[ship_get_sound(Player_obj, SND_SECONDARY_CYCLE)] );
-					hud_gauge_popup_start(HUD_WEAPONS_GAUGE);
-				}
-			} else {
-				Ships[objp->instance].flags |= SF_SECONDARY_DUAL_FIRE;
-				if(at_self) {
-					HUD_sourced_printf(HUD_SOURCE_HIDDEN, XSTR( "Secondary weapon set to dual fire mode", 35));
-					snd_play( &Snds[ship_get_sound(Player_obj, SND_SECONDARY_CYCLE)] );
-					hud_gauge_popup_start(HUD_WEAPONS_GAUGE);
-				}
-			}
-
-			// multiplayer server should maintain bank/link status here
-			if( MULTIPLAYER_MASTER ){
-				Assert(npl != NULL);
-				multi_server_update_player_weapons(npl,&Ships[objp->instance]);										
-			}
-			break;
+	// cycle to next primary weapon
+	case CYCLE_NEXT_PRIMARY:
+		if (at_self) {
+			control_used(CYCLE_NEXT_PRIMARY);
 		}
 
-		// increase weapon recharge rate
-		case INCREASE_WEAPON:
-			if(at_self)
-				control_used(INCREASE_WEAPON);
-			increase_recharge_rate(objp, WEAPONS);
+		hud_gauge_popup_start(HUD_WEAPONS_GAUGE);
+		if (ship_select_next_primary(objp, CYCLE_PRIMARY_NEXT)) {
+			ship* shipp = &Ships[objp->instance];
+			if (timestamp_elapsed(shipp->weapons.next_primary_fire_stamp[shipp->weapons.current_primary_bank])) {
+				shipp->weapons.next_primary_fire_stamp[shipp->weapons.current_primary_bank] = timestamp(250);	//	1/4 second delay until can fire
+			}
 
 			// multiplayer server should maintain bank/link status here
-			if( MULTIPLAYER_MASTER ){
+			if (MULTIPLAYER_MASTER) {
 				Assert(npl != NULL);
-				multi_server_update_player_weapons(npl,&Ships[objp->instance]);										
+				multi_server_update_player_weapons(npl, shipp);
 			}
-			break;
+		}
+		break;
+
+		// cycle to previous primary weapon
+	case CYCLE_PREV_PRIMARY:
+		if (at_self) {
+			control_used(CYCLE_PREV_PRIMARY);
+		}
+
+		hud_gauge_popup_start(HUD_WEAPONS_GAUGE);
+		if (ship_select_next_primary(objp, CYCLE_PRIMARY_PREV)) {
+			ship* shipp = &Ships[objp->instance];
+			if (timestamp_elapsed(shipp->weapons.next_primary_fire_stamp[shipp->weapons.current_primary_bank])) {
+				shipp->weapons.next_primary_fire_stamp[shipp->weapons.current_primary_bank] = timestamp(250);	//	1/4 second delay until can fire
+			}
+
+			// multiplayer server should maintain bank/link status here
+			if (MULTIPLAYER_MASTER) {
+				Assert(npl != NULL);
+				multi_server_update_player_weapons(npl, shipp);
+			}
+		}
+		break;
+
+		// cycle to next secondary weapon
+	case CYCLE_SECONDARY:
+		if (at_self)
+			control_used(CYCLE_SECONDARY);
+
+		hud_gauge_popup_start(HUD_WEAPONS_GAUGE);
+		if (ship_select_next_secondary(objp)) {
+			ship* shipp = &Ships[objp->instance];
+			if (timestamp_elapsed(shipp->weapons.next_secondary_fire_stamp[shipp->weapons.current_secondary_bank])) {
+				shipp->weapons.next_secondary_fire_stamp[shipp->weapons.current_secondary_bank] = timestamp(250);	//	1/4 second delay until can fire
+			}
+
+			// multiplayer server should maintain bank/link status here
+			if (MULTIPLAYER_MASTER) {
+				Assert(npl != NULL);
+				multi_server_update_player_weapons(npl, shipp);
+			}
+		}
+		break;
+
+		// cycle number of missiles
+	case CYCLE_NUM_MISSLES: {
+		if (at_self)
+			control_used(CYCLE_NUM_MISSLES);
+
+		if (objp == Player_obj) {
+			if (Player_ship->weapons.num_secondary_banks <= 0) {
+				HUD_sourced_printf(HUD_SOURCE_HIDDEN, XSTR("This ship has no secondary weapons", 33));
+				gamesnd_play_iface(SND_GENERAL_FAIL);
+				break;
+			}
+		}
+
+		polymodel *pm = model_get(Ship_info[Ships[objp->instance].ship_info_index].model_num);
+
+		int firepoints = pm->missile_banks[Ships[objp->instance].weapons.current_secondary_bank].num_slots;
+
+		if (Ships[objp->instance].flags & SF_SECONDARY_DUAL_FIRE || firepoints < 2) {
+			Ships[objp->instance].flags &= ~SF_SECONDARY_DUAL_FIRE;
+			if (at_self) {
+				HUD_sourced_printf(HUD_SOURCE_HIDDEN, XSTR("Secondary weapon set to normal fire mode", 34));
+				snd_play(&Snds[ship_get_sound(Player_obj, SND_SECONDARY_CYCLE)]);
+				hud_gauge_popup_start(HUD_WEAPONS_GAUGE);
+			}
+		} else {
+			Ships[objp->instance].flags |= SF_SECONDARY_DUAL_FIRE;
+			if (at_self) {
+				HUD_sourced_printf(HUD_SOURCE_HIDDEN, XSTR("Secondary weapon set to dual fire mode", 35));
+				snd_play(&Snds[ship_get_sound(Player_obj, SND_SECONDARY_CYCLE)]);
+				hud_gauge_popup_start(HUD_WEAPONS_GAUGE);
+			}
+		}
+
+		// multiplayer server should maintain bank/link status here
+		if (MULTIPLAYER_MASTER) {
+			Assert(npl != NULL);
+			multi_server_update_player_weapons(npl, &Ships[objp->instance]);
+		}
+		break;
+	}
+
+							// increase weapon recharge rate
+	case INCREASE_WEAPON:
+		if (at_self)
+			control_used(INCREASE_WEAPON);
+		increase_recharge_rate(objp, WEAPONS);
+
+		// multiplayer server should maintain bank/link status here
+		if (MULTIPLAYER_MASTER) {
+			Assert(npl != NULL);
+			multi_server_update_player_weapons(npl, &Ships[objp->instance]);
+		}
+		break;
 
 		// decrease weapon recharge rate
-		case DECREASE_WEAPON:
-			if(at_self)
-				control_used(DECREASE_WEAPON);
-			decrease_recharge_rate(objp, WEAPONS);
+	case DECREASE_WEAPON:
+		if (at_self)
+			control_used(DECREASE_WEAPON);
+		decrease_recharge_rate(objp, WEAPONS);
 
-			// multiplayer server should maintain bank/link status here
-			if( MULTIPLAYER_MASTER ){
-				Assert(npl != NULL);
-				multi_server_update_player_weapons(npl,&Ships[objp->instance]);										
-			}
-			break;
+		// multiplayer server should maintain bank/link status here
+		if (MULTIPLAYER_MASTER) {
+			Assert(npl != NULL);
+			multi_server_update_player_weapons(npl, &Ships[objp->instance]);
+		}
+		break;
 
 		// increase shield recharge rate
-		case INCREASE_SHIELD:
-			if(at_self)
-				control_used(INCREASE_SHIELD);
-			increase_recharge_rate(objp, SHIELDS);
+	case INCREASE_SHIELD:
+		if (at_self)
+			control_used(INCREASE_SHIELD);
+		increase_recharge_rate(objp, SHIELDS);
 
-			// multiplayer server should maintain bank/link status here
-			if( MULTIPLAYER_MASTER ){
-				Assert(npl != NULL);
-				multi_server_update_player_weapons(npl,&Ships[objp->instance]);										
-			}
-			break;
+		// multiplayer server should maintain bank/link status here
+		if (MULTIPLAYER_MASTER) {
+			Assert(npl != NULL);
+			multi_server_update_player_weapons(npl, &Ships[objp->instance]);
+		}
+		break;
 
 		// decrease shield recharge rate
-		case DECREASE_SHIELD:
-			if(at_self)
-				control_used(DECREASE_SHIELD);
-			decrease_recharge_rate(objp, SHIELDS);
+	case DECREASE_SHIELD:
+		if (at_self)
+			control_used(DECREASE_SHIELD);
+		decrease_recharge_rate(objp, SHIELDS);
 
-			// multiplayer server should maintain bank/link status here
-			if( MULTIPLAYER_MASTER ){
-				Assert(npl != NULL);
-				multi_server_update_player_weapons(npl,&Ships[objp->instance]);										
-			}
-			break;
+		// multiplayer server should maintain bank/link status here
+		if (MULTIPLAYER_MASTER) {
+			Assert(npl != NULL);
+			multi_server_update_player_weapons(npl, &Ships[objp->instance]);
+		}
+		break;
 
 		// increase energy to engines
-		case INCREASE_ENGINE:
-			if(at_self)
-				control_used(INCREASE_ENGINE);
-			increase_recharge_rate(objp, ENGINES);
+	case INCREASE_ENGINE:
+		if (at_self)
+			control_used(INCREASE_ENGINE);
+		increase_recharge_rate(objp, ENGINES);
 
-			// multiplayer server should maintain bank/link status here
-			if( MULTIPLAYER_MASTER ){
-				Assert(npl != NULL);
-				multi_server_update_player_weapons(npl,&Ships[objp->instance]);										
-			}
-			break;
+		// multiplayer server should maintain bank/link status here
+		if (MULTIPLAYER_MASTER) {
+			Assert(npl != NULL);
+			multi_server_update_player_weapons(npl, &Ships[objp->instance]);
+		}
+		break;
 
 		// decrease energy to engines
-		case DECREASE_ENGINE:
-			if(at_self)
-   			control_used(DECREASE_ENGINE);
-			decrease_recharge_rate(objp, ENGINES);
+	case DECREASE_ENGINE:
+		if (at_self)
+			control_used(DECREASE_ENGINE);
+		decrease_recharge_rate(objp, ENGINES);
 
-			// multiplayer server should maintain bank/link status here
-			if( MULTIPLAYER_MASTER ){
-				Assert(npl != NULL);
-				multi_server_update_player_weapons(npl,&Ships[objp->instance]);										
-			}
-			break;
+		// multiplayer server should maintain bank/link status here
+		if (MULTIPLAYER_MASTER) {
+			Assert(npl != NULL);
+			multi_server_update_player_weapons(npl, &Ships[objp->instance]);
+		}
+		break;
 
 		// equalize recharge rates
-		case ETS_EQUALIZE:
-			if (at_self) {
-   			control_used(ETS_EQUALIZE);
-			}
+	case ETS_EQUALIZE:
+		if (at_self) {
+			control_used(ETS_EQUALIZE);
+		}
 
-			set_default_recharge_rates(objp);
-			snd_play( &Snds[SND_ENERGY_TRANS] );
+		set_default_recharge_rates(objp);
+		snd_play(&Snds[SND_ENERGY_TRANS]);
 
-			// multiplayer server should maintain bank/link status here
-			if( MULTIPLAYER_MASTER ){
-				Assert(npl != NULL);
-				multi_server_update_player_weapons(npl,&Ships[objp->instance]);										
-			}
-			break;
+		// multiplayer server should maintain bank/link status here
+		if (MULTIPLAYER_MASTER) {
+			Assert(npl != NULL);
+			multi_server_update_player_weapons(npl, &Ships[objp->instance]);
+		}
+		break;
 
 		// equalize shield energy to all quadrants
-		case SHIELD_EQUALIZE:
-			if(at_self){
-				control_used(SHIELD_EQUALIZE);
-			}
-			hud_shield_equalize(objp, pl);
-			break;
+	case SHIELD_EQUALIZE:
+		if (at_self) {
+			control_used(SHIELD_EQUALIZE);
+		}
+		hud_shield_equalize(objp, pl);
+		break;
 
 		// transfer shield energy to front
-		case SHIELD_XFER_TOP:
-			if(at_self){
-   			control_used(SHIELD_XFER_TOP);
-			}
-			hud_augment_shield_quadrant(objp, FRONT_QUAD);
-			break;
+	case SHIELD_XFER_TOP:
+		if (at_self) {
+			control_used(SHIELD_XFER_TOP);
+		}
+		hud_augment_shield_quadrant(objp, FRONT_QUAD);
+		break;
 
 		// transfer shield energy to rear
-		case SHIELD_XFER_BOTTOM:
-			if(at_self)
-				control_used(SHIELD_XFER_BOTTOM);
-			hud_augment_shield_quadrant(objp, REAR_QUAD);
-			break;
+	case SHIELD_XFER_BOTTOM:
+		if (at_self)
+			control_used(SHIELD_XFER_BOTTOM);
+		hud_augment_shield_quadrant(objp, REAR_QUAD);
+		break;
 
 		// transfer shield energy to left
-		case SHIELD_XFER_LEFT:
-			if(at_self)
-				control_used(SHIELD_XFER_LEFT);
-			hud_augment_shield_quadrant(objp, LEFT_QUAD);
-			break;
-			
+	case SHIELD_XFER_LEFT:
+		if (at_self)
+			control_used(SHIELD_XFER_LEFT);
+		hud_augment_shield_quadrant(objp, LEFT_QUAD);
+		break;
+
 		// transfer shield energy to right
-		case SHIELD_XFER_RIGHT:
-			if(at_self)
-				control_used(SHIELD_XFER_RIGHT);
-			hud_augment_shield_quadrant(objp, RIGHT_QUAD);
-			break;
+	case SHIELD_XFER_RIGHT:
+		if (at_self)
+			control_used(SHIELD_XFER_RIGHT);
+		hud_augment_shield_quadrant(objp, RIGHT_QUAD);
+		break;
 
 		// transfer energy to shield from weapons
-		case XFER_SHIELD:
-			if(at_self)
-				control_used(XFER_SHIELD);
-			transfer_energy_to_shields(objp);
-			break;
+	case XFER_SHIELD:
+		if (at_self)
+			control_used(XFER_SHIELD);
+		transfer_energy_to_shields(objp);
+		break;
 
 		// transfer energy to weapons from shield
-		case XFER_LASER:
-			if(at_self)
-				control_used(XFER_LASER);
-			transfer_energy_to_weapons(objp);
-			break;
+	case XFER_LASER:
+		if (at_self)
+			control_used(XFER_LASER);
+		transfer_energy_to_weapons(objp);
+		break;
 
 		// following are not handled here, but we need to bypass the Int3()
-		case LAUNCH_COUNTERMEASURE:
-		case VIEW_SLEW:
-		case VIEW_EXTERNAL:
-		case VIEW_EXTERNAL_TOGGLE_CAMERA_LOCK:
-		case VIEW_TRACK_TARGET:
-		case ONE_THIRD_THROTTLE:
-		case TWO_THIRDS_THROTTLE:
-		case MINUS_5_PERCENT_THROTTLE:
-		case PLUS_5_PERCENT_THROTTLE:
-		case ZERO_THROTTLE:
-		case MAX_THROTTLE:
-		case TOGGLE_GLIDING:
-			return 0;
+	case LAUNCH_COUNTERMEASURE:
+	case VIEW_SLEW:
+	case VIEW_EXTERNAL:
+	case VIEW_EXTERNAL_TOGGLE_CAMERA_LOCK:
+	case VIEW_TRACK_TARGET:
+	case ONE_THIRD_THROTTLE:
+	case TWO_THIRDS_THROTTLE:
+	case MINUS_5_PERCENT_THROTTLE:
+	case PLUS_5_PERCENT_THROTTLE:
+	case ZERO_THROTTLE:
+	case MAX_THROTTLE:
+	case TOGGLE_GLIDING:
+		return 0;
 
-		default :
-			Int3(); // bad bad bad
-			break;
+	default:
+		Int3(); // bad bad bad
+		break;
 	}
 
 	return 1;
 }
 
-/**
- * Execute function corresponding to action n
- * Basically, these are actions which don't affect demo playback at all
- * @param n Action number
- */
-int button_function_demo_valid(int n)
-{
+int button_function_demo_valid(int n) {
 	// by default, we'll return "not processed". ret will get set to 1, if this is one of the keys which is always allowed, even in demo
 	// playback.
 	int ret = 0;
 
 	//	No keys, not even targeting keys, when player in death roll.  He can press keys after he blows up.
-	if (Game_mode & GM_DEAD_DIED){
+	if (Game_mode & GM_DEAD_DIED) {
 		return 0;
 	}
 
 	// any of these buttons are valid
-	switch(n){
+	switch (n) {
 	case VIEW_CHASE:
 		control_used(VIEW_CHASE);
-		if(!Perspective_locked)
-		{
+		if (!Perspective_locked) {
 			Viewer_mode ^= VM_CHASE;
-		}
-		else
-		{
-			snd_play( &Snds[SND_TARGET_FAIL] );
+		} else {
+			snd_play(&Snds[SND_TARGET_FAIL]);
 		}
 		ret = 1;
 		break;
@@ -2084,52 +1591,46 @@ int button_function_demo_valid(int n)
 	case VIEW_TRACK_TARGET: // Target padlock mode toggle (Swifty)
 		control_used(VIEW_TRACK_TARGET);
 		if (!Perspective_locked) {
-			if(Viewer_mode & VM_TRACK) {
+			if (Viewer_mode & VM_TRACK) {
 				chase_slew_angles.h = 0;
 				chase_slew_angles.p = 0;
 			}
 			Viewer_mode ^= VM_TRACK;
 		} else {
-			snd_play( &Snds[SND_TARGET_FAIL] );
+			snd_play(&Snds[SND_TARGET_FAIL]);
 		}
 		ret = 1;
 		break;
 
 	case VIEW_EXTERNAL:
 		control_used(VIEW_EXTERNAL);
-		if(!Perspective_locked)
-		{
+		if (!Perspective_locked) {
 			Viewer_mode ^= VM_EXTERNAL;
 			Viewer_mode &= ~VM_EXTERNAL_CAMERA_LOCKED;	// reset camera lock when leaving/entering external view
-		}
-		else
-		{
-			snd_play( &Snds[SND_TARGET_FAIL] );
+		} else {
+			snd_play(&Snds[SND_TARGET_FAIL]);
 		}
 		ret = 1;
 		break;
 
 	case VIEW_TOPDOWN:
 		control_used(VIEW_TOPDOWN);
-		if(!Perspective_locked)
-		{
+		if (!Perspective_locked) {
 			Viewer_mode ^= VM_TOPDOWN;
-		}
-		else
-		{
-			snd_play( &Snds[SND_TARGET_FAIL] );
+		} else {
+			snd_play(&Snds[SND_TARGET_FAIL]);
 		}
 		ret = 1;
 		break;
 
 	case VIEW_EXTERNAL_TOGGLE_CAMERA_LOCK:
 		control_used(VIEW_EXTERNAL_TOGGLE_CAMERA_LOCK);
-		if ( Viewer_mode & VM_EXTERNAL ) {
-		Viewer_mode ^= VM_EXTERNAL_CAMERA_LOCKED;
-		if ( Viewer_mode & VM_EXTERNAL_CAMERA_LOCKED ) {
-			HUD_sourced_printf(HUD_SOURCE_HIDDEN, XSTR( "External camera is locked, controls will move ship", 36));
+		if (Viewer_mode & VM_EXTERNAL) {
+			Viewer_mode ^= VM_EXTERNAL_CAMERA_LOCKED;
+			if (Viewer_mode & VM_EXTERNAL_CAMERA_LOCKED) {
+				HUD_sourced_printf(HUD_SOURCE_HIDDEN, XSTR("External camera is locked, controls will move ship", 36));
 			} else {
-				HUD_sourced_printf(HUD_SOURCE_HIDDEN, XSTR( "External camera is free, controls will move the camera, not the ship", 37));
+				HUD_sourced_printf(HUD_SOURCE_HIDDEN, XSTR("External camera is free, controls will move the camera, not the ship", 37));
 			}
 		}
 		ret = 1;
@@ -2137,11 +1638,11 @@ int button_function_demo_valid(int n)
 
 	case VIEW_OTHER_SHIP:
 		control_used(VIEW_OTHER_SHIP);
-		if ( Player_ai->target_objnum < 0 || Perspective_locked) {
-			snd_play( &Snds[SND_TARGET_FAIL] );
+		if (Player_ai->target_objnum < 0 || Perspective_locked) {
+			snd_play(&Snds[SND_TARGET_FAIL]);
 		} else {
-			if ( Objects[Player_ai->target_objnum].type != OBJ_SHIP )  {
-				snd_play( &Snds[SND_TARGET_FAIL] );
+			if (Objects[Player_ai->target_objnum].type != OBJ_SHIP) {
+				snd_play(&Snds[SND_TARGET_FAIL]);
 			} else {
 				Viewer_mode ^= VM_OTHER_SHIP;
 			}
@@ -2150,10 +1651,10 @@ int button_function_demo_valid(int n)
 		break;
 
 	case TIME_SLOW_DOWN:
-		if ( Game_mode & GM_NORMAL ) {
+		if (Game_mode & GM_NORMAL) {
 			// Goober5000 - time dilation only available in cheat mode (see above);
 			// now you can do it with or without pressing the tilde, per Kazan's request
-			if ( ((Game_time_compression > F1_0) || (Cheats_enabled && (Game_time_compression > (F1_0/MAX_TIME_DIVIDER)))) && !Time_compression_locked) {
+			if (((Game_time_compression > F1_0) || (Cheats_enabled && (Game_time_compression > (F1_0 / MAX_TIME_DIVIDER)))) && !Time_compression_locked) {
 				change_time_compression(0.5f);
 			} else {
 				gamesnd_play_error_beep();
@@ -2165,8 +1666,8 @@ int button_function_demo_valid(int n)
 		break;
 
 	case TIME_SPEED_UP:
-		if ( Game_mode & GM_NORMAL ) {
-			if ( (Game_time_compression < (F1_0*MAX_TIME_MULTIPLIER)) && !Time_compression_locked ) {
+		if (Game_mode & GM_NORMAL) {
+			if ((Game_time_compression < (F1_0*MAX_TIME_MULTIPLIER)) && !Time_compression_locked) {
 				change_time_compression(2.0f);
 			} else {
 				gamesnd_play_error_beep();
@@ -2182,652 +1683,14 @@ int button_function_demo_valid(int n)
 	return ret;
 }
 
-bool key_is_targeting(int n) 
-{
-	switch(n) {
-		case TARGET_NEXT:
-		case TARGET_PREV:
-		case TARGET_NEXT_CLOSEST_HOSTILE:
-		case TARGET_PREV_CLOSEST_HOSTILE:
-		case TARGET_NEXT_CLOSEST_FRIENDLY:
-		case TARGET_PREV_CLOSEST_FRIENDLY:
-		case TARGET_SHIP_IN_RETICLE:
-		case TARGET_LAST_TRANMISSION_SENDER:
-		case TARGET_CLOSEST_SHIP_ATTACKING_TARGET:
-		case TARGET_CLOSEST_SHIP_ATTACKING_SELF:
-		case TARGET_TARGETS_TARGET:
-		case TARGET_SUBOBJECT_IN_RETICLE:
-		case TARGET_PREV_SUBOBJECT:
-		case TARGET_NEXT_SUBOBJECT:
-			return true;
+void button_info_clear(button_info *bi) {
+	int i;
 
-		default:
-			return false;
+	for (i = 0; i<NUM_BUTTON_FIELDS; i++) {
+		bi->status[i] = 0;
 	}
 }
 
-/**
- * Execute function corresponding to action n (BUTTON_ from KeyControl.h)
- * @return 1 when action was taken
- */
-int button_function(int n)
-{
-	Assert(n >= 0);
-
-	if (Control_config[n].disabled)
-		return 0;
-
-	// check if the button has been set to be ignored by a SEXP
-	if (Ignored_keys[n]) {
-		if (Ignored_keys[n] > 0) {
-			Ignored_keys[n]--;
-		}
-		return 0;
-	}
-
-	//	No keys, not even targeting keys, when player in death roll.  He can press keys after he blows up.
-	if (Game_mode & GM_DEAD_DIED){
-		return 0;
-	}
-
-	// Goober5000 - if the ship doesn't have subspace drive, jump key doesn't work: so test and exit early
-	if (Player_ship->flags2 & SF2_NO_SUBSPACE_DRIVE)
-	{
-		switch(n)
-		{
-			case END_MISSION:
-				control_used(n);	// set the timestamp for when we used the control, in case we need it
-				return 1;			// pretend we took the action: if we return 0, strange stuff may happen
-		}
-	}
-
-	// Goober5000 - if we have primitive sensors, some keys don't work: so test and exit early
-	if (Player_ship->flags2 & SF2_PRIMITIVE_SENSORS)
-	{
-		switch (n)
-		{
-			case MATCH_TARGET_SPEED:
-			case TOGGLE_AUTO_MATCH_TARGET_SPEED:
-			case TOGGLE_AUTO_TARGETING:
-			case TARGET_NEXT:
-			case TARGET_PREV:
-			case TARGET_NEXT_CLOSEST_HOSTILE:
-			case TARGET_PREV_CLOSEST_HOSTILE:
-			case TARGET_NEXT_CLOSEST_FRIENDLY:
-			case TARGET_PREV_CLOSEST_FRIENDLY:
-			case TARGET_SHIP_IN_RETICLE:
-			case TARGET_LAST_TRANMISSION_SENDER:
-			case TARGET_CLOSEST_REPAIR_SHIP:
-			case TARGET_CLOSEST_SHIP_ATTACKING_TARGET:
-			case STOP_TARGETING_SHIP:
-			case TARGET_CLOSEST_SHIP_ATTACKING_SELF:
-			case TARGET_TARGETS_TARGET:
-			case TARGET_SUBOBJECT_IN_RETICLE:
-			case TARGET_NEXT_SUBOBJECT:
-			case TARGET_PREV_SUBOBJECT:
-			case STOP_TARGETING_SUBSYSTEM:
-			case TARGET_NEXT_BOMB:
-			case TARGET_PREV_BOMB:
-			case TARGET_NEXT_UNINSPECTED_CARGO:
-			case TARGET_PREV_UNINSPECTED_CARGO:
-			case TARGET_NEWEST_SHIP:
-			case TARGET_NEXT_LIVE_TURRET:
-			case TARGET_PREV_LIVE_TURRET:
-			case TARGET_NEXT_ESCORT_SHIP:
-				control_used(n);	// set the timestamp for when we used the control, in case we need it
-				return 1;			// pretend we took the action: if we return 0, strange stuff may happen
-		}
-	}
-
-	switch(n) {
-		// following are not handled here, but we need to bypass the Int3()
-		case LAUNCH_COUNTERMEASURE:
-		case VIEW_SLEW:
-		case VIEW_TRACK_TARGET:
-		case ONE_THIRD_THROTTLE:
-		case TWO_THIRDS_THROTTLE:
-		case MINUS_5_PERCENT_THROTTLE:
-		case PLUS_5_PERCENT_THROTTLE:
-		case ZERO_THROTTLE:
-		case MAX_THROTTLE:
-		case TOGGLE_GLIDING:
-		case GLIDE_WHEN_PRESSED:
-			return 0;
-	}
-
-	/**
-	 * This switch handles the critical buttons
-	 *
-	 * button_function_critical is also called from network
-	 */
-	switch (n) {
-		case CYCLE_PRIMARY_WEAPON_SEQUENCE:
-		case CYCLE_NEXT_PRIMARY:	// cycle to next primary weapon
-		case CYCLE_PREV_PRIMARY:	// cycle to previous primary weapon
-		case CYCLE_SECONDARY:		// cycle to next secondary weapon
-		case CYCLE_NUM_MISSLES:		// cycle number of missiles fired from secondary bank
-		case SHIELD_EQUALIZE:		// equalize shield energy to all quadrants
-		case SHIELD_XFER_TOP:		// transfer shield energy to front
-		case SHIELD_XFER_BOTTOM:	// transfer shield energy to rear
-		case SHIELD_XFER_LEFT:		// transfer shield energy to left
-		case SHIELD_XFER_RIGHT:		// transfer shield energy to right
-		case XFER_SHIELD:			// transfer energy to shield from weapons
-		case XFER_LASER:			// transfer energy to weapons from shield
-			return button_function_critical(n);
-			break;
-
-		case INCREASE_WEAPON:		// increase weapon recharge rate
-		case DECREASE_WEAPON:		// decrease weapon recharge rate
-		case INCREASE_SHIELD:		// increase shield recharge rate
-		case DECREASE_SHIELD:		// decrease shield recharge rate
-		case INCREASE_ENGINE:		// increase energy to engines
-		case DECREASE_ENGINE:		// decrease energy to engines
-		case ETS_EQUALIZE:
-			if ((Player_ship->flags2 & SF2_NO_ETS) == 0) {
-				hud_gauge_popup_start(HUD_ETS_GAUGE);
-				return button_function_critical(n);
-			}
-			return 1;
-			break;
-	}
-
-	/**
-	 * Assume the switches below will catch the key, if not, set to FALSE in default
-	 *
-	 * Below, you must not use return in cases,
-	 * else the check for invalid keys will fail
-	 */
-	int keyHasBeenUsed = TRUE;
-
-	switch(n) {
-		// message all netplayers button
-		case MULTI_MESSAGE_ALL:
-			multi_msg_key_down(MULTI_MSG_ALL);
-			break;
-
-		// message all friendlies button
-		case MULTI_MESSAGE_FRIENDLY:
-			multi_msg_key_down(MULTI_MSG_FRIENDLY);
-			break;
-
-		// message all hostiles button
-		case MULTI_MESSAGE_HOSTILE:
-			multi_msg_key_down(MULTI_MSG_HOSTILE);
-			break;
-
-		// message targeted ship (if player)
-		case MULTI_MESSAGE_TARGET:
-			multi_msg_key_down(MULTI_MSG_TARGET);
-			break;
-
-		// undefined in multiplayer for clients right now
-		// toggle auto-match target speed
-		case TOGGLE_AUTO_MATCH_TARGET_SPEED:
-			// multiplayer observers can't match target speed
-			if((Game_mode & GM_MULTIPLAYER) && (Net_player != NULL) && ((Net_player->flags & NETINFO_FLAG_OBSERVER) || (Player_obj->type == OBJ_OBSERVER)) ){
-				break;
-			}
-
-			Player->flags ^= PLAYER_FLAGS_AUTO_MATCH_SPEED;
-			control_used(TOGGLE_AUTO_MATCH_TARGET_SPEED);
-			hud_gauge_popup_start(HUD_AUTO_SPEED);
-			if ( Players[Player_num].flags & PLAYER_FLAGS_AUTO_MATCH_SPEED ) {
-				snd_play(&Snds[SND_SHIELD_XFER_OK], 1.0f);
-				if ( !(Player->flags & PLAYER_FLAGS_MATCH_TARGET) ) {
-					player_match_target_speed();
-				}
-			}
-			else
-			{
-				snd_play(&Snds[SND_SHIELD_XFER_OK], 1.0f);
-				player_match_target_speed();
-			}
-			break;
-
-		case TARGET_NEXT_UNINSPECTED_CARGO:
-			hud_target_uninspected_object(1);
-			break;
-
-		case TARGET_PREV_UNINSPECTED_CARGO:
-			hud_target_uninspected_object(0);
-			break;
-
-		case TARGET_NEWEST_SHIP:
-			hud_target_newest_ship();
-			break;
-
-		case TARGET_NEXT_LIVE_TURRET:
-			hud_target_live_turret(1);
-			break;
-
-		case TARGET_PREV_LIVE_TURRET:
-			hud_target_live_turret(0);
-			break;
-
-		// end the mission
-		case END_MISSION:
-			// in multiplayer, all end mission requests should go through the server
-			if (Game_mode & GM_MULTIPLAYER) {
-				multi_handle_end_mission_request();
-				break;
-			}
-
-			control_used(END_MISSION);
-
-			if (collide_predict_large_ship(Player_obj, 200.0f) 
-			|| (Ship_info[Ships[Player_obj->instance].ship_info_index].warpout_type == WT_HYPERSPACE 
-			&& collide_predict_large_ship(Player_obj, 100000.0f)))
-			{
-				gamesnd_play_iface(SND_GENERAL_FAIL);
-				HUD_printf(XSTR( "** WARNING ** Collision danger.  Subspace drive not activated.", 39));
-			} else if (!ship_engine_ok_to_warp(Player_ship)) {
-				gamesnd_play_iface(SND_GENERAL_FAIL);
-				HUD_printf(XSTR("Engine failure.  Cannot engage subspace drive.", 40));
-			} else if (!ship_navigation_ok_to_warp(Player_ship)) {
-				gamesnd_play_iface(SND_GENERAL_FAIL);
-				HUD_printf(XSTR("Navigation failure.  Cannot engage subspace drive.", 1596));
-			} else if ( (Player_obj != NULL) && object_get_gliding(Player_obj)) {
-				gamesnd_play_iface(SND_GENERAL_FAIL);
-				HUD_printf(XSTR("Cannot engage subspace drive while gliding.", 1597));
-			} else {
-				gameseq_post_event( GS_EVENT_PLAYER_WARPOUT_START );
-			}
-			break;
-
-		case ADD_REMOVE_ESCORT:
-			if ( Player_ai->target_objnum >= 0 ) {
-				control_used(ADD_REMOVE_ESCORT);
-				hud_add_remove_ship_escort(Player_ai->target_objnum);
-			}
-			break;
-
-		// if i'm an observer, zoom to my targeted object
-		case MULTI_OBSERVER_ZOOM_TO:
-			multi_obs_zoom_to_target();
-			break;
-
-		// toggle between high and low HUD contrast
-		case TOGGLE_HUD_CONTRAST:
-			gamesnd_play_iface(SND_USER_SELECT);
-			hud_toggle_contrast();
-			break;
-
-		// toggle network info
-		case MULTI_TOGGLE_NETINFO:
-			extern int Multi_display_netinfo;
-			Multi_display_netinfo = !Multi_display_netinfo;
-			break;
-
-		// self destruct (multiplayer only)
-		case MULTI_SELF_DESTRUCT:
-			if (!(Game_mode & GM_MULTIPLAYER)) {
-				break;
-			}
-
-			// bogus netplayer
-			if ( (Net_player == NULL) || (Net_player->m_player == NULL) ) {
-				break;
-			}
-
-			// blow myself up, if I'm the server
-			if (Net_player->flags & NETINFO_FLAG_AM_MASTER) {
-				if ( (Net_player->m_player->objnum >= 0) && 
-					(Net_player->m_player->objnum < MAX_OBJECTS) && 
-					(Objects[Net_player->m_player->objnum].type == OBJ_SHIP) && 
-					(Objects[Net_player->m_player->objnum].instance >= 0) && 
-					(Objects[Net_player->m_player->objnum].instance < MAX_SHIPS) )
-				{
-
-					ship_self_destruct(&Objects[Net_player->m_player->objnum]);
-				}
-			} else { // otherwise send a packet to the server
-				send_self_destruct_packet();
-			}
-			break;
-
-		case TOGGLE_HUD:
-			gamesnd_play_iface(SND_USER_SELECT);
-			hud_toggle_draw();
-			break;
-
-		case HUD_TARGETBOX_TOGGLE_WIREFRAME:
-			if (!Lock_targetbox_mode) {
-				gamesnd_play_iface(SND_USER_SELECT);
-				hud_targetbox_switch_wireframe_mode();
-			} else {
-				gamesnd_play_iface(SND_GENERAL_FAIL);
-			}
-			break;
-
-		// Autopilot key control
-		case AUTO_PILOT_TOGGLE:
-			if (!(The_mission.flags & MISSION_FLAG_DEACTIVATE_AP)) {
-				if (AutoPilotEngaged) {
-					if (Cmdline_autopilot_interruptable == 1) //allow WCS to disable autopilot interrupt via commandline
-						EndAutoPilot();
-				} else {
-					if (!StartAutopilot())
-						gamesnd_play_iface(SND_GENERAL_FAIL);
-				}
-			}
-			break;
-
-		case NAV_CYCLE:
-			if (!Sel_NextNav())
-				gamesnd_play_iface(SND_GENERAL_FAIL);
-			break;
-		default:
-			keyHasBeenUsed = FALSE;
-			break;
-	}
-
-	/**
-	 * The key has been handled, return early before the timestamp is set
-	 */
-	if (keyHasBeenUsed) {
-		return 1;
-	}
-
-	/**
-	 * 	Update the last used timestamp of this key
-	 */
-	control_used(n);
-
-	if ( hud_sensors_ok(Player_ship) ) {
-		keyHasBeenUsed = TRUE;
-		switch(n) {
-			// target next
-			case TARGET_NEXT:
-				hud_target_next();
-				break;
-
-			// target previous
-			case TARGET_PREV:
-				hud_target_prev();
-				break;
-
-			// target the next hostile target
-			case TARGET_NEXT_CLOSEST_HOSTILE:
-				hud_target_next_list();
-				break;
-
-			// target the previous closest hostile
-			case TARGET_PREV_CLOSEST_HOSTILE:
-				hud_target_next_list(1,0);
-				break;
-
-			// target the next friendly ship
-			case TARGET_NEXT_CLOSEST_FRIENDLY:
-				hud_target_next_list(0);
-				break;
-
-			// target the closest friendly ship
-			case TARGET_PREV_CLOSEST_FRIENDLY:
-				hud_target_next_list(0,0);
-				break;
-
-			// target ship closest to center of reticle
-			case TARGET_SHIP_IN_RETICLE:
-				hud_target_in_reticle_new();
-				break;
-
-			case TARGET_LAST_TRANMISSION_SENDER:
-				hud_target_last_transmit();
-				break;
-
-			// target the closest ship attacking current target
-			case TARGET_CLOSEST_SHIP_ATTACKING_TARGET:
-				if (Player_ai->target_objnum < 0) {
-					snd_play(&Snds[SND_TARGET_FAIL]);
-					break;
-				}
-
-				hud_target_closest(iff_get_attacker_mask(obj_team(&Objects[Player_ai->target_objnum])), Player_ai->target_objnum);
-				break;
-
-			// target closest ship that is attacking player
-			case TARGET_CLOSEST_SHIP_ATTACKING_SELF:
-				hud_target_next_list(1, 0, iff_get_attacker_mask(Player_ship->team), OBJ_INDEX(Player_obj), TRUE, 0, 1);
-				break;
-
-			// target your target's target
-			case TARGET_TARGETS_TARGET:
-				hud_target_targets_target();
-				break;
-
-			// target ships subsystem in reticle
-			case TARGET_SUBOBJECT_IN_RETICLE:
-				hud_target_subsystem_in_reticle();
-				break;
-
-			case TARGET_PREV_SUBOBJECT:
-				hud_target_prev_subobject();
-				break;
-
-			// target next subsystem on current target
-			case TARGET_NEXT_SUBOBJECT:
-				hud_target_next_subobject();
-				break;
-
-			default:
-				keyHasBeenUsed = FALSE;
-				break;
-		};
-		if (keyHasBeenUsed) {
-			return 1;
-		}
-	}
-	else 
-	{
-		//if sensors are gone, and the passed key is one of the targeting keys, we need to exit here before we hit the Int3() later in this function
-		if (key_is_targeting(n)) {
-			return 1;
-		}
-	}
-
-	keyHasBeenUsed = TRUE;
-	switch(n) {
-		// undefined in multiplayer for clients right now
-		// match target speed
-		case MATCH_TARGET_SPEED:
-			// If player is auto-matching, break auto-match speed
-			if ( Player->flags & PLAYER_FLAGS_AUTO_MATCH_SPEED ) {
-				Player->flags &= ~PLAYER_FLAGS_AUTO_MATCH_SPEED;
-			}
-			player_match_target_speed();
-			break;
-
-		// toggle auto-targeting
-		case TOGGLE_AUTO_TARGETING:
-			hud_gauge_popup_start(HUD_AUTO_TARGET);
-			Players[Player_num].flags ^= PLAYER_FLAGS_AUTO_TARGETING;
-			if ( Players[Player_num].flags & PLAYER_FLAGS_AUTO_TARGETING ) {
-				if (hud_sensors_ok(Player_ship)) {
-					hud_target_closest(iff_get_attackee_mask(Player_ship->team), -1, FALSE, TRUE );
-					snd_play(&Snds[SND_SHIELD_XFER_OK], 1.0f);
-					//HUD_sourced_printf(HUD_SOURCE_HIDDEN, XSTR( "Auto targeting activated", -1));
-				} else {
-					Players[Player_num].flags ^= PLAYER_FLAGS_AUTO_TARGETING;
-				}
-			} else {
-				snd_play(&Snds[SND_SHIELD_XFER_OK], 1.0f);
-				//HUD_sourced_printf(HUD_SOURCE_HIDDEN, XSTR( "Auto targeting deactivated", -1));
-			}
-			break;
-
-		// target the closest repair ship
-		case TARGET_CLOSEST_REPAIR_SHIP:
-			// AL: Try to find the closest repair ship coming to repair the player... if no support
-			//		 ships are coming to rearm the player, just try for the closest repair ship
-			if ( hud_target_closest_repair_ship(OBJ_INDEX(Player_obj)) == 0 ) {
-				if ( hud_target_closest_repair_ship() == 0 ) {
-					snd_play(&Snds[SND_TARGET_FAIL]);
-				}
-			}
-			break;
-
-		// stop targeting ship
-		case STOP_TARGETING_SHIP:
-			hud_cease_targeting();
-			break;
-
-		// stop targeting subsystems on ship
-		case STOP_TARGETING_SUBSYSTEM:
-			hud_cease_subsystem_targeting();
-			break;
-			
-		case TARGET_NEXT_BOMB:
-			hud_target_missile(Player_obj, 1);
-			break;
-
-		case TARGET_PREV_BOMB:
-			hud_target_missile(Player_obj, 0);
-			break;
-
-		// wingman message: attack current target
-		case ATTACK_MESSAGE:
-			hud_squadmsg_shortcut( ATTACK_TARGET_ITEM );
-			break;
-
-		// wingman message: disarm current target
-		case DISARM_MESSAGE:
-			hud_squadmsg_shortcut( DISARM_TARGET_ITEM );
-			break;
-
-		// wingman message: disable current target
-		case DISABLE_MESSAGE:
-			hud_squadmsg_shortcut( DISABLE_TARGET_ITEM );
-			break;
-
-		// wingman message: disable current target
-		case ATTACK_SUBSYSTEM_MESSAGE:
-			hud_squadmsg_shortcut( DISABLE_SUBSYSTEM_ITEM );
-			break;
-
-		// wingman message: capture current target
-		case CAPTURE_MESSAGE:
-			hud_squadmsg_shortcut( CAPTURE_TARGET_ITEM );
-			break;
-
-		// wingman message: engage enemy
-		case ENGAGE_MESSAGE:
-			hud_squadmsg_shortcut( ENGAGE_ENEMY_ITEM );
-			break;
-
-		// wingman message: form on my wing
-		case FORM_MESSAGE:
-			hud_squadmsg_shortcut( FORMATION_ITEM );
-			break;
-
-		// wingman message: protect current target
-		case PROTECT_MESSAGE:
-			hud_squadmsg_shortcut( PROTECT_TARGET_ITEM );
-			break;
-
-		// wingman message: cover me
-		case COVER_MESSAGE:
-			hud_squadmsg_shortcut( COVER_ME_ITEM );
-			break;
-		
-		// wingman message: warp out
-		case WARP_MESSAGE:
-			hud_squadmsg_shortcut( DEPART_ITEM );
-			break;
-
-		case IGNORE_MESSAGE:
-			hud_squadmsg_shortcut( IGNORE_TARGET_ITEM );
-			break;
-
-		// rearm message
-		case REARM_MESSAGE:
-			hud_squadmsg_rearm_shortcut();
-			break;
-
-		// cycle to next radar range
-		case RADAR_RANGE_CYCLE:
-			HUD_config.rp_dist++;
-			if ( HUD_config.rp_dist >= RR_MAX_RANGES )
-				HUD_config.rp_dist = 0;
-
-			HUD_sourced_printf(HUD_SOURCE_HIDDEN, XSTR( "Radar range set to %s", 38), Radar_range_text(HUD_config.rp_dist));
-			break;
-
-		// toggle the squadmate messaging menu
-		case SQUADMSG_MENU:
-			hud_squadmsg_toggle();				// leave the details to the messaging code!!!
-			break;
-
-		// show the mission goals screen
-		case SHOW_GOALS:
-			gameseq_post_event( GS_EVENT_SHOW_GOALS );
-			break;
-
-		// end the mission
-		case END_MISSION:
-			// in multiplayer, all end mission requests should go through the server
-			if(Game_mode & GM_MULTIPLAYER){				
-				multi_handle_end_mission_request();
-				break;
-			}
-
-			control_used(END_MISSION);
-			
-			if (collide_predict_large_ship(Player_obj, 200.0f) 
-			|| (Ship_info[Ships[Player_obj->instance].ship_info_index].warpout_type == WT_HYPERSPACE 
-			&& collide_predict_large_ship(Player_obj, 100000.0f)))
-			{
-				gamesnd_play_iface(SND_GENERAL_FAIL);
-				HUD_printf(XSTR( "** WARNING ** Collision danger.  Subspace drive not activated.", 39));
-			} else if (!ship_engine_ok_to_warp(Player_ship)) {
-				gamesnd_play_iface(SND_GENERAL_FAIL);
-				HUD_printf(XSTR("Engine failure.  Cannot engage subspace drive.", 40));
-			} else if (!ship_navigation_ok_to_warp(Player_ship)) {
-				gamesnd_play_iface(SND_GENERAL_FAIL);
-				HUD_printf(XSTR("Navigation failure.  Cannot engage subspace drive.", 1572));
-			} else if (Player_obj != NULL && object_get_gliding(Player_obj)) {
-				gamesnd_play_iface(SND_GENERAL_FAIL);
-				HUD_printf(XSTR("Cannot engage subspace drive while gliding.", 1573));			
-			} else {
-				gameseq_post_event( GS_EVENT_PLAYER_WARPOUT_START );
-			}			
-			break;
-
-		case ADD_REMOVE_ESCORT:
-			if ( Player_ai->target_objnum >= 0 ) {
-				control_used(ADD_REMOVE_ESCORT);
-				hud_add_remove_ship_escort(Player_ai->target_objnum);
-			}
-			break;
-
-		case ESCORT_CLEAR:
-			hud_escort_clear_all(true);
-			break;
-
-		case TARGET_NEXT_ESCORT_SHIP:
-			hud_escort_target_next();
-			break;
-
-		default:
-			keyHasBeenUsed = FALSE;
-			break;
-	};
-	if (keyHasBeenUsed) {
-		return 1;
-	}
-
-	/**
-	 * All keys should have been handled above, if not panic
-	 */
-	mprintf(("Unknown key %d at %s:%u\n", n, __FILE__, __LINE__));
-	Int3();
-
-	return 1;
-}
-
-/**
- * Calls multiple event handlers for each active button
- * @param bi currently active buttons
- */
 void button_info_do(button_info *bi)
 {
 	for (int i = 0; i < CCFG_MAX; i++) {
@@ -2849,10 +1712,10 @@ void button_info_do(button_info *bi)
 	}
 }
 
+bool button_info_query(button_info *bi, int n) {
+	return bi->status[n / 32] & (1 << (n % 32));
+}
 
-/**
- * Set the bit for the corresponding action n (BUTTON_ from KeyControl.h)
- */
 void button_info_set(button_info *bi, int n)
 {
 	int field_num, bit_num;
@@ -2863,9 +1726,6 @@ void button_info_set(button_info *bi, int n)
 	bi->status[field_num] |= (1 << bit_num);	
 }
 
-/**
- * Unset the bit for the corresponding action n (BUTTON_ from KeyControl.h)
- */
 void button_info_unset(button_info *bi, int n)
 {
 	int field_num, bit_num;
@@ -2876,26 +1736,6 @@ void button_info_unset(button_info *bi, int n)
 	bi->status[field_num] &= ~(1 << bit_num);	
 }
 
-int button_info_query(button_info *bi, int n)
-{
-	return bi->status[n / 32] & (1 << (n % 32));
-}
-
-/**
- * Clear out the ::button_info struct
- */
-void button_info_clear(button_info *bi)
-{
-	int i;
-
-	for (i=0; i<NUM_BUTTON_FIELDS; i++) {
-		bi->status[i] = 0;
-	}
-}
-
-/**
- * Strip out all noncritical keys from the ::button_info struct
- */
 void button_strip_noncritical_keys(button_info *bi)
 {
 	int idx;
@@ -2904,4 +1744,1197 @@ void button_strip_noncritical_keys(button_info *bi)
 	for(idx=0;idx<Non_critical_key_set_size;idx++){
 		button_info_unset(bi,Non_critical_key_set[idx]);
 	}
+}
+
+void debug_change_song(int delta) {
+	char buf[256];
+	if (event_music_next_soundtrack(delta) != -1) {
+		event_music_get_soundtrack_name(buf);
+		HUD_sourced_printf(HUD_SOURCE_HIDDEN, XSTR("Soundtrack changed to: %s", 2), buf);
+
+	} else {
+		HUD_sourced_printf(HUD_SOURCE_HIDDEN, XSTR("Event music is not playing", 3));
+	}
+}
+
+void debug_cycle_player_ship(int delta) {
+	if (Player_obj == NULL)
+		return;
+
+	int si_index = Ships[Player_obj->instance].ship_info_index;
+	int sanity = 0;
+	ship_info	*sip;
+	while (TRUE) {
+		si_index += delta;
+		if (si_index >= static_cast<int>(Ship_info.size())) {
+			si_index = 0;
+		}
+		if (si_index < 0) {
+			si_index = static_cast<int>(Ship_info.size() - 1);
+		}
+		sip = &Ship_info[si_index];
+		if (sip->flags & SIF_PLAYER_SHIP) {
+			break;
+		}
+
+		// just in case
+		sanity++;
+		if (sanity >= static_cast<int>(Ship_info.size())) {
+			break;
+		}
+	}
+
+	change_ship_type(Player_obj->instance, si_index);
+	HUD_sourced_printf(HUD_SOURCE_HIDDEN, XSTR("Player ship changed to %s", 0), Ship_info[si_index].name);
+}
+
+void debug_cycle_targeted_ship(int delta) {
+	object		*objp;
+	ship_info	*sip;
+	int			si_index, species;
+	char			name[NAME_LENGTH];
+
+	if (Player_ai->target_objnum == -1)
+		return;
+
+	objp = &Objects[Player_ai->target_objnum];
+	if (objp->type != OBJ_SHIP)
+		return;
+
+	si_index = Ships[objp->instance].ship_info_index;
+	Assert(si_index != -1);
+	species = Ship_info[si_index].species;
+
+	int sanity = 0;
+
+	while (TRUE) {
+		si_index += delta;
+		if (si_index >= static_cast<int>(Ship_info.size()))
+			si_index = 0;
+		if (si_index < 0)
+			si_index = static_cast<int>(Ship_info.size() - 1);
+
+
+		sip = &Ship_info[si_index];
+
+		// if it has test in the name, jump over it
+		strcpy_s(name, sip->name);
+		_strlwr(name);
+		if (strstr(name, NOX("test")) != NULL)
+			continue;
+
+		if (sip->species == species && (sip->flags & (SIF_FIGHTER | SIF_BOMBER | SIF_TRANSPORT)))
+			break;
+
+		// just in case
+		sanity++;
+		if (sanity >= static_cast<int>(Ship_info.size()))
+			break;
+	}
+
+	change_ship_type(objp->instance, si_index);
+	HUD_sourced_printf(HUD_SOURCE_HIDDEN, XSTR("Changed player target to %s", 1), Ship_info[si_index].name);
+}
+
+void debug_max_primary_weapons(object *objp)	// Goober5000
+{
+	Assert(objp);	// Goober5000
+
+	int index;
+	ship *shipp = &Ships[objp->instance];
+	ship_info *sip = &Ship_info[shipp->ship_info_index];
+	ship_weapon *swp = &shipp->weapons;
+	weapon_info *wip;
+
+	if (sip->flags & SIF_BALLISTIC_PRIMARIES) {
+		for (index = 0; index < MAX_SHIP_PRIMARY_BANKS; index++) {
+			wip = &Weapon_info[swp->primary_bank_weapons[index]];
+			if (wip->wi_flags2 & WIF2_BALLISTIC) {
+				float capacity, size;
+				capacity = (float)sip->primary_bank_ammo_capacity[index];
+				size = (float)wip->cargo_size;
+				swp->primary_bank_ammo[index] = fl2i((capacity / size) + 0.5f);
+			}
+		}
+	}
+}
+
+void debug_max_secondary_weapons(object *objp) {
+	int index;
+	ship *shipp = &Ships[objp->instance];
+	ship_info *sip = &Ship_info[shipp->ship_info_index];
+	ship_weapon *swp = &shipp->weapons;
+
+	for (index = 0; index < MAX_SHIP_SECONDARY_BANKS; index++) {
+		swp->secondary_bank_ammo[index] = sip->secondary_bank_ammo_capacity[index];
+	}
+}
+
+void game_do_end_mission_popup() {
+	int	pf_flags, choice;
+
+	// do the multiplayer version of this
+	if (Game_mode & GM_MULTIPLAYER) {
+		multi_quit_game(PROMPT_ALL);
+	} else {
+		// single player version....
+		// do housekeeping things.
+		game_stop_time();
+		game_stop_looped_sounds();
+		snd_stop_all();
+
+		quit_mission_popup_shown = true;
+
+		pf_flags = PF_BODY_BIG | PF_USE_AFFIRMATIVE_ICON | PF_USE_NEGATIVE_ICON;
+		choice = popup(pf_flags, 3, POPUP_NO, XSTR("&Yes, Quit", 28), XSTR("Yes, &Restart", 29), XSTR("Do you really want to end the mission?", 30));
+
+		switch (choice) {
+		case 1:
+			gameseq_post_event(GS_EVENT_END_GAME);
+			break;
+
+		case 2:
+			gameseq_post_event(GS_EVENT_ENTER_GAME);
+			break;
+
+		default:
+			break;  // do nothing
+		}
+		quit_mission_popup_shown = false;
+
+		game_start_time();
+		game_flush();
+	}
+}
+
+void game_process_cheats(int k) {
+	size_t i;
+
+	if (k == 0) {
+		return;
+	}
+
+	// no cheats in multiplayer, ever
+	if (Game_mode & GM_MULTIPLAYER) {
+		Cheats_enabled = 0;
+		return;
+	}
+
+	for (i = 0; i < CHEAT_BUFFER_LEN; i++) {
+		CheatBuffer[i] = CheatBuffer[i + 1];
+	}
+
+	CheatBuffer[CHEAT_BUFFER_LEN - 1] = (char)key_to_ascii(k);
+
+	cheatCode detectedCheatCode = CHEAT_CODE_NONE;
+
+	for (i = 0; i < CHEATS_TABLE_LEN; i++) {
+		Cheat cheat = cheatsTable[i];
+
+		if (!strncmp(cheat.data, CheatBuffer, CHEAT_BUFFER_LEN)) {
+			detectedCheatCode = cheat.code;
+			break;
+		}
+	}
+
+	if (detectedCheatCode == CHEAT_CODE_FREESPACE) {
+		Cheats_enabled = 1;
+
+		// cheating allows the changing of weapons so we have to grab anything
+		// that we don't already have loaded, just in case
+		extern void weapons_page_in_cheats();
+		weapons_page_in_cheats();
+
+		HUD_printf("Cheats enabled");
+	}
+	if (detectedCheatCode == CHEAT_CODE_FISH) {
+		// only enable in the Vasudan main hall
+		if ((gameseq_get_state() == GS_STATE_MAIN_MENU) && main_hall_is_vasudan()) {
+			extern void fishtank_start();
+			fishtank_start();
+		}
+	}
+	if (detectedCheatCode == CHEAT_CODE_HEADZ) {
+		// only enable in the Vasudan main hall
+		if ((gameseq_get_state() == GS_STATE_MAIN_MENU) && main_hall_is_vasudan()) {
+			main_hall_vasudan_funny();
+		}
+	}
+	if (detectedCheatCode == CHEAT_CODE_SKIP && (gameseq_get_state() == GS_STATE_MAIN_MENU)) {
+		extern void main_hall_campaign_cheat();
+		main_hall_campaign_cheat();
+	}
+	if (detectedCheatCode == CHEAT_CODE_TOOLED && (Game_mode & GM_IN_MISSION)) {
+		Tool_enabled = 1;
+		HUD_printf("Prepare to be taken to school");
+	}
+	if (detectedCheatCode == CHEAT_CODE_PIRATE && (Game_mode & GM_IN_MISSION) && (Player_obj != NULL)) {
+		extern void prevent_spawning_collision(object *new_obj);
+		ship_subsys *ptr;
+		char name[NAME_LENGTH];
+		int ship_idx, ship_class;
+
+		// if not found, then don't create it :(
+		ship_class = ship_info_lookup("Volition Bravos");
+		if (ship_class < 0)
+			return;
+
+		HUD_printf(NOX("Walk the plank"));
+
+		vec3d pos = Player_obj->pos;
+		matrix orient = Player_obj->orient;
+		pos.xyz.x += frand_range(-700.0f, 700.0f);
+		pos.xyz.y += frand_range(-700.0f, 700.0f);
+		pos.xyz.z += frand_range(-700.0f, 700.0f);
+
+		int objnum = ship_create(&orient, &pos, ship_class);
+		if (objnum < 0)
+			return;
+
+		ship *shipp = &Ships[Objects[objnum].instance];
+		shipp->ship_name[0] = '\0';
+		shipp->orders_accepted = (1 << NUM_COMM_ORDER_ITEMS) - 1;
+
+		// Goober5000 - stolen from support ship creation
+		// create a name for the ship.  use "Volition Bravos #".  look for collisions until one isn't found anymore
+		ship_idx = 1;
+		do {
+			sprintf(name, NOX("Volition Bravos %d"), ship_idx);
+			if ((ship_name_lookup(name) == -1) && (ship_find_exited_ship_by_name(name) == -1)) {
+				strcpy_s(shipp->ship_name, name);
+				break;
+			}
+
+			ship_idx++;
+		} while (1);
+
+		shipp->flags |= SF_ESCORT;
+		shipp->escort_priority = 1000 - ship_idx;
+
+		// now make sure we're not colliding with anyone
+		prevent_spawning_collision(&Objects[objnum]);
+
+		// Goober5000 - beam free
+		for (ptr = GET_FIRST(&shipp->subsys_list); ptr != END_OF_LIST(&shipp->subsys_list); ptr = GET_NEXT(ptr)) {
+			// mark all turrets as beam free
+			if (ptr->system_info->type == SUBSYSTEM_TURRET) {
+				ptr->weapons.flags |= SW_FLAG_BEAM_FREE;
+				ptr->turret_next_fire_stamp = timestamp((int)frand_range(50.0f, 4000.0f));
+			}
+		}
+
+		// warpin
+		shipfx_warpin_start(&Objects[objnum]);
+	}
+}
+
+void game_process_keys() {
+	int k;
+
+	button_info_clear(&Player->bi);	// clear out the button info struct for the player
+	do {
+		k = game_poll();
+
+		if (Game_mode & GM_DEAD_BLEW_UP) {
+			continue;
+		}
+
+		game_process_cheats(k);
+		process_player_ship_keys(k);
+		process_debug_keys(k);
+
+		switch (k) {
+		case 0:
+			// No key
+			break;
+
+		case KEY_ESC:
+			if (Player->control_mode != PCM_NORMAL) {
+				if (Player->control_mode == PCM_WARPOUT_STAGE1) {
+					gameseq_post_event(GS_EVENT_PLAYER_WARPOUT_STOP);
+				} else {
+					// too late to abort warp out!
+				}
+			} else {
+				// let the ESC key break out of messaging mode
+				if (Players[Player_num].flags & PLAYER_FLAGS_MSG_MODE) {
+					hud_squadmsg_toggle();
+					break;
+				}
+
+				//If topdown view in non-2D mission, go back to cockpit view.
+				if ((Viewer_mode & VM_TOPDOWN) && !(The_mission.flags & MISSION_FLAG_2D_MISSION) && !(Perspective_locked)) {
+					Viewer_mode &= ~VM_TOPDOWN;
+					break;
+				}
+
+				// if in external view or chase view, go back to cockpit view
+				if ((Viewer_mode & (VM_EXTERNAL | VM_CHASE | VM_OTHER_SHIP)) && !(Perspective_locked)) {
+					Viewer_mode &= ~(VM_EXTERNAL | VM_CHASE | VM_OTHER_SHIP);
+					break;
+				}
+
+				if (!(Game_mode & GM_DEAD_DIED))
+					game_do_end_mission_popup();
+
+			}
+			break;
+
+		case KEY_Y:
+			break;
+
+			case KEY_N:
+				break;
+
+		case KEY_DEBUGGED | KEY_PAUSE:
+			gameseq_post_event(GS_EVENT_DEBUG_PAUSE_GAME);
+			break;
+
+		case KEY_ALTED + KEY_PAUSE:
+			if (Game_mode & GM_DEAD_BLEW_UP ||
+				Game_mode & GM_DEAD_DIED) {
+				break;
+			}
+
+			pause_set_type(PAUSE_TYPE_VIEWER);
+			game_process_pause_key();
+			break;
+		case KEY_PAUSE:
+			if (Game_mode & GM_DEAD_BLEW_UP ||
+				Game_mode & GM_DEAD_DIED) {
+				break;
+			}
+
+			pause_set_type(PAUSE_TYPE_NORMAL);
+			game_process_pause_key();
+			break;
+
+		} // end switch
+	} while (k);
+
+	// lua button command override goes here!!
+	if (lua_game_control & LGC_B_OVERRIDE) {
+		button_info temp = Player->bi;
+		Player->bi = Player->lua_bi;
+		Player->lua_bi = temp;
+	} else if (lua_game_control & LGC_B_ADDITIVE) {
+		// add the lua commands to current commands 
+		int i;
+		for (i = 0; i<NUM_BUTTON_FIELDS; i++)
+			Player->bi.status[i] |= Player->lua_bi.status[i];
+		Player->lua_bi = Player->bi;
+	} else {
+		// just copy over the values
+		Player->lua_bi = Player->bi;
+	}
+	// there.. wasnt that bad hack was it?
+
+	button_info_do(&Player->bi);	// call functions based on status of button_info bit vectors
+}
+
+void game_process_pause_key() {
+	if (Game_mode & GM_MULTIPLAYER) {
+		// special processing for multiplayer
+		if (Multi_pause_status) {
+			multi_pause_request(0);
+
+		} else {
+			multi_pause_request(1);
+		}
+
+	} else {
+		gameseq_post_event(GS_EVENT_PAUSE_GAME);
+	}
+}
+
+int get_next_weapon_looped(int current_weapon, int subtype) {
+	int i, new_index;
+
+	for (i = 1; i < Num_weapon_types; i++) {
+		new_index = (current_weapon + i) % Num_weapon_types;
+
+		if (Weapon_info[new_index].subtype == subtype) {
+			return new_index;
+		}
+	}
+
+	return current_weapon;
+}
+
+int get_prev_weapon_looped(int current_weapon, int subtype) {
+	int i, new_index;
+
+	for (i = 1; i < Num_weapon_types; i++) {
+		new_index = (Num_weapon_types + current_weapon - i) % Num_weapon_types;
+
+		if (Weapon_info[new_index].subtype == subtype) {
+			return new_index;
+		}
+	}
+
+	return current_weapon;
+}
+
+bool key_is_targeting(int n) {
+	switch (n) {
+	case TARGET_NEXT:
+	case TARGET_PREV:
+	case TARGET_NEXT_CLOSEST_HOSTILE:
+	case TARGET_PREV_CLOSEST_HOSTILE:
+	case TARGET_NEXT_CLOSEST_FRIENDLY:
+	case TARGET_PREV_CLOSEST_FRIENDLY:
+	case TARGET_SHIP_IN_RETICLE:
+	case TARGET_LAST_TRANMISSION_SENDER:
+	case TARGET_CLOSEST_SHIP_ATTACKING_TARGET:
+	case TARGET_CLOSEST_SHIP_ATTACKING_SELF:
+	case TARGET_TARGETS_TARGET:
+	case TARGET_SUBOBJECT_IN_RETICLE:
+	case TARGET_PREV_SUBOBJECT:
+	case TARGET_NEXT_SUBOBJECT:
+		return true;
+
+	default:
+		return false;
+	}
+}
+
+void ppsk_hotkeys(int k) {
+	// use k to check for keys that can have Shift,Ctrl,Alt,Del status
+	int hotkey_set;
+
+#ifndef NDEBUG
+	k &= ~KEY_DEBUGGED;			// since hitting F11 will set this bit
+#endif
+
+	switch (k) {
+	case KEY_F5:
+	case KEY_F6:
+	case KEY_F7:
+	case KEY_F8:
+	case KEY_F9:
+	case KEY_F10:
+	case KEY_F11:
+	case KEY_F12:
+		hotkey_set = mission_hotkey_get_set_num(k);
+		if (!(Players[Player_num].flags & PLAYER_FLAGS_MSG_MODE))
+			hud_target_hotkey_select(hotkey_set);
+		else
+			hud_squadmsg_hotkey_select(hotkey_set);
+
+		break;
+
+	case KEY_F5 + KEY_SHIFTED:
+	case KEY_F6 + KEY_SHIFTED:
+	case KEY_F7 + KEY_SHIFTED:
+	case KEY_F8 + KEY_SHIFTED:
+	case KEY_F9 + KEY_SHIFTED:
+	case KEY_F10 + KEY_SHIFTED:
+	case KEY_F11 + KEY_SHIFTED:
+	case KEY_F12 + KEY_SHIFTED:
+		hotkey_set = mission_hotkey_get_set_num(k&(~KEY_SHIFTED));
+		mprintf(("Adding to set %d\n", hotkey_set + 1));
+		if (Player_ai->target_objnum == -1)
+			HUD_sourced_printf(HUD_SOURCE_HIDDEN, XSTR("No target to add/remove from set %d.", 26), hotkey_set + 1);
+		else {
+			hud_target_hotkey_add_remove(hotkey_set, &Objects[Player_ai->target_objnum], HOTKEY_USER_ADDED);
+			HUD_sourced_printf(HUD_SOURCE_HIDDEN, XSTR("%s added to set %d. (F%d)", 27), Ships[Objects[Player_ai->target_objnum].instance].ship_name, hotkey_set, 4 + hotkey_set + 1);
+		}
+
+		break;
+
+	case KEY_F5 + KEY_SHIFTED + KEY_ALTED:
+	case KEY_F6 + KEY_SHIFTED + KEY_ALTED:
+	case KEY_F7 + KEY_SHIFTED + KEY_ALTED:
+	case KEY_F8 + KEY_SHIFTED + KEY_ALTED:
+	case KEY_F9 + KEY_SHIFTED + KEY_ALTED:
+	case KEY_F10 + KEY_SHIFTED + KEY_ALTED:
+	case KEY_F11 + KEY_SHIFTED + KEY_ALTED:
+	case KEY_F12 + KEY_SHIFTED + KEY_ALTED:
+		hotkey_set = mission_hotkey_get_set_num(k & (~(KEY_SHIFTED + KEY_ALTED)));
+		hud_target_hotkey_clear(hotkey_set);
+		break;
+
+	case KEY_SHIFTED + KEY_MINUS:
+		if (HUD_color_alpha > HUD_COLOR_ALPHA_USER_MIN) {
+			HUD_color_alpha--;
+			HUD_init_colors();
+		}
+		break;
+
+	case KEY_SHIFTED + KEY_EQUAL:
+		if (HUD_color_alpha < HUD_COLOR_ALPHA_USER_MAX) {
+			HUD_color_alpha++;
+			HUD_init_colors();
+		}
+		break;
+	}	// end switch
+}
+
+void process_debug_keys(int k) {
+	// Kazan -- NO CHEATS IN MULTI
+	if (Game_mode & GM_MULTIPLAYER) {
+		Cheats_enabled = 0;
+		return;
+	}
+
+	switch (k) {
+	case KEY_DEBUGGED + KEY_Q:
+	case KEY_DEBUGGED1 + KEY_Q:
+		Snapshot_all_events = true;
+		break;
+
+	case KEY_DEBUGGED + KEY_H:
+		hud_target_toggle_hidden_from_sensors();
+		break;
+
+	case KEY_DEBUGGED + KEY_F:
+		extern int wacky_scheme;
+		if (wacky_scheme == 3) {
+			wacky_scheme = 0;
+		} else {
+			wacky_scheme++;
+		}
+		break;
+
+	case KEY_DEBUGGED + KEY_ALTED + KEY_F:
+		Framerate_delay += 10;
+		HUD_printf(XSTR("Framerate delay increased to %i milliseconds per frame.", 4), Framerate_delay);
+		break;
+
+	case KEY_DEBUGGED + KEY_ALTED + KEY_SHIFTED + KEY_F:
+		Framerate_delay -= 10;
+		if (Framerate_delay < 0)
+			Framerate_delay = 0;
+
+		HUD_printf(XSTR("Framerate delay decreased to %i milliseconds per frame.", 5), Framerate_delay);
+		break;
+
+	case KEY_DEBUGGED + KEY_X:
+	case KEY_DEBUGGED1 + KEY_X:
+		HUD_printf("Cloaking has been disabled, thank you for playing fs2_open, %s", Player->callsign);
+		break;
+
+	case KEY_DEBUGGED + KEY_C:
+	case KEY_DEBUGGED1 + KEY_C:
+		if (Player_obj->flags & OF_COLLIDES) {
+			obj_set_flags(Player_obj, Player_obj->flags & ~(OF_COLLIDES));
+			HUD_sourced_printf(HUD_SOURCE_HIDDEN, "Player no longer collides");
+		} else {
+			obj_set_flags(Player_obj, Player_obj->flags | OF_COLLIDES);
+			HUD_sourced_printf(HUD_SOURCE_HIDDEN, "Player collides");
+		}
+		break;
+
+	case KEY_DEBUGGED + KEY_SHIFTED + KEY_C:
+	case KEY_DEBUGGED1 + KEY_SHIFTED + KEY_C:
+		Countermeasures_enabled = !Countermeasures_enabled;
+		HUD_printf(XSTR("Countermeasure firing: %s", 6), Countermeasures_enabled ? XSTR("ENABLED", 7) : XSTR("DISABLED", 8));
+		break;
+
+		// Goober5000: this should only be compiled in debug builds, since it crashes release
+#ifndef NDEBUG
+	case KEY_DEBUGGED + KEY_E:
+		gameseq_post_event(GS_EVENT_EVENT_DEBUG);
+		break;
+#endif
+
+		// Goober5000: handle time dilation in cheat section
+	case KEY_DEBUGGED + KEY_SHIFTED + KEY_COMMA:
+	case KEY_DEBUGGED1 + KEY_SHIFTED + KEY_COMMA:
+		if (Game_mode & GM_NORMAL) {
+			if (Game_time_compression > (F1_0 / MAX_TIME_DIVIDER)) {
+				change_time_compression(0.5);
+			} else {
+				gamesnd_play_error_beep();
+			}
+		} else {
+			gamesnd_play_error_beep();
+		}
+		break;
+
+		// Goober5000: handle as normal here
+	case KEY_DEBUGGED + KEY_SHIFTED + KEY_PERIOD:
+	case KEY_DEBUGGED1 + KEY_SHIFTED + KEY_PERIOD:
+		if (Game_mode & GM_NORMAL) {
+			if (Game_time_compression < (F1_0*MAX_TIME_MULTIPLIER)) {
+				change_time_compression(2);
+			} else {
+				gamesnd_play_error_beep();
+			}
+		} else {
+			gamesnd_play_error_beep();
+		}
+		break;
+
+		//	Kill! the currently targeted ship.
+	case KEY_DEBUGGED + KEY_K:
+	case KEY_DEBUGGED1 + KEY_K:
+		if (Player_ai->target_objnum != -1) {
+			object	*objp = &Objects[Player_ai->target_objnum];
+
+			switch (objp->type) {
+			case OBJ_SHIP:
+
+				// remove guardian flag -- kazan
+				Ships[objp->instance].ship_guardian_threshold = 0;
+
+				ship_apply_local_damage(objp, Player_obj, &objp->pos, 100000.0f, MISS_SHIELDS, CREATE_SPARKS);
+				ship_apply_local_damage(objp, Player_obj, &objp->pos, 1.0f, MISS_SHIELDS, CREATE_SPARKS);
+				break;
+			case OBJ_WEAPON:
+				Weapons[objp->instance].lifeleft = 0.01f;
+				break;
+			}
+		}
+
+		break;
+
+		// play the next mission message
+	case KEY_DEBUGGED + KEY_V:
+		extern int Message_debug_index;
+		extern int Num_messages_playing;
+		// stop any other messages
+		if (Num_messages_playing) {
+			message_kill_all(1);
+		}
+
+		// next message
+		if (Message_debug_index >= Num_messages - 1) {
+			Message_debug_index = Num_builtin_messages;
+		} else {
+			Message_debug_index++;
+		}
+
+		// play the message
+		message_send_unique_to_player(Messages[Message_debug_index].name, Message_waves[Messages[Message_debug_index].wave_info.index].name, MESSAGE_SOURCE_SPECIAL, MESSAGE_PRIORITY_HIGH, 0, 0);
+		if (Messages[Message_debug_index].avi_info.index == -1) {
+			HUD_printf("No anim set for message \"%s\"; None will play!", Messages[Message_debug_index].name);
+		}
+		break;
+
+		// play the previous mission message
+	case KEY_DEBUGGED + KEY_SHIFTED + KEY_V:
+		extern int Message_debug_index;
+		extern int Num_messages_playing;
+		// stop any other messages
+		if (Num_messages_playing) {
+			message_kill_all(1);
+		}
+
+		// go maybe go down one
+		if (Message_debug_index == Num_builtin_messages - 1) {
+			Message_debug_index = Num_builtin_messages;
+		} else if (Message_debug_index > Num_builtin_messages) {
+			Message_debug_index--;
+		}
+
+		// play the message
+		message_send_unique_to_player(Messages[Message_debug_index].name, Message_waves[Messages[Message_debug_index].wave_info.index].name, MESSAGE_SOURCE_SPECIAL, MESSAGE_PRIORITY_HIGH, 0, 0);
+		if (Messages[Message_debug_index].avi_info.index == -1) {
+			HUD_printf("No avi associated with this message; None will play!");
+		}
+		break;
+
+		// reset to the beginning of mission messages
+	case KEY_DEBUGGED + KEY_ALTED + KEY_V:
+		extern int Message_debug_index;
+		Message_debug_index = Num_builtin_messages - 1;
+		HUD_printf("Resetting to first mission message");
+		break;
+
+		//	Kill! the currently targeted ship.
+	case KEY_DEBUGGED + KEY_ALTED + KEY_SHIFTED + KEY_K:
+	case KEY_DEBUGGED1 + KEY_ALTED + KEY_SHIFTED + KEY_K:
+		if (Player_ai->target_objnum != -1) {
+			object	*objp = &Objects[Player_ai->target_objnum];
+
+			if (objp->type == OBJ_SHIP) {
+				ship_apply_local_damage(objp, Player_obj, &objp->pos, Ships[objp->instance].ship_max_hull_strength * 0.1f + 10.0f, MISS_SHIELDS, CREATE_SPARKS);
+			}
+		}
+		break;
+
+		//	Kill the currently targeted subsystem.
+	case KEY_DEBUGGED + KEY_SHIFTED + KEY_K:
+	case KEY_DEBUGGED1 + KEY_SHIFTED + KEY_K:
+		if ((Player_ai->target_objnum != -1) && (Player_ai->targeted_subsys != NULL)) {
+			object	*objp = &Objects[Player_ai->target_objnum];
+			if (objp->type == OBJ_SHIP) {
+				ship		*sp = &Ships[objp->instance];
+				vec3d	g_subobj_pos;
+
+				get_subsystem_world_pos(objp, Player_ai->targeted_subsys, &g_subobj_pos);
+
+				do_subobj_hit_stuff(objp, Player_obj, &g_subobj_pos, Player_ai->targeted_subsys->system_info->subobj_num, (float)-Player_ai->targeted_subsys->system_info->type, NULL); //100.0f);
+
+				if (sp->subsys_info[SUBSYSTEM_ENGINE].aggregate_current_hits <= 0.0f) {
+					mission_log_add_entry(LOG_SHIP_DISABLED, sp->ship_name, NULL);
+					sp->flags |= SF_DISABLED;				// add the disabled flag
+				}
+
+				if (sp->subsys_info[SUBSYSTEM_TURRET].aggregate_current_hits <= 0.0f) {
+					mission_log_add_entry(LOG_SHIP_DISARMED, sp->ship_name, NULL);
+				}
+			}
+		}
+		break;
+
+	case KEY_DEBUGGED + KEY_ALTED + KEY_K:
+	case KEY_DEBUGGED1 + KEY_ALTED + KEY_K:
+	{
+		float	shield, integrity;
+		vec3d	pos, randvec;
+
+		vm_vec_rand_vec_quick(&randvec);
+		vm_vec_scale_add(&pos, &Player_obj->pos, &randvec, Player_obj->radius);
+		ship_apply_local_damage(Player_obj, Player_obj, &pos, 25.0f, MISS_SHIELDS, CREATE_SPARKS);
+		hud_get_target_strength(Player_obj, &shield, &integrity);
+		HUD_sourced_printf(HUD_SOURCE_HIDDEN, XSTR("You knocked yourself down to %7.3f percent hull.\n", 9), 100.0f * integrity);
+		break;
+	}
+
+	//	Whack down the player's shield and hull by a little more than 50%
+	//	Select next object to be viewed by AI.
+	case KEY_DEBUGGED + KEY_I:
+	case KEY_DEBUGGED1 + KEY_I:
+		Player_obj->flags ^= OF_INVULNERABLE;
+		HUD_sourced_printf(HUD_SOURCE_HIDDEN, XSTR("You are %s", 10), Player_obj->flags & OF_INVULNERABLE ? XSTR("now INVULNERABLE!", 11) : XSTR("no longer invulnerable...", 12));
+		break;
+
+	case KEY_DEBUGGED + KEY_SHIFTED + KEY_I:
+	case KEY_DEBUGGED1 + KEY_SHIFTED + KEY_I:
+		if (Player_ai->target_objnum != -1) {
+			object	*objp = &Objects[Player_ai->target_objnum];
+
+			objp->flags ^= OF_INVULNERABLE;
+			HUD_sourced_printf(HUD_SOURCE_HIDDEN, XSTR("Player's target [%s] is %s", 13), Ships[objp->instance].ship_name, objp->flags & OF_INVULNERABLE ? XSTR("now INVULNERABLE!", 11) : XSTR("no longer invulnerable...", 12));
+		}
+		break;
+
+	case KEY_DEBUGGED + KEY_N:
+		AI_watch_object++;
+		HUD_sourced_printf(HUD_SOURCE_HIDDEN, XSTR("Spewing debug info about object #%d", 14), AI_watch_object);
+		break;
+
+	case KEY_DEBUGGED + KEY_O:
+	case KEY_DEBUGGED1 + KEY_O:
+		toggle_player_object();
+		break;
+
+	case KEY_DEBUGGED + KEY_SHIFTED + KEY_O:
+		extern int Debug_octant;
+		if (Debug_octant == 7) {
+			Debug_octant = -1;
+		} else {
+			Debug_octant++;
+		}
+		nprintf(("General", "Debug_octant == %d\n", Debug_octant));
+		break;
+
+	case KEY_DEBUGGED + KEY_P:
+		supernova_start(20);
+		break;
+
+	case KEY_DEBUGGED + KEY_W:
+	case KEY_DEBUGGED1 + KEY_W:
+	case KEY_DEBUGGED + KEY_SHIFTED + KEY_W:
+	case KEY_DEBUGGED1 + KEY_SHIFTED + KEY_W:
+		// temp code for testing purposes, toggles weapon energy cheat
+		Weapon_energy_cheat = !Weapon_energy_cheat;
+		if (Weapon_energy_cheat) {
+			if (k & KEY_SHIFTED)
+				HUD_sourced_printf(HUD_SOURCE_HIDDEN, XSTR("Weapon energy and missile count will always be at full ALL SHIPS!", 15));
+			else
+				HUD_sourced_printf(HUD_SOURCE_HIDDEN, XSTR("Weapon energy and missile count will always be at full for player", 16));
+
+			debug_max_secondary_weapons(Player_obj);
+			debug_max_primary_weapons(Player_obj);
+			if (k & KEY_SHIFTED) {
+				object	*objp;
+
+				for (objp = GET_FIRST(&obj_used_list); objp != END_OF_LIST(&obj_used_list); objp = GET_NEXT(objp))
+					if (objp->type == OBJ_SHIP) {
+						debug_max_secondary_weapons(objp);
+						debug_max_primary_weapons(objp);
+					}
+			}
+
+		} else
+			HUD_sourced_printf(HUD_SOURCE_HIDDEN, XSTR("Normal weapon energy system / missile count restored", 17));
+
+		break;
+
+	case KEY_DEBUGGED + KEY_G:
+	case KEY_DEBUGGED1 + KEY_G:
+		mission_goal_mark_all_true(PRIMARY_GOAL);
+		break;
+
+	case KEY_DEBUGGED + KEY_G + KEY_SHIFTED:
+	case KEY_DEBUGGED1 + KEY_G + KEY_SHIFTED:
+		mission_goal_mark_all_true(SECONDARY_GOAL);
+		break;
+
+	case KEY_DEBUGGED + KEY_G + KEY_ALTED:
+	case KEY_DEBUGGED1 + KEY_G + KEY_ALTED:
+		mission_goal_mark_all_true(BONUS_GOAL);
+		break;
+
+	case KEY_DEBUGGED + KEY_9: {
+	case KEY_DEBUGGED1 + KEY_9:
+		ship* shipp;
+
+		shipp = &Ships[Player_obj->instance];
+		int *weap = &shipp->weapons.secondary_bank_weapons[shipp->weapons.current_secondary_bank];
+		*weap = get_next_weapon_looped(*weap, WP_MISSILE);
+
+		HUD_sourced_printf(HUD_SOURCE_HIDDEN, XSTR("Secondary Weapon forced to %s", 18), Weapon_info[*weap].name);
+		break;
+	}
+
+
+	case KEY_DEBUGGED + KEY_SHIFTED + KEY_9: {
+	case KEY_DEBUGGED1 + KEY_SHIFTED + KEY_9:
+		ship* shipp;
+
+		shipp = &Ships[Player_obj->instance];
+		int *weap = &shipp->weapons.secondary_bank_weapons[shipp->weapons.current_secondary_bank];
+		*weap = get_prev_weapon_looped(*weap, WP_MISSILE);
+
+		HUD_sourced_printf(HUD_SOURCE_HIDDEN, XSTR("Secondary Weapon forced to %s", 18), Weapon_info[*weap].name);
+		break;
+	}
+
+	case KEY_DEBUGGED + KEY_U: {
+	case KEY_DEBUGGED1 + KEY_U:
+		// launch asteroid
+		object *asteroid_create(asteroid_field *asfieldp, int asteroid_type, int subtype);
+		object *objp = asteroid_create(&Asteroid_field, 0, 0);
+		if (objp == NULL) {
+			break;
+		}
+		vec3d vel;
+		vm_vec_copy_scale(&vel, &Player_obj->orient.vec.fvec, 50.0f);
+		objp->phys_info.vel = vel;
+		objp->phys_info.desired_vel = vel;
+		objp->pos = Player_obj->pos;
+		HUD_sourced_printf(HUD_SOURCE_HIDDEN, XSTR("Asteroid launched", 1595));
+		break;
+	}
+
+	case KEY_DEBUGGED + KEY_0: {
+	case KEY_DEBUGGED1 + KEY_0:
+		ship* shipp;
+
+		shipp = &Ships[Player_obj->instance];
+		int *weap = &shipp->weapons.primary_bank_weapons[shipp->weapons.current_primary_bank];
+		*weap = get_next_weapon_looped(*weap, WP_LASER);
+
+		HUD_sourced_printf(HUD_SOURCE_HIDDEN, XSTR("Primary Weapon forced to %s", 19), Weapon_info[*weap].name);
+		break;
+	}
+
+	case KEY_DEBUGGED + KEY_SHIFTED + KEY_0: {
+	case KEY_DEBUGGED1 + KEY_SHIFTED + KEY_0:
+		ship* shipp;
+
+		shipp = &Ships[Player_obj->instance];
+		int *weap = &shipp->weapons.primary_bank_weapons[shipp->weapons.current_primary_bank];
+		*weap = get_prev_weapon_looped(*weap, WP_LASER);
+
+		HUD_sourced_printf(HUD_SOURCE_HIDDEN, XSTR("Primary Weapon forced to %s", 19), Weapon_info[*weap].name);
+		break;
+	}
+
+	case KEY_DEBUGGED + KEY_J: {
+		int new_pattern = event_music_return_current_pattern();
+
+		new_pattern++;
+		if (new_pattern >= MAX_PATTERNS)
+			new_pattern = 0;
+
+		event_music_change_pattern(new_pattern);
+		break;
+	}
+
+	case KEY_DEBUGGED + KEY_M: {
+		if (Event_music_enabled) {
+			event_music_disable();
+			HUD_sourced_printf(HUD_SOURCE_HIDDEN, XSTR("Event music disabled", 20));
+
+		} else {
+			event_music_enable();
+			HUD_sourced_printf(HUD_SOURCE_HIDDEN, XSTR("Event music enabled", 21));
+		}
+
+		break;
+	}
+
+	case KEY_DEBUGGED + KEY_R:
+	case KEY_DEBUGGED1 + KEY_R:
+	{
+		// rearm the target, if we have one
+		object *obj_to_rearm = (Player_ai->target_objnum >= 0) ? &Objects[Player_ai->target_objnum] : Player_obj;
+
+		if (is_support_allowed(obj_to_rearm)) {
+			HUD_sourced_printf(HUD_SOURCE_HIDDEN, XSTR("Issuing rearm request for %s", -1), Ships[obj_to_rearm->instance].ship_name);
+			ai_issue_rearm_request(obj_to_rearm);
+		} else {
+			HUD_sourced_printf(HUD_SOURCE_HIDDEN, XSTR("Cannot issue rearm request for %s", -1), Ships[obj_to_rearm->instance].ship_name);
+		}
+
+		break;
+	}
+
+	case KEY_DEBUGGED + KEY_SHIFTED + KEY_UP:
+		Game_detail_level++;
+		HUD_printf(XSTR("Detail level set to %+d\n", 22), Game_detail_level);
+		break;
+
+	case KEY_DEBUGGED + KEY_SHIFTED + KEY_DOWN:
+		Game_detail_level--;
+		HUD_printf(XSTR("Detail level set to %+d\n", 22), Game_detail_level);
+		break;
+
+#ifndef NDEBUG
+	case KEY_DEBUGGED + KEY_SHIFTED + KEY_T:	{
+		extern int Test_begin;
+
+		if (Test_begin == 1)
+			break;
+
+		Test_begin = 1;
+		HUD_sourced_printf(HUD_SOURCE_HIDDEN, XSTR("Frame Rate test started", 23));
+
+		break;
+	}
+#endif
+	case KEY_DEBUGGED + KEY_A:	{
+
+		HUD_printf("frame rate currently is %0.2 FPS", 1 / flFrametime);
+
+		break;
+	}
+
+
+	case KEY_DEBUGGED + KEY_D:
+		extern int OO_update_index;
+
+		if (MULTIPLAYER_MASTER) {
+			do {
+				OO_update_index++;
+			} while ((OO_update_index < (MAX_PLAYERS - 1)) && !MULTI_CONNECTED(Net_players[OO_update_index]));
+			if (OO_update_index >= MAX_PLAYERS - 1) {
+				OO_update_index = -1;
+			}
+		} else {
+			if (OO_update_index < 0) {
+				OO_update_index = MY_NET_PLAYER_NUM;
+			} else {
+				OO_update_index = -1;
+			}
+		}
+		break;
+
+		// change player ship to next flyable type
+	case KEY_DEBUGGED + KEY_RIGHT:
+		debug_cycle_player_ship(1);
+		break;
+
+		// change player ship to previous flyable ship
+	case KEY_DEBUGGED + KEY_LEFT:
+		debug_cycle_player_ship(-1);
+		break;
+
+		// cycle target to ship
+	case KEY_DEBUGGED + KEY_SHIFTED + KEY_RIGHT:
+		debug_cycle_targeted_ship(1);
+		break;
+
+		// cycle target to previous ship
+	case KEY_DEBUGGED + KEY_SHIFTED + KEY_LEFT:
+		debug_cycle_targeted_ship(-1);
+		break;
+
+		// change species of the targeted ship
+	case KEY_DEBUGGED + KEY_S: {
+		if (Player_ai->target_objnum < 0)
+			break;
+
+		object		*objp;
+		ship_info	*sip;
+
+		objp = &Objects[Player_ai->target_objnum];
+		if (objp->type != OBJ_SHIP)
+			return;
+
+		sip = &Ship_info[Ships[objp->instance].ship_info_index];
+		sip->species++;
+
+		if (sip->species >= (int)Species_info.size())
+			sip->species = 0;
+
+		HUD_sourced_printf(HUD_SOURCE_HIDDEN, XSTR("Species of target changed to: %s", 24), Species_info[sip->species].species_name);
+		break;
+	}
+
+	case KEY_DEBUGGED + KEY_SHIFTED + KEY_S:
+		game_increase_skill_level();
+		HUD_sourced_printf(HUD_SOURCE_HIDDEN, XSTR("Skill level set to %s.", 25), Skill_level_names(Game_skill_level));
+		break;
+
+	case KEY_DEBUGGED + KEY_T: {
+		char buf[256];
+		event_music_get_info(buf);
+		HUD_sourced_printf(HUD_SOURCE_HIDDEN, buf);
+		break;
+	}
+
+	case KEY_DEBUGGED + KEY_UP:
+	case KEY_DEBUGGED1 + KEY_UP:
+		debug_change_song(1);
+		break;
+
+	case KEY_DEBUGGED + KEY_DOWN:
+	case KEY_DEBUGGED1 + KEY_DOWN:
+		debug_change_song(-1);
+		break;
+
+	case KEY_PADMINUS: {
+		int init_flag = 0;
+
+		if (keyd_pressed[KEY_1]) {
+			init_flag = 1;
+			HUD_color_red -= 4;
+		}
+
+		if (keyd_pressed[KEY_2]) {
+			init_flag = 1;
+			HUD_color_green -= 4;
+		}
+
+		if (keyd_pressed[KEY_3]) {
+			init_flag = 1;
+			HUD_color_blue -= 4;
+		}
+
+		if (init_flag)
+			HUD_init_colors();
+
+		break;
+	}
+
+	case KEY_DEBUGGED + KEY_Y:
+		extern int tst;
+		tst = 2;
+		break;
+
+	case KEY_PADPLUS: {
+		int init_flag = 0;
+
+		if (keyd_pressed[KEY_1]) {
+			init_flag = 1;
+			HUD_color_red += 4;
+		}
+
+		if (keyd_pressed[KEY_2]) {
+			init_flag = 1;
+			HUD_color_green += 4;
+		}
+
+		if (keyd_pressed[KEY_3]) {
+			init_flag = 1;
+			HUD_color_blue += 4;
+		}
+
+		if (init_flag)
+			HUD_init_colors();
+
+		break;
+	}
+	case KEY_DEBUGGED + KEY_ALTED + KEY_EQUAL:
+	case KEY_DEBUGGED1 + KEY_ALTED + KEY_EQUAL:
+	{
+		camera *cam = Main_camera.getCamera();
+		if (cam == NULL) {
+			HUD_sourced_printf(HUD_SOURCE_HIDDEN, "Couldn't get camera FOV");
+			break;
+		}
+		cam->set_fov(cam->get_fov() + 0.1f);
+		HUD_sourced_printf(HUD_SOURCE_HIDDEN, "Camera fov raised to %0.2f", cam->get_fov());
+	}
+	break;
+
+	case KEY_DEBUGGED + KEY_ALTED + KEY_MINUS:
+	case KEY_DEBUGGED1 + KEY_ALTED + KEY_MINUS:
+	{
+		camera *cam = Main_camera.getCamera();
+		if (cam == NULL) {
+			HUD_sourced_printf(HUD_SOURCE_HIDDEN, "Couldn't get camera FOV");
+			break;
+		}
+		cam->set_fov(cam->get_fov() - 0.1f);
+		HUD_sourced_printf(HUD_SOURCE_HIDDEN, "Camera fov lowered to %0.2f", cam->get_fov());
+	}
+	break;
+	case KEY_DEBUGGED + KEY_Z:
+	case KEY_DEBUGGED1 + KEY_Z:
+	{
+		Show_cpu = !Show_cpu;
+	}
+	break;
+
+	}	// end switch
+}
+
+void process_player_ship_keys(int k) {
+	int masked_k;
+
+	masked_k = k & ~KEY_CTRLED;	// take out CTRL modifier only	
+
+	// moved this line to beginning of function since hotkeys now encompass
+	// F5 - F12.  We can return after using F11 as a hotkey.
+	ppsk_hotkeys(masked_k);
+	if (keyd_pressed[KEY_DEBUG_KEY]) {
+		return;
+	}
+
+	// if we're in supernova mode. do nothing
+	if (Player->control_mode == PCM_SUPERNOVA) {
+		return;
+	}
+
+	// pass the key to the squadmate messaging code.  If the messaging code took the key, then return
+	// from here immediately since we don't want to do further key processing.
+	if (hud_squadmsg_read_key(k))
+		return;
+
+	if (Player->control_mode == PCM_NORMAL) {
+		//	The following things are not legal to do while dead.
+		if (!(Game_mode & GM_DEAD)) {
+			process_set_of_keys(masked_k, Normal_key_set_size, Normal_key_set);
+		} else {
+			process_set_of_keys(masked_k, Dead_key_set_size, Dead_key_set);
+		}
+		if (lua_game_control & LGC_B_POLL_ALL) {
+			// first clear all
+			button_info_clear(&Player->lua_bi_full);
+
+			// then check the keys.
+			int i;
+			for (i = 0; i < CCFG_MAX; i++) {
+				if (check_control(i, masked_k))
+					button_info_set(&Player->lua_bi_full, i);
+			}
+		}
+	} else {
+
+	}
+}
+
+void process_set_of_keys(int key, int count, int *list) {
+	int i;
+
+	for (i = 0; i<count; i++)
+		if (check_control(list[i], key))
+			button_info_set(&Player->bi, list[i]);
 }

--- a/code/io/keycontrol.cpp
+++ b/code/io/keycontrol.cpp
@@ -14,7 +14,6 @@
 #include "asteroid/asteroid.h"
 #include "autopilot/autopilot.h"
 #include "cmdline/cmdline.h"
-#include "freespace2/freespace.h"	//For time compression stuff
 #include "gamesequence/gamesequence.h"
 #include "gamesnd/eventmusic.h"
 #include "gamesnd/gamesnd.h"
@@ -59,6 +58,7 @@
 #include "starfield/supernova.h"
 #include "weapon/weapon.h"
 
+#include <freespace.h>
 
 /**
 * Natural number factor lookup class.

--- a/code/io/keycontrol.cpp
+++ b/code/io/keycontrol.cpp
@@ -1,17 +1,20 @@
 /*
  * Copyright (C) Volition, Inc. 1999.  All rights reserved.
  *
- * All source code herein is the property of Volition, Inc. You may not sell 
- * or otherwise commercially exploit the source or things you created based on the 
+ * All source code herein is the property of Volition, Inc. You may not sell
+ * or otherwise commercially exploit the source or things you created based on the
  * source.
  *
-*/ 
+ */
+
+
+
+#include "io/keycontrol.h"
 
 #include "asteroid/asteroid.h"
 #include "autopilot/autopilot.h"
 #include "cmdline/cmdline.h"
 #include "freespace2/freespace.h"	//For time compression stuff
-#include "freespace2/freespace.h"
 #include "gamesequence/gamesequence.h"
 #include "gamesnd/eventmusic.h"
 #include "gamesnd/gamesnd.h"
@@ -56,7 +59,6 @@
 #include "starfield/supernova.h"
 #include "weapon/weapon.h"
 
-#include "io/keycontrol.h"
 
 /**
 * Natural number factor lookup class.
@@ -105,15 +107,13 @@ private:
 	static bool isNaturalNumberFactor(size_t factor, size_t n);
 };
 
-factor_table::factor_table(size_t size)
-{
+factor_table::factor_table(size_t size) {
 	resize(size);
 }
 
 factor_table::~factor_table() {}
 
-size_t factor_table::getNext(size_t n, size_t current)
-{
+size_t factor_table::getNext(size_t n, size_t current) {
 	Assertion(n >= 1, "factor_table::getNext() called with " SIZE_T_ARG ", when only natural numbers make sense; get a coder!\n", n);
 
 	// Resize lookup table if the value is greater than the current size
@@ -121,17 +121,12 @@ size_t factor_table::getNext(size_t n, size_t current)
 		resize(n);
 
 	int index = n - 1;
-	for (size_t i = 0; i < _lookup[index].size(); ++i)
-	{
-		if (_lookup[index][i] == current)
-		{
-			if (_lookup[index].size() == i + 1)
-			{
+	for (size_t i = 0; i < _lookup[index].size(); ++i) {
+		if (_lookup[index][i] == current) {
+			if (_lookup[index].size() == i + 1) {
 				// Overflow back to 1
 				return 1;
-			}
-			else
-			{
+			} else {
 				// Next factor in the table
 				return _lookup[index][i + 1];
 			}
@@ -142,26 +137,21 @@ size_t factor_table::getNext(size_t n, size_t current)
 	return 1;
 }
 
-void factor_table::resize(size_t size)
-{
+void factor_table::resize(size_t size) {
 	size_t oldSize = _lookup.size();
 	_lookup.resize(size);
 
 	// Fill lookup table for the missing values
-	for (size_t i = oldSize; i < size; ++i)
-	{
-		for (size_t j = 1; j <= i + 1; ++j)
-		{
-			if (isNaturalNumberFactor(j, i + 1))
-			{
+	for (size_t i = oldSize; i < size; ++i) {
+		for (size_t j = 1; j <= i + 1; ++j) {
+			if (isNaturalNumberFactor(j, i + 1)) {
 				_lookup[i].push_back(j);
 			}
 		}
 	}
 }
 
-bool factor_table::isNaturalNumberFactor(size_t factor, size_t n)
-{
+bool factor_table::isNaturalNumberFactor(size_t factor, size_t n) {
 	return ((float)n / (float)factor) == n / factor;
 }
 
@@ -178,12 +168,10 @@ factor_table ftables;
 #define MAX_TIME_MULTIPLIER		64
 #define MAX_TIME_DIVIDER		4
 
-// --------------------------------------------------------
-// Cheats!!!!1!1
 #define CHEAT_BUFFER_LEN	17
-char CheatBuffer[CHEAT_BUFFER_LEN+1];
 
-enum cheatCode {
+enum cheatCode
+{
 	CHEAT_CODE_NONE = 0,
 	CHEAT_CODE_FREESPACE,
 	CHEAT_CODE_FISH,
@@ -193,26 +181,100 @@ enum cheatCode {
 	CHEAT_CODE_SKIP
 };
 
-struct Cheat {
+struct Cheat
+{
 	cheatCode code;
 	char* data;
 };
 
-static struct Cheat cheatsTable[] = {
-  { CHEAT_CODE_FREESPACE, "www.freespace2.com" },
-  { CHEAT_CODE_FISH,      "vasudanswuvfishes" },
-  { CHEAT_CODE_HEADZ,     "humanheadsinside." },
-  { CHEAT_CODE_TOOLED,    "tooledworkedowned" },
-  { CHEAT_CODE_PIRATE,    "arrrrwalktheplank" },
-  { CHEAT_CODE_SKIP,      "skipmemymissionyo" }
+
+// --------------------------------------------------------------------------------------------------------------------
+// Inherited members (Protected members defined in .c/.cpp's)
+// --------------------------------------------------------------------------------------------------------------------
+extern int AI_watch_object;
+
+extern int Countermeasures_enabled;
+
+extern int Framerate_delay;
+
+extern vec3d Eye_position;
+extern matrix Eye_matrix;
+
+extern int Show_cpu;
+
+// --------------------------------------------------------------------------------------------------------------------
+// Public members (Declared as extern in .h)
+// --------------------------------------------------------------------------------------------------------------------
+int Dead_key_set[] = {
+	TARGET_NEXT,
+	TARGET_PREV,
+	TARGET_NEXT_CLOSEST_HOSTILE,
+	TARGET_PREV_CLOSEST_HOSTILE,
+	TARGET_NEXT_CLOSEST_FRIENDLY,
+	TARGET_PREV_CLOSEST_FRIENDLY,
+	TARGET_TARGETS_TARGET,
+	TARGET_CLOSEST_SHIP_ATTACKING_TARGET,
+	STOP_TARGETING_SHIP,
+	TOGGLE_AUTO_TARGETING,
+	TARGET_SUBOBJECT_IN_RETICLE,
+	TARGET_PREV_SUBOBJECT,
+	TARGET_NEXT_SUBOBJECT,
+	STOP_TARGETING_SUBSYSTEM,
+	TARGET_NEWEST_SHIP,
+	TARGET_NEXT_LIVE_TURRET,
+	TARGET_PREV_LIVE_TURRET,
+	TARGET_NEXT_BOMB,
+	TARGET_PREV_BOMB,
+
+	VIEW_CHASE,
+	VIEW_OTHER_SHIP,
+	VIEW_TOPDOWN,
+
+	SHOW_GOALS,
+
+	ADD_REMOVE_ESCORT,
+	ESCORT_CLEAR,
+	TARGET_NEXT_ESCORT_SHIP,
+	TARGET_CLOSEST_REPAIR_SHIP,
+
+	MULTI_MESSAGE_ALL,
+	MULTI_MESSAGE_FRIENDLY,
+	MULTI_MESSAGE_HOSTILE,
+	MULTI_MESSAGE_TARGET,
+	MULTI_OBSERVER_ZOOM_TO,
+
+	TIME_SPEED_UP,
+	TIME_SLOW_DOWN
 };
 
+const int Dead_key_set_size = sizeof(Dead_key_set) / sizeof(int);
+
+int Ignored_keys[CCFG_MAX];
+
+bool Perspective_locked = false;
+bool quit_mission_popup_shown = false;
+
+
+// --------------------------------------------------------------------------------------------------------------------
+// Protected members (extern'd in other .c/.cpp files)
+// --------------------------------------------------------------------------------------------------------------------
+int Tool_enabled = 0;
+
+
+// --------------------------------------------------------------------------------------------------------------------
+// Private members (declared as static)
+// --------------------------------------------------------------------------------------------------------------------
+static const struct Cheat cheatsTable[] = {
+	{ CHEAT_CODE_FREESPACE, "www.freespace2.com" },
+	{ CHEAT_CODE_FISH, "vasudanswuvfishes" },
+	{ CHEAT_CODE_HEADZ, "humanheadsinside." },
+	{ CHEAT_CODE_TOOLED, "tooledworkedowned" },
+	{ CHEAT_CODE_PIRATE, "arrrrwalktheplank" },
+	{ CHEAT_CODE_SKIP, "skipmemymissionyo" }
+};
 #define CHEATS_TABLE_LEN	6
 
-// End Cheats
-// --------------------------------------------------------
-
-int Normal_key_set[] = {
+static int Normal_key_set[] = {
 	TARGET_NEXT,
 	TARGET_PREV,
 	TARGET_NEXT_CLOSEST_HOSTILE,
@@ -325,49 +387,7 @@ int Normal_key_set[] = {
 	CYCLE_PRIMARY_WEAPON_SEQUENCE
 };
 
-int Dead_key_set[] = {
-	TARGET_NEXT,
-	TARGET_PREV,
-	TARGET_NEXT_CLOSEST_HOSTILE,
-	TARGET_PREV_CLOSEST_HOSTILE,
-	TARGET_NEXT_CLOSEST_FRIENDLY,
-	TARGET_PREV_CLOSEST_FRIENDLY,
-	TARGET_TARGETS_TARGET,
-	TARGET_CLOSEST_SHIP_ATTACKING_TARGET,
-	STOP_TARGETING_SHIP,
-	TOGGLE_AUTO_TARGETING,
-	TARGET_SUBOBJECT_IN_RETICLE,
-	TARGET_PREV_SUBOBJECT,
-	TARGET_NEXT_SUBOBJECT,
-	STOP_TARGETING_SUBSYSTEM,
-	TARGET_NEWEST_SHIP,
-	TARGET_NEXT_LIVE_TURRET,
-	TARGET_PREV_LIVE_TURRET,
-	TARGET_NEXT_BOMB,
-	TARGET_PREV_BOMB,
-
-	VIEW_CHASE,
-	VIEW_OTHER_SHIP,
-	VIEW_TOPDOWN,
-
-	SHOW_GOALS,
-
-	ADD_REMOVE_ESCORT,
-	ESCORT_CLEAR,
-	TARGET_NEXT_ESCORT_SHIP,
-	TARGET_CLOSEST_REPAIR_SHIP,	
-
-	MULTI_MESSAGE_ALL,
-	MULTI_MESSAGE_FRIENDLY,
-	MULTI_MESSAGE_HOSTILE,
-	MULTI_MESSAGE_TARGET,
-	MULTI_OBSERVER_ZOOM_TO,
-
-	TIME_SPEED_UP,
-	TIME_SLOW_DOWN
-};
-
-int Critical_key_set[] = {
+static int Critical_key_set[] = {
 	CYCLE_NEXT_PRIMARY,
 	CYCLE_PREV_PRIMARY,
 	CYCLE_SECONDARY,
@@ -388,7 +408,7 @@ int Critical_key_set[] = {
 	XFER_LASER,
 };
 
-int Non_critical_key_set[] = {
+static int Non_critical_key_set[] = {
 	MATCH_TARGET_SPEED,
 	TOGGLE_AUTO_MATCH_TARGET_SPEED,
 	TARGET_NEXT,
@@ -460,38 +480,16 @@ int Non_critical_key_set[] = {
 	CYCLE_PRIMARY_WEAPON_SEQUENCE
 };
 
+static const int Normal_key_set_size = sizeof(Normal_key_set) / sizeof(int);
+static const int Critical_key_set_size = sizeof(Critical_key_set) / sizeof(int);
+static const int Non_critical_key_set_size = sizeof(Non_critical_key_set) / sizeof(int);
 
-// Inherited members
-extern int AI_watch_object;
-
-extern int Countermeasures_enabled;
-
-extern int Framerate_delay;
-
-extern vec3d Eye_position;
-extern matrix Eye_matrix;
-
-extern int Show_cpu;
+char CheatBuffer[CHEAT_BUFFER_LEN + 1];
 
 
-// Public members
-int Ignored_keys[CCFG_MAX];
-
-bool Perspective_locked = false;
-bool quit_mission_popup_shown = false;
-
-int Normal_key_set_size = sizeof(Normal_key_set) / sizeof(int);
-int Dead_key_set_size = sizeof(Dead_key_set) / sizeof(int);
-
-
-// Private members
-int Tool_enabled = 0;
-
-int Critical_key_set_size = sizeof(Critical_key_set) / sizeof(int);
-int Non_critical_key_set_size = sizeof(Non_critical_key_set) / sizeof(int);
-
-
-// Inherited/Friended/Referenced methods
+// --------------------------------------------------------------------------------------------------------------------
+// Inherited/Friended methods
+// --------------------------------------------------------------------------------------------------------------------
 extern void hud_target_asteroid();
 
 extern void g3_set_view_matrix(const vec3d *view_pos, const matrix *view_matrix, float zoom);
@@ -503,13 +501,8 @@ extern float do_subobj_hit_stuff(object *ship_obj, object *other_obj, vec3d *hit
 extern void mission_goal_mark_all_true(int type);
 
 // --------------------------------------------------------------------------------------------------------------------
-// Declaration of private functions(declared as static type func(type param);)
+// Declaration of protected functions.
 // --------------------------------------------------------------------------------------------------------------------
-/**
- * @brief Handler for when player hits 'ESC' during the game
- */
-void game_do_end_mission_popup();
-
 /**
  * @brief Processes cheat codes
  */
@@ -519,16 +512,6 @@ void game_process_cheats(int k);
  * @brief Processes all keys pressed since last frame
  */
 void game_process_keys();
-
-/**
- * @brief Gets the index of the next weapon type. Loops around
- */
-int get_next_weapon_looped(int current_weapon, int subtype);
-
-/**
- * @brief Gets the index of the previous weapon type. Loops around
- */
-int get_prev_weapon_looped(int current_weapon, int subtype);
 
 /**
  * @brief Execute function corresponding to action n
@@ -563,10 +546,28 @@ int button_function_critical(int n, net_player *p = NULL);
 int button_function_demo_valid(int n);
 
 
+// --------------------------------------------------------------------------------------------------------------------
+// Declaration of private functions(declared as static type func(type param);)
+// --------------------------------------------------------------------------------------------------------------------
+/**
+ * @brief Handler for when player hits 'ESC' during the game
+ */
+static void game_do_end_mission_popup();
+
+/**
+ * @brief Gets the index of the next weapon type. Loops around
+ */
+static int get_next_weapon_looped(int current_weapon, int subtype);
+
+/**
+ * @brief Gets the index of the previous weapon type. Loops around
+ */
+static int get_prev_weapon_looped(int current_weapon, int subtype);
+
 /**
  * @brief Returns true if the given action is a targeting control
  */
-bool key_is_targeting(int n);
+static bool key_is_targeting(int n);
 
 /**
  * @brief If the given key is a hotkey, do the corresponding action
@@ -576,56 +577,56 @@ bool key_is_targeting(int n);
  * @details Pre-Process Special Key? This is called within process_player_ship_keys before it checks the other actions
  *   for a match
  */
-void ppsk_hotkeys(int k);
+static void ppsk_hotkeys(int k);
 
 /**
  * @brief If the given key is tied to a hardcoded debug action, do the corresponding action
  *
  * @param[in] k The key to check
  */
-void process_debug_keys(int k);
+static void process_debug_keys(int k);
 
 /**
  * @brief If the given keys is used for player ship stuff (*not* ship movement), do the corresponding action
  *
  * @param[in] k The key to check
  */
-void process_player_ship_keys(int k);
+static void process_player_ship_keys(int k);
 
 /**
  * @brief DEBUG: Changes the currently playing soundtrack. Maybe.
  *
  * @param[in] delta Not used
  */
-void debug_change_song(int delta);
+static void debug_change_song(int delta);
 
 /**
  * @brief DEBUG: Cycle the player's ship to the next ship in its species
  *
  * @param[in] delta Number of ships to skip. Ex: +1 uses the next ship, -1 uses previous, +2 uses the 2nd next, etc.
  */
-void debug_cycle_player_ship(int delta);
+static void debug_cycle_player_ship(int delta);
 
 /**
  * @brief DEBUG: Cycle the targeted ship to the next ship in its species
  *
  * @param[in] delta Number of ships to skip. Ex: +1 uses the next ship, -1 uses previous, +2 uses the 2nd next, etc.
  */
-void debug_cycle_targeted_ship(int delta);
+static void debug_cycle_targeted_ship(int delta);
 
 /**
  * @brief DEBUG: Refills ammo for ballistic primaries for the given obj
  *
  * @param[in] delta
  */
-void debug_max_primary_weapons(object *objp);
+static void debug_max_primary_weapons(object *objp);
 
 /**
  * @brief DEBUG: Refills secondary ammo for the given obj
  *
  * @param[in] delta
  */
-void debug_max_secondary_weapons(object *objp);
+static void debug_max_secondary_weapons(object *objp);
 
 
 // --------------------------------------------------------------------------------------------------------------------
@@ -1686,26 +1687,25 @@ int button_function_demo_valid(int n) {
 void button_info_clear(button_info *bi) {
 	int i;
 
-	for (i = 0; i<NUM_BUTTON_FIELDS; i++) {
+	for (i = 0; i < NUM_BUTTON_FIELDS; i++) {
 		bi->status[i] = 0;
 	}
 }
 
-void button_info_do(button_info *bi)
-{
+void button_info_do(button_info *bi) {
 	for (int i = 0; i < CCFG_MAX; i++) {
-		if( button_info_query(bi, i) ) {
+		if (button_info_query(bi, i)) {
 			int keyHasBeenUsed = FALSE;
-			
-			if( !keyHasBeenUsed ) {
+
+			if (!keyHasBeenUsed) {
 				keyHasBeenUsed = button_function_demo_valid(i);
 			}
-			
-			if( !keyHasBeenUsed ) {
+
+			if (!keyHasBeenUsed) {
 				keyHasBeenUsed = button_function(i);
 			}
-			
-			if( keyHasBeenUsed ) {
+
+			if (keyHasBeenUsed) {
 				button_info_unset(bi, i);
 			}
 		}
@@ -1716,37 +1716,34 @@ bool button_info_query(button_info *bi, int n) {
 	return bi->status[n / 32] & (1 << (n % 32));
 }
 
-void button_info_set(button_info *bi, int n)
-{
+void button_info_set(button_info *bi, int n) {
 	int field_num, bit_num;
-	
+
 	field_num = n / 32;
 	bit_num = n % 32;
 
-	bi->status[field_num] |= (1 << bit_num);	
+	bi->status[field_num] |= (1 << bit_num);
 }
 
-void button_info_unset(button_info *bi, int n)
-{
+void button_info_unset(button_info *bi, int n) {
 	int field_num, bit_num;
-	
+
 	field_num = n / 32;
 	bit_num = n % 32;
 
-	bi->status[field_num] &= ~(1 << bit_num);	
+	bi->status[field_num] &= ~(1 << bit_num);
 }
 
-void button_strip_noncritical_keys(button_info *bi)
-{
+void button_strip_noncritical_keys(button_info *bi) {
 	int idx;
 
 	// clear out all noncritical keys
-	for(idx=0;idx<Non_critical_key_set_size;idx++){
-		button_info_unset(bi,Non_critical_key_set[idx]);
+	for (idx = 0; idx < Non_critical_key_set_size; idx++) {
+		button_info_unset(bi, Non_critical_key_set[idx]);
 	}
 }
 
-void debug_change_song(int delta) {
+static void debug_change_song(int delta) {
 	char buf[256];
 	if (event_music_next_soundtrack(delta) != -1) {
 		event_music_get_soundtrack_name(buf);
@@ -1757,7 +1754,7 @@ void debug_change_song(int delta) {
 	}
 }
 
-void debug_cycle_player_ship(int delta) {
+static void debug_cycle_player_ship(int delta) {
 	if (Player_obj == NULL)
 		return;
 
@@ -1788,7 +1785,7 @@ void debug_cycle_player_ship(int delta) {
 	HUD_sourced_printf(HUD_SOURCE_HIDDEN, XSTR("Player ship changed to %s", 0), Ship_info[si_index].name);
 }
 
-void debug_cycle_targeted_ship(int delta) {
+static void debug_cycle_targeted_ship(int delta) {
 	object		*objp;
 	ship_info	*sip;
 	int			si_index, species;
@@ -1836,7 +1833,7 @@ void debug_cycle_targeted_ship(int delta) {
 	HUD_sourced_printf(HUD_SOURCE_HIDDEN, XSTR("Changed player target to %s", 1), Ship_info[si_index].name);
 }
 
-void debug_max_primary_weapons(object *objp)	// Goober5000
+static void debug_max_primary_weapons(object *objp)	// Goober5000
 {
 	Assert(objp);	// Goober5000
 
@@ -1859,7 +1856,7 @@ void debug_max_primary_weapons(object *objp)	// Goober5000
 	}
 }
 
-void debug_max_secondary_weapons(object *objp) {
+static void debug_max_secondary_weapons(object *objp) {
 	int index;
 	ship *shipp = &Ships[objp->instance];
 	ship_info *sip = &Ship_info[shipp->ship_info_index];
@@ -1870,7 +1867,7 @@ void debug_max_secondary_weapons(object *objp) {
 	}
 }
 
-void game_do_end_mission_popup() {
+static void game_do_end_mission_popup() {
 	int	pf_flags, choice;
 
 	// do the multiplayer version of this
@@ -2120,7 +2117,7 @@ void game_process_keys() {
 	} else if (lua_game_control & LGC_B_ADDITIVE) {
 		// add the lua commands to current commands 
 		int i;
-		for (i = 0; i<NUM_BUTTON_FIELDS; i++)
+		for (i = 0; i < NUM_BUTTON_FIELDS; i++)
 			Player->bi.status[i] |= Player->lua_bi.status[i];
 		Player->lua_bi = Player->bi;
 	} else {
@@ -2147,7 +2144,7 @@ void game_process_pause_key() {
 	}
 }
 
-int get_next_weapon_looped(int current_weapon, int subtype) {
+static int get_next_weapon_looped(int current_weapon, int subtype) {
 	int i, new_index;
 
 	for (i = 1; i < Num_weapon_types; i++) {
@@ -2161,7 +2158,7 @@ int get_next_weapon_looped(int current_weapon, int subtype) {
 	return current_weapon;
 }
 
-int get_prev_weapon_looped(int current_weapon, int subtype) {
+static int get_prev_weapon_looped(int current_weapon, int subtype) {
 	int i, new_index;
 
 	for (i = 1; i < Num_weapon_types; i++) {
@@ -2175,7 +2172,7 @@ int get_prev_weapon_looped(int current_weapon, int subtype) {
 	return current_weapon;
 }
 
-bool key_is_targeting(int n) {
+static bool key_is_targeting(int n) {
 	switch (n) {
 	case TARGET_NEXT:
 	case TARGET_PREV:
@@ -2198,7 +2195,7 @@ bool key_is_targeting(int n) {
 	}
 }
 
-void ppsk_hotkeys(int k) {
+static void ppsk_hotkeys(int k) {
 	// use k to check for keys that can have Shift,Ctrl,Alt,Del status
 	int hotkey_set;
 
@@ -2270,7 +2267,7 @@ void ppsk_hotkeys(int k) {
 	}	// end switch
 }
 
-void process_debug_keys(int k) {
+static void process_debug_keys(int k) {
 	// Kazan -- NO CHEATS IN MULTI
 	if (Game_mode & GM_MULTIPLAYER) {
 		Cheats_enabled = 0;
@@ -2886,7 +2883,7 @@ void process_debug_keys(int k) {
 	}	// end switch
 }
 
-void process_player_ship_keys(int k) {
+static void process_player_ship_keys(int k) {
 	int masked_k;
 
 	masked_k = k & ~KEY_CTRLED;	// take out CTRL modifier only	
@@ -2934,7 +2931,7 @@ void process_player_ship_keys(int k) {
 void process_set_of_keys(int key, int count, int *list) {
 	int i;
 
-	for (i = 0; i<count; i++)
+	for (i = 0; i < count; i++)
 		if (check_control(list[i], key))
 			button_info_set(&Player->bi, list[i]);
 }

--- a/code/io/keycontrol.h
+++ b/code/io/keycontrol.h
@@ -14,29 +14,81 @@
 
 #include "controlconfig/controlsconfig.h"
 
-// Holds the bit arrays that indicate which action is to be executed.
+/**
+ * @brief Number of int32_t's in button_info's status[]
+ *
+ * @details Since CCFG_MAX is garunteed to be a value of at least 1, add 31 to ensure a minimum of 1x int32_t
+ */
 #define NUM_BUTTON_FIELDS	((CCFG_MAX + 31) / 32)
 
-extern int Dead_key_set[];
-extern int Dead_key_set_size;
-extern bool Perspective_locked;
+extern int Dead_key_set[];      //!< Set of controls available while dead
+extern int Dead_key_set_size;   //!< Dead_key_set.size()
+extern bool Perspective_locked; //!< If true, prevent the player from being able to switch perspectives (such as between 3rd person and cockpit)
 
-extern int Ignored_keys[];
+extern int Ignored_keys[];      //!< Set of controls that are ignored. Counter based. 0 Means don't ignore this control
 
-extern bool quit_mission_popup_shown;
+extern bool quit_mission_popup_shown;   //!< True if the "Quit Mission" popup is visible/in focus
 
+/**
+ * @brief Structure containing the activation status of all controls
+ *
+ * @details Basically a bitset. Active controls have set bits and inactive controls have cleared bits.
+ */
 typedef struct button_info
 {
 	int status[NUM_BUTTON_FIELDS];
 } button_info;
 
+/**
+ * @brief Set the bit in button_info for the given IoActionId
+ *
+ * @param[in] n The IoActionId
+ */
 void button_info_set(button_info *bi, int n);
+
+/**
+ * @brief Clear the bit in button_info for the given IoActionId
+ *
+ * @param[in] n The IoActionId
+ */
 void button_info_unset(button_info *bi, int n);
-int button_info_query(button_info *bi, int n);
+
+/**
+ * @brief Returns the state of the associated IoActionId bit in button_info
+ *
+ * @param[in] n The IoActionId
+ */
+bool button_info_query(button_info *bi, int n);
+
+/**
+ * @brief Calls the event handlers for each active button in button_info
+ */
 void button_info_do(button_info *bi);
+
+/**
+ * @brief Clears the entire button_info struct
+ */
 void button_info_clear(button_info *bi);
+
+/**
+ * @brief Marks the key/button in the player's button_info if it is in the given control list
+ *
+ * @param[in] key   Scancode (plus modifiers)
+ * @param[in] count Total size of the list
+ * @param[in] list  List of ::Control_config struct action indices to check for
+ *
+ * @details Also checks joystick controls in the set.
+ */
 void process_set_of_keys(int key, int count, int *list);
+
+/**
+ * @brief Handle pause keypress
+ */
 void game_process_pause_key();
+
+/**
+ * @brief Strip out all noncritical keys from the ::button_info struct
+ */
 void button_strip_noncritical_keys(button_info *bi);
 
 

--- a/code/io/keycontrol.h
+++ b/code/io/keycontrol.h
@@ -22,10 +22,10 @@
 #define NUM_BUTTON_FIELDS	((CCFG_MAX + 31) / 32)
 
 extern int Dead_key_set[];      //!< Set of controls available while dead
-extern int Dead_key_set_size;   //!< Dead_key_set.size()
+extern const int Dead_key_set_size;   //!< Dead_key_set.size()
 extern bool Perspective_locked; //!< If true, prevent the player from being able to switch perspectives (such as between 3rd person and cockpit)
 
-extern int Ignored_keys[];      //!< Set of controls that are ignored. Counter based. 0 Means don't ignore this control
+extern int Ignored_keys[CCFG_MAX];      //!< Set of controls that are ignored. Counter based. 0 Means don't ignore this control
 
 extern bool quit_mission_popup_shown;   //!< True if the "Quit Mission" popup is visible/in focus
 

--- a/code/io/mouse.cpp
+++ b/code/io/mouse.cpp
@@ -131,20 +131,23 @@ static void mousewheel_decay(int btn);
 
 
 static void mousewheel_decay(int btn) {
-	switch (btn) {
-	case MOUSE_WHEEL_UP:
+	// btn may have multiple flags active, so can't use a simple switch here
+
+	if (btn & MOUSE_WHEEL_UP) {
 		Mouse_wheel_y -= 1;
-		break;
-	case MOUSE_WHEEL_DOWN:
+
+	} else if (btn & MOUSE_WHEEL_DOWN) {
 		Mouse_wheel_y += 1;
-		break;
-	case MOUSE_WHEEL_LEFT:
-		Mouse_wheel_x -= 1;
-		break;
-	case MOUSE_WHEEL_RIGHT:
-		Mouse_wheel_x += 1;
-		break;
 	}
+
+
+	if (btn & MOUSE_WHEEL_LEFT) {
+		Mouse_wheel_x -= 1;
+	
+	} else if (btn & MOUSE_WHEEL_RIGHT) {
+		Mouse_wheel_x += 1;
+	}
+
 
 	if (Mouse_wheel_x == 0) {
 		mouse_flags &= ~(MOUSE_WHEEL_UP | MOUSE_WHEEL_DOWN);

--- a/code/io/mouse.cpp
+++ b/code/io/mouse.cpp
@@ -27,36 +27,38 @@
 
 int mouse_inited = 0;
 
-static int Mouse_x;
-static int Mouse_y;
-
-static int Mouse_wheel_x;
-static int Mouse_wheel_y;
+int Mouse_sensitivity = 4;
+int Use_mouse_to_fly = 0;
 
 SDL_mutex* mouse_lock;
 
-int mouse_flags;
-int mouse_left_pressed = 0;
-int mouse_right_pressed = 0;
-int mouse_middle_pressed = 0;
-int mouse_x1_pressed = 0;
-int mouse_x2_pressed = 0;
-int mouse_left_up = 0;
-int mouse_right_up = 0;
-int mouse_middle_up = 0;
-int mouse_x1_up = 0;
-int mouse_x2_up = 0;
+
+// Mouse axes
+static int Mouse_x;
+static int Mouse_y;
 
 static int Mouse_dx = 0;
 static int Mouse_dy = 0;
-static int Mouse_dz = 0;
 
 static int Last_mouse_dx = 0;
 static int Last_mouse_dy = 0;
-static int Last_mouse_dz = 0;
 
-int Mouse_sensitivity = 4;
-int Use_mouse_to_fly = 0;
+// Mousewheel axes
+static int Mouse_wheel_x;
+static int Mouse_wheel_y;
+
+// Mouse button states
+static int mouse_flags;
+static int mouse_left_pressed = 0;
+static int mouse_right_pressed = 0;
+static int mouse_middle_pressed = 0;
+static int mouse_x1_pressed = 0;
+static int mouse_x2_pressed = 0;
+static int mouse_left_up = 0;
+static int mouse_right_up = 0;
+static int mouse_middle_up = 0;
+static int mouse_x1_up = 0;
+static int mouse_x2_up = 0;
 
 static bool Mouse_in_focus = true;
 namespace
@@ -105,6 +107,7 @@ namespace
 }
 
 void mouse_force_pos(int x, int y);
+
 
 /**
  * @brief Handler called by OS on shutdown
@@ -320,7 +323,7 @@ void mouse_flush() {
 		return;
 
 	mouse_reset_deltas();
-	Mouse_dx = Mouse_dy = Mouse_dz = 0;
+	Mouse_dx = Mouse_dy = 0;
 	Mouse_wheel_x = Mouse_wheel_y = 0;
 	SDL_LockMutex(mouse_lock);
 	mouse_left_pressed = 0;
@@ -338,13 +341,11 @@ void mouse_force_pos(int x, int y) {
 	}
 }
 
-void mouse_get_delta(int *dx, int *dy, int *dz) {
+void mouse_get_delta(int *dx, int *dy) {
 	if (dx)
 		*dx = Mouse_dx;
 	if (dy)
 		*dy = Mouse_dy;
-	if (dz)
-		*dz = Mouse_dz;
 }
 
 int mouse_get_pos(int *xpos, int *ypos) {
@@ -538,9 +539,8 @@ void mouse_mark_button(uint flags, int set) {
 void mouse_reset_deltas() {
 	Last_mouse_dx = Mouse_dx;
 	Last_mouse_dy = Mouse_dy;
-	Last_mouse_dz = Mouse_dz;
 
-	Mouse_dx = Mouse_dy = Mouse_dz = 0;
+	Mouse_dx = Mouse_dy = 0;
 }
 
 void mouse_set_pos(int xpos, int ypos) {

--- a/code/io/mouse.cpp
+++ b/code/io/mouse.cpp
@@ -5,32 +5,33 @@
  * or otherwise commercially exploit the source or things you created based on the
  * source.
  *
-*/
+ */
 
 
+
+#include "io/mouse.h"
+
+#include "cmdline/cmdline.h"
+#include "gamesequence/gamesequence.h"
+#include "graphics/2d.h"
+#include "parse/scripting.h"
+
+#define THREADED	// to use the proper set of macros
+#include "osapi/osapi.h"
 
 #ifdef _WIN32
 #include <windows.h>
 #include <windowsx.h>
 #endif
 
-#include "io/mouse.h"
-#include "graphics/2d.h"
-#include "parse/scripting.h"
-
-#define THREADED	// to use the proper set of macros
-#include "osapi/osapi.h"
-#include "cmdline/cmdline.h"
-
-#include "gamesequence/gamesequence.h"
 
 int mouse_inited = 0;
 
-LOCAL int Mouse_x;
-LOCAL int Mouse_y;
+static int Mouse_x;
+static int Mouse_y;
 
-LOCAL int Mouse_wheel_x;
-LOCAL int Mouse_wheel_y;
+static int Mouse_wheel_x;
+static int Mouse_wheel_y;
 
 SDL_mutex* mouse_lock;
 
@@ -46,17 +47,18 @@ int mouse_middle_up = 0;
 int mouse_x1_up = 0;
 int mouse_x2_up = 0;
 
-int Mouse_dx = 0;
-int Mouse_dy = 0;
-int Mouse_dz = 0;
+static int Mouse_dx = 0;
+static int Mouse_dy = 0;
+static int Mouse_dz = 0;
 
-int Last_mouse_dx = 0;
-int Last_mouse_dy = 0;
-int Last_mouse_dz = 0;
+static int Last_mouse_dx = 0;
+static int Last_mouse_dy = 0;
+static int Last_mouse_dz = 0;
 
 int Mouse_sensitivity = 4;
 int Use_mouse_to_fly = 0;
 
+static bool Mouse_in_focus = true;
 namespace
 {
 	bool mouse_key_event_handler(const SDL_Event& e)
@@ -105,463 +107,58 @@ namespace
 void mouse_force_pos(int x, int y);
 
 /**
- * @brief Decays the mousewheel position back to 0 and clears the appropriate flags when nuetral
+ * @brief Handler called by OS on shutdown
+ */
+void mouse_close();
+
+/**
+* @brief Forces the mouse position to the given coordinates, if we have focus
+*
+* @param[in] x The new X position
+* @param[in] y The new Y position
+*/
+void mouse_force_pos(int x, int y);
+
+/**
+ * @brief Decays the mousewheel position back to 0 and clears the appropriate flags when centered
+ *
  * @param[in] btn The button (wheel direction) to check against
  */
-void mousewheel_decay(int btn);
-
-static bool Mouse_in_focus = true;
-
-void mouse_got_focus()
-{
-    if ( !mouse_inited ) return;
-
-    Mouse_in_focus = true;
-
-    mouse_flush();
-}
-
-void mouse_lost_focus()
-{
-    if ( !mouse_inited ) return;
-
-    Mouse_in_focus = false;
-
-    mouse_flush();
-}
-
-void mouse_close()
-{
-	if (!mouse_inited)
-		return;
+static void mousewheel_decay(int btn);
 
 
-	mouse_inited = 0;
-
-	SDL_DestroyMutex( mouse_lock );
-}
-
-void mouse_init()
-{
-	// Initialize queue
-	if ( mouse_inited ) return;
-	mouse_inited = 1;
-
-	mouse_lock = SDL_CreateMutex();
-
-	SDL_LockMutex( mouse_lock );
-
-	mouse_flags = 0;
-	Mouse_x = gr_screen.max_w / 2;
-	Mouse_y = gr_screen.max_h / 2;
-	Mouse_wheel_x = 0;
-	Mouse_wheel_y = 0;
-
-	// we do want to make sure that button presses go through event polling though
-	// (should be on by default already, just here as a reminder)
-	SDL_EventState( SDL_MOUSEBUTTONDOWN, SDL_ENABLE );
-	SDL_EventState( SDL_MOUSEBUTTONUP, SDL_ENABLE );
-	SDL_EventState( SDL_MOUSEWHEEL, SDL_ENABLE );
-
-	SDL_UnlockMutex( mouse_lock );
-
-	os::events::addEventListener(SDL_MOUSEBUTTONDOWN, os::events::DEFAULT_LISTENER_WEIGHT, mouse_key_event_handler);
-	os::events::addEventListener(SDL_MOUSEBUTTONUP, os::events::DEFAULT_LISTENER_WEIGHT, mouse_key_event_handler);
-
-	os::events::addEventListener(SDL_MOUSEMOTION, os::events::DEFAULT_LISTENER_WEIGHT, mouse_motion_event_handler);
-
-	os::events::addEventListener(SDL_MOUSEWHEEL, os::events::DEFAULT_LISTENER_WEIGHT, mouse_wheel_event_handler);
-
-	atexit( mouse_close );
-}
-
-
-/******************************************************************************
- * @brief Marks a mouse button as up or down
- *
- * @param[in] flags Which button(s) are pressed/released
- * @param[in] set   Direction of the button(s). 1 = pressed, 0 = released
- *
- * @note This function is extern'ed by osapi.cpp and freespace.cpp
- */
-void mouse_mark_button( uint flags, int set)
-{
-	if ( !mouse_inited ) return;
-
-	SDL_LockMutex( mouse_lock );
-
-	if ( !(mouse_flags & MOUSE_LEFT_BUTTON) )	{
-
-		if ( (flags & MOUSE_LEFT_BUTTON) && (set == 1) ) {
-			mouse_left_pressed++;
-		}
-	}
-	else {
-		if ( (flags & MOUSE_LEFT_BUTTON) && (set == 0) ){
-			mouse_left_up++;
-		}
+static void mousewheel_decay(int btn) {
+	switch (btn) {
+	case MOUSE_WHEEL_UP:
+		Mouse_wheel_y -= 1;
+		break;
+	case MOUSE_WHEEL_DOWN:
+		Mouse_wheel_y += 1;
+		break;
+	case MOUSE_WHEEL_LEFT:
+		Mouse_wheel_x -= 1;
+		break;
+	case MOUSE_WHEEL_RIGHT:
+		Mouse_wheel_x += 1;
+		break;
 	}
 
-	if ( !(mouse_flags & MOUSE_RIGHT_BUTTON) )	{
-
-		if ( (flags & MOUSE_RIGHT_BUTTON) && (set == 1) ){
-			mouse_right_pressed++;
-		}
+	if (Mouse_wheel_x == 0) {
+		mouse_flags &= ~(MOUSE_WHEEL_UP | MOUSE_WHEEL_DOWN);
 	}
-	else {
-		if ( (flags & MOUSE_RIGHT_BUTTON) && (set == 0) ){
-			mouse_right_up++;
-		}
-	}
-
-	if ( !(mouse_flags & MOUSE_MIDDLE_BUTTON) )	{
-
-		if ( (flags & MOUSE_MIDDLE_BUTTON) && (set == 1) ){
-			mouse_middle_pressed++;
-		}
-	}
-	else {
-		if ( (flags & MOUSE_MIDDLE_BUTTON) && (set == 0) ){
-			mouse_middle_up++;
-		}
-	}
-
-	if (!(mouse_flags & MOUSE_X1_BUTTON)) {
-
-		if ((flags & MOUSE_X1_BUTTON) && (set == 1)) {
-			mouse_x1_pressed++;
-		}
-	} else {
-		if ((flags & MOUSE_X1_BUTTON) && (set == 0)) {
-			mouse_x1_up++;
-		}
-	}
-
-	if (!(mouse_flags & MOUSE_X2_BUTTON)) {
-
-		if ((flags & MOUSE_X2_BUTTON) && (set == 1)) {
-			mouse_x2_pressed++;
-		}
-	} else {
-		if ((flags & MOUSE_X2_BUTTON) && (set == 0)) {
-			mouse_x2_up++;
-		}
-	}
-
-	if ( set ){
-		mouse_flags |= flags;
-	} else {
-		mouse_flags &= ~flags;
-	}
-
-	SDL_UnlockMutex( mouse_lock );
-
-	Script_system.SetHookVar("MouseButton", 'i', &flags);
-
-	//WMC - On Mouse Pressed and On Mouse Released hooks
-	if (set == 1)
-	{
-		Script_system.RunCondition(CHA_MOUSEPRESSED);
-	}
-	else if (set == 0)
-	{
-		Script_system.RunCondition(CHA_MOUSERELEASED);
-	}
-
-	Script_system.RemHookVar("MouseButton");
-}
-
-void mouse_flush()
-{
-	if (!mouse_inited)
-		return;
-
-	mouse_reset_deltas();
-	Mouse_dx = Mouse_dy = Mouse_dz = 0;
-	Mouse_wheel_x = Mouse_wheel_y = 0;
-	SDL_LockMutex( mouse_lock );
-	mouse_left_pressed = 0;
-	mouse_right_pressed = 0;
-	mouse_middle_pressed = 0;
-	mouse_x1_pressed = 0;
-	mouse_x2_pressed = 0;
-	mouse_flags = 0;
-	SDL_UnlockMutex( mouse_lock );
-}
-
-int mouse_down_count(int n, int reset_count)
-{
-	int tmp = 0;
-	if ( !mouse_inited ) return 0;
-
-	if ( (n < LOWEST_MOUSE_BUTTON) || (n > HIGHEST_MOUSE_BUTTON)) return 0;
-
-	SDL_LockMutex( mouse_lock );
-
-	switch (n) {
-		case MOUSE_LEFT_BUTTON:
-			tmp = mouse_left_pressed;
-			if ( reset_count ) {
-				mouse_left_pressed = 0;
-			}
-			break;
-
-		case MOUSE_RIGHT_BUTTON:
-			tmp = mouse_right_pressed;
-			if ( reset_count ) {
-				mouse_right_pressed = 0;
-			}
-			break;
-
-		case MOUSE_MIDDLE_BUTTON:
-			tmp = mouse_middle_pressed;
-			if ( reset_count ) {
-				mouse_middle_pressed = 0;
-			}
-			break;
-
-		case MOUSE_X1_BUTTON:
-			tmp = mouse_x1_pressed;
-			if (reset_count) {
-				mouse_x1_pressed = 0;
-			}
-			break;
-
-		case MOUSE_X2_BUTTON:
-			tmp = mouse_x2_pressed;
-			if (reset_count) {
-				mouse_x2_pressed = 0;
-			}
-			break;
-	} // end switch
-
-	SDL_UnlockMutex( mouse_lock );
-
-	return tmp;
-}
-
-// mouse_up_count() returns the number of times button n has gone from down to up
-// since the last call
-//
-// parameters:  n - button of mouse (see #define's in mouse.h)
-//
-int mouse_up_count(int n)
-{
-	int tmp = 0;
-	if ( !mouse_inited ) return 0;
-
-	if ( (n < LOWEST_MOUSE_BUTTON) || (n > HIGHEST_MOUSE_BUTTON)) return 0;
-
-	SDL_LockMutex( mouse_lock );
-
-	switch (n) {
-		case MOUSE_LEFT_BUTTON:
-			tmp = mouse_left_up;
-			mouse_left_up = 0;
-			break;
-
-		case MOUSE_RIGHT_BUTTON:
-			tmp = mouse_right_up;
-			mouse_right_up = 0;
-			break;
-
-		case MOUSE_MIDDLE_BUTTON:
-			tmp = mouse_middle_up;
-			mouse_middle_up = 0;
-			break;
-
-		case MOUSE_X1_BUTTON:
-			tmp = mouse_x1_up;
-			mouse_x1_up = 0;
-			break;
-
-		case MOUSE_X2_BUTTON:
-			tmp = mouse_x2_up;
-			mouse_x2_up = 0;
-			break;
-
-		default:
-			Assert(0);	// can't happen
-			break;
-	} // end switch
-
-	SDL_UnlockMutex( mouse_lock );
-
-	return tmp;
-}
-
-// returns 1 if mouse button btn is down, 0 otherwise
-
-int mouse_down(int btn)
-{
-	int tmp;
-	if ( !mouse_inited ) return 0;
-
-	// Bail if not a button or wheel direction
-	if ((btn < LOWEST_MOUSE_BUTTON) || (btn > HIGHEST_MOUSE_WHEEL)) return 0;
-
-
-	SDL_LockMutex( mouse_lock );
-
-
-	if (mouse_flags & btn) {
-		tmp = 1;
-		if ((btn >= LOWEST_MOUSE_WHEEL) && (btn <= HIGHEST_MOUSE_WHEEL)) {
-			mousewheel_decay(btn);
-		}
-	} else {
-		tmp = 0;
-	}
-
-	SDL_UnlockMutex( mouse_lock );
-
-	return tmp;
-}
-
-// returns the fraction of time btn has been down since last call
-// (currently returns 1 if buttons is down, 0 otherwise)
-//
-float mouse_down_time(int btn)
-{
-	float tmp;
-	if ( !mouse_inited ) return 0.0f;
-
-	// Bail if not a button or wheel direction
-	if ( (btn < LOWEST_MOUSE_BUTTON) || (btn > HIGHEST_MOUSE_WHEEL)) return 0.0f;
-
-	SDL_LockMutex( mouse_lock );
-
-	if (mouse_flags & btn) {
-		tmp = 1.0f;
-		if ((btn >= LOWEST_MOUSE_WHEEL) && (btn <= HIGHEST_MOUSE_WHEEL)) {
-			mousewheel_decay(btn);
-		}
-	} else {
-		tmp = 0.0f;
-	}
-
-	SDL_UnlockMutex( mouse_lock );
-
-	return tmp;
-}
-
-void mouse_get_delta(int *dx, int *dy, int *dz)
-{
-	if (dx)
-		*dx = Mouse_dx;
-	if (dy)
-		*dy = Mouse_dy;
-	if (dz)
-		*dz = Mouse_dz;
-}
-
-// Forces the actual windows cursor to be at (x,y).  This may be independent of our tracked (x,y) mouse pos.
-void mouse_force_pos(int x, int y)
-{
-	if (os_foreground()) {  // only mess with windows's mouse if we are in control of it
-		SDL_WarpMouseInWindow(os_get_window(), x, y);
+	if (Mouse_wheel_y == 0) {
+		mouse_flags &= ~(MOUSE_WHEEL_RIGHT | MOUSE_WHEEL_LEFT);
 	}
 }
 
-// Reset deltas so we don't have duplicate mouse deltas
-void mouse_reset_deltas()
-{
-	Last_mouse_dx = Mouse_dx;
-	Last_mouse_dy = Mouse_dy;
-	Last_mouse_dz = Mouse_dz;
+void mousewheel_motion(int x, int y) {
 
-	Mouse_dx = Mouse_dy = Mouse_dz = 0;
-}
-
-void mouse_event(int x, int y, int dx, int dy)
-{
-	Mouse_x = x;
-	Mouse_y = y;
-
-	// Add up these delta values so we don't overwrite previous events,
-	// should be reset in gr_flip my mouse_reset_deltas()
-	Mouse_dx += dx;
-	Mouse_dy += dy;
-
-	if(Mouse_dx != 0 || Mouse_dy != 0)
-	{
-		Script_system.RunCondition(CHA_MOUSEMOVED);
-	}
-}
-
-int mouse_get_pos(int *xpos, int *ypos)
-{
-	int flags;
-
-    if (!Mouse_in_focus)
-    {
-        if (xpos)
-			*xpos = Mouse_x;
-
-		if (ypos)
-			*ypos = Mouse_y;
-
-        return 0;
-    }
-
-	if (!mouse_inited) {
-		*xpos = *ypos = 0;
-		return 0;
-	}
-
-	flags = mouse_flags;
-
-	if (Mouse_x < 0){
-		Mouse_x = 0;
-	}
-
-	if (Mouse_y < 0){
-		Mouse_y = 0;
-	}
-
-	if (Mouse_x >= gr_screen.max_w){
-		Mouse_x = gr_screen.max_w - 1;
-	}
-
-	if (Mouse_y >= gr_screen.max_h){
- 		Mouse_y = gr_screen.max_h - 1;
-	}
-
-	if (xpos){
-		*xpos = Mouse_x;
-	}
-
-	if (ypos){
-		*ypos = Mouse_y;
-	}
-
-	return flags;
-}
-
-int mouse_get_pos_unscaled( int *xpos, int *ypos )
-{
-	int flags = mouse_get_pos( xpos, ypos );
-
-	gr_unsize_screen_pos( (xpos) ? xpos : NULL, (ypos) ? ypos : NULL, NULL, NULL, GR_RESIZE_MENU );
-
-	return flags;
-}
-
-void mouse_get_real_pos(int *mx, int *my)
-{
-	SDL_GetMouseState(mx, my);
-}
-
-void mouse_set_pos(int xpos, int ypos)
-{
-	mouse_force_pos(xpos, ypos);
-}
-
-void mousewheel_motion(int x, int y, bool reversed) {
-	if (reversed) {
+#if SDL_VERSION_ATLEAST(2, 0, 4)
+	if (direction == SDL_MOUSEWHEEL_FLIPPED) {
 		x = -x;
 		y = -y;
 	}
+#endif
 
 	Mouse_wheel_x += x;
 	Mouse_wheel_y += y;
@@ -593,26 +190,404 @@ void mousewheel_motion(int x, int y, bool reversed) {
 	}
 }
 
-void mousewheel_decay(int btn) {
-	switch (btn) {
-	case MOUSE_WHEEL_UP:
-		Mouse_wheel_y -= 1;
+void mouse_close() {
+	if (!mouse_inited)
+		return;
+
+
+	mouse_inited = 0;
+
+	SDL_DestroyMutex(mouse_lock);
+}
+
+int mouse_down(int btn) {
+	int tmp;
+	if (!mouse_inited) return 0;
+
+	// Bail if not a button or wheel direction
+	if ((btn < LOWEST_MOUSE_BUTTON) || (btn > HIGHEST_MOUSE_WHEEL)) return 0;
+
+
+	SDL_LockMutex(mouse_lock);
+
+
+	if (mouse_flags & btn) {
+		tmp = 1;
+		if ((btn >= LOWEST_MOUSE_WHEEL) && (btn <= HIGHEST_MOUSE_WHEEL)) {
+			mousewheel_decay(btn);
+		}
+	} else {
+		tmp = 0;
+	}
+
+	SDL_UnlockMutex(mouse_lock);
+
+	return tmp;
+}
+
+int mouse_down_count(int n, int reset_count) {
+	int tmp = 0;
+	if (!mouse_inited) return 0;
+
+	if ((n < LOWEST_MOUSE_BUTTON) || (n > HIGHEST_MOUSE_BUTTON)) return 0;
+
+	SDL_LockMutex(mouse_lock);
+
+	switch (n) {
+	case MOUSE_LEFT_BUTTON:
+		tmp = mouse_left_pressed;
+		if (reset_count) {
+			mouse_left_pressed = 0;
+		}
 		break;
-	case MOUSE_WHEEL_DOWN:
-		Mouse_wheel_y += 1;
+
+	case MOUSE_RIGHT_BUTTON:
+		tmp = mouse_right_pressed;
+		if (reset_count) {
+			mouse_right_pressed = 0;
+		}
 		break;
-	case MOUSE_WHEEL_LEFT:
-		Mouse_wheel_x -= 1;
+
+	case MOUSE_MIDDLE_BUTTON:
+		tmp = mouse_middle_pressed;
+		if (reset_count) {
+			mouse_middle_pressed = 0;
+		}
 		break;
-	case MOUSE_WHEEL_RIGHT:
-		Mouse_wheel_x += 1;
+
+	case MOUSE_X1_BUTTON:
+		tmp = mouse_x1_pressed;
+		if (reset_count) {
+			mouse_x1_pressed = 0;
+		}
+		break;
+
+	case MOUSE_X2_BUTTON:
+		tmp = mouse_x2_pressed;
+		if (reset_count) {
+			mouse_x2_pressed = 0;
+		}
+		break;
+	default:
+		// Somebody tried checking multiple buttons. Get a Coder!
+		Assert(0);
+	}
+
+	SDL_UnlockMutex(mouse_lock);
+
+	return tmp;
+}
+
+float mouse_down_time(int btn) {
+	float tmp;
+	if (!mouse_inited) return 0.0f;
+
+	// Bail if not a button or wheel direction
+	if ((btn < LOWEST_MOUSE_BUTTON) || (btn > HIGHEST_MOUSE_WHEEL)) return 0.0f;
+
+	SDL_LockMutex(mouse_lock);
+
+	if (mouse_flags & btn) {
+		tmp = 1.0f;
+		if ((btn >= LOWEST_MOUSE_WHEEL) && (btn <= HIGHEST_MOUSE_WHEEL)) {
+			mousewheel_decay(btn);
+		}
+	} else {
+		tmp = 0.0f;
+	}
+
+	SDL_UnlockMutex(mouse_lock);
+
+	return tmp;
+}
+
+void mouse_event(int x, int y, int dx, int dy) {
+	Mouse_x = x;
+	Mouse_y = y;
+
+	// Add up these delta values so we don't overwrite previous events,
+	// should be reset in gr_flip my mouse_reset_deltas()
+	Mouse_dx += dx;
+	Mouse_dy += dy;
+
+	if (Mouse_dx != 0 || Mouse_dy != 0) {
+		Script_system.RunCondition(CHA_MOUSEMOVED);
+	}
+}
+
+void mouse_flush() {
+	if (!mouse_inited)
+		return;
+
+	mouse_reset_deltas();
+	Mouse_dx = Mouse_dy = Mouse_dz = 0;
+	Mouse_wheel_x = Mouse_wheel_y = 0;
+	SDL_LockMutex(mouse_lock);
+	mouse_left_pressed = 0;
+	mouse_right_pressed = 0;
+	mouse_middle_pressed = 0;
+	mouse_x1_pressed = 0;
+	mouse_x2_pressed = 0;
+	mouse_flags = 0;
+	SDL_UnlockMutex(mouse_lock);
+}
+
+void mouse_force_pos(int x, int y) {
+	if (os_foreground()) {  // only mess with windows's mouse if we are in control of it
+		SDL_WarpMouseInWindow(os_get_window(), x, y);
+	}
+}
+
+void mouse_get_delta(int *dx, int *dy, int *dz) {
+	if (dx)
+		*dx = Mouse_dx;
+	if (dy)
+		*dy = Mouse_dy;
+	if (dz)
+		*dz = Mouse_dz;
+}
+
+int mouse_get_pos(int *xpos, int *ypos) {
+	int flags;
+
+	if (!Mouse_in_focus) {
+		if (xpos)
+			*xpos = Mouse_x;
+
+		if (ypos)
+			*ypos = Mouse_y;
+
+		return 0;
+	}
+
+	if (!mouse_inited) {
+		*xpos = *ypos = 0;
+		return 0;
+	}
+
+	flags = mouse_flags;
+
+	if (Mouse_x < 0) {
+		Mouse_x = 0;
+	}
+
+	if (Mouse_y < 0) {
+		Mouse_y = 0;
+	}
+
+	if (Mouse_x >= gr_screen.max_w) {
+		Mouse_x = gr_screen.max_w - 1;
+	}
+
+	if (Mouse_y >= gr_screen.max_h) {
+		Mouse_y = gr_screen.max_h - 1;
+	}
+
+	if (xpos) {
+		*xpos = Mouse_x;
+	}
+
+	if (ypos) {
+		*ypos = Mouse_y;
+	}
+
+	return flags;
+}
+
+int mouse_get_pos_unscaled(int *xpos, int *ypos) {
+	int flags = mouse_get_pos(xpos, ypos);
+
+	gr_unsize_screen_pos((xpos) ? xpos : NULL, (ypos) ? ypos : NULL, NULL, NULL, GR_RESIZE_MENU);
+
+	return flags;
+}
+
+void mouse_get_real_pos(int *mx, int *my) {
+	SDL_GetMouseState(mx, my);
+}
+
+void mouse_got_focus() {
+	if (!mouse_inited) return;
+
+	Mouse_in_focus = true;
+
+	mouse_flush();
+}
+
+void mouse_init() {
+	// Initialize queue
+	if (mouse_inited) return;
+	mouse_inited = 1;
+
+	mouse_lock = SDL_CreateMutex();
+
+	SDL_LockMutex(mouse_lock);
+
+	mouse_flags = 0;
+	Mouse_x = gr_screen.max_w / 2;
+	Mouse_y = gr_screen.max_h / 2;
+	Mouse_wheel_x = 0;
+	Mouse_wheel_y = 0;
+
+	// we do want to make sure that button presses go through event polling though
+	// (should be on by default already, just here as a reminder)
+	SDL_EventState(SDL_MOUSEBUTTONDOWN, SDL_ENABLE);
+	SDL_EventState(SDL_MOUSEBUTTONUP, SDL_ENABLE);
+	SDL_EventState(SDL_MOUSEWHEEL, SDL_ENABLE);
+
+	SDL_UnlockMutex(mouse_lock);
+
+	os::events::addEventListener(SDL_MOUSEBUTTONDOWN, os::events::DEFAULT_LISTENER_WEIGHT, mouse_key_event_handler);
+	os::events::addEventListener(SDL_MOUSEBUTTONUP, os::events::DEFAULT_LISTENER_WEIGHT, mouse_key_event_handler);
+
+	os::events::addEventListener(SDL_MOUSEMOTION, os::events::DEFAULT_LISTENER_WEIGHT, mouse_motion_event_handler);
+
+	os::events::addEventListener(SDL_MOUSEWHEEL, os::events::DEFAULT_LISTENER_WEIGHT, mouse_wheel_event_handler);
+
+	atexit(mouse_close);
+}
+
+void mouse_lost_focus() {
+	if (!mouse_inited) return;
+
+	Mouse_in_focus = false;
+
+	mouse_flush();
+}
+
+void mouse_mark_button(uint flags, int set) {
+	if (!mouse_inited) return;
+
+	SDL_LockMutex(mouse_lock);
+
+	if (!(mouse_flags & MOUSE_LEFT_BUTTON)) {
+
+		if ((flags & MOUSE_LEFT_BUTTON) && (set == 1)) {
+			mouse_left_pressed++;
+		}
+	} else {
+		if ((flags & MOUSE_LEFT_BUTTON) && (set == 0)) {
+			mouse_left_up++;
+		}
+	}
+
+	if (!(mouse_flags & MOUSE_RIGHT_BUTTON)) {
+
+		if ((flags & MOUSE_RIGHT_BUTTON) && (set == 1)) {
+			mouse_right_pressed++;
+		}
+	} else {
+		if ((flags & MOUSE_RIGHT_BUTTON) && (set == 0)) {
+			mouse_right_up++;
+		}
+	}
+
+	if (!(mouse_flags & MOUSE_MIDDLE_BUTTON)) {
+
+		if ((flags & MOUSE_MIDDLE_BUTTON) && (set == 1)) {
+			mouse_middle_pressed++;
+		}
+	} else {
+		if ((flags & MOUSE_MIDDLE_BUTTON) && (set == 0)) {
+			mouse_middle_up++;
+		}
+	}
+
+	if (!(mouse_flags & MOUSE_X1_BUTTON)) {
+
+		if ((flags & MOUSE_X1_BUTTON) && (set == 1)) {
+			mouse_x1_pressed++;
+		}
+	} else {
+		if ((flags & MOUSE_X1_BUTTON) && (set == 0)) {
+			mouse_x1_up++;
+		}
+	}
+
+	if (!(mouse_flags & MOUSE_X2_BUTTON)) {
+
+		if ((flags & MOUSE_X2_BUTTON) && (set == 1)) {
+			mouse_x2_pressed++;
+		}
+	} else {
+		if ((flags & MOUSE_X2_BUTTON) && (set == 0)) {
+			mouse_x2_up++;
+		}
+	}
+
+	if (set) {
+		mouse_flags |= flags;
+	} else {
+		mouse_flags &= ~flags;
+	}
+
+	SDL_UnlockMutex(mouse_lock);
+
+	Script_system.SetHookVar("MouseButton", 'i', &flags);
+
+	//WMC - On Mouse Pressed and On Mouse Released hooks
+	if (set == 1) {
+		Script_system.RunCondition(CHA_MOUSEPRESSED);
+	} else if (set == 0) {
+		Script_system.RunCondition(CHA_MOUSERELEASED);
+	}
+
+	Script_system.RemHookVar("MouseButton");
+}
+
+void mouse_reset_deltas() {
+	Last_mouse_dx = Mouse_dx;
+	Last_mouse_dy = Mouse_dy;
+	Last_mouse_dz = Mouse_dz;
+
+	Mouse_dx = Mouse_dy = Mouse_dz = 0;
+}
+
+void mouse_set_pos(int xpos, int ypos) {
+	mouse_force_pos(xpos, ypos);
+}
+
+int mouse_up_count(int n) {
+	int tmp = 0;
+	if (!mouse_inited) return 0;
+
+	if ((n < LOWEST_MOUSE_BUTTON) || (n > HIGHEST_MOUSE_BUTTON)) return 0;
+
+	SDL_LockMutex(mouse_lock);
+
+	switch (n) {
+	case MOUSE_LEFT_BUTTON:
+		tmp = mouse_left_up;
+		mouse_left_up = 0;
+		break;
+
+	case MOUSE_RIGHT_BUTTON:
+		tmp = mouse_right_up;
+		mouse_right_up = 0;
+		break;
+
+	case MOUSE_MIDDLE_BUTTON:
+		tmp = mouse_middle_up;
+		mouse_middle_up = 0;
+		break;
+
+	case MOUSE_X1_BUTTON:
+		tmp = mouse_x1_up;
+		mouse_x1_up = 0;
+		break;
+
+	case MOUSE_X2_BUTTON:
+		tmp = mouse_x2_up;
+		mouse_x2_up = 0;
+		break;
+
+	default:
+		// Somebody tried to check multiple buttons. Get a Coder!
+		Assert(0);
 		break;
 	}
 
-	if (Mouse_wheel_x == 0) {
-		mouse_flags &= ~(MOUSE_WHEEL_UP | MOUSE_WHEEL_DOWN);
-	}
-	if (Mouse_wheel_y == 0) {
-		mouse_flags &= ~(MOUSE_WHEEL_RIGHT | MOUSE_WHEEL_LEFT);
-	}
+	SDL_UnlockMutex(mouse_lock);
+
+	return tmp;
 }

--- a/code/io/mouse.h
+++ b/code/io/mouse.h
@@ -33,10 +33,10 @@ extern int Use_mouse_to_fly;
 // [z64555] These mouse_button defines are a quick check to verify the input button is a mouse button
 // [z64555] Likewise, the mouse_wheel defines quickly check against the mousewheel directions
 #define LOWEST_MOUSE_BUTTON     MOUSE_LEFT_BUTTON
-#define HIGHEST_MOUSE_BUTTON    MOUSE_X2_BUTTON
+#define HIGHEST_MOUSE_BUTTON    (MOUSE_X2_BUTTON << 1) - 1
 
 #define LOWEST_MOUSE_WHEEL      MOUSE_WHEEL_UP
-#define HIGHEST_MOUSE_WHEEL     MOUSE_WHEEL_RIGHT
+#define HIGHEST_MOUSE_WHEEL     (MOUSE_WHEEL_RIGHT << 1) - 1
 
 
 /**

--- a/code/io/mouse.h
+++ b/code/io/mouse.h
@@ -1,3 +1,5 @@
+#ifndef _MOUSE_H
+#define _MOUSE_H
 /*
  * Copyright (C) Volition, Inc. 1999.  All rights reserved.
  *
@@ -9,51 +11,84 @@
 
 
 
-#ifndef _MOUSE_H
-#define _MOUSE_H
-
 #include "globalincs/pstypes.h"
+
 
 extern int Mouse_sensitivity;
 extern int Use_mouse_to_fly;
-
-// call once to init the mouse
-void mouse_init();
-
-extern void mouse_mark_button( uint flags, int set );
-
-// Fills in xpos & ypos if not NULL.
-// Returns Button states
-// Always returns coordinates clipped to screen coordinates.
-extern int mouse_get_pos( int *xpos, int *ypos );
-// same as above but gets an unscaled reading (ie. the 1024x768/640x480 equivalent)
-extern int mouse_get_pos_unscaled( int *xpos, int *ypos );
-
-// get_real_pos could be negative.
-extern void mouse_get_real_pos(int *mx, int *my);
-
-extern void mouse_set_pos(int xpos,int ypos);
 
 #define MOUSE_LEFT_BUTTON   (1<<0)
 #define MOUSE_RIGHT_BUTTON  (1<<1)
 #define MOUSE_MIDDLE_BUTTON (1<<2)
 #define MOUSE_X1_BUTTON     (1<<3)
 #define MOUSE_X2_BUTTON     (1<<4)
-#define MOUSE_WHEEL_UP      (1<<5)  // Wheel is treated like a pair of buttons, but they don't have a down nor up count
+#define MOUSE_WHEEL_UP      (1<<5)  //!< [z64555] Wheel is treated like a pair of buttons, but they don't have a down nor up count
 #define MOUSE_WHEEL_DOWN    (1<<6)
 #define MOUSE_WHEEL_LEFT    (1<<7)
 #define MOUSE_WHEEL_RIGHT   (1<<8)
 
 #define MOUSE_NUM_BUTTONS		9
 
-// keep the following #defines up to date with the #defines above
-// These mouse_button defines are a quick check to verify the input button is a mouse button
-// Likewise, the mouse_wheel defines quickly check against the mousewheel directions
+// [:V:] keep the following #defines up to date with the #defines above
+// [z64555] These mouse_button defines are a quick check to verify the input button is a mouse button
+// [z64555] Likewise, the mouse_wheel defines quickly check against the mousewheel directions
 #define LOWEST_MOUSE_BUTTON     MOUSE_LEFT_BUTTON
 #define HIGHEST_MOUSE_BUTTON    MOUSE_X2_BUTTON
 
 #define LOWEST_MOUSE_WHEEL      MOUSE_WHEEL_UP
 #define HIGHEST_MOUSE_WHEEL     MOUSE_WHEEL_RIGHT
+
+
+/**
+ * @brief Inits the mouse
+ */
+void mouse_init();
+
+/**
+ * @brief Marks a mouse button as up or down
+ *
+ * @param[in] flags Which button(s) are pressed/released
+ * @param[in] set   Direction of the button(s). 1 = pressed, 0 = released
+ *
+ * @note This function is extern'ed by osapi.cpp and freespace.cpp
+ */
+void mouse_mark_button(uint flags, int set);
+
+/**
+ * @brief Gets the current mouse position clipped to screen coordinates
+ *
+ * @param[out] xpos If not NULL, The x (left/right) position
+ * @param[out] ypos If not NULL, The y (up/down) position
+ *
+ * @returns Button states as a bitfield
+ */
+int mouse_get_pos(int *xpos, int *ypos);
+
+/**
+ * @brief Gets the current (unscaled) mouse position clipped to screen coordinates
+ *
+ * @param[out] xpos If not NULL, The x (left/right) position
+ * @param[out] ypos If not NULL, The y (up/down) position
+ *
+ * @returns Button states as a bitfield
+ */
+int mouse_get_pos_unscaled(int *xpos, int *ypos);
+
+/**
+ * @brief Gets the current mouse position (OS coordinates). Can be negative.
+ *
+ * @param[out] mx If not NULL, The x (left/right) position
+ * @param[out] my If not NULL, The y (up/down) position
+ */
+void mouse_get_real_pos(int *mx, int *my);
+
+/**
+ * @brief Move the mouse cursor to the specified coordinates
+ *
+ * @param[in] xpos The new x position
+ * @param[in] ypos The new y position
+ */
+void mouse_set_pos(int xpos, int ypos);
 
 /**
  * @brief Returns the number of times button n went from up to down since last call
@@ -70,22 +105,69 @@ int mouse_up_count(int n);
  */
 void mouse_flush();
 
-int mouse_down(int btn);			// returns 1 if mouse button btn is down, 0 otherwise
-float mouse_down_time(int btn);	// returns the fraction of time btn has been down since last call
+/**
+ * @brief Checks if the given mouse button(s) are down
+ *
+ * @returns 1 if true, or
+ * @returns 0 otherwise
+ *
+ * @details Also covers mousewheels, and applies decay
+ */
+int mouse_down(int btn);
 
+/**
+ * @brief Returns the time of how long the button has been since last call
+ *
+ * @note Currently just returns 1.0f if down, 0.0f if not.
+ *
+ * @details Also covers mousewheels, and applies decay
+ */
+float mouse_down_time(int btn);
+
+/**
+ * @brief Handler called when we loose focus
+ *
+ * @note Currently unused
+ */
 void mouse_lost_focus();
+
+/**
+ * @brief Handler called when we gain focus
+ *
+ * @note Currently unused
+ */
 void mouse_got_focus();
 
+/**
+ * @brief Saves the current deltas into Last_mouse deltas, and clears the current deltas
+ */
 void mouse_reset_deltas();
+
+/**
+ * @brief Gets the current mouse deltas
+ *
+ * @param[out] dx If not NULL, The delta x
+ * @param[out] dy If not NULL, The delta y
+ * @param[out] dz If not NULL, The delta z (usually 0)
+ */
 void mouse_get_delta(int *dx = NULL, int *dy = NULL, int *dz = NULL);
 
+/**
+ * @brief Handler called when a mouse movement even occurs
+ *
+ * param[in] x  The current X position
+ * param[in] y  The current Y position
+ * param[in] dx The current delta X
+ * param[in] dy The current delta Y
+ */
 void mouse_event(int x, int y, int dx, int dy);
 
 /**
- * Called when there is motion on the mouse wheel(s). Supports 2 axes
+ * @brief Called when there is motion on the mouse wheel(s). Supports 2 axes
+ *
+ * @param[in] x Current mousewheel movement along the X axis (left/right)
+ * @param[in] y Current mousewheel movement along the Y axis (up/down)
  */
 void mousewheel_motion(int x, int y, bool reversed);
-
-extern void mouse_force_pos(int x, int y);
 
 #endif

--- a/code/io/mouse.h
+++ b/code/io/mouse.h
@@ -148,9 +148,8 @@ void mouse_reset_deltas();
  *
  * @param[out] dx If not NULL, The delta x
  * @param[out] dy If not NULL, The delta y
- * @param[out] dz If not NULL, The delta z (usually 0)
  */
-void mouse_get_delta(int *dx = NULL, int *dy = NULL, int *dz = NULL);
+void mouse_get_delta(int *dx = NULL, int *dy = NULL);
 
 /**
  * @brief Handler called when a mouse movement even occurs

--- a/code/playerman/playercontrol.cpp
+++ b/code/playerman/playercontrol.cpp
@@ -369,15 +369,15 @@ void playercontrol_read_stick(int *axis, float frame_time)
 	control_get_axes_readings(&axis[0], &axis[1], &axis[2], &axis[3], &axis[4]);
 
 	if (Use_mouse_to_fly) {
-		int dx, dy, dz;
+		int dx, dy;
 		float factor;
 
 		factor = (float) Mouse_sensitivity + 1.77f;
 		factor = factor * factor / frame_time / 0.6f;
 
-		mouse_get_delta(&dx, &dy, &dz);
-		int x_axis, y_axis, z_axis;
-		x_axis = y_axis = z_axis = -1;
+		mouse_get_delta(&dx, &dy);
+		int x_axis, y_axis;
+		x_axis = y_axis = -1;
 
 		for (i = 0; i < NUM_JOY_AXIS_ACTIONS; i++) {
 			switch(Axis_map_to[i])
@@ -387,9 +387,6 @@ void playercontrol_read_stick(int *axis, float frame_time)
 				break;
 			case JOY_Y_AXIS:
 				y_axis = i;
-				break;
-			case JOY_Z_AXIS:
-				z_axis = i;
 				break;
 			}
 		}
@@ -406,13 +403,6 @@ void playercontrol_read_stick(int *axis, float frame_time)
 				dy = -dy;
 			}
 			axis[y_axis] += (int) ((float) dy * factor);
-		}
-
-		if (z_axis >= 0) {
-			if (Invert_axis[z_axis]) {
-				dz = -dz;
-			}
-			axis[z_axis] += (int) ((float) dz * factor);
 		}
 	}
 }


### PR DESCRIPTION
Part of z64's Controls Code Overhaul (TM), this organizes, doxy's, and generally cleans up input related files to a more manageable state.

Also patches a minor bug with the mouse scroll wheel.

Originally [PR#559](https://github.com/scp-fs2open/fs2open.github.com/pull/559), this has been rebased on master.