### PR TITLE
Enable cotire by default for Visual Studio

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,7 +108,13 @@ SET(FSO_RUN_ARGUMENTS "" CACHE STRING "Additional arguments passed to a generate
 
 option(FSO_INSTALL_DEBUG_FILES "Install some debug files (currently only PDB files on windows)" OFF)
 
-OPTION(COTIRE_ENABLE "Enable cotire, this speeds up builds but may cause issues while developing (default = OFF)" OFF)
+set(DEFAULT_VAL OFF)
+if(MSVC)
+	# MSVC has been tested
+	set(DEFAULT_VAL ON)
+endif()
+
+OPTION(COTIRE_ENABLE "Enable cotire, this speeds up builds but may cause issues while developing (default = OFF)" ${DEFAULT_VAL})
 
 MARK_AS_ADVANCED(FORCE FSO_CMAKE_DEBUG)
 MARK_AS_ADVANCED(FORCE FSO_BUILD_INCLUDED_LIBS)

--- a/cmake/toolchain-msvc.cmake
+++ b/cmake/toolchain-msvc.cmake
@@ -12,25 +12,25 @@ MARK_AS_ADVANCED(FORCE MSVC_USE_RUNTIME_DLL)
 
 # These are the warnings we disable
 set(WARNING_FLAGS
-	/wd"4100" # unreferenced formal parameters
-	/wd"4127" # constant conditional (assert)
-	/wd"4201" # nonstandard extension used: nameless struct/union (happens a lot in Windows include headers)
-	/wd"4290" # C++ exception specification ignored except to indicate a function is not __declspec(nothrow)
-	/wd"4390" # empty control statement (triggered by nprintf and mprintf's inside of one-line if's, etc)
-	/wd"4410" # illegal size for operand... ie... 	fxch st(1)
-	/wd"4511" # copy constructor could not be generated (happens a lot in Windows include headers)
-	/wd"4512" # assignment operator could not be generated (happens a lot in Windows include headers)
-	/wd"4514" # unreferenced inline function removed
-	/wd"4611" # _setjmp warning.  Since we use setjmp alot, and we don't really use constructors or destructors, this warning doesn't really apply to us.
-	/wd"4663" # C++ language change (template specification)
-	/wd"4710" # is inline function not expanded (who cares?)
-	/wd"4711" # tells us an inline function was expanded (who cares?)
-	/wd"4786" # is identifier truncated to 255 characters (happens all the time in Microsoft #includes) -- Goober5000"
-	/wd"4996" # deprecated strcpy, strcat, sprintf, etc. (from MSVC 2005) - taylor
-	/wd"4311" # Disables warnings about casting pointer types to ints. The funny thing is these warnings can't be resolved, just disabled... - m!m
-	/wd"4302" # Same as above - m!m
-	/wd"4366" # The result of the unary '&' operator may be unaligned - m!m
-	$<$<CONFIG:Release>:/wd"4101"> # In release mode there are unreferenced variables because debug needs them
+	/wd4100 # unreferenced formal parameters
+	/wd4127 # constant conditional (assert)
+	/wd4201 # nonstandard extension used: nameless struct/union (happens a lot in Windows include headers)
+	/wd4290 # C++ exception specification ignored except to indicate a function is not __declspec(nothrow)
+	/wd4390 # empty control statement (triggered by nprintf and mprintf's inside of one-line if's, etc)
+	/wd4410 # illegal size for operand... ie... 	fxch st(1)
+	/wd4511 # copy constructor could not be generated (happens a lot in Windows include headers)
+	/wd4512 # assignment operator could not be generated (happens a lot in Windows include headers)
+	/wd4514 # unreferenced inline function removed
+	/wd4611 # _setjmp warning.  Since we use setjmp alot, and we don't really use constructors or destructors, this warning doesn't really apply to us.
+	/wd4663 # C++ language change (template specification)
+	/wd4710 # is inline function not expanded (who cares?)
+	/wd4711 # tells us an inline function was expanded (who cares?)
+	/wd4786 # is identifier truncated to 255 characters (happens all the time in Microsoft #includes) -- Goober5000"
+	/wd4996 # deprecated strcpy, strcat, sprintf, etc. (from MSVC 2005) - taylor
+	/wd4311 # Disables warnings about casting pointer types to ints. The funny thing is these warnings can't be resolved, just disabled... - m!m
+	/wd4302 # Same as above - m!m
+	/wd4366 # The result of the unary '&' operator may be unaligned - m!m
+	$<$<CONFIG:Release>:/wd4101> # In release mode there are unreferenced variables because debug needs them
 )
 
 target_compile_options(compiler INTERFACE ${WARNING_FLAGS})

--- a/cmake/util.cmake
+++ b/cmake/util.cmake
@@ -128,12 +128,7 @@ macro(configure_cotire target)
 		# add ignored paths for the precompiled header here
 		set_target_properties(code PROPERTIES COTIRE_PREFIX_HEADER_IGNORE_PATH
 			"${CMAKE_SOURCE_DIR};${CMAKE_BINARY_DIR}")
-
-		IF(DEFINED CMAKE_CONFIGURATION_TYPES)
-			cotire(${target} CONFIGURATIONS ${CMAKE_CONFIGURATION_TYPES})
-		ELSE(DEFINED CMAKE_CONFIGURATION_TYPES)
-			cotire(${target})
-		ENDIF(DEFINED CMAKE_CONFIGURATION_TYPES)
+		cotire(${target})
 	ENDIF(COTIRE_ENABLE)
 endmacro(configure_cotire)
 


### PR DESCRIPTION
This speeds up MSVC builds a bit (up to 1 minute when building a full release configuration). Other platforms have issues with precompiled headers so it's disabled by default for them.