### PR TITLE
Ignore Carriage return characters when rendering strings

### DIFF
--- a/code/graphics/opengl/gropengldraw.cpp
+++ b/code/graphics/opengl/gropengldraw.cpp
@@ -750,7 +750,7 @@ void gr_opengl_string(float sx, float sy, const char *s, int resize_mode, int in
 				bool doRender = true;
 				bool specialChar = false;
 				if (tokenLength == 1) {
-					// We may have encoutered a special character
+					// We may have encountered a special character
 					switch (*text) {
 						case '\n':
 							doRender = false;
@@ -762,6 +762,10 @@ void gr_opengl_string(float sx, float sy, const char *s, int resize_mode, int in
 							doRender = false;
 
 							x += nvgFont->getTabWidth();
+							break;
+						case '\r':
+							// Ignore Carriage return chars
+							doRender = false;
 							break;
 						default:
 							if (*text >= Lcl_special_chars || *text < 0) {

--- a/code/graphics/software/NVGFont.cpp
+++ b/code/graphics/software/NVGFont.cpp
@@ -8,7 +8,7 @@
 
 namespace
 {
-	const char* const TOKEN_SEPARATORS = "\n\t";
+	const char* const TOKEN_SEPARATORS = "\n\t\r";
 }
 
 namespace font


### PR DESCRIPTION
Since Windows line endings include this character it needs to be ignored
since the text rendering would display it as an unknown character
otherwise.

This was reported by @AxemP.