### PR TITLE
Add lua function for checking the engine version

### DIFF
--- a/code/scripting/api/libs/base.cpp
+++ b/code/scripting/api/libs/base.cpp
@@ -6,6 +6,7 @@
 #include <network/multi.h>
 #include <playerman/player.h>
 #include <parse/parselo.h>
+#include <globalincs/version.h>
 
 #include "base.h"
 
@@ -261,6 +262,26 @@ ADE_FUNC(XSTR,
 
 ADE_FUNC(inMissionEditor, l_Base, nullptr, "Determine if the current script is running in the mission editor (e.g. FRED2). This should be used to control which code paths will be executed even if running in the editor.", "boolean", "true when we are in the mission editor, false otherwise") {
 	return ade_set_args(L, "b", Fred_running != 0);
+}
+
+ADE_FUNC(isEngineVersionAtLeast,
+		 l_Base,
+		 "number major, number minor, number build[, number revision = 0]",
+		 "Checks if the current version of the engine is at least the specified version. This can be used to check if a feature introduced in a later version of the engine is available.",
+		 "boolean",
+		 "true if the version is at least the specified version. false otherwise.") {
+	int major = 0;
+	int minor = 0;
+	int build = 0;
+	int revision = 0;
+
+	if (!ade_get_args(L, "iii|i", &major, &minor, &build, &revision)) {
+		return ade_set_error(L, "b", false);
+	}
+
+	auto version = gameversion::version(major, minor, build, revision);
+
+	return ade_set_args(L, "b", gameversion::check_at_least(version));
 }
 
 //**********SUBLIBRARY: Base/Events


### PR DESCRIPTION
This can be used to check if an API function is available in the current
version of the engine without causing runtime errors.