### PR TITLE
Handle emissive light properly in nebulas

### DIFF
--- a/code/def_files/data/effects/main-f.sdr
+++ b/code/def_files/data/effects/main-f.sdr
@@ -383,6 +383,7 @@ void main()
 	if(blend_alpha == 1) finalFogColor *= baseColor.a;
  #endif
 	baseColor.rgb = mix(baseColor.rgb, finalFogColor, vertIn.fogDist);
+	emissiveColor.rgb = mix(emissiveColor.rgb, finalFogColor, vertIn.fogDist);
 	specColor.rgb *= vertIn.fogDist;
 #endif
 


### PR DESCRIPTION
The emissive part of the lighting was not using the fog values properly
so ships didn't rendered right in nebulas. This fixes that by applying
the standard fog color transform to the emissive part of the scene.