### PR TITLE
Fix TTF rendering on cockpit displays

### DIFF
--- a/code/bmpman/bmpman.cpp
+++ b/code/bmpman/bmpman.cpp
@@ -2994,6 +2994,8 @@ void bm_set_low_mem(int mode) {
 }
 
 bool bm_set_render_target(int handle, int face) {
+	GR_DEBUG_SCOPE("Set render target");
+
 	int n = handle % MAX_BITMAPS;
 
 	if (n >= 0) {

--- a/code/graphics/opengl/gropengldraw.cpp
+++ b/code/graphics/opengl/gropengldraw.cpp
@@ -52,6 +52,12 @@ namespace
         float h = 1.0f;
         bool do_resize = gr_resize_screen_posf(&x, &y, &w, &h, resize_mode);
 
+		if (GL_rendering_to_texture) {
+			// Flip the Y-axis when rendering to texture
+			path->translate(0.f, i2fl(gr_screen.max_h));
+			path->scale(1.f, -1.f);
+		}
+
         path->translate(x, y);
         path->scale(w, h);
 

--- a/code/graphics/paths/nanovg/nanovg_gl.h
+++ b/code/graphics/paths/nanovg/nanovg_gl.h
@@ -957,10 +957,9 @@ static void glnvg__fill(GLNVGcontext* gl, GLNVGcall* call)
 
 	glStencilOpSeparate(GL_FRONT, GL_KEEP, GL_KEEP, GL_INCR_WRAP);
 	glStencilOpSeparate(GL_BACK, GL_KEEP, GL_KEEP, GL_DECR_WRAP);
-	glDisable(GL_CULL_FACE);
+
 	for (i = 0; i < npaths; i++)
 		glDrawArrays(GL_TRIANGLE_FAN, paths[i].fillOffset, paths[i].fillCount);
-	glEnable(GL_CULL_FACE);
 
 	// Draw anti-aliased pixels
 	glColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
@@ -1075,7 +1074,7 @@ static void glnvg__renderFlush(void* uptr)
 		glUseProgram(gl->shader.prog);
 
 		glBlendFunc(GL_ONE, GL_ONE_MINUS_SRC_ALPHA);
-		glEnable(GL_CULL_FACE);
+		glDisable(GL_CULL_FACE);
 		glCullFace(GL_BACK);
 		glFrontFace(GL_CCW);
 		glEnable(GL_BLEND);
@@ -1136,8 +1135,7 @@ static void glnvg__renderFlush(void* uptr)
 		glDisableVertexAttribArray(1);
 #if defined NANOVG_GL3
 		glBindVertexArray(0);
-#endif	
-		glDisable(GL_CULL_FACE);
+#endif
 			glBindBuffer(GL_ARRAY_BUFFER, 0);
 		glUseProgram(0);
 		glnvg__bindTexture(gl, 0);

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -7112,6 +7112,7 @@ int ship_start_render_cockpit_display(size_t cockpit_display_num)
 	if ( !bm_set_render_target(display->target) ) {
 		return -1;
 	}
+	gr_push_debug_group("Render cockpit display");
 	
 	int cull = gr_set_cull(0);
 
@@ -7159,6 +7160,8 @@ void ship_end_render_cockpit_display(size_t cockpit_display_num)
 
 	gr_set_cull(cull);
 	bm_set_render_target(-1);
+
+	gr_pop_debug_group();
 }
 
 void ship_subsystems_delete(ship *shipp)


### PR DESCRIPTION
I needed to disable backface culling but I don't think it actually
matters.

Fixes #1038.