### PR TITLE
Use uniform buffer blocks for passing uniform data to shaders

### DIFF
--- a/cmake/platformChecks.h.in
+++ b/cmake/platformChecks.h.in
@@ -9,6 +9,7 @@
 #cmakedefine HAVE_STD_MAX_ALIGN_T
 
 #cmakedefine HAVE_STD_IS_TRIVIALLY_COPYABLE
+#cmakedefine HAVE_STD_IS_TRIVIALLY_COPYABLE_ARRAY
 
 #cmakedefine01 IS_64BIT
 

--- a/code/bmpman/bmpman.cpp
+++ b/code/bmpman/bmpman.cpp
@@ -3329,3 +3329,6 @@ int bm_get_base_frame(const int handle, int* num_frames) {
 	}
 	return animation_begin;
 }
+int bm_get_array_index(const int handle) {
+	return handle - bm_get_base_frame(handle, nullptr);
+}

--- a/code/bmpman/bmpman.h
+++ b/code/bmpman/bmpman.h
@@ -718,4 +718,15 @@ bool bm_is_texture_array(const int handle);
  */
 int bm_get_base_frame(const int handle, int* num_frames = nullptr);
 
+/**
+ * @brief Get the array index of the specified bitmap
+ *
+ * This should be used when passing the array index to the GPU (e.g. when building uniform structs or streaming particle
+ * data)
+ *
+ * @param handle The handle of the bitmap
+ * @return The index into the array
+ */
+int bm_get_array_index(const int handle);
+
 #endif

--- a/code/def_files/main-f.sdr
+++ b/code/def_files/main-f.sdr
@@ -2,94 +2,134 @@
 #define LT_DIRECTIONAL		0
 #define LT_POINT			1
 #define LT_TUBE			2
-uniform vec4 color;
-#ifdef FLAG_LIGHT
-uniform vec4 lightPosition[MAX_LIGHTS];
-uniform vec3 lightDirection[MAX_LIGHTS];
-uniform vec3 lightDiffuseColor[MAX_LIGHTS];
-uniform vec3 lightSpecColor[MAX_LIGHTS];
-uniform int lightType[MAX_LIGHTS];
-uniform float lightAttenuation[MAX_LIGHTS];
-uniform int n_lights;
-uniform float defaultGloss;
-uniform vec3 ambientFactor;
-uniform vec3 diffuseFactor;
-uniform vec3 emissionFactor;
-#endif
+struct model_light {
+	vec4 position;
+
+	vec3 diffuse_color;
+	int light_type;
+
+	vec3 spec_color;
+	float attenuation;
+
+	vec3 direction;
+};
+
+layout (std140) uniform modelData {
+	mat4 modelViewMatrix;
+	mat4 modelMatrix;
+	mat4 viewMatrix;
+	mat4 projMatrix;
+	mat4 textureMatrix;
+	mat4 shadow_mv_matrix;
+	mat4 shadow_proj_matrix[4];
+	mat4 envMatrix;
+
+	vec4 color;
+
+	model_light lights[MAX_LIGHTS];
+
+	float extrudeWidth;
+	float fogStart;
+	float fogScale;
+	int buffer_matrix_offset;
+
+	vec4 clip_equation;
+
+	float thruster_scale;
+	bool use_clip_plane;
+	int n_lights;
+	float defaultGloss;
+
+	vec3 ambientFactor;
+	int desaturate;
+
+	vec3 diffuseFactor;
+	int blend_alpha;
+
+	vec3 emissionFactor;
+	bool overrideDiffuse;
+
+	vec3 diffuseClr;
+	bool overrideGlow;
+
+	vec3 glowClr;
+	bool overrideSpec;
+
+	vec3 specClr;
+	bool alphaGloss;
+
+	bool gammaSpec;
+	bool envGloss;
+	bool alpha_spec;
+	int effect_num;
+
+	vec4 fogColor;
+
+	vec3 base_color;
+	float anim_timer;
+
+	vec3 stripe_color;
+	float vpwidth;
+
+	float vpheight;
+	bool team_glow_enabled;
+	float znear;
+	float zfar;
+
+	float veryneardist;
+	float neardist;
+	float middist;
+	float fardist;
+
+	vec2 normalAlphaMinMax;
+	int sBasemapIndex;
+	int sGlowmapIndex;
+
+	int sSpecmapIndex;
+	int sNormalmapIndex;
+	int sAmbientmapIndex;
+	int sMiscmapIndex;
+};
+
 #ifdef FLAG_DIFFUSE_MAP
 uniform sampler2DArray sBasemap;
-uniform int sBasemapIndex;
-uniform int desaturate;
-uniform int blend_alpha;
-uniform bool overrideDiffuse;
-uniform vec3 diffuseClr;
 #endif
 #ifdef FLAG_GLOW_MAP
 uniform sampler2DArray sGlowmap;
-uniform int sGlowmapIndex;
-uniform bool overrideGlow;
-uniform vec3 glowClr;
 #endif
 #ifdef FLAG_SPEC_MAP
 uniform sampler2DArray sSpecmap;
-uniform int sSpecmapIndex;
-uniform bool overrideSpec;
-uniform vec3 specClr;
-uniform bool alphaGloss;
-uniform bool gammaSpec;
 #endif
 #ifdef FLAG_ENV_MAP
 uniform samplerCube sEnvmap;
-uniform bool envGloss;
-uniform bool alpha_spec;
 in vec3 fragEnvReflect;
 #endif
 #ifdef FLAG_NORMAL_MAP
 uniform sampler2DArray sNormalmap;
-uniform int sNormalmapIndex;
 in mat3 fragTangentMatrix;
 #endif
 #ifdef FLAG_AMBIENT_MAP
 uniform sampler2DArray sAmbientmap;
-uniform int sAmbientmapIndex;
 #endif
 #ifdef FLAG_FOG
-uniform vec4 fogColor;
 in float fragFogDist;
 #endif
 #ifdef FLAG_ANIMATED
 uniform sampler2D sFramebuffer;
-uniform int effect_num;
-uniform float anim_timer;
-uniform float vpwidth;
-uniform float vpheight;
 #endif
 #ifdef FLAG_TRANSFORM
 in float fragNotVisible;
 #endif
 #ifdef FLAG_TEAMCOLOR
-uniform vec3 base_color;
-uniform vec3 stripe_color;
-uniform bool team_glow_enabled;
 vec2 teamMask = vec2(0.0, 0.0);
 #endif
 #ifdef FLAG_MISC_MAP
 uniform sampler2DArray sMiscmap;
-uniform int sMiscmapIndex;
 #endif
 #ifdef FLAG_SHADOWS
 in vec4 fragShadowUV[4];
 in vec4 fragShadowPos;
 uniform sampler2DArray shadow_map;
-uniform float znear;
-uniform float zfar;
-uniform float veryneardist;
-uniform float neardist;
-uniform float middist;
-uniform float fardist;
-#endif
-#ifdef FLAG_NORMAL_ALPHA
-uniform vec2 normalAlphaMinMax;
 #endif
 #define SPEC_INTENSITY_POINT      5.3 // Point light
 #define SPEC_INTENSITY_DIRECTIONAL   3.0 // Directional light
@@ -216,26 +256,26 @@ vec3 SpecularBlinnPhong(vec3 specColor, vec3 light, vec3 normal, vec3 halfVec, f
 #ifdef FLAG_LIGHT
 void GetLightInfo(int i, out vec3 lightDir, out float attenuation)
 {
-	lightDir = normalize(lightPosition[i].xyz);
+	lightDir = normalize(lights[i].position.xyz);
 	attenuation = 1.0;
-	if (lightType[i] != LT_DIRECTIONAL) {
+	if (lights[i].light_type != LT_DIRECTIONAL) {
 		// Positional light source
-		float dist = distance(lightPosition[i].xyz, fragPosition.xyz);
-		lightDir = (lightPosition[i].xyz - fragPosition.xyz);
+		float dist = distance(lights[i].position.xyz, fragPosition.xyz);
+		lightDir = (lights[i].position.xyz - fragPosition.xyz);
 
-		if (lightType[i] == LT_TUBE) {  // Tube light
-			float beamlength = length(lightDirection[i]);
-			vec3 beamDir = normalize(lightDirection[i]);
+		if (lights[i].light_type == LT_TUBE) {  // Tube light
+			float beamlength = length(lights[i].direction);
+			vec3 beamDir = normalize(lights[i].direction);
 			// Get nearest point on line
-			float neardist = dot(fragPosition.xyz - lightPosition[i].xyz, beamDir);
+			float neardist = dot(fragPosition.xyz - lights[i].position.xyz, beamDir);
 			// Move back from the endpoint of the beam along the beam by the distance we calculated
-			vec3 nearest = lightPosition[i].xyz - beamDir * abs(neardist);
+			vec3 nearest = lights[i].position.xyz - beamDir * abs(neardist);
 			lightDir = nearest - fragPosition.xyz;
 			dist = length(lightDir);
 		}
 
 		lightDir = normalize(lightDir);
-		attenuation = 1.0 / (1.0 + lightAttenuation[i] * dist);
+		attenuation = 1.0 / (1.0 + lights[i].attenuation * dist);
 	}
 }
 vec3 CalculateLighting(vec3 normal, vec3 diffuseMaterial, vec3 specularMaterial, float gloss, float fresnel, float shadow, float aoFactor)
@@ -245,10 +285,7 @@ vec3 CalculateLighting(vec3 normal, vec3 diffuseMaterial, vec3 specularMaterial,
 	vec3 lightDiffuse = vec3(0.0, 0.0, 0.0);
 	vec3 lightSpecular = vec3(0.0, 0.0, 0.0);
 	#pragma optionNV unroll all
-	for (int i = 0; i < MAX_LIGHTS; ++i) {
-		if (i > n_lights)
-			break;
-
+	for (int i = 0; i < n_lights; ++i) {
         if(i > 0) {
             shadow = 1.0;
         }
@@ -260,8 +297,8 @@ vec3 CalculateLighting(vec3 normal, vec3 diffuseMaterial, vec3 specularMaterial,
 		vec3 halfVec = normalize(lightDir + eyeDir);
 		float NdotL = max(dot(normal, lightDir), 0.0);
 		// Ambient, Diffuse, and Specular
-		lightDiffuse += (lightDiffuseColor[i].rgb * diffuseFactor * NdotL * attenuation) * shadow;
-		lightSpecular += lightSpecColor[i] * SpecularBlinnPhong(specularMaterial, lightDir, normal, halfVec, exp2(10.0 * gloss + 1.0), fresnel, NdotL) * attenuation * shadow;
+		lightDiffuse += (lights[i].diffuse_color.rgb * diffuseFactor * NdotL * attenuation) * shadow;
+		lightSpecular += lights[i].spec_color * SpecularBlinnPhong(specularMaterial, lightDir, normal, halfVec, exp2(10.0 * gloss + 1.0), fresnel, NdotL) * attenuation * shadow;
 	}
 	return diffuseMaterial * (lightAmbient + lightDiffuse) + lightSpecular;
 }

--- a/code/def_files/main-g.sdr
+++ b/code/def_files/main-g.sdr
@@ -6,7 +6,96 @@ layout (triangle_strip, max_vertices = 3) out;
 layout(invocations = 4) in;
 #endif
 
-uniform mat4 shadow_proj_matrix[4];
+#define MAX_LIGHTS 8
+struct model_light {
+	vec4 position;
+
+	vec3 diffuse_color;
+	int light_type;
+
+	vec3 spec_color;
+	float attenuation;
+
+	vec3 direction;
+};
+
+layout (std140) uniform modelData {
+	mat4 modelViewMatrix;
+	mat4 modelMatrix;
+	mat4 viewMatrix;
+	mat4 projMatrix;
+	mat4 textureMatrix;
+	mat4 shadow_mv_matrix;
+	mat4 shadow_proj_matrix[4];
+	mat4 envMatrix;
+
+	vec4 color;
+
+	model_light lights[MAX_LIGHTS];
+
+	float extrudeWidth;
+	float fogStart;
+	float fogScale;
+	int buffer_matrix_offset;
+
+	vec4 clip_equation;
+
+	float thruster_scale;
+	bool use_clip_plane;
+	int n_lights;
+	float defaultGloss;
+
+	vec3 ambientFactor;
+	int desaturate;
+
+	vec3 diffuseFactor;
+	int blend_alpha;
+
+	vec3 emissionFactor;
+	bool overrideDiffuse;
+
+	vec3 diffuseClr;
+	bool overrideGlow;
+
+	vec3 glowClr;
+	bool overrideSpec;
+
+	vec3 specClr;
+	bool alphaGloss;
+
+	bool gammaSpec;
+	bool envGloss;
+	bool alpha_spec;
+	int effect_num;
+
+	vec4 fogColor;
+
+	vec3 base_color;
+	float anim_timer;
+
+	vec3 stripe_color;
+	float vpwidth;
+
+	float vpheight;
+	bool team_glow_enabled;
+	float znear;
+	float zfar;
+
+	float veryneardist;
+	float neardist;
+	float middist;
+	float fardist;
+
+	vec2 normalAlphaMinMax;
+	int sBasemapIndex;
+	int sGlowmapIndex;
+
+	int sSpecmapIndex;
+	int sNormalmapIndex;
+	int sAmbientmapIndex;
+	int sMiscmapIndex;
+};
+
 #if !defined(GL_ARB_gpu_shader5)
 in float geoInstance[];
 #endif

--- a/code/def_files/main-v.sdr
+++ b/code/def_files/main-v.sdr
@@ -1,34 +1,112 @@
 #extension GL_ARB_gpu_shader5: enable
 
+#define MAX_LIGHTS 8
+
+struct model_light {
+	vec4 position;
+
+	vec3 diffuse_color;
+	int light_type;
+
+	vec3 spec_color;
+	float attenuation;
+
+	vec3 direction;
+};
+
+layout (std140) uniform modelData {
+	mat4 modelViewMatrix;
+	mat4 modelMatrix;
+	mat4 viewMatrix;
+	mat4 projMatrix;
+	mat4 textureMatrix;
+	mat4 shadow_mv_matrix;
+	mat4 shadow_proj_matrix[4];
+	mat4 envMatrix;
+
+	vec4 color;
+
+	model_light lights[MAX_LIGHTS];
+
+	float extrudeWidth;
+	float fogStart;
+	float fogScale;
+	int buffer_matrix_offset;
+
+	vec4 clip_equation;
+
+	float thruster_scale;
+	bool use_clip_plane;
+	int n_lights;
+	float defaultGloss;
+
+	vec3 ambientFactor;
+	int desaturate;
+
+	vec3 diffuseFactor;
+	int blend_alpha;
+
+	vec3 emissionFactor;
+	bool overrideDiffuse;
+
+	vec3 diffuseClr;
+	bool overrideGlow;
+
+	vec3 glowClr;
+	bool overrideSpec;
+
+	vec3 specClr;
+	bool alphaGloss;
+
+	bool gammaSpec;
+	bool envGloss;
+	bool alpha_spec;
+	int effect_num;
+
+	vec4 fogColor;
+
+	vec3 base_color;
+	float anim_timer;
+
+	vec3 stripe_color;
+	float vpwidth;
+
+	float vpheight;
+	bool team_glow_enabled;
+	float znear;
+	float zfar;
+
+	float veryneardist;
+	float neardist;
+	float middist;
+	float fardist;
+
+	vec2 normalAlphaMinMax;
+	int sBasemapIndex;
+	int sGlowmapIndex;
+
+	int sSpecmapIndex;
+	int sNormalmapIndex;
+	int sAmbientmapIndex;
+	int sMiscmapIndex;
+};
+
 in vec4 vertPosition;
 in vec4 vertTexCoord;
 in vec3 vertNormal;
 in vec4 vertTangent;
 in float vertModelID;
-uniform mat4 modelViewMatrix;
-uniform mat4 modelMatrix;
-uniform mat4 viewMatrix;
-uniform mat4 projMatrix;
-uniform mat4 textureMatrix;
-uniform vec4 color;
-#ifdef FLAG_NORMAL_EXTRUDE
-uniform float extrudeWidth;
-#endif
 #ifdef FLAG_ENV_MAP
-uniform mat4 envMatrix;
 out vec3 fragEnvReflect;
 #endif
 #ifdef FLAG_NORMAL_MAP
 out mat3 fragTangentMatrix;
 #endif
 #ifdef FLAG_FOG
-uniform float fogStart;
-uniform float fogScale;
 out float fragFogDist;
 #endif
 #ifdef FLAG_TRANSFORM
 uniform samplerBuffer transform_tex;
-uniform int buffer_matrix_offset;
 #ifdef FLAG_SHADOW_MAP
 out float geoNotVisible;
 #else
@@ -39,7 +117,6 @@ out float fragNotVisible;
 #if !defined(GL_ARB_gpu_shader5)
 out float geoInstance;
 #endif
-uniform mat4 shadow_proj_matrix[4];
 out vec3 geoNormal;
 out vec4 geoTexCoord;
 #else
@@ -48,17 +125,8 @@ out vec3 fragNormal;
 out vec4 fragTexCoord;
 #endif
 #ifdef FLAG_SHADOWS
-uniform mat4 shadow_mv_matrix;
-uniform mat4 shadow_proj_matrix[4];
 out vec4 fragShadowUV[4];
 out vec4 fragShadowPos;
-#endif
-#ifdef FLAG_THRUSTER
-uniform float thruster_scale;
-#endif
-#ifdef FLAG_CLIP
-uniform int use_clip_plane;
-uniform vec4 clip_equation;
 #endif
 #ifdef FLAG_TRANSFORM
 #define TEXELS_PER_MATRIX 4
@@ -149,7 +217,7 @@ void main()
 	fragFogDist = clamp((gl_Position.z - fogStart) * 0.75 * fogScale, 0.0, 1.0);
  #endif
  #ifdef FLAG_CLIP
-	if(use_clip_plane == 1) {
+	if(use_clip_plane) {
 		gl_ClipDistance[0] = dot(clip_equation, modelMatrix * orient * vertex);
 	} else {
 		gl_ClipDistance[0] = -1.0f;

--- a/code/graphics/2d.cpp
+++ b/code/graphics/2d.cpp
@@ -2253,7 +2253,7 @@ static void uniform_buffer_managers_deinit() {
 	}
 }
 static void uniform_buffer_managers_retire_buffers() {
-	GR_DEBUG_SCOPE("Retiring uniform buffers");
+	GR_DEBUG_SCOPE("Retiring unused uniform buffers");
 
 	for (auto& manager: uniform_buffer_managers) {
 		manager->retireBuffers();

--- a/code/graphics/2d.h
+++ b/code/graphics/2d.h
@@ -118,6 +118,10 @@ public:
 
 		Current_transform = Stack.back();
 	}
+
+	size_t depth() {
+		return Stack.size();
+	}
 };
 
 enum primitive_type {
@@ -185,6 +189,7 @@ enum shader_type {
 
 enum class uniform_block_type {
 	Lights = 0,
+	ModelData = 1,
 
 	NUM_BLOCK_TYPES
 };
@@ -707,7 +712,6 @@ typedef struct screen {
 	void (*gf_update_buffer_data)(int handle, size_t size, void* data);
 	void (*gf_update_buffer_data_offset)(int handle, size_t offset, size_t size, void* data);
 	void (*gf_update_transform_buffer)(void* data, size_t size);
-	void (*gf_set_transform_buffer_offset)(size_t offset);
 
 	// postprocessing effects
 	void (*gf_post_process_set_effect)(const char*, int, const vec3d*);
@@ -729,7 +733,6 @@ typedef struct screen {
 	void (*gf_zbias)(int zbias);
 
 	void (*gf_set_fill_mode)(int);
-	void (*gf_set_texture_panning)(float u, float v, bool enable);
 
 	void (*gf_set_line_width)(float width);
 
@@ -945,7 +948,6 @@ inline int gr_create_buffer(BufferType type, BufferUsageHint usage)
 #define gr_update_buffer_data			GR_CALL(*gr_screen.gf_update_buffer_data)
 #define gr_update_buffer_data_offset	GR_CALL(*gr_screen.gf_update_buffer_data_offset)
 #define gr_update_transform_buffer		GR_CALL(*gr_screen.gf_update_transform_buffer)
-#define gr_set_transform_buffer_offset	GR_CALL(*gr_screen.gf_set_transform_buffer_offset)
 
 #define gr_scene_texture_begin			GR_CALL(*gr_screen.gf_scene_texture_begin)
 #define gr_scene_texture_end			GR_CALL(*gr_screen.gf_scene_texture_end)
@@ -966,7 +968,6 @@ inline void gr_post_process_restore_zbuffer() {
 
 #define	gr_zbias						GR_CALL(*gr_screen.gf_zbias)
 #define	gr_set_fill_mode				GR_CALL(*gr_screen.gf_set_fill_mode)
-#define	gr_set_texture_panning			GR_CALL(*gr_screen.gf_set_texture_panning)
 
 #define gr_set_line_width				GR_CALL(*gr_screen.gf_set_line_width)
 

--- a/code/graphics/grstub.cpp
+++ b/code/graphics/grstub.cpp
@@ -131,11 +131,6 @@ void gr_stub_update_transform_buffer(void* data, size_t size)
 
 }
 
-void gr_stub_set_transform_buffer_offset(size_t offset)
-{
-
-}
-
 void gr_stub_set_clear_color(int r, int g, int b)
 {
 }
@@ -249,10 +244,6 @@ void gr_stub_deferred_lighting_end()
 }
 
 void gr_stub_deferred_lighting_finish()
-{
-}
-
-void gr_stub_set_texture_panning(float u, float v, bool enable)
 {
 }
 
@@ -472,7 +463,6 @@ bool gr_stub_init()
 	gr_screen.gf_set_texture_addressing	= gr_stub_set_texture_addressing;
 	gr_screen.gf_zbias					= gr_stub_zbias_stub;
 	gr_screen.gf_set_fill_mode			= gr_set_fill_mode_stub;
-	gr_screen.gf_set_texture_panning	= gr_stub_set_texture_panning;
 
 	gr_screen.gf_create_buffer	= gr_stub_create_buffer;
 	gr_screen.gf_delete_buffer		= gr_stub_delete_buffer;
@@ -480,7 +470,6 @@ bool gr_stub_init()
 	gr_screen.gf_update_transform_buffer	= gr_stub_update_transform_buffer;
 	gr_screen.gf_update_buffer_data		= gr_stub_update_buffer_data;
 	gr_screen.gf_update_buffer_data_offset = gr_stub_update_buffer_data_offset;
-	gr_screen.gf_set_transform_buffer_offset	= gr_stub_set_transform_buffer_offset;
 
 	gr_screen.gf_post_process_set_effect	= gr_stub_post_process_set_effect;
 	gr_screen.gf_post_process_set_defaults	= gr_stub_post_process_set_defaults;

--- a/code/graphics/light.h
+++ b/code/graphics/light.h
@@ -3,20 +3,12 @@
 
 #include "globalincs/pstypes.h"
 #include "lighting/lighting.h"
-
-struct gr_light_uniform_data {
-	vec4 *Position;
-	vec3d *Diffuse_color;
-	vec3d *Spec_color;
-	vec3d *Direction;
-	int *Light_type;
-	float *Attenuation;
-};
-
-extern gr_light_uniform_data gr_light_uniforms;
+#include "graphics/util/uniform_structs.h"
 
 //Variables
-extern const int gr_max_lights;
+extern graphics::model_light gr_light_uniforms[graphics::MAX_UNIFORM_LIGHTS];
+
+//Variables
 extern int Num_active_gr_lights;
 
 extern const float gr_light_color[4];

--- a/code/graphics/material.cpp
+++ b/code/graphics/material.cpp
@@ -186,12 +186,12 @@ void material::set_shader_type(shader_type init_sdr_type)
 	Sdr_type = init_sdr_type;
 }
 
-uint material::get_shader_flags()
+uint material::get_shader_flags() const
 {
 	return 0;
 }
 
-int material::get_shader_handle()
+int material::get_shader_handle() const
 {
 	return gr_maybe_create_shader(Sdr_type, get_shader_flags());
 }
@@ -203,14 +203,14 @@ void material::set_texture_map(int tex_type, int texture_num)
 	Texture_maps[tex_type] = texture_num;
 }
 
-int material::get_texture_map(int tex_type)
+int material::get_texture_map(int tex_type) const
 {
 	Assert(tex_type > -1 && tex_type < TM_NUM_TYPES);
 
 	return Texture_maps[tex_type];
 }
 
-bool material::is_textured()
+bool material::is_textured() const
 {
 	return 
 	Texture_maps[TM_BASE_TYPE]		> -1 ||
@@ -226,7 +226,7 @@ void material::set_texture_type(texture_type t_type)
 	Tex_type = t_type;
 }
 
-int material::get_texture_type()
+int material::get_texture_type() const
 {
 	switch ( Tex_type ) {
 	default:
@@ -241,7 +241,7 @@ int material::get_texture_type()
 	}
 }
 
-bool material::is_clipped()
+bool material::is_clipped() const
 {
 	return Clip_params.enabled;
 }
@@ -258,7 +258,7 @@ void material::set_clip_plane()
 	Clip_params.enabled = false;
 }
 
-material::clip_plane& material::get_clip_plane()
+const material::clip_plane& material::get_clip_plane() const
 {
 	return Clip_params;
 }
@@ -268,7 +268,7 @@ void material::set_texture_addressing(int addressing)
 	Texture_addressing = addressing;
 }
 
-int material::get_texture_addressing()
+int material::get_texture_addressing() const
 {
 	return Texture_addressing;
 }
@@ -288,12 +288,12 @@ void material::set_fog()
 	Fog_params.enabled = false;
 }
 
-bool material::is_fogged()
+bool material::is_fogged() const
 {
 	return Fog_params.enabled;
 }
 
-material::fog& material::get_fog()
+const material::fog& material::get_fog() const
 {
 	return Fog_params; 
 }
@@ -303,7 +303,7 @@ void material::set_depth_mode(gr_zbuffer_type mode)
 	Depth_mode = mode;
 }
 
-gr_zbuffer_type material::get_depth_mode()
+gr_zbuffer_type material::get_depth_mode() const
 {
 	return Depth_mode;
 }
@@ -313,7 +313,7 @@ void material::set_cull_mode(bool mode)
 	Cull_mode = mode;
 }
 
-bool material::get_cull_mode()
+bool material::get_cull_mode() const
 {
 	return Cull_mode;
 }
@@ -323,7 +323,7 @@ void material::set_fill_mode(int mode)
 	Fill_mode = mode;
 }
 
-int material::get_fill_mode()
+int material::get_fill_mode() const
 {
 	return Fill_mode;
 }
@@ -333,7 +333,7 @@ void material::set_blend_mode(gr_alpha_blend mode)
 	Blend_mode = mode;
 }
 
-gr_alpha_blend material::get_blend_mode()
+gr_alpha_blend material::get_blend_mode() const
 {
 	return Blend_mode;
 }
@@ -343,7 +343,7 @@ void material::set_depth_bias(int bias)
 	Depth_bias = bias;
 }
 
-int material::get_depth_bias()
+int material::get_depth_bias() const
 {
 	return Depth_bias;
 }
@@ -384,7 +384,7 @@ void material::set_color(color &clr_in)
 	}
 }
 
-const vec4& material::get_color()
+const vec4& material::get_color() const
 {
 	return Clr;
 }
@@ -394,7 +394,7 @@ void material::set_color_scale(float scale)
 	Clr_scale = scale;
 }
 
-float material::get_color_scale()
+float material::get_color_scale() const
 {
 	return Clr_scale;
 }
@@ -408,7 +408,7 @@ void model_material::set_desaturation(bool enabled)
 	Desaturate = enabled;
 }
 
-bool model_material::is_desaturated()
+bool model_material::is_desaturated() const
 {
 	return Desaturate;
 }
@@ -423,7 +423,7 @@ void model_material::set_light_factor(float factor)
 	Light_factor = factor;
 }
 
-float model_material::get_light_factor()
+float model_material::get_light_factor() const
 {
 	return Light_factor;
 }
@@ -433,7 +433,7 @@ void model_material::set_lighting(bool mode)
 	lighting = mode;
 } 
 
-bool model_material::is_lit()
+bool model_material::is_lit() const
 {
 	return lighting;
 }
@@ -453,7 +453,7 @@ void model_material::set_center_alpha(int c_alpha)
 	Center_alpha = c_alpha;
 }
 
-int model_material::get_center_alpha()
+int model_material::get_center_alpha() const
 {
 	return Center_alpha;
 }
@@ -463,7 +463,7 @@ void model_material::set_thrust_scale(float scale)
 	Thrust_scale = scale;
 }
 
-float model_material::get_thrust_scale()
+float model_material::get_thrust_scale() const
 {
 	return Thrust_scale;
 }
@@ -479,7 +479,7 @@ void model_material::set_team_color()
 	Team_color_set = false;
 }
 
-team_color& model_material::get_team_color()
+const team_color& model_material::get_team_color() const
 {
 	return Tm_color;
 }
@@ -496,12 +496,12 @@ void model_material::set_animated_effect()
 	Animated_timer = 0.0f;
 }
 
-int model_material::get_animated_effect()
+int model_material::get_animated_effect() const
 {
 	return Animated_effect;
 }
 
-float model_material::get_animated_effect_time()
+float model_material::get_animated_effect_time() const
 {
 	return Animated_timer;
 }
@@ -511,7 +511,7 @@ void model_material::set_batching(bool enabled)
 	Batched = enabled;
 }
 
-bool model_material::is_batched()
+bool model_material::is_batched() const
 {
 	return Batched;
 }
@@ -528,17 +528,17 @@ void model_material::set_normal_alpha()
 	Normal_alpha = false;
 }
 
-bool model_material::is_normal_alpha_active()
+bool model_material::is_normal_alpha_active() const
 {
 	return Normal_alpha;
 }
 
-float model_material::get_normal_alpha_min()
+float model_material::get_normal_alpha_min() const
 {
 	return Normal_alpha_min;
 }
 
-float model_material::get_normal_alpha_max()
+float model_material::get_normal_alpha_max() const
 {
 	return Normal_alpha_max;
 }
@@ -554,17 +554,17 @@ void model_material::set_normal_extrude()
 	Normal_extrude = false;
 }
 
-bool model_material::is_normal_extrude_active()
+bool model_material::is_normal_extrude_active() const
 {
 	return Normal_extrude;
 }
 
-float model_material::get_normal_extrude_width()
+float model_material::get_normal_extrude_width() const
 {
 	return Normal_extrude_width;
 }
 
-uint model_material::get_shader_flags()
+uint model_material::get_shader_flags() const
 {
 	uint Shader_flags = 0;
 
@@ -674,7 +674,7 @@ bool particle_material::get_point_sprite_mode()
 	return Point_sprite;
 }
 
-uint particle_material::get_shader_flags()
+uint particle_material::get_shader_flags() const
 {
 	uint flags = 0;
 

--- a/code/graphics/material.h
+++ b/code/graphics/material.h
@@ -53,51 +53,51 @@ protected:
 public:
 	material();
 
-	int get_shader_handle();
-	virtual uint get_shader_flags();
+	int get_shader_handle() const;
+	virtual uint get_shader_flags() const;
 
 	void set_texture_map(int tex_type, int texture_num);
-	int get_texture_map(int tex_type);
-	bool is_textured();
+	int get_texture_map(int tex_type) const;
+	bool is_textured() const;
 
 	void set_texture_type(texture_type t_type);
-	int get_texture_type();
+	int get_texture_type() const;
 	
-	bool is_clipped();
+	bool is_clipped() const;
 	void set_clip_plane(const vec3d &normal, const vec3d &position);
 	void set_clip_plane();
-	clip_plane& get_clip_plane();
+	const clip_plane& get_clip_plane() const;
 
 	void set_texture_addressing(int addressing);
-	int get_texture_addressing();
+	int get_texture_addressing() const;
 
 	void set_fog(int r, int g, int b, float near, float far);
 	void set_fog();
-	bool is_fogged();
-	fog& get_fog();
+	bool is_fogged() const;
+	const fog& get_fog() const;
 
 	void set_depth_mode(gr_zbuffer_type mode);
-	gr_zbuffer_type get_depth_mode();
+	gr_zbuffer_type get_depth_mode() const;
 
 	void set_cull_mode(bool mode);
-	bool get_cull_mode();
+	bool get_cull_mode() const;
 
 	void set_fill_mode(int mode);
-	int get_fill_mode();
+	int get_fill_mode() const;
 
 	void set_blend_mode(gr_alpha_blend mode);
-	gr_alpha_blend get_blend_mode();
+	gr_alpha_blend get_blend_mode() const;
 
 	void set_depth_bias(int bias);
-	int get_depth_bias();
+	int get_depth_bias() const;
 
 	void set_color(float red, float green, float blue, float alpha);
 	void set_color(int r, int g, int b, int a);
 	void set_color(color &clr_in);
-	const vec4& get_color();
+	const vec4& get_color() const;
 
 	void set_color_scale(float scale);
-	float get_color_scale();
+	float get_color_scale() const;
 };
 
 class model_material : public material
@@ -133,50 +133,50 @@ public:
 	model_material();
 
 	void set_desaturation(bool enabled);
-	bool is_desaturated();
+	bool is_desaturated() const;
 
 	void set_shadow_casting(bool enabled);
-	bool is_shadow_casting();
+	bool is_shadow_casting() const;
 
 	void set_light_factor(float factor);
-	float get_light_factor();
+	float get_light_factor() const;
 
 	void set_lighting(bool mode);
-	bool is_lit();
+	bool is_lit() const;
 
 	void set_deferred_lighting(bool enabled);
 	void set_high_dynamic_range(bool enabled);
 	
 	void set_center_alpha(int center_alpha);
-	int get_center_alpha();
+	int get_center_alpha() const;
 
 	void set_thrust_scale(float scale = -1.0f);
-	float get_thrust_scale();
+	float get_thrust_scale() const;
 
 	void set_team_color(const team_color &Team_clr);
 	void set_team_color();
-	team_color& get_team_color();
+	const team_color& get_team_color() const;
 
 	void set_animated_effect(int effect, float time);
 	void set_animated_effect();
-	int get_animated_effect();
-	float get_animated_effect_time();
+	int get_animated_effect() const;
+	float get_animated_effect_time() const;
 
 	void set_normal_alpha(float min, float max);
 	void set_normal_alpha();
-	bool is_normal_alpha_active();
-	float get_normal_alpha_min();
-	float get_normal_alpha_max();
+	bool is_normal_alpha_active() const;
+	float get_normal_alpha_min() const;
+	float get_normal_alpha_max() const;
 
 	void set_normal_extrude(float width);
 	void set_normal_extrude();
-	bool is_normal_extrude_active();
-	float get_normal_extrude_width();
+	bool is_normal_extrude_active() const;
+	float get_normal_extrude_width() const;
 
 	void set_batching(bool enabled);
-	bool is_batched();
+	bool is_batched() const;
 
-	virtual uint get_shader_flags();
+	virtual uint get_shader_flags() const override;
 };
 
 class particle_material : public material
@@ -188,7 +188,7 @@ public:
 	void set_point_sprite_mode(bool enabled);
 	bool get_point_sprite_mode();
 
-	virtual uint get_shader_flags();
+	uint get_shader_flags() const override;
 };
 
 class distortion_material: public material

--- a/code/graphics/matrix.cpp
+++ b/code/graphics/matrix.cpp
@@ -8,6 +8,8 @@ matrix4 gr_projection_matrix;
 matrix4 gr_last_projection_matrix;
 matrix4 gr_last_view_matrix;
 
+matrix4 gr_texture_matrix;
+
 matrix4 gr_env_texture_matrix;
 static bool gr_env_texture_matrix_set = false;
 
@@ -71,10 +73,6 @@ void gr_start_instance_matrix(const vec3d *offset, const matrix *rotation)
 	if (rotation == NULL) {
 		rotation = &vmd_identity_matrix;
 	}
-
-	vec3d axis;
-	float ang;
-	vm_matrix_to_rot_axis_and_angle(rotation, &ang, &axis);
 
 	gr_model_matrix_stack.push(offset, rotation);
 
@@ -296,4 +294,14 @@ void gr_reset_matrices() {
 
 	vm_matrix4_set_identity(&gr_model_view_matrix);
 	gr_model_matrix_stack.clear();
+
+	vm_matrix4_set_identity(&gr_texture_matrix);
+}
+
+void gr_set_texture_panning(float u, float v, bool enable) {
+	vm_matrix4_set_identity(&gr_texture_matrix);
+	if (enable) {
+		gr_texture_matrix.a2d[3][0] = u;
+		gr_texture_matrix.a2d[3][1] = v;
+	}
 }

--- a/code/graphics/matrix.h
+++ b/code/graphics/matrix.h
@@ -28,3 +28,7 @@ void gr_pop_scale_matrix();
 void gr_setup_viewport();
 
 void gr_reset_matrices();
+
+extern matrix4 gr_texture_matrix;
+
+void gr_set_texture_panning(float u, float v, bool enable);

--- a/code/graphics/opengl/gropengl.cpp
+++ b/code/graphics/opengl/gropengl.cpp
@@ -1124,7 +1124,6 @@ void opengl_setup_function_pointers()
 	gr_screen.gf_set_texture_addressing	= gr_opengl_set_texture_addressing;
 	gr_screen.gf_zbias					= gr_opengl_zbias;
 	gr_screen.gf_set_fill_mode			= gr_opengl_set_fill_mode;
-	gr_screen.gf_set_texture_panning	= gr_opengl_set_texture_panning;
 
 	gr_screen.gf_create_buffer	= gr_opengl_create_buffer;
 	gr_screen.gf_delete_buffer		= gr_opengl_delete_buffer;
@@ -1133,7 +1132,6 @@ void opengl_setup_function_pointers()
 	gr_screen.gf_bind_uniform_buffer = gr_opengl_bind_uniform_buffer;
 
 	gr_screen.gf_update_transform_buffer	= gr_opengl_update_transform_buffer;
-	gr_screen.gf_set_transform_buffer_offset	= gr_opengl_set_transform_buffer_offset;
 
 	gr_screen.gf_post_process_set_effect	= gr_opengl_post_process_set_effect;
 	gr_screen.gf_post_process_set_defaults	= gr_opengl_post_process_set_defaults;

--- a/code/graphics/opengl/gropenglshader.cpp
+++ b/code/graphics/opengl/gropenglshader.cpp
@@ -49,7 +49,8 @@ struct opengl_uniform_block_binding {
 };
 
 opengl_uniform_block_binding GL_uniform_blocks[] = {
-	{ uniform_block_type::Lights, "lightData" }
+	{ uniform_block_type::Lights, "lightData" },
+	{ uniform_block_type::ModelData, "modelData" },
 };
 
 /**

--- a/code/graphics/opengl/gropengltexture.cpp
+++ b/code/graphics/opengl/gropengltexture.cpp
@@ -1171,24 +1171,6 @@ int gr_opengl_preload(int bitmap_num, int is_aabitmap)
 	return retval;
 }
 
-static int GL_texture_panning_enabled = 0;
-void gr_opengl_set_texture_panning(float u, float v, bool enable)
-{
-	if (enable) {
-		vm_matrix4_set_identity(&GL_texture_matrix);
-		GL_texture_matrix.vec.pos.xyzw.x = u;
-		GL_texture_matrix.vec.pos.xyzw.y = v;
-
-
-		GL_texture_panning_enabled = 1;
-	} else if (GL_texture_panning_enabled) {
-		vm_matrix4_set_identity(&GL_texture_matrix);
-
-	
-		GL_texture_panning_enabled = 0;
-	}
-}
-
 void gr_opengl_set_texture_addressing(int mode)
 {
 	GL_CHECK_FOR_ERRORS("start of set_texture_addressing()");

--- a/code/graphics/opengl/gropengltexture.h
+++ b/code/graphics/opengl/gropengltexture.h
@@ -55,8 +55,6 @@ typedef struct tcache_slot_opengl {
 	}
 } tcache_slot_opengl;
 
-extern matrix4 GL_texture_matrix;
-
 extern int GL_min_texture_width;
 extern GLint GL_max_texture_width;
 extern int GL_min_texture_height;

--- a/code/graphics/opengl/gropengltnl.cpp
+++ b/code/graphics/opengl/gropengltnl.cpp
@@ -57,8 +57,6 @@ size_t GL_vertex_data_in = 0;
 GLint GL_max_elements_vertices = 4096;
 GLint GL_max_elements_indices = 4096;
 
-size_t GL_transform_buffer_offset = INVALID_SIZE;
-
 GLuint Shadow_map_texture = 0;
 GLuint Shadow_map_depth_texture = 0;
 GLuint shadow_fbo = 0;
@@ -313,11 +311,6 @@ GLuint opengl_get_transform_buffer_texture()
 	return GL_buffer_objects[Transform_buffer_handle].texture;
 }
 
-void gr_opengl_set_transform_buffer_offset(size_t offset)
-{
-	GL_transform_buffer_offset = offset;
-}
-
 void opengl_destroy_all_buffers()
 {
 	for ( uint i = 0; i < GL_buffer_objects.size(); i++ ) {
@@ -518,7 +511,7 @@ void opengl_create_orthographic_projection_matrix(matrix4* out, float left, floa
 	out->a1d[15] = 1.0f;
 }
 
-void gr_opengl_set_clip_plane(vec3d *clip_normal, vec3d *clip_point)
+void gr_opengl_set_clip_plane(const vec3d *clip_normal, const vec3d *clip_point)
 {
 	if ( clip_normal == NULL || clip_point == NULL ) {
 		GL_state.ClipDistance(0, false);
@@ -599,7 +592,7 @@ void opengl_tnl_set_material(material* material_info, bool set_base_map)
 
 	gr_set_fill_mode(material_info->get_fill_mode());
 
-	material::fog &fog_params = material_info->get_fog();
+	auto& fog_params = material_info->get_fog();
 
 	if ( fog_params.enabled ) {
 		gr_fog_set(GR_FOGMODE_FOG, fog_params.r, fog_params.g, fog_params.b, fog_params.dist_near, fog_params.dist_far);
@@ -609,7 +602,7 @@ void opengl_tnl_set_material(material* material_info, bool set_base_map)
 
 	gr_set_texture_addressing(material_info->get_texture_addressing());
 
-	material::clip_plane &clip_params = material_info->get_clip_plane();
+	auto& clip_params = material_info->get_clip_plane();
 
 	if ( material_info->is_clipped() ) {
 		gr_opengl_set_clip_plane(&clip_params.normal, &clip_params.position);
@@ -653,108 +646,12 @@ void opengl_tnl_set_model_material(model_material *material_info)
 	Assert( Current_shader->shader == SDR_TYPE_MODEL );
 
 	GL_state.Texture.SetShaderMode(GL_TRUE);
-	
-	Current_shader->program->Uniforms.setUniformMatrix4f("modelViewMatrix", gr_model_view_matrix);
-	Current_shader->program->Uniforms.setUniformMatrix4f("modelMatrix", gr_model_matrix_stack.get_transform());
-	Current_shader->program->Uniforms.setUniformMatrix4f("viewMatrix", gr_view_matrix);
-	Current_shader->program->Uniforms.setUniformMatrix4f("projMatrix", gr_projection_matrix);
-	Current_shader->program->Uniforms.setUniformMatrix4f("textureMatrix", GL_texture_matrix);
 
-	vec4 clr = material_info->get_color();
-	Current_shader->program->Uniforms.setUniform4f("color", clr);
-
-	if ( Current_shader->flags & SDR_FLAG_MODEL_ANIMATED ) {
-		Current_shader->program->Uniforms.setUniformf("anim_timer", material_info->get_animated_effect_time());
-		Current_shader->program->Uniforms.setUniformi("effect_num", material_info->get_animated_effect());
-		Current_shader->program->Uniforms.setUniformf("vpwidth", 1.0f / gr_screen.max_w);
-		Current_shader->program->Uniforms.setUniformf("vpheight", 1.0f / gr_screen.max_h);
-	}
-
-	if ( Current_shader->flags & SDR_FLAG_MODEL_CLIP ) {
-		if (material_info->is_clipped()) {
-			material::clip_plane &clip_info = material_info->get_clip_plane();
-			
-			Current_shader->program->Uniforms.setUniformi("use_clip_plane", 1);
-
-			vec4 clip_equation;
-			clip_equation.xyzw.x = clip_info.normal.xyz.x;
-			clip_equation.xyzw.y = clip_info.normal.xyz.y;
-			clip_equation.xyzw.z = clip_info.normal.xyz.z;
-			clip_equation.xyzw.w = -vm_vec_dot(&clip_info.normal, &clip_info.position);
-
-			Current_shader->program->Uniforms.setUniform4f("clip_equation", clip_equation);
-		} else {
-			Current_shader->program->Uniforms.setUniformi("use_clip_plane", 0);
-		}
-	}
-
-	if ( Current_shader->flags & SDR_FLAG_MODEL_LIGHT ) {
-		int num_lights = MIN(Num_active_gr_lights, gr_max_lights) - 1;
-		float light_factor = material_info->get_light_factor();
-		Current_shader->program->Uniforms.setUniformi("n_lights", num_lights);
-		Current_shader->program->Uniforms.setUniform4fv("lightPosition", gr_max_lights, gr_light_uniforms.Position);
-		Current_shader->program->Uniforms.setUniform3fv("lightDirection", gr_max_lights, gr_light_uniforms.Direction);
-		Current_shader->program->Uniforms.setUniform3fv("lightDiffuseColor", gr_max_lights, gr_light_uniforms.Diffuse_color);
-		Current_shader->program->Uniforms.setUniform3fv("lightSpecColor", gr_max_lights, gr_light_uniforms.Spec_color);
-		Current_shader->program->Uniforms.setUniform1iv("lightType", gr_max_lights, gr_light_uniforms.Light_type);
-		Current_shader->program->Uniforms.setUniform1fv("lightAttenuation", gr_max_lights, gr_light_uniforms.Attenuation);
-
-		if ( !material_info->get_center_alpha() ) {
-			Current_shader->program->Uniforms.setUniform3f("diffuseFactor", gr_light_color[0] * light_factor, gr_light_color[1] * light_factor, gr_light_color[2] * light_factor);
-			Current_shader->program->Uniforms.setUniform3f("ambientFactor", gr_light_ambient[0], gr_light_ambient[1], gr_light_ambient[2]);
-		} else {
-			//Current_shader->program->Uniforms.setUniform3f("diffuseFactor", GL_light_true_zero[0], GL_light_true_zero[1], GL_light_true_zero[2]);
-			//Current_shader->program->Uniforms.setUniform3f("ambientFactor", GL_light_true_zero[0], GL_light_true_zero[1], GL_light_true_zero[2]);
-			Current_shader->program->Uniforms.setUniform3f("diffuseFactor", gr_light_color[0] * light_factor, gr_light_color[1] * light_factor, gr_light_color[2] * light_factor);
-			Current_shader->program->Uniforms.setUniform3f("ambientFactor", gr_light_ambient[0], gr_light_ambient[1], gr_light_ambient[2]);
-		}
-
-		if ( material_info->get_light_factor() > 0.25f && !Cmdline_no_emissive ) {
-			Current_shader->program->Uniforms.setUniform3f("emissionFactor", gr_light_emission[0], gr_light_emission[1], gr_light_emission[2]);
-		} else {
-			Current_shader->program->Uniforms.setUniform3f("emissionFactor", gr_light_zero[0], gr_light_zero[1], gr_light_zero[2]);
-		}
-
-		Current_shader->program->Uniforms.setUniformf("specPower", Cmdline_ogl_spec);
-
-		if ( Gloss_override_set ) {
-			Current_shader->program->Uniforms.setUniformf("defaultGloss", Gloss_override);
-		} else {
-			Current_shader->program->Uniforms.setUniformf("defaultGloss", 0.6f); // add user configurable default gloss in the command line later
-		}
-	}
-
+	uint32_t array_index;
 	if ( Current_shader->flags & SDR_FLAG_MODEL_DIFFUSE_MAP ) {
 		Current_shader->program->Uniforms.setUniformi("sBasemap", render_pass);
 
-		if ( material_info->is_desaturated() ) {
-			Current_shader->program->Uniforms.setUniformi("desaturate", 1);
-		} else {
-			Current_shader->program->Uniforms.setUniformi("desaturate", 0);
-		}
-
-		if ( Basemap_color_override_set ) {
-			Current_shader->program->Uniforms.setUniformi("overrideDiffuse", 1);
-			Current_shader->program->Uniforms.setUniform3f("diffuseClr", Basemap_color_override[0], Basemap_color_override[1], Basemap_color_override[2]);
-		} else {
-			Current_shader->program->Uniforms.setUniformi("overrideDiffuse", 0);
-		}
-
-		switch ( material_info->get_blend_mode() ) {
-		case ALPHA_BLEND_PREMULTIPLIED:
-			Current_shader->program->Uniforms.setUniformi("blend_alpha", 1);
-			break;
-		case ALPHA_BLEND_ADDITIVE:
-			Current_shader->program->Uniforms.setUniformi("blend_alpha", 2);
-			break;
-		default:
-			Current_shader->program->Uniforms.setUniformi("blend_alpha", 0);
-			break;
-		}
-
-		uint32_t array_index = 0;
 		gr_opengl_tcache_set(material_info->get_texture_map(TM_BASE_TYPE), TCACHE_TYPE_NORMAL, &u_scale, &v_scale, &array_index, render_pass);
-		Current_shader->program->Uniforms.setUniformi("sBasemapIndex", array_index);
 		
 		++render_pass;
 	}
@@ -762,16 +659,7 @@ void opengl_tnl_set_model_material(model_material *material_info)
 	if ( Current_shader->flags & SDR_FLAG_MODEL_GLOW_MAP ) {
 		Current_shader->program->Uniforms.setUniformi("sGlowmap", render_pass);
 
-		if ( Glowmap_color_override_set ) {
-			Current_shader->program->Uniforms.setUniformi("overrideGlow", 1);
-			Current_shader->program->Uniforms.setUniform3f("glowClr", Glowmap_color_override[0], Glowmap_color_override[1], Glowmap_color_override[2]);
-		} else {
-			Current_shader->program->Uniforms.setUniformi("overrideGlow", 0);
-		}
-
-		uint32_t array_index = 0;
 		gr_opengl_tcache_set(material_info->get_texture_map(TM_GLOW_TYPE), TCACHE_TYPE_NORMAL, &u_scale, &v_scale, &array_index, render_pass);
-		Current_shader->program->Uniforms.setUniformi("sGlowmapIndex", array_index);
 
 		++render_pass;
 	}
@@ -779,42 +667,15 @@ void opengl_tnl_set_model_material(model_material *material_info)
 	if ( Current_shader->flags & SDR_FLAG_MODEL_SPEC_MAP ) {
 		Current_shader->program->Uniforms.setUniformi("sSpecmap", render_pass);
 
-		if ( Specmap_color_override_set ) {
-			Current_shader->program->Uniforms.setUniformi("overrideSpec", 1);
-			Current_shader->program->Uniforms.setUniform3f("specClr", Specmap_color_override[0], Specmap_color_override[1], Specmap_color_override[2]);
-		} else {
-			Current_shader->program->Uniforms.setUniformi("overrideSpec", 0);
-		}
-
-		uint32_t array_index = 0;
 		if ( material_info->get_texture_map(TM_SPEC_GLOSS_TYPE) > 0 ) {
 			gr_opengl_tcache_set(material_info->get_texture_map(TM_SPEC_GLOSS_TYPE), TCACHE_TYPE_NORMAL, &u_scale, &v_scale, &array_index, render_pass);
-
-			Current_shader->program->Uniforms.setUniformi("gammaSpec", 1);
-
-			if ( Gloss_override_set ) {
-				Current_shader->program->Uniforms.setUniformi("alphaGloss", 0);
-			} else {
-				Current_shader->program->Uniforms.setUniformi("alphaGloss", 1);
-			}
 		} else {
 			gr_opengl_tcache_set(material_info->get_texture_map(TM_SPECULAR_TYPE), TCACHE_TYPE_NORMAL, &u_scale, &v_scale, &array_index, render_pass);
-
-			Current_shader->program->Uniforms.setUniformi("gammaSpec", 0);
-			Current_shader->program->Uniforms.setUniformi("alphaGloss", 0);
 		}
-		Current_shader->program->Uniforms.setUniformi("sSpecmapIndex", array_index);
 		
 		++render_pass;
 
 		if ( Current_shader->flags & SDR_FLAG_MODEL_ENV_MAP ) {
-			if ( material_info->get_texture_map(TM_SPEC_GLOSS_TYPE) > 0 || Gloss_override_set ) {
-				Current_shader->program->Uniforms.setUniformi("envGloss", 1);
-			} else {
-				Current_shader->program->Uniforms.setUniformi("envGloss", 0);
-			}
-
-			Current_shader->program->Uniforms.setUniformMatrix4f("envMatrix", gr_env_texture_matrix);
 			Current_shader->program->Uniforms.setUniformi("sEnvmap", render_pass);
 
 			gr_opengl_tcache_set(ENVMAP, TCACHE_TYPE_CUBEMAP, &u_scale, &v_scale, &array_index, render_pass);
@@ -827,9 +688,7 @@ void opengl_tnl_set_model_material(model_material *material_info)
 	if ( Current_shader->flags & SDR_FLAG_MODEL_NORMAL_MAP ) {
 		Current_shader->program->Uniforms.setUniformi("sNormalmap", render_pass);
 
-		uint32_t array_index = 0;
 		gr_opengl_tcache_set(material_info->get_texture_map(TM_NORMAL_TYPE), TCACHE_TYPE_NORMAL, &u_scale, &v_scale, &array_index, render_pass);
-		Current_shader->program->Uniforms.setUniformi("sNormalmapIndex", array_index);
 
 		++render_pass;
 	}
@@ -837,9 +696,7 @@ void opengl_tnl_set_model_material(model_material *material_info)
 	if ( Current_shader->flags & SDR_FLAG_MODEL_HEIGHT_MAP ) {
 		Current_shader->program->Uniforms.setUniformi("sHeightmap", render_pass);
 
-		uint32_t array_index = 0;
 		gr_opengl_tcache_set(material_info->get_texture_map(TM_HEIGHT_TYPE), TCACHE_TYPE_NORMAL, &u_scale, &v_scale, &array_index, render_pass);
-		Current_shader->program->Uniforms.setUniformi("sHeightmapIndex", array_index);
 
 		++render_pass;
 	}
@@ -847,9 +704,7 @@ void opengl_tnl_set_model_material(model_material *material_info)
 	if ( Current_shader->flags & SDR_FLAG_MODEL_AMBIENT_MAP ) {
 		Current_shader->program->Uniforms.setUniformi("sAmbientmap", render_pass);
 
-		uint32_t array_index = 0;
 		gr_opengl_tcache_set(material_info->get_texture_map(TM_AMBIENT_TYPE), TCACHE_TYPE_NORMAL, &u_scale, &v_scale, &array_index, render_pass);
-		Current_shader->program->Uniforms.setUniformi("sAmbientmapIndex", array_index);
 
 		++render_pass;
 	}
@@ -857,29 +712,17 @@ void opengl_tnl_set_model_material(model_material *material_info)
 	if ( Current_shader->flags & SDR_FLAG_MODEL_MISC_MAP ) {
 		Current_shader->program->Uniforms.setUniformi("sMiscmap", render_pass);
 
-		uint32_t array_index = 0;
 		gr_opengl_tcache_set(material_info->get_texture_map(TM_MISC_TYPE), TCACHE_TYPE_NORMAL, &u_scale, &v_scale, &array_index, render_pass);
-		Current_shader->program->Uniforms.setUniformi("sMiscmapIndex", array_index);
 
 		++render_pass;
 	}
 
 	if ( Current_shader->flags & SDR_FLAG_MODEL_SHADOWS ) {
-		Current_shader->program->Uniforms.setUniformMatrix4f("shadow_mv_matrix", Shadow_view_matrix);
-		Current_shader->program->Uniforms.setUniformMatrix4fv("shadow_proj_matrix", MAX_SHADOW_CASCADES, Shadow_proj_matrix);
-		Current_shader->program->Uniforms.setUniformf("veryneardist", Shadow_cascade_distances[0]);
-		Current_shader->program->Uniforms.setUniformf("neardist", Shadow_cascade_distances[1]);
-		Current_shader->program->Uniforms.setUniformf("middist", Shadow_cascade_distances[2]);
-		Current_shader->program->Uniforms.setUniformf("fardist", Shadow_cascade_distances[3]);
 		Current_shader->program->Uniforms.setUniformi("shadow_map", render_pass);
 
 		GL_state.Texture.Enable(render_pass, GL_TEXTURE_2D_ARRAY, Shadow_map_texture);
 
 		++render_pass; // bump!
-	}
-
-	if ( Current_shader->flags & SDR_FLAG_MODEL_SHADOW_MAP ) {
-		Current_shader->program->Uniforms.setUniformMatrix4fv("shadow_proj_matrix", MAX_SHADOW_CASCADES, Shadow_proj_matrix);
 	}
 
 	if ( Current_shader->flags & SDR_FLAG_MODEL_ANIMATED ) {
@@ -897,60 +740,9 @@ void opengl_tnl_set_model_material(model_material *material_info)
 
 	if ( Current_shader->flags & SDR_FLAG_MODEL_TRANSFORM ) {
 		Current_shader->program->Uniforms.setUniformi("transform_tex", render_pass);
-		Current_shader->program->Uniforms.setUniformi("buffer_matrix_offset", (int)GL_transform_buffer_offset);
-
 		GL_state.Texture.Enable(render_pass, GL_TEXTURE_BUFFER, opengl_get_transform_buffer_texture());
 
 		++render_pass;
-	}
-
-	// Team colors are passed to the shader here, but the shader needs to handle their application.
-	// By default, this is handled through the r and g channels of the misc map, but this can be changed
-	// in the shader; test versions of this used the normal map r and b channels
-	if ( Current_shader->flags & SDR_FLAG_MODEL_TEAMCOLOR ) {
-		team_color &tm_clr = material_info->get_team_color();
-		vec3d stripe_color;
-		vec3d base_color;
-
-		stripe_color.xyz.x = tm_clr.stripe.r;
-		stripe_color.xyz.y = tm_clr.stripe.g;
-		stripe_color.xyz.z = tm_clr.stripe.b;
-
-		base_color.xyz.x = tm_clr.base.r;
-		base_color.xyz.y = tm_clr.base.g;
-		base_color.xyz.z = tm_clr.base.b;
-
-		Current_shader->program->Uniforms.setUniform3f("stripe_color", stripe_color);
-		Current_shader->program->Uniforms.setUniform3f("base_color", base_color);
-
-		if ( bm_has_alpha_channel(material_info->get_texture_map(TM_MISC_TYPE)) ) {
-			Current_shader->program->Uniforms.setUniformi("team_glow_enabled", 1);
-		} else {
-			Current_shader->program->Uniforms.setUniformi("team_glow_enabled", 0);
-		}
-	}
-
-	if ( Current_shader->flags & SDR_FLAG_MODEL_THRUSTER ) {
-		Current_shader->program->Uniforms.setUniformf("thruster_scale", material_info->get_thrust_scale());
-	}
-
-	
-	if ( Current_shader->flags & SDR_FLAG_MODEL_FOG ) {
-		material::fog fog_params = material_info->get_fog();
-
-		if ( fog_params.enabled ) {
-			Current_shader->program->Uniforms.setUniformf("fogStart", fog_params.dist_near);
-			Current_shader->program->Uniforms.setUniformf("fogScale", 1.0f / (fog_params.dist_far - fog_params.dist_near));
-			Current_shader->program->Uniforms.setUniform4f("fogColor", i2fl(fog_params.r) / 255.0f, i2fl(fog_params.g) / 255.0f, i2fl(fog_params.b) / 255.0f, 1.0f);
-		}
-	}
-
-	if ( Current_shader->flags & SDR_FLAG_MODEL_NORMAL_ALPHA ) {
-		Current_shader->program->Uniforms.setUniform2f("normalAlphaMinMax", material_info->get_normal_alpha_min(), material_info->get_normal_alpha_max());
-	}
-
-	if ( Current_shader->flags & SDR_FLAG_MODEL_NORMAL_EXTRUDE ) {
-		Current_shader->program->Uniforms.setUniformf("extrudeWidth", material_info->get_normal_extrude_width());
 	}
 
 	if ( Deferred_lighting ) {

--- a/code/graphics/opengl/gropengltnl.h
+++ b/code/graphics/opengl/gropengltnl.h
@@ -42,7 +42,6 @@ void gr_opengl_delete_buffer(int handle);
 void gr_opengl_bind_uniform_buffer(uniform_block_type bind_point, size_t offset, size_t size, int buffer);
 
 void gr_opengl_update_transform_buffer(void* data, size_t size);
-void gr_opengl_set_transform_buffer_offset(size_t offset);
 
 void opengl_tnl_init();
 void opengl_tnl_shutdown();

--- a/code/graphics/uniforms.cpp
+++ b/code/graphics/uniforms.cpp
@@ -1,0 +1,270 @@
+//
+//
+
+#include "uniforms.h"
+#include "matrix.h"
+#include "light.h"
+#include "globalincs/systemvars.h"
+#include "shadows.h"
+
+namespace {
+void scale_matrix(matrix4& mat, const vec3d& scale) {
+	mat.a2d[0][0] *= scale.xyz.x;
+	mat.a2d[0][1] *= scale.xyz.x;
+	mat.a2d[0][2] *= scale.xyz.x;
+
+	mat.a2d[1][0] *= scale.xyz.y;
+	mat.a2d[1][1] *= scale.xyz.y;
+	mat.a2d[1][2] *= scale.xyz.y;
+
+	mat.a2d[2][0] *= scale.xyz.z;
+	mat.a2d[2][1] *= scale.xyz.z;
+	mat.a2d[2][2] *= scale.xyz.z;
+}
+}
+
+namespace graphics {
+namespace uniforms {
+
+void convert_model_material(model_uniform_data* data_out,
+							const model_material& material,
+							const matrix4& model_transform,
+							const vec3d& scale,
+							size_t transform_buffer_offset) {
+	auto shader_flags = material.get_shader_flags();
+
+	Assertion(gr_model_matrix_stack.depth() == 1, "Uniform conversion does not respect previous transforms! "
+		"Model matrix stack must be empty!");
+
+	matrix4 scaled_matrix = model_transform;
+	scale_matrix(scaled_matrix, scale);
+
+	data_out->modelMatrix = scaled_matrix;
+	data_out->viewMatrix = gr_view_matrix;
+	vm_matrix4_x_matrix4(&data_out->modelViewMatrix, &data_out->viewMatrix, &data_out->modelMatrix);
+	data_out->projMatrix = gr_projection_matrix;
+	data_out->textureMatrix = gr_texture_matrix;
+
+	data_out->color = material.get_color();
+
+	if (shader_flags & SDR_FLAG_MODEL_ANIMATED) {
+		data_out->anim_timer = material.get_animated_effect_time();
+		data_out->effect_num = material.get_animated_effect();
+		data_out->vpwidth = 1.0f / i2fl(gr_screen.max_w);
+		data_out->vpheight = 1.0f / i2fl(gr_screen.max_h);
+	}
+
+	if (shader_flags & SDR_FLAG_MODEL_CLIP) {
+		if (material.is_clipped()) {
+			auto& clip_info = material.get_clip_plane();
+
+			data_out->use_clip_plane = true;
+
+			vec4 clip_equation;
+			clip_equation.xyzw.x = clip_info.normal.xyz.x;
+			clip_equation.xyzw.y = clip_info.normal.xyz.y;
+			clip_equation.xyzw.z = clip_info.normal.xyz.z;
+			clip_equation.xyzw.w = -vm_vec_dot(&clip_info.normal, &clip_info.position);
+			data_out->clip_equation = clip_equation;
+		} else {
+			data_out->use_clip_plane = false;
+		}
+	}
+
+	if (shader_flags & SDR_FLAG_MODEL_LIGHT) {
+		int num_lights = MIN(Num_active_gr_lights, (int)graphics::MAX_UNIFORM_LIGHTS);
+		data_out->n_lights = num_lights;
+
+		std::copy(std::begin(gr_light_uniforms), std::end(gr_light_uniforms), std::begin(data_out->lights));
+
+		float light_factor = material.get_light_factor();
+		data_out->diffuseFactor.xyz.x = gr_light_color[0] * light_factor;
+		data_out->diffuseFactor.xyz.y = gr_light_color[1] * light_factor;
+		data_out->diffuseFactor.xyz.z = gr_light_color[2] * light_factor;
+		data_out->ambientFactor.xyz.x = gr_light_ambient[0];
+		data_out->ambientFactor.xyz.y = gr_light_ambient[1];
+		data_out->ambientFactor.xyz.z = gr_light_ambient[2];
+
+		if (material.get_light_factor() > 0.25f && !Cmdline_no_emissive) {
+			data_out->emissionFactor.xyz.x = gr_light_emission[0];
+			data_out->emissionFactor.xyz.y = gr_light_emission[1];
+			data_out->emissionFactor.xyz.z = gr_light_emission[2];
+		} else {
+			data_out->emissionFactor.xyz.x = gr_light_zero[0];
+			data_out->emissionFactor.xyz.y = gr_light_zero[1];
+			data_out->emissionFactor.xyz.z = gr_light_zero[2];
+		}
+
+		if (Gloss_override_set) {
+			data_out->defaultGloss = Gloss_override;
+		} else {
+			data_out->defaultGloss = 0.6f;
+		}
+	}
+
+	if (shader_flags & SDR_FLAG_MODEL_DIFFUSE_MAP) {
+		if (material.is_desaturated()) {
+			data_out->desaturate = 1;
+		} else {
+			data_out->desaturate = 0;
+		}
+
+		if (Basemap_color_override_set) {
+			data_out->overrideDiffuse = 1;
+			data_out->diffuseClr.xyz.x = Basemap_color_override[0];
+			data_out->diffuseClr.xyz.y = Basemap_color_override[1];
+			data_out->diffuseClr.xyz.z = Basemap_color_override[2];
+		} else {
+			data_out->overrideDiffuse = 0;
+		}
+
+		switch (material.get_blend_mode()) {
+		case ALPHA_BLEND_PREMULTIPLIED:
+			data_out->blend_alpha = 1;
+			break;
+		case ALPHA_BLEND_ADDITIVE:
+			data_out->blend_alpha = 2;
+			break;
+		default:
+			data_out->blend_alpha = 0;
+			break;
+		}
+
+		data_out->sBasemapIndex = bm_get_array_index(material.get_texture_map(TM_BASE_TYPE));
+	}
+
+	if (shader_flags & SDR_FLAG_MODEL_GLOW_MAP) {
+		if (Glowmap_color_override_set) {
+			data_out->overrideGlow = 1;
+			data_out->glowClr.xyz.x = Glowmap_color_override[0];
+			data_out->glowClr.xyz.y = Glowmap_color_override[1];
+			data_out->glowClr.xyz.z = Glowmap_color_override[2];
+		} else {
+			data_out->overrideGlow = 0;
+		}
+		data_out->sGlowmapIndex = bm_get_array_index(material.get_texture_map(TM_GLOW_TYPE));
+	}
+
+	if (shader_flags & SDR_FLAG_MODEL_SPEC_MAP) {
+		if (Specmap_color_override_set) {
+			data_out->overrideSpec = 1;
+			data_out->specClr.xyz.x = Specmap_color_override[0];
+			data_out->specClr.xyz.y = Specmap_color_override[1];
+			data_out->specClr.xyz.z = Specmap_color_override[2];
+		} else {
+			data_out->overrideSpec = 0;
+		}
+
+		if (material.get_texture_map(TM_SPEC_GLOSS_TYPE) > 0) {
+			data_out->sSpecmapIndex = bm_get_array_index(material.get_texture_map(TM_SPEC_GLOSS_TYPE));
+
+			data_out->gammaSpec = 1;
+
+			if (Gloss_override_set) {
+				data_out->alphaGloss = 0;
+			} else {
+				data_out->alphaGloss = 1;
+			}
+		} else {
+			data_out->sSpecmapIndex = bm_get_array_index(material.get_texture_map(TM_SPECULAR_TYPE));
+
+			data_out->gammaSpec = 0;
+			data_out->alphaGloss = 0;
+		}
+
+		if (shader_flags & SDR_FLAG_MODEL_ENV_MAP) {
+			if (material.get_texture_map(TM_SPEC_GLOSS_TYPE) > 0 || Gloss_override_set) {
+				data_out->envGloss = 1;
+			} else {
+				data_out->envGloss = 0;
+			}
+
+			data_out->envMatrix = gr_env_texture_matrix;
+		}
+	}
+
+	if ( shader_flags & SDR_FLAG_MODEL_NORMAL_MAP ) {
+		data_out->sNormalmapIndex = bm_get_array_index(material.get_texture_map(TM_NORMAL_TYPE));
+	}
+
+	if ( shader_flags & SDR_FLAG_MODEL_AMBIENT_MAP ) {
+		data_out->sAmbientmapIndex = bm_get_array_index(material.get_texture_map(TM_AMBIENT_TYPE));
+	}
+
+	if ( shader_flags & SDR_FLAG_MODEL_MISC_MAP ) {
+		data_out->sMiscmapIndex = bm_get_array_index(material.get_texture_map(TM_MISC_TYPE));
+	}
+
+	if (shader_flags & SDR_FLAG_MODEL_SHADOWS) {
+		data_out->shadow_mv_matrix = Shadow_view_matrix;
+
+		for (size_t i = 0; i < MAX_SHADOW_CASCADES; ++i) {
+			data_out->shadow_proj_matrix[i] = Shadow_proj_matrix[i];
+		}
+
+		data_out->veryneardist = Shadow_cascade_distances[0];
+		data_out->neardist = Shadow_cascade_distances[1];
+		data_out->middist = Shadow_cascade_distances[2];
+		data_out->fardist = Shadow_cascade_distances[3];
+	}
+
+	if (shader_flags & SDR_FLAG_MODEL_SHADOW_MAP) {
+		for (size_t i = 0; i < MAX_SHADOW_CASCADES; ++i) {
+			data_out->shadow_proj_matrix[i] = Shadow_proj_matrix[i];
+		}
+	}
+
+	if (shader_flags & SDR_FLAG_MODEL_TRANSFORM) {
+		data_out->buffer_matrix_offset = (int) transform_buffer_offset;
+	}
+
+	// Team colors are passed to the shader here, but the shader needs to handle their application.
+	// By default, this is handled through the r and g channels of the misc map, but this can be changed
+	// in the shader; test versions of this used the normal map r and b channels
+	if (shader_flags & SDR_FLAG_MODEL_TEAMCOLOR) {
+		auto& tm_clr = material.get_team_color();
+		vec3d stripe_color;
+		vec3d base_color;
+
+		stripe_color.xyz.x = tm_clr.stripe.r;
+		stripe_color.xyz.y = tm_clr.stripe.g;
+		stripe_color.xyz.z = tm_clr.stripe.b;
+
+		base_color.xyz.x = tm_clr.base.r;
+		base_color.xyz.y = tm_clr.base.g;
+		base_color.xyz.z = tm_clr.base.b;
+
+		data_out->stripe_color = stripe_color;
+		data_out->base_color = base_color;
+	}
+
+	if (shader_flags & SDR_FLAG_MODEL_THRUSTER) {
+		data_out->thruster_scale = material.get_thrust_scale();
+	}
+
+
+	if (shader_flags & SDR_FLAG_MODEL_FOG) {
+		material::fog fog_params = material.get_fog();
+
+		if (fog_params.enabled) {
+			data_out->fogStart = fog_params.dist_near;
+			data_out->fogScale = 1.0f / (fog_params.dist_far - fog_params.dist_near);
+			data_out->fogColor.xyzw.x = i2fl(fog_params.r) / 255.0f;
+			data_out->fogColor.xyzw.y = i2fl(fog_params.g) / 255.0f;
+			data_out->fogColor.xyzw.z = i2fl(fog_params.b) / 255.0f;
+			data_out->fogColor.xyzw.w = 1.0f;
+		}
+	}
+
+	if (shader_flags & SDR_FLAG_MODEL_NORMAL_ALPHA) {
+		data_out->normalAlphaMinMax.x = material.get_normal_alpha_min();
+		data_out->normalAlphaMinMax.y = material.get_normal_alpha_max();
+	}
+
+	if (shader_flags & SDR_FLAG_MODEL_NORMAL_EXTRUDE) {
+		data_out->extrudeWidth = material.get_normal_extrude_width();
+	}
+}
+
+}
+}

--- a/code/graphics/uniforms.h
+++ b/code/graphics/uniforms.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "graphics/util/uniform_structs.h"
+#include "material.h"
+
+/**
+ * @file
+ *
+ * @brief Contains procedures for converting rendering data into their GPU uniform representations
+ */
+
+namespace graphics {
+namespace uniforms {
+
+void convert_model_material(model_uniform_data* data_out,
+							const model_material& material,
+							const matrix4& model_transform,
+							const vec3d& scale,
+							size_t transform_buffer_offset);
+
+}
+}

--- a/code/graphics/util/UniformAligner.cpp
+++ b/code/graphics/util/UniformAligner.cpp
@@ -80,5 +80,8 @@ void* UniformAligner::getData() {
 void UniformAligner::clear() {
 	resize(0);
 }
+size_t UniformAligner::getCurrentOffset() {
+	return getOffset(getNumElements() - 1);
+}
 }
 }

--- a/code/graphics/util/UniformAligner.h
+++ b/code/graphics/util/UniformAligner.h
@@ -61,6 +61,12 @@ class UniformAligner {
 
 	size_t getOffset(size_t index);
 
+	/**
+	 * @brief Gets the offset of the last element in the aligner
+	 * @return The offset in bytes
+	 */
+	size_t getCurrentOffset();
+
 	template<typename T>
 	T* nextTypedElement(T* currentEl) {
 		Assertion(sizeof(T) == _dataSize,

--- a/code/graphics/util/UniformBufferManager.cpp
+++ b/code/graphics/util/UniformBufferManager.cpp
@@ -9,6 +9,8 @@ size_t getElementSize(uniform_block_type type) {
 	switch (type) {
 	case uniform_block_type::Lights:
 		return sizeof(graphics::deferred_light_data);
+	case uniform_block_type::ModelData:
+		return sizeof(graphics::model_uniform_data);
 	case uniform_block_type::NUM_BLOCK_TYPES:
 	default:
 		Assertion(false, "Invalid block type encountered!");
@@ -19,6 +21,8 @@ size_t getElementSize(uniform_block_type type) {
 size_t getHeaderSize(uniform_block_type type) {
 	switch (type) {
 	case uniform_block_type::Lights:
+		return 0;
+	case uniform_block_type::ModelData:
 		return 0;
 	case uniform_block_type::NUM_BLOCK_TYPES:
 	default:
@@ -57,6 +61,8 @@ UniformBuffer* UniformBufferManager::getBuffer() {
 	return ptr;
 }
 void UniformBufferManager::retireBuffers() {
+	GR_DEBUG_SCOPE("Retiring buffers of buffer manager");
+
 	for (auto& buffer : _usedBuffers) {
 		if (!buffer->isInUse()) {
 			// This buffer will be retired soon so add it to the list before removing it from the used list

--- a/code/graphics/util/uniform_structs.h
+++ b/code/graphics/util/uniform_structs.h
@@ -32,4 +32,94 @@ struct deferred_light_data {
 	int pad0[3]; // Struct size must be 16-bytes aligned because we use vec3s
 };
 
+struct model_light {
+	vec4 position;
+	vec3d diffuse_color;
+	int light_type;
+	vec3d spec_color;
+	float attenuation;
+	vec3d direction;
+
+	float pad;
+};
+
+const size_t MAX_UNIFORM_LIGHTS = 8;
+
+struct model_uniform_data {
+	matrix4 modelViewMatrix;
+	matrix4 modelMatrix;
+	matrix4 viewMatrix;
+	matrix4 projMatrix;
+	matrix4 textureMatrix;
+	matrix4 shadow_mv_matrix;
+	matrix4 shadow_proj_matrix[4];
+	matrix4 envMatrix;
+
+	vec4 color;
+
+	model_light lights[MAX_UNIFORM_LIGHTS];
+
+	float extrudeWidth;
+	float fogStart;
+	float fogScale;
+	int buffer_matrix_offset;
+
+	vec4 clip_equation;
+
+	float thruster_scale;
+	int use_clip_plane;
+	int n_lights;
+	float defaultGloss;
+
+	vec3d ambientFactor;
+	int desaturate;
+
+	vec3d diffuseFactor;
+	int blend_alpha;
+
+	vec3d emissionFactor;
+	int overrideDiffuse;
+
+	vec3d diffuseClr;
+	int overrideGlow;
+
+	vec3d glowClr;
+	int overrideSpec;
+
+	vec3d specClr;
+	int alphaGloss;
+
+	int gammaSpec;
+	int envGloss;
+	int alpha_spec;
+	int effect_num;
+
+	vec4 fogColor;
+
+	vec3d base_color;
+	float anim_timer;
+
+	vec3d stripe_color;
+	float vpwidth;
+
+	float vpheight;
+	int team_glow_enabled;
+	float znear;
+	float zfar;
+
+	float veryneardist;
+	float neardist;
+	float middist;
+	float fardist;
+
+	vec2d normalAlphaMinMax;
+	int sBasemapIndex;
+	int sGlowmapIndex;
+
+	int sSpecmapIndex;
+	int sNormalmapIndex;
+	int sAmbientmapIndex;
+	int sMiscmapIndex;
+};
+
 }

--- a/code/jumpnode/jumpnode.cpp
+++ b/code/jumpnode/jumpnode.cpp
@@ -296,6 +296,7 @@ void CJumpNode::Render(vec3d *pos, vec3d *view_pos)
 
 	Render(&scene, pos, view_pos);
 
+	scene.init_render();
 	scene.render_all();
 	scene.render_outlines();
 

--- a/code/math/vecmat.cpp
+++ b/code/math/vecmat.cpp
@@ -2829,3 +2829,22 @@ void vm_vec_transform(vec3d *dest, vec3d *src, matrix4 *m, bool pos)
 	dest->xyz.y = temp_dest.xyzw.y;
 	dest->xyz.z = temp_dest.xyzw.z;
 }
+vec3d vm_vec4_to_vec3(const vec4& vec) {
+	vec3d out;
+
+	out.xyz.x = vec.xyzw.x;
+	out.xyz.y = vec.xyzw.y;
+	out.xyz.z = vec.xyzw.z;
+
+	return out;
+}
+vec4 vm_vec3_to_ve4(const vec3d& vec, float w) {
+	vec4 out;
+
+	out.xyzw.x = vec.xyz.x;
+	out.xyzw.y = vec.xyz.y;
+	out.xyzw.z = vec.xyz.z;
+	out.xyzw.w = w;
+
+	return out;
+}

--- a/code/math/vecmat.h
+++ b/code/math/vecmat.h
@@ -480,6 +480,21 @@ void vm_matrix4_x_matrix4(matrix4 *dest, const matrix4 *src0, const matrix4 *src
 
 float vm_vec4_dot4(float x, float y, float z, float w, const vec4 *v);
 
+/**
+ * @brief Converts a 4 component vector to a 3 component vector by discarding the w component
+ * @param vec The vector to convert
+ * @return The converted 3 component vector
+ */
+vec3d vm_vec4_to_vec3(const vec4& vec);
+
+/**
+ * @brief Converts a 3 component vector to a 4 component vector with the specified w value
+ * @param vec The first 3 components of the new vector
+ * @param w The w component of the new vector. Defaults to 1.0f which is correct for position vectors.
+ * @return The 4 component vector
+ */
+vec4 vm_vec3_to_ve4(const vec3d& vec, float w = 1.0f);
+
 #endif
 
 

--- a/code/model/modelrender.cpp
+++ b/code/model/modelrender.cpp
@@ -17,6 +17,7 @@
 #include "graphics/tmapper.h"
 #include "graphics/matrix.h"
 #include "graphics/light.h"
+#include "graphics/uniforms.h"
 #include "io/timer.h"
 #include "math/staticrand.h"
 #include "model/modelrender.h"
@@ -424,6 +425,11 @@ void model_draw_list::reset()
 	Current_scale.xyz.x = 1.0f;
 	Current_scale.xyz.y = 1.0f;
 	Current_scale.xyz.z = 1.0f;
+
+	if (_dataBuffer) {
+		_dataBuffer->finished();
+		_dataBuffer = nullptr;
+	}
 }
 
 void model_draw_list::sort_draws()
@@ -518,31 +524,12 @@ void model_draw_list::render_buffer(queued_buffer_draw &render_elements)
 	GR_DEBUG_SCOPE("Render buffer");
 	TRACE_SCOPE(tracing::RenderBuffer);
 
-	gr_set_transform_buffer_offset(render_elements.transform_buffer_offset);
-
-	if ( render_elements.render_material.is_lit() ) {
-		Scene_light_handler.setLights(&render_elements.lights);
-	} else {
-		gr_set_lighting(false, false);
-
-		Scene_light_handler.resetLightState();
-	}
-
-	matrix orient;
-	vec3d pos;
-
-	vm_matrix4_get_offset(&pos, &render_elements.transform);
-	vm_matrix4_get_orientation(&orient, &render_elements.transform);
-
-	g3_start_instance_matrix(&pos, &orient);
-
-	gr_push_scale_matrix(&render_elements.scale);
+	gr_bind_uniform_buffer(uniform_block_type::ModelData,
+						   render_elements.uniform_buffer_offset,
+						   sizeof(graphics::model_uniform_data),
+						   _dataBuffer->bufferHandle());
 
 	gr_render_model(&render_elements.render_material, render_elements.vert_src, render_elements.buffer, render_elements.texi);
-
-	gr_pop_scale_matrix();
-
-	g3_done_instance(true);
 }
 
 vec3d model_draw_list::get_view_position()
@@ -609,6 +596,8 @@ void model_draw_list::init_render(bool sort)
 	}
 
 	TransformBufferHandler.submit_buffer_data();
+
+	build_uniform_buffer();
 }
 
 void model_draw_list::render_all(gr_zbuffer_type depth_mode)
@@ -780,6 +769,41 @@ bool model_draw_list::sort_draw_pair(model_draw_list* target, const int a, const
 	}
 
 	return draw_call_a->lights.index_start < draw_call_b->lights.index_start;
+}
+void model_draw_list::build_uniform_buffer() {
+	GR_DEBUG_SCOPE("Build model uniform buffer");
+
+	TRACE_SCOPE(tracing::BuildModelUniforms);
+
+	_dataBuffer = gr_get_uniform_buffer(uniform_block_type::ModelData);
+
+	for (auto render_index : Render_keys) {
+		auto& queued_draw = Render_elements[render_index];
+
+		// Set lighting here so that it can be captured by the uniform conversion below
+		if ( queued_draw.render_material.is_lit() ) {
+			Scene_light_handler.setLights(&queued_draw.lights);
+		} else {
+			gr_set_lighting(false, false);
+
+			Scene_light_handler.resetLightState();
+		}
+
+		auto element = _dataBuffer->aligner().addTypedElement<graphics::model_uniform_data>();
+		graphics::uniforms::convert_model_material(element,
+												   queued_draw.render_material,
+												   queued_draw.transform,
+												   queued_draw.scale,
+												   queued_draw.transform_buffer_offset);
+		queued_draw.uniform_buffer_offset = _dataBuffer->aligner().getCurrentOffset();
+	}
+
+	TRACE_SCOPE(tracing::UploadModelUniforms);
+
+	_dataBuffer->submitData();
+}
+model_draw_list::~model_draw_list() {
+	reset();
 }
 
 void model_render_add_lightning( model_draw_list *scene, model_render_params* interp, polymodel *pm, bsp_info * sm )

--- a/code/model/modelrender.cpp
+++ b/code/model/modelrender.cpp
@@ -430,6 +430,8 @@ void model_draw_list::reset()
 		_dataBuffer->finished();
 		_dataBuffer = nullptr;
 	}
+
+	Render_initialized = false;
 }
 
 void model_draw_list::sort_draws()
@@ -598,12 +600,16 @@ void model_draw_list::init_render(bool sort)
 	TransformBufferHandler.submit_buffer_data();
 
 	build_uniform_buffer();
+
+	Render_initialized = true;
 }
 
 void model_draw_list::render_all(gr_zbuffer_type depth_mode)
 {
 	GR_DEBUG_SCOPE("Render draw list");
 	TRACE_SCOPE(tracing::SubmitDraws);
+
+	Assertion(Render_initialized, "init_render must be called before any render_all call!");
 
 	Scene_light_handler.resetLightState();
 
@@ -1480,7 +1486,8 @@ void submodel_render_immediate(model_render_params *render_info, int model_num, 
 	model_list.init();
 
 	submodel_render_queue(render_info, &model_list, model_num, submodel_num, orient, pos);
-	
+
+	model_list.init_render();
 	model_list.render_all();
 
 	gr_zbias(0);

--- a/code/model/modelrender.h
+++ b/code/model/modelrender.h
@@ -15,6 +15,7 @@
 #include "math/vecmat.h"
 #include "model/model.h"
 #include "mission/missionparse.h"
+#include "graphics/util/UniformBuffer.h"
 
 extern light Lights[MAX_LIGHTS];
 extern int Num_lights;
@@ -178,7 +179,8 @@ struct insignia_draw_data
 
 struct queued_buffer_draw
 {
-	size_t transform_buffer_offset;
+	size_t transform_buffer_offset = 0;
+	size_t uniform_buffer_offset = 0;
 
 	model_material render_material;
 
@@ -250,10 +252,19 @@ class model_draw_list
 	SCP_vector<insignia_draw_data> Insignias;
 	SCP_vector<outline_draw> Outlines;
 
+	graphics::util::UniformBuffer* _dataBuffer = nullptr;
+
 	static bool sort_draw_pair(model_draw_list* target, const int a, const int b);
 	void sort_draws();
+
+	void build_uniform_buffer();
 public:
 	model_draw_list();
+	~model_draw_list();
+
+	model_draw_list(const model_draw_list&) = delete;
+	model_draw_list& operator=(const model_draw_list&) = delete;
+
 	void init();
 
 	void add_submodel_to_batch(int model_num);

--- a/code/model/modelrender.h
+++ b/code/model/modelrender.h
@@ -253,7 +253,9 @@ class model_draw_list
 	SCP_vector<outline_draw> Outlines;
 
 	graphics::util::UniformBuffer* _dataBuffer = nullptr;
-
+	
+	bool Render_initialized = false; //!< A flag for checking if init_render has been called before a render_all call
+	
 	static bool sort_draw_pair(model_draw_list* target, const int a, const int b);
 	void sort_draws();
 

--- a/code/source_groups.cmake
+++ b/code/source_groups.cmake
@@ -308,6 +308,8 @@ set (file_root_graphics
 	graphics/shadows.cpp
 	graphics/shadows.h
 	graphics/tmapper.h
+	graphics/uniforms.cpp
+	graphics/uniforms.h
 )
 
 # Graphics -> OpenGLGr files

--- a/code/tracing/categories.cpp
+++ b/code/tracing/categories.cpp
@@ -49,6 +49,8 @@ Category CollisionDetection("Collision Detection", false);
 Category RenderBuffer("Render Buffer", true);
 
 Category QueueRender("Queue Render", false);
+Category BuildModelUniforms("Build Model Uniforms", false);
+Category UploadModelUniforms("Upload Model Uniforms", true);
 Category SubmitDraws("Submit Draws", true);
 Category ApplyLights("Apply Lights", true);
 Category DrawEffects("Draw Effects", true);

--- a/code/tracing/categories.h
+++ b/code/tracing/categories.h
@@ -61,6 +61,8 @@ extern Category CollisionDetection;
 extern Category RenderBuffer;
 
 extern Category QueueRender;
+extern Category BuildModelUniforms;
+extern Category UploadModelUniforms;
 extern Category SubmitDraws;
 extern Category ApplyLights;
 extern Category DrawEffects;


### PR DESCRIPTION
This uses UBOs for building a buffer object of uniform data before
using that data to draw objects. This should reduce the CPU overhead by
reducing the amount of glUniform calls required for executing a single
draw call. This is especially useful if rendering is limited by the CPU
which should help performance for people with slower CPUs.

This fixes #910.