### PR TITLE
Fix for #1115

### DIFF
--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -309,7 +309,7 @@ flag_def_list_new<Mission::Parse_Object_Flags> Parse_object_flags[] = {
     { "ship-locked",					Mission::Parse_Object_Flags::SF_Ship_locked,			true, false },
     { "weapons-locked",					Mission::Parse_Object_Flags::SF_Weapons_locked,			true, false },
     { "scramble-messages",				Mission::Parse_Object_Flags::SF_Scramble_messages,		true, false },
-    { "no-collide",						Mission::Parse_Object_Flags::OF_No_collide,				true, false },
+    { "no_collide",						Mission::Parse_Object_Flags::OF_No_collide,				true, false },
 	{ "no-disabled-self-destruct",		Mission::Parse_Object_Flags::SF_No_disabled_self_destruct, true, false }
 };
 

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -309,7 +309,8 @@ flag_def_list_new<Mission::Parse_Object_Flags> Parse_object_flags[] = {
     { "ship-locked",					Mission::Parse_Object_Flags::SF_Ship_locked,			true, false },
     { "weapons-locked",					Mission::Parse_Object_Flags::SF_Weapons_locked,			true, false },
     { "scramble-messages",				Mission::Parse_Object_Flags::SF_Scramble_messages,		true, false },
-    { "no_collide",						Mission::Parse_Object_Flags::OF_No_collide,				true, false },
+    { "no-collide",						Mission::Parse_Object_Flags::OF_No_collide,				true, false },
+	{ "no-disabled-self-destruct",		Mission::Parse_Object_Flags::SF_No_disabled_self_destruct, true, false }
 };
 
 const size_t num_parse_object_flags = sizeof(Parse_object_flags) / sizeof(flag_def_list_new<Mission::Parse_Object_Flags>);

--- a/fred2/missionsave.cpp
+++ b/fred2/missionsave.cpp
@@ -2997,7 +2997,7 @@ int CFred_mission_save::save_objects() {
 			if (shipp->flags[Ship::Ship_Flags::Scramble_messages])
 				fout(" \"scramble-messages\"");
 			if (!(objp->flags[Object::Object_Flags::Collides]))
-				fout(" \"no-collide\"");
+				fout(" \"no_collide\"");
 			if (shipp->flags[Ship::Ship_Flags::No_disabled_self_destruct])
 				fout(" \"no-disabled-self-destruct\"");
 			fout(" )");


### PR DESCRIPTION
The "no collide" parse object flag needs to be written as "no_collide" in the flags list, and the "no-disabled-self-destruct" flag needs to be parsed