### PR TITLE
Correctly apply scaling to TTF rendered strings

### DIFF
--- a/code/graphics/opengl/gropengldraw.cpp
+++ b/code/graphics/opengl/gropengldraw.cpp
@@ -781,8 +781,14 @@ void gr_opengl_string(float sx, float sy, const char *s, int resize_mode, int in
 
 				if (specialChar) {
 					if (pass == 1) {
+						// We compute the top offset of the special character by aligning it to the base line of the string
+						// This is done by moving to the base line of the string by adding the ascender value and then
+						// accounting for the height of the text with the height of the special font
+						auto yOffset = nvgFont->getTopOffset() +
+							(nvgFont->getAscender() - nvgFont->getSpecialCharacterFont()->h);
+
 						gr_opengl_string_old(sx + x * scaleX,
-											 sy + (y + nvgFont->getTopOffset()) * scaleY,
+											 sy + (y + yOffset) * scaleY,
 											 text,
 											 text + 1,
 											 nvgFont->getSpecialCharacterFont(),

--- a/code/graphics/opengl/gropengldraw.cpp
+++ b/code/graphics/opengl/gropengldraw.cpp
@@ -553,7 +553,7 @@ void gr_opengl_string_old(float sx, float sy, const char* s, const char* end, fo
 			break;
 		}
 
-		letter = font::get_char_width_old(fontData, s[0], s[1], &width, &spacing);
+		letter = font::get_char_width_old(fontData, (ubyte)s[0], (ubyte)s[1], &width, &spacing);
 		s++;
 
 		// not in font, draw as space
@@ -793,24 +793,21 @@ void gr_opengl_string(float sx, float sy, const char *s, int resize_mode, int in
 
 					int width;
 					int spacing;
-					get_char_width_old(nvgFont->getSpecialCharacterFont(), *text, '\0', &width, &spacing);
+					get_char_width_old(nvgFont->getSpecialCharacterFont(), (ubyte)*text, (ubyte)*(text + 1), &width, &spacing);
 
-					x += spacing;
+					x += i2fl(spacing) * invscaleX;
 				}
 				else if (doRender) {
 					if (doRender && tokenLength > 0) {
 						float advance;
-						float currentX = x;
+						float currentX = x * scaleX;
 						float currentY = y + nvgFont->getTopOffset();
 
 						if (pass == 0) {
-							advance = path->text(currentX, currentY, text, text + tokenLength) - currentX;
-						}
-						else {
-							advance =
-								path->textBounds(currentX, currentY, text, text + tokenLength, nullptr) - currentX;
+							path->text(currentX, currentY, text, text + tokenLength);
 						}
 
+						advance = path->textBounds(0.f, 0.f, text, text + tokenLength, nullptr);
 						x += advance * invscaleX;
 					}
 				}

--- a/code/graphics/software/FSFont.cpp
+++ b/code/graphics/software/FSFont.cpp
@@ -37,7 +37,7 @@ namespace font
 
 	float FSFont::getHeight() const
 	{
-		return this->getTextHeight() + this->offsetTop + this->offsetBottom;
+		return _height;
 	}
 
 	const SCP_string &FSFont::getName() const
@@ -45,13 +45,26 @@ namespace font
 		return this->name;
 	}
 
-	void FSFont::checkHeight() {
-		float height = this->getTextHeight() + this->offsetTop + this->offsetBottom;
+	void FSFont::computeFontMetrics() {
+		_height = this->getTextHeight() + this->offsetTop + this->offsetBottom;
 
-		if (height <= 1.0f)
+		// By default the base line of the font is also the lowest point of the font
+		_ascender = _height;
+		_descender = 0.0f;
+
+		checkFontMetrics();
+	}
+	void FSFont::checkFontMetrics() {
+		if (_height <= 1.0f)
 		{
 			Warning(LOCATION, "The height of font %s has an invalid height of %f, must be greater than one!",
-					getName().c_str(), height);
+					getName().c_str(), _height);
 		}
+	}
+	float FSFont::getAscender() {
+		return _ascender;
+	}
+	float FSFont::getDescender() {
+		return _descender;
 	}
 }

--- a/code/graphics/software/FSFont.h
+++ b/code/graphics/software/FSFont.h
@@ -37,6 +37,12 @@ namespace font
 		float offsetTop;		//!< The offset at the top of a line of text
 		float offsetBottom;	//!< The offset at the bottom of a line of text
 
+		float _height;
+		float _ascender;
+		float _descender;
+
+		void checkFontMetrics();
+
 	public:
 
 		/**
@@ -92,7 +98,7 @@ namespace font
 		*
 		* @return	The height.
 		*/
-		virtual float getHeight() const;
+		float getHeight() const;
 
 		/**
 		* @brief	Gets the height of this font in pixels without the top and bottom offsets.
@@ -155,6 +161,21 @@ namespace font
 		*/
 		void setBottomOffset(float newOffset);
 
-		void checkHeight();
+		/**
+		 * @brief Recomputes the font metrics
+		 */
+		virtual void computeFontMetrics();
+
+		/**
+		 * @brief Gets the ascender value of this font
+		 * @return The ascender value
+		 */
+		float getAscender();
+
+		/**
+		 * @breif Gets the descender value of this font
+		 * @return The descender value
+		 */
+		float getDescender();
 	};
 }

--- a/code/graphics/software/NVGFont.cpp
+++ b/code/graphics/software/NVGFont.cpp
@@ -108,21 +108,7 @@ namespace font
 	
 	float NVGFont::getTextHeight() const
 	{
-		auto path = graphics::paths::PathRenderer::instance();
-
-		path->saveState();
-		path->resetState();
-
-		path->fontFaceId(m_handle);
-		path->fontSize(m_size);
-		path->textLetterSpacing(m_letterSpacing);
-
-		float lineh;
-		path->textMetrics(nullptr, nullptr, &lineh);
-
-		path->restoreState();
-
-		return lineh;
+		return m_lineHeight;
 	}
 
 	extern int get_char_width_old(font* fnt, ubyte c1, ubyte c2, int *width, int* spacing);
@@ -231,5 +217,23 @@ namespace font
 			*width = w;
 
 		path->restoreState();
+	}
+	void NVGFont::computeFontMetrics() {
+		auto path = graphics::paths::PathRenderer::instance();
+
+		path->saveState();
+		path->resetState();
+
+		path->fontFaceId(m_handle);
+		path->fontSize(m_size);
+		path->textLetterSpacing(m_letterSpacing);
+
+		path->textMetrics(&_ascender, &_descender, &m_lineHeight);
+
+		path->restoreState();
+
+		_height = m_lineHeight + this->offsetTop + this->offsetBottom;
+
+		checkFontMetrics();
 	}
 }

--- a/code/graphics/software/NVGFont.h
+++ b/code/graphics/software/NVGFont.h
@@ -16,6 +16,8 @@ namespace font
 
 		font* m_specialCharacters;
 
+		float m_lineHeight = 0.0f;
+
 	public:
 		NVGFont();
 		virtual ~NVGFont();
@@ -38,6 +40,8 @@ namespace font
 
 		virtual void getStringSize(const char *text, size_t textLen, int resize_mode,
 			float *width, float *height) const SCP_OVERRIDE;
+
+		void computeFontMetrics() override;
 
 		static size_t getTokenLength(const char *string, size_t maxLength);
 	};

--- a/code/graphics/software/font.cpp
+++ b/code/graphics/software/font.cpp
@@ -203,7 +203,7 @@ namespace
 		nvgFont->setName(fontStr);
 
 		// Make sure that the height is not invalid
-		nvgFont->checkHeight();
+		nvgFont->computeFontMetrics();
 	}
 
 	void parse_vfnt_font(const SCP_string& fontFilename)
@@ -300,7 +300,7 @@ namespace
 			font->setBottomOffset(temp);
 		}
 		// Make sure that the height is not invalid
-		font->checkHeight();
+		font->computeFontMetrics();
 	}
 
 	void font_parse_setup(const char *fileName)


### PR DESCRIPTION
This fixes weird misplaced special characters since the TTF strings
weren't rendered at the right position. This should fix that.

This fixes an issue reported [on the forums](http://www.hard-light.net/forums/index.php?topic=93685.msg1850724) by Novachen.