### PR TITLE
Add badges to Readme

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,5 +1,8 @@
 FreeSpace2 *S*ource *C*ode *P*roject
 ==
+[![Build Status](https://travis-ci.org/scp-fs2open/fs2open.github.com.svg?branch=master)](https://travis-ci.org/scp-fs2open/fs2open.github.com)
+[![Coverity](https://img.shields.io/coverity/scan/870.svg)](https://scan.coverity.com/projects/870)
+
 Building
 --
 For building you will need [CMake](http://www.cmake.org/cmake/resources/software.html). Version 3.4 is required. Once you have installed CMake you should create a build directory where the project/make files should be created, **do not create them inside the source tree!**<br>


### PR DESCRIPTION
Re-add visual badges that provide overview of build and code quality status via Travis and Coverity.

These existing previously and appear to have been omitted in the CMake transition.