### PR TITLE
Add alternate pof for use in techroom

### DIFF
--- a/code/missionui/missionweaponchoice.cpp
+++ b/code/missionui/missionweaponchoice.cpp
@@ -755,7 +755,12 @@ void wl_render_overhead_view(float frametime)
 		{
 			if (wl_ship->model_num < 0)
 			{
-				wl_ship->model_num = model_load(sip->pof_file, sip->n_subsystems, &sip->subsystems[0]);
+				if (sip->pof_file_tech[0] != '\0') {
+					wl_ship->model_num = model_load(sip->pof_file_tech, sip->n_subsystems, &sip->subsystems[0]);
+				}
+				else {
+					wl_ship->model_num = model_load(sip->pof_file, sip->n_subsystems, &sip->subsystems[0]);
+				}
 				model_page_in_textures(wl_ship->model_num, ship_class);
 			}
 
@@ -823,13 +828,18 @@ void wl_render_overhead_view(float frametime)
 		// Load the necessary model file, if necessary
 		if (wl_ship->model_num < 0)
 		{
-			wl_ship->model_num = model_load(sip->pof_file, sip->n_subsystems, &sip->subsystems[0]);
+			if (sip->pof_file_tech[0] != '\0') {
+				wl_ship->model_num = model_load(sip->pof_file_tech, sip->n_subsystems, &sip->subsystems[0]);
+			}
+			else {
+				wl_ship->model_num = model_load(sip->pof_file, sip->n_subsystems, &sip->subsystems[0]);
+			}
 			model_page_in_textures(wl_ship->model_num, ship_class);
 		}
 		
 		if (wl_ship->model_num < 0)
 		{
-			mprintf(("Couldn't load model file in missionweaponchoice.cpp\n"));
+			mprintf(("Couldn't load model file '%s' in missionweaponchoice.cpp\n", sip->pof_file));
 		}
 		else
 		{

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -811,6 +811,7 @@ void ship_info::clone(const ship_info& other)
 	cockpit_offset = other.cockpit_offset;
 	strcpy_s(pof_file, other.pof_file);
 	strcpy_s(pof_file_hud, other.pof_file_hud);
+	strcpy_s(pof_file_tech, other.pof_file_tech);
 	num_detail_levels = other.num_detail_levels;
 	memcpy(detail_distance, other.detail_distance, sizeof(int) * MAX_SHIP_DETAIL_LEVELS);
 	collision_lod = other.collision_lod;
@@ -1125,6 +1126,7 @@ void ship_info::move(ship_info&& other)
 	std::swap(cockpit_offset, other.cockpit_offset);
 	std::swap(pof_file, other.pof_file);
 	std::swap(pof_file_hud, other.pof_file_hud);
+	std::swap(pof_file_tech, other.pof_file_tech);
 	num_detail_levels = other.num_detail_levels;
 	std::swap(detail_distance, other.detail_distance);
 	collision_lod = other.collision_lod;
@@ -1451,6 +1453,7 @@ ship_info::ship_info()
 	vm_vec_zero(&cockpit_offset);
 	pof_file[0] = '\0';
 	pof_file_hud[0] = '\0';
+	pof_file_tech[0] = '\0';
 	num_detail_levels = 1;
 	detail_distance[0] = 0;
 	collision_lod = -1;
@@ -2469,6 +2472,26 @@ int parse_ship_values(ship_info* sip, const bool is_template, const bool first_t
 			strcpy_s(sip->pof_file, temp);
 		else
 			WarningEx(LOCATION, "Ship %s\nPOF file \"%s\" invalid!", sip->name, temp);
+	}
+
+	if(optional_string( "$POF file Techroom:" ))
+	{
+		char temp[MAX_FILENAME_LEN];
+		stuff_string(temp, F_NAME, MAX_FILENAME_LEN);
+
+		// assume we're using this file name
+		bool valid = true;
+
+		// if this is a modular table, and we're replacing an existing file name, and the file doesn't exist, don't replace it
+		if (replace)
+			if (sip->pof_file_tech[0] != '\0')
+				if (!cf_exists_full(temp, CF_TYPE_MODELS))
+					valid = false;
+
+		if (valid)
+			strcpy_s(sip->pof_file_tech, temp);
+		else
+			WarningEx(LOCATION, "Ship %s\nTechroom POF file \"%s\" invalid!", sip->name, temp);
 	}
 
 	// ship class texture replacement - Goober5000

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -936,6 +936,7 @@ public:
 	vec3d		cockpit_offset;
 	char		pof_file[MAX_FILENAME_LEN];			// POF file to load/associate with ship
 	char		pof_file_hud[MAX_FILENAME_LEN];		// POF file to load for the HUD target box
+	char		pof_file_tech[MAX_FILENAME_LEN];	// POF file to load for the techroom
 	int		num_detail_levels;				// number of detail levels for this ship
 	int		detail_distance[MAX_SHIP_DETAIL_LEVELS];					// distance to change detail levels at
 	int		collision_lod;						// check for collisions using a LOD


### PR DESCRIPTION
Designed to work around issues with gunpoints on animated subsystems,
and those gunpoints being in the "triggered" position, and thus there's
lines pointing to empty space in the weapon loadout screen.

Use this to specify an alternate model that has the gunpoints in the
"correct" position.

(finally implemented alternate solution to #627)