### PR TITLE
Add LTTng Tracing

### DIFF
--- a/cmake/finder/FindLTTngUST.cmake
+++ b/cmake/finder/FindLTTngUST.cmake
@@ -1,0 +1,111 @@
+#.rst:
+# FindLTTngUST
+# ------------
+#
+# This module finds the `LTTng-UST <http://lttng.org/>`__ library.
+#
+# Imported target
+# ^^^^^^^^^^^^^^^
+#
+# This module defines the following :prop_tgt:`IMPORTED` target:
+#
+# ``LTTng::UST``
+#   The LTTng-UST library, if found
+#
+# Result variables
+# ^^^^^^^^^^^^^^^^
+#
+# This module sets the following
+#
+# ``LTTNGUST_FOUND``
+#   ``TRUE`` if system has LTTng-UST
+# ``LTTNGUST_INCLUDE_DIRS``
+#   The LTTng-UST include directories
+# ``LTTNGUST_LIBRARIES``
+#   The libraries needed to use LTTng-UST
+# ``LTTNGUST_VERSION_STRING``
+#   The LTTng-UST version
+# ``LTTNGUST_HAS_TRACEF``
+#   ``TRUE`` if the ``tracef()`` API is available in the system's LTTng-UST
+# ``LTTNGUST_HAS_TRACELOG``
+#   ``TRUE`` if the ``tracelog()`` API is available in the system's LTTng-UST
+
+#=============================================================================
+# Copyright 2016 Kitware, Inc.
+# Copyright 2016 Philippe Proulx <pproulx@efficios.com>
+#
+# Distributed under the OSI-approved BSD License (the "License");
+# see accompanying file Copyright.txt for details.
+#
+# This software is distributed WITHOUT ANY WARRANTY; without even the
+# implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the License for more information.
+#=============================================================================
+# (To distribute this file outside of CMake, substitute the full
+#  License text for the above reference.)
+
+find_path(LTTNGUST_INCLUDE_DIRS NAMES lttng/tracepoint.h)
+find_library(LTTNGUST_LIBRARIES NAMES lttng-ust)
+
+if(LTTNGUST_INCLUDE_DIRS AND LTTNGUST_LIBRARIES)
+  # find tracef() and tracelog() support
+  set(LTTNGUST_HAS_TRACEF 0)
+  set(LTTNGUST_HAS_TRACELOG 0)
+
+  if(EXISTS "${LTTNGUST_INCLUDE_DIRS}/lttng/tracef.h")
+    set(LTTNGUST_HAS_TRACEF TRUE)
+  endif()
+
+  if(EXISTS "${LTTNGUST_INCLUDE_DIRS}/lttng/tracelog.h")
+    set(LTTNGUST_HAS_TRACELOG TRUE)
+  endif()
+
+  # get version
+  set(lttngust_version_file "${LTTNGUST_INCLUDE_DIRS}/lttng/ust-version.h")
+
+  if(EXISTS "${lttngust_version_file}")
+    file(STRINGS "${lttngust_version_file}" lttngust_version_major_string
+         REGEX "^[\t ]*#define[\t ]+LTTNG_UST_MAJOR_VERSION[\t ]+[0-9]+[\t ]*$")
+    file(STRINGS "${lttngust_version_file}" lttngust_version_minor_string
+         REGEX "^[\t ]*#define[\t ]+LTTNG_UST_MINOR_VERSION[\t ]+[0-9]+[\t ]*$")
+    file(STRINGS "${lttngust_version_file}" lttngust_version_patch_string
+         REGEX "^[\t ]*#define[\t ]+LTTNG_UST_PATCHLEVEL_VERSION[\t ]+[0-9]+[\t ]*$")
+    string(REGEX REPLACE ".*([0-9]+).*" "\\1"
+           lttngust_v_major "${lttngust_version_major_string}")
+    string(REGEX REPLACE ".*([0-9]+).*" "\\1"
+           lttngust_v_minor "${lttngust_version_minor_string}")
+    string(REGEX REPLACE ".*([0-9]+).*" "\\1"
+           lttngust_v_patch "${lttngust_version_patch_string}")
+    set(LTTNGUST_VERSION_STRING
+        "${lttngust_v_major}.${lttngust_v_minor}.${lttngust_v_patch}")
+    unset(lttngust_version_major_string)
+    unset(lttngust_version_minor_string)
+    unset(lttngust_version_patch_string)
+    unset(lttngust_v_major)
+    unset(lttngust_v_minor)
+    unset(lttngust_v_patch)
+  endif()
+
+  unset(lttngust_version_file)
+
+  if(NOT TARGET LTTng::UST)
+    add_library(LTTng::UST UNKNOWN IMPORTED)
+    set_target_properties(LTTng::UST PROPERTIES
+      INTERFACE_INCLUDE_DIRECTORIES "${LTTNGUST_INCLUDE_DIRS}"
+      INTERFACE_LINK_LIBRARIES ${CMAKE_DL_LIBS}
+      IMPORTED_LINK_INTERFACE_LANGUAGES "C"
+      IMPORTED_LOCATION "${LTTNGUST_LIBRARIES}")
+  endif()
+
+  # add libdl to required libraries
+  set(LTTNGUST_LIBRARIES ${LTTNGUST_LIBRARIES} ${CMAKE_DL_LIBS})
+endif()
+
+# handle the QUIETLY and REQUIRED arguments and set LTTNGUST_FOUND to
+# TRUE if all listed variables are TRUE
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(LTTngUST FOUND_VAR LTTNGUST_FOUND
+  REQUIRED_VARS LTTNGUST_LIBRARIES
+  LTTNGUST_INCLUDE_DIRS
+  VERSION_VAR LTTNGUST_VERSION_STRING)
+mark_as_advanced(LTTNGUST_LIBRARIES LTTNGUST_INCLUDE_DIRS)

--- a/cmake/platform-unix.cmake
+++ b/cmake/platform-unix.cmake
@@ -3,4 +3,10 @@ INCLUDE(util)
 
 MESSAGE(STATUS "Configuring UNIX specific things and stuff...")
 
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/finder")
+
+include (FindLTTngUST REQUIRED)
+
+target_link_libraries(platform INTERFACE LTTng::UST)
+
 target_compile_definitions(platform INTERFACE SCP_UNIX USE_OPENAL)

--- a/code/globalincs/tracepoints.cpp
+++ b/code/globalincs/tracepoints.cpp
@@ -1,0 +1,14 @@
+ /*
+ * Copyright (C) Freespace Open 2016.  All rights reserved.
+ *
+ * All source code herein is the property of Freespace Open. You may not sell
+ * or otherwise commercially exploit the source or things you created based on the
+ * source.
+ *
+ */
+
+#define TRACEPOINT_CREATE_PROBES
+#define TRACEPOINT_DEFINE
+
+#include "tracepoints.h"
+

--- a/code/globalincs/tracepoints.h
+++ b/code/globalincs/tracepoints.h
@@ -1,0 +1,436 @@
+/*
+ * Copyright (C) Freespace Open 2016.  All rights reserved.
+ *
+ * All source code herein is the property of Freespace Open. You may not sell
+ * or otherwise commercially exploit the source or things you created based on the
+ * source.
+ *
+ */
+
+#include <SDL_platform.h>
+
+#undef TRACEPOINT_PROVIDER
+#define TRACEPOINT_PROVIDER fs2open
+
+#undef TRACEPOINT_INCLUDE
+#define TRACEPOINT_INCLUDE "./globalincs/tracepoints.h"
+
+#if !defined(_TRACEPOINTS_H) || defined(TRACEPOINT_HEADER_MULTI_READ)
+#define _TRACEPOINTS_H
+
+#ifdef __LINUX__
+#include <lttng/tracepoint.h>
+
+/**
+ * NAMING CONVENTION:
+ *
+ * 1 For entry/exits, please end the common name with "__begin" or "__end"
+ * 2 for send receives, please ent the common name with "__send" or "__recv"
+ */
+
+TRACEPOINT_EVENT(
+		fs2open,
+		draw_list_render_all__begin,
+		TP_ARGS(
+				int, zbuffer_type
+		),
+		TP_FIELDS(
+				ctf_integer(int, zbuffer_type, zbuffer_type)
+		)
+)
+
+TRACEPOINT_EVENT(
+		fs2open,
+		draw_list_render_all__end,
+		TP_ARGS(
+		),
+		TP_FIELDS(
+		)
+)
+
+TRACEPOINT_EVENT(
+		fs2open,
+		game_frame__begin,
+		TP_ARGS(
+				char, paused
+		),
+		TP_FIELDS(
+				ctf_integer(char, paused, paused)
+		)
+)
+
+TRACEPOINT_EVENT(
+		fs2open,
+		game_frame__end,
+		TP_ARGS(
+		),
+		TP_FIELDS(
+		)
+)
+
+TRACEPOINT_EVENT(
+		fs2open,
+		game_render_frame__begin,
+		TP_ARGS(
+		),
+		TP_FIELDS(
+		)
+)
+
+TRACEPOINT_EVENT(
+		fs2open,
+		game_render_frame__end,
+		TP_ARGS(
+		),
+		TP_FIELDS(
+		)
+)
+
+TRACEPOINT_EVENT(
+		fs2open,
+		game_simulation_frame__begin,
+		TP_ARGS(
+		),
+		TP_FIELDS(
+		)
+)
+
+TRACEPOINT_EVENT(
+		fs2open,
+		game_simulation_frame__end,
+		TP_ARGS(
+		),
+		TP_FIELDS(
+		)
+)
+
+TRACEPOINT_EVENT(
+		fs2open,
+		gr_flip__begin,
+		TP_ARGS(
+		),
+		TP_FIELDS(
+		)
+)
+
+TRACEPOINT_EVENT(
+		fs2open,
+		gr_flip__end,
+		TP_ARGS(
+		),
+		TP_FIELDS(
+		)
+)
+
+TRACEPOINT_EVENT(
+		fs2open,
+		mission_eval_goals__begin,
+		TP_ARGS(
+				int, objective
+		),
+		TP_FIELDS(
+				ctf_integer(int, objective, objective)
+		)
+)
+
+TRACEPOINT_EVENT(
+		fs2open,
+		mission_eval_goals__end,
+		TP_ARGS(
+				int, objective
+		),
+		TP_FIELDS(
+				ctf_integer(int, objective, objective)
+		)
+)
+
+TRACEPOINT_EVENT(
+		fs2open,
+		obj_move_all__begin,
+		TP_ARGS(
+				float, arg
+		),
+		TP_FIELDS(
+				ctf_float(int, sequence, arg)
+		)
+)
+
+TRACEPOINT_EVENT(
+		fs2open,
+		obj_move_all__end,
+		TP_ARGS(
+		),
+		TP_FIELDS(
+		)
+)
+
+TRACEPOINT_EVENT(
+		fs2open,
+		obj_move_all_pre__begin,
+		TP_ARGS(
+		),
+		TP_FIELDS(
+		)
+)
+
+TRACEPOINT_EVENT(
+		fs2open,
+		obj_move_all_pre__end,
+		TP_ARGS(
+		),
+		TP_FIELDS(
+		)
+)
+
+TRACEPOINT_EVENT(
+		fs2open,
+		obj_render_queue_all__begin,
+		TP_ARGS(
+		),
+		TP_FIELDS(
+		)
+)
+
+TRACEPOINT_EVENT(
+		fs2open,
+		obj_render_queue_all__end,
+		TP_ARGS(
+		),
+		TP_FIELDS(
+		)
+)
+
+TRACEPOINT_EVENT(
+		fs2open,
+		obj_sort_and_collide__begin,
+		TP_ARGS(
+		),
+		TP_FIELDS(
+		)
+)
+
+TRACEPOINT_EVENT(
+		fs2open,
+		obj_sort_and_collide__end,
+		TP_ARGS(
+		),
+		TP_FIELDS(
+		)
+)
+
+TRACEPOINT_EVENT(
+		fs2open,
+		particle_render_all__begin,
+		TP_ARGS(
+		),
+		TP_FIELDS(
+		)
+)
+
+TRACEPOINT_EVENT(
+		fs2open,
+		particle_render_all__end,
+		TP_ARGS(
+		),
+		TP_FIELDS(
+		)
+)
+
+TRACEPOINT_EVENT(
+		fs2open,
+		particle_render_set_up__begin,
+		TP_ARGS(
+		),
+		TP_FIELDS(
+		)
+)
+
+TRACEPOINT_EVENT(
+		fs2open,
+		particle_render_set_up__end,
+		TP_ARGS(
+		),
+		TP_FIELDS(
+		)
+)
+
+TRACEPOINT_EVENT(
+		fs2open,
+		particle_render_batch_render__begin,
+		TP_ARGS(
+		),
+		TP_FIELDS(
+		)
+)
+
+TRACEPOINT_EVENT(
+		fs2open,
+		particle_render_batch_render__end,
+		TP_ARGS(
+		),
+		TP_FIELDS(
+		)
+)
+
+TRACEPOINT_EVENT(
+		fs2open,
+		trail_render__begin,
+		TP_ARGS(
+		),
+		TP_FIELDS(
+		)
+)
+
+TRACEPOINT_EVENT(
+		fs2open,
+		LUA_On_Frame__begin,
+		TP_ARGS(
+		),
+		TP_FIELDS(
+		)
+)
+
+TRACEPOINT_EVENT(
+		fs2open,
+		LUA_On_Frame__end,
+		TP_ARGS(
+		),
+		TP_FIELDS(
+		)
+)
+
+TRACEPOINT_EVENT(
+		fs2open,
+		draw_list__render_all__begin,
+		TP_ARGS(
+		),
+		TP_FIELDS(
+		)
+)
+
+TRACEPOINT_EVENT(
+		fs2open,
+		draw_list__render_all__end,
+		TP_ARGS(
+		),
+		TP_FIELDS(
+		)
+)
+
+TRACEPOINT_EVENT(
+		fs2open,
+		sort_colliders_phase_1__begin,
+		TP_ARGS(
+		),
+		TP_FIELDS(
+		)
+)
+
+TRACEPOINT_EVENT(
+		fs2open,
+		sort_colliders_phase_1__end,
+		TP_ARGS(
+		),
+		TP_FIELDS(
+		)
+)
+
+TRACEPOINT_EVENT(
+		fs2open,
+		sort_colliders_phase_2__begin,
+		TP_ARGS(
+		),
+		TP_FIELDS(
+		)
+)
+
+TRACEPOINT_EVENT(
+		fs2open,
+		sort_colliders_phase_2__end,
+		TP_ARGS(
+		),
+		TP_FIELDS(
+		)
+)
+
+TRACEPOINT_EVENT(
+		fs2open,
+		sort_colliders_phase_3__begin,
+		TP_ARGS(
+		),
+		TP_FIELDS(
+		)
+)
+
+TRACEPOINT_EVENT(
+		fs2open,
+		sort_colliders_phase_3__end,
+		TP_ARGS(
+		),
+		TP_FIELDS(
+		)
+)
+
+TRACEPOINT_EVENT(
+		fs2open,
+		trail_render_draw__begin,
+		TP_ARGS(
+		),
+		TP_FIELDS(
+		)
+)
+
+TRACEPOINT_EVENT(
+		fs2open,
+		trail_render_draw__end,
+		TP_ARGS(
+		),
+		TP_FIELDS(
+		)
+)
+
+TRACEPOINT_EVENT(
+		fs2open,
+		queue_render__begin,
+		TP_ARGS(
+		),
+		TP_FIELDS(
+		)
+)
+
+TRACEPOINT_EVENT(
+		fs2open,
+		queue_render__end,
+		TP_ARGS(
+		),
+		TP_FIELDS(
+		)
+)
+
+TRACEPOINT_EVENT(
+		fs2open,
+		page_flip__begin,
+		TP_ARGS(
+		),
+		TP_FIELDS(
+		)
+)
+
+TRACEPOINT_EVENT(
+		fs2open,
+		page_flip__end,
+		TP_ARGS(
+		),
+		TP_FIELDS(
+		)
+)
+
+#include <lttng/tracepoint-event.h>
+
+#else
+
+#define tracepoint( ... )
+
+#endif /* LINUX */
+
+#endif /* _tracepoints */

--- a/code/graphics/2d.cpp
+++ b/code/graphics/2d.cpp
@@ -21,6 +21,7 @@
 #include "debugconsole/console.h"
 #include "gamesequence/gamesequence.h"	//WMC - for scripting hooks in gr_flip()
 #include "globalincs/systemvars.h"
+#include "globalincs/tracepoints.h"
 #include "graphics/2d.h"
 #include "graphics/font.h"
 #include "graphics/grbatch.h"
@@ -2124,6 +2125,7 @@ void gr_flip()
 	// m!m avoid running CHA_ONFRAME when the "Quit mission" popup is shown. See mantis 2446 for reference
 	if (!quit_mission_popup_shown)
 	{
+		tracepoint(fs2open, LUA_On_Frame__begin);
 		profile_begin("LUA On Frame");
 		//WMC - Evaluate global hook if not override.
 		Script_system.RunBytecode(Script_globalhook);
@@ -2132,6 +2134,7 @@ void gr_flip()
 		//WMC - Do scripting reset stuff
 		Script_system.EndFrame();
 		profile_end("LUA On Frame");
+		tracepoint(fs2open, LUA_On_Frame__end);
 	}
 
 	gr_screen.gf_flip();

--- a/code/mission/missiongoals.cpp
+++ b/code/mission/missiongoals.cpp
@@ -16,6 +16,7 @@
 #include "gamesnd/eventmusic.h"
 #include "gamesnd/gamesnd.h"
 #include "globalincs/alphacolors.h"
+#include "globalincs/tracepoints.h"
 #include "hud/hud.h"
 #include "hud/hudmessage.h"
 #include "io/key.h"
@@ -1044,8 +1045,10 @@ void mission_eval_goals()
 				continue;
 			}
 
+			tracepoint(fs2open, mission_eval_goals__begin, i);
 			// if we get here, then the timestamp on the event has popped -- we should reevaluate
 			PROFILE("Repeating events", mission_process_event(i));
+			tracepoint(fs2open, mission_eval_goals__end, i);
 		}
 	}
 	

--- a/code/model/modelrender.cpp
+++ b/code/model/modelrender.cpp
@@ -12,6 +12,7 @@
 #include "asteroid/asteroid.h"
 #include "cmdline/cmdline.h"
 #include "gamesequence/gamesequence.h"
+#include "globalincs/tracepoints.h"
 #include "graphics/opengl/gropengldraw.h"
 #include "graphics/opengl/gropenglshader.h"
 #include "graphics/tmapper.h"
@@ -639,7 +640,9 @@ void draw_list::render_all(gr_zbuffer_type depth_mode)
 		int render_index = Render_keys[i];
 
 		if ( depth_mode == ZBUFFER_TYPE_DEFAULT || Render_elements[render_index].render_material.get_depth_mode() == depth_mode ) {
+			tracepoint(fs2open, draw_list__render_all__begin);
 			PROFILE("Render buffer", render_buffer(Render_elements[render_index]));
+			tracepoint(fs2open, draw_list__render_all__end);
 		}
 	}
 

--- a/code/object/objcollide.cpp
+++ b/code/object/objcollide.cpp
@@ -10,6 +10,7 @@
 
 
 #include "globalincs/linklist.h"
+#include "globalincs/tracepoints.h"
 #include "io/timer.h"
 #include "object/objcollide.h"
 #include "object/object.h"
@@ -1227,16 +1228,20 @@ void obj_sort_and_collide()
 	SCP_vector<int> sort_list_z;
 
 	sort_list_y.clear();
+	tracepoint(fs2open, sort_colliders_phase_1__begin);
 	PROFILE("Sort Colliders", obj_quicksort_colliders(&Collision_sort_list, 0, (int)(Collision_sort_list.size() - 1), 0));
 	obj_find_overlap_colliders(&sort_list_y, &Collision_sort_list, 0, false);
-
+	tracepoint(fs2open, sort_colliders_phase_1__end);
+	tracepoint(fs2open, sort_colliders_phase_2__begin);
 	sort_list_z.clear();
 	PROFILE("Sort Colliders", obj_quicksort_colliders(&sort_list_y, 0, (int)(sort_list_y.size() - 1), 1));
 	obj_find_overlap_colliders(&sort_list_z, &sort_list_y, 1, false);
-
+	tracepoint(fs2open, sort_colliders_phase_2__end);
+	tracepoint(fs2open, sort_colliders_phase_3__begin);
 	sort_list_y.clear();
 	PROFILE("Sort Colliders", obj_quicksort_colliders(&sort_list_z, 0, (int)(sort_list_z.size() - 1), 2));
 	obj_find_overlap_colliders(&sort_list_y, &sort_list_z, 2, true);
+	tracepoint(fs2open, sort_colliders_phase_3__end);
 }
 
 void obj_find_overlap_colliders(SCP_vector<int> *overlap_list_out, SCP_vector<int> *list, int axis, bool collide)

--- a/code/object/object.cpp
+++ b/code/object/object.cpp
@@ -17,6 +17,7 @@
 #include "fireball/fireballs.h"
 #include "freespace.h"
 #include "globalincs/linklist.h"
+#include "globalincs/tracepoints.h"
 #include "iff_defs/iff_defs.h"
 #include "io/timer.h"
 #include "jumpnode/jumpnode.h"
@@ -1433,9 +1434,10 @@ void obj_move_all(float frametime)
 #ifdef OBJECT_CHECK 
 			obj_check_object( objp );
 #endif
-
+		tracepoint(fs2open, obj_move_all_pre__begin);
 		// pre-move
 		PROFILE("Pre Move", obj_move_all_pre(objp, frametime));
+		tracepoint(fs2open, obj_move_all_pre__end);
 
 		// store last pos and orient
 		objp->last_pos = cur_pos;

--- a/code/object/objectsort.cpp
+++ b/code/object/objectsort.cpp
@@ -16,6 +16,7 @@
 #include "asteroid/asteroid.h"
 #include "cmdline/cmdline.h"
 #include "debris/debris.h"
+#include "globalincs/tracepoints.h"
 #include "graphics/opengl/gropengldraw.h"
 #include "jumpnode/jumpnode.h"
 #include "mission/missionparse.h"
@@ -368,9 +369,11 @@ void obj_render_queue_all()
 			}
 
             objp->flags.set(Object::Object_Flags::Was_rendered);
+            tracepoint(fs2open, queue_render__begin);
 			profile_begin("Queue Render");
 			obj_queue_render(objp, &scene);
 			profile_end("Queue Render");
+			tracepoint(fs2open, queue_render__end);
 		}
 	}
 

--- a/code/particle/ParticleManager.cpp
+++ b/code/particle/ParticleManager.cpp
@@ -12,6 +12,7 @@
 
 #include "bmpman/bmpman.h"
 #include "globalincs/systemvars.h"
+#include "globalincs/tracepoints.h"
 
 /**
  * @defgroup particleSystems Particle System

--- a/code/particle/particle.cpp
+++ b/code/particle/particle.cpp
@@ -15,6 +15,7 @@
 #include "cmdline/cmdline.h"
 #include "debugconsole/console.h"
 #include "globalincs/systemvars.h"
+#include "globalincs/tracepoints.h"
 #include "graphics/2d.h"
 #include "graphics/grbatch.h"
 #include "object/object.h"
@@ -349,7 +350,7 @@ namespace particle
 
 		if (Particles.empty())
 			return;
-
+		tracepoint(fs2open, particle_render_set_up__begin);
 		for (SCP_vector<ParticlePtr>::iterator p = Particles.begin(); p != Particles.end(); ++p)
 		{
 			ParticlePtr part = *p;
@@ -415,13 +416,15 @@ namespace particle
 				render_batch = true;
 			}
 		}
-
+		tracepoint(fs2open, particle_render_set_up__end);
+		tracepoint(fs2open, particle_render_batch_render__begin);
 		profile_begin("Batch Render");
 		if (render_batch)
 		{
 			batching_render_all();
 		}
 		profile_end("Batch Render");
+		tracepoint(fs2open, particle_render_batch_render__end);
 	}
 
 	//============================================================================

--- a/code/source_groups.cmake
+++ b/code/source_groups.cmake
@@ -254,6 +254,8 @@ set (file_root_globalincs
 	globalincs/vmallocator.h
 	globalincs/scp_defines.h
 	globalincs/flagset.h
+	globalincs/tracepoints.h
+	globalincs/tracepoints.cpp
 )
 
 IF (WIN32)

--- a/code/weapon/trails.cpp
+++ b/code/weapon/trails.cpp
@@ -11,6 +11,7 @@
 
 #include "cmdline/cmdline.h"
 #include "globalincs/systemvars.h"
+#include "globalincs/tracepoints.h"
 #include "graphics/2d.h"
 #include "io/timer.h"
 #include "render/3d.h" 
@@ -292,7 +293,7 @@ void trail_render( trail * trailp )
 	// there should always be three verts in the last section and 2 everyware else, therefore there should always be an odd number of verts
 	if ( (nv % 2) != 1 )
 		Warning( LOCATION, "even number of verts in trail render\n" );
-
+	tracepoint(fs2open, trail_render_draw__begin);
 	profile_begin("Trail Draw");
 	//gr_set_bitmap( ti->texture.bitmap_id, GR_ALPHABLEND_FILTER, GR_BITBLT_MODE_NORMAL, 1.0f );
 	//gr_render(nv, Trail_v_list, TMAP_FLAG_TEXTURED | TMAP_FLAG_ALPHA | TMAP_FLAG_GOURAUD | TMAP_FLAG_RGB | TMAP_HTL_3D_UNLIT | TMAP_FLAG_TRISTRIP);
@@ -302,6 +303,7 @@ void trail_render( trail * trailp )
 	g3_render_primitives_colored_textured(&material_def, Trail_v_list, nv, PRIM_TYPE_TRISTRIP, false);
 
 	profile_end("Trail Draw");
+	tracepoint(fs2open, trail_render_draw__end);
 }
 
 void trail_add_segment( trail *trailp, vec3d *pos )

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -47,6 +47,7 @@
 #include "gamesnd/gamesnd.h"
 #include "globalincs/alphacolors.h"
 #include "globalincs/mspdb_callstack.h"
+#include "globalincs/tracepoints.h"
 #include "globalincs/version.h"
 #include "graphics/font.h"
 #include "graphics/shadows.h"
@@ -3576,9 +3577,9 @@ void game_render_frame( camid cid )
 	// this, make sure that the current render target gets restored right afterwards!
 	if ( Cmdline_env && !Env_cubemap_drawn && gr_screen.rendering_to_texture == -1 ) {
 		GR_DEBUG_SCOPE("Environment Mapping");
-
+		tracepoint(fs2open, game_render_frame__begin);
 		PROFILE("Environment Mapping", setup_environment_mapping(cid));
-
+		tracepoint(fs2open, game_render_frame__end);
 		if ( !Dynamic_environment ) {
 			Env_cubemap_drawn = true;
 		}
@@ -3864,8 +3865,10 @@ void game_simulation_frame()
 			obj_observer_move(flFrametime);
 		}
 		
+		tracepoint(fs2open, game_simulation_frame__begin);
 		// move all the objects now
 		PROFILE("Move Objects - Master", obj_move_all(flFrametime));
+		tracepoint(fs2open, game_simulation_frame__end);
 
 		mission_eval_goals();
 	}
@@ -4199,6 +4202,7 @@ void game_frame(bool paused)
 	}
 #endif
 	// start timing frame
+	tracepoint(fs2open, game_frame__begin, paused);
 	profile_begin("Main Frame");
 
 	DEBUG_GET_TIME( total_time1 )
@@ -4258,7 +4262,9 @@ void game_frame(bool paused)
 			return;
 		}
 		
+		tracepoint(fs2open, game_simulation_frame__begin);
 		PROFILE("Simulation", game_simulation_frame()); 
+		tracepoint(fs2open, game_simulation_frame__end);
 		
 		// if not actually in a game play state, then return.  This condition could only be true in 
 		// a multiplayer game.
@@ -4369,7 +4375,9 @@ void game_frame(bool paused)
 			// If a regular popup is active, don't flip (popup code flips)
 			if( !popup_running_state() ){
 				DEBUG_GET_TIME( flip_time1 )
+				tracepoint(fs2open, page_flip__begin);
 				PROFILE("Page Flip", game_flip_page_and_time_it());
+				tracepoint(fs2open, page_flip__end);
 				DEBUG_GET_TIME( flip_time2 )
 			}
 
@@ -4384,6 +4392,7 @@ void game_frame(bool paused)
 	// process lightning (nebula only)
 	nebl_process();
 
+	tracepoint(fs2open, game_frame__end);
 	profile_end("Main Frame");
 	profile_dump_output();
 	profile_dump_json_output();


### PR DESCRIPTION
This allows fast in production tracing for performance monitoring.
The information is available in Linux, in a the form of binary CTF
trace.

Tracer information is here: www.lttng.org

Signed-off-by: Matthew Khouzam matthew.khouzam@gmail.com
