### PR TITLE
Move graphics matrix handling out of OpenGL code

### DIFF
--- a/code/bmpman/bmpman.cpp
+++ b/code/bmpman/bmpman.cpp
@@ -24,6 +24,7 @@
 #include "debugconsole/console.h"
 #include "globalincs/systemvars.h"
 #include "graphics/2d.h"
+#include "graphics/matrix.h"
 #include "graphics/grinternal.h"
 #include "io/key.h"
 #include "io/timer.h"
@@ -3109,10 +3110,7 @@ bool bm_set_render_target(int handle, int face) {
 
 		gr_reset_clip();
 
-		if (gr_screen.mode == GR_OPENGL) {
-			extern void opengl_setup_viewport();
-			opengl_setup_viewport();
-		}
+		gr_setup_viewport();
 
 		return true;
 	}

--- a/code/camera/camera.cpp
+++ b/code/camera/camera.cpp
@@ -2,7 +2,7 @@
 #include "globalincs/alphacolors.h"
 #include "globalincs/linklist.h"
 #include "globalincs/systemvars.h" //VM_FREECAMERA etc
-#include "graphics/font.h"
+#include "graphics/matrix.h"
 #include "hud/hud.h" //hud_get_draw
 #include "math/vecmat.h"
 #include "mod_table/mod_table.h"

--- a/code/cutscene/VideoPresenter.cpp
+++ b/code/cutscene/VideoPresenter.cpp
@@ -1,5 +1,6 @@
 #include "VideoPresenter.h"
 
+#include "graphics/matrix.h"
 
 using namespace cutscene;
 using namespace cutscene::player;

--- a/code/graphics/2d.cpp
+++ b/code/graphics/2d.cpp
@@ -22,6 +22,7 @@
 #include "gamesequence/gamesequence.h"	//WMC - for scripting hooks in gr_flip()
 #include "globalincs/systemvars.h"
 #include "graphics/2d.h"
+#include "graphics/matrix.h"
 #include "graphics/font.h"
 #include "graphics/grbatch.h"
 #include "graphics/grinternal.h"
@@ -752,10 +753,7 @@ void gr_screen_resize(int width, int height)
 	gr_screen.save_max_w_unscaled_zoomed = gr_screen.max_w_unscaled_zoomed;
 	gr_screen.save_max_h_unscaled_zoomed = gr_screen.max_h_unscaled_zoomed;
 
-	if (gr_screen.mode == GR_OPENGL) {
-		extern void opengl_setup_viewport();
-		opengl_setup_viewport();
-	}
+	gr_setup_viewport();
 }
 
 int gr_get_resolution_class(int width, int height)

--- a/code/graphics/2d.h
+++ b/code/graphics/2d.h
@@ -709,20 +709,6 @@ typedef struct screen {
 	void (*gf_update_transform_buffer)(void* data, size_t size);
 	void (*gf_set_transform_buffer_offset)(size_t offset);
 
-	//the projection matrix; fov, aspect ratio, near, far
- 	void (*gf_set_proj_matrix)(float, float, float, float);
-  	void (*gf_end_proj_matrix)();
-	//the view matrix
- 	void (*gf_set_view_matrix)(const vec3d*, const matrix*);
-  	void (*gf_end_view_matrix)();
-	//object scaleing
-	void (*gf_push_scale_matrix)(const vec3d*);
- 	void (*gf_pop_scale_matrix)();
-	//object position and orientation
-	void (*gf_start_instance_matrix)(const vec3d*, const matrix*);
-	void (*gf_start_angles_instance_matrix)(const vec3d*, const angles*);
-	void (*gf_end_instance_matrix)();
-
 	void (*gf_set_light)(light*);
 	void (*gf_reset_lighting)();
 	void (*gf_set_ambient_light)(int,int,int);
@@ -795,6 +781,8 @@ typedef struct screen {
 	gr_sync (*gf_sync_fence)();
 	bool (*gf_sync_wait)(gr_sync sync, uint64_t timeoutns);
 	void (*gf_sync_delete)(gr_sync sync);
+
+	void (*gf_set_viewport)(int x, int y, int width, int height);
 } screen;
 
 // handy macro
@@ -965,16 +953,6 @@ inline int gr_create_buffer(BufferType type, BufferUsageHint usage)
 #define gr_update_transform_buffer		GR_CALL(*gr_screen.gf_update_transform_buffer)
 #define gr_set_transform_buffer_offset	GR_CALL(*gr_screen.gf_set_transform_buffer_offset)
 
-#define gr_set_proj_matrix					GR_CALL(*gr_screen.gf_set_proj_matrix)
-#define gr_end_proj_matrix					GR_CALL(*gr_screen.gf_end_proj_matrix)
-#define gr_set_view_matrix					GR_CALL(*gr_screen.gf_set_view_matrix)
-#define gr_end_view_matrix					GR_CALL(*gr_screen.gf_end_view_matrix)
-#define gr_push_scale_matrix				GR_CALL(*gr_screen.gf_push_scale_matrix)
-#define gr_pop_scale_matrix					GR_CALL(*gr_screen.gf_pop_scale_matrix)
-#define gr_start_instance_matrix			GR_CALL(*gr_screen.gf_start_instance_matrix)
-#define gr_start_angles_instance_matrix		GR_CALL(*gr_screen.gf_start_angles_instance_matrix)
-#define gr_end_instance_matrix				GR_CALL(*gr_screen.gf_end_instance_matrix)
-
 #define	gr_set_light					GR_CALL(*gr_screen.gf_set_light)
 #define gr_reset_lighting				GR_CALL(*gr_screen.gf_reset_lighting)
 #define gr_set_ambient_light			GR_CALL(*gr_screen.gf_set_ambient_light)
@@ -1103,6 +1081,9 @@ inline std::unique_ptr<os::Viewport> gr_create_viewport(const os::ViewPortProper
 }
 inline void gr_use_viewport(os::Viewport* view) {
 	(*gr_screen.gf_use_viewport)(view);
+}
+inline void gr_set_viewport(int x, int y, int width, int height) {
+	(*gr_screen.gf_set_viewport)(x, y, width, height);
 }
 
 inline void gr_bind_uniform_buffer(uniform_block_type bind_point, size_t offset, size_t size, int buffer) {

--- a/code/graphics/grstub.cpp
+++ b/code/graphics/grstub.cpp
@@ -70,18 +70,6 @@ void gr_stub_clear()
 {
 }
 
-void gr_stub_end_instance_matrix()
-{
-}
-
-void gr_stub_end_projection_matrix()
-{
-}
-
-void gr_stub_end_view_matrix()
-{
-}
-
 void gr_stub_flip()
 {
 }
@@ -98,10 +86,6 @@ void gr_stub_get_region(int front, int w, int h, ubyte *data)
 {
 }
 
-void gr_stub_pop_scale_matrix()
-{
-}
-
 void gr_stub_pop_texture_matrix(int unit)
 {
 }
@@ -111,10 +95,6 @@ void gr_stub_preload_init()
 }
 
 void gr_stub_print_screen(const char *filename)
-{
-}
-
-void gr_stub_push_scale_matrix(const vec3d *scale_factor)
 {
 }
 
@@ -190,27 +170,11 @@ void gr_stub_set_light(light *light)
 {
 }
 
-void gr_stub_set_projection_matrix(float fov, float aspect, float z_near, float z_far)
-{
-}
-
 void gr_stub_set_tex_env_scale(float scale)
 {
 }
 
 void gr_stub_set_texture_addressing(int mode)
-{
-}
-
-void gr_stub_set_view_matrix(const vec3d *pos, const matrix* orient)
-{
-}
-
-void gr_stub_start_instance_angles(const vec3d *pos, const angles *rotation)
-{
-}
-
-void gr_stub_start_instance_matrix(const vec3d *offset, const matrix *rotation)
 {
 }
 
@@ -534,10 +498,6 @@ bool gr_stub_init()
 	gr_screen.gf_update_buffer_data_offset = gr_stub_update_buffer_data_offset;
 	gr_screen.gf_set_transform_buffer_offset	= gr_stub_set_transform_buffer_offset;
 
-	gr_screen.gf_start_instance_matrix			= gr_stub_start_instance_matrix;
-	gr_screen.gf_end_instance_matrix			= gr_stub_end_instance_matrix;
-	gr_screen.gf_start_angles_instance_matrix	= gr_stub_start_instance_angles;
-
 	gr_screen.gf_set_light			= gr_stub_set_light;
 	gr_screen.gf_reset_lighting		= gr_stub_reset_lighting;
 	gr_screen.gf_set_ambient_light	= gr_stub_set_ambient_light;
@@ -560,15 +520,6 @@ bool gr_stub_init()
 
 	gr_screen.gf_lighting			= gr_stub_set_lighting;
 
-	gr_screen.gf_set_proj_matrix	= gr_stub_set_projection_matrix;
-	gr_screen.gf_end_proj_matrix	= gr_stub_end_projection_matrix;
-
-	gr_screen.gf_set_view_matrix	= gr_stub_set_view_matrix;
-	gr_screen.gf_end_view_matrix	= gr_stub_end_view_matrix;
-
-	gr_screen.gf_push_scale_matrix	= gr_stub_push_scale_matrix;
-	gr_screen.gf_pop_scale_matrix	= gr_stub_pop_scale_matrix;
-	
 	gr_screen.gf_set_line_width		= gr_stub_set_line_width;
 
 	gr_screen.gf_sphere				= gr_stub_draw_sphere;

--- a/code/graphics/matrix.cpp
+++ b/code/graphics/matrix.cpp
@@ -1,0 +1,299 @@
+
+#include "matrix.h"
+
+transform_stack gr_model_matrix_stack;
+matrix4 gr_view_matrix;
+matrix4 gr_model_view_matrix;
+matrix4 gr_projection_matrix;
+matrix4 gr_last_projection_matrix;
+matrix4 gr_last_view_matrix;
+
+matrix4 gr_env_texture_matrix;
+static bool gr_env_texture_matrix_set = false;
+
+static int modelview_matrix_depth = 1;
+static bool htl_view_matrix_set = false;
+static int htl_2d_matrix_depth = 0;
+static bool htl_2d_matrix_set = false;
+
+static matrix4 create_view_matrix(const vec3d *pos, const matrix *orient)
+{
+	vec3d scaled_pos;
+	vec3d inv_pos;
+	matrix scaled_orient = *orient;
+	matrix inv_orient;
+
+	vm_vec_copy_scale(&scaled_pos, pos, -1.0f);
+	vm_vec_scale(&scaled_orient.vec.fvec, -1.0f);
+
+	vm_copy_transpose(&inv_orient, &scaled_orient);
+	vm_vec_rotate(&inv_pos, &scaled_pos, &scaled_orient);
+
+	matrix4 out;
+	vm_matrix4_set_transform(&out, &inv_orient, &inv_pos);
+
+	return out;
+}
+static void create_perspective_projection_matrix(matrix4 *out, float left, float right, float bottom, float top, float near_dist, float far_dist)
+{
+	memset(out, 0, sizeof(matrix4));
+
+	out->a1d[0] = 2.0f * near_dist / (right - left);
+	out->a1d[5] = 2.0f * near_dist / (top - bottom);
+	out->a1d[8] = (right + left) / (right - left);
+	out->a1d[9] = (top + bottom) / (top - bottom);
+	out->a1d[10] = -(far_dist + near_dist) / (far_dist - near_dist);
+	out->a1d[11] = -1.0f;
+	out->a1d[14] = -2.0f * far_dist * near_dist / (far_dist - near_dist);
+}
+
+static void create_orthographic_projection_matrix(matrix4* out, float left, float right, float bottom, float top, float near_dist, float far_dist)
+{
+	memset(out, 0, sizeof(matrix4));
+
+	out->a1d[0] = 2.0f / (right - left);
+	out->a1d[5] = 2.0f / (top - bottom);
+	out->a1d[10] = -2.0f / (far_dist - near_dist);
+	out->a1d[12] = -(right + left) / (right - left);
+	out->a1d[13] = -(top + bottom) / (top - bottom);
+	out->a1d[14] = -(far_dist + near_dist) / (far_dist - near_dist);
+	out->a1d[15] = 1.0f;
+}
+
+void gr_start_instance_matrix(const vec3d *offset, const matrix *rotation)
+{
+	Assert( htl_view_matrix_set );
+
+	if (offset == NULL) {
+		offset = &vmd_zero_vector;
+	}
+
+	if (rotation == NULL) {
+		rotation = &vmd_identity_matrix;
+	}
+
+	vec3d axis;
+	float ang;
+	vm_matrix_to_rot_axis_and_angle(rotation, &ang, &axis);
+
+	gr_model_matrix_stack.push(offset, rotation);
+
+	auto model_matrix = gr_model_matrix_stack.get_transform();
+	vm_matrix4_x_matrix4(&gr_model_view_matrix, &gr_view_matrix, &model_matrix);
+
+	modelview_matrix_depth++;
+}
+
+void gr_start_angles_instance_matrix(const vec3d *pos, const angles *rotation)
+{
+	Assert(htl_view_matrix_set);
+
+	matrix m;
+	vm_angles_2_matrix(&m, rotation);
+
+	gr_start_instance_matrix(pos, &m);
+}
+
+void gr_end_instance_matrix()
+{
+	Assert(htl_view_matrix_set);
+
+	gr_model_matrix_stack.pop();
+
+	auto model_matrix = gr_model_matrix_stack.get_transform();
+	vm_matrix4_x_matrix4(&gr_model_view_matrix, &gr_view_matrix, &model_matrix);
+
+	modelview_matrix_depth--;
+}
+
+// the projection matrix; fov, aspect ratio, near, far
+void gr_set_proj_matrix(float fov, float aspect, float z_near, float z_far) {
+	if (gr_screen.rendering_to_texture != -1) {
+		gr_set_viewport(gr_screen.offset_x, gr_screen.offset_y, gr_screen.clip_width, gr_screen.clip_height);
+	} else {
+		gr_set_viewport(gr_screen.offset_x, (gr_screen.max_h - gr_screen.offset_y - gr_screen.clip_height), gr_screen.clip_width, gr_screen.clip_height);
+	}
+
+	float clip_width, clip_height;
+
+	clip_height = tan( fov * 0.5f ) * z_near;
+	clip_width = clip_height * aspect;
+
+	gr_last_projection_matrix = gr_projection_matrix;
+	if (gr_screen.rendering_to_texture != -1) {
+		create_perspective_projection_matrix(&gr_projection_matrix, -clip_width, clip_width, clip_height, -clip_height, z_near, z_far);
+	} else {
+		create_perspective_projection_matrix(&gr_projection_matrix, -clip_width, clip_width, -clip_height, clip_height, z_near, z_far);
+	}
+}
+
+void gr_end_proj_matrix() {
+	gr_set_viewport(0, 0, gr_screen.max_w, gr_screen.max_h);
+
+	gr_last_projection_matrix = gr_projection_matrix;
+
+	// the top and bottom positions are reversed on purpose, but RTT needs them the other way
+	if (gr_screen.rendering_to_texture != -1) {
+		create_orthographic_projection_matrix(&gr_projection_matrix, 0.0f, i2fl(gr_screen.max_w), 0.0f, i2fl(gr_screen.max_h), -1.0f, 1.0f);
+	} else {
+		create_orthographic_projection_matrix(&gr_projection_matrix, 0.0f, i2fl(gr_screen.max_w), i2fl(gr_screen.max_h), 0.0f, -1.0f, 1.0f);
+	}
+}
+
+void gr_set_view_matrix(const vec3d *pos, const matrix *orient)
+{
+	Assert(modelview_matrix_depth == 1);
+
+	gr_view_matrix = create_view_matrix(pos, orient);
+
+	gr_model_matrix_stack.clear();
+	gr_model_view_matrix = gr_view_matrix;
+
+	if (Cmdline_env) {
+		gr_env_texture_matrix_set = true;
+
+		// setup the texture matrix which will make the the envmap keep lined
+		// up properly with the environment
+
+		// r.xyz  <--  r.x, u.x, f.x
+		gr_env_texture_matrix.a1d[0] = gr_model_view_matrix.a1d[0];
+		gr_env_texture_matrix.a1d[1] = gr_model_view_matrix.a1d[4];
+		gr_env_texture_matrix.a1d[2] = gr_model_view_matrix.a1d[8];
+		// u.xyz  <--  r.y, u.y, f.y
+		gr_env_texture_matrix.a1d[4] = gr_model_view_matrix.a1d[1];
+		gr_env_texture_matrix.a1d[5] = gr_model_view_matrix.a1d[5];
+		gr_env_texture_matrix.a1d[6] = gr_model_view_matrix.a1d[9];
+		// f.xyz  <--  r.z, u.z, f.z
+		gr_env_texture_matrix.a1d[8] = gr_model_view_matrix.a1d[2];
+		gr_env_texture_matrix.a1d[9] = gr_model_view_matrix.a1d[6];
+		gr_env_texture_matrix.a1d[10] = gr_model_view_matrix.a1d[10];
+
+		gr_env_texture_matrix.a1d[15] = 1.0f;
+	}
+
+	modelview_matrix_depth = 2;
+	htl_view_matrix_set = true;
+}
+
+void gr_end_view_matrix()
+{
+	Assert(modelview_matrix_depth == 2);
+
+	gr_model_matrix_stack.clear();
+	vm_matrix4_set_identity(&gr_view_matrix);
+	vm_matrix4_set_identity(&gr_model_view_matrix);
+
+	modelview_matrix_depth = 1;
+	htl_view_matrix_set = false;
+	gr_env_texture_matrix_set = false;
+}
+
+// set a view and projection matrix for a 2D element
+// TODO: this probably needs to accept values
+void gr_set_2d_matrix(/*int x, int y, int w, int h*/)
+{
+	Assert( htl_2d_matrix_set == 0 );
+	Assert( htl_2d_matrix_depth == 0 );
+
+	// the viewport needs to be the full screen size since glOrtho() is relative to it
+	gr_set_viewport(0, 0, gr_screen.max_w, gr_screen.max_h);
+
+	gr_last_projection_matrix = gr_projection_matrix;
+
+	// the top and bottom positions are reversed on purpose, but RTT needs them the other way
+	if (gr_screen.rendering_to_texture != -1) {
+		create_orthographic_projection_matrix(&gr_projection_matrix, 0, i2fl(gr_screen.max_w), 0, i2fl(gr_screen.max_h), -1, 1);
+	} else {
+		create_orthographic_projection_matrix(&gr_projection_matrix, 0, i2fl(gr_screen.max_w), i2fl(gr_screen.max_h), 0, -1, 1);
+	}
+
+	matrix4 identity_mat;
+	vm_matrix4_set_identity(&identity_mat);
+
+	gr_model_matrix_stack.push_and_replace(identity_mat);
+
+	gr_last_view_matrix = gr_view_matrix;
+	gr_view_matrix = identity_mat;
+
+	vm_matrix4_x_matrix4(&gr_model_view_matrix, &gr_view_matrix, &identity_mat);
+
+	htl_2d_matrix_set = true;
+	htl_2d_matrix_depth++;
+}
+
+// ends a previously set 2d view and projection matrix
+void gr_end_2d_matrix()
+{
+	if (!htl_2d_matrix_set)
+		return;
+
+	Assert( htl_2d_matrix_depth == 1 );
+
+	// reset viewport to what it was originally set to by the proj matrix
+	gr_set_viewport(gr_screen.offset_x, (gr_screen.max_h - gr_screen.offset_y - gr_screen.clip_height), gr_screen.clip_width, gr_screen.clip_height);
+
+	gr_projection_matrix = gr_last_projection_matrix;
+
+	gr_model_matrix_stack.pop();
+
+	gr_view_matrix = gr_last_view_matrix;
+
+	auto model_matrix = gr_model_matrix_stack.get_transform();
+	vm_matrix4_x_matrix4(&gr_model_view_matrix, &gr_view_matrix, &model_matrix);
+
+	htl_2d_matrix_set = false;
+	htl_2d_matrix_depth = 0;
+}
+
+static bool scale_matrix_set = false;
+
+void gr_push_scale_matrix(const vec3d *scale_factor)
+{
+	if ( (scale_factor->xyz.x == 1) && (scale_factor->xyz.y == 1) && (scale_factor->xyz.z == 1) )
+		return;
+
+	scale_matrix_set = true;
+
+	modelview_matrix_depth++;
+
+	gr_model_matrix_stack.push(NULL, NULL, scale_factor);
+
+	auto model_matrix = gr_model_matrix_stack.get_transform();
+	vm_matrix4_x_matrix4(&gr_model_view_matrix, &gr_view_matrix, &model_matrix);
+}
+
+void gr_pop_scale_matrix()
+{
+	if (!scale_matrix_set)
+		return;
+
+	gr_model_matrix_stack.pop();
+
+	auto model_matrix = gr_model_matrix_stack.get_transform();
+	vm_matrix4_x_matrix4(&gr_model_view_matrix, &gr_view_matrix, &model_matrix);
+
+	modelview_matrix_depth--;
+	scale_matrix_set = false;
+}
+void gr_setup_viewport() {
+	gr_set_viewport(0, 0, gr_screen.max_w, gr_screen.max_h);
+
+	gr_last_projection_matrix = gr_projection_matrix;
+
+	// the top and bottom positions are reversed on purpose, but RTT needs them the other way
+	if (gr_screen.rendering_to_texture != -1) {
+		create_orthographic_projection_matrix(&gr_projection_matrix, 0, i2fl(gr_screen.max_w), 0, i2fl(gr_screen.max_h), -1, 1);
+	} else {
+		create_orthographic_projection_matrix(&gr_projection_matrix, 0, i2fl(gr_screen.max_w), i2fl(gr_screen.max_h), 0, -1, 1);
+	}
+}
+void gr_reset_matrices() {
+	vm_matrix4_set_identity(&gr_projection_matrix);
+	vm_matrix4_set_identity(&gr_last_projection_matrix);
+
+	vm_matrix4_set_identity(&gr_view_matrix);
+	vm_matrix4_set_identity(&gr_last_view_matrix);
+
+	vm_matrix4_set_identity(&gr_model_view_matrix);
+	gr_model_matrix_stack.clear();
+}

--- a/code/graphics/matrix.h
+++ b/code/graphics/matrix.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "graphics/2d.h"
+
+extern transform_stack gr_model_matrix_stack;
+extern matrix4 gr_view_matrix;
+extern matrix4 gr_model_view_matrix;
+extern matrix4 gr_projection_matrix;
+extern matrix4 gr_last_projection_matrix;
+extern matrix4 gr_env_texture_matrix;
+
+void gr_start_instance_matrix(const vec3d *offset, const matrix *rotation);
+void gr_start_angles_instance_matrix(const vec3d *pos, const angles *rotation);
+void gr_end_instance_matrix();
+
+void gr_set_proj_matrix(float fov, float aspect, float z_near, float z_far);
+void gr_end_proj_matrix();
+
+void gr_set_view_matrix(const vec3d *pos, const matrix *orient);
+void gr_end_view_matrix();
+
+void gr_set_2d_matrix(/*int x, int y, int w, int h*/);
+void gr_end_2d_matrix();
+
+void gr_push_scale_matrix(const vec3d *scale_factor);
+void gr_pop_scale_matrix();
+
+void gr_setup_viewport();
+
+void gr_reset_matrices();

--- a/code/graphics/opengl/gropengldeferred.cpp
+++ b/code/graphics/opengl/gropengldeferred.cpp
@@ -6,6 +6,7 @@
 #include "gropengldraw.h"
 #include "gropengldeferred.h"
 #include "gropengltnl.h"
+#include "graphics/matrix.h"
 #include "graphics/util/UniformAligner.h"
 #include "graphics/util/uniform_structs.h"
 #include "graphics/util/UniformBuffer.h"
@@ -290,8 +291,8 @@ void gr_opengl_draw_deferred_light_sphere(const vec3d *position)
 {
 	g3_start_instance_matrix(position, &vmd_identity_matrix, true);
 
-	Current_shader->program->Uniforms.setUniformMatrix4f("modelViewMatrix", GL_model_view_matrix);
-	Current_shader->program->Uniforms.setUniformMatrix4f("projMatrix", GL_projection_matrix);
+	Current_shader->program->Uniforms.setUniformMatrix4f("modelViewMatrix", gr_model_view_matrix);
+	Current_shader->program->Uniforms.setUniformMatrix4f("projMatrix", gr_projection_matrix);
 
 	opengl_draw_sphere();
 
@@ -522,8 +523,8 @@ void gr_opengl_draw_deferred_light_cylinder(const vec3d *position, const matrix 
 {
 	g3_start_instance_matrix(position, orient, true);
 
-	Current_shader->program->Uniforms.setUniformMatrix4f("modelViewMatrix", GL_model_view_matrix);
-	Current_shader->program->Uniforms.setUniformMatrix4f("projMatrix", GL_projection_matrix);
+	Current_shader->program->Uniforms.setUniformMatrix4f("modelViewMatrix", gr_model_view_matrix);
+	Current_shader->program->Uniforms.setUniformMatrix4f("projMatrix", gr_projection_matrix);
 
 	GL_state.Array.BindArrayBuffer(deferred_light_cylinder_vbo);
 	GL_state.Array.BindElementBuffer(deferred_light_cylinder_ibo);

--- a/code/graphics/opengl/gropengldraw.cpp
+++ b/code/graphics/opengl/gropengldraw.cpp
@@ -10,6 +10,7 @@
 #include "globalincs/pstypes.h"
 #include "cmdline/cmdline.h"
 #include "freespace.h"
+#include "graphics/matrix.h"
 #include "gropengl.h"
 #include "gropengldraw.h"
 #include "gropengllight.h"
@@ -663,8 +664,8 @@ void gr_opengl_render_shield_impact(shield_material *material_info, primitive_ty
 	Current_shader->program->Uniforms.setUniformi("shieldMapIndex", array_index);
 	Current_shader->program->Uniforms.setUniformi("srgb", High_dynamic_range ? 1 : 0);
 	Current_shader->program->Uniforms.setUniform4f("color", material_info->get_color());
-	Current_shader->program->Uniforms.setUniformMatrix4f("modelViewMatrix", GL_model_view_matrix);
-	Current_shader->program->Uniforms.setUniformMatrix4f("projMatrix", GL_projection_matrix);
+	Current_shader->program->Uniforms.setUniformMatrix4f("modelViewMatrix", gr_model_view_matrix);
+	Current_shader->program->Uniforms.setUniformMatrix4f("projMatrix", gr_projection_matrix);
 	
 	opengl_render_primitives(prim_type, layout, n_verts, buffer_handle, 0, 0);
 }
@@ -802,11 +803,11 @@ void gr_opengl_render_primitives_2d(material* material_info, primitive_type prim
 	//glPushMatrix();
 	//glTranslatef((float)gr_screen.offset_x, (float)gr_screen.offset_y, -0.99f);
 
-	gr_opengl_set_2d_matrix();
+	gr_set_2d_matrix();
 
 	gr_opengl_render_primitives(material_info, prim_type, layout, offset, n_verts, buffer_handle);
 
-	gr_opengl_end_2d_matrix();
+	gr_end_2d_matrix();
 
 	//glPopMatrix();
 
@@ -847,13 +848,13 @@ void gr_opengl_render_movie(movie_material* material_info,
 							int buffer) {
 	GR_DEBUG_SCOPE("Render movie frame");
 
-	gr_opengl_set_2d_matrix();
+	gr_set_2d_matrix();
 
 	opengl_tnl_set_material_movie(material_info);
 
 	opengl_render_primitives(prim_type, layout, n_verts, buffer, 0, 0);
 
-	gr_opengl_end_2d_matrix();
+	gr_end_2d_matrix();
 }
 
 void gr_opengl_render_primitives_batched(batched_bitmap_material* material_info,

--- a/code/graphics/opengl/gropengllight.cpp
+++ b/code/graphics/opengl/gropengllight.cpp
@@ -20,6 +20,7 @@
 #include "globalincs/pstypes.h"
 #include <globalincs/systemvars.h>
 #include "graphics/2d.h"
+#include "graphics/matrix.h"
 #include "gropengllight.h"
 #include "gropenglstate.h"
 #include "gropengltnl.h"
@@ -164,8 +165,8 @@ void opengl_set_light(int light_num, opengl_light *ltp)
 	light_dir_world.xyz.y = ltp->SpotDir[1];
 	light_dir_world.xyz.z = ltp->SpotDir[2];
 
-	vm_vec_transform(&opengl_light_uniforms.Position[light_num], &light_pos_world, &GL_view_matrix);
-	vm_vec_transform(&opengl_light_uniforms.Direction[light_num], &light_dir_world, &GL_view_matrix, false);
+	vm_vec_transform(&opengl_light_uniforms.Position[light_num], &light_pos_world, &gr_view_matrix);
+	vm_vec_transform(&opengl_light_uniforms.Direction[light_num], &light_dir_world, &gr_view_matrix, false);
 
 	opengl_light_uniforms.Diffuse_color[light_num].xyz.x = ltp->Diffuse[0];
 	opengl_light_uniforms.Diffuse_color[light_num].xyz.y = ltp->Diffuse[1];

--- a/code/graphics/opengl/gropenglshader.cpp
+++ b/code/graphics/opengl/gropenglshader.cpp
@@ -11,6 +11,7 @@
 #include "cmdline/cmdline.h"
 #include "def_files/def_files.h"
 #include "graphics/2d.h"
+#include "graphics/matrix.h"
 #include "graphics/grinternal.h"
 #include "graphics/opengl/gropengldraw.h"
 #include "graphics/opengl/gropengllight.h"
@@ -785,8 +786,8 @@ void opengl_shader_set_passthrough(bool textured)
 
 	Current_shader->program->Uniforms.setUniform4f("color", 1.0f, 1.0f, 1.0f, 1.0f);
 
-	Current_shader->program->Uniforms.setUniformMatrix4f("modelViewMatrix", GL_model_view_matrix);
-	Current_shader->program->Uniforms.setUniformMatrix4f("projMatrix", GL_projection_matrix);
+	Current_shader->program->Uniforms.setUniformMatrix4f("modelViewMatrix", gr_model_view_matrix);
+	Current_shader->program->Uniforms.setUniformMatrix4f("projMatrix", gr_projection_matrix);
 }
 
 void opengl_shader_set_default_material(bool textured, bool alpha, vec4 *clr, float color_scale, uint32_t array_index, const material::clip_plane& clip_plane)
@@ -834,11 +835,11 @@ void opengl_shader_set_default_material(bool textured, bool alpha, vec4 *clr, fl
 		clip_equation.xyzw.w = -vm_vec_dot(&clip_plane.normal, &clip_plane.position);
 
 		Current_shader->program->Uniforms.setUniform4f("clipEquation", clip_equation);
-		Current_shader->program->Uniforms.setUniformMatrix4f("modelMatrix", GL_model_matrix_stack.get_transform());
+		Current_shader->program->Uniforms.setUniformMatrix4f("modelMatrix", gr_model_matrix_stack.get_transform());
 	} else {
 		Current_shader->program->Uniforms.setUniformi("clipEnabled", 0);
 	}
 
-	Current_shader->program->Uniforms.setUniformMatrix4f("modelViewMatrix", GL_model_view_matrix);
-	Current_shader->program->Uniforms.setUniformMatrix4f("projMatrix", GL_projection_matrix);
+	Current_shader->program->Uniforms.setUniformMatrix4f("modelViewMatrix", gr_model_view_matrix);
+	Current_shader->program->Uniforms.setUniformMatrix4f("projMatrix", gr_projection_matrix);
 }

--- a/code/graphics/opengl/gropengltnl.h
+++ b/code/graphics/opengl/gropengltnl.h
@@ -33,28 +33,6 @@ extern float shadow_middist;
 extern float shadow_fardist;
 extern bool Rendering_to_shadow_map;
 
-extern transform_stack GL_model_matrix_stack;
-extern matrix4 GL_view_matrix;
-extern matrix4 GL_model_view_matrix;
-extern matrix4 GL_projection_matrix;
-extern matrix4 GL_last_projection_matrix;
-
-void gr_opengl_start_instance_matrix(const vec3d *offset, const matrix *rotation);
-void gr_opengl_start_instance_angles(const vec3d *pos, const angles *rotation);
-void gr_opengl_end_instance_matrix();
-void gr_opengl_set_projection_matrix(float fov, float aspect, float z_near, float z_far);
-void gr_opengl_end_projection_matrix();
-void gr_opengl_set_view_matrix(const vec3d *pos, const matrix *orient);
-void gr_opengl_end_view_matrix();
-void gr_opengl_set_2d_matrix(/*int x, int y, int w, int h*/);
-void gr_opengl_end_2d_matrix();
-void gr_opengl_push_scale_matrix(const vec3d *scale_factor);
-void gr_opengl_pop_scale_matrix();
-
-void opengl_create_perspective_projection_matrix(matrix4 *out, float left, float right, float bottom, float top, float near_dist, float far_dist);
-void opengl_create_orthographic_projection_matrix(matrix4* out, float left, float right, float bottom, float top, float near_dist, float far_dist);
-void opengl_create_view_matrix(matrix4 *out, const vec3d *pos, const matrix *orient);
-
 int gr_opengl_create_buffer(BufferType type, BufferUsageHint usage);
 
 void opengl_bind_buffer_object(int handle);
@@ -79,5 +57,7 @@ void opengl_tnl_set_material_movie(movie_material* material_info);
 void opengl_tnl_set_material_batched(batched_bitmap_material * material_info);
 
 void opengl_tnl_set_model_material(model_material *material_info);
+
+void gr_opengl_set_viewport(int x, int y, int width, int height);
 
 #endif //_GROPENGLTNL_H

--- a/code/graphics/paths/NVGRenderer.cpp
+++ b/code/graphics/paths/NVGRenderer.cpp
@@ -1,5 +1,6 @@
 
 #include "globalincs/pstypes.h"
+#include "graphics/matrix.h"
 
 #if SCP_COMPILER_IS_GNU
 // Disable warnings inside the NanoVG implementation
@@ -105,11 +106,11 @@ namespace graphics
 
 			glBindVertexArray(0);
 
-			gr_opengl_set_2d_matrix();
+			gr_set_2d_matrix();
 
 			nvgEndFrame(m_context);
 
-			gr_opengl_end_2d_matrix();
+			gr_end_2d_matrix();
 
 			resetGLState();
 			m_inFrame = false;

--- a/code/graphics/shadows.cpp
+++ b/code/graphics/shadows.cpp
@@ -11,6 +11,7 @@
 #include "cmdline/cmdline.h"
 #include "debris/debris.h"
 #include "graphics/shadows.h"
+#include "graphics/matrix.h"
 #include "lighting/lighting.h"
 #include "math/vecmat.h"
 #include "model/model.h"

--- a/code/hud/hudshield.cpp
+++ b/code/hud/hudshield.cpp
@@ -24,6 +24,7 @@
 #include "render/3d.h"	//For g3_start_frame
 #include "ship/ship.h"
 #include "weapon/emp.h"
+#include "graphics/matrix.h"
 
 
 

--- a/code/hud/hudtarget.cpp
+++ b/code/hud/hudtarget.cpp
@@ -17,6 +17,7 @@
 #include "gamesnd/gamesnd.h"
 #include "globalincs/alphacolors.h"
 #include "globalincs/linklist.h"
+#include "graphics/matrix.h"
 #include "hud/hudartillery.h"
 #include "hud/hudbrackets.h"
 #include "hud/hudlock.h"

--- a/code/hud/hudtargetbox.cpp
+++ b/code/hud/hudtargetbox.cpp
@@ -14,6 +14,7 @@
 #include "debris/debris.h"
 #include "freespace.h"
 #include "gamesnd/gamesnd.h"
+#include "graphics/matrix.h"
 #include "hud/hudbrackets.h"
 #include "hud/hudtargetbox.h"
 #include "iff_defs/iff_defs.h"

--- a/code/lab/lab.cpp
+++ b/code/lab/lab.cpp
@@ -12,6 +12,7 @@
 #include "cmdline/cmdline.h"
 #include "freespace.h"
 #include "gamesequence/gamesequence.h"
+#include "graphics/matrix.h"
 #include "graphics/shadows.h"
 #include "hud/hudshield.h"
 #include "io/key.h"

--- a/code/menuui/techmenu.cpp
+++ b/code/menuui/techmenu.cpp
@@ -18,6 +18,7 @@
 #include "globalincs/alphacolors.h"
 #include "graphics/font.h"
 #include "graphics/shadows.h"
+#include "graphics/matrix.h"
 #include "io/key.h"
 #include "io/mouse.h"
 #include "lighting/lighting.h"

--- a/code/missionui/missionbrief.cpp
+++ b/code/missionui/missionbrief.cpp
@@ -20,6 +20,7 @@
 #include "globalincs/alphacolors.h"
 #include "globalincs/linklist.h"
 #include "graphics/font.h"
+#include "graphics/matrix.h"
 #include "hud/hud.h"
 #include "io/key.h"
 #include "io/mouse.h"

--- a/code/missionui/missionscreencommon.cpp
+++ b/code/missionui/missionscreencommon.cpp
@@ -23,6 +23,7 @@
 #include "gamesnd/gamesnd.h"
 #include "globalincs/linklist.h"
 #include "graphics/2d.h"
+#include "graphics/matrix.h"
 #include "graphics/shadows.h"
 #include "hud/hudwingmanstatus.h"
 #include "io/key.h"

--- a/code/missionui/missionweaponchoice.cpp
+++ b/code/missionui/missionweaponchoice.cpp
@@ -17,6 +17,7 @@
 #include "gamesnd/gamesnd.h"
 #include "globalincs/alphacolors.h"
 #include "graphics/shadows.h"
+#include "graphics/matrix.h"
 #include "hud/hudbrackets.h"
 #include "io/mouse.h"
 #include "io/timer.h"

--- a/code/model/modelrender.cpp
+++ b/code/model/modelrender.cpp
@@ -15,6 +15,7 @@
 #include "graphics/opengl/gropengldraw.h"
 #include "graphics/opengl/gropenglshader.h"
 #include "graphics/tmapper.h"
+#include "graphics/matrix.h"
 #include "io/timer.h"
 #include "math/staticrand.h"
 #include "model/modelrender.h"

--- a/code/radar/radar.cpp
+++ b/code/radar/radar.cpp
@@ -16,6 +16,7 @@
 #include "gamesnd/gamesnd.h"
 #include "globalincs/linklist.h"
 #include "graphics/font.h"
+#include "graphics/matrix.h"
 #include "iff_defs/iff_defs.h"
 #include "io/timer.h"
 #include "jumpnode/jumpnode.h"

--- a/code/radar/radardradis.cpp
+++ b/code/radar/radardradis.cpp
@@ -12,6 +12,7 @@
 #include "globalincs/alphacolors.h"
 #include "globalincs/systemvars.h"
 #include "graphics/font.h"
+#include "graphics/matrix.h"
 #include "hud/hudwingmanstatus.h"
 #include "iff_defs/iff_defs.h"
 #include "io/timer.h"

--- a/code/radar/radarorb.cpp
+++ b/code/radar/radarorb.cpp
@@ -15,6 +15,7 @@
 #include "gamesnd/gamesnd.h"
 #include "globalincs/linklist.h"
 #include "graphics/font.h"
+#include "graphics/matrix.h"
 #include "iff_defs/iff_defs.h"
 #include "io/timer.h"
 #include "jumpnode/jumpnode.h"

--- a/code/render/3ddraw.cpp
+++ b/code/render/3ddraw.cpp
@@ -14,6 +14,7 @@
 #include "globalincs/alphacolors.h"
 #include "graphics/grbatch.h"
 #include "graphics/tmapper.h"
+#include "graphics/matrix.h"
 #include "io/key.h"
 #include "physics/physics.h"		// For Physics_viewer_bank for g3_draw_rotated_bitmap
 #include "render/3dinternal.h"

--- a/code/render/3dsetup.cpp
+++ b/code/render/3dsetup.cpp
@@ -11,6 +11,7 @@
 
 
 #include "graphics/2d.h"			// Needed for w,h,aspect of canvas
+#include "graphics/matrix.h"
 #include "graphics/tmapper.h"
 #include "lighting/lighting.h"
 #include "render/3dinternal.h"

--- a/code/scripting/api/objs/graphics.cpp
+++ b/code/scripting/api/objs/graphics.cpp
@@ -4,6 +4,7 @@
 #include <graphics/2d.h>
 #include <camera/camera.h>
 #include <graphics/opengl/gropenglpostprocessing.h>
+#include <graphics/matrix.h>
 #include <globalincs/systemvars.h>
 #include <freespace.h>
 #include <render/3d.h>

--- a/code/scripting/api/objs/shipclass.cpp
+++ b/code/scripting/api/objs/shipclass.cpp
@@ -9,6 +9,7 @@
 #include "vecmath.h"
 #include "ship/ship.h"
 #include "playerman/player.h"
+#include "graphics/matrix.h"
 
 namespace scripting {
 namespace api {

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -24,6 +24,7 @@
 #include "gamesnd/eventmusic.h"
 #include "gamesnd/gamesnd.h"
 #include "globalincs/alphacolors.h"
+#include "graphics/matrix.h"
 #include "def_files/def_files.h"
 #include "globalincs/linklist.h"
 #include "hud/hud.h"

--- a/code/source_groups.cmake
+++ b/code/source_groups.cmake
@@ -299,6 +299,8 @@ set (file_root_graphics
 	graphics/grinternal.h
 	graphics/material.cpp
 	graphics/material.h
+	graphics/matrix.cpp
+	graphics/matrix.h
 	graphics/render.cpp
 	graphics/render.h
 	graphics/shadows.cpp

--- a/code/starfield/starfield.cpp
+++ b/code/starfield/starfield.cpp
@@ -15,6 +15,7 @@
 #include "debugconsole/console.h"
 #include "freespace.h"
 #include "graphics/paths/PathRenderer.h"
+#include "graphics/matrix.h"
 #include "hud/hud.h"
 #include "hud/hudtarget.h"
 #include "io/timer.h"

--- a/fred2/fredrender.cpp
+++ b/fred2/fredrender.cpp
@@ -25,6 +25,7 @@
 #include "cmdline/cmdline.h"
 #include "globalincs/linklist.h"
 #include "graphics/2d.h"
+#include "graphics/matrix.h"
 #include "graphics/font.h"
 #include "graphics/tmapper.h"
 #include "iff_defs/iff_defs.h"

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -51,6 +51,7 @@
 #include "globalincs/version.h"
 #include "graphics/font.h"
 #include "graphics/shadows.h"
+#include "graphics/matrix.h"
 #include "headtracking/headtracking.h"
 #include "hud/hud.h"
 #include "hud/hudconfig.h"


### PR DESCRIPTION
All transformations are now handled by shaders so there is nothing
special going on in the graphics API specific code anymore. Since model
uniform buffers require access to these matrices I moved the matrix
handling out of the graphics API code.