### PR TITLE
Clean up CMake MSVC warning handling

### DIFF
--- a/cmake/toolchain-msvc.cmake
+++ b/cmake/toolchain-msvc.cmake
@@ -10,6 +10,28 @@ set_property(GLOBAL PROPERTY DEBUG_CONFIGURATIONS Debug)
 option(MSVC_USE_RUNTIME_DLL "Use the dynamically linked version of the runtime" OFF)
 MARK_AS_ADVANCED(FORCE MSVC_USE_RUNTIME_DLL)
 
+# These are the warnings we disable
+set(WARNING_FLAGS
+	/wd"4100" # unreferenced formal parameters
+	/wd"4127" # constant conditional (assert)
+	/wd"4201" # nonstandard extension used: nameless struct/union (happens a lot in Windows include headers)
+	/wd"4290" # C++ exception specification ignored except to indicate a function is not __declspec(nothrow)
+	/wd"4390" # empty control statement (triggered by nprintf and mprintf's inside of one-line if's, etc)
+	/wd"4410" # illegal size for operand... ie... 	fxch st(1)
+	/wd"4511" # copy constructor could not be generated (happens a lot in Windows include headers)
+	/wd"4512" # assignment operator could not be generated (happens a lot in Windows include headers)
+	/wd"4514" # unreferenced inline function removed
+	/wd"4611" # _setjmp warning.  Since we use setjmp alot, and we don't really use constructors or destructors, this warning doesn't really apply to us.
+	/wd"4663" # C++ language change (template specification)
+	/wd"4710" # is inline function not expanded (who cares?)
+	/wd"4711" # tells us an inline function was expanded (who cares?)
+	/wd"4786" # is identifier truncated to 255 characters (happens all the time in Microsoft #includes) -- Goober5000"
+	/wd"4996" # deprecated strcpy, strcat, sprintf, etc. (from MSVC 2005) - taylor
+	$<$<CONFIG:Release>:/wd"4101"> # In release mode there are unreferenced variables because debug needs them
+)
+
+target_compile_options(compiler INTERFACE ${WARNING_FLAGS})
+
 # Base
 set(CMAKE_C_FLAGS "/MP /GS- /analyze- /Zc:wchar_t /errorReport:prompt /WX- /Zc:forScope /Gd /EHsc /nologo")
 set(CMAKE_CXX_FLAGS "/MP /GS- /analyze- /Zc:wchar_t /errorReport:prompt /WX- /Zc:forScope /Gd /EHsc /nologo")

--- a/code/graphics/2d.h
+++ b/code/graphics/2d.h
@@ -696,13 +696,13 @@ bool gr_resize_screen_posf(float *x, float *y, float *w = NULL, float *h = NULL,
 // Does formatted printing.  This calls gr_string after formatting,
 // so if you don't need to format the string, then call gr_string
 // directly.
-extern void _cdecl gr_printf( int x, int y, const char * format, ... );
+extern void gr_printf( int x, int y, const char * format, ... );
 // same as gr_printf but positions text correctly in menus
-extern void _cdecl gr_printf_menu( int x, int y, const char * format, ... );
+extern void gr_printf_menu( int x, int y, const char * format, ... );
 // same as gr_printf_menu but accounts for menu zooming
-extern void _cdecl gr_printf_menu_zoomed( int x, int y, const char * format, ... );
+extern void gr_printf_menu_zoomed( int x, int y, const char * format, ... );
 // same as gr_printf but doesn't resize for non-standard resolutions
-extern void _cdecl gr_printf_no_resize( int x, int y, const char * format, ... );
+extern void gr_printf_no_resize( int x, int y, const char * format, ... );
 
 // Returns the size of the string in pixels in w and h
 extern void gr_get_string_size( int *w, int *h, const char * text, int len = 9999 );

--- a/code/graphics/software/font.cpp
+++ b/code/graphics/software/font.cpp
@@ -592,7 +592,7 @@ void gr_string_win(int x, int y, char *s)
 
 char grx_printf_text[2048];
 
-void _cdecl gr_printf(int x, int y, const char * format, ...)
+void gr_printf(int x, int y, const char * format, ...)
 {
 	va_list args;
 
@@ -606,7 +606,7 @@ void _cdecl gr_printf(int x, int y, const char * format, ...)
 	gr_string(x, y, grx_printf_text);
 }
 
-void _cdecl gr_printf_menu(int x, int y, const char * format, ...)
+void gr_printf_menu(int x, int y, const char * format, ...)
 {
 	va_list args;
 
@@ -620,7 +620,7 @@ void _cdecl gr_printf_menu(int x, int y, const char * format, ...)
 	gr_string(x, y, grx_printf_text, GR_RESIZE_MENU);
 }
 
-void _cdecl gr_printf_menu_zoomed(int x, int y, const char * format, ...)
+void gr_printf_menu_zoomed(int x, int y, const char * format, ...)
 {
 	va_list args;
 
@@ -634,7 +634,7 @@ void _cdecl gr_printf_menu_zoomed(int x, int y, const char * format, ...)
 	gr_string(x, y, grx_printf_text, GR_RESIZE_MENU_ZOOMED);
 }
 
-void _cdecl gr_printf_no_resize(int x, int y, const char * format, ...)
+void gr_printf_no_resize(int x, int y, const char * format, ...)
 {
 	va_list args;
 

--- a/code/windows_stub/config.h
+++ b/code/windows_stub/config.h
@@ -25,13 +25,6 @@
 
 #if defined _WIN32
 
-#if defined _MSC_VER
-
-#elif defined(__MINGW32__) || defined(__GNUC__)
-// We're using mingw or we're crosscompiling
-#define _cdecl __cdecl
-#endif
-
 #ifndef snprintf
 #define snprintf _snprintf
 #endif
@@ -52,7 +45,6 @@
 #define DEBUGME(d1) nprintf(( "Warning", "DEBUGME: %s in " __FILE__ " at line %d, msg \"%s\", thread %d\n", __FUNCTION__, __LINE__, d1, getpid() ))
 
 
-#define _cdecl
 #define __cdecl
 #define __stdcall
 #define PASCAL

--- a/code/windows_stub/config.h
+++ b/code/windows_stub/config.h
@@ -25,35 +25,7 @@
 
 #if defined _WIN32
 
-// Goober5000 - now these warnings will only be disabled when compiling with MSVC :)
 #if defined _MSC_VER
-
-// 4002 is too many actual parameters for macro 'Assertion'
-// 4100 is unreferenced formal parameters,
-// 4127 is constant conditional (assert)
-// 4201 nonstandard extension used: nameless struct/union (happens a lot in Windows include headers)
-// 4290 C++ exception specification ignored except to indicate a function is not __declspec(nothrow)
-// 4390 empty control statement (triggered by nprintf and mprintf's inside of one-line if's, etc)
-// 4410 illegal size for operand... ie... 	fxch st(1)
-// 4511 copy constructor could not be generated (happens a lot in Windows include headers)
-// 4512 assignment operator could not be generated (happens a lot in Windows include headers)
-// 4514 unreferenced inline function removed,
-// 4611 _setjmp warning.  Since we use setjmp alot, and we don't really use constructors or destructors, this warning doesn't really apply to us.
-// 4663 C++ language change (template specification)
-// 4710 is inline function not expanded (who cares?)
-// 4711 tells us an inline function was expanded (who cares?)
-// 4725 is the pentium division bug warning, and I can't seem to get rid of it, even with this pragma.
-//      JS: I figured out the disabling 4725 works, but not on the first function in the module.
-//      So to disable this, I add in a stub function at the top of each module that does nothing.
-// 4786 is identifier truncated to 255 characters (happens all the time in Microsoft #includes) -- Goober5000
-// 4996 deprecated strcpy, strcat, sprintf, etc. (from MSVC 2005) - taylor
-#pragma warning(disable: 4002 4100 4127 4201 4290 4390 4410 4511 4512 4514 4611 4663 4710 4711 4725 4786 4996)
-
-#ifdef NDEBUG
-// Try/Catch in MSVC is not handling these right, so for Release Builds
-// we are disabling unreferenced local variable warnings from showing. Zacam.
-#pragma warning(disable: 4101)
-#endif
 
 #elif defined(__MINGW32__) || defined(__GNUC__)
 // We're using mingw or we're crosscompiling


### PR DESCRIPTION
Also removes `_cdecl` since it's not needed anymore and not compatible with other compilers.