### PR TITLE
Absolute values

### DIFF
--- a/code/math/floating.h
+++ b/code/math/floating.h
@@ -100,5 +100,12 @@ inline bool fl_equal(float a, float b)
 // rounds off a floating point number to a multiple of some number
 extern float fl_roundoff(float x, int multiple);
 
+/**
+ * @brief Determines if @a x falls between +/- @a e
+ *
+ * @param x Value to test
+ * @param e Value to test against (must be positive)
+ */
+#define IS_NEAR_ZERO(x, e) (fl_abs(x) < (float)(e))
 
 #endif

--- a/code/math/vecmat.cpp
+++ b/code/math/vecmat.cpp
@@ -371,20 +371,9 @@ float vm_vec_mag_quick(const vec3d *v)
 {
 	float a,b,c,bc, t;
 
-	if ( v->xyz.x < 0.0 )
-		a = -v->xyz.x;
-	else
-		a = v->xyz.x;
-
-	if ( v->xyz.y < 0.0 )
-		b = -v->xyz.y;
-	else
-		b = v->xyz.y;
-
-	if ( v->xyz.z < 0.0 )
-		c = -v->xyz.z;
-	else
-		c = v->xyz.z;
+	a = fl_abs(v->xyz.x);
+	b = fl_abs(v->xyz.y);
+	c = fl_abs(v->xyz.z);
 
 	if (a < b) {
 		t = a;

--- a/code/math/vecmat.cpp
+++ b/code/math/vecmat.cpp
@@ -553,26 +553,6 @@ float vm_vec_copy_normalize_quick_mag(vec3d *dest, const vec3d *src)
 
 }
 
-//normalize a vector. returns mag of source vec. uses approx mag
-float vm_vec_normalize_quick_mag(vec3d *v)
-{
-//	return vm_vec_normalize(v);
-	float m;
-
-	m = vm_vec_mag_quick(v);
-
-	Assert(m > 0.0f);
-
-	v->xyz.x = v->xyz.x*m;
-	v->xyz.y = v->xyz.y*m;
-	v->xyz.z = v->xyz.z*m;
-
-	return m;
-
-}
-
-
-
 //return the normalized direction vector between two points
 //dest = normalized(end - start).  Returns mag of direction vector
 //NOTE: the order of the parameters matches the vector subtraction
@@ -594,18 +574,6 @@ float vm_vec_normalized_dir_quick(vec3d *dest, const vec3d *end, const vec3d *st
 	vm_vec_sub(dest,end,start);
 
 	return vm_vec_normalize_quick(dest);
-}
-
-//return the normalized direction vector between two points
-//dest = normalized(end - start).  Returns mag of direction vector
-//NOTE: the order of the parameters matches the vector subtraction
-float vm_vec_normalized_dir_quick_mag(vec3d *dest, const vec3d *end, const vec3d *start)
-{
-	float t;
-	vm_vec_sub(dest,end,start);
-
-	t = vm_vec_normalize_quick_mag(dest);
-	return t;
 }
 
 //computes surface normal from three points. result is normalized

--- a/code/math/vecmat.h
+++ b/code/math/vecmat.h
@@ -184,13 +184,11 @@ float vm_vec_normalize_quick(vec3d *v);
 
 //normalize a vector. returns mag of source vec. uses approx mag
 float vm_vec_copy_normalize_quick_mag(vec3d *dest, const vec3d *src);
-float vm_vec_normalize_quick_mag(vec3d *v);
 
 //return the normalized direction vector between two points
 //dest = normalized(end - start).  Returns mag of direction vector
 //NOTE: the order of the parameters matches the vector subtraction
 float vm_vec_normalized_dir(vec3d *dest,const vec3d *end, const vec3d *start);
-float vm_vec_normalized_dir_quick_mag(vec3d *dest, const vec3d *end, const vec3d *start);
 // Returns mag of direction vector
 float vm_vec_normalized_dir_quick(vec3d *dest, const vec3d *end, const vec3d *start);
 

--- a/code/math/vecmat.h
+++ b/code/math/vecmat.h
@@ -21,13 +21,13 @@
 //Macros/functions to fill in fields of structures
 
 //macro to check if vector is zero
-#define IS_VEC_NULL_SQ_SAFE(v) ( ( (v)->xyz.x > -1e-16 ) && ( (v)->xyz.x < 1e-16 ) && \
-								 ( (v)->xyz.y > -1e-16 ) && ( (v)->xyz.y < 1e-16 ) && \
-								 ( (v)->xyz.z > -1e-16 ) && ( (v)->xyz.z < 1e-16 ) )
+#define IS_VEC_NULL_SQ_SAFE(v) (IS_NEAR_ZERO((v)->xyz.x, 1e-16) && \
+								IS_NEAR_ZERO((v)->xyz.y, 1e-16) && \
+								IS_NEAR_ZERO((v)->xyz.z, 1e-16))
 
-#define IS_VEC_NULL(v) ( ( (v)->xyz.x > -1e-36 ) && ( (v)->xyz.x < 1e-36 ) && \
-						 ( (v)->xyz.y > -1e-36 ) && ( (v)->xyz.y < 1e-36 ) && \
-						 ( (v)->xyz.z > -1e-36 ) && ( (v)->xyz.z < 1e-36 ) )
+#define IS_VEC_NULL(v) (IS_NEAR_ZERO((v)->xyz.x, 1e-36) && \
+						IS_NEAR_ZERO((v)->xyz.y, 1e-36) && \
+						IS_NEAR_ZERO((v)->xyz.z, 1e-36))
 
 #define IS_MAT_NULL(v) (IS_VEC_NULL(&(v)->vec.fvec) && IS_VEC_NULL(&(v)->vec.uvec) && IS_VEC_NULL(&(v)->vec.rvec))
 


### PR DESCRIPTION
I happened to notice that with the x86 GCC compiler (not tested with other compilers) that using fl_abs() (which evaluates to fabsf) can be used to generate tighter code.

As fabsf() is a function well known to the compiler, GCC is able to optimize it such that the sign bit in a float is unconditionally cleared in a single SSE instruction (and no function call).

Although I would expect that this would generate slightly more efficient code, I have not benchmarked that. I have however done a size check and found that the text section is smaller by about half a page (peanuts in the grand scheme of things).