### PR TITLE
Fix wrong control flow in stars_draw_sun

### DIFF
--- a/code/starfield/starfield.cpp
+++ b/code/starfield/starfield.cpp
@@ -1104,7 +1104,7 @@ void stars_draw_sun(int show_sun)
 		g3_rotate_faraway_vertex(&sun_vex, &sun_pos);
 
 		if ( sun_vex.codes & (CC_BEHIND|CC_OFF_USER) ) {
-			return;
+			continue;
 		}
 
 		if ( !(sun_vex.flags & PF_PROJECTED) ) {
@@ -1112,7 +1112,7 @@ void stars_draw_sun(int show_sun)
 		}
 
 		if ( sun_vex.flags & PF_OVERFLOW ) {
-			return;
+			continue;
 		}
 
 		material mat_params;


### PR DESCRIPTION
The code wrongly used return instead of continue. This caused a second
sun to disappear if the bitmap of the first sun wasn't drawn.

This fixes [Mantis 3188](http://scp.indiegames.us/mantis/view.php?id=3188).