### PR TITLE
Adds a small sanity check after reading an ani header

### DIFF
--- a/code/anim/animplay.cpp
+++ b/code/anim/animplay.cpp
@@ -733,6 +733,10 @@ anim *anim_load(const char *real_filename, int cf_dir_type, int file_mapped)
 
 		anim_read_header(ptr, fp);
 
+		if (ptr->width < 0 || ptr->height < 0) {
+			Error(LOCATION, "Ani file %s has a faulty header and cannot be loaded.", name);
+		}
+
 		if(ptr->num_keys > 0){
 			ptr->keys = (key_frame*)vm_malloc(sizeof(key_frame) * ptr->num_keys);
 			Assert(ptr->keys != NULL);
@@ -969,6 +973,11 @@ void anim_display_info(char *real_filename)
 	}
 
 	anim_read_header(&A, fp);
+
+	if (A.width < 0 || A.height < 0) {
+		Error(LOCATION, "Ani file %s has a faulty header and cannot be loaded.", filename);
+	}
+
 	// read the keyframe frame nums and offsets
 	key_frame_nums = (int*)vm_malloc(sizeof(int)*A.num_keys);
 	Assert(key_frame_nums != NULL);

--- a/code/bmpman/bmpman.cpp
+++ b/code/bmpman/bmpman.cpp
@@ -1619,6 +1619,10 @@ int bm_load_animation(const char *real_filename, int *nframes, int *fps, int *ke
 #endif
 		anim_read_header(&the_anim, img_cfp);
 
+		if (the_anim.width < 0 || the_anim.height < 0) {
+			Error(LOCATION, "Ani file %s has a faulty header and cannot be loaded.", real_filename);
+		}
+
 		anim_frames = the_anim.total_frames;
 		anim_fps = the_anim.fps;
 		if (anim_fps == 0) {


### PR DESCRIPTION
This was noted by FrikgFeek. When loading an ani that had its header corrupted, it's very easy for invalid data to get written to rather important fields; this adds a small check that should at least catch a few of these.