### PR TITLE
Fix parsing code error introduced by TTF merge

### DIFF
--- a/code/hud/hudparse.cpp
+++ b/code/hud/hudparse.cpp
@@ -1252,7 +1252,7 @@ T* gauge_load_common(gauge_settings* settings, T* preAllocated = NULL)
 		}
 	}
 
-	if (optional_string("$Font:")) {
+	if (optional_string("Font:")) {
 		settings->font_num = font::parse_font();
 	} else {
 		if ( settings->font_num < 0 ) {
@@ -3032,7 +3032,7 @@ void load_gauge_radar_dradis(gauge_settings* settings)
 		settings->use_coords = true;
 	}
 
-	if (optional_string("$Font:")) {
+	if (optional_string("Font:")) {
 		settings->font_num = font::parse_font();
 	} else {
 		if ( settings->font_num < 0 ) {


### PR DESCRIPTION
Thanks to @AxemP for providing a test mod to fix this issue.

This shows that the hud parse code is flawed because instead of showing an error it skipped the invalid entry and continued with the next. I'll try to improve that a bit in a separate PR.