### PR TITLE
Fix duplicate tracing/profiling category.

### DIFF
--- a/code/tracing/categories.cpp
+++ b/code/tracing/categories.cpp
@@ -89,7 +89,7 @@ Category CutsceneProcessVideoData("Process video data", true);
 Category CutsceneProcessAudioData("Process audio data", false);
 
 Category CutsceneFFmpegVideoDecoder("FFmpeg decode video", false);
-Category CutsceneFFmpegAudioDecoder("FFmpeg decode video", false);
+Category CutsceneFFmpegAudioDecoder("FFmpeg decode audio", false);
 
 Category LoadMissionLoad("Load mission", false);
 Category LoadPostMissionLoad("Mission load post processing", false);


### PR DESCRIPTION
Cutscene audio decoding was accidentally named "FFmpeg decode video", causing some minor problems in the profiling code (because the same name is used for actual video decoding, resulting in an assertion firing).