### PR TITLE
Make sure that SDL OpenGL is initialized

### DIFF
--- a/code/osapi/osapi.cpp
+++ b/code/osapi/osapi.cpp
@@ -114,19 +114,12 @@ namespace
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 
+static HWND window_override;
+
 // For FRED
 void os_set_window_from_hwnd(HWND handle)
 {
-	if (SDL_InitSubSystem(SDL_INIT_VIDEO) < 0) {
-		Error(LOCATION, "Couldn't init SDL video: %s", SDL_GetError());
-	}
-
-	if (SDL_GL_LoadLibrary(NULL) < 0)
-		Error(LOCATION, "Failed to load OpenGL library: %s!", SDL_GetError());
-
-	SDL_Window* window = SDL_CreateWindowFrom((void*) handle);
-
-	os_set_window(window);
+	window_override = handle;
 }
 
 // go through all windows and try and find the one that matches the search string
@@ -318,6 +311,15 @@ void os_set_window(SDL_Window* new_handle)
 {
 	main_window = new_handle;
 	fAppActive = true;
+}
+
+void* os_get_window_override()
+{
+#ifdef WIN32
+	return window_override;
+#else
+	return nullptr;
+#endif
 }
 
 // process management -----------------------------------------------------------------

--- a/code/osapi/osapi.h
+++ b/code/osapi/osapi.h
@@ -61,7 +61,9 @@ int os_foreground();
 // Returns the handle to the main window
 SDL_Window* os_get_window();
 
-void os_set_window(SDL_Window* new_handle);	 
+void os_set_window(SDL_Window* new_handle);
+
+void* os_get_window_override();
 
 // process management --------------------------------------------------------------
 

--- a/fred2/fredview.cpp
+++ b/fred2/fredview.cpp
@@ -4667,13 +4667,15 @@ void CFREDView::OnDestroy()
 	CView::OnDestroy();
 }
 
+extern void os_set_window_from_hwnd(HWND handle);
 int CFREDView::OnCreate(LPCREATESTRUCT lpCreateStruct) 
 {
 	if (CView::OnCreate(lpCreateStruct) == -1)
 		return -1;
 	
 	MoveWindow(0,0,200,300,1);
-   	if(fred_init(this->GetSafeHwnd()) == false)
+	os_set_window_from_hwnd(this->GetSafeHwnd());
+   	if(fred_init() == false)
 		return -1;
 
 	return 0;

--- a/fred2/management.cpp
+++ b/fred2/management.cpp
@@ -273,8 +273,7 @@ void fred_preload_all_briefing_icons()
 	}
 }
 
-extern void os_set_window_from_hwnd(HWND handle);
-bool fred_init(HWND windowHandle)
+bool fred_init()
 {
 	int i;
 	char palette_filename[1024];
@@ -286,8 +285,6 @@ bool fred_init(HWND windowHandle)
 	init_pending_messages();
 
 	os_init(Osreg_class_name, Osreg_app_name);
-
-	os_set_window_from_hwnd(windowHandle);
 
 	timer_init();
 

--- a/fred2/management.h
+++ b/fred2/management.h
@@ -69,7 +69,7 @@ void	convert_multiline_string(CString &dest, const char *src);
 void	deconvert_multiline_string(char *dest, const CString &str, int max_len);
 void	deconvert_multiline_string(SCP_string &dest, const CString &str);
 
-bool	fred_init(HWND windowHandle);
+bool	fred_init();
 void	set_physics_controls();
 int	dup_object(object *objp);
 int	create_object_on_grid(int waypoint_instance = -1);


### PR DESCRIPTION
The documentation says that the SDL OpenGL attributes need to be
initialized before a window is created. These changes implement that by
moving the actual SD_Window creation inside the OpenGL setup. FRED only
sets the native window handle to the correct HWND and gropengl uses
that.