### PR TITLE
Fixes electronics flag behavior with shockwaves

### DIFF
--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -6007,12 +6007,7 @@ void weapon_do_area_effect(object *wobjp, shockwave_create_info *sci, vec3d *pos
 
 	}	// end for
 
-	// if this weapon has the "Electronics" flag set, then disrupt subsystems in sphere
-	if ( (other_obj != NULL) && (wip->wi_flags[Weapon::Info_Flags::Electronics]) ) {
-		if ( other_obj->type == OBJ_SHIP ) {
-			weapon_do_electronics_effect(other_obj, pos, Weapons[wobjp->instance].weapon_info_index);
-		}
-	}
+
 }
 
 //	----------------------------------------------------------------------
@@ -6262,6 +6257,13 @@ void weapon_hit( object * weapon_obj, object * other_obj, vec3d * hitpos, int qu
 	if(wip->wi_flags[Weapon::Info_Flags::Emp]){
 		emp_apply(&weapon_obj->pos, wip->shockwave.inner_rad, wip->shockwave.outer_rad, wip->emp_intensity, wip->emp_time, (wip->wi_flags[Weapon::Info_Flags::Use_emp_time_for_capship_turrets]) != 0);
 	}	
+
+	// if this weapon has the "Electronics" flag set, then disrupt subsystems in sphere
+	if ((other_obj != NULL) && (wip->wi_flags[Weapon::Info_Flags::Electronics])) {
+		if (other_obj->type == OBJ_SHIP) {
+			weapon_do_electronics_effect(other_obj, &weapon_obj->pos, Weapons[weapon_obj->instance].weapon_info_index);
+		}
+	}
 
 	// spawn weapons - note the change from FS 1 multiplayer.
 	if (wip->wi_flags[Weapon::Info_Flags::Spawn]){


### PR DESCRIPTION
The electronics flag only worked if your weapon had a shockwave speed of 0. If it had a shockwave speed > 0 you had to have an AoE.

This fixes that