### PR TITLE
Replace texture2D with texture in shaders

### DIFF
--- a/code/def_files/effect-f.sdr
+++ b/code/def_files/effect-f.sdr
@@ -5,6 +5,6 @@ uniform sampler2D baseMap;
 uniform int textured;
 void main()
 {
-	vec4 fragmentColor = mix(fragColor, texture2D(baseMap, fragTexCoord.xy)*fragColor.a, (float)textured);
+	vec4 fragmentColor = mix(fragColor, texture(baseMap, fragTexCoord.xy)*fragColor.a, (float)textured);
 	fragOut0 = fragmentColor;
 }

--- a/code/def_files/fxaa-f.sdr
+++ b/code/def_files/fxaa-f.sdr
@@ -163,11 +163,11 @@
 	#define FxaaSat(x) saturate(x)
 #endif
 #if (FXAA_GLSL_120 == 1)
-	#define FxaaTexTop(t, p) texture2DLod(t, p, 0.0)
+	#define FxaaTexTop(t, p) textureLod(t, p, 0.0)
 	#if (FXAA_FAST_PIXEL_OFFSET == 1)
-		#define FxaaTexOff(t, p, o, r) texture2DLodOffset(t, p, 0.0, o)
+		#define FxaaTexOff(t, p, o, r) textureLodOffset(t, p, 0.0, o)
 	#else
-		#define FxaaTexOff(t, p, o, r) texture2DLod(t, p + (o * r), 0.0)
+		#define FxaaTexOff(t, p, o, r) textureLod(t, p + (o * r), 0.0)
 	#endif
 	#if (FXAA_GATHER4_ALPHA == 1)
 		#define FxaaTexAlpha4(t, p) textureGather(t, p, 3)

--- a/code/def_files/ls-f.sdr
+++ b/code/def_files/ls-f.sdr
@@ -15,14 +15,14 @@ void main()
 	step *= 1.0 / float(SAMPLE_NUM) * density;
 	float decay = 1.0;
 	vec4 sum = vec4(0.0);
-	vec4 mask = texture2D(cockpit, fragTexCoord.st);
+	vec4 mask = texture(cockpit, fragTexCoord.st);
 	if (mask.r < 1.0) {
 		fragOut0 = vec4(cp_intensity);
 		return;
 	}
 	for(int i=0; i < SAMPLE_NUM ; i++) {
 		pos.st -= step;
-		vec4 tex_sample = texture2D(scene, pos);
+		vec4 tex_sample = texture(scene, pos);
 		if (tex_sample.r == 1.0)
 			sum += decay * weight;
 		decay *= falloff;

--- a/code/def_files/main-f.sdr
+++ b/code/def_files/main-f.sdr
@@ -310,7 +310,7 @@ void main()
 #ifdef	FLAG_AMBIENT_MAP
 	// red channel is ambient occlusion factor which only affects ambient lighting.
 	// green is cavity occlusion factor which only affects diffuse and specular lighting.
-	aoFactors = texture2D(sAmbientmap, texCoord).xy;
+	aoFactors = texture(sAmbientmap, texCoord).xy;
 #endif
 	vec3 unitNormal = normalize(fragNormal);
 	vec3 normal = unitNormal;
@@ -354,7 +354,7 @@ void main()
 
    specData = vec4(baseColor.rgb * SPEC_FACTOR_NO_SPEC_MAP, glossData);
 #ifdef FLAG_SPEC_MAP
-   vec4 specColour = texture2D(sSpecmap, texCoord);
+   vec4 specColour = texture(sSpecmap, texCoord);
 	if(alphaGloss) glossData = specColour.a;
 	if(overrideSpec) specColour.rgb = specClr;
  #ifdef FLAG_HDR
@@ -400,7 +400,7 @@ void main()
 	baseColor.rgb += envColour.rgb * FresnelLazarovEnv(specColour.rgb, eyeDir, normal, glossData);
 #endif
 #ifdef FLAG_GLOW_MAP
-	vec3 glowColor = texture2D(sGlowmap, texCoord).rgb;
+	vec3 glowColor = texture(sGlowmap, texCoord).rgb;
 	if(overrideGlow) glowColor = glowClr;
  #ifdef FLAG_HDR
 	glowColor = pow(glowColor, vec3(SRGB_GAMMA)) * 3.0f;

--- a/code/def_files/passthrough-f.sdr
+++ b/code/def_files/passthrough-f.sdr
@@ -10,7 +10,7 @@ uniform float alphaThreshold;
 #define SRGB_GAMMA 2.2
 void main()
 {
-	vec4 baseColor = texture2D(baseMap, fragTexCoord.xy);
+	vec4 baseColor = texture(baseMap, fragTexCoord.xy);
 	if(alphaThreshold > baseColor.a) discard;
 	baseColor.rgb = (srgb == 1) ? pow(baseColor.rgb, vec3(SRGB_GAMMA)) : baseColor.rgb;
 	vec4 blendColor = (srgb == 1) ? vec4(pow(fragColor.rgb, vec3(SRGB_GAMMA)), fragColor.a) : fragColor;

--- a/code/def_files/shield-impact-f.sdr
+++ b/code/def_files/shield-impact-f.sdr
@@ -10,7 +10,7 @@ void main()
 {
 	if(fragNormOffset < 0.0) discard;
 	if(fragImpactUV.x < 0.0 || fragImpactUV.x > 1.0 || fragImpactUV.y < 0.0 || fragImpactUV.y > 1.0) discard;
-	vec4 shieldColor = texture2D(shieldMap, fragImpactUV.xy);
+	vec4 shieldColor = texture(shieldMap, fragImpactUV.xy);
 	shieldColor.rgb = (srgb == 1) ? pow(shieldColor.rgb, vec3(SRGB_GAMMA)) * EMISSIVE_GAIN : shieldColor.rgb;
 	vec4 blendColor = color;
 	blendColor.rgb = (srgb == 1) ? pow(blendColor.rgb, vec3(SRGB_GAMMA)) * EMISSIVE_GAIN : blendColor.rgb;


### PR DESCRIPTION
texture2D has been deprecated for some time and Mac also doesn't support
it anymore. The 1.50 GLSL specification says that texture is the correct
function for texel lookup so I used that.