### PR TITLE
Replaced Blinn-Phong BRDF with GGX BRDF

### DIFF
--- a/code/def_files/deferred-f.sdr
+++ b/code/def_files/deferred-f.sdr
@@ -43,6 +43,29 @@ vec3 SpecularBlinnPhong(vec3 specColor, vec3 light, vec3 normal, vec3 halfVec, f
 {
 	return mix(specColor, FresnelSchlick(specColor, light, halfVec), fresnel) * ((specPower + 2.0) / 8.0 ) * pow(clamp(dot(normal, halfVec), 0.0, 1.0), specPower) * dotNL;
 }
+vec3 SpecularGGX(vec3 specColor, vec3 light, vec3 normal, vec3 halfVec, vec3 view, float gloss, float dotNL)
+{
+	float roughness = clamp(1.0f - gloss, 0.0f, 1.0f);
+	float alpha = roughness * roughness;
+
+	float dotNH = clamp(dot(normal, halfVec), 0.0f, 1.0f);
+	float dotNV = clamp(dot(normal, view), 0.0f, 1.0f);
+
+	float alphaSqr = alpha * alpha;
+	float pi = 3.14159f;
+	float denom = dotNH * dotNH * (alphaSqr - 1.0f) + 1.0f;
+	float distribution = alphaSqr / (pi * denom * denom);
+
+	vec3 fresnel = FresnelSchlick(specColor, light, halfVec);
+	
+	float alphaPrime = roughness + 1.0f;
+	float k = alphaPrime * alphaPrime / 8.0f;
+	float g1vNL = 1.0f / (dotNL * (1.0f - k) + k);
+	float g1vNV = 1.0f / (dotNV * (1.0f - k) + k);
+	float visibility = g1vNL * g1vNV;
+
+	return distribution * fresnel * visibility * dotNL;
+}
 vec4 SpecularLegacy(vec4 specColor, vec3 normal, vec3 halfVec, float specPower)
 {
 	return specColor * pow(clamp(dot(normal, halfVec), 0.0, 1.0), specPower);
@@ -101,6 +124,6 @@ void main()
 	vec3 halfVec = normalize(lightDir + eyeDir);
 	float NdotL = clamp(dot(normal.xyz, lightDir), 0.0, 1.0);
 	vec4 fragmentColor = vec4(color * (diffuseLightColor * NdotL * attenuation), 1.0);
-	fragmentColor.rgb += SpecularBlinnPhong(specColor.rgb, lightDir, normal.xyz, halfVec, exp2(10.0 * gloss + 1.0), fresnel, NdotL).rgb * specLightColor * attenuation;
+	fragmentColor.rgb += SpecularGGX(specColor.rgb, lightDir, normal.xyz, halfVec, eyeDir, gloss, NdotL).rgb * specLightColor * attenuation;
 	fragOut0 = max(fragmentColor, vec4(0.0));
 }

--- a/code/def_files/main-f.sdr
+++ b/code/def_files/main-f.sdr
@@ -214,6 +214,7 @@ float samplePoissonPCF(int cascade)
 	sum += sampleShadowMap(fragShadowUV[cascade].xy, poissonDisc[15], cascade, maxUVOffset[cascade])*(1.0/16.0);
 	return computeShadowFactor(sum, 0.1);
 }
+
 float getShadowValue()
 {
 	// Valathil's Shadows
@@ -236,20 +237,48 @@ float getShadowValue()
 	return mix(samplePoissonPCF(cascade), samplePoissonPCF(cascade+1), smoothstep(cascade_start_dist[cascade+1] - dist_threshold, cascade_start_dist[cascade+1], depth));
 }
 #endif
+
 vec3 FresnelLazarovEnv(vec3 specColor, vec3 view, vec3 normal, float gloss)
 {
 	// Fresnel for environment lighting 
 	// Equation referenced from Dimitar Lazarov's presentation titled Physically Based Rendering in Call of Duty: Black Ops
 	return specColor + (vec3(1.0) - specColor) * pow(1.0 - clamp(dot(view, normal), 0.0, 1.0), 5.0) / (4.0 - 3.0 * gloss);
 }
+
 vec3 FresnelSchlick(vec3 specColor, vec3 light, vec3 halfVec)
 {
 	return specColor + (vec3(1.0) - specColor) * pow(1.0 - clamp(dot(light, halfVec), 0.0, 1.0), 5.0);
 }
+
 vec3 SpecularBlinnPhong(vec3 specColor, vec3 light, vec3 normal, vec3 halfVec, float specPower, float fresnel, float dotNL)
 {
 	return mix(specColor, FresnelSchlick(specColor, light, halfVec), fresnel) * ((specPower + 2.0) / 8.0 ) * pow(clamp(dot(normal, halfVec), 0.0, 1.0), specPower) * dotNL;
 }
+
+vec3 SpecularGGX(vec3 specColor, vec3 light, vec3 normal, vec3 halfVec, vec3 view, float gloss, float dotNL)
+{
+	float roughness = clamp(1.0f - gloss, 0.0f, 1.0f);
+	float alpha = roughness * roughness;
+
+	float dotNH = clamp(dot(normal, halfVec), 0.0f, 1.0f);
+	float dotNV = clamp(dot(normal, view), 0.0f, 1.0f);
+
+	float alphaSqr = alpha * alpha;
+	float pi = 3.14159f;
+	float denom = dotNH * dotNH * (alphaSqr - 1.0f) + 1.0f;
+	float distribution = alphaSqr / (pi * denom * denom);
+
+	vec3 fresnel = FresnelSchlick(specColor, light, halfVec);
+	
+	float alphaPrime = roughness + 1.0f;
+	float k = alphaPrime * alphaPrime / 8.0f;
+	float g1vNL = 1.0f / (dotNL * (1.0f - k) + k);
+	float g1vNV = 1.0f / (dotNV * (1.0f - k) + k);
+	float visibility = g1vNL * g1vNV;
+
+	return distribution * fresnel * visibility * dotNL;
+}
+
 #ifdef FLAG_LIGHT
 void GetLightInfo(int i, out vec3 lightDir, out float attenuation)
 {
@@ -295,7 +324,7 @@ vec3 CalculateLighting(vec3 normal, vec3 diffuseMaterial, vec3 specularMaterial,
 		float NdotL = max(dot(normal, lightDir), 0.0);
 		// Ambient, Diffuse, and Specular
 		lightDiffuse += (lights[i].diffuse_color.rgb * diffuseFactor * NdotL * attenuation) * shadow;
-		lightSpecular += lights[i].spec_color * SpecularBlinnPhong(specularMaterial, lightDir, normal, halfVec, exp2(10.0 * gloss + 1.0), fresnel, NdotL) * attenuation * shadow;
+		lightSpecular += lights[i].spec_color * SpecularGGX(specularMaterial, lightDir, normal, halfVec, eyeDir, gloss, NdotL) * attenuation * shadow;
 	}
 	return diffuseMaterial * (lightAmbient + lightDiffuse) + lightSpecular;
 }


### PR DESCRIPTION
Ditches the Blinn-Phong specular lighting model with the GGX BRDF. Should make specular highlights look even more closer to reality.