### PR TITLE
Disable building targets with runtime DLLs as default

### DIFF
--- a/ci/appveyor/build.ps1
+++ b/ci/appveyor/build.ps1
@@ -132,7 +132,7 @@ if ($DeployBuild) {
 	}
 	
 	cmake -DCMAKE_INSTALL_PREFIX="$env:APPVEYOR_BUILD_FOLDER/../install" -DFSO_USE_SPEECH="ON" `
-		-DFSO_USE_VOICEREC="ON" -DMSVC_SIMD_INSTRUCTIONS="$($buildConfig.SimdType)" -DMSVC_USE_RUNTIME_DLL="ON" `
+		-DFSO_USE_VOICEREC="ON" -DMSVC_SIMD_INSTRUCTIONS="$($buildConfig.SimdType)" `
 		-G "$($buildConfig.Generator)" -T "$($buildConfig.Toolset)" ..
 
 	$Configs = @("Release", "FastDebug")
@@ -148,7 +148,7 @@ if ($DeployBuild) {
     Push-AppveyorArtifact "$($PackageName)-builds-$($buildConfig.PackageType).zip"
 } else {
 	cmake -DFSO_USE_SPEECH="ON" -DFSO_FATAL_WARNINGS="ON" -DFSO_USE_VOICEREC="ON" -DFSO_BUILD_TESTS="ON" -DMSVC_SIMD_INSTRUCTIONS=SSE2 `
-	-DFSO_BUILD_QTFRED=ON -DQT5_INSTALL_ROOT="$env:QT_DIR" -DMSVC_USE_RUNTIME_DLL="ON" -DFSO_BUILD_FRED2="OFF" `
+	-DFSO_BUILD_QTFRED=ON -DQT5_INSTALL_ROOT="$env:QT_DIR" -DFSO_BUILD_FRED2="OFF" `
 	-G "$Env:CMAKE_GENERATOR" -T "$Env:PlatformToolset" ..
 
     cmake --build . --config "$Env:CONFIGURATION" -- /verbosity:minimal

--- a/qtfred/CMakeLists.txt
+++ b/qtfred/CMakeLists.txt
@@ -12,6 +12,9 @@ find_package(Qt5 COMPONENTS Widgets OpenGL REQUIRED)
 
 include(source_groups.cmake)
 
+# When building qtFRED we need to install the runtime libraries since the Qt DLLs need them
+INCLUDE(InstallRequiredSystemLibraries)
+
 qt5_wrap_ui(QTFRED_UI_GENERATED ${files_UI})
 
 source_group("UI\\Generated"            FILES ${QTFRED_UI_GENERATED})


### PR DESCRIPTION
This caused issues for some users and was an accidental change
introduced by the qtFRED merge.