### PR TITLE
Fixes two crashes in red-alert missions, cleans up and refactors some of the docking code

### DIFF
--- a/code/missionui/redalert.cpp
+++ b/code/missionui/redalert.cpp
@@ -781,20 +781,18 @@ void red_alert_store_wingman_status()
 void red_alert_delete_ship(int shipnum, int ship_state)
 {
 	ship* shipp = &Ships[shipnum];
+	int cleanup_mode;	// See ship.h for cleanup mode defines. SHIP_VANISHED etc.
 
-	int cleanup_mode = SHIP_REDALERT;	// See ship.h for cleanup mode defines
 	switch (ship_state) {
 	case RED_ALERT_DESTROYED_SHIP_CLASS:
-		cleanup_mode |= SHIP_DESTROYED;
+		cleanup_mode = SHIP_DESTROYED_REDALERT;
 		break;
 	case RED_ALERT_PLAYER_DEL_SHIP_CLASS:
-		cleanup_mode |= SHIP_DEPARTED;
+		cleanup_mode = SHIP_DEPARTED_REDALERT;
 		break;
 	default:
-#ifdef DEBUG
-		Warning(LOCATION, "Red-alert: Unknown delete state, assuming vanished.");
-#endif
-		cleanup_mode |= SHIP_VANISHED;
+		Assertion(false, "Red-alert: Unknown delete state '%i'\n", ship_state);
+		cleanup_mode = SHIP_VANISHED;
 		break;
 	}
 

--- a/code/missionui/redalert.cpp
+++ b/code/missionui/redalert.cpp
@@ -29,6 +29,8 @@
 #include "missionui/redalert.h"
 #include "mod_table/mod_table.h"
 #include "model/model.h"
+#include "object/deadobjectdock.h"
+#include "object/objectdock.h"
 #include "ship/ship.h"
 #include "sound/audiostr.h"
 #include "sound/fsspeech.h"
@@ -787,6 +789,10 @@ void red_alert_delete_ship(ship *shipp, int ship_state)
 			Error(LOCATION, "Red Alert: asked to delete ship (%s) with invalid ship state (%d)", shipp->ship_name, ship_state);
 		}
 	}
+
+	// If this ship is docked with anybody, undock them all before deleting
+	dock_undock_all(&Objects[shipp->objnum]);
+	dock_dead_undock_all(&Objects[shipp->objnum]);
 
 	ship_add_exited_ship( shipp, Ship::Exit_Flags::Player_deleted );
 	obj_delete(shipp->objnum);

--- a/code/missionui/redalert.cpp
+++ b/code/missionui/redalert.cpp
@@ -781,43 +781,25 @@ void red_alert_store_wingman_status()
 void red_alert_delete_ship(int shipnum, int ship_state)
 {
 	ship* shipp = &Ships[shipnum];
-	if ( (shipp->wing_status_wing_index >= 0) && (shipp->wing_status_wing_pos >= 0) ) {
-		if (ship_state == RED_ALERT_DESTROYED_SHIP_CLASS) {
-		hud_set_wingman_status_dead(shipp->wing_status_wing_index, shipp->wing_status_wing_pos);
-		} else if (ship_state == RED_ALERT_PLAYER_DEL_SHIP_CLASS) {
-			hud_set_wingman_status_none(shipp->wing_status_wing_index, shipp->wing_status_wing_pos);
-		} else {
-			Error(LOCATION, "Red Alert: asked to delete ship (%s) with invalid ship state (%d)", shipp->ship_name, ship_state);
-		}
-	}
 
-	// If this ship is docked with anybody, undock them all before deleting
-	dock_undock_all(&Objects[shipp->objnum]);
-	dock_dead_undock_all(&Objects[shipp->objnum]);
-
-	int cleanup_mode;	// See ship.h for cleanup mode defines (SHIP_VANISHED)
+	int cleanup_mode = SHIP_REDALERT;	// See ship.h for cleanup mode defines
 	switch (ship_state) {
 	case RED_ALERT_DESTROYED_SHIP_CLASS:
-		cleanup_mode = SHIP_DESTROYED;
+		cleanup_mode |= SHIP_DESTROYED;
 		break;
 	case RED_ALERT_PLAYER_DEL_SHIP_CLASS:
-		cleanup_mode = SHIP_DEPARTED;
+		cleanup_mode |= SHIP_DEPARTED;
 		break;
 	default:
-		cleanup_mode = SHIP_VANISHED;
+#ifdef DEBUG
+		Warning(LOCATION, "Red-alert: Unknown delete state, assuming vanished.");
+#endif
+		cleanup_mode |= SHIP_VANISHED;
 		break;
 	}
 
 	Objects[shipp->objnum].flags.set(Object::Object_Flags::Should_be_dead);
 	ship_cleanup(shipnum, cleanup_mode);
-	/*
-	ship_add_exited_ship( shipp, exit_flag );
-
-	obj_delete(shipp->objnum);
-	if ( shipp->wingnum >= 0 ) {
-		ship_wing_cleanup( SHIP_INDEX(shipp), &Wings[shipp->wingnum] );
-	}
-	*/
 }
 
 // just mark the parse object as never going to arrive

--- a/code/object/deadobjectdock.cpp
+++ b/code/object/deadobjectdock.cpp
@@ -73,22 +73,17 @@ void dock_dead_undock_objects(object *objp1, object *objp2)
 	Assert(objp1 != NULL);
 	Assert(objp2 != NULL);
 
-#ifndef NDEBUG
-	if ((dead_dock_find_instance(objp1, objp2) == NULL) || (dead_dock_find_instance(objp2, objp1) == NULL))
-	{
-		Error(LOCATION, "Trying to undock an object that isn't docked!\n");
-	}
-#endif
-
 	// remove objects from each others' dock lists
 	dead_dock_remove_instance(objp1, objp2);
 	dead_dock_remove_instance(objp2, objp1);
 }
 
-void dock_dead_undock_all(object *objp) {
+void dock_dead_undock_all(object *objp)
+{
 	Assert(objp != NULL);
 
-	while (object_is_dead_docked(objp)) {
+	while (object_is_dead_docked(objp))
+	{
 		object* dockee = dock_get_first_dead_docked_object(objp);
 
 		dock_dead_undock_objects(objp, dockee);
@@ -148,6 +143,16 @@ void dead_dock_remove_instance(object *objp, object *other_objp)
 
 		// delete it
 		vm_free(ptr);
+	}
+	else
+	{
+		// Raise an error if we're in a release build.
+		// Raise a warning if we're in a debug build, the user may be doing something silly
+#ifndef NDEBUG
+		Error(LOCATION, "Tried to undock an object that isn't docked!\n");
+#else
+		Warning(LOCATION, "Tried to undock an object that isn't docked! Proceed with caution!\n");
+#endif
 	}
 }
 

--- a/code/object/deadobjectdock.cpp
+++ b/code/object/deadobjectdock.cpp
@@ -23,6 +23,8 @@ dock_instance *dead_dock_find_instance(object *objp, int dockpoint);
 
 object *dock_get_first_dead_docked_object(object *objp)
 {
+	Assert(objp != NULL);
+
 	// are we docked?
 	if (!object_is_dead_docked(objp))
 		return NULL;
@@ -32,6 +34,9 @@ object *dock_get_first_dead_docked_object(object *objp)
 
 int dock_find_dead_dockpoint_used_by_object(object *objp, object *other_objp)
 {
+	Assert(objp != NULL);
+	Assert(other_objp != NULL);
+
 	dock_instance *result = dead_dock_find_instance(objp, other_objp);
 	
 	if (result == NULL)
@@ -43,6 +48,9 @@ int dock_find_dead_dockpoint_used_by_object(object *objp, object *other_objp)
 // dock management functions -------------------------------------------------------------------------------------
 void dock_dead_dock_objects(object *objp1, int dockpoint1, object *objp2, int dockpoint2)
 {
+	Assert(objp1 != NULL);
+	Assert(objp2 != NULL);
+
 #ifndef NDEBUG
 	if ((dead_dock_find_instance(objp1, objp2) != NULL) || (dead_dock_find_instance(objp2, objp1) != NULL))
 	{
@@ -62,6 +70,9 @@ void dock_dead_dock_objects(object *objp1, int dockpoint1, object *objp2, int do
 
 void dock_dead_undock_objects(object *objp1, object *objp2)
 {
+	Assert(objp1 != NULL);
+	Assert(objp2 != NULL);
+
 #ifndef NDEBUG
 	if ((dead_dock_find_instance(objp1, objp2) == NULL) || (dead_dock_find_instance(objp2, objp1) == NULL))
 	{
@@ -72,6 +83,16 @@ void dock_dead_undock_objects(object *objp1, object *objp2)
 	// remove objects from each others' dock lists
 	dead_dock_remove_instance(objp1, objp2);
 	dead_dock_remove_instance(objp2, objp1);
+}
+
+void dock_dead_undock_all(object *objp) {
+	Assert(objp != NULL);
+
+	while (objp->dock_list != NULL) {
+		object* dockee = objp->dock_list->docked_objp;
+
+		dock_dead_undock_objects(objp, dockee);
+	}
 }
 
 void dead_dock_add_instance(object *objp, int dockpoint, object *other_objp)
@@ -133,6 +154,8 @@ void dead_dock_remove_instance(object *objp, object *other_objp)
 // just free the list without worrying about undocking anything
 void dock_free_dead_dock_list(object *objp)
 {
+	Assert(objp != NULL);
+
 	while (objp->dead_dock_list != NULL)
 	{
 		dock_instance *ptr = objp->dead_dock_list;

--- a/code/object/deadobjectdock.cpp
+++ b/code/object/deadobjectdock.cpp
@@ -88,8 +88,8 @@ void dock_dead_undock_objects(object *objp1, object *objp2)
 void dock_dead_undock_all(object *objp) {
 	Assert(objp != NULL);
 
-	while (objp->dock_list != NULL) {
-		object* dockee = objp->dock_list->docked_objp;
+	while (object_is_dead_docked(objp)) {
+		object* dockee = dock_get_first_dead_docked_object(objp);
 
 		dock_dead_undock_objects(objp, dockee);
 	}

--- a/code/object/deadobjectdock.cpp
+++ b/code/object/deadobjectdock.cpp
@@ -146,13 +146,8 @@ void dead_dock_remove_instance(object *objp, object *other_objp)
 	}
 	else
 	{
-		// Raise an error if we're in a release build.
-		// Raise a warning if we're in a debug build, the user may be doing something silly
-#ifndef NDEBUG
-		Error(LOCATION, "Tried to undock an object that isn't docked!\n");
-#else
-		Warning(LOCATION, "Tried to undock an object that isn't docked! Proceed with caution!\n");
-#endif
+		// Trigger assertion. We can recover from this, thankfully
+		Assertion(false, "Tried to undock an object that isn't dead docked!\n");
 	}
 }
 

--- a/code/object/deadobjectdock.h
+++ b/code/object/deadobjectdock.h
@@ -25,6 +25,12 @@ void dock_dead_dock_objects(object *objp1, int dockpoint1, object *objp2, int do
 // remove objp1 and objp2 from each others' dock lists; currently called by do_dying_undock_physics and ship_cleanup
 void dock_dead_undock_objects(object *objp1, object *objp2);
 
+/**
+ * @brief Undocks all dead docks.
+ * @note This is a slow method. Use dock_free_dead_dock_list() when doing object cleanup
+ */
+void dock_dead_undock_all(object *objp);
+
 // free the entire dock list without undocking anything; should only be used on object cleanup
 void dock_free_dead_dock_list(object *objp);
 

--- a/code/object/object.h
+++ b/code/object/object.h
@@ -304,9 +304,37 @@ void obj_client_post_interpolate();
 // move an observer object in multiplayer
 void obj_observer_move(float frame_time);
 
-// Goober5000
+/**
+ * @brief Checks if the given object is docked with anyone.
+ *
+ * @returns Nonzero if docked, or
+ * @returns 0 if not docked
+ *
+ * @author Goober5000
+ */
 int object_is_docked(object *objp);
+
+/**
+ * @brief Checks if the given object is dead-docked with anyone.
+ *
+ * @returns Nonzero if docked, or
+ * @returns 0 if not docked
+ *
+ * @details An object is "dead-docked" when it is dying and still has objects docked to it. The dead_dock list is
+ *   populated when the object dies, and is used later on to jettison and maybe damage the docked objects.
+ *
+ * @author Goober5000
+ */
 int object_is_dead_docked(object *objp);
+
+/**
+ * @brief Moves a docked object to keep up with the parent object as it moves
+ *
+ * @param[in,out] objp The docked object
+ * @param[in]     parent_objp The object that it's docked to
+ *
+ * @author Goober5000
+ */
 void obj_move_one_docked_object(object *objp, object *parent_objp);
 
 //WMC

--- a/code/object/objectdock.cpp
+++ b/code/object/objectdock.cpp
@@ -677,8 +677,8 @@ void dock_undock_objects(object *objp1, object *objp2)
 void dock_undock_all(object *objp) {
 	Assert(objp != NULL);
 
-	while (objp->dock_list != NULL) {
-		object* dockee = objp->dock_list->docked_objp;
+	while (object_is_docked(objp)) {
+		object* dockee = dock_get_first_docked_object(objp);
 
 		dock_undock_objects(objp, dockee);
 	}

--- a/code/object/objectdock.cpp
+++ b/code/object/objectdock.cpp
@@ -768,13 +768,8 @@ void dock_remove_instance(object *objp, object *other_objp)
 	}
 	else
 	{
-		// Raise an error if we're in a release build.
-		// Raise a warning if we're in a debug build, the user may be doing something silly
-#ifndef NDEBUG
-		Error(LOCATION, "Tried to undock an object that isn't docked!\n");
-#else
-		Warning(LOCATION, "Tried to undock an object that isn't docked! Proceed with caution!\n");
-#endif
+		// Trigger an assertion, we can recover from this one, thankfully.
+		Assertion(false, "Tried to undock an object that isn't docked!\n");
 	}
 }
 

--- a/code/object/objectdock.cpp
+++ b/code/object/objectdock.cpp
@@ -662,22 +662,17 @@ void dock_undock_objects(object *objp1, object *objp2)
 	Assert(objp1 != NULL);
 	Assert(objp2 != NULL);
 
-#ifndef NDEBUG
-	if ((dock_find_instance(objp1, objp2) == NULL) || (dock_find_instance(objp2, objp1) == NULL))
-	{
-		Error(LOCATION, "Trying to undock an object that isn't docked!\n");
-	}
-#endif
-
 	// remove objects from each others' dock lists
 	dock_remove_instance(objp1, objp2);
 	dock_remove_instance(objp2, objp1);
 }
 
-void dock_undock_all(object *objp) {
+void dock_undock_all(object *objp)
+{
 	Assert(objp != NULL);
 
-	while (object_is_docked(objp)) {
+	while (object_is_docked(objp))
+	{
 		object* dockee = dock_get_first_docked_object(objp);
 
 		dock_undock_objects(objp, dockee);
@@ -770,6 +765,16 @@ void dock_remove_instance(object *objp, object *other_objp)
 
 		// delete it
 		vm_free(ptr);
+	}
+	else
+	{
+		// Raise an error if we're in a release build.
+		// Raise a warning if we're in a debug build, the user may be doing something silly
+#ifndef NDEBUG
+		Error(LOCATION, "Tried to undock an object that isn't docked!\n");
+#else
+		Warning(LOCATION, "Tried to undock an object that isn't docked! Proceed with caution!\n");
+#endif
 	}
 }
 

--- a/code/object/objectdock.cpp
+++ b/code/object/objectdock.cpp
@@ -46,6 +46,8 @@ int dock_count_instances(object *objp);
 
 object *dock_get_first_docked_object(object *objp)
 {
+	Assert(objp != NULL);
+
 	// are we docked?
 	if (!object_is_docked(objp))
 		return NULL;
@@ -55,6 +57,8 @@ object *dock_get_first_docked_object(object *objp)
 
 bool dock_check_docked_one_on_one(object *objp)
 {
+	Assert(objp != NULL);
+
 	// we must be docked
 	if (!object_is_docked(objp))
 		return false;
@@ -76,11 +80,14 @@ bool dock_check_docked_one_on_one(object *objp)
 
 int dock_count_direct_docked_objects(object *objp)
 {
+	Assert(objp != NULL);
 	return dock_count_instances(objp);
 }
 
 int dock_count_total_docked_objects(object *objp)
 {
+	Assert(objp != NULL);
+
 	dock_function_info dfi;
 
 	dock_evaluate_all_docked_objects(objp, &dfi, dock_count_total_docked_objects_helper);
@@ -90,11 +97,17 @@ int dock_count_total_docked_objects(object *objp)
 
 bool dock_check_find_direct_docked_object(object *objp, object *other_objp)
 {
+	Assert(objp != NULL);
+	Assert(other_objp != NULL);
+
 	return (dock_find_instance(objp, other_objp) != NULL);
 }
 
 bool dock_check_find_docked_object(object *objp, object *other_objp)
 {
+	Assert(objp != NULL);
+	Assert(other_objp != NULL);
+
 	dock_function_info dfi;
 	dfi.parameter_variables.objp_value = other_objp;
 
@@ -105,6 +118,8 @@ bool dock_check_find_docked_object(object *objp, object *other_objp)
 
 object *dock_find_object_at_dockpoint(object *objp, int dockpoint)
 {
+	Assert(objp != NULL);
+
 	dock_instance *result = dock_find_instance(objp, dockpoint);
 	
 	if (result == NULL)
@@ -115,6 +130,9 @@ object *dock_find_object_at_dockpoint(object *objp, int dockpoint)
 
 int dock_find_dockpoint_used_by_object(object *objp, object *other_objp)
 {
+	Assert(objp != NULL);
+	Assert(other_objp != NULL);
+
 	dock_instance *result = dock_find_instance(objp, other_objp);
 	
 	if (result == NULL)
@@ -125,6 +143,9 @@ int dock_find_dockpoint_used_by_object(object *objp, object *other_objp)
 
 void dock_calc_docked_center(vec3d *dest, object *objp)
 {
+	Assert(dest != NULL);
+	Assert(objp != NULL);
+
 	vm_vec_zero(dest);
 
 	dock_function_info dfi;
@@ -138,6 +159,9 @@ void dock_calc_docked_center(vec3d *dest, object *objp)
 
 void dock_calc_docked_center_of_mass(vec3d *dest, object *objp)
 {
+	Assert(dest != NULL);
+	Assert(objp != NULL);
+
 	vm_vec_zero(dest);
 
 	dock_function_info dfi;
@@ -151,6 +175,8 @@ void dock_calc_docked_center_of_mass(vec3d *dest, object *objp)
 
 float dock_calc_total_docked_mass(object *objp)
 {
+	Assert(objp != NULL);
+
 	dock_function_info dfi;
 	
 	dock_evaluate_all_docked_objects(objp, &dfi, dock_calc_total_docked_mass_helper);
@@ -160,6 +186,8 @@ float dock_calc_total_docked_mass(object *objp)
 
 float dock_calc_max_cross_sectional_radius_perpendicular_to_axis(object *objp, axis_type axis)
 {
+	Assert(objp != NULL);
+
 	vec3d local_line_end;
 	vec3d *world_line_start, world_line_end;
 	dock_function_info dfi;
@@ -210,6 +238,8 @@ float dock_calc_max_cross_sectional_radius_perpendicular_to_axis(object *objp, a
 
 float dock_calc_max_semilatus_rectum_parallel_to_axis(object *objp, axis_type axis)
 {
+	Assert(objp != NULL);
+
 	vec3d local_line_end;
 	vec3d *world_line_start, world_line_end;
 	dock_function_info dfi;
@@ -260,6 +290,8 @@ float dock_calc_max_semilatus_rectum_parallel_to_axis(object *objp, axis_type ax
 
 float dock_calc_docked_fspeed(object *objp)
 {
+	Assert(objp != NULL);
+
 	// *sigh*... the docked fspeed is simply the max fspeed of all docked objects
 	dock_function_info dfi;
 	dock_evaluate_all_docked_objects(objp, &dfi, dock_find_max_fspeed_helper);
@@ -268,6 +300,8 @@ float dock_calc_docked_fspeed(object *objp)
 
 float dock_calc_docked_speed(object *objp)
 {
+	Assert(objp != NULL);
+
 	// ditto with speed
 	dock_function_info dfi;
 	dock_evaluate_all_docked_objects(objp, &dfi, dock_find_max_speed_helper);
@@ -370,6 +404,8 @@ void dock_evaluate_tree(object *objp, dock_function_info *infop, void (*function
 
 void dock_move_docked_objects(object *objp)
 {
+	Assert(objp != NULL);
+
 	if ((objp->type != OBJ_SHIP) && (objp->type != OBJ_START))
 		return;
 
@@ -601,6 +637,9 @@ void dock_find_max_speed_helper(object *objp, dock_function_info *infop)
 // dock management functions -------------------------------------------------------------------------------------
 void dock_dock_objects(object *objp1, int dockpoint1, object *objp2, int dockpoint2)
 {
+	Assert(objp1 != NULL);
+	Assert(objp2 != NULL);
+
 #ifndef NDEBUG
 	if ((dock_find_instance(objp1, objp2) != NULL) || (dock_find_instance(objp2, objp1) != NULL))
 	{
@@ -620,6 +659,9 @@ void dock_dock_objects(object *objp1, int dockpoint1, object *objp2, int dockpoi
 
 void dock_undock_objects(object *objp1, object *objp2)
 {
+	Assert(objp1 != NULL);
+	Assert(objp2 != NULL);
+
 #ifndef NDEBUG
 	if ((dock_find_instance(objp1, objp2) == NULL) || (dock_find_instance(objp2, objp1) == NULL))
 	{
@@ -630,6 +672,16 @@ void dock_undock_objects(object *objp1, object *objp2)
 	// remove objects from each others' dock lists
 	dock_remove_instance(objp1, objp2);
 	dock_remove_instance(objp2, objp1);
+}
+
+void dock_undock_all(object *objp) {
+	Assert(objp != NULL);
+
+	while (objp->dock_list != NULL) {
+		object* dockee = objp->dock_list->docked_objp;
+
+		dock_undock_objects(objp, dockee);
+	}
 }
 
 // dock list functions -------------------------------------------------------------------------------------------
@@ -724,6 +776,8 @@ void dock_remove_instance(object *objp, object *other_objp)
 // just free the list without worrying about undocking anything
 void dock_free_dock_list(object *objp)
 {
+	Assert(objp != NULL);
+
 	while (objp->dock_list != NULL)
 	{
 		dock_instance *ptr = objp->dock_list;

--- a/code/object/objectdock.h
+++ b/code/object/objectdock.h
@@ -128,6 +128,12 @@ void dock_dock_objects(object *objp1, int dockpoint1, object *objp2, int dockpoi
 // remove objp1 and objp2 from each others' dock lists; currently only called by ai_do_objects_undocked_stuff
 void dock_undock_objects(object *objp1, object *objp2);
 
+/**
+ * @brief Undocks everything from the given object
+ * @note This is a slow method. use dock_free_dock_list() when doing object cleanup.
+ */
+void dock_undock_all(object *objp);
+
 // free the entire dock list without undocking anything; should only be used on object cleanup
 void dock_free_dock_list(object *objp);
 

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -7397,21 +7397,31 @@ void ship_cleanup(int shipnum, int cleanup_mode)
 	object *objp = &Objects[shipp->objnum];
 
 	// add the information to the exited ship list
-	if (!(cleanup_mode & SHIP_REDALERT)) {
-		if (cleanup_mode & SHIP_DESTROYED) {
-			ship_add_exited_ship(shipp, Ship::Exit_Flags::Destroyed);
-		} else {
-			// (cleanup_mode & (SHIP_DEPARTED | SHIP_VANISHED)
-			ship_add_exited_ship(shipp, Ship::Exit_Flags::Departed);
-		}
-	} else {
-		// (cleanup_mode & SHIP_REDALERT)
+	switch (cleanup_mode) {
+	case SHIP_DESTROYED:
+		ship_add_exited_ship(shipp, Ship::Exit_Flags::Destroyed);
+		break;
+	case SHIP_DEPARTED:
+	case SHIP_DEPARTED_WARP:
+	case SHIP_DEPARTED_BAY:
+		ship_add_exited_ship(shipp, Ship::Exit_Flags::Departed);
+		break;
+	case SHIP_DESTROYED_REDALERT:
+	case SHIP_DEPARTED_REDALERT:
 		// Ship was removed in previous mission. Mark as "player deleted" for this mission
 		ship_add_exited_ship(shipp, Ship::Exit_Flags::Player_deleted);
+		break;
+	case SHIP_VANISHED:
+		// Do nothing
+		break;
+	default:
+		// Can't Happen
+		Assertion(false, "Unknown cleanup_mode '%i' passed to ship_cleanup!", cleanup_mode);
+		break;
 	}
 
 	// record kill?
-	if (!(cleanup_mode & SHIP_REDALERT) && (cleanup_mode & SHIP_DESTROYED)) {
+	if (cleanup_mode == SHIP_DESTROYED) {
 		// determine if we need to count this ship as a kill in counting number of kills per ship type
 		// look at the ignore flag for the ship (if not in a wing), or the ignore flag for the wing
 		// (if the ship is in a wing), and add to the kill count if the flags are not set
@@ -7425,7 +7435,7 @@ void ship_cleanup(int shipnum, int cleanup_mode)
 
 	// add mission log entry?
 	// (vanished ships and red-alert deleted ships have no log, and destroyed ships are logged in ship_hit_kill)
-	if (!(cleanup_mode & SHIP_REDALERT) && (cleanup_mode & SHIP_DEPARTED)) {
+	if ((cleanup_mode == SHIP_DEPARTED_WARP) || (cleanup_mode == SHIP_DEPARTED_BAY) || (cleanup_mode == SHIP_DEPARTED)) {\
 		// see if this ship departed within the radius of a jump node -- if so, put the node name into
 		// the secondary mission log field
 		CJumpNode *jnp = jumpnode_get_which_in(objp);
@@ -7436,31 +7446,51 @@ void ship_cleanup(int shipnum, int cleanup_mode)
 	}
 
 #ifndef NDEBUG
-	// add a debug log entry
-	if (cleanup_mode & SHIP_DESTROYED) {
-		nprintf(("Alan", "SHIP DESTROYED: %s", shipp->ship_name));
-	} else if (cleanup_mode & SHIP_DEPARTED) {
-		nprintf(("Alan", "SHIP DEPARTED: %s", shipp->ship_name));
-	} else {
-		nprintf(("Alan", "SHIP VANISHED: %s", shipp->ship_name));
-	}
-
-	// if it was removed via red_alert_delete_ship, log it as such
-	if (cleanup_mode & SHIP_REDALERT) {
-		nprintf(("Alan", "(RED-ALERT)\n"));
-	} else {
-		nprintf(("Alan", "\n"));
+	switch (cleanup_mode) {
+	case SHIP_DESTROYED:
+		nprintf(("Alan", "SHIP DESTROYED: %s'\n'", shipp->ship_name));
+		break;
+	case SHIP_DEPARTED:
+	case SHIP_DEPARTED_WARP:
+	case SHIP_DEPARTED_BAY:
+		nprintf(("Alan", "SHIP DEPARTED: %s'\n'", shipp->ship_name));
+		break;
+	case SHIP_DESTROYED_REDALERT:
+		nprintf(("Alan", "SHIP REDALERT DESTROYED: %s'\n'", shipp->ship_name));
+		break;
+	case SHIP_DEPARTED_REDALERT:
+		nprintf(("Alan", "SHIP REDALERT DEPARTED: %s'\n'", shipp->ship_name));
+		break;
+	case SHIP_VANISHED:
+		nprintf(("Alan", "SHIP VANISHED: %s'\n'", shipp->ship_name));
+		break;
+	default:
+		// Can't Happen, but we should've already caught this
+		Assertion(false, "Unknown cleanup_mode '%i' passed to ship_cleanup!", cleanup_mode);
+		break;
 	}
 #endif
 
 	// update wingman status gauge
 	if ( (shipp->wing_status_wing_index >= 0) && (shipp->wing_status_wing_pos >= 0) ) {
-		if (cleanup_mode & SHIP_DESTROYED) {
+		switch (cleanup_mode) {
+		case SHIP_DESTROYED:
+		case SHIP_DESTROYED_REDALERT:
 			hud_set_wingman_status_dead(shipp->wing_status_wing_index, shipp->wing_status_wing_pos);
-		} else if ((cleanup_mode & SHIP_DEPARTED) && !(cleanup_mode & SHIP_REDALERT)){
+			break;
+		case SHIP_DEPARTED:
+		case SHIP_DEPARTED_WARP:
+		case SHIP_DEPARTED_BAY:
+		case SHIP_DEPARTED_REDALERT:
 			hud_set_wingman_status_departed(shipp->wing_status_wing_index, shipp->wing_status_wing_pos);
-		} else {
+			break;
+		case SHIP_VANISHED:
 			hud_set_wingman_status_none(shipp->wing_status_wing_index, shipp->wing_status_wing_pos);
+			break;
+		default:
+			// Can't Happen, but we should've already caught this
+			Assertion(false, "Unknown cleanup_mode '%i' passed to ship_cleanup!", cleanup_mode);
+			break;
 		}
 	}
 
@@ -7468,20 +7498,31 @@ void ship_cleanup(int shipnum, int cleanup_mode)
 	if ( shipp->wingnum != -1 ) {
 		wing *wingp = &Wings[shipp->wingnum];
 
-		if (cleanup_mode & SHIP_DESTROYED) {
+		switch (cleanup_mode) {
+		case SHIP_DESTROYED:
+		case SHIP_DESTROYED_REDALERT:
 			wingp->total_destroyed++;
-		} else if (cleanup_mode & SHIP_DEPARTED) {
+			break;
+		case SHIP_DEPARTED:
+		case SHIP_DEPARTED_WARP:
+		case SHIP_DEPARTED_BAY:
+		case SHIP_DEPARTED_REDALERT:
 			wingp->total_departed++;
-		} else {
+			break;
+		case SHIP_VANISHED:
 			wingp->total_vanished++;
+			break;
+		default:
+			// Can't Happen, but we should've already caught this
+			Assertion(false, "Unknown cleanup_mode '%i' passed to ship_cleanup!", cleanup_mode);
+			break;
 		}
-
 		ship_wing_cleanup(shipnum, wingp);
 	}
 
 	// Note, this call to ai_ship_destroy must come after ship_wing_cleanup for guarded wings to
 	// properly note the destruction of a ship in their wing.
-	if (cleanup_mode & SHIP_DESTROYED) {
+	if (cleanup_mode == SHIP_DESTROYED) {
 		ai_ship_destroy(shipnum, Ship::Exit_Flags::Destroyed);	// Do AI stuff for destruction of ship.
 	} else {
 		ai_ship_destroy(shipnum, Ship::Exit_Flags::Departed);		// should still do AI cleanup after ship has departed

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -1386,9 +1386,10 @@ extern int ship_get_num_ships();
  * @param[in] cleanup_mode Flags describing how this ship is to be removed. See SHIP_VANISHED, SHIP_DESTROYED, etc.
  *
  * @details This is the deconstructor of a ship, it does all the necassary processes to remove the ship from the Ships
- *   array, and frees the slot for use by others. De-init of its Objects[] slot is handled elsewhere.
+ *   array, and frees the slot for use by others. De-init of its Objects[] slot is handled by obj_delete_all_that_should_be_dead().
  *
  * @author Goober5000
+ * @sa obj_delete_all_that_should_be_dead()
  */
 extern void ship_cleanup(int shipnum, int cleanup_mode);
 

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -1376,7 +1376,8 @@ extern int ship_get_num_ships();
 #define SHIP_DEPARTED_WARP		(1<<2)
 #define SHIP_DEPARTED_BAY		(1<<3)
 #define SHIP_DEPARTED			( SHIP_DEPARTED_BAY | SHIP_DEPARTED_WARP )
-#define SHIP_REDALERT			(1<<4)
+#define SHIP_DESTROYED_REDALERT	(1<<4)
+#define SHIP_DEPARTED_REDALERT	(1<<5)
 
 /**
  * @brief Deletes and de-inits a ship.

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -1376,8 +1376,22 @@ extern int ship_get_num_ships();
 #define SHIP_DEPARTED_WARP		(1<<2)
 #define SHIP_DEPARTED_BAY		(1<<3)
 #define SHIP_DEPARTED			( SHIP_DEPARTED_BAY | SHIP_DEPARTED_WARP )
-// Goober5000
+#define SHIP_REDALERT			(1<<4)
+
+/**
+ * @brief Deletes and de-inits a ship.
+ *
+ * @param[in] shipnum      Index of this ship in Ships[]
+ * @param[in] cleanup_mode Flags describing how this ship is to be removed. See SHIP_VANISHED, SHIP_DESTROYED, etc.
+ *
+ * @details This is the deconstructor of a ship, it does all the necassary processes to remove the ship from the Ships
+ *   array, and frees the slot for use by others. De-init of its Objects[] slot is handled elsewhere.
+ *
+ * @author Goober5000
+ */
 extern void ship_cleanup(int shipnum, int cleanup_mode);
+
+// Goober5000
 extern void ship_destroy_instantly(object *ship_obj, int shipnum);
 extern void ship_actually_depart(int shipnum, int method = SHIP_DEPARTED_WARP);
 


### PR DESCRIPTION
First fix is when a deleted carried ship (one that has the "red-alert-carry" flag) is docked with another ship in the red-alert mission at start. Before the fix, if a carried ship was deleted, any docked object to the ship would not be properly undocked and would cause an access violation to the NULL location.

Second fix is when a deleted carried ship is on the escort list. Before the fix, it wouldn't be removed from the escort list.