### PR TITLE
Fix "On Object Render" behavior regression

### DIFF
--- a/code/object/object.cpp
+++ b/code/object/object.cpp
@@ -1578,13 +1578,17 @@ void obj_queue_render(object* obj, model_draw_list* scene)
 
 	if ( obj->flags[Object::Object_Flags::Should_be_dead] ) return;
 
-	// need to figure out what to do with this hook. 
-	// maybe save an array of these and run the script conditions after we finish drawing
 	Script_system.SetHookObject("Self", obj);
+	
+	auto skip_render = Script_system.IsConditionOverride(CHA_OBJECTRENDER, obj);
+	
+	// Always execute the hook content
+	Script_system.RunCondition(CHA_OBJECTRENDER, '\0', NULL, obj);
+	
+	Script_system.RemHookVar("Self");
 
-	if ( Script_system.IsConditionOverride(CHA_OBJECTRENDER, obj) ) {
-		Script_system.RunCondition(CHA_OBJECTRENDER, '\0', NULL, obj);
-		Script_system.RemHookVar("Self");
+	if (skip_render) {
+		// Script said that it want's to skip rendering
 		return;
 	}
 


### PR DESCRIPTION
This regression was introduced with the new model draw list which separates
collecting the drawing information and actually drawing the objects.

Previously, the scripting hook was always executed and the override
condition was used to determine if the normal rendering should happen.
Since 3.7.4, the scripting code is only executed if the condition was
overridden by Lua and if that override is active then the model isn't
rendered at all.

This executes the scripting hook in all cases and then checks if the
scripting system specified if rendering of that object should be
skipped. This introduces some slight changes in behavior since, when the
scripting hook is executed, the object isn't actually being rendered but
instead it's added to the draw list. IMO, that is not a major issue for
any existing application or else we would have heard about that until
now.

This fixes [Mantis 3175](http://scp.indiegames.us/mantis/view.php?id=3175).