### PR TITLE
Use a manually maintained prefix header for cotire

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,27 +108,16 @@ SET(FSO_RUN_ARGUMENTS "" CACHE STRING "Additional arguments passed to a generate
 
 option(FSO_INSTALL_DEBUG_FILES "Install some debug files (currently only PDB files on windows)" OFF)
 
-set(DEFAULT_VAL OFF)
-if(MSVC)
-	# MSVC has been tested
-	set(DEFAULT_VAL ON)
-endif()
-
-OPTION(COTIRE_ENABLE "Enable cotire, this speeds up builds but may cause issues while developing (default = OFF)" ${DEFAULT_VAL})
-
 MARK_AS_ADVANCED(FORCE FSO_CMAKE_DEBUG)
 MARK_AS_ADVANCED(FORCE FSO_BUILD_INCLUDED_LIBS)
 MARK_AS_ADVANCED(FORCE FSO_USE_OPENALSOFT)
 MARK_AS_ADVANCED(FORCE FSO_USE_LUAJIT)
 MARK_AS_ADVANCED(FORCE FSO_DEVELOPMENT_MODE)
 MARK_AS_ADVANCED(FORCE FSO_FATAL_WARNINGS)
-MARK_AS_ADVANCED(FORCE COTIRE_ENABLE)
 mark_as_advanced(FORCE FSO_INSTALL_DEBUG_FILES)
 
-IF(COTIRE_ENABLE)
-	# Include cotire file from https://github.com/sakra/cotire/
-	include(cotire)
-ENDIF(COTIRE_ENABLE)
+# Include cotire file from https://github.com/sakra/cotire/
+include(cotire)
 
 INCLUDE(globals)
 INCLUDE(toolchain)

--- a/cmake/util.cmake
+++ b/cmake/util.cmake
@@ -141,15 +141,10 @@ macro(set_if_not_defined VAR VALUE)
 endmacro(set_if_not_defined)
 
 macro(configure_cotire target)
-	IF(COTIRE_ENABLE)
-		# Disable unity build as it doesn't work well for us
-		set_target_properties(${target} PROPERTIES COTIRE_ADD_UNITY_BUILD FALSE)
+	# Disable unity build as it doesn't work well for us
+	set_target_properties(${target} PROPERTIES COTIRE_ADD_UNITY_BUILD FALSE)
 
-		# add ignored paths for the precompiled header here
-		set_target_properties(code PROPERTIES COTIRE_PREFIX_HEADER_IGNORE_PATH
-			"${CMAKE_SOURCE_DIR};${CMAKE_BINARY_DIR};${FFMPEG_ROOT_DIR}")
-		cotire(${target})
-	ENDIF(COTIRE_ENABLE)
+	cotire(${target})
 endmacro(configure_cotire)
 
 macro(add_target_copy_files)

--- a/code/CMakeLists.txt
+++ b/code/CMakeLists.txt
@@ -53,6 +53,8 @@ IF(FSO_BUILD_TOOLS)
 	ADD_SUBDIRECTORY(cfileextractor)
 ENDIF(FSO_BUILD_TOOLS)
 
+set_target_properties(code PROPERTIES COTIRE_CXX_PREFIX_HEADER_INIT "prefix_header.h")
+
 include(util)
 configure_cotire(code)
 

--- a/code/jpgutils/jpgutils.cpp
+++ b/code/jpgutils/jpgutils.cpp
@@ -13,24 +13,24 @@
 #include <string.h>
 #include <setjmp.h>
 
-#include "jpeglib.h"
-
-#undef LOCAL // fix from a jpeg header, pstypes.h will define it again
-
-// fix a warning where jpeg and SDL headers collide
-#ifdef HAVE_STDDEF_H
-#undef HAVE_STDDEF_H
-#endif 
-
-#ifdef HAVE_STDLIB_H
-#undef HAVE_STDLIB_H
-#endif
-
 #include "globalincs/pstypes.h"
 #include "jpgutils/jpgutils.h"
 #include "cfile/cfile.h"
 #include "bmpman/bmpman.h"
 #include "graphics/2d.h"
+
+#undef LOCAL // fix for the jpeg header, pstypes.h has defined these macros
+
+// fix a warning where jpeg and SDL headers collide
+#ifdef HAVE_STDDEF_H
+#undef HAVE_STDDEF_H
+#endif
+
+#ifdef HAVE_STDLIB_H
+#undef HAVE_STDLIB_H
+#endif
+
+#include "jpeglib.h"
 
 
 // forward declarations

--- a/code/prefix_header.h
+++ b/code/prefix_header.h
@@ -1,0 +1,39 @@
+#pragma once
+
+// This header is used for compiling the precompiled header file that is included in the entire code project
+
+#include <stdio.h>
+#include <stddef.h>
+#include <string.h>
+#include <stdlib.h>
+#include <memory.h>
+#include <math.h>
+#include <time.h>
+#include <inttypes.h>
+#include <assert.h>
+#include <stdarg.h>
+
+#include <algorithm>
+#include <stdexcept>
+#include <vector>
+#include <list>
+#include <map>
+#include <string>
+#include <sstream>
+#include <queue>
+#include <unordered_map>
+#include <bitset>
+#include <functional>
+#include <memory>
+#include <cstdarg>
+#include <csetjmp>
+#include <iterator>
+#include <iomanip>
+#include <mutex>
+#include <condition_variable>
+#include <iostream>
+#include <set>
+#include <stack>
+#include <fstream>
+#include <random>
+#include <future>

--- a/code/source_groups.cmake
+++ b/code/source_groups.cmake
@@ -1,5 +1,6 @@
 # top-level files
 set (file_root
+	prefix_header.h
 )
 
 # AI files


### PR DESCRIPTION
Cotire (the CMake module we use for handling precompiled headers) can
auotmaically generate a prefix header by examining the includes of the
project. However, if a system include changes, the prefix header may
change as well which triggers a complete project rebuild. To avoid this
and to add the ability to customize the prefix header, I added a
manually maintaned header which will be used by all platforms and which
will only change if that file is manually changed.