### PR TITLE
Use correct attachment for depth/stencil buffer

### DIFF
--- a/code/graphics/opengl/gropengldeferred.cpp
+++ b/code/graphics/opengl/gropengldeferred.cpp
@@ -97,8 +97,7 @@ void gr_opengl_deferred_lighting_finish()
 	opengl_shader_set_current( gr_opengl_maybe_create_shader(SDR_TYPE_DEFERRED_LIGHTING, 0) );
 
 	glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, Scene_luminance_texture, 0);
-	glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER, Scene_stencil_buffer);
-	glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_STENCIL_ATTACHMENT, GL_RENDERBUFFER, Scene_stencil_buffer);
+	glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT, GL_RENDERBUFFER, Scene_stencil_buffer);
 
 	GL_state.Texture.SetShaderMode(GL_TRUE);
 


### PR DESCRIPTION
This should be the correct way to set the combined depth/stencil buffer.
This has not been tested yet since I do not have a GPU which causes
these issues.

This fixes #1555.