### PR TITLE
Fixes for $Substitute

### DIFF
--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -6050,6 +6050,8 @@ ship_weapon::ship_weapon()
         secondary_next_slot[i] = 0;
         secondary_bank_rearm_time[i] = timestamp(0);
 
+		secondary_bank_pattern_index[i] = 0;
+
         burst_counter[i + MAX_SHIP_PRIMARY_BANKS] = 0;
         external_model_fp_counter[i + MAX_SHIP_PRIMARY_BANKS] = 0;
     }

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -6309,6 +6309,11 @@ void weapon_mark_as_used(int weapon_type)
 
 	if (weapon_type < Num_weapon_types) {
 		used_weapons[weapon_type]++;
+		if (Weapon_info[weapon_type].num_substitution_patterns > 0) {
+			for (size_t i = 0; i < Weapon_info[weapon_type].num_substitution_patterns; i++) {
+				used_weapons[Weapon_info[weapon_type].weapon_substitution_pattern[i]]++;
+			}
+		}
 	}
 }
 

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -5078,15 +5078,19 @@ int weapon_create( vec3d * pos, matrix * porient, int weapon_type, int parent_ob
 		size_t *position = get_pointer_to_weapon_fire_pattern_index(weapon_type, parent_shipp, src_turret);
 		Assertion( position != NULL, "'%s' is trying to fire a weapon that is not selected", Ships[parent_objp->instance].ship_name );
 
+		size_t curr_pos = *position;
+		if (((Player_ship->flags[Ship::Ship_Flags::Secondary_dual_fire]) || (Player_ship->flags[Ship::Ship_Flags::Primary_linked])) && (curr_pos > 0)) {
+			curr_pos--;
+		}
 		++(*position);
 		*position = (*position) % wip->num_substitution_patterns;
 
-		if ( wip->weapon_substitution_pattern[*position] == -1 ) {
+		if ( wip->weapon_substitution_pattern[curr_pos] == -1 ) {
 			// weapon doesn't want any sub
 			return -1;
-		} else if ( wip->weapon_substitution_pattern[*position] != weapon_type ) {
+		} else if ( wip->weapon_substitution_pattern[curr_pos] != weapon_type ) {
 			// weapon wants to sub with weapon other than me
-			return weapon_create(pos, porient, wip->weapon_substitution_pattern[*position], parent_objnum, group_id, is_locked, is_spawned, fof_cooldown);
+			return weapon_create(pos, porient, wip->weapon_substitution_pattern[curr_pos], parent_objnum, group_id, is_locked, is_spawned, fof_cooldown);
 		}
 	}
 


### PR DESCRIPTION
Axem reported a few issues with $Substitute: relating to secondary dual fire and primary linking as well as thruster glows.

Made it so that substitution weapons get paged in alongside the base weapon.

Ensure dual/linked fire is in sequence.