### PR TITLE
Only use 16 bit-per-pixel for PCX data loading

### DIFF
--- a/code/graphics/opengl/gropengltexture.cpp
+++ b/code/graphics/opengl/gropengltexture.cpp
@@ -759,17 +759,27 @@ void opengl_determine_bpp_and_flags(int bitmap_handle, int bitmap_type, ubyte& f
 		case TCACHE_TYPE_CUBEMAP:
 		case TCACHE_TYPE_NORMAL:
 			flags |= BMP_TEX_OTHER;
-			if (bm_has_alpha_channel(bitmap_handle)) {
-				bpp = 32; // Since this bitmap has an alpha channel we need to respect that
+			if (bm_get_type(bitmap_handle) == BM_TYPE_PCX) {
+				// PCX is special since the locking code only works with bpp = 16 for some reason
+				bpp = 16;
 			} else {
-				bpp = 24; // RGB, 8-bits per channel
+				if (bm_has_alpha_channel(bitmap_handle)) {
+					bpp = 32; // Since this bitmap has an alpha channel we need to respect that
+				} else {
+					bpp = 24; // RGB, 8-bits per channel
+				}
 			}
 			break;
 
 		case TCACHE_TYPE_INTERFACE:
 		case TCACHE_TYPE_XPARENT:
 			flags |= BMP_TEX_XPARENT;
-			bpp = 32; // RGBA, 8-bits per channel
+			if (bm_get_type(bitmap_handle) == BM_TYPE_PCX) {
+				// PCX is special since the locking code only works with bpp = 16 for some reason
+				bpp = 16;
+			} else {
+				bpp = 32; // RGBA, 8-bits per channel
+			}
 			break;
 
 		case TCACHE_TYPE_COMPRESSED:


### PR DESCRIPTION
The PCX loader requires this or else the data isn't loaded correctly.
This matches what the code did before the texture array merge but it
only does it for PCX textures now since the other formats handle 32 and
24 bits per pixel correctly.

This fixes #1472.