### PR TITLE
Fix new warnings generated by GCC 7

### DIFF
--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -10395,6 +10395,7 @@ void ai_get_dock_goal_indexes(object *objp, ai_info *aip, ai_goal *aigp, object 
 		case AIS_DOCK_2:
 		case AIS_DOCK_3:
 			Warning(LOCATION, "Normally dock indexes should be calculated for only AIS_DOCK_0 and AIS_UNDOCK_0.  Trace out and debug.");
+			FALLTHROUGH;
 		case AIS_DOCK_0:
 		{
 			// get them from the active goal
@@ -10412,6 +10413,7 @@ void ai_get_dock_goal_indexes(object *objp, ai_info *aip, ai_goal *aigp, object 
 		case AIS_UNDOCK_1:
 		case AIS_UNDOCK_2:
 			Warning(LOCATION, "Normally dock indexes should be calculated for only AIS_DOCK_0 and AIS_UNDOCK_0.  Trace out and debug.");
+			FALLTHROUGH;
 		case AIS_UNDOCK_0:
 		{
 			// get them from the guy I'm docked to
@@ -10478,9 +10480,11 @@ void ai_cleanup_dock_mode_subjective(object *objp)
 			case AIS_UNDOCK_0:
 				model_anim_start_type(shipp, TRIGGER_TYPE_DOCKED, docker_index, -1);
 				model_anim_start_type(goal_shipp, TRIGGER_TYPE_DOCKED, dockee_index, -1);
+				FALLTHROUGH;
 			case AIS_UNDOCK_1:
 				model_anim_start_type(shipp, TRIGGER_TYPE_DOCKING_STAGE_3, docker_index, -1);
 				model_anim_start_type(goal_shipp, TRIGGER_TYPE_DOCKING_STAGE_3, dockee_index, -1);
+				FALLTHROUGH;
 			case AIS_UNDOCK_2:
 				model_anim_start_type(shipp, TRIGGER_TYPE_DOCKING_STAGE_2, docker_index, -1);
 				model_anim_start_type(goal_shipp, TRIGGER_TYPE_DOCKING_STAGE_2, dockee_index, -1);
@@ -10490,9 +10494,11 @@ void ai_cleanup_dock_mode_subjective(object *objp)
 			case AIS_DOCK_4A:
 				model_anim_start_type(shipp, TRIGGER_TYPE_DOCKED, docker_index, -1);
 				model_anim_start_type(goal_shipp, TRIGGER_TYPE_DOCKED, dockee_index, -1);
+				FALLTHROUGH;
 			case AIS_DOCK_3:
 				model_anim_start_type(shipp, TRIGGER_TYPE_DOCKING_STAGE_3, docker_index, -1);
 				model_anim_start_type(goal_shipp, TRIGGER_TYPE_DOCKING_STAGE_3, dockee_index, -1);
+				FALLTHROUGH;
 			case AIS_DOCK_2:
 				model_anim_start_type(shipp, TRIGGER_TYPE_DOCKING_STAGE_2, docker_index, -1);
 				model_anim_start_type(goal_shipp, TRIGGER_TYPE_DOCKING_STAGE_2, dockee_index, -1);
@@ -12376,6 +12382,7 @@ void ai_maybe_evade_locked_missile(object *objp, ai_info *aip)
 				case AIM_DOCK:	//	Ships in dock mode can evade iif they are not currently repairing or docked.
 					if (object_is_docked(objp) || (aip->ai_flags[AI::AI_Flags::Repairing, AI::AI_Flags::Being_repaired]))
 						break;
+					FALLTHROUGH;
 				case AIM_GUARD:
 					//	If in guard mode and far away from guard object, don't pursue guy that hit me.
 					if ((aip->guard_objnum != -1) && (aip->guard_signature == Objects[aip->guard_objnum].signature)) {
@@ -12383,6 +12390,7 @@ void ai_maybe_evade_locked_missile(object *objp, ai_info *aip)
 							return;
 						}
 					}
+					FALLTHROUGH;
 				case AIM_EVADE:
 				case AIM_GET_BEHIND:
 				case AIM_STAY_NEAR:

--- a/code/cfile/cfilesystem.cpp
+++ b/code/cfile/cfilesystem.cpp
@@ -1567,8 +1567,10 @@ int cf_get_file_list( SCP_vector<SCP_string> &list, int pathtype, const char *fi
 				continue;
 
 			char fn[MAX_PATH];
-			snprintf(fn, MAX_PATH-1, "%s/%s", filespec, dir->d_name);
-			fn[MAX_PATH-1] = 0;
+			if (snprintf(fn, MAX_PATH, "%s/%s", filespec, dir->d_name) >= MAX_PATH) {
+				// Make sure the string is null terminated
+				fn[MAX_PATH-1] = 0;
+			}
 
 			struct stat buf;
 			if (stat(fn, &buf) == -1) {
@@ -1776,8 +1778,10 @@ int cf_get_file_list( int max, char **list, int pathtype, const char *filter, in
 				continue;
 
 			char fn[MAX_PATH];
-			snprintf(fn, MAX_PATH-1, "%s/%s", filespec, dir->d_name);
-			fn[MAX_PATH-1] = 0;
+			if (snprintf(fn, MAX_PATH, "%s/%s", filespec, dir->d_name) >= MAX_PATH) {
+				// Make sure the string is null terminated
+				fn[MAX_PATH-1] = 0;
+			}
 
 			struct stat buf;
 			if (stat(fn, &buf) == -1) {
@@ -1991,8 +1995,10 @@ int cf_get_file_list_preallocated( int max, char arr[][MAX_FILENAME_LEN], char *
 				continue;
 
 			char fn[MAX_PATH];
-			snprintf(fn, MAX_PATH-1, "%s/%s", filespec, dir->d_name);
-			fn[MAX_PATH-1] = 0;
+			if (snprintf(fn, MAX_PATH, "%s/%s", filespec, dir->d_name) >= MAX_PATH) {
+				// Make sure the string is null terminated
+				fn[MAX_PATH-1] = 0;
+			}
 
 			struct stat buf;
 			if (stat(fn, &buf) == -1) {

--- a/code/globalincs/toolchain/clang.h
+++ b/code/globalincs/toolchain/clang.h
@@ -67,3 +67,11 @@
 #define unlikely(x)  __builtin_expect((long) !!(x), 0L)
 
 #define USED_VARIABLE __attribute__((used))
+
+#if __has_cpp_attribute(fallthough)
+#define FALLTHROUGH [[fallthrough]]
+#elif __has_cpp_attribute(clang::fallthough)
+#define FALLTHROUGH [[clang::fallthrough]]
+#else
+#define FALLTHROUGH
+#endif

--- a/code/globalincs/toolchain/doxygen.h
+++ b/code/globalincs/toolchain/doxygen.h
@@ -51,3 +51,10 @@
  * This can be used to ensure that a static variable is present even if it isn't referenced in the translation unit
  */
 #define USED_VARIABLE
+
+/**
+ * @brief For use in a case statement which falls through
+ *
+ * Some compilers issue a warning if a fallthrough is detected. This define can be used to suppress that warning.
+ */
+#define FALLTHROUGH

--- a/code/globalincs/toolchain/gcc.h
+++ b/code/globalincs/toolchain/gcc.h
@@ -66,3 +66,9 @@
 #define unlikely(x)  __builtin_expect((long) !!(x), 0L)
 
 #define USED_VARIABLE __attribute__((used))
+
+#if SCP_COMPILER_VERSION_MAJOR >= 7
+#define FALLTHROUGH [[fallthrough]]
+#else
+#define FALLTHROUGH
+#endif

--- a/code/globalincs/toolchain/mingw.h
+++ b/code/globalincs/toolchain/mingw.h
@@ -63,3 +63,9 @@
 #define __STDC_FORMAT_MACROS 1
 
 #define USED_VARIABLE __attribute__((used))
+
+#if SCP_COMPILER_VERSION_MAJOR >= 7
+#define FALLTHROUGH [[fallthough]]
+#else
+#define FALLTHROUGH
+#endif

--- a/code/globalincs/toolchain/msvc.h
+++ b/code/globalincs/toolchain/msvc.h
@@ -85,3 +85,5 @@
 #define unlikely(x)
 
 #define USED_VARIABLE
+
+#define FALLTHROUGH

--- a/code/graphics/generic.cpp
+++ b/code/graphics/generic.cpp
@@ -251,13 +251,19 @@ int generic_anim_stream(generic_anim *ga, const bool cache)
 		if ( p )
 			*p = 0;
 		char frame_name[MAX_FILENAME_LEN];
-		snprintf(frame_name, MAX_FILENAME_LEN, "%s_0000", ga->filename);
+		if (snprintf(frame_name, MAX_FILENAME_LEN, "%s_0000", ga->filename) >= MAX_FILENAME_LEN) {
+			// Make sure the string is null terminated
+			frame_name[MAX_FILENAME_LEN - 1] = '\0';
+		}
 		ga->bitmap_id = bm_load(frame_name);
 		if(ga->bitmap_id < 0) {
 			mprintf(("Cannot find first frame for eff streaming. eff Filename: %s", ga->filename));
 			return -1;
 		}
-		snprintf(frame_name, MAX_FILENAME_LEN, "%s_0001", ga->filename);
+		if (snprintf(frame_name, MAX_FILENAME_LEN, "%s_0001", ga->filename) >= MAX_FILENAME_LEN) {
+			// Make sure the string is null terminated
+			frame_name[MAX_FILENAME_LEN - 1] = '\0';
+		}
 		ga->eff.next_frame = bm_load(frame_name);
 		bm_get_info(ga->bitmap_id, &ga->width, &ga->height);
 		ga->previous_frame = 0;
@@ -369,7 +375,10 @@ void generic_render_eff_stream(generic_anim *ga)
 		mprintf(("frame: %d\n", ga->current_frame));
 	#endif
 		char frame_name[MAX_FILENAME_LEN];
-		snprintf(frame_name, MAX_FILENAME_LEN, "%s_%.4d", ga->filename, ga->current_frame);
+		if (snprintf(frame_name, MAX_FILENAME_LEN, "%s_%.4d", ga->filename, ga->current_frame) >= MAX_FILENAME_LEN) {
+			// Make sure the string is null terminated
+			frame_name[MAX_FILENAME_LEN - 1] = '\0';
+		}
 		if(bm_reload(ga->eff.next_frame, frame_name) == ga->eff.next_frame)
 		{
 			bitmap* next_frame_bmp = bm_lock(ga->eff.next_frame, bpp, (bpp==8)?BMP_AABITMAP:BMP_TEX_NONCOMP, true);
@@ -379,7 +388,10 @@ void generic_render_eff_stream(generic_anim *ga)
 			bm_unload(ga->eff.next_frame, 0, true);
 			if (ga->current_frame == ga->num_frames-1)
 			{
-				snprintf(frame_name, MAX_FILENAME_LEN, "%s_0001", ga->filename);
+				if (snprintf(frame_name, MAX_FILENAME_LEN, "%s_0001", ga->filename) >= MAX_FILENAME_LEN) {
+					// Make sure the string is null terminated
+					frame_name[MAX_FILENAME_LEN - 1] = '\0';
+				}
 				bm_reload(ga->eff.next_frame, frame_name);
 			}
 		}

--- a/code/graphics/opengl/gropengldeferred.cpp
+++ b/code/graphics/opengl/gropengldeferred.cpp
@@ -154,6 +154,7 @@ void gr_opengl_deferred_lighting_finish()
 				light_data->coneAngle = l->cone_angle;
 				light_data->coneInnerAngle = l->cone_inner_angle;
 				light_data->coneDir = l->vec2;
+				FALLTHROUGH;
 			case LT_POINT:
 				light_data->diffuseLightColor = diffuse;
 				light_data->specLightColor = spec;

--- a/code/graphics/paths/nanovg/stb_image.h
+++ b/code/graphics/paths/nanovg/stb_image.h
@@ -5228,7 +5228,7 @@ static int stbi__tga_get_comp(int bits_per_pixel, int is_grey, int* is_rgb16)
    switch(bits_per_pixel) {
       case 8:  return STBI_grey;
       case 16: if(is_grey) return STBI_grey_alpha;
-            // else: fall-through
+            // fall-through
       case 15: if(is_rgb16) *is_rgb16 = 1;
             return STBI_rgb;
       case 24: // fall-through

--- a/code/hud/hudartillery.cpp
+++ b/code/hud/hudartillery.cpp
@@ -144,6 +144,7 @@ void parse_ssm(const char *filename)
 					break;
 				case 1:
 					required_string("Circle");
+					FALLTHROUGH;
 				case -1:	// If we're ignoring parse errors and can't identify the shape, go with a circle.
 					s.shape = SSM_SHAPE_CIRCLE;
 					break;

--- a/code/inetfile/cftp.cpp
+++ b/code/inetfile/cftp.cpp
@@ -269,7 +269,10 @@ uint CFtpGet::GetFile()
 		return 0;
 	if(m_szDir[0])
 	{
-		sprintf(szCommandString,"CWD %s\r\n",m_szDir);
+		if (snprintf(szCommandString, sizeof(szCommandString), "CWD %s\r\n",m_szDir) >= (int)sizeof(szCommandString)) {
+			// Make sure the string is null terminated
+			szCommandString[sizeof(szCommandString) - 1] = '\0';
+		}
 		rcode = SendFTPCommand(szCommandString);
 		if(rcode >=400)
 		{

--- a/code/menuui/credits.cpp
+++ b/code/menuui/credits.cpp
@@ -693,6 +693,7 @@ void credits_do_frame(float frametime)
 			break;
 		}
 		// else, react like tab key.
+		FALLTHROUGH;
 
 	case KEY_CTRLED | KEY_DOWN:
 	case KEY_TAB:

--- a/code/mission/missionhotkey.cpp
+++ b/code/mission/missionhotkey.cpp
@@ -880,6 +880,7 @@ void hotkey_button_pressed(int n)
 		case ACCEPT_BUTTON:
 			save_hotkeys();
 			// fall through to CANCEL_BUTTON
+			FALLTHROUGH;
 
 		case CANCEL_BUTTON:			
 			mission_hotkey_exit();
@@ -1052,6 +1053,7 @@ void mission_hotkey_do_frame(float frametime)
 		case KEY_CTRLED | KEY_ENTER:
 			save_hotkeys();
 			// fall through to next state -- allender changed this behavior since ESC should always cancel, no?
+			FALLTHROUGH;
 
 		case KEY_ESC:			
 			mission_hotkey_exit();

--- a/code/model/modelrender.cpp
+++ b/code/model/modelrender.cpp
@@ -1776,6 +1776,7 @@ void model_render_glowpoint(int point_num, vec3d *pos, matrix *orient, glow_poin
 					} else {
 						x %= gpo->pulse_period;
 					}
+					FALLTHROUGH;
 
 				case PULSE_TRI:
 					float inv;

--- a/code/network/multi_pxo.cpp
+++ b/code/network/multi_pxo.cpp
@@ -1827,7 +1827,10 @@ int multi_pxo_connect_do()
 
 		// build the ip string
 		memset(ip_string, 0, MAX_PXO_TEXT_LEN);
-		sprintf(ip_string, "%s:%d", Multi_options_g.pxo_ip, PXO_CHAT_PORT);
+		if (snprintf(ip_string, MAX_PXO_TEXT_LEN, "%s:%d", Multi_options_g.pxo_ip, PXO_CHAT_PORT) >= MAX_PXO_TEXT_LEN) {
+			// Make sure the string is null terminated
+			ip_string[MAX_PXO_TEXT_LEN - 1] = '\0';
+		}
 
 		// connect to the server
 		ret_code = ConnectToChatServer(ip_string, Multi_pxo_nick, id_string);		

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -9250,6 +9250,7 @@ int sexp_is_iff(int n)
 					// it's probably an exited wing, which we don't store information about
 					return SEXP_NAN_FOREVER;
 				}
+				FALLTHROUGH;
 			}
 
 			// we don't handle the other cases
@@ -13036,7 +13037,8 @@ void sexp_alter_ship_flag_helper(object_ship_wing_point_team &oswpt, bool future
 				Ai_info[oswpt.shipp->ai_index].ai_flags.set(ai_flag, set_flag);
 			}
 			
-			// no break statement. We want to fall through. 
+			// no break statement. We want to fall through.
+			FALLTHROUGH;
 			
 		case OSWPT_TYPE_PARSE_OBJECT:
 			if (!future_ships) {
@@ -26281,6 +26283,9 @@ int query_operator_argument_type(int op, int argnum)
 				return OPF_STRING;
 			} else if (argnum == 2) {
 				return OPF_VARIABLE_NAME;
+			} else {
+				// This shouldn't happen
+				return OPF_NONE;
 			}
 
 		case OP_STRING_CONCATENATE_BLOCK:
@@ -26295,6 +26300,9 @@ int query_operator_argument_type(int op, int argnum)
 				return OPF_NUMBER;
 			} else if (argnum == 1) {
 				return OPF_VARIABLE_NAME;
+			} else {
+				// This shouldn't happen
+				return OPF_NONE;
 			}
 
 		case OP_STRING_GET_SUBSTRING:
@@ -26304,6 +26312,9 @@ int query_operator_argument_type(int op, int argnum)
 				return OPF_POSITIVE;
 			} else if (argnum == 3) {
 				return OPF_VARIABLE_NAME;
+			} else {
+				// This shouldn't happen
+				return OPF_NONE;
 			}
 
 		case OP_STRING_SET_SUBSTRING:
@@ -26315,6 +26326,9 @@ int query_operator_argument_type(int op, int argnum)
 				return OPF_STRING;
 			} else if (argnum == 4) {
 				return OPF_VARIABLE_NAME;
+			} else {
+				// This shouldn't happen
+				return OPF_NONE;
 			}
 
 		case OP_DEBUG:
@@ -26723,6 +26737,9 @@ int query_operator_argument_type(int op, int argnum)
 				return OPF_SHIP;
 			else if (argnum == 1)
 				return OPF_SUBSYSTEM;
+			else
+				// This shouldn't happen
+				return OPF_NONE;
 
 		case OP_DISTANCE_SUBSYSTEM:
 			if (argnum == 0)
@@ -26732,7 +26749,8 @@ int query_operator_argument_type(int op, int argnum)
 			else if (argnum == 2)
 				return OPF_SUBSYSTEM;
 			else
-				Int3();		// shouldn't happen
+				// This shouldn't happen
+				return OPF_NONE;
 
 		case OP_NUM_WITHIN_BOX:
 			if(argnum < 3)
@@ -26778,6 +26796,8 @@ int query_operator_argument_type(int op, int argnum)
 				return OPF_JUMP_NODE_NAME;
 			else if (argnum == 1)
 				return OPF_POSITIVE;
+			else
+				return OPF_NONE;
 
 		case OP_IS_SUBSYSTEM_DESTROYED_DELAY:
 			if ( argnum == 0 )
@@ -27007,6 +27027,7 @@ int query_operator_argument_type(int op, int argnum)
 
 			// fall through
 			argnum--;
+			FALLTHROUGH;
 
 		case OP_UPDATE_SOUND_ENVIRONMENT:
 		{
@@ -27110,6 +27131,9 @@ int query_operator_argument_type(int op, int argnum)
 				return OPF_MESSAGE;
 			else if(a_mod == 3)
 				return OPF_POSITIVE;
+			else
+				// This can't happen
+				return OPF_NONE;
 		}
 
 		case OP_TRAINING_MSG:
@@ -27256,6 +27280,8 @@ int query_operator_argument_type(int op, int argnum)
 				return OPF_POSITIVE;
 			else if (argnum == 2)
 				return OPF_BOOL;
+			else
+				return OPF_NONE;
 
 		case OP_GOAL_INCOMPLETE:
 		case OP_GOAL_TRUE_DELAY:
@@ -27566,6 +27592,8 @@ int query_operator_argument_type(int op, int argnum)
 				return OPF_WEAPON_NAME;
 			} else if(argnum > 2) {
 				return OPF_POSITIVE;
+			} else {
+				return OPF_NONE;
 			}
 
 		case OP_TURRET_SET_DIRECTION_PREFERENCE:
@@ -27700,6 +27728,8 @@ int query_operator_argument_type(int op, int argnum)
 				return OPF_BOOL;
 			else if (argnum == 5)
 				return OPF_SUBSYSTEM;
+			else
+				return OPF_NONE;
 
 		case OP_BEAM_FREE_ALL:
 		case OP_BEAM_LOCK_ALL:
@@ -28129,6 +28159,8 @@ int query_operator_argument_type(int op, int argnum)
 				return OPF_POSITIVE;
 			else if (argnum == 12 )
 				return OPF_BOOL;
+			else
+				return OPF_NONE;
 
 		case OP_CUTSCENES_SHOW_SUBTITLE_TEXT:
 			if (argnum == 0)
@@ -28143,6 +28175,8 @@ int query_operator_argument_type(int op, int argnum)
 				return OPF_FONT;
 			else if (argnum == 12)
 				return OPF_BOOL;
+			else
+				return OPF_NONE;
 
 		case OP_CUTSCENES_SHOW_SUBTITLE_IMAGE:
 			if (argnum == 0)
@@ -28155,6 +28189,8 @@ int query_operator_argument_type(int op, int argnum)
 				return OPF_POSITIVE;
 			else if (argnum == 9)
 				return OPF_BOOL;
+			else
+				return OPF_NONE;
 
 		//</Cutscenes>
 
@@ -28163,6 +28199,8 @@ int query_operator_argument_type(int op, int argnum)
 				return OPF_JUMP_NODE_NAME;
 			else if (argnum==1)
 				return OPF_STRING;
+			else
+				return OPF_NONE;
 
 		case OP_JUMP_NODE_SET_JUMPNODE_COLOR:
 			if(argnum==0)

--- a/code/scripting/ade.cpp
+++ b/code/scripting/ade.cpp
@@ -679,6 +679,7 @@ void ade_table_entry::OutputMeta(FILE *fp)
 				break;
 			default:
 				Warning(LOCATION, "Unknown type '%c' passed to ade_table_entry::OutputMeta", Type);
+				FALLTHROUGH;
 			case 'b':
 			case 'd':
 			case 'f':

--- a/code/scripting/api/objs/order.cpp
+++ b/code/scripting/api/objs/order.cpp
@@ -299,6 +299,7 @@ ADE_VIRTVAR(Target, l_Order, "object", "Target of the order. Value may also be a
 				objnum = Ships[shipnum].objnum;
 				break;
 			}
+			break;
 		case AI_GOAL_CHASE_WING:
 		case AI_GOAL_GUARD_WING:
 			int wingnum = wing_name_lookup(ohp->aigp->target_name);

--- a/code/scripting/scripting.cpp
+++ b/code/scripting/scripting.cpp
@@ -260,6 +260,7 @@ bool ConditionedHook::ConditionsValid(int action, object *objp, int more_data)
 					return false;
 				if(stricmp(Ship_types[sip->class_type].name, scp->data.name))
 					return false;
+				break;
 			case CHC_SHIPCLASS:
 				if(objp == NULL || objp->type != OBJ_SHIP)
 					return false;

--- a/code/stats/medals.cpp
+++ b/code/stats/medals.cpp
@@ -830,7 +830,10 @@ void init_medal_bitmaps()
 	// load up rank insignia
 	if (gr_screen.res == GR_1024) {
 		char filename[NAME_LENGTH];
-		sprintf(filename, "2_%s", Ranks[Player_score->rank].bitmap);
+		if (snprintf(filename, NAME_LENGTH, "2_%s", Ranks[Player_score->rank].bitmap) >= NAME_LENGTH) {
+			// Make sure the string is null terminated
+			filename[NAME_LENGTH - 1] = '\0';
+		}
 		Rank_bm = bm_load(filename);
 	} else {
 		Rank_bm = bm_load(Ranks[Player_score->rank].bitmap);

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -5354,6 +5354,7 @@ void game_leave_state( int old_state, int new_state )
 		case GS_STATE_TRAINING_PAUSED:
 			Training_num_lines = 0;
 			// fall through to GS_STATE_GAME_PAUSED
+			FALLTHROUGH;
 
 		case GS_STATE_GAME_PAUSED:
 			game_start_time();


### PR DESCRIPTION
The two new warning types are switch-case fallthrough detection and `sprintf` truncation warnings. I fixed the first type by adding the fallthrough attribute where appropriate. Since `[[fallthrough]]` is a C++17 feature I added detection for other versions of the same attribute.

The second type was fixed by looking at the return value of `snprintf` and if the return value indicated a truncation then a null byte was written at the end of the buffer.

This fixes #1375.