### PR TITLE
Fix for incorrect alpha channel detection for animations.

### DIFF
--- a/code/bmpman/bmpman.cpp
+++ b/code/bmpman/bmpman.cpp
@@ -525,6 +525,7 @@ int bm_create(int bpp, int w, int h, void *data, int flags) {
 	bm_bitmaps[n].bm.h = (short)h;
 	bm_bitmaps[n].bm.rowsize = (short)w;
 	bm_bitmaps[n].bm.bpp = (ubyte)bpp;
+	bm_bitmaps[n].bm.true_bpp = (ubyte)bpp;
 	bm_bitmaps[n].bm.flags = (ubyte)flags;
 	bm_bitmaps[n].bm.data = 0;
 	bm_bitmaps[n].bm.palette = NULL;


### PR DESCRIPTION
bm_has_alpha_channel() checks true_bpp for bmps. true_bpp is 0 for animations. That's because they're created with bm_create, not bm_load or bm_load_animation. Suffice to say, that causes problems when the material setting functions wants to figure out if a bitmap needs to be alpha or additively blended. Made a simple  change to bm_create that should address this. Hopefully this should fix the waifus in https://github.com/scp-fs2open/fs2open.github.com/issues/1074