### PR TITLE
Fix lightshaft rendering with cockpits

### DIFF
--- a/code/graphics/opengl/gropenglpostprocessing.cpp
+++ b/code/graphics/opengl/gropenglpostprocessing.cpp
@@ -599,10 +599,6 @@ void gr_opengl_post_process_restore_zbuffer()
 	GR_DEBUG_SCOPE("Restore z-Buffer");
 
 	if (zbuffer_saved) {
-		gr_zbuffer_set(GR_ZBUFF_FULL);
-		glClear(GL_DEPTH_BUFFER_BIT);
-		gr_zbuffer_set(GR_ZBUFF_NONE);
-
 		glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_TEXTURE_2D, Scene_depth_texture, 0);
 
 		zbuffer_saved = false;


### PR DESCRIPTION
Immediately clearing the z-buffer is definitely not a good way of
saving it for later use. This fixes the lightshaft rendering (which was
broken by my fix in #1282) by removing the depth buffer clear from the
z-buffer restore function. The z-Buffer is cleared anyway before
rendering into it so it shouldn't make a difference.