### PR TITLE
Fix assertion failure in ship_get_sound

### DIFF
--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -18405,11 +18405,11 @@ int ship_get_sound(object *objp, GameSoundsIndex id)
 	Assert( objp != NULL );
 	Assert( gamesnd_game_sound_valid(id) );
 
-	// ugh, it's possible that we're an observer at this point
-	if (objp->type == OBJ_OBSERVER)
+	// It's possible that this gets called when an object (in most cases the player) is dead or an observer
+	if (objp->type == OBJ_OBSERVER || objp->type == OBJ_GHOST)
 		return id;
 
-	Assert( objp->type == OBJ_SHIP );
+	Assertion(objp->type == OBJ_SHIP, "Expected a ship, got '%s'.", Object_type_names[objp->type]);
 
 	ship *shipp = &Ships[objp->instance];
 	ship_info *sip = &Ship_info[shipp->ship_info_index];
@@ -18427,7 +18427,11 @@ bool ship_has_sound(object *objp, GameSoundsIndex id)
 	Assert( objp != NULL );
 	Assert( gamesnd_game_sound_valid(id) );
 
-	Assert( objp->type == OBJ_SHIP );
+	// It's possible that this gets called when an object (in most cases the player) is dead or an observer
+	if (objp->type == OBJ_OBSERVER || objp->type == OBJ_GHOST)
+		return false;
+
+	Assertion(objp->type == OBJ_SHIP, "Expected a ship, got '%s'.", Object_type_names[objp->type]);
 
 	ship *shipp = &Ships[objp->instance];
 	ship_info *sip = &Ship_info[shipp->ship_info_index];


### PR DESCRIPTION
This assertion could be hit if the player died and the engine tried to
play a sound for the now destroyed ship. Since the existing code already
had a check for the case that the object is an observer I just added
another case for `OBJ_GHOST`.