### PR TITLE
Add option for writing pilot files in JSON format

### DIFF
--- a/code/CMakeLists.txt
+++ b/code/CMakeLists.txt
@@ -38,9 +38,10 @@ IF (FSO_USE_SPEECH)
 	target_link_libraries(code PUBLIC speech)
 ENDIF(FSO_USE_SPEECH)
 
+TARGET_LINK_LIBRARIES(code PUBLIC jansson)
+
 # Headers for standalone "gui" on UNIX
 IF(UNIX)
-	TARGET_LINK_LIBRARIES(code PUBLIC jansson)
 	TARGET_LINK_LIBRARIES(code PUBLIC ${MONGOOSE_LIBS})
 ENDIF(UNIX)
 

--- a/code/cmdline/cmdline.cpp
+++ b/code/cmdline/cmdline.cpp
@@ -239,6 +239,7 @@ Flag exe_params[] =
 	{ "-no_unfocused_pause","Don't pause if the window isn't focused",	true,	0,					EASY_DEFAULT,		"Dev Tool",		"http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-no_unfocused_pause", },
 	{ "-benchmark_mode",	"Puts the game into benchmark mode",		true,	0,					EASY_DEFAULT,		"Dev Tool",		"http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-benchmark_mode", },
 	{ "-noninteractive",	"Disables interactive dialogs",				true,	0,					EASY_DEFAULT,		"Dev Tool",		"http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-noninteractive", },
+	{ "-json_pilot",		"Dump pilot files in JSON format",			true,	0,					EASY_DEFAULT,		"Dev Tool",		"http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-json_pilot", },
 };
 
 // forward declaration
@@ -485,6 +486,7 @@ cmdline_parm frame_profile_write_file("-profile_write_file", NULL, AT_NONE); // 
 cmdline_parm no_unfocused_pause_arg("-no_unfocused_pause", NULL, AT_NONE); //Cmdline_no_unfocus_pause
 cmdline_parm benchmark_mode_arg("-benchmark_mode", NULL, AT_NONE); //Cmdline_benchmark_mode
 cmdline_parm noninteractive_arg("-noninteractive", NULL, AT_NONE); //Cmdline_noninteractive
+cmdline_parm json_pilot("-json_pilot", NULL, AT_NONE); //Cmdline_json_pilot
 
 
 char *Cmdline_start_mission = NULL;
@@ -511,6 +513,7 @@ bool Cmdline_profile_write_file = false;
 bool Cmdline_no_unfocus_pause = false;
 bool Cmdline_benchmark_mode = false;
 bool Cmdline_noninteractive = false;
+bool Cmdline_json_pilot = false;
 
 // Other
 cmdline_parm get_flags_arg("-get_flags", "Output the launcher flags file", AT_NONE);
@@ -1851,6 +1854,11 @@ bool SetCmdlineParams()
 	if (noninteractive_arg.found())
 	{
 		Cmdline_noninteractive = true;
+	}
+
+	if (json_pilot.found())
+	{
+		Cmdline_json_pilot = true;
 	}
 
 	//Deprecated flags - CommanderDJ

--- a/code/cmdline/cmdline.h
+++ b/code/cmdline/cmdline.h
@@ -158,5 +158,6 @@ extern bool Cmdline_profile_write_file;
 extern bool Cmdline_no_unfocus_pause;
 extern bool Cmdline_benchmark_mode;
 extern bool Cmdline_noninteractive;
+extern bool Cmdline_json_pilot;
 
 #endif

--- a/code/cutscene/cutscenes.h
+++ b/code/cutscene/cutscenes.h
@@ -21,7 +21,15 @@ typedef struct cutscene_info {
 	bool	viewable;
 } cutscene_info;
 
+#if SCP_COMPILER_IS_GNU
+#pragma GCC diagnostic push
+// This suppresses a GCC bug where it thinks that the Cutscenes from the enum class below shadows a global variable
+#pragma GCC diagnostic ignored "-Wshadow"
+#endif
 extern SCP_vector<cutscene_info> Cutscenes;
+#if SCP_COMPILER_IS_GNU
+#pragma GCC diagnostic pop
+#endif
 
 // initializa table data
 void cutscene_init();

--- a/code/globalincs/vmallocator.h
+++ b/code/globalincs/vmallocator.h
@@ -14,28 +14,28 @@
 #include <sstream>
 
 template< typename T >
-class SCP_vector : public std::vector< T, std::allocator< T > > { };
+using SCP_vector = std::vector< T, std::allocator< T > >;
 
 template< typename T >
-class SCP_list : public std::list< T, std::allocator< T > > { };
+using SCP_list = std::list< T, std::allocator< T > >;
 
 typedef std::basic_string<char, std::char_traits<char>, std::allocator<char> > SCP_string;
 
 typedef std::basic_stringstream<char, std::char_traits<char>, std::allocator<char> > SCP_stringstream;
 
 template< typename T, typename U >
-class SCP_map : public std::map<T, U, std::less<T>, std::allocator<std::pair<const T, U> > > { };
+using SCP_map = std::map<T, U, std::less<T>, std::allocator<std::pair<const T, U> > >;
 
 template< typename T, typename U >
-class SCP_multimap : public std::multimap<T, U, std::less<T>, std::allocator<std::pair<const T, U> > > { };
+using SCP_multimap = std::multimap<T, U, std::less<T>, std::allocator<std::pair<const T, U> > >;
 
 template< typename T >
-class SCP_queue : public std::queue< T, std::deque< T, std::allocator< T > > > { };
+using SCP_queue = std::queue< T, std::deque< T, std::allocator< T > > >;
 
 template< typename T >
-class SCP_deque : public std::deque< T, std::allocator< T > > { };
+using SCP_deque = std::deque< T, std::allocator< T > >;
 
 template< typename Key, typename T, typename Hash = std::hash<Key>, typename KeyEqual = std::equal_to<Key> >
-class SCP_unordered_map : public std::unordered_map< Key, T, Hash, KeyEqual, std::allocator< std::pair<const Key, T> > > { };
+using SCP_unordered_map = std::unordered_map< Key, T, Hash, KeyEqual, std::allocator< std::pair<const Key, T> > >;
 
 #endif // _VMALLOCATOR_H_INCLUDED_

--- a/code/pilotfile/BinaryFileHandler.cpp
+++ b/code/pilotfile/BinaryFileHandler.cpp
@@ -1,0 +1,89 @@
+
+#include "pilotfile/BinaryFileHandler.h"
+
+pilot::BinaryFileHandler::BinaryFileHandler(CFILE* cfp) : _cfp(cfp) {
+	Assertion(cfp != nullptr, "File pointer must be valid!");
+}
+
+pilot::BinaryFileHandler::~BinaryFileHandler() {
+	cfclose(_cfp);
+	_cfp = nullptr;
+}
+
+void pilot::BinaryFileHandler::writeUByte(const char*, std::uint8_t value) {
+	cfwrite_ubyte(value, _cfp);
+}
+void pilot::BinaryFileHandler::writeShort(const char*, std::int16_t value) {
+	cfwrite_short(value, _cfp);
+}
+
+void pilot::BinaryFileHandler::writeInt(const char*, std::int32_t value) {
+	cfwrite_int(value, _cfp);
+}
+
+void pilot::BinaryFileHandler::writeUInt(const char*, std::uint32_t value) {
+	cfwrite_uint(value, _cfp);
+}
+
+void pilot::BinaryFileHandler::writeFloat(const char*, float value) {
+	cfwrite_float(value, _cfp);
+}
+
+void pilot::BinaryFileHandler::writeString(const char*, const char* str) {
+	cfwrite_string_len(str, _cfp);
+}
+
+void pilot::BinaryFileHandler::startSectionWrite(Section id) {
+	if (id == Section::Unnamed) {
+		_sectionOffsets.push_back({id, 0});
+		return;
+	}
+
+	cfwrite_ushort((ushort) id, _cfp);
+
+	// to be updated when endSection() is called
+	cfwrite_int(0, _cfp);
+
+	// starting offset, for size of section
+	_sectionOffsets.push_back({id, (size_t)cftell(_cfp)});
+}
+
+void pilot::BinaryFileHandler::endSectionWrite() {
+	Assertion(!_sectionOffsets.empty(), "No active section!");
+	auto previous_off = _sectionOffsets.back();
+
+	if (previous_off.id == Section::Unnamed) {
+		// ignore unnamed sections, these are only needed for JSON
+		return;
+	}
+
+
+	size_t cur = (size_t) cftell(_cfp);
+	_sectionOffsets.pop_back();
+
+	Assert(cur >= previous_off.offset);
+
+	size_t section_size = cur - previous_off.offset;
+
+	if (section_size) {
+		// go back to section size in file and write proper value
+		cfseek(_cfp, (int) (cur - section_size - sizeof(int)), CF_SEEK_SET);
+		cfwrite_int((int) section_size, _cfp);
+
+		// go back to previous location for next section
+		cfseek(_cfp, (int) cur, CF_SEEK_SET);
+	}
+}
+void pilot::BinaryFileHandler::startArrayWrite(const char*, size_t size, bool short_index) {
+	if (short_index) {
+		cfwrite_ushort((short)size, _cfp);
+	} else {
+		cfwrite_int((int)size, _cfp);
+	}
+}
+void pilot::BinaryFileHandler::endArrayWrite() {
+	// Nothing to do here for the binary version
+}
+void pilot::BinaryFileHandler::flush() {
+	cflush(_cfp);
+}

--- a/code/pilotfile/BinaryFileHandler.h
+++ b/code/pilotfile/BinaryFileHandler.h
@@ -1,0 +1,53 @@
+
+#ifndef BINARY_FILE_HANDLER_H
+#define BINARY_FILE_HANDLER_H
+#pragma once
+
+#include "pilotfile/FileHandler.h"
+
+#include "globalincs/pstypes.h"
+#include "cfile/cfile.h"
+
+namespace pilot {
+class BinaryFileHandler: public FileHandler {
+	CFILE* _cfp;
+
+	struct SectionOffset {
+		Section id;
+		size_t offset;
+	};
+
+	SCP_vector<SectionOffset> _sectionOffsets;
+ public:
+	explicit BinaryFileHandler(CFILE* cfp);
+
+	~BinaryFileHandler() override;
+
+	void writeUByte(const char* name, std::uint8_t value) override;
+
+	void writeShort(const char* name, std::int16_t value) override;
+
+	void writeInt(const char* name, std::int32_t value) override;
+
+	void writeUInt(const char* name, std::uint32_t value) override;
+
+	void writeFloat(const char* name, float value) override;
+
+	void writeString(const char* name, const char* str) override;
+
+
+	void startSectionWrite(Section id) override;
+
+	void endSectionWrite() override;
+
+
+	void startArrayWrite(const char* name, size_t size, bool short_length = false) override;
+
+	void endArrayWrite() override;
+
+
+	virtual void flush() override;
+};
+}
+
+#endif // BINARY_FILE_HANDLER_H

--- a/code/pilotfile/FileHandler.h
+++ b/code/pilotfile/FileHandler.h
@@ -1,0 +1,68 @@
+
+#ifndef FILEHANDLER_H
+#define FILEHANDLER_H
+#pragma once
+
+#include <cstdint>
+#include <memory>
+
+#include "globalincs/pstypes.h"
+
+#if SCP_COMPILER_IS_GNU
+#pragma GCC diagnostic push
+// This suppresses a GCC bug where it thinks that the Cutscenes from the enum class below shadows a global variable
+#pragma GCC diagnostic ignored "-Wshadow"
+#endif
+// sections of a pilot file. includes both plr and csg sections
+enum class Section {
+	Unnamed = 0, //!< Special unnamed section
+	Flags = 0x0001,
+	Info = 0x0002,
+	Loadout = 0x0003,
+	Controls = 0x0004,
+	Multiplayer = 0x0005,
+	Scoring = 0x0006,
+	ScoringMulti = 0x0007,
+	Techroom = 0x0008,
+	HUD = 0x0009,
+	Settings = 0x0010,
+	RedAlert = 0x0011,
+	Variables = 0x0012,
+	Missions = 0x0013,
+	Cutscenes = 0x0014,
+	LastMissions = 0x0015
+};
+#if SCP_COMPILER_IS_GNU
+#pragma GCC diagnostic pop
+#endif
+
+namespace pilot {
+class FileHandler {
+ public:
+	virtual ~FileHandler() {}
+
+	virtual void writeUByte(const char* name, std::uint8_t value) = 0;
+
+	virtual void writeShort(const char* name, std::int16_t value) = 0;
+
+	virtual void writeInt(const char* name, std::int32_t value) = 0;
+
+	virtual void writeUInt(const char* name, std::uint32_t value) = 0;
+
+	virtual void writeFloat(const char* name, float value) = 0;
+
+	virtual void writeString(const char* name, const char* str) = 0;
+
+	virtual void startSectionWrite(Section id) = 0;
+
+	virtual void endSectionWrite() = 0;
+
+	virtual void startArrayWrite(const char* name, size_t size, bool short_length = false) = 0;
+
+	virtual void endArrayWrite() = 0;
+
+	virtual void flush() = 0;
+};
+}
+
+#endif // FILEHANDLER_H

--- a/code/pilotfile/JSONFileHandler.cpp
+++ b/code/pilotfile/JSONFileHandler.cpp
@@ -1,0 +1,146 @@
+
+#include "pilotfile/JSONFileHandler.h"
+
+namespace {
+int json_write_callback(const char *buffer, size_t size, void *data) {
+	CFILE* cfp = (CFILE*)data;
+
+	if (cfwrite(buffer, 1, (int)size, cfp) != size) {
+		return -1; // Error
+	} else {
+		return 0; // Success
+	}
+}
+
+const SCP_vector<std::pair<Section, const char*>> SectionMapping {
+	std::pair<Section, const char*>(Section::Unnamed, nullptr),
+	std::pair<Section, const char*>(Section::Flags, "flags"),
+	std::pair<Section, const char*>(Section::Info, "info"),
+	std::pair<Section, const char*>(Section::Loadout, "loadout"),
+	std::pair<Section, const char*>(Section::Controls, "controls"),
+	std::pair<Section, const char*>(Section::Multiplayer, "multiplayer"),
+	std::pair<Section, const char*>(Section::Scoring, "scoring"),
+	std::pair<Section, const char*>(Section::ScoringMulti, "scoring_multi"),
+	std::pair<Section, const char*>(Section::Techroom, "techroom"),
+	std::pair<Section, const char*>(Section::HUD, "hud"),
+	std::pair<Section, const char*>(Section::Settings, "settings"),
+	std::pair<Section, const char*>(Section::RedAlert, "red_alert"),
+	std::pair<Section, const char*>(Section::Variables, "variables"),
+	std::pair<Section, const char*>(Section::Missions, "missions"),
+	std::pair<Section, const char*>(Section::Cutscenes, "cutscenes"),
+	std::pair<Section, const char*>(Section::LastMissions, "last_mission")
+};
+
+const char* lookupSectionName(Section s) {
+	for (auto& pair : SectionMapping) {
+		if (pair.first == s) {
+			return pair.second;
+		}
+	}
+	Assertion(false, "Unknown section!");
+	return nullptr;
+}
+
+Section lookupSectionValue(const char* name) {
+	for (auto& pair : SectionMapping) {
+		if (!strcmp(pair.second, name)) {
+			return pair.first;
+		}
+	}
+	Assertion(false, "Unknown section name!");
+	return Section::Unnamed;
+}
+}
+
+pilot::JSONFileHandler::JSONFileHandler(CFILE* cfp) : _cfp(cfp) {
+	Assertion(cfp != nullptr, "File pointer must be valid!");
+
+	_rootObj = json_object();
+	_currentEl = _rootObj;
+	_elementStack.push_back(_currentEl);
+}
+
+pilot::JSONFileHandler::~JSONFileHandler() {
+	json_decref(_rootObj);
+
+	cfclose(_cfp);
+	_cfp = nullptr;
+}
+void pilot::JSONFileHandler::writeUByte(const char* name, std::uint8_t value) {
+	writeInteger(name, value);
+}
+void pilot::JSONFileHandler::writeShort(const char* name, std::int16_t value) {
+	writeInteger(name, value);
+}
+void pilot::JSONFileHandler::writeInt(const char* name, std::int32_t value) {
+	writeInteger(name, value);
+}
+void pilot::JSONFileHandler::writeUInt(const char* name, std::uint32_t value) {
+	writeInteger(name, value);
+}
+void pilot::JSONFileHandler::writeFloat(const char* name, float value) {
+	ensureNotExists(name);
+	json_object_set_new(_currentEl, name, json_real(value));
+}
+void pilot::JSONFileHandler::writeString(const char* name, const char* str) {
+	ensureNotExists(name);
+	json_object_set_new(_currentEl, name, json_string(str));
+}
+void pilot::JSONFileHandler::startSectionWrite(Section id) {
+	auto key_name = lookupSectionName(id);
+
+	json_t* obj = json_object();
+
+	if (json_is_array(_currentEl)) {
+		// We are in an array, section must be unnamed
+		Assertion(key_name == nullptr, "Inside an array there can be no named section!");
+		json_array_append_new(_currentEl, obj);
+	} else {
+		Assertion(key_name != nullptr, "Section outside of arrays must be named!");
+		json_object_set_new(_currentEl, key_name, obj);
+	}
+	_currentEl = obj;
+	_elementStack.push_back(_currentEl);
+}
+void pilot::JSONFileHandler::endSectionWrite() {
+	Assertion(json_is_object(_currentEl), "Section ended while not in a section!");
+
+	_elementStack.pop_back();
+	_currentEl = _elementStack.back();
+}
+void pilot::JSONFileHandler::startArrayWrite(const char* name, size_t, bool) {
+	auto array = json_array();
+
+	if (json_is_array(_currentEl)) {
+		// We are in an array, section must be unnamed
+		Assertion(name == nullptr, "Inside an array there can be no named section!");
+		json_array_append_new(_currentEl, array);
+	} else {
+		Assertion(name != nullptr, "Section outside of arrays must be named!");
+		json_object_set_new(_currentEl, name, array);
+	}
+	_currentEl = array;
+	_elementStack.push_back(_currentEl);
+}
+void pilot::JSONFileHandler::endArrayWrite() {
+	Assertion(json_is_array(_currentEl), "Array ended while not in an array!");
+
+	_elementStack.pop_back();
+	_currentEl = _elementStack.back();
+}
+void pilot::JSONFileHandler::flush() {
+	Assertion(_elementStack.size() == 1, "Not all sections or arrays have been ended!");
+
+	json_dump_callback(_rootObj, json_write_callback, _cfp, JSON_INDENT(4));
+}
+void pilot::JSONFileHandler::writeInteger(const char* name, json_int_t val) {
+	ensureNotExists(name);
+
+	json_object_set_new(_currentEl, name, json_integer(val));
+}
+void pilot::JSONFileHandler::ensureNotExists(const char* name) {
+	Assertion(json_is_object(_currentEl), "Currently not in an element that supports keys!");
+	// Make sure we don't overwrite previous values
+	Assertion(json_object_get(_currentEl, name) == nullptr, "Entry with name %s already exists!", name);
+}
+

--- a/code/pilotfile/JSONFileHandler.h
+++ b/code/pilotfile/JSONFileHandler.h
@@ -1,0 +1,56 @@
+
+#ifndef JSON_FILE_HANDLER_H
+#define JSON_FILE_HANDLER_H
+#pragma once
+
+#include "pilotfile/FileHandler.h"
+
+#include "globalincs/pstypes.h"
+#include "cfile/cfile.h"
+
+#include <jansson.h>
+
+namespace pilot {
+class JSONFileHandler: public FileHandler {
+	CFILE* _cfp;
+
+	json_t* _rootObj;
+
+	json_t* _currentEl;
+
+	SCP_vector<json_t*> _elementStack;
+
+	void ensureNotExists(const char* name);
+	void writeInteger(const char* name, json_int_t value);
+ public:
+	explicit JSONFileHandler(CFILE* cfp);
+
+	~JSONFileHandler() override;
+
+	void writeUByte(const char* name, std::uint8_t value) override;
+
+	void writeShort(const char* name, std::int16_t value) override;
+
+	void writeInt(const char* name, std::int32_t value) override;
+
+	void writeUInt(const char* name, std::uint32_t value) override;
+
+	void writeFloat(const char* name, float value) override;
+
+	void writeString(const char* name, const char* str) override;
+
+
+	void startSectionWrite(Section id) override;
+
+	void endSectionWrite() override;
+
+
+	void startArrayWrite(const char* name, size_t size, bool short_length = false) override;
+
+	void endArrayWrite() override;
+
+	void flush() override;
+};
+}
+
+#endif // JSON_FILE_HANDLER_H

--- a/code/pilotfile/csg.cpp
+++ b/code/pilotfile/csg.cpp
@@ -1408,7 +1408,7 @@ bool pilotfile::load_savefile(const char *campaign)
 
 	// the point of all this: read in the CSG contents
 	while ( !cfeof(cfp) ) {
-		ushort section_id = cfread_ushort(cfp);
+		Section section_id = static_cast<Section>(cfread_ushort(cfp));
 		uint section_size = cfread_uint(cfp);
 
 		size_t start_pos = cftell(cfp);
@@ -1647,7 +1647,7 @@ bool pilotfile::get_csg_rank(int *rank)
 
 	// the point of all this: read in the CSG contents
 	while ( !m_have_flags && !cfeof(cfp) ) {
-		ushort section_id = cfread_ushort(cfp);
+		Section section_id = static_cast<Section>(cfread_ushort(cfp));
 		uint section_size = cfread_uint(cfp);
 
 		size_t start_pos = cftell(cfp);

--- a/code/pilotfile/pilotfile.cpp
+++ b/code/pilotfile/pilotfile.cpp
@@ -27,7 +27,7 @@ pilotfile::~pilotfile()
 	}
 }
 
-void pilotfile::startSection(Section::id section_id)
+void pilotfile::startSection(Section section_id)
 {
 	Assert( cfp );
 

--- a/code/pilotfile/pilotfile.h
+++ b/code/pilotfile/pilotfile.h
@@ -5,7 +5,9 @@
 #include "cfile/cfile.h"
 #include "globalincs/pstypes.h"
 #include "stats/scoring.h"
+#include "pilotfile/FileHandler.h"
 
+#include <memory>
 
 class player;
 
@@ -60,6 +62,7 @@ class pilotfile {
 		// info shared between PLR and CSG ...
 		// --------------------------------------------------------------------
 		CFILE *cfp;
+		std::unique_ptr<pilot::FileHandler> handler;
 		SCP_string filename;
 		player *p;
 
@@ -129,29 +132,8 @@ class pilotfile {
 		scoring_special_t all_time_stats;
 		scoring_special_t multi_stats;
 
-		// sections of a pilot file. includes both plr and csg sections
-		struct Section {
-			enum id {
-				Flags			= 0x0001,
-				Info			= 0x0002,
-				Loadout			= 0x0003,
-				Controls		= 0x0004,
-				Multiplayer		= 0x0005,
-				Scoring			= 0x0006,
-				ScoringMulti	= 0x0007,
-				Techroom		= 0x0008,
-				HUD				= 0x0009,
-				Settings		= 0x0010,
-				RedAlert		= 0x0011,
-				Variables		= 0x0012,
-				Missions		= 0x0013,
-				Cutscenes		= 0x0014,
-				LastMissions	= 0x0015
-			};
-		};
-
 		// for writing files, sets/updates section info
-		void startSection(Section::id section_id);
+		void startSection(Section section_id);
 		void endSection();
 		// file offset of the size value for the current section (set with startSection())
 		size_t m_size_offset;

--- a/code/source_groups.cmake
+++ b/code/source_groups.cmake
@@ -831,7 +831,12 @@ set (file_root_physics
 
 # PilotFile files
 set (file_root_pilotfile
+	pilotfile/BinaryFileHandler.cpp
+	pilotfile/BinaryFileHandler.h
 	pilotfile/csg.cpp
+	pilotfile/FileHandler.h
+	pilotfile/JSONFileHandler.cpp
+	pilotfile/JSONFileHandler.h
 	pilotfile/csg_convert.cpp
 	pilotfile/pilotfile.cpp
 	pilotfile/pilotfile.h

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -19,9 +19,8 @@ add_subdirectory(opengl)
 
 ADD_SUBDIRECTORY(libsdl)
 
+ADD_SUBDIRECTORY(jansson)
 # These are only required for the web-ui which is non-Windows
 IF(UNIX)
-	ADD_SUBDIRECTORY(jansson)
-
 	ADD_SUBDIRECTORY(mongoose)
 ENDIF(UNIX)

--- a/lib/jansson/CMakeLists.txt
+++ b/lib/jansson/CMakeLists.txt
@@ -49,7 +49,7 @@
 # the source directory.
 # The rest is down to the usual make process.
 
-IF(NOT ${FSO_BUILD_INCLUDED_LIBS} AND ${UNIX})
+IF(NOT FSO_BUILD_INCLUDED_LIBS AND UNIX)
 	find_package(PkgConfig)
 
 	if (PKG_CONFIG_FOUND)
@@ -66,7 +66,7 @@ IF(NOT ${FSO_BUILD_INCLUDED_LIBS} AND ${UNIX})
 	endif()
 ENDIF()
 
-IF(${FSO_BUILD_INCLUDED_LIBS} OR NOT ${JANSSON_FOUND})
+IF(FSO_BUILD_INCLUDED_LIBS OR NOT JANSSON_FOUND)
 	MESSAGE(STATUS "Building jansson from source...")
     # Options
     set(USE_URANDOM ON)


### PR DESCRIPTION
This is a new implementation of the JSON dumping which was already
proposed in #22 but this version tries to allow implementing both
reading and writing JSON files without having to change the existing
code too much. This is done by using an abstract class to hide the
differences between writing the JSON and binary files.

This is currently only capable of writing the files but not reading them
so if the option is enabled all changes to the pilot file are lost. I
will implement reading after this PR has been merged since I would like
to reduce the amount of changes that need to be reviewed.