### PR TITLE
change excluded_moods to be a bitstring instead of a vector, due to MMessage being a struct

### DIFF
--- a/code/mission/missionmessage.h
+++ b/code/mission/missionmessage.h
@@ -123,8 +123,8 @@ typedef struct MissionMessage {
 	char	message[MESSAGE_LENGTH];			// actual message
 	int	persona_index;							// which persona says this message
 	int	multi_team;								// multiplayer team filter (important for TvT only)
-	int				mood;
-	SCP_vector<int> excluded_moods;
+	int mood;
+	int excluded_moods;
 
 	// unions for avi/wave information.  Because of issues with Fred, we are using
 	// the union to specify either the index into the avi or wave arrays above,


### PR DESCRIPTION
MMessage, being a struct, cannot have any classes or STL structures in it.  This will lead to memory leaks and/or crashes in FRED, since messages are being reordered, added, and removed.

There are two ways to fix this.  One is to make MMessage a full class, but that would be going down a rabbit hole.  The other is to make the `excluded_moods` field a bitfield.  Since it is unlikely that there will be more than 31 built-in moods, and even more unlikely that there will be more than 31 excluded moods, I have used this technique in the PR.