### PR TITLE
Cleanup for flag-related sexp helper functions

### DIFF
--- a/code/network/multi_sexp.cpp
+++ b/code/network/multi_sexp.cpp
@@ -270,23 +270,6 @@ void multi_send_int(int value)
 	current_argument_count += sizeof(int); 
 }
 
-template<typename T>
-void multi_send_flag(T value)
-{
-    if (cannot_send_data()) {
-        return;
-    }
-
-    multi_sexp_ensure_space_remains(sizeof(int));
-
-    //Write INT into the Type buffer.
-    type[packet_size] = TYPE_INT;
-    //Write the int into the data buffer
-    ADD_INT(static_cast<int>(value));
-    //Increment the COUNT by 4 (i.e the size of an int).
-    current_argument_count += sizeof(int);
-}
-
 /**
 * Adds a ship's net sig to the SEXP packet.
 */
@@ -642,21 +625,6 @@ bool multi_get_int(int &value)
 	return true; 
 }
 
-template <typename T>
-bool multi_get_flag(T &value) 
-{
-    if (!Multi_sexp_bytes_left || !current_argument_count) {
-        return false;
-    }
-    int tmp = 0;
-    GET_INT(tmp);
-
-    value = static_cast<T>(tmp);
-
-    multi_reduce_counts(sizeof(int));
-
-    return true;
-}
 
 /**
 * Attempts to get an index for the Ships array based on the net sig it removes from the SEXP packet. Returns it as the value 

--- a/code/network/multi_sexp.h
+++ b/code/network/multi_sexp.h
@@ -27,6 +27,8 @@ void multi_send_bool(bool value);
 void multi_send_float(float value);
 void multi_send_short(short value);
 void multi_send_ushort(ushort value);
+template<typename T>
+void multi_send_flag(T value);
 
 void sexp_packet_received(ubyte *received_packet, int num_ubytes);
 int multi_sexp_get_next_operator(); 
@@ -48,3 +50,5 @@ bool multi_get_bool(bool &value);
 bool multi_get_float(float &value);
 bool multi_get_short(short &value);
 bool multi_get_ushort(ushort &value);
+template <typename T>
+bool multi_get_flag(T &value);


### PR DESCRIPTION
Changes a few of the sexp helper functions to use flags directly instead of casting to and from int