### PR TITLE
Fix the rest of the string conversion warnings

### DIFF
--- a/cmake/toolchain-clang.cmake
+++ b/cmake/toolchain-clang.cmake
@@ -58,9 +58,6 @@ endif()
 
 set(COMPILER_FLAGS "${COMPILER_FLAGS} ${SANITIZE_FLAGS}")
 
-# Omit "deprecated conversion from string constant to 'char*'" warnings.
-set(COMPILER_FLAGS "${COMPILER_FLAGS} -Wno-write-strings")
-
 set(COMPILER_FLAGS "${COMPILER_FLAGS} -Wno-unused-function")
 
 set(COMPILER_FLAGS "${COMPILER_FLAGS} -Wno-char-subscripts")

--- a/cmake/toolchain-gcc.cmake
+++ b/cmake/toolchain-gcc.cmake
@@ -70,9 +70,6 @@ endif()
 
 set(COMPILER_FLAGS "${COMPILER_FLAGS} ${SANITIZE_FLAGS}")
 
-# Omit "deprecated conversion from string constant to 'char*'" warnings.
-set(COMPILER_FLAGS "${COMPILER_FLAGS} -Wno-write-strings")
-
 set(COMPILER_FLAGS "${COMPILER_FLAGS} -Wno-unused-function")
 
 set(COMPILER_FLAGS "${COMPILER_FLAGS} -Wno-deprecated -Wno-char-subscripts")

--- a/code/fs2netd/fs2netd_client.cpp
+++ b/code/fs2netd/fs2netd_client.cpp
@@ -1660,7 +1660,7 @@ void fs2netd_update_game_count(const char *chan_name)
 	FS2NetD_GameCountUpdate(chan_name);
 }
 
-void fs2netd_spew_table_checksums(char *outfile)
+void fs2netd_spew_table_checksums(const char *outfile)
 {
 	char full_name[MAX_PATH_LEN];
 	FILE *out = NULL;

--- a/code/hud/hudgauges.h
+++ b/code/hud/hudgauges.h
@@ -55,7 +55,7 @@
 #define HUD_SUPPORT_GAUGE						37
 #define HUD_LAG_GAUGE							38
 
-extern char *HUD_gauge_text[NUM_HUD_GAUGES];					// defined in sexp.cpp!!!!
+extern const char *HUD_gauge_text[NUM_HUD_GAUGES];					// defined in sexp.cpp!!!!
 
 
 #endif	/* __HUD_COMMON_H__ */

--- a/code/lab/wmcgui.cpp
+++ b/code/lab/wmcgui.cpp
@@ -139,7 +139,7 @@ bool ScreenClassInfoEntry::Parse()
 	return false;
 }
 
-void GUISystem::ParseClassInfo(char* filename)
+void GUISystem::ParseClassInfo(const char* filename)
 {
 	if (ClassInfoParsed) {
 		Warning(LOCATION, "Class info is being parsed twice");

--- a/code/lab/wmcgui.h
+++ b/code/lab/wmcgui.h
@@ -364,7 +364,7 @@ public:
 	//-----
 
 	//Set stuff
-	void ParseClassInfo(char* section);
+	void ParseClassInfo(const char* section);
 	void SetActiveObject(GUIObject *cgp);
 	void SetGraspedObject(GUIObject *cgp, int button);
 	void SetFocusObject(GUIObject *cgp);

--- a/code/network/multi_pmsg.cpp
+++ b/code/network/multi_pmsg.cpp
@@ -69,8 +69,8 @@ char Multi_msg_text[MULTI_MSG_MAX_TEXT_LEN+1];
 #define MULTI_MSG_CMD_KICK						0								// kick command
 
 //XSTR:OFF
-char *Multi_msg_commands[MULTI_MSG_CMD_COUNT] = {						// commands themselves
-	"kick"	
+const char *Multi_msg_commands[MULTI_MSG_CMD_COUNT] = {						// commands themselves
+	"kick"
 };
 //XSTR:ON
 
@@ -425,7 +425,7 @@ void multi_msg_perform_command(int command,char *param)
 
 //XSTR:OFF
 
-char *Multi_msg_subsys_name[SUBSYSTEM_MAX] = {
+const char *Multi_msg_subsys_name[SUBSYSTEM_MAX] = {
 	"None",
 	"Engine",
 	"Turret",

--- a/code/network/multi_pxo.cpp
+++ b/code/network/multi_pxo.cpp
@@ -416,7 +416,7 @@ int Multi_pxo_player_slider_coords[GR_NUM_RESOLUTIONS][4] = {
 		2, 219, 33, 314
 	}
 };
-char *Multi_pxo_player_slider_name[GR_NUM_RESOLUTIONS] = {
+const char *Multi_pxo_player_slider_name[GR_NUM_RESOLUTIONS] = {
 	"slider",				// GR_640
 	"2_slider"			// GR_1024
 };
@@ -549,7 +549,7 @@ int Multi_pxo_chat_slider_coords[GR_NUM_RESOLUTIONS][4] = {
 	}
 };
 
-char *Multi_pxo_chat_slider_name[GR_NUM_RESOLUTIONS] = {
+const char *Multi_pxo_chat_slider_name[GR_NUM_RESOLUTIONS] = {
 	"slider",
 	"2_slider"
 };
@@ -642,11 +642,11 @@ void multi_pxo_motd_maybe_blit();
 
 
 // common dialog stuff ------------------------------------------------
-char *Multi_pxo_com_fname[GR_NUM_RESOLUTIONS] = {
+const char *Multi_pxo_com_fname[GR_NUM_RESOLUTIONS] = {
 	"PXOPop",
 	"2_PXOPop"
 };
-char *Multi_pxo_com_mask_fname[GR_NUM_RESOLUTIONS] = {
+const char *Multi_pxo_com_mask_fname[GR_NUM_RESOLUTIONS] = {
 	"PXOPop-m",
 	"2_PXOPop-m"
 };
@@ -805,11 +805,11 @@ void multi_pxo_find_search_process();
 
 
 // player info stuff -----------------------------------------
-char *Multi_pxo_pinfo_fname[GR_NUM_RESOLUTIONS] = {
+const char *Multi_pxo_pinfo_fname[GR_NUM_RESOLUTIONS] = {
 	"PilotInfo2",
 	"2_PilotInfo2"
 };
-char *Multi_pxo_pinfo_mask_fname[GR_NUM_RESOLUTIONS] = {
+const char *Multi_pxo_pinfo_mask_fname[GR_NUM_RESOLUTIONS] = {
 	"PilotInfo2-M",
 	"2_PilotInfo2-M"
 };
@@ -921,11 +921,11 @@ void multi_pxo_notify_blit();
 
 // help screen stuff -----------------------------------------
 //XSTR:OFF
-char *Multi_pxo_help_fname[GR_NUM_RESOLUTIONS] = {
+const char *Multi_pxo_help_fname[GR_NUM_RESOLUTIONS] = {
 	"PXHelp",
 	"2_PXHelp"
 };
-char *Multi_pxo_help_mask_fname[GR_NUM_RESOLUTIONS] = {
+const char *Multi_pxo_help_mask_fname[GR_NUM_RESOLUTIONS] = {
 	"PXOHelp-M",
 	"2_PXOHelp-M"
 };
@@ -3426,7 +3426,7 @@ void multi_pxo_scroll_chat_down()
  */
 void multi_pxo_chat_process()
 {
-	char *remainder;
+	const char *remainder;
 	const char *result;
 	char msg[512];
 	int msg_pixel_width;
@@ -3441,10 +3441,10 @@ void multi_pxo_chat_process()
 	// then send the message
 	gr_get_string_size(&msg_pixel_width, NULL, msg);
 	if ( msg_pixel_width >= (Multi_pxo_input_coords[gr_screen.res][2])) {
-		remainder = strrchr(msg, ' ');
-		if ( remainder ) {
-			*remainder = '\0';
-			remainder++;
+		auto last_space = strrchr(msg, ' ');
+		if ( last_space ) {
+			*last_space = '\0';
+			remainder = last_space + 1;
 		} else {
 			remainder = "";
 		}	

--- a/code/network/multimsgs.cpp
+++ b/code/network/multimsgs.cpp
@@ -4811,7 +4811,7 @@ void process_jump_into_mission_packet(ubyte *data, header *hinfo)
 
 //XSTR:OFF
 
-char *repair_text[] = {
+const char *repair_text[] = {
 	"unknown",
 	"REPAIR_INFO_BEGIN",
 	"REPAIR_INFO_END",
@@ -6813,7 +6813,7 @@ void process_asteroid_info( ubyte *data, header *hinfo )
 	PACKET_SET_SIZE();
 }
 
-void send_host_restr_packet(char *callsign,int code,int mode)
+void send_host_restr_packet(const char *callsign,int code,int mode)
 {
 	ubyte data[MAX_PACKET_SIZE],val;
 	int packet_size = 0;

--- a/code/network/multimsgs.h
+++ b/code/network/multimsgs.h
@@ -436,7 +436,7 @@ void send_shield_explosion_packet(int objnum, int tri_num, vec3d hit_pos);
 
 void send_player_stats_block_packet(net_player *pl, int stats_type, net_player *target = NULL, short offset = 0);
 
-void send_host_restr_packet(char *callsign, int code, int mode);
+void send_host_restr_packet(const char *callsign, int code, int mode);
 
 void send_netgame_end_error_packet(int notify_code, int err_code);
 

--- a/code/network/multiteamselect.cpp
+++ b/code/network/multiteamselect.cpp
@@ -50,12 +50,12 @@ extern int Next_screen;
 // bitmap defines
 #define MULTI_TS_PALETTE							"InterfacePalette"
 
-char *Multi_ts_bitmap_fname[GR_NUM_RESOLUTIONS] = {
+const char *Multi_ts_bitmap_fname[GR_NUM_RESOLUTIONS] = {
 	"TeamSelect",		// GR_640
 	"2_TeamSelect"		// GR_1024
 };
 
-char *Multi_ts_bitmap_mask_fname[GR_NUM_RESOLUTIONS] = {
+const char *Multi_ts_bitmap_mask_fname[GR_NUM_RESOLUTIONS] = {
 	"TeamSelect-M",	// GR_640
 	"2_TeamSelect-M"		// GR_1024
 };
@@ -101,7 +101,7 @@ ui_button_info Multi_ts_buttons[GR_NUM_RESOLUTIONS][MULTI_TS_NUM_BUTTONS] = {
 // players locked ani graphic
 #define MULTI_TS_NUM_LOCKED_BITMAPS				3
 
-char *Multi_ts_bmap_names[GR_NUM_RESOLUTIONS][3] = {
+const char *Multi_ts_bmap_names[GR_NUM_RESOLUTIONS][3] = {
 	{ // GR_640
 		"TSB_340000",
 		"TSB_340001",

--- a/code/network/multiui.cpp
+++ b/code/network/multiui.cpp
@@ -310,7 +310,7 @@ void multi_common_notify_do()
 // common icon stuff
 int Multi_common_icons[MULTI_NUM_COMMON_ICONS];
 //XSTR:OFF
-char *Multi_common_icon_names[MULTI_NUM_COMMON_ICONS] = {
+const char *Multi_common_icon_names[MULTI_NUM_COMMON_ICONS] = {
 	"DotRed",				// voice denied
 	"DotGreen",				// voice recording
 	"OvalGreen",			// team 0
@@ -469,19 +469,19 @@ void multi_common_verify_cd()
 // bitmaps defs
 #define MULTI_JOIN_PALETTE				"InterfacePalette"
 
-static char *Multi_join_bitmap_fname[GR_NUM_RESOLUTIONS] = {
+static const char *Multi_join_bitmap_fname[GR_NUM_RESOLUTIONS] = {
 	"MultiJoin",		// GR_640
 	"2_MultiJoin"			// GR_1024
 };
 
-static char *Multi_join_bitmap_mask_fname[GR_NUM_RESOLUTIONS] = {
+static const char *Multi_join_bitmap_mask_fname[GR_NUM_RESOLUTIONS] = {
 	"MultiJoin-M",		// GR_640
 	"2_MultiJoin-M"		// GR_1024
 };
 //XSTR:ON
 
 // slider
-char *Mj_slider_name[GR_NUM_RESOLUTIONS] = {
+const char *Mj_slider_name[GR_NUM_RESOLUTIONS] = {
 	"slider",
 	"2_slider"
 };
@@ -657,7 +657,7 @@ int Mj_ping_coords[GR_NUM_RESOLUTIONS][4] = {
 
 // game speed labels
 #define MJ_NUM_SPEED_LABELS		5
-char *Multi_join_speed_labels[MJ_NUM_SPEED_LABELS] = {
+const char *Multi_join_speed_labels[MJ_NUM_SPEED_LABELS] = {
 	"< 56k",
 	"56k",
 	"isdn",
@@ -2083,12 +2083,12 @@ void multi_join_blit_protocol()
 // bitmap defs
 #define MULTI_SG_PALETTE			"InterfacePalette"
 
-static char *Multi_sg_bitmap_fname[GR_NUM_RESOLUTIONS] = {
+static const char *Multi_sg_bitmap_fname[GR_NUM_RESOLUTIONS] = {
 	"MultiStartGame",			// GR_640
 	"2_MultiStartGame"			// GR_1024
 };
 
-static char *Multi_sg_bitmap_mask_fname[GR_NUM_RESOLUTIONS] = {
+static const char *Multi_sg_bitmap_mask_fname[GR_NUM_RESOLUTIONS] = {
 	"MultiStartGame-M",			// GR_640
 	"2_MultiStartGame-M"			// GR_1024
 };
@@ -3001,17 +3001,17 @@ void multi_sg_select_rank_default()
 
 //XSTR:OFF
 // bitmaps defs
-char *Multi_create_bitmap_fname[GR_NUM_RESOLUTIONS] = {
+const char *Multi_create_bitmap_fname[GR_NUM_RESOLUTIONS] = {
 	"MultiCreate",			// GR_640
 	"2_MultiCreate"		// GR_1024
 };
 
-char *Multi_create_bitmap_mask_fname[GR_NUM_RESOLUTIONS] = {
+const char *Multi_create_bitmap_mask_fname[GR_NUM_RESOLUTIONS] = {
 	"MultiCreate-M",		// GR_640
 	"2_MultiCreate-M"		// GR_1024
 };
 
-char *Multi_create_loading_fname[GR_NUM_RESOLUTIONS] = {
+const char *Multi_create_loading_fname[GR_NUM_RESOLUTIONS] = {
 	"PleaseWait",			// GR_640
 	"2_PleaseWait"			// GR_1024
 };
@@ -3150,7 +3150,7 @@ UI_XSTR Multi_create_text[GR_NUM_RESOLUTIONS][MULTI_CREATE_NUM_BUTTONS] = {
 
 // squad war checkbox
 UI_CHECKBOX	Multi_create_sw_checkbox;
-char *Multi_create_sw_checkbox_fname[GR_NUM_RESOLUTIONS] = {
+const char *Multi_create_sw_checkbox_fname[GR_NUM_RESOLUTIONS] = {
 	"MC_SW_00",
 	"MC_SW_00",
 };
@@ -3291,7 +3291,7 @@ int Mc_slider_coords[GR_NUM_RESOLUTIONS][4] = {
 	}
 };
 
-char *Mc_slider_bitmap[GR_NUM_RESOLUTIONS] = {
+const char *Mc_slider_bitmap[GR_NUM_RESOLUTIONS] = {
 	"slider",
 	"2_slider"
 };
@@ -5491,12 +5491,12 @@ void multi_create_sw_clicked()
 // bitmaps defs
 #define MULTI_HO_PALETTE				"InterfacePalette"
 
-static char *Multi_ho_bitmap_fname[GR_NUM_RESOLUTIONS] = {
+static const char *Multi_ho_bitmap_fname[GR_NUM_RESOLUTIONS] = {
 	"MultiHost",			// GR_640
 	"2_MultiHost"			// GR_1024
 };
 
-static char *Multi_ho_bitmap_mask_fname[GR_NUM_RESOLUTIONS] = {
+static const char *Multi_ho_bitmap_mask_fname[GR_NUM_RESOLUTIONS] = {
 	"MultiHost-M",			// GR_640
 	"2_MultiHost-M"		// GR_1024
 };
@@ -5639,14 +5639,14 @@ int Multi_ho_radio_info[MULTI_HO_NUM_RADIO_BUTTONS][3] = {	// info related to ea
 #define MULTI_HO_SLIDER_VOICE_DUR			1						// max duration of voice recording
 #define MULTI_HO_SLIDER_SKILL					2						// skill level
 struct ho_sliders {
-	char *filename;
+	const char *filename;
 	int x, y, xt, yt;
 	int hotspot;
 	int dot_w;
 	int dots;
 	UI_DOT_SLIDER_NEW slider;  // because we have a class inside this struct, we need the constructor below..
 
-	ho_sliders(char *name, int x1, int y1, int xt1, int yt1, int h, int _dot_w, int _dots) : filename(name), x(x1), y(y1), xt(xt1), yt(yt1), hotspot(h), dot_w(_dot_w), dots(_dots){}
+	ho_sliders(const char *name, int x1, int y1, int xt1, int yt1, int h, int _dot_w, int _dots) : filename(name), x(x1), y(y1), xt(xt1), yt(yt1), hotspot(h), dot_w(_dot_w), dots(_dots){}
 };
 ho_sliders Multi_ho_sliders[GR_NUM_RESOLUTIONS][MULTI_HO_NUM_SLIDERS] = {
 	{ // GR_640
@@ -6506,12 +6506,12 @@ void multi_ho_display_skill_level()
 // bitmaps defs
 #define MULTI_JW_PALETTE				"InterfacePalette"
 
-static char *Multi_jw_bitmap_fname[GR_NUM_RESOLUTIONS] = {
+static const char *Multi_jw_bitmap_fname[GR_NUM_RESOLUTIONS] = {
 	"MultiJoinWait",		// GR_640
 	"2_MultiJoinWait"		// GR_1024
 };
 
-static char *Multi_jw_bitmap_mask_fname[GR_NUM_RESOLUTIONS] = {
+static const char *Multi_jw_bitmap_mask_fname[GR_NUM_RESOLUTIONS] = {
 	"MultiJoinWait-M",		// GR_640
 	"2_MultiJoinWait-M"		// GR_1024
 };
@@ -6603,7 +6603,7 @@ int Mjw_mission_name_coords[GR_NUM_RESOLUTIONS][2] = {
 
 // squad war checkbox
 UI_CHECKBOX	Multi_jw_sw_checkbox;
-char *Multi_jw_sw_checkbox_fname[GR_NUM_RESOLUTIONS] = {
+const char *Multi_jw_sw_checkbox_fname[GR_NUM_RESOLUTIONS] = {
 	"MC_SW_00",
 	"MC_SW_00",
 };
@@ -7229,12 +7229,12 @@ short multi_jw_get_mouse_id()
 #define MULTI_SYNC_HOST_COUNT				4		// host uses 4 buttons (and sometimes 5)
 #define MULTI_SYNC_CLIENT_COUNT			3		// client only uses 3 buttons
 
-char *Multi_sync_bitmap_fname[GR_NUM_RESOLUTIONS] = {
+const char *Multi_sync_bitmap_fname[GR_NUM_RESOLUTIONS] = {
 	"MultiSynch",		// GR_640
 	"2_MultiSynch"		// GR_1024
 };
 
-char *Multi_sync_bitmap_mask_fname[GR_NUM_RESOLUTIONS] = {
+const char *Multi_sync_bitmap_mask_fname[GR_NUM_RESOLUTIONS] = {
 	"MultiSynch-M",		// GR_640
 	"2_MultiSynch-M"			// GR_1024
 };
@@ -7347,7 +7347,7 @@ int Multi_launch_button_created;
 
 //XSTR:OFF
 // countdown animation timer
-char* Multi_sync_countdown_fname[GR_NUM_RESOLUTIONS] = {
+const char* Multi_sync_countdown_fname[GR_NUM_RESOLUTIONS] = {
 	"Count",		// GR_640
 	"2_Count"		// GR_1024
 };
@@ -9043,12 +9043,12 @@ void multi_debrief_server_process()
 
 //XSTR:OFF
 // bitmaps defs
-static char *Multi_pwd_bitmap_fname[GR_NUM_RESOLUTIONS] = {
+static const char *Multi_pwd_bitmap_fname[GR_NUM_RESOLUTIONS] = {
 	"Password",			// GR_640
 	"2_Password"		// GR_1024
 };
 
-static char *Multi_pwd_bitmap_mask_fname[GR_NUM_RESOLUTIONS] = {
+static const char *Multi_pwd_bitmap_mask_fname[GR_NUM_RESOLUTIONS] = {
 	"Password-M",		// GR_640
 	"2_Password-M"		// GR_1024
 };

--- a/code/network/stand_gui-unix.cpp
+++ b/code/network/stand_gui-unix.cpp
@@ -539,7 +539,7 @@ json_t* missionGoalsGet(ResourceContext *context) {
         json_object_set_new(goalEntity, "score", json_integer(goal.score));
         json_object_set_new(goalEntity, "team", json_integer(goal.team));
 
-        char *typeString;
+        const char *typeString;
         switch (goal.type) {
         case PRIMARY_GOAL:
             typeString = "primary";
@@ -556,7 +556,7 @@ json_t* missionGoalsGet(ResourceContext *context) {
         };
         json_object_set_new(goalEntity, "type", json_string(typeString));
 
-        char *statusString;
+        const char *statusString;
         switch (goal.satisfied) {
         case GOAL_FAILED:
             statusString = "failed";

--- a/code/object/object.cpp
+++ b/code/object/object.cpp
@@ -75,7 +75,7 @@ int Object_inited = 0;
 int Show_waypoints = 0;
 
 //WMC - Made these prettier
-char *Object_type_names[MAX_OBJECT_TYPES] = {
+const char *Object_type_names[MAX_OBJECT_TYPES] = {
 //XSTR:OFF
 	"None",
 	"Ship",

--- a/code/object/object.h
+++ b/code/object/object.h
@@ -51,7 +51,7 @@
 
 #define UNUSED_OBJNUM		(-MAX_OBJECTS*2)	//	Newer systems use this instead of -1 for invalid object.
 
-extern char	*Object_type_names[MAX_OBJECT_TYPES];
+extern const char	*Object_type_names[MAX_OBJECT_TYPES];
 
 // each object type should have these functions:  (I will use weapon as example)
 //

--- a/code/osapi/outwnd.cpp
+++ b/code/osapi/outwnd.cpp
@@ -42,7 +42,7 @@ bool outwnd_inited = false;
 // used for file logging
 int Log_debug_output_to_file = 1;
 FILE *Log_fp = NULL;
-char *FreeSpace_logfilename = NULL;
+const char *FreeSpace_logfilename = NULL;
 
 void load_filter_info(void)
 {

--- a/code/parse/parselo.cpp
+++ b/code/parse/parselo.cpp
@@ -973,7 +973,7 @@ void stuff_string_until(SCP_string &outstr, const char *endstr)
 //or NULL on failure
 //Does depth checks for the start and end strings
 //extra_chars indicates extra malloc space that should be allocated.
-char* alloc_block(char* startstr, char* endstr, int extra_chars)
+char* alloc_block(const char* startstr, const char* endstr, int extra_chars)
 {
 	Assert(startstr != NULL && endstr != NULL);
 	Assert(stricmp(startstr, endstr));

--- a/code/parse/parselo.h
+++ b/code/parse/parselo.h
@@ -128,7 +128,7 @@ extern void stuff_string(SCP_string &outstr, int type, const char *terminators =
 extern void stuff_string_line(SCP_string &outstr);
 
 //alloc
-extern char* alloc_block(char* startstr, char* endstr, int extra_chars = 0);
+extern char* alloc_block(const char* startstr, const char* endstr, int extra_chars = 0);
 
 // Exactly the same as stuff string only Malloc's the buffer.
 //	Supports various FreeSpace primitive types.  If 'len' is supplied, it will override

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -770,7 +770,7 @@ sexp_ai_goal_link Sexp_ai_goal_links[] = {
 	{ AI_GOAL_FORM_ON_WING, OP_AI_FORM_ON_WING }
 };
 
-char *HUD_gauge_text[NUM_HUD_GAUGES] = 
+const char *HUD_gauge_text[NUM_HUD_GAUGES] =
 {
 	"LEAD_INDICATOR",
 	"ORIENTATION_TEE",
@@ -816,7 +816,7 @@ char *HUD_gauge_text[NUM_HUD_GAUGES] =
 
 void sexp_set_skybox_model_preload(char *name); // taylor
 int Num_skybox_flags = 6;
-char *Skybox_flags[] = {
+const char *Skybox_flags[] = {
 	"force-clamp",
 	"add-lighting",
 	"no-transparency",
@@ -867,11 +867,11 @@ void sexp_stop_music(int fade = 1);
 #define SEO_DECAY_TIME	1
 #define SEO_DAMPING		2
 int sexp_sound_environment_option_lookup(char *text);
-char *Sound_environment_option[] = { "volume", "decay time", "damping" };
+const char *Sound_environment_option[] = { "volume", "decay time", "damping" };
 int Num_sound_environment_options = 3;
 
 // for adjust-audio-volume - The E
-char *Adjust_audio_options[] = { "Music", "Voice", "Effects" };
+const char *Adjust_audio_options[] = { "Music", "Voice", "Effects" };
 int Num_adjust_audio_options = 3;
 int audio_volume_option_lookup(char *text);
 
@@ -885,7 +885,7 @@ int hud_gauge_type_lookup(char* name);
 #define EO_SHOCKWAVE_SPEED	4
 #define EO_DEATH_ROLL_TIME	5
 int sexp_explosion_option_lookup(char *text);
-char *Explosion_option[] = { "damage", "blast", "inner radius", "outer radius", "shockwave speed", "death roll time" };
+const char *Explosion_option[] = { "damage", "blast", "inner radius", "outer radius", "shockwave speed", "death roll time" };
 int Num_explosion_options = 6;
 
 int get_sexp();
@@ -1122,7 +1122,7 @@ void init_sexp()
 /**
  * Allocate an sexp node.
  */
-int alloc_sexp(char *text, int type, int subtype, int first, int rest)
+int alloc_sexp(const char *text, int type, int subtype, int first, int rest)
 {
 	int node;
 	int sexp_const = get_operator_const(text);
@@ -22668,7 +22668,7 @@ void maybe_write_to_event_log(int result)
 /**
 * Returns the constant used as a SEXP's result as text for printing to the event log
 */
-char *sexp_get_result_as_text(int result)
+const char *sexp_get_result_as_text(int result)
 {
 	switch (result) {
 		case SEXP_TRUE:
@@ -28471,7 +28471,7 @@ int sexp_query_type_match(int opf, int opr)
 	return 0;
 }
 
-char *sexp_error_message(int num)
+const char *sexp_error_message(int num)
 {
 	switch (num) {
 		case SEXP_CHECK_NONOP_ARGS:
@@ -33789,8 +33789,8 @@ static void output_sexp_html(int sexp_idx, FILE *fp)
 		{
 			char* new_buf = new char[2*strlen(Sexp_help[i].help)];
 			char* dest_ptr = new_buf;
-			char* curr_ptr = Sexp_help[i].help;
-			char* end_ptr = curr_ptr + strlen(Sexp_help[i].help);
+			const char* curr_ptr = Sexp_help[i].help;
+			const char* end_ptr = curr_ptr + strlen(Sexp_help[i].help);
 			while(curr_ptr < end_ptr)
 			{
 				if(*curr_ptr == '\n')

--- a/code/parse/sexp.h
+++ b/code/parse/sexp.h
@@ -1019,7 +1019,7 @@ typedef struct sexp_ai_goal_link {
 #define SEXP_TRIGGER_OPERATOR		( SEXP_ARITHMETIC_OPERATOR | SEXP_BOOLEAN_OPERATOR | SEXP_INTEGER_OPERATOR ) 
 
 typedef struct sexp_oper {
-	char	*text;
+	const char	*text;
 	int	value;
 	int	min, max;
 	int type;
@@ -1113,7 +1113,7 @@ extern SCP_vector<SCP_string> *Current_event_log_variable_buffer;
 extern SCP_vector<SCP_string> *Current_event_log_argument_buffer;
 
 extern void init_sexp();
-extern int alloc_sexp(char *text, int type, int subtype, int first, int rest);
+extern int alloc_sexp(const char *text, int type, int subtype, int first, int rest);
 extern int find_free_sexp();
 extern int free_one_sexp(int num);
 extern int free_sexp(int num);
@@ -1144,7 +1144,7 @@ extern void skip_white(char **str);
 extern int validate_float(char **str);
 extern int build_sexp_string(SCP_string &accumulator, int cur_node, int level, int mode);
 extern int sexp_query_type_match(int opf, int opr);
-extern char *sexp_error_message(int num);
+extern const char *sexp_error_message(int num);
 extern int count_free_sexp_nodes();
 
 // Goober5000
@@ -1204,13 +1204,13 @@ extern int Knossos_warp_ani_used;
 //WMC - moved here from FRED
 typedef struct sexp_help_struct {
 	int id;
-	char *help;
+	const char *help;
 } sexp_help_struct;
 
 extern sexp_help_struct Sexp_help[];
 
 typedef struct op_menu_struct {
-	char *name;
+	const char *name;
 	int id;
 } op_menu_struct;
 
@@ -1229,18 +1229,18 @@ void multi_sexp_eval();
 
 // Goober5000/Taylor
 extern int Num_sound_environment_options;
-extern char *Sound_environment_option[];
+extern const char *Sound_environment_option[];
 
 // Goober5000
 extern int Num_explosion_options;
-extern char *Explosion_option[];
+extern const char *Explosion_option[];
 
 //The E
 extern int Num_adjust_audio_options;
-extern char *Adjust_audio_options[];
+extern const char *Adjust_audio_options[];
 
 extern int Num_skybox_flags;
-extern char *Skybox_flags[];
+extern const char *Skybox_flags[];
 
 /** Global state variables for the hud-display-gauge sexp.
 They all should be named Sexp_hud_display_*;

--- a/code/playerman/managepilot.cpp
+++ b/code/playerman/managepilot.cpp
@@ -342,7 +342,7 @@ void pilot_load_squad_pic_list()
 }
 
 // will attempt to load an insignia bitmap and set it as active for the player
-void player_set_squad_bitmap(player *p, char *fname, bool ismulti)
+void player_set_squad_bitmap(player *p, const char *fname, bool ismulti)
 {
 	// sanity check
 	if(p == NULL){

--- a/code/playerman/player.h
+++ b/code/playerman/player.h
@@ -249,7 +249,7 @@ void player_stop_cargo_scan_sound();
 void player_maybe_start_cargo_scan_sound();
 
 // will attempt to load an insignia bitmap and set it as active for the player
-void player_set_squad_bitmap(player *p, char *fnamem, bool ismulti);
+void player_set_squad_bitmap(player *p, const char *fnamem, bool ismulti);
 
 // set squadron
 void player_set_squad(player *p, char *squad_name);

--- a/code/popup/popup.cpp
+++ b/code/popup/popup.cpp
@@ -41,7 +41,7 @@ int Popup_max_display[GR_NUM_RESOLUTIONS] = {
 	19
 };
 
-char *Popup_slider_name[GR_NUM_RESOLUTIONS] = {
+const char *Popup_slider_name[GR_NUM_RESOLUTIONS] = {
 	"slider",
 	"2_slider"
 };
@@ -112,7 +112,7 @@ int Popup_input_text_y_offset[GR_NUM_RESOLUTIONS] = {
 
 typedef struct popup_background
 {
-	char	*filename;							// filename for background
+	const char *filename;							// filename for background
 	int	coords[2];							// coords to draw background at
 } popup_background;
 
@@ -189,7 +189,7 @@ static popup_background Popup_background[GR_NUM_RESOLUTIONS][3] =
 #define BUTTON_GENERIC_FIRST		2
 #define BUTTON_GENERIC_SECOND		3
 #define BUTTON_GENERIC_THIRD		4
-static char *Popup_button_filenames[GR_NUM_RESOLUTIONS][2][5] = 
+static const char *Popup_button_filenames[GR_NUM_RESOLUTIONS][2][5] =
 {
 	{ // GR_640
 		{"Pop_00",				// negative
@@ -388,9 +388,9 @@ void popup_split_lines(popup_info *pi, int flags)
 }
 
 // figure out what filename to use for the button icon
-char *popup_get_button_filename(popup_info *pi, int i, int flags)
+const char *popup_get_button_filename(popup_info *pi, int i, int flags)
 {
-	char *fname = NULL;
+	const char *fname = NULL;
 	int is_tiny=0;	
 
 	// check for special button texts and if found, use specialized buttons for them.
@@ -464,7 +464,7 @@ int popup_init(popup_info *pi, int flags)
 	int					i;
 	UI_BUTTON			*b;
 	popup_background	*pbg;
-	char					*fname;
+	const char			*fname;
 
 	if(pi->nchoices == 0){
 		pbg = &Popup_background[gr_screen.res][0];

--- a/code/popup/popupdead.cpp
+++ b/code/popup/popupdead.cpp
@@ -69,7 +69,7 @@ int Popupdead_button_coords[GR_NUM_RESOLUTIONS][POPUPDEAD_NUM_CHOICES_MAX][2] =
 	}
 };
 
-char *Popupdead_background_filename[GR_NUM_RESOLUTIONS] = {
+const char *Popupdead_background_filename[GR_NUM_RESOLUTIONS] = {
 	"PopDeath",		// GR_640
 	"2_PopDeath"	// GR-1024
 };
@@ -84,7 +84,7 @@ int Popupdead_background_coords[GR_NUM_RESOLUTIONS][2] =
 	}
 };
 
-char *Popupdead_button_filenames[GR_NUM_RESOLUTIONS][POPUPDEAD_NUM_CHOICES_MAX] = 
+const char *Popupdead_button_filenames[GR_NUM_RESOLUTIONS][POPUPDEAD_NUM_CHOICES_MAX] =
 {
 	{	// GR_640
 		"PopD_00",				// first choice

--- a/code/scripting/api/libs/cfile.cpp
+++ b/code/scripting/api/libs/cfile.cpp
@@ -65,7 +65,7 @@ ADE_LIB(l_CFile, "CFile", "cf", "CFile FS2 filesystem access");
 ADE_FUNC(deleteFile, l_CFile, "string Filename, string Path", "Deletes given file. Path must be specified. Use a slash for the root directory.", "boolean", "True if deleted, false")
 {
 	char *n_filename = NULL;
-	char *n_path = "";
+	const char *n_path = "";
 	if(!ade_get_args(L, "ss", &n_filename, &n_path))
 		return ade_set_error(L, "b", false);
 
@@ -82,7 +82,7 @@ ADE_FUNC(deleteFile, l_CFile, "string Filename, string Path", "Deletes given fil
 ADE_FUNC(fileExists, l_CFile, "string Filename, [string Path = \"\", boolean CheckVPs = false]", "Checks if a file exists. Use a blank string for path for any directory, or a slash for the root directory.", "boolean", "True if file exists, false or nil otherwise")
 {
 	char *n_filename = NULL;
-	char *n_path = "";
+	const char *n_path = "";
 	bool check_vps = false;
 	if(!ade_get_args(L, "s|sb", &n_filename, &n_path, &check_vps))
 		return ADE_RETURN_NIL;
@@ -107,8 +107,8 @@ ADE_FUNC(openFile, l_CFile, "string Filename, [string Mode=\"r\", string Path = 
 		 "File handle, or invalid file handle if the specified file couldn't be opened")
 {
 	char *n_filename = NULL;
-	char *n_mode = "r";
-	char *n_path = "";
+	const char *n_mode = "r";
+	const char *n_path = "";
 	if(!ade_get_args(L, "s|ss", &n_filename, &n_mode, &n_path))
 		return ade_set_error(L, "o", l_File.Set(NULL));
 
@@ -138,7 +138,7 @@ ADE_FUNC(renameFile, l_CFile, "string CurrentFilename, string NewFilename, strin
 {
 	char *n_filename = NULL;
 	char *n_new_filename = NULL;
-	char *n_path = "";
+	const char *n_path = "";
 	if(!ade_get_args(L, "ss|s", &n_filename, &n_new_filename, &n_path))
 		return ade_set_error(L, "b", false);
 

--- a/code/scripting/api/objs/graphics.cpp
+++ b/code/scripting/api/objs/graphics.cpp
@@ -1030,7 +1030,7 @@ ADE_FUNC(drawOffscreenIndicator, l_Graphics, "object Object, [boolean draw=true,
 }
 
 #define MAX_TEXT_LINES		256
-static char *BooleanValues[] = {"False", "True"};
+static const char *BooleanValues[] = {"False", "True"};
 
 ADE_FUNC(drawString, l_Graphics, "string Message, [number X1, number Y1, number X2, number Y2]",
 		 "Draws a string. Use x1/y1 to control position, x2/y2 to limit textbox size."
@@ -1047,7 +1047,7 @@ ADE_FUNC(drawString, l_Graphics, "string Message, [number X1, number Y1, number 
 	int x=NextDrawStringPos[0];
 	int y = NextDrawStringPos[1];
 
-	char *s = "(null)";
+	const char *s = "(null)";
 	int x2=-1,y2=-1;
 	int num_lines = 0;
 

--- a/code/scripting/api/objs/ship.cpp
+++ b/code/scripting/api/objs/ship.cpp
@@ -181,7 +181,7 @@ ADE_VIRTVAR(ShieldArmorClass, l_Ship, "string", "Current Armor class of the ship
 {
 	object_h *objh;
 	char *s = NULL;
-	char *name = NULL;
+	const char *name = NULL;
 
 	if(!ade_get_args(L, "o|s", l_Ship.GetPtr(&objh), &s))
 		return ade_set_error(L, "s", "");
@@ -208,7 +208,7 @@ ADE_VIRTVAR(ArmorClass, l_Ship, "string", "Current Armor class", "string", "Armo
 {
 	object_h *objh;
 	char *s = NULL;
-	char *name = NULL;
+	const char *name = NULL;
 
 	if(!ade_get_args(L, "o|s", l_Ship.GetPtr(&objh), &s))
 		return ade_set_error(L, "s", "");

--- a/code/scripting/api/objs/subsystem.cpp
+++ b/code/scripting/api/objs/subsystem.cpp
@@ -43,7 +43,7 @@ ADE_VIRTVAR(ArmorClass, l_Subsystem, "string", "Current Armor class", "string", 
 {
 	ship_subsys_h *sso;
 	char *s = NULL;
-	char *name = NULL;
+	const char *name = NULL;
 
 	if(!ade_get_args(L, "o|s", l_Subsystem.GetPtr(&sso), &s))
 		return ade_set_error(L, "s", "");

--- a/code/scripting/scripting.cpp
+++ b/code/scripting/scripting.cpp
@@ -958,7 +958,7 @@ void script_state::SetLuaSession(lua_State *L)
 	}
 }
 
-int script_state::OutputMeta(char *filename)
+int script_state::OutputMeta(const char *filename)
 {
 	FILE *fp = fopen(filename,"w");
 	int i;

--- a/code/scripting/scripting.h
+++ b/code/scripting/scripting.h
@@ -208,7 +208,7 @@ public:
 	int CreateLuaState();
 
 	//***Get data
-	int OutputMeta(char *filename);
+	int OutputMeta(const char *filename);
 
 	//***Moves data
 	//void MoveData(script_state &in);

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -735,7 +735,7 @@ void parse_engine_wash(bool replace)
 	}
 }
 
-char *Warp_types[] = {
+const char *Warp_types[] = {
 	"Default",
 	"Knossos",
 	"Babylon5",
@@ -758,7 +758,7 @@ int warptype_match(char *p)
 	return -1;
 }
 
-char *Lightning_types[] = {
+const char *Lightning_types[] = {
 	"None",
 	"Default",
 };
@@ -1971,7 +1971,7 @@ int parse_ship_template()
 	return rtn;
 }
 
-void parse_ship_sound(char *name, GameSoundsIndex id, ship_info *sip)
+void parse_ship_sound(const char *name, GameSoundsIndex id, ship_info *sip)
 {
 	Assert( name != NULL );
 
@@ -2012,7 +2012,7 @@ void parse_ship_sounds(ship_info *sip)
 	parse_ship_sound("$ExplosionSnd:",                    SND_SHIP_EXPLODE_1, sip);
 } 
 
-void parse_ship_particle_effect(ship_info* sip, particle_effect* pe, char *id_string)
+void parse_ship_particle_effect(ship_info* sip, particle_effect* pe, const char *id_string)
 {
 	float tempf;
 	int temp;
@@ -2279,8 +2279,8 @@ int parse_and_add_briefing_icon_info()
 int parse_ship_values(ship_info* sip, const bool is_template, const bool first_time, const bool replace)
 {
 	char buf[SHIP_MULTITEXT_LENGTH];
-	char* info_type_name;
-	char* type_name;
+	const char* info_type_name;
+	const char* type_name;
 	int rtn = 0;
 	char name_tmp[NAME_LENGTH];
 
@@ -3409,7 +3409,7 @@ int parse_ship_values(ship_info* sip, const bool is_template, const bool first_t
 		for (auto i = 0; i < num_strings; i++)
 		{
 			// get ship type from ship flags
-			char *ship_type = ship_strings[i];
+			const char *ship_type = ship_strings[i];
 			bool flag_found = false;
 
 			// Goober5000 - in retail FreeSpace, some ship classes were specified differently
@@ -4741,7 +4741,7 @@ void parse_ship_type()
 		strcpy_s(stp->name, name_buf);
 	}
 
-	char *ship_type = NULL;
+	const char *ship_type = NULL;
 	if (!stricmp(stp->name, "sentrygun")) {
 		ship_type = "sentry gun";
 	} else if (!stricmp(stp->name, "escapepod")) {
@@ -17629,7 +17629,7 @@ int armor_type_constants_get(char *str){
 #define AT_NUM_STORAGE_LOCATIONS		8
 
 //STEP 2: Add the name string to the array
-char *TypeNames[] = {
+const char *TypeNames[] = {
 	"additive",
 	"multiplicative",
 	"exponential",
@@ -17944,7 +17944,7 @@ float ArmorType::GetPiercingLimit(int damage_type_idx)
 
 //***********************************Member functions
 
-ArmorType::ArmorType(char* in_name)
+ArmorType::ArmorType(const char* in_name)
 {
 	auto len = strlen(in_name);
 	if(len >= NAME_LENGTH) {

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -214,7 +214,7 @@ private:
 
 	SCP_vector<ArmorDamageType> DamageTypes;
 public:
-	ArmorType(char* in_name);
+	ArmorType(const char* in_name);
 	int flags;
 
 	//Get

--- a/code/sound/ds.h
+++ b/code/sound/ds.h
@@ -95,7 +95,7 @@ void ds_do_frame();
 // used for const array of default values
 typedef struct EFXREVERBPROPERTIES_list
 {
-	char *name;
+	const char *name;
 	float flDensity;
 	float flDiffusion;
 	float flGain;

--- a/code/stats/medals.cpp
+++ b/code/stats/medals.cpp
@@ -182,7 +182,7 @@ int Rank_medal_index = -1;
 int Init_flags;
 
 medal_stuff::medal_stuff()
-	: num_versions(1), version_starts_at_1(false), available_from_start(false), kills_needed(0), promotion_text()
+	: num_versions(1), version_starts_at_1(false), available_from_start(false), kills_needed(0)
 {
 	name[0] = '\0';
 	bitmap[0] = '\0';
@@ -192,12 +192,6 @@ medal_stuff::medal_stuff()
 
 medal_stuff::~medal_stuff()
 {
-	SCP_map<int, char*>::iterator it;
-	for (it = promotion_text.begin(); it != promotion_text.end(); ++it) {
-		if (it->second) {
-			vm_free(it->second);
-		}
-	}
 	promotion_text.clear();
 }
 
@@ -217,26 +211,13 @@ void medal_stuff::clone(const medal_stuff &m)
 	kills_needed = m.kills_needed;
 	memcpy(voice_base, m.voice_base, MAX_FILENAME_LEN);
 
-	promotion_text.clear();
-	SCP_map<int, char*>::const_iterator it;
-	for (it = m.promotion_text.begin(); it != m.promotion_text.end(); ++it) {
-		if (it->second) {
-			promotion_text[it->first] = vm_strdup(it->second);
-		}
-	}
+	promotion_text = m.promotion_text;
 }
 
 // assignment operator
 const medal_stuff &medal_stuff::operator=(const medal_stuff &m)
 {
 	if (this != &m) {
-		SCP_map<int, char*>::iterator it;
-		for (it = promotion_text.begin(); it != promotion_text.end(); ++it) {
-			if (it->second) {
-				vm_free(it->second);
-			}
-		}
-		promotion_text.clear();
 		clone(m);
 	}
 
@@ -405,7 +386,7 @@ void parse_medal_tbl()
 							continue;
 						}
 					}
-					temp_medal.promotion_text[persona] = vm_strdup(buf);
+					temp_medal.promotion_text[persona] = SCP_string(buf);
 				}
 				if (temp_medal.promotion_text.find(-1) == temp_medal.promotion_text.end()) {
 					Warning(LOCATION, "%s medal is missing default debriefing text.\n", temp_medal.name);

--- a/code/stats/medals.h
+++ b/code/stats/medals.h
@@ -38,7 +38,7 @@ public:
 
 	//If this is a badge (kills_needed > 0)
 	char voice_base[MAX_FILENAME_LEN];
-	SCP_map<int, char*> promotion_text;
+	SCP_map<int, SCP_string> promotion_text;
 
 	medal_stuff();
 	~medal_stuff();

--- a/code/stats/scoring.cpp
+++ b/code/stats/scoring.cpp
@@ -93,7 +93,7 @@ void parse_rank_tbl()
 						continue;
 					}
 				}
-				Ranks[idx].promotion_text[persona] = vm_strdup(buf);
+				Ranks[idx].promotion_text[persona] = SCP_string(buf);
 			}
 			if (Ranks[idx].promotion_text.find(-1) == Ranks[idx].promotion_text.end()) {
 				Warning(LOCATION, "%s rank is missing default debriefing text.\n", Ranks[idx].name);
@@ -1305,11 +1305,6 @@ void scoreing_close()
 {
 	SCP_map<int, char*>::iterator it;
 	for(int i = 0; i<NUM_RANKS; i++) {
-		for (it = Ranks[i].promotion_text.begin(); it != Ranks[i].promotion_text.end(); ++it) {
-			if (it->second) {
-				vm_free(it->second);
-			}
-		}
 		Ranks[i].promotion_text.clear();
 	}
 }

--- a/code/stats/scoring.h
+++ b/code/stats/scoring.h
@@ -64,7 +64,7 @@ extern int Num_medals;
 
 typedef struct rank_stuff {
 	char		name[NAME_LENGTH];		// name of this rank
-	SCP_map<int, char*>	promotion_text;		// text to display when promoted to this rank
+	SCP_map<int, SCP_string>	promotion_text;		// text to display when promoted to this rank
 	int		points;						// points needed to reach this rank
 	char		bitmap[MAX_FILENAME_LEN];		// bitmap of this rank medal
 	char		promotion_voice_base[MAX_FILENAME_LEN];

--- a/code/ui/scroll.cpp
+++ b/code/ui/scroll.cpp
@@ -72,8 +72,8 @@ void UI_SCROLLBAR::unhide()
 
 void UI_SCROLLBAR::create(UI_WINDOW *wnd, int _x, int _y, int _h, int _start, int _stop, int _position, int _window_size)
 {
-	char *up = "^";
-	char *down = "v";
+	const char *up = "^";
+	const char *down = "v";
 	int bw = 20;
 
 	base_create( wnd, UI_KIND_SCROLLBAR, _x, _y + bw, bw, _h - bw * 2 );

--- a/code/ui/ui.h
+++ b/code/ui/ui.h
@@ -634,7 +634,7 @@ public:
 	~UI_WINDOW();	// destructor
 	void set_mask_bmap(const char *fname);
 	void set_mask_bmap(int bmap, const char *name);
-	void set_foreground_bmap(char *fname);
+	void set_foreground_bmap(const char *fname);
 	void create( int _x, int _y, int _w, int _h, int _flags, int _f_id = -1 );
 	int process( int key_in = -1,int process_mouse = 1);
 	void draw();

--- a/code/ui/uidefs.h
+++ b/code/ui/uidefs.h
@@ -29,7 +29,7 @@
 
 void ui_hline(int x1, int x2, int y );
 void ui_vline(int y1, int y2, int x );
-void ui_string_centered( int x, int y, char * s );
+void ui_string_centered( int x, int y, const char * s );
 void ui_draw_shad( int x1, int y1, int x2, int y2, int r1, int g1, int b1, int r2, int g2, int b2 );
 void ui_draw_frame( int x1, int y1, int x2, int y2 );
 void ui_rect( int x1, int y1, int x2, int y2 );

--- a/code/ui/uidraw.cpp
+++ b/code/ui/uidraw.cpp
@@ -25,7 +25,7 @@ void ui_vline(int y1, int y2, int x )
 	gr_line(x,y1,x,y2,GR_RESIZE_MENU);
 }
 
-void ui_string_centered( int x, int y, char * s )
+void ui_string_centered( int x, int y, const char * s )
 {
 	int height, width;
 

--- a/code/ui/window.cpp
+++ b/code/ui/window.cpp
@@ -124,7 +124,7 @@ void UI_WINDOW::set_mask_bmap(int bmap, const char *name)
 // Specify the filename for the mask bitmap to display on the ui window as
 // a background.
 //
-void UI_WINDOW::set_foreground_bmap(char *fname)
+void UI_WINDOW::set_foreground_bmap(const char *fname)
 {
 	// load in the background bitmap 
 	foreground_bmap_id = bm_load(fname);

--- a/code/weapon/shockwave.cpp
+++ b/code/weapon/shockwave.cpp
@@ -26,8 +26,8 @@
 // Module-wide globals
 // -----------------------------------------------------------
 
-static char *Default_shockwave_2D_filename = "shockwave01";
-static char *Default_shockwave_3D_filename = "shockwave.pof";
+static const char *Default_shockwave_2D_filename = "shockwave01";
+static const char *Default_shockwave_3D_filename = "shockwave.pof";
 static int Default_shockwave_loaded = 0;
 
 SCP_vector<shockwave_info> Shockwave_info;
@@ -416,7 +416,7 @@ void shockwave_render(object *objp, model_draw_list *scene)
 /**
  * Call to load a shockwave, or add it and then load it
  */
-int shockwave_load(char *s_name, bool shock_3D)
+int shockwave_load(const char *s_name, bool shock_3D)
 {
 	size_t i;
 	int s_index = -1;

--- a/code/weapon/shockwave.h
+++ b/code/weapon/shockwave.h
@@ -95,7 +95,7 @@ void shockwave_delete(object *objp);
 void shockwave_move_all(float frametime);
 int  shockwave_create(int parent_objnum, vec3d *pos, shockwave_create_info *sci, int flag, int delay = -1);
 void shockwave_render(object *objp, model_draw_list *scene);
-int shockwave_load(char *s_name, bool shock_3D = false);
+int shockwave_load(const char *s_name, bool shock_3D = false);
 
 int   shockwave_get_weapon_index(int index);
 float shockwave_get_min_radius(int index);

--- a/code/weapon/weapon.h
+++ b/code/weapon/weapon.h
@@ -29,7 +29,7 @@ class ship_subsys;
 #define	WP_LASER			0		// PLEASE NOTE that this flag specifies ballistic primaries as well - Goober5000
 #define	WP_MISSILE			1
 #define	WP_BEAM				2
-extern char *Weapon_subtype_names[];
+extern const char *Weapon_subtype_names[];
 extern int Num_weapon_subtypes;
 
 #define WRT_NONE	-1

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -89,12 +89,12 @@ missile_obj Missile_objs[MAX_MISSILE_OBJS];	// array used to store missile objec
 missile_obj Missile_obj_list;						// head of linked list of missile_obj structs
 
 //WEAPON SUBTYPE STUFF
-char *Weapon_subtype_names[] = {
+const char *Weapon_subtype_names[] = {
 	"Laser",
 	"Missile",
 	"Beam"
 };
-int Num_weapon_subtypes = sizeof(Weapon_subtype_names)/sizeof(char *);
+int Num_weapon_subtypes = sizeof(Weapon_subtype_names)/sizeof(Weapon_subtype_names[0]);
 
 flag_def_list_new<Weapon::Burst_Flags> Burst_fire_flags[] = {
 	{ "fast firing",		Weapon::Burst_Flags::Fast_firing,		true, false },
@@ -704,7 +704,7 @@ void parse_wi_flags(weapon_info *weaponp, flagset<Weapon::Info_Flags> wi_flags)
     }
 }
 
-void parse_shockwave_info(shockwave_create_info *sci, char *pre_char)
+void parse_shockwave_info(shockwave_create_info *sci, const char *pre_char)
 {
 	char buf[NAME_LENGTH];
 

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -208,7 +208,7 @@ extern "C" {
 //  This function is defined in code\network\multiutil.cpp so will be linked from multiutil.obj
 //  it's required fro the -missioncrcs command line option - Kazan
 void multi_spew_pxo_checksums(int max_files, const char *outfile);
-void fs2netd_spew_table_checksums(char *outfile);
+void fs2netd_spew_table_checksums(const char *outfile);
 
 extern bool frame_rate_display;
 
@@ -483,23 +483,23 @@ void game_title_screen_display();
 void game_title_screen_close();
 
 // loading background filenames
-static char *Game_loading_bground_fname[GR_NUM_RESOLUTIONS] = {
+static const char *Game_loading_bground_fname[GR_NUM_RESOLUTIONS] = {
 	"LoadingBG",		// GR_640
 	"2_LoadingBG"		// GR_1024
 };
 
 
-static char *Game_loading_ani_fname[GR_NUM_RESOLUTIONS] = {
+static const char *Game_loading_ani_fname[GR_NUM_RESOLUTIONS] = {
 	"Loading",		// GR_640
 	"2_Loading"		// GR_1024
 };
 
-static char *Game_title_screen_fname[GR_NUM_RESOLUTIONS] = {
+static const char *Game_title_screen_fname[GR_NUM_RESOLUTIONS] = {
 	"PreLoad",
 	"2_PreLoad"
 };
 
-static char *Game_logo_screen_fname[GR_NUM_RESOLUTIONS] = {
+static const char *Game_logo_screen_fname[GR_NUM_RESOLUTIONS] = {
 	"PreLoadLogo",
 	"2_PreLoadLogo"
 };


### PR DESCRIPTION
This has a few minor changes that go beyond just adding a `const`. Some of the scoring code used a  `char` pointer returned by `strdup` inside a map. However, if parsing fails a string literal is assigned to that map entry. When the map is destroyed then the memory is freed but if there was a parsing error we would now be freeing a string literal which is Not Good™.

I fixed that by storing a `SCP_string` inside the map which is the correct way of doing such a thing.

Also, since all warnings are fixed now, we no longer need to suppress these warnings so I reenabled them.