### PR TITLE
Fixes beam behaviour with additive/cap/etc damage types

### DIFF
--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -17724,8 +17724,7 @@ int calculation_type_get(char *str)
 }
 
 //STEP 4: Add the calculation to the switch statement.
-float ArmorType::GetDamage(float damage_applied, int in_damage_type_idx, float diff_dmg_scale)
-{
+float ArmorType::GetDamage(float damage_applied, int in_damage_type_idx, float diff_dmg_scale, int is_beam) {
 	// Nuke: If the weapon has no damage type, just return damage
 	if (in_damage_type_idx < 0) {
 		// multiply by difficulty scaler now, since it is no longer done where this is called
@@ -17811,6 +17810,16 @@ float ArmorType::GetDamage(float damage_applied, int in_damage_type_idx, float d
 				constant_val = 0.0f;
 				curr_arg = constant_val;
 			}
+
+			//face: terrible hack to work consistently with beams and additive damages
+			if (is_beam && adtp->Calculations[i] != AT_TYPE_MULTIPLICATIVE
+				&& adtp->Calculations[i] != AT_TYPE_EXPONENTIAL
+				&& adtp->Calculations[i] != AT_TYPE_EXPONENTIAL_BASE
+				&& adtp->Calculations[i] != AT_TYPE_STORE
+				&& adtp->Calculations[i] != AT_TYPE_LOAD) {
+				curr_arg = curr_arg * (flFrametime * 1000.0f) / i2fl(170);
+			}
+
 			// new calcs go here
 			switch(adtp->Calculations[i])
 			{

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -17812,12 +17812,16 @@ float ArmorType::GetDamage(float damage_applied, int in_damage_type_idx, float d
 			}
 
 			//face: terrible hack to work consistently with beams and additive damages
-			if (is_beam && adtp->Calculations[i] != AT_TYPE_MULTIPLICATIVE
-				&& adtp->Calculations[i] != AT_TYPE_EXPONENTIAL
-				&& adtp->Calculations[i] != AT_TYPE_EXPONENTIAL_BASE
-				&& adtp->Calculations[i] != AT_TYPE_STORE
-				&& adtp->Calculations[i] != AT_TYPE_LOAD) {
-				curr_arg = curr_arg * (flFrametime * 1000.0f) / i2fl(170);
+			if (is_beam && ( adtp->Calculations[i] == AT_TYPE_ADDITIVE
+				|| adtp->Calculations[i] == AT_TYPE_CUTOFF
+				|| adtp->Calculations[i] == AT_TYPE_REVERSE_CUTOFF
+				|| adtp->Calculations[i] == AT_TYPE_INSTANT_CUTOFF
+				|| adtp->Calculations[i] == AT_TYPE_INSTANT_REVERSE_CUTOFF
+				|| adtp->Calculations[i] == AT_TYPE_CAP
+				|| adtp->Calculations[i] == AT_TYPE_INSTANT_CAP
+				|| adtp->Calculations[i] == AT_TYPE_SET
+				|| adtp->Calculations[i] == AT_TYPE_RANDOM)) {
+				curr_arg = curr_arg * (flFrametime * 1000.0f) / i2fl(BEAM_DAMAGE_TIME);
 			}
 
 			// new calcs go here

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -227,7 +227,7 @@ public:
 	//Get
 	char *GetNamePtr(){return Name;}
 	bool IsName(char *in_name){return (stricmp(in_name,Name)==0);}
-	float GetDamage(float damage_applied, int in_damage_type_idx, float diff_dmg_scale);
+	float GetDamage(float damage_applied, int in_damage_type_idx, float diff_dmg_scale, int is_beam = 0);
 	float GetShieldPiercePCT(int damage_type_idx);
 	int GetPiercingType(int damage_type_idx);
 	float GetPiercingLimit(int damage_type_idx);

--- a/code/ship/shiphit.cpp
+++ b/code/ship/shiphit.cpp
@@ -2087,7 +2087,8 @@ static void ship_do_damage(object *ship_objp, object *other_obj, vec3d *hitpos, 
 			if(shipp->shield_armor_type_idx != -1)
 			{
 				// Nuke: this call will decide when to use the damage factor, but it will get used, unless the modder is dumb (like setting +Difficulty Scale Type: to 'manual' and not manually applying it in their calculations)
-				damage = Armor_types[shipp->shield_armor_type_idx].GetDamage(damage, dmg_type_idx, difficulty_scale_factor);
+				damage = Armor_types[shipp->shield_armor_type_idx].GetDamage(damage, dmg_type_idx, difficulty_scale_factor, other_obj_is_beam);
+
 			} else { // Nuke: if that didn't get called, difficulty would not be applied to damage so apply it here
 				damage *= difficulty_scale_factor;
 			}
@@ -2149,7 +2150,7 @@ static void ship_do_damage(object *ship_objp, object *other_obj, vec3d *hitpos, 
 			
 			if(shipp->armor_type_idx != -1)
 			{
-				damage = Armor_types[shipp->armor_type_idx].GetDamage(damage, dmg_type_idx, difficulty_scale_factor);
+				damage = Armor_types[shipp->armor_type_idx].GetDamage(damage, dmg_type_idx, difficulty_scale_factor, other_obj_is_beam);
 				apply_diff_scale = false;
 			}
 		}

--- a/code/weapon/beam.cpp
+++ b/code/weapon/beam.cpp
@@ -53,7 +53,6 @@
 // randomness factor - all beam weapon aiming is adjusted by +/- some factor within this range
 #define BEAM_RANDOM_FACTOR			0.4f
 
-#define BEAM_DAMAGE_TIME			170			// apply damage 
 #define MAX_SHOT_POINTS				30
 #define SHOT_POINT_TIME				200			// 5 arcs a second
 

--- a/code/weapon/beam.h
+++ b/code/weapon/beam.h
@@ -39,6 +39,9 @@ struct vec3d;
 #define MAX_BEAM_SHOTS				5
 #define MAX_BEAMS					500
 
+// apply damage
+#define BEAM_DAMAGE_TIME			170
+
 // uses to define beam behavior ahead of time - needed for multiplayer
 typedef struct beam_info {
 	vec3d			dir_a, dir_b;						// direction vectors for beams	


### PR DESCRIPTION
Intended armor type behaviour: Subtracting 500 damage from a beam with a tabled damage of 3100 causes the beam to do ~0.85x damage

Actual armor type behaviour: Subtracting 500 damage from a beam with a tabled damage of 3100 causes the beam to do 0 damage on low time accelerations and 1x damage at high time accelerations, as the damage is subtracted every frame and beam damage is recalculated according to frametimes each frame

Hopefully fixed armor type behaviour: Subtracting 500 damage from a beam with a tabled damage of 3100 causes the beam to do ~0.85x damage