### PR TITLE
Fix gloss-dependent blurred reflections

### DIFF
--- a/code/graphics/opengl/gropengltexture.cpp
+++ b/code/graphics/opengl/gropengltexture.cpp
@@ -825,6 +825,13 @@ void opengl_tex_array_storage(GLenum target, GLint levels, GLenum format, GLint 
 
 		if (GLAD_GL_ARB_texture_storage) {
 			// This version has a better way of specifying the texture storage
+
+			if ( levels == 1 ) {
+				// looks like we only have one mipmap for this cube map
+				// allocate additional storage for the mip maps we're going to later generate using glGenerateMipMap
+				levels = get_num_mipmap_levels(width, height);
+			}
+
 			glTexStorage2D(target, levels, format, width, height);
 		} else {
 			for (auto i = 0; i < 6; ++i) {


### PR DESCRIPTION
Cubemaps following https://github.com/scp-fs2open/fs2open.github.com/commit/bd62ceeeb0d1b64d8b8a066519e40680e8b8a5f2 get allocated with immutable storage. But because it only allocates the number of available mip levels, this prevents additional mip levels being generated when we need to generate them using glGenerateMipMap.

This rectifies this issue by making sure we allocate the exact amount of storage we need. This fixes https://github.com/scp-fs2open/fs2open.github.com/issues/1577