### PR TITLE
Fix gr_print_timestamp() to actually display timestamps properly.

### DIFF
--- a/code/graphics/2d.cpp
+++ b/code/graphics/2d.cpp
@@ -2254,12 +2254,14 @@ uint gr_determine_model_shader_flags(
 	return shader_flags;
 }
 
-void gr_print_timestamp(int x, int y, int timestamp, int resize_mode)
+void gr_print_timestamp(int x, int y, fix timestamp, int resize_mode)
 {
 	char time[8];
 
+	int seconds = fl2i(f2fl(timestamp));
+
 	// format the time information into strings
-	sprintf(time, "%.1d:%.2d:%.2d", (timestamp / 3600000) % 10, (timestamp / 60000) % 60, (timestamp / 1000) % 60);
+	sprintf(time, "%.1d:%.2d:%.2d", (seconds / 3600) % 10, (seconds / 60) % 60, seconds % 60);
 	time[7] = '\0';
 
 	gr_string(x, y, time, resize_mode);

--- a/code/graphics/2d.h
+++ b/code/graphics/2d.h
@@ -1245,10 +1245,10 @@ void gr_pline_special(SCP_vector<vec3d> *pts, int thickness,int resize_mode=GR_R
 *
 * @param x The x position where the timestamp should be draw
 * @param y The y position where the timestamp should be draw
-* @param timestamp The timespamp in milliseconds to be printed
+* @param timestamp The timestamp (in 65536ths of a second) to be printed
 * @param resize_mode The resize mode to use
 */
-void gr_print_timestamp(int x, int y, int timestamp, int resize_mode);
+void gr_print_timestamp(int x, int y, fix timestamp, int resize_mode);
 
 namespace graphics {
 class DebugScope {


### PR DESCRIPTION
When the function was rewritten as part of the TrueType PR, its logic was also unintentionally changed so that it expected timestamps in milliseconds when everything calling it provides "fix"es, which represent 65536ths of a second.

Fixes #1142.