### PR TITLE
Update BinTray API keys

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ deploy:
     - provider: bintray
       user: sirknightly
       key:
-          secure: "CZtvDW/zPf1Nxru21i8Wd+9hgiBRA8VowWBX0gmCOGgRq9WHISttKQQmBWGHuyVZ3rYvtE4Va2bR+2qRN+TFNkUUuOCOQkdBJTCal9nS3G/LprEmsOashG0Q5PTfMMBnlKzKxaxGJW6UhFj2GySmHEAjsFLVpuNWGJeeZgZQ3UE="
+          secure: "N/6QerkSgkt3elhJMeOyyHHjFri1Bi0GF0msucVCuTXVxMmq/E2XVldHT1TVfD7u6EUlkH5Tr+Aer5fXrrDfk2RZH1RXgQk1FYWUC+JY9dpD6AOtlffRfVHwhSMsZbuSt0sbDmHjnrFiGnxOFojBHpA/iTdZ4fvUl6Mg47hxaVI="
       file: ci/bintray.json
       on:
           condition: '"$NIGHTLY_BUILD" == true'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,7 +28,7 @@ deploy:
     - provider: BinTray
       username: sirknightly
       api_key:
-          secure: pYWqfiZhIWvFYdjVWPXNaHobmnkXIWa4+LwoiyMTEiu4Z0CiCAW0ZrMfTKVkORKz
+          secure: 242iJ1rSVahaH+SskiwK2YcIVTO+yEOn5lRAvrBESHVfw6cqrSWfUROPp0Y6bxxX
       subject: scp-fs2open
       repo: FSO
       package: nightly


### PR DESCRIPTION
While searching for the cause of the rate-limiting of our BinTray
organization, I revoked the API key used by the CI servers in case the
key got compromised somehow. These are the updated keys which should
allow us to upload nightly builds again.

@chief1983 and I are working on a nightly solution which does not
require BinTray but until that works we need these updated keys.