### PR TITLE
Actually unpause 3D beam sounds correctly.

### DIFF
--- a/code/weapon/beam.cpp
+++ b/code/weapon/beam.cpp
@@ -717,8 +717,14 @@ void beam_unpause_sounds()
 	if(moveup == NULL){
 		return;
 	}
-	while(moveup != END_OF_LIST(&Beam_used_list)){				
-		beam_recalc_sounds(moveup);
+	while(moveup != END_OF_LIST(&Beam_used_list)){
+		if (Cmdline_no_3d_sound) {
+			beam_recalc_sounds(moveup);
+		} else {
+			if (moveup->beam_sound_loop >= 0) {
+				snd_set_volume(moveup->beam_sound_loop, 1.0f);
+			}
+		}
 
 		// next beam
 		moveup = GET_NEXT(moveup);


### PR DESCRIPTION
`beam_pause_sounds()` "pauses" looping beam sounds by setting their volume to 0; `beam_unpause_sounds()` "unpaused" by calling `beam_recalc_sounds()`, which only set the volume correctly when -no_3d_sound is set; 3D sound updates the sound's position without changing its volume. This PR just makes `beam_unpause_sounds()` perform the inverse operation of `beam_pause_sounds()` if 3D sounds are enabled.