### PR TITLE
Unify version string handling

### DIFF
--- a/code/cmdline/cmdline.cpp
+++ b/code/cmdline/cmdline.cpp
@@ -785,12 +785,7 @@ void os_validate_parms(int argc, char *argv[])
 			if (parm_found == 0) {
 				// if we got a -help, --help, -h, or -? then show the help text, otherwise show unknown option
 				if (!stricmp(token, "-help") || !stricmp(token, "--help") || !stricmp(token, "-h") || !stricmp(token, "-?")) {
-					if (FS_VERSION_HAS_REVIS == 0) {
-						printf("FreeSpace 2 Open, version %i.%i.%i\n", FS_VERSION_MAJOR, FS_VERSION_MINOR, FS_VERSION_BUILD);
-					}
-					else {
-						printf("FreeSpace 2 Open, version %i.%i.%i.%i\n", FS_VERSION_MAJOR, FS_VERSION_MINOR, FS_VERSION_BUILD, FS_VERSION_REVIS);
-					}
+					printf("FreeSpace 2 Open, version %s\n", FS_VERSION_FULL);
 					printf("Website: http://scp.indiegames.us\n");
 					printf("Mantis (bug reporting): http://scp.indiegames.us/mantis/\n\n");
 					printf("Usage: fs2_open [options]\n");

--- a/code/debugconsole/console.cpp
+++ b/code/debugconsole/console.cpp
@@ -306,7 +306,7 @@ void dc_init(void)
 	dc_command_buf.reserve(MAX_CLI_LEN);
 	dc_command_buf.clear();
 
-	sprintf(dc_title, "FreeSpace Open v%i.%i.%i", FS_VERSION_MAJOR, FS_VERSION_MINOR, FS_VERSION_BUILD);
+	sprintf(dc_title, "FreeSpace Open v%s", FS_VERSION_FULL);
 	dc_printf("Debug console started.\n" );
 }
 

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -33831,24 +33831,9 @@ bool output_sexps(const char *filepath)
 	}
 
 	//Header
-	if (FS_VERSION_BUILD == 0 && FS_VERSION_HAS_REVIS == 0) //-V547
-	{
-		fprintf(fp, "<html>\n<head>\n\t<title>SEXP Output - FSO v%i.%i</title>\n</head>\n", FS_VERSION_MAJOR, FS_VERSION_MINOR);
-		fputs("<body>", fp);
-		fprintf(fp,"\t<h1>SEXP Output - FSO v%i.%i</h1>\n", FS_VERSION_MAJOR, FS_VERSION_MINOR);
-	}
-	else if (FS_VERSION_HAS_REVIS == 0)
-	{
-		fprintf(fp, "<html>\n<head>\n\t<title>SEXP Output - FSO v%i.%i.%i</title>\n</head>\n", FS_VERSION_MAJOR, FS_VERSION_MINOR, FS_VERSION_BUILD);
-		fputs("<body>", fp);
-		fprintf(fp,"\t<h1>SEXP Output - FSO v%i.%i.%i</h1>\n", FS_VERSION_MAJOR, FS_VERSION_MINOR, FS_VERSION_BUILD);
-	}
-	else
-	{
-		fprintf(fp, "<html>\n<head>\n\t<title>SEXP Output - FSO v%i.%i.%i.%i</title>\n</head>\n", FS_VERSION_MAJOR, FS_VERSION_MINOR, FS_VERSION_BUILD, FS_VERSION_REVIS);
-		fputs("<body>", fp);
-		fprintf(fp,"\t<h1>SEXP Output - FSO v%i.%i.%i.%i</h1>\n", FS_VERSION_MAJOR, FS_VERSION_MINOR, FS_VERSION_BUILD, FS_VERSION_REVIS);
-	}
+	fprintf(fp, "<html>\n<head>\n\t<title>SEXP Output - FSO v%s</title>\n</head>\n", FS_VERSION_FULL);
+	fputs("<body>", fp);
+	fprintf(fp,"\t<h1>SEXP Output - FSO v%s</h1>\n", FS_VERSION_FULL);
 
 	SCP_vector<int> done_sexp_ids;
 	int x,y,z;

--- a/code/scripting/scripting.cpp
+++ b/code/scripting/scripting.cpp
@@ -968,24 +968,9 @@ int script_state::OutputMeta(const char *filename)
 		return 0; 
 	}
 
-	if (FS_VERSION_BUILD == 0 && FS_VERSION_HAS_REVIS == 0) //-V547
-	{
-		fprintf(fp, "<html>\n<head>\n\t<title>Script Output - FSO v%i.%i (%s)</title>\n</head>\n", FS_VERSION_MAJOR, FS_VERSION_MINOR, StateName);
-		fputs("<body>", fp);
-		fprintf(fp,"\t<h1>Script Output - FSO v%i.%i (%s)</h1>\n", FS_VERSION_MAJOR, FS_VERSION_MINOR, StateName);
-	}
-	else if (FS_VERSION_HAS_REVIS == 0)
-	{
-		fprintf(fp, "<html>\n<head>\n\t<title>Script Output - FSO v%i.%i.%i (%s)</title>\n</head>\n", FS_VERSION_MAJOR, FS_VERSION_MINOR, FS_VERSION_BUILD, StateName);
-		fputs("<body>", fp);
-		fprintf(fp,"\t<h1>Script Output - FSO v%i.%i.%i (%s)</h1>\n", FS_VERSION_MAJOR, FS_VERSION_MINOR, FS_VERSION_BUILD, StateName);
-	}
-	else
-	{
-		fprintf(fp, "<html>\n<head>\n\t<title>Script Output - FSO v%i.%i.%i.%i (%s)</title>\n</head>\n", FS_VERSION_MAJOR, FS_VERSION_MINOR, FS_VERSION_BUILD, FS_VERSION_REVIS, StateName);
-		fputs("<body>", fp);
-		fprintf(fp,"\t<h1>Script Output - FSO v%i.%i.%i.%i (%s)</h1>\n", FS_VERSION_MAJOR, FS_VERSION_MINOR, FS_VERSION_BUILD, FS_VERSION_REVIS, StateName);
-	}
+	fprintf(fp, "<html>\n<head>\n\t<title>Script Output - FSO v%s (%s)</title>\n</head>\n", FS_VERSION_FULL, StateName);
+	fputs("<body>", fp);
+	fprintf(fp,"\t<h1>Script Output - FSO v%s (%s)</h1>\n", FS_VERSION_FULL, StateName);
 		
 	//Scripting languages links
 	fputs("<dl>", fp);

--- a/fred2/fredstubs.cpp
+++ b/fred2/fredstubs.cpp
@@ -210,7 +210,6 @@ void game_shudder_apply(int, float){}
 int game_hacked_data(){return 0;}
 int game_single_step;
 int last_single_step;
-void get_version_string_short(char *){}
 void game_tst_mark(class object *, class ship *){}
 int tst;
 //int Player_multi_died_check;

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -1700,11 +1700,7 @@ void game_init()
 	}
 
 #ifndef NDEBUG
-	#if FS_VERSION_HAS_REVIS == 0
-		mprintf(("FreeSpace 2 Open version: %i.%i.%i\n", FS_VERSION_MAJOR, FS_VERSION_MINOR, FS_VERSION_BUILD));
-	#else
-		mprintf(("FreeSpace 2 Open version: %i.%i.%i.%i\n", FS_VERSION_MAJOR, FS_VERSION_MINOR, FS_VERSION_BUILD, FS_VERSION_REVIS));
-	#endif
+	mprintf(("FreeSpace 2 Open version: %s\n", FS_VERSION_FULL));
 
 	extern void cmdline_debug_print_cmdline();
 	cmdline_debug_print_cmdline();
@@ -7544,11 +7540,7 @@ void get_version_string(char *str, int max_size)
 //XSTR:OFF
 	Assert( max_size > 6 );
 
-	#if FS_VERSION_HAS_REVIS == 0
-		sprintf(str, "FreeSpace 2 Open v%i.%i.%i", FS_VERSION_MAJOR, FS_VERSION_MINOR, FS_VERSION_BUILD);
-	#else
-		sprintf(str, "FreeSpace 2 Open v%i.%i.%i.%i", FS_VERSION_MAJOR, FS_VERSION_MINOR, FS_VERSION_BUILD, FS_VERSION_REVIS);
-	#endif
+	sprintf(str, "FreeSpace 2 Open v%s", FS_VERSION_FULL);
 
 #ifndef NDEBUG
 	strcat_s( str, max_size, " Debug" );
@@ -7561,18 +7553,6 @@ void get_version_string(char *str, int max_size)
 			strcat_s( str, max_size, " OpenGL" );
 			break;
 	}
-
-	// if a custom identifier exists, put it at the very end
-	#ifdef FS_VERSION_IDENT
-		strcat_s( str, max_size, " (" );
-		strcat_s( str, max_size, FS_VERSION_IDENT );
-		strcat_s( str, max_size, ")" );
-	#endif
-}
-
-void get_version_string_short(char *str)
-{
-	sprintf(str,"v%d.%d", FS_VERSION_MAJOR, FS_VERSION_MINOR);
 }
 
 // ----------------------------------------------------------------

--- a/test/src/test_stubs.cpp
+++ b/test/src/test_stubs.cpp
@@ -218,7 +218,6 @@ void game_shudder_apply(int, float){}
 int game_hacked_data(){return 0;}
 int game_single_step;
 int last_single_step;
-void get_version_string_short(char *){}
 void game_tst_mark(class object *, class ship *){}
 int tst;
 //int Player_multi_died_check;


### PR DESCRIPTION
Currently there are multiple locations in the code where the version is
constructed by printing the individual numbers together. This is mostly
sufficient but it hides information such as the commit hash or the build
name (e.g. RC1). These changes unify that behavior by always using the
version string generated by CMake.