### PR TITLE
fix typo in AI flag conversion

### DIFF
--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -3814,7 +3814,7 @@ float ai_path_0()
 		int path_num;
 		Assert(aip->active_goal >= 0);
 		ai_goal *aigp = &aip->goals[aip->active_goal];
-		Assert(aigp->flags[AI::Goal_Flags::Dockee_index_valid] || aigp->flags[AI::Goal_Flags::Docker_index_valid]);
+		Assert(aigp->flags[AI::Goal_Flags::Dockee_index_valid] && aigp->flags[AI::Goal_Flags::Docker_index_valid]);
 
 		path_num = ai_return_path_num_from_dockbay(&Objects[aip->goal_objnum], aigp->dockee.index);
 		ai_find_path(Pl_objp, aip->goal_objnum, path_num, 0);
@@ -3957,7 +3957,7 @@ float ai_path_1()
 		int path_num;
 		Assert(aip->active_goal >= 0);
 		ai_goal *aigp = &aip->goals[aip->active_goal];
-		Assert(aigp->flags[AI::Goal_Flags::Dockee_index_valid] || aigp->flags[AI::Goal_Flags::Docker_index_valid]);
+		Assert(aigp->flags[AI::Goal_Flags::Dockee_index_valid] && aigp->flags[AI::Goal_Flags::Docker_index_valid]);
 
 		path_num = ai_return_path_num_from_dockbay(&Objects[aip->goal_objnum], aigp->dockee.index);
 		ai_find_path(Pl_objp, aip->goal_objnum, path_num, 0);
@@ -10399,7 +10399,7 @@ void ai_get_dock_goal_indexes(object *objp, ai_info *aip, ai_goal *aigp, object 
 		{
 			// get them from the active goal
 			Assert(aigp != NULL);
-			Assert(aigp->flags[AI::Goal_Flags::Dockee_index_valid] || aigp->flags[AI::Goal_Flags::Docker_index_valid]);
+			Assert(aigp->flags[AI::Goal_Flags::Dockee_index_valid] && aigp->flags[AI::Goal_Flags::Docker_index_valid]);
 			docker_index = aigp->docker.index;
 			dockee_index = aigp->dockee.index;
 			Assert(docker_index >= 0);

--- a/code/network/multimsgs.cpp
+++ b/code/network/multimsgs.cpp
@@ -4902,7 +4902,7 @@ void process_repair_info_packet(ubyte *data, header *hinfo)
 			ai_info *aip = &Ai_info[Ships[repair_objp->instance].ai_index];
 			Assert(aip->active_goal >= 0);
 			ai_goal *aigp = &aip->goals[aip->active_goal];
-			Assert(aigp->flags[AI::Goal_Flags::Dockee_index_valid, AI::Goal_Flags::Docker_index_valid]);
+			Assert(aigp->flags[AI::Goal_Flags::Dockee_index_valid] || aigp->flags[AI::Goal_Flags::Docker_index_valid]);
 
 			int docker_index = aigp->docker.index;
 			int dockee_index = aigp->dockee.index;

--- a/code/network/multimsgs.cpp
+++ b/code/network/multimsgs.cpp
@@ -4902,7 +4902,7 @@ void process_repair_info_packet(ubyte *data, header *hinfo)
 			ai_info *aip = &Ai_info[Ships[repair_objp->instance].ai_index];
 			Assert(aip->active_goal >= 0);
 			ai_goal *aigp = &aip->goals[aip->active_goal];
-			Assert(aigp->flags[AI::Goal_Flags::Dockee_index_valid] || aigp->flags[AI::Goal_Flags::Docker_index_valid]);
+			Assert(aigp->flags[AI::Goal_Flags::Dockee_index_valid] && aigp->flags[AI::Goal_Flags::Docker_index_valid]);
 
 			int docker_index = aigp->docker.index;
 			int dockee_index = aigp->dockee.index;
@@ -5020,7 +5020,7 @@ void send_ai_info_update_packet( object *objp, char what, object * other_objp )
 
 		// for docking, add the dock and dockee index
 		if (aigp->ai_mode & (AI_GOAL_DOCK | AI_GOAL_REARM_REPAIR)) {
-			Assert(aigp->flags[AI::Goal_Flags::Dockee_index_valid] || aigp->flags[AI::Goal_Flags::Docker_index_valid]);
+			Assert(aigp->flags[AI::Goal_Flags::Dockee_index_valid] && aigp->flags[AI::Goal_Flags::Docker_index_valid]);
 			Assert( (aigp->docker.index >= 0) && (aigp->docker.index < UCHAR_MAX) );
 			Assert( (aigp->dockee.index >= 0) && (aigp->dockee.index < UCHAR_MAX) );
 			docker_index = (ubyte) aigp->docker.index;


### PR DESCRIPTION
I noticed that there was one line in #922 where two flags were checked using the comma operator.  This is incorrect as the comma operator evaluates both expressions but only returns the value of the rightmost expression, resulting in only one flag being checked.  This PR fixes the Assert by copying the same condition as another Assert elsewhere in the file.

This PR is actually a no-op because the problematic code is commented out, but one never knows when it might be used again.