### PR TITLE
Fix memory allocation in tga loading code

### DIFF
--- a/code/bmpman/bmpman.cpp
+++ b/code/bmpman/bmpman.cpp
@@ -2411,7 +2411,7 @@ void bm_lock_tga(int handle, int bitmapnum, bitmap_entry *be, bitmap *bmp, int b
 	Assert(byte_size);
 	Assert(be->mem_taken > 0);
 
-	data = (ubyte*)bm_malloc(bitmapnum, be->mem_taken);
+	data = (ubyte*)bm_malloc(bitmapnum, static_cast<size_t>(bmp->w * bmp->h * byte_size));
 
 	if (data) {
 		memset(data, 0, be->mem_taken);


### PR DESCRIPTION
The code did not use the right method for calculating the required size
of the memory. This was never noticed before because the old OpenGL
texture loading code only used 16-bit textures for interface data but
the new code uses 32-bit textures which exhausted the available memory.

This was found and reported by @chief1983.