### PR TITLE
Window title overhaul.

### DIFF
--- a/cmake/fred_rc.h.in
+++ b/cmake/fred_rc.h.in
@@ -1,0 +1,9 @@
+
+
+#ifndef __FREDRC_H
+#define __FREDRC_H
+
+#define ABOUT_LINE_1 "FRED2_OPEN - FreeSpace Editor, Version @FSO_PRODUCT_VERSION_STRING@ OpenGL"
+#define MAINFRAME_CONTENTS "FRED2_OPEN @FSO_PRODUCT_VERSION_STRING@ - FreeSpace2 Mission Editor\nUntitled\nFRED2\nFreeSpace2 Missions (*.fs2)\n.fs2\nFreeSpace2Mission\nFreeSpace2 Mission"
+
+#endif // __FREDRC_H

--- a/cmake/generateHeaders.cmake
+++ b/cmake/generateHeaders.cmake
@@ -3,3 +3,4 @@ include(platformChecks)
 include(Cxx11)
 
 CONFIGURE_FILE(${CMAKE_CURRENT_LIST_DIR}/project.h.in ${GENERATED_SOURCE_DIR}/project.h)
+CONFIGURE_FILE(${CMAKE_CURRENT_LIST_DIR}/fred_rc.h.in ${GENERATED_SOURCE_DIR}/fred_rc.h)

--- a/code/graphics/opengl/gropengl.cpp
+++ b/code/graphics/opengl/gropengl.cpp
@@ -72,6 +72,7 @@ static GLuint GL_screen_pbo = 0;
 float GL_alpha_threshold = 0.0f;
 
 extern const char *Osreg_title;
+extern SCP_string Window_title;
 
 extern GLfloat GL_anisotropy;
 
@@ -1020,6 +1021,9 @@ int opengl_init_display_device()
 	attrs.height = (uint32_t) gr_screen.max_h;
 
 	attrs.title = Osreg_title;
+	if (!Window_title.empty()) {
+		attrs.title = Window_title;
+	}
 
 	if (!Cmdline_window && ! Cmdline_fullscreen_window) {
 		attrs.flags.set(os::ViewPortFlags::Fullscreen);

--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -37,6 +37,7 @@ bool Beams_use_damage_factors = false;
 float Generic_pain_flash_factor = 1.0f;
 float Shield_pain_flash_factor = 0.0f;
 gameversion::version Targetted_version(2, 0, 0, 0); // Defaults to retail
+SCP_string Window_title = "";
 
 void parse_mod_table(const char *filename)
 {
@@ -64,6 +65,10 @@ void parse_mod_table(const char *filename)
 					gameversion::format_version(Targetted_version).c_str(),
 					gameversion::format_version(gameversion::get_executable_version()).c_str());
 			}
+		}
+
+		if (optional_string("$Window title:")) {
+			stuff_string(Window_title, F_NAME);
 		}
 
 		optional_string("#CAMPAIGN SETTINGS");

--- a/code/mod_table/mod_table.h
+++ b/code/mod_table/mod_table.h
@@ -30,6 +30,7 @@ extern bool Red_alert_applies_to_delayed_ships;
 extern bool Beams_use_damage_factors;
 extern float Generic_pain_flash_factor;
 extern float Shield_pain_flash_factor;
+extern SCP_string Window_title;
 
 void mod_table_init();
 

--- a/code/network/stand_gui.cpp
+++ b/code/network/stand_gui.cpp
@@ -2403,7 +2403,7 @@ DWORD standalone_process(WORD lparam)
 
 void std_init_os()
 {
-	os_init_registry_stuff(Osreg_company_name, Osreg_app_name,NULL);
+	os_init_registry_stuff(Osreg_company_name, Osreg_app_name);
 }
 
 

--- a/code/osapi/osapi.cpp
+++ b/code/osapi/osapi.cpp
@@ -218,9 +218,16 @@ void os_deinit();
 
 // If app_name is NULL or ommited, then TITLE is used
 // for the app name, which is where registry keys are stored.
-void os_init(const char * wclass, const char * title, const char *app_name, const char *version_string )
+void os_init(const char * wclass, const char * title, const char * app_name)
 {
-	os_init_registry_stuff(Osreg_company_name, title, version_string);
+	if (app_name == nullptr || !app_name[0])
+	{
+		os_init_registry_stuff(Osreg_company_name, title);
+	}
+	else
+	{
+		os_init_registry_stuff(Osreg_company_name, app_name);
+	}
 
 	strcpy_s( szWinTitle, title );
 	strcpy_s( szWinClass, wclass );

--- a/code/osapi/osapi.h
+++ b/code/osapi/osapi.h
@@ -44,7 +44,7 @@ extern int Os_debugger_running;
 
 // If app_name is NULL or ommited, then TITLE is used
 // for the app name, which is where registry keys are stored.
-void os_init(const char * wclass, const char * title, const char *app_name=NULL, const char *version_string=NULL );
+void os_init(const char * wclass, const char * title, const char * app_name = nullptr);
 
 // set the main window title
 void os_set_title( const char * title );

--- a/code/osapi/osregistry.cpp
+++ b/code/osapi/osregistry.cpp
@@ -766,7 +766,7 @@ static void profile_save(Profile *profile, const char *file)
 // os registry functions -------------------------------------------------------------
 
 // initialize the registry. setup default keys to use
-void os_init_registry_stuff(const char *company, const char *app, const char *version)
+void os_init_registry_stuff(const char *company, const char *app)
 {
 	if (company) {
 		strcpy_s(szCompanyName, company);

--- a/code/osapi/osregistry.h
+++ b/code/osapi/osregistry.h
@@ -31,7 +31,7 @@ extern const char *Osreg_config_file_name;
 
 
 // initialize the registry. setup default keys to use
-void os_init_registry_stuff( const char *company, const char *app, const char *version );
+void os_init_registry_stuff( const char *company, const char *app);
 
 // Writes a string to the registry
 void os_config_write_string( const char *section, const char *name, const char *value );

--- a/fred2/fred.rc
+++ b/fred2/fred.rc
@@ -13,6 +13,7 @@
 // Generated from the TEXTINCLUDE 2 resource.
 //
 #include "afxres.h"
+#include "fred_rc.h"
 
 /////////////////////////////////////////////////////////////////////////////
 #undef APSTUDIO_READONLY_SYMBOLS
@@ -38,6 +39,7 @@ END
 2 TEXTINCLUDE 
 BEGIN
     "#include ""afxres.h""\r\n"
+    "#include ""fred_rc.h""\r\n"
     "\0"
 END
 
@@ -657,8 +659,8 @@ CAPTION "About FRED2"
 FONT 8, "MS Sans Serif"
 BEGIN
     ICON            IDR_MAINFRAME,IDC_STATIC,10,17,20,20,SS_REALSIZEIMAGE
-    LTEXT           "FRED2_OPEN - FreeSpace Editor, Version 3.7.5 OpenGL",IDC_STATIC,39,8,184,10,SS_NOPREFIX
-    LTEXT           "Copyright � 1999 Volition, Inc.  All Rights Reserved",IDC_STATIC,39,17,164,8
+    LTEXT           ABOUT_LINE_1,IDC_STATIC,39,8,184,10,SS_NOPREFIX
+    LTEXT           L"Copyright \x00A9 1999 Volition, Inc.  All Rights Reserved",IDC_STATIC,39,17,164,8
     DEFPUSHBUTTON   "OK",IDOK,229,7,48,14,WS_GROUP
     LTEXT           """Fred2 is the omega of all giant unwieldy pieces of code. Its big, its horrifying, and it just doesn't care. View it at your own risk."" - Dave Baranec",IDC_STATIC,39,62,238,20
     LTEXT           "Ported to OGL by RT",IDC_STATIC,39,40,68,8
@@ -2697,7 +2699,7 @@ IDC_CURSOR2             CURSOR                  "res\\cursor2.cur"
 
 STRINGTABLE
 BEGIN
-    IDR_MAINFRAME           "FRED2_OPEN 3.7.5 - FreeSpace2 Mission Editor\nUntitled\nFRED2\nFreeSpace2 Missions (*.fs2)\n.fs2\nFreeSpace2Mission\nFreeSpace2 Mission"
+    IDR_MAINFRAME           MAINFRAME_CONTENTS
 END
 
 STRINGTABLE

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -1684,7 +1684,7 @@ void game_init()
 
 	// init os stuff next
 	if ( !Is_standalone ) {		
-		os_init( Osreg_class_name, Osreg_app_name );
+		os_init( Osreg_class_name, Window_title.c_str(), Osreg_app_name );
 	}
 	else {
 		std_init_os();


### PR DESCRIPTION
FSO now allows the window title to be specified via game_settings.tbl, some never-used function arguments were pruned at the same time, and fred.rc now receives version information (for the About dialogue and the title bar) from a cmake-generated header, so the version numbers get filled in properly. Speaking of FRED's About dialogue, it now displays the copyright symbol properly.