### PR TITLE
Fix a few Mesa warnings in the shader code

### DIFF
--- a/code/def_files/fxaa-f.sdr
+++ b/code/def_files/fxaa-f.sdr
@@ -1,22 +1,7 @@
-#extension GL_EXT_gpu_shader4 : enable
 #define FXAA_EARLY_EXIT 1
 #define FXAA_DISCARD 1
-#ifndef FXAA_FAST_PIXEL_OFFSET
-	#ifdef GL_EXT_gpu_shader4
-		#define FXAA_FAST_PIXEL_OFFSET 1
-	#endif
-	#ifdef GL_NV_gpu_shader5
-		#extension GL_NV_gpu_shader5 : enable
-		#define FXAA_FAST_PIXEL_OFFSET 1
-	#endif
-	#ifdef GL_ARB_gpu_shader5
-		#extension GL_ARB_gpu_shader5 : enable
-		#define FXAA_FAST_PIXEL_OFFSET 1
-	#endif
-	#ifndef FXAA_FAST_PIXEL_OFFSET
-		#define FXAA_FAST_PIXEL_OFFSET 0
-	#endif
-#endif
+#define FXAA_FAST_PIXEL_OFFSET 1 // With OpenGL 3.2 we can always do this
+
 #ifndef FXAA_GATHER4_ALPHA
 	#ifdef GL_ARB_gpu_shader5
 		#extension GL_ARB_gpu_shader5 : enable

--- a/code/def_files/fxaa-v.sdr
+++ b/code/def_files/fxaa-v.sdr
@@ -1,4 +1,4 @@
-#extension GL_EXT_gpu_shader4 : enable
+
 in vec4 vertPosition;
 uniform float rt_w;
 uniform float rt_h;

--- a/code/def_files/main-v.sdr
+++ b/code/def_files/main-v.sdr
@@ -64,7 +64,7 @@ out float fragClipDistance;
 #endif
 #ifdef FLAG_TRANSFORM
 #define TEXELS_PER_MATRIX 4
-void getModelTransform(inout mat4 transform, inout float invisible, int id, int matrix_offset)
+void getModelTransform(inout mat4 transform, out float invisible, int id, int matrix_offset)
 {
 	transform[0] = texelFetch(transform_tex, (matrix_offset + id) * TEXELS_PER_MATRIX);
 	transform[1] = texelFetch(transform_tex, (matrix_offset + id) * TEXELS_PER_MATRIX + 1);

--- a/code/graphics/opengl/gropenglpostprocessing.cpp
+++ b/code/graphics/opengl/gropenglpostprocessing.cpp
@@ -731,16 +731,13 @@ void opengl_post_shader_header(SCP_stringstream &sflags, shader_type shader_t, i
 		sprintf(temp, "#define SAMPLE_NUM %d\n", ls_samplenum);
 		sflags << temp;
 	} else if ( shader_t == SDR_TYPE_POST_PROCESS_FXAA ) {
-		/* GLSL version < 120 are guarded against reaching this code
-		   path via testing is_minimum_GLSL_version().
-		   Accordingly do not test for them again here. */
-		if (GLSL_version == 120) {
-			sflags << "#define FXAA_GLSL_120 1\n";
-			sflags << "#define FXAA_GLSL_130 0\n";
-		}
-		if (GLSL_version > 120) {
-			sflags << "#define FXAA_GLSL_120 0\n";
-			sflags << "#define FXAA_GLSL_130 1\n";
+		// Since we require OpenGL 3.2 we always have support for GLSL 130
+		sflags << "#define FXAA_GLSL_120 0\n";
+		sflags << "#define FXAA_GLSL_130 1\n";
+
+		if (GLSL_version >= 400) {
+			// The gather function became part of the standard with GLSL 4.00
+			sflags << "#define FXAA_GATHER4_ALPHA 1\n";
 		}
 
 		switch (Cmdline_fxaa_preset) {


### PR DESCRIPTION
GL_EXT_gpu_shader4 is part of the GLSL 1.50 language standard so the
FXAA shader doesn't need to check against that. I also added a
conditional define for FXAA_GATHER4_ALPHA if the GLSL version supports
it which is the case when it's >= 4.00.

The other issue was a minor change from inout to out where Mesa
complained that the target variable might not have been initialized.