### PR TITLE
Add ability to dynamically add new SEXPs at runtime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -256,3 +256,7 @@ CMakeSettings.json
 
 # Weird files created by Linux
 .fuse_hidden*
+
+# This gets ignored by one of the rules above for some reason...
+!/code/scripting/lua/LuaConvert.h
+!/code/debugconsole/

--- a/code/cmdline/cmdline.cpp
+++ b/code/cmdline/cmdline.cpp
@@ -508,6 +508,7 @@ char *Cmdline_start_mission = NULL;
 int Cmdline_old_collision_sys = 0;
 int Cmdline_dis_collisions = 0;
 int Cmdline_dis_weapons = 0;
+bool Cmdline_output_sexp_info = false;
 int Cmdline_noparseerrors = 0;
 #ifdef Allow_NoWarn
 int Cmdline_nowarn = 0; // turn warnings off in FRED
@@ -1890,7 +1891,7 @@ bool SetCmdlineParams()
 		Output_scripting_meta = true;
 
 	if (output_sexp_arg.found() ) {
-		output_sexps("sexps.html");
+		Cmdline_output_sexp_info = true;
 	}
 
 	if ( no_pbo_arg.found() )

--- a/code/cmdline/cmdline.h
+++ b/code/cmdline/cmdline.h
@@ -145,6 +145,7 @@ extern char *Cmdline_start_mission;
 extern int Cmdline_old_collision_sys;
 extern int Cmdline_dis_collisions;
 extern int Cmdline_dis_weapons;
+extern bool Cmdline_output_sexp_info;
 extern int Cmdline_noparseerrors;
 extern int Cmdline_extra_warn;
 extern int Cmdline_bmpman_usage;

--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -40,6 +40,7 @@ gameversion::version Targetted_version; // Defaults to retail
 SCP_string Window_title;
 bool Unicode_text_mode;
 SCP_string Movie_subtitle_font;
+bool Enable_scripts_in_fred; // By default FRED does not initialize the scripting system
 
 void parse_mod_table(const char *filename)
 {
@@ -270,6 +271,16 @@ void parse_mod_table(const char *filename)
 			}
 		}
 
+		if (optional_string("$Enable scripting in FRED:")) {
+			stuff_boolean(&Enable_scripts_in_fred);
+			if (Enable_scripts_in_fred) {
+				mprintf(("Game Settings Table: FRED - Scripts will be executed when running FRED.\n"));
+			}
+			else {
+				mprintf(("Game Settings Table: FRED - Scripts will not be executed when running FRED.\n"));
+			}
+		}
+
 		optional_string("#OTHER SETTINGS");
 
 		if (optional_string("$Fixed Turret Collisions:")) {
@@ -397,4 +408,5 @@ void mod_table_reset() {
 	Window_title = "";
 	Unicode_text_mode = false;
 	Movie_subtitle_font = "font01.vf";
+	Enable_scripts_in_fred = false;
 }

--- a/code/mod_table/mod_table.h
+++ b/code/mod_table/mod_table.h
@@ -33,6 +33,7 @@ extern float Shield_pain_flash_factor;
 extern SCP_string Window_title;
 extern bool Unicode_text_mode;
 extern SCP_string Movie_subtitle_font;
+extern bool Enable_scripts_in_fred;
 
 void mod_table_init();
 

--- a/code/parse/sexp.h
+++ b/code/parse/sexp.h
@@ -1131,6 +1131,7 @@ extern SCP_vector<SCP_string> *Current_event_log_variable_buffer;
 extern SCP_vector<SCP_string> *Current_event_log_argument_buffer;
 
 extern void init_sexp();
+extern void sexp_shutdown();
 extern int alloc_sexp(const char *text, int type, int subtype, int first, int rest);
 extern int find_free_sexp();
 extern int free_one_sexp(int num);

--- a/code/parse/sexp/DynamicSEXP.cpp
+++ b/code/parse/sexp/DynamicSEXP.cpp
@@ -1,0 +1,18 @@
+//
+//
+
+#include "DynamicSEXP.h"
+
+namespace sexp {
+
+DynamicSEXP::DynamicSEXP(const SCP_string& name) : _name(name) {
+}
+const SCP_string& DynamicSEXP::getName() const {
+	return _name;
+}
+const SCP_string& DynamicSEXP::getHelpText() const {
+	return _help_text;
+}
+
+}
+

--- a/code/parse/sexp/DynamicSEXP.h
+++ b/code/parse/sexp/DynamicSEXP.h
@@ -1,0 +1,87 @@
+#pragma once
+
+#include "globalincs/pstypes.h"
+
+namespace sexp {
+
+/**
+ * @brief An abstract SEXP instance
+ *
+ * This class represents an implementation of a SEXP that can be added dynamically to the SEXP system
+ */
+class DynamicSEXP {
+ protected:
+	SCP_string _name; //!< The operator name of this SEXP
+	SCP_string _help_text; //!< The help text to be displayed in FRED
+
+	explicit DynamicSEXP(const SCP_string& name);
+ public:
+	virtual ~DynamicSEXP() = default;
+
+	const SCP_string& getName() const;
+
+	const SCP_string& getHelpText() const;
+
+	/**
+	 * @brief Retrieves the minimum number of parameters this SEXP needs
+	 *
+	 * All remaining parameters are optional and the implementation must handle non-existing parameters gracefully
+	 *
+	 * @return The minimum amount of arguments
+	 */
+	virtual int getMinimumArguments() = 0;
+
+	/**
+	 * @brief Gets the maximum number of how many arguments this SEXP may be called with
+	 *
+	 * If this returns INT_MAX then there will be no limit to how many parameters may be specified.
+	 *
+	 * @return The maximum amount of arguments for this SEXP
+	 */
+	virtual int getMaximumArguments() = 0;
+
+	/**
+	 * @brief Retrieves the type of the specified argument (0-base)
+	 * @param argnum The argument to query the type for
+	 * @return The argument type
+	 */
+	virtual int getArgumentType(int argnum) const = 0;
+
+	/**
+	 * @brief Executes the SEXP implementation
+	 * @param node The SEXP node containing the first parameter of the parameter list
+	 * @return The return value of the SEXP
+	 */
+	virtual int execute(int node) = 0;
+
+	/**
+	 * @brief Gets the return type of the SEXP
+	 *
+	 * See the OPR_* defines for what values this function may return.
+	 *
+	 * @return The return type
+	 */
+	virtual int getReturnType() = 0;
+
+	/**
+	 * @brief The subcategory identifier this SEXP belongs to
+	 *
+	 * This is used by FRED to group SEXPs with similar purposes together. This can be one of the *_SUBCATEGORY_*
+	 * defines or a new id which has been added dynamically.
+	 *
+	 * @return The subcategory id
+	 */
+	virtual int getSubcategory() = 0;
+
+	/**
+	 * @brief The general category of this SEXP
+	 *
+	 * This can be any of the OP_CATEGORY_* defines.
+	 *
+	 * @return The category id.
+	 */
+	virtual int getCategory() = 0;
+};
+
+}
+

--- a/code/parse/sexp/LuaSEXP.cpp
+++ b/code/parse/sexp/LuaSEXP.cpp
@@ -1,0 +1,411 @@
+//
+//
+#include <scripting/api/objs/waypoint.h>
+#include "LuaSEXP.h"
+
+#include "parse/parselo.h"
+#include "parse/sexp/sexp_lookup.h"
+
+#include "object/waypoint.h"
+#include "iff_defs/iff_defs.h"
+
+#include "scripting/api/objs/sexpvar.h"
+#include "scripting/api/objs/team.h"
+#include "scripting/api/objs/waypoint.h"
+
+using namespace luacpp;
+
+namespace {
+
+SCP_unordered_map<SCP_string, int> parameter_type_mapping{{ "boolean",      OPF_BOOL },
+														  { "number",       OPF_NUMBER },
+														  { "ship",         OPF_SHIP },
+														  { "string",       OPF_STRING },
+														  { "team",         OPF_IFF },
+														  { "waypointpath", OPF_WAYPOINT_PATH },
+														  { "variable",     OPF_VARIABLE_NAME }, };
+int get_parameter_type(const SCP_string& name) {
+	SCP_string copy = name;
+	std::transform(copy.begin(), copy.end(), copy.begin(), ::tolower);
+
+	auto iter = parameter_type_mapping.find(copy);
+	if (iter == parameter_type_mapping.end()) {
+		return -1;
+	} else {
+		return iter->second;
+	}
+}
+
+SCP_unordered_map<SCP_string, int> return_type_mapping{{ "number",  OPR_NUMBER },
+													   { "boolean", OPR_BOOL },
+													   { "nothing", OPR_NULL }, };
+int get_return_type(const SCP_string& name) {
+	SCP_string copy = name;
+	std::transform(copy.begin(), copy.end(), copy.begin(), ::tolower);
+
+	auto iter = return_type_mapping.find(copy);
+	if (iter == return_type_mapping.end()) {
+		return -1;
+	} else {
+		return iter->second;
+	}
+}
+
+int get_category(const SCP_string& name) {
+	for (auto& subcat : op_menu) {
+		if (subcat.name == name) {
+			return subcat.id;
+		}
+	}
+
+	return -1;
+}
+
+int get_subcategory(const SCP_string& name) {
+	for (auto& subcat : op_submenu) {
+		if (subcat.name == name) {
+			return subcat.id;
+		}
+	}
+
+	return -1;
+}
+
+}
+
+namespace sexp {
+
+LuaSEXP::LuaSEXP(const SCP_string& name) : DynamicSEXP(name) {
+}
+int LuaSEXP::getMinimumArguments() {
+	return _min_args;
+}
+int LuaSEXP::getMaximumArguments() {
+	return _max_args;
+}
+int LuaSEXP::getArgumentType(int argnum) const {
+	if (argnum < 0) {
+		return OPF_NONE;
+	}
+
+	if (argnum < (int) _argument_types.size()) {
+		// Normal, non variable argument types
+		return _argument_types[argnum];
+	}
+
+	// We are in the variable argument types region
+	// First, adjust the argnum base index so that our variable index starts at 0
+	auto varargs_index = argnum - _argument_types.size();
+
+	// Then use modulo magic to bring the argument number into the right range
+	varargs_index = varargs_index % _varargs_type_pattern.size();
+
+	// And then use that to get the parameter type
+	return _varargs_type_pattern[varargs_index];
+}
+luacpp::LuaValue LuaSEXP::sexpToLua(int node, int argnum) const {
+	auto argtype = getArgumentType(argnum);
+
+	switch (argtype) {
+	case OPF_BOOL: {
+		auto value = is_sexp_true(node) != 0;
+		return LuaValue::createValue(_action.getLuaState(), value);
+	}
+	case OPF_NUMBER: {
+		auto res = eval_num(node);
+		float value;
+		if (res == SEXP_NAN || res == SEXP_NAN_FOREVER) {
+			value = std::numeric_limits<float>::quiet_NaN();
+		} else {
+			value = (float) res;
+		}
+		return LuaValue::createValue(_action.getLuaState(), value);
+	}
+	case OPF_VARIABLE_NAME: {
+		using namespace scripting::api;
+
+		// Variable names work by getting the variable index from the text node
+		auto sexp_variable_index = atoi(Sexp_nodes[node].text);
+
+		// verify variable set
+		Assert(Sexp_variables[sexp_variable_index].type & SEXP_VARIABLE_SET);
+
+		// Add the variable to the parameter list as a SEXPVariable object handle
+		return LuaValue::createValue(_action.getLuaState(), l_SEXPVariable.Set(sexpvar_h(sexp_variable_index)));
+	}
+	case OPF_IFF: {
+		using namespace scripting::api;
+
+		auto team_idx = iff_lookup(CTEXT(node));
+
+		return LuaValue::createValue(_action.getLuaState(), l_Team.Set(team_idx));
+	}
+	case OPF_WAYPOINT_PATH: {
+		using namespace scripting::api;
+
+		waypoint_list *wp_list = find_matching_waypoint_list(CTEXT(node));
+
+		return LuaValue::createValue(_action.getLuaState(), l_WaypointList.Set(waypointlist_h(wp_list)));
+	}
+		// The following argument types are all strings
+	case OPF_SHIP:
+		// We don't convert ships to handles since this may include invalid ship names and the script should
+		// still be able to handle those gracefully
+	case OPF_STRING: {
+		auto text = CTEXT(node);
+		return LuaValue::createValue(_action.getLuaState(), text);
+	}
+	default:
+		Assertion(false,
+				  "Unhandled argument type! Someone added an argument type but didn't add handling code to execute().");
+		return LuaValue::createNil(_action.getLuaState());
+	}
+}
+int LuaSEXP::getSexpReturnValue(const LuaValueList& retVals) const {
+	switch (_return_type) {
+	case OPR_NUMBER:
+		if (retVals.size() != 1) {
+			Warning(LOCATION,
+					"Wrong number of return values for Lua SEXP '%s'! Expected 1, got " SIZE_T_ARG ".",
+					_name.c_str(),
+					retVals.size());
+			return 0;
+		} else if (retVals[0].getValueType() != ValueType::NUMBER) {
+			Warning(LOCATION, "Wrong return type detected for Lua SEXP '%s', expected a number.", _name.c_str());
+			return 0;
+		} else {
+			return retVals[0].getValue<int>();
+		}
+	case OPR_BOOL:
+		if (retVals.size() != 1) {
+			Warning(LOCATION,
+					"Wrong number of return values for Lua SEXP '%s'! Expected 1, got " SIZE_T_ARG ".",
+					_name.c_str(),
+					retVals.size());
+			return SEXP_FALSE;
+		} else if (retVals[0].getValueType() != ValueType::BOOLEAN) {
+			Warning(LOCATION, "Wrong return type detected for Lua SEXP '%s', expected a boolean.", _name.c_str());
+			return SEXP_FALSE;
+		} else {
+			return retVals[0].getValue<bool>() ? SEXP_TRUE : SEXP_FALSE;
+		}
+	case OPR_NULL:
+		if (retVals.size() != 0) {
+			Warning(LOCATION,
+					"Wrong number of return values for Lua SEXP '%s'! Expected 0, got " SIZE_T_ARG ".",
+					_name.c_str(),
+					retVals.size());
+		}
+		return SEXP_TRUE;
+	default:
+		return SEXP_TRUE;
+	}
+}
+int LuaSEXP::execute(int node) {
+	LuaValueList luaParameters;
+
+	// We need to adapt how we handle parameters based on their type. We use this variable to keep track of which parameter
+	// we are currently looking at
+	int argnum = 0;
+	while (node != -1) {
+		if (argnum < (int) _argument_types.size()) {
+			// This is a parameter in the normal list so we add it to the normal parameter list
+			luaParameters.push_back(sexpToLua(node, argnum));
+
+			node = CDR(node);
+			++argnum;
+		} else {
+			// The varargs part is handled in chunks so that scripts can use the data more easily
+			// Every repeat pattern instance is put into its own table
+			LuaTable varargs_part = LuaTable::create(_action.getLuaState());
+
+			// Iterate over all parameters in this varargs pattern and put them all in the table
+			// If we reach the end of the parameter list inside this for loop we just exit since all parameters are optional
+			for (auto i = 0; i < (int)_varargs_type_pattern.size() && node != -1; ++i) {
+				// i + 1 since lua arrays are 1-indexed
+				varargs_part.addValue(i + 1, sexpToLua(node, argnum));
+
+				node = CDR(node);
+				++argnum;
+			}
+
+			luaParameters.push_back(varargs_part);
+		}
+	}
+
+	// All parameters are now in LuaValues, time to call our function
+	try {
+		auto retVals = _action.call(luaParameters);
+
+		return getSexpReturnValue(retVals);
+	} catch(const LuaException&) {
+		// This is only caused by an error in the function but those are already handled by our error function
+		// These values are close to what the existing SEXP code does if errors occur while processing a SEXP
+		switch(_return_type) {
+		case OPR_NUMBER:
+		case OPR_BOOL:
+			return SEXP_NAN;
+		case OPR_NULL:
+			return SEXP_TRUE;
+		default:
+			return SEXP_NAN;
+		}
+	}
+}
+int LuaSEXP::getReturnType() {
+	return _return_type;
+}
+
+int LuaSEXP::getSubcategory() {
+	return _subcategory;
+}
+int LuaSEXP::getCategory() {
+	if (_category == OP_CATEGORY_CHANGE) {
+		// "Change" is a special case since we can't add new SEXPs to the primary category
+		return OP_CATEGORY_CHANGE2;
+	}
+	return _category;
+}
+void LuaSEXP::parseTable() {
+	required_string("$Category:");
+	SCP_string category;
+	stuff_string(category, F_NAME);
+
+	_category = get_category(category);
+	if (_category < 0) {
+		error_display(0, "Invalid category '%s' found. New main categories can't be added!", category.c_str());
+		_category = OP_CATEGORY_CHANGE; // Default to change2 so we have a valid value later on
+	}
+
+	required_string("$Subcategory:");
+	SCP_string subcategory;
+	stuff_string(subcategory, F_NAME);
+
+	_subcategory = get_subcategory(subcategory);
+	if (_subcategory < 0) {
+		// Unknown subcategory so we need to add this one
+		_subcategory = sexp::add_subcategory(_category, subcategory);
+		if (_subcategory < 0) {
+			// Couldn't add subcategory!
+			error_display(0,
+						  "No more space for subcategory '%s' free in category '%s'!",
+						  subcategory.c_str(),
+						  category.c_str());
+
+			// Default to the first subcategory in our category, hopefully it will exist...
+			_subcategory = 0x0000 | _category;
+		}
+	} else if ((_subcategory & OP_CATEGORY_MASK) != _category) {
+		error_display(0,
+					  "Subcategory '%s' is in a different category than the specified category! Subcategory names must be unique.",
+					  subcategory.c_str());
+
+		// Default to the first subcategory in our category, hopefully it will exist...
+		_subcategory = 0x0000 | _category;
+	}
+
+	required_string("$Minimum Arguments:");
+
+	stuff_int(&_min_args);
+
+	if (_min_args < 0) {
+		error_display(0, "Minimum argument number must be at least 0! Got %d.", _min_args);
+		_min_args = 0;
+	}
+
+	if (optional_string("$Maximum Arguments:")) {
+		stuff_int(&_max_args);
+
+		if (_max_args < 0) {
+			error_display(0, "Maximum argument number must be at least 0! Got %d.", _max_args);
+			_max_args = 0;
+		}
+	} else {
+		_max_args = INT_MAX;
+	}
+
+	if (_max_args < _min_args) {
+		error_display(0, "Maximum argument number must be greater or equal to minimum number of arguments!");
+		std::swap(_min_args, _max_args);
+	}
+
+	if (optional_string("$Return Type:")) {
+		SCP_string type;
+		stuff_string(type, F_NAME);
+
+		_return_type = get_return_type(type);
+
+		if (_return_type < 0) {
+			error_display(0, "Unknown return type '%s'!", type.c_str());
+			_return_type = OPR_NULL;
+		}
+	} else {
+		_return_type = OPR_NULL;
+	}
+
+	SCP_stringstream help_text;
+	help_text << _name << "\r\n";
+
+	required_string("$Description:");
+
+	SCP_string description;
+	stuff_string(description, F_NAME);
+
+	help_text << "\t" << description << "\r\n";
+
+	bool variable_arg_part = false;
+	if (optional_string("$Repeat")) {
+		help_text << "Rest: (The following pattern repeats)\r\n";
+		variable_arg_part = true;
+	}
+
+	while (optional_string("$Parameter:")) {
+		required_string("+Description:");
+
+		SCP_string param_desc;
+		stuff_string(param_desc, F_NAME);
+
+		if (variable_arg_part) {
+			help_text << "\t" << _varargs_type_pattern.size() + 1;
+		} else {
+			help_text << "\t" << _argument_types.size() + 1;
+		}
+		help_text << ": " << param_desc << "\r\n";
+
+		required_string("+Type:");
+		SCP_string type_str;
+		stuff_string(type_str, F_NAME);
+
+		auto type = get_parameter_type(type_str);
+		if (type < 0) {
+			error_display(0, "Unknown parameter type '%s'!", type_str.c_str());
+			type = OPF_STRING;
+		}
+
+		if (variable_arg_part) {
+			_varargs_type_pattern.push_back(type);
+		} else {
+			_argument_types.push_back(type);
+		}
+
+		if (optional_string("$Repeat")) {
+			if (!variable_arg_part) {
+				help_text << "Rest: (The following pattern repeats)\r\n";
+				variable_arg_part = true;
+			} else {
+				error_display(0, "A second $Repeat has been encountered! Only one may appear in the parameter list.");
+			}
+		}
+	}
+
+	_help_text = help_text.str();
+}
+void LuaSEXP::setAction(const luacpp::LuaFunction& action) {
+	Assertion(action.isValid(), "Invalid function handle supplied!");
+	_action = action;
+}
+
+luacpp::LuaFunction LuaSEXP::getAction() const {
+	return _action;
+}
+}

--- a/code/parse/sexp/LuaSEXP.h
+++ b/code/parse/sexp/LuaSEXP.h
@@ -1,0 +1,53 @@
+#pragma once
+
+#include "parse/sexp/DynamicSEXP.h"
+
+#include "scripting/lua/LuaFunction.h"
+#include "scripting/lua/LuaTable.h"
+
+#include "parse/sexp.h"
+
+namespace sexp {
+
+class LuaSEXP : public DynamicSEXP {
+	luacpp::LuaFunction _action;
+
+	int _min_args;
+	int _max_args;
+
+	SCP_vector<int> _argument_types; //!< These are the types of the static, non-repeating arguments
+	SCP_vector<int> _varargs_type_pattern; //!< This is the pattern for the variable argument part of the SEXP
+
+	int _return_type = OPR_NULL;
+
+	int _category;
+	int _subcategory;
+
+	luacpp::LuaValue sexpToLua(int node, int argnum) const;
+ public:
+	explicit LuaSEXP(const SCP_string& name);
+
+	int getMinimumArguments() override;
+
+	int getMaximumArguments() override;
+
+	int getArgumentType(int argnum) const override;
+
+	int execute(int node) override;
+
+	int getReturnType() override;
+
+	int getSubcategory() override;
+
+	int getCategory() override;
+
+	void parseTable();
+
+	void setAction(const luacpp::LuaFunction& action);
+
+	luacpp::LuaFunction getAction() const;
+	int getSexpReturnValue(const luacpp::LuaValueList& retVals) const;
+};
+
+}
+

--- a/code/parse/sexp/sexp_lookup.cpp
+++ b/code/parse/sexp/sexp_lookup.cpp
@@ -1,0 +1,149 @@
+
+#include "parse/sexp/sexp_lookup.h"
+#include "parse/sexp/LuaSEXP.h"
+
+#include "parse/sexp.h"
+#include "parse/parselo.h"
+
+#include <memory>
+
+namespace {
+using namespace sexp;
+
+SCP_unordered_map<int, std::unique_ptr<sexp::DynamicSEXP>> operator_const_mapping;
+
+// This contains which operator is the next free operator in a specific category
+SCP_unordered_map<int, int> next_free_operator_mapping;
+
+int get_next_free_operator(int category) {
+	Assertion(category != OP_CATEGORY_CHANGE, "The primary change category is full so it can't be used for new operators!");
+
+	auto iter = next_free_operator_mapping.find(category);
+
+	if (iter == next_free_operator_mapping.end()) {
+		// The next operator number isn't initialized yet so we initialize that here
+		int max_op_value = 0;
+		for (auto& oper : Operators) {
+			// We need to do some ugly bit masking here since the SEXP system uses different bytes of the operator number for storing various things
+			if ((oper.value & OP_CATEGORY_MASK) == category) {
+				// This operator has the right category
+				// We only store the number part which is the lowest byte of the operator number
+				max_op_value = std::max(max_op_value, oper.value & 0xFF);
+			}
+		}
+		iter = next_free_operator_mapping.insert(std::make_pair(category, max_op_value + 1)).first;
+	}
+
+	auto value = iter->second;
+	iter->second = value + 1; // Update the value inside the iterator
+	return value;
+}
+
+void parse_sexp_table(const char* filename) {
+	try {
+		read_file_text(filename, CF_TYPE_TABLES);
+		reset_parse();
+
+		required_string("#Lua SEXPs");
+
+		// These characters may not appear in a SEXP name
+		const char* INVALID_CHARS = "()\"'\t ";
+
+		while (optional_string("$Operator:")) {
+			SCP_string name;
+			stuff_string(name, F_NAME);
+
+			if (std::strpbrk(name.c_str(), INVALID_CHARS) != nullptr) {
+				error_display(0, "Found invalid SEXP name '%s'!", name.c_str());
+
+				// Skip the invalid entry
+				skip_to_start_of_string_either("$Operator:", "#End");
+				continue;
+			}
+			if (get_operator_index(name.c_str()) >= 0) {
+				error_display(0, "The SEXP '%s' is already defined!", name.c_str());
+
+				// Skip the invalid entry
+				skip_to_start_of_string_either("$Operator:", "#End");
+				continue;
+			}
+
+			std::unique_ptr<DynamicSEXP> instance(new LuaSEXP(name));
+			auto luaSexp = static_cast<LuaSEXP*>(instance.get());
+			luaSexp->parseTable();
+
+			add_dynamic_sexp(std::move(instance));
+		}
+
+		required_string("#End");
+	} catch (const parse::ParseException& e) {
+		mprintf(("TABLES: Unable to parse '%s'!  Error message = %s.\n", filename, e.what()));
+		return;
+	}
+}
+
+}
+
+namespace sexp {
+
+void add_dynamic_sexp(std::unique_ptr<DynamicSEXP>&& sexp) {
+	auto name = sexp->getName();
+	auto help_text = sexp->getHelpText();
+
+	sexp_oper new_op;
+	new_op.text = name;
+	new_op.min = sexp->getMinimumArguments();
+	new_op.max = sexp->getMaximumArguments();
+
+	// For now, all dynamic SEXPS are only valid in missions
+	new_op.value = get_next_free_operator(sexp->getCategory()) | sexp->getCategory() | OP_NONCAMPAIGN_FLAG;
+	new_op.type = SEXP_ACTION_OPERATOR;
+
+	operator_const_mapping.insert(std::make_pair(new_op.value, std::move(sexp)));
+
+	// Now actually add the operator to the SEXP containers
+	Operators.push_back(new_op);
+
+	sexp_help_struct new_help;
+	new_help.id = new_op.value;
+	new_help.help = help_text;
+	Sexp_help.push_back(new_help);
+}
+DynamicSEXP* get_dynamic_sexp(int operator_const) {
+	auto iter = operator_const_mapping.find(operator_const);
+	if (iter == operator_const_mapping.end()) {
+		return nullptr;
+	}
+
+	return iter->second.get();
+}
+void dynamic_sexp_init() {
+	parse_modular_table("*-sexp.tbm", parse_sexp_table, CF_TYPE_TABLES);
+}
+void dynamic_sexp_shutdown() {
+	operator_const_mapping.clear();
+}
+int add_subcategory(int parent_category, const SCP_string& name) {
+	// Another hack to make sure change2 is interpreted as the normal change category
+	if (parent_category == OP_CATEGORY_CHANGE2) {
+		parent_category = OP_CATEGORY_CHANGE;
+	}
+
+	int max_subcategory_value = 0;
+	for (auto& subcat : op_submenu) {
+		if ((subcat.id & OP_CATEGORY_MASK) == parent_category) {
+			max_subcategory_value = std::max(max_subcategory_value, subcat.id & SUBCATEGORY_MASK);
+		}
+	}
+
+	if (max_subcategory_value >= SUBCATEGORY_MASK) {
+		// No more entries left in this subcategory!
+		return -1;
+	}
+
+	int subcategory_id = (max_subcategory_value + 1) | parent_category;
+	op_submenu.push_back({ name, subcategory_id });
+	return subcategory_id;
+}
+
+}

--- a/code/parse/sexp/sexp_lookup.h
+++ b/code/parse/sexp/sexp_lookup.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include "parse/sexp/DynamicSEXP.h"
+
+namespace sexp {
+
+/**
+ * @brief Adds the sexp to the dynamic SEXP system
+ *
+ * The pointer is transferred to the ownership of the SEXP system and may not be deleted by outside code.
+ *
+ * @warning The new SEXP name is not validated! If the name conflicts with an existing name then this SEXP will not be
+ * usable!
+ *
+ * @param sexp The sexp to add
+ */
+void add_dynamic_sexp(std::unique_ptr<DynamicSEXP>&& sexp);
+
+/**
+ * @brief Given an operator constant, return the associated dynamic SEXP
+ * @param operator_const The operator constant to check
+ * @return The SEXP pointer or @c nullptr if the constant is not known.
+ */
+DynamicSEXP* get_dynamic_sexp(int operator_const);
+
+/**
+ * @brief Dynamically add a new subcategory to the SEXP system
+ *
+ * @warning Subcategory names must be globally unique! This is not validated by this function.
+ *
+ * @param parent_category The parent category of this category
+ * @param name The display name of the category
+ * @return The new category identifier or -1 on error
+ */
+int add_subcategory(int parent_category, const SCP_string& name);
+
+/**
+ * @brief Initializes the dynamic SEXP system
+ *
+ * This parses the SEXP table and initializes the resources required for dynamic SEXPs.
+ */
+void dynamic_sexp_init();
+
+/**
+ * @brief Frees the registered dynamic SEXPs
+ *
+ * @warning This just makes sure that the resources of the SEXPs are freed in an orderly fashion. This does not clean up
+ * the Operators vector of the SEXP system so it should only be used at game shutdown.
+ */
+void dynamic_sexp_shutdown();
+
+}

--- a/code/scripting/api/libs/base.cpp
+++ b/code/scripting/api/libs/base.cpp
@@ -259,6 +259,10 @@ ADE_FUNC(XSTR,
 	return ade_set_args(L, "s", translated.c_str());
 }
 
+ADE_FUNC(inMissionEditor, l_Base, nullptr, "Determine if the current script is running in the mission editor (e.g. FRED2). This should be used to control which code paths will be executed even if running in the editor.", "boolean", "true when we are in the mission editor, false otherwise") {
+	return ade_set_args(L, "b", Fred_running != 0);
+}
+
 //**********SUBLIBRARY: Base/Events
 ADE_LIB_DERIV(l_Base_Events, "GameEvents", NULL, "Freespace 2 game events", l_Base);
 

--- a/code/scripting/api/libs/mission.cpp
+++ b/code/scripting/api/libs/mission.cpp
@@ -19,6 +19,7 @@
 #include "scripting/api/objs/shipclass.h"
 #include "scripting/api/objs/vecmath.h"
 #include "scripting/api/objs/weaponclass.h"
+#include "scripting/api/objs/LuaSEXP.h"
 
 #include "parse/sexp.h"
 #include "parse/parselo.h"
@@ -38,6 +39,12 @@
 #include "mission/missionload.h"
 #include "gamesequence/gamesequence.h"
 
+#include "scripting/lua/LuaTable.h"
+#include "scripting/lua/LuaFunction.h"
+
+#include "parse/sexp/DynamicSEXP.h"
+#include "parse/sexp/LuaSEXP.h"
+#include "parse/sexp/sexp_lookup.h"
 
 extern int ships_inited;
 
@@ -1028,6 +1035,43 @@ ADE_FUNC(isInCampaign, l_Mission, NULL, "Get whether or not the current mission 
 
 ADE_FUNC(getMissionTitle, l_Mission, NULL, "Get the title of the current mission", "string", "The mission title or an empty string if currently not in mission") {
 	return ade_set_args(L, "s", The_mission.name);
+}
+
+ADE_LIB_DERIV(l_Mission_LuaSEXPs, "LuaSEXPs", NULL, "Lua SEXPs", l_Mission);
+
+ADE_INDEXER(l_Mission_LuaSEXPs, "string Name", "Gets a handle of a Lua SEXP", "LuaSEXP", "Lua SEXP handle or invalid handle on error")
+{
+	const char* name = nullptr;
+	if( !ade_get_args(L, "*s", &name) ) {
+		return ade_set_error( L, "o", l_LuaSEXP.Set( lua_sexp_h() ) );
+	}
+
+	if (name == nullptr) {
+		return ade_set_error(L, "o", l_LuaSEXP.Set(lua_sexp_h()));
+	}
+
+	if (ADE_SETTING_VAR) {
+		LuaError(L, "Setting of Lua SEXPs is not supported!");
+	}
+
+	auto op = get_operator_const(name);
+
+	if (op == 0) {
+		return ade_set_args(L, "o", l_LuaSEXP.Set(lua_sexp_h()));
+	}
+
+	auto dynamicSEXP = sexp::get_dynamic_sexp(op);
+
+	if (dynamicSEXP == nullptr) {
+		return ade_set_args(L, "o", l_LuaSEXP.Set(lua_sexp_h()));
+	}
+
+	if (typeid(*dynamicSEXP) != typeid(sexp::LuaSEXP)) {
+		LuaError(L, "Specified dynamic SEXP name does not refer to a Lua SEXP!");
+		return ade_set_error(L, "o", l_LuaSEXP.Set(lua_sexp_h()));
+	}
+
+	return ade_set_args(L, "o", l_LuaSEXP.Set(lua_sexp_h(static_cast<sexp::LuaSEXP*>(dynamicSEXP))));
 }
 
 //****LIBRARY: Campaign

--- a/code/scripting/api/objs/LuaSEXP.cpp
+++ b/code/scripting/api/objs/LuaSEXP.cpp
@@ -1,0 +1,42 @@
+//
+//
+
+#include "LuaSEXP.h"
+
+namespace scripting {
+namespace api {
+
+lua_sexp_h::lua_sexp_h(sexp::LuaSEXP* handle) : sexp_handle(handle) {
+}
+lua_sexp_h::lua_sexp_h() : sexp_handle(nullptr) {
+}
+bool lua_sexp_h::isValid() {
+	return sexp_handle != nullptr;
+}
+
+ADE_OBJ(l_LuaSEXP, lua_sexp_h, "LuaSEXP", "Lua SEXP handle");
+
+ADE_VIRTVAR(Action, l_LuaSEXP, "function action", "The action of this SEXP", "function", "The action function or nil on error") {
+	lua_sexp_h lua_sexp;
+	luacpp::LuaFunction action_arg;
+	if (!ade_get_args(L, "o|u", l_LuaSEXP.Get(&lua_sexp), &action_arg)) {
+		return ADE_RETURN_NIL;
+	}
+
+	if (!lua_sexp.isValid()) {
+		return ADE_RETURN_NIL;
+	}
+
+	if (ADE_SETTING_VAR) {
+		Assertion(action_arg.isValid(), "Action function reference must be valid!");
+
+		lua_sexp.sexp_handle->setAction(action_arg);
+	}
+
+	auto action = lua_sexp.sexp_handle->getAction();
+	return ade_set_args(L, "u", &action);
+}
+
+}
+}
+

--- a/code/scripting/api/objs/LuaSEXP.h
+++ b/code/scripting/api/objs/LuaSEXP.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "scripting/ade_api.h"
+#include "parse/sexp/LuaSEXP.h"
+
+namespace scripting {
+namespace api {
+
+struct lua_sexp_h {
+	sexp::LuaSEXP* sexp_handle;
+
+	lua_sexp_h(sexp::LuaSEXP* sexp_handle);
+	lua_sexp_h();
+
+	bool isValid();
+};
+
+DECLARE_ADE_OBJ(l_LuaSEXP, lua_sexp_h);
+
+}
+}
+

--- a/code/scripting/lua/LuaArgs.h
+++ b/code/scripting/lua/LuaArgs.h
@@ -31,7 +31,7 @@ inline int getArgsInternal(lua_State* L, bool, int, int) {
 
 template<typename T>
 inline int popArgumentValue(lua_State* L, T& target, bool& optionalOut, int& stackIndexOut) {
-	target = convert::popValue<T>(L, stackIndexOut, false);
+	convert::popValue(L, target, stackIndexOut, false);
 	stackIndexOut = stackIndexOut + 1;
 
 	return 1;

--- a/code/scripting/lua/LuaConvert.cpp
+++ b/code/scripting/lua/LuaConvert.cpp
@@ -1,0 +1,225 @@
+
+#include "LuaConvert.h"
+
+namespace
+{
+using namespace scripting;
+
+ade_table_entry& getTableEntry(size_t idx) {
+	return ade_manager::getInstance()->getEntry(idx);
+}
+}
+
+namespace luacpp {
+namespace convert {
+namespace internal {
+
+bool isValidIndex(lua_State* state, int index) {
+	if (1 <= std::abs(index) && std::abs(index) <= lua_gettop(state)) {
+		return true;
+	} else {
+		return false;
+	}
+}
+
+}
+
+void pushValue(lua_State* luaState, const double& value) {
+	lua_pushnumber(luaState, value);
+}
+void pushValue(lua_State* luaState, const float& value) {
+	lua_pushnumber(luaState, value);
+}
+void pushValue(lua_State* luaState, const int& value) {
+	lua_pushnumber(luaState, value);
+}
+void pushValue(lua_State* luaState, const size_t& value) {
+	lua_pushnumber(luaState, (lua_Number)value);
+}
+void pushValue(lua_State* luaState, const std::string& value) {
+	lua_pushlstring(luaState, value.c_str(), value.size());
+}
+void pushValue(lua_State* luaState, const char* value) {
+	lua_pushstring(luaState, value);
+}
+void pushValue(lua_State* luaState, const bool& value) {
+	lua_pushboolean(luaState, value);
+}
+void pushValue(lua_State* luaState, const lua_CFunction& value) {
+	lua_pushcfunction(luaState, value);
+}
+
+void pushValue(lua_State* L, const ade_odata& od) {
+	using namespace scripting;
+
+	//WMC - char must be 1 byte, foo.
+	static_assert(sizeof(char) == 1, "char must be 1 byte!");
+	//WMC - step by step
+
+	//Create new LUA object and get handle
+	char *newod = (char*)lua_newuserdata(L, od.size + sizeof(ODATA_SIG_TYPE));
+	//Create or get object metatable
+	luaL_getmetatable(L, getTableEntry(od.idx).Name);
+	//Set the metatable for the object
+	lua_setmetatable(L, -2);
+
+	//Copy the actual object data to the Lua object
+	memcpy(newod, od.buf, od.size);
+
+	//Also copy in the unique sig
+	if (od.sig != NULL)
+		memcpy(newod + od.size, od.sig, sizeof(ODATA_SIG_TYPE));
+	else
+	{
+		ODATA_SIG_TYPE tempsig = ODATA_SIG_DEFAULT;
+		memcpy(newod + od.size, &tempsig, sizeof(ODATA_SIG_TYPE));
+	}
+}
+
+bool popValue(lua_State* luaState, int& target, int stackposition, bool remove) {
+	double temp;
+
+	auto ret = popValue(luaState, temp, stackposition, remove);
+	if (ret) {
+		target = (int)temp;
+	}
+	return ret;
+}
+bool popValue(lua_State* luaState, size_t& target, int stackposition, bool remove) {
+	double temp;
+
+	auto ret = popValue(luaState, temp, stackposition, remove);
+	if (ret) {
+		target = (size_t)temp;
+	}
+	return ret;
+}
+bool popValue(lua_State* luaState, float& target, int stackposition, bool remove) {
+	double temp;
+
+	auto ret = popValue(luaState, temp, stackposition, remove);
+	if (ret) {
+		target = (float)temp;
+	}
+	return ret;
+}
+bool popValue(lua_State* luaState, double& target, int stackposition, bool remove) {
+	if (!internal::isValidIndex(luaState, stackposition)) {
+		return false;
+	}
+
+	if (!lua_isnumber(luaState, stackposition)) {
+		return false;
+	} else {
+		target = lua_tonumber(luaState, stackposition);
+
+		if (remove) {
+			lua_remove(luaState, stackposition);
+		}
+
+		return true;
+	}
+}
+bool popValue(lua_State* luaState, std::string& target, int stackposition, bool remove) {
+	if (!internal::isValidIndex(luaState, stackposition)) {
+		return false;
+	}
+
+	if (!lua_isstring(luaState, stackposition)) {
+		return false;
+	} else {
+		size_t size;
+		const char* string = lua_tolstring(luaState, stackposition, &size);
+		target.assign(string, size);
+
+		if (remove) {
+			lua_remove(luaState, stackposition);
+		}
+
+		return true;
+	}
+}
+
+bool popValue(lua_State* luaState, bool& target, int stackposition, bool remove) {
+	if (!internal::isValidIndex(luaState, stackposition)) {
+		return false;
+	}
+
+	if (!lua_isboolean(luaState, stackposition)) {
+		return false;
+	} else {
+		target = lua_toboolean(luaState, stackposition) != 0;
+
+		if (remove) {
+			lua_remove(luaState, stackposition);
+		}
+
+		return target;
+	}
+}
+
+bool popValue(lua_State* luaState, lua_CFunction& target, int stackposition, bool remove) {
+	if (!internal::isValidIndex(luaState, stackposition)) {
+		return false;
+	}
+
+	if (!lua_iscfunction(luaState, stackposition)) {
+		return false;
+	} else {
+		target = lua_tocfunction(luaState, stackposition);
+
+		if (remove) {
+			lua_remove(luaState, stackposition);
+		}
+
+		return true;
+	}
+}
+
+bool popValue(lua_State* L, scripting::ade_odata& od, int stackposition, bool remove) {
+	//WMC - Get metatable
+	lua_getmetatable(L, stackposition);
+	int mtb_ldx = lua_gettop(L);
+	Assert(!lua_isnil(L, -1));
+
+	//Get ID
+	lua_pushstring(L, "__adeid");
+	lua_rawget(L, mtb_ldx);
+
+	if (lua_tonumber(L, -1) != od.idx)
+	{
+		lua_pushstring(L, "__adederivid");
+		lua_rawget(L, mtb_ldx);
+		if ((uint)lua_tonumber(L, -1) != od.idx)
+		{
+			// Issue the LuaError here since this is the only place where we have all relevant information
+			LuaError(L, "Argument %d is the wrong type of userdata; '%s' given, but '%s' expected", stackposition, getTableEntry((uint)lua_tonumber(L, -2)).Name, getTableEntry(od.idx).GetName());
+			return false;
+		}
+		lua_pop(L, 1);
+	}
+	lua_pop(L, 2);
+	if (od.size != ODATA_PTR_SIZE)
+	{
+		memcpy(od.buf, lua_touserdata(L, stackposition), od.size);
+		if (od.sig != NULL) {
+			//WMC - char must be 1
+			Assert(sizeof(char) == 1);
+			//WMC - Yuck. Copy sig data.
+			//Maybe in the future I'll do a packet userdata thing.
+			(*od.sig) = *(ODATA_SIG_TYPE*)(*(char **)od.buf + od.size);
+		}
+	}
+	else {
+		(*(void**)od.buf) = lua_touserdata(L, stackposition);
+	}
+
+	if (remove) {
+		lua_remove(L, stackposition);
+	}
+
+	return true;
+}
+
+}
+}

--- a/code/scripting/lua/LuaConvert.h
+++ b/code/scripting/lua/LuaConvert.h
@@ -7,6 +7,8 @@
 #include "LuaConvert.h"
 #include "LuaReference.h"
 
+#include "scripting/ade.h"
+
 #include <cstdlib>
 
 namespace luacpp {
@@ -27,31 +29,30 @@ namespace luacpp {
  */
 namespace convert {
 
-namespace {
-
-bool isValidIndex(lua_State* state, int index) {
-	if (1 <= std::abs(index) && std::abs(index) <= lua_gettop(state)) {
-		return true;
-	} else {
-		return false;
-	}
+namespace internal {
+bool isValidIndex(lua_State* state, int index);
 }
 
-}
-/**
- * @brief Pushes the lua value of the given @c value onto the lua stack.
- * @param luaState The lua_State to push the values to
- * @param value The value which should be pushed.
- *
- * @tparam ValueType The type of the value being pushed, for a custom type you
- * 	need to specialize this template.
- */
-template<class ValueType>
-void pushValue(lua_State* luaState, const ValueType& value);
+void pushValue(lua_State* luaState, const double& value);
 
+void pushValue(lua_State* luaState, const float& value);
+
+void pushValue(lua_State* luaState, const int& value);
+
+void pushValue(lua_State* luaState, const size_t& value);
+
+void pushValue(lua_State* luaState, const std::string& value);
+
+void pushValue(lua_State* luaState, const char* value);
+
+void pushValue(lua_State* luaState, const bool& value);
+
+void pushValue(lua_State* luaState, const lua_CFunction& value);
+
+void pushValue(lua_State* L, const scripting::ade_odata& value);
 
 /**
- * @brief Convinient function for string literals
+ * @brief Convenience function for string literals
  *
  * @param luaState The lua_State to push the values to
  * @param value The value which should be pushed.
@@ -59,182 +60,26 @@ void pushValue(lua_State* luaState, const ValueType& value);
  */
 template<size_t N>
 inline void pushValue(lua_State* luaState, const char(& value)[N]) {
-	pushValue<const char*>(luaState, value);
-}
-
-template<>
-inline void pushValue<double>(lua_State* luaState, const double& value) {
-	lua_pushnumber(luaState, value);
-}
-
-template<>
-inline void pushValue<float>(lua_State* luaState, const float& value) {
-	lua_pushnumber(luaState, value);
-}
-
-template<>
-inline void pushValue<int>(lua_State* luaState, const int& value) {
-	lua_pushnumber(luaState, value);
-}
-
-template<>
-inline void pushValue<size_t>(lua_State* luaState, const size_t& value) {
-	lua_pushnumber(luaState, (lua_Number)value);
-}
-
-template<>
-inline void pushValue<std::string>(lua_State* luaState, const std::string& value) {
-	lua_pushlstring(luaState, value.c_str(), value.size());
-}
-
-template<>
-inline void pushValue<const char*>(lua_State* luaState, const char* const& value) {
-	lua_pushstring(luaState, value);
-}
-
-template<>
-inline void pushValue<bool>(lua_State* luaState, const bool& value) {
-	lua_pushboolean(luaState, value);
-}
-
-template<>
-inline void pushValue<lua_CFunction>(lua_State* luaState,
-							  const lua_CFunction& value) {
-	lua_pushcfunction(luaState, value);
+	pushValue(luaState, (const char*)value);
 }
 
 
-/**
-* @brief Pops a value or throws an exception.
-* If the conversion of the lua value fails, this function throws an exception.
-*
-* @param luaState The lua state
-* @param stackPos The stack position of the value. Defaults to -1.
-* @param remove Specifies if the value should be removed. Defaults to true.
-* @return ValueType The type of value to be poped from the stack, must have a default and copy constructor.
-*/
-template<class ValueType>
-ValueType popValue(lua_State* luaState, int stackPos = -1, bool remove = true);
+bool popValue(lua_State* luaState, float& target, int stackposition = -1, bool remove = true);
 
+bool popValue(lua_State* luaState, double& target, int stackposition = -1, bool remove = true);
 
-template<>
-inline double popValue<double>(lua_State* luaState, int stackposition, bool remove) {
-	if (!isValidIndex(luaState, stackposition)) {
-		throw LuaException("Specified stack position is not valid!");
-	}
+bool popValue(lua_State* luaState, int& target, int stackposition = -1, bool remove = true);
 
-	if (!lua_isnumber(luaState, stackposition)) {
-		throw LuaException("Specified position is no number!");
-	} else {
-		double number = lua_tonumber(luaState, stackposition);
+bool popValue(lua_State* luaState, size_t& target, int stackposition = -1, bool remove = true);
 
-		if (remove) {
-			lua_remove(luaState, stackposition);
-		}
+bool popValue(lua_State* luaState, std::string& target, int stackposition = -1, bool remove = true);
 
-		return number;
-	}
-}
+bool popValue(lua_State* luaState, bool& target, int stackposition = -1, bool remove = true);
 
-template<>
-inline float popValue<float>(lua_State* luaState, int stackposition, bool remove) {
-	return static_cast<float>(popValue<double>(luaState, stackposition, remove));
-}
+bool popValue(lua_State* luaState, lua_CFunction& target, int stackposition = -1, bool remove = true);
 
-template<>
-inline int popValue<int>(lua_State* luaState, int stackposition, bool remove) {
-	return static_cast<int>(popValue<double>(luaState, stackposition, remove));
-}
+bool popValue(lua_State* L, scripting::ade_odata& od, int stackposition = -1, bool remove = true);
 
-template<>
-inline size_t popValue<size_t>(lua_State* luaState, int stackposition, bool remove) {
-	return static_cast<size_t>(popValue<double>(luaState, stackposition, remove));
-}
-
-template<>
-inline std::string popValue<std::string>(lua_State* luaState, int stackposition, bool remove) {
-	if (!isValidIndex(luaState, stackposition)) {
-		throw LuaException("Specified stack position is not valid!");
-	}
-
-	if (!lua_isstring(luaState, stackposition)) {
-		throw LuaException("Specified index is no string!");
-	} else {
-		std::string target;
-
-		size_t size;
-		const char* string = lua_tolstring(luaState, stackposition, &size);
-		target.assign(string, size);
-
-		if (remove) {
-			lua_remove(luaState, stackposition);
-		}
-
-		return target;
-	}
-}
-
-template<>
-inline bool popValue<bool>(lua_State* luaState, int stackposition, bool remove) {
-	if (!isValidIndex(luaState, stackposition)) {
-		throw LuaException("Specified stack position is not valid!");
-	}
-
-	if (!lua_isboolean(luaState, stackposition)) {
-		throw LuaException("Specified index is no boolean value!");
-	} else {
-		bool target = lua_toboolean(luaState, stackposition) != 0;
-
-		if (remove) {
-			lua_remove(luaState, stackposition);
-		}
-
-		return target;
-	}
-}
-
-template<>
-inline lua_CFunction popValue<lua_CFunction>(lua_State* luaState, int stackposition, bool remove) {
-	if (!isValidIndex(luaState, stackposition)) {
-		throw LuaException("Specified stack position is not valid!");
-	}
-
-	if (!lua_iscfunction(luaState, stackposition)) {
-		throw LuaException("Specified index is no C-function!");
-	} else {
-		lua_CFunction target = lua_tocfunction(luaState, stackposition);
-
-		if (remove) {
-			lua_remove(luaState, stackposition);
-		}
-
-		return target;
-	}
-}
-
-/**
- * @brief Pops a value from the lua stack and stores it.
- *
- * This function checks if the topmost value on the lua stack is of the right type and if
- * that is the case pops this value from the stack and stors the value inside @c target.
- *
- * @param luaState The lua_State which should be checked
- * @param target The location where the value should be stored
- * @param stackPos The position of the value that should be used. Defaults to -1
- * @param remove @c true to remove the value from the stack, @c false to leave it on the stack
- * @return @c true when the value could successfully be converted,
- * 		@c false if the topmost value is not of the right type.
- */
-template<class ValueType>
-inline bool popValue(lua_State* L, ValueType& target, int stackPos = -1, bool remove = true) {
-	try {
-		target = popValue<ValueType>(L, stackPos, remove);
-		return true;
-	}
-	catch (LuaException&) {
-		return false;
-	}
-}
 }
 }
 

--- a/code/scripting/lua/LuaFunction.cpp
+++ b/code/scripting/lua/LuaFunction.cpp
@@ -140,7 +140,9 @@ LuaValueList LuaFunction::call(const LuaValueList& args) {
 			err_msg = "Invalid lua value on stack!";
 			lua_pop(_luaState, 1); // Remove the value on the stack
 		} else {
-			err_msg = convert::popValue<std::string>(_luaState);
+			if (!convert::popValue(_luaState, err_msg)) {
+				err_msg = "Failed to get error message from Lua stack!";
+			}
 		}
 
 		// Throw exception with generated message
@@ -154,4 +156,23 @@ LuaValueList LuaFunction::call(const LuaValueList& args) {
 		throw exception;
 	}
 }
+
+bool ::luacpp::convert::popValue(lua_State* luaState, LuaFunction& target, int stackposition, bool remove) {
+	if (!internal::isValidIndex(luaState, stackposition)) {
+		return false;
+	}
+
+	if (!lua_isfunction(luaState, stackposition)) {
+		return false;
+	} else {
+		target.setReference(UniqueLuaReference::create(luaState, stackposition));
+
+		if (remove) {
+			lua_remove(luaState, stackposition);
+		}
+
+		return true;
+	}
+}
+
 }

--- a/code/scripting/lua/LuaFunction.h
+++ b/code/scripting/lua/LuaFunction.h
@@ -121,25 +121,7 @@ class LuaFunction: public LuaValue {
 
 namespace convert {
 
-template<>
-inline LuaFunction popValue<LuaFunction>(lua_State* luaState, int stackposition, bool remove) {
-	if (!isValidIndex(luaState, stackposition)) {
-		throw LuaException("Specified stack position is not valid!");
-	}
-
-	if (!lua_isfunction(luaState, stackposition)) {
-		throw LuaException("Specified index is no function!");
-	} else {
-		LuaFunction target;
-		target.setReference(UniqueLuaReference::create(luaState, stackposition));
-
-		if (remove) {
-			lua_remove(luaState, stackposition);
-		}
-
-		return target;
-	}
-}
+bool popValue(lua_State* luaState, LuaFunction& target, int stackposition = -1, bool remove = true);
 
 }
 }

--- a/code/scripting/lua/LuaTable.cpp
+++ b/code/scripting/lua/LuaTable.cpp
@@ -132,4 +132,23 @@ void LuaTableIterator::toNextElement() {
 std::pair<LuaValue, LuaValue> LuaTableIterator::getElement() {
 	return _currentVal;
 }
+
+bool convert::popValue(lua_State* luaState, LuaTable& target, int stackposition, bool remove) {
+	if (!internal::isValidIndex(luaState, stackposition)) {
+		return false;
+	}
+
+	if (!lua_istable(luaState, stackposition)) {
+		return false;
+	} else {
+		target.setReference(UniqueLuaReference::create(luaState, stackposition));
+
+		if (remove) {
+			lua_remove(luaState, stackposition);
+		}
+
+		return true;
+	}
+}
+
 }

--- a/code/scripting/lua/LuaTable.h
+++ b/code/scripting/lua/LuaTable.h
@@ -232,25 +232,7 @@ class LuaTable: public LuaValue {
 
 namespace convert {
 
-template<>
-inline LuaTable popValue<LuaTable>(lua_State* luaState, int stackposition, bool remove) {
-	if (!isValidIndex(luaState, stackposition)) {
-		throw LuaException("Specified stack position is not valid!");
-	}
-
-	if (!lua_istable(luaState, stackposition)) {
-		throw LuaException("Specified index is no table!");
-	} else {
-		LuaTable target;
-		target.setReference(UniqueLuaReference::create(luaState, stackposition));
-
-		if (remove) {
-			lua_remove(luaState, stackposition);
-		}
-
-		return target;
-	}
-}
+bool popValue(lua_State* luaState, LuaTable& target, int stackposition = -1, bool remove = true);
 
 }
 }

--- a/code/scripting/lua/LuaUtil.h
+++ b/code/scripting/lua/LuaUtil.h
@@ -36,10 +36,17 @@ void tableListPairs(LuaTable& table, Container& keyValueList) {
 
 	for (auto val : table) {
 		val.first.pushValue();
-		key_type key = convert::popValue<key_type>(L);
+		key_type key;
+		if (!convert::popValue(L, key)) {
+			throw LuaException("Failed to pop key!");
+		}
 
 		val.second.pushValue();
-		value_type value = convert::popValue<value_type>(L);
+		value_type value;
+
+		if (!convert::popValue(L, value)) {
+			throw LuaException("Failed to pop value!");
+		}
 
 		keyValueList.push_back(std::make_pair(key, value));
 	}

--- a/code/scripting/lua/LuaValue.cpp
+++ b/code/scripting/lua/LuaValue.cpp
@@ -95,4 +95,31 @@ bool LuaValue::pushValue() const {
 lua_State* LuaValue::getLuaState() const {
 	return _luaState;
 }
+
+namespace convert {
+
+void pushValue(lua_State* luaState, const LuaValue& value) {
+	if (luaState != value.getLuaState()) {
+		throw LuaException("Lua state mismatch!");
+	}
+
+	value.pushValue();
+}
+
+bool popValue(lua_State* luaState, LuaValue& target, int stackposition, bool remove) {
+	if (!internal::isValidIndex(luaState, stackposition)) {
+		return false;
+	}
+
+	target.setReference(UniqueLuaReference::create(luaState, stackposition));
+
+	if (remove) {
+		lua_remove(luaState, stackposition);
+	}
+
+	return true;
+}
+
+}
+
 }

--- a/code/source_groups.cmake
+++ b/code/source_groups.cmake
@@ -804,6 +804,15 @@ set (file_root_parse
 	parse/sexp.h
 )
 
+set (file_root_parse_sexp
+	parse/sexp/DynamicSEXP.cpp
+	parse/sexp/DynamicSEXP.h
+	parse/sexp/LuaSEXP.cpp
+	parse/sexp/LuaSEXP.h
+	parse/sexp/sexp_lookup.cpp
+	parse/sexp/sexp_lookup.h
+)
+
 # Particle files
 set (file_root_particle
 	particle/particle.cpp
@@ -981,6 +990,8 @@ set(file_root_scripting_api_objs
 	scripting/api/objs/graphics.h
 	scripting/api/objs/hudgauge.cpp
 	scripting/api/objs/hudgauge.h
+	scripting/api/objs/LuaSEXP.cpp
+	scripting/api/objs/LuaSEXP.h
 	scripting/api/objs/mc_info.cpp
 	scripting/api/objs/mc_info.h
 	scripting/api/objs/message.cpp
@@ -1038,6 +1049,7 @@ set(file_root_scripting_api_objs
 set(file_root_scripting_lua
 	scripting/lua/LuaArgs.cpp
 	scripting/lua/LuaArgs.h
+	scripting/lua/LuaConvert.cpp
 	scripting/lua/LuaConvert.h
 	scripting/lua/LuaException.h
 	scripting/lua/LuaFunction.cpp
@@ -1291,6 +1303,7 @@ source_group("Object"                             FILES ${file_root_object})
 source_group("Observer"                           FILES ${file_root_observer})
 source_group("OsApi"                              FILES ${file_root_osapi})
 source_group("Parse"                              FILES ${file_root_parse})
+source_group("Parse\\SEXP"                        FILES ${file_root_parse_sexp})
 source_group("Particle"                           FILES ${file_root_particle})
 source_group("Particle\\Effects"                  FILES ${file_root_particle_effects})
 source_group("Particle\\Util"                     FILES ${file_root_particle_util})
@@ -1385,6 +1398,7 @@ set (file_root
 	${file_root_observer}
 	${file_root_osapi}
 	${file_root_parse}
+	${file_root_parse_sexp}
 	${file_root_particle}
 	${file_root_particle_effects}
 	${file_root_particle_util}

--- a/fred2/management.cpp
+++ b/fred2/management.cpp
@@ -35,6 +35,7 @@
 #include "math/fvi.h"
 #include "starfield/starfield.h"
 #include "parse/sexp.h"
+#include "parse/sexp/sexp_lookup.h"
 #include "io/mouse.h"
 #include "mission/missioncampaign.h"
 #include "wing.h"
@@ -65,6 +66,7 @@
 #include "missionui/fictionviewer.h"
 #include "mod_table/mod_table.h"
 #include "libs/ffmpeg/FFmpeg.h"
+#include "scripting/scripting.h"
 
 #include <direct.h>
 #include "cmdline/cmdline.h"
@@ -344,6 +346,12 @@ bool fred_init(std::unique_ptr<os::GraphicsOperations>&& graphicsOps)
 
 	io::mouse::CursorManager::get()->showCursor(false);
 
+	// To avoid breaking current mods which do not support scripts in FRED we only initialize the scripting
+	// system if a special mod_table option is set
+	if (Enable_scripts_in_fred) {
+		script_init();			//WMC
+	}
+
 	font::init();					// loads up all fonts  
 
 	gr_set_gamma(3.0f);
@@ -418,6 +426,8 @@ bool fred_init(std::unique_ptr<os::GraphicsOperations>&& graphicsOps)
 
 	libs::ffmpeg::initialize();
 
+	sexp::dynamic_sexp_init();
+
 	gr_reset_clip();
 	g3_start_frame(0);
 	g3_set_view_matrix(&eye_pos, &eye_orient, 0.5f);
@@ -428,7 +438,10 @@ bool fred_init(std::unique_ptr<os::GraphicsOperations>&& graphicsOps)
 	Id_select_type_start = (int)(Ship_info.size() + 2);
 	Id_select_type_jump_node = (int)(Ship_info.size() + 1);
 	Id_select_type_waypoint = (int)(Ship_info.size());
-	Fred_main_wnd -> init_tools();	
+	Fred_main_wnd -> init_tools();
+
+	Script_system.RunCondition(CHA_GAMEINIT);
+
 	return true;
 }
 

--- a/fred2/sexp_tree.cpp
+++ b/fred2/sexp_tree.cpp
@@ -79,7 +79,6 @@ END_MESSAGE_MAP()
 static int Add_count, Replace_count;
 static int Modify_variable;
 
-
 // constructor
 sexp_tree::sexp_tree()
 {

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -134,6 +134,7 @@
 #include "parse/parselo.h"
 #include "scripting/scripting.h"
 #include "parse/sexp.h"
+#include "parse/sexp/sexp_lookup.h"
 #include "particle/particle.h"
 #include "particle/ParticleManager.h"
 #include "pilotfile/pilotfile.h"
@@ -1988,6 +1989,14 @@ void game_init()
 	if(!Cmdline_reparse_mainhall)
 	{
 		main_hall_table_init();
+	}
+
+	// Initialize dynamic SEXPs
+	sexp::dynamic_sexp_init();
+
+	// This needs to be done after the dynamic SEXP init so that our documentation contains the dynamic sexps
+	if (Cmdline_output_sexp_info) {
+		output_sexps("sexps.html");
 	}
 
 	Viewer_mode = 0;
@@ -6860,6 +6869,9 @@ void game_shutdown(void)
 	multi_lag_close();
 #endif
 	fs2netd_close();
+
+	// Free SEXP resources
+	sexp_shutdown();
 
 	if ( Cmdline_old_collision_sys ) {
 		obj_pairs_close();		// free memory from object collision pairs

--- a/test/src/scripting/lua/Convert.cpp
+++ b/test/src/scripting/lua/Convert.cpp
@@ -118,7 +118,7 @@ TEST_F(LuaConvertTest, PushValue) {
 
 	LuaTable table = LuaTable::create(L);
 
-	pushValue<LuaValue>(L, table);
+	pushValue(L, table);
 
 	ASSERT_TRUE(lua_istable(L, -1) == 1);
 
@@ -130,7 +130,7 @@ TEST_F(LuaConvertTest, PushFunction) {
 
 	LuaFunction func = LuaFunction::createFromCode(L, "return 0");
 
-	pushValue<LuaValue>(L, func);
+	pushValue(L, func);
 
 	ASSERT_TRUE(lua_isfunction(L, -1) == 1 && !lua_iscfunction(L, -1));
 
@@ -176,7 +176,8 @@ TEST_F(LuaConvertTest, PopDouble) {
 
 		lua_pushnumber(L, 1.0);
 
-		double target = popValue<double>(L);
+		double target;
+		ASSERT_TRUE(popValue(L, target));
 
 		ASSERT_DOUBLE_EQ(1.0, target);
 	}
@@ -185,7 +186,8 @@ TEST_F(LuaConvertTest, PopDouble) {
 
 		lua_pushnumber(L, 1.0);
 
-		double target = popValue<double>(L, -1, false);
+		double target;
+		ASSERT_TRUE(popValue(L, target, -1, false));
 
 		ASSERT_DOUBLE_EQ(1.0, target);
 		ASSERT_TRUE(lua_isnumber(L, -1) == 1);
@@ -197,7 +199,8 @@ TEST_F(LuaConvertTest, PopDouble) {
 
 		lua_pushliteral(L, "TestTest");
 
-		ASSERT_THROW(popValue<double>(L), LuaException);
+		double target;
+		ASSERT_FALSE(popValue(L, target));
 
 		lua_pop(L, 1);
 	}
@@ -210,7 +213,7 @@ TEST_F(LuaConvertTest, PopFloat) {
 		lua_pushnumber(L, 1.0);
 
 		float target = -1.f;
-		ASSERT_NO_THROW(target = popValue<float>(L));
+		ASSERT_TRUE(popValue(L, target));
 
 		ASSERT_FLOAT_EQ(1.0f, target);
 	}
@@ -220,7 +223,7 @@ TEST_F(LuaConvertTest, PopFloat) {
 		lua_pushnumber(L, 1.0);
 
 		float target = -1.f;
-		ASSERT_NO_THROW(target = popValue<float>(L, -1, false));
+		ASSERT_TRUE(popValue(L, target, -1, false));
 
 		ASSERT_FLOAT_EQ(1.0f, target);
 		ASSERT_TRUE(lua_isnumber(L, -1) == 1);
@@ -232,7 +235,8 @@ TEST_F(LuaConvertTest, PopFloat) {
 
 		lua_pushboolean(L, 1);
 
-		ASSERT_THROW(popValue<float>(L), LuaException);
+		float target;
+		ASSERT_FALSE(popValue(L, target));
 
 		lua_pop(L, 1);
 	}
@@ -245,7 +249,7 @@ TEST_F(LuaConvertTest, PopInt) {
 		lua_pushnumber(L, 1.0);
 
 		int target = -1;
-		ASSERT_NO_THROW(target = popValue<int>(L));
+		ASSERT_TRUE(popValue(L, target));
 
 		ASSERT_EQ(1, target);
 	}
@@ -255,7 +259,7 @@ TEST_F(LuaConvertTest, PopInt) {
 		lua_pushnumber(L, 1.0);
 
 		int target = -1;
-		ASSERT_NO_THROW(target = popValue<int>(L, -1, false));
+		ASSERT_TRUE(popValue(L, target, -1, false));
 
 		ASSERT_EQ(1, target);
 		ASSERT_TRUE(lua_isnumber(L, -1) == 1);
@@ -267,7 +271,8 @@ TEST_F(LuaConvertTest, PopInt) {
 
 		lua_pushboolean(L, 1);
 
-		ASSERT_THROW(popValue<int>(L), LuaException);
+		int target;
+		ASSERT_FALSE(popValue(L, target));
 
 		lua_pop(L, 1);
 	}
@@ -280,7 +285,7 @@ TEST_F(LuaConvertTest, PopSizeT) {
 		lua_pushnumber(L, 1.0);
 
 		size_t target = SIZE_MAX;
-		ASSERT_NO_THROW(target = popValue<size_t>(L));
+		ASSERT_TRUE(popValue(L, target));
 
 		ASSERT_EQ(1, (int)target);
 	}
@@ -290,7 +295,7 @@ TEST_F(LuaConvertTest, PopSizeT) {
 		lua_pushnumber(L, 1.0);
 
 		size_t target = SIZE_MAX;
-		ASSERT_NO_THROW(target = popValue<size_t>(L, -1, false));
+		ASSERT_TRUE(popValue(L, target, -1, false));
 
 		ASSERT_EQ(1, (int)target);
 		ASSERT_TRUE(lua_isnumber(L, -1) == 1);
@@ -302,7 +307,8 @@ TEST_F(LuaConvertTest, PopSizeT) {
 
 		lua_pushboolean(L, 1);
 
-		ASSERT_THROW(popValue<size_t>(L), LuaException);
+		size_t target;
+		ASSERT_FALSE(popValue(L, target));
 
 		lua_pop(L, 1);
 	}
@@ -315,7 +321,7 @@ TEST_F(LuaConvertTest, PopStdString) {
 		lua_pushliteral(L, "TestTest");
 
 		std::string target;
-		ASSERT_NO_THROW(target = popValue<std::string>(L));
+		ASSERT_TRUE(popValue(L, target));
 
 		ASSERT_STREQ("TestTest", target.c_str());
 	}
@@ -325,7 +331,7 @@ TEST_F(LuaConvertTest, PopStdString) {
 		lua_pushliteral(L, "TestTest");
 
 		std::string target;
-		ASSERT_NO_THROW(target = popValue<std::string>(L, -1, false));
+		ASSERT_TRUE(popValue(L, target, -1, false));
 
 		ASSERT_STREQ("TestTest", target.c_str());
 		ASSERT_TRUE(lua_isstring(L, -1) == 1);
@@ -337,7 +343,8 @@ TEST_F(LuaConvertTest, PopStdString) {
 
 		lua_pushboolean(L, 1);
 
-		ASSERT_THROW(popValue<std::string>(L), LuaException);
+		std::string target;
+		ASSERT_FALSE(popValue(L, target));
 
 		lua_pop(L, 1);
 	}
@@ -350,7 +357,7 @@ TEST_F(LuaConvertTest, PopBool) {
 		lua_pushboolean(L, 1);
 
 		bool target = false;
-		ASSERT_NO_THROW(target = popValue<bool>(L));
+		ASSERT_TRUE(popValue(L, target));
 
 		ASSERT_TRUE(target);
 	}
@@ -360,7 +367,7 @@ TEST_F(LuaConvertTest, PopBool) {
 		lua_pushboolean(L, 1);
 
 		bool target = false;
-		ASSERT_NO_THROW(target = popValue<bool>(L, -1, false));
+		ASSERT_TRUE(popValue(L, target, -1, false));
 
 		ASSERT_TRUE(target);
 		ASSERT_TRUE(lua_isboolean(L, -1) == 1);
@@ -372,7 +379,8 @@ TEST_F(LuaConvertTest, PopBool) {
 
 		lua_pushnumber(L, 1.0);
 
-		ASSERT_THROW(popValue<bool>(L), LuaException);
+		bool target;
+		ASSERT_FALSE(popValue(L, target));
 
 		lua_pop(L, 1);
 	}
@@ -385,7 +393,7 @@ TEST_F(LuaConvertTest, PopCFunction) {
 		lua_pushcfunction(L, &testCFunction);
 
 		lua_CFunction target = nullptr;
-		ASSERT_NO_THROW(target = popValue<lua_CFunction>(L));
+		ASSERT_TRUE(popValue(L, target));
 
 		ASSERT_EQ(target, &testCFunction);
 	}
@@ -395,7 +403,7 @@ TEST_F(LuaConvertTest, PopCFunction) {
 		lua_pushcfunction(L, &testCFunction);
 
 		lua_CFunction target = nullptr;
-		ASSERT_NO_THROW(target = popValue<lua_CFunction>(L, -1, false));
+		ASSERT_TRUE(popValue(L, target, -1, false));
 
 		ASSERT_EQ(target, &testCFunction);
 		ASSERT_TRUE(lua_iscfunction(L, -1) == 1);
@@ -407,7 +415,8 @@ TEST_F(LuaConvertTest, PopCFunction) {
 
 		lua_pushnumber(L, 1.0);
 
-		ASSERT_THROW(popValue<lua_CFunction>(L), LuaException);
+		lua_CFunction target;
+		ASSERT_FALSE(popValue(L, target));
 
 		lua_pop(L, 1);
 	}
@@ -420,7 +429,7 @@ TEST_F(LuaConvertTest, PopLuaTable) {
 		lua_newtable(L);
 
 		LuaTable target;
-		ASSERT_NO_THROW(target = popValue<LuaTable>(L));
+		ASSERT_TRUE(popValue(L, target));
 
 		ASSERT_EQ(ValueType::TABLE, target.getValueType());
 	}
@@ -430,7 +439,7 @@ TEST_F(LuaConvertTest, PopLuaTable) {
 		lua_newtable(L);
 
 		LuaTable target;
-		ASSERT_NO_THROW(target = popValue<LuaTable>(L, -1, false));
+		ASSERT_TRUE(popValue(L, target, -1, false));
 
 		ASSERT_EQ(ValueType::TABLE, target.getValueType());
 		ASSERT_TRUE(lua_istable(L, -1) == 1);
@@ -442,7 +451,8 @@ TEST_F(LuaConvertTest, PopLuaTable) {
 
 		lua_pushnumber(L, 1.0);
 
-		ASSERT_THROW(popValue<LuaTable>(L), LuaException);
+		LuaTable target;
+		ASSERT_FALSE(popValue(L, target));
 
 		lua_pop(L, 1);
 	}
@@ -456,7 +466,7 @@ TEST_F(LuaConvertTest, PopLuaFunction) {
 		lua_getglobal(L, "print");
 
 		LuaFunction target;
-		ASSERT_NO_THROW(target = popValue<LuaFunction>(L));
+		ASSERT_TRUE(popValue(L, target));
 
 		ASSERT_EQ(ValueType::FUNCTION, target.getValueType());
 	}
@@ -466,7 +476,7 @@ TEST_F(LuaConvertTest, PopLuaFunction) {
 		lua_getglobal(L, "print");
 
 		LuaFunction target;
-		ASSERT_NO_THROW(target = popValue<LuaFunction>(L, -1, false));
+		ASSERT_TRUE(popValue(L, target, -1, false));
 
 		ASSERT_EQ(ValueType::FUNCTION, target.getValueType());
 		ASSERT_TRUE(lua_isfunction(L, -1) == 1);
@@ -478,7 +488,8 @@ TEST_F(LuaConvertTest, PopLuaFunction) {
 
 		lua_pushnumber(L, 1.0);
 
-		ASSERT_THROW(popValue<LuaFunction>(L), LuaException);
+		LuaFunction target;
+		ASSERT_FALSE(popValue(L, target));
 
 		lua_pop(L, 1);
 	}
@@ -491,7 +502,7 @@ TEST_F(LuaConvertTest, PopLuaValue) {
 		lua_pushnumber(L, 1.0);
 
 		LuaValue target;
-		ASSERT_NO_THROW(target = popValue<LuaValue>(L));
+		ASSERT_TRUE(popValue(L, target));
 
 		ASSERT_EQ(ValueType::NUMBER, target.getValueType());
 	}
@@ -501,7 +512,7 @@ TEST_F(LuaConvertTest, PopLuaValue) {
 		lua_pushnumber(L, 1.0);
 
 		LuaValue target;
-		ASSERT_NO_THROW(target = popValue<LuaValue>(L, -1, false));
+		ASSERT_TRUE(popValue(L, target, -1, false));
 
 		ASSERT_EQ(ValueType::NUMBER, target.getValueType());
 		ASSERT_TRUE(lua_isnumber(L, -1) == 1);


### PR DESCRIPTION
This add a system for adding generic instances of the DynamicSEXP class
to the SEXP system. The only implementation at the moment is the LuaSEXP
which is used by the mn.addSEXP lua API to allow Lua to add new SEXPs.

Since this requires that FRED also runs lua scripts I added a mod table
option to enable scripting in FRED. Since the current scripts are not
built with FRED in mind it would likely break all these scripts if FRED
would be opened with normal scripting enabled.

This fixes #1320.