### PR TITLE
Fix a few minor issues with the new debug window

### DIFF
--- a/code/cmdline/cmdline.cpp
+++ b/code/cmdline/cmdline.cpp
@@ -240,6 +240,7 @@ Flag exe_params[] =
 	{ "-json_pilot",		"Dump pilot files in JSON format",			true,	0,					EASY_DEFAULT,		"Dev Tool",		"http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-json_pilot", },
 	{ "-json_profiling",	"Generate JSON profiling output",			true,	0,					EASY_DEFAULT,		"Dev Tool",		"http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-json_profiling", },
 	{ "-profile_frame_time","Profile engine subsystems",				true,	0,					EASY_DEFAULT,		"Dev Tool",		"http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-profile_frame_timings", },
+	{ "-debug_window",		"Enable the debug window",					true,	0,					EASY_DEFAULT,		"Dev Tool",		"http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-debug_window", },
 };
 
 // forward declaration

--- a/code/graphics/2d.h
+++ b/code/graphics/2d.h
@@ -907,7 +907,7 @@ extern void gr_activate(int active);
 #define gr_print_screen		GR_CALL(gr_screen.gf_print_screen)
 
 //#define gr_flip				GR_CALL(gr_screen.gf_flip)
-void gr_flip(bool execute_scripting = false);
+void gr_flip(bool execute_scripting = true);
 
 //#define gr_set_clip			GR_CALL(gr_screen.gf_set_clip)
 __inline void gr_set_clip(int x, int y, int w, int h, int resize_mode=GR_RESIZE_FULL)

--- a/code/osapi/DebugWindow.cpp
+++ b/code/osapi/DebugWindow.cpp
@@ -41,14 +41,20 @@ DebugWindow::DebugWindow() {
 
 	SDL_Rect size;
 	SDL_GetDisplayBounds(display, &size);
-	attrs.width = (uint32_t) size.w;
-	attrs.height = (uint32_t) size.h - 40; // Reduce the height a bit to account for window decorations
+	// Make the window a bit smaller so that it doesn't take up the whole screen
+	attrs.width = (uint32_t) (size.w / 1.3f);
+	attrs.height = (uint32_t) (size.h / 1.3f);
 
 	attrs.title = "FreeSpace Open - Debug Window";
+
+	attrs.flags.set(os::ViewPortFlags::Resizeable); // Make this window resizeable
 
 	auto debugView = gr_create_viewport(attrs);
 	if (debugView) {
 		debug_view = os::addViewport(std::move(debugView));
+	}
+	if (debug_view->toSDLWindow() != nullptr && os::getSDLMainWindow() != nullptr) {
+		SDL_RaiseWindow(os::getSDLMainWindow());
 	}
 }
 

--- a/code/osapi/osapi.h
+++ b/code/osapi/osapi.h
@@ -178,6 +178,7 @@ namespace os
 	{
 		Fullscreen = 0,
 		Borderless,
+		Resizeable,
 
 		NUM_VALUES
 	};

--- a/freespace2/SDLGraphicsOperations.cpp
+++ b/freespace2/SDLGraphicsOperations.cpp
@@ -159,6 +159,9 @@ std::unique_ptr<os::Viewport> SDLGraphicsOperations::createViewport(const os::Vi
 	if (props.flags[os::ViewPortFlags::Fullscreen]) {
 		windowflags |= SDL_WINDOW_FULLSCREEN;
 	}
+	if (props.flags[os::ViewPortFlags::Resizeable]) {
+		windowflags |= SDL_WINDOW_RESIZABLE;
+	}
 
 	SDL_Window* window = SDL_CreateWindow(props.title.c_str(),
 										  SDL_WINDOWPOS_CENTERED_DISPLAY(props.display),


### PR DESCRIPTION
This makes the debug window resizable and also reduces the default size
to ~80% of the used display. This also makes sure that the main window
has input focus after the debug window was created.