### PR TITLE
Negative damages no longer heal subsystems

### DIFF
--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -17904,7 +17904,11 @@ float ArmorType::GetDamage(float damage_applied, int in_damage_type_idx, float d
 		// Nuke: check to see if we need to difficulty scale damage last
 		if (adtp->difficulty_scale_type == ADT_DIFF_SCALE_LAST)
 			damage_applied *= diff_dmg_scale;
-	
+
+		// Face: negative damages should not heal you!!!
+		if (damage_applied < 0.0f)
+			damage_applied = 0;
+
 		return damage_applied;
 	}
 	// fail return is fail

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -17907,7 +17907,7 @@ float ArmorType::GetDamage(float damage_applied, int in_damage_type_idx, float d
 
 		// Face: negative damages should not heal you!!!
 		if (damage_applied < 0.0f)
-			damage_applied = 0;
+			damage_applied = 0.0f;
 
 		return damage_applied;
 	}


### PR DESCRIPTION
The +additive armor type no longer heals a subsystem when you shoot a subsystem with a low damage weapon and the weapon has less damage than the damage subtraction