### PR TITLE
Fix depth test of lasers when using a cockpit ... again

### DIFF
--- a/code/graphics/2d.h
+++ b/code/graphics/2d.h
@@ -755,6 +755,7 @@ typedef struct screen {
 	void (*gf_post_process_begin)();
 	void (*gf_post_process_end)();
 	void (*gf_post_process_save_zbuffer)();
+	void (*gf_post_process_restore_zbuffer)();
 
 	void (*gf_deferred_lighting_begin)();
 	void (*gf_deferred_lighting_end)();
@@ -1071,6 +1072,9 @@ __inline int gr_create_index_buffer(bool static_buffer = false)
 #define gr_post_process_begin			GR_CALL(*gr_screen.gf_post_process_begin)
 #define gr_post_process_end				GR_CALL(*gr_screen.gf_post_process_end)
 #define gr_post_process_save_zbuffer	GR_CALL(*gr_screen.gf_post_process_save_zbuffer)
+inline void gr_post_process_restore_zbuffer() {
+	gr_screen.gf_post_process_restore_zbuffer();
+}
 
 #define gr_deferred_lighting_begin		GR_CALL(*gr_screen.gf_deferred_lighting_begin)
 #define gr_deferred_lighting_end		GR_CALL(*gr_screen.gf_deferred_lighting_end)

--- a/code/graphics/grstub.cpp
+++ b/code/graphics/grstub.cpp
@@ -639,6 +639,7 @@ bool gr_stub_init()
 	gr_screen.gf_post_process_begin		= gr_stub_post_process_begin;
 	gr_screen.gf_post_process_end		= gr_stub_post_process_end;
 	gr_screen.gf_post_process_save_zbuffer	= gr_stub_post_process_save_zbuffer;
+	gr_screen.gf_post_process_restore_zbuffer = [](){};
 
 	gr_screen.gf_scene_texture_begin = gr_stub_scene_texture_begin;
 	gr_screen.gf_scene_texture_end = gr_stub_scene_texture_end;

--- a/code/graphics/opengl/gropengl.cpp
+++ b/code/graphics/opengl/gropengl.cpp
@@ -1223,6 +1223,7 @@ void opengl_setup_function_pointers()
 	gr_screen.gf_post_process_begin		= gr_opengl_post_process_begin;
 	gr_screen.gf_post_process_end		= gr_opengl_post_process_end;
 	gr_screen.gf_post_process_save_zbuffer	= gr_opengl_post_process_save_zbuffer;
+	gr_screen.gf_post_process_restore_zbuffer	= gr_opengl_post_process_restore_zbuffer;
 
 	gr_screen.gf_scene_texture_begin = gr_opengl_scene_texture_begin;
 	gr_screen.gf_scene_texture_end = gr_opengl_scene_texture_end;

--- a/code/graphics/opengl/gropenglpostprocessing.cpp
+++ b/code/graphics/opengl/gropenglpostprocessing.cpp
@@ -355,14 +355,6 @@ void opengl_post_lightshafts()
 			}
 		}
 	}
-
-	if ( zbuffer_saved ) {
-		zbuffer_saved = false;
-		gr_zbuffer_set(GR_ZBUFF_FULL);
-		glClear(GL_DEPTH_BUFFER_BIT);
-		gr_zbuffer_set(GR_ZBUFF_NONE);
-		glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_TEXTURE_2D, Scene_depth_texture, 0);
-	}
 }
 
 void gr_opengl_post_process_end()
@@ -600,6 +592,20 @@ void gr_opengl_post_process_save_zbuffer()
 		// If we can't save the z-buffer then just clear it so cockpits are still rendered correctly when
 		// post-processing isn't available/enabled.
 		gr_zbuffer_clear(TRUE);
+	}
+}
+void gr_opengl_post_process_restore_zbuffer()
+{
+	GR_DEBUG_SCOPE("Restore z-Buffer");
+
+	if (zbuffer_saved) {
+		gr_zbuffer_set(GR_ZBUFF_FULL);
+		glClear(GL_DEPTH_BUFFER_BIT);
+		gr_zbuffer_set(GR_ZBUFF_NONE);
+
+		glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_TEXTURE_2D, Scene_depth_texture, 0);
+
+		zbuffer_saved = false;
 	}
 }
 

--- a/code/graphics/opengl/gropenglpostprocessing.h
+++ b/code/graphics/opengl/gropenglpostprocessing.h
@@ -8,6 +8,7 @@ void opengl_post_process_shutdown();
 void gr_opengl_post_process_set_effect(const char *name, int x);
 void gr_opengl_post_process_set_defaults();
 void gr_opengl_post_process_save_zbuffer();
+void gr_opengl_post_process_restore_zbuffer();
 void gr_opengl_post_process_begin();
 void gr_opengl_post_process_end();
 void get_post_process_effect_names(SCP_vector<SCP_string> &names);

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -3652,6 +3652,7 @@ void game_render_frame( camid cid )
 	{
 		gr_post_process_save_zbuffer();
 		ship_render_show_ship_cockpit(Viewer_obj);
+		gr_post_process_restore_zbuffer();
 	}
 
 
@@ -3671,6 +3672,7 @@ void game_render_frame( camid cid )
 
 		gr_post_process_save_zbuffer();
 		ship_render_cockpit(Viewer_obj);
+		gr_post_process_restore_zbuffer();
 	}
 
 	gr_set_proj_matrix(Proj_fov, gr_screen.clip_aspect, Min_draw_distance, Max_draw_distance);


### PR DESCRIPTION
This introduces code to explicitly restore the z-buffer binding to the
previous value instead of relying on the lightshaft code to restore it.

I'm not sure why the code to reset the depth buffer was in the position
it was previously in. The way it was, it looked like some kind of hack 
but I have no idea why it would be put there in the first place. @SamuelCho Maybe you could take a look at this? I tested the lightshaft effect with and without my changes and I couldn't find any difference.