### PR TITLE
Remove include of OpenGL header in non-OpenGL code

### DIFF
--- a/code/menuui/techmenu.cpp
+++ b/code/menuui/techmenu.cpp
@@ -17,6 +17,7 @@
 #include "gamesnd/gamesnd.h"
 #include "globalincs/alphacolors.h"
 #include "graphics/font.h"
+#include "graphics/shadows.h"
 #include "io/key.h"
 #include "io/mouse.h"
 #include "lighting/lighting.h"

--- a/code/missionui/missionscreencommon.cpp
+++ b/code/missionui/missionscreencommon.cpp
@@ -23,6 +23,7 @@
 #include "gamesnd/gamesnd.h"
 #include "globalincs/linklist.h"
 #include "graphics/2d.h"
+#include "graphics/shadows.h"
 #include "graphics/opengl/gropenglshader.h"
 #include "hud/hudwingmanstatus.h"
 #include "io/key.h"

--- a/code/missionui/missionweaponchoice.cpp
+++ b/code/missionui/missionweaponchoice.cpp
@@ -16,6 +16,7 @@
 #include "gamehelp/contexthelp.h"
 #include "gamesnd/gamesnd.h"
 #include "globalincs/alphacolors.h"
+#include "graphics/shadows.h"
 #include "hud/hudbrackets.h"
 #include "io/mouse.h"
 #include "io/timer.h"

--- a/code/model/modelrender.h
+++ b/code/model/modelrender.h
@@ -10,7 +10,6 @@
 #ifndef _MODELRENDER_H
 #define _MODELRENDER_H
 
-#include "graphics/opengl/gropengltnl.h"
 #include "graphics/material.h"
 #include "lighting/lighting.h"
 #include "math/vecmat.h"


### PR DESCRIPTION
The OpenGL headers should never be included by code outside of the OpenGL implementation.