### PR TITLE
Correctly terminate Sexp_variable text with a null byte

### DIFF
--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -28877,7 +28877,7 @@ void sexp_add_array_block_variable(int index, bool is_numeric)
  *
  * This should be called in mission when an sexp_variable is to be modified
  */
-void sexp_modify_variable(char *text, int index, bool sexp_callback)
+void sexp_modify_variable(const char *text, int index, bool sexp_callback)
 {
 	Assert(index >= 0 && index < MAX_SEXP_VARIABLES);
 	Assert(Sexp_variables[index].type & SEXP_VARIABLE_SET);
@@ -28891,7 +28891,7 @@ void sexp_modify_variable(char *text, int index, bool sexp_callback)
 
 		// copy to original buffer
 		auto len = temp_text.copy(Sexp_variables[index].text, TOKEN_LENGTH);
-		text[len] = 0;
+		Sexp_variables[index].text[len] = 0;
 	}
 	else
 	{

--- a/code/parse/sexp.h
+++ b/code/parse/sexp.h
@@ -1176,7 +1176,7 @@ int query_node_in_sexp(int node, int sexp);
 void flush_sexp_tree(int node);
 
 // sexp_variable
-void sexp_modify_variable(char *text, int index, bool sexp_callback = true);
+void sexp_modify_variable(const char *text, int index, bool sexp_callback = true);
 int get_index_sexp_variable_from_node (int node);
 int get_index_sexp_variable_name(const char *text);
 int get_index_sexp_variable_name(SCP_string &text);	// Goober5000


### PR DESCRIPTION
I'm pretty sure that this is a bug since the documentation of
std::string::copy says that it doesn't append a 0 byte so our code would
need to do it manually. Instead, the code appended the 0 byte to the
input buffer which also conflicts with const-correctness (the function
was used on a lua-string buffer which should be const outside Lua).