### PR TITLE
Fix scripting hook object parameter

### DIFF
--- a/code/weapon/beam.cpp
+++ b/code/weapon/beam.cpp
@@ -1908,7 +1908,7 @@ int beam_start_firing(beam *b)
 	}	
 
 	Script_system.SetHookObjects(3, "Beam", &Objects[b->objnum], "User", b->objp, "Target", b->target);
-	Script_system.RunCondition(CHA_BEAMFIRE, 0, NULL, b->objp, b->weapon_info_index);
+	Script_system.RunCondition(CHA_BEAMFIRE, 0, NULL, &Objects[b->objnum], b->weapon_info_index);
 	Script_system.RemHookVars(3, "Beam", "User", "Target");
 
 	// success


### PR DESCRIPTION
It was using the object pointer of the User before which is not correct
since the object pointer of the beam is needed.