### PR TITLE
Load unloaded sounds when trying to determine sound length

### DIFF
--- a/code/gamesnd/gamesnd.cpp
+++ b/code/gamesnd/gamesnd.cpp
@@ -1322,7 +1322,10 @@ float gamesnd_get_max_duration(game_snd* gs) {
 	int max_length = 0;
 
 	for (auto& entry : gs->sound_entries) {
-		Assertion(entry.id != -1, "Game sound must be loaded to determine maximum duration!");
+		if (entry.id < 0) {
+			// Lazily load unloaded sound entries when required
+			entry.id = snd_load(&entry, gs->flags);
+		}
 
 		max_length = std::max(max_length, snd_get_duration(entry.id));
 	}


### PR DESCRIPTION
This can happen if a script tries to determine the length of a sound
before actually playing it. This fixes the assertion by loading the
sound when it is necessary.