### PR TITLE
Fix out-of-range vector access in ballistic sound code

### DIFF
--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -13692,7 +13692,7 @@ int ship_do_rearm_frame( object *objp, float frametime )
 				{
 					// Goober5000
 					int sound_index;
-					if (Snds[SND_BALLISTIC_START_LOAD].id >= 0)
+					if (Snds.size() > SND_BALLISTIC_START_LOAD)
 						sound_index = SND_BALLISTIC_START_LOAD;
 					else
 						sound_index = SND_MISSILE_START_LOAD;
@@ -13746,7 +13746,7 @@ int ship_do_rearm_frame( object *objp, float frametime )
 				if (primary_banks_full != swp->num_primary_banks) {
 					// Goober5000
 					int sound_index;
-					if (Snds[SND_BALLISTIC_START_LOAD].id >= 0)
+					if (Snds.size() > SND_BALLISTIC_START_LOAD)
 						sound_index = SND_BALLISTIC_START_LOAD;
 					else
 						sound_index = SND_MISSILE_START_LOAD;


### PR DESCRIPTION
The code probably tried to check if the sound is available but since the
sounds vector is not long enough if the sound is not specified in the
table it would cause an out-of-bounds failure if the sound was missing
from the table. Furthermore, the current code would only have worked if
the sound was preloaded since the id is -1 until the sound is loaded for
the first time.