### PR TITLE
Reset campaign room text pointers when freeing campaign data

### DIFF
--- a/code/menuui/readyroom.cpp
+++ b/code/menuui/readyroom.cpp
@@ -1728,6 +1728,11 @@ void campaign_room_close()
 	if (Background_bitmap >= 0)
 		bm_release(Background_bitmap);
 
+	// Reset info text pointers and size since they may contain pointers into the campaign description which will be
+	// freed soon.
+	memset(Info_text_line_size, 0, sizeof(Info_text_line_size));
+	memset(Info_text_ptrs, 0, sizeof(Info_text_ptrs));
+
 	// free the global Campaign_* list stuff
 	mission_campaign_free_list();
 


### PR DESCRIPTION
Previously the campaign room caused a heap-use-after-free error
(detected by AddressSanitizer) when loading the campaign failed two
times. This fixes the error by resetting the text pointers to their
default values when freeing the campaign list data.