### PR TITLE
Fix for #470: Proposal 2

### DIFF
--- a/code/fs2netd/tcp_socket.cpp
+++ b/code/fs2netd/tcp_socket.cpp
@@ -34,6 +34,14 @@
 #include <ctype.h>
 
 #define WSAGetLastError()  (errno)
+#define RESTART(syscall)                        \
+  ({                                            \
+    __typeof__(syscall) _res;                   \
+    do                                          \
+      _res = syscall;                           \
+    while (_res == -1 && errno == EINTR);       \
+    _res;                                       \
+})
 #else
 #include <windows.h>
 #include <process.h>


### PR DESCRIPTION
PLEASE DO NOT MERGE WITHOUT A DECISION BETWEEN PROPOSAL 1 OR 2

This is my second attempt at preventing the SIGPIPE standalone crash on all supported *nix platforms.  I recently discovered that jg18's proposal did not work on Solaris based platforms as they don't currently support MSG_NOSIGNAL or SO_NOSIGPIPE.  After a lot of searching I came up with a couple of proposals.  This one is mostly copied from https://github.com/kroki/XProbes/blob/1447f3d93b6dbf273919af15e59f35cca58fcc23/src/libxprobes.c#L156 and revolves around managing the SIGPIPE restoration differently than the first proposal.  Other proposals involving sigaction() I decided against because of thread concerns.  It may not be an issue today, but the solutions weren't any simpler so I figured I would just stick with a thread safe example rather than globally adjust SIGPIPE behavior.