### PR TITLE
Add localized subtitle support to the video player

### DIFF
--- a/code/cutscene/Decoder.h
+++ b/code/cutscene/Decoder.h
@@ -58,6 +58,14 @@ struct AudioFrame {
 };
 typedef std::unique_ptr<AudioFrame> AudioFramePtr;
 
+struct SubtitleFrame {
+    double displayStartTime = -1.0;
+    double displayEndTime = -1.0;
+
+	SCP_string text;
+};
+typedef std::unique_ptr<SubtitleFrame> SubtitleFramePtr;
+
 /**
  * @brief Abstract class for decoding a video or audio stream
  *
@@ -68,6 +76,7 @@ class Decoder {
  private:
 	std::unique_ptr<sync_bounded_queue<VideoFramePtr>> m_videoQueue;
 	std::unique_ptr<sync_bounded_queue<AudioFramePtr>> m_audioQueue;
+	std::unique_ptr<sync_bounded_queue<SubtitleFramePtr>> m_subtitleQueue;
 
 	bool m_decoding;
 	size_t m_queueSize = 0;
@@ -109,6 +118,8 @@ class Decoder {
 	 */
 	virtual bool hasAudio() = 0;
 
+	virtual bool hasSubtitles() = 0;
+
 	/**
 	 * @brief Ends decoding of the video file
 	 */
@@ -121,6 +132,14 @@ class Decoder {
 	size_t getAudioQueueSize() { return m_audioQueue->size(); }
 
 	bool tryPopAudioData(AudioFramePtr&);
+
+	bool isSubtitleQueueFull() { return m_subtitleQueue->size() == m_queueSize; }
+
+	bool isSubtitleFrameAvailable() { return !m_subtitleQueue->empty(); }
+
+	size_t getSubtitleQueueSize() { return m_subtitleQueue->size(); }
+
+	bool tryPopSubtitleData(SubtitleFramePtr&);
 
 	bool isVideoQueueFull() { return m_videoQueue->size() == m_queueSize; }
 
@@ -140,6 +159,10 @@ class Decoder {
 	bool canPushAudioData();
 
 	void pushAudioData(AudioFramePtr&& data);
+
+	bool canPushSubtitleData();
+
+	void pushSubtitleData(SubtitleFramePtr&& data);
 
 	bool canPushVideoData();
 

--- a/code/cutscene/VideoPresenter.cpp
+++ b/code/cutscene/VideoPresenter.cpp
@@ -5,12 +5,17 @@
 using namespace cutscene;
 using namespace cutscene::player;
 
+namespace {
+struct movie_vertex {
+	vec2d pos;
+	vec2d uv;
+};
+}
+
 namespace cutscene {
 namespace player {
-VideoPresenter::VideoPresenter(const MovieProperties& props) : _scaleVideo(false) {
+VideoPresenter::VideoPresenter(const MovieProperties& props) {
 	GR_DEBUG_SCOPE("Init video");
-
-	_vertexBuffer = gr_create_buffer(BufferType::Vertex, BufferUsageHint::Static);
 
 	auto w = static_cast<int>(props.size.width);
 	auto h = static_cast<int>(props.size.height);
@@ -26,83 +31,10 @@ VideoPresenter::VideoPresenter(const MovieProperties& props) : _scaleVideo(false
 	_vtex = bm_create(8, w / 2, h / 2, _vTexBuffer.get(), BMP_AABITMAP);
 
 	material_set_movie(&_render_material, _ytex, _utex, _vtex);
-
-	float screen_ratio = (float) gr_screen.center_w / (float) gr_screen.center_h;
-	float movie_ratio = (float) props.size.width / (float) props.size.height;
-
-	float scale_by;
-	if (screen_ratio > movie_ratio) {
-		scale_by = (float) gr_screen.center_h / (float) props.size.height;
-	} else {
-		scale_by = (float) gr_screen.center_w / (float) props.size.width;
-	}
-
-	// don't bother setting anything if we aren't going to need it
-	if (!Cmdline_noscalevid && (scale_by != 1.0f)) {
-		vec3d scale;
-
-		scale.xyz.x = scale_by;
-		scale.xyz.y = scale_by;
-		scale.xyz.z = -1.0f;
-
-		gr_push_scale_matrix(&scale);
-		_scaleVideo = true;
-	}
-
-	int screenX;
-	int screenY;
-
-	if (_scaleVideo) {
-		screenX = fl2i(((gr_screen.center_w / 2.0f + gr_screen.center_offset_x) / scale_by)
-						   - (static_cast<int>(props.size.width) / 2.0f) + 0.5f);
-		screenY = fl2i(((gr_screen.center_h / 2.0f + gr_screen.center_offset_y) / scale_by)
-						   - (static_cast<int>(props.size.height) / 2.0f) + 0.5f);
-	} else {
-		// centers on 1024x768, fills on 640x480
-		screenX = ((gr_screen.center_w - static_cast<int>(props.size.width)) / 2) + gr_screen.center_offset_x;
-		screenY = ((gr_screen.center_h - static_cast<int>(props.size.height)) / 2) + gr_screen.center_offset_y;
-	}
-
-	// set additional values for screen width/height and UV coords
-	int screenXW = screenX + static_cast<int>(props.size.width);
-	int screenYH = screenY + static_cast<int>(props.size.height);
-
-	float glVertices[4][4] = {{ 0 }};
-	glVertices[0][0] = (float) screenX;
-	glVertices[0][1] = (float) screenY;
-	glVertices[0][2] = 0.0f;
-	glVertices[0][3] = 0.0f;
-
-	glVertices[1][0] = (float) screenX;
-	glVertices[1][1] = (float) screenYH;
-	glVertices[1][2] = 0.0f;
-	glVertices[1][3] = 1.0f;
-
-	glVertices[2][0] = (float) screenXW;
-	glVertices[2][1] = (float) screenY;
-	glVertices[2][2] = 1.0f;
-	glVertices[2][3] = 0.0f;
-
-	glVertices[3][0] = (float) screenXW;
-	glVertices[3][1] = (float) screenYH;
-	glVertices[3][2] = 1.0f;
-	glVertices[3][3] = 1.0f;
-
-	_vertexLayout.add_vertex_component(vertex_format_data::POSITION2, sizeof(glVertices[0]), 0);
-	_vertexLayout.add_vertex_component(vertex_format_data::TEX_COORD2, sizeof(glVertices[0]), sizeof(float) * 2);
-
-	gr_update_buffer_data(_vertexBuffer, sizeof(glVertices[0]) * 4, glVertices);
 }
 
 VideoPresenter::~VideoPresenter() {
 	GR_DEBUG_SCOPE("Deinit video");
-
-	if (_scaleVideo) {
-		gr_pop_scale_matrix();
-	}
-
-	gr_delete_buffer(_vertexBuffer);
-	_vertexBuffer = -1;
 
 	bm_release(_ytex);
 	bm_release(_utex);
@@ -124,10 +56,39 @@ void VideoPresenter::uploadVideoFrame(const VideoFramePtr& frame) {
 	gr_update_texture(_vtex, 8, _vTexBuffer.get(), (int) frame->uvSize.width, (int) frame->uvSize.height);
 }
 
-void VideoPresenter::displayFrame() {
+void VideoPresenter::displayFrame(float x1, float y1, float x2, float y2) {
 	GR_DEBUG_SCOPE("Draw video frame");
 
-	gr_render_movie(&_render_material, PRIM_TYPE_TRISTRIP, &_vertexLayout, 4, _vertexBuffer);
+	movie_vertex vertex_data[4];
+
+	vertex_data[0].pos.x = x1;
+	vertex_data[0].pos.y = y1;
+	vertex_data[0].uv.x = 0.0f;
+	vertex_data[0].uv.y = 0.0f;
+
+	vertex_data[1].pos.x = x1;
+	vertex_data[1].pos.y = y2;
+	vertex_data[1].uv.x = 0.0f;
+	vertex_data[1].uv.y = 1.0f;
+
+	vertex_data[2].pos.x = x2;
+	vertex_data[2].pos.y = y1;
+	vertex_data[2].uv.x = 1.0f;
+	vertex_data[2].uv.y = 0.0f;
+
+	vertex_data[3].pos.x = x2;
+	vertex_data[3].pos.y = y2;
+	vertex_data[3].uv.x = 1.0f;
+	vertex_data[3].uv.y = 1.0f;
+
+	// Use the immediate buffer for storing our data since that is exactly what we need
+	auto offset = gr_add_to_immediate_buffer(sizeof(vertex_data), vertex_data);
+
+	vertex_layout layout;
+	layout.add_vertex_component(vertex_format_data::POSITION2, sizeof(vertex_data[0]), offset + offsetof(movie_vertex, pos));
+	layout.add_vertex_component(vertex_format_data::TEX_COORD2, sizeof(vertex_data[0]), offset + offsetof(movie_vertex, uv));
+
+	gr_render_movie(&_render_material, PRIM_TYPE_TRISTRIP, &layout, 4, gr_immediate_buffer_handle);
 }
 
 }

--- a/code/cutscene/VideoPresenter.h
+++ b/code/cutscene/VideoPresenter.h
@@ -12,11 +12,6 @@ namespace cutscene {
 namespace player {
 
 class VideoPresenter {
-	int _vertexBuffer = -1;
-	vertex_layout _vertexLayout;
-
-	bool _scaleVideo = false;
-
 	int _ytex = -1;
 	std::unique_ptr<uint8_t[]> _yTexBuffer;
 
@@ -38,7 +33,7 @@ class VideoPresenter {
 
 	void uploadVideoFrame(const VideoFramePtr& frame);
 
-	void displayFrame();
+	void displayFrame(float x1, float y1, float x2, float y2);
 };
 }
 }

--- a/code/cutscene/ffmpeg/FFMPEGDecoder.cpp
+++ b/code/cutscene/ffmpeg/FFMPEGDecoder.cpp
@@ -9,6 +9,9 @@
 
 #include "cutscene/ffmpeg/AudioDecoder.h"
 #include "cutscene/ffmpeg/VideoDecoder.h"
+#include "cutscene/ffmpeg/SubtitleDecoder.h"
+
+#include "localization/localize.h"
 
 using namespace libs::ffmpeg;
 
@@ -62,6 +65,8 @@ CodecContextParameters getCodecParameters(AVStream* stream) {
 	paras.channel_layout = stream->codecpar->channel_layout;
 	paras.sample_rate = stream->codecpar->sample_rate;
 	paras.audio_format = (AVSampleFormat)stream->codecpar->format;
+
+    paras.codec_id = stream->codecpar->codec_id;
 #else
     paras.width = stream->codec->width;
 	paras.height = stream->codec->height;
@@ -70,8 +75,28 @@ CodecContextParameters getCodecParameters(AVStream* stream) {
 	paras.channel_layout = stream->codec->channel_layout;
 	paras.sample_rate = stream->codec->sample_rate;
 	paras.audio_format = stream->codec->sample_fmt;
+
+    paras.codec_id = stream->codec->codec_id;
 #endif
     return paras;
+}
+
+SCP_string normalizeLanguage(const char* langauge_name) {
+    if (!stricmp(langauge_name, "eng")) {
+        return "English";
+    }
+    if (!stricmp(langauge_name, "ger")) {
+        return "German";
+    }
+    if (!stricmp(langauge_name, "spa")) {
+        return "Spanish";
+    }
+
+    // Print to log so that we can find the actual value more easily later
+    mprintf(("FFmpeg log: Found unknown language value '%s'!\n", langauge_name));
+
+    // Default to english for everything else
+    return "English";
 }
 }
 
@@ -155,7 +180,30 @@ std::unique_ptr<DecoderStatus> initializeStatus(std::unique_ptr<InputStream>& st
 		status->audioStream = ctx->streams[audioStream];
 	}
 
-	status->videoCodecPars = getCodecParameters(status->videoStream);
+	auto& current_language = Lcl_languages[Lcl_current_lang];
+	for (uint32_t i = 0; i < ctx->nb_streams; ++i) {
+		auto test_stream = ctx->streams[i];
+
+		auto& pars = test_stream->codecpar;
+
+		if (!(pars->codec_type == AVMEDIA_TYPE_SUBTITLE)) {
+			continue;
+		}
+		AVDictionaryEntry* tag = nullptr;
+		if ((tag = av_dict_get(test_stream->metadata, "language", nullptr, 0)) == nullptr) {
+			continue;
+		}
+
+		auto normalized_language = normalizeLanguage(tag->value);
+
+		if (!stricmp(normalized_language.c_str(), current_language.lang_name)) {
+			status->subtitleStreamIndex = i;
+			status->subtitleStream = test_stream;
+			break;
+		}
+	}
+
+    status->videoCodecPars = getCodecParameters(status->videoStream);
 
 	int err;
 #if LIBAVCODEC_VERSION_INT > AV_VERSION_INT(57, 24, 255)
@@ -212,6 +260,37 @@ std::unique_ptr<DecoderStatus> initializeStatus(std::unique_ptr<InputStream>& st
 		mprintf(("FFmpeg: Using audio codec %s (%s).\n", status->audioCodec->long_name ? status->audioCodec->long_name : "<Unknown>",
 			status->audioCodec->name ? status->audioCodec->name : "<Unknown>"));
 	}
+
+    if (status->subtitleStreamIndex >= 0) {
+        // Not really sure if this makes sense for subtitles but it shouldn't break anything...
+        status->subtitleCodecPars = getCodecParameters(status->subtitleStream);
+
+        status->subtitleCodec = avcodec_find_decoder(status->subtitleCodecPars.codec_id);
+
+#if LIBAVCODEC_VERSION_INT > AV_VERSION_INT(57, 24, 255)
+        status->subtitleCodecCtx = avcodec_alloc_context3(status->subtitleCodec);
+
+        err = avcodec_parameters_to_context(status->subtitleCodecCtx, status->subtitleStream->codecpar);
+        if (err < 0) {
+            char errorStr[512];
+            av_strerror(err, errorStr, sizeof(errorStr));
+            mprintf(("FFMPEG: Failed to copy context parameters! Error: %s\n", errorStr));
+            return nullptr;
+        }
+#else
+        status->subtitleCodecCtx = status->subtitleStream->codec;
+#endif
+
+        err = avcodec_open2(status->subtitleCodecCtx, status->subtitleCodec, nullptr);
+        if (err < 0) {
+            char errorStr[512];
+            av_strerror(err, errorStr, sizeof(errorStr));
+            mprintf(("FFMPEG: Failed to open subtitle codec! Error: %s\n", errorStr));
+        }
+
+        mprintf(("FFmpeg: Using subtitle codec %s (%s).\n", status->subtitleCodec->long_name ? status->subtitleCodec->long_name : "<Unknown>",
+            status->subtitleCodec->name ? status->subtitleCodec->name : "<Unknown>"));
+    }
 
 	return status;
 }
@@ -279,10 +358,14 @@ void FFMPEGDecoder::startDecoding() {
 	std::unique_ptr<VideoDecoder> videoDecoder(new VideoDecoder(m_status.get()));
 
 	std::unique_ptr<AudioDecoder> audioDecoder;
+    std::unique_ptr<SubtitleDecoder> subtitleDecoder;
 
 	if (hasAudio()) {
 		audioDecoder.reset(new AudioDecoder(m_status.get()));
 	}
+    if (hasSubtitles()) {
+        subtitleDecoder.reset(new SubtitleDecoder(m_status.get()));
+    }
 
 	auto ctx = m_input->m_ctx->ctx();
 	AVPacket packet;
@@ -322,7 +405,14 @@ void FFMPEGDecoder::startDecoding() {
 			while ((ptr = audioDecoder->getFrame()) != nullptr) {
 				pushAudioData(std::move(ptr));
 			}
-		}
+		} else if (subtitleDecoder && packet.stream_index == m_status->subtitleStreamIndex) {
+            subtitleDecoder->decodePacket(&packet);
+
+            SubtitleFramePtr ptr;
+            while((ptr = subtitleDecoder->getFrame()) != nullptr) {
+                pushSubtitleData(std::move(ptr));
+            }
+        }
 	}
 
 	if (isDecoding()) {
@@ -347,6 +437,10 @@ void FFMPEGDecoder::startDecoding() {
 
 bool FFMPEGDecoder::hasAudio() {
 	return m_status->audioStreamIndex >= 0;
+}
+
+bool FFMPEGDecoder::hasSubtitles() {
+	return m_status->subtitleStreamIndex >= 0;
 }
 
 void FFMPEGDecoder::close() {

--- a/code/cutscene/ffmpeg/FFMPEGDecoder.h
+++ b/code/cutscene/ffmpeg/FFMPEGDecoder.h
@@ -27,6 +27,8 @@ class FFMPEGDecoder: public Decoder {
 
 	bool hasAudio() SCP_OVERRIDE;
 
+	bool hasSubtitles() SCP_OVERRIDE;
+
 	void close() SCP_OVERRIDE;
 };
 }

--- a/code/cutscene/ffmpeg/SubtitleDecoder.cpp
+++ b/code/cutscene/ffmpeg/SubtitleDecoder.cpp
@@ -1,0 +1,117 @@
+//
+//
+
+#include "SubtitleDecoder.h"
+
+namespace {
+
+double getFrameTime(int64_t pts, AVRational time_base) {
+	return pts * av_q2d(time_base);
+}
+
+}
+
+namespace cutscene {
+namespace ffmpeg {
+
+SubtitleDecoder::SubtitleDecoder(cutscene::ffmpeg::DecoderStatus* status) : FFMPEGStreamDecoder(status) {
+}
+SubtitleDecoder::~SubtitleDecoder() {
+
+}
+void SubtitleDecoder::decodePacket(AVPacket* packet) {
+	int finishedFrame = 0;
+	AVSubtitle subtitle;
+	auto result = avcodec_decode_subtitle2(m_status->subtitleCodecCtx, &subtitle, &finishedFrame, packet);
+
+	if (result >= 0 && finishedFrame) {
+		pushSubtitleFrame(packet, &subtitle);
+
+		avsubtitle_free(&subtitle);
+	}
+}
+void SubtitleDecoder::finishDecoding() {
+
+}
+void SubtitleDecoder::pushSubtitleFrame(AVPacket* packet, AVSubtitle* subtitle) {
+	if (subtitle->format != 1) {
+		// Non-text subtitles are not supported yet.
+		mprintf(("FFmpeg: Detected a non-text subtitle! This is not supported yet!\n"));
+		return;
+	}
+	if (subtitle->num_rects < 1) {
+		return;
+	}
+
+	int64_t pts = subtitle->pts;
+	if (pts == AV_NOPTS_VALUE) {
+		pts = packet->pts;
+	}
+	if (pts == AV_NOPTS_VALUE) {
+		// Still no valid timestamp...
+		return;
+	}
+	auto packet_time = getFrameTime(pts, m_status->subtitleStream->time_base);
+
+	auto start_time = packet_time + (subtitle->start_display_time / 1000.0);
+	auto end_time = packet_time + (subtitle->end_display_time / 1000.0);
+	if (subtitle->end_display_time == 0 && m_status->subtitleStream->time_base.num != 0) {
+		end_time = packet_time + getFrameTime(packet->duration, m_status->subtitleStream->time_base);
+	}
+
+	SCP_string processed_text;
+	// For now we only use the first subtitle rectangle
+	auto subtitle_rect = subtitle->rects[0];
+	if (subtitle_rect->type == SUBTITLE_BITMAP) {
+		// Same as above, non-text subtitles are not supported yet.
+		mprintf(("FFmpeg: Detected a non-text subtitle! This is not supported yet!\n"));
+		return;
+	} else if (subtitle_rect->type == SUBTITLE_TEXT) {
+		// Subtitle does not need to be processed any further
+		processed_text = subtitle_rect->text;
+	} else if (subtitle_rect->type == SUBTITLE_ASS) {
+		SCP_string ass_text = subtitle_rect->ass;
+		
+		// We are not interested in any of the other information contained in the ASS line but we still need to figure
+		// out where our text starts
+		auto comma_pos = ass_text.find(',');
+		for (auto i = 0; i < 8 && comma_pos != SCP_string::npos; ++i) {
+			comma_pos = ass_text.find(',', comma_pos + 1);
+		}
+		Assertion(comma_pos != SCP_string::npos, "Received an ill-formed ASS line from FFmpeg! Text was '%s'.", subtitle_rect->ass);
+
+		// This + 1 is safe since comma_pos points to a valid character so the next character is at worst the end of the string
+		processed_text = ass_text.substr(comma_pos + 1);
+
+		// ASS has a special sequence for new lines that needs to be converted to an actual new line
+		auto newline_pos = processed_text.find("\\N");
+		while(newline_pos != SCP_string::npos) {
+			processed_text.replace(newline_pos, 2, "\n");
+
+			newline_pos = processed_text.find("\\N");
+		}
+	} else {
+		mprintf(("FFmpeg: Detected unknown subtitle name in movie!\n"));
+		return;
+	}
+
+	// Remove \r from string. Some subtitles use \r\n for line breaks and we only support \n
+	auto ret_pos = processed_text.find('\r');
+	while(ret_pos != SCP_string::npos) {
+		processed_text.erase(ret_pos, 1);
+
+		ret_pos = processed_text.find('\r');
+	}
+
+	SubtitleFramePtr frame(new SubtitleFrame());
+	frame->text = processed_text;
+
+	frame->displayStartTime = start_time;
+	frame->displayEndTime = end_time;
+
+	pushFrame(std::move(frame));
+}
+
+}
+}
+

--- a/code/cutscene/ffmpeg/SubtitleDecoder.h
+++ b/code/cutscene/ffmpeg/SubtitleDecoder.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "cutscene/ffmpeg/internal.h"
+#include "cutscene/ffmpeg/FFMPEGDecoder.h"
+
+namespace cutscene {
+namespace ffmpeg {
+
+class SubtitleDecoder: public FFMPEGStreamDecoder<SubtitleFrame> {
+ public:
+    explicit SubtitleDecoder(DecoderStatus* status);
+
+    virtual ~SubtitleDecoder();
+
+    virtual void decodePacket(AVPacket* packet) SCP_OVERRIDE;
+
+    virtual void finishDecoding() SCP_OVERRIDE;
+    void pushSubtitleFrame(AVPacket* subtitle, AVSubtitle* pSubtitle);
+};
+
+}
+}
+
+

--- a/code/cutscene/ffmpeg/internal.cpp
+++ b/code/cutscene/ffmpeg/internal.cpp
@@ -30,6 +30,18 @@ DecoderStatus::~DecoderStatus() {
 #endif
 		audioCodecCtx = nullptr;
 	}
+
+	subtitleStreamIndex = -1;
+	subtitleStream = nullptr;
+	subtitleCodec = nullptr;
+
+	if (subtitleCodecCtx != nullptr) {
+		avcodec_close(subtitleCodecCtx);
+#if LIBAVCODEC_VERSION_INT > AV_VERSION_INT(57, 24, 255)
+		avcodec_free_context(&subtitleCodecCtx);
+#endif
+		subtitleCodecCtx = nullptr;
+	}
 }
 
 } // namespace ffmpeg

--- a/code/cutscene/ffmpeg/internal.h
+++ b/code/cutscene/ffmpeg/internal.h
@@ -16,6 +16,8 @@ struct CodecContextParameters {
 	uint64_t channel_layout = 0;
 	int sample_rate = -1;
 	AVSampleFormat audio_format = AV_SAMPLE_FMT_NONE;
+
+	AVCodecID codec_id = AV_CODEC_ID_NONE;
 };
 
 struct DecoderStatus {
@@ -30,6 +32,12 @@ struct DecoderStatus {
 	CodecContextParameters audioCodecPars;
 	AVCodec* audioCodec = nullptr;
 	AVCodecContext* audioCodecCtx = nullptr;
+
+	int subtitleStreamIndex = -1;
+	AVStream* subtitleStream = nullptr;
+	CodecContextParameters subtitleCodecPars;
+	AVCodec* subtitleCodec = nullptr;
+	AVCodecContext* subtitleCodecCtx = nullptr;
 
 	DecoderStatus();
 

--- a/code/cutscene/movie.cpp
+++ b/code/cutscene/movie.cpp
@@ -14,6 +14,7 @@
 #endif
 
 #include "globalincs/pstypes.h"
+#include "globalincs/alphacolors.h"
 #include "globalincs/systemvars.h"
 #include "io/cursor.h"
 #include "graphics/2d.h"
@@ -21,9 +22,168 @@
 #include "cmdline/cmdline.h"	
 #include "cutscene/cutscenes.h" // cutscene_mark_viewable()
 #include "cutscene/player.h" // cutscene_mark_viewable()
+#include "tracing/categories.h"
+#include "tracing/tracing.h"
+#include "io/timer.h"
+#include "io/key.h"
 
 extern int Game_mode;
 extern int Is_standalone;
+
+namespace {
+
+using namespace cutscene;
+
+struct PlaybackState {
+	bool playing = true;
+
+	vec2d posTopLeft;
+	vec2d posBottomRight;
+};
+
+void processEvents(PlaybackState* state) {
+	io::mouse::CursorManager::get()->showCursor(false);
+
+	os_poll();
+
+	int k = key_inkey();
+	switch (k) {
+	case KEY_ESC:
+	case KEY_ENTER:
+	case KEY_SPACEBAR:
+		state->playing = false;
+		break;
+	default:
+		break;
+	}
+}
+
+template<typename... Args>
+float print_string(float x, float y, const char* fmt, Args... params) {
+	SCP_string text;
+	sprintf(text, fmt, params...);
+
+	gr_string(x, y, text.c_str(), GR_RESIZE_NONE);
+
+	return y + font::get_current_font()->getHeight();
+}
+
+void showVideoInfo(const PlayerState& state) {
+	gr_set_color_fast(&Color_white);
+
+	float y = 200.f;
+	float x = 100.f;
+	y = print_string(x, y, "Movie FPS: %f", state.props.fps);
+	y = print_string(x, y, "Size: %dx%d", state.props.size.width, state.props.size.height);
+
+	y = gr_screen.max_h - 200.f;
+
+	size_t audio_queue_size = state.decoder->getAudioQueueSize();
+	if (state.hasAudio) {
+		ALint queued;
+		OpenAL_ErrorPrint(alGetSourcei(state.audioSid, AL_BUFFERS_QUEUED, &queued));
+		audio_queue_size += queued;
+	}
+
+	y = print_string(x, y, "Audio Queue size: " SIZE_T_ARG, audio_queue_size);
+	y = print_string(x, y, "Video Queue size: " SIZE_T_ARG, state.decoder->getVideoQueueSize());
+	y += font::get_current_font()->getHeight();
+	// Estimate the size of the video buffer
+	// We use YUV420p frames so one pixel uses 1.5 bytes of storage
+	size_t single_frame_size = (size_t) (state.props.size.width * state.props.size.height * 1.5);
+	size_t total_size = single_frame_size * state.decoder->getVideoQueueSize();
+	print_string(x, y, "Video buffer size: " SIZE_T_ARG "B", total_size);
+}
+
+void displayVideo(Player* player, PlaybackState* state) {
+	TRACE_SCOPE(tracing::CutsceneDrawVideoFrame);
+
+	gr_clear();
+	player->draw(state->posTopLeft.x, state->posTopLeft.y, state->posBottomRight.x, state->posBottomRight.y);
+
+	if (Cmdline_show_video_info) {
+		showVideoInfo(player->getInternalState());
+	}
+
+	gr_flip();
+}
+
+void determine_display_positions(Player* player, PlaybackState* state) {
+	auto& props = player->getMovieProperties();
+
+	float screen_ratio = (float) gr_screen.center_w / (float) gr_screen.center_h;
+	float movie_ratio = (float) props.size.width / (float) props.size.height;
+
+	float scale_by;
+	if (screen_ratio > movie_ratio) {
+		scale_by = (float) gr_screen.center_h / (float) props.size.height;
+	} else {
+		scale_by = (float) gr_screen.center_w / (float) props.size.width;
+	}
+
+	float screenX;
+	float screenY;
+
+	if (!Cmdline_noscalevid && (scale_by != 1.0f)) {
+		screenX = ((gr_screen.center_w / 2.0f + gr_screen.center_offset_x) / scale_by) - (static_cast<int>(props.size.width) / 2.0f) + 0.5f;
+		screenY = ((gr_screen.center_h / 2.0f + gr_screen.center_offset_y) / scale_by) - (static_cast<int>(props.size.height) / 2.0f) + 0.5f;
+	} else {
+		// centers on 1024x768, fills on 640x480
+		screenX = i2fl(((gr_screen.center_w - static_cast<int>(props.size.width)) / 2) + gr_screen.center_offset_x);
+		screenY = i2fl(((gr_screen.center_h - static_cast<int>(props.size.height)) / 2) + gr_screen.center_offset_y);
+	}
+
+	// set additional values for screen width/height and UV coords
+	float screenXW = screenX + static_cast<int>(props.size.width);
+	float screenYH = screenY + static_cast<int>(props.size.height);
+
+	if (!Cmdline_noscalevid && (scale_by != 1.0f)) {
+		// Apply scaling
+		screenX *= scale_by;
+		screenY *= scale_by;
+
+		screenXW *= scale_by;
+		screenYH *= scale_by;
+	}
+
+	state->posTopLeft.x = screenX;
+	state->posTopLeft.y = screenY;
+
+	state->posBottomRight.x = screenXW;
+	state->posBottomRight.y = screenYH;
+}
+
+void movie_display_loop(Player* player, PlaybackState* state) {
+	// Compute the maximum time we will sleep to make sure we can still maintain the movie FPS
+	// and not waste too much CPU time
+	// We will sleep at most half the time a frame would be displayed
+	auto sleepTime = static_cast<std::uint64_t>((1. / (4. * player->getMovieProperties().fps)) * 1000.);
+
+	auto lastDisplayTimestamp = timer_get_microseconds();
+	while (state->playing) {
+		TRACE_SCOPE(tracing::CutsceneStep);
+
+		auto timestamp = timer_get_microseconds();
+
+		auto passed = timestamp - lastDisplayTimestamp;
+		lastDisplayTimestamp = timestamp;
+
+		// Play as long as the player reports that there is more to display
+		state->playing = player->update(passed);
+
+		displayVideo(player, state);
+
+		processEvents(state);
+
+		if (passed < sleepTime) {
+			auto sleep = sleepTime - passed;
+
+			os_sleep(static_cast<uint>(sleep));
+		}
+	}
+}
+
+}
 
 namespace movie {
 // Play one movie
@@ -57,7 +217,12 @@ bool play(const char* name) {
 
 	auto player = cutscene::Player::newPlayer(name);
 	if (player) {
-		player->startPlayback();
+		PlaybackState state;
+		determine_display_positions(player.get(), &state);
+
+		movie_display_loop(player.get(), &state);
+
+		player->stopPlayback();
 	} else {
 		// uh-oh, movie is invalid... Abory, Retry, Fail?
 		mprintf(("MOVIE ERROR: Found invalid movie! (%s)\n", name));

--- a/code/cutscene/player.cpp
+++ b/code/cutscene/player.cpp
@@ -21,58 +21,17 @@
 
 using namespace cutscene::player;
 
-namespace cutscene {
-struct PlayerState {
-	MovieProperties props;
-	Decoder* decoder = nullptr;
-
-	bool playing = true;
-
-	bool playbackHasBegun = false;
-
-	// Timing state
-	std::uint64_t playback_time = 0;
-
-	// Audio state
-	bool audioInited = false;
-	bool hasAudio = false;
-	ALuint audioSid = 0;
-	SCP_vector<ALuint> audioBuffers;
-	SCP_queue<ALuint> unqueuedAudioBuffers;
-
-	// Graphics state following
-	bool videoInited = false;
-
-	VideoFramePtr currentFrame;
-	VideoFramePtr nextFrame;
-	bool newFrameAdded = false;
-
-	std::unique_ptr<VideoPresenter> videoPresenter;
-
-	PlayerState() : decoder(nullptr), playing(true), playbackHasBegun(false),
-					playback_time(0),
-					audioInited(0), hasAudio(false), audioSid(0),
-					videoInited(false), newFrameAdded(false) {}
-
- private:
-	PlayerState(const PlayerState&) SCP_DELETED_FUNCTION;
-
-	PlayerState& operator=(const PlayerState&) SCP_DELETED_FUNCTION;
-};
-}
-
 namespace {
 using namespace cutscene;
 
 const int MAX_AUDIO_BUFFERS = 15;
 
-Decoder* findDecoder(const SCP_string& name) {
+std::unique_ptr<Decoder> findDecoder(const SCP_string& name) {
 	{
-		auto ffmpeg = new ffmpeg::FFMPEGDecoder();
+		std::unique_ptr<Decoder> ffmpeg(new ffmpeg::FFMPEGDecoder());
 		if (ffmpeg->initialize(name)) {
 			return ffmpeg;
 		}
-		delete ffmpeg;
 	}
 
 	return nullptr;
@@ -267,79 +226,6 @@ void videoPlaybackClose(PlayerState* state) {
 	state->videoInited = false;
 }
 
-template<typename... Args>
-float print_string(float x, float y, const char* fmt, Args... params) {
-	SCP_string text;
-	sprintf(text, fmt, params...);
-
-	gr_string(x, y, text.c_str(), GR_RESIZE_NONE);
-
-	return y + font::get_current_font()->getHeight();
-}
-
-void showVideoInfo(PlayerState* state) {
-	gr_set_color_fast(&Color_white);
-
-	float y = 200.f;
-	float x = 100.f;
-	y = print_string(x, y, "Movie FPS: %f", state->props.fps);
-	y = print_string(x, y, "Size: %dx%d", state->props.size.width, state->props.size.height);
-
-	y = gr_screen.max_h - 200.f;
-
-	size_t audio_queue_size = state->decoder->getAudioQueueSize();
-	if (state->hasAudio) {
-		ALint queued;
-		OpenAL_ErrorPrint(alGetSourcei(state->audioSid, AL_BUFFERS_QUEUED, &queued));
-		audio_queue_size += queued;
-	}
-
-	y = print_string(x, y, "Audio Queue size: " SIZE_T_ARG, audio_queue_size);
-	y = print_string(x, y, "Video Queue size: " SIZE_T_ARG, state->decoder->getVideoQueueSize());
-	y += font::get_current_font()->getHeight();
-	// Estimate the size of the video buffer
-	// We use YUV420p frames so one pixel uses 1.5 bytes of storage
-	size_t single_frame_size = (size_t) (state->props.size.width * state->props.size.height * 1.5);
-	size_t total_size = single_frame_size * state->decoder->getVideoQueueSize();
-	print_string(x, y, "Video buffer size: " SIZE_T_ARG "B", total_size);
-}
-
-void displayVideo(PlayerState* state) {
-	if (!state->currentFrame) {
-		return;
-	}
-
-	TRACE_SCOPE(tracing::CutsceneDrawVideoFrame);
-
-	gr_clear();
-	if (state->videoPresenter) {
-		state->videoPresenter->displayFrame();
-	}
-
-	if (Cmdline_show_video_info) {
-		showVideoInfo(state);
-	}
-
-	gr_flip();
-}
-
-void processEvents(PlayerState* state) {
-	io::mouse::CursorManager::get()->showCursor(false);
-
-	os_poll();
-
-	int k = key_inkey();
-	switch (k) {
-		case KEY_ESC:
-		case KEY_ENTER:
-		case KEY_SPACEBAR:
-			state->playing = false;
-			break;
-		default:
-			break;
-	}
-}
-
 bool shouldBeginPlayback(Decoder* decoder) {
 	auto video = decoder->isVideoQueueFull();
 	auto audio = decoder->isAudioQueueFull();
@@ -355,31 +241,37 @@ bool shouldBeginPlayback(Decoder* decoder) {
 }
 
 namespace cutscene {
-Player::Player() {
+Player::Player(std::unique_ptr<Decoder>&& decoder) : m_decoder(std::move(decoder)) {
+	initPlayback();
 }
 
 Player::~Player() {
+	// If video is initialized it means that stopPlayback has not been called yet
+	if (m_state.videoInited) {
+		stopPlayback();
+	}
+
 	if (m_decoder) {
 		m_decoder->close();
 	}
 }
 
-void Player::processDecoderData(PlayerState* state) {
-	if (!state->playbackHasBegun) {
+bool Player::processDecoderData() {
+	if (!m_state.playbackHasBegun) {
 		// Wait until video and audio are available
 		// If we don't have audio, don't wait for it (obviously...)
-		if (!shouldBeginPlayback(state->decoder)) {
-			return;
+		if (!shouldBeginPlayback(m_state.decoder)) {
+			return true;
 		}
 
-		state->playbackHasBegun = true;
+		m_state.playbackHasBegun = true;
 	}
 
 	TRACE_SCOPE(tracing::CutsceneProcessDecoder);
 
-	processVideoData(state);
+	processVideoData(&m_state);
 
-	auto audioPlaying = processAudioData(state);
+	auto audioPlaying = processAudioData(&m_state);
 
 	// Set the playing flag if the decoder is still active or there is still data available
 	auto decoding = m_decoder->isDecoding();
@@ -388,54 +280,33 @@ void Player::processDecoderData(PlayerState* state) {
 	auto pendingAudio = (m_decoder->isAudioFrameAvailable() && m_decoder->hasAudio()) || audioPlaying;
 	auto pendingVideo = m_decoder->isVideoFrameAvailable();
 
-	state->playing = decoding || pendingAudio || pendingVideo;
+	return decoding || pendingAudio || pendingVideo;
 }
 
-void Player::startPlayback() {
+void Player::initPlayback() {
+	Assertion(!m_state.videoInited, "Internal State has been initialized before! Create a new player for replaying a movie.");
+
 	m_decoderThread.reset(new std::thread(std::bind(&Player::decoderThread, this)));
 
-	PlayerState state;
-	state.props = m_decoder->getProperties();
-	state.decoder = m_decoder.get();
+	m_state.props = m_decoder->getProperties();
+	m_state.decoder = m_decoder.get();
 
-	// Compute the maximum time we will sleep to make sure we can still maintain the movie FPS
-	// and not waste too much CPU time
-	// We will sleep at most half the time a frame would be displayed
-	auto sleepTime = static_cast<std::uint64_t>((1. / (4. * state.props.fps)) * 1000.);
+	videoPlaybackInit(&m_state);
 
-	videoPlaybackInit(&state);
-
-	audioPlaybackInit(&state);
-
-	auto lastDisplayTimestamp = timer_get_microseconds();
-	while (state.playing) {
-		TRACE_SCOPE(tracing::CutsceneStep);
-
-		processDecoderData(&state);
-
-		displayVideo(&state);
-
-		processEvents(&state);
-
-		auto timestamp = timer_get_microseconds();
-
-		auto passed = timestamp - lastDisplayTimestamp;
-		lastDisplayTimestamp = timestamp;
-
-		if (state.playbackHasBegun) {
-			state.playback_time += passed;
-		}
-
-		if (passed < sleepTime) {
-			auto sleep = sleepTime - passed;
-
-			os_sleep(static_cast<uint>(sleep));
-		}
+	audioPlaybackInit(&m_state);
+}
+bool Player::update(uint64_t diff_time_micro) {
+	if (m_state.playbackHasBegun) {
+		m_state.playback_time += diff_time_micro;
 	}
+
+	return processDecoderData();
+}
+void Player::stopPlayback() {
 	m_decoder->stopDecoder();
 
-	audioPlaybackClose(&state);
-	videoPlaybackClose(&state);
+	audioPlaybackClose(&m_state);
+	videoPlaybackClose(&m_state);
 
 	m_decoderThread->join();
 }
@@ -458,10 +329,21 @@ std::unique_ptr<Player> Player::newPlayer(const SCP_string& name) {
 	if (decoder == nullptr) {
 		return nullptr;
 	}
+	return std::unique_ptr<Player>(new Player(std::move(decoder)));
+}
+const PlayerState& Player::getInternalState() const {
+	return m_state;
+}
+const MovieProperties& Player::getMovieProperties() const {
+	return m_state.props;
+}
+void Player::draw(float x1, float y1, float x2, float y2) {
+	if (!m_state.currentFrame) {
+		return;
+	}
 
-	std::unique_ptr<Player> player(new Player());
-	player->m_decoder.reset(decoder);
-
-	return player;
+	if (m_state.videoPresenter) {
+		m_state.videoPresenter->displayFrame(x1, y1, x2, y2);
+	}
 }
 }

--- a/code/cutscene/player.h
+++ b/code/cutscene/player.h
@@ -38,6 +38,9 @@ struct PlayerState {
 
 	std::unique_ptr<player::VideoPresenter> videoPresenter;
 
+	SCP_queue<SubtitleFramePtr> queued_subtitles;
+	SubtitleFramePtr currentSubtitle;
+
 	PlayerState() {
 	}
 
@@ -105,6 +108,8 @@ class Player {
 	 * @param y2 The Y coordinate of the bottom right corner
 	 */
 	void draw(float x1, float y1, float x2, float y2);
+
+	SCP_string getCurrentSubtitle();
 
 	/**
 	 * @brief Stops playback

--- a/code/cutscene/player.h
+++ b/code/cutscene/player.h
@@ -5,11 +5,45 @@
 #include <thread>
 
 #include "globalincs/pstypes.h"
+#include "sound/openal.h"
+
+#include "Decoder.h"
+#include "VideoPresenter.h"
 
 namespace cutscene {
 class Decoder;
 
-struct PlayerState;
+struct PlayerState {
+	MovieProperties props;
+	Decoder* decoder = nullptr;
+
+	bool playbackHasBegun = false;
+
+	// Timing state
+	std::uint64_t playback_time = 0;
+
+	// Audio state
+	bool audioInited = false;
+	bool hasAudio = false;
+	ALuint audioSid = 0;
+	SCP_vector<ALuint> audioBuffers;
+	SCP_queue<ALuint> unqueuedAudioBuffers;
+
+	// Graphics state following
+	bool videoInited = false;
+
+	VideoFramePtr currentFrame;
+	VideoFramePtr nextFrame;
+	bool newFrameAdded = false;
+
+	std::unique_ptr<player::VideoPresenter> videoPresenter;
+
+	PlayerState() {
+	}
+
+	PlayerState(const PlayerState&) = delete;
+	PlayerState& operator=(const PlayerState&) = delete;
+};
 
 /**
  * @brief A movie player
@@ -20,22 +54,64 @@ class Player {
 
 	std::unique_ptr<std::thread> m_decoderThread;
 
-	void processDecoderData(PlayerState* state);
+	PlayerState m_state;
+
+	bool processDecoderData();
 
  private:
-	Player(const Player&) = delete;
-
 	void decoderThread();
 
+	void initPlayback();
+
  public:
-	Player();
+	explicit Player(std::unique_ptr<Decoder>&& decoder);
 
 	~Player();
 
+	Player(const Player&) = delete;
+	Player& operator=(const Player&) = delete;
+
 	/**
-     * @brief Begin playing the previously selected movie
-     */
-	void startPlayback();
+	 * @brief Update the player and increase display timestamp by specified delta time
+	 * @param diff_time_micro The time to increase the display timestamp in microseconds (not milliseconds!)
+	 * @return @c true if there is more content to display. @c false if the player reached the end of the movie and has
+	 * 			displayed the last frame.
+	 */
+	bool update(uint64_t diff_time_micro);
+
+	/**
+	 * @brief Gives access to the internal state of the player
+	 *
+	 * @warning This should only be used for debugging purposed!
+	 *
+	 * @return A reference to the internal state
+	 */
+	const PlayerState& getInternalState() const;
+
+	/**
+	 * @brief Gets the properties of the movie that this player is displaying
+	 * @return A reference to the movie properties
+	 */
+	const MovieProperties& getMovieProperties() const;
+
+	/**
+	 * @brief Draws the current movie frame at the specified coordinates.
+	 *
+	 * This may not draw anything if there is currently not a frame to display.
+	 *
+	 * @param x1 The X coordinate of the top left corner
+	 * @param y1 The Y coordinate of the top left corner
+	 * @param x2 The X coordinate of the bottom right corner
+	 * @param y2 The Y coordinate of the bottom right corner
+	 */
+	void draw(float x1, float y1, float x2, float y2);
+
+	/**
+	 * @brief Stops playback
+	 *
+	 * This is also automatically called when this instance is destroyed.
+	 */
+	void stopPlayback();
 
 	/**
      * @brief Creates a player

--- a/code/graphics/opengl/gropengltexture.cpp
+++ b/code/graphics/opengl/gropengltexture.cpp
@@ -1499,7 +1499,7 @@ void gr_opengl_update_texture(int bitmap_handle, int bpp, const ubyte* data, int
 		}
 	}
 	glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
-	glBindTexture(t->texture_target, t->texture_id);
+	GL_state.Texture.Enable(0, t->texture_target, t->texture_id);
 	glTexSubImage3D(t->texture_target, 0, 0, 0, t->array_index, width, height, 1, glFormat, texFormat, (texmem)?texmem:data);
 
 	if (texmem != NULL)

--- a/code/graphics/render.cpp
+++ b/code/graphics/render.cpp
@@ -1,6 +1,7 @@
 
 #include "graphics/render.h"
 #include "graphics/material.h"
+#include "graphics/matrix.h"
 #include "graphics/software/font_internal.h"
 #include "graphics/software/FSFont.h"
 #include "graphics/software/NVGFont.h"
@@ -534,6 +535,8 @@ static void gr_string_old(float sx,
 	vert_def.add_vertex_component(vertex_format_data::POSITION2, sizeof(v4), (int) offsetof(v4, x));
 	vert_def.add_vertex_component(vertex_format_data::TEX_COORD2, sizeof(v4), (int) offsetof(v4, u));
 
+	gr_set_2d_matrix();
+
 	// pick out letter coords, draw it, goto next letter and do the same
 	while (s < end) {
 		x += spacing;
@@ -678,6 +681,8 @@ static void gr_string_old(float sx,
 									   String_render_buff,
 									   sizeof(v4) * buffer_offset);
 	}
+
+	gr_end_2d_matrix();
 }
 
 namespace {

--- a/code/localization/localize.h
+++ b/code/localization/localize.h
@@ -58,6 +58,9 @@ extern int Lcl_gr;
 extern int Lcl_pl;
 extern int Lcl_english;
 
+// The currently active language. Index into Lcl_languages.
+extern int Lcl_current_lang;
+
 
 // ------------------------------------------------------------------------------------------------------------
 // LOCALIZE FUNCTIONS

--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -39,6 +39,7 @@ float Shield_pain_flash_factor;
 gameversion::version Targetted_version; // Defaults to retail
 SCP_string Window_title;
 bool Unicode_text_mode;
+SCP_string Movie_subtitle_font;
 
 void parse_mod_table(const char *filename)
 {
@@ -337,6 +338,11 @@ void parse_mod_table(const char *filename)
 			}
 		}
 
+		if (optional_string("$Movie subtitle font:")) {
+			// Fonts have not been parsed at this point so we can't validate the font name here
+			stuff_string(Movie_subtitle_font, F_NAME);
+		}
+
 		required_string("#END");
 	}
 	catch (const parse::ParseException& e)
@@ -390,4 +396,5 @@ void mod_table_reset() {
 	Targetted_version = gameversion::version(2, 0, 0, 0); // Defaults to retail
 	Window_title = "";
 	Unicode_text_mode = false;
+	Movie_subtitle_font = "font01.vf";
 }

--- a/code/mod_table/mod_table.h
+++ b/code/mod_table/mod_table.h
@@ -32,6 +32,7 @@ extern float Generic_pain_flash_factor;
 extern float Shield_pain_flash_factor;
 extern SCP_string Window_title;
 extern bool Unicode_text_mode;
+extern SCP_string Movie_subtitle_font;
 
 void mod_table_init();
 

--- a/code/source_groups.cmake
+++ b/code/source_groups.cmake
@@ -104,6 +104,8 @@ set (file_root_cutscene_ffmpeg
 	cutscene/ffmpeg/FFMPEGDecoder.h
 	cutscene/ffmpeg/internal.cpp
 	cutscene/ffmpeg/internal.h
+	cutscene/ffmpeg/SubtitleDecoder.cpp
+	cutscene/ffmpeg/SubtitleDecoder.h
 	cutscene/ffmpeg/VideoDecoder.cpp
 	cutscene/ffmpeg/VideoDecoder.h
 )


### PR DESCRIPTION
This adds support for displaying subtitles embedded in movie files. This
supports files with multiple subtitle streams where each stream contains
the subtitles for one language. When the movie file is opened, the
stream for the currently active language will be used and displayed.

This resolves one of the points mentioned in #1522.

This also depends on PR #1484.