### PR TITLE
Use SCP_strings and SCP_vectors in SEXP code

### DIFF
--- a/code/network/multi_sexp.cpp
+++ b/code/network/multi_sexp.cpp
@@ -58,7 +58,7 @@ void sexp_network_packet::ensure_space_remains(size_t data_size)
 
     // At very least must include OP, COUNT, TERMINATOR 
     if (packet_end < 9 && !packet_flagged_invalid) {
-        Warning(LOCATION, "Sexp %s has attempted to write too much data to a single packet. It is advised that you split this SEXP up into smaller ones", Operators[Current_sexp_operator.back()].text);
+        Warning(LOCATION, "Sexp %s has attempted to write too much data to a single packet. It is advised that you split this SEXP up into smaller ones", Operators[Current_sexp_operator.back()].text.c_str());
         packet_flagged_invalid = true;
         return;
     }
@@ -109,7 +109,7 @@ bool sexp_network_packet::argument_count_is_valid()
             sexp_bytes_left--;
 
             if (possible_terminator == CALLBACK_TERMINATOR) {
-                Warning(LOCATION, "%s has returned to multi_sexp_eval() claiming %d arguments left. %d actually found. Trace out and fix this!", Operators[op_num].text, current_argument_count, i);
+                Warning(LOCATION, "%s has returned to multi_sexp_eval() claiming %d arguments left. %d actually found. Trace out and fix this!", Operators[op_num].text.c_str(), current_argument_count, i);
                 terminator_found = true;
                 break;
             }
@@ -122,13 +122,13 @@ bool sexp_network_packet::argument_count_is_valid()
 
             if (possible_terminator != CALLBACK_TERMINATOR) {
                 // discard remainder of packet if we still haven't found the terminator as it is hopelessly corrupt
-                Warning(LOCATION, "%s has returned to multi_sexp_eval() without finding the terminator. Discarding packet! Trace out and fix this!", Operators[op_num].text);
+                Warning(LOCATION, "%s has returned to multi_sexp_eval() without finding the terminator. Discarding packet! Trace out and fix this!", Operators[op_num].text.c_str());
                 sexp_bytes_left = 0;
                 return false;
             }
             else {
                 // the previous SEXP hasn't removed all it's data from the packet correctly but it appears we've managed to fix it
-                Warning(LOCATION, "%s has returned to multi_sexp_eval() without removing all the data the server wrote during its callback. Trace out and fix this!", Operators[op_num].text);
+                Warning(LOCATION, "%s has returned to multi_sexp_eval() without removing all the data the server wrote during its callback. Trace out and fix this!", Operators[op_num].text.c_str());
                 op_num = -1;
             }
         }

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -115,7 +115,7 @@
 #define FALSE	0
 
 
-sexp_oper Operators[] = {
+SCP_vector<sexp_oper> Operators = {
 //   Operator, Identity, Min / Max arguments
 	//Arithmetic Category
 	{ "+",								OP_PLUS,								2,	INT_MAX,	SEXP_ARITHMETIC_OPERATOR,	},
@@ -1569,12 +1569,11 @@ int find_argnum(int parent_node, int arg_node)
  */
 int get_operator_index(const char *token)
 {
-	int	i;
 	Assertion(token != NULL, "get_operator_index(char*) called with a null token; get a coder!\n");
 
-	for (i=0; i<Num_operators; i++){
-		if (!stricmp(token, Operators[i].text)){
-			return i;
+	for (size_t i=0; i < Operators.size(); i++){
+		if (Operators[i].text == token){
+			return (int)i;
 		}
 	}
 
@@ -25611,7 +25610,7 @@ int query_operator_return_type(int op)
 {
 	if (op < FIRST_OP)
 	{
-		Assert(op >= 0 && op < Num_operators);
+		Assert(op >= 0 && op < (int)Operators.size());
 		op = Operators[op].value;
 	}
 
@@ -26197,17 +26196,17 @@ int query_operator_argument_type(int op, int argnum)
 
 	if (op < FIRST_OP)
 	{
-		Assert(index >= 0 && index < Num_operators);
+		Assert(index >= 0 && index < (int)Operators.size());
 		op = Operators[index].value;
 
 	} else {
 		Warning(LOCATION, "Possible unnecessary search for operator index.  Trace out and see if this is necessary.\n");
 
-		for (index=0; index<Num_operators; index++)
+		for (index=0; index<(int)Operators.size(); index++)
 			if (Operators[index].value == op)
 				break;
 
-		Assert(index < Num_operators);
+		Assert(index < (int)Operators.size());
 	}
 
 	if (argnum >= Operators[index].max)
@@ -28813,11 +28812,11 @@ int query_sexp_ai_goal_valid(int sexp_ai_goal, int ship_num)
 {
 	int i, op;
 
-	for (op=0; op<Num_operators; op++)
+	for (op=0; op<(int)Operators.size(); op++)
 		if (Operators[op].value == sexp_ai_goal)
 			break;
 
-	Assert(op < Num_operators);
+	Assert(op < (int)Operators.size());
 	for (i=0; i<Num_sexp_ai_goal_links; i++)
 		if (Sexp_ai_goal_links[i].op_code == sexp_ai_goal)
 			break;
@@ -29640,9 +29639,9 @@ int eval_num(int n)
 // Goober5000
 int get_sexp_id(char *sexp_name)
 {
-	for (int i = 0; i < Num_operators; i++)
+	for (size_t i=0; i < Operators.size(); i++)
 	{
-		if (!stricmp(sexp_name, Operators[i].text))
+		if (!stricmp(sexp_name, Operators[i].text.c_str()))
 			return Operators[i].value;
 	}
 	return -1;
@@ -30124,7 +30123,7 @@ int get_subcategory(int sexp_id)
 	}
 }
 
-sexp_help_struct Sexp_help[] = {
+SCP_vector<sexp_help_struct> Sexp_help = {
 	{ OP_PLUS, "Plus (Arithmetic operator)\r\n"
 		"\tAdds numbers and returns results.\r\n\r\n"
 		"Returns a number.  Takes 2 or more numeric arguments." },
@@ -33878,28 +33877,28 @@ sexp_help_struct Sexp_help[] = {
 
 
 
-op_menu_struct op_menu[] =
+SCP_vector<op_menu_struct> op_menu =
 {
-	{ "Objectives",		OP_CATEGORY_OBJECTIVE },
-	{ "Time",			OP_CATEGORY_TIME },
-	{ "Logical",		OP_CATEGORY_LOGICAL },
-	{ "Arithmetic",		OP_CATEGORY_ARITHMETIC },
-	{ "Status",			OP_CATEGORY_STATUS },
-	{ "Change",			OP_CATEGORY_CHANGE },
-	{ "Conditionals",	OP_CATEGORY_CONDITIONAL },
-	{ "Ai goals",		OP_CATEGORY_AI },
-	{ "Event/Goals",	OP_CATEGORY_GOAL_EVENT },
-	{ "Training",		OP_CATEGORY_TRAINING },
+	{ "Objectives",		OP_CATEGORY_OBJECTIVE	},
+	{ "Time",			OP_CATEGORY_TIME		},
+	{ "Logical",		OP_CATEGORY_LOGICAL		},
+	{ "Arithmetic",		OP_CATEGORY_ARITHMETIC	},
+	{ "Status",			OP_CATEGORY_STATUS		},
+	{ "Change",			OP_CATEGORY_CHANGE		},
+	{ "Conditionals",	OP_CATEGORY_CONDITIONAL	},
+	{ "Ai goals",		OP_CATEGORY_AI			},
+	{ "Event/Goals",	OP_CATEGORY_GOAL_EVENT	},
+	{ "Training",		OP_CATEGORY_TRAINING	},
 };
 
 // Goober5000's subcategorization of the Change menu (and possibly other menus in the future,
 // if people so choose - see sexp.h)
-op_menu_struct op_submenu[] =
+SCP_vector<op_menu_struct> op_submenu =
 {
 	{	"Messages and Personas",		CHANGE_SUBCATEGORY_MESSAGING						},
 	{	"AI Control",					CHANGE_SUBCATEGORY_AI_CONTROL						},
 	{	"Ship Status",					CHANGE_SUBCATEGORY_SHIP_STATUS						},
-	{	"Weapons, Shields, and Engines",	CHANGE_SUBCATEGORY_SHIELDS_ENGINES_AND_WEAPONS		},
+	{	"Weapons, Shields, and Engines",CHANGE_SUBCATEGORY_SHIELDS_ENGINES_AND_WEAPONS		},
 	{	"Subsystems and Health",		CHANGE_SUBCATEGORY_SUBSYSTEMS						},
 	{	"Cargo",						CHANGE_SUBCATEGORY_CARGO							},
 	{	"Armor and Damage Types",		CHANGE_SUBCATEGORY_ARMOR_AND_DAMAGE_TYPES			},
@@ -33918,39 +33917,34 @@ op_menu_struct op_submenu[] =
 	{	"Other",						CHANGE_SUBCATEGORY_OTHER							},
 	{	"Mission",						STATUS_SUBCATEGORY_MISSION							},
 	{	"Player",						STATUS_SUBCATEGORY_PLAYER							},
-	{	"Multiplayer",						STATUS_SUBCATEGORY_MULTIPLAYER					},
+	{	"Multiplayer",					STATUS_SUBCATEGORY_MULTIPLAYER						},
 	{	"Ship Status",					STATUS_SUBCATEGORY_SHIP_STATUS						},
-	{	"Weapons, Shields, and Engines",	STATUS_SUBCATEGORY_SHIELDS_ENGINES_AND_WEAPONS	},
+	{	"Weapons, Shields, and Engines",STATUS_SUBCATEGORY_SHIELDS_ENGINES_AND_WEAPONS		},
 	{	"Cargo",						STATUS_SUBCATEGORY_CARGO							},
 	{	"Damage",						STATUS_SUBCATEGORY_DAMAGE							},
 	{	"Distance and Coordinates",		STATUS_SUBCATEGORY_DISTANCE_AND_COORDINATES			},
 	{	"Variables",					STATUS_SUBCATEGORY_VARIABLES						},
 	{	"Other",						STATUS_SUBCATEGORY_OTHER							},
-
-
 };
-int Num_sexp_help = sizeof(Sexp_help) / sizeof(sexp_help_struct);
-int Num_op_menus = sizeof(op_menu) / sizeof(op_menu_struct);
-int Num_submenus = sizeof(op_submenu) / sizeof(op_menu_struct);
 
 /**
  * Internal file used by output_sexps, should not be called from output_sexps
  */
 static void output_sexp_html(int sexp_idx, FILE *fp)
 {
-	if(sexp_idx < 0 || sexp_idx > Num_operators)
+	if(sexp_idx < 0 || sexp_idx > (int)Operators.size())
 		return;
 
 	bool printed=false;
 
-	for(int i = 0; i < Num_sexp_help; i++)
+	for(auto& help : Sexp_help)
 	{
-		if(Sexp_help[i].id == Operators[sexp_idx].value)
+		if(help.id == Operators[sexp_idx].value)
 		{
-			char* new_buf = new char[2*strlen(Sexp_help[i].help)];
+			char* new_buf = new char[2 * help.help.size()];
 			char* dest_ptr = new_buf;
-			const char* curr_ptr = Sexp_help[i].help;
-			const char* end_ptr = curr_ptr + strlen(Sexp_help[i].help);
+			const char* curr_ptr = help.help.c_str();
+			const char* end_ptr = curr_ptr + help.help.size();
 			while(curr_ptr < end_ptr)
 			{
 				if(*curr_ptr == '\n')
@@ -33966,7 +33960,7 @@ static void output_sexp_html(int sexp_idx, FILE *fp)
 			}
 			*dest_ptr = '\0';
 
-			fprintf(fp, "<dt><b>%s</b></dt>\n<dd>%s</dd>\n", Operators[sexp_idx].text, new_buf);
+			fprintf(fp, "<dt><b>%s</b></dt>\n<dd>%s</dd>\n", Operators[sexp_idx].text.c_str(), new_buf);
 			delete[] new_buf;
 
 			printed = true;
@@ -33974,7 +33968,7 @@ static void output_sexp_html(int sexp_idx, FILE *fp)
 	}
 
 	if(!printed)
-		fprintf(fp, "<dt><b>%s</b></dt>\n<dd>Min arguments: %d, Max arguments: %d</dd>\n", Operators[sexp_idx].text, Operators[sexp_idx].min, Operators[sexp_idx].max);
+		fprintf(fp, "<dt><b>%s</b></dt>\n<dd>Min arguments: %d, Max arguments: %d</dd>\n", Operators[sexp_idx].text.c_str(), Operators[sexp_idx].min, Operators[sexp_idx].max);
 }
 
 /**
@@ -34000,14 +33994,14 @@ bool output_sexps(const char *filepath)
 
 	//Output an overview
 	fputs("<dl>", fp);
-	for(x = 0; x < Num_op_menus; x++)
+	for(x = 0; x < (int)op_menu.size(); x++)
 	{
-		fprintf(fp, "<dt><a href=\"#%d\">%s</a></dt>", (op_menu[x].id & OP_CATEGORY_MASK), op_menu[x].name);
-		for(y = 0; y < Num_submenus; y++)
+		fprintf(fp, "<dt><a href=\"#%d\">%s</a></dt>", (op_menu[x].id & OP_CATEGORY_MASK), op_menu[x].name.c_str());
+		for(y = 0; y < (int)op_submenu.size(); y++)
 		{
 			if(((op_submenu[y].id & OP_CATEGORY_MASK) == op_menu[x].id))
 			{
-				fprintf(fp, "<dd><a href=\"#%d\">%s</a></dd>", op_submenu[y].id & (OP_CATEGORY_MASK | SUBCATEGORY_MASK), op_submenu[y].name);
+				fprintf(fp, "<dd><a href=\"#%d\">%s</a></dd>", op_submenu[y].id & (OP_CATEGORY_MASK | SUBCATEGORY_MASK), op_submenu[y].name.c_str());
 			}
 		}
 	}
@@ -34015,19 +34009,19 @@ bool output_sexps(const char *filepath)
 
 	//Output the full descriptions
 	fputs("<dl>", fp);
-	for(x = 0; x < Num_op_menus; x++)
+	for(x = 0; x < (int)op_menu.size(); x++)
 	{
-		fprintf(fp, "<dt id=\"%d\"><h2>%s</h2></dt>\n", (op_menu[x].id & OP_CATEGORY_MASK), op_menu[x].name);
+		fprintf(fp, "<dt id=\"%d\"><h2>%s</h2></dt>\n", (op_menu[x].id & OP_CATEGORY_MASK), op_menu[x].name.c_str());
 		fputs("<dd>", fp);
 		fputs("<dl>", fp);
-		for(y = 0; y < Num_submenus; y++)
+		for(y = 0; y < (int)op_submenu.size(); y++)
 		{
 			if(((op_submenu[y].id & OP_CATEGORY_MASK) == op_menu[x].id))
 			{
-				fprintf(fp, "<dt id=\"%d\"><h3>%s</h3></dt>\n", op_submenu[y].id & (OP_CATEGORY_MASK | SUBCATEGORY_MASK), op_submenu[y].name);
+				fprintf(fp, "<dt id=\"%d\"><h3>%s</h3></dt>\n", op_submenu[y].id & (OP_CATEGORY_MASK | SUBCATEGORY_MASK), op_submenu[y].name.c_str());
 				fputs("<dd>", fp);
 				fputs("<dl>", fp);
-				for(z = 0; z < Num_operators; z++)
+				for(z = 0; z < (int)Operators.size(); z++)
 				{
 					if((get_category(Operators[z].value) == op_menu[x].id)
 						&& (get_subcategory(Operators[z].value) != -1)
@@ -34040,7 +34034,7 @@ bool output_sexps(const char *filepath)
 				fputs("</dd>", fp);
 			}
 		}
-		for(z = 0; z < Num_operators; z++)
+		for(z = 0; z < (int)Operators.size(); z++)
 		{
 			if((get_category(Operators[z].value) == op_menu[x].id)
 				&& (get_subcategory(Operators[z].value) == -1))
@@ -34051,7 +34045,7 @@ bool output_sexps(const char *filepath)
 		fputs("</dl>", fp);
 		fputs("</dd>", fp);
 	}
-	for(z = 0; z < Num_operators; z++)
+	for(z = 0; z < (int)Operators.size(); z++)
 	{
 		if(!get_category(Operators[z].value))
 		{

--- a/code/parse/sexp.h
+++ b/code/parse/sexp.h
@@ -1036,7 +1036,7 @@ typedef struct sexp_ai_goal_link {
 #define SEXP_TRIGGER_OPERATOR		( SEXP_ARITHMETIC_OPERATOR | SEXP_BOOLEAN_OPERATOR | SEXP_INTEGER_OPERATOR ) 
 
 typedef struct sexp_oper {
-	const char	*text;
+	SCP_string text;
 	int	value;
 	int	min, max;
 	int type;
@@ -1100,8 +1100,8 @@ extern sexp_node *Sexp_nodes;
 extern sexp_variable Sexp_variables[MAX_SEXP_VARIABLES];
 extern sexp_variable Block_variables[MAX_SEXP_VARIABLES];
 
-extern sexp_oper Operators[];
-extern int Num_operators;
+extern SCP_vector<sexp_oper> Operators;
+
 extern int Locked_sexp_true, Locked_sexp_false;
 extern int Directive_count;
 extern int Sexp_useful_number;  // a variable to pass useful info in from external modules
@@ -1150,6 +1150,7 @@ extern int get_sexp_main(void);	//	Returns start node
 extern int run_sexp(const char* sexpression); // debug and lua sexps
 extern int stuff_sexp_variable_list();
 extern int eval_sexp(int cur_node, int referenced_node = -1);
+extern int eval_num(int n);
 extern bool is_sexp_true(int cur_node, int referenced_node = -1);
 extern int query_operator_return_type(int op);
 extern int query_operator_argument_type(int op, int argnum);
@@ -1221,22 +1222,18 @@ extern int Knossos_warp_ani_used;
 //WMC - moved here from FRED
 typedef struct sexp_help_struct {
 	int id;
-	const char *help;
+	SCP_string help;
 } sexp_help_struct;
 
-extern sexp_help_struct Sexp_help[];
+extern SCP_vector<sexp_help_struct> Sexp_help;
 
 typedef struct op_menu_struct {
-	const char *name;
+	SCP_string name;
 	int id;
 } op_menu_struct;
 
-extern op_menu_struct op_menu[];
-extern op_menu_struct op_submenu[];
-
-extern int Num_sexp_help;
-extern int Num_op_menus;
-extern int Num_submenus;
+extern SCP_vector<op_menu_struct> op_menu;
+extern SCP_vector<op_menu_struct> op_submenu;
 
 //WMC
 //Outputs sexp.html file

--- a/fred2/sexp_tree.cpp
+++ b/fred2/sexp_tree.cpp
@@ -79,9 +79,6 @@ END_MESSAGE_MAP()
 static int Add_count, Replace_count;
 static int Modify_variable;
 
-extern sexp_help_struct Sexp_help[];
-extern op_menu_struct op_menu[];
-extern op_menu_struct op_submenu[];
 
 // constructor
 sexp_tree::sexp_tree()
@@ -585,9 +582,9 @@ void sexp_tree::right_clicked(int mode)
 
 	m_mode = mode;
 	add_instance = replace_instance = -1;
-	Assert(Num_operators <= MAX_OPERATORS);
-	Assert(Num_op_menus < MAX_OP_MENUS);
-	Assert(Num_submenus < MAX_SUBMENUS);
+	Assert(Operators.size() <= MAX_OPERATORS);
+	Assert((int)op_menu.size() < MAX_OP_MENUS);
+	Assert((int)op_submenu.size() < MAX_SUBMENUS);
 
 	GetCursorPos(&mouse);
 	click_point = mouse;
@@ -631,15 +628,15 @@ void sexp_tree::right_clicked(int mode)
 		}
 
 		// add popup menus for all the operator categories
-		for (i=0; i<Num_op_menus; i++)
+		for (i=0; i<(int)op_menu.size(); i++)
 		{
 			add_op_submenu[i].CreatePopupMenu();
 			replace_op_submenu[i].CreatePopupMenu();
 			insert_op_submenu[i].CreatePopupMenu();
 
-			add_op_menu->AppendMenu(MF_POPUP, (UINT) add_op_submenu[i].m_hMenu, op_menu[i].name);
-			replace_op_menu->AppendMenu(MF_POPUP, (UINT) replace_op_submenu[i].m_hMenu, op_menu[i].name);
-			insert_op_menu->AppendMenu(MF_POPUP, (UINT) insert_op_submenu[i].m_hMenu, op_menu[i].name);
+			add_op_menu->AppendMenu(MF_POPUP, (UINT) add_op_submenu[i].m_hMenu, op_menu[i].name.c_str());
+			replace_op_menu->AppendMenu(MF_POPUP, (UINT) replace_op_submenu[i].m_hMenu, op_menu[i].name.c_str());
+			insert_op_menu->AppendMenu(MF_POPUP, (UINT) insert_op_submenu[i].m_hMenu, op_menu[i].name.c_str());
 		}
 
 		// get rid of the placeholders we needed to ensure popup menus stayed popup menus,
@@ -790,33 +787,33 @@ void sexp_tree::right_clicked(int mode)
 		}
 
 		// add all the submenu items first
-		for (i=0; i<Num_submenus; i++)
+		for (i=0; i<(int)op_submenu.size(); i++)
 		{
 			add_op_subcategory_menu[i].CreatePopupMenu();
 			replace_op_subcategory_menu[i].CreatePopupMenu();
 			insert_op_subcategory_menu[i].CreatePopupMenu();
 			
-			for (j=0; j<Num_op_menus; j++)
+			for (j=0; j<(int)op_menu.size(); j++)
 			{
 				if (op_menu[j].id == category_of_subcategory(op_submenu[i].id))
 				{
-					add_op_submenu[j].AppendMenu(MF_POPUP, (UINT) add_op_subcategory_menu[i].m_hMenu, op_submenu[i].name);
-					replace_op_submenu[j].AppendMenu(MF_POPUP, (UINT) replace_op_subcategory_menu[i].m_hMenu, op_submenu[i].name);
-					insert_op_submenu[j].AppendMenu(MF_POPUP, (UINT) insert_op_subcategory_menu[i].m_hMenu, op_submenu[i].name);
+					add_op_submenu[j].AppendMenu(MF_POPUP, (UINT) add_op_subcategory_menu[i].m_hMenu, op_submenu[i].name.c_str());
+					replace_op_submenu[j].AppendMenu(MF_POPUP, (UINT) replace_op_subcategory_menu[i].m_hMenu, op_submenu[i].name.c_str());
+					insert_op_submenu[j].AppendMenu(MF_POPUP, (UINT) insert_op_subcategory_menu[i].m_hMenu, op_submenu[i].name.c_str());
 					break;	// only 1 category valid
 				}
 			}
 		}
 
 		// add operator menu items to the various CATEGORY submenus they belong in
-		for (i=0; i<Num_operators; i++)
+		for (i=0; i<(int)Operators.size(); i++)
 		{
 			// add only if it is not in a subcategory
 			subcategory_id = get_subcategory(Operators[i].value);
 			if (subcategory_id == -1)
 			{
 				// put it in the appropriate menu
-				for (j=0; j<Num_op_menus; j++)
+				for (j=0; j<(int)op_menu.size(); j++)
 				{
 					if (op_menu[j].id == get_category(Operators[i].value))
 					{
@@ -842,14 +839,14 @@ void sexp_tree::right_clicked(int mode)
 							case OP_HUD_ACTIVATE_GAUGE_TYPE:
 							case OP_JETTISON_CARGO_DELAY:
 							case OP_STRING_CONCATENATE:
-								j = Num_op_menus;	// don't allow these operators to be visible
+								j = (int)op_menu.size();	// don't allow these operators to be visible
 								break;
 						}
 
-						if (j < Num_op_menus) {
-							add_op_submenu[j].AppendMenu(MF_STRING | MF_GRAYED, Operators[i].value, Operators[i].text);
-							replace_op_submenu[j].AppendMenu(MF_STRING | MF_GRAYED, Operators[i].value | OP_REPLACE_FLAG, Operators[i].text);
-							insert_op_submenu[j].AppendMenu(MF_STRING, Operators[i].value | OP_INSERT_FLAG, Operators[i].text);
+						if (j < (int)op_menu.size()) {
+							add_op_submenu[j].AppendMenu(MF_STRING | MF_GRAYED, Operators[i].value, Operators[i].text.c_str());
+							replace_op_submenu[j].AppendMenu(MF_STRING | MF_GRAYED, Operators[i].value | OP_REPLACE_FLAG, Operators[i].text.c_str());
+							insert_op_submenu[j].AppendMenu(MF_STRING, Operators[i].value | OP_INSERT_FLAG, Operators[i].text.c_str());
 						}
 
 						break;	// only 1 category valid
@@ -860,7 +857,7 @@ void sexp_tree::right_clicked(int mode)
 			else
 			{
 				// put it in the appropriate submenu
-				for (j=0; j<Num_submenus; j++)
+				for (j=0; j<(int)op_submenu.size(); j++)
 				{
 					if (op_submenu[j].id == subcategory_id)
 					{
@@ -886,14 +883,14 @@ void sexp_tree::right_clicked(int mode)
 							case OP_HUD_ACTIVATE_GAUGE_TYPE:
 							case OP_JETTISON_CARGO_DELAY:
 							case OP_STRING_CONCATENATE:
-								j = Num_submenus;	// don't allow these operators to be visible
+								j = (int)op_submenu.size();	// don't allow these operators to be visible
 								break;
 						}
 
-						if (j < Num_submenus) {
-							add_op_subcategory_menu[j].AppendMenu(MF_STRING | MF_GRAYED, Operators[i].value, Operators[i].text);
-							replace_op_subcategory_menu[j].AppendMenu(MF_STRING | MF_GRAYED, Operators[i].value | OP_REPLACE_FLAG, Operators[i].text);
-							insert_op_subcategory_menu[j].AppendMenu(MF_STRING, Operators[i].value | OP_INSERT_FLAG, Operators[i].text);
+						if (j < (int)op_submenu.size()) {
+							add_op_subcategory_menu[j].AppendMenu(MF_STRING | MF_GRAYED, Operators[i].value, Operators[i].text.c_str());
+							replace_op_subcategory_menu[j].AppendMenu(MF_STRING | MF_GRAYED, Operators[i].value | OP_REPLACE_FLAG, Operators[i].text.c_str());
+							insert_op_subcategory_menu[j].AppendMenu(MF_STRING, Operators[i].value | OP_INSERT_FLAG, Operators[i].text.c_str());
 						}
 
 						break;	// only 1 subcategory valid
@@ -920,7 +917,7 @@ void sexp_tree::right_clicked(int mode)
 
 			// disable copy, insert op
 			menu.EnableMenuItem(ID_EDIT_COPY, MF_GRAYED);
-			for (j=0; j<Num_operators; j++) {
+			for (j=0; j<(int)Operators.size(); j++) {
 				menu.EnableMenuItem(Operators[j].value | OP_INSERT_FLAG, MF_GRAYED);
 			}
 
@@ -974,9 +971,9 @@ void sexp_tree::right_clicked(int mode)
 					} else {
 						// add data
 						if ( (data_idx + 3) % 30) {
-							add_data_menu->AppendMenu(MF_STRING | MF_ENABLED, ID_ADD_MENU + data_idx, ptr->text);
+							add_data_menu->AppendMenu(MF_STRING | MF_ENABLED, ID_ADD_MENU + data_idx, ptr->text.c_str());
 						} else {
-							add_data_menu->AppendMenu(MF_MENUBARBREAK | MF_STRING | MF_ENABLED, ID_ADD_MENU + data_idx, ptr->text);
+							add_data_menu->AppendMenu(MF_MENUBARBREAK | MF_STRING | MF_ENABLED, ID_ADD_MENU + data_idx, ptr->text.c_str());
 						}
 					}
 
@@ -1020,7 +1017,7 @@ void sexp_tree::right_clicked(int mode)
 		}
 
 		// disable operators that do not have arguments available
-		for (j=0; j<Num_operators; j++) {
+		for (j=0; j<(int)Operators.size(); j++) {
 			if (!query_default_argument_available(j)) {
 				menu.EnableMenuItem(Operators[j].value, MF_GRAYED);
 			}
@@ -1084,9 +1081,9 @@ void sexp_tree::right_clicked(int mode)
 
 					} else {
 						if ( (data_idx + 3) % 30)
-							replace_data_menu->AppendMenu(MF_STRING | MF_ENABLED, ID_REPLACE_MENU + data_idx, ptr->text);
+							replace_data_menu->AppendMenu(MF_STRING | MF_ENABLED, ID_REPLACE_MENU + data_idx, ptr->text.c_str());
 						else
-							replace_data_menu->AppendMenu(MF_MENUBARBREAK | MF_STRING | MF_ENABLED, ID_REPLACE_MENU + data_idx, ptr->text);
+							replace_data_menu->AppendMenu(MF_MENUBARBREAK | MF_STRING | MF_ENABLED, ID_REPLACE_MENU + data_idx, ptr->text.c_str());
 					}
 
 					data_idx++;
@@ -1163,20 +1160,20 @@ void sexp_tree::right_clicked(int mode)
 		} else {  // top node, so should be a Boolean type.
 			if (m_mode == MODE_EVENTS) {  // return type should be null
 				replace_type = OPR_NULL;
-				for (j=0; j<Num_operators; j++)
+				for (j=0; j<(int)Operators.size(); j++)
 					if (query_operator_return_type(j) == OPR_NULL)
 						menu.EnableMenuItem(Operators[j].value | OP_REPLACE_FLAG, MF_ENABLED);
 
 			} else {
 				replace_type = OPR_BOOL;
-				for (j=0; j<Num_operators; j++)
+				for (j=0; j<(int)Operators.size(); j++)
 					if (query_operator_return_type(j) == OPR_BOOL)
 						menu.EnableMenuItem(Operators[j].value | OP_REPLACE_FLAG, MF_ENABLED);
 			}
 		}
 
 		// disable operators that do not have arguments available
-		for (j=0; j<Num_operators; j++) {
+		for (j=0; j<(int)Operators.size(); j++) {
 			if (!query_default_argument_available(j)) {
 				menu.EnableMenuItem(Operators[j].value | OP_REPLACE_FLAG, MF_GRAYED);
 			}
@@ -1205,7 +1202,7 @@ void sexp_tree::right_clicked(int mode)
 				type = OPF_BOOL;
 		}
 
-		for (j=0; j<Num_operators; j++) {
+		for (j=0; j<(int)Operators.size(); j++) {
 			z = query_operator_return_type(j);
 			if (!sexp_query_type_match(type, z) || (Operators[j].min < 1))
 				menu.EnableMenuItem(Operators[j].value | OP_INSERT_FLAG, MF_GRAYED);
@@ -1223,7 +1220,7 @@ void sexp_tree::right_clicked(int mode)
 		}
 
 		// disable operators that do not have arguments available
-		for (j=0; j<Num_operators; j++) {
+		for (j=0; j<(int)Operators.size(); j++) {
 			if (!query_default_argument_available(j)) {
 				menu.EnableMenuItem(Operators[j].value | OP_INSERT_FLAG, MF_GRAYED);
 			}
@@ -1231,7 +1228,7 @@ void sexp_tree::right_clicked(int mode)
 
 
 		// disable non campaign operators if in campaign mode
-		for (j=0; j<Num_operators; j++) {
+		for (j=0; j<(int)Operators.size(); j++) {
 			z = 0;
 			if (m_mode == MODE_CAMPAIGN) {
 				if (Operators[j].value & OP_NONCAMPAIGN_FLAG)
@@ -1445,12 +1442,12 @@ int sexp_tree::end_label_edit(TVITEMA &item)
 
 	Assert(node < tree_nodes.size());
 	if (tree_nodes[node].type & SEXPT_OPERATOR) {
-		const char *op = match_closest_operator(str, node);
-		if (!op) return 0;	// Goober5000 - avoids crashing
+		auto op = match_closest_operator(str, node);
+		if (op.empty()) return 0;	// Goober5000 - avoids crashing
 
-		SetItemText(h, op);
+		SetItemText(h, op.c_str());
 		item_index = node;
-		int op_num = get_operator_index(op); 
+		int op_num = get_operator_index(op.c_str()); 
 		if (op_num >= 0 ) {
 			add_or_replace_operator(op_num, 1);
 		}
@@ -1502,10 +1499,11 @@ int sexp_tree::end_label_edit(TVITEMA &item)
 // number of it.  What operators are valid is determined by 'node', and an operator is valid
 // if it is allowed to fit at position 'node'
 //
-const char *sexp_tree::match_closest_operator(const char *str, int node)
+SCP_string sexp_tree::match_closest_operator(const char *str, int node)
 {
 	int z, i, op, arg_num, opf, opr;
-	const char *sub_best = NULL, *best = NULL;
+	SCP_string sub_best;
+	SCP_string best;
 
 	z = tree_nodes[node].parent;
 	if (z < 0) {
@@ -1521,20 +1519,20 @@ const char *sexp_tree::match_closest_operator(const char *str, int node)
 
 	opf = query_operator_argument_type(op, arg_num); // check argument type at this position
 	opr = query_operator_return_type(op);
-	for (i=0; i<Num_operators; i++) {
+	for (i=0; i<(int)Operators.size(); i++) {
 		if (sexp_query_type_match(opf, opr)) {
-			if ( (stricmp(str, Operators[i].text) <= 0) && (!best || (stricmp(str, best) < 0)) )
+			if ( (stricmp(str, Operators[i].text.c_str()) <= 0) && (stricmp(str, best.c_str()) < 0) )
 				best = Operators[i].text;
 			
-			if ( !sub_best || (stricmp(Operators[i].text, sub_best) > 0) )
+			if ( stricmp(Operators[i].text.c_str(), sub_best.c_str()) > 0 )
 				sub_best = Operators[i].text;
 		}
 	}
 
-	if (!best)
+	if (best.empty())
 		best = sub_best;  // no best found, use our plan #2 best found.
 
-	Assert(best);  // we better have some valid operator at this point.
+	Assert(!best.empty());  // we better have some valid operator at this point.
 	return best;
 
 /*	char buf[256];
@@ -1742,7 +1740,7 @@ BOOL sexp_tree::OnCommand(WPARAM wParam, LPARAM lParam)
 
 		Assert((SEXPT_TYPE(ptr->type) != SEXPT_OPERATOR) && (ptr->op < 0));
 		expand_operator(item_index);
-		add_data(ptr->text, ptr->type);
+		add_data(ptr->text.c_str(), ptr->type);
 		list->destroy();
 		return 1;
 	}
@@ -1767,12 +1765,12 @@ BOOL sexp_tree::OnCommand(WPARAM wParam, LPARAM lParam)
 
 		Assert((SEXPT_TYPE(ptr->type) != SEXPT_OPERATOR) && (ptr->op < 0));
 		expand_operator(item_index);
-		replace_data(ptr->text, ptr->type);
+		replace_data(ptr->text.c_str(), ptr->type);
 		list->destroy();
 		return 1;
 	}
 
-	for (op=0; op<Num_operators; op++) {
+	for (op=0; op<(int)Operators.size(); op++) {
 		if (id == Operators[op].value) {
 			add_or_replace_operator(op);
 			return 1;
@@ -1790,7 +1788,7 @@ BOOL sexp_tree::OnCommand(WPARAM wParam, LPARAM lParam)
 			z = tree_nodes[item_index].parent;
 			flags = tree_nodes[item_index].flags;
 			node = allocate_node(z, item_index);
-			set_node(node, (SEXPT_OPERATOR | SEXPT_VALID), Operators[op].text);
+			set_node(node, (SEXPT_OPERATOR | SEXPT_VALID), Operators[op].text.c_str());
 			tree_nodes[node].flags = flags;
 			if (z >= 0)
 				h = tree_nodes[z].handle;
@@ -1817,7 +1815,7 @@ BOOL sexp_tree::OnCommand(WPARAM wParam, LPARAM lParam)
 				}
 			}
 
-			item_handle = tree_nodes[node].handle = insert(Operators[op].text, BITMAP_OPERATOR, BITMAP_OPERATOR, h, tree_nodes[item_index].handle);
+			item_handle = tree_nodes[node].handle = insert(Operators[op].text.c_str(), BITMAP_OPERATOR, BITMAP_OPERATOR, h, tree_nodes[item_index].handle);
 			move_branch(item_index, node);
 
 			item_index = node;
@@ -2053,18 +2051,18 @@ void sexp_tree::add_or_replace_operator(int op, int replace_flag)
 						break;
 
 				if (i < 0) {  // everything is ok, so we can keep old arguments with new operator
-					set_node(item_index, (SEXPT_OPERATOR | SEXPT_VALID), Operators[op].text);
-					SetItemText(tree_nodes[item_index].handle, Operators[op].text);
+					set_node(item_index, (SEXPT_OPERATOR | SEXPT_VALID), Operators[op].text.c_str());
+					SetItemText(tree_nodes[item_index].handle, Operators[op].text.c_str());
 					tree_nodes[item_index].flags = OPERAND;
 					return;
 				}
 			}
 		}
 
-		replace_operator(Operators[op].text);
+		replace_operator(Operators[op].text.c_str());
 
 	} else
-		add_operator(Operators[op].text);
+		add_operator(Operators[op].text.c_str());
 
 	// fill in all the required (minimum) arguments with default values
 	for (i=0; i<Operators[op].min; i++)
@@ -2080,7 +2078,7 @@ void sexp_list_item::set_op(int op_num)
 	int i;
 
 	if (op_num >= FIRST_OP) {  // do we have an op value instead of an op number (index)?
-		for (i=0; i<Num_operators; i++)
+		for (i=0; i<(int)Operators.size(); i++)
 			if (op_num == Operators[i].value)
 				op_num = i;  // convert op value to op number
 	}
@@ -2181,8 +2179,6 @@ void sexp_list_item::destroy()
 	ptr = this;
 	while (ptr) {
 		ptr2 = ptr->next;
-		if (ptr->flags & SEXP_ITEM_F_DUP)
-			free((void *) ptr->text);
 
 		delete ptr;
 		ptr = ptr2;
@@ -2202,7 +2198,7 @@ int sexp_tree::add_default_operator(int op_index, int argnum)
 		return -1;
 
 	if (item.type & SEXPT_OPERATOR) {
-		Assert((item.op >= 0) && (item.op < Num_operators));
+		Assert((item.op >= 0) && (item.op < (int)Operators.size()));
 		add_or_replace_operator(item.op);
 		item_index = index;
 		item_handle = h;
@@ -2222,7 +2218,7 @@ int sexp_tree::add_default_operator(int op_index, int argnum)
 			}
 
 			char node_text[2*TOKEN_LENGTH + 2];
-			sprintf(node_text, "%s(%s)", item.text, Sexp_variables[sexp_var_index].text);
+			sprintf(node_text, "%s(%s)", item.text.c_str(), Sexp_variables[sexp_var_index].text);
 			add_variable_data(node_text, type);
 		}
 		// modify-variable data type depends on type of variable being modified
@@ -2246,11 +2242,11 @@ int sexp_tree::add_default_operator(int op_index, int argnum)
 			} else {
 				Int3();
 			}
-			add_data(item.text, type);
+			add_data(item.text.c_str(), type);
 		}
 		// all other sexps and parameters
 		else {
-			add_data(item.text, item.type);
+			add_data(item.text.c_str(), item.type);
 		}
 	}
 
@@ -2453,15 +2449,12 @@ int sexp_tree::get_default_value(sexp_list_item *item, char *text_buf, int op, i
 
 	// Goober5000 - the way this is done is really stupid, so stupid hacks are needed to deal with it
 	// this particular hack is necessary because the argument string should never be a default
-	if (list && !strcmp(list->text, SEXP_ARGUMENT_STRING))
+	if (list && list->text == SEXP_ARGUMENT_STRING)
 	{
 		sexp_list_item *first_ptr;
 
 		first_ptr = list;
 		list = list->next;
-
-		if (first_ptr->flags & SEXP_ITEM_F_DUP)
-			free((void *) first_ptr->text);
 
 		delete first_ptr;
 	}
@@ -2472,7 +2465,7 @@ int sexp_tree::get_default_value(sexp_list_item *item, char *text_buf, int op, i
 		*item = *list;
 
 		// but use the provided text buffer
-		strcpy(text_buf, list->text);
+		strcpy(text_buf, list->text.c_str());
 		item->text = text_buf;
 
 		// get rid of the list, since we're done with it
@@ -3310,25 +3303,19 @@ void sexp_tree::verify_and_fix_arguments(int node)
 
 				ptr = list;
 				while (ptr) {
+					// make sure text is not NULL
+					// check that proposed text is valid for operator
+					if ( !stricmp(ptr->text.c_str(), text_ptr) )
+						break;
 
-					if (ptr->text != NULL) {
-						// make sure text is not NULL
-						// check that proposed text is valid for operator
-						if ( !stricmp(ptr->text, text_ptr) )
-							break;
-
-						ptr = ptr->next;
-					} else {
-						// text is NULL, so set ptr to NULL to end loop
-						ptr = NULL;
-					}
+					ptr = ptr->next;
 				}
 
 				if (!ptr) {  // argument isn't in list of valid choices, 
 					if (list->op >= 0) {
-						replace_operator(list->text);
+						replace_operator(list->text.c_str());
 					} else {
-						replace_data(list->text, list->type);
+						replace_data(list->text.c_str(), list->type);
 					}
 				}
 
@@ -3847,14 +3834,14 @@ const char *sexp_tree::help(int code)
 {
 	int i;
 
-	i = Num_sexp_help;
+	i = (int)Sexp_help.size();
 	while (i--) {
 		if (Sexp_help[i].id == code)
 			break;
 	}
 
 	if (i >= 0)
-		return Sexp_help[i].help;
+		return Sexp_help[i].help.c_str();
 
 	return NULL;
 }
@@ -3884,8 +3871,8 @@ void sexp_tree::update_help(HTREEITEM h)
 	int i, j, z, c, code, index, sibling_place;
 	CString text;
 
-	for (i=0; i<Num_operators; i++) {
-		for (j=0; j<Num_op_menus; j++) {
+	for (i=0; i<(int)Operators.size(); i++) {
+		for (j=0; j<(int)op_menu.size(); j++) {
 			if (get_category(Operators[i].value) == op_menu[j].id) {
 				if (!help(Operators[i].value)) {
 					mprintf(("Allender!  If you add new sexp operators, add help for them too! :)\n"));
@@ -4607,7 +4594,7 @@ sexp_list_item *sexp_tree::get_listing_opf_null()
 	int i;
 	sexp_list_item head;
 
-	for (i=0; i<Num_operators; i++)
+	for (i=0; i<(int)Operators.size(); i++)
 		if (query_operator_return_type(i) == OPR_NULL)
 			head.add_op(i);
 
@@ -4619,7 +4606,7 @@ sexp_list_item *sexp_tree::get_listing_opf_flexible_argument()
 	int i;
 	sexp_list_item head;
 
-	for (i=0; i<Num_operators; i++)
+	for (i=0; i<(int)Operators.size(); i++)
 		if (query_operator_return_type(i) == OPR_FLEXIBLE_ARGUMENT)
 			head.add_op(i);
 
@@ -4643,7 +4630,7 @@ sexp_list_item *sexp_tree::get_listing_opf_bool(int parent_node)
 
 	}
 
-	for (i=0; i<Num_operators; i++) {
+	for (i=0; i<(int)Operators.size(); i++) {
 		if (query_operator_return_type(i) == OPR_BOOL) {
 			if ( !only_basic || (only_basic && ((Operators[i].value == OP_TRUE) || (Operators[i].value == OP_FALSE))) ) {
 				head.add_op(i);
@@ -4659,7 +4646,7 @@ sexp_list_item *sexp_tree::get_listing_opf_positive()
 	int i, z;
 	sexp_list_item head;
 
-	for (i=0; i<Num_operators; i++) {
+	for (i=0; i<(int)Operators.size(); i++) {
 		z = query_operator_return_type(i);
 		// Goober5000's number hack
 		if ((z == OPR_NUMBER) || (z == OPR_POSITIVE))
@@ -4674,7 +4661,7 @@ sexp_list_item *sexp_tree::get_listing_opf_number()
 	int i, z;
 	sexp_list_item head;
 
-	for (i=0; i<Num_operators; i++) {
+	for (i=0; i<(int)Operators.size(); i++) {
 		z = query_operator_return_type(i);
 		if ((z == OPR_NUMBER) || (z == OPR_POSITIVE))
 			head.add_op(i);
@@ -5153,7 +5140,7 @@ sexp_list_item *sexp_tree::get_listing_opf_ai_goal(int parent_node)
 	n = ship_name_lookup(tree_nodes[child].text, 1);
 	if (n >= 0) {
 		// add operators if it's an ai-goal and ai-goal is allowed for that ship
-		for (i=0; i<Num_operators; i++) {
+		for (i=0; i<(int)Operators.size(); i++) {
 			if ( (query_operator_return_type(i) == OPR_AI_GOAL) && query_sexp_ai_goal_valid(Operators[i].value, n) )
 				head.add_op(i);
 		}
@@ -5164,14 +5151,14 @@ sexp_list_item *sexp_tree::get_listing_opf_ai_goal(int parent_node)
 			for (w=0; w<Wings[z].wave_count; w++) {
 				n = Wings[z].ship_index[w];
 				// add operators if it's an ai-goal and ai-goal is allowed for that ship
-				for (i=0; i<Num_operators; i++) {
+				for (i=0; i<(int)Operators.size(); i++) {
 					if ( (query_operator_return_type(i) == OPR_AI_GOAL) && query_sexp_ai_goal_valid(Operators[i].value, n) )
 						head.add_op(i);
 				}
 			}
 		// when dealing with the special argument add them all. It's up to the FREDder to ensure invalid orders aren't given
 		} else if (!strcmp(tree_nodes[child].text, SEXP_ARGUMENT_STRING)) {
-			for (i=0; i<Num_operators; i++) {
+			for (i=0; i<(int)Operators.size(); i++) {
 				if (query_operator_return_type(i) == OPR_AI_GOAL) {
 					head.add_op(i);
 				}

--- a/fred2/sexp_tree.h
+++ b/fred2/sexp_tree.h
@@ -97,7 +97,7 @@ class sexp_list_item
 public:
 	int type;
 	int op;
-	const char *text;
+	SCP_string text;
 	int flags;
 	sexp_list_item *next;
 
@@ -175,7 +175,7 @@ public:
 	void add_sub_tree(int node, HTREEITEM root);
 	int load_sub_tree(int index, bool valid, const char *text);
 	void hilite_item(int node);
-	const char *match_closest_operator(const char *str, int node);
+	SCP_string match_closest_operator(const char *str, int node);
 	void delete_sexp_tree_variable(const char *var_name);
 	void modify_sexp_tree_variable(const char *old_name, int sexp_var_index);
 	int get_item_index_to_var_index();


### PR DESCRIPTION
I split this from #1331 to make reviewing these two changesets easier.

These changes convert all usages of const char* to SCP_string in the
static SEXP arrays so that the dynamic SEXP system can use SCP_strings
instead of having to allocate the strings and then somehow figure out
which strings must be freed at the end of the program.

This also converts the SEXP arrays to vectors so that new SEXP operators
can be added at runtime later.