### PR TITLE
Small imporvements to debug messages

### DIFF
--- a/code/model/modelinterp.cpp
+++ b/code/model/modelinterp.cpp
@@ -2356,7 +2356,7 @@ void interp_configure_vertex_buffers(polymodel *pm, int mn)
 
 	int time_elapsed = timer_get_milliseconds() - milliseconds;
 
-	mprintf(("BSP Parse took %d milliseconds.", time_elapsed));
+	nprintf(("Model", "BSP Parse took %d milliseconds.\n", time_elapsed));
 
 	if (total_verts < 1) {
 		return;

--- a/code/pilotfile/plr.cpp
+++ b/code/pilotfile/plr.cpp
@@ -139,6 +139,8 @@ void pilotfile::plr_read_hud()
 
 	HUD_config.rp_flags = cfread_int(cfp);
 	HUD_config.rp_dist = cfread_int(cfp);
+	if (HUD_config.rp_dist < 0 || HUD_config.rp_dist >= RR_MAX_RANGES)
+		Error(LOCATION, "Player file has invalid radar range %d\n", HUD_config.rp_dist);
 
 	// basic colors
 	HUD_config.main_color = cfread_int(cfp);
@@ -846,6 +848,11 @@ bool pilotfile::load_player(const char *callsign, player *_p)
 
 		size_t start_pos = cftell(cfp);
 
+		if (section_size == 0) {
+			mprintf(("PLR => 0 size section with id %d starting at %zu\n", section_id, start_pos));
+			return false;
+		}
+
 		// safety, to help protect against long reads
 		cf_set_max_read_len(cfp, section_size);
 
@@ -1068,6 +1075,11 @@ bool pilotfile::verify(const char *fname, int *rank, char *valid_language)
 		uint section_size = cfread_uint(cfp);
 
 		size_t start_pos = cftell(cfp);
+
+		if (section_size == 0) {
+			mprintf(("PLR => 0 size section with id %d starting at %zu\n", section_id, start_pos));
+			return false;
+		}
 
 		// safety, to help protect against long reads
 		cf_set_max_read_len(cfp, section_size);

--- a/code/radar/radarsetup.cpp
+++ b/code/radar/radarsetup.cpp
@@ -484,7 +484,7 @@ void HudGaugeRadar::drawRange()
 		break;
 
 	default:
-		Int3();	// can't happen (get Alan if it does)
+		Error(LOCATION, "Unknown radar range: %d!\n", HUD_config.rp_dist);
 		break;
 	}
 }


### PR DESCRIPTION
Add missing new line to BSP Parse timing.

Log value of HUD_config.rp_dist when it is not valid.
I'm hitting this one with rp_dist=-1, I'll try to debug it later.