### PR TITLE
Add -nograb commandline option

### DIFF
--- a/code/cmdline/cmdline.cpp
+++ b/code/cmdline/cmdline.cpp
@@ -209,6 +209,7 @@ Flag exe_params[] =
 	{ "-no_batching",		"Disable batched model rendering",			true,	0,					EASY_DEFAULT,		"Troubleshoot", "", },
 	{ "-no_geo_effects",	"Disable geometry shader for effects",		true,	0,					EASY_DEFAULT,		"Troubleshoot", "", },
 	{ "-set_cpu_affinity",	"Sets processor affinity to config value",	true,	0,					EASY_DEFAULT,		"Troubleshoot", "", },
+	{ "-nograb",			"Disables mouse grabbing",					true,	0,					EASY_DEFAULT,		"Troubleshoot", "http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-nograb", },
 #ifdef WIN32
 	{ "-fix_registry",	"Use a different registry path",			true,		0,					EASY_DEFAULT,		"Troubleshoot", "", },
 #endif
@@ -441,6 +442,7 @@ cmdline_parm old_collision_system("-old_collision", NULL, AT_NONE); // Cmdline_o
 cmdline_parm gl_finish ("-gl_finish", NULL, AT_NONE);
 cmdline_parm no_geo_sdr_effects("-no_geo_effects", NULL, AT_NONE);
 cmdline_parm set_cpu_affinity("-set_cpu_affinity", NULL, AT_NONE);
+cmdline_parm nograb_arg("-nograb", NULL, AT_NONE);
 #ifdef WIN32
 cmdline_parm fix_registry("-fix_registry", NULL, AT_NONE);
 #endif
@@ -459,6 +461,7 @@ char* Cmdline_keyboard_layout = NULL;
 bool Cmdline_gl_finish = false;
 bool Cmdline_no_geo_sdr_effects = false;
 bool Cmdline_set_cpu_affinity = false;
+bool Cmdline_nograb = false;
 #ifdef WIN32
 bool Cmdline_alternate_registry_path = false;
 #endif
@@ -1697,6 +1700,11 @@ bool SetCmdlineParams()
 	if (set_cpu_affinity.found())
 	{
 		Cmdline_set_cpu_affinity = true;
+	}
+
+	if (nograb_arg.found())
+	{
+		Cmdline_nograb = true;
 	}
 
 	if (portable_mode.found())

--- a/code/cmdline/cmdline.h
+++ b/code/cmdline/cmdline.h
@@ -136,6 +136,7 @@ extern char* Cmdline_keyboard_layout;
 extern bool Cmdline_gl_finish;
 extern bool Cmdline_no_geo_sdr_effects;
 extern bool Cmdline_set_cpu_affinity;
+extern bool Cmdline_nograb;
 #ifdef WIN32
 extern bool Cmdline_alternate_registry_path;
 #endif

--- a/code/io/cursor.cpp
+++ b/code/io/cursor.cpp
@@ -53,24 +53,33 @@ namespace
 
 		return cursorHandle;
 	}
+
+	void setRelativeMouseMode(bool grab) {
+		if (Cmdline_nograb) {
+			// Never grab the mouse if this is enabled
+			SDL_SetRelativeMouseMode(SDL_FALSE);
+		} else {
+			SDL_SetRelativeMouseMode(grab ? SDL_TRUE : SDL_FALSE);
+		}
+	}
 	
 	void changeMouseStatus(bool show, bool grab)
 	{
 		if (show)
 		{
 			// If shown don't grab the mouse
-			SDL_SetRelativeMouseMode(SDL_FALSE);
+			setRelativeMouseMode(false);
 			SDL_ShowCursor(1);
 		}
 		else
 		{
 			if (grab)
 			{
-				SDL_SetRelativeMouseMode(SDL_TRUE);
+				setRelativeMouseMode(true);
 			}
 			else
 			{
-				SDL_SetRelativeMouseMode(SDL_FALSE);
+				setRelativeMouseMode(false);
 			}
 
 			SDL_ShowCursor(0);


### PR DESCRIPTION
This disables all mouse grabbing which is useful for debugging when SDL gets interrupted without giving up control of the mouse. That usually leads to problems since you can't interact with the debugger window anymore.