### PR TITLE
Add GLSL version to debug log

### DIFF
--- a/code/graphics/gropengl.cpp
+++ b/code/graphics/gropengl.cpp
@@ -1625,6 +1625,7 @@ bool gr_opengl_init(os::GraphicsOperations* graphicsOps)
 	mprintf(( "  OpenGL Vendor    : %s\n", glGetString(GL_VENDOR) ));
 	mprintf(( "  OpenGL Renderer  : %s\n", glGetString(GL_RENDERER) ));
 	mprintf(( "  OpenGL Version   : %s\n", glGetString(GL_VERSION) ));
+	mprintf(( "  GLSL Version     : %s\n", glGetString(GL_SHADING_LANGUAGE_VERSION) ));
 	mprintf(( "\n" ));
 
 	if (Cmdline_fullscreen_window || Cmdline_window) {


### PR DESCRIPTION
Adding this to the debug log is probably a good idea to aid end user troubleshooting as more and more OpenGL shading language features are utilized in fs2open.

Not clear why fs2open has not recorded this previously, but here it is.

Uses `glGetString(GL_SHADING_LANGUAGE_VERSION)`.

For example:
```
  OpenGL Vendor    : Intel Open Source Technology Center
  OpenGL Renderer  : Mesa DRI Intel(R) Ironlake Mobile 
  OpenGL Version   : 2.1 Mesa 12.1.0-devel (git-3fb4a9b)
  GLSL Version     : 1.20
```