### PR TITLE
Fix stencil rendering in hardpoint rendering

### DIFF
--- a/code/graphics/material.cpp
+++ b/code/graphics/material.cpp
@@ -415,6 +415,12 @@ void material::set_stencil_func(ComparisionFunction compare, int ref, uint32_t m
 const material::StencilFunc& material::get_stencil_func() const {
 	return Stencil_func;
 }
+void material::set_stencil_op(StencilOperation stencilFailOperation,
+							  StencilOperation depthFailOperation,
+							  StencilOperation successOperation) {
+	set_front_stencil_op(stencilFailOperation, depthFailOperation, successOperation);
+	set_back_stencil_op(stencilFailOperation, depthFailOperation, successOperation);
+}
 void material::set_front_stencil_op(StencilOperation stencilFailOperation,
 									StencilOperation depthFailOperation,
 									StencilOperation successOperation) {

--- a/code/graphics/material.h
+++ b/code/graphics/material.h
@@ -136,6 +136,10 @@ public:
 	void set_stencil_func(ComparisionFunction compare, int ref, uint32_t mask);
 	const StencilFunc& get_stencil_func() const;
 
+	void set_stencil_op(StencilOperation stencilFailOperation,
+						StencilOperation depthFailOperation,
+						StencilOperation successOperation);
+
 	void set_front_stencil_op(StencilOperation stencilFailOperation,
 							  StencilOperation depthFailOperation,
 							  StencilOperation successOperation);

--- a/code/graphics/opengl/gropengl.cpp
+++ b/code/graphics/opengl/gropengl.cpp
@@ -502,16 +502,16 @@ int gr_opengl_stencil_set(int mode)
 
 	if ( mode == GR_STENCIL_READ ) {
 		GL_state.StencilTest(1);
-		GL_state.StencilFunc(GL_NEVER, 1, 0xFFFF);
+		GL_state.StencilFunc(GL_NOTEQUAL, 1, 0xFFFF);
 		GL_state.StencilOpSeparate(GL_FRONT_AND_BACK, GL_KEEP, GL_KEEP, GL_KEEP);
 	} else if ( mode == GR_STENCIL_WRITE ) {
 		GL_state.StencilTest(1);
-		GL_state.StencilFunc(GL_NOTEQUAL, 1, 0XFFFF);
-		GL_state.StencilOpSeparate(GL_FRONT_AND_BACK, GL_KEEP, GL_KEEP, GL_KEEP);
-	} else {
-		GL_state.StencilTest(0);
 		GL_state.StencilFunc(GL_ALWAYS, 1, 0xFFFF);
 		GL_state.StencilOpSeparate(GL_FRONT_AND_BACK, GL_KEEP, GL_KEEP, GL_REPLACE);
+	} else {
+		GL_state.StencilTest(0);
+		GL_state.StencilFunc(GL_NEVER, 1, 0xFFFF);
+		GL_state.StencilOpSeparate(GL_FRONT_AND_BACK, GL_KEEP, GL_KEEP, GL_KEEP);
 	}
 
 	return tmp;

--- a/code/hud/hudtarget.cpp
+++ b/code/hud/hudtarget.cpp
@@ -7168,25 +7168,20 @@ void HudGaugeHardpoints::render(float frametime)
 	//We're ready to show stuff
 	model_render_params render_info;
 
-	int detail_level_lock = 1;
-	int cull = gr_set_cull(0);
 	gr_stencil_clear();
-	gr_stencil_set(GR_STENCIL_WRITE);
-	int zbuffer = gr_zbuffer_set(GR_ZBUFF_NONE);
-	gr_set_color_buffer(0);
 
-	render_info.set_color(gauge_color);
+	const int detail_level_lock = 1;
+
 	render_info.set_detail_level_lock(detail_level_lock);
-	render_info.set_flags(MR_NO_LIGHTING | MR_AUTOCENTER | MR_NO_FOGGING | MR_NO_TEXTURING | MR_NO_CULL);
+	render_info.set_flags(
+		MR_NO_LIGHTING | MR_AUTOCENTER | MR_NO_FOGGING | MR_NO_TEXTURING | MR_NO_CULL | MR_NO_ZBUFFER | MR_STENCIL_WRITE
+			| MR_NO_COLOR_WRITES);
 	render_info.set_object_number(OBJ_INDEX(objp));
 
 	model_render_immediate( &render_info, sip->model_num, &object_orient, &vmd_zero_vector);
 
-	gr_set_color_buffer(1);
-	gr_stencil_set(GR_STENCIL_READ);
-	gr_set_cull(cull);
-
-	render_info.set_flags(MR_NO_LIGHTING | MR_AUTOCENTER | MR_NO_FOGGING | MR_NO_TEXTURING | MR_NO_ZBUFFER | MR_NO_CULL);
+	render_info.set_color(gauge_color);
+	render_info.set_flags(MR_NO_LIGHTING | MR_AUTOCENTER | MR_NO_FOGGING | MR_NO_TEXTURING | MR_NO_ZBUFFER | MR_NO_CULL | MR_STENCIL_READ);
 	render_info.set_normal_extrude_width(_line_width * 0.01f);
 
 	model_render_immediate(
@@ -7197,7 +7192,6 @@ void HudGaugeHardpoints::render(float frametime)
 	);
 
 	gr_stencil_set(GR_STENCIL_NONE);
-	gr_zbuffer_set(zbuffer);
 
 	// draw weapon models
 	int i, k;

--- a/code/model/model.h
+++ b/code/model/model.h
@@ -825,10 +825,10 @@ void model_set_detail_level(int n);
 #define MR_SHOW_OUTLINE				(1<<0)		// Draw the object in outline mode. Color specified by model_set_outline_color
 #define MR_SKYBOX					(1<<1)		// Draw as a skybox
 #define MR_DESATURATED				(1<<2)		// Draw model in monochrome using outline color
-#define MR_EMPTY_SLOT0				(1<<3)		// Show the radius around the object
-#define MR_EMPTY_SLOT1				(1<<4)		// Show the shield mesh
+#define MR_STENCIL_WRITE			(1<<3)		// Write stencil buffere where the model was rendered
+#define MR_STENCIL_READ				(1<<4)		// Only draw pixels of the model where the stencil buffer has the right value (see MR_STENCIL_WRITE)
 #define MR_SHOW_THRUSTERS			(1<<5)		// Show the engine thrusters. See model_set_thrust for how long it draws.
-#define MR_EMPTY_SLOT2				(1<<6)		// Only draw the detail level defined in model_set_detail_level
+#define MR_NO_COLOR_WRITES			(1<<6)		// Don't write anything to the color buffers (used when setting the stencil buffer)
 #define MR_NO_POLYS					(1<<7)		// Don't draw the polygons.
 #define MR_NO_LIGHTING				(1<<8)		// Don't perform any lighting on the model.
 #define MR_NO_TEXTURING				(1<<9)		// Draw textures as flat-shaded polygons.

--- a/code/model/modelrender.cpp
+++ b/code/model/modelrender.cpp
@@ -2746,6 +2746,29 @@ void model_render_queue(model_render_params *interp, model_draw_list *scene, int
 		rendering_material.set_lighting(false);
 	}
 
+	Assertion(!(model_flags & MR_STENCIL_READ && model_flags & MR_STENCIL_WRITE),
+			  "Enabling stencil read and write at the same time is not supported!");
+
+	if (model_flags & MR_STENCIL_READ) {
+		rendering_material.set_stencil_test(true);
+		rendering_material.set_stencil_func(ComparisionFunction::NotEqual, 1, 0xFFFF);
+		rendering_material.set_stencil_op(StencilOperation::Keep, StencilOperation::Keep, StencilOperation::Keep);
+	} else if (model_flags & MR_STENCIL_WRITE) {
+		rendering_material.set_stencil_test(true);
+		rendering_material.set_stencil_func(ComparisionFunction::Always, 1, 0xFFFF);
+		rendering_material.set_stencil_op(StencilOperation::Keep, StencilOperation::Keep, StencilOperation::Replace);
+	} else {
+		rendering_material.set_stencil_test(false);
+		rendering_material.set_stencil_func(ComparisionFunction::Never, 1, 0xFFFF);
+		rendering_material.set_stencil_op(StencilOperation::Keep, StencilOperation::Keep, StencilOperation::Keep);
+	}
+
+	if (model_flags & MR_NO_COLOR_WRITES) {
+		rendering_material.set_color_mask(false, false, false, false);
+	} else {
+		rendering_material.set_color_mask(true, true, true, true);
+	}
+
 	if ( Rendering_to_shadow_map ) {
 		rendering_material.set_depth_bias(-1024);
 	} else {


### PR DESCRIPTION
There were actually multiple issues here. The addition of color mask and
stencil state to the material system overwrote the state set by the
hardpoint renderer so the stencil buffer was never written or read
correctly. I fixed this by introducing three new model render flags
(there were a few open slots in the bit mask so I used those) which set
the correct state using the material system. That also makes setting up
the rendering environment much easier.

Second, `gr_opengl_stencil_set` used mixed up parameter values which were
probably broken when I introduced more detailed stencil state tracking.
I restored those values to how they were in 3.8.

This fixes the other issue reported in #1640.