### PR TITLE
Add screen space decal rendering system

### DIFF
--- a/code/bmpman/bmpman.cpp
+++ b/code/bmpman/bmpman.cpp
@@ -3320,6 +3320,13 @@ bool bm_is_texture_array(const int handle) {
 }
 
 int bm_get_base_frame(const int handle, int* num_frames) {
+	if (handle == -1) {
+		if (num_frames != nullptr) {
+			*num_frames = 0;
+		}
+		return -1;
+	}
+
 	// If the bitmap is no animation then num_frames will still be at least 1
 	auto animation_begin = bm_get_info(handle, nullptr, nullptr, nullptr, num_frames);
 
@@ -3353,4 +3360,27 @@ int bmpman_count_bitmaps() {
 	}
 
 	return total_bitmaps;
+}
+
+bool bm_validate_filename(const SCP_string& file, bool single_frame, bool animation) {
+	Assertion(single_frame || animation, "At least one of single_frame or animation must be true!");
+
+	if (!VALID_FNAME(file.c_str())) {
+		return false;
+	}
+
+	int handle = -1;
+	if (single_frame && animation) {
+		// Caller has indicated that single frames and animations are valid
+		handle = bm_load_either(file.c_str());
+	} else if (single_frame) {
+		handle = bm_load(file);
+	} else {
+		handle = bm_load_animation(file.c_str());
+	}
+	if (handle != -1) {
+		bm_release(handle);
+		return true;
+	}
+	return false;
 }

--- a/code/bmpman/bmpman.h
+++ b/code/bmpman/bmpman.h
@@ -741,4 +741,20 @@ int bm_get_array_index(const int handle);
  */
 int bmpman_count_bitmaps();
 
+/**
+ * @brief Checks if the given filename is a valid effect or texture file name
+ *
+ * @note At least one of @c single_frame or @c animation must be true since the result would make no sense otherwise. It
+ * is also valid to set both parmeters to @c true.
+ *
+ * @todo This currently just tries to load the file but could be improved by not actually loading the file in the future.
+ *
+ * @param file The file name to check
+ * @param single_frame If set to @c true then single frames are valid files
+ * @param animation If set to @c true then animations are valid files
+ * @return @c true if the file name is valid, @c false otherwise
+ */
+bool bm_validate_filename(const SCP_string& file, bool single_frame, bool animation);
+
+
 #endif

--- a/code/decals/decals.cpp
+++ b/code/decals/decals.cpp
@@ -1,0 +1,485 @@
+#include <nebula/neb.h>
+#include "decals/decals.h"
+
+#include "graphics/2d.h"
+#include "graphics/decal_draw_list.h"
+#include "graphics/util/uniform_structs.h"
+#include "parse/parselo.h"
+#include "tracing/tracing.h"
+#include "ship/ship.h"
+
+namespace {
+
+class DecalDefinition {
+	SCP_string _name;
+
+	SCP_string _diffuseFilename;
+	SCP_string _normalMapFilename;
+
+	bool _loop = true;
+
+	int _diffuseBitmap = -1;
+	int _normalBitmap = -1;
+
+ public:
+	DecalDefinition(const SCP_string& name) : _name(name) {
+	}
+
+	~DecalDefinition() {
+		if (_diffuseBitmap >= 0) {
+			bm_release(_diffuseBitmap);
+		}
+		if (_normalBitmap >= 0) {
+			bm_release(_normalBitmap);
+		}
+	}
+
+	// Disallow copying
+	DecalDefinition(const DecalDefinition&) = delete;
+	DecalDefinition& operator=(const DecalDefinition&) = delete;
+
+	// Move constructor and operator
+	DecalDefinition(DecalDefinition&& other) {
+		*this = std::move(other); // Use operator implementation
+	}
+	DecalDefinition& operator=(DecalDefinition&& other) {
+		std::swap(_name, other._name);
+
+		std::swap(_diffuseFilename, other._diffuseFilename);
+		std::swap(_normalMapFilename, other._normalMapFilename);
+
+		std::swap(_diffuseBitmap, other._diffuseBitmap);
+		std::swap(_normalBitmap, other._normalBitmap);
+
+		std::swap(_loop, other._loop);
+
+		return *this;
+	}
+
+	void parse() {
+		if (optional_string("+Diffuse:")) {
+			stuff_string(_diffuseFilename, F_FILESPEC);
+
+			if (!bm_validate_filename(_diffuseFilename, true, true)) {
+				error_display(0, "Animation '%s' is not valid!", _diffuseFilename.c_str());
+				_diffuseFilename = "";
+			}
+		}
+
+		if (optional_string("+Loop:")) {
+			stuff_boolean(&_loop);
+		}
+	}
+
+	void loadBitmaps() {
+		if (_diffuseBitmap == -1 && VALID_FNAME(_diffuseFilename)) {
+			_diffuseBitmap = bm_load_either(_diffuseFilename.c_str());
+			if (_diffuseBitmap == -1) {
+				Warning(LOCATION,
+						"Bitmap '%s' failed to load for decal definition %s!",
+						_diffuseFilename.c_str(),
+						_name.c_str());
+			}
+		}
+		if (_normalBitmap == -1 && VALID_FNAME(_normalMapFilename)) {
+			_normalBitmap = bm_load_either(_normalMapFilename.c_str());
+			if (_normalBitmap == -1) {
+				Warning(LOCATION,
+						"Bitmap '%s' failed to load for decal definition %s!",
+						_normalMapFilename.c_str(),
+						_name.c_str());
+			}
+		}
+	}
+
+	void pageIn() {
+		if (_diffuseBitmap >= 0) {
+			bm_page_in_texture(_diffuseBitmap);
+		}
+		if (_normalBitmap >= 0) {
+			bm_page_in_texture(_normalBitmap);
+		}
+	}
+
+	bool bitmapsLoaded() {
+		// Since both bitmap types are optional we need to check if either is loaded to determine if any bitmap is loaded
+		return _diffuseBitmap >= 0 || _normalBitmap >= 0;
+	}
+
+	const SCP_string& getName() const {
+		return _name;
+	}
+	int getDiffuseBitmap() const {
+		return _diffuseBitmap;
+	}
+	int getNormalBitmap() const {
+		return _normalBitmap;
+	}
+	bool isLooping() const {
+		return _loop;
+	}
+};
+
+SCP_vector<DecalDefinition> decalDefinitions;
+
+// Variable to indicate if the system is able to work correctly on the current system
+bool decal_system_active = true;
+
+void parse_decals_table(const char* filename) {
+	try {
+		read_file_text(filename, CF_TYPE_TABLES);
+		reset_parse();
+
+		required_string("#Decals");
+
+		while (optional_string("$Decal:")) {
+			SCP_string name;
+			stuff_string(name, F_NAME);
+
+			DecalDefinition def(name);
+			def.parse();
+
+			decalDefinitions.push_back(std::move(def));
+		}
+
+		required_string("#End");
+	} catch (const parse::ParseException& e) {
+		mprintf(("TABLES: Unable to parse '%s'!  Error message = %s.\n", filename, e.what()));
+		return;
+	}
+
+	if (!gr_is_capable(CAPABILITY_DEFERRED_LIGHTING)) {
+		// we need deferred lighting
+		decal_system_active = false;
+		mprintf(("Note: Decal system has been disabled due to lack of deferred lighting.\n"));
+	}
+	/*
+	Normal mapping isn't used at the moment. This check needs to be reenabled once support for that is added
+	if (!gr_is_capable(CAPABILITY_NORMAL_MAP)) {
+		// We need normal mapping for the full feature range
+		decal_system_active = false;
+		mprintf(("Note: Decal system has been disabled due to lack of normal mapping.\n"));
+	}
+	 */
+}
+
+struct Decal {
+	int definition_handle = -1;
+	object_h object;
+	int submodel = -1;
+
+	float creation_time = -1.0f; //!< The mission time at which this decal was created
+	float lifetime = -1.0f; //!< The time this decal is active. When negative it never expires
+
+	vec3d position = vmd_zero_vector;
+	vec3d scale;
+	matrix orientation = vmd_identity_matrix;
+
+	Decal() {
+		vm_vec_make(&scale, 1.f, 1.f, 1.f);
+	}
+
+	bool isValid() {
+		if (!object.IsValid()) {
+			return false;
+		}
+
+		if (lifetime > 0.0f) {
+			if (f2fl(Missiontime) >= creation_time + lifetime) {
+				// Decal has expired
+				return false;
+			}
+		}
+
+		auto objp = object.objp;
+		if (objp->type == OBJ_SHIP) {
+			auto shipp = &Ships[objp->instance];
+			auto model_instance = model_get_instance(shipp->model_instance_num);
+
+			Assertion(submodel >= 0 && submodel < model_get(object_get_model(objp))->n_models,
+					  "Invalid submodel number detected!");
+			auto smi = &model_instance->submodel[submodel];
+
+			if (smi->blown_off) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+};
+
+SCP_vector<Decal> active_decals;
+
+bool required_string_if_new(const char* token, bool new_entry) {
+	if (!new_entry) {
+		return optional_string(token) == 1;
+	}
+
+	required_string(token);
+	return true;
+}
+
+float clamp(float x, float min, float max) {
+	return std::min(std::max(x, min), max);
+}
+
+/**
+ * @brief Produces a smoothstep value as specified by the GLSL specification
+ * @param edge0
+ * @param edge1
+ * @param x
+ * @return
+ */
+float smoothstep(float edge0, float edge1, float x) {
+	auto t = clamp((x - edge0) / (edge1 - edge0), 0.0f, 1.0f);
+	return t * t * (3.0f - 2.0f * t);
+}
+
+}
+
+namespace decals {
+
+void initialize() {
+	decalDefinitions.clear();
+	graphics::decal_draw_list::globalInit();
+
+	parse_modular_table(NOX("*-dcl.tbm"), parse_decals_table);
+}
+void shutdown() {
+	graphics::decal_draw_list::globalShutdown();
+
+	// Free allocated resources
+	decalDefinitions.clear();
+}
+
+int getDecalConfig(const SCP_string& name) {
+	int index = 0;
+	for (auto& def : decalDefinitions) {
+		if (!stricmp(def.getName().c_str(), name.c_str())) {
+			return index;
+		}
+		++index;
+	}
+
+	return -1;
+}
+
+void parseDecalReference(creation_info& dest_info, bool is_new_entry) {
+	SCP_string name;
+	stuff_string(name, F_NAME);
+
+	auto decalRef = getDecalConfig(name);
+
+	if (decalRef < 0) {
+		error_display(0, "Decal definition '%s' is unknown!", name.c_str());
+	}
+	dest_info.definition_handle = decalRef;
+
+	if (required_string_if_new("+Radius:", is_new_entry)) {
+		stuff_float(&dest_info.radius);
+
+		if (dest_info.radius <= 0.0f) {
+			error_display(0, "Invalid radius of %f! Must be a positive number.", dest_info.radius);
+			dest_info.radius = 1.0f;
+		}
+	}
+
+	if (required_string_if_new("+Lifetime:", is_new_entry)) {
+		if (optional_string("Eternal")) {
+			dest_info.lifetime = util::UniformFloatRange(-1.0f);
+		} else {
+			// Require at least a small lifetime so that the calculations don't have to deal with div-by-zero
+			dest_info.lifetime = util::parseUniformRange(0.0001f);
+		}
+	}
+}
+void loadBitmaps(const creation_info& info) {
+	if (!decal_system_active) {
+		return;
+	}
+	// Silently ignore invalid definition handle since weapons use the default values if the decal option is not present
+	if (info.definition_handle < 0) {
+		return;
+	}
+
+	Assertion(info.definition_handle >= 0 && info.definition_handle < (int) decalDefinitions.size(),
+			  "Invalid decal handle detected!");
+
+	auto& def = decalDefinitions[info.definition_handle];
+
+	def.loadBitmaps();
+}
+void pageInDecal(const creation_info& info) {
+	if (!decal_system_active) {
+		return;
+	}
+	// Silently ignore invalid definition handle since weapons use the default values if the decal option is not present
+	if (info.definition_handle < 0) {
+		return;
+	}
+
+	Assertion(info.definition_handle >= 0 && info.definition_handle < (int) decalDefinitions.size(),
+			  "Invalid decal handle detected!");
+
+	decalDefinitions[info.definition_handle].pageIn();
+}
+
+void initializeMission() {
+	active_decals.clear();
+}
+
+matrix4 getDecalTransform(Decal& decal) {
+	Assertion(decal.object.objp->type == OBJ_SHIP, "Only ships are currently supported for decals!");
+
+	auto objp = decal.object.objp;
+	auto ship = &Ships[objp->instance];
+
+	vec3d worldPos;
+	model_instance_find_world_point(&worldPos,
+									&decal.position,
+									ship->model_instance_num,
+									decal.submodel,
+									&objp->orient,
+									&objp->pos);
+
+	vec3d worldDir;
+	model_instance_find_world_dir(&worldDir,
+								  &decal.orientation.vec.fvec,
+								  ship->model_instance_num,
+								  decal.submodel,
+								  &objp->orient);
+
+	vec3d worldUp;
+	model_instance_find_world_dir(&worldUp,
+								  &decal.orientation.vec.fvec,
+								  ship->model_instance_num,
+								  decal.submodel,
+								  &objp->orient);
+
+	matrix worldOrient;
+	vm_vector_2_matrix(&worldOrient, &worldDir, &worldUp);
+
+	// Apply scaling
+	worldOrient.a2d[0][0] *= decal.scale.xyz.x;
+	worldOrient.a2d[0][1] *= decal.scale.xyz.x;
+	worldOrient.a2d[0][2] *= decal.scale.xyz.x;
+	worldOrient.a2d[1][0] *= decal.scale.xyz.y;
+	worldOrient.a2d[1][1] *= decal.scale.xyz.y;
+	worldOrient.a2d[1][2] *= decal.scale.xyz.y;
+	worldOrient.a2d[2][0] *= decal.scale.xyz.z;
+	worldOrient.a2d[2][1] *= decal.scale.xyz.z;
+	worldOrient.a2d[2][2] *= decal.scale.xyz.z;
+
+	matrix4 mat4;
+	vm_matrix4_set_transform(&mat4, &worldOrient, &worldPos);
+
+	return mat4;
+}
+
+void renderAll() {
+	if (!decal_system_active) {
+		return;
+	}
+
+	// Clear out any invalid decals
+	for (auto iter = active_decals.begin(); iter != active_decals.end(); ++iter) {
+		if (!iter->isValid()) {
+			// if we're sitting on the very last element, popping-back will invalidate the iterator!
+			if (iter + 1 == active_decals.end()) {
+				active_decals.pop_back();
+				break;
+			}
+
+			*iter = active_decals.back();
+			active_decals.pop_back();
+			continue;
+		}
+	}
+
+	if (active_decals.empty()) {
+		return;
+	}
+
+
+	graphics::decal_draw_list draw_list;
+	auto mission_time = f2fl(Missiontime);
+
+	bool full_neb = ((The_mission.flags[Mission::Mission_Flags::Fullneb]) && (Neb2_render_mode != NEB2_RENDER_NONE)
+		&& !Fred_running);
+
+	if (full_neb) {
+		// Rendering decals is not supported when the fog effect is active (since the two effects do not work well
+		// together) so we skip rendering the decals in this case
+		// The active decals are still processed as usual though in case the nebula type of the mission is switched
+		return;
+	}
+
+	for (auto& decal : active_decals) {
+		int diffuse_bm = -1;
+		int normal_bm = -1;
+
+		Assertion(decal.definition_handle >= 0 && decal.definition_handle < (int) decalDefinitions.size(),
+				  "Invalid decal handle detected!");
+		auto& decalDef = decalDefinitions[decal.definition_handle];
+
+		auto decal_time = mission_time - decal.creation_time;
+		auto progress = decal_time / decal.lifetime;
+
+		float alpha = 1.0f;
+		if (progress > 0.8) {
+			// Fade the decal out for the last 20% of its lifetime
+			alpha = 1.0f - smoothstep(0.8f, 1.0f, progress);
+		}
+
+		if (decalDef.getDiffuseBitmap() >= 0) {
+			diffuse_bm = decalDef.getDiffuseBitmap()
+				+ bm_get_anim_frame(decalDef.getDiffuseBitmap(), decal_time, 0.0f, decalDef.isLooping());
+		}
+
+		if (decalDef.getNormalBitmap() >= 0) {
+			normal_bm = decalDef.getNormalBitmap()
+				+ bm_get_anim_frame(decalDef.getNormalBitmap(), decal_time, 0.0f, decalDef.isLooping());
+		}
+
+		draw_list.add_decal(diffuse_bm, normal_bm, decal_time, getDecalTransform(decal), alpha);
+	}
+
+	draw_list.render();
+}
+void
+addDecal(creation_info& info, object* host, int submodel, const vec3d& local_pos, const matrix& local_orient) {
+	if (!decal_system_active) {
+		return;
+	}
+	// Silently ignore invalid definition handle since weapons use the default values if the decal option is not present
+	if (info.definition_handle < 0) {
+		return;
+	}
+
+	Assertion(info.definition_handle >= 0 && info.definition_handle < (int) decalDefinitions.size(),
+			  "Invalid decal handle detected!");
+	auto& def = decalDefinitions[info.definition_handle];
+
+	if (!def.bitmapsLoaded()) {
+		// If this decal was never used before then the bitmaps are not loaded so we need to do that here.
+		def.loadBitmaps();
+	}
+
+	Decal newDecal;
+	newDecal.definition_handle = info.definition_handle;
+	newDecal.object = object_h(host);
+	newDecal.submodel = submodel;
+	newDecal.creation_time = f2fl(Missiontime);
+	newDecal.lifetime = info.lifetime.next();
+
+	newDecal.position = local_pos;
+	newDecal.orientation = local_orient;
+	newDecal.scale.xyz.x = info.radius;
+	newDecal.scale.xyz.y = info.radius;
+	newDecal.scale.xyz.z = info.radius;
+
+	active_decals.push_back(newDecal);
+}
+
+}

--- a/code/decals/decals.h
+++ b/code/decals/decals.h
@@ -1,0 +1,87 @@
+#pragma once
+
+#include "globalincs/pstypes.h"
+
+#include "object/object.h"
+
+#include "utils/RandomRange.h"
+
+namespace decals {
+
+/**
+ * @brief A reference to a decal definition
+ */
+typedef int DecalReference;
+
+/**
+ * @brief A structure containing all information for creating a decal
+ */
+struct creation_info {
+	DecalReference definition_handle = -1;
+	float radius = -1.0f;
+	util::UniformFloatRange lifetime = ::util::UniformFloatRange(-1.0f);
+};
+
+/**
+ * @brief Initializes the global state of the decal system. Call once at game init.
+ */
+void initialize();
+
+
+/**
+ * @brief Parses the information for a decal reference
+ *
+ * @details This function expects that the initial token has already been consumed by the parse system.
+ *
+ * @param dest_info The creation information struct to parse the information into
+ * @param is_new_entry Set to @c false if the currently parsed object used +nocreate
+ */
+void parseDecalReference(creation_info& dest_info, bool is_new_entry = true);
+
+/**
+ * @brief Loads the bitmaps specified by the creation info into texture memory
+ *
+ * This should be called when the bitmaps of the object using this decal are loaded.
+ *
+ * @param info The creation information containing the decal definition handle
+ */
+void loadBitmaps(const creation_info& info);
+
+/**
+ * @brief Page in the bitmap data of the specified creation information. Needs to be called after loadBitmaps
+ * @param info The information to page in
+ */
+void pageInDecal(const creation_info& info);
+
+/**
+ * @brief Shut down the decal system. Must be called from game_shutdown
+ */
+void shutdown();
+
+/**
+ * @brief Initialize the decal system for the mission. Must be called before every mission is started
+ */
+void initializeMission();
+
+/**
+ * @brief Renders all currently active decals and removes invalid decals from the active list.
+ */
+void renderAll();
+
+/**
+ * @brief Creates a new decal on the specified object at the specified location
+ *
+ * @param info The decal to create
+ * @param host The object host on which to create this decal. Must be a ship.
+ * @param submodel The submodel of the object model on which to create the decal.
+ * @param local_pos The position in the frame of reference of the submodel at which the decal should be created.
+ * @param local_orient The orientation of the decal in the frame of reference of the submodel. The forward vector of the
+ * orientation should look along the direction
+ */
+void addDecal(creation_info& info,
+			  object* host,
+			  int submodel,
+			  const vec3d& local_pos,
+			  const matrix& local_orient);
+
+}

--- a/code/def_files/decal-f.sdr
+++ b/code/def_files/decal-f.sdr
@@ -1,0 +1,122 @@
+
+// NOTE: The technique and some of this code is based on this tutorial:
+// http://martindevans.me/game-development/2015/02/27/Drawing-Stuff-On-Other-Stuff-With-Deferred-Screenspace-Decals/
+
+out vec4 fragOut0;
+out vec4 fragOut1;
+out vec4 fragOut2;
+out vec4 fragOut3;
+
+#define SRGB_GAMMA 2.2
+
+uniform sampler2D gDepthBuffer;
+uniform sampler2D gNormalBuffer;
+
+uniform sampler2DArray diffuseMap;
+uniform sampler2DArray normalMap;
+
+layout (std140) uniform decalGlobalData {
+	mat4 viewMatrix;
+	mat4 projMatrix;
+	mat4 invViewMatrix;
+	mat4 invProjMatrix;
+
+	vec2 viewportSize;
+};
+layout (std140) uniform decalInfoData {
+	mat4 model_matrix;
+	mat4 inv_model_matrix;
+
+	vec3 decal_direction;
+	float normal_angle_cutoff;
+
+	int diffuse_index;
+	int normal_index;
+	float angle_fade_start;
+	float alpha_scale;
+
+	int blend_mode;
+};
+
+vec3 computeViewPosition(vec2 textureCoord) {
+	vec4 clipSpaceLocation;
+	vec2 normalizedCoord = textureCoord / viewportSize;
+
+	clipSpaceLocation.xy = normalizedCoord * 2.0f - 1.0f;
+	clipSpaceLocation.z = texelFetch(gDepthBuffer, ivec2(textureCoord), 0).r * 2.0f - 1.0f;
+	clipSpaceLocation.w = 1.0f;
+
+	vec4 homogenousLocation = invProjMatrix * clipSpaceLocation;
+
+	return homogenousLocation.xyz / homogenousLocation.w;
+}
+
+vec3 getPixelNormal(vec3 frag_position, vec2 tex_coord, inout float alpha) {
+#ifdef USE_NORMAL_MAP
+	// If we can then we just use the existing normal buffer
+    vec3 normal = texelFetch(gNormalBuffer, ivec2(tex_coord), 0).xyz;
+#else
+	// Use some fancy screen-space derivates to determine the normal of the current pixel by looking at the surrounding pixels
+	vec3 pos_dx = dFdx(frag_position);
+	vec3 pos_dy = dFdy(frag_position);
+
+    vec3 normal = normalize(cross(pos_dx, pos_dy));
+#endif
+
+	//Calculate angle between surface normal and decal direction
+	float angle = acos(dot(normal, decal_direction));
+
+	if (angle > normal_angle_cutoff) {
+		// The angle between surface normal and decal direction is too big
+		discard;
+	}
+
+	// Make a smooth alpha transition leading up to an edge
+	alpha = alpha * (1 - smoothstep(angle_fade_start, normal_angle_cutoff, angle));
+
+	return normal;
+}
+
+vec2 getDecalTexCoord(vec3 view_pos, inout float alpha) {
+	vec4 object_pos = inv_model_matrix * invViewMatrix * vec4(view_pos, 1.0);
+
+	bvec3 invalidComponents = greaterThan(abs(object_pos.xyz), vec3(0.5));
+	bvec4 nanComponents = isnan(object_pos); // nan can happen some times if we have an infinite depth value
+
+	if (any(invalidComponents) || any(nanComponents)) {
+		// Fragment is out of the box
+		discard;
+	}
+
+	// Fade out the texture when it gets close to the top or bottom of the decal box
+	alpha = alpha * (1.0 - smoothstep(0.4, 0.5, abs(object_pos.z)));
+
+	return object_pos.xy + 0.5;
+}
+
+void main() {
+	vec3 frag_position = computeViewPosition(gl_FragCoord.xy);
+
+	float alpha = alpha_scale;
+	vec2 tex_coord = getDecalTexCoord(frag_position, alpha);
+
+	vec3 normal = getPixelNormal(frag_position, gl_FragCoord.xy, alpha);
+
+	if (diffuse_index >= 0) {
+		// We have a valid diffuse map
+		vec4 color = texture(diffuseMap, vec3(tex_coord, float(diffuse_index)));
+		//color = vec4(0.6, 0.1, 0.1, 0.7);
+
+		color.rgb = pow(color.rgb, vec3(SRGB_GAMMA));
+
+		if (blend_mode == 0) {
+			// Normal alpha blending
+			fragOut0 = vec4(color.rgb, color.a * alpha);
+		} else {
+			// Additive blending
+			fragOut0 = vec4(color.rgb * alpha, 1.0);
+		}
+	} else {
+		fragOut0 = vec4(0.0, 0.0, 0.0, 0.0);
+	}
+}

--- a/code/def_files/decal-v.sdr
+++ b/code/def_files/decal-v.sdr
@@ -1,0 +1,30 @@
+
+in vec4 vertPosition;
+
+layout (std140) uniform decalGlobalData {
+	mat4 viewMatrix;
+	mat4 projMatrix;
+	mat4 invViewMatrix;
+	mat4 invProjMatrix;
+
+	vec2 viewportSize;
+};
+
+layout (std140) uniform decalInfoData {
+	mat4 model_matrix;
+	mat4 inv_model_matrix;
+
+	vec3 decal_direction;
+	float normal_angle_cutoff;
+
+	int diffuse_index;
+	int normal_index;
+	float angle_fade_start;
+	float alpha_scale;
+
+	int blend_mode;
+};
+
+void main() {
+	gl_Position = projMatrix * viewMatrix * model_matrix * vertPosition;
+}

--- a/code/globalincs/pstypes.h
+++ b/code/globalincs/pstypes.h
@@ -363,15 +363,6 @@ typedef struct lod_checker {
 } lod_checker;
 
 
-// check to see that a passed sting is valid, ie:
-//  - has >0 length
-//  - is not "none"
-//  - is not "<none>"
-inline bool VALID_FNAME(const char* x) {
-	return strlen((x)) && stricmp((x), "none") && stricmp((x), "<none>");
-}
-
-
 // Callback Loading function.
 // If you pass a function to this, that function will get called
 // around 10x per second, so you can update the screen.
@@ -432,6 +423,35 @@ public:
 
 #include "globalincs/vmallocator.h"
 #include "globalincs/safe_strings.h"
+
+// check to see that a passed sting is valid, ie:
+//  - has >0 length
+//  - is not "none"
+//  - is not "<none>"
+inline bool VALID_FNAME(const char* x) {
+	return strlen((x)) && stricmp((x), "none") && stricmp((x), "<none>");
+}
+/**
+ * @brief Checks if the specified string may be a valid file name
+ *
+ * @warning This only does a quick check against an empty string and a few known invalid names. It does not check if the
+ * file actually exists.
+ *
+ * @param x The file name to check
+ * @return @c true if the name is valid, @c false otherwise
+ */
+inline bool VALID_FNAME(const SCP_string& x) {
+	if (x.empty()) {
+		return false;
+	}
+	if (!stricmp(x.c_str(), "none")) {
+		return false;
+	}
+	if (!stricmp(x.c_str(), "<none>")) {
+		return false;
+	}
+	return true;
+}
 
 // Function to generate a stacktrace
 SCP_string dump_stacktrace();

--- a/code/graphics/2d.h
+++ b/code/graphics/2d.h
@@ -47,6 +47,7 @@ class shield_material;
 class movie_material;
 class batched_bitmap_material;
 class nanovg_material;
+class decal_material;
 
 class transform_stack {
 
@@ -157,6 +158,7 @@ enum shader_type {
 	SDR_TYPE_BATCHED_BITMAP,
 	SDR_TYPE_DEFAULT_MATERIAL,
 	SDR_TYPE_NANOVG,
+	SDR_TYPE_DECAL,
 	NUM_SHADER_TYPES
 };
 
@@ -191,10 +193,14 @@ enum shader_type {
 
 #define SDR_FLAG_NANOVG_EDGE_AA		(1<<0)
 
+#define SDR_FLAG_DECAL_USE_NORMAL_MAP (1<<0)
+
 enum class uniform_block_type {
 	Lights = 0,
 	ModelData = 1,
 	NanoVGData = 2,
+	DecalInfo = 3,
+	DecalGlobals = 4,
 
 	NUM_BLOCK_TYPES
 };
@@ -215,6 +221,7 @@ struct vertex_format_data
 		MODEL_ID,
 		RADIUS,
 		UVEC,
+		WORLD_MATRIX,
 	};
 
 	vertex_format format_type;
@@ -277,7 +284,8 @@ typedef enum gr_capability {
 } gr_capability;
 
 enum class gr_property {
-	UNIFORM_BUFFER_OFFSET_ALIGNMENT
+	UNIFORM_BUFFER_OFFSET_ALIGNMENT,
+	UNIFORM_BUFFER_MAX_SIZE,
 };
 
 // stencil buffering stuff
@@ -759,6 +767,9 @@ typedef struct screen {
 	void (*gf_shadow_map_start)(matrix4 *shadow_view_matrix, const matrix *light_matrix);
 	void (*gf_shadow_map_end)();
 
+	void (*gf_start_decal_pass)();
+	void (*gf_stop_decal_pass)();
+
 	// new drawing functions
 	void (*gf_render_model)(model_material* material_info, indexed_vertex_source *vert_source, vertex_buffer* bufferp, size_t texi);
 	void (*gf_render_shield_impact)(shield_material *material_info, primitive_type prim_type, vertex_layout *layout, int buffer_handle, int n_verts);
@@ -768,6 +779,7 @@ typedef struct screen {
 	void (*gf_render_movie)(movie_material* material_info, primitive_type prim_type, vertex_layout* layout, int n_verts, int buffer);
 	void (*gf_render_primitives_batched)(batched_bitmap_material* material_info, primitive_type prim_type, vertex_layout* layout, int offset, int n_verts, int buffer_handle);
 	void (*gf_render_nanovg)(nanovg_material* material_info, primitive_type prim_type, vertex_layout* layout, int offset, int n_verts, int buffer_handle);
+	void (*gf_render_decals)(decal_material* material_info, primitive_type prim_type, vertex_layout* layout, int num_elements, const indexed_vertex_source& buffers);
 
 	bool (*gf_is_capable)(gr_capability capability);
 	bool (*gf_get_property)(gr_property property, void* destination);

--- a/code/graphics/decal_draw_list.cpp
+++ b/code/graphics/decal_draw_list.cpp
@@ -1,0 +1,187 @@
+#include "graphics/decal_draw_list.h"
+
+#include "graphics/util/uniform_structs.h"
+#include "graphics/matrix.h"
+
+#include "render/3d.h"
+#include "tracing/tracing.h"
+
+namespace {
+
+// Discard any fragments where the angle to the direction to greater than 45°
+const float DECAL_ANGLE_CUTOFF = fl_radians(45.f);
+const float DECAL_ANGLE_FADE_START = fl_radians(30.f);
+
+vec3d BOX_VERTS[] = {{{{ -0.5f, -0.5f, -0.5f }}},
+					 {{{ -0.5f, 0.5f,  -0.5f }}},
+					 {{{ 0.5f,  0.5f,  -0.5f }}},
+					 {{{ 0.5f,  -0.5f, -0.5f }}},
+					 {{{ -0.5f, -0.5f, 0.5f }}},
+					 {{{ -0.5f, 0.5f,  0.5f }}},
+					 {{{ 0.5f,  0.5f,  0.5f }}},
+					 {{{ 0.5f,  -0.5f, 0.5f }}}};
+
+uint32_t BOX_FACES[] =
+	{ 7, 3, 4, 3, 0, 4, 2, 6, 1, 6, 5, 1, 7, 6, 3, 6, 2, 3, 0, 1, 4, 1, 5, 4, 6, 7, 4, 5, 6, 4, 3, 2, 0, 2, 1, 0, };
+
+const size_t BOX_NUM_FACES = sizeof(BOX_FACES) / sizeof(BOX_FACES[0]);
+
+int box_vertex_buffer = -1;
+int box_index_buffer = -1;
+
+void init_buffers() {
+	box_vertex_buffer = gr_create_buffer(BufferType::Vertex, BufferUsageHint::Static);
+	gr_update_buffer_data(box_vertex_buffer, sizeof(BOX_VERTS), BOX_VERTS);
+
+	box_index_buffer = gr_create_buffer(BufferType::Index, BufferUsageHint::Static);
+	gr_update_buffer_data(box_index_buffer, sizeof(BOX_FACES), BOX_FACES);
+}
+
+bool check_box_in_view(const matrix4& transform) {
+	for (auto& point : BOX_VERTS) {
+		vec3d pt;
+		vm_vec_transform(&pt, &point, &transform, true);
+		vec3d tmp;
+		if (!g3_rotate_vector(&tmp, &pt)) {
+			// This point lies in the view cone so we need to render it
+			return true;
+		}
+	}
+
+	return false;
+}
+
+}
+
+namespace graphics {
+
+/**
+ * @brief Sorts Decals so that as many decals can be batched together as possible
+ *
+ * This uses the bitmaps in the definitions to determine if two decals can be rendered at the same time. Since we use
+ * texture arrays we can use the base frame for batching which increases the number of draw calls that can be batched together.
+ *
+ * @param left
+ * @param right
+ * @return
+ */
+bool decal_draw_list::sort_draws(const decal_draw_info& left, const decal_draw_info& right) {
+	auto left_diffuse_base = bm_get_base_frame(left.draw_mat.get_texture_map(TM_BASE_TYPE));
+	auto right_diffuse_base = bm_get_base_frame(right.draw_mat.get_texture_map(TM_BASE_TYPE));
+
+	if (left_diffuse_base != right_diffuse_base) {
+		return left_diffuse_base < right_diffuse_base;
+	}
+
+	auto left_normal_base = bm_get_base_frame(left.draw_mat.get_texture_map(TM_NORMAL_TYPE));
+	auto right_normal_base = bm_get_base_frame(left.draw_mat.get_texture_map(TM_NORMAL_TYPE));
+
+	return left_normal_base < right_normal_base;
+}
+void decal_draw_list::globalInit() {
+	init_buffers();
+
+	gr_maybe_create_shader(SDR_TYPE_DECAL, 0);
+	gr_maybe_create_shader(SDR_TYPE_DECAL, SDR_FLAG_DECAL_USE_NORMAL_MAP);
+}
+void decal_draw_list::globalShutdown() {
+	gr_delete_buffer(box_vertex_buffer);
+	gr_delete_buffer(box_index_buffer);
+}
+
+decal_draw_list::decal_draw_list() {
+	_buffer = gr_get_uniform_buffer(uniform_block_type::DecalInfo);
+	auto& aligner = _buffer->aligner();
+
+	// Initialize header data
+	auto header = aligner.getHeader<graphics::decal_globals>();
+	matrix4 invView;
+	vm_inverse_matrix4(&gr_view_matrix, &invView);
+
+	header->viewMatrix = gr_view_matrix;
+	header->projMatrix = gr_projection_matrix;
+	header->invViewMatrix = invView;
+	vm_inverse_matrix4(&gr_projection_matrix, &header->invProjMatrix);
+
+	header->viewportSize.x = (float) gr_screen.max_w;
+	header->viewportSize.y = (float) gr_screen.max_h;
+}
+decal_draw_list::~decal_draw_list() {
+	_buffer->finished();
+}
+void decal_draw_list::render() {
+	GR_DEBUG_SCOPE("Render decals");
+	TRACE_SCOPE(tracing::RenderDecals);
+
+	_buffer->submitData();
+
+	std::sort(_draws.begin(), _draws.end(), decal_draw_list::sort_draws);
+
+	vertex_layout layout;
+	layout.add_vertex_component(vertex_format_data::POSITION3, sizeof(vec3d), 0);
+
+	indexed_vertex_source source;
+	source.Vbuffer_handle = box_vertex_buffer;
+	source.Ibuffer_handle = box_index_buffer;
+
+	// Bind the global data only once
+	gr_bind_uniform_buffer(uniform_block_type::DecalGlobals,
+						   0,
+						   sizeof(graphics::decal_globals),
+						   _buffer->bufferHandle());
+	gr_screen.gf_start_decal_pass();
+
+	for (auto& draw : _draws) {
+		GR_DEBUG_SCOPE("Draw single decal");
+		TRACE_SCOPE(tracing::RenderSingleDecal);
+
+		gr_bind_uniform_buffer(uniform_block_type::DecalInfo,
+							   draw.uniform_offset,
+							   sizeof(graphics::decal_info),
+							   _buffer->bufferHandle());
+
+		gr_screen.gf_render_decals(&draw.draw_mat, PRIM_TYPE_TRIS, &layout, BOX_NUM_FACES, source);
+	}
+
+	gr_screen.gf_stop_decal_pass();
+}
+void decal_draw_list::add_decal(int diffuse_bitmap,
+								int normal_bitmap,
+								float decal_timer,
+								const matrix4& transform,
+								float base_alpha) {
+	if (!check_box_in_view(transform)) {
+		// The decal box is not in view so we don't need to render it
+		return;
+	}
+
+	auto& aligner = _buffer->aligner();
+
+	auto info = aligner.addTypedElement<graphics::decal_info>();
+	info->model_matrix = transform;
+	// This is currently a constant but in the future this may be configurable by the decals table
+	info->normal_angle_cutoff = DECAL_ANGLE_CUTOFF;
+	info->angle_fade_start = DECAL_ANGLE_FADE_START;
+	info->alpha_scale = base_alpha;
+
+	matrix transform_rot;
+	vm_matrix4_get_orientation(&transform_rot, &transform);
+
+	// The decal shader works in view-space so the direction also has to be transformed into that space
+	vm_vec_transform(&info->decal_direction, &transform_rot.vec.fvec, &gr_view_matrix, false);
+
+	vm_inverse_matrix4(&info->model_matrix, &info->inv_model_matrix);
+
+	info->diffuse_index = bm_get_array_index(diffuse_bitmap);
+	info->normal_index = bm_get_array_index(normal_bitmap);
+
+	decal_draw_info current_draw;
+	current_draw.uniform_offset = aligner.getCurrentOffset();
+
+	material_set_decal(&current_draw.draw_mat, bm_get_base_frame(diffuse_bitmap), bm_get_base_frame(normal_bitmap));
+	info->blend_mode = current_draw.draw_mat.get_blend_mode() == ALPHA_BLEND_ADDITIVE ? 1 : 0;
+
+	_draws.push_back(current_draw);
+}
+
+}

--- a/code/graphics/decal_draw_list.h
+++ b/code/graphics/decal_draw_list.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include "globalincs/pstypes.h"
+
+#include "graphics/material.h"
+#include "graphics/util/UniformBuffer.h"
+
+namespace graphics {
+
+class decal_draw_list {
+	struct decal_draw_info {
+		decal_material draw_mat;
+
+		size_t uniform_offset;
+	};
+	SCP_vector<decal_draw_info> _draws;
+
+	util::UniformBuffer* _buffer = nullptr;
+
+	static bool sort_draws(const decal_draw_info& left, const decal_draw_info& right);
+
+ public:
+	decal_draw_list();
+	~decal_draw_list();
+
+	decal_draw_list(const decal_draw_list&) = delete;
+	decal_draw_list& operator=(const decal_draw_list&) = delete;
+
+	void add_decal(int diffuse_bitmap,
+				   int normal_bitmap,
+				   float decal_timer,
+				   const matrix4& transform,
+				   float base_alpha);
+
+	void render();
+
+	static void globalInit();
+
+	static void globalShutdown();
+};
+
+}

--- a/code/graphics/material.cpp
+++ b/code/graphics/material.cpp
@@ -158,6 +158,18 @@ void material_set_nanovg(nanovg_material* mat_info, int base_tex) {
 	mat_info->set_back_stencil_op(StencilOperation::Keep, StencilOperation::Keep, StencilOperation::Keep);
 }
 
+void material_set_decal(material* mat_info, int diffuse_tex, int normal_tex) {
+	mat_info->set_depth_mode(ZBUFFER_TYPE_READ);
+
+	// TODO: This blend mode is not correct for normal blending!! If decal normal mapping is added then the normal buffer
+	// needs to use a different blending equation.
+	mat_info->set_blend_mode(material_determine_blend_mode(diffuse_tex, true));
+
+	mat_info->set_texture_map(TM_BASE_TYPE, diffuse_tex);
+	mat_info->set_texture_map(TM_NORMAL_TYPE, normal_tex);
+	mat_info->set_cull_mode(false);
+}
+
 material::material():
 Sdr_type(SDR_TYPE_DEFAULT_MATERIAL),
 Tex_type(TEX_TYPE_NORMAL),
@@ -835,4 +847,18 @@ batched_bitmap_material::batched_bitmap_material() {
 
 nanovg_material::nanovg_material() {
 	set_shader_type(SDR_TYPE_NANOVG);
+}
+
+decal_material::decal_material() {
+	set_shader_type(SDR_TYPE_DECAL);
+}
+uint decal_material::get_shader_flags() const {
+	uint flags = 0;
+
+	if (get_texture_map(TM_NORMAL_TYPE) == -1) {
+		// If we don't write to the normal map then we can use the existing normal map for better normal accuracy
+		flags |= SDR_FLAG_DECAL_USE_NORMAL_MAP;
+	}
+
+	return flags;
 }

--- a/code/graphics/material.h
+++ b/code/graphics/material.h
@@ -307,7 +307,16 @@ class nanovg_material : public material {
 	nanovg_material();
 };
 
+class decal_material : public material
+{
+ public:
+	decal_material();
+
+	uint get_shader_flags() const override;
+};
+
 gr_alpha_blend material_determine_blend_mode(int base_bitmap, bool is_transparent);
+
 gr_zbuffer_type material_determine_depth_mode(bool depth_testing, bool is_transparent);
 
 void material_set_interface(material* mat_info, int texture, bool blended, float alpha);
@@ -320,5 +329,6 @@ void material_set_distortion(distortion_material *mat_info, int texture, bool th
 void material_set_movie(movie_material *mat_info, int y_bm, int u_bm, int v_bm);
 void material_set_batched_bitmap(batched_bitmap_material* mat_info, int base_tex, float alpha, float color_scale);
 void material_set_nanovg(nanovg_material* mat_info, int base_tex);
+void material_set_decal(material* mat_info, int diffuse_tex, int normal_tex);
 
 #endif

--- a/code/graphics/opengl/gropengl.cpp
+++ b/code/graphics/opengl/gropengl.cpp
@@ -1173,6 +1173,9 @@ void opengl_setup_function_pointers()
 
 	gr_screen.gf_clear_states	= gr_opengl_clear_states;
 
+	gr_screen.gf_start_decal_pass = gr_opengl_start_decal_pass;
+	gr_screen.gf_stop_decal_pass = gr_opengl_stop_decal_pass;
+
 	gr_screen.gf_render_model = gr_opengl_render_model;
 	gr_screen.gf_render_primitives= gr_opengl_render_primitives;
 	gr_screen.gf_render_primitives_particle	= gr_opengl_render_primitives_particle;
@@ -1180,6 +1183,7 @@ void opengl_setup_function_pointers()
 	gr_screen.gf_render_primitives_distortion = gr_opengl_render_primitives_distortion;
 	gr_screen.gf_render_movie = gr_opengl_render_movie;
 	gr_screen.gf_render_nanovg = gr_opengl_render_nanovg;
+	gr_screen.gf_render_decals = gr_opengl_render_decals;
 
 	gr_screen.gf_is_capable = gr_opengl_is_capable;
 	gr_screen.gf_get_property = gr_opengl_get_property;
@@ -1582,6 +1586,9 @@ bool gr_opengl_get_property(gr_property prop, void* dest) {
 	switch(prop) {
 		case gr_property::UNIFORM_BUFFER_OFFSET_ALIGNMENT:
 			*((int*)dest) = GL_state.Constants.GetUniformBufferOffsetAlignment();
+			return true;
+		case gr_property::UNIFORM_BUFFER_MAX_SIZE:
+			*((int*)dest) = GL_state.Constants.GetMaxUniformBlockSize();
 			return true;
 		default:
 			return false;

--- a/code/graphics/opengl/gropengldeferred.cpp
+++ b/code/graphics/opengl/gropengldeferred.cpp
@@ -503,7 +503,6 @@ void gr_opengl_deferred_light_sphere_init(int rings, int segments) // Generate a
 		vm_free(Indices);
 		Indices = NULL;
 	}
-
 }
 
 void opengl_draw_sphere()

--- a/code/graphics/opengl/gropengldraw.cpp
+++ b/code/graphics/opengl/gropengldraw.cpp
@@ -825,3 +825,34 @@ void opengl_draw_textured_quad(GLfloat x1,
 
 	opengl_render_primitives_immediate(PRIM_TYPE_TRISTRIP, &vert_def, 4, glVertices, sizeof(GLfloat) * 4 * 4);
 }
+
+void gr_opengl_render_decals(decal_material* material_info,
+							 primitive_type prim_type,
+							 vertex_layout* layout,
+							 int num_elements,
+							 const indexed_vertex_source& binding) {
+	opengl_tnl_set_material_decal(material_info);
+
+	opengl_bind_vertex_layout(*layout,
+							  opengl_buffer_get_id(GL_ARRAY_BUFFER, binding.Vbuffer_handle),
+							  opengl_buffer_get_id(GL_ELEMENT_ARRAY_BUFFER, binding.Ibuffer_handle));
+
+	glDrawElements(opengl_primitive_type(prim_type), num_elements, GL_UNSIGNED_INT, nullptr);
+}
+
+void gr_opengl_start_decal_pass() {
+	// For now we only render into the diffuse channel of the framebuffer
+	GLenum buffers[] = {
+		GL_COLOR_ATTACHMENT0
+	};
+	glDrawBuffers(1, buffers);
+}
+void gr_opengl_stop_decal_pass() {
+	GLenum buffers2[] = {
+		GL_COLOR_ATTACHMENT0,
+		GL_COLOR_ATTACHMENT1,
+		GL_COLOR_ATTACHMENT2,
+		GL_COLOR_ATTACHMENT3
+	};
+	glDrawBuffers(4, buffers2);
+}

--- a/code/graphics/opengl/gropengldraw.h
+++ b/code/graphics/opengl/gropengldraw.h
@@ -56,11 +56,15 @@ void gr_opengl_render_primitives_batched(batched_bitmap_material* material_info,
 void gr_opengl_render_primitives_distortion(distortion_material* material_info, primitive_type prim_type, vertex_layout* layout, int offset, int n_verts, int buffer_handle);
 void gr_opengl_render_movie(movie_material* material_info, primitive_type prim_type, vertex_layout* layout, int n_verts, int buffer);
 void gr_opengl_render_nanovg(nanovg_material* material_info, primitive_type prim_type, vertex_layout* layout, int offset, int n_verts, int buffer_handle);
+void gr_opengl_render_decals(decal_material* material_info, primitive_type prim_type, vertex_layout* layout, int num_elements, const indexed_vertex_source& binding);
 
 void opengl_draw_textured_quad(GLfloat x1, GLfloat y1, GLfloat u1, GLfloat v1,
 							   GLfloat x2, GLfloat y2, GLfloat u2, GLfloat v2 );
 
 inline GLenum opengl_primitive_type(primitive_type prim_type);
+
+void gr_opengl_start_decal_pass();
+void gr_opengl_stop_decal_pass();
 
 extern int Scene_texture_initialized;
 

--- a/code/graphics/opengl/gropenglshader.cpp
+++ b/code/graphics/opengl/gropenglshader.cpp
@@ -42,6 +42,7 @@ SCP_vector<opengl_vert_attrib> GL_vertex_attrib_info =
 		{ opengl_vert_attrib::MODEL_ID,		"vertModelID",		{{{ 0.0f, 0.0f, 0.0f, 0.0f }}} },
 		{ opengl_vert_attrib::RADIUS,		"vertRadius",		{{{ 1.0f, 0.0f, 0.0f, 0.0f }}} },
 		{ opengl_vert_attrib::UVEC,			"vertUvec",			{{{ 0.0f, 1.0f, 0.0f, 0.0f }}} },
+		{ opengl_vert_attrib::WORLD_MATRIX,	"vertWorldMatrix",	{{{ 1.0f, 0.0f, 0.0f, 0.0f }}} },
 	};
 
 struct opengl_uniform_block_binding {
@@ -53,6 +54,8 @@ opengl_uniform_block_binding GL_uniform_blocks[] = {
 	{ uniform_block_type::Lights, "lightData" },
 	{ uniform_block_type::ModelData, "modelData" },
 	{ uniform_block_type::NanoVGData, "NanoVGUniformData" },
+	{ uniform_block_type::DecalInfo, "decalInfoData" },
+	{ uniform_block_type::DecalGlobals, "decalGlobalData" },
 };
 
 /**
@@ -117,6 +120,8 @@ static opengl_shader_type_t GL_shader_types[] = {
 	{ SDR_TYPE_NANOVG, "nanovg-v.sdr", "nanovg-f.sdr", nullptr,
 		{ opengl_vert_attrib::POSITION, opengl_vert_attrib::TEXCOORD }, "NanoVG shader" },
 
+	{ SDR_TYPE_DECAL, "decal-v.sdr", "decal-f.sdr", nullptr,
+		{ opengl_vert_attrib::POSITION, opengl_vert_attrib::WORLD_MATRIX }, "Decal rendering" },
 };
 
 /**
@@ -222,7 +227,11 @@ static opengl_shader_variant_t GL_shader_variants[] = {
 
 	{ SDR_TYPE_NANOVG, false, SDR_FLAG_NANOVG_EDGE_AA, "EDGE_AA",
 		{  },
-		"NanoVG edge anti-alias" }
+		"NanoVG edge anti-alias" },
+
+	{ SDR_TYPE_DECAL, false, SDR_FLAG_DECAL_USE_NORMAL_MAP, "USE_NORMAL_MAP",
+		{  },
+		"Decal use scene normal map" },
 };
 
 static const int GL_num_shader_variants = sizeof(GL_shader_variants) / sizeof(opengl_shader_variant_t);

--- a/code/graphics/opengl/gropenglshader.h
+++ b/code/graphics/opengl/gropenglshader.h
@@ -39,7 +39,9 @@ struct opengl_vert_attrib {
 		TANGENT,
 		MODEL_ID,
 		RADIUS,
-		UVEC
+		UVEC,
+		WORLD_MATRIX,
+		NUM_ATTRIBS,
 	};
 
 	attrib_id attribute_id;

--- a/code/graphics/opengl/gropengltnl.cpp
+++ b/code/graphics/opengl/gropengltnl.cpp
@@ -287,7 +287,7 @@ void gr_opengl_update_buffer_data_offset(int handle, size_t offset, size_t size,
 	opengl_buffer_object &buffer_obj = GL_buffer_objects[handle];
 
 	opengl_bind_buffer_object(handle);
-	
+
 	glBufferSubData(buffer_obj.type, offset, size, data);
 }
 
@@ -428,7 +428,7 @@ void opengl_tnl_init()
 		GL_state.Texture.SetActiveUnit(0);
 		GL_state.Texture.SetTarget(GL_TEXTURE_2D_ARRAY);
 		GL_state.Texture.Enable(Shadow_map_depth_texture);
-		
+
 		glTexParameteri(GL_TEXTURE_2D_ARRAY, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
 		glTexParameteri(GL_TEXTURE_2D_ARRAY, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
 		glTexParameteri(GL_TEXTURE_2D_ARRAY, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
@@ -617,7 +617,7 @@ void gr_opengl_shadow_map_start(matrix4 *shadow_view_matrix, const matrix *light
 	glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 
 	gr_set_lighting(false,false);
-	
+
 	Rendering_to_shadow_map = true;
 	Glowpoint_override_save = Glowpoint_override;
 	Glowpoint_override = true;
@@ -744,7 +744,7 @@ void opengl_tnl_set_model_material(model_material *material_info)
 	if ( GL_state.CullFace() ) {
 		GL_state.FrontFaceValue(GL_CW);
 	}
-	
+
 	gr_set_center_alpha(material_info->get_center_alpha());
 
 	Assert( Current_shader->shader == SDR_TYPE_MODEL );
@@ -762,7 +762,6 @@ void opengl_tnl_set_model_material(model_material *material_info)
 		Current_shader->program->Uniforms.setUniformi("sBasemap", render_pass);
 
 		gr_opengl_tcache_set(material_info->get_texture_map(TM_BASE_TYPE), TCACHE_TYPE_NORMAL, &u_scale, &v_scale, &array_index, render_pass);
-		
 		++render_pass;
 	}
 
@@ -782,7 +781,6 @@ void opengl_tnl_set_model_material(model_material *material_info)
 		} else {
 			gr_opengl_tcache_set(material_info->get_texture_map(TM_SPECULAR_TYPE), TCACHE_TYPE_NORMAL, &u_scale, &v_scale, &array_index, render_pass);
 		}
-		
 		++render_pass;
 
 		if ( Current_shader->flags & SDR_FLAG_MODEL_ENV_MAP ) {
@@ -968,6 +966,26 @@ void opengl_tnl_set_material_nanovg(nanovg_material* material_info) {
 	opengl_tnl_set_material(material_info, true);
 
 	Current_shader->program->Uniforms.setUniformi("nvg_tex", 0);
+}
+void opengl_tnl_set_material_decal(decal_material* material_info) {
+	opengl_tnl_set_material(material_info, false);
+
+	float u_scale, v_scale;
+	uint32_t array_index;
+
+	gr_opengl_tcache_set(material_info->get_texture_map(TM_BASE_TYPE), material_info->get_texture_type(), &u_scale, &v_scale, &array_index, 0);
+	Current_shader->program->Uniforms.setUniformi("diffuseMap", 0);
+
+	gr_opengl_tcache_set(material_info->get_texture_map(TM_NORMAL_TYPE), material_info->get_texture_type(), &u_scale, &v_scale, &array_index, 1);
+	Current_shader->program->Uniforms.setUniformi("normalMap", 1);
+
+	GL_state.Texture.Enable(2, GL_TEXTURE_2D, Scene_depth_texture);
+	Current_shader->program->Uniforms.setUniformi("gDepthBuffer", 2);
+
+	if (Current_shader->flags & SDR_FLAG_DECAL_USE_NORMAL_MAP) {
+		GL_state.Texture.Enable(3, GL_TEXTURE_2D, Scene_normal_texture);
+		Current_shader->program->Uniforms.setUniformi("gNormalBuffer", 3);
+	}
 }
 
 void gr_opengl_set_viewport(int x, int y, int width, int height) {

--- a/code/graphics/opengl/gropengltnl.h
+++ b/code/graphics/opengl/gropengltnl.h
@@ -71,6 +71,7 @@ void opengl_tnl_set_material_particle(particle_material * material_info);
 void opengl_tnl_set_material_movie(movie_material* material_info);
 void opengl_tnl_set_material_batched(batched_bitmap_material * material_info);
 void opengl_tnl_set_material_nanovg(nanovg_material * material_info);
+void opengl_tnl_set_material_decal(decal_material * material_info);
 
 void opengl_tnl_set_model_material(model_material *material_info);
 

--- a/code/graphics/util/UniformAligner.cpp
+++ b/code/graphics/util/UniformAligner.cpp
@@ -29,10 +29,10 @@ UniformAligner::UniformAligner(size_t dataSize, size_t headerSize) :
 	resize(0);
 }
 void UniformAligner::setAlignment(size_t align) {
+	_requiredAlignment = align;
+
 	// Clear the buffer since changing the alignment invalidates the stored data
 	clear();
-
-	_requiredAlignment = align;
 }
 void UniformAligner::resize(size_t num_elements) {
 	size_t final_size =

--- a/code/graphics/util/UniformAligner.h
+++ b/code/graphics/util/UniformAligner.h
@@ -44,7 +44,7 @@ class UniformAligner {
 
 	template<typename THeader>
 	THeader* getHeader() {
-		static_assert(sizeof(THeader) == _headerSize, "Header size does not match requested header type!");
+		Assertion(sizeof(THeader) == _headerSize, "Header size does not match requested header type!");
 
 		return reinterpret_cast<THeader*>(_buffer.data());
 	}

--- a/code/graphics/util/UniformBufferManager.cpp
+++ b/code/graphics/util/UniformBufferManager.cpp
@@ -13,6 +13,8 @@ size_t getElementSize(uniform_block_type type) {
 		return sizeof(graphics::model_uniform_data);
 	case uniform_block_type::NanoVGData:
 		return sizeof(graphics::nanovg_draw_data);
+	case uniform_block_type::DecalInfo:
+		return sizeof(graphics::decal_info);
 	case uniform_block_type::NUM_BLOCK_TYPES:
 	default:
 		Assertion(false, "Invalid block type encountered!");
@@ -23,10 +25,11 @@ size_t getElementSize(uniform_block_type type) {
 size_t getHeaderSize(uniform_block_type type) {
 	switch (type) {
 	case uniform_block_type::Lights:
-		return 0;
 	case uniform_block_type::ModelData:
 	case uniform_block_type::NanoVGData:
 		return 0;
+	case uniform_block_type::DecalInfo:
+		return sizeof(graphics::decal_globals);
 	case uniform_block_type::NUM_BLOCK_TYPES:
 	default:
 		Assertion(false, "Invalid block type encountered!");

--- a/code/graphics/util/uniform_structs.h
+++ b/code/graphics/util/uniform_structs.h
@@ -152,4 +152,32 @@ struct nanovg_draw_data {
 	float pad3;
 };
 
+struct decal_globals {
+	matrix4 viewMatrix;
+	matrix4 projMatrix;
+	matrix4 invViewMatrix;
+	matrix4 invProjMatrix;
+
+	vec2d viewportSize;
+
+	float pad[2];
+};
+
+struct decal_info {
+	matrix4 model_matrix;
+	matrix4 inv_model_matrix;
+
+	vec3d decal_direction;
+	float normal_angle_cutoff;
+
+	int diffuse_index;
+	int normal_index;
+	float angle_fade_start;
+	float alpha_scale;
+
+	int blend_mode;
+
+	float pad[3];
+};
+
 }

--- a/code/math/vecmat.cpp
+++ b/code/math/vecmat.cpp
@@ -2753,7 +2753,7 @@ void vm_matrix4_set_transform(matrix4 *out, matrix *m, vec3d *v)
 	out->a2d[3][2] = v->a1d[2];
 }
 
-void vm_matrix4_get_orientation(matrix *out, matrix4 *m)
+void vm_matrix4_get_orientation(matrix *out, const matrix4 *m)
 {
 	out->a2d[0][0] = m->a2d[0][0];
 	out->a2d[0][1] = m->a2d[0][1];
@@ -2803,7 +2803,7 @@ float vm_vec4_dot4(float x, float y, float z, float w, const vec4 *v)
 	return (x * v->xyzw.x) + (y * v->xyzw.y) + (z * v->xyzw.z) + (w * v->xyzw.w);
 }
 
-void vm_vec_transform(vec4 *dest, vec4 *src, matrix4 *m)
+void vm_vec_transform(vec4 *dest, const vec4 *src, const matrix4 *m)
 {
 	dest->xyzw.x = (m->vec.rvec.xyzw.x * src->xyzw.x) + (m->vec.uvec.xyzw.x * src->xyzw.y) + (m->vec.fvec.xyzw.x * src->xyzw.z) + (m->vec.pos.xyzw.x * src->xyzw.w);
 	dest->xyzw.y = (m->vec.rvec.xyzw.y * src->xyzw.x) + (m->vec.uvec.xyzw.y * src->xyzw.y) + (m->vec.fvec.xyzw.y * src->xyzw.z) + (m->vec.pos.xyzw.y * src->xyzw.w);
@@ -2811,7 +2811,7 @@ void vm_vec_transform(vec4 *dest, vec4 *src, matrix4 *m)
 	dest->xyzw.w = (m->vec.rvec.xyzw.w * src->xyzw.x) + (m->vec.uvec.xyzw.w * src->xyzw.y) + (m->vec.fvec.xyzw.w * src->xyzw.z) + (m->vec.pos.xyzw.w * src->xyzw.w);
 }
 
-void vm_vec_transform(vec3d *dest, vec3d *src, matrix4 *m, bool pos)
+void vm_vec_transform(vec3d *dest, const vec3d *src, const matrix4 *m, bool pos)
 {
 	vec4 temp_src, temp_dest;
 

--- a/code/math/vecmat.h
+++ b/code/math/vecmat.h
@@ -254,7 +254,7 @@ matrix *vm_vec_ang_2_matrix(matrix *m, const vec3d *v, float a);
  *
  * @sa vm_vector_2_matrix_norm
  */
-matrix *vm_vector_2_matrix(matrix *m, const vec3d *fvec, const vec3d *uvec, const vec3d *rvec);
+matrix *vm_vector_2_matrix(matrix *m, const vec3d *fvec, const vec3d *uvec = nullptr, const vec3d *rvec = nullptr);
 
 
 /**
@@ -469,12 +469,12 @@ void vm_matrix4_set_identity(matrix4 *out);
 
 void vm_matrix4_set_transform(matrix4 *out, matrix *m, vec3d *v);
 
-void vm_matrix4_get_orientation(matrix *out, matrix4 *m);
+void vm_matrix4_get_orientation(matrix *out, const matrix4 *m);
 
 void vm_matrix4_get_offset(vec3d *out, matrix4 *m);
 
-void vm_vec_transform(vec4 *dest, vec4 *src, matrix4 *m);
-void vm_vec_transform(vec3d *dest, vec3d *src, matrix4 *m, bool pos = true);
+void vm_vec_transform(vec4 *dest, const vec4 *src, const matrix4 *m);
+void vm_vec_transform(vec3d *dest, const vec3d *src, const matrix4 *m, bool pos = true);
 
 void vm_matrix4_x_matrix4(matrix4 *dest, const matrix4 *src0, const matrix4 *src1);
 

--- a/code/object/collideshipweapon.cpp
+++ b/code/object/collideshipweapon.cpp
@@ -119,6 +119,13 @@ void ship_weapon_do_hit_stuff(object *pship_obj, object *weapon_obj, vec3d *worl
 		ship_apply_whack( &force, hitpos, pship_obj );
 	}
 
+	// Add impact decal
+	if (quadrant_num == -1 && wip->impact_decal.definition_handle >= 0) {
+		matrix decal_orient;
+		vm_vector_2_matrix_norm(&decal_orient, &hit_dir); // hit_dir is already normalized so we can use the more efficient function
+
+		decals::addDecal(wip->impact_decal, pship_obj, submodel_num, *hitpos, decal_orient);
+	}
 }
 
 extern int Framecount;

--- a/code/object/objectsort.cpp
+++ b/code/object/objectsort.cpp
@@ -28,6 +28,7 @@
 #include "ship/ship.h"
 #include "tracing/tracing.h"
 #include "weapon/weapon.h"
+#include "decals/decals.h"
 
 
 class sorted_obj
@@ -387,6 +388,8 @@ void obj_render_queue_all()
 
 	gr_clear_states();
 	gr_set_fill_mode(GR_FILL_MODE_SOLID);
+
+	decals::renderAll();
 
  	gr_deferred_lighting_end();
 	gr_deferred_lighting_finish();

--- a/code/source_groups.cmake
+++ b/code/source_groups.cmake
@@ -131,6 +131,10 @@ set (file_root_debugconsole
 	debugconsole/consoleparse.h
 )
 
+set(file_root_decals
+	decals/decals.cpp
+	decals/decals.h
+)
 
 SET(file_root_def_files
 	def_files/def_files.h
@@ -156,6 +160,8 @@ SET(file_root_def_files_files
 	def_files/blur-f.sdr
 	def_files/brightpass-f.sdr
 	def_files/controlconfigdefaults.tbl
+	def_files/decal-f.sdr
+	def_files/decal-v.sdr
 	def_files/default-material-f.sdr
 	def_files/deferred-clear-f.sdr
 	def_files/deferred-clear-v.sdr
@@ -298,6 +304,8 @@ set(file_root_globalincs_toolchain
 set (file_root_graphics
 	graphics/2d.cpp
 	graphics/2d.h
+	graphics/decal_draw_list.cpp
+	graphics/decal_draw_list.h
 	graphics/grbatch.cpp
 	graphics/grbatch.h
 	graphics/grinternal.h
@@ -1257,6 +1265,7 @@ source_group("Cutscene\\Player"                   FILES ${file_root_cutscene_pla
 source_group("ddsutils"                           FILES ${file_root_ddsutils})
 source_group("Debris"                             FILES ${file_root_debris})
 source_group("DebugConsole"                       FILES ${file_root_debugconsole})
+source_group("Decals"                             FILES ${file_root_decals})
 source_group("Default files"                      FILES ${file_root_def_files})
 source_group("Default files\\Files"               FILES ${file_root_def_files_files})
 source_group("ExceptionHandler"                   FILES ${file_root_exceptionhandler})
@@ -1352,6 +1361,7 @@ set (file_root
 	${file_root_ddsutils}
 	${file_root_debris}
 	${file_root_debugconsole}
+	${file_root_decals}
 	${file_root_def_files}
 	${file_root_def_files_files}
 	${file_root_exceptionhandler}

--- a/code/tracing/categories.cpp
+++ b/code/tracing/categories.cpp
@@ -116,4 +116,7 @@ Category PageInStop("Finish page in", false);
 Category PageInSingleBitmap("Page in single bitmap", false);
 Category ShipPageIn("Ship page in", false);
 Category WeaponPageIn("Weapon page in", false);
+
+Category RenderDecals("Render all decals", true);
+Category RenderSingleDecal("Render single decal", true);
 }

--- a/code/tracing/categories.h
+++ b/code/tracing/categories.h
@@ -130,6 +130,8 @@ extern Category PageInSingleBitmap;
 extern Category ShipPageIn;
 extern Category WeaponPageIn;
 
+extern Category RenderDecals;
+extern Category RenderSingleDecal;
 }
 
 #endif // _TRACING_CATEGORIES_H

--- a/code/utils/RandomRange.h
+++ b/code/utils/RandomRange.h
@@ -96,7 +96,7 @@ class RandomRange {
 		return m_distribution(m_generator);
 	}
 
-	ValueType min() {
+	ValueType min() const {
 		return m_minValue;
 	}
 

--- a/code/weapon/weapon.h
+++ b/code/weapon/weapon.h
@@ -21,6 +21,7 @@
 #include "weapon/trails.h"
 #include "particle/ParticleManager.h"
 #include "weapon/weapon_flags.h"
+#include "decals/decals.h"
 
 class object;
 class ship_subsys;
@@ -457,6 +458,8 @@ typedef struct weapon_info {
 	int hud_locked_snd; // Sound played when this weapon locked onto a target
 	int hud_in_flight_snd; // Sound played while the weapon is in flight
 	InFlightSoundType in_flight_play_type; // The status when the sound should be played
+
+	decals::creation_info impact_decal;
 
 public:
 	weapon_info();

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -2600,6 +2600,10 @@ int parse_weapon(int subtype, bool replace, const char *filename)
 		}
 	}
 
+	// New decal system parsing
+	if (optional_string("$Impact Decal:")) {
+		decals::parseDecalReference(wip->impact_decal, create_if_not_found);
+	}
 
 	if (optional_string("$Transparent:")) {
         wip->wi_flags.set(Weapon::Info_Flags::Transparent);
@@ -3338,6 +3342,8 @@ void weapon_load_bitmaps(int weapon_index)
 			generic_anim_load(&wip->thruster_glow);
 		}
 	}
+
+	decals::loadBitmaps(wip->impact_decal);
 
 	// if this weapon isn't already marked as used, then mark it as such now
 	// (this should really only happen if the player is cheating)
@@ -6456,6 +6462,8 @@ void weapons_page_in()
 
 		bm_page_in_texture(wip->thruster_flame.first_frame);
 		bm_page_in_texture(wip->thruster_glow.first_frame);
+
+		decals::pageInDecal(wip->impact_decal);
 	}
 }
 
@@ -6641,6 +6649,9 @@ bool weapon_page_in(int weapon_type)
 
 		bm_page_in_texture(wip->thruster_flame.first_frame);
 		bm_page_in_texture(wip->thruster_glow.first_frame);
+
+		// Page in decal bitmaps
+		decals::pageInDecal(wip->impact_decal);
 
 		used_weapons[page_in_weapons.at(k)]++;	// Ensures weapon can be counted as used
 	}
@@ -7717,4 +7728,7 @@ void weapon_info::reset()
 	this->hud_locked_snd = -1;
 	this->hud_tracking_snd = -1;
 	this->hud_in_flight_snd = -1;
+
+	// Reset using default constructor
+	this->impact_decal = decals::creation_info();
 }

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -167,6 +167,7 @@
 #include "stats/stats.h"
 #include "tracing/tracing.h"
 #include "weapon/beam.h"
+#include "decals/decals.h"
 #include "weapon/emp.h"
 #include "weapon/flak.h"
 #include "weapon/muzzleflash.h"
@@ -1348,7 +1349,10 @@ void game_post_level_init()
 	// While trying to track down the nebula bug I encountered a cool effect -
 	// comment this out to fly a mission in a void. Maybe we should develop this
 	// into a full effect or something, because it is seriously cool.
-	neb2_post_level_init();		
+	neb2_post_level_init();
+
+	// Initialize decal system
+	decals::initializeMission();
 
 #ifndef NDEBUG
 	game_event_debug_init();
@@ -1948,6 +1952,8 @@ void game_init()
 	// initialize alpha colors
 	// CommanderDJ: try with colors.tbl first, then use the old way if that doesn't work
 	alpha_colors_init();
+
+	decals::initialize();
 
 	obj_init();	
 	mflash_game_init();	
@@ -6863,6 +6869,8 @@ void game_shutdown(void)
 	weapon_close();					// free any memory that was allocated for the weapons
 	ship_close();					// free any memory that was allocated for the ships
 	hud_free_scrollback_list();// free space allocated to store hud messages in hud scrollback
+
+	decals::shutdown();
 
 	io::mouse::CursorManager::shutdown();
 


### PR DESCRIPTION
This allows to render screen space decals into the deferred lighting
buffers no matter how complex the underlying geometry is.

Currently there is only limited support for using this in the engine.
Only weapon impact decals are supported at the moment for testing
purposes.