### PR TITLE
Extends the existing parse pausing system (used by bmpman) to use a

### DIFF
--- a/code/parse/parselo.h
+++ b/code/parse/parselo.h
@@ -354,6 +354,20 @@ namespace parse
 		ParseException(const std::string& msg) : std::runtime_error(msg) {}
 		~ParseException() throw() {}
 	};
+
+	/**
+	* @brief Parsing checkpoint
+	*
+	* @details Keeps track of the information it needs to be able to resume parsing a file at this location.
+	*/
+	class Bookmark
+	{
+	public:
+		SCP_string filename;
+		char* Mp;
+		int Warning_count;
+		int Error_count;
+	};
 }
 
 #endif


### PR DESCRIPTION
bookmark stack.

The stack is First In Last Out, so the parser will resume its most recently saved parsing location before going onto the oldest.

Another mechanism will be needed to ensure double-parsing doesn't occur when resuming from a bookmark, such as an [indexer](https://github.com/z64555/fs2open.github.com/tree/feature/parse_index).