### PR TITLE
Add support for building test builds on the CI servers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,10 +48,17 @@ deploy:
           tags: true
 
     - provider: script
-      script: ci/travis/nightly_deploy.sh
+      script: ci/travis/ftp_deploy.sh
       on:
           condition: '"$NIGHTLY_BUILD" == true'
           tags: true
+
+    - provider: script
+      skip_cleanup: true
+      script: bash ci/travis/ftp_deploy.sh
+      on:
+          condition: $TEST_BUILD = true
+          all_branches: true
 
 matrix:
     include:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -47,3 +47,15 @@ deploy:
       beta: true
       on:
           NightlyBuild: true        # deploy on nightly push only
+
+    - provider: FTP
+      protocol: ftp
+      host: swc.fs2downloads.com
+      username: 
+        secure: EXg2ADoKzMduZF90ip2Q0g==
+      password:
+        secure: x0LL0uY9yBAQ7JTARhQ6AA==
+      folder: swc.fs2downloads.com/builds/test/$(VersionName)
+      beta: true
+      on:
+          TestBuild: true        # deploy on test build push only

--- a/ci/appveyor/test.ps1
+++ b/ci/appveyor/test.ps1
@@ -1,5 +1,5 @@
 
-if ([System.Convert]::ToBoolean($env:ReleaseBuild) -Or [System.Convert]::ToBoolean($env:NightlyBuild)) {
+if ([System.Convert]::ToBoolean($env:ReleaseBuild) -Or [System.Convert]::ToBoolean($env:NightlyBuild) -Or [System.Convert]::ToBoolean($env:TestBuild)) {
     # Skip tests for deployment
     exit 0
 } else {

--- a/ci/travis/check_release.sh
+++ b/ci/travis/check_release.sh
@@ -2,6 +2,8 @@
 
 RELEASE_BUILD=false
 NIGHTLY_BUILD=false
+TEST_BUILD=false
+
 BUILD_DEPLOYMENT=false
 BUILD_CONFIGS="Release FastDebug"
 VERSION_NAME=""
@@ -9,10 +11,12 @@ PACKAGE_NAME=""
 
 RELEASE_PATTERN="^release_(.*)$"
 NIGHTLY_PATTERN="^nightly_(.*)$"
+TEST_BUILD_PATTERN="^test\/(.*)$"
 
 # These are for testing
 NIGHTLY_TEST=false
 RELEASE_TEST=false
+TEST_BUILD_TEST=false
 
 if [ "$RELEASE_TEST" = true ] || [[ "$TRAVIS_TAG" =~ $RELEASE_PATTERN ]]; then
     echo "This is a release tag!";
@@ -25,8 +29,22 @@ if [ "$NIGHTLY_TEST" = true ] || [[ "$TRAVIS_TAG" =~ $NIGHTLY_PATTERN ]]; then
     VERSION_NAME="${BASH_REMATCH[1]}";
 	PACKAGE_NAME="nightly_${BASH_REMATCH[1]}";
 fi
+if [ "$TEST_BUILD_TEST" = true ] || [[ "$TRAVIS_PULL_REQUEST" == "false" && "$TRAVIS_BRANCH" =~ $TEST_BUILD_PATTERN ]]; then
+    echo "This is a test build branch!";
+    TEST_BUILD=true;
+    if [ "$TEST_BUILD_TEST" = true ]; then
+        VERSION_NAME="test";
+        PACKAGE_NAME="test_test";
+    else
+        VERSION_NAME="${BASH_REMATCH[1]}";
+        PACKAGE_NAME="test_${BASH_REMATCH[1]}";
+    fi
 
-if ([ "$RELEASE_BUILD" = true ] || [ "$NIGHTLY_BUILD" = true ]); then
+    # Override the revision string so that the builds are named correctly
+    echo "set(FSO_VERSION_REVISION_STR $VERSION_NAME)" > "$TRAVIS_BUILD_DIR/version_override.cmake"
+fi
+
+if ([ "$RELEASE_BUILD" = true ] || [ "$NIGHTLY_BUILD" = true ] || [ "$TEST_BUILD" = true ]); then
     BUILD_DEPLOYMENT=true;
 fi
 
@@ -44,6 +62,7 @@ fi
 
 export RELEASE_BUILD
 export NIGHTLY_BUILD
+export TEST_BUILD
 export BUILD_DEPLOYMENT
 export BUILD_CONFIGS
 export VERSION_NAME

--- a/ci/travis/ftp_deploy.sh
+++ b/ci/travis/ftp_deploy.sh
@@ -41,9 +41,14 @@ fi
 cd /tmp/builds
 
 for file in *; do
-	# Upload to indiegames
-	curl -k "sftp://scp.indiegames.us/~/public_html/builds/nightly/$VERSION_NAME/" --user "$INDIEGAMES_USER:$INDIEGAMES_PASSWORD" -T "$file" --ftp-create-dirs
+    if [ "$TEST_BUILD" = true ]; then
+        # Upload to fs2downloads
+        curl -k "ftp://swc.fs2downloads.com/swc.fs2downloads.com/builds/test/$VERSION_NAME/" --user "$FS2DOWNLOADS_USER:$FS2DOWNLOADS_PASSWORD" -T "$file" --ftp-create-dirs
+    else
+        # Upload to indiegames
+        curl -k "sftp://scp.indiegames.us/~/public_html/builds/nightly/$VERSION_NAME/" --user "$INDIEGAMES_USER:$INDIEGAMES_PASSWORD" -T "$file" --ftp-create-dirs
 
-	# Upload to fs2downloads
-	curl -k "ftp://swc.fs2downloads.com/swc.fs2downloads.com/builds/nightly/$VERSION_NAME/" --user "$FS2DOWNLOADS_USER:$FS2DOWNLOADS_PASSWORD" -T "$file" --ftp-create-dirs
+        # Upload to fs2downloads
+        curl -k "ftp://swc.fs2downloads.com/swc.fs2downloads.com/builds/nightly/$VERSION_NAME/" --user "$FS2DOWNLOADS_USER:$FS2DOWNLOADS_PASSWORD" -T "$file" --ftp-create-dirs
+    fi
 done

--- a/ci/travis/release.sh
+++ b/ci/travis/release.sh
@@ -4,8 +4,10 @@ set -ex
 mkdir -p /tmp/builds
 
 if [ "$TRAVIS_OS_NAME" = "linux" ]; then
-    PARENT_DIR="$(basename $PWD)"
-    (cd .. && tar cvf /tmp/builds/$PACKAGE_NAME-source-Unix.tar.gz --exclude-vcs "$PARENT_DIR")
+    if [ "$RELEASE_BUILD" = true ]; then
+        PARENT_DIR="$(basename $PWD)"
+        (cd .. && tar cvf /tmp/builds/$PACKAGE_NAME-source-Unix.tar.gz --exclude-vcs "$PARENT_DIR")
+    fi
 
 	cd build
     for config in $BUILD_CONFIGS


### PR DESCRIPTION
Any branch starting with "test/" will cause test builds to be compiled
and uploaded to fs2downloads. This will only work for the main
repository since the secure variables for the FTP credentials only work
for that repository.

Once this is merged I will add a short explanation to our wiki so that other
people can also use this functionality. Since this only works for the main
repository it shouldn't cause any bandwidth or storage issues since only a
few people have push access to the main repository.