### PR TITLE
Fix music table parsing when a soundtrack needs to be skipped.

### DIFF
--- a/code/gamesnd/eventmusic.cpp
+++ b/code/gamesnd/eventmusic.cpp
@@ -1283,7 +1283,7 @@ void parse_soundtrack()
 	}
 
 	//We're done here.
-	//required_string("#SoundTrack End");
+	required_string("#SoundTrack End");
 
 
 	// Goober5000 - set the valid flag according to whether we can load all our patterns
@@ -1372,12 +1372,11 @@ void event_music_parse_musictbl(const char *filename)
 		read_file_text(filename, CF_TYPE_TABLES);
 		reset_parse();
 
-		while ( skip_to_start_of_string_either("#Soundtrack Start", "#Menu Music Start", NULL ) )
+		while ( check_for_string("#Soundtrack Start") || check_for_string("#Menu Music Start") )
 		{
 			if ( optional_string("#Soundtrack Start") )
 			{
 				parse_soundtrack( );
-				required_string("#Soundtrack End");
 			}
 			if ( optional_string("#Menu Music Start") )
 			{


### PR DESCRIPTION
For some reason, commit 8b43ed823c39ec6f489450883ccac4ee81e5559f moved the consumption of the "#Soundtrack End" token out of `parse_soundtrack()`, when if a soundtrack needs to be skipped (e.g. because it's in a .tbm, flagged with +nocreate, and the original doesn't exist), it will skip straight past "#Soundtrack End" to reach the next "#Soundtrack Start". It also changed how music tables are parsed so that they'll skip any junk data that happens to be between sections, which is atypical of how tables are parsed. This commit changes both of these things: "Soundtrack End" is once again consumed near the end of `parse_soundtrack()`, and the while loop uses `check_for_string()` instead of skipping to the start of a section.

(For reference, the original [Mantis issue](http://scp.indiegames.us/mantis/view.php?id=1938) the aforementioned commit was solving.)