### PR TITLE
Don't initialize mission text when it's not used

### DIFF
--- a/code/parse/parselo.cpp
+++ b/code/parse/parselo.cpp
@@ -2112,12 +2112,12 @@ void read_raw_file_text(const char *filename, int mode, char *raw_text)
         throw parse::ParseException("Failed to open file");
 	}
 
-	// allocate, or reallocate, memory for Mission_text and Mission_text_raw based on size we need now
-	allocate_mission_text((size_t) (file_len + 1));
-
-	// NOTE: this always has to be done *after* the allocate_mission_text() call!!
-	if (raw_text == NULL)
+	if (raw_text == nullptr) {
+		// allocate, or reallocate, memory for Mission_text and Mission_text_raw based on size we need now
+		allocate_mission_text((size_t) (file_len + 1));
+		// NOTE: this always has to be done *after* the allocate_mission_text() call!!
 		raw_text = Mission_text_raw;
+	}
 
 	// read first 10 bytes to determine if file is encrypted
 	cfread(raw_text, MIN(file_len, 10), 1, mf);

--- a/test/src/parse/test_parselo.cpp
+++ b/test/src/parse/test_parselo.cpp
@@ -3,7 +3,56 @@
 
 #include <parse/parselo.h>
 
-TEST(ParseloTest, drop_trailing_whitespace_cstr) {
+#include "util/FSTestFixture.h"
+
+class ParseloTest : public test::FSTestFixture {
+ public:
+	ParseloTest() : test::FSTestFixture(0) {
+		pushModDir("parselo");
+	}
+
+ protected:
+	virtual void SetUp() override {
+		test::FSTestFixture::SetUp();
+	}
+	virtual void TearDown() override {
+		stop_parse();
+
+		test::FSTestFixture::TearDown();
+	}
+};
+
+TEST_F(ParseloTest, parse_pausing) {
+	read_file_text("test.tbl", CF_TYPE_TABLES);
+	reset_parse();
+
+	// Consume a token
+	required_string("#Start");
+
+	// Now pause parsing and check if the right text is loaded
+	char file_text[1024];
+	char file_text_raw[1024];
+
+	memset(file_text, 0, sizeof(file_text));
+	memset(file_text_raw, 0, sizeof(file_text_raw));
+
+	pause_parse();
+
+	read_file_text("test2.tbl", CF_TYPE_TABLES, file_text, file_text_raw);
+	reset_parse(file_text);
+
+	required_string("#Begin");
+	required_string("#End");
+
+	unpause_parse();
+
+	// We should be back in the original file
+	required_string("$Token:");
+	required_string("+OtherToken:");
+	required_string("#End");
+}
+
+TEST(ParseloUtilTest, drop_trailing_whitespace_cstr) {
 	char test_str[256];
 
 	strcpy_s(test_str, "Test string       ");
@@ -19,7 +68,7 @@ TEST(ParseloTest, drop_trailing_whitespace_cstr) {
 	ASSERT_STREQ(test_str, "");
 }
 
-TEST(ParseloTest, drop_trailing_whitespace) {
+TEST(ParseloUtilTest, drop_trailing_whitespace) {
 	SCP_string test_str;
 
 	test_str = "Test string       ";
@@ -35,7 +84,7 @@ TEST(ParseloTest, drop_trailing_whitespace) {
 	ASSERT_EQ(test_str, "");
 }
 
-TEST(ParseloTest, drop_leading_whitespace_cstr) {
+TEST(ParseloUtilTest, drop_leading_whitespace_cstr) {
 	char test_str[256];
 
 	strcpy_s(test_str, "          Test string");
@@ -51,7 +100,7 @@ TEST(ParseloTest, drop_leading_whitespace_cstr) {
 	ASSERT_STREQ(test_str, "");
 }
 
-TEST(ParseloTest, drop_leading_whitespace) {
+TEST(ParseloUtilTest, drop_leading_whitespace) {
 	SCP_string test_str;
 
 	test_str = "          Test string";
@@ -67,7 +116,7 @@ TEST(ParseloTest, drop_leading_whitespace) {
 	ASSERT_EQ(test_str, "");
 }
 
-TEST(ParseloTest, drop_whitespace_cstr) {
+TEST(ParseloUtilTest, drop_whitespace_cstr) {
 	char test_str[256];
 
 	strcpy_s(test_str, "          Test string          ");
@@ -91,7 +140,7 @@ TEST(ParseloTest, drop_whitespace_cstr) {
 	ASSERT_STREQ(test_str, "");
 }
 
-TEST(ParseloTest, drop_whitespace) {
+TEST(ParseloUtilTest, drop_whitespace) {
 	SCP_string test_str;
 
 	test_str = "          Test string";

--- a/test/test_data/parselo/data/tables/test.tbl
+++ b/test/test_data/parselo/data/tables/test.tbl
@@ -1,0 +1,6 @@
+#Start
+
+$Token:
++OtherToken:
+
+#End

--- a/test/test_data/parselo/parse_pausing/data/tables/test2.tbl
+++ b/test/test_data/parselo/parse_pausing/data/tables/test2.tbl
@@ -1,0 +1,2 @@
+#Begin
+#End


### PR DESCRIPTION
As far as I can tell this issue has been present for a very long time,
maybe even since retail. It was only uncovered since the recent changes
initialized the mission text by default which corrupted the table text
that was currently being parsed.

This also adds a unit test that validated that pausing works correctly.