### PR TITLE
timer: Increase precision of timer as well as reducing potential of o…

### DIFF
--- a/code/io/timer.cpp
+++ b/code/io/timer.cpp
@@ -1,11 +1,11 @@
 /*
  * Copyright (C) Volition, Inc. 1999.  All rights reserved.
  *
- * All source code herein is the property of Volition, Inc. You may not sell 
- * or otherwise commercially exploit the source or things you created based on the 
+ * All source code herein is the property of Volition, Inc. You may not sell
+ * or otherwise commercially exploit the source or things you created based on the
  * source.
  *
-*/ 
+*/
 
 
 
@@ -26,8 +26,9 @@ static int Timer_inited = 0;
 
 
 #define MICROSECONDS_PER_SECOND 1000000
-
 #define NANOSECONDS_PER_SECOND 1000000000
+
+static long double Timer_to_nanoseconds;
 
 static uint64_t get_performance_counter()
 {
@@ -50,7 +51,7 @@ void timer_init()
 	if ( !Timer_inited )	{
 		Timer_perf_counter_freq = SDL_GetPerformanceFrequency();
 		Timer_base_value = SDL_GetPerformanceCounter();
-
+		Timer_to_nanoseconds = (long double) NANOSECONDS_PER_SECOND / (long double) Timer_perf_counter_freq;
 		Timer_inited = 1;
 
 		atexit(timer_close);
@@ -106,12 +107,7 @@ std::uint64_t timer_get_nanoseconds()
 {
 	auto time = get_performance_counter();
 
-	if (Timer_perf_counter_freq < NANOSECONDS_PER_SECOND) {
-		// This can cause overflows but I don't know a better solution...
-		return (time * NANOSECONDS_PER_SECOND) / Timer_perf_counter_freq;
-	} else {
-		return time / (Timer_perf_counter_freq / NANOSECONDS_PER_SECOND);
-	}
+    return (uint64_t) (time * Timer_to_nanoseconds);
 }
 
 // 0 means invalid,
@@ -126,7 +122,7 @@ void timestamp_reset()
 
 // Restrict all time values between 0 and MAX_TIME
 // so we don't have to use UINTs to calculate rollover.
-// For debugging & testing, you could set this to 
+// For debugging & testing, you could set this to
 // something like 1 minute (6000).
 const std::uint32_t MAX_TIME = INT_MAX / 2;
 
@@ -175,14 +171,14 @@ int timestamp_until(int stamp) {
 	// JAS: FIX
 	// HACK!! This doesn't handle rollover!
 	// (Will it ever happen?)
-	
+
 	return stamp - timestamp_ms();
 
 /*
 	uint	delta;
 
 	delta = stamp - timestamp_ticker;
-	
+
 
 	if (delta > UINT_MAX/2)
 		delta = UINT_MAX - delta + 1;


### PR DESCRIPTION
…verflows.

This creates a factor that is used to multiply the timestamp. It will
overflow less, (once every 300 years or so) and not lose as much precision
as the previous implementation.

The performance is slightly improved, there are no more branches and one
floating point multiply.

Signed-off-by: Matthew Khouzam <matthew.khouzam@gmail.com>