### PR TITLE
Fix double rendering of effect ships

### DIFF
--- a/code/object/objectsort.cpp
+++ b/code/object/objectsort.cpp
@@ -369,6 +369,7 @@ void obj_render_queue_all()
 			if ( obj_render_is_model(objp) ) {
 				if( (objp->type == OBJ_SHIP) && Ships[objp->instance].shader_effect_active ) {
 					effect_ships.push_back(objp);
+					continue;
 				}
 			}
 


### PR DESCRIPTION
This fixes #653.

@AxemP Could you check if this is the desired behavior? In my tests the effects looks good now but just to be sure.

If this works then it's probably among one of the most time-intensive one-line fixes I have done...