### PR TITLE
Add missing variable to ship_weapon constructor.

### DIFF
--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -6026,11 +6026,9 @@ ship_weapon::ship_weapon()
         primary_bank_start_ammo[i] = 0;
         primary_bank_capacity[i] = 0;
         primary_next_slot[i] = 0;
-        primary_bank_rearm_time[i] = timestamp(0);
         primary_bank_fof_cooldown[i] = 0;
 
         primary_animation_position[i] = EModelAnimationPosition::MA_POS_NOT_SET;
-        primary_animation_done_time[i] = 0;
 
         primary_bank_pattern_index[i] = 0;
 
@@ -6052,7 +6050,8 @@ ship_weapon::ship_weapon()
         secondary_bank_start_ammo[i] = 0;
         secondary_bank_capacity[i] = 0;
         secondary_next_slot[i] = 0;
-        secondary_bank_rearm_time[i] = timestamp(0);
+
+		secondary_animation_position[i] = EModelAnimationPosition::MA_POS_NOT_SET;
 
 		secondary_bank_pattern_index[i] = 0;
 
@@ -6065,12 +6064,8 @@ ship_weapon::ship_weapon()
     tertiary_bank_capacity = 0;
     tertiary_bank_rearm_time = timestamp(0);
 
-    last_fired_weapon_index = 0;
-    last_fired_weapon_signature = 0;
     detonate_weapon_time = 0;
     ai_class = 0;
-
-    next_tertiary_fire_stamp = timestamp(0);
 
     last_fired_weapon_index = -1;
     last_fired_weapon_signature = -1;


### PR DESCRIPTION
`secondary_animation_position` wasn't being set by the `ship_weapon` constructor, which could cause potential issues with whatever uninitialized data it wound up being set to (like, say, being unable to fire any weapons in the second secondary bank until you've cycled through it once). Since it depended on uninitialized data, the behavior could even change between 32-bit and 64-bit builds (and Release/Debug, of course).

While I was at it, I also noticed some variables were getting set twice; in one instance (`primary_animation_done_time`), it was even being set to the *wrong* value the second time (according to the pre-flagset code that used `memset()` on it and then overrode some values that shouldn't have been zero). Not sure what problems that could've caused; possibly some issues with animations and primary weapons, I guess, if the "done" timestamp was invalid when it shouldn't have been.