### PR TITLE
Load the Fire particle animations

### DIFF
--- a/code/particle/particle.cpp
+++ b/code/particle/particle.cpp
@@ -87,6 +87,11 @@ namespace particle
 	void init()
 	{
 
+		if (Anim_bitmap_id_fire == -1) 
+		{
+			Anim_bitmap_id_fire = bm_load_animation("particleexp01", &Anim_num_frames_fire, nullptr, NULL, 0);
+		}
+
 		// Cough, cough
 		if (Anim_bitmap_id_smoke == -1)
 		{

--- a/code/particle/particle.cpp
+++ b/code/particle/particle.cpp
@@ -86,7 +86,7 @@ namespace particle
 	// Reset everything between levels
 	void init()
 	{
-
+		// FIRE!!!
 		if (Anim_bitmap_id_fire == -1) 
 		{
 			Anim_bitmap_id_fire = bm_load_animation("particleexp01", &Anim_num_frames_fire, nullptr, NULL, 0);

--- a/code/particle/particle.cpp
+++ b/code/particle/particle.cpp
@@ -87,7 +87,7 @@ namespace particle
 	void init()
 	{
 		// FIRE!!!
-		if (Anim_bitmap_id_fire == -1) 
+		if (Anim_bitmap_id_fire == -1)
 		{
 			Anim_bitmap_id_fire = bm_load_animation("particleexp01", &Anim_num_frames_fire, nullptr, NULL, 0);
 		}


### PR DESCRIPTION
The new particle system didn't load the particleexp01 anim as a generic fire animation. This caused calls to create PARTICLE_FIRE particles to fail silently.

Fixes #1245.