### PR TITLE
Add mod table setting for specifying targetted FSO version

### DIFF
--- a/code/globalincs/version.cpp
+++ b/code/globalincs/version.cpp
@@ -5,85 +5,130 @@
  * or otherwise commercially exploit the source or things you created based on the 
  * source.
  *
-*/ 
+*/
 
 #include "globalincs/pstypes.h"
 #include "globalincs/version.h"
 
-namespace gameversion
-{
-	bool check_at_least(int major, int minor, int build, int revision)
-	{
-		if (FS_VERSION_MAJOR < major)
-		{
-			return false;
-		}
-		if (FS_VERSION_MAJOR > major)
-		{
-			// Major is greater than the given version => the rest doesn't matter
-			return true;
-		}
-		// major is now equal to our major version
-		
-		if (FS_VERSION_MINOR < minor)
-		{
-			return false;
-		}
-		if (FS_VERSION_MINOR > minor)
-		{
-			// Minor is greater than the given version => the rest doesn't matter
-			return true;
-		}
-		// minor is now equal to our minor version
-		
-		if (FS_VERSION_BUILD < build)
-		{
-			return false;
-		}
-		if (FS_VERSION_BUILD > build)
-		{
-			// build is greater than the given version => the rest doesn't matter
-			return true;
-		}
-		// build is now equal to our build version
-		
-		if (revision == 0)
-		{
-			// Special case, if there is no revision info, skip it
-			return true;
-		}
-		if (FS_VERSION_REVIS == 0)
-		{
-			// Special case, when there is no revision ignore it
-			return true;
-		}
-		
-		if (FS_VERSION_REVIS < revision)
-		{
-			return false;
-		}
-		if (FS_VERSION_REVIS > revision)
-		{
-			// build is greater than the given version => the rest doesn't matter
-			return true;
-		}
-		
-		// revision is now equal to our revision version
+#include "parse/parselo.h"
+
+namespace gameversion {
+
+bool check_at_least(const version& v) {
+	return get_executable_version() >= v;
+}
+
+SCP_string format_version(const version& v) {
+	SCP_stringstream ss;
+
+	ss << v.major << "." << v.minor << "." << v.build;
+
+	if (v.revision != 0) {
+		ss << "." << v.revision;
+	}
+
+	return ss.str();
+}
+version parse_version() {
+	version v;
+
+	required_string("+Major:");
+	stuff_int(&v.major);
+
+	required_string("+Minor:");
+	stuff_int(&v.minor);
+
+	required_string("+Build:");
+	stuff_int(&v.build);
+
+	if (optional_string("+Revision:")) {
+		stuff_int(&v.revision);
+	}
+
+	return v;
+}
+version get_executable_version() {
+	version v;
+	v.major = FS_VERSION_MAJOR;
+	v.minor = FS_VERSION_MINOR;
+	v.build = FS_VERSION_BUILD;
+	v.revision = FS_VERSION_REVIS;
+
+	return v;
+}
+
+version::version(int major_in, int minor_in, int build_in, int revision_in) :
+	major(major_in), minor(minor_in), build(build_in), revision(revision_in) {
+}
+bool version::operator<(const version& v) const {
+
+	if (major < v.major) {
 		return true;
 	}
-	
-	SCP_string format_version(int major, int minor, int build, int revision)
-	{
-		SCP_stringstream ss;
-		
-		ss << major << "." << minor << "." << build;
-		
-		if (revision != 0)
-		{
-			ss << "." << revision;
-		}
-		
-		return ss.str();
+	if (major > v.major) {
+		// Major is greater than the given version => the rest doesn't matter
+		return false;
 	}
+	// major is now equal to our major version
+
+	if (minor < v.minor) {
+		return true;
+	}
+	if (minor > v.minor) {
+		// Minor is greater than the given version => the rest doesn't matter
+		return false;
+	}
+	// minor is now equal to our minor version
+
+	if (build < v.build) {
+		return true;
+	}
+	if (build > v.build) {
+		// build is greater than the given version => the rest doesn't matter
+		return false;
+	}
+	// build is now equal to our build version
+
+	if (revision == 0 || v.revision == 0) {
+		// Special case, if there is no revision info, then the versions are equal which means they are not less than each other
+		return false;
+	}
+
+	if (revision < v.revision) {
+		return true;
+	}
+	if (revision > v.revision) {
+		// build is greater than the given version => the rest doesn't matter
+		return false;
+	}
+
+	// revision is now equal to our revision version
+	return false;
+}
+bool version::operator==(const version& other) const {
+	if (major == other.major && minor == other.minor && build == other.build) {
+		if (revision == 0 || other.revision == 0) {
+			// Zero revisions always means that these are equal
+			return true;
+		}
+
+		return revision == other.revision;
+	}
+
+	return false;
+}
+bool version::operator>(const version& other) const {
+	return other < *this;
+}
+bool version::operator<=(const version& other) const {
+	return !(other < *this);
+}
+bool version::operator>=(const version& other) const {
+	return !(*this < other);
+}
+bool version::operator!=(const version& other) const {
+	return !(*this == other);
+}
+
 }
 

--- a/code/globalincs/version.h
+++ b/code/globalincs/version.h
@@ -5,7 +5,7 @@
  * or otherwise commercially exploit the source or things you created based on the 
  * source.
  *
-*/ 
+*/
 
 
 
@@ -36,29 +36,55 @@
 
 #include "project.h"
 
-namespace gameversion
-{
-	/**
-	 * @brief Checks if the current version is at least the given version
-	 * 
-	 * @param major The major version to check
-	 * @param minor The minor version to check
-	 * @param build The build version to check
-	 * @param revision The revision version to check
-	 *
-	 * @returns @c true when we are at least the given version, @c false otherwise
-	 */
-	bool check_at_least(int major, int minor, int build, int revision);
-	
-	/**
-	 * @brief Returns the string representation of the passed version
-	 * @param major The major version to format
-	 * @param minor The minor version to format
-	 * @param build The build version to format
-	 * @param revision The revision version to format
-	 * @returns A string representation of the version number
-	 */
-	SCP_string format_version(int major, int minor, int build, int revision);
+// The GCC POSIX headers seem to think defining a common word like "major" is a good idea...
+// FYI, no it isn't.
+#ifdef major
+#undef major
+#endif
+#ifdef minor
+#undef minor
+#endif
+
+namespace gameversion {
+
+struct version {
+	int major = 0;
+	int minor = 0;
+	int build = 0;
+	int revision = 0;
+
+	version() {}
+
+	version(int major, int minor, int build, int revision);
+
+	bool operator<(const version& other) const;
+	bool operator==(const version& other) const;
+	bool operator!=(const version& other) const;
+	bool operator>(const version& rhs) const;
+	bool operator<=(const version& rhs) const;
+	bool operator>=(const version& rhs) const;
+};
+
+version parse_version();
+
+version get_executable_version();
+
+/**
+ * @brief Checks if the current version is at least the given version
+ *
+ * @param v The version to check
+ *
+ * @returns @c true when we are at least the given version, @c false otherwise
+ */
+bool check_at_least(const version& v);
+
+/**
+ * @brief Returns the string representation of the passed version
+ * @param major The version to format
+ * @returns A string representation of the version number
+ */
+SCP_string format_version(const version& v);
+
 }
 
 #endif

--- a/code/mod_table/mod_table.h
+++ b/code/mod_table/mod_table.h
@@ -32,3 +32,17 @@ extern float Generic_pain_flash_factor;
 extern float Shield_pain_flash_factor;
 
 void mod_table_init();
+
+/**
+ * @brief Checks if the mod specified support for the given engine version
+ *
+ * This is the function for implementing backwards-incompatible changes while not actually breaking backwards
+ * compatibility. If you want to introduce a change that may impact compatibility with an earlier version (e.g. retail)
+ * then you can use this function to check if the current mod targets a recent enough version.
+ *
+ * @param major The major version to check support for
+ * @param minor The minor version to check support for
+ * @param build The build version to check support for
+ * @return @c true if the mod specified support for this or a later version, @c false otherwise
+ */
+bool mod_supports_version(int major, int minor, int build);

--- a/test/src/globalincs/test_version.cpp
+++ b/test/src/globalincs/test_version.cpp
@@ -1,0 +1,33 @@
+//
+//
+
+#include <gtest/gtest.h>
+
+#include "globalincs/version.h"
+
+using namespace gameversion;
+
+TEST(VersionTest, equal_version) {
+	ASSERT_TRUE(version(1, 2, 3, 4) == version(1, 2, 3, 4));
+	ASSERT_TRUE(version(1, 2, 3, 0) == version(1, 2, 3, 20));
+
+	ASSERT_FALSE(version(1, 2, 3, 4) != version(1, 2, 3, 4));
+}
+
+TEST(VersionTest, inequal_version) {
+	ASSERT_TRUE(version(1, 2, 3, 4) != version(4, 3, 2, 1));
+
+	ASSERT_FALSE(version(1, 2, 3, 4) == version(4, 3, 2, 1));
+	ASSERT_FALSE(version(1, 2, 3, 0) == version(4, 3, 2, 0));
+}
+
+TEST(VersionTest, lesser_version) {
+	ASSERT_TRUE(version(2, 0, 0, 0) < version(3, 0, 0, 0));
+	ASSERT_TRUE(version(2, 1, 0, 0) < version(2, 2, 0, 0));
+	ASSERT_TRUE(version(2, 1, 0, 0) < version(2, 1, 1, 0));
+	ASSERT_TRUE(version(2, 1, 0, 1) < version(2, 1, 0, 2));
+
+	ASSERT_FALSE(version(2, 1, 0, 0) < version(2, 1, 0, 1)); // Special case, no revision
+	ASSERT_FALSE(version(2, 0, 0, 0) < version(2, 0, 0, 0));
+	ASSERT_FALSE(version(2, 0, 0, 0) < version(1, 0, 0, 0));
+}

--- a/test/src/mod/test_mod_table.cpp
+++ b/test/src/mod/test_mod_table.cpp
@@ -1,0 +1,28 @@
+//
+//
+
+
+#include <util/FSTestFixture.h>
+#include <mod_table/mod_table.h>
+
+class ModTableTest : public test::FSTestFixture {
+ public:
+	ModTableTest() : test::FSTestFixture(INIT_CFILE) {
+		pushModDir("mod");
+	}
+};
+
+TEST_F(ModTableTest, future_targetted_version) {
+	ASSERT_THROW(mod_table_init(), os::dialogs::ErrorException);
+}
+
+TEST_F(ModTableTest, correct_targetted_version) {
+	mod_table_init();
+}
+
+TEST_F(ModTableTest, mod_support_test) {
+	mod_table_init();
+
+	ASSERT_TRUE(mod_supports_version(3, 7, 0));
+	ASSERT_FALSE(mod_supports_version(4, 0, 0));
+}

--- a/test/src/source_groups.cmake
+++ b/test/src/source_groups.cmake
@@ -19,6 +19,7 @@ add_file_folder(cfile "CFile"
 add_file_folder(graphics "Globalincs"
     globalincs/test_flagset.cpp
     globalincs/test_safe_strings.cpp
+    globalincs/test_version.cpp
 )
 
 add_file_folder(graphics "Graphics"
@@ -27,6 +28,10 @@ add_file_folder(graphics "Graphics"
 
 add_file_folder(menuui "menuui"
     menuui/test_intel_parse.cpp
+)
+
+add_file_folder(mod "mod"
+    mod/test_mod_table.cpp
 )
 
 add_file_folder(graphics "Parse"

--- a/test/test_data/mod/correct_targetted_version/data/tables/test-mod.tbm
+++ b/test/test_data/mod/correct_targetted_version/data/tables/test-mod.tbm
@@ -1,0 +1,8 @@
+#GAME SETTINGS
+
+$Target Version:
+    +Major: 2
+    +Minor: 0
+    +Build: 0
+
+#End

--- a/test/test_data/mod/future_targetted_version/data/tables/test-mod.tbm
+++ b/test/test_data/mod/future_targetted_version/data/tables/test-mod.tbm
@@ -1,0 +1,8 @@
+#GAME SETTINGS
+
+$Target Version:
+    +Major: 20
+    +Minor: 5
+    +Build: 10
+
+#End

--- a/test/test_data/mod/mod_support_test/data/tables/test-mod.tbm
+++ b/test/test_data/mod/mod_support_test/data/tables/test-mod.tbm
@@ -1,0 +1,8 @@
+#GAME SETTINGS
+
+$Target Version:
+    +Major: 3
+    +Minor: 7
+    +Build: 4
+
+#End


### PR DESCRIPTION
This adds a small system for letting a mod specify which version of FSO
was designed for. That would allow us to introduce code which would
normally break backwards-compatibility by putting it in an if block
which checks if the mod supports the FSO version which ontroduced the
behavioral change.

There is currently no code which uses the new functions yet so I added a
few tests to verify that the options do what they are designed to do.

This fixes #1389.