### PR TITLE
Fix some string literal conversion warnings

### DIFF
--- a/code/ai/ai_profiles.cpp
+++ b/code/ai/ai_profiles.cpp
@@ -38,7 +38,7 @@ void set_flag(ai_profile_t *profile, const char *name, AI::Profile_Flags flag)
 	}
 }
 
-char *AI_path_types[] = {
+const char *AI_path_types[] = {
 	"normal",
 	"alt1",
 };

--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -105,7 +105,7 @@
 
 //XSTR:OFF
 
-char *Mode_text[MAX_AI_BEHAVIORS] = {
+const char *Mode_text[MAX_AI_BEHAVIORS] = {
 	"CHASE",
 	"EVADE",
 	"GET_BEHIND",
@@ -130,7 +130,7 @@ char *Mode_text[MAX_AI_BEHAVIORS] = {
 };
 
 //	Submode text is only valid for CHASE mode.
-char *Submode_text[] = {
+const char *Submode_text[] = {
 "undefined",
 "CONT_TURN",
 "ATTACK   ",
@@ -151,7 +151,7 @@ char *Submode_text[] = {
 "BIG_PARL"
 };
 
-char *Strafe_submode_text[5] = {
+const char *Strafe_submode_text[5] = {
 "ATTACK",
 "AVOID",
 "RETREAT1",
@@ -570,7 +570,7 @@ void init_ai_class(ai_class *aicp)
 	aicp->ai_class_autoscale = true;	//Retail behavior is to do the stupid autoscaling
 }
 
-void set_aic_flag(ai_class *aicp, char *name, AI::Profile_Flags flag)
+void set_aic_flag(ai_class *aicp, const char *name, AI::Profile_Flags flag)
 {
     auto flags = &(aicp->ai_profile_flags);
     auto set = &(aicp->ai_profile_flags_set);

--- a/code/ai/aiturret.cpp
+++ b/code/ai/aiturret.cpp
@@ -47,7 +47,7 @@ float Player_lethality_bump[NUM_SKILL_LEVELS] = {
 	0.0f, 0.0f, 0.0f, 0.0f, 0.0f
 };
 
-char *Turret_target_order_names[NUM_TURRET_ORDER_TYPES] = {
+const char *Turret_target_order_names[NUM_TURRET_ORDER_TYPES] = {
 	"Bombs",
 	"Ships",
 	"Asteroids",

--- a/code/autopilot/autopilot.cpp
+++ b/code/autopilot/autopilot.cpp
@@ -1272,7 +1272,7 @@ void NavSystem_Init()
 
 // ********************************************************************************************
 
-void parse_autopilot_table(char *filename)
+void parse_autopilot_table(const char *filename)
 {
 	SCP_vector<SCP_string> lines;
 
@@ -1315,7 +1315,7 @@ void parse_autopilot_table(char *filename)
 			Cmdline_autopilot_interruptable = 0;
 
 		// No Nav selected message
-		char *msg_tags[] = { "$No Nav Selected:", "$Gliding:",
+		const char *msg_tags[] = { "$No Nav Selected:", "$Gliding:",
 			"$Too Close:", "$Hostiles:", "$Linked:", "$Hazard:",
 			"$Support Present:", "$Support Working:" };
 		for (int i = 0; i < NP_NUM_MESSAGES; i++)

--- a/code/autopilot/autopilot.h
+++ b/code/autopilot/autopilot.h
@@ -118,7 +118,7 @@ void NavSystem_Do();
 void NavSystem_Init();
 
 // parse autopilot.tbl
-void parse_autopilot_table(char *filename);
+void parse_autopilot_table(const char *filename);
 
 // Finds a Nav point by name
 int FindNav(char *Nav);

--- a/code/camera/camera.cpp
+++ b/code/camera/camera.cpp
@@ -26,7 +26,7 @@ camid Main_camera;
 
 //*************************CLASS: camera*************************
 //This is where the camera class beings! :D
-camera::camera(char *in_name, int in_signature)
+camera::camera(const char *in_name, int in_signature)
 {
 	set_name(in_name);
 	sig = in_signature;
@@ -78,7 +78,7 @@ void camera::reset()
 	}
 }
 
-void camera::set_name(char *in_name)
+void camera::set_name(const char *in_name)
 {
 	if(in_name != NULL)
 		strncpy(name, in_name, NAME_LENGTH-1);
@@ -885,14 +885,14 @@ int cam_get_next_sig()
 	return next_sig++;
 }
 
-camid cam_create(char *n_name, vec3d *n_pos, vec3d *n_norm, object *n_object, int n_object_host_submodel)
+camid cam_create(const char *n_name, vec3d *n_pos, vec3d *n_norm, object *n_object, int n_object_host_submodel)
 {
 	matrix ori;
 	vm_vector_2_matrix_norm(&ori, n_norm);
 	return cam_create(n_name, n_pos, &ori, n_object, n_object_host_submodel);
 }
 
-camid cam_create(char *n_name, vec3d *n_pos, matrix *n_ori, object *n_object, int n_object_host_submodel)
+camid cam_create(const char *n_name, vec3d *n_pos, matrix *n_ori, object *n_object, int n_object_host_submodel)
 {
 	camera *cam = NULL;
 	camid cid;

--- a/code/camera/camera.h
+++ b/code/camera/camera.h
@@ -43,13 +43,13 @@ protected:
 	vec3d c_pos;
 	matrix c_ori;
 public:
-	camera(char *in_name=NULL, int in_signature=-1);
+	camera(const char *in_name=NULL, int in_signature=-1);
 	~camera();
 	void clear();
 	void reset();
 
 	//Set
-	void set_name(char *in_name);
+	void set_name(const char *in_name);
 
 	void set_object_host(object *objp, int n_object_host_submodel = -1);
 	void set_object_target(object *objp, int n_object_target_submodel = -1);
@@ -158,8 +158,8 @@ extern float Sexp_fov;
 void cam_init();
 void cam_close();
 void cam_do_frame(float frametime);
-camid cam_create(char *n_name=NULL, vec3d *n_pos=NULL, matrix *n_ori=NULL, object *n_object=NULL, int n_submodel_parent=-1);
-camid cam_create(char *n_name, vec3d *n_pos, vec3d *n_norm, object *n_object=NULL, int n_submodel_parent=-1);
+camid cam_create(const char *n_name=NULL, vec3d *n_pos=NULL, matrix *n_ori=NULL, object *n_object=NULL, int n_submodel_parent=-1);
+camid cam_create(const char *n_name, vec3d *n_pos, vec3d *n_norm, object *n_object=NULL, int n_submodel_parent=-1);
 void cam_delete(camid cid);
 bool cam_set_camera(camid cid);
 void cam_reset_camera();

--- a/code/cfile/cfilesystem.h
+++ b/code/cfile/cfilesystem.h
@@ -20,10 +20,10 @@ void cf_free_secondary_filelist();
 
 // Internal stuff
 typedef struct cf_pathtype {
-	int		index;					// To verify that the CF_TYPE define is correctly indexed into this array
-	char		*path;					// Path relative to FreeSpace root, has ending backslash.
-	char		*extensions;			// Extensions used in this pathtype, separated by spaces
-	int		parent_index;			// Index of this directory's parent.  Used for creating directories when writing.
+	int			index;					// To verify that the CF_TYPE define is correctly indexed into this array
+	const char*	path;					// Path relative to FreeSpace root, has ending backslash.
+	const char*	extensions;				// Extensions used in this pathtype, separated by spaces
+	int			parent_index;			// Index of this directory's parent.  Used for creating directories when writing.
 } cf_pathtype;
 
 // During cfile_init, verify that Pathtypes[n].index == n for each item

--- a/code/controlconfig/controlsconfig.cpp
+++ b/code/controlconfig/controlsconfig.cpp
@@ -48,12 +48,12 @@
 #define CONTROL_W_COORD 2
 #define CONTROL_H_COORD 3
 
-char* Conflict_background_bitmap_fname[GR_NUM_RESOLUTIONS] = {
+const char* Conflict_background_bitmap_fname[GR_NUM_RESOLUTIONS] = {
 	"ControlConfig",		// GR_640
 	"2_ControlConfig"		// GR_1024
 };
 
-char* Conflict_background_bitmap_mask_fname[GR_NUM_RESOLUTIONS] = {
+const char* Conflict_background_bitmap_mask_fname[GR_NUM_RESOLUTIONS] = {
 	"ControlConfig-m",		// GR_640
 	"2_ControlConfig-m"		// GR_1024
 };

--- a/code/controlconfig/controlsconfig.h
+++ b/code/controlconfig/controlsconfig.h
@@ -311,7 +311,7 @@ void control_config_cancel_exit();
 void control_config_reset_defaults(int presetnum=-1);
 int translate_key_to_index(const char *key, bool find_override=true);
 char *translate_key(char *key);
-char *textify_scancode(int code);
+const char *textify_scancode(int code);
 float check_control_timef(int id);
 int check_control(int id, int key = -1);
 void control_get_axes_readings(int *h, int *p, int *b, int *ta, int *tr);

--- a/code/controlconfig/controlsconfig.h
+++ b/code/controlconfig/controlsconfig.h
@@ -63,7 +63,7 @@ typedef struct config_item {
 	short joy_default;		//!< default joystick button bound to action
 	char tab;				//!< what tab (category) it belongs in
 	bool hasXSTR;			//!< whether we should translate this with an XSTR
-	char *text;				//!< describes the action in the config screen
+	const char *text;		//!< describes the action in the config screen
 	char type;				//!< manner control should be checked in
 	short key_id;			//!< actual key bound to action
 	short joy_id;			//!< joystick button bound to action
@@ -296,8 +296,8 @@ extern int Control_config_overlay_id;
 extern config_item Control_config[];		//!< Stores the keyboard configuration
 extern SCP_vector<config_item*> Control_config_presets; // tabled control presets; pointers to config_item arrays
 extern SCP_vector<SCP_string> Control_config_preset_names; // names for Control_config_presets (identical order of items)
-extern char **Scan_code_text;
-extern char **Joy_button_text;
+extern const char **Scan_code_text;
+extern const char **Joy_button_text;
 
 void control_config_common_init();			//!< initialize common control config stuff - call at game startup after localization has been initialized
 void control_config_common_close();			//!< close common control config stuff - call at game shutdown

--- a/code/controlconfig/controlsconfigcommon.cpp
+++ b/code/controlconfig/controlsconfigcommon.cpp
@@ -553,7 +553,7 @@ char *translate_key(char *key)
 	return text;
 }
 
-char *textify_scancode(int code)
+const char *textify_scancode(int code)
 {
 	static char text[40];
 

--- a/code/controlconfig/controlsconfigcommon.cpp
+++ b/code/controlconfig/controlsconfigcommon.cpp
@@ -199,7 +199,7 @@ config_item Control_config[CCFG_MAX + 1] = {
 	{                           -1,                 -1, -1,           false, "",                                       CC_TYPE_TRIGGER,    -1, -1, 0, false, false }
 };
 
-char *Scan_code_text_german[] = {
+const char *Scan_code_text_german[] = {
 	"",				"Esc",				"1",				"2",				"3",				"4",				"5",				"6",
 	"7",				"8",				"9",				"0",				"Akzent '",				"Eszett",				"R\x81""cktaste",		"Tab",
 	"Q",				"W",				"E",				"R",				"T",				"Z",				"U",				"I",
@@ -241,7 +241,7 @@ char *Scan_code_text_german[] = {
 	"",				"",				"",				"",				"",				"",				"",				"",
 };
 
-char *Joy_button_text_german[] = {
+const char *Joy_button_text_german[] = {
 	"Knopf 1",		"Knopf 2",		"Knopf 3",		"Knopf 4",		"Knopf 5",		"Knopf 6",
 	"Knopf 7",		"Knopf 8",		"Knopf 9",		"Knopf 10",		"Knopf 11",		"Knopf 12",
 	"Knopf 13",		"Knopf 14",		"Knopf 15",		"Knopf 16",		"Knopf 17",		"Knopf 18",
@@ -250,7 +250,7 @@ char *Joy_button_text_german[] = {
 	"Knopf 31",		"Knopf 32",		"Hut Hinten",	"Hut Vorne",	"Hut Links",	"Hut Rechts"
 };
 
-char *Scan_code_text_french[] = {
+const char *Scan_code_text_french[] = {
 	"",				"\x90""chap",			"1",				"2",				"3",				"4",				"5",				"6",
 	"7",				"8",				"9",				"0",				"-",				"=",				"Fl\x82""che Ret.",			"Tab",
 	"Q",				"W",				"E",				"R",				"T",				"Y",				"U",				"I",
@@ -292,7 +292,7 @@ char *Scan_code_text_french[] = {
 	"",				"",				"",				"",				"",				"",				"",				"",
 };
 
-char *Joy_button_text_french[] = {
+const char *Joy_button_text_french[] = {
 	"Bouton 1",		"Bouton 2",		"Bouton 3",		"Bouton 4",		"Bouton 5",		"Bouton 6",
 	"Bouton 7",		"Bouton 8",		"Bouton 9",		"Bouton 10",		"Bouton 11",		"Bouton 12",
 	"Bouton 13",		"Bouton 14",		"Bouton 15",		"Bouton 16",		"Bouton 17",		"Bouton 18",
@@ -301,7 +301,7 @@ char *Joy_button_text_french[] = {
 	"Bouton 31",		"Bouton 32",		"Chapeau Arri\x8Are",		"Chapeau Avant",		"Chapeau Gauche",		"Chapeau Droite"
 };
 
-char *Scan_code_text_polish[] = {
+const char *Scan_code_text_polish[] = {
 	"",				"Esc",			"1",				"2",				"3",				"4",				"5",				"6",
 	"7",				"8",				"9",				"0",				"-",				"=",				"Backspace",	"Tab",
 	"Q",				"W",				"E",				"R",				"T",				"Y",				"U",				"I",
@@ -343,7 +343,7 @@ char *Scan_code_text_polish[] = {
 	"",				"",				"",				"",				"",				"",				"",				"",
 };
 
-char *Joy_button_text_polish[] = {
+const char *Joy_button_text_polish[] = {
 	"Przyc.1",		"Przyc.2",		"Przyc.3",		"Przyc.4",		"Przyc.5",		"Przyc.6",
 	"Przyc.7",		"Przyc.8",		"Przyc.9",		"Przyc.10",	"Przyc.11",	"Przyc.12",
 	"Przyc.13",	"Przyc.14",	"Przyc.15",	"Przyc.16",	"Przyc.17",	"Przyc.18",
@@ -353,7 +353,7 @@ char *Joy_button_text_polish[] = {
 };
 
 //!	This is the text that is displayed on the screen for the keys a player selects
-char *Scan_code_text_english[] = {
+const char *Scan_code_text_english[] = {
 	"",				"Esc",			"1",				"2",				"3",				"4",				"5",				"6",
 	"7",				"8",				"9",				"0",				"-",				"=",				"Backspace",	"Tab",
 	"Q",				"W",				"E",				"R",				"T",				"Y",				"U",				"I",
@@ -395,7 +395,7 @@ char *Scan_code_text_english[] = {
 	"",				"",				"",				"",				"",				"",				"",				"",
 };
 
-char *Joy_button_text_english[] = {
+const char *Joy_button_text_english[] = {
 	"Button 1",		"Button 2",		"Button 3",		"Button 4",		"Button 5",		"Button 6",
 	"Button 7",		"Button 8",		"Button 9",		"Button 10",	"Button 11",	"Button 12",
 	"Button 13",	"Button 14",	"Button 15",	"Button 16",	"Button 17",	"Button 18",
@@ -404,8 +404,8 @@ char *Joy_button_text_english[] = {
 	"Button 31",	"Button 32",	"Hat Back",		"Hat Forward",	"Hat Left",		"Hat Right"
 };
 
-char **Scan_code_text = Scan_code_text_english;
-char **Joy_button_text = Joy_button_text_english;
+const char **Scan_code_text = Scan_code_text_english;
+const char **Joy_button_text = Joy_button_text_english;
 
 SCP_vector<config_item*> Control_config_presets;
 SCP_vector<SCP_string> Control_config_preset_names;
@@ -510,8 +510,8 @@ int translate_key_to_index(const char *key, bool find_override)
 char *translate_key(char *key)
 {
 	int index = -1, key_code = -1, joy_code = -1;
-	char *key_text = NULL;
-	char *joy_text = NULL;
+	const char *key_text = NULL;
+	const char *joy_text = NULL;
 
 	static char text[40] = {"None"};
 

--- a/code/cutscene/cutscenes.cpp
+++ b/code/cutscene/cutscenes.cpp
@@ -26,11 +26,11 @@
 extern int Cmdline_nomovies;
 
 
-char* Cutscene_bitmap_name[GR_NUM_RESOLUTIONS] = {
+const char* Cutscene_bitmap_name[GR_NUM_RESOLUTIONS] = {
 		"ViewFootage",
 		"2_ViewFootage"
 };
-char* Cutscene_mask_name[GR_NUM_RESOLUTIONS] = {
+const char* Cutscene_mask_name[GR_NUM_RESOLUTIONS] = {
 		"ViewFootage-m",
 		"2_ViewFootage-m"
 };

--- a/code/gamehelp/gameplayhelp.cpp
+++ b/code/gamehelp/gameplayhelp.cpp
@@ -56,14 +56,14 @@ int Gp_last_screen;
 #define CONTINUE_BUTTON					2
 
 struct gameplay_help_buttons {
-	char *filename;
+	const char *filename;
 	int x, y;
 	int hotspot;
 	int tab;
 	int flags;
 	UI_BUTTON button;  // because we have a class inside this struct, we need the constructor below..
 
-	gameplay_help_buttons(char *name, int x1, int y1, int h) : filename(name), x(x1), y(y1), hotspot(h) {}
+	gameplay_help_buttons(const char *name, int x1, int y1, int h) : filename(name), x(x1), y(y1), hotspot(h) {}
 };
 
 static gameplay_help_buttons Buttons[GR_NUM_RESOLUTIONS][NUM_BUTTONS] = {
@@ -93,12 +93,12 @@ static UI_XSTR Game_help_text[GR_NUM_RESOLUTIONS][GAME_HELP_NUM_TEXT] = {
 	}
 };
 
-static char *Game_help_filename[GR_NUM_RESOLUTIONS] = {
+static const char *Game_help_filename[GR_NUM_RESOLUTIONS] = {
 	"F1",
 	"2_F1"
 };
 
-static char *Game_help_mask_filename[GR_NUM_RESOLUTIONS] = {
+static const char *Game_help_mask_filename[GR_NUM_RESOLUTIONS] = {
 	"F1-m",
 	"2_F1-m"
 };
@@ -112,7 +112,7 @@ static int Current_help_page;
 // generate a line for the on-line help for a control item with specified id
 // input:	id		=>	index for control item within Control_config[]
 //				buf	=> buffer with enough space to hold ouput string
-char *gameplay_help_control_text(int id, char *buf)
+const char *gameplay_help_control_text(int id, char *buf)
 {
 	int			has_key=0, has_joy=0;
 	config_item	*ci;

--- a/code/gamesequence/gamesequence.cpp
+++ b/code/gamesequence/gamesequence.cpp
@@ -44,7 +44,7 @@ script_hook GS_state_hooks[GS_NUM_STATES];
 
 // Text of state, corresponding to enum values for GS_STATE_*
 //XSTR:OFF
-char *GS_event_text[] =
+const char *GS_event_text[] =
 {
 	"GS_EVENT_MAIN_MENU",							// 0
 	"GS_EVENT_START_GAME",
@@ -120,7 +120,7 @@ int Num_gs_event_text = sizeof(GS_event_text)/sizeof(char*);
 
 // Text of state, corresponding to enum values for GS_STATE_*
 //XSTR:OFF
-char *GS_state_text[] =
+const char *GS_state_text[] =
 {
 	"NOT A VALID STATE",							// 0
 	"GS_STATE_MAIN_MENU",

--- a/code/gamesequence/gamesequence.h
+++ b/code/gamesequence/gamesequence.h
@@ -95,7 +95,7 @@ enum GS_EVENT {
 // IMPORTANT:  When you add a new event, update the initialization for GS_event_text[]
 //             which is done in gamesequence.cpp
 //
-extern char *GS_event_text[];		// text description for the GS_EVENT_* #defines above
+extern const char *GS_event_text[];		// text description for the GS_EVENT_* #defines above
 
 
 /**
@@ -166,7 +166,7 @@ enum GS_STATE {
 //             which is done in GameSequence.cpp
 //
 extern struct script_hook GS_state_hooks[];	//WMC-for scripting
-extern char *GS_state_text[];		// text description for the GS_STATE_* #defines above
+extern const char *GS_state_text[];		// text description for the GS_STATE_* #defines above
 extern int Num_gs_event_text;
 extern int Num_gs_state_text;		//WMC - for scripting
 

--- a/code/gamesnd/eventmusic.cpp
+++ b/code/gamesnd/eventmusic.cpp
@@ -84,8 +84,8 @@ int	Pattern_samples_per_measure[MAX_SOUNDTRACKS][MAX_PATTERNS];
 
 typedef struct pattern_info
 {
-	char *pattern_name;
-	char *pattern_desc;
+	const char *pattern_name;
+	const char *pattern_desc;
 	int pattern_can_force;
 	int pattern_loop_for;
 	int pattern_default_next_fs1;
@@ -1773,7 +1773,7 @@ int event_music_get_spooled_music_index(const SCP_string& name)
 	}
 
 // set a score based on name
-void event_music_set_score(int score_index, char *name)
+void event_music_set_score(int score_index, const char *name)
 {
 	Assert(score_index < NUM_SCORES);
 

--- a/code/gamesnd/eventmusic.h
+++ b/code/gamesnd/eventmusic.h
@@ -121,7 +121,7 @@ void	event_music_get_soundtrack_name(char *outbuf);
 int	event_music_next_soundtrack(int delta);
 void event_sexp_change_soundtrack(char *name);
 void	event_music_set_soundtrack(char *name);
-void	event_music_set_score(int score_index, char *name);
+void	event_music_set_score(int score_index, const char *name);
 int event_music_get_soundtrack_index(char *name);
 int	event_music_get_spooled_music_index(const char *name);
 int	event_music_get_spooled_music_index(const SCP_string& name);

--- a/code/globalincs/alphacolors.cpp
+++ b/code/globalincs/alphacolors.cpp
@@ -292,7 +292,7 @@ void parse_colors(const char *filename)
 			int rgba[4] = { 0, 0, 0, 0 };
 			int i, j;
 
-			char* color_names[TOTAL_COLORS] = {
+			const char* color_names[TOTAL_COLORS] = {
 				"$Blue:",
 				"$Bright Blue:",
 				"$Green:",

--- a/code/globalincs/pstypes.h
+++ b/code/globalincs/pstypes.h
@@ -274,7 +274,7 @@ extern int Global_error_count;
 	// No debug version of Int3
 	#define Int3() do { } while (0)
 #else
-	void debug_int3(char *file, int line);
+	void debug_int3(const char *file, int line);
 
 	// Debug version of Int3
 	#define Int3() debug_int3(__FILE__, __LINE__)

--- a/code/globalincs/pstypes.h
+++ b/code/globalincs/pstypes.h
@@ -189,21 +189,12 @@ struct particle_pnt {
 	vec3d up;
 };
 
-struct trail_shader_info {
-	vec3d pos;
-	vec3d fvec;
-
-	float intensity;
-	float width;
-	uv_pair tex_coord;
-};
-
 //def_list
-typedef struct flag_def_list {
-	char *name;
+struct flag_def_list {
+	const char *name;
 	int def;
 	ubyte var;
-} def_list;
+};
 
 template<class T>
 struct flag_def_list_new {

--- a/code/graphics/opengl/gropengl.cpp
+++ b/code/graphics/opengl/gropengl.cpp
@@ -875,7 +875,7 @@ void gr_opengl_set_line_width(float width)
 	GL_line_width = width;
 }
 
-int opengl_check_for_errors(char *err_at)
+int opengl_check_for_errors(const char *err_at)
 {
 #ifdef NDEBUG
 	return 0;

--- a/code/graphics/opengl/gropengl.h
+++ b/code/graphics/opengl/gropengl.h
@@ -20,7 +20,7 @@ const ubyte GL_zero_3ub[3] = { 0, 0, 0 };
 
 bool gr_opengl_init(os::GraphicsOperations* graphicsOps);
 void gr_opengl_cleanup(os::GraphicsOperations* graphicsOps, bool closing, int minimize=1);
-int opengl_check_for_errors(char *err_at = NULL);
+int opengl_check_for_errors(const char *err_at = NULL);
 bool gr_opengl_is_capable(gr_capability capability);
 void gr_opengl_push_debug_group(const char* name);
 void gr_opengl_pop_debug_group();

--- a/code/hud/hudconfig.cpp
+++ b/code/hud/hudconfig.cpp
@@ -233,19 +233,19 @@ int HC_select_all = 0;
 //////////////////////////////////////////////////////////////////////////////
 
 
-char *Hud_config_fname[GR_NUM_RESOLUTIONS] = {
+const char *Hud_config_fname[GR_NUM_RESOLUTIONS] = {
 	"HUDConfig",
 	"2_HUDConfig"
 };
 
-char *Hud_config_mask_fname[GR_NUM_RESOLUTIONS] = {
+const char *Hud_config_mask_fname[GR_NUM_RESOLUTIONS] = {
 	"HUDConfig-m",
 	"2_HUDConfig-m"
 };
 
 struct HC_gauge_region
 {
-	char			*filename;
+	const char		*filename;
 	int			x,y;
 	int			hotspot;
 	int			use_iff;
@@ -255,7 +255,7 @@ struct HC_gauge_region
 	int			color;
 	UI_BUTTON	button;
 
-	HC_gauge_region(char *name, int x1, int y1, int h, int iff, int cp, int b, int nf, int cl) : filename(name), x(x1), y(y1), hotspot(h), use_iff(iff), can_popup(cp), bitmap(b), nframes(nf), color(cl){}
+	HC_gauge_region(const char *name, int x1, int y1, int h, int iff, int cp, int b, int nf, int cl) : filename(name), x(x1), y(y1), hotspot(h), use_iff(iff), can_popup(cp), bitmap(b), nframes(nf), color(cl){}
 };
 
 // hud config gauges
@@ -670,7 +670,7 @@ int HC_slider_coords[GR_NUM_RESOLUTIONS][NUM_HC_SLIDERS][4] = {
 };
 #define HCS_CONV(__v)			( 255 - (__v) )
 
-char *HC_slider_fname[GR_NUM_RESOLUTIONS] = {
+const char *HC_slider_fname[GR_NUM_RESOLUTIONS] = {
 	"slider",
 	"2_slider"
 };
@@ -1639,7 +1639,7 @@ void hud_config_color_save(char *name)
 	cfclose(out);	
 }
 
-void hud_config_color_load(char *name)
+void hud_config_color_load(const char *name)
 {
 	int idx;
 	char str[1024];

--- a/code/hud/hudconfig.h
+++ b/code/hud/hudconfig.h
@@ -97,7 +97,7 @@ void hud_config_record_color(int color);
 void hud_config_set_color(int color);
 
 // load up the given hcf file
-void hud_config_color_load(char *name);
+void hud_config_color_load(const char *name);
 
 #endif
 

--- a/code/hud/hudmessage.cpp
+++ b/code/hud/hudmessage.cpp
@@ -121,13 +121,13 @@ static int Hud_mission_log_status_coords[GR_NUM_RESOLUTIONS][2] = {
 */
 
 struct scrollback_buttons {
-	char *filename;
+	const char *filename;
 	int x, y;
 	int xt, yt;
 	int hotspot;
 	UI_BUTTON button;  // because we have a class inside this struct, we need the constructor below..
 
-	scrollback_buttons(char *name, int x1, int y1, int x2, int y2, int h) : filename(name), x(x1), y(y1), xt(x2), yt(y2), hotspot(h) {}
+	scrollback_buttons(const char *name, int x1, int y1, int x2, int y2, int h) : filename(name), x(x1), y(y1), xt(x2), yt(y2), hotspot(h) {}
 };
 
 SCP_vector<HUD_message_data> HUD_msg_buffer;
@@ -160,7 +160,7 @@ static int Scrollback_mode = SCROLLBACK_MODE_OBJECTIVES;
 static int Background_bitmap;
 static UI_WINDOW Ui_window;
 
-static char* Hud_mission_log_fname[GR_NUM_RESOLUTIONS] = {
+static const char* Hud_mission_log_fname[GR_NUM_RESOLUTIONS] = {
 	"MissionLog",		// GR_640
 	"2_MissionLog"		// GR_1024
 };
@@ -172,7 +172,7 @@ static char* Hud_mission_log_status_fname[GR_NUM_RESOLUTIONS] = {
 };
 */
 
-static char* Hud_mission_log_mask_fname[GR_NUM_RESOLUTIONS] = {
+static const char* Hud_mission_log_mask_fname[GR_NUM_RESOLUTIONS] = {
 	"MissionLog-m",		// GR_640
 	"2_MissionLog-m"		// GR_1024
 };

--- a/code/hud/hudtarget.h
+++ b/code/hud/hudtarget.h
@@ -63,8 +63,8 @@ extern int Hud_target_w, Hud_target_h;
 extern shader Training_msg_glass;
 
 extern char **Ai_class_names;
-extern char *Submode_text[];
-extern char *Strafe_submode_text[];
+extern const char *Submode_text[];
+extern const char *Strafe_submode_text[];
 
 extern void hud_init_targeting_colors();
 

--- a/code/mission/missionmessage.cpp
+++ b/code/mission/missionmessage.cpp
@@ -2317,7 +2317,7 @@ void message_pagein_mission_messages()
 // ---------------------------------------------------
 // Add and remove messages - used by autopilot code now, but useful elswhere
 
-bool add_message(char *name, char *message, int persona_index, int multi_team)
+bool add_message(const char *name, char *message, int persona_index, int multi_team)
 {
 	MissionMessage msg; 
 	strcpy_s(msg.name, name);
@@ -2332,7 +2332,7 @@ bool add_message(char *name, char *message, int persona_index, int multi_team)
 	return true;
 }
 
-bool change_message(char *name, char *message, int persona_index, int multi_team)
+bool change_message(const char *name, char *message, int persona_index, int multi_team)
 {
 	for (int i = Num_builtin_messages; i < Num_messages; i++) 
 	{

--- a/code/mission/missionmessage.h
+++ b/code/mission/missionmessage.h
@@ -230,7 +230,7 @@ void message_load_wave(int index, const char *filename);
 
 // these two are probably safe
 // if change_message fails to find the message it'll fall through to add_message
-bool add_message(char *name, char *message, int persona_index, int multi_team);
-bool change_message(char *name, char *message, int persona_index, int multi_team);
+bool add_message(const char *name, char *message, int persona_index, int multi_team);
+bool change_message(const char *name, char *message, int persona_index, int multi_team);
 
 #endif

--- a/code/mission/missiontraining.cpp
+++ b/code/mission/missiontraining.cpp
@@ -105,7 +105,7 @@ training_message_mods Training_message_mods[MAX_TRAINING_MESSAGE_MODS];
 
 // local module prototypes
 void training_process_message(char *message);
-void message_translate_tokens(char *buf, char *text);
+void message_translate_tokens(char *buf, const char *text);
 
 
 #define NUM_DIRECTIVE_GAUGES			3
@@ -643,9 +643,10 @@ char *translate_message_token(char *str)
 /**
  * Translates all special tokens in a message, producing the new finalized message to be displayed
  */
-void message_translate_tokens(char *buf, char *text)
+void message_translate_tokens(char *buf, const char *text)
 {
-	char temp[40], *toke1, *toke2, *ptr;
+	char temp[40], *ptr;
+	const char *toke1, *toke2;
 	int r;
 
 	*buf = 0;
@@ -855,7 +856,7 @@ void message_training_setup(int m, int length, char *special_message)
 /**
  * Add a message to the queue to be sent later
  */
-void message_training_queue(char *text, int timestamp, int length)
+void message_training_queue(const char *text, int timestamp, int length)
 {
 	int m;
 	char temp_buf[TRAINING_MESSAGE_LENGTH];

--- a/code/mission/missiontraining.h
+++ b/code/mission/missiontraining.h
@@ -21,9 +21,9 @@ extern int Training_failure;
 void training_mission_init();
 void training_mission_shutdown();
 void training_check_objectives();
-void message_training_queue(char *text, int timestamp, int length = -1);
+void message_training_queue(const char *text, int timestamp, int length = -1);
 void message_training_setup(int num, int length = -1);
-void message_translate_tokens(char *buf, char *text);
+void message_translate_tokens(char *buf, const char *text);
 void training_fail();
 void message_training_update_frame();
 

--- a/code/missionui/missionscreencommon.cpp
+++ b/code/missionui/missionscreencommon.cpp
@@ -405,7 +405,7 @@ void common_maybe_play_cutscene(int movie_type, bool restart_music, int music)
 
 // function that sets the current palette to the interface palette.  This function
 // needs to be followed by common_free_interface_palette() to restore the game palette.
-void common_set_interface_palette(char *filename)
+void common_set_interface_palette(const char *filename)
 {
 	static char buf[MAX_FILENAME_LEN + 1] = {0};
 

--- a/code/missionui/missionscreencommon.h
+++ b/code/missionui/missionscreencommon.h
@@ -90,7 +90,7 @@ void ship_select_common_init();
 
 int mission_ui_background_load(const char *custom_background, const char *single_background, const char *multi_background = NULL);
 
-void common_set_interface_palette(char *filename = NULL);		// set the interface palette
+void common_set_interface_palette(const char *filename = NULL);		// set the interface palette
 void common_free_interface_palette();		// restore game palette
 
 void load_wing_icons(char *filename);

--- a/code/model/model.h
+++ b/code/model/model.h
@@ -795,7 +795,7 @@ void model_free_all();
 void model_instance_free_all();
 
 // Loads a model from disk and returns the model number it loaded into.
-int model_load(char *filename, int n_subsystems, model_subsystem *subsystems, int ferror = 1, int duplicate = 0);
+int model_load(const char *filename, int n_subsystems, model_subsystem *subsystems, int ferror = 1, int duplicate = 0);
 
 int model_create_instance(bool is_ship, int model_num);
 void model_delete_instance(int model_instance_num);

--- a/code/model/modelread.cpp
+++ b/code/model/modelread.cpp
@@ -1043,7 +1043,7 @@ void parse_triggers(int &n_trig, queued_animation **triggers, char *props);
 
 
 //reads a binary file containing a 3d model
-int read_model_file(polymodel * pm, char *filename, int n_subsystems, model_subsystem *subsystems, int ferror)
+int read_model_file(polymodel * pm, const char *filename, int n_subsystems, model_subsystem *subsystems, int ferror)
 {
 	CFILE *fp;
 	int version;
@@ -2619,7 +2619,7 @@ void model_load_texture(polymodel *pm, int i, char *file)
 }
 
 //returns the number of this model
-int model_load(char *filename, int n_subsystems, model_subsystem *subsystems, int ferror, int duplicate)
+int model_load(const  char *filename, int n_subsystems, model_subsystem *subsystems, int ferror, int duplicate)
 {
 	int i, num, arc_idx;
 	polymodel *pm = NULL;

--- a/code/network/stand_gui-unix.cpp
+++ b/code/network/stand_gui-unix.cpp
@@ -972,11 +972,11 @@ void std_multi_add_goals() {}
 void std_multi_update_goals() {}
 void std_multi_update_netgame_info_controls() {}
 void std_multi_set_standalone_mission_name(char *mission_name) {}
-void std_gen_set_text(char *str, int field_num) {}
-void std_create_gen_dialog(char *title) {}
+void std_gen_set_text(const char *str, int field_num) {}
+void std_create_gen_dialog(const char *title) {}
 void std_destroy_gen_dialog() {}
 int std_gen_is_active() {return 0;}
-void std_debug_set_standalone_state_string(char *str) {}
+void std_debug_set_standalone_state_string(const char *str) {}
 void std_reset_standalone_gui() {}
 void std_reset_timestamps() {}
 void std_multi_set_standalone_missiontime(float mission_time) {}

--- a/code/network/stand_gui.cpp
+++ b/code/network/stand_gui.cpp
@@ -126,7 +126,7 @@ BOOL CALLBACK std_gen_dialog_proc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM
 }
 
 // create the validate dialog 
-void std_create_gen_dialog(char *title)
+void std_create_gen_dialog(const char *title)
 {
 	// if the dialog is already active, do nothing
 	if(Multi_gen_dialog != NULL){
@@ -160,7 +160,7 @@ void std_destroy_gen_dialog()
 
 // set the text in the filename of the validate dialog
 // valid values for field_num == 0 .. 2
-void std_gen_set_text(char *str, int field_num)
+void std_gen_set_text(const char *str, int field_num)
 {
 	HWND ctrl;
 
@@ -1532,7 +1532,7 @@ static HWND Standalone_multilog_string = NULL;
 void std_debug_init_debug_controls(HWND hwndDlg);
 
 // set the text on the standalones state indicator box
-void std_debug_set_standalone_state_string(char *str)
+void std_debug_set_standalone_state_string(const char *str)
 {
    // set the text
 	SetWindowText(Standalone_state_string,str);

--- a/code/network/stand_gui.h
+++ b/code/network/stand_gui.h
@@ -30,14 +30,14 @@ struct net_player;
 //
 
 // create the validate dialog 
-void std_create_gen_dialog(char *title);
+void std_create_gen_dialog(const char *title);
 
 // kill the validate dialog();
 void std_destroy_gen_dialog();
 
 // set the text in the filename of the validate dialog
 // valid values for field_num == 0 .. 2
-void std_gen_set_text(char *str, int field_num);
+void std_gen_set_text(const char *str, int field_num);
 
 // is the validate dialog active
 int std_gen_is_active();
@@ -159,7 +159,7 @@ void std_gs_clear_controls();
 //
 
 // set the text on the standalones state indicator box
-void std_debug_set_standalone_state_string(char *str);
+void std_debug_set_standalone_state_string(const char *str);
 
 // clear all the controls for this page
 void std_debug_clear_controls();

--- a/code/object/collideshipship.cpp
+++ b/code/object/collideshipship.cpp
@@ -361,7 +361,7 @@ int ship_ship_check_collision(collision_info_struct *ship_ship_hit_info, vec3d *
 			collide_obj = heavy_obj;
 		}
 		if ((collide_obj != NULL) && (Ship_info[Ships[collide_obj->instance].ship_info_index].is_fighter_bomber())) {
-			char	*submode_string = "";
+			const char	*submode_string = "";
 			ai_info	*aip;
 
 			extern char *Mode_text[];

--- a/code/object/collideshipship.cpp
+++ b/code/object/collideshipship.cpp
@@ -364,7 +364,7 @@ int ship_ship_check_collision(collision_info_struct *ship_ship_hit_info, vec3d *
 			const char	*submode_string = "";
 			ai_info	*aip;
 
-			extern char *Mode_text[];
+			extern const char *Mode_text[];
 			aip = &Ai_info[Ships[collide_obj->instance].ai_index];
 
 			if (aip->mode == AIM_CHASE)

--- a/code/osapi/osapi.cpp
+++ b/code/osapi/osapi.cpp
@@ -363,7 +363,7 @@ void os_deinit()
 	SDL_Quit();
 }
 
-void debug_int3(char *file, int line)
+void debug_int3(const char *file, int line)
 {
 	mprintf(("Int3(): From %s at line %d\n", file, line));
 

--- a/code/parse/parselo.cpp
+++ b/code/parse/parselo.cpp
@@ -633,7 +633,7 @@ int optional_string_fred(char *pstr, char *end, char *end2)
  * @details Advances the Mp until a string is found or exceeds RS_MAX_TRIES. Once a string is found, Mp is located at
  * the start of the found string.
  */
-int required_string_either(char *str1, char *str2)
+int required_string_either(const char *str1, const char *str2)
 {
 	ignore_white_space();
 

--- a/code/parse/parselo.cpp
+++ b/code/parse/parselo.cpp
@@ -291,7 +291,7 @@ void error_display(int error_level, const char *format, ...)
 }
 
 //	Advance Mp to the next eoln character.
-void advance_to_eoln(char *more_terminators)
+void advance_to_eoln(const char *more_terminators)
 {
 	char	terminators[128];
 
@@ -331,7 +331,7 @@ void advance_to_next_white()
 // Search for specified string, skipping everything up to that point.  Returns 1 if found,
 // 0 if string wasn't found (and hit end of file), or -1 if not found, but end of checking
 // block was reached.
-int skip_to_string(char *pstr, char *end)
+int skip_to_string(const char *pstr, const char *end)
 {
 	ignore_white_space();
 	auto len = strlen(pstr);
@@ -360,7 +360,7 @@ int skip_to_string(char *pstr, char *end)
 
 // Goober5000
 // Advance to start of pstr.  Return 0 is successful, otherwise return !0
-int skip_to_start_of_string(char *pstr, char *end)
+int skip_to_start_of_string(const char *pstr, const char *end)
 {
 	ignore_white_space();
 	auto len = strlen(pstr);
@@ -388,7 +388,7 @@ int skip_to_start_of_string(char *pstr, char *end)
 }
 
 // Advance to start of either pstr1 or pstr2.  Return 0 is successful, otherwise return !0
-int skip_to_start_of_string_either(char *pstr1, char *pstr2, char *end)
+int skip_to_start_of_string_either(const char *pstr1, const char *pstr2, const char *end)
 {
 	size_t len1, len2, endlen;
 
@@ -511,7 +511,7 @@ int optional_string(const char *pstr)
 	return 0;
 }
 
-int optional_string_either(char *str1, char *str2)
+int optional_string_either(const char *str1, const char *str2)
 {
 	ignore_white_space();
 
@@ -745,7 +745,7 @@ int required_string_either_fred(char *str1, char *str2)
 
 //	Copy characters from instr to outstr until eoln is found, or until max
 //	characters have been copied (including terminator).
-void copy_to_eoln(char *outstr, char *more_terminators, char *instr, int max)
+void copy_to_eoln(char *outstr, const char *more_terminators, const char *instr, int max)
 {
 	int	count = 0;
 	char	ch;
@@ -773,7 +773,7 @@ void copy_to_eoln(char *outstr, char *more_terminators, char *instr, int max)
 }
 
 //	Ditto for SCP_string.
-void copy_to_eoln(SCP_string &outstr, char *more_terminators, char *instr)
+void copy_to_eoln(SCP_string &outstr, const char *more_terminators, const char *instr)
 {
 	char	ch;
 	char	terminators[128];
@@ -1144,7 +1144,7 @@ void get_string(SCP_string &str)
 //	Stuff a string into a string buffer.
 //	Supports various FreeSpace primitive types.  If 'len' is supplied, it will override
 // the default string length if using the F_NAME case.
-void stuff_string(char *outstr, int type, int len, char *terminators)
+void stuff_string(char *outstr, int type, int len, const char *terminators)
 {
 	char read_str[PARSE_BUF_SIZE] = "";
 	int read_len = PARSE_BUF_SIZE;
@@ -1231,7 +1231,7 @@ void stuff_string(char *outstr, int type, int len, char *terminators)
 
 //	Stuff a string into a string buffer.
 //	Supports various FreeSpace primitive types.
-void stuff_string(SCP_string &outstr, int type, char *terminators)
+void stuff_string(SCP_string &outstr, int type, const char *terminators)
 {
 	SCP_string read_str;
 	int tag_id;

--- a/code/parse/parselo.cpp
+++ b/code/parse/parselo.cpp
@@ -717,7 +717,7 @@ int required_string_one_of(int arg_count, ...)
 	return -1;
 }
 
-int required_string_either_fred(char *str1, char *str2)
+int required_string_either_fred(const char *str1, const char *str2)
 {
 	ignore_white_space();
 

--- a/code/parse/parselo.h
+++ b/code/parse/parselo.h
@@ -108,7 +108,7 @@ extern int optional_string_one_of(int arg_count, ...);
 
 // required
 extern int required_string(const char *pstr);
-extern int required_string_either(char *str1, char *str2);
+extern int required_string_either(const char *str1, const char *str2);
 extern int required_string_one_of(int arg_count, ...);
 
 // stuff
@@ -266,7 +266,7 @@ int split_str(const char *src, int max_pixel_w, SCP_vector<int> &n_chars, SCP_ve
 
 // fred
 extern int required_string_fred(char *pstr, char *end = NULL);
-extern int required_string_either_fred(char *str1, char *str2);
+extern int required_string_either_fred(const char *str1, const char *str2);
 extern int optional_string_fred(char *pstr, char *end = NULL, char *end2 = NULL);
 
 // Goober5000 - returns position of replacement or -1 for exceeded length (SCP_string variants return the result)

--- a/code/parse/parselo.h
+++ b/code/parse/parselo.h
@@ -95,15 +95,15 @@ extern void diag_printf(char *format, ...);
 extern void error_display(int error_level, const char *format, ...);
 
 // skip
-extern int skip_to_string(char *pstr, char *end = NULL);
-extern int skip_to_start_of_string(char *pstr, char *end = NULL);
-extern int skip_to_start_of_string_either(char *pstr1, char *pstr2, char *end = NULL);
-extern void advance_to_eoln(char *terminators);
+extern int skip_to_string(const char *pstr, const char *end = NULL);
+extern int skip_to_start_of_string(const char *pstr, const char *end = NULL);
+extern int skip_to_start_of_string_either(const char *pstr1, const char *pstr2, const char *end = NULL);
+extern void advance_to_eoln(const char *terminators);
 extern void skip_token();
 
 // optional
 extern int optional_string(const char *pstr);
-extern int optional_string_either(char *str1, char *str2);
+extern int optional_string_either(const char *str1, const char *str2);
 extern int optional_string_one_of(int arg_count, ...);
 
 // required
@@ -112,19 +112,19 @@ extern int required_string_either(const char *str1, const char *str2);
 extern int required_string_one_of(int arg_count, ...);
 
 // stuff
-extern void copy_to_eoln(char *outstr, char *more_terminators, char *instr, int max);
+extern void copy_to_eoln(char *outstr, const char *more_terminators, const char *instr, int max);
 extern void copy_text_until(char *outstr, char *instr, char *endstr, int max_chars);
 extern void stuff_string_white(char *outstr, int len = 0);
 extern void stuff_string_until(char *outstr, char *endstr, int len = 0);
-extern void stuff_string(char *outstr, int type, int len, char *terminators = NULL);
+extern void stuff_string(char *outstr, int type, int len, const char *terminators = NULL);
 extern void stuff_string_line(char *outstr, int len);
 
 // SCP_string stuff
-extern void copy_to_eoln(SCP_string &outstr, char *more_terminators, char *instr);
+extern void copy_to_eoln(SCP_string &outstr, const char *more_terminators, const char *instr);
 extern void copy_text_until(SCP_string &outstr, char *instr, char *endstr);
 extern void stuff_string_white(SCP_string &outstr);
 extern void stuff_string_until(SCP_string &outstr, char *endstr);
-extern void stuff_string(SCP_string &outstr, int type, char *terminators = NULL);
+extern void stuff_string(SCP_string &outstr, int type, const char *terminators = NULL);
 extern void stuff_string_line(SCP_string &outstr);
 
 //alloc

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -33820,7 +33820,7 @@ static void output_sexp_html(int sexp_idx, FILE *fp)
 /**
  * Output sexp.html file
  */
-bool output_sexps(char *filepath)
+bool output_sexps(const char *filepath)
 {
 	FILE *fp = fopen(filepath,"w");
 

--- a/code/parse/sexp.h
+++ b/code/parse/sexp.h
@@ -1223,7 +1223,7 @@ extern int Num_submenus;
 
 //WMC
 //Outputs sexp.html file
-bool output_sexps(char *filepath);
+bool output_sexps(const char *filepath);
 
 void multi_sexp_eval();
 

--- a/code/scripting/scripting.cpp
+++ b/code/scripting/scripting.cpp
@@ -650,7 +650,7 @@ bool script_state::CloseHookVarTable()
 	}
 }
 
-void script_state::SetHookVar(char *name, char format, void *data)
+void script_state::SetHookVar(char *name, char format, const void *data)
 {
 	if(format == '\0')
 		return;

--- a/code/scripting/scripting.cpp
+++ b/code/scripting/scripting.cpp
@@ -551,7 +551,7 @@ bool ConditionedHook::IsOverride(script_state *sys, int action)
 //Most of the icky stuff is here. Lots of #ifdefs
 
 //WMC - defined in parse/scripting.h
-void script_state::SetHookObject(char *name, object *objp)
+void script_state::SetHookObject(const char *name, object *objp)
 {
 	SetHookObjects(1, name, objp);
 }
@@ -650,7 +650,7 @@ bool script_state::CloseHookVarTable()
 	}
 }
 
-void script_state::SetHookVar(char *name, char format, const void *data)
+void script_state::SetHookVar(const char *name, char format, const void *data)
 {
 	if(format == '\0')
 		return;
@@ -720,7 +720,7 @@ void script_state::SetHookVar(char *name, char format, const void *data)
 }
 
 //WMC - data can be NULL, if we just want to know if it exists
-bool script_state::GetHookVar(char *name, char format, void *data)
+bool script_state::GetHookVar(const char *name, char format, void *data)
 {
 	bool got_global = false;
 	if(LuaState != NULL)
@@ -757,7 +757,7 @@ bool script_state::GetHookVar(char *name, char format, void *data)
 	return got_global;
 }
 
-void script_state::RemHookVar(char *name)
+void script_state::RemHookVar(const char *name)
 {
 	this->RemHookVars(1, name);
 }
@@ -793,7 +793,7 @@ void script_state::RemHookVars(unsigned int num, ...)
 }
 
 //WMC - data can be NULL, if we just want to know if it exists
-bool script_state::GetGlobal(char *name, char format, void *data)
+bool script_state::GetGlobal(const char *name, char format, void *data)
 {
 	bool got_global = false;
 	if(LuaState != NULL)
@@ -816,7 +816,7 @@ bool script_state::GetGlobal(char *name, char format, void *data)
 	return got_global;
 }
 
-void script_state::RemGlobal(char *name)
+void script_state::RemGlobal(const char *name)
 {
 	if(LuaState != NULL)
 	{

--- a/code/scripting/scripting.h
+++ b/code/scripting/scripting.h
@@ -185,14 +185,14 @@ public:
 	//void MoveData(script_state &in);
 
 	//***Variable handling functions
-	bool GetGlobal(char *name, char format='\0', void *data=NULL);
-	void RemGlobal(char *name);
+	bool GetGlobal(const char *name, char format='\0', void *data=NULL);
+	void RemGlobal(const char *name);
 
-	void SetHookVar(char *name, char format, const void *data=NULL);
-	void SetHookObject(char *name, object *objp);
+	void SetHookVar(const char *name, char format, const void *data=NULL);
+	void SetHookObject(const char *name, object *objp);
 	void SetHookObjects(int num, ...);
-	bool GetHookVar(char *name, char format='\0', void *data=NULL);
-	void RemHookVar(char *name);
+	bool GetHookVar(const char *name, char format='\0', void *data=NULL);
+	void RemHookVar(const char *name);
 	void RemHookVars(unsigned int num, ...);
 
 	//***Hook creation functions

--- a/code/scripting/scripting.h
+++ b/code/scripting/scripting.h
@@ -188,7 +188,7 @@ public:
 	bool GetGlobal(char *name, char format='\0', void *data=NULL);
 	void RemGlobal(char *name);
 
-	void SetHookVar(char *name, char format, void *data=NULL);
+	void SetHookVar(char *name, char format, const void *data=NULL);
 	void SetHookObject(char *name, object *objp);
 	void SetHookObjects(int num, ...);
 	bool GetHookVar(char *name, char format='\0', void *data=NULL);

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -252,7 +252,7 @@ extern SCP_vector<DamageTypeStruct>	Damage_types;
 #define SLT_DEFAULT	1
 
 #define NUM_TURRET_ORDER_TYPES		3
-extern char *Turret_target_order_names[NUM_TURRET_ORDER_TYPES];	//aiturret.cpp
+extern const char *Turret_target_order_names[NUM_TURRET_ORDER_TYPES];	//aiturret.cpp
 
 // Swifty: Cockpit displays
 typedef struct cockpit_display {

--- a/code/ui/button.cpp
+++ b/code/ui/button.cpp
@@ -23,7 +23,7 @@
 //			ignore_focus	=>		whether to allow Enter/Spacebar to affect pressed state when
 //										control has focus
 //
-void UI_BUTTON::create(UI_WINDOW *wnd, char *_text, int _x, int _y, int _w, int _h, int do_repeat, int ignore_focus)
+void UI_BUTTON::create(UI_WINDOW *wnd, const char *_text, int _x, int _y, int _w, int _h, int do_repeat, int ignore_focus)
 {
 	text = NULL;
 

--- a/code/ui/gadget.cpp
+++ b/code/ui/gadget.cpp
@@ -68,7 +68,7 @@ void UI_GADGET::link_hotspot(int num)
 // anything < start_frame will not be loaded.
 // this keeps the loading code from trying to load bitmaps which don't exist
 // and taking an unnecessary disk hit.		
-int UI_GADGET::set_bmaps(char *ani_fname, int nframes, int start_frame)
+int UI_GADGET::set_bmaps(const char *ani_fname, int nframes, int start_frame)
 {
 	int first_frame, i;	
 	char full_name[MAX_FILENAME_LEN] = "";

--- a/code/ui/inputbox.cpp
+++ b/code/ui/inputbox.cpp
@@ -78,7 +78,7 @@ void UI_INPUTBOX::init_cursor()
 	cursor_current_frame=0;
 }
 
-void UI_INPUTBOX::create(UI_WINDOW *wnd, int _x, int _y, int _w, int _text_len, char *_text, int _flags, int pixel_lim, color *clr)
+void UI_INPUTBOX::create(UI_WINDOW *wnd, int _x, int _y, int _w, int _text_len, const char *_text, int _flags, int pixel_lim, color *clr)
 {
 	int tw, th;
 

--- a/code/ui/slider2.cpp
+++ b/code/ui/slider2.cpp
@@ -18,7 +18,7 @@
 
 // captureCallback is called when an item is "selected" by mouse release. That is, the user has clicked, dragged and _released_. 
 // the callback is called when the scrollbar has been released
-void UI_SLIDER2::create(UI_WINDOW *wnd, int _x, int _y, int _w, int _h, int _numberItems, char *_bitmapSliderControl, void (* _upCallback)(), void (*_downCallback)(),
+void UI_SLIDER2::create(UI_WINDOW *wnd, int _x, int _y, int _w, int _h, int _numberItems, const char *_bitmapSliderControl, void (* _upCallback)(), void (*_downCallback)(),
 				void (* _captureCallback)()) {
 
 	int buttonHeight, buttonWidth;

--- a/code/ui/ui.h
+++ b/code/ui/ui.h
@@ -75,7 +75,7 @@ class UI_GADGET
 	friend class UI_DOT_SLIDER_NEW;
 
 	protected:
-		char *bm_filename;
+		const char *bm_filename;
 		int kind;
 		int hotkey;
 		int x, y, w, h;
@@ -151,7 +151,7 @@ class UI_GADGET
 		// anything < start_frame will not be loaded.
 		// this keeps the loading code from trying to load bitmaps which don't exist
 		// and taking an unnecessary disk hit.		
-		int set_bmaps(char *ani_filename, int nframes = 3, int start_frame = 1);		// extracts MAX_BMAPS_PER_GADGET from .ani file		
+		int set_bmaps(const char *ani_filename, int nframes = 3, int start_frame = 1);		// extracts MAX_BMAPS_PER_GADGET from .ani file
 
 		void reset();  // zero out m_flags
 		virtual int is_hidden();
@@ -632,8 +632,8 @@ protected:
 public:
 	UI_WINDOW();	// constructor
 	~UI_WINDOW();	// destructor
-	void set_mask_bmap(char *fname);
-	void set_mask_bmap(int bmap, char *name);
+	void set_mask_bmap(const char *fname);
+	void set_mask_bmap(int bmap, const char *name);
 	void set_foreground_bmap(char *fname);
 	void create( int _x, int _y, int _w, int _h, int _flags, int _f_id = -1 );
 	int process( int key_in = -1,int process_mouse = 1);
@@ -656,7 +656,7 @@ public:
 
 // 2 extremely useful structs
 typedef struct ui_button_info {
-	char *filename;
+	const char *filename;
 	int x, y, xt, yt;
 	int hotspot;
 	UI_BUTTON button;  // because we have a class inside this struct, we need the constructor below..

--- a/code/ui/ui.h
+++ b/code/ui/ui.h
@@ -162,7 +162,7 @@ class UI_GADGET
 #define UI_XSTR_COLOR_GREEN		0			// shades of green/gray
 #define UI_XSTR_COLOR_PINK			1			// pinkish hue
 typedef struct UI_XSTR {
-	char *xstr;										// base string
+	const char *xstr;										// base string
 	int xstr_id;									// xstring id	
 	int x, y;										// coords of the string
 	int clr;											// color to use
@@ -239,7 +239,7 @@ class UI_BUTTON : public UI_GADGET
 		int button_hilighted();	// is the mouse over this button?
 		void set_button_hilighted();	// force button to be highlighted
 		void press_button();		// force button to get pressed
-		void create(UI_WINDOW *wnd, char *_text, int _x, int _y, int _w, int _h, int do_repeat=0, int ignore_focus = 0);
+		void create(UI_WINDOW *wnd, const char *_text, int _x, int _y, int _w, int _h, int do_repeat=0, int ignore_focus = 0);
 		void set_highlight_action( void (*_user_function)(void) );
 		void set_disabled_action( void (*_user_function)(void) );
 		void draw_forced(int frame_num);
@@ -309,7 +309,7 @@ class UI_INPUTBOX : public UI_GADGET
 		virtual void destroy();
 
 	public:
-		void create(UI_WINDOW *wnd, int _x, int _y, int _w, int _textlen, char *_text, int _flags = 0, int pixel_lim = -1, color *clr = NULL);
+		void create(UI_WINDOW *wnd, int _x, int _y, int _w, int _textlen, const char *_text, int _flags = 0, int pixel_lim = -1, color *clr = NULL);
 		void set_valid_chars(char *vchars);
 		void set_invalid_chars(char *ichars);
 		int changed();
@@ -461,7 +461,7 @@ class UI_SLIDER2 : public UI_GADGET
 
 	public:
 		// create the slider
-		void create(UI_WINDOW *wnd, int _x, int _y, int _w, int _h, int _numberItems, char *_bitmapSliderControl,
+		void create(UI_WINDOW *wnd, int _x, int _y, int _w, int _h, int _numberItems, const char *_bitmapSliderControl,
 						void (*_upCallback)(), void (*_downCallback)(), void (*_captureCallback)());
 		
 		// range management
@@ -645,7 +645,7 @@ public:
 	ubyte *get_mask_data(int *w_md, int *h_md) { *w_md = mask_w; *h_md = mask_h; return mask_data; }
 	void render_tooltip(char *str);
 	void set_ignore_gadgets(int state);
-	void add_XSTR(char *string, int _xstr_id, int _x, int _y, UI_GADGET *_assoc, int _color_type, int _font_id = -1);
+	void add_XSTR(const char *string, int _xstr_id, int _x, int _y, UI_GADGET *_assoc, int _color_type, int _font_id = -1);
 	void add_XSTR(UI_XSTR *xstr);
 
 	const char *(*tooltip_handler)(const char *text);
@@ -661,7 +661,7 @@ typedef struct ui_button_info {
 	int hotspot;
 	UI_BUTTON button;  // because we have a class inside this struct, we need the constructor below..
 
-	ui_button_info(char *name, int x1, int y1, int xt1, int yt1, int h) : filename(name), x(x1), y(y1), xt(xt1), yt(yt1), hotspot(h) {}
+	ui_button_info(const char *name, int x1, int y1, int xt1, int yt1, int h) : filename(name), x(x1), y(y1), xt(xt1), yt(yt1), hotspot(h) {}
 } ui_button_info;
 
 

--- a/code/ui/window.cpp
+++ b/code/ui/window.cpp
@@ -72,7 +72,7 @@ UI_WINDOW::~UI_WINDOW()
 // Specify the filename for the mask bitmap to use.  This has the hotspots
 // for all the different controls.
 //
-void UI_WINDOW::set_mask_bmap(char *fname)
+void UI_WINDOW::set_mask_bmap(const char *fname)
 {
 	int bmap;
 
@@ -86,7 +86,7 @@ void UI_WINDOW::set_mask_bmap(char *fname)
 	}
 }
 
-void UI_WINDOW::set_mask_bmap(int bmap, char *name)
+void UI_WINDOW::set_mask_bmap(int bmap, const char *name)
 {
 	// int i;
 

--- a/code/ui/window.cpp
+++ b/code/ui/window.cpp
@@ -206,7 +206,8 @@ void UI_WINDOW::destroy()
 		// free up this struct
 		if(xstrs[idx] != NULL){
 			if(xstrs[idx]->xstr != NULL){
-				vm_free(xstrs[idx]->xstr);
+				// This const_cast is safe since the string was allocated by vm_strdup
+				vm_free(const_cast<char*>(xstrs[idx]->xstr));
 			}
 			vm_free(xstrs[idx]);
 			xstrs[idx] = NULL;
@@ -470,7 +471,7 @@ void UI_WINDOW::set_ignore_gadgets(int state)
 	ignore_gadgets = state;
 }
 
-void UI_WINDOW::add_XSTR(char *string, int _xstr_id, int _x, int _y, UI_GADGET *_assoc, int _color_type, int _font_id)
+void UI_WINDOW::add_XSTR(const char *string, int _xstr_id, int _x, int _y, UI_GADGET *_assoc, int _color_type, int _font_id)
 {
 	int idx;
 	int found = -1;

--- a/fred2/management.cpp
+++ b/fred2/management.cpp
@@ -2296,7 +2296,7 @@ char *object_name(int obj)
 	return "*unknown*";
 }
 
-char *get_order_name(int order)
+const char *get_order_name(int order)
 {
 	int i;
 

--- a/fred2/management.h
+++ b/fred2/management.h
@@ -119,7 +119,7 @@ int	reference_handler(char *name, int type, int obj);
 int	orders_reference_handler(int code, char *msg);
 int	sexp_reference_handler(int node, int code, char *msg);
 char	*object_name(int obj);
-char	*get_order_name(int order);
+const char* get_order_name(int order);
 void	object_moved(object *ptr);
 int	invalidate_references(char *name, int type);
 int	query_whole_wing_marked(int wing);


### PR DESCRIPTION
We currently suppress these warnings but I would like to enable them at some point since const correctness is something that is easy to get wrong.

There are no functional changes in this PR but there is one `const_cast` that I needed since the UI code manages the XSTR instances itself. The cast itself should be safe.