### PR TITLE
Moves player control check for modelpoint shields into…

### DIFF
--- a/code/hud/hudshield.cpp
+++ b/code/hud/hudshield.cpp
@@ -262,6 +262,21 @@ void hud_shield_equalize(object *objp, player *pl)
 //
 void hud_augment_shield_quadrant(object *objp, int direction)
 {
+	Assertion((direction >= 0) && (direction < 4), "Invalid quadrant index %i!", direction);
+
+	ship *shipp = &Ships[objp->instance];
+	ship_info *sip = &Ship_info[shipp->ship_info_index];
+
+	if (sip->flags[Ship::Info_Flags::Model_point_shields]) {
+		// Using model point shields, so map to the correct quadrant
+		direction = sip->shield_point_augment_ctrls[direction];
+
+		if (direction < 0) {
+			// This quadrant cannot be augmented, ignore request and bail
+			return;
+		}
+	}	// Else, using standard shields.
+
 	shield_transfer(objp, direction, SHIELD_TRANSFER_PERCENT);
 }
 

--- a/code/object/objectshield.cpp
+++ b/code/object/objectshield.cpp
@@ -383,19 +383,6 @@ void shield_transfer(object *objp, int quadrant, float rate) {
 	Assert(objp);
 	Assert(objp->type == OBJ_SHIP);
 
-	ship *shipp = &Ships[objp->instance];
-	ship_info *sip = &Ship_info[shipp->ship_info_index];
-
-	if (sip->flags[Ship::Info_Flags::Model_point_shields]) {
-		// Using model point shields, so map to the correct quadrant
-		quadrant = sip->shield_point_augment_ctrls[quadrant];
-
-		if (quadrant < 0) {
-			// This quadrant cannot be augmented, bail
-			return;
-		}
-	}
-
 	Assert(quadrant >= 0 && quadrant < objp->n_quadrants);
 	Assert((0.0f < rate) && (rate <= 1.0f));
 


### PR DESCRIPTION
…hud_augment_shield_quadrant(). AI ships can now use shield_transfer() on quadrant indices larger than 3.

AI controlled ships which have modelpoint shields with more than 4 shield quadrants would run into an assertion within shield_transfer() whenever they tried transfering energy to a quadrant with an index greater than 3. I'm assuming the Assertion() was intended to prevent only player ships from augmenting more than 4 sectors (since a control scheme for doing so hasn't been needed/designed just yet) and have thus moved the relative block into hug_augment_shield_quadrant() which should be only called by players.