### PR TITLE
Add a check for an empty string to the freetrack loading code.

### DIFF
--- a/code/headtracking/freetrack.cpp
+++ b/code/headtracking/freetrack.cpp
@@ -58,7 +58,7 @@ namespace
 		value.resize(value.length() - 1);
 
 		// Fix paths without slash at the end
-		if (value[value.length() - 1] != '\\' && value[value.length() - 1] != '/')
+		if (!value.empty() && value[value.length() - 1] != '\\' && value[value.length() - 1] != '/')
 		{
 			value.append("/");
 		}


### PR DESCRIPTION
If `value` is empty, then attempting to access `value[value.length() - 1]` is equivalent to trying to access `value[-1]`, which is an out-of-bounds access (causing debug builds to complain and undefined behavior).