### PR TITLE
Create data path for log file

### DIFF
--- a/code/osapi/outwnd.cpp
+++ b/code/osapi/outwnd.cpp
@@ -23,6 +23,7 @@
 #include "cfile/cfilesystem.h"
 #include "globalincs/globals.h"
 #include "parse/parselo.h"
+#include "windows_stub/config.h"
 
 struct outwnd_filter_struct {
 	char name[NAME_LENGTH];
@@ -240,6 +241,9 @@ void outwnd_init()
 		} else {
 			FreeSpace_logfilename = "fs2_open.log";
 		}
+
+		// create data file path if it does not exist
+		_mkdir(os_get_config_path(Pathtypes[CF_TYPE_DATA].path).c_str());
 
 		memset( pathname, 0, sizeof(pathname) );
 		snprintf( pathname, MAX_PATH_LEN, "%s/%s", Pathtypes[CF_TYPE_DATA].path, FreeSpace_logfilename);

--- a/code/windows_stub/config.h
+++ b/code/windows_stub/config.h
@@ -26,6 +26,8 @@
 
 #if defined _WIN32
 
+#include <direct.h> // for _mkdir, ...
+
 #ifndef snprintf
 #define snprintf _snprintf
 #endif


### PR DESCRIPTION
Opening the log file failed when the data path did not exists, e.g.
during the user's first run. Create it before trying to open the log
file.

Also, include `<direct.h>` in windows_stubs/config.h since the equivalent
stubs for Unix are also declared there.