### PR TITLE
Move immediate mode rendering into generic graphics code

### DIFF
--- a/code/graphics/2d.cpp
+++ b/code/graphics/2d.cpp
@@ -2096,6 +2096,8 @@ void gr_flip(bool execute_scripting)
 		Script_system.EndFrame();
 	}
 
+	gr_reset_immediate_buffer();
+
 	gr_screen.gf_flip();
 }
 

--- a/code/graphics/2d.h
+++ b/code/graphics/2d.h
@@ -196,14 +196,10 @@ struct vertex_format_data
 
 	vertex_format format_type;
 	size_t stride;
-	void *data_src;
-	int offset;
+	size_t offset;
 
-	vertex_format_data(vertex_format i_format_type, size_t i_stride, void *i_data_src) : 
-	format_type(i_format_type), stride(i_stride), data_src(i_data_src), offset(-1) {}
-
-	vertex_format_data(vertex_format i_format_type, size_t i_stride, int i_offset) : 
-	format_type(i_format_type), stride(i_stride), data_src(NULL), offset(i_offset) {}
+	vertex_format_data(vertex_format i_format_type, size_t i_stride, size_t i_offset) :
+	format_type(i_format_type), stride(i_stride), offset(i_offset) {}
 
 	static inline uint mask(vertex_format v_format) { return 1 << v_format; }
 };
@@ -216,34 +212,16 @@ class vertex_layout
 public:
 	vertex_layout(): Vertex_mask(0) {}
 
-	vertex_layout(void* init_ptr): Vertex_mask(0) {}
+	size_t get_num_vertex_components() const { return Vertex_components.size(); }
 
-	size_t get_num_vertex_components() { return Vertex_components.size(); }
-
-	vertex_format_data* get_vertex_component(size_t index) { return &Vertex_components[index]; }
+	const vertex_format_data* get_vertex_component(size_t index) const { return &Vertex_components[index]; }
 	
-	bool resident_vertex_format(vertex_format_data::vertex_format format_type)
+	bool resident_vertex_format(vertex_format_data::vertex_format format_type) const
 	{ 
 		return ( Vertex_mask & vertex_format_data::mask(format_type) ) ? true : false; 
 	} 
 
-	void add_vertex_component(vertex_format_data::vertex_format format_type, void* src)
-	{
-		add_vertex_component(format_type, 0, src);
-	}
-
-	void add_vertex_component(vertex_format_data::vertex_format format_type, size_t stride, void* src) 
-	{
-		if ( resident_vertex_format(format_type) ) {
-			// we already have a vertex component of this format type
-			return;
-		}
-
-		Vertex_mask |= (1 << format_type);
-		Vertex_components.push_back(vertex_format_data(format_type, stride, src));
-	}
-
-	void add_vertex_component(vertex_format_data::vertex_format format_type, size_t stride, int offset) 
+	void add_vertex_component(vertex_format_data::vertex_format format_type, size_t stride, size_t offset)
 	{
 		if ( resident_vertex_format(format_type) ) {
 			// we already have a vertex component of this format type
@@ -694,6 +672,7 @@ typedef struct screen {
 	void (*gf_delete_buffer)(int handle);
 
 	void (*gf_update_buffer_data)(int handle, size_t size, void* data);
+	void (*gf_update_buffer_data_offset)(int handle, size_t offset, size_t size, void* data);
 	void (*gf_update_transform_buffer)(void* data, size_t size);
 	void (*gf_set_transform_buffer_offset)(size_t offset);
 
@@ -760,11 +739,9 @@ typedef struct screen {
 	void (*gf_render_model)(model_material* material_info, indexed_vertex_source *vert_source, vertex_buffer* bufferp, size_t texi);
 	void (*gf_render_shield_impact)(shield_material *material_info, primitive_type prim_type, vertex_layout *layout, int buffer_handle, int n_verts);
 	void (*gf_render_primitives)(material* material_info, primitive_type prim_type, vertex_layout* layout, int offset, int n_verts, int buffer_handle);
-	void (*gf_render_primitives_immediate)(material* material_info, primitive_type prim_type, vertex_layout* layout, int n_verts, void* data, int size);
 	void (*gf_render_primitives_particle)(particle_material* material_info, primitive_type prim_type, vertex_layout* layout, int offset, int n_verts, int buffer_handle);
 	void (*gf_render_primitives_distortion)(distortion_material* material_info, primitive_type prim_type, vertex_layout* layout, int offset, int n_verts, int buffer_handle);
 	void (*gf_render_primitives_2d)(material* material_info, primitive_type prim_type, vertex_layout* layout, int offset, int n_verts, int buffer_handle);
-	void (*gf_render_primitives_2d_immediate)(material* material_info, primitive_type prim_type, vertex_layout* layout, int n_verts, void* data, int size);
 	void (*gf_render_movie)(movie_material* material_info, primitive_type prim_type, vertex_layout* layout, int n_verts, int buffer);
 	void (*gf_render_primitives_batched)(batched_bitmap_material* material_info, primitive_type prim_type, vertex_layout* layout, int offset, int n_verts, int buffer_handle);
 
@@ -952,6 +929,7 @@ __inline int gr_create_index_buffer(bool static_buffer = false)
 
 #define gr_delete_buffer				GR_CALL(*gr_screen.gf_delete_buffer)
 #define gr_update_buffer_data			GR_CALL(*gr_screen.gf_update_buffer_data)
+#define gr_update_buffer_data_offset	GR_CALL(*gr_screen.gf_update_buffer_data_offset)
 #define gr_update_transform_buffer		GR_CALL(*gr_screen.gf_update_transform_buffer)
 #define gr_set_transform_buffer_offset	GR_CALL(*gr_screen.gf_set_transform_buffer_offset)
 
@@ -1016,11 +994,6 @@ __inline void gr_render_primitives(material* material_info, primitive_type prim_
 	(*gr_screen.gf_render_primitives)(material_info, prim_type, layout, offset, n_verts, buffer_handle);
 }
 
-__inline void gr_render_primitives_immediate(material* material_info, primitive_type prim_type, vertex_layout* layout, int n_verts, void* data, int size)
-{
-	(*gr_screen.gf_render_primitives_immediate)(material_info, prim_type, layout, n_verts, data, size);
-}
-
 __inline void gr_render_primitives_particle(particle_material* material_info, primitive_type prim_type, vertex_layout* layout, int offset, int n_verts, int buffer_handle = -1)
 {
 	(*gr_screen.gf_render_primitives_particle)(material_info, prim_type, layout, offset, n_verts, buffer_handle);
@@ -1039,11 +1012,6 @@ __inline void gr_render_primitives_distortion(distortion_material* material_info
 __inline void gr_render_primitives_2d(material* material_info, primitive_type prim_type, vertex_layout* layout, int offset, int n_verts, int buffer_handle = -1)
 {
 	(*gr_screen.gf_render_primitives_2d)(material_info, prim_type, layout, offset, n_verts, buffer_handle);
-}
-
-__inline void gr_render_primitives_2d_immediate(material* material_info, primitive_type prim_type, vertex_layout* layout, int n_verts, void* data, int size)
-{
-	(*gr_screen.gf_render_primitives_2d_immediate)(material_info, prim_type, layout, n_verts, data, size);
 }
 
 inline void gr_render_movie(movie_material* material_info, primitive_type prim_type, vertex_layout* layout, int n_verts, int buffer)

--- a/code/graphics/grstub.cpp
+++ b/code/graphics/grstub.cpp
@@ -153,7 +153,10 @@ void gr_stub_save_mouse_area(int x, int y, int w, int h)
 
 void gr_stub_update_buffer_data(int handle, size_t size, void* data)
 {
+}
 
+void gr_stub_update_buffer_data_offset(int handle, size_t offset, size_t size, void* data)
+{
 }
 
 void gr_stub_update_transform_buffer(void* data, size_t size)
@@ -397,17 +400,7 @@ void gr_stub_render_primitives(material* material_info, primitive_type prim_type
 
 }
 
-void gr_stub_render_primitives_immediate(material* material_info, primitive_type prim_type, vertex_layout* layout, int n_verts, void* data, int size)
-{
-
-}
-
 void gr_stub_render_primitives_2d(material* material_info, primitive_type prim_type, vertex_layout* layout, int offset, int n_verts, int buffer_handle)
-{
-
-}
-
-void gr_stub_render_primitives_2d_immediate(material* material_info, primitive_type prim_type, vertex_layout* layout, int n_verts, void* data, int size)
 {
 
 }
@@ -552,6 +545,7 @@ bool gr_stub_init()
 
 	gr_screen.gf_update_transform_buffer	= gr_stub_update_transform_buffer;
 	gr_screen.gf_update_buffer_data		= gr_stub_update_buffer_data;
+	gr_screen.gf_update_buffer_data_offset = gr_stub_update_buffer_data_offset;
 	gr_screen.gf_set_transform_buffer_offset	= gr_stub_set_transform_buffer_offset;
 
 	gr_screen.gf_start_instance_matrix			= gr_stub_start_instance_matrix;
@@ -610,9 +604,7 @@ bool gr_stub_init()
 
 	gr_screen.gf_render_model = gr_stub_render_model;
 	gr_screen.gf_render_primitives	= gr_stub_render_primitives;
-	gr_screen.gf_render_primitives_immediate = gr_stub_render_primitives_immediate;
 	gr_screen.gf_render_primitives_2d	= gr_stub_render_primitives_2d;
-	gr_screen.gf_render_primitives_2d_immediate = gr_stub_render_primitives_2d_immediate;
 	gr_screen.gf_render_primitives_particle	= gr_stub_render_primitives_particle;
 	gr_screen.gf_render_primitives_distortion = gr_stub_render_primitives_distortion;
 	gr_screen.gf_render_movie = gr_stub_render_movie;

--- a/code/graphics/opengl/gropengl.cpp
+++ b/code/graphics/opengl/gropengl.cpp
@@ -169,7 +169,6 @@ void gr_opengl_flip()
 	current_viewport->swapBuffers();
 
 	opengl_tcache_frame();
-	opengl_reset_immediate_buffer();
 
 #ifndef NDEBUG
 	int ic = opengl_check_for_errors();
@@ -1181,10 +1180,11 @@ void opengl_setup_function_pointers()
 	gr_screen.gf_set_fill_mode			= gr_opengl_set_fill_mode;
 	gr_screen.gf_set_texture_panning	= gr_opengl_set_texture_panning;
 
-	gr_screen.gf_create_vertex_buffer	= gr_opengl_create_vertex_buffer;
-	gr_screen.gf_create_index_buffer	= gr_opengl_create_index_buffer;
-	gr_screen.gf_delete_buffer		= gr_opengl_delete_buffer;
-	gr_screen.gf_update_buffer_data		= gr_opengl_update_buffer_data;
+	gr_screen.gf_create_vertex_buffer		= gr_opengl_create_vertex_buffer;
+	gr_screen.gf_create_index_buffer		= gr_opengl_create_index_buffer;
+	gr_screen.gf_delete_buffer				= gr_opengl_delete_buffer;
+	gr_screen.gf_update_buffer_data			= gr_opengl_update_buffer_data;
+	gr_screen.gf_update_buffer_data_offset	= gr_opengl_update_buffer_data_offset;
 
 	gr_screen.gf_update_transform_buffer	= gr_opengl_update_transform_buffer;
 	gr_screen.gf_set_transform_buffer_offset	= gr_opengl_set_transform_buffer_offset;
@@ -1244,9 +1244,7 @@ void opengl_setup_function_pointers()
 
 	gr_screen.gf_render_model = gr_opengl_render_model;
 	gr_screen.gf_render_primitives= gr_opengl_render_primitives;
-	gr_screen.gf_render_primitives_immediate = gr_opengl_render_primitives_immediate;
 	gr_screen.gf_render_primitives_2d = gr_opengl_render_primitives_2d;
-	gr_screen.gf_render_primitives_2d_immediate = gr_opengl_render_primitives_2d_immediate;
 	gr_screen.gf_render_primitives_particle	= gr_opengl_render_primitives_particle;
 	gr_screen.gf_render_primitives_batched	= gr_opengl_render_primitives_batched;
 	gr_screen.gf_render_primitives_distortion = gr_opengl_render_primitives_distortion;

--- a/code/graphics/opengl/gropengldraw.h
+++ b/code/graphics/opengl/gropengldraw.h
@@ -57,9 +57,7 @@ void opengl_render_primitives(primitive_type prim_type, vertex_layout* layout, i
 void opengl_render_primitives_immediate(primitive_type prim_type, vertex_layout* layout, int n_verts, void* data, int size);
 
 void gr_opengl_render_primitives(material* material_info, primitive_type prim_type, vertex_layout* layout, int offset, int n_verts, int buffer_handle);
-void gr_opengl_render_primitives_immediate(material* material_info, primitive_type prim_type, vertex_layout* layout, int n_verts, void* data, int size);
 void gr_opengl_render_primitives_2d(material* material_info, primitive_type prim_type, vertex_layout* layout, int offset, int n_verts, int buffer_handle);
-void gr_opengl_render_primitives_2d_immediate(material* material_info, primitive_type prim_type, vertex_layout* layout, int n_verts, void* data, int size);
 void gr_opengl_render_primitives_particle(particle_material* material_info, primitive_type prim_type, vertex_layout* layout, int offset, int n_verts, int buffer_handle);
 void gr_opengl_render_primitives_batched(batched_bitmap_material* material_info, primitive_type prim_type, vertex_layout* layout, int offset, int n_verts, int buffer_handle);
 void gr_opengl_render_primitives_distortion(distortion_material* material_info, primitive_type prim_type, vertex_layout* layout, int offset, int n_verts, int buffer_handle);
@@ -67,91 +65,8 @@ void gr_opengl_render_movie(movie_material* material_info, primitive_type prim_t
 
 void opengl_bind_vertex_layout(vertex_layout &layout, uint base_vertex = 0, ubyte* base_ptr = NULL);
 
-inline void opengl_draw_textured_quad_instanced(
-	GLfloat x1, GLfloat y1, GLfloat u1, GLfloat v1,
-	GLfloat x2, GLfloat y2, GLfloat u2, GLfloat v2, 
-	int count )
-{
-	GLfloat glVertices[4][4] = {
-		{ x1, y1, u1, v1 },
-		{ x1, y2, u1, v2 },
-		{ x2, y1, u2, v1 },
-		{ x2, y2, u2, v2 }
-	};
-
-	GL_state.Array.BindArrayBuffer(0);
-
-	vertex_layout vert_def;
-
-	vert_def.add_vertex_component(vertex_format_data::POSITION2, sizeof(glVertices[0]), glVertices);
-	vert_def.add_vertex_component(vertex_format_data::TEX_COORD2, sizeof(glVertices[0]), &(glVertices[0][2]));
-
-	opengl_bind_vertex_layout(vert_def);
-
-	//glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
-	glDrawArraysInstanced(GL_TRIANGLE_STRIP, 0, 4, count);
-}
-
-inline void opengl_draw_textured_quad(
-	GLfloat x1, GLfloat y1, GLfloat u1, GLfloat v1,
-	GLfloat x2, GLfloat y2, GLfloat u2, GLfloat v2 )
-{
-	GR_DEBUG_SCOPE("Draw textured quad");
-
-	GLfloat glVertices[4][4] = {
-		{ x1, y1, u1, v1 },
-		{ x1, y2, u1, v2 },
-		{ x2, y1, u2, v1 },
-		{ x2, y2, u2, v2 }
-	};
-
-	vertex_layout vert_def;
-
-	vert_def.add_vertex_component(vertex_format_data::POSITION2, sizeof(GLfloat) * 4, 0);
-	vert_def.add_vertex_component(vertex_format_data::TEX_COORD2, sizeof(GLfloat) * 4, sizeof(GLfloat) * 2);
-
-	opengl_render_primitives_immediate(PRIM_TYPE_TRISTRIP, &vert_def, 4, glVertices, sizeof(GLfloat) * 4 * 4);
-}
-
-inline void opengl_draw_coloured_quad(
-	GLint x1, GLint y1,
-	GLint x2, GLint y2)
-{
-	GLint glVertices[8] = {
-		x1, y1,
-		x1, y2,
-		x2, y1,
-		x2, y2
-	};
-
-	vertex_layout vert_def;
-
-	vert_def.add_vertex_component(vertex_format_data::SCREEN_POS, 0, 0);
-
-	opengl_bind_vertex_layout(vert_def);
-
-	opengl_render_primitives_immediate(PRIM_TYPE_TRISTRIP, &vert_def, 4, glVertices, sizeof(GLint) * 8);
-}
-
-inline void opengl_draw_coloured_quad(
-	GLfloat x1, GLfloat y1,
-	GLfloat x2, GLfloat y2 )
-{
-	GLfloat glVertices[8] = {
-		x1, y1,
-		x1, y2,
-		x2, y1,
-		x2, y2
-	};
-
-	vertex_layout vert_def;
-
-	vert_def.add_vertex_component(vertex_format_data::POSITION2, 0, 0);
-
-	opengl_bind_vertex_layout(vert_def);
-
-	opengl_render_primitives_immediate(PRIM_TYPE_TRISTRIP, &vert_def, 4, glVertices, sizeof(GLfloat) * 8);
-}
+void opengl_draw_textured_quad(GLfloat x1, GLfloat y1, GLfloat u1, GLfloat v1,
+							   GLfloat x2, GLfloat y2, GLfloat u2, GLfloat v2 );
 
 inline GLenum opengl_primitive_type(primitive_type prim_type);
 

--- a/code/graphics/opengl/gropengltnl.h
+++ b/code/graphics/opengl/gropengltnl.h
@@ -39,8 +39,6 @@ extern matrix4 GL_model_view_matrix;
 extern matrix4 GL_projection_matrix;
 extern matrix4 GL_last_projection_matrix;
 
-extern int GL_immediate_buffer_handle;
-
 void gr_opengl_start_instance_matrix(const vec3d *offset, const matrix *rotation);
 void gr_opengl_start_instance_angles(const vec3d *pos, const angles *rotation);
 void gr_opengl_end_instance_matrix();
@@ -65,13 +63,11 @@ int gr_opengl_create_index_buffer(bool static_buffer);
 
 void opengl_bind_buffer_object(int handle);
 void gr_opengl_update_buffer_data(int handle, size_t size, void* data);
+void gr_opengl_update_buffer_data_offset(int handle, size_t offset, size_t size, void* data);
 void gr_opengl_delete_buffer(int handle);
 
 void gr_opengl_update_transform_buffer(void* data, size_t size);
 void gr_opengl_set_transform_buffer_offset(size_t offset);
-
-uint opengl_add_to_immediate_buffer(uint size, void *data);
-void opengl_reset_immediate_buffer();
 
 void opengl_tnl_init();
 void opengl_tnl_shutdown();

--- a/code/graphics/render.cpp
+++ b/code/graphics/render.cpp
@@ -1054,3 +1054,91 @@ void gr_shade(int x, int y, int w, int h, int resize_mode) {
 
 	endDrawing(path);
 }
+
+int gr_immediate_buffer_handle = -1;
+static size_t immediate_buffer_offset = 0;
+static size_t immediate_buffer_size = 0;
+static const int IMMEDIATE_BUFFER_RESIZE_BLOCK_SIZE = 2048;
+
+size_t gr_add_to_immediate_buffer(size_t size, void* data) {
+	GR_DEBUG_SCOPE("Add data to immediate buffer");
+
+	if ( gr_immediate_buffer_handle < 0 ) {
+		gr_immediate_buffer_handle = gr_create_vertex_buffer(false);
+	}
+
+	Assert(size > 0 && data != NULL);
+
+	if ( immediate_buffer_offset + size > immediate_buffer_size ) {
+		// incoming data won't fit the immediate buffer. time to reallocate.
+		immediate_buffer_offset = 0;
+		immediate_buffer_size += MAX(IMMEDIATE_BUFFER_RESIZE_BLOCK_SIZE, size);
+
+		gr_update_buffer_data(gr_immediate_buffer_handle, immediate_buffer_size, NULL);
+	}
+
+	// only update a section of the immediate vertex buffer
+	gr_update_buffer_data_offset(gr_immediate_buffer_handle, immediate_buffer_offset, size, data);
+
+	auto old_offset = immediate_buffer_offset;
+
+	immediate_buffer_offset += size;
+
+	return old_offset;
+}
+void gr_reset_immediate_buffer() {
+	if ( gr_immediate_buffer_handle < 0 ) {
+		// we haven't used the immediate buffer yet
+		return;
+	}
+
+	// orphan the immediate buffer so we can start fresh in a new frame
+	gr_update_buffer_data(gr_immediate_buffer_handle, immediate_buffer_size, NULL);
+
+	// bring our offset to the beginning of the immediate buffer
+	immediate_buffer_offset = 0;
+}
+
+/**
+ * @brief Adjusts the offset in a vertex layout to adjust for the immediate buffer offset
+ * @param layout
+ * @param immediate_offset
+ * @return
+ */
+static vertex_layout adjust_immediate_vertex_layout(const vertex_layout* layout, size_t immediate_offset) {
+	vertex_layout adjusted;
+
+	for (size_t i = 0; i < layout->get_num_vertex_components(); ++i) {
+		auto component = layout->get_vertex_component(i);
+
+		adjusted.add_vertex_component(component->format_type, component->stride, component->offset + immediate_offset);
+	}
+
+	return adjusted;
+}
+
+void gr_render_primitives_immediate(material* material_info,
+									primitive_type prim_type,
+									vertex_layout* layout,
+									int n_verts,
+									void* data,
+									int size) {
+	auto offset = gr_add_to_immediate_buffer(size, data);
+
+	vertex_layout immediate_layout = adjust_immediate_vertex_layout(layout, offset);
+
+	gr_render_primitives(material_info, prim_type, &immediate_layout, 0, n_verts, gr_immediate_buffer_handle);
+}
+
+void gr_render_primitives_2d_immediate(material* material_info,
+									   primitive_type prim_type,
+									   vertex_layout* layout,
+									   int n_verts,
+									   void* data,
+									   int size) {
+	auto offset = gr_add_to_immediate_buffer(size, data);
+
+	vertex_layout immediate_layout = adjust_immediate_vertex_layout(layout, offset);
+
+	gr_render_primitives_2d(material_info, prim_type, &immediate_layout, 0, n_verts, gr_immediate_buffer_handle);
+}

--- a/code/graphics/render.cpp
+++ b/code/graphics/render.cpp
@@ -1122,7 +1122,7 @@ void gr_render_primitives_immediate(material* material_info,
 									vertex_layout* layout,
 									int n_verts,
 									void* data,
-									int size) {
+									size_t size) {
 	auto offset = gr_add_to_immediate_buffer(size, data);
 
 	vertex_layout immediate_layout = adjust_immediate_vertex_layout(layout, offset);
@@ -1135,7 +1135,7 @@ void gr_render_primitives_2d_immediate(material* material_info,
 									   vertex_layout* layout,
 									   int n_verts,
 									   void* data,
-									   int size) {
+									   size_t size) {
 	auto offset = gr_add_to_immediate_buffer(size, data);
 
 	vertex_layout immediate_layout = adjust_immediate_vertex_layout(layout, offset);

--- a/code/graphics/render.h
+++ b/code/graphics/render.h
@@ -165,3 +165,13 @@ void gr_arc(int xc, int yc, float r, float angle_start, float angle_end, bool fi
  * @param resize_mode The mode for translating the screen positions
  */
 void gr_curve(int x, int y, int r, int direction, int resize_mode);
+
+
+extern int gr_immediate_buffer_handle;
+
+size_t gr_add_to_immediate_buffer(size_t size, void *data);
+
+void gr_reset_immediate_buffer();
+
+void gr_render_primitives_immediate(material* material_info, primitive_type prim_type, vertex_layout* layout, int n_verts, void* data, int size);
+void gr_render_primitives_2d_immediate(material* material_info, primitive_type prim_type, vertex_layout* layout, int n_verts, void* data, int size);

--- a/code/graphics/render.h
+++ b/code/graphics/render.h
@@ -166,12 +166,45 @@ void gr_arc(int xc, int yc, float r, float angle_start, float angle_end, bool fi
  */
 void gr_curve(int x, int y, int r, int direction, int resize_mode);
 
-
+/**
+ * @brief The buffer object holding the data for immediate draws
+ */
 extern int gr_immediate_buffer_handle;
 
+/**
+ * @brief Adds data to the immediate buffer for use by draw operations
+ *
+ * @warning The data is only available in the buffer for one frame.
+ *
+ * @param size The size of the data buffer
+ * @param data The pointer to the data
+ * @return The offset into the immediate buffer where this data starts at
+ */
 size_t gr_add_to_immediate_buffer(size_t size, void *data);
 
+/**
+ * @brief Resets the immediate buffer for reuse
+ */
 void gr_reset_immediate_buffer();
 
-void gr_render_primitives_immediate(material* material_info, primitive_type prim_type, vertex_layout* layout, int n_verts, void* data, int size);
-void gr_render_primitives_2d_immediate(material* material_info, primitive_type prim_type, vertex_layout* layout, int n_verts, void* data, int size);
+/**
+ * @brief Renders some vertex data from an immediate memory buffer
+ * @param material_info The material information for rendering the data
+ * @param prim_type The primitive type of the data
+ * @param layout The vertex layout of the data
+ * @param n_verts How many vertices are in the data
+ * @param data The pointer to the data to render
+ * @param size The size of the data
+ */
+void gr_render_primitives_immediate(material* material_info, primitive_type prim_type, vertex_layout* layout, int n_verts, void* data, size_t size);
+
+/**
+ * @brief Renders some vertex data from an immediate memory buffer with a 2D projection matrix
+ * @param material_info The material information for rendering the data
+ * @param prim_type The primitive type of the data
+ * @param layout The vertex layout of the data
+ * @param n_verts How many vertices are in the data
+ * @param data The pointer to the data to render
+ * @param size The size of the data
+ */
+void gr_render_primitives_2d_immediate(material* material_info, primitive_type prim_type, vertex_layout* layout, int n_verts, void* data, size_t size);


### PR DESCRIPTION
Since this code is the same for all possible graphics backends it can be
moved outside the OpenGL implementation to simplify that code.