### PR TITLE
Restart spring effect after stopping all FF effects

### DIFF
--- a/code/io/joy_ff-sdl.cpp
+++ b/code/io/joy_ff-sdl.cpp
@@ -52,6 +52,34 @@ static int joy_ff_has_valid_effects();
 static int joy_ff_effect_playing(haptic_effect_t *eff);
 static void joy_ff_start_effect(haptic_effect_t *eff, const char *name);
 
+static void check_and_print_haptic_feature(uint32_t flags, uint32_t check_flag, const char* description) {
+	auto has_flag = (flags & check_flag) == check_flag;
+
+	mprintf(("      Supports %s: %s\n", description, has_flag ? "true" : "false"));
+}
+
+static void print_haptic_support() {
+	mprintf(("    Haptic feature support:\n"));
+
+	auto supported = SDL_HapticQuery(haptic);
+	check_and_print_haptic_feature(supported, SDL_HAPTIC_CONSTANT, "Constant effect");
+	check_and_print_haptic_feature(supported, SDL_HAPTIC_SINE, "Sine effect");
+	check_and_print_haptic_feature(supported, SDL_HAPTIC_LEFTRIGHT, "Left right effect");
+	check_and_print_haptic_feature(supported, SDL_HAPTIC_TRIANGLE, "Triangle effect");
+	check_and_print_haptic_feature(supported, SDL_HAPTIC_SAWTOOTHUP, "Sawtooth up effect");
+	check_and_print_haptic_feature(supported, SDL_HAPTIC_SAWTOOTHDOWN, "Sawtooth down effect");
+	check_and_print_haptic_feature(supported, SDL_HAPTIC_RAMP, "Ramp effect");
+	check_and_print_haptic_feature(supported, SDL_HAPTIC_SPRING, "Spring effect");
+	check_and_print_haptic_feature(supported, SDL_HAPTIC_DAMPER, "Damper effect");
+	check_and_print_haptic_feature(supported, SDL_HAPTIC_INERTIA, "Inertia effect");
+	check_and_print_haptic_feature(supported, SDL_HAPTIC_FRICTION, "Friction effect");
+	check_and_print_haptic_feature(supported, SDL_HAPTIC_CUSTOM, "Custom effect");
+	check_and_print_haptic_feature(supported, SDL_HAPTIC_GAIN, "global gain");
+	check_and_print_haptic_feature(supported, SDL_HAPTIC_AUTOCENTER, "Autocenter");
+	check_and_print_haptic_feature(supported, SDL_HAPTIC_STATUS, "Status query");
+	check_and_print_haptic_feature(supported, SDL_HAPTIC_PAUSE, "Pause effects");
+}
+
 int joy_ff_init()
 {
 	int ff_enabled = 0;
@@ -118,6 +146,7 @@ int joy_ff_init()
 	mprintf(("    Number of haptic axes: %d\n", SDL_HapticNumAxes(haptic)));
 	mprintf(("    Number of effects supported: %d\n", SDL_HapticNumEffects(haptic)));
 	mprintf(("    Number of simultaneous effects: %d\n", SDL_HapticNumEffectsPlaying(haptic)));
+	print_haptic_support();
 
 	mprintf(("  ... Haptic successfully initialized!\n"));
 
@@ -129,6 +158,11 @@ void joy_ff_shutdown()
 	if ( !Joy_ff_enabled ) {
 		return;
 	}
+
+	if (pSpring.loaded) {
+		SDL_HapticStopEffect(haptic, pSpring.id);
+	}
+	joy_ff_stop_effects();
 
 	SDL_HapticClose(haptic);
 	haptic = NULL;
@@ -416,7 +450,15 @@ void joy_ff_stop_effects()
 		return;
 	}
 
-	SDL_HapticStopAll(haptic);
+	joy_ff_afterburn_off();
+
+	if (pDeathroll1.loaded) {
+		SDL_HapticStopEffect(haptic, pDeathroll1.id);
+	}
+
+	if (pDeathroll2.loaded) {
+		SDL_HapticStopEffect(haptic, pDeathroll2.id);
+	}
 }
 
 void joy_ff_mission_init(vec3d v)


### PR DESCRIPTION
`SDL_HapticStopAll` stops all effects, including the spring effect so the
joystick goes limp after one mission (`joy_ff_stop_effects` gets called at
the end of each mission).

This restarts the spring effect which should fix that issue.

This fixes #1417.