### PR TITLE
Disable iterator debugging for FastDebug

### DIFF
--- a/cmake/toolchain-msvc.cmake
+++ b/cmake/toolchain-msvc.cmake
@@ -134,7 +134,7 @@ else()
 endif()
 
 target_compile_definitions(compiler INTERFACE _CRT_SECURE_NO_DEPRECATE
-	_CRT_SECURE_NO_WARNINGS _SECURE_SCL=0 NOMINMAX)
+_CRT_SECURE_NO_WARNINGS _SECURE_SCL=0 NOMINMAX "$<$<CONFIG:FastDebug>:_ITERATOR_DEBUG_LEVEL=0>")
 	
 if (FSO_FATAL_WARNINGS)
 	# Make warnings fatal if the right variable is set

--- a/lib/jansson/CMakeLists.txt
+++ b/lib/jansson/CMakeLists.txt
@@ -316,4 +316,5 @@ IF(FSO_BUILD_INCLUDED_LIBS OR NOT JANSSON_FOUND)
 
     target_include_directories(jansson PUBLIC ${CMAKE_CURRENT_BINARY_DIR}/include)
     target_include_directories(jansson PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/private_include)
+	target_link_libraries(jansson PUBLIC compiler)
 endif()

--- a/lib/libjpeg/CMakeLists.txt
+++ b/lib/libjpeg/CMakeLists.txt
@@ -57,6 +57,7 @@ IF (FSO_BUILD_INCLUDED_LIBS OR NOT JPEG_FOUND)
 	if (MSVC)
 		target_compile_options(jpeg PRIVATE "/W0")
 	endif()
+	target_link_libraries(jpeg PUBLIC compiler)
 
 	SET(JPEG_LIBS jpeg CACHE INTERNAL "JPEG library")
 ELSE(FSO_BUILD_INCLUDED_LIBS OR NOT JPEG_FOUND)

--- a/lib/libpng/CMakeLists.txt
+++ b/lib/libpng/CMakeLists.txt
@@ -57,6 +57,7 @@ IF (FSO_BUILD_INCLUDED_LIBS OR NOT PNG_FOUND)
 	endif()
 
 	target_link_libraries(png PUBLIC ${ZLIB_LIBS})
+	target_link_libraries(png PUBLIC compiler)
 
 	SET(PNG_LIBS png CACHE INTERNAL "PNG library")
 

--- a/lib/lua/CMakeLists.txt
+++ b/lib/lua/CMakeLists.txt
@@ -201,6 +201,7 @@ ELSE(FSO_USE_LUAJIT)
 			# Disable warnings if building from source
 			target_compile_options(lua51 PRIVATE "/W0")
 		endif()
+		target_link_libraries(lua51 PUBLIC compiler)
 
 		SET(LUA_INCLUDE_DIR ${CMAKE_CURRENT_LIST_DIR} CACHE INTERNAL "Lua 5.1 include directory")
 

--- a/lib/md5/CMakeLists.txt
+++ b/lib/md5/CMakeLists.txt
@@ -7,4 +7,8 @@ ADD_LIBRARY(md5 STATIC ${MD5_SOURCES})
 
 target_include_directories(md5 PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")
 
+if (MSVC)
+    target_compile_options(md5 PRIVATE "/W0")
+endif()
 set_target_properties(md5 PROPERTIES FOLDER "3rdparty")
+target_link_libraries(md5 PUBLIC compiler)

--- a/lib/mongoose/CMakeLists.txt
+++ b/lib/mongoose/CMakeLists.txt
@@ -20,11 +20,13 @@ set_target_properties(mongoose
 		FOLDER "3rdparty"
 		INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_CURRENT_SOURCE_DIR}
 )
-	
+
+# Disable warnings if building from source
 if (MSVC)
-	# Disable warnings if building from source
 	target_compile_options(mongoose PRIVATE "/W0")
+else()
+	target_compile_options(mongoose PRIVATE "-w")
 endif()
+target_link_libraries(mongoose PUBLIC compiler)
 
 SET(MONGOOSE_LIBS mongoose CACHE INTERNAL "mongoose library")
-

--- a/lib/zlib/CMakeLists.txt
+++ b/lib/zlib/CMakeLists.txt
@@ -43,6 +43,7 @@ IF (FSO_BUILD_INCLUDED_LIBS OR NOT ZLIB_FOUND)
 		# Disable warnings if building from source
 		target_compile_options(zlib PRIVATE "/W0")
 	endif()
+	target_link_libraries(zlib PUBLIC compiler)
 
 	IF(BUILD_SHARED_LIBS)
 		target_compile_definitions(zlib INTERFACE ZLIB_DLL)


### PR DESCRIPTION
This is a feature for developers that is not needed in FastDebug builds.
This should speed up these builds a bit since iterator debugging causes
quite a performance penalty.