### PR TITLE
Add a lua loader that uses the CFile system

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -3,6 +3,7 @@ Checks: "-*,\
 modernize-*,\
 -modernize-raw-string-literal,\
 -modernize-use-using,\
+-modernize-make-unique,\
 performance-*,\
 -performance-type-promotion-in-math-fn,\
 misc-*,\

--- a/ci/travis/script.sh
+++ b/ci/travis/script.sh
@@ -7,8 +7,13 @@ cd build
 if [ "$TRAVIS_OS_NAME" = "linux" ]; then
     ninja -k 20 all
 
-    valgrind --leak-check=full --error-exitcode=1 --gen-suppressions=all \
-        --suppressions="$TRAVIS_BUILD_DIR/ci/travis/valgrind.supp" ./bin/unittests --gtest_shuffle
+
+    if [ "$CONFIGURATION" = "Debug" ]; then
+        valgrind --leak-check=full --error-exitcode=1 --gen-suppressions=all \
+            --suppressions="$TRAVIS_BUILD_DIR/ci/travis/valgrind.supp" ./bin/unittests --gtest_shuffle
+    else
+        ./bin/unittests --gtest_shuffle
+    fi
 elif [ "$TRAVIS_OS_NAME" = "osx" ]; then
     cmake --build . --config "$CONFIGURATION" | tee build.log | xcpretty
     XCODE_RET=${PIPESTATUS[0]}

--- a/ci/travis/valgrind.supp
+++ b/ci/travis/valgrind.supp
@@ -26,3 +26,11 @@
     fun:dl_open_worker
     fun:_dl_catch_error
 }
+{
+   CLang Lua unitialized value error
+   Memcheck:Cond
+   ...
+   fun:luaH_get
+   fun:lua_rawget
+   fun:_ZN12_GLOBAL__N_117ade_index_handlerEP9lua_State
+}

--- a/code/def_files/data/scripts/cfile_require.lua
+++ b/code/def_files/data/scripts/cfile_require.lua
@@ -1,0 +1,36 @@
+local exts = {
+    "",
+    ".lua",
+    ".lc"
+}
+
+local function cfileLoader(name)
+    local file = nil
+
+    for i,v in ipairs(exts) do
+        local real_name = name .. v
+        file = cf.openFile(real_name, "r", "data/scripts")
+
+        if (file:isValid()) then
+            name = real_name
+            break;
+        end
+    end
+
+    if (file == nil or not file:isValid()) then
+        return "Module '" .. name .. "' is not known by the CFile system"
+    end
+
+    local content = file:read("*a")
+    file:close()
+
+    local func, err = loadstring(content, name)
+
+    if err then
+        return err
+    end
+
+    return func
+end
+
+table.insert(package.loaders, 2, cfileLoader)

--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -25,6 +25,7 @@ int Default_ship_select_effect;
 int Default_weapon_select_effect;
 int Default_fiction_viewer_ui;
 bool Enable_external_shaders;
+bool Enable_external_default_scripts;
 int Default_detail_level;
 bool Full_color_head_anis;
 bool Weapons_inherit_parent_collision_group;
@@ -365,6 +366,16 @@ void parse_mod_table(const char *filename)
 			stuff_boolean(&Weapon_shockwaves_respect_huge);
 		}
 
+		if (optional_string("$Enable external default scripts:")) {
+			stuff_boolean(&Enable_external_default_scripts);
+
+			if (Enable_external_default_scripts) {
+				mprintf(("Game Settings Table: Enabled external default scripts.\n"));
+			} else {
+				mprintf(("Game Settings Table: Disabled external default scripts.\n"));
+			}
+		}
+
 		required_string("#END");
 	}
 	catch (const parse::ParseException& e)
@@ -404,6 +415,7 @@ void mod_table_reset() {
 	Default_weapon_select_effect = 2;
 	Default_fiction_viewer_ui = -1;
 	Enable_external_shaders = false;
+	Enable_external_default_scripts = false;
 	Default_detail_level = 3; // "very high" seems a reasonable default in 2012 -zookeeper
 	Full_color_head_anis = false;
 	Weapons_inherit_parent_collision_group = false;

--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -415,7 +415,7 @@ void mod_table_reset() {
 	Default_weapon_select_effect = 2;
 	Default_fiction_viewer_ui = -1;
 	Enable_external_shaders = false;
-	Enable_external_default_scripts = false;
+	Enable_external_default_scripts             = false;
 	Default_detail_level = 3; // "very high" seems a reasonable default in 2012 -zookeeper
 	Full_color_head_anis = false;
 	Weapons_inherit_parent_collision_group = false;

--- a/code/mod_table/mod_table.h
+++ b/code/mod_table/mod_table.h
@@ -19,6 +19,7 @@ extern int Default_ship_select_effect;
 extern int Default_weapon_select_effect;
 extern int Default_fiction_viewer_ui;
 extern bool Enable_external_shaders;
+extern bool Enable_external_default_scripts;
 extern int Default_detail_level;
 extern bool Full_color_head_anis;
 extern bool Weapons_inherit_parent_collision_group;

--- a/code/scripting/ade.cpp
+++ b/code/scripting/ade.cpp
@@ -1,12 +1,12 @@
 //
 //
 
+#include "scripting/ade.h"
+#include "ade_api.h"
 #include "def_files/def_files.h"
 #include "mod_table/mod_table.h"
-#include "scripting/ade.h"
 #include "scripting/lua/LuaFunction.h"
 #include "ship/ship.h"
-#include "ade_api.h"
 
 #include "ade.h"
 #include "scripting/api/objs/asteroid.h"
@@ -1004,7 +1004,8 @@ int ade_set_object_with_breed(lua_State *L, int obj_idx)
 	}
 }
 
-void load_default_script(lua_State* L, const char* name) {
+void load_default_script(lua_State* L, const char* name)
+{
 	using namespace luacpp;
 
 	SCP_string source;
@@ -1018,7 +1019,7 @@ void load_default_script(lua_State* L, const char* name) {
 
 		auto length = cfilelength(cfp);
 
-		source.resize((size_t) length);
+		source.resize((size_t)length);
 		cfread(&source[0], 1, length, cfp);
 
 		cfclose(cfp);
@@ -1038,11 +1039,11 @@ void load_default_script(lua_State* L, const char* name) {
 		try {
 			func();
 		} catch (const LuaException&) {
-			// The execution of the function may also throw an exception but that should have been handled by a LuaError before
+			// The execution of the function may also throw an exception but that should have been handled by a LuaError
+			// before
 		}
 	} catch (const LuaException& e) {
 		LuaError(L, "Error while loading default script: %s", e.what());
 	}
 }
-
 }

--- a/code/scripting/ade.cpp
+++ b/code/scripting/ade.cpp
@@ -1,7 +1,10 @@
 //
 //
 
+#include "def_files/def_files.h"
+#include "mod_table/mod_table.h"
 #include "scripting/ade.h"
+#include "scripting/lua/LuaFunction.h"
 #include "ship/ship.h"
 #include "ade_api.h"
 
@@ -998,6 +1001,47 @@ int ade_set_object_with_breed(lua_State *L, int obj_idx)
 		return ade_set_args(L, "o", l_Beam.Set(object_h(objp)));
 	default:
 		return ade_set_args(L, "o", l_Object.Set(object_h(objp)));
+	}
+}
+
+void load_default_script(lua_State* L, const char* name) {
+	using namespace luacpp;
+
+	SCP_string source;
+	SCP_string source_name;
+	if (Enable_external_default_scripts && cf_exists(name, CF_TYPE_SCRIPTS)) {
+		// Load from disk (or built-in file)
+		source_name = name;
+
+		auto cfp = cfopen(name, "rb", CFILE_NORMAL, CF_TYPE_SCRIPTS);
+		Assertion(cfp != nullptr, "Failed to open default file!");
+
+		auto length = cfilelength(cfp);
+
+		source.resize((size_t) length);
+		cfread(&source[0], 1, length, cfp);
+
+		cfclose(cfp);
+	} else {
+		// Load from default files
+		source_name = SCP_string("default ") + name;
+
+		auto def = defaults_get_file(name);
+
+		auto c = reinterpret_cast<const char*>(def.data);
+		source.assign(c, c + def.size);
+	}
+
+	try {
+		auto func = LuaFunction::createFromCode(L, source, source_name);
+		func.setErrorFunction(LuaFunction::createFromCFunction(L, ade_friendly_error));
+		try {
+			func();
+		} catch (const LuaException&) {
+			// The execution of the function may also throw an exception but that should have been handled by a LuaError before
+		}
+	} catch (const LuaException& e) {
+		LuaError(L, "Error while loading default script: %s", e.what());
 	}
 }
 

--- a/code/scripting/ade.h
+++ b/code/scripting/ade.h
@@ -357,8 +357,22 @@ const char *ade_get_type_string(lua_State *L, int argnum);
  * @return The return value of ade_set_args
  *
  * @author WMC
+ * @ingroup ade_api
  */
 int ade_set_object_with_breed(lua_State *L, int obj_idx);
+
+/**
+ * @brief Loads and executes a default lua script
+ *
+ * This uses the specified file name and either retrieves it from the default files or uses it as a file name if the mod
+ * option is enabled.
+ *
+ * @param L The lua state
+ * @param name The name of the script file
+ *
+ * @ingroup ade_api
+ */
+void load_default_script(lua_State* L, const char* name);
 }
 
 #endif //FS2_OPEN_ADE_H

--- a/code/scripting/lua.cpp
+++ b/code/scripting/lua.cpp
@@ -201,8 +201,6 @@ int script_state::CreateLuaState()
 	mprintf(("ADE: Loading default scripts...\n"));
 	load_default_script(L, "cfile_require.lua");
 
-//	(void)l_BitOps.GetName();
-
 	return 1;
 }
 

--- a/code/scripting/lua.cpp
+++ b/code/scripting/lua.cpp
@@ -197,6 +197,10 @@ int script_state::CreateLuaState()
 	mprintf(("ADE: Assigning Lua session...\n"));
 	SetLuaSession(L);
 
+	//***** LOAD DEFAULT SCRIPTS
+	mprintf(("ADE: Loading default scripts...\n"));
+	load_default_script(L, "cfile_require.lua");
+
 //	(void)l_BitOps.GetName();
 
 	return 1;

--- a/code/source_groups.cmake
+++ b/code/source_groups.cmake
@@ -209,6 +209,10 @@ add_file_folder("Default files\\\\data\\\\maps"
 	def_files/data/maps/app_icon_sse_d.png
 )
 
+add_file_folder("Default files\\\\data\\\\scripts"
+	def_files/data/scripts/cfile_require.lua
+)
+
 add_file_folder("Default files\\\\data\\\\tables"
 	def_files/data/tables/autopilot.tbl
 	def_files/data/tables/controlconfigdefaults.tbl
@@ -230,6 +234,7 @@ set(default_files_files
 	${files_Default_files_data}
 	${files_Default_files_data_effects}
 	${files_Default_files_data_maps}
+	${files_Default_files_data_scripts}
 	${files_Default_files_data_tables}
 	${files_Default_files_builtin}
 )

--- a/test/gtest/include/gtest/internal/gtest-internal.h
+++ b/test/gtest/include/gtest/internal/gtest-internal.h
@@ -1214,12 +1214,12 @@ class NativeArray {
 #define GTEST_TEST_(test_case_name, test_name, parent_class, parent_id)\
 class GTEST_TEST_CLASS_NAME_(test_case_name, test_name) : public parent_class {\
  public:\
-  GTEST_TEST_CLASS_NAME_(test_case_name, test_name)() {}\
+  GTEST_TEST_CLASS_NAME_(test_case_name, test_name)() = default;\
+  GTEST_DISALLOW_COPY_AND_ASSIGN_(\
+      GTEST_TEST_CLASS_NAME_(test_case_name, test_name));\
  private:\
   virtual void TestBody();\
   static ::testing::TestInfo* const test_info_ GTEST_ATTRIBUTE_UNUSED_;\
-  GTEST_DISALLOW_COPY_AND_ASSIGN_(\
-      GTEST_TEST_CLASS_NAME_(test_case_name, test_name));\
 };\
 \
 ::testing::TestInfo* const GTEST_TEST_CLASS_NAME_(test_case_name, test_name)\

--- a/test/gtest/include/gtest/internal/gtest-port.h
+++ b/test/gtest/include/gtest/internal/gtest-port.h
@@ -867,12 +867,12 @@ using ::std::tuple_size;
 // A macro to disallow operator=
 // This should be used in the private: declarations for a class.
 #define GTEST_DISALLOW_ASSIGN_(type)\
-  void operator=(type const &)
+  void operator=(type const &) = delete
 
 // A macro to disallow copy constructor and operator=
 // This should be used in the private: declarations for a class.
 #define GTEST_DISALLOW_COPY_AND_ASSIGN_(type)\
-  type(type const &);\
+  type(type const &) = delete;\
   GTEST_DISALLOW_ASSIGN_(type)
 
 // Tell the compiler to warn about unused return values for functions declared

--- a/test/src/scripting/require.cpp
+++ b/test/src/scripting/require.cpp
@@ -1,0 +1,18 @@
+
+#include "scripting/ScriptingTestFixture.h"
+
+class RequireTest : public test::scripting::ScriptingTestFixture {
+ public:
+	RequireTest() : test::scripting::ScriptingTestFixture(INIT_CFILE | INIT_MOD_TABLE) {
+		pushModDir("require");
+	}
+};
+
+TEST_F(RequireTest, defaultRequire) {
+	this->EvalTestScript();
+}
+
+TEST_F(RequireTest, overrideRequire) {
+	this->EvalTestScript();
+}
+

--- a/test/src/scripting/require.cpp
+++ b/test/src/scripting/require.cpp
@@ -2,17 +2,10 @@
 #include "scripting/ScriptingTestFixture.h"
 
 class RequireTest : public test::scripting::ScriptingTestFixture {
- public:
-	RequireTest() : test::scripting::ScriptingTestFixture(INIT_CFILE | INIT_MOD_TABLE) {
-		pushModDir("require");
-	}
+  public:
+	RequireTest() : test::scripting::ScriptingTestFixture(INIT_CFILE | INIT_MOD_TABLE) { pushModDir("require"); }
 };
 
-TEST_F(RequireTest, defaultRequire) {
-	this->EvalTestScript();
-}
+TEST_F(RequireTest, defaultRequire) { this->EvalTestScript(); }
 
-TEST_F(RequireTest, overrideRequire) {
-	this->EvalTestScript();
-}
-
+TEST_F(RequireTest, overrideRequire) { this->EvalTestScript(); }

--- a/test/src/source_groups.cmake
+++ b/test/src/source_groups.cmake
@@ -34,6 +34,7 @@ add_file_folder("Parse"
 
 add_file_folder("Scripting"
     scripting/ade_args.cpp
+    scripting/require.cpp
     scripting/ScriptingTestFixture.h
     scripting/ScriptingTestFixture.cpp
 )

--- a/test/src/util/FSTestFixture.cpp
+++ b/test/src/util/FSTestFixture.cpp
@@ -3,13 +3,13 @@
 
 #include "FSTestFixture.h"
 
-#include <osapi/outwnd.h>
 #include <cmdline/cmdline.h>
 #include <graphics/2d.h>
-#include <ship/ship.h>
 #include <io/timer.h>
 #include <localization/localize.h>
 #include <mod_table/mod_table.h>
+#include <osapi/outwnd.h>
+#include <ship/ship.h>
 
 test::FSTestFixture::FSTestFixture(uint64_t init_flags) : testing::Test(), _initFlags(init_flags) {
 	addCommandlineArg("-parse_cmdline_only");
@@ -48,7 +48,7 @@ void test::FSTestFixture::SetUp() {
 		lcl_xstr_init();
 
 		if (_initFlags & INIT_MOD_TABLE) {
-			mod_table_init();		// load in all the mod dependent settings
+			mod_table_init(); // load in all the mod dependent settings
 		}
 
 		if (_initFlags & INIT_GRAPHICS) {

--- a/test/src/util/FSTestFixture.cpp
+++ b/test/src/util/FSTestFixture.cpp
@@ -9,6 +9,7 @@
 #include <ship/ship.h>
 #include <io/timer.h>
 #include <localization/localize.h>
+#include <mod_table/mod_table.h>
 
 test::FSTestFixture::FSTestFixture(uint64_t init_flags) : testing::Test(), _initFlags(init_flags) {
 	addCommandlineArg("-parse_cmdline_only");
@@ -45,6 +46,10 @@ void test::FSTestFixture::SetUp() {
 
 		lcl_init(-1);
 		lcl_xstr_init();
+
+		if (_initFlags & INIT_MOD_TABLE) {
+			mod_table_init();		// load in all the mod dependent settings
+		}
 
 		if (_initFlags & INIT_GRAPHICS) {
 			if (!gr_init(nullptr, GR_STUB, 1024, 768)) {

--- a/test/test_data/scripting/require/defaultRequire/data/scripts/lib.lua
+++ b/test/test_data/scripting/require/defaultRequire/data/scripts/lib.lua
@@ -1,0 +1,8 @@
+
+local lib = {}
+
+function lib.test()
+    return "TestString"
+end
+
+return lib

--- a/test/test_data/scripting/require/defaultRequire/data/scripts/test.lua
+++ b/test/test_data/scripting/require/defaultRequire/data/scripts/test.lua
@@ -1,0 +1,4 @@
+
+local lib = require("lib");
+
+assert(lib.test() == "TestString")

--- a/test/test_data/scripting/require/overrideRequire/data/scripts/cfile_require.lua
+++ b/test/test_data/scripting/require/overrideRequire/data/scripts/cfile_require.lua
@@ -1,0 +1,9 @@
+
+
+local function cfileLoader(name)
+    return function()
+        return "Overridden loader"
+    end
+end
+
+table.insert(package.loaders, 2, cfileLoader)

--- a/test/test_data/scripting/require/overrideRequire/data/scripts/test.lua
+++ b/test/test_data/scripting/require/overrideRequire/data/scripts/test.lua
@@ -1,0 +1,4 @@
+
+local lib = require("lib");
+
+assert(lib == "Overridden loader")

--- a/test/test_data/scripting/require/overrideRequire/data/tables/scripting-mod.tbm
+++ b/test/test_data/scripting/require/overrideRequire/data/tables/scripting-mod.tbm
@@ -1,0 +1,4 @@
+
+$Enable external default scripts: true
+
+#End


### PR DESCRIPTION
This allows to use the built-in lua "require" function with our file
system. This will help organize complicated scripts and it will also
allow to use libraries which were designed for this system.

To enable this change, this includes a new mechanism which allows to
load scripts from the default file system so that the files don't need
to be included in every mod. The default files can be overridden by a
mod if a special mod-table option has been set, similar to how external
shaders are handled right now.