### PR TITLE
Fix wrong usage of cockpit depth buffer

### DIFF
--- a/code/graphics/opengl/gropengl.cpp
+++ b/code/graphics/opengl/gropengl.cpp
@@ -1658,6 +1658,11 @@ void gr_opengl_pop_debug_group() {
 		glPopDebugGroup();
 	}
 }
+void opengl_set_object_label(GLenum type, GLuint handle, const SCP_string& name) {
+	if (GLAD_GL_KHR_debug) {
+		glObjectLabelKHR(type, handle, (GLsizei) name.size(), name.c_str());
+	}
+}
 
 uint opengl_data_type_size(GLenum data_type)
 {

--- a/code/graphics/opengl/gropengl.h
+++ b/code/graphics/opengl/gropengl.h
@@ -24,6 +24,17 @@ int opengl_check_for_errors(const char *err_at = NULL);
 bool gr_opengl_is_capable(gr_capability capability);
 void gr_opengl_push_debug_group(const char* name);
 void gr_opengl_pop_debug_group();
+
+/**
+ * @brief Assigns a string name to the specified handle
+ * @details This uses @c GL_KHR_debug for assigning a human readable name to an OpenGL object. This can help with debugging
+ *  since it makes it easier to identify which object is currently being used.
+ * @param type The type of the handle, e.g. GL_FRAMEBUFFER
+ * @param handle The handle of the object
+ * @param name The name of the object
+ */
+void opengl_set_object_label(GLenum type, GLuint handle, const SCP_string& name);
+
 uint opengl_data_type_size(GLenum data_type);
 
 #ifndef NDEBUG

--- a/code/graphics/opengl/gropengldraw.cpp
+++ b/code/graphics/opengl/gropengldraw.cpp
@@ -1576,7 +1576,8 @@ void opengl_setup_scene_textures()
 
 	// create framebuffer
 	glGenFramebuffers(1, &Scene_framebuffer);
-	glBindFramebuffer(GL_FRAMEBUFFER, Scene_framebuffer);
+	GL_state.BindFrameBuffer(Scene_framebuffer);
+	glObjectLabelKHR(GL_FRAMEBUFFER, Scene_framebuffer, -1, "Scene framebuffer");
 
 	// setup main render texture
 
@@ -1596,6 +1597,7 @@ void opengl_setup_scene_textures()
 	glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA16F, Scene_texture_width, Scene_texture_height, 0, GL_BGRA, GL_UNSIGNED_INT_8_8_8_8_REV, NULL);
 
 	glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, Scene_color_texture, 0);
+	glObjectLabelKHR(GL_TEXTURE, Scene_color_texture, -1, "Scene color texture");
 
 	// setup low dynamic range color texture
 	glGenTextures(1, &Scene_ldr_texture);
@@ -1611,6 +1613,7 @@ void opengl_setup_scene_textures()
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_R, GL_CLAMP_TO_EDGE);
 
 	glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, Scene_texture_width, Scene_texture_height, 0, GL_BGRA, GL_UNSIGNED_INT_8_8_8_8_REV, NULL);
+	glObjectLabelKHR(GL_TEXTURE, Scene_ldr_texture, -1, "Scene LDR texture");
 
 	// setup position render texture
 	glGenTextures(1, &Scene_position_texture);
@@ -1626,6 +1629,7 @@ void opengl_setup_scene_textures()
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_R, GL_CLAMP_TO_EDGE);
 
 	glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA16F, Scene_texture_width, Scene_texture_height, 0, GL_BGRA, GL_UNSIGNED_INT_8_8_8_8_REV, NULL);
+	glObjectLabelKHR(GL_TEXTURE, Scene_position_texture, -1, "Scene Position texture");
 
 	glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT1, GL_TEXTURE_2D, Scene_position_texture, 0);
 
@@ -1643,6 +1647,7 @@ void opengl_setup_scene_textures()
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_R, GL_CLAMP_TO_EDGE);
 
 	glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA16F, Scene_texture_width, Scene_texture_height, 0, GL_BGRA, GL_UNSIGNED_INT_8_8_8_8_REV, NULL);
+	glObjectLabelKHR(GL_TEXTURE, Scene_normal_texture, -1, "Scene Normal texture");
 
 	glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT2, GL_TEXTURE_2D, Scene_normal_texture, 0);
 
@@ -1660,6 +1665,7 @@ void opengl_setup_scene_textures()
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_R, GL_CLAMP_TO_EDGE);
 
 	glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, Scene_texture_width, Scene_texture_height, 0, GL_BGRA, GL_UNSIGNED_INT_8_8_8_8_REV, NULL);
+	glObjectLabelKHR(GL_TEXTURE, Scene_specular_texture, -1, "Scene Specular texture");
 
 	glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT3, GL_TEXTURE_2D, Scene_specular_texture, 0);
 
@@ -1678,6 +1684,7 @@ void opengl_setup_scene_textures()
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_R, GL_CLAMP_TO_EDGE);
 
 	glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA16F, Scene_texture_width, Scene_texture_height, 0, GL_BGRA, GL_UNSIGNED_INT_8_8_8_8_REV, NULL);
+	glObjectLabelKHR(GL_TEXTURE, Scene_luminance_texture, -1, "Scene Luminance texture");
 
 	// setup effect texture
 
@@ -1694,6 +1701,7 @@ void opengl_setup_scene_textures()
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_R, GL_CLAMP_TO_EDGE);
 
 	glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA16F, Scene_texture_width, Scene_texture_height, 0, GL_BGRA, GL_UNSIGNED_INT_8_8_8_8_REV, NULL);
+	glObjectLabelKHR(GL_TEXTURE, Scene_effect_texture, -1, "Scene Effect texture");
 
 	glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT4, GL_TEXTURE_2D, Scene_effect_texture, 0);
 
@@ -1712,6 +1720,8 @@ void opengl_setup_scene_textures()
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_COMPARE_MODE, GL_NONE);
 
 	glTexImage2D(GL_TEXTURE_2D, 0, GL_DEPTH_COMPONENT24, Scene_texture_width, Scene_texture_height, 0, GL_DEPTH_COMPONENT, GL_FLOAT, NULL);
+	glObjectLabelKHR(GL_TEXTURE, Cockpit_depth_texture, -1, "Cockpit depth texture");
+
 	glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_TEXTURE_2D, Cockpit_depth_texture, 0);
 	gr_zbuffer_set(GR_ZBUFF_FULL);
 	glClear(GL_DEPTH_BUFFER_BIT);
@@ -1731,6 +1741,7 @@ void opengl_setup_scene_textures()
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_COMPARE_MODE, GL_NONE);
 
 	glTexImage2D(GL_TEXTURE_2D, 0, GL_DEPTH_COMPONENT24, Scene_texture_width, Scene_texture_height, 0, GL_DEPTH_COMPONENT, GL_FLOAT, NULL);
+	glObjectLabelKHR(GL_TEXTURE, Scene_depth_texture, -1, "Scene depth texture");
 	glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_TEXTURE_2D, Scene_depth_texture, 0);
 
 	//setup main stencil buffer
@@ -1742,7 +1753,7 @@ void opengl_setup_scene_textures()
 	glReadBuffer(GL_COLOR_ATTACHMENT0);
 
 	if ( opengl_check_framebuffer() ) {
-		glBindFramebuffer(GL_FRAMEBUFFER, 0);
+		GL_state.BindFrameBuffer(0);
 		glDeleteFramebuffers(1, &Scene_framebuffer);
 		Scene_framebuffer = 0;
 
@@ -1779,7 +1790,7 @@ void opengl_setup_scene_textures()
     if (Cmdline_fb_thrusters || Cmdline_fb_explosions) 
     {
         glGenFramebuffers(1, &Distortion_framebuffer);
-        glBindFramebuffer(GL_FRAMEBUFFER, Distortion_framebuffer);
+		GL_state.BindFrameBuffer(Distortion_framebuffer);
 
         glGenTextures(2, Distortion_texture);
 
@@ -1810,7 +1821,7 @@ void opengl_setup_scene_textures()
 
 
 	if ( opengl_check_framebuffer() ) {
-		glBindFramebuffer(GL_FRAMEBUFFER, 0);
+		GL_state.BindFrameBuffer(0);
 		glDeleteFramebuffers(1, &Distortion_framebuffer);
 		Distortion_framebuffer = 0;
 
@@ -1829,7 +1840,7 @@ void opengl_setup_scene_textures()
 		return;
 	}
 
-	glBindFramebuffer(GL_FRAMEBUFFER, 0);
+	GL_state.BindFrameBuffer(0);
 
 	Scene_texture_initialized = 1;
 	Scene_framebuffer_in_frame = false;
@@ -1902,7 +1913,9 @@ void gr_opengl_scene_texture_begin()
 
 	GR_DEBUG_SCOPE("Begin scene texture");
 
-	glBindFramebuffer(GL_FRAMEBUFFER, Scene_framebuffer);
+	GL_state.PushFramebufferState();
+	GL_state.BindFrameBuffer(Scene_framebuffer);
+	//glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_TEXTURE_2D, Scene_depth_texture, 0);
 
 	if (GL_rendering_to_texture)
 	{
@@ -1967,7 +1980,7 @@ void gr_opengl_scene_texture_end()
 		GLboolean blend = GL_state.Blend(GL_FALSE);
 		GLboolean cull = GL_state.CullFace(GL_FALSE);
 
-		glBindFramebuffer(GL_FRAMEBUFFER, opengl_get_rtt_framebuffer());
+		GL_state.PopFramebufferState();
 
 		GL_state.Texture.SetActiveUnit(0);
 		GL_state.Texture.SetTarget(GL_TEXTURE_2D);
@@ -2046,6 +2059,8 @@ void gr_opengl_deferred_lighting_begin()
 	if ( Cmdline_no_deferred_lighting)
 		return;
 
+	GR_DEBUG_SCOPE("Deferred lighting begin");
+
 	Deferred_lighting = true;
 	glColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
 
@@ -2057,6 +2072,9 @@ void gr_opengl_deferred_lighting_end()
 {
 	if(!Deferred_lighting)
 		return;
+
+	GR_DEBUG_SCOPE("Deferred lighting end");
+
 	Deferred_lighting = false;
 	glDrawBuffer(GL_COLOR_ATTACHMENT0);
 
@@ -2071,6 +2089,7 @@ extern float static_tube_factor;
 
 void gr_opengl_deferred_lighting_finish()
 {
+	GR_DEBUG_SCOPE("Deferred lighting finish");
 	TRACE_SCOPE(tracing::ApplyLights);
 
 	if ( Cmdline_no_deferred_lighting ) {
@@ -2122,6 +2141,8 @@ void gr_opengl_deferred_lighting_finish()
 
 	for(int i = 0; i < Num_lights; ++i)
 	{
+		GR_DEBUG_SCOPE("Deferred apply single light");
+
 		light *l = &lights_copy[i];
 		Current_shader->program->Uniforms.setUniformi( "lightType", 0 );
 		switch(l->type)
@@ -2209,6 +2230,7 @@ void gr_opengl_deferred_lighting_finish()
 	GL_state.Texture.Enable(Scene_luminance_texture);
 
 	GL_state.SetAlphaBlendMode( ALPHA_BLEND_ADDITIVE );
+	GL_state.DepthMask(GL_FALSE);
 
 	opengl_draw_textured_quad(0.0f, 0.0f, 0.0f, Scene_texture_v_scale, (float)gr_screen.max_w, (float)gr_screen.max_h, Scene_texture_u_scale, 0.0f);
 
@@ -2270,7 +2292,9 @@ void gr_opengl_update_distortion()
 	GLboolean cull = GL_state.CullFace(GL_FALSE);
 
 	opengl_shader_set_passthrough(true, false);
-	glBindFramebuffer(GL_FRAMEBUFFER, Distortion_framebuffer);
+
+	GL_state.PushFramebufferState();
+	GL_state.BindFrameBuffer(Distortion_framebuffer);
 	glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, Distortion_texture[!Distortion_switch], 0);
 	glDrawBuffer(GL_COLOR_ATTACHMENT0);
 
@@ -2339,7 +2363,7 @@ void gr_opengl_update_distortion()
 	Distortion_switch = !Distortion_switch;
 
 	// reset state
-	glBindFramebuffer(GL_FRAMEBUFFER, Scene_framebuffer);
+	GL_state.PopFramebufferState();
 
 	glViewport(0,0,gr_screen.max_w,gr_screen.max_h);
 

--- a/code/graphics/opengl/gropengldraw.cpp
+++ b/code/graphics/opengl/gropengldraw.cpp
@@ -1900,6 +1900,8 @@ void gr_opengl_scene_texture_begin()
 		return;
 	}
 
+	GR_DEBUG_SCOPE("Begin scene texture");
+
 	glBindFramebuffer(GL_FRAMEBUFFER, Scene_framebuffer);
 
 	if (GL_rendering_to_texture)
@@ -2016,6 +2018,8 @@ void gr_opengl_copy_effect_texture()
 
 void opengl_clear_deferred_buffers()
 {
+	GR_DEBUG_SCOPE("Clear deferred buffers");
+
 	GLboolean depth = GL_state.DepthTest(GL_FALSE);
 	GLboolean depth_mask = GL_state.DepthMask(GL_FALSE);
 	GLboolean blend = GL_state.Blend(GL_FALSE);
@@ -2347,6 +2351,8 @@ void gr_opengl_update_distortion()
 
 void opengl_render_primitives(primitive_type prim_type, vertex_layout* layout, int n_verts, int buffer_handle, size_t vert_offset, size_t byte_offset)
 {
+	GR_DEBUG_SCOPE("Render primitives");
+
 	if ( buffer_handle >= 0 ) {
 		opengl_bind_buffer_object(buffer_handle);
 	} else {

--- a/code/graphics/opengl/gropengldraw.cpp
+++ b/code/graphics/opengl/gropengldraw.cpp
@@ -1577,7 +1577,7 @@ void opengl_setup_scene_textures()
 	// create framebuffer
 	glGenFramebuffers(1, &Scene_framebuffer);
 	GL_state.BindFrameBuffer(Scene_framebuffer);
-	glObjectLabelKHR(GL_FRAMEBUFFER, Scene_framebuffer, -1, "Scene framebuffer");
+	opengl_set_object_label(GL_FRAMEBUFFER, Scene_framebuffer, "Scene framebuffer");
 
 	// setup main render texture
 
@@ -1597,7 +1597,7 @@ void opengl_setup_scene_textures()
 	glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA16F, Scene_texture_width, Scene_texture_height, 0, GL_BGRA, GL_UNSIGNED_INT_8_8_8_8_REV, NULL);
 
 	glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, Scene_color_texture, 0);
-	glObjectLabelKHR(GL_TEXTURE, Scene_color_texture, -1, "Scene color texture");
+	opengl_set_object_label(GL_TEXTURE, Scene_color_texture, "Scene color texture");
 
 	// setup low dynamic range color texture
 	glGenTextures(1, &Scene_ldr_texture);
@@ -1613,7 +1613,7 @@ void opengl_setup_scene_textures()
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_R, GL_CLAMP_TO_EDGE);
 
 	glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, Scene_texture_width, Scene_texture_height, 0, GL_BGRA, GL_UNSIGNED_INT_8_8_8_8_REV, NULL);
-	glObjectLabelKHR(GL_TEXTURE, Scene_ldr_texture, -1, "Scene LDR texture");
+	opengl_set_object_label(GL_TEXTURE, Scene_ldr_texture, "Scene LDR texture");
 
 	// setup position render texture
 	glGenTextures(1, &Scene_position_texture);
@@ -1629,7 +1629,7 @@ void opengl_setup_scene_textures()
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_R, GL_CLAMP_TO_EDGE);
 
 	glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA16F, Scene_texture_width, Scene_texture_height, 0, GL_BGRA, GL_UNSIGNED_INT_8_8_8_8_REV, NULL);
-	glObjectLabelKHR(GL_TEXTURE, Scene_position_texture, -1, "Scene Position texture");
+	opengl_set_object_label(GL_TEXTURE, Scene_position_texture, "Scene Position texture");
 
 	glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT1, GL_TEXTURE_2D, Scene_position_texture, 0);
 
@@ -1647,7 +1647,7 @@ void opengl_setup_scene_textures()
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_R, GL_CLAMP_TO_EDGE);
 
 	glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA16F, Scene_texture_width, Scene_texture_height, 0, GL_BGRA, GL_UNSIGNED_INT_8_8_8_8_REV, NULL);
-	glObjectLabelKHR(GL_TEXTURE, Scene_normal_texture, -1, "Scene Normal texture");
+	opengl_set_object_label(GL_TEXTURE, Scene_normal_texture, "Scene Normal texture");
 
 	glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT2, GL_TEXTURE_2D, Scene_normal_texture, 0);
 
@@ -1665,7 +1665,7 @@ void opengl_setup_scene_textures()
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_R, GL_CLAMP_TO_EDGE);
 
 	glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, Scene_texture_width, Scene_texture_height, 0, GL_BGRA, GL_UNSIGNED_INT_8_8_8_8_REV, NULL);
-	glObjectLabelKHR(GL_TEXTURE, Scene_specular_texture, -1, "Scene Specular texture");
+	opengl_set_object_label(GL_TEXTURE, Scene_specular_texture, "Scene Specular texture");
 
 	glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT3, GL_TEXTURE_2D, Scene_specular_texture, 0);
 
@@ -1684,7 +1684,7 @@ void opengl_setup_scene_textures()
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_R, GL_CLAMP_TO_EDGE);
 
 	glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA16F, Scene_texture_width, Scene_texture_height, 0, GL_BGRA, GL_UNSIGNED_INT_8_8_8_8_REV, NULL);
-	glObjectLabelKHR(GL_TEXTURE, Scene_luminance_texture, -1, "Scene Luminance texture");
+	opengl_set_object_label(GL_TEXTURE, Scene_luminance_texture, "Scene Luminance texture");
 
 	// setup effect texture
 
@@ -1701,7 +1701,7 @@ void opengl_setup_scene_textures()
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_R, GL_CLAMP_TO_EDGE);
 
 	glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA16F, Scene_texture_width, Scene_texture_height, 0, GL_BGRA, GL_UNSIGNED_INT_8_8_8_8_REV, NULL);
-	glObjectLabelKHR(GL_TEXTURE, Scene_effect_texture, -1, "Scene Effect texture");
+	opengl_set_object_label(GL_TEXTURE, Scene_effect_texture, "Scene Effect texture");
 
 	glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT4, GL_TEXTURE_2D, Scene_effect_texture, 0);
 
@@ -1720,7 +1720,7 @@ void opengl_setup_scene_textures()
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_COMPARE_MODE, GL_NONE);
 
 	glTexImage2D(GL_TEXTURE_2D, 0, GL_DEPTH_COMPONENT24, Scene_texture_width, Scene_texture_height, 0, GL_DEPTH_COMPONENT, GL_FLOAT, NULL);
-	glObjectLabelKHR(GL_TEXTURE, Cockpit_depth_texture, -1, "Cockpit depth texture");
+	opengl_set_object_label(GL_TEXTURE, Cockpit_depth_texture, "Cockpit depth texture");
 
 	glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_TEXTURE_2D, Cockpit_depth_texture, 0);
 	gr_zbuffer_set(GR_ZBUFF_FULL);
@@ -1741,7 +1741,7 @@ void opengl_setup_scene_textures()
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_COMPARE_MODE, GL_NONE);
 
 	glTexImage2D(GL_TEXTURE_2D, 0, GL_DEPTH_COMPONENT24, Scene_texture_width, Scene_texture_height, 0, GL_DEPTH_COMPONENT, GL_FLOAT, NULL);
-	glObjectLabelKHR(GL_TEXTURE, Scene_depth_texture, -1, "Scene depth texture");
+	opengl_set_object_label(GL_TEXTURE, Scene_depth_texture, "Scene depth texture");
 	glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_TEXTURE_2D, Scene_depth_texture, 0);
 
 	//setup main stencil buffer

--- a/code/graphics/opengl/gropengldraw.h
+++ b/code/graphics/opengl/gropengldraw.h
@@ -109,6 +109,8 @@ inline void opengl_draw_textured_quad(
 	GLfloat x1, GLfloat y1, GLfloat u1, GLfloat v1,
 	GLfloat x2, GLfloat y2, GLfloat u2, GLfloat v2 )
 {
+	GR_DEBUG_SCOPE("Draw textured quad");
+
 	GLfloat glVertices[4][4] = {
 		{ x1, y1, u1, v1 },
 		{ x1, y2, u1, v2 },

--- a/code/graphics/opengl/gropenglshader.cpp
+++ b/code/graphics/opengl/gropenglshader.cpp
@@ -227,6 +227,8 @@ opengl_shader_t *Current_shader = NULL;
 void opengl_shader_set_current(opengl_shader_t *shader_obj)
 {
 	if (Current_shader != shader_obj) {
+		GR_DEBUG_SCOPE("Set shader");
+
 		GL_state.Array.ResetVertexAttribs();
 
 		if(shader_obj) {

--- a/code/graphics/opengl/gropenglstate.cpp
+++ b/code/graphics/opengl/gropenglstate.cpp
@@ -180,6 +180,11 @@ void opengl_state::init()
 
 	current_program = 0;
 	glUseProgram(0);
+
+	current_framebuffer = 0;
+	glBindFramebuffer(GL_FRAMEBUFFER, 0);
+
+	framebuffer_stack.clear();
 }
 
 GLboolean opengl_state::Blend(GLint state)
@@ -507,6 +512,23 @@ void opengl_state::UseProgram(GLuint program)
 }
 bool opengl_state::IsCurrentProgram(GLuint program) {
 	return current_program == program;
+}
+void opengl_state::BindFrameBuffer(GLuint name) {
+	if (current_framebuffer != name) {
+		glBindFramebuffer(GL_FRAMEBUFFER, name);
+		current_framebuffer = name;
+	}
+}
+void opengl_state::PushFramebufferState() {
+	framebuffer_stack.push_back(current_framebuffer);
+}
+void opengl_state::PopFramebufferState() {
+	Assertion(framebuffer_stack.size() > 0, "Tried to pop the framebuffer state stack while it was empty!");
+
+	auto restoreBuffer = framebuffer_stack.back();
+	framebuffer_stack.pop_back();
+
+	BindFrameBuffer(restoreBuffer);
 }
 
 opengl_array_state::~opengl_array_state()

--- a/code/graphics/opengl/gropenglstate.h
+++ b/code/graphics/opengl/gropenglstate.h
@@ -173,6 +173,10 @@ class opengl_state
         gr_stencil_type Current_stencil_type;
 
 		GLuint current_program;
+
+		// The framebuffer state actually consists of draw and read buffers but we only use both at the same time
+		GLuint current_framebuffer;
+		SCP_vector<GLuint> framebuffer_stack;
 	public:
 		opengl_state() {}
 		~opengl_state() {}
@@ -213,6 +217,11 @@ class opengl_state
 
 		void UseProgram(GLuint program);
 		bool IsCurrentProgram(GLuint program);
+
+		void BindFrameBuffer(GLuint name);
+
+		void PushFramebufferState();
+		void PopFramebufferState();
 };
 
 inline GLenum opengl_state::FrontFaceValue(GLenum new_val)
@@ -276,6 +285,5 @@ extern opengl_state GL_state;
 
 void gr_opengl_clear_states();
 void opengl_setup_render_states(int &r,int &g,int &b,int &alpha, int &tmap_type, int flags, int is_scaler = 0);
-
 
 #endif	// _GROPENGLSTATE_H

--- a/code/graphics/opengl/gropengltexture.cpp
+++ b/code/graphics/opengl/gropengltexture.cpp
@@ -1583,7 +1583,7 @@ int opengl_set_render_target( int slot, int face, int is_static )
 
 		glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, 0, 0);
 
-		glBindFramebuffer(GL_FRAMEBUFFER, 0);
+		GL_state.BindFrameBuffer(0);
 		glBindRenderbuffer(GL_RENDERBUFFER, 0);
 
 		if (render_target != NULL) {
@@ -1622,7 +1622,7 @@ int opengl_set_render_target( int slot, int face, int is_static )
 	}
 
 //	glBindRenderbuffer(GL_RENDERBUFFER, fbo->renderbuffer_id);
-	glBindFramebuffer(GL_FRAMEBUFFER, fbo->framebuffer_id);
+	GL_state.BindFrameBuffer(fbo->framebuffer_id);
 
 	if (ts->texture_target == GL_TEXTURE_CUBE_MAP) {
 		Assert( (face >= 0) && (face < 6) );
@@ -1819,7 +1819,7 @@ int opengl_make_render_target( int handle, int slot, int *w, int *h, int *bpp, i
 
 	// frame buffer
 	glGenFramebuffers(1, &new_fbo.framebuffer_id);
-	glBindFramebuffer(GL_FRAMEBUFFER, new_fbo.framebuffer_id);
+	GL_state.BindFrameBuffer(new_fbo.framebuffer_id);
 
 	if (flags & BMP_FLAG_CUBEMAP) {
 		glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_CUBE_MAP_POSITIVE_X, ts->texture_id, 0);
@@ -1833,7 +1833,7 @@ int opengl_make_render_target( int handle, int slot, int *w, int *h, int *bpp, i
 		// Oops!!  reset everything and then bail
 		mprintf(("OpenGL: Unable to create FBO!\n"));
 
-		glBindFramebuffer(GL_FRAMEBUFFER, 0);
+		GL_state.BindFrameBuffer(0);
 
 		GL_state.Texture.Delete(ts->texture_id);
 		glDeleteTextures(1, &ts->texture_id);
@@ -1872,7 +1872,7 @@ int opengl_make_render_target( int handle, int slot, int *w, int *h, int *bpp, i
 	glClearColor(0.0f,0.0f,0.0f,1.0f);
 	glClear(GL_COLOR_BUFFER_BIT);
 
-	glBindFramebuffer(GL_FRAMEBUFFER, 0);
+	GL_state.BindFrameBuffer(0);
 
 	new_fbo.ref_count++;
 

--- a/code/graphics/opengl/gropengltnl.cpp
+++ b/code/graphics/opengl/gropengltnl.cpp
@@ -226,6 +226,8 @@ int gr_opengl_create_index_buffer(bool static_buffer)
 
 uint opengl_add_to_immediate_buffer(uint size, void *data)
 {
+	GR_DEBUG_SCOPE("Add data to immediate buffer");
+
 	if ( GL_immediate_buffer_handle < 0 ) {
 		GL_immediate_buffer_handle = opengl_create_buffer_object(GL_ARRAY_BUFFER, GL_STREAM_DRAW);
 	}

--- a/code/render/batching.cpp
+++ b/code/render/batching.cpp
@@ -859,6 +859,7 @@ void batching_add_tri(int texture, vertex *verts)
 
 void batching_render_batch_item(primitive_batch_item *item, vertex_layout *layout, primitive_type prim_type, int buffer_num)
 {
+	GR_DEBUG_SCOPE("Batching render item");
 	TRACE_SCOPE(tracing::RenderBatchItem);
 
 	if ( item->batch_item_info.mat_type == batch_info::VOLUME_EMISSIVE ) { // Cmdline_softparticles
@@ -914,6 +915,7 @@ void batching_allocate_and_load_buffer(primitive_batch_buffer *draw_queue)
 
 void batching_load_buffers(bool distortion)
 {
+	GR_DEBUG_SCOPE("Batching load buffers");
 	TRACE_SCOPE(tracing::LoadBatchingBuffers);
 
 	SCP_map<batch_info, primitive_batch>::iterator bi;
@@ -962,6 +964,7 @@ void batching_load_buffers(bool distortion)
 
 void batching_render_buffer(primitive_batch_buffer *buffer)
 {
+	GR_DEBUG_SCOPE("Batching render buffer");
 	TRACE_SCOPE(tracing::RenderBatchBuffer);
 
 	size_t num_batches = buffer->items.size();

--- a/code/scripting/scripting.cpp
+++ b/code/scripting/scripting.cpp
@@ -848,6 +848,8 @@ int script_state::RunBytecodeSub(script_function& func, char format, void *data)
 		return 1;
 	}
 
+	GR_DEBUG_SCOPE("Lua code");
+
 	try {
 		auto ret = func.function.call();
 


### PR DESCRIPTION
The root issue of #976 was that the code that reset the depth buffer of
the scene framebuffer was actually setting the depth buffer of the bloom
framebuffer since that didn't get reset properly. To fix this I
introduced a system in our GL_state which keeps track of a stack of
"bound" framebuffers which allows us to return to the previous
framebuffer with a simple function call.

I also added support for GL_KHR_debug since that help me while debugging
which texture was in use. In the future I'll probably extend that to
other areas of the OpenGL code as needed.

This fixes #976.