### PR TITLE
Make table-based texture replacement work

### DIFF
--- a/code/lab/lab.cpp
+++ b/code/lab/lab.cpp
@@ -912,6 +912,12 @@ void labviewer_render_model(float frametime)
 				model_show_damaged(Lab_model_num, 1);
 			}
 		}
+
+		// Deal with tabled replacement textures
+		if (sip != NULL && sip->replacement_textures.size() > 0) 
+		{			
+			render_info.set_replacement_textures(Lab_model_num, sip->replacement_textures);
+		}
 		
 		if( !( flagggs & MR_NO_LIGHTING ) && Cmdline_shadow_quality ) {
 			polymodel *pm = model_get(Lab_model_num);

--- a/code/menuui/techmenu.cpp
+++ b/code/menuui/techmenu.cpp
@@ -562,6 +562,11 @@ void techroom_ships_render(float frametime)
 		}
 	}
 
+	if (sip->replacement_textures.size() > 0)
+	{
+		render_info.set_replacement_textures(Techroom_ship_modelnum, sip->replacement_textures);
+	}
+
     if(Cmdline_shadow_quality)
     {
         gr_reset_clip();

--- a/code/missionui/missionscreencommon.cpp
+++ b/code/missionui/missionscreencommon.cpp
@@ -1619,6 +1619,11 @@ void draw_model_icon(int model_id, int flags, float closeup_zoom, int x, int y, 
 		light_rotate_all();
 	}
 
+	if (sip != NULL && sip->replacement_textures.size() > 0) 
+	{
+		render_info.set_replacement_textures(model_id, sip->replacement_textures);
+	}
+
 	Glowpoint_override = true;
 	model_clear_instance(model_id);
 

--- a/code/missionui/missionshipchoice.cpp
+++ b/code/missionui/missionshipchoice.cpp
@@ -1464,6 +1464,11 @@ void ship_select_do(float frametime)
 				render_info.set_team_color(sip->default_team_name, "none", 0, 0);
 			}
 
+			if (sip->replacement_textures.size() > 0)
+			{
+				render_info.set_replacement_textures(ShipSelectModelNum, sip->replacement_textures);
+			}
+
 			draw_model_rotating(
 				&render_info, 
 				ShipSelectModelNum,

--- a/code/missionui/missionweaponchoice.cpp
+++ b/code/missionui/missionweaponchoice.cpp
@@ -903,6 +903,11 @@ void wl_render_overhead_view(float frametime)
 			model_clear_instance(wl_ship->model_num);
 			polymodel *pm = model_get(wl_ship->model_num);
 
+			if (sip->replacement_textures.size() > 0) 
+			{
+				render_info.set_replacement_textures(wl_ship->model_num, sip->replacement_textures);
+			}
+
 			if(Cmdline_shadow_quality)
 			{
 				gr_reset_clip();

--- a/code/model/modelrender.cpp
+++ b/code/model/modelrender.cpp
@@ -55,7 +55,7 @@ model_render_params::model_render_params() :
 	Forced_bitmap(-1),
 	Insignia_bitmap(-1),
 	Replacement_textures(NULL),
-	manage_replacement_textures(false),
+	Manage_replacement_textures(false),
 	Team_color_set(false),
 	Clip_plane_set(false),
 	Animated_effect(-1),
@@ -83,7 +83,7 @@ model_render_params::model_render_params() :
 
 model_render_params::~model_render_params() 
 {
-	if (manage_replacement_textures)
+	if (Manage_replacement_textures)
 		vm_free(Replacement_textures);
 }
 
@@ -220,7 +220,7 @@ void model_render_params::set_replacement_textures(int *textures)
 void model_render_params::set_replacement_textures(int modelnum, SCP_vector<texture_replace>& replacement_textures)
 {
 	Replacement_textures = (int*)vm_malloc(MAX_REPLACEMENT_TEXTURES * sizeof(int));
-	manage_replacement_textures = true;
+	Manage_replacement_textures = true;
 
 	polymodel* pm = model_get(modelnum);
 

--- a/code/model/modelrender.h
+++ b/code/model/modelrender.h
@@ -75,7 +75,7 @@ class model_render_params
 	int Insignia_bitmap;
 
 	int *Replacement_textures;
-	bool manage_replacement_textures; // This is set when we are rendering a model without an associated ship object;
+	bool Manage_replacement_textures; // This is set when we are rendering a model without an associated ship object;
 									  // in that case, model_render_params is responsible for allocating and destroying
 									  // the Replacement_textures array (this is handled elsewhere otherwise)
 
@@ -97,6 +97,8 @@ class model_render_params
 
 	bool Normal_extrude;
 	float Normal_extrude_width;
+
+	model_render_params(const model_render_params& other);
 public:
 	model_render_params();
 	~model_render_params();

--- a/code/model/modelrender.h
+++ b/code/model/modelrender.h
@@ -98,7 +98,8 @@ class model_render_params
 	bool Normal_extrude;
 	float Normal_extrude_width;
 
-	model_render_params(const model_render_params& other);
+	model_render_params(const model_render_params&) = delete;
+	model_render_params& operator=(const model_render_params&) = delete;
 public:
 	model_render_params();
 	~model_render_params();

--- a/code/model/modelrender.h
+++ b/code/model/modelrender.h
@@ -15,6 +15,7 @@
 #include "lighting/lighting.h"
 #include "math/vecmat.h"
 #include "model/model.h"
+#include "mission/missionparse.h"
 
 extern light Lights[MAX_LIGHTS];
 extern int Num_lights;
@@ -74,6 +75,9 @@ class model_render_params
 	int Insignia_bitmap;
 
 	int *Replacement_textures;
+	bool manage_replacement_textures; // This is set when we are rendering a model without an associated ship object;
+									  // in that case, model_render_params is responsible for allocating and destroying
+									  // the Replacement_textures array (this is handled elsewhere otherwise)
 
 	bool Team_color_set;
 	team_color Current_team_color;
@@ -95,6 +99,7 @@ class model_render_params
 	float Normal_extrude_width;
 public:
 	model_render_params();
+	~model_render_params();
 
 	void set_flags(uint flags);
 	void set_debug_flags(uint flags);
@@ -108,6 +113,7 @@ public:
 	void set_forced_bitmap(int bitmap);
 	void set_insignia_bitmap(int bitmap);
 	void set_replacement_textures(int *textures);
+	void set_replacement_textures(int modelnum, SCP_vector<texture_replace>& replacement_textures);
 	void set_team_color(team_color &clr);
 	void set_team_color(const SCP_string &team, const SCP_string &secondaryteam, fix timestamp, int fadetime);
 	void set_clip_plane(vec3d &pos, vec3d &normal);

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -18645,9 +18645,9 @@ void ship_render_weapon_models(model_render_params *ship_render_info, model_draw
 
 	scene->push_transform(&obj->pos, &obj->orient);
 
-	model_render_params render_info = *ship_render_info;
-
+	auto ship_render_flags = ship_render_info->get_model_flags();
 	render_flags &= ~MR_SHOW_THRUSTERS;
+	ship_render_info->set_flags(render_flags);
 
 	//primary weapons
 	for ( i = 0; i < swp->num_primary_banks; i++ ) {
@@ -18656,15 +18656,14 @@ void ship_render_weapon_models(model_render_params *ship_render_info, model_draw
 		}
 
 		w_bank *bank = &model_get(sip->model_num)->gun_banks[i];
+
 		for ( k = 0; k < bank->num_slots; k++ ) {
 			polymodel* pm = model_get(Weapon_info[swp->primary_bank_weapons[i]].external_model_num);
 
 			pm->gun_submodel_rotation = shipp->primary_rotate_ang[i];
 
-			render_info.set_flags(render_flags);
 
-			model_render_queue(&render_info, scene, Weapon_info[swp->primary_bank_weapons[i]].external_model_num, &vmd_identity_matrix, &bank->pnt[k]);
-
+			model_render_queue(ship_render_info, scene, Weapon_info[swp->primary_bank_weapons[i]].external_model_num, &vmd_identity_matrix, &bank->pnt[k]);
 			pm->gun_submodel_rotation = 0.0f;
 		}
 	}
@@ -18681,11 +18680,9 @@ void ship_render_weapon_models(model_render_params *ship_render_info, model_draw
 
 		bank = &(model_get(sip->model_num))->missile_banks[i];
 
-		if (Weapon_info[swp->secondary_bank_weapons[i]].wi_flags[Weapon::Info_Flags::External_weapon_lnch]) {
+		if (Weapon_info[swp->secondary_bank_weapons[i]].wi_flags[Weapon::Info_Flags::External_weapon_lnch]) {			
 			for(k = 0; k < bank->num_slots; k++) {
-				render_info.set_flags(render_flags);
-
-				model_render_queue(&render_info, scene, Weapon_info[swp->secondary_bank_weapons[i]].external_model_num, &vmd_identity_matrix, &bank->pnt[k]);
+				model_render_queue(ship_render_info, scene, Weapon_info[swp->secondary_bank_weapons[i]].external_model_num, &vmd_identity_matrix, &bank->pnt[k]);
 			}
 		} else {
 			num_secondaries_rendered = 0;
@@ -18705,12 +18702,12 @@ void ship_render_weapon_models(model_render_params *ship_render_info, model_draw
 
 				vm_vec_scale_add2(&secondary_weapon_pos, &vmd_z_vector, -(1.0f-shipp->secondary_point_reload_pct[i][k]) * model_get(Weapon_info[swp->secondary_bank_weapons[i]].external_model_num)->rad);
 
-				render_info.set_flags(render_flags);
-
-				model_render_queue(&render_info, scene, Weapon_info[swp->secondary_bank_weapons[i]].external_model_num, &vmd_identity_matrix, &secondary_weapon_pos);
+				model_render_queue(ship_render_info, scene, Weapon_info[swp->secondary_bank_weapons[i]].external_model_num, &vmd_identity_matrix, &secondary_weapon_pos);
 			}
 		}
 	}
+
+	ship_render_info->set_flags(ship_render_flags);
 
 	scene->pop_transform();
 }


### PR DESCRIPTION
This applies table-based texture replacement settings in the lab, techroom and the weapon/ship select screens.

Fixes #1264 