### PR TITLE
Fix for parsing the no pierce flag

### DIFF
--- a/code/parse/parselo.h
+++ b/code/parse/parselo.h
@@ -160,7 +160,8 @@ int parse_string_flag_list(Flagset& dest, flag_def_list_new<T> defs [], size_t n
         for (size_t j = 0; j < n_defs; j++)
         {
             if (!stricmp(slp[i], defs[j].name)) {
-				if (defs[j].in_use && defs[j].def != T::NUM_VALUES) {
+				if (defs[j].in_use) {
+					Assertion(defs[j].def != T::NUM_VALUES, "Error in definition for flag_def_list, flag '%s' has been given an invalid value but is still marked as in use.\n", defs[j].name);
 					dest.set(defs[j].def);
 				}
 

--- a/code/parse/parselo.h
+++ b/code/parse/parselo.h
@@ -160,8 +160,7 @@ int parse_string_flag_list(Flagset& dest, flag_def_list_new<T> defs [], size_t n
         for (size_t j = 0; j < n_defs; j++)
         {
             if (!stricmp(slp[i], defs[j].name)) {
-				if (defs[j].in_use) {
-					Assertion(defs[j].def != T::NUM_VALUES, "Error in definition for flag_def_list, flag '%s' has been given an invalid value but is still marked as in use.\n", defs[j].name);
+				if (defs[j].in_use && defs[j].def != T::NUM_VALUES) {
 					dest.set(defs[j].def);
 				}
 

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -131,7 +131,6 @@ flag_def_list_new<Weapon::Info_Flags> Weapon_Info_Flags[] = {
     { "countermeasure",					Weapon::Info_Flags::Cmeasure,							true, false },
     { "ballistic",						Weapon::Info_Flags::Ballistic,							true, false },
     { "pierce shields",					Weapon::Info_Flags::Pierce_shields,						true, false },
-    { "no pierce shields",				Weapon::Info_Flags::NUM_VALUES,							true, true }, //special case
     { "local ssm",						Weapon::Info_Flags::Local_ssm,							true, false },
     { "tagged only",					Weapon::Info_Flags::Tagged_only,						true, false },
     { "beam no whack",					Weapon::Info_Flags::NUM_VALUES,							false, true }, //special case


### PR DESCRIPTION
Putting an assertion in here was the wrong thing to do, as "no pierce shields" is very definitely "in use".