### PR TITLE
Fix crash/Error in techmenu with 0 intel entries.

### DIFF
--- a/code/menuui/techmenu.cpp
+++ b/code/menuui/techmenu.cpp
@@ -713,6 +713,10 @@ void techroom_anim_render(float frametime)
 	// render common stuff
 	tech_common_render();
 
+	// exit now if there are no entries to show
+	if (Current_list_size == 0 || Cur_entry < 0)
+		return;
+
 	// render the animation
 	if(Current_list[Cur_entry].animation.num_frames > 0)
 	{


### PR DESCRIPTION
`tech_render_anim` did not check whether there were any intel/weapon
entries before trying to read from`Current_list`, which means that it
read at `Current_list[-1]`, which is a Bad Thing (TM).

Do not try to render an anim if there is no entry.