### PR TITLE
Avoid Int3() when finding a rank with an out-of-order points value.

### DIFF
--- a/code/stats/scoring.cpp
+++ b/code/stats/scoring.cpp
@@ -105,12 +105,10 @@ void parse_rank_tbl()
 		required_string("#End");
 
 		// be sure that all rank points are in order
-#ifndef NDEBUG
 		for (idx = 0; idx < NUM_RANKS - 1; idx++) {
 			if (Ranks[idx].points >= Ranks[idx + 1].points)
-				Int3();
+				Warning(LOCATION, "Rank #%d (%s) has a higher \"$Points:\" value (%d) than the following rank (%s, %d points). This shouldn't actually crash FSO, but it might result in unexpected or incorrect behavior.\n", idx + 1, Ranks[idx].name, Ranks[idx].points, Ranks[idx+1].name, Ranks[idx+1].points);
 		}
-#endif
 	}
 	catch (const parse::ParseException& e)
 	{


### PR DESCRIPTION
There's a bit of debug code that checks to make sure all ranks are in ascending point order; if this check fails, FSO calls `Int3()` instead of trying to describe the problem. I've changed it to a Warning that actually explains the problem, so the modder can fix it.

Is a conversion to a Warning the correct response here? It shouldn't be an Assertion instead (it's not a coding mistake, since it results from bad data), but making it an Error seemed like a bad idea (Release builds would go from silently ignoring it to crashing outright). Nonetheless, making it a Warning means that people could continue past it, and certain code expects all point values to be in ascending order. I don't think any of them will actually crash if they aren't, but it could result in things like a forced promotion decreasing how many points the player has, or odd things happening when refusing to accept the results of a mission.

Anyone have any thoughts to add?