### PR TITLE
Fix misused assertion in music table parsing code.

### DIFF
--- a/code/gamesnd/eventmusic.cpp
+++ b/code/gamesnd/eventmusic.cpp
@@ -1186,7 +1186,9 @@ void parse_soundtrack()
 		}
 
 		//Track doesn't exist and has nocreate, so don't create it
-		Assertion(skip_to_start_of_string_either("#SoundTrack Start", "#Menu Music Start") || skip_to_string("#SoundTrack End"), "Couldn't find #Soundtrack Start, #Menu Music Start or #Soundtrack End. Music.tbl or -mus.tbm is invalid.\n");
+		if ( !skip_to_start_of_string_either("#SoundTrack Start", "#Menu Music Start") && !skip_to_string("#SoundTrack End")) {
+			error_display(1, "Couldn't find #Soundtrack Start, #Menu Music Start or #Soundtrack End.");
+		}
 
 		return;
 	}


### PR DESCRIPTION
The condition of an assertion doesn't exist in a release build, and assertions should never be used for bad data anyway.

(Technically a regression caused by commit c28989e1218117805cdcac02d56002f7f334a01a, although an `Int3()` on bad data isn't any better, but at least it did the skipping in release builds properly.)