### PR TITLE
Fix for Fixed Messages gauge position

### DIFF
--- a/code/hud/hudmessage.cpp
+++ b/code/hud/hudmessage.cpp
@@ -1350,6 +1350,10 @@ HudGauge(HUD_OBJECT_FIXED_MESSAGES, HUD_MESSAGE_LINES, false, true, (VM_WARP_CHA
 {
 }
 
+void HudGaugeFixedMessages::initCenterText(bool center) {
+	center_text = center;
+}
+
 void HudGaugeFixedMessages::render(float frametime) {
 	HUD_ft	*hp;
 
@@ -1358,7 +1362,13 @@ void HudGaugeFixedMessages::render(float frametime) {
 	if (!timestamp_elapsed(hp->end_time)) {
 		gr_set_color((hp->color >> 16) & 0xff, (hp->color >> 8) & 0xff, hp->color & 0xff);
 		
-		renderString(position[0], position[1], hp->text);
+		if (center_text) {
+			int w = 0;
+			gr_get_string_size(&w, nullptr, hp->text);
+			renderString(position[0] - (w / 2), position[1], hp->text);
+		} else {
+			renderString(position[0], position[1], hp->text);
+		}
 		//renderString(0x8000, MSG_WINDOW_Y_START + MSG_WINDOW_HEIGHT + 8, hp->text);
 	}
 }

--- a/code/hud/hudmessage.h
+++ b/code/hud/hudmessage.h
@@ -145,8 +145,10 @@ public:
 
 class HudGaugeFixedMessages: public HudGauge
 {
+	bool center_text;
 public:
 	HudGaugeFixedMessages();
+	void initCenterText(bool center);
 	void render(float frametime);
 	void pageIn();
 };

--- a/code/hud/hudparse.cpp
+++ b/code/hud/hudparse.cpp
@@ -4454,11 +4454,32 @@ void load_gauge_fixed_messages(gauge_settings* settings)
 	
 	int h = gr_get_font_height();
 
+	bool center_text;
+
 	settings->use_coords = true;
-	settings->coords[0] = 0x8000; //Magic number, means "Center on X"
-	settings->coords[1] = 5 + (h * 3);
+	// set both coords to INT_MIN so that it's possible to check whether a HUD table has overridden them
+	// (this is necessary to determine the default value for center_text)
+	settings->coords[0] = INT_MIN;
+	settings->coords[1] = INT_MIN;
 
 	HudGaugeFixedMessages* hud_gauge = gauge_load_common<HudGaugeFixedMessages>(settings);
+
+	if(settings->coords[0] == INT_MIN && settings->coords[1] == INT_MIN) {
+		// coords have almost certainly not been overridden; set them to their true defaults and set center_text to true
+		settings->coords[0] = settings->base_res[0] / 2;
+		settings->coords[1] = 5 + (h * 3);
+		hud_gauge->initPosition(settings->coords[0], settings->coords[1]);
+		center_text = true;
+	} else {
+		// coords have been overridden; set center_text to false
+		center_text = false;
+	}
+
+	if(optional_string("Center Text On Gauge X-Position:")) {
+		stuff_boolean(&center_text);
+	}
+
+	hud_gauge->initCenterText(center_text);
 
 	if(settings->ship_idx->at(0) >= 0) {
 		for (SCP_vector<int>::iterator ship_index = settings->ship_idx->begin(); ship_index != settings->ship_idx->end(); ++ship_index) {


### PR DESCRIPTION
This fixes #865, which was caused by the gauge still using 0x8000 as its default X-position even after support for that magic number was removed.

This also adds the "Center Text On Gauge X-Position:" option for the Fixed Messages gauge, which defaults to false if a position is specified and true otherwise, matching previous behavior.