### PR TITLE
Discard non-main thread events for the frame profiler

### DIFF
--- a/code/tracing/FrameProfiler.cpp
+++ b/code/tracing/FrameProfiler.cpp
@@ -136,6 +136,17 @@ void FrameProfiler::processEvent(const trace_event* event) {
 		return;
 	}
 
+	if (_mainThreadID == -1) {
+		// We need the ID of the main thread to filter out multi threaded events. We just assume that the first event
+		// of the main process we see is from the main thread. That should be a safe assumption.
+		_mainThreadID = event->tid;
+	}
+
+	if (event->tid != _mainThreadID) {
+		// Multithreaded events don't have a deterministic sequence and that confuses the old profiling system
+		return;
+	}
+
 	if (event->duration == 0) {
 		// Discard events with no duration
 		return;

--- a/code/tracing/FrameProfiler.h
+++ b/code/tracing/FrameProfiler.h
@@ -41,6 +41,8 @@ class FrameProfiler {
 
 	SCP_vector<profile_sample_history> history;
 
+	std::int64_t _mainThreadID = -1;
+
 	SCP_string content;
 
 	/**


### PR DESCRIPTION
The old code is not able to handle multi-threaded events so this change
simply filters out all the events that originated from another thread.

This fixes an Assertion caused by an invalid event.