### PR TITLE
Render correct number of vertices for shield icon

### DIFF
--- a/code/hud/hud.cpp
+++ b/code/hud/hud.cpp
@@ -1761,6 +1761,8 @@ void hud_render_gauges(int cockpit_display_num)
 		num_gauges = sip->hud_gauges.size();
 
 		for(j = 0; j < num_gauges; j++) {
+			GR_DEBUG_SCOPE("Render HUD gauge");
+
 			// only preprocess gauges if we're not rendering to cockpit
 			if ( cockpit_display_num < 0 ) {
 				sip->hud_gauges[j]->preprocess();
@@ -1784,6 +1786,8 @@ void hud_render_gauges(int cockpit_display_num)
 		num_gauges = default_hud_gauges.size();
 
 		for(j = 0; j < num_gauges; j++) {
+			GR_DEBUG_SCOPE("Render HUD gauge");
+
 			default_hud_gauges[j]->preprocess();
 
 			default_hud_gauges[j]->onFrame(flFrametime);

--- a/code/hud/hudshield.cpp
+++ b/code/hud/hudshield.cpp
@@ -582,6 +582,8 @@ void HudGaugeShield::showShields(object *objp, int mode)
 	}
 	else
 	{
+		GR_DEBUG_SCOPE("Render generated shield icon");
+
 		bool g3_yourself = !g3_in_frame();
 		angles rot_angles = {-1.570796327f,0.0f,0.0f};
 		matrix	object_orient;
@@ -667,6 +669,7 @@ void HudGaugeShield::showShields(object *objp, int mode)
 			if ( objp->shield_quadrant[i] < 0.1f )
 				continue;
 		}
+		GR_DEBUG_SCOPE("Render shield quadrant");
 
 		range = MAX(HUD_COLOR_ALPHA_MAX, HUD_color_alpha + objp->n_quadrants);
 

--- a/code/render/3ddraw.cpp
+++ b/code/render/3ddraw.cpp
@@ -1093,6 +1093,8 @@ void g3_render_rod(color *clr, int num_points, vec3d *pvecs, float width)
 // adapted from g3_draw_2d_shield_icon()
 void g3_render_shield_icon(color *clr, coord2d coords[6], int resize_mode)
 {
+	GR_DEBUG_SCOPE("Render shield icon");
+
 	vertex v[6];
 
 	memset(v, 0, sizeof(vertex) * 6);
@@ -1188,7 +1190,7 @@ void g3_render_shield_icon(color *clr, coord2d coords[6], int resize_mode)
 	material_instance.set_color(1.0f, 1.0f, 1.0f, 1.0f);
 
 	// draw the polys
-	g3_render_primitives_colored(&material_instance, v, 4, PRIM_TYPE_TRISTRIP, true);
+	g3_render_primitives_colored(&material_instance, v, 6, PRIM_TYPE_TRISTRIP, true);
 }
 
 void g3_render_shield_icon(coord2d coords[6], int resize_mode)


### PR DESCRIPTION
I also added a few graphics debug scopes since I needed those for
tracking down which code renders the shield icons.

This fixes #1261.