### PR TITLE
Fix two bugs with transferring energy to/from shields/weapons.

### DIFF
--- a/code/object/objectshield.cpp
+++ b/code/object/objectshield.cpp
@@ -87,7 +87,7 @@ void shield_add_strength(object *objp, float delta) {
 	float shield_str = shield_get_strength(objp);
 	float shield_recharge_limit = shield_get_max_strength(objp);
 
-	if (shield_str >= shield_recharge_limit)
+	if ((delta > 0.0f) && (shield_str >= shield_recharge_limit))
 		return;
 
 	if (!(Ai_info[Ships[objp->instance].ai_index].ai_profile_flags[AI::Profile_Flags::Smart_shield_management])

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -8132,7 +8132,7 @@ void ship_chase_shield_energy_targets(ship *shipp, object *obj, float frametime)
 		shield_add_strength(obj, delta);
 		shipp->target_shields_delta -= delta;
 	} else if (shipp->target_shields_delta < 0.0f) {
-		if (delta < -shipp->target_shields_delta)
+		//if (delta > -shipp->target_shields_delta)
 			delta = -shipp->target_shields_delta;
 
 		shield_add_strength(obj, -delta);
@@ -8148,7 +8148,7 @@ void ship_chase_shield_energy_targets(ship *shipp, object *obj, float frametime)
 		shipp->weapon_energy += delta;
 		shipp->target_weapon_energy_delta -= delta;
 	} else if (shipp->target_weapon_energy_delta < 0.0f) {
-		if (delta < -shipp->target_weapon_energy_delta)
+		//if (delta > -shipp->target_weapon_energy_delta)
 			delta = -shipp->target_weapon_energy_delta;
 
 		shipp->weapon_energy -= delta;


### PR DESCRIPTION
**The first fix: Allow transferring energy from shields to work properly at full shields.**

A conditional originally added to `shield_add_strength()` to make shields not recharge beyond the recharge limit forgot to check that the amount shields are changing by was positive (unlike a couple other conditionals added/modified around the same time), so a call to `shield_add_strength()` with a negative delta (e.g. when transferring energy from shields to weapons) when the current shield strength is at or above the recharge limit (i.e. full strength when a recharge limit isn't specified) would immediately return without doing anything. This would, of course, result in no change to shield strength... so if you had full shields and had drained your weapon batteries dry, you could get free energy by hitting the button to transfer energy from your shields.
<br>

**The second fix: Avoid silly behavior when transferring almost-nonexistent energy.**

This is a bit complicated to explain, so stick with me.

When transferring energy from shields to weapons (or vice versa), the values modified are the so-called "target deltas" rather than directly modifying the shield strength or weapon energy values. The `ship_chase_shield_energy_targets()` function carries out actually meeting these targets without exceeding a change of `ETS_RECHARGE_RATE` percent per second. At least, that's what it's *supposed* to do, and obviously works that way when the target delta is positive.

When the target delta is negative, however, a logic error with the conditional meant to limit the rate of change instead functions backwards; if the amount of desired change exceeds the per-frame limit, the amount of change is set to the total desired change, and if the amount of desired change is smaller than the per-frame limit, than the amount of change is the per-frame limit (even though that's more than the amount that's supposed to be drained).

Since the target delta is modified by the amount by which the value changed, this leads to an interesting consequence whereby the "extra" amount taken away is added back in the next frame... which has another interesting side-effect if the "extra" drain tried to reduce shields below 0. Namely, the shield code doesn't let it, while `ship_chase_shield_energy_targets()` remains blissfully unaware that the actual change was smaller than requested. So on the next frame, you spontaneously get some fraction of a percent of your shields back. Which, naturally, you can then transfer energy from to your weapons *ad infinitum;* the amount is small, but you can continually transfer it, so you're getting weapon energy out of nowhere.

Now, straight-up fixing the logic error would be a major retail balance change; if transferring energy from your shields to your weapons only gradually reduced your shields, instead of taking a huge chunk at the start, it would be a much safer option. Therefore, the only non-balance-changing fix is to just remove the broken conditional entirely (so that it always drains the full amount instantaneously, regardless of how big or small it is).

I've left the fixed conditional commented out so that somebody, when we're not in a feature freeze, can add an AI profile or mod table flag to restore the check, allowing for slow energy transfers.

An interesting consequence of this fix is that trying to transfer small quantities of shielding will result in smaller and smaller amounts of shielding trying to transfer to weapons, so small that the user cannot notice any change (because you're gaining an amount of energy on the order of 10^-45th), but since it's a nonzero amount, you still get the "transfer successful" sound. I'm not quite sure how to fix that without an outright behavior change; if anybody has a better idea, I'm all ears.