### PR TITLE
Remove gr_set_fog

### DIFF
--- a/code/graphics/2d.h
+++ b/code/graphics/2d.h
@@ -630,7 +630,6 @@ typedef struct screen {
 
 	int		current_alphablend_mode;		// See GR_ALPHABLEND defines above
 	int		current_bitblt_mode;				// See GR_BITBLT_MODE defines above
-	int		current_fog_mode;					// See GR_FOGMODE_* defines above
 	int		current_bitmap;
 	color		current_color;
 	color		current_fog_color;				// current fog color
@@ -692,9 +691,6 @@ typedef struct screen {
 
 	// grab a region of the screen. assumes data is large enough
 	void (*gf_get_region)(int front, int w, int h, ubyte *data);
-
-	// set fog attributes
-	void (*gf_fog_set)(int fog_mode, int r, int g, int b, float fog_near, float fog_far);
 
 	// poly culling
 	int (*gf_set_cull)(int cull);
@@ -926,11 +922,6 @@ void gr_shield_icon(coord2d coords[6], const int resize_mode = GR_RESIZE_FULL);
 #define gr_set_gamma			GR_CALL(gr_screen.gf_set_gamma)
 
 #define gr_get_region		GR_CALL(gr_screen.gf_get_region)
-
-__inline void gr_fog_set(int fog_mode, int r, int g, int b, float fog_near = -1.0f, float fog_far = -1.0f)
-{
-	(*gr_screen.gf_fog_set)(fog_mode, r, g, b, fog_near, fog_far);
-}
 
 #define gr_set_cull			GR_CALL(gr_screen.gf_set_cull)
 #define gr_set_color_buffer	GR_CALL(gr_screen.gf_set_color_buffer)

--- a/code/graphics/grstub.cpp
+++ b/code/graphics/grstub.cpp
@@ -438,8 +438,6 @@ bool gr_stub_init()
 	
 	gr_screen.gf_set_gamma			= gr_stub_set_gamma;
 
-	gr_screen.gf_fog_set			= gr_stub_fog_set;	
-
 	// UnknownPlayer : Don't recognize this - MAY NEED DEBUGGING
 	gr_screen.gf_get_region			= gr_stub_get_region;
 

--- a/code/graphics/material.cpp
+++ b/code/graphics/material.cpp
@@ -195,13 +195,6 @@ Depth_bias(0)
 	Texture_maps[TM_SPEC_GLOSS_TYPE] = -1;
 	Texture_maps[TM_AMBIENT_TYPE] = -1;
 
-	Fog_params.dist_near = -1.0f;
-	Fog_params.dist_far = -1.0f;
-	Fog_params.r = 0;
-	Fog_params.g = 0;
-	Fog_params.b = 0;
-	Fog_params.enabled = false;
-
 	Clip_params.enabled = false;
 
 	Color_mask.x = true;
@@ -300,31 +293,6 @@ void material::set_texture_addressing(int addressing)
 int material::get_texture_addressing() const
 {
 	return Texture_addressing;
-}
-
-void material::set_fog(int r, int g, int b, float _near, float _far)
-{
-	Fog_params.enabled = true;
-	Fog_params.r = r;
-	Fog_params.g = g;
-	Fog_params.b = b;
-	Fog_params.dist_near = _near;
-	Fog_params.dist_far = _far;
-}
-
-void material::set_fog()
-{
-	Fog_params.enabled = false;
-}
-
-bool material::is_fogged() const
-{
-	return Fog_params.enabled;
-}
-
-const material::fog& material::get_fog() const
-{
-	return Fog_params; 
 }
 
 void material::set_depth_mode(gr_zbuffer_type mode)
@@ -640,6 +608,31 @@ bool model_material::is_normal_extrude_active() const
 float model_material::get_normal_extrude_width() const
 {
 	return Normal_extrude_width;
+}
+
+void model_material::set_fog(int r, int g, int b, float _near, float _far)
+{
+	Fog_params.enabled = true;
+	Fog_params.r = r;
+	Fog_params.g = g;
+	Fog_params.b = b;
+	Fog_params.dist_near = _near;
+	Fog_params.dist_far = _far;
+}
+
+void model_material::set_fog()
+{
+	Fog_params.enabled = false;
+}
+
+bool model_material::is_fogged() const
+{
+	return Fog_params.enabled;
+}
+
+const model_material::fog& model_material::get_fog() const
+{
+	return Fog_params;
 }
 
 uint model_material::get_shader_flags() const

--- a/code/graphics/material.h
+++ b/code/graphics/material.h
@@ -30,16 +30,6 @@ enum class StencilOperation {
 class material
 {
 public:
-	struct fog 
-	{
-		bool enabled;
-		int r;
-		int g;
-		int b;
-		float dist_near;
-		float dist_far;
-	};
-
 	struct clip_plane
 	{
 		bool enabled;
@@ -74,7 +64,6 @@ private:
 
 	clip_plane Clip_params;
 	int Texture_addressing;
-	fog Fog_params;
 	gr_zbuffer_type Depth_mode;
 	gr_alpha_blend Blend_mode;
 	bool Cull_mode;
@@ -111,11 +100,6 @@ public:
 
 	void set_texture_addressing(int addressing);
 	int get_texture_addressing() const;
-
-	void set_fog(int r, int g, int b, float near, float far);
-	void set_fog();
-	bool is_fogged() const;
-	const fog& get_fog() const;
 
 	void set_depth_mode(gr_zbuffer_type mode);
 	gr_zbuffer_type get_depth_mode() const;
@@ -165,6 +149,18 @@ public:
 
 class model_material : public material
 {
+ public:
+	struct fog
+	{
+		bool enabled = false;
+		int r = 0;
+		int g = 0;
+		int b = 0;
+		float dist_near = -1.0f;
+		float dist_far = -1.0f;
+	};
+
+ private:
 	bool Desaturate = false;
 
 	bool Shadow_casting = false;
@@ -192,6 +188,7 @@ class model_material : public material
 	bool Normal_extrude = false;
 	float Normal_extrude_width = -1.0f;
 
+	fog Fog_params;
 public:
 	model_material();
 
@@ -240,6 +237,11 @@ public:
 	bool is_batched() const;
 
 	virtual uint get_shader_flags() const override;
+
+	void set_fog(int r, int g, int b, float near, float far);
+	void set_fog();
+	bool is_fogged() const;
+	const fog& get_fog() const;
 };
 
 class particle_material : public material

--- a/code/graphics/opengl/gropengl.cpp
+++ b/code/graphics/opengl/gropengl.cpp
@@ -409,21 +409,6 @@ void gr_opengl_cleanup(bool closing, int minimize)
 	graphic_operations.reset();
 }
 
-void gr_opengl_fog_set(int fog_mode, int r, int g, int b, float fog_near, float fog_far)
-{
-//	mprintf(("gr_opengl_fog_set(%d,%d,%d,%d,%f,%f)\n",fog_mode,r,g,b,fog_near,fog_far));
-
-	Assert((r >= 0) && (r < 256));
-	Assert((g >= 0) && (g < 256));
-	Assert((b >= 0) && (b < 256));
-
-	if (fog_mode == GR_FOGMODE_NONE) {
-		gr_screen.current_fog_mode = fog_mode;
-
-		return;
-	}
-}
-
 int gr_opengl_set_cull(int cull)
 {
 	GLboolean enabled = GL_FALSE;
@@ -1106,8 +1091,6 @@ void opengl_setup_function_pointers()
 	gr_screen.gf_free_screen		= gr_opengl_free_screen;
 
 	gr_screen.gf_set_gamma			= gr_opengl_set_gamma;
-
-	gr_screen.gf_fog_set			= gr_opengl_fog_set;
 
 	// UnknownPlayer : Don't recognize this - MAY NEED DEBUGGING
 	gr_screen.gf_get_region			= gr_opengl_get_region;

--- a/code/graphics/opengl/gropengltnl.cpp
+++ b/code/graphics/opengl/gropengltnl.cpp
@@ -666,14 +666,6 @@ void opengl_tnl_set_material(material* material_info, bool set_base_map, bool se
 
 	gr_set_fill_mode(material_info->get_fill_mode());
 
-	auto& fog_params = material_info->get_fog();
-
-	if ( fog_params.enabled ) {
-		gr_fog_set(GR_FOGMODE_FOG, fog_params.r, fog_params.g, fog_params.b, fog_params.dist_near, fog_params.dist_far);
-	} else {
-		gr_fog_set(GR_FOGMODE_NONE, 0, 0, 0);
-	}
-
 	gr_set_texture_addressing(material_info->get_texture_addressing());
 
 	if (set_clipping) {

--- a/code/graphics/uniforms.cpp
+++ b/code/graphics/uniforms.cpp
@@ -248,7 +248,7 @@ void convert_model_material(model_uniform_data* data_out,
 
 
 	if (shader_flags & SDR_FLAG_MODEL_FOG) {
-		material::fog fog_params = material.get_fog();
+		auto& fog_params = material.get_fog();
 
 		if (fog_params.enabled) {
 			data_out->fogStart = fog_params.dist_near;

--- a/code/nebula/neb.cpp
+++ b/code/nebula/neb.cpp
@@ -1074,7 +1074,6 @@ void neb2_render_player()
 				//gr_set_bitmap(Neb2_cubes[idx1][idx2][idx3].bmap, GR_ALPHABLEND_FILTER, GR_BITBLT_MODE_NORMAL, (alpha + Neb2_cubes[idx1][idx2][idx3].flash));
 
 				gr_set_lighting(false, false);
-				//gr_fog_set(GR_FOGMODE_NONE, 0, 0, 0);
 				//g3_draw_rotated_bitmap(&p, fl_radians(Neb2_cubes[idx1][idx2][idx3].rot), Nd->prad, TMAP_FLAG_TEXTURED);
 				material mat_params;
 				material_set_unlit(&mat_params, Neb2_cubes[idx1][idx2][idx3].bmap, alpha + Neb2_cubes[idx1][idx2][idx3].flash, true, true);

--- a/code/object/objectsort.cpp
+++ b/code/object/objectsort.cpp
@@ -265,12 +265,6 @@ void obj_render_all(void (*render_function)(object *objp), bool *draw_viewer_las
 			// get the fog values
 			neb2_get_adjusted_fog_values(&fog_near, &fog_far, obj);
 
-			// only reset fog if the fog mode has changed - since regenerating a fog table takes
-			// a bit of time
-			if((fog_near != gr_screen.fog_near) || (fog_far != gr_screen.fog_far)){
-		 		gr_fog_set(GR_FOGMODE_FOG, gr_screen.current_fog_color.red, gr_screen.current_fog_color.green, gr_screen.current_fog_color.blue, fog_near, fog_far);
-			}
-
 			// maybe skip rendering an object because its obscured by the nebula
 			if(neb2_skip_render(obj, os->z)){
 				continue;
@@ -308,12 +302,6 @@ void obj_render_all(void (*render_function)(object *objp), bool *draw_viewer_las
 			// get the fog values
 			neb2_get_adjusted_fog_values(&fog_near, &fog_far, obj);
 
-			// only reset fog if the fog mode has changed - since regenerating a fog table takes
-			// a bit of time
-			if((GR_FOGMODE_FOG != gr_screen.current_fog_mode) || (fog_near != gr_screen.fog_near) || (fog_far != gr_screen.fog_far)) {
-				gr_fog_set(GR_FOGMODE_FOG, gr_screen.current_fog_color.red, gr_screen.current_fog_color.green, gr_screen.current_fog_color.blue, fog_near, fog_far);
-			}
-
 			// maybe skip rendering an object because its obscured by the nebula
 			if(neb2_skip_render(obj, os->z)){
 				continue;
@@ -327,11 +315,6 @@ void obj_render_all(void (*render_function)(object *objp), bool *draw_viewer_las
 	
 	batching_render_all();
 	batching_render_all(true);
-
-	// if we're fullneb, switch off the fog effet
-	if((The_mission.flags[Mission::Mission_Flags::Fullneb]) && (Neb2_render_mode != NEB2_RENDER_NONE)){
-		gr_fog_set(GR_FOGMODE_NONE, 0, 0, 0);
-	}
 }
 
 void obj_render_queue_all()
@@ -417,11 +400,6 @@ void obj_render_queue_all()
 
 	gr_reset_lighting();
 	gr_set_lighting(false, false);
-	
-	// if we're fullneb, switch off the fog effet
-	if((The_mission.flags[Mission::Mission_Flags::Fullneb]) && (Neb2_render_mode != NEB2_RENDER_NONE)){
-		gr_fog_set(GR_FOGMODE_NONE, 0, 0, 0);
-	}
 
 	batching_render_all();
 

--- a/code/starfield/starfield.cpp
+++ b/code/starfield/starfield.cpp
@@ -1694,11 +1694,6 @@ void stars_draw_debris()
 
 	gr_set_color( 0, 0, 0 );
 
-	// turn off fogging
-	if (The_mission.flags[Mission::Mission_Flags::Fullneb]) {
-		gr_fog_set(GR_FOGMODE_NONE, 0, 0, 0);
-	}
-
 	old_debris * d = odebris; 
 
 	for (i=0; i<MAX_DEBRIS; i++, d++ ) {


### PR DESCRIPTION
Specifying the fog rendering options is now handled by the materials
system and the implementation of `gr_set_fog` was pretty much empty so I
removed it.