### PR TITLE
Better handling of specular maps when using unlit rendering

### DIFF
--- a/code/def_files/main-f.sdr
+++ b/code/def_files/main-f.sdr
@@ -199,25 +199,21 @@ float getShadowValue()
 	return mix(samplePoissonPCF(cascade), samplePoissonPCF(cascade+1), smoothstep(cascade_start_dist[cascade+1] - dist_threshold, cascade_start_dist[cascade+1], depth));
 }
 #endif
-#ifdef FLAG_LIGHT
-vec3 FresnelSchlick(vec3 specColor, vec3 light, vec3 halfVec)
-{
-	return specColor + (vec3(1.0) - specColor) * pow(1.0 - clamp(dot(light, halfVec), 0.0, 1.0), 5.0);
-}
 vec3 FresnelLazarovEnv(vec3 specColor, vec3 view, vec3 normal, float gloss)
 {
 	// Fresnel for environment lighting 
 	// Equation referenced from Dimitar Lazarov's presentation titled Physically Based Rendering in Call of Duty: Black Ops
 	return specColor + (vec3(1.0) - specColor) * pow(1.0 - clamp(dot(view, normal), 0.0, 1.0), 5.0) / (4.0 - 3.0 * gloss);
 }
+vec3 FresnelSchlick(vec3 specColor, vec3 light, vec3 halfVec)
+{
+	return specColor + (vec3(1.0) - specColor) * pow(1.0 - clamp(dot(light, halfVec), 0.0, 1.0), 5.0);
+}
 vec3 SpecularBlinnPhong(vec3 specColor, vec3 light, vec3 normal, vec3 halfVec, float specPower, float dotNL)
 {
 	return FresnelSchlick(max(specColor, vec3(0.04)), light, halfVec) * ((specPower + 2.0) / 8.0 ) * pow(clamp(dot(normal, halfVec), 0.0, 1.0), specPower) * dotNL;
 }
-vec4 SpecularLegacy(vec4 specColor, vec3 normal, vec3 halfVec, float specPower)
-{
-	return specColor * pow(clamp(dot(normal, halfVec), 0.0, 1.0), specPower);
-}
+#ifdef FLAG_LIGHT
 void GetLightInfo(int i, out vec3 lightDir, out float attenuation, out float specIntensity)
 {
 	lightDir = normalize(lightPosition[i].xyz);
@@ -369,7 +365,6 @@ void main()
 	specColour.rgb = max(specColour.rgb, vec3(0.04)); // hardcoded minimum specular value. read John Hable's blog post titled 'Everything Is Shiny'. 
    specData = vec4(specColour.rgb, glossData);
 #endif
-
 #ifdef FLAG_MISC_MAP
  #ifdef FLAG_TEAMCOLOR
 	vec4 teamMask = vec4(0.0, 0.0, 0.0, 0.0);
@@ -380,16 +375,17 @@ void main()
 	baseColor.rgb = max(baseColor.rgb, vec3(0.0));
  #endif
 #endif
-
 	float shadow = 1.0;
 #ifdef FLAG_SHADOWS
 	shadow = getShadowValue();
 #endif
-
 #ifdef FLAG_LIGHT
 	baseColor.rgb = CalculateLighting(normal, baseColor.rgb, specData.rgb, glossData, shadow, aoFactors.x);
+#else
+ #ifdef FLAG_SPEC_MAP
+	baseColor.rgb += pow(1.0 - dot(eyeDir, normal), 5.0 * clamp(glossData, 0.01, 1.0)) * specColour.rgb;
+ #endif
 #endif
-
 #ifdef FLAG_ENV_MAP
    vec3 envReflectNM = fragEnvReflect;
  #ifdef FLAG_NORMAL_MAP
@@ -404,7 +400,6 @@ void main()
 	envColour.rgb *= (envGloss) ? 1.0 : specColour.a;
 	baseColor.rgb += envColour.rgb * FresnelLazarovEnv(specColour.rgb, eyeDir, normal, glossData);
 #endif
-
 #ifdef FLAG_GLOW_MAP
 	vec3 glowColor = texture2D(sGlowmap, texCoord).rgb;
 	if(overrideGlow) glowColor = glowClr;

--- a/code/graphics/material.cpp
+++ b/code/graphics/material.cpp
@@ -576,25 +576,25 @@ uint model_material::get_shader_flags()
 		Shader_flags |= SDR_FLAG_MODEL_GLOW_MAP;
 	}
 
+	if ( (get_texture_map(TM_SPECULAR_TYPE) > 0) && !Specmap_override ) {
+		Shader_flags |= SDR_FLAG_MODEL_SPEC_MAP;
+
+		if ( (ENVMAP > 0) && !Envmap_override ) {
+			Shader_flags |= SDR_FLAG_MODEL_ENV_MAP;
+		}
+	}
+
+	if ( (get_texture_map(TM_NORMAL_TYPE) > 0) && !Normalmap_override ) {
+		Shader_flags |= SDR_FLAG_MODEL_NORMAL_MAP;
+	}
+
+	if ( (get_texture_map(TM_HEIGHT_TYPE) > 0) && !Heightmap_override ) {
+		Shader_flags |= SDR_FLAG_MODEL_HEIGHT_MAP;
+	}
+
 	if ( lighting ) {
 		Shader_flags |= SDR_FLAG_MODEL_LIGHT;
-
-		if ( ( get_texture_map(TM_SPECULAR_TYPE) > 0) && !Specmap_override ) {
-			Shader_flags |= SDR_FLAG_MODEL_SPEC_MAP;
-
-			if ( (ENVMAP > 0) && !Envmap_override ) {
-				Shader_flags |= SDR_FLAG_MODEL_ENV_MAP;
-			}
-		}
-
-		if ( (get_texture_map(TM_NORMAL_TYPE) > 0) && !Normalmap_override ) {
-			Shader_flags |= SDR_FLAG_MODEL_NORMAL_MAP;
-		}
-
-		if ( (get_texture_map(TM_HEIGHT_TYPE) > 0) && !Heightmap_override ) {
-			Shader_flags |= SDR_FLAG_MODEL_HEIGHT_MAP;
-		}
-
+		
 		if ( Cmdline_shadow_quality && !Shadow_casting && !Shadow_override ) {
 			Shader_flags |= SDR_FLAG_MODEL_SHADOWS;
 		}


### PR DESCRIPTION
Following my conversation of wanting to keep targetbox lighting enabled by default but encountering some unusually salient pushback, I've decided to go another route to solve our black PBR model in targetbox issue. Unlit models, in addition to their constant diffuse, will have their specular color added with a view-dependant Fresnel factor that varies based off of their gloss. The result is a sort of rim effect that still goes well with the unlit aesthetic while conveying the view dependent nature of a specular map.

Here is a lit Zeus rendered with PBR textures:

![zeus_lighting](https://cloud.githubusercontent.com/assets/426809/18121997/29f66124-6f1c-11e6-9550-491655cbf4a0.PNG)

And here it is using the unlit specular effect:

![zeus_nolighting](https://cloud.githubusercontent.com/assets/426809/18121968/01275c1c-6f1c-11e6-8bca-d8c833fbdbd4.PNG)
