### PR TITLE
Apply clipping planes to passthrough shader

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -2,3 +2,6 @@ root = true
 
 [*.{h,cpp}]
 indent_style = tab
+
+[*.sdr]
+indent_style = tab

--- a/code/def_files/passthrough-v.sdr
+++ b/code/def_files/passthrough-v.sdr
@@ -6,9 +6,18 @@ out vec4 fragColor;
 uniform mat4 modelViewMatrix;
 uniform mat4 projMatrix;
 uniform vec4 color;
+
+uniform mat4 modelMatrix;
+uniform bool clipEnabled;
+uniform vec4 clipEquation;
+
 void main()
 {
 	fragTexCoord = vertTexCoord;
 	fragColor = vertColor * color;
 	gl_Position = projMatrix * modelViewMatrix * vertPosition;
+
+	if (clipEnabled) {
+		gl_ClipDistance[0] = dot(clipEquation, modelMatrix * vertPosition);
+	}
 }

--- a/code/graphics/opengl/gropenglshader.h
+++ b/code/graphics/opengl/gropenglshader.h
@@ -14,6 +14,7 @@
 #include "globalincs/pstypes.h"
 #include "graphics/2d.h"
 #include "graphics/opengl/gropengl.h"
+#include "graphics/material.h"
 #include "ShaderProgram.h"
 
 #include <string>
@@ -166,7 +167,7 @@ void opengl_shader_compile_deferred_light_shader();
 void opengl_shader_compile_deferred_light_clear_shader();
 
 void opengl_shader_compile_passthrough_shader();
-void opengl_shader_set_passthrough(bool textured = true, bool alpha = false, vec4* clr = NULL, float color_scale = 1.0f);
+void opengl_shader_set_passthrough(bool textured = true, bool alpha = false, vec4* clr = NULL, float color_scale = 1.0f, const material::clip_plane& clip_plane = material::clip_plane());
 void opengl_shader_set_passthrough(bool textured, bool alpha, color *clr);
 
 #define ANIMATED_SHADER_LOADOUTSELECT_FS1	0

--- a/code/graphics/opengl/gropengltnl.h
+++ b/code/graphics/opengl/gropengltnl.h
@@ -33,6 +33,7 @@ extern float shadow_middist;
 extern float shadow_fardist;
 extern bool Rendering_to_shadow_map;
 
+extern transform_stack GL_model_matrix_stack;
 extern matrix4 GL_view_matrix;
 extern matrix4 GL_model_view_matrix;
 extern matrix4 GL_projection_matrix;


### PR DESCRIPTION
This adds support for using clipping planes with the passthrough shader
by passing through the clip equation of the specified plane and then
using gl_ClipDistance for using the built-in clipping capabilities.

This fixes ##1326.