### PR TITLE
Validate seek offsets in cfseek

### DIFF
--- a/code/libs/ffmpeg/FFmpegContext.cpp
+++ b/code/libs/ffmpeg/FFmpegContext.cpp
@@ -43,7 +43,7 @@ int64_t cfileSeek(void* ptr, int64_t offset, int whence) {
 	
 	auto ret = cfseek(cfile, intOff, op);
 
-	if (ret < 0) {
+	if (ret != 0) {
 		// Error
 		return -1;
 	}


### PR DESCRIPTION
Invalid values previously corrupted the internal position counter which
caused crashes on some platforms because the position counter would
overflow in the next read operation. I added some assertions to track
the position counter corruption and it's probably a good idea to leave
them in to catch possible future errors early.

The actual fix was to just ensure that the seek position it always valid
for the file.

This fixes #1059.