### PR TITLE
Add AVX2 to the list of supported MSVC compiler optimizations.

### DIFF
--- a/cmake/cpufeatures.cpp
+++ b/cmake/cpufeatures.cpp
@@ -27,6 +27,7 @@ int main( int argc, char* argv[] )
 	int SSE     = false;
 	int SSE2    = false;
 	int AVX     = false;
+	int AVX2    = false;
 
 	int info[4];
 	cpuid(info, 0);
@@ -40,8 +41,14 @@ int main( int argc, char* argv[] )
 
 		AVX   = (info[2] & ((int)1 << 28)) != 0;
 	}
+	if (nIds >= 7){
+		cpuid(info,0x00000007);
+		AVX2  = (info[1] & ((int)1 <<  5)) != 0;
+	}
 
-	if(AVX)
+	if (AVX2)
+		std::cout << "AVX2";
+	else if(AVX)
 		std::cout << "AVX";
 	else if(SSE2)
 		std::cout << "SSE2";

--- a/cmake/toolchain-msvc.cmake
+++ b/cmake/toolchain-msvc.cmake
@@ -88,7 +88,7 @@ ENDIF(MSVC_USE_RUNTIME_DLL)
 INCLUDE(MSVCMultipleProcessCompile)
 
 # Visual Studio supports compiling for multiple vector instruction sets
-SET(POSSIBLE_INSTUCTION_SETS "" SSE SSE2 AVX)
+SET(POSSIBLE_INSTUCTION_SETS "" SSE SSE2 AVX AVX2)
 
 if (NOT DEFINED MSVC_SIMD_INSTRUCTIONS)
 	detect_simd_instructions(MSVC_DETECTED_SIMD_INSTRUCTIONS)


### PR DESCRIPTION
Also adds AVX2 autodetection so that AVX2-capable processors will generate AVX2 projects by default. To my surprise, there is actually a noticeable performance increase between AVX and AVX2 builds.

With the help of @TRBlount (he runs at a higher resolution than I do), I generated this graph showing the FPS differences (running Icarus as the benchmark):
![A graph comparing the FPS of a runthrough of Icarus with an AVX build and an AVX2 build.](http://deviance.duckish.net/pictures/AVX_vs_AVX2.png)

The speedup appears to be related to models loading faster the first time they appear.