### PR TITLE
Fix wrong joystick event assignment

### DIFF
--- a/code/io/joy-sdl.cpp
+++ b/code/io/joy-sdl.cpp
@@ -240,7 +240,7 @@ bool device_event_handler(const SDL_Event &evt)
 
 			for (auto iter = joysticks.begin(); iter != joysticks.end(); ++iter)
 			{
-				if ((*iter)->getGUID() == added->getGUID())
+				if ((*iter)->getID() == added->getID())
 				{
 					// Already have this stick
 					*(*iter) = std::move(*added);


### PR DESCRIPTION
Kobrar reported that joystick events were not properly assigned to the
right Joystick instances because the GUIDs of the joysticks was the same
(that's another problem since the code assumes that they actually are
Globally Unique like the name says).

The fix was to simply use the instance ID for checking if two sticks are
the same which seems to work more reliably.