### PR TITLE
Fix deferred lighting shader compilation

### DIFF
--- a/code/def_files/deferred-f.sdr
+++ b/code/def_files/deferred-f.sdr
@@ -30,7 +30,7 @@ vec3 FresnelSchlick(vec3 specColor, vec3 light, vec3 halfVec)
 }
 vec3 SpecularBlinnPhong(vec3 specColor, vec3 light, vec3 normal, vec3 halfVec, float specPower, float dotNL)
 {
-	return FresnelSchlick(max(specColor, vec3(0.04)), light, halfVec) * ((specPower + 2) / 8 ) * pow(clamp(dot(normal, halfVec), 0.0, 1.0), specPower) * dotNL;
+	return FresnelSchlick(max(specColor, vec3(0.04)), light, halfVec) * ((specPower + 2.0) / 8.0 ) * pow(clamp(dot(normal, halfVec), 0.0, 1.0), specPower) * dotNL;
 }
 vec4 SpecularLegacy(vec4 specColor, vec3 normal, vec3 halfVec, float specPower)
 {


### PR DESCRIPTION
Fix the error below by using float constants instead of integers.

```
Compiling new shader:
        Deferred Lighting
   Loading built-in default shader for: deferred-v.sdr
   Loading built-in default shader for: deferred-f.sdr
Fragment shader failed to compile:
0:33(72): error: could not implicitly convert operands to arithmetic operator
0:33(71): error: operands to arithmetic operators must be numeric
0:33(9): error: operands to arithmetic operators must be numeric
0:33(9): error: operands to arithmetic operators must be numeric
0:33(9): error: operands to arithmetic operators must be numeric
0:33(2): error: `return' with wrong type error, in function `SpecularBlinnPhong' returning vec3

ERROR! Unable to create fragment shader!
Failed to compile deferred lighting shader!
```