### PR TITLE
Use deferred shader for applying directional lights

### DIFF
--- a/code/def_files/data/effects/deferred-clear-f.sdr
+++ b/code/def_files/data/effects/deferred-clear-f.sdr
@@ -2,10 +2,12 @@ out vec4 fragOut0;
 out vec4 fragOut1;
 out vec4 fragOut2;
 out vec4 fragOut3;
+out vec4 fragOut4;
 void main()
 {
 	fragOut0 = vec4(0.0, 0.0, 0.0, 1.0); // color
 	fragOut1 = vec4(0.0, 0.0, -1000000.0, 1.0); // position
 	fragOut2 = vec4(0.0, 0.0, 0.0, 1.0); // normal
 	fragOut3 = vec4(0.0, 0.0, 0.0, 0.0); // specular
+	fragOut4 = vec4(0.0, 0.0, 0.0, 1.0); // emissive
 }

--- a/code/def_files/data/effects/deferred-f.sdr
+++ b/code/def_files/data/effects/deferred-f.sdr
@@ -1,6 +1,8 @@
 
 #include "lighting.sdr"
 
+#include "shadows.sdr"
+
 in vec3 beamVec;
 in vec3 lightPosition;
 out vec4 fragOut0;
@@ -9,10 +11,23 @@ uniform sampler2D ColorBuffer;
 uniform sampler2D NormalBuffer;
 uniform sampler2D PositionBuffer;
 uniform sampler2D SpecBuffer;
+uniform sampler2DArray shadow_map;
 
-uniform float specFactor;
-uniform float invScreenWidth;
-uniform float invScreenHeight;
+layout (std140) uniform globalDeferredData {
+	mat4 shadow_mv_matrix;
+	mat4 shadow_proj_matrix[4];
+
+	mat4 inv_view_matrix;
+
+	float veryneardist;
+	float neardist;
+	float middist;
+	float fardist;
+
+	float specFactor;
+	float invScreenWidth;
+	float invScreenHeight;
+};
 
 layout (std140) uniform lightData {
 	vec3 diffuseLightColor;
@@ -27,8 +42,59 @@ layout (std140) uniform lightData {
 	vec3 scale;
 	float lightRadius;
 
+	vec3 lightDir;
 	int lightType;
+
+	bool enable_shadows;
 };
+
+void GetLightInfo(vec3 position, out vec3 lightDir, out float attenuation)
+{
+	if (lightType == LT_DIRECTIONAL) {
+		lightDir = normalize(lightPosition);
+		attenuation = 1.0;
+	} else {
+		// Positional light source
+		lightDir = lightPosition - position.xyz;
+		float dist = length(lightDir);
+		attenuation = 1.0 - clamp(dist / lightRadius, 0.0, 1.0);
+
+		if(dist > lightRadius && lightType != LT_TUBE) {
+			discard;
+		}
+
+		if (lightType == LT_TUBE) {  // Tube light
+			float beamLength = length(beamVec);
+			vec3 beamDir = beamVec / beamLength;
+			// Get nearest point on line
+			float neardist = clamp(dot(lightDir, beamDir), 0.0, beamLength);
+			// Move back from the endpoint of the beam along the beam by the distance we calculated
+			vec3 nearest = lightPosition - beamDir * neardist;
+			lightDir = nearest - position.xyz;
+			dist = length(lightDir);
+			if(dist > lightRadius) {
+				discard;
+			}
+		} else if (lightType == LT_CONE) {
+			float coneDot = dot(normalize(-lightDir), coneDir);
+			if(dualCone) {
+				if(abs(coneDot) < coneAngle) {
+					discard;
+				} else {
+					attenuation *= smoothstep(coneAngle, coneInnerAngle, abs(coneDot));
+				}
+			} else {
+				if (coneDot < coneAngle) {
+					discard;
+				} else {
+					attenuation *= smoothstep(coneAngle, coneInnerAngle, coneDot);
+				}
+			}
+		}
+
+		lightDir = normalize(lightDir);
+	}
+}
 
 void main()
 {
@@ -37,10 +103,7 @@ void main()
 
 	if(abs(dot(position, position)) < 0.1)
 		discard;
-	vec3 lightDir = lightPosition - position.xyz;
-	float dist = length(lightDir);
-	if(dist > lightRadius && lightType != 1)
-		discard;
+
 	vec3 color = texture(ColorBuffer, screenPos).rgb;
 	vec4 normal = texture(NormalBuffer, screenPos);
 	vec4 specColor = texture(SpecBuffer, screenPos);
@@ -48,39 +111,23 @@ void main()
 	float fresnel = specColor.a;
 	vec3 eyeDir = normalize(-position);
 
-	if(lightType == 1)
-	{
-		float beamLength = length(beamVec);
-		vec3 beamDir = beamVec / beamLength;
-		// Get nearest point on line
-		float neardist = clamp(dot(lightDir, beamDir), 0.0, beamLength);
-		// Move back from the endpoint of the beam along the beam by the distance we calculated
-		vec3 nearest = lightPosition - beamDir * neardist;
-		lightDir = nearest - position.xyz;
-		dist = length(lightDir);
-		if(dist > lightRadius)
-			discard;
+	vec3 lightDir;
+	float attenuation;
+
+	GetLightInfo(position, lightDir, attenuation);
+
+	if (enable_shadows) {
+		vec4 fragShadowPos = shadow_mv_matrix * inv_view_matrix * vec4(position, 1.0);
+		vec4 fragShadowUV[4];
+		fragShadowUV[0] = transformToShadowMap(shadow_proj_matrix[0], 0, fragShadowPos);
+		fragShadowUV[1] = transformToShadowMap(shadow_proj_matrix[1], 1, fragShadowPos);
+		fragShadowUV[2] = transformToShadowMap(shadow_proj_matrix[2], 2, fragShadowPos);
+		fragShadowUV[3] = transformToShadowMap(shadow_proj_matrix[3], 3, fragShadowPos);
+
+		attenuation *= getShadowValue(shadow_map, -position.z, fragShadowPos.z, fragShadowUV, fardist, middist,
+								neardist, veryneardist);
 	}
 
-	float attenuation = 1.0 - clamp(dist / lightRadius, 0.0, 1.0);
-
-	if(lightType == 2)
-	{
-		float coneDot = dot(normalize(-lightDir), coneDir);
-		if(dualCone) {
-			if(abs(coneDot) < coneAngle)
-				discard;
-			else
-				attenuation *= smoothstep(coneAngle, coneInnerAngle, abs(coneDot));
-		} else {
-			if(coneDot < coneAngle)
-				discard;
-			else
-				attenuation *= smoothstep(coneAngle, coneInnerAngle, coneDot);
-		}
-	}
-
-	lightDir /= dist;
 	vec3 halfVec = normalize(lightDir + eyeDir);
 	float NdotL = clamp(dot(normal.xyz, lightDir), 0.0, 1.0);
 	vec4 fragmentColor = vec4(color * (diffuseLightColor * NdotL * attenuation), 1.0);

--- a/code/def_files/data/effects/deferred-v.sdr
+++ b/code/def_files/data/effects/deferred-v.sdr
@@ -1,3 +1,6 @@
+
+#include "lighting.sdr"
+
 in vec4 vertPosition;
 uniform mat4 modelViewMatrix;
 uniform mat4 projMatrix;
@@ -15,15 +18,23 @@ layout (std140) uniform lightData {
 	vec3 scale;
 	float lightRadius;
 
+	vec3 lightDir;
 	int lightType;
+
+	bool enable_shadows;
 };
 
 out vec3 lightPosition;
 out vec3 beamVec;
 void main()
 {
-	gl_Position = projMatrix * modelViewMatrix * vec4(vertPosition.xyz * scale, 1.0);
-	lightPosition = modelViewMatrix[3].xyz;
-	if(lightType == 1)
-		beamVec = vec3(modelViewMatrix * vec4(0.0, 0.0, -scale.z, 0.0));
+	if (lightType == LT_DIRECTIONAL) {
+		gl_Position = vec4(vertPosition.xyz, 1.0);
+		lightPosition = lightDir;
+	} else {
+		gl_Position = projMatrix * modelViewMatrix * vec4(vertPosition.xyz * scale, 1.0);
+		lightPosition = modelViewMatrix[3].xyz;
+		if(lightType == LT_TUBE)
+			beamVec = vec3(modelViewMatrix * vec4(0.0, 0.0, -scale.z, 0.0));
+	}
 }

--- a/code/def_files/data/effects/lighting.sdr
+++ b/code/def_files/data/effects/lighting.sdr
@@ -1,4 +1,9 @@
 
+const int LT_DIRECTIONAL	= 0;		// A light like a sun
+const int LT_POINT			= 1;		// A point light, like an explosion
+const int LT_TUBE			= 2;		// A tube light, like a fluorescent light
+const int LT_CONE			= 3;		// A cone light, like a flood light
+
 const float SPEC_INTENSITY_POINT		= 5.3 ;// Point light
 const float SPEC_INTENSITY_DIRECTIONAL	= 3.0 ;// Directional light
 const float SPECULAR_FACTOR				= 1.75;

--- a/code/def_files/data/effects/main-f.sdr
+++ b/code/def_files/data/effects/main-f.sdr
@@ -146,6 +146,7 @@ out vec4 fragOut0;
 out vec4 fragOut1;
 out vec4 fragOut2;
 out vec4 fragOut3;
+out vec4 fragOut4;
 
 vec3 FresnelLazarovEnv(vec3 specColor, vec3 view, vec3 normal, float gloss)
 {
@@ -213,12 +214,15 @@ void main()
 #ifdef FLAG_SHADOW_MAP
 	// need depth and depth squared for variance shadow maps
 	fragOut0 = vec4(fragPosition.z, fragPosition.z * fragPosition.z * VARIANCE_SHADOW_SCALE_INV, 0.0, 1.0);
-	return;
+	if (true) {
+		return;
+	}
 #endif
 	vec3 eyeDir = vec3(normalize(-fragPosition).xyz);
 	vec2 texCoord = fragTexCoord.xy;
 	vec4 baseColor = color;
 	vec4 specColor = vec4(0.0, 0.0, 0.0, 1.0);
+	vec4 emissiveColor = vec4(0.0, 0.0, 0.0, 1.0);
 	float fresnelFactor = 0.0;
 	float glossData = 0.6;
 #ifdef FLAG_LIGHT
@@ -295,30 +299,45 @@ void main()
 	baseColor.rgb = max(baseColor.rgb, vec3(0.0));
  #endif
 #endif
-	float shadow = 1.0;
-#ifdef FLAG_SHADOWS
-	shadow = getShadowValue(shadow_map, -fragPosition.z, fragShadowPos.z, fragShadowUV, fardist, middist, neardist, veryneardist);
-#endif
-#ifdef FLAG_LIGHT
-	baseColor.rgb = CalculateLighting(normal, baseColor.rgb, specColor.rgb, glossData, fresnelFactor, shadow, aoFactors.x);
-#else
- #ifdef FLAG_SPEC_MAP
+	// Lights aren't applied when we are rendering to the G-buffers since that gets handled later
+#ifdef FLAG_DEFERRED
+ #ifdef FLAG_LIGHT
+	// Ambient lighting still needs to be done since that counts as an "emissive" color
+	vec3 lightAmbient = (emissionFactor + ambientFactor * ambientFactor) * aoFactors.x; // ambientFactor^2 due to legacy OpenGL compatibility behavior
+	emissiveColor.rgb += baseColor.rgb * lightAmbient;
+ #else
+  #ifdef FLAG_SPEC_MAP
 	baseColor.rgb += pow(1.0 - clamp(dot(eyeDir, normal), 0.0, 1.0), 5.0 * clamp(glossData, 0.01, 1.0)) * specColor.rgb;
+  #endif
+	// If there is no lighting then we copy the color data so far into the
+	emissiveColor.rgb += baseColor.rgb;
+ #endif
+#else
+ #ifdef FLAG_LIGHT
+	float shadow = 1.0;
+  #ifdef FLAG_SHADOWS
+	shadow = getShadowValue(shadow_map, -fragPosition.z, fragShadowPos.z, fragShadowUV, fardist, middist, neardist, veryneardist);
+  #endif
+	baseColor.rgb = CalculateLighting(normal, baseColor.rgb, specColor.rgb, glossData, fresnelFactor, shadow, aoFactors.x);
+ #else
+  #ifdef FLAG_SPEC_MAP
+	baseColor.rgb += pow(1.0 - clamp(dot(eyeDir, normal), 0.0, 1.0), 5.0 * clamp(glossData, 0.01, 1.0)) * specColor.rgb;
+  #endif
  #endif
 #endif
 #ifdef FLAG_ENV_MAP
-   vec3 envReflectNM = fragEnvReflect;
+	vec3 envReflectNM = fragEnvReflect;
  #ifdef FLAG_NORMAL_MAP
-   envReflectNM += vec3(normalSample, 0.0);
+	envReflectNM += vec3(normalSample, 0.0);
 	envReflectNM = normalize(envReflectNM);
  #endif
 	float mip = (envGloss) ? (1.0 - glossData) * 7.0 : 0.0;
-   vec4 envColour = textureLod(sEnvmap, envReflectNM, mip);
+	vec4 envColour = textureLod(sEnvmap, envReflectNM, mip);
  #ifdef FLAG_HDR
 	envColour.rgb = pow(envColour.rgb, vec3(SRGB_GAMMA));
  #endif
 	envColour.rgb *= (envGloss) ? 1.0 : specColor.a;
-	baseColor.rgb += envColour.rgb * FresnelLazarovEnv(specColor.rgb, eyeDir, normal, glossData);
+	emissiveColor.rgb += envColour.rgb * FresnelLazarovEnv(specColor.rgb, eyeDir, normal, glossData);
 #endif
 #ifdef FLAG_GLOW_MAP
 	vec3 glowColor = texture(sGlowmap, vec3(texCoord, float(sGlowmapIndex))).rgb;
@@ -332,7 +351,7 @@ void main()
 	glowColor = team_glow_enabled ? mix((base * teamMask.b) + (stripe * teamMask.a), glowColor, clamp(glowColorLuminance - teamMask.b - teamMask.a, 0.0, 1.0)) : glowColor;
   #endif
  #endif
-   baseColor.rgb += glowColor * GLOW_MAP_INTENSITY;
+   emissiveColor.rgb += glowColor * GLOW_MAP_INTENSITY;
 #endif
 
 #ifdef FLAG_FOG
@@ -355,15 +374,13 @@ void main()
 #ifdef FLAG_ANIMATED
    if (effect_num == 0) {
       float shinefactor = 1.0/(1.0 + pow(abs((fract(abs(texCoord.x))-anim_timer) * 1000.0), 2.0)) * 1000.0;
-      baseColor.rgb = baseColor.rgb + vec3(shinefactor);
+      emissiveColor.rgb += vec3(shinefactor);
       baseColor.a = baseColor.a * clamp(shinefactor * (fract(abs(texCoord.x))-anim_timer) * -10000.0,0.0,1.0);
    }
    if (effect_num == 1) {
       float shinefactor = 1.0/(1.0 + pow(abs(fragPosition.y-anim_timer), 2.0));
-      baseColor.rgb = baseColor.rgb + vec3(shinefactor);
- #ifdef FLAG_LIGHT
-      baseColor.a = baseColor.a;
- #else
+      emissiveColor.rgb += vec3(shinefactor);
+ #ifndef FLAG_LIGHT
       // ATI Wireframe fix *grumble*
       baseColor.a = clamp((fragPosition.y-anim_timer) * 10000.0,0.0,1.0);
  #endif
@@ -383,10 +400,15 @@ void main()
 	float normViewOffset = dot(vec3(0.0, 0.0, 1.0), normal);
 	baseColor.a = smoothstep(min(normalAlphaMinMax.x, normalAlphaMinMax.y), max(normalAlphaMinMax.x, normalAlphaMinMax.y), clamp(normalAlphaMinMax.x > normalAlphaMinMax.y ? normViewOffset : 1.0 - normViewOffset, 0.0, 1.0));
 #endif
+#ifndef FLAG_DEFERRED
+	// emissive colors won't be added later when we are using forward rendering so we need to do that here
+	baseColor.rgb += emissiveColor.rgb;
+#endif
 	fragOut0 = baseColor;
 #ifdef FLAG_DEFERRED
 	fragOut1 = vec4(fragPosition.xyz, 1.0);
 	fragOut2 = vec4(normal, glossData);
 	fragOut3 = vec4(specColor.rgb, fresnelFactor);
+	fragOut4 = emissiveColor;
 #endif
 }

--- a/code/def_files/data/effects/main-v.sdr
+++ b/code/def_files/data/effects/main-v.sdr
@@ -1,5 +1,7 @@
 #extension GL_ARB_gpu_shader5: enable
 
+#include "shadows.sdr"
+
 #define MAX_LIGHTS 8
 
 struct model_light {
@@ -144,18 +146,6 @@ void getModelTransform(inout mat4 transform, out bool invisible, int id, int mat
 	transform[3].w = 1.0;
 }
 #endif
-#ifdef FLAG_SHADOWS
-vec4 transformToShadowMap(int i, vec4 pos)
-{
-	vec4 shadow_proj;
-	shadow_proj = shadow_proj_matrix[i] * pos;
-	shadow_proj += 1.0;
-	shadow_proj *= 0.5;
-	shadow_proj.w = shadow_proj.z;
-	shadow_proj.z = float(i);
-	return shadow_proj;
-}
-#endif
 void main()
 {
 	vec4 position;
@@ -210,10 +200,10 @@ void main()
  #endif
  #ifdef FLAG_SHADOWS
 	fragShadowPos = shadow_mv_matrix * modelMatrix * orient * vertPosition;
-	fragShadowUV[0] = transformToShadowMap(0, fragShadowPos);
-	fragShadowUV[1] = transformToShadowMap(1, fragShadowPos);
-	fragShadowUV[2] = transformToShadowMap(2, fragShadowPos);
-	fragShadowUV[3] = transformToShadowMap(3, fragShadowPos);
+	fragShadowUV[0] = transformToShadowMap(shadow_proj_matrix[0], 0, fragShadowPos);
+	fragShadowUV[1] = transformToShadowMap(shadow_proj_matrix[1], 1, fragShadowPos);
+	fragShadowUV[2] = transformToShadowMap(shadow_proj_matrix[2], 2, fragShadowPos);
+	fragShadowUV[3] = transformToShadowMap(shadow_proj_matrix[3], 3, fragShadowPos);
  #endif
  #ifdef FLAG_NORMAL_MAP
  // Setup stuff for normal maps

--- a/code/def_files/data/effects/shadows.sdr
+++ b/code/def_files/data/effects/shadows.sdr
@@ -92,3 +92,14 @@ float getShadowValue(sampler2DArray shadow_map, float depth, float shadowDepth, 
 	return mix(samplePoissonPCF(shadow_map, shadowDepth, cascade, shadowUV), samplePoissonPCF(shadow_map, shadowDepth, cascade+1, shadowUV),
 			smoothstep(cascade_start_dist[cascade+1] - dist_threshold, cascade_start_dist[cascade+1], depth));
 }
+
+vec4 transformToShadowMap(mat4 shadow_proj_matrix, int i, vec4 pos)
+{
+	vec4 shadow_proj;
+	shadow_proj = shadow_proj_matrix * pos;
+	shadow_proj += 1.0;
+	shadow_proj *= 0.5;
+	shadow_proj.w = shadow_proj.z;
+	shadow_proj.z = float(i);
+	return shadow_proj;
+}

--- a/code/graphics/2d.h
+++ b/code/graphics/2d.h
@@ -202,6 +202,7 @@ enum class uniform_block_type {
 	NanoVGData = 2,
 	DecalInfo = 3,
 	DecalGlobals = 4,
+	DeferredGlobals = 5,
 
 	NUM_BLOCK_TYPES
 };

--- a/code/graphics/material.cpp
+++ b/code/graphics/material.cpp
@@ -496,6 +496,18 @@ void model_material::set_shadow_casting(bool enabled)
 	Shadow_casting = enabled;
 }
 
+bool model_material::is_shadow_casting() const {
+	return Shadow_casting;
+}
+
+void model_material::set_shadow_receiving(bool enabled) {
+	Shadow_receiving = enabled;
+}
+
+bool model_material::is_shadow_receiving() const {
+	return Shadow_receiving;
+}
+
 void model_material::set_light_factor(float factor)
 {
 	Light_factor = factor;
@@ -700,7 +712,7 @@ uint model_material::get_shader_flags() const
 	if ( lighting ) {
 		Shader_flags |= SDR_FLAG_MODEL_LIGHT;
 		
-		if ( Cmdline_shadow_quality && !Shadow_casting && !Shadow_override ) {
+		if ( Shadow_receiving && !Shadow_override ) {
 			Shader_flags |= SDR_FLAG_MODEL_SHADOWS;
 		}
 	}

--- a/code/graphics/material.h
+++ b/code/graphics/material.h
@@ -168,6 +168,7 @@ class model_material : public material
 	bool Desaturate = false;
 
 	bool Shadow_casting = false;
+	bool Shadow_receiving = false;
 	bool Batched = false;
 
 	bool Deferred = false;
@@ -200,6 +201,9 @@ public:
 
 	void set_shadow_casting(bool enabled);
 	bool is_shadow_casting() const;
+
+	void set_shadow_receiving(bool enabled);
+	bool is_shadow_receiving() const;
 
 	void set_light_factor(float factor);
 	float get_light_factor() const;

--- a/code/graphics/opengl/gropengldraw.h
+++ b/code/graphics/opengl/gropengldraw.h
@@ -23,6 +23,7 @@ extern GLuint Scene_color_texture;
 extern GLuint Scene_position_texture;
 extern GLuint Scene_normal_texture;
 extern GLuint Scene_specular_texture;
+extern GLuint Scene_emissive_texture;
 extern GLuint Scene_luminance_texture;
 extern GLuint Scene_effect_texture;
 extern GLuint Scene_depth_texture;

--- a/code/graphics/opengl/gropenglpostprocessing.cpp
+++ b/code/graphics/opengl/gropenglpostprocessing.cpp
@@ -253,7 +253,7 @@ void opengl_post_pass_fxaa() {
 
 	// We only want to draw to ATTACHMENT0
 	glDrawBuffer(GL_COLOR_ATTACHMENT0);
-	glColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
+	GL_state.ColorMask(true, true, true, true);
 
 	// Do a prepass to convert the main shaders' RGBA output into RGBL
 	opengl_shader_set_current( gr_opengl_maybe_create_shader(SDR_TYPE_POST_PROCESS_FXAA_PREPASS, 0) );

--- a/code/graphics/opengl/gropenglshader.cpp
+++ b/code/graphics/opengl/gropenglshader.cpp
@@ -56,6 +56,7 @@ opengl_uniform_block_binding GL_uniform_blocks[] = {
 	{ uniform_block_type::NanoVGData, "NanoVGUniformData" },
 	{ uniform_block_type::DecalInfo, "decalInfoData" },
 	{ uniform_block_type::DecalGlobals, "decalGlobalData" },
+	{ uniform_block_type::DeferredGlobals, "globalDeferredData" },
 };
 
 /**
@@ -847,9 +848,7 @@ void opengl_shader_compile_deferred_light_shader()
 		Current_shader->program->Uniforms.setUniformi("NormalBuffer", 1);
 		Current_shader->program->Uniforms.setUniformi("PositionBuffer", 2);
 		Current_shader->program->Uniforms.setUniformi("SpecBuffer", 3);
-		Current_shader->program->Uniforms.setUniformf("invScreenWidth", 1.0f / gr_screen.max_w);
-		Current_shader->program->Uniforms.setUniformf("invScreenHeight", 1.0f / gr_screen.max_h);
-		Current_shader->program->Uniforms.setUniformf("specFactor", Cmdline_ogl_spec);
+		Current_shader->program->Uniforms.setUniformi("shadow_map", 4);
 	} else {
 		opengl_shader_set_current();
 		mprintf(("Failed to compile deferred lighting shader!\n"));

--- a/code/graphics/opengl/gropengltnl.cpp
+++ b/code/graphics/opengl/gropengltnl.cpp
@@ -424,6 +424,7 @@ void opengl_tnl_init()
 		GL_state.Texture.SetActiveUnit(0);
 		GL_state.Texture.SetTarget(GL_TEXTURE_2D_ARRAY);
 		GL_state.Texture.Enable(Shadow_map_depth_texture);
+		opengl_set_object_label(GL_TEXTURE, Shadow_map_depth_texture, "Scene shadow depth map");
 
 		glTexParameteri(GL_TEXTURE_2D_ARRAY, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
 		glTexParameteri(GL_TEXTURE_2D_ARRAY, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
@@ -451,6 +452,7 @@ void opengl_tnl_init()
 		GL_state.Texture.SetActiveUnit(0);
 		GL_state.Texture.SetTarget(GL_TEXTURE_2D_ARRAY);
 		GL_state.Texture.Enable(Shadow_map_texture);
+		opengl_set_object_label(GL_TEXTURE, Shadow_map_texture, "Scene shadow map");
 
 		glTexParameteri(GL_TEXTURE_2D_ARRAY, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
 		glTexParameteri(GL_TEXTURE_2D_ARRAY, GL_TEXTURE_MAG_FILTER, GL_LINEAR);

--- a/code/graphics/opengl/gropengltnl.h
+++ b/code/graphics/opengl/gropengltnl.h
@@ -33,6 +33,8 @@ extern float shadow_middist;
 extern float shadow_fardist;
 extern bool Rendering_to_shadow_map;
 
+extern GLuint Shadow_map_texture;
+
 struct opengl_vertex_bind {
 	vertex_format_data::vertex_format format;
 	GLint size;

--- a/code/graphics/util/UniformBufferManager.cpp
+++ b/code/graphics/util/UniformBufferManager.cpp
@@ -25,11 +25,12 @@ size_t getElementSize(uniform_block_type type) {
 size_t getHeaderSize(uniform_block_type type) {
 	switch (type) {
 	case uniform_block_type::Lights:
+		return sizeof(graphics::deferred_global_data);
+	case uniform_block_type::DecalInfo:
+		return sizeof(graphics::decal_globals);
 	case uniform_block_type::ModelData:
 	case uniform_block_type::NanoVGData:
 		return 0;
-	case uniform_block_type::DecalInfo:
-		return sizeof(graphics::decal_globals);
 	case uniform_block_type::NUM_BLOCK_TYPES:
 	default:
 		Assertion(false, "Invalid block type encountered!");

--- a/code/graphics/util/uniform_structs.h
+++ b/code/graphics/util/uniform_structs.h
@@ -11,6 +11,24 @@ namespace graphics {
  * Read the OpenGL specification for the exact layout and padding rules.
  */
 
+struct deferred_global_data {
+	matrix4 shadow_mv_matrix;
+	matrix4 shadow_proj_matrix[4];
+
+	matrix4 inv_view_matrix;
+
+	float veryneardist;
+	float neardist;
+	float middist;
+	float fardist;
+
+	float specFactor;
+	float invScreenWidth;
+	float invScreenHeight;
+
+	float pad;
+};
+
 /**
  * @brief Data for one deferred light rendering call
  */
@@ -27,9 +45,12 @@ struct deferred_light_data {
 	vec3d scale;
 	float lightRadius;
 
+	vec3d lightDir;
 	int lightType;
 
-	int pad0[3]; // Struct size must be 16-bytes aligned because we use vec3s
+	int enable_shadows;
+
+	float pad0[3]; // Struct size must be 16-bytes aligned because we use vec3s
 };
 
 struct model_light {

--- a/code/model/modelrender.cpp
+++ b/code/model/modelrender.cpp
@@ -488,9 +488,17 @@ void model_draw_list::add_buffer_draw(model_material *render_material, indexed_v
 {
 	queued_buffer_draw draw_data;
 
-	render_material->set_deferred_lighting(Deferred_lighting);
-	render_material->set_high_dynamic_range(High_dynamic_range);
-	render_material->set_shadow_casting(Rendering_to_shadow_map ? true : false);
+	if (Rendering_to_shadow_map) {
+		render_material->set_shadow_casting(true);
+	} else {
+		// If the zbuffer type is FULL then this buffer may be drawn in the deferred lighting part otehrwise we need to
+		// make sure that the deferred flag is disabled or else some parts of the rendered colors go missing
+		// TODO: This should really be handled somewhere else. This feels like a crude hack...
+		auto possibly_deferred = render_material->get_depth_mode() == ZBUFFER_TYPE_FULL;
+		render_material->set_deferred_lighting(possibly_deferred ? Deferred_lighting : false);
+		render_material->set_high_dynamic_range(High_dynamic_range);
+		render_material->set_shadow_receiving(Cmdline_shadow_quality != 0);
+	}
 
 	if (tmap_flags & TMAP_FLAG_BATCH_TRANSFORMS && buffer->flags & VB_FLAG_MODEL_ID) {
 		vm_matrix4_set_identity(&draw_data.transform);


### PR DESCRIPTION
This moves all lighting operations into the deferred shading phase of
the rendering pipeline. Previously, directional lights were applied to
all objects while they were being rendered. This was probably done to
avoid doing multiple full screen passes later but caused some problems
since the color information in the G-buffers was not correct for doing
later lighting operations.

This was especially noticeable in dark scenes where point lights would
appear to ignore the color of the rendered objects. This should be fixed
with these changes.

I did some performance testing and to my surprise this actually improves
performance in very demanding scenes. My guess would be that applying
the shadows while rendering the objects caused a lot of overdraw which
is not the case anymore since shadows are only computed for visible
pixels. In simple scenes the opposite happens which leads to decreased
performance in those cases but in my opinion the improvement in
demanding scenes outweighs this performance decrease.

There are still some issues with flickering lights so until I can fix that this
should not be merged.