### PR TITLE
Fix SIGBUS crash in fs2netd

### DIFF
--- a/code/fs2netd/fs2netd_client.cpp
+++ b/code/fs2netd/fs2netd_client.cpp
@@ -615,6 +615,10 @@ static void fs2netd_handle_ping()
 
 static void fs2netd_handle_messages()
 {
+	if (!Is_connected) {
+		return;
+	}
+
 	int buffer_size = 0, buffer_offset = 0;
 	int bytes_read = 0;
 	char tbuf[256];
@@ -808,6 +812,12 @@ void fs2netd_do_frame()
 
 	// do ping/pong and ident
 	fs2netd_handle_ping();
+
+	if (!Is_connected) {
+		// The ping handling above made us realize that we are disconnected. We will reconnect in some time so we can
+		// just return here
+		return;
+	}
 
 	// handle gameserver updates
 	fs2netd_gameserver_update();


### PR DESCRIPTION
This was reported by @chief1983 on Discord. The standalone server crashed
with a `SIGBUS` error caused by an invalid socket file handle in
`FS2NetD_DataReady()`. This should fix that by adding additional checks
where necessary to make sure that our socket is valid when the socket
functions are used.