### PR TITLE
Make shortcuts for Warning/Errors consistent

### DIFF
--- a/code/osapi/dialogs.cpp
+++ b/code/osapi/dialogs.cpp
@@ -402,8 +402,8 @@ namespace os
 			boxMessage += "\n\nUse Debug to break into Debugger\n";
 
 			const SDL_MessageBoxButtonData buttons[] = {
-				{ SDL_MESSAGEBOX_BUTTON_ESCAPEKEY_DEFAULT, 2, "Exit" },
-				{ SDL_MESSAGEBOX_BUTTON_RETURNKEY_DEFAULT, 1, "Continue" },
+				{ SDL_MESSAGEBOX_BUTTON_RETURNKEY_DEFAULT, 2, "Exit" },
+				{ SDL_MESSAGEBOX_BUTTON_ESCAPEKEY_DEFAULT, 1, "Continue" },
 				{ /* .flags, .buttonid, .text */        0, 0, "Debug" },
 			};
 


### PR DESCRIPTION
LuaError, Error & Warning use RETURN for Exit
LuaError & Warning use ESCAPE for Continue