### PR TITLE
Fix integer overflow in mission-time-msecs SEXP

### DIFF
--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -5580,7 +5580,9 @@ int sexp_mission_time()
 int sexp_mission_time_msecs()
 {
 	// multiplying by 1000 can go over the limit for LONG_MAX so cast to long long int first
-	return f2i((longlong)Missiontime * 1000);
+	auto mission_time = (std::int64_t) Missiontime;
+	// This hack is necessary since fix is a 32-bit integer which would overflow if f2i would be used
+	return (int)((mission_time * 1000) / 65536);
 }
 
 /**


### PR DESCRIPTION
This is another issue introduced by converting `f2i` to a function. The parameter in the current version gets truncated to a `fix` (aka `std::int32_t`) which is not enough to hold the values. The new version "fixes" that by moving the conversion into the SEXP code which is not a perfect solution.

An alternative would be to use a templated `f2i` function but that would reduce the type-safety of the function since then it could be used with any integer type without causing a warning.