### PR TITLE
Refactored material handling of shaders

### DIFF
--- a/code/graphics/material.cpp
+++ b/code/graphics/material.cpp
@@ -119,8 +119,7 @@ void material_set_distortion(distortion_material *mat_info, int texture, bool th
 }
 
 material::material():
-Sdr_handle(-1), 
-Sdr_type(SDR_TYPE_NONE),
+Sdr_type(SDR_TYPE_PASSTHROUGH_RENDER),
 Tex_type(TEX_TYPE_NORMAL),
 Texture_addressing(TMAP_ADDRESS_WRAP),
 Depth_bias(0),
@@ -158,14 +157,14 @@ void material::set_shader_type(shader_type init_sdr_type)
 	Sdr_type = init_sdr_type;
 }
 
-void material::set_shader_handle(int handle)
+uint material::get_shader_flags()
 {
-	Sdr_handle = handle;
+	return 0;
 }
 
 int material::get_shader_handle()
 {
-	return Sdr_handle;
+	return gr_maybe_create_shader(Sdr_type, get_shader_flags());
 }
 
 void material::set_texture_map(int tex_type, int texture_num)
@@ -631,19 +630,6 @@ uint model_material::get_shader_flags()
 	return Shader_flags;
 }
 
-int model_material::get_shader_handle()
-{
-	int handle = material::get_shader_handle();
-
-	if ( handle >= 0 ) {
-		return handle;
-	}
-
-	set_shader_handle(gr_maybe_create_shader(SDR_TYPE_MODEL, get_shader_flags()));
-
-	return material::get_shader_handle();
-}
-
 particle_material::particle_material(): 
 material()  
 {
@@ -660,23 +646,15 @@ bool particle_material::get_point_sprite_mode()
 	return Point_sprite;
 }
 
-int particle_material::get_shader_handle()
+uint particle_material::get_shader_flags()
 {
-	int handle = material::get_shader_handle();
-
-	if ( handle >= 0 ) {
-		return handle;
-	}
-
 	uint flags = 0;
 
 	if ( Point_sprite ) {
 		flags |= SDR_FLAG_PARTICLE_POINT_GEN;
 	}
 
-	set_shader_handle(gr_maybe_create_shader(SDR_TYPE_EFFECT_PARTICLE, flags));
-
-	return material::get_shader_handle();
+	return flags;
 }
 
 distortion_material::distortion_material(): 
@@ -684,20 +662,6 @@ material()
 {
 	set_shader_type(SDR_TYPE_EFFECT_DISTORTION);
 }
-
-int distortion_material::get_shader_handle()
-{
-	int handle = material::get_shader_handle();
-
-	if ( handle >= 0 ) {
-		return handle;
-	}
-
-	set_shader_handle(gr_maybe_create_shader(SDR_TYPE_EFFECT_DISTORTION, 0));
-
-	return material::get_shader_handle();
-}
-
 
 void distortion_material::set_thruster_rendering(bool enabled)
 {
@@ -717,19 +681,6 @@ shield_material::shield_material() :
 	vm_set_identity(&Impact_orient);
 	Impact_pos = { 0.0f, 0.0f, 0.0f };
 	Impact_radius = 1.0f;
-}
-
-int shield_material::get_shader_handle()
-{
-	int handle = material::get_shader_handle();
-
-	if ( handle >= 0 ) {
-		return handle;
-	}
-
-	set_shader_handle(gr_maybe_create_shader(SDR_TYPE_SHIELD_DECAL, 0));
-
-	return material::get_shader_handle();
 }
 
 void shield_material::set_impact_transform(matrix &orient, vec3d &pos)

--- a/code/graphics/material.h
+++ b/code/graphics/material.h
@@ -33,7 +33,6 @@ public:
 
 private:
 	shader_type Sdr_type;
-	int Sdr_handle;
 
 	int Texture_maps[TM_NUM_TYPES];
 	texture_type Tex_type;
@@ -51,12 +50,11 @@ private:
 
 protected:
 	void set_shader_type(shader_type init_sdr_type = SDR_TYPE_NONE);
-
 public:
 	material();
 
-	void set_shader_handle(int handle);
-	virtual int get_shader_handle();
+	int get_shader_handle();
+	virtual uint get_shader_flags();
 
 	void set_texture_map(int tex_type, int texture_num);
 	int get_texture_map(int tex_type);
@@ -178,8 +176,7 @@ public:
 	void set_batching(bool enabled);
 	bool is_batched();
 
-	uint get_shader_flags();
-	virtual int get_shader_handle();
+	virtual uint get_shader_flags();
 };
 
 class particle_material : public material
@@ -191,7 +188,7 @@ public:
 	void set_point_sprite_mode(bool enabled);
 	bool get_point_sprite_mode();
 
-	virtual int get_shader_handle();
+	virtual uint get_shader_flags();
 };
 
 class distortion_material: public material
@@ -202,8 +199,6 @@ public:
 
 	void set_thruster_rendering(bool enabled);
 	bool get_thruster_rendering();
-
-	virtual int get_shader_handle();
 };
 
 class shield_material : public material
@@ -220,8 +215,6 @@ public:
 	const matrix& get_impact_orient();
 	const vec3d& get_impact_pos();
 	float get_impact_radius();
-
-	virtual int get_shader_handle();
 };
 
 gr_alpha_blend material_determine_blend_mode(int base_bitmap, bool is_transparent);

--- a/code/graphics/opengl/gropengltnl.cpp
+++ b/code/graphics/opengl/gropengltnl.cpp
@@ -871,9 +871,11 @@ void opengl_tnl_set_material(material* material_info, bool set_base_map)
 	int base_map = material_info->get_texture_map(TM_BASE_TYPE);
 	vec4 clr = material_info->get_color();
 
-	if ( shader_handle >= 0 ) {
-		opengl_shader_set_current(shader_handle);
-	} else {
+	Assert(shader_handle >= 0);
+
+	opengl_shader_set_current(shader_handle);
+
+	if ( Current_shader->shader == SDR_TYPE_PASSTHROUGH_RENDER ) {
 		opengl_shader_set_passthrough(base_map >= 0, material_info->get_texture_type() == TCACHE_TYPE_AABITMAP, &clr, material_info->get_color_scale());
 	}
 


### PR DESCRIPTION
This was something I planned on doing before the OpenGL Core migration but I got sidetracked. The way materials decide what shader a draw call was left in an overly complicated state and wasn't very clear. I simplified it so that a material just needs an override of the get_shader_flags() if a shader type of a derived material class needs a flag for its particular case. 