### PR TITLE
Fix reading credits table without #end

### DIFF
--- a/code/menuui/credits.cpp
+++ b/code/menuui/credits.cpp
@@ -354,7 +354,7 @@ void credits_parse_table(const char* filename)
 		int numLines = -1;
 
 		bool first_run = true;
-		while (!check_for_string_raw("#end"))
+		while (!check_for_eof_raw() && !check_for_string_raw("#end"))
 		{
 			// Read in a line of text			
 			stuff_string_line(line);

--- a/code/parse/parselo.cpp
+++ b/code/parse/parselo.cpp
@@ -446,14 +446,19 @@ int required_string(const char *pstr)
 	return 1;
 }
 
-int check_for_eof()
+int check_for_eof_raw()
 {
-	ignore_white_space();
-
 	if (*Mp == EOF_CHAR)
 		return 1;
 
 	return 0;
+}
+
+int check_for_eof()
+{
+	ignore_white_space();
+
+	return check_for_eof_raw();
 }
 
 /**

--- a/code/parse/parselo.h
+++ b/code/parse/parselo.h
@@ -230,6 +230,7 @@ void stuff_boolean_flag(Flagset& destination, Flags flag, bool a_to_eol = true)
 extern int check_for_string(const char *pstr);
 extern int check_for_string_raw(const char *pstr);
 extern int check_for_eof();
+extern int check_for_eof_raw();
 extern int check_for_eoln();
 
 // from aicode.cpp


### PR DESCRIPTION
This just checks if the end of the file has been reached so existing
tables without the #end will still work (I'm looking at you
FSPort...).