### PR TITLE
Enable all color channels before doing a clear

### DIFF
--- a/code/graphics/opengl/gropengl.cpp
+++ b/code/graphics/opengl/gropengl.cpp
@@ -151,6 +151,9 @@ void gr_opengl_clear()
 		blue = pow(blue, SRGB_GAMMA);
 	}
 
+	// Make sure that all channels are enabled before doing this.
+	GL_state.ColorMask(true, true, true, true);
+
 	glClearColor(red, green, blue, alpha);
 
 	glClear ( GL_COLOR_BUFFER_BIT );


### PR DESCRIPTION
If the previous rendering operation left the color mask in any other
state than completely enabled then the clear will only affect the
enabled channels. This makes sure that all channels are enabled before
doing the clear.

This fixes an issue reported on the forums:
https://www.hard-light.net/forums/index.php?topic=94200.msg1859118#msg1859118