### PR TITLE
Use TrackIR DLL with 64 suffix when compiling a 64-bit build

### DIFF
--- a/code/headtracking/trackirpublic.h
+++ b/code/headtracking/trackirpublic.h
@@ -7,7 +7,11 @@
 
 #include <SDL_syswm.h>
 
+#ifdef _WIN64
+#define TRACKIRBRIDGEDLLNAME "scptrackir64.dll"
+#else
 #define TRACKIRBRIDGEDLLNAME "scptrackir.dll"
+#endif
 
 #define SCP_INITRESULT_SUCCESS 0
 #define SCP_INITRESULT_BADKEY 1


### PR DESCRIPTION
This should make it possible to have both DLL version installed at the
same time without causing conflicts.

Combined with the new DLL, this will finally fix #974.