### PR TITLE
Removes log spam

### DIFF
--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -1240,7 +1240,7 @@ objp->orient = objp_orient_copy; //-V587
 
 	#ifndef NDEBUG
 	if (!((objp->type == OBJ_WEAPON) && (Weapon_info[Weapons[objp->instance].weapon_info_index].subtype == WP_MISSILE))) {
-		if (!(delta_time < 0.25f && vm_vec_dot(&objp->orient.vec.fvec, &tvec) < 0.1f))
+		if (delta_time < 0.25f && vm_vec_dot(&objp->orient.vec.fvec, &tvec) < 0.1f)
 			mprintf(("A ship rotated too far. Offending vessel is %s, please investigate.\n", Ships[objp->instance].ship_name));
 	}
 	#endif


### PR DESCRIPTION
When converting an Assertion to a Warning or log print, remember to invert the Assertion's condition to get correct behaviour. Fix for #1217.