### PR TITLE
Make script-eval return SEXP_TRUE 

### DIFF
--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -22055,8 +22055,8 @@ int sexp_script_eval(int node, int return_type, bool concat_args = false)
 					if (!success)
 						Warning(LOCATION, "sexp-script-eval failed to evaluate string \"%s\"; check your syntax", script_cmd.c_str());
 				}
+				return SEXP_TRUE;
 			}
-			break;
 		default:
 			Error(LOCATION, "Bad type passed to sexp_script_eval - get a coder");
 			break;


### PR DESCRIPTION
So that it behaves as expected when used in an event without a when conditional.

Fixes #1256 