### PR TITLE
add small bsp tree optimisation

### DIFF
--- a/code/model/modelread.cpp
+++ b/code/model/modelread.cpp
@@ -2851,10 +2851,11 @@ int model_load(const  char *filename, int n_subsystems, model_subsystem *subsyst
 		TRACE_SCOPE(tracing::ModelParseAllBSPTrees);
 
 		for ( i = 0; i < pm->n_models; ++i ) {
-			pm->submodel[i].collision_tree_index = model_create_bsp_collision_tree();
-			bsp_collision_tree *tree = model_get_bsp_collision_tree(pm->submodel[i].collision_tree_index);
-
-			model_collide_parse_bsp(tree, pm->submodel[i].bsp_data, pm->version);
+			if ( !(pm->submodel[i].nocollide_this_only || pm->submodel[i].no_collisions) ) {
+				pm->submodel[i].collision_tree_index = model_create_bsp_collision_tree();
+				bsp_collision_tree *tree = model_get_bsp_collision_tree(pm->submodel[i].collision_tree_index);
+				model_collide_parse_bsp(tree, pm->submodel[i].bsp_data, pm->version);
+			}
 		}
 	}
 


### PR DESCRIPTION
don't add no_collide (& similar) submodels to the bsp trees
this has been in the fotg branch for ages without causing any apparant
issues