### PR TITLE
Always use alpha blending for interface materials

### DIFF
--- a/code/graphics/2d.h
+++ b/code/graphics/2d.h
@@ -737,9 +737,6 @@ typedef struct screen {
 	// color buffer writes
 	int (*gf_set_color_buffer)(int mode);
 
-	// cross fade
-	void (*gf_cross_fade)(int bmap1, int bmap2, int x1, int y1, int x2, int y2, float pct, int resize_mode);
-
 	// set a texture into cache. for sectioned bitmaps, pass in sx and sy to set that particular section of the bitmap
 	int (*gf_tcache_set)(int bitmap_id, int bitmap_type, float *u_scale, float *v_scale, int stage);	
 
@@ -1042,8 +1039,6 @@ __inline void gr_fog_set(int fog_mode, int r, int g, int b, float fog_near = -1.
 
 #define gr_set_cull			GR_CALL(gr_screen.gf_set_cull)
 #define gr_set_color_buffer	GR_CALL(gr_screen.gf_set_color_buffer)
-
-#define gr_cross_fade		GR_CALL(gr_screen.gf_cross_fade)
 
 __inline int gr_tcache_set(int bitmap_id, int bitmap_type, float *u_scale, float *v_scale, int stage = 0)
 {

--- a/code/graphics/grstub.cpp
+++ b/code/graphics/grstub.cpp
@@ -107,10 +107,6 @@ void gr_stub_clear()
 {
 }
 
-void gr_stub_cross_fade(int bmap1, int bmap2, int x1, int y1, int x2, int y2, float pct, int resize_mode)
-{
-}
-
 void gr_stub_curve(int xc, int yc, int r, int direction, int resize_mode)
 {
 }
@@ -587,8 +583,6 @@ bool gr_stub_init()
 
 	gr_screen.gf_set_cull			= gr_stub_set_cull;
 	gr_screen.gf_set_color_buffer	= gr_stub_set_color_buffer;
-
-	gr_screen.gf_cross_fade			= gr_stub_cross_fade;
 
 	gr_screen.gf_tcache_set			= gr_stub_tcache_set;
 

--- a/code/graphics/material.cpp
+++ b/code/graphics/material.cpp
@@ -86,7 +86,7 @@ void material_set_interface(material* mat_info, int texture, bool blended, float
 	mat_info->set_texture_map(TM_BASE_TYPE, texture);
 	mat_info->set_texture_type(material::TEX_TYPE_INTERFACE);
 
-	mat_info->set_blend_mode(material_determine_blend_mode(texture, blended));
+	mat_info->set_blend_mode(ALPHA_BLEND_ALPHA_BLEND_ALPHA);
 	mat_info->set_depth_mode(ZBUFFER_TYPE_NONE);
 	mat_info->set_cull_mode(false);
 

--- a/code/graphics/opengl/gropengl.cpp
+++ b/code/graphics/opengl/gropengl.cpp
@@ -1164,8 +1164,6 @@ void opengl_setup_function_pointers()
 	gr_screen.gf_set_cull			= gr_opengl_set_cull;
 	gr_screen.gf_set_color_buffer	= gr_opengl_set_color_buffer;
 
-	gr_screen.gf_cross_fade			= gr_opengl_cross_fade;
-
 	gr_screen.gf_tcache_set			= gr_opengl_tcache_set;
 
 	gr_screen.gf_set_clear_color	= gr_opengl_set_clear_color;

--- a/code/graphics/opengl/gropengldraw.cpp
+++ b/code/graphics/opengl/gropengldraw.cpp
@@ -988,16 +988,6 @@ void gr_opengl_curve(int xc, int yc, int r, int direction, int resize_mode)
     endDrawing(path);
 }
 
-// cross fade
-void gr_opengl_cross_fade(int bmap1, int bmap2, int x1, int y1, int x2, int y2, float pct, int resize_mode)
-{
-   	gr_set_bitmap(bmap1, GR_ALPHABLEND_FILTER, GR_BITBLT_MODE_NORMAL, 1.0f - pct);
-	gr_bitmap(x1, y1, resize_mode);
-
-  	gr_set_bitmap(bmap2, GR_ALPHABLEND_FILTER, GR_BITBLT_MODE_NORMAL, pct);
-	gr_bitmap(x2, y2, resize_mode);
-}
-
 void gr_opengl_shade(int x, int y, int w, int h, int resize_mode)
 {
 	if (resize_mode != GR_RESIZE_NONE) {

--- a/code/graphics/opengl/gropengldraw.cpp
+++ b/code/graphics/opengl/gropengldraw.cpp
@@ -478,6 +478,8 @@ namespace font
 
 void gr_opengl_string_old(float sx, float sy, const char* s, const char* end, font::font* fontData, float top, float height, int resize_mode)
 {
+	GR_DEBUG_SCOPE("Render VFNT string");
+
 	int width, spacing, letter;
 	float x, y;
 	bool do_resize;
@@ -485,7 +487,7 @@ void gr_opengl_string_old(float sx, float sy, const char* s, const char* end, fo
 	float u0, u1, v0, v1;
 	float x1, x2, y1, y2;
 	float u_scale = 1.0f, v_scale = 1.0f;
-		
+
 	GL_CHECK_FOR_ERRORS("start of string()");
 
  	gr_set_bitmap(fontData->bitmap_id);
@@ -671,6 +673,8 @@ void gr_opengl_string_old(float sx, float sy, const char* s, const char* end, fo
 }
 
 void gr_opengl_string(float sx, float sy, const char *s, int resize_mode, int in_length) {
+	GR_DEBUG_SCOPE("Render string");
+
 	using namespace font;
 	using namespace graphics::paths;
 	namespace fo = font;
@@ -703,6 +707,8 @@ void gr_opengl_string(float sx, float sy, const char *s, int resize_mode, int in
 							 fnt->getHeight(), resize_mode);
 	}
 	else if (currentFont->getType() == NVG_FONT) {
+		GR_DEBUG_SCOPE("Render TTF string");
+
 		auto path = beginDrawing(resize_mode);
 		path->translate(sx, sy);
 

--- a/code/graphics/opengl/gropengldraw.h
+++ b/code/graphics/opengl/gropengldraw.h
@@ -36,7 +36,6 @@ void gr_opengl_circle(int xc, int yc, int d, int resize_mode);
 void gr_opengl_unfilled_circle(int xc, int yc, int d, int resize_mode);
 void gr_opengl_arc(int xc, int yc, float r, float angle_start, float angle_end, bool fill, int resize_mode);
 void gr_opengl_curve(int xc, int yc, int r, int direction, int resize_mode);
-void gr_opengl_cross_fade(int bmap1, int bmap2, int x1, int y1, int x2, int y2, float pct, int resize_mode);
 void gr_opengl_shade(int x, int y, int w, int h, int resize_mode);
 void gr_opengl_flash(int r, int g, int b);
 void gr_opengl_flash_alpha(int r, int g, int b, int a);

--- a/code/menuui/credits.cpp
+++ b/code/menuui/credits.cpp
@@ -762,7 +762,13 @@ void credits_do_frame(float frametime)
 		bx2 = Credits_image_coords[gr_screen.res][CREDITS_X_COORD] + ((Credits_image_coords[gr_screen.res][CREDITS_W_COORD] - bw2)/2);
 		by2 = Credits_image_coords[gr_screen.res][CREDITS_Y_COORD] + ((Credits_image_coords[gr_screen.res][CREDITS_H_COORD] - bh2)/2);
 
-		gr_cross_fade(bm1, bm2, bx1, by1, bx2, by2, (float)percent / 100.0f, GR_RESIZE_MENU);
+		auto alpha = (float)percent / 100.0f;
+
+		gr_set_bitmap(bm1, GR_ALPHABLEND_FILTER, GR_BITBLT_MODE_NORMAL, 1.0f - alpha);
+		gr_bitmap(bx1, by1, GR_RESIZE_MENU);
+
+		gr_set_bitmap(bm2, GR_ALPHABLEND_FILTER, GR_BITBLT_MODE_NORMAL, alpha);
+		gr_bitmap(bx2, by2, GR_RESIZE_MENU);
 	}
 
 	Ui_window.draw();

--- a/code/menuui/credits.cpp
+++ b/code/menuui/credits.cpp
@@ -665,6 +665,8 @@ void credits_close()
 
 void credits_do_frame(float frametime)
 {
+	GR_DEBUG_SCOPE("Credits do frame");
+
 	int i, k, next, percent, bm1, bm2;
 	int bx1, by1, bw1, bh1;
 	int bx2, by2, bw2, bh2;
@@ -750,6 +752,8 @@ void credits_do_frame(float frametime)
 	bm2 = Credits_bmps[next];
 
 	if((bm1 != -1) && (bm2 != -1)){
+		GR_DEBUG_SCOPE("Render credits bitmap");
+
 		Assert(percent >= 0 && percent <= 100);
 
 		// get width and height


### PR DESCRIPTION
This fixes #914. I tested it and it seems to be working fine and it fixes the bitmap alpha blending.

There are a few additional changes that I made while searching for the cause of the bug which may be helpful for future debugging to I also included it here.