### PR TITLE
add string-concatenate-block sexp

### DIFF
--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -20291,7 +20291,7 @@ void sexp_string_concatenate(int n)
 	// check length
 	if (strlen(new_text) >= TOKEN_LENGTH)
 	{
-		Warning(LOCATION, "Concatenated string '%s' has %d characters, but the maximum is %d.  The string will be truncated.", new_text, strlen(new_text), TOKEN_LENGTH - 1);
+		Warning(LOCATION, "Concatenated string '%s' has " SIZE_T_ARG " characters, but the maximum is " SIZE_T_ARG ".  The string will be truncated.", new_text, strlen(new_text), TOKEN_LENGTH - 1);
 		new_text[TOKEN_LENGTH] = 0;
 	}
 
@@ -20334,7 +20334,7 @@ void sexp_string_concatenate_block(int n)
 	// check length
 	if (new_text.length() >= TOKEN_LENGTH)
 	{
-		Warning(LOCATION, "Concatenated string '%s' has %d characters, but the maximum is %d.  The string will be truncated.", new_text.c_str(), new_text.length(), TOKEN_LENGTH - 1);
+		Warning(LOCATION, "Concatenated string '%s' has " SIZE_T_ARG " characters, but the maximum is " SIZE_T_ARG ".  The string will be truncated.", new_text.c_str(), new_text.length(), TOKEN_LENGTH - 1);
 		new_text.resize(TOKEN_LENGTH - 1);
 	}
 

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -678,6 +678,7 @@ sexp_oper Operators[] = {
 	{ "copy-variable-between-indexes",	OP_COPY_VARIABLE_BETWEEN_INDEXES,		2,	2,			SEXP_ACTION_OPERATOR,	},	// Goober5000
 	{ "int-to-string",					OP_INT_TO_STRING,						2,	2,			SEXP_ACTION_OPERATOR,	},	// Goober5000
 	{ "string-concatenate",				OP_STRING_CONCATENATE,					3,	3,			SEXP_ACTION_OPERATOR,	},	// Goober5000
+	{ "string-concatenate-block",		OP_STRING_CONCATENATE_BLOCK,			3,	INT_MAX,	SEXP_ACTION_OPERATOR,	},	// Goober5000
 	{ "string-get-substring",			OP_STRING_GET_SUBSTRING,				4,	4,			SEXP_ACTION_OPERATOR,	},	// Goober5000
 	{ "string-set-substring",			OP_STRING_SET_SUBSTRING,				5,	5,			SEXP_ACTION_OPERATOR,	},	// Goober5000  
 
@@ -3092,6 +3093,7 @@ int check_sexp_syntax(int node, int return_type, int recursive, int *bad_node, i
 
 					// some demand a string variable
 					case OP_STRING_CONCATENATE:
+					case OP_STRING_CONCATENATE_BLOCK:
 					case OP_INT_TO_STRING:
 					case OP_STRING_GET_SUBSTRING:
 					case OP_STRING_SET_SUBSTRING:
@@ -20298,6 +20300,49 @@ void sexp_string_concatenate(int n)
 }
 
 // Goober5000
+void sexp_string_concatenate_block(int n)
+{
+	int sexp_variable_index;
+	SCP_string new_text;
+
+	// Only do single player or multi host
+	if (MULTIPLAYER_CLIENT)
+		return;
+
+	// get sexp_variable index
+	Assert(Sexp_nodes[n].first == -1);
+	sexp_variable_index = atoi(Sexp_nodes[n].text);
+	n = CDR(n);
+
+	// verify variable set
+	Assert(Sexp_variables[sexp_variable_index].type & SEXP_VARIABLE_SET);
+
+	// check variable type
+	if (!(Sexp_variables[sexp_variable_index].type & SEXP_VARIABLE_STRING))
+	{
+		Warning(LOCATION, "Cannot assign a string to a non-string variable!");
+		return;
+	}
+
+	// concatenate strings
+	while (n >= 0)
+	{
+		new_text.append(CTEXT(n));
+		n = CDR(n);
+	}
+
+	// check length
+	if (new_text.length() >= TOKEN_LENGTH)
+	{
+		Warning(LOCATION, "Concatenated string is too long and will be truncated.");
+		new_text.resize(TOKEN_LENGTH - 1);
+	}
+
+	// assign to variable
+	sexp_modify_variable(new_text.c_str(), sexp_variable_index);
+}
+
+// Goober5000
 int sexp_string_get_length(int node)
 {
 	return (int)strlen(CTEXT(node));
@@ -24162,6 +24207,12 @@ int eval_sexp(int cur_node, int referenced_node)
 				break;
 
 			// Goober5000
+			case OP_STRING_CONCATENATE_BLOCK:
+				sexp_string_concatenate_block(node);
+				sexp_val = SEXP_TRUE;
+				break;
+
+				// Goober5000
 			case OP_STRING_GET_SUBSTRING:
 				sexp_string_get_substring(node);
 				sexp_val = SEXP_TRUE;
@@ -25988,6 +26039,7 @@ int query_operator_return_type(int op)
 		case OP_HUD_GAUGE_SET_ACTIVE:
 		case OP_HUD_ACTIVATE_GAUGE_TYPE:
 		case OP_STRING_CONCATENATE:
+		case OP_STRING_CONCATENATE_BLOCK:
 		case OP_INT_TO_STRING:
 		case OP_DISABLE_ETS:
 		case OP_ENABLE_ETS:
@@ -26152,6 +26204,13 @@ int query_operator_argument_type(int op, int argnum)
 				return OPF_STRING;
 			} else if (argnum == 2) {
 				return OPF_VARIABLE_NAME;
+			}
+
+		case OP_STRING_CONCATENATE_BLOCK:
+			if (argnum == 0) {
+				return OPF_VARIABLE_NAME;
+			} else {
+				return OPF_STRING;
 			}
 
 		case OP_INT_TO_STRING:
@@ -29867,6 +29926,7 @@ int get_subcategory(int sexp_id)
 		case OP_COPY_VARIABLE_BETWEEN_INDEXES:
 		case OP_INT_TO_STRING:
 		case OP_STRING_CONCATENATE:
+		case OP_STRING_CONCATENATE_BLOCK:
 		case OP_STRING_GET_SUBSTRING:
 		case OP_STRING_SET_SUBSTRING:
 			return CHANGE_SUBCATEGORY_VARIABLES;
@@ -31636,6 +31696,14 @@ sexp_help_struct Sexp_help[] = {
 		"\t1: First string\r\n"
 		"\t2: Second string\r\n"
 		"\t3: String variable to hold the result\r\n" },
+
+	// Goober5000
+	{ OP_STRING_CONCATENATE_BLOCK, "string-concatenate-block\r\n"
+		"\tConcatenates two or more strings, putting the result into a string variable.  If the length of the string will "
+		"exceed the sexp variable token limit (currently 32), it will be truncated.\r\n\r\n"
+		"Takes 3 or more arguments...\r\n"
+		"\t1: String variable to hold the result\r\n"
+		"\tRest: Strings to concatenate.  At least two of these are required; the rest are optional.\r\n" },
 
 	// Goober5000
 	{ OP_STRING_GET_SUBSTRING, "string-get-substring\r\n"

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -20291,7 +20291,7 @@ void sexp_string_concatenate(int n)
 	// check length
 	if (strlen(new_text) >= TOKEN_LENGTH)
 	{
-		Warning(LOCATION, "Concatenated string '%s' is too long and will be truncated.", new_text);
+		Warning(LOCATION, "Concatenated string '%s' has %d characters, but the maximum is %d.  The string will be truncated.", new_text, strlen(new_text), TOKEN_LENGTH - 1);
 		new_text[TOKEN_LENGTH] = 0;
 	}
 
@@ -20334,7 +20334,7 @@ void sexp_string_concatenate_block(int n)
 	// check length
 	if (new_text.length() >= TOKEN_LENGTH)
 	{
-		Warning(LOCATION, "Concatenated string '%s' is too long and will be truncated.", new_text.c_str());
+		Warning(LOCATION, "Concatenated string '%s' has %d characters, but the maximum is %d.  The string will be truncated.", new_text.c_str(), new_text.length(), TOKEN_LENGTH - 1);
 		new_text.resize(TOKEN_LENGTH - 1);
 	}
 

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -20291,7 +20291,7 @@ void sexp_string_concatenate(int n)
 	// check length
 	if (strlen(new_text) >= TOKEN_LENGTH)
 	{
-		Warning(LOCATION, "Concatenated string is too long and will be truncated.");
+		Warning(LOCATION, "Concatenated string '%s' is too long and will be truncated.", new_text);
 		new_text[TOKEN_LENGTH] = 0;
 	}
 
@@ -20334,7 +20334,7 @@ void sexp_string_concatenate_block(int n)
 	// check length
 	if (new_text.length() >= TOKEN_LENGTH)
 	{
-		Warning(LOCATION, "Concatenated string is too long and will be truncated.");
+		Warning(LOCATION, "Concatenated string '%s' is too long and will be truncated.", new_text.c_str());
 		new_text.resize(TOKEN_LENGTH - 1);
 	}
 

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -20291,7 +20291,7 @@ void sexp_string_concatenate(int n)
 	// check length
 	if (strlen(new_text) >= TOKEN_LENGTH)
 	{
-		Warning(LOCATION, "Concatenated string '%s' has " SIZE_T_ARG " characters, but the maximum is " SIZE_T_ARG ".  The string will be truncated.", new_text, strlen(new_text), TOKEN_LENGTH - 1);
+		Warning(LOCATION, "Concatenated string '%s' has " SIZE_T_ARG " characters, but the maximum is %d.  The string will be truncated.", new_text, strlen(new_text), TOKEN_LENGTH - 1);
 		new_text[TOKEN_LENGTH] = 0;
 	}
 
@@ -20334,7 +20334,7 @@ void sexp_string_concatenate_block(int n)
 	// check length
 	if (new_text.length() >= TOKEN_LENGTH)
 	{
-		Warning(LOCATION, "Concatenated string '%s' has " SIZE_T_ARG " characters, but the maximum is " SIZE_T_ARG ".  The string will be truncated.", new_text.c_str(), new_text.length(), TOKEN_LENGTH - 1);
+		Warning(LOCATION, "Concatenated string '%s' has " SIZE_T_ARG " characters, but the maximum is %d.  The string will be truncated.", new_text.c_str(), new_text.length(), TOKEN_LENGTH - 1);
 		new_text.resize(TOKEN_LENGTH - 1);
 	}
 

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -31689,7 +31689,7 @@ sexp_help_struct Sexp_help[] = {
 		"\t2:\tString variable to contain the result\r\n" },
 
 	// Goober5000
-	{ OP_STRING_CONCATENATE, "string-concatenate\r\n"
+	{ OP_STRING_CONCATENATE, "string-concatenate (deprecated in favor of string-concatenate-block)\r\n"
 		"\tConcatenates two strings, putting the result into a string variable.  If the length of the string will "
 		"exceed the sexp variable token limit (currently 32), it will be truncated.\r\n\r\n"
 		"Takes 3 arguments...\r\n"

--- a/code/parse/sexp.h
+++ b/code/parse/sexp.h
@@ -733,6 +733,7 @@ class waypoint_list;
 #define OP_TURRET_SET_PRIMARY_AMMO			(0x002c | OP_CATEGORY_CHANGE2 | OP_NONCAMPAIGN_FLAG)	// DahBlount, part of the turret ammo changes
 #define OP_TURRET_SET_SECONDARY_AMMO		(0x002d | OP_CATEGORY_CHANGE2 | OP_NONCAMPAIGN_FLAG)	// DahBlount, part of the turret ammo changes
 #define OP_JETTISON_CARGO_NEW				(0x002e | OP_CATEGORY_CHANGE2 | OP_NONCAMPAIGN_FLAG)	// Goober5000
+#define OP_STRING_CONCATENATE_BLOCK			(0x002f | OP_CATEGORY_CHANGE2 | OP_NONCAMPAIGN_FLAG)	// Goober5000
 
 // defined for AI goals
 #define OP_AI_CHASE							(0x0000 | OP_CATEGORY_AI | OP_NONCAMPAIGN_FLAG)

--- a/fred2/sexp_tree.cpp
+++ b/fred2/sexp_tree.cpp
@@ -841,6 +841,7 @@ void sexp_tree::right_clicked(int mode)
 							case OP_HUD_GAUGE_SET_ACTIVE:
 							case OP_HUD_ACTIVATE_GAUGE_TYPE:
 							case OP_JETTISON_CARGO_DELAY:
+							case OP_STRING_CONCATENATE:
 								j = Num_op_menus;	// don't allow these operators to be visible
 								break;
 						}
@@ -884,6 +885,7 @@ void sexp_tree::right_clicked(int mode)
 							case OP_HUD_GAUGE_SET_ACTIVE:
 							case OP_HUD_ACTIVATE_GAUGE_TYPE:
 							case OP_JETTISON_CARGO_DELAY:
+							case OP_STRING_CONCATENATE:
 								j = Num_submenus;	// don't allow these operators to be visible
 								break;
 						}


### PR DESCRIPTION
Add `string-concatenate-block` and deprecate `string-concatenate`.  The new sexp is a better design since the destination variable appears first in the argument list and the sexp allows an unlimited number of concatenations (subject to length limits).  The old sexp was cumbersome for doing more than one concatenation at a time.