### PR TITLE
Fix several issues blocking a Solaris compile

### DIFF
--- a/cmake/platform-solaris.cmake
+++ b/cmake/platform-solaris.cmake
@@ -1,2 +1,18 @@
 
 target_compile_definitions(platform INTERFACE SCP_SOLARIS)
+
+find_library(SOCKET_LIB socket)
+
+if (NOT SOCKET_LIB)
+    message(FATAL_ERROR "Couldn't find libsocket! Please install it and rerun the configuration.")
+else()
+    target_link_libraries(platform INTERFACE "${SOCKET_LIB}")
+endif()
+
+find_library(NSL_LIB nsl)
+
+if (NOT NSL_LIB)
+    message(FATAL_ERROR "Couldn't find libnsl! Please install it and rerun the configuration.")
+else()
+    target_link_libraries(platform INTERFACE "${NSL_LIB}")
+endif()

--- a/code/globalincs/pstypes.h
+++ b/code/globalincs/pstypes.h
@@ -318,6 +318,7 @@ const size_t INVALID_SIZE = static_cast<size_t>(-1);
 
 #ifdef SCP_SOLARIS // Solaris
 #define INTEL_INT(x)	x
+#define INTEL_LONG(x)   x
 #define INTEL_SHORT(x)	x
 #define INTEL_FLOAT(x)	(*x)
 #elif BYTE_ORDER == BIG_ENDIAN

--- a/code/globalincs/version.cpp
+++ b/code/globalincs/version.cpp
@@ -10,7 +10,7 @@
 #include "globalincs/pstypes.h"
 #include "globalincs/version.h"
 
-namespace version
+namespace gameversion
 {
 	bool check_at_least(int major, int minor, int build, int revision)
 	{

--- a/code/globalincs/version.h
+++ b/code/globalincs/version.h
@@ -36,7 +36,7 @@
 
 #include "project.h"
 
-namespace version
+namespace gameversion
 {
 	/**
 	 * @brief Checks if the current version is at least the given version

--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -53,35 +53,35 @@ void parse_mod_table(const char *filename)
 
 		// start parsing
 		optional_string("#GAME SETTINGS");
-		
+
 		if (optional_string("$Minimum version:")) {
 			int major = 0;
 			int minor = 0;
 			int build = 0;
 			int revision = 0;
-			
+
 			required_string("+Major:");
 			stuff_int(&major);
-			
+
 			required_string("+Minor:");
 			stuff_int(&minor);
-			
+
 			required_string("+Build:");
 			stuff_int(&build);
-			
+
 			if (optional_string("+Revision:")) {
 				stuff_int(&revision);
 			}
-			
-			mprintf(("Game Settings Table: Parsed minimum version of %s\n", version::format_version(major, minor, build, revision).c_str()));
-			
-			if (!version::check_at_least(major, minor, build, revision)) {
+
+			mprintf(("Game Settings Table: Parsed minimum version of %s\n", gameversion::format_version(major, minor, build, revision).c_str()));
+
+			if (!gameversion::check_at_least(major, minor, build, revision)) {
 				Error(LOCATION, "This modification needs at least version %s of FreeSpace Open. However, the current is only %s!",
-					  version::format_version(major, minor, build, revision).c_str(),
-					  version::format_version(FS_VERSION_MAJOR, FS_VERSION_MINOR, FS_VERSION_BUILD, FS_VERSION_REVIS).c_str());
+					gameversion::format_version(major, minor, build, revision).c_str(),
+					gameversion::format_version(FS_VERSION_MAJOR, FS_VERSION_MINOR, FS_VERSION_BUILD, FS_VERSION_REVIS).c_str());
 			}
 		}
-		
+
 		optional_string("#CAMPAIGN SETTINGS");
 
 		if (optional_string("$Default Campaign File Name:")) {
@@ -215,19 +215,16 @@ void parse_mod_table(const char *filename)
 			Briefing_window_FOV = fov;
 		}
 
-		
-			if (optional_string("$Generic Pain Flash Factor:")) {
+		if (optional_string("$Generic Pain Flash Factor:")) {
 			stuff_float(&Generic_pain_flash_factor);
 			if (Generic_pain_flash_factor != 1.0f)
 				mprintf(("Game Settings Table: Setting generic pain flash factor to %.2f\n", Generic_pain_flash_factor));
-			
 		}
-		
-			if (optional_string("$Shield Pain Flash Factor:")) {
+
+		if (optional_string("$Shield Pain Flash Factor:")) {
 			stuff_float(&Shield_pain_flash_factor);
 			if (Shield_pain_flash_factor != 0.0f)
 				 mprintf(("Game Settings Table: Setting shield pain flash factor to %.2f\n", Shield_pain_flash_factor));
-			
 		}
 
 		optional_string("#NETWORK SETTINGS");
@@ -343,7 +340,7 @@ void parse_mod_table(const char *filename)
 }
 
 void mod_table_init()
-{	
+{
 	// first parse the default table
 	parse_mod_table(NULL);
 


### PR DESCRIPTION
I have actually produced a fully functioning build on OpenIndiana (the fork of OpenSolaris), and have compiled on a Solaris 11.3 VM with these changes.  I am open to suggestions for alternative names for the version->gameversion rename, but the rename itself is required because version is a defined enum in math.h in the Solaris system headers, which resulted in a symbol conflict on Solaris distros since this was committed nearly two years ago.  The other fixes just enhance the existing platform file to fix library linking, and address a missing line from when a series of IFDEFs were modified without addressing the Solaris case (probably since no one was available to test it on Solaris at the time).