### PR TITLE
Invisible beam section fix

### DIFF
--- a/code/lighting/lighting.cpp
+++ b/code/lighting/lighting.cpp
@@ -298,8 +298,12 @@ void light_add_point(const vec3d *pos, float r1, float r2, float intensity, floa
 
 void light_add_point_unique(const vec3d *pos, float r1, float r2, float intensity, float r, float g, float b, int affected_objnum, float spec_r, float spec_g, float spec_b, bool specular)
 {
-	Assert(r1 >0);
-	Assert(r2 >0);
+	Assertion(r1 > 0.0f, "Invalid radius r1 specified for light: %f. Radius must be > 0.0f. Examine stack trace to determine culprit.\n", r1);
+	Assertion(r2 > 0.0f, "Invalid radius r2 specified for light: %f. Radius must be > 0.0f. Examine stack trace to determine culprit.\n", r2);
+
+	if (r1 < 0.0001f || r2 < 0.0001f)
+		return;
+
 	if(!specular){
 		spec_r = r;
 		spec_g = g;
@@ -341,8 +345,12 @@ void light_add_point_unique(const vec3d *pos, float r1, float r2, float intensit
 // beams affect every ship except the firing ship
 void light_add_tube(const vec3d *p0, const vec3d *p1, float r1, float r2, float intensity, float r, float g, float b, int affected_objnum, float spec_r, float spec_g, float spec_b, bool specular)
 {
-	Assert(r1 >0);
-	Assert(r2 >0);
+	Assertion(r1 > 0.0f, "Invalid radius r1 specified for light: %f. Radius must be > 0.0f. Examine stack trace to determine culprit.\n", r1);
+	Assertion(r2 > 0.0f, "Invalid radius r2 specified for light: %f. Radius must be > 0.0f. Examine stack trace to determine culprit.\n", r2);
+
+	if (r1 < 0.0001f || r2 < 0.0001f)
+		return;
+
 	if(!specular){
 		spec_r = r;
 		spec_g = g;

--- a/code/lighting/lighting.cpp
+++ b/code/lighting/lighting.cpp
@@ -254,9 +254,6 @@ void light_add_point(const vec3d *pos, float r1, float r2, float intensity, floa
 	Assertion( r1 > 0.0f, "Invalid radius r1 specified for light: %f. Radius must be > 0.0f. Examine stack trace to determine culprit.\n", r1 );
 	Assertion( r2 > 0.0f, "Invalid radius r2 specified for light: %f. Radius must be > 0.0f. Examine stack trace to determine culprit.\n", r2 );
 
-	if (r1 < 0.0001f || r2 < 0.0001f)
-		return;
-
 	if(!specular){
 		spec_r = r;
 		spec_g = g;
@@ -301,9 +298,6 @@ void light_add_point_unique(const vec3d *pos, float r1, float r2, float intensit
 	Assertion(r1 > 0.0f, "Invalid radius r1 specified for light: %f. Radius must be > 0.0f. Examine stack trace to determine culprit.\n", r1);
 	Assertion(r2 > 0.0f, "Invalid radius r2 specified for light: %f. Radius must be > 0.0f. Examine stack trace to determine culprit.\n", r2);
 
-	if (r1 < 0.0001f || r2 < 0.0001f)
-		return;
-
 	if(!specular){
 		spec_r = r;
 		spec_g = g;
@@ -347,9 +341,6 @@ void light_add_tube(const vec3d *p0, const vec3d *p1, float r1, float r2, float 
 {
 	Assertion(r1 > 0.0f, "Invalid radius r1 specified for light: %f. Radius must be > 0.0f. Examine stack trace to determine culprit.\n", r1);
 	Assertion(r2 > 0.0f, "Invalid radius r2 specified for light: %f. Radius must be > 0.0f. Examine stack trace to determine culprit.\n", r2);
-
-	if (r1 < 0.0001f || r2 < 0.0001f)
-		return;
 
 	if(!specular){
 		spec_r = r;
@@ -1051,9 +1042,6 @@ void light_add_cone(const vec3d *pos, const vec3d *dir, float angle, float inner
 {
 	Assertion( r1 > 0.0f, "Invalid radius r1 specified for light: %f. Radius must be > 0.0f. Examine stack trace to determine culprit.\n", r1 );
 	Assertion( r2 > 0.0f, "Invalid radius r2 specified for light: %f. Radius must be > 0.0f. Examine stack trace to determine culprit.\n", r2 );
-
-	if (r1 < 0.0001f || r2 < 0.0001f)
-		return;
 
 	if(!specular){
 		spec_r = r;


### PR DESCRIPTION
While replaying Sesquipedalian's mission "The Fourth Vial", I discovered that all of the beam sections were being removed from the subspace rift beams.  I tracked this down to an unintended side-effect of the `weapon_clean_entries()` function added by Taylor in 2007 (!) in SVN revision 4019.  Invisible beam sections are initialized with no filename, but removed beam sections are also re-initialized with no filename and then culled later on.  This PR adds a check in the cleanup function to whitelist invisible beam sections while still allowing removed beam sections to be culled.

I also added a Warning for beams that (through either improper table entry creation or overzealous beam section removal) end up with 0 sections.  Although issue #1366 makes this of limited utility at present.

Finally, I copied over the expanded Assertion checks that were added to `light_add_point` and `light_add_cone` but not `light_add_point_unique` or `light_add_tube`.  The practical effect of a beam with 0 sections is that the code tries to create lights with negative radius.  Interestingly, release builds seem not to care about this.