### PR TITLE
Avoid exception when closing FRED related to bm_release().

### DIFF
--- a/fred2/fredview.cpp
+++ b/fred2/fredview.cpp
@@ -4594,7 +4594,6 @@ void CFREDView::OnDestroy()
 {
 	audiostream_close();
 	snd_close();
- 	gr_close();
 
 	CView::OnDestroy();
 }

--- a/fred2/mainfrm.cpp
+++ b/fred2/mainfrm.cpp
@@ -148,6 +148,7 @@ void CMainFrame::OnClose() {
 	theApp.write_ini_file();
 	SaveBarState("Tools state");
 	CFrameWnd::OnClose();
+	gr_close();
 }
 
 int CMainFrame::OnCreate(LPCREATESTRUCT lpCreateStruct) {


### PR DESCRIPTION
Now that BMPMAN dynamically allocates the `bm_bitmaps` array, and deallocates it in `bm_close()`, which is explicitly called by `gr_close()`, FRED generates an exception on close because of trying to release bitmap handles after `bm_bitmaps` has been deallocated and set to null. This is because `gr_close()` is called by `CFREDView::OnDestroy()`, but the mission textures aren't fully paged out until `CMainFrame::OnClose()` (well, technically, `CMainFrame::OnClose()` calls `CFrameWnd::OnClose()`, which calls `CWinApp::CloseAllDocuments()`, which calls `CDocManager::CloseAllDocuments()`, which calls `CDocTemplate::CloseAllDocuments()`, which calls `CDocument::OnCloseDocument()`, which calls `CFREDDoc::DeleteContents()`, which calls `CFREDDoc::editor_init_mission()`, which calls `reset_mission()`, which calls `clear_mission()`, which calls `model_free_all()`, which calls `model_instance_free_all()`, which calls `model_unload()` for every model, which calls `model_page_out_textures()`, which *finally* calls the crashing `bm_release()`). This commit moves the `gr_close()` call to `CMainFrame::OnClose()`, *after* it calls `CFrameWnd::OnClose()`, which avoids the exception as `bm_bitmaps` is still intact long enough for those final textures to be freed from it.