### PR TITLE
Ignore leading whitespace for gr.drawString

### DIFF
--- a/code/parse/parselo.cpp
+++ b/code/parse/parselo.cpp
@@ -3438,7 +3438,7 @@ char *split_str_once(char *src, int max_pixel_w)
 //	returns:			number of lines src is broken into
 //						-1 is returned when an error occurs
 //
-int split_str(const char *src, int max_pixel_w, int *n_chars, const char **p_str, int max_lines, char ignore_char)
+int split_str(const char *src, int max_pixel_w, int *n_chars, const char **p_str, int max_lines, char ignore_char, bool strip_leading_whitespace)
 {
 	char buffer[SPLIT_STR_BUFFER_SIZE];
 	const char *breakpoint = NULL;
@@ -3457,7 +3457,7 @@ int split_str(const char *src, int max_pixel_w, int *n_chars, const char **p_str
 	ignore_until_whitespace = 0;
 
 	// get rid of any leading whitespace
-	while (is_white_space(*src))
+	while (strip_leading_whitespace && is_white_space(*src))
 		src++;
 
 	new_line = 1;
@@ -3472,7 +3472,7 @@ int split_str(const char *src, int max_pixel_w, int *n_chars, const char **p_str
 		// starting a new line of text, init stuff for that
 		if (new_line) {
 			p_str[line_num] = NULL;
-			if (is_gray_space(*src))
+			if (strip_leading_whitespace && is_gray_space(*src))
 				continue;
 
 			p_str[line_num] = src;
@@ -3560,7 +3560,7 @@ int split_str(const char *src, int max_pixel_w, int *n_chars, const char **p_str
 	return line_num;
 }
 
-int split_str(const char *src, int max_pixel_w, SCP_vector<int> &n_chars, SCP_vector<const char*> &p_str, char ignore_char)
+int split_str(const char *src, int max_pixel_w, SCP_vector<int> &n_chars, SCP_vector<const char*> &p_str, char ignore_char, bool strip_leading_whitespace)
 {
 	char buffer[SPLIT_STR_BUFFER_SIZE];
 	const char *breakpoint = NULL;
@@ -3574,7 +3574,7 @@ int split_str(const char *src, int max_pixel_w, SCP_vector<int> &n_chars, SCP_ve
 	memset(buffer, 0, SPLIT_STR_BUFFER_SIZE);
 
 	// get rid of any leading whitespace
-	while (is_white_space(*src))
+	while (strip_leading_whitespace && is_white_space(*src))
 		src++;
 
 	p_str.clear();
@@ -3585,7 +3585,7 @@ int split_str(const char *src, int max_pixel_w, SCP_vector<int> &n_chars, SCP_ve
 
 		// starting a new line of text, init stuff for that
 		if (new_line) {
-			if (is_gray_space(*src))
+			if (strip_leading_whitespace && is_gray_space(*src))
 				continue;
 
 			p_str.push_back(src);

--- a/code/parse/parselo.h
+++ b/code/parse/parselo.h
@@ -267,8 +267,8 @@ extern void maybe_convert_foreign_characters(SCP_string &text);
 extern size_t get_converted_string_length(const char *text);
 extern size_t get_converted_string_length(const SCP_string &text);
 char *split_str_once(char *src, int max_pixel_w);
-int split_str(const char *src, int max_pixel_w, int *n_chars, const char **p_str, int max_lines, char ignore_char = -1);
-int split_str(const char *src, int max_pixel_w, SCP_vector<int> &n_chars, SCP_vector<const char*> &p_str, char ignore_char = -1);
+int split_str(const char *src, int max_pixel_w, int *n_chars, const char **p_str, int max_lines, char ignore_char = -1, bool strip_leading_whitespace = true);
+int split_str(const char *src, int max_pixel_w, SCP_vector<int> &n_chars, SCP_vector<const char*> &p_str, char ignore_char = -1, bool strip_leading_whitespace = true);
 
 // fred
 extern int required_string_fred(char *pstr, char *end = NULL);

--- a/code/scripting/api/objs/graphics.cpp
+++ b/code/scripting/api/objs/graphics.cpp
@@ -1084,8 +1084,8 @@ ADE_FUNC(drawString, l_Graphics, "string Message, [number X1, number Y1, number 
 	}
 	else
 	{
-		int linelengths[MAX_TEXT_LINES];
-		const char *linestarts[MAX_TEXT_LINES];
+		SCP_vector<int> linelengths;
+		SCP_vector<const char*> linestarts;
 
 		if (y2 >= 0 && y2 < y)
 		{
@@ -1097,7 +1097,7 @@ ADE_FUNC(drawString, l_Graphics, "string Message, [number X1, number Y1, number 
 			y2 = temp;
 		}
 
-		num_lines = split_str(s, x2-x, linelengths, linestarts, MAX_TEXT_LINES);
+		num_lines = split_str(s, x2-x, linelengths, linestarts, -1, false);
 
 		//Make sure we don't go over size
 		int line_ht = gr_get_font_height();


### PR DESCRIPTION
This was reported by @AxemP who wanted to have leading tabs in a text
line. However, `split_str` removed those characters by default since it
ignores leading whitespace. To fix that unexpected behavior of
gr.drawString I added a new paramter to `split_str` which disabled
whitespace removal and enabled that flag for the scripting function.

That should not be a problem for existing scripts since the expected
behavior would be that leading whitespace remains in place and since we
have not received any bug reports about missing white space I'm going to
assume that no one has used the function like this before removed those
characters by default since it ignores leading whitespace. To fix that
unexpected behavior of gr.drawString I added a new paramter to `split_str`
which disabled whitespace removal and enabled that flag for the
scripting function.

That should not be a problem for existing scripts since the expected
behavior would be that leading whitespace remains in place and since we
have not received any bug reports about missing white space I'm going to
assume that no one has used the function like this before.