### PR TITLE
Fixes issue #1097:

### DIFF
--- a/code/render/batching.cpp
+++ b/code/render/batching.cpp
@@ -78,6 +78,7 @@ void batching_init_buffer(primitive_batch_buffer *buffer, primitive_type prim_ty
 	buffer->buffer_num = gr_create_vertex_buffer();
 	buffer->buffer_ptr = NULL;
 	buffer->buffer_size = 0;
+	buffer->desired_buffer_size = 0;
 	buffer->prim_type = prim_type;
 }
 


### PR DESCRIPTION
primative_batch_buffer:desired_buffer_size was not properly initialized with the vc120 (Visual Studio 2013) toolset during debugging. Default constructors proved insufficient, and std:map::operator[] seems to ignore them anyway. This fix gets around that by explicitly clearing desired_buffer)size from within batching_init_buffer()