### PR TITLE
Use an enum class to mark light types

### DIFF
--- a/code/graphics/light.cpp
+++ b/code/graphics/light.cpp
@@ -62,7 +62,7 @@ void FSLight2GLLight(light* FSLight, gr_light* GLLight) {
 	GLLight->Specular.xyzw.z = FSLight->spec_b * FSLight->intensity;
 	GLLight->Specular.xyzw.w = 1.0f;
 
-	GLLight->type = FSLight->type;
+	GLLight->type = static_cast<int>(FSLight->type);
 
 	// GL default values...
 	// spot direction
@@ -85,7 +85,7 @@ void FSLight2GLLight(light* FSLight, gr_light* GLLight) {
 
 
 	switch (FSLight->type) {
-	case LT_POINT: {
+	case Light_Type::Point: {
 		// this crap still needs work...
 		GLLight->ConstantAtten = 1.0f;
 		GLLight->LinearAtten = (1.0f / MAX(FSLight->rada, FSLight->radb)) * 1.25f;
@@ -97,7 +97,7 @@ void FSLight2GLLight(light* FSLight, gr_light* GLLight) {
 		break;
 	}
 
-	case LT_TUBE: {
+	case Light_Type::Tube: {
 		GLLight->ConstantAtten = 1.0f;
 		GLLight->LinearAtten = (1.0f / MAX(FSLight->rada, FSLight->radb)) * 1.25f;
 		GLLight->QuadraticAtten = (1.0f / MAX(FSLight->rada_squared, FSLight->radb_squared)) * 1.25f;
@@ -121,7 +121,7 @@ void FSLight2GLLight(light* FSLight, gr_light* GLLight) {
 		break;
 	}
 
-	case LT_DIRECTIONAL: {
+	case Light_Type::Directional: {
 		GLLight->Position.xyzw.x = -FSLight->vec.xyz.x;
 		GLLight->Position.xyzw.y = -FSLight->vec.xyz.y;
 		GLLight->Position.xyzw.z = -FSLight->vec.xyz.z;
@@ -134,11 +134,11 @@ void FSLight2GLLight(light* FSLight, gr_light* GLLight) {
 		break;
 	}
 
-	case LT_CONE:
+	case Light_Type::Cone:
 		break;
 
 	default:
-		Int3();
+		Error(LOCATION, "Unknown light type in FSLight2GLLight. Expected was 0, 1, 2 or 3, we got %i", FSLight->type);
 		break;
 	}
 }

--- a/code/graphics/light.cpp
+++ b/code/graphics/light.cpp
@@ -138,7 +138,7 @@ void FSLight2GLLight(light* FSLight, gr_light* GLLight) {
 		break;
 
 	default:
-		Error(LOCATION, "Unknown light type in FSLight2GLLight. Expected was 0, 1, 2 or 3, we got %i", FSLight->type);
+		Error(LOCATION, "Unknown light type in FSLight2GLLight. Expected was 0, 1, 2 or 3, we got %i", static_cast<int>(FSLight->type));
 		break;
 	}
 }

--- a/code/graphics/opengl/gropengldeferred.cpp
+++ b/code/graphics/opengl/gropengldeferred.cpp
@@ -132,7 +132,7 @@ void gr_opengl_deferred_lighting_finish()
 			if (l.type == Light_Type::Directional) {
 				continue;
 			}
-
+			float length = 0.0f;
 			auto light_data = uniformAligner.addTypedElement<deferred_light_data>();
 
 			light_data->lightType = 0;
@@ -172,7 +172,7 @@ void gr_opengl_deferred_lighting_finish()
 
 				vec3d a;
 				vm_vec_sub(&a, &l.vec, &l.vec2);
-				auto length = vm_vec_mag(&a);
+				length = vm_vec_mag(&a);
 
 				light_data->scale.xyz.x = l.radb * 1.53f;
 				light_data->scale.xyz.y = l.radb * 1.53f;
@@ -189,8 +189,8 @@ void gr_opengl_deferred_lighting_finish()
 				light_data->scale.xyz.y = l.radb * 1.53f;
 				light_data->scale.xyz.z = l.radb * 1.53f;
 				break;
-			case Light_Type::Directional:
-				break;
+			case Light_Type::Directional: //We need to "handle" this here as well to make the compilers happy; 
+				break;					  //The code will never actually get here.
 			}
 		}
 

--- a/code/graphics/opengl/gropengldeferred.cpp
+++ b/code/graphics/opengl/gropengldeferred.cpp
@@ -189,6 +189,8 @@ void gr_opengl_deferred_lighting_finish()
 				light_data->scale.xyz.y = l.radb * 1.53f;
 				light_data->scale.xyz.z = l.radb * 1.53f;
 				break;
+			case Light_Type::Directional:
+				break;
 			}
 		}
 

--- a/code/graphics/opengl/gropengldeferred.cpp
+++ b/code/graphics/opengl/gropengldeferred.cpp
@@ -129,7 +129,7 @@ void gr_opengl_deferred_lighting_finish()
 
 		for (auto& l : lights_copy) {
 
-			if (l.type != LT_CONE && l.type != LT_POINT && l.type != LT_TUBE) {
+			if (l.type == Light_Type::Directional) {
 				continue;
 			}
 
@@ -148,14 +148,14 @@ void gr_opengl_deferred_lighting_finish()
 			spec.xyz.z = l.spec_b * l.intensity;
 
 			switch (l.type) {
-			case LT_CONE:
+			case Light_Type::Cone:
 				light_data->lightType = 2;
 				light_data->dualCone = l.dual_cone ? 1.0f : 0.0f;
 				light_data->coneAngle = l.cone_angle;
 				light_data->coneInnerAngle = l.cone_inner_angle;
 				light_data->coneDir = l.vec2;
 				FALLTHROUGH;
-			case LT_POINT:
+			case Light_Type::Point:
 				light_data->diffuseLightColor = diffuse;
 				light_data->specLightColor = spec;
 				light_data->lightRadius = MAX(l.rada, l.radb) * 1.25f;
@@ -164,7 +164,7 @@ void gr_opengl_deferred_lighting_finish()
 				light_data->scale.xyz.y = MAX(l.rada, l.radb) * 1.28f;
 				light_data->scale.xyz.z = MAX(l.rada, l.radb) * 1.28f;
 				break;
-			case LT_TUBE:
+			case Light_Type::Tube:
 				light_data->diffuseLightColor = diffuse;
 				light_data->specLightColor = spec;
 				light_data->lightRadius = l.radb * 1.5f;
@@ -204,8 +204,8 @@ void gr_opengl_deferred_lighting_finish()
 			GR_DEBUG_SCOPE("Deferred apply single light");
 
 			switch (l.type) {
-			case LT_CONE:
-			case LT_POINT:
+			case Light_Type::Cone:
+			case Light_Type::Point:
 				gr_bind_uniform_buffer(uniform_block_type::Lights,
 									   uniformAligner.getOffset(element_index),
 									   sizeof(graphics::deferred_light_data),
@@ -213,7 +213,7 @@ void gr_opengl_deferred_lighting_finish()
 				gr_opengl_draw_deferred_light_sphere(&l.vec);
 				++element_index;
 				break;
-			case LT_TUBE:
+			case Light_Type::Tube:
 				gr_bind_uniform_buffer(uniform_block_type::Lights,
 									   uniformAligner.getOffset(element_index),
 									   sizeof(graphics::deferred_light_data),

--- a/code/lighting/lighting.cpp
+++ b/code/lighting/lighting.cpp
@@ -112,13 +112,13 @@ extern vec3d Object_position;
 static void light_rotate(light * l)
 {
 	switch( l->type )	{
-	case LT_DIRECTIONAL:
+	case Light_Type::Directional:
 		// Rotate the light direction into local coodinates
 		
 		vm_vec_rotate(&l->local_vec, &l->vec, &Light_matrix );
 		break;
 	
-	case LT_POINT:	{
+	case Light_Type::Point:	{
 			vec3d tempv;
 			// Rotate the point into local coordinates
 	
@@ -127,7 +127,7 @@ static void light_rotate(light * l)
 		}
 		break;
 	
-	case LT_TUBE:{
+	case Light_Type::Tube:{
 			vec3d tempv;
 
 			// Rotate the point into local coordinates
@@ -140,7 +140,7 @@ static void light_rotate(light * l)
 		}
 		break;
 
-	case LT_CONE:
+	case Light_Type::Cone:
 			break;
 
 	default:
@@ -162,7 +162,7 @@ void light_add_directional(const vec3d *dir, float intensity, float r, float g, 
 
 	light l;
 
-	l.type = LT_DIRECTIONAL;
+	l.type = Light_Type::Directional;
 
 	vm_vec_copy_scale( &l.vec, dir, -1.0f );
 
@@ -205,7 +205,7 @@ void light_add_point(const vec3d *pos, float r1, float r2, float intensity, floa
 	
 	Num_lights++;
 
-	l.type = LT_POINT;
+	l.type = Light_Type::Point;
 	l.vec = *pos;
 	l.r = r;
 	l.g = g;
@@ -243,7 +243,7 @@ void light_add_point_unique(const vec3d *pos, float r1, float r2, float intensit
 
 	Num_lights++;
 
-	l.type = LT_POINT;
+	l.type = Light_Type::Point;
 	l.vec = *pos;
 	l.r = r;
 	l.g = g;
@@ -283,7 +283,7 @@ void light_add_tube(const vec3d *p0, const vec3d *p1, float r1, float r2, float 
 
 	Num_lights++;
 
-	l.type = LT_TUBE;
+	l.type = Light_Type::Tube;
 	l.vec = *p0;
 	l.vec2 = *p1;
 	l.r = r;
@@ -408,12 +408,12 @@ void light_apply_rgb( ubyte *param_r, ubyte *param_g, ubyte *param_b, const vec3
 		dist = -1.0f;
 		switch(l.type){
 		// point lights
-		case LT_POINT:			
+		case Light_Type::Point:
 			vm_vec_sub( &to_light, &l.local_vec, pos );
 			break;
 
 		// tube lights
-		case LT_TUBE:						
+		case Light_Type::Tube:
 			if(vm_vec_dist_to_line(pos, &l.local_vec, &l.local_vec2, &temp, &dist) != 0){
 				continue;
 			}
@@ -421,10 +421,10 @@ void light_apply_rgb( ubyte *param_r, ubyte *param_g, ubyte *param_b, const vec3
 			dist *= dist;	// since we use radius squared
 			break;
 
-		case LT_DIRECTIONAL:
+		case Light_Type::Directional:
 			continue;
 
-		case LT_CONE:
+		case Light_Type::Cone:
 			continue;
 
 		// others. BAD
@@ -501,7 +501,7 @@ void light_add_cone(const vec3d *pos, const vec3d *dir, float angle, float inner
 
 	Num_lights++;
 
-	l.type = LT_CONE;
+	l.type = Light_Type::Cone;
 	l.vec = *pos;
 	l.vec2= *dir;
 	l.cone_angle = angle;
@@ -536,7 +536,7 @@ void scene_lights::addLight(const light *light_ptr)
 
 	AllLights.push_back(*light_ptr);
 
-	if ( light_ptr->type == LT_DIRECTIONAL ) {
+	if ( light_ptr->type == Light_Type::Directional ) {
 		StaticLightIndices.push_back(AllLights.size() - 1);
 	}
 }
@@ -550,9 +550,9 @@ void scene_lights::setLightFilter(int objnum, const vec3d *pos, float rad)
 
 	for ( auto& l : AllLights ) {
 		switch ( l.type ) {
-			case LT_DIRECTIONAL:
+			case Light_Type::Directional:
 				continue;
-			case LT_POINT: {
+			case Light_Type::Point: {
 				// if this is a "unique" light source, it only affects one guy
 				if ( l.affected_objnum >= 0 ) {
 					if ( objnum == l.affected_objnum ) {
@@ -583,7 +583,7 @@ void scene_lights::setLightFilter(int objnum, const vec3d *pos, float rad)
 				}
 			}
 			break;
-			case LT_TUBE: {
+			case Light_Type::Tube: {
 				if ( l.light_ignore_objnum != objnum ) {
 					vec3d nearest;
 					float dist_squared, max_dist_squared;
@@ -599,7 +599,7 @@ void scene_lights::setLightFilter(int objnum, const vec3d *pos, float rad)
 			}
 			break;
 
-			case LT_CONE:
+			case Light_Type::Cone:
 				break;
 
 			default:

--- a/code/lighting/lighting.cpp
+++ b/code/lighting/lighting.cpp
@@ -543,8 +543,7 @@ void scene_lights::addLight(const light *light_ptr)
 
 void scene_lights::setLightFilter(int objnum, const vec3d *pos, float rad)
 {
-	size_t i;
-
+	size_t i = 0;
 	// clear out current filtered lights
 	FilteredLights.clear();
 
@@ -605,6 +604,7 @@ void scene_lights::setLightFilter(int objnum, const vec3d *pos, float rad)
 			default:
 				break;
 		}
+		++i;
 	}
 }
 

--- a/code/lighting/lighting.cpp
+++ b/code/lighting/lighting.cpp
@@ -550,6 +550,7 @@ void scene_lights::setLightFilter(int objnum, const vec3d *pos, float rad)
 	for ( auto& l : AllLights ) {
 		switch ( l.type ) {
 			case Light_Type::Directional:
+				++i;
 				continue;
 			case Light_Type::Point: {
 				// if this is a "unique" light source, it only affects one guy

--- a/code/lighting/lighting.h
+++ b/code/lighting/lighting.h
@@ -29,9 +29,9 @@
 
 enum class Light_Type : int {
 	Directional = 0,// A light like a sun
-	Point,		// A point light, like an explosion
-	Tube,		// A tube light, like a fluorescent light
-	Cone		// A cone light, like a flood light
+	Point = 1,		// A point light, like an explosion
+	Tube = 2,		// A tube light, like a fluorescent light
+	Cone = 3		// A cone light, like a flood light
 };
 
 typedef struct light {

--- a/code/lighting/lighting.h
+++ b/code/lighting/lighting.h
@@ -28,7 +28,7 @@
 #define LT_CONE			3		// A cone light, like a flood light
 
 enum class Light_Type : int {
-	Directional,// A light like a sun
+	Directional = 0,// A light like a sun
 	Point,		// A point light, like an explosion
 	Tube,		// A tube light, like a fluorescent light
 	Cone		// A cone light, like a flood light

--- a/code/lighting/lighting.h
+++ b/code/lighting/lighting.h
@@ -27,8 +27,15 @@
 #define LT_TUBE			2		// A tube light, like a fluorescent light
 #define LT_CONE			3		// A cone light, like a flood light
 
+enum class Light_Type : int {
+	Directional,// A light like a sun
+	Point,		// A point light, like an explosion
+	Tube,		// A tube light, like a fluorescent light
+	Cone		// A cone light, like a flood light
+};
+
 typedef struct light {
-	int		type;							// What type of light this is
+	Light_Type type;							// What type of light this is
 	vec3d	vec;							// location in world space of a point light or the direction of a directional light or the first point on the tube for a tube light
 	vec3d	vec2;							// second point on a tube light or direction of a cone light
 	vec3d	local_vec;						// rotated light vector

--- a/code/model/modelrender.cpp
+++ b/code/model/modelrender.cpp
@@ -583,7 +583,7 @@ void model_draw_list::init()
 	reset();
 
 	for (auto& l : Lights) {
-		if ( l.type == LT_DIRECTIONAL || !Deferred_lighting ) {
+		if ( l.type == Light_Type::Directional || !Deferred_lighting ) {
 			Scene_light_handler.addLight(&l);
 		}	
 	}


### PR DESCRIPTION
This also fixes an issue where an uninitialized variable was used as an index