### PR TITLE
Fix crash when using glObjectLabel

### DIFF
--- a/code/graphics/opengl/gropengl.cpp
+++ b/code/graphics/opengl/gropengl.cpp
@@ -1658,7 +1658,7 @@ void gr_opengl_pop_debug_group() {
 }
 void opengl_set_object_label(GLenum type, GLuint handle, const SCP_string& name) {
 	if (GLAD_GL_KHR_debug) {
-		glObjectLabelKHR(type, handle, (GLsizei) name.size(), name.c_str());
+		glObjectLabel(type, handle, (GLsizei) name.size(), name.c_str());
 	}
 }
 


### PR DESCRIPTION
Apparently OpenGL contexts aren't supposed to expose the KHR variant so
this version should work better if the extension is supported.