### PR TITLE
Remove the -missile_lighting commandline parameter

### DIFF
--- a/code/cmdline/cmdline.cpp
+++ b/code/cmdline/cmdline.cpp
@@ -544,6 +544,7 @@ cmdline_parm deprecated_jpgtga_arg("-jpgtga", "Deprecated", AT_NONE);
 cmdline_parm deprecated_htl_arg("-nohtl", "Deprecated", AT_NONE);
 cmdline_parm deprecated_brieflighting_arg("-brief_lighting", "Deprecated", AT_NONE);
 cmdline_parm deprecated_sndpreload_arg("-snd_preload", "Deprecated", AT_NONE);
+cmdline_parm deprecated_missile_lighting_arg("-missile_lighting", "Deprecated", AT_NONE);
 
 int Cmdline_deprecated_spec = 0;
 int Cmdline_deprecated_glow = 0;
@@ -553,6 +554,7 @@ int Cmdline_deprecated_tbp = 0;
 int Cmdline_deprecated_jpgtga = 0;
 int Cmdline_deprecated_nohtl = 0;
 bool Cmdline_deprecated_brief_lighting = 0;
+bool Cmdline_deprecated_missile_lighting = false;
 
 #ifndef NDEBUG
 // NOTE: this assumes that os_init() has already been called but isn't a fatal error if it hasn't
@@ -617,6 +619,11 @@ void cmdline_debug_print_cmdline()
 	if(Cmdline_deprecated_brief_lighting == 1)
 	{
 		mprintf(("Deprecated flag '-brief_lighting' found. Please remove from your cmdline.\n"));
+	}
+
+	if (Cmdline_deprecated_missile_lighting) 
+	{
+		mprintf(("Deprecated flag '-missile_lighting' found. Please remove from your cmdline.\n"));
 	}
 }
 #endif
@@ -2130,6 +2137,11 @@ bool SetCmdlineParams()
 	if ( deprecated_brieflighting_arg.found() )
 	{
 		Cmdline_deprecated_brief_lighting = 1;
+	}
+
+	if (deprecated_missile_lighting_arg.found())
+	{
+		Cmdline_deprecated_missile_lighting = true;
 	}
 
 	return true; 

--- a/code/cmdline/cmdline.cpp
+++ b/code/cmdline/cmdline.cpp
@@ -314,7 +314,6 @@ cmdline_parm spec_static_arg("-spec_static", "Adjusts suns contribution to specu
 cmdline_parm spec_point_arg("-spec_point", "Adjusts laser weapons contribution to specular highlights", AT_FLOAT);
 cmdline_parm spec_tube_arg("-spec_tube", "Adjusts beam weapons contribution to specular highlights", AT_FLOAT);
 cmdline_parm ambient_factor_arg("-ambient_factor", "Adjusts ambient light applied to all parts of a ship", AT_INT);		// Cmdline_ambient_factor
-cmdline_parm missile_lighting_arg("-missile_lighting", NULL, AT_NONE);	// Cmdline_missile_lighting
 cmdline_parm env("-noenv", NULL, AT_NONE);								// Cmdline_env
 cmdline_parm glow_arg("-noglow", NULL, AT_NONE); 						// Cmdline_glow  -- use Bobs glow code
 cmdline_parm nomotiondebris_arg("-nomotiondebris", NULL, AT_NONE);		// Cmdline_nomotiondebris  -- Removes those ugly floating rocks -C
@@ -342,7 +341,6 @@ float Cmdline_ogl_spec = 80.0f;
 int Cmdline_ambient_factor = 128;
 int Cmdline_env = 1;
 int Cmdline_mipmap = 0;
-int Cmdline_missile_lighting = 0;
 int Cmdline_glow = 1;
 int Cmdline_nomotiondebris = 0;
 int Cmdline_noscalevid = 0;
@@ -1979,9 +1977,6 @@ bool SetCmdlineParams()
 
 	if ( rearm_timer_arg.found() )
 		Cmdline_rearm_timer = 1;
-
-	if ( missile_lighting_arg.found() )
-		Cmdline_missile_lighting = 1;
 
 	if ( save_render_targets_arg.found() )
 		Cmdline_save_render_targets = 1;

--- a/code/cmdline/cmdline.h
+++ b/code/cmdline/cmdline.h
@@ -62,7 +62,6 @@ extern float static_point_factor;
 extern float static_tube_factor;
 extern int Cmdline_ambient_factor;
 extern int Cmdline_env;
-extern int Cmdline_missile_lighting;
 extern int Cmdline_glow;
 extern int Cmdline_nomotiondebris;
 extern int Cmdline_noscalevid;	// disables fit-to-window for movies - taylor

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -7347,7 +7347,7 @@ void weapon_render(object* obj, model_draw_list *scene)
 			uint render_flags = MR_NORMAL|MR_IS_MISSILE|MR_NO_BATCH;
 
 			if (wip->wi_flags[Weapon::Info_Flags::Mr_no_lighting])
-				render_flags &= MR_NO_LIGHTING;
+				render_flags |= MR_NO_LIGHTING;
 
 			if (wip->wi_flags[Weapon::Info_Flags::Transparent]) {
 				render_info.set_alpha(wp->alpha_current);

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -7344,10 +7344,10 @@ void weapon_render(object* obj, model_draw_list *scene)
 		{
 			model_render_params render_info;
 
-			uint render_flags = MR_NORMAL|MR_IS_MISSILE|MR_NO_LIGHTING|MR_NO_BATCH;
+			uint render_flags = MR_NORMAL|MR_IS_MISSILE|MR_NO_BATCH;
 
-			if (Cmdline_missile_lighting && !(wip->wi_flags[Weapon::Info_Flags::Mr_no_lighting]))
-				render_flags &= ~MR_NO_LIGHTING;
+			if (wip->wi_flags[Weapon::Info_Flags::Mr_no_lighting])
+				render_flags &= MR_NO_LIGHTING;
 
 			if (wip->wi_flags[Weapon::Info_Flags::Transparent]) {
 				render_info.set_alpha(wp->alpha_current);


### PR DESCRIPTION
This also came up while digging around the lighting-related commandline parameters. In the previosu render pipeline, excluding missiles from lighting made sense; there was a lot of cost associated with it. Now, things are reversed: Excluding models from lighting is more expensive than lighting them, thus this parameter no longer serves any useful purpose.
