### PR TITLE
Do not try to delete opengl buffers when we have no idea what they are

### DIFF
--- a/code/graphics/opengl/gropengltnl.cpp
+++ b/code/graphics/opengl/gropengltnl.cpp
@@ -293,6 +293,8 @@ void gr_opengl_update_buffer_data_offset(int handle, size_t offset, size_t size,
 
 void gr_opengl_delete_buffer(int handle)
 {
+	if (GL_buffer_objects.size() == 0) return;
+
 	GR_DEBUG_SCOPE("Deleting buffer");
 
 	Assert(handle >= 0);


### PR DESCRIPTION
While working through the atexit table, this function somehow got called, leading to the debug_filter.cfg being altered, as explained in #1615. While this does fix one immediate cause of the behaviour in #1615, it opens up a few more questions: Why gr_opengl_delete_buffer is called at this point, for example.