### PR TITLE
Add a Windows executable manifest to FreeSpace2

### DIFF
--- a/freespace2/SDLGraphicsOperations.cpp
+++ b/freespace2/SDLGraphicsOperations.cpp
@@ -148,7 +148,7 @@ SDLGraphicsOperations::~SDLGraphicsOperations() {
 	SDL_QuitSubSystem(SDL_INIT_VIDEO);
 }
 std::unique_ptr<os::Viewport> SDLGraphicsOperations::createViewport(const os::ViewPortProperties& props) {
-	uint32_t windowflags = SDL_WINDOW_SHOWN;
+	uint32_t windowflags = SDL_WINDOW_SHOWN | SDL_WINDOW_ALLOW_HIGHDPI;
 	if (props.enable_opengl) {
 		windowflags |= SDL_WINDOW_OPENGL;
 		setOGLProperties(props);

--- a/freespace2/resources.cmake
+++ b/freespace2/resources.cmake
@@ -1,6 +1,6 @@
 
 if(WIN32)
-    # Handling of windows resources+
+    # Handling of windows resources
 
     set(subpath resources/win)
 
@@ -23,16 +23,22 @@ if(WIN32)
         ${subpath}/V_sse-d.ico
         ${subpath}/V_sse.ico
     )
+    
+    set(MANIFESTS
+        ${subpath}/default.manifest
+    )
 
     set(RESOURCES
         ${RESOURCE_FILES}
         ${ICONS}
+        ${MANIFESTS}
     )
 
     target_sources(Freespace2 PRIVATE ${RESOURCES})
 
     source_group("Resources" FILES ${RESOURCE_FILES})
     source_group("Resources\\Icons" FILES ${ICONS})
+    source_group("Resources\\Manifests" FILES ${MANIFESTS})
 
     SET_SOURCE_FILES_PROPERTIES(${subpath}/freespace.rc PROPERTIES COMPILE_DEFINITIONS "_VC08")
 

--- a/freespace2/resources/win/default.manifest
+++ b/freespace2/resources/win/default.manifest
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0" xmlns:asmv3="urn:schemas-microsoft-com:asm.v3" >>
+    <!-- Enable themes for Windows common controls and dialogs (Windows XP and later) -->
+    <dependency>
+        <dependentAssembly>
+            <assemblyIdentity
+                type="win32"
+                name="Microsoft.Windows.Common-Controls"
+                version="6.0.0.0"
+                processorArchitecture="*"
+                publicKeyToken="6595b64144ccf1df"
+                language="*"
+            />
+        </dependentAssembly>
+    </dependency>
+
+    <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+        <application>
+            <!-- Windows 10 --> 
+            <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
+            <!-- Windows 8.1 -->
+            <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
+            <!-- Windows 8 -->
+            <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/>
+            <!-- Windows 7 -->
+            <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
+            <!-- Windows Vista -->
+            <supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}"/> 
+        </application>
+    </compatibility>
+
+    <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
+        <security>
+            <requestedPrivileges>
+                <requestedExecutionLevel
+                    level="asInvoker"
+                    uiAccess="false"/>
+            </requestedPrivileges>
+        </security>
+    </trustInfo>
+    
+    <asmv3:application>
+        <asmv3:windowsSettings xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">
+            <dpiAware>true</dpiAware>
+        </asmv3:windowsSettings>
+    </asmv3:application>
+</assembly>

--- a/freespace2/resources/win/default.manifest
+++ b/freespace2/resources/win/default.manifest
@@ -26,6 +26,7 @@
             <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
             <!-- Windows Vista -->
             <supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}"/> 
+            <!-- Windows XP does not need this but it's still supported -->
         </application>
     </compatibility>
 


### PR DESCRIPTION
This sets the dpiAware flag which should improve the compatibility with
High-DPI displays. It also sets a few values for specfying what Windows
versions we support and it also enabled the nicer dialog boxes which
makes the error and warning dialogs look a bit nicer.