### PR TITLE
Add tracing scopes for HUD rendering

### DIFF
--- a/code/hud/hud.cpp
+++ b/code/hud/hud.cpp
@@ -43,6 +43,7 @@
 #include "network/multi_pmsg.h"
 #include "network/multi_voice.h"
 #include "network/multiutil.h"
+#include "tracing/tracing.h"
 #include "object/object.h"
 #include "object/objectdock.h"
 #include "playerman/player.h"
@@ -1764,6 +1765,8 @@ void hud_render_gauges(int cockpit_display_num)
 				continue;
 			}
 
+			TRACE_SCOPE(tracing::RenderHUDGauge);
+
 			sip->hud_gauges[j]->resetClip();
 			sip->hud_gauges[j]->setFont();
 			sip->hud_gauges[j]->render(flFrametime);
@@ -1781,6 +1784,8 @@ void hud_render_gauges(int cockpit_display_num)
 			if ( !default_hud_gauges[j]->canRender() ) {
 				continue;
 			}
+
+			TRACE_SCOPE(tracing::RenderHUDGauge);
 
 			default_hud_gauges[j]->resetClip();
 			default_hud_gauges[j]->setFont();

--- a/code/tracing/categories.cpp
+++ b/code/tracing/categories.cpp
@@ -81,6 +81,9 @@ Category ProcessParticleEffects("Process particle effects", false);
 Category TrailsMoveAll("Trails move all", false);
 Category Simulation("Simulation", false);
 Category RenderMainFrame("Render frame", true);
+Category RenderHUD("Render HUD", true);
+Category RenderHUDHook("Render HUD Scripting Hook", true);
+Category RenderHUDGauge("Render HUD Gauge", true);
 Category MainFrame("Main Frame", true);
 Category PageFlip("Page flip", true);
 

--- a/code/tracing/categories.h
+++ b/code/tracing/categories.h
@@ -93,6 +93,9 @@ extern Category ProcessParticleEffects;
 extern Category TrailsMoveAll;
 extern Category Simulation;
 extern Category RenderMainFrame;
+extern Category RenderHUD;
+extern Category RenderHUDHook;
+extern Category RenderHUDGauge;
 extern Category MainFrame;
 extern Category PageFlip;
 

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -4169,6 +4169,7 @@ void game_frame(bool paused)
 
 			if(Scripting_didnt_draw_hud) {
 				GR_DEBUG_SCOPE("Render HUD");
+				TRACE_SCOPE(tracing::RenderHUD);
 
 				game_render_hud(cid);
 			}
@@ -4180,6 +4181,8 @@ void game_frame(bool paused)
 
 			if (!(Viewer_mode & (VM_EXTERNAL | VM_DEAD_VIEW | VM_WARP_CHASE | VM_PADLOCK_ANY))) 
 			{
+				TRACE_SCOPE(tracing::RenderHUDHook);
+
 				Script_system.RunCondition(CHA_HUDDRAW, '\0', NULL, Viewer_obj);
 			}
 			Script_system.RemHookVar("Self");


### PR DESCRIPTION
While debugging a performance issue reported on Discord I noticed that
the HUD rendering code does not have any tracing scopes. This adds a few
tracing scopes to that code to make performance debugging a bit easier.