### PR TITLE
Fix for improper setting of +Red Alert:

### DIFF
--- a/fred2/missionsave.cpp
+++ b/fred2/missionsave.cpp
@@ -2260,7 +2260,7 @@ int CFred_mission_save::save_mission_info() {
 		else
 			fout("\n+Red Alert:");
 
-		fout(" %d", (The_mission.flags[Mission::Mission_Flags::Fullneb]) ? 1 : 0);
+		fout(" %d", (The_mission.flags[Mission::Mission_Flags::Red_alert]) ? 1 : 0);
 	}
 
 	if (Format_fs2_open == FSO_FORMAT_RETAIL) //-V581


### PR DESCRIPTION
Currently, when saving a retail-compatible mission, FRED sets +Red Alert: based on whether the Full Nebula option is enabled rather than the Red Alert option. This PR fixes this behavior.