### PR TITLE
Allow BMPMAN slot limit to be defined by mod table.

### DIFF
--- a/code/bmpman/bm_internal.h
+++ b/code/bmpman/bm_internal.h
@@ -90,7 +90,7 @@ struct bitmap_entry {
 #endif
 };
 
-extern bitmap_entry bm_bitmaps[MAX_BITMAPS];
+extern bitmap_entry* bm_bitmaps;
 
 // image specific lock functions
 void bm_lock_ani( int handle, int bitmapnum, bitmap_entry *be, bitmap *bmp, int bpp, ubyte flags );

--- a/code/bmpman/bmpman.cpp
+++ b/code/bmpman/bmpman.cpp
@@ -96,7 +96,7 @@ bitmap_entry* bm_bitmaps = nullptr;
 
 // --------------------------------------------------------------------------------------------------------------------
 // Definition of private variables at file scope (static).
-static int bm_inited = 0;
+static bool bm_inited = false;
 static uint Bm_next_signature = 0x1234;
 static int  bm_next_handle = 1;
 static int Bm_low_mem = 0;
@@ -487,7 +487,7 @@ void bm_close() {
 			delete[] bm_bitmaps;
 			bm_bitmaps = nullptr;
 		}
-		bm_inited = 0;
+		bm_inited = false;
 	}
 }
 
@@ -498,7 +498,7 @@ int bm_create(int bpp, int w, int h, void *data, int flags) {
 		Assert((bpp == 16) || (bpp == 24) || (bpp == 32));
 	}
 
-	if (!bm_inited) bm_init();
+	Assertion(bm_inited, "bmpman must be initialized before this function can be called!");
 
 	int n = -1;
 
@@ -949,7 +949,7 @@ void bm_get_palette(int handle, ubyte *pal, char *name) {
 }
 
 uint bm_get_signature(int handle) {
-	if (!bm_inited) bm_init();
+	Assertion(bm_inited, "bmpman must be initialized before this function can be called!");
 
 	int bitmapnum = handle % MAX_BITMAPS;
 	Assertion(bm_bitmaps[bitmapnum].handle == handle, "Invalid bitmap handle %d passed to bm_get_signature().\nThis might be due to an invalid animation somewhere else.\n", handle);		// INVALID BITMAP HANDLE!
@@ -974,7 +974,7 @@ int bm_get_tcache_type(int num) {
 }
 
 BM_TYPE bm_get_type(int handle) {
-	if (!bm_inited) bm_init();
+	Assertion(bm_inited, "bmpman must be initialized before this function can be called!");
 
 	int bitmapnum = handle % MAX_BITMAPS;
 	Assertion(bm_bitmaps[bitmapnum].handle == handle, "Invalid bitmap handle %d passed to bm_get_type().\nThis might be due to an invalid animation somewhere else.\n", handle);		// INVALID BITMAP HANDLE!
@@ -996,12 +996,9 @@ bool bm_has_alpha_channel(int handle) {
 }
 
 void bm_init() {
-	int i;
+	Assertion(!bm_inited, "bmpman cannot be initialized more than once!");
 
-	if (!bm_inited) {
-		bm_inited = 1;
-		atexit(bm_close);
-	}
+	int i;
 
 	if (bm_bitmaps == nullptr) {
 		bm_bitmaps = new bitmap_entry[MAX_BITMAPS];
@@ -1033,6 +1030,8 @@ void bm_init() {
 
 		bm_free_data(i);  	// clears flags, bbp, data, etc
 	}
+
+	bm_inited = true;
 }
 
 int bm_is_compressed(int num) {
@@ -1214,8 +1213,7 @@ int bm_load(const char *real_filename) {
 	CFILE *img_cfp = NULL;
 	int handle = -1;
 
-	if (!bm_inited)
-		bm_init();
+	Assertion(bm_inited, "bmpman must be initialized before this function can be called!");
 
 	// if no file was passed then get out now
 	if ((real_filename == NULL) || (strlen(real_filename) <= 0))
@@ -1520,8 +1518,7 @@ int bm_load_animation(const char *real_filename, int *nframes, int *fps, int *ke
 	size_t img_size = 0;
 	char clean_name[MAX_FILENAME_LEN];
 
-	if (!bm_inited)
-		bm_init();
+	Assertion(bm_inited, "bmpman must be initialized before this function can be called!");
 
 	// set output param defaults before going any further
 	if (nframes != nullptr)
@@ -1941,7 +1938,7 @@ bitmap * bm_lock(int handle, int bpp, ubyte flags, bool nodebug) {
 	bitmap			*bmp;
 	bitmap_entry	*be;
 
-	if (!bm_inited) bm_init();
+	Assertion(bm_inited, "bmpman must be initialized before this function can be called!");
 
 	int bitmapnum = handle % MAX_BITMAPS;
 
@@ -2507,8 +2504,7 @@ int bm_make_render_target(int width, int height, int flags) {
 	int bpp = 32;
 	int size = 0;
 
-	if (!bm_inited)
-		bm_init();
+	Assertion(bm_inited, "bmpman must be initialized before this function can be called!");
 
 	// Find an open slot (starting from the end)
 	for (n = -1, i = MAX_BITMAPS - 1; i >= 0; i--) {
@@ -2939,8 +2935,7 @@ int bm_release(int handle, int clear_render_targets) {
 }
 
 int bm_reload(int bitmap_handle, const char* filename) {
-	if (!bm_inited)
-		bm_init();
+	Assertion(bm_inited, "bmpman must be initialized before this function can be called!");
 
 	// if no file was passed then get out now
 	if ((filename == NULL) || (strlen(filename) <= 0))
@@ -3250,7 +3245,7 @@ int bm_unload_fast(int handle, int clear_render_targets) {
 void bm_unlock(int handle) {
 	bitmap_entry	*be;
 
-	if (!bm_inited) bm_init();
+	Assertion(bm_inited, "bmpman must be initialized before this function can be called!");
 
 	int bitmapnum = handle % MAX_BITMAPS;
 

--- a/code/bmpman/bmpman.cpp
+++ b/code/bmpman/bmpman.cpp
@@ -90,7 +90,7 @@ extern int Cmdline_cache_bitmaps;
 
 // --------------------------------------------------------------------------------------------------------------------
 // Definition of public variables (declared as extern in bm_internal.h).
-bitmap_entry bm_bitmaps[MAX_BITMAPS];
+bitmap_entry* bm_bitmaps;
 
 // --------------------------------------------------------------------------------------------------------------------
 // Definition of private variables at file scope (static).
@@ -481,6 +481,7 @@ void bm_close() {
 		for (i = 0; i<MAX_BITMAPS; i++) {
 			bm_free_data(i);			// clears flags, bbp, data, etc
 		}
+		delete bm_bitmaps;
 		bm_inited = 0;
 	}
 }
@@ -992,13 +993,15 @@ bool bm_has_alpha_channel(int handle) {
 void bm_init() {
 	int i;
 
-	mprintf(("Size of bitmap info = " SIZE_T_ARG " KB\n", sizeof(bm_bitmaps) / 1024));
-	mprintf(("Size of bitmap extra info = " SIZE_T_ARG " bytes\n", sizeof(bm_extra_info)));
-
 	if (!bm_inited) {
 		bm_inited = 1;
 		atexit(bm_close);
 	}
+
+	bm_bitmaps = new bitmap_entry[MAX_BITMAPS];
+
+	mprintf(("Size of bitmap info = " SIZE_T_ARG " KB\n", sizeof(bm_bitmaps) / 1024));
+	mprintf(("Size of bitmap extra info = " SIZE_T_ARG " bytes\n", sizeof(bm_extra_info)));
 
 	for (i = 0; i<MAX_BITMAPS; i++) {
 		bm_bitmaps[i].filename[0] = '\0';

--- a/code/bmpman/bmpman.cpp
+++ b/code/bmpman/bmpman.cpp
@@ -84,6 +84,8 @@ const int BM_ANI_NUM_TYPES = sizeof(bm_ani_type_list) / sizeof(bm_ani_type_list[
 void(*bm_set_components)(ubyte *pixel, ubyte *r, ubyte *g, ubyte *b, ubyte *a) = NULL;
 void(*bm_set_components_32)(ubyte *pixel, ubyte *r, ubyte *g, ubyte *b, ubyte *a) = NULL;
 
+int MAX_BITMAPS = DEFAULT_MAX_BITMAPS;
+
 // --------------------------------------------------------------------------------------------------------------------
 // Declaration of protected variables (defined in cmdline.cpp).
 extern int Cmdline_cache_bitmaps;
@@ -481,7 +483,7 @@ void bm_close() {
 		for (i = 0; i<MAX_BITMAPS; i++) {
 			bm_free_data(i);			// clears flags, bbp, data, etc
 		}
-		delete bm_bitmaps;
+		delete[] bm_bitmaps;
 		bm_inited = 0;
 	}
 }
@@ -1000,7 +1002,7 @@ void bm_init() {
 
 	bm_bitmaps = new bitmap_entry[MAX_BITMAPS];
 
-	mprintf(("Size of bitmap info = " SIZE_T_ARG " KB\n", sizeof(bm_bitmaps) / 1024));
+	mprintf(("Size of bitmap info = " SIZE_T_ARG " KB\n", (sizeof(bm_bitmaps[0]) * MAX_BITMAPS) / 1024));
 	mprintf(("Size of bitmap extra info = " SIZE_T_ARG " bytes\n", sizeof(bm_extra_info)));
 
 	for (i = 0; i<MAX_BITMAPS; i++) {

--- a/code/bmpman/bmpman.cpp
+++ b/code/bmpman/bmpman.cpp
@@ -92,7 +92,7 @@ extern int Cmdline_cache_bitmaps;
 
 // --------------------------------------------------------------------------------------------------------------------
 // Definition of public variables (declared as extern in bm_internal.h).
-bitmap_entry* bm_bitmaps;
+bitmap_entry* bm_bitmaps = nullptr;
 
 // --------------------------------------------------------------------------------------------------------------------
 // Definition of private variables at file scope (static).
@@ -483,7 +483,10 @@ void bm_close() {
 		for (i = 0; i<MAX_BITMAPS; i++) {
 			bm_free_data(i);			// clears flags, bbp, data, etc
 		}
-		delete[] bm_bitmaps;
+		if (bm_bitmaps != nullptr) {
+			delete[] bm_bitmaps;
+			bm_bitmaps = nullptr;
+		}
 		bm_inited = 0;
 	}
 }
@@ -1000,7 +1003,9 @@ void bm_init() {
 		atexit(bm_close);
 	}
 
-	bm_bitmaps = new bitmap_entry[MAX_BITMAPS];
+	if (bm_bitmaps == nullptr) {
+		bm_bitmaps = new bitmap_entry[MAX_BITMAPS];
+	}
 
 	mprintf(("Size of bitmap info = " SIZE_T_ARG " KB\n", (sizeof(bm_bitmaps[0]) * MAX_BITMAPS) / 1024));
 	mprintf(("Size of bitmap extra info = " SIZE_T_ARG " bytes\n", sizeof(bm_extra_info)));

--- a/code/bmpman/bmpman.h
+++ b/code/bmpman/bmpman.h
@@ -33,7 +33,7 @@
  */
 
 /**
- * @brief How many bitmaps the game can handle
+ * @brief How many bitmaps the game can handle by default
  *
  * @attention  MAX_BITMAPS shouldn't need to be bumped again.  With the fixed bm_release() and it's proper use even the
  *   largest missions should stay under this number.  With the largest retail missions and wasteful content we should
@@ -45,7 +45,9 @@
  *   If anything we could/should reduce MAX_BITMAPS in the future.  Where it's at now should accomidate even the
  *   largest mods.  --  Taylor
  */
-#define MAX_BITMAPS 4750
+#define DEFAULT_MAX_BITMAPS 4750
+
+extern int MAX_BITMAPS;
 
 // Flag positions for bitmap.flags
 // ***** NOTE:  bitmap.flags is an 8-bit value, no more BMP_TEX_* flags can be added unless the type is changed!! ******

--- a/code/graphics/2d.cpp
+++ b/code/graphics/2d.cpp
@@ -663,6 +663,8 @@ void gr_close()
 			Int3();		// Invalid graphics mode
 	}
 
+	bm_close();
+
 	Gr_inited = 0;
 }
 

--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -37,7 +37,6 @@ bool Beams_use_damage_factors = false;
 float Generic_pain_flash_factor = 1.0f;
 float Shield_pain_flash_factor = 0.0f;
 gameversion::version Targetted_version(2, 0, 0, 0); // Defaults to retail
-int MAX_BITMAPS = DEFAULT_MAX_BITMAPS;
 
 void parse_mod_table(const char *filename)
 {
@@ -82,7 +81,7 @@ void parse_mod_table(const char *filename)
 			size_t maxlen = (MAX_FILENAME_LEN - 4);
 			auto len = strlen(temp);
 			if (len > maxlen) {
-				Warning(LOCATION, "Token too long: [%s].  Length = " SIZE_T_ARG ".  Max is " SIZE_T_ARG ".\n", temp, len, maxlen);
+				error_display(0, "Token too long: [%s].  Length = " SIZE_T_ARG ".  Max is " SIZE_T_ARG ".", temp, len, maxlen);
 				temp[maxlen] = 0;
 			}
 
@@ -183,7 +182,7 @@ void parse_mod_table(const char *filename)
 			mprintf(("Game Settings Table: Setting default detail level to %i of %i-%i\n", detail_level, 0, NUM_DEFAULT_DETAIL_LEVELS - 1));
 
 			if (detail_level < 0 || detail_level > NUM_DEFAULT_DETAIL_LEVELS - 1) {
-				Warning(LOCATION, "Invalid detail level: %i, setting to %i\n", detail_level, Default_detail_level);
+				error_display(0, "Invalid detail level: %i, setting to %i", detail_level, Default_detail_level);
 			}
 			else {
 				Default_detail_level = detail_level;
@@ -216,7 +215,7 @@ void parse_mod_table(const char *filename)
 			int slots;
 			stuff_int(&slots);
 			if (slots < 3500) {
-				Warning(LOCATION, "Invalid BMPMAN slot limit [%d]; must be at least 3500.\n", slots);
+				error_display(0, "Invalid BMPMAN slot limit [%d]; must be at least 3500.", slots);
 			} else {
 				mprintf(("Game Settings Table: Setting BMPMAN slot limit to %d\n", slots));
 				MAX_BITMAPS = slots;
@@ -322,7 +321,7 @@ void parse_mod_table(const char *filename)
 				if (ui_index >= 0)
 					Default_fiction_viewer_ui = ui_index;
 				else
-					Warning(LOCATION, "Unrecognized fiction viewer UI: %s", ui_name);
+					error_display(0, "Unrecognized fiction viewer UI: %s", ui_name);
 			}
 		}
 

--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -37,6 +37,7 @@ bool Beams_use_damage_factors = false;
 float Generic_pain_flash_factor = 1.0f;
 float Shield_pain_flash_factor = 0.0f;
 gameversion::version Targetted_version(2, 0, 0, 0); // Defaults to retail
+int MAX_BITMAPS = DEFAULT_MAX_BITMAPS;
 
 void parse_mod_table(const char *filename)
 {
@@ -209,6 +210,17 @@ void parse_mod_table(const char *filename)
 			stuff_float(&Shield_pain_flash_factor);
 			if (Shield_pain_flash_factor != 0.0f)
 				 mprintf(("Game Settings Table: Setting shield pain flash factor to %.2f\n", Shield_pain_flash_factor));
+		}
+
+		if (optional_string("$BMPMAN Slot Limit:")) {
+			int slots;
+			stuff_int(&slots);
+			if (slots < 3500) {
+				Warning(LOCATION, "Invalid BMPMAN slot limit [%d]; must be at least 3500.\n", slots);
+			} else {
+				mprintf(("Game Settings Table: Setting BMPMAN slot limit to %d\n", slots));
+				MAX_BITMAPS = slots;
+			}
 		}
 
 		optional_string("#NETWORK SETTINGS");

--- a/code/mod_table/mod_table.h
+++ b/code/mod_table/mod_table.h
@@ -30,6 +30,7 @@ extern bool Red_alert_applies_to_delayed_ships;
 extern bool Beams_use_damage_factors;
 extern float Generic_pain_flash_factor;
 extern float Shield_pain_flash_factor;
+extern int MAX_BITMAPS;
 
 void mod_table_init();
 

--- a/code/mod_table/mod_table.h
+++ b/code/mod_table/mod_table.h
@@ -30,7 +30,6 @@ extern bool Red_alert_applies_to_delayed_ships;
 extern bool Beams_use_damage_factors;
 extern float Generic_pain_flash_factor;
 extern float Shield_pain_flash_factor;
-extern int MAX_BITMAPS;
 
 void mod_table_init();
 


### PR DESCRIPTION
`bm_init()` now dynamically allocates the `bm_bitmaps` array, and `MAX_BITMAPS` can be changed by the mod table.

After the question was raised as to the possibility of making the BMPMAN limit be a mod table entry (as a way to make Wings of Dawn no longer require custom builds with an increased limit), it was pointed out that the mod table gets parsed before BMPMAN is initialized, which led to me trying out allocating the array at runtime. I've tested it and it *seems* to work.