### PR TITLE
Improve legacy mode warning console message

### DIFF
--- a/code/osapi/osapi.cpp
+++ b/code/osapi/osapi.cpp
@@ -351,7 +351,7 @@ bool os_is_legacy_mode()
 	if (legacyMode) {
 		// Print a message for the people running it from the terminal
 		fprintf(stdout, "FSO is running in legacy config mode. Please either update your launcher or"
-			" copy the configuration and pilot files to '%s' for better future compatibility.", getPreferencesPath());
+			" copy the configuration and pilot files to '%s' for better future compatibility.\n", getPreferencesPath());
 	}
 
 	checkedLegacyMode = true;


### PR DESCRIPTION
Without the new line, this important warning line can get lost within the console messages e.g. on Linux.

e.g. now properly formatted
```
$ ./fs2_open_3_7_5_x64-DEBUG -window
FSO is running in legacy config mode. Please either update your launcher or copy the configuration and pilot files to '/home/usera/.local/share/HardLightProductions/FreeSpaceOpen/' for better future compatibility.
ATTENTION: default value of option force_s3tc_enable overridden by environment.
```