### PR TITLE
Fixes an assertion due to insufficient amount of hats

### DIFF
--- a/code/io/joy-sdl.cpp
+++ b/code/io/joy-sdl.cpp
@@ -902,27 +902,7 @@ int joy_down_count(int btn, int reset_count)
 
 int joy_down(int btn)
 {
-	if (btn < 0) return 0;
-
 	auto current = io::joystick::getCurrentJoystick();
 
-	if (current == nullptr)
-	{
-		return 0;
-	}
-
-	if (btn >= JOY_TOTAL_BUTTONS || (btn >= current->numButtons() && btn < JOY_NUM_BUTTONS))
-	{
-		// Not a valid button
-		return 0;
-
-	}
-	else if (btn >= JOY_NUM_BUTTONS)
-	{
-		// Is hat
-		return current->getHatDownTime(0, hatBtnToEnum(btn), false) > 0;
-	} // Else, is a button
-
-
-	return current->isButtonDown(btn) ? 1 : 0;
+	return current->getButtonDownTime(btn) > 0.0f;
 }

--- a/code/io/joy-sdl.cpp
+++ b/code/io/joy-sdl.cpp
@@ -902,7 +902,5 @@ int joy_down_count(int btn, int reset_count)
 
 int joy_down(int btn)
 {
-	auto current = io::joystick::getCurrentJoystick();
-
-	return current->getButtonDownTime(btn) > 0.0f;
+	return joy_down_time(btn) > 0.0f;
 }


### PR DESCRIPTION
The logic for joy_down was missing a safety check, which could cause an assertion in Joystick::getHatDownTime if a joystick without a hat (or no joystick at all?) was attached. Was reported by Bryan See here: http://www.hard-light.net/forums/index.php?topic=93045.msg1839250#new