### PR TITLE
Fix ADPCM playback with older FFmpeg versions

### DIFF
--- a/code/sound/ffmpeg/FFmpegAudioReader.cpp
+++ b/code/sound/ffmpeg/FFmpegAudioReader.cpp
@@ -46,8 +46,29 @@ bool FFmpegAudioReader::readFrame(AVFrame* decode_frame) {
 		return false;
 	}
 #else
-	// Assume that everything was handled before for this version
-	// That might not be true in all cases but supporting those rare cases for an outdated version is not worth the trouble
+	if (_currentPacket != nullptr) {
+		// Got some data left
+		int finishedFrame = 0;
+		auto bytes_read = avcodec_decode_audio4(_codec_ctx, decode_frame, &finishedFrame, _currentPacket);
+
+		if (bytes_read < 0) {
+			// Error!
+			return false;
+		}
+
+		_currentPacket->data += bytes_read;
+		_currentPacket->size -= bytes_read;
+
+		if (_currentPacket->size <= 0) {
+			// Done with this packet
+			av_packet_unref(_currentPacket);
+			av_packet_free(&_currentPacket);
+		}
+
+		if (finishedFrame) {
+			return true;
+		}
+	}
 #endif
 
 	AVPacket packet;
@@ -80,13 +101,21 @@ bool FFmpegAudioReader::readFrame(AVFrame* decode_frame) {
 			// EGAIN was returned, send new input
 #else
 			int finishedFrame = 0;
-			auto err = avcodec_decode_audio4(_codec_ctx, decode_frame, &finishedFrame, &packet);
+			auto bytes_read = avcodec_decode_audio4(_codec_ctx, decode_frame, &finishedFrame, &packet);
+
+			if (bytes_read < packet.size) {
+				// Not all data was read
+				packet.data += bytes_read;
+				packet.size -= bytes_read;
+
+				_currentPacket = av_packet_clone(&packet);
+			}
 
 			if (finishedFrame) {
 				return true;
 			}
 
-			if (err < 0) {
+			if (bytes_read < 0) {
 				// Error
 				return false;
 			}
@@ -123,4 +152,18 @@ bool FFmpegAudioReader::readFrame(AVFrame* decode_frame) {
 	// If we are here then read_frame reached the end or returned an error
 	return false;
 }
+FFmpegAudioReader::~FFmpegAudioReader() {
+#if LIBAVCODEC_VERSION_INT <= AV_VERSION_INT(57, 24, 255)
+    if (_currentPacket != nullptr) {
+		av_packet_unref(_currentPacket);
+		av_packet_free(&_currentPacket);
+	}
+#endif
+}
+
+#if LIBAVCODEC_VERSION_INT <= AV_VERSION_INT(57, 24, 255)
+void FFmpegAudioReader::processPendingPacket() {
+
+}
+#endif
 }

--- a/code/sound/ffmpeg/FFmpegAudioReader.cpp
+++ b/code/sound/ffmpeg/FFmpegAudioReader.cpp
@@ -160,10 +160,4 @@ FFmpegAudioReader::~FFmpegAudioReader() {
 	}
 #endif
 }
-
-#if LIBAVCODEC_VERSION_INT <= AV_VERSION_INT(57, 24, 255)
-void FFmpegAudioReader::processPendingPacket() {
-
-}
-#endif
 }

--- a/code/sound/ffmpeg/FFmpegAudioReader.h
+++ b/code/sound/ffmpeg/FFmpegAudioReader.h
@@ -16,8 +16,15 @@ class FFmpegAudioReader
 	AVFormatContext* _format_ctx = nullptr;
 	AVCodecContext* _codec_ctx = nullptr;
 
+#if LIBAVCODEC_VERSION_INT <= AV_VERSION_INT(57, 24, 255)
+    AVPacket* _currentPacket = nullptr;
+
+	void processPendingPacket();
+#endif
+
 public:
 	FFmpegAudioReader(AVFormatContext* av_format_context, AVCodecContext* codec_ctx, int stream_idx);
+	~FFmpegAudioReader();
 
 	bool readFrame(AVFrame* decode_frame);
 };

--- a/code/sound/ffmpeg/FFmpegAudioReader.h
+++ b/code/sound/ffmpeg/FFmpegAudioReader.h
@@ -18,8 +18,6 @@ class FFmpegAudioReader
 
 #if LIBAVCODEC_VERSION_INT <= AV_VERSION_INT(57, 24, 255)
     AVPacket* _currentPacket = nullptr;
-
-	void processPendingPacket();
 #endif
 
 public:

--- a/code/sound/ffmpeg/WaveFile.h
+++ b/code/sound/ffmpeg/WaveFile.h
@@ -24,6 +24,9 @@ struct AudioProperties
 	AVSampleFormat format = AV_SAMPLE_FMT_NONE;
 };
 
+// Forward declaration
+class FFmpegAudioReader;
+
 /**
  * @brief A class responsible for reading auto data from media files
  *
@@ -46,6 +49,8 @@ class WaveFile
 	AVFrame* m_decodeFrame;
 
 	AVCodecContext* m_audioCodecCtx;
+
+	std::unique_ptr<FFmpegAudioReader> m_frameReader;
 
 	size_t getBufferedData(uint8_t* buffer, size_t buffer_size);
  public:


### PR DESCRIPTION
ADPCM playback was broken by #991 when an older FFmpeg version (< 3.1)
was used. The newer version has a better API for handling decoders that
return multiple frames of data per packet which I already used. However,
I didn't bother implementing that for the older API since I haven't seen
a decoder that actually returned multiple frames per packet but ADPCM is
such a decoder. This fixes that by implementing the correct behavior
with the old API.