### PR TITLE
Fix a few cutscene playback issues

### DIFF
--- a/code/cutscene/ffmpeg/AudioDecoder.cpp
+++ b/code/cutscene/ffmpeg/AudioDecoder.cpp
@@ -97,6 +97,7 @@ AudioDecoder::~AudioDecoder() {
 void AudioDecoder::flushAudioBuffer() {
 	if (m_audioBuffer.empty()) {
 		// Nothing to do here
+		return;
 	}
 
 	AudioFramePtr audioFrame(new AudioFrame());

--- a/code/libs/ffmpeg/FFmpeg.cpp
+++ b/code/libs/ffmpeg/FFmpeg.cpp
@@ -6,7 +6,7 @@
 #include "parse/parselo.h"
 
 namespace {
-const int MIN_LOG_LEVEL = AV_LOG_ERROR;
+const int MIN_LOG_LEVEL = AV_LOG_WARNING;
 
 bool initialized = false;
 
@@ -63,7 +63,7 @@ void initialize() {
 
 #ifndef NDEBUG
 	av_log_set_callback(&log_callback_report);
-	av_log_set_level(AV_LOG_ERROR);
+	av_log_set_level(MIN_LOG_LEVEL);
 #else
 	av_log_set_level(AV_LOG_QUIET);
 #endif


### PR DESCRIPTION
There were some issues with the timing of the video frames which are fixed by these changes. This also improved the error handling when reading the cutscene since some existing cutscenes cause errors for some unknown reason.

This fixes #1028.