### PR TITLE
Add new bmpman slot management system

### DIFF
--- a/code/bmpman/bm_internal.h
+++ b/code/bmpman/bm_internal.h
@@ -23,6 +23,16 @@
 
 #include "bmpman/bmpman.h"
 
+#include <array>
+
+/**
+ * @brief Container class for graphics API specific bitmap data
+ */
+class gr_bitmap_info {
+ public:
+	virtual ~gr_bitmap_info() = 0;
+};
+
 union bm_extra_info {
 	struct {
 		// Stuff needed for animations
@@ -90,17 +100,35 @@ struct bitmap_entry {
 #endif
 };
 
-extern bitmap_entry* bm_bitmaps;
+struct bitmap_slot {
+	bitmap_entry entry;
+
+	gr_bitmap_info* gr_info = nullptr;
+};
 
 // image specific lock functions
-void bm_lock_ani( int handle, int bitmapnum, bitmap_entry *be, bitmap *bmp, int bpp, ubyte flags );
-void bm_lock_dds( int handle, int bitmapnum, bitmap_entry *be, bitmap *bmp, int bpp, ubyte flags );
-void bm_lock_png( int handle, int bitmapnum, bitmap_entry *be, bitmap *bmp, int bpp, ubyte flags );
-void bm_lock_apng( int handle, int bitmapnum, bitmap_entry *be, bitmap *bmp, int bpp, ubyte flags );
-void bm_lock_jpg( int handle, int bitmapnum, bitmap_entry *be, bitmap *bmp, int bpp, ubyte flags );
-void bm_lock_pcx( int handle, int bitmapnum, bitmap_entry *be, bitmap *bmp, int bpp, ubyte flags );
-void bm_lock_tga( int handle, int bitmapnum, bitmap_entry *be, bitmap *bmp, int bpp, ubyte flags );
-void bm_lock_user( int handle, int bitmapnum, bitmap_entry *be, bitmap *bmp, int bpp, ubyte flags );
+void bm_lock_ani( int handle, bitmap_slot *bs, bitmap *bmp, int bpp, ubyte flags );
+void bm_lock_dds( int handle, bitmap_slot *bs, bitmap *bmp, int bpp, ubyte flags );
+void bm_lock_png( int handle, bitmap_slot *bs, bitmap *bmp, int bpp, ubyte flags );
+void bm_lock_apng( int handle, bitmap_slot *bs, bitmap *bmp, int bpp, ubyte flags );
+void bm_lock_jpg( int handle, bitmap_slot *bs, bitmap *bmp, int bpp, ubyte flags );
+void bm_lock_pcx( int handle, bitmap_slot *bs, bitmap *bmp, int bpp, ubyte flags );
+void bm_lock_tga( int handle, bitmap_slot *bs, bitmap *bmp, int bpp, ubyte flags );
+void bm_lock_user( int handle, bitmap_slot *bs, bitmap *bmp, int bpp, ubyte flags );
 
+const size_t BM_BLOCK_SIZE = 4096;
+
+extern SCP_vector<std::array<bitmap_slot, BM_BLOCK_SIZE>> bm_blocks;
+
+bitmap_slot* bm_get_slot(int handle, bool separate_ani_frames = true);
+
+inline bitmap_entry* bm_get_entry(int handle, bool separate_ani_frames = true) {
+	return &bm_get_slot(handle, separate_ani_frames)->entry;
+}
+
+template<typename T>
+T* bm_get_gr_info(int handle, bool separate_ani_frames = true) {
+	return static_cast<T*>(bm_get_slot(handle, separate_ani_frames)->gr_info);
+}
 
 #endif // __BM_INTERNAL_H__

--- a/code/bmpman/bmpman.h
+++ b/code/bmpman/bmpman.h
@@ -32,23 +32,6 @@
  * @{
  */
 
-/**
- * @brief How many bitmaps the game can handle by default
- *
- * @attention  MAX_BITMAPS shouldn't need to be bumped again.  With the fixed bm_release() and it's proper use even the
- *   largest missions should stay under this number.  With the largest retail missions and wasteful content we should
- *   still have about 20% of the slots free.  If it still goes over then it's something the artists need to fix.
- *   For instance the Terran Mara fighter, with -spec and -glow and using the Shinepack, needs 117 bitmap slots alone.
- *   111 of those is just for the glowmaps.  This number can be greatly reduced if the number of ani frames for another
- *   LOD than LOD0 has fewer or no ani frames.  A 37 frame glow ani for LOD2 is little more than a waste of resources.
- *   Future reports of texture corruption should be initially approached with content as the cause and not code.
- *   If anything we could/should reduce MAX_BITMAPS in the future.  Where it's at now should accomidate even the
- *   largest mods.  --  Taylor
- */
-#define DEFAULT_MAX_BITMAPS 4750
-
-extern int MAX_BITMAPS;
-
 // Flag positions for bitmap.flags
 // ***** NOTE:  bitmap.flags is an 8-bit value, no more BMP_TEX_* flags can be added unless the type is changed!! ******
 #define	BMP_AABITMAP        (1<<0)      //!< antialiased bitmap
@@ -115,6 +98,10 @@ struct bitmap
 	                     */
 };
 
+// Forward definition for the graphics API
+struct bitmap_entry;
+struct bitmap_slot;
+
 extern size_t bm_texture_ram;  //!< how many bytes of textures are used.
 
 extern int Bm_paging;   //!< Bool type that indicates if BMPMAN is currently paging.
@@ -142,22 +129,6 @@ void bm_init();
  * @brief Closes the bitmap manager, freeing any allocated memory used by bitmaps. Is called at program close.
  */
 void bm_close();
-
-/**
- * Gets the cache slot of the bitmap indexed by handle.
- *
- * @details if the bitmap is an ani, gets the first frame
- *
- * @returns The cache slot index of the bitmap if handle is valid
- *
- * @note If the handle is invalid, an Assert() fails
- */
-int bm_get_cache_slot(int bitmap_id, int separate_ani_frames);
-
-/**
- * @brief Gets the next available bitmap slot.
- */
-int bm_get_next_handle();
 
 #define BMP_FLAG_RENDER_TARGET_STATIC		(1<<0)
 #define BMP_FLAG_RENDER_TARGET_DYNAMIC		(1<<1)
@@ -413,13 +384,6 @@ void bm_get_filename(int bitmapnum, char *filename);
 const char *bm_get_filename(int handle);
 
 /**
- * @brief Loads all data for all bitmaps that have been requested to be loaded
- *
- * @note This function is not defined.
- */
-void bm_gfx_load_all();
-
-/**
  * @brief Unloads all used bitmaps, should only ever be called by game_shutdown()
  *
  * @todo Maybe move this declaration into bmpman.cpp and then extern this function within game_shutdown() to
@@ -436,15 +400,6 @@ void bm_unload_all();
  * @todo Maybe get rid of the optional filename and have the callers call bm_get_filename. Less efficient, however.
  */
 void bm_get_palette(int handle, ubyte *pal, char *name);
-
-/**
- * @brief Hack to get a pixel from a bitmap
- *
- * @details only works good in 8bpp mode
- *
- * @note This function is not defined.
- */
-void bm_gfx_get_pixel(int bitmap, float u, float v, ubyte *r, ubyte *g, ubyte *b);
 
 /**
  * @brief (DEBUG) Gets memory size, in bytes, of the locked bitmaps
@@ -740,6 +695,18 @@ int bm_get_array_index(const int handle);
  * @return The number of used slots
  */
 int bmpman_count_bitmaps();
+
+/**
+ * @brief Counts how many slots are available to the bmpman system
+ *
+ * Since the number of slots is dynamic now, this should be used for determining the total amount of available slots at
+ * the moment.
+ *
+ * @warning This is entirely for debugging and logging purposes. It should not be used in actual engine code.
+ *
+ * @return The number of available slots
+ */
+int bmpman_count_available_slots();
 
 /**
  * @brief Checks if the given filename is a valid effect or texture file name

--- a/code/globalincs/pstypes.h
+++ b/code/globalincs/pstypes.h
@@ -261,14 +261,14 @@ extern int Global_error_count;
 // Disabling this functionality is dangerous, crazy values can run rampent unchecked and the longer its disabled
 // the more likely you are to have problems getting it working again.
 #if defined(NDEBUG)
-#	define Assert(expr) do { ASSUME(expr); } while (0)
+#	define Assert(expr) do { ASSUME(expr); } while (false)
 #else
 #	define Assert(expr) do {\
 		if (!(expr)) {\
 			os::dialogs::AssertMessage(#expr,__FILE__,__LINE__);\
 		}\
 		ASSUME( expr );\
-	} while (0)
+	} while (false)
 #endif
 /*******************NEVER COMMENT Assert ************************************************/
 

--- a/code/globalincs/toolchain/clang.h
+++ b/code/globalincs/toolchain/clang.h
@@ -32,7 +32,7 @@
 #define ASSUME(x)
 
 #if defined(NDEBUG)
-#	define Assertion(expr, msg, ...)  do { } while (0)
+#	define Assertion(expr, msg, ...)  do { } while (false)
 #else
 /*
  * NOTE: Assertion() can only use its proper functionality in compilers
@@ -43,7 +43,7 @@
 			if (!(expr)) {                                                \
 				os::dialogs::AssertMessage(#expr, __FILE__, __LINE__, msg, ##__VA_ARGS__); \
 			}                                                             \
-		} while (0)
+		} while (false)
 #endif
 
 /* C++11 Standard Detection */

--- a/code/globalincs/toolchain/gcc.h
+++ b/code/globalincs/toolchain/gcc.h
@@ -32,7 +32,7 @@
 #define ASSUME(x)
 
 #if defined(NDEBUG)
-#	define Assertion(expr, msg, ...)  do {} while (0)
+#	define Assertion(expr, msg, ...)  do {} while (false)
 #else
 /*
  * NOTE: Assertion() can only use its proper functionality in compilers
@@ -43,7 +43,7 @@
 			if (!(expr)) {                                                \
 				os::dialogs::AssertMessage(#expr, __FILE__, __LINE__, msg, ##__VA_ARGS__); \
 			}                                                             \
-		} while (0)
+		} while (false)
 #endif
 
 /* C++11 Standard Detection */

--- a/code/globalincs/toolchain/mingw.h
+++ b/code/globalincs/toolchain/mingw.h
@@ -34,7 +34,7 @@
 #define ASSUME(x)
 
 #if defined(NDEBUG)
-#	define Assertion(expr, msg, ...)  do {} while (0)
+#	define Assertion(expr, msg, ...)  do {} while (false)
 #else
 /*
  * NOTE: Assertion() can only use its proper functionality in compilers
@@ -45,7 +45,7 @@
 			if (!(expr)) {                                                \
 				os::dialogs::AssertMessage(#expr, __FILE__, __LINE__, msg, ##__VA_ARGS__); \
 			}                                                             \
-		} while (0)
+		} while (false)
 #endif
 
 /* C++11 Standard Detection */

--- a/code/globalincs/toolchain/msvc.h
+++ b/code/globalincs/toolchain/msvc.h
@@ -38,9 +38,9 @@
 
 #if defined(NDEBUG)
 #	if _MSC_VER >= 1400  /* MSVC 2005 or newer */
-#		define Assertion(expr, msg, ...)  do { ASSUME(expr); } while (0)
+#		define Assertion(expr, msg, ...)  do { ASSUME(expr); } while (false)
 #	else
-#		define Assertion(expr, msg)  do {} while (0)
+#		define Assertion(expr, msg)  do {} while (false)
 #	endif
 #else
 	/*
@@ -53,13 +53,13 @@
 				if (!(expr)) {                                              \
 					os::dialogs::AssertMessage(#expr, __FILE__, __LINE__, msg, __VA_ARGS__); \
 				}                                                           \
-			} while (0)
+			} while (false)
 #	else                 /* Older MSVC compilers */
 #		define Assertion(expr, msg)                        \
 			do {                                           \
 				if (!(expr)) {                             \
 					os::dialogs::AssertMessage(#expr, __FILE__, __LINE__);  \
-			} while (0)
+			} while (false)
 #	endif
 #endif
 

--- a/code/graphics/2d.h
+++ b/code/graphics/2d.h
@@ -709,14 +709,14 @@ typedef struct screen {
 	void (*gf_set_clear_color)(int r, int g, int b);
 
 	// Here be the bitmap functions
-	void (*gf_bm_free_data)(int n, bool release);
-	void (*gf_bm_create)(int n);
-	void (*gf_bm_init)(int n);
+	void (*gf_bm_free_data)(bitmap_slot* slot, bool release);
+	void (*gf_bm_create)(bitmap_slot* slot);
+	void (*gf_bm_init)(bitmap_slot* slot);
 	void (*gf_bm_page_in_start)();
-	bool (*gf_bm_data)(int n, bitmap* bm);
+	bool (*gf_bm_data)(int handle, bitmap* bm);
 
-	int (*gf_bm_make_render_target)(int n, int *width, int *height, int *bpp, int *mm_lvl, int flags );
-	int (*gf_bm_set_render_target)(int n, int face);
+	int (*gf_bm_make_render_target)(int handle, int *width, int *height, int *bpp, int *mm_lvl, int flags );
+	int (*gf_bm_set_render_target)(int handle, int face);
 
 	void (*gf_translate_texture_matrix)(int unit, const vec3d *shift);
 	void (*gf_push_texture_matrix)(int unit);

--- a/code/graphics/grstub.cpp
+++ b/code/graphics/grstub.cpp
@@ -278,15 +278,15 @@ int gr_stub_bm_set_render_target(int  /*n*/, int  /*face*/)
 	return 0;
 }
 
-void gr_stub_bm_create(int  /*n*/)
+void gr_stub_bm_create(bitmap_slot* /*slot*/)
 {
 }
 
-void gr_stub_bm_free_data(int  /*n*/, bool  /*release*/)
+void gr_stub_bm_free_data(bitmap_slot* /*slot*/, bool /*release*/)
 {
 }
 
-void gr_stub_bm_init(int  /*n*/)
+void gr_stub_bm_init(bitmap_slot* /*slot*/)
 {
 }
 

--- a/code/graphics/opengl/gropenglbmpman.cpp
+++ b/code/graphics/opengl/gropenglbmpman.cpp
@@ -51,31 +51,28 @@ int get_num_mipmap_levels(int w, int h)
 /**
  * Anything API specific to freeing bm data
  */
-void gr_opengl_bm_free_data(int n, bool release)
+void gr_opengl_bm_free_data(bitmap_slot* slot, bool release)
 {
-	Assert( (n >= 0) && (n < MAX_BITMAPS) );
-
 	if ( release )
-		 opengl_free_texture_slot( n );
+		 opengl_free_texture_slot( slot );
 
-	if ( (bm_bitmaps[n].type == BM_TYPE_RENDER_TARGET_STATIC) || (bm_bitmaps[n].type == BM_TYPE_RENDER_TARGET_DYNAMIC) )
-		opengl_kill_render_target( n );
+	if ( (slot->entry.type == BM_TYPE_RENDER_TARGET_STATIC) || (slot->entry.type == BM_TYPE_RENDER_TARGET_DYNAMIC) )
+		opengl_kill_render_target( slot );
 }
 
 /**
  * API specifics for creating a user bitmap
  */
-void gr_opengl_bm_create(int n)
+void gr_opengl_bm_create(bitmap_slot* /*entry*/)
 {
-	Assert( (n >= 0) && (n < MAX_BITMAPS) );
 }
 
 /**
  * API specific init instructions
  */
-void gr_opengl_bm_init(int n)
+void gr_opengl_bm_init(bitmap_slot* slot)
 {
-	Assert( (n >= 0) && (n < MAX_BITMAPS) );
+	slot->gr_info = new tcache_slot_opengl;
 }
 
 /**
@@ -86,23 +83,19 @@ void gr_opengl_bm_page_in_start()
 	opengl_preload_init();
 }
 
-extern void bm_clean_slot(int n);
-
 extern bool opengl_texture_slot_valid(int n, int handle);
 
 
-void gr_opengl_bm_save_render_target(int n)
+void gr_opengl_bm_save_render_target(int handle)
 {
-	Assert( (n >= 0) && (n < MAX_BITMAPS) );
-
 	if ( Cmdline_no_fbo ) {
 		return;
 	}
 
-	bitmap_entry *be = &bm_bitmaps[n];
+	bitmap_entry *be = bm_get_entry(handle);
 	bitmap *bmp = &be->bm;
 
-	size_t rc = opengl_export_render_target( n, bmp->w, bmp->h, (bmp->true_bpp == 32), be->num_mipmaps, (ubyte*)bmp->data );
+	size_t rc = opengl_export_render_target( handle, bmp->w, bmp->h, (bmp->true_bpp == 32), be->num_mipmaps, (ubyte*)bmp->data );
 
 	if (rc != be->mem_taken) {
 		Int3();
@@ -112,10 +105,8 @@ void gr_opengl_bm_save_render_target(int n)
 	dds_save_image(bmp->w, bmp->h, bmp->true_bpp, be->num_mipmaps, (ubyte*)bmp->data, (bmp->flags & BMP_FLAG_CUBEMAP));
 }
 
-int gr_opengl_bm_make_render_target(int n, int *width, int *height, int *bpp, int *mm_lvl, int flags)
+int gr_opengl_bm_make_render_target(int handle, int *width, int *height, int *bpp, int *mm_lvl, int flags)
 {
-	Assert( (n >= 0) && (n < MAX_BITMAPS) );
-
 	if ( Cmdline_no_fbo ) {
 		return 0;
 	}
@@ -124,7 +115,7 @@ int gr_opengl_bm_make_render_target(int n, int *width, int *height, int *bpp, in
 		MIN(*width, *height) = MAX(*width, *height);
 	}
 
-	if ( opengl_make_render_target(bm_bitmaps[n].handle, n, width, height, bpp, mm_lvl, flags) ) {
+	if ( opengl_make_render_target(handle, width, height, bpp, mm_lvl, flags) ) {
 		return 1;
 	}
 
@@ -142,9 +133,9 @@ int gr_opengl_bm_set_render_target(int n, int face)
 		return 1;
 	}
 
-	Assert( (n >= 0) && (n < MAX_BITMAPS) );
+	auto entry = bm_get_entry(n);
 
-	int is_static = (bm_bitmaps[n].type == BM_TYPE_RENDER_TARGET_STATIC);
+	int is_static = (entry->type == BM_TYPE_RENDER_TARGET_STATIC);
 
 	if ( opengl_set_render_target(n, face, is_static) ) {
 		return 1;

--- a/code/graphics/opengl/gropenglbmpman.h
+++ b/code/graphics/opengl/gropenglbmpman.h
@@ -18,18 +18,18 @@
 #include <glad/glad.h>
 
 // anything API specific to freeing bm data
-void gr_opengl_bm_free_data(int n, bool release);
+void gr_opengl_bm_free_data(bitmap_slot* entry, bool release);
 
 // API specifics for creating a user bitmap
-void gr_opengl_bm_create(int n);
+void gr_opengl_bm_create(bitmap_slot* entry);
 
 // API specific init instructions
-void gr_opengl_bm_init(int n);
+void gr_opengl_bm_init(bitmap_slot* entry);
 
 // specific instructions for setting up the start of a page-in session
 void gr_opengl_bm_page_in_start();
 
-bool gr_opengl_bm_data(int n, bitmap* bm);
+bool gr_opengl_bm_data(int handle, bitmap* bm);
 
 void gr_opengl_bm_save_render_target(int slot);
 int gr_opengl_bm_make_render_target(int n, int *width, int *height, int *bpp, int *mm_lvl, int flags);

--- a/code/graphics/opengl/gropengltexture.h
+++ b/code/graphics/opengl/gropengltexture.h
@@ -14,9 +14,13 @@
 #include "globalincs/pstypes.h"
 #include "gropengl.h"
 
+#define BMPMAN_INTERNAL
+#include "bmpman/bm_internal.h"
+
 #include <glad/glad.h>
 
-typedef struct tcache_slot_opengl {
+class tcache_slot_opengl : public gr_bitmap_info {
+ public:
 	GLuint texture_id;
 	GLenum texture_target;
 	GLenum wrap_mode;
@@ -53,7 +57,7 @@ typedef struct tcache_slot_opengl {
 		used = false;
 		fbo_id = -1;
 	}
-} tcache_slot_opengl;
+};
 
 extern int GL_min_texture_width;
 extern GLint GL_max_texture_width;
@@ -69,7 +73,7 @@ extern GLint GL_max_renderbuffer_size;
 
 void opengl_switch_arb(int unit, int state);
 void opengl_tcache_init();
-void opengl_free_texture_slot(int n);
+void opengl_free_texture_slot(bitmap_slot* slot);
 void opengl_tcache_flush();
 void opengl_tcache_shutdown();
 void opengl_tcache_frame();
@@ -77,8 +81,8 @@ void opengl_set_additive_tex_env();
 void opengl_set_modulate_tex_env();
 void opengl_preload_init();
 GLfloat opengl_get_max_anisotropy();
-void opengl_kill_render_target(int slot);
-int opengl_make_render_target(int handle, int slot, int *w, int *h, int *bpp, int *mm_lvl, int flags);
+void opengl_kill_render_target(bitmap_slot* slot);
+int opengl_make_render_target(int handle, int *w, int *h, int *bpp, int *mm_lvl, int flags);
 int opengl_set_render_target(int slot, int face = -1, int is_static = 0);
 void gr_opengl_get_bitmap_from_texture(void* data_out, int bitmap_num);
 size_t opengl_export_render_target( int slot, int width, int height, int alpha, int num_mipmaps, ubyte *image_data );

--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -231,14 +231,10 @@ void parse_mod_table(const char *filename)
 		}
 
 		if (optional_string("$BMPMAN Slot Limit:")) {
-			int slots;
-			stuff_int(&slots);
-			if (slots < 3500) {
-				error_display(0, "Invalid BMPMAN slot limit [%d]; must be at least 3500.", slots);
-			} else {
-				mprintf(("Game Settings Table: Setting BMPMAN slot limit to %d\n", slots));
-				MAX_BITMAPS = slots;
-			}
+			int tmp;
+			stuff_int(&tmp);
+
+			mprintf(("Game Settings Table: $BMPMAN Slot Limit is deprecated and should be removed. It is not needed anymore.\n"));
 		}
 
 		optional_string("#NETWORK SETTINGS");

--- a/code/scripting/api/objs/texture.cpp
+++ b/code/scripting/api/objs/texture.cpp
@@ -27,7 +27,7 @@ ADE_FUNC(__gc, l_Texture, NULL, "Auto-deletes texture", NULL, NULL)
 	// might get called even for handles to bitmaps which are actually still in
 	// use, and in order to prevent that we want to double-check the load count
 	// here before unloading the bitmap. -zookeeper
-	if(idx > -1 && bm_is_valid(idx) && bm_bitmaps[bm_get_cache_slot(idx, 0)].load_count < 1)
+	if(idx > -1 && bm_is_valid(idx) && bm_get_entry(idx)->load_count < 1)
 		bm_release(idx);
 
 	return ADE_RETURN_NIL;

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -2134,7 +2134,7 @@ void game_show_framerate()
 		}
 
 		if (Cmdline_bmpman_usage) {
-			gr_printf_no_resize( gr_screen.center_offset_x + 20, gr_screen.center_offset_y + 100 - line_height, "BMPMAN: %d/%d", bmpman_count_bitmaps(), MAX_BITMAPS );
+			gr_printf_no_resize( gr_screen.center_offset_x + 20, gr_screen.center_offset_y + 100 - line_height, "BMPMAN: %d/%d", bmpman_count_bitmaps(), bmpman_count_available_slots() );
 		}
 	}
 


### PR DESCRIPTION
This changes how the bitmap slots are managed by the bmpman system.
Instead of allocating a fixed-size array when the game starts this will
manage multiple "blocks" of bitmap slots. When the engine runs out of
slots in the already allocated blocks it simply creates a new block and
allocates the new slot in that.

This removed the hard limit on how many bitmaps can be loaded at the
same time and should fix issues encountered by mods which use a lot of
bitmap slots (I'm looking at you Spoon).

This implements the idea described in #1503.

I will create a post in the test build forum once the builds have finished compiling. Until this has received more testing it should not be merged.