### PR TITLE
Fix removing a collision group via SEXP.

### DIFF
--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -22294,7 +22294,7 @@ void sexp_manipulate_colgroup(int node, bool add_to_group) {
 			if (add_to_group) {
 				colgroup_id |= (1<<group);
 			} else {
-				colgroup_id &= !(1<<group);
+				colgroup_id &= ~(1<<group);
 			}
 		}
 


### PR DESCRIPTION
`sexp_manipulate_colgroup()` was using logical NOT when it should've been using bitwise NOT, meaning that removing any collision group would remove *all* collision groups.