### PR TITLE
Sanity checking in maybe_play_flyby_snd

### DIFF
--- a/code/object/objectsnd.cpp
+++ b/code/object/objectsnd.cpp
@@ -431,6 +431,9 @@ void maybe_play_flyby_snd(float closest_dist, object *closest_objp, object *list
 				else
 					snd = &Species_info[sip->species].snd_flyby_fighter;
 
+				if (snd->sound_entries.empty())
+					return; //This species does not define any relevant flyby sounds
+
 				// play da sound
 				snd_play_3d(snd, &closest_objp->pos, &View_position);
 


### PR DESCRIPTION
If no flyby sounds are defined for a species, do not attempt to play any. This fixes #1559,