### PR TITLE
Fixes issue with framebuffer initialization

### DIFF
--- a/code/graphics/gropengldraw.cpp
+++ b/code/graphics/gropengldraw.cpp
@@ -2594,7 +2594,7 @@ void opengl_setup_scene_textures()
 	}
 
 	//Setup thruster distortion framebuffer
-    if (Cmdline_fb_thrusters) 
+    if (Cmdline_fb_thrusters || Cmdline_fb_explosions) 
     {
         glGenFramebuffersEXT(1, &Distortion_framebuffer);
         glBindFramebufferEXT(GL_FRAMEBUFFER_EXT, Distortion_framebuffer);


### PR DESCRIPTION
When I created Cmdline_fb_thrusters, I hid the initialization for the distortion framebuffer behind a check for that flag. This was wrong, as the same FB is used to render framebuffer explosion effects, so this change makes sure that when either of those flags is set, the distortion framebuffer is correctly initialized.