### PR TITLE
Light attenuation fixes.

### DIFF
--- a/code/def_files/deferred-f.sdr
+++ b/code/def_files/deferred-f.sdr
@@ -46,7 +46,7 @@ void main()
 		discard;
 	vec3 lightDir = lightPosition - position.xyz;
 	float dist = length(lightDir);
-	float attenuation = (1.0 - dist/lightRadius);
+	float attenuation = 1.0 / (1.0 + dist/lightRadius);
 	if(lightType == 2)
 	{
 		float coneDot = dot(normalize(-lightDir), coneDir);
@@ -86,7 +86,6 @@ void main()
 	}
 	lightDir /= dist;
 	vec3 halfVec = normalize(lightDir + eyeDir);
-	float NdotHV = clamp(dot(normal.xyz, halfVec), 0.0, 1.0);
 	float NdotL = clamp(dot(normal.xyz, lightDir), 0.0, 1.0);
 	vec4 fragmentColor = vec4(color * (diffuseLightColor * NdotL * attenuation), 1.0);
 	fragmentColor.rgb += SpecularBlinnPhong(specColor.rgb, lightDir, normal.xyz, halfVec, exp2(10.0 * gloss + 1.0), fresnel, NdotL).rgb * specLightColor * attenuation;

--- a/code/def_files/main-f.sdr
+++ b/code/def_files/main-f.sdr
@@ -212,11 +212,10 @@ vec3 SpecularBlinnPhong(vec3 specColor, vec3 light, vec3 normal, vec3 halfVec, f
 	return mix(specColor, FresnelSchlick(specColor, light, halfVec), fresnel) * ((specPower + 2.0) / 8.0 ) * pow(clamp(dot(normal, halfVec), 0.0, 1.0), specPower) * dotNL;
 }
 #ifdef FLAG_LIGHT
-void GetLightInfo(int i, out vec3 lightDir, out float attenuation, out float specIntensity)
+void GetLightInfo(int i, out vec3 lightDir, out float attenuation)
 {
 	lightDir = normalize(lightPosition[i].xyz);
 	attenuation = 1.0;
-	specIntensity = SPEC_INTENSITY_DIRECTIONAL;
 	if (lightType[i] != LT_DIRECTIONAL) {
 		// Positional light source
 		float dist = distance(lightPosition[i].xyz, fragPosition.xyz);
@@ -234,8 +233,7 @@ void GetLightInfo(int i, out vec3 lightDir, out float attenuation, out float spe
 		}
 
 		lightDir = normalize(lightDir);
-		attenuation = 1.0 / (lightAttenuation[i] * dist);
-		specIntensity = SPEC_INTENSITY_POINT;
+		attenuation = 1.0 / (1.0 + lightAttenuation[i] * dist);
 	}
 }
 vec3 CalculateLighting(vec3 normal, vec3 diffuseMaterial, vec3 specularMaterial, float gloss, float fresnel, float shadow, float aoFactor)
@@ -255,9 +253,8 @@ vec3 CalculateLighting(vec3 normal, vec3 diffuseMaterial, vec3 specularMaterial,
 
 		vec3 lightDir;
 		float attenuation;
-		float specIntensity;
 		// gather light params
-		GetLightInfo(i, lightDir, attenuation, specIntensity);
+		GetLightInfo(i, lightDir, attenuation);
 		vec3 halfVec = normalize(lightDir + eyeDir);
 		float NdotL = max(dot(normal, lightDir), 0.0);
 		// Ambient, Diffuse, and Specular

--- a/code/graphics/opengl/gropengldraw.cpp
+++ b/code/graphics/opengl/gropengldraw.cpp
@@ -2154,7 +2154,7 @@ void gr_opengl_deferred_lighting_finish()
 				Current_shader->program->Uniforms.setUniformf( "coneInnerAngle", l->cone_inner_angle );
 				Current_shader->program->Uniforms.setUniform3f( "coneDir", l->vec2.xyz.x, l->vec2.xyz.y, l->vec2.xyz.z);
 			case LT_POINT:
-				Current_shader->program->Uniforms.setUniform3f( "diffuseLightColor", l->r * l->intensity * static_point_factor, l->g * l->intensity * static_point_factor, l->b * l->intensity * static_point_factor );
+				Current_shader->program->Uniforms.setUniform3f( "diffuseLightColor", l->r * l->intensity, l->g * l->intensity, l->b * l->intensity );
 				Current_shader->program->Uniforms.setUniform3f( "specLightColor", l->spec_r * l->intensity * static_point_factor, l->spec_g * l->intensity * static_point_factor, l->spec_b * l->intensity * static_point_factor );
 				Current_shader->program->Uniforms.setUniformf( "lightRadius", MAX(l->rada, l->radb) * 1.25f );
 
@@ -2167,7 +2167,7 @@ void gr_opengl_deferred_lighting_finish()
 				gr_opengl_draw_deferred_light_sphere(&l->vec, MAX(l->rada, l->radb) * 1.28f);
 				break;
 			case LT_TUBE:
-				Current_shader->program->Uniforms.setUniform3f( "diffuseLightColor", l->r * l->intensity * static_tube_factor, l->g * l->intensity * static_tube_factor, l->b * l->intensity * static_tube_factor );
+				Current_shader->program->Uniforms.setUniform3f( "diffuseLightColor", l->r * l->intensity, l->g * l->intensity, l->b * l->intensity );
 				Current_shader->program->Uniforms.setUniform3f( "specLightColor", l->spec_r * l->intensity * static_tube_factor, l->spec_g * l->intensity * static_tube_factor, l->spec_b * l->intensity * static_tube_factor );
 				Current_shader->program->Uniforms.setUniformf( "lightRadius", l->radb * 1.5f );
 				Current_shader->program->Uniforms.setUniformi( "lightType", 1 );


### PR DESCRIPTION
After fixing Fresnel reflectivity in the deferred lighting shader, deferred lighting appears a bit less intense (http://www.hard-light.net/forums/index.php?topic=93291.0). That led me to identifying that our light attenuation is incorrect. Attenuation behavior between the forward and deferred lighting shaders should match following this pull request.

I've also fixed spec_tube and spec_point command line factors from affecting diffuse deferred lights while taking the opporunity to remove the defunct specular intensity code from the forward lighting shader.