### PR TITLE
Add support for includes in shader files

### DIFF
--- a/code/def_files/data/effects/deferred-f.sdr
+++ b/code/def_files/data/effects/deferred-f.sdr
@@ -1,3 +1,6 @@
+
+#include "lighting.sdr"
+
 in vec3 beamVec;
 in vec3 lightPosition;
 out vec4 fragOut0;
@@ -27,49 +30,6 @@ layout (std140) uniform lightData {
 	int lightType;
 };
 
-#define SPEC_INTENSITY_POINT			5.3 // Point light
-#define SPEC_INTENSITY_DIRECTIONAL		3.0 // Directional light
-#define SPECULAR_FACTOR				1.75
-#define SPECULAR_ALPHA					0.1
-#define SPEC_FACTOR_NO_SPEC_MAP		0.6
-#define ENV_ALPHA_FACTOR				0.3
-#define GLOW_MAP_INTENSITY				1.5
-#define AMBIENT_LIGHT_BOOST			1.0
-vec3 FresnelSchlick(vec3 specColor, vec3 light, vec3 halfVec)
-{
-	return specColor + (vec3(1.0) - specColor) * pow(1.0 - clamp(dot(light, halfVec), 0.0, 1.0), 5.0);
-}
-vec3 SpecularBlinnPhong(vec3 specColor, vec3 light, vec3 normal, vec3 halfVec, float specPower, float fresnel, float dotNL)
-{
-	return mix(specColor, FresnelSchlick(specColor, light, halfVec), fresnel) * ((specPower + 2.0) / 8.0 ) * pow(clamp(dot(normal, halfVec), 0.0, 1.0), specPower) * dotNL;
-}
-vec3 SpecularGGX(vec3 specColor, vec3 light, vec3 normal, vec3 halfVec, vec3 view, float gloss, float dotNL)
-{
-	float roughness = clamp(1.0f - gloss, 0.0f, 1.0f);
-	float alpha = roughness * roughness;
-
-	float dotNH = clamp(dot(normal, halfVec), 0.0f, 1.0f);
-	float dotNV = clamp(dot(normal, view), 0.0f, 1.0f);
-
-	float alphaSqr = alpha * alpha;
-	float pi = 3.14159f;
-	float denom = dotNH * dotNH * (alphaSqr - 1.0f) + 1.0f;
-	float distribution = alphaSqr / (pi * denom * denom);
-
-	vec3 fresnel = FresnelSchlick(specColor, light, halfVec);
-	
-	float alphaPrime = roughness + 1.0f;
-	float k = alphaPrime * alphaPrime / 8.0f;
-	float g1vNL = 1.0f / (dotNL * (1.0f - k) + k);
-	float g1vNV = 1.0f / (dotNV * (1.0f - k) + k);
-	float visibility = g1vNL * g1vNV;
-
-	return distribution * fresnel * visibility * dotNL;
-}
-vec4 SpecularLegacy(vec4 specColor, vec3 normal, vec3 halfVec, float specPower)
-{
-	return specColor * pow(clamp(dot(normal, halfVec), 0.0, 1.0), specPower);
-}
 void main()
 {
 	vec2 screenPos = gl_FragCoord.xy * vec2(invScreenWidth, invScreenHeight);
@@ -124,6 +84,6 @@ void main()
 	vec3 halfVec = normalize(lightDir + eyeDir);
 	float NdotL = clamp(dot(normal.xyz, lightDir), 0.0, 1.0);
 	vec4 fragmentColor = vec4(color * (diffuseLightColor * NdotL * attenuation), 1.0);
-	fragmentColor.rgb += SpecularGGX(specColor.rgb, lightDir, normal.xyz, halfVec, eyeDir, gloss, NdotL).rgb * specLightColor * attenuation;
+	fragmentColor.rgb += SpecularGGX(specColor.rgb, lightDir, normal.xyz, halfVec, eyeDir, gloss, fresnel, NdotL).rgb * specLightColor * attenuation;
 	fragOut0 = max(fragmentColor, vec4(0.0));
 }

--- a/code/def_files/data/effects/lighting.sdr
+++ b/code/def_files/data/effects/lighting.sdr
@@ -1,0 +1,43 @@
+
+const float SPEC_INTENSITY_POINT		= 5.3 ;// Point light
+const float SPEC_INTENSITY_DIRECTIONAL	= 3.0 ;// Directional light
+const float SPECULAR_FACTOR				= 1.75;
+const float SPECULAR_ALPHA				= 0.1;
+const float SPEC_FACTOR_NO_SPEC_MAP		= 0.6;
+const float ENV_ALPHA_FACTOR			= 0.3;
+const float GLOW_MAP_INTENSITY			= 1.5;
+const float AMBIENT_LIGHT_BOOST			= 1.0;
+
+vec3 FresnelSchlick(vec3 specColor, vec3 light, vec3 halfVec)
+{
+	return specColor + (vec3(1.0) - specColor) * pow(1.0 - clamp(dot(light, halfVec), 0.0, 1.0), 5.0);
+}
+
+vec3 SpecularBlinnPhong(vec3 specColor, vec3 light, vec3 normal, vec3 halfVec, float specPower, float fresnel, float dotNL)
+{
+	return mix(specColor, FresnelSchlick(specColor, light, halfVec), fresnel) * ((specPower + 2.0) / 8.0 ) * pow(clamp(dot(normal, halfVec), 0.0, 1.0), specPower) * dotNL;
+}
+
+vec3 SpecularGGX(vec3 specColor, vec3 light, vec3 normal, vec3 halfVec, vec3 view, float gloss, float fresnelFactor, float dotNL)
+{
+	float roughness = clamp(1.0f - gloss, 0.0f, 1.0f);
+	float alpha = roughness * roughness;
+
+	float dotNH = clamp(dot(normal, halfVec), 0.0f, 1.0f);
+	float dotNV = clamp(dot(normal, view), 0.0f, 1.0f);
+
+	float alphaSqr = alpha * alpha;
+	float pi = 3.14159f;
+	float denom = dotNH * dotNH * (alphaSqr - 1.0f) + 1.0f;
+	float distribution = alphaSqr / (pi * denom * denom);
+
+	vec3 fresnel = mix(specColor, FresnelSchlick(specColor, light, halfVec), fresnelFactor);
+
+	float alphaPrime = roughness + 1.0f;
+	float k = alphaPrime * alphaPrime / 8.0f;
+	float g1vNL = 1.0f / (dotNL * (1.0f - k) + k);
+	float g1vNV = 1.0f / (dotNV * (1.0f - k) + k);
+	float visibility = g1vNL * g1vNV;
+
+	return distribution * fresnel * visibility * dotNL;
+}

--- a/code/def_files/data/effects/main-f.sdr
+++ b/code/def_files/data/effects/main-f.sdr
@@ -1,3 +1,6 @@
+
+#include "shadows.sdr"
+
 #define MAX_LIGHTS 8
 #define LT_DIRECTIONAL		0
 #define LT_POINT			1
@@ -140,8 +143,6 @@ uniform sampler2DArray shadow_map;
 #define ENV_ALPHA_FACTOR         0.3
 #define GLOW_MAP_INTENSITY         1.5
 #define AMBIENT_LIGHT_BOOST      1.0
-#define VARIANCE_SHADOW_SCALE		1000000.0
-#define VARIANCE_SHADOW_SCALE_INV	1.0/VARIANCE_SHADOW_SCALE
 #define SRGB_GAMMA 2.2
 in vec4 fragPosition;
 in vec3 fragNormal;
@@ -150,98 +151,6 @@ out vec4 fragOut0;
 out vec4 fragOut1;
 out vec4 fragOut2;
 out vec4 fragOut3;
-
-#ifdef FLAG_SHADOWS
-vec2 sampleShadowMap(vec2 uv, vec2 offset_uv, int cascade, float shadowMapSizeInv)
-{
-	return texture(shadow_map, vec3(uv + offset_uv * shadowMapSizeInv, float(cascade))).xy;
-}
-
-float computeShadowFactor(vec2 moments, float bias)
-{
-	float shadow = 1.0;
-	if((moments.x - bias) > fragShadowPos.z)
-	{
-		// variance shadow mapping using Chebychev's Formula
-		float variance = moments.y * VARIANCE_SHADOW_SCALE - moments.x * moments.x;
-		float mD = moments.x - bias - fragShadowPos.z;
-		shadow = variance / (variance + mD * mD);
-		shadow = clamp(shadow, 0.0, 1.0);
-	}
-	return shadow;
-}
-
-float sampleNoPCF(int cascade)
-{
-	return computeShadowFactor(sampleShadowMap(fragShadowUV[cascade].xy, vec2(0.0, 0.0), cascade, 1.0/1024.0), 0.05);
-}
-
-float samplePoissonPCF(int cascade)
-{
-	if(cascade > 3 || cascade < 0) return 1.0;
-	vec2 poissonDisc[16];
-	poissonDisc[0] = vec2(-0.76275, -0.3432573);
-	poissonDisc[1] = vec2(-0.5226235, -0.8277544);
-	poissonDisc[2] = vec2(-0.3780261, 0.01528688);
-	poissonDisc[3] = vec2(-0.7742821, 0.4245702);
-	poissonDisc[4] = vec2(0.04196143, -0.02622231);
-	poissonDisc[5] = vec2(-0.2974772, -0.4722782);
-	poissonDisc[6] = vec2(-0.516093, 0.71495);
-	poissonDisc[7] = vec2(-0.3257416, 0.3910343);
-	poissonDisc[8] = vec2(0.2705966, 0.6670476);
-	poissonDisc[9] = vec2(0.4918377, 0.1853267);
-	poissonDisc[10] = vec2(0.4428544, -0.6251478);
-	poissonDisc[11] = vec2(-0.09204347, 0.9267113);
-	poissonDisc[12] = vec2(0.391505, -0.2558275);
-	poissonDisc[13] = vec2(0.05605913, -0.7570801);
-	poissonDisc[14] = vec2(0.81772, -0.02475523);
-	poissonDisc[15] = vec2(0.6890262, 0.5191521);
-	float maxUVOffset[4];
-	maxUVOffset[0] = 1.0/300.0;
-	maxUVOffset[1] = 1.0/250.0;
-	maxUVOffset[2] = 1.0/200.0;
-	maxUVOffset[3] = 1.0/200.0;
-	vec2 sum = sampleShadowMap(fragShadowUV[cascade].xy, poissonDisc[0], cascade, maxUVOffset[cascade])*(1.0/16.0);
-	sum += sampleShadowMap(fragShadowUV[cascade].xy, poissonDisc[1], cascade, maxUVOffset[cascade])*(1.0/16.0);
-	sum += sampleShadowMap(fragShadowUV[cascade].xy, poissonDisc[2], cascade, maxUVOffset[cascade])*(1.0/16.0);
-	sum += sampleShadowMap(fragShadowUV[cascade].xy, poissonDisc[3], cascade, maxUVOffset[cascade])*(1.0/16.0);
-	sum += sampleShadowMap(fragShadowUV[cascade].xy, poissonDisc[4], cascade, maxUVOffset[cascade])*(1.0/16.0);
-	sum += sampleShadowMap(fragShadowUV[cascade].xy, poissonDisc[5], cascade, maxUVOffset[cascade])*(1.0/16.0);
-	sum += sampleShadowMap(fragShadowUV[cascade].xy, poissonDisc[6], cascade, maxUVOffset[cascade])*(1.0/16.0);
-	sum += sampleShadowMap(fragShadowUV[cascade].xy, poissonDisc[7], cascade, maxUVOffset[cascade])*(1.0/16.0);
-	sum += sampleShadowMap(fragShadowUV[cascade].xy, poissonDisc[8], cascade, maxUVOffset[cascade])*(1.0/16.0);
-	sum += sampleShadowMap(fragShadowUV[cascade].xy, poissonDisc[9], cascade, maxUVOffset[cascade])*(1.0/16.0);
-	sum += sampleShadowMap(fragShadowUV[cascade].xy, poissonDisc[10], cascade, maxUVOffset[cascade])*(1.0/16.0);
-	sum += sampleShadowMap(fragShadowUV[cascade].xy, poissonDisc[11], cascade, maxUVOffset[cascade])*(1.0/16.0);
-	sum += sampleShadowMap(fragShadowUV[cascade].xy, poissonDisc[12], cascade, maxUVOffset[cascade])*(1.0/16.0);
-	sum += sampleShadowMap(fragShadowUV[cascade].xy, poissonDisc[13], cascade, maxUVOffset[cascade])*(1.0/16.0);
-	sum += sampleShadowMap(fragShadowUV[cascade].xy, poissonDisc[14], cascade, maxUVOffset[cascade])*(1.0/16.0);
-	sum += sampleShadowMap(fragShadowUV[cascade].xy, poissonDisc[15], cascade, maxUVOffset[cascade])*(1.0/16.0);
-	return computeShadowFactor(sum, 0.1);
-}
-
-float getShadowValue()
-{
-	// Valathil's Shadows
-	float depth = -fragPosition.z;
-	int cascade = 4;
-	cascade -= int(step(depth, fardist));
-	cascade -= int(step(depth, middist));
-	cascade -= int(step(depth, neardist));
-	cascade -= int(step(depth, veryneardist));
-	float cascade_start_dist[5];
-	cascade_start_dist[0] = 0.0;
-	cascade_start_dist[1] = veryneardist;
-	cascade_start_dist[2] = neardist;
-	cascade_start_dist[3] = middist;
-	cascade_start_dist[4] = fardist;
-	if(cascade > 3 || cascade < 0) return 1.0;
-	float dist_threshold = (cascade_start_dist[cascade+1] - cascade_start_dist[cascade])*0.2;
-	if(cascade_start_dist[cascade+1] - dist_threshold > depth)
-		return samplePoissonPCF(cascade);
-	return mix(samplePoissonPCF(cascade), samplePoissonPCF(cascade+1), smoothstep(cascade_start_dist[cascade+1] - dist_threshold, cascade_start_dist[cascade+1], depth));
-}
-#endif
 
 vec3 FresnelLazarovEnv(vec3 specColor, vec3 view, vec3 normal, float gloss)
 {
@@ -428,7 +337,7 @@ void main()
 #endif
 	float shadow = 1.0;
 #ifdef FLAG_SHADOWS
-	shadow = getShadowValue();
+	shadow = getShadowValue(shadow_map, -fragPosition.z, fragShadowPos.z, fragShadowUV, fardist, middist, neardist, veryneardist);
 #endif
 #ifdef FLAG_LIGHT
 	baseColor.rgb = CalculateLighting(normal, baseColor.rgb, specColor.rgb, glossData, fresnelFactor, shadow, aoFactors.x);

--- a/code/def_files/data/effects/main-f.sdr
+++ b/code/def_files/data/effects/main-f.sdr
@@ -1,6 +1,8 @@
 
 #include "shadows.sdr"
 
+#include "lighting.sdr"
+
 #define MAX_LIGHTS 8
 #define LT_DIRECTIONAL		0
 #define LT_POINT			1
@@ -136,13 +138,6 @@ in vec4 fragShadowUV[4];
 in vec4 fragShadowPos;
 uniform sampler2DArray shadow_map;
 #endif
-#define SPEC_INTENSITY_POINT      5.3 // Point light
-#define SPEC_INTENSITY_DIRECTIONAL   3.0 // Directional light
-#define SPECULAR_FACTOR         1.75
-#define SPEC_FACTOR_NO_SPEC_MAP   0.6
-#define ENV_ALPHA_FACTOR         0.3
-#define GLOW_MAP_INTENSITY         1.5
-#define AMBIENT_LIGHT_BOOST      1.0
 #define SRGB_GAMMA 2.2
 in vec4 fragPosition;
 in vec3 fragNormal;
@@ -159,41 +154,6 @@ vec3 FresnelLazarovEnv(vec3 specColor, vec3 view, vec3 normal, float gloss)
 	return specColor + (vec3(1.0) - specColor) * pow(1.0 - clamp(dot(view, normal), 0.0, 1.0), 5.0) / (4.0 - 3.0 * gloss);
 }
 
-vec3 FresnelSchlick(vec3 specColor, vec3 light, vec3 halfVec)
-{
-	return specColor + (vec3(1.0) - specColor) * pow(1.0 - clamp(dot(light, halfVec), 0.0, 1.0), 5.0);
-}
-
-vec3 SpecularBlinnPhong(vec3 specColor, vec3 light, vec3 normal, vec3 halfVec, float specPower, float fresnel, float dotNL)
-{
-	return mix(specColor, FresnelSchlick(specColor, light, halfVec), fresnel) * ((specPower + 2.0) / 8.0 ) * pow(clamp(dot(normal, halfVec), 0.0, 1.0), specPower) * dotNL;
-}
-
-vec3 SpecularGGX(vec3 specColor, vec3 light, vec3 normal, vec3 halfVec, vec3 view, float gloss, float fresnelFactor, float dotNL)
-{
-	float roughness = clamp(1.0f - gloss, 0.0f, 1.0f);
-	float alpha = roughness * roughness;
-
-	float dotNH = clamp(dot(normal, halfVec), 0.0f, 1.0f);
-	float dotNV = clamp(dot(normal, view), 0.0f, 1.0f);
-
-	float alphaSqr = alpha * alpha;
-	float pi = 3.14159f;
-	float denom = dotNH * dotNH * (alphaSqr - 1.0f) + 1.0f;
-	float distribution = alphaSqr / (pi * denom * denom);
-
-	vec3 fresnel = mix(specColor, FresnelSchlick(specColor, light, halfVec), fresnelFactor);
-	
-	float alphaPrime = roughness + 1.0f;
-	float k = alphaPrime * alphaPrime / 8.0f;
-	float g1vNL = 1.0f / (dotNL * (1.0f - k) + k);
-	float g1vNV = 1.0f / (dotNV * (1.0f - k) + k);
-	float visibility = g1vNL * g1vNV;
-
-	return distribution * fresnel * visibility * dotNL;
-}
-
-#ifdef FLAG_LIGHT
 void GetLightInfo(int i, out vec3 lightDir, out float attenuation)
 {
 	lightDir = normalize(lights[i].position.xyz);
@@ -242,7 +202,7 @@ vec3 CalculateLighting(vec3 normal, vec3 diffuseMaterial, vec3 specularMaterial,
 	}
 	return diffuseMaterial * (lightAmbient + lightDiffuse) + lightSpecular;
 }
-#endif
+
 void main()
 {
 #ifdef WORKAROUND_CLIPPING_PLANES

--- a/code/def_files/data/effects/shadows.sdr
+++ b/code/def_files/data/effects/shadows.sdr
@@ -1,0 +1,94 @@
+
+const float VARIANCE_SHADOW_SCALE = 1000000.0;
+const float VARIANCE_SHADOW_SCALE_INV = 1.0/VARIANCE_SHADOW_SCALE;
+
+vec2 sampleShadowMap(sampler2DArray shadow_map, vec2 uv, vec2 offset_uv, int cascade, float shadowMapSizeInv)
+{
+	return texture(shadow_map, vec3(uv + offset_uv * shadowMapSizeInv, float(cascade))).xy;
+}
+
+float computeShadowFactor(float shadowDepth, vec2 moments, float bias)
+{
+	float shadow = 1.0;
+	if((moments.x - bias) > shadowDepth)
+	{
+		// variance shadow mapping using Chebychev's Formula
+		float variance = moments.y * VARIANCE_SHADOW_SCALE - moments.x * moments.x;
+		float mD = moments.x - bias - shadowDepth;
+		shadow = variance / (variance + mD * mD);
+		shadow = clamp(shadow, 0.0, 1.0);
+	}
+	return shadow;
+}
+
+float sampleNoPCF(sampler2DArray shadow_map, float shadowDepth, int cascade, vec4 shadowUV[4])
+{
+	return computeShadowFactor(shadowDepth, sampleShadowMap(shadow_map, shadowUV[cascade].xy, vec2(0.0, 0.0), cascade, 1.0/1024.0), 0.05);
+}
+
+float samplePoissonPCF(sampler2DArray shadow_map, float shadowDepth, int cascade, vec4 shadowUV[4])
+{
+	if(cascade > 3 || cascade < 0) return 1.0;
+	vec2 poissonDisc[16];
+	poissonDisc[0] = vec2(-0.76275, -0.3432573);
+	poissonDisc[1] = vec2(-0.5226235, -0.8277544);
+	poissonDisc[2] = vec2(-0.3780261, 0.01528688);
+	poissonDisc[3] = vec2(-0.7742821, 0.4245702);
+	poissonDisc[4] = vec2(0.04196143, -0.02622231);
+	poissonDisc[5] = vec2(-0.2974772, -0.4722782);
+	poissonDisc[6] = vec2(-0.516093, 0.71495);
+	poissonDisc[7] = vec2(-0.3257416, 0.3910343);
+	poissonDisc[8] = vec2(0.2705966, 0.6670476);
+	poissonDisc[9] = vec2(0.4918377, 0.1853267);
+	poissonDisc[10] = vec2(0.4428544, -0.6251478);
+	poissonDisc[11] = vec2(-0.09204347, 0.9267113);
+	poissonDisc[12] = vec2(0.391505, -0.2558275);
+	poissonDisc[13] = vec2(0.05605913, -0.7570801);
+	poissonDisc[14] = vec2(0.81772, -0.02475523);
+	poissonDisc[15] = vec2(0.6890262, 0.5191521);
+	float maxUVOffset[4];
+	maxUVOffset[0] = 1.0/300.0;
+	maxUVOffset[1] = 1.0/250.0;
+	maxUVOffset[2] = 1.0/200.0;
+	maxUVOffset[3] = 1.0/200.0;
+	vec2 sum = sampleShadowMap(shadow_map, shadowUV[cascade].xy, poissonDisc[0], cascade, maxUVOffset[cascade])*(1.0/16.0);
+	sum += sampleShadowMap(shadow_map, shadowUV[cascade].xy, poissonDisc[1], cascade, maxUVOffset[cascade])*(1.0/16.0);
+	sum += sampleShadowMap(shadow_map, shadowUV[cascade].xy, poissonDisc[2], cascade, maxUVOffset[cascade])*(1.0/16.0);
+	sum += sampleShadowMap(shadow_map, shadowUV[cascade].xy, poissonDisc[3], cascade, maxUVOffset[cascade])*(1.0/16.0);
+	sum += sampleShadowMap(shadow_map, shadowUV[cascade].xy, poissonDisc[4], cascade, maxUVOffset[cascade])*(1.0/16.0);
+	sum += sampleShadowMap(shadow_map, shadowUV[cascade].xy, poissonDisc[5], cascade, maxUVOffset[cascade])*(1.0/16.0);
+	sum += sampleShadowMap(shadow_map, shadowUV[cascade].xy, poissonDisc[6], cascade, maxUVOffset[cascade])*(1.0/16.0);
+	sum += sampleShadowMap(shadow_map, shadowUV[cascade].xy, poissonDisc[7], cascade, maxUVOffset[cascade])*(1.0/16.0);
+	sum += sampleShadowMap(shadow_map, shadowUV[cascade].xy, poissonDisc[8], cascade, maxUVOffset[cascade])*(1.0/16.0);
+	sum += sampleShadowMap(shadow_map, shadowUV[cascade].xy, poissonDisc[9], cascade, maxUVOffset[cascade])*(1.0/16.0);
+	sum += sampleShadowMap(shadow_map, shadowUV[cascade].xy, poissonDisc[10], cascade, maxUVOffset[cascade])*(1.0/16.0);
+	sum += sampleShadowMap(shadow_map, shadowUV[cascade].xy, poissonDisc[11], cascade, maxUVOffset[cascade])*(1.0/16.0);
+	sum += sampleShadowMap(shadow_map, shadowUV[cascade].xy, poissonDisc[12], cascade, maxUVOffset[cascade])*(1.0/16.0);
+	sum += sampleShadowMap(shadow_map, shadowUV[cascade].xy, poissonDisc[13], cascade, maxUVOffset[cascade])*(1.0/16.0);
+	sum += sampleShadowMap(shadow_map, shadowUV[cascade].xy, poissonDisc[14], cascade, maxUVOffset[cascade])*(1.0/16.0);
+	sum += sampleShadowMap(shadow_map, shadowUV[cascade].xy, poissonDisc[15], cascade, maxUVOffset[cascade])*(1.0/16.0);
+	return computeShadowFactor(shadowDepth, sum, 0.1);
+}
+
+float getShadowValue(sampler2DArray shadow_map, float depth, float shadowDepth, vec4 shadowUV[4], float fardist,
+					 float middist, float neardist, float veryneardist)
+{
+	// Valathil's Shadows
+	int cascade = 4;
+	cascade -= int(step(depth, fardist));
+	cascade -= int(step(depth, middist));
+	cascade -= int(step(depth, neardist));
+	cascade -= int(step(depth, veryneardist));
+	float cascade_start_dist[5];
+	cascade_start_dist[0] = 0.0;
+	cascade_start_dist[1] = veryneardist;
+	cascade_start_dist[2] = neardist;
+	cascade_start_dist[3] = middist;
+	cascade_start_dist[4] = fardist;
+	if(cascade > 3 || cascade < 0) return 1.0;
+	float dist_threshold = (cascade_start_dist[cascade+1] - cascade_start_dist[cascade])*0.2;
+	if(cascade_start_dist[cascade+1] - dist_threshold > depth)
+		return samplePoissonPCF(shadow_map, shadowDepth, cascade, shadowUV);
+	return mix(samplePoissonPCF(shadow_map, shadowDepth, cascade, shadowUV), samplePoissonPCF(shadow_map, shadowDepth, cascade+1, shadowUV),
+			smoothstep(cascade_start_dist[cascade+1] - dist_threshold, cascade_start_dist[cascade+1], depth));
+}

--- a/code/source_groups.cmake
+++ b/code/source_groups.cmake
@@ -187,6 +187,7 @@ set(file_root_def_files_data_effects
 	def_files/data/effects/post-v.sdr
 	def_files/data/effects/shadowdebug-f.sdr
 	def_files/data/effects/shadowdebug-v.sdr
+	def_files/data/effects/shadows.sdr
 	def_files/data/effects/tonemapping-f.sdr
 	def_files/data/effects/video-f.sdr
 	def_files/data/effects/video-v.sdr

--- a/code/source_groups.cmake
+++ b/code/source_groups.cmake
@@ -175,6 +175,7 @@ set(file_root_def_files_data_effects
 	def_files/data/effects/fxaa-f.sdr
 	def_files/data/effects/fxaa-v.sdr
 	def_files/data/effects/fxaapre-f.sdr
+	def_files/data/effects/lighting.sdr
 	def_files/data/effects/ls-f.sdr
 	def_files/data/effects/main-f.sdr
 	def_files/data/effects/main-g.sdr


### PR DESCRIPTION
This can be used for keeping code for common functionality in one file
(e.g. lighting functions). The code which detects include statements is
pretty simple so it may break if it is used in a more complicated.
Circular includes are detected and treated as an error.

There was a slight difference between the GGX function from the main
shader and the deferred shader. The deferred shader didn't use the
fresnel value stored in the G-buffer for some reason. I changed the code
so that both shaders use the same parameters.

@SamuelCho Please let me know if that difference was intentional.