### PR TITLE
some riffs on PR #806

### DIFF
--- a/code/hud/hudobserver.cpp
+++ b/code/hud/hudobserver.cpp
@@ -25,23 +25,9 @@ ai_info Hud_obs_ai;
  */
 void hud_observer_init(ship *shipp, ai_info *aip)
 {
-	// setup the pseduo ship and ai
+	// setup the pseudo ship and ai
+	Hud_obs_ship = *shipp;
 	Hud_obs_ai = *aip;
-	// (we used to do a memcpy here, but that doesn't work any longer, so let's just assign the values we need)
-	Hud_obs_ship.clear();
-	strcpy_s(Hud_obs_ship.ship_name, shipp->ship_name);
-	Hud_obs_ship.team = shipp->team;
-	Hud_obs_ship.ai_index = shipp->ai_index;
-	Hud_obs_ship.flags = shipp->flags;
-	Hud_obs_ship.ship_info_index = shipp->ship_info_index;
-	Hud_obs_ship.objnum = shipp->objnum;
-	Hud_obs_ship.wingnum = shipp->wingnum;
-	Hud_obs_ship.alt_type_index = shipp->alt_type_index;
-	Hud_obs_ship.callsign_index = shipp->callsign_index;
-	memcpy(&Hud_obs_ship.np_updates, shipp->np_updates, MAX_PLAYERS * sizeof(np_update));
-	Hud_obs_ship.ship_max_hull_strength = shipp->ship_max_hull_strength;
-	Hud_obs_ship.ship_max_shield_strength = shipp->ship_max_shield_strength;
-	Hud_obs_ship.weapons = shipp->weapons;
 
 	HUD_config.is_observer = 1;
 	HUD_config.show_flags = HUD_observer_default_flags;

--- a/code/hud/hudobserver.cpp
+++ b/code/hud/hudobserver.cpp
@@ -25,9 +25,23 @@ ai_info Hud_obs_ai;
  */
 void hud_observer_init(ship *shipp, ai_info *aip)
 {
-	// setup the pseudo ship and ai
-	Hud_obs_ship = *shipp;
+	// setup the pseduo ship and ai
 	Hud_obs_ai = *aip;
+	// (we used to do a memcpy here, but that doesn't work any longer, so let's just assign the values we need)
+	Hud_obs_ship.clear();
+	strcpy_s(Hud_obs_ship.ship_name, shipp->ship_name);
+	Hud_obs_ship.team = shipp->team;
+	Hud_obs_ship.ai_index = shipp->ai_index;
+	Hud_obs_ship.flags = shipp->flags;
+	Hud_obs_ship.ship_info_index = shipp->ship_info_index;
+	Hud_obs_ship.objnum = shipp->objnum;
+	Hud_obs_ship.wingnum = shipp->wingnum;
+	Hud_obs_ship.alt_type_index = shipp->alt_type_index;
+	Hud_obs_ship.callsign_index = shipp->callsign_index;
+	memcpy(&Hud_obs_ship.np_updates, shipp->np_updates, MAX_PLAYERS * sizeof(np_update));
+	Hud_obs_ship.ship_max_hull_strength = shipp->ship_max_hull_strength;
+	Hud_obs_ship.ship_max_shield_strength = shipp->ship_max_shield_strength;
+	Hud_obs_ship.weapons = shipp->weapons;
 
 	HUD_config.is_observer = 1;
 	HUD_config.show_flags = HUD_observer_default_flags;

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -5821,6 +5821,8 @@ void ship::clear()
 	target_shields_delta = 0.0f;
 	target_weapon_energy_delta = 0.0f;
 
+	weapons = ship_weapon();
+
 	// ---------- special weapons init that isn't setting things to 0
 	for (i = 0; i < MAX_SHIP_PRIMARY_BANKS; i++)
 	{


### PR DESCRIPTION
In ship::clear(), @The-E removed

`memset(&weapons, 0, sizeof(ship_weapon));`

but did not replace it with the corresponding

`weapons = ship_weapon();`

This fixes that.  Additionally, this PR removes the need for one of the uses of `ship::clear()` by tweaking `hud_observer_init`.  Originally, the code used memcpy, but if the assignment operator works for `ai_info`, it should be suitable for `ship` too.

Edit:
Link to PR #806 