### PR TITLE
Fix OpenGL errors when framebuffer effects are disabled

### DIFF
--- a/code/graphics/opengl/gropengl.cpp
+++ b/code/graphics/opengl/gropengl.cpp
@@ -1349,12 +1349,15 @@ static void APIENTRY debug_callback(GLenum source, GLenum type, GLuint id, GLenu
 			break;
 	}
 
+	bool print_to_general_log = false;
 	switch(severity) {
 		case GL_DEBUG_SEVERITY_HIGH_ARB:
 			severityStr = "High";
+			print_to_general_log = true; // High and medium messages are sent to the normal log for later troubleshooting
 			break;
 		case GL_DEBUG_SEVERITY_MEDIUM_ARB:
 			severityStr = "Medium";
+			print_to_general_log = true;
 			break;
 		case GL_DEBUG_SEVERITY_LOW_ARB:
 			severityStr = "Low";
@@ -1364,8 +1367,14 @@ static void APIENTRY debug_callback(GLenum source, GLenum type, GLuint id, GLenu
 			break;
 	}
 
-	nprintf(("OpenGL Debug", "OpenGL Debug: Source:%s\tType:%s\tID:%d\tSeverity:%s\tMessage:%s\n",
-		sourceStr, typeStr, id, severityStr, message));
+	if (print_to_general_log) {
+		mprintf(("OpenGL Debug: Source:%s\tType:%s\tID:%d\tSeverity:%s\tMessage:%s\n",
+			sourceStr, typeStr, id, severityStr, message));
+	} else {
+		// We still print these messages but only to the special debug stream
+		nprintf(("OpenGL Debug", "OpenGL Debug: Source:%s\tType:%s\tID:%d\tSeverity:%s\tMessage:%s\n",
+			sourceStr, typeStr, id, severityStr, message));
+	}
 	printf("OpenGL Debug: Source:%s\tType:%s\tID:%d\tSeverity:%s\tMessage:%s\n",
 		   sourceStr, typeStr, id, severityStr, message);
 }

--- a/code/graphics/opengl/gropengldraw.cpp
+++ b/code/graphics/opengl/gropengldraw.cpp
@@ -107,7 +107,7 @@ GLuint Scene_depth_texture;
 GLuint Cockpit_depth_texture;
 GLuint Scene_stencil_buffer;
 
-GLuint Distortion_framebuffer;
+GLuint Distortion_framebuffer = 0;
 GLuint Distortion_texture[2];
 int Distortion_switch = 0;
 
@@ -2272,6 +2272,11 @@ void gr_opengl_render_shield_impact(shield_material *material_info, primitive_ty
 
 void gr_opengl_update_distortion()
 {
+	if (Distortion_framebuffer == 0) {
+		// distortion is disabled
+		return;
+	}
+
 	GR_DEBUG_SCOPE("Update distortion");
 	TRACE_SCOPE(tracing::UpdateDistortion);
 


### PR DESCRIPTION
This also promotes medium and high severity OpenGL messages to the
general logging category to help troubleshooting in the future.