### PR TITLE
Reduce the amount of Debug message spam due to non-fatal OGL warnings

### DIFF
--- a/code/graphics/opengl/gropengl.cpp
+++ b/code/graphics/opengl/gropengl.cpp
@@ -1277,11 +1277,10 @@ static void APIENTRY debug_callback(GLenum source, GLenum type, GLuint id, GLenu
 	switch(severity) {
 		case GL_DEBUG_SEVERITY_HIGH_ARB:
 			severityStr = "High";
-			print_to_general_log = true; // High and medium messages are sent to the normal log for later troubleshooting
+			print_to_general_log = true; // High priority messages are sent to the normal log for later troubleshooting
 			break;
 		case GL_DEBUG_SEVERITY_MEDIUM_ARB:
 			severityStr = "Medium";
-			print_to_general_log = true;
 			break;
 		case GL_DEBUG_SEVERITY_LOW_ARB:
 			severityStr = "Low";


### PR DESCRIPTION
Since OGL debug messages are only useful for coders, most of the time, we shouldn't print them to the general log unless they're actually critical