### PR TITLE
Fix OpenGL distortion map update

### DIFF
--- a/code/graphics/opengl/gropengldraw.cpp
+++ b/code/graphics/opengl/gropengldraw.cpp
@@ -2338,7 +2338,7 @@ void gr_opengl_update_distortion()
 		distortion_verts[i].b = 255;
 		distortion_verts[i].a = 255;
 
-		distortion_verts[i].screen.xyw.x = 0.04f;
+		distortion_verts[i].screen.xyw.x = 1.f;
 		distortion_verts[i].screen.xyw.y = (float)gr_screen.max_h*0.03125f*i;
 	}
 

--- a/code/lab/lab.cpp
+++ b/code/lab/lab.cpp
@@ -1238,6 +1238,8 @@ void labviewer_render_bitmap(float frametime)
 
 void labviewer_do_render(float frametime)
 {
+	GR_DEBUG_SCOPE("Lab Render");
+
 	int w, h;
 
 	if ( (Lab_model_num < 0) && (Lab_bitmap_id < 0) ) {
@@ -1250,7 +1252,8 @@ void labviewer_do_render(float frametime)
 
 	// render our particular thing
 	if (Lab_model_num >= 0) {
-		
+		GR_DEBUG_SCOPE("Lab Render model");
+
 		gr_scene_texture_begin();
 
 		labviewer_render_model(frametime);
@@ -1264,6 +1267,8 @@ void labviewer_do_render(float frametime)
 			gr_string(gr_screen.center_offset_x + gr_screen.center_w - w, gr_screen.center_offset_y + gr_screen.center_h - h, Lab_model_filename, GR_RESIZE_NONE);
 		}
 	} else if (Lab_bitmap_id >= 0) {
+		GR_DEBUG_SCOPE("Lab Render bitmap");
+
 		gr_scene_texture_begin();
 
 		labviewer_render_bitmap(frametime);
@@ -1377,13 +1382,13 @@ void labviewer_flags_clear()
 	if (Lab_flags_window != NULL) {
 		Lab_flags_window->DeleteChildren();
 	}
-	
+
 	Ship_Class_Flags.clear();
 	Weapon_Class_Flags.clear();
 }
 
 template <class T>
-void labviewer_flags_add(int* X, int* Y, const char *flag_name, T flag, SCP_vector<lab_flag<T>>& flag_list) 
+void labviewer_flags_add(int* X, int* Y, const char *flag_name, T flag, SCP_vector<lab_flag<T>>& flag_list)
 {
 	int x = 0, y = 0;
 
@@ -1424,12 +1429,12 @@ void labviewer_populate_flags_window()
 
 	// clear out anything that already exists
 	labviewer_flags_clear();
-    
+
 	int y = 0;
 
     // ship flags ...
     if (Lab_mode == LAB_MODE_SHIP) {
-		for (size_t i = 0; i < Num_ship_flags; ++i) 
+		for (size_t i = 0; i < Num_ship_flags; ++i)
 		{
 			labviewer_flags_add<Ship::Info_Flags>(nullptr, &y, Ship_flags[i].name, Ship_flags[i].def, Ship_Class_Flags);
 		}
@@ -1448,11 +1453,11 @@ void labviewer_update_flags_window()
 	if ( (Lab_selected_index < 0) || (Lab_mode == LAB_MODE_NONE) ) {
 		return;
 	}
-	
+
     if (Lab_mode == LAB_MODE_SHIP) {
 		auto sip = &Ship_info[Lab_selected_index];
 
-		for (auto flag_def : Ship_Class_Flags) 
+		for (auto flag_def : Ship_Class_Flags)
 		{
 			if (flag_def.flag == Ship::Info_Flags::NUM_VALUES) continue;
 			flag_def.cb->SetFlag(sip->flags, flag_def.flag, sip);
@@ -1633,20 +1638,20 @@ void labviewer_populate_variables_window()
 		labviewer_variables_add(&y, "Lifetime");
 		labviewer_variables_add(&y, "Range");
 		labviewer_variables_add(&y, "Min Range");
-	
+
 		VAR_ADD_HEADER("Damage");
 		labviewer_variables_add(&y, "Fire wait");
 		labviewer_variables_add(&y, "Damage");
 		labviewer_variables_add(&y, "Armor factor");
 		labviewer_variables_add(&y, "Shield factor");
 		labviewer_variables_add(&y, "Subsys factor");
-	
+
 		VAR_ADD_HEADER("Armor");
 		labviewer_variables_add(&y, "Damage type");
-	
+
 		VAR_ADD_HEADER("Shockwave");
 		labviewer_variables_add(&y, "Speed");
-	
+
 		VAR_ADD_HEADER("Missiles");
 		labviewer_variables_add(&y, "Turn time");
 		labviewer_variables_add(&y, "FOV");
@@ -1757,17 +1762,17 @@ void labviewer_update_variables_window()
 		VAR_SET_VALUE_SAVE(wip->lifetime, 0);
 		VAR_SET_VALUE_SAVE(wip->weapon_range, 0);
 		VAR_SET_VALUE_SAVE(wip->WeaponMinRange, 0);
-	
+
 		VAR_SET_VALUE_SAVE(wip->fire_wait, 0);
 		VAR_SET_VALUE_SAVE(wip->damage, 0);
 		VAR_SET_VALUE_SAVE(wip->armor_factor, 0);
 		VAR_SET_VALUE_SAVE(wip->shield_factor, 0);
 		VAR_SET_VALUE_SAVE(wip->subsystem_factor, 0);
-	
+
 		VAR_SET_VALUE_SAVE(wip->damage_type_idx, 0);
-	
+
 		VAR_SET_VALUE_SAVE(wip->shockwave.speed, 0);
-	
+
 		VAR_SET_VALUE_SAVE(wip->turn_time, 0);
 		VAR_SET_VALUE_SAVE(wip->fov, 0);
 		VAR_SET_VALUE_SAVE(wip->min_lock_time, 0);
@@ -2276,7 +2281,7 @@ void labviewer_change_ship(Tree *caller)
 	if ( !Lab_in_mission ) {
 		return;
 	}
-	
+
 	Lab_selected_index = (int)(caller->GetSelectedItem()->GetData());
 
 	labviewer_update_desc_window();
@@ -2370,7 +2375,7 @@ void labviewer_make_weap_window(Button* caller)
 
 	// populate the weapons window
 	Tree *cmp = (Tree*)Lab_class_window->AddChild(new Tree("Weapon Tree", 0, 0));
-	
+
 	// Unfortunately these are hardcoded
 	TreeItem **type_nodes = new TreeItem*[Num_weapon_subtypes];
 	int i;
@@ -2388,7 +2393,7 @@ void labviewer_make_weap_window(Button* caller)
 			Warning(LOCATION, "Invalid weapon subtype found on weapon %s", Weapon_info[i].name);
 			continue;
 		}
-		
+
 		if (Weapon_info[i].wi_flags[Weapon::Info_Flags::Beam]) {
 			stip = type_nodes[WP_BEAM];
 		} else {
@@ -2520,6 +2525,8 @@ void lab_init()
 #include "controlconfig/controlsconfig.h"
 void lab_do_frame(float frametime)
 {
+	GR_DEBUG_SCOPE("Lab Frame");
+
 	gr_reset_clip();
 	gr_clear();
 

--- a/code/lab/wmcgui.cpp
+++ b/code/lab/wmcgui.cpp
@@ -472,6 +472,8 @@ void GUIScreen::DeleteObject(GUIObject* dgp)
 
 int GUIScreen::OnFrame(float frametime, bool doevents)
 {
+	GR_DEBUG_SCOPE("GUIScreen Frame");
+
 	GUIObject* cgp;
 	GUIObject* cgp_prev;
 	bool SomethingPressed = false;
@@ -608,6 +610,8 @@ ScreenClassInfoEntry *GUISystem::GetScreenClassInfo(const SCP_string & screen_na
 
 int GUISystem::OnFrame(float frametime, bool doevents, bool clearandflip)
 {
+	GR_DEBUG_SCOPE("GUISystem Frame");
+
 	//Set the global status variables for this frame
 	LastStatus = Status;
 	Status = GST_MOUSE_OVER;
@@ -748,7 +752,7 @@ GUIObject::GUIObject(const SCP_string &in_Name, int x_coord, int y_coord, int x_
 	if (x_width == 0 || y_height == 0) {
 		return;
 	}
-	
+
 	//No! Bad!
 	if (in_Name.length() < 1) {
 		return;
@@ -831,7 +835,7 @@ GUIObject* GUIObject::AddChildInternal(GUIObject *cgp)
 	cgp->GetOIECoords(&cgp->Coords[0], &cgp->Coords[1], &cgp->Coords[2], &cgp->Coords[3]);
 	//In case we need to resize
 	cgp->OnRefreshSize();
-	
+
 	return cgp;
 }
 
@@ -840,7 +844,7 @@ GUIObject* GUIObject::AddChild(GUIObject* cgp)
 	if (cgp == NULL) {
 		return NULL;
 	}
-	
+
 	//AddInternalChild must be used
 	if (cgp->Style & GS_INTERNALCHILD) {
 		return NULL;
@@ -892,6 +896,8 @@ void GUIObject::OnDraw(float frametime)
 
 int GUIObject::OnFrame(float frametime, int *unused_queue)
 {
+	GR_DEBUG_SCOPE("GUIObject Frame");
+
 	int rval = OF_TRUE;
 
 	GUIObject *cgp_prev;	//Elements will move themselves to the end of the list if they become active


### PR DESCRIPTION
The updated values for the distortion map were rendered too close to the
edge of the screen so they were clipped which meant that there was no
distortion data available. This fixes that by moving the rendered
primitives farther away from the edge. I'm not sure why this worked in
3.7.4, maybe the fixed function rendering used some slightly different
matrix.

I also don't know why this wouldn't work consistently across GPU vendors
but maybe the rasterization rules vary a bit across drivers.

This fixes #1307.