### PR TITLE
Fix Assertion failure when rendering clip planes using default material

### DIFF
--- a/code/graphics/opengl/gropengltnl.cpp
+++ b/code/graphics/opengl/gropengltnl.cpp
@@ -523,9 +523,9 @@ void gr_opengl_set_clip_plane(vec3d *clip_normal, vec3d *clip_point)
 	if ( clip_normal == NULL || clip_point == NULL ) {
 		GL_state.ClipDistance(0, false);
 	} else {
-		Assertion(Current_shader != NULL &&
-				  (Current_shader->shader == SDR_TYPE_MODEL || Current_shader->shader == SDR_TYPE_PASSTHROUGH_RENDER),
-				  "Clip planes are not supported by this shader!");
+		Assertion(Current_shader != NULL && (Current_shader->shader == SDR_TYPE_MODEL
+			|| Current_shader->shader == SDR_TYPE_PASSTHROUGH_RENDER
+			|| Current_shader->shader == SDR_TYPE_DEFAULT_MATERIAL), "Clip planes are not supported by this shader!");
 
 		GL_state.ClipDistance(0, true);
 	}


### PR DESCRIPTION
The texture array changes introduced the default material which is
similar to the passthrough shader but allows to use texture arrays. The
vertex shader is the same as for the passthrough shader so that shader
also supports clipping planes.