### PR TITLE
Move 4 bit color conversion out of graphics code

### DIFF
--- a/code/anim/packunpack.cpp
+++ b/code/anim/packunpack.cpp
@@ -512,7 +512,14 @@ int unpack_pixel(anim_instance *ai, ubyte *data, ubyte pix, int aabitmap, int bp
 			bit_16 = (ushort)pix;
 			break;
 		case 8:
-			bit_8 = pix;
+			// 8 bit-per-pixel aa bitmaps are a bit special since they only use value in the range [0, 15] where 15 wraps
+			// around back to 0. Since the rest of the code expects the value to be in the range [0, 255] the pixel value
+			// needs to be adjusted here. By muliplying the value with 17 the original range [0, 15] is mapped to [0, 255]
+			if (pix >= 15) {
+				bit_8 = 0;
+			} else {
+				bit_8 = (ubyte)(pix * 17);
+			}
 			break;
 		default:
 			Int3();
@@ -596,7 +603,14 @@ int unpack_pixel_count(anim_instance *ai, ubyte *data, ubyte pix, int count = 0,
 			bit_16 = (ushort)pix;
 			break;
 		case 8 :
-			bit_8 = pix;
+			// 8 bit-per-pixel aa bitmaps are a bit special since they only use value in the range [0, 15] where 15 wraps
+			// around back to 0. Since the rest of the code expects the value to be in the range [0, 255] the pixel value
+			// needs to be adjusted here. By muliplying the value with 17 the original range [0, 15] is mapped to [0, 255]
+			if (pix >= 15) {
+				bit_8 = 0;
+			} else {
+				bit_8 = (ubyte)(pix * 17);
+			}
 			break;
 		default :
 			Int3();			

--- a/code/graphics/opengl/gropengltexture.cpp
+++ b/code/graphics/opengl/gropengltexture.cpp
@@ -37,7 +37,6 @@ int GL_textures_in_frame = 0;
 int GL_last_detail = -1;
 GLint GL_supported_texture_units = 2;
 int GL_should_preload = 0;
-ubyte GL_xlat[256];
 GLfloat GL_anisotropy = 1.0f;
 GLfloat GL_max_anisotropy = -1.0f;
 int GL_mipmap_filter = 0;
@@ -167,16 +166,6 @@ void opengl_tcache_init()
 		CLAMP(GL_anisotropy, 1.0f, GL_max_anisotropy);
 	}
 
-
-	// set the alpha gamma settings (for fonts)
-	memset( GL_xlat, 0, sizeof(GL_xlat) );
-
-	for (i = 1; i < 15; i++) {
-		GL_xlat[i] = (ubyte)(GL_xlat[i-1] + 17);
-	}
-
-	GL_xlat[15] = GL_xlat[1];
-	
 	Assert( GL_supported_texture_units >= 2 );
 
 	GL_last_detail = Detail.hardware_textures;
@@ -544,7 +533,7 @@ int opengl_create_texture_sub(int bitmap_handle, int bitmap_type, int bmap_w, in
 								*texmemp++ = (ubyte)(luminance / byte_mult);
 							}
 						} else {
-							*texmemp++ = GL_xlat[bmp_data[i*bmap_w+j]];
+							*texmemp++ = bmp_data[i*bmap_w+j];
 						}
 					} else {
 						*texmemp++ = 0;
@@ -1403,7 +1392,7 @@ void gr_opengl_update_texture(int bitmap_handle, int bpp, const ubyte* data, int
 							*texmemp++ = (ubyte)(luminance / true_byte_mult);
 						}
 					} else {
-						*texmemp++ = GL_xlat[data[i*width+j]];
+						*texmemp++ = data[i*width+j];
 					}
 				} else {
 					*texmemp++ = 0;

--- a/code/graphics/software/FontManager.cpp
+++ b/code/graphics/software/FontManager.cpp
@@ -226,7 +226,11 @@ namespace font
 				for (x1 = 0; x1<fnt->char_data[i].byte_width; x1++)	{
 					uint c = *ubp++;
 					if (c > 14) c = 14;
-					fnt->bm_data[(x + x1) + (y + y1)*fnt->bm_w] = (unsigned char)(c);
+					// The font pixels only have ~4 bits of information in them (since the value is at maximum 14) but
+					// the bmpman code expects 8 bits of pixel information. To fix that we simply rescale this value to
+					// fit into the [0, 255] range (15 * 17 is 255). This was adapted from the previous version where
+					// the graphics code used an internal array for converting these values
+					fnt->bm_data[(x + x1) + (y + y1)*fnt->bm_w] = (unsigned char)(c * 17);
 				}
 			}
 			x += fnt->char_data[i].byte_width + 2;


### PR DESCRIPTION
Currently, the graphics code does some color remapping on 8
bit-per-pixel textures since those textures use special 4-bit pixel
values. These changes move that conversion out of the graphics code and
into the image loading/font bitmap creation code.

The reason this is needed is because this conversion breaks 8-bit
textures that try to use the full range of colors. I need to do exactly
that for moving the cutscene renderer to our generic rendering interface
which I can't do at the moment since the existing color conversion
corrupts the video data.

I have tested this with retail data and could not find any visual
changes after applying these changes.