### PR TITLE
Stops debug log printing "Creating new directory"

### DIFF
--- a/code/cfile/cfile.cpp
+++ b/code/cfile/cfile.cpp
@@ -14,6 +14,7 @@
 #include <string.h>
 #include <stdio.h>
 #include <errno.h>
+#include <sys/stat.h>
 
 #ifdef _WIN32
 #include <io.h>
@@ -23,7 +24,6 @@
 #endif
 
 #ifdef SCP_UNIX
-#include <sys/stat.h>
 #include <glob.h>
 #include <sys/mman.h>
 #endif
@@ -621,6 +621,7 @@ void cf_create_directory( int dir_type )
 	int num_dirs = 0;
 	int dir_tree[CF_MAX_PATH_TYPES];
 	char longname[MAX_PATH_LEN];
+	struct stat statbuf;
 
 	Assertion( CF_TYPE_SPECIFIED(dir_type), "Invalid dir_type passed to cf_create_directory." );
 
@@ -634,13 +635,14 @@ void cf_create_directory( int dir_type )
 
 	} while( current_dir != CF_TYPE_ROOT );
 
-	
 	int i;
 
 	for (i=num_dirs-1; i>=0; i-- )	{
 		cf_create_default_path_string( longname, sizeof(longname)-1, dir_tree[i], NULL );
-		mprintf(( "CFILE: Creating new directory '%s'\n", longname ));
-        mkdir_recursive(longname);
+		if (stat(longname, &statbuf) != 0) {
+			mprintf(( "CFILE: Creating new directory '%s'\n", longname ));
+			mkdir_recursive(longname);
+		}
 	}
 }
 


### PR DESCRIPTION
Fix for log printing creating directory lines for directories that already exist.  Numerous "Creating new directory..." lines were appearing in my log, and it seems like checking to see if the directory already exists before creating it would make sense.

I could be wrong, but I assume that this code has already ensured that the path is a folder and not a filename, and that any relevant assert was not done deeper inside the logic that I'm now bypassing.  If I'm wrong on that it can be added here instead with a simple enough addition, but I wanted to keep it as simple as possible.  That check might not also be as cross-platform as just checking for existence so I wanted to avoid that for that reason too.

I have confirmed in testing that both the create statements for existing directories have stopped, and, when I removed one of the directories it constantly attempted to create before, it throws the line in the log only one time now.