### PR TITLE
Correct shield decal selection logic

### DIFF
--- a/code/ship/shield.cpp
+++ b/code/ship/shield.cpp
@@ -499,7 +499,7 @@ void render_shield(int shield_num)
 
 		if ( (Detail.shield_effects == 1) || (Detail.shield_effects == 2) ) {
 			shield_render_low_detail_bitmap(bitmap_id, alpha, &Global_tris[Shield_hits[shield_num].tri_list[0]], orient, centerp, Shield_hits[shield_num].rgb[0], Shield_hits[shield_num].rgb[1], Shield_hits[shield_num].rgb[2]);
-		} else if ( Detail.shield_effects <= 4 ) {
+		} else if ( Detail.shield_effects < 4 ) {
 			for ( int i = 0; i < Shield_hits[shield_num].num_tris; i++ ) {
 				shield_render_triangle(bitmap_id, alpha, &Global_tris[Shield_hits[shield_num].tri_list[i]], orient, centerp, Shield_hits[shield_num].rgb[0], Shield_hits[shield_num].rgb[1], Shield_hits[shield_num].rgb[2]);
 			}


### PR DESCRIPTION
This ensures that the conditional statement that allows shields to be rendered as decals uses the correct logic with the detail level values.

This is a "fix" for #1294 