### PR TITLE
Fix rendering on high DPI displays on Mac

### DIFF
--- a/freespace2/SDLGraphicsOperations.cpp
+++ b/freespace2/SDLGraphicsOperations.cpp
@@ -148,7 +148,7 @@ SDLGraphicsOperations::~SDLGraphicsOperations() {
 	SDL_QuitSubSystem(SDL_INIT_VIDEO);
 }
 std::unique_ptr<os::Viewport> SDLGraphicsOperations::createViewport(const os::ViewPortProperties& props) {
-	uint32_t windowflags = SDL_WINDOW_SHOWN | SDL_WINDOW_ALLOW_HIGHDPI;
+	uint32_t windowflags = SDL_WINDOW_SHOWN;
 	if (props.enable_opengl) {
 		windowflags |= SDL_WINDOW_OPENGL;
 		setOGLProperties(props);


### PR DESCRIPTION
I added the "allow high DPI windows" SDL-flag while investigating #998
but since that flag isn't used on Windows we can safely remove it again
without causing issues.