### PR TITLE
Add interface for creating an OpenGL context

### DIFF
--- a/code/graphics/2d.h
+++ b/code/graphics/2d.h
@@ -12,6 +12,7 @@
 #ifndef _GRAPHICS_H
 #define _GRAPHICS_H
 
+#include <osapi/osapi.h>
 #include "bmpman/bmpman.h"
 #include "cfile/cfile.h"
 #include "globalincs/pstypes.h"
@@ -655,12 +656,14 @@ typedef struct screen {
 
 extern const char *Resolution_prefixes[GR_NUM_RESOLUTIONS];
 
-extern bool gr_init(int d_mode = GR_DEFAULT, int d_width = GR_DEFAULT, int d_height = GR_DEFAULT, int d_depth = GR_DEFAULT);
+extern bool gr_init(os::GraphicsOperations* graphicsOps, int d_mode = GR_DEFAULT,
+					int d_width = GR_DEFAULT, int d_height = GR_DEFAULT, int d_depth = GR_DEFAULT);
+
 extern void gr_screen_resize(int width, int height);
 extern int gr_get_resolution_class(int width, int height);
 
 // Call this when your app ends.
-extern void gr_close();
+extern void gr_close(os::GraphicsOperations* graphicsOps);
 
 extern screen gr_screen;
 

--- a/code/graphics/gropengl.cpp
+++ b/code/graphics/gropengl.cpp
@@ -84,7 +84,7 @@ static int GL_minimized = 0;
 
 static GLenum GL_read_format = GL_BGRA;
 
-SDL_GLContext GL_context = NULL;
+static std::unique_ptr<os::OpenGLContext> GL_context = nullptr;
 
 void opengl_go_fullscreen()
 {
@@ -92,7 +92,6 @@ void opengl_go_fullscreen()
 		return;
 
 	if ( (os_config_read_uint(NULL, NOX("Fullscreen"), 1) == 1) && (!os_get_window() || !(SDL_GetWindowFlags(os_get_window()) & SDL_WINDOW_FULLSCREEN)) ) {
-		os_suspend();
 		if(os_get_window())
 		{
 			SDL_SetWindowFullscreen(os_get_window(), SDL_WINDOW_FULLSCREEN);
@@ -113,7 +112,6 @@ void opengl_go_fullscreen()
 
 			os_set_window(window);
 		}
-		os_resume();
 	}
 
 	gr_opengl_set_gamma(FreeSpace_gamma);
@@ -129,7 +127,6 @@ void opengl_go_windowed()
 		return;
 
 	if (!os_get_window() || SDL_GetWindowFlags(os_get_window()) & SDL_WINDOW_FULLSCREEN) {
-		os_suspend();
 		if(os_get_window())
 		{
 			SDL_SetWindowFullscreen(os_get_window(), Cmdline_fullscreen_window ? SDL_WINDOW_FULLSCREEN_DESKTOP : 0 );
@@ -144,8 +141,6 @@ void opengl_go_windowed()
 			}
 			os_set_window(new_window);
 		}
-
-		os_resume();
 	}
 
 	GL_windowed = 1;
@@ -163,14 +158,11 @@ void opengl_minimize()
 	if ( !(SDL_GetWindowFlags(os_get_window()) & SDL_WINDOW_FULLSCREEN) )
 		return;
 
-	os_suspend();
-
 	if (GL_original_gamma_ramp != NULL) {
 		SDL_SetWindowGammaRamp( os_get_window(), GL_original_gamma_ramp, (GL_original_gamma_ramp+256), (GL_original_gamma_ramp+512) );
 	}
 
 	SDL_MinimizeWindow(os_get_window());
-	os_resume();
 
 	GL_minimized = 1;
 	GL_windowed = 0;
@@ -221,7 +213,7 @@ void gr_opengl_flip()
 	if (Cmdline_gl_finish)
 		glFinish();
 
-	SDL_GL_SwapWindow(os_get_window());
+	GL_context->swapBuffers();
 
 	opengl_tcache_frame();
 
@@ -444,7 +436,33 @@ void gr_opengl_print_screen(const char *filename)
 	}
 }
 
-void gr_opengl_cleanup(bool closing, int minimize)
+void gr_opengl_shutdown(os::GraphicsOperations* graphicsOps)
+{
+	graphics::paths::PathRenderer::shutdown();
+
+	opengl_tcache_shutdown();
+	opengl_light_shutdown();
+	opengl_tnl_shutdown();
+	opengl_scene_texture_shutdown();
+	opengl_post_process_shutdown();
+	opengl_shader_shutdown();
+
+	GL_initted = false;
+
+	if (GL_original_gamma_ramp != NULL) {
+		SDL_SetWindowGammaRamp( os_get_window(), GL_original_gamma_ramp, (GL_original_gamma_ramp+256), (GL_original_gamma_ramp+512) );
+	}
+
+	if (GL_original_gamma_ramp != NULL) {
+		vm_free(GL_original_gamma_ramp);
+		GL_original_gamma_ramp = NULL;
+	}
+
+	graphicsOps->makeOpenGLContextCurrent(nullptr);
+	GL_context = nullptr;
+}
+
+void gr_opengl_cleanup(os::GraphicsOperations* graphicsOps, bool closing, int minimize)
 {
 	if ( !GL_initted ) {
 		return;
@@ -465,9 +483,7 @@ void gr_opengl_cleanup(bool closing, int minimize)
 
 	opengl_minimize();
 
-	if (minimize) {
-
-	}
+	gr_opengl_shutdown(graphicsOps);
 }
 
 void gr_opengl_fog_set(int fog_mode, int r, int g, int b, float fog_near, float fog_far)
@@ -1020,7 +1036,7 @@ void opengl_set_vsync(int status)
 		return;
 	}
 
-	SDL_GL_SetSwapInterval(status);
+	GL_context->setSwapInterval(status);
 
 	GL_CHECK_FOR_ERRORS("end of set_vsync()");
 }
@@ -1043,41 +1059,8 @@ void opengl_setup_viewport()
 	glLoadIdentity();
 }
 
-// NOTE: This should only ever be called through os_cleanup(), or when switching video APIs
-void gr_opengl_shutdown()
+int opengl_init_display_device(os::GraphicsOperations* graphicsOps)
 {
-	graphics::paths::PathRenderer::shutdown();
-
-	opengl_tcache_shutdown();
-	opengl_light_shutdown();
-	opengl_tnl_shutdown();
-	opengl_scene_texture_shutdown();
-	opengl_post_process_shutdown();
-	opengl_shader_shutdown();
-
-	GL_initted = false;
-
-	if (GL_original_gamma_ramp != NULL) {
-		SDL_SetWindowGammaRamp( os_get_window(), GL_original_gamma_ramp, (GL_original_gamma_ramp+256), (GL_original_gamma_ramp+512) );
-	}
-
-	if (GL_original_gamma_ramp != NULL) {
-		vm_free(GL_original_gamma_ramp);
-		GL_original_gamma_ramp = NULL;
-	}
-
-	SDL_GL_DeleteContext(GL_context);
-	GL_context = NULL;
-}
-
-// NOTE: This should only ever be called through atexit()!!!
-void opengl_close()
-{
-//	if ( !GL_initted )
-//		return;
-}
-
-bool opengl_setup_sdl_attributes() {
 	int bpp = gr_screen.bits_per_pixel;
 
 	Assertion((bpp == 16) || (bpp == 32), "Invalid bits-per-pixel value %d!", bpp);
@@ -1170,42 +1153,6 @@ bool opengl_setup_sdl_attributes() {
 	Gr_ta_alpha.shift = 12;
 	Gr_ta_alpha.scale = 17;
 
-	mprintf(("  Initializing SDL video...\n"));
-
-#ifdef SCP_UNIX
-	// Slight hack to make Mesa advertise S3TC support without libtxc_dxtn
-	setenv("force_s3tc_enable", "true", 1);
-#endif
-
-	if (SDL_InitSubSystem(SDL_INIT_VIDEO) < 0) {
-		mprintf(("Couldn't init SDL video: %s", SDL_GetError()));
-		Error(LOCATION, "Couldn't init SDL video: %s", SDL_GetError());
-		return false;
-	}
-
-	SDL_GL_SetAttribute(SDL_GL_RED_SIZE, Gr_red.bits);
-	SDL_GL_SetAttribute(SDL_GL_GREEN_SIZE, Gr_green.bits);
-	SDL_GL_SetAttribute(SDL_GL_BLUE_SIZE, Gr_blue.bits);
-	SDL_GL_SetAttribute(SDL_GL_DEPTH_SIZE, (bpp == 32) ? 24 : 16);
-	SDL_GL_SetAttribute(SDL_GL_STENCIL_SIZE, (bpp == 32) ? 8 : 1);
-	SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 1);
-
-	int fsaa_samples = os_config_read_uint(NULL, "OGL_AntiAliasSamples", 0);
-
-	SDL_GL_SetAttribute(SDL_GL_MULTISAMPLEBUFFERS, (fsaa_samples == 0) ? 0 : 1);
-	SDL_GL_SetAttribute(SDL_GL_MULTISAMPLESAMPLES, fsaa_samples);
-
-	mprintf(("  Requested SDL Video values = R: %d, G: %d, B: %d, depth: %d, stencil: %d, double-buffer: %d, FSAA: %d\n", Gr_red.bits, Gr_green.bits, Gr_blue.bits, (bpp == 32) ? 24 : 16, (bpp == 32) ? 8 : 1, 1, fsaa_samples));
-
-	return true;
-}
-
-int opengl_init_display_device()
-{
-	if (!opengl_setup_sdl_attributes()) {
-		return 1;
-	}
-
 	// allocate storage for original gamma settings
 	if ( !Cmdline_no_set_gamma && (GL_original_gamma_ramp == NULL) ) {
 		GL_original_gamma_ramp = (ushort*) vm_malloc( 3 * 256 * sizeof(ushort), memory::quiet_alloc);
@@ -1221,59 +1168,33 @@ int opengl_init_display_device()
 		}
 	}
 
-	// This code also gets called in the FRED initialization, that means we may need to use the override window.
-	if (os_get_window_override() != nullptr)
-	{
-		if (SDL_GL_LoadLibrary(nullptr) < 0)
-			 Error(LOCATION, "Failed to load OpenGL library: %s!", SDL_GetError());
+	os::OpenGLContextAttributes attrs;
+	attrs.red_size = Gr_red.bits;
+	attrs.green_size = Gr_green.bits;
+	attrs.blue_size = Gr_blue.bits;
+	attrs.alpha_size = (bpp == 32) ? Gr_alpha.bits : 0;
+	attrs.depth_size = (bpp == 32) ? 24 : 16;
+	attrs.stencil_size = (bpp == 32) ? 8 : 1;
 
-		auto window = SDL_CreateWindowFrom(os_get_window_override());
-		if (window == nullptr)
-		{
-			mprintf(("Could not create window: %s\n", SDL_GetError()));
-			Error(LOCATION, "Could not create window: %s\n", SDL_GetError());
-			return 1;
-		}
-		os_set_window(window);
-	}
-	else
-	{
-		int windowflags = SDL_WINDOW_OPENGL;
-		if (Cmdline_fullscreen_window)
-			windowflags |= SDL_WINDOW_BORDERLESS;
+	attrs.multi_samples = os_config_read_uint(NULL, "OGL_AntiAliasSamples", 0);
 
-		uint display = os_config_read_uint("Video", "Display", 0);
-		SDL_Window* window = SDL_CreateWindow(Osreg_title, SDL_WINDOWPOS_CENTERED_DISPLAY(display), SDL_WINDOWPOS_CENTERED_DISPLAY(display),
-			gr_screen.max_w, gr_screen.max_h, windowflags);
-		if (window == NULL)
-		{
-			mprintf(("Could not create window: %s\n", SDL_GetError()));
-			return 1;
-		}
+	attrs.major_version = 2;
+	attrs.minor_version = 0;
 
-		os_set_window(window);
-	}
+	attrs.flags = os::OGL_NONE;
+#ifndef NDEBUG
+	attrs.flags |= os::OGL_DEBUG;
+#endif
 
-	GL_context = SDL_GL_CreateContext(os_get_window());
+	attrs.profile = os::OpenGLProfile::Compatibility;
+
+	GL_context = graphicsOps->createOpenGLContext(attrs, (uint32_t) gr_screen.max_w, (uint32_t) gr_screen.max_h);
 
 	if (GL_context == nullptr) {
-		mprintf(("Error creating GL_context: %s\n", SDL_GetError()));
 		return 1;
 	}
 
-	SDL_GL_MakeCurrent(os_get_window(), GL_context);
-	//TODO: set up bpp settings
-
-	int r, g, b, depth, stencil, db, fsaa_samples;
-	SDL_GL_GetAttribute(SDL_GL_RED_SIZE, &r);
-	SDL_GL_GetAttribute(SDL_GL_GREEN_SIZE, &g);
-	SDL_GL_GetAttribute(SDL_GL_BLUE_SIZE, &b);
-	SDL_GL_GetAttribute(SDL_GL_DEPTH_SIZE, &depth);
-	SDL_GL_GetAttribute(SDL_GL_DOUBLEBUFFER, &db);
-	SDL_GL_GetAttribute(SDL_GL_STENCIL_SIZE, &stencil);
-	SDL_GL_GetAttribute(SDL_GL_MULTISAMPLESAMPLES, &fsaa_samples);
-
-	mprintf(("  Actual SDL Video values    = R: %d, G: %d, B: %d, depth: %d, stencil: %d, double-buffer: %d, FSAA: %d\n", r, g, b, depth, stencil, db, fsaa_samples));
+	graphicsOps->makeOpenGLContextCurrent(GL_context.get());
 
 	if (GL_original_gamma_ramp != NULL) {
 		SDL_GetWindowGammaRamp( os_get_window(), GL_original_gamma_ramp, (GL_original_gamma_ramp+256), (GL_original_gamma_ramp+512) );
@@ -1640,13 +1561,10 @@ static void init_extensions() {
 	}
 }
 
-bool gr_opengl_init()
+bool gr_opengl_init(os::GraphicsOperations* graphicsOps)
 {
-	if ( !GL_initted )
-		atexit(opengl_close);
-
 	if (GL_initted) {
-		gr_opengl_cleanup(false);
+		gr_opengl_cleanup(graphicsOps, false);
 		GL_initted = false;
 	}
 
@@ -1655,12 +1573,12 @@ bool gr_opengl_init()
 		  gr_screen.max_h,
 		  gr_screen.bits_per_pixel ));
 
-	if ( opengl_init_display_device() ) {
+	if ( opengl_init_display_device(graphicsOps) ) {
 		Error(LOCATION, "Unable to initialize display device!\n");
 	}
 
 	// Initialize function pointers
-	if (!gladLoadGLLoader(SDL_GL_GetProcAddress)) {
+	if (!gladLoadGLLoader(GL_context->getLoaderFunction())) {
 		Error(LOCATION, "Failed to load OpenGL!");
 	}
 

--- a/code/graphics/gropengl.h
+++ b/code/graphics/gropengl.h
@@ -17,8 +17,8 @@
 
 const ubyte GL_zero_3ub[3] = { 0, 0, 0 };
 
-bool gr_opengl_init();
-void gr_opengl_cleanup(bool closing, int minimize=1);
+bool gr_opengl_init(os::GraphicsOperations* graphicsOps);
+void gr_opengl_cleanup(os::GraphicsOperations* graphicsOps, bool closing, int minimize=1);
 int opengl_check_for_errors(char *err_at = NULL);
 bool is_minimum_GLSL_version();
 

--- a/code/model/modelread.cpp
+++ b/code/model/modelread.cpp
@@ -423,7 +423,6 @@ void model_init()
 		Polygon_models[i] = NULL;
 	}
 
-	atexit( model_free_all );
 	model_initted = 1;
 }
 

--- a/code/osapi/osapi.cpp
+++ b/code/osapi/osapi.cpp
@@ -114,14 +114,6 @@ namespace
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 
-static HWND window_override;
-
-// For FRED
-void os_set_window_from_hwnd(HWND handle)
-{
-	window_override = handle;
-}
-
 // go through all windows and try and find the one that matches the search string
 BOOL __stdcall os_enum_windows( HWND hwnd, LPARAM param )
 {
@@ -208,8 +200,6 @@ static char			szWinTitle[128];
 static char			szWinClass[128];
 static int			Os_inited = 0;
 
-static SDL_mutex* Os_lock;
-
 static SCP_vector<SDL_Event> buffered_events;
 
 int Os_debugger_running = 0;
@@ -217,8 +207,6 @@ int Os_debugger_running = 0;
 // ----------------------------------------------------------------------------------------------------
 // OSAPI FORWARD DECLARATIONS
 //
-
-// called at shutdown. Makes sure all thread processing terminates.
 void os_deinit();
 
 // ----------------------------------------------------------------------------------------------------
@@ -235,8 +223,6 @@ void os_init(const char * wclass, const char * title, const char *app_name, cons
 
 	strcpy_s( szWinTitle, title );
 	strcpy_s( szWinClass, wclass );
-
-	Os_lock = SDL_CreateMutex();
 
 	mprintf(("  Initializing SDL...\n"));
 
@@ -269,8 +255,6 @@ void os_init(const char * wclass, const char * title, const char *app_name, cons
 
 	os::events::addEventListener(SDL_WINDOWEVENT, os::events::DEFAULT_LISTENER_WEIGHT, window_event_handler);
 	os::events::addEventListener(SDL_QUIT, os::events::DEFAULT_LISTENER_WEIGHT, quit_handler);
-
-	atexit(os_deinit);
 }
 
 // set the main window title
@@ -281,15 +265,14 @@ void os_set_title( const char * title )
 	SDL_SetWindowTitle(main_window, szWinTitle);
 }
 
-extern void gr_opengl_shutdown();
 // call at program end
 void os_cleanup()
 {
-	gr_opengl_shutdown();
-
 #ifndef NDEBUG
 	outwnd_close();
 #endif
+
+	os_deinit();
 }
 
 // window management -----------------------------------------------------------------
@@ -313,13 +296,8 @@ void os_set_window(SDL_Window* new_handle)
 	fAppActive = true;
 }
 
-void* os_get_window_override()
-{
-#ifdef WIN32
-	return window_override;
-#else
-	return nullptr;
-#endif
+void os_set_window_state(WindowState state) {
+
 }
 
 // process management -----------------------------------------------------------------
@@ -337,18 +315,6 @@ void os_sleep(uint ms)
 #else
 	SDL_Delay(ms);
 #endif
-}
-
-// Used to stop message processing
-void os_suspend()
-{
-	SDL_LockMutex( Os_lock );
-}
-
-// resume message processing
-void os_resume()
-{
-	SDL_UnlockMutex( Os_lock );
 }
 
 bool os_is_legacy_mode()
@@ -403,8 +369,6 @@ void os_deinit()
 		SDL_free(preferencesPath);
 		preferencesPath = nullptr;
 	}
-
-	SDL_DestroyMutex(Os_lock);
 
 	SDL_Quit();
 }

--- a/code/osapi/osapi.h
+++ b/code/osapi/osapi.h
@@ -24,6 +24,7 @@
 #include "osapi/dialogs.h"
 
 #include <functional>
+#include <memory>
 
 #include <SDL_events.h>
 
@@ -52,8 +53,13 @@ void os_cleanup();
 
 // window management ---------------------------------------------------------------
 
-// toggle window size between full screen and windowed
-void os_toggle_fullscreen();
+enum class WindowState {
+	Windowed,
+	Borderless,
+	Fullscreen
+};
+
+void os_set_window_state(WindowState state);
 
 // Returns 1 if app is not the foreground app.
 int os_foreground();
@@ -62,8 +68,6 @@ int os_foreground();
 SDL_Window* os_get_window();
 
 void os_set_window(SDL_Window* new_handle);
-
-void* os_get_window_override();
 
 // process management --------------------------------------------------------------
 
@@ -77,12 +81,6 @@ void os_poll();
 
 // Sleeps for n milliseconds or until app becomes active.
 void os_sleep(uint ms);
-
-// Used to stop message processing
-void os_suspend();
-
-// resume message processing
-void os_resume(); 
 
 /**
  * @brief Determines if FSO is running in legacy config mode
@@ -98,14 +96,116 @@ bool os_is_legacy_mode();
  */
 SCP_string os_get_config_path(const SCP_string& subpath = "");
 
-/**
- * @defgroup eventhandling API for consuming OS events
- * @ingroup osapi
- * See \ref eventhandling_page for more information.
- *  @{
- */
 namespace os
 {
+	/**
+	 * @brief Flags for OpenGL context creation
+	 */
+	enum OpenGLContextFlags
+	{
+		OGL_NONE = 0,
+		OGL_DEBUG = 1 << 0,
+		OGL_FORWARD_COMPATIBLE = 1 << 1
+	};
+
+	/**
+	 * @brief The required context profile
+	 */
+	enum class OpenGLProfile
+	{
+		Core,
+		Compatibility
+	};
+
+	/**
+	 * @brief Attributes for OpenGL context creation
+	 */
+	struct OpenGLContextAttributes
+	{
+		uint32_t red_size;
+		uint32_t green_size;
+		uint32_t blue_size;
+		uint32_t alpha_size;
+
+		uint32_t depth_size;
+		uint32_t stencil_size;
+
+		uint32_t multi_samples;
+
+		uint32_t major_version;
+		uint32_t minor_version;
+
+		uint32_t flags;
+		OpenGLProfile profile;
+	};
+
+	/**
+	 * @brief A function pointer for loading an OpenGL function
+	 */
+	typedef void* (*OpenGLLoadProc)(const char *name);
+
+	/**
+	 * @brief An OpenGL context
+	 * Can be deleted which will properly free the resources of the underlying OpenGL context
+	 */
+	class OpenGLContext
+	{
+	public:
+		virtual ~OpenGLContext() {}
+
+		/**
+		 * @brief Gets an OpenGL loader function
+		 */
+		virtual OpenGLLoadProc getLoaderFunction() = 0;
+
+		/**
+		 * @brief Swaps the buffers of this context
+		 */
+		virtual void swapBuffers() = 0;
+
+		/**
+		 * @brief Sets the swap interval
+		 */
+		virtual void setSwapInterval(int status) = 0;
+	};
+
+	/**
+	 * @brief Abstraction for various graphics operations
+	 * 
+	 * This is used for providing platform specific functionality for various graphics operations.
+	 */
+	class GraphicsOperations {
+	public:
+		virtual ~GraphicsOperations() {}
+
+		/**
+		 * @brief Creates an OpenGL contex
+		 *
+		 * Uses the specified attributes and creates an OpenGL context. The width and height
+		 * values may be used for creating the main window.
+		 *
+		 * @param attrs The desired Context attributes
+		 * @param width The width of the main window
+		 * @param height The height of the main window
+		 *
+		 * @return A pointer to the OpenGL context or @c nullptr if the creation has failed
+		 */
+		virtual std::unique_ptr<OpenGLContext> createOpenGLContext(const OpenGLContextAttributes& attrs,
+												  uint32_t width, uint32_t height) = 0;
+
+		/**
+		 * @brief Makes an OpenGL context current
+		 * @param ctx The OpenGL context to make current, may be @c nullptr
+		 */
+		virtual void makeOpenGLContextCurrent(OpenGLContext* ctx) = 0;
+	};
+
+	/**
+	 * @defgroup eventhandling API for consuming OS events
+	 * @ingroup osapi
+	 * See \ref eventhandling_page for more information.
+	 *  @{
+	 */
 	namespace events
 	{
 		/**
@@ -153,9 +253,8 @@ namespace os
 		*/
 		bool isWindowEvent(const SDL_Event& e, SDL_Window* window);
 	}
+	/** @} */ // end of OsAPI
 }
-
-/** @} */ // end of OsAPI
 
 // Documentation pages
 /**

--- a/fred2/fredview.cpp
+++ b/fred2/fredview.cpp
@@ -132,6 +132,195 @@ void view_universe(int just_marked = 0);
 void select_objects();
 void drag_rotate_save_backup();
 
+class MFCOpenGLContext : public os::OpenGLContext
+{
+	// HACK: Since OpenGL apparently likes global state we also have to make this global...
+	static void* _oglDllHandle;
+	static size_t _oglDllReferenceCount;
+
+	HWND _windowHandle = nullptr;
+	HDC _device_context = nullptr;
+	HGLRC _render_context = nullptr;
+
+	BOOL(WINAPI * wglSwapIntervalEXT)(int interval) = nullptr;
+public:
+
+	MFCOpenGLContext(HWND hwnd, HDC hdc, HGLRC hglrc)
+		: _windowHandle(hwnd),
+		  _device_context(hdc),
+		  _render_context(hglrc)
+	{
+		_oglDllHandle = SDL_LoadObject("OPENGL32.DLL");
+	}
+
+	~MFCOpenGLContext() override
+	{
+		if (!wglDeleteContext(_render_context)) {
+			mprintf(("Failed to delete render context!"));
+		}
+
+		ReleaseDC(_windowHandle, _device_context);
+	}
+
+	static void* wglLoader(const char* name)
+	{
+		auto wglAddr = reinterpret_cast<void*>(wglGetProcAddress(name));
+		if (wglAddr == nullptr && _oglDllHandle != nullptr)
+		{
+			wglAddr = SDL_LoadFunction(_oglDllHandle, name);
+		}
+
+		return wglAddr;
+	}
+
+	os::OpenGLLoadProc getLoaderFunction() override
+	{
+		return wglLoader;
+	}
+
+	void makeCurrent()
+	{
+		if (!wglMakeCurrent(_device_context, _render_context))
+		{
+			mprintf(("Failed to make OpenGL context current!\n"));
+		}
+	}
+
+	void swapBuffers() override
+	{
+		SwapBuffers(_device_context);
+	}
+
+	void setSwapInterval(int status) override
+	{
+		if (wglSwapIntervalEXT != nullptr)
+		{
+			wglSwapIntervalEXT(status);
+		}
+	}
+};
+
+class MFCGraphicsOperations : public os::GraphicsOperations
+{
+	HWND _windowHandle = nullptr;
+public:
+
+	explicit MFCGraphicsOperations(HWND hwnd)
+		: _windowHandle(hwnd)
+	{}
+
+	~MFCGraphicsOperations() override
+	{}
+
+	std::unique_ptr<os::OpenGLContext> createOpenGLContext(const os::OpenGLContextAttributes& attrs, uint32_t, uint32_t) override
+	{
+		int PixelFormat;
+		PIXELFORMATDESCRIPTOR pfd_test;
+		PIXELFORMATDESCRIPTOR GL_pfd;
+
+		mprintf(("  Initializing WGL...\n"));
+
+		memset(&GL_pfd, 0, sizeof(PIXELFORMATDESCRIPTOR));
+		memset(&pfd_test, 0, sizeof(PIXELFORMATDESCRIPTOR));
+
+		GL_pfd.nSize = sizeof(PIXELFORMATDESCRIPTOR);
+		GL_pfd.nVersion = 1;
+		GL_pfd.dwFlags = PFD_DRAW_TO_WINDOW | PFD_SUPPORT_OPENGL | PFD_DOUBLEBUFFER;
+		GL_pfd.iPixelType = PFD_TYPE_RGBA;
+		GL_pfd.cColorBits = attrs.red_size + attrs.green_size + attrs.blue_size + attrs.alpha_size;
+		GL_pfd.cRedBits = attrs.red_size;
+		GL_pfd.cGreenBits = attrs.green_size;
+		GL_pfd.cBlueBits = attrs.blue_size;
+		GL_pfd.cAlphaBits = attrs.alpha_size;
+		GL_pfd.cDepthBits = attrs.depth_size;
+		GL_pfd.cStencilBits = attrs.stencil_size;
+
+		Assert(_windowHandle != NULL);
+
+		auto device_context = GetDC(_windowHandle);
+
+		if (!device_context) {
+			Error(LOCATION, "Unable to get device context for OpenGL W32!");
+			return nullptr;
+		}
+
+		PixelFormat = ChoosePixelFormat(device_context, &GL_pfd);
+
+		if (!PixelFormat) {
+			Error(LOCATION, "Unable to choose pixel format for OpenGL W32!");
+			ReleaseDC(_windowHandle, device_context);
+			return nullptr;
+		}
+		else {
+			DescribePixelFormat(device_context, PixelFormat, sizeof(PIXELFORMATDESCRIPTOR), &pfd_test);
+		}
+
+		if (!SetPixelFormat(device_context, PixelFormat, &GL_pfd)) {
+			Error(LOCATION, "Unable to set pixel format for OpenGL W32!");
+			ReleaseDC(_windowHandle, device_context);
+			return nullptr;
+		}
+
+		auto render_context = wglCreateContext(device_context);
+		if (!render_context) {
+			Error(LOCATION, "Unable to create rendering context for OpenGL W32!");
+			ReleaseDC(_windowHandle, device_context);
+			return nullptr;
+		}
+
+		if (!wglMakeCurrent(device_context, render_context)) {
+			Error(LOCATION, "Unable to make current thread for OpenGL W32!");
+			
+			if (!wglDeleteContext(render_context)) {
+				mprintf(("Failed to delete render context!"));
+			}
+
+			ReleaseDC(_windowHandle, device_context);
+			return nullptr;
+		}
+
+		mprintf(("  Requested SDL Video values = R: %d, G: %d, B: %d, depth: %d, stencil: %d\n",
+			attrs.red_size, attrs.green_size, attrs.blue_size, attrs.depth_size, attrs.stencil_size));
+
+		// now report back as to what we ended up getting
+
+		DescribePixelFormat(device_context, PixelFormat, sizeof(PIXELFORMATDESCRIPTOR), &GL_pfd);
+
+		int r = GL_pfd.cRedBits;
+		int g = GL_pfd.cGreenBits;
+		int b = GL_pfd.cBlueBits;
+		int depth = GL_pfd.cDepthBits;
+		int stencil = GL_pfd.cStencilBits;
+		int db = ((GL_pfd.dwFlags & PFD_DOUBLEBUFFER) > 0);
+
+		mprintf(("  Actual WGL Video values    = R: %d, G: %d, B: %d, depth: %d, stencil: %d\n", r, g, b, depth, stencil, db));
+		
+		// Load the OpenGL DLL so we can use it to look up function pointers
+		// The name is from the SDL sources so it should be the right one
+		
+		return std::unique_ptr<os::OpenGLContext>(new MFCOpenGLContext(_windowHandle, device_context, render_context));
+	}
+
+	void makeOpenGLContextCurrent(os::OpenGLContext* ctx) override
+	{
+		if (ctx == nullptr)
+		{
+			if (!wglMakeCurrent(nullptr, nullptr))
+			{
+				mprintf(("Failed to make OpenGL context current!\n"));
+			}
+		}
+		else
+		{
+			reinterpret_cast<MFCOpenGLContext*>(ctx)->makeCurrent();
+		}
+	}
+};
+static std::unique_ptr<MFCGraphicsOperations> graphicsOperations;
+
+void* MFCOpenGLContext::_oglDllHandle = nullptr;
+size_t MFCOpenGLContext::_oglDllReferenceCount = 0;
+
 /////////////////////////////////////////////////////////////////////////////
 // CFREDView
 
@@ -4661,21 +4850,20 @@ void CFREDView::OnDestroy()
 {
 	audiostream_close();
 	snd_close();
- 	gr_close();
-   	os_set_window(NULL);	 
+ 	gr_close(graphicsOperations.get());
+	graphicsOperations.reset();
 
 	CView::OnDestroy();
 }
 
-extern void os_set_window_from_hwnd(HWND handle);
 int CFREDView::OnCreate(LPCREATESTRUCT lpCreateStruct) 
 {
 	if (CView::OnCreate(lpCreateStruct) == -1)
 		return -1;
 	
 	MoveWindow(0,0,200,300,1);
-	os_set_window_from_hwnd(this->GetSafeHwnd());
-   	if(fred_init() == false)
+	graphicsOperations.reset(new MFCGraphicsOperations(this->GetSafeHwnd()));
+   	if(fred_init(graphicsOperations.get()) == false)
 		return -1;
 
 	return 0;

--- a/fred2/management.cpp
+++ b/fred2/management.cpp
@@ -273,7 +273,7 @@ void fred_preload_all_briefing_icons()
 	}
 }
 
-bool fred_init()
+bool fred_init(os::GraphicsOperations* graphicsOps)
 {
 	int i;
 	char palette_filename[1024];
@@ -340,7 +340,7 @@ bool fred_init()
  // 	Cmdline_noglow = 1;
  	Cmdline_window = 1;
 
-	gr_init(GR_OPENGL, 640, 480, 32);
+	gr_init(graphicsOps, GR_OPENGL, 640, 480, 32);
 
 	io::mouse::CursorManager::get()->showCursor(false);
 

--- a/fred2/management.h
+++ b/fred2/management.h
@@ -69,7 +69,7 @@ void	convert_multiline_string(CString &dest, const char *src);
 void	deconvert_multiline_string(char *dest, const CString &str, int max_len);
 void	deconvert_multiline_string(SCP_string &dest, const CString &str);
 
-bool	fred_init();
+bool	fred_init(os::GraphicsOperations* graphicsOps);
 void	set_physics_controls();
 int	dup_object(object *objp);
 int	create_object_on_grid(int waypoint_instance = -1);

--- a/freespace2/CMakeLists.txt
+++ b/freespace2/CMakeLists.txt
@@ -3,7 +3,9 @@
 SET(FREESPACE_SRC freespace.cpp
 				levelpaging.cpp
 				freespace.h
-				levelpaging.h)
+				levelpaging.h
+				SDLGraphicsOperations.cpp
+				SDLGraphicsOperations.h)
 
 IF(FSO_BUILD_PACKAGE)
 	IF(FSO_INSTRUCTION_SET STREQUAL "SSE2" OR FSO_INSTRUCTION_SET STREQUAL "AVX")

--- a/freespace2/SDLGraphicsOperations.cpp
+++ b/freespace2/SDLGraphicsOperations.cpp
@@ -1,0 +1,123 @@
+//
+//
+
+#include "SDLGraphicsOperations.h"
+
+#include "cmdline/cmdline.h"
+
+#include <stdlib.h>
+
+class SDLOpenGLContext : public os::OpenGLContext
+{
+	SDL_GLContext _glCtx;
+public:
+	explicit SDLOpenGLContext(SDL_GLContext sdl_gl_context)
+		: _glCtx(sdl_gl_context)
+	{
+	}
+
+	~SDLOpenGLContext() override
+	{
+		SDL_GL_DeleteContext(_glCtx);
+	}
+
+	os::OpenGLLoadProc getLoaderFunction() override
+	{
+		return SDL_GL_GetProcAddress;
+	}
+
+	void makeCurrent()
+	{
+		SDL_GL_MakeCurrent(os_get_window(), _glCtx);
+	}
+
+	void swapBuffers() override
+	{
+		SDL_GL_SwapWindow(os_get_window());
+	}
+
+	void setSwapInterval(int status) override
+	{
+		SDL_GL_SetSwapInterval(status);
+	}
+};
+
+SDLGraphicsOperations::~SDLGraphicsOperations() {
+}
+
+std::unique_ptr<os::OpenGLContext> SDLGraphicsOperations::createOpenGLContext(const os::OpenGLContextAttributes& attrs,
+															 uint32_t width,
+															 uint32_t height) {
+	mprintf(("  Initializing SDL video...\n"));
+
+#ifdef SCP_UNIX
+	// Slight hack to make Mesa advertise S3TC support without libtxc_dxtn
+	setenv("force_s3tc_enable", "true", 1);
+#endif
+
+	if (SDL_InitSubSystem(SDL_INIT_VIDEO) < 0) {
+		Error(LOCATION, "Couldn't init SDL video: %s", SDL_GetError());
+		return nullptr;
+	}
+
+	SDL_GL_SetAttribute(SDL_GL_RED_SIZE, attrs.red_size);
+	SDL_GL_SetAttribute(SDL_GL_GREEN_SIZE, attrs.green_size);
+	SDL_GL_SetAttribute(SDL_GL_BLUE_SIZE, attrs.blue_size);
+	SDL_GL_SetAttribute(SDL_GL_DEPTH_SIZE, attrs.depth_size);
+	SDL_GL_SetAttribute(SDL_GL_STENCIL_SIZE, attrs.stencil_size);
+	SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 1);
+	SDL_GL_SetAttribute(SDL_GL_MULTISAMPLEBUFFERS, (attrs.multi_samples == 0) ? 0 : 1);
+	SDL_GL_SetAttribute(SDL_GL_MULTISAMPLESAMPLES, attrs.multi_samples);
+
+	mprintf(("  Requested SDL Video values = R: %d, G: %d, B: %d, depth: %d, stencil: %d, double-buffer: %d, FSAA: %d\n",
+		attrs.red_size, attrs.green_size, attrs.blue_size, attrs.depth_size, attrs.stencil_size, 1, attrs.multi_samples));
+
+	uint32_t windowflags = SDL_WINDOW_OPENGL;
+	if (Cmdline_fullscreen_window) {
+		windowflags |= SDL_WINDOW_BORDERLESS;
+	}
+
+	uint display = os_config_read_uint("Video", "Display", 0);
+	SDL_Window* window =
+		SDL_CreateWindow(Osreg_title, SDL_WINDOWPOS_CENTERED_DISPLAY(display), SDL_WINDOWPOS_CENTERED_DISPLAY(display),
+						 width, height, windowflags);
+	if (window == nullptr) {
+		Error(LOCATION, "Could not create window: %s\n", SDL_GetError());
+		return nullptr;
+	}
+
+	os_set_window(window);
+
+	auto ctx = SDL_GL_CreateContext(os_get_window());
+
+	if (ctx == nullptr) {
+		Error(LOCATION, "Could not create OpenGL Context: %s\n", SDL_GetError());
+		return nullptr;
+	}
+
+	int r, g, b, depth, stencil, db, fsaa_samples;
+	SDL_GL_GetAttribute(SDL_GL_RED_SIZE, &r);
+	SDL_GL_GetAttribute(SDL_GL_GREEN_SIZE, &g);
+	SDL_GL_GetAttribute(SDL_GL_BLUE_SIZE, &b);
+	SDL_GL_GetAttribute(SDL_GL_DEPTH_SIZE, &depth);
+	SDL_GL_GetAttribute(SDL_GL_DOUBLEBUFFER, &db);
+	SDL_GL_GetAttribute(SDL_GL_STENCIL_SIZE, &stencil);
+	SDL_GL_GetAttribute(SDL_GL_MULTISAMPLESAMPLES, &fsaa_samples);
+
+	mprintf(("  Actual SDL Video values    = R: %d, G: %d, B: %d, depth: %d, stencil: %d, double-buffer: %d, FSAA: %d\n",
+		r, g, b, depth, stencil, db, fsaa_samples));
+
+
+	return std::unique_ptr<os::OpenGLContext>(new SDLOpenGLContext(ctx));
+}
+
+void SDLGraphicsOperations::makeOpenGLContextCurrent(os::OpenGLContext* ctx)
+{
+	if (ctx == nullptr)
+	{
+		SDL_GL_MakeCurrent(os_get_window(), nullptr);
+	} else
+	{
+		reinterpret_cast<SDLOpenGLContext*>(ctx)->makeCurrent();
+	}
+}

--- a/freespace2/SDLGraphicsOperations.h
+++ b/freespace2/SDLGraphicsOperations.h
@@ -1,0 +1,18 @@
+
+#ifndef _SDL_GRAPHICS_OPERATIONS
+#define _SDL_GRAPHICS_OPERATIONS
+#pragma once
+
+#include "osapi/osapi.h"
+
+class SDLGraphicsOperations: public os::GraphicsOperations {
+ public:
+	~SDLGraphicsOperations() override;
+
+	std::unique_ptr<os::OpenGLContext> createOpenGLContext(const os::OpenGLContextAttributes& attrs,
+												  uint32_t width, uint32_t height) override;
+
+	void makeOpenGLContextCurrent(os::OpenGLContext* ctx) override;
+};
+
+#endif // _SDL_GRAPHICS_OPERATIONS

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -162,6 +162,8 @@
 #include "weapon/shockwave.h"
 #include "weapon/weapon.h"
 
+#include "SDLGraphicsOperations.h"
+
 #include <stdexcept>
 #include <SDL.h>
 #include <SDL_main.h>
@@ -524,6 +526,7 @@ sound_env Game_sound_env;
 sound_env Game_default_sound_env = { EAX_ENVIRONMENT_BATHROOM, 0.2f, 0.2f, 1.0f };
 int Game_sound_env_update_timestamp;
 
+static std::unique_ptr<SDLGraphicsOperations> sdlGraphicsOperations;
 
 fs_builtin_mission *game_find_builtin_mission(char *filename)
 {
@@ -1865,7 +1868,8 @@ void game_init()
 // SOUND INIT END
 /////////////////////////////
 
-	if ( gr_init() == false ) {
+	sdlGraphicsOperations.reset(new SDLGraphicsOperations());
+	if ( gr_init(sdlGraphicsOperations.get()) == false ) {
 		os::dialogs::Message(os::dialogs::MESSAGEBOX_ERROR, "Error intializing graphics!");
 		exit(1);
 		return;
@@ -7146,7 +7150,6 @@ void game_shutdown(void)
 	// the menu close functions will unload the bitmaps if they were displayed during the game
 	main_hall_close();
 	training_menu_close();
-	gr_close();
 
 	// free left over memory from table parsing
 	player_tips_close();
@@ -7163,6 +7166,8 @@ void game_shutdown(void)
 	model_free_all();
 	bm_unload_all();			// unload/free bitmaps, has to be called *after* model_free_all()!
 
+	gr_close(sdlGraphicsOperations.get());
+	sdlGraphicsOperations.reset();
 	os_cleanup();
 
 	// although the comment in cmdline.cpp said this isn't needed,


### PR DESCRIPTION
This allows to use a different method of creating and managing the
OpenGL context. This is needed by wxFRED where the OpenGL context is
created by wxWidgets. This will probably also fix #753 since it uses the
old wgl based method of creating an OpenGL context in FRED.

There are still a few SDL calls in gropengl.cpp but those are related to windowing instead of OpenGL. I'll fix that in another PR.