### PR TITLE
Fix negative array index

### DIFF
--- a/code/object/object.cpp
+++ b/code/object/object.cpp
@@ -452,9 +452,11 @@ void obj_free(int objnum)
 
 	Assert(Num_objects >= 0);
 
-	if (objnum == Highest_object_index)
-		while (Objects[--Highest_object_index].type == OBJ_NONE);
-
+	if (objnum == Highest_object_index) {
+		while (Highest_object_index >= 0 && Objects[Highest_object_index].type == OBJ_NONE) {
+			--Highest_object_index;
+		}
+	}
 }
 
 /**


### PR DESCRIPTION
If there was only one object and that got deleted the code that keeps
track of the highest object index would cause a negativ array index. I
added a check to make sure that the index was positive but that still
means that Highest_object_index will be negativ after that function
returns. I looked at the usages of the value and that value seems to be
fine with that code so I think this should be safe.