### PR TITLE
Add a workaround for clipping planes on NVIDIA

### DIFF
--- a/code/def_files/main-f.sdr
+++ b/code/def_files/main-f.sdr
@@ -117,6 +117,11 @@ in float fragFogDist;
 #ifdef FLAG_ANIMATED
 uniform sampler2D sFramebuffer;
 #endif
+#ifdef WORKAROUND_CLIPPING_PLANES
+ #ifdef FLAG_TRANSFORM
+in float fragNotVisible;
+ #endif
+#endif
 #ifdef FLAG_TEAMCOLOR
 vec2 teamMask = vec2(0.0, 0.0);
 #endif
@@ -331,6 +336,11 @@ vec3 CalculateLighting(vec3 normal, vec3 diffuseMaterial, vec3 specularMaterial,
 #endif
 void main()
 {
+#ifdef WORKAROUND_CLIPPING_PLANES
+ #ifdef FLAG_TRANSFORM
+	if(fragNotVisible >= 0.9) { discard; }
+ #endif
+#endif
 #ifdef FLAG_SHADOW_MAP
 	// need depth and depth squared for variance shadow maps
 	fragOut0 = vec4(fragPosition.z, fragPosition.z * fragPosition.z * VARIANCE_SHADOW_SCALE_INV, 0.0, 1.0);

--- a/code/def_files/main-g.sdr
+++ b/code/def_files/main-g.sdr
@@ -104,6 +104,14 @@ in vec4 geoTexCoord[];
 out vec4 fragPosition;
 out vec3 fragNormal;
 out vec4 fragTexCoord;
+
+#ifdef WORKAROUND_CLIPPING_PLANES
+#ifdef FLAG_TRANSFORM
+in float geoNotVisible[];
+out float fragNotVisible;
+#endif
+#endif
+
 void main(void)
 {
 #ifdef GL_ARB_gpu_shader5
@@ -121,8 +129,17 @@ void main(void)
 		fragTexCoord = geoTexCoord[vert];
 
 		gl_Layer = instanceID;
-#if defined(FLAG_CLIP) || defined(FLAG_TRANSFORM)
+#ifdef WORKAROUND_CLIPPING_PLANES
+ #ifdef FLAG_TRANSFORM
+		fragNotVisible = geoNotVisible[0];
+ #endif
+ #ifdef FLAG_CLIP
 		gl_ClipDistance[0] = gl_in[vert].gl_ClipDistance[0];
+ #endif
+#else
+ #if defined(FLAG_CLIP) || defined(FLAG_TRANSFORM)
+		gl_ClipDistance[0] = gl_in[vert].gl_ClipDistance[0];
+ #endif
 #endif
 		EmitVertex();
 	}

--- a/code/def_files/main-v.sdr
+++ b/code/def_files/main-v.sdr
@@ -107,6 +107,15 @@ out float fragFogDist;
 #endif
 #ifdef FLAG_TRANSFORM
 uniform samplerBuffer transform_tex;
+
+#ifdef WORKAROUND_CLIPPING_PLANES
+ #ifdef FLAG_SHADOW_MAP
+out float geoNotVisible;
+ #else
+out float fragNotVisible;
+ #endif
+#endif
+
 #endif
 #ifdef FLAG_SHADOW_MAP
 #if !defined(GL_ARB_gpu_shader5)
@@ -154,12 +163,24 @@ void main()
 	vec4 texCoord;
 	mat4 orient = mat4(1.0);
 	mat4 scale = mat4(1.0);
+#ifdef WORKAROUND_CLIPPING_PLANES
+ #ifdef FLAG_TRANSFORM
+	bool clipModel;
+	getModelTransform(orient, clipModel, int(vertModelID), buffer_matrix_offset);
+   #ifdef FLAG_SHADOW_MAP
+	geoNotVisible = clipModel ? 1.0 : 0.0;
+   #else
+	fragNotVisible = clipModel ? 1.0 : 0.0;
+   #endif
+ #endif
+#else
  #ifdef FLAG_TRANSFORM
 	bool clipModel;
 	getModelTransform(orient, clipModel, int(vertModelID), buffer_matrix_offset);
  #else
 	bool clipModel = false;
  #endif
+#endif
 	texCoord = textureMatrix * vertTexCoord;
 	vec4 vertex = vertPosition;
  #ifdef FLAG_THRUSTER
@@ -208,6 +229,13 @@ void main()
  #ifdef FLAG_FOG
 	fragFogDist = clamp((gl_Position.z - fogStart) * 0.75 * fogScale, 0.0, 1.0);
  #endif
+#ifdef WORKAROUND_CLIPPING_PLANES
+	if(use_clip_plane) {
+ 		gl_ClipDistance[0] = dot(clip_equation, modelMatrix * orient * vertex);
+ 	} else {
+		gl_ClipDistance[0] = 1.0;
+ 	}
+#else
  #ifdef FLAG_CLIP
 	if (clipModel) {
 		gl_ClipDistance[0] = -1.0;
@@ -219,6 +247,7 @@ void main()
  #elif defined(FLAG_TRANSFORM)
 	gl_ClipDistance[0] = clipModel ? -1.0 : 1.0;
  #endif
+#endif
  #ifndef FLAG_SHADOW_MAP
 	fragPosition = position;
 	fragNormal = normal;

--- a/code/graphics/opengl/gropengl.h
+++ b/code/graphics/opengl/gropengl.h
@@ -58,4 +58,6 @@ extern GLuint GL_vao;
 
 extern float GL_alpha_threshold;
 
+extern bool GL_workaround_clipping_planes; //!< If set then clipping planes can not be used for batched model rendering
+
 #endif

--- a/code/graphics/opengl/gropenglshader.cpp
+++ b/code/graphics/opengl/gropenglshader.cpp
@@ -331,6 +331,10 @@ static SCP_string opengl_shader_get_header(shader_type type_id, int flags, shade
 
 	sflags << "#version " << GLSL_version << " core\n";
 
+	if (GL_workaround_clipping_planes) {
+		sflags << "#define WORKAROUND_CLIPPING_PLANES\n";
+	}
+
 	if (type_id == SDR_TYPE_POST_PROCESS_MAIN || type_id == SDR_TYPE_POST_PROCESS_LIGHTSHAFTS || type_id == SDR_TYPE_POST_PROCESS_FXAA) {
 		// ignore looking for variants. main post process, lightshafts, and FXAA shaders need special headers to be hacked in
 		opengl_post_shader_header(sflags, type_id, flags);

--- a/code/graphics/opengl/gropengltnl.cpp
+++ b/code/graphics/opengl/gropengltnl.cpp
@@ -751,10 +751,18 @@ void opengl_tnl_set_model_material(model_material *material_info)
 
 	GL_state.Texture.SetShaderMode(GL_TRUE);
 
-	if (Current_shader->flags & SDR_FLAG_MODEL_CLIP || Current_shader->flags & SDR_FLAG_MODEL_TRANSFORM) {
-		GL_state.ClipDistance(0, true);
+	if (GL_workaround_clipping_planes) {
+		if (Current_shader->flags & SDR_FLAG_MODEL_CLIP) {
+			GL_state.ClipDistance(0, true);
+		} else {
+			GL_state.ClipDistance(0, false);
+		}
 	} else {
-		GL_state.ClipDistance(0, false);
+		if (Current_shader->flags & SDR_FLAG_MODEL_CLIP || Current_shader->flags & SDR_FLAG_MODEL_TRANSFORM) {
+			GL_state.ClipDistance(0, true);
+		} else {
+			GL_state.ClipDistance(0, false);
+		}
 	}
 
 	uint32_t array_index;


### PR DESCRIPTION
This will enable a workaround for Nvidia GPUs which will disable the new clipping optimization since it caused issues with those GPUs.

This fixes #1579.