### PR TITLE
Only change directory on MacOS when parent process path is /sbin/launchd.

### DIFF
--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -19,6 +19,10 @@
  #include <crtdbg.h>
 #endif // !_MINGW
 #else
+#ifdef APPLE_APP
+ #include <sys/types.h>
+ #include <libproc.h>
+#endif
  #include <unistd.h>
  #include <sys/stat.h>
 #endif
@@ -7939,11 +7943,17 @@ int actual_main(int argc, char *argv[])
 	SCP_mspdbcs_Initialise();
 #else
 #ifdef APPLE_APP
-	// Finder sets the working directory to the root of the drive so we have to get a little creative
-	// to find out where on the disk we should be running from for CFILE's sake.
-	char *path_name = SDL_GetBasePath();
-	chdir(path_name);
-	SDL_free(path_name);
+    char pathbuf[PROC_PIDPATHINFO_MAXSIZE];
+    if (proc_pidpath(getppid(), pathbuf, sizeof(pathbuf)) <= 0) {
+        Warning(LOCATION, "Could not retrieve parent pidpath!");
+    }
+    if (strcmp("/sbin/launchd", pathbuf) == 0) {
+        // Finder sets the working directory to the root of the drive so we have to get a little creative
+        // to find out where on the disk we should be running from for CFILE's sake.
+        char *path_name = SDL_GetBasePath();
+        chdir(path_name);
+        SDL_free(path_name);
+    }
 #endif
 
 	// create user's directory	


### PR DESCRIPTION
Fix for #1541.  Tested to work when run via wxLauncher, Finder, open, and terminal after entering my FS2 data directory.  Please inspect for string and any necessary const adjustments, as again, this definitely isn't my daily language, and the gist of the code was basically from the internet.