### PR TITLE
Remove some unneeded OpenGL version checks

### DIFF
--- a/code/graphics/2d.cpp
+++ b/code/graphics/2d.cpp
@@ -1775,9 +1775,7 @@ void poly_list::allocate(int _verts)
 			tsb = (tsb_t*)vm_malloc(sizeof(tsb_t) * _verts);
 		}
 
-		if ( GLSL_version >= 150 ) {
-			submodels = (int*)vm_malloc(sizeof(int) * _verts);
-		}
+		submodels = (int*)vm_malloc(sizeof(int) * _verts);
 
 		sorted_indices = (uint*)vm_malloc(sizeof(uint) * _verts);
 	}
@@ -1957,9 +1955,7 @@ void poly_list::make_index_buffer(SCP_vector<int> &vertex_list)
 			buffer_list_internal.tsb[z] = tsb[j];
 		}
 
-		if ( GLSL_version >= 150 ) {
-			buffer_list_internal.submodels[z] = submodels[j];
-		}
+		buffer_list_internal.submodels[z] = submodels[j];
 
 		buffer_list_internal.n_verts++;
 		z++;
@@ -1987,9 +1983,7 @@ poly_list& poly_list::operator = (poly_list &other_list)
 		memcpy(tsb, other_list.tsb, sizeof(tsb_t) * other_list.n_verts);
 	}
 
-	if ( GLSL_version >= 150 ) {
-		memcpy(submodels, other_list.submodels, sizeof(int) * other_list.n_verts);
-	}
+	memcpy(submodels, other_list.submodels, sizeof(int) * other_list.n_verts);
 
 	memcpy(sorted_indices, other_list.sorted_indices, sizeof(uint) * other_list.n_verts);
 
@@ -2159,9 +2153,7 @@ uint gr_determine_model_shader_flags(
 ) {
 	uint shader_flags = 0;
 
-	if ( GLSL_version >= 120 ) {
-		shader_flags |= SDR_FLAG_MODEL_CLIP;
-	}
+	shader_flags |= SDR_FLAG_MODEL_CLIP;
 
 	if ( transform ) {
 		shader_flags |= SDR_FLAG_MODEL_TRANSFORM;

--- a/code/graphics/grbatch.cpp
+++ b/code/graphics/grbatch.cpp
@@ -692,12 +692,12 @@ int batch_add_bitmap(int texture, int tmap_flags, vertex *pnt, int orient, float
 		return 1;
 	}
 
-	if ( tmap_flags & TMAP_FLAG_SOFT_QUAD && ( !Cmdline_softparticles || GLSL_version <= 120 ) ) {
+	if ( tmap_flags & TMAP_FLAG_SOFT_QUAD && !Cmdline_softparticles ) {
 		// don't render this as a soft particle if we don't support soft particles
 		tmap_flags &= ~(TMAP_FLAG_SOFT_QUAD);
 	}
 
-	if ( GLSL_version > 120 && Cmdline_softparticles && !Cmdline_no_geo_sdr_effects && (tmap_flags & TMAP_FLAG_VERTEX_GEN) ) {
+	if ( Cmdline_softparticles && !Cmdline_no_geo_sdr_effects && (tmap_flags & TMAP_FLAG_VERTEX_GEN) ) {
 		geometry_batch_add_bitmap(texture, tmap_flags, pnt, orient, rad, alpha, depth);
 		return 0;
 	} else if ( tmap_flags & TMAP_FLAG_VERTEX_GEN ) {
@@ -761,7 +761,7 @@ int batch_add_bitmap_rotated(int texture, int tmap_flags, vertex *pnt, float ang
 		return 1;
 	}
 
-	if ( tmap_flags & TMAP_FLAG_SOFT_QUAD && ( !Cmdline_softparticles || GLSL_version <= 120 ) ) {
+	if ( tmap_flags & TMAP_FLAG_SOFT_QUAD && !Cmdline_softparticles ) {
 		// don't render this as a soft particle if we don't support soft particles
 		tmap_flags &= ~(TMAP_FLAG_SOFT_QUAD);
 	}
@@ -1143,11 +1143,6 @@ int distortion_add_bitmap_rotated(int texture, int tmap_flags, vertex *pnt, floa
 		return 1;
 	}
 
-	if ( GLSL_version < 120 ) {
-		// don't render distortions if we can't support them.
-		return 0;
-	}
-
 	batch_item *item = NULL;
 
 	SCP_map<int, batch_item>::iterator it = distortion_map.find(texture);
@@ -1176,11 +1171,6 @@ int distortion_add_beam(int texture, int tmap_flags, vec3d *start, vec3d *end, f
 	if (texture < 0) {
 		Int3();
 		return 1;
-	}
-
-	if ( GLSL_version < 120 ) {
-		// don't render distortions if we can't support them.
-		return 0;
 	}
 
 	batch_item *item = NULL;

--- a/code/graphics/opengl/gropengl.cpp
+++ b/code/graphics/opengl/gropengl.cpp
@@ -1641,7 +1641,7 @@ bool gr_opengl_is_capable(gr_capability capability)
 	case CAPABILITY_BATCHED_SUBMODELS:
 		return true;
 	case CAPABILITY_POINT_PARTICLES:
-		return true && !Cmdline_no_geo_sdr_effects;
+		return !Cmdline_no_geo_sdr_effects;
 	case CAPABILITY_TIMESTAMP_QUERY:
 		return GL_version >= 33; // Timestamp queries are available from 3.3 onwards
 	}

--- a/code/graphics/opengl/gropengl.cpp
+++ b/code/graphics/opengl/gropengl.cpp
@@ -1434,12 +1434,6 @@ static void init_extensions() {
 		Error(LOCATION,  "Current GL Shading Langauge Version of %d is less than the required version of %d. Switch video modes or update your drivers.", GLSL_version, MIN_REQUIRED_GLSL_VERSION);
 	}
 
-	if ( GLSL_version < 120 ) {
-		mprintf(("  No hardware support for deferred lighting. Deferred lighting will be disabled. \n"));
-		Cmdline_no_deferred_lighting = 1;
-		Cmdline_no_batching = true;
-	}
-
 	GLint max_texture_units;
 	glGetIntegerv(GL_MAX_TEXTURE_IMAGE_UNITS, &max_texture_units);
 
@@ -1453,8 +1447,7 @@ static void init_extensions() {
 		Cmdline_normal = 0;
 		Cmdline_height = 0;
 	} else if (max_texture_units < 4) {
-		mprintf(( "Not enough texture units found for GLSL support. We need at least 4, we found %d.\n", max_texture_units ));
-		GLSL_version = 0;
+		Error(LOCATION, "Not enough texture units found for proper rendering support! We need at least 4, we found %d.", max_texture_units);
 	}
 }
 
@@ -1646,15 +1639,15 @@ bool gr_opengl_is_capable(gr_capability capability)
 		return Cmdline_height ? true : false;
 	case CAPABILITY_SOFT_PARTICLES:
 	case CAPABILITY_DISTORTION:
-		return Cmdline_softparticles && (GLSL_version >= 120) && !Cmdline_no_fbo;
+		return Cmdline_softparticles && !Cmdline_no_fbo;
 	case CAPABILITY_POST_PROCESSING:
-		return Cmdline_postprocess && (GLSL_version >= 120) && !Cmdline_no_fbo;
+		return Cmdline_postprocess  && !Cmdline_no_fbo;
 	case CAPABILITY_DEFERRED_LIGHTING:
-		return !Cmdline_no_fbo && !Cmdline_no_deferred_lighting && (GLSL_version >= 120);
+		return !Cmdline_no_fbo && !Cmdline_no_deferred_lighting;
 	case CAPABILITY_SHADOWS:
 		return GL_version >= 32;
 	case CAPABILITY_BATCHED_SUBMODELS:
-		return (GLSL_version >= 150);
+		return true;
 	case CAPABILITY_POINT_PARTICLES:
 		return GL_version >= 32 && !Cmdline_no_geo_sdr_effects;
 	case CAPABILITY_TIMESTAMP_QUERY:

--- a/code/graphics/opengl/gropengl.cpp
+++ b/code/graphics/opengl/gropengl.cpp
@@ -406,10 +406,8 @@ void gr_opengl_shutdown()
 
 	GL_initted = false;
 
-	if ( GL_version >= 30 ) {
-		glDeleteVertexArrays(1, &GL_vao);
-		GL_vao = 0;
-	}
+	glDeleteVertexArrays(1, &GL_vao);
+	GL_vao = 0;
 	
 	if (GL_original_gamma_ramp != NULL && os::getSDLMainWindow() != nullptr) {
 		SDL_SetWindowGammaRamp( os::getSDLMainWindow(), GL_original_gamma_ramp, (GL_original_gamma_ramp+256), (GL_original_gamma_ramp+512) );
@@ -1536,11 +1534,9 @@ bool gr_opengl_init(std::unique_ptr<os::GraphicsOperations>&& graphicsOps)
 	glGetIntegerv(GL_MAX_TEXTURE_IMAGE_UNITS, &max_texture_units);
 	max_texture_coords = 1;
 
-	// create vertex array object to make OpenGL Core happy if we can
-	if ( GL_version >= 30 ) {
-		glGenVertexArrays(1, &GL_vao);
-		glBindVertexArray(GL_vao);
-	}
+	// create vertex array object to make OpenGL Core happy
+	glGenVertexArrays(1, &GL_vao);
+	glBindVertexArray(GL_vao);
 
 	GL_state.Texture.init(max_texture_units);
 	GL_state.Array.init(max_texture_coords);
@@ -1626,10 +1622,6 @@ bool gr_opengl_init(std::unique_ptr<os::GraphicsOperations>&& graphicsOps)
 
 bool gr_opengl_is_capable(gr_capability capability)
 {
-	if ( GL_version < 20 ) {
-		return false;
-	}
-
 	switch ( capability ) {
 	case CAPABILITY_ENVIRONMENT_MAP:
 		return true;
@@ -1645,11 +1637,11 @@ bool gr_opengl_is_capable(gr_capability capability)
 	case CAPABILITY_DEFERRED_LIGHTING:
 		return !Cmdline_no_fbo && !Cmdline_no_deferred_lighting;
 	case CAPABILITY_SHADOWS:
-		return GL_version >= 32;
+		return true;
 	case CAPABILITY_BATCHED_SUBMODELS:
 		return true;
 	case CAPABILITY_POINT_PARTICLES:
-		return GL_version >= 32 && !Cmdline_no_geo_sdr_effects;
+		return true && !Cmdline_no_geo_sdr_effects;
 	case CAPABILITY_TIMESTAMP_QUERY:
 		return GL_version >= 33; // Timestamp queries are available from 3.3 onwards
 	}

--- a/code/graphics/opengl/gropengldraw.cpp
+++ b/code/graphics/opengl/gropengldraw.cpp
@@ -2040,7 +2040,7 @@ void opengl_clear_deferred_buffers()
 
 void gr_opengl_deferred_lighting_begin()
 {
-	if (GLSL_version < 120 || Cmdline_no_deferred_lighting)
+	if ( Cmdline_no_deferred_lighting)
 		return;
 
 	Deferred_lighting = true;
@@ -2070,7 +2070,7 @@ void gr_opengl_deferred_lighting_finish()
 {
 	TRACE_SCOPE(tracing::ApplyLights);
 
-	if ( GLSL_version < 120 || Cmdline_no_deferred_lighting ) {
+	if ( Cmdline_no_deferred_lighting ) {
 		return;
 	}
 

--- a/code/graphics/opengl/gropenglshader.cpp
+++ b/code/graphics/opengl/gropenglshader.cpp
@@ -601,13 +601,11 @@ int opengl_compile_shader(shader_type sdr, uint flags)
 	opengl_shader_set_current(&new_shader);
 
 	// bind fragment data locations
-	if ( GL_version >= 32 ) {
-		glBindFragDataLocation(new_shader.program->getShaderHandle(), 0, "fragOut0");
-		glBindFragDataLocation(new_shader.program->getShaderHandle(), 1, "fragOut1");
-		glBindFragDataLocation(new_shader.program->getShaderHandle(), 2, "fragOut2");
-		glBindFragDataLocation(new_shader.program->getShaderHandle(), 3, "fragOut3");
-		glBindFragDataLocation(new_shader.program->getShaderHandle(), 4, "fragOut4");
-	}
+	glBindFragDataLocation(new_shader.program->getShaderHandle(), 0, "fragOut0");
+	glBindFragDataLocation(new_shader.program->getShaderHandle(), 1, "fragOut1");
+	glBindFragDataLocation(new_shader.program->getShaderHandle(), 2, "fragOut2");
+	glBindFragDataLocation(new_shader.program->getShaderHandle(), 3, "fragOut3");
+	glBindFragDataLocation(new_shader.program->getShaderHandle(), 4, "fragOut4");
 
 	// initialize uniforms and attributes
 	for (auto& unif : sdr_info->uniforms) {

--- a/code/graphics/opengl/gropenglshader.cpp
+++ b/code/graphics/opengl/gropenglshader.cpp
@@ -601,7 +601,7 @@ int opengl_compile_shader(shader_type sdr, uint flags)
 	opengl_shader_set_current(&new_shader);
 
 	// bind fragment data locations
-	if ( GL_version >= 32 && GLSL_version >= 150 ) {
+	if ( GL_version >= 32 ) {
 		glBindFragDataLocation(new_shader.program->getShaderHandle(), 0, "fragOut0");
 		glBindFragDataLocation(new_shader.program->getShaderHandle(), 1, "fragOut1");
 		glBindFragDataLocation(new_shader.program->getShaderHandle(), 2, "fragOut2");

--- a/code/graphics/opengl/gropenglstate.cpp
+++ b/code/graphics/opengl/gropenglstate.cpp
@@ -153,11 +153,9 @@ void opengl_state::init()
 		clipplane_Status[i] = GL_FALSE;
 	}
 
-	if (GL_version >= 30) {
-		for (i = 0; i < (int)(sizeof(clipdistance_Status) / sizeof(GLboolean)); i++) {
-			//glDisable(GL_CLIP_DISTANCE0+i);
-			clipdistance_Status[i] = GL_FALSE;
-		}
+	for (i = 0; i < (int)(sizeof(clipdistance_Status) / sizeof(GLboolean)); i++) {
+		//glDisable(GL_CLIP_DISTANCE0+i);
+		clipdistance_Status[i] = GL_FALSE;
 	}
 
 	glDepthMask(GL_FALSE);
@@ -334,7 +332,7 @@ GLboolean opengl_state::ClipPlane(GLint num, GLint state)
 
 GLboolean opengl_state::ClipDistance(GLint num, GLint state)
 {
-	Assert( (num >= 0) || (num < (int)(sizeof(clipdistance_Status) / sizeof(GLboolean))) || GL_version >= 30 );
+	Assert( (num >= 0) && (num < (int)(sizeof(clipdistance_Status) / sizeof(GLboolean))) );
 
 	GLboolean save_state = clipdistance_Status[num];
 
@@ -700,9 +698,7 @@ void opengl_array_state::BindUniformBuffer(GLuint id)
 
 void gr_opengl_clear_states()
 {
-	if ( GL_version >= 30 ) {
-		glBindVertexArray(GL_vao);
-	}
+	glBindVertexArray(GL_vao);
 
 	gr_zbias(0);
 	gr_zbuffer_set(ZBUFFER_TYPE_READ);

--- a/code/graphics/opengl/gropengltnl.cpp
+++ b/code/graphics/opengl/gropengltnl.cpp
@@ -266,10 +266,6 @@ void opengl_reset_immediate_buffer()
 
 int opengl_create_texture_buffer_object()
 {
-	if ( GLSL_version < 130 ) {
-		return -1;
-	}
-
 	// create the buffer
 	int buffer_object_handle = opengl_create_buffer_object(GL_TEXTURE_BUFFER, GL_DYNAMIC_DRAW);
 

--- a/code/graphics/paths/NVGRenderer.cpp
+++ b/code/graphics/paths/NVGRenderer.cpp
@@ -50,9 +50,7 @@ namespace
 		GL_state.Texture.SetActiveUnit(0);
 		GL_state.Texture.SetTarget(0);
 
-		if ( GL_version >= 30 ) {
-			glBindVertexArray(GL_vao);
-		}
+		glBindVertexArray(GL_vao);
 
 		GL_state.Array.BindArrayBuffer(0);
 		GL_state.Array.BindUniformBuffer(0);
@@ -105,9 +103,7 @@ namespace graphics
 		{
 			GR_DEBUG_SCOPE("NanoVG flush");
 
-			if ( GL_version >= 30 ) {
-				glBindVertexArray(0);
-			}
+			glBindVertexArray(0);
 
 			gr_opengl_set_2d_matrix();
 

--- a/code/model/modelinterp.cpp
+++ b/code/model/modelinterp.cpp
@@ -2283,10 +2283,8 @@ void interp_configure_vertex_buffers(polymodel *pm, int mn)
 		polygon_list[i].n_verts = vert_count;
 
 		// set submodel ID
-		if ( GLSL_version >= 150 ) {
-			for ( j = 0; j < polygon_list[i].n_verts; ++j ) {
-				polygon_list[i].submodels[j] = mn;
-			}
+		for ( j = 0; j < polygon_list[i].n_verts; ++j ) {
+			polygon_list[i].submodels[j] = mn;
 		}
 
 		// for the moment we can only support INT_MAX worth of verts per index buffer
@@ -2343,9 +2341,7 @@ void interp_configure_vertex_buffers(polymodel *pm, int mn)
 			memcpy( (model_list->tsb) + model_list->n_verts, polygon_list[i].tsb, sizeof(tsb_t) * polygon_list[i].n_verts );
 		}
 
-		if ( GLSL_version >= 150 ) {
-			memcpy( (model_list->submodels) + model_list->n_verts, polygon_list[i].submodels, sizeof(int) * polygon_list[i].n_verts );
-		}
+		memcpy( (model_list->submodels) + model_list->n_verts, polygon_list[i].submodels, sizeof(int) * polygon_list[i].n_verts );
 
 		model_list->n_verts += polygon_list[i].n_verts;
 	}
@@ -2363,7 +2359,6 @@ void interp_configure_vertex_buffers(polymodel *pm, int mn)
 	}
 
 	if ( model_list->submodels != NULL ) {
-		Assert( GLSL_version >= 150 );
 		vertex_flags |= VB_FLAG_MODEL_ID;
 	}
 

--- a/code/model/modelread.cpp
+++ b/code/model/modelread.cpp
@@ -893,7 +893,7 @@ void create_vertex_buffer(polymodel *pm)
 
 	bool use_batched_rendering = true;
 
-	if ( GLSL_version >= 150 && !Cmdline_no_batching ) {
+	if ( !Cmdline_no_batching ) {
 		size_t stride = 0;
 
 		// figure out if the vertex stride of this entire model matches. if not, turn off batched rendering for this model
@@ -2589,7 +2589,7 @@ void model_load_texture(polymodel *pm, int i, char *file)
 	gr_maybe_create_shader(SDR_TYPE_MODEL, shader_flags | SDR_FLAG_MODEL_LIGHT);
 	gr_maybe_create_shader(SDR_TYPE_MODEL, shader_flags | SDR_FLAG_MODEL_LIGHT | SDR_FLAG_MODEL_FOG);
 	
-	if( !Cmdline_no_batching && GLSL_version >= 150 ) {
+	if( !Cmdline_no_batching ) {
 		shader_flags &= ~SDR_FLAG_MODEL_DEFERRED;
 		shader_flags |= SDR_FLAG_MODEL_TRANSFORM;
 


### PR DESCRIPTION
These are now unneeded since we check for OpenGL 3.2 and GLSL 1.50 support when starting the engine. After that, these conditions were always true which means that they weren't needed anymore.