### PR TITLE
Compile curl with SSH support for nightly deploy

### DIFF
--- a/ci/travis/nightly_deploy.sh
+++ b/ci/travis/nightly_deploy.sh
@@ -1,13 +1,42 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 set -e
 set -u
+
+if [[ ! "$(curl -V)" == *"sftp"* ]]; then
+    # Before
+    echo "Before:"
+    curl -V
+
+    # Since the Travis CI people are not capable of enabling SSH/SCP support for their libcurl we need to build that manually...mkdir /tmp/curl
+    # These commands are based on the tutorial from here: http://zeroset.mnim.org/2013/03/14/sftp-support-for-curl-in-ubuntu-12-10-quantal-quetzal-and-later/
+    mkdir /tmp/curl
+    cd /tmp/curl
+    sudo apt-get update
+    sudo apt-get install build-essential debhelper libssh2-1-dev libgnutls-dev libidn11-dev libkrb5-dev libldap2-dev libnss3-dev librtmp-dev libtool openssh-server quilt
+    apt-get source curl
+    sudo apt-get build-dep curl
+
+    cd curl-*
+    export DEB_BUILD_OPTIONS="nocheck"
+    sudo dpkg-buildpackage -uc -us -j"$(grep -c ^processor /proc/cpuinfo)"
+
+    cd ..
+    dpkg -l | grep curl
+    ls -al
+    sudo dpkg -i curl*.deb
+    sudo dpkg -i libcurl3*.deb
+
+    # After
+    echo "After:"
+    curl -V
+fi
 
 cd /tmp/builds
 
 for file in *; do
 	# Upload to indiegames
-	curl -k "ftp://scp.indiegames.us/public_html/builds/nightly/$VERSION_NAME/" --user "$INDIEGAMES_USER:$INDIEGAMES_PASSWORD" -T "$file" --ftp-create-dirs
+	curl -k "sftp://scp.indiegames.us/public_html/builds/nightly/$VERSION_NAME/" --user "$INDIEGAMES_USER:$INDIEGAMES_PASSWORD" -T "$file" --ftp-create-dirs
 
 	# Upload to fs2downloads
 	curl -k "ftp://swc.fs2downloads.com/swc.fs2downloads.com/builds/nightly/$VERSION_NAME/" --user "$FS2DOWNLOADS_USER:$FS2DOWNLOADS_PASSWORD" -T "$file" --ftp-create-dirs


### PR DESCRIPTION
This fixes the failures of the nightly builds which failed to upload because indiegames does not accept FTP connections anymore.