### PR TITLE
Add GPU time tracing to JSON output

### DIFF
--- a/code/globalincs/profiling.cpp
+++ b/code/globalincs/profiling.cpp
@@ -85,6 +85,19 @@ std::uint64_t end_profile_time = 0;
 SCP_string profile_output;
 std::ofstream profiling_file;
 
+static SCP_vector<int> query_objects;
+static SCP_queue<int> free_query_objects;
+
+static int get_query_object() {
+	if (!free_query_objects.empty()) {
+		auto id = free_query_objects.front();
+		free_query_objects.pop();
+		return id;
+	}
+
+	auto id = g
+}
+
 struct json_data
 {
 	SCP_string name;

--- a/code/globalincs/systemvars.h
+++ b/code/globalincs/systemvars.h
@@ -208,66 +208,6 @@ void detail_level_set(int level);
 // Returns the current detail level or -1 if custom.
 int current_detail_level();
 
-//=========================================================
-// Functions to profile frame performance
-
-typedef struct profile_sample {
-	uint profile_instances;
-	int open_profiles;
-	//char name[256];
-	SCP_string name;
-	std::uint64_t start_time;	// in microseconds
-	std::uint64_t accumulator;
-	std::uint64_t children_sample_time;
-	uint num_parents;
-	uint num_children;
-	int parent;
-} profile_sample;
-
-typedef struct profile_sample_history {
-	bool valid;
-	//char name[256];
-	SCP_string name;
-	float avg;
-	float min;
-	float max;
-	std::uint64_t avg_micro_sec;
-	std::uint64_t min_micro_sec;
-	std::uint64_t max_micro_sec;
-} profile_sample_history;
-
-extern SCP_string profile_output;
-
-void profile_init();
-void profile_deinit();
-void profile_begin(const char* name);
-void profile_begin(SCP_string &output_handle, const char* name);
-void profile_end(const char* name);
-void profile_dump_output();
-void profile_dump_json_output();
-void store_profile_in_history(SCP_string &name, float percent, uint64_t time);
-void get_profile_from_history(SCP_string &name, float* avg, float* min, float* max, uint64_t *avg_micro_sec, uint64_t *min_micro_sec, uint64_t *max_micro_sec);
-
-class profile_auto
-{
-	SCP_string name;
-public:
-	profile_auto(const char* profile_name): name(profile_name)
-	{
-		profile_begin(profile_name);
-	}
-
-	~profile_auto()
-	{
-		profile_end(name.c_str());
-	}
-};
-
-// Helper macro to encapsulate a single function call in a profile_begin()/profile_end() pair.
-#define PROFILE(name, function) { profile_begin(name); function; profile_end(name); }
-
-//====================================================================================
-
 #define MAX_LIGHTS 256
 #define MAX_LIGHT_LEVELS 16
 

--- a/code/graphics/2d.cpp
+++ b/code/graphics/2d.cpp
@@ -36,6 +36,7 @@
 #include "parse/scripting.h"
 #include "parse/parselo.h"
 #include "render/3d.h"
+#include "tracing/tracing.h"
 
 #if ( SDL_VERSION_ATLEAST(1, 2, 7) )
 #include "SDL_cpuinfo.h"

--- a/code/graphics/2d.h
+++ b/code/graphics/2d.h
@@ -286,7 +286,8 @@ typedef enum gr_capability {
 	CAPABILITY_DEFERRED_LIGHTING,
 	CAPABILITY_SHADOWS,
 	CAPABILITY_BATCHED_SUBMODELS,
-	CAPABILITY_POINT_PARTICLES
+	CAPABILITY_POINT_PARTICLES,
+	CAPABILITY_TIMESTAMP_QUERY,
 } gr_capability;
 
 // stencil buffering stuff
@@ -593,6 +594,10 @@ struct light;
 #define GR_FOGMODE_NONE				0		// set this to turn off fog
 #define GR_FOGMODE_FOG				1		// linear fog
 
+enum class QueryType {
+	Timestamp
+};
+
 typedef struct screen {
 	uint	signature;			// changes when mode or palette or width or height changes
 	int	max_w, max_h;		// Width and height
@@ -844,6 +849,12 @@ typedef struct screen {
 
 	void (*gf_push_debug_group)(const char* name);
 	void (*gf_pop_debug_group)();
+
+	int (*gf_create_query_object)();
+	void (*gf_query_value)(int obj, QueryType type);
+	bool (*gf_query_value_available)(int obj);
+	std::uint64_t (*gf_get_query_value)(int obj);
+	void (*gf_delete_query_object)(int obj);
 } screen;
 
 // handy macro
@@ -1186,6 +1197,31 @@ inline void gr_push_debug_group(const char* name)
 inline void gr_pop_debug_group()
 {
 	(*gr_screen.gf_pop_debug_group)();
+}
+
+inline int gr_create_query_object()
+{
+	return (*gr_screen.gf_create_query_object)();
+}
+
+inline void gr_query_value(int obj, QueryType type)
+{
+	(*gr_screen.gf_query_value)(obj, type);
+}
+
+inline bool gr_query_value_available(int obj)
+{
+	return (*gr_screen.gf_query_value_available)(obj);
+}
+
+inline std::uint64_t gr_get_query_value(int obj)
+{
+	return (*gr_screen.gf_get_query_value)(obj);
+}
+
+inline void gr_delete_query_object(int obj)
+{
+	(*gr_screen.gf_delete_query_object)(obj);
 }
 
 // color functions

--- a/code/graphics/grstub.cpp
+++ b/code/graphics/grstub.cpp
@@ -497,6 +497,29 @@ void gr_stub_push_debug_group(const char*){
 void gr_stub_pop_debug_group(){
 }
 
+int gr_stub_create_query_object()
+{
+	return -1;
+}
+
+void gr_stub_query_value(int obj, QueryType type)
+{
+}
+
+bool gr_stub_query_value_available(int obj)
+{
+	return false;
+}
+
+std::uint64_t gr_stub_get_query_value(int obj)
+{
+	return 0;
+}
+
+void gr_stub_delete_query_object(int obj)
+{
+}
+
 bool gr_stub_init() 
 {
 	if (gr_screen.res != GR_640) {
@@ -674,6 +697,12 @@ bool gr_stub_init()
 
 	gr_screen.gf_push_debug_group = gr_stub_push_debug_group;
 	gr_screen.gf_pop_debug_group = gr_stub_pop_debug_group;
+
+	gr_screen.gf_create_query_object = gr_stub_create_query_object;
+	gr_screen.gf_query_value = gr_stub_query_value;
+	gr_screen.gf_query_value_available = gr_stub_query_value_available;
+	gr_screen.gf_get_query_value = gr_stub_get_query_value;
+	gr_screen.gf_delete_query_object = gr_stub_delete_query_object;
 
 	return true;
 }

--- a/code/graphics/opengl/gropengl.cpp
+++ b/code/graphics/opengl/gropengl.cpp
@@ -16,6 +16,7 @@
 #include "gropengldraw.h"
 #include "gropengllight.h"
 #include "gropenglpostprocessing.h"
+#include "gropenglquery.h"
 #include "gropenglshader.h"
 #include "gropenglstate.h"
 #include "gropengltexture.h"
@@ -1252,6 +1253,12 @@ void opengl_setup_function_pointers()
 	gr_screen.gf_push_debug_group = gr_opengl_push_debug_group;
 	gr_screen.gf_pop_debug_group = gr_opengl_pop_debug_group;
 
+	gr_screen.gf_create_query_object = gr_opengl_create_query_object;
+	gr_screen.gf_query_value = gr_opengl_query_value;
+	gr_screen.gf_query_value_available = gr_opengl_query_value_available;
+	gr_screen.gf_get_query_value = gr_opengl_get_query_value;
+	gr_screen.gf_delete_query_object = gr_opengl_delete_query_object;
+
 	// NOTE: All function pointers here should have a Cmdline_nohtl check at the top
 	//       if they shouldn't be run in non-HTL mode, Don't keep separate entries.
 	// *****************************************************************************
@@ -1619,6 +1626,8 @@ bool gr_opengl_is_capable(gr_capability capability)
 		return (GLSL_version >= 150);
 	case CAPABILITY_POINT_PARTICLES:
 		return GL_version >= 32 && !Cmdline_no_geo_sdr_effects;
+	case CAPABILITY_TIMESTAMP_QUERY:
+		return GL_version >= 33; // Timestamp queries are available from 3.3 onwards
 	}
 
 	return false;

--- a/code/graphics/opengl/gropenglquery.cpp
+++ b/code/graphics/opengl/gropenglquery.cpp
@@ -1,0 +1,82 @@
+
+#include "graphics/opengl/gropenglquery.h"
+#include "graphics/opengl/gropengl.h"
+
+namespace {
+
+struct query_object_slot {
+	bool used = false;
+	GLuint name = 0;
+};
+
+SCP_vector<query_object_slot> query_objects;
+
+int get_new_query_slot() {
+	auto end = query_objects.end();
+	for (auto iter = query_objects.begin(); iter != end; ++iter) {
+		if (!iter->used) {
+			return (int) std::distance(query_objects.begin(), iter);
+		}
+	}
+
+	query_objects.emplace_back();
+	return (int) (query_objects.size() - 1);
+}
+
+query_object_slot& get_query_slot(int handle) {
+	Assertion(handle >= 0 && handle < (int)query_objects.size(), "Query object index %d is invalid!", handle);
+	return query_objects[handle];
+}
+
+}
+
+int gr_opengl_create_query_object() {
+	auto idx = get_new_query_slot();
+
+	auto& slot = query_objects[idx];
+	slot.used = true;
+
+	glGenQueries(1, &slot.name);
+
+	return idx;
+}
+
+void gr_opengl_query_value(int obj, QueryType type) {
+	auto& slot = get_query_slot(obj);
+
+	switch(type) {
+		case QueryType::Timestamp:
+			Assertion(GL_version >= 33, "Timestamp queries are only available from OpenGL 3.3 onwards.");
+			glQueryCounter(slot.name, GL_TIMESTAMP);
+			break;
+		default:
+			Assertion(false, "Unhandled enum value!");
+			break;
+	}
+}
+
+bool gr_opengl_query_value_available(int obj) {
+	auto& slot = get_query_slot(obj);
+
+	GLuint available;
+	glGetQueryObjectuiv(slot.name, GL_QUERY_RESULT_AVAILABLE, &available);
+
+	return available == GL_TRUE;
+}
+
+std::uint64_t gr_opengl_get_query_value(int obj) {
+	auto& slot = get_query_slot(obj);
+
+	GLuint64 available;
+	glGetQueryObjectui64v(slot.name, GL_QUERY_RESULT, &available);
+
+	return available;
+}
+
+void gr_opengl_delete_query_object(int obj) {
+	auto& slot = get_query_slot(obj);
+	glDeleteQueries(1, &slot.name);
+
+	slot.name = 0;
+	slot.used = false;
+}

--- a/code/graphics/opengl/gropenglquery.h
+++ b/code/graphics/opengl/gropenglquery.h
@@ -1,0 +1,18 @@
+
+#ifndef _GROPENGLQUERY_H
+#define _GROPENGLQUERY_H
+#pragma once
+
+#include "graphics/2d.h"
+
+int gr_opengl_create_query_object();
+
+void gr_opengl_query_value(int obj, QueryType type);
+
+bool gr_opengl_query_value_available(int obj);
+
+std::uint64_t gr_opengl_get_query_value(int obj);
+
+void gr_opengl_delete_query_object(int obj);
+
+#endif // _GROPENGLQUERY_H

--- a/code/io/timer.h
+++ b/code/io/timer.h
@@ -40,10 +40,10 @@ extern void timer_close();
 // 1 hr, respectively.
 
 extern fix timer_get_fixed_seconds();		// Rolls about every 9 hours...
-extern fix timer_get_fixed_secondsX();		// Assume interrupts already disabled
 extern fix timer_get_approx_seconds();		// Returns time since program started... accurate to 1/120th of a second
 extern int timer_get_milliseconds();		//
 extern std::uint64_t timer_get_microseconds();
+extern std::uint64_t timer_get_nanoseconds();
 extern int timer_get_seconds();				// seconds since program started... not accurate, but good for long
 											//     runtimes with second-based timeouts
 

--- a/code/mission/missiongoals.cpp
+++ b/code/mission/missiongoals.cpp
@@ -33,6 +33,7 @@
 #include "parse/parselo.h"
 #include "parse/sexp.h"
 #include "playerman/player.h"
+#include "tracing/tracing.h"
 #include "ui/ui.h"
 
 

--- a/code/model/modelrender.cpp
+++ b/code/model/modelrender.cpp
@@ -25,6 +25,7 @@
 #include "math/staticrand.h"
 #include "ship/ship.h"
 #include "ship/shipfx.h"
+#include "tracing/tracing.h"
 #include "weapon/weapon.h"
 
 extern int Model_texturing;

--- a/code/object/objcollide.cpp
+++ b/code/object/objcollide.cpp
@@ -15,6 +15,7 @@
 #include "object/object.h"
 #include "object/objectdock.h"
 #include "ship/ship.h"
+#include "tracing/tracing.h"
 #include "weapon/beam.h"
 #include "weapon/weapon.h"
 

--- a/code/object/object.cpp
+++ b/code/object/object.cpp
@@ -38,6 +38,7 @@
 #include "render/3d.h"
 #include "ship/afterburner.h"
 #include "ship/ship.h"
+#include "tracing/tracing.h"
 #include "weapon/beam.h"
 #include "weapon/shockwave.h"
 #include "weapon/swarm.h"

--- a/code/object/objectsort.cpp
+++ b/code/object/objectsort.cpp
@@ -26,6 +26,7 @@
 #include "render/3d.h"
 #include "render/batching.h"
 #include "ship/ship.h"
+#include "tracing/tracing.h"
 #include "weapon/weapon.h"
 
 

--- a/code/particle/particle.cpp
+++ b/code/particle/particle.cpp
@@ -21,6 +21,7 @@
 #include "particle/particle.h"
 #include "render/3d.h"
 #include "render/batching.h"
+#include "tracing/tracing.h"
 
 using namespace particle;
 

--- a/code/render/batching.cpp
+++ b/code/render/batching.cpp
@@ -13,6 +13,7 @@
 #include "graphics/2d.h"
 #include "render/3d.h"
 #include "graphics/material.h"
+#include "tracing/tracing.h"
 
 static SCP_map<batch_info, primitive_batch> Batching_primitives;
 static SCP_map<batch_buffer_key, primitive_batch_buffer> Batching_buffers;

--- a/code/source_groups.cmake
+++ b/code/source_groups.cmake
@@ -304,6 +304,7 @@ set (file_root_graphics_openglgr_opengl_cpps
 	graphics/opengl/gropengldraw.cpp
 	graphics/opengl/gropengllight.cpp
 	graphics/opengl/gropenglpostprocessing.cpp
+	graphics/opengl/gropenglquery.cpp
 	graphics/opengl/gropenglshader.cpp
 	graphics/opengl/gropenglstate.cpp
 	graphics/opengl/gropengltexture.cpp
@@ -318,6 +319,7 @@ set (file_root_graphics_openglgr_opengl_headers
 	graphics/opengl/gropengldraw.h
 	graphics/opengl/gropengllight.h
 	graphics/opengl/gropenglpostprocessing.h
+	graphics/opengl/gropenglquery.h
 	graphics/opengl/gropenglshader.h
 	graphics/opengl/gropenglstate.h
 	graphics/opengl/gropengltexture.h

--- a/code/source_groups.cmake
+++ b/code/source_groups.cmake
@@ -241,7 +241,6 @@ set (file_root_globalincs
 	globalincs/fsmemory.h
 	globalincs/globals.h
 	globalincs/linklist.h
-	globalincs/profiling.cpp
 	globalincs/pstypes.h
 	globalincs/safe_strings.cpp
 	globalincs/safe_strings.h
@@ -965,6 +964,12 @@ set (file_root_tgautils
 	tgautils/tgautils.h
 )
 
+# Tracing files
+set (file_root_tracing
+	tracing/tracing.h
+	tracing/tracing.cpp
+)
+
 # Ui files
 set (file_root_ui
 	ui/button.cpp
@@ -1098,6 +1103,7 @@ source_group("Species_Defs"                       FILES ${file_root_species_defs
 source_group("Starfield"                          FILES ${file_root_starfield})
 source_group("Stats"                              FILES ${file_root_stats})
 source_group("TgaUtils"                           FILES ${file_root_tgautils})
+source_group("Tracing"                            FILES ${file_root_tracing})
 source_group("Ui"                                 FILES ${file_root_ui})
 source_group("Weapon"                             FILES ${file_root_weapon})
 source_group("Windows Stubs"                      FILES ${file_root_windows_stubs})
@@ -1181,6 +1187,7 @@ set (file_root
 	${file_root_starfield}
 	${file_root_stats}
 	${file_root_tgautils}
+	${file_root_tracing}
 	${file_root_ui}
 	${file_root_weapon}
 	${file_root_windows_stubs}

--- a/code/tracing/tracing.cpp
+++ b/code/tracing/tracing.cpp
@@ -7,11 +7,12 @@
  *
 */ 
 
+#include "tracing/tracing.h"
 #include "cmdline/cmdline.h"
 #include "globalincs/pstypes.h"
-#include "globalincs/systemvars.h"
 #include "io/timer.h"
 #include "parse/parselo.h"
+#include "globalincs/systemvars.h"
 
 #if SCP_COMPILER_IS_MSVC
 #include <direct.h>

--- a/code/tracing/tracing.cpp
+++ b/code/tracing/tracing.cpp
@@ -124,7 +124,7 @@ struct tracing_data
 
 struct tracing_frame_data {
 	SCP_vector<tracing_data> data;
-	size_t frame_num;
+	std::uint64_t frame_num;
 };
 
 static SCP_vector<tracing_frame_data> pending_frame_data;

--- a/code/tracing/tracing.cpp
+++ b/code/tracing/tracing.cpp
@@ -10,6 +10,7 @@
 #include "tracing/tracing.h"
 #include "cmdline/cmdline.h"
 #include "globalincs/pstypes.h"
+#include "graphics/2d.h"
 #include "io/timer.h"
 #include "parse/parselo.h"
 #include "globalincs/systemvars.h"
@@ -87,7 +88,9 @@ SCP_string profile_output;
 std::ofstream profiling_file;
 
 static SCP_vector<int> query_objects;
+// The GPU timestamp queries use an internal free list to reduce the number of graphics API calls
 static SCP_queue<int> free_query_objects;
+static bool do_gpu_queries = true;
 
 static int get_query_object() {
 	if (!free_query_objects.empty()) {
@@ -96,10 +99,15 @@ static int get_query_object() {
 		return id;
 	}
 
-	auto id = g
+	auto id = gr_create_query_object();
+	query_objects.push_back(id);
+	return id;
+}
+static void free_query_object(int obj) {
+	free_query_objects.push(obj);
 }
 
-struct json_data
+struct tracing_data
 {
 	SCP_string name;
 	
@@ -108,10 +116,111 @@ struct json_data
 	
 	uint64_t time;
 
+	int gpu_query;
+	uint64_t gpu_time;
+
 	bool enter;
 };
 
-static SCP_vector<json_data> json_profile_data;
+struct tracing_frame_data {
+	SCP_vector<tracing_data> data;
+	size_t frame_num;
+};
+
+static SCP_vector<tracing_frame_data> pending_frame_data;
+
+static void write_json_data_file(const tracing_frame_data& data, const SCP_string& file_name, bool print_gpu_times) {
+	std::ofstream out(file_name, std::ios::out | std::ios::binary);
+	out << "[";
+
+	auto first = true;
+	// Output CPU times
+	for (auto& trace : data.data)
+	{
+		if (!first) {
+			out << ",";
+		}
+		out << "\n{\"tid\": " << trace.tid << ",\"ts\":";
+
+		// Save stream state
+		auto flags = out.flags();
+		out << std::fixed;
+
+		if (print_gpu_times) {
+			out << trace.gpu_time / 1000.;
+		} else {
+			out << trace.time / 1000.;
+		}
+
+		// and now restore it
+		out.flags(flags);
+
+		out << ",\"pid\":";
+		if (print_gpu_times) {
+			out << "\"GPU\"";
+		} else {
+			out << trace.pid;
+		}
+
+		out << ",\"name\":\"" << trace.name << "\",\"ph\":\"" << (trace.enter ? "B" : "E") << "\"}";
+
+		first = false;
+	}
+	out << "]\n";
+}
+
+static void write_json_data(const tracing_frame_data& data)
+{
+	SCP_string file_path;
+
+	sprintf(file_path, "tracing/cpu_%" PRIu64 ".json", data.frame_num);
+	write_json_data_file(data, file_path, false);
+
+	sprintf(file_path, "tracing/gpu_%" PRIu64 ".json", data.frame_num);
+	write_json_data_file(data, file_path, true);
+}
+
+static void process_pending_data() {
+	while (!pending_frame_data.empty()) {
+		auto& frame_data = pending_frame_data.front();
+
+		bool finished;
+		if (!do_gpu_queries) {
+			finished = true;
+		} else {
+			// Determine if all queries have passed already
+			finished = true;
+			for (auto& trace_data : frame_data.data) {
+				if (trace_data.gpu_query == -1) {
+					// Event has been processed before
+					continue;
+				}
+
+				if (gr_query_value_available(trace_data.gpu_query)) {
+					trace_data.gpu_time = gr_get_query_value(trace_data.gpu_query);
+					free_query_object(trace_data.gpu_query);
+					trace_data.gpu_query = -1;
+				} else {
+					// If we are here then a query hasn't finished yet. Try again next time...
+					finished = false;
+					break;
+				}
+			}
+		}
+
+		if (finished) {
+			std::thread writer_thread(std::bind(write_json_data, frame_data));
+			writer_thread.detach();
+
+			pending_frame_data.erase(pending_frame_data.begin());
+		} else {
+			// GPU queries always finish in sequence so the later queries can't be finished yet
+			break;
+		}
+	}
+}
+
+static SCP_vector<tracing_data> current_frame_data;
 static uint64_t json_frame_num = 0;
 static std::mutex json_mutex;
 
@@ -150,7 +259,16 @@ void profile_deinit()
 	if (Cmdline_json_profiling)
 	{
 		profile_dump_json_output();
+		while (!pending_frame_data.empty()) {
+			process_pending_data();
+		}
 	}
+
+	for (auto obj : query_objects) {
+		gr_delete_query_object(obj);
+	}
+	query_objects.clear();
+	SCP_queue<int>().swap(free_query_objects);
 }
 
 /**
@@ -164,7 +282,7 @@ void profile_begin(const char* name)
 	{
 		std::lock_guard<std::mutex> guard(json_mutex);
 
-		json_data data;
+		tracing_data data;
 
 		data.name = name;
 		
@@ -172,9 +290,16 @@ void profile_begin(const char* name)
 		data.tid = get_tid();
 
 		data.enter = true;
-		data.time = timer_get_microseconds();
+		data.time = timer_get_nanoseconds();
 
-		json_profile_data.push_back(data);
+		if (do_gpu_queries) {
+			data.gpu_query = get_query_object();
+			gr_query_value(data.gpu_query, QueryType::Timestamp);
+		} else {
+			data.gpu_query = -1;
+		}
+
+		current_frame_data.push_back(data);
 	}
 
 	if (Cmdline_frame_profile)
@@ -231,7 +356,7 @@ void profile_end(const char* name)
 	{
 		std::lock_guard<std::mutex> guard(json_mutex);
 
-		json_data data;
+		tracing_data data;
 
 		data.name = name;
 
@@ -239,9 +364,16 @@ void profile_end(const char* name)
 		data.tid = get_tid();
 
 		data.enter = false;
-		data.time = timer_get_microseconds();
+		data.time = timer_get_nanoseconds();
 
-		json_profile_data.push_back(data);
+		if (do_gpu_queries) {
+			data.gpu_query = get_query_object();
+			gr_query_value(data.gpu_query, QueryType::Timestamp);
+		} else {
+			data.gpu_query = -1;
+		}
+
+		current_frame_data.push_back(data);
 	}
 
 	if (Cmdline_frame_profile) {
@@ -369,30 +501,6 @@ void profile_dump_output()
 	}
 }
 
-static void write_json_data(const SCP_vector<json_data>& data, uint64_t frame_num)
-{
-	SCP_string file_path;
-	sprintf(file_path, "tracing/frame_%" PRIu64 ".json", frame_num);
-
-	std::ofstream out(file_path, std::ios::out | std::ios::binary);
-	out << "[\n";
-
-	auto end = data.end();
-	for (auto iter = data.begin(); iter != end; ++iter)
-	{
-		// {"tid": 4692, "ts": 13716257504, "pid": 4028, "name": "Main Frame", "ph": "B"}
-		out << "{\"tid\": " << iter->tid << ",\"ts\":" << iter->time << ",\"pid\":" << iter->pid
-			<< ",\"name\":\"" << iter->name << "\",\"ph\":\"" << (iter->enter ? "B" : "E") << "\"}";
-
-		if (iter +  1 != end)
-		{
-			out << ",";
-		}
-		out << "\n";
-	}
-	out << "]\n";
-}
-
 /**
  * @brief Writes JSON tracing data to a file if the commandlinfe option is enabled
  */
@@ -402,10 +510,15 @@ void profile_dump_json_output() {
 
 		// FIXME: This could be improved by using only a single thread and a synchronized bounded
 		// queue. Boost has an implementation of that.
-		std::thread writer_thread(std::bind(write_json_data, SCP_vector<json_data>(json_profile_data), ++json_frame_num));
-		writer_thread.detach();
+		tracing_frame_data frame_data;
+		frame_data.data = current_frame_data;
+		frame_data.frame_num = ++json_frame_num;
 
-		json_profile_data.clear();
+		pending_frame_data.push_back(std::move(frame_data));
+
+		current_frame_data.clear();
+
+		process_pending_data();
 	}
 }
 

--- a/code/tracing/tracing.h
+++ b/code/tracing/tracing.h
@@ -1,0 +1,65 @@
+//
+//
+
+#ifndef _TRACING_H
+#define _TRACING_H
+#pragma once
+
+#include "globalincs/pstypes.h"
+
+typedef struct profile_sample {
+	uint profile_instances;
+	int open_profiles;
+	//char name[256];
+	SCP_string name;
+	std::uint64_t start_time;	// in microseconds
+	std::uint64_t accumulator;
+	std::uint64_t children_sample_time;
+	uint num_parents;
+	uint num_children;
+	int parent;
+} profile_sample;
+
+typedef struct profile_sample_history {
+	bool valid;
+	//char name[256];
+	SCP_string name;
+	float avg;
+	float min;
+	float max;
+	std::uint64_t avg_micro_sec;
+	std::uint64_t min_micro_sec;
+	std::uint64_t max_micro_sec;
+} profile_sample_history;
+
+extern SCP_string profile_output;
+
+void profile_init();
+void profile_deinit();
+void profile_begin(const char* name);
+void profile_begin(SCP_string &output_handle, const char* name);
+void profile_end(const char* name);
+void profile_dump_output();
+void profile_dump_json_output();
+void store_profile_in_history(SCP_string &name, float percent, uint64_t time);
+void get_profile_from_history(SCP_string &name, float* avg, float* min, float* max, uint64_t *avg_micro_sec, uint64_t *min_micro_sec, uint64_t *max_micro_sec);
+
+class profile_auto
+{
+	SCP_string name;
+ public:
+	profile_auto(const char* profile_name): name(profile_name)
+	{
+		profile_begin(profile_name);
+	}
+
+	~profile_auto()
+	{
+		profile_end(name.c_str());
+	}
+};
+
+// Helper macro to encapsulate a single function call in a profile_begin()/profile_end() pair.
+#define PROFILE(name, function) { profile_begin(name); function; profile_end(name); }
+
+#endif //_TRACING_H

--- a/code/weapon/trails.cpp
+++ b/code/weapon/trails.cpp
@@ -15,6 +15,7 @@
 #include "io/timer.h"
 #include "render/3d.h" 
 #include "ship/ship.h"
+#include "tracing/tracing.h"
 #include "weapon/trails.h"
 
 int Num_trails;

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -157,6 +157,7 @@
 #include "starfield/supernova.h"
 #include "stats/medals.h"
 #include "stats/stats.h"
+#include "tracing/tracing.h"
 #include "weapon/beam.h"
 #include "weapon/emp.h"
 #include "weapon/flak.h"


### PR DESCRIPTION
This adds support for profiling the time the GPU takes for executing a set of commands. The OpenGL renderer uses query objects with timestamp queries to implement this and those values are then written in the same format the CPU times are already being written. The chrome trace viewer always threw an error when I tried to combine the two data sets so I choose to write the two data sets to two different files which can be opened separately.