### PR TITLE
vecmat: Fix vm_test_parallel()

### DIFF
--- a/code/math/vecmat.cpp
+++ b/code/math/vecmat.cpp
@@ -617,14 +617,26 @@ vec3d *vm_vec_cross(vec3d *dest, const vec3d *src0, const vec3d *src1)
 
 int vm_test_parallel(const vec3d *src0, const vec3d *src1)
 {
-	// This version assumes SIMD/SSE optimizations, which would essentially be only 2 operations
-	// If SIMD/SSE is not available, you could check if the vectors are a scalar of each other. i.g. if((x1/x2) == (y1/y2) == (z1/z2)
-	// TODO: make a compile-time check for SIMD/SSE optimizations, If we have them, then use the vecmath method, if not, then use the logical method.
+	vec3d partial1;
+	vec3d partial2;
 
-	vec3d test;
+	/*
+	 * To test if two vectors are parallel, calculate their cross product.
+	 * If the result is zero, then the vectors are parallel. It is better
+	 * to compare the two cross product "partials" (for lack of a better
+	 * word) against each other instead of the final cross product against
+	 * zero.
+	 */
 
-	vm_vec_cross(&test, src0, src1);
-	return vm_vec_equal(test, vmd_zero_vector);
+	partial1.xyz.x = (src0->xyz.y * src1->xyz.z);
+	partial1.xyz.y = (src0->xyz.z * src1->xyz.x);
+	partial1.xyz.z = (src0->xyz.x * src1->xyz.y);
+
+	partial2.xyz.x =  (src0->xyz.z * src1->xyz.y);
+	partial2.xyz.y =  (src0->xyz.x * src1->xyz.z);
+	partial2.xyz.z =  (src0->xyz.y * src1->xyz.x);
+
+	return vm_vec_equal(partial1, partial2);
 }
 
 //computes non-normalized surface normal from three points.


### PR DESCRIPTION
Fixes a subtle problem with vm_test_parallel() wherein a relative error
was accidentally converted into an absolute error.

Instead of comparing the result of the cross product to the zero vector,
the two calculated components of the cross product are compared against
each other. This permits vectors whose cross product is a large number
but whose cross product partials are within relative error of each other
to be treated as parallel.

For example, the following two vectors may now be considered as parallel
whereas before they were not:
   v1 = (1000004.0, 1.0, 1.0)
   v2 = (1000000.0, 1.0, 1.0)
The relative difference between them is sufficiently small according to
vm_vec_equal() for them to be considered equal, but their cross product
would have elements whose magnitudes would be near 4.0 which would
otherwise indicate that they are not parallel. By comparing the partials
instead, a higher degree of consistency is maintained.

Signed-off-by: Peter Mitsis <peter.mitsis@gmail.com>