### PR TITLE
Fix OpenGL context creation for FRED

### DIFF
--- a/fred2/fredview.cpp
+++ b/fred2/fredview.cpp
@@ -324,11 +324,6 @@ public:
 
 	std::unique_ptr<os::OpenGLContext> createOpenGLContext(os::Viewport* port, const os::OpenGLContextAttributes& ctx) override
 	{
-		if (ctx.profile != os::OpenGLProfile::Compatibility) {
-			mprintf(("ERROR: FRED code can only create compatibility profiles!\n"));
-			return nullptr;
-		}
-
 		auto mfcView = reinterpret_cast<MFCViewport*>(port);
 
 		auto render_context = wglCreateContext(mfcView->getHDC());


### PR DESCRIPTION
This is not technically correct since the FRED code is not able to
create an OpenGL Core context but since FRED is Windows only it's not a
problem because those drivers usually support the Core profile features
in the Compatibility profile.