### PR TITLE
[Feature] Ngon Radar

### DIFF
--- a/code/hud/hudparse.cpp
+++ b/code/hud/hudparse.cpp
@@ -2714,16 +2714,17 @@ void load_gauge_radar_std(gauge_settings* settings)
 		}
 	}
 
-	HudGaugeRadarStd* hud_gauge;
-	if (num_sides == 0) {
-		// Standard radar
-		hud_gauge = gauge_load_common<HudGaugeRadarStd>(settings);
-	} else {
-		// Ngon radar
-		hud_gauge = new HudGaugeRadarNgon(num_sides, offset);
-		hud_gauge = gauge_load_common<HudGaugeRadarNgon>(settings, static_cast<HudGaugeRadarNgon*>(hud_gauge));
-	}
+	//=======================================================================================================
+	// Cyborg17 - not using auto here is a huge pain to get exactly right and to read. If we put this in a 
+	// normal if block, either auto will break or hud_gauge will go out of scope before the last block below.
+	// The ternery operator lets us circumvent this problem by allowing us to use auto, while also loading 
+	// the radar and creating the unique_ptr.
 
+	// did we have a normal radar? If so, load the regular radar.
+	auto hud_gauge = (num_sides == 0) ? gauge_load_common<HudGaugeRadarStd>(settings)
+						 // if not *construct* and then load the ngon radar
+	                     : gauge_load_common<HudGaugeRadarNgon>(settings, new HudGaugeRadarNgon(num_sides, offset));
+	
 	// Only load this if the user hasn't specified a preference
 	if (Cmdline_orb_radar == 0) {
 		hud_gauge->initBitmaps(fname);

--- a/code/math/vecmat.cpp
+++ b/code/math/vecmat.cpp
@@ -1227,7 +1227,7 @@ int find_intersection(float* s, const vec3d* p0, const vec3d* p1, const vec3d* v
 	vm_vec_cross(&crossA, v0, v1);
 	vm_vec_cross(&crossB, &v2, v1);
 
-	if (vm_vec_equal(crossA, ZERO_VECTOR)) {
+	if (vm_vec_equal(crossA, vmd_zero_vector)) {
 		// Colinear
 		return -1;
 	}

--- a/code/math/vecmat.cpp
+++ b/code/math/vecmat.cpp
@@ -1216,6 +1216,31 @@ float find_nearest_point_on_line(vec3d *nearest_point, const vec3d *p0, const ve
 	return dot/mag;
 }
 
+int find_intersection(float* s, const vec3d* p0, const vec3d* p1, const vec3d* v0, const vec3d* v1)
+{
+	// Vector v2 forms an edge between v0 and v1, thus forming a triangle.
+	// An intersection exists between v0 and v1 if their cross product is parallel with the cross product of v2 and v1
+	// The scalar of v0 can then be found by the ratio between the two cross products
+	vec3d v2, crossA, crossB;
+
+	vm_vec_sub(&v2, p1, p0);
+	vm_vec_cross(&crossA, v0, v1);
+	vm_vec_cross(&crossB, &v2, v1);
+
+	if (vm_vec_equal(crossA, ZERO_VECTOR)) {
+		// Colinear
+		return -1;
+	}
+
+	if (!vm_test_parallel(&crossA, &crossB)) {
+		// The two cross products are not parallel, so no intersection between v0 and v1
+		return -2;
+	}
+
+	*s = vm_vec_mag(&crossB) / vm_vec_mag(&crossA);
+	return 0;
+};
+
 //make sure matrix is orthogonal
 //computes a matrix from one or more vectors. The forward vector is required,
 //with the other two being optional.  If both up & right vectors are passed,

--- a/code/math/vecmat.h
+++ b/code/math/vecmat.h
@@ -344,6 +344,23 @@ void vm_trackball( int idx, int idy, matrix * RotMat );
 //	beyond *p1 by 2x.
 float find_nearest_point_on_line(vec3d *nearest_point, const vec3d *p0, const vec3d *p1, const vec3d *int_pnt);
 
+/**
+ * @brief Find the intersection between two lines
+ *
+ * @param[out] s  If successful, s is the scalar of v0 where the intersection is at
+ * @param[in]  p0 Reference point for line 1
+ * @param[in]  p1 Reference point for line 2
+ * @param[in]  v0 Direction vector for line 1
+ * @param[in]  v1 Direction vector for line 2
+ *
+ * @returns  0 If successful, or
+ * @returns -1 If colinear, or
+ * @returns -2 If no intersection
+ *
+ * @note If you want the coords of the intersection, just vm_scale(in_ray, s)
+ */
+int find_intersection(float *s, const vec3d* p0, const vec3d* p1, const vec3d* v0, const vec3d* v1);
+
 float vm_vec_dot_to_point(const vec3d *dir, const vec3d *p1, const vec3d *p2);
 
 void compute_point_on_plane(vec3d *q, const plane *planep, const vec3d *p);

--- a/code/math/vecmat.h
+++ b/code/math/vecmat.h
@@ -347,7 +347,7 @@ float find_nearest_point_on_line(vec3d *nearest_point, const vec3d *p0, const ve
 /**
  * @brief Find the intersection between two lines
  *
- * @param[out] s  If successful, s is the scalar of v0 where the intersection is at
+ * @param[out] s  If successful, s is the scalar of v0
  * @param[in]  p0 Reference point for line 1
  * @param[in]  p1 Reference point for line 2
  * @param[in]  v0 Direction vector for line 1
@@ -357,7 +357,7 @@ float find_nearest_point_on_line(vec3d *nearest_point, const vec3d *p0, const ve
  * @returns -1 If colinear, or
  * @returns -2 If no intersection
  *
- * @note If you want the coords of the intersection, just vm_scale(in_ray, s)
+ * @note If you want the coords of the intersection, scale v0 by s, then add p0.
  */
 int find_intersection(float *s, const vec3d* p0, const vec3d* p1, const vec3d* v0, const vec3d* v1);
 

--- a/code/radar/radar.cpp
+++ b/code/radar/radar.cpp
@@ -394,7 +394,7 @@ void HudGaugeRadarStd::plotBlip(blip *b, int *x, int *y)
 
 	zdist = hypotf(pos->xyz.x, pos->xyz.y);
 
-	vec3d new_pos = ZERO_VECTOR;
+	vec3d new_pos = {};
 
 	if (zdist >= 0.01f)
 	{

--- a/code/radar/radar.cpp
+++ b/code/radar/radar.cpp
@@ -360,7 +360,7 @@ void HudGaugeRadarStd::pageIn()
 	bm_page_in_aabitmap( Radar_gauge.first_frame, Radar_gauge.num_frames );
 }
 
-void HudGaugeRadarStd::clampBlip(vec3d* blip)
+void HudGaugeRadarStd::clampBlip(vec3d* b)
 {
 	float max_radius;
 	float hypotenuse;
@@ -368,17 +368,17 @@ void HudGaugeRadarStd::clampBlip(vec3d* blip)
 	max_radius = i2fl(Radar_radius[0] - 5);
 
 	// Scale blip to radar size
-	vm_vec_scale(blip, i2fl(Radar_radius[0])/2.0f);
+	vm_vec_scale(b, i2fl(Radar_radius[0])/2.0f);
 
-	hypotenuse = _hypotf(blip->xyz.x, blip->xyz.y);
+	hypotenuse = hypotf(b->xyz.x, b->xyz.y);
 
 	// Clamp to inside of plot area, if needed
 	if (hypotenuse > max_radius) {
-		vm_vec_scale2(blip, max_radius, hypotenuse);
+		vm_vec_scale2(b, max_radius, hypotenuse);
 	}
 
 	// Scale Y to respect aspect ratio
-	blip->xyz.y *= (i2fl(Radar_radius[1]) / i2fl(Radar_radius[0]));
+	b->xyz.y *= (i2fl(Radar_radius[1]) / i2fl(Radar_radius[0]));
 }
 
 void HudGaugeRadarStd::plotBlip(blip *b, int *x, int *y)
@@ -392,14 +392,12 @@ void HudGaugeRadarStd::plotBlip(blip *b, int *x, int *y)
 		rscale = (float) acosf(pos->xyz.z / b->dist) / PI;
 	}
 
-	zdist = _hypotf(pos->xyz.x, pos->xyz.y);
+	zdist = hypotf(pos->xyz.x, pos->xyz.y);
 
-	vec3d new_pos;
+	vec3d new_pos = ZERO_VECTOR;
 
-	if (zdist < 0.01f)
+	if (zdist >= 0.01f)
 	{
-		new_pos = ZERO_VECTOR;
-	} else {
 		new_pos = *pos;
 		new_pos.xyz.z = 0.0f;
 		vm_vec_scale(&new_pos, rscale / zdist);		// Values are within +/- 1.0f

--- a/code/radar/radar.h
+++ b/code/radar/radar.h
@@ -48,9 +48,9 @@ class HudGaugeRadarStd: public HudGaugeRadar
 protected:
 	/**
 	 * @brief Clamps and scales the blip to be within the plot area
-	 * @param[in] vec The blip coordinates (only x and y are nonzero)
+	 * @param[in] b The blip coordinates (only x and y are nonzero)
 	 */
-	virtual void clampBlip(vec3d* blip);
+	virtual void clampBlip(vec3d* b);
 public:
 	HudGaugeRadarStd();
 	void initCenterOffsets(float x, float y);

--- a/code/radar/radar.h
+++ b/code/radar/radar.h
@@ -44,6 +44,13 @@ class HudGaugeRadarStd: public HudGaugeRadar
 
 	// formerly parts of Current_radar_global
 	float Radar_center_offsets[2];
+
+protected:
+	/**
+	 * @brief Clamps and scales the blip to be within the plot area
+	 * @param[in] vec The blip coordinates (only x and y are nonzero)
+	 */
+	virtual void clampBlip(vec3d* blip);
 public:
 	HudGaugeRadarStd();
 	void initCenterOffsets(float x, float y);

--- a/code/radar/radarngon.cpp
+++ b/code/radar/radarngon.cpp
@@ -2,31 +2,31 @@
 
 #include "math/vecmat.h"
 
-#include <math.h>
+#include <cmath>
 
-void HudGaugeRadarNgon::clampBlip(vec3d* blip) {
+void HudGaugeRadarNgon::clampBlip(vec3d* blip_instance) {
 	float hypotenuse;
 
-	hypotenuse = _hypotf(blip->xyz.x, blip->xyz.y);
+	hypotenuse = hypotf(blip_instance->xyz.x, blip_instance->xyz.y);
 
 	// Only do this math if the blip hypotenuse is longer than or equal to the apothem
 	if (hypotenuse >= r_min) {
-		float angle = atan2(blip->xyz.y, blip->xyz.x);
+		float angle = atan2(blip_instance->xyz.y, blip_instance->xyz.x);
 		vec3d Line_p;
 		vec3d Line_v;
 		formLine(&Line_p, &Line_v, angle);
 
 		float s;
-		int success = find_intersection(&s, &vmd_zero_vector, &Line_p, blip, &Line_v);
+		int success = find_intersection(&s, &vmd_zero_vector, &Line_p, blip_instance, &Line_v);
 
 		if ((success == 0) && (s < 1.0f)) {
 			// Clamp the blip to the edge
-			vm_vec_scale(blip, s);
+			vm_vec_scale(blip_instance, s);
 		}
 	}
 
 	// Use Std's method of clamping and scaling, we'll get some nice rounded corners in the process
-	HudGaugeRadarStd::clampBlip(blip);
+	HudGaugeRadarStd::clampBlip(blip_instance);
 }
 
 void HudGaugeRadarNgon::formLine(vec3d* p, vec3d* v, float angle) {
@@ -50,9 +50,9 @@ void HudGaugeRadarNgon::formLine(vec3d* p, vec3d* v, float angle) {
 
 // Default to a hexagon
 HudGaugeRadarNgon::HudGaugeRadarNgon()
-	: arclen(PI2 / i2fl(6)), offset(0.0f), r_min(cos(PI / i2fl(6))) {}
+	: arclen(PI2 / i2fl(6)), r_min(cos(PI / i2fl(6))) {}
 
-HudGaugeRadarNgon::HudGaugeRadarNgon(int num_sides, float offset)
-	: arclen(PI2 / i2fl(num_sides)), offset(offset * (PI / 180.0f)), r_min(cos(PI / i2fl(num_sides)))
+HudGaugeRadarNgon::HudGaugeRadarNgon(int num_sides, float offset_incoming)
+	: arclen(PI2 / i2fl(num_sides)), offset(offset_incoming * (PI / 180.0f)), r_min(cos(PI / i2fl(num_sides)))
 {
 }

--- a/code/radar/radarngon.cpp
+++ b/code/radar/radarngon.cpp
@@ -1,0 +1,58 @@
+#include "radar/radarngon.h"
+
+#include "math/vecmat.h"
+
+#include <math.h>
+
+void HudGaugeRadarNgon::clampBlip(vec3d* blip) {
+	float hypotenuse;
+
+	hypotenuse = _hypotf(blip->xyz.x, blip->xyz.y);
+
+	// Only do this math if the blip hypotenuse is longer than or equal to the apothem
+	if (hypotenuse >= r_min) {
+		float angle = atan2(blip->xyz.y, blip->xyz.x);
+		vec3d Line_p;
+		vec3d Line_v;
+		formLine(&Line_p, &Line_v, angle);
+
+		float s;
+		int success = find_intersection(&s, &vmd_zero_vector, &Line_p, blip, &Line_v);
+
+		if ((success == 0) && (s < 1.0f)) {
+			// Clamp the blip to the edge
+			vm_vec_scale(blip, s);
+		}
+	}
+
+	// Use Std's method of clamping and scaling, we'll get some nice rounded corners in the process
+	HudGaugeRadarStd::clampBlip(blip);
+}
+
+void HudGaugeRadarNgon::formLine(vec3d* p, vec3d* v, float angle) {
+	int n;  // sector the blip is in
+
+	angle -= offset;
+	n = fl2i(angle / arclen);
+
+	p->xyz.x = cos((arclen * n) + offset);
+	p->xyz.y = sin((arclen * n) + offset);
+	p->xyz.z = 0.0f;
+
+	(angle >= 0.0f) ? (n += 1) : (n -= 1);
+
+	v->xyz.x = cos((arclen * n) + offset);
+	v->xyz.y = sin((arclen * n) + offset);
+	v->xyz.z = 0.0f;
+
+	vm_vec_sub2(v, p);
+}
+
+// Default to a hexagon
+HudGaugeRadarNgon::HudGaugeRadarNgon()
+	: arclen(PI2 / i2fl(6)), offset(0.0f), r_min(cos(PI / i2fl(6))) {}
+
+HudGaugeRadarNgon::HudGaugeRadarNgon(int num_sides, float offset)
+	: arclen(PI2 / i2fl(num_sides)), offset(offset * (PI / 180.0f)), r_min(cos(PI / i2fl(num_sides)))
+{
+}

--- a/code/radar/radarngon.h
+++ b/code/radar/radarngon.h
@@ -20,7 +20,7 @@ const int RADAR_NGON_MIN_SIDES = 3;		//!< Required, things break if n < 3
 class HudGaugeRadarNgon : public HudGaugeRadarStd
 {
 	float arclen;	// The arc length of each n-gon sector (radians)
-	float offset;	// The angle offset of the plot area (+ is counter-clockwise) (radians)
+	float offset {0.0f};	// The angle offset of the plot area (+ is counter-clockwise) (radians), 
 	float r_min;	// The apothem of the ngon (0.0f < r_min <= 1.0f)
 
 protected:
@@ -36,7 +36,7 @@ protected:
 	* @brief Clamps and scales the blip to be within the plot area
 	* @param[in] vec The blip coordinates (only x and y are nonzero)
 	*/
-	void clampBlip(vec3d* blip);
+	void clampBlip(vec3d* blip) override;
 
 public:
 	/**

--- a/code/radar/radarngon.h
+++ b/code/radar/radarngon.h
@@ -1,0 +1,59 @@
+/*
+ * z64555's N-gon radar
+ *
+ * You may not sell or otherwise commercially exploit the source or things you created based on the
+ * source.
+ *
+ */
+
+#ifndef _RADAR_NGON_H
+#define _RADAR_NGON_H
+
+#include "radar/radarsetup.h"
+#include "radar/radar.h"
+
+const int RADAR_NGON_MIN_SIDES = 3;		//!< Required, things break if n < 3
+
+/**
+ * @brief Flavor of the standard radar gauge which has an polygonal plot surface (vs. the standard oval)
+ */
+class HudGaugeRadarNgon : public HudGaugeRadarStd
+{
+	float arclen;	// The arc length of each n-gon sector (radians)
+	float offset;	// The angle offset of the plot area (+ is counter-clockwise) (radians)
+	float r_min;	// The apothem of the ngon (0.0f < r_min <= 1.0f)
+
+protected:
+	/**
+	* @brief Forms the N-gon edge/line that the blip will be clamped/projected to
+	* @param[out] p     Reference point for the line
+	* @param[out] v     Directional vector (not normalized) for the line
+	* @param[in]  angle The azimuth of the blip on the plot surface;
+	*/
+	void formLine(vec3d* p, vec3d* v, float angle);
+
+	/**
+	* @brief Clamps and scales the blip to be within the plot area
+	* @param[in] vec The blip coordinates (only x and y are nonzero)
+	*/
+	void clampBlip(vec3d* blip);
+
+public:
+	/**
+	 * @brief Default constructor the Ngon radar.
+	 *
+	 * @note This shouldn't be actually used, but it breaks compiling if the default constructor isn't present
+	 */
+	HudGaugeRadarNgon();
+
+	/**
+	 * @brief Constructor for the Ngon radar
+	 *
+	 * @param[in] num_sides Number of sides the n-gon should have
+	 * @param[in] offset    Offset angle, in degrees
+	 */
+	HudGaugeRadarNgon(int num_sides, float offset);
+};
+
+#endif
+

--- a/code/source_groups.cmake
+++ b/code/source_groups.cmake
@@ -993,6 +993,8 @@ add_file_folder("Radar"
 	radar/radar.h
 	radar/radardradis.cpp
 	radar/radardradis.h
+	radar/radarngon.cpp
+	radar/radarngon.h
 	radar/radarorb.cpp
 	radar/radarorb.h
 	radar/radarsetup.cpp


### PR DESCRIPTION
This features adds the Ngon radar gauge, which is a derivative of the standard radar gauge. Instead of the standard's oval plot area, the Ngon radar gauge has a polygonal plot area.

The projection algorithm is the same as the standard's radar, so all the Ngon does is clamp the blip to the edges of the plot area.

I also refactored the standard radar plotting code a bit, there was some clamping in the original code that didn't work right, so blips could be drawn on top of the oval's edges. I'm not counting this as a bugfix, though.

Included is a test .tbm that activates a hexagonal plot area with "points up."

[radar_test-hdg.tbm.txt](https://github.com/scp-fs2open/fs2open.github.com/files/767768/radar_test-hdg.tbm.txt)