### PR TITLE
Fix for #768

### DIFF
--- a/code/globalincs/memory/memory.cpp
+++ b/code/globalincs/memory/memory.cpp
@@ -207,7 +207,12 @@ namespace memory
 	// Memory tracking functions
 	void register_malloc(size_t size, const char *filename, int)
 	{
+		// MSVC <= 2013 somehow allocates memory when locking a mutex
+		// MSVC >= 2015 should be fine, for earlier version this probably means 
+		// that the values will be corrupted but at least they will be able to run...
+#if !SCP_COMPILER_IS_MSVC || SCP_COMPILER_VERSION_MAJOR >= 19
 		std::lock_guard<std::mutex> guard(reportLock);
+#endif
 
 		usedMemory += size;
 
@@ -235,7 +240,12 @@ namespace memory
 
 	void unregister_malloc(size_t size, const char *filename, int)
 	{
+		// MSVC <= 2013 somehow allocates memory when locking a mutex
+		// MSVC >= 2015 should be fine, for earlier version this probably means 
+		// that the values will be corrupted but at least they will be able to run...
+#if !SCP_COMPILER_IS_MSVC || SCP_COMPILER_VERSION_MAJOR >= 19
 		std::lock_guard<std::mutex> guard(reportLock);
+#endif
 
 		usedMemory -= size;
 


### PR DESCRIPTION
Apparently MSVC 2013 allocates memory when locking a mutex which calls
our allocation hook when the tries to call our memory tracking function
which leads to a deadlock. Since there is no way of providing a memory
allocation function for std::mutex the best solution is to simply
disable the lock_guard for everything before MSVC 2015. That will
probably corrupt the memory tracking values at some point but it's
better than not being able to run FSO at all.

This fixes #768.