### PR TITLE
Fix error line reported by Lua Errors

### DIFF
--- a/code/scripting/scripting.cpp
+++ b/code/scripting/scripting.cpp
@@ -1127,6 +1127,11 @@ void script_state::ParseChunkSub(script_function& script_func, const char* debug
 	else if(check_for_string("["))
 	{
 		//Lua string
+
+		// Determine the current line in the file so that the Lua source can begin at the same line as in the table
+		// This will make sure that the line in the error message matches the line number in the table.
+		auto line = get_line_num();
+
 		//Allocate raw script
 		char* raw_lua = alloc_block("[", "]", 1);
 		//WMC - minor hack to make sure that the last line gets
@@ -1134,7 +1139,10 @@ void script_state::ParseChunkSub(script_function& script_func, const char* debug
 		//crash, so this is here just to be on the safe side.
 		strcat(raw_lua, "\n");
 
-		source = raw_lua;
+		for (auto i = 0; i <= line; ++i) {
+			source += "\n";
+		}
+		source += raw_lua;
 		vm_free(raw_lua);
 	}
 	else


### PR DESCRIPTION
This adds empty lines to the beginning of the Lua source passed to the
interpreter so that the interpreter sees the lines in the source as they
appear in the table.

This might slow down parsing a bit since `get_line_num` is quite slow but
it should not be noticable in most instances since the script tables
tend to be quite short.

This fixes #1469.