### PR TITLE
Reset loaded ship object when closing the F3 lab

### DIFF
--- a/code/lab/lab.cpp
+++ b/code/lab/lab.cpp
@@ -2748,6 +2748,11 @@ void lab_close()
 		Lab_ship_subsys = NULL;
 	}
 
+	if (Lab_selected_object != -1) {
+		obj_delete(Lab_selected_object);
+		Lab_selected_object = -1;
+	}
+
 	memset( Lab_model_filename, 0, sizeof(Lab_model_filename) );
 
 	Basemap_override = false;


### PR DESCRIPTION
The crash described in #1561 was caused by a `NULL` ai profile. The
profile was not set because the lab system already had a loaded ship
object (see line 2230). These changes make sure that the loaded ship
object is deleted before closing the lab system which ensures that the
ai profile is set the next time the lab is initialized.

This fixes #1561.