### PR TITLE
Avoid faulty assumption in message bracket code.

### DIFF
--- a/code/hud/hudtarget.cpp
+++ b/code/hud/hudtarget.cpp
@@ -3289,7 +3289,11 @@ void hud_show_message_sender()
 	targetp = &Objects[Ships[Message_shipnum].objnum];
 	Assert ( targetp != NULL );
 
-	Assert ( targetp->type == OBJ_SHIP );
+	if (targetp->type != OBJ_SHIP) {
+		// if it's not a ship (maybe it got ship-vanished in the middle of talking) then clear Message_shipnum
+		Message_shipnum = -1;
+		return;
+	}
 
 	// Don't do this for the ship you're flying!
 	if ( targetp == Player_obj ) {


### PR DESCRIPTION
This assertion could apparently be hit if a ship was vanished (e.g. with `ship-vanish`) in the middle of talking. Rather than making the vanishing code aware of (and responsible for) `Message_shipnum`, it seemed simpler to just make `hud_show_message_sender()` clear the invalid shipnum itself.