### PR TITLE
Add in-game BMPMAN usage display.

### DIFF
--- a/code/bmpman/bmpman.cpp
+++ b/code/bmpman/bmpman.cpp
@@ -3337,3 +3337,17 @@ int bm_get_base_frame(const int handle, int* num_frames) {
 int bm_get_array_index(const int handle) {
 	return handle - bm_get_base_frame(handle, nullptr);
 }
+
+int bmpman_count_bitmaps() {
+	if (!bm_inited)
+		return -1;
+
+	int total_bitmaps = 0;
+	for (int i = 0; i < MAX_BITMAPS; i++) {
+		if (bm_bitmaps[i].type != BM_TYPE_NONE) {
+			total_bitmaps++;
+		}
+	}
+
+	return total_bitmaps;
+}

--- a/code/bmpman/bmpman.h
+++ b/code/bmpman/bmpman.h
@@ -731,4 +731,13 @@ int bm_get_base_frame(const int handle, int* num_frames = nullptr);
  */
 int bm_get_array_index(const int handle);
 
+/**
+ * @brief Counts how many slots are used in bm_bitmaps
+ *
+ * This needs to iterate through all the slots in order to determine whether or not they're used, so shouldn't be used frivolously.
+ *
+ * @return The number of used slots
+ */
+int bmpman_count_bitmaps();
+
 #endif

--- a/code/cmdline/cmdline.cpp
+++ b/code/cmdline/cmdline.cpp
@@ -218,6 +218,7 @@ Flag exe_params[] =
 	{ "-voicer",			"Enable voice recognition",					true,	0,					EASY_DEFAULT,		"Experimental",	"http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-voicer", },
 
 	{ "-fps",				"Show frames per second on HUD",			false,	0,					EASY_DEFAULT,		"Dev Tool",		"http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-fps", },
+	{ "-bmpmanusage",		"Show how many BMPMAN slots are in use",	false,	0,					EASY_DEFAULT,		"Dev Tool",		"http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-bmpmanusage", },
 	{ "-pos",				"Show position of camera",					false,	0,					EASY_DEFAULT,		"Dev Tool",		"http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-pos", },
 	{ "-window",			"Run in window",							true,	0,					EASY_DEFAULT,		"Dev Tool",		"http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-window", },
 	{ "-fullscreen_window",	"Run in fullscreen window",					false,	0,					EASY_DEFAULT,		"Dev Tool",		"http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-fullscreen_window", },
@@ -472,6 +473,7 @@ cmdline_parm dis_weapons("-dis_weapons", NULL, AT_NONE);		// Cmdline_dis_weapons
 cmdline_parm noparseerrors_arg("-noparseerrors", NULL, AT_NONE);	// Cmdline_noparseerrors  -- turns off parsing errors -C
 cmdline_parm extra_warn_arg("-extra_warn", "Enable 'extra' warnings", AT_NONE);	// Cmdline_extra_warn
 cmdline_parm fps_arg("-fps", NULL, AT_NONE);					// Cmdline_show_fps
+cmdline_parm bmpmanusage_arg("-bmpmanusage", NULL, AT_NONE);	// Cmdline_bmpman_usage
 cmdline_parm pos_arg("-pos", NULL, AT_NONE);					// Cmdline_show_pos
 cmdline_parm stats_arg("-stats", NULL, AT_NONE);				// Cmdline_show_stats
 cmdline_parm save_render_targets_arg("-save_render_target", NULL, AT_NONE);	// Cmdline_save_render_targets
@@ -502,6 +504,7 @@ int Cmdline_noparseerrors = 0;
 int Cmdline_nowarn = 0; // turn warnings off in FRED
 #endif
 int Cmdline_extra_warn = 0;
+int Cmdline_bmpman_usage = 0;
 int Cmdline_show_pos = 0;
 int Cmdline_show_stats = 0;
 int Cmdline_save_render_targets = 0;
@@ -1539,6 +1542,11 @@ bool SetCmdlineParams()
 	if (fps_arg.found())
 	{
 		Show_framerate = 1;
+	}
+
+	if (bmpmanusage_arg.found())
+	{
+		Cmdline_bmpman_usage = 1;
 	}
 
 	if(pos_arg.found())

--- a/code/cmdline/cmdline.h
+++ b/code/cmdline/cmdline.h
@@ -148,6 +148,7 @@ extern int Cmdline_dis_collisions;
 extern int Cmdline_dis_weapons;
 extern int Cmdline_noparseerrors;
 extern int Cmdline_extra_warn;
+extern int Cmdline_bmpman_usage;
 extern int Cmdline_show_pos;
 extern int Cmdline_show_stats;
 extern int Cmdline_save_render_targets;

--- a/code/io/keycontrol.cpp
+++ b/code/io/keycontrol.cpp
@@ -1278,6 +1278,11 @@ void process_debug_keys(int k)
 				Show_cpu = !Show_cpu;
 			}
 			break;
+		case KEY_DEBUGGED + KEY_B:
+		case KEY_DEBUGGED1 + KEY_B:
+			{
+				Cmdline_bmpman_usage = !Cmdline_bmpman_usage;
+			}
 
 	}	// end switch
 }

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -1460,6 +1460,7 @@ extern int Training_message_method;
 DCF_BOOL( training_msg_method, Training_message_method )
 DCF_BOOL( show_player_pos, Show_player_pos )
 DCF_BOOL(i_framerate, Interface_framerate )
+DCF_BOOL( show_bmpman_usage, Cmdline_bmpman_usage )
 
 DCF(warp, "Tests warpin effect")
 {
@@ -2087,7 +2088,7 @@ void game_show_framerate()
 #endif
 
 
-	if (Show_framerate || Cmdline_frame_profile) {
+	if (Show_framerate || Cmdline_frame_profile || Cmdline_bmpman_usage) {
 		gr_set_color_fast(&HUD_color_debug);
 
 		if (Cmdline_frame_profile) {
@@ -2100,6 +2101,10 @@ void game_show_framerate()
 				gr_printf_no_resize( gr_screen.center_offset_x + 20, gr_screen.center_offset_y + 100, "FPS: %0.1f", Framerate );
 			else
 				gr_string( gr_screen.center_offset_x + 20, gr_screen.center_offset_y + 100, "FPS: ?", GR_RESIZE_NONE );
+		}
+
+		if (Cmdline_bmpman_usage) {
+			gr_printf_no_resize( gr_screen.center_offset_x + 20, gr_screen.center_offset_y + 100 - line_height, "BMPMAN: %d/%d", bmpman_count_bitmaps(), MAX_BITMAPS );
 		}
 	}
 


### PR DESCRIPTION
Can be enabled with the "-bmpmanusage" command-line option, toggled via the debug console, or toggled via a debug/cheat key combo (`+B).

I wrote this while I was working on #1502, and it makes an interesting diagnostic tool (although the fact that framerate isn't displayed during menus means, since it uses the same function, you also can't monitor BMPMAN usage during menus, which limits its utility somewhat). ~~I *may* do some experiments with calling `game_show_frametime()` outside of missions, but otherwise~~ this PR is complete.