### PR TITLE
Fixes pointer access violation when docked ships warp out by moving...

### DIFF
--- a/code/missionui/redalert.cpp
+++ b/code/missionui/redalert.cpp
@@ -797,6 +797,7 @@ void red_alert_delete_ship(int shipnum, int ship_state)
 	}
 
 	Objects[shipp->objnum].flags.set(Object::Object_Flags::Should_be_dead);
+	dock_undock_all(&Objects[shipp->objnum]);
 	ship_cleanup(shipnum, cleanup_mode);
 }
 

--- a/code/object/objectdock.h
+++ b/code/object/objectdock.h
@@ -131,6 +131,7 @@ void dock_undock_objects(object *objp1, object *objp2);
 /**
  * @brief Undocks everything from the given object
  * @note This is a slow method. use dock_free_dock_list() when doing object cleanup.
+ * @note Currently, this function cannot be called from within ship_cleanup() [Github Issue #1177:https://github.com/scp-fs2open/fs2open.github.com/issues/1177]
  */
 void dock_undock_all(object *objp);
 

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -7530,8 +7530,6 @@ void ship_cleanup(int shipnum, int cleanup_mode)
 	// Goober5000 - lastly, clear out the dead-docked list, per Mantis #2294
 	// (for exploding ships, this list should have already been cleared by now, via
 	// do_dying_undock_physics, except in the case of the destroy-instantly sexp)
-	// z64555 - Also clear out the docked list, since a red-alert-carry ship could be docked with somebody
-	dock_undock_all(objp);
 	dock_dead_undock_all(objp);
 }
 


### PR DESCRIPTION
...dock_undock_all call to red_alert_delete.

It was previously thought that dock_undock_all() was supposed to be within ship_cleanup() and was safe to do so. Nope.

dock_evaluate_all_docked_objects makes the assumption that the dock_list is still valid, so if the function called by it happens to nuke the dock_list (like with ship_cleanup) then it'll work with invalid pointer values.

[Link to #1177]