### PR TITLE
Use built-in OpenGL clip plane instead of custom variant

### DIFF
--- a/code/def_files/main-f.sdr
+++ b/code/def_files/main-f.sdr
@@ -82,10 +82,6 @@ uniform float neardist;
 uniform float middist;
 uniform float fardist;
 #endif
-#ifdef FLAG_CLIP
-uniform int use_clip_plane;
-in float fragClipDistance;
-#endif
 #ifdef FLAG_NORMAL_ALPHA
 uniform vec2 normalAlphaMinMax;
 #endif
@@ -270,9 +266,6 @@ void main()
 	if(fragNotVisible >= 0.9) { discard; }
 #endif
 #ifdef FLAG_SHADOW_MAP
- #ifdef FLAG_CLIP
-	if(use_clip_plane == 1) { if(fragClipDistance <= 0.0) { discard; } }
- #endif
 	// need depth and depth squared for variance shadow maps
 	fragOut0 = vec4(fragPosition.z, fragPosition.z * fragPosition.z * VARIANCE_SHADOW_SCALE_INV, 0.0, 1.0);
 	return;
@@ -444,10 +437,6 @@ void main()
 #ifdef FLAG_NORMAL_ALPHA
 	float normViewOffset = dot(vec3(0.0, 0.0, 1.0), normal);
 	baseColor.a = smoothstep(min(normalAlphaMinMax.x, normalAlphaMinMax.y), max(normalAlphaMinMax.x, normalAlphaMinMax.y), clamp(normalAlphaMinMax.x > normalAlphaMinMax.y ? normViewOffset : 1.0 - normViewOffset, 0.0, 1.0));
-#endif
-#ifdef FLAG_CLIP
-	// for some odd reason if we try to discard the pixel early for plane clipping, it screws up glow maps so let's just do it down here.
-	if(use_clip_plane == 1) { if(fragClipDistance <= 0.0) { discard; } }
 #endif
 	fragOut0 = baseColor;
 #ifdef FLAG_DEFERRED

--- a/code/def_files/main-g.sdr
+++ b/code/def_files/main-g.sdr
@@ -11,10 +11,6 @@ out vec4 fragTexCoord;
 in float geoNotVisible[];
 out float fragNotVisible;
 #endif
-#ifdef FLAG_CLIP
-in float geoClipDistance[];
-out float fragClipDistance;
-#endif
 void main(void)
 {
 	int instanceID = int(geoInstance[0]);
@@ -31,7 +27,7 @@ void main(void)
 		fragNotVisible = geoNotVisible[0];
 #endif
 #ifdef FLAG_CLIP
-		fragClipDistance = geoClipDistance[0];
+		gl_ClipDistance[0] = gl_in[vert].gl_ClipDistance[0];
 #endif
 		EmitVertex();
 	}

--- a/code/def_files/main-v.sdr
+++ b/code/def_files/main-v.sdr
@@ -54,13 +54,7 @@ uniform float thruster_scale;
 #endif
 #ifdef FLAG_CLIP
 uniform int use_clip_plane;
-uniform vec3 clip_normal;
-uniform vec3 clip_position;
-#ifdef FLAG_SHADOW_MAP
-out float geoClipDistance;
-#else
-out float fragClipDistance;
-#endif
+uniform vec4 clip_equation;
 #endif
 #ifdef FLAG_TRANSFORM
 #define TEXELS_PER_MATRIX 4
@@ -147,13 +141,11 @@ void main()
 	fragFogDist = clamp((gl_Position.z - fogStart) * 0.75 * fogScale, 0.0, 1.0);
  #endif
  #ifdef FLAG_CLIP
-   float clip_dist = 0.0;
-	if(use_clip_plane == 1) clip_dist = dot(normalize((modelMatrix * orient * vertex).xyz - clip_position), clip_normal);
-  #ifdef FLAG_SHADOW_MAP
-   geoClipDistance = clip_dist;
-  #else
-   fragClipDistance = clip_dist;
-  #endif
+	if(use_clip_plane == 1) {
+		gl_ClipDistance[0] = dot(clip_equation, modelMatrix * orient * vertex);
+	} else {
+		gl_ClipDistance[0] = -1.0f;
+	}
  #endif
  #ifndef FLAG_SHADOW_MAP
 	fragPosition = position;

--- a/code/graphics/opengl/gropenglshader.cpp
+++ b/code/graphics/opengl/gropenglshader.cpp
@@ -184,7 +184,7 @@ static opengl_shader_variant_t GL_shader_variants[] = {
 		"Submodel Transforms" },
 	
 	{ SDR_TYPE_MODEL, false, SDR_FLAG_MODEL_CLIP, "FLAG_CLIP", 
-		{ "use_clip_plane", "clip_normal", "clip_position" }, {  },
+		{ "use_clip_plane", "clip_equation" }, {  },
 		"Clip Plane" },
 
 	{ SDR_TYPE_MODEL, false, SDR_FLAG_MODEL_HDR, "FLAG_HDR",

--- a/code/graphics/opengl/gropenglstate.cpp
+++ b/code/graphics/opengl/gropenglstate.cpp
@@ -317,39 +317,19 @@ GLboolean opengl_state::PolygonOffsetFill(GLint state)
 	return save_state;
 }
 
-GLboolean opengl_state::ClipPlane(GLint num, GLint state)
-{
-	Assert( (num >= 0) || (num < (int)(sizeof(clipplane_Status) / sizeof(GLboolean))) );
-
-	GLboolean save_state = clipplane_Status[num];
-
-	if ( !((state == -1) || (state == clipplane_Status[num])) ) {
-		if (state) {
-			Assert( state == GL_TRUE );
-			clipplane_Status[num] = GL_TRUE;
-		} else {
-			clipplane_Status[num] = GL_FALSE;
-		}
-	}
-
-	return save_state;
-}
-
-GLboolean opengl_state::ClipDistance(GLint num, GLint state)
+GLboolean opengl_state::ClipDistance(GLint num, bool state)
 {
 	Assert( (num >= 0) && (num < (int)(sizeof(clipdistance_Status) / sizeof(GLboolean))) );
 
 	GLboolean save_state = clipdistance_Status[num];
 
-	if ( !((state == -1) || (state == clipdistance_Status[num])) ) {
+	if (state != clipdistance_Status[num]) {
 		if (state) {
-			Assert( state == GL_TRUE );
-			//glEnable(GL_CLIP_DISTANCE0+num);
-			clipdistance_Status[num] = GL_TRUE;
+			glEnable(GL_CLIP_DISTANCE0+num);
 		} else {
-			//glDisable(GL_CLIP_DISTANCE0+num);
-			clipdistance_Status[num] = GL_FALSE;
+			glDisable(GL_CLIP_DISTANCE0+num);
 		}
+		clipdistance_Status[num] = state;
 	}
 
 	return save_state;

--- a/code/graphics/opengl/gropenglstate.h
+++ b/code/graphics/opengl/gropenglstate.h
@@ -152,7 +152,7 @@ class opengl_state
 		GLboolean polygonoffsetfill_Status;
 		GLboolean normalize_Status;
 		GLboolean clipplane_Status[6];
-		GLboolean clipdistance_Status[6];
+		bool clipdistance_Status[6];
 		GLboolean depthmask_Status;
         GLboolean colormask_Status;
 
@@ -202,8 +202,7 @@ class opengl_state
         GLboolean StencilTest(GLint state = -1);
 		GLboolean CullFace(GLint state = -1);
 		GLboolean PolygonOffsetFill(GLint state = -1);
-		GLboolean ClipPlane(GLint num, GLint state = -1);
-		GLboolean ClipDistance(GLint num, GLint state = -1);
+		GLboolean ClipDistance(GLint num, bool state = false);
 		GLboolean DepthMask(GLint state = -1);
         GLboolean ColorMask(GLint state = -1);
 


### PR DESCRIPTION
The current shaders compute the clip values in the vertex shader and
then discard fragments if those values say that the fragment is clipped.
I don't know why this was done but, as far as I can tell, this behavior
can be fully replaced by using the built-in OpenGL clip-plane feature
which should also reduce the amount of fragment shader invocations. This
won't affect performance too much since we rarely use clip planes but it
seems like the correct thing to do.