### PR TITLE
Fix Assertion when default Volition font could not be found

### DIFF
--- a/code/graphics/software/NVGFont.cpp
+++ b/code/graphics/software/NVGFont.cpp
@@ -189,6 +189,13 @@ namespace font
 
 						int charWidth;
 						int spacing;
+
+						if (m_specialCharacters == nullptr) {
+							Error(LOCATION,
+								  "Font %s has no special characters font! This is usually caused by ignoring a font table parsing warning.",
+								  getName().c_str());
+						}
+
 						get_char_width_old(m_specialCharacters, static_cast<ubyte>(*s), '\0', &charWidth, &spacing);
 
 						lineWidth += i2fl(spacing);

--- a/code/graphics/software/font.cpp
+++ b/code/graphics/software/font.cpp
@@ -188,7 +188,16 @@ namespace
 		else
 		{
 			fo::font* fontData = FontManager::loadFontOld("font01.vf");
-			nvgFont->setSpecialCharacterFont(fontData);
+
+			if (fontData == nullptr) {
+				error_display(0,
+							  "Failed to load default font \"%s\" for special characters of font \"%s\"! "
+								  "This font is required for rendering special characters and will cause an error later.",
+							  "font01.vf",
+							  fontFilename.c_str());
+			} else {
+				nvgFont->setSpecialCharacterFont(fontData);
+			}
 		}
 
 		nvgFont->setName(fontStr);


### PR DESCRIPTION
Instead, this will now cause a Warning when the issue is detected while
parsing the table and an Error when it still occurs at runtime.