### PR TITLE
Fix Coverity 1363382

### DIFF
--- a/code/hud/hudmessage.cpp
+++ b/code/hud/hudmessage.cpp
@@ -1345,8 +1345,9 @@ bool HudGaugeTalkingHead::canRender()
 	return true;
 }
 
-HudGaugeFixedMessages::HudGaugeFixedMessages():
-HudGauge(HUD_OBJECT_FIXED_MESSAGES, HUD_MESSAGE_LINES, false, true, (VM_WARP_CHASE), 255, 255, 255)
+HudGaugeFixedMessages::HudGaugeFixedMessages()
+	: HudGauge(HUD_OBJECT_FIXED_MESSAGES, HUD_MESSAGE_LINES, false, true, (VM_WARP_CHASE), 255, 255, 255)
+	, center_text(true)
 {
 }
 


### PR DESCRIPTION
Init center_text in ctor, safety/defensive measure only since is
currently correctly set via init function in all code paths