### PR TITLE
Remove old cmdline parms before parsing new ones.

### DIFF
--- a/code/cmdline/cmdline.cpp
+++ b/code/cmdline/cmdline.cpp
@@ -924,11 +924,27 @@ bool has_cmdline_only_flag(int argc, char *argv[])
 	return false;
 }
 
+// remove old parms - needed for tests
+static void reset_cmdline_parms()
+{
+	for (cmdline_parm *parmp = GET_FIRST(&Parm_list); parmp != END_OF_LIST(&Parm_list); parmp = GET_NEXT(parmp)) {
+		if (parmp->args != NULL) {
+			delete[] parmp->args;
+			parmp->args = NULL;
+		}
+		parmp->name_found = 0;
+	}
+}
+
 // Call once to initialize the command line system
 //
 // cmdline - command line string passed to the application
 void os_init_cmdline(int argc, char *argv[])
 {
+	// Tests call this multiple times, so reset the params here.
+	// Otherwise e.g. the modlist just grows and grows...
+	reset_cmdline_parms();
+
 	FILE *fp;
 	
 	if (!has_cmdline_only_flag(argc, argv)) {


### PR DESCRIPTION
This was causing my (yet unpublished) tests to fail because the mod list
was just being appended to instead of being reset for each test.

It would be nice if there was a simple way to reset all global state. This is probably not the only state which is leaking between tests. Running each test in a new process would be ideal, but I don't know if that is (a) even possible and (b) fast enough.  A quick browse of the Google Test docs did not reveal any sensible way to do this.