### PR TITLE
Make repair-subsystem/set-subsystem-strength fix submodels by default.

### DIFF
--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -11405,7 +11405,7 @@ void sexp_repair_subsystem(int n)
 	subsystem = CTEXT(CDR(n));
 	shipnum = ship_name_lookup(shipname);
 	
-	do_submodel_repair = is_sexp_true(CDDDR(n));
+	do_submodel_repair = CDDDR(n) == -1 || is_sexp_true(CDDDR(n));
 	
 	// if no ship, then return immediately.
 	if ( shipnum == -1 ) {
@@ -11515,7 +11515,7 @@ void sexp_set_subsystem_strength(int n)
 	subsystem = CTEXT(CDR(n));
 	percentage = eval_num(CDR(CDR(n)));
 
-	do_submodel_repair = is_sexp_true(CDDDR(n));
+	do_submodel_repair = CDDDR(n) == -1 || is_sexp_true(CDDDR(n));
 
 	shipnum = ship_name_lookup(shipname);
 	


### PR DESCRIPTION
When this functionality was added in commit 0662cb6959177723c4dd218872f006eeeb3365d0 it made an explicit check to see if the node was -1, and if so (meaning the node is not present), defaulted the value to true; a month later commit 57c4855e25c3410f39fdbb07ef346b9b1298fe71 "simplified" this to a single `is_sexp_true()` call, which returns false if the node isn't present... but the documentation still claimed that the default value was true.

Ten years later, and Axem wanted to know why his submodel wasn't being fixed by the `repair-subsystem` SEXP. I don't know if this is the first time in ten years anybody's wanted to use `repair-subsystem` on a destroyable submodel, or if everyone was just assuming it worked as intended and never noticing it didn't; regardless, while the "simple" solution would seem to be to fix the documentation (since the current behavior has been the actual behavior for almost as long as the feature has existed), it seems unlikely that there would be many unintended consequences of just fixing submodels by default, and if anyone *has* used these SEXPs in the intervening ten years, it was probably under the assumption that they worked as the documentation claimed.