### PR TITLE
Fix for Mantis 3187.

### DIFF
--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -3495,7 +3495,7 @@ void mission_parse_maybe_create_parse_object(p_object *pobjp)
 			{
 				// be sure to set the variable in the ships structure for the final death time!!!
 				Ships[objp->instance].final_death_time = pobjp->destroy_before_mission_time;
-				Ships[objp->instance].flags[Ship::Ship_Flags::Kill_before_mission];
+				Ships[objp->instance].flags.set(Ship::Ship_Flags::Kill_before_mission);
 			}
 		}
 	}


### PR DESCRIPTION
When this line was [converted by the bitset flags PR](https://github.com/scp-fs2open/fs2open.github.com/commit/770fce8de5dc3ab4fd1db0e4d74724664dd60047#diff-88098ad7c34083a6bd8b42e955eeca45R3493), it was accidentally changed from setting the flag to reading the flag, making it a do-nothing line and causing the flag to be cleared on mission load.

[Corresponding Mantis issue.](http://scp.indiegames.us/mantis/view.php?id=3187)