### PR TITLE
Unload models after loading them for -pofspew

### DIFF
--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -6791,11 +6791,8 @@ void game_spew_pof_info()
 				}				
 				cfputs("------------------------------------------------------------------------\n\n", out);				
 			}
-		}
-
-		if(counted >= MAX_POLYGON_MODELS - 5){
-			model_free_all();
-			counted = 0;
+			// Free memory of this model again
+			model_unload(model_num);
 		}
 	}
 


### PR DESCRIPTION
In large mods this caused memory issues since we reached the 32-bit
memory limit when loading all models of a large mod (e.g. Blue Planet).

I fixed that by explicitly unloading the loaded model once the code is
done with it.

This fixes [Mantis 3177](http://scp.indiegames.us/mantis/view.php?id=3177).