### PR TITLE
Remove graphics functions for explicit clipping planes

### DIFF
--- a/code/graphics/2d.h
+++ b/code/graphics/2d.h
@@ -713,9 +713,6 @@ typedef struct screen {
 
 	void (*gf_lighting)(bool,bool);
 
-	void (*gf_start_clip_plane)();
-	void (*gf_end_clip_plane)();
-
 	void (*gf_zbias)(int zbias);
 
 	void (*gf_set_fill_mode)(int);
@@ -965,9 +962,6 @@ inline void gr_post_process_restore_zbuffer() {
 #define gr_deferred_lighting_finish		GR_CALL(*gr_screen.gf_deferred_lighting_finish)
 
 #define	gr_set_lighting					GR_CALL(*gr_screen.gf_lighting)
-
-#define	gr_start_clip					GR_CALL(*gr_screen.gf_start_clip_plane)
-#define	gr_end_clip						GR_CALL(*gr_screen.gf_end_clip_plane)
 
 #define	gr_zbias						GR_CALL(*gr_screen.gf_zbias)
 #define	gr_set_fill_mode				GR_CALL(*gr_screen.gf_set_fill_mode)

--- a/code/graphics/grstub.cpp
+++ b/code/graphics/grstub.cpp
@@ -75,10 +75,6 @@ void gr_stub_clear()
 {
 }
 
-void gr_stub_end_clip_plane()
-{
-}
-
 void gr_stub_end_instance_matrix()
 {
 }
@@ -212,10 +208,6 @@ void gr_stub_set_texture_addressing(int mode)
 }
 
 void gr_stub_set_view_matrix(const vec3d *pos, const matrix* orient)
-{
-}
-
-void gr_stub_start_clip_plane()
 {
 }
 
@@ -571,9 +563,6 @@ bool gr_stub_init()
 	gr_screen.gf_deferred_lighting_begin = gr_stub_deferred_lighting_begin;
 	gr_screen.gf_deferred_lighting_end = gr_stub_deferred_lighting_end;
 	gr_screen.gf_deferred_lighting_finish = gr_stub_deferred_lighting_finish;
-
-	gr_screen.gf_start_clip_plane	= gr_stub_start_clip_plane;
-	gr_screen.gf_end_clip_plane		= gr_stub_end_clip_plane;
 
 	gr_screen.gf_lighting			= gr_stub_set_lighting;
 

--- a/code/graphics/opengl/gropengl.cpp
+++ b/code/graphics/opengl/gropengl.cpp
@@ -1213,9 +1213,6 @@ void opengl_setup_function_pointers()
 	gr_screen.gf_deferred_lighting_end = gr_opengl_deferred_lighting_end;
 	gr_screen.gf_deferred_lighting_finish = gr_opengl_deferred_lighting_finish;
 
-	gr_screen.gf_start_clip_plane	= gr_opengl_start_clip_plane;
-	gr_screen.gf_end_clip_plane		= gr_opengl_end_clip_plane;
-
 	gr_screen.gf_lighting			= gr_opengl_set_lighting;
 
 	gr_screen.gf_set_proj_matrix	= gr_opengl_set_projection_matrix;

--- a/code/graphics/opengl/gropengltnl.cpp
+++ b/code/graphics/opengl/gropengltnl.cpp
@@ -726,16 +726,6 @@ void gr_opengl_pop_scale_matrix()
 	GL_scale_matrix_set = false;
 }
 
-void gr_opengl_end_clip_plane()
-{
-	// The shaders handle this now
-}
-
-void gr_opengl_start_clip_plane()
-{
-	// The shaders handle this now
-}
-
 void gr_opengl_set_clip_plane(vec3d *clip_normal, vec3d *clip_point)
 {
 	if ( clip_normal == NULL || clip_point == NULL ) {

--- a/code/graphics/opengl/gropengltnl.h
+++ b/code/graphics/opengl/gropengltnl.h
@@ -55,9 +55,6 @@ void opengl_create_perspective_projection_matrix(matrix4 *out, float left, float
 void opengl_create_orthographic_projection_matrix(matrix4* out, float left, float right, float bottom, float top, float near_dist, float far_dist);
 void opengl_create_view_matrix(matrix4 *out, const vec3d *pos, const matrix *orient);
 
-void gr_opengl_start_clip_plane();
-void gr_opengl_end_clip_plane();
-
 int gr_opengl_create_vertex_buffer(bool static_buffer);
 int gr_opengl_create_index_buffer(bool static_buffer);
 

--- a/code/render/3d.h
+++ b/code/render/3d.h
@@ -208,31 +208,6 @@ int g3_draw_sphere(vertex *pnt, float rad);
  */
 int g3_draw_sphere_ez(const vec3d *pnt, float rad);
 
-
-/**
- * Enables clipping with an arbritary plane.   
- *
- * This will be on until g3_stop_clip_plane is called or until next frame.
- * The points passed should be relative to the instance. Probably
- * that means world coordinates.
- * 
- * This works like any other clip plane... if this is enabled and you
- * rotate a point, the CC_OFF_USER bit will be set in the clipping codes.
- * It is completely handled by most g3_draw primitives, except maybe lines.
- *
- * As far as performance, when enabled, it will slow down each point
- * rotation (or g3_code_vertex call) by a vec3d subtraction and dot
- * product.   It won't slow anything down for polys that are completely
- * clipped on or off by the plane, and will slow each clipped polygon by
- * not much more than any other clipping we do.
- */
-void g3_start_user_clip_plane(const vec3d *plane_point, const vec3d *plane_normal);
-
-/**
- * Stops arbritary plane clipping
- */
-void g3_stop_user_clip_plane();
-
 ubyte g3_transfer_vertex(vertex *dest, const vec3d *src);
 
 /**

--- a/code/render/3dsetup.cpp
+++ b/code/render/3dsetup.cpp
@@ -80,9 +80,6 @@ void g3_start_frame_func(int zbuffer_flag, const char *filename, int lineno)
  	Assert( G3_count == 0 );
 	G3_count++;
 
-	// Clear any user-defined clip planes
-	g3_stop_user_clip_plane();
-
 	// Get the values from the 2d...
 	width = gr_screen.clip_width;
 	height = gr_screen.clip_height;
@@ -348,54 +345,6 @@ void g3_done_instance(bool use_api)
 int G3_user_clip = 0;
 vec3d G3_user_clip_normal;
 vec3d G3_user_clip_point;
-
-/**
- * Enables clipping with an arbritary plane.   
- *
- * This will be on until g3_stop_clip_plane is called or until next frame.
- * The points passed should be relative to the instance. Probably
- * that means world coordinates.
- * 
- * This works like any other clip plane... if this is enabled and you
- * rotate a point, the CC_OFF_USER bit will be set in the clipping codes.
- * It is completely handled by most g3_draw primitives, except maybe lines.
- *
- * As far as performance, when enabled, it will slow down each point
- * rotation (or g3_code_vertex call) by a vec3d subtraction and dot
- * product.   It won't slow anything down for polys that are completely
- * clipped on or off by the plane, and will slow each clipped polygon by
- * not much more than any other clipping we do.
- */
-void g3_start_user_clip_plane(const vec3d *plane_point, const vec3d *plane_normal )
-{
-	float mag = vm_vec_mag( plane_normal );
-	if ( (mag < 0.1f) || (mag > 1.5f ) )	{
-		// Invalid plane_normal passed in.  Get Allender (since it is
-		// probably a ship warp in bug:) or John.   
-		Int3();			
-		return;
-	}
-
-	G3_user_clip = 1;
-	G3_user_clip_normal = *plane_normal;
-	G3_user_clip_point = *plane_point;
-	gr_start_clip();
-	vm_vec_rotate(&G3_user_clip_normal, plane_normal, &Eye_matrix );
-	vm_vec_normalize(&G3_user_clip_normal);
-
-	vec3d tempv;
-	vm_vec_sub(&tempv,plane_point,&Eye_position);
-	vm_vec_rotate(&G3_user_clip_point,&tempv,&Eye_matrix );
-}
-
-/**
- * Stops arbritary plane clipping
- */
-void g3_stop_user_clip_plane()
-{
-	G3_user_clip = 0;
-	gr_end_clip();
-}
 
 /**
  * Returns TRUE if point is behind user plane

--- a/code/ship/shipfx.cpp
+++ b/code/ship/shipfx.cpp
@@ -3374,11 +3374,6 @@ int WarpEffect::warpFrame(float frametime)
 	return 0;
 }
 
-int WarpEffect::warpShipClip()
-{
-	return 0;
-}
-
 int WarpEffect::warpShipClip(model_render_params *render_info)
 {
 	return 0;
@@ -3659,15 +3654,6 @@ int WE_Default::warpFrame(float frametime)
 	return 1;
 }
 
-int WE_Default::warpShipClip()
-{
-	if(!this->isValid())
-		return 0;
-
-	g3_start_user_clip_plane( &pos, &fvec );
-	return 1;
-}
-
 int WE_Default::warpShipClip(model_render_params *render_info)
 {
 	if(!this->isValid())
@@ -3939,20 +3925,6 @@ int WE_BSG::warpFrame(float frametime)
 	if(snd_start > -1)
 		snd_update_3d_pos(snd_start, snd_start_gs, &objp->pos, 0.0f, snd_range_factor);
 
-	return 1;
-}
-
-int WE_BSG::warpShipClip()
-{
-	if(!this->isValid())
-		return 0;
-
-	if(direction == WD_WARP_OUT && stage > 0)
-	{
-		vec3d position;
-		vm_vec_scale_add(&position, &objp->pos, &objp->orient.vec.fvec, objp->radius);
-		g3_start_user_clip_plane( &position, &objp->orient.vec.fvec );
-	}
 	return 1;
 }
 
@@ -4264,15 +4236,6 @@ int WE_Homeworld::warpFrame(float frametime)
 	if(snd > -1)
 		snd_update_3d_pos(snd, snd_gs, &pos, 0.0f, snd_range_factor);
 		
-	return 1;
-}
-
-int WE_Homeworld::warpShipClip()
-{
-	if(!this->isValid())
-		return 0;
-
-	g3_start_user_clip_plane( &pos, &fvec );
 	return 1;
 }
 

--- a/code/ship/shipfx.h
+++ b/code/ship/shipfx.h
@@ -179,7 +179,6 @@ public:
 
 	virtual int warpStart();
 	virtual int warpFrame(float frametime);
-	virtual int warpShipClip();
 	virtual int warpShipClip(model_render_params *render_info);
 	virtual int warpShipRender();
 	virtual int warpShipQueueRender(model_draw_list *scene);
@@ -218,7 +217,6 @@ public:
 
 	int warpStart();
 	int warpFrame(float frametime);
-	int warpShipClip();
 	int warpShipClip(model_render_params *render_info);
 	int warpShipRender();
 
@@ -275,7 +273,6 @@ public:
 
 	virtual int warpStart();
 	virtual int warpFrame(float frametime);
-	virtual int warpShipClip();
 	virtual int warpShipClip(model_render_params *render_info);
 	virtual int warpShipRender();
 	virtual int warpEnd();
@@ -325,7 +322,6 @@ public:
 
 	virtual int warpStart();
 	virtual int warpFrame(float frametime);
-	virtual int warpShipClip();
 	virtual int warpShipClip(model_render_params *render_info);
 	virtual int warpShipRender();
 	virtual int warpEnd();


### PR DESCRIPTION
The function implementations were empty anyway and the code that called
them wasn't used anymore.