### PR TITLE
Change get_max_ammo_count_for_bank to return "correct" max missile count

### DIFF
--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -16087,7 +16087,7 @@ int get_max_ammo_count_for_bank(int ship_class, int bank, int ammo_type)
 		capacity = (float) Ship_info[ship_class].secondary_bank_ammo_capacity[bank];
 		size = (float) Weapon_info[ammo_type].cargo_size;
 		Assertion(size > 0.0f, "Weapon cargo size for %s must be greater than 0!", Weapon_info[ammo_type].name);
-		return (int) (capacity / size);
+		return fl2ir(capacity / size);
 	}
 }
 


### PR DESCRIPTION
Most of the game considers a ship bank's max missile count to be the bank's capacity divided by the missile's cargo size, rounded to the nearest integer. So, for example, the GTF Ares' first missile bank, which has a capacity of 90, can hold 23 Rockeyes, which have a cargo size of 4 (90 / 4 = 22.5, rounded to 23).

The `get_max_ammo_count_for_bank` function, however, doesn't do the rounding, so in the scenario above, it thinks the Ares' first missile bank can hold only 22 Rockeyes (90 / 4 = 22.5, truncated to 22). (This function is used by FRED to obtain max missile counts, and is also used by the game to determine how many missiles a support ship can load into a bank during a red-alert mission.)

This PR fixes this discrepancy by adjusting the `get_max_ammo_count_for_bank` function to match the rest of the game.