### PR TITLE
Adds macro to replace instances of the deprecated filelength with...

### DIFF
--- a/code/windows_stub/config.h
+++ b/code/windows_stub/config.h
@@ -29,6 +29,10 @@
 #define snprintf _snprintf
 #endif
 
+#ifndef filelength
+#define filelength _filelength
+#endif
+
 #define STUB_FUNCTION nprintf(( "Warning", "STUB: %s in "__FILE__" at line %d\n", __FUNCTION__, __LINE__))
 
 #else  // ! Win32


### PR DESCRIPTION
 `_filelength` if using MSVC.

This is currently causing issues in wxFred2 on windows machines, where filelength is called in `cfilesystem.cpp:673`