### PR TITLE
Reset generic animation type to BM_TYPE_NONE if APNG processing fails.

### DIFF
--- a/code/graphics/generic.cpp
+++ b/code/graphics/generic.cpp
@@ -226,6 +226,7 @@ int generic_anim_stream(generic_anim *ga, const bool cache)
 				mprintf(("Failed to load apng: %s\n", e.what() ));
 				delete ga->png.anim;
 				ga->png.anim = nullptr;
+				ga->type = BM_TYPE_NONE;
 				return -1;
 			}
 			nprintf(("apng", "apng read OK (%ix%i@%i) duration (%f)\n", ga->png.anim->w, ga->png.anim->h,


### PR DESCRIPTION
Prior to APNG support, a regular non-animated PNG could be used as a still-frame command briefing animation. This started causing a crash when APNG support was added because any PNGs sent through `generic_anim_stream()` would get `ga->type` set to `BM_TYPE_PNG`, then sent through the APNG code... which would determine that they weren't APNGs, throw an `ApngException`, and `generic_anim_stream()` would return -1... except that `BM_TYPE_PNG` would still be set, so that when it later came time to render the still frame in `generic_frame_render()`, it would be sent through `generic_anim_render_variable_frame_delay()`... which expected a fully-formed APNG, tried to dereference `ga->png.anim`, and crashed.

This commit is a simple fix to reset `ga->type` to `BM_TYPE_NONE` if APNG processing fails, allowing the still-frame PNG to go through `generic_anim_render_fixed_frame_delay()`, the code path it used to take, and allowing it to display properly instead of crashing.

A more complicated solution might be to change how still frames get processed entirely.