### PR TITLE
Fix standalone timer overflow

### DIFF
--- a/code/io/timer.cpp
+++ b/code/io/timer.cpp
@@ -28,6 +28,7 @@ static int Timer_inited = 0;
 #define MICROSECONDS_PER_SECOND 1000000
 #define NANOSECONDS_PER_SECOND 1000000000
 
+static long double Timer_to_microseconds;
 static long double Timer_to_nanoseconds;
 
 static uint64_t get_performance_counter()
@@ -52,6 +53,7 @@ void timer_init()
 		Timer_perf_counter_freq = SDL_GetPerformanceFrequency();
 		Timer_base_value = SDL_GetPerformanceCounter();
 		Timer_to_nanoseconds = (long double) NANOSECONDS_PER_SECOND / (long double) Timer_perf_counter_freq;
+		Timer_to_microseconds = (long double) MICROSECONDS_PER_SECOND / (long double) Timer_perf_counter_freq;
 		Timer_inited = 1;
 
 		atexit(timer_close);
@@ -100,7 +102,7 @@ std::uint64_t timer_get_microseconds()
 {
 	auto time = get_performance_counter();
 
-	return (time * MICROSECONDS_PER_SECOND) / Timer_perf_counter_freq;
+	return (uint64_t) (time * Timer_to_microseconds);
 }
 
 std::uint64_t timer_get_nanoseconds()


### PR DESCRIPTION
If FSO runs for a very long time (5 hours to be exact) then the SDL
performance counter reaches a value so hight that rescaling it to
microseconds causes an overflow which is bad.

This fixes that by implementing the rescaling by computing the factor in
the timer initialization code and then multiplying the SDL time with
that. This uses the same principle as the changes done by @TheMatthew in #1082.

According to the tests done by @chief1983, this fixes #1237.