### PR TITLE
Fixed jumpnode colors following OGL Core changes

### DIFF
--- a/code/model/modelrender.cpp
+++ b/code/model/modelrender.cpp
@@ -739,7 +739,7 @@ void draw_list::render_outline(outline_draw &outline_info)
 	material_instance.set_blend_mode(ALPHA_BLEND_ALPHA_BLEND_ALPHA);
 	material_instance.set_color(outline_info.clr);
 
-	g3_render_primitives_colored(&material_instance, outline_info.vert_array, outline_info.n_verts, PRIM_TYPE_LINES, false);
+	g3_render_primitives(&material_instance, outline_info.vert_array, outline_info.n_verts, PRIM_TYPE_LINES, false);
 
 	g3_done_instance(true);
 }

--- a/code/render/3d.h
+++ b/code/render/3d.h
@@ -241,6 +241,7 @@ void g3_draw_htl_line(const vec3d *start, const vec3d *end);
 void g3_draw_htl_sphere(color *clr, const vec3d *position, float radius);
 void g3_draw_htl_sphere(const vec3d* position, float radius);
 
+void g3_render_primitives(material* mat, vertex* verts, int n_verts, primitive_type prim_type, bool orthographic = false);
 void g3_render_primitives_textured(material* mat, vertex* verts, int n_verts, primitive_type prim_type, bool orthographic = false);
 void g3_render_primitives_colored(material* mat, vertex* verts, int n_verts, primitive_type prim_type, bool orthographic = false);
 void g3_render_primitives_colored_textured(material* mat, vertex* verts, int n_verts, primitive_type prim_type, bool orthographic = false);

--- a/code/render/3ddraw.cpp
+++ b/code/render/3ddraw.cpp
@@ -371,6 +371,23 @@ void g3_draw_htl_sphere(const vec3d* position, float radius)
 	g3_draw_htl_sphere(&gr_screen.current_color, position, radius);
 }
 
+void g3_render_primitives(material* mat, vertex* verts, int n_verts, primitive_type prim_type, bool orthographic)
+{
+	vertex_layout layout;
+
+	if ( orthographic ) {
+		layout.add_vertex_component(vertex_format_data::POSITION2, sizeof(vertex), (int)offsetof(vertex, screen));
+	} else {
+		layout.add_vertex_component(vertex_format_data::POSITION3, sizeof(vertex), (int)offsetof(vertex, world));
+	}
+
+	if ( orthographic ) {
+		gr_render_primitives_2d_immediate(mat, prim_type, &layout, n_verts, verts, n_verts * sizeof(vertex));
+	} else {
+		gr_render_primitives_immediate(mat, prim_type, &layout, n_verts, verts, n_verts * sizeof(vertex));
+	}
+}
+
 void g3_render_primitives_textured(material* mat, vertex* verts, int n_verts, primitive_type prim_type, bool orthographic)
 {
 	vertex_layout layout;


### PR DESCRIPTION
Nipping this in the bud before someone submits an issue report. I'm sure some people noticed jumpnodes were rendering in red. This gets them back to normal.