### PR TITLE
Resize Messages vector before storing messages into it in FRED.

### DIFF
--- a/fred2/eventeditor.cpp
+++ b/fred2/eventeditor.cpp
@@ -547,6 +547,7 @@ void event_editor::OnOk()
 	}
 
 	Num_messages = m_num_messages + Num_builtin_messages;
+	Messages.resize(Num_messages);
 	for (i=0; i<m_num_messages; i++)
 		Messages[i + Num_builtin_messages] = m_messages[i];
 


### PR DESCRIPTION
Not resizing the Messages vector here was leading to a debug error about an out-of-range vector subscript, and who knows what other problems were being caused by overwriting whatever memory was after the Messages vector. There's no equivalent problem when parsing, because as each message is parsed, it gets pushed onto the back of the vector instead of assigned directly to an index.

This fixes at least one issue raised by [Mantis #3006](http://scp.indiegames.us/mantis/view.php?id=3006).