### PR TITLE
Clean up Lua function references before destroying the Lua state

### DIFF
--- a/code/scripting/scripting.cpp
+++ b/code/scripting/scripting.cpp
@@ -926,6 +926,20 @@ void script_state::EndFrame()
 
 void script_state::Clear()
 {
+	// Free all lua value references
+	ConditionalHooks.clear();
+
+	// Also do the same to the old hooks
+	Script_globalhook.freeFunctions();
+	Script_simulationhook.freeFunctions();
+	Script_hudhook.freeFunctions();
+	Script_splashhook.freeFunctions();
+	Script_gameinithook.freeFunctions();
+
+	if(LuaState != NULL) {
+		lua_close(LuaState);
+	}
+
 	StateName[0] = '\0';
 	Langs = 0;
 
@@ -946,10 +960,6 @@ script_state::script_state(const char *name)
 
 script_state::~script_state()
 {
-	if(LuaState != NULL) {
-		lua_close(LuaState);
-	}
-
 	Clear();
 }
 

--- a/code/scripting/scripting.h
+++ b/code/scripting/scripting.h
@@ -32,6 +32,15 @@ struct script_hook
 
 	//Actual hook
 	script_function hook_function;
+
+	void freeFunctions() {
+		if (override_function.function.isValid()) {
+			override_function.function.getReference()->removeReference();
+		}
+		if (hook_function.function.isValid()) {
+			hook_function.function.getReference()->removeReference();
+		}
+	}
 };
 
 extern void script_hook_init(script_hook *hook);


### PR DESCRIPTION
This fixes #1127.

The old-style hooks make the code a bit ugly but removing those while keeping backwards compatibility is a bit more involved so I'll do that in a separate PR.