### PR TITLE
Fix issue with head tracking and freelook interaction

### DIFF
--- a/code/headtracking/freetrack.cpp
+++ b/code/headtracking/freetrack.cpp
@@ -128,6 +128,25 @@ namespace headtracking
 				throw internal::HeadTrackingException("Library could not be loaded!");
 			}
 
+			// Try to get initial test data
+			FreeTrackData data;
+			data.dataID = std::numeric_limits<unsigned int>::max();
+			data.camHeight = std::numeric_limits<int>::min();
+			data.camWidth = std::numeric_limits<int>::min();
+
+			if (!library.GetData(&data))
+			{
+				throw internal::HeadTrackingException("Failed to get test data set!");
+			}
+
+			if (data.dataID == std::numeric_limits<unsigned int>::max() ||
+				data.camHeight == std::numeric_limits<int>::min() ||
+				data.camWidth == std::numeric_limits<int>::min())
+			{
+				// Check if all the values have been changed
+				throw internal::HeadTrackingException("The test values reported by FreeTrack were invalid!");
+			}
+
 			// I have no idea what a correct value for this function is so I used this random value
 			library.ReportID(7919);
 

--- a/code/playerman/playercontrol.cpp
+++ b/code/playerman/playercontrol.cpp
@@ -392,6 +392,7 @@ void do_view_slew(float frame_time)
 	if (!(Viewer_mode & VM_PADLOCK_ANY)) {
 		if (headtracking::isEnabled()) {
 			// Can't do slewing if TrackIR is enabled
+			Viewer_mode |= VM_CAMERA_LOCKED;
 			return;
 		}
 		


### PR DESCRIPTION
Also adds code for detecting if the FreeTrack client is actually
reporting valid values. I only tested it with FaceTrackNoIR so it may
not work for other head trackers.