### PR TITLE
Mark ship destroyed before a mission as exited

### DIFF
--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -3465,6 +3465,10 @@ void mission_parse_maybe_create_parse_object(p_object *pobjp)
 				shipfx_blow_up_model(objp, Ship_info[Ships[objp->instance].ship_info_index].model_num, 0, 0, &objp->pos);
 				objp->flags.set(Object::Object_Flags::Should_be_dead);
 
+				// Make sure that the ship is marked as destroyed so the AI doesn't freak out later
+				auto sip = &Ships[objp->instance];
+				ship_add_exited_ship(sip, Ship::Exit_Flags::Destroyed);
+
 				// once the ship is exploded, find the debris pieces belonging to this object, mark them
 				// as not to expire, and move them forward in time N seconds
 				for (i = 0; i < MAX_DEBRIS_PIECES; i++)


### PR DESCRIPTION
This fixes an Int3 in the ai code where it couldn't find a ship that was
destroyed before a mission. This was found through a mission bug in
FreeSpace Blue "Slaying Ravana" where the "Somtus" is marked as
destroyed before mission but then the AI is given orders which target
that ship.