### PR TITLE
for backwards compatibility, check both no-collide and no_collide

### DIFF
--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -3036,7 +3036,13 @@ int parse_object(mission *pm, int flag, p_object *p_objp)
         parse_string_flag_list(p_objp->flags, Parse_object_flags, num_parse_object_flags, &unparsed);
         if (!unparsed.empty()) {
             for (size_t k = 0; k < unparsed.size(); ++k) {
-                WarningEx(LOCATION, "Unknown flag in parse object flags: %s", unparsed[k].c_str());
+				// catch typos or deprecations
+				if (!stricmp(unparsed[k].c_str(), "no-collide") || !stricmp(unparsed[k].c_str(), "no_collide")) {
+					p_objp->flags.set(Mission::Parse_Object_Flags::OF_No_collide);
+				}
+				else {
+					WarningEx(LOCATION, "Unknown flag in parse object flags: %s", unparsed[k].c_str());
+				}
             }
         }
     }

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -3430,7 +3430,15 @@ int parse_ship_values(ship_info* sip, const bool is_template, const bool first_t
 						Warning(LOCATION, "Use of '%s' flag for %s '%s' - this flag is no longer needed.", Ship_flags[idx].name, info_type_name, sip->name);
 					else 
 						sip->flags.set(Ship_flags[idx].def);
+
+					break;
 				}
+			}
+
+			// catch typos or deprecations
+			if (!stricmp(ship_strings[i], "no-collide") || !stricmp(ship_strings[i], "no_collide")) {
+				flag_found = true;
+				sip->flags.set(Ship::Info_Flags::No_collide);
 			}
 
 			if ( !flag_found && (ship_type_index < 0) )


### PR DESCRIPTION
In the bitset flags PR #775, the `no-collide` ship flag was mistakenly changed to `no_collide`.  (This was probably because the equivalent ships.tbl flag was `no_collide`.)  As a result, this flag is not recognized in missions created with older versions of FRED, as noted in #1425.

I added code to check both variants of flag in both ship parsing and mission parsing.  This should not only fix the regression bug but also guard against typos in ships.tbl.