### PR TITLE
Add interface for viewport management

### DIFF
--- a/code/graphics/2d.cpp
+++ b/code/graphics/2d.cpp
@@ -1095,8 +1095,6 @@ bool gr_init(os::GraphicsOperations* graphicsOps, int d_mode, int d_width, int d
 
 	gr_set_shader(NULL);
 
-	os_set_title(Osreg_title);
-
 	Gr_inited = 1;
 
 	return true;
@@ -1133,6 +1131,16 @@ void gr_activate(int active)
 
 	if ( !Gr_inited ) { 
 		return;
+	}
+
+	if (active) {
+		if (Cmdline_fullscreen_window||Cmdline_window) {
+			os::getMainViewport()->restore();
+		} else {
+			os::getMainViewport()->setState(os::ViewportState::Fullscreen);
+		}
+	} else {
+		os::getMainViewport()->minimize();
 	}
 
 	switch( gr_screen.mode ) {

--- a/code/graphics/gropengl.cpp
+++ b/code/graphics/gropengl.cpp
@@ -93,29 +93,6 @@ void opengl_go_fullscreen()
 	if (Cmdline_fullscreen_window || Cmdline_window || GL_fullscreen || Fred_running)
 		return;
 
-	if ( (os_config_read_uint(NULL, NOX("Fullscreen"), 1) == 1) && (!os_get_window() || !(SDL_GetWindowFlags(os_get_window()) & SDL_WINDOW_FULLSCREEN)) ) {
-		if(os_get_window())
-		{
-			SDL_SetWindowFullscreen(os_get_window(), SDL_WINDOW_FULLSCREEN);
-		}
-		else
-		{
-			uint display = os_config_read_uint("Video", "Display", 0);
-			SDL_Window* window = SDL_CreateWindow(Osreg_title, SDL_WINDOWPOS_CENTERED_DISPLAY(display), SDL_WINDOWPOS_CENTERED_DISPLAY(display),
-				gr_screen.max_w, gr_screen.max_h, SDL_WINDOW_FULLSCREEN | SDL_WINDOW_OPENGL);
-			if (window == NULL) {
-				mprintf(("Couldn't go fullscreen!\n"));
-				if ((window = SDL_CreateWindow(Osreg_title, SDL_WINDOWPOS_CENTERED_DISPLAY(display), SDL_WINDOWPOS_CENTERED_DISPLAY(display),
-					gr_screen.max_w, gr_screen.max_h, SDL_WINDOW_OPENGL)) == NULL) {
-					mprintf(("Couldn't drop back to windowed mode either!\n"));
-					exit(1);
-				}
-			}
-
-			os_set_window(window);
-		}
-	}
-
 	gr_opengl_set_gamma(FreeSpace_gamma);
 
 	GL_fullscreen = 1;
@@ -128,23 +105,6 @@ void opengl_go_windowed()
 	if ( ( !Cmdline_fullscreen_window && !Cmdline_window ) /*|| GL_windowed*/ || Fred_running )
 		return;
 
-	if (!os_get_window() || SDL_GetWindowFlags(os_get_window()) & SDL_WINDOW_FULLSCREEN) {
-		if(os_get_window())
-		{
-			SDL_SetWindowFullscreen(os_get_window(), Cmdline_fullscreen_window ? SDL_WINDOW_FULLSCREEN_DESKTOP : 0 );
-		}
-		else
-		{
-			uint display = os_config_read_uint("Video", "Display", 0);
-			SDL_Window* new_window = SDL_CreateWindow(Osreg_title, SDL_WINDOWPOS_CENTERED_DISPLAY(display), SDL_WINDOWPOS_CENTERED_DISPLAY(display),
-				gr_screen.max_w, gr_screen.max_h, SDL_WINDOW_OPENGL);
-			if (new_window == NULL) {
-				Warning( LOCATION, "Unable to enter windowed mode: %s!", SDL_GetError() );
-			}
-			os_set_window(new_window);
-		}
-	}
-
 	GL_windowed = 1;
 	GL_minimized = 0;
 	GL_fullscreen = 0;
@@ -152,20 +112,6 @@ void opengl_go_windowed()
 
 void opengl_minimize()
 {
-	// don't attempt to minimize if we are already in a window, or already minimized, or when playing a movie
-	if (GL_minimized /*|| GL_windowed || Cmdline_window*/ || Fred_running)
-		return;
-
-	// lets not minimize if we are in windowed mode
-	if ( !(SDL_GetWindowFlags(os_get_window()) & SDL_WINDOW_FULLSCREEN) )
-		return;
-
-	if (GL_original_gamma_ramp != NULL) {
-		SDL_SetWindowGammaRamp( os_get_window(), GL_original_gamma_ramp, (GL_original_gamma_ramp+256), (GL_original_gamma_ramp+512) );
-	}
-
-	SDL_MinimizeWindow(os_get_window());
-
 	GL_minimized = 1;
 	GL_windowed = 0;
 	GL_fullscreen = 0;
@@ -215,7 +161,7 @@ void gr_opengl_flip()
 	if (Cmdline_gl_finish)
 		glFinish();
 
-	GL_context->swapBuffers();
+	os::getMainViewport()->swapBuffers();
 
 	opengl_tcache_frame();
 
@@ -451,8 +397,8 @@ void gr_opengl_shutdown(os::GraphicsOperations* graphicsOps)
 
 	GL_initted = false;
 
-	if (GL_original_gamma_ramp != NULL) {
-		SDL_SetWindowGammaRamp( os_get_window(), GL_original_gamma_ramp, (GL_original_gamma_ramp+256), (GL_original_gamma_ramp+512) );
+	if (GL_original_gamma_ramp != NULL && os::getSDLMainWindow() != nullptr) {
+		SDL_SetWindowGammaRamp( os::getSDLMainWindow(), GL_original_gamma_ramp, (GL_original_gamma_ramp+256), (GL_original_gamma_ramp+512) );
 	}
 
 	if (GL_original_gamma_ramp != NULL) {
@@ -460,7 +406,7 @@ void gr_opengl_shutdown(os::GraphicsOperations* graphicsOps)
 		GL_original_gamma_ramp = NULL;
 	}
 
-	graphicsOps->makeOpenGLContextCurrent(nullptr);
+	graphicsOps->makeOpenGLContextCurrent(nullptr, nullptr);
 	GL_context = nullptr;
 }
 
@@ -729,7 +675,7 @@ void gr_opengl_set_gamma(float gamma)
 	Gr_gamma_int = int (Gr_gamma*10);
 
 	// new way - but not while running FRED
-	if (!Fred_running && !Cmdline_no_set_gamma) {
+	if (!Fred_running && !Cmdline_no_set_gamma && os::getSDLMainWindow() != nullptr) {
 		gamma_ramp = (ushort*) vm_malloc( 3 * 256 * sizeof(ushort), memory::quiet_alloc);
 
 		if (gamma_ramp == NULL) {
@@ -742,7 +688,7 @@ void gr_opengl_set_gamma(float gamma)
 		// Create the Gamma lookup table
 		opengl_make_gamma_ramp(gamma, gamma_ramp);
 
-		SDL_SetWindowGammaRamp( os_get_window(), gamma_ramp, (gamma_ramp+256), (gamma_ramp+512) );
+		SDL_SetWindowGammaRamp( os::getSDLMainWindow(), gamma_ramp, (gamma_ramp+256), (gamma_ramp+512) );
 
 		vm_free(gamma_ramp);
 	}
@@ -1171,36 +1117,56 @@ int opengl_init_display_device(os::GraphicsOperations* graphicsOps)
 		}
 	}
 
-	os::OpenGLContextAttributes attrs;
-	attrs.red_size = Gr_red.bits;
-	attrs.green_size = Gr_green.bits;
-	attrs.blue_size = Gr_blue.bits;
-	attrs.alpha_size = (bpp == 32) ? Gr_alpha.bits : 0;
-	attrs.depth_size = (bpp == 32) ? 24 : 16;
-	attrs.stencil_size = (bpp == 32) ? 8 : 1;
+	os::ViewPortProperties attrs;
+	attrs.pixel_format.red_size = Gr_red.bits;
+	attrs.pixel_format.green_size = Gr_green.bits;
+	attrs.pixel_format.blue_size = Gr_blue.bits;
+	attrs.pixel_format.alpha_size = (bpp == 32) ? Gr_alpha.bits : 0;
+	attrs.pixel_format.depth_size = (bpp == 32) ? 24 : 16;
+	attrs.pixel_format.stencil_size = (bpp == 32) ? 8 : 1;
 
-	attrs.multi_samples = os_config_read_uint(NULL, "OGL_AntiAliasSamples", 0);
+	attrs.pixel_format.multi_samples = os_config_read_uint(NULL, "OGL_AntiAliasSamples", 0);
 
-	attrs.major_version = 2;
-	attrs.minor_version = 0;
+	attrs.enable_opengl = true;
+	attrs.gl_attributes.major_version = 2;
+	attrs.gl_attributes.minor_version = 0;
 
-	attrs.flags = os::OGL_NONE;
 #ifndef NDEBUG
-	attrs.flags |= os::OGL_DEBUG;
+	attrs.gl_attributes.flags.set(os::OpenGLContextFlags::Debug);
 #endif
 
-	attrs.profile = os::OpenGLProfile::Compatibility;
+	attrs.gl_attributes.profile = os::OpenGLProfile::Compatibility;
 
-	GL_context = graphicsOps->createOpenGLContext(attrs, (uint32_t) gr_screen.max_w, (uint32_t) gr_screen.max_h);
+	attrs.display = os_config_read_uint("Video", "Display", 0);
+	attrs.width = (uint32_t) gr_screen.max_w;
+	attrs.height = (uint32_t) gr_screen.max_h;
+
+	attrs.title = Osreg_title;
+
+	if (!Cmdline_window && ! Cmdline_fullscreen_window) {
+		attrs.flags.set(os::ViewPortFlags::Fullscreen);
+	} else if (Cmdline_fullscreen_window) {
+		attrs.flags.set(os::ViewPortFlags::Borderless);
+	}
+
+	auto viewport = graphicsOps->createViewport(attrs);
+	if (!viewport) {
+		return 1;
+	}
+	GL_context = graphicsOps->createOpenGLContext(viewport.get(), attrs.gl_attributes);
 
 	if (GL_context == nullptr) {
 		return 1;
 	}
 
-	graphicsOps->makeOpenGLContextCurrent(GL_context.get());
+	graphicsOps->makeOpenGLContextCurrent(viewport.get(), GL_context.get());
 
-	if (GL_original_gamma_ramp != NULL) {
-		SDL_GetWindowGammaRamp( os_get_window(), GL_original_gamma_ramp, (GL_original_gamma_ramp+256), (GL_original_gamma_ramp+512) );
+	auto port = os::addViewport(std::move(viewport));
+	os::setMainViewPort(port);
+
+	if (GL_original_gamma_ramp != NULL && os::getSDLMainWindow() != nullptr) {
+		SDL_GetWindowGammaRamp( os::getSDLMainWindow(), GL_original_gamma_ramp, (GL_original_gamma_ramp+256),
+								(GL_original_gamma_ramp+512) );
 	}
 
 	return 0;

--- a/code/headtracking/trackir.cpp
+++ b/code/headtracking/trackir.cpp
@@ -13,8 +13,14 @@ namespace headtracking
 	{
 		TrackIRProvider::TrackIRProvider()
 		{
+			auto window = os::getSDLMainWindow();
+			if (window == nullptr)
+			{
+				throw internal::HeadTrackingException("TrackIR is only available with a valid window!");
+			}
+
 			// calling the function that will init all the function pointers for TrackIR stuff (Swifty)
-			int trackIrInitResult = _trackIRDll.Init(os_get_window());
+			int trackIrInitResult = _trackIRDll.Init(window);
 			if (trackIrInitResult != SCP_INITRESULT_SUCCESS)
 			{
 				mprintf(("TrackIR Init Failed - %d\n", trackIrInitResult));

--- a/code/io/key.cpp
+++ b/code/io/key.cpp
@@ -91,7 +91,7 @@ namespace
 {
 	bool key_down_event_handler(const SDL_Event& e)
 	{
-		if (!os::events::isWindowEvent(e, os_get_window())) {
+		if (!os::events::isWindowEvent(e, os::getSDLMainWindow())) {
 			return false;
 		}
 
@@ -106,7 +106,7 @@ namespace
 
 	bool key_up_event_handler(const SDL_Event& e)
 	{
-		if (!os::events::isWindowEvent(e, os_get_window())) {
+		if (!os::events::isWindowEvent(e, os::getSDLMainWindow())) {
 			return false;
 		}
 

--- a/code/io/mouse.cpp
+++ b/code/io/mouse.cpp
@@ -61,7 +61,7 @@ namespace
 {
 	bool mouse_key_event_handler(const SDL_Event& e)
 	{
-		if (!os::events::isWindowEvent(e, os_get_window())) {
+		if (!os::events::isWindowEvent(e, os::getSDLMainWindow())) {
 			return false;
 		}
 
@@ -77,7 +77,7 @@ namespace
 
 	bool mouse_motion_event_handler(const SDL_Event& e)
 	{
-		if (!os::events::isWindowEvent(e, os_get_window())) {
+		if (!os::events::isWindowEvent(e, os::getSDLMainWindow())) {
 			return false;
 		}
 
@@ -88,7 +88,7 @@ namespace
 
 	bool mouse_wheel_event_handler(const SDL_Event& e)
 	{
-		if (!os::events::isWindowEvent(e, os_get_window())) {
+		if (!os::events::isWindowEvent(e, os::getSDLMainWindow())) {
 			return false;
 		}
 
@@ -459,7 +459,7 @@ void mouse_get_delta(int *dx, int *dy, int *dz)
 void mouse_force_pos(int x, int y)
 {
 	if (os_foreground()) {  // only mess with windows's mouse if we are in control of it
-		SDL_WarpMouseInWindow(os_get_window(), x, y);
+		SDL_WarpMouseInWindow(os::getSDLMainWindow(), x, y);
 	}
 }
 

--- a/code/osapi/dialogs.cpp
+++ b/code/osapi/dialogs.cpp
@@ -246,7 +246,7 @@ namespace os
 			boxData.flags = SDL_MESSAGEBOX_ERROR;
 			boxData.message = boxText.c_str();
 			boxData.title = "Error!";
-			boxData.window = os_get_window();
+			boxData.window = os::getSDLMainWindow();
 
 			gr_activate(0);
 
@@ -330,7 +330,7 @@ namespace os
 			boxData.flags = SDL_MESSAGEBOX_ERROR;
 			boxData.message = text;
 			boxData.title = "Error!";
-			boxData.window = os_get_window();
+			boxData.window = os::getSDLMainWindow();
 
 			gr_activate(0);
 
@@ -411,7 +411,7 @@ namespace os
 			boxData.flags = SDL_MESSAGEBOX_WARNING;
 			boxData.message = boxMessage.c_str();
 			boxData.title = "Warning!";
-			boxData.window = os_get_window();
+			boxData.window = os::getSDLMainWindow();
 
 			gr_activate(0);
 
@@ -499,7 +499,7 @@ namespace os
 					break;
 			}
 
-			SDL_ShowSimpleMessageBox(flags, title, message, os_get_window());
+			SDL_ShowSimpleMessageBox(flags, title, message, os::getSDLMainWindow());
 		}
 	}
 }

--- a/code/osapi/osapi.cpp
+++ b/code/osapi/osapi.cpp
@@ -34,6 +34,10 @@ namespace
 	bool checkedLegacyMode = false;
 	bool legacyMode = false;
 
+	SCP_vector<std::unique_ptr<os::Viewport>> viewports;
+	os::Viewport* mainViewPort = nullptr;
+	SDL_Window* mainSDLWindow = nullptr;
+
 	const char* getPreferencesPath()
 	{
 		// Lazily initialize the preferences path
@@ -57,7 +61,8 @@ namespace
 	bool fAppActive = false;
 	bool window_event_handler(const SDL_Event& e)
 	{
-		if (os::events::isWindowEvent(e, os_get_window())) {
+		Assertion(mainSDLWindow != nullptr, "This function may only be called with a valid SDL Window.");
+		if (os::events::isWindowEvent(e, mainSDLWindow)) {
 			switch (e.window.event) {
 			case SDL_WINDOWEVENT_MINIMIZED:
 			case SDL_WINDOWEVENT_FOCUS_LOST:
@@ -193,8 +198,6 @@ void os_set_process_affinity()
 // OSAPI DEFINES/VARS
 //
 
-static SDL_Window* main_window = NULL;
-
 // os-wide globals
 static char			szWinTitle[128];
 static char			szWinClass[128];
@@ -260,9 +263,10 @@ void os_init(const char * wclass, const char * title, const char *app_name, cons
 // set the main window title
 void os_set_title( const char * title )
 {
+	Assertion(mainSDLWindow != nullptr, "This function may only be called with a valid SDL Window.");
 	strcpy_s( szWinTitle, title );
 
-	SDL_SetWindowTitle(main_window, szWinTitle);
+	SDL_SetWindowTitle(mainSDLWindow, szWinTitle);
 }
 
 // call at program end
@@ -281,23 +285,6 @@ void os_cleanup()
 int os_foreground()
 {
 	return fAppActive;
-}
-
-// Returns the handle to the main window
-SDL_Window* os_get_window()
-{
-	return main_window;
-}
-
-// Returns the handle to the main window
-void os_set_window(SDL_Window* new_handle)
-{
-	main_window = new_handle;
-	fAppActive = true;
-}
-
-void os_set_window_state(WindowState state) {
-
 }
 
 // process management -----------------------------------------------------------------
@@ -365,6 +352,9 @@ bool os_is_legacy_mode()
 // called at shutdown. Makes sure all thread processing terminates.
 void os_deinit()
 {
+	// Free the view ports 
+	viewports.clear();
+
 	if (preferencesPath) {
 		SDL_free(preferencesPath);
 		preferencesPath = nullptr;
@@ -395,6 +385,22 @@ void debug_int3(char *file, int line)
 
 namespace os
 {
+	Viewport* addViewport(std::unique_ptr<Viewport>&& viewport) {
+		auto port = viewport.get();
+		viewports.push_back(std::move(viewport));
+		return port;
+	}
+	void setMainViewPort(Viewport* mainView) {
+		mainViewPort = mainView;
+		mainSDLWindow = mainView->toSDLWindow();
+	}
+	SDL_Window* getSDLMainWindow() {
+		return mainSDLWindow;
+	}
+	Viewport* getMainViewport() {
+		return mainViewPort;
+	}
+
 	namespace events
 	{
 		namespace

--- a/fred2/fredview.cpp
+++ b/fred2/fredview.cpp
@@ -132,25 +132,85 @@ void view_universe(int just_marked = 0);
 void select_objects();
 void drag_rotate_save_backup();
 
+class MFCViewport : public os::Viewport
+{
+	HWND _windowHandle = nullptr;
+	HDC _device_context = nullptr;
+public:
+	explicit MFCViewport(HWND hwnd, HDC dc) : _windowHandle(hwnd), _device_context(dc)
+	{
+		Assertion(hwnd != nullptr, "Invalid window handle!");
+		Assertion(dc != nullptr, "Invalid device context handle!");
+	}
+
+	~MFCViewport() override
+	{
+		ReleaseDC(_windowHandle, _device_context);
+
+		_windowHandle = nullptr;
+		_device_context = nullptr;
+	}
+
+	SDL_Window* toSDLWindow() override
+	{
+		return nullptr;
+	}
+
+	std::pair<uint32_t, uint32_t> getSize() override
+	{
+		RECT size;
+		if (!GetWindowRect(_windowHandle, &size))
+		{
+			return std::make_pair(0, 0);
+		}
+
+		return std::make_pair(size.right - size.left, size.bottom - size.top);
+	}
+
+	void swapBuffers() override
+	{
+		SwapBuffers(_device_context);
+	}
+
+	void setState(os::ViewportState state) override
+	{
+		// Not implemented
+	}
+
+	void minimize() override
+	{
+		// Not implemented
+	}
+
+	void restore() override
+	{
+		// Not implemented
+	}
+
+	HDC getHDC()
+	{
+		return _device_context;
+	}
+};
+
 class MFCOpenGLContext : public os::OpenGLContext
 {
 	// HACK: Since OpenGL apparently likes global state we also have to make this global...
 	static void* _oglDllHandle;
 	static size_t _oglDllReferenceCount;
 
-	HWND _windowHandle = nullptr;
-	HDC _device_context = nullptr;
 	HGLRC _render_context = nullptr;
 
 	BOOL(WINAPI * wglSwapIntervalEXT)(int interval) = nullptr;
 public:
-
-	MFCOpenGLContext(HWND hwnd, HDC hdc, HGLRC hglrc)
-		: _windowHandle(hwnd),
-		  _device_context(hdc),
-		  _render_context(hglrc)
+	explicit MFCOpenGLContext(HGLRC hglrc)
+		: _render_context(hglrc)
 	{
-		_oglDllHandle = SDL_LoadObject("OPENGL32.DLL");
+		if (_oglDllHandle == nullptr)
+		{
+			_oglDllHandle = SDL_LoadObject("OPENGL32.DLL");
+		}
+		++_oglDllReferenceCount;
 	}
 
 	~MFCOpenGLContext() override
@@ -159,7 +219,12 @@ public:
 			mprintf(("Failed to delete render context!"));
 		}
 
-		ReleaseDC(_windowHandle, _device_context);
+		--_oglDllReferenceCount;
+		if (_oglDllReferenceCount == 0)
+		{
+			SDL_UnloadObject(_oglDllHandle);
+			_oglDllHandle = nullptr;
+		}
 	}
 
 	static void* wglLoader(const char* name)
@@ -177,26 +242,18 @@ public:
 	{
 		return wglLoader;
 	}
-
-	void makeCurrent()
-	{
-		if (!wglMakeCurrent(_device_context, _render_context))
-		{
-			mprintf(("Failed to make OpenGL context current!\n"));
-		}
-	}
-
-	void swapBuffers() override
-	{
-		SwapBuffers(_device_context);
-	}
-
+	
 	void setSwapInterval(int status) override
 	{
 		if (wglSwapIntervalEXT != nullptr)
 		{
 			wglSwapIntervalEXT(status);
 		}
+	}
+
+	HGLRC getHandle()
+	{
+		return _render_context;
 	}
 };
 
@@ -212,7 +269,7 @@ public:
 	~MFCGraphicsOperations() override
 	{}
 
-	std::unique_ptr<os::OpenGLContext> createOpenGLContext(const os::OpenGLContextAttributes& attrs, uint32_t, uint32_t) override
+	std::unique_ptr<os::Viewport> createViewport(const os::ViewPortProperties& props) override
 	{
 		int PixelFormat;
 		PIXELFORMATDESCRIPTOR pfd_test;
@@ -225,29 +282,34 @@ public:
 
 		GL_pfd.nSize = sizeof(PIXELFORMATDESCRIPTOR);
 		GL_pfd.nVersion = 1;
-		GL_pfd.dwFlags = PFD_DRAW_TO_WINDOW | PFD_SUPPORT_OPENGL | PFD_DOUBLEBUFFER;
+		GL_pfd.dwFlags = PFD_DRAW_TO_WINDOW | PFD_DOUBLEBUFFER;
+		if (props.enable_opengl)
+		{
+			GL_pfd.dwFlags |= PFD_SUPPORT_OPENGL;
+		}
+
 		GL_pfd.iPixelType = PFD_TYPE_RGBA;
-		GL_pfd.cColorBits = attrs.red_size + attrs.green_size + attrs.blue_size + attrs.alpha_size;
-		GL_pfd.cRedBits = attrs.red_size;
-		GL_pfd.cGreenBits = attrs.green_size;
-		GL_pfd.cBlueBits = attrs.blue_size;
-		GL_pfd.cAlphaBits = attrs.alpha_size;
-		GL_pfd.cDepthBits = attrs.depth_size;
-		GL_pfd.cStencilBits = attrs.stencil_size;
+		GL_pfd.cColorBits = props.pixel_format.red_size + props.pixel_format.green_size + props.pixel_format.blue_size + props.pixel_format.alpha_size;
+		GL_pfd.cRedBits = props.pixel_format.red_size;
+		GL_pfd.cGreenBits = props.pixel_format.green_size;
+		GL_pfd.cBlueBits = props.pixel_format.blue_size;
+		GL_pfd.cAlphaBits = props.pixel_format.alpha_size;
+		GL_pfd.cDepthBits = props.pixel_format.depth_size;
+		GL_pfd.cStencilBits = props.pixel_format.stencil_size;
 
 		Assert(_windowHandle != NULL);
 
 		auto device_context = GetDC(_windowHandle);
 
 		if (!device_context) {
-			Error(LOCATION, "Unable to get device context for OpenGL W32!");
+			mprintf(("Unable to get device context for OpenGL W32!\n"));
 			return nullptr;
 		}
 
 		PixelFormat = ChoosePixelFormat(device_context, &GL_pfd);
 
 		if (!PixelFormat) {
-			Error(LOCATION, "Unable to choose pixel format for OpenGL W32!");
+			mprintf(("Unable to choose pixel format for OpenGL W32!\n"));
 			ReleaseDC(_windowHandle, device_context);
 			return nullptr;
 		}
@@ -256,63 +318,68 @@ public:
 		}
 
 		if (!SetPixelFormat(device_context, PixelFormat, &GL_pfd)) {
-			Error(LOCATION, "Unable to set pixel format for OpenGL W32!");
-			ReleaseDC(_windowHandle, device_context);
-			return nullptr;
-		}
-
-		auto render_context = wglCreateContext(device_context);
-		if (!render_context) {
-			Error(LOCATION, "Unable to create rendering context for OpenGL W32!");
-			ReleaseDC(_windowHandle, device_context);
-			return nullptr;
-		}
-
-		if (!wglMakeCurrent(device_context, render_context)) {
-			Error(LOCATION, "Unable to make current thread for OpenGL W32!");
-			
-			if (!wglDeleteContext(render_context)) {
-				mprintf(("Failed to delete render context!"));
-			}
-
+			mprintf(("Unable to set pixel format for OpenGL W32!\n"));
 			ReleaseDC(_windowHandle, device_context);
 			return nullptr;
 		}
 
 		mprintf(("  Requested SDL Video values = R: %d, G: %d, B: %d, depth: %d, stencil: %d\n",
-			attrs.red_size, attrs.green_size, attrs.blue_size, attrs.depth_size, attrs.stencil_size));
+			props.pixel_format.red_size, props.pixel_format.green_size, props.pixel_format.blue_size,
+			props.pixel_format.depth_size, props.pixel_format.stencil_size));
 
-		// now report back as to what we ended up getting
+		return std::unique_ptr<os::Viewport>(new MFCViewport(_windowHandle, device_context));
+	}
 
-		DescribePixelFormat(device_context, PixelFormat, sizeof(PIXELFORMATDESCRIPTOR), &GL_pfd);
+	std::unique_ptr<os::OpenGLContext> createOpenGLContext(os::Viewport* port, const os::OpenGLContextAttributes& ctx) override
+	{
+		if (ctx.profile != os::OpenGLProfile::Compatibility) {
+			mprintf(("ERROR: FRED code can only create compatibility profiles!\n"));
+			return nullptr;
+		}
 
-		int r = GL_pfd.cRedBits;
-		int g = GL_pfd.cGreenBits;
-		int b = GL_pfd.cBlueBits;
-		int depth = GL_pfd.cDepthBits;
-		int stencil = GL_pfd.cStencilBits;
-		int db = ((GL_pfd.dwFlags & PFD_DOUBLEBUFFER) > 0);
+		auto mfcView = reinterpret_cast<MFCViewport*>(port);
 
-		mprintf(("  Actual WGL Video values    = R: %d, G: %d, B: %d, depth: %d, stencil: %d\n", r, g, b, depth, stencil, db));
-		
+		auto render_context = wglCreateContext(mfcView->getHDC());
+		if (!render_context) {
+			mprintf(("Unable to create rendering context for OpenGL W32!\n"));
+			return nullptr;
+		}
+
+		if (!wglMakeCurrent(mfcView->getHDC(), render_context)) {
+			mprintf(("Unable to make current thread for OpenGL W32!\n"));
+			
+			if (!wglDeleteContext(render_context)) {
+				mprintf(("Failed to delete render context!"));
+			}
+
+			return nullptr;
+		}
+
 		// Load the OpenGL DLL so we can use it to look up function pointers
 		// The name is from the SDL sources so it should be the right one
 		
-		return std::unique_ptr<os::OpenGLContext>(new MFCOpenGLContext(_windowHandle, device_context, render_context));
+		return std::unique_ptr<os::OpenGLContext>(new MFCOpenGLContext(render_context));
 	}
 
-	void makeOpenGLContextCurrent(os::OpenGLContext* ctx) override
+	void makeOpenGLContextCurrent(os::Viewport* view, os::OpenGLContext* ctx) override
 	{
-		if (ctx == nullptr)
-		{
+		if (view == nullptr && ctx == nullptr) {
 			if (!wglMakeCurrent(nullptr, nullptr))
 			{
 				mprintf(("Failed to make OpenGL context current!\n"));
 			}
+			return;
 		}
-		else
+
+		Assertion(view != nullptr, "Both viewport of context must be valid at this point!");
+		Assertion(ctx != nullptr, "Both viewport of context must be valid at this point!");
+
+		auto mfcCtx = reinterpret_cast<MFCOpenGLContext*>(ctx);
+		auto mfcView = reinterpret_cast<MFCViewport*>(view);
+
+		if (!wglMakeCurrent(mfcView->getHDC(), mfcCtx->getHandle()))
 		{
-			reinterpret_cast<MFCOpenGLContext*>(ctx)->makeCurrent();
+			mprintf(("Failed to make OpenGL context current!\n"));
 		}
 	}
 };

--- a/fred2/missionsave.cpp
+++ b/fred2/missionsave.cpp
@@ -1265,7 +1265,7 @@ int CFred_mission_save::save_campaign_file(char *pathname) {
 			if (mission_loop && num_mission_special > 1) {
 				char buffer[1024];
 				sprintf(buffer, "Multiple branching loop error from mission %s\nEdit campaign for *at most* 1 loop from each mission.", Campaign.missions[m].name);
-				MessageBox((HWND) os_get_window(), buffer, "Error", MB_OK);
+				Message(os::dialogs::MESSAGEBOX_ERROR, buffer);
 			}
 		}
 

--- a/freespace2/SDLGraphicsOperations.h
+++ b/freespace2/SDLGraphicsOperations.h
@@ -7,12 +7,15 @@
 
 class SDLGraphicsOperations: public os::GraphicsOperations {
  public:
+	SDLGraphicsOperations();
 	~SDLGraphicsOperations() override;
 
-	std::unique_ptr<os::OpenGLContext> createOpenGLContext(const os::OpenGLContextAttributes& attrs,
-												  uint32_t width, uint32_t height) override;
+	std::unique_ptr<os::OpenGLContext> createOpenGLContext(os::Viewport* viewport,
+														   const os::OpenGLContextAttributes& gl_attrs) override;
 
-	void makeOpenGLContextCurrent(os::OpenGLContext* ctx) override;
+	void makeOpenGLContextCurrent(os::Viewport* view, os::OpenGLContext* ctx) override;
+
+	std::unique_ptr<os::Viewport> createViewport(const os::ViewPortProperties& props) override;
 };
 
 #endif // _SDL_GRAPHICS_OPERATIONS

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -1887,7 +1887,7 @@ void game_init()
 		SDL_VERSION(&info.version); // initialize info structure with SDL version info
 
 		bool voiceRectOn = false;
-		if(SDL_GetWindowWMInfo(os_get_window(), &info)) { // the call returns true on success
+		if(SDL_GetWindowWMInfo(os::getSDLMainWindow(), &info)) { // the call returns true on success
 			// success
 			voiceRectOn = VOICEREC_init(info.info.win.window, WM_RECOEVENT, GRAMMARID1, IDR_CMD_CFG);
 		} else {


### PR DESCRIPTION
This separates OpenGL context creation from window creation and also allows to implement multiple viewports in the future. This is a continuation of the previous PR where I added the OpenGL context abstraction.