### PR TITLE
Species tbl test improvements

### DIFF
--- a/test/src/menuui/test_intel_parse.cpp
+++ b/test/src/menuui/test_intel_parse.cpp
@@ -284,3 +284,14 @@ TEST_F(IntelParseTest, always_techroom_values) {
 	test_intel_data_equal(expected_baz, Intel_info[2]);
 	test_intel_data_equal(expected_baz, Intel_info[3]);
 }
+
+// Data must be in the correct order.
+TEST_F(IntelParseTest, wrong_order) {
+	SCOPED_TRACE("wrong_order");
+
+	EXPECT_ANY_THROW(techroom_intel_init());
+
+	ASSERT_EQ(Intel_info_size, 1);
+
+	test_intel_data_equal(expected_foo, Intel_info[0]);
+}

--- a/test/src/menuui/test_intel_parse.cpp
+++ b/test/src/menuui/test_intel_parse.cpp
@@ -255,12 +255,7 @@ TEST_F(IntelParseTest, missing_end_multi_text) {
 
 	techroom_intel_init();
 
-	// Something is doing an out of bounds read, since this varies
-	// when running the tests with --gtest_shuffle.
-	//ASSERT_EQ(Intel_info_size, 1);
-
-	// Remove this when the above issue is fixed.
-	ASSERT_GE(Intel_info_size, 1);
+	ASSERT_EQ(Intel_info_size, 1);
 
 	test_intel_data_equal(expected_foo, Intel_info[0]);
 }

--- a/test/test_data/menuui/intel_parse/missing_end_multi_text/data/tables/species.tbl
+++ b/test/test_data/menuui/intel_parse/missing_end_multi_text/data/tables/species.tbl
@@ -8,7 +8,7 @@ XSTR(
 "Foo desc", 3001)
 $end_multi_text
 
-; An otherwise valid entry but missing the description.
+; An otherwise valid entry but missing the $end_multi_text
 $Entry:
 $Name: XSTR("Bar name", 3002)
 $Anim: Bar anim

--- a/test/test_data/menuui/intel_parse/wrong_order/data/tables/species.tbl
+++ b/test/test_data/menuui/intel_parse/wrong_order/data/tables/species.tbl
@@ -1,0 +1,29 @@
+; A valid entry.
+$Entry:
+$Name: XSTR("Foo name",3000)
+$Anim: Foo anim
+$AlwaysInTechRoom: 1
+$Description:
+XSTR(
+"Foo desc", 3001)
+$end_multi_text
+
+; Otherwise valid but $Anim in wrong place.
+$Entry:
+$Name: XSTR("Bar name", 3002)
+$AlwaysInTechRoom: 0
+$Anim: Bar anim
+$Description:
+XSTR(
+"Bar desc", 3003)
+$end_multi_text
+
+; Another valid entry.
+$Entry:
+$Name: XSTR("Baz name",3004)
+$Anim: Baz anim
+$AlwaysInTechRoom: 1
+$Description:
+XSTR(
+"Baz desc", 3005)
+$end_multi_text


### PR DESCRIPTION
Since 16d5f88 and c9f9e1b there is no longer the danger of reading old data from `Mission_text`, so the test `missing_end_multi_text` can now be uncommented.

Also, add a unit test to check that intel entry data must be in the correct order for parsing to succeed.