### PR TITLE
Fix for rounding errors in weapons dialog

### DIFF
--- a/fred2/weaponeditordlg.cpp
+++ b/fred2/weaponeditordlg.cpp
@@ -353,10 +353,10 @@ void WeaponEditorDlg::change_selection()
 			m_missile4 += First_secondary_index;
 
 		cur_weapon->secondary_bank_weapons[3] = m_missile4 - 1;
-		cur_weapon->secondary_bank_ammo[0] = m_ammo_max1 ? (m_ammo1 * 100 / m_ammo_max1) : 0;
-		cur_weapon->secondary_bank_ammo[1] = m_ammo_max2 ? (m_ammo2 * 100 / m_ammo_max2) : 0;
-		cur_weapon->secondary_bank_ammo[2] = m_ammo_max3 ? (m_ammo3 * 100 / m_ammo_max3) : 0;
-		cur_weapon->secondary_bank_ammo[3] = m_ammo_max4 ? (m_ammo4 * 100 / m_ammo_max4) : 0;
+		cur_weapon->secondary_bank_ammo[0] = m_ammo_max1 ? fl2ir(m_ammo1 * 100.0f / m_ammo_max1) : 0;
+		cur_weapon->secondary_bank_ammo[1] = m_ammo_max2 ? fl2ir(m_ammo2 * 100.0f / m_ammo_max2) : 0;
+		cur_weapon->secondary_bank_ammo[2] = m_ammo_max3 ? fl2ir(m_ammo3 * 100.0f / m_ammo_max3) : 0;
+		cur_weapon->secondary_bank_ammo[3] = m_ammo_max4 ? fl2ir(m_ammo4 * 100.0f / m_ammo_max4) : 0;
 		if (m_multi_edit) {
 			if (!strlen(a1))
 				cur_weapon->secondary_bank_ammo[0] = BLANK_FIELD;
@@ -425,7 +425,7 @@ void WeaponEditorDlg::change_selection()
 				m_ammo_max1 = get_max_ammo_count_for_turret_bank(cur_weapon, 0, m_missile1 - 1);
 			}
 			if (cur_weapon->secondary_bank_ammo[0] != BLANK_FIELD)
-				m_ammo1 = cur_weapon->secondary_bank_ammo[0] * m_ammo_max1 / 100;
+				m_ammo1 = fl2ir(cur_weapon->secondary_bank_ammo[0] * m_ammo_max1 / 100.0f);
 			m_missile1 -= First_secondary_index;
 		}
 
@@ -448,7 +448,7 @@ void WeaponEditorDlg::change_selection()
 				m_ammo_max2 = get_max_ammo_count_for_turret_bank(cur_weapon, 1, m_missile2 - 1);
 			}
 			if (cur_weapon->secondary_bank_ammo[1] != BLANK_FIELD)
-				m_ammo2 = cur_weapon->secondary_bank_ammo[1] * m_ammo_max2 / 100;
+				m_ammo2 = fl2ir(cur_weapon->secondary_bank_ammo[1] * m_ammo_max2 / 100.0f);
 			m_missile2 -= First_secondary_index;
 		}
 
@@ -471,7 +471,7 @@ void WeaponEditorDlg::change_selection()
 				m_ammo_max3 = get_max_ammo_count_for_turret_bank(cur_weapon, 2, m_missile3 - 1);
 			}
 			if (cur_weapon->secondary_bank_ammo[2] != BLANK_FIELD)
-				m_ammo3 = cur_weapon->secondary_bank_ammo[2] * m_ammo_max3 / 100;
+				m_ammo3 = fl2ir(cur_weapon->secondary_bank_ammo[2] * m_ammo_max3 / 100.0f);
 			m_missile3 -= First_secondary_index;
 		}
 
@@ -494,7 +494,7 @@ void WeaponEditorDlg::change_selection()
 				m_ammo_max4 = get_max_ammo_count_for_turret_bank(cur_weapon, 3, m_missile4 - 1);
 			}
 			if (cur_weapon->secondary_bank_ammo[3] != BLANK_FIELD)
-				m_ammo4 = cur_weapon->secondary_bank_ammo[3] * m_ammo_max4 / 100;
+				m_ammo4 = fl2ir(cur_weapon->secondary_bank_ammo[3] * m_ammo_max4 / 100.0f);
 			m_missile4 -= First_secondary_index;
 		}
 


### PR DESCRIPTION
This fixes the improper rounding in the weapons dialog, which can cause missile counts to decrease progressively if the dialog is repeatedly opened and closed. (Rounding is necessary because mission files store missile counts as integral percentages rather than the actual numbers of missiles.)

More information can be found in this thread:
http://www.hard-light.net/forums/index.php?topic=93161.new