### PR TITLE
Fix crash when using JPEGs as interface bitmaps

### DIFF
--- a/code/bmpman/bmpman.cpp
+++ b/code/bmpman/bmpman.cpp
@@ -2280,6 +2280,9 @@ void bm_lock_jpg(int handle, int bitmapnum, bitmap_entry *be, bitmap *bmp, int b
 	// Unload any existing data
 	bm_free_data(bitmapnum);
 
+	// JPEG actually only support 24 bits per pixel so we enforce that here
+	bpp = 24;
+
 	d_size = (bpp >> 3);
 
 	// allocate bitmap data

--- a/code/jpgutils/jpgutils.cpp
+++ b/code/jpgutils/jpgutils.cpp
@@ -219,6 +219,9 @@ int jpeg_read_bitmap(const char *real_filename, ubyte *image_data, ubyte *palett
 		jpeg_info.output_components = dest_size;
 		jpeg_info.out_color_components = dest_size;	// may need/have to match above
 
+		// Actually check the precondition specified in the comment above
+		Assertion(dest_size == 3, "JPEG decompression currently only support 24-bit bitmap locking!");
+
 		// multiplying by rec_outbuf_height isn't required but is more efficient
 		int size = jpeg_info.output_width * jpeg_info.output_components * jpeg_info.rec_outbuf_height;
 		// a standard malloc doesn't appear to work properly here (debug vm_malloc??), crashes in lib


### PR DESCRIPTION
The new OpenGL texture data handling code uses different bits-per-pixel values than before which caused a crash when using a JPEG image as the mission load screen. The JPEg decompression code only supports decompressing to 24-bits per pixel but the new code requested 32 bits-per-pixel. `bm_lock` uses either the supplied bpp value (32 in the new code or 16 in the old code) or the true bpp value of the bitmap, whichever is higher. This meant that the new code always tried to lock JPEGs with 32 bits per pixel instead of the supported 24 bits per pixel which caused a crash when the decompression code tried to write out of the bounds of the supplied buffer.

This fixes that issue by always forcing the bpp value to 24 (which is similar to how PNGs are handled).