### PR TITLE
Fix Don't Spawn If Shot

### DIFF
--- a/code/weapon/beam.cpp
+++ b/code/weapon/beam.cpp
@@ -3187,10 +3187,12 @@ void beam_handle_collisions(beam *b)
 							trgt->hull_strength -= damage;
 
 							if (trgt->hull_strength < 0) {
+								Weapons[trgt->instance].weapon_flags.set(Weapon::Weapon_Flags::Destroyed_by_weapon);
 								weapon_hit(trgt, NULL, &trgt->pos);
 							}
 						} else {
 							if (!(Game_mode & GM_MULTIPLAYER) || MULTIPLAYER_MASTER) {
+								Weapons[trgt->instance].weapon_flags.set(Weapon::Weapon_Flags::Destroyed_by_weapon);
 								weapon_hit(&Objects[target], NULL, &Objects[target].pos);
 							}
 						}
@@ -3202,6 +3204,7 @@ void beam_handle_collisions(beam *b)
 					Assert(Weapon_info[Weapons[Objects[target].instance].weapon_info_index].subtype == WP_MISSILE);
 
 					if (!(Game_mode & GM_MULTIPLAYER) || MULTIPLAYER_MASTER) {
+						Weapons[Objects[target].instance].weapon_flags.set(Weapon::Weapon_Flags::Destroyed_by_weapon);
 						weapon_hit(&Objects[target], NULL, &Objects[target].pos);
 					}
 				}

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -6260,7 +6260,7 @@ void weapon_hit( object * weapon_obj, object * other_obj, vec3d * hitpos, int qu
 
 	// spawn weapons - note the change from FS 1 multiplayer.
 	if (wip->wi_flags[Weapon::Info_Flags::Spawn]){
-		if (!((wip->wi_flags[Weapon::Info_Flags::Dont_spawn_if_shot]) && (sw_flag == SW_WEAPON_KILL))){			// prevent spawning of children if shot down and the dont spawn if shot flag is set (DahBlount)
+		if (!((wip->wi_flags[Weapon::Info_Flags::Dont_spawn_if_shot]) && (Weapons[num].weapon_flags[Weapon::Weapon_Flags::Destroyed_by_weapon]))){			// prevent spawning of children if shot down and the dont spawn if shot flag is set (DahBlount)
 			spawn_child_weapons(weapon_obj);
 		}
 	}	


### PR DESCRIPTION
Previously beams would not set the Destroyed by weapon flag, which means spawn weapons shot by beams would spawn regardless of whether "don't spawn if shot" was set on the weapon. This has been fixed according to Axem.