### PR TITLE
Remove the MAX_LIGHTS define

### DIFF
--- a/code/globalincs/globals.h
+++ b/code/globalincs/globals.h
@@ -82,9 +82,6 @@
 // object.h
 #define MAX_OBJECTS			3500		
 
-// from lighting.cpp
-#define MAX_LIGHTS 256
-
 // from weapon.h (and beam.h)
 #define MAX_BEAM_SECTIONS				5
 

--- a/code/globalincs/systemvars.h
+++ b/code/globalincs/systemvars.h
@@ -208,8 +208,6 @@ void detail_level_set(int level);
 // Returns the current detail level or -1 if custom.
 int current_detail_level();
 
-#define MAX_LIGHTS 256
-
 #define safe_kill(a) if(a)vm_free(a)
 
 

--- a/code/graphics/light.cpp
+++ b/code/graphics/light.cpp
@@ -215,9 +215,6 @@ void gr_set_center_alpha(int type) {
 		return;
 	}
 
-	if (Num_active_gr_lights == MAX_LIGHTS) {
-		return;
-	}
 	gr_light glight;
 
 	vec3d dir;
@@ -293,7 +290,7 @@ void gr_light_init() {
 	gr_calculate_ambient_factor();
 
 	// allocate memory for enabled lights
-	gr_lights.reserve(MAX_LIGHTS);
+	gr_lights.reserve(1024);
 }
 
 void gr_set_lighting(bool set, bool state) {

--- a/code/graphics/opengl/gropengldeferred.cpp
+++ b/code/graphics/opengl/gropengldeferred.cpp
@@ -116,17 +116,11 @@ void gr_opengl_deferred_lighting_finish()
 	if (Cmdline_shadow_quality) {
 		GL_state.Texture.Enable(4, GL_TEXTURE_2D_ARRAY, Shadow_map_texture);
 	}
-
-	SCP_vector<light> lights_copy(Lights);
-
+	
 	// We need to use stable sorting here to make sure that the relative ordering of the same light types is the same as
 	// the rest of the code. Otherwise the shadow mapping would be applied while rendering the wrong light which would
 	// lead to flickering lights in some circumstances
-	std::stable_sort(lights_copy.begin(), lights_copy.end(), light_compare_by_type);
-	if (lights_copy.size() > MAX_LIGHTS) {
-		lights_copy.resize(MAX_LIGHTS);
-	}
-
+	std::stable_sort(Lights.begin(), Lights.end(), light_compare_by_type);
 	using namespace graphics;
 
 	// Get a uniform buffer for out data
@@ -157,7 +151,7 @@ void gr_opengl_deferred_lighting_finish()
 
 		// Only the first directional light uses shaders so we need to know when we already saw that light
 		bool first_directional = true;
-		for (auto& l : lights_copy) {
+		for (auto& l : Lights) {
 			auto light_data = uniformAligner.addTypedElement<deferred_light_data>();
 
 			light_data->lightType = static_cast<int>(l.type);
@@ -247,7 +241,7 @@ void gr_opengl_deferred_lighting_finish()
 							   buffer->bufferHandle());
 
 		size_t element_index = 0;
-		for (auto& l : lights_copy) {
+		for (auto& l : Lights) {
 			GR_DEBUG_SCOPE("Deferred apply single light");
 
 			switch (l.type) {


### PR DESCRIPTION
This is sort of a companion piece to the discussion in #1634. I feel that using a global limit on lights makes no real sense anymore; it is far better to control the number of lights we're adding than trying to impose a hard cap on things.