### PR TITLE
Pack vertex and index data into one buffer

### DIFF
--- a/code/cmdline/cmdline.cpp
+++ b/code/cmdline/cmdline.cpp
@@ -216,7 +216,6 @@ Flag exe_params[] =
 	{ "-use_gldrawelements","Don't use glDrawRangeElements",			true,	0,					EASY_DEFAULT,		"Troubleshoot",	"http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-use_gldrawelements", },
 	{ "-old_collision",		"Use old collision detection system",		true,	EASY_DEFAULT,		EASY_ALL_ON,		"Troubleshoot",	"http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-old_collision", },
 	{ "-gl_finish",			"Fix input lag on some ATI+Linux systems",	true,	0,					EASY_DEFAULT,		"Troubleshoot", "http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-gl_finish", },
-	{ "-no_batching",		"Disable batched model rendering",			true,	0,					EASY_DEFAULT,		"Troubleshoot", "", },
 	{ "-no_geo_effects",	"Disable geometry shader for effects",		true,	0,					EASY_DEFAULT,		"Troubleshoot", "", },
 	{ "-set_cpu_affinity",	"Sets processor affinity to config value",	true,	0,					EASY_DEFAULT,		"Troubleshoot", "", },
 	{ "-nograb",			"Disables mouse grabbing",					true,	0,					EASY_DEFAULT,		"Troubleshoot", "http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-nograb", },
@@ -333,7 +332,6 @@ cmdline_parm fxaa_preset_arg("-fxaa_preset", "FXAA quality (0-9), requires -post
 cmdline_parm fb_explosions_arg("-fb_explosions", NULL, AT_NONE);
 cmdline_parm fb_thrusters_arg("-fb_thrusters", NULL, AT_NONE);
 cmdline_parm flightshaftsoff_arg("-nolightshafts", NULL, AT_NONE);
-cmdline_parm no_batching("-no_batching", NULL, AT_NONE);
 cmdline_parm shadow_quality_arg("-shadow_quality", NULL, AT_INT);
 cmdline_parm enable_shadows_arg("-enable_shadows", NULL, AT_NONE);
 cmdline_parm no_deferred_lighting_arg("-no_deferred", NULL, AT_NONE);	// Cmdline_no_deferred
@@ -361,7 +359,6 @@ int Cmdline_fxaa_preset = 6;
 extern int Fxaa_preset_last_frame;
 bool Cmdline_fb_explosions = 0;
 bool Cmdline_fb_thrusters = false;
-bool Cmdline_no_batching = false;
 extern bool ls_force_off;
 int Cmdline_shadow_quality = 0;
 int Cmdline_no_deferred_lighting = 0;
@@ -2019,11 +2016,6 @@ bool SetCmdlineParams()
     {
         Cmdline_fb_thrusters = true;
     }
-
-	if ( no_batching.found() ) 
-	{
-		Cmdline_no_batching = true;
-	}
 
 	if ( postprocess_arg.found() )
 	{

--- a/code/cmdline/cmdline.h
+++ b/code/cmdline/cmdline.h
@@ -77,7 +77,6 @@ extern bool Cmdline_fxaa;
 extern int Cmdline_fxaa_preset;
 extern bool Cmdline_fb_explosions;
 extern bool Cmdline_fb_thrusters;
-extern bool Cmdline_no_batching;
 extern int Cmdline_shadow_quality;
 extern int Cmdline_no_deferred_lighting;
 extern int Cmdline_no_emissive;

--- a/code/graphics/2d.h
+++ b/code/graphics/2d.h
@@ -26,6 +26,7 @@
 namespace graphics {
 namespace util {
 class UniformBuffer;
+class GPUMemoryHeap;
 }
 }
 
@@ -544,20 +545,18 @@ public:
 };
 
 struct indexed_vertex_source {
-	void *Vertex_list;
-	void *Index_list;
+	void *Vertex_list = nullptr;
+	void *Index_list = nullptr;
 
-	int Vbuffer_handle;
-	int Ibuffer_handle;
+	int Vbuffer_handle = -1;
+	size_t Vertex_offset = 0;
+	size_t Base_vertex_offset = 0;
 
-	uint Vertex_list_size;
-	uint Index_list_size;
+	int Ibuffer_handle = -1;
+	size_t Index_offset = 0;
 
-	indexed_vertex_source() :
-		Vertex_list(NULL), Index_list(NULL),
-		Vbuffer_handle(-1), Ibuffer_handle(-1), Vertex_list_size(0), Index_list_size(0)
-	{
-	}
+	uint Vertex_list_size = 0;
+	uint Index_list_size = 0;
 };
 
 struct light;
@@ -1227,6 +1226,30 @@ struct DisplayData {
 };
 
 SCP_vector<DisplayData> gr_enumerate_displays();
+
+enum class GpuHeap {
+	ModelVertex = 0,
+	ModelIndex,
+
+	NUM_VALUES
+};
+
+/**
+ * @brief Allocates storage on the specified GPU heap and stores data in that storage
+ * @param heap_type The heap type to store this memory on
+ * @param size The size of the data
+ * @param data A pointer to the data
+ * @param[out] offset_out The offset at which the data is stored in the buffer
+ * @param[out] handle_out The handle of the buffer object this data is stored in
+ */
+void gr_heap_allocate(GpuHeap heap_type, size_t size, void* data, size_t& offset_out, int& handle_out);
+
+/**
+ * @brief Deallocates memory previously allocated with gr_heap_allocate.
+ * @param heap_type The heap type to deallocate this memory from
+ * @param data_offset The offset at which the data is stored.
+ */
+void gr_heap_deallocate(GpuHeap heap_type, size_t data_offset);
 
 // Include this last to make the 2D rendering function available everywhere
 #include "graphics/render.h"

--- a/code/graphics/util/GPUMemoryHeap.cpp
+++ b/code/graphics/util/GPUMemoryHeap.cpp
@@ -1,0 +1,71 @@
+//
+//
+
+#include "GPUMemoryHeap.h"
+
+namespace {
+BufferType getBufferType(GpuHeap heap_type) {
+	switch(heap_type) {
+	case GpuHeap::ModelVertex:
+		return BufferType::Vertex;
+	case GpuHeap::ModelIndex:
+		return BufferType::Index;
+	case GpuHeap::NUM_VALUES:
+	default:
+		Assertion(false, "Invalid heap type detected!");
+		return BufferType::Vertex;
+	}
+}
+}
+
+namespace graphics {
+namespace util {
+
+GPUMemoryHeap::GPUMemoryHeap(GpuHeap heap_type) {
+	_bufferHandle = gr_create_buffer(getBufferType(heap_type), BufferUsageHint::Static);
+
+	_allocator.reset(new ::util::HeapAllocator([this](size_t n) { resizeBuffer(n); }));
+}
+GPUMemoryHeap::~GPUMemoryHeap() {
+	if (_bufferHandle != -1) {
+		gr_delete_buffer(_bufferHandle);
+		_bufferHandle = -1;
+	}
+
+	if (_dataBuffer != nullptr) {
+		vm_free(_dataBuffer);
+
+		_dataBuffer = nullptr;
+		_bufferSize = 0;
+	}
+}
+void GPUMemoryHeap::resizeBuffer(size_t newSize) {
+	_dataBuffer = vm_realloc(_dataBuffer, newSize);
+	_bufferSize = newSize;
+
+	gr_update_buffer_data(_bufferHandle, _bufferSize, _dataBuffer);
+}
+void* GPUMemoryHeap::bufferPointer(size_t offset) {
+	auto bytePtr = reinterpret_cast<uint8_t*>(_dataBuffer);
+
+	return reinterpret_cast<void*>(bytePtr + offset);
+}
+size_t GPUMemoryHeap::allocateGpuData(size_t size, void* data) {
+	auto offset = _allocator->allocate(size);
+
+	auto dataPtr = bufferPointer(offset);
+	memcpy(dataPtr, data, size);
+	gr_update_buffer_data_offset(_bufferHandle, offset, size, data);
+
+	return offset;
+}
+void GPUMemoryHeap::freeGpuData(size_t offset) {
+	_allocator->free(offset);
+	// Just leave the data in the buffers since it doesn't hurt anyone if it's kept in there
+}
+int GPUMemoryHeap::bufferHandle() {
+	return _bufferHandle;
+}
+
+}
+}

--- a/code/graphics/util/GPUMemoryHeap.h
+++ b/code/graphics/util/GPUMemoryHeap.h
@@ -1,0 +1,61 @@
+#pragma once
+
+#include "globalincs/pstypes.h"
+#include "utils/HeapAllocator.h"
+#include "graphics/2d.h"
+
+
+namespace graphics {
+namespace util {
+
+/**
+ * @brief A custom heap structure that uses a GPU buffer for storing the data
+ *
+ * @details This also keeps a client side copy of the data since that is required if the buffer is resized since the
+ * original data will not be kept in that case.
+ */
+class GPUMemoryHeap {
+	std::unique_ptr<::util::HeapAllocator> _allocator;
+	int _bufferHandle = -1;
+
+	void* _dataBuffer = nullptr;
+	size_t _bufferSize = 0;
+
+	void resizeBuffer(size_t newSize);
+
+	void* bufferPointer(size_t offset);
+ public:
+	explicit GPUMemoryHeap(GpuHeap heap_type);
+	~GPUMemoryHeap();
+
+	GPUMemoryHeap(const GPUMemoryHeap&) = delete;
+	GPUMemoryHeap& operator=(const GPUMemoryHeap&) = delete;
+
+	/**
+	 * @brief Store some data in a GPU heap
+	 * @param size The size of the data to store
+	 * @param data The data to store
+	 * @return The offset in bytes from the beginning of the buffer where the stored data begins
+	 */
+	size_t allocateGpuData(size_t size, void* data);
+
+	/**
+	 * @brief Frees up some GPU data from this heap
+	 * @param offset The offset at which to free the data
+	 */
+	void freeGpuData(size_t offset);
+
+	/**
+	 * @brief Gets the handle of the used buffer for use in rendering operations
+	 *
+	 * @warning Do no change the contents of this buffer! The contents are managed by this class and may not be changed
+	 * by external code.
+	 *
+	 * @return The graphics code buffer handle.
+	 */
+	int bufferHandle();
+};
+
+}
+}
+

--- a/code/model/model.h
+++ b/code/model/model.h
@@ -1313,6 +1313,7 @@ void model_draw_bay_paths_htl(int model_num);
 
 bool model_interp_config_buffer(indexed_vertex_source *vert_src, vertex_buffer *vb, bool update_ibuffer_only);
 bool model_interp_pack_buffer(indexed_vertex_source *vert_src, vertex_buffer *vb);
+void model_interp_submit_buffers(indexed_vertex_source *vert_src, size_t vertex_stride);
 void model_allocate_interp_data(int n_verts = 0, int n_norms = 0);
 
 void glowpoint_init();

--- a/code/model/modelread.cpp
+++ b/code/model/modelread.cpp
@@ -303,8 +303,11 @@ void model_unload(int modelnum, int force)
 	}
 
 	if ( pm->vert_source.Vbuffer_handle > -1 ) {
-		gr_delete_buffer(pm->vert_source.Vbuffer_handle);
+		gr_heap_deallocate(GpuHeap::ModelVertex, pm->vert_source.Vertex_offset);
 		pm->vert_source.Vbuffer_handle = -1;
+
+		pm->vert_source.Vertex_offset = 0;
+		pm->vert_source.Base_vertex_offset = 0;
 	}
 
 	if ( pm->vert_source.Vertex_list != NULL ) {
@@ -313,8 +316,10 @@ void model_unload(int modelnum, int force)
 	}
 
 	if ( pm->vert_source.Ibuffer_handle > -1 ) {
-		gr_delete_buffer(pm->vert_source.Ibuffer_handle);
+		gr_heap_deallocate(GpuHeap::ModelIndex, pm->vert_source.Index_offset);
+
 		pm->vert_source.Ibuffer_handle = -1;
+		pm->vert_source.Index_offset = 0;
 	}
 
 	if ( pm->vert_source.Index_list != NULL ) {
@@ -895,31 +900,23 @@ void create_vertex_buffer(polymodel *pm)
 		}
 	}
 
-	bool use_batched_rendering = true;
+	size_t stride = 0;
+	// Determine the global stride of this model (should be the same for every submodel)
+	for ( i = 0; i < pm->n_models; ++i ) {
+		if (pm->submodel[i].buffer.model_list != nullptr && pm->submodel[i].buffer.stride != stride) {
+			Assertion(stride == 0, "Submodel %d of model %s has a stride of "
+				SIZE_T_ARG
+				" while the rest of the model has a vertex stride of "
+				SIZE_T_ARG
+				"!", i, pm->filename, pm->submodel[i].buffer.stride, stride);
 
-	if ( !Cmdline_no_batching ) {
-		size_t stride = 0;
-
-		// figure out if the vertex stride of this entire model matches. if not, turn off batched rendering for this model
-		for ( i = 0; i < pm->n_models; ++i ) {
-			if ( pm->submodel[i].buffer.model_list != NULL && pm->submodel[i].buffer.stride != stride) {
-				if ( stride == 0 ) {
-					stride = pm->submodel[i].buffer.stride;
-				} else {
-					use_batched_rendering = false;
-					break;
-				}
-			}
+			stride = pm->submodel[i].buffer.stride;
 		}
-	} else {
-		use_batched_rendering = false;
 	}
 
 	// create another set of indexes for the detail buffers
-	if ( use_batched_rendering ) {
-		for ( i = 0; i < pm->n_detail_levels; i++ )	{
-			interp_create_detail_index_buffer(pm, i);
-		}
+	for ( i = 0; i < pm->n_detail_levels; i++ )	{
+		interp_create_detail_index_buffer(pm, i);
 	}
 
 	// now actually fill the buffer with our info ...
@@ -931,22 +928,20 @@ void create_vertex_buffer(polymodel *pm)
 		pm->submodel[i].trans_buffer.release();
 	}
 
-	if ( use_batched_rendering ) {
-		// pack the merged index buffers to the vbo.
-		for ( i = 0; i < pm->n_detail_levels; ++i ) {
-			if ( pm->detail_buffers[i].model_list == NULL ) {
-				continue;
-			}
-
-			model_interp_pack_buffer(&pm->vert_source, &pm->detail_buffers[i]);
-			pm->detail_buffers[i].release();
+	// pack the merged index buffers to the vbo.
+	for ( i = 0; i < pm->n_detail_levels; ++i ) {
+		if ( pm->detail_buffers[i].model_list == NULL ) {
+			continue;
 		}
 
-		pm->flags |= PM_FLAG_BATCHED;
+		model_interp_pack_buffer(&pm->vert_source, &pm->detail_buffers[i]);
+		pm->detail_buffers[i].release();
 	}
 
+	pm->flags |= PM_FLAG_BATCHED;
+
 	// ... and then finalize buffer
-	model_interp_pack_buffer(&pm->vert_source, NULL);
+	model_interp_submit_buffers(&pm->vert_source, stride);
 
 	model_interp_process_shield_mesh(pm);
 }
@@ -1154,6 +1149,7 @@ int read_model_file(polymodel * pm, const char *filename, int n_subsystems, mode
 				pm->n_models = cfread_int(fp);
 //				mprintf(( "Num models = %d\n", pm->n_models ));
 #endif
+                Assertion(pm->n_models >= 1, "Models without any submodels are not supported!");
 
 				// Check for unrealistic radii
 				if ( pm->rad <= 0.1f )
@@ -2594,25 +2590,23 @@ void model_load_texture(polymodel *pm, int i, char *file)
 
 	gr_maybe_create_shader(SDR_TYPE_MODEL, shader_flags | SDR_FLAG_MODEL_LIGHT);
 	gr_maybe_create_shader(SDR_TYPE_MODEL, shader_flags | SDR_FLAG_MODEL_LIGHT | SDR_FLAG_MODEL_FOG);
-	
-	if( !Cmdline_no_batching ) {
-		shader_flags &= ~SDR_FLAG_MODEL_DEFERRED;
-		shader_flags |= SDR_FLAG_MODEL_TRANSFORM;
 
-		gr_maybe_create_shader(SDR_TYPE_MODEL, shader_flags | SDR_FLAG_MODEL_LIGHT | SDR_FLAG_MODEL_ANIMATED);
-		gr_maybe_create_shader(SDR_TYPE_MODEL, shader_flags | SDR_FLAG_MODEL_LIGHT | SDR_FLAG_MODEL_ANIMATED | SDR_FLAG_MODEL_FOG);
+	shader_flags &= ~SDR_FLAG_MODEL_DEFERRED;
+	shader_flags |= SDR_FLAG_MODEL_TRANSFORM;
 
-		gr_maybe_create_shader(SDR_TYPE_MODEL, shader_flags | SDR_FLAG_MODEL_LIGHT);
-		gr_maybe_create_shader(SDR_TYPE_MODEL, shader_flags | SDR_FLAG_MODEL_LIGHT | SDR_FLAG_MODEL_FOG);
+	gr_maybe_create_shader(SDR_TYPE_MODEL, shader_flags | SDR_FLAG_MODEL_LIGHT | SDR_FLAG_MODEL_ANIMATED);
+	gr_maybe_create_shader(SDR_TYPE_MODEL, shader_flags | SDR_FLAG_MODEL_LIGHT | SDR_FLAG_MODEL_ANIMATED | SDR_FLAG_MODEL_FOG);
 
-		shader_flags |= SDR_FLAG_MODEL_DEFERRED;
+	gr_maybe_create_shader(SDR_TYPE_MODEL, shader_flags | SDR_FLAG_MODEL_LIGHT);
+	gr_maybe_create_shader(SDR_TYPE_MODEL, shader_flags | SDR_FLAG_MODEL_LIGHT | SDR_FLAG_MODEL_FOG);
 
-		gr_maybe_create_shader(SDR_TYPE_MODEL, shader_flags | SDR_FLAG_MODEL_LIGHT | SDR_FLAG_MODEL_ANIMATED);
-		gr_maybe_create_shader(SDR_TYPE_MODEL, shader_flags | SDR_FLAG_MODEL_LIGHT | SDR_FLAG_MODEL_ANIMATED | SDR_FLAG_MODEL_FOG);
+	shader_flags |= SDR_FLAG_MODEL_DEFERRED;
 
-		gr_maybe_create_shader(SDR_TYPE_MODEL, shader_flags | SDR_FLAG_MODEL_LIGHT);
-		gr_maybe_create_shader(SDR_TYPE_MODEL, shader_flags | SDR_FLAG_MODEL_LIGHT | SDR_FLAG_MODEL_FOG);
-	}
+	gr_maybe_create_shader(SDR_TYPE_MODEL, shader_flags | SDR_FLAG_MODEL_LIGHT | SDR_FLAG_MODEL_ANIMATED);
+	gr_maybe_create_shader(SDR_TYPE_MODEL, shader_flags | SDR_FLAG_MODEL_LIGHT | SDR_FLAG_MODEL_ANIMATED | SDR_FLAG_MODEL_FOG);
+
+	gr_maybe_create_shader(SDR_TYPE_MODEL, shader_flags | SDR_FLAG_MODEL_LIGHT);
+	gr_maybe_create_shader(SDR_TYPE_MODEL, shader_flags | SDR_FLAG_MODEL_LIGHT | SDR_FLAG_MODEL_FOG);
 }
 
 //returns the number of this model

--- a/code/model/modelrender.cpp
+++ b/code/model/modelrender.cpp
@@ -2736,7 +2736,7 @@ void model_render_queue(model_render_params *interp, model_draw_list *scene, int
 		rendering_material.set_depth_bias(0);
 	}
 
-	if ( !Cmdline_no_batching && !(model_flags & MR_NO_BATCH) && pm->flags & PM_FLAG_BATCHED 
+	if ( !(model_flags & MR_NO_BATCH) && pm->flags & PM_FLAG_BATCHED
 		&& !(is_outlines_only || is_outlines_only_htl) ) {
 		// always set batched rendering on if supported
 		tmap_flags |= TMAP_FLAG_BATCH_TRANSFORMS;

--- a/code/source_groups.cmake
+++ b/code/source_groups.cmake
@@ -403,6 +403,8 @@ set (file_root_graphics_softwaregr_font
 )
 
 set(file_root_graphics_util
+	graphics/util/GPUMemoryHeap.cpp
+	graphics/util/GPUMemoryHeap.h
 	graphics/util/uniform_structs.h
 	graphics/util/UniformAligner.h
 	graphics/util/UniformAligner.cpp
@@ -1200,6 +1202,8 @@ set (file_root_ui
 set(file_root_utils
 	utils/encoding.cpp
     utils/encoding.h
+	utils/HeapAllocator.cpp
+	utils/HeapAllocator.h
 	utils/RandomRange.h
 	utils/strings.h
     utils/unicode.cpp

--- a/code/tracing/categories.cpp
+++ b/code/tracing/categories.cpp
@@ -119,4 +119,6 @@ Category WeaponPageIn("Weapon page in", false);
 
 Category RenderDecals("Render all decals", true);
 Category RenderSingleDecal("Render single decal", true);
+Category GpuHeapAllocate("GPU heap allocate", false);
+Category GpuHeapDeallocate("GPU heap deallocate", false);
 }

--- a/code/tracing/categories.h
+++ b/code/tracing/categories.h
@@ -132,6 +132,10 @@ extern Category WeaponPageIn;
 
 extern Category RenderDecals;
 extern Category RenderSingleDecal;
+
+extern Category GpuHeapAllocate;
+extern Category GpuHeapDeallocate;
+
 }
 
 #endif // _TRACING_CATEGORIES_H

--- a/code/utils/HeapAllocator.cpp
+++ b/code/utils/HeapAllocator.cpp
@@ -1,0 +1,198 @@
+#include "utils/HeapAllocator.h"
+
+namespace {
+
+const size_t HEAP_SIZE_INCREASE = 1 * 1024 * 1024; // Always increment in 1MB steps
+const size_t HEAP_MAX_INCREASE = 20 * 1024 * 1024; // never increase heap size by more than 20MB
+
+template<typename TIter, typename T>
+TIter get_element_before(TIter first, TIter last, const T& value) {
+	if (first == last) {
+		// There are no elements in the range
+		return last;
+	}
+
+	auto iter = std::upper_bound(first, last, value);
+
+	if (iter == first) {
+		// The element before this does not exist
+		return last;
+	}
+
+	// We found the position (which may be last) so now we can decrement it once to get the element before this found position
+	return std::next(iter, -1);
+}
+
+}
+
+namespace util {
+HeapAllocator::HeapAllocator(const HeapAllocator::HeapResizer& creator) : _heapResizer(creator) {
+	_heapSize = HEAP_SIZE_INCREASE;
+	_lastSizeIncraese = HEAP_SIZE_INCREASE;
+	_heapResizer(_heapSize);
+
+	MemoryRange range;
+	range.offset = 0;
+	range.size = _heapSize;
+
+	addFreeRange(range);
+}
+size_t HeapAllocator::allocate(size_t size) {
+	// Do a simple first-fit algorithm. Not very efficient but it should do the job well for our purposes
+	for (auto iter = _freeRanges.begin(); iter != _freeRanges.end(); ++iter) {
+		if (iter->size >= size) {
+			// Found a match!
+			auto offset = iter->offset;
+
+			iter->offset += size;
+			iter->size -= size;
+
+			if (iter->size == 0) {
+				// This range is now empty and must be removed. Since we won't be using this iterator anymore it can be
+				// safely erased
+				_freeRanges.erase(iter);
+			}
+
+			MemoryRange allocated;
+			allocated.size = size;
+			allocated.offset = offset;
+
+			addAllocatedRange(allocated);
+
+			return offset;
+		}
+	}
+
+	// No free range found => increase size of heap
+
+	// We increase the heap size every time we run out of memory in order to reduce reallocation times
+	_lastSizeIncraese = std::min(HEAP_MAX_INCREASE, 2 * _lastSizeIncraese);
+
+	// Make sure that our allocation can actually fit into the new block if its too large for a single increase
+	auto increase = std::max(HEAP_SIZE_INCREASE, _lastSizeIncraese);
+	auto lastOffset = _heapSize;
+
+	_heapSize += increase;
+	_heapResizer(_heapSize);
+
+	MemoryRange newFree;
+	newFree.offset = lastOffset;
+	newFree.size = increase;
+
+	addFreeRange(newFree);
+
+	// Call us again but this time it should succeed
+	return allocate(size);
+}
+void HeapAllocator::addFreeRange(const HeapAllocator::MemoryRange& range) {
+	if (range.size == 0) {
+		// Ignore empty ranges
+		return;
+	}
+
+	Assertion(std::is_sorted(_freeRanges.begin(), _freeRanges.end()),
+			  "Free ranges were not sorted before adding a free range.");
+
+	auto left = get_element_before(_freeRanges.begin(), _freeRanges.end(), range);
+	auto right = std::upper_bound(_freeRanges.begin(), _freeRanges.end(), range);
+
+	if (left != _freeRanges.end()) {
+		// This new range may be just after another
+		if (left->offset + left->size == range.offset) {
+			left->size += range.size;
+
+			// After this operation the two ranges may be connected. If that happens then they need to be merged as well
+			if (right != _freeRanges.end() && check_connected_range(*left, *right)) {
+				left->size += right->size;
+				_freeRanges.erase(right);
+			}
+
+			checkRangesMerged();
+
+			// The range has been added by merging it with another
+			return;
+		}
+	}
+
+	if (right != _freeRanges.end()) {
+		// This new range may be just before another
+		if (range.offset + range.size == right->offset) {
+			right->offset = range.offset;
+			right->size += range.size;
+
+			// After this operation the two ranges may be connected. If that happens then they need to be merged as well
+			if (left != _freeRanges.end() && check_connected_range(*left, *right)) {
+				left->size += right->size;
+				_freeRanges.erase(right);
+			}
+
+			checkRangesMerged();
+
+			// The range has been added by merging it with another
+			return;
+		}
+	}
+
+	// If we are here then we found no range to merge the new range into
+	_freeRanges.insert(right, range);
+
+	checkRangesMerged();
+}
+void HeapAllocator::addAllocatedRange(const HeapAllocator::MemoryRange& range) {
+	Assertion(std::is_sorted(_allocatedRanges.begin(), _allocatedRanges.end()), "Allocated ranges are not sorted!");
+	Assertion(!std::binary_search(_allocatedRanges.begin(), _allocatedRanges.end(), range),
+			  "Allocated ranges already contain the specified range!");
+
+	// We need to keep the vector sorted for better search performance so we insert this new range at the sorted position
+	// into the vector
+	auto it = std::upper_bound(_allocatedRanges.begin(), _allocatedRanges.end(), range);
+
+	// This works even if it is .end() since .insert will just add it to the vector in that case
+	_allocatedRanges.insert(it, range);
+
+	Assertion(std::is_sorted(_allocatedRanges.begin(), _allocatedRanges.end()), "Allocated ranges are not sorted!");
+}
+void HeapAllocator::free(size_t offset) {
+	// We use a dummy range for finding the entry in our allocated ranges
+	MemoryRange range;
+	range.offset = offset;
+
+	auto it = std::lower_bound(_allocatedRanges.begin(), _allocatedRanges.end(), range);
+
+	// Make sure that the range is valid
+	Assertion(it != _allocatedRanges.end(), "Specified offset was not found in the allocated ranges!");
+	Assertion(it->offset == offset, "Specified offset does not point to the start of an allocated range!");
+
+	// Copy the range out of the vector before erasing it so we can add it to the free ranges
+	auto freedRange = *it;
+
+	_allocatedRanges.erase(it);
+
+	addFreeRange(freedRange);
+}
+size_t HeapAllocator::numAllocations() const {
+	return _allocatedRanges.size();
+}
+bool HeapAllocator::check_connected_range(const MemoryRange& left, const MemoryRange& right) {
+	return left.offset + left.size == right.offset;
+}
+void HeapAllocator::checkRangesMerged() {
+	bool first = true;
+	size_t lastEnd = 0;
+	for (auto& range : _freeRanges) {
+		if (!first) {
+			Assertion(lastEnd != range.offset, "Found unmerged ranges at offset " SIZE_T_ARG "!", lastEnd);
+		}
+
+		lastEnd = range.offset + range.size;
+		first = false;
+	}
+}
+
+bool HeapAllocator::MemoryRange::operator<(const HeapAllocator::MemoryRange& other) const {
+	return offset < other.offset;
+}
+bool HeapAllocator::MemoryRange::operator==(const HeapAllocator::MemoryRange& other) const {
+	return offset == other.offset;
+}
+}

--- a/code/utils/HeapAllocator.h
+++ b/code/utils/HeapAllocator.h
@@ -1,0 +1,74 @@
+#pragma once
+
+#include "globalincs/pstypes.h"
+
+#include <functional>
+
+namespace util {
+
+/**
+ * @brief A generic heap manager
+ *
+ * This class does not allocate memory! It only keeps track of where memory is stored and which memory ranges may be
+ * reused later. This needs some kind of underlying memory manager before it can do anything.
+ */
+class HeapAllocator {
+ public:
+	/**
+	 * @brief A function that can resize a generic heap structure.
+	 *
+	 * This takes the new size of the heap as its only parameter.
+	 */
+	typedef std::function<void(size_t)> HeapResizer;
+
+ private:
+	struct MemoryRange {
+		size_t offset = 0;
+		size_t size = 0;
+
+		bool operator<(const MemoryRange& other) const;
+		bool operator==(const MemoryRange& other) const;
+	};
+
+	size_t _heapSize = 0;
+	size_t _lastSizeIncraese = 0;
+
+	HeapResizer _heapResizer;
+
+	SCP_vector<MemoryRange> _freeRanges;
+	SCP_vector<MemoryRange> _allocatedRanges;
+
+	void addFreeRange(const MemoryRange& range);
+	void addAllocatedRange(const MemoryRange& range);
+
+	/**
+	 * @brief Checks if all free ranges are merged properly.
+	 */
+	void checkRangesMerged();
+
+	static bool check_connected_range(const MemoryRange& left, const MemoryRange& right);
+ public:
+	explicit HeapAllocator(const HeapResizer& creatorFunction);
+	~HeapAllocator() = default;
+
+	/**
+	 * @brief Allocates the specified amount of memory
+	 * @param size The size of the memory block to allocate
+	 * @return The offset at which the specified amount of memory can be used
+	 */
+	size_t allocate(size_t size);
+
+	/**
+	 * @brief Frees the memory starting at the specified offset.
+	 * @param offset The offset at which to free memory. This value must have been returned by allocate previously!
+	 */
+	void free(size_t offset);
+
+	/**
+	 * @brief Retrieves the amount of allocations currently active
+	 * @return The active allocations in this heap.
+	 */
+	size_t numAllocations() const;
+};
+
+}

--- a/test/src/source_groups.cmake
+++ b/test/src/source_groups.cmake
@@ -61,10 +61,14 @@ add_file_folder(scripting_api "Scripting\\\\Lua"
     scripting/lua/Value.cpp
 )
 
-add_file_folder(util "Util"
+add_file_folder(util "Test Util"
     util/FSTestFixture.cpp
     util/FSTestFixture.h
     util/test_util.h
+)
+
+add_file_folder(utils "Utils"
+    utils/HeapAllocatorTest.cpp
 )
 
 add_file_folder(weapon "Weapon"

--- a/test/src/utils/HeapAllocatorTest.cpp
+++ b/test/src/utils/HeapAllocatorTest.cpp
@@ -1,0 +1,141 @@
+
+#include <gtest/gtest.h>
+#include <random>
+
+#include "utils/HeapAllocator.h"
+
+using namespace util;
+
+namespace {
+void dummyResizer(size_t) {}
+}
+
+TEST(HeapAllocatorTests, simpleAllocate) {
+	HeapAllocator allocator(dummyResizer);
+
+	ASSERT_EQ((size_t)0, allocator.numAllocations());
+
+	auto offset = allocator.allocate(200);
+
+	ASSERT_EQ((size_t)1, allocator.numAllocations());
+
+	allocator.free(offset);
+
+	ASSERT_EQ((size_t)0, allocator.numAllocations());
+}
+
+TEST(HeapAllocatorTests, manySmallAllocations) {
+	HeapAllocator allocator(dummyResizer);
+
+	std::random_device rd;  //Will be used to obtain a seed for the random number engine
+	std::mt19937 gen(rd()); //Standard mersenne_twister_engine seeded with rd()
+	std::uniform_int_distribution<size_t> sizeDist(1, 50000);
+
+	SCP_vector<size_t> offsets;
+	// Allocate enough small ranges to require a resize at some point
+	for (auto i = 0; i < 1500; ++i) {
+		auto size = sizeDist(gen);
+
+		// Use multiples of 52 since that is what the model code uses as the vertex stride
+		size_t x = allocator.allocate(52 * size);
+
+		// Make sure that all offsets are aligned properly
+		ASSERT_EQ((size_t)0, x % 52);
+
+		offsets.push_back(x);
+	}
+
+	ASSERT_EQ(offsets.size(), allocator.numAllocations());
+
+
+	// Free some ranges in a non-contiguous manner to test range freeing and merging
+	while (offsets.size() > 512) {
+		std::uniform_int_distribution<size_t> dis(0, offsets.size() - 1);
+		auto el = std::next(offsets.begin(), dis(gen));
+
+		allocator.free(*el);
+		offsets.erase(el);
+
+		ASSERT_EQ(offsets.size(), allocator.numAllocations());
+	}
+
+	ASSERT_EQ(offsets.size(), allocator.numAllocations());
+
+	// Allocate some more ranges to test range reuse
+	for (auto i = 0; i < 1500; ++i) {
+		auto size = sizeDist(gen);
+
+		// Use multiples of 52 since that is what the model code uses as the vertex stride
+		size_t x = allocator.allocate(52 * size);
+
+		// Make sure that all offsets are aligned properly
+		ASSERT_EQ((size_t)0, x % 52);
+
+		offsets.push_back(x);
+	}
+
+	ASSERT_EQ(offsets.size(), allocator.numAllocations());
+
+	// And now empty the entire allocator
+	while (!offsets.empty()) {
+		std::uniform_int_distribution<size_t> dis(0, offsets.size() - 1);
+		auto el = std::next(offsets.begin(), dis(gen));
+
+		allocator.free(*el);
+		offsets.erase(el);
+
+		ASSERT_EQ(offsets.size(), allocator.numAllocations());
+	}
+
+	ASSERT_EQ(offsets.size(), allocator.numAllocations());
+	ASSERT_EQ((size_t)0, offsets.size());
+}
+
+TEST(HeapAllocatorTests, largeAllocations) {
+	HeapAllocator allocator(dummyResizer);
+
+	SCP_vector<size_t> offsets;
+	// Allocate enough small ranges to require a resize at some point
+	for (auto i = 0; i < 100; ++i) {
+		offsets.push_back(allocator.allocate(10 * 1024 * 1024));
+	}
+
+	ASSERT_EQ(offsets.size(), allocator.numAllocations());
+
+	std::random_device rd;  //Will be used to obtain a seed for the random number engine
+	std::mt19937 gen(rd()); //Standard mersenne_twister_engine seeded with rd()
+
+	// Free some ranges in a non-contiguous manner to test range freeing and merging
+	while (offsets.size() > 50) {
+		std::uniform_int_distribution<size_t> dis(0, offsets.size() - 1);
+		auto el = std::next(offsets.begin(), dis(gen));
+
+		allocator.free(*el);
+		offsets.erase(el);
+
+		ASSERT_EQ(offsets.size(), allocator.numAllocations());
+	}
+
+	ASSERT_EQ(offsets.size(), allocator.numAllocations());
+
+	// Allocate some more ranges to test range reuse
+	for (auto i = 0; i < 100; ++i) {
+		offsets.push_back(allocator.allocate(10 * 1024 * 1024));
+	}
+
+	ASSERT_EQ(offsets.size(), allocator.numAllocations());
+
+	// And now empty the entire allocator
+	while (!offsets.empty()) {
+		std::uniform_int_distribution<size_t> dis(0, offsets.size() - 1);
+		auto el = std::next(offsets.begin(), dis(gen));
+
+		allocator.free(*el);
+		offsets.erase(el);
+
+		ASSERT_EQ(offsets.size(), allocator.numAllocations());
+	}
+
+	ASSERT_EQ(offsets.size(), allocator.numAllocations());
+	ASSERT_EQ((size_t)0, offsets.size());
+}


### PR DESCRIPTION
This changes the model loading code such that all index and vertex data
is packed in a single GPU buffer for each data type (index and vertex
data are still in separate buffers). This reduces the amount of buffer
rebinding needed when rendering a scene which will reduce the CPU
overhead. Furthermore, this opens up possibilities of future
improvements for which it is beneficial if all data is in the same
buffer (e.g. MultiDrawIndirect rendering).

To manage where to put the data in the GPU buffer I implemented a
custom HeapAllocator which manages where data can be put. It uses a very
primitive first-fit algorithm but that is sufficient for this usage
type. This does add quite a lot of overhead while allocating GPU model
data (I did some tracing and some allocation calls took as long as
130ms).

This fixes #1457.