### PR TITLE
Add simple NanoVG draw buffer for better performance

### DIFF
--- a/code/graphics/render.h
+++ b/code/graphics/render.h
@@ -167,6 +167,24 @@ void gr_arc(int xc, int yc, float r, float angle_start, float angle_end, bool fi
 void gr_curve(int x, int y, int r, int direction, int resize_mode);
 
 /**
+ * @brief Start buffering 2D rendering operations
+ *
+ * This will defer rendering 2D interface elements until gr_2d_stop_buffer is called. This can improve performance when
+ * doing a lot of 2D operations since the actual drawing will only be done once.
+ *
+ * @warning This will only affect a few rendering operations and might change the drawing order if incompatible rendering
+ * commands are executed while the buffering mechanism is active.
+ */
+void gr_2d_start_buffer();
+
+/**
+ * @brief Stop buffering 2D rendering operations
+ *
+ * This will stop the 2D buffering mechanism and also flush all previous render commands.
+ */
+void gr_2d_stop_buffer();
+
+/**
  * @brief The buffer object holding the data for immediate draws
  */
 extern int gr_immediate_buffer_handle;

--- a/code/hud/hudbrackets.cpp
+++ b/code/hud/hudbrackets.cpp
@@ -734,6 +734,8 @@ void HudGaugeBrackets::render(float frametime)
 	if(!in_frame)
 		g3_start_frame(0);
 
+	gr_2d_start_buffer();
+
 	for(size_t i = 0; i < target_display_list.size(); i++) {
 		// make sure this point is projected. Otherwise, skip.
 		if( !(target_display_list[i].target_point.flags & PF_OVERFLOW) ) {
@@ -747,6 +749,8 @@ void HudGaugeBrackets::render(float frametime)
 			}
 		}
 	}
+
+	gr_2d_stop_buffer();
 
 	if(!in_frame)
 		g3_end_frame();


### PR DESCRIPTION
This improves the rendering performance of the target hotkey brackets a
bit which caused a significant slowdown previously.