### PR TITLE
Correct backwards arguments in unicode::num_codepoints().

### DIFF
--- a/code/utils/unicode.h
+++ b/code/utils/unicode.h
@@ -149,7 +149,7 @@ size_t num_codepoints(octet_iterator start, octet_iterator end) {
 			return 0;
 		}
 	} else {
-		return static_cast<size_t>(std::distance(end, start));
+		return static_cast<size_t>(std::distance(start, end));
 	}
 }
 


### PR DESCRIPTION
When `Unicode_text_mode` was false, `unicode::num_codepoints()` would return (the `size_t` equivalent of) a negative number, because it was checking the distance from `end` to `start` instead of the distance from `start` to `end`.

Fixes #1571.