### PR TITLE
Return correct bits-per-pixel data for 16-bit PNGs

### DIFF
--- a/code/pngutils/pngutils.cpp
+++ b/code/pngutils/pngutils.cpp
@@ -145,7 +145,11 @@ int png_read_header(const char *real_filename, CFILE *img_cfp, int *w, int *h, i
 	if (w) *w = png_get_image_width(png_ptr, info_ptr);
 	if (h) *h = png_get_image_height(png_ptr, info_ptr);
 	// this turns out to be near useless, but meh
-	if (bpp) *bpp = (png_get_channels(png_ptr, info_ptr) * png_get_bit_depth(png_ptr, info_ptr));
+	if (bpp) {
+		// bit depth can also be 16 bit we tell libpng to reduce that to 8 bits so we also need to tell our caller about that
+		auto bits = std::min(8, (int)png_get_bit_depth(png_ptr, info_ptr));
+		*bpp = (png_get_channels(png_ptr, info_ptr) * bits);
+	}
 
 	if (img_cfp == NULL) {
 		cfclose(status.cfp);


### PR DESCRIPTION
PNGs can have 16 bits per channel but we always tell libpng to reduce
that to 8 bits per channel. However, we do not tell the caller of
png_read_header that this will happen so instead of 32-bits per pixel,
we tell bmpman that the image has 64 bits per pixel which causes some
issues.

The specific issue I fixed was the system map of BtA where the jump
nodes used a 16-bit PNG which broke the alpha blending of those bitmaps
since bmpan though that the image had no alpha channel.