### PR TITLE
Fix two minor issues detected by GCC7 warnings

### DIFF
--- a/code/graphics/2d.cpp
+++ b/code/graphics/2d.cpp
@@ -2231,15 +2231,13 @@ uint gr_determine_model_shader_flags(
 
 void gr_print_timestamp(int x, int y, fix timestamp, int resize_mode)
 {
-	char time[8];
-
 	int seconds = fl2i(f2fl(timestamp));
 
 	// format the time information into strings
+	SCP_string time;
 	sprintf(time, "%.1d:%.2d:%.2d", (seconds / 3600) % 10, (seconds / 60) % 60, seconds % 60);
-	time[7] = '\0';
 
-	gr_string(x, y, time, resize_mode);
+	gr_string(x, y, time.c_str(), resize_mode);
 }
 
 static std::unique_ptr<graphics::util::UniformBufferManager>

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -3369,7 +3369,9 @@ void weapon_generate_indexes_for_substitution() {
 						Warning(LOCATION, "Weapon '%s' requests substitution with '%s' which is of a different subtype.",
 							wip->name, wip->weapon_substitution_pattern_names[j]);
 						wip->num_substitution_patterns = 0;
-						memset(wip->weapon_substitution_pattern, -1, MAX_SUBSTITUTION_PATTERNS);
+						std::fill(std::begin(wip->weapon_substitution_pattern),
+								  std::end(wip->weapon_substitution_pattern),
+								  -1);
 						break;
 					}
 				}


### PR DESCRIPTION
The first issue was a wrong usage of `memset`. The commit message contains more information on what the bug was.

The second issue was another `sprintf` warning which I fixed by using our `SCP_string` variant of that function.