### PR TITLE
Restore color icon behavior in DRADIS HUD gauge

### DIFF
--- a/code/radar/radardradis.cpp
+++ b/code/radar/radardradis.cpp
@@ -9,6 +9,7 @@
 #include "freespace.h"
 #include "gamesnd/gamesnd.h"
 #include "globalincs/linklist.h"
+#include "globalincs/alphacolors.h"
 #include "globalincs/systemvars.h"
 #include "graphics/font.h"
 #include "hud/hudwingmanstatus.h"
@@ -164,7 +165,7 @@ void HudGaugeRadarDradis::drawContact(vec3d *pnt, int idx, int clr_idx, float di
         //gr_set_bitmap(clr_idx, GR_ALPHABLEND_FILTER, GR_BITBLT_MODE_NORMAL, alpha);
         //g3_draw_polygon(&p, &vmd_identity_matrix, sizef/35.0f, aspect_mp*sizef/35.0f, TMAP_FLAG_TEXTURED | TMAP_HTL_3D_UNLIT);
 		material mat_params;
-		material_set_unlit_color(&mat_params, clr_idx, &gr_screen.current_color, true, false);
+		material_set_unlit_color(&mat_params, clr_idx, &Color_bright_white, true, false);
 		g3_render_rect_oriented(&mat_params, &p, &vmd_identity_matrix, sizef/35.0f, aspect_mp*sizef/35.0f);
     }
     
@@ -444,6 +445,8 @@ void HudGaugeRadarDradis::drawSweeps()
 
 void HudGaugeRadarDradis::drawBlipsSorted(int distort)
 {
+	GR_DEBUG_SCOPE("Draw Dradis blips");
+
 	matrix base_tilt = vmd_identity_matrix;
 	
 	vm_angle_2_matrix(&base_tilt, -PI/6, 0);


### PR DESCRIPTION
The DRADIS has two icon types, one where the color is scaled with the
IFF color and once which isn't. Due to a regression, both icons were
previously scaled with the IFF color which made the icons look bad. This
fixes that.