### PR TITLE
fix negative coordinates in play-sound-from-x

### DIFF
--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -26907,13 +26907,13 @@ int query_operator_argument_type(int op, int argnum)
 			if (argnum == 3)
 				return OPF_GAME_SND;
 			else
-				return OPF_POSITIVE;
+				return OPF_NUMBER;
 
 		case OP_PLAY_SOUND_FROM_FILE:
 			if (argnum==0)
 				return OPF_STRING;
 			else
-				return OPF_POSITIVE;
+				return OPF_NUMBER;
 
 		case OP_CLOSE_SOUND_FROM_FILE:
 		case OP_PAUSE_SOUND_FROM_FILE:


### PR DESCRIPTION
When the OPF_NUMBER and OPF_POSITIVE behaviors were made more robust, it exposed a latent bug in the play-sound sexps.  These had OPF_POSITIVE where they should have had OPF_NUMBER.  With this fix, sounds can now play from all coordinates, positive or negative.