### PR TITLE
Fix PCX alpha color correction

### DIFF
--- a/code/bmpman/bmpman.cpp
+++ b/code/bmpman/bmpman.cpp
@@ -2340,7 +2340,7 @@ void bm_lock_pcx(int handle, int bitmapnum, bitmap_entry *be, bitmap *bmp, int b
 	// this will populate filename[] whether it's EFF or not
 	EFF_FILENAME_CHECK;
 
-	pcx_error = pcx_read_bitmap(filename, data, NULL, (bpp >> 3), (flags & BMP_AABITMAP), 0, be->dir_type);
+	pcx_error = pcx_read_bitmap(filename, data, NULL, (bpp >> 3), (flags & BMP_AABITMAP), (flags & BMP_MASK_BITMAP) != 0, be->dir_type);
 
 	if (pcx_error != PCX_ERROR_NONE) {
 		mprintf(("Couldn't load PCX!!! (%s)\n", filename));

--- a/code/bmpman/bmpman.h
+++ b/code/bmpman/bmpman.h
@@ -58,6 +58,7 @@ extern int MAX_BITMAPS;
 #define BMP_TEX_DXT3        (1<<4)      //!< dxt3 compressed 8r8g8b4a (32bit)
 #define BMP_TEX_DXT5        (1<<5)      //!< dxt5 compressed 8r8g8b8a (32bit)
 #define BMP_TEX_CUBEMAP     (1<<6)      //!< a texture made for cubic environment map
+#define BMP_MASK_BITMAP     (1<<7)      //!< a bitmap that will be used for masking mouse interaction. Typically not used in render operations
 
 // Combined flags
 #define BMP_TEX_COMP        ( BMP_TEX_DXT1 | BMP_TEX_DXT3 | BMP_TEX_DXT5 )  //!< Compressed textures

--- a/code/graphics/render.cpp
+++ b/code/graphics/render.cpp
@@ -147,6 +147,7 @@ static void bitmap_ex_internal(int x,
 }
 
 void gr_aabitmap(int x, int y, int resize_mode, bool mirror) {
+	GR_DEBUG_SCOPE("Draw AA-bitmap");
 
 	int w, h, do_resize;
 

--- a/code/menuui/mainhallmenu.cpp
+++ b/code/menuui/mainhallmenu.cpp
@@ -510,7 +510,7 @@ void main_hall_init(const SCP_string &main_hall_name)
 		}
 	} else {
 		// get a pointer to bitmap by using bm_lock(), so we can feed it to he snazzy menu system
-		Main_hall_mask_bitmap = bm_lock(Main_hall_mask, 8, BMP_AABITMAP);
+		Main_hall_mask_bitmap = bm_lock(Main_hall_mask, 8, BMP_AABITMAP | BMP_MASK_BITMAP);
 		Main_hall_mask_data = (ubyte*)Main_hall_mask_bitmap->data;
 		bm_get_info(Main_hall_mask, &Main_hall_mask_w, &Main_hall_mask_h);
 	}

--- a/code/menuui/trainingmenu.cpp
+++ b/code/menuui/trainingmenu.cpp
@@ -51,7 +51,7 @@ void training_menu_init()
 	}
 	else {
 		// get a pointer to bitmap by using bm_lock()
-		trainingMenuMaskPtr = bm_lock(trainingMenuMask, 8, BMP_AABITMAP);
+		trainingMenuMaskPtr = bm_lock(trainingMenuMask, 8, BMP_AABITMAP | BMP_MASK_BITMAP);
 		mask_data = (ubyte*)trainingMenuMaskPtr->data;		
 		bm_get_info(trainingMenuMask, &Training_mask_w, &Training_mask_h);
 	}

--- a/code/missionui/missionshipchoice.cpp
+++ b/code/missionui/missionshipchoice.cpp
@@ -689,7 +689,7 @@ void ship_select_init()
 	Shipselect_mask_h = -1;
 
 	// get a pointer to bitmap by using bm_lock()
-	ShipSelectMaskPtr = bm_lock(ShipSelectMaskBitmap, 8, BMP_AABITMAP);
+	ShipSelectMaskPtr = bm_lock(ShipSelectMaskBitmap, 8, BMP_AABITMAP | BMP_MASK_BITMAP);
 	ShipSelectMaskData = (ubyte*)ShipSelectMaskPtr->data;	
 	bm_get_info(ShipSelectMaskBitmap, &Shipselect_mask_w, &Shipselect_mask_h);
 

--- a/code/missionui/missionweaponchoice.cpp
+++ b/code/missionui/missionweaponchoice.cpp
@@ -2018,7 +2018,7 @@ void weapon_select_init()
 	Weaponselect_mask_h = -1;
 
 	// get a pointer to bitmap by using bm_lock()
-	WeaponSelectMaskPtr = bm_lock(WeaponSelectMaskBitmap, 8, BMP_AABITMAP);
+	WeaponSelectMaskPtr = bm_lock(WeaponSelectMaskBitmap, 8, BMP_AABITMAP | BMP_MASK_BITMAP);
 	WeaponSelectMaskData = (ubyte*)WeaponSelectMaskPtr->data;
 	Assert(WeaponSelectMaskData != NULL);
 	bm_get_info(WeaponSelectMaskBitmap, &Weaponselect_mask_w, &Weaponselect_mask_h);

--- a/code/pcxutils/pcxutils.cpp
+++ b/code/pcxutils/pcxutils.cpp
@@ -213,7 +213,7 @@ typedef struct { ubyte b, g, r, a; } COLOR32;
 #endif
 
 //int pcx_read_bitmap_16bpp( char * real_filename, ubyte *org_data, ubyte bpp, int aabitmap, int nondark )
-int pcx_read_bitmap( const char * real_filename, ubyte *org_data, ubyte *pal, int byte_size, int aabitmap, int nondark, int cf_type )
+int pcx_read_bitmap( const char * real_filename, ubyte *org_data, ubyte *pal, int byte_size, int aabitmap, bool mask_bitmap, int cf_type )
 {
 	PCXHeader header;
 	CFILE * PCXfile;
@@ -310,7 +310,22 @@ int pcx_read_bitmap( const char * real_filename, ubyte *org_data, ubyte *pal, in
 			if ( col < xsize ) {
 				// 8-bit PCX reads
 				if ( byte_size == 1 ) {
-					*pixdata++ = data;
+					auto pixel_val = data;
+					if (!mask_bitmap) {
+						// 8 bit-per-pixel aa bitmaps are a bit special since they only use values in the range [0, 15] where 15 wraps
+						// around back to 0. Since the rest of the code expects the value to be in the range [0, 255] the pixel value
+						// needs to be adjusted here. By multiplying the value with 17 the original range [0, 15] is mapped to [0, 255]
+						// This only applies to bitmaps that are not used as masks since mask bitmaps use higher values
+						// to indicate their mask area
+						if (data > 15) {
+							pixel_val = 0;
+						} else if (data == 15) {
+							pixel_val = 17;
+						} else {
+							pixel_val = (ubyte) (data * 17);
+						}
+					}
+					*pixdata++ = pixel_val;
 				} else {
 					// 16-bit AABITMAP reads
 					if ( (byte_size == 2) && aabitmap ) {

--- a/code/pcxutils/pcxutils.h
+++ b/code/pcxutils/pcxutils.h
@@ -37,7 +37,7 @@ extern int pcx_read_header(const char *filename, CFILE *img_cfp = NULL, int *w =
 //extern int pcx_read_bitmap_16bpp_aabitmap( const char *filename, ubyte *org_data );
 //extern int pcx_read_bitmap_16bpp_nondark( const char *filename, ubyte *org_data );
 //extern int pcx_read_bitmap_32(const char *real_filename, ubyte *data );
-extern int pcx_read_bitmap(const char *filename, ubyte *org_data, ubyte *pal, int byte_size, int aabitmap = 0, int nondark = 0, int cf_type = CF_TYPE_ANY);
+extern int pcx_read_bitmap(const char *filename, ubyte *org_data, ubyte *pal, int byte_size, int aabitmap = 0, bool mask_bitmap = false, int cf_type = CF_TYPE_ANY);
 
 // Dumps a 8bpp bitmap to a file.
 // Set rowoff to -w for upside down bitmaps.

--- a/code/stats/medals.cpp
+++ b/code/stats/medals.cpp
@@ -586,7 +586,7 @@ void medal_main_init(player *pl, int mode)
 		Warning(LOCATION, "Error loading medal mask file %s", bitmap_buf);
 	} else {
 		Init_flags |= MASK_BITMAP_INIT;
-		Medals_mask = bm_lock(Medals_bitmap_mask, 8, BMP_AABITMAP);
+		Medals_mask = bm_lock(Medals_bitmap_mask, 8, BMP_AABITMAP | BMP_MASK_BITMAP);
 		bm_get_info(Medals_bitmap_mask, &Medals_mask_w, &Medals_mask_h);
 
 		init_medal_bitmaps();

--- a/code/ui/window.cpp
+++ b/code/ui/window.cpp
@@ -101,7 +101,7 @@ void UI_WINDOW::set_mask_bmap(int bmap, const char *name)
 		mask_h = -1;
 
 		mask_bmap_id = bmap;
-		mask_bmap_ptr = bm_lock(mask_bmap_id, 8, BMP_AABITMAP);
+		mask_bmap_ptr = bm_lock(mask_bmap_id, 8, BMP_AABITMAP | BMP_MASK_BITMAP);
 		mask_data = (ubyte *) mask_bmap_ptr->data;		
 		bm_get_info( bmap, &mask_w, &mask_h );
 		tt_group = -1;


### PR DESCRIPTION
This is a bugfix for an issue introduced in 72a797f73219f709a4617480bdf53c86c721491f which broke 8 bits-per-pixel alpha bitmap reading.

This fixes #1516.