### PR TITLE
Add support for outputting profiling data as JSON

### DIFF
--- a/code/cmdline/cmdline.cpp
+++ b/code/cmdline/cmdline.cpp
@@ -238,6 +238,7 @@ Flag exe_params[] =
 	{ "-benchmark_mode",	"Puts the game into benchmark mode",		true,	0,					EASY_DEFAULT,		"Dev Tool",		"http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-benchmark_mode", },
 	{ "-noninteractive",	"Disables interactive dialogs",				true,	0,					EASY_DEFAULT,		"Dev Tool",		"http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-noninteractive", },
 	{ "-json_pilot",		"Dump pilot files in JSON format",			true,	0,					EASY_DEFAULT,		"Dev Tool",		"http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-json_pilot", },
+	{ "-json_profiling",	"Generate JSON profiling output",			true,	0,					EASY_DEFAULT,		"Dev Tool",		"http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-json_profiling", },
 };
 
 // forward declaration
@@ -483,6 +484,7 @@ cmdline_parm no_unfocused_pause_arg("-no_unfocused_pause", NULL, AT_NONE); //Cmd
 cmdline_parm benchmark_mode_arg("-benchmark_mode", NULL, AT_NONE); //Cmdline_benchmark_mode
 cmdline_parm noninteractive_arg("-noninteractive", NULL, AT_NONE); //Cmdline_noninteractive
 cmdline_parm json_pilot("-json_pilot", NULL, AT_NONE); //Cmdline_json_pilot
+cmdline_parm json_profiling("-json_profiling", NULL, AT_NONE); //Cmdline_json_profiling
 
 
 char *Cmdline_start_mission = NULL;
@@ -510,6 +512,7 @@ bool Cmdline_no_unfocus_pause = false;
 bool Cmdline_benchmark_mode = false;
 bool Cmdline_noninteractive = false;
 bool Cmdline_json_pilot = false;
+bool Cmdline_json_profiling = false;
 
 // Other
 cmdline_parm get_flags_arg("-get_flags", "Output the launcher flags file", AT_NONE);
@@ -1851,6 +1854,11 @@ bool SetCmdlineParams()
 	if (json_pilot.found())
 	{
 		Cmdline_json_pilot = true;
+	}
+
+	if (json_profiling.found())
+	{
+		Cmdline_json_profiling = true;
 	}
 
 	//Deprecated flags - CommanderDJ

--- a/code/cmdline/cmdline.h
+++ b/code/cmdline/cmdline.h
@@ -159,5 +159,6 @@ extern bool Cmdline_no_unfocus_pause;
 extern bool Cmdline_benchmark_mode;
 extern bool Cmdline_noninteractive;
 extern bool Cmdline_json_pilot;
+extern bool Cmdline_json_profiling;
 
 #endif

--- a/code/globalincs/systemvars.h
+++ b/code/globalincs/systemvars.h
@@ -244,6 +244,7 @@ void profile_begin(const char* name);
 void profile_begin(SCP_string &output_handle, const char* name);
 void profile_end(const char* name);
 void profile_dump_output();
+void profile_dump_json_output();
 void store_profile_in_history(SCP_string &name, float percent, uint64_t time);
 void get_profile_from_history(SCP_string &name, float* avg, float* min, float* max, uint64_t *avg_micro_sec, uint64_t *min_micro_sec, uint64_t *max_micro_sec);
 

--- a/code/model/modelrender.cpp
+++ b/code/model/modelrender.cpp
@@ -639,7 +639,7 @@ void draw_list::render_all(gr_zbuffer_type depth_mode)
 		int render_index = Render_keys[i];
 
 		if ( depth_mode == ZBUFFER_TYPE_DEFAULT || Render_elements[render_index].render_material.get_depth_mode() == depth_mode ) {
-			render_buffer(Render_elements[render_index]);
+			PROFILE("Render buffer", render_buffer(Render_elements[render_index]));
 		}
 	}
 

--- a/code/object/objcollide.cpp
+++ b/code/object/objcollide.cpp
@@ -1227,20 +1227,22 @@ void obj_sort_and_collide()
 	SCP_vector<int> sort_list_z;
 
 	sort_list_y.clear();
-	obj_quicksort_colliders(&Collision_sort_list, 0, (int)(Collision_sort_list.size() - 1), 0);
+	PROFILE("Sort Colliders", obj_quicksort_colliders(&Collision_sort_list, 0, (int)(Collision_sort_list.size() - 1), 0));
 	obj_find_overlap_colliders(&sort_list_y, &Collision_sort_list, 0, false);
 
 	sort_list_z.clear();
-	obj_quicksort_colliders(&sort_list_y, 0, (int)(sort_list_y.size() - 1), 1);
+	PROFILE("Sort Colliders", obj_quicksort_colliders(&sort_list_y, 0, (int)(sort_list_y.size() - 1), 1));
 	obj_find_overlap_colliders(&sort_list_z, &sort_list_y, 1, false);
 
 	sort_list_y.clear();
-	obj_quicksort_colliders(&sort_list_z, 0, (int)(sort_list_z.size() - 1), 2);
+	PROFILE("Sort Colliders", obj_quicksort_colliders(&sort_list_z, 0, (int)(sort_list_z.size() - 1), 2));
 	obj_find_overlap_colliders(&sort_list_y, &sort_list_z, 2, true);
 }
 
 void obj_find_overlap_colliders(SCP_vector<int> *overlap_list_out, SCP_vector<int> *list, int axis, bool collide)
 {
+	profile_auto profile_scope("Find overlap colliders");
+
 	size_t i, j;
 	bool overlapped;
 	bool first_not_added = true;
@@ -1377,6 +1379,8 @@ void obj_quicksort_colliders(SCP_vector<int> *list, int left, int right, int axi
 
 void obj_collide_pair(object *A, object *B)
 {
+	profile_auto profile_scope("Collide Pair");
+
 	uint ctype;
 	int (*check_collision)( obj_pair *pair );
 	int swapped = 0;	

--- a/code/object/object.cpp
+++ b/code/object/object.cpp
@@ -1179,6 +1179,8 @@ void obj_move_all_post(object *objp, float frametime)
 	{
 		case OBJ_WEAPON:
 		{
+			profile_auto profile_scope("Weapon post move");
+
 			if ( !physics_paused )
 				weapon_process_post( objp, frametime );
 
@@ -1224,6 +1226,8 @@ void obj_move_all_post(object *objp, float frametime)
 
 		case OBJ_SHIP:
 		{
+			profile_auto profile_scope("Ship post move");
+
 			if ( !physics_paused || (objp==Player_obj) ) {
 				ship_process_post( objp, frametime );
 				ship_model_update_instance(objp);
@@ -1269,6 +1273,8 @@ void obj_move_all_post(object *objp, float frametime)
 
 		case OBJ_FIREBALL:
 		{
+			profile_auto profile_scope("Fireball post move");
+
 			if ( !physics_paused )
 				fireball_process_post(objp,frametime);
 
@@ -1312,6 +1318,8 @@ void obj_move_all_post(object *objp, float frametime)
 
 		case OBJ_DEBRIS:
 		{
+			profile_auto profile_scope("Debris post move");
+
 			if ( !physics_paused )
 				debris_process_post(objp, frametime);
 
@@ -1346,6 +1354,8 @@ void obj_move_all_post(object *objp, float frametime)
 
 		case OBJ_ASTEROID:
 		{
+			profile_auto profile_scope("Asteroid post move");
+
 			if ( !physics_paused )
 				asteroid_process_post(objp);
 

--- a/code/render/batching.cpp
+++ b/code/render/batching.cpp
@@ -9,6 +9,7 @@
 
 #include "render/batching.h"
 #include "globalincs/pstypes.h"
+#include "globalincs/systemvars.h"
 #include "graphics/2d.h"
 #include "render/3d.h"
 #include "graphics/material.h"
@@ -856,6 +857,8 @@ void batching_add_tri(int texture, vertex *verts)
 
 void batching_render_batch_item(primitive_batch_item *item, vertex_layout *layout, primitive_type prim_type, int buffer_num)
 {
+	profile_auto profile_scope("Render batch item");
+
 	if ( item->batch_item_info.mat_type == batch_info::VOLUME_EMISSIVE ) { // Cmdline_softparticles
 		particle_material material_def;
 
@@ -909,6 +912,8 @@ void batching_allocate_and_load_buffer(primitive_batch_buffer *draw_queue)
 
 void batching_load_buffers(bool distortion)
 {
+	profile_auto profile_scope("Load batching buffers");
+
 	SCP_map<batch_info, primitive_batch>::iterator bi;
 	SCP_map<batch_buffer_key, primitive_batch_buffer>::iterator buffer_iter;
 
@@ -955,6 +960,8 @@ void batching_load_buffers(bool distortion)
 
 void batching_render_buffer(primitive_batch_buffer *buffer)
 {
+	profile_auto profile_scope("Render batching buffer");
+
 	size_t num_batches = buffer->items.size();
 
 	for ( int j = 0; j < batch_info::NUM_RENDER_TYPES; ++j ) {

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -4520,6 +4520,7 @@ void game_frame(bool paused)
 
 	profile_end("Main Frame");
 	profile_dump_output();
+	profile_dump_json_output();
 
 	DEBUG_GET_TIME( total_time2 )
 


### PR DESCRIPTION
This output is compatible with the Chromium tracing viewer which
provides a very nice visual overview of what FSO does in a frame.

Here is an example of how it looks like: ![chrometracing](https://cloud.githubusercontent.com/assets/1013983/18053370/536d2b0a-6dff-11e6-996c-7560baad73e6.png)

The files are written to a directory called "tracing" where each frame is written into a separate file. Here is an example file that you can use directly in the trace viewer: [frame_354.txt](https://github.com/scp-fs2open/fs2open.github.com/files/442507/frame_354.txt) (You have to change the extension to json).

You can also view these files without Chromium since the [Trace-viewer](https://github.com/catapult-project/catapult/blob/master/tracing/README.md) can also be used as a standalone script.