### PR TITLE
Fix Assert in Lua API when passing invalid name to mn.WaypointList

### DIFF
--- a/code/scripting/api/libs/mission.cpp
+++ b/code/scripting/api/libs/mission.cpp
@@ -393,8 +393,12 @@ ADE_INDEXER(l_Mission_WaypointLists, "number Index/string WaypointListName", "Ar
 	wpl = waypointlist_h(name);
 
 	if (!wpl.IsValid()) {
-		int idx = atoi(name) - 1;
-		wpl = waypointlist_h(find_waypoint_list_at_index(idx));
+		char* end_ptr;
+		auto idx = (int)strtol(name, &end_ptr, 10);
+		if (end_ptr != name && idx >= 1) {
+			// The string is a valid number and the number has a valid value
+			wpl = waypointlist_h(find_waypoint_list_at_index(idx - 1));
+		}
 	}
 
 	if (wpl.IsValid()) {

--- a/code/scripting/api/libs/mission.cpp
+++ b/code/scripting/api/libs/mission.cpp
@@ -365,7 +365,7 @@ ADE_INDEXER(l_Mission_Waypoints, "number Index", "Array of waypoints in the curr
 		ptr = GET_NEXT(ptr);
 	}
 
-	return ade_set_error(L, "o", l_Weapon.Set(object_h()));
+	return ade_set_error(L, "o", l_Waypoint.Set(object_h()));
 }
 
 ADE_FUNC(__len, l_Mission_Waypoints, NULL, "Gets number of waypoints in mission. Note that this is only accurate for one frame.", "number", "Number of waypoints in the mission")

--- a/code/scripting/api/objs/waypoint.cpp
+++ b/code/scripting/api/objs/waypoint.cpp
@@ -34,8 +34,11 @@ ADE_FUNC(getList, l_Waypoint, NULL, "Returns the waypoint list", "waypointlist",
 waypointlist_h::waypointlist_h() {wlp=NULL;name[0]='\0';}
 waypointlist_h::waypointlist_h(waypoint_list* n_wlp) {
 	wlp = n_wlp;
-	if(n_wlp != NULL)
+	if(n_wlp != NULL) {
 		strcpy_s(name, wlp->get_name());
+	} else {
+		memset(name, 0, sizeof(name));
+	}
 }
 waypointlist_h::waypointlist_h(char* wlname) {
 	wlp = NULL;


### PR DESCRIPTION
Since `atoi` returns 0 on error the code tries to access the waypoint list
with index -1 which causes an assert in the lookup code. This fixes that
by using the error detection capabilities of `strtol`.