### PR TITLE
Show an error dialog when an exception is thrown in main

### DIFF
--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -8479,7 +8479,7 @@ int actual_main(int argc, char *argv[])
 
 #if defined(GAME_ERRORLOG_TXT) && defined(_MSC_VER)
 	__try {
-#else
+#elif !defined(DONT_CATCH_MAIN_EXCEPTIONS)
 	try {
 #endif
 		result = game_main(argc, argv);
@@ -8491,14 +8491,18 @@ int actual_main(int argc, char *argv[])
 		// get called unless you return EXCEPTION_EXECUTE_HANDLER from
 		// the __except clause.
 	}
-#else
+#elif !defined(DONT_CATCH_MAIN_EXCEPTIONS)
 	}
-	catch (std::exception &ex) {
+	catch (const std::exception &ex) {
+		Error(LOCATION, "Caught std::exception in main(): '%s'!", ex.what());
 		fprintf(stderr, "Caught std::exception in main(): '%s'!\n", ex.what());
+
 		result = EXIT_FAILURE;
 	}
 	catch (...) {
+		Error(LOCATION, "Caught exception in main()!");
 		fprintf(stderr, "Caught exception in main()!\n");
+
 		result = EXIT_FAILURE;
 	}
 #endif


### PR DESCRIPTION
This will make sure that an exception doesn't just silently crash the
game (if the dialog can be shown at that point). This caused some issues
in the past so I thought it would be a good idea. I also added a check
for a preprocessor define to disable exception catching completely which
should make it possible to use a debugger to debug uncaught exceptions.