### PR TITLE
Fix LD_LIBRARY_PATH value in AppImage runs

### DIFF
--- a/cmake/AppRun.in
+++ b/cmake/AppRun.in
@@ -1,4 +1,4 @@
 #!/bin/sh
 HERE=$(dirname $(readlink -f "${0}"))
-export LD_LIBRARY_PATH="${HERE}"/lib:$PATH
+export LD_LIBRARY_PATH="${HERE}"/lib:"$LD_LIBRARY_PATH"
 "${HERE}"/bin/$<TARGET_FILE_NAME:Freespace2> $@


### PR DESCRIPTION
The previous version used `PATH` instead of `LD_LIBRARY_PATH` which may have
caused some issues if the system is configured in a way that depends on
the value of `LD_LIBRARY_PATH`. It also broke launchers that tried to fix
library issues by changing `LD_LIBRARY_PATH`.