### PR TITLE
Output briefing icon lables as XSTRs

### DIFF
--- a/fred2/missionsave.cpp
+++ b/fred2/missionsave.cpp
@@ -1010,7 +1010,7 @@ int CFred_mission_save::save_briefing() {
 					else
 						fout("\n$label:");
 
-					fout(" %s", bi->label);
+					fout_ext(" ", "%s", bi->label);
 				}
 
 				if (optional_string_fred("+id:"))


### PR DESCRIPTION
The briefing icon lables previously just wrote the label string to the
mission files without surrounding it with an XSTR which made is
impossible to translate them. I fixed that by using the right function
call when saving the value.

This fixes Mantis 3193.