### PR TITLE
make "same emp time for capships" actually work

### DIFF
--- a/code/weapon/emp.cpp
+++ b/code/weapon/emp.cpp
@@ -167,7 +167,7 @@ void emp_apply(vec3d *pos, float inner_radius, float outer_radius, float emp_int
 
 		// if the ship is a cruiser or cap ship, only apply the EMP effect to turrets
 		if(Ship_info[Ships[target->instance].ship_info_index].is_big_or_huge()) {
-			float capship_emp_time = use_emp_time_for_capship_turrets ? emp_time : MAX_TURRET_DISRUPT_TIME;
+			float capship_emp_time = use_emp_time_for_capship_turrets ? (emp_time * 1000.0f) : MAX_TURRET_DISRUPT_TIME;
 			
 			moveup = &Ships[target->instance].subsys_list;
 			if(moveup->next != NULL){


### PR DESCRIPTION
Back when I added the "same emp time for capships" flag in SVN r9540, I neglected to multiply the EMP time by 1000, as the EMP disruption time for fighters is specified in seconds but the time for capships is specified in milliseconds.  So, using this flag would cause capships to suffer EMP disruption for almost no time at all.

This PR fixes that, and also extends the explosion-effect sexp to specify this parameter.  And I also cleaned up the fireball section by calling eval_num(n) just once instead of several times.