### PR TITLE
Avoid redundant glActiveTexture calls

### DIFF
--- a/code/graphics/opengl/gropengldraw.cpp
+++ b/code/graphics/opengl/gropengldraw.cpp
@@ -838,9 +838,7 @@ void gr_opengl_scene_texture_end()
 
 		GL_state.PopFramebufferState();
 
-		GL_state.Texture.SetActiveUnit(0);
-		GL_state.Texture.SetTarget(GL_TEXTURE_2D);
-		GL_state.Texture.Enable(Scene_color_texture);
+		GL_state.Texture.Enable(0, GL_TEXTURE_2D, Scene_color_texture);
 
 		glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
 		glClear(GL_COLOR_BUFFER_BIT);
@@ -966,21 +964,13 @@ void gr_opengl_deferred_lighting_finish()
 
 	GL_state.Texture.SetShaderMode(GL_TRUE);
 
-	GL_state.Texture.SetActiveUnit(0);
-	GL_state.Texture.SetTarget(GL_TEXTURE_2D);
-	GL_state.Texture.Enable(Scene_color_texture);
+	GL_state.Texture.Enable(0, GL_TEXTURE_2D, Scene_color_texture);
 
-	GL_state.Texture.SetActiveUnit(1);
-	GL_state.Texture.SetTarget(GL_TEXTURE_2D);
-	GL_state.Texture.Enable(Scene_normal_texture);
+	GL_state.Texture.Enable(1, GL_TEXTURE_2D, Scene_normal_texture);
 
-	GL_state.Texture.SetActiveUnit(2);
-	GL_state.Texture.SetTarget(GL_TEXTURE_2D);
-	GL_state.Texture.Enable(Scene_position_texture);
+	GL_state.Texture.Enable(2, GL_TEXTURE_2D, Scene_position_texture);
 
-	GL_state.Texture.SetActiveUnit(3);
-	GL_state.Texture.SetTarget(GL_TEXTURE_2D);
-	GL_state.Texture.Enable(Scene_specular_texture);
+	GL_state.Texture.Enable(3, GL_TEXTURE_2D, Scene_specular_texture);
 
 	glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
 	glClear(GL_COLOR_BUFFER_BIT);
@@ -1069,10 +1059,8 @@ void gr_opengl_deferred_lighting_finish()
 	} else {
 		opengl_shader_set_passthrough(true);
 	}
-	
-	GL_state.Texture.SetActiveUnit(0);
-	GL_state.Texture.SetTarget(GL_TEXTURE_2D);
-	GL_state.Texture.Enable(Scene_luminance_texture);
+
+	GL_state.Texture.Enable(0, GL_TEXTURE_2D, Scene_luminance_texture);
 
 	GL_state.SetAlphaBlendMode( ALPHA_BLEND_ADDITIVE );
 	GL_state.DepthMask(GL_FALSE);
@@ -1159,9 +1147,7 @@ void gr_opengl_update_distortion()
 	glDrawBuffer(GL_COLOR_ATTACHMENT0);
 
 	glViewport(0,0,32,32);
-	GL_state.Texture.SetActiveUnit(0);
-	GL_state.Texture.SetTarget(GL_TEXTURE_2D);
-	GL_state.Texture.Enable(Distortion_texture[Distortion_switch]);
+	GL_state.Texture.Enable(0, GL_TEXTURE_2D, Distortion_texture[Distortion_switch]);
 	glClearColor(0.5f, 0.5f, 0.0f, 1.0f);
 	glClear(GL_COLOR_BUFFER_BIT);
 

--- a/code/graphics/opengl/gropenglpostprocessing.cpp
+++ b/code/graphics/opengl/gropenglpostprocessing.cpp
@@ -91,9 +91,7 @@ void opengl_post_pass_tonemap()
 
 	glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, Scene_ldr_texture, 0);
 
-	GL_state.Texture.SetActiveUnit(0);
-	GL_state.Texture.SetTarget(GL_TEXTURE_2D);
-	GL_state.Texture.Enable(Scene_color_texture);
+	GL_state.Texture.Enable(0, GL_TEXTURE_2D, Scene_color_texture);
 
 	opengl_draw_textured_quad(-1.0f, -1.0f, 0.0f, 0.0f, 1.0f, 1.0f, Scene_texture_u_scale, Scene_texture_u_scale);
 }
@@ -128,9 +126,7 @@ void opengl_post_pass_bloom()
 
 		Current_shader->program->Uniforms.setUniformi("tex", 0);
 
-		GL_state.Texture.SetActiveUnit(0);
-		GL_state.Texture.SetTarget(GL_TEXTURE_2D);
-		GL_state.Texture.Enable(Scene_color_texture);
+		GL_state.Texture.Enable(0, GL_TEXTURE_2D, Scene_color_texture);
 
 		opengl_draw_textured_quad(-1.0f, -1.0f, 0.0f, 0.0f, 1.0f, 1.0f, 1.0f, 1.0f);
 	}
@@ -138,9 +134,7 @@ void opengl_post_pass_bloom()
 
 	// ------ begin blur pass ------
 
-	GL_state.Texture.SetActiveUnit(0);
-	GL_state.Texture.SetTarget(GL_TEXTURE_2D);
-	GL_state.Texture.Enable(Bloom_textures[0]);
+	GL_state.Texture.Enable(0, GL_TEXTURE_2D, Bloom_textures[0]);
 
 	glGenerateMipmap(GL_TEXTURE_2D);
 
@@ -160,9 +154,7 @@ void opengl_post_pass_bloom()
 
 			Current_shader->program->Uniforms.setUniformi("tex", 0);
 
-			GL_state.Texture.SetActiveUnit(0);
-			GL_state.Texture.SetTarget(GL_TEXTURE_2D);
-			GL_state.Texture.Enable(source_tex);
+			GL_state.Texture.Enable(0, GL_TEXTURE_2D, source_tex);
 
 			for (int mipmap = 0; mipmap < MAX_MIP_BLUR_LEVELS; ++mipmap) {
 				int bloom_width = width >> mipmap;
@@ -194,9 +186,7 @@ void opengl_post_pass_bloom()
 		Current_shader->program->Uniforms.setUniformi("levels", MAX_MIP_BLUR_LEVELS);
 		Current_shader->program->Uniforms.setUniformf("bloom_intensity", Cmdline_bloom_intensity / 100.0f);
 
-		GL_state.Texture.SetActiveUnit(0);
-		GL_state.Texture.SetTarget(GL_TEXTURE_2D);
-		GL_state.Texture.Enable(Bloom_textures[0]);
+		GL_state.Texture.Enable(0, GL_TEXTURE_2D, Bloom_textures[0]);
 
 		GL_state.SetAlphaBlendMode(ALPHA_BLEND_ADDITIVE);
 
@@ -272,9 +262,7 @@ void opengl_post_pass_fxaa() {
 
 	glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, Scene_luminance_texture, 0);
 
-	GL_state.Texture.SetActiveUnit(0);
-	GL_state.Texture.SetTarget(GL_TEXTURE_2D);
-	GL_state.Texture.Enable(Scene_ldr_texture);
+	GL_state.Texture.Enable(0, GL_TEXTURE_2D, Scene_ldr_texture);
 
 	opengl_draw_textured_quad(-1.0f, -1.0f, 0.0f, 0.0f, 1.0f, 1.0f, Scene_texture_u_scale, Scene_texture_u_scale);
 
@@ -288,9 +276,7 @@ void opengl_post_pass_fxaa() {
 	Current_shader->program->Uniforms.setUniformf( "rt_w", static_cast<float>(Post_texture_width));
 	Current_shader->program->Uniforms.setUniformf( "rt_h", static_cast<float>(Post_texture_height));
 
-	GL_state.Texture.SetActiveUnit(0);
-	GL_state.Texture.SetTarget(GL_TEXTURE_2D);
-	GL_state.Texture.Enable(Scene_luminance_texture);
+	GL_state.Texture.Enable(0, GL_TEXTURE_2D, Scene_luminance_texture);
 
 	opengl_draw_textured_quad(-1.0f, -1.0f, 0.0f, 0.0f, 1.0f, 1.0f, Scene_texture_u_scale, Scene_texture_u_scale);
 
@@ -342,12 +328,8 @@ void opengl_post_lightshafts()
 				Current_shader->program->Uniforms.setUniformf("intensity", Sun_spot * ls_intensity);
 				Current_shader->program->Uniforms.setUniformf("cp_intensity", Sun_spot * ls_cpintensity);
 
-				GL_state.Texture.SetActiveUnit(0);
-				GL_state.Texture.SetTarget(GL_TEXTURE_2D);
-				GL_state.Texture.Enable(Scene_depth_texture);
-				GL_state.Texture.SetActiveUnit(1);
-				GL_state.Texture.SetTarget(GL_TEXTURE_2D);
-				GL_state.Texture.Enable(Cockpit_depth_texture);
+				GL_state.Texture.Enable(0, GL_TEXTURE_2D, Scene_depth_texture);
+				GL_state.Texture.Enable(1, GL_TEXTURE_2D, Cockpit_depth_texture);
 				GL_state.Blend(GL_TRUE);
 				GL_state.SetAlphaBlendMode(ALPHA_BLEND_ADDITIVE);
 
@@ -436,14 +418,10 @@ void gr_opengl_post_process_end()
 
 	// now render it to the screen ...
 	GL_state.PopFramebufferState();
-	GL_state.Texture.SetActiveUnit(0);
-	GL_state.Texture.SetTarget(GL_TEXTURE_2D);
 	//GL_state.Texture.Enable(Scene_color_texture);
-	GL_state.Texture.Enable(Scene_ldr_texture);
+	GL_state.Texture.Enable(0, GL_TEXTURE_2D, Scene_ldr_texture);
 
-	GL_state.Texture.SetActiveUnit(1);
-	GL_state.Texture.SetTarget(GL_TEXTURE_2D);
-	GL_state.Texture.Enable(Scene_depth_texture);
+	GL_state.Texture.Enable(1, GL_TEXTURE_2D, Scene_depth_texture);
 
 	opengl_draw_textured_quad(-1.0f, -1.0f, 0.0f, 0.0f, 1.0f, 1.0f, Scene_texture_u_scale, Scene_texture_u_scale);
 
@@ -936,8 +914,6 @@ static bool opengl_post_init_framebuffer()
 
 		glGenTextures(1, &Post_shadow_depth_texture_id);
 
-		GL_state.Texture.SetActiveUnit(0);
-		GL_state.Texture.SetTarget(GL_TEXTURE_2D_ARRAY);
 //		GL_state.Texture.SetTarget(GL_TEXTURE_2D);
 		GL_state.Texture.Enable(Post_shadow_depth_texture_id);
 

--- a/code/graphics/opengl/gropenglstate.cpp
+++ b/code/graphics/opengl/gropenglstate.cpp
@@ -97,6 +97,20 @@ void opengl_texture_state::Enable(GLuint tex_id)
 	}
 }
 
+void opengl_texture_state::Enable(GLuint unit, GLenum tex_target, GLuint tex_id) {
+	Assertion(unit < num_texture_units, "Invalid texture unit value!");
+
+	if (units[unit].texture_target == tex_target && units[unit].texture_id == tex_id) {
+		// The texture unit already uses this texture. There is no need to change it
+		return;
+	}
+
+	// Go the standard route
+	SetActiveUnit(unit);
+	SetTarget(tex_target);
+	Enable(tex_id);
+}
+
 void opengl_texture_state::Delete(GLuint tex_id)
 {
 	if (tex_id == 0) {

--- a/code/graphics/opengl/gropenglstate.h
+++ b/code/graphics/opengl/gropenglstate.h
@@ -50,6 +50,20 @@ class opengl_texture_state
 		void SetTarget(GLenum tex_target);
 		void SetActiveUnit(GLuint id = 0);
 		void Enable(GLuint tex_id = 0);
+		/**
+		 * @brief Directly enables a texture on the specified unit
+		 *
+		 * This is a more efficient version of the standard activeTexture -> Enable since it does not cause an
+		 * OpenGL call if the texture is already set correctly
+		 *
+		 * @warning This may not actually set the active texture unit to the specified value! If you require that then
+		 * you need to call SetActiveUnit!
+		 *
+		 * @param unit The texture unit to use
+		 * @param tex_target The texture target of the texture id
+		 * @param tex_id The ID of the texture to enable
+		 */
+		void Enable(GLuint unit, GLenum tex_target, GLuint tex_id);
 		void Delete(GLuint tex_id);
 		
 		inline GLenum GetTarget();

--- a/code/graphics/opengl/gropengltexture.cpp
+++ b/code/graphics/opengl/gropengltexture.cpp
@@ -1064,10 +1064,10 @@ int gr_opengl_tcache_set_internal(int bitmap_handle, int bitmap_type, float *u_s
 	int n = bm_get_cache_slot (bitmap_handle, 1);
 	tcache_slot_opengl *t = &Textures[n];
 
-	GL_state.Texture.SetActiveUnit(tex_unit);
-
 	if (!bm_is_render_target(bitmap_handle) && t->bitmap_handle < 0)
 	{
+		GL_state.Texture.SetActiveUnit(tex_unit);
+
 		ret_val = opengl_create_texture( bitmap_handle, bitmap_type, t );
 	}
 
@@ -1077,12 +1077,13 @@ int gr_opengl_tcache_set_internal(int bitmap_handle, int bitmap_type, float *u_s
 		*v_scale = t->v_scale;
 		*array_index = t->array_index;
 
-		GL_state.Texture.SetTarget(t->texture_target);
-		GL_state.Texture.Enable(t->texture_id);
+		GL_state.Texture.Enable(tex_unit, t->texture_target, t->texture_id);
 
 		if ( (t->wrap_mode != GL_texture_addressing) && (bitmap_type != TCACHE_TYPE_AABITMAP)
 			&& (bitmap_type != TCACHE_TYPE_INTERFACE) && (bitmap_type != TCACHE_TYPE_CUBEMAP) )
 		{
+			// In this case we need to make sure that the texture unit is actually active
+			GL_state.Texture.SetActiveUnit(tex_unit);
 			glTexParameteri(t->texture_target, GL_TEXTURE_WRAP_S, GL_texture_addressing);
 			glTexParameteri(t->texture_target, GL_TEXTURE_WRAP_T, GL_texture_addressing);
 			glTexParameteri(t->texture_target, GL_TEXTURE_WRAP_R, GL_texture_addressing);

--- a/code/graphics/opengl/gropengltnl.cpp
+++ b/code/graphics/opengl/gropengltnl.cpp
@@ -345,8 +345,6 @@ void opengl_tnl_init()
 
 		glGenTextures(1, &Shadow_map_depth_texture);
 
-		GL_state.Texture.SetActiveUnit(0);
-		GL_state.Texture.SetTarget(GL_TEXTURE_2D_ARRAY);
 //		GL_state.Texture.SetTarget(GL_TEXTURE_2D);
 		GL_state.Texture.Enable(Shadow_map_depth_texture);
 		
@@ -373,8 +371,6 @@ void opengl_tnl_init()
 
 		glGenTextures(1, &Shadow_map_texture);
 
-		GL_state.Texture.SetActiveUnit(0);
-		GL_state.Texture.SetTarget(GL_TEXTURE_2D_ARRAY);
 		//GL_state.Texture.SetTarget(GL_TEXTURE_2D);
 		GL_state.Texture.Enable(Shadow_map_texture);
 
@@ -1154,9 +1150,7 @@ void opengl_tnl_set_model_material(model_material *material_info)
 		Current_shader->program->Uniforms.setUniformf("fardist", Shadow_cascade_distances[3]);
 		Current_shader->program->Uniforms.setUniformi("shadow_map", render_pass);
 
-		GL_state.Texture.SetActiveUnit(render_pass);
-		GL_state.Texture.SetTarget(GL_TEXTURE_2D_ARRAY);
-		GL_state.Texture.Enable(Shadow_map_texture);
+		GL_state.Texture.Enable(render_pass, GL_TEXTURE_2D_ARRAY, Shadow_map_texture);
 
 		++render_pass; // bump!
 	}
@@ -1168,14 +1162,11 @@ void opengl_tnl_set_model_material(model_material *material_info)
 	if ( Current_shader->flags & SDR_FLAG_MODEL_ANIMATED ) {
 		Current_shader->program->Uniforms.setUniformi("sFramebuffer", render_pass);
 
-		GL_state.Texture.SetActiveUnit(render_pass);
-		GL_state.Texture.SetTarget(GL_TEXTURE_2D);
-
 		if ( Scene_framebuffer_in_frame ) {
-			GL_state.Texture.Enable(Scene_effect_texture);
+			GL_state.Texture.Enable(render_pass, GL_TEXTURE_2D, Scene_effect_texture);
 			glDrawBuffer(GL_COLOR_ATTACHMENT0);
 		} else {
-			GL_state.Texture.Enable(Framebuffer_fallback_texture_id);
+			GL_state.Texture.Enable(render_pass, GL_TEXTURE_2D, Framebuffer_fallback_texture_id);
 		}
 
 		++render_pass;
@@ -1184,10 +1175,8 @@ void opengl_tnl_set_model_material(model_material *material_info)
 	if ( Current_shader->flags & SDR_FLAG_MODEL_TRANSFORM ) {
 		Current_shader->program->Uniforms.setUniformi("transform_tex", render_pass);
 		Current_shader->program->Uniforms.setUniformi("buffer_matrix_offset", (int)GL_transform_buffer_offset);
-		
-		GL_state.Texture.SetActiveUnit(render_pass);
-		GL_state.Texture.SetTarget(GL_TEXTURE_BUFFER);
-		GL_state.Texture.Enable(opengl_get_transform_buffer_texture());
+
+		GL_state.Texture.Enable(render_pass, GL_TEXTURE_BUFFER, opengl_get_transform_buffer_texture());
 
 		++render_pass;
 	}
@@ -1272,15 +1261,11 @@ void opengl_tnl_set_material_particle(particle_material * material_info)
 	if ( !Cmdline_no_deferred_lighting ) {
 		Assert(Scene_position_texture != 0);
 
-		GL_state.Texture.SetActiveUnit(1);
-		GL_state.Texture.SetTarget(GL_TEXTURE_2D);
-		GL_state.Texture.Enable(Scene_position_texture);
+		GL_state.Texture.Enable(1, GL_TEXTURE_2D, Scene_position_texture);
 	} else {
 		Assert(Scene_depth_texture != 0);
 
-		GL_state.Texture.SetActiveUnit(1);
-		GL_state.Texture.SetTarget(GL_TEXTURE_2D);
-		GL_state.Texture.Enable(Scene_depth_texture);
+		GL_state.Texture.Enable(1, GL_TEXTURE_2D, Scene_depth_texture);
 	}
 }
 void opengl_tnl_set_material_batched(batched_bitmap_material* material_info) {
@@ -1312,30 +1297,24 @@ void opengl_tnl_set_material_distortion(distortion_material* material_info)
 	Current_shader->program->Uniforms.setUniformf("farZ", Max_draw_distance);
 	Current_shader->program->Uniforms.setUniformi("frameBuffer", 2);
 
-	GL_state.Texture.SetActiveUnit(2);
-	GL_state.Texture.SetTarget(GL_TEXTURE_2D);
-	GL_state.Texture.Enable(Scene_effect_texture);
+	GL_state.Texture.Enable(2, GL_TEXTURE_2D, Scene_effect_texture);
 
 	Current_shader->program->Uniforms.setUniformi("distMap", 3);
-	GL_state.Texture.SetActiveUnit(3);
-	GL_state.Texture.SetTarget(GL_TEXTURE_2D);
 
 	if(material_info->get_thruster_rendering()) {
-		GL_state.Texture.Enable(Distortion_texture[!Distortion_switch]);
+		GL_state.Texture.Enable(3, GL_TEXTURE_2D, Distortion_texture[!Distortion_switch]);
 
 		Current_shader->program->Uniforms.setUniformf("use_offset", 1.0f);
 	} else {
 		// Disable this texture unit
-		GL_state.Texture.Enable(0);
+		GL_state.Texture.Enable(3, GL_TEXTURE_2D, 0);
 
 		Current_shader->program->Uniforms.setUniformf("use_offset", 0.0f);
 	}
 
 	Assert(Scene_depth_texture != 0);
 
-	GL_state.Texture.SetActiveUnit(1);
-	GL_state.Texture.SetTarget(GL_TEXTURE_2D);
-	GL_state.Texture.Enable(Scene_depth_texture);
+	GL_state.Texture.Enable(1, GL_TEXTURE_2D, Scene_depth_texture);
 }
 
 void opengl_tnl_set_material_movie(movie_material* material_info) {


### PR DESCRIPTION
This introduces a new function in the OpenGL state tracker which
combines setting the active texture unit and enabling a texture. The
reason this is a good idea is that this new function can filter out
unneeded calls to glActiveTexture if the texture is already enabled on
that specific unit. This happens very often when rendering several
submodels of a model which share their textures.

This is unlikely to yield significant performance improvements but
avoiding unneded OpenGL calls is always a good idea.