### PR TITLE
Model code cleanup

### DIFF
--- a/code/asteroid/asteroid.cpp
+++ b/code/asteroid/asteroid.cpp
@@ -1180,7 +1180,7 @@ int asteroid_check_collision(object *pasteroid, object *other_obj, vec3d *hitpos
 	}
 }
 
-void asteroid_render(object * obj, draw_list *scene)
+void asteroid_render(object * obj, model_draw_list *scene)
 {
 	if (Asteroids_enabled) {
 		int			num;

--- a/code/asteroid/asteroid.h
+++ b/code/asteroid/asteroid.h
@@ -19,7 +19,7 @@
 class object;
 class polymodel;
 struct collision_info_struct;
-class draw_list;
+class model_draw_list;
 
 #define	MAX_ASTEROIDS			512
 
@@ -152,7 +152,7 @@ void	asteroid_init();
 void	asteroid_level_init();
 void	asteroid_level_close();
 void	asteroid_create_all();
-void	asteroid_render(object * obj, draw_list *scene);
+void	asteroid_render(object * obj, model_draw_list *scene);
 void	asteroid_delete( object *asteroid_objp );
 void	asteroid_process_pre( object *asteroid_objp );
 void	asteroid_process_post( object *asteroid_objp);

--- a/code/bmpman/bmpman.cpp
+++ b/code/bmpman/bmpman.cpp
@@ -56,7 +56,6 @@ MONITOR(SizeBitmapPage)
 
 // --------------------------------------------------------------------------------------------------------------------
 // Definition of public variables (declared as extern in bmpman.h).
-int UNLITMAP = -1;
 int GLOWMAP = -1;
 int SPECMAP = -1;
 int SPECGLOSSMAP = -1;

--- a/code/debris/debris.cpp
+++ b/code/debris/debris.cpp
@@ -1052,7 +1052,7 @@ void calc_debris_physics_properties( physics_info *pi, vec3d *mins, vec3d *maxs 
 /**
 * Renders debris
 */
-void debris_render(object * obj, draw_list *scene)
+void debris_render(object * obj, model_draw_list *scene)
 {
 	int			i, num, swapped;
 	polymodel	*pm;

--- a/code/debris/debris.h
+++ b/code/debris/debris.h
@@ -16,7 +16,7 @@
 
 class object;
 struct CFILE;
-class draw_list;
+class model_draw_list;
 
 #define MAX_DEBRIS_ARCS 8		// Must be less than MAX_ARC_EFFECTS in model.h
 
@@ -63,7 +63,7 @@ extern int Num_debris_pieces;
 struct collision_info_struct;
 
 void debris_init();
-void debris_render(object * obj, draw_list *scene);
+void debris_render(object * obj, model_draw_list *scene);
 void debris_delete( object * obj );
 void debris_process_post( object * obj, float frame_time);
 object *debris_create( object * source_obj, int model_num, int submodel_num, vec3d *pos, vec3d *exp_center, int hull_flag, float exp_force );

--- a/code/fireball/fireballs.cpp
+++ b/code/fireball/fireballs.cpp
@@ -965,7 +965,7 @@ float fireball_wormhole_intensity( object *obj )
 	return rad;
 } 
 
-void fireball_render(object* obj, draw_list *scene)
+void fireball_render(object* obj, model_draw_list *scene)
 {
 	int		num;
 	vertex	p;

--- a/code/fireball/fireballs.h
+++ b/code/fireball/fireballs.h
@@ -77,7 +77,7 @@ typedef struct fireball {
 // end move
 
 void fireball_init();
-void fireball_render(object* obj, draw_list *scene);
+void fireball_render(object* obj, model_draw_list *scene);
 void fireball_delete( object * obj );
 void fireball_process_post(object * obj, float frame_time);
 
@@ -115,7 +115,7 @@ float fireball_wormhole_intensity( object *obj );
 // internal function to draw warp grid.
 extern void warpin_render(object *obj, matrix *orient, vec3d *pos, int texture_bitmap_num, float radius, float life_percent, float max_radius, int warp_3d = 0 );
 
-extern void warpin_queue_render(draw_list *scene, object *obj, matrix *orient, vec3d *pos, int texture_bitmap_num, float radius, float life_percent, float max_radius, int warp_3d);
+extern void warpin_queue_render(model_draw_list *scene, object *obj, matrix *orient, vec3d *pos, int texture_bitmap_num, float radius, float life_percent, float max_radius, int warp_3d);
 
 extern int Warp_model;
 

--- a/code/fireball/warpineffect.cpp
+++ b/code/fireball/warpineffect.cpp
@@ -45,7 +45,7 @@ void warpin_batch_draw_face( int texture, vertex *v1, vertex *v2, vertex *v3 )
 	batching_add_tri(texture, vertlist); // TODO render as emissive
 }
 
-void warpin_queue_render(draw_list *scene, object *obj, matrix *orient, vec3d *pos, int texture_bitmap_num, float radius, float life_percent, float max_radius, int warp_3d)
+void warpin_queue_render(model_draw_list *scene, object *obj, matrix *orient, vec3d *pos, int texture_bitmap_num, float radius, float life_percent, float max_radius, int warp_3d)
 {
 	vec3d center;
 	vec3d vecs[5];

--- a/code/graphics/2d.h
+++ b/code/graphics/2d.h
@@ -38,32 +38,6 @@ class particle_material;
 class distortion_material;
 class shield_material;
 
-struct transform
-{
-	matrix basis;
-	vec3d origin;
-	vec3d scale;
-
-	transform() : basis(vmd_identity_matrix), origin(vmd_zero_vector), scale(vmd_scale_identity_vector) {}
-	transform(matrix *m, vec3d *v) : basis(*m), origin(*v) {}
-
-	matrix4 get_matrix4()
-	{
-		matrix4 new_mat;
-		vm_matrix4_set_identity(&new_mat);
-
-		new_mat.a1d[0] = basis.vec.rvec.xyz.x;   new_mat.a1d[4] = basis.vec.uvec.xyz.x;   new_mat.a1d[8] = basis.vec.fvec.xyz.x;
-		new_mat.a1d[1] = basis.vec.rvec.xyz.y;   new_mat.a1d[5] = basis.vec.uvec.xyz.y;   new_mat.a1d[9] = basis.vec.fvec.xyz.y;
-		new_mat.a1d[2] = basis.vec.rvec.xyz.z;   new_mat.a1d[6] = basis.vec.uvec.xyz.z;   new_mat.a1d[10] = basis.vec.fvec.xyz.z;
-		new_mat.a1d[12] = origin.xyz.x;
-		new_mat.a1d[13] = origin.xyz.y;
-		new_mat.a1d[14] = origin.xyz.z;
-
-		return new_mat;
-	}
-};
-
-
 class transform_stack {
 	
 	matrix4 Current_transform;
@@ -382,24 +356,6 @@ private:
 	int find_first_vertex(int idx);
 	int find_first_vertex_fast(int idx);
 	void generate_sorted_index_list();
-};
-
-class colored_vector
-{
-public:
-	colored_vector()
-		: pad(1.0f)
-	{}
-
-	vec3d vec;
-	float pad;	//needed so I can just memcpy it in d3d
-	ubyte color[4];
-};
-
-
-struct line_list {
-	int n_line;
-	vertex *vert;
 };
 
 class buffer_data

--- a/code/graphics/opengl/gropengldraw.h
+++ b/code/graphics/opengl/gropengldraw.h
@@ -52,8 +52,6 @@ void gr_opengl_draw_deferred_light_sphere(const vec3d *position, float rad, bool
 void gr_opengl_deferred_light_cylinder_init(int segments);
 void gr_opengl_draw_deferred_light_cylinder(const vec3d *position, const matrix *orient, float rad, float length, bool clearStencil);
 
-void gr_opengl_draw_line_list(const colored_vector *lines, int num);
-
 void gr_opengl_shadow_map_start(matrix4 *shadow_view_matrix, const matrix *light_orient);
 void gr_opengl_shadow_map_end();
 

--- a/code/graphics/opengl/gropengltnl.cpp
+++ b/code/graphics/opengl/gropengltnl.cpp
@@ -1036,11 +1036,7 @@ void opengl_tnl_set_model_material(model_material *material_info)
 			break;
 		}
 
-		if ( material_info->get_texture_map(TM_UNLIT_TYPE) >= 0 ) {
-			gr_opengl_tcache_set(material_info->get_texture_map(TM_UNLIT_TYPE), TCACHE_TYPE_NORMAL, &u_scale, &v_scale, render_pass);
-		} else {
-			gr_opengl_tcache_set(material_info->get_texture_map(TM_BASE_TYPE), TCACHE_TYPE_NORMAL, &u_scale, &v_scale, render_pass);
-		}
+		gr_opengl_tcache_set(material_info->get_texture_map(TM_BASE_TYPE), TCACHE_TYPE_NORMAL, &u_scale, &v_scale, render_pass);
 		
 		++render_pass;
 	}

--- a/code/graphics/shadows.cpp
+++ b/code/graphics/shadows.cpp
@@ -422,7 +422,7 @@ void shadows_render_all(float fov, matrix *eye_orient, vec3d *eye_pos)
 	// maybe we could use a more programmatic algorithim? 
 	matrix light_matrix = shadows_start_render(eye_orient, eye_pos, fov, gr_screen.clip_aspect, 200.0f, 600.0f, 2500.0f, 8000.0f);
 
-	draw_list scene;
+	model_draw_list scene;
 	object *objp = Objects;
 
 	for ( int i = 0; i <= Highest_object_index; i++, objp++ ) {

--- a/code/jumpnode/jumpnode.cpp
+++ b/code/jumpnode/jumpnode.cpp
@@ -292,7 +292,7 @@ bool CJumpNode::IsSpecialModel()
 */
 void CJumpNode::Render(vec3d *pos, vec3d *view_pos)
 {
-	draw_list scene;
+	model_draw_list scene;
 
 	Render(&scene, pos, view_pos);
 
@@ -310,7 +310,7 @@ void CJumpNode::Render(vec3d *pos, vec3d *view_pos)
 * @param pos		World position
 * @param view_pos	Viewer's world position, can be NULL
 */
-void CJumpNode::Render(draw_list* scene, vec3d *pos, vec3d *view_pos)
+void CJumpNode::Render(model_draw_list* scene, vec3d *pos, vec3d *view_pos)
 {
 	Assert(pos != NULL);
 	// Assert(view_pos != NULL); - view_pos can be NULL

--- a/code/jumpnode/jumpnode.h
+++ b/code/jumpnode/jumpnode.h
@@ -20,7 +20,7 @@
 struct vec3d;
 class object;
 
-class draw_list;
+class model_draw_list;
 
 //Jump node flags
 #define JN_USE_DISPLAY_COLOR		(1<<0)		//Use display_color instead of HUD color
@@ -75,7 +75,7 @@ public:
 
     //Rendering
 	void Render(vec3d *pos, vec3d *view_pos = NULL);
-	void Render(draw_list *scene, vec3d *pos, vec3d *view_pos = NULL);
+	void Render(model_draw_list *scene, vec3d *pos, vec3d *view_pos = NULL);
 };
 
 //-----Globals------

--- a/code/math/vecmat.cpp
+++ b/code/math/vecmat.cpp
@@ -251,6 +251,14 @@ void vm_vec_scale(vec3d *dest, float s)
 	dest->xyz.z = dest->xyz.z * s;
 }
 
+//scales a 4-component vector in place.
+void vm_vec_scale(vec4 *dest, float s)
+{
+	dest->xyzw.x = dest->xyzw.x * s;
+	dest->xyzw.y = dest->xyzw.y * s;
+	dest->xyzw.z = dest->xyzw.z * s;
+	dest->xyzw.w = dest->xyzw.w * s;
+}
 
 //scales and copies a vector.
 void vm_vec_copy_scale(vec3d *dest, const vec3d *src, float s)

--- a/code/math/vecmat.h
+++ b/code/math/vecmat.h
@@ -115,6 +115,9 @@ vec3d *vm_vec_avg4(vec3d *dest, const vec3d *src0, const vec3d *src1, const vec3
 //scales a vector in place.  returns ptr to vector
 void vm_vec_scale(vec3d *dest, float s);
 
+//scales a 4-component vector in place. returns ptr to vector
+void vm_vec_scale(vec4 *dest, float s);
+
 //scales and copies a vector.  returns ptr to dest
 void vm_vec_copy_scale(vec3d *dest, const vec3d *src, float s);
 
@@ -441,6 +444,8 @@ void vm_matrix4_set_identity(matrix4 *out);
 void vm_matrix4_set_transform(matrix4 *out, matrix *m, vec3d *v);
 
 void vm_matrix4_get_orientation(matrix *out, matrix4 *m);
+
+void vm_matrix4_get_offset(vec3d *out, matrix4 *m);
 
 void vm_vec_transform(vec4 *dest, vec4 *src, matrix4 *m);
 void vm_vec_transform(vec3d *dest, vec3d *src, matrix4 *m, bool pos = true);

--- a/code/model/model.h
+++ b/code/model/model.h
@@ -626,9 +626,8 @@ public:
 #define TM_HEIGHT_TYPE		4		// optional height map (for parallax mapping)
 #define TM_MISC_TYPE		5		// optional utility map
 #define TM_SPEC_GLOSS_TYPE	6		// optional reflectance map (specular and gloss)
-#define TM_UNLIT_TYPE		7		// optional unlit map to display instead of the base when rendering unlit models
-#define TM_AMBIENT_TYPE		8		// optional ambient occlusion map with ambient occlusion and cavity occlusion factors for red and green channels.
-#define TM_NUM_TYPES		9		//WMC - Number of texture_info objects in texture_map
+#define TM_AMBIENT_TYPE		7		// optional ambient occlusion map with ambient occlusion and cavity occlusion factors for red and green channels.
+#define TM_NUM_TYPES		8		//WMC - Number of texture_info objects in texture_map
 									//Used by scripting - if you change this, do a search
 									//to update switch() statement in lua.cpp
 // taylor

--- a/code/model/modelread.cpp
+++ b/code/model/modelread.cpp
@@ -2444,14 +2444,12 @@ void model_load_texture(polymodel *pm, int i, char *file)
 
 	// base maps ---------------------------------------------------------------
 	texture_info *tbase = &tmap->textures[TM_BASE_TYPE];
-	texture_info *tunlit = &tmap->textures[TM_UNLIT_TYPE];
 
 	if (strstr(tmp_name, "thruster") || strstr(tmp_name, "invisible") || strstr(tmp_name, "warpmap"))
 	{
 		// Don't load textures for thruster animations or invisible textures
 		// or warp models!-Bobboau
 		tbase->clear();
-		tunlit->clear();
 	}
 	else
 	{
@@ -2469,13 +2467,6 @@ void model_load_texture(polymodel *pm, int i, char *file)
 		if ( tbase->GetTexture() < 0 ) {
 			Warning(LOCATION, "Couldn't open texture '%s'\nreferenced by model '%s'\n", tmp_name, pm->filename);
 		}
-
-		// look for unlit map as well in case this texture needs a different diffuse response when rendered in no lighting
-		strcpy_s(tmp_name, file);
-		strcat_s(tmp_name, "-unlit");
-		strlwr(tmp_name);
-
-		tunlit->LoadTexture(tmp_name, pm->filename);
 	}
 	// -------------------------------------------------------------------------
 

--- a/code/model/modelrender.cpp
+++ b/code/model/modelrender.cpp
@@ -41,7 +41,7 @@ extern bool Scene_framebuffer_in_frame;
 
 extern void interp_render_arc_segment( vec3d *v1, vec3d *v2, int depth );
 
-draw_list *draw_list::Target = NULL;
+model_draw_list *model_draw_list::Target = NULL;
 
 model_batch_buffer TransformBufferHandler;
 
@@ -381,57 +381,45 @@ void model_batch_buffer::submit_buffer_data()
 	gr_update_transform_buffer(Mem_alloc, Mem_alloc_size);
 }
 
-draw_list::draw_list()
+model_draw_list::model_draw_list():
+Transformations()
 {
 	reset();
 }
 
-void draw_list::reset()
+void model_draw_list::reset()
 {
 	Render_elements.clear();
 	Render_keys.clear();
 
-	clear_transforms();
+	Transformations.clear();
 
 	Current_scale.xyz.x = 1.0f;
 	Current_scale.xyz.y = 1.0f;
 	Current_scale.xyz.z = 1.0f;
 }
 
-void draw_list::sort_draws()
+void model_draw_list::sort_draws()
 {
 	Target = this;
-	std::sort(Target->Render_keys.begin(), Target->Render_keys.end(), draw_list::sort_draw_pair);
+	std::sort(Target->Render_keys.begin(), Target->Render_keys.end(), model_draw_list::sort_draw_pair);
 }
 
-void draw_list::start_model_batch(int n_models)
+void model_draw_list::start_model_batch(int n_models)
 {
 	TransformBufferHandler.set_num_models(n_models);
 }
 
-void draw_list::add_submodel_to_batch(int model_num)
+void model_draw_list::add_submodel_to_batch(int model_num)
 {
 	matrix4 transform;
 
-	vm_matrix4_set_identity(&transform);
+	transform = Transformations.get_transform();
 
-	// set basis
-	transform.a1d[0] = Current_transform.basis.a1d[0] * Current_scale.xyz.x;
-	transform.a1d[1] = Current_transform.basis.a1d[1];
-	transform.a1d[2] = Current_transform.basis.a1d[2];
-
-	transform.a1d[4] = Current_transform.basis.a1d[3];
-	transform.a1d[5] = Current_transform.basis.a1d[4] * Current_scale.xyz.y;
-	transform.a1d[6] = Current_transform.basis.a1d[5];
-
-	transform.a1d[8] = Current_transform.basis.a1d[6];
-	transform.a1d[9] = Current_transform.basis.a1d[7];
-	transform.a1d[10] = Current_transform.basis.a1d[8] * Current_scale.xyz.z;
-
-	// set position
-	transform.a1d[12] = Current_transform.origin.a1d[0];
-	transform.a1d[13] = Current_transform.origin.a1d[1];
-	transform.a1d[14] = Current_transform.origin.a1d[2];
+	// set scale
+	vm_vec_scale(&transform.vec.rvec, Current_scale.xyz.x);
+	vm_vec_scale(&transform.vec.uvec, Current_scale.xyz.y);
+	vm_vec_scale(&transform.vec.fvec, Current_scale.xyz.z);
 
 	// set visibility
 	transform.a1d[15] = 0.0f;
@@ -439,11 +427,11 @@ void draw_list::add_submodel_to_batch(int model_num)
 	TransformBufferHandler.set_model_transform(transform, model_num);
 }
 
-void draw_list::add_arc(vec3d *v1, vec3d *v2, color *primary, color *secondary, float arc_width)
+void model_draw_list::add_arc(vec3d *v1, vec3d *v2, color *primary, color *secondary, float arc_width)
 {
 	arc_effect new_arc;
 
-	new_arc.transformation = Current_transform;
+	new_arc.transform = Transformations.get_transform();
 	new_arc.v1 = *v1;
 	new_arc.v2 = *v2;
 	new_arc.primary = *primary;
@@ -453,14 +441,14 @@ void draw_list::add_arc(vec3d *v1, vec3d *v2, color *primary, color *secondary, 
 	Arcs.push_back(new_arc);
 }
 
-void draw_list::set_light_filter(int objnum, vec3d *pos, float rad)
+void model_draw_list::set_light_filter(int objnum, vec3d *pos, float rad)
 {
 	Scene_light_handler.setLightFilter(objnum, pos, rad);
 
 	Current_lights_set = Scene_light_handler.bufferLights();
 }
 
-void draw_list::add_buffer_draw(model_material *render_material, indexed_vertex_source *vert_src, vertex_buffer *buffer, size_t texi, uint tmap_flags)
+void model_draw_list::add_buffer_draw(model_material *render_material, indexed_vertex_source *vert_src, vertex_buffer *buffer, size_t texi, uint tmap_flags)
 {
 	queued_buffer_draw draw_data;
 
@@ -469,7 +457,7 @@ void draw_list::add_buffer_draw(model_material *render_material, indexed_vertex_
 	render_material->set_shadow_casting(Rendering_to_shadow_map ? true : false);
 
 	if (tmap_flags & TMAP_FLAG_BATCH_TRANSFORMS && buffer->flags & VB_FLAG_MODEL_ID) {
-		draw_data.transformation = transform();
+		vm_matrix4_set_identity(&draw_data.transform);
 
 		draw_data.scale.xyz.x = 1.0f;
 		draw_data.scale.xyz.y = 1.0f;
@@ -479,7 +467,7 @@ void draw_list::add_buffer_draw(model_material *render_material, indexed_vertex_
 
 		render_material->set_batching(true);
 	} else {
-		draw_data.transformation = Current_transform;
+		draw_data.transform = Transformations.get_transform();
 		draw_data.scale = Current_scale;
 		draw_data.transform_buffer_offset = INVALID_SIZE;
 		render_material->set_batching(false);
@@ -498,7 +486,7 @@ void draw_list::add_buffer_draw(model_material *render_material, indexed_vertex_
 	Render_keys.push_back((int) (Render_elements.size() - 1));
 }
 
-void draw_list::render_buffer(queued_buffer_draw &render_elements)
+void model_draw_list::render_buffer(queued_buffer_draw &render_elements)
 {
 	GR_DEBUG_SCOPE("Render buffer");
 	TRACE_SCOPE(tracing::RenderBuffer);
@@ -513,7 +501,13 @@ void draw_list::render_buffer(queued_buffer_draw &render_elements)
 		Scene_light_handler.resetLightState();
 	}
 
-	g3_start_instance_matrix(&render_elements.transformation.origin, &render_elements.transformation.basis);
+	matrix orient;
+	vec3d pos;
+
+	vm_matrix4_get_offset(&pos, &render_elements.transform);
+	vm_matrix4_get_orientation(&orient, &render_elements.transform);
+
+	g3_start_instance_matrix(&pos, &orient);
 
 	gr_push_scale_matrix(&render_elements.scale);
 
@@ -524,15 +518,21 @@ void draw_list::render_buffer(queued_buffer_draw &render_elements)
 	g3_done_instance(true);
 }
 
-vec3d draw_list::get_view_position()
+vec3d model_draw_list::get_view_position()
 {
 	matrix basis_world;
+	matrix4 transform_mat = Transformations.get_transform();
+	matrix orient;
+	vec3d pos;
+
+	vm_matrix4_get_orientation(&orient, &transform_mat);
+	vm_matrix4_get_offset(&pos, &transform_mat);
 
 	// get the world basis of our current local space.
-	vm_matrix_x_matrix(&basis_world, &Object_matrix, &Current_transform.basis);
+	vm_matrix_x_matrix(&basis_world, &Object_matrix, &orient);
 
 	vec3d eye_pos_local;
-	vm_vec_sub(&eye_pos_local, &Eye_position, &Current_transform.origin);
+	vm_vec_sub(&eye_pos_local, &Eye_position, &pos);
 
 	vec3d return_val;
 	vm_vec_rotate(&return_val, &eye_pos_local, &basis_world);
@@ -540,64 +540,17 @@ vec3d draw_list::get_view_position()
 	return return_val;
 }
 
-void draw_list::clear_transforms()
+void model_draw_list::push_transform(vec3d *pos, matrix *orient)
 {
-	Current_transform = transform();
-	Transform_stack.clear();
+	Transformations.push(pos, orient);
 }
 
-void draw_list::push_transform(vec3d *pos, matrix *orient)
+void model_draw_list::pop_transform()
 {
-	matrix basis;
-	vec3d origin;
-
-	if ( orient == NULL ) {
-		basis = vmd_identity_matrix;
-	} else {
-		basis = *orient;
-	}
-
-	if ( pos == NULL ) {
-		origin = vmd_zero_vector;
-	} else {
-		origin = *pos;
-	}
-
-	if ( Transform_stack.empty() ) {
-		Current_transform.basis = basis;
-		Current_transform.origin = origin;
-
-		Transform_stack.push_back(Current_transform);
-
-		return;
-	}
-
-	vec3d tempv;
-	transform newTransform = Current_transform;
-
-	vm_vec_unrotate(&tempv, &origin, &Current_transform.basis);
-	vm_vec_add2(&newTransform.origin, &tempv);
-
-	vm_matrix_x_matrix(&newTransform.basis, &Current_transform.basis, &basis);
-
-	Current_transform = newTransform;
-	Transform_stack.push_back(Current_transform);
+	Transformations.pop();
 }
 
-void draw_list::pop_transform()
-{
-	Assert( !Transform_stack.empty() );
-
-	Transform_stack.pop_back();
-
-	if ( !Transform_stack.empty() ) {
-		Current_transform = Transform_stack.back();
-	} else {
-		Current_transform = transform();
-	}
-}
-
-void draw_list::set_scale(vec3d *scale)
+void model_draw_list::set_scale(vec3d *scale)
 {
 	if ( scale == NULL ) {
 		Current_scale.xyz.x = 1.0f;
@@ -609,7 +562,7 @@ void draw_list::set_scale(vec3d *scale)
 	Current_scale = *scale;
 }
 
-void draw_list::init()
+void model_draw_list::init()
 {
 	reset();
 
@@ -622,7 +575,7 @@ void draw_list::init()
 	TransformBufferHandler.reset();
 }
 
-void draw_list::init_render(bool sort)
+void model_draw_list::init_render(bool sort)
 {
 	if ( sort ) {
 		sort_draws();
@@ -631,7 +584,7 @@ void draw_list::init_render(bool sort)
 	TransformBufferHandler.submit_buffer_data();
 }
 
-void draw_list::render_all(gr_zbuffer_type depth_mode)
+void model_draw_list::render_all(gr_zbuffer_type depth_mode)
 {
 	GR_DEBUG_SCOPE("Render draw list");
 	TRACE_SCOPE(tracing::SubmitDraws);
@@ -649,16 +602,16 @@ void draw_list::render_all(gr_zbuffer_type depth_mode)
 	gr_alpha_mask_set(0, 1.0f);
 }
 
-void draw_list::render_arc(arc_effect &arc)
+void model_draw_list::render_arc(arc_effect &arc)
 {
-	g3_start_instance_matrix(&arc.transformation.origin, &arc.transformation.basis);	
+	g3_start_instance_matrix(&arc.transform);	
 
 	model_render_arc(&arc.v1, &arc.v2, &arc.primary, &arc.secondary, arc.width);
 
 	g3_done_instance(true);
 }
 
-void draw_list::render_arcs()
+void model_draw_list::render_arcs()
 {
 	int mode = gr_zbuffer_set(GR_ZBUFF_READ);
 
@@ -669,11 +622,11 @@ void draw_list::render_arcs()
 	gr_zbuffer_set(mode);
 }
 
-void draw_list::add_insignia(model_render_params *params, polymodel *pm, int detail_level, int bitmap_num)
+void model_draw_list::add_insignia(model_render_params *params, polymodel *pm, int detail_level, int bitmap_num)
 {
 	insignia_draw_data new_insignia;
 
-	new_insignia.transformation = Current_transform;
+	new_insignia.transform = Transformations.get_transform();
 	new_insignia.pm = pm;
 	new_insignia.detail_level = detail_level;
 	new_insignia.bitmap_num = bitmap_num;
@@ -685,11 +638,14 @@ void draw_list::add_insignia(model_render_params *params, polymodel *pm, int det
 	Insignias.push_back(new_insignia);
 }
 
-void draw_list::render_insignia(insignia_draw_data &insignia_info)
+void model_draw_list::render_insignia(insignia_draw_data &insignia_info)
 {
 	if ( insignia_info.clip ) {
 		vec3d tmp;
-		vm_vec_sub(&tmp, &insignia_info.transformation.origin, &insignia_info.clip_position);
+		vec3d pos;
+
+		vm_matrix4_get_offset(&pos, &insignia_info.transform);
+		vm_vec_sub(&tmp, &pos, &insignia_info.clip_position);
 		vm_vec_normalize(&tmp);
 
 		if ( vm_vec_dot(&tmp, &insignia_info.clip_normal) < 0.0f) {
@@ -697,33 +653,33 @@ void draw_list::render_insignia(insignia_draw_data &insignia_info)
 		}
 	}
 
-	g3_start_instance_matrix(&insignia_info.transformation.origin, &insignia_info.transformation.basis);	
+	g3_start_instance_matrix(&insignia_info.transform);	
 
 	model_render_insignias(&insignia_info);
 
 	g3_done_instance(true);
 }
 
-void draw_list::render_insignias()
+void model_draw_list::render_insignias()
 {
 	for ( size_t i = 0; i < Insignias.size(); ++i ) {
 		render_insignia(Insignias[i]);
 	}
 }
 
-void draw_list::add_outline(vertex* vert_array, int n_verts, color *clr)
+void model_draw_list::add_outline(vertex* vert_array, int n_verts, color *clr)
 {
 	outline_draw draw_info;
 
 	draw_info.vert_array = vert_array;
 	draw_info.n_verts = n_verts;
 	draw_info.clr = *clr;
-	draw_info.transformation = Current_transform;
+	draw_info.transform = Transformations.get_transform();
 
 	Outlines.push_back(draw_info);
 }
 
-void draw_list::render_outlines()
+void model_draw_list::render_outlines()
 {
 	gr_clear_states();
 
@@ -732,9 +688,9 @@ void draw_list::render_outlines()
 	}
 }
 
-void draw_list::render_outline(outline_draw &outline_info)
+void model_draw_list::render_outline(outline_draw &outline_info)
 {
-	g3_start_instance_matrix(&outline_info.transformation.origin, &outline_info.transformation.basis);
+	g3_start_instance_matrix(&outline_info.transform);
 
 	material material_instance;
 
@@ -747,7 +703,7 @@ void draw_list::render_outline(outline_draw &outline_info)
 	g3_done_instance(true);
 }
 
-bool draw_list::sort_draw_pair(const int a, const int b)
+bool model_draw_list::sort_draw_pair(const int a, const int b)
 {
 	queued_buffer_draw *draw_call_a = &Target->Render_elements[a];
 	queued_buffer_draw *draw_call_b = &Target->Render_elements[b];
@@ -799,7 +755,7 @@ bool draw_list::sort_draw_pair(const int a, const int b)
 	return draw_call_a->lights.index_start < draw_call_b->lights.index_start;
 }
 
-void model_render_add_lightning( draw_list *scene, model_render_params* interp, polymodel *pm, bsp_info * sm )
+void model_render_add_lightning( model_draw_list *scene, model_render_params* interp, polymodel *pm, bsp_info * sm )
 {
 	int i;
 	float width = 0.9f;
@@ -944,7 +900,7 @@ int model_render_determine_detail(float depth, int obj_num, int model_num, matri
 	}
 }
 
-void model_render_buffers(draw_list* scene, model_material *rendering_material, model_render_params* interp, vertex_buffer *buffer, polymodel *pm, int mn, int detail_level, uint tmap_flags)
+void model_render_buffers(model_draw_list* scene, model_material *rendering_material, model_render_params* interp, vertex_buffer *buffer, polymodel *pm, int mn, int detail_level, uint tmap_flags)
 {
 	bsp_info *model = NULL;
 	const uint model_flags = interp->get_model_flags();
@@ -1026,7 +982,6 @@ void model_render_buffers(draw_list* scene, model_material *rendering_material, 
 		texture_maps[TM_HEIGHT_TYPE] = -1;
 		texture_maps[TM_MISC_TYPE] = -1;
 		texture_maps[TM_SPEC_GLOSS_TYPE] = -1;
-		texture_maps[TM_UNLIT_TYPE] = -1;
 		texture_maps[TM_AMBIENT_TYPE] = -1;
 
 		if (forced_texture != -2) {
@@ -1052,18 +1007,6 @@ void model_render_buffers(draw_list* scene, model_material *rendering_material, 
 			}
 
 			if ( texture_maps[TM_BASE_TYPE] < 0 ) {
-				continue;
-			}
-
-			if (replacement_textures != NULL && replacement_textures[rt_begin_index + TM_UNLIT_TYPE] >= 0) {
-				tex_replace[TM_UNLIT_TYPE] = texture_info(replacement_textures[rt_begin_index + TM_UNLIT_TYPE]);
-				texture_maps[TM_UNLIT_TYPE] = model_interp_get_texture(&tex_replace[TM_UNLIT_TYPE], base_frametime);
-			} else {
-				texture_maps[TM_UNLIT_TYPE] = model_interp_get_texture(&tmap->textures[TM_UNLIT_TYPE], base_frametime);
-			}
-
-			if ( (texture_maps[TM_UNLIT_TYPE] >= 0) && (model_flags & MR_NO_LIGHTING) && (buffer->flags & VB_FLAG_TRANS) ) {
-				// don't render transparent buffers for unlit textures in no lighting mode.
 				continue;
 			}
 
@@ -1193,10 +1136,8 @@ void model_render_buffers(draw_list* scene, model_material *rendering_material, 
 
 		if ( (tmap_flags & TMAP_FLAG_TEXTURED) && (buffer->flags & VB_FLAG_UV1) ) {
 			rendering_material->set_texture_map(TM_BASE_TYPE,	texture_maps[TM_BASE_TYPE]);
-			rendering_material->set_texture_map(TM_UNLIT_TYPE, texture_maps[TM_UNLIT_TYPE]);
 
-			if ( ( texture_maps[TM_BASE_TYPE] >= 0 && bm_has_alpha_channel(texture_maps[TM_BASE_TYPE]) ) || 
-				(texture_maps[TM_UNLIT_TYPE] >= 0 && bm_has_alpha_channel(texture_maps[TM_UNLIT_TYPE])) ) {
+			if ( texture_maps[TM_BASE_TYPE] >= 0 && bm_has_alpha_channel(texture_maps[TM_BASE_TYPE]) ) {
 				rendering_material->set_texture_type(material::TEX_TYPE_XPARENT);
 			}
 
@@ -1213,7 +1154,7 @@ void model_render_buffers(draw_list* scene, model_material *rendering_material, 
 	}
 }
 
-void model_render_children_buffers(draw_list* scene, model_material *rendering_material, model_render_params* interp, polymodel* pm, polymodel_instance *pmi, int mn, int detail_level, uint tmap_flags, bool trans_buffer)
+void model_render_children_buffers(model_draw_list* scene, model_material *rendering_material, model_render_params* interp, polymodel* pm, polymodel_instance *pmi, int mn, int detail_level, uint tmap_flags, bool trans_buffer)
 {
 	int i;
 
@@ -1483,7 +1424,7 @@ bool model_render_check_detail_box(vec3d *view_pos, polymodel *pm, int submodel_
 
 void submodel_render_immediate(model_render_params *render_info, int model_num, int submodel_num, matrix *orient, vec3d * pos)
 {
-	draw_list model_list;
+	model_draw_list model_list;
 	
 	model_list.init();
 
@@ -1502,7 +1443,7 @@ void submodel_render_immediate(model_render_params *render_info, int model_num, 
 	gr_set_lighting(false, false);
 }
 
-void submodel_render_queue(model_render_params *render_info, draw_list *scene, int model_num, int submodel_num, matrix *orient, vec3d * pos)
+void submodel_render_queue(model_render_params *render_info, model_draw_list *scene, int model_num, int submodel_num, matrix *orient, vec3d * pos)
 {
 	polymodel * pm;
 	model_material rendering_material;
@@ -2518,7 +2459,7 @@ void model_render_debug(int model_num, matrix *orient, vec3d * pos, uint flags, 
 
 void model_render_immediate(model_render_params *render_info, int model_num, matrix *orient, vec3d * pos, int render, bool sort)
 {
-	draw_list model_list;
+	model_draw_list model_list;
 
 	model_list.init();
 
@@ -2558,7 +2499,7 @@ void model_render_immediate(model_render_params *render_info, int model_num, mat
 	}
 }
 
-void model_render_queue(model_render_params *interp, draw_list *scene, int model_num, matrix *orient, vec3d *pos)
+void model_render_queue(model_render_params *interp, model_draw_list *scene, int model_num, matrix *orient, vec3d *pos)
 {
 	int i;
 

--- a/code/object/object.cpp
+++ b/code/object/object.cpp
@@ -1554,7 +1554,7 @@ extern int Cmdline_dis_weapons;
 
 void obj_render(object *obj)
 {
-	draw_list render_list;
+	model_draw_list render_list;
 
 	obj_queue_render(obj, &render_list);
 
@@ -1572,7 +1572,7 @@ void obj_render(object *obj)
 	gr_set_lighting(false, false);
 }
 
-void obj_queue_render(object* obj, draw_list* scene)
+void obj_queue_render(object* obj, model_draw_list* scene)
 {
 	TRACE_SCOPE(tracing::QueueRender);
 

--- a/code/object/object.h
+++ b/code/object/object.h
@@ -110,7 +110,7 @@ typedef struct obj_flag_name {
 extern obj_flag_name Object_flag_names[];
 
 struct dock_instance;
-class draw_list;
+class model_draw_list;
 
 class object
 {
@@ -227,7 +227,7 @@ int obj_create(ubyte type,int parent_obj, int instance, matrix * orient, vec3d *
 
 void obj_render(object* obj);
 
-void obj_queue_render(object* obj, draw_list* scene);
+void obj_queue_render(object* obj, model_draw_list* scene);
 
 //Sorts and renders all the ojbects
 void obj_render_all(void (*render_function)(object *objp), bool* render_viewer_last );

--- a/code/object/objectsort.cpp
+++ b/code/object/objectsort.cpp
@@ -340,7 +340,7 @@ void obj_render_queue_all()
 
 	object *objp;
 	int i;
-	draw_list scene;
+	model_draw_list scene;
 
 	objp = Objects;
 

--- a/code/render/3d.h
+++ b/code/render/3d.h
@@ -98,6 +98,11 @@ void g3_draw_horizon_line();
 void g3_start_instance_matrix(const vec3d *pos, const matrix *orient, bool set_api = true);
 
 /**
+ * Instance at specified point with specified transform.
+ */
+void g3_start_instance_matrix(const matrix4 *transform, bool set_api = true);
+
+/**
  * Instance at specified point with specified orientation
  */
 void g3_start_instance_angles(const vec3d *pos, const angles *orient);

--- a/code/render/3dsetup.cpp
+++ b/code/render/3dsetup.cpp
@@ -287,6 +287,16 @@ void g3_start_instance_matrix(const vec3d *pos, const matrix *orient, bool set_a
 
 }
 
+void g3_start_instance_matrix(const matrix4 *transform, bool set_api)
+{
+	matrix orient;
+	vec3d pos;
+
+	vm_matrix4_get_orientation(&orient, (matrix4*)transform);
+	vm_matrix4_get_offset(&pos, (matrix4*)transform);
+
+	g3_start_instance_matrix(&pos, &orient, set_api);
+}
 
 /**
  * Instance at specified point with specified orientation

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -18588,7 +18588,7 @@ void ship_render_batch_thrusters(object *obj)
 	}
 }
 
-void ship_render_weapon_models(model_render_params *ship_render_info, draw_list *scene, object *obj, int render_flags)
+void ship_render_weapon_models(model_render_params *ship_render_info, model_draw_list *scene, object *obj, int render_flags)
 {
 	int num = obj->instance;
 	ship *shipp = &Ships[num];
@@ -18739,7 +18739,7 @@ void ship_render_set_animated_effect(model_render_params *render_info, ship *shi
 	}
 }
 
-void ship_render(object* obj, draw_list* scene)
+void ship_render(object* obj, model_draw_list* scene)
 {
 	int num = obj->instance;
 	ship *shipp = &Ships[num];

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -1364,7 +1364,7 @@ extern void change_ship_type(int n, int ship_type, int by_sexp = 0);
 extern void ship_model_change(int n, int ship_type);
 extern void ship_process_pre( object * objp, float frametime );
 extern void ship_process_post( object * objp, float frametime );
-extern void ship_render( object * obj, draw_list * scene );
+extern void ship_render( object * obj, model_draw_list * scene );
 extern void ship_render_cockpit( object * objp);
 extern void ship_render_show_ship_cockpit( object * objp);
 extern void ship_delete( object * objp );

--- a/code/ship/shipfx.cpp
+++ b/code/ship/shipfx.cpp
@@ -1810,7 +1810,7 @@ static void split_ship_init( ship* shipp, split_ship* split_shipp )
 	shipfx_maybe_create_live_debris_at_ship_death( parent_ship_obj );
 }
 
-void shipfx_queue_render_ship_halves_and_debris(draw_list *scene, clip_ship* half_ship, ship *shipp)
+void shipfx_queue_render_ship_halves_and_debris(model_draw_list *scene, clip_ship* half_ship, ship *shipp)
 {
 	polymodel *pm = model_get(Ship_info[shipp->ship_info_index].model_num);
 
@@ -2281,7 +2281,7 @@ int shipfx_large_blowup_do_frame(ship *shipp, float frametime)
 	return 0;
 }
 
-void shipfx_large_blowup_queue_render(draw_list *scene, ship* shipp)
+void shipfx_large_blowup_queue_render(model_draw_list *scene, ship* shipp)
 {
 	Assert( shipp->large_ship_blowup_index > -1 );
 	Assert( shipp->large_ship_blowup_index < (int)Split_ships.size() );
@@ -3389,7 +3389,7 @@ int WarpEffect::warpShipRender()
 	return 0;
 }
 
-int WarpEffect::warpShipQueueRender(draw_list *scene)
+int WarpEffect::warpShipQueueRender(model_draw_list *scene)
 {
 	return 0;
 }

--- a/code/ship/shipfx.h
+++ b/code/ship/shipfx.h
@@ -111,7 +111,7 @@ void shipfx_large_blowup_init(ship *shipp);
 // Returns 1 when explosion is done
 int shipfx_large_blowup_do_frame(ship *shipp, float frametime);
 
-void shipfx_large_blowup_queue_render(draw_list *scene, ship* shipp);
+void shipfx_large_blowup_queue_render(model_draw_list *scene, ship* shipp);
 
 void shipfx_debris_limit_speed(struct debris *db, ship *shipp);
 
@@ -182,7 +182,7 @@ public:
 	virtual int warpShipClip();
 	virtual int warpShipClip(model_render_params *render_info);
 	virtual int warpShipRender();
-	virtual int warpShipQueueRender(draw_list *scene);
+	virtual int warpShipQueueRender(model_draw_list *scene);
 	virtual int warpEnd();
 
 	//For VM_WARP_CHASE

--- a/code/weapon/shockwave.cpp
+++ b/code/weapon/shockwave.cpp
@@ -362,7 +362,7 @@ void shockwave_move(object *shockwave_objp, float frametime)
 * @param objp	pointer to shockwave object
 * @param scene	the scene's draw list we're adding this to
 */
-void shockwave_render(object *objp, draw_list *scene)
+void shockwave_render(object *objp, model_draw_list *scene)
 {
 	shockwave		*sw;
 	vertex			p;

--- a/code/weapon/shockwave.h
+++ b/code/weapon/shockwave.h
@@ -16,7 +16,7 @@
 #include "globalincs/pstypes.h"
 
 class object;
-class draw_list;
+class model_draw_list;
 
 #define	SW_USED				(1<<0)
 #define	SW_WEAPON			(1<<1)
@@ -94,7 +94,7 @@ void shockwave_level_close();
 void shockwave_delete(object *objp);
 void shockwave_move_all(float frametime);
 int  shockwave_create(int parent_objnum, vec3d *pos, shockwave_create_info *sci, int flag, int delay = -1);
-void shockwave_render(object *objp, draw_list *scene);
+void shockwave_render(object *objp, model_draw_list *scene);
 int shockwave_load(char *s_name, bool shock_3D = false);
 
 int   shockwave_get_weapon_index(int index);

--- a/code/weapon/weapon.h
+++ b/code/weapon/weapon.h
@@ -529,7 +529,7 @@ int weapon_info_lookup(const char *name = NULL);
 void weapon_init();					// called at game startup
 void weapon_close();				// called at game shutdown
 void weapon_level_init();			// called before the start of each level
-void weapon_render(object* obj, draw_list *scene);
+void weapon_render(object* obj, model_draw_list *scene);
 void weapon_delete( object * obj );
 void weapon_process_pre( object *obj, float frame_time);
 void weapon_process_post( object *obj, float frame_time);

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -7216,7 +7216,7 @@ void shield_impact_explosion(vec3d *hitpos, object *objp, float radius, int idx)
 	particle::create( hitpos, &vmd_zero_vector, 0.0f, radius, particle::PARTICLE_BITMAP_PERSISTENT, expl_ani_handle, objp );
 }
 
-void weapon_render(object* obj, draw_list *scene)
+void weapon_render(object* obj, model_draw_list *scene)
 {
 	int num;
 	weapon_info *wip;


### PR DESCRIPTION
Rebased because I didn't want an extra commit in my pull request but it looks like I inadvertantly clobbered the previous pull request. Whoopsy daisy. But let's try this again:

Cleaned up a bunch of stuff related to draw_list which is now model_draw_list to be a better description of what it does. I also killed the transform class and replaced all uses of transform with matrix4. Killed the transform handling in model_draw_list as well and replaced it with the transform_stack that the OpenGL code uses. Unlit maps are gone since unlit specular doesn't look like ass anymore. Cut out a bunch of unused graphics code I found here and there.