### PR TITLE
Clear the player's variable vector in init_new_pilot() if reset is true.

### DIFF
--- a/code/playerman/managepilot.cpp
+++ b/code/playerman/managepilot.cpp
@@ -101,6 +101,8 @@ void init_new_pilot(player *p, int reset)
 		Mouse_sensitivity = 4;
 		Joy_sensitivity = 9;
 		Joy_dead_zone_size = 10;
+
+		p->variables.clear();
 	}
 
 	// unassigned squadron


### PR DESCRIPTION
This fixes a bug whereby creating a pilot in the barracks screen (not the initial pilot selection screen) would effectively clone the variable vector from whatever pilot was selected beforehand.