### PR TITLE
Make shaders use uniforms instead of compile time flags

### DIFF
--- a/code/def_files/effect-distort-f.sdr
+++ b/code/def_files/effect-distort-f.sdr
@@ -3,7 +3,6 @@ in vec4 fragColor;
 in float fragOffset;
 out vec4 fragOut0;
 uniform sampler2D baseMap;
-uniform sampler2D depthMap;
 uniform float window_width;
 uniform float window_height;
 uniform sampler2D distMap;

--- a/code/def_files/main-f.sdr
+++ b/code/def_files/main-f.sdr
@@ -50,9 +50,9 @@ uniform sampler2D sNormalmap;
 in mat3 fragTangentMatrix;
 #endif
 
-#ifdef FLAG_AMBIENT_MAP
+uniform bool FLAG_AMBIENT_MAP;
 uniform sampler2D sAmbientmap;
-#endif
+
 #ifdef FLAG_FOG
 uniform vec4 fogColor;
 in float fragFogDist;
@@ -313,11 +313,13 @@ void main()
 	glossData = defaultGloss;
 #endif
 	vec2 aoFactors = vec2(1.0, 1.0);
-#ifdef	FLAG_AMBIENT_MAP
-	// red channel is ambient occlusion factor which only affects ambient lighting.
-	// green is cavity occlusion factor which only affects diffuse and specular lighting.
-	aoFactors = texture2D(sAmbientmap, texCoord).xy;
-#endif
+	
+	if (FLAG_AMBIENT_MAP) {
+		// red channel is ambient occlusion factor which only affects ambient lighting.
+		// green is cavity occlusion factor which only affects diffuse and specular lighting.
+		aoFactors = texture2D(sAmbientmap, texCoord).xy;
+	}
+	
 	vec3 unitNormal = normalize(fragNormal);
 	vec3 normal = unitNormal;
 #ifndef HAS_GEOMETRY_SHADER

--- a/code/def_files/main-f.sdr
+++ b/code/def_files/main-f.sdr
@@ -93,9 +93,10 @@ uniform float fardist;
 uniform int use_clip_plane;
 in float fragClipDistance;
 #endif
-#ifdef FLAG_NORMAL_ALPHA
+
+uniform bool FLAG_NORMAL_ALPHA;
 uniform vec2 normalAlphaMinMax;
-#endif
+
 #define SPEC_INTENSITY_POINT      5.3 // Point light
 #define SPEC_INTENSITY_DIRECTIONAL   3.0 // Directional light
 #define SPECULAR_FACTOR         1.75
@@ -480,10 +481,11 @@ void main()
 		}
 	}
 	
-#ifdef FLAG_NORMAL_ALPHA
-	float normViewOffset = dot(vec3(0.0, 0.0, 1.0), normal);
-	baseColor.a = smoothstep(min(normalAlphaMinMax.x, normalAlphaMinMax.y), max(normalAlphaMinMax.x, normalAlphaMinMax.y), clamp(normalAlphaMinMax.x > normalAlphaMinMax.y ? normViewOffset : 1.0 - normViewOffset, 0.0, 1.0));
-#endif
+ 	if (FLAG_NORMAL_ALPHA) {
+		float normViewOffset = dot(vec3(0.0, 0.0, 1.0), normal);
+		baseColor.a = smoothstep(min(normalAlphaMinMax.x, normalAlphaMinMax.y), max(normalAlphaMinMax.x, normalAlphaMinMax.y), clamp(normalAlphaMinMax.x > normalAlphaMinMax.y ? normViewOffset : 1.0 - normViewOffset, 0.0, 1.0));
+	}
+	
 #ifdef FLAG_CLIP
 	// for some odd reason if we try to discard the pixel early for plane clipping, it screws up glow maps so let's just do it down here.
 	if(use_clip_plane == 1) { if(fragClipDistance <= 0.0) { discard; } }

--- a/code/def_files/main-f.sdr
+++ b/code/def_files/main-f.sdr
@@ -57,13 +57,14 @@ uniform sampler2D sAmbientmap;
 uniform vec4 fogColor;
 in float fragFogDist;
 #endif
-#ifdef FLAG_ANIMATED
+
+uniform bool FLAG_ANIMATED;
 uniform sampler2D sFramebuffer;
 uniform int effect_num;
 uniform float anim_timer;
 uniform float vpwidth;
 uniform float vpheight;
-#endif
+
 #ifdef FLAG_TRANSFORM
 in float fragNotVisible;
 #endif
@@ -335,17 +336,18 @@ void main()
 #endif
 	normData = vec4(normal, 1.0);
 
-#ifdef FLAG_ANIMATED
-   vec2 distort = vec2(cos(fragPosition.x*fragPosition.w*0.005+anim_timer*20.0)*sin(fragPosition.y*fragPosition.w*0.005),sin(fragPosition.x*fragPosition.w*0.005+anim_timer*20.0)*cos(fragPosition.y*fragPosition.w*0.005))*0.03;
-#endif
+	vec2 distort = vec2(0.0);
+ 	if (FLAG_ANIMATED) {
+		distort = vec2(cos(fragPosition.x*fragPosition.w*0.005+anim_timer*20.0)*sin(fragPosition.y*fragPosition.w*0.005),sin(fragPosition.x*fragPosition.w*0.005+anim_timer*20.0)*cos(fragPosition.y*fragPosition.w*0.005))*0.03;
+	}
 
     if (FLAG_DIFFUSE_MAP) {
         vec2 diffuseTexCoord = texCoord;
-     #ifdef FLAG_ANIMATED
-       if (effect_num == 2) {
-          diffuseTexCoord = texCoord + distort*(1.0-anim_timer);
-       }
-     #endif
+		
+		if (FLAG_ANIMATED && effect_num == 2) {
+			diffuseTexCoord = texCoord + distort*(1.0-anim_timer);
+		}
+	   
         baseColor = texture(sBasemap, diffuseTexCoord);
         if ( blend_alpha == 0 && baseColor.a < 0.95 ) discard; // if alpha blending is not on, discard transparent pixels
         // premultiply alpha if blend_alpha is 1. assume that our blend function is srcColor + (1-Alpha)*destColor.
@@ -447,33 +449,34 @@ void main()
 		baseColor.rgb = color.rgb * dot(vec3(1.0), baseColor.rgb) * 0.3333333;
 	}
 
-#ifdef FLAG_ANIMATED
-   if (effect_num == 0) {
-      float shinefactor = 1.0/(1.0 + pow(abs((fract(abs(texCoord.x))-anim_timer) * 1000.0), 2.0)) * 1000.0;
-      baseColor.rgb = baseColor.rgb + vec3(shinefactor);
-      baseColor.a = baseColor.a * clamp(shinefactor * (fract(abs(texCoord.x))-anim_timer) * -10000.0,0.0,1.0);
-   }
-   if (effect_num == 1) {
-      float shinefactor = 1.0/(1.0 + pow(abs(fragPosition.y-anim_timer), 2.0));
-      baseColor.rgb = baseColor.rgb + vec3(shinefactor);
- #ifdef FLAG_LIGHT
-      baseColor.a = baseColor.a;
- #else
-      // ATI Wireframe fix *grumble*
-      baseColor.a = clamp((fragPosition.y-anim_timer) * 10000.0,0.0,1.0);
- #endif
-   }
-   if (effect_num == 2) {
-      vec2 screenPos = gl_FragCoord.xy * vec2(vpwidth,vpheight);
-      baseColor.a = baseColor.a;
-      float cloak_interp = (sin(fragPosition.x*fragPosition.w*0.005+anim_timer*20.0)*sin(fragPosition.y*fragPosition.w*0.005)*0.5)-0.5;
- #ifdef FLAG_LIGHT
-      baseColor.rgb = mix(texture(sFramebuffer, screenPos + distort*anim_timer + anim_timer*0.1*normal.xy).rgb,baseColor.rgb,clamp(cloak_interp+anim_timer*2.0,0.0,1.0));
- #else
-      baseColor.rgb = mix(texture(sFramebuffer, screenPos + distort*anim_timer + anim_timer*0.1*fragNormal.xy).rgb,baseColor.rgb,clamp(cloak_interp+anim_timer*2.0,0.0,1.0));
- #endif
-   }
+	if (FLAG_ANIMATED) {
+		if (effect_num == 0) {
+			float shinefactor = 1.0/(1.0 + pow(abs((fract(abs(texCoord.x))-anim_timer) * 1000.0), 2.0)) * 1000.0;
+			baseColor.rgb = baseColor.rgb + vec3(shinefactor);
+			baseColor.a = baseColor.a * clamp(shinefactor * (fract(abs(texCoord.x))-anim_timer) * -10000.0,0.0,1.0);
+		}
+		if (effect_num == 1) {
+			float shinefactor = 1.0/(1.0 + pow(abs(fragPosition.y-anim_timer), 2.0));
+			baseColor.rgb = baseColor.rgb + vec3(shinefactor);
+#ifdef FLAG_LIGHT
+			baseColor.a = baseColor.a;
+#else
+			// ATI Wireframe fix *grumble*
+			baseColor.a = clamp((fragPosition.y-anim_timer) * 10000.0,0.0,1.0);
 #endif
+		}
+		if (effect_num == 2) {
+			vec2 screenPos = gl_FragCoord.xy * vec2(vpwidth,vpheight);
+			baseColor.a = baseColor.a;
+			float cloak_interp = (sin(fragPosition.x*fragPosition.w*0.005+anim_timer*20.0)*sin(fragPosition.y*fragPosition.w*0.005)*0.5)-0.5;
+#ifdef FLAG_LIGHT
+			baseColor.rgb = mix(texture(sFramebuffer, screenPos + distort*anim_timer + anim_timer*0.1*normal.xy).rgb,baseColor.rgb,clamp(cloak_interp+anim_timer*2.0,0.0,1.0));
+#else
+			baseColor.rgb = mix(texture(sFramebuffer, screenPos + distort*anim_timer + anim_timer*0.1*fragNormal.xy).rgb,baseColor.rgb,clamp(cloak_interp+anim_timer*2.0,0.0,1.0));
+#endif
+		}
+	}
+	
 #ifdef FLAG_NORMAL_ALPHA
 	float normViewOffset = dot(vec3(0.0, 0.0, 1.0), normal);
 	baseColor.a = smoothstep(min(normalAlphaMinMax.x, normalAlphaMinMax.y), max(normalAlphaMinMax.x, normalAlphaMinMax.y), clamp(normalAlphaMinMax.x > normalAlphaMinMax.y ? normViewOffset : 1.0 - normViewOffset, 0.0, 1.0));

--- a/code/def_files/main-f.sdr
+++ b/code/def_files/main-f.sdr
@@ -74,9 +74,10 @@ uniform vec3 stripe_color;
 uniform bool team_glow_enabled;
 vec2 teamMask = vec2(0.0, 0.0);
 #endif
-#ifdef FLAG_MISC_MAP
+
+uniform bool FLAG_MISC_MAP;
 uniform sampler2D sMiscmap;
-#endif
+
 #ifdef FLAG_SHADOWS
 in vec4 fragShadowUV[4];
 in vec4 fragShadowPos;
@@ -377,16 +378,22 @@ void main()
 		specData = vec4(specColour.rgb, glossData);
    }
    
-#ifdef FLAG_MISC_MAP
- #ifdef FLAG_TEAMCOLOR
-	vec4 teamMask = vec4(0.0, 0.0, 0.0, 0.0);
-	teamMask = texture(sMiscmap, texCoord);
-	vec3 base = base_color - vec3(0.5);
-	vec3 stripe = stripe_color - vec3(0.5);
-	baseColor.rgb += (base * teamMask.x) + (stripe * teamMask.y);
-	baseColor.rgb = max(baseColor.rgb, vec3(0.0));
- #endif
+#ifdef FLAG_TEAMCOLOR
+	vec4 teamMask;
+	vec3 base;
+	vec3 stripe;
 #endif
+	if (FLAG_MISC_MAP) {
+#ifdef FLAG_TEAMCOLOR
+		teamMask = vec4(0.0, 0.0, 0.0, 0.0);
+		teamMask = texture(sMiscmap, texCoord);
+		base = base_color - vec3(0.5);
+		stripe = stripe_color - vec3(0.5);
+		baseColor.rgb += (base * teamMask.x) + (stripe * teamMask.y);
+		baseColor.rgb = max(baseColor.rgb, vec3(0.0));
+#endif
+	}
+	
 	float shadow = 1.0;
 #ifdef FLAG_SHADOWS
 	shadow = getShadowValue();
@@ -423,12 +430,12 @@ void main()
 #ifdef FLAG_HDR
         glowColor = pow(glowColor, vec3(SRGB_GAMMA)) * 3.0f;
 #endif
-#ifdef FLAG_MISC_MAP
- #ifdef FLAG_TEAMCOLOR
-        float glowColorLuminance = dot(glowColor, vec3(0.299, 0.587, 0.114));
-        glowColor = team_glow_enabled ? mix((base * teamMask.b) + (stripe * teamMask.a), glowColor, clamp(glowColorLuminance - teamMask.b - teamMask.a, 0.0, 1.0)) : glowColor;
- #endif
+		if (FLAG_MISC_MAP) {
+#ifdef FLAG_TEAMCOLOR
+			float glowColorLuminance = dot(glowColor, vec3(0.299, 0.587, 0.114));
+			glowColor = team_glow_enabled ? mix((base * teamMask.b) + (stripe * teamMask.a), glowColor, clamp(glowColorLuminance - teamMask.b - teamMask.a, 0.0, 1.0)) : glowColor;
 #endif
+		}
         baseColor.rgb += glowColor * GLOW_MAP_INTENSITY;
     }
 

--- a/code/def_files/main-f.sdr
+++ b/code/def_files/main-f.sdr
@@ -29,13 +29,13 @@ uniform sampler2D sGlowmap;
 uniform bool overrideGlow;
 uniform vec3 glowClr;
 
-#ifdef FLAG_SPEC_MAP
+uniform bool FLAG_SPEC_MAP;
 uniform sampler2D sSpecmap;
 uniform bool overrideSpec;
 uniform vec3 specClr;
 uniform bool alphaGloss;
 uniform bool gammaSpec;
-#endif
+
 #ifdef FLAG_ENV_MAP
 uniform samplerCube sEnvmap;
 uniform bool envGloss;
@@ -359,17 +359,22 @@ void main()
     }
 
    specData = vec4(baseColor.rgb * SPEC_FACTOR_NO_SPEC_MAP, glossData);
-#ifdef FLAG_SPEC_MAP
-   vec4 specColour = texture2D(sSpecmap, texCoord);
-	if(alphaGloss) glossData = specColour.a;
-	if(overrideSpec) specColour.rgb = specClr;
- #ifdef FLAG_HDR
-	if(gammaSpec) specColour.rgb = pow(specColour.rgb, vec3(SRGB_GAMMA));
- #endif
-	specColour.rgb *= aoFactors.y;
-	specColour.rgb = max(specColour.rgb, vec3(0.04)); // hardcoded minimum specular value. read John Hable's blog post titled 'Everything Is Shiny'. 
-   specData = vec4(specColour.rgb, glossData);
+   vec4 specColour;
+	if (FLAG_SPEC_MAP) {
+		specColour = texture2D(sSpecmap, texCoord);
+		if(alphaGloss)
+			glossData = specColour.a;
+		if(overrideSpec)
+			specColour.rgb = specClr;
+#ifdef FLAG_HDR
+		if(gammaSpec)
+			specColour.rgb = pow(specColour.rgb, vec3(SRGB_GAMMA));
 #endif
+		specColour.rgb *= aoFactors.y;
+		specColour.rgb = max(specColour.rgb, vec3(0.04)); // hardcoded minimum specular value. read John Hable's blog post titled 'Everything Is Shiny'. 
+		specData = vec4(specColour.rgb, glossData);
+   }
+   
 #ifdef FLAG_MISC_MAP
  #ifdef FLAG_TEAMCOLOR
 	vec4 teamMask = vec4(0.0, 0.0, 0.0, 0.0);
@@ -387,9 +392,9 @@ void main()
 #ifdef FLAG_LIGHT
 	baseColor.rgb = CalculateLighting(normal, baseColor.rgb, specData.rgb, glossData, shadow, aoFactors.x);
 #else
- #ifdef FLAG_SPEC_MAP
-	baseColor.rgb += pow(1.0 - dot(eyeDir, normal), 5.0 * clamp(glossData, 0.01, 1.0)) * specColour.rgb;
- #endif
+	if (FLAG_SPEC_MAP) {
+		baseColor.rgb += pow(1.0 - dot(eyeDir, normal), 5.0 * clamp(glossData, 0.01, 1.0)) * specColour.rgb;
+	}
 #endif
 #ifdef FLAG_ENV_MAP
    vec3 envReflectNM = fragEnvReflect;

--- a/code/def_files/main-f.sdr
+++ b/code/def_files/main-f.sdr
@@ -68,12 +68,12 @@ uniform float vpheight;
 #ifdef FLAG_TRANSFORM
 in float fragNotVisible;
 #endif
-#ifdef FLAG_TEAMCOLOR
+
+uniform bool FLAG_TEAMCOLOR;
 uniform vec3 base_color;
 uniform vec3 stripe_color;
 uniform bool team_glow_enabled;
 vec2 teamMask = vec2(0.0, 0.0);
-#endif
 
 uniform bool FLAG_MISC_MAP;
 uniform sampler2D sMiscmap;
@@ -378,20 +378,16 @@ void main()
 		specData = vec4(specColour.rgb, glossData);
    }
    
-#ifdef FLAG_TEAMCOLOR
 	vec4 teamMask;
 	vec3 base;
 	vec3 stripe;
-#endif
-	if (FLAG_MISC_MAP) {
-#ifdef FLAG_TEAMCOLOR
+	if (FLAG_MISC_MAP && FLAG_TEAMCOLOR) {
 		teamMask = vec4(0.0, 0.0, 0.0, 0.0);
 		teamMask = texture(sMiscmap, texCoord);
 		base = base_color - vec3(0.5);
 		stripe = stripe_color - vec3(0.5);
 		baseColor.rgb += (base * teamMask.x) + (stripe * teamMask.y);
 		baseColor.rgb = max(baseColor.rgb, vec3(0.0));
-#endif
 	}
 	
 	float shadow = 1.0;
@@ -430,11 +426,9 @@ void main()
 #ifdef FLAG_HDR
         glowColor = pow(glowColor, vec3(SRGB_GAMMA)) * 3.0f;
 #endif
-		if (FLAG_MISC_MAP) {
-#ifdef FLAG_TEAMCOLOR
+		if (FLAG_MISC_MAP && FLAG_TEAMCOLOR) {
 			float glowColorLuminance = dot(glowColor, vec3(0.299, 0.587, 0.114));
 			glowColor = team_glow_enabled ? mix((base * teamMask.b) + (stripe * teamMask.a), glowColor, clamp(glowColorLuminance - teamMask.b - teamMask.a, 0.0, 1.0)) : glowColor;
-#endif
 		}
         baseColor.rgb += glowColor * GLOW_MAP_INTENSITY;
     }

--- a/code/def_files/main-f.sdr
+++ b/code/def_files/main-f.sdr
@@ -24,11 +24,11 @@ uniform int blend_alpha;
 uniform bool overrideDiffuse;
 uniform vec3 diffuseClr;
 
-#ifdef FLAG_GLOW_MAP
+uniform bool FLAG_GLOW_MAP;
 uniform sampler2D sGlowmap;
 uniform bool overrideGlow;
 uniform vec3 glowClr;
-#endif
+
 #ifdef FLAG_SPEC_MAP
 uniform sampler2D sSpecmap;
 uniform bool overrideSpec;
@@ -409,20 +409,21 @@ void main()
 	envColour.rgb *= (envGloss) ? 1.0 : specColour.a;
 	baseColor.rgb += envColour.rgb * FresnelLazarovEnv(specColour.rgb, eyeDir, normal, glossData);
 #endif
-#ifdef FLAG_GLOW_MAP
-	vec3 glowColor = texture2D(sGlowmap, texCoord).rgb;
-	if(overrideGlow) glowColor = glowClr;
- #ifdef FLAG_HDR
-	glowColor = pow(glowColor, vec3(SRGB_GAMMA)) * 3.0f;
- #endif
- #ifdef FLAG_MISC_MAP
-  #ifdef FLAG_TEAMCOLOR
-	float glowColorLuminance = dot(glowColor, vec3(0.299, 0.587, 0.114));
-	glowColor = team_glow_enabled ? mix((base * teamMask.b) + (stripe * teamMask.a), glowColor, clamp(glowColorLuminance - teamMask.b - teamMask.a, 0.0, 1.0)) : glowColor;
-  #endif
- #endif
-   baseColor.rgb += glowColor * GLOW_MAP_INTENSITY;
+
+    if (FLAG_GLOW_MAP) {
+        vec3 glowColor = texture2D(sGlowmap, texCoord).rgb;
+        if(overrideGlow) glowColor = glowClr;
+#ifdef FLAG_HDR
+        glowColor = pow(glowColor, vec3(SRGB_GAMMA)) * 3.0f;
 #endif
+#ifdef FLAG_MISC_MAP
+ #ifdef FLAG_TEAMCOLOR
+        float glowColorLuminance = dot(glowColor, vec3(0.299, 0.587, 0.114));
+        glowColor = team_glow_enabled ? mix((base * teamMask.b) + (stripe * teamMask.a), glowColor, clamp(glowColorLuminance - teamMask.b - teamMask.a, 0.0, 1.0)) : glowColor;
+ #endif
+#endif
+        baseColor.rgb += glowColor * GLOW_MAP_INTENSITY;
+    }
 
 #ifdef FLAG_FOG
 	vec3 finalFogColor = fogColor.rgb;

--- a/code/def_files/main-f.sdr
+++ b/code/def_files/main-f.sdr
@@ -16,13 +16,14 @@ uniform vec3 ambientFactor;
 uniform vec3 diffuseFactor;
 uniform vec3 emissionFactor;
 #endif
-#ifdef FLAG_DIFFUSE_MAP
+
+uniform bool FLAG_DIFFUSE_MAP;
 uniform sampler2D sBasemap;
 uniform int desaturate;
 uniform int blend_alpha;
 uniform bool overrideDiffuse;
 uniform vec3 diffuseClr;
-#endif
+
 #ifdef FLAG_GLOW_MAP
 uniform sampler2D sGlowmap;
 uniform bool overrideGlow;
@@ -338,24 +339,24 @@ void main()
    vec2 distort = vec2(cos(fragPosition.x*fragPosition.w*0.005+anim_timer*20.0)*sin(fragPosition.y*fragPosition.w*0.005),sin(fragPosition.x*fragPosition.w*0.005+anim_timer*20.0)*cos(fragPosition.y*fragPosition.w*0.005))*0.03;
 #endif
 
-#ifdef FLAG_DIFFUSE_MAP
-	vec2 diffuseTexCoord = texCoord;
- #ifdef FLAG_ANIMATED
-   if (effect_num == 2) {
-      diffuseTexCoord = texCoord + distort*(1.0-anim_timer);
-   }
- #endif
-	baseColor = texture(sBasemap, diffuseTexCoord);
-	if ( blend_alpha == 0 && baseColor.a < 0.95 ) discard; // if alpha blending is not on, discard transparent pixels
-	// premultiply alpha if blend_alpha is 1. assume that our blend function is srcColor + (1-Alpha)*destColor.
-	// if blend_alpha is 2, assume blend func is additive and don't modify color
-	if(blend_alpha == 1) baseColor.rgb = baseColor.rgb * baseColor.a;
-	if(overrideDiffuse) baseColor.rgb = diffuseClr;
- #ifdef FLAG_HDR
-	baseColor.rgb = pow(baseColor.rgb, vec3(SRGB_GAMMA));
- #endif
-	baseColor.rgb *= aoFactors.y;
-#endif
+    if (FLAG_DIFFUSE_MAP) {
+        vec2 diffuseTexCoord = texCoord;
+     #ifdef FLAG_ANIMATED
+       if (effect_num == 2) {
+          diffuseTexCoord = texCoord + distort*(1.0-anim_timer);
+       }
+     #endif
+        baseColor = texture(sBasemap, diffuseTexCoord);
+        if ( blend_alpha == 0 && baseColor.a < 0.95 ) discard; // if alpha blending is not on, discard transparent pixels
+        // premultiply alpha if blend_alpha is 1. assume that our blend function is srcColor + (1-Alpha)*destColor.
+        // if blend_alpha is 2, assume blend func is additive and don't modify color
+        if(blend_alpha == 1) baseColor.rgb = baseColor.rgb * baseColor.a;
+        if(overrideDiffuse) baseColor.rgb = diffuseClr;
+     #ifdef FLAG_HDR
+        baseColor.rgb = pow(baseColor.rgb, vec3(SRGB_GAMMA));
+     #endif
+        baseColor.rgb *= aoFactors.y;
+    }
 
    specData = vec4(baseColor.rgb * SPEC_FACTOR_NO_SPEC_MAP, glossData);
 #ifdef FLAG_SPEC_MAP
@@ -428,18 +429,18 @@ void main()
  #ifdef FLAG_HDR
 	finalFogColor = pow(finalFogColor, vec3(SRGB_GAMMA));
  #endif
- #ifdef FLAG_DIFFUSE_MAP
-	if(blend_alpha == 1) finalFogColor *= baseColor.a;
- #endif
-   baseColor.rgb = mix(baseColor.rgb, finalFogColor, fragFogDist);
-	specData.rgb *= fragFogDist;
-#endif
+    if (FLAG_DIFFUSE_MAP && blend_alpha == 1) {
+        finalFogColor *= baseColor.a;
+    }
 
-#ifdef FLAG_DIFFUSE_MAP
-	if(desaturate == 1) {
+    baseColor.rgb = mix(baseColor.rgb, finalFogColor, fragFogDist);
+    specData.rgb *= fragFogDist;
+ #endif
+ 
+ 	if(FLAG_DIFFUSE_MAP && desaturate == 1) {
 		baseColor.rgb = color.rgb * dot(vec3(1.0), baseColor.rgb) * 0.3333333;
 	}
-#endif
+
 #ifdef FLAG_ANIMATED
    if (effect_num == 0) {
       float shinefactor = 1.0/(1.0 + pow(abs((fract(abs(texCoord.x))-anim_timer) * 1000.0), 2.0)) * 1000.0;

--- a/code/def_files/main-f.sdr
+++ b/code/def_files/main-f.sdr
@@ -42,10 +42,13 @@ uniform bool alpha_spec;
 varying vec3 envReflect;
 in vec3 fragEnvReflect;
 #endif
-#ifdef FLAG_NORMAL_MAP
+
+uniform bool FLAG_NORMAL_MAP;
 uniform sampler2D sNormalmap;
+#ifndef HAS_GEOMETRY_SHADER
 in mat3 fragTangentMatrix;
 #endif
+
 #ifdef FLAG_AMBIENT_MAP
 uniform sampler2D sAmbientmap;
 #endif
@@ -314,18 +317,20 @@ void main()
 #endif
 	vec3 unitNormal = normalize(fragNormal);
 	vec3 normal = unitNormal;
-#ifdef FLAG_NORMAL_MAP
-   // Normal map - convert from DXT5nm
-   vec2 normalSample;
-   normal.rg = normalSample = (texture(sNormalmap, texCoord).ag * 2.0) - 1.0;
-   normal.b = sqrt(1.0 - dot(normal.rg, normal.rg));
-   normal = fragTangentMatrix * normal;
-   float norm = length(normal);
-   // prevent breaking of normal maps
-   if (norm > 0.0)
-      normal /= norm;
-   else
-      normal = unitNormal;
+#ifndef HAS_GEOMETRY_SHADER
+    vec2 normalSample;
+    if (FLAG_NORMAL_MAP) {
+        // Normal map - convert from DXT5nm
+        normal.rg = normalSample = (texture(sNormalmap, texCoord).ag * 2.0) - 1.0;
+        normal.b = sqrt(1.0 - dot(normal.rg, normal.rg));
+        normal = fragTangentMatrix * normal;
+        float norm = length(normal);
+        // prevent breaking of normal maps
+        if (norm > 0.0)
+            normal /= norm;
+        else
+            normal = unitNormal;
+    }
 #endif
 	normData = vec4(normal, 1.0);
 
@@ -387,10 +392,14 @@ void main()
 #endif
 #ifdef FLAG_ENV_MAP
    vec3 envReflectNM = fragEnvReflect;
- #ifdef FLAG_NORMAL_MAP
-   envReflectNM += vec3(normalSample, 0.0);
-	envReflectNM = normalize(envReflectNM);
- #endif
+
+#ifndef HAS_GEOMETRY_SHADER
+    if (FLAG_NORMAL_MAP) {
+        envReflectNM += vec3(normalSample, 0.0);
+        envReflectNM = normalize(envReflectNM);
+    }
+#endif
+
 	float mip = (envGloss) ? (1.0 - glossData) * 7.0 : 0.0;
    vec4 envColour = textureLod(sEnvmap, envReflectNM, mip);
  #ifdef FLAG_HDR

--- a/code/def_files/main-v.sdr
+++ b/code/def_files/main-v.sdr
@@ -9,9 +9,10 @@ uniform mat4 viewMatrix;
 uniform mat4 projMatrix;
 uniform mat4 textureMatrix;
 uniform vec4 color;
-#ifdef FLAG_NORMAL_EXTRUDE
+
+uniform bool FLAG_NORMAL_EXTRUDE;
 uniform float extrudeWidth;
-#endif
+
 #ifdef FLAG_ENV_MAP
 uniform mat4 envMatrix;
 out vec3 fragEnvReflect;
@@ -126,9 +127,11 @@ void main()
  #else
 	gl_Position = projMatrix * position;
  #endif
- #ifdef FLAG_NORMAL_EXTRUDE
-	gl_Position.xy += (mat3(projMatrix) * normal.xyz).xy * gl_Position.z * extrudeWidth;
- #endif
+
+    if (FLAG_NORMAL_EXTRUDE) {
+	    gl_Position.xy += (mat3(projMatrix) * normal.xyz).xy * gl_Position.z * extrudeWidth;
+    }
+
  #ifdef FLAG_SHADOWS
 	fragShadowPos = shadow_mv_matrix * modelMatrix * orient * vertPosition;
 	fragShadowUV[0] = transformToShadowMap(0, fragShadowPos);

--- a/code/def_files/main-v.sdr
+++ b/code/def_files/main-v.sdr
@@ -54,9 +54,10 @@ uniform mat4 shadow_proj_matrix[4];
 out vec4 fragShadowUV[4];
 out vec4 fragShadowPos;
 #endif
-#ifdef FLAG_THRUSTER
+
+uniform bool FLAG_THRUSTER;
 uniform float thruster_scale;
-#endif
+
 #ifdef FLAG_CLIP
 uniform int use_clip_plane;
 uniform vec3 clip_normal;
@@ -109,11 +110,11 @@ void main()
  #endif
 	texCoord = textureMatrix * vertTexCoord;
 	vec4 vertex = vertPosition;
- #ifdef FLAG_THRUSTER
-	if(vertex.z < -1.5) {
+	
+	if(FLAG_THRUSTER && vertex.z < -1.5) {
 		vertex.z *= thruster_scale;
 	}
- #endif
+	
  // Transform the normal into eye space and normalize the result.
 	normal = normalize(mat3(modelViewMatrix) * mat3(orient) * vertNormal);
 	position = modelViewMatrix * orient * vertex;

--- a/code/def_files/main-v.sdr
+++ b/code/def_files/main-v.sdr
@@ -16,9 +16,13 @@ uniform float extrudeWidth;
 uniform mat4 envMatrix;
 out vec3 fragEnvReflect;
 #endif
-#ifdef FLAG_NORMAL_MAP
+
+uniform bool FLAG_NORMAL_MAP;
+
+#ifndef HAS_GEOMETRY_SHADER
 out mat3 fragTangentMatrix;
 #endif
+
 #ifdef FLAG_FOG
 uniform float fogStart;
 uniform float fogScale;
@@ -64,7 +68,7 @@ out float fragClipDistance;
 #endif
 #ifdef FLAG_TRANSFORM
 #define TEXELS_PER_MATRIX 4
-void getModelTransform(inout mat4 transform, inout float invisible, int id, int matrix_offset)
+void getModelTransform(inout mat4 transform, out float invisible, int id, int matrix_offset)
 {
 	transform[0] = texelFetch(transform_tex, (matrix_offset + id) * TEXELS_PER_MATRIX);
 	transform[1] = texelFetch(transform_tex, (matrix_offset + id) * TEXELS_PER_MATRIX + 1);
@@ -132,12 +136,16 @@ void main()
 	fragShadowUV[2] = transformToShadowMap(2, fragShadowPos);
 	fragShadowUV[3] = transformToShadowMap(3, fragShadowPos);
  #endif
- #ifdef FLAG_NORMAL_MAP
- // Setup stuff for normal maps
-	vec3 t = normalize(mat3(modelViewMatrix) * mat3(orient) * vertTangent.xyz);
-	vec3 b = cross(normal, t) * vertTangent.w;
-	fragTangentMatrix = mat3(t, b, normal);
- #endif
+
+#ifndef HAS_GEOMETRY_SHADER
+    // Setup stuff for normal maps
+    if (FLAG_NORMAL_MAP) {
+        vec3 t = normalize(mat3(modelViewMatrix) * mat3(orient) * vertTangent.xyz);
+        vec3 b = cross(normal, t) * vertTangent.w;
+        fragTangentMatrix = mat3(t, b, normal);
+    }
+#endif
+
  #ifdef FLAG_ENV_MAP
  // Environment mapping reflection vector.
 	fragEnvReflect = reflect(normalize(position.xyz), normal);

--- a/code/def_files/post-f.sdr
+++ b/code/def_files/post-f.sdr
@@ -26,8 +26,6 @@ uniform float cutoff;
 #ifdef FLAG_DITH
 uniform float dither;
 #endif
-uniform sampler2D blurred_tex;
-uniform sampler2D depth_tex;
 void main()
 {
  #ifdef FLAG_DISTORT_NOISE

--- a/code/graphics/opengl/ShaderProgram.cpp
+++ b/code/graphics/opengl/ShaderProgram.cpp
@@ -226,20 +226,6 @@ opengl::ShaderUniforms::ShaderUniforms(ShaderProgram* shaderProgram) : _program(
 	Assertion(shaderProgram != nullptr, "Shader program may not be null!");
 }
 
-void opengl::ShaderUniforms::initUniform(const SCP_string& name)
-{
-	auto location = glGetUniformLocation(_program->getShaderHandle(), name.c_str());
-
-	if (location == -1)
-	{
-		// This can happen if the uniform has been optimized out by the driver
-		mprintf(("WARNING: Failed to find uniform '%s'.\n", name.c_str()));
-		return;
-	}
-
-	_uniform_locations.insert(std::make_pair(name, location));
-}
-
 size_t opengl::ShaderUniforms::findUniform(const SCP_string& name)
 {
 	auto iter = _uniform_lookup.find(name);
@@ -812,9 +798,11 @@ GLint opengl::ShaderUniforms::findUniformLocation(const SCP_string& name) {
 	auto iter = _uniform_locations.find(name);
 
 	if (iter == _uniform_locations.end()) {
-		return -1;
+		// Lazily get uniform location
+		auto location = glGetUniformLocation(_program->getShaderHandle(), name.c_str());
+
+		iter = _uniform_locations.insert(std::make_pair(name, location)).first;
 	}
-	else {
-		return iter->second;
-	}
+
+	return iter->second;
 }

--- a/code/graphics/opengl/ShaderProgram.h
+++ b/code/graphics/opengl/ShaderProgram.h
@@ -67,6 +67,23 @@ class ShaderUniforms {
 	void setUniformMatrix4f(const SCP_string &name, const matrix4 &val);
 };
 
+class SamplerManager {
+	ShaderProgram* _program;
+
+	SCP_vector<SCP_string> _samplers;
+	SCP_unordered_map<SCP_string, int> _samplerTexUnits;
+ public:
+	explicit SamplerManager(ShaderProgram* program);
+
+	void initSampler(const SCP_string& name);
+
+	void reset();
+
+	void bindSampler(const SCP_string& name, int texture_unit);
+
+	void flush();
+};
+
 enum ShaderStage {
 	STAGE_VERTEX,
 	STAGE_GEOMETRY,
@@ -86,6 +103,8 @@ class ShaderProgram {
 	~ShaderProgram();
 
 	ShaderUniforms Uniforms;
+
+	SamplerManager Samplers;
 
 	ShaderProgram(const ShaderProgram&) SCP_DELETED_FUNCTION;
 	ShaderProgram& operator=(const ShaderProgram&) SCP_DELETED_FUNCTION;

--- a/code/graphics/opengl/ShaderProgram.h
+++ b/code/graphics/opengl/ShaderProgram.h
@@ -51,8 +51,6 @@ class ShaderUniforms {
  public:
 	explicit ShaderUniforms(ShaderProgram* shaderProgram);
 
-	void initUniform(const SCP_string& name);
-
 	void setUniformi(const SCP_string &name, const int value);
 	void setUniform1iv(const SCP_string &name, const int count, const int *val);
 	void setUniformf(const SCP_string &name, const float value);

--- a/code/graphics/opengl/gropenglpostprocessing.cpp
+++ b/code/graphics/opengl/gropenglpostprocessing.cpp
@@ -489,15 +489,6 @@ void get_post_process_effect_names(SCP_vector<SCP_string> &names)
 	}
 }
 
-void opengl_post_init_uniforms(int flags)
-{
-	for (int idx = 0; idx < (int)Post_effects.size(); idx++) {
-		if (flags & (1 << idx)) {
-			Current_shader->program->Uniforms.initUniform(Post_effects[idx].uniform_name.c_str());
-		}
-	}
-}
-
 void gr_opengl_post_process_set_effect(const char *name, int value)
 {
 	if ( !Post_initialized ) {

--- a/code/graphics/opengl/gropenglpostprocessing.h
+++ b/code/graphics/opengl/gropenglpostprocessing.h
@@ -12,7 +12,6 @@ void gr_opengl_post_process_begin();
 void gr_opengl_post_process_end();
 void get_post_process_effect_names(SCP_vector<SCP_string> &names);
 
-void opengl_post_init_uniforms(int flags);
 void opengl_post_shader_header(SCP_stringstream &sflags, shader_type shader_t, int flags);
 
 #endif	// _GROPENGLPOSTPROCESSING_H

--- a/code/graphics/opengl/gropenglshader.cpp
+++ b/code/graphics/opengl/gropenglshader.cpp
@@ -218,7 +218,7 @@ static opengl_shader_variant_t GL_shader_variants[] = {
 		{ "sAmbientmap" }, {  },
 		"Ambient Occlusion Map" },
 
-	{ SDR_TYPE_MODEL, false, true, SDR_FLAG_MODEL_NORMAL_ALPHA, "FLAG_NORMAL_ALPHA",
+	{ SDR_TYPE_MODEL, false, false, SDR_FLAG_MODEL_NORMAL_ALPHA, "FLAG_NORMAL_ALPHA",
 		{ }, { },
 		"Normal Alpha" },
 

--- a/code/graphics/opengl/gropenglshader.cpp
+++ b/code/graphics/opengl/gropenglshader.cpp
@@ -159,7 +159,7 @@ static opengl_shader_variant_t GL_shader_variants[] = {
 		{ "sGlowmap", "overrideGlow", "glowClr" }, {  },
 		"Glow Mapping" },
 	
-	{ SDR_TYPE_MODEL, false, true, SDR_FLAG_MODEL_SPEC_MAP, "FLAG_SPEC_MAP",
+	{ SDR_TYPE_MODEL, false, false, SDR_FLAG_MODEL_SPEC_MAP, "FLAG_SPEC_MAP",
 		{ "sSpecmap", "overrideSpec", "specClr", "gammaSpec", "alphaGloss" }, {  },
 		"Specular Mapping" },
 	

--- a/code/graphics/opengl/gropenglshader.cpp
+++ b/code/graphics/opengl/gropenglshader.cpp
@@ -178,7 +178,7 @@ static opengl_shader_variant_t GL_shader_variants[] = {
 		{ "sFramebuffer" }, {  },
 		"Animated Effects" },
 	
-	{ SDR_TYPE_MODEL, false, true, SDR_FLAG_MODEL_MISC_MAP, "FLAG_MISC_MAP",
+	{ SDR_TYPE_MODEL, false, false, SDR_FLAG_MODEL_MISC_MAP, "FLAG_MISC_MAP",
 		{ "sMiscmap" }, {  },
 		"Utility mapping" },
 	

--- a/code/graphics/opengl/gropenglshader.cpp
+++ b/code/graphics/opengl/gropenglshader.cpp
@@ -155,7 +155,7 @@ static opengl_shader_variant_t GL_shader_variants[] = {
 		{ "sBasemap", "desaturate", "desaturate_clr", "blend_alpha", "overrideDiffuse", "diffuseClr" }, {  },
 		"Diffuse Mapping" },
 	
-	{ SDR_TYPE_MODEL, false, true, SDR_FLAG_MODEL_GLOW_MAP, "FLAG_GLOW_MAP",
+	{ SDR_TYPE_MODEL, false, false, SDR_FLAG_MODEL_GLOW_MAP, "FLAG_GLOW_MAP",
 		{ "sGlowmap", "overrideGlow", "glowClr" }, {  },
 		"Glow Mapping" },
 	

--- a/code/graphics/opengl/gropenglshader.cpp
+++ b/code/graphics/opengl/gropenglshader.cpp
@@ -182,7 +182,7 @@ static opengl_shader_variant_t GL_shader_variants[] = {
 		{ "sMiscmap" }, {  },
 		"Utility mapping" },
 	
-	{ SDR_TYPE_MODEL, false, true, SDR_FLAG_MODEL_TEAMCOLOR, "FLAG_TEAMCOLOR",
+	{ SDR_TYPE_MODEL, false, false, SDR_FLAG_MODEL_TEAMCOLOR, "FLAG_TEAMCOLOR",
 		{  }, {  },
 		"Team Colors" },
 	

--- a/code/graphics/opengl/gropenglshader.cpp
+++ b/code/graphics/opengl/gropenglshader.cpp
@@ -73,27 +73,27 @@ opengl_vert_attrib GL_vertex_attrib_info[] =
  */
 static opengl_shader_type_t GL_shader_types[] = {
 	{ SDR_TYPE_MODEL, "main-v.sdr", "main-f.sdr", "main-g.sdr", 
-		{ "modelViewMatrix", "modelMatrix", "viewMatrix", "projMatrix", "textureMatrix", "color" },
+		{  },
 		{ opengl_vert_attrib::POSITION, opengl_vert_attrib::TEXCOORD, opengl_vert_attrib::NORMAL, opengl_vert_attrib::TANGENT, opengl_vert_attrib::MODEL_ID }, "Model Rendering" },
 
 	{ SDR_TYPE_EFFECT_PARTICLE, "effect-v.sdr", "effect-particle-f.sdr", "effect-screen-g.sdr", 
-		{ "modelViewMatrix", "projMatrix", "baseMap", "depthMap", "window_width", "window_height", "nearZ", "farZ", "linear_depth", "srgb", "blend_alpha" },
+		{ "baseMap", "depthMap" },
 		{ opengl_vert_attrib::POSITION, opengl_vert_attrib::TEXCOORD, opengl_vert_attrib::RADIUS, opengl_vert_attrib::COLOR }, "Particle Effects" },
 
 	{ SDR_TYPE_EFFECT_DISTORTION, "effect-distort-v.sdr", "effect-distort-f.sdr", 0, 
-		{ "modelViewMatrix", "projMatrix", "baseMap", "window_width", "window_height", "distMap", "frameBuffer", "use_offset" },
+		{ "baseMap", "distMap", "frameBuffer" },
 		{ opengl_vert_attrib::POSITION, opengl_vert_attrib::TEXCOORD, opengl_vert_attrib::RADIUS, opengl_vert_attrib::COLOR }, "Distortion Effects" },
 
 	{ SDR_TYPE_POST_PROCESS_MAIN, "post-v.sdr", "post-f.sdr", 0, 
-		{ "tex", "depth_tex", "timer" },
+		{ "tex" },
 		{ opengl_vert_attrib::POSITION, opengl_vert_attrib::TEXCOORD }, "Post Processing" },
 
 	{ SDR_TYPE_POST_PROCESS_BLUR, "post-v.sdr", "blur-f.sdr", 0, 
-		{ "tex", "texSize", "level", "tapSize", "debug" },
+		{ "tex" },
 		{ opengl_vert_attrib::POSITION, opengl_vert_attrib::TEXCOORD }, "Gaussian Blur" },
 
 	{ SDR_TYPE_POST_PROCESS_BLOOM_COMP, "post-v.sdr", "bloom-comp-f.sdr", 0, 
-		{ "bloomed", "bloom_intensity", "levels" },
+		{ "bloomed" },
 		{ opengl_vert_attrib::POSITION, opengl_vert_attrib::TEXCOORD }, "Bloom Compositing" },
 
 	{ SDR_TYPE_POST_PROCESS_BRIGHTPASS, "post-v.sdr", "brightpass-f.sdr", 0, 
@@ -101,7 +101,7 @@ static opengl_shader_type_t GL_shader_types[] = {
 		{ opengl_vert_attrib::POSITION, opengl_vert_attrib::TEXCOORD }, "Bloom Brightpass" },
 
 	{ SDR_TYPE_POST_PROCESS_FXAA, "fxaa-v.sdr", "fxaa-f.sdr", 0, 
-		{ "tex0", "rt_w", "rt_h" },
+		{ "tex0" },
 		{ opengl_vert_attrib::POSITION }, "FXAA" },
 
 	{ SDR_TYPE_POST_PROCESS_FXAA_PREPASS, "post-v.sdr", "fxaapre-f.sdr", 0, 
@@ -109,16 +109,15 @@ static opengl_shader_type_t GL_shader_types[] = {
 		{ opengl_vert_attrib::POSITION, opengl_vert_attrib::TEXCOORD }, "FXAA Prepass" },
 
 	{ SDR_TYPE_POST_PROCESS_LIGHTSHAFTS, "post-v.sdr", "ls-f.sdr", 0, 
-		{ "scene", "cockpit", "sun_pos", "weight", "intensity", "falloff", "density", "cp_intensity" },
+		{ "scene", "cockpit" },
 		{ opengl_vert_attrib::POSITION, opengl_vert_attrib::TEXCOORD }, "Lightshafts" },
 
 	{ SDR_TYPE_POST_PROCESS_TONEMAPPING, "post-v.sdr", "tonemapping-f.sdr", 0, 
-		{ "tex", "exposure" },
+		{ "tex" },
 		{ opengl_vert_attrib::POSITION, opengl_vert_attrib::TEXCOORD }, "Tonemapping" },
 
 	{ SDR_TYPE_DEFERRED_LIGHTING, "deferred-v.sdr", "deferred-f.sdr", 0, 
-		{ "modelViewMatrix", "projMatrix", "scale", "ColorBuffer", "NormalBuffer", "PositionBuffer", "SpecBuffer", "invScreenWidth", "invScreenHeight", "lightType", "lightRadius",
-		"diffuseLightColor", "specLightColor", "dualCone", "coneDir", "coneAngle", "coneInnerAngle", "specFactor" }, 
+		{ "ColorBuffer", "NormalBuffer", "PositionBuffer", "SpecBuffer" },
 		{ opengl_vert_attrib::POSITION }, "Deferred Lighting" },
 	
 	{ SDR_TYPE_DEFERRED_CLEAR, "deferred-clear-v.sdr", "deferred-clear-f.sdr", 0, 
@@ -126,15 +125,15 @@ static opengl_shader_type_t GL_shader_types[] = {
 		{ opengl_vert_attrib::POSITION }, "Clear Deferred Lighting Buffer" },
 
 	{ SDR_TYPE_VIDEO_PROCESS, "video-v.sdr", "video-f.sdr", 0, 
-		{ "modelViewMatrix", "projMatrix", "ytex", "utex", "vtex" },
+		{ "ytex", "utex", "vtex" },
 		{ opengl_vert_attrib::POSITION, opengl_vert_attrib::TEXCOORD }, "Video Playback" },
 
 	{ SDR_TYPE_PASSTHROUGH_RENDER, "passthrough-v.sdr", "passthrough-f.sdr", 0,
-		{ "modelViewMatrix", "projMatrix", "baseMap", "noTexturing", "alphaTexture", "srgb", "intensity", "color", "alphaThreshold" },
+		{ "baseMap" },
 		{ opengl_vert_attrib::POSITION, opengl_vert_attrib::TEXCOORD, opengl_vert_attrib::COLOR }, "Passthrough" },
 
 	{ SDR_TYPE_SHIELD_DECAL, "shield-impact-v.sdr",	"shield-impact-f.sdr", 0,
-		{ "modelViewMatrix", "projMatrix", "shieldMap", "shieldModelViewMatrix", "shieldProjMatrix", "hitNormal", "srgb", "color" }, 
+		{ "shieldMap" },
 		{ opengl_vert_attrib::POSITION, opengl_vert_attrib::NORMAL }, "Shield Decals" }
 };
 
@@ -144,23 +143,23 @@ static opengl_shader_type_t GL_shader_types[] = {
  */
 static opengl_shader_variant_t GL_shader_variants[] = {
 	{ SDR_TYPE_MODEL, false, true, SDR_FLAG_MODEL_LIGHT, "FLAG_LIGHT",
-		{ "n_lights", "lightPosition", "lightDirection", "lightDiffuseColor", "lightSpecColor", "lightType", "lightAttenuation", "ambientFactor", "diffuseFactor", "emissionFactor", "defaultGloss" }, {  },
+		{  }, {  },
 		"Lighting" },
 
 	{ SDR_TYPE_MODEL, false, true, SDR_FLAG_MODEL_FOG, "FLAG_FOG",
-		{ "fogStart", "fogScale", "fogColor" }, {  },
+		{ }, {  },
 		"Fog Effect" },
 
 	{ SDR_TYPE_MODEL, false, false, SDR_FLAG_MODEL_DIFFUSE_MAP, "FLAG_DIFFUSE_MAP",
-		{ "sBasemap", "desaturate", "desaturate_clr", "blend_alpha", "overrideDiffuse", "diffuseClr" }, {  },
+		{ "sBasemap" }, {  },
 		"Diffuse Mapping" },
 	
 	{ SDR_TYPE_MODEL, false, false, SDR_FLAG_MODEL_GLOW_MAP, "FLAG_GLOW_MAP",
-		{ "sGlowmap", "overrideGlow", "glowClr" }, {  },
+		{ "sGlowmap" }, {  },
 		"Glow Mapping" },
 	
 	{ SDR_TYPE_MODEL, false, false, SDR_FLAG_MODEL_SPEC_MAP, "FLAG_SPEC_MAP",
-		{ "sSpecmap", "overrideSpec", "specClr", "gammaSpec", "alphaGloss" }, {  },
+		{ "sSpecmap" }, {  },
 		"Specular Mapping" },
 	
 	{ SDR_TYPE_MODEL, false, false, SDR_FLAG_MODEL_NORMAL_MAP, "FLAG_NORMAL_MAP",
@@ -172,11 +171,11 @@ static opengl_shader_variant_t GL_shader_variants[] = {
 		"Parallax Mapping" },
 	
 	{ SDR_TYPE_MODEL, false, true, SDR_FLAG_MODEL_ENV_MAP, "FLAG_ENV_MAP",
-		{ "sEnvmap", "envGloss", "envMatrix" }, {  },
+		{ "sEnvmap" }, {  },
 		"Environment Mapping" },
 	
 	{ SDR_TYPE_MODEL, false, false, SDR_FLAG_MODEL_ANIMATED, "FLAG_ANIMATED",
-		{ "sFramebuffer", "effect_num", "anim_timer", "vpwidth", "vpheight" }, {  },
+		{ "sFramebuffer" }, {  },
 		"Animated Effects" },
 	
 	{ SDR_TYPE_MODEL, false, true, SDR_FLAG_MODEL_MISC_MAP, "FLAG_MISC_MAP",
@@ -184,7 +183,7 @@ static opengl_shader_variant_t GL_shader_variants[] = {
 		"Utility mapping" },
 	
 	{ SDR_TYPE_MODEL, false, true, SDR_FLAG_MODEL_TEAMCOLOR, "FLAG_TEAMCOLOR",
-		{ "stripe_color", "base_color", "team_glow_enabled" }, {  },
+		{  }, {  },
 		"Team Colors" },
 	
 	{ SDR_TYPE_MODEL, false, true, SDR_FLAG_MODEL_DEFERRED, "FLAG_DEFERRED",
@@ -192,23 +191,23 @@ static opengl_shader_variant_t GL_shader_variants[] = {
 		"Deferred lighting" },
 	
 	{ SDR_TYPE_MODEL, true, true, SDR_FLAG_MODEL_SHADOW_MAP, "FLAG_SHADOW_MAP",
-		{ "shadow_proj_matrix" }, {  },
+		{  }, {  },
 		"Shadow Mapping" },
 	
 	{ SDR_TYPE_MODEL, false, true, SDR_FLAG_MODEL_SHADOWS, "FLAG_SHADOWS",
-		{ "shadow_map", "shadow_mv_matrix", "shadow_proj_matrix", "veryneardist", "neardist", "middist", "fardist" }, { },
+		{ "shadow_map" }, { },
 		"Shadows" },
 	
 	{ SDR_TYPE_MODEL, false, true, SDR_FLAG_MODEL_THRUSTER, "FLAG_THRUSTER",
-		{ "thruster_scale" }, {  },
+		{ }, {  },
 		"Thruster scaling" },
 	
 	{ SDR_TYPE_MODEL, false, true, SDR_FLAG_MODEL_TRANSFORM, "FLAG_TRANSFORM",
-		{ "transform_tex", "buffer_matrix_offset" }, {  },
+		{ "transform_tex" }, {  },
 		"Submodel Transforms" },
 	
 	{ SDR_TYPE_MODEL, false, true, SDR_FLAG_MODEL_CLIP, "FLAG_CLIP",
-		{ "use_clip_plane", "clip_normal", "clip_position" }, {  },
+		{  }, {  },
 		"Clip Plane" },
 
 	{ SDR_TYPE_MODEL, false, true, SDR_FLAG_MODEL_HDR, "FLAG_HDR",
@@ -220,11 +219,11 @@ static opengl_shader_variant_t GL_shader_variants[] = {
 		"Ambient Occlusion Map" },
 
 	{ SDR_TYPE_MODEL, false, true, SDR_FLAG_MODEL_NORMAL_ALPHA, "FLAG_NORMAL_ALPHA",
-		{ "normalAlphaMinMax" }, { },
+		{ }, { },
 		"Normal Alpha" },
 
 	{ SDR_TYPE_MODEL, false, false, SDR_FLAG_MODEL_NORMAL_EXTRUDE, "FLAG_NORMAL_EXTRUDE",
-		{ "extrudeWidth" }, { },
+		{  }, { },
 		"Normal Extrusion" },
 
 	{ SDR_TYPE_EFFECT_PARTICLE, true, true, SDR_FLAG_PARTICLE_POINT_GEN, "FLAG_EFFECT_GEOMETRY",
@@ -532,11 +531,24 @@ int opengl_compile_shader(shader_type sdr, uint flags)
 		new_shader.program->initAttribute(GL_vertex_attrib_info[attr].name, GL_vertex_attrib_info[attr].default_value);
 	}
 
+	// initialize samplers
+	for (auto& sampler : sdr_info->samplers) {
+		new_shader.program->Samplers.initSampler(sampler);
+	}
+
 	mprintf(("Shader Variant Features:\n"));
 
 	// initialize all uniforms and attributes that are specific to this variant
 	for (auto& variant : GL_shader_variants) {
 		if ( sdr_info->type_id == variant.type_id ) {
+			// Determine if we need to initialize the samplers of the variant
+			// They need to be initialized if that variant uses uniforms or if the flag of that variant is enabled
+			if (!variant.use_define || variant.flag & flags) {
+				for (auto& sampler : variant.samplers) {
+					new_shader.program->Samplers.initSampler(sampler);
+				}
+			}
+
 			if (variant.flag & flags) {
 				for (auto& attr : variant.attributes) {
 					auto& attr_info = GL_vertex_attrib_info[attr];

--- a/code/graphics/opengl/gropenglshader.cpp
+++ b/code/graphics/opengl/gropenglshader.cpp
@@ -214,7 +214,7 @@ static opengl_shader_variant_t GL_shader_variants[] = {
 		{ }, {  },
 		"High Dynamic Range" },
 
-	{ SDR_TYPE_MODEL, false, true, SDR_FLAG_MODEL_AMBIENT_MAP, "FLAG_AMBIENT_MAP",
+	{ SDR_TYPE_MODEL, false, false, SDR_FLAG_MODEL_AMBIENT_MAP, "FLAG_AMBIENT_MAP",
 		{ "sAmbientmap" }, {  },
 		"Ambient Occlusion Map" },
 

--- a/code/graphics/opengl/gropenglshader.cpp
+++ b/code/graphics/opengl/gropenglshader.cpp
@@ -175,7 +175,7 @@ static opengl_shader_variant_t GL_shader_variants[] = {
 		{ "sEnvmap", "envGloss", "envMatrix" }, {  },
 		"Environment Mapping" },
 	
-	{ SDR_TYPE_MODEL, false, true, SDR_FLAG_MODEL_ANIMATED, "FLAG_ANIMATED",
+	{ SDR_TYPE_MODEL, false, false, SDR_FLAG_MODEL_ANIMATED, "FLAG_ANIMATED",
 		{ "sFramebuffer", "effect_num", "anim_timer", "vpwidth", "vpheight" }, {  },
 		"Animated Effects" },
 	

--- a/code/graphics/opengl/gropenglshader.cpp
+++ b/code/graphics/opengl/gropenglshader.cpp
@@ -151,8 +151,8 @@ static opengl_shader_variant_t GL_shader_variants[] = {
 		{ "fogStart", "fogScale", "fogColor" }, {  },
 		"Fog Effect" },
 
-	{ SDR_TYPE_MODEL, false, true, SDR_FLAG_MODEL_DIFFUSE_MAP, "FLAG_DIFFUSE_MAP", 
-		{ "sBasemap", "desaturate", "blend_alpha", "overrideDiffuse", "diffuseClr" }, {  },
+	{ SDR_TYPE_MODEL, false, false, SDR_FLAG_MODEL_DIFFUSE_MAP, "FLAG_DIFFUSE_MAP",
+		{ "sBasemap", "desaturate", "desaturate_clr", "blend_alpha", "overrideDiffuse", "diffuseClr" }, {  },
 		"Diffuse Mapping" },
 	
 	{ SDR_TYPE_MODEL, false, true, SDR_FLAG_MODEL_GLOW_MAP, "FLAG_GLOW_MAP",

--- a/code/graphics/opengl/gropenglshader.cpp
+++ b/code/graphics/opengl/gropenglshader.cpp
@@ -223,7 +223,7 @@ static opengl_shader_variant_t GL_shader_variants[] = {
 		{ "normalAlphaMinMax" }, { },
 		"Normal Alpha" },
 
-	{ SDR_TYPE_MODEL, false, true, SDR_FLAG_MODEL_NORMAL_EXTRUDE, "FLAG_NORMAL_EXTRUDE",
+	{ SDR_TYPE_MODEL, false, false, SDR_FLAG_MODEL_NORMAL_EXTRUDE, "FLAG_NORMAL_EXTRUDE",
 		{ "extrudeWidth" }, { },
 		"Normal Extrusion" },
 

--- a/code/graphics/opengl/gropenglshader.cpp
+++ b/code/graphics/opengl/gropenglshader.cpp
@@ -167,7 +167,7 @@ static opengl_shader_variant_t GL_shader_variants[] = {
 		{ "sNormalmap" }, {  },
 		"Normal Mapping" },
 	
-	{ SDR_TYPE_MODEL, false, true, SDR_FLAG_MODEL_HEIGHT_MAP, "FLAG_HEIGHT_MAP",
+	{ SDR_TYPE_MODEL, false, false, SDR_FLAG_MODEL_HEIGHT_MAP, "FLAG_HEIGHT_MAP",
 		{ "sHeightmap" }, {  },
 		"Parallax Mapping" },
 	

--- a/code/graphics/opengl/gropenglshader.cpp
+++ b/code/graphics/opengl/gropenglshader.cpp
@@ -198,7 +198,7 @@ static opengl_shader_variant_t GL_shader_variants[] = {
 		{ "shadow_map" }, { },
 		"Shadows" },
 	
-	{ SDR_TYPE_MODEL, false, true, SDR_FLAG_MODEL_THRUSTER, "FLAG_THRUSTER",
+	{ SDR_TYPE_MODEL, false, false, SDR_FLAG_MODEL_THRUSTER, "FLAG_THRUSTER",
 		{ }, {  },
 		"Thruster scaling" },
 	

--- a/code/graphics/opengl/gropenglshader.h
+++ b/code/graphics/opengl/gropenglshader.h
@@ -59,7 +59,7 @@ struct opengl_shader_type_t {
 	const char *frag;
 	const char *geo;
 
-	SCP_vector<const char*> uniforms;
+	SCP_vector<const char*> samplers;
 
 	SCP_vector<opengl_vert_attrib::attrib_id> attributes;
 
@@ -75,45 +75,12 @@ struct opengl_shader_variant_t {
 	int flag;
 	SCP_string flag_text;
 
-	SCP_vector<const char*> uniforms;
+	SCP_vector<const char*> samplers;
 
 	SCP_vector<opengl_vert_attrib::attrib_id> attributes;
 
 	const char* description;
 };
-
-struct opengl_shader_file_t {
-	const char *vert;
-	const char *frag;
-	const char *geo;
-
-	int flags;
-
-	SCP_vector<const char*> uniforms;
-
-	SCP_vector<const char*> attributes;
-
-	const char* description;
-};
-
-struct opengl_shader_uniform_reference_t {
-	unsigned int flag;
-
-	SCP_vector<const char*> uniforms;
-
-	SCP_vector<const char*> attributes;
-
-	SCP_vector<const char*> uniform_blocks;
-
-	const char* name;
-};
-
-typedef struct opengl_shader_uniform_t {
-	SCP_string text_id;
-	GLint location;
-
-	opengl_shader_uniform_t() : location(-1) {}
-} opengl_shader_uniform_t;
 
 typedef struct opengl_shader_t {
 	opengl::ShaderProgram* program;

--- a/code/graphics/opengl/gropenglshader.h
+++ b/code/graphics/opengl/gropenglshader.h
@@ -70,6 +70,7 @@ struct opengl_shader_variant_t {
 	shader_type type_id;
 
 	bool use_geometry_sdr;
+	bool use_define;
 
 	int flag;
 	SCP_string flag_text;
@@ -115,32 +116,15 @@ typedef struct opengl_shader_uniform_t {
 } opengl_shader_uniform_t;
 
 typedef struct opengl_shader_t {
-	std::unique_ptr<opengl::ShaderProgram> program;
+	opengl::ShaderProgram* program;
 
 	shader_type shader;
 	unsigned int flags;
 	int flags2;
 
-	opengl_shader_t() : shader(SDR_TYPE_NONE), flags(0), flags2(0)
+	opengl_shader_t() : program(nullptr), shader(SDR_TYPE_NONE), flags(0), flags2(0)
 	{
 	}
-
-	opengl_shader_t(opengl_shader_t&& other) {
-		*this = std::move(other);
-	}
-	opengl_shader_t& operator=(opengl_shader_t&& other) {
-		// VS2013 doesn't support implicit move constructors so we need to explicitly declare it
-		shader = other.shader;
-		flags = other.flags;
-		flags2 = other.flags2;
-
-		program = std::move(other.program);
-
-		return *this;
-	}
-
-	opengl_shader_t(const opengl_shader_t&) = delete;
-	opengl_shader_t& operator=(const opengl_shader_t&) = delete;
 } opengl_shader_t;
 
 extern SCP_vector<opengl_shader_t> GL_shader;

--- a/code/graphics/opengl/gropenglshader.h
+++ b/code/graphics/opengl/gropenglshader.h
@@ -118,6 +118,8 @@ typedef struct opengl_shader_uniform_t {
 typedef struct opengl_shader_t {
 	opengl::ShaderProgram* program;
 
+	SCP_vector<std::pair<SCP_string, bool>> variant_uniforms;
+
 	shader_type shader;
 	unsigned int flags;
 	int flags2;

--- a/code/graphics/opengl/gropengltnl.cpp
+++ b/code/graphics/opengl/gropengltnl.cpp
@@ -918,7 +918,6 @@ void opengl_tnl_set_material(material* material_info, bool set_base_map)
 void opengl_tnl_set_model_material(model_material *material_info)
 {
 	float u_scale, v_scale;
-	int render_pass = 0;
 
 	opengl_tnl_set_material(material_info, false);
 
@@ -929,6 +928,10 @@ void opengl_tnl_set_model_material(model_material *material_info)
 	gr_opengl_set_center_alpha(material_info->get_center_alpha());
 
 	Assert( Current_shader->shader == SDR_TYPE_MODEL );
+
+	// Use the sampler tracker to make sure the bound samplers are right
+	Current_shader->program->Samplers.reset();
+	int render_pass = 1;
 
 	GL_state.Texture.SetShaderMode(GL_TRUE);
 	
@@ -999,7 +1002,7 @@ void opengl_tnl_set_model_material(model_material *material_info)
 	}
 
 	if ( Current_shader->flags & SDR_FLAG_MODEL_DIFFUSE_MAP ) {
-		Current_shader->program->Uniforms.setUniformi("sBasemap", render_pass);
+		Current_shader->program->Samplers.bindSampler("sBasemap", render_pass);
 
 		if ( material_info->is_desaturated() ) {
 			Current_shader->program->Uniforms.setUniformi("desaturate", 1);
@@ -1036,7 +1039,7 @@ void opengl_tnl_set_model_material(model_material *material_info)
 	}
 
 	if ( Current_shader->flags & SDR_FLAG_MODEL_GLOW_MAP ) {
-		Current_shader->program->Uniforms.setUniformi("sGlowmap", render_pass);
+		Current_shader->program->Samplers.bindSampler("sGlowmap", render_pass);
 
 		if ( Glowmap_color_override_set ) {
 			Current_shader->program->Uniforms.setUniformi("overrideGlow", 1);
@@ -1051,7 +1054,7 @@ void opengl_tnl_set_model_material(model_material *material_info)
 	}
 
 	if ( Current_shader->flags & SDR_FLAG_MODEL_SPEC_MAP ) {
-		Current_shader->program->Uniforms.setUniformi("sSpecmap", render_pass);
+		Current_shader->program->Samplers.bindSampler("sSpecmap", render_pass);
 
 		if ( Specmap_color_override_set ) {
 			Current_shader->program->Uniforms.setUniformi("overrideSpec", 1);
@@ -1093,7 +1096,7 @@ void opengl_tnl_set_model_material(model_material *material_info)
 			}
 
 			Current_shader->program->Uniforms.setUniformMatrix4f("envMatrix", texture_mat);
-			Current_shader->program->Uniforms.setUniformi("sEnvmap", render_pass);
+			Current_shader->program->Samplers.bindSampler("sEnvmap", render_pass);
 
 			gr_opengl_tcache_set(ENVMAP, TCACHE_TYPE_CUBEMAP, &u_scale, &v_scale, render_pass);
 
@@ -1102,7 +1105,7 @@ void opengl_tnl_set_model_material(model_material *material_info)
 	}
 
 	if ( Current_shader->flags & SDR_FLAG_MODEL_NORMAL_MAP ) {
-		Current_shader->program->Uniforms.setUniformi("sNormalmap", render_pass);
+		Current_shader->program->Samplers.bindSampler("sNormalmap", render_pass);
 
 		gr_opengl_tcache_set(material_info->get_texture_map(TM_NORMAL_TYPE), TCACHE_TYPE_NORMAL, &u_scale, &v_scale, render_pass);
 
@@ -1110,7 +1113,7 @@ void opengl_tnl_set_model_material(model_material *material_info)
 	}
 
 	if ( Current_shader->flags & SDR_FLAG_MODEL_HEIGHT_MAP ) {
-		Current_shader->program->Uniforms.setUniformi("sHeightmap", render_pass);
+		Current_shader->program->Samplers.bindSampler("sHeightmap", render_pass);
 
 		gr_opengl_tcache_set(material_info->get_texture_map(TM_HEIGHT_TYPE), TCACHE_TYPE_NORMAL, &u_scale, &v_scale, render_pass);
 
@@ -1118,7 +1121,7 @@ void opengl_tnl_set_model_material(model_material *material_info)
 	}
 
 	if ( Current_shader->flags & SDR_FLAG_MODEL_MISC_MAP ) {
-		Current_shader->program->Uniforms.setUniformi("sMiscmap", render_pass);
+		Current_shader->program->Samplers.bindSampler("sMiscmap", render_pass);
 
 		gr_opengl_tcache_set(material_info->get_texture_map(TM_MISC_TYPE), TCACHE_TYPE_NORMAL, &u_scale, &v_scale, render_pass);
 
@@ -1132,7 +1135,7 @@ void opengl_tnl_set_model_material(model_material *material_info)
 		Current_shader->program->Uniforms.setUniformf("neardist", Shadow_cascade_distances[1]);
 		Current_shader->program->Uniforms.setUniformf("middist", Shadow_cascade_distances[2]);
 		Current_shader->program->Uniforms.setUniformf("fardist", Shadow_cascade_distances[3]);
-		Current_shader->program->Uniforms.setUniformi("shadow_map", render_pass);
+		Current_shader->program->Samplers.bindSampler("shadow_map", render_pass);
 
 		GL_state.Texture.SetActiveUnit(render_pass);
 		GL_state.Texture.SetTarget(GL_TEXTURE_2D_ARRAY);
@@ -1146,7 +1149,7 @@ void opengl_tnl_set_model_material(model_material *material_info)
 	}
 
 	if ( Current_shader->flags & SDR_FLAG_MODEL_ANIMATED ) {
-		Current_shader->program->Uniforms.setUniformi("sFramebuffer", render_pass);
+		Current_shader->program->Samplers.bindSampler("sFramebuffer", render_pass);
 
 		GL_state.Texture.SetActiveUnit(render_pass);
 		GL_state.Texture.SetTarget(GL_TEXTURE_2D);
@@ -1162,7 +1165,7 @@ void opengl_tnl_set_model_material(model_material *material_info)
 	}
 
 	if ( Current_shader->flags & SDR_FLAG_MODEL_TRANSFORM ) {
-		Current_shader->program->Uniforms.setUniformi("transform_tex", render_pass);
+		Current_shader->program->Samplers.bindSampler("transform_tex", render_pass);
 		Current_shader->program->Uniforms.setUniformi("buffer_matrix_offset", (int)GL_transform_buffer_offset);
 		
 		GL_state.Texture.SetActiveUnit(render_pass);
@@ -1214,6 +1217,8 @@ void opengl_tnl_set_model_material(model_material *material_info)
 	if ( Current_shader->flags & SDR_FLAG_MODEL_NORMAL_EXTRUDE ) {
 		Current_shader->program->Uniforms.setUniformf("extrudeWidth", material_info->get_normal_extrude_width());
 	}
+
+	Current_shader->program->Samplers.flush();
 
 	if ( Deferred_lighting ) {
 		// don't blend if we're drawing to the g-buffers


### PR DESCRIPTION
This makes certain shader variant flags use boolean uniforms instead of compile time flags which can improve performance since switching shaders is more expensive than setting a uniform. Here is some performance data I collected:
![figure_1](https://cloud.githubusercontent.com/assets/1013983/18210758/625fb338-713a-11e6-98ac-aae4a0282090.png)

There are some changes but nothing major.