### PR TITLE
Remove unneded assert in change_ship_class

### DIFF
--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -9710,8 +9710,7 @@ void change_ship_type(int n, int ship_type, int by_sexp)
 		}
 
 		// extra check
-		Assert(hull_pct > 0.0f && hull_pct <= 1.0f);
-		CLAMP(hull_pct, 0.1f, 1.0f);
+		CLAMP(hull_pct, 0.01f, 1.0f);
 
 		// shield
 		if (sp->special_shield > 0) {


### PR DESCRIPTION
I just encountered this assertion while debugging another issue. As far
as I can tell, this can happen if the ship dies the same frame that
change_ship_class is called. Since a negative hull_strength value is a
valid value this assert is invalid. The CLAMP should ensure that the
following code still behaves as expected.