### PR TITLE
Fix overflow problem accidentally introduced to is-event-*-msecs-delay.

### DIFF
--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -13871,9 +13871,14 @@ int sexp_event_delay_status( int n, int want_true, bool use_msecs = false)
 		return SEXP_FALSE;
 	}
 
-	delay = i2f(eval_num(CDR(n)));
 	if (use_msecs) {
-		delay = delay / 1000;
+		uint64_t tempDelay = eval_num(CDR(n));
+		tempDelay = tempDelay << 16;
+		tempDelay = tempDelay / 1000;
+
+		delay = (fix) tempDelay;
+	} else {
+		delay = i2f(eval_num(CDR(n)));
 	}
 
 	for (i = 0; i < Num_mission_events; i++ ) {


### PR DESCRIPTION
When PR #831 got rid of a warning in `sexp_event_delay_status()`, it did so by getting rid of the 64-bit temporary variable (in order to get rid of a warning in the non-`use_msecs` branch). However, that 64-bit variable was protecting against overflow when using numbers of milliseconds `>= 65535`, which are used by e.g. the Icarus cutscene mission from Blue Planet, leading to interesting (but wrong) behavior.

This restores usage of the `uint64_t` temporary variable by reverting that specific change, but then avoids the warning by moving that temporary variable to be inside the `use_msecs` branch; I get no warnings when compiling this version of sexp.cpp, and Icarus works again.