### PR TITLE
Reorder fragment shader destination binds to fix Mac deferred lighting.

### DIFF
--- a/code/graphics/opengl/gropenglshader.cpp
+++ b/code/graphics/opengl/gropenglshader.cpp
@@ -582,6 +582,13 @@ int opengl_compile_shader(shader_type sdr, uint flags)
 				glBindAttribLocation(program->getShaderHandle(), i, GL_vertex_attrib_info[i].name.c_str());
 			}
 
+			// bind fragment data locations before we link the shader
+			glBindFragDataLocation(new_shader.program->getShaderHandle(), 0, "fragOut0");
+			glBindFragDataLocation(new_shader.program->getShaderHandle(), 1, "fragOut1");
+			glBindFragDataLocation(new_shader.program->getShaderHandle(), 2, "fragOut2");
+			glBindFragDataLocation(new_shader.program->getShaderHandle(), 3, "fragOut3");
+			glBindFragDataLocation(new_shader.program->getShaderHandle(), 4, "fragOut4");
+
 			if (do_shader_caching()) {
 				// Enable shader caching
 				glProgramParameteri(program->getShaderHandle(), GL_PROGRAM_BINARY_RETRIEVABLE_HINT, GL_TRUE);
@@ -601,13 +608,6 @@ int opengl_compile_shader(shader_type sdr, uint flags)
 	new_shader.program = std::move(program);
 
 	opengl_shader_set_current(&new_shader);
-
-	// bind fragment data locations
-	glBindFragDataLocation(new_shader.program->getShaderHandle(), 0, "fragOut0");
-	glBindFragDataLocation(new_shader.program->getShaderHandle(), 1, "fragOut1");
-	glBindFragDataLocation(new_shader.program->getShaderHandle(), 2, "fragOut2");
-	glBindFragDataLocation(new_shader.program->getShaderHandle(), 3, "fragOut3");
-	glBindFragDataLocation(new_shader.program->getShaderHandle(), 4, "fragOut4");
 
 	// initialize uniforms and attributes
 	for (auto& unif : sdr_info->uniforms) {

--- a/code/graphics/opengl/gropenglshader.cpp
+++ b/code/graphics/opengl/gropenglshader.cpp
@@ -583,11 +583,11 @@ int opengl_compile_shader(shader_type sdr, uint flags)
 			}
 
 			// bind fragment data locations before we link the shader
-			glBindFragDataLocation(new_shader.program->getShaderHandle(), 0, "fragOut0");
-			glBindFragDataLocation(new_shader.program->getShaderHandle(), 1, "fragOut1");
-			glBindFragDataLocation(new_shader.program->getShaderHandle(), 2, "fragOut2");
-			glBindFragDataLocation(new_shader.program->getShaderHandle(), 3, "fragOut3");
-			glBindFragDataLocation(new_shader.program->getShaderHandle(), 4, "fragOut4");
+			glBindFragDataLocation(program->getShaderHandle(), 0, "fragOut0");
+			glBindFragDataLocation(program->getShaderHandle(), 1, "fragOut1");
+			glBindFragDataLocation(program->getShaderHandle(), 2, "fragOut2");
+			glBindFragDataLocation(program->getShaderHandle(), 3, "fragOut3");
+			glBindFragDataLocation(program->getShaderHandle(), 4, "fragOut4");
 
 			if (do_shader_caching()) {
 				// Enable shader caching


### PR DESCRIPTION
Fixes https://github.com/scp-fs2open/fs2open.github.com/issues/969. glBindFragDataLocation needs to be called before a shader program is linked, not after. Apple likes following the Core spec to the letter.