### PR TITLE
Delete all objects on mission end (Fix for #1653)

### DIFF
--- a/code/lab/lab.cpp
+++ b/code/lab/lab.cpp
@@ -1924,6 +1924,10 @@ void lab_init()
 	Lab_viewer_flags |= LAB_FLAG_NO_ROTATION;
 	Lab_viewer_flags |= LAB_FLAG_INITIAL_ROTATION;
 
+	obj_init();
+
+	//Reset the background
+	labviewer_change_background_actual();
 
 	flagset<Object::Object_Flags> obs_flags;
 	auto obj_index = obj_create(OBJ_OBSERVER, -1, 0, &vmd_identity_matrix, &vmd_zero_vector, 0, obs_flags);
@@ -1941,6 +1945,19 @@ void lab_init()
 
 	if (The_mission.ai_profile == nullptr)
 		The_mission.ai_profile = &Ai_profiles[Default_ai_profile];
+
+	lab_cam_distance = 100.0f;
+	lab_cam_phi = 1.24f;
+	lab_cam_theta = 2.25f;
+
+	Lab_selected_index = -1;
+	Lab_last_selected_ship = -1;
+	Lab_selected_object = -1;
+	Lab_last_selected_weapon = -1;
+	Lab_model_num = -1;
+
+	Lab_selected_mission = "None";
+	Lab_skybox_orientation = vmd_identity_matrix;
 }
 
 #include "controlconfig/controlsconfig.h"
@@ -2174,5 +2191,5 @@ void lab_close()
 
 	cam_delete(Lab_cam);
 
-	Missiontime = Lab_Save_Missiontime;
+	obj_init();
 }

--- a/code/lab/lab.cpp
+++ b/code/lab/lab.cpp
@@ -1806,6 +1806,7 @@ void labviewer_change_background_actual()
 	else {
 		// (DahBlount) - This spot should be used to disable rendering features that only apply to missions.
 		Motion_debris_override = true;
+		Num_stars = 0;
 	}
 }
 

--- a/code/object/object.cpp
+++ b/code/object/object.cpp
@@ -518,7 +518,7 @@ int obj_create(ubyte type,int parent_obj,int instance, matrix * orient,
 
 void obj_delete_all() 
 {
-	size_t counter = 0;
+	int counter = 0;
 	for (size_t i = 0; i < MAX_OBJECTS; ++i) 
 	{
 		if (Objects[i].type == OBJ_NONE)

--- a/code/object/object.cpp
+++ b/code/object/object.cpp
@@ -516,6 +516,20 @@ int obj_create(ubyte type,int parent_obj,int instance, matrix * orient,
 	return objnum;
 }
 
+void obj_delete_all() 
+{
+	size_t counter = 0;
+	for (size_t i = 0; i < MAX_OBJECTS; ++i) 
+	{
+		if (Objects[i].type == OBJ_NONE)
+			continue;
+		++counter;
+		obj_delete(i);
+	}
+
+	mprintf(("Cleanup: Deleted %i objects\n", counter));
+}
+
 /**
  * Remove object from the world
  * If Player_obj, don't remove it!
@@ -574,7 +588,7 @@ void obj_delete(int objnum)
 	case OBJ_START:
 	case OBJ_WAYPOINT:
 	case OBJ_POINT:
-		Assert(Fred_running);
+		//Assert(Fred_running);
 		break;  // requires no action, handled by the Fred code.
 	case OBJ_JUMP_NODE:
 		break;  // requires no further action, handled by jumpnode deconstructor.

--- a/code/object/object.cpp
+++ b/code/object/object.cpp
@@ -519,7 +519,7 @@ int obj_create(ubyte type,int parent_obj,int instance, matrix * orient,
 void obj_delete_all() 
 {
 	int counter = 0;
-	for (size_t i = 0; i < MAX_OBJECTS; ++i) 
+	for (int i = 0; i < MAX_OBJECTS; ++i) 
 	{
 		if (Objects[i].type == OBJ_NONE)
 			continue;

--- a/code/object/object.cpp
+++ b/code/object/object.cpp
@@ -588,7 +588,6 @@ void obj_delete(int objnum)
 	case OBJ_START:
 	case OBJ_WAYPOINT:
 	case OBJ_POINT:
-		//Assert(Fred_running);
 		break;  // requires no action, handled by the Fred code.
 	case OBJ_JUMP_NODE:
 		break;  // requires no further action, handled by jumpnode deconstructor.

--- a/code/object/object.h
+++ b/code/object/object.h
@@ -243,6 +243,8 @@ void obj_move_one(object * obj, float frametime);
 // function to delete an object -- should probably only be called directly from editor code
 void obj_delete(int objnum);
 
+void obj_delete_all();
+
 // should only be used by the editor!
 void obj_merge_created_list(void);
 

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -891,6 +891,7 @@ void game_level_close()
 		mission_campaign_save_player_persistent_variables();	// Goober5000
 
 		// De-Initialize the game subsystems
+		obj_delete_all();
 		sexp_music_close();	// Goober5000
 		event_music_level_close();
 		game_stop_looped_sounds();


### PR DESCRIPTION
This adds a step to the post-mission cleanup where we explicitly go through Objects and call obj_delete on everything not already deleted; this obviously needs testing.

Also a few cleanup steps in lab_init to make sure the lab isn't contaminated by leftover data from previously played missions.