### PR TITLE
Actually initialize Ignore_List.

### DIFF
--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -5226,6 +5226,9 @@ void ship_init()
 {
 	if ( !ships_inited )
 	{
+		//Initialize Ignore_List for targeting
+		set_default_ignore_list();
+
 		//Parse main TBL first
 		if (cf_exists_full("objecttypes.tbl", CF_TYPE_TABLES))
 			parse_shiptype_tbl("objecttypes.tbl");


### PR DESCRIPTION
`Ignore_List` (the list of flags used to determine if a ship is an invalid target) was originally a statically-initialized bitfield stored in an `int`; the new bitset flags code added a `set_default_ignore_list()` function to provide the default values, but then forgot to call it anywhere. As a result, "hidden-from-sensors" (and the other, less-likely-to-be-noticed flags) was having no effect on the player's ability to target anything. This adds a call to `set_default_ignore_list()` to `ship_init()` so that the original functionality is restored.