### PR TITLE
Disallow to use non-trivial types as scripting handles

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,6 +69,7 @@ matrix:
                       - llvm-toolchain-precise
                   packages:
                       - clang-3.6
+                      - libc++-dev
                       - *global_deps
         - os: osx
           env: CONFIGURATION="Debug"
@@ -90,6 +91,7 @@ matrix:
                       - llvm-toolchain-precise
                   packages:
                       - clang-3.6
+                      - libc++-dev
                       - *global_deps
         - os: osx
           env: CONFIGURATION="Release"

--- a/ci/travis/before_script.sh
+++ b/ci/travis/before_script.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 set -ex
 
@@ -6,7 +6,15 @@ mkdir -p build
 cd build
 
 if [ "$TRAVIS_OS_NAME" = "linux" ]; then
-    export CXXFLAGS="-m64 -mtune=generic -mfpmath=sse -msse -msse2 -pipe -Wno-unknown-pragmas"
+    CXXFLAGS="-m64 -mtune=generic -mfpmath=sse -msse -msse2 -pipe -Wno-unknown-pragmas"
+    CFLAGS="-m64 -mtune=generic -mfpmath=sse -msse -msse2 -pipe -Wno-unknown-pragmas"
+
+    if [[ "$CC" =~ ^clang.*$ ]]; then
+        CXXFLAGS="$CXXFLAGS -stdlib=libc++"
+    fi
+
+    export CXXFLAGS
+    export CFLAGS
     CMAKE="cmake -G Ninja -DFSO_FATAL_WARNINGS=ON"
     if [ "$BUILD_DEPLOYMENT" = true ]; then
         for config in $BUILD_CONFIGS

--- a/cmake/toolchain-clang.cmake
+++ b/cmake/toolchain-clang.cmake
@@ -7,14 +7,20 @@ MESSAGE(STATUS "Doing configuration specific to clang...")
 option(CLANG_ENABLE_LEAK_CHECK "Enable -fsanitize=leak" OFF)
 option(CLANG_ENABLE_ADDRESS_SANITIZER "Enable -fsanitize=address" OFF)
 
-unset(COMPILER_FLAGS)
+# These are the default values
+set(C_BASE_FLAGS "-march=native -pipe")
+set(CXX_BASE_FLAGS "-march=native -pipe")
+
+# For C and C++, the values can be overwritten independently
 if(DEFINED ENV{CXXFLAGS})
-	set(COMPILER_FLAGS $ENV{CXXFLAGS})
+	set(CXX_BASE_FLAGS $ENV{CXXFLAGS})
+endif()
+if(DEFINED ENV{CFLAGS})
+	set(C_BASE_FLAGS $ENV{CFLAGS})
 endif()
 
-if(NOT COMPILER_FLAGS)
-	set(COMPILER_FLAGS "-march=native -pipe")
-endif()
+# Initialize with an empty string to make sure we always get a clean start
+set(COMPILER_FLAGS "")
 
 # This is a slight hack since our flag setup is a bit more complicated
 _enable_extra_compiler_warnings_flags()
@@ -76,8 +82,9 @@ set(COMPILER_FLAGS_RELEASE "-O2 -Wno-unused-variable")
 
 set(COMPILER_FLAGS_DEBUG "-O0 -g -Wshadow")
 
-set(CMAKE_CXX_FLAGS ${COMPILER_FLAGS})
-set(CMAKE_C_FLAGS ${COMPILER_FLAGS})
+# Always use the base flags and add our compiler flags at the bacl
+set(CMAKE_CXX_FLAGS "${CXX_BASE_FLAGS} ${COMPILER_FLAGS}")
+set(CMAKE_C_FLAGS "${C_BASE_FLAGS} ${COMPILER_FLAGS}")
 
 set(CMAKE_CXX_FLAGS_RELEASE ${COMPILER_FLAGS_RELEASE})
 set(CMAKE_C_FLAGS_RELEASE ${COMPILER_FLAGS_RELEASE})

--- a/cmake/toolchain-gcc.cmake
+++ b/cmake/toolchain-gcc.cmake
@@ -9,14 +9,20 @@ option(GCC_ENABLE_LEAK_CHECK "Enable -fsanitize=leak" OFF)
 option(GCC_ENABLE_ADDRESS_SANITIZER "Enable -fsanitize=address" OFF)
 option(GCC_ENABLE_SANITIZE_UNDEFINED "Enable -fsanitize=undefined" OFF)
 
-unset(COMPILER_FLAGS)
+# These are the default values
+set(C_BASE_FLAGS "-march=native -pipe")
+set(CXX_BASE_FLAGS "-march=native -pipe")
+
+# For C and C++, the values can be overwritten independently
+if(DEFINED ENV{CFLAGS})
+	set(C_BASE_FLAGS $ENV{CFLAGS})
+endif()
 if(DEFINED ENV{CXXFLAGS})
-	set(COMPILER_FLAGS $ENV{CXXFLAGS})
+	set(CXX_BASE_FLAGS $ENV{CXXFLAGS})
 endif()
 
-if(NOT COMPILER_FLAGS)
-	set(COMPILER_FLAGS "-march=native -pipe")
-endif()
+# Initialize with an empty string to make sure we always get a clean start
+set(COMPILER_FLAGS "")
 
 # This is a slight hack since our flag setup is a bit more complicated
 _enable_extra_compiler_warnings_flags()
@@ -83,8 +89,12 @@ set(COMPILER_FLAGS_RELEASE "-O2 -Wno-unused-variable -Wno-unused-but-set-variabl
 
 set(COMPILER_FLAGS_DEBUG "-O0 -g -Wshadow")
 
-set(CMAKE_CXX_FLAGS ${COMPILER_FLAGS})
-set(CMAKE_C_FLAGS ${COMPILER_FLAGS})
+# Always use the base flags and add our compiler flags at the bacl
+set(CMAKE_CXX_FLAGS "${CXX_BASE_FLAGS} ${COMPILER_FLAGS}")
+set(CMAKE_C_FLAGS "${C_BASE_FLAGS} ${COMPILER_FLAGS}")
+
+message("${CMAKE_CXX_FLAGS}")
+message("${CMAKE_C_FLAGS}")
 
 set(CMAKE_CXX_FLAGS_RELEASE ${COMPILER_FLAGS_RELEASE})
 set(CMAKE_C_FLAGS_RELEASE ${COMPILER_FLAGS_RELEASE})

--- a/code/scripting/ade.h
+++ b/code/scripting/ade.h
@@ -225,6 +225,9 @@ class ade_lib_handle {
 template<class StoreType>
 class ade_obj: public ade_lib_handle {
  public:
+	// Make sure that the stored type is compatible with our requirements
+	static_assert(std::is_trivially_copyable<StoreType>::value, "ADE object types must be trivially copyable!");
+
 	ade_obj(const char* in_name, const char* in_desc, const ade_lib_handle* in_deriv = NULL) {
 		ade_table_entry ate;
 

--- a/code/scripting/api/libs/hud.cpp
+++ b/code/scripting/api/libs/hud.cpp
@@ -99,7 +99,7 @@ ADE_FUNC(getHUDGaugeHandle, l_HUD, "string Name", "Returns a handle to a specifi
 	if (gauge == NULL)
 		return ADE_RETURN_NIL;
 	else
-		return ade_set_args(L, "o", l_HudGauge.Set(*gauge));
+		return ade_set_args(L, "o", l_HudGauge.Set(gauge));
 }
 
 

--- a/code/scripting/api/libs/testing.cpp
+++ b/code/scripting/api/libs/testing.cpp
@@ -116,7 +116,7 @@ ADE_FUNC(createParticle, l_Testing, "vector Position, vector Velocity, number Li
 	particle::WeakParticlePtr p = particle::create(&pi);
 
 	if (!p.expired())
-		return ade_set_args(L, "o", l_Particle.Set(particle_h(p)));
+		return ade_set_args(L, "o", l_Particle.Set(new particle_h(p)));
 	else
 		return ADE_RETURN_NIL;
 }

--- a/code/scripting/api/objs/hudgauge.cpp
+++ b/code/scripting/api/objs/hudgauge.cpp
@@ -6,13 +6,13 @@
 namespace scripting {
 namespace api {
 
-ADE_OBJ(l_HudGauge, HudGauge, "HudGauge", "HUD Gauge handle");
+ADE_OBJ(l_HudGauge, HudGauge*, "HudGauge", "HUD Gauge handle");
 
 ADE_VIRTVAR(Name, l_HudGauge, "string", "Custom HUD Gauge name", "string", "Custom HUD Gauge name, or nil if handle is invalid")
 {
 	HudGauge* gauge;
 
-	if (!ade_get_args(L, "o", l_HudGauge.GetPtr(&gauge)))
+	if (!ade_get_args(L, "o", l_HudGauge.Get(&gauge)))
 		return ADE_RETURN_NIL;
 
 	if (gauge->getObjectType() != HUD_OBJECT_CUSTOM)
@@ -26,7 +26,7 @@ ADE_VIRTVAR(Text, l_HudGauge, "string", "Custom HUD Gauge text", "string", "Cust
 	HudGauge* gauge;
 	char* text = NULL;
 
-	if (!ade_get_args(L, "o|s", l_HudGauge.GetPtr(&gauge), &text))
+	if (!ade_get_args(L, "o|s", l_HudGauge.Get(&gauge), &text))
 		return ADE_RETURN_NIL;
 
 	if (gauge->getObjectType() != HUD_OBJECT_CUSTOM)

--- a/code/scripting/api/objs/hudgauge.h
+++ b/code/scripting/api/objs/hudgauge.h
@@ -8,7 +8,7 @@
 namespace scripting {
 namespace api {
 
-DECLARE_ADE_OBJ(l_HudGauge, HudGauge);
+DECLARE_ADE_OBJ(l_HudGauge, HudGauge*);
 
 }
 }

--- a/code/scripting/api/objs/particle.cpp
+++ b/code/scripting/api/objs/particle.cpp
@@ -9,9 +9,8 @@ namespace scripting {
 namespace api {
 
 particle_h::particle_h() {
-	part = particle::WeakParticlePtr();
 }
-particle_h::particle_h(particle::WeakParticlePtr part_p) {
+particle_h::particle_h(const particle::WeakParticlePtr& part_p) {
 	this->part = part_p;
 }
 particle::WeakParticlePtr particle_h::Get() {
@@ -23,13 +22,32 @@ bool particle_h::isValid() {
 
 
 //**********HANDLE: Particle
-ADE_OBJ(l_Particle, particle_h, "particle", "Handle to a particle");
+ADE_OBJ(l_Particle, particle_h*, "particle", "Handle to a particle");
+
+ADE_FUNC(__gc, l_Particle, NULL, "Removes the allocated reference of this handle", NULL, NULL)
+{
+	particle_h *ph = NULL;
+	if (!ade_get_args(L, "o", l_Particle.Get(&ph)))
+		return ADE_RETURN_NIL;
+
+	if (ph == NULL)
+		return ADE_RETURN_NIL;
+
+	if (!ph->isValid()) {
+		return ADE_RETURN_NIL;
+	}
+
+	// Clean up the pointer
+	delete ph;
+
+	return ADE_RETURN_NIL;
+}
 
 ADE_VIRTVAR(Position, l_Particle, "vector", "The current position of the particle (world vector)", "vector", "The current position")
 {
 	particle_h *ph = NULL;
 	vec3d newVec = vmd_zero_vector;
-	if (!ade_get_args(L, "o|o", l_Particle.GetPtr(&ph), l_Vector.Get(&newVec)))
+	if (!ade_get_args(L, "o|o", l_Particle.Get(&ph), l_Vector.Get(&newVec)))
 		return ade_set_error(L, "o", l_Vector.Set(vmd_zero_vector));
 
 	if (ph == NULL)
@@ -50,7 +68,7 @@ ADE_VIRTVAR(Velocity, l_Particle, "vector", "The current velocity of the particl
 {
 	particle_h *ph = NULL;
 	vec3d newVec = vmd_zero_vector;
-	if (!ade_get_args(L, "o|o", l_Particle.GetPtr(&ph), l_Vector.Get(&newVec)))
+	if (!ade_get_args(L, "o|o", l_Particle.Get(&ph), l_Vector.Get(&newVec)))
 		return ade_set_error(L, "o", l_Vector.Set(vmd_zero_vector));
 
 	if (ph == NULL)
@@ -71,7 +89,7 @@ ADE_VIRTVAR(Age, l_Particle, "number", "The time this particle already lives", "
 {
 	particle_h *ph = NULL;
 	float newAge = -1.0f;
-	if (!ade_get_args(L, "o|f", l_Particle.GetPtr(&ph), &newAge))
+	if (!ade_get_args(L, "o|f", l_Particle.Get(&ph), &newAge))
 		return ade_set_error(L, "f", -1.0f);
 
 	if (ph == NULL)
@@ -93,7 +111,7 @@ ADE_VIRTVAR(MaximumLife, l_Particle, "number", "The time this particle can live"
 {
 	particle_h *ph = NULL;
 	float newLife = -1.0f;
-	if (!ade_get_args(L, "o|f", l_Particle.GetPtr(&ph), &newLife))
+	if (!ade_get_args(L, "o|f", l_Particle.Get(&ph), &newLife))
 		return ade_set_error(L, "f", -1.0f);
 
 	if (ph == NULL)
@@ -115,7 +133,7 @@ ADE_VIRTVAR(Radius, l_Particle, "number", "The radius of the particle", "number"
 {
 	particle_h *ph = NULL;
 	float newRadius = -1.0f;
-	if (!ade_get_args(L, "o|f", l_Particle.GetPtr(&ph), &newRadius))
+	if (!ade_get_args(L, "o|f", l_Particle.Get(&ph), &newRadius))
 		return ade_set_error(L, "f", -1.0f);
 
 	if (ph == NULL)
@@ -137,7 +155,7 @@ ADE_VIRTVAR(TracerLength, l_Particle, "number", "The tracer legth of the particl
 {
 	particle_h *ph = NULL;
 	float newTracer = -1.0f;
-	if (!ade_get_args(L, "o|f", l_Particle.GetPtr(&ph), &newTracer))
+	if (!ade_get_args(L, "o|f", l_Particle.Get(&ph), &newTracer))
 		return ade_set_error(L, "f", -1.0f);
 
 	if (ph == NULL)
@@ -154,7 +172,7 @@ ADE_VIRTVAR(AttachedObject, l_Particle, "object", "The object this particle is a
 {
 	particle_h *ph = NULL;
 	object_h *newObj = nullptr;
-	if (!ade_get_args(L, "o|o", l_Particle.GetPtr(&ph), l_Object.GetPtr(&newObj)))
+	if (!ade_get_args(L, "o|o", l_Particle.Get(&ph), l_Object.GetPtr(&newObj)))
 		return ade_set_error(L, "o", l_Object.Set(object_h()));
 
 	if (ph == NULL)
@@ -175,7 +193,7 @@ ADE_VIRTVAR(AttachedObject, l_Particle, "object", "The object this particle is a
 ADE_FUNC(isValid, l_Particle, NULL, "Detects whether this handle is valid", "boolean", "true if valid false if not")
 {
 	particle_h *ph = NULL;
-	if (!ade_get_args(L, "o", l_Particle.GetPtr(&ph)))
+	if (!ade_get_args(L, "o", l_Particle.Get(&ph)))
 		return ADE_RETURN_FALSE;
 
 	if (ph == NULL)

--- a/code/scripting/api/objs/particle.h
+++ b/code/scripting/api/objs/particle.h
@@ -13,14 +13,14 @@ class particle_h
  public:
 	particle_h();
 
-	explicit particle_h(particle::WeakParticlePtr part_p);
+	explicit particle_h(const particle::WeakParticlePtr& part_p);
 
 	particle::WeakParticlePtr Get();
 
 	bool isValid();
 };
 
-DECLARE_ADE_OBJ(l_Particle, particle_h);
+DECLARE_ADE_OBJ(l_Particle, particle_h*);
 
 }
 }


### PR DESCRIPTION
As described in #1278, the current scripting system has issues with
handling non-trivial C++ types. Since fixing that deficiency is too much
work, especially since we are in a feature freeze, I decided to simply
enforce the usage of trivial types for scripting handles. Fortunately,
only two handles used non-trivial types so it was relatively easy to fix
those instances by dynamically allocating those and only storing the
pointers in the lua memory.

This fixes a bug in JAD-XA where the game would crash at the last boss.

Also, I noticed that the HudGauge handle used a copy of the hud gauge
rather than a pointer to the actual instance so I'm pretty sure that any
scripting changes to a custom HUD gauge simply didn't work before.