### PR TITLE
Make debris from a ship use the ship class's alt name, if specified.

### DIFF
--- a/code/hud/hudtargetbox.cpp
+++ b/code/hud/hudtargetbox.cpp
@@ -776,7 +776,7 @@ void HudGaugeTargetBox::renderTargetDebris(object *target_objp)
 	if (debrisp->parent_alt_name >= 0)
 		mission_parse_lookup_alt_index(debrisp->parent_alt_name, printable_ship_class);
 	else
-		strcpy_s(printable_ship_class, Ship_info[debrisp->ship_info_index].name);
+		strcpy_s(printable_ship_class, (Ship_info[debrisp->ship_info_index].alt_name[0]) ? Ship_info[debrisp->ship_info_index].alt_name : Ship_info[debrisp->ship_info_index].name);
 
 	end_string_at_first_hash_symbol(printable_ship_class);
 	


### PR DESCRIPTION
A piece of debris spawned from a ship will say what class of ship it came from. If that ship has an alternate class name defined in FRED, that's used instead. If the ship class table entry specifies an "$Alt name:", however, that isn't used, which could potentially be confusing. This fixes that oversight.