### PR TITLE
add is-docked sexp

### DIFF
--- a/code/parse/sexp.h
+++ b/code/parse/sexp.h
@@ -387,6 +387,7 @@ class waypoint_list;
 #define OP_TURRET_GET_PRIMARY_AMMO			(0x004f | OP_CATEGORY_STATUS | OP_NONCAMPAIGN_FLAG)	// DahBlount, part of the turret ammo code
 
 #define OP_TURRET_GET_SECONDARY_AMMO		(0x0050 | OP_CATEGORY_STATUS | OP_NONCAMPAIGN_FLAG)	// DahBlount, part of the turret ammo code
+#define OP_IS_DOCKED						(0x0051 | OP_CATEGORY_STATUS | OP_NONCAMPAIGN_FLAG)	// Goober5000
 
 // conditional sexpressions
 #define OP_WHEN								(0x0000 | OP_CATEGORY_CONDITIONAL)


### PR DESCRIPTION
Surprised nobody else has added this yet.  From the help text for this sexp:

> Checks whether the specified ships are currently docked.  This sexp is different from has-docked-delay, which will return true if the ships have docked at any point in the past.  The has-docked-delay sexp checks the mission log, whereas the is-docked sexp examines the actual dockpoints.