### PR TITLE
Make sure updating a texture uses the right texture unit

### DIFF
--- a/code/graphics/opengl/gropengltexture.cpp
+++ b/code/graphics/opengl/gropengltexture.cpp
@@ -1499,7 +1499,11 @@ void gr_opengl_update_texture(int bitmap_handle, int bpp, const ubyte* data, int
 		}
 	}
 	glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
-	GL_state.Texture.Enable(0, t->texture_target, t->texture_id);
+
+	GL_state.Texture.SetActiveUnit(0);
+	GL_state.Texture.SetTarget(t->texture_target);
+	GL_state.Texture.Enable(t->texture_id);
+
 	glTexSubImage3D(t->texture_target, 0, 0, 0, t->array_index, width, height, 1, glFormat, texFormat, (texmem)?texmem:data);
 
 	if (texmem != NULL)


### PR DESCRIPTION
The normally faster version that was used before misbehaved if that
texture unit already used the specified texture object which caused the
glTexSubImage3D to cause out of bounds issues some times.

This fixes #1554.