### PR TITLE
Improve video player API

### DIFF
--- a/code/cutscene/VideoPresenter.cpp
+++ b/code/cutscene/VideoPresenter.cpp
@@ -5,12 +5,17 @@
 using namespace cutscene;
 using namespace cutscene::player;
 
+namespace {
+struct movie_vertex {
+	vec2d pos;
+	vec2d uv;
+};
+}
+
 namespace cutscene {
 namespace player {
-VideoPresenter::VideoPresenter(const MovieProperties& props) : _scaleVideo(false) {
+VideoPresenter::VideoPresenter(const MovieProperties& props) {
 	GR_DEBUG_SCOPE("Init video");
-
-	_vertexBuffer = gr_create_buffer(BufferType::Vertex, BufferUsageHint::Static);
 
 	auto w = static_cast<int>(props.size.width);
 	auto h = static_cast<int>(props.size.height);
@@ -26,83 +31,10 @@ VideoPresenter::VideoPresenter(const MovieProperties& props) : _scaleVideo(false
 	_vtex = bm_create(8, w / 2, h / 2, _vTexBuffer.get(), BMP_AABITMAP);
 
 	material_set_movie(&_render_material, _ytex, _utex, _vtex);
-
-	float screen_ratio = (float) gr_screen.center_w / (float) gr_screen.center_h;
-	float movie_ratio = (float) props.size.width / (float) props.size.height;
-
-	float scale_by;
-	if (screen_ratio > movie_ratio) {
-		scale_by = (float) gr_screen.center_h / (float) props.size.height;
-	} else {
-		scale_by = (float) gr_screen.center_w / (float) props.size.width;
-	}
-
-	// don't bother setting anything if we aren't going to need it
-	if (!Cmdline_noscalevid && (scale_by != 1.0f)) {
-		vec3d scale;
-
-		scale.xyz.x = scale_by;
-		scale.xyz.y = scale_by;
-		scale.xyz.z = -1.0f;
-
-		gr_push_scale_matrix(&scale);
-		_scaleVideo = true;
-	}
-
-	int screenX;
-	int screenY;
-
-	if (_scaleVideo) {
-		screenX = fl2i(((gr_screen.center_w / 2.0f + gr_screen.center_offset_x) / scale_by)
-						   - (static_cast<int>(props.size.width) / 2.0f) + 0.5f);
-		screenY = fl2i(((gr_screen.center_h / 2.0f + gr_screen.center_offset_y) / scale_by)
-						   - (static_cast<int>(props.size.height) / 2.0f) + 0.5f);
-	} else {
-		// centers on 1024x768, fills on 640x480
-		screenX = ((gr_screen.center_w - static_cast<int>(props.size.width)) / 2) + gr_screen.center_offset_x;
-		screenY = ((gr_screen.center_h - static_cast<int>(props.size.height)) / 2) + gr_screen.center_offset_y;
-	}
-
-	// set additional values for screen width/height and UV coords
-	int screenXW = screenX + static_cast<int>(props.size.width);
-	int screenYH = screenY + static_cast<int>(props.size.height);
-
-	float glVertices[4][4] = {{ 0 }};
-	glVertices[0][0] = (float) screenX;
-	glVertices[0][1] = (float) screenY;
-	glVertices[0][2] = 0.0f;
-	glVertices[0][3] = 0.0f;
-
-	glVertices[1][0] = (float) screenX;
-	glVertices[1][1] = (float) screenYH;
-	glVertices[1][2] = 0.0f;
-	glVertices[1][3] = 1.0f;
-
-	glVertices[2][0] = (float) screenXW;
-	glVertices[2][1] = (float) screenY;
-	glVertices[2][2] = 1.0f;
-	glVertices[2][3] = 0.0f;
-
-	glVertices[3][0] = (float) screenXW;
-	glVertices[3][1] = (float) screenYH;
-	glVertices[3][2] = 1.0f;
-	glVertices[3][3] = 1.0f;
-
-	_vertexLayout.add_vertex_component(vertex_format_data::POSITION2, sizeof(glVertices[0]), 0);
-	_vertexLayout.add_vertex_component(vertex_format_data::TEX_COORD2, sizeof(glVertices[0]), sizeof(float) * 2);
-
-	gr_update_buffer_data(_vertexBuffer, sizeof(glVertices[0]) * 4, glVertices);
 }
 
 VideoPresenter::~VideoPresenter() {
 	GR_DEBUG_SCOPE("Deinit video");
-
-	if (_scaleVideo) {
-		gr_pop_scale_matrix();
-	}
-
-	gr_delete_buffer(_vertexBuffer);
-	_vertexBuffer = -1;
 
 	bm_release(_ytex);
 	bm_release(_utex);
@@ -124,10 +56,39 @@ void VideoPresenter::uploadVideoFrame(const VideoFramePtr& frame) {
 	gr_update_texture(_vtex, 8, _vTexBuffer.get(), (int) frame->uvSize.width, (int) frame->uvSize.height);
 }
 
-void VideoPresenter::displayFrame() {
+void VideoPresenter::displayFrame(float x1, float y1, float x2, float y2) {
 	GR_DEBUG_SCOPE("Draw video frame");
 
-	gr_render_movie(&_render_material, PRIM_TYPE_TRISTRIP, &_vertexLayout, 4, _vertexBuffer);
+	movie_vertex vertex_data[4];
+
+	vertex_data[0].pos.x = x1;
+	vertex_data[0].pos.y = y1;
+	vertex_data[0].uv.x = 0.0f;
+	vertex_data[0].uv.y = 0.0f;
+
+	vertex_data[1].pos.x = x1;
+	vertex_data[1].pos.y = y2;
+	vertex_data[1].uv.x = 0.0f;
+	vertex_data[1].uv.y = 1.0f;
+
+	vertex_data[2].pos.x = x2;
+	vertex_data[2].pos.y = y1;
+	vertex_data[2].uv.x = 1.0f;
+	vertex_data[2].uv.y = 0.0f;
+
+	vertex_data[3].pos.x = x2;
+	vertex_data[3].pos.y = y2;
+	vertex_data[3].uv.x = 1.0f;
+	vertex_data[3].uv.y = 1.0f;
+
+	// Use the immediate buffer for storing our data since that is exactly what we need
+	auto offset = gr_add_to_immediate_buffer(sizeof(vertex_data), vertex_data);
+
+	vertex_layout layout;
+	layout.add_vertex_component(vertex_format_data::POSITION2, sizeof(vertex_data[0]), offset + offsetof(movie_vertex, pos));
+	layout.add_vertex_component(vertex_format_data::TEX_COORD2, sizeof(vertex_data[0]), offset + offsetof(movie_vertex, uv));
+
+	gr_render_movie(&_render_material, PRIM_TYPE_TRISTRIP, &layout, 4, gr_immediate_buffer_handle);
 }
 
 }

--- a/code/cutscene/VideoPresenter.h
+++ b/code/cutscene/VideoPresenter.h
@@ -12,11 +12,6 @@ namespace cutscene {
 namespace player {
 
 class VideoPresenter {
-	int _vertexBuffer = -1;
-	vertex_layout _vertexLayout;
-
-	bool _scaleVideo = false;
-
 	int _ytex = -1;
 	std::unique_ptr<uint8_t[]> _yTexBuffer;
 
@@ -38,7 +33,7 @@ class VideoPresenter {
 
 	void uploadVideoFrame(const VideoFramePtr& frame);
 
-	void displayFrame();
+	void displayFrame(float x1, float y1, float x2, float y2);
 };
 }
 }

--- a/code/cutscene/movie.cpp
+++ b/code/cutscene/movie.cpp
@@ -14,6 +14,7 @@
 #endif
 
 #include "globalincs/pstypes.h"
+#include "globalincs/alphacolors.h"
 #include "globalincs/systemvars.h"
 #include "io/cursor.h"
 #include "graphics/2d.h"
@@ -21,9 +22,168 @@
 #include "cmdline/cmdline.h"	
 #include "cutscene/cutscenes.h" // cutscene_mark_viewable()
 #include "cutscene/player.h" // cutscene_mark_viewable()
+#include "tracing/categories.h"
+#include "tracing/tracing.h"
+#include "io/timer.h"
+#include "io/key.h"
 
 extern int Game_mode;
 extern int Is_standalone;
+
+namespace {
+
+using namespace cutscene;
+
+struct PlaybackState {
+	bool playing = true;
+
+	vec2d posTopLeft;
+	vec2d posBottomRight;
+};
+
+void processEvents(PlaybackState* state) {
+	io::mouse::CursorManager::get()->showCursor(false);
+
+	os_poll();
+
+	int k = key_inkey();
+	switch (k) {
+	case KEY_ESC:
+	case KEY_ENTER:
+	case KEY_SPACEBAR:
+		state->playing = false;
+		break;
+	default:
+		break;
+	}
+}
+
+template<typename... Args>
+float print_string(float x, float y, const char* fmt, Args... params) {
+	SCP_string text;
+	sprintf(text, fmt, params...);
+
+	gr_string(x, y, text.c_str(), GR_RESIZE_NONE);
+
+	return y + font::get_current_font()->getHeight();
+}
+
+void showVideoInfo(const PlayerState& state) {
+	gr_set_color_fast(&Color_white);
+
+	float y = 200.f;
+	float x = 100.f;
+	y = print_string(x, y, "Movie FPS: %f", state.props.fps);
+	y = print_string(x, y, "Size: %dx%d", state.props.size.width, state.props.size.height);
+
+	y = gr_screen.max_h - 200.f;
+
+	size_t audio_queue_size = state.decoder->getAudioQueueSize();
+	if (state.hasAudio) {
+		ALint queued;
+		OpenAL_ErrorPrint(alGetSourcei(state.audioSid, AL_BUFFERS_QUEUED, &queued));
+		audio_queue_size += queued;
+	}
+
+	y = print_string(x, y, "Audio Queue size: " SIZE_T_ARG, audio_queue_size);
+	y = print_string(x, y, "Video Queue size: " SIZE_T_ARG, state.decoder->getVideoQueueSize());
+	y += font::get_current_font()->getHeight();
+	// Estimate the size of the video buffer
+	// We use YUV420p frames so one pixel uses 1.5 bytes of storage
+	size_t single_frame_size = (size_t) (state.props.size.width * state.props.size.height * 1.5);
+	size_t total_size = single_frame_size * state.decoder->getVideoQueueSize();
+	print_string(x, y, "Video buffer size: " SIZE_T_ARG "B", total_size);
+}
+
+void displayVideo(Player* player, PlaybackState* state) {
+	TRACE_SCOPE(tracing::CutsceneDrawVideoFrame);
+
+	gr_clear();
+	player->draw(state->posTopLeft.x, state->posTopLeft.y, state->posBottomRight.x, state->posBottomRight.y);
+
+	if (Cmdline_show_video_info) {
+		showVideoInfo(player->getInternalState());
+	}
+
+	gr_flip();
+}
+
+void determine_display_positions(Player* player, PlaybackState* state) {
+	auto& props = player->getMovieProperties();
+
+	float screen_ratio = (float) gr_screen.center_w / (float) gr_screen.center_h;
+	float movie_ratio = (float) props.size.width / (float) props.size.height;
+
+	float scale_by;
+	if (screen_ratio > movie_ratio) {
+		scale_by = (float) gr_screen.center_h / (float) props.size.height;
+	} else {
+		scale_by = (float) gr_screen.center_w / (float) props.size.width;
+	}
+
+	float screenX;
+	float screenY;
+
+	if (!Cmdline_noscalevid && (scale_by != 1.0f)) {
+		screenX = ((gr_screen.center_w / 2.0f + gr_screen.center_offset_x) / scale_by) - (static_cast<int>(props.size.width) / 2.0f) + 0.5f;
+		screenY = ((gr_screen.center_h / 2.0f + gr_screen.center_offset_y) / scale_by) - (static_cast<int>(props.size.height) / 2.0f) + 0.5f;
+	} else {
+		// centers on 1024x768, fills on 640x480
+		screenX = i2fl(((gr_screen.center_w - static_cast<int>(props.size.width)) / 2) + gr_screen.center_offset_x);
+		screenY = i2fl(((gr_screen.center_h - static_cast<int>(props.size.height)) / 2) + gr_screen.center_offset_y);
+	}
+
+	// set additional values for screen width/height and UV coords
+	float screenXW = screenX + static_cast<int>(props.size.width);
+	float screenYH = screenY + static_cast<int>(props.size.height);
+
+	if (!Cmdline_noscalevid && (scale_by != 1.0f)) {
+		// Apply scaling
+		screenX *= scale_by;
+		screenY *= scale_by;
+
+		screenXW *= scale_by;
+		screenYH *= scale_by;
+	}
+
+	state->posTopLeft.x = screenX;
+	state->posTopLeft.y = screenY;
+
+	state->posBottomRight.x = screenXW;
+	state->posBottomRight.y = screenYH;
+}
+
+void movie_display_loop(Player* player, PlaybackState* state) {
+	// Compute the maximum time we will sleep to make sure we can still maintain the movie FPS
+	// and not waste too much CPU time
+	// We will sleep at most half the time a frame would be displayed
+	auto sleepTime = static_cast<std::uint64_t>((1. / (4. * player->getMovieProperties().fps)) * 1000.);
+
+	auto lastDisplayTimestamp = timer_get_microseconds();
+	while (state->playing) {
+		TRACE_SCOPE(tracing::CutsceneStep);
+
+		auto timestamp = timer_get_microseconds();
+
+		auto passed = timestamp - lastDisplayTimestamp;
+		lastDisplayTimestamp = timestamp;
+
+		// Play as long as the player reports that there is more to display
+		state->playing = player->update(passed);
+
+		displayVideo(player, state);
+
+		processEvents(state);
+
+		if (passed < sleepTime) {
+			auto sleep = sleepTime - passed;
+
+			os_sleep(static_cast<uint>(sleep));
+		}
+	}
+}
+
+}
 
 namespace movie {
 // Play one movie
@@ -57,7 +217,12 @@ bool play(const char* name) {
 
 	auto player = cutscene::Player::newPlayer(name);
 	if (player) {
-		player->startPlayback();
+		PlaybackState state;
+		determine_display_positions(player.get(), &state);
+
+		movie_display_loop(player.get(), &state);
+
+		player->stopPlayback();
 	} else {
 		// uh-oh, movie is invalid... Abory, Retry, Fail?
 		mprintf(("MOVIE ERROR: Found invalid movie! (%s)\n", name));

--- a/code/cutscene/player.cpp
+++ b/code/cutscene/player.cpp
@@ -21,58 +21,17 @@
 
 using namespace cutscene::player;
 
-namespace cutscene {
-struct PlayerState {
-	MovieProperties props;
-	Decoder* decoder = nullptr;
-
-	bool playing = true;
-
-	bool playbackHasBegun = false;
-
-	// Timing state
-	std::uint64_t playback_time = 0;
-
-	// Audio state
-	bool audioInited = false;
-	bool hasAudio = false;
-	ALuint audioSid = 0;
-	SCP_vector<ALuint> audioBuffers;
-	SCP_queue<ALuint> unqueuedAudioBuffers;
-
-	// Graphics state following
-	bool videoInited = false;
-
-	VideoFramePtr currentFrame;
-	VideoFramePtr nextFrame;
-	bool newFrameAdded = false;
-
-	std::unique_ptr<VideoPresenter> videoPresenter;
-
-	PlayerState() : decoder(nullptr), playing(true), playbackHasBegun(false),
-					playback_time(0),
-					audioInited(0), hasAudio(false), audioSid(0),
-					videoInited(false), newFrameAdded(false) {}
-
- private:
-	PlayerState(const PlayerState&) SCP_DELETED_FUNCTION;
-
-	PlayerState& operator=(const PlayerState&) SCP_DELETED_FUNCTION;
-};
-}
-
 namespace {
 using namespace cutscene;
 
 const int MAX_AUDIO_BUFFERS = 15;
 
-Decoder* findDecoder(const SCP_string& name) {
+std::unique_ptr<Decoder> findDecoder(const SCP_string& name) {
 	{
-		auto ffmpeg = new ffmpeg::FFMPEGDecoder();
+		std::unique_ptr<Decoder> ffmpeg(new ffmpeg::FFMPEGDecoder());
 		if (ffmpeg->initialize(name)) {
 			return ffmpeg;
 		}
-		delete ffmpeg;
 	}
 
 	return nullptr;
@@ -267,79 +226,6 @@ void videoPlaybackClose(PlayerState* state) {
 	state->videoInited = false;
 }
 
-template<typename... Args>
-float print_string(float x, float y, const char* fmt, Args... params) {
-	SCP_string text;
-	sprintf(text, fmt, params...);
-
-	gr_string(x, y, text.c_str(), GR_RESIZE_NONE);
-
-	return y + font::get_current_font()->getHeight();
-}
-
-void showVideoInfo(PlayerState* state) {
-	gr_set_color_fast(&Color_white);
-
-	float y = 200.f;
-	float x = 100.f;
-	y = print_string(x, y, "Movie FPS: %f", state->props.fps);
-	y = print_string(x, y, "Size: %dx%d", state->props.size.width, state->props.size.height);
-
-	y = gr_screen.max_h - 200.f;
-
-	size_t audio_queue_size = state->decoder->getAudioQueueSize();
-	if (state->hasAudio) {
-		ALint queued;
-		OpenAL_ErrorPrint(alGetSourcei(state->audioSid, AL_BUFFERS_QUEUED, &queued));
-		audio_queue_size += queued;
-	}
-
-	y = print_string(x, y, "Audio Queue size: " SIZE_T_ARG, audio_queue_size);
-	y = print_string(x, y, "Video Queue size: " SIZE_T_ARG, state->decoder->getVideoQueueSize());
-	y += font::get_current_font()->getHeight();
-	// Estimate the size of the video buffer
-	// We use YUV420p frames so one pixel uses 1.5 bytes of storage
-	size_t single_frame_size = (size_t) (state->props.size.width * state->props.size.height * 1.5);
-	size_t total_size = single_frame_size * state->decoder->getVideoQueueSize();
-	print_string(x, y, "Video buffer size: " SIZE_T_ARG "B", total_size);
-}
-
-void displayVideo(PlayerState* state) {
-	if (!state->currentFrame) {
-		return;
-	}
-
-	TRACE_SCOPE(tracing::CutsceneDrawVideoFrame);
-
-	gr_clear();
-	if (state->videoPresenter) {
-		state->videoPresenter->displayFrame();
-	}
-
-	if (Cmdline_show_video_info) {
-		showVideoInfo(state);
-	}
-
-	gr_flip();
-}
-
-void processEvents(PlayerState* state) {
-	io::mouse::CursorManager::get()->showCursor(false);
-
-	os_poll();
-
-	int k = key_inkey();
-	switch (k) {
-		case KEY_ESC:
-		case KEY_ENTER:
-		case KEY_SPACEBAR:
-			state->playing = false;
-			break;
-		default:
-			break;
-	}
-}
-
 bool shouldBeginPlayback(Decoder* decoder) {
 	auto video = decoder->isVideoQueueFull();
 	auto audio = decoder->isAudioQueueFull();
@@ -355,31 +241,37 @@ bool shouldBeginPlayback(Decoder* decoder) {
 }
 
 namespace cutscene {
-Player::Player() {
+Player::Player(std::unique_ptr<Decoder>&& decoder) : m_decoder(std::move(decoder)) {
+	initPlayback();
 }
 
 Player::~Player() {
+	// If video is initialized it means that stopPlayback has not been called yet
+	if (m_state.videoInited) {
+		stopPlayback();
+	}
+
 	if (m_decoder) {
 		m_decoder->close();
 	}
 }
 
-void Player::processDecoderData(PlayerState* state) {
-	if (!state->playbackHasBegun) {
+bool Player::processDecoderData() {
+	if (!m_state.playbackHasBegun) {
 		// Wait until video and audio are available
 		// If we don't have audio, don't wait for it (obviously...)
-		if (!shouldBeginPlayback(state->decoder)) {
-			return;
+		if (!shouldBeginPlayback(m_state.decoder)) {
+			return true;
 		}
 
-		state->playbackHasBegun = true;
+		m_state.playbackHasBegun = true;
 	}
 
 	TRACE_SCOPE(tracing::CutsceneProcessDecoder);
 
-	processVideoData(state);
+	processVideoData(&m_state);
 
-	auto audioPlaying = processAudioData(state);
+	auto audioPlaying = processAudioData(&m_state);
 
 	// Set the playing flag if the decoder is still active or there is still data available
 	auto decoding = m_decoder->isDecoding();
@@ -388,54 +280,33 @@ void Player::processDecoderData(PlayerState* state) {
 	auto pendingAudio = (m_decoder->isAudioFrameAvailable() && m_decoder->hasAudio()) || audioPlaying;
 	auto pendingVideo = m_decoder->isVideoFrameAvailable();
 
-	state->playing = decoding || pendingAudio || pendingVideo;
+	return decoding || pendingAudio || pendingVideo;
 }
 
-void Player::startPlayback() {
+void Player::initPlayback() {
+	Assertion(!m_state.videoInited, "Internal State has been initialized before! Create a new player for replaying a movie.");
+
 	m_decoderThread.reset(new std::thread(std::bind(&Player::decoderThread, this)));
 
-	PlayerState state;
-	state.props = m_decoder->getProperties();
-	state.decoder = m_decoder.get();
+	m_state.props = m_decoder->getProperties();
+	m_state.decoder = m_decoder.get();
 
-	// Compute the maximum time we will sleep to make sure we can still maintain the movie FPS
-	// and not waste too much CPU time
-	// We will sleep at most half the time a frame would be displayed
-	auto sleepTime = static_cast<std::uint64_t>((1. / (4. * state.props.fps)) * 1000.);
+	videoPlaybackInit(&m_state);
 
-	videoPlaybackInit(&state);
-
-	audioPlaybackInit(&state);
-
-	auto lastDisplayTimestamp = timer_get_microseconds();
-	while (state.playing) {
-		TRACE_SCOPE(tracing::CutsceneStep);
-
-		processDecoderData(&state);
-
-		displayVideo(&state);
-
-		processEvents(&state);
-
-		auto timestamp = timer_get_microseconds();
-
-		auto passed = timestamp - lastDisplayTimestamp;
-		lastDisplayTimestamp = timestamp;
-
-		if (state.playbackHasBegun) {
-			state.playback_time += passed;
-		}
-
-		if (passed < sleepTime) {
-			auto sleep = sleepTime - passed;
-
-			os_sleep(static_cast<uint>(sleep));
-		}
+	audioPlaybackInit(&m_state);
+}
+bool Player::update(uint64_t diff_time_micro) {
+	if (m_state.playbackHasBegun) {
+		m_state.playback_time += diff_time_micro;
 	}
+
+	return processDecoderData();
+}
+void Player::stopPlayback() {
 	m_decoder->stopDecoder();
 
-	audioPlaybackClose(&state);
-	videoPlaybackClose(&state);
+	audioPlaybackClose(&m_state);
+	videoPlaybackClose(&m_state);
 
 	m_decoderThread->join();
 }
@@ -458,10 +329,21 @@ std::unique_ptr<Player> Player::newPlayer(const SCP_string& name) {
 	if (decoder == nullptr) {
 		return nullptr;
 	}
+	return std::unique_ptr<Player>(new Player(std::move(decoder)));
+}
+const PlayerState& Player::getInternalState() const {
+	return m_state;
+}
+const MovieProperties& Player::getMovieProperties() const {
+	return m_state.props;
+}
+void Player::draw(float x1, float y1, float x2, float y2) {
+	if (!m_state.currentFrame) {
+		return;
+	}
 
-	std::unique_ptr<Player> player(new Player());
-	player->m_decoder.reset(decoder);
-
-	return player;
+	if (m_state.videoPresenter) {
+		m_state.videoPresenter->displayFrame(x1, y1, x2, y2);
+	}
 }
 }

--- a/code/cutscene/player.h
+++ b/code/cutscene/player.h
@@ -5,11 +5,45 @@
 #include <thread>
 
 #include "globalincs/pstypes.h"
+#include "sound/openal.h"
+
+#include "Decoder.h"
+#include "VideoPresenter.h"
 
 namespace cutscene {
 class Decoder;
 
-struct PlayerState;
+struct PlayerState {
+	MovieProperties props;
+	Decoder* decoder = nullptr;
+
+	bool playbackHasBegun = false;
+
+	// Timing state
+	std::uint64_t playback_time = 0;
+
+	// Audio state
+	bool audioInited = false;
+	bool hasAudio = false;
+	ALuint audioSid = 0;
+	SCP_vector<ALuint> audioBuffers;
+	SCP_queue<ALuint> unqueuedAudioBuffers;
+
+	// Graphics state following
+	bool videoInited = false;
+
+	VideoFramePtr currentFrame;
+	VideoFramePtr nextFrame;
+	bool newFrameAdded = false;
+
+	std::unique_ptr<player::VideoPresenter> videoPresenter;
+
+	PlayerState() {
+	}
+
+	PlayerState(const PlayerState&) = delete;
+	PlayerState& operator=(const PlayerState&) = delete;
+};
 
 /**
  * @brief A movie player
@@ -20,22 +54,64 @@ class Player {
 
 	std::unique_ptr<std::thread> m_decoderThread;
 
-	void processDecoderData(PlayerState* state);
+	PlayerState m_state;
+
+	bool processDecoderData();
 
  private:
-	Player(const Player&) = delete;
-
 	void decoderThread();
 
+	void initPlayback();
+
  public:
-	Player();
+	explicit Player(std::unique_ptr<Decoder>&& decoder);
 
 	~Player();
 
+	Player(const Player&) = delete;
+	Player& operator=(const Player&) = delete;
+
 	/**
-     * @brief Begin playing the previously selected movie
-     */
-	void startPlayback();
+	 * @brief Update the player and increase display timestamp by specified delta time
+	 * @param diff_time_micro The time to increase the display timestamp in microseconds (not milliseconds!)
+	 * @return @c true if there is more content to display. @c false if the player reached the end of the movie and has
+	 * 			displayed the last frame.
+	 */
+	bool update(uint64_t diff_time_micro);
+
+	/**
+	 * @brief Gives access to the internal state of the player
+	 *
+	 * @warning This should only be used for debugging purposed!
+	 *
+	 * @return A reference to the internal state
+	 */
+	const PlayerState& getInternalState() const;
+
+	/**
+	 * @brief Gets the properties of the movie that this player is displaying
+	 * @return A reference to the movie properties
+	 */
+	const MovieProperties& getMovieProperties() const;
+
+	/**
+	 * @brief Draws the current movie frame at the specified coordinates.
+	 *
+	 * This may not draw anything if there is currently not a frame to display.
+	 *
+	 * @param x1 The X coordinate of the top left corner
+	 * @param y1 The Y coordinate of the top left corner
+	 * @param x2 The X coordinate of the bottom right corner
+	 * @param y2 The Y coordinate of the bottom right corner
+	 */
+	void draw(float x1, float y1, float x2, float y2);
+
+	/**
+	 * @brief Stops playback
+	 *
+	 * This is also automatically called when this instance is destroyed.
+	 */
+	void stopPlayback();
 
 	/**
      * @brief Creates a player


### PR DESCRIPTION
This moves all the cutscene specific code out of the movie player code
and into the cutscene code so that the movie player can be reused for
usage in other environments.

This is required for #1041 since an implementation of that feature would
reuse the movie player code of the cutscene code but without all the
main loop stuff.