### PR TITLE
Add support for printing command line flags in JSON output

### DIFF
--- a/code/graphics/2d.h
+++ b/code/graphics/2d.h
@@ -1184,6 +1184,26 @@ enum AnimatedShader {
 
 graphics::util::UniformBuffer* gr_get_uniform_buffer(uniform_block_type type);
 
+struct VideoModeData {
+	uint32_t width = 0;
+	uint32_t height = 0;
+	uint32_t bit_depth = 0;
+};
+
+struct DisplayData {
+	uint32_t index;
+	SCP_string name;
+
+	int32_t x = 0;
+	int32_t y = 0;
+	int32_t width = 0;
+	int32_t height = 0;
+
+	SCP_vector<VideoModeData> video_modes;
+};
+
+SCP_vector<DisplayData> gr_enumerate_displays();
+
 // Include this last to make the 2D rendering function available everywhere
 #include "graphics/render.h"
 

--- a/code/io/joy-sdl.cpp
+++ b/code/io/joy-sdl.cpp
@@ -800,6 +800,42 @@ namespace joystick
 
 		SDL_QuitSubSystem(SDL_INIT_JOYSTICK);
 	}
+
+	SCP_vector<JoystickInformation> getJoystickInformations() {
+		SCP_vector<JoystickInformation> joystickInfo;
+
+		if (SDL_InitSubSystem(SDL_INIT_JOYSTICK) < 0) {
+			return SCP_vector<JoystickInformation>();
+		}
+
+		auto num_joysticks = SDL_NumJoysticks();
+		for (auto i = 0; i < num_joysticks; ++i) {
+			auto joystick = SDL_JoystickOpen(i);
+
+			JoystickInformation info{};
+
+			auto name = SDL_JoystickName(joystick);
+			if (name != nullptr) {
+				info.name = name;
+			}
+			info.guid = getJoystickGUID(joystick);
+
+			info.num_axes = static_cast<uint32_t>(SDL_JoystickNumAxes(joystick));
+			info.num_balls = static_cast<uint32_t>(SDL_JoystickNumBalls(joystick));
+			info.num_buttons = static_cast<uint32_t>(SDL_JoystickNumButtons(joystick));
+			info.num_hats = static_cast<uint32_t>(SDL_JoystickNumHats(joystick));
+
+			info.is_haptic = SDL_JoystickIsHaptic(joystick) == SDL_TRUE;
+
+			joystickInfo.push_back(info);
+
+			SDL_JoystickClose(joystick);
+		}
+
+		SDL_QuitSubSystem(SDL_INIT_JOYSTICK);
+
+		return joystickInfo;
+	}
 }
 }
 

--- a/code/io/joy.h
+++ b/code/io/joy.h
@@ -308,6 +308,20 @@ namespace io
 		 * @brief Frees resources of the joystick subsystem
 		 */
 		void shutdown();
+
+		struct JoystickInformation {
+			SCP_string name;
+			SCP_string guid;
+
+			uint32_t num_axes;
+			uint32_t num_balls;
+			uint32_t num_buttons;
+			uint32_t num_hats;
+
+			bool is_haptic;
+		};
+
+		SCP_vector<JoystickInformation> getJoystickInformations();
 	}
 }
 

--- a/code/sound/openal.h
+++ b/code/sound/openal.h
@@ -19,6 +19,18 @@ bool openal_init_device(SCP_string *playback, SCP_string *capture);
 
 ALenum openal_get_format(ALint bits, ALint n_channels);
 
+struct OpenALInformation {
+	uint32_t version_major = 0;
+	uint32_t version_minor = 0;
+
+	SCP_string default_playback_device{};
+	SCP_string default_capture_device{};
+
+	SCP_vector<SCP_string> playback_devices;
+	SCP_vector<SCP_string> capture_devices;
+};
+
+OpenALInformation openal_get_platform_information();
 
 // if an error occurs after executing 'x' then do 'y'
 #define OpenAL_ErrorCheck( x, y )	do {	\

--- a/code/sound/speech.h
+++ b/code/sound/speech.h
@@ -9,6 +9,7 @@
 #ifndef _SPEECH_H_
 #define _SPEECH_H_
 
+#include "globalincs/pstypes.h"
 
 #if FS2_SPEECH
 
@@ -26,6 +27,8 @@ bool speech_set_voice(int voice);
 
 bool speech_is_speaking();
 
+SCP_vector<SCP_string> speech_enumerate_voices();
+
 #else
 
 // Goober5000: see, the *real* way to do stubs (avoiding the warnings)
@@ -39,6 +42,10 @@ bool speech_is_speaking();
 #define speech_set_volume(volume) ((volume), false)
 #define speech_set_voice(voice) ((voice), false)
 #define speech_is_speaking() (false)
+
+SCP_vector<SCP_string> speech_enumerate_voices() {
+	return SCP_vector<SCP_string>();
+}
 
 #endif
 


### PR DESCRIPTION
This will output the flags data in a better format than the current
binary format. For determining if the JSON output should be used this
uses an optional parameter for -get_flags. The command line parsing does
not cause an error if a parameter is specified for an option that does
not support them. This way, the launcher can just pass "json_v1" to the
option and an old build will just silently ignore it and use the binary
format.