### PR TITLE
Remove object instance from lab render info

### DIFF
--- a/code/lab/lab.cpp
+++ b/code/lab/lab.cpp
@@ -902,6 +902,12 @@ void labviewer_render_model(float frametime)
 				}
 			}
 		}
+
+		if (sip != NULL) {
+			if (Lab_viewer_flags & LAB_FLAG_DESTROYED_SUBSYSTEMS) {
+				model_show_damaged(Lab_model_num, 1);
+			}
+		}
 		
 		if( !( flagggs & MR_NO_LIGHTING ) && Cmdline_shadow_quality ) {
 			polymodel *pm = model_get(Lab_model_num);
@@ -930,6 +936,7 @@ void labviewer_render_model(float frametime)
 						for(k = 0; k < bank->num_slots; k++) {	
 
 							render_info.set_flags(render_flags);
+							render_info.set_object_number(-1);
 							model_render_immediate(&render_info, Lab_weaponmodel_num[l], &vmd_identity_matrix, &bank->pnt[k]);
 						}
 					}
@@ -947,6 +954,7 @@ void labviewer_render_model(float frametime)
 						if (Weapon_info[sip->secondary_bank_weapons[j]].wi_flags[Weapon::Info_Flags::External_weapon_lnch]) {
 							for(k = 0; k < bank->num_slots; k++) {
 								render_info.set_flags(render_flags);
+								render_info.set_object_number(-1);
 								model_render_immediate(&render_info, Lab_weaponmodel_num[l], &vmd_identity_matrix, &bank->pnt[k]);
 							}
 						} else {
@@ -954,6 +962,7 @@ void labviewer_render_model(float frametime)
 							{
 								secondary_weapon_pos = bank->pnt[k];
 								render_info.set_flags(render_flags);
+								render_info.set_object_number(-1);
 								model_render_immediate(&render_info, Lab_weaponmodel_num[l], &vmd_identity_matrix, &secondary_weapon_pos);
 							}
 						}
@@ -976,12 +985,6 @@ void labviewer_render_model(float frametime)
 // 			MIN((timer_get_milliseconds()-anim_timer_start)/1500.0f, 2.0f)
 // 		);
 
-		if (sip != NULL) {
-			if (Lab_viewer_flags & LAB_FLAG_DESTROYED_SUBSYSTEMS) {
-				model_show_damaged(Lab_model_num, 1);
-			}
-		}
-
 		//render weapon models if selected
 		if (Lab_mode == LAB_MODE_SHIP && (Lab_viewer_flags & LAB_FLAG_SHOW_WEAPONS)) {
 			int k,l;
@@ -1000,6 +1003,7 @@ void labviewer_render_model(float frametime)
 					w_bank *bank = &model_get(Lab_model_num)->gun_banks[j];
 					for(k = 0; k < bank->num_slots; k++) {	
 						render_info.set_flags(render_flags);
+						render_info.set_object_number(-1);
 						model_render_immediate(&render_info, Lab_weaponmodel_num[l], &vmd_identity_matrix, &bank->pnt[k]);
 					}
 				}
@@ -1024,6 +1028,7 @@ void labviewer_render_model(float frametime)
 						{
 							secondary_weapon_pos = bank->pnt[k];
 							render_info.set_flags(render_flags);
+							render_info.set_object_number(-1);
 							model_render_immediate(&render_info, Lab_weaponmodel_num[l], &vmd_identity_matrix, &secondary_weapon_pos);
 						}
 					}
@@ -1035,7 +1040,6 @@ void labviewer_render_model(float frametime)
 
 		render_info.set_debug_flags(Lab_model_debug_flags);
 		render_info.set_flags(flagggs);
-		render_info.set_object_number(Lab_selected_object);
 
 		model_render_immediate(&render_info, Lab_model_num, &Lab_viewer_orient, &vmd_zero_vector, MODEL_RENDER_OPAQUE);
 		gr_opengl_deferred_lighting_end();


### PR DESCRIPTION
If the object number is set for the render info the renderer uses the
instance information of that object to render the model. That is not
correct for the lab since the instance data is handled by the lab code
in that case.

This fixes #643.