### PR TITLE
Fix minor bug with parallel vector testing

### DIFF
--- a/code/math/vecmat.cpp
+++ b/code/math/vecmat.cpp
@@ -615,14 +615,16 @@ vec3d *vm_vec_cross(vec3d *dest, const vec3d *src0, const vec3d *src1)
 	return dest;
 }
 
-// test if 2 vectors are parallel or not.
 int vm_test_parallel(const vec3d *src0, const vec3d *src1)
 {
-	if ( (fl_abs(src0->xyz.x - src1->xyz.x) < 1e-4) && (fl_abs(src0->xyz.y - src1->xyz.y) < 1e-4) && (fl_abs(src0->xyz.z - src1->xyz.z) < 1e-4) ) {
-		return 1;
-	} else {
-		return 0;
-	}
+	// This version assumes SIMD/SSE optimizations, which would essentially be only 2 operations
+	// If SIMD/SSE is not available, you could check if the vectors are a scalar of each other. i.g. if((x1/x2) == (y1/y2) == (z1/z2)
+	// TODO: make a compile-time check for SIMD/SSE optimizations, If we have them, then use the vecmath method, if not, then use the logical method.
+
+	vec3d test;
+
+	vm_vec_cross(&test, src0, src1);
+	return vm_vec_equal(test, vmd_zero_vector);
 }
 
 //computes non-normalized surface normal from three points.

--- a/code/math/vecmat.h
+++ b/code/math/vecmat.h
@@ -204,7 +204,9 @@ float vm_vec_dot3(float x, float y, float z, vec3d *v);
 //dest CANNOT equal either source
 vec3d *vm_vec_cross(vec3d *dest, const vec3d *src0, const vec3d *src1);
 
-// test if 2 vectors are parallel or not.
+/**
+ * @brief Tests if the two vectors are parallel
+ */
 int vm_test_parallel(const vec3d *src0, const vec3d *src1);
 
 //computes surface normal from three points. result is normalized

--- a/code/render/3ddraw.cpp
+++ b/code/render/3ddraw.cpp
@@ -830,13 +830,12 @@ void g3_render_laser(material *mat_params, vec3d *headp, float head_width, vec3d
 	vm_vec_normalize(&reye);
 
 	// code intended to prevent possible null vector normalize issue - start
-	if ( vm_test_parallel(&reye, &fvec) ) {
+	if ( vm_vec_equal(reye, fvec) ) {
 		fvec.xyz.x = -reye.xyz.z;
 		fvec.xyz.y = 0.0f;
 		fvec.xyz.z = -reye.xyz.x;
-	}
 
-	if ( vm_test_parallel(&reye, &rfvec) ) {
+	} else if ( vm_vec_equal(reye, rfvec) ) {
 		fvec.xyz.x = reye.xyz.z;
 		fvec.xyz.y = 0.0f;
 		fvec.xyz.z = reye.xyz.x;


### PR DESCRIPTION
Previous version only checked if the two vectors were equal, which only half-way works for normalized vectors.

Two normalized vectors are indeed parallel if they are equal to each other, but they are also parallel if one is the negative scalar of the other (v2 = vm_vec_scale(v1, -1))

New method checks if the crossprod of the two is the zero vector. If using SSE2 optimizations, this should be only 2 ops. I commented in the function definition an alternative method should SSE2 be unavailable. The Best Fix (TM) would be to have a compile-time check for SSE2 optimizations and choose the appropriate version.