### PR TITLE
Make AI profile tables actually stop parsing if #End is missing.

### DIFF
--- a/code/ai/ai_profiles.cpp
+++ b/code/ai/ai_profiles.cpp
@@ -498,7 +498,8 @@ void parse_ai_profiles_tbl(const char *filename)
 				}
 
 				// find next valid option
-				skip_to_start_of_string_either("$", "#");
+				if (!skip_to_start_of_string_either("$", "#"))
+					break;
 				saved_Mp = Mp;
 			}
 		}


### PR DESCRIPTION
By making `parse_ai_profiles_tbl()` actually check the return value of `skip_to_start_of_string_either()` (and break if the appropriate characters aren't found), AI profile tables should no longer keep parsing past the end of the file and into invalid memory, until they either find an "#End" in memory somewhere or just plain crash.

As a pleasant bonus, a missing "#End" should now generate an appropriate error message.