### PR TITLE
Fix wrong negation in HudGaugeExtraTargetData

### DIFF
--- a/code/hud/hudtargetbox.cpp
+++ b/code/hud/hudtargetbox.cpp
@@ -1433,16 +1433,19 @@ void HudGaugeExtraTargetData::render(float frametime)
 		// Print out current orders if the targeted ship is friendly
 		// AL 12-26-97: only show orders and time to target for friendly ships
 		// Backslash: actually let's consult the IFF table.  Maybe we want to show orders for certain teams, or hide orders for friendlies
-		if ( ((Player_ship->team == target_shipp->team) || ((Iff_info[target_shipp->team].flags & IFFF_ORDERS_SHOWN) && !(Iff_info[target_shipp->team].flags & IFFF_ORDERS_HIDDEN)) ) && !(Ship_info[target_shipp->ship_info_index].is_flyable() ) ) {
-			extra_data_shown=1;
-			if ( ship_return_orders(outstr, target_shipp) ) {
+		if (((Player_ship->team == target_shipp->team) ||
+			((Iff_info[target_shipp->team].flags & IFFF_ORDERS_SHOWN) &&
+				!(Iff_info[target_shipp->team].flags & IFFF_ORDERS_HIDDEN)))
+			&& Ship_info[target_shipp->ship_info_index].is_flyable()) {
+			extra_data_shown = 1;
+			if (ship_return_orders(outstr, target_shipp)) {
 				font::force_fit_string(outstr, 255, order_max_w);
 				has_orders = 1;
 			} else {
-				strcpy_s(outstr, XSTR( "no orders", 337));
+				strcpy_s(outstr, XSTR("no orders", 337));
 			}
-			
-			renderString(position[0] + order_offsets[0], position[1] + order_offsets[1], EG_TBOX_EXTRA1, outstr);			
+
+			renderString(position[0] + order_offsets[0], position[1] + order_offsets[1], EG_TBOX_EXTRA1, outstr);
 		}
 
 		if ( has_orders ) {


### PR DESCRIPTION
This fixes #960. The flagsets patch negated the flyable logic but this
one spot was missed when negating the conditions.