### PR TITLE
Remove tcache_set from rendering API

### DIFF
--- a/code/graphics/2d.h
+++ b/code/graphics/2d.h
@@ -698,9 +698,6 @@ typedef struct screen {
 	// color buffer writes
 	int (*gf_set_color_buffer)(int mode);
 
-	// set a texture into cache. for sectioned bitmaps, pass in sx and sy to set that particular section of the bitmap
-	int (*gf_tcache_set)(int bitmap_id, int bitmap_type, float *u_scale, float *v_scale, int stage);	
-
 	// preload a bitmap into texture memory
 	int (*gf_preload)(int bitmap_num, int is_aabitmap);
 
@@ -1010,10 +1007,6 @@ __inline void gr_fog_set(int fog_mode, int r, int g, int b, float fog_near = -1.
 #define gr_set_cull			GR_CALL(gr_screen.gf_set_cull)
 #define gr_set_color_buffer	GR_CALL(gr_screen.gf_set_color_buffer)
 
-__inline int gr_tcache_set(int bitmap_id, int bitmap_type, float *u_scale, float *v_scale, int stage = 0)
-{
-	return (*gr_screen.gf_tcache_set)(bitmap_id, bitmap_type, u_scale, v_scale, stage);
-}
 
 #define gr_preload			GR_CALL(gr_screen.gf_preload)
 

--- a/code/graphics/grstub.cpp
+++ b/code/graphics/grstub.cpp
@@ -48,11 +48,6 @@ int gr_stub_save_screen()
 	return 1;
 }
 
-int gr_stub_tcache_set(int bitmap_id, int bitmap_type, float *u_scale, float *v_scale, int tex_unit = 0)
-{
-	return 0;
-}
-
 int gr_stub_zbuffer_get()
 {
 	return 0;
@@ -606,8 +601,6 @@ bool gr_stub_init()
 
 	gr_screen.gf_set_cull			= gr_stub_set_cull;
 	gr_screen.gf_set_color_buffer	= gr_stub_set_color_buffer;
-
-	gr_screen.gf_tcache_set			= gr_stub_tcache_set;
 
 	gr_screen.gf_set_clear_color	= gr_stub_set_clear_color;
 

--- a/code/graphics/opengl/gropengl.cpp
+++ b/code/graphics/opengl/gropengl.cpp
@@ -1191,8 +1191,6 @@ void opengl_setup_function_pointers()
 	gr_screen.gf_set_cull			= gr_opengl_set_cull;
 	gr_screen.gf_set_color_buffer	= gr_opengl_set_color_buffer;
 
-	gr_screen.gf_tcache_set			= gr_opengl_tcache_set;
-
 	gr_screen.gf_set_clear_color	= gr_opengl_set_clear_color;
 
 	gr_screen.gf_preload			= gr_opengl_preload;


### PR DESCRIPTION
It wasn't used anywhere and has been superseded by the material system.
It would also interfere with a possible texture array usage.