### PR TITLE
Fix a couple button-related joystick issues.

### DIFF
--- a/code/io/joy-sdl.cpp
+++ b/code/io/joy-sdl.cpp
@@ -801,8 +801,6 @@ int joy_down(int btn)
 	else if (btn >= JOY_NUM_BUTTONS)
 	{
 		// Is hat
-		btn -= JOY_NUM_BUTTONS;
-
 		return (current->getHatPosition(0) == btn) ? 1 : 0;
 	} // Else, is a button
 

--- a/code/io/joy-sdl.cpp
+++ b/code/io/joy-sdl.cpp
@@ -734,7 +734,7 @@ float joy_down_time(int btn)
 		return 0.0f;
 	}
 
-	if (btn >= JOY_TOTAL_BUTTONS)
+	if (btn >= JOY_TOTAL_BUTTONS || (btn >= current->numButtons() && btn < JOY_NUM_BUTTONS))
 	{
 		// Not a valid button
 		return 0.f;
@@ -763,7 +763,7 @@ int joy_down_count(int btn, int reset_count)
 		return 0;
 	}
 
-	if (btn >= JOY_TOTAL_BUTTONS)
+	if (btn >= JOY_TOTAL_BUTTONS || (btn >= current->numButtons() && btn < JOY_NUM_BUTTONS))
 	{
 		// Not a valid button
 		return 0;
@@ -792,7 +792,7 @@ int joy_down(int btn)
 		return 0;
 	}
 
-	if (btn >= JOY_TOTAL_BUTTONS)
+	if (btn >= JOY_TOTAL_BUTTONS || (btn >= current->numButtons() && btn < JOY_NUM_BUTTONS))
 	{
 		// Not a valid button
 		return 0;


### PR DESCRIPTION
When the hat switch code was fixed to restrict joysticks to 32 buttons again, it forgot to invalidate buttons between `numButtons()` and 32. This could lead to some assertions being failed when the joystick got asked for the status of a nonexistent button.

Also, `joy_down()` was comparing the hat's current position (a value from the `HatPosition` enum) to a 0-based index (such as `joy_down_count()` uses to index the relevant array), which was making hat switches not work with continuous controls.