### PR TITLE
Check if the used SIMD set is supported by the CPU

### DIFF
--- a/cmake/toolchain-msvc.cmake
+++ b/cmake/toolchain-msvc.cmake
@@ -100,6 +100,7 @@ set(FSO_INSTRUCTION_SET ${MSVC_SIMD_INSTRUCTIONS})
 
 LIST(FIND POSSIBLE_INSTUCTION_SETS "${MSVC_SIMD_INSTRUCTIONS}" SET_INDEX)
 
+set(SIMD_SET "NONE")
 if (SET_INDEX LESS 0)
 	MESSAGE(STATUS "An invalid instruction set was specified, defaulting to no special compiler options.")
 else()
@@ -113,6 +114,8 @@ else()
 			IF(COMPILER_SUPPORTS_ARCH_${_simd_set})
 				set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /arch:${_simd_set}")
 				set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /arch:${_simd_set}")
+                
+                set(SIMD_SET "${_simd_set}")
 
 				SET(FOUND TRUE)
 				BREAK()
@@ -135,6 +138,9 @@ endif()
 
 target_compile_definitions(compiler INTERFACE _CRT_SECURE_NO_DEPRECATE
 _CRT_SECURE_NO_WARNINGS _SECURE_SCL=0 NOMINMAX "$<$<CONFIG:FastDebug>:_ITERATOR_DEBUG_LEVEL=0>")
+    
+# Define preprocessor defines for used SIMD set
+target_compile_definitions(compiler INTERFACE SIMD_USE_${SIMD_SET} SIMD_SET="${SIMD_SET}")
 	
 if (FSO_FATAL_WARNINGS)
 	# Make warnings fatal if the right variable is set

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -8077,11 +8077,33 @@ void game_unpause()
 	}
 }
 
+static bool check_simd_usage() {
+#if defined(SIMD_USE_AVX)
+	return SDL_HasAVX() == SDL_TRUE;
+#elif defined(SIMD_USE_SSE2)
+	return SDL_HasSSE2() == SDL_TRUE;
+#elif defined(SIMD_USE_SSE)
+	return SDL_HasSSE() == SDL_TRUE;
+#elif defined(SIMD_USE_NONE)
+	return true;
+#else
+	return true;
+#endif
+}
+
 
 int actual_main(int argc, char *argv[])
 {
 	int result = -1;
 	Assert(argc > 0);
+
+#ifdef SIMD_SET
+	// Check if we support the SIMD set with which this binary was compiled with
+	if (!check_simd_usage()) {
+		Message(os::dialogs::MESSAGEBOX_ERROR, "Your CPU does not support the SIMD feature \"" SIMD_SET "\" with which this executable was compiled with!");
+		return EXIT_FAILURE;
+	}
+#endif
 
 #ifdef WIN32
 	// Don't let more than one instance of FreeSpace run.


### PR DESCRIPTION
This will show an error if SDL detectes that the CPU does not support
the SIMD instruction set with which the binary was compiled. This is
currently only used by MSVC since only that actually offers the option
to choose between different SIMD optimizations.