### PR TITLE
Add waypoint editor

### DIFF
--- a/qtfred/source_groups.cmake
+++ b/qtfred/source_groups.cmake
@@ -45,6 +45,8 @@ add_file_folder("Source/Mission/Dialogs"
     src/mission/dialogs/AbstractDialogModel.h
     src/mission/dialogs/EventEditorDialogModel.cpp
     src/mission/dialogs/EventEditorDialogModel.h
+	src/mission/dialogs/WaypointEditorDialogModel.cpp
+	src/mission/dialogs/WaypointEditorDialogModel.h
 )
 
 add_file_folder("Source/UI"
@@ -63,6 +65,8 @@ add_file_folder("Source/UI/Dialogs"
 	src/ui/dialogs/MissionGoalsDialog.h
 	src/ui/dialogs/TeamLoadoutDialog.cpp
 	src/ui/dialogs/TeamLoadoutDialog.h
+	src/ui/dialogs/WaypointEditorDialog.cpp
+	src/ui/dialogs/WaypointEditorDialog.h
 )
 
 add_file_folder("Source/UI/Widgets"

--- a/qtfred/source_groups.cmake
+++ b/qtfred/source_groups.cmake
@@ -78,6 +78,7 @@ add_file_folder("UI"
     ui/BriefingEditorDialog.ui
 	ui/MissionGoalsDialog.ui
 	ui/TeamLoadoutDialog.ui
+    ui/WaypointEditorDialog.ui
 )
 
 add_file_folder("Resources"

--- a/qtfred/src/mission/Editor.h
+++ b/qtfred/src/mission/Editor.h
@@ -10,8 +10,8 @@
 #include <stdexcept>
 
 #include <globalincs/globals.h>
-
 #include <osapi/osapi.h>
+#include <object/waypoint.h>
 
 namespace fso {
 namespace fred {
@@ -58,8 +58,6 @@ class Editor : public QObject {
 
 	void fix_ship_name(int ship);
 
-	int getCurrentObject();
-
 	int getNumMarked();
 
 	void hideMarkedObjects();
@@ -91,6 +89,19 @@ signals:
 	 * @brief A signal emitted when the mission has changed somehow
 	 */
 	void missionChanged();
+
+	/**
+	 * @brief Signal which is emitted when the currently selected object changed
+	 * @param new_obj The newly selected object index, may be -1 if no object is selected
+	 */
+	void currentObjectChanged(int new_obj);
+
+	/**
+	 * @brief A signal which is emitted if the marking status of an object changed
+	 * @param obj The object which changed
+	 * @param marked @c true if the object is now marked, @c false otherwise
+	 */
+	void objectMarkingChanged(int obj, bool marked);
  public:
 
 	int Id_select_type_jump_node = 0;
@@ -98,6 +109,20 @@ signals:
 
 	// object numbers for ships in a wing.
 	int wing_objects[MAX_WINGS][MAX_SHIPS_PER_WING];
+
+	int currentObject = -1;
+	int cur_wing = -1;
+	int cur_ship = -1;
+
+	int cur_wing_index = -1;
+
+	waypoint *cur_waypoint = nullptr;
+	waypoint_list *cur_waypoint_list = nullptr;
+
+	void ai_update_goal_references(int type, const char *old_name, const char *new_name);
+
+	// Goober5000
+	void update_texture_replacements(const char *old_name, const char *new_name);
 
  private:
 	void clearMission();
@@ -109,7 +134,6 @@ signals:
 	SCP_vector<std::unique_ptr<EditorViewport>> _viewports;
 	EditorViewport* _lastActiveViewport = nullptr;
 
-	int currentObject = -1;
 	int numMarked = 0;
 
 	int Default_player_model = -1;
@@ -118,8 +142,6 @@ signals:
 	int Shield_sys_types[MAX_SHIP_CLASSES];
 
 	int delete_flag;
-
-	int cur_wing = -1;
 
 	bool already_deleting_wing = false;
 
@@ -133,11 +155,6 @@ signals:
 	int delete_ship_from_wing(int ship);
 
 	int invalidate_references(const char *name, int type);
-
-	void ai_update_goal_references(int type, const char *old_name, const char *new_name);
-
-	// Goober5000
-	void update_texture_replacements(const char *old_name, const char *new_name);
 
 	// DA 1/7/99 These ship names are not variables
 	int rename_ship(int ship, char *name);

--- a/qtfred/src/mission/EditorViewport.cpp
+++ b/qtfred/src/mission/EditorViewport.cpp
@@ -304,6 +304,7 @@ void EditorViewport::process_system_keys(int key) {
 
 	case KEY_SPACEBAR:
 		Selection_lock = !Selection_lock;
+		dialogProvider->showButtonDialog(DialogType::Error, "Title test", "Message", { DialogButton::Yes, DialogButton::No, DialogButton::Cancel });
 		break;
 
 	case KEY_ESC:
@@ -943,7 +944,7 @@ int EditorViewport::drag_objects(int x, int y)
 	}
 	*/
 
-	if (!query_valid_object(editor->getCurrentObject()))
+	if (!query_valid_object(editor->currentObject))
 		return -1;
 
 	if (Dup_drag == 1
@@ -977,7 +978,7 @@ int EditorViewport::drag_objects(int x, int y)
 					break;
 				}
 
-				if (editor->getCurrentObject() == OBJ_INDEX(objp) )
+				if (editor->currentObject == OBJ_INDEX(objp) )
 					cobj = z;
 			}
 
@@ -1022,7 +1023,7 @@ int EditorViewport::drag_objects(int x, int y)
 		editor->missionChanged();
 	}
 
-	objp = &Objects[editor->getCurrentObject()];
+	objp = &Objects[editor->currentObject];
 	Assert(objp->type != OBJ_NONE);
 	obj = int_pnt = objp->pos;
 
@@ -1128,11 +1129,11 @@ int EditorViewport::drag_rotate_objects(int mouse_dx, int mouse_dy) {
     }
     */
 
-	if (!query_valid_object(editor->getCurrentObject())){
+	if (!query_valid_object(editor->currentObject)){
 		return -1;
 	}
 
-	objp = &Objects[editor->getCurrentObject()];
+	objp = &Objects[editor->currentObject];
 	Assert(objp->type != OBJ_NONE);
 	obj = int_pnt = objp->pos;
 
@@ -1158,7 +1159,7 @@ int EditorViewport::drag_rotate_objects(int mouse_dx, int mouse_dy) {
 		}
 	}
 
-	leader = &Objects[editor->getCurrentObject()];
+	leader = &Objects[editor->currentObject];
 	leader_orient = leader->orient;			// save original orientation
 	vm_copy_transpose(&leader_transpose, &leader_orient);
 
@@ -1169,7 +1170,7 @@ int EditorViewport::drag_rotate_objects(int mouse_dx, int mouse_dy) {
 	objp = GET_FIRST(&obj_used_list);
 	while (objp != END_OF_LIST(&obj_used_list))			{
 		Assert(objp->type != OBJ_NONE);
-		if ((objp->flags[Object::Object_Flags::Marked]) && (editor->getCurrentObject() != OBJ_INDEX(objp) )) {
+		if ((objp->flags[Object::Object_Flags::Marked]) && (editor->currentObject != OBJ_INDEX(objp) )) {
 			if (Group_rotate) {
 				matrix rot_trans;
 				vec3d tmpv1, tmpv2;

--- a/qtfred/src/mission/dialogs/AbstractDialogModel.h
+++ b/qtfred/src/mission/dialogs/AbstractDialogModel.h
@@ -9,8 +9,8 @@ namespace fso {
 namespace fred {
 namespace dialogs {
 
-class AbstractDialogModel : public QObject {
-	Q_OBJECT
+class AbstractDialogModel: public QObject {
+ Q_OBJECT
 
  protected:
 	Editor* _editor = nullptr;
@@ -18,6 +18,20 @@ class AbstractDialogModel : public QObject {
 
  public:
 	AbstractDialogModel(QObject* parent, EditorViewport* viewport);
+
+	virtual ~AbstractDialogModel() {
+	}
+
+	virtual bool apply() = 0;
+	virtual void reject() = 0;
+
+ signals:
+	/**
+	 * @brief Signal emitted when the model has changed caused by an update operation
+	 *
+	 * This should be used for updating the view
+	 */
+	void modelChanged();
 };
 
 }

--- a/qtfred/src/mission/dialogs/EventEditorDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/EventEditorDialogModel.cpp
@@ -10,11 +10,10 @@ namespace dialogs {
 EventEditorDialogModel::EventEditorDialogModel(QObject* parent, EditorViewport* viewport) :
 	AbstractDialogModel(parent, viewport) {
 }
-void EventEditorDialogModel::applyChanges() {
-
+bool EventEditorDialogModel::apply() {
+	return true;
 }
-void EventEditorDialogModel::discardChanges() {
-
+void EventEditorDialogModel::reject() {
 }
 }
 }

--- a/qtfred/src/mission/dialogs/EventEditorDialogModel.h
+++ b/qtfred/src/mission/dialogs/EventEditorDialogModel.h
@@ -11,8 +11,8 @@ class EventEditorDialogModel: public AbstractDialogModel {
  public:
 	EventEditorDialogModel(QObject* parent, EditorViewport* viewport);
 
-	void applyChanges();
-	void discardChanges();
+	bool apply() override;
+	void reject() override;
 };
 
 }

--- a/qtfred/src/mission/dialogs/WaypointEditorDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/WaypointEditorDialogModel.cpp
@@ -1,0 +1,397 @@
+#include <jumpnode/jumpnode.h>
+#include <mission/object.h>
+#include <globalincs/linklist.h>
+#include <ship/ship.h>
+#include <iff_defs/iff_defs.h>
+#include "mission/dialogs/WaypointEditorDialogModel.h"
+
+namespace fso {
+namespace fred {
+namespace dialogs {
+
+WaypointEditorDialogModel::WaypointEditorDialogModel(QObject* parent, EditorViewport* viewport) :
+	AbstractDialogModel(parent, viewport) {
+	connect(viewport->editor, &Editor::currentObjectChanged, this, &WaypointEditorDialogModel::onSelectedObjectChanged);
+	connect(viewport->editor,
+			&Editor::objectMarkingChanged,
+			this,
+			&WaypointEditorDialogModel::onSelectedObjectMarkingChanged);
+	connect(viewport->editor, &Editor::missionChanged, this, &WaypointEditorDialogModel::missionChanged);
+
+	initializeData();
+}
+bool WaypointEditorDialogModel::showErrorDialog(const SCP_string& message, const SCP_string title) {
+	if (bypass_errors) {
+		return true;
+	}
+
+	bypass_errors = 1;
+	auto z = _viewport->dialogProvider->showButtonDialog(DialogType::Error,
+														 title,
+														 message,
+														 { DialogButton::Ok, DialogButton::Cancel });
+
+	if (z == DialogButton::Cancel) {
+		return true;
+	}
+
+	return false;
+}
+bool WaypointEditorDialogModel::apply() {
+	// Reset flag before applying
+	bypass_errors = false;
+
+	const char* str;
+	char old_name[255];
+	int i;
+	object* ptr;
+	SCP_list<CJumpNode>::iterator jnp;
+
+	if (query_valid_object(_editor->currentObject) && Objects[_editor->currentObject].type == OBJ_WAYPOINT) {
+		Assert(
+			_editor->cur_waypoint_list == find_waypoint_list_with_instance(Objects[_editor->currentObject].instance));
+	}
+
+	if (_editor->cur_waypoint_list != NULL) {
+		for (i = 0; i < MAX_WINGS; i++) {
+			if (!stricmp(Wings[i].name, _currentName.c_str())) {
+				if (showErrorDialog("This waypoint path name is already being used by a wing\n"
+										"Press OK to restore old name", "Error")) {
+					return false;
+				}
+
+				_currentName = _editor->cur_waypoint_list->get_name();
+				modelChanged();
+			}
+		}
+
+		ptr = GET_FIRST(&obj_used_list);
+		while (ptr != END_OF_LIST(&obj_used_list)) {
+			if ((ptr->type == OBJ_SHIP) || (ptr->type == OBJ_START)) {
+				if (!stricmp(_currentName.c_str(), Ships[ptr->instance].ship_name)) {
+					if (showErrorDialog("This waypoint path name is already being used by a ship\n"
+											"Press OK to restore old name", "Error")) {
+						return false;
+					}
+
+					_currentName = _editor->cur_waypoint_list->get_name();
+					modelChanged();
+				}
+			}
+
+			ptr = GET_NEXT(ptr);
+		}
+
+		for (i = 0; i < Num_iffs; i++) {
+			if (!stricmp(_currentName.c_str(), Iff_info[i].iff_name)) {
+				if (showErrorDialog("This waypoint path name is already being used by a team.\n"
+										"Press OK to restore old name", "Error")) {
+					return false;
+				}
+
+				_currentName = _editor->cur_waypoint_list->get_name();
+				modelChanged();
+			}
+		}
+
+		for (i = 0; i < (int) Ai_tp_list.size(); i++) {
+			if (!stricmp(_currentName.c_str(), Ai_tp_list[i].name)) {
+				if (showErrorDialog("This waypoint path name is already being used by a target priority group.\n"
+										"Press OK to restore old name", "Error")) {
+					return false;
+				}
+
+				_currentName = _editor->cur_waypoint_list->get_name();
+				modelChanged();
+			}
+		}
+
+		SCP_list<waypoint_list>::iterator ii;
+		for (ii = Waypoint_lists.begin(); ii != Waypoint_lists.end(); ++ii) {
+			if (!stricmp(ii->get_name(), _currentName.c_str()) && (&(*ii) != _editor->cur_waypoint_list)) {
+				if (showErrorDialog("This waypoint path name is already being used by another waypoint path\n"
+										"Press OK to restore old name", "Error")) {
+					return false;
+				}
+
+				_currentName = _editor->cur_waypoint_list->get_name();
+				modelChanged();
+			}
+		}
+
+		if (jumpnode_get_by_name(_currentName.c_str()) != NULL) {
+			if (showErrorDialog("This waypoint path name is already being used by a jump node\n"
+									"Press OK to restore old name", "Error")) {
+				return false;
+			}
+
+			_currentName = _editor->cur_waypoint_list->get_name();
+			modelChanged();
+		}
+
+		if (_currentName[0] == '<') {
+			if (showErrorDialog("Waypoint names not allowed to begin with <\n"
+									"Press OK to restore old name", "Error")) {
+				return false;
+			}
+
+			_currentName = _editor->cur_waypoint_list->get_name();
+			modelChanged();
+		}
+
+
+		strcpy_s(old_name, _editor->cur_waypoint_list->get_name());
+		strcpy_s(_editor->cur_waypoint_list->get_name(), NAME_LENGTH, _currentName.c_str());
+
+		str = _currentName.c_str();
+		if (strcmp(old_name, str)) {
+			update_sexp_references(old_name, str);
+			_editor->ai_update_goal_references(REF_TYPE_WAYPOINT, old_name, str);
+			_editor->update_texture_replacements(old_name, str);
+		}
+
+		_editor->missionChanged();
+	} else if (Objects[_editor->currentObject].type == OBJ_JUMP_NODE) {
+		for (jnp = Jump_nodes.begin(); jnp != Jump_nodes.end(); ++jnp) {
+			if (jnp->GetSCPObject() == &Objects[_editor->currentObject]) {
+				break;
+			}
+		}
+
+		for (i = 0; i < MAX_WINGS; i++) {
+			if (!stricmp(Wings[i].name, _currentName.c_str())) {
+				if (showErrorDialog("This jump node name is already being used by a wing\n"
+										"Press OK to restore old name", "Error")) {
+					return false;
+				}
+
+				_currentName = jnp->GetName();
+				modelChanged();
+			}
+		}
+
+		ptr = GET_FIRST(&obj_used_list);
+		while (ptr != END_OF_LIST(&obj_used_list)) {
+			if ((ptr->type == OBJ_SHIP) || (ptr->type == OBJ_START)) {
+				if (!stricmp(_currentName.c_str(), Ships[ptr->instance].ship_name)) {
+					if (showErrorDialog("This jump node name is already being used by a ship\n"
+											"Press OK to restore old name", "Error")) {
+						return false;
+					}
+
+					_currentName = jnp->GetName();
+					modelChanged();
+				}
+			}
+
+			ptr = GET_NEXT(ptr);
+		}
+
+		for (i = 0; i < Num_iffs; i++) {
+			if (!stricmp(_currentName.c_str(), Iff_info[i].iff_name)) {
+				if (showErrorDialog("This jump node name is already being used by a team.\n"
+										"Press OK to restore old name", "Error")) {
+					return false;
+				}
+
+				_currentName = jnp->GetName();
+				modelChanged();
+			}
+		}
+
+		for (i = 0; i < (int) Ai_tp_list.size(); i++) {
+			if (!stricmp(_currentName.c_str(), Ai_tp_list[i].name)) {
+				if (showErrorDialog("This jump node name is already being used by a target priority group.\n"
+										"Press OK to restore old name", "Error")) {
+					return false;
+				}
+
+				_currentName = jnp->GetName();
+				modelChanged();
+			}
+		}
+
+		if (find_matching_waypoint_list(_currentName.c_str()) != NULL) {
+			if (showErrorDialog("This jump node name is already being used by a waypoint path\n"
+									"Press OK to restore old name", "Error")) {
+				return false;
+			}
+
+			_currentName = jnp->GetName();
+			modelChanged();
+		}
+
+		if (_currentName[0] == '<') {
+			if (showErrorDialog("Jump node names not allowed to begin with <\n"
+									"Press OK to restore old name", "Error")) {
+				return false;
+			}
+
+			_currentName = jnp->GetName();
+			modelChanged();
+		}
+
+		CJumpNode* found = jumpnode_get_by_name(_currentName.c_str());
+		if (found != NULL && &(*jnp) != found) {
+			if (showErrorDialog("This jump node name is already being used by another jump node\n"
+									"Press OK to restore old name", "Error")) {
+				return false;
+			}
+
+			_currentName = jnp->GetName();
+			modelChanged();
+		}
+
+		strcpy_s(old_name, jnp->GetName());
+		jnp->SetName(_currentName.c_str());
+
+		str = _currentName.c_str();
+		if (strcmp(old_name, str)) {
+			update_sexp_references(old_name, str);
+		}
+
+		_editor->missionChanged();
+	}
+
+	return true;
+}
+void WaypointEditorDialogModel::reject() {
+}
+void WaypointEditorDialogModel::onSelectedObjectChanged(int) {
+	initializeData();
+}
+void WaypointEditorDialogModel::onSelectedObjectMarkingChanged(int, bool) {
+	initializeData();
+}
+void WaypointEditorDialogModel::initializeData() {
+	_enabled = true;
+	SCP_list<CJumpNode>::iterator jnp;
+
+	updateElementList();
+
+	if (query_valid_object(_editor->currentObject) && Objects[_editor->currentObject].type == OBJ_WAYPOINT) {
+		Assert(
+			_editor->cur_waypoint_list == find_waypoint_list_with_instance(Objects[_editor->currentObject].instance));
+	}
+
+	if (_editor->cur_waypoint_list != NULL) {
+		_currentName = _editor->cur_waypoint_list->get_name();
+	} else if (Objects[_editor->currentObject].type == OBJ_JUMP_NODE) {
+		for (jnp = Jump_nodes.begin(); jnp != Jump_nodes.end(); ++jnp) {
+			if (jnp->GetSCPObject() == &Objects[_editor->currentObject]) {
+				break;
+			}
+		}
+
+		_currentName = jnp->GetName();
+	} else {
+		_currentName = "";
+		_enabled = false;
+	}
+
+	modelChanged();
+}
+const SCP_string& WaypointEditorDialogModel::getCurrentName() const {
+	return _currentName;
+}
+int WaypointEditorDialogModel::getCurrentElementId() const {
+	return _currentElementId;
+}
+bool WaypointEditorDialogModel::isEnabled() const {
+	return _enabled;
+}
+const SCP_vector<WaypointEditorDialogModel::PointListElement>& WaypointEditorDialogModel::getElements() const {
+	return _elements;
+}
+void WaypointEditorDialogModel::updateElementList() {
+	int i;
+	SCP_list<waypoint_list>::iterator ii;
+	SCP_list<CJumpNode>::iterator jnp;
+
+	_elements.clear();
+	_currentElementId = -1;
+
+	for (i = 0, ii = Waypoint_lists.begin(); ii != Waypoint_lists.end(); ++i, ++ii) {
+		_elements.push_back(PointListElement(ii->get_name(), ID_WAYPOINT_MENU + i));
+	}
+
+	i = 0;
+	for (jnp = Jump_nodes.begin(); jnp != Jump_nodes.end(); ++jnp) {
+		_elements.push_back(PointListElement(jnp->GetName(), ID_JUMP_NODE_MENU + i));
+		if (jnp->GetSCPObjectNumber() == _editor->currentObject) {
+			_currentElementId = ID_JUMP_NODE_MENU + i;
+		}
+		i++;
+
+	}
+
+	if (_editor->cur_waypoint_list != NULL) {
+		int index = find_index_of_waypoint_list(_editor->cur_waypoint_list);
+		Assert(index >= 0);
+		_currentElementId = ID_WAYPOINT_MENU + index;
+	}
+}
+void WaypointEditorDialogModel::idSelected(int id) {
+	if (_currentElementId == id) {
+		// Nothing to do here
+		return;
+	}
+
+	int point;
+	object* ptr;
+
+	if ((id >= ID_WAYPOINT_MENU) && (id < ID_WAYPOINT_MENU + (int) Waypoint_lists.size())) {
+		if (apply()) {
+			point = id - ID_WAYPOINT_MENU;
+			_editor->unmark_all();
+			ptr = GET_FIRST(&obj_used_list);
+			while (ptr != END_OF_LIST(&obj_used_list)) {
+				if (ptr->type == OBJ_WAYPOINT) {
+					if (calc_waypoint_list_index(ptr->instance) == point) {
+						_editor->markObject(OBJ_INDEX(ptr));
+					}
+				}
+
+				ptr = GET_NEXT(ptr);
+			}
+
+			return;
+		}
+	}
+
+	if ((id >= ID_JUMP_NODE_MENU) && (id < ID_JUMP_NODE_MENU + (int) Jump_nodes.size())) {
+		if (apply()) {
+			point = id - ID_JUMP_NODE_MENU;
+			_editor->unmark_all();
+			ptr = GET_FIRST(&obj_used_list);
+			while ((ptr != END_OF_LIST(&obj_used_list)) && (point > -1)) {
+				if (ptr->type == OBJ_JUMP_NODE) {
+					if (point == 0) {
+						_editor->markObject(OBJ_INDEX(ptr));
+					}
+					point--;
+				}
+
+				ptr = GET_NEXT(ptr);
+			}
+
+			return;
+		}
+	}
+}
+void WaypointEditorDialogModel::setNameEditText(const SCP_string& name) {
+	_currentName = name;
+
+	modelChanged();
+}
+void WaypointEditorDialogModel::missionChanged() {
+	// When the mission is changed we also need to update our data in case one of our elements changed
+	initializeData();
+}
+
+WaypointEditorDialogModel::PointListElement::PointListElement(const SCP_string& in_name, int in_id) :
+	name(in_name), id(in_id) {
+}
+}
+}
+}

--- a/qtfred/src/mission/dialogs/WaypointEditorDialogModel.h
+++ b/qtfred/src/mission/dialogs/WaypointEditorDialogModel.h
@@ -1,0 +1,57 @@
+#pragma once
+
+#include "mission/dialogs/AbstractDialogModel.h"
+
+namespace fso {
+namespace fred {
+namespace dialogs {
+
+class WaypointEditorDialogModel: public AbstractDialogModel {
+ Q_OBJECT
+
+ public:
+	struct PointListElement {
+		SCP_string name;
+		int id = -1;
+
+		PointListElement(const SCP_string& name, int id);
+	};
+
+	WaypointEditorDialogModel(QObject* parent, EditorViewport* viewport);
+
+	bool apply() override;
+
+	void reject() override;
+
+	static const int ID_JUMP_NODE_MENU = 8000;
+	static const int ID_WAYPOINT_MENU = 9000;
+
+	const SCP_string& getCurrentName() const;
+	int getCurrentElementId() const;
+	bool isEnabled() const;
+	const SCP_vector<WaypointEditorDialogModel::PointListElement>& getElements() const;
+
+	void idSelected(int elementId);
+	void setNameEditText(const SCP_string& name);
+ private:
+	bool showErrorDialog(const SCP_string& message, const SCP_string title);
+
+	void onSelectedObjectChanged(int);
+	void onSelectedObjectMarkingChanged(int, bool);
+	void missionChanged();
+
+	void updateElementList();
+
+	void initializeData();
+
+	SCP_string _currentName;
+	int _currentElementId = -1;
+	bool _enabled = false;
+	SCP_vector<PointListElement> _elements;
+
+	bool bypass_errors = false;
+};
+
+}
+}
+}

--- a/qtfred/src/ui/FredView.cpp
+++ b/qtfred/src/ui/FredView.cpp
@@ -13,6 +13,7 @@
 #include <io/key.h>
 #include <ui/dialogs/EventEditorDialog.h>
 #include <ui/dialogs/BriefingEditorDialog.h>
+#include <ui/dialogs/WaypointEditorDialog.h>
 
 #include "mission/Editor.h"
 #include "mission/management.h"
@@ -403,6 +404,8 @@ void FredView::windowActivated() {
 
 	// Track the last active viewport
 	fred->setActiveViewport(_viewport);
+
+	viewWindowActivated();
 }
 void FredView::windowDeactivated() {
 	key_lost_focus();
@@ -526,7 +529,7 @@ void FredView::on_actionCamera_triggered(bool enabled) {
 void FredView::on_actionCurrent_Ship_triggered(bool enabled) {
 	if (enabled) {
 		_viewport->viewpoint = 1;
-		_viewport->view_obj = fred->getCurrentObject();
+		_viewport->view_obj = fred->currentObject;
 
 		_viewport->needsUpdate();
 	}
@@ -581,6 +584,10 @@ void FredView::onShipClassSelected(int ship_class) {
 void FredView::on_actionBriefing_triggered(bool) {
 	auto eventEditor = new dialogs::BriefingEditorDialog(this);
 	eventEditor->show();
+}
+void FredView::on_actionWaypoint_Paths_triggered(bool) {
+	auto editorDialog = new dialogs::WaypointEditorDialog(this, _viewport);
+	editorDialog->show();
 }
 DialogButton FredView::showButtonDialog(DialogType type,
 										const SCP_string& title,

--- a/qtfred/src/ui/FredView.h
+++ b/qtfred/src/ui/FredView.h
@@ -23,14 +23,13 @@ namespace Ui {
 class FredView;
 }
 
-class FredView : public QMainWindow, public IDialogProvider
-{
-    Q_OBJECT
+class FredView: public QMainWindow, public IDialogProvider {
+ Q_OBJECT
 
-public:
-    explicit FredView(QWidget *parent = nullptr);
-    ~FredView();
-    void setEditor(Editor* editor, EditorViewport* viewport);
+ public:
+	explicit FredView(QWidget* parent = nullptr);
+	~FredView();
+	void setEditor(Editor* editor, EditorViewport* viewport);
 
 	void loadMissionFile(const QString& pathName);
 
@@ -39,12 +38,12 @@ public:
 
 	void showContextMenu(const QPoint& globalPos);
 
-public slots:
-    void openLoadMissionDIalog();
+ public slots:
+	void openLoadMissionDIalog();
 
 	void newMission();
 
-private slots:
+ private slots:
 	void on_actionExit_triggered(bool);
 
 	void on_actionConstrainX_triggered(bool enabled);
@@ -84,7 +83,7 @@ private slots:
 	void on_actionWaypoint_Paths_triggered(bool);
 
 	void on_actionSelectionLock_triggered(bool enabled);
-signals:
+ signals:
 	/**
 	 * @brief Special version of FredApplication::onIdle which is limited to the lifetime of this object
 	 */
@@ -94,11 +93,13 @@ signals:
 	 * @brief This is emitted when the view window is activated after being deactivated
 	 */
 	void viewWindowActivated();
-protected:
+ protected:
 	bool event(QEvent* event) override;
 
 	void keyPressEvent(QKeyEvent* event) override;
 	void keyReleaseEvent(QKeyEvent* event) override;
+
+	void mouseDoubleClickEvent(QMouseEvent* event) override;
 
  private:
 	void on_mission_loaded(const std::string& filepath);
@@ -127,6 +128,11 @@ protected:
 
 	QMenu* _viewPopup = nullptr;
 
+	QMenu* _editPopup = nullptr;
+	QAction* _editObjectAction = nullptr;
+	QAction* _editOrientPositionAction = nullptr;
+	QAction* _editWingAction = nullptr;
+
 	QMenu* _controlModeMenu = nullptr;
 	QAction* _controlModeCamera = nullptr;
 	QAction* _controlModeCurrentShip = nullptr;
@@ -135,11 +141,13 @@ protected:
 
 	std::unique_ptr<ColorComboBox> _shipClassBox;
 
-    Editor* fred = nullptr;
+	Editor* fred = nullptr;
 	EditorViewport* _viewport = nullptr;
 
 	bool _inKeyPressHandler = false;
 	bool _inKeyReleaseHandler = false;
+
+	int _currentPopupObject = -1; //!< This is the object that was under the cursor when the context menu was requested
 
 	void onUpdateConstrains();
 	void onUpdateEditingMode();
@@ -153,13 +161,15 @@ protected:
 	void windowActivated();
 	void windowDeactivated();
 
+	void editObjectTriggered();
+
  public:
 	DialogButton showButtonDialog(DialogType type,
 								  const SCP_string& title,
 								  const SCP_string& message,
 								  const flagset<DialogButton>& buttons) override;
+	void handleObjectEditor(int objNum);
 };
-
 
 } // namespace fred
 } // namespace fso

--- a/qtfred/src/ui/FredView.h
+++ b/qtfred/src/ui/FredView.h
@@ -81,6 +81,7 @@ private slots:
 
 	void on_actionEvents_triggered(bool);
 	void on_actionBriefing_triggered(bool);
+	void on_actionWaypoint_Paths_triggered(bool);
 
 	void on_actionSelectionLock_triggered(bool enabled);
 signals:
@@ -89,6 +90,10 @@ signals:
 	 */
 	void viewIdle();
 
+	/**
+	 * @brief This is emitted when the view window is activated after being deactivated
+	 */
+	void viewWindowActivated();
 protected:
 	bool event(QEvent* event) override;
 

--- a/qtfred/src/ui/dialogs/EventEditorDialog.cpp
+++ b/qtfred/src/ui/dialogs/EventEditorDialog.cpp
@@ -12,8 +12,8 @@ EventEditorDialog::EventEditorDialog(QWidget* parent, EditorViewport* viewport) 
 	QDialog(parent), ui(new Ui::EventEditorDialog()), _model(new EventEditorDialogModel(this, viewport)) {
 	ui->setupUi(this);
 
-	connect(this, &QDialog::accepted, _model.get(), &EventEditorDialogModel::applyChanges);
-	connect(this, &QDialog::rejected, _model.get(), &EventEditorDialogModel::discardChanges);
+	connect(this, &QDialog::accepted, _model.get(), &EventEditorDialogModel::apply);
+	connect(this, &QDialog::rejected, _model.get(), &EventEditorDialogModel::reject);
 }
 EventEditorDialog::~EventEditorDialog() {
 }

--- a/qtfred/src/ui/dialogs/WaypointEditorDialog.cpp
+++ b/qtfred/src/ui/dialogs/WaypointEditorDialog.cpp
@@ -1,0 +1,87 @@
+#include <object/waypoint.h>
+#include <jumpnode/jumpnode.h>
+#include <QtWidgets/QTextEdit>
+#include "ui/dialogs/WaypointEditorDialog.h"
+
+#include "ui_WaypointEditorDialog.h"
+
+namespace fso {
+namespace fred {
+namespace dialogs {
+
+
+WaypointEditorDialog::WaypointEditorDialog(FredView* parent, EditorViewport* viewport) :
+	QDialog(parent),
+	_viewport(viewport),
+	_editor(viewport->editor),
+	ui(new Ui::WaypointEditorDialog()),
+	_model(new WaypointEditorDialogModel(this, viewport)) {
+	ui->setupUi(this);
+
+	connect(this, &QDialog::accepted, _model.get(), &WaypointEditorDialogModel::apply);
+	connect(this, &QDialog::rejected, _model.get(), &WaypointEditorDialogModel::reject);
+
+	connect(parent, &FredView::viewWindowActivated, _model.get(), &WaypointEditorDialogModel::apply);
+
+	connect(_model.get(), &AbstractDialogModel::modelChanged, this, &WaypointEditorDialog::updateUI);
+
+	connect(ui->pathSelection,
+			static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged),
+			this,
+			&WaypointEditorDialog::pathSelectionChanged);
+
+	connect(ui->nameEdit, &QLineEdit::textChanged, this, &WaypointEditorDialog::nameTextChanged);
+
+	// Initial set up of the UI
+	updateUI();
+}
+WaypointEditorDialog::~WaypointEditorDialog() {
+}
+void WaypointEditorDialog::pathSelectionChanged(int index) {
+	auto itemId = ui->pathSelection->itemData(index).value<int>();
+	_model->idSelected(itemId);
+}
+void WaypointEditorDialog::reject() {
+	// This dialog never rejects
+	accept();
+}
+void WaypointEditorDialog::updateComboBox() {
+	QSignalBlocker blocker(ui->pathSelection);
+
+	// Remove all previous entries
+	ui->pathSelection->clear();
+
+	for (auto& el : _model->getElements()) {
+		ui->pathSelection->addItem(QString::fromStdString(el.name), QVariant(el.id));
+	}
+
+	auto itemIndex = ui->pathSelection->findData(QVariant(_model->getCurrentElementId()));
+	ui->pathSelection->setCurrentIndex(itemIndex); // This also works if the index is -1
+}
+void WaypointEditorDialog::updateUI() {
+	// We need to block signals here or else updating the combobox would lead to and update of the model
+	// which would call this function again
+	QSignalBlocker blocker(this);
+
+	updateComboBox();
+
+	ui->nameEdit->setText(QString::fromStdString(_model->getCurrentName()));
+	ui->nameEdit->setEnabled(_model->isEnabled());
+}
+void WaypointEditorDialog::nameTextChanged(const QString& newText) {
+	_model->setNameEditText(newText.toStdString());
+}
+bool WaypointEditorDialog::event(QEvent* event) {
+	switch(event->type()) {
+	case QEvent::WindowDeactivate:
+		_model->apply();
+		event->accept();
+		return true;
+	default:
+		return QDialog::event(event);
+	}
+}
+
+}
+}
+}

--- a/qtfred/src/ui/dialogs/WaypointEditorDialog.h
+++ b/qtfred/src/ui/dialogs/WaypointEditorDialog.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <QDialog>
+
+#include <mission/dialogs/WaypointEditorDialogModel.h>
+#include <ui/FredView.h>
+
+#include <memory>
+
+namespace fso {
+namespace fred {
+namespace dialogs {
+
+namespace Ui {
+class WaypointEditorDialog;
+}
+
+class WaypointEditorDialog : public QDialog {
+	Q_OBJECT
+public:
+	WaypointEditorDialog(FredView* parent, EditorViewport* viewport);
+	~WaypointEditorDialog();
+
+	void reject() override;
+
+ protected:
+	bool event(QEvent* event) override;
+
+ private:
+
+	void pathSelectionChanged(int index);
+
+	void updateComboBox();
+
+	void updateUI();
+
+	void nameTextChanged(const QString& newText);
+
+	EditorViewport* _viewport = nullptr;
+	Editor* _editor = nullptr;
+	
+	std::unique_ptr<Ui::WaypointEditorDialog> ui;
+
+	std::unique_ptr<WaypointEditorDialogModel> _model;
+};
+
+}
+}
+}
+

--- a/qtfred/src/ui/widgets/ColorComboBox.h
+++ b/qtfred/src/ui/widgets/ColorComboBox.h
@@ -2,8 +2,9 @@
 
 
 #include <QtWidgets/QComboBox>
-#include <mission/EditorViewport.h>
+#include <QtGui/QStandardItemModel>
 
+#include <mission/EditorViewport.h>
 
 namespace fso {
 namespace fred {
@@ -20,6 +21,8 @@ class ColorComboBox: public QComboBox {
 
  private:
 	void indexChanged(int index);
+
+	QStandardItemModel* getShipClassModel();
 
  signals:
 	void shipClassSelected(int ship_class);

--- a/qtfred/src/ui/widgets/renderwidget.cpp
+++ b/qtfred/src/ui/widgets/renderwidget.cpp
@@ -1,3 +1,4 @@
+
 #include "renderwidget.h"
 
 #include <array>
@@ -198,7 +199,7 @@ void RenderWidget::keyReleaseEvent(QKeyEvent* key) {
 	key_mark(qt2fsKeys.at(code), 0, 0);
 }
 void RenderWidget::mouseDoubleClickEvent(QMouseEvent* event) {
-	QWidget::mouseDoubleClickEvent(event);
+	event->ignore();
 }
 void RenderWidget::mousePressEvent(QMouseEvent* event) {
 	if (event->button() != Qt::LeftButton) {

--- a/qtfred/src/ui/widgets/renderwidget.cpp
+++ b/qtfred/src/ui/widgets/renderwidget.cpp
@@ -207,14 +207,11 @@ void RenderWidget::mousePressEvent(QMouseEvent* event) {
 	}
 
 	int waypoint_instance = -1;
-	/*
-	 * // TODO: Port this when waypoints are implemented
-	if (cur_waypoint != NULL)
+	if (fred->cur_waypoint != NULL)
 	{
-		Assert(cur_waypoint_list != NULL);
-		waypoint_instance = Objects[cur_waypoint->get_objnum()].instance;
+		Assert(fred->cur_waypoint_list != NULL);
+		waypoint_instance = Objects[fred->cur_waypoint->get_objnum()].instance;
 	}
-	*/
 
 	_markingBox.x1 = event->x();
 	_markingBox.y1 = event->y();
@@ -268,8 +265,8 @@ void RenderWidget::mousePressEvent(QMouseEvent* event) {
 		}
 	}
 
-	if (query_valid_object(fred->getCurrentObject())) {
-		_viewport->original_pos = Objects[fred->getCurrentObject()].pos;
+	if (query_valid_object(fred->currentObject)) {
+		_viewport->original_pos = Objects[fred->currentObject].pos;
 	}
 
 	_viewport->moved = 0;
@@ -480,7 +477,7 @@ void RenderWidget::setCursorMode(CursorMode mode) {
 void RenderWidget::renderFrame() {
 	subsys_to_render Render_subsys;
 
-	_viewport->renderer->render_frame(fred->getCurrentObject(), Render_subsys, _usingMarkingBox, _markingBox, false);
+	_viewport->renderer->render_frame(fred->currentObject, Render_subsys, _usingMarkingBox, _markingBox, false);
 }
 } // namespace fred
 } // namespace fso

--- a/qtfred/ui/FredView.ui
+++ b/qtfred/ui/FredView.ui
@@ -1037,6 +1037,9 @@
    <property name="text">
     <string>Waypoint &amp;Paths</string>
    </property>
+   <property name="shortcut">
+    <string>Shift+Y</string>
+   </property>
   </action>
   <action name="actionEvents">
    <property name="text">

--- a/qtfred/ui/WaypointEditorDialog.ui
+++ b/qtfred/ui/WaypointEditorDialog.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
- <class>fso::fred::dialogs:WaypointDialog</class>
- <widget class="QDialog" name="fso::fred::dialogs:WaypointDialog">
+ <class>fso::fred::dialogs::WaypointEditorDialog</class>
+ <widget class="QDialog" name="fso::fred::dialogs::WaypointEditorDialog">
   <property name="geometry">
    <rect>
     <x>0</x>

--- a/qtfred/ui/WaypointEditorDialog.ui
+++ b/qtfred/ui/WaypointEditorDialog.ui
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>fso::fred::dialogs:WaypointDialog</class>
+ <widget class="QDialog" name="fso::fred::dialogs:WaypointDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>210</width>
+    <height>64</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Waypoint Path/Jump Node Editor</string>
+  </property>
+  <layout class="QFormLayout" name="formLayout">
+   <item row="1" column="0">
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>Name</string>
+     </property>
+     <property name="buddy">
+      <cstring>nameEdit</cstring>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="1">
+    <widget class="QLineEdit" name="nameEdit"/>
+   </item>
+   <item row="0" column="0">
+    <widget class="QLabel" name="label_2">
+     <property name="text">
+      <string>Waypoint Path</string>
+     </property>
+     <property name="buddy">
+      <cstring>pathSelection</cstring>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="1">
+    <widget class="QComboBox" name="pathSelection"/>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>


### PR DESCRIPTION
This adds the first fully functioning editor window to qtFRED. The system uses a Model-View system to separate the GUI view from the underlying data model. Updating the view is done through a signal which is emitted by the model when it changes and the view can change the model using normal function calls.

This is how I would like to build all the editor dialogs so this is the time and place to discuss possible alternatives.