### PR TITLE
Removed unnecessary conditional when making render targets.

### DIFF
--- a/code/graphics/opengl/gropenglbmpman.cpp
+++ b/code/graphics/opengl/gropenglbmpman.cpp
@@ -124,11 +124,7 @@ int gr_opengl_bm_make_render_target(int n, int *width, int *height, int *bpp, in
 	if ( Cmdline_no_fbo ) {
 		return 0;
 	}
-
-	if ( (flags & BMP_FLAG_CUBEMAP) ) {
-		return 0;
-	}
-
+	
 	if ( (flags & BMP_FLAG_CUBEMAP) && (*width != *height) ) {
 		MIN(*width, *height) = MAX(*width, *height);
 	}


### PR DESCRIPTION
It looks like this conditional needed to be removed entirely when we removed code that checked for certain OpenGL extensions. This prevented render targets for environment cube maps from being generated. 

Fixes https://github.com/scp-fs2open/fs2open.github.com/issues/900