### PR TITLE
Fix warnings in nightly builds

### DIFF
--- a/ci/travis/before_script.sh
+++ b/ci/travis/before_script.sh
@@ -19,7 +19,7 @@ if [ "$TRAVIS_OS_NAME" = "linux" ]; then
             cd ..
         done
     else
-        eval $CMAKE -DCMAKE_BUILD_TYPE=$CONFIGURATION -DFSO_BUILD_TESTS=ON ..
+        eval $CMAKE -DCMAKE_BUILD_TYPE=$CONFIGURATION -DFSO_BUILD_TESTS=ON -DFSO_BUILD_INCLUDED_LIBS=ON ..
     fi
 elif [ "$TRAVIS_OS_NAME" = "osx" ]; then
     if [ "$BUILD_DEPLOYMENT" = true ]; then

--- a/cmake/util.cmake
+++ b/cmake/util.cmake
@@ -178,3 +178,13 @@ function (check_linker_flag _flag _out_var)
 	SET(CMAKE_REQUIRED_FLAGS "${_flag}")
 	CHECK_C_COMPILER_FLAG("" ${_out_var})
 endfunction(check_linker_flag)
+
+# Suppresses warnings for the specified target
+function(suppress_warnings _target)
+    if (MSVC)
+        target_compile_options(${_target} PRIVATE "/W0")
+	else()
+        # Assume everything else uses GCC style options
+		target_compile_options(${_target} PRIVATE "-w")
+    endif()
+endfunction(suppress_warnings)

--- a/lib/jansson/CMakeLists.txt
+++ b/lib/jansson/CMakeLists.txt
@@ -306,11 +306,9 @@ IF(FSO_BUILD_INCLUDED_LIBS OR NOT JANSSON_FOUND)
       ${JANSSON_SRC}
       ${JANSSON_HDR_PRIVATE}
       ${JANSSON_HDR_PUBLIC})
-
-    if (MSVC)
-        # Disable warnings if building from source
-        target_compile_options(jansson PRIVATE "/W0")
-    endif()
+      
+    # Disable warnings if building from source
+    suppress_warnings(jansson)
 
     set_target_properties(jansson PROPERTIES FOLDER "3rdparty")
 

--- a/lib/libjpeg/CMakeLists.txt
+++ b/lib/libjpeg/CMakeLists.txt
@@ -53,10 +53,11 @@ IF (FSO_BUILD_INCLUDED_LIBS OR NOT JPEG_FOUND)
 		PROPERTIES
 			FOLDER "3rdparty"
 	)
-	
-	if (MSVC)
-		target_compile_options(jpeg PRIVATE "/W0")
-	endif()
+    
+    
+    # Disable warnings if building from source
+    suppress_warnings(jpeg)
+    
 	target_link_libraries(jpeg PUBLIC compiler)
 
 	SET(JPEG_LIBS jpeg CACHE INTERNAL "JPEG library")

--- a/lib/libpng/CMakeLists.txt
+++ b/lib/libpng/CMakeLists.txt
@@ -50,11 +50,9 @@ IF (FSO_BUILD_INCLUDED_LIBS OR NOT PNG_FOUND)
 		PROPERTIES
 			FOLDER "3rdparty"
 	)
-	
-	if (MSVC)
-		# Disable warnings if building from source
-		target_compile_options(png PRIVATE "/W0")
-	endif()
+    
+    # Disable warnings if building from source
+    suppress_warnings(png)
 
 	target_link_libraries(png PUBLIC ${ZLIB_LIBS})
 	target_link_libraries(png PUBLIC compiler)

--- a/lib/lua/CMakeLists.txt
+++ b/lib/lua/CMakeLists.txt
@@ -207,6 +207,8 @@ ELSE(FSO_USE_LUAJIT)
 		if (MSVC)
 			# Disable warnings if building from source
 			target_compile_options(lua51 PRIVATE "/W0")
+		else()
+			target_compile_options(lua51 PRIVATE "-w")
 		endif()
 		target_link_libraries(lua51 PUBLIC compiler)
 

--- a/lib/lua/CMakeLists.txt
+++ b/lib/lua/CMakeLists.txt
@@ -204,12 +204,9 @@ ELSE(FSO_USE_LUAJIT)
 			target_compile_definitions(lua51 PUBLIC LUA_USE_MACOSX)
 		endif()
 
-		if (MSVC)
-			# Disable warnings if building from source
-			target_compile_options(lua51 PRIVATE "/W0")
-		else()
-			target_compile_options(lua51 PRIVATE "-w")
-		endif()
+		# Disable warnings if building from source
+		suppress_warnings(lua51)
+
 		target_link_libraries(lua51 PUBLIC compiler)
 
 		SET(LUA_INCLUDE_DIR ${CMAKE_CURRENT_LIST_DIR} CACHE INTERNAL "Lua 5.1 include directory")

--- a/lib/md5/CMakeLists.txt
+++ b/lib/md5/CMakeLists.txt
@@ -7,8 +7,8 @@ ADD_LIBRARY(md5 STATIC ${MD5_SOURCES})
 
 target_include_directories(md5 PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")
 
-if (MSVC)
-    target_compile_options(md5 PRIVATE "/W0")
-endif()
+# Disable warnings if building from source
+suppress_warnings(md5)
+
 set_target_properties(md5 PROPERTIES FOLDER "3rdparty")
 target_link_libraries(md5 PUBLIC compiler)

--- a/lib/mongoose/CMakeLists.txt
+++ b/lib/mongoose/CMakeLists.txt
@@ -22,11 +22,8 @@ set_target_properties(mongoose
 )
 
 # Disable warnings if building from source
-if (MSVC)
-	target_compile_options(mongoose PRIVATE "/W0")
-else()
-	target_compile_options(mongoose PRIVATE "-w")
-endif()
+suppress_warnings(mongoose)
+
 target_link_libraries(mongoose PUBLIC compiler)
 
 SET(MONGOOSE_LIBS mongoose CACHE INTERNAL "mongoose library")

--- a/lib/zlib/CMakeLists.txt
+++ b/lib/zlib/CMakeLists.txt
@@ -38,11 +38,10 @@ IF (FSO_BUILD_INCLUDED_LIBS OR NOT ZLIB_FOUND)
 			FOLDER "3rdparty"
 			DEFINE_SYMBOL ZLIB_DLL # This will only be defined if we are building a shared library
 	)
-	
-	if (MSVC)
-		# Disable warnings if building from source
-		target_compile_options(zlib PRIVATE "/W0")
-	endif()
+
+    # Disable warnings if building from source
+    suppress_warnings(zlib)
+    
 	target_link_libraries(zlib PUBLIC compiler)
 
 	IF(BUILD_SHARED_LIBS)


### PR DESCRIPTION
This should suppress the warnings that made the Linux nightly builds fail for the past few days.

This also changes the Travis configuration so that it always builds the included libraries which matches what the nightly build does. This should reduce the likelihood that the CI builds pass but the nightly builds fail.