### PR TITLE
Add disable AA info to OGL init failure

### DIFF
--- a/code/graphics/opengl/gropengl.cpp
+++ b/code/graphics/opengl/gropengl.cpp
@@ -1442,7 +1442,12 @@ bool gr_opengl_init(os::GraphicsOperations* graphicsOps)
 		  gr_screen.bits_per_pixel ));
 
 	if ( opengl_init_display_device(graphicsOps) ) {
-		Error(LOCATION, "Unable to initialize display device!\n");
+		if (os_config_read_uint(NULL, "OGL_AntiAliasSamples", 0) != 0) {
+			Error(LOCATION, "Unable to initialize display device!\n\nTry disabling Anti-Aliasing in the Launcher\n");
+		}
+		else {
+			Error(LOCATION, "Unable to initialize display device!\n");
+		}
 	}
 
 	// Initialize function pointers


### PR DESCRIPTION
Reported as occuring to several people, so far two on Linux with nVidia
binary blob drivers. Extra info should assist in users fixing the
problem on their own.

(see #986)