### PR TITLE
Fix for #967 - Enable APPLE_APP in Mac CMake project

### DIFF
--- a/cmake/platform-darwin.cmake
+++ b/cmake/platform-darwin.cmake
@@ -1,5 +1,6 @@
 
 MESSAGE(STATUS "Doing Mac OSX specific things...")
+target_compile_definitions(platform INTERFACE APPLE_APP)
 SET(EXE_GUI_TYPE MACOSX_BUNDLE)
 
 FIND_LIBRARY(COCOA_LIBRARY Cocoa)

--- a/code/cmdline/cmdline.cpp
+++ b/code/cmdline/cmdline.cpp
@@ -948,26 +948,23 @@ void os_init_cmdline(int argc, char *argv[])
 	reset_cmdline_parms();
 
 	FILE *fp;
-	
+
 	if (!has_cmdline_only_flag(argc, argv)) {
 		// Only parse the config file in the current directory if we are in legacy config mode
 		if (os_is_legacy_mode()) {
 			// read the cmdline_fso.cfg file from the data folder, and pass the command line arguments to
 			// the the parse_parms and validate_parms line.  Read these first so anything actually on
 			// the command line will take precedence
-#ifdef _WIN32
-			fp = fopen("data\\cmdline_fso.cfg", "rt");
-#elif defined(APPLE_APP)
+#ifdef APPLE_APP
 			char resolved_path[MAX_PATH], data_path[MAX_PATH_LEN];
 
-			GetCurrentDirectory(MAX_PATH_LEN - 1, data_path);
+			getcwd(data_path, sizeof(data_path));
 			snprintf(resolved_path, MAX_PATH, "%s/data/cmdline_fso.cfg", data_path);
 
 			fp = fopen(resolved_path, "rt");
 #else
-			fp = fopen("data/cmdline_fso.cfg", "rt");
+			fp = fopen("data" DIR_SEPARATOR_STR "cmdline_fso.cfg", "rt");
 #endif
-
 			// if the file exists, get a single line, and deal with it
 			if (fp) {
 				char *buf, *p;
@@ -981,7 +978,6 @@ void os_init_cmdline(int argc, char *argv[])
 					if ((p = strrchr(buf, '\n')) != NULL) {
 						*p = '\0';
 					}
-
 #ifdef SCP_UNIX
 					// append a space for the os_parse_parms() check
 					strcat_s(buf, len, " ");
@@ -1012,14 +1008,14 @@ void os_init_cmdline(int argc, char *argv[])
 
 				// append a space for the os_parse_parms() check
 				strcat_s(buf, len, " ");
-			
+
 				os_process_cmdline(buf);
 			}
 			delete [] buf;
 			fclose(fp);
 		}
 	} // If cmdline included PARSE_COMMAND_LINE_STRING
-    
+
 	// By parsing cmdline last, anything actually on the command line will take precedence.
 	os_parse_parms(argc, argv);
 	os_validate_parms(argc, argv);

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -8092,7 +8092,7 @@ int actual_main(int argc, char *argv[])
 	// Finder sets the working directory to the root of the drive so we have to get a little creative
 	// to find out where on the disk we should be running from for CFILE's sake.
 	char *path_name = SDL_GetBasePath();
-	SetCurrentDirectory(path_name);
+	chdir(path_name);
 	SDL_free(path_name);
 #endif
 


### PR DESCRIPTION
fix/967: Define APPLE_APP to fix some issues introduced on Mac in the CMake conversion (may have other effects we aren't yet aware of).

Specifically fixes being able to double click the app in the finder (issue #967), as opposed to having to launch through the finder.  Before this returned an error, now it will run as expected, with the last saved command line settings.

Also unifies a three-part ifdef into a two part by using our standard DIR_SEPARATOR.

GetCurrentDirectory and SetCurrentDirectory had to be replaced with more standard equivalents as they don't seem to be part of any current Mac framework, if they ever were.

The target_compile_definitions line is paired alongside the EXE_GUI_TYPE set because if the Mac build is ever supported in a non-bundled fashion, those two lines would need to be addressed as a pair.