### PR TITLE
Fix for #765

### DIFF
--- a/code/graphics/gropengl.cpp
+++ b/code/graphics/gropengl.cpp
@@ -64,6 +64,8 @@ static ushort *GL_original_gamma_ramp = NULL;
 int Use_VBOs = 0;
 int Use_PBOs = 0;
 
+float GL_line_width = 1.0f;
+
 static ubyte *GL_saved_screen = NULL;
 static int GL_saved_screen_id = -1;
 static GLuint GL_screen_pbo = 0;
@@ -973,6 +975,7 @@ void gr_opengl_translate_texture_matrix(int unit, const vec3d *shift)
 
 void gr_opengl_set_line_width(float width)
 {
+	GL_line_width = width;
 	glLineWidth(width);
 }
 

--- a/code/graphics/gropengl.h
+++ b/code/graphics/gropengl.h
@@ -34,4 +34,6 @@ extern int GLSL_version;
 extern int Use_VBOs;
 extern int Use_PBOs;
 
+extern float GL_line_width;
+
 #endif

--- a/code/graphics/gropengldraw.cpp
+++ b/code/graphics/gropengldraw.cpp
@@ -77,6 +77,8 @@ namespace
 
         path->beginPath();
 
+		path->setStrokeWidth(GL_line_width);
+
         return path;
     }
 
@@ -888,7 +890,6 @@ void gr_opengl_line(float x1, float y1, float x2, float y2, int resize_mode)
         path->lineTo(x2, y2);
 
         path->setStrokeColor(&gr_screen.current_color);
-        path->setStrokeWidth(1.0f);
         path->stroke();
     }
 
@@ -965,7 +966,6 @@ void gr_opengl_gradient(int x1, int y1, int x2, int y2, int resize_mode)
     path->lineTo(i2fl(x2), i2fl(y2));
 
     path->setStrokePaint(gradientPaint);
-    path->setStrokeWidth(1.0f);
     path->stroke();
 
     endDrawing(path);


### PR DESCRIPTION
glLineWidth is no longer an effective way of setting the line width of
2D operations.