### PR TITLE
Actually Fixes Issue 965.

### DIFF
--- a/code/scripting/api/enums.cpp
+++ b/code/scripting/api/enums.cpp
@@ -392,6 +392,12 @@ flag_def_list Enumerations[] = {
 	},
 
 	{
+		"VM_CAMERA_LOCKED",
+		LE_VM_CAMERA_LOCKED,
+		0
+	},
+
+	{
 		"VM_WARP_CHASE",
 		LE_VM_WARP_CHASE,
 		0
@@ -436,6 +442,12 @@ flag_def_list Enumerations[] = {
 	{
 		"VM_FREECAMERA",
 		LE_VM_FREECAMERA,
+		0
+	},
+
+	{
+		"VM_CENTERING",
+		LE_VM_CENTERING,
 		0
 	},
 

--- a/code/scripting/api/enums.h
+++ b/code/scripting/api/enums.h
@@ -73,6 +73,7 @@ const int32_t LE_VM_DEAD_VIEW					= 57;
 const int32_t LE_VM_CHASE						= 58;
 const int32_t LE_VM_OTHER_SHIP					= 59;
 const int32_t LE_VM_EXTERNAL_CAMERA_LOCKED		= 60;
+const int32_t LE_VM_CAMERA_LOCKED				= 75;
 const int32_t LE_VM_WARP_CHASE					= 61;
 const int32_t LE_VM_PADLOCK_UP					= 62;
 const int32_t LE_VM_PADLOCK_REAR				= 63;
@@ -81,11 +82,12 @@ const int32_t LE_VM_PADLOCK_RIGHT				= 65;
 const int32_t LE_VM_WARPIN_ANCHOR				= 66;
 const int32_t LE_VM_TOPDOWN						= 67;
 const int32_t LE_VM_FREECAMERA					= 68;
+const int32_t LE_VM_CENTERING					= 76;
 const int32_t LE_MESSAGE_PRIORITY_LOW			= 71;
 const int32_t LE_MESSAGE_PRIORITY_NORMAL		= 72;
 const int32_t LE_MESSAGE_PRIORITY_HIGH			= 73;
 
-const int ENUM_NEXT_INDEX = 75; // <<<<<<<<<<<<<<<<<<<<<<
+const int ENUM_NEXT_INDEX = 77; // <<<<<<<<<<<<<<<<<<<<<<
 extern flag_def_list Enumerations[];
 extern size_t Num_enumerations;
 

--- a/code/scripting/lua.cpp
+++ b/code/scripting/lua.cpp
@@ -13740,7 +13740,7 @@ ADE_FUNC(hasViewmode, l_Graphics, "enumeration", "Specifies if the current viemo
 	switch(type->index)
 	{
 	case LE_VM_INTERNAL:
-		return ade_set_args(L, "b", (Viewer_mode & !VM_CAMERA_LOCKED) == 0);	// z64: Ignore camera lock state
+		return ade_set_args(L, "b", (Viewer_mode & ~(VM_CAMERA_LOCKED | VM_CENTERING)) == 0);	// z64: Ignore camera lock state and centering state
 		break;
 
 	case LE_VM_EXTERNAL:

--- a/code/scripting/lua.cpp
+++ b/code/scripting/lua.cpp
@@ -13760,6 +13760,10 @@ ADE_FUNC(hasViewmode, l_Graphics, "enumeration", "Specifies if the current viemo
 		break;
 
 	case LE_VM_EXTERNAL_CAMERA_LOCKED:
+		return ade_set_args(L, "b", (Viewer_mode & VM_CAMERA_LOCKED) && (Viewer_mode & VM_EXTERNAL));
+		break;
+
+	case LE_VM_CAMERA_LOCKED:
 		bit = VM_CAMERA_LOCKED;
 		break;
 
@@ -13797,6 +13801,10 @@ ADE_FUNC(hasViewmode, l_Graphics, "enumeration", "Specifies if the current viemo
 
 	case LE_VM_WARPIN_ANCHOR:
 		bit = VM_WARPIN_ANCHOR;
+		break;
+
+	case LE_VM_CENTERING:
+		bit = VM_CENTERING;
 		break;
 
 	default:


### PR DESCRIPTION
Previous fixed used a logical NOT (!) instead of a bitwise NOT (~), derp!
In addition, the LE_VM_INTERNAL state now ignores VM_CENTERING, so it won't go false if the camera is returning to center.

Adds scripting support for VM_CAMERA_LOCKED and VM_CENTERING. VM_EXTERNAL_CAMERA_LOCKED is now a soft-state that is equal to (VM_EXTERNAL && VM_CAMERA_LOCKED)