### PR TITLE
minor tweaks and adjustments to AI goal code

### DIFF
--- a/code/ai/aigoals.cpp
+++ b/code/ai/aigoals.cpp
@@ -59,6 +59,7 @@ int	Ai_goal_signature;
 int	Num_ai_dock_names = 0;
 char	Ai_dock_names[MAX_AI_DOCK_NAMES][NAME_LENGTH];
 
+// Used in objecttypes.tbl to define custom ship types
 ai_goal_list Ai_goal_names[] =
 {
 	{ "Attack ship",			AI_GOAL_CHASE,			0 },
@@ -96,34 +97,33 @@ int Num_ai_goals = sizeof(Ai_goal_names) / sizeof(ai_goal_list);
 const char *Ai_goal_text(int goal)
 {
 	switch(goal)	{
-	case 1:
+	case AI_GOAL_CHASE:
+	case AI_GOAL_CHASE_WING:
 		return XSTR( "attack ", 474);
-	case 2:
+	case AI_GOAL_DOCK:
 		return XSTR( "dock ", 475);
-	case 3:
+	case AI_GOAL_WAYPOINTS:
+	case AI_GOAL_WAYPOINTS_ONCE:
 		return XSTR( "waypoints", 476);
-	case 4:
-		return XSTR( "waypoints", 476);
-	case 6:
+	case AI_GOAL_DESTROY_SUBSYSTEM:
 		return XSTR( "destroy ", 477);
-	case 7:
+	case AI_GOAL_FORM_ON_WING:
 		return XSTR( "form on ", 478);
-	case 8:
+	case AI_GOAL_UNDOCK:
 		return XSTR( "undock ", 479);
-	case 9:
-		return XSTR( "attack ", 474);
-	case 10:
+	case AI_GOAL_GUARD:
+	case AI_GOAL_GUARD_WING:
 		return XSTR( "guard ", 480);
-	case 11:
+	case AI_GOAL_DISABLE_SHIP:
 		return XSTR( "disable ", 481);
-	case 12:
+	case AI_GOAL_DISARM_SHIP:
 		return XSTR( "disarm ", 482);
-	case 15:
-		return XSTR( "guard ", 480);
-	case 16:
+	case AI_GOAL_EVADE_SHIP:
 		return XSTR( "evade ", 483);
-	case 19:
+	case AI_GOAL_REARM_REPAIR:
 		return XSTR( "rearm ", 484);
+	case AI_GOAL_FLY_TO_SHIP:
+		return XSTR( "rendezvous with ", -1);
 	}
 
 	// Avoid compiler warning
@@ -934,9 +934,9 @@ void ai_add_goal_sub_sexp( int sexp, int type, ai_goal *aigp, char *actor_name )
 		break;
 
 	case OP_AI_CHASE:
+	case OP_AI_CHASE_WING:
 	case OP_AI_GUARD:
 	case OP_AI_GUARD_WING:
-	case OP_AI_CHASE_WING:
 	case OP_AI_EVADE_SHIP:
 	case OP_AI_STAY_NEAR_SHIP:
 	case OP_AI_IGNORE:
@@ -2347,15 +2347,22 @@ void ai_update_goal_references(ai_goal *goals, int type, const char *old_name, c
 						flag = 1;
 				}
 				break;
+
+			default:
+				Warning(LOCATION, "unhandled FRED reference type %d in ai_update_goal_references", type);
+				break;
 		}
 
 		if (flag)  // is this a valid goal to parse for this conversion?
-			if (!stricmp(goals[i].target_name, old_name)) {
+		{
+			if (!stricmp(goals[i].target_name, old_name))
+			{
 				if (*new_name == '<')  // target was just deleted..
 					goals[i].ai_mode = AI_GOAL_NONE;
 				else
 					goals[i].target_name = ai_get_goal_target_name(new_name, &dummy);
 			}
+		}
 	}
 }
 

--- a/code/ai/aigoals.h
+++ b/code/ai/aigoals.h
@@ -26,6 +26,7 @@ struct ai_goal;
 // Fred.  If the goal you add doesn't have a target (such as chase_any), then you don't have
 // to worry about doing this.  Also add it to list in Fred\Management.cpp, and let Hoffoss know!
 // WMC - Oh and add them to Ai_goal_names plz. TY! :)
+// Goober5000 - And Ai_goal_text, if appropriate
 #define AI_GOAL_CHASE					(1<<1)	// 0x00000002
 #define AI_GOAL_DOCK					(1<<2)	// 0x00000004	// used for undocking as well
 #define AI_GOAL_WAYPOINTS				(1<<3)	// 0x00000008
@@ -51,8 +52,9 @@ struct ai_goal;
 // resume regular goals
 #define AI_GOAL_STAY_STILL				(1<<20)	// 0x00100000
 #define AI_GOAL_PLAY_DEAD				(1<<21)	// 0x00200000
-#define AI_GOAL_CHASE_WEAPON			(1<<22)	// 0x00400000
 
+// added by SCP
+#define AI_GOAL_CHASE_WEAPON			(1<<22)	// 0x00400000
 #define AI_GOAL_FLY_TO_SHIP				(1<<23) // 0x00800000
 #define AI_GOAL_IGNORE_NEW				(1<<24)	// 0x01000000
 

--- a/code/ai/aigoals.h
+++ b/code/ai/aigoals.h
@@ -26,7 +26,7 @@ struct ai_goal;
 // Fred.  If the goal you add doesn't have a target (such as chase_any), then you don't have
 // to worry about doing this.  Also add it to list in Fred\Management.cpp, and let Hoffoss know!
 // WMC - Oh and add them to Ai_goal_names plz. TY! :)
-// Goober5000 - And Ai_goal_text, if appropriate
+// Goober5000 - As well as Ai_goal_text and Ai_goal_list, if appropriate
 #define AI_GOAL_CHASE					(1<<1)	// 0x00000002
 #define AI_GOAL_DOCK					(1<<2)	// 0x00000004	// used for undocking as well
 #define AI_GOAL_WAYPOINTS				(1<<3)	// 0x00000008

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -26000,6 +26000,8 @@ int query_operator_return_type(int op)
 			return OPR_NULL;
 
 		case OP_AI_CHASE:
+		case OP_AI_CHASE_WING:
+		case OP_AI_CHASE_ANY:
 		case OP_AI_DOCK:
 		case OP_AI_UNDOCK:
 		case OP_AI_WARP:						// this particular operator is obsolete
@@ -26007,12 +26009,10 @@ int query_operator_return_type(int op)
 		case OP_AI_WAYPOINTS:
 		case OP_AI_WAYPOINTS_ONCE:
 		case OP_AI_DESTROY_SUBSYS:
-		case OP_AI_CHASE_WING:
 		case OP_AI_DISABLE_SHIP:
 		case OP_AI_DISARM_SHIP:
 		case OP_AI_GUARD:
 		case OP_AI_GUARD_WING:
-		case OP_AI_CHASE_ANY:
 		case OP_AI_EVADE_SHIP:
 		case OP_AI_STAY_NEAR_SHIP:
 		case OP_AI_KEEP_SAFE_DISTANCE:
@@ -26728,9 +26728,23 @@ int query_operator_argument_type(int op, int argnum)
 			else
 				return OPF_BOOL;
 
+		case OP_AI_CHASE_WING:
+			if (argnum == 0)
+				return OPF_WING;
+			else if (argnum == 1)
+				return OPF_POSITIVE;
+			else
+				return OPF_BOOL;
+
 		case OP_AI_GUARD:
 			if (!argnum)
 				return OPF_SHIP_WING;
+			else
+				return OPF_POSITIVE;
+
+		case OP_AI_GUARD_WING:
+			if (!argnum)
+				return OPF_WING;
 			else
 				return OPF_POSITIVE;
 
@@ -26752,20 +26766,6 @@ int query_operator_argument_type(int op, int argnum)
 				return OPF_POSITIVE;
 			else
 				return OPF_SHIP;
-
-		case OP_AI_CHASE_WING:
-			if (argnum == 0)
-				return OPF_WING;
-			else if (argnum == 1)
-				return OPF_POSITIVE;
-			else
-				return OPF_BOOL;
-
-		case OP_AI_GUARD_WING:
-			if (!argnum)
-				return OPF_WING;
-			else
-				return OPF_POSITIVE;
 
 		case OP_AI_DESTROY_SUBSYS:
 			if (!argnum)
@@ -31318,6 +31318,20 @@ sexp_help_struct Sexp_help[] = {
 		"\t3 (optional):\tWhether to attack the target even if it is on the same team; defaults to false."
 	},
 
+	{ OP_AI_CHASE_WING, "Ai-chase wing (Ship goal)\r\n"
+		"\tCauses the specified ship to chase and attack the specified target.\r\n\r\n"
+		"Takes 2 or 3 arguments...\r\n"
+		"\t1:\tName of wing to chase.\r\n"
+		"\t2:\tGoal priority (number between 0 and 200. Player orders have a priority of 90-100).\r\n"
+		"\t3 (optional):\tWhether to attack the target even if it is on the same team; defaults to false."
+	},
+
+	{ OP_AI_CHASE_ANY, "Ai-chase-any (Ship goal)\r\n"
+		"\tCauses the specified ship to chase and attack any ship on the opposite team.\r\n\r\n"
+		"Takes 1 argument...\r\n"
+		"\t1:\tGoal priority (number between 0 and 200. Player orders have a priority of 90-100)."
+	},
+
 	{ OP_AI_DOCK, "Ai-dock (Ship goal)\r\n"
 		"\tCauses one ship to dock with another ship.\r\n\r\n"
 		"Takes 4 arguments...\r\n"
@@ -31361,14 +31375,6 @@ sexp_help_struct Sexp_help[] = {
 		"\t4 (optional):\tWhether to attack the target even if it is on the same team; defaults to false."
 	},
 
-	{ OP_AI_CHASE_WING, "Ai-chase wing (Ship goal)\r\n"
-		"\tCauses the specified ship to chase and attack the specified target.\r\n\r\n"
-		"Takes 2 or 3 arguments...\r\n"
-		"\t1:\tName of wing to chase.\r\n"
-		"\t2:\tGoal priority (number between 0 and 200. Player orders have a priority of 90-100).\r\n"
-		"\t3 (optional):\tWhether to attack the target even if it is on the same team; defaults to false."
-	},
-
 	{ OP_AI_DISABLE_SHIP, "Ai-disable-ship (Ship/wing goal)\r\n"
 		"\tThis AI goal causes a ship/wing to destroy all of the engine subsystems on "
 		"the specified ship.  This goal is different than ai-destroy-subsystem since a ship "
@@ -31402,11 +31408,6 @@ sexp_help_struct Sexp_help[] = {
 		"Takes 2 arguments...\r\n"
 		"\t1:\tName of ship to guard.\r\n"
 		"\t2:\tGoal priority (number between 0 and 200. Player orders have a priority of 90-100)." },
-
-	{ OP_AI_CHASE_ANY, "Ai-chase-any (Ship goal)\r\n"
-		"\tCauses the specified ship to chase and attack any ship on the opposite team.\r\n\r\n"
-		"Takes 1 argument...\r\n"
-		"\t1:\tGoal priority (number between 0 and 200. Player orders have a priority of 90-100)." },
 
 	{ OP_AI_GUARD_WING, "Ai-guard wing (Ship goal)\r\n"
 		"\tCauses the specified ship to guard a wing of ships from other ships not on the "

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -15000,7 +15000,7 @@ char *ship_return_orders(char *outbuf, ship *sp)
 	ai_info	*aip;
 	ai_goal	*aigp;
 	const char		*order_text;
-	char ship_name[NAME_LENGTH];
+	char target_name[NAME_LENGTH];
 	
 	Assert(sp->ai_index >= 0);
 	aip = &Ai_info[sp->ai_index];
@@ -15011,29 +15011,29 @@ char *ship_return_orders(char *outbuf, ship *sp)
 	if ( aigp->ai_mode < 0 ) 
 		return NULL;
 
-	order_text = Ai_goal_text(bitmask_2_bitnum(aigp->ai_mode));
+	order_text = Ai_goal_text(aigp->ai_mode);
 	if ( order_text == NULL )
 		return NULL;
 
 	strcpy(outbuf, order_text);
 
 	if ( aigp->target_name ) {
-		strcpy_s(ship_name, aigp->target_name);
-		end_string_at_first_hash_symbol(ship_name);
+		strcpy_s(target_name, aigp->target_name);
+		end_string_at_first_hash_symbol(target_name);
 	}
-	switch (aigp->ai_mode ) {
+	switch ( aigp->ai_mode ) {
 
 		case AI_GOAL_FORM_ON_WING:
 		case AI_GOAL_GUARD_WING:
 		case AI_GOAL_CHASE_WING:
 			if ( aigp->target_name ) {
-				strcat(outbuf, ship_name);
-				strcat(outbuf, XSTR( "'s Wing", 494));
+				strcat(outbuf, target_name);
+				strcat(outbuf, XSTR("'s wing", 494));
 			} else {
-				strcpy(outbuf, XSTR( "no orders", 495));
+				strcpy(outbuf, XSTR("no orders", 495));
 			}
 			break;
-	
+
 		case AI_GOAL_CHASE:
 		case AI_GOAL_DOCK:
 		case AI_GOAL_UNDOCK:
@@ -15042,8 +15042,9 @@ char *ship_return_orders(char *outbuf, ship *sp)
 		case AI_GOAL_DISARM_SHIP:
 		case AI_GOAL_EVADE_SHIP:
 		case AI_GOAL_REARM_REPAIR:
-			if ( aigp->target_name ) {
-				strcat(outbuf, ship_name);
+		case AI_GOAL_FLY_TO_SHIP:
+			if (aigp->target_name) {
+				strcat(outbuf, target_name);
 			} else {
 				strcpy(outbuf, XSTR( "no orders", 495));
 			}
@@ -15054,9 +15055,9 @@ char *ship_return_orders(char *outbuf, ship *sp)
 				char subsys_name[NAME_LENGTH];
 				strcpy_s(subsys_name, aip->targeted_subsys->system_info->subobj_name);
 				hud_targetbox_truncate_subsys_name(subsys_name);
-				sprintf(outbuf, XSTR( "atk %s %s", 496), ship_name, subsys_name);
+				sprintf(outbuf, XSTR("atk %s %s", 496), target_name, subsys_name);
 			} else {
-				strcpy(outbuf, XSTR( "no orders", 495) );
+				strcpy(outbuf, XSTR("no orders", 495));
 			}
 			break;
 		}
@@ -15065,11 +15066,6 @@ char *ship_return_orders(char *outbuf, ship *sp)
 		case AI_GOAL_WAYPOINTS_ONCE:
 			// don't do anything, all info is in order_text
 			break;
-
-		case AI_GOAL_FLY_TO_SHIP:
-			strcpy(outbuf, "Flying to ship");
-			break;
-
 
 		default:
 			return NULL;

--- a/fred2/management.cpp
+++ b/fred2/management.cpp
@@ -107,19 +107,21 @@ bool Show_iff[MAX_IFFS];
 
 CCriticalSection CS_cur_object_index;
 
-// Used in the FRED drop-down menu
+// Used in the FRED drop-down menu and in error_check_initial_orders
+// NOTE: Certain goals (Form On Wing, Rearm, Chase Weapon, Fly To Ship) aren't listed here.  This may or may not be intentional,
+// but if they are added in the future, it will be necessary to verify correct functionality in the various FRED dialog functions.
 ai_goal_list Ai_goal_list[] = {
 	{ "Waypoints",				AI_GOAL_WAYPOINTS,			0 },
 	{ "Waypoints once",			AI_GOAL_WAYPOINTS_ONCE,		0 },
-	{ "Warp",					AI_GOAL_WARP,				0 },
-	{ "Destroy subsystem",		AI_GOAL_DESTROY_SUBSYSTEM,	0 },
 	{ "Attack",					AI_GOAL_CHASE | AI_GOAL_CHASE_WING,	0 },
-	{ "Dock",					AI_GOAL_DOCK,				0 },
-	{ "Undock",					AI_GOAL_UNDOCK,				0 },
-	{ "Guard",					AI_GOAL_GUARD | AI_GOAL_GUARD_WING,	0 },
 	{ "Attack any ship",		AI_GOAL_CHASE_ANY,			0 },
+	{ "Guard",					AI_GOAL_GUARD | AI_GOAL_GUARD_WING,	0 },
 	{ "Disable ship",			AI_GOAL_DISABLE_SHIP,		0 },
 	{ "Disarm ship",			AI_GOAL_DISARM_SHIP,		0 },
+	{ "Destroy subsystem",		AI_GOAL_DESTROY_SUBSYSTEM,	0 },
+	{ "Dock",					AI_GOAL_DOCK,				0 },
+	{ "Undock",					AI_GOAL_UNDOCK,				0 },
+	{ "Warp",					AI_GOAL_WARP,				0 },
 	{ "Evade ship",				AI_GOAL_EVADE_SHIP,			0 },
 	{ "Ignore ship",			AI_GOAL_IGNORE,				0 },
 	{ "Ignore ship (new)",		AI_GOAL_IGNORE_NEW,			0 },

--- a/fred2/management.cpp
+++ b/fred2/management.cpp
@@ -107,6 +107,7 @@ bool Show_iff[MAX_IFFS];
 
 CCriticalSection CS_cur_object_index;
 
+// Used in the FRED drop-down menu
 ai_goal_list Ai_goal_list[] = {
 	{ "Waypoints",				AI_GOAL_WAYPOINTS,			0 },
 	{ "Waypoints once",			AI_GOAL_WAYPOINTS_ONCE,		0 },


### PR DESCRIPTION
A few things I noticed while working on ai-chase-ship-class, split out into a separate PR.  Some code is reordered, some is cleaned up; nothing too extensive.  The most notable changes are a) the modification of the Ai_goal_text function to work on the AI_GOAL_X #define directly rather than unnecessarily calculate the bit; b) changing the HUD text of "fly to ship" to "rendezvous with" plus the ship name; c) adding a Warning in ai_update_goal_references; and d) changing ship_name to target_name in ship_return_orders for clarity