### PR TITLE
remove the SIF_BALLISTIC_PRIMARIES flag

### DIFF
--- a/code/hud/hudtarget.cpp
+++ b/code/hud/hudtarget.cpp
@@ -5541,11 +5541,11 @@ void HudGaugeWeaponEnergy::render(float frametime)
 	bool use_new_gauge = false;
 
 	// Goober5000 - only check for the new gauge in case of command line + a ballistic-capable ship
-	if (Cmdline_ballistic_gauge && Ship_info[Player_ship->ship_info_index].flags[Ship::Info_Flags::Ballistic_primaries])
+	if (Cmdline_ballistic_gauge)
 	{
-		for(x = 0; x < Player_ship->weapons.num_primary_banks; x++)
+		for (x = 0; x < Player_ship->weapons.num_primary_banks; ++x)
 		{
-			if(Weapon_info[Player_ship->weapons.primary_bank_weapons[x]].wi_flags[Weapon::Info_Flags::Ballistic])
+			if (Weapon_info[Player_ship->weapons.primary_bank_weapons[x]].wi_flags[Weapon::Info_Flags::Ballistic])
 			{
 				use_new_gauge = true;
 				break;
@@ -5651,7 +5651,7 @@ void HudGaugeWeaponEnergy::render(float frametime)
 		sw = &Player_ship->weapons;
 
 		// show ballistic ammunition in energy gauge if need be
-		if ( Show_ballistic && Ship_info[Player_ship->ship_info_index].flags[Ship::Info_Flags::Ballistic_primaries] ) {
+		if ( Show_ballistic ) {
 			if ( Player_ship->flags[Ship::Ship_Flags::Primary_linked] ) {
 
 				// go through all ballistic primaries and add up their ammunition totals and max capacities
@@ -5670,7 +5670,11 @@ void HudGaugeWeaponEnergy::render(float frametime)
 				max_ballistic_ammo = sw->primary_bank_start_ammo[sw->current_primary_bank];
 			}
 
-			percent_left = i2fl(ballistic_ammo) / i2fl(max_ballistic_ammo);
+			if (max_ballistic_ammo > 0) {
+				percent_left = i2fl(ballistic_ammo) / i2fl(max_ballistic_ammo);
+			} else {
+				percent_left = 1.0f;
+			}
 		} else {
 			// also leave if no energy can be stored for weapons - Goober5000
 			if (!ship_has_energy_weapons(Player_ship))

--- a/code/io/keycontrol.cpp
+++ b/code/io/keycontrol.cpp
@@ -588,18 +588,15 @@ void debug_max_primary_weapons(object *objp)	// Goober5000
 	ship_weapon *swp = &shipp->weapons;
 	weapon_info *wip;
 
-	if (sip->flags[Ship::Info_Flags::Ballistic_primaries])
+	for ( index = 0; index < MAX_SHIP_PRIMARY_BANKS; index++ )
 	{
-		for ( index = 0; index < MAX_SHIP_PRIMARY_BANKS; index++ )
+		wip = &Weapon_info[swp->primary_bank_weapons[index]];
+		if (wip->wi_flags[Weapon::Info_Flags::Ballistic])
 		{
-			wip = &Weapon_info[swp->primary_bank_weapons[index]];
-			if (wip->wi_flags[Weapon::Info_Flags::Ballistic])
-			{
-				float capacity, size;
-				capacity = (float) sip->primary_bank_ammo_capacity[index];
-				size = (float) wip->cargo_size;
-				swp->primary_bank_ammo[index] = fl2i((capacity / size)+0.5f);
-			}
+			float capacity, size;
+			capacity = (float) sip->primary_bank_ammo_capacity[index];
+			size = (float) wip->cargo_size;
+			swp->primary_bank_ammo[index] = fl2i((capacity / size)+0.5f);
 		}
 	}
 }

--- a/code/missionui/missionweaponchoice.cpp
+++ b/code/missionui/missionweaponchoice.cpp
@@ -1119,16 +1119,6 @@ void wl_set_disabled_weapons(int ship_class)
 		//	Determine whether weapon #i is allowed on this ship class in the current type of mission.
 		//	As of 9/6/99, the only difference is dogfight missions have a different list of legal weapons.
 		Wl_icons[i].can_use = eval_weapon_flag_for_game_type(sip->allowed_weapons[i]);
-
-		// Goober5000: ballistic primaries
-		if (Weapon_info[i].wi_flags[Weapon::Info_Flags::Ballistic])
-		{
-			// not allowed if this ship is not ballistic
-			if (!(sip->flags[Ship::Info_Flags::Ballistic_primaries]))
-			{
-				Wl_icons[i].can_use = 0;
-			}
-		}
 	}
 }
 
@@ -4043,8 +4033,7 @@ void wl_apply_current_loadout_to_all_ships_in_current_wing()
 			}
 
 			// make sure this ship can accept this weapon
-			if (!eval_weapon_flag_for_game_type(sip->allowed_weapons[weapon_type_to_add])
-				|| ((wip->wi_flags[Weapon::Info_Flags::Ballistic]) && !(sip->flags[Ship::Info_Flags::Ballistic_primaries])))
+			if (!eval_weapon_flag_for_game_type(sip->allowed_weapons[weapon_type_to_add]))
 			{
 				SCP_string temp;
 				sprintf(temp, XSTR("%s is unable to carry %s weaponry", 1629), ship_name, wep_display_name);

--- a/code/network/multi_ingame.cpp
+++ b/code/network/multi_ingame.cpp
@@ -1439,11 +1439,8 @@ void send_ingame_ship_request_packet(int code,int rdata,net_player *pl)
 		val = (ubyte)shipp->engine_recharge_index;
 		ADD_DATA(val);
 
-		// add the ballistic primary flag - Goober5000
+		// dummy field to replace ballistic primary flag
 		val = 0;
-		if(sip->flags[Ship::Info_Flags::Ballistic_primaries]){
-			val |= (1<<0);
-		}
 		ADD_DATA(val);
 
 		// add current primary and secondary banks, and add link status
@@ -1685,11 +1682,8 @@ void process_ingame_ship_request_packet(ubyte *data, header *hinfo)
 		GET_DATA(val);
 		Player_ship->engine_recharge_index = val;		
 
-		// handle the ballistic primary flag - Goober5000
+		// handle the dummy value that used to be the ballistic primary flag
 		GET_DATA(val);
-		if(val & (1<<0)){
-			Ship_info[Player_ship->ship_info_index].flags.set(Ship::Info_Flags::Ballistic_primaries);
-		}
 
 		// get current primary and secondary banks, and add link status
 		GET_DATA(val);

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -15142,30 +15142,25 @@ int sexp_primaries_depleted(int node)
 		return SEXP_FALSE;
 	}
 
-	// see if ship has ballistic primary weapons   
-	if (!(Ship_info[shipp->ship_info_index].flags[Ship::Info_Flags::Ballistic_primaries]))   
-		return SEXP_FALSE; 
-
 	// get num primary banks
 	num_banks = shipp->weapons.num_primary_banks;
 	num_depleted_banks = 0;
 
 	// get number of depleted banks
-	for (int idx=0; idx<num_banks; idx++)
-	{
+	for (int idx=0; idx<num_banks; idx++) {
 		// is this a ballistic bank?
-		if (Weapon_info[shipp->weapons.primary_bank_weapons[idx]].wi_flags[Weapon::Info_Flags::Ballistic])
-		{
-			// is this bank out of ammo?
-			if (shipp->weapons.primary_bank_ammo[idx] == 0)
-			{
-				num_depleted_banks++;
-			}
+		if (!(Weapon_info[shipp->weapons.primary_bank_weapons[idx]].wi_flags[Weapon::Info_Flags::Ballistic])) {
+			continue;
+		}
+
+		// is this bank out of ammo?
+		if (shipp->weapons.primary_bank_ammo[idx] == 0)	{
+			num_depleted_banks++;
 		}
 	}
 
 	// are they all depleted?
-	return (num_depleted_banks == num_banks);
+	return (num_depleted_banks == num_banks) ? SEXP_TRUE : SEXP_FALSE;
 }
 
 int sexp_secondaries_depleted(int node)
@@ -15190,13 +15185,14 @@ int sexp_secondaries_depleted(int node)
 
 	// get number of depleted banks
 	for (int idx=0; idx<num_banks; idx++) {
+		// is this bank out of ammo?
 		if (shipp->weapons.secondary_bank_ammo[idx] == 0) {
 			num_depleted_banks++;
 		}
 	}
 
 	// are they all depleted?
-	return (num_depleted_banks == num_banks);
+	return (num_depleted_banks == num_banks) ? SEXP_TRUE : SEXP_FALSE;
 }
 
 int sexp_facing(int node)

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -3441,21 +3441,6 @@ int parse_ship_values(ship_info* sip, const bool is_template, const bool first_t
 		}
 	}
 
-	sip->flags.remove(Ship::Info_Flags::Ballistic_primaries);
-
-	//Set ship ballistic flag if necessary
-	for (i = 0; i < MAX_SHIP_PRIMARY_BANKS; i++)
-	{
-		for (j = 0; j < Num_weapon_types; j++)
-		{
-			if(sip->allowed_bank_restricted_weapons[i][j] && (Weapon_info[j].wi_flags[Weapon::Info_Flags::Ballistic]))
-			{
-				sip->flags.set(Ship::Info_Flags::Ballistic_primaries);
-				break;
-			}
-		}
-	}
-
 	find_and_stuff_optional("$AI Class:", &sip->ai_class, F_NAME, Ai_class_names, Num_ai_classes, "AI class names");
 
 	// Get Afterburner information
@@ -5095,6 +5080,20 @@ int ship_show_velocity_dot = 0;
 
 DCF_BOOL( show_velocity_dot, ship_show_velocity_dot )
 
+bool ballistic_possible_for_this_ship(const ship_info *sip)
+{
+	for (int i = 0; i < MAX_SHIP_PRIMARY_BANKS; i++)
+	{
+		for (int j = 0; j < Num_weapon_types; ++j)
+		{
+			if (sip->allowed_bank_restricted_weapons[i][j] && (Weapon_info[j].wi_flags2 & WIF2_BALLISTIC))
+				return true;
+		}
+	}
+
+	return false;
+}
+
 /**
  * Clean up ship entries, making sure various flags and settings are correct
  */
@@ -5119,7 +5118,7 @@ void ship_parse_post_cleanup()
 
 			// be friendly; ensure ballistic flags check out
 			if (pbank_capacity_specified) {
-				if ( !(sip->flags[Ship::Info_Flags::Ballistic_primaries]) ) {
+				if ( !ballistic_possible_for_this_ship(&(*sip)) ) {
 					Warning(LOCATION, "Pbank capacity specified for non-ballistic-primary-enabled ship %s.\nResetting capacities to 0.\nTo fix this, add a ballistic primary to the list of allowed primaries.\n", sip->name);
 
 					for (j = 0; j < MAX_SHIP_PRIMARY_BANKS; j++) {
@@ -5127,7 +5126,7 @@ void ship_parse_post_cleanup()
 					}
 				}
 			} else {
-				if (sip->flags[Ship::Info_Flags::Ballistic_primaries]) {
+				if ( ballistic_possible_for_this_ship(&(*sip)) ) {
 					Warning(LOCATION, "Pbank capacity not specified for ballistic-primary-enabled ship %s.\nDefaulting to capacity of 1 per bank.\n", sip->name);
 
 					for (j = 0; j < MAX_SHIP_PRIMARY_BANKS; j++) {
@@ -8823,19 +8822,16 @@ void ship_process_post(object * obj, float frametime)
 			}
 		}
 
-		if ( sip->flags[Ship::Info_Flags::Ballistic_primaries] )
+		for ( int i=0; i<MAX_SHIP_PRIMARY_BANKS; i++ )
 		{
-			for ( int i=0; i<MAX_SHIP_PRIMARY_BANKS; i++ )
+			if ( red_alert_mission() )
 			{
-				if ( red_alert_mission() )
-				{
-					max_missiles = get_max_ammo_count_for_primary_bank(shipp->ship_info_index, i, shipp->weapons.primary_bank_weapons[i]);
-					shipp->weapons.primary_bank_start_ammo[i] = max_missiles;
-				}
-				else
-				{
-					shipp->weapons.primary_bank_start_ammo[i] = shipp->weapons.primary_bank_ammo[i];
-				}
+				max_missiles = get_max_ammo_count_for_primary_bank(shipp->ship_info_index, i, shipp->weapons.primary_bank_weapons[i]);
+				shipp->weapons.primary_bank_start_ammo[i] = max_missiles;
+			}
+			else
+			{
+				shipp->weapons.primary_bank_start_ammo[i] = shipp->weapons.primary_bank_ammo[i];
 			}
 		}
 		
@@ -11018,10 +11014,6 @@ int ship_fire_primary(object * obj, int stream_weapons, int force)
 				// ballistics support for primaries - Goober5000
 				if ( winfo_p->wi_flags[Weapon::Info_Flags::Ballistic] )
 				{
-					// Make sure this ship is set up for ballistics.
-					// If you get this error, add the ballistic primaries tags to ships.tbl.
-					Assert ( sip->flags[Ship::Info_Flags::Ballistic_primaries] );
-
 					// If ship is being repaired/rearmed, it cannot fire ballistics
 					if ( aip->ai_flags & AIF_BEING_REPAIRED )
 					{
@@ -12114,6 +12106,19 @@ int primary_out_of_ammo(ship_weapon *swp, int bank)
 	return 0;
 }
 
+bool ship_has_a_ballistic_primary(const ship *shipp)
+{
+	const ship_weapon *swp = &shipp->weapons;
+
+	for (int i = 0; i < swp->num_primary_banks; i++)
+	{
+		if (Weapon_info[swp->primary_bank_weapons[i]].wi_flags2 & WIF2_BALLISTIC)
+			return true;
+	}
+
+	return false;
+}
+
 /**
  * Return true if a new index gets selected.
  * 
@@ -12228,7 +12233,7 @@ int ship_select_next_primary(object *objp, int direction)
 	}
 
 	// test for ballistics - Goober5000
-	if ( sip->flags[Ship::Info_Flags::Ballistic_primaries] )
+	if (ship_has_a_ballistic_primary(shipp))
 	{
 		// if we can't link, disengage primary linking and change to next available bank
 		if (shipp->flags[Ship_Flags::Primary_linked])
@@ -13395,35 +13400,32 @@ float ship_calculate_rearm_duration( object *objp )
 
 	//now do the primary rearm time
 	found_first_empty = false;
-	if (sip->flags[Ship::Info_Flags::Ballistic_primaries])
+	for (i = 0; i < swp->num_primary_banks; i++)
 	{
-		for (i = 0; i < swp->num_primary_banks; i++)
+		wip = &Weapon_info[swp->primary_bank_weapons[i]];
+		if (wip->wi_flags[Weapon::Info_Flags::Ballistic])
 		{
-			wip = &Weapon_info[swp->primary_bank_weapons[i]];
-			if (wip->wi_flags[Weapon::Info_Flags::Ballistic])
+			//check how many full reloads we need
+			num_reloads = (swp->primary_bank_start_ammo[i] - swp->primary_bank_ammo[i])/REARM_NUM_BALLISTIC_PRIMARIES_PER_BATCH;
+
+			//take into account a fractional reload
+			if ((swp->primary_bank_start_ammo[i] - swp->primary_bank_ammo[i]) % REARM_NUM_BALLISTIC_PRIMARIES_PER_BATCH != 0)
 			{
-				//check how many full reloads we need
-				num_reloads = (swp->primary_bank_start_ammo[i] - swp->primary_bank_ammo[i])/REARM_NUM_BALLISTIC_PRIMARIES_PER_BATCH;
-
-				//take into account a fractional reload
-				if ((swp->primary_bank_start_ammo[i] - swp->primary_bank_ammo[i]) % REARM_NUM_BALLISTIC_PRIMARIES_PER_BATCH != 0)
-				{
-					num_reloads++;
-				}
-
-				//don't factor in the time it takes for the first reload, since that is loaded instantly
-				num_reloads--;
-
-				if (num_reloads < 0) continue;
-
-				if (!found_first_empty && (swp->primary_bank_start_ammo[i] - swp->primary_bank_ammo[i]))
-				{
-					found_first_empty = true;
-					prim_rearm_time += (float)snd_get_duration(Snds[SND_MISSILE_START_LOAD].id) / 1000.0f;
-				}
-
-				prim_rearm_time += num_reloads * wip->rearm_rate;
+				num_reloads++;
 			}
+
+			//don't factor in the time it takes for the first reload, since that is loaded instantly
+			num_reloads--;
+
+			if (num_reloads < 0) continue;
+
+			if (!found_first_empty && (swp->primary_bank_start_ammo[i] - swp->primary_bank_ammo[i]))
+			{
+				found_first_empty = true;
+				prim_rearm_time += (float)snd_get_duration(Snds[SND_MISSILE_START_LOAD].id) / 1000.0f;
+			}
+
+			prim_rearm_time += num_reloads * wip->rearm_rate;
 		}
 	}
 
@@ -13471,7 +13473,7 @@ float ship_calculate_rearm_duration( object *objp )
 //
 int ship_do_rearm_frame( object *objp, float frametime )
 {
-	int			i, banks_full, primary_banks_full, subsys_type, subsys_all_ok, last_ballistic_idx = 0;
+	int			i, banks_full, primary_banks_full, subsys_type, subsys_all_ok, last_ballistic_idx = -1;
 	float			shield_str, repair_delta, repair_allocated, max_hull_repair, max_subsys_repair;
 	ship			*shipp;
 	ship_weapon	*swp;
@@ -13661,80 +13663,22 @@ int ship_do_rearm_frame( object *objp, float frametime )
 		}	// end for
 
 		// rearm ballistic primaries - Goober5000
-		if (sip->flags[Ship::Info_Flags::Ballistic_primaries])
+		if ( aip->rearm_first_ballistic_primary == TRUE)
 		{
-			if ( aip->rearm_first_ballistic_primary == TRUE)
-			{
-				for (i = 1; i < swp->num_primary_banks; i++ )
-				{
-					if ( Weapon_info[swp->primary_bank_weapons[i]].wi_flags[Weapon::Info_Flags::Ballistic] )
-						last_ballistic_idx = i;
-				}
-			}
-
 			for (i = 0; i < swp->num_primary_banks; i++ )
 			{
 				if ( Weapon_info[swp->primary_bank_weapons[i]].wi_flags[Weapon::Info_Flags::Ballistic] )
-				{
-					// Actual loading of bullets is preceded by a sound effect which is the bullet
-					// loading equipment moving into place
-					if ( aip->rearm_first_ballistic_primary == TRUE )
-					{
-						// Goober5000
-						int sound_index;
-						if (Snds[SND_BALLISTIC_START_LOAD].id >= 0)
-							sound_index = SND_BALLISTIC_START_LOAD;
-						else
-							sound_index = SND_MISSILE_START_LOAD;
+					last_ballistic_idx = i;
+			}
+		}
 
-						swp->primary_bank_rearm_time[i] = timestamp(snd_get_duration(Snds[sound_index].id));			
-
-						if (i == last_ballistic_idx) 
-							aip->rearm_first_ballistic_primary = FALSE;
-					}
-
-					if ( swp->primary_bank_ammo[i] < swp->primary_bank_start_ammo[i] )
-					{
-						float rearm_time;
-	
-						if ( objp == Player_obj )
-						{
-							hud_gauge_popup_start(HUD_WEAPONS_GAUGE);
-						}
-
-						if ( timestamp_elapsed(swp->primary_bank_rearm_time[i]) )
-						{
-							rearm_time = Weapon_info[swp->primary_bank_weapons[i]].rearm_rate;
-							swp->primary_bank_rearm_time[i] = timestamp( (int)(rearm_time * 1000.f) );
-	
-							// Goober5000
-							int sound_index;
-							if (Snds[SND_BALLISTIC_LOAD].id >= 0)
-								sound_index = SND_BALLISTIC_LOAD;
-							else
-								sound_index = SND_MISSILE_LOAD;
-
-							snd_play_3d( &Snds[sound_index], &objp->pos, &View_position );
-	
-							swp->primary_bank_ammo[i] += REARM_NUM_BALLISTIC_PRIMARIES_PER_BATCH;
-							if ( swp->primary_bank_ammo[i] > swp->primary_bank_start_ammo[i] )
-							{
-								swp->primary_bank_ammo[i] = swp->primary_bank_start_ammo[i]; 
-							}
-						}
-					}
-					else
-					{
-						primary_banks_full++;
-					}
-				}
-				// if the bank is not a ballistic
-				else
-				{
-					primary_banks_full++;
-				}
-
-				if ((aip->rearm_first_ballistic_primary == TRUE) && (i == swp->num_primary_banks - 1) && (primary_banks_full != swp->num_primary_banks))
+		for (i = 0; i < swp->num_primary_banks; i++ )
+		{
+			if (Weapon_info[swp->primary_bank_weapons[i]].wi_flags[Weapon::Info_Flags::Ballistic])
+			{
+				// Actual loading of bullets is preceded by a sound effect which is the bullet
+				// loading equipment moving into place
+				if ( aip->rearm_first_ballistic_primary == TRUE )
 				{
 					// Goober5000
 					int sound_index;
@@ -13743,10 +13687,65 @@ int ship_do_rearm_frame( object *objp, float frametime )
 					else
 						sound_index = SND_MISSILE_START_LOAD;
 
-					snd_play_3d( &Snds[sound_index], &objp->pos, &View_position );
+					swp->primary_bank_rearm_time[i] = timestamp(snd_get_duration(Snds[sound_index].id));			
+
+					if (i == last_ballistic_idx) 
+						aip->rearm_first_ballistic_primary = FALSE;
 				}
-			}	// end for
-		}	// end if - rearm ballistic primaries
+
+				if ( swp->primary_bank_ammo[i] < swp->primary_bank_start_ammo[i] )
+				{
+					float rearm_time;
+	
+					if ( objp == Player_obj )
+					{
+						hud_gauge_popup_start(HUD_WEAPONS_GAUGE);
+					}
+
+					if ( timestamp_elapsed(swp->primary_bank_rearm_time[i]) )
+					{
+						rearm_time = Weapon_info[swp->primary_bank_weapons[i]].rearm_rate;
+						swp->primary_bank_rearm_time[i] = timestamp( (int)(rearm_time * 1000.f) );
+	
+						// Goober5000
+						int sound_index;
+						if (Snds[SND_BALLISTIC_LOAD].id >= 0)
+							sound_index = SND_BALLISTIC_LOAD;
+						else
+							sound_index = SND_MISSILE_LOAD;
+
+						snd_play_3d( &Snds[sound_index], &objp->pos, &View_position );
+	
+						swp->primary_bank_ammo[i] += REARM_NUM_BALLISTIC_PRIMARIES_PER_BATCH;
+						if ( swp->primary_bank_ammo[i] > swp->primary_bank_start_ammo[i] )
+						{
+							swp->primary_bank_ammo[i] = swp->primary_bank_start_ammo[i]; 
+						}
+					}
+				}
+				else
+				{
+					primary_banks_full++;
+				}
+			}
+			// if the bank is not a ballistic
+			else
+			{
+				primary_banks_full++;
+			}
+
+			if ((aip->rearm_first_ballistic_primary == TRUE) && (i == last_ballistic_idx) && (primary_banks_full != swp->num_primary_banks))
+			{
+				// Goober5000
+				int sound_index;
+				if (Snds[SND_BALLISTIC_START_LOAD].id >= 0)
+					sound_index = SND_BALLISTIC_START_LOAD;
+				else
+					sound_index = SND_MISSILE_START_LOAD;
+
+				snd_play_3d( &Snds[sound_index], &objp->pos, &View_position );
+			}
+		}	// end for
 	} // end if (subsys_all_ok)
 
 	if ( banks_full == swp->num_secondary_banks )
@@ -13789,8 +13788,7 @@ int ship_do_rearm_frame( object *objp, float frametime )
 			aip->rearm_release_delay = timestamp(1200);
 
 		// check both primary and secondary banks are full
-		if ( (banks_full == swp->num_secondary_banks) &&
-			( !(sip->flags[Ship::Info_Flags::Ballistic_primaries]) || ((sip->flags[Ship::Info_Flags::Ballistic_primaries]) && (primary_banks_full == swp->num_primary_banks)) )	)
+		if ( (banks_full == swp->num_secondary_banks) && (primary_banks_full == swp->num_primary_banks) )
 		{
 			if ( timestamp_elapsed(aip->rearm_release_delay) )
 				return 1;
@@ -15680,34 +15678,31 @@ void ship_maybe_tell_about_low_ammo(ship *sp)
 	swp = &sp->weapons;
 	
 	// stole the code for this from ship_maybe_tell_about_rearm()
-	if (Ship_info[sp->ship_info_index].flags[Ship::Info_Flags::Ballistic_primaries])
+	for (i = 0; i < swp->num_primary_banks; i++)
 	{
-		for (i = 0; i < swp->num_primary_banks; i++)
+		wip = &Weapon_info[swp->primary_bank_weapons[i]];
+
+		if (wip->wi_flags[Weapon::Info_Flags::Ballistic])
 		{
-			wip = &Weapon_info[swp->primary_bank_weapons[i]];
-
-			if (wip->wi_flags[Weapon::Info_Flags::Ballistic])
+			if (swp->primary_bank_start_ammo[i] > 0)
 			{
-				if (swp->primary_bank_start_ammo[i] > 0)
+				if ((float)swp->primary_bank_ammo[i] / (float)swp->primary_bank_start_ammo[i] < 0.3f)
 				{
-					if ((float)swp->primary_bank_ammo[i] / (float)swp->primary_bank_start_ammo[i] < 0.3f)
-					{
-						// multiplayer tvt
-						if(MULTI_TEAM) {
-							multi_team_filter = sp->team;
-						}
-
-						message_send_builtin_to_player(MESSAGE_PRIMARIES_LOW, sp, MESSAGE_PRIORITY_NORMAL, MESSAGE_TIME_SOON, 0, 0, -1, multi_team_filter);
-
-						Player->allow_ammo_timestamp = timestamp(PLAYER_LOW_AMMO_MSG_INTERVAL);
-
-						// better reset this one too
-						Player->request_repair_timestamp = timestamp(PLAYER_REQUEST_REPAIR_MSG_INTERVAL);
-
-						Player->low_ammo_complaint_count++;
-						sp->ammo_low_complaint_count++;
-						break;
+					// multiplayer tvt
+					if(MULTI_TEAM) {
+						multi_team_filter = sp->team;
 					}
+
+					message_send_builtin_to_player(MESSAGE_PRIMARIES_LOW, sp, MESSAGE_PRIORITY_NORMAL, MESSAGE_TIME_SOON, 0, 0, -1, multi_team_filter);
+
+					Player->allow_ammo_timestamp = timestamp(PLAYER_LOW_AMMO_MSG_INTERVAL);
+
+					// better reset this one too
+					Player->request_repair_timestamp = timestamp(PLAYER_REQUEST_REPAIR_MSG_INTERVAL);
+
+					Player->low_ammo_complaint_count++;
+					sp->ammo_low_complaint_count++;
+					break;
 				}
 			}
 		}
@@ -15761,21 +15756,18 @@ void ship_maybe_tell_about_rearm(ship *sp)
 		}
 
 		// also check ballistic primaries - Goober5000
-		if (Ship_info[sp->ship_info_index].flags[Ship::Info_Flags::Ballistic_primaries])
+		for (i = 0; i < swp->num_primary_banks; i++)
 		{
-			for (i = 0; i < swp->num_primary_banks; i++)
-			{
-				wip = &Weapon_info[swp->primary_bank_weapons[i]];
+			wip = &Weapon_info[swp->primary_bank_weapons[i]];
 
-				if (wip->wi_flags[Weapon::Info_Flags::Ballistic])
+			if (wip->wi_flags[Weapon::Info_Flags::Ballistic])
+			{
+				if (swp->primary_bank_start_ammo[i] > 0)
 				{
-					if (swp->primary_bank_start_ammo[i] > 0)
+					if ((float)swp->primary_bank_ammo[i] / (float)swp->primary_bank_start_ammo[i] < 0.3f)
 					{
-						if ((float)swp->primary_bank_ammo[i] / (float)swp->primary_bank_start_ammo[i] < 0.3f)
-						{
-							message_type = MESSAGE_REARM_PRIMARIES;
-							break;
-						}
+						message_type = MESSAGE_REARM_PRIMARIES;
+						break;
 					}
 				}
 			}
@@ -16071,13 +16063,14 @@ int get_max_ammo_count_for_primary_bank(int ship_class, int bank, int ammo_type)
 {
 	float capacity, size;
 	
-	if (!(Ship_info[ship_class].flags[Ship::Info_Flags::Ballistic_primaries]))
+	if (!(Weapon_info[ammo_type].wi_flags2 & WIF2_BALLISTIC))
 	{
 		return 0;
 	}
 
 	capacity = (float) Ship_info[ship_class].primary_bank_ammo_capacity[bank];
 	size = (float) Weapon_info[ammo_type].cargo_size;
+	Assertion(size > 0.0f, "Weapon cargo size for %s must be greater than 0!", Weapon_info[ammo_type].name);
 	return  fl2i((capacity / size)+0.5f);
 }
 
@@ -16097,6 +16090,7 @@ int get_max_ammo_count_for_bank(int ship_class, int bank, int ammo_type)
 	} else {
 		capacity = (float) Ship_info[ship_class].secondary_bank_ammo_capacity[bank];
 		size = (float) Weapon_info[ammo_type].cargo_size;
+		Assertion(size > 0.0f, "Weapon cargo size for %s must be greater than 0!", Weapon_info[ammo_type].name);
 		return (int) (capacity / size);
 	}
 }

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -5086,7 +5086,7 @@ bool ballistic_possible_for_this_ship(const ship_info *sip)
 	{
 		for (int j = 0; j < Num_weapon_types; ++j)
 		{
-			if (sip->allowed_bank_restricted_weapons[i][j] && (Weapon_info[j].wi_flags2 & WIF2_BALLISTIC))
+			if (sip->allowed_bank_restricted_weapons[i][j] && (Weapon_info[j].wi_flags[Weapon::Info_Flags::Ballistic]))
 				return true;
 		}
 	}
@@ -12112,7 +12112,7 @@ bool ship_has_a_ballistic_primary(const ship *shipp)
 
 	for (int i = 0; i < swp->num_primary_banks; i++)
 	{
-		if (Weapon_info[swp->primary_bank_weapons[i]].wi_flags2 & WIF2_BALLISTIC)
+		if (Weapon_info[swp->primary_bank_weapons[i]].wi_flags[Weapon::Info_Flags::Ballistic])
 			return true;
 	}
 
@@ -16055,7 +16055,6 @@ float ship_get_secondary_weapon_range(ship *shipp)
 	return srange;
 }
 
-// Goober5000 - added for ballistic primaries
 /**
  * Determine the number of primary ammo units allowed max for a ship
  */
@@ -16063,10 +16062,8 @@ int get_max_ammo_count_for_primary_bank(int ship_class, int bank, int ammo_type)
 {
 	float capacity, size;
 	
-	if (!(Weapon_info[ammo_type].wi_flags2 & WIF2_BALLISTIC))
-	{
+	if (!(Weapon_info[ammo_type].wi_flags[Weapon::Info_Flags::Ballistic]))
 		return 0;
-	}
 
 	capacity = (float) Ship_info[ship_class].primary_bank_ammo_capacity[bank];
 	size = (float) Weapon_info[ammo_type].cargo_size;


### PR DESCRIPTION
See also my comments on #762.  The flag is almost entirely redundant, so this PR removes it in all instances where it's used in the ballistic primaries code.  There are one or two places where removing it was not a no-op, so I adjusted the rest of the code accordingly (most notably in the parsing validation when it checks that primary weapon cargo has been assigned).  I also added a few divide-by-zero checks and slightly tweaked the support ship rearm code.  The use of the SIF_BALLISTIC_PRIMARIES flag in the ingame_join code was replaced with a dummy value to avoid bumping the multiplayer packet version number.