### PR TITLE
Remove unused varying envReflect from main fragment shader.

### DIFF
--- a/code/def_files/main-f.sdr
+++ b/code/def_files/main-f.sdr
@@ -39,7 +39,6 @@ uniform bool gammaSpec;
 uniform samplerCube sEnvmap;
 uniform bool envGloss;
 uniform bool alpha_spec;
-varying vec3 envReflect;
 in vec3 fragEnvReflect;
 #endif
 #ifdef FLAG_NORMAL_MAP


### PR DESCRIPTION
This caused problems with the Mac GLSL compiler on my machine. Other compilers prob didn't catch this since it was unused and likely optimized out.