### PR TITLE
Reenable the deprecated warnings of GCC and Clang

### DIFF
--- a/cmake/toolchain-clang.cmake
+++ b/cmake/toolchain-clang.cmake
@@ -63,7 +63,7 @@ set(COMPILER_FLAGS "${COMPILER_FLAGS} -Wno-write-strings")
 
 set(COMPILER_FLAGS "${COMPILER_FLAGS} -Wno-unused-function")
 
-set(COMPILER_FLAGS "${COMPILER_FLAGS} -Wno-deprecated -Wno-char-subscripts")
+set(COMPILER_FLAGS "${COMPILER_FLAGS} -Wno-char-subscripts")
 
 set(COMPILER_FLAGS "${COMPILER_FLAGS} -Wno-unused-parameter")
 


### PR DESCRIPTION
This warning isn't caused by our code at the moment so there is no
reason to keep them disabled.