### PR TITLE
Fix several oversights and bugs in the particle effect code

### DIFF
--- a/code/particle/ParticleSource.h
+++ b/code/particle/ParticleSource.h
@@ -67,6 +67,8 @@ class SourceOrigin {
 	 */
 	void getGlobalPosition(vec3d* posOut) const;
 
+	void getHostOrientation(matrix* matOut) const;
+
 	inline SourceOriginType getType() const { return m_originType; }
 
 	inline object* getObjectHost() const { return m_origin.m_object.objp; }
@@ -129,6 +131,9 @@ class SourceOrigin {
  *
  * Currently only the forward direction vector is useful because the other vectors of the matrix are chosen pretty
  * arbitrarily. This also contains a normal vector if it was specified when creating the source.
+ *
+ * An orientation can be either relative or global. In relative mode all transforms should be relative to the host
+ * object while in global mode all directions are in world-space. Normals are always in world-space.
  */
 class SourceOrientation {
  private:
@@ -136,6 +141,9 @@ class SourceOrientation {
 
 	bool m_hasNormal = false;
 	vec3d m_normal;
+
+	// By default the orientation of a source is relative to the host
+	bool m_isRelative = true;
 
  public:
 	SourceOrientation();
@@ -151,6 +159,7 @@ class SourceOrientation {
 
 	/**
 	 * @brief Sets the direction from an already normalized vector
+	 *
 	 * @param vec The normalized vector
 	 */
 	void setFromNormalizedVector(const vec3d& vec);
@@ -159,7 +168,9 @@ class SourceOrientation {
 
 	void setFromMatrix(const matrix& mat);
 
-	vec3d getDirectionVector() const;
+	vec3d getDirectionVector(const SourceOrigin* origin) const;
+
+	bool isRelative() const { return m_isRelative; }
 
 	/**
 	 * @brief Gets the normal of this orientation

--- a/code/particle/effects/BeamPiercingEffect.cpp
+++ b/code/particle/effects/BeamPiercingEffect.cpp
@@ -24,7 +24,7 @@ bool BeamPiercingEffect::processSource(const ParticleSource* source) {
 
 	info.rad = m_radius * frand_range(0.5f, 2.0f);
 
-	vec3d fvec = source->getOrientation()->getDirectionVector();
+	vec3d fvec = source->getOrientation()->getDirectionVector(source->getOrigin());
 
 	float base_v, back_v;
 	vec3d rnd_vec;

--- a/code/particle/effects/GenericShapeEffect.h
+++ b/code/particle/effects/GenericShapeEffect.h
@@ -41,18 +41,18 @@ class GenericShapeEffect : public ParticleEffect {
 	vec3d getNewDirection(const ParticleSource* source) const {
 		switch (m_direction) {
 			case ConeDirection::Incoming:
-				return source->getOrientation()->getDirectionVector();
+				return source->getOrientation()->getDirectionVector(source->getOrigin());
 			case ConeDirection::Normal: {
 				vec3d normal;
 				if (!source->getOrientation()->getNormal(&normal)) {
 					mprintf(("Effect '%s' tried to use normal direction for source without a normal!\n", m_name.c_str()));
-					return source->getOrientation()->getDirectionVector();
+					return source->getOrientation()->getDirectionVector(source->getOrigin());
 				}
 
 				return normal;
 			}
 			case ConeDirection::Reflected: {
-				vec3d out = source->getOrientation()->getDirectionVector();
+				vec3d out = source->getOrientation()->getDirectionVector(source->getOrigin());
 				vec3d normal;
 				if (!source->getOrientation()->getNormal(&normal)) {
 					mprintf(("Effect '%s' tried to use normal direction for source without a normal!\n", m_name.c_str()));
@@ -70,7 +70,7 @@ class GenericShapeEffect : public ParticleEffect {
 				return out;
 			}
 			case ConeDirection::Reverse: {
-				vec3d out = source->getOrientation()->getDirectionVector();
+				vec3d out = source->getOrientation()->getDirectionVector(source->getOrigin());
 				vm_vec_scale(&out, -1.0f);
 				return out;
 			}

--- a/code/particle/effects/GenericShapeEffect.h
+++ b/code/particle/effects/GenericShapeEffect.h
@@ -34,6 +34,8 @@ class GenericShapeEffect : public ParticleEffect {
 
 	ParticleEffectIndex m_particleTrail = -1;
 
+	util::EffectTiming m_timing;
+
 	TShape m_shape;
 
 	vec3d getNewDirection(const ParticleSource* source) const {
@@ -83,6 +85,10 @@ class GenericShapeEffect : public ParticleEffect {
 	}
 
 	virtual bool processSource(const ParticleSource* source) override {
+		if (!m_timing.continueProcessing(source)) {
+			return false;
+		}
+
 		auto num = m_particleNum.next();
 
 		vec3d dir = getNewDirection(source);
@@ -118,7 +124,7 @@ class GenericShapeEffect : public ParticleEffect {
 			}
 		}
 
-		return false;
+		return true;
 	}
 
 	virtual void parseValues(bool nocreate) override {
@@ -158,6 +164,12 @@ class GenericShapeEffect : public ParticleEffect {
 		if (optional_string("+Trail effect:")) {
 			m_particleTrail = internal::parseEffectElement();
 		}
+
+		m_timing = util::EffectTiming::parseTiming();
+	}
+
+	void initializeSource(ParticleSource& source) override {
+		m_timing.applyToSource(&source);
 	}
 
 	virtual EffectType getType() const override { return m_shape.getType(); }

--- a/code/particle/effects/ParticleEmitterEffect.cpp
+++ b/code/particle/effects/ParticleEmitterEffect.cpp
@@ -13,7 +13,7 @@ ParticleEmitterEffect::ParticleEmitterEffect() : ParticleEffect("") {
 bool ParticleEmitterEffect::processSource(const ParticleSource* source) {
 	particle_emitter emitter = m_emitter;
 	source->getOrigin()->getGlobalPosition(&emitter.pos);
-	emitter.normal = source->getOrientation()->getDirectionVector();
+	emitter.normal = source->getOrientation()->getDirectionVector(source->getOrigin());
 
 	emit(&emitter, PARTICLE_BITMAP, m_particleBitmap, m_range);
 


### PR DESCRIPTION
The particle sources of the beams were missing multiple properties
(direction and impact normals) and the generic shape effect didn't have
any way of controlling how long the source was active. This fixes that
by introducing an effect timing field similar to the single particle
effect.