### PR TITLE
several fixes to time-docked and time-undocked

### DIFF
--- a/code/mission/missionlog.cpp
+++ b/code/mission/missionlog.cpp
@@ -431,6 +431,7 @@ int mission_log_get_time_indexed( int type, const char *pname, const char *sname
 {
 	int i, found;
 	log_entry *entry;
+	Assertion(count > 0, "The count parameter is %d; it should be greater than 0!", count);
 
 	entry = &log_entries[0];
 

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -5667,30 +5667,19 @@ int sexp_time_wing_destroyed(int n)
 	return f2i(time);
 }
 
-int sexp_time_docked(int n)
+int sexp_time_docked_or_undocked(int n, bool docked)
 {
 	fix time;
 	char *docker = CTEXT(n);
 	char *dockee = CTEXT(CDR(n));
 	int count = eval_num(CDR(CDR(n)));
 
-	Assert ( count > 0 );
-	if ( !mission_log_get_time_indexed(LOG_SHIP_DOCKED, docker, dockee, count, &time) ){
-		return SEXP_NAN;
+	if (count <= 0) {
+		Warning(LOCATION, "Time-%sdocked count should be at least 1!  This has been automatically adjusted.", docked ? "" : "un");
+		count = 1;
 	}
 
-	return f2i(time);
-}
-
-int sexp_time_undocked(int n)
-{
-	fix time;
-	char *docker = CTEXT(n);
-	char *dockee = CTEXT(CDR(n));
-	int count = eval_num(CDR(CDR(n)));
-
-	Assert ( count > 0 );
-	if ( !mission_log_get_time_indexed(LOG_SHIP_UNDOCKED, docker, dockee, count, &time) ){
+	if ( !mission_log_get_time_indexed(docked ? LOG_SHIP_DOCKED : LOG_SHIP_UNDOCKED, docker, dockee, count, &time) ){
 		return SEXP_NAN;
 	}
 
@@ -23145,11 +23134,8 @@ int eval_sexp(int cur_node, int referenced_node)
 				break;
 
 			case OP_TIME_DOCKED:
-				sexp_val = sexp_time_docked(node);
-				break;
-
 			case OP_TIME_UNDOCKED:
-				sexp_val = sexp_time_undocked(node);
+				sexp_val = sexp_time_docked_or_undocked(node, op_num == OP_TIME_DOCKED);
 				break;
 
 			case OP_AFTERBURNER_LEFT:

--- a/fred2/sexp_tree.cpp
+++ b/fred2/sexp_tree.cpp
@@ -2288,7 +2288,7 @@ int sexp_tree::get_default_value(sexp_list_item *item, char *text_buf, int op, i
 			{
 				item->set_data("89", (SEXPT_NUMBER | SEXPT_VALID));
 			}
-			else if (((Operators[op].value == OP_HAS_DOCKED_DELAY) || (Operators[op].value == OP_HAS_UNDOCKED_DELAY)) && (i == 2))
+			else if (((Operators[op].value == OP_HAS_DOCKED_DELAY) || (Operators[op].value == OP_HAS_UNDOCKED_DELAY) || (Operators[op].value == OP_TIME_DOCKED) || (Operators[op].value == OP_TIME_UNDOCKED)) && (i == 2))
 			{
 				item->set_data("1", (SEXPT_NUMBER | SEXPT_VALID));
 			}


### PR DESCRIPTION
The `time-docked` and `time-undocked` sexps will cause FSO to freeze unless you know what you're doing, so this PR fixes some gotcha areas.  Inspired by The E's rant on Discord which, while not correct about `OPF_POSITIVE`, did indicate some areas for improvement.

1) Set the default "number of times docked" argument to 1 when the sexp is created in FRED, same as with the `has-[un]docked-delay` sexps
2) Catch any <= 0 counts when the sexp is called in FRED and set them to 1.  (This was done for other sexps which used `mission_log_get_time_indexed`, but was not done for `time-[un]docked` for some reason.)
3) Add an Assertion to `mission_log_get_time_indexed` as a last resort to guard against invalid counts.

Also, I merged `sexp_time_docked` and `sexp_time_undocked` since the functions were identical except for one value on one line.