### PR TITLE
Add generic configuration system

### DIFF
--- a/code/config/ConfigurationItem.cpp
+++ b/code/config/ConfigurationItem.cpp
@@ -1,0 +1,24 @@
+//
+//
+
+#include "ConfigurationItem.h"
+
+#include "config/ConfigurationManager.h"
+
+namespace {
+config::ConfigurationItem<uint64_t> test("Test", "Section", 20);
+}
+
+namespace config {
+
+ConfigurationItemBase::ConfigurationItemBase(const char* section, const char* name) : _section(section), _name(name) {
+	ConfigurationManager::getInstance().addConfigItem(this);
+}
+const char* ConfigurationItemBase::getSection() const {
+	return _section;
+}
+const char* ConfigurationItemBase::getName() const {
+	return _name;
+}
+
+}

--- a/code/config/ConfigurationItem.h
+++ b/code/config/ConfigurationItem.h
@@ -1,0 +1,106 @@
+#pragma once
+
+#include "config/serializers.h"
+#include "ConfigurationManager.h"
+
+namespace config {
+
+/**
+ * @brief Non-template base class of ConfigurationItem
+ */
+class ConfigurationItemBase {
+ protected:
+	const char* _section;
+	const char* _name;
+
+ public:
+	ConfigurationItemBase(const char* section, const char* name);
+
+	/**
+	 * @brief Gets the section name of this config item
+	 * @return The section name
+	 */
+	const char* getSection() const;
+	/**
+	 * @brief Gets the name of this config item
+	 * @return The item name
+	 */
+	const char* getName() const;
+
+	/**
+	 * @brief Called to deserialize the given string value
+	 *
+	 * @details This should initialize the value contained in this item to correspond to the value contained in the
+	 * string. This may throw an exception if deserialization fails (e.g. if the input is malformed).
+	 *
+	 * @param value The value to deserialize
+	 */
+	virtual void deserialize(const SCP_string& value) = 0;
+	/**
+	 * @brief Serializes the current value into a string value
+	 * @return The serialized string value
+	 */
+	virtual SCP_string serialize() const = 0;
+};
+
+/**
+ * @brief A configuration item of a specific type
+ *
+ * @tparam T The type of the value contained in this item
+ * @tparam Serializer The type responsible for serializing and deserializing
+ */
+template<typename T, typename Serializer = ::config::serializer<T>>
+class ConfigurationItem: public ConfigurationItemBase {
+	T _value;
+	bool _has_value = false; //!< @c true if the value above was loaded from the config file
+ public:
+	/**
+	 * @brief Initializes this config item.
+	 * @param section The section of this item
+	 * @param name The name in the section of this item
+	 * @param default_value The default value that will be returned if no value exists in the config file
+	 */
+	ConfigurationItem(const char* section, const char* name, T&& default_value) : ConfigurationItemBase(section, name),
+																				  _value(default_value) {
+	}
+
+	/**
+	 * @brief Deserializes the value using Serializer and sets it as the current value
+	 * @param value The value to deserialize
+	 */
+	void deserialize(const SCP_string& value) override {
+		setValue(Serializer::deserialize(value));
+	}
+	/**
+	 * @brief Serializes the current value using Serializer
+	 * @return The serialized value
+	 */
+	SCP_string serialize() const override {
+		return Serializer::serialize(_value);
+	}
+
+	/**
+	 * @brief Gets the current value of this item
+	 *
+	 * @details This will lazily load the value from the config if it hasn't been loaded yet
+	 *
+	 * @return The current value
+	 */
+	T getValue() {
+		if (!_has_value) {
+			ConfigurationManager::getInstance().loadConfigItem(this);
+		}
+		return _value;
+	}
+	/**
+	 * @brief Sets the value of this item to the specified value
+	 * @param value The new value of this item
+	 */
+	void setValue(const T& value) {
+		_value = value;
+		_has_value = true;
+	}
+};
+
+}
+

--- a/code/config/ConfigurationManager.cpp
+++ b/code/config/ConfigurationManager.cpp
@@ -1,0 +1,68 @@
+//
+//
+
+#include "ConfigurationManager.h"
+#include "ConfigurationItem.h"
+
+#include "osapi/osregistry.h"
+
+namespace config {
+
+ConfigurationManager::ConfigurationManager() {
+}
+
+ConfigurationManager& ConfigurationManager::getInstance() {
+	// Use the static initializer trick to avoid initialization issues
+	static ConfigurationManager manager;
+
+	return manager;
+}
+void ConfigurationManager::addConfigItem(ConfigurationItemBase* item) {
+	Assertion(item != nullptr, "Invalid item pointer detected!");
+
+#ifndef NDEBUG
+	// Check if this section:name combination already exists
+	for (auto& existing : _config_items) {
+		bool sameSection;
+		if (existing->getSection() == item->getSection()) {
+			sameSection = true;
+		} else if (existing->getSection() == nullptr) {
+			sameSection = false;
+		} else if (item->getSection() == nullptr) {
+			sameSection = false;
+		} else {
+			sameSection = !strcmp(existing->getSection(), item->getSection());
+		}
+
+		auto sameName = strcmp(existing->getName(), item->getName());
+
+		Assertion(!(sameSection && sameName),
+				  "A config item with name '%s:%s' already exists!",
+				  existing->getSection(),
+				  existing->getName());
+	}
+#endif
+
+	_config_items.push_back(item);
+}
+void ConfigurationManager::loadConfigItem(ConfigurationItemBase* item) {
+	Assertion(item != nullptr, "Invalid item pointer detected!");
+
+	auto data = os_config_read_string(item->getSection(), item->getName(), nullptr);
+
+	if (data != nullptr) {
+		try {
+			item->deserialize(data);
+		} catch (const std::exception& e) {
+			mprintf(("Failed to read config item %s:%s! Error: '%s'. Value was '%s'.\n", item->getSection(), item->getName(), e.what(), data));
+		}
+	}
+}
+void ConfigurationManager::saveSettings() {
+	for (auto item : _config_items) {
+		auto value = item->serialize();
+		os_config_write_string(item->getSection(), item->getName(), value.c_str());
+	}
+}
+
+}

--- a/code/config/ConfigurationManager.h
+++ b/code/config/ConfigurationManager.h
@@ -1,0 +1,60 @@
+#pragma once
+
+#include "globalincs/pstypes.h"
+
+namespace config {
+
+class ConfigurationItemBase;
+
+/**
+ * @brief Class for managing known configuration items
+ *
+ * This class is a static singleton which keeps track of all registered config items and allows to save them when the
+ * application exits.
+ */
+class ConfigurationManager {
+	SCP_vector<ConfigurationItemBase*> _config_items;
+
+	ConfigurationManager();
+ public:
+	// Disallow copying since this is a singleton
+	ConfigurationManager(const ConfigurationManager&) = delete;
+	ConfigurationManager& operator=(const ConfigurationManager&) = delete;
+
+	// Disallow moving since this is a singleton
+	ConfigurationManager(ConfigurationManager&&) = delete;
+	ConfigurationManager& operator=(ConfigurationManager&&) = delete;
+
+	/**
+	 * @brief Gets the manager instance
+	 *
+	 * @details This uses a local static variable so you can call this from static initializers of other classes in
+	 * other files and it will still work.
+	 *
+	 * @return The manager instance
+	 */
+	static ConfigurationManager& getInstance();
+
+	/**
+	 * @brief Adds a config item to this manager
+	 *
+	 * Added items will be saved when the manager instance is saved. A new item can be added at runtime.
+	 *
+	 * @param item The item to add
+	 */
+	void addConfigItem(ConfigurationItemBase* item);
+
+	/**
+	 * @brief Loads the value for the specified item
+	 * @param item The item to load the data for
+	 */
+	void loadConfigItem(ConfigurationItemBase* item);
+
+	/**
+	 * @brief Save the values currently stored in the configuration items
+	 */
+	void saveSettings();
+};
+
+}
+

--- a/code/config/serializers.cpp
+++ b/code/config/serializers.cpp
@@ -1,0 +1,16 @@
+//
+//
+
+#include "serializers.h"
+
+namespace config {
+
+SCP_string serialize(const SCP_string& str) {
+	return str;
+}
+
+SCP_string deserialize(const SCP_string& str) {
+	return str;
+}
+
+}

--- a/code/config/serializers.h
+++ b/code/config/serializers.h
@@ -1,0 +1,72 @@
+#pragma once
+
+#include "globalincs/pstypes.h"
+
+#include <type_traits>
+
+namespace config {
+
+class serialization_error: public std::runtime_error {
+ public:
+	serialization_error() : std::runtime_error("Serialization error") {
+	}
+
+	serialization_error(const std::string& excuse) : std::runtime_error(excuse) {
+	}
+
+	~serialization_error() throw() {
+	}
+};
+
+// Integer serializer functions
+template<typename T>
+typename std::enable_if<std::is_integral<T>::value, SCP_string>::type serialize(const T& value) {
+	SCP_stringstream stream;
+	stream << value;
+	return stream.str();
+}
+template<typename T>
+typename std::enable_if<std::is_integral<T>::value, T>::type deserialize(const SCP_string& value) {
+	SCP_stringstream stream(value);
+	T parsed;
+	stream >> parsed;
+
+	if (!stream.good()) {
+		throw serialization_error("Failed to deserialize value '" + value + "'");
+	}
+
+	return parsed;
+}
+
+// string serializer functions, simply passes the string through
+SCP_string serialize(const SCP_string& str);
+SCP_string deserialize(const SCP_string& str);
+
+/**
+ * @brief Default serializer that uses predefined, free functions
+ * @tparam T The type of the object that should be serialized
+ */
+template<typename T>
+struct serializer {
+	// The default implementation uses free functions since I can't figure out how to do this only with structs...
+
+	/**
+	 * @brief Serializes the given raw value to a string representation
+	 * @param value The value to serialize
+	 * @return The serialized string representation
+	 */
+	static SCP_string serialize(const T& value) {
+		return ::config::serialize<T>(value);
+	}
+	/**
+	 * @brief Converts a string back into the raw value
+	 * @param value The string value to deserialize
+	 * @return The deserialized, raw value
+	 */
+	static T deserialize(const SCP_string& value) {
+		return ::config::deserialize<T>(value);
+	}
+};
+
+}
+

--- a/code/source_groups.cmake
+++ b/code/source_groups.cmake
@@ -75,6 +75,16 @@ set (file_root_cmeasure
 	cmeasure/cmeasure.h
 )
 
+# Config files
+set (file_root_config
+	config/ConfigurationItem.cpp
+	config/ConfigurationItem.h
+	config/ConfigurationManager.cpp
+	config/ConfigurationManager.h
+	config/serializers.cpp
+	config/serializers.h
+)
+
 # ControlConfig files
 set (file_root_controlconfig
 	controlconfig/controlsconfig.cpp
@@ -1212,6 +1222,7 @@ source_group("Camera"                             FILES ${file_root_camera})
 source_group("CFile"                              FILES ${file_root_cfile})
 source_group("Cmdline"                            FILES ${file_root_cmdline})
 source_group("CMeasure"                           FILES ${file_root_cmeasure})
+source_group("Config"                             FILES ${file_root_config})
 source_group("ControlConfig"                      FILES ${file_root_controlconfig})
 source_group("Cutscene"                           FILES ${file_root_cutscene})
 source_group("Cutscene\\ffmpeg"                   FILES ${file_root_cutscene_ffmpeg})
@@ -1305,6 +1316,7 @@ set (file_root
 	${file_root_cfile}
 	${file_root_cmdline}
 	${file_root_cmeasure}
+	${file_root_config}
 	${file_root_controlconfig}
 	${file_root_cutscene}
 	${file_root_cutscene_ffmpeg}

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -33,6 +33,7 @@
 #include "cutscene/cutscenes.h"
 #include "cutscene/player.h"
 #include "cutscene/movie.h"
+#include "config/ConfigurationManager.h"
 #include "debris/debris.h"
 #include "debugconsole/console.h"
 #include "exceptionhandler/exceptionhandler.h"
@@ -7053,6 +7054,10 @@ void game_shutdown(void)
 #endif
 
 	gr_close();
+
+	// Save the config system as late as possible so that all the other code has updates the config items if there were
+	// any changes
+	config::ConfigurationManager::getInstance().saveSettings();
 
 	os_cleanup();
 


### PR DESCRIPTION
I would like to add an in-engine options screen at some point but to do
that we first need a system that is actually able to handle loading and
saving of various configuration values in a generic way.

These changes add a config system on top of the existing system that
provide an easy to use API for defining configuration options that are
automatically read and written to the config file at the appropriate
moments.

Since this is clearly a feature addition, this should not be merged before 3.8. Also, since this is supposed to be a generic system that will be used more in the future I would like to know if anyone has an idea on how to make this better.