### PR TITLE
Use unique_ptr for storing HUD gauge pointers

### DIFF
--- a/code/hud/hud.cpp
+++ b/code/hud/hud.cpp
@@ -54,7 +54,7 @@
 #include "weapon/emp.h"
 #include "weapon/weapon.h"
 
-SCP_vector<HudGauge*> default_hud_gauges;
+SCP_vector<std::unique_ptr<HudGauge>> default_hud_gauges;
 
 // new values for HUD alpha
 #define HUD_NEW_ALPHA_DIM				80	
@@ -1246,24 +1246,10 @@ void hud_level_close()
  */
 void hud_close()
 {
-	size_t j, num_gauges = 0;
-
 	for (auto it = Ship_info.begin(); it != Ship_info.end(); ++it) {
-		num_gauges = it->hud_gauges.size();
-
-		for(j = 0; j < num_gauges; j++) {
-			delete it->hud_gauges[j];
-			it->hud_gauges[j] = NULL;
-		}
 		it->hud_gauges.clear();
 	}
 
-	num_gauges = default_hud_gauges.size();
-
-	for(j = 0; j < num_gauges; j++) {
-		delete default_hud_gauges[j];
-		default_hud_gauges[j] = NULL;
-	}
 	default_hud_gauges.clear();
 }
 
@@ -3785,7 +3771,7 @@ HudGauge* hud_get_gauge(const char* name)
 
 			gauge_name = Ship_info[Player_ship->ship_info_index].hud_gauges[j]->getCustomGaugeName();
 			if(!strcmp(name, gauge_name)) {
-				return Ship_info[Player_ship->ship_info_index].hud_gauges[j];
+				return Ship_info[Player_ship->ship_info_index].hud_gauges[j].get();
 			}
 		}
 	} else {
@@ -3793,7 +3779,7 @@ HudGauge* hud_get_gauge(const char* name)
 
 			gauge_name = default_hud_gauges[j]->getCustomGaugeName();
 			if(!strcmp(name, gauge_name)) {
-				return default_hud_gauges[j];
+				return default_hud_gauges[j].get();
 			}
 		}
 	}

--- a/code/hud/hud.h
+++ b/code/hud/hud.h
@@ -538,7 +538,7 @@ public:
 
 HudGauge* hud_get_gauge(const char* name);
 
-extern SCP_vector<HudGauge*> default_hud_gauges;
+extern SCP_vector<std::unique_ptr<HudGauge>> default_hud_gauges;
 
 extern flag_def_list Hud_gauge_types[];
 extern int Num_hud_gauge_types;

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -9953,7 +9953,7 @@ void sexp_hud_clear_messages()
 
 		for(size_t i = 0; i < num_gauges; i++) {
 			if (Ship_info[Player_ship->ship_info_index].hud_gauges[i]->getObjectType() == HUD_OBJECT_MESSAGES) {
-				HudGaugeMessages* gauge = static_cast<HudGaugeMessages*>(Ship_info[Player_ship->ship_info_index].hud_gauges[i]);
+				HudGaugeMessages* gauge = static_cast<HudGaugeMessages*>(Ship_info[Player_ship->ship_info_index].hud_gauges[i].get());
 				gauge->clearMessages();
 			}
 		}
@@ -9962,7 +9962,7 @@ void sexp_hud_clear_messages()
 
 		for(size_t i = 0; i < num_gauges; i++) {
 			if (default_hud_gauges[i]->getObjectType() == HUD_OBJECT_MESSAGES) {
-				HudGaugeMessages* gauge = static_cast<HudGaugeMessages*>(default_hud_gauges[i]);
+				HudGaugeMessages* gauge = static_cast<HudGaugeMessages*>(default_hud_gauges[i].get());
 				gauge->clearMessages();
 			}
 		}

--- a/code/scripting/api/objs/graphics.cpp
+++ b/code/scripting/api/objs/graphics.cpp
@@ -992,7 +992,7 @@ ADE_FUNC(drawOffscreenIndicator, l_Graphics, "object Object, [boolean draw=true,
 
 	for(j = 0; j < num_gauges; j++) {
 		if (default_hud_gauges[j]->getObjectType() == HUD_OBJECT_OFFSCREEN) {
-			HudGaugeOffscreen *offscreengauge = static_cast<HudGaugeOffscreen*>(default_hud_gauges[j]);
+			HudGaugeOffscreen *offscreengauge = static_cast<HudGaugeOffscreen*>(default_hud_gauges[j].get());
 
 			offscreengauge->preprocess();
 			offscreengauge->onFrame(flFrametime);

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -1089,7 +1089,13 @@ void ship_info::clone(const ship_info& other)
 	damage_lightning_type = other.damage_lightning_type;
 
 	shield_impact_explosion_anim = other.shield_impact_explosion_anim;
-	hud_gauges = other.hud_gauges;
+
+	// We can't copy the HUD gauge vector here since we can't construct a copy of every HUD gauge since the type
+	// information is not available anymore when we are at this point. Since this function is only needed before HUD
+	// gauge parsing it should be save to assume that the other HUD gauge vector is empty
+	Assertion(other.hud_gauges.empty(), "Ship_info cloning is only possible if there are no HUD gauges in the ship class.");
+	hud_gauges.clear();
+
 	hud_enabled = other.hud_enabled;
 	hud_retail = other.hud_retail;
 
@@ -7069,7 +7075,7 @@ void ship_set_hud_cockpit_targets()
 		return;
 	}
 
-	SCP_vector<HudGauge*> &hud = Ship_info[Player_ship->ship_info_index].hud_gauges;
+	auto& hud = Ship_info[Player_ship->ship_info_index].hud_gauges;
 
 	for ( int i = 0; i < (int)hud.size(); i++ ) {
 		for ( int j = 0; j < (int)Player_displays.size(); j++ ) {

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -1204,7 +1204,7 @@ public:
 
 	int damage_lightning_type;
 
-	SCP_vector<HudGauge*> hud_gauges;
+	SCP_vector<std::unique_ptr<HudGauge>> hud_gauges;
 	bool hud_enabled;
 	bool hud_retail;
 


### PR DESCRIPTION
The previous system used naked pointers which probably worked fine but
this should give us some extra memory-leak security.

@MageKing17 `ship_info::clone` is only used by the ship template feature.
Is my assumption correct that this will always be called before the HUD is
parsed? If not then the previous code is invalid and needs to be fixed. Otherwise
this is a simple cleanup PR which does not need to be in 3.8.