### PR TITLE
Remove stack trace from warning dialogs

### DIFF
--- a/code/osapi/dialogs.cpp
+++ b/code/osapi/dialogs.cpp
@@ -384,10 +384,9 @@ namespace os
 			boxMsgStream << "File: " << filename << "\n";
 			boxMsgStream << "Line: " << line << "\n";
 
-			boxMsgStream << "\n";
-			boxMsgStream << dump_stacktrace();
-
 			set_clipboard_text(boxMsgStream.str().c_str());
+
+			boxMsgStream << "\n";
 
 			SCP_string boxMessage = truncateLines(boxMsgStream, Messagebox_lines);
 			boxMessage += "\n[ This info is in the clipboard so you can paste it somewhere now ]\n";


### PR DESCRIPTION
It serves no purpose there since it's a message specifically designed to
be seen by modders and most times the stack trace doesn't even contain
useful information since there are no debug symbols present.