### PR TITLE
Small improvement in error messages in stuff_int_list and mark_int_list

### DIFF
--- a/code/parse/parselo.cpp
+++ b/code/parse/parselo.cpp
@@ -2857,7 +2857,7 @@ int stuff_int_list(int *ilp, int max_ints, int lookup_type)
 					break;
 
 				default:
-					Error(LOCATION,"Unknown lookup_type in stuff_int_list");
+					Error(LOCATION,"Unknown lookup_type %d in stuff_int_list", lookup_type);
 					break;
 			}
 
@@ -3079,7 +3079,7 @@ void mark_int_list(int *ilp, int max_ints, int lookup_type)
 					break;
 
 				default:
-					Error(LOCATION,"Unknown lookup_type in stuff_int_list");
+					Error(LOCATION,"Unknown lookup_type %d in mark_int_list", lookup_type);
 					break;
 			}
 


### PR DESCRIPTION
While looking into the issue described in [this thread](http://www.hard-light.net/forums/index.php?topic=93624.0), I noticed that an Error message in `mark_int_list` incorrectly says `stuff_int_list`.  Then I saw that the invalid `lookup_type` value isn't printed in the error messages, so I thought that would be good to add.