### PR TITLE
Fix error message for failure to load mask file in weaponloadout

### DIFF
--- a/code/missionui/missionweaponchoice.cpp
+++ b/code/missionui/missionweaponchoice.cpp
@@ -2010,13 +2010,7 @@ void weapon_select_init()
 
 	WeaponSelectMaskBitmap = bm_load(Wl_loadout_select_mask[Uses_apply_all_button][gr_screen.res]);
 	if (WeaponSelectMaskBitmap < 0) {
-		if (gr_screen.res == GR_640) {
-			Error(LOCATION,"Could not load in 'weaponloadout-m'!");
-		} else if (gr_screen.res == GR_1024) {
-			Error(LOCATION,"Could not load in '2_weaponloadout-m'!");
-		} else {
-			Error(LOCATION,"Could not load in 'weaponloadout-m'!");
-		}
+		Error(LOCATION,"Could not load in '%s'!", Wl_loadout_select_mask[Uses_apply_all_button][gr_screen.res]);
 	}
 
 	Weaponselect_mask_w = -1;


### PR DESCRIPTION
When loading the mask file fails, correctly report which file we were trying to load.