### PR TITLE
Fix lua drawImage rendering

### DIFF
--- a/code/graphics/2d.cpp
+++ b/code/graphics/2d.cpp
@@ -1315,6 +1315,8 @@ void gr_bitmap(int _x, int _y, int resize_mode)
 
 void gr_bitmap_uv(int _x, int _y, int _w, int _h, float _u0, float _v0, float _u1, float _v1, int resize_mode)
 {
+	GR_DEBUG_SCOPE("2D Bitmap UV");
+
 	float x, y, w, h;
 	vertex verts[4];
 
@@ -1351,8 +1353,12 @@ void gr_bitmap_uv(int _x, int _y, int _w, int _h, float _u0, float _v0, float _u
 	verts[3].texture_position.v = _v1;
 
 	material material_params;
-
-	material_set_interface(&material_params, gr_screen.current_bitmap, false, 1.0f);
+	material_set_interface(
+		&material_params,
+		gr_screen.current_bitmap,
+		gr_screen.current_alphablend_mode == GR_ALPHABLEND_FILTER ? true : false,
+		gr_screen.current_alphablend_mode == GR_ALPHABLEND_FILTER ? gr_screen.current_alpha : 1.0f
+	);
 	g3_render_primitives_textured(&material_params, verts, 4, PRIM_TYPE_TRIFAN, true);
 }
 
@@ -1376,6 +1382,8 @@ void gr_bitmap_uv(int _x, int _y, int _w, int _h, float _u0, float _v0, float _u
 //takes a list of rectangles that have assosiated rectangles in a texture
 void gr_bitmap_list(bitmap_rect_list* list, int n_bm, int resize_mode)
 {
+	GR_DEBUG_SCOPE("2D Bitmap list");
+
 	// adapted from g3_draw_2d_poly_bitmap_list
 
 	for ( int i = 0; i < n_bm; i++ ) {
@@ -1456,10 +1464,14 @@ void gr_bitmap_list(bitmap_rect_list* list, int n_bm, int resize_mode)
 		V->codes = 0;
 	}
 
-	material material_params;
-
-	material_set_unlit(&material_params, gr_screen.current_bitmap, 1.0f, true, false);
-	g3_render_primitives_textured(&material_params, vert_list, 6 * n_bm, PRIM_TYPE_TRIS, true);
+	material mat_params;
+	material_set_interface(
+		&mat_params,
+		gr_screen.current_bitmap,
+		gr_screen.current_alphablend_mode == GR_ALPHABLEND_FILTER ? true : false,
+		gr_screen.current_alphablend_mode == GR_ALPHABLEND_FILTER ? gr_screen.current_alpha : 1.0f
+	);
+	g3_render_primitives_textured(&mat_params, vert_list, 6 * n_bm, PRIM_TYPE_TRIS, true);
 
 	delete[] vert_list;
 }

--- a/code/graphics/generic.cpp
+++ b/code/graphics/generic.cpp
@@ -668,7 +668,7 @@ void generic_anim_render_variable_frame_delay(generic_anim* ga, float frametime,
 		// note: generic anims are not currently ever non-streaming in FSO
 		// I'm not even sure that the existing ani/eff code would allow non-streaming generic anims
 		generic_render_png_stream(ga);
-		gr_set_bitmap(ga->bitmap_id, GR_ALPHABLEND_NONE, GR_BITBLT_MODE_NORMAL, alpha);
+		gr_set_bitmap(ga->bitmap_id, GR_ALPHABLEND_FILTER, GR_BITBLT_MODE_NORMAL, alpha);
 	}
 }
 

--- a/code/parse/lua.cpp
+++ b/code/parse/lua.cpp
@@ -3712,7 +3712,7 @@ ade_obj<int> l_Texture("texture", "Texture handle");
 //WMC - int should NEVER EVER be an invalid handle. Return Nil instead. Nil FTW.
 
 static float lua_Opacity = 1.0f;
-static int lua_Opacity_type = GR_ALPHABLEND_NONE;
+static int lua_Opacity_type = GR_ALPHABLEND_FILTER;
 
 ADE_FUNC(__gc, l_Texture, NULL, "Auto-deletes texture", NULL, NULL)
 {


### PR DESCRIPTION
This now uses the same material properties that `gr_bitmap` already uses and fixes the alpha blending mode for interface materials.