### PR TITLE
Enable GCC and Clang warning for missing return

### DIFF
--- a/cmake/toolchain-clang.cmake
+++ b/cmake/toolchain-clang.cmake
@@ -60,6 +60,9 @@ set(COMPILER_FLAGS "${COMPILER_FLAGS} ${SANITIZE_FLAGS}")
 
 set(COMPILER_FLAGS "${COMPILER_FLAGS} -Wno-unused-function")
 
+# Dear Clang, please tell us if a function does not return a value since that part of the standard is stupid!
+set(COMPILER_FLAGS "${COMPILER_FLAGS} -Wreturn-type")
+
 set(COMPILER_FLAGS "${COMPILER_FLAGS} -Wno-char-subscripts")
 
 set(COMPILER_FLAGS "${COMPILER_FLAGS} -Wno-unused-parameter")

--- a/cmake/toolchain-gcc.cmake
+++ b/cmake/toolchain-gcc.cmake
@@ -72,6 +72,9 @@ set(COMPILER_FLAGS "${COMPILER_FLAGS} ${SANITIZE_FLAGS}")
 
 set(COMPILER_FLAGS "${COMPILER_FLAGS} -Wno-unused-function")
 
+# Dear GCC, please tell us if a function does not return a value since that part of the standard is stupid!
+set(COMPILER_FLAGS "${COMPILER_FLAGS} -Wreturn-type")
+
 set(COMPILER_FLAGS "${COMPILER_FLAGS} -Wno-deprecated -Wno-char-subscripts")
 
 set(COMPILER_FLAGS "${COMPILER_FLAGS} -Wno-unused-parameter")


### PR DESCRIPTION
The C++ standard allows to have no return in a function but in most
cases that is not the desired behavior. There are currently no instances
of this warning in our code but I encountered this error while
developing something else.