### PR TITLE
Disable resizing for cubemaps

### DIFF
--- a/code/graphics/opengl/gropengltexture.cpp
+++ b/code/graphics/opengl/gropengltexture.cpp
@@ -904,7 +904,8 @@ int opengl_create_texture(int bitmap_handle, int bitmap_type, tcache_slot_opengl
 	}
 
 	if ( (Detail.hardware_textures < 4) && (bitmap_type != TCACHE_TYPE_AABITMAP) && (bitmap_type != TCACHE_TYPE_INTERFACE)
-			&& ((bitmap_type != TCACHE_TYPE_COMPRESSED) || ((bitmap_type == TCACHE_TYPE_COMPRESSED) && (max_levels > 1))) )
+		&& (bitmap_type != TCACHE_TYPE_CUBEMAP)
+		&& ((bitmap_type != TCACHE_TYPE_COMPRESSED) || ((bitmap_type == TCACHE_TYPE_COMPRESSED) && (max_levels > 1))) )
 	{
 		if (max_levels == 1) {
 			// if we are going to cull the size then we need to force a resize


### PR DESCRIPTION
Since the cubemap loading code explicitly states that it doesn't support
resizing it's only logical to skip that if the bitmap that is currently
being loaded is a cube map.

This fixes #611.