### PR TITLE
Convert speech text properly to wide string

### DIFF
--- a/code/sound/speech.h
+++ b/code/sound/speech.h
@@ -13,8 +13,6 @@
 
 #if FS2_SPEECH
 
-const size_t MAX_SPEECH_CHAR_LEN = 10000;
-
 bool speech_init();
 void speech_deinit();
 bool speech_play(const char *text);


### PR DESCRIPTION
The previous code could only handle ASCII data correctly but this new
code is also able to handle UTF-8 data correctly by using the Windows
API function `MultiByteToWideChar`. Since the conversion only happens in
Windows-only code this is not a portability issue.

This fixes an issue reported on the forums where non-ASCII text was not
spoken correctly by the TTS system.