### PR TITLE
Only display 3D sound warnings for mods with 3.8.0 support

### DIFF
--- a/code/sound/sound.cpp
+++ b/code/sound/sound.cpp
@@ -17,6 +17,7 @@
 #include "globalincs/alphacolors.h"
 #include "globalincs/pstypes.h"
 #include "globalincs/vmallocator.h"
+#include "mod_table/mod_table.h"
 #include "osapi/osapi.h"
 #include "render/3d.h"
 #include "sound/ffmpeg/WaveFile.h"
@@ -361,7 +362,14 @@ int snd_load( game_snd_entry *entry, int flags, int allow_hardware_load )
 			}
 
 			if (show_warning) {
-				Warning(LOCATION, "Sound '%s' has more than one channel but is used as a 3D sound! 3D sounds may only have one channel.", entry->filename);
+				if (mod_supports_version(3, 8, 0)) {
+					// This warning was introduced in 3.8.0 and caused a few issues since a lot of mods use 3D sounds
+					// with more than one channel. This will silence the warnings for any mod that does not support
+					// 3.8.0.
+					Warning(LOCATION, "Sound '%s' has more than one channel but is used as a 3D sound! 3D sounds may only have one channel.", entry->filename);
+				} else {
+					mprintf(("Warning: Sound '%s' has more than one channel but is used as a 3D sound! 3D sounds may only have one channel.\n", entry->filename));
+				}
 			}
 #endif
 		}


### PR DESCRIPTION
This was an issue since a lot of mods used wrong sounds and after the
FFmpeg changes the code would display a warning for those sounds by
default. This will restore the old behavior of printing the warning to
the log where it is easier to ignore if the mod does not explicitly
support 3.8.0.