### PR TITLE
Improves FSO's compatibility with the FS2 Demo data

### DIFF
--- a/code/bmpman/bmpman.cpp
+++ b/code/bmpman/bmpman.cpp
@@ -3080,6 +3080,10 @@ int bm_unload(int handle, int clear_render_targets, bool nodebug) {
 	bitmap_entry *be;
 	bitmap *bmp;
 
+	if (handle == -1) {
+		return -1;
+	}
+
 	int n = handle % MAX_BITMAPS;
 
 	Assert((n >= 0) && (n < MAX_BITMAPS));

--- a/code/graphics/2d.cpp
+++ b/code/graphics/2d.cpp
@@ -995,10 +995,8 @@ bool gr_init(std::unique_ptr<os::GraphicsOperations>&& graphicsOps, int d_mode, 
 
 	if (gr_get_resolution_class(width, height) != GR_640) {
 		// check for hi-res interface files so that we can verify our width/height is correct
-		bool has_sparky_hi = (cf_exists_full("2_ChoosePilot-m.pcx", CF_TYPE_ANY) && cf_exists_full("2_TechShipData-m.pcx", CF_TYPE_ANY));
-
 		// if we don't have it then fall back to 640x480 mode instead
-		if ( !has_sparky_hi ) {
+		if ( !cf_exists_full("2_ChoosePilot-m.pcx", CF_TYPE_ANY)) {
 			if ( (width == 1024) && (height == 768) ) {
 				width = 640;
 				height = 480;

--- a/code/menuui/mainhallmenu.cpp
+++ b/code/menuui/mainhallmenu.cpp
@@ -2187,9 +2187,10 @@ void parse_main_hall_table(const char* filename)
 				stuff_string(temp_string, F_NAME, MAX_FILENAME_LEN);
 				m->mask = temp_string;
 
-				required_string("+Music:");
-				stuff_string(temp_string, F_NAME, MAX_FILENAME_LEN);
-				m->music_name = temp_string;
+				if (optional_string("+Music:")) {	// Demo doesn't have these lines.
+					stuff_string(temp_string, F_NAME, MAX_FILENAME_LEN);
+					m->music_name = temp_string;
+				}
 
 				// Goober5000
 				if (optional_string("+Substitute Music:")) {

--- a/code/menuui/techmenu.cpp
+++ b/code/menuui/techmenu.cpp
@@ -25,6 +25,7 @@
 #include "missionui/missionscreencommon.h"
 #include "parse/parselo.h"
 #include "playerman/player.h"
+#include "popup/popup.h"
 #include "render/3d.h"
 #include "render/batching.h"
 #include "ship/ship.h"
@@ -192,6 +193,7 @@ static techroom_buttons Buttons[GR_NUM_RESOLUTIONS][NUM_BUTTONS] = {
 static UI_WINDOW Ui_window;
 static UI_BUTTON View_window;
 static int Tech_background_bitmap;
+static int Tech_background_bitmap_mask;
 static int Tab = SHIPS_DATA_TAB;
 static int List_offset;
 static int Select_tease_line;
@@ -210,7 +212,6 @@ static int Cur_entry_index = -1;		// this is the current entry selected, using m
 static int Techroom_ship_modelnum;
 static float Techroom_ship_rot;
 static UI_BUTTON List_buttons[LIST_BUTTONS_MAX];  // buttons for each line of text in list
-static int Palette_bmp;
 
 static int Ships_loaded = 0;
 static int Weapons_loaded = 0;
@@ -1117,12 +1118,19 @@ void techroom_init()
 
 	// set up UI stuff
 	Ui_window.create(0, 0, gr_screen.max_w_unscaled, gr_screen.max_h_unscaled, 0);
-	Ui_window.set_mask_bmap(Tech_mask_filename[gr_screen.res]);
 
 	Tech_background_bitmap = bm_load(Tech_background_filename[gr_screen.res]);
 	if (Tech_background_bitmap < 0) {
 		// failed to load bitmap, not a good thing
-		Error(LOCATION,"Couldn't load techroom background bitmap");
+		Warning(LOCATION,"Error loading techroom background bitmap %s", Tech_background_filename[gr_screen.res]);
+	}
+
+	Tech_background_bitmap_mask = bm_load(Tech_mask_filename[gr_screen.res]);
+	if (Tech_background_bitmap_mask < 0) {
+		Warning(LOCATION, "Error loading techroom background mask %s", Tech_mask_filename[gr_screen.res]);
+		return;
+	} else {
+		Ui_window.set_mask_bmap(Tech_mask_filename[gr_screen.res]);
 	}
 
 	for (i=0; i<NUM_BUTTONS; i++) {
@@ -1260,21 +1268,30 @@ void techroom_close()
 
 	Techroom_show_all = 0;
 
-	if (Tech_background_bitmap) {
+	if (Tech_background_bitmap != -1) {
 		bm_release(Tech_background_bitmap);
 	}
 
 	Ui_window.destroy();
-	common_free_interface_palette();		// restore game palette
-	if (Palette_bmp){
-		bm_release(Palette_bmp);
+
+	if (Tech_background_bitmap_mask != -1) {
+		bm_release(Tech_background_bitmap_mask);
 	}
+
+	common_free_interface_palette();		// restore game palette
 }
 
 void techroom_do_frame(float frametime)
 {
 	
 	int i, k;	
+
+	// If we don't have a mask, we don't have enough data to do anything with this screen.
+	if (Tech_background_bitmap_mask == -1) {
+		popup_game_feature_not_in_demo();
+		gameseq_post_event(GS_EVENT_MAIN_MENU);
+		return;
+	}
 
 	// turn off controls when overlay is on
 	if ( help_overlay_active(Techroom_overlay_id) ) {

--- a/code/mission/missiontraining.cpp
+++ b/code/mission/missiontraining.cpp
@@ -380,9 +380,6 @@ int comp_training_lines_by_born_on_date(const void *m1, const void *m2)
 	int *e1, *e2;
 	e1 = (int*) m1;
 	e2 = (int*) m2;
-	
-	Assert(Mission_events[*e1 & 0xffff].born_on_date != 0);
-	Assert(Mission_events[*e2 & 0xffff].born_on_date != 0);
 
 	return (Mission_events[*e1 & 0xffff].born_on_date - Mission_events[*e2 & 0xffff].born_on_date);
 }

--- a/code/missionui/missionbrief.cpp
+++ b/code/missionui/missionbrief.cpp
@@ -1156,7 +1156,9 @@ void brief_render(float frametime)
 		}
 	}
 
-	brief_maybe_blit_scene_cut(frametime);	
+	if (Fade_anim.first_frame != -1) {
+		brief_maybe_blit_scene_cut(frametime);
+	}
 
 #if !defined(NDEBUG)
 	gr_set_color_fast(&Color_normal);
@@ -1822,7 +1824,9 @@ void brief_close()
 	// unload the audio streams used for voice playback
 	brief_voice_unload_all();
 
-	bm_unload(Fade_anim.first_frame);
+	if (Fade_anim.first_frame != -1) {
+		bm_unload(Fade_anim.first_frame);
+	}
 
 	Brief_ui_window.destroy();
 

--- a/code/popup/popup.cpp
+++ b/code/popup/popup.cpp
@@ -1164,3 +1164,9 @@ void popup_change_text(const char *new_text)
 	// recalculate all display information
 	popup_split_lines(&Popup_info,Popup_flags);
 }
+
+// If we're running on demo data, certain menus can't be displayed; this message will get shown instead.
+void popup_game_feature_not_in_demo()
+{
+	popup(PF_USE_AFFIRMATIVE_ICON|PF_BODY_BIG, 1, POPUP_OK, XSTR( "Sorry, this feature is available only in the retail version", 200));
+}

--- a/code/popup/popup.h
+++ b/code/popup/popup.h
@@ -107,4 +107,7 @@ void popup_kill_any_active();
 // change the text inside of the popup 
 void popup_change_text(const char *new_text);
 
+// Used if certain data is missing (e.g. running demo data).
+void popup_game_feature_not_in_demo();
+
 #endif

--- a/code/stats/medals.cpp
+++ b/code/stats/medals.cpp
@@ -20,6 +20,7 @@
 #include "palman/palman.h"
 #include "parse/parselo.h"
 #include "playerman/player.h"
+#include "popup/popup.h"
 #include "stats/medals.h"
 #include "ui/ui.h"
 
@@ -557,7 +558,7 @@ void medal_main_init(player *pl, int mode)
 
 	Medals_bitmap = bm_load(bitmap_buf);
 	if (Medals_bitmap < 0) {
-		Error(LOCATION, "Error loading medal background bitmap %s", bitmap_buf);
+		Warning(LOCATION, "Error loading medal background bitmap %s", bitmap_buf);
 	} else {
 		Init_flags |= MEDAL_BITMAP_INIT;
 	}
@@ -570,18 +571,21 @@ void medal_main_init(player *pl, int mode)
 
 	Medals_bitmap_mask = bm_load(bitmap_buf);
 	if (Medals_bitmap_mask < 0) {
-		Error(LOCATION, "Error loading medal mask file %s", bitmap_buf);
+		Warning(LOCATION, "Error loading medal mask file %s", bitmap_buf);
 	} else {
 		Init_flags |= MASK_BITMAP_INIT;
 		Medals_mask = bm_lock(Medals_bitmap_mask, 8, BMP_AABITMAP);
 		bm_get_info(Medals_bitmap_mask, &Medals_mask_w, &Medals_mask_h);
+
+		init_medal_bitmaps();
 	}
-	init_medal_bitmaps();
+
 	init_snazzy_regions();
 
 	gr_set_color_fast(&Color_normal);
 
-	Medals_window.set_mask_bmap(bitmap_buf);
+	if (Medals_bitmap_mask >= 0)
+		Medals_window.set_mask_bmap(bitmap_buf);
 }
 
 void blit_label(char *label, int num)
@@ -659,6 +663,16 @@ void blit_callsign()
 int medal_main_do()
 {
 	int region,selected, k;
+
+	// If we don't have a mask, we don't have enough data to do anything with this screen.
+	if (Medals_bitmap_mask == -1) {
+		popup_game_feature_not_in_demo();
+		if (Medals_mode == MM_NORMAL)
+			gameseq_post_event(GS_EVENT_PREVIOUS_STATE);
+		// any calling popup function will know to close the screen down
+		return 0;
+	}
+
 	k = Medals_window.process();
 
 	// process an exit command

--- a/code/stats/medals.cpp
+++ b/code/stats/medals.cpp
@@ -729,7 +729,6 @@ void medal_main_close()
 
 	if (Init_flags & MASK_BITMAP_INIT) {
 		bm_unlock(Medals_bitmap_mask);
-		bm_release(Medals_bitmap_mask);
 	}
 
 	for (SCP_vector<medal_display_info>::iterator idx = Medal_display_info.begin(); idx != Medal_display_info.end(); ++idx) {
@@ -743,7 +742,13 @@ void medal_main_close()
 	Medal_regions = NULL;
 
 	Player_score = NULL;
+
 	Medals_window.destroy();
+
+	if (Init_flags & MASK_BITMAP_INIT) {
+		bm_release(Medals_bitmap_mask);
+	}
+
 	snazzy_menu_close();
 	palette_restore_palette();
 }


### PR DESCRIPTION
These commits prevent FSO from crashing when running with the data from the FS2 Demo. Some of these bugs could theoretically be encountered outside the demo, although it's unlikely. This PR makes no attempt to stop demo data from generating warnings; only errors or assertions.

Only commit I'm really iffy on is 559b07da63e52237d5ce66052bc2b07cec8164fa, but I never liked the hi-res interface art check anyway.