### PR TITLE
Fix unloading streaming ANI files.

### DIFF
--- a/code/anim/animplay.cpp
+++ b/code/anim/animplay.cpp
@@ -765,7 +765,7 @@ anim *anim_load(const char *real_filename, int cf_dir_type, int file_mapped)
 		}
 
 		// couldn't memory-map file... must be in a packfile, so stream manually
-		if ( file_mapped && !ptr->cfile_ptr ) {
+		if ( file_mapped == PAGE_FROM_MEM && !ptr->cfile_ptr ) {
 			ptr->flags &= ~ANF_MEM_MAPPED;
 			ptr->flags |= ANF_STREAMED;
 			ptr->cfile_ptr = cfopen(name, "rb", CFILE_NORMAL, cf_dir_type);

--- a/code/anim/animplay.h
+++ b/code/anim/animplay.h
@@ -40,9 +40,8 @@ typedef struct {
 
 enum
 {
-	PAGE_FROM_MEM		  = 0,
-	PAGE_FROM_DISK		  = 1,
-	PAGE_FROM_DISK_FORCED = 2
+	PAGE_FROM_DISK		  = 0,
+	PAGE_FROM_MEM		  = 1
 };
 
 extern int Anim_paused;
@@ -59,7 +58,7 @@ int				anim_stop_playing(anim_instance* anim_instance);
 int				anim_show_next_frame(anim_instance *instance, float frametime);
 void				anim_release_all_instances(int screen_id = 0);
 void				anim_release_render_instance(anim_instance* instance);
-anim			  *anim_load(const char *name, int cf_dir_type = CF_TYPE_ANY, int file_mapped = PAGE_FROM_MEM);
+anim			  *anim_load(const char *name, int cf_dir_type = CF_TYPE_ANY, int file_mapped = PAGE_FROM_DISK);
 int				anim_free(anim *ptr);
 int				anim_playing(anim_instance *ai);
 int				anim_write_frames_out(char *filename);

--- a/code/graphics/generic.cpp
+++ b/code/graphics/generic.cpp
@@ -323,8 +323,8 @@ void generic_anim_unload(generic_anim *ga)
 	if(ga->num_frames > 0) {
 		if(ga->streaming) {
 			if(ga->type == BM_TYPE_ANI) {
-				anim_free(ga->ani.animation);
 				free_anim_instance(ga->ani.instance);
+				anim_free(ga->ani.animation);
 			}
 			if(ga->type == BM_TYPE_EFF) {
 				if(ga->eff.next_frame >= 0) 

--- a/code/mission/missionmessage.cpp
+++ b/code/mission/missionmessage.cpp
@@ -748,11 +748,6 @@ void message_mission_free_avi(int m_index)
 	if ( (m_index < 0) || (m_index >= Num_message_avis) )
 		return;
 
-	// Make sure this code doesn't get run if the talking head guage is off
-	// helps prevent a crash on jump out if this code doesn't work right
-	if ( !hud_gauge_active(HUD_TALKING_HEAD) )
-		return;
-
 	generic_anim_unload(&Message_avis[m_index].anim_data);
 }
 


### PR DESCRIPTION
Two commits here. The first removes a condition from `message_mission_free_avi()` that didn't seem to serve a useful purpose. The second is the real meat of the PR and so I'll copy its description here:

When streaming an ANI file, first `anim_load()` is called, then `init_anim_instance()`. The latter increments the animation's `instance_count`. If `anim_free()` is called on an animation that still has instances, it refuses to free the animation. `generic_anim_unload()` first called `anim_free()`, then `free_anim_instance()`.

The fact that ANI files would ever unload at all seems to be because some code would unload twice. I can only assume that, combined with the fact that the bug only applies to ANI files, explains how this bug went undetected since November of 2009 (commit b43417882fef18371b6d58c05095d4ec8525c4f4 seems to be when it was added, from a quick glance at git blame).
<br>
This was causing problems when some ANIs didn't unload and slowly accumulated between missions, eventually resulting in all 64 cfile blocks getting used up. ~~For unknown reasons, it doesn't seem to happen to ANIs located in a VP file, even though all the relevant code doesn't seem to care whether or not the file came from a packfile (beyond whether or not it's memory-mapped, but that doesn't change the fact that a cfile block should be consumed, and *stay* consumed until explicitly unloaded by the missionmessage code, either way). This is especially bizarre in that, even without this PR, even having more headanis than the cfile block limit in the same mission (a guaranteed tripping of the "out of cfile blocks" assertion when the ANI files are loose) works perfectly fine if the headanis have been put in a VP file. This nonsensical outcome makes me reluctant to let this PR get merged when we apparently still don't understand the underlying problem; anybody have any idea what's going on there?~~ @ngld discovered why files in VP archives didn't exhibit the same problem, and I've added a third commit to fix the issue.