### PR TITLE
Move game_do_training_checks() to be right before goal processing.

### DIFF
--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -3698,6 +3698,8 @@ void game_simulation_frame()
 		// move all the objects now
 		obj_move_all(flFrametime);
 
+		game_do_training_checks();
+
 		mission_eval_goals();
 	}
 
@@ -4207,7 +4209,6 @@ void game_frame(bool paused)
 		}
 	}
 
-	game_do_training_checks();
 	asteroid_frame();
 
 	// process lightning (nebula only)


### PR DESCRIPTION
In-mission events (SEXP chains that are used for directives and all mission logic) can sometimes call "training SEXPs", which depend on special variables set in the `game_do_training_checks()` function. However, this function was called near the end of `game_frame()`, well after `mission_eval_goals()` (which processes all mission events). This means that most training SEXPs wouldn't actually evaluate as true until the frame after whatever condition they were checking became fulfilled. This, combined with PR #1388 making the `targeted` SEXP actually use the appropriate variables (`Players_target` and `Players_targeted_subsys`), means that Diaspora's very first training mission's very first instruction (after launching from the launch tube, anyway) could not be completed, because the mission logic assumed that `key-pressed` and `targeted` would both return true on the same frame (which, after PR #1388, they did not).

This PR moves `game_do_training_checks()` to be called immediately before `mission_eval_goals()`, and therefore immediately after `obj_move_all()`, meaning `Training_context_speed_set` can become set the same frame the player's ship reaches the appropriate velocity and the relevant SEXPs can operate on the most up-to-date data available.