### PR TITLE
Get rid of OpenGL warnings about the framebuffer being unsupported.

### DIFF
--- a/code/graphics/opengl/gropengldraw.cpp
+++ b/code/graphics/opengl/gropengldraw.cpp
@@ -2198,8 +2198,8 @@ void gr_opengl_deferred_lighting_finish()
 	}
 
 	glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, Scene_color_texture, 0);
+	glFramebufferTexture2D(GL_FRAMEBUFFER, GL_STENCIL_ATTACHMENT, GL_TEXTURE_2D, 0, 0);
 	glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_TEXTURE_2D, Scene_depth_texture, 0);
-	glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_STENCIL_ATTACHMENT, GL_RENDERBUFFER, 0);
 
 	gr_end_view_matrix();
 	gr_end_proj_matrix();


### PR DESCRIPTION
At least on NVidia drivers, the medium-severity warning "Framebuffer unsupported. Framebuffer object Scene framebuffer is unsupported because the depth and stencil attachments are mismatched." would get repeatedly output to the debug log. @SamuelCho suggested this change, which gets rid of the warnings and doesn't appear to have introduced any graphical glitches.

Fixes #1382.