### PR TITLE
Improve handling of environment map redrawing

### DIFF
--- a/code/graphics/opengl/gropengldraw.cpp
+++ b/code/graphics/opengl/gropengldraw.cpp
@@ -1912,6 +1912,7 @@ void gr_opengl_scene_texture_begin()
 	}
 
 	GR_DEBUG_SCOPE("Begin scene texture");
+	TRACE_SCOPE(tracing::SceneTextureBegin);
 
 	GL_state.PushFramebufferState();
 	GL_state.BindFrameBuffer(Scene_framebuffer);
@@ -1956,11 +1957,13 @@ void gr_opengl_scene_texture_begin()
 float time_buffer = 0.0f;
 void gr_opengl_scene_texture_end()
 {
-	GR_DEBUG_SCOPE("End scene texture");
 
 	if ( !Scene_framebuffer_in_frame ) {
 		return;
 	}
+
+	GR_DEBUG_SCOPE("End scene texture");
+	TRACE_SCOPE(tracing::SceneTextureEnd);
 
 	time_buffer+=flFrametime;
 	if(time_buffer>0.03f)

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -3505,11 +3505,6 @@ int get_sexp()
 			case OP_MISSION_SET_NEBULA:
 				// set flag for WMC
 				Nebula_sexp_used = true;
-				Dynamic_environment = true;
-				break;
-				
-			case OP_MISSION_SET_SUBSPACE:
-				Dynamic_environment = true;
 				break;
 
 			case OP_WARP_EFFECT:
@@ -3529,7 +3524,6 @@ int get_sexp()
 				// model is argument #1
 				n = CDR(start);
 				do_preload_for_arguments(sexp_set_skybox_model_preload, n, arg_handler);
-				Dynamic_environment = true;
 				break;
 
 			case OP_TURRET_CHANGE_WEAPON:
@@ -3541,13 +3535,11 @@ int get_sexp()
 			case OP_ADD_SUN_BITMAP:
 				n = CDR(start);
 				do_preload_for_arguments(stars_preload_sun_bitmap, n, arg_handler);
-				Dynamic_environment = true;
 				break;
 
 			case OP_ADD_BACKGROUND_BITMAP:
 				n = CDR(start);
 				do_preload_for_arguments(stars_preload_background_bitmap, n, arg_handler);
-				Dynamic_environment = true;
 				break;
 
 			case OP_TECH_ADD_INTEL_XSTR:
@@ -12157,7 +12149,8 @@ void sexp_mission_set_subspace(int n)
         Game_subspace_effect = 0;
 		game_stop_subspace_ambient_sound();
 	}
-    
+
+	stars_set_dynamic_environment(Game_subspace_effect != 0);
     The_mission.flags.set(Mission::Mission_Flags::Subspace, Game_subspace_effect != 0);
 }
 

--- a/code/starfield/starfield.cpp
+++ b/code/starfield/starfield.cpp
@@ -177,6 +177,10 @@ int Num_debris_nebula = 0;
 bool Dynamic_environment = false;
 bool Motion_debris_override = false;
 
+static int Default_env_map = -1;
+static int Mission_env_map = -1;
+static bool Env_cubemap_drawn = false;
+
 void stars_release_debris_vclips(debris_vclip *vclips)
 {
 	int i;
@@ -702,6 +706,10 @@ void stars_init()
 	parse_startbl("stars.tbl");
 
 	parse_modular_table("*-str.tbm", parse_startbl);
+
+	if (Cmdline_env) {
+		ENVMAP = Default_env_map = bm_load("cubemap");
+	}
 }
 
 // call only from game_shutdown()!!
@@ -778,6 +786,41 @@ void stars_pre_level_init(bool clear_backgrounds)
 
 	Dynamic_environment = false;
 	Motion_debris_override = false;
+
+	Env_cubemap_drawn = false;
+}
+
+// setup the render target ready for this mission's environment map
+static void environment_map_gen()
+{
+	const int size = 512;
+	int gen_flags = (BMP_FLAG_RENDER_TARGET_STATIC | BMP_FLAG_CUBEMAP | BMP_FLAG_RENDER_TARGET_MIPMAP);
+
+	if ( !Cmdline_env ) {
+		return;
+	}
+
+	if (gr_screen.envmap_render_target >= 0) {
+		if ( !bm_release(gr_screen.envmap_render_target, 1) ) {
+			Warning(LOCATION, "Unable to release environment map render target.");
+		}
+
+		gr_screen.envmap_render_target = -1;
+	}
+
+	if ( Dynamic_environment || (The_mission.flags[Mission::Mission_Flags::Subspace]) ) {
+		Dynamic_environment = true;
+		gen_flags &= ~BMP_FLAG_RENDER_TARGET_STATIC;
+		gen_flags |= BMP_FLAG_RENDER_TARGET_DYNAMIC;
+	}
+		// bail if we are going to be static, and have an envmap specified already
+	else if ( strlen(The_mission.envmap_name) ) {
+		// Load the mission map so we can use it later
+		Mission_env_map = bm_load(The_mission.envmap_name);
+		return;
+	}
+
+	gr_screen.envmap_render_target = bm_make_render_target(size, size, gen_flags);
 }
 
 // call this in game_post_level_init() so we know whether we're running in full nebula mode or not
@@ -853,6 +896,23 @@ void stars_post_level_init()
 	}
 
 	starfield_generate_bitmap_buffers();
+
+	environment_map_gen();
+}
+
+void stars_level_close() {
+	if (gr_screen.envmap_render_target >= 0) {
+		if ( bm_release(gr_screen.envmap_render_target, 1) ) {
+			gr_screen.envmap_render_target = -1;
+		}
+	}
+
+	if (Mission_env_map >= 0) {
+		bm_release(Mission_env_map);
+		Mission_env_map = -1;
+	}
+
+	ENVMAP = Default_env_map;
 }
 
 
@@ -2092,6 +2152,9 @@ void stars_set_background_model(const char *model_name, const char *texture_name
 			Nmodel_instance_num = model_create_instance(false, Nmodel_num);
 		}
 	}
+
+	// Since we have a new skybox we need to rerender the environment map
+	stars_invalidate_environment_map();
 }
 
 // call this to set a specific orientation for the background
@@ -2216,6 +2279,9 @@ int stars_add_sun_entry(starfield_list_entry *sun_ptr)
 		}
 	}
 
+	// The background changed so we need to invalidate the environment map
+	stars_invalidate_environment_map();
+
 	// now check if we can make use of a previously discarded instance entry
 	// this should never happen with FRED
 	if ( !Fred_running ) {
@@ -2274,6 +2340,9 @@ int stars_add_bitmap_entry(starfield_list_entry *sle)
 			}
 		}
 	}
+
+	// The background changed so we need to invalidate the environment map
+	stars_invalidate_environment_map();
 
 	// now check if we can make use of a previously discarded instance entry
 	for (int i = 0; i < (int)Starfield_bitmap_instances.size(); i++) {
@@ -2379,6 +2448,9 @@ void stars_mark_instance_unused(int index, bool is_a_sun)
 		delete [] Starfield_bitmap_instances[index].verts;
 		Starfield_bitmap_instances[index].verts = NULL;
 	}
+
+	// The background changed so we need to invalidate the environment map
+	stars_invalidate_environment_map();
 }
 
 // retrieves the name from starfield_bitmap for the instance index
@@ -2427,6 +2499,8 @@ void stars_set_nebula(bool activate)
 		Debris_vclips = Debris_vclips_normal;
 		HUD_contrast = 0;
 	}
+	// We need to reload the environment map now
+	stars_invalidate_environment_map();
 }
 
 // retrieves the name from starfield_bitmap, really only used by FRED2
@@ -2662,4 +2736,150 @@ void stars_pack_backgrounds()
 			}
 		}
 	}
+}
+
+static void render_environment(int i, vec3d *eye_pos, matrix *new_orient, float new_zoom)
+{
+	bm_set_render_target(gr_screen.envmap_render_target, i);
+
+	gr_clear();
+
+	g3_set_view_matrix( eye_pos, new_orient, new_zoom );
+
+	gr_set_proj_matrix( PI_2 * new_zoom, 1.0f, Min_draw_distance, Max_draw_distance);
+	gr_set_view_matrix( &Eye_position, &Eye_matrix );
+
+	if ( Game_subspace_effect ) {
+		stars_draw(0, 0, 0, 1, 1);
+	} else {
+		stars_draw(0, 1, 1, 0, 1);
+	}
+
+	gr_end_view_matrix();
+	gr_end_proj_matrix();
+}
+
+void stars_setup_environment_mapping(camid cid) {
+	matrix new_orient = IDENTITY_MATRIX;
+
+	extern float View_zoom;
+	float old_zoom = View_zoom, new_zoom = 1.0f;//0.925f;
+	int i = 0;
+
+	if(!cid.isValid())
+		return;
+
+	vec3d cam_pos;
+	matrix cam_orient;
+	cid.getCamera()->get_info(&cam_pos, &cam_orient);
+
+	// prefer the mission specified envmap over the static-generated envmap, but
+	// the dynamic envmap should always get preference if in a subspace mission
+	if ( !Dynamic_environment && Mission_env_map >= 0 ) {
+		ENVMAP = Mission_env_map;
+		return;
+	}
+
+	if (gr_screen.envmap_render_target < 0) {
+		if (ENVMAP >= 0)
+			return;
+
+		if (Mission_env_map >= 0) {
+			ENVMAP = Mission_env_map;
+		} else {
+			ENVMAP = Default_env_map;
+		}
+
+		return;
+	}
+
+	if (Env_cubemap_drawn) {
+		// Nothing to do here anymore
+		return;
+	}
+
+	GR_DEBUG_SCOPE("Environment Mapping");
+	TRACE_SCOPE(tracing::EnvironmentMapping);
+
+	ENVMAP = gr_screen.envmap_render_target;
+
+	/*
+	 * Envmap matrix setup -- left-handed
+	 * -------------------------------------------------
+	 * Face --	Forward		Up		Right
+	 * px		+X			+Y		-Z
+	 * nx		-X			+Y		+Z
+	 * py		+Y			-Z		+X
+	 * ny		-Y			+Z		+X
+	 * pz		+Z 			+Y		+X
+	 * nz		-Z			+Y		-X
+	*/
+	// NOTE: OpenGL needs up/down reversed
+
+	// Save the previous render target so we can reset it once we are done here
+	auto previous_target = gr_screen.rendering_to_texture;
+
+	// face 1 (px / right)
+	memset( &new_orient, 0, sizeof(matrix) );
+	new_orient.vec.fvec.xyz.x =  1.0f;
+	new_orient.vec.uvec.xyz.y =  1.0f;
+	new_orient.vec.rvec.xyz.z = -1.0f;
+	render_environment(i, &cam_pos, &new_orient, new_zoom);
+	i++; // bump!
+
+	// face 2 (nx / left)
+	memset( &new_orient, 0, sizeof(matrix) );
+	new_orient.vec.fvec.xyz.x = -1.0f;
+	new_orient.vec.uvec.xyz.y =  1.0f;
+	new_orient.vec.rvec.xyz.z =  1.0f;
+	render_environment(i, &cam_pos, &new_orient, new_zoom);
+	i++; // bump!
+
+	// face 3 (py / up)
+	memset( &new_orient, 0, sizeof(matrix) );
+	new_orient.vec.fvec.xyz.y =  (gr_screen.mode == GR_OPENGL) ?  1.0f : -1.0f;
+	new_orient.vec.uvec.xyz.z =  (gr_screen.mode == GR_OPENGL) ? -1.0f :  1.0f;
+	new_orient.vec.rvec.xyz.x =  1.0f;
+	render_environment(i, &cam_pos, &new_orient, new_zoom);
+	i++; // bump!
+
+	// face 4 (ny / down)
+	memset( &new_orient, 0, sizeof(matrix) );
+	new_orient.vec.fvec.xyz.y =  (gr_screen.mode == GR_OPENGL) ? -1.0f :  1.0f;
+	new_orient.vec.uvec.xyz.z =  (gr_screen.mode == GR_OPENGL) ?  1.0f : -1.0f;
+	new_orient.vec.rvec.xyz.x =  1.0f;
+	render_environment(i, &cam_pos, &new_orient, new_zoom);
+	i++; // bump!
+
+	// face 5 (pz / forward)
+	memset( &new_orient, 0, sizeof(matrix) );
+	new_orient.vec.fvec.xyz.z =  1.0f;
+	new_orient.vec.uvec.xyz.y =  1.0f;
+	new_orient.vec.rvec.xyz.x =  1.0f;
+	render_environment(i, &cam_pos, &new_orient, new_zoom);
+	i++; // bump!
+
+	// face 6 (nz / back)
+	memset( &new_orient, 0, sizeof(matrix) );
+	new_orient.vec.fvec.xyz.z = -1.0f;
+	new_orient.vec.uvec.xyz.y =  1.0f;
+	new_orient.vec.rvec.xyz.x = -1.0f;
+	render_environment(i, &cam_pos, &new_orient, new_zoom);
+
+
+	// we're done, so now reset
+	bm_set_render_target(previous_target);
+	g3_set_view_matrix( &cam_pos, &cam_orient, old_zoom );
+
+	if ( !Dynamic_environment ) {
+		Env_cubemap_drawn = true;
+	}
+}
+void stars_set_dynamic_environment(bool dynamic) {
+	Dynamic_environment = dynamic;
+	stars_invalidate_environment_map();
+}
+void stars_invalidate_environment_map() {
+	// This will cause a redraw in the next frame
+	Env_cubemap_drawn = false;
 }

--- a/code/starfield/starfield.h
+++ b/code/starfield/starfield.h
@@ -47,7 +47,6 @@ extern int Cur_background;
 extern background_t Backgrounds[MAX_BACKGROUNDS];
 extern int Nmodel_flags;
 
-extern bool Dynamic_environment;
 extern bool Motion_debris_override;
 
 void stars_swap_backgrounds(int idx1, int idx2);
@@ -93,6 +92,8 @@ void stars_pre_level_init(bool clear_backgrounds = true);
 
 // call this in game_post_level_init() so we know whether we're running in full nebula mode or not
 void stars_post_level_init();
+
+void stars_level_close();
 
 // draw background bitmaps
 void stars_draw_background();
@@ -144,5 +145,20 @@ void stars_modify_entry_FRED(int index, const char *name, starfield_list_entry *
 void stars_load_first_valid_background();
 int stars_get_first_valid_background();
 void stars_load_background(int background_idx);
+
+void stars_setup_environment_mapping(camid cid);
+
+/**
+ * @brief Enabled dynamic rendering of environment map
+ * @param dynamic @c true if the environment should be dynamic
+ */
+void stars_set_dynamic_environment(bool dynamic);
+
+/**
+ * @brief Invalidates the current environment map
+ *
+ * This will cause a redraw of the environment map in the next frame
+ */
+void stars_invalidate_environment_map();
 
 #endif

--- a/code/tracing/categories.cpp
+++ b/code/tracing/categories.cpp
@@ -17,6 +17,8 @@ Category LuaOnFrame("LUA On Frame", true);
 Category DrawSceneTexture("Draw scene texture", true);
 Category UpdateDistortion("Update distortion", true);
 
+Category SceneTextureBegin("Scene texture begin", true);
+Category SceneTextureEnd("Scene texture end", true);
 Category Tonemapping("Tonemapping", true);
 Category Bloom("Bloom", true);
 Category BloomBrightPass("Bloom bright pass", true);

--- a/code/tracing/categories.h
+++ b/code/tracing/categories.h
@@ -29,6 +29,8 @@ extern Category LuaOnFrame;
 extern Category DrawSceneTexture;
 extern Category UpdateDistortion;
 
+extern Category SceneTextureBegin;
+extern Category SceneTextureEnd;
 extern Category Tonemapping;
 extern Category Bloom;
 extern Category BloomBrightPass;

--- a/scripts/performance_graph.py
+++ b/scripts/performance_graph.py
@@ -21,9 +21,10 @@ parser.add_argument("--fps", action="store_true",
 parser.add_argument("--save_img", help="Saves the generated graph to the specified file path.")
 args = parser.parse_args()
 
-averageTime = 0.2
+averageTime = 0.3
 
-MICROSECONDS_PER_SECOND = 1000000.
+NANOSECONDS_PER_SECOND = 1000000000.
+
 
 def average(time, frametime):
     startIndex = 0
@@ -46,8 +47,8 @@ def average(time, frametime):
 
 
 def adjustData(data):
-    times = data[2:, 0] / MICROSECONDS_PER_SECOND
-    frametimes = data[2:, 1] / MICROSECONDS_PER_SECOND
+    times = data[2:, 0] / NANOSECONDS_PER_SECOND
+    frametimes = data[2:, 1] / NANOSECONDS_PER_SECOND
 
     times = times - times[0]
 
@@ -62,6 +63,12 @@ changedData = np.genfromtxt(args.changed_data, delimiter=';')
 
 nT, nF = adjustData(normalData)
 cT, cF = adjustData(changedData)
+
+avgNormalData = np.mean(nF)
+avgChangedData = np.mean(cF)
+
+ratio = avgNormalData / avgChangedData
+print(ratio)
 
 plot.plot(nT, nF, label=args.base_title)
 plot.plot(cT, cF, label=args.changed_title)


### PR DESCRIPTION
This should make sure that the environment map is only redrawn if
necessary. In my case that should improve frame times by around 1ms for
the normal case when the environment map doesn't need to be redrawn.

This only affects missions which use SEXPs to change the background but since that is more and more common with new releases this should improve framerates a bit.