### PR TITLE
Don't use discard in main model shader

### DIFF
--- a/code/def_files/data/effects/main-f.sdr
+++ b/code/def_files/data/effects/main-f.sdr
@@ -262,7 +262,6 @@ void main()
    }
  #endif
 	baseColor = texture(sBasemap, vec3(diffuseTexCoord, float(sBasemapIndex)));
-	if ( blend_alpha == 0 && baseColor.a < 0.95 ) discard; // if alpha blending is not on, discard transparent pixels
 	// premultiply alpha if blend_alpha is 1. assume that our blend function is srcColor + (1-Alpha)*destColor.
 	// if blend_alpha is 2, assume blend func is additive and don't modify color
 	if(blend_alpha == 1) baseColor.rgb = baseColor.rgb * baseColor.a;


### PR DESCRIPTION
The only remaining occurence of discard was for when blending was
disabled and the pixel of the texture had an alpha value less than 0.95.
That combination cannot happen anymore since all transparent textures
are handled using one of the other blend modes and all other textures
won't have an alpha value less than 0.95.

This has some minor performance benefits in GPU limited scenes.