### PR TITLE
Show error message when a data directory uses the wrong case

### DIFF
--- a/code/cfile/cfilesystem.cpp
+++ b/code/cfile/cfilesystem.cpp
@@ -16,14 +16,13 @@
 #include <sstream>
 #include <algorithm>
 #include <memory>
-#include <locale>
-#include <codecvt>
 
 #ifdef _WIN32
 #include <io.h>
 #include <direct.h>
 #include <windows.h>
 #include <winbase.h>		/* needed for memory mapping of file functions */
+#include <shlwapi.h>
 
 struct dir_handle_deleter {
 	typedef HANDLE pointer;
@@ -686,7 +685,7 @@ void cf_search_root_path(int root_index)
 			// According to the documentation of dirname and basename, the return value does not need to be freed
 			auto search_name = basename(basename_copy);
 
-			auto parentDirP = unique_dir_ptr(opendir(directory_name.c_str()));
+			auto parentDirP = unique_dir_ptr(opendir(directory_name));
 			if (parentDirP) {
 				struct dirent *dir = nullptr;
 				while ((dir = readdir (parentDirP.get())) != nullptr) {
@@ -696,7 +695,7 @@ void cf_search_root_path(int root_index)
 					}
 
 					SCP_string fn;
-					sprintf(fn, "%s/%s", directory_name.c_str(), dir->d_name);
+					sprintf(fn, "%s/%s", directory_name, dir->d_name);
 
 					struct stat buf;
 					if (stat(fn.c_str(), &buf) == -1) {

--- a/code/cfile/cfilesystem.cpp
+++ b/code/cfile/cfilesystem.cpp
@@ -30,6 +30,8 @@
 #include <fnmatch.h>
 #include <sys/stat.h>
 #include <unistd.h>
+#include <libgen.h>
+#include <cstdio>
 #endif
 
 #include "cfile/cfile.h"
@@ -38,6 +40,7 @@
 #include "globalincs/pstypes.h"
 #include "localization/localize.h"
 #include "osapi/osapi.h"
+#include "parse/parselo.h"
 
 #define CF_ROOTTYPE_PATH 0
 #define CF_ROOTTYPE_PACK 1
@@ -77,12 +80,13 @@ static int Num_path_roots = 0;
 
 // Created by searching all roots in order.   This means Files is then sorted by precedence.
 typedef struct cf_file {
-	char		name_ext[CF_MAX_FILENAME_LENGTH];		// Filename and extension
-	int		root_index;										// Where in Roots this is located
-	int		pathtype_index;								// Where in Paths this is located
-	time_t	write_time;										// When it was last written
-	int		size;												// How big it is in bytes
-	int		pack_offset;									// For pack files, where it is at.   0 if not in a pack file.  This can be used to tell if in a pack file.
+	char	name_ext[CF_MAX_FILENAME_LENGTH];	// Filename and extension
+	int		root_index;							// Where in Roots this is located
+	int		pathtype_index;						// Where in Paths this is located
+	time_t	write_time;							// When it was last written
+	int		size;								// How big it is in bytes
+	int		pack_offset;						// For pack files, where it is at.   0 if not in a pack file.  This can be used to tell if in a pack file.
+	char*	real_name;							// For real files, the full path
 } cf_file;
 
 #define CF_NUM_FILES_PER_BLOCK   512
@@ -534,6 +538,10 @@ void cf_search_root_path(int root_index)
 	mprintf(( "Searching root '%s' ... ", root->path ));
 
 	char search_path[CF_MAX_PATHNAME_LENGTH];
+#ifdef SCP_UNIX
+    // This map stores the mapping between a specific path type and the actual path that we use for it
+	SCP_unordered_map<int, SCP_string> pathTypeToRealPath;
+#endif
 
 	for (i=CF_TYPE_ROOT; i<CF_MAX_PATH_TYPES; i++ )	{
 
@@ -588,21 +596,80 @@ void cf_search_root_path(int root_index)
 			_findclose( find_handle );
 		}
 #elif defined SCP_UNIX
-		DIR *dirp;
-		struct dirent *dir;
+		DIR *dirp = nullptr;
+		SCP_string search_dir;
+		{
+			if (i == CF_TYPE_ROOT) {
+				// Don't search for the same name for the root case since we would be searching in other mod directories in that case
+				dirp = opendir (search_path);
+				search_dir.assign(search_path);
+			} else {
+				// On Unix we can have a different case for the search paths so we also need to account for that
+				// We do that by looking at the parent of search_path and enumerating all directories and the check if any of
+				// them are a case-insensitive match
+				SCP_string directory_name;
 
-		dirp = opendir (search_path);
+				auto parentPathIter = pathTypeToRealPath.find(Pathtypes[i].parent_index);
+
+				if (parentPathIter == pathTypeToRealPath.end()) {
+					// No parent known yet, use the standard dirname
+					char dirname_copy[CF_MAX_PATHNAME_LENGTH];
+					memcpy(dirname_copy, search_path, sizeof(search_path));
+					// According to the documentation of directory_name and basename, the return value does not need to be freed
+					directory_name.assign(dirname(dirname_copy));
+				} else {
+					// we have a valid parent path -> use that
+					directory_name = parentPathIter->second;
+				}
+
+				char basename_copy[CF_MAX_PATHNAME_LENGTH];
+				memcpy(basename_copy, search_path, sizeof(search_path));
+				// According to the documentation of dirname and basename, the return value does not need to be freed
+				auto search_name = basename(basename_copy);
+
+				auto parentDirP = opendir(directory_name.c_str());
+
+				if (parentDirP) {
+					struct dirent *dir = nullptr;
+					while ((dir = readdir (parentDirP)) != nullptr) {
+
+						if (stricmp(search_name, dir->d_name)) {
+							continue;
+						}
+
+						SCP_string fn;
+						sprintf(fn, "%s/%s", directory_name.c_str(), dir->d_name);
+
+						struct stat buf;
+						if (stat(fn.c_str(), &buf) == -1) {
+							continue;
+						}
+
+						if (S_ISDIR(buf.st_mode)) {
+							// Found a case insensitive match
+							dirp = opendir(fn.c_str());
+							search_dir = fn;
+							// We also need to store this in our mapping since we may need it in the future
+							pathTypeToRealPath.insert(std::make_pair(i, fn));
+							break;
+						}
+					}
+					closedir(parentDirP);
+				}
+			}
+		}
+
 		if ( dirp ) {
+			struct dirent *dir = nullptr;
 			while ((dir = readdir (dirp)) != NULL)
 			{
 				if (!fnmatch ("*.*", dir->d_name, 0))
 				{
-					char fn[MAX_PATH];
-					snprintf(fn, MAX_PATH-1, "%s%s", search_path, dir->d_name);
-					fn[MAX_PATH-1] = 0;
+					SCP_string fn;
+					sprintf(fn, "%s/%s", search_dir.c_str(), dir->d_name);
 
 					struct stat buf;
-					if (stat(fn, &buf) == -1) {
+					if (stat(fn.c_str(), &buf) == -1) {
 						continue;
 					}
 					
@@ -625,6 +692,8 @@ void cf_search_root_path(int root_index)
 							file->size = buf.st_size;
 
 							file->pack_offset = 0;			// Mark as a non-packed file
+
+							file->real_name = vm_strdup(fn.c_str());
 
 							num_files++;
 							//mprintf(( "Found file '%s'\n", file->name_ext ));
@@ -827,6 +896,14 @@ void cf_free_secondary_filelist()
 	// Init the file blocks	
 	for (i=0; i<CF_MAX_FILE_BLOCKS; i++ )	{
 		if ( File_blocks[i] )	{
+			// Free file paths
+			for (auto& f : File_blocks[i]->files) {
+				if (f.real_name) {
+					vm_free(f.real_name);
+					f.real_name = nullptr;
+				}
+			}
+
 			vm_free( File_blocks[i] );
 			File_blocks[i] = NULL;
 		}
@@ -985,17 +1062,14 @@ int cf_find_file_location( const char *filespec, int pathtype, int max_out, char
 						*offset = (size_t)f->pack_offset;
 
 					if (pack_filename) {
-						cf_root *r = cf_get_root(f->root_index);
-
-						strncpy( pack_filename, r->path, max_out );
-
 						if (f->pack_offset < 1) {
-							strcat_s( pack_filename, max_out, Pathtypes[f->pathtype_index].path );
+							// This is a real file, return the actual file path
+							strncpy( pack_filename, f->real_name, max_out );
+						} else {
+							// File is in a pack file
+							cf_root *r = cf_get_root(f->root_index);
 
-							if ( pack_filename[strlen(pack_filename)-1] != DIR_SEPARATOR_CHAR )
-								strcat_s( pack_filename, max_out, DIR_SEPARATOR_STR );
-
-							strcat_s( pack_filename, max_out, f->name_ext );
+							strncpy( pack_filename, r->path, max_out );
 						}
 					}
 
@@ -1013,19 +1087,14 @@ int cf_find_file_location( const char *filespec, int pathtype, int max_out, char
 				*offset = (size_t)f->pack_offset;
 
 			if (pack_filename) {
-				cf_root *r = cf_get_root(f->root_index);
-
-				strcpy( pack_filename, r->path );
-
 				if (f->pack_offset < 1) {
-					if ( strlen(Pathtypes[f->pathtype_index].path) ) {
-						strcat_s( pack_filename, max_out, Pathtypes[f->pathtype_index].path );
+					// This is a real file, return the actual file path
+					strncpy( pack_filename, f->real_name, max_out );
+				} else {
+					// File is in a pack file
+					cf_root *r = cf_get_root(f->root_index);
 
-						if ( pack_filename[strlen(pack_filename)-1] != DIR_SEPARATOR_CHAR )
-							strcat_s( pack_filename, max_out, DIR_SEPARATOR_STR );
-					}
-
-					strcat_s( pack_filename, max_out, f->name_ext );
+					strncpy( pack_filename, r->path, max_out );
 				}
 			}
 
@@ -1260,17 +1329,14 @@ int cf_find_file_location_ext( const char *filename, const int ext_num, const ch
 							*offset = f->pack_offset;
 
 						if (pack_filename) {
-							cf_root *r = cf_get_root(f->root_index);
-
-							strncpy( pack_filename, r->path, max_out );
-
 							if (f->pack_offset < 1) {
-								strcat_s( pack_filename, max_out, Pathtypes[f->pathtype_index].path );
+								// This is a real file, return the actual file path
+								strncpy( pack_filename, f->real_name, max_out );
+							} else {
+								// File is in a pack file
+								cf_root *r = cf_get_root(f->root_index);
 
-								if ( pack_filename[strlen(pack_filename)-1] != DIR_SEPARATOR_CHAR )
-									strcat_s( pack_filename, max_out, DIR_SEPARATOR_STR );
-
-								strcat_s( pack_filename, max_out, f->name_ext );
+								strncpy( pack_filename, r->path, max_out );
 							}
 						}
 
@@ -1291,20 +1357,14 @@ int cf_find_file_location_ext( const char *filename, const int ext_num, const ch
 					*offset = f->pack_offset;
 
 				if (pack_filename) {
-					cf_root *r = cf_get_root(f->root_index);
-
-					strcpy( pack_filename, r->path );
-
 					if (f->pack_offset < 1) {
+						// This is a real file, return the actual file path
+						strncpy( pack_filename, f->real_name, max_out );
+					} else {
+						// File is in a pack file
+						cf_root *r = cf_get_root(f->root_index);
 
-						if ( strlen(Pathtypes[f->pathtype_index].path) ) {
-							strcat_s( pack_filename, max_out, Pathtypes[f->pathtype_index].path );
-
-							if ( pack_filename[strlen(pack_filename)-1] != DIR_SEPARATOR_CHAR )
-								strcat_s( pack_filename, max_out, DIR_SEPARATOR_STR );
-						}
-
-						strcat_s( pack_filename, max_out, f->name_ext );
+						strncpy( pack_filename, r->path, max_out );
 					}
 				}
 

--- a/code/cfile/cfilesystem.cpp
+++ b/code/cfile/cfilesystem.cpp
@@ -557,10 +557,6 @@ void cf_search_root_path(int root_index)
 	mprintf(( "Searching root '%s' ... ", root->path ));
 
 	char search_path[CF_MAX_PATHNAME_LENGTH];
-#ifdef SCP_UNIX
-    // This map stores the mapping between a specific path type and the actual path that we use for it
-	SCP_unordered_map<int, SCP_string> pathTypeToRealPath;
-#endif
 
 	for (i=CF_TYPE_ROOT; i<CF_MAX_PATH_TYPES; i++ )	{
 
@@ -680,20 +676,10 @@ void cf_search_root_path(int root_index)
 			// On Unix we can have a different case for the search paths so we also need to account for that
 			// We do that by looking at the parent of search_path and enumerating all directories and then check if any of
 			// them are a case-insensitive match
-			SCP_string directory_name;
-
-			auto parentPathIter = pathTypeToRealPath.find(Pathtypes[i].parent_index);
-
-//			if (parentPathIter == pathTypeToRealPath.end()) {
-				// No parent known yet, use the standard dirname
-				char dirname_copy[CF_MAX_PATHNAME_LENGTH];
-				memcpy(dirname_copy, search_path, sizeof(search_path));
-				// According to the documentation of directory_name and basename, the return value does not need to be freed
-				directory_name.assign(dirname(dirname_copy));
-//			} else {
-//				// we have a valid parent path -> use that
-//				directory_name = parentPathIter->second;
-//			}
+			char dirname_copy[CF_MAX_PATHNAME_LENGTH];
+			memcpy(dirname_copy, search_path, sizeof(search_path));
+			// According to the documentation of directory_name and basename, the return value does not need to be freed
+			auto directory_name = dirname(dirname_copy);
 
 			char basename_copy[CF_MAX_PATHNAME_LENGTH];
 			memcpy(basename_copy, search_path, sizeof(search_path));

--- a/test/src/cfile/cfile.cpp
+++ b/test/src/cfile/cfile.cpp
@@ -1,0 +1,31 @@
+
+#include <gtest/gtest.h>
+#include <graphics/font.h>
+
+#include "util/FSTestFixture.h"
+
+class CFileTest : public test::FSTestFixture {
+ public:
+	CFileTest() : test::FSTestFixture(INIT_NONE) {
+		pushModDir("cfile");
+	}
+
+ protected:
+	virtual void SetUp() override {
+		test::FSTestFixture::SetUp();
+	}
+	virtual void TearDown() override {
+		test::FSTestFixture::TearDown();
+
+		cfile_close();
+	}
+};
+
+
+TEST_F(CFileTest, wrong_data_case) {
+	SCP_string cfile_dir(TEST_DATA_PATH);
+	cfile_dir += DIR_SEPARATOR_CHAR;
+	cfile_dir += "test"; // Cfile expects something after the path
+
+	ASSERT_THROW(cfile_init(cfile_dir.c_str()), os::dialogs::ErrorException);
+}

--- a/test/src/menuui/test_intel_parse.cpp
+++ b/test/src/menuui/test_intel_parse.cpp
@@ -7,7 +7,7 @@
 
 class IntelParseTest : public test::FSTestFixture {
  public:
-	IntelParseTest() : test::FSTestFixture(0) {
+	IntelParseTest() : test::FSTestFixture(INIT_CFILE) {
 		pushModDir("menuui");
 		pushModDir("intel_parse");
 	}

--- a/test/src/parse/test_parselo.cpp
+++ b/test/src/parse/test_parselo.cpp
@@ -7,7 +7,7 @@
 
 class ParseloTest : public test::FSTestFixture {
  public:
-	ParseloTest() : test::FSTestFixture(0) {
+	ParseloTest() : test::FSTestFixture(INIT_CFILE) {
 		pushModDir("parselo");
 	}
 

--- a/test/src/scripting/ScriptingTestFixture.cpp
+++ b/test/src/scripting/ScriptingTestFixture.cpp
@@ -11,7 +11,7 @@ extern "C" {
 namespace test {
 namespace scripting {
 
-ScriptingTestFixture::ScriptingTestFixture(uint64_t init_flags) : FSTestFixture(init_flags) {
+ScriptingTestFixture::ScriptingTestFixture(uint64_t init_flags) : FSTestFixture(init_flags | INIT_CFILE) {
 	pushModDir("scripting");
 }
 void ScriptingTestFixture::SetUp() {

--- a/test/src/scripting/api/base.cpp
+++ b/test/src/scripting/api/base.cpp
@@ -3,7 +3,7 @@
 
 class ScriptingBaseTest : public test::scripting::ScriptingTestFixture {
  public:
-	ScriptingBaseTest() : test::scripting::ScriptingTestFixture(0) {
+	ScriptingBaseTest() : test::scripting::ScriptingTestFixture(INIT_NONE) {
 		pushModDir("base");
 	}
 };

--- a/test/src/scripting/api/bitops.cpp
+++ b/test/src/scripting/api/bitops.cpp
@@ -3,7 +3,7 @@
 
 class BitOpsTest : public test::scripting::ScriptingTestFixture {
  public:
-	BitOpsTest() : test::scripting::ScriptingTestFixture(0) {
+	BitOpsTest() : test::scripting::ScriptingTestFixture(INIT_NONE) {
 		pushModDir("bitops");
 	}
 };

--- a/test/src/scripting/api/enums.cpp
+++ b/test/src/scripting/api/enums.cpp
@@ -3,7 +3,7 @@
 
 class EnumsTest : public test::scripting::ScriptingTestFixture {
  public:
-	EnumsTest() : test::scripting::ScriptingTestFixture(0) {
+	EnumsTest() : test::scripting::ScriptingTestFixture(INIT_NONE) {
 		pushModDir("enums");
 	}
 };

--- a/test/src/source_groups.cmake
+++ b/test/src/source_groups.cmake
@@ -12,6 +12,10 @@ add_file_folder(root ""
     test_stubs.cpp
 )
 
+add_file_folder(cfile "cfile"
+    cfile/cfile.cpp
+)
+
 add_file_folder(graphics "Globalincs"
     globalincs/test_flagset.cpp
     globalincs/test_safe_strings.cpp

--- a/test/src/util/FSTestFixture.cpp
+++ b/test/src/util/FSTestFixture.cpp
@@ -30,6 +30,11 @@ void test::FSTestFixture::SetUp() {
 
 	os_init("Test", "Test");
 
+	if (!(_initFlags & INIT_CFILE)) {
+		return;
+	}
+
+	// The rest depends on cfile initialization
 	SCP_string cfile_dir(TEST_DATA_PATH);
 	cfile_dir += DIR_SEPARATOR_CHAR;
 	cfile_dir += "test"; // Cfile expects something after the path
@@ -52,19 +57,21 @@ void test::FSTestFixture::SetUp() {
 	}
 }
 void test::FSTestFixture::TearDown() {
-	if (_initFlags & INIT_SHIPS) {
-		ship_close();
+	if (_initFlags & INIT_CFILE) {
+		if (_initFlags & INIT_SHIPS) {
+			ship_close();
+		}
+
+		if (_initFlags & INIT_GRAPHICS) {
+			io::mouse::CursorManager::shutdown();
+
+			bm_unload_all();
+
+			gr_close();
+		}
+
+		cfile_close();
 	}
-
-	if (_initFlags & INIT_GRAPHICS) {
-		io::mouse::CursorManager::shutdown();
-
-		bm_unload_all();
-
-		gr_close();
-	}
-
-	cfile_close();
 
 	timer_close();
 

--- a/test/src/util/FSTestFixture.h
+++ b/test/src/util/FSTestFixture.h
@@ -7,8 +7,9 @@ namespace test {
 
 enum InitFlags {
 	INIT_NONE = 0,
-	INIT_GRAPHICS = 1 << 0,
-	INIT_SHIPS = 1 << 1,
+	INIT_CFILE = 1 << 0,
+	INIT_GRAPHICS = 1 << 1 | INIT_CFILE, // This depends on CFILE
+	INIT_SHIPS = 1 << 2 | INIT_CFILE, // This depends on CFILE
 };
 
 class FSTestFixture: public ::testing::Test {
@@ -20,7 +21,7 @@ class FSTestFixture: public ::testing::Test {
 
 	void init_cmdline();
  protected:
-	explicit FSTestFixture(uint64_t init_flags);
+	explicit FSTestFixture(uint64_t init_flags = INIT_CFILE);
 	virtual ~FSTestFixture() {};
 
 	void addCommandlineArg(const SCP_string& arg);


### PR DESCRIPTION
Since Unix is case sensitive this should make sure that case errors are
cought early in mod development. This is an `Error` and not a `Warning`
since a mod with such a folder structure would never work under Unix and
as such it's justified to break mods that currently use this.

This fixes #1182.