### PR TITLE
Fix briefing word wrapping when a script changes the font

### DIFF
--- a/code/missionui/missioncmdbrief.cpp
+++ b/code/missionui/missioncmdbrief.cpp
@@ -350,6 +350,9 @@ void cmd_brief_new_stage(int stage)
 		Cur_stage = -1;
 	}
 
+	// Make sure that the text wrapping and the rendering code use the same font
+	font::set_font(font::FONT1);
+
 	Cur_stage = stage;
 	brief_color_text_init(Cur_cmd_brief->stage[stage].text.c_str(), Cmd_text_wnd_coords[Uses_scroll_buttons][gr_screen.res][CMD_W_COORD], default_command_briefing_color);
 

--- a/code/missionui/missiondebrief.cpp
+++ b/code/missionui/missiondebrief.cpp
@@ -1835,6 +1835,9 @@ void debrief_text_init()
 		}
 	}
 
+	// Make sure that the text wrapping and the rendering code use the same font
+	font::set_font(DEBRIEFING_FONT);
+
 	Num_text_lines = Text_offset = brief_color_text_init("", Debrief_text_wnd_coords[gr_screen.res][2], default_debriefing_color, 0, 0);	// Initialize color stuff -MageKing17
 
 	fsspeech_start_buffer();

--- a/code/missionui/redalert.cpp
+++ b/code/missionui/redalert.cpp
@@ -338,6 +338,9 @@ void red_alert_init()
 	// load in background image and flashing red alert animation
 	Background_bitmap = mission_ui_background_load(Briefing->background[gr_screen.res], Red_alert_fname[gr_screen.res]);
 
+	// Make sure word wrapping and rendering use the same font
+	font::set_font(font::FONT1);
+
 	if ( Briefing->num_stages > 0 ) {
 		brief_color_text_init(Briefing->stages[0].text.c_str(), Ra_brief_text_wnd_coords[gr_screen.res][RA_W_COORD], default_redalert_briefing_color, 0);
 	}


### PR DESCRIPTION
This happened in BtA where a script changed the font after rendering its
UI. Since the briefing code didn't account for that, the word wrapping
code used the wrong font for calculating how long a line would be which
made the display look wrong.