### PR TITLE
Use built-in OpenGL clipping planes for model transforms

### DIFF
--- a/code/def_files/main-f.sdr
+++ b/code/def_files/main-f.sdr
@@ -117,9 +117,6 @@ in float fragFogDist;
 #ifdef FLAG_ANIMATED
 uniform sampler2D sFramebuffer;
 #endif
-#ifdef FLAG_TRANSFORM
-in float fragNotVisible;
-#endif
 #ifdef FLAG_TEAMCOLOR
 vec2 teamMask = vec2(0.0, 0.0);
 #endif
@@ -305,9 +302,6 @@ vec3 CalculateLighting(vec3 normal, vec3 diffuseMaterial, vec3 specularMaterial,
 #endif
 void main()
 {
-#ifdef FLAG_TRANSFORM
-	if(fragNotVisible >= 0.9) { discard; }
-#endif
 #ifdef FLAG_SHADOW_MAP
 	// need depth and depth squared for variance shadow maps
 	fragOut0 = vec4(fragPosition.z, fragPosition.z * fragPosition.z * VARIANCE_SHADOW_SCALE_INV, 0.0, 1.0);

--- a/code/def_files/main-g.sdr
+++ b/code/def_files/main-g.sdr
@@ -104,10 +104,6 @@ in vec4 geoTexCoord[];
 out vec4 fragPosition;
 out vec3 fragNormal;
 out vec4 fragTexCoord;
-#ifdef FLAG_TRANSFORM
-in float geoNotVisible[];
-out float fragNotVisible;
-#endif
 void main(void)
 {
 #ifdef GL_ARB_gpu_shader5
@@ -125,10 +121,7 @@ void main(void)
 		fragTexCoord = geoTexCoord[vert];
 
 		gl_Layer = instanceID;
-#ifdef FLAG_TRANSFORM
-		fragNotVisible = geoNotVisible[0];
-#endif
-#ifdef FLAG_CLIP
+#if defined(FLAG_CLIP) || defined(FLAG_TRANSFORM)
 		gl_ClipDistance[0] = gl_in[vert].gl_ClipDistance[0];
 #endif
 		EmitVertex();

--- a/code/def_files/main-v.sdr
+++ b/code/def_files/main-v.sdr
@@ -107,11 +107,6 @@ out float fragFogDist;
 #endif
 #ifdef FLAG_TRANSFORM
 uniform samplerBuffer transform_tex;
-#ifdef FLAG_SHADOW_MAP
-out float geoNotVisible;
-#else
-out float fragNotVisible;
-#endif
 #endif
 #ifdef FLAG_SHADOW_MAP
 #if !defined(GL_ARB_gpu_shader5)
@@ -130,13 +125,13 @@ out vec4 fragShadowPos;
 #endif
 #ifdef FLAG_TRANSFORM
 #define TEXELS_PER_MATRIX 4
-void getModelTransform(inout mat4 transform, out float invisible, int id, int matrix_offset)
+void getModelTransform(inout mat4 transform, out bool invisible, int id, int matrix_offset)
 {
 	transform[0] = texelFetch(transform_tex, (matrix_offset + id) * TEXELS_PER_MATRIX);
 	transform[1] = texelFetch(transform_tex, (matrix_offset + id) * TEXELS_PER_MATRIX + 1);
 	transform[2] = texelFetch(transform_tex, (matrix_offset + id) * TEXELS_PER_MATRIX + 2);
 	transform[3] = texelFetch(transform_tex, (matrix_offset + id) * TEXELS_PER_MATRIX + 3);
-	invisible = transform[3].w;
+	invisible = transform[3].w >= 0.9;
 	transform[3].w = 1.0;
 }
 #endif
@@ -160,13 +155,10 @@ void main()
 	mat4 orient = mat4(1.0);
 	mat4 scale = mat4(1.0);
  #ifdef FLAG_TRANSFORM
-	float invisible;
-	getModelTransform(orient, invisible, int(vertModelID), buffer_matrix_offset);
-  #ifdef FLAG_SHADOW_MAP
-	geoNotVisible = invisible;
-  #else
-	fragNotVisible = invisible;
-  #endif
+	bool clipModel;
+	getModelTransform(orient, clipModel, int(vertModelID), buffer_matrix_offset);
+ #else
+	bool clipModel = false;
  #endif
 	texCoord = textureMatrix * vertTexCoord;
 	vec4 vertex = vertPosition;
@@ -217,11 +209,15 @@ void main()
 	fragFogDist = clamp((gl_Position.z - fogStart) * 0.75 * fogScale, 0.0, 1.0);
  #endif
  #ifdef FLAG_CLIP
-	if(use_clip_plane) {
+	if (clipModel) {
+		gl_ClipDistance[0] = -1.0;
+	} else if(use_clip_plane) {
 		gl_ClipDistance[0] = dot(clip_equation, modelMatrix * orient * vertex);
 	} else {
-		gl_ClipDistance[0] = -1.0f;
+		gl_ClipDistance[0] = 1.0;
 	}
+ #elif defined(FLAG_TRANSFORM)
+	gl_ClipDistance[0] = clipModel ? -1.0 : 1.0;
  #endif
  #ifndef FLAG_SHADOW_MAP
 	fragPosition = position;

--- a/code/graphics/opengl/gropengltnl.cpp
+++ b/code/graphics/opengl/gropengltnl.cpp
@@ -511,19 +511,6 @@ void opengl_create_orthographic_projection_matrix(matrix4* out, float left, floa
 	out->a1d[15] = 1.0f;
 }
 
-void gr_opengl_set_clip_plane(const vec3d *clip_normal, const vec3d *clip_point)
-{
-	if ( clip_normal == NULL || clip_point == NULL ) {
-		GL_state.ClipDistance(0, false);
-	} else {
-		Assertion(Current_shader != NULL && (Current_shader->shader == SDR_TYPE_MODEL
-			|| Current_shader->shader == SDR_TYPE_PASSTHROUGH_RENDER
-			|| Current_shader->shader == SDR_TYPE_DEFAULT_MATERIAL), "Clip planes are not supported by this shader!");
-
-		GL_state.ClipDistance(0, true);
-	}
-}
-
 extern bool Glowpoint_override;
 bool Glowpoint_override_save;
 
@@ -577,7 +564,7 @@ void gr_opengl_shadow_map_end()
 	glScissor(gr_screen.offset_x, (gr_screen.max_h - gr_screen.offset_y - gr_screen.clip_height), gr_screen.clip_width, gr_screen.clip_height);
 }
 
-void opengl_tnl_set_material(material* material_info, bool set_base_map)
+void opengl_tnl_set_material(material* material_info, bool set_base_map, bool set_clipping)
 {
 	int shader_handle = material_info->get_shader_handle();
 	int base_map = material_info->get_texture_map(TM_BASE_TYPE);
@@ -606,12 +593,19 @@ void opengl_tnl_set_material(material* material_info, bool set_base_map)
 
 	gr_set_texture_addressing(material_info->get_texture_addressing());
 
-	auto& clip_params = material_info->get_clip_plane();
+	if (set_clipping) {
+		// Only set the clipping state if explicitly requested by the caller to avoid unnecessary state changes
+		auto& clip_params = material_info->get_clip_plane();
+		if (!clip_params.enabled) {
+			GL_state.ClipDistance(0, false);
+		} else {
+			Assertion(Current_shader != NULL && (Current_shader->shader == SDR_TYPE_MODEL
+				|| Current_shader->shader == SDR_TYPE_PASSTHROUGH_RENDER
+				|| Current_shader->shader == SDR_TYPE_DEFAULT_MATERIAL),
+					  "Clip planes are not supported by this shader!");
 
-	if ( material_info->is_clipped() ) {
-		gr_opengl_set_clip_plane(&clip_params.normal, &clip_params.position);
-	} else {
-		gr_opengl_set_clip_plane(NULL, NULL);
+			GL_state.ClipDistance(0, true);
+		}
 	}
 
 	// This is only needed for the passthrough shader
@@ -630,7 +624,7 @@ void opengl_tnl_set_material(material* material_info, bool set_base_map)
 										   &clr,
 										   material_info->get_color_scale(),
 										   array_index,
-										   clip_params);
+										   material_info->get_clip_plane());
 	}
 }
 
@@ -639,7 +633,7 @@ void opengl_tnl_set_model_material(model_material *material_info)
 	float u_scale, v_scale;
 	int render_pass = 0;
 
-	opengl_tnl_set_material(material_info, false);
+	opengl_tnl_set_material(material_info, false, false);
 
 	if ( GL_state.CullFace() ) {
 		GL_state.FrontFaceValue(GL_CW);
@@ -650,6 +644,12 @@ void opengl_tnl_set_model_material(model_material *material_info)
 	Assert( Current_shader->shader == SDR_TYPE_MODEL );
 
 	GL_state.Texture.SetShaderMode(GL_TRUE);
+
+	if (Current_shader->flags & SDR_FLAG_MODEL_CLIP || Current_shader->flags & SDR_FLAG_MODEL_TRANSFORM) {
+		GL_state.ClipDistance(0, true);
+	} else {
+		GL_state.ClipDistance(0, false);
+	}
 
 	uint32_t array_index;
 	if ( Current_shader->flags & SDR_FLAG_MODEL_DIFFUSE_MAP ) {

--- a/code/graphics/opengl/gropengltnl.h
+++ b/code/graphics/opengl/gropengltnl.h
@@ -49,7 +49,7 @@ void opengl_tnl_shutdown();
 void gr_opengl_render_model(model_material* material_info, indexed_vertex_source *vert_source, vertex_buffer* bufferp, size_t texi);
 void opengl_render_model_program(model_material* material_info, indexed_vertex_source *vert_source, vertex_buffer* bufferp, buffer_data *datap);
 
-void opengl_tnl_set_material(material* material_info, bool set_base_map);
+void opengl_tnl_set_material(material* material_info, bool set_base_map, bool set_clipping = true);
 void opengl_tnl_set_material_distortion(distortion_material* material_info);
 void opengl_tnl_set_material_particle(particle_material * material_info);
 void opengl_tnl_set_material_movie(movie_material* material_info);


### PR DESCRIPTION
This changes the batched transform code so that instead of using `discard`
in the fragment shader it uses the built-in clipping capabilities of
OpenGL for removing invisible sub models. This improves performance in
GPU-limited scenes by ~1ms if shadows are enabled.