### PR TITLE
Render all damage elements of the damage HUD gauge

### DIFF
--- a/code/hud/hud.cpp
+++ b/code/hud/hud.cpp
@@ -1991,14 +1991,9 @@ void HudGaugeDamage::render(float frametime)
 {
 	model_subsystem	*psub;
 	ship_subsys			*pss;
-	int					sx, sy, bx, by, w, h, screen_integrity, num, best_str, best_index;
+	int					screen_integrity, num, best_str, best_index;
 	float					strength, shield, integrity;
-	char					buf[128];
 	hud_subsys_damage	hud_subsys_list[SUBSYSTEM_MAX];	
-
-	if ( (Player_ship->ship_max_hull_strength - Player_obj->hull_strength) <= 1.0f ) {
-		return;
-	}
 
 	if ( damage_top.first_frame == -1 ) {
 		return;
@@ -2007,47 +2002,11 @@ void HudGaugeDamage::render(float frametime)
 	if ( (The_mission.game_type & MISSION_TYPE_TRAINING) && Training_message_visible ){
 		return;
 	}
-		
-	hud_get_target_strength(Player_obj, &shield, &integrity);
-	screen_integrity = fl2i(integrity*100);
-
-	if ( hud_gauge_is_popup(gauge_config) ) {
-		if ( screen_integrity >= 100 ) {
-			return;
-		}
-	}
 
 	if ( timestamp_elapsed(Damage_flash_timer) ) {
 		Damage_flash_timer = timestamp(DAMAGE_FLASH_TIME);
 		Damage_flash_bright = !Damage_flash_bright;
 	}
-
-	setGaugeColor();
-
-	// Draw the top of the damage pop-up
-	renderBitmap(damage_top.first_frame, position[0], position[1]);	
-	renderString(position[0] + header_offsets[0], position[1] + header_offsets[1], XSTR( "damage", 218));
-
-	// Show hull integrity
-	if ( screen_integrity < 100 ) {		
-		if ( screen_integrity == 0 ) {
-			screen_integrity = 1;
-		}
-		sprintf(buf, XSTR( "%d%%", 219), screen_integrity);
-		hud_num_make_mono(buf, font_num);
-		gr_get_string_size(&w, &h, buf);
-		if ( screen_integrity < 30 ) {
-			gr_set_color_fast(&Color_red);
-		}
-		renderString(position[0] + hull_integ_offsets[0], position[1] + hull_integ_offsets[1], XSTR( "Hull Integrity", 220));
-		renderString(position[0] + hull_integ_val_offset_x - w, position[1] + hull_integ_offsets[1], buf);
-	} 
-
-	// Show damaged subsystems
-	sx = position[0] + subsys_integ_start_offsets[0];
-	sy = position[1] + subsys_integ_start_offsets[1];
-	bx = position[0];
-	by = position[1] + middle_frame_start_offset_y;
 
 	num = 0;
 	for ( pss = GET_FIRST(&Player_ship->subsys_list); pss !=END_OF_LIST(&Player_ship->subsys_list); pss = GET_NEXT(pss) ) {
@@ -2084,6 +2043,15 @@ void HudGaugeDamage::render(float frametime)
 		}
 	}
 
+	// Build a list of damage values to display and then actually display them in a second pass
+	// This allows to hide the gauge when there is no damage
+	SCP_vector<DamageInfo> info_lines;
+
+	auto sx = position[0] + subsys_integ_start_offsets[0];
+	auto sy = position[1] + subsys_integ_start_offsets[1];
+	auto bx = position[0];
+	auto by = position[1] + middle_frame_start_offset_y;
+
 	int type;
 	for ( int i = 0; i < num; i++ ) {
 		best_str = 1000;
@@ -2098,10 +2066,11 @@ void HudGaugeDamage::render(float frametime)
 		Assert(best_index >= 0);
 		Assert(best_str >= 0);
 
-		setGaugeColor();
+		DamageInfo info;
 
-		renderBitmap(damage_middle.first_frame, bx, by);
-		by += line_h;
+		info.draw_background = true;
+		info.background_x = bx;
+		info.background_y = by;
 
 		type = hud_subsys_list[best_index].type;
 		if ( !timestamp_elapsed( Pl_hud_subsys_info[type].flash_duration_timestamp ) ) {
@@ -2112,9 +2081,7 @@ void HudGaugeDamage::render(float frametime)
 			
 			if ( flash_status ) {
 				int alpha_color = MIN(HUD_COLOR_ALPHA_MAX,HUD_color_alpha+HUD_BRIGHT_DELTA);
-				setGaugeColor(alpha_color);
-			} else {				
-				setGaugeColor();
+				info.bright_index = alpha_color;
 			}
 		}
 
@@ -2122,36 +2089,46 @@ void HudGaugeDamage::render(float frametime)
 		if ( best_str < 30 ) {
 			if ( best_str <= 0 ) {
 				if ( Damage_flash_bright ) {
-					gr_set_color_fast(&Color_bright_red);
+					info.color_override = &Color_bright_red;
 				} else {
-					gr_set_color_fast(&Color_red);
+					info.color_override = &Color_red;
 				}
-
 			} else {
-				gr_set_color_fast(&Color_red);
+				info.color_override = &Color_red;
 			}
-		} else {
-			setGaugeColor();
-		}		
+		}
 
 		const char *n_firstline;
 		n_firstline = strrchr(hud_subsys_list[best_index].name, '|');
 		if (n_firstline) {
 			// Print only the last line
 			n_firstline++;
-			renderString(sx, sy, n_firstline);
+			info.name = n_firstline;
 		} else {
 			char temp_name[NAME_LENGTH];
 			strcpy_s(temp_name, hud_subsys_list[best_index].name);
 			hud_targetbox_truncate_subsys_name(temp_name);
-			renderString(sx, sy, temp_name);
+			info.name = temp_name;
 		}
 
+		char buf[128];
 		sprintf(buf, XSTR( "%d%%", 219), best_str);
 		hud_num_make_mono(buf, font_num);
+
+		int w, h;
 		gr_get_string_size(&w, &h, buf);
-		renderString(position[0] + subsys_integ_val_offset_x - w, sy, buf);
+
+		info.value_x = position[0] + subsys_integ_val_offset_x - w;
+		info.value_y = sy;
+		info.strength = best_str;
+
+		info.name_x = sx;
+		info.name_y = sy;
+
+		by += line_h;
 		sy += line_h;
+
+		info_lines.push_back(info);
 
 		// Remove it from hud_subsys_list
 		if ( best_index < (num-i-1) ) {
@@ -2159,8 +2136,82 @@ void HudGaugeDamage::render(float frametime)
 		}
 	}
 
+	hud_get_target_strength(Player_obj, &shield, &integrity);
+	screen_integrity = fl2i(integrity*100);
+
+	// Show hull integrity if it's below 100% or if a subsystem is damaged
+	// The second case is just to make the display look complete
+	// The third case is there to make the gauge appear only if needed if the right option is set
+	if ( screen_integrity < 100 || !info_lines.empty() ) {
+		DamageInfo info;
+
+		info.name = XSTR( "Hull Integrity", 220);
+
+		if ( screen_integrity == 0 ) {
+			screen_integrity = 1;
+		}
+		info.strength = screen_integrity;
+
+		char buf[128];
+		sprintf(buf, XSTR( "%d%%", 219), screen_integrity);
+		hud_num_make_mono(buf, font_num);
+
+		int w, h;
+		gr_get_string_size(&w, &h, buf);
+
+		if ( screen_integrity < 30 ) {
+			info.color_override = &Color_red;
+		}
+
+		info.name_x = position[0] + hull_integ_offsets[0];
+		info.name_y = position[1] + hull_integ_offsets[1];
+
+		info.value_x = position[0] + hull_integ_val_offset_x - w;
+		info.value_y = position[1] + hull_integ_offsets[1];
+
+		// Insert at the top since hull is always first
+		info_lines.insert(info_lines.begin(), info);
+	}
+
+	if (info_lines.empty()) {
+		// Nothing to display, return before dawing anything
+		return;
+	}
+
 	setGaugeColor();
-	renderBitmap(damage_bottom.first_frame, bx, by + bottom_bg_offset);		
+
+	// Draw the top of the damage pop-up
+	renderBitmap(damage_top.first_frame, position[0], position[1]);
+	renderString(position[0] + header_offsets[0], position[1] + header_offsets[1], XSTR( "damage", 218));
+
+	// These variables keep track of where the background was drawn last so we can draw the bottom correctly
+	int last_bx = position[0];
+	int last_by = position[1] + middle_frame_start_offset_y;
+	for (auto& line : info_lines) {
+		if (line.draw_background) {
+			renderBitmap(damage_middle.first_frame, line.background_x, line.background_y);
+			last_bx = line.background_x;
+			last_by = line.background_y + line_h; // Add line_h here so that the footer is properly aligned
+		}
+
+		char buf[128];
+		sprintf(buf, XSTR( "%d%%", 219), line.strength);
+		hud_num_make_mono(buf, font_num);
+
+		if (line.color_override != nullptr) {
+			gr_set_color_fast(line.color_override);
+		} else {
+			setGaugeColor(line.bright_index);
+		}
+
+		renderString(line.name_x, line.name_y, line.name.c_str());
+		renderString(line.value_x, line.value_y, buf);
+
+		setGaugeColor();
+	}
+
+	setGaugeColor();
+	renderBitmap(damage_bottom.first_frame, last_bx, last_by + bottom_bg_offset);
 }
 
 /** 

--- a/code/hud/hud.h
+++ b/code/hud/hud.h
@@ -300,7 +300,7 @@ public:
 	void resetCockpitTarget();
 	
 	void setFont();
-	void setGaugeColor(int bright_index = -4);
+	void setGaugeColor(int bright_index = HUD_C_NONE);
 	
 	// rendering functions
 	void renderBitmap(int x, int y);
@@ -419,6 +419,24 @@ public:
 
 class HudGaugeDamage: public HudGauge
 {
+	struct DamageInfo {
+		SCP_string name;
+		int strength = -1;
+
+		int bright_index = HUD_C_NONE;
+		color* color_override = nullptr;
+
+		int name_x = -1;
+		int name_y = -1;
+
+		int value_x = -1;
+		int value_y = -1;
+
+		bool draw_background = false;
+		int background_x = -1;
+		int background_y = -1;
+	};
+
 protected:
 	hud_frames damage_top;
 	hud_frames damage_middle;


### PR DESCRIPTION
Previously, the hud gauge was hidden if the player ship had taken no
damage. However, this made it impossible to see if subsystems have been
damaged.

These changes make sure that the subsystem values are shown even if the
hull integrity is at 100%. This is done by first collecting all the
necessary information about each line in the gauge and then, if that list
is non-empty, rendering it. This is necessary since the gauge code can't
decide if anything will be visible before looking at the entire
subsystem list.

There is a minor behavior change with how popups are handled.
Previously, the code would return if the HUD gauge was a popup and its
strength was at 100%. However, I think that this was dead code anyway
since that condition could never be true at that point because the code
would have returned earlier if there was no damage.

This fixes Mantis 3183.