### PR TITLE
Add catch clauses everywhere where parselo is used

### DIFF
--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -780,39 +780,46 @@ void reset_ai_class_names()
 #define AI_CLASS_INCREMENT		10
 void parse_aitbl()
 {
-	read_file_text("ai.tbl", CF_TYPE_TABLES);
-	reset_parse();
+	try {
+		read_file_text("ai.tbl", CF_TYPE_TABLES);
+		reset_parse();
 
-	//Just in case parse_aitbl is called twice
-	free_ai_stuff();
-	
-	Num_ai_classes = 0;
-	Num_alloced_ai_classes = AI_CLASS_INCREMENT;
-	Ai_classes = (ai_class*) vm_malloc(Num_alloced_ai_classes * sizeof(ai_class));
-	Ai_class_names = (char**) vm_malloc(Num_alloced_ai_classes * sizeof(char*));
-	
-	required_string("#AI Classes");
+		//Just in case parse_aitbl is called twice
+		free_ai_stuff();
 
-	while (required_string_either("#End", "$Name:")) {
+		Num_ai_classes = 0;
+		Num_alloced_ai_classes = AI_CLASS_INCREMENT;
+		Ai_classes = (ai_class*) vm_malloc(Num_alloced_ai_classes * sizeof(ai_class));
+		Ai_class_names = (char**) vm_malloc(Num_alloced_ai_classes * sizeof(char*));
 
-		parse_ai_class();
+		required_string("#AI Classes");
 
-		Num_ai_classes++;
+		while (required_string_either("#End", "$Name:")) {
 
-		if(Num_ai_classes >= Num_alloced_ai_classes)
-		{
-			Num_alloced_ai_classes += AI_CLASS_INCREMENT;
-			Ai_classes = (ai_class*) vm_realloc(Ai_classes, Num_alloced_ai_classes * sizeof(ai_class));
+			parse_ai_class();
 
-			// Ai_class_names doesn't realloc all that well so we have to do it the hard way.
-			// Luckily, it's contents can be easily replaced so we don't have to save anything.
-			vm_free(Ai_class_names);
-			Ai_class_names = (char **) vm_malloc(Num_alloced_ai_classes * sizeof(char*));
-			reset_ai_class_names();
+			Num_ai_classes++;
+
+			if(Num_ai_classes >= Num_alloced_ai_classes)
+			{
+				Num_alloced_ai_classes += AI_CLASS_INCREMENT;
+				Ai_classes = (ai_class*) vm_realloc(Ai_classes, Num_alloced_ai_classes * sizeof(ai_class));
+
+				// Ai_class_names doesn't realloc all that well so we have to do it the hard way.
+				// Luckily, it's contents can be easily replaced so we don't have to save anything.
+				vm_free(Ai_class_names);
+				Ai_class_names = (char **) vm_malloc(Num_alloced_ai_classes * sizeof(char*));
+				reset_ai_class_names();
+			}
 		}
+
+		atexit(free_ai_stuff);
 	}
-	
-	atexit(free_ai_stuff);
+	catch (const parse::ParseException& e)
+	{
+		mprintf(("TABLES: Unable to parse 'ai.tbl'!  Error message = %s.\n", e.what()));
+		return;
+	}
 }
 
 LOCAL int ai_inited = 0;

--- a/code/controlconfig/controlsconfigcommon.cpp
+++ b/code/controlconfig/controlsconfigcommon.cpp
@@ -811,116 +811,123 @@ void control_config_common_load_overrides()
 {
 	LoadEnumsIntoMaps();
 
-	if (cf_exists_full("controlconfigdefaults.tbl", CF_TYPE_TABLES)) {
-		read_file_text("controlconfigdefaults.tbl", CF_TYPE_TABLES);
-	} else {
-		read_file_text_from_default(defaults_get_file("controlconfigdefaults.tbl"));
-	}
-
-	reset_parse();
-
-	// start parsing
-	// TODO: Split this out into more helps. Too many tabs!
-	while(optional_string("#ControlConfigOverride")) {
-		config_item *cfg_preset = new config_item[CCFG_MAX + 1];
-		std::copy(Control_config, Control_config + CCFG_MAX + 1, cfg_preset);
-		Control_config_presets.push_back(cfg_preset);
-
-		SCP_string preset_name;
-		if (optional_string("$Name:")) {
-			stuff_string_line(preset_name);
+	try {
+		if (cf_exists_full("controlconfigdefaults.tbl", CF_TYPE_TABLES)) {
+			read_file_text("controlconfigdefaults.tbl", CF_TYPE_TABLES);
 		} else {
-			preset_name = "<unnamed preset>";
+			read_file_text_from_default(defaults_get_file("controlconfigdefaults.tbl"));
 		}
-		Control_config_preset_names.push_back(preset_name);
 
-		while (required_string_either("#End","$Bind Name:")) {
-			const int iBufferLength = 64;
-			char szTempBuffer[iBufferLength];
+		reset_parse();
 
-			required_string("$Bind Name:");
-			stuff_string(szTempBuffer, F_NAME, iBufferLength);
+		// start parsing
+		// TODO: Split this out into more helps. Too many tabs!
+		while(optional_string("#ControlConfigOverride")) {
+			config_item *cfg_preset = new config_item[CCFG_MAX + 1];
+			std::copy(Control_config, Control_config + CCFG_MAX + 1, cfg_preset);
+			Control_config_presets.push_back(cfg_preset);
 
-			const size_t cCntrlAryLength = sizeof(Control_config) / sizeof(Control_config[0]);
-			for (size_t i = 0; i < cCntrlAryLength; ++i) {
-				config_item& r_ccConfig = cfg_preset[i];
+			SCP_string preset_name;
+			if (optional_string("$Name:")) {
+				stuff_string_line(preset_name);
+			} else {
+				preset_name = "<unnamed preset>";
+			}
+			Control_config_preset_names.push_back(preset_name);
 
-				if (!strcmp(szTempBuffer, r_ccConfig.text)) {
-					/**
-					* short key_default;
-					* short joy_default;
-					* char tab;
-					* bool hasXSTR;
-					* char type;
-					*/
+			while (required_string_either("#End","$Bind Name:")) {
+				const int iBufferLength = 64;
+				char szTempBuffer[iBufferLength];
 
-					int iTemp;
+				required_string("$Bind Name:");
+				stuff_string(szTempBuffer, F_NAME, iBufferLength);
 
-					if (optional_string("$Key Default:")) {
-						if (optional_string("NONE")) {
-							r_ccConfig.key_default = (short)-1;
-						} else {
-							stuff_string(szTempBuffer, F_NAME, iBufferLength);
-							r_ccConfig.key_default = (short)mKeyNameToVal[szTempBuffer];
+				const size_t cCntrlAryLength = sizeof(Control_config) / sizeof(Control_config[0]);
+				for (size_t i = 0; i < cCntrlAryLength; ++i) {
+					config_item& r_ccConfig = cfg_preset[i];
+
+					if (!strcmp(szTempBuffer, r_ccConfig.text)) {
+						/**
+                        * short key_default;
+                        * short joy_default;
+                        * char tab;
+                        * bool hasXSTR;
+                        * char type;
+                        */
+
+						int iTemp;
+
+						if (optional_string("$Key Default:")) {
+							if (optional_string("NONE")) {
+								r_ccConfig.key_default = (short)-1;
+							} else {
+								stuff_string(szTempBuffer, F_NAME, iBufferLength);
+								r_ccConfig.key_default = (short)mKeyNameToVal[szTempBuffer];
+							}
 						}
-					}
 
-					if (optional_string("$Joy Default:")) {
-						stuff_int(&iTemp);
-						r_ccConfig.joy_default = (short)iTemp;
-					}
+						if (optional_string("$Joy Default:")) {
+							stuff_int(&iTemp);
+							r_ccConfig.joy_default = (short)iTemp;
+						}
 
-					if (optional_string("$Key Mod Shift:")) {
-						stuff_int(&iTemp);
-						r_ccConfig.key_default |= (iTemp == 1) ? KEY_SHIFTED : 0;
-					}
+						if (optional_string("$Key Mod Shift:")) {
+							stuff_int(&iTemp);
+							r_ccConfig.key_default |= (iTemp == 1) ? KEY_SHIFTED : 0;
+						}
 
-					if (optional_string("$Key Mod Alt:")) {
-						stuff_int(&iTemp);
-						r_ccConfig.key_default |= (iTemp == 1) ? KEY_ALTED : 0;
-					}
+						if (optional_string("$Key Mod Alt:")) {
+							stuff_int(&iTemp);
+							r_ccConfig.key_default |= (iTemp == 1) ? KEY_ALTED : 0;
+						}
 
-					if (optional_string("$Key Mod Ctrl:")) {
-						stuff_int(&iTemp);
-						r_ccConfig.key_default |= (iTemp == 1) ? KEY_CTRLED : 0;
-					}
+						if (optional_string("$Key Mod Ctrl:")) {
+							stuff_int(&iTemp);
+							r_ccConfig.key_default |= (iTemp == 1) ? KEY_CTRLED : 0;
+						}
 
-					if (optional_string("$Category:")) {
-						stuff_string(szTempBuffer, F_NAME, iBufferLength);
-						r_ccConfig.tab = (char)mCCTabNameToVal[szTempBuffer];
-					}
+						if (optional_string("$Category:")) {
+							stuff_string(szTempBuffer, F_NAME, iBufferLength);
+							r_ccConfig.tab = (char)mCCTabNameToVal[szTempBuffer];
+						}
 
-					if (optional_string("$Has XStr:")) {
-						stuff_int(&iTemp);
-						r_ccConfig.hasXSTR = (iTemp == 1);
-					}
+						if (optional_string("$Has XStr:")) {
+							stuff_int(&iTemp);
+							r_ccConfig.hasXSTR = (iTemp == 1);
+						}
 
-					if (optional_string("$Type:")) {
-						stuff_string(szTempBuffer, F_NAME, iBufferLength);
-						r_ccConfig.type = (char)mCCTypeNameToVal[szTempBuffer];
-					}
+						if (optional_string("$Type:")) {
+							stuff_string(szTempBuffer, F_NAME, iBufferLength);
+							r_ccConfig.type = (char)mCCTypeNameToVal[szTempBuffer];
+						}
 
-					if (optional_string("+Disable")) {
-						r_ccConfig.disabled = true;
+						if (optional_string("+Disable")) {
+							r_ccConfig.disabled = true;
+						}
+						if (optional_string("$Disable:")) {
+							stuff_boolean(&r_ccConfig.disabled);
+						}
+
+						// Nerf the buffer now.
+						szTempBuffer[0] = '\0';
+					} else if ((i + 1) == cCntrlAryLength) {
+						error_display(1, "Bind Name not found: %s\n", szTempBuffer);
+						advance_to_eoln(NULL);
+						ignore_white_space();
+						return;
 					}
-					if (optional_string("$Disable:")) {
-						stuff_boolean(&r_ccConfig.disabled);
-					}
-					
-					// Nerf the buffer now.
-					szTempBuffer[0] = '\0';
-				} else if ((i + 1) == cCntrlAryLength) {
-					error_display(1, "Bind Name not found: %s\n", szTempBuffer);
-					advance_to_eoln(NULL);
-					ignore_white_space();
-					return;
 				}
 			}
-		}
 
-		required_string("#End");
+			required_string("#End");
+		}
 	}
-	
+	catch (const parse::ParseException& e)
+	{
+		mprintf(("TABLES: Unable to parse 'controlconfigdefaults.tbl'!  Error message = %s.\n", e.what()));
+		return;
+	}
+
 	// Overwrite the control config with the first preset that was found
 	if (!Control_config_presets.empty()) {
 		std::copy(Control_config_presets[0], Control_config_presets[0] + CCFG_MAX + 1, Control_config);

--- a/code/globalincs/alphacolors.cpp
+++ b/code/globalincs/alphacolors.cpp
@@ -277,10 +277,11 @@ void alpha_colors_init()
 void parse_colors(const char *filename)
 {
 	Assertion(filename != NULL, "parse_colors() called on NULL; get a coder!\n");
-	read_file_text(filename, CF_TYPE_TABLES);
 	
 	try
 	{
+		read_file_text(filename, CF_TYPE_TABLES);
+
 		reset_parse();
 
 		// we search for the colors based on their order of definition above
@@ -353,10 +354,11 @@ void parse_colors(const char *filename)
 void parse_everything_else(const char *filename)
 {
 	Assertion(filename != NULL, "parse_everything_else() called on NULL; get a coder!\n");
-	read_file_text(filename, CF_TYPE_TABLES);
 
 	try
 	{
+		read_file_text(filename, CF_TYPE_TABLES);
+
 		reset_parse();
 
 		int rgba[4] = { 0, 0, 0, 0 };

--- a/code/mission/missionmessage.cpp
+++ b/code/mission/missionmessage.cpp
@@ -546,110 +546,117 @@ void parse_msgtbl()
 	Message_waves.reserve(300);
 	Message_avis.reserve(30);
 
-	read_file_text("messages.tbl", CF_TYPE_TABLES);
-	reset_parse();
-	Num_messages = 0;
-	Num_personas = 0;
+	try {
+		read_file_text("messages.tbl", CF_TYPE_TABLES);
+		reset_parse();
+		Num_messages = 0;
+		Num_personas = 0;
 
-	// Goober5000 - ugh, ugly hack to fix the FS2 retail tables
-	char *pVawacs25 = strstr(Mp, "Vawacs25.wav");
-	if (pVawacs25)
-	{
-		char *pAwacs75 = strstr(pVawacs25, "Awacs75.wav");
-		if (pAwacs75)
+		// Goober5000 - ugh, ugly hack to fix the FS2 retail tables
+		char *pVawacs25 = strstr(Mp, "Vawacs25.wav");
+		if (pVawacs25)
 		{
-			// move the 'V' from the first filename to the second, and adjust the 'A' case
-			*pVawacs25 = 'A';
-			for (i = 1; i < (pAwacs75 - pVawacs25) - 1; i++)
-				pVawacs25[i] = pVawacs25[i+1];
-			pAwacs75[-1] = 'V';
-			pAwacs75[0] = 'a';
-		}
-	}
-
-	// now we can start parsing
-	if (optional_string("#Message Frequencies")) {
-		while (!required_string_one_of(3, "$Name:", "#Personas", "#Moods" )) {
-			message_frequency_parse();
-		}
-	}	
-
-	Builtin_moods.push_back("Default");
-	if (optional_string("#Moods")) {
-		message_moods_parse();
-	}	
-
-
-	required_string("#Personas");
-	while ( required_string_either("#Messages", "$Persona:")){
-		persona_parse();
-	}
-
-	required_string("#Messages");
-	while (required_string_either("#End", "$Name:")){
-		message_parse();
-	}
-
-	required_string("#End");
-
-	// save the number of builtin message things -- make initing between missions easier
-	Num_builtin_messages = Num_messages;
-	Num_builtin_avis = Num_message_avis;
-	Num_builtin_waves = Num_message_waves;
-
-	
-	memset(Valid_builtin_message_types, 0, sizeof(int)*MAX_BUILTIN_MESSAGE_TYPES); 
-	// now cycle through the messages to determine which type of builtins we have messages for
-	for (i = 0; i < Num_builtin_messages; i++) {
-		for (j = 0; j < MAX_BUILTIN_MESSAGE_TYPES; j++) {
-			if (!(stricmp(Messages[i].name, Builtin_messages[j].name))) {
-				Valid_builtin_message_types[j] = 1; 
-				break;
-			}
-		}
-	}
-
-
-	// additional table part!
-	generic_message_filenames.clear();
-	generic_message_filenames.push_back("none");
-	generic_message_filenames.push_back("cuevoice");
-	generic_message_filenames.push_back("emptymsg");
-	generic_message_filenames.push_back("generic");
-	generic_message_filenames.push_back("msgstart");
-
-	if (optional_string("#Simulated Speech Overrides"))
-	{
-		char filename[MAX_FILENAME_LEN];
-
-		while (required_string_either("#End", "$File Name:"))
-		{
-			required_string("$File Name:");
-			stuff_string(filename, F_NAME, MAX_FILENAME_LEN);
-
-			// get extension
-			char *ptr = strchr(filename, '.');
-			if (ptr == NULL)
+			char *pAwacs75 = strstr(pVawacs25, "Awacs75.wav");
+			if (pAwacs75)
 			{
-				Warning(LOCATION, "Simulated speech override file '%s' was provided with no extension!", filename);
-				continue;
+				// move the 'V' from the first filename to the second, and adjust the 'A' case
+				*pVawacs25 = 'A';
+				for (i = 1; i < (pAwacs75 - pVawacs25) - 1; i++)
+					pVawacs25[i] = pVawacs25[i+1];
+				pAwacs75[-1] = 'V';
+				pAwacs75[0] = 'a';
 			}
+		}
 
-			// test extension
-			if (stricmp(ptr, ".ogg") && stricmp(ptr, ".wav"))
-			{
-				Warning(LOCATION, "Simulated speech override file '%s' was provided with an extension other than .wav or .ogg!", filename);
-				continue;
+		// now we can start parsing
+		if (optional_string("#Message Frequencies")) {
+			while (!required_string_one_of(3, "$Name:", "#Personas", "#Moods" )) {
+				message_frequency_parse();
 			}
+		}
 
-			// truncate extension
-			*ptr = '\0';
+		Builtin_moods.push_back("Default");
+		if (optional_string("#Moods")) {
+			message_moods_parse();
+		}
 
-			// add truncated file name
-			generic_message_filenames.push_back(filename);
+
+		required_string("#Personas");
+		while ( required_string_either("#Messages", "$Persona:")){
+			persona_parse();
+		}
+
+		required_string("#Messages");
+		while (required_string_either("#End", "$Name:")){
+			message_parse();
 		}
 
 		required_string("#End");
+
+		// save the number of builtin message things -- make initing between missions easier
+		Num_builtin_messages = Num_messages;
+		Num_builtin_avis = Num_message_avis;
+		Num_builtin_waves = Num_message_waves;
+
+
+		memset(Valid_builtin_message_types, 0, sizeof(int)*MAX_BUILTIN_MESSAGE_TYPES);
+		// now cycle through the messages to determine which type of builtins we have messages for
+		for (i = 0; i < Num_builtin_messages; i++) {
+			for (j = 0; j < MAX_BUILTIN_MESSAGE_TYPES; j++) {
+				if (!(stricmp(Messages[i].name, Builtin_messages[j].name))) {
+					Valid_builtin_message_types[j] = 1;
+					break;
+				}
+			}
+		}
+
+
+		// additional table part!
+		generic_message_filenames.clear();
+		generic_message_filenames.push_back("none");
+		generic_message_filenames.push_back("cuevoice");
+		generic_message_filenames.push_back("emptymsg");
+		generic_message_filenames.push_back("generic");
+		generic_message_filenames.push_back("msgstart");
+
+		if (optional_string("#Simulated Speech Overrides"))
+		{
+			char filename[MAX_FILENAME_LEN];
+
+			while (required_string_either("#End", "$File Name:"))
+			{
+				required_string("$File Name:");
+				stuff_string(filename, F_NAME, MAX_FILENAME_LEN);
+
+				// get extension
+				char *ptr = strchr(filename, '.');
+				if (ptr == NULL)
+				{
+					Warning(LOCATION, "Simulated speech override file '%s' was provided with no extension!", filename);
+					continue;
+				}
+
+				// test extension
+				if (stricmp(ptr, ".ogg") && stricmp(ptr, ".wav"))
+				{
+					Warning(LOCATION, "Simulated speech override file '%s' was provided with an extension other than .wav or .ogg!", filename);
+					continue;
+				}
+
+				// truncate extension
+				*ptr = '\0';
+
+				// add truncated file name
+				generic_message_filenames.push_back(filename);
+			}
+
+			required_string("#End");
+		}
+	}
+	catch (const parse::ParseException& e)
+	{
+		mprintf(("MISSIONCAMPAIGN: Unable to parse 'messages.tbl'!  Error message = %s.\n", e.what()));
+		return;
 	}
 }
 

--- a/code/particle/ParticleManager.cpp
+++ b/code/particle/ParticleManager.cpp
@@ -90,22 +90,29 @@ EffectType parseEffectType() {
 void parseCallback(const char* fileName) {
 	using namespace particle;
 
-	read_file_text(fileName, CF_TYPE_TABLES);
+	try {
+		read_file_text(fileName, CF_TYPE_TABLES);
 
-	reset_parse();
+		reset_parse();
 
-	required_string("#Particle Effects");
+		required_string("#Particle Effects");
 
-	while (optional_string("$Effect:")) {
-		SCP_string name;
-		stuff_string(name, F_NAME);
+		while (optional_string("$Effect:")) {
+			SCP_string name;
+			stuff_string(name, F_NAME);
 
-		auto type = parseEffectType();
+			auto type = parseEffectType();
 
-		ParticleManager::get()->addEffect(constructEffect(name, type));
+			ParticleManager::get()->addEffect(constructEffect(name, type));
+		}
+
+		required_string("#End");
 	}
-
-	required_string("#End");
+	catch (const parse::ParseException& e)
+	{
+		mprintf(("TABLES: Unable to parse '%s'!  Error message = %s.\n", fileName, e.what()));
+		return;
+	}
 }
 
 void parseConfigFiles() {


### PR DESCRIPTION
Before, if any parsing call failed it would throw an exception which
would have been propagated to the exception handler in main() which
terminates the program. This should fix that.