### PR TITLE
Handle ships removed from play via ship-vanish correctly in ai goal processing

### DIFF
--- a/code/ai/aigoals.cpp
+++ b/code/ai/aigoals.cpp
@@ -1640,7 +1640,7 @@ int ai_mission_goal_achievable( int objnum, ai_goal *aigp )
 		}
 		else
 		{
-			Int3();		// get ALLENDER
+			mprintf(("Potentially incorrect behaviour in AI goal for ship %s: Ship %s could not be found among currently active, departed, or yet-to-arrive ships.\nPlease check the mission file.\n", Ships[objp->instance].ship_name, aigp->target_name));
 			status = SHIP_STATUS_UNKNOWN;
 		}
 	}


### PR DESCRIPTION
This just popped up in Artemis: When a ship is removed from play using ship-vanish, any AI goals still referencing that ship become instant death for debug builds due to a leftover bit of Volition-vintage sanity checking. Said checking is actually unnecessary; the code can handle this case gracefully (and actually does so in release), ships that have vanished without a trace are treated the same as ships that haven't arrived yet. Downgrading the Int3() to a log print (Because, after all, this could result in unintended behaviour) seems the correct course of action.