### PR TITLE
Add initializer_list support for flagset

### DIFF
--- a/code/globalincs/flagset.h
+++ b/code/globalincs/flagset.h
@@ -9,6 +9,13 @@ class flagset {
 protected:
     std::bitset<SIZE> values;
 public:
+	flagset() {}
+
+	flagset(const std::initializer_list<T>& init_list) {
+		for (auto& val : init_list) {
+			set(val);
+		}
+	}
 
     bool operator [] (const T idx) const { return values[(static_cast < size_t >(idx))]; };
 

--- a/code/weapon/beam.cpp
+++ b/code/weapon/beam.cpp
@@ -555,9 +555,7 @@ int beam_fire_targeting(fighter_beam_fire_info *fire_info)
 	// type c is a very special weapon type - binfo has no meaning
 
 	// create the associated object
-    flagset<Object::Object_Flags> default_flags;
-    default_flags.set(Object::Object_Flags::Collides);
-	objnum = obj_create(OBJ_BEAM, OBJ_INDEX(fire_info->shooter), BEAM_INDEX(new_item), &vmd_identity_matrix, &vmd_zero_vector, 1.0f, default_flags);
+	objnum = obj_create(OBJ_BEAM, OBJ_INDEX(fire_info->shooter), BEAM_INDEX(new_item), &vmd_identity_matrix, &vmd_zero_vector, 1.0f, {Object::Object_Flags::Collides});
 
 	if(objnum < 0){
 		beam_delete(new_item);


### PR DESCRIPTION
This allows to initialize a flagset instance from a {...} expression
without having to create an intermediary instance.