### PR TITLE
Add collision group support to beams.

### DIFF
--- a/code/weapon/beam.cpp
+++ b/code/weapon/beam.cpp
@@ -24,6 +24,7 @@
 #include "iff_defs/iff_defs.h"
 #include "io/timer.h"
 #include "lighting/lighting.h"
+#include "mod_table/mod_table.h"
 #include "network/multi.h"
 #include "network/multimsgs.h"
 #include "object/objcollide.h"
@@ -438,6 +439,10 @@ int beam_fire(beam_fire_info *fire_info)
 		return -1;
 	}
 	new_item->objnum = objnum;
+
+	if (new_item->objp != nullptr && Weapons_inherit_parent_collision_group) {
+		Objects[objnum].collision_group_id = new_item->objp->collision_group_id;
+	}
 
 	// this sets up all info for the first frame the beam fires
 	beam_aim(new_item);						// to fill in shot_point, etc.	
@@ -2391,6 +2396,9 @@ int beam_collide_ship(obj_pair *pair)
 		return 1;
 	ship_objp = pair->b;
 	shipp = &Ships[ship_objp->instance];
+
+	if (reject_due_collision_groups(weapon_objp, ship_objp))
+		return 0;
 
 	int quadrant_num = -1;
 	int	valid_hit_occurred = 0;


### PR DESCRIPTION
Makes beams inherit their firing ship's collision group if "$Weapons inherit parent collision group:" is enabled, and adds a collision group check to beam/ship collisions (and only beam/ship collisions, since collision groups are only currently checked for ship/ship and ship/weapon collisions).

This shouldn't break any existing mods, since usage of collision groups is surprisingly rare, and so is usage of weapons inheriting their parent's collision groups, and this change should only affect mods that do both at the same time; from a (very quick, non-representative) survey of modders, it's entirely possible that the mod requesting this change is the only one that does so (theoretically, there could be a mod out there that uses scripting to explicitly set the collision group of a beam object, but if they did so and then relied on it not actually doing anything, that's incredibly silly of them).

This was requested by the Dimensional Eclipse team, and tested to work:
![A screenshot of an Orion shooting a beam through another Orion to hit a third.](http://deviance.duckish.net/pictures/screen0013.png)