### PR TITLE
Fix assertion when applying particle effect to laser

### DIFF
--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -4518,7 +4518,11 @@ static void weapon_set_state(weapon_info* wip, weapon* wp, WeaponState state)
 		return;
 	}
 
-	if (wp->weapon_state == WeaponState::INVALID)
+	auto current_state = wp->weapon_state;
+
+	wp->weapon_state = state;
+
+	if (current_state == WeaponState::INVALID)
 	{
 		// First weapon state, create the in-flight effect
 		auto map_entry = wip->state_effects.find(WeaponState::NORMAL);
@@ -4533,8 +4537,6 @@ static void weapon_set_state(weapon_info* wip, weapon* wp, WeaponState state)
 			source.finish();
 		}
 	}
-
-	wp->weapon_state = state;
 
 	auto map_entry = wip->state_effects.find(wp->weapon_state);
 


### PR DESCRIPTION
The weapon state value of the weapon was updated after the particle
source was created so the source was always invalid which caused an
assertion.