### PR TITLE
Fix the build on OpenBSD

### DIFF
--- a/cmake/platformChecks.cmake
+++ b/cmake/platformChecks.cmake
@@ -7,6 +7,7 @@ include(CheckLibraryExists)
 include(CheckPrototypeDefinition)
 include(CheckStructHasMember)
 include(CheckSymbolExists)
+include(CheckCXXSymbolExists)
 include(CheckTypeSize)
 
 CHECK_INCLUDE_FILE("execinfo.h" HAVE_EXECINFO_H)
@@ -14,9 +15,18 @@ CHECK_INCLUDE_FILE_CXX("cxxabi.h" HAVE_CXXAPI_H)
 
 CHECK_TYPE_SIZE("max_align_t" MAX_ALIGN_T)
 
+if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+    set(CMAKE_REQUIRED_FLAGS "-std=c++11") # required for g++ <= 5
+endif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+
 set(CMAKE_EXTRA_INCLUDE_FILES "cstddef")
 CHECK_TYPE_SIZE("std::max_align_t" STD_MAX_ALIGN_T LANGUAGE CXX)
+set(CMAKE_EXTRA_INCLUDE_FILES "type_traits")
+CHECK_TYPE_SIZE("std::is_trivially_copyable<int>" STD_IS_TRIVIALLY_COPYABLE LANGUAGE CXX)
 set(CMAKE_EXTRA_INCLUDE_FILES)
+
+set(CMAKE_REQUIRED_FLAGS)
+
 
 CHECK_FUNCTION_EXISTS(strcasecmp HAVE_STRCASECMP)
 CHECK_FUNCTION_EXISTS(strncasecmp HAVE_STRNCASECMP)

--- a/cmake/platformChecks.h.in
+++ b/cmake/platformChecks.h.in
@@ -8,6 +8,8 @@
 #cmakedefine HAVE_MAX_ALIGN_T
 #cmakedefine HAVE_STD_MAX_ALIGN_T
 
+#cmakedefine HAVE_STD_IS_TRIVIALLY_COPYABLE
+
 #cmakedefine01 IS_64BIT
 
 #cmakedefine01 HAVE_STRCASECMP

--- a/code/scripting/ade.h
+++ b/code/scripting/ade.h
@@ -5,6 +5,7 @@
 #define FS2_OPEN_ADE_H
 
 #include "globalincs/pstypes.h"
+#include "platformChecks.h"
 
 extern "C" {
 #include <lauxlib.h>
@@ -226,8 +227,9 @@ template<class StoreType>
 class ade_obj: public ade_lib_handle {
  public:
 	// Make sure that the stored type is compatible with our requirements
+#ifdef HAVE_STD_IS_TRIVIALLY_COPYABLE
 	static_assert(std::is_trivially_copyable<StoreType>::value, "ADE object types must be trivially copyable!");
-
+#endif
 	ade_obj(const char* in_name, const char* in_desc, const ade_lib_handle* in_deriv = NULL) {
 		ade_table_entry ate;
 

--- a/code/scripting/lua/LuaTable.cpp
+++ b/code/scripting/lua/LuaTable.cpp
@@ -97,36 +97,36 @@ LuaTable::iterator LuaTable::end() {
 	return iterator(); // Empty iterator
 }
 
-LuaTableIterator::LuaTableIterator(const LuaTable& t) : _L(t.getLuaState()) {
-	_stackTop = lua_gettop(_L);
+LuaTableIterator::LuaTableIterator(const LuaTable& t) : _luaState(t.getLuaState()) {
+	_stackTop = lua_gettop(_luaState);
 
 	t.pushValue();
-	lua_pushnil(_L);
+	lua_pushnil(_luaState);
 
 	toNextElement();
 }
 LuaTableIterator::~LuaTableIterator() {
-	lua_settop(_L, _stackTop);
+	lua_settop(_luaState, _stackTop);
 }
 bool LuaTableIterator::hasElement() {
 	return _hasElement;
 }
 void LuaTableIterator::toNextElement() {
-	auto ret = lua_next(_L, -2);
+	auto ret = lua_next(_luaState, -2);
 
 	_hasElement = ret != 0;
 
 	if (_hasElement) {
 		LuaValue key;
-		key.setReference(UniqueLuaReference::create(_L, -2));
+		key.setReference(UniqueLuaReference::create(_luaState, -2));
 
 		LuaValue value;
-		value.setReference(UniqueLuaReference::create(_L, -1));
+		value.setReference(UniqueLuaReference::create(_luaState, -1));
 
 		_currentVal = std::make_pair(key, value);
 
 		// Remove value from stack
-		lua_pop(_L, 1);
+		lua_pop(_luaState, 1);
 	}
 }
 std::pair<LuaValue, LuaValue> LuaTableIterator::getElement() {

--- a/code/scripting/lua/LuaTable.h
+++ b/code/scripting/lua/LuaTable.h
@@ -19,7 +19,7 @@ class LuaTable;
  * be in the exact same state when you call the next method of this class.
  */
 class LuaTableIterator {
-	lua_State* _L = nullptr;
+	lua_State* _luaState = nullptr;
 
 	int _stackTop = 0;
 


### PR DESCRIPTION
FSO doesn't build from source on OpenBSD anymore. This patch corrects the only significant problem: the iterator in LuaTable.h/cpp known as _L clashes with a #define in OpenBSD's standard headers (ctypes.h to be specific). The new name proposed here is simply taken from the type.

One other problem still prevents building on OpenBSD at this time: an assert in code/scripting/ade.h that calls std::is_trivially_copyable, available in libstdc++ >= 5 (where OpenBSD has 4.9 in ports/packages). OpenBSD on i386/amd64 will probably use clang/libc++ in the future, so this issue will go away anyhow. For the record, the following diff on top of this PR fixes the build on OpenBSD 6.1-current at this time:

```diff
diff --git a/code/scripting/ade.h b/code/scripting/ade.h
index 8478ea3ea..04cf920ef 100644
--- a/code/scripting/ade.h
+++ b/code/scripting/ade.h
@@ -226,7 +226,7 @@ template<class StoreType>
 class ade_obj: public ade_lib_handle {
  public:
        // Make sure that the stored type is compatible with our requirements
-       static_assert(std::is_trivially_copyable<StoreType>::value, "ADE object types must be trivially copyable!");
+       //static_assert(std::is_trivially_copyable<StoreType>::value, "ADE object types must be trivially copyable!");
 
        ade_obj(const char* in_name, const char* in_desc, const ade_lib_handle* in_deriv = NULL) {
                ade_table_entry ate;
```