### PR TITLE
Upload nightly builds to FTP instead of BinTray

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,19 @@ addons:
         build_command:   "ci/travis/script.sh"
         # must match TRAVIS_BRANCH check below
         branch_pattern: coverity_scan
+env:
+    global:
+     # The next declaration is the encrypted COVERITY_SCAN_TOKEN, created
+     #   via the "travis encrypt" command using the project repo's public key
+     #   also note that fork's don't get access to secure keys
+     #   you have to test using a branch in the main repo
+     - secure: "C3wF967ZeliwwP1vC12EMIBOaC568n26Z/cPnwzn317ve59DWH3YSfPZVgvt08GzmaXITGGsJvPB+qxfGoKvQzYE4O1B73q81RpUe5pB3IhF+ThQ91VfQZIRJR5xEGJaLINUlHTTZGX5jxlkVO9wAcauVj/s3b8sQ3dvUZauPvk="
+     # These declarations set INDIEGAMES_USER and INDIEGAMES_PASSWORD for uploading nightly builds to the indiegames server
+     - secure: "lUuRu8XIi8MKNf1ebOfyC4iVEpPyASojJIDWXRo2bNqEF4ILAljXdkVeXeN6H5yKCHD52cxCNTtyePIG/o3p3QEuGSVud9bDS3D7LaQicLETGGrsw3l07U49gF2OKHXGopg0MzBbZUU9QmhoFTAe8t6PV9NDuEayYCheqvTqjZg="
+     - secure: "E/DHLYcPK/hBUqxBYYlUqp5sjgvIqY5A0qRHyQ4bmjsB+WB/Xx71bGCSiF7hk6lTxar1ZI1i5RAXXh9AIvNVaYAIdEOlCP+q3gvwCYuc5naZEKmkxlUCf0oEL4O9Fye93A/3VkFHuBdC1TGPYYf69m4W5r4367wWO9dPRIdWpJA="
+     # These declarations set FS2DOWNLOADS_USER and FS2DOWNLOADS_PASSWORD
+     - secure: "h6GbMX2jLsW1bS9fCM9fthOSJ1nfQQIRWi6EUH2p8u4NFLD5Bfi/C8JhQPKHUzyo3wvKkSHl+PsW7bgr1oXLusRwAur/dtv2N3imqvtbfIz305b00hZlsvbcYmQmUzQFSAdOGShK57JJ5aKQKccaUBP25KqB7Q+JaqBRdaMBS54="
+     - secure: "fUDAPAUUaaYZy8I4zU3SJ0JcK7aw4eb6eTdaEr7LyNyTMSfPgwY6P1MrbSQC0lJNQIUQ5ffjdxE5g7D7OYpoJF9L14ni4UY8t2QASt7kmpgcYihmjeuYy8FQXgmFG8CTxiWBPKTybZJ7voQcvIvRaNG7b2wM9PMfc5lRIondB6c="
 deploy:
     - provider: releases
       api_key:
@@ -34,21 +47,12 @@ deploy:
           condition: '"$RELEASE_BUILD" == true'
           tags: true
 
-    - provider: bintray
-      user: sirknightly
-      key:
-          secure: "N/6QerkSgkt3elhJMeOyyHHjFri1Bi0GF0msucVCuTXVxMmq/E2XVldHT1TVfD7u6EUlkH5Tr+Aer5fXrrDfk2RZH1RXgQk1FYWUC+JY9dpD6AOtlffRfVHwhSMsZbuSt0sbDmHjnrFiGnxOFojBHpA/iTdZ4fvUl6Mg47hxaVI="
-      file: ci/bintray.json
+    - provider: script
+      script: ci/travis/nightly_deploy.sh
       on:
           condition: '"$NIGHTLY_BUILD" == true'
           tags: true
-env:
-    global:
-     # The next declaration is the encrypted COVERITY_SCAN_TOKEN, created
-     #   via the "travis encrypt" command using the project repo's public key
-     #   also note that fork's don't get access to secure keys
-     #   you have to test using a branch in the main repo
-     - secure: "C3wF967ZeliwwP1vC12EMIBOaC568n26Z/cPnwzn317ve59DWH3YSfPZVgvt08GzmaXITGGsJvPB+qxfGoKvQzYE4O1B73q81RpUe5pB3IhF+ThQ91VfQZIRJR5xEGJaLINUlHTTZGX5jxlkVO9wAcauVj/s3b8sQ3dvUZauPvk="
+
 matrix:
     include:
         # note that gcc Debug MUST be 1st for Coverity
@@ -111,5 +115,3 @@ before_script:
     - "./ci/travis/before_script.sh"
 script:
     - if [ "$BUILD_DEPLOYMENT" = true ] ; then ./ci/travis/release.sh ; else ./ci/travis/script.sh ; fi
-before_deploy:
-    - "./ci/travis/before_deploy.sh"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,15 +25,25 @@ deploy:
       on:
           ReleaseBuild: true        # deploy on release push only
 
-    - provider: BinTray
-      username: sirknightly
-      api_key:
-          secure: 242iJ1rSVahaH+SskiwK2YcIVTO+yEOn5lRAvrBESHVfw6cqrSWfUROPp0Y6bxxX
-      subject: scp-fs2open
-      repo: FSO
-      package: nightly
-      version: $(VersionName)
-      publish: true
-      override: true
+    - provider: FTP
+      protocol: sftp
+      host: scp.indiegames.us
+      username:
+        secure: qYjBh+lgEf+DktbBh4rpDQ==
+      password:
+        secure: U9TBaMEMZyAWE52oudZ30Q==
+      folder: public_html/builds/nightly/$(VersionName)
+      on:
+          NightlyBuild: true        # deploy on nightly push only
+
+    - provider: FTP
+      protocol: ftp
+      host: swc.fs2downloads.com
+      username: 
+        secure: p0kIQ+ZucNpwP/kfijXQSQ==
+      password:
+        secure: 7mbQOfwTIkMbsF4hG1onow==
+      folder: swc.fs2downloads.com/builds/nightly/$(VersionName)
+      beta: true
       on:
           NightlyBuild: true        # deploy on nightly push only

--- a/ci/travis/nightly_deploy.sh
+++ b/ci/travis/nightly_deploy.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env sh
+
+set -e
+set -u
+
+cd /tmp/builds
+
+for file in *; do
+	# Upload to indiegames
+	curl -k "ftp://scp.indiegames.us/public_html/builds/nightly/$VERSION_NAME/" --user "$INDIEGAMES_USER:$INDIEGAMES_PASSWORD" -T "$file" --ftp-create-dirs
+
+	# Upload to fs2downloads
+	curl -k "ftp://swc.fs2downloads.com/swc.fs2downloads.com/builds/nightly/$VERSION_NAME/" --user "$FS2DOWNLOADS_USER:$FS2DOWNLOADS_PASSWORD" -T "$file" --ftp-create-dirs
+done


### PR DESCRIPTION
Since BinTray may be unreliable as our nightly host @chief1983 and I
decided that it would be best to return hosting to our dedicated FTP
servers. These changes implement that together with a pending pull
request for the nightly script.