### PR TITLE
Improve the JumpNode::SetName assertion to be readable by non-coders

### DIFF
--- a/code/jumpnode/jumpnode.cpp
+++ b/code/jumpnode/jumpnode.cpp
@@ -229,7 +229,7 @@ void CJumpNode::SetName(const char *new_name)
     
 	#ifndef NDEBUG
 	CJumpNode* check = jumpnode_get_by_name(new_name);
-	Assert((check == this || !check));
+	Assertion((check == this || !check), "Jumpnode %s is being renamed to %s, but a jump node with that name already exists in the mission!\n", m_name, new_name);
 	#endif
     
 	strcpy_s(m_name, new_name);


### PR DESCRIPTION
Because it really wasn't, before.