### PR TITLE
Update git submodules when CMake runs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,9 @@ endif()
 
 include(cmake/util.cmake)
 
+# Update git submodules
+include(cmake/git-submodules.cmake)
+
 # Set a few policies
 set_policy(CMP0051 OLD)
 set_policy(CMP0053 NEW)

--- a/cmake/git-submodules.cmake
+++ b/cmake/git-submodules.cmake
@@ -1,0 +1,26 @@
+
+message(STATUS "Checking for submodule updates...")
+if (NOT IS_DIRECTORY "${CMAKE_SOURCE_DIR}/.git")
+    message("Project is no git working copy, skipping submodule check...")
+    return()
+endif()
+
+find_package(Git)
+if(NOT GIT_FOUND)
+    message("Git could not be found, skipping submodule check...")
+    return()
+endif()
+
+# Update the submodules
+execute_process(COMMAND ${GIT_EXECUTABLE} submodule update --init --recursive
+        RESULT_VARIABLE UPDATE_RESULT
+        OUTPUT_VARIABLE GIT_OUTPUT
+        ERROR_VARIABLE GIT_OUTPUT)
+
+if (GIT_OUTPUT)
+    message(STATUS "${GIT_OUTPUT}")
+endif()
+
+if (UPDATE_RESULT)
+    message("Submodule updating has failed!")
+endif()


### PR DESCRIPTION
For this to work CMake needs to find a git executable. If it isn't found
then it's not an error but the submodules won't be updated.