### PR TITLE
Assign OpenGL labels to more objects

### DIFF
--- a/code/graphics/opengl/ShaderProgram.cpp
+++ b/code/graphics/opengl/ShaderProgram.cpp
@@ -143,8 +143,9 @@ GLenum get_gl_shader_stage(opengl::ShaderStage stage) {
 }
 }
 
-opengl::ShaderProgram::ShaderProgram() : _program_id(0), Uniforms(this) {
+opengl::ShaderProgram::ShaderProgram(const SCP_string& program_name) : _program_id(0), Uniforms(this) {
 	_program_id = glCreateProgram();
+	opengl_set_object_label(GL_PROGRAM, _program_id, program_name);
 }
 opengl::ShaderProgram::~ShaderProgram() {
 	freeCompiledShaders();
@@ -172,8 +173,9 @@ void opengl::ShaderProgram::use() {
 GLuint opengl::ShaderProgram::getShaderHandle() {
 	return _program_id;
 }
-void opengl::ShaderProgram::addShaderCode(opengl::ShaderStage stage, const SCP_vector<SCP_string>& codeParts) {
+void opengl::ShaderProgram::addShaderCode(opengl::ShaderStage stage, const SCP_string& name, const SCP_vector<SCP_string>& codeParts) {
 	auto shader_obj = compile_shader_object(codeParts, get_gl_shader_stage(stage));
+	opengl_set_object_label(GL_SHADER, shader_obj, name);
 	_compiled_shaders.push_back(shader_obj);
 	glAttachShader(_program_id, shader_obj);
 }

--- a/code/graphics/opengl/ShaderProgram.h
+++ b/code/graphics/opengl/ShaderProgram.h
@@ -84,7 +84,7 @@ class ShaderProgram {
 
 	void freeCompiledShaders();
  public:
-	ShaderProgram();
+	explicit ShaderProgram(const SCP_string& program_name);
 	~ShaderProgram();
 
 	ShaderUniforms Uniforms;
@@ -97,7 +97,7 @@ class ShaderProgram {
 
 	void use();
 
-	void addShaderCode(ShaderStage stage, const SCP_vector<SCP_string>& codeParts);
+	void addShaderCode(ShaderStage stage, const SCP_string& name, const SCP_vector<SCP_string>& codeParts);
 
 	void linkProgram();
 

--- a/code/graphics/opengl/gropengl.cpp
+++ b/code/graphics/opengl/gropengl.cpp
@@ -1656,11 +1656,13 @@ void gr_opengl_pop_debug_group() {
 		glPopDebugGroup();
 	}
 }
+#if !defined(NDEBUG) || defined(FS_OPENGL_DEBUG) || defined(DOXYGEN)
 void opengl_set_object_label(GLenum type, GLuint handle, const SCP_string& name) {
 	if (GLAD_GL_KHR_debug) {
 		glObjectLabel(type, handle, (GLsizei) name.size(), name.c_str());
 	}
 }
+#endif
 
 uint opengl_data_type_size(GLenum data_type)
 {

--- a/code/graphics/opengl/gropengl.h
+++ b/code/graphics/opengl/gropengl.h
@@ -33,7 +33,12 @@ void gr_opengl_pop_debug_group();
  * @param handle The handle of the object
  * @param name The name of the object
  */
+#if !defined(NDEBUG) || defined(FS_OPENGL_DEBUG) || defined(DOXYGEN)
 void opengl_set_object_label(GLenum type, GLuint handle, const SCP_string& name);
+#else
+// Remove this definition
+inline void opengl_set_object_label(GLenum, GLuint, const SCP_string&) {}
+#endif
 
 uint opengl_data_type_size(GLenum data_type);
 

--- a/code/graphics/opengl/gropenglshader.cpp
+++ b/code/graphics/opengl/gropenglshader.cpp
@@ -566,15 +566,15 @@ int opengl_compile_shader(shader_type sdr, uint flags)
 	}
 
 	auto shader_hash = get_shader_hash(vert_content, geom_content, frag_content);
-	std::unique_ptr<opengl::ShaderProgram> program(new opengl::ShaderProgram());
+	std::unique_ptr<opengl::ShaderProgram> program(new opengl::ShaderProgram(sdr_info->description));
 
 	if (!load_cached_shader_binary(program.get(), shader_hash)) {
 		GR_DEBUG_SCOPE("Compiling shader code");
 		try {
-			program->addShaderCode(opengl::STAGE_VERTEX, vert_content);
-			program->addShaderCode(opengl::STAGE_FRAGMENT, frag_content);
+			program->addShaderCode(opengl::STAGE_VERTEX, sdr_info->vert, vert_content);
+			program->addShaderCode(opengl::STAGE_FRAGMENT, sdr_info->frag, frag_content);
 			if (use_geo_sdr) {
-				program->addShaderCode(opengl::STAGE_GEOMETRY, geom_content);
+				program->addShaderCode(opengl::STAGE_GEOMETRY, sdr_info->geo, geom_content);
 			}
 
 			for (int i = 0; i < opengl_vert_attrib::NUM_ATTRIBS; ++i) {

--- a/code/graphics/opengl/gropengltexture.cpp
+++ b/code/graphics/opengl/gropengltexture.cpp
@@ -425,6 +425,9 @@ int opengl_create_texture_sub(int bitmap_handle, int bitmap_type, int bmap_w, in
 
 	glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
 	glBindTexture(t->texture_target, t->texture_id);
+	if (!reload) {
+		opengl_set_object_label(GL_TEXTURE, t->texture_id, bm_get_filename(bitmap_handle));
+	}
 
 	GLenum min_filter = GL_LINEAR;
 


### PR DESCRIPTION
The texture labels make it easier to debug which texture is currently
bound when tracing with APItrace.

I also surrounded the definition of `opengl_set_object_label` with preprocessor directives so that it only appears in debug builds or if a special preprocessor directive is enabled. This should help reduce the overhead of this feature in release builds.