### PR TITLE
Restore 2D matrix setting behavior

### DIFF
--- a/code/graphics/matrix.cpp
+++ b/code/graphics/matrix.cpp
@@ -11,6 +11,8 @@ matrix4 gr_last_view_matrix;
 matrix4 gr_env_texture_matrix;
 static bool gr_env_texture_matrix_set = false;
 
+bool gr_htl_projection_matrix_set = false;
+
 static int modelview_matrix_depth = 1;
 static bool htl_view_matrix_set = false;
 static int htl_2d_matrix_depth = 0;
@@ -125,6 +127,8 @@ void gr_set_proj_matrix(float fov, float aspect, float z_near, float z_far) {
 	} else {
 		create_perspective_projection_matrix(&gr_projection_matrix, -clip_width, clip_width, -clip_height, clip_height, z_near, z_far);
 	}
+
+	gr_htl_projection_matrix_set = true;
 }
 
 void gr_end_proj_matrix() {
@@ -138,6 +142,8 @@ void gr_end_proj_matrix() {
 	} else {
 		create_orthographic_projection_matrix(&gr_projection_matrix, 0.0f, i2fl(gr_screen.max_w), i2fl(gr_screen.max_h), 0.0f, -1.0f, 1.0f);
 	}
+
+	gr_htl_projection_matrix_set = false;
 }
 
 void gr_set_view_matrix(const vec3d *pos, const matrix *orient)
@@ -192,6 +198,11 @@ void gr_end_view_matrix()
 // TODO: this probably needs to accept values
 void gr_set_2d_matrix(/*int x, int y, int w, int h*/)
 {
+	// don't bother with this if we aren't even going to need it
+	if (!gr_htl_projection_matrix_set) {
+		return;
+	}
+
 	Assert( htl_2d_matrix_set == 0 );
 	Assert( htl_2d_matrix_depth == 0 );
 

--- a/code/graphics/opengl/gropengltnl.cpp
+++ b/code/graphics/opengl/gropengltnl.cpp
@@ -534,6 +534,8 @@ void gr_opengl_set_clip_plane(vec3d *clip_normal, vec3d *clip_point)
 extern bool Glowpoint_override;
 bool Glowpoint_override_save;
 
+extern bool gr_htl_projection_matrix_set;
+
 void gr_opengl_shadow_map_start(matrix4 *shadow_view_matrix, const matrix *light_orient)
 {
 	if ( !Cmdline_shadow_quality )
@@ -555,6 +557,7 @@ void gr_opengl_shadow_map_start(matrix4 *shadow_view_matrix, const matrix *light
 	Glowpoint_override_save = Glowpoint_override;
 	Glowpoint_override = true;
 
+	gr_htl_projection_matrix_set = true;
 	gr_set_view_matrix(&Eye_position, light_orient);
 
 	*shadow_view_matrix = gr_view_matrix;
@@ -575,6 +578,7 @@ void gr_opengl_shadow_map_end()
 	GL_state.PopFramebufferState();
 
 	Glowpoint_override = Glowpoint_override_save;
+	gr_htl_projection_matrix_set = false;
 
 	glViewport(gr_screen.offset_x, (gr_screen.max_h - gr_screen.offset_y - gr_screen.clip_height), gr_screen.clip_width, gr_screen.clip_height);
 	glScissor(gr_screen.offset_x, (gr_screen.max_h - gr_screen.offset_y - gr_screen.clip_height), gr_screen.clip_width, gr_screen.clip_height);


### PR DESCRIPTION
This restores the behavior from before the matrix system changes. The
observed behavior is more or less the desired behavior sinde setting the
2D projection matrix resets the model matrix stack but it happens to
work with the previous movie code since the 2D matrix is not set if no
perspective projection matrix was set before. This would need to be
fixed if the movie player should ever work within a mission but for now
this will fix the reported bug.