### PR TITLE
Add support for translating strings in scripts

### DIFF
--- a/code/scripting/api/libs/base.cpp
+++ b/code/scripting/api/libs/base.cpp
@@ -5,6 +5,7 @@
 #include <gamesequence/gamesequence.h>
 #include <network/multi.h>
 #include <playerman/player.h>
+#include <parse/parselo.h>
 
 #include "base.h"
 
@@ -233,6 +234,29 @@ ADE_FUNC(postGameEvent, l_Base, "gameevent Event", "Sets current game event. Not
 	gameseq_post_event(gh->Get());
 
 	return ADE_RETURN_TRUE;
+}
+
+ADE_FUNC(XSTR,
+		 l_Base,
+		 "string text, number id",
+		 "Gets the translated version of text with the given id. "
+			 "The uses the tstrings table for performing the translation. Passing -1 as the id will always return the given text.",
+		 "string",
+		 "The translated text") {
+	const char* text = nullptr;
+	int id = -1;
+
+	if (!ade_get_args(L, "si", &text, &id)) {
+		return ADE_RETURN_NIL;
+	}
+
+	SCP_string xstr;
+	sprintf(xstr, "XSTR(\"%s\", %d)", text, id);
+
+	SCP_string translated;
+	lcl_ext_localize(xstr, translated);
+
+	return ade_set_args(L, "s", translated.c_str());
 }
 
 //**********SUBLIBRARY: Base/Events

--- a/code/scripting/api/libs/mission.cpp
+++ b/code/scripting/api/libs/mission.cpp
@@ -1026,6 +1026,10 @@ ADE_FUNC(isInCampaign, l_Mission, NULL, "Get whether or not the current mission 
 	return ade_set_args(L, "b", b);
 }
 
+ADE_FUNC(getMissionTitle, l_Mission, NULL, "Get the title of the current mission", "string", "The mission title or an empty string if currently not in mission") {
+	return ade_set_args(L, "s", The_mission.name);
+}
+
 //****LIBRARY: Campaign
 ADE_LIB(l_Campaign, "Campaign", "ca", "Campaign Library");
 

--- a/code/scripting/scripting.cpp
+++ b/code/scripting/scripting.cpp
@@ -83,7 +83,8 @@ flag_def_list Script_actions[] =
 	{ "On Afterburner Engage",	CHA_AFTERBURNSTART, 0 },
 	{ "On Afterburner Stop",	CHA_AFTERBURNEND,	0 },
 	{ "On Beam Fire",			CHA_BEAMFIRE,		0 },
-	{ "On Simulation",			CHA_SIMULATION,		0 }
+	{ "On Simulation",			CHA_SIMULATION,		0 },
+	{ "On Load Screen",			CHA_LOADSCREEN,		0 },
 };
 
 int Num_script_actions = sizeof(Script_actions)/sizeof(flag_def_list);
@@ -670,6 +671,9 @@ void script_state::SetHookVar(const char *name, char format, const void *data)
 						break;
 					case 'b':
 						ade_set_args(LuaState, fmt, *(bool*)data);
+						break;
+					case 'f':
+						ade_set_args(LuaState, fmt, *(float*)data);
 						break;
 					default:
 						ade_set_args(LuaState, fmt, *(ade_odata*)data);

--- a/code/scripting/scripting.h
+++ b/code/scripting/scripting.h
@@ -97,6 +97,7 @@ extern bool script_hook_valid(script_hook *hook);
 #define CHA_AFTERBURNEND    37
 #define CHA_BEAMFIRE        38
 #define CHA_SIMULATION      39
+#define CHA_LOADSCREEN      40
 
 // management stuff
 void scripting_state_init();

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -1123,7 +1123,7 @@ static int framenum;
  * called since the current callback function was set.
  */
 void game_loading_callback(int count)
-{	
+{
 	game_do_networking();
 
 	Assert( Game_loading_callback_inited==1 );
@@ -1175,6 +1175,17 @@ void game_loading_callback(int count)
 		memset( Processing_filename, 0, MAX_PATH_LEN );
 	}
 #endif
+
+	auto progress = static_cast<float>(count) / static_cast<float>(COUNT_ESTIMATE);
+	CLAMP(progress, 0.0f, 1.0f);
+	Script_system.SetHookVar("Progress", 'f', &progress);
+
+	if (Script_system.RunCondition(CHA_LOADSCREEN)) {
+		// At least one script exeuted so we probably need to do a flip now
+		do_flip = 1;
+	}
+
+	Script_system.RemHookVar("Progress");
 
 	os_ignore_events();
 


### PR DESCRIPTION
This allows to use the XSTR mechanism in script to make translating
script text possible. This is compatible with the existing XSTR format
so automatic tstrings.tbl generator tools should work fine with this.

This also adds a scripting hook for the mission load screen since that
was requested in #1522.

This resolves points 2 and 4 of #1522.