### PR TITLE
Always use the english key name in the scripting interface

### DIFF
--- a/code/controlconfig/controlsconfig.h
+++ b/code/controlconfig/controlsconfig.h
@@ -311,7 +311,26 @@ void control_config_cancel_exit();
 void control_config_reset_defaults(int presetnum=-1);
 int translate_key_to_index(const char *key, bool find_override=true);
 char *translate_key(char *key);
+
+/**
+ * @brief Converts the specified key code to a human readable string
+ *
+ * @note The returned value is localized to the current language
+ *
+ * @param code The key code to convert
+ * @return The text representation of the code. The returned value is stored in a temporary location, copy it to your
+ * own buffer if you want to continue using it.
+ */
 const char *textify_scancode(int code);
+
+/**
+ * @note Same as textify_scancode but always returns the same value regardless of current language
+ * @param code The key code to convert
+ * @return The name of the key
+ * @see textify_scancode
+ */
+const char *textify_scancode_universal(int code);
+
 float check_control_timef(int id);
 int check_control(int id, int key = -1);
 void control_get_axes_readings(int *h, int *p, int *b, int *ta, int *tr);

--- a/code/controlconfig/controlsconfigcommon.cpp
+++ b/code/controlconfig/controlsconfigcommon.cpp
@@ -586,6 +586,28 @@ const char *textify_scancode(int code)
 	strcat_s(text, Scan_code_text[keycode]);
 	return text;
 }
+
+const char *textify_scancode_universal(int code)
+{
+	if (code < 0)
+		return "None";
+
+	int keycode = code & KEY_MASK;
+
+	static char text[40];
+	*text = 0;
+	if (code & KEY_ALTED && !(keycode == KEY_LALT || keycode == KEY_RALT)) {
+		strcat_s(text, "Alt-");
+	}
+
+	if (code & KEY_SHIFTED && !(keycode == KEY_LSHIFT || keycode == KEY_RSHIFT)) {
+		strcat_s(text, "Shift-");
+	}
+
+	// Always use the english version here
+	strcat_s(text, Scan_code_text_english[keycode]);
+	return text;
+}
 //XSTR:ON
 
 void control_config_common_load_overrides();

--- a/code/io/key.cpp
+++ b/code/io/key.cpp
@@ -634,7 +634,7 @@ void key_mark( uint code, int state, uint latency )
 			Current_key_down |= KEY_CTRLED;
 		}
 
-		Script_system.SetHookVar("Key", 's', textify_scancode(Current_key_down));
+		Script_system.SetHookVar("Key", 's', textify_scancode_universal(Current_key_down));
 		Script_system.RunCondition(CHA_KEYRELEASED);
 		Script_system.RemHookVar("Key");
 	} else {
@@ -662,7 +662,8 @@ void key_mark( uint code, int state, uint latency )
 				Current_key_down |= KEY_CTRLED;
 			}
 
-			Script_system.SetHookVar("Key", 's', textify_scancode(Current_key_down));
+			// We use the universal value here to keep the scripting interface consistent regardless of the current language
+			Script_system.SetHookVar("Key", 's', textify_scancode_universal(Current_key_down));
 			Script_system.RunCondition(CHA_KEYPRESSED);
 			Script_system.RemHookVar("Key");
 		} else if (!keyd_repeat) {


### PR DESCRIPTION
Previously, the key text would use the localized key name which made it
hard for scripts to consistently handle key presses across different
languages. This changes that interface so that it always returns the
english name of the key.

This was reported in the [BtA bug report thread](http://www.hard-light.net/forums/index.php?topic=92701.msg1843838#msg1843838).