### PR TITLE
Adjustable fresnel term in lighting model. Model shader cleanup. Deferred lighting shader fix.

### DIFF
--- a/code/def_files/deferred-f.sdr
+++ b/code/def_files/deferred-f.sdr
@@ -29,9 +29,9 @@ vec3 FresnelSchlick(vec3 specColor, vec3 light, vec3 halfVec)
 {
 	return specColor + (vec3(1.0) - specColor) * pow(1.0 - clamp(dot(light, halfVec), 0.0, 1.0), 5.0);
 }
-vec3 SpecularBlinnPhong(vec3 specColor, vec3 light, vec3 normal, vec3 halfVec, float specPower, float dotNL)
+vec3 SpecularBlinnPhong(vec3 specColor, vec3 light, vec3 normal, vec3 halfVec, float specPower, float fresnel, float dotNL)
 {
-	return FresnelSchlick(max(specColor, vec3(0.04)), light, halfVec) * ((specPower + 2.0) / 8.0 ) * pow(clamp(dot(normal, halfVec), 0.0, 1.0), specPower) * dotNL;
+	return mix(specColor, FresnelSchlick(specColor, light, halfVec), fresnel) * ((specPower + 2.0) / 8.0 ) * pow(clamp(dot(normal, halfVec), 0.0, 1.0), specPower) * dotNL;
 }
 vec4 SpecularLegacy(vec4 specColor, vec3 normal, vec3 halfVec, float specPower)
 {
@@ -67,7 +67,8 @@ void main()
 	vec3 color = texture(ColorBuffer, screenPos).rgb;
 	vec4 normal = texture(NormalBuffer, screenPos);
 	vec4 specColor = texture(SpecBuffer, screenPos);
-	float gloss = specColor.a;
+	float gloss = normal.a;
+	float fresnel = specColor.a;
 	vec3 eyeDir = normalize(-position);
 
 	if(lightType == 1)
@@ -88,6 +89,6 @@ void main()
 	float NdotHV = clamp(dot(normal.xyz, halfVec), 0.0, 1.0);
 	float NdotL = clamp(dot(normal.xyz, lightDir), 0.0, 1.0);
 	vec4 fragmentColor = vec4(color * (diffuseLightColor * NdotL * attenuation), 1.0);
-	fragmentColor.rgb += SpecularBlinnPhong(specLightColor, lightDir, normal.xyz, halfVec, exp2(10.0 * gloss + 1.0), NdotL).rgb * specColor.rgb * attenuation;
+	fragmentColor.rgb += SpecularBlinnPhong(specColor.rgb, lightDir, normal.xyz, halfVec, exp2(10.0 * gloss + 1.0), fresnel, NdotL).rgb * specLightColor * attenuation;
 	fragOut0 = max(fragmentColor, vec4(0.0));
 }

--- a/code/def_files/main-f.sdr
+++ b/code/def_files/main-f.sdr
@@ -207,9 +207,9 @@ vec3 FresnelSchlick(vec3 specColor, vec3 light, vec3 halfVec)
 {
 	return specColor + (vec3(1.0) - specColor) * pow(1.0 - clamp(dot(light, halfVec), 0.0, 1.0), 5.0);
 }
-vec3 SpecularBlinnPhong(vec3 specColor, vec3 light, vec3 normal, vec3 halfVec, float specPower, float dotNL)
+vec3 SpecularBlinnPhong(vec3 specColor, vec3 light, vec3 normal, vec3 halfVec, float specPower, float fresnel, float dotNL)
 {
-	return FresnelSchlick(max(specColor, vec3(0.04)), light, halfVec) * ((specPower + 2.0) / 8.0 ) * pow(clamp(dot(normal, halfVec), 0.0, 1.0), specPower) * dotNL;
+	return mix(specColor, FresnelSchlick(specColor, light, halfVec), fresnel) * ((specPower + 2.0) / 8.0 ) * pow(clamp(dot(normal, halfVec), 0.0, 1.0), specPower) * dotNL;
 }
 #ifdef FLAG_LIGHT
 void GetLightInfo(int i, out vec3 lightDir, out float attenuation, out float specIntensity)
@@ -238,13 +238,12 @@ void GetLightInfo(int i, out vec3 lightDir, out float attenuation, out float spe
 		specIntensity = SPEC_INTENSITY_POINT;
 	}
 }
-vec3 CalculateLighting(vec3 normal, vec3 diffuseMaterial, vec3 specularMaterial, float gloss, float shadow, float aoFactor)
+vec3 CalculateLighting(vec3 normal, vec3 diffuseMaterial, vec3 specularMaterial, float gloss, float fresnel, float shadow, float aoFactor)
 {
 	vec3 eyeDir = vec3(normalize(-fragPosition).xyz);
 	vec3 lightAmbient = (emissionFactor + ambientFactor * ambientFactor) * aoFactor; // ambientFactor^2 due to legacy OpenGL compatibility behavior
-	vec3 lightAmbientDiffuse = vec3(0.0, 0.0, 0.0);
-   vec3 lightDiffuse = vec3(0.0, 0.0, 0.0);
-   vec3 lightSpecular = vec3(0.0, 0.0, 0.0);
+	vec3 lightDiffuse = vec3(0.0, 0.0, 0.0);
+	vec3 lightSpecular = vec3(0.0, 0.0, 0.0);
 	#pragma optionNV unroll all
 	for (int i = 0; i < MAX_LIGHTS; ++i) {
 		if (i > n_lights)
@@ -263,13 +262,9 @@ vec3 CalculateLighting(vec3 normal, vec3 diffuseMaterial, vec3 specularMaterial,
 		float NdotL = max(dot(normal, lightDir), 0.0);
 		// Ambient, Diffuse, and Specular
 		lightDiffuse += (lightDiffuseColor[i].rgb * diffuseFactor * NdotL * attenuation) * shadow;
-		lightSpecular += lightSpecColor[i] * SpecularBlinnPhong(specularMaterial, lightDir, normal, halfVec, exp2(10.0 * gloss + 1.0), NdotL) * attenuation * shadow;
+		lightSpecular += lightSpecColor[i] * SpecularBlinnPhong(specularMaterial, lightDir, normal, halfVec, exp2(10.0 * gloss + 1.0), fresnel, NdotL) * attenuation * shadow;
 	}
-	lightAmbientDiffuse = lightAmbient + lightDiffuse;
-	vec3 finalColor = diffuseMaterial;
-	finalColor *= lightAmbientDiffuse.rgb;
-	finalColor += lightSpecular;
-	return finalColor;
+	return diffuseMaterial * (lightAmbient + lightDiffuse) + lightSpecular;
 }
 #endif
 void main()
@@ -286,18 +281,10 @@ void main()
 	return;
 #endif
 	vec3 eyeDir = vec3(normalize(-fragPosition).xyz);
-	vec3 lightAmbientDiffuse = vec3(0.0, 0.0, 0.0);
-   vec3 lightDiffuse = vec3(0.0, 0.0, 0.0);
-   vec3 lightAmbient = vec3(0.0, 0.0, 0.0);
-   vec4 lightSpecular = vec4(0.0, 0.0, 0.0, 1.0);
 	vec2 texCoord = fragTexCoord.xy;
 	vec4 baseColor = color;
-#ifdef FLAG_HDR
-	baseColor.rgb = pow(baseColor.rgb, vec3(SRGB_GAMMA));
-#endif
-	vec4 posData = vec4(fragPosition.xyz,1.0);
-	vec4 normData = vec4(0.0, 0.0, 0.0, 1.0);
-	vec4 specData = vec4(0.0, 0.0, 0.0, 1.0);
+	vec4 specColor = vec4(0.0, 0.0, 0.0, 1.0);
+	float fresnelFactor = 0.0;
 	float glossData = 0.6;
 #ifdef FLAG_LIGHT
 	glossData = defaultGloss;
@@ -323,7 +310,6 @@ void main()
    else
       normal = unitNormal;
 #endif
-	normData = vec4(normal, 1.0);
 
 #ifdef FLAG_ANIMATED
    vec2 distort = vec2(cos(fragPosition.x*fragPosition.w*0.005+anim_timer*20.0)*sin(fragPosition.y*fragPosition.w*0.005),sin(fragPosition.x*fragPosition.w*0.005+anim_timer*20.0)*cos(fragPosition.y*fragPosition.w*0.005))*0.03;
@@ -342,24 +328,28 @@ void main()
 	// if blend_alpha is 2, assume blend func is additive and don't modify color
 	if(blend_alpha == 1) baseColor.rgb = baseColor.rgb * baseColor.a;
 	if(overrideDiffuse) baseColor.rgb = diffuseClr;
- #ifdef FLAG_HDR
+#endif
+	specColor = vec4(baseColor.rgb * SPEC_FACTOR_NO_SPEC_MAP, glossData);
+#ifdef FLAG_HDR
 	baseColor.rgb = pow(baseColor.rgb, vec3(SRGB_GAMMA));
- #endif
-	baseColor.rgb *= aoFactors.y;
 #endif
-
-   specData = vec4(baseColor.rgb * SPEC_FACTOR_NO_SPEC_MAP, glossData);
 #ifdef FLAG_SPEC_MAP
-   vec4 specColour = texture(sSpecmap, texCoord);
-	if(alphaGloss) glossData = specColour.a;
-	if(overrideSpec) specColour.rgb = specClr;
+	specColor = texture(sSpecmap, texCoord);
+	if(alphaGloss) glossData = specColor.a;
+	if(overrideSpec) {
+		specColor.rgb = specClr;
+		fresnelFactor = 1.0;
+	}
+	if(gammaSpec) {
  #ifdef FLAG_HDR
-	if(gammaSpec) specColour.rgb = pow(specColour.rgb, vec3(SRGB_GAMMA));
+		specColor.rgb = pow(specColor.rgb, vec3(SRGB_GAMMA));
  #endif
-	specColour.rgb *= aoFactors.y;
-	specColour.rgb = max(specColour.rgb, vec3(0.04)); // hardcoded minimum specular value. read John Hable's blog post titled 'Everything Is Shiny'. 
-   specData = vec4(specColour.rgb, glossData);
+		specColor.rgb = max(specColor.rgb, vec3(0.04)); // hardcoded minimum specular value. read John Hable's blog post titled 'Everything Is Shiny'. 
+		fresnelFactor = 1.0;
+	}
 #endif
+	baseColor.rgb *= aoFactors.y;
+	specColor.rgb *= aoFactors.y;
 #ifdef FLAG_MISC_MAP
  #ifdef FLAG_TEAMCOLOR
 	vec4 teamMask = vec4(0.0, 0.0, 0.0, 0.0);
@@ -375,10 +365,10 @@ void main()
 	shadow = getShadowValue();
 #endif
 #ifdef FLAG_LIGHT
-	baseColor.rgb = CalculateLighting(normal, baseColor.rgb, specData.rgb, glossData, shadow, aoFactors.x);
+	baseColor.rgb = CalculateLighting(normal, baseColor.rgb, specColor.rgb, glossData, fresnelFactor, shadow, aoFactors.x);
 #else
  #ifdef FLAG_SPEC_MAP
-	baseColor.rgb += pow(1.0 - dot(eyeDir, normal), 5.0 * clamp(glossData, 0.01, 1.0)) * specColour.rgb;
+	baseColor.rgb += pow(1.0 - dot(eyeDir, normal), 5.0 * clamp(glossData, 0.01, 1.0)) * specColor.rgb;
  #endif
 #endif
 #ifdef FLAG_ENV_MAP
@@ -392,8 +382,8 @@ void main()
  #ifdef FLAG_HDR
 	envColour.rgb = pow(envColour.rgb, vec3(SRGB_GAMMA));
  #endif
-	envColour.rgb *= (envGloss) ? 1.0 : specColour.a;
-	baseColor.rgb += envColour.rgb * FresnelLazarovEnv(specColour.rgb, eyeDir, normal, glossData);
+	envColour.rgb *= (envGloss) ? 1.0 : glossData;
+	baseColor.rgb += envColour.rgb * FresnelLazarovEnv(specColor.rgb, eyeDir, normal, glossData);
 #endif
 #ifdef FLAG_GLOW_MAP
 	vec3 glowColor = texture(sGlowmap, texCoord).rgb;
@@ -418,8 +408,8 @@ void main()
  #ifdef FLAG_DIFFUSE_MAP
 	if(blend_alpha == 1) finalFogColor *= baseColor.a;
  #endif
-   baseColor.rgb = mix(baseColor.rgb, finalFogColor, fragFogDist);
-	specData.rgb *= fragFogDist;
+	baseColor.rgb = mix(baseColor.rgb, finalFogColor, fragFogDist);
+	specColor.rgb *= fragFogDist;
 #endif
 
 #ifdef FLAG_DIFFUSE_MAP
@@ -462,10 +452,10 @@ void main()
 	// for some odd reason if we try to discard the pixel early for plane clipping, it screws up glow maps so let's just do it down here.
 	if(use_clip_plane == 1) { if(fragClipDistance <= 0.0) { discard; } }
 #endif
-   fragOut0 = baseColor;
+	fragOut0 = baseColor;
 #ifdef FLAG_DEFERRED
-	fragOut1 = posData;
-	fragOut2 = normData;
-	fragOut3 = specData;
+	fragOut1 = vec4(fragPosition.xyz, 1.0);
+	fragOut2 = vec4(normal, glossData);
+	fragOut3 = vec4(specColor.rgb, fresnelFactor);
 #endif
 }

--- a/code/def_files/main-f.sdr
+++ b/code/def_files/main-f.sdr
@@ -382,7 +382,7 @@ void main()
  #ifdef FLAG_HDR
 	envColour.rgb = pow(envColour.rgb, vec3(SRGB_GAMMA));
  #endif
-	envColour.rgb *= (envGloss) ? 1.0 : glossData;
+	envColour.rgb *= (envGloss) ? 1.0 : specColor.a;
 	baseColor.rgb += envColour.rgb * FresnelLazarovEnv(specColor.rgb, eyeDir, normal, glossData);
 #endif
 #ifdef FLAG_GLOW_MAP


### PR DESCRIPTION
This pull request should address a lot of the concerns expressed in this thread (http://www.hard-light.net/forums/index.php?topic=93151.0) about the physically-based specular lighting model. Namely, this changes it so that we don't use Fresnel reflectivity when using legacy specular data. This preserves the darker specular colors, preventing legacy specular data from looking really flat at grazing angles when Fresnel reflections become really prominent. 

I also tidied up the model shader a bit, removing a bunch of unused or unnecessary variables.

I also discovered a bug in the deferred lighting shader, where it was using specular light source color as the specular material instead of using the specular material from the g-buffer.