### PR TITLE
Fixed reflectance maps and ambient/cavity maps not being used

### DIFF
--- a/code/graphics/material.cpp
+++ b/code/graphics/material.cpp
@@ -575,7 +575,7 @@ uint model_material::get_shader_flags()
 		Shader_flags |= SDR_FLAG_MODEL_GLOW_MAP;
 	}
 
-	if ( (get_texture_map(TM_SPECULAR_TYPE) > 0) && !Specmap_override ) {
+	if ( (get_texture_map(TM_SPECULAR_TYPE) > 0 || get_texture_map(TM_SPEC_GLOSS_TYPE) > 0) && !Specmap_override ) {
 		Shader_flags |= SDR_FLAG_MODEL_SPEC_MAP;
 
 		if ( (ENVMAP > 0) && !Envmap_override ) {
@@ -589,6 +589,10 @@ uint model_material::get_shader_flags()
 
 	if ( (get_texture_map(TM_HEIGHT_TYPE) > 0) && !Heightmap_override ) {
 		Shader_flags |= SDR_FLAG_MODEL_HEIGHT_MAP;
+	}
+
+	if ( get_texture_map(TM_AMBIENT_TYPE) > 0) ) {
+		Shader_flags |= SDR_FLAG_MODEL_AMBIENT_MAP;
 	}
 
 	if ( lighting ) {

--- a/code/graphics/material.cpp
+++ b/code/graphics/material.cpp
@@ -591,7 +591,7 @@ uint model_material::get_shader_flags()
 		Shader_flags |= SDR_FLAG_MODEL_HEIGHT_MAP;
 	}
 
-	if ( get_texture_map(TM_AMBIENT_TYPE) > 0) ) {
+	if ( get_texture_map(TM_AMBIENT_TYPE) > 0) {
 		Shader_flags |= SDR_FLAG_MODEL_AMBIENT_MAP;
 	}
 

--- a/code/graphics/opengl/gropengltnl.cpp
+++ b/code/graphics/opengl/gropengltnl.cpp
@@ -1127,6 +1127,14 @@ void opengl_tnl_set_model_material(model_material *material_info)
 		++render_pass;
 	}
 
+	if ( Current_shader->flags & SDR_FLAG_MODEL_AMBIENT_MAP ) {
+		Current_shader->program->Uniforms.setUniformi("sAmbientmap", render_pass);
+
+		gr_opengl_tcache_set(material_info->get_texture_map(TM_AMBIENT_TYPE), TCACHE_TYPE_NORMAL, &u_scale, &v_scale, render_pass);
+
+		++render_pass;
+	}
+
 	if ( Current_shader->flags & SDR_FLAG_MODEL_MISC_MAP ) {
 		Current_shader->program->Uniforms.setUniformi("sMiscmap", render_pass);
 


### PR DESCRIPTION
A hiccup in the transition to OpenGL Core. Sorry for the inconvenience. Should fix https://github.com/scp-fs2open/fs2open.github.com/issues/995