### PR TITLE
Fix wrong return value when getting boolean value from Lua

### DIFF
--- a/code/scripting/lua/LuaConvert.cpp
+++ b/code/scripting/lua/LuaConvert.cpp
@@ -154,7 +154,7 @@ bool popValue(lua_State* luaState, bool& target, int stackposition, bool remove)
 			lua_remove(luaState, stackposition);
 		}
 
-		return target;
+		return true;
 	}
 }
 


### PR DESCRIPTION
This is probably a bug from when I changed how those functions worked.
The function is supposed to return if it successfully retreived a value
from the Lua stack but instead of returning `true` if it was, it returned
the value it just retrieved. This works fine if that value is `true` but
causes issues if it was `false`.