### PR TITLE
Make shield impact sounds more intuitive.

### DIFF
--- a/code/network/multimsgs.cpp
+++ b/code/network/multimsgs.cpp
@@ -8223,7 +8223,7 @@ void process_player_pain_packet(ubyte *data, header *hinfo)
 	}
 	
 	//Assume the weapon is armed -WMC
-	weapon_hit_do_sound(Player_obj, wip, &Player_obj->pos, true);
+	weapon_hit_do_sound(Player_obj, wip, &Player_obj->pos, true, quadrant_num);
 
 	// we need to do 3 things here. player pain (game flash), weapon hit sound, ship_apply_whack()
 	ship_hit_pain((float)udamage, quadrant_num);

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -1579,7 +1579,7 @@ extern int Ship_auto_repair;	// flag to indicate auto-repair of subsystem should
 
 void ship_subsystem_delete(ship *shipp);
 void ship_set_default_weapons(ship *shipp, ship_info *sip);
-float ship_quadrant_shield_strength(object *hit_objp, vec3d *hitpos);
+float ship_quadrant_shield_strength(object *hit_objp, int quadrant_num);
 
 int ship_dumbfire_threat(ship *sp);
 int ship_lock_threat(ship *sp);

--- a/code/weapon/weapon.h
+++ b/code/weapon/weapon.h
@@ -593,7 +593,7 @@ void ship_do_weapon_thruster_frame( weapon *weaponp, object *objp, float frameti
 // call to get the "color" of the laser at the given moment (since glowing lasers can cycle colors)
 void weapon_get_laser_color(color *c, object *objp);
 
-void weapon_hit_do_sound(object *hit_obj, weapon_info *wip, vec3d *hitpos, bool is_armed);
+void weapon_hit_do_sound(object *hit_obj, weapon_info *wip, vec3d *hitpos, bool is_armed, int quadrant);
 
 void weapon_do_electronics_effect(object *ship_objp, vec3d *blast_pos, int wi_index);
 

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -5650,9 +5650,8 @@ void weapon_play_impact_sound(weapon_info *wip, vec3d *hitpos, bool is_armed)
  *
  * @note Uses Weapon_impact_timer global for timer variable
  */
-void weapon_hit_do_sound(object *hit_obj, weapon_info *wip, vec3d *hitpos, bool is_armed)
+void weapon_hit_do_sound(object *hit_obj, weapon_info *wip, vec3d *hitpos, bool is_armed, int quadrant)
 {
-	int	is_hull_hit;
 	float shield_str;
 
 	// If non-missiles (namely lasers) expire without hitting a ship, don't play impact sound
@@ -5691,19 +5690,14 @@ void weapon_hit_do_sound(object *hit_obj, weapon_info *wip, vec3d *hitpos, bool 
 
 	if ( timestamp_elapsed(Weapon_impact_timer) ) {
 
-		is_hull_hit = 1;
-		if ( hit_obj->type == OBJ_SHIP ) {
-			shield_str = ship_quadrant_shield_strength(hit_obj, hitpos);
+		if ( hit_obj->type == OBJ_SHIP && quadrant >= 0 ) {
+			shield_str = ship_quadrant_shield_strength(hit_obj, quadrant);
 		} else {
 			shield_str = 0.0f;
 		}
 
 		// play a shield hit if shields are above 10% max in this quadrant
 		if ( shield_str > 0.1f ) {
-			is_hull_hit = 0;
-		}
-
-		if ( !is_hull_hit ) {
 			// Play a shield impact sound effect
 			if ( hit_obj == Player_obj ) {
 				snd_play_3d( &Snds[SND_SHIELD_HIT_YOU], hitpos, &Eye_position );
@@ -6109,7 +6103,7 @@ void weapon_hit( object * weapon_obj, object * other_obj, vec3d * hitpos, int qu
 
 	// if this is the player ship, and is a laser hit, skip it. wait for player "pain" to take care of it
 	if ((other_obj != Player_obj) || (wip->subtype != WP_LASER) || !MULTIPLAYER_CLIENT) {
-		weapon_hit_do_sound(other_obj, wip, hitpos, armed_weapon);
+		weapon_hit_do_sound(other_obj, wip, hitpos, armed_weapon, quadrant);
 	}
 
 	if ( wip->impact_weapon_expl_effect >= 0 && armed_weapon)


### PR DESCRIPTION
Shield impact sounds now re-use the shield quadrant calculated by the collision code instead of naively recalculating based on global hitpos, allowing the hull impact sound to play if the shot pierces shields or was fired from within the shield mesh, and simplifying the relevant calculations in the process.