### PR TITLE
More compatibility code for joystick hats.

### DIFF
--- a/code/io/joy-sdl.cpp
+++ b/code/io/joy-sdl.cpp
@@ -609,24 +609,8 @@ namespace joystick
 		std::bitset<4> hatset = evt.value;
 		auto hatpos = convertSDLHat(evt.value);
 
-		if ((hatpos == HAT_DOWN) || (hatpos == HAT_UP) || (hatpos == HAT_LEFT) || (hatpos == HAT_RIGHT)) {
-			// Hat was reported to be in a cardinal position
-			std::bitset<4> lastset = _hat[hat].Value_SDL;
-
-			// Using bitfield here because it is bodasciously cleaner and faster than trying to do the same with enum's
-			if ((lastset.count() == 1) && (((hatset >> 1) == lastset) || ((hatset << 1) == lastset) || ((hatset | lastset) == 0x09))) {
-				// Hat is in a corner position
-				// Combine the bitfields and translate it to the hatpos
-				hatset |= lastset;
-
-				hatpos = convertSDLHat(hatset.to_ulong());
-			} // Else, hat is in a cardinal value. Don't need to change hatpos.
-
-		}
-
 		// Set current values
 		_hat[hat].Value = hatpos;
-		_hat[hat].Value_SDL = hatset.to_ulong();
 
 		// Reset inactive hat positions
 		for (auto i = 0; i < 4; ++i) {

--- a/code/io/joy-sdl.cpp
+++ b/code/io/joy-sdl.cpp
@@ -2,9 +2,10 @@
 #include "io/timer.h"
 #include "osapi/osapi.h"
 
+#include <algorithm>
+#include <bitset>
 #include <memory>
 #include <utility>
-#include <algorithm>
 
 using namespace io::joystick;
 using namespace os::events;
@@ -26,10 +27,14 @@ int hatEnumToIdx(HatPosition in) {
 }
 
 /**
-* @brief Compatibility conversion from array index to HatPosition
+* @brief Compatibility conversion from Button index to HatPosition
 */
 inline
-HatPosition hatIdxToEnum(int in) {
+HatPosition hatBtnToEnum(int in) {
+	Assertion(in >= JOY_NUM_BUTTONS, "Invalid button value passed to hatBtnToEnum: %i", in);
+
+	in -= JOY_NUM_BUTTONS;
+
 	switch (in) {
 	case 0:
 		return HAT_DOWN;
@@ -372,35 +377,58 @@ namespace joystick
 		return _hat[index].Value;
 	}
 
-	int Joystick::getHatDownCount(int index, int pos, bool reset) {
+	int Joystick::getHatDownCount(int index, HatPosition pos, bool ext, bool reset) {
 		Assertion(index >= 0 && index < numHats(), "Invalid index %d!", index);
-		Assertion(pos >= 0 && pos < HAT_NUM_POS, "Invalid hat position %d!", pos);
 
-		auto val = _hat[index].DownCount[pos];
+		int val;
 
-		if (reset) {
-			_hat[index].DownCount[pos] = 0;
+		if (pos == HAT_CENTERED) {
+			return 0;
+		}
+
+		if (ext) {
+			// Use 8-position
+			val = _hat[index].DownCount8[pos];
+
+			if (reset) {
+				_hat[index].DownCount8[pos] = 0;
+			}
+		} else {
+			// Use 4-position
+			val = _hat[index].DownCount4[pos];
+
+			if (reset) {
+				_hat[index].DownCount4[pos] = 0;
+			}
 		}
 
 		return val;
 	}
 
-	float Joystick::getHatDownTime(int index, int pos) const
+	float Joystick::getHatDownTime(int index, HatPosition pos, bool ext) const
 	{
 		Assertion(index >= 0 && index < numHats(), "Invalid index %d!", index);
-		Assertion(pos >= 0 && pos < HAT_NUM_POS, "Invalid hat position %d!", pos);
 
-		if ((_hat[index].Value == HAT_CENTERED) || (_hat[index].DownTimestamp < 0)) {
-			// Hat is inactive
+		if (pos == HAT_CENTERED) {
 			return 0.0f;
+		}
 
-		} else if (_hat[index].Value != hatIdxToEnum(pos)) {
-			// Hat is active, but not in this position
+		int val;
+
+		if (ext) {
+			// Use 8-position
+			val = _hat[index].DownTimestamp8[pos];
+
+		} else {
+			// Use 4-position
+			val = _hat[index].DownTimestamp4[pos];
+		}
+
+		if (val < 0) {
 			return 0.0f;
+		}
 
-		} // Else Hat is active in this position
-
-		auto diff = timer_get_milliseconds() - _hat[index].DownTimestamp;
+		auto diff = timer_get_milliseconds() - val;
 
 		return static_cast<float>(diff) / 1000.f;
 	}
@@ -486,11 +514,36 @@ namespace joystick
 		_hat.resize(static_cast<size_t>(hatNum));
 		for (auto i = 0; i < hatNum; ++i)
 		{
-			_hat[i].Value = convertSDLHat(SDL_JoystickGetHat(_joystick, i));
+			std::bitset<4> hatset = SDL_JoystickGetHat(_joystick, i);
+			auto hatval = convertSDLHat(SDL_JoystickGetHat(_joystick, i));
+			_hat[i].Value = hatval;
+
+			// Reset timestampts
+			for (auto j = 0; j < 4; ++j) {
+				_hat[i].DownTimestamp4[j] = -1;
+			}
+			for (auto j = 0; j < 8; ++j) {
+				_hat[i].DownTimestamp8[j] = -1;
+			}
 
 			if (_hat[i].Value != HAT_CENTERED)
 			{
-				_hat[i].DownTimestamp = timer_get_milliseconds();
+				// Set the 4-pos timestamp(s)
+				if ((hatset[HAT_DOWN])) {
+					_hat[i].DownTimestamp4[HAT_DOWN] = timer_get_milliseconds();
+				}
+				if ((hatset[HAT_UP])) {
+					_hat[i].DownTimestamp4[HAT_UP] = timer_get_milliseconds();
+				}
+				if ((hatset[HAT_LEFT])) {
+					_hat[i].DownTimestamp4[HAT_LEFT] = timer_get_milliseconds();
+				}
+				if ((hatset[HAT_RIGHT])) {
+					_hat[i].DownTimestamp4[HAT_RIGHT] = timer_get_milliseconds();
+				}
+
+				// Set the 8-pos timestamp
+				_hat[i].DownTimestamp8[hatval] = timer_get_milliseconds();
 			}
 		}
 	}
@@ -553,13 +606,62 @@ namespace joystick
 
 		Assertion(hat < numHats(), "SDL event contained invalid hat index!");
 
+		std::bitset<4> hatset = evt.value;
 		auto hatpos = convertSDLHat(evt.value);
-		_hat[hat].DownTimestamp = (hatpos != HAT_CENTERED) ? timer_get_milliseconds() : -1;
-		_hat[hat].Value = hatpos;
 
-		if (hatpos != HAT_CENTERED)
-		{
-			++_hat[hat].DownCount[hatEnumToIdx(hatpos)];
+		if ((hatpos == HAT_DOWN) || (hatpos == HAT_UP) || (hatpos == HAT_LEFT) || (hatpos == HAT_RIGHT)) {
+			// Hat was reported to be in a cardinal position
+			std::bitset<4> lastset = _hat[hat].Value_SDL;
+
+			// Using bitfield here because it is bodasciously cleaner and faster than trying to do the same with enum's
+			if ((lastset.count() == 1) && (((hatset >> 1) == lastset) || ((hatset << 1) == lastset) || ((hatset | lastset) == 0x09))) {
+				// Hat is in a corner position
+				// Combine the bitfields and translate it to the hatpos
+				hatset |= lastset;
+
+				hatpos = convertSDLHat(hatset.to_ulong());
+			} // Else, hat is in a cardinal value. Don't need to change hatpos.
+
+		}
+
+		// Set current values
+		_hat[hat].Value = hatpos;
+		_hat[hat].Value_SDL = hatset.to_ulong();
+
+		// Reset inactive hat positions
+		for (auto i = 0; i < 4; ++i) {
+			if (!hatset[i]) {
+				_hat[hat].DownTimestamp4[i] = -1;
+			}
+		}
+		for (auto i = 0; i < 8; ++i) {
+			if (i != hatpos) {
+				_hat[hat].DownTimestamp8[i] = -1;
+			}
+		}
+
+		if (hatpos != HAT_CENTERED) {
+			// Set the 4-pos timestamps and down counts if the timestamp is not set
+			if ((hatset[HAT_DOWN]) && (_hat[hat].DownTimestamp4[HAT_DOWN] == -1)) {
+				_hat[hat].DownTimestamp4[HAT_DOWN] = timer_get_milliseconds();
+				++_hat[hat].DownCount4[HAT_DOWN];
+			}
+			if ((hatset[HAT_UP]) && (_hat[hat].DownTimestamp4[HAT_UP] == -1)) {
+				_hat[hat].DownTimestamp4[HAT_UP] = timer_get_milliseconds();
+				++_hat[hat].DownCount4[HAT_UP];
+			}
+			if ((hatset[HAT_LEFT]) && (_hat[hat].DownTimestamp4[HAT_LEFT] == -1)) {
+				_hat[hat].DownTimestamp4[HAT_LEFT] = timer_get_milliseconds();
+				++_hat[hat].DownCount4[HAT_LEFT];
+			}
+			if ((hatset[HAT_RIGHT]) && (_hat[hat].DownTimestamp4[HAT_RIGHT] == -1)) {
+				_hat[hat].DownTimestamp4[HAT_RIGHT] = timer_get_milliseconds();
+				++_hat[hat].DownCount4[HAT_RIGHT];
+			}
+
+			// Set the 8-pos timestamp and down count
+			_hat[hat].DownTimestamp8[hatpos] = timer_get_milliseconds();
+			++_hat[hat].DownCount8[hatpos];
 		}
 	}
 
@@ -743,9 +845,7 @@ float joy_down_time(int btn)
 	else if (btn >= JOY_NUM_BUTTONS)
 	{
 		// Is hat
-		btn -= JOY_NUM_BUTTONS;
-
-		return current->getHatDownTime(0, btn);
+		return current->getHatDownTime(0, hatBtnToEnum(btn), false);
 
 	} // Else, Is a button
 
@@ -772,9 +872,7 @@ int joy_down_count(int btn, int reset_count)
 	else if (btn >= JOY_NUM_BUTTONS)
 	{
 		// Is hat
-		btn -= JOY_NUM_BUTTONS;
-
-		return current->getHatDownCount(0, btn, reset_count != 0);
+		return current->getHatDownCount(0, hatBtnToEnum(btn), false, reset_count != 0);
 
 	} // Else, is a button
 
@@ -801,7 +899,7 @@ int joy_down(int btn)
 	else if (btn >= JOY_NUM_BUTTONS)
 	{
 		// Is hat
-		return (current->getHatPosition(0) == btn) ? 1 : 0;
+		return current->getHatDownTime(0, hatBtnToEnum(btn), false) > 0;
 	} // Else, is a button
 
 

--- a/code/io/joy.h
+++ b/code/io/joy.h
@@ -16,7 +16,7 @@
 
 // z64: Moved up here for compatibility. Bye bye, organization!
 const int JOY_NUM_BUTTONS = 32;
-const int JOY_NUM_HAT_POS = 4;	// z64: This stays at 4 until we have translation text for the corners
+const int JOY_NUM_HAT_POS = 4;
 const int JOY_TOTAL_BUTTONS = (JOY_NUM_BUTTONS + JOY_NUM_HAT_POS);
 
 namespace io
@@ -28,21 +28,19 @@ namespace io
 	{
 		/**
 		 * @brief A hat position
-		 * @note Order here is how the old code used it (except for the corner positions)
+		 * @note Order here is based on SDL bit positions
 		 */
 		enum HatPosition
 		{
 			HAT_CENTERED = -1,
-			HAT_DOWN = JOY_NUM_BUTTONS,
-			HAT_UP,
-			HAT_LEFT,
+			HAT_UP = 0,
 			HAT_RIGHT,
-			HAT_LEFTDOWN,
-			HAT_LEFTUP,
-			HAT_RIGHTDOWN,
+			HAT_DOWN,
+			HAT_LEFT,
 			HAT_RIGHTUP,
-
-			HAT_NUM_POS = 8     // This one is always last. Currently set to 8 for compatibility reasons
+			HAT_RIGHTDOWN,
+			HAT_LEFTUP,
+			HAT_LEFTDOWN
 		};
 
 		/**
@@ -144,24 +142,26 @@ namespace io
 			/**
 			 * @brief Gets the down time of the given hat and position
 			 * @param[in] index The index of the hat to query, must be in [0, numHats())
-			 * @param[in] pos The position to query, must be in [0, int(HAT_NUM_POS))
+			 * @param[in] pos The position to query, must be in [0, JOY_NUM_HAT_POS)
+			 * @param[in] ext If @c false, uses the four-position hat values. If @c ture, uses the eight-position hat values
 			 *
 			 * @returns 0.0f If the queried hat positions is not active, or
 			 * @returns The time, in seconds, that the hat has been active in that position
 			 */
-			float getHatDownTime(int index, int pos) const;
+			float getHatDownTime(int index, HatPosition pos, bool ext) const;
 
 			/**
 			* @brief Times the specified button has been pressed since the last reset
-			* @param index The index of the button, must be in [0, numHats())
-			* @param[in] pos The position to query, must be in [0, int(HAT_NUM_POS))
+			* @param[in] index The index of the button, must be in [0, numHats())
+			* @param[in] pos The position to query, must be in [0, JOY_NUM_HAT_POS)
+			* @param[in] ext If @c false, uses the four-position hat values. If @c true, uses the eight-position hat values
 			* @param reset @c true to reset the count
 			* @return The number of times the button has been pressed
 			*
 			* @warning This function may be removed in the future, it's only here for compatibility with the
 			* current code base.
 			*/
-			int getHatDownCount(int index, int pos, bool reset);
+			int getHatDownCount(int index, HatPosition pos, bool ext, bool reset);
 
 			/**
 			 * @brief Gets the number of axes on this joystick
@@ -254,9 +254,14 @@ namespace io
 
 			struct hat_info
 			{
-				HatPosition Value;                  //!< The current hat value.
-				int         DownTimestamp;          //!< The timestamp when the hat last activated, -1 if centered.
-				int         DownCount[HAT_NUM_POS]; //!< The number of times each hat position has been hit since we last checked.
+				HatPosition Value;      //!< The current hat position
+				int Value_SDL;          //!< The current hat position (SDL format)
+				
+				int DownTimestamp4[4];  //!< The timestamp when each 4-hat position was last hit, -1 if inactive.
+				int DownTimestamp8[8];  //!< The timestamp when each 8-hat posision was last hit, -1 if inactive.
+
+				int DownCount4[4];      //!< The number of times each 4-hat position has been hit since we last checked.
+				int DownCount8[8];      //!< The number of times each 8-hat position has been hit since we last checked.
 			};
 
 			SCP_vector<hat_info> _hat;

--- a/code/io/joy.h
+++ b/code/io/joy.h
@@ -255,8 +255,7 @@ namespace io
 			struct hat_info
 			{
 				HatPosition Value;      //!< The current hat position
-				int Value_SDL;          //!< The current hat position (SDL format)
-				
+
 				int DownTimestamp4[4];  //!< The timestamp when each 4-hat position was last hit, -1 if inactive.
 				int DownTimestamp8[8];  //!< The timestamp when each 8-hat posision was last hit, -1 if inactive.
 


### PR DESCRIPTION
* There's now registers for both 4 position and 8 position hats for both timestamps and downcounts
* There's conversion code to allow an 8-position hat to act like a 4-position hat, which is needed by the FSO codebase which only uses 4-pos hats
* There's also conversion code to allow a 4-pos hat to act like an 8-position hat to some degree, This is currently "omitted" by the second commit, so if anybody needs it in the future you can just revert the commit.