### PR TITLE
Make the OGL_Anisotropy setting more usable

### DIFF
--- a/code/cmdline/cmdline.cpp
+++ b/code/cmdline/cmdline.cpp
@@ -333,6 +333,7 @@ cmdline_parm flightshaftsoff_arg("-nolightshafts", NULL, AT_NONE);
 cmdline_parm shadow_quality_arg("-shadow_quality", NULL, AT_INT);
 cmdline_parm enable_shadows_arg("-enable_shadows", NULL, AT_NONE);
 cmdline_parm no_deferred_lighting_arg("-no_deferred", NULL, AT_NONE);	// Cmdline_no_deferred
+cmdline_parm anisotropy_level_arg("-anisotropic_filter", NULL, AT_INT);
 
 float Cmdline_clip_dist = Default_min_draw_distance;
 float Cmdline_fov = 0.75f;
@@ -359,6 +360,7 @@ bool Cmdline_fb_thrusters = false;
 extern bool ls_force_off;
 int Cmdline_shadow_quality = 0;
 int Cmdline_no_deferred_lighting = 0;
+int Cmdline_aniso_level = 0;
 
 // Game Speed related
 cmdline_parm cache_bitmaps_arg("-cache_bitmaps", NULL, AT_NONE);	// Cmdline_cache_bitmaps
@@ -2051,6 +2053,11 @@ bool SetCmdlineParams()
 	if( no_deferred_lighting_arg.found() )
 	{
 		Cmdline_no_deferred_lighting = 1;
+	}
+
+	if (anisotropy_level_arg.found()) 
+	{
+		Cmdline_aniso_level = anisotropy_level_arg.get_int();
 	}
 
 	if (frame_profile_write_file.found())

--- a/code/cmdline/cmdline.h
+++ b/code/cmdline/cmdline.h
@@ -79,6 +79,7 @@ extern bool Cmdline_fb_thrusters;
 extern int Cmdline_shadow_quality;
 extern int Cmdline_no_deferred_lighting;
 extern int Cmdline_no_emissive;
+extern int Cmdline_aniso_level;
 
 // Game Speed related
 extern int Cmdline_cache_bitmaps;

--- a/code/graphics/opengl/gropengltexture.cpp
+++ b/code/graphics/opengl/gropengltexture.cpp
@@ -149,8 +149,7 @@ void opengl_tcache_init()
 		opengl_get_max_anisotropy();
 
 		// now for the user setting
-		const char *plevel = os_config_read_string( NULL, NOX("OGL_AnisotropicFilter"), NOX("1.0") );
-		GL_anisotropy = (GLfloat) strtod(plevel, (char**)NULL);
+		GL_anisotropy = (GLfloat) Cmdline_aniso_level;
 
 		CLAMP(GL_anisotropy, 1.0f, GL_max_anisotropy);
 	}

--- a/code/graphics/opengl/gropengltexture.cpp
+++ b/code/graphics/opengl/gropengltexture.cpp
@@ -146,10 +146,11 @@ void opengl_tcache_init()
 	// anisotropy
 	if ( GLAD_GL_EXT_texture_filter_anisotropic ) {
 		// set max value first thing
-		opengl_get_max_anisotropy();
+		GL_anisotropy = opengl_get_max_anisotropy();
 
 		// now for the user setting
-		GL_anisotropy = (GLfloat) Cmdline_aniso_level;
+		if (Cmdline_aniso_level != 0)
+			GL_anisotropy = (GLfloat) Cmdline_aniso_level;
 
 		CLAMP(GL_anisotropy, 1.0f, GL_max_anisotropy);
 	}


### PR DESCRIPTION
This addresses #1658. It introduces a new commandline parameter, `-anisotropic_filter`, which takes an int argument which is then used as the anisotropic filtering value in OpenGL. If it is not set, we default to the highest supported level (this has performance implications, of course; I am open to suggestions for a better default than 1...)