### PR TITLE
Allow "+Minimum Distance:" to actually work with automatic convergence.

### DIFF
--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -10910,6 +10910,7 @@ int ship_fire_primary(object * obj, int stream_weapons, int force)
 					float dist_mult;
 					dist_mult = sip->minimum_convergence_distance / dist_to_aim;
 					vm_vec_scale_add(&predicted_target_pos, &obj->pos, &plr_to_target_vec, dist_mult);
+					dist_to_aim = sip->minimum_convergence_distance;
 				}
 			}
 			


### PR DESCRIPTION
The gun convergence code would detect if the target was within the minimum distance and move the predicted target point farther away if so, but wouldn't also alter the `dist_to_aim` variable to match; since `predicted_target_pos` is used by the autoaim code while `dist_to_aim` is what automatic convergence uses, this meant automatic convergence didn't respect the minimum distance at all.

Looks like this was broken in 7bb10d8408de60ccb69d88e342679a94cc4b3226.