### PR TITLE
Log a proper error message if WaveFile::Open tries to load a missing file

### DIFF
--- a/code/sound/ffmpeg/WaveFile.cpp
+++ b/code/sound/ffmpeg/WaveFile.cpp
@@ -150,7 +150,11 @@ bool WaveFile::Open(const char* pszFilename, bool keep_ext) {
 				throw FFmpegException("Unknown file extension.");
 			}
 
-			cf_find_file_location(pszFilename, CF_TYPE_ANY, sizeof(fullpath) - 1, fullpath, &FileSize, &FileOffset);
+			rc = cf_find_file_location(pszFilename, CF_TYPE_ANY, sizeof(fullpath) - 1, fullpath, &FileSize, &FileOffset);
+
+			if(rc == 0) {
+				throw FFmpegException("File not found.");
+			}
 		}
 		else {
 			// ... otherwise we just find the best match


### PR DESCRIPTION
`SOUND ==> Could not open wave file 2ndRDeath.ogg for streaming. Reason: File not found.`

is much more helpful than

`ASSERTION: "file_path && strlen(file_path)" at cfile.cpp:831`