### PR TITLE
Add option for showing video debug informations

### DIFF
--- a/code/cmdline/cmdline.cpp
+++ b/code/cmdline/cmdline.cpp
@@ -487,6 +487,7 @@ cmdline_parm benchmark_mode_arg("-benchmark_mode", NULL, AT_NONE); //Cmdline_ben
 cmdline_parm noninteractive_arg("-noninteractive", NULL, AT_NONE); //Cmdline_noninteractive
 cmdline_parm json_pilot("-json_pilot", NULL, AT_NONE); //Cmdline_json_pilot
 cmdline_parm json_profiling("-json_profiling", NULL, AT_NONE); //Cmdline_json_profiling
+cmdline_parm show_video_info("-show_video_info", NULL, AT_NONE); //Cmdline_show_video_info
 
 
 char *Cmdline_start_mission = NULL;
@@ -514,6 +515,7 @@ bool Cmdline_benchmark_mode = false;
 bool Cmdline_noninteractive = false;
 bool Cmdline_json_pilot = false;
 bool Cmdline_json_profiling = false;
+bool Cmdline_show_video_info = false;
 
 // Other
 cmdline_parm get_flags_arg("-get_flags", "Output the launcher flags file", AT_NONE);
@@ -1878,6 +1880,11 @@ bool SetCmdlineParams()
 	if (json_profiling.found())
 	{
 		Cmdline_json_profiling = true;
+	}
+
+	if (show_video_info.found())
+	{
+		Cmdline_show_video_info = true;
 	}
 
 	//Deprecated flags - CommanderDJ

--- a/code/cmdline/cmdline.h
+++ b/code/cmdline/cmdline.h
@@ -160,5 +160,6 @@ extern bool Cmdline_benchmark_mode;
 extern bool Cmdline_noninteractive;
 extern bool Cmdline_json_pilot;
 extern bool Cmdline_json_profiling;
+extern bool Cmdline_show_video_info;
 
 #endif

--- a/code/cutscene/Decoder.h
+++ b/code/cutscene/Decoder.h
@@ -118,11 +118,15 @@ class Decoder {
 
 	bool isAudioFrameAvailable() { return !m_audioQueue->empty(); }
 
+	size_t getAudioQueueSize() { return m_audioQueue->size(); }
+
 	bool tryPopAudioData(AudioFramePtr&);
 
 	bool isVideoQueueFull() { return m_videoQueue->size() == m_queueSize; }
 
 	bool isVideoFrameAvailable() { return !m_videoQueue->empty(); }
+
+	size_t getVideoQueueSize() { return m_videoQueue->size(); }
 
 	bool tryPopVideoFrame(VideoFramePtr&);
 

--- a/code/cutscene/player.cpp
+++ b/code/cutscene/player.cpp
@@ -6,12 +6,16 @@
 
 #include "graphics/2d.h"
 
+#include "globalincs/alphacolors.h"
+
 #include "osapi/osapi.h"
 
 #include "sound/openal.h"
 
 #include "io/key.h"
 #include "io/timer.h"
+
+#include "parse/parselo.h"
 
 #include "cutscene/player/OpenGLVideoPresenter.h"
 
@@ -241,6 +245,43 @@ void videoPlaybackClose(PlayerState* state) {
 	state->videoInited = false;
 }
 
+template<typename... Args>
+float print_string(float x, float y, const char* fmt, Args... params) {
+	SCP_string text;
+	sprintf(text, fmt, params...);
+
+	gr_string(x, y, text.c_str(), GR_RESIZE_NONE);
+
+	return y + font::get_current_font()->getHeight();
+}
+
+void showVideoInfo(PlayerState* state) {
+	gr_set_color_fast(&Color_white);
+
+	float y = 200.f;
+	float x = 100.f;
+	y = print_string(x, y, "Movie FPS: %f", state->props.fps);
+	y = print_string(x, y, "Size: %dx%d", state->props.size.width, state->props.size.height);
+
+	y = gr_screen.max_h - 200.f;
+
+	size_t audio_queue_size = state->decoder->getAudioQueueSize();
+	if (state->hasAudio) {
+		ALint queued;
+		OpenAL_ErrorPrint(alGetSourcei(state->audioSid, AL_BUFFERS_QUEUED, &queued));
+		audio_queue_size += queued;
+	}
+
+	y = print_string(x, y, "Audio Queue size: " SIZE_T_ARG, audio_queue_size);
+	y = print_string(x, y, "Video Queue size: " SIZE_T_ARG, state->decoder->getVideoQueueSize());
+	y += font::get_current_font()->getHeight();
+	// Estimate the size of the video buffer
+	// We use YUV420p frames so one pixel uses 1.5 bytes of storage
+	size_t single_frame_size = (size_t) (state->props.size.width * state->props.size.height * 1.5);
+	size_t total_size = single_frame_size * state->decoder->getVideoQueueSize();
+	print_string(x, y, "Video buffer size: " SIZE_T_ARG "B", total_size);
+}
+
 void displayVideo(PlayerState* state) {
 	if (!state->currentFrame) {
 		return;
@@ -249,6 +290,10 @@ void displayVideo(PlayerState* state) {
 	gr_clear();
 	if (state->videoPresenter) {
 		state->videoPresenter->displayFrame();
+	}
+
+	if (Cmdline_show_video_info) {
+		showVideoInfo(state);
 	}
 
 	gr_flip();

--- a/code/cutscene/player.cpp
+++ b/code/cutscene/player.cpp
@@ -246,24 +246,16 @@ void displayVideo(PlayerState* state) {
 		return;
 	}
 
-	if (!state->newFrameAdded) {
-		// Don't draw anything if no frame has been added
-		return;
-	}
-
 	gr_clear();
 	if (state->videoPresenter) {
 		state->videoPresenter->displayFrame();
 	}
+
+	gr_flip();
 }
 
 void processEvents(PlayerState* state) {
 	io::mouse::CursorManager::get()->showCursor(false);
-
-	if (state->newFrameAdded) {
-		// No need to flip if there is nothing new to show
-		gr_flip();
-	}
 
 	os_poll();
 

--- a/code/cutscene/player/OpenGLVideoPresenter.h
+++ b/code/cutscene/player/OpenGLVideoPresenter.h
@@ -8,17 +8,20 @@
 #include <glad/glad.h>
 
 #include <memory>
+#include <graphics/2d.h>
 
 namespace cutscene {
 namespace player {
 class OpenGLVideoPresenter: public VideoPresenter {
-	int _vertexBuffer;
+	int _vertexBuffer = -1;
+	vertex_layout _vertexLayout;
+	int _sdr_handle = -1;
 
-	bool _scaleVideo;
+	bool _scaleVideo = false;
 
-	GLuint _ytex;
-	GLuint _utex;
-	GLuint _vtex;
+	GLuint _ytex = 0;
+	GLuint _utex = 0;
+	GLuint _vtex = 0;
  public:
 	OpenGLVideoPresenter(const MovieProperties& props);
 


### PR DESCRIPTION
This makes two changes to how the cutscenes are rendered. First, it makes the rendering code more robust against external changes so that the other graphics functions can be used while rendering the cutscene. This allows to render text over a cutscene that is being played.
Second, this adds an option which uses that capability to render some debug information about the played cutscene to the screen when a command line option is set.
These changes are also necessary for allowing to render movie files outside of the cutscene player which can be used in the future to allow H.264 encoded cbanims.