### PR TITLE
Remove unneded Int3 in hudreticle.cpp

### DIFF
--- a/code/hud/hudreticle.cpp
+++ b/code/hud/hudreticle.cpp
@@ -950,7 +950,6 @@ void HudGaugeWeaponLinking::render(float frametime)
 
 	switch( num_banks ) {
 		case 0:
-			Int3();
 			gauge_index = -1;
 			break;
 


### PR DESCRIPTION
The code works perfectly fine without it and it causes issues with a
release campaign so there is no reason to keep it.