### PR TITLE
Adjust object_h validity check to avoid assertion failure

### DIFF
--- a/code/object/object.h
+++ b/code/object/object.h
@@ -156,7 +156,7 @@ struct object_h {
 	object *objp;
 	int sig;
 
-	bool IsValid() const {return (objp != NULL && objp->signature == sig);}
+	bool IsValid() const {return (objp != NULL && objp->signature == sig && sig > 0);}
 	object_h(object *in){objp=in; if(objp!=NULL){sig=in->signature;}}
 	object_h(){objp=NULL;sig=-1;}
 };

--- a/code/scripting/api/objs/object.cpp
+++ b/code/scripting/api/objs/object.cpp
@@ -229,9 +229,6 @@ ADE_FUNC(getSignature, l_Object, NULL, "Gets the object's unique signature", "nu
 	if(!oh->IsValid())
 		return ade_set_error(L, "i", -1);
 
-	// this shouldn't be possible, added here to trap the offending object
-	Assert(oh->sig > 0);
-
 	return ade_set_args(L, "i", oh->sig);
 }
 


### PR DESCRIPTION
I found this issue while debugging the JAD gauntlet where a script calls
getSignature() on an invalid object. However, object_h does not see the
object as invalid even though its signature is 0 which is defined to be
an invalid sigature. This should fix that by making sure that
object_h::isValid returns false if the saved signature is not valid.