### PR TITLE
Fix FRED crash when rendering waypoints

### DIFF
--- a/code/graphics/2d.h
+++ b/code/graphics/2d.h
@@ -820,8 +820,6 @@ typedef struct screen {
 	
 	void (*gf_set_line_width)(float width);
 
-	void (*gf_line_htl)(const vec3d *start, const vec3d *end);
-	void (*gf_sphere_htl)(float rad);
 	void (*gf_sphere)(material *material_def, float rad);
 
 	int (*gf_maybe_create_shader)(shader_type type, unsigned int flags);
@@ -1129,8 +1127,6 @@ __inline int gr_create_index_buffer(bool static_buffer = false)
 
 #define gr_set_line_width				GR_CALL(*gr_screen.gf_set_line_width)
 
-#define gr_line_htl						GR_CALL(*gr_screen.gf_line_htl)
-#define gr_sphere_htl					GR_CALL(*gr_screen.gf_sphere_htl)
 #define gr_sphere						GR_CALL(*gr_screen.gf_sphere)
 
 #define gr_maybe_create_shader			GR_CALL(*gr_screen.gf_maybe_create_shader)

--- a/code/graphics/grstub.cpp
+++ b/code/graphics/grstub.cpp
@@ -390,14 +390,6 @@ void gr_stub_set_line_width(float width)
 {
 }
 
-void gr_stub_draw_htl_line(const vec3d *start, const vec3d *end)
-{
-}
-
-void gr_stub_draw_htl_sphere(float rad)
-{
-}
-
 void gr_stub_draw_sphere(material *material_def, float rad)
 {
 }
@@ -657,8 +649,6 @@ bool gr_stub_init()
 	
 	gr_screen.gf_set_line_width		= gr_stub_set_line_width;
 
-	gr_screen.gf_line_htl			= gr_stub_draw_htl_line;
-	gr_screen.gf_sphere_htl			= gr_stub_draw_htl_sphere;
 	gr_screen.gf_sphere				= gr_stub_draw_sphere;
 
 	gr_screen.gf_shadow_map_start	= gr_stub_shadow_map_start;

--- a/code/graphics/opengl/gropengl.cpp
+++ b/code/graphics/opengl/gropengl.cpp
@@ -1249,7 +1249,6 @@ void opengl_setup_function_pointers()
 	
 	gr_screen.gf_set_line_width		= gr_opengl_set_line_width;
 
-	gr_screen.gf_line_htl			= gr_opengl_line_htl;
 	gr_screen.gf_sphere				= gr_opengl_sphere;
 	
 	gr_screen.gf_maybe_create_shader = gr_opengl_maybe_create_shader;

--- a/code/graphics/opengl/gropengldraw.cpp
+++ b/code/graphics/opengl/gropengldraw.cpp
@@ -847,38 +847,6 @@ void gr_opengl_line(int x1, int y1, int x2, int y2, int resize_mode)
     gr_opengl_line(i2fl(x1), i2fl(y1), i2fl(x2), i2fl(y2), resize_mode);
 }
 
-void gr_opengl_line_htl(const vec3d *start, const vec3d *end)
-{
-	gr_zbuffer_type zbuffer_state = (gr_zbuffering) ? ZBUFFER_TYPE_FULL : ZBUFFER_TYPE_NONE;
-	GL_state.SetZbufferType(zbuffer_state);
-
-
-    if (gr_screen.current_color.is_alphacolor) {
-        GL_state.SetAlphaBlendMode(ALPHA_BLEND_ALPHA_BLEND_ALPHA);
-	} else {
-        GL_state.SetAlphaBlendMode(ALPHA_BLEND_NONE);
-    }
-
-	GLfloat line[6] = {
-		start->xyz.x,	start->xyz.y,	start->xyz.z,
-		end->xyz.x,		end->xyz.y,		end->xyz.z
-	};
-
-	GL_state.Array.BindArrayBuffer(0);
-	opengl_shader_set_current();
-
-	vertex_layout vert_def;
-
-	vert_def.add_vertex_component(vertex_format_data::POSITION3, 0, line);
-
-	opengl_bind_vertex_layout(vert_def);
-	opengl_shader_set_passthrough(false);
-
-	glDrawArrays(GL_LINES, 0, 2);
-
-	GL_CHECK_FOR_ERRORS("end of opengl_line_htl()");
-}
-
 void gr_opengl_aaline(vertex *v1, vertex *v2)
 {
 	float x1 = v1->screen.xyw.x;

--- a/code/graphics/opengl/gropengldraw.h
+++ b/code/graphics/opengl/gropengldraw.h
@@ -47,7 +47,6 @@ void opengl_set_spec_mapping(int tmap_type, float *u_scale, float *v_scale, int 
 void opengl_reset_spec_mapping();
 
 void opengl_draw_sphere();
-void gr_opengl_line_htl(const vec3d *start, const vec3d *end);
 void gr_opengl_sphere(material *material_def, float rad);
 void gr_opengl_deferred_light_sphere_init(int rings, int segments);
 void gr_opengl_draw_deferred_light_sphere(const vec3d *position, float rad, bool clearStencil);

--- a/code/render/3ddraw.cpp
+++ b/code/render/3ddraw.cpp
@@ -353,8 +353,6 @@ void g3_draw_htl_sphere(color *clr, const vec3d* position, float radius)
 {
 	g3_start_instance_matrix(position, &vmd_identity_matrix, true);
 
-	gr_sphere_htl(radius);
-
 	material material_def;
 
 	material_def.set_blend_mode(ALPHA_BLEND_NONE);


### PR DESCRIPTION
There seem to be a few graphics functions that aren't used anymore but still exist in the interface definition. This fixes the crash by removing the `gr_sphere_htl` call and also removes those unused functions.