### PR TITLE
Boost the color of nebula bitmaps to make them visible again

### DIFF
--- a/code/nebula/neb.cpp
+++ b/code/nebula/neb.cpp
@@ -915,6 +915,8 @@ int frame_count = 0;
 float frame_avg;
 void neb2_render_player()
 {
+	GR_DEBUG_SCOPE("Nebula render player");
+
 	vertex p, ptemp;
 	int idx1, idx2, idx3;
 	float alpha;
@@ -1075,6 +1077,7 @@ void neb2_render_player()
 				//g3_draw_rotated_bitmap(&p, fl_radians(Neb2_cubes[idx1][idx2][idx3].rot), Nd->prad, TMAP_FLAG_TEXTURED);
 				material mat_params;
 				material_set_unlit(&mat_params, Neb2_cubes[idx1][idx2][idx3].bmap, alpha + Neb2_cubes[idx1][idx2][idx3].flash, true, true);
+				mat_params.set_color_scale(3.f);
 				g3_render_rect_screen_aligned_rotated(&mat_params, &p, fl_radians(Neb2_cubes[idx1][idx2][idx3].rot), Nd->prad);
 			}
 		}

--- a/code/nebula/neblightning.cpp
+++ b/code/nebula/neblightning.cpp
@@ -322,6 +322,8 @@ void nebl_set_storm(char *name)
 // render all lightning bolts
 void nebl_render_all()
 {
+	GR_DEBUG_SCOPE("Nebula render all");
+
 	l_bolt *b;
 	bolt_type *bi;
 


### PR DESCRIPTION
The HDR changes made the nebula bitmaps a lot less visible. This fixes
that by boosting the color of the bitmaps when they are rendered.

I choose 3 since that gives a similar look to 3.7.4 but that can be
further tweaked if desired.

I also added two debug scopes to help track down where that stuff was
actually rendered.

This fixes #712.