### PR TITLE
Fix for Coverity 1093292

### DIFF
--- a/code/fs2netd/tcp_client.cpp
+++ b/code/fs2netd/tcp_client.cpp
@@ -832,7 +832,9 @@ void FS2NetD_CheckDuplicateLogin()
 
 	DONE_PACKET();
 
-	FS2NetD_SendData(buffer, buffer_size);
+	if (FS2NetD_SendData(buffer, buffer_size) < 0) {
+		ml_printf("FS2NetD WARNING: Failed to send data packet to server!");
+	}
 
 	delete [] ids;
 }

--- a/code/fs2netd/tcp_client.cpp
+++ b/code/fs2netd/tcp_client.cpp
@@ -649,7 +649,9 @@ void FS2NetD_Ping()
 
 	DONE_PACKET();
 
-	FS2NetD_SendData(buffer, buffer_size);
+	if (FS2NetD_SendData(buffer, buffer_size) < 0) {
+		ml_printf("Failed to send PING packet!");
+	}
 }
 
 void FS2NetD_Pong(int tstamp)

--- a/code/fs2netd/tcp_client.cpp
+++ b/code/fs2netd/tcp_client.cpp
@@ -571,7 +571,9 @@ void FS2NetD_SendServerStart()
 
 	DONE_PACKET();
 
-	FS2NetD_SendData(buffer, buffer_size);
+	if (FS2NetD_SendData(buffer, buffer_size) < 0) {
+		ml_printf("FS2NetD WARNING: Failed to send server start packet!");
+	}
 }
 
 void FS2NetD_SendServerUpdate()

--- a/code/fs2netd/tcp_client.cpp
+++ b/code/fs2netd/tcp_client.cpp
@@ -598,7 +598,9 @@ void FS2NetD_SendServerUpdate()
 
 	DONE_PACKET();
 
-	FS2NetD_SendData(buffer, buffer_size);
+	if (FS2NetD_SendData(buffer, buffer_size) < 0) {
+		ml_printf("FS2NetD WARNING: Failed to send server update packet!");
+	}
 }
 
 void FS2NetD_SendServerDisconnect()

--- a/code/fs2netd/tcp_client.cpp
+++ b/code/fs2netd/tcp_client.cpp
@@ -610,7 +610,9 @@ void FS2NetD_SendServerDisconnect()
 
 	DONE_PACKET();
 
-	FS2NetD_SendData(buffer, buffer_size);
+	if (FS2NetD_SendData(buffer, buffer_size) < 0) {
+		ml_printf("FS2NetD WARNING: Failed to send server disconnect packet!");
+	}
 }
 
 void FS2NetD_RequestServerList()


### PR DESCRIPTION
"Unchecked return value from library". The function can't return an
error value so I added a ml_printf (which is used at another place for
error logging as well) to log the error.