### PR TITLE
Fix assertion failure in weapon choice screen 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -283,3 +283,6 @@ documentation/doxygen/*
 projects/*
 /.vs
 CMakeSettings.json
+
+# Weird files created by Linux
+.fuse_hidden*

--- a/code/missionui/missionweaponchoice.cpp
+++ b/code/missionui/missionweaponchoice.cpp
@@ -357,8 +357,7 @@ static int Wl_mouse_down_on_region = -1;
 
 // weapon desc stuff
 #define WEAPON_DESC_WIPE_TIME			1.5f			// time in seconds for wipe to occur (over WEAPON_DESC_MAX_LENGTH number of chars)
-#define WEAPON_DESC_MAX_LINES			7				// max lines in the description incl. title
-#define WEAPON_DESC_MAX_LENGTH		50				// max chars per line of description text
+
 static int Weapon_desc_wipe_done = 0;
 static float Weapon_desc_wipe_time_elapsed = 0.0f;
 static char Weapon_desc_lines[WEAPON_DESC_MAX_LINES][WEAPON_DESC_MAX_LENGTH];			// 1st 2 lines are title, rest are desc
@@ -2428,9 +2427,6 @@ void wl_weapon_desc_start_wipe()
 			}
 
 			currchar_src++;
-
-			Assert(currline_dest < WEAPON_DESC_MAX_LINES);
-			Assert(currchar_dest < WEAPON_DESC_MAX_LENGTH);
 		}
 	}
 

--- a/code/missionui/missionweaponchoice.h
+++ b/code/missionui/missionweaponchoice.h
@@ -35,6 +35,8 @@ class ship_weapon;
 #define ICON_SHIP_SECONDARY_2		37
 #define ICON_SHIP_SECONDARY_3		38
 
+#define WEAPON_DESC_MAX_LINES			7				// max lines in the description incl. title
+#define WEAPON_DESC_MAX_LENGTH		50				// max chars per line of description text
 
 extern int Weapon_select_overlay_id;
 

--- a/code/osapi/dialogs.cpp
+++ b/code/osapi/dialogs.cpp
@@ -384,7 +384,7 @@ namespace os
 			}
 
 			if (running_unittests) {
-				throw AssertException(printfString);
+				throw WarningException(printfString);
 			}
 
 			SCP_stringstream boxMsgStream;

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -28,6 +28,7 @@
 #include "math/staticrand.h"
 #include "mod_table/mod_table.h"
 #include "model/modelrender.h"
+#include "missionui/missionweaponchoice.h"
 #include "network/multi.h"
 #include "network/multimsgs.h"
 #include "network/multiutil.h"
@@ -883,6 +884,27 @@ int parse_weapon(int subtype, bool replace, const char *filename)
 		}
 
 		stuff_malloc_string(&wip->desc, F_MULTITEXT);
+
+		// Check if the text exceeds the limits
+		auto current_line = wip->desc;
+		size_t num_lines = 0;
+		while (current_line != nullptr) {
+			auto line_end = strchr(current_line, '\n');
+			auto line_length = line_end - current_line;
+			if (line_end == nullptr) {
+				line_length = strlen(current_line);
+			}
+
+			if (line_length >= WEAPON_DESC_MAX_LENGTH) {
+				error_display(0, "Weapon description line " SIZE_T_ARG " is too long. Maximum is %d.", num_lines + 1, WEAPON_DESC_MAX_LENGTH);
+			}
+
+			++num_lines;
+			current_line = line_end == nullptr ? nullptr : line_end + 1; // Skip the \n character if it was a complete line
+		}
+		if (num_lines >= WEAPON_DESC_MAX_LINES) {
+			error_display(0, "Weapon description has too many lines. Maximum is %d.", WEAPON_DESC_MAX_LINES);
+		}
 	}
 
 	if (optional_string("+Tech Title:")) {

--- a/test/src/source_groups.cmake
+++ b/test/src/source_groups.cmake
@@ -60,3 +60,7 @@ add_file_folder(util "Util"
     util/FSTestFixture.cpp
     util/FSTestFixture.h
 )
+
+add_file_folder(weapon "Weapon"
+    weapon/weapons.cpp
+)

--- a/test/src/source_groups.cmake
+++ b/test/src/source_groups.cmake
@@ -59,6 +59,7 @@ add_file_folder(scripting_api "Scripting\\\\Lua"
 add_file_folder(util "Util"
     util/FSTestFixture.cpp
     util/FSTestFixture.h
+    util/test_util.h
 )
 
 add_file_folder(weapon "Weapon"

--- a/test/src/util/test_util.h
+++ b/test/src/util/test_util.h
@@ -1,0 +1,18 @@
+//
+//
+
+#ifndef FS2_OPEN_TEST_UTIL_H
+#define FS2_OPEN_TEST_UTIL_H
+
+#include <gtest/gtest.h>
+
+// This macro skips the following test if we are not in debug mode
+// useful for things like parsing tests where there are no warnings in release mode
+#ifdef NDEBUG
+// This case needs an if condition to fix a MSVC warning which rightfully warns that the following code is unreachable
+#define DEBUG_TEST() do { GTEST_SUCCEED(); if (1 == 1) { return; } } while (false)
+#else
+#define DEBUG_TEST() do {  } while (false)
+#endif
+
+#endif //FS2_OPEN_TEST_UTIL_H

--- a/test/src/weapon/weapons.cpp
+++ b/test/src/weapon/weapons.cpp
@@ -1,0 +1,31 @@
+
+#include <gtest/gtest.h>
+
+#include "util/FSTestFixture.h"
+
+#include "weapon/weapon.h"
+
+class WeaponsParseTest : public test::FSTestFixture {
+ public:
+	WeaponsParseTest() : test::FSTestFixture(INIT_CFILE) {
+		pushModDir("weapon");
+	}
+
+ protected:
+	virtual void SetUp() override {
+		test::FSTestFixture::SetUp();
+	}
+	virtual void TearDown() override {
+		weapon_close();
+
+		test::FSTestFixture::TearDown();
+	}
+};
+
+TEST_F(WeaponsParseTest, description_line_too_long) {
+	ASSERT_THROW(weapon_init(), os::dialogs::WarningException);
+}
+
+TEST_F(WeaponsParseTest, description_too_many_lines) {
+	ASSERT_THROW(weapon_init(), os::dialogs::WarningException);
+}

--- a/test/src/weapon/weapons.cpp
+++ b/test/src/weapon/weapons.cpp
@@ -2,6 +2,7 @@
 #include <gtest/gtest.h>
 
 #include "util/FSTestFixture.h"
+#include "util/test_util.h"
 
 #include "weapon/weapon.h"
 
@@ -23,9 +24,13 @@ class WeaponsParseTest : public test::FSTestFixture {
 };
 
 TEST_F(WeaponsParseTest, description_line_too_long) {
+	DEBUG_TEST();
+
 	ASSERT_THROW(weapon_init(), os::dialogs::WarningException);
 }
 
 TEST_F(WeaponsParseTest, description_too_many_lines) {
+	DEBUG_TEST();
+
 	ASSERT_THROW(weapon_init(), os::dialogs::WarningException);
 }

--- a/test/test_data/weapon/data/tables/weapons.tbl
+++ b/test/test_data/weapon/data/tables/weapons.tbl
@@ -1,0 +1,12 @@
+
+;; Nothing to see here
+
+#Primary Weapons
+
+#End
+
+#Secondary Weapons
+
+#End
+
+$Player Weapon Precedence: ( )

--- a/test/test_data/weapon/description_line_too_long/data/tables/test-wep.tbm
+++ b/test/test_data/weapon/description_line_too_long/data/tables/test-wep.tbm
@@ -1,0 +1,42 @@
+
+#Primary Weapons
+
+#End
+
+#Secondary Weapons
+
+$Name:                                 		Test weapon
++Title:                                 	XSTR("A test!", -1)
++Description:	XSTR("This   is   a   very   long   line   to   test   the   parsing   code", -1)
+$end_multi_text
+$Model File:								<none>
+$Mass:										0.1
+$Velocity:									5000.0
+$Fire Wait:									6.0
+$Damage:									1.0
+$Blast Force:								1.0
+$Inner Radius:								1.0
+$Outer Radius:								1.5
+$Shockwave Speed:							0
+$Armor Factor:								0.0
+$Shield Factor:								0.0
+$Subsystem Factor:							0.0
+$Lifetime:									0.5
+$Energy Consumed:							0.0													;; Energy used when fired
+$Cargo Size:								1.0													;; Amount of space taken up in weapon cargo
+$Homing:									YES
+	+Type:					ASPECT
+	+Turn Time:				0.1
+	+View Cone:				360.0
+	+Min Lock Time:			2.0
+	+Lock Pixels/Sec:		110
+	+Catch-up Pixels/Sec:	100
+	+Catch-up Penalty:		30
+	+Seeker Strength:		999
+$LaunchSnd:									-1                                       ;; The sound it makes when fired
+$ImpactSnd:									-1                                        ;; The sound it makes when it hits something
+$FlyBySnd:									-1
+$Rearm Rate:								1.0													;; number of missiles/sec that are rearmed
+$Flags:										( "player allowed" "no homing speed ramp" "no dumbfire")
+
+#End

--- a/test/test_data/weapon/description_too_many_lines/data/tables/test-wep.tbm
+++ b/test/test_data/weapon/description_too_many_lines/data/tables/test-wep.tbm
@@ -1,0 +1,52 @@
+
+#Primary Weapons
+
+#End
+
+#Secondary Weapons
+
+$Name:                                 		Test weapon
++Title:                                 	XSTR("A test!", -1)
++Description:	XSTR("This
+descripting
+has
+too
+many
+lines
+to
+cause
+a
+parsing
+warning!", -1)
+$end_multi_text
+$Model File:								<none>
+$Mass:										0.1
+$Velocity:									5000.0
+$Fire Wait:									6.0
+$Damage:									1.0
+$Blast Force:								1.0
+$Inner Radius:								1.0
+$Outer Radius:								1.5
+$Shockwave Speed:							0
+$Armor Factor:								0.0
+$Shield Factor:								0.0
+$Subsystem Factor:							0.0
+$Lifetime:									0.5
+$Energy Consumed:							0.0													;; Energy used when fired
+$Cargo Size:								1.0													;; Amount of space taken up in weapon cargo
+$Homing:									YES
+	+Type:					ASPECT
+	+Turn Time:				0.1
+	+View Cone:				360.0
+	+Min Lock Time:			2.0
+	+Lock Pixels/Sec:		110
+	+Catch-up Pixels/Sec:	100
+	+Catch-up Penalty:		30
+	+Seeker Strength:		999
+$LaunchSnd:									-1                                       ;; The sound it makes when fired
+$ImpactSnd:									-1                                        ;; The sound it makes when it hits something
+$FlyBySnd:									-1
+$Rearm Rate:								1.0													;; number of missiles/sec that are rearmed
+$Flags:										( "player allowed" "no homing speed ramp" "no dumbfire")
+
+#End


### PR DESCRIPTION
If the description of a weapon is too long it would currently cause a
very unhelpful assertion message. This fixes that by checking the length
of the lines when parsing the weapon description. I removed the
assertions since the string is just cut of if it is too long so that
fixes the actual assertion.

I also added two unit tests for making sure that too long descriptions
cause warnings.