### PR TITLE
Remove unused cmdline arguments

### DIFF
--- a/code/cmdline/cmdline.cpp
+++ b/code/cmdline/cmdline.cpp
@@ -308,7 +308,6 @@ int Cmdline_use_last_pilot = 0;
 // Graphics related
 cmdline_parm fov_arg("-fov", "Vertical field-of-view factor", AT_FLOAT);					// Cmdline_fov  -- comand line FOV -Bobboau
 cmdline_parm clip_dist_arg("-clipdist", "Changes the distance from the viewpoint for the near-clipping plane", AT_FLOAT);		// Cmdline_clip_dist
-cmdline_parm spec_exp_arg("-spec_exp", "Adjusts the size of shiny spots on ships", AT_FLOAT);
 cmdline_parm spec_static_arg("-spec_static", "Adjusts suns contribution to specular highlights", AT_FLOAT);
 cmdline_parm spec_point_arg("-spec_point", "Adjusts laser weapons contribution to specular highlights", AT_FLOAT);
 cmdline_parm spec_tube_arg("-spec_tube", "Adjusts beam weapons contribution to specular highlights", AT_FLOAT);
@@ -1809,10 +1808,6 @@ bool SetCmdlineParams()
 
 	if ( stretch_menu.found() )	{
 		Cmdline_stretch_menu = 1;
-	}
-	// specular comand lines
-	if ( spec_exp_arg.found() ) {
-		specular_exponent_value = spec_exp_arg.get_float();
 	}
 
 	if ( spec_point_arg.found() ) {

--- a/code/cmdline/cmdline.cpp
+++ b/code/cmdline/cmdline.cpp
@@ -309,7 +309,6 @@ int Cmdline_use_last_pilot = 0;
 cmdline_parm fov_arg("-fov", "Vertical field-of-view factor", AT_FLOAT);					// Cmdline_fov  -- comand line FOV -Bobboau
 cmdline_parm clip_dist_arg("-clipdist", "Changes the distance from the viewpoint for the near-clipping plane", AT_FLOAT);		// Cmdline_clip_dist
 cmdline_parm spec_exp_arg("-spec_exp", "Adjusts the size of shiny spots on ships", AT_FLOAT);
-cmdline_parm ogl_spec_arg("-ogl_spec", "Shininess of specular light", AT_FLOAT);		// Cmdline_ogl_spec
 cmdline_parm spec_static_arg("-spec_static", "Adjusts suns contribution to specular highlights", AT_FLOAT);
 cmdline_parm spec_point_arg("-spec_point", "Adjusts laser weapons contribution to specular highlights", AT_FLOAT);
 cmdline_parm spec_tube_arg("-spec_tube", "Adjusts beam weapons contribution to specular highlights", AT_FLOAT);
@@ -338,7 +337,6 @@ cmdline_parm no_deferred_lighting_arg("-no_deferred", NULL, AT_NONE);	// Cmdline
 
 float Cmdline_clip_dist = Default_min_draw_distance;
 float Cmdline_fov = 0.75f;
-float Cmdline_ogl_spec = 80.0f;
 int Cmdline_ambient_factor = 128;
 int Cmdline_env = 1;
 int Cmdline_mipmap = 0;
@@ -1969,12 +1967,6 @@ bool SetCmdlineParams()
 
 	if ( noemissive_arg.found() ) {
 		Cmdline_no_emissive = 1;
-	}
-
-	if ( ogl_spec_arg.found() ) {
-		Cmdline_ogl_spec = ogl_spec_arg.get_float();
-
-		CLAMP(Cmdline_ogl_spec, 0.0f, 128.0f);
 	}
 
 	if ( rearm_timer_arg.found() )

--- a/code/cmdline/cmdline.h
+++ b/code/cmdline/cmdline.h
@@ -56,7 +56,6 @@ extern char *Cmdline_center_res;
 extern double specular_exponent_value;
 extern float Cmdline_clip_dist;
 extern float Cmdline_fov;
-extern float Cmdline_ogl_spec;
 extern float static_light_factor;
 extern float static_point_factor;
 extern float static_tube_factor;

--- a/code/cmdline/cmdline.h
+++ b/code/cmdline/cmdline.h
@@ -53,7 +53,6 @@ extern char *Cmdline_center_res;
 // FSO OPTIONS -------------------------------------------------
 
 // Graphics related
-extern double specular_exponent_value;
 extern float Cmdline_clip_dist;
 extern float Cmdline_fov;
 extern float static_light_factor;

--- a/code/def_files/deferred-f.sdr
+++ b/code/def_files/deferred-f.sdr
@@ -7,7 +7,6 @@ uniform sampler2D NormalBuffer;
 uniform sampler2D PositionBuffer;
 uniform sampler2D SpecBuffer;
 
-uniform float specFactor;
 uniform float invScreenWidth;
 uniform float invScreenHeight;
 

--- a/code/graphics/light.cpp
+++ b/code/graphics/light.cpp
@@ -31,7 +31,7 @@ struct gr_light
 	// spotlight direction (for tube lights)
 	vec3d SpotDir;
 
-	float SpotExp, SpotCutOff;
+	float SpotCutOff;
 	float ConstantAtten, LinearAtten, QuadraticAtten;
 
 	bool occupied;
@@ -73,8 +73,6 @@ void FSLight2GLLight(light* FSLight, gr_light* GLLight) {
 	GLLight->SpotDir.xyz.x = 0.0f;
 	GLLight->SpotDir.xyz.y = 0.0f;
 	GLLight->SpotDir.xyz.z = -1.0f;
-	// spot exponent
-	GLLight->SpotExp = Cmdline_ogl_spec * 0.5f;
 	// spot cutoff
 	GLLight->SpotCutOff = 180.0f; // special value, light in all directions
 	// defaults to disable attenuation
@@ -266,7 +264,6 @@ void gr_set_center_alpha(int type) {
 	glight.SpotDir.xyz.x = 0.0f;
 	glight.SpotDir.xyz.y = 0.0f;
 	glight.SpotDir.xyz.z = -1.0f;
-	glight.SpotExp = Cmdline_ogl_spec * 0.5f;
 	glight.SpotCutOff = 180.0f;
 	glight.ConstantAtten = 1.0f;
 	glight.LinearAtten = 0.0f;

--- a/code/graphics/opengl/gropenglshader.cpp
+++ b/code/graphics/opengl/gropenglshader.cpp
@@ -775,7 +775,6 @@ void opengl_shader_compile_deferred_light_shader()
 		Current_shader->program->Uniforms.setUniformi("SpecBuffer", 3);
 		Current_shader->program->Uniforms.setUniformf("invScreenWidth", 1.0f / gr_screen.max_w);
 		Current_shader->program->Uniforms.setUniformf("invScreenHeight", 1.0f / gr_screen.max_h);
-		Current_shader->program->Uniforms.setUniformf("specFactor", Cmdline_ogl_spec);
 	} else {
 		opengl_shader_set_current();
 		mprintf(("Failed to compile deferred lighting shader!\n"));

--- a/code/lighting/lighting.cpp
+++ b/code/lighting/lighting.cpp
@@ -454,8 +454,6 @@ float static_light_factor = 1.0f;
 float static_tube_factor = 1.0f;
 float static_point_factor = 1.0f;
 
-double specular_exponent_value = 16.0;
-
 void light_apply_rgb( ubyte *param_r, ubyte *param_g, ubyte *param_b, const vec3d *pos, const vec3d *norm, float static_light_level )
 {
 	int idx;


### PR DESCRIPTION
While discussing the various lighting-related commandline arguments (see #1587), it became clear that two of them (-spec_exp and -ogl_spec) don't actually do anything at the moment. Removing them seems like a good idea.