### PR TITLE
toss out the campaign savefile if we are restarting a previously finished campaign

### DIFF
--- a/code/menuui/readyroom.cpp
+++ b/code/menuui/readyroom.cpp
@@ -1546,16 +1546,8 @@ void campaign_room_commit()
 		return;
 	}
 
-	if (stricmp(Campaign_file_names[Selected_campaign_index], Campaign.filename)) {  // new campaign selected
-		/* This is all that's stopping us from switching campaigns without restarting - taylor
-		if ((Active_campaign_index >= 0) && campaign_room_reset_campaign(Active_campaign_index)) {
-			gamesnd_play_iface(SND_GENERAL_FAIL);
-			return;
-		}
-
-		mission_campaign_savefile_delete(Campaign_file_names[Selected_campaign_index]);
-		*/
-
+	// new campaign selected?
+	if (stricmp(Campaign_file_names[Selected_campaign_index], Campaign.filename)) {
 		// Goober5000 - reinitialize tech database if needed
 		if ( (Campaign.flags & CF_CUSTOM_TECH_DATABASE) || !stricmp(Campaign.filename, "freespace2") )
 		{

--- a/code/menuui/readyroom.cpp
+++ b/code/menuui/readyroom.cpp
@@ -1563,8 +1563,20 @@ void campaign_room_commit()
 			tech_reset_to_default();
 		}
 
-		mission_campaign_load(Campaign_file_names[Selected_campaign_index]);
-		strcpy_s(Player->current_campaign, Campaign.filename);  // track new campaign for player
+		int load_status = mission_campaign_load(Campaign_file_names[Selected_campaign_index]);
+
+		if (load_status == 0) {
+			strcpy_s(Player->current_campaign, Campaign.filename);  // track new campaign for player
+
+			// sanity check: if we just loaded a savefile, but we have no next mission,
+			// then we are switching back to an old campaign that we previously completed,
+			// and we want to clear it to start afresh
+			if (Campaign.next_mission == -1) {
+				mission_campaign_savefile_delete(Campaign_file_names[Selected_campaign_index]);
+				Campaign.next_mission = 0;
+			}
+		}
+		// TODO: other return values were never checked previously; do we need to check them???
 	}
 
 	if (mission_campaign_next_mission()) {  // is campaign and next mission valid?


### PR DESCRIPTION
When switching to a previously completed campaign, the game will currently attempt to make further progress due to the existing campaign savefile, which is obviously not possible.  This PR deletes the old campaign savefile (which is retail behavior) and sets the next mission to the first in the campaign.  This way, the player can start the campaign afresh.  Pilot stats are not modified.

This PR fixes Mantis #3174.