### PR TITLE
Add colour-configurable tint shader

### DIFF
--- a/code/def_files/post-f.sdr
+++ b/code/def_files/post-f.sdr
@@ -26,6 +26,9 @@ uniform float cutoff;
 #ifdef FLAG_DITH
 uniform float dither;
 #endif
+#ifdef FLAG_TINT
+uniform vec3 tint;
+#endif
 uniform sampler2D blurred_tex;
 uniform sampler2D depth_tex;
 void main()
@@ -98,6 +101,9 @@ void main()
 	float downsampling_factor = 4;
 	float bias = 0.5;
 	color_out.rgb = floor(color_out.rgb * downsampling_factor + bias) / downsampling_factor;
+ #endif
+ #ifdef FLAG_TINT
+	color_out.rgb += tint;
  #endif
 	color_out.a = 1.0;
 	fragOut0 = color_out;

--- a/code/graphics/2d.h
+++ b/code/graphics/2d.h
@@ -749,7 +749,7 @@ typedef struct screen {
 	void (*gf_set_ambient_light)(int,int,int);
 
 	// postprocessing effects
-	void (*gf_post_process_set_effect)(const char*, int);
+	void (*gf_post_process_set_effect)(const char*, int, const vec3d*);
 	void (*gf_post_process_set_defaults)();
 
 	void (*gf_post_process_begin)();

--- a/code/graphics/grstub.cpp
+++ b/code/graphics/grstub.cpp
@@ -321,7 +321,7 @@ int gr_stub_alpha_mask_set(int mode, float alpha)
 {
 }*/
 
-void gr_stub_post_process_set_effect(const char *name, int x)
+void gr_stub_post_process_set_effect(const char *name, int x, const vec3d *rgb)
 {
 }
 

--- a/code/graphics/opengl/gropenglpostprocessing.cpp
+++ b/code/graphics/opengl/gropenglpostprocessing.cpp
@@ -530,7 +530,7 @@ void opengl_post_init_uniforms(int flags)
 	}
 }
 
-void gr_opengl_post_process_set_effect(const char *name, int value)
+void gr_opengl_post_process_set_effect(const char *name, int value, const vec3d *rgb)
 {
 	if ( !Post_initialized ) {
 		return;
@@ -555,6 +555,9 @@ void gr_opengl_post_process_set_effect(const char *name, int value)
 
 		if ( !stricmp(eff_name, name) ) {
 			Post_effects[idx].intensity = (value / Post_effects[idx].div) + Post_effects[idx].add;
+			if ((rgb != nullptr) && !(vmd_zero_vector == *rgb)) {
+				Post_effects[idx].rgb = *rgb;
+			}
 			break;
 		}
 	}

--- a/code/graphics/opengl/gropenglpostprocessing.cpp
+++ b/code/graphics/opengl/gropenglpostprocessing.cpp
@@ -48,10 +48,13 @@ typedef struct post_effect_t {
 	float div;
 	float add;
 
+	vec3d rgb;
+
 	bool always_on;
 
 	post_effect_t() :
 		intensity(0.0f), default_intensity(0.0f), div(1.0f), add(0.0f),
+		rgb(),
 		always_on(false)
 	{
 	}
@@ -422,7 +425,12 @@ void gr_opengl_post_process_end()
 			const char *name = Post_effects[idx].uniform_name.c_str();
 			float value = Post_effects[idx].intensity;
 
-			Current_shader->program->Uniforms.setUniformf( name, value);
+			if (!(vmd_zero_vector == Post_effects[idx].rgb)) {
+				Current_shader->program->Uniforms.setUniform3f( name, Post_effects[idx].rgb );
+			}
+			else {
+				Current_shader->program->Uniforms.setUniformf( name, value );
+			}
 		}
 	}
 
@@ -649,6 +657,10 @@ static bool opengl_post_init_table()
 
 				required_string("$Add:");
 				stuff_float(&eff.add);
+
+				if (optional_string("$RGB:")) {
+					stuff_vec3d(&eff.rgb);
+				}
 
 				// Post_effects index is used for flag checks, so we can't have more than 32
 				if (Post_effects.size() < 32) {

--- a/code/graphics/opengl/gropenglpostprocessing.h
+++ b/code/graphics/opengl/gropenglpostprocessing.h
@@ -5,7 +5,7 @@
 void opengl_post_process_init();
 void opengl_post_process_shutdown();
 
-void gr_opengl_post_process_set_effect(const char *name, int x);
+void gr_opengl_post_process_set_effect(const char *name, int x, const vec3d *rgb);
 void gr_opengl_post_process_set_defaults();
 void gr_opengl_post_process_save_zbuffer();
 void gr_opengl_post_process_restore_zbuffer();

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -16693,14 +16693,17 @@ void sexp_set_post_effect(int node)
 	if (amount < 0 || amount > 100)
 		amount = 0;
 
-	vec3d rgb = { 0.0f, 0.0f, 0.0f };
+	vec3d rgb; rgb.xyz.x = 0.0f; rgb.xyz.y = 0.0f; rgb.xyz.z = 0.0f; // clang you are a PITA
 	node = CDDR(node);
 	if (node != -1) {
-		// expect that the next 3 will all be supplied
 		rgb.xyz.x = static_cast<float>(eval_num(node)) / 255.0f;
 		node = CDR(node);
+	}
+	if (node != -1) {
 		rgb.xyz.y = static_cast<float>(eval_num(node)) / 255.0f;
 		node = CDR(node);
+	}
+	if (node != -1) {
 		rgb.xyz.z = static_cast<float>(eval_num(node)) / 255.0f;
 		node = CDR(node);
 	}

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -655,7 +655,7 @@ sexp_oper Operators[] = {
 	{ "hide-jumpnode",					OP_JUMP_NODE_HIDE_JUMPNODE,				1,	INT_MAX,	SEXP_ACTION_OPERATOR,	},
 
 	//Special Effects Sub-Category
-	{ "set-post-effect",				OP_SET_POST_EFFECT,						2,	2,			SEXP_ACTION_OPERATOR,	},	// Hery
+	{ "set-post-effect",				OP_SET_POST_EFFECT,						2,	5,			SEXP_ACTION_OPERATOR,	},	// Hery
 	{ "ship-effect",					OP_SHIP_EFFECT,							3,	INT_MAX,	SEXP_ACTION_OPERATOR,	},	// Valathil
 	{ "ship-create",					OP_SHIP_CREATE,							5,	8,			SEXP_ACTION_OPERATOR,	},	// WMC
 	{ "weapon-create",					OP_WEAPON_CREATE,						5,	10,			SEXP_ACTION_OPERATOR,	},	// Goober5000
@@ -16693,7 +16693,22 @@ void sexp_set_post_effect(int node)
 	if (amount < 0 || amount > 100)
 		amount = 0;
 
-	gr_post_process_set_effect(name, amount);
+	vec3d rgb = { 0.0f, 0.0f, 0.0f };
+	node = CDDR(node);
+	if (node != -1) {
+		// expect that the next 3 will all be supplied
+		rgb.xyz.x = static_cast<float>(eval_num(node)) / 255.0f;
+		node = CDR(node);
+		rgb.xyz.y = static_cast<float>(eval_num(node)) / 255.0f;
+		node = CDR(node);
+		rgb.xyz.z = static_cast<float>(eval_num(node)) / 255.0f;
+		node = CDR(node);
+	}
+	CAP(rgb.xyz.x, 0.0f, 1.0f);
+	CAP(rgb.xyz.y, 0.0f, 1.0f);
+	CAP(rgb.xyz.z, 0.0f, 1.0f);
+
+	gr_post_process_set_effect(name, amount, &rgb);
 }
 
 // Goober5000
@@ -33049,6 +33064,9 @@ sexp_help_struct Sexp_help[] = {
 		"\tTakes 2 arguments\r\n"
 		"\t1: Effect type\r\n"
 		"\t2: Effect intensity (0 - 100)."
+		"\t3: (Optional) Red (0 - 255)."
+		"\t4: (Optional) Green (0 - 255)."
+		"\t5: (Optional) Blue (0 - 255)."
 	},
 
 	{ OP_CHANGE_SUBSYSTEM_NAME, "change-subsystem-name\r\n"

--- a/code/scripting/api/objs/graphics.cpp
+++ b/code/scripting/api/objs/graphics.cpp
@@ -164,7 +164,7 @@ ADE_FUNC(__len, l_Graphics_Posteffects, NULL, "Gets the number or available post
 	return ade_set_args(L, "i", ((int) names.size()) + 1);
 }
 
-ADE_FUNC(setPostEffect, l_Graphics, "string name, [number value=0] [red 0.0 - 1.0] [green 0.0 - 1.0] [blue 0.0 - 1.0]", "Sets the intensity of the specified post processing effect. Optionally set RGB values for post effects that use them", "boolean", "true when successful, false otherwise")
+ADE_FUNC(setPostEffect, l_Graphics, "string name, [number value=0, number red=0.0, number green=0.0, number blue=0.0]", "Sets the intensity of the specified post processing effect. Optionally sets RGB values for post effects that use them (valid values are 0.0 to 1.0)", "boolean", "true when successful, false otherwise")
 {
 	char* name = NULL;
 	int intensity = 0;

--- a/code/scripting/api/objs/graphics.cpp
+++ b/code/scripting/api/objs/graphics.cpp
@@ -168,7 +168,7 @@ ADE_FUNC(setPostEffect, l_Graphics, "string name, [number value=0] [red 0.0 - 1.
 {
 	char* name = NULL;
 	int intensity = 0;
-	vec3d rgb = { 0.0f, 0.0f, 0.0f };
+	vec3d rgb; rgb.xyz.x = 0.0f; rgb.xyz.y = 0.0f; rgb.xyz.z = 0.0f; // clang you are a PITA
 
 	if (!ade_get_args(L, "s|ifff", &name, &intensity, &rgb.xyz.x, &rgb.xyz.y, &rgb.xyz.z))
 		return ADE_RETURN_FALSE;

--- a/code/scripting/api/objs/graphics.cpp
+++ b/code/scripting/api/objs/graphics.cpp
@@ -164,18 +164,23 @@ ADE_FUNC(__len, l_Graphics_Posteffects, NULL, "Gets the number or available post
 	return ade_set_args(L, "i", ((int) names.size()) + 1);
 }
 
-ADE_FUNC(setPostEffect, l_Graphics, "string name, [number value=0]", "Sets the intensity of the specified post processing effect", "boolean", "true when successful, false otherwise")
+ADE_FUNC(setPostEffect, l_Graphics, "string name, [number value=0] [red 0.0 - 1.0] [green 0.0 - 1.0] [blue 0.0 - 1.0]", "Sets the intensity of the specified post processing effect. Optionally set RGB values for post effects that use them", "boolean", "true when successful, false otherwise")
 {
 	char* name = NULL;
 	int intensity = 0;
+	vec3d rgb = { 0.0f, 0.0f, 0.0f };
 
-	if (!ade_get_args(L, "s|i", &name, &intensity))
+	if (!ade_get_args(L, "s|ifff", &name, &intensity, &rgb.xyz.x, &rgb.xyz.y, &rgb.xyz.z))
 		return ADE_RETURN_FALSE;
 
 	if (name == NULL || intensity < 0)
 		return ADE_RETURN_FALSE;
 
-	gr_post_process_set_effect(name, intensity);
+	CAP(rgb.xyz.x, 0.0f, 1.0f);
+	CAP(rgb.xyz.y, 0.0f, 1.0f);
+	CAP(rgb.xyz.z, 0.0f, 1.0f);
+
+	gr_post_process_set_effect(name, intensity, &rgb);
 
 	return ADE_RETURN_TRUE;
 }


### PR DESCRIPTION
FotG needs a tint shader for a feature; basically toggle screen tinting
when a key is pressed as a visual indicator of which mode your ship is
in. Was previously done in a custom shader.