### PR TITLE
Use vertex interface blocks for vertex shader attributes

### DIFF
--- a/code/def_files/data/effects/main-f.sdr
+++ b/code/def_files/data/effects/main-f.sdr
@@ -96,6 +96,30 @@ layout (std140) uniform modelData {
 	int sMiscmapIndex;
 };
 
+in VertexOutput {
+#ifdef FLAG_ENV_MAP
+	vec3 envReflect;
+#endif
+#ifdef FLAG_NORMAL_MAP
+	mat3 tangentMatrix;
+#endif
+#ifdef FLAG_FOG
+	float fogDist;
+#endif
+#ifdef WORKAROUND_CLIPPING_PLANES
+ #ifdef FLAG_TRANSFORM
+	float notVisible;
+ #endif
+#endif
+	vec4 position;
+	vec3 normal;
+	vec4 texCoord;
+#ifdef FLAG_SHADOWS
+	vec4 shadowUV[4];
+	vec4 shadowPos;
+#endif
+} vertIn;
+
 #ifdef FLAG_DIFFUSE_MAP
 uniform sampler2DArray sBasemap;
 #endif
@@ -107,25 +131,15 @@ uniform sampler2DArray sSpecmap;
 #endif
 #ifdef FLAG_ENV_MAP
 uniform samplerCube sEnvmap;
-in vec3 fragEnvReflect;
 #endif
 #ifdef FLAG_NORMAL_MAP
 uniform sampler2DArray sNormalmap;
-in mat3 fragTangentMatrix;
 #endif
 #ifdef FLAG_AMBIENT_MAP
 uniform sampler2DArray sAmbientmap;
 #endif
-#ifdef FLAG_FOG
-in float fragFogDist;
-#endif
 #ifdef FLAG_ANIMATED
 uniform sampler2D sFramebuffer;
-#endif
-#ifdef WORKAROUND_CLIPPING_PLANES
- #ifdef FLAG_TRANSFORM
-in float fragNotVisible;
- #endif
 #endif
 #ifdef FLAG_TEAMCOLOR
 vec2 teamMask = vec2(0.0, 0.0);
@@ -134,14 +148,10 @@ vec2 teamMask = vec2(0.0, 0.0);
 uniform sampler2DArray sMiscmap;
 #endif
 #ifdef FLAG_SHADOWS
-in vec4 fragShadowUV[4];
-in vec4 fragShadowPos;
 uniform sampler2DArray shadow_map;
 #endif
 #define SRGB_GAMMA 2.2
-in vec4 fragPosition;
-in vec3 fragNormal;
-in vec4 fragTexCoord;
+
 out vec4 fragOut0;
 out vec4 fragOut1;
 out vec4 fragOut2;
@@ -161,17 +171,17 @@ void GetLightInfo(int i, out vec3 lightDir, out float attenuation)
 	attenuation = 1.0;
 	if (lights[i].light_type != LT_DIRECTIONAL) {
 		// Positional light source
-		float dist = distance(lights[i].position.xyz, fragPosition.xyz);
-		lightDir = (lights[i].position.xyz - fragPosition.xyz);
+		float dist = distance(lights[i].position.xyz, vertIn.position.xyz);
+		lightDir = (lights[i].position.xyz - vertIn.position.xyz);
 
 		if (lights[i].light_type == LT_TUBE) {  // Tube light
 			float beamlength = length(lights[i].direction);
 			vec3 beamDir = normalize(lights[i].direction);
 			// Get nearest point on line
-			float neardist = dot(fragPosition.xyz - lights[i].position.xyz, beamDir);
+			float neardist = dot(vertIn.position.xyz - lights[i].position.xyz, beamDir);
 			// Move back from the endpoint of the beam along the beam by the distance we calculated
 			vec3 nearest = lights[i].position.xyz - beamDir * abs(neardist);
-			lightDir = nearest - fragPosition.xyz;
+			lightDir = nearest - vertIn.position.xyz;
 			dist = length(lightDir);
 		}
 
@@ -181,7 +191,7 @@ void GetLightInfo(int i, out vec3 lightDir, out float attenuation)
 }
 vec3 CalculateLighting(vec3 normal, vec3 diffuseMaterial, vec3 specularMaterial, float gloss, float fresnel, float shadow, float aoFactor)
 {
-	vec3 eyeDir = vec3(normalize(-fragPosition).xyz);
+	vec3 eyeDir = vec3(normalize(-vertIn.position).xyz);
 	vec3 lightAmbient = (emissionFactor + ambientFactor * ambientFactor) * aoFactor; // ambientFactor^2 due to legacy OpenGL compatibility behavior
 	vec3 lightDiffuse = vec3(0.0, 0.0, 0.0);
 	vec3 lightSpecular = vec3(0.0, 0.0, 0.0);
@@ -208,18 +218,18 @@ void main()
 {
 #ifdef WORKAROUND_CLIPPING_PLANES
  #ifdef FLAG_TRANSFORM
-	if(fragNotVisible >= 0.9) { discard; }
+	if(vertIn.notVisible >= 0.9) { discard; }
  #endif
 #endif
 #ifdef FLAG_SHADOW_MAP
 	// need depth and depth squared for variance shadow maps
-	fragOut0 = vec4(fragPosition.z, fragPosition.z * fragPosition.z * VARIANCE_SHADOW_SCALE_INV, 0.0, 1.0);
+	fragOut0 = vec4(vertIn.position.z, vertIn.position.z * vertIn.position.z * VARIANCE_SHADOW_SCALE_INV, 0.0, 1.0);
 	if (true) {
 		return;
 	}
 #endif
-	vec3 eyeDir = vec3(normalize(-fragPosition).xyz);
-	vec2 texCoord = fragTexCoord.xy;
+	vec3 eyeDir = vec3(normalize(-vertIn.position).xyz);
+	vec2 texCoord = vertIn.texCoord.xy;
 	vec4 baseColor = color;
 	vec4 specColor = vec4(0.0, 0.0, 0.0, 1.0);
 	vec4 emissiveColor = vec4(0.0, 0.0, 0.0, 1.0);
@@ -234,14 +244,14 @@ void main()
 	// green is cavity occlusion factor which only affects diffuse and specular lighting.
 	aoFactors = texture(sAmbientmap, vec3(texCoord, float(sAmbientmapIndex))).xy;
 #endif
-	vec3 unitNormal = normalize(fragNormal);
+	vec3 unitNormal = normalize(vertIn.normal);
 	vec3 normal = unitNormal;
 #ifdef FLAG_NORMAL_MAP
    // Normal map - convert from DXT5nm
    vec2 normalSample;
    normal.rg = normalSample = (texture(sNormalmap, vec3(texCoord, float(sNormalmapIndex))).ag * 2.0) - 1.0;
    normal.b = clamp(sqrt(1.0 - dot(normal.rg, normal.rg)), 0.0001, 1.0);
-   normal = fragTangentMatrix * normal;
+   normal = vertIn.tangentMatrix * normal;
    float norm = length(normal);
    // prevent breaking of normal maps
    if (norm > 0.0)
@@ -251,7 +261,7 @@ void main()
 #endif
 
 #ifdef FLAG_ANIMATED
-   vec2 distort = vec2(cos(fragPosition.x*fragPosition.w*0.005+anim_timer*20.0)*sin(fragPosition.y*fragPosition.w*0.005),sin(fragPosition.x*fragPosition.w*0.005+anim_timer*20.0)*cos(fragPosition.y*fragPosition.w*0.005))*0.03;
+   vec2 distort = vec2(cos(vertIn.position.x*vertIn.position.w*0.005+anim_timer*20.0)*sin(vertIn.position.y*vertIn.position.w*0.005),sin(vertIn.position.x*vertIn.position.w*0.005+anim_timer*20.0)*cos(vertIn.position.y*vertIn.position.w*0.005))*0.03;
 #endif
 
 #ifdef FLAG_DIFFUSE_MAP
@@ -316,7 +326,7 @@ void main()
  #ifdef FLAG_LIGHT
 	float shadow = 1.0;
   #ifdef FLAG_SHADOWS
-	shadow = getShadowValue(shadow_map, -fragPosition.z, fragShadowPos.z, fragShadowUV, fardist, middist, neardist, veryneardist);
+	shadow = getShadowValue(shadow_map, -vertIn.position.z, vertIn.shadowPos.z, vertIn.shadowUV, fardist, middist, neardist, veryneardist);
   #endif
 	baseColor.rgb = CalculateLighting(normal, baseColor.rgb, specColor.rgb, glossData, fresnelFactor, shadow, aoFactors.x);
  #else
@@ -326,7 +336,7 @@ void main()
  #endif
 #endif
 #ifdef FLAG_ENV_MAP
-	vec3 envReflectNM = fragEnvReflect;
+	vec3 envReflectNM = vertIn.envReflect;
  #ifdef FLAG_NORMAL_MAP
 	envReflectNM += vec3(normalSample, 0.0);
 	envReflectNM = normalize(envReflectNM);
@@ -362,8 +372,8 @@ void main()
  #ifdef FLAG_DIFFUSE_MAP
 	if(blend_alpha == 1) finalFogColor *= baseColor.a;
  #endif
-	baseColor.rgb = mix(baseColor.rgb, finalFogColor, fragFogDist);
-	specColor.rgb *= fragFogDist;
+	baseColor.rgb = mix(baseColor.rgb, finalFogColor, vertIn.fogDist);
+	specColor.rgb *= vertIn.fogDist;
 #endif
 
 #ifdef FLAG_DIFFUSE_MAP
@@ -378,21 +388,21 @@ void main()
       baseColor.a = baseColor.a * clamp(shinefactor * (fract(abs(texCoord.x))-anim_timer) * -10000.0,0.0,1.0);
    }
    if (effect_num == 1) {
-      float shinefactor = 1.0/(1.0 + pow(abs(fragPosition.y-anim_timer), 2.0));
+      float shinefactor = 1.0/(1.0 + pow(abs(vertIn.position.y-anim_timer), 2.0));
       emissiveColor.rgb += vec3(shinefactor);
  #ifndef FLAG_LIGHT
       // ATI Wireframe fix *grumble*
-      baseColor.a = clamp((fragPosition.y-anim_timer) * 10000.0,0.0,1.0);
+      baseColor.a = clamp((vertIn.position.y-anim_timer) * 10000.0,0.0,1.0);
  #endif
    }
    if (effect_num == 2) {
       vec2 screenPos = gl_FragCoord.xy * vec2(vpwidth,vpheight);
       baseColor.a = baseColor.a;
-      float cloak_interp = (sin(fragPosition.x*fragPosition.w*0.005+anim_timer*20.0)*sin(fragPosition.y*fragPosition.w*0.005)*0.5)-0.5;
+      float cloak_interp = (sin(vertIn.position.x*vertIn.position.w*0.005+anim_timer*20.0)*sin(vertIn.position.y*vertIn.position.w*0.005)*0.5)-0.5;
  #ifdef FLAG_LIGHT
       baseColor.rgb = mix(texture(sFramebuffer, screenPos + distort*anim_timer + anim_timer*0.1*normal.xy).rgb,baseColor.rgb,clamp(cloak_interp+anim_timer*2.0,0.0,1.0));
  #else
-      baseColor.rgb = mix(texture(sFramebuffer, screenPos + distort*anim_timer + anim_timer*0.1*fragNormal.xy).rgb,baseColor.rgb,clamp(cloak_interp+anim_timer*2.0,0.0,1.0));
+      baseColor.rgb = mix(texture(sFramebuffer, screenPos + distort*anim_timer + anim_timer*0.1*vertIn.normal.xy).rgb,baseColor.rgb,clamp(cloak_interp+anim_timer*2.0,0.0,1.0));
  #endif
    }
 #endif
@@ -406,7 +416,7 @@ void main()
 #endif
 	fragOut0 = baseColor;
 #ifdef FLAG_DEFERRED
-	fragOut1 = vec4(fragPosition.xyz, 1.0);
+	fragOut1 = vec4(vertIn.position.xyz, 1.0);
 	fragOut2 = vec4(normal, glossData);
 	fragOut3 = vec4(specColor.rgb, fresnelFactor);
 	fragOut4 = emissiveColor;

--- a/code/def_files/data/effects/main-g.sdr
+++ b/code/def_files/data/effects/main-g.sdr
@@ -96,42 +96,96 @@ layout (std140) uniform modelData {
 	int sMiscmapIndex;
 };
 
-#if !defined(GL_ARB_gpu_shader5)
-in float geoInstance[];
+in VertexOutput {
+#ifdef FLAG_ENV_MAP
+	vec3 envReflect;
 #endif
-in vec3 geoNormal[];
-in vec4 geoTexCoord[];
-out vec4 fragPosition;
-out vec3 fragNormal;
-out vec4 fragTexCoord;
-
+#ifdef FLAG_NORMAL_MAP
+	mat3 tangentMatrix;
+#endif
+#ifdef FLAG_FOG
+	float fogDist;
+#endif
 #ifdef WORKAROUND_CLIPPING_PLANES
-#ifdef FLAG_TRANSFORM
-in float geoNotVisible[];
-out float fragNotVisible;
+ #ifdef FLAG_TRANSFORM
+	float notVisible;
+ #endif
 #endif
+#ifdef FLAG_SHADOW_MAP
+ #if !defined(GL_ARB_gpu_shader5)
+	float instance;
+ #endif
+#else
+	vec4 position;
 #endif
+	vec3 normal;
+	vec4 texCoord;
+#ifdef FLAG_SHADOWS
+	vec4 shadowUV[4];
+	vec4 shadowPos;
+#endif
+} vertIn[];
+
+out VertexOutput {
+#ifdef FLAG_ENV_MAP
+	vec3 envReflect;
+#endif
+#ifdef FLAG_NORMAL_MAP
+	mat3 tangentMatrix;
+#endif
+#ifdef FLAG_FOG
+	float fogDist;
+#endif
+#ifdef WORKAROUND_CLIPPING_PLANES
+ #ifdef FLAG_TRANSFORM
+	float notVisible;
+ #endif
+#endif
+	vec4 position;
+	vec3 normal;
+	vec4 texCoord;
+#ifdef FLAG_SHADOWS
+	vec4 shadowUV[4];
+	vec4 shadowPos;
+#endif
+} vertOut;
 
 void main(void)
 {
 #ifdef GL_ARB_gpu_shader5
 	int instanceID = gl_InvocationID;
 #else
-	int instanceID = int(geoInstance[0]);
+	int instanceID = int(vertIn[0].instance);
 #endif
 	for(int vert = 0; vert < gl_in.length(); vert++)
 	{
 		gl_Position = shadow_proj_matrix[instanceID] * gl_in[vert].gl_Position;
 		if(gl_Position.z < -1.0)
 			gl_Position.z = -1.0;
-		fragPosition = gl_in[vert].gl_Position;
-		fragNormal = geoNormal[vert];
-		fragTexCoord = geoTexCoord[vert];
+		vertOut.position = gl_in[vert].gl_Position;
+		vertOut.normal = vertIn[vert].normal;
+		vertOut.texCoord = vertIn[vert].texCoord;
 
 		gl_Layer = instanceID;
+#ifdef FLAG_ENV_MAP
+		vertOut.envReflect = vertIn[vert].envReflect;
+#endif
+#ifdef FLAG_NORMAL_MAP
+		vertOut.tangentMatrix = vertIn[vert].tangentMatrix;
+#endif
+#ifdef FLAG_FOG
+		vertOut.fogDist = vertIn[vert].fogDist;
+#endif
+#ifdef FLAG_SHADOWS
+		vertOut.shadowUV[0] = vertIn[vert].shadowUV[0];
+		vertOut.shadowUV[1] = vertIn[vert].shadowUV[1];
+		vertOut.shadowUV[2] = vertIn[vert].shadowUV[2];
+		vertOut.shadowUV[3] = vertIn[vert].shadowUV[3];
+		vertOut.shadowPos = vertIn[vert].shadowPos;
+#endif
 #ifdef WORKAROUND_CLIPPING_PLANES
  #ifdef FLAG_TRANSFORM
-		fragNotVisible = geoNotVisible[0];
+		vertOut.notVisible = vertIn[vert].notVisible;
  #endif
  #ifdef FLAG_CLIP
 		gl_ClipDistance[0] = gl_in[vert].gl_ClipDistance[0];

--- a/code/def_files/data/effects/main-v.sdr
+++ b/code/def_files/data/effects/main-v.sdr
@@ -2,6 +2,12 @@
 
 #include "shadows.sdr"
 
+in vec4 vertPosition;
+in vec4 vertTexCoord;
+in vec3 vertNormal;
+in vec4 vertTangent;
+in float vertModelID;
+
 #define MAX_LIGHTS 8
 
 struct model_light {
@@ -93,47 +99,40 @@ layout (std140) uniform modelData {
 	int sMiscmapIndex;
 };
 
-in vec4 vertPosition;
-in vec4 vertTexCoord;
-in vec3 vertNormal;
-in vec4 vertTangent;
-in float vertModelID;
-#ifdef FLAG_ENV_MAP
-out vec3 fragEnvReflect;
-#endif
-#ifdef FLAG_NORMAL_MAP
-out mat3 fragTangentMatrix;
-#endif
-#ifdef FLAG_FOG
-out float fragFogDist;
-#endif
 #ifdef FLAG_TRANSFORM
 uniform samplerBuffer transform_tex;
+#endif
 
+out VertexOutput {
+#ifdef FLAG_ENV_MAP
+	vec3 envReflect;
+#endif
+#ifdef FLAG_NORMAL_MAP
+	mat3 tangentMatrix;
+#endif
+#ifdef FLAG_FOG
+	float fogDist;
+#endif
 #ifdef WORKAROUND_CLIPPING_PLANES
- #ifdef FLAG_SHADOW_MAP
-out float geoNotVisible;
- #else
-out float fragNotVisible;
+ #ifdef FLAG_TRANSFORM
+	float notVisible;
  #endif
 #endif
-
-#endif
 #ifdef FLAG_SHADOW_MAP
-#if !defined(GL_ARB_gpu_shader5)
-out float geoInstance;
-#endif
-out vec3 geoNormal;
-out vec4 geoTexCoord;
+ #if !defined(GL_ARB_gpu_shader5)
+	float instance;
+ #endif
 #else
-out vec4 fragPosition;
-out vec3 fragNormal;
-out vec4 fragTexCoord;
+	vec4 position;
 #endif
+	vec3 normal;
+	vec4 texCoord;
 #ifdef FLAG_SHADOWS
-out vec4 fragShadowUV[4];
-out vec4 fragShadowPos;
+	vec4 shadowUV[4];
+	vec4 shadowPos;
 #endif
+} vertOut;
+
 #ifdef FLAG_TRANSFORM
 #define TEXELS_PER_MATRIX 4
 void getModelTransform(inout mat4 transform, out bool invisible, int id, int matrix_offset)
@@ -157,11 +156,7 @@ void main()
  #ifdef FLAG_TRANSFORM
 	bool clipModel;
 	getModelTransform(orient, clipModel, int(vertModelID), buffer_matrix_offset);
-   #ifdef FLAG_SHADOW_MAP
-	geoNotVisible = clipModel ? 1.0 : 0.0;
-   #else
-	fragNotVisible = clipModel ? 1.0 : 0.0;
-   #endif
+	vertOut.notVisible = clipModel ? 1.0 : 0.0;
  #endif
 #else
  #ifdef FLAG_TRANSFORM
@@ -183,15 +178,13 @@ void main()
 	position = modelViewMatrix * orient * vertex;
  #ifdef FLAG_SHADOW_MAP
 	gl_Position = position;
-
- #if !defined(GL_ARB_gpu_shader5)
-  #ifdef APPLE
-	geoInstance = float(gl_InstanceIDARB);
-  #else
-	geoInstance = float(gl_InstanceID);
+  #if !defined(GL_ARB_gpu_shader5)
+   #ifdef APPLE
+	vertOut.instance = float(gl_InstanceIDARB);
+   #else
+	vertOut.instance = float(gl_InstanceID);
+   #endif
   #endif
- #endif
-
  #else
 	gl_Position = projMatrix * position;
  #endif
@@ -199,25 +192,26 @@ void main()
 	gl_Position.xy += (mat3(projMatrix) * normal.xyz).xy * gl_Position.z * extrudeWidth;
  #endif
  #ifdef FLAG_SHADOWS
-	fragShadowPos = shadow_mv_matrix * modelMatrix * orient * vertPosition;
-	fragShadowUV[0] = transformToShadowMap(shadow_proj_matrix[0], 0, fragShadowPos);
-	fragShadowUV[1] = transformToShadowMap(shadow_proj_matrix[1], 1, fragShadowPos);
-	fragShadowUV[2] = transformToShadowMap(shadow_proj_matrix[2], 2, fragShadowPos);
-	fragShadowUV[3] = transformToShadowMap(shadow_proj_matrix[3], 3, fragShadowPos);
+	vec4 shadowPos = shadow_mv_matrix * modelMatrix * orient * vertPosition;
+	vertOut.shadowPos = shadow_mv_matrix * modelMatrix * orient * vertPosition;
+	vertOut.shadowUV[0] = transformToShadowMap(shadow_proj_matrix[0], 0, shadowPos);
+	vertOut.shadowUV[1] = transformToShadowMap(shadow_proj_matrix[1], 1, shadowPos);
+	vertOut.shadowUV[2] = transformToShadowMap(shadow_proj_matrix[2], 2, shadowPos);
+	vertOut.shadowUV[3] = transformToShadowMap(shadow_proj_matrix[3], 3, shadowPos);
  #endif
  #ifdef FLAG_NORMAL_MAP
  // Setup stuff for normal maps
 	vec3 t = normalize(mat3(modelViewMatrix) * mat3(orient) * vertTangent.xyz);
 	vec3 b = cross(normal, t) * vertTangent.w;
-	fragTangentMatrix = mat3(t, b, normal);
+	vertOut.tangentMatrix = mat3(t, b, normal);
  #endif
  #ifdef FLAG_ENV_MAP
  // Environment mapping reflection vector.
-	fragEnvReflect = reflect(normalize(position.xyz), normal);
-	fragEnvReflect = vec3(envMatrix * vec4(fragEnvReflect, 0.0));
+	vec3 envReflect = reflect(normalize(position.xyz), normal);
+	vertOut.envReflect = vec3(envMatrix * vec4(envReflect, 0.0));
  #endif
  #ifdef FLAG_FOG
-	fragFogDist = clamp((gl_Position.z - fogStart) * 0.75 * fogScale, 0.0, 1.0);
+	vertOut.fogDist = clamp((gl_Position.z - fogStart) * 0.75 * fogScale, 0.0, 1.0);
  #endif
 #ifdef WORKAROUND_CLIPPING_PLANES
 	if(use_clip_plane) {
@@ -239,11 +233,11 @@ void main()
  #endif
 #endif
  #ifndef FLAG_SHADOW_MAP
-	fragPosition = position;
-	fragNormal = normal;
-	fragTexCoord = texCoord;
+	vertOut.position = position;
+	vertOut.normal = normal;
+	vertOut.texCoord = texCoord;
  #else
-	geoNormal = normal;
-	geoTexCoord = texCoord;
+	vertOut.normal = normal;
+	vertOut.texCoord = texCoord;
  #endif
 }


### PR DESCRIPTION
This is a minor cleanup of how the engine passes vertex attribute data
from one shader stage to the next. The current code uses standalone
attribute variables which require a unique name over the entire shader
program which means that the variable names need to be different when a
geometry shader is used which makes the code more complicated and harder
to understand.

Also, if other shader stages (e.g. the tesselation shader) this change will make
it easier to add support for this shader without introducing even more
conditional attribute names.