### PR TITLE
Fix off-by-one error in script_state::EvalString

### DIFF
--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -21986,7 +21986,7 @@ int sexp_script_eval(int node, int return_type, bool concat_args = false)
 			{
 				char* s = CTEXT(n);
 				int r = -1;
-				bool success = Script_system.EvalString(CTEXT(n), "|i", &r);
+				bool success = Script_system.EvalString(s, "|i", &r);
 
 				if(!success)
 					Warning(LOCATION, "sexp-script-eval failed to evaluate string \"%s\"; check your syntax", s);

--- a/code/scripting/scripting.cpp
+++ b/code/scripting/scripting.cpp
@@ -1087,7 +1087,7 @@ bool script_state::EvalString(const char *string, const char *format, void *rtn,
 				auto val = ret.front();
 				val.pushValue();
 
-				Ade_get_args_skip = stack_start+1;
+				Ade_get_args_skip = stack_start;
 				Ade_get_args_lfunction = true;
 				ade_get_args(LuaState, format, rtn);
 				Ade_get_args_skip = 0;


### PR DESCRIPTION
This also fixes a small inefficiency in sexp_script_eval.

This fixes #1139.