### PR TITLE
fix Assertion in sexp error reporting

### DIFF
--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -3780,7 +3780,7 @@ void stuff_sexp_text_string(SCP_string &dest, int node, int mode)
 	if (Sexp_nodes[node].type & SEXP_FLAG_VARIABLE) {
 
 		int sexp_variables_index = get_index_sexp_variable_name(Sexp_nodes[node].text);
-		// during error-reporting mode, sexp variables have already been transcoded to their indexes
+		// during the last pass through error-reporting mode, sexp variables have already been transcoded to their indexes
 		if (mode == SEXP_ERROR_CHECK_MODE && sexp_variables_index < 0) {
 			if (can_construe_as_integer(Sexp_nodes[node].text)) {
 				sexp_variables_index = atoi(Sexp_nodes[node].text);

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -3780,6 +3780,12 @@ void stuff_sexp_text_string(SCP_string &dest, int node, int mode)
 	if (Sexp_nodes[node].type & SEXP_FLAG_VARIABLE) {
 
 		int sexp_variables_index = get_index_sexp_variable_name(Sexp_nodes[node].text);
+		// during error-reporting mode, sexp variables have already been transcoded to their indexes
+		if (sexp_variables_index < 0) {
+			if (can_construe_as_integer(Sexp_nodes[node].text)) {
+				sexp_variables_index = atoi(Sexp_nodes[node].text);
+			}
+		}
 		Assertion(sexp_variables_index != -1, "Couldn't find variable: %s\n", Sexp_nodes[node].text);
 		Assert( (Sexp_variables[sexp_variables_index].type & SEXP_VARIABLE_NUMBER) || (Sexp_variables[sexp_variables_index].type & SEXP_VARIABLE_STRING) );
 

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -3781,7 +3781,7 @@ void stuff_sexp_text_string(SCP_string &dest, int node, int mode)
 
 		int sexp_variables_index = get_index_sexp_variable_name(Sexp_nodes[node].text);
 		// during error-reporting mode, sexp variables have already been transcoded to their indexes
-		if (sexp_variables_index < 0) {
+		if (mode == SEXP_ERROR_CHECK_MODE && sexp_variables_index < 0) {
 			if (can_construe_as_integer(Sexp_nodes[node].text)) {
 				sexp_variables_index = atoi(Sexp_nodes[node].text);
 			}


### PR DESCRIPTION
There is a bug where, when displaying an error message with a sexp node that contains a variable, the code will trigger an Assertion in the process of printing the error message.  This is because it tries to transcode the sexp variable from name to index, when that has already been done further up the pipeline.  This fixes that by adding a quick test to see if the expected variable name is an integer.