### PR TITLE
Add typesafe handle types and use it in game sound system

### DIFF
--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -10839,7 +10839,7 @@ void ai_dock()
 
 				if (aip->submode == AIS_DOCK_3) {
 					// Play a ship docking attach sound
-					snd_play_3d( gamesnd_get_game_sound(SND_DOCK_ATTACH), &Pl_objp->pos, &View_position );
+					snd_play_3d( gamesnd_get_game_sound(GameSounds::DOCK_ATTACH), &Pl_objp->pos, &View_position );
 
 					// start the dock animation
 					model_anim_start_type(shipp, TRIGGER_TYPE_DOCKED, docker_index, 1);
@@ -10966,7 +10966,7 @@ void ai_dock()
 		ai_find_path(Pl_objp, OBJ_INDEX(goal_objp), path_num, 0);
 
 		// Play a ship docking detach sound
-		snd_play_3d( gamesnd_get_game_sound(SND_DOCK_DETACH), &Pl_objp->pos, &View_position );
+		snd_play_3d( gamesnd_get_game_sound(GameSounds::DOCK_DETACH), &Pl_objp->pos, &View_position );
 
 		aip->submode = AIS_UNDOCK_1;
 		aip->submode_start_time = Missiontime;
@@ -10986,7 +10986,7 @@ void ai_dock()
 		// play the depart sound, but only once, since this mode is called multiple times per frame
 		if ( !(aigp->flags[AI::Goal_Flags::Depart_sound_played]))
 		{
-			snd_play_3d( gamesnd_get_game_sound(SND_DOCK_DEPART), &Pl_objp->pos, &View_position );
+			snd_play_3d( gamesnd_get_game_sound(GameSounds::DOCK_DEPART), &Pl_objp->pos, &View_position );
 			aigp->flags.set(AI::Goal_Flags::Depart_sound_played);
 		}
 

--- a/code/ai/aiturret.cpp
+++ b/code/ai/aiturret.cpp
@@ -2048,7 +2048,7 @@ bool turret_fire_weapon(int weapon_num, ship_subsys *turret, int parent_objnum, 
 						}
 					}
 
-					if ( wip->launch_snd != -1 ) {
+					if ( wip->launch_snd.isValid() ) {
 						// Don't play turret firing sound if turret sits on player ship... it gets annoying.
 						if ( parent_objnum != OBJ_INDEX(Player_obj) || (turret->flags[Ship::Subsystem_Flags::Play_sound_for_player]) ) {						
 							snd_play_3d( gamesnd_get_game_sound(wip->launch_snd), turret_pos, &View_position );
@@ -2135,7 +2135,7 @@ void turret_swarm_fire_from_turret(turret_swarm_info *tsi)
 		}
 
 		// maybe sound
-		if ( Weapon_info[tsi->weapon_class].launch_snd != -1 ) {
+		if ( Weapon_info[tsi->weapon_class].launch_snd.isValid() ) {
 			// Don't play turret firing sound if turret sits on player ship... it gets annoying.
 			if ( tsi->parent_objnum != OBJ_INDEX(Player_obj) ) {
 				snd_play_3d( gamesnd_get_game_sound(Weapon_info[tsi->weapon_class].launch_snd), &turret_pos, &View_position );

--- a/code/asteroid/asteroid.cpp
+++ b/code/asteroid/asteroid.cpp
@@ -1278,21 +1278,21 @@ static float asteroid_create_explosion(object *objp)
  */
 static void asteroid_explode_sound(object *objp, int type, int play_loud)
 {
-	int	sound_index = -1;
+	gamesnd_id sound_index;
 	float range_factor = 1.0f;		// how many times sound should traver farther than normal
 
 	if (type % NUM_DEBRIS_SIZES <= 1)
 	{
-		sound_index = SND_ASTEROID_EXPLODE_SMALL;
+		sound_index = gamesnd_id(GameSounds::ASTEROID_EXPLODE_SMALL);
 		range_factor = 5.0;
 	}
 	else
 	{
-		sound_index = SND_ASTEROID_EXPLODE_LARGE;
+		sound_index = gamesnd_id(GameSounds::ASTEROID_EXPLODE_LARGE);
 		range_factor = 10.0f;
 	}
 
-	Assert(sound_index != -1);
+	Assert(sound_index.isValid());
 
 	if ( !play_loud ) {
 		range_factor = 1.0f;

--- a/code/cmeasure/cmeasure.cpp
+++ b/code/cmeasure/cmeasure.cpp
@@ -92,7 +92,7 @@ void cmeasure_maybe_alert_success(object *objp)
 
 	if ( objp->parent == OBJ_INDEX(Player_obj) ) {
 		hud_start_text_flash(XSTR("Evaded", 1430), 800);
-		snd_play(gamesnd_get_game_sound(ship_get_sound(Player_obj, SND_MISSILE_EVADED_POPUP)));
+		snd_play(gamesnd_get_game_sound(ship_get_sound(Player_obj, GameSounds::MISSILE_EVADED_POPUP)));
 	} else if ( Objects[objp->parent].flags[Object::Object_Flags::Player_ship] ) {
 		send_countermeasure_success_packet( objp->parent );
 	}

--- a/code/controlconfig/controlsconfig.cpp
+++ b/code/controlconfig/controlsconfig.cpp
@@ -615,7 +615,7 @@ int control_config_undo_last()
 	int i, z, tab;
 
 	if (!Config_item_undo) {
-		gamesnd_play_iface(SND_GENERAL_FAIL);
+		gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 		return -1;
 	}
 
@@ -664,7 +664,7 @@ int control_config_undo_last()
 	free_undo_block();
 	control_config_conflict_check();
 	control_config_list_prepare();
-	gamesnd_play_iface(SND_USER_SELECT);
+	gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 	return 0;
 }
 
@@ -715,7 +715,7 @@ int control_config_remove_binding()
 	config_item_undo *ptr;
 
 	if (Selected_line < 0) {
-		gamesnd_play_iface(SND_GENERAL_FAIL);
+		gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 		return -1;
 	}
 
@@ -723,7 +723,7 @@ int control_config_remove_binding()
 	if (z & JOY_AXIS) {
 		z &= ~JOY_AXIS;
 		if (Axis_map_to[z] < 0) {
-			gamesnd_play_iface(SND_GENERAL_FAIL);
+			gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 			return -1;
 		}
 
@@ -731,13 +731,13 @@ int control_config_remove_binding()
 		Axis_map_to[z] = -1;
 		control_config_conflict_check();
 		control_config_list_prepare();
-		gamesnd_play_iface(SND_USER_SELECT);
+		gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 		Selected_item = -1;
 		return 0;
 	}
 
 	if ((Control_config[z].joy_id < 0) && (Control_config[z].key_id < 0)) {
-		gamesnd_play_iface(SND_GENERAL_FAIL);
+		gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 		return -1;
 	}
 
@@ -755,7 +755,7 @@ int control_config_remove_binding()
 
 	control_config_conflict_check();
 	control_config_list_prepare();
-	gamesnd_play_iface(SND_USER_SELECT);
+	gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 	Selected_item = -1;
 	return 0;
 }
@@ -766,7 +766,7 @@ int control_config_clear_other()
 	config_item_undo *ptr;
 
 	if (Selected_line < 0) {
-		gamesnd_play_iface(SND_GENERAL_FAIL);
+		gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 		return -1;
 	}
 
@@ -776,7 +776,7 @@ int control_config_clear_other()
 
 		z &= ~JOY_AXIS;
 		if (Axis_map_to[z] < 0) {
-			gamesnd_play_iface(SND_GENERAL_FAIL);
+			gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 			return -1;
 		}
 
@@ -787,7 +787,7 @@ int control_config_clear_other()
 		}
 
 		if (!total) {
-			gamesnd_play_iface(SND_GENERAL_FAIL);
+			gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 			return -1;
 		}
 
@@ -808,7 +808,7 @@ int control_config_clear_other()
 		}
 		control_config_conflict_check();
 		control_config_list_prepare();
-		gamesnd_play_iface(SND_USER_SELECT);
+		gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 		return 0;
 	}
 
@@ -820,12 +820,12 @@ int control_config_clear_other()
 		}
 	}
 	if (!total) {
-		gamesnd_play_iface(SND_GENERAL_FAIL);
+		gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 		return -1;
 	}
 
 	if ((Control_config[z].joy_id < 0) && (Control_config[z].key_id < 0)) {
-		gamesnd_play_iface(SND_GENERAL_FAIL);
+		gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 		return -1;
 	}
 
@@ -850,7 +850,7 @@ int control_config_clear_other()
 	}
 	control_config_conflict_check();
 	control_config_list_prepare();
-	gamesnd_play_iface(SND_USER_SELECT);
+	gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 	return 0;
 }
 
@@ -867,7 +867,7 @@ int control_config_clear_all()
 	}
 
 	if (!total) {
-		gamesnd_play_iface(SND_GENERAL_FAIL);
+		gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 		return -1;
 	}
 
@@ -888,7 +888,7 @@ int control_config_clear_all()
 
 	control_config_conflict_check();
 	control_config_list_prepare();
-	gamesnd_play_iface(SND_RESET_PRESSED);
+	gamesnd_play_iface(InterfaceSounds::RESET_PRESSED);
 	return 0;
 }
 
@@ -945,7 +945,7 @@ int control_config_do_reset()
 	}
 
 	if (!total && !cycling_presets) {
-		gamesnd_play_iface(SND_GENERAL_FAIL);
+		gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 		return -1;
 	}
 
@@ -981,7 +981,7 @@ int control_config_do_reset()
 
 	control_config_conflict_check();
 	control_config_list_prepare();
-	gamesnd_play_iface(SND_RESET_PRESSED);
+	gamesnd_play_iface(InterfaceSounds::RESET_PRESSED);
 	return 0;
 }
 
@@ -1026,10 +1026,10 @@ void control_config_scroll_screen_up()
 		}
 
 		Selected_item = -1;
-		gamesnd_play_iface(SND_SCROLL);
+		gamesnd_play_iface(InterfaceSounds::SCROLL);
 
 	} else {
-		gamesnd_play_iface(SND_GENERAL_FAIL);
+		gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 	}
 }
 
@@ -1042,10 +1042,10 @@ void control_config_scroll_line_up()
 		}
 
 		Selected_item = -1;
-		gamesnd_play_iface(SND_SCROLL);
+		gamesnd_play_iface(InterfaceSounds::SCROLL);
 
 	} else {
-		gamesnd_play_iface(SND_GENERAL_FAIL);
+		gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 	}
 }
 
@@ -1059,10 +1059,10 @@ void control_config_scroll_screen_down()
 		}
 
 		Selected_item = -1;
-		gamesnd_play_iface(SND_SCROLL);
+		gamesnd_play_iface(InterfaceSounds::SCROLL);
 
 	} else {
-		gamesnd_play_iface(SND_GENERAL_FAIL);
+		gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 	}
 }
 
@@ -1076,10 +1076,10 @@ void control_config_scroll_line_down()
 		}
 
 		Selected_item = -1;
-		gamesnd_play_iface(SND_SCROLL);
+		gamesnd_play_iface(InterfaceSounds::SCROLL);
 
 	} else {
-		gamesnd_play_iface(SND_GENERAL_FAIL);
+		gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 	}
 }
 
@@ -1091,13 +1091,13 @@ void control_config_toggle_modifier(int bit)
 	Assert(!(z & JOY_AXIS));
 	k = Control_config[z].key_id;
 	if (k < 0) {
-		gamesnd_play_iface(SND_GENERAL_FAIL);
+		gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 		return;
 	}
 
 	control_config_bind_key(z, k ^ bit);
 	control_config_conflict_check();
-	gamesnd_play_iface(SND_USER_SELECT);
+	gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 }
 
 void control_config_toggle_invert()
@@ -1118,7 +1118,7 @@ void control_config_do_bind()
 	game_flush();
 //	if ((Selected_line < 0) || (Cc_lines[Selected_line].cc_index & JOY_AXIS)) {
 	if (Selected_line < 0) {
-		gamesnd_play_iface(SND_GENERAL_FAIL);
+		gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 		return;
 	}
 
@@ -1142,7 +1142,7 @@ void control_config_do_bind()
 	Search_mode = 0;
 	Last_key = -1;
 	Axis_override = -1;
-	gamesnd_play_iface(SND_USER_SELECT);
+	gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 }
 
 void control_config_do_search()
@@ -1166,7 +1166,7 @@ void control_config_do_search()
 	Binding_mode = 0;
 	Search_mode = 1;
 	Last_key = -1;
-	gamesnd_play_iface(SND_USER_SELECT);
+	gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 }
 
 void control_config_do_cancel(int fail = 0)
@@ -1189,9 +1189,9 @@ void control_config_do_cancel(int fail = 0)
 
 	Binding_mode = Search_mode = 0;
 	if (fail){
-		gamesnd_play_iface(SND_GENERAL_FAIL);
+		gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 	} else {
-		gamesnd_play_iface(SND_USER_SELECT);
+		gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 	}
 }
 
@@ -1206,13 +1206,13 @@ int control_config_accept()
 	}
 
 	if (i < NUM_TABS) {
-		gamesnd_play_iface(SND_GENERAL_FAIL);
+		gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 		return -1;
 	}
 
 	hud_squadmsg_save_keys();  // rebuild map for saving/restoring keys in squadmsg mode
 	gameseq_post_event(GS_EVENT_PREVIOUS_STATE);
-	gamesnd_play_iface(SND_COMMIT_PRESSED);
+	gamesnd_play_iface(InterfaceSounds::COMMIT_PRESSED);
 	return 0;
 }
 
@@ -1237,7 +1237,7 @@ void control_config_button_pressed(int n)
 			Tab = n;
 			Scroll_offset = Selected_line = 0;
 			control_config_list_prepare();
-			gamesnd_play_iface(SND_SCREEN_MODE_PRESSED);
+			gamesnd_play_iface(InterfaceSounds::SCREEN_MODE_PRESSED);
 			break;
 
 		case BIND_BUTTON:
@@ -1250,17 +1250,17 @@ void control_config_button_pressed(int n)
 
 		case SHIFT_TOGGLE:
 			control_config_toggle_modifier(KEY_SHIFTED);
-			gamesnd_play_iface(SND_USER_SELECT);
+			gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 			break;
 
 		case ALT_TOGGLE:
 			control_config_toggle_modifier(KEY_ALTED);
-			gamesnd_play_iface(SND_USER_SELECT);
+			gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 			break;
 
 		case INVERT_AXIS:
 			control_config_toggle_invert();
-			gamesnd_play_iface(SND_USER_SELECT);
+			gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 			break;
 
 		case SCROLL_UP_BUTTON:
@@ -1281,7 +1281,7 @@ void control_config_button_pressed(int n)
 
 		case HELP_BUTTON:
 			launch_context_help();
-			gamesnd_play_iface(SND_HELP_PRESSED);
+			gamesnd_play_iface(InterfaceSounds::HELP_PRESSED);
 			break;
 
 		case RESET_BUTTON:
@@ -1799,7 +1799,7 @@ void control_config_do_frame(float frametime)
 
 				Scroll_offset = Selected_line = 0;
 				control_config_list_prepare();
-				gamesnd_play_iface(SND_SCREEN_MODE_PRESSED);
+				gamesnd_play_iface(InterfaceSounds::SCREEN_MODE_PRESSED);
 				break;
 
 			case KEY_TAB:  // activate next tab
@@ -1810,7 +1810,7 @@ void control_config_do_frame(float frametime)
 
 				Scroll_offset = Selected_line = 0;
 				control_config_list_prepare();
-				gamesnd_play_iface(SND_SCREEN_MODE_PRESSED);
+				gamesnd_play_iface(InterfaceSounds::SCREEN_MODE_PRESSED);
 				break;
 
 			case KEY_LEFT:
@@ -1825,7 +1825,7 @@ void control_config_do_frame(float frametime)
 					}
 				}
 
-				gamesnd_play_iface(SND_SCROLL);
+				gamesnd_play_iface(InterfaceSounds::SCROLL);
 				break;
 
 			case KEY_RIGHT:
@@ -1837,7 +1837,7 @@ void control_config_do_frame(float frametime)
 				} else if (Selected_item > 1) {
 					Selected_item = -1;
 				}
-				gamesnd_play_iface(SND_SCROLL);
+				gamesnd_play_iface(InterfaceSounds::SCROLL);
 				break;
 
 			case KEY_BACKSP:  // undo
@@ -1873,7 +1873,7 @@ void control_config_do_frame(float frametime)
 				Selected_item = 1;
 			}
 
-			gamesnd_play_iface(SND_USER_SELECT);
+			gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 		}
 
 		if (List_buttons[i].double_clicked()) {

--- a/code/cutscene/cutscenes.cpp
+++ b/code/cutscene/cutscenes.cpp
@@ -286,10 +286,10 @@ void cutscenes_screen_scroll_line_up()
 	if (Selected_line)
 	{
 		Selected_line--;
-		gamesnd_play_iface(SND_SCROLL);
+		gamesnd_play_iface(InterfaceSounds::SCROLL);
 
 	} else
-		gamesnd_play_iface(SND_GENERAL_FAIL);
+		gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 
 	if (Selected_line < Scroll_offset)
 		Scroll_offset = Selected_line;
@@ -302,10 +302,10 @@ void cutscenes_screen_scroll_line_down()
 	if (Selected_line < (int) Cutscene_list.size() - 1)
 	{
 		Selected_line++;
-		gamesnd_play_iface(SND_SCROLL);
+		gamesnd_play_iface(InterfaceSounds::SCROLL);
 
 	} else
-		gamesnd_play_iface(SND_GENERAL_FAIL);
+		gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 
 	h = Cutscene_list_coords[gr_screen.res][3] / gr_get_font_height();
 	if (Selected_line >= Scroll_offset + h)
@@ -328,11 +328,11 @@ void cutscenes_screen_scroll_screen_up()
 			Selected_line--;
 		}
 
-		gamesnd_play_iface(SND_SCROLL);
+		gamesnd_play_iface(InterfaceSounds::SCROLL);
 
 	} else
 	{
-		gamesnd_play_iface(SND_GENERAL_FAIL);
+		gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 	}
 }
 
@@ -349,10 +349,10 @@ void cutscenes_screen_scroll_screen_down()
 			Selected_line = Scroll_offset;
 		}
 
-		gamesnd_play_iface(SND_SCROLL);
+		gamesnd_play_iface(InterfaceSounds::SCROLL);
 	} else
 	{
-		gamesnd_play_iface(SND_GENERAL_FAIL);
+		gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 	}
 }
 
@@ -361,17 +361,17 @@ int cutscenes_screen_button_pressed(int n)
 	switch (n)
 	{
 		case TECH_DATABASE_BUTTON:
-			gamesnd_play_iface(SND_SWITCH_SCREENS);
+			gamesnd_play_iface(InterfaceSounds::SWITCH_SCREENS);
 			gameseq_post_event(GS_EVENT_TECH_MENU);
 			return 1;
 
 		case SIMULATOR_BUTTON:
-			gamesnd_play_iface(SND_SWITCH_SCREENS);
+			gamesnd_play_iface(InterfaceSounds::SWITCH_SCREENS);
 			gameseq_post_event(GS_EVENT_SIMULATOR_ROOM);
 			return 1;
 
 		case CREDITS_BUTTON:
-			gamesnd_play_iface(SND_SWITCH_SCREENS);
+			gamesnd_play_iface(InterfaceSounds::SWITCH_SCREENS);
 			gameseq_post_event(GS_EVENT_CREDITS);
 			return 1;
 
@@ -388,7 +388,7 @@ int cutscenes_screen_button_pressed(int n)
 			break;
 
 		case EXIT_BUTTON:
-			gamesnd_play_iface(SND_COMMIT_PRESSED);
+			gamesnd_play_iface(InterfaceSounds::COMMIT_PRESSED);
 			gameseq_post_event(GS_EVENT_MAIN_MENU);
 			game_flush();
 			break;

--- a/code/debris/debris.cpp
+++ b/code/debris/debris.cpp
@@ -74,7 +74,7 @@ static void debris_start_death_roll(object *debris_obj, debris *debris_p)
 
 		// only play debris destroy sound if hull piece and it has been around for at least 2 seconds
 		if ( Missiontime > debris_p->time_started + 2*F1_0 ) {
-			snd_play_3d( gamesnd_get_game_sound(SND_MISSILE_IMPACT1), &debris_obj->pos, &View_position, debris_obj->radius );
+			snd_play_3d( gamesnd_get_game_sound(gamesnd_id(GameSounds::MISSILE_IMPACT1)), &debris_obj->pos, &View_position, debris_obj->radius );
 			
 		}
 	}
@@ -238,7 +238,7 @@ void debris_process_post(object * obj, float frame_time)
 		radar_plot_object( obj );
 
 		if ( timestamp_elapsed(db->sound_delay) ) {
-			obj_snd_assign(objnum, SND_DEBRIS, &vmd_zero_vector, 0);
+			obj_snd_assign(objnum, GameSounds::DEBRIS, &vmd_zero_vector, 0);
 			db->sound_delay = 0;
 		}
 	} else {
@@ -324,19 +324,19 @@ void debris_process_post(object * obj, float frame_time)
 			//Play a sound effect
 			if ( lifetime > 750 )	{
 				// 1.00 second effect
-				snd_play_3d( gamesnd_get_game_sound(SND_DEBRIS_ARC_05), &snd_pos, &View_position, obj->radius );
+				snd_play_3d( gamesnd_get_game_sound(GameSounds::DEBRIS_ARC_05), &snd_pos, &View_position, obj->radius );
 			} else if ( lifetime >  500 )	{
 				// 0.75 second effect
-				snd_play_3d( gamesnd_get_game_sound(SND_DEBRIS_ARC_04), &snd_pos, &View_position, obj->radius );
+				snd_play_3d( gamesnd_get_game_sound(GameSounds::DEBRIS_ARC_04), &snd_pos, &View_position, obj->radius );
 			} else if ( lifetime >  250 )	{
 				// 0.50 second effect
-				snd_play_3d( gamesnd_get_game_sound(SND_DEBRIS_ARC_03), &snd_pos, &View_position, obj->radius );
+				snd_play_3d( gamesnd_get_game_sound(GameSounds::DEBRIS_ARC_03), &snd_pos, &View_position, obj->radius );
 			} else if ( lifetime >  100 )	{
 				// 0.25 second effect
-				snd_play_3d( gamesnd_get_game_sound(SND_DEBRIS_ARC_02), &snd_pos, &View_position, obj->radius );
+				snd_play_3d( gamesnd_get_game_sound(GameSounds::DEBRIS_ARC_02), &snd_pos, &View_position, obj->radius );
 			} else {
 				// 0.10 second effect
-				snd_play_3d( gamesnd_get_game_sound(SND_DEBRIS_ARC_01), &snd_pos, &View_position, obj->radius );
+				snd_play_3d( gamesnd_get_game_sound(GameSounds::DEBRIS_ARC_01), &snd_pos, &View_position, obj->radius );
 			}
 		}
 	}

--- a/code/fireball/fireballs.cpp
+++ b/code/fireball/fireballs.cpp
@@ -63,7 +63,7 @@ int Warp_ball_bitmap = -1;
  */
 void fireball_play_warphole_open_sound(int ship_class, fireball *fb)
 {
-	int		sound_index;
+	gamesnd_id sound_index;
 	float		range_multiplier = 1.0f;
 	object	*fireball_objp;	
 		
@@ -73,13 +73,13 @@ void fireball_play_warphole_open_sound(int ship_class, fireball *fb)
 	}
 	fireball_objp = &Objects[fb->objnum];
 
-	sound_index = SND_WARP_IN;
+	sound_index = gamesnd_id(GameSounds::WARP_IN);
 
-	if(fb->warp_open_sound_index > -1) {
+	if(fb->warp_open_sound_index.isValid()) {
 		sound_index = fb->warp_open_sound_index;
 	} else if ((ship_class >= 0) && (ship_class < static_cast<int>(Ship_info.size()))) {
 		if ( Ship_info[ship_class].is_huge_ship() ) {
-			sound_index = SND_CAPITAL_WARP_IN;
+			sound_index = gamesnd_id(GameSounds::CAPITAL_WARP_IN);
 			fb->flags |= FBF_WARP_CAPITAL_SIZE;
 		} else if ( Ship_info[ship_class].is_big_ship() ) {
 			range_multiplier = 6.0f;
@@ -95,18 +95,18 @@ void fireball_play_warphole_open_sound(int ship_class, fireball *fb)
  */
 void fireball_play_warphole_close_sound(fireball *fb)
 {
-	int	sound_index;	
+	gamesnd_id sound_index;
 
 	object *fireball_objp;
 
 	fireball_objp = &Objects[fb->objnum];
 
-	sound_index = SND_WARP_OUT;
+	sound_index = gamesnd_id(GameSounds::WARP_OUT);
 
-	if ( fb->warp_close_sound_index > -1 ) {
+	if ( fb->warp_close_sound_index.isValid() ) {
 		sound_index = fb->warp_close_sound_index;
 	} else if ( fb->flags & FBF_WARP_CAPITAL_SIZE ) {
-		sound_index = SND_CAPITAL_WARP_OUT;
+		sound_index = gamesnd_id(GameSounds::CAPITAL_WARP_OUT);
 	} else {
 		return;
 	}
@@ -696,7 +696,7 @@ int fireball_get_lod(vec3d *pos, fireball_info *fd, float size)
 /**
  * Create a fireball, return object index.
  */
-int fireball_create( vec3d * pos, int fireball_type, int render_type, int parent_obj, float size, int reverse, vec3d *velocity, float warp_lifetime, int ship_class, matrix *orient_override, int low_res, int extra_flags, int warp_open_sound, int warp_close_sound)
+int fireball_create( vec3d * pos, int fireball_type, int render_type, int parent_obj, float size, int reverse, vec3d *velocity, float warp_lifetime, int ship_class, matrix *orient_override, int low_res, int extra_flags, gamesnd_id warp_open_sound, gamesnd_id warp_close_sound)
 {
 	int				n, objnum, fb_lod;
 	object			*obj;

--- a/code/fireball/fireballs.h
+++ b/code/fireball/fireballs.h
@@ -14,6 +14,7 @@
 
 #include "globalincs/pstypes.h"
 #include "model/modelrender.h"
+#include "gamesnd/gamesnd.h"
 
 class object;
 class ship_info;
@@ -71,8 +72,8 @@ typedef struct fireball {
 	char	lod;					// current LOD
 	float	time_elapsed;			// in seconds
 	float	total_time;				// total lifetime of animation in seconds
-	int warp_open_sound_index;		// for warp-effect - Goober5000
-	int warp_close_sound_index;		// for warp-effect - Goober5000
+	gamesnd_id warp_open_sound_index;		// for warp-effect - Goober5000
+	gamesnd_id warp_close_sound_index;		// for warp-effect - Goober5000
 } fireball;
 // end move
 
@@ -84,7 +85,7 @@ void fireball_process_post(object * obj, float frame_time);
 // reversed is for warp_in/out effects
 // Velocity: If not NULL, the fireball will move at a constant velocity.
 // warp_lifetime: If warp_lifetime > 0.0f then makes the explosion loop so it lasts this long.  Only works for warp effect
-int fireball_create(vec3d *pos, int fireball_type, int render_type, int parent_obj, float size, int reversed=0, vec3d *velocity=NULL, float warp_lifetime=0.0f, int ship_class=-1, matrix *orient=NULL, int low_res=0, int extra_flags=0, int warp_open_sound=-1, int warp_close_sound=-1); 
+int fireball_create(vec3d *pos, int fireball_type, int render_type, int parent_obj, float size, int reversed=0, vec3d *velocity=NULL, float warp_lifetime=0.0f, int ship_class=-1, matrix *orient=NULL, int low_res=0, int extra_flags=0, gamesnd_id warp_open_sound=gamesnd_id(), gamesnd_id warp_close_sound=gamesnd_id());
 void fireball_render_plane(int plane);
 void fireball_close();
 

--- a/code/fs2netd/fs2netd_client.cpp
+++ b/code/fs2netd/fs2netd_client.cpp
@@ -21,6 +21,7 @@
 #include "graphics/2d.h"
 #include "graphics/font.h"
 #include "io/timer.h"
+#include "mission/missionparse.h"
 #include "mod_table/mod_table.h"
 #include "network/multi.h"
 #include "network/multi_log.h"
@@ -545,7 +546,7 @@ static void fs2netd_handle_ping()
 		// make sure that we are good to go
 		if ( !Is_connected ) {
 			if (!Is_standalone) {
-				gamesnd_play_iface(SND_GENERAL_FAIL);
+				gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 				popup(PF_USE_AFFIRMATIVE_ICON | PF_TITLE_BIG | PF_TITLE_RED, 1, POPUP_OK, "ERROR:\nLost connection to the FS2NetD server!");
 			}
 
@@ -587,7 +588,7 @@ static void fs2netd_handle_ping()
 			// make sure that we are good to go
 			if ( !Is_connected ) {
 				if (!Is_standalone) {
-					gamesnd_play_iface(SND_GENERAL_FAIL);
+					gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 					popup(PF_USE_AFFIRMATIVE_ICON | PF_TITLE_BIG | PF_TITLE_RED, 1, POPUP_OK, "ERROR:\nLost connection to the FS2NetD server!");
 				}
 

--- a/code/gamehelp/gameplayhelp.cpp
+++ b/code/gamehelp/gameplayhelp.cpp
@@ -255,7 +255,7 @@ void gameplay_help_goto_prev_screen()
 	if (Current_help_page < GP_FIRST_SCREEN) {
 		Current_help_page = Gp_last_screen;
 	}
-	gamesnd_play_iface(SND_SWITCH_SCREENS);
+	gamesnd_play_iface(InterfaceSounds::SWITCH_SCREENS);
 
 }
 
@@ -266,7 +266,7 @@ void gameplay_help_goto_next_screen()
 	if (Current_help_page > Gp_last_screen) {
 		Current_help_page = GP_FIRST_SCREEN;
 	}
-	gamesnd_play_iface(SND_SWITCH_SCREENS);
+	gamesnd_play_iface(InterfaceSounds::SWITCH_SCREENS);
 }
 
 // called when the screen is exited
@@ -321,7 +321,7 @@ void gameplay_help_button_pressed(int n)
 
 	case CONTINUE_BUTTON:
 		gameplay_help_leave();
-		gamesnd_play_iface(SND_COMMIT_PRESSED);
+		gamesnd_play_iface(InterfaceSounds::COMMIT_PRESSED);
 		break;
 
 	default:

--- a/code/gamesnd/gamesnd.h
+++ b/code/gamesnd/gamesnd.h
@@ -12,42 +12,8 @@
 #ifndef __GAMESND_H__
 #define __GAMESND_H__
 
-#include "mission/missionparse.h"
 #include "sound/sound.h"
-
-
-void gamesnd_parse_soundstbl();	// Loads in general game sounds from sounds.tbl
-void gamesnd_close();	// close out gamesnd... only call from game_shutdown()!
-void gamesnd_load_gameplay_sounds();
-void gamesnd_unload_gameplay_sounds();
-void gamesnd_load_interface_sounds();
-void gamesnd_unload_interface_sounds();
-void gamesnd_preload_common_sounds();
-void gamesnd_load_gameplay_sounds();
-void gamesnd_unload_gameplay_sounds();
-void gamesnd_play_iface(int n);
-void gamesnd_play_error_beep();
-int gamesnd_get_by_name(const char* name);
-int gamesnd_get_by_iface_name(const char* name);
-int gamesnd_get_by_tbl_index(int index);
-int gamesnd_get_by_iface_tbl_index(int index);
-
-//flags for parse_sound and parse_sound_list
-enum parse_sound_flags
-{
-	PARSE_SOUND_GENERAL_SOUND = 0,				//!< search for sound in the general table in sound.tbl
-	PARSE_SOUND_INTERFACE_SOUND = (1 << 0),		//!< Search for sound in the interface part of sounds.tbl
-	PARSE_SOUND_SCP_SOUND_LIST = (1 << 1),		//!< Parse the list of sounds SCP style (just indexes and/or files names, no count first)
-	PARSE_SOUND_MAX
-};
-
-//This should handle NO_SOUND just fine since it doesn't directly access lowlevel code
-//Does all parsing for a sound
-void parse_sound(const char* tag, int* idx_dest, const char* object_name, parse_sound_flags = PARSE_SOUND_GENERAL_SOUND);
-void parse_sound_list(const char* tag, SCP_vector<int>& destination, const char* object_name, parse_sound_flags = PARSE_SOUND_GENERAL_SOUND);
-
-// this is a callback, so it needs to be a real function
-void common_play_highlight_sound();
+#include "utils/id.h"
 
 /**
  * symbolic names for misc. game sounds.
@@ -61,325 +27,384 @@ void common_play_highlight_sound();
  * Then add a symbolic name to the appropriate position in the enum below
  * and add an entry to sounds.tbl.  If there is no .wav file for the sound yet, specify sound_hook.wav in sounds.tbl.
  */
-enum GameSoundsIndex {
-	SND_MISSILE_TRACKING           = 0,  //!< Missle tracking to acquire a lock (looped)
-	SND_MISSILE_LOCK               = 1,  //!< Missle lock (non-looping)
-	SND_PRIMARY_CYCLE              = 2,  //!< cycle primary weapon
-	SND_SECONDARY_CYCLE            = 3,  //!< cycle secondary weapon
-	SND_ENGINE                     = 4,  //!< engine sound (as heard in cockpit)
-	SND_CARGO_REVEAL               = 5,  //!< cargo revealed
-	SND_DEATH_ROLL                 = 6,  //!< ship death roll
-	SND_SHIP_EXPLODE_1             = 7,  //!< ship explosion 1
-	SND_TARGET_ACQUIRE             = 8,  //!< target acquried
-	SND_ENERGY_ADJUST              = 9,  //!< energy level change success
-	SND_ENERGY_ADJUST_FAIL         = 10, //!< energy level change fail
-	SND_ENERGY_TRANS               = 11, //!< energy transfer success
-	SND_ENERGY_TRANS_FAIL          = 12, //!< energy transfer fail
-	SND_FULL_THROTTLE              = 13, //!< set full throttle
-	SND_ZERO_THROTTLE              = 14, //!< set zero throttle
-	SND_THROTTLE_UP                = 15, //!< set 1/3 or 2/3 throttle (up)
-	SND_THROTTLE_DOWN              = 16, //!< set 1/3 or 2/3 throttle (down)
-	SND_DOCK_APPROACH              = 17, //!< dock approach retros
-	SND_DOCK_ATTACH                = 18, //!< dock attach
-	SND_DOCK_DETACH                = 19, //!< dock detach
-	SND_DOCK_DEPART                = 20, //!< dock depart retros
-	SND_ABURN_ENGAGE               = 21, //!< afterburner engage
-	SND_ABURN_LOOP                 = 22, //!< afterburner burn sound (looped)
-	SND_VAPORIZED                  = 23, //!< Destroyed by a beam (vaporized)
-	SND_ABURN_FAIL                 = 24, //!< afterburner fail (no fuel when aburn pressed)
-	SND_HEATLOCK_WARN              = 25, //!< heat-seeker launch warning
-	SND_OUT_OF_MISSLES             = 26, //!< tried to fire a missle when none are left
-	SND_OUT_OF_WEAPON_ENERGY       = 27, //!< tried to fire lasers when not enough energy left
-	SND_TARGET_FAIL                = 28, //!< target fail sound (i.e. press targeting key, but nothing happens)
-	SND_SQUADMSGING_ON             = 29, //!< squadmate message menu appears
-	SND_SQUADMSGING_OFF            = 30, //!< squadmate message menu disappears
-	SND_DEBRIS                     = 31, //!< debris sound (persistant, looping)
-	SND_SUBSYS_DIE_1               = 32, //!< subsystem gets destroyed on player ship
-	SND_MISSILE_START_LOAD         = 33, //!< missle start load (during rearm/repair)
-	SND_MISSILE_LOAD               = 34, //!< missle load (during rearm/repair)
-	SND_SHIP_REPAIR                = 35, //!< ship is being repaired (during rearm/repair)
-	SND_PLAYER_HIT_LASER           = 36, //!< player ship is hit by laser fire
-	SND_PLAYER_HIT_MISSILE         = 37, //!< player ship is hit by missile
-	SND_CMEASURE_CYCLE             = 38, //!< countermeasure cycle
-	SND_SHIELD_HIT                 = 39, //!< shield hit
-	SND_SHIELD_HIT_YOU             = 40, //!< player shield is hit
-	SND_GAME_MOUSE_CLICK           = 41, //!< mouse click
-	SND_ASPECTLOCK_WARN            = 42, //!< aspect launch warning
-	SND_SHIELD_XFER_OK             = 43, //!< shield quadrant transfer successful
-	SND_ENGINE_WASH                = 44, //!< Engine wash (looped)
-	SND_WARP_IN                    = 45, //!< warp hole opening up for arriving
-	SND_WARP_OUT                   = 46, //!< warp hole opening up for departing (Same as warp in for now)
-	SND_PLAYER_WARP_FAIL           = 47, //!< player warp has failed
-	SND_STATIC                     = 48, //!< hud gauge static
-	SND_SHIP_EXPLODE_2             = 49, //!< ship explosion 2
-	SND_PLAYER_WARP_OUT            = 50, //!< ship is warping out in 3rd person
-	SND_SHIP_SHIP_HEAVY            = 51, //!< heavy ship-ship collide sound
-	SND_SHIP_SHIP_LIGHT            = 52, //!< light ship-ship collide sound
-	SND_SHIP_SHIP_SHIELD           = 53, //!< shield ship-ship collide overlay sound
-	SND_THREAT_FLASH               = 54, //!< missile threat indicator flashes
-	SND_PROXIMITY_WARNING          = 55, //!< proximity warning (heat seeker)
-	SND_PROXIMITY_ASPECT_WARNING   = 56, //!< proximity warning (aspect)
-	SND_DIRECTIVE_COMPLETE         = 57, //!< directive complete
-	SND_SUBSYS_EXPLODE             = 58, //!< other ship subsystem destroyed
-	SND_CAPSHIP_EXPLODE            = 59, //!< captial ship explosion
-	SND_CAPSHIP_SUBSYS_EXPLODE     = 60, //!< captial ship subsystem destroyed
-	SND_LARGESHIP_WARPOUT          = 61, //!< large ship warps out
-	SND_ASTEROID_EXPLODE_LARGE     = 62, //!< large asteroid blows up
-	SND_ASTEROID_EXPLODE_SMALL     = 63, //!< small asteroid blows up
-	SND_CUE_VOICE                  = 64, //!< sound to indicate voice is about to start
-	SND_END_VOICE                  = 65, //!< sound to indicate voice has ended
-	SND_CARGO_SCAN                 = 66, //!< cargo scanning (looped)
-	SND_WEAPON_FLYBY               = 67, //!< weapon flyby sound
-	SND_ASTEROID                   = 68, //!< asteroid sound (persistant, looped)
-	SND_CAPITAL_WARP_IN            = 69, //!< capital warp hole opening
-	SND_CAPITAL_WARP_OUT           = 70, //!< capital warp hole closing
-	SND_ENGINE_LOOP_LARGE          = 71, //!< LARGE engine ambient
-	SND_SUBSPACE_LEFT_CHANNEL      = 72, //!< subspace ambient sound (left channel) (looped)
-	SND_SUBSPACE_RIGHT_CHANNEL     = 73, //!< subspace ambient sound (right channel) (looped)
-	SND_MISSILE_EVADED_POPUP       = 74, //!< "evaded" HUD popup
-	SND_ENGINE_LOOP_HUGE           = 75, //!< HUGE engine ambient
+enum class GameSounds {
+	MISSILE_TRACKING           = 0,  //!< Missle tracking to acquire a lock (looped)
+	MISSILE_LOCK               = 1,  //!< Missle lock (non-looping)
+	PRIMARY_CYCLE              = 2,  //!< cycle primary weapon
+	SECONDARY_CYCLE            = 3,  //!< cycle secondary weapon
+	ENGINE                     = 4,  //!< engine sound (as heard in cockpit)
+	CARGO_REVEAL               = 5,  //!< cargo revealed
+	DEATH_ROLL                 = 6,  //!< ship death roll
+	SHIP_EXPLODE_1             = 7,  //!< ship explosion 1
+	TARGET_ACQUIRE             = 8,  //!< target acquried
+	ENERGY_ADJUST              = 9,  //!< energy level change success
+	ENERGY_ADJUST_FAIL         = 10, //!< energy level change fail
+	ENERGY_TRANS               = 11, //!< energy transfer success
+	ENERGY_TRANS_FAIL          = 12, //!< energy transfer fail
+	FULL_THROTTLE              = 13, //!< set full throttle
+	ZERO_THROTTLE              = 14, //!< set zero throttle
+	THROTTLE_UP                = 15, //!< set 1/3 or 2/3 throttle (up)
+	THROTTLE_DOWN              = 16, //!< set 1/3 or 2/3 throttle (down)
+	DOCK_APPROACH              = 17, //!< dock approach retros
+	DOCK_ATTACH                = 18, //!< dock attach
+	DOCK_DETACH                = 19, //!< dock detach
+	DOCK_DEPART                = 20, //!< dock depart retros
+	ABURN_ENGAGE               = 21, //!< afterburner engage
+	ABURN_LOOP                 = 22, //!< afterburner burn sound (looped)
+	VAPORIZED                  = 23, //!< Destroyed by a beam (vaporized)
+	ABURN_FAIL                 = 24, //!< afterburner fail (no fuel when aburn pressed)
+	HEATLOCK_WARN              = 25, //!< heat-seeker launch warning
+	OUT_OF_MISSLES             = 26, //!< tried to fire a missle when none are left
+	OUT_OF_WEAPON_ENERGY       = 27, //!< tried to fire lasers when not enough energy left
+	TARGET_FAIL                = 28, //!< target fail sound (i.e. press targeting key, but nothing happens)
+	SQUADMSGING_ON             = 29, //!< squadmate message menu appears
+	SQUADMSGING_OFF            = 30, //!< squadmate message menu disappears
+	DEBRIS                     = 31, //!< debris sound (persistant, looping)
+	SUBSYS_DIE_1               = 32, //!< subsystem gets destroyed on player ship
+	MISSILE_START_LOAD         = 33, //!< missle start load (during rearm/repair)
+	MISSILE_LOAD               = 34, //!< missle load (during rearm/repair)
+	SHIP_REPAIR                = 35, //!< ship is being repaired (during rearm/repair)
+	PLAYER_HIT_LASER           = 36, //!< player ship is hit by laser fire
+	PLAYER_HIT_MISSILE         = 37, //!< player ship is hit by missile
+	CMEASURE_CYCLE             = 38, //!< countermeasure cycle
+	SHIELD_HIT                 = 39, //!< shield hit
+	SHIELD_HIT_YOU             = 40, //!< player shield is hit
+	GAME_MOUSE_CLICK           = 41, //!< mouse click
+	ASPECTLOCK_WARN            = 42, //!< aspect launch warning
+	SHIELD_XFER_OK             = 43, //!< shield quadrant transfer successful
+	ENGINE_WASH                = 44, //!< Engine wash (looped)
+	WARP_IN                    = 45, //!< warp hole opening up for arriving
+	WARP_OUT                   = 46, //!< warp hole opening up for departing (Same as warp in for now)
+	PLAYER_WARP_FAIL           = 47, //!< player warp has failed
+	STATIC                     = 48, //!< hud gauge static
+	SHIP_EXPLODE_2             = 49, //!< ship explosion 2
+	PLAYER_WARP_OUT            = 50, //!< ship is warping out in 3rd person
+	SHIP_SHIP_HEAVY            = 51, //!< heavy ship-ship collide sound
+	SHIP_SHIP_LIGHT            = 52, //!< light ship-ship collide sound
+	SHIP_SHIP_SHIELD           = 53, //!< shield ship-ship collide overlay sound
+	THREAT_FLASH               = 54, //!< missile threat indicator flashes
+	PROXIMITY_WARNING          = 55, //!< proximity warning (heat seeker)
+	PROXIMITY_ASPECT_WARNING   = 56, //!< proximity warning (aspect)
+	DIRECTIVE_COMPLETE         = 57, //!< directive complete
+	SUBSYS_EXPLODE             = 58, //!< other ship subsystem destroyed
+	CAPSHIP_EXPLODE            = 59, //!< captial ship explosion
+	CAPSHIP_SUBSYS_EXPLODE     = 60, //!< captial ship subsystem destroyed
+	LARGESHIP_WARPOUT          = 61, //!< large ship warps out
+	ASTEROID_EXPLODE_LARGE     = 62, //!< large asteroid blows up
+	ASTEROID_EXPLODE_SMALL     = 63, //!< small asteroid blows up
+	CUE_VOICE                  = 64, //!< sound to indicate voice is about to start
+	END_VOICE                  = 65, //!< sound to indicate voice has ended
+	CARGO_SCAN                 = 66, //!< cargo scanning (looped)
+	WEAPON_FLYBY               = 67, //!< weapon flyby sound
+	ASTEROID                   = 68, //!< asteroid sound (persistant, looped)
+	CAPITAL_WARP_IN            = 69, //!< capital warp hole opening
+	CAPITAL_WARP_OUT           = 70, //!< capital warp hole closing
+	ENGINE_LOOP_LARGE          = 71, //!< LARGE engine ambient
+	SUBSPACE_LEFT_CHANNEL      = 72, //!< subspace ambient sound (left channel) (looped)
+	SUBSPACE_RIGHT_CHANNEL     = 73, //!< subspace ambient sound (right channel) (looped)
+	MISSILE_EVADED_POPUP       = 74, //!< "evaded" HUD popup
+	ENGINE_LOOP_HUGE           = 75, //!< HUGE engine ambient
 	//Weapons section
-	SND_LIGHT_LASER_FIRE           = 76, //!< SD-4 Sidearm laser fired
-	SND_LIGHT_LASER_IMPACT         = 77, //!< DR-2 Scalpel fired
-	SND_HVY_LASER_FIRE             = 78, //!< Flail II fired
-	SND_HVY_LASER_IMPACT           = 79, //!< Prometheus R laser fired
-	SND_MASSDRV_FIRED              = 80, //!< Prometheus S laser fired
-	SND_MASSDRV_IMPACT             = 81, //!< GTW-66 Newton Cannon fired
-	SND_FLAIL_FIRED                = 82, //!< UD-8 Kayser Laser fired
-	SND_FLAIL_IMPACT               = 83, //!< GTW-19 Circe laser fired
-	SND_NEUTRON_FLUX_FIRED         = 84, //!< GTW-83 Lich laser fired
-	SND_NEUTRON_FLUX_IMPACT        = 85, //!< Laser impact
-	SND_DEBUG_LASER_FIRED          = 86, //!< Subach-HLV Vasudan laser
-	SND_ROCKEYE_FIRED              = 87, //!< rockeye missile launch
-	SND_MISSILE_IMPACT1            = 88, //!< missile impact 1
-	SND_MAG_MISSILE_LAUNCH         = 89, //!< mag pulse missile launch
-	SND_FURY_MISSILE_LAUNCH        = 90, //!< fury missile launch
-	SND_SHRIKE_MISSILE_LAUNCH      = 91, //!< shrike missile launch
-	SND_ANGEL_MISSILE_LAUNCH       = 92, //!< angel fire missile launch
-	SND_CLUSTER_MISSILE_LAUNCH     = 93, //!< cluster bomb launch
-	SND_CLUSTERB_MISSILE_LAUNCH    = 94, //!< cluster baby bomb launch
-	SND_STILETTO_MISSILE_LAUNCH    = 95, //!< stiletto bomb launch
-	SND_TSUNAMI_MISSILE_LAUNCH     = 96, //!< tsunami bomb launch
-	SND_HARBINGER_MISSILE_LAUNCH   = 97, //!< harbinger bomb launch
-	SND_MEGAWOKKA_MISSILE_LAUNCH   = 98, //!< mega wokka launch
-	SND_CMEASURE1_LAUNCH           = 99, //!< countermeasure 1 launch
-	SND_SHIVAN_LIGHT_LASER_FIRE    = 100,//!< Shivan light laser
-	SND_SHOCKWAVE_EXPLODE          = 101,//!< shockwave ignition
-	SND_SWARM_MISSILE_LAUNCH       = 102,//!< swarm missile sound
-	SND_UNDEFINED_103              = 103,//!< Shivan heavy laser
-	SND_UNDEFINED_104              = 104,//!< Vasudan SuperCap engine
-	SND_UNDEFINED_105              = 105,//!< Shivan SuperCap engine
-	SND_UNDEFINED_106              = 106,//!< Terran SuperCap engine
-	SND_UNDEFINED_107              = 107,//!< Vasudan light laser fired
-	SND_UNDEFINED_108              = 108,//!< Shivan heavy laser
-	SND_SHOCKWAVE_IMPACT           = 109,//!< shockwave impact
-	SND_UNDEFINED_110              = 110,//!< TERRAN TURRET 1
-	SND_UNDEFINED_111              = 111,//!< TERRAN TURRET 2
-	SND_UNDEFINED_112              = 112,//!< VASUDAN TURRET 1
-	SND_UNDEFINED_113              = 113,//!< VASUDAN TURRET 2
-	SND_UNDEFINED_114              = 114,//!< SHIVAN TURRET 1
-	SND_TARG_LASER_LOOP            = 115,//!< targeting laser loop sound
-	SND_FLAK_FIRE                  = 116,//!< Flak Gun Launch
-	SND_SHIELD_BREAKER             = 117,//!< Flak Gun Impact
-	SND_EMP_MISSILE                = 118,//!< EMP Missle
-	SND_AUTOCANNON_LOOP            = 119,//!< Escape Pod Drone
-	SND_AUTOCANNON_SHOT            = 120,//!< Beam Hit 1
-	SND_BEAM_LOOP                  = 121,//!< beam loop
-	SND_BEAM_UP                    = 122,//!< beam power up
-	SND_BEAM_DOWN                  = 123,//!< beam power down
-	SND_BEAM_SHOT                  = 124,//!< Beam shot 1
-	SND_BEAM_VAPORIZE              = 125,//!< Beam shot 2
+		LIGHT_LASER_FIRE           = 76, //!< SD-4 Sidearm laser fired
+	LIGHT_LASER_IMPACT         = 77, //!< DR-2 Scalpel fired
+	HVY_LASER_FIRE             = 78, //!< Flail II fired
+	HVY_LASER_IMPACT           = 79, //!< Prometheus R laser fired
+	MASSDRV_FIRED              = 80, //!< Prometheus S laser fired
+	MASSDRV_IMPACT             = 81, //!< GTW-66 Newton Cannon fired
+	FLAIL_FIRED                = 82, //!< UD-8 Kayser Laser fired
+	FLAIL_IMPACT               = 83, //!< GTW-19 Circe laser fired
+	NEUTRON_FLUX_FIRED         = 84, //!< GTW-83 Lich laser fired
+	NEUTRON_FLUX_IMPACT        = 85, //!< Laser impact
+	DEBUG_LASER_FIRED          = 86, //!< Subach-HLV Vasudan laser
+	ROCKEYE_FIRED              = 87, //!< rockeye missile launch
+	MISSILE_IMPACT1            = 88, //!< missile impact 1
+	MAG_MISSILE_LAUNCH         = 89, //!< mag pulse missile launch
+	FURY_MISSILE_LAUNCH        = 90, //!< fury missile launch
+	SHRIKE_MISSILE_LAUNCH      = 91, //!< shrike missile launch
+	ANGEL_MISSILE_LAUNCH       = 92, //!< angel fire missile launch
+	CLUSTER_MISSILE_LAUNCH     = 93, //!< cluster bomb launch
+	CLUSTERB_MISSILE_LAUNCH    = 94, //!< cluster baby bomb launch
+	STILETTO_MISSILE_LAUNCH    = 95, //!< stiletto bomb launch
+	TSUNAMI_MISSILE_LAUNCH     = 96, //!< tsunami bomb launch
+	HARBINGER_MISSILE_LAUNCH   = 97, //!< harbinger bomb launch
+	MEGAWOKKA_MISSILE_LAUNCH   = 98, //!< mega wokka launch
+	CMEASURE1_LAUNCH           = 99, //!< countermeasure 1 launch
+	SHIVAN_LIGHT_LASER_FIRE    = 100,//!< Shivan light laser
+	SHOCKWAVE_EXPLODE          = 101,//!< shockwave ignition
+	SWARM_MISSILE_LAUNCH       = 102,//!< swarm missile sound
+	UNDEFINED_103              = 103,//!< Shivan heavy laser
+	UNDEFINED_104              = 104,//!< Vasudan SuperCap engine
+	UNDEFINED_105              = 105,//!< Shivan SuperCap engine
+	UNDEFINED_106              = 106,//!< Terran SuperCap engine
+	UNDEFINED_107              = 107,//!< Vasudan light laser fired
+	UNDEFINED_108              = 108,//!< Shivan heavy laser
+	SHOCKWAVE_IMPACT           = 109,//!< shockwave impact
+	UNDEFINED_110              = 110,//!< TERRAN TURRET 1
+	UNDEFINED_111              = 111,//!< TERRAN TURRET 2
+	UNDEFINED_112              = 112,//!< VASUDAN TURRET 1
+	UNDEFINED_113              = 113,//!< VASUDAN TURRET 2
+	UNDEFINED_114              = 114,//!< SHIVAN TURRET 1
+	TARG_LASER_LOOP            = 115,//!< targeting laser loop sound
+	FLAK_FIRE                  = 116,//!< Flak Gun Launch
+	SHIELD_BREAKER             = 117,//!< Flak Gun Impact
+	EMP_MISSILE                = 118,//!< EMP Missle
+	AUTOCANNON_LOOP            = 119,//!< Escape Pod Drone
+	AUTOCANNON_SHOT            = 120,//!< Beam Hit 1
+	BEAM_LOOP                  = 121,//!< beam loop
+	BEAM_UP                    = 122,//!< beam power up
+	BEAM_DOWN                  = 123,//!< beam power down
+	BEAM_SHOT                  = 124,//!< Beam shot 1
+	BEAM_VAPORIZE              = 125,//!< Beam shot 2
 	//Ship Engine Sounds section
-	SND_TERRAN_FIGHTER_ENG         = 126,//!< Terran fighter engine
-	SND_TERRAN_BOMBER_ENG          = 127,//!< Terran bomber engine
-	SND_TERRAN_CAPITAL_ENG         = 128,//!< Terran cruiser engine
-	SND_SPECIESB_FIGHTER_ENG       = 129,//!< Vasudan fighter engine
-	SND_SPECIESB_BOMBER_ENG        = 130,//!< Vasudan bomber engine
-	SND_SPECIESB_CAPITAL_ENG       = 131,//!< Vasudan cruiser engine
-	SND_SHIVAN_FIGHTER_ENG         = 132,//!< Shivan fighter engine
-	SND_SHIVAN_BOMBER_ENG          = 133,//!< Shivan bomber engine
-	SND_SHIVAN_CAPITAL_ENG         = 134,//!< Shivan cruiser engine
-	SND_REPAIR_SHIP_ENG            = 135,//!< Repair ship beacon/engine sound
-	SND_UNDEFINED_136              = 136,//!< Terran capital engine
-	SND_UNDEFINED_137              = 137,//!< Vasudan capital engine
-	SND_UNDEFINED_138              = 138,//!< Shivan capital engine
+		TERRAN_FIGHTER_ENG         = 126,//!< Terran fighter engine
+	TERRAN_BOMBER_ENG          = 127,//!< Terran bomber engine
+	TERRAN_CAPITAL_ENG         = 128,//!< Terran cruiser engine
+	SPECIESB_FIGHTER_ENG       = 129,//!< Vasudan fighter engine
+	SPECIESB_BOMBER_ENG        = 130,//!< Vasudan bomber engine
+	SPECIESB_CAPITAL_ENG       = 131,//!< Vasudan cruiser engine
+	SHIVAN_FIGHTER_ENG         = 132,//!< Shivan fighter engine
+	SHIVAN_BOMBER_ENG          = 133,//!< Shivan bomber engine
+	SHIVAN_CAPITAL_ENG         = 134,//!< Shivan cruiser engine
+	REPAIR_SHIP_ENG            = 135,//!< Repair ship beacon/engine sound
+	UNDEFINED_136              = 136,//!< Terran capital engine
+	UNDEFINED_137              = 137,//!< Vasudan capital engine
+	UNDEFINED_138              = 138,//!< Shivan capital engine
 	// Electrical arc sound fx on the debris pieces
-	SND_DEBRIS_ARC_01              = 139,//!< 0.10 second spark sound effect
-	SND_DEBRIS_ARC_02              = 140,//!< 0.25 second spark sound effect
-	SND_DEBRIS_ARC_03              = 141,//!< 0.50 second spark sound effect
-	SND_DEBRIS_ARC_04              = 142,//!< 0.75 second spark sound effect
-	SND_DEBRIS_ARC_05              = 143,//!< 1.00 second spark sound effect
+		DEBRIS_ARC_01              = 139,//!< 0.10 second spark sound effect
+	DEBRIS_ARC_02              = 140,//!< 0.25 second spark sound effect
+	DEBRIS_ARC_03              = 141,//!< 0.50 second spark sound effect
+	DEBRIS_ARC_04              = 142,//!< 0.75 second spark sound effect
+	DEBRIS_ARC_05              = 143,//!< 1.00 second spark sound effect
 	// Beam Sounds
-	SND_UNDEFINED_144              = 144,//!< LTerSlash beam loop
-	SND_UNDEFINED_145              = 145,//!< TerSlash	beam loop
-	SND_UNDEFINED_146              = 146,//!< SGreen 	beam loop
-	SND_UNDEFINED_147              = 147,//!< BGreen	beem loop
-	SND_UNDEFINED_148              = 148,//!< BFGreen	been loop
-	SND_UNDEFINED_149              = 149,//!< Antifighter 	beam loop
-	SND_UNDEFINED_150              = 150,//!< 1 sec		warm up
-	SND_UNDEFINED_151              = 151,//!< 1.5 sec 	warm up
-	SND_UNDEFINED_152              = 152,//!< 2.5 sec 	warm up
-	SND_UNDEFINED_153              = 153,//!< 3 sec 	warm up
-	SND_UNDEFINED_154              = 154,//!< 3.5 sec 	warm up
-	SND_UNDEFINED_155              = 155,//!< 5 sec 	warm up
-	SND_UNDEFINED_156              = 156,//!< LTerSlash	warm down
-	SND_UNDEFINED_157              = 157,//!< TerSlash	warm down
-	SND_UNDEFINED_158              = 158,//!< SGreen	warm down
-	SND_UNDEFINED_159              = 159,//!< BGreen	warm down
-	SND_UNDEFINED_160              = 160,//!< BFGreen	warm down
-	SND_UNDEFINED_161              = 161,//!< T_AntiFtr	warm down
+		UNDEFINED_144              = 144,//!< LTerSlash beam loop
+	UNDEFINED_145              = 145,//!< TerSlash	beam loop
+	UNDEFINED_146              = 146,//!< SGreen 	beam loop
+	UNDEFINED_147              = 147,//!< BGreen	beem loop
+	UNDEFINED_148              = 148,//!< BFGreen	been loop
+	UNDEFINED_149              = 149,//!< Antifighter 	beam loop
+	UNDEFINED_150              = 150,//!< 1 sec		warm up
+	UNDEFINED_151              = 151,//!< 1.5 sec 	warm up
+	UNDEFINED_152              = 152,//!< 2.5 sec 	warm up
+	UNDEFINED_153              = 153,//!< 3 sec 	warm up
+	UNDEFINED_154              = 154,//!< 3.5 sec 	warm up
+	UNDEFINED_155              = 155,//!< 5 sec 	warm up
+	UNDEFINED_156              = 156,//!< LTerSlash	warm down
+	UNDEFINED_157              = 157,//!< TerSlash	warm down
+	UNDEFINED_158              = 158,//!< SGreen	warm down
+	UNDEFINED_159              = 159,//!< BGreen	warm down
+	UNDEFINED_160              = 160,//!< BFGreen	warm down
+	UNDEFINED_161              = 161,//!< T_AntiFtr	warm down
 
-	SND_COPILOT                    = 162,//!< copilot (SCP)
-	SND_UNDEFINED_163              = 163,//!< (Empty in Retail)
-	SND_UNDEFINED_164              = 164,//!< (Empty in Retail)
-	SND_UNDEFINED_165              = 165,//!< (Empty in Retail)
-	SND_UNDEFINED_166              = 166,//!< (Empty in Retail)
-	SND_UNDEFINED_167              = 167,//!< (Empty in Retail)
-	SND_UNDEFINED_168              = 168,//!< (Empty in Retail)
-	SND_UNDEFINED_169              = 169,//!< (Empty in Retail)
-	SND_UNDEFINED_170              = 170,//!< (Empty in Retail)
-	SND_UNDEFINED_171              = 171,//!< (Empty in Retail)
-	SND_UNDEFINED_172              = 172,//!< (Empty in Retail)
-	SND_SUPERNOVA_1                = 173,//!< SuperNova (distant)
-	SND_SUPERNOVA_2                = 174,//!< SuperNova (shockwave)
-	SND_UNDEFINED_175              = 175,//!< Shivan large engine
-	SND_UNDEFINED_176              = 176,//!< Shivan large engine
-	SND_UNDEFINED_177              = 177,//!< SRed 		beam loop
-	SND_UNDEFINED_178              = 178,//!< LRed		beam loop
-	SND_UNDEFINED_179              = 179,//!< Antifighter	beam loop
-	SND_LIGHTNING_1                = 180,//!< Thunder 1 sound in neblua
-	SND_LIGHTNING_2                = 181,//!< Thunder 2 sound in neblua
-	SND_UNDEFINED_182              = 182,//!< 1 sec 	warm up
-	SND_UNDEFINED_183              = 183,//!< 1.5 sec 	warm up
-	SND_UNDEFINED_184              = 184,//!< 3 sec 	warm up
-	SND_UNDEFINED_185              = 185,//!< Shivan Commnode
-	SND_UNDEFINED_186              = 186,//!< Volition PirateShip
-	SND_UNDEFINED_187              = 187,//!< SRed 		warm down
-	SND_UNDEFINED_188              = 188,//!< LRed 		warm down
-	SND_UNDEFINED_189              = 189,//!< AntiFtr	warm down
-	SND_UNDEFINED_190              = 190,//!< Instellation 1
-	SND_UNDEFINED_191              = 191,//!< Instellation 2
-	SND_UNDEFINED_192              = 192,//!< (Undefined in Retail)
-	SND_UNDEFINED_193              = 193,//!< (Undefined in Retail)
-	SND_UNDEFINED_194              = 194,//!< (Undefined in Retail)
-	SND_UNDEFINED_195              = 195,//!< (Undefined in Retail)
-	SND_UNDEFINED_196              = 196,//!< (Undefined in Retail)
-	SND_UNDEFINED_197              = 197,//!< (Undefined in Retail)
-	SND_UNDEFINED_198              = 198,//!< (Undefined in Retail)
-	SND_UNDEFINED_199              = 199,//!< (Undefined in Retail)
+	COPILOT                    = 162,//!< copilot (SCP)
+	UNDEFINED_163              = 163,//!< (Empty in Retail)
+	UNDEFINED_164              = 164,//!< (Empty in Retail)
+	UNDEFINED_165              = 165,//!< (Empty in Retail)
+	UNDEFINED_166              = 166,//!< (Empty in Retail)
+	UNDEFINED_167              = 167,//!< (Empty in Retail)
+	UNDEFINED_168              = 168,//!< (Empty in Retail)
+	UNDEFINED_169              = 169,//!< (Empty in Retail)
+	UNDEFINED_170              = 170,//!< (Empty in Retail)
+	UNDEFINED_171              = 171,//!< (Empty in Retail)
+	UNDEFINED_172              = 172,//!< (Empty in Retail)
+	SUPERNOVA_1                = 173,//!< SuperNova (distant)
+	SUPERNOVA_2                = 174,//!< SuperNova (shockwave)
+	UNDEFINED_175              = 175,//!< Shivan large engine
+	UNDEFINED_176              = 176,//!< Shivan large engine
+	UNDEFINED_177              = 177,//!< SRed 		beam loop
+	UNDEFINED_178              = 178,//!< LRed		beam loop
+	UNDEFINED_179              = 179,//!< Antifighter	beam loop
+	LIGHTNING_1                = 180,//!< Thunder 1 sound in neblua
+	LIGHTNING_2                = 181,//!< Thunder 2 sound in neblua
+	UNDEFINED_182              = 182,//!< 1 sec 	warm up
+	UNDEFINED_183              = 183,//!< 1.5 sec 	warm up
+	UNDEFINED_184              = 184,//!< 3 sec 	warm up
+	UNDEFINED_185              = 185,//!< Shivan Commnode
+	UNDEFINED_186              = 186,//!< Volition PirateShip
+	UNDEFINED_187              = 187,//!< SRed 		warm down
+	UNDEFINED_188              = 188,//!< LRed 		warm down
+	UNDEFINED_189              = 189,//!< AntiFtr	warm down
+	UNDEFINED_190              = 190,//!< Instellation 1
+	UNDEFINED_191              = 191,//!< Instellation 2
+	UNDEFINED_192              = 192,//!< (Undefined in Retail)
+	UNDEFINED_193              = 193,//!< (Undefined in Retail)
+	UNDEFINED_194              = 194,//!< (Undefined in Retail)
+	UNDEFINED_195              = 195,//!< (Undefined in Retail)
+	UNDEFINED_196              = 196,//!< (Undefined in Retail)
+	UNDEFINED_197              = 197,//!< (Undefined in Retail)
+	UNDEFINED_198              = 198,//!< (Undefined in Retail)
+	UNDEFINED_199              = 199,//!< (Undefined in Retail)
 
-	SND_BALLISTIC_START_LOAD       = 200,//!< (SCP)
-	SND_BALLISTIC_LOAD             = 201,//!< (SCP)
+	BALLISTIC_START_LOAD       = 200,//!< (SCP)
+	BALLISTIC_LOAD             = 201,//!< (SCP)
 
 	/**
 	 * Keep this below all defined enum values
 	 */
-	MIN_GAME_SOUNDS = 202
+		MIN_GAME_SOUNDS = 202
 };
 
 /**
  * Interface sounds
  */
-enum InterfaceSoundsIndex {
-	SND_IFACE_MOUSE_CLICK       =0, //!< mouse click
-	SND_ICON_PICKUP             =1, //!< pick up a ship icon (Empty in Retail)
-	SND_ICON_DROP_ON_WING       =2, //!< drop a ship icon on a wing slot
-	SND_ICON_DROP               =3, //!< drop a ship icon back to the list
-	SND_SCREEN_MODE_PRESSED     =4, //!< press briefing, ship selection or weapons bar (top-left)
-	SND_SWITCH_SCREENS          =5, //!< Switching to a new screen, but not commit
-	SND_HELP_PRESSED            =6, //!< help pressed
-	SND_COMMIT_PRESSED          =7, //!< commit pressed
-	SND_PREV_NEXT_PRESSED       =8, //!< prev/next pressed
-	SND_SCROLL                  =9, //!< scroll pressed (and scroll)
-	SND_GENERAL_FAIL            =10,//!< general failure sound for any event
-	SND_SHIP_ICON_CHANGE        =11,//!< ship animation starts (ie text and ship first appear)
-	SND_MAIN_HALL_AMBIENT       =12,//!< ambient sound for the Terran main hall (looping)
-	SND_BTN_SLIDE               =13,//!< ambient sound for the Vasudan main hall (looping)
-	SND_BRIEF_STAGE_CHG         =14,//!< brief stage change
-	SND_BRIEF_STAGE_CHG_FAIL    =15,//!< brief stage change fail
-	SND_BRIEF_ICON_SELECT       =16,//!< selet brief icon
-	SND_USER_OVER               =17,//!< user_over (mouse over a control)
-	SND_USER_SELECT             =18,//!< user_click (mouse selects a control)
-	SND_RESET_PRESSED           =19,//!< reset (or similar button) pressed
-	SND_BRIEF_TEXT_WIPE         =20,//!< briefing text wipe
-	SND_VASUDAN_PA_1            =21,//!< main hall - elevator
-	SND_WEAPON_ANIM_START       =22,//!< weapon animation starts
-	SND_MAIN_HALL_DOOR_OPEN     =23,//!< door in main hall opens
-	SND_MAIN_HALL_DOOR_CLOSE    =24,//!< door in main hall closes
-	SND_GLOW_OPEN               =25,//!< glow in main hall opens
-	SND_VASUDAN_PA_2            =26,//!< main hall - crane 1
-	SND_AMBIENT_MENU            =27,//!< ambient sound for menus off the main hall (looping)
-	SND_POPUP_APPEAR            =28,//!< popup dialog box appeared
-	SND_POPUP_DISAPPEAR         =29,//!< popup dialog box goes away
-	SND_VOICE_SLIDER_CLIP       =30,//!< voice clip played when volume slider changes
-	SND_VASUDAN_PA_3            =31,//!< main hall - crane 2
-	SND_MAIN_HALL_GET_PEPSI     =32,//!< main hall options - mouse on
-	SND_MAIN_HALL_LIFT_UP       =33,//!< main hall options - mouse off
-	SND_MAIN_HALL_WELD1         =34,//!< main hall tech room - mouse on
-	SND_MAIN_HALL_WELD2         =35,//!< main hall tech room - mouse off
-	SND_MAIN_HALL_WELD3         =36,//!< main hall exit open
-	SND_MAIN_HALL_WELD4         =37,//!< main hall exit close
-	SND_MAIN_HALL_INT1          =38,//!< main hall random intercom 1
-	SND_MAIN_HALL_INT2          =39,//!< main hall random intercom 2
-	SND_MAIN_HALL_INT3          =40,//!< main hall random intercom 3
-	SND_ICON_HIGHLIGHT          =41,//!< spinning highlight in briefing
-	SND_BRIEFING_STATIC         =42,//!< static in a briefing stage cut
-	SND_MAIN_HALL2_CRANE1_1     =43,//!< main hall campaign - mouse on
-	SND_MAIN_HALL2_CRANE1_2     =44,//!< main hall campaign - mouse off
-	SND_MAIN_HALL2_CRANE2_1     =45,//!< vasudan hall - hatch open
-	SND_MAIN_HALL2_CRANE2_2     =46,//!< vasudan hall - hatch close
-	SND_MAIN_HALL2_CAR1         =47,//!< vasudan hall - roll open
-	SND_MAIN_HALL2_CAR2         =48,//!< vasudan hall - roll close
-	SND_MAIN_HALL2_INT1         =49,//!< vasudan hall - lift up
-	SND_MAIN_HALL2_INT2         =50,//!< vasudan hall - lift down
-	SND_MAIN_HALL2_INT3         =51,//!< vasudan hall - glow on
-	SND_INTERFACE_UNDEFINED_52  =52,//!< vasudan hall - glow off
-	SND_INTERFACE_UNDEFINED_53  =53,//!< vasudan hall - skiff loop
-	SND_INTERFACE_UNDEFINED_54  =54,//!< vasudan hall - screen on
-	SND_INTERFACE_UNDEFINED_55  =55,//!< vasudan hall - screen off
-	SND_INTERFACE_UNDEFINED_56  =56,//!< vasudan hall - vasudan greeting
-	SND_INTERFACE_UNDEFINED_57  =57,//!< vasudan hall - vasudan bye
-	SND_INTERFACE_UNDEFINED_58  =58,//!< vasudan hall - vasudan pa 1
-	SND_INTERFACE_UNDEFINED_59  =59,//!< vasudan hall - vasudan pa 2
-	SND_INTERFACE_UNDEFINED_60  =60,//!< vasudan hall - vasudan pa 3
-	SND_VASUDAN_BUP             =61,//!< bup bup bup-bup bup bup
-	SND_INTERFACE_UNDEFINED_62  =62,//!< thankyou
-	SND_INTERFACE_UNDEFINED_63  =62,//!< vasudan hall - exit open
-	SND_INTERFACE_UNDEFINED_64  =62,//!< vasudan hall - exit close
+enum InterfaceSounds {
+	IFACE_MOUSE_CLICK       =0, //!< mouse click
+	ICON_PICKUP             =1, //!< pick up a ship icon (Empty in Retail)
+	ICON_DROP_ON_WING       =2, //!< drop a ship icon on a wing slot
+	ICON_DROP               =3, //!< drop a ship icon back to the list
+	SCREEN_MODE_PRESSED     =4, //!< press briefing, ship selection or weapons bar (top-left)
+	SWITCH_SCREENS          =5, //!< Switching to a new screen, but not commit
+	HELP_PRESSED            =6, //!< help pressed
+	COMMIT_PRESSED          =7, //!< commit pressed
+	PREV_NEXT_PRESSED       =8, //!< prev/next pressed
+	SCROLL                  =9, //!< scroll pressed (and scroll)
+	GENERAL_FAIL            =10,//!< general failure sound for any event
+	SHIP_ICON_CHANGE        =11,//!< ship animation starts (ie text and ship first appear)
+	MAIN_HALL_AMBIENT       =12,//!< ambient sound for the Terran main hall (looping)
+	BTN_SLIDE               =13,//!< ambient sound for the Vasudan main hall (looping)
+	BRIEF_STAGE_CHG         =14,//!< brief stage change
+	BRIEF_STAGE_CHG_FAIL    =15,//!< brief stage change fail
+	BRIEF_ICON_SELECT       =16,//!< selet brief icon
+	USER_OVER               =17,//!< user_over (mouse over a control)
+	USER_SELECT             =18,//!< user_click (mouse selects a control)
+	RESET_PRESSED           =19,//!< reset (or similar button) pressed
+	BRIEF_TEXT_WIPE         =20,//!< briefing text wipe
+	VASUDAN_PA_1            =21,//!< main hall - elevator
+	WEAPON_ANIM_START       =22,//!< weapon animation starts
+	MAIN_HALL_DOOR_OPEN     =23,//!< door in main hall opens
+	MAIN_HALL_DOOR_CLOSE    =24,//!< door in main hall closes
+	GLOW_OPEN               =25,//!< glow in main hall opens
+	VASUDAN_PA_2            =26,//!< main hall - crane 1
+	AMBIENT_MENU            =27,//!< ambient sound for menus off the main hall (looping)
+	POPUP_APPEAR            =28,//!< popup dialog box appeared
+	POPUP_DISAPPEAR         =29,//!< popup dialog box goes away
+	VOICE_SLIDER_CLIP       =30,//!< voice clip played when volume slider changes
+	VASUDAN_PA_3            =31,//!< main hall - crane 2
+	MAIN_HALL_GET_PEPSI     =32,//!< main hall options - mouse on
+	MAIN_HALL_LIFT_UP       =33,//!< main hall options - mouse off
+	MAIN_HALL_WELD1         =34,//!< main hall tech room - mouse on
+	MAIN_HALL_WELD2         =35,//!< main hall tech room - mouse off
+	MAIN_HALL_WELD3         =36,//!< main hall exit open
+	MAIN_HALL_WELD4         =37,//!< main hall exit close
+	MAIN_HALL_INT1          =38,//!< main hall random intercom 1
+	MAIN_HALL_INT2          =39,//!< main hall random intercom 2
+	MAIN_HALL_INT3          =40,//!< main hall random intercom 3
+	ICON_HIGHLIGHT          =41,//!< spinning highlight in briefing
+	BRIEFING_STATIC         =42,//!< static in a briefing stage cut
+	MAIN_HALL2_CRANE1_1     =43,//!< main hall campaign - mouse on
+	MAIN_HALL2_CRANE1_2     =44,//!< main hall campaign - mouse off
+	MAIN_HALL2_CRANE2_1     =45,//!< vasudan hall - hatch open
+	MAIN_HALL2_CRANE2_2     =46,//!< vasudan hall - hatch close
+	MAIN_HALL2_CAR1         =47,//!< vasudan hall - roll open
+	MAIN_HALL2_CAR2         =48,//!< vasudan hall - roll close
+	MAIN_HALL2_INT1         =49,//!< vasudan hall - lift up
+	MAIN_HALL2_INT2         =50,//!< vasudan hall - lift down
+	MAIN_HALL2_INT3         =51,//!< vasudan hall - glow on
+	INTERFACE_UNDEFINED_52  =52,//!< vasudan hall - glow off
+	INTERFACE_UNDEFINED_53  =53,//!< vasudan hall - skiff loop
+	INTERFACE_UNDEFINED_54  =54,//!< vasudan hall - screen on
+	INTERFACE_UNDEFINED_55  =55,//!< vasudan hall - screen off
+	INTERFACE_UNDEFINED_56  =56,//!< vasudan hall - vasudan greeting
+	INTERFACE_UNDEFINED_57  =57,//!< vasudan hall - vasudan bye
+	INTERFACE_UNDEFINED_58  =58,//!< vasudan hall - vasudan pa 1
+	INTERFACE_UNDEFINED_59  =59,//!< vasudan hall - vasudan pa 2
+	INTERFACE_UNDEFINED_60  =60,//!< vasudan hall - vasudan pa 3
+	VASUDAN_BUP             =61,//!< bup bup bup-bup bup bup
+	INTERFACE_UNDEFINED_62  =62,//!< thankyou
+	INTERFACE_UNDEFINED_63  =62,//!< vasudan hall - exit open
+	INTERFACE_UNDEFINED_64  =62,//!< vasudan hall - exit close
 
 	/**
 	* Keep this below all defined enum values
 	*/
-	MIN_INTERFACE_SOUNDS        =70 //!< MIN_INTERFACE_SOUNDS
+		MIN_INTERFACE_SOUNDS        =70 //!< MIN_INTERFACE_SOUNDS
 };
+
+// These two id types are defined as sublcasses so that type safe implicit conversions are possible from the predefined
+// sound enum values
+
+struct gamesnd_id_tag{};
+/**
+ * @brief A game sound handle type
+ *
+ * This allows implicit conversions from the GameSounds enum class.
+ */
+class gamesnd_id : public util::ID<gamesnd_id_tag, int, -1> {
+ public:
+	/*implicit*/ gamesnd_id(GameSounds snd) : util::ID<gamesnd_id_tag, int, -1>(static_cast<int>(snd)) {}
+	explicit gamesnd_id(int val) : ID(val) {
+	}
+	gamesnd_id() {
+	}
+};
+
+struct interface_snd_tag{};
+/**
+ * @brief A interface sound handle type
+ *
+ * This allows implicit conversions from the InterfaceSounds enum class.
+ */
+class interface_snd_id : public util::ID<interface_snd_tag, int, -1> {
+ public:
+	/*implicit*/ interface_snd_id(InterfaceSounds snd) : util::ID<interface_snd_tag, int, -1>(static_cast<int>(snd)) {}
+	interface_snd_id() {
+	}
+	explicit interface_snd_id(int val) : ID(val) {
+	}
+};
+
+void gamesnd_parse_soundstbl();	// Loads in general game sounds from sounds.tbl
+void gamesnd_close();	// close out gamesnd... only call from game_shutdown()!
+void gamesnd_load_gameplay_sounds();
+void gamesnd_unload_gameplay_sounds();
+void gamesnd_load_interface_sounds();
+void gamesnd_unload_interface_sounds();
+void gamesnd_preload_common_sounds();
+void gamesnd_load_gameplay_sounds();
+void gamesnd_unload_gameplay_sounds();
+void gamesnd_play_iface(interface_snd_id n);
+void gamesnd_play_error_beep();
+gamesnd_id gamesnd_get_by_name(const char* name);
+interface_snd_id gamesnd_get_by_iface_name(const char* name);
+gamesnd_id gamesnd_get_by_tbl_index(int index);
+interface_snd_id gamesnd_get_by_iface_tbl_index(int index);
+
+//This should handle NO_SOUND just fine since it doesn't directly access lowlevel code
+//Does all parsing for a sound
+void parse_game_sound(const char* tag, gamesnd_id* idx_dest, const char* object_name);
+
+void parse_iface_sound(const char* tag, interface_snd_id* idx_dest, const char* object_name);
+void parse_iface_sound_list(const char* tag, SCP_vector<interface_snd_id>& destination, const char* object_name, bool scp_list = false);
+
+// this is a callback, so it needs to be a real function
+void common_play_highlight_sound();
 
 /**
  * @brief Gets a pointer to the game sound with the specified handle
  * @param handle The sound handle
  * @return The game sound handle
  */
-game_snd* gamesnd_get_game_sound(int handle);
+game_snd* gamesnd_get_game_sound(gamesnd_id handle);
 
 /**
  * @brief Gets a pointer to the interface sound with the specified handle
  * @param handle The sound handle
  * @return The interface sound handle
  */
-game_snd* gamesnd_get_interface_sound(int handle);
+game_snd* gamesnd_get_interface_sound(interface_snd_id handle);
 
 /**
  * @brief Checks if the given sound handle is a valid game sound handle
  * @param sound The handle to check
  * @return @c true if the handle is valid
  */
-bool gamesnd_game_sound_valid(int sound);
+bool gamesnd_game_sound_valid(gamesnd_id sound);
 
 /**
  * @brief Checks if the given sound handle is a valid interface sound handle
  * @param sound The handle to check
  * @return @c true if the handle is valid
  */
-bool gamesnd_interface_sound_valid(int sound);
+bool gamesnd_interface_sound_valid(interface_snd_id sound);
 
 /**
  * @brief Determines the maximum time this game sound may take to be played.

--- a/code/globalincs/pstypes.h
+++ b/code/globalincs/pstypes.h
@@ -462,9 +462,8 @@ inline bool VALID_FNAME(const SCP_string& x) {
 SCP_string dump_stacktrace();
 
 // DEBUG compile time catch for dangerous uses of memset/memcpy/memmove
-// would prefer std::is_trivially_copyable but it's not supported by gcc yet
-// ref: http://gcc.gnu.org/onlinedocs/libstdc++/manual/status.html
-#if !defined(NDEBUG) && !defined(USING_THIRD_PARTY_LIBS)
+// This is disabled for VS2013 and lower since that doesn't support the necessary features
+#if !defined(NDEBUG) && !defined(USING_THIRD_PARTY_LIBS) && (!defined(_MSC_VER) || _MSC_VER >= 1900)
 	#if SCP_COMPILER_CXX_AUTO_TYPE && SCP_COMPILER_CXX_STATIC_ASSERT && defined(HAVE_STD_IS_TRIVIALLY_COPYABLE)
 	// feature support seems to be: gcc   clang   msvc
 	// auto                         4.4   2.9     2010
@@ -480,15 +479,8 @@ SCP_string dump_stacktrace();
 // Put into std to be compatible with code that uses std::mem*
 namespace std
 {
-
-// This is a separate check which also checks if arrays are trivially copyable since Visual Studio 2013 thinks they are not
-#if SCP_COMPILER_IS_MSVC && _MSC_VER <= 1800
-template<typename T>
-using trivial_check = std::is_trivial<T>;
-#else
-template<typename T>
-using trivial_check = std::is_trivially_copyable<T>;
-#endif
+	template<typename T>
+	using trivial_check = std::is_trivially_copyable<T>;
 
 	template<typename T>
 	void *memset_if_trivial_else_error(T *memset_data, int ch, size_t count)

--- a/code/hud/hud.cpp
+++ b/code/hud/hud.cpp
@@ -1861,7 +1861,7 @@ void update_throttle_sound()
 			}
 			else {
 				if ( Player_engine_snd_loop == -1 ){
-					Player_engine_snd_loop = snd_play_looping( gamesnd_get_game_sound(ship_get_sound(Player_obj, SND_ENGINE)), 0.0f , -1, -1, percent_throttle * ENGINE_MAX_VOL, FALSE);
+					Player_engine_snd_loop = snd_play_looping( gamesnd_get_game_sound(ship_get_sound(Player_obj, GameSounds::ENGINE)), 0.0f , -1, -1, percent_throttle * ENGINE_MAX_VOL, FALSE);
 				} else {
 					// The sound may have been trashed at the low-level if sound channel overflow.
 					// TODO: implement system where certain sounds cannot be interrupted (priority?)
@@ -3561,7 +3561,7 @@ void hud_stop_objective_notify()
 
 void hud_start_objective_notify()
 {
-	snd_play(gamesnd_get_game_sound(SND_DIRECTIVE_COMPLETE));
+	snd_play(gamesnd_get_game_sound(GameSounds::DIRECTIVE_COMPLETE));
 	Objective_notify_active = 1;
 }
 

--- a/code/hud/hudartillery.cpp
+++ b/code/hud/hudartillery.cpp
@@ -169,8 +169,8 @@ void parse_ssm(const char *filename)
 				s.use_custom_message = true;
 			}
 
-			s.sound_index = -1;
-			parse_sound("+Alarm Sound:", &s.sound_index, s.name);
+			s.sound_index = gamesnd_id();
+			parse_game_sound("+Alarm Sound:", &s.sound_index, s.name);
 
 			// see if we have a valid weapon
 			s.weapon_info_index = weapon_info_lookup(weapon_name);
@@ -332,7 +332,7 @@ void ssm_create(object *target, vec3d *start, size_t ssm_index, ssm_firing_info 
 		else
 			HUD_printf("%s", Ssm_info[ssm_index].message);
 	}
-	if (Ssm_info[ssm_index].sound_index >= 0) {
+	if (Ssm_info[ssm_index].sound_index.isValid()) {
 		snd_play(gamesnd_get_game_sound(Ssm_info[ssm_index].sound_index));
 	}
 

--- a/code/hud/hudartillery.h
+++ b/code/hud/hudartillery.h
@@ -39,7 +39,7 @@ typedef struct ssm_info {
 	char		message[NAME_LENGTH];
 	bool		use_custom_message;
 	bool		send_message;
-	int			sound_index;
+	gamesnd_id	sound_index;
 	int			shape;
 } ssm_info;
 

--- a/code/hud/hudconfig.cpp
+++ b/code/hud/hudconfig.cpp
@@ -954,7 +954,7 @@ void hud_config_check_regions()
 		}
 
 		if ( b->pressed() ) {
-			gamesnd_play_iface(SND_USER_SELECT);
+			gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 			HC_gauge_selected = i;
 
 			// turn off select all
@@ -1053,7 +1053,7 @@ void hud_config_cancel()
 // leave hud config with accepting changes
 void hud_config_commit()
 {
-	gamesnd_play_iface(SND_COMMIT_PRESSED);
+	gamesnd_play_iface(InterfaceSounds::COMMIT_PRESSED);
 	gameseq_post_event(GS_EVENT_PREVIOUS_STATE);
 }
 
@@ -1095,7 +1095,7 @@ void hud_config_handle_keypresses(int k)
 		hud_config_commit();
 		break;
 	case KEY_TAB:
-		gamesnd_play_iface(SND_USER_SELECT);
+		gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 		hud_cycle_gauge_status();
 		break;
 	}
@@ -1110,39 +1110,39 @@ void hud_config_button_do(int n)
 	switch (n) {
 	case HCB_AMBER:
 		hud_config_set_color(HUD_COLOR_AMBER);
-		gamesnd_play_iface(SND_USER_SELECT);
+		gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 		break;
 	case HCB_BLUE:
 		hud_config_set_color(HUD_COLOR_BLUE);
-		gamesnd_play_iface(SND_USER_SELECT);
+		gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 		break;
 	case HCB_GREEN:
 		hud_config_set_color(HUD_COLOR_GREEN);
-		gamesnd_play_iface(SND_USER_SELECT);
+		gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 		break;
 	case HCB_ON:
 		if ( HC_gauge_selected < 0 ) {
 			break;
 		}
-		gamesnd_play_iface(SND_USER_SELECT);
+		gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 		hud_config_set_gauge_flags(HC_gauge_selected,1,0);
 		break;
 	case HCB_OFF:
 		if ( HC_gauge_selected < 0 ) {
 			break;
 		}
-		gamesnd_play_iface(SND_USER_SELECT);
+		gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 		hud_config_set_gauge_flags(HC_gauge_selected,0,0);
 		break;
 	case HCB_POPUP:
 		if ( HC_gauge_selected < 0 ) {
 			break;
 		}
-		gamesnd_play_iface(SND_USER_SELECT);
+		gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 		hud_config_set_gauge_flags(HC_gauge_selected,1,1);
 		break;
 	case HCB_RESET:
-		gamesnd_play_iface(SND_RESET_PRESSED);
+		gamesnd_play_iface(InterfaceSounds::RESET_PRESSED);
 		hud_config_select_all_toggle(0);
 		hud_set_default_hud_config(Player);
 		hud_config_synch_ui();
@@ -1154,9 +1154,9 @@ void hud_config_button_do(int n)
 	// new stuff
 	case HCB_RED_UP:
 		if( HCS_CONV(HC_color_sliders[HCS_RED].get_currentItem()) >= 255){
-			gamesnd_play_iface(SND_GENERAL_FAIL);
+			gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 		} else {
-			gamesnd_play_iface(SND_USER_SELECT);
+			gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 			HC_color_sliders[HCS_RED].force_currentItem( HCS_CONV( HCS_CONV(HC_color_sliders[HCS_RED].get_currentItem()) + 1)  );
 			hud_config_red_slider();			
 		}		
@@ -1164,9 +1164,9 @@ void hud_config_button_do(int n)
 
 	case HCB_GREEN_UP:
 		if( HCS_CONV(HC_color_sliders[HCS_GREEN].get_currentItem()) >= 255){
-			gamesnd_play_iface(SND_GENERAL_FAIL);
+			gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 		} else {
-			gamesnd_play_iface(SND_USER_SELECT);
+			gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 			HC_color_sliders[HCS_GREEN].force_currentItem( HCS_CONV( HCS_CONV(HC_color_sliders[HCS_GREEN].get_currentItem()) + 1) );
 			hud_config_green_slider();
 		}		
@@ -1174,9 +1174,9 @@ void hud_config_button_do(int n)
 
 	case HCB_BLUE_UP:
 		if( HCS_CONV(HC_color_sliders[HCS_BLUE].get_currentItem()) >= 255){
-			gamesnd_play_iface(SND_GENERAL_FAIL);
+			gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 		} else {
-			gamesnd_play_iface(SND_USER_SELECT);
+			gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 			HC_color_sliders[HCS_BLUE].force_currentItem( HCS_CONV( HCS_CONV(HC_color_sliders[HCS_BLUE].get_currentItem()) + 1) );
 			hud_config_blue_slider();
 		}		
@@ -1184,9 +1184,9 @@ void hud_config_button_do(int n)
 
 	case HCB_I_UP:
 		if( HCS_CONV(HC_color_sliders[HCS_ALPHA].get_currentItem()) >= 255){
-			gamesnd_play_iface(SND_GENERAL_FAIL);
+			gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 		} else {
-			gamesnd_play_iface(SND_USER_SELECT);
+			gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 			HC_color_sliders[HCS_ALPHA].force_currentItem( HCS_CONV( HCS_CONV(HC_color_sliders[HCS_ALPHA].get_currentItem()) + 1) );
 			hud_config_alpha_slider_up();
 		}		
@@ -1194,9 +1194,9 @@ void hud_config_button_do(int n)
 
 	case HCB_RED_DOWN:
 		if( HCS_CONV(HC_color_sliders[HCS_RED].get_currentItem()) <= 0){
-			gamesnd_play_iface(SND_GENERAL_FAIL);
+			gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 		} else {
-			gamesnd_play_iface(SND_USER_SELECT);
+			gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 			HC_color_sliders[HCS_RED].force_currentItem( HCS_CONV( HCS_CONV(HC_color_sliders[HCS_RED].get_currentItem()) - 1) );
 			hud_config_red_slider();
 		}		
@@ -1204,9 +1204,9 @@ void hud_config_button_do(int n)
 
 	case HCB_GREEN_DOWN:
 		if( HCS_CONV(HC_color_sliders[HCS_GREEN].get_currentItem()) <= 0){
-			gamesnd_play_iface(SND_GENERAL_FAIL);
+			gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 		} else {
-			gamesnd_play_iface(SND_USER_SELECT);
+			gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 			HC_color_sliders[HCS_GREEN].force_currentItem( HCS_CONV( HCS_CONV(HC_color_sliders[HCS_GREEN].get_currentItem()) - 1) );
 			hud_config_green_slider();
 		}		
@@ -1214,9 +1214,9 @@ void hud_config_button_do(int n)
 
 	case HCB_BLUE_DOWN:
 		if( HCS_CONV(HC_color_sliders[HCS_BLUE].get_currentItem()) <= 0){
-			gamesnd_play_iface(SND_GENERAL_FAIL);
+			gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 		} else {
-			gamesnd_play_iface(SND_USER_SELECT);
+			gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 			HC_color_sliders[HCS_BLUE].force_currentItem( HCS_CONV( HCS_CONV(HC_color_sliders[HCS_BLUE].get_currentItem()) - 1) );
 			hud_config_blue_slider();
 		}		
@@ -1224,9 +1224,9 @@ void hud_config_button_do(int n)
 
 	case HCB_I_DOWN:
 		if( HCS_CONV(HC_color_sliders[HCS_ALPHA].get_currentItem()) <= 0){
-			gamesnd_play_iface(SND_GENERAL_FAIL);
+			gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 		} else {
-			gamesnd_play_iface(SND_USER_SELECT);
+			gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 			HC_color_sliders[HCS_ALPHA].force_currentItem( HCS_CONV( HCS_CONV(HC_color_sliders[HCS_ALPHA].get_currentItem()) - 1) );
 			hud_config_alpha_slider_down();
 		}		

--- a/code/hud/hudescort.cpp
+++ b/code/hud/hudescort.cpp
@@ -905,7 +905,7 @@ void hud_add_ship_to_escort(int objnum, int supress_feedback)
 
 		if (!found) {
 			HUD_sourced_printf(HUD_SOURCE_HIDDEN, XSTR( "Escort list is full with %d ships", 288), Num_escort_ships);
-			snd_play( gamesnd_get_game_sound(SND_TARGET_FAIL));
+			snd_play( gamesnd_get_game_sound(GameSounds::TARGET_FAIL));
 		}
 	}
 
@@ -932,7 +932,7 @@ void hud_add_remove_ship_escort(int objnum, int supress_feedback)
 
 	if ( Objects[objnum].type != OBJ_SHIP ) {
 		if ( !supress_feedback ) {
-			snd_play( gamesnd_get_game_sound(SND_TARGET_FAIL));
+			snd_play( gamesnd_get_game_sound(GameSounds::TARGET_FAIL));
 		}
 		return;
 	}
@@ -1010,7 +1010,7 @@ void hud_escort_target_next()
 	int objnum;
 
 	if ( Num_escort_ships == 0 ) {
-		snd_play( gamesnd_get_game_sound(SND_TARGET_FAIL), 0.0f );
+		snd_play( gamesnd_get_game_sound(GameSounds::TARGET_FAIL), 0.0f );
 		return;
 	}
 

--- a/code/hud/hudets.cpp
+++ b/code/hud/hudets.cpp
@@ -426,7 +426,7 @@ void increase_recharge_rate(object* obj, SYSTEM_TYPE ship_system)
 	{
 		if ( obj == Player_obj )
 		{
-			snd_play( gamesnd_get_game_sound(SND_ENERGY_TRANS_FAIL), 0.0f );
+			snd_play( gamesnd_get_game_sound(GameSounds::ENERGY_TRANS_FAIL), 0.0f );
 		}
 		return;
 	}
@@ -464,7 +464,7 @@ void increase_recharge_rate(object* obj, SYSTEM_TYPE ship_system)
 	}
 
 	if ( obj == Player_obj )
-		snd_play( gamesnd_get_game_sound(SND_ENERGY_TRANS), 0.0f );
+		snd_play( gamesnd_get_game_sound(GameSounds::ENERGY_TRANS), 0.0f );
 }
 
 // -------------------------------------------------------------------------------------------------
@@ -545,7 +545,7 @@ void decrease_recharge_rate(object* obj, SYSTEM_TYPE ship_system)
 	count = MIN(2, *lose_index);
 	if ( count <= 0 ) {
 		if ( obj == Player_obj ) {
-			snd_play( gamesnd_get_game_sound(SND_ENERGY_TRANS_FAIL), 0.0f );
+			snd_play( gamesnd_get_game_sound(GameSounds::ENERGY_TRANS_FAIL), 0.0f );
 		}
 		return;
 	}
@@ -583,7 +583,7 @@ void decrease_recharge_rate(object* obj, SYSTEM_TYPE ship_system)
 	}
 
 	if ( obj == Player_obj )
-		snd_play( gamesnd_get_game_sound(SND_ENERGY_TRANS), 0.0f );
+		snd_play( gamesnd_get_game_sound(GameSounds::ENERGY_TRANS), 0.0f );
 }
 
 void transfer_energy_weapon_common(object *objp, float from_field, float to_field, float *from_delta, float *to_delta, float max, float scale)
@@ -597,7 +597,7 @@ void transfer_energy_weapon_common(object *objp, float from_field, float to_fiel
 
 	if ( delta > 0 ) {
 		if ( objp == Player_obj )
-			snd_play( gamesnd_get_game_sound(SND_ENERGY_TRANS), 0.0f );
+			snd_play( gamesnd_get_game_sound(GameSounds::ENERGY_TRANS), 0.0f );
 
 		if (delta > from_field)
 			delta = from_field;
@@ -606,7 +606,7 @@ void transfer_energy_weapon_common(object *objp, float from_field, float to_fiel
 		*from_delta -= delta;
 	} else
 		if ( objp == Player_obj )
-			snd_play( gamesnd_get_game_sound(SND_ENERGY_TRANS_FAIL), 0.0f );
+			snd_play( gamesnd_get_game_sound(GameSounds::ENERGY_TRANS_FAIL), 0.0f );
 }
 
 // -------------------------------------------------------------------------------------------------

--- a/code/hud/hudlock.cpp
+++ b/code/hud/hudlock.cpp
@@ -610,13 +610,13 @@ void hud_do_lock_indicator(float frametime)
 			snd_stop(Missile_track_loop);
 			Missile_track_loop = -1;
 
-			if (wip->hud_locked_snd >= 0)
+			if (wip->hud_locked_snd.isValid())
 			{
 				Missile_lock_loop = snd_play(gamesnd_get_game_sound(wip->hud_locked_snd));
 			}
 			else
 			{
-				Missile_lock_loop = snd_play(gamesnd_get_game_sound(ship_get_sound(Player_obj, SND_MISSILE_LOCK)));
+				Missile_lock_loop = snd_play(gamesnd_get_game_sound(ship_get_sound(Player_obj, GameSounds::MISSILE_LOCK)));
 			}
 		}
 	}
@@ -841,13 +841,13 @@ void hud_calculate_lock_position(float frametime)
 		}
 
 		if ( Missile_track_loop == -1 ) {
-			if (wip->hud_tracking_snd >= 0)
+			if (wip->hud_tracking_snd.isValid())
 			{
 				Missile_track_loop = snd_play_looping( gamesnd_get_game_sound(wip->hud_tracking_snd), 0.0f , -1, -1);
 			}
 			else
 			{
-				Missile_track_loop = snd_play_looping( gamesnd_get_game_sound(ship_get_sound(Player_obj, SND_MISSILE_TRACKING)), 0.0f , -1, -1);
+				Missile_track_loop = snd_play_looping( gamesnd_get_game_sound(ship_get_sound(Player_obj, GameSounds::MISSILE_TRACKING)), 0.0f , -1, -1);
 			}
 		}
 

--- a/code/hud/hudmessage.cpp
+++ b/code/hud/hudmessage.cpp
@@ -812,18 +812,18 @@ void hud_scroll_list(int dir)
 	if (dir) {
 		if (Scroll_offset) {
 			Scroll_offset--;
-			gamesnd_play_iface(SND_SCROLL);
+			gamesnd_play_iface(InterfaceSounds::SCROLL);
 
 		} else
-			gamesnd_play_iface(SND_GENERAL_FAIL);
+			gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 
 	} else {
 		if (Scroll_offset < hud_get_scroll_max_pos()) {
 			Scroll_offset++;
-			gamesnd_play_iface(SND_SCROLL);
+			gamesnd_play_iface(InterfaceSounds::SCROLL);
 
 		} else
-			gamesnd_play_iface(SND_GENERAL_FAIL);
+			gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 	}
 }
 
@@ -884,10 +884,10 @@ void hud_page_scroll_list(int dir)
 			if (Scroll_offset < 0)
 				Scroll_offset = 0;
 
-			gamesnd_play_iface(SND_SCROLL);
+			gamesnd_play_iface(InterfaceSounds::SCROLL);
 
 		} else
-			gamesnd_play_iface(SND_GENERAL_FAIL);
+			gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 
 	} else {
 		if (Scroll_offset < max) {
@@ -895,10 +895,10 @@ void hud_page_scroll_list(int dir)
 			if (Scroll_offset > max)
 				Scroll_offset = max;
 
-			gamesnd_play_iface(SND_SCROLL);
+			gamesnd_play_iface(InterfaceSounds::SCROLL);
 
 		} else
-			gamesnd_play_iface(SND_GENERAL_FAIL);
+			gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 	}
 }
 

--- a/code/hud/hudparse.cpp
+++ b/code/hud/hudparse.cpp
@@ -2794,14 +2794,14 @@ void load_gauge_radar_dradis(gauge_settings* settings)
 	int display_size[2] = {0, 0};
 	int canvas_size[2] = {0, 0};
 
-	int loop_snd = -1;
+	gamesnd_id loop_snd;
 	float loop_snd_volume = 1.0f;
 
-	int arrival_beep_snd = -1;
-	int departure_beep_snd = -1;
+	gamesnd_id arrival_beep_snd;
+	gamesnd_id departure_beep_snd;
 
-	int stealth_arrival_snd = -1;
-	int stealth_departure_snd = -1;
+	gamesnd_id stealth_arrival_snd;
+	gamesnd_id stealth_departure_snd;
 
 	float arrival_beep_delay = 0.0f;
 	float departure_beep_delay = 0.0f;
@@ -2910,7 +2910,7 @@ void load_gauge_radar_dradis(gauge_settings* settings)
 		adjust_for_multimonitor(settings->base_res, true, settings->coords);
 	}
 
-	parse_sound("Loop Sound:", &loop_snd, "DRADIS HudGauge");
+	parse_game_sound("Loop Sound:", &loop_snd, "DRADIS HudGauge");
 
 	if (optional_string("Loop Volume:"))
 	{
@@ -2923,8 +2923,8 @@ void load_gauge_radar_dradis(gauge_settings* settings)
 		}
 	}
 
-	parse_sound("Arrival Beep Sound:", &arrival_beep_snd, "DRADIS HudGauge");
-	parse_sound("Stealth arrival Beep Sound:", &stealth_arrival_snd, "DRADIS HudGauge");
+	parse_game_sound("Arrival Beep Sound:", &arrival_beep_snd, "DRADIS HudGauge");
+	parse_game_sound("Stealth arrival Beep Sound:", &stealth_arrival_snd, "DRADIS HudGauge");
 
 	if (optional_string("Minimum Beep Delay:"))
 	{
@@ -2937,8 +2937,8 @@ void load_gauge_radar_dradis(gauge_settings* settings)
 		}
 	}
 
-	parse_sound("Departure Beep Sound:", &departure_beep_snd, "DRADIS HudGauge");
-	parse_sound("Stealth departure Beep Sound:", &stealth_departure_snd, "DRADIS HudGauge");
+	parse_game_sound("Departure Beep Sound:", &departure_beep_snd, "DRADIS HudGauge");
+	parse_game_sound("Stealth departure Beep Sound:", &stealth_departure_snd, "DRADIS HudGauge");
 
 	if (optional_string("Minimum Beep Delay:"))
 	{

--- a/code/hud/hudreticle.cpp
+++ b/code/hud/hudreticle.cpp
@@ -1041,7 +1041,7 @@ void hud_update_reticle( player *pp )
 				Threat_lock_frame = 1;
 			}
 			if ( (Threat_lock_frame == 2) && (Player->threat_flags & THREAT_ATTEMPT_LOCK ) ) {
-				snd_play( gamesnd_get_game_sound(ship_get_sound(Player_obj, SND_THREAT_FLASH)));
+				snd_play( gamesnd_get_game_sound(ship_get_sound(Player_obj, GameSounds::THREAT_FLASH)));
 			}
 		}
 	} 

--- a/code/hud/hudshield.cpp
+++ b/code/hud/hudshield.cpp
@@ -241,7 +241,7 @@ void hud_shield_equalize(object *objp, player *pl)
 
 	// beep
 	if (objp == Player_obj) {
-		snd_play(gamesnd_get_game_sound(SND_SHIELD_XFER_OK));
+		snd_play(gamesnd_get_game_sound(GameSounds::SHIELD_XFER_OK));
 	}
 }
 

--- a/code/hud/hudsquadmsg.cpp
+++ b/code/hud/hudsquadmsg.cpp
@@ -267,7 +267,7 @@ void hud_squadmsg_start()
 	Msg_enemies = 0;														// tells us if we are messaging enemy ships
 #endif
 
-	snd_play( gamesnd_get_game_sound(SND_SQUADMSGING_ON) );
+	snd_play( gamesnd_get_game_sound(GameSounds::SQUADMSGING_ON) );
 }
 
 // functions which will restore all of the key binding stuff when messaging mode is done
@@ -285,7 +285,7 @@ void hud_squadmsg_end()
 */
 
 	if ( message_is_playing() == FALSE )
-		snd_play( gamesnd_get_game_sound(SND_SQUADMSGING_OFF) );
+		snd_play( gamesnd_get_game_sound(GameSounds::SQUADMSGING_OFF) );
 }
 
 // function which returns true if there are fighters/bombers on the players team in the mission
@@ -637,7 +637,7 @@ int hud_squadmsg_get_key()
 
 			// play general fail sound if inactive item hit.
 			else if ( (i < Num_menu_items) && !(MsgItems[i].active) )
-				gamesnd_play_iface(SND_GENERAL_FAIL);
+				gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 
 			else if ( (i < Num_menu_items) && (MsgItems[i].active) )	// only return keys that are associated with menu items
 				return i;

--- a/code/hud/hudtarget.cpp
+++ b/code/hud/hudtarget.cpp
@@ -1075,12 +1075,12 @@ void hud_target_subobject_common(int next_flag)
 {
 	if (Player_ai->target_objnum == -1) {
 		HUD_sourced_printf(HUD_SOURCE_HIDDEN, "%s", XSTR( "No target selected.", 322));
-		snd_play( gamesnd_get_game_sound(SND_TARGET_FAIL) );
+		snd_play( gamesnd_get_game_sound(GameSounds::TARGET_FAIL) );
 		return;
 	}
 
 	if (Objects[Player_ai->target_objnum].type != OBJ_SHIP) {
-		snd_play( gamesnd_get_game_sound(SND_TARGET_FAIL));
+		snd_play( gamesnd_get_game_sound(GameSounds::TARGET_FAIL));
 		return;
 	}
 
@@ -1119,7 +1119,7 @@ void hud_target_subobject_common(int next_flag)
 	} // end for
 
 	if ( subsys_to_target == NULL ) {
-		snd_play( gamesnd_get_game_sound(SND_TARGET_FAIL));
+		snd_play( gamesnd_get_game_sound(GameSounds::TARGET_FAIL));
 	} else {
 		set_targeted_subsys(Player_ai, subsys_to_target, Player_ai->target_objnum);
 		target_shipp->last_targeted_subobject[Player_num] =  Player_ai->targeted_subsys;
@@ -1240,7 +1240,7 @@ void hud_target_common(int team_mask, int next_flag)
 	}
 
 	if ( target_found == FALSE ) {
-		snd_play( gamesnd_get_game_sound(SND_TARGET_FAIL) );
+		snd_play( gamesnd_get_game_sound(GameSounds::TARGET_FAIL) );
 	}
 }
 
@@ -1549,7 +1549,7 @@ void hud_target_missile(object *source_obj, int next_flag)
 	}
 
 	if ( !target_found ) {
-		snd_play( gamesnd_get_game_sound(SND_TARGET_FAIL), 0.0f );
+		snd_play( gamesnd_get_game_sound(GameSounds::TARGET_FAIL), 0.0f );
 	}
 }
 
@@ -1623,7 +1623,7 @@ void hud_target_uninspected_cargo(int next_flag)
 	}
 
 	if ( target_found == FALSE ) {
-		snd_play( gamesnd_get_game_sound(SND_TARGET_FAIL));
+		snd_play( gamesnd_get_game_sound(GameSounds::TARGET_FAIL));
 	}
 }
 
@@ -1686,7 +1686,7 @@ void hud_target_newest_ship()
 		hud_restore_subsystem_target(&Ships[newest_obj->instance]);
 	}
 	else {
-		snd_play( gamesnd_get_game_sound(SND_TARGET_FAIL));
+		snd_play( gamesnd_get_game_sound(GameSounds::TARGET_FAIL));
 	}
 }
 
@@ -1744,13 +1744,13 @@ void hud_target_live_turret(int next_flag, int auto_advance, int only_player_tar
 
 	// make sure we're targeting a ship
 	if (Player_ai->target_objnum == -1 && !auto_advance) {
-		snd_play(gamesnd_get_game_sound(SND_TARGET_FAIL));
+		snd_play(gamesnd_get_game_sound(GameSounds::TARGET_FAIL));
 		return;
 	}
 
 	// only targeting subsystems on ship
 	if ((Objects[Player_ai->target_objnum].type != OBJ_SHIP) && (!auto_advance)) {
-		snd_play( gamesnd_get_game_sound(SND_TARGET_FAIL));
+		snd_play( gamesnd_get_game_sound(GameSounds::TARGET_FAIL));
 		return;
 	}
 
@@ -1903,7 +1903,7 @@ void hud_target_live_turret(int next_flag, int auto_advance, int only_player_tar
 		target_shipp->last_targeted_subobject[Player_num] = Player_ai->targeted_subsys;
 	} else {
 		if (!auto_advance) {
-			snd_play( gamesnd_get_game_sound(SND_TARGET_FAIL));
+			snd_play( gamesnd_get_game_sound(GameSounds::TARGET_FAIL));
 		}
 	}
 }
@@ -1975,7 +1975,7 @@ void hud_target_closest_locked_missile(object *locked_obj)
 	}
 
 	if ( !target_found ){
-		snd_play( gamesnd_get_game_sound(SND_TARGET_FAIL), 0.0f );
+		snd_play( gamesnd_get_game_sound(GameSounds::TARGET_FAIL), 0.0f );
 	}
 }
 
@@ -2322,7 +2322,7 @@ int hud_target_closest(int team_mask, int attacked_objnum, int play_fail_snd, in
 	} else {
 		// no target found, maybe play fail sound
 		if (play_fail_snd == TRUE) {
-			snd_play(gamesnd_get_game_sound(SND_TARGET_FAIL));
+			snd_play(gamesnd_get_game_sound(GameSounds::TARGET_FAIL));
 		}
 	}
 
@@ -2445,7 +2445,7 @@ void hud_target_targets_target()
 	return;
 
 	ttt_fail:
-	snd_play( gamesnd_get_game_sound(SND_TARGET_FAIL), 0.0f );
+	snd_play( gamesnd_get_game_sound(GameSounds::TARGET_FAIL), 0.0f );
 }
 
 // Return !0 if target_objp is a valid object type for targeting in reticle, otherwise return 0
@@ -2667,7 +2667,7 @@ void hud_target_in_reticle_old()
 		}
 	}
 	else {
-			snd_play( gamesnd_get_game_sound(SND_TARGET_FAIL), 0.0f );
+			snd_play( gamesnd_get_game_sound(GameSounds::TARGET_FAIL), 0.0f );
 	}
 }
 
@@ -2698,7 +2698,7 @@ void hud_target_subsystem_in_reticle()
 	}
 
 	if ( Player_ai->target_objnum == -1) { //-V581
-		snd_play( gamesnd_get_game_sound(SND_TARGET_FAIL));
+		snd_play( gamesnd_get_game_sound(GameSounds::TARGET_FAIL));
 		return;
 	}
 
@@ -2747,7 +2747,7 @@ void hud_target_subsystem_in_reticle()
 		Ships[shipnum].last_targeted_subobject[Player_num] =  Player_ai->targeted_subsys;
 	}
 	else {
-		snd_play( gamesnd_get_game_sound(SND_TARGET_FAIL));
+		snd_play( gamesnd_get_game_sound(GameSounds::TARGET_FAIL));
 	}
 }
 
@@ -3159,9 +3159,9 @@ void hud_process_homing_missiles()
 			}
 
 			if ( closest_is_aspect ) {
-				Homing_beep.snd_handle = snd_play(gamesnd_get_game_sound(ship_get_sound(Player_obj, SND_PROXIMITY_ASPECT_WARNING)));
+				Homing_beep.snd_handle = snd_play(gamesnd_get_game_sound(ship_get_sound(Player_obj, GameSounds::PROXIMITY_ASPECT_WARNING)));
 			} else {
-				Homing_beep.snd_handle = snd_play(gamesnd_get_game_sound(ship_get_sound(Player_obj, SND_PROXIMITY_WARNING)));
+				Homing_beep.snd_handle = snd_play(gamesnd_get_game_sound(ship_get_sound(Player_obj, GameSounds::PROXIMITY_WARNING)));
 			}
 		}
 	}
@@ -4437,7 +4437,7 @@ void hud_target_change_check()
 	if (Player_ai->last_target != Player_ai->target_objnum) {
 
 		if ( Player_ai->target_objnum != -1){
-			snd_play( gamesnd_get_game_sound(ship_get_sound(Player_obj, SND_TARGET_ACQUIRE)), 0.0f );
+			snd_play( gamesnd_get_game_sound(ship_get_sound(Player_obj, GameSounds::TARGET_ACQUIRE)), 0.0f );
 		}
 
 		// if we have a hotkey set active, see if new target is in set.  If not in
@@ -4616,7 +4616,7 @@ int hud_sensors_ok(ship *sp, int show_msg)
 	if ( (sensors_str < MIN_SENSOR_STR_TO_TARGET) || (ship_subsys_disrupted(sp, SUBSYSTEM_SENSORS)) ) {
 		if ( show_msg ) {
 			HUD_sourced_printf(HUD_SOURCE_HIDDEN, "%s", XSTR( "Targeting is disabled due to sensors damage", 330));
-			snd_play(gamesnd_get_game_sound(SND_TARGET_FAIL));
+			snd_play(gamesnd_get_game_sound(GameSounds::TARGET_FAIL));
 		}
 		return 0;
 	} else {
@@ -4669,7 +4669,7 @@ void hud_target_next_list(int hostile, int next_flag, int team_mask, int attacke
 	} else {
 		// everyone hates a traitor including other traitors so the friendly target option shouldn't work for them
 		if (Player_ship->team == Iff_traitor) {
-			snd_play( gamesnd_get_game_sound(SND_TARGET_FAIL), 0.0f );
+			snd_play( gamesnd_get_game_sound(GameSounds::TARGET_FAIL), 0.0f );
 			return;
 		}
 
@@ -4696,7 +4696,7 @@ void hud_target_next_list(int hostile, int next_flag, int team_mask, int attacke
 		hud_restore_subsystem_target(&Ships[nearest_object->instance]);
 	}
 	else {
-		snd_play( gamesnd_get_game_sound(SND_TARGET_FAIL), 0.0f );
+		snd_play( gamesnd_get_game_sound(GameSounds::TARGET_FAIL), 0.0f );
 	}
 }
 
@@ -4989,7 +4989,7 @@ void hud_target_closest_uninspected_object()
 		hud_restore_subsystem_target(&Ships[nearest_obj->instance]);
 	}
 	else {
-		snd_play( gamesnd_get_game_sound(SND_TARGET_FAIL) );
+		snd_play( gamesnd_get_game_sound(GameSounds::TARGET_FAIL) );
 	}
 }
 
@@ -5092,7 +5092,7 @@ void hud_target_uninspected_object(int next_flag)
 		hud_restore_subsystem_target(&Ships[nearest_obj->instance]);
 	}
 	else {
-		snd_play( gamesnd_get_game_sound(SND_TARGET_FAIL) );
+		snd_play( gamesnd_get_game_sound(GameSounds::TARGET_FAIL) );
 	}
 }
 
@@ -5189,7 +5189,7 @@ void hud_target_last_transmit()
 
 	if ( i == MAX_TRANSMIT_TARGETS ) {
 		if ( play_fail_sound ) {
-			snd_play( gamesnd_get_game_sound(SND_TARGET_FAIL) );
+			snd_play( gamesnd_get_game_sound(GameSounds::TARGET_FAIL) );
 		}
 		Transmit_target_current_slot = -1;
 		return;

--- a/code/hud/hudtargetbox.cpp
+++ b/code/hud/hudtargetbox.cpp
@@ -2223,7 +2223,7 @@ void hud_update_target_static()
 
 	if ( Target_static_playing ) {
 		if ( Target_static_looping == -1 ) {
-			Target_static_looping = snd_play_looping(gamesnd_get_game_sound(SND_STATIC));
+			Target_static_looping = snd_play_looping(gamesnd_get_game_sound(GameSounds::STATIC));
 		}
 	} else {
 		if ( Target_static_looping != -1 ) {

--- a/code/io/keycontrol.cpp
+++ b/code/io/keycontrol.cpp
@@ -1851,7 +1851,7 @@ int button_function_critical(int n, net_player *p = NULL)
 			if ( objp == Player_obj ) {
 				if ( Player_ship->weapons.num_secondary_banks <= 0 ) {
 					HUD_sourced_printf(HUD_SOURCE_HIDDEN, "%s", XSTR( "This ship has no secondary weapons", 33));
-					gamesnd_play_iface(SND_GENERAL_FAIL);
+					gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 					break;
 				}
 			}
@@ -1864,14 +1864,14 @@ int button_function_critical(int n, net_player *p = NULL)
                 Ships[objp->instance].flags.remove(Ship::Ship_Flags::Secondary_dual_fire);
 				if(at_self) {
 					HUD_sourced_printf(HUD_SOURCE_HIDDEN, "%s", XSTR( "Secondary weapon set to normal fire mode", 34));
-					snd_play( gamesnd_get_game_sound(ship_get_sound(Player_obj, SND_SECONDARY_CYCLE)) );
+					snd_play( gamesnd_get_game_sound(ship_get_sound(Player_obj, GameSounds::SECONDARY_CYCLE)) );
 					hud_gauge_popup_start(HUD_WEAPONS_GAUGE);
 				}
 			} else {
                 Ships[objp->instance].flags.set(Ship::Ship_Flags::Secondary_dual_fire);
 				if(at_self) {
 					HUD_sourced_printf(HUD_SOURCE_HIDDEN, "%s", XSTR( "Secondary weapon set to dual fire mode", 35));
-					snd_play( gamesnd_get_game_sound(ship_get_sound(Player_obj, SND_SECONDARY_CYCLE)) );
+					snd_play( gamesnd_get_game_sound(ship_get_sound(Player_obj, GameSounds::SECONDARY_CYCLE)) );
 					hud_gauge_popup_start(HUD_WEAPONS_GAUGE);
 				}
 			}
@@ -1969,7 +1969,7 @@ int button_function_critical(int n, net_player *p = NULL)
 			}
 
 			set_default_recharge_rates(objp);
-			snd_play( gamesnd_get_game_sound(SND_ENERGY_TRANS) );
+			snd_play( gamesnd_get_game_sound(GameSounds::ENERGY_TRANS) );
 
 			// multiplayer server should maintain bank/link status here
 			if( MULTIPLAYER_MASTER ){
@@ -2078,7 +2078,7 @@ int button_function_demo_valid(int n)
 		}
 		else
 		{
-			snd_play( gamesnd_get_game_sound(SND_TARGET_FAIL) );
+			snd_play( gamesnd_get_game_sound(GameSounds::TARGET_FAIL) );
 		}
 		ret = 1;
 		break;
@@ -2092,7 +2092,7 @@ int button_function_demo_valid(int n)
 			}
 			Viewer_mode ^= VM_TRACK;
 		} else {
-			snd_play( gamesnd_get_game_sound(SND_TARGET_FAIL) );
+			snd_play( gamesnd_get_game_sound(GameSounds::TARGET_FAIL) );
 		}
 		ret = 1;
 		break;
@@ -2106,7 +2106,7 @@ int button_function_demo_valid(int n)
 		}
 		else
 		{
-			snd_play( gamesnd_get_game_sound(SND_TARGET_FAIL) );
+			snd_play( gamesnd_get_game_sound(GameSounds::TARGET_FAIL) );
 		}
 		ret = 1;
 		break;
@@ -2119,7 +2119,7 @@ int button_function_demo_valid(int n)
 		}
 		else
 		{
-			snd_play( gamesnd_get_game_sound(SND_TARGET_FAIL) );
+			snd_play( gamesnd_get_game_sound(GameSounds::TARGET_FAIL) );
 		}
 		ret = 1;
 		break;
@@ -2140,10 +2140,10 @@ int button_function_demo_valid(int n)
 	case VIEW_OTHER_SHIP:
 		control_used(VIEW_OTHER_SHIP);
 		if ( Player_ai->target_objnum < 0 || Perspective_locked) {
-			snd_play( gamesnd_get_game_sound(SND_TARGET_FAIL) );
+			snd_play( gamesnd_get_game_sound(GameSounds::TARGET_FAIL) );
 		} else {
 			if ( Objects[Player_ai->target_objnum].type != OBJ_SHIP )  {
-				snd_play( gamesnd_get_game_sound(SND_TARGET_FAIL) );
+				snd_play( gamesnd_get_game_sound(GameSounds::TARGET_FAIL) );
 			} else {
 				Viewer_mode ^= VM_OTHER_SHIP;
 			}
@@ -2374,14 +2374,14 @@ int button_function(int n)
 			control_used(TOGGLE_AUTO_MATCH_TARGET_SPEED);
 			hud_gauge_popup_start(HUD_AUTO_SPEED);
 			if ( Players[Player_num].flags & PLAYER_FLAGS_AUTO_MATCH_SPEED ) {
-				snd_play(gamesnd_get_game_sound(SND_SHIELD_XFER_OK), 1.0f);
+				snd_play(gamesnd_get_game_sound(GameSounds::SHIELD_XFER_OK), 1.0f);
 				if ( !(Player->flags & PLAYER_FLAGS_MATCH_TARGET) ) {
 					player_match_target_speed();
 				}
 			}
 			else
 			{
-				snd_play(gamesnd_get_game_sound(SND_SHIELD_XFER_OK), 1.0f);
+				snd_play(gamesnd_get_game_sound(GameSounds::SHIELD_XFER_OK), 1.0f);
 				player_match_target_speed();
 			}
 			break;
@@ -2420,16 +2420,16 @@ int button_function(int n)
 			|| (Ship_info[Ships[Player_obj->instance].ship_info_index].warpout_type == WT_HYPERSPACE 
 			&& collide_predict_large_ship(Player_obj, 100000.0f)))
 			{
-				gamesnd_play_iface(SND_GENERAL_FAIL);
+				gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 				HUD_printf("%s", XSTR( "** WARNING ** Collision danger.  Subspace drive not activated.", 39));
 			} else if (!ship_engine_ok_to_warp(Player_ship)) {
-				gamesnd_play_iface(SND_GENERAL_FAIL);
+				gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 				HUD_printf("%s", XSTR("Engine failure.  Cannot engage subspace drive.", 40));
 			} else if (!ship_navigation_ok_to_warp(Player_ship)) {
-				gamesnd_play_iface(SND_GENERAL_FAIL);
+				gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 				HUD_printf("%s", XSTR("Navigation failure.  Cannot engage subspace drive.", 1596));
 			} else if ( (Player_obj != NULL) && object_get_gliding(Player_obj)) {
-				gamesnd_play_iface(SND_GENERAL_FAIL);
+				gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 				HUD_printf("%s", XSTR("Cannot engage subspace drive while gliding.", 1597));
 			} else {
 				gameseq_post_event( GS_EVENT_PLAYER_WARPOUT_START );
@@ -2450,7 +2450,7 @@ int button_function(int n)
 
 		// toggle between high and low HUD contrast
 		case TOGGLE_HUD_CONTRAST:
-			gamesnd_play_iface(SND_USER_SELECT);
+			gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 			hud_toggle_contrast();
 			break;
 
@@ -2488,16 +2488,16 @@ int button_function(int n)
 			break;
 
 		case TOGGLE_HUD:
-			gamesnd_play_iface(SND_USER_SELECT);
+			gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 			hud_toggle_draw();
 			break;
 
 		case HUD_TARGETBOX_TOGGLE_WIREFRAME:
 			if (!Lock_targetbox_mode) {
-				gamesnd_play_iface(SND_USER_SELECT);
+				gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 				hud_targetbox_switch_wireframe_mode();
 			} else {
-				gamesnd_play_iface(SND_GENERAL_FAIL);
+				gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 			}
 			break;
 
@@ -2509,14 +2509,14 @@ int button_function(int n)
 						EndAutoPilot();
 				} else {
 					if (!StartAutopilot())
-						gamesnd_play_iface(SND_GENERAL_FAIL);
+						gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 				}
 			}
 			break;
 
 		case NAV_CYCLE:
 			if (!Sel_NextNav())
-				gamesnd_play_iface(SND_GENERAL_FAIL);
+				gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 			break;
 		default:
 			keyHasBeenUsed = FALSE;
@@ -2580,7 +2580,7 @@ int button_function(int n)
 			// target the closest ship attacking current target
 			case TARGET_CLOSEST_SHIP_ATTACKING_TARGET:
 				if (Player_ai->target_objnum < 0) {
-					snd_play(gamesnd_get_game_sound(SND_TARGET_FAIL));
+					snd_play(gamesnd_get_game_sound(GameSounds::TARGET_FAIL));
 					break;
 				}
 
@@ -2646,13 +2646,13 @@ int button_function(int n)
 			if ( Players[Player_num].flags & PLAYER_FLAGS_AUTO_TARGETING ) {
 				if (hud_sensors_ok(Player_ship)) {
 					hud_target_closest(iff_get_attackee_mask(Player_ship->team), -1, FALSE, TRUE );
-					snd_play(gamesnd_get_game_sound(SND_SHIELD_XFER_OK), 1.0f);
+					snd_play(gamesnd_get_game_sound(GameSounds::SHIELD_XFER_OK), 1.0f);
 					//HUD_sourced_printf(HUD_SOURCE_HIDDEN, XSTR( "Auto targeting activated", -1));
 				} else {
 					Players[Player_num].flags ^= PLAYER_FLAGS_AUTO_TARGETING;
 				}
 			} else {
-				snd_play(gamesnd_get_game_sound(SND_SHIELD_XFER_OK), 1.0f);
+				snd_play(gamesnd_get_game_sound(GameSounds::SHIELD_XFER_OK), 1.0f);
 				//HUD_sourced_printf(HUD_SOURCE_HIDDEN, XSTR( "Auto targeting deactivated", -1));
 			}
 			break;
@@ -2663,7 +2663,7 @@ int button_function(int n)
 			//		 ships are coming to rearm the player, just try for the closest repair ship
 			if ( hud_target_closest_repair_ship(OBJ_INDEX(Player_obj)) == 0 ) {
 				if ( hud_target_closest_repair_ship() == 0 ) {
-					snd_play(gamesnd_get_game_sound(SND_TARGET_FAIL));
+					snd_play(gamesnd_get_game_sound(GameSounds::TARGET_FAIL));
 				}
 			}
 			break;
@@ -2778,16 +2778,16 @@ int button_function(int n)
 			|| (Ship_info[Ships[Player_obj->instance].ship_info_index].warpout_type == WT_HYPERSPACE 
 			&& collide_predict_large_ship(Player_obj, 100000.0f)))
 			{
-				gamesnd_play_iface(SND_GENERAL_FAIL);
+				gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 				HUD_printf("%s", XSTR( "** WARNING ** Collision danger.  Subspace drive not activated.", 39));
 			} else if (!ship_engine_ok_to_warp(Player_ship)) {
-				gamesnd_play_iface(SND_GENERAL_FAIL);
+				gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 				HUD_printf("%s", XSTR("Engine failure.  Cannot engage subspace drive.", 40));
 			} else if (!ship_navigation_ok_to_warp(Player_ship)) {
-				gamesnd_play_iface(SND_GENERAL_FAIL);
+				gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 				HUD_printf("%s", XSTR("Navigation failure.  Cannot engage subspace drive.", 1572));
 			} else if (Player_obj != NULL && object_get_gliding(Player_obj)) {
-				gamesnd_play_iface(SND_GENERAL_FAIL);
+				gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 				HUD_printf("%s", XSTR("Cannot engage subspace drive while gliding.", 1573));
 			} else {
 				gameseq_post_event( GS_EVENT_PLAYER_WARPOUT_START );

--- a/code/menuui/barracks.cpp
+++ b/code/menuui/barracks.cpp
@@ -599,12 +599,12 @@ void barracks_create_new_pilot()
 {
 	// check if too many pilots
 	if (Num_pilots >= MAX_PILOTS) {
-		gamesnd_play_iface(SND_GENERAL_FAIL);
+		gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 		return;
 	}
 
 	// play sound for pilot creation
-	gamesnd_play_iface(SND_SCROLL);
+	gamesnd_play_iface(InterfaceSounds::SCROLL);
 	
 	// only write pilot file if there is an active pilot
 	if (strlen(Player->callsign)) {
@@ -672,9 +672,9 @@ void barracks_scroll_callsign_up()
 {
 	if (Selected_line > 0) {
 		Selected_line--;
-		gamesnd_play_iface(SND_SCROLL);
+		gamesnd_play_iface(InterfaceSounds::SCROLL);
 	} else {
-		gamesnd_play_iface(SND_GENERAL_FAIL);
+		gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 	}
 	
 	if ((Selected_line >= 0) && (Selected_line < List_scroll_offset)) {
@@ -687,9 +687,9 @@ void barracks_scroll_callsign_down()
 {
 	if (Selected_line < Num_pilots - 1) {
 		Selected_line++;
-		gamesnd_play_iface(SND_SCROLL);
+		gamesnd_play_iface(InterfaceSounds::SCROLL);
 	} else {
-		gamesnd_play_iface(SND_GENERAL_FAIL);
+		gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 	}
 	
 	// num_pilots_to_fill_height is the number of pilots that can fit in given height
@@ -704,9 +704,9 @@ void barracks_scroll_stats_up()
 {
 	if (Stats_scroll_offset > 0) {
 		Stats_scroll_offset--;
-		gamesnd_play_iface(SND_SCROLL);
+		gamesnd_play_iface(InterfaceSounds::SCROLL);
 	} else {
-		gamesnd_play_iface(SND_GENERAL_FAIL);
+		gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 	}
 }
 
@@ -717,9 +717,9 @@ void barracks_scroll_stats_down()
 
 	if (Stats_scroll_offset + Barracks_stats_coords[gr_screen.res][BARRACKS_H_COORD] / font_height < static_cast<int>(Num_stat_lines)) {
 		Stats_scroll_offset++;
-		gamesnd_play_iface(SND_SCROLL);
+		gamesnd_play_iface(InterfaceSounds::SCROLL);
 	} else {
-		gamesnd_play_iface(SND_GENERAL_FAIL);
+		gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 	}
 }
 
@@ -728,7 +728,7 @@ void barracks_prev_pic()
 {
 	// check if no pilot images or no pilot selected
 	if ((Num_pilot_images == 0) || (Cur_pilot->callsign[0] == '\0')) {
-		gamesnd_play_iface(SND_GENERAL_FAIL);
+		gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 		return;
 	}
 
@@ -744,7 +744,7 @@ void barracks_prev_pic()
 	}
 
 	// play scroll sound
-	gamesnd_play_iface(SND_SCROLL);
+	gamesnd_play_iface(InterfaceSounds::SCROLL);
 }
 
 // show next pilot pic
@@ -752,7 +752,7 @@ void barracks_next_pic()
 {
 	// check if no pilot images or no pilot selected
 	if ((Num_pilot_images == 0) || (Cur_pilot->callsign[0] == '\0')) {
-		gamesnd_play_iface(SND_GENERAL_FAIL);
+		gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 		return;
 	}
 
@@ -768,7 +768,7 @@ void barracks_next_pic()
 	}
 
 	// play scroll sound
-	gamesnd_play_iface(SND_SCROLL);
+	gamesnd_play_iface(InterfaceSounds::SCROLL);
 }
 
 // show previous squad pic
@@ -776,7 +776,7 @@ void barracks_prev_squad_pic()
 {
 	// check if no squad images or no pilot selected
 	if ((Num_pilot_squad_images == 0) || (Cur_pilot->callsign[0] == '\0')) {
-		gamesnd_play_iface(SND_GENERAL_FAIL);
+		gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 		return;
 	}
 
@@ -796,7 +796,7 @@ void barracks_prev_squad_pic()
 	}
 
 	// play scroll sound
-	gamesnd_play_iface(SND_SCROLL);
+	gamesnd_play_iface(InterfaceSounds::SCROLL);
 }
 
 // show next squad pic
@@ -804,7 +804,7 @@ void barracks_next_squad_pic()
 {
 	// check if no squad images or no pilot selected
 	if ((Num_pilot_squad_images == 0) || (Cur_pilot->callsign[0] == '\0')) {
-		gamesnd_play_iface(SND_GENERAL_FAIL);
+		gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 		return;
 	}
 
@@ -824,7 +824,7 @@ void barracks_next_squad_pic()
 	}
 
 	// play scroll sound
-	gamesnd_play_iface(SND_SCROLL);
+	gamesnd_play_iface(InterfaceSounds::SCROLL);
 }
 
 void barracks_delete_pilot()
@@ -834,12 +834,12 @@ void barracks_delete_pilot()
 	int del_rval;
 
 	if (!Num_pilots) {
-		gamesnd_play_iface(SND_GENERAL_FAIL);
+		gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 		return;
 	}
 
 	if (Player_sel_mode == PLAYER_SELECT_MODE_MULTI) {
-		gamesnd_play_iface(SND_GENERAL_FAIL);
+		gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 		popup(PF_TITLE_BIG | PF_TITLE_RED | PF_USE_AFFIRMATIVE_ICON, 1, POPUP_OK, XSTR("Disabled!\n\nMulti and single player pilots are now identical. "
 					"Deleting a multi-player pilot will also delete all single-player data for that pilot.\n\nAs a safety precaution, pilots can only be "
 					"deleted from the single-player menu.", 1598));
@@ -886,7 +886,7 @@ void barracks_delete_pilot()
 		}
 	}
 
-	gamesnd_play_iface(SND_USER_SELECT);
+	gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 }
 
 // Filter out pilots of wrong type (which shouldn't be in the directory we are checking, but just to be safe..)
@@ -1012,14 +1012,14 @@ void barracks_button_pressed(int n)
 
 		case B_PILOT_SET_ACTIVE_BUTTON:
 			if (barracks_new_pilot_selected()){
-				gamesnd_play_iface(SND_GENERAL_FAIL);
+				gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 
 				// if it's just the missing campaign file that failed for us then don't give the second popup
 				if (Campaign_file_missing) {
 					break;
 				}
 			} else {
-				gamesnd_play_iface(SND_SCROLL);
+				gamesnd_play_iface(InterfaceSounds::SCROLL);
 
 				if (Campaign_file_missing) {
 					popup(PF_USE_AFFIRMATIVE_ICON, 1, POPUP_OK, XSTR( "The currently active campaign cannot be found.  Please select another...", 1600));
@@ -1030,7 +1030,7 @@ void barracks_button_pressed(int n)
 
 		case B_ACCEPT_BUTTON:
 			if (Num_pilots && !barracks_pilot_accepted()) {
-				gamesnd_play_iface(SND_COMMIT_PRESSED);
+				gamesnd_play_iface(InterfaceSounds::COMMIT_PRESSED);
 
 				if (Campaign_file_missing) {
 					popup(PF_USE_AFFIRMATIVE_ICON, 1, POPUP_OK, XSTR( "The currently active campaign cannot be found.  Please select another...", 1600));
@@ -1039,7 +1039,7 @@ void barracks_button_pressed(int n)
 					gameseq_post_event(GS_EVENT_MAIN_MENU);
 				}
 			} else {
-				gamesnd_play_iface(SND_GENERAL_FAIL);
+				gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 
 				// if it's just the missing campaign file that failed for us then don't give the second popup
 				if (Campaign_file_missing) {
@@ -1085,16 +1085,16 @@ void barracks_button_pressed(int n)
 
 		case B_HELP_BUTTON:
 			launch_context_help();
-			gamesnd_play_iface(SND_HELP_PRESSED);
+			gamesnd_play_iface(InterfaceSounds::HELP_PRESSED);
 			break;
 
 		case B_OPTION_BUTTON:
-			gamesnd_play_iface(SND_SWITCH_SCREENS);
+			gamesnd_play_iface(InterfaceSounds::SWITCH_SCREENS);
 			gameseq_post_event(GS_EVENT_OPTIONS_MENU);
 			break;
 
 		case B_STATS_MEDAL_BUTTON:
-			gamesnd_play_iface(SND_SWITCH_SCREENS);
+			gamesnd_play_iface(InterfaceSounds::SWITCH_SCREENS);
 			gameseq_post_event(GS_EVENT_VIEW_MEDALS);
 			break;
 
@@ -1104,7 +1104,7 @@ void barracks_button_pressed(int n)
 
 		case B_PILOT_SINGLE_MODE_BUTTON:
 			if (Player_sel_mode != PLAYER_SELECT_MODE_SINGLE) {
-				gamesnd_play_iface(SND_USER_SELECT);
+				gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 				// make sure we don't carry over the multi flag
 				if (Cur_pilot->flags & PLAYER_FLAGS_IS_MULTI) {
 					Cur_pilot->flags &= ~PLAYER_FLAGS_IS_MULTI;
@@ -1121,7 +1121,7 @@ void barracks_button_pressed(int n)
 			}
 
 			if (Player_sel_mode != PLAYER_SELECT_MODE_MULTI) {
-				gamesnd_play_iface(SND_USER_SELECT);
+				gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 				Cur_pilot->flags |= PLAYER_FLAGS_IS_MULTI;
 				Pilot.save_player(Cur_pilot);
 				barracks_init_player_stuff(PLAYER_SELECT_MODE_MULTI);
@@ -1253,7 +1253,7 @@ void barracks_accept_new_pilot_callsign()
 	}
 
 	if (z) {
-		gamesnd_play_iface(SND_GENERAL_FAIL);
+		gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 		return;
 	}
 
@@ -1477,9 +1477,9 @@ void barracks_do_frame(float frametime)
 		switch (k) {
 			case KEY_ENTER:
 				if (barracks_new_pilot_selected()) {
-					gamesnd_play_iface(SND_GENERAL_FAIL);
+					gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 				} else {
-					gamesnd_play_iface(SND_USER_SELECT);
+					gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 				}
 				break;
 
@@ -1488,7 +1488,7 @@ void barracks_do_frame(float frametime)
 					if (Num_pilots && !barracks_pilot_accepted()) {
 						gameseq_post_event(GS_EVENT_MAIN_MENU);
 					} else {
-						gamesnd_play_iface(SND_GENERAL_FAIL);
+						gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 					}
 				} else {
 					// kill the overlay
@@ -1513,15 +1513,15 @@ void barracks_do_frame(float frametime)
 					barracks_init_player_stuff(PLAYER_SELECT_MODE_SINGLE);
 				}
 
-				gamesnd_play_iface(SND_USER_SELECT);
+				gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 				break;
 
 			case KEY_F1:  // show help overlay
-				gamesnd_play_iface(SND_HELP_PRESSED);
+				gamesnd_play_iface(InterfaceSounds::HELP_PRESSED);
 				break;
 
 			case KEY_F2:  // goto options screen
-				gamesnd_play_iface(SND_SWITCH_SCREENS);
+				gamesnd_play_iface(InterfaceSounds::SWITCH_SCREENS);
 				gameseq_post_event(GS_EVENT_OPTIONS_MENU);
 				break;
 		}	// end switch
@@ -1547,7 +1547,7 @@ void barracks_do_frame(float frametime)
 		if (List_region.pressed()) {
 			if (prospective_pilot != -1) {
 				Selected_line = prospective_pilot;
-				gamesnd_play_iface(SND_USER_SELECT);
+				gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 			}
 		}
 	}

--- a/code/menuui/credits.cpp
+++ b/code/menuui/credits.cpp
@@ -256,22 +256,22 @@ int credits_screen_button_pressed(int n)
 {
 	switch (n) {
 	case TECH_DATABASE_BUTTON:
-		gamesnd_play_iface(SND_SWITCH_SCREENS);
+		gamesnd_play_iface(InterfaceSounds::SWITCH_SCREENS);
 		gameseq_post_event(GS_EVENT_TECH_MENU);
 		return 1;
 
 	case SIMULATOR_BUTTON:
-		gamesnd_play_iface(SND_SWITCH_SCREENS);
+		gamesnd_play_iface(InterfaceSounds::SWITCH_SCREENS);
 		gameseq_post_event(GS_EVENT_SIMULATOR_ROOM);
 		return 1;
 
 	case CUTSCENES_BUTTON:
-		gamesnd_play_iface(SND_SWITCH_SCREENS);
+		gamesnd_play_iface(InterfaceSounds::SWITCH_SCREENS);
 		gameseq_post_event(GS_EVENT_GOTO_VIEW_CUTSCENES_SCREEN);
 		return 1;
 
 	case EXIT_BUTTON:
-		gamesnd_play_iface(SND_COMMIT_PRESSED);
+		gamesnd_play_iface(InterfaceSounds::COMMIT_PRESSED);
 		gameseq_post_event(GS_EVENT_MAIN_MENU);
 		game_flush();
 		break;

--- a/code/menuui/mainhallmenu.cpp
+++ b/code/menuui/mainhallmenu.cpp
@@ -455,7 +455,7 @@ void main_hall_init(const SCP_string &main_hall_name)
 	// Read the menu regions from mainhall.tbl
 	SCP_vector<main_hall_region>::iterator it;
 	for (it = Main_hall->regions.begin(); Main_hall->regions.end() != it; ++it) {
-		snazzy_menu_add_region(&Main_hall_region[it - Main_hall->regions.begin()], it->description.c_str(), it->mask, it->key, -1);
+		snazzy_menu_add_region(&Main_hall_region[it - Main_hall->regions.begin()], it->description.c_str(), it->mask, it->key, interface_snd_id());
 	}
 
 	// init tooltip shader						// nearly black
@@ -464,8 +464,8 @@ void main_hall_init(const SCP_string &main_hall_name)
 	// are we funny?
 	if (Vasudan_funny && main_hall_is_vasudan()) {
 		if (!stricmp(Main_hall->bitmap.c_str(), "vhall")) {
-			Main_hall->door_sounds.at(OPTIONS_REGION).at(0) = SND_VASUDAN_BUP;
-			Main_hall->door_sounds.at(OPTIONS_REGION).at(1) = SND_VASUDAN_BUP;
+			Main_hall->door_sounds.at(OPTIONS_REGION).at(0) = InterfaceSounds::VASUDAN_BUP;
+			Main_hall->door_sounds.at(OPTIONS_REGION).at(1) = InterfaceSounds::VASUDAN_BUP;
 			
 			// set head anim. hehe
 			Main_hall->door_anim_name.at(OPTIONS_REGION) = "vhallheads";
@@ -473,8 +473,8 @@ void main_hall_init(const SCP_string &main_hall_name)
 			// set the background
 			Main_hall->bitmap = "vhallhead";
 		} else if (!stricmp(Main_hall->bitmap.c_str(), "2_vhall")) {
-			Main_hall->door_sounds.at(OPTIONS_REGION).at(0) = SND_VASUDAN_BUP;
-			Main_hall->door_sounds.at(OPTIONS_REGION).at(1) = SND_VASUDAN_BUP;
+			Main_hall->door_sounds.at(OPTIONS_REGION).at(0) = InterfaceSounds::VASUDAN_BUP;
+			Main_hall->door_sounds.at(OPTIONS_REGION).at(1) = InterfaceSounds::VASUDAN_BUP;
 			
 			// set head anim. hehe
 			Main_hall->door_anim_name.at(OPTIONS_REGION) = "2_vhallheads";
@@ -771,7 +771,7 @@ void main_hall_do(float frametime)
 			snazzy_action = SNAZZY_CLICKED;
 			break;
 		case KEY_F3:
-			gamesnd_play_iface(SND_IFACE_MOUSE_CLICK);
+			gamesnd_play_iface(InterfaceSounds::IFACE_MOUSE_CLICK);
 			gameseq_post_event(GS_EVENT_LAB);
 			break;
 	#ifndef NDEBUG
@@ -831,7 +831,7 @@ void main_hall_do(float frametime)
 			switch (region_action) {
 				// clicked on the exit region
 				case EXIT_REGION:
-					gamesnd_play_iface(SND_IFACE_MOUSE_CLICK);
+					gamesnd_play_iface(InterfaceSounds::IFACE_MOUSE_CLICK);
 					main_hall_exit_game();
 					break;
 
@@ -842,24 +842,24 @@ void main_hall_do(float frametime)
 					Game_mode = GM_NORMAL;
 					
 					gameseq_post_event(GS_EVENT_NEW_CAMPAIGN);
-					gamesnd_play_iface(SND_IFACE_MOUSE_CLICK);
+					gamesnd_play_iface(InterfaceSounds::IFACE_MOUSE_CLICK);
 					break;
 
 				// clicked on the tech room region
 				case TECH_ROOM_REGION:
-					gamesnd_play_iface(SND_IFACE_MOUSE_CLICK);
+					gamesnd_play_iface(InterfaceSounds::IFACE_MOUSE_CLICK);
 					gameseq_post_event(GS_EVENT_TECH_MENU);
 					break;
 
 				// clicked on the options region
 				case OPTIONS_REGION:
-					gamesnd_play_iface(SND_IFACE_MOUSE_CLICK);
+					gamesnd_play_iface(InterfaceSounds::IFACE_MOUSE_CLICK);
 					gameseq_post_event(GS_EVENT_OPTIONS_MENU);
 					break;
 
 				// clicked on the campaign toom region
 				case CAMPAIGN_ROOM_REGION:
-					gamesnd_play_iface(SND_IFACE_MOUSE_CLICK);
+					gamesnd_play_iface(InterfaceSounds::IFACE_MOUSE_CLICK);
 					gameseq_post_event(GS_EVENT_CAMPAIGN_ROOM);
 					break;
 
@@ -897,7 +897,7 @@ void main_hall_do(float frametime)
 
 				// clicked on the barracks region
 				case BARRACKS_REGION:
-					gamesnd_play_iface(SND_IFACE_MOUSE_CLICK);
+					gamesnd_play_iface(InterfaceSounds::IFACE_MOUSE_CLICK);
 					gameseq_post_event(GS_EVENT_BARRACKS_MENU);
 					break;
 
@@ -913,7 +913,7 @@ void main_hall_do(float frametime)
 				case ESC_PRESSED:
 					// if there is a help overlay active, then don't quit the game - just kill the overlay
 					if (!help_overlay_active(Main_hall_overlay_id)) {
-						gamesnd_play_iface(SND_IFACE_MOUSE_CLICK);
+						gamesnd_play_iface(InterfaceSounds::IFACE_MOUSE_CLICK);
 						main_hall_exit_game();
 					} else { // kill the overlay
 						help_overlay_set_state(Main_hall_overlay_id,gr_screen.res,0);
@@ -1027,7 +1027,7 @@ void main_hall_do(float frametime)
  */
 void main_hall_close()
 {
-	int idx, s_idx;
+	int idx;
 
 	if (!Main_hall_inited) {
 		return;
@@ -1064,18 +1064,6 @@ void main_hall_close()
 		if ( (Main_hall_door_sound_handles.at(idx) != -1) && snd_is_playing(Main_hall_door_sound_handles.at(idx)) ) {
 			snd_stop(Main_hall_door_sound_handles.at(idx));
 			Main_hall_door_sound_handles.at(idx) = -1;
-		}
-	}
-
-	// stop any playing misc animation sounds
-	for (idx = 0; idx < Main_hall->num_misc_animations; idx++) {
-		// if this goes wrong, the int cast could overflow
-		Assert(Main_hall->misc_anim_special_sounds.at(idx).size() < INT_MAX);
-
-		for (s_idx = 0; s_idx < (int)Main_hall->misc_anim_special_sounds.at(idx).size(); s_idx++) {
-			if (snd_is_playing(Main_hall->misc_anim_special_sounds.at(idx).at(s_idx))) {
-				snd_stop(Main_hall->misc_anim_special_sounds.at(idx).at(s_idx));
-			}
 		}
 	}
 
@@ -1264,17 +1252,10 @@ void main_hall_render_misc_anims(float frametime, bool over_doors)
 							&& !Main_hall->misc_anim_sound_flag.at(idx).at(s_idx) ) {
 						Main_hall->misc_anim_sound_flag.at(idx).at(s_idx) = 1;
 
-						// if the sound is already playing, then kill it.
-						// This is a pretty safe thing to do since we can assume that by the time we get to this point again,
-						// the sound will have been long finished
-						if (snd_is_playing(Main_hall->misc_anim_special_sounds.at(idx).at(s_idx))) {
-							snd_stop(Main_hall->misc_anim_special_sounds.at(idx).at(s_idx));
-						}
-
-						int sound = Main_hall->misc_anim_special_sounds.at(idx).at(s_idx);
+						auto sound = Main_hall->misc_anim_special_sounds.at(idx).at(s_idx);
 
 						// Check if the sound is valid
-						if (sound >= 0)
+						if (sound.isValid())
 						{
 							// play the sound
 							snd_play(gamesnd_get_interface_sound(sound),Main_hall->misc_anim_sound_pan.at(idx));
@@ -1405,9 +1386,9 @@ void main_hall_mouse_release_region(int region)
 			snd_stop(Main_hall_door_sound_handles.at(region));
 		}
 
-		int sound = Main_hall->door_sounds.at(region).at(1);
+		auto sound = Main_hall->door_sounds.at(region).at(1);
 
-		if (sound >= 0)
+		if (sound.isValid())
 		{
 			Main_hall_door_sound_handles.at(region) = snd_play(gamesnd_get_interface_sound(sound), Main_hall->door_sound_pan.at(region));
 		}
@@ -1449,9 +1430,9 @@ void main_hall_mouse_grab_region(int region)
 	}
 
 
-	int sound = Main_hall->door_sounds.at(region).at(0);
+	auto sound = Main_hall->door_sounds.at(region).at(0);
 
-	if (sound >= 0)
+	if (sound.isValid())
 	{
 		Main_hall_door_sound_handles.at(region) = snd_play(gamesnd_get_interface_sound(sound),Main_hall->door_sound_pan.at(region));
 	}
@@ -1559,10 +1540,10 @@ void main_hall_handle_random_intercom_sounds()
 
 		// if the timestamp has popped, play a sound
 		if ( (Main_hall_next_intercom_sound_stamp != -1) && (timestamp_elapsed(Main_hall_next_intercom_sound_stamp)) ) {
-			int sound = Main_hall->intercom_sounds.at(Main_hall_next_intercom_sound);
+			auto sound = Main_hall->intercom_sounds.at(Main_hall_next_intercom_sound);
 
 			// Check if the sound is valid
-			if (sound >= 0)
+			if (sound.isValid())
 			{
 				// play the sound
 				Main_hall_intercom_sound_handle = snd_play(gamesnd_get_interface_sound(sound));
@@ -1652,7 +1633,7 @@ void main_hall_start_ambient()
 	}
 
 	if (play_ambient_loop) {
-		Main_hall_ambient_loop = snd_play_looping(gamesnd_get_interface_sound(SND_MAIN_HALL_AMBIENT));
+		Main_hall_ambient_loop = snd_play_looping(gamesnd_get_interface_sound(InterfaceSounds::MAIN_HALL_AMBIENT));
 	}
 }
 
@@ -1675,7 +1656,7 @@ void main_hall_stop_ambient()
 void main_hall_reset_ambient_vol()
 {
 	if (Main_hall_ambient_loop >= 0) {
-		snd_set_volume(Main_hall_ambient_loop, gamesnd_get_interface_sound(SND_MAIN_HALL_AMBIENT)->volume_range.next());
+		snd_set_volume(Main_hall_ambient_loop, gamesnd_get_interface_sound(InterfaceSounds::MAIN_HALL_AMBIENT)->volume_range.next());
 	}
 }
 
@@ -1903,7 +1884,7 @@ void intercom_sounds_init(main_hall_defines &m)
 		m.intercom_delay.at(idx).push_back(0);
 
 		// intercom_sounds
-		m.intercom_sounds.push_back(-1);
+		m.intercom_sounds.push_back(interface_snd_id());
 
 		// intercom_sound_pan
 		m.intercom_sound_pan.push_back(0);
@@ -1970,7 +1951,7 @@ void misc_anim_init(main_hall_defines &m)
 
 		// misc_anim_special_sounds
 		// parse_sound_list deals with the rest of the initialisation for this one
-		m.misc_anim_special_sounds.push_back(temp);
+		m.misc_anim_special_sounds.push_back(SCP_vector<interface_snd_id>());
 
 		// misc_anim_special_trigger
 		m.misc_anim_special_trigger.push_back(temp);
@@ -2018,7 +1999,7 @@ void door_anim_init(main_hall_defines &m)
 		m.door_anim_coords.at(idx).push_back(0);
 
 		// door_sounds
-		m.door_sounds.push_back(temp);
+		m.door_sounds.push_back(SCP_vector<interface_snd_id>());
 
 		// door_sound_pan
 		m.door_sound_pan.push_back(0.0f);
@@ -2238,7 +2219,7 @@ void parse_main_hall_table(const char* filename)
 
 				for (idx = 0; idx < m->num_random_intercom_sounds; idx++) {
 					// intercom sound id
-					parse_sound("+Intercom sound:", &m->intercom_sounds.at(idx), "+Intercom sound:", PARSE_SOUND_INTERFACE_SOUND);
+					parse_iface_sound("+Intercom sound:", &m->intercom_sounds.at(idx), "+Intercom sound:");
 				}
 
 				for (idx = 0; idx < m->num_random_intercom_sounds; idx++) {
@@ -2300,7 +2281,7 @@ void parse_main_hall_table(const char* filename)
 
 				for (idx = 0; idx < m->num_misc_animations; idx++) {
 					// anim sound id
-					parse_sound_list("+Misc anim sounds:", m->misc_anim_special_sounds.at(idx), "+Misc anim sounds:", PARSE_SOUND_INTERFACE_SOUND);
+					parse_iface_sound_list("+Misc anim sounds:", m->misc_anim_special_sounds.at(idx), "+Misc anim sounds:");
 				}
 
 				for (idx = 0; idx < m->num_misc_animations; idx++) {
@@ -2374,7 +2355,7 @@ void parse_main_hall_table(const char* filename)
 
 				for (idx = 0; idx < m->num_door_animations; idx++) {
 					// door open and close sounds
-					parse_sound_list("+Door sounds:", m->door_sounds.at(idx), "+Door sounds:", (parse_sound_flags)(PARSE_SOUND_INTERFACE_SOUND | PARSE_SOUND_SCP_SOUND_LIST));
+					parse_iface_sound_list("+Door sounds:", m->door_sounds.at(idx), "+Door sounds:", true);
 				}
 
 				for (idx = 0; idx < m->num_door_animations; idx++) {

--- a/code/menuui/mainhallmenu.h
+++ b/code/menuui/mainhallmenu.h
@@ -12,6 +12,7 @@
 
 #include "globalincs/globals.h"
 #include "globalincs/pstypes.h"
+#include "gamesnd/gamesnd.h"
 
 // CommanderDJ - this is now dynamic
 // #define MAIN_HALLS_MAX			10
@@ -74,7 +75,7 @@ public:
 	SCP_vector<SCP_vector<int> > intercom_delay;
 
 	// intercom sounds themselves
-	SCP_vector<int> intercom_sounds;
+	SCP_vector<interface_snd_id> intercom_sounds;
 
 	// intercom sound pan values
 	SCP_vector<float> intercom_sound_pan;
@@ -107,7 +108,7 @@ public:
 	SCP_vector<float> misc_anim_sound_pan;
 
 	//sounds for each of the misc anims
-	SCP_vector<SCP_vector<int> > misc_anim_special_sounds;
+	SCP_vector<SCP_vector<interface_snd_id> > misc_anim_special_sounds;
 
 	//frame number triggers for each of the misc anims
 	SCP_vector<SCP_vector<int> > misc_anim_special_trigger;
@@ -132,7 +133,7 @@ public:
 	SCP_vector<SCP_vector<int> > door_anim_coords;
 
 	// sounds for each region (open/close)
-	SCP_vector<SCP_vector<int> > door_sounds;
+	SCP_vector<SCP_vector<interface_snd_id> > door_sounds;
 
 	// pan values for the door sounds
 	SCP_vector<float> door_sound_pan;

--- a/code/menuui/mainhalltemp.cpp
+++ b/code/menuui/mainhalltemp.cpp
@@ -218,33 +218,33 @@ void mht_button_pressed(int n)
 		} else {			
 			gameseq_post_event(GS_EVENT_NEW_CAMPAIGN);			
 
-			gamesnd_play_iface(SND_USER_SELECT);
+			gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 		}
 		break;
 
 	case MHT_CAMPAIGN_ROOM:
 		gameseq_post_event(GS_EVENT_CAMPAIGN_ROOM);			
-		gamesnd_play_iface(SND_USER_SELECT);
+		gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 		break;
 		
 	case MHT_OPTIONS:
 		gameseq_post_event(GS_EVENT_OPTIONS_MENU);
-		gamesnd_play_iface(SND_USER_SELECT);
+		gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 		break;
 
 	case MHT_TECH_ROOM:
 		gameseq_post_event( GS_EVENT_TECH_MENU );
-		gamesnd_play_iface(SND_USER_SELECT);
+		gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 		break;
 	
 	case MHT_BARRACKS:
 		gameseq_post_event( GS_EVENT_BARRACKS_MENU );
-		gamesnd_play_iface(SND_USER_SELECT);
+		gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 		break;
 
 	case MHT_EXIT:
 		mht_exit_game();
-		gamesnd_play_iface(SND_USER_SELECT);
+		gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 		break;
 	}							
 }

--- a/code/menuui/optionsmenu.cpp
+++ b/code/menuui/optionsmenu.cpp
@@ -471,7 +471,7 @@ void options_play_voice_clip()
 		snd_stop(Voice_vol_handle);
 		Voice_vol_handle=-1;
 	}
-	auto gs = gamesnd_get_interface_sound(SND_VOICE_SLIDER_CLIP);
+	auto gs = gamesnd_get_interface_sound(InterfaceSounds::VOICE_SLIDER_CLIP);
 	auto entry = gamesnd_choose_entry(gs);
 
 	snd_id = snd_load(entry, gs->flags, 0);
@@ -634,7 +634,7 @@ void options_change_tab(int n)
 
 	if (n != MULTIPLAYER_TAB) {
 		if (Backgrounds[gr_screen.res][n].mask < 0) {
-			gamesnd_play_iface(SND_GENERAL_FAIL);
+			gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 			return;
 		}
 	}
@@ -643,7 +643,7 @@ void options_change_tab(int n)
 
 	Tab = n;
 	options_tab_setup(1);
-	gamesnd_play_iface(SND_SCREEN_MODE_PRESSED);
+	gamesnd_play_iface(InterfaceSounds::SCREEN_MODE_PRESSED);
 }
 
 void set_sound_volume()
@@ -691,14 +691,14 @@ void options_change_gamma(float delta)
 	FreeSpace_gamma += delta;
 	if (FreeSpace_gamma < 0.1f) {
 		FreeSpace_gamma = 0.1f;
-		gamesnd_play_iface(SND_GENERAL_FAIL);
+		gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 
 	} else if (FreeSpace_gamma > 5.0f) {
 		FreeSpace_gamma = 5.0f;
-		gamesnd_play_iface(SND_GENERAL_FAIL);
+		gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 
 	} else {
-		gamesnd_play_iface(SND_USER_SELECT);
+		gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 	}
 
 	gr_set_gamma(FreeSpace_gamma);
@@ -721,26 +721,26 @@ void options_button_pressed(int n)
 			break;
 
 		case ABORT_GAME_BUTTON:
-			gamesnd_play_iface(SND_USER_SELECT);
+			gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 			choice = popup( PF_NO_NETWORKING | PF_BODY_BIG, 2, POPUP_NO, POPUP_YES, XSTR( "Exit Game?", 374));
 			if ( choice == 1 )
 				gameseq_post_event(GS_EVENT_QUIT_GAME);
 			break;
 
 		case CONTROL_CONFIG_BUTTON:
-			gamesnd_play_iface(SND_SWITCH_SCREENS);
+			gamesnd_play_iface(InterfaceSounds::SWITCH_SCREENS);
 			gameseq_post_event(GS_EVENT_CONTROL_CONFIG);
 			break;				
 
 		case HUD_CONFIG_BUTTON:
 			// can't go to the hud config screen when a multiplayer observer
 			if((Game_mode & GM_MULTIPLAYER) && (Net_player->flags & NETINFO_FLAG_OBSERVER)){
-				gamesnd_play_iface(SND_GENERAL_FAIL);
+				gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 				options_add_notify(XSTR( "Cannot use HUD config when an observer!", 375));
 				break;
 			}
 
-			gamesnd_play_iface(SND_SWITCH_SCREENS);
+			gamesnd_play_iface(InterfaceSounds::SWITCH_SCREENS);
 			gameseq_post_event(GS_EVENT_HUD_CONFIG);
 			break;
 
@@ -752,57 +752,57 @@ void options_button_pressed(int n)
 
 		case HUD_TARGETVIEW_RENDER_ON:
 			Detail.targetview_model = 1;
-			gamesnd_play_iface(SND_USER_SELECT);
+			gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 			break;
 
 		case HUD_TARGETVIEW_RENDER_OFF:
 			Detail.targetview_model = 0;
-			gamesnd_play_iface(SND_USER_SELECT);
+			gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 			break;
 
 		case PLANETS_ON:
 			Detail.planets_suns = 1;
-			gamesnd_play_iface(SND_USER_SELECT);
+			gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 			break;
 
 		case PLANETS_OFF:
 			Detail.planets_suns = 0;
-			gamesnd_play_iface(SND_USER_SELECT);
+			gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 			break;
 
 		case WEAPON_EXTRAS_ON:
 			Detail.weapon_extras = 1;
-			gamesnd_play_iface(SND_USER_SELECT);
+			gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 			break;
 
 		case WEAPON_EXTRAS_OFF:
 			Detail.weapon_extras = 0;
-			gamesnd_play_iface(SND_USER_SELECT);
+			gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 			break;		
 
 		case LOW_DETAIL_N:
 			options_detail_set_level(0);
-			gamesnd_play_iface(SND_USER_SELECT);
+			gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 			break;
 
 		case MEDIUM_DETAIL_N:
 			options_detail_set_level(1);
-			gamesnd_play_iface(SND_USER_SELECT);
+			gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 			break;
 
 		case HIGH_DETAIL_N:
 			options_detail_set_level(2);
-			gamesnd_play_iface(SND_USER_SELECT);
+			gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 			break;
 
 		case VERY_HIGH_DETAIL_N:
 			options_detail_set_level(3);
-			gamesnd_play_iface(SND_USER_SELECT);
+			gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 			break;
 
 		case CUSTOM_DETAIL_N:
 			options_detail_set_level(-1);
-			gamesnd_play_iface(SND_USER_SELECT);
+			gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 			break;
 			// END - detail level tab buttons
 
@@ -816,22 +816,22 @@ void options_button_pressed(int n)
 
 		case BRIEF_VOICE_ON:
 			Briefing_voice_enabled = 1;
-			gamesnd_play_iface(SND_USER_SELECT);
+			gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 			break;
 
 		case BRIEF_VOICE_OFF:
 			Briefing_voice_enabled = 0;
-			gamesnd_play_iface(SND_USER_SELECT);
+			gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 			break;
 
 		case MOUSE_ON:
 			Use_mouse_to_fly = 1;
-			gamesnd_play_iface(SND_USER_SELECT);
+			gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 			break;
 
 		case MOUSE_OFF:
 			Use_mouse_to_fly = 0;
-			gamesnd_play_iface(SND_USER_SELECT);
+			gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 			break;
 	}
 }
@@ -843,7 +843,7 @@ void options_sliders_update()
 		Sound_volume_int = Options_sliders[gr_screen.res][OPT_SOUND_VOLUME_SLIDER].slider.pos;
 		Master_sound_volume = ((float) (Sound_volume_int) / 9.0f);
 		set_sound_volume();
-		gamesnd_play_iface(SND_USER_SELECT);
+		gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 	}
 
 	// music slider
@@ -855,7 +855,7 @@ void options_sliders_update()
 		}
 
 		set_music_volume();
-		gamesnd_play_iface(SND_USER_SELECT);
+		gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 	}
 
 	// voice slider
@@ -868,22 +868,22 @@ void options_sliders_update()
 
 	if (Mouse_sensitivity != Options_sliders[gr_screen.res][OPT_MOUSE_SENS_SLIDER].slider.pos) {
 		Mouse_sensitivity = Options_sliders[gr_screen.res][OPT_MOUSE_SENS_SLIDER].slider.pos;
-		gamesnd_play_iface(SND_USER_SELECT);
+		gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 	}
 
 	if (Joy_sensitivity != Options_sliders[gr_screen.res][OPT_JOY_SENS_SLIDER].slider.pos) {
 		Joy_sensitivity = Options_sliders[gr_screen.res][OPT_JOY_SENS_SLIDER].slider.pos;
-		gamesnd_play_iface(SND_USER_SELECT);
+		gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 	}
 
 	if (Joy_dead_zone_size != Options_sliders[gr_screen.res][OPT_JOY_DEADZONE_SLIDER].slider.pos * 5) {
 		Joy_dead_zone_size = Options_sliders[gr_screen.res][OPT_JOY_DEADZONE_SLIDER].slider.pos * 5;
-		gamesnd_play_iface(SND_USER_SELECT);
+		gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 	}
 
 	if (Game_skill_level != Options_sliders[gr_screen.res][OPT_SKILL_SLIDER].slider.pos) {
 		Game_skill_level = Options_sliders[gr_screen.res][OPT_SKILL_SLIDER].slider.pos;
-		gamesnd_play_iface(SND_USER_SELECT);
+		gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 	}
 }
 
@@ -893,7 +893,7 @@ void options_accept()
 	if ( Options_multi_inited ) {
 		// if we've failed to provide a PXO password or username but have turned on PXO, we don't want to quit
 		if (!options_multi_accept()) {
-			gamesnd_play_iface(SND_COMMIT_PRESSED);
+			gamesnd_play_iface(InterfaceSounds::COMMIT_PRESSED);
 			popup(PF_USE_AFFIRMATIVE_ICON, 1, POPUP_OK, "PXO is selected but password or username is missing");
 			return;
 		}
@@ -908,7 +908,7 @@ void options_accept()
 	// apply other options (display options, etc)
 	// note: return in here (and play failed sound) if they can't accept yet for some reason
 
-	gamesnd_play_iface(SND_COMMIT_PRESSED);
+	gamesnd_play_iface(InterfaceSounds::COMMIT_PRESSED);
 	gameseq_post_event(GS_EVENT_PREVIOUS_STATE);
 }
 
@@ -1171,7 +1171,7 @@ void options_menu_do_frame(float frametime)
 
 		case KEY_C:
 			if (Tab == OPTIONS_TAB) {
-				gamesnd_play_iface(SND_SWITCH_SCREENS);
+				gamesnd_play_iface(InterfaceSounds::SWITCH_SCREENS);
 				gameseq_post_event(GS_EVENT_CONTROL_CONFIG);
 			}
 
@@ -1179,7 +1179,7 @@ void options_menu_do_frame(float frametime)
 
 		case KEY_H:
 			if (Tab == OPTIONS_TAB) {
-				gamesnd_play_iface(SND_SWITCH_SCREENS);
+				gamesnd_play_iface(InterfaceSounds::SWITCH_SCREENS);
 				gameseq_post_event(GS_EVENT_HUD_CONFIG);
 			}
 
@@ -1387,7 +1387,7 @@ void options_detail_sliders_update()
 	for (i = 0; i < NUM_DETAIL_SLIDERS; i++) {
 		if (Detail_sliders[gr_screen.res][i].slider.pos != Detail_slider_pos[i]) {
 			Detail_slider_pos[i] = Detail_sliders[gr_screen.res][i].slider.pos;
-			gamesnd_play_iface(SND_USER_SELECT);
+			gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 		}
 	}
 

--- a/code/menuui/optionsmenumulti.cpp
+++ b/code/menuui/optionsmenumulti.cpp
@@ -841,17 +841,17 @@ void options_multi_protocol_do(int key)
 		// if the tracker login inputbox has focus, lose it
 		if(Om_tracker_login.has_focus()){
 			Om_tracker_login.clear_focus();
-			gamesnd_play_iface(SND_COMMIT_PRESSED);
+			gamesnd_play_iface(InterfaceSounds::COMMIT_PRESSED);
 		}
 		// if the tracker password inputbox has focus, lose it
 		if(Om_tracker_passwd.has_focus()){
 			Om_tracker_passwd.clear_focus();
-			gamesnd_play_iface(SND_COMMIT_PRESSED);
+			gamesnd_play_iface(InterfaceSounds::COMMIT_PRESSED);
 		}
 		// if the tracker squad name inputbox has focus, lose it
 		if(Om_tracker_squad_name.has_focus()){
 			Om_tracker_squad_name.clear_focus();
-			gamesnd_play_iface(SND_COMMIT_PRESSED);
+			gamesnd_play_iface(InterfaceSounds::COMMIT_PRESSED);
 		}
 		break;
 
@@ -906,17 +906,17 @@ void options_multi_protocol_do(int key)
 	if (Om_tracker_login.has_focus()) {
 		if (Om_tracker_focus != TRACKER_FOCUS_LOGIN) {
 			Om_tracker_focus = TRACKER_FOCUS_LOGIN;
-			gamesnd_play_iface(SND_USER_SELECT);
+			gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 		}
 	} else if (Om_tracker_passwd.has_focus()) {
 		if (Om_tracker_focus != TRACKER_FOCUS_PASSWORD) {
 			Om_tracker_focus = TRACKER_FOCUS_PASSWORD;
-			gamesnd_play_iface(SND_USER_SELECT);
+			gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 		}
 	} else if (Om_tracker_squad_name.has_focus()) {
 		if (Om_tracker_focus != TRACKER_FOCUS_SQUADRON) {
 			Om_tracker_focus = TRACKER_FOCUS_SQUADRON;
-			gamesnd_play_iface(SND_USER_SELECT);
+			gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 		}
 	} else {
 		Om_tracker_focus = TRACKER_FOCUS_NONE;
@@ -985,7 +985,7 @@ void options_multi_protocol_button_pressed(int n)
 		Om_ip_input.unhide();
 		Om_ip_input.set_text(IP_EMPTY_STRING);
 		Om_ip_input.set_focus();
-		gamesnd_play_iface(SND_USER_SELECT);
+		gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 		break;
 
 	// delete the currently selected ip
@@ -996,7 +996,7 @@ void options_multi_protocol_button_pressed(int n)
 		}
 
 		options_multi_protocol_delete_ip();
-		gamesnd_play_iface(SND_USER_SELECT);
+		gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 		break;
 
 	// the "local" broadcast button - toggle
@@ -1012,7 +1012,7 @@ void options_multi_protocol_button_pressed(int n)
 			Om_local_broadcast = 0;
 		}
 
-		gamesnd_play_iface(SND_USER_SELECT);
+		gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 		break;
 
 	// scroll ips down
@@ -1058,7 +1058,7 @@ void options_multi_protocol_button_pressed(int n)
 		}
 
 		// play a sound
-		gamesnd_play_iface(SND_USER_SELECT);
+		gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 		break;
 
 	// general tab button 
@@ -1079,7 +1079,7 @@ void options_multi_protocol_button_pressed(int n)
 		}
 
 		// play a sound
-		gamesnd_play_iface(SND_USER_SELECT);
+		gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 
 		break;
 
@@ -1100,19 +1100,19 @@ void options_multi_protocol_button_pressed(int n)
 			Om_window->set_mask_bmap(Om_mask_1, Om_background_1_mask_fname[gr_screen.res]);
 		}
 		// play a sound
-		gamesnd_play_iface(SND_USER_SELECT);
+		gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 
 		break;
 
 	// tcp mode
 	case OM_PRO_TCP:
 		Om_protocol = NET_TCP;
-		gamesnd_play_iface(SND_USER_SELECT);
+		gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 		break;
 
 	// ipx mode, no longer supported
 	case OM_PRO_IPX:
-		gamesnd_play_iface(SND_GENERAL_FAIL);
+		gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 		popup(PF_USE_AFFIRMATIVE_ICON, 1, POPUP_OK, "The old IPX protocol is no longer supported.");
 		break;
 	}
@@ -1222,10 +1222,10 @@ void options_multi_protocol_display_ips()
 void options_multi_protocol_scroll_ip_down()
 {
 	if(Om_ip_start >= Ip_list_max_display[gr_screen.res]){
-		gamesnd_play_iface(SND_SCROLL);
+		gamesnd_play_iface(InterfaceSounds::SCROLL);
 		Om_ip_start--;
 	} else {
-		gamesnd_play_iface(SND_GENERAL_FAIL);
+		gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 	}	
 }
 
@@ -1233,10 +1233,10 @@ void options_multi_protocol_scroll_ip_down()
 void options_multi_protocol_scroll_ip_up()
 {
 	if(Om_ip_start < Om_num_ips-1){
-		gamesnd_play_iface(SND_SCROLL);
+		gamesnd_play_iface(InterfaceSounds::SCROLL);
 		Om_ip_start++;
 	} else {
-		gamesnd_play_iface(SND_GENERAL_FAIL);
+		gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 	}
 }
 
@@ -1523,100 +1523,100 @@ void options_multi_gen_button_pressed(int n)
 	// low object update level
 	case OM_GEN_OBJ_LOW:
 		if(Om_gen_obj_update != OBJ_UPDATE_LOW){
-			gamesnd_play_iface(SND_USER_SELECT);
+			gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 			Om_gen_obj_update = OBJ_UPDATE_LOW;
 		} else {
-			gamesnd_play_iface(SND_GENERAL_FAIL);
+			gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 		}
 		break;
 	
 	// medium object update level
 	case OM_GEN_OBJ_MED:
 		if(Om_gen_obj_update != OBJ_UPDATE_MEDIUM){
-			gamesnd_play_iface(SND_USER_SELECT);
+			gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 			Om_gen_obj_update = OBJ_UPDATE_MEDIUM;
 		} else {
-			gamesnd_play_iface(SND_GENERAL_FAIL);
+			gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 		}
 		break;
 	
 	// high object update level
 	case OM_GEN_OBJ_HIGH:
 		if(Om_gen_obj_update != OBJ_UPDATE_HIGH){
-			gamesnd_play_iface(SND_USER_SELECT);
+			gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 			Om_gen_obj_update = OBJ_UPDATE_HIGH;
 		} else {
-			gamesnd_play_iface(SND_GENERAL_FAIL);
+			gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 		}
 		break;
 
 	// lan object update level
 	case OM_GEN_OBJ_LAN:
 		if(Om_gen_obj_update != OBJ_UPDATE_LAN){
-			gamesnd_play_iface(SND_USER_SELECT);
+			gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 			Om_gen_obj_update = OBJ_UPDATE_LAN;
 		} else {
-			gamesnd_play_iface(SND_GENERAL_FAIL);
+			gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 		}
 		break;
 	
 	// accept pix
 	case OM_GEN_PIX_YES:
 		if(!Om_gen_pix){
-			gamesnd_play_iface(SND_USER_SELECT);
+			gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 			Om_gen_pix = 1;
 		} else {
-			gamesnd_play_iface(SND_GENERAL_FAIL);
+			gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 		}
 		break;
 	
 	// don't accept pix
 	case OM_GEN_PIX_NO:
 		if(Om_gen_pix){
-			gamesnd_play_iface(SND_USER_SELECT);
+			gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 			Om_gen_pix = 0;
 		} else {
-			gamesnd_play_iface(SND_GENERAL_FAIL);
+			gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 		}
 		break;
 	
 	// put missions in the multidate directory
 	case OM_GEN_XFER_MULTIDATA_YES:
 		if(!Om_gen_xfer_multidata){
-			gamesnd_play_iface(SND_USER_SELECT);
+			gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 			Om_gen_xfer_multidata = 1;
 		} else {
-			gamesnd_play_iface(SND_GENERAL_FAIL);
+			gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 		}
 		break;
 	
 	// don't put missions in the multidata directory
 	case OM_GEN_XFER_MULTIDATA_NO:
 		if(Om_gen_xfer_multidata){
-			gamesnd_play_iface(SND_USER_SELECT);
+			gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 			Om_gen_xfer_multidata = 0;
 		} else {
-			gamesnd_play_iface(SND_GENERAL_FAIL);
+			gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 		}
 		break;
 	
 	// flush the cache before each mission
 	case OM_GEN_FLUSH_YES:
 		if(!Om_gen_flush_cache){
-			gamesnd_play_iface(SND_USER_SELECT);
+			gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 			Om_gen_flush_cache = 1;
 		} else {
-			gamesnd_play_iface(SND_GENERAL_FAIL);
+			gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 		}
 		break;
 	
 	// don't flush the cache before each mission
 	case OM_GEN_FLUSH_NO:
 		if(Om_gen_flush_cache){
-			gamesnd_play_iface(SND_USER_SELECT);
+			gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 			Om_gen_flush_cache = 0;
 		} else {
-			gamesnd_play_iface(SND_GENERAL_FAIL);
+			gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 		}
 		break;	
 	}
@@ -1890,20 +1890,20 @@ void options_multi_vox_button_pressed(int n)
 	// accept voice button
 	case OM_VOX_VOICE_YES:
 		if(!Om_vox_accept_voice){
-			gamesnd_play_iface(SND_USER_SELECT);
+			gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 			Om_vox_accept_voice = 1;
 		} else {
-			gamesnd_play_iface(SND_GENERAL_FAIL);
+			gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 		}
 		break;
 	
 	// don't accept voice button
 	case OM_VOX_VOICE_NO:
 		if(Om_vox_accept_voice){
-			gamesnd_play_iface(SND_USER_SELECT);
+			gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 			Om_vox_accept_voice = 0;
 		} else {
-			gamesnd_play_iface(SND_GENERAL_FAIL);
+			gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 		}
 		break;
 
@@ -1911,9 +1911,9 @@ void options_multi_vox_button_pressed(int n)
 	case OM_VOX_VOICE_MUTE:
 		if(Om_vox_player_select != NULL){
 			Om_vox_player_flags[options_multi_vox_plist_get(Om_vox_player_select)] = !Om_vox_player_flags[options_multi_vox_plist_get(Om_vox_player_select)];
-			gamesnd_play_iface(SND_USER_SELECT);
+			gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 		} else {
-			gamesnd_play_iface(SND_GENERAL_FAIL);
+			gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 		}
 		break;
 
@@ -2118,15 +2118,15 @@ int options_multi_vox_plist_get(net_player *pl)
 void options_multi_vox_plist_scroll_down()
 {
 	if(Om_vox_num_players < Om_vox_plist_max_display[gr_screen.res]){
-		gamesnd_play_iface(SND_GENERAL_FAIL);
+		gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 		return;
 	}
 
 	if((Om_vox_num_players - Om_vox_plist_start) >= Om_vox_plist_max_display[gr_screen.res]){
 		Om_vox_plist_start++;
-		gamesnd_play_iface(SND_USER_SELECT);
+		gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 	} else {
-		gamesnd_play_iface(SND_GENERAL_FAIL);
+		gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 	}
 }
 
@@ -2135,9 +2135,9 @@ void options_multi_vox_plist_scroll_up()
 {
 	if(Om_vox_plist_start > 0){
 		Om_vox_plist_start--;
-		gamesnd_play_iface(SND_USER_SELECT);
+		gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 	} else {
-		gamesnd_play_iface(SND_GENERAL_FAIL);
+		gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 	}
 }
 

--- a/code/menuui/playermenu.cpp
+++ b/code/menuui/playermenu.cpp
@@ -375,12 +375,12 @@ void player_select_do()
 		// switch between single and multiplayer modes
 		case KEY_TAB: {
 			if (Player_select_input_mode) {
-				gamesnd_play_iface(SND_GENERAL_FAIL);
+				gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 				break;
 			}
 
 			// play a little sound
-			gamesnd_play_iface(SND_USER_SELECT);
+			gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 
 			if (Player_select_mode == PLAYER_SELECT_MODE_MULTI) {
 				player_select_set_bottom_text(XSTR( "Single-Player Mode", 376));
@@ -579,7 +579,7 @@ void player_select_button_pressed(int n)
 		if (Player_select_num_pilots >= MAX_PILOTS) {
 			player_select_set_bottom_text(XSTR( "You already have the maximum # of pilots!", 379));
 
-			gamesnd_play_iface(SND_GENERAL_FAIL);
+			gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 			break;
 		}
 
@@ -622,7 +622,7 @@ void player_select_button_pressed(int n)
 		if(Player_select_num_pilots >= MAX_PILOTS) {
 			player_select_set_bottom_text(XSTR( "You already have the maximum # of pilots!", 379));
 
-			gamesnd_play_iface(SND_GENERAL_FAIL);
+			gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 			break;
 		}
 
@@ -668,14 +668,14 @@ void player_select_button_pressed(int n)
 		// switch to single player mode
 		if (Player_select_mode != PLAYER_SELECT_MODE_SINGLE) {
 			// play a little sound
-			gamesnd_play_iface(SND_USER_SELECT);
+			gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 
 			player_select_set_bottom_text(XSTR( "Single Player Mode", 376));
 
 			// reinitialize as single player mode
 			player_select_init_player_stuff(PLAYER_SELECT_MODE_SINGLE);
 		} else {
-			gamesnd_play_iface(SND_GENERAL_FAIL);
+			gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 		}
 		break;
 
@@ -691,14 +691,14 @@ void player_select_button_pressed(int n)
 		// switch to multiplayer mode
 		if (Player_select_mode != PLAYER_SELECT_MODE_MULTI) {
 			// play a little sound
-			gamesnd_play_iface(SND_USER_SELECT);
+			gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 
 			player_select_set_bottom_text(XSTR( "Multiplayer Mode", 377));
 
 			// reinitialize as multiplayer mode
 			player_select_init_player_stuff(PLAYER_SELECT_MODE_MULTI);
 		} else {
-			gamesnd_play_iface(SND_GENERAL_FAIL);
+			gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 		}
 		break;
 	}
@@ -710,14 +710,14 @@ int player_select_create_new_pilot()
 
 	// make sure we haven't reached the max
 	if (Player_select_num_pilots >= MAX_PILOTS) {
-		gamesnd_play_iface(SND_GENERAL_FAIL);
+		gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 		return 0;
 	}
 
 	int play_scroll_sound = 1;
 
 	if ( play_scroll_sound ) {
-		gamesnd_play_iface(SND_SCROLL);
+		gamesnd_play_iface(InterfaceSounds::SCROLL);
 	}
 
 	idx = Player_select_num_pilots;	
@@ -787,9 +787,9 @@ void player_select_scroll_list_up()
 	// change the pilot selected index and play the appropriate sound
 	if (Player_select_pilot) {
 		Player_select_pilot--;
-		gamesnd_play_iface(SND_SCROLL);
+		gamesnd_play_iface(InterfaceSounds::SCROLL);
 	} else {
-		gamesnd_play_iface(SND_GENERAL_FAIL);
+		gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 	}
 
 	if (Player_select_pilot < Player_select_list_start) {
@@ -803,9 +803,9 @@ void player_select_scroll_list_down()
 	// change the pilot selected index and play the appropriate sound
 	if ( Player_select_pilot < Player_select_num_pilots - 1 ) {
 		Player_select_pilot++;
-		gamesnd_play_iface(SND_SCROLL);
+		gamesnd_play_iface(InterfaceSounds::SCROLL);
 	} else {
-		gamesnd_play_iface(SND_GENERAL_FAIL);
+		gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 	}
 
 	if ( Player_select_pilot >= (Player_select_list_start + Max_lines) ) {
@@ -1059,7 +1059,7 @@ void player_select_process_input(int k)
 		}
 
 		if (z) {
-			gamesnd_play_iface(SND_GENERAL_FAIL);
+			gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 			break;
 		}
 
@@ -1216,7 +1216,7 @@ void player_select_commit()
 	Assert(Player_select_num_pilots > 0);
 
 	gameseq_post_event(GS_EVENT_MAIN_MENU);
-	gamesnd_play_iface(SND_COMMIT_PRESSED);
+	gamesnd_play_iface(InterfaceSounds::COMMIT_PRESSED);
 
 	// evaluate if this is the _very_ first pilot
 	player_select_eval_very_first_pilot();

--- a/code/menuui/readyroom.cpp
+++ b/code/menuui/readyroom.cpp
@@ -22,6 +22,7 @@
 #include "menuui/mainhallmenu.h"
 #include "menuui/readyroom.h"
 #include "menuui/techmenu.h"	// for tech menu reset stuff
+#include "mission/missionparse.h"
 #include "mission/missioncampaign.h"
 #include "missionui/missionscreencommon.h"
 #include "parse/parselo.h"
@@ -677,10 +678,10 @@ void sim_room_scroll_screen_up()
 			}
 		}
 
-		gamesnd_play_iface(SND_SCROLL);
+		gamesnd_play_iface(InterfaceSounds::SCROLL);
 
 	} else
-		gamesnd_play_iface(SND_GENERAL_FAIL);
+		gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 }
 
 void sim_room_scroll_line_up()
@@ -693,10 +694,10 @@ void sim_room_scroll_line_up()
 			Sim_room_slider.forceUp();
 		}
 
-		gamesnd_play_iface(SND_SCROLL);
+		gamesnd_play_iface(InterfaceSounds::SCROLL);
 
 	} else
-		gamesnd_play_iface(SND_GENERAL_FAIL);
+		gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 }
 
 void sim_room_scroll_screen_down()
@@ -713,10 +714,10 @@ void sim_room_scroll_screen_down()
 			}
 		}
 
-		gamesnd_play_iface(SND_SCROLL);
+		gamesnd_play_iface(InterfaceSounds::SCROLL);
 
 	} else
-		gamesnd_play_iface(SND_GENERAL_FAIL);
+		gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 }
 
 void sim_room_scroll_line_down()
@@ -731,10 +732,10 @@ void sim_room_scroll_line_down()
 			Sim_room_slider.forceDown();
 		}
 
-		gamesnd_play_iface(SND_SCROLL);
+		gamesnd_play_iface(InterfaceSounds::SCROLL);
 
 	} else
-		gamesnd_play_iface(SND_GENERAL_FAIL);
+		gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 }
 
 /*  Goober5000 - why are there two nearly identical functions?
@@ -876,13 +877,13 @@ int readyroom_continue_campaign()
 	int mc_rval = mission_campaign_next_mission();
 	if (mc_rval == -1)
 	{  // is campaign and next mission valid?
-		gamesnd_play_iface(SND_GENERAL_FAIL);
+		gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 		popup(PF_USE_AFFIRMATIVE_ICON, 1, POPUP_OK, XSTR( "The campaign is over.  To replay the campaign, either create a new pilot or restart the campaign in the campaign room.", 112) );
 		return -1;
 	}
 	else if(mc_rval == -2)
 	{
-		gamesnd_play_iface(SND_GENERAL_FAIL);
+		gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 		popup(PF_USE_AFFIRMATIVE_ICON, 1, POPUP_OK, NOX("The current campaign has no missions") );
 		return -1;
 	}
@@ -897,7 +898,7 @@ int readyroom_continue_campaign()
 void sim_room_commit()
 {
 	if ((Selected_line >= Num_lines) || !sim_room_lines[Selected_line].filename) {
-		gamesnd_play_iface(SND_GENERAL_FAIL);
+		gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 		return;
 	}
 
@@ -906,7 +907,7 @@ void sim_room_commit()
 	Game_mode &= ~(GM_CAMPAIGN_MODE);						// be sure this bit is clear
 
 	gameseq_post_event(GS_EVENT_START_GAME);
-	gamesnd_play_iface(SND_COMMIT_PRESSED);
+	gamesnd_play_iface(InterfaceSounds::COMMIT_PRESSED);
 }
 
 int sim_room_button_pressed(int n)
@@ -926,7 +927,7 @@ int sim_room_button_pressed(int n)
 			Simroom_show_all = 0;
 			Player->readyroom_listing_mode = MODE_MISSIONS;
 			Selected_line = Scroll_offset = 0;
-			gamesnd_play_iface(SND_USER_SELECT);
+			gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 			sim_room_build_listing();
 			break;
 
@@ -941,7 +942,7 @@ int sim_room_button_pressed(int n)
 
 			Player->readyroom_listing_mode = MODE_CAMPAIGNS;
 			Scroll_offset = 0;
-			gamesnd_play_iface(SND_USER_SELECT);
+			gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 			sim_room_build_listing();
 			break;
 
@@ -951,26 +952,26 @@ int sim_room_button_pressed(int n)
 
 		case HELP_BUTTON:
 			launch_context_help();
-			gamesnd_play_iface(SND_HELP_PRESSED);
+			gamesnd_play_iface(InterfaceSounds::HELP_PRESSED);
 			break;
 
 		case OPTIONS_BUTTON:
-			gamesnd_play_iface(SND_SWITCH_SCREENS);
+			gamesnd_play_iface(InterfaceSounds::SWITCH_SCREENS);
 			gameseq_post_event(GS_EVENT_OPTIONS_MENU);
 			return 1;
 
 		case TECH_DATABASE_BUTTON:
-			gamesnd_play_iface(SND_SWITCH_SCREENS);
+			gamesnd_play_iface(InterfaceSounds::SWITCH_SCREENS);
 			gameseq_post_event(GS_EVENT_TECH_MENU);
 			return 1;
 
 		case CUTSCENES_BUTTON:
-			gamesnd_play_iface(SND_SWITCH_SCREENS);
+			gamesnd_play_iface(InterfaceSounds::SWITCH_SCREENS);
 			gameseq_post_event(GS_EVENT_GOTO_VIEW_CUTSCENES_SCREEN);
 			return 1;
 
 		case CREDITS_BUTTON:
-			gamesnd_play_iface(SND_SWITCH_SCREENS);
+			gamesnd_play_iface(InterfaceSounds::SWITCH_SCREENS);
 			gameseq_post_event(GS_EVENT_CREDITS);
 			return 1;
 	}
@@ -1226,12 +1227,12 @@ void sim_room_do_frame(float frametime)
 				Player->readyroom_listing_mode = MODE_MISSIONS;
 
 			Selected_line = Scroll_offset = Simroom_show_all = 0;
-			gamesnd_play_iface(SND_USER_SELECT);
+			gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 			sim_room_build_listing();
 			break;
 
 		case KEY_F2:
-			gamesnd_play_iface(SND_SWITCH_SCREENS);
+			gamesnd_play_iface(InterfaceSounds::SWITCH_SCREENS);
 			gameseq_post_event(GS_EVENT_OPTIONS_MENU);
 			break;
 
@@ -1257,7 +1258,7 @@ void sim_room_do_frame(float frametime)
 	
 		if (List_buttons[i].pressed()) {
 			Selected_line = i + Scroll_offset;
-			gamesnd_play_iface(SND_USER_SELECT);
+			gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 		}
 	}
 
@@ -1498,20 +1499,20 @@ void campaign_room_scroll_info_up()
 {
 	if (Desc_scroll_offset) {
 		Desc_scroll_offset--;
-		gamesnd_play_iface(SND_SCROLL);
+		gamesnd_play_iface(InterfaceSounds::SCROLL);
 
 	} else
-		gamesnd_play_iface(SND_GENERAL_FAIL);
+		gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 }
 
 void campaign_room_scroll_info_down()
 {
 	if ( (Num_info_lines - Desc_scroll_offset) * gr_get_font_height() > Cr_info_coords[gr_screen.res][3]) {
 		Desc_scroll_offset++;
-		gamesnd_play_iface(SND_SCROLL);
+		gamesnd_play_iface(InterfaceSounds::SCROLL);
 
 	} else
-		gamesnd_play_iface(SND_GENERAL_FAIL);
+		gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 }
 
 // returns: 0 = success, !0 = aborted or failed
@@ -1542,7 +1543,7 @@ int campaign_room_reset_campaign(int n)
 void campaign_room_commit()
 {
 	if (Selected_campaign_index < 0) {
-		gamesnd_play_iface(SND_GENERAL_FAIL);
+		gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 		return;
 	}
 
@@ -1572,12 +1573,12 @@ void campaign_room_commit()
 	}
 
 	if (mission_campaign_next_mission()) {  // is campaign and next mission valid?
-		gamesnd_play_iface(SND_GENERAL_FAIL);
+		gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 		return;
 	}
 
 	gameseq_post_event(GS_EVENT_MAIN_MENU);
-	gamesnd_play_iface(SND_COMMIT_PRESSED);
+	gamesnd_play_iface(InterfaceSounds::COMMIT_PRESSED);
 }
 
 int campaign_room_button_pressed(int n)
@@ -1617,12 +1618,12 @@ int campaign_room_button_pressed(int n)
 
 		case CR_RESET_BUTTON:
 			if ( (Active_campaign_index < 0) || (Active_campaign_index >= Num_campaigns) )
-				gamesnd_play_iface(SND_GENERAL_FAIL);
+				gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 			else if (campaign_room_reset_campaign(Active_campaign_index))
-				gamesnd_play_iface(SND_GENERAL_FAIL);
+				gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 			else
 			{
-				gamesnd_play_iface(SND_USER_SELECT);
+				gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 
 				// Goober5000 - reinitialize tech database if needed
 				if ( (Campaign.flags & CF_CUSTOM_TECH_DATABASE) || !stricmp(Campaign.filename, "freespace2") )
@@ -1790,10 +1791,10 @@ void campaign_room_do_frame(float frametime)
 		case KEY_DOWN:  // scroll list down
 			if (Selected_campaign_index < Num_campaigns - 1) {
 				set_new_campaign_line(Selected_campaign_index + 1);
-				gamesnd_play_iface(SND_SCROLL);
+				gamesnd_play_iface(InterfaceSounds::SCROLL);
 
 			} else
-				gamesnd_play_iface(SND_GENERAL_FAIL);
+				gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 
 			break;
 
@@ -1803,10 +1804,10 @@ void campaign_room_do_frame(float frametime)
 
 			if (Selected_campaign_index) {
 				set_new_campaign_line(Selected_campaign_index - 1);
-				gamesnd_play_iface(SND_SCROLL);
+				gamesnd_play_iface(InterfaceSounds::SCROLL);
 
 			} else
-				gamesnd_play_iface(SND_GENERAL_FAIL);
+				gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 
 			break;
 
@@ -1830,7 +1831,7 @@ void campaign_room_do_frame(float frametime)
 	
 		if (List_buttons[i].pressed()) {
 			set_new_campaign_line(i + Scroll_offset);
-			gamesnd_play_iface(SND_USER_SELECT);
+			gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 		}
 	}
 

--- a/code/menuui/snazzyui.cpp
+++ b/code/menuui/snazzyui.cpp
@@ -95,7 +95,7 @@ int snazzy_menu_do(ubyte *data, int mask_w, int mask_h, int num_regions, MENU_RE
 		for (i=0; i < num_regions; i++) {
 			if (pixel_value == regions[i].mask) {
 				choice = regions[i].mask;
-				if ( regions[i].click_sound != -1 ) {
+				if ( regions[i].click_sound.isValid() ) {
 					snd_play( gamesnd_get_interface_sound(regions[i].click_sound), 0.0f );
 				}
 			}
@@ -114,7 +114,7 @@ int snazzy_menu_do(ubyte *data, int mask_w, int mask_h, int num_regions, MENU_RE
 						continue;
 					if (ascii_table[k] == regions[i].key || shifted_ascii_table[k] == regions[i].key) {
 						choice = regions[i].mask;
-						if ( regions[i].click_sound != -1 ) {
+						if ( regions[i].click_sound.isValid() ) {
 							snd_play( gamesnd_get_interface_sound(regions[i].click_sound), 0.0f );
 						}
 					}
@@ -165,7 +165,7 @@ int snazzy_menu_do(ubyte *data, int mask_w, int mask_h, int num_regions, MENU_RE
 //
 //
 
-void snazzy_menu_add_region(MENU_REGION* region, const char* text, int mask, int key, int click_sound)
+void snazzy_menu_add_region(MENU_REGION* region, const char* text, int mask, int key, interface_snd_id click_sound)
 {
 	region->mask = mask;
 	region->key = key;
@@ -246,9 +246,9 @@ void read_menu_tbl(const char* menu_name, char* bkg_filename, char* mask_filenam
 
 				// stuff default click sound (not in menu.tbl)
 				if ( play_sound ) {
-					regions[*num_regions].click_sound = SND_IFACE_MOUSE_CLICK;
+					regions[*num_regions].click_sound = InterfaceSounds::IFACE_MOUSE_CLICK;
 				} else {
-					regions[*num_regions].click_sound = -1;
+					regions[*num_regions].click_sound = interface_snd_id();
 				}
 
 				*num_regions = *num_regions + 1;

--- a/code/menuui/snazzyui.h
+++ b/code/menuui/snazzyui.h
@@ -16,12 +16,13 @@
 #define ESC_PRESSED	-2
 
 #include "globalincs/pstypes.h"
+#include "gamesnd/gamesnd.h"
 
 typedef struct menu_region {
 	int 	mask;					// mask color for the region
 	int	key;					// shortcut key for the region
 	char	text[MAX_CHAR];	// The text associated with this item.
-	int	click_sound;		// Id of sound to play when mask area clicked on
+	interface_snd_id	click_sound;		// Id of sound to play when mask area clicked on
 } MENU_REGION;
 
 // These are the actions thare are returned in the action parameter.  
@@ -30,7 +31,7 @@ typedef struct menu_region {
 
 int snazzy_menu_do(ubyte *data, int mask_w, int mask_h, int num_regions, MENU_REGION *regions, int *action, int poll_key = 1, int *key = NULL);
 void read_menu_tbl(const char *menu_name, char *bkg_filename, char *mask_filename, MENU_REGION *regions, int* num_regions, int play_sound=1);
-void snazzy_menu_add_region(MENU_REGION *region, const char* text, int mask, int key, int click_sound = -1);
+void snazzy_menu_add_region(MENU_REGION *region, const char* text, int mask, int key, interface_snd_id click_sound = interface_snd_id());
 
 void snazzy_menu_init();		// Call the first time a snazzy menu is inited
 void snazzy_menu_close();

--- a/code/menuui/techmenu.cpp
+++ b/code/menuui/techmenu.cpp
@@ -632,7 +632,7 @@ void tech_prev_entry()
 	}
 
 	techroom_select_new_entry();
-	gamesnd_play_iface(SND_SCROLL);
+	gamesnd_play_iface(InterfaceSounds::SCROLL);
 }
 
 // select next entry in current list
@@ -657,16 +657,16 @@ void tech_next_entry()
 	}
 
 	techroom_select_new_entry();
-	gamesnd_play_iface(SND_SCROLL);
+	gamesnd_play_iface(InterfaceSounds::SCROLL);
 }
 
 void tech_scroll_info_up()
 {
 	if (Text_offset) {
 		Text_offset--;
-		gamesnd_play_iface(SND_SCROLL);
+		gamesnd_play_iface(InterfaceSounds::SCROLL);
 	} else {
-		gamesnd_play_iface(SND_GENERAL_FAIL);
+		gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 	}
 }
 
@@ -678,9 +678,9 @@ void tech_scroll_info_down()
 
 	if (Text_offset + h / gr_get_font_height() < Text_size) {
 		Text_offset++;
-		gamesnd_play_iface(SND_SCROLL);
+		gamesnd_play_iface(InterfaceSounds::SCROLL);
 	} else { //-V523
-		gamesnd_play_iface(SND_GENERAL_FAIL);
+		gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 	}
 }
 
@@ -690,9 +690,9 @@ void tech_scroll_list_up()
 
 	if (List_offset > 0) {
 		List_offset--;
-		gamesnd_play_iface(SND_SCROLL);
+		gamesnd_play_iface(InterfaceSounds::SCROLL);
 	} else {
-		gamesnd_play_iface(SND_GENERAL_FAIL);
+		gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 	}
 }
 
@@ -700,9 +700,9 @@ void tech_scroll_list_down()
 {
 	if (List_offset + Tech_list_coords[gr_screen.res][SHIP_H_COORD] / gr_get_font_height() < Current_list_size) {
 		List_offset++;
-		gamesnd_play_iface(SND_SCROLL);
+		gamesnd_play_iface(InterfaceSounds::SCROLL);
 	} else {
-		gamesnd_play_iface(SND_GENERAL_FAIL);
+		gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 	}
 }
 
@@ -966,19 +966,19 @@ int techroom_button_pressed(int num)
 
 		case SIMULATOR_TAB:
 			fsspeech_stop();
-			gamesnd_play_iface(SND_SWITCH_SCREENS);
+			gamesnd_play_iface(InterfaceSounds::SWITCH_SCREENS);
 			gameseq_post_event(GS_EVENT_SIMULATOR_ROOM);
 			return 1;
 
 		case CUTSCENES_TAB:
 			fsspeech_stop();
-			gamesnd_play_iface(SND_SWITCH_SCREENS);
+			gamesnd_play_iface(InterfaceSounds::SWITCH_SCREENS);
 			gameseq_post_event(GS_EVENT_GOTO_VIEW_CUTSCENES_SCREEN);
 			return 1;
 
 		case CREDITS_TAB:
 			fsspeech_stop();
-			gamesnd_play_iface(SND_SWITCH_SCREENS);
+			gamesnd_play_iface(InterfaceSounds::SWITCH_SCREENS);
 			gameseq_post_event(GS_EVENT_CREDITS);
 			return 1;
 
@@ -1010,17 +1010,17 @@ int techroom_button_pressed(int num)
 
 		case HELP_BUTTON:
 			launch_context_help();
-			gamesnd_play_iface(SND_HELP_PRESSED);
+			gamesnd_play_iface(InterfaceSounds::HELP_PRESSED);
 			break;
 
 		case OPTIONS_BUTTON:
-			gamesnd_play_iface(SND_SWITCH_SCREENS);
+			gamesnd_play_iface(InterfaceSounds::SWITCH_SCREENS);
 			gameseq_post_event(GS_EVENT_OPTIONS_MENU);
 			break;
 
 		case EXIT_BUTTON:
 			fsspeech_stop();
-			gamesnd_play_iface(SND_COMMIT_PRESSED);
+			gamesnd_play_iface(InterfaceSounds::COMMIT_PRESSED);
 			gameseq_post_event(GS_EVENT_MAIN_MENU);
 			break;
 	}
@@ -1397,7 +1397,7 @@ void techroom_do_frame(float frametime)
 	
 		if (List_buttons[i].pressed()) {
 			Cur_entry = i + List_offset;
-			gamesnd_play_iface(SND_USER_SELECT);
+			gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 			techroom_select_new_entry();
 		}
 	}

--- a/code/mission/missionbriefcommon.cpp
+++ b/code/mission/missionbriefcommon.cpp
@@ -972,7 +972,7 @@ void brief_render_icon(int stage_num, int icon_num, float frametime, int selecte
 
 				if ( Brief_stage_highlight_sound_handle < 0 ) {
 					if ( !Fred_running) {
-						Brief_stage_highlight_sound_handle = snd_play(gamesnd_get_interface_sound(SND_ICON_HIGHLIGHT));
+						Brief_stage_highlight_sound_handle = snd_play(gamesnd_get_interface_sound(InterfaceSounds::ICON_HIGHLIGHT));
 					}
 				}
 			}
@@ -1289,7 +1289,7 @@ int brief_render_text(int line_offset, int x, int y, int h, float frametime, int
 		if (snd_is_playing(Brief_text_wipe_snd)) {
 			snd_stop(Brief_text_wipe_snd);
 		}
-		gamesnd_play_iface(SND_BRIEF_TEXT_WIPE);
+		gamesnd_play_iface(InterfaceSounds::BRIEF_TEXT_WIPE);
 		Play_brief_voice = 1;
 	}
 

--- a/code/mission/missiongoals.cpp
+++ b/code/mission/missiongoals.cpp
@@ -1028,7 +1028,7 @@ void mission_maybe_play_directive_success_sound()
 {
 	if ( timestamp_elapsed(Mission_directive_sound_timestamp) ) {
 		Mission_directive_sound_timestamp=0;
-		snd_play( gamesnd_get_game_sound(SND_DIRECTIVE_COMPLETE) );
+		snd_play( gamesnd_get_game_sound(GameSounds::DIRECTIVE_COMPLETE) );
 	}
 }
 
@@ -1403,9 +1403,9 @@ void goal_screen_scroll_up()
 {
 	if (Scroll_offset) {
 		Scroll_offset--;
-		gamesnd_play_iface(SND_SCROLL);
+		gamesnd_play_iface(InterfaceSounds::SCROLL);
 	} else {
-		gamesnd_play_iface(SND_GENERAL_FAIL);
+		gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 	}
 }
 
@@ -1416,9 +1416,9 @@ void goal_screen_scroll_down()
 	max_lines = Goal_screen_text_h / gr_get_font_height();
 	if (Scroll_offset + max_lines < Goal_text.m_num_lines) {
 		Scroll_offset++;
-		gamesnd_play_iface(SND_SCROLL);
+		gamesnd_play_iface(InterfaceSounds::SCROLL);
 	} else {
-		gamesnd_play_iface(SND_GENERAL_FAIL);
+		gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 	}
 }
 
@@ -1484,6 +1484,6 @@ int mission_goals_incomplete(int desired_type, int team)
 
 void mission_goal_exit()
 {
-	snd_play( gamesnd_get_interface_sound(SND_USER_SELECT) );
+	snd_play( gamesnd_get_interface_sound(InterfaceSounds::USER_SELECT) );
 	gameseq_post_event(GS_EVENT_PREVIOUS_STATE);
 }

--- a/code/mission/missionhotkey.cpp
+++ b/code/mission/missionhotkey.cpp
@@ -705,10 +705,10 @@ void hotkey_scroll_screen_up()
 		while (!hotkey_line_query_visible(Selected_line) || (Hotkey_lines[Selected_line].type == HOTKEY_LINE_HEADING))
 			Selected_line--;
 
-		gamesnd_play_iface(SND_SCROLL);
+		gamesnd_play_iface(InterfaceSounds::SCROLL);
 
 	} else
-		gamesnd_play_iface(SND_GENERAL_FAIL);
+		gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 }
 
 void hotkey_scroll_line_up()
@@ -721,10 +721,10 @@ void hotkey_scroll_line_up()
 		if (Selected_line < Scroll_offset)
 			Scroll_offset = Selected_line;
 
-		gamesnd_play_iface(SND_SCROLL);
+		gamesnd_play_iface(InterfaceSounds::SCROLL);
 
 	} else
-		gamesnd_play_iface(SND_GENERAL_FAIL);
+		gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 }
 
 void hotkey_scroll_screen_down()
@@ -736,10 +736,10 @@ void hotkey_scroll_screen_down()
 			Assert(Selected_line < Num_lines);
 		}
 
-		gamesnd_play_iface(SND_SCROLL);
+		gamesnd_play_iface(InterfaceSounds::SCROLL);
 
 	} else
-		gamesnd_play_iface(SND_GENERAL_FAIL);
+		gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 }
 
 void hotkey_scroll_line_down()
@@ -753,10 +753,10 @@ void hotkey_scroll_line_down()
 		while (!hotkey_line_query_visible(Selected_line))
 			Scroll_offset++;
 
-		gamesnd_play_iface(SND_SCROLL);
+		gamesnd_play_iface(InterfaceSounds::SCROLL);
 
 	} else
-		gamesnd_play_iface(SND_GENERAL_FAIL);
+		gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 }
 
 void expand_wing()
@@ -869,12 +869,12 @@ void hotkey_button_pressed(int n)
 
 		case ADD_HOTKEY_BUTTON:
 			add_hotkey(Cur_hotkey);
-			gamesnd_play_iface(SND_USER_SELECT);
+			gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 			break;
 
 		case REMOVE_HOTKEY_BUTTON:
 			remove_hotkey();
-			gamesnd_play_iface(SND_USER_SELECT);
+			gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 			break;
 
 		case ACCEPT_BUTTON:
@@ -884,27 +884,27 @@ void hotkey_button_pressed(int n)
 
 		case CANCEL_BUTTON:			
 			mission_hotkey_exit();
-			gamesnd_play_iface(SND_USER_SELECT);
+			gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 			break;
 
 		case HELP_BUTTON:
 			launch_context_help();
-			gamesnd_play_iface(SND_HELP_PRESSED);
+			gamesnd_play_iface(InterfaceSounds::HELP_PRESSED);
 			break;
 
 		case OPTIONS_BUTTON:			
 			gameseq_post_event(GS_EVENT_OPTIONS_MENU);
-			gamesnd_play_iface(SND_USER_SELECT);
+			gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 			break;
 
 		case CLEAR_BUTTON:
 			clear_hotkeys();
-			gamesnd_play_iface(SND_USER_SELECT);
+			gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 			break;
 
 		case RESET_BUTTON:
 			reset_hotkeys();
-			gamesnd_play_iface(SND_USER_SELECT);
+			gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 			break;
 	}
 }

--- a/code/mission/missionmessage.cpp
+++ b/code/mission/missionmessage.cpp
@@ -1569,7 +1569,7 @@ void message_queue_process()
 	// debug only -- if the message is a builtin message, put in parens whether or not the voice played
 	if ( Sound_enabled && (Playing_messages[Num_messages_playing].wave == -1) ) {
 		strcat_s( buf, NOX("..(no wavefile for voice)"));
-		snd_play(gamesnd_get_game_sound(SND_CUE_VOICE));
+		snd_play(gamesnd_get_game_sound(GameSounds::CUE_VOICE));
 	}
 #endif
 	

--- a/code/missionui/chatbox.cpp
+++ b/code/missionui/chatbox.cpp
@@ -958,14 +958,14 @@ void chatbox_toggle_size()
 		chatbox_force_big();
 		
 		// play a sound
-		gamesnd_play_iface(SND_IFACE_MOUSE_CLICK);
+		gamesnd_play_iface(InterfaceSounds::IFACE_MOUSE_CLICK);
 	}
 	// if we're in "big" mode
 	else if(Chatbox_mode_flags & CHATBOX_FLAG_BIG){
 		chatbox_force_small();
 		
 		// play a sound
-		gamesnd_play_iface(SND_IFACE_MOUSE_CLICK);
+		gamesnd_play_iface(InterfaceSounds::IFACE_MOUSE_CLICK);
 	}
 }
 

--- a/code/missionui/fictionviewer.cpp
+++ b/code/missionui/fictionviewer.cpp
@@ -214,11 +214,11 @@ void fiction_viewer_scroll_up()
 	if (Top_fiction_viewer_text_line < 0)
 	{
 		Top_fiction_viewer_text_line = 0;
-		gamesnd_play_iface(SND_GENERAL_FAIL);
+		gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 	}
 	else
 	{
-		gamesnd_play_iface(SND_SCROLL);
+		gamesnd_play_iface(InterfaceSounds::SCROLL);
 	}
 }
 
@@ -228,11 +228,11 @@ void fiction_viewer_scroll_down()
 	if ((Num_brief_text_lines[0] - Top_fiction_viewer_text_line) < Fiction_viewer_text_max_lines)
 	{
 		Top_fiction_viewer_text_line--;
-		gamesnd_play_iface(SND_GENERAL_FAIL);
+		gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 	}
 	else
 	{
-		gamesnd_play_iface(SND_SCROLL);
+		gamesnd_play_iface(InterfaceSounds::SCROLL);
 	}
 }
 
@@ -248,7 +248,7 @@ void fiction_viewer_button_pressed(int button)
 	{
 		case FVW_BUTTON_ACCEPT:
 			fiction_viewer_exit();
-			gamesnd_play_iface(SND_COMMIT_PRESSED);
+			gamesnd_play_iface(InterfaceSounds::COMMIT_PRESSED);
 			break;
 
 		case FVW_BUTTON_SCROLL_UP:

--- a/code/missionui/missionbrief.cpp
+++ b/code/missionui/missionbrief.cpp
@@ -372,12 +372,12 @@ void brief_do_next_pressed(int play_sound)
 	Current_brief_stage++;
 	if ( Current_brief_stage >= Num_brief_stages ) {
 		Current_brief_stage = Num_brief_stages - 1;
-		gamesnd_play_iface(SND_GENERAL_FAIL);
+		gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 		if ( Quick_transition_stage != -1 )
 			brief_transition_reset();
 	} else {
 		if ( play_sound ) {
-			gamesnd_play_iface(SND_BRIEF_STAGE_CHG);
+			gamesnd_play_iface(InterfaceSounds::BRIEF_STAGE_CHG);
 		}
 	}
 
@@ -397,12 +397,12 @@ void brief_do_prev_pressed()
 			common_maybe_play_cutscene(MOVIE_PRE_BRIEF, true, SCORE_BRIEFING);
 		}
 		else {
-			gamesnd_play_iface(SND_GENERAL_FAIL);
+			gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 			if ( Quick_transition_stage != -1 )
 				brief_transition_reset();
 		}
 	} else {
-		gamesnd_play_iface(SND_BRIEF_STAGE_CHG);
+		gamesnd_play_iface(InterfaceSounds::BRIEF_STAGE_CHG);
 	}
 	Assert(Current_brief_stage >= 0);
 }
@@ -419,12 +419,12 @@ void brief_do_start_pressed()
 		Current_brief_stage = 0;
 	}
 	else if ( Current_brief_stage != 0 ) {
-		gamesnd_play_iface(SND_BRIEF_STAGE_CHG);
+		gamesnd_play_iface(InterfaceSounds::BRIEF_STAGE_CHG);
 		Current_brief_stage = 0;
 		if ( Quick_transition_stage != -1 )
 			brief_transition_reset();
 	} else {
-		gamesnd_play_iface(SND_GENERAL_FAIL);
+		gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 	}
 	Assert(Current_brief_stage >= 0);
 }
@@ -436,13 +436,13 @@ void brief_do_start_pressed()
 void brief_do_end_pressed()
 {
 	if ( Current_brief_stage != Num_brief_stages - 1 ) {
-		gamesnd_play_iface(SND_BRIEF_STAGE_CHG);
+		gamesnd_play_iface(InterfaceSounds::BRIEF_STAGE_CHG);
 		Current_brief_stage = Num_brief_stages - 1;
 		if ( Quick_transition_stage != -1 )
 			brief_transition_reset();
 
 	} else {
-		gamesnd_play_iface(SND_GENERAL_FAIL);
+		gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 	}
 	Assert(Current_brief_stage >= 0);
 }
@@ -453,9 +453,9 @@ void brief_scroll_up_text()
 	Top_brief_text_line--;
 	if ( Top_brief_text_line < 0 ) {
 		Top_brief_text_line = 0;
-		gamesnd_play_iface(SND_GENERAL_FAIL);
+		gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 	} else {
-		gamesnd_play_iface(SND_SCROLL);
+		gamesnd_play_iface(InterfaceSounds::SCROLL);
 	}
 }
 
@@ -464,9 +464,9 @@ void brief_scroll_down_text()
 	Top_brief_text_line++;
 	if ( (Num_brief_text_lines[0] - Top_brief_text_line) < Max_brief_Lines) {
 		Top_brief_text_line--;
-		gamesnd_play_iface(SND_GENERAL_FAIL);
+		gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 	} else {
-		gamesnd_play_iface(SND_SCROLL);
+		gamesnd_play_iface(InterfaceSounds::SCROLL);
 	}
 }
 
@@ -518,7 +518,7 @@ void brief_button_do(int i)
 			break;
 
 		case BRIEF_BUTTON_PAUSE:
-			gamesnd_play_iface(SND_USER_SELECT);
+			gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 			fsspeech_pause(Player->auto_advance != 0);
 			Player->auto_advance ^= 1;
 			break;
@@ -708,7 +708,7 @@ void brief_turn_off_closeup_icon()
 {
 	// turn off closup
 	if ( Closeup_icon != NULL ) {
-		gamesnd_play_iface(SND_BRIEF_ICON_SELECT);
+		gamesnd_play_iface(InterfaceSounds::BRIEF_ICON_SELECT);
 		Closeup_icon = NULL;
 		Closeup_close_button.disable();
 		Closeup_close_button.hide();
@@ -1411,9 +1411,9 @@ void brief_check_for_anim()
 	}
 
 	if ( brief_setup_closeup(bi) == 0 ) {
-		gamesnd_play_iface(SND_BRIEF_ICON_SELECT);
+		gamesnd_play_iface(InterfaceSounds::BRIEF_ICON_SELECT);
 	} else {
-		gamesnd_play_iface(SND_GENERAL_FAIL);
+		gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 	}
 }
 
@@ -1914,7 +1914,7 @@ void brief_maybe_blit_scene_cut(float frametime)
 		Fade_anim.time_elapsed += frametime;
 
 		if ( !Brief_playing_fade_sound ) {
-			gamesnd_play_iface(SND_BRIEFING_STATIC);					
+			gamesnd_play_iface(InterfaceSounds::BRIEFING_STATIC);
 			Brief_playing_fade_sound = 1;
 		}
 

--- a/code/missionui/missioncmdbrief.cpp
+++ b/code/missionui/missioncmdbrief.cpp
@@ -5,7 +5,7 @@
  * or otherwise commercially exploit the source or things you created based on the 
  * source.
  *
-*/ 
+*/
 
 
 
@@ -19,6 +19,7 @@
 #include "graphics/font.h"
 #include "io/key.h"
 #include "io/timer.h"
+#include "mission/missionparse.h"
 #include "mission/missionbriefcommon.h"
 #include "missionui/missioncmdbrief.h"
 #include "missionui/missionscreencommon.h"
@@ -440,11 +441,11 @@ void cmd_brief_button_pressed(int n)
 	switch (n) {
 		case CMD_BRIEF_BUTTON_HELP:
 			launch_context_help();
-			gamesnd_play_iface(SND_HELP_PRESSED);
+			gamesnd_play_iface(InterfaceSounds::HELP_PRESSED);
 			break;
 
 		case CMD_BRIEF_BUTTON_OPTIONS:
-			gamesnd_play_iface(SND_SWITCH_SCREENS);
+			gamesnd_play_iface(InterfaceSounds::SWITCH_SCREENS);
 			gameseq_post_event(GS_EVENT_OPTIONS_MENU);
 			break;
 
@@ -456,10 +457,10 @@ void cmd_brief_button_pressed(int n)
 			}
 			else if (Cur_stage) {
 				cmd_brief_new_stage(0);
-				gamesnd_play_iface(SND_BRIEF_STAGE_CHG);
+				gamesnd_play_iface(InterfaceSounds::BRIEF_STAGE_CHG);
 			} 
 			else {
-				gamesnd_play_iface(SND_GENERAL_FAIL);
+				gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 			}
 
 			break;
@@ -472,9 +473,9 @@ void cmd_brief_button_pressed(int n)
 			}
 			else if (Cur_stage) {
 				cmd_brief_new_stage(Cur_stage - 1);
-				gamesnd_play_iface(SND_BRIEF_STAGE_CHG);
+				gamesnd_play_iface(InterfaceSounds::BRIEF_STAGE_CHG);
 			} else {
-				gamesnd_play_iface(SND_GENERAL_FAIL);
+				gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 			}
 
 			break;
@@ -482,9 +483,9 @@ void cmd_brief_button_pressed(int n)
 		case CMD_BRIEF_BUTTON_NEXT_STAGE:
 			if (Cur_stage < Cur_cmd_brief->num_stages - 1) {
 				cmd_brief_new_stage(Cur_stage + 1);
-				gamesnd_play_iface(SND_BRIEF_STAGE_CHG);
+				gamesnd_play_iface(InterfaceSounds::BRIEF_STAGE_CHG);
 			} else {
-				gamesnd_play_iface(SND_GENERAL_FAIL);
+				gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 			}
 
 			break;
@@ -492,19 +493,19 @@ void cmd_brief_button_pressed(int n)
 		case CMD_BRIEF_BUTTON_LAST_STAGE:
 			if (Cur_stage < Cur_cmd_brief->num_stages - 1) {
 				cmd_brief_new_stage(Cur_cmd_brief->num_stages - 1);
-				gamesnd_play_iface(SND_BRIEF_STAGE_CHG);
+				gamesnd_play_iface(InterfaceSounds::BRIEF_STAGE_CHG);
 			} else {
-				gamesnd_play_iface(SND_GENERAL_FAIL);
+				gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 			}
 			break;
 
 		case CMD_BRIEF_BUTTON_ACCEPT:
 			cmd_brief_exit();
-			gamesnd_play_iface(SND_COMMIT_PRESSED);
+			gamesnd_play_iface(InterfaceSounds::COMMIT_PRESSED);
 			break;
 
 		case CMD_BRIEF_BUTTON_PAUSE:
-			gamesnd_play_iface(SND_USER_SELECT);
+			gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 			fsspeech_pause(Player->auto_advance != 0);
 			Player->auto_advance ^= 1;
 			break;
@@ -513,9 +514,9 @@ void cmd_brief_button_pressed(int n)
 			Top_cmd_brief_text_line--;
 			if ( Top_cmd_brief_text_line < 0 ) {
 				Top_cmd_brief_text_line = 0;
-				gamesnd_play_iface(SND_GENERAL_FAIL);
+				gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 			} else {
-				gamesnd_play_iface(SND_SCROLL);
+				gamesnd_play_iface(InterfaceSounds::SCROLL);
 			}
 			break;
 
@@ -523,9 +524,9 @@ void cmd_brief_button_pressed(int n)
 			Top_cmd_brief_text_line++;
 			if ( (Num_brief_text_lines[0] - Top_cmd_brief_text_line) < Max_cmdbrief_Lines) {
 				Top_cmd_brief_text_line--;
-				gamesnd_play_iface(SND_GENERAL_FAIL);
+				gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 			} else {
-				gamesnd_play_iface(SND_SCROLL);
+				gamesnd_play_iface(InterfaceSounds::SCROLL);
 			}
 			break;
 	}

--- a/code/missionui/missiondebrief.cpp
+++ b/code/missionui/missiondebrief.cpp
@@ -1149,30 +1149,30 @@ void debrief_multi_list_scroll_up()
 {
 	// if we're at the beginning of the list, don't do anything
 	if(Multi_list_offset == 0){
-		gamesnd_play_iface(SND_GENERAL_FAIL);
+		gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 		return;
 	}
 
 	// otherwise scroll up
 	Multi_list_offset--;
-	gamesnd_play_iface(SND_USER_SELECT);
+	gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 }
 
 void debrief_multi_list_scroll_down()
 {		
 	// if we can scroll down no further
 	if(Multi_list_size < Debrief_multi_list_team_max_display[gr_screen.res]){
-		gamesnd_play_iface(SND_GENERAL_FAIL);
+		gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 		return;
 	}
 	if((Multi_list_offset + Debrief_multi_list_team_max_display[gr_screen.res]) >= Multi_list_size){
-		gamesnd_play_iface(SND_GENERAL_FAIL);
+		gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 		return;
 	}
 
 	// otherwise scroll down
 	Multi_list_offset++;
-	gamesnd_play_iface(SND_USER_SELECT);
+	gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 }
 
 // draw the connected net players
@@ -1405,7 +1405,7 @@ void debrief_accept(int ok_to_post_start_game_event)
 
 		// Goober5000
 		if ( play_commit_sound && !(The_mission.flags[Mission::Mission_Flags::Toggle_debriefing])) {
-			gamesnd_play_iface(SND_COMMIT_PRESSED);
+			gamesnd_play_iface(InterfaceSounds::COMMIT_PRESSED);
 		}
 
 		game_flush();
@@ -1433,10 +1433,10 @@ void debrief_next_stage()
 {
 	if (Current_stage < Num_stages - 1) {
 		New_stage = Current_stage + 1;
-		gamesnd_play_iface(SND_BRIEF_STAGE_CHG);
+		gamesnd_play_iface(InterfaceSounds::BRIEF_STAGE_CHG);
 
 	} else
-		gamesnd_play_iface(SND_BRIEF_STAGE_CHG_FAIL);
+		gamesnd_play_iface(InterfaceSounds::BRIEF_STAGE_CHG_FAIL);
 }
 
 // --------------------------------------------------------------------------------------
@@ -1446,10 +1446,10 @@ void debrief_prev_stage()
 {
 	if (Current_stage) {
 		New_stage = Current_stage - 1;
-		gamesnd_play_iface(SND_BRIEF_STAGE_CHG);
+		gamesnd_play_iface(InterfaceSounds::BRIEF_STAGE_CHG);
 
 	} else
-		gamesnd_play_iface(SND_BRIEF_STAGE_CHG_FAIL);
+		gamesnd_play_iface(InterfaceSounds::BRIEF_STAGE_CHG_FAIL);
 }
 
 // --------------------------------------------------------------------------------------
@@ -1458,10 +1458,10 @@ void debrief_first_stage()
 {
 	if (Current_stage) {
 		New_stage = 0;
-		gamesnd_play_iface(SND_BRIEF_STAGE_CHG);
+		gamesnd_play_iface(InterfaceSounds::BRIEF_STAGE_CHG);
 
 	} else
-		gamesnd_play_iface(SND_BRIEF_STAGE_CHG_FAIL);
+		gamesnd_play_iface(InterfaceSounds::BRIEF_STAGE_CHG_FAIL);
 }
 
 // --------------------------------------------------------------------------------------
@@ -1470,10 +1470,10 @@ void debrief_last_stage()
 {
 	if (Current_stage != Num_stages - 1) {
 		New_stage = Num_stages - 1;
-		gamesnd_play_iface(SND_BRIEF_STAGE_CHG);
+		gamesnd_play_iface(InterfaceSounds::BRIEF_STAGE_CHG);
 
 	} else
-		gamesnd_play_iface(SND_BRIEF_STAGE_CHG_FAIL);
+		gamesnd_play_iface(InterfaceSounds::BRIEF_STAGE_CHG_FAIL);
 }
 
 // draw what stage number the debriefing is on
@@ -1603,7 +1603,7 @@ void debrief_replay_pressed()
 	}
 
 	gameseq_post_event(GS_EVENT_START_GAME);	// restart mission
-	gamesnd_play_iface(SND_COMMIT_PRESSED);
+	gamesnd_play_iface(InterfaceSounds::COMMIT_PRESSED);
 }
 
 // -------------------------------------------------------------------
@@ -1636,7 +1636,7 @@ void debrief_button_pressed(int num)
 			Buttons[gr_screen.res][RECOMMENDATIONS].button.enable();			
 			// Debrief_ui_window.use_hack_to_get_around_stupid_problem_flag = 0;
 			if (num != Current_mode){
-				gamesnd_play_iface(SND_SCREEN_MODE_PRESSED);
+				gamesnd_play_iface(InterfaceSounds::SCREEN_MODE_PRESSED);
 			}
 			New_mode = num;
 			break;
@@ -1644,7 +1644,7 @@ void debrief_button_pressed(int num)
 			// Debrief_ui_window.use_hack_to_get_around_stupid_problem_flag = 1;			// allows failure sound to be played
 			Buttons[gr_screen.res][RECOMMENDATIONS].button.disable();			
 			if (num != Current_mode){
-				gamesnd_play_iface(SND_SCREEN_MODE_PRESSED);
+				gamesnd_play_iface(InterfaceSounds::SCREEN_MODE_PRESSED);
 			}
 			New_mode = num;
 			break;
@@ -1652,18 +1652,18 @@ void debrief_button_pressed(int num)
 		case TEXT_SCROLL_UP:
 			if (Text_offset) {
 				Text_offset--;
-				gamesnd_play_iface(SND_SCROLL);
+				gamesnd_play_iface(InterfaceSounds::SCROLL);
 			} else {
-				gamesnd_play_iface(SND_GENERAL_FAIL);
+				gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 			}
 			break;
 
 		case TEXT_SCROLL_DOWN:
 			if (Max_debrief_Lines < (Num_text_lines - Text_offset)) {
 				Text_offset++;
-				gamesnd_play_iface(SND_SCROLL);
+				gamesnd_play_iface(InterfaceSounds::SCROLL);
 			} else {
-				gamesnd_play_iface(SND_GENERAL_FAIL);
+				gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 			}
 			break;
 
@@ -1676,7 +1676,7 @@ void debrief_button_pressed(int num)
 			break;
 
 		case RECOMMENDATIONS:
-			gamesnd_play_iface(SND_USER_SELECT);
+			gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 			Recommend_active = !Recommend_active;
 			debrief_text_init();
 			break;
@@ -1698,12 +1698,12 @@ void debrief_button_pressed(int num)
 			break;
 
 		case HELP_BUTTON:
-			gamesnd_play_iface(SND_HELP_PRESSED);
+			gamesnd_play_iface(InterfaceSounds::HELP_PRESSED);
 			launch_context_help();
 			break;
 
 		case OPTIONS_BUTTON:
-			gamesnd_play_iface(SND_SWITCH_SCREENS);
+			gamesnd_play_iface(InterfaceSounds::SWITCH_SCREENS);
 			gameseq_post_event( GS_EVENT_OPTIONS_MENU );
 			break;
 
@@ -1712,7 +1712,7 @@ void debrief_button_pressed(int num)
 			break;
 
 		case MEDALS_BUTTON:
-			gamesnd_play_iface(SND_SWITCH_SCREENS);
+			gamesnd_play_iface(InterfaceSounds::SWITCH_SCREENS);
 			gameseq_post_event(GS_EVENT_VIEW_MEDALS);
 			break;
 
@@ -1807,7 +1807,7 @@ void debrief_check_buttons()
 			Debrief_player = Net_players[Multi_list[z].net_player_index].m_player;
 			Multi_list_select = z;
 			debrief_setup_ship_kill_stats(Current_stage);
-			gamesnd_play_iface(SND_USER_SELECT);			
+			gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 		}
 	}	
 

--- a/code/missionui/missionloopbrief.cpp
+++ b/code/missionui/missionloopbrief.cpp
@@ -106,7 +106,7 @@ void loop_brief_button_pressed(int i)
 	switch(i){
 	case LOOP_BRIEF_DECLINE:		
 		gameseq_post_event(GS_EVENT_START_GAME);
-		gamesnd_play_iface(SND_USER_SELECT);
+		gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 		break;
 
 	case LOOP_BRIEF_ACCEPT:
@@ -116,7 +116,7 @@ void loop_brief_button_pressed(int i)
 		Campaign.next_mission = Campaign.loop_mission;		
 
 		gameseq_post_event(GS_EVENT_START_GAME);
-		gamesnd_play_iface(SND_USER_SELECT);
+		gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 		break;
 	}
 }

--- a/code/missionui/missionscreencommon.cpp
+++ b/code/missionui/missionscreencommon.cpp
@@ -752,7 +752,7 @@ void common_button_do(int i)
 
 	case COMMON_BRIEFING_BUTTON:
 		if ( Current_screen != ON_BRIEFING_SELECT ) {
-			gamesnd_play_iface(SND_SCREEN_MODE_PRESSED);
+			gamesnd_play_iface(InterfaceSounds::SCREEN_MODE_PRESSED);
 			Next_screen = ON_BRIEFING_SELECT;
 		}
 		break;
@@ -760,7 +760,7 @@ void common_button_do(int i)
 	case COMMON_WEAPON_BUTTON:
 		if ( Current_screen != ON_WEAPON_SELECT ) {
 			if ( !wss_slots_all_empty() ) {
-				gamesnd_play_iface(SND_SCREEN_MODE_PRESSED);
+				gamesnd_play_iface(InterfaceSounds::SCREEN_MODE_PRESSED);
 				Next_screen = ON_WEAPON_SELECT;
 			} else {
 				common_show_no_ship_error();
@@ -770,18 +770,18 @@ void common_button_do(int i)
 
 	case COMMON_SS_BUTTON:
 		if ( Current_screen != ON_SHIP_SELECT ) {
-			gamesnd_play_iface(SND_SCREEN_MODE_PRESSED);
+			gamesnd_play_iface(InterfaceSounds::SCREEN_MODE_PRESSED);
 			Next_screen = ON_SHIP_SELECT;
 		}
 		break;
 
 	case COMMON_OPTIONS_BUTTON:
-		gamesnd_play_iface(SND_SWITCH_SCREENS);
+		gamesnd_play_iface(InterfaceSounds::SWITCH_SCREENS);
 		gameseq_post_event( GS_EVENT_OPTIONS_MENU );
 		break;
 
 	case COMMON_HELP_BUTTON:
-		gamesnd_play_iface(SND_HELP_PRESSED);
+		gamesnd_play_iface(InterfaceSounds::HELP_PRESSED);
 		launch_context_help();
 		break;
 
@@ -833,7 +833,7 @@ void common_check_keys(int k)
 
 		case KEY_W:
 			if ( brief_only_allow_briefing() ) {
-				gamesnd_play_iface(SND_GENERAL_FAIL);
+				gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 				break;
 			}
 
@@ -850,7 +850,7 @@ void common_check_keys(int k)
 		case KEY_S:
 
 			if ( brief_only_allow_briefing() ) {
-				gamesnd_play_iface(SND_GENERAL_FAIL);
+				gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 				break;
 			}
 
@@ -863,7 +863,7 @@ void common_check_keys(int k)
 		case KEY_SHIFTED+KEY_TAB:
 
 			if ( brief_only_allow_briefing() ) {
-				gamesnd_play_iface(SND_GENERAL_FAIL);
+				gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 				break;
 			}
 
@@ -895,7 +895,7 @@ void common_check_keys(int k)
 		case KEY_TAB:
 
 			if ( brief_only_allow_briefing() ) {
-				gamesnd_play_iface(SND_GENERAL_FAIL);
+				gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 				break;
 			}
 
@@ -1319,7 +1319,7 @@ int wss_get_mode(int from_slot, int from_list, int to_slot, int to_list, int wl_
 }
 
 // store all the unit data and pool data 
-int store_wss_data(ubyte *block, int max_size, int sound,int player_index)
+int store_wss_data(ubyte *block, int max_size, interface_snd_id sound,int player_index)
 {
 	int j, i,offset=0;	
 	short player_id;	
@@ -1394,10 +1394,10 @@ int store_wss_data(ubyte *block, int max_size, int sound,int player_index)
 	}
 
 	// any sound index
-	if(sound == -1){
+	if(!sound.isValid()){
 		block[offset++] = 0xff;
 	} else {
-		block[offset++] = (ubyte)sound;
+		block[offset++] = (ubyte)sound.value();
 	}
 
 	// add a netplayer address to identify who should play the sound
@@ -1511,7 +1511,7 @@ int restore_wss_data(ubyte *block)
 	if((Net_player != NULL) && (Net_player->player_id == player_id)){
 		// play the sound
 		if(sound != 0xff){
-			gamesnd_play_iface((int)sound);
+			gamesnd_play_iface(static_cast<InterfaceSounds>(sound));
 		}
 	}
 

--- a/code/missionui/missionscreencommon.h
+++ b/code/missionui/missionscreencommon.h
@@ -13,6 +13,7 @@
 #define _MISSION_SCREEN_COMMON_HEADER_FILE
 
 #include "globalincs/globals.h"
+#include "gamesnd/gamesnd.h"
 #include "model/model.h"
 #include "ui/ui.h"
 
@@ -201,7 +202,7 @@ void wss_maybe_restore_loadout();
 void wss_direct_restore_loadout();
 
 int wss_get_mode(int from_slot, int from_list, int to_slot, int to_list, int wl_ship_slot);
-int store_wss_data(ubyte *block, int max_size, int sound,int player_index);
+int store_wss_data(ubyte *block, int max_size, interface_snd_id sound,int player_index);
 int restore_wss_data(ubyte *block);
 
 class ship_info;

--- a/code/missionui/missionshipchoice.cpp
+++ b/code/missionui/missionshipchoice.cpp
@@ -613,9 +613,9 @@ void ship_select_button_do(int i)
 				break;
 
 			if ( common_scroll_down_pressed(&SS_active_list_start, SS_active_list_size, MAX_ICONS_ON_SCREEN) ) {
-				gamesnd_play_iface(SND_SCROLL);
+				gamesnd_play_iface(InterfaceSounds::SCROLL);
 			} else {
-				gamesnd_play_iface(SND_GENERAL_FAIL);
+				gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 			}
 			break;
 
@@ -624,9 +624,9 @@ void ship_select_button_do(int i)
 				break;
 
 			if ( common_scroll_up_pressed(&SS_active_list_start, SS_active_list_size, MAX_ICONS_ON_SCREEN) ) {
-				gamesnd_play_iface(SND_SCROLL);
+				gamesnd_play_iface(InterfaceSounds::SCROLL);
 			} else {
-				gamesnd_play_iface(SND_GENERAL_FAIL);
+				gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 			}
 
 			break;
@@ -847,7 +847,7 @@ int do_mouse_over_wing_slot(int block, int slot)
 		if ( ss_icon_being_carried() ) {
 
 			if ( ss_disabled_slot(block*MAX_WING_SLOTS+slot) ) {
-				gamesnd_play_iface(SND_ICON_DROP);
+				gamesnd_play_iface(InterfaceSounds::ICON_DROP);
 				return 0;
 			}
 
@@ -892,7 +892,7 @@ void ss_maybe_drop_icon()
 				ss_drop(Carried_ss_icon.from_slot, -1, -1, Carried_ss_icon.ship_class);
 			} else {
 				if ( ss_carried_icon_moved() ) {
-					gamesnd_play_iface(SND_ICON_DROP);
+					gamesnd_play_iface(InterfaceSounds::ICON_DROP);
 				}
 			}
 			ss_reset_carried_icon();
@@ -1815,7 +1815,7 @@ void start_ship_animation(int ship_class, int play_sound)
 	}
 
 //	if ( play_sound ) {
-		gamesnd_play_iface(SND_SHIP_ICON_CHANGE);
+		gamesnd_play_iface(InterfaceSounds::SHIP_ICON_CHANGE);
 //	}
 }
 
@@ -1864,7 +1864,7 @@ void commit_pressed()
 			int rc;
 			rc = create_wings();
 			if (rc != 0) {
-				gamesnd_play_iface(SND_GENERAL_FAIL);
+				gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 				return;
 			}
 		}
@@ -1927,7 +1927,7 @@ void commit_pressed()
 
 	// Goober5000 - no sound when skipping briefing
 	if (!(The_mission.flags[Mission::Mission_Flags::No_briefing]))
-		gamesnd_play_iface(SND_COMMIT_PRESSED);
+		gamesnd_play_iface(InterfaceSounds::COMMIT_PRESSED);
 
 	// save the player loadout
 	if ( !(Game_mode & GM_MULTIPLAYER) ) {
@@ -2023,7 +2023,7 @@ void pick_from_wing(int wb_num, int ws_num)
 		if ( !ss_disabled_slot(slot_index) ) {
 			ss_drop(Carried_ss_icon.from_slot, Carried_ss_icon.ship_class, slot_index, -1);
 			ss_reset_carried_icon();
-			gamesnd_play_iface(SND_ICON_DROP_ON_WING);
+			gamesnd_play_iface(InterfaceSounds::ICON_DROP_ON_WING);
 		}
 	}
 
@@ -3247,18 +3247,18 @@ void ss_synch_interface()
 }
 
 // exit: data changed flag
-int ss_swap_slot_slot(int from_slot, int to_slot, int *sound)
+int ss_swap_slot_slot(int from_slot, int to_slot, interface_snd_id *sound)
 {
 	int i, tmp;
 
 	if ( from_slot == to_slot ) {
-		*sound=SND_ICON_DROP_ON_WING;
+		*sound=InterfaceSounds::ICON_DROP_ON_WING;
 		return 0;
 	}
 
 	// ensure from_slot has a ship to pick up
 	if ( Wss_slots[from_slot].ship_class < 0 ) {
-		*sound=SND_ICON_DROP;
+		*sound=InterfaceSounds::ICON_DROP;
 		return 0;
 	}
 
@@ -3278,12 +3278,12 @@ int ss_swap_slot_slot(int from_slot, int to_slot, int *sound)
 		Wss_slots[to_slot].wep_count[i] = tmp;
 	}
 
-	*sound=SND_ICON_DROP_ON_WING;
+	*sound=InterfaceSounds::ICON_DROP_ON_WING;
 	return 1;
 }
 
 // exit: data changed flag
-int ss_dump_to_list(int from_slot, int to_list, int *sound)
+int ss_dump_to_list(int from_slot, int to_list, interface_snd_id *sound)
 {
 	int i;
 	wss_unit	*slot;
@@ -3294,7 +3294,7 @@ int ss_dump_to_list(int from_slot, int to_list, int *sound)
 
 	// ensure from_slot has a ship to pick up
 	if ( slot->ship_class < 0 ) {
-		*sound=SND_ICON_DROP;
+		*sound=InterfaceSounds::ICON_DROP;
 		return 0;
 	}
 
@@ -3311,12 +3311,12 @@ int ss_dump_to_list(int from_slot, int to_list, int *sound)
 		}
 	}
 
-	*sound=SND_ICON_DROP;
+	*sound=InterfaceSounds::ICON_DROP;
 	return 1;
 }
 
 // exit: data changed flag
-int ss_grab_from_list(int from_list, int to_slot, int *sound)
+int ss_grab_from_list(int from_list, int to_slot, interface_snd_id *sound)
 {
 	wss_unit        *slot;
 	int i, wep[MAX_SHIP_WEAPONS], wep_count[MAX_SHIP_WEAPONS];
@@ -3328,7 +3328,7 @@ int ss_grab_from_list(int from_list, int to_slot, int *sound)
 	// ensure that pool has ship
 	if ( Ss_pool[from_list] <= 0 )
 	{
-		*sound=SND_ICON_DROP;
+		*sound=InterfaceSounds::ICON_DROP;
 		return 0;
 	}
 
@@ -3347,12 +3347,12 @@ int ss_grab_from_list(int from_list, int to_slot, int *sound)
 		slot->wep_count[i] = wep_count[i];
 	}
 
-	*sound=SND_ICON_DROP_ON_WING;
+	*sound=InterfaceSounds::ICON_DROP_ON_WING;
 	return 1;
 }
                         
 // exit: data changed flag
-int ss_swap_list_slot(int from_list, int to_slot, int *sound)
+int ss_swap_list_slot(int from_list, int to_slot, interface_snd_id *sound)
 {
 	int i, wep[MAX_SHIP_WEAPONS], wep_count[MAX_SHIP_WEAPONS];
 	wss_unit        *slot;
@@ -3362,7 +3362,7 @@ int ss_swap_list_slot(int from_list, int to_slot, int *sound)
 	// ensure that pool has ship
 	if ( Ss_pool[from_list] <= 0 )
 	{
-		*sound=SND_ICON_DROP;
+		*sound=InterfaceSounds::ICON_DROP;
 		return 0;
 	}
 
@@ -3396,14 +3396,14 @@ int ss_swap_list_slot(int from_list, int to_slot, int *sound)
 		slot->wep_count[i] = wep_count[i];
 	}
 
-	*sound=SND_ICON_DROP_ON_WING;
+	*sound=InterfaceSounds::ICON_DROP_ON_WING;
 	return 1;
 }
                         
 void ss_apply(int mode, int from_slot, int from_list, int to_slot, int to_list,int player_index)
 {
 	int update=0;
-	int sound=-1;
+	interface_snd_id sound;
 
 	switch(mode){
 	case WSS_SWAP_SLOT_SLOT:
@@ -3421,7 +3421,7 @@ void ss_apply(int mode, int from_slot, int from_list, int to_slot, int to_list,i
 	}
 
 	// only play this sound if the move was done locally (by the host in other words)
-	if ( (sound >= 0) && (player_index == -1) ) {
+	if ( (sound.isValid()) && (player_index == -1) ) {
 		gamesnd_play_iface(sound);		
 	}
 

--- a/code/missionui/missionshipchoice.h
+++ b/code/missionui/missionshipchoice.h
@@ -12,6 +12,8 @@
 #ifndef __MISSIONSHIPCHOICE_H__
 #define __MISSIONSHIPCHOICE_H__
 
+#include "gamesnd/gamesnd.h"
+
 class p_object;
 
 ///////////////////////////////////////////////////////
@@ -93,10 +95,10 @@ void ss_synch_interface();
 void ss_make_slot_empty(int slot_index);
 void ss_make_slot_full(int slot_index);
 
-int ss_dump_to_list(int from_slot, int to_list, int *sound);
-int ss_swap_slot_slot(int from_slot, int to_slot, int *sound);
-int ss_grab_from_list(int from_list, int to_slot, int *sound);
-int ss_swap_list_slot(int from_list, int to_slot, int *sound);
+int ss_dump_to_list(int from_slot, int to_list, interface_snd_id *sound);
+int ss_swap_slot_slot(int from_slot, int to_slot, interface_snd_id *sound);
+int ss_grab_from_list(int from_list, int to_slot, interface_snd_id *sound);
+int ss_swap_list_slot(int from_list, int to_slot, interface_snd_id *sound);
 
 void ss_apply(int mode, int from_slot,int from_index,int to_slot,int to_index,int player_index = -1);
 void ss_drop(int from_slot,int from_index,int to_slot,int to_index,int player_index = -1);

--- a/code/missionui/missionweaponchoice.cpp
+++ b/code/missionui/missionweaponchoice.cpp
@@ -571,33 +571,33 @@ void weapon_button_do(int i)
 	switch ( i ) {
 			case WL_BUTTON_SCROLL_PRIMARY_UP:
 				if ( common_scroll_up_pressed(&Plist_start, Plist_size, 4) ) {
-					gamesnd_play_iface(SND_SCROLL);
+					gamesnd_play_iface(InterfaceSounds::SCROLL);
 				} else {
-					gamesnd_play_iface(SND_GENERAL_FAIL);
+					gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 				}
 			break;
 
 			case WL_BUTTON_SCROLL_PRIMARY_DOWN:
 				if ( common_scroll_down_pressed(&Plist_start, Plist_size, 4) ) {
-					gamesnd_play_iface(SND_SCROLL);
+					gamesnd_play_iface(InterfaceSounds::SCROLL);
 				} else {
-					gamesnd_play_iface(SND_GENERAL_FAIL);
+					gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 				}
 			break;
 
 			case WL_BUTTON_SCROLL_SECONDARY_UP:
 				if ( common_scroll_up_pressed(&Slist_start, Slist_size, 4) ) {
-					gamesnd_play_iface(SND_SCROLL);
+					gamesnd_play_iface(InterfaceSounds::SCROLL);
 				} else {
-					gamesnd_play_iface(SND_GENERAL_FAIL);
+					gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 				}
 			break;
 
 			case WL_BUTTON_SCROLL_SECONDARY_DOWN:
 				if ( common_scroll_down_pressed(&Slist_start, Slist_size, 4) ) {
-					gamesnd_play_iface(SND_SCROLL);
+					gamesnd_play_iface(InterfaceSounds::SCROLL);
 				} else {
-					gamesnd_play_iface(SND_GENERAL_FAIL);
+					gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 				}
 			break;
 
@@ -739,7 +739,7 @@ void wl_render_overhead_view(float frametime)
 	// check if ship class has changed and maybe play sound
 	if (Last_wl_ship_class != ship_class) {
 		if (Last_wl_ship_class != -1) {
-			gamesnd_play_iface(SND_ICON_DROP);
+			gamesnd_play_iface(InterfaceSounds::ICON_DROP);
 		}
 		Last_wl_ship_class = ship_class;
 		new_ship = 1;
@@ -2097,7 +2097,7 @@ void wl_dump_carried_icon()
 			wl_drop(Carried_wl_icon.from_bank, -1, -1, Carried_wl_icon.weapon_class, Carried_wl_icon.from_slot);
 		} else {
 			if ( wl_carried_icon_moved() ) {
-				gamesnd_play_iface(SND_ICON_DROP);
+				gamesnd_play_iface(InterfaceSounds::ICON_DROP);
 			}			
 		}
 
@@ -3336,7 +3336,7 @@ void start_weapon_animation(int weapon_class)
 	if ( weapon_class == Weapon_anim_class ) 
 		return;
 
-	gamesnd_play_iface(SND_WEAPON_ANIM_START);
+	gamesnd_play_iface(InterfaceSounds::WEAPON_ANIM_START);
 
 	//load a new animation if it's different to what's already playing
 	if(strcmp(Cur_Anim.filename, Weapon_info[weapon_class].anim_filename) != 0) {
@@ -3502,7 +3502,7 @@ void wl_saturate_bank(int ship_slot, int bank)
 //			1 -> data changed
 //       sound => gets filled with sound id to play
 // updated for specific bank by Goober5000
-int wl_swap_slot_slot(int from_bank, int to_bank, int ship_slot, int *sound, net_player *pl)
+int wl_swap_slot_slot(int from_bank, int to_bank, int ship_slot, interface_snd_id *sound, net_player *pl)
 {
 	wss_unit	*slot;
 	int class_mismatch_flag, forced_update;
@@ -3521,7 +3521,7 @@ int wl_swap_slot_slot(int from_bank, int to_bank, int ship_slot, int *sound, net
 	
 	// do nothing if swapping with self
 	if ( from_bank == to_bank ) {
-		*sound=SND_ICON_DROP_ON_WING;
+		*sound=InterfaceSounds::ICON_DROP_ON_WING;
 		return forced_update;	// no update
 	}
 
@@ -3579,7 +3579,7 @@ int wl_swap_slot_slot(int from_bank, int to_bank, int ship_slot, int *sound, net
 				Wl_pool[slot->wep[to_bank]] += slot->wep_count[to_bank];			// return to list
 				slot->wep[to_bank] = -1;											// remove from slot
 				slot->wep_count[to_bank] = 0;
-				*sound=SND_ICON_DROP;				// unless it changes later
+				*sound=InterfaceSounds::ICON_DROP;				// unless it changes later
 				forced_update = 1;					// because we can't return right away
 			}
 		}
@@ -3590,14 +3590,14 @@ int wl_swap_slot_slot(int from_bank, int to_bank, int ship_slot, int *sound, net
 		Wl_pool[slot->wep[from_bank]] += slot->wep_count[from_bank];		// return to list
 		slot->wep[from_bank] = -1;														// remove from slot
 		slot->wep_count[from_bank] = 0;
-		*sound=SND_ICON_DROP;
+		*sound=InterfaceSounds::ICON_DROP;
 		return 1;
 	}
 
 	// case 1: primaries (easy, even with ballistics, because ammo is always maximized)
 	if ( IS_BANK_PRIMARY(from_bank) && IS_BANK_PRIMARY(to_bank) ) {
 		wl_swap_weapons(ship_slot, from_bank, to_bank);
-		*sound=SND_ICON_DROP_ON_WING;
+		*sound=InterfaceSounds::ICON_DROP_ON_WING;
 		return 1;
 	}
 
@@ -3621,7 +3621,7 @@ int wl_swap_slot_slot(int from_bank, int to_bank, int ship_slot, int *sound, net
 			if ( source_can_give > 0 ) {			
 				slot->wep_count[to_bank] += source_can_give;		// add to dest
 				slot->wep_count[from_bank] -= source_can_give;	// take from source
-				*sound=SND_ICON_DROP_ON_WING;
+				*sound=InterfaceSounds::ICON_DROP_ON_WING;
 				return 1;
 			} else {
 				return forced_update;
@@ -3636,7 +3636,7 @@ int wl_swap_slot_slot(int from_bank, int to_bank, int ship_slot, int *sound, net
 			// put back some on list if required
 			wl_saturate_bank(ship_slot, from_bank);
 			wl_saturate_bank(ship_slot, to_bank);
-			*sound=SND_ICON_DROP_ON_WING;
+			*sound=InterfaceSounds::ICON_DROP_ON_WING;
 			return 1;
 		}
 	}
@@ -3648,7 +3648,7 @@ int wl_swap_slot_slot(int from_bank, int to_bank, int ship_slot, int *sound, net
 // exit: 0 -> no data changed
 //			1 -> data changed
 //       sound => gets filled with sound id to play
-int wl_dump_to_list(int from_bank, int to_list, int ship_slot, int *sound)
+int wl_dump_to_list(int from_bank, int to_list, int ship_slot, interface_snd_id *sound)
 {
 	wss_unit	*slot;
 
@@ -3665,7 +3665,7 @@ int wl_dump_to_list(int from_bank, int to_list, int ship_slot, int *sound)
 	Wl_pool[to_list] += slot->wep_count[from_bank];			// return to list
 	slot->wep[from_bank] = -1;										// remove from slot
 	slot->wep_count[from_bank] = 0;
-	*sound=SND_ICON_DROP;
+	*sound=InterfaceSounds::ICON_DROP;
 
 	return 1;
 }
@@ -3673,7 +3673,7 @@ int wl_dump_to_list(int from_bank, int to_list, int ship_slot, int *sound)
 // exit: 0 -> no data changed
 //			1 -> data changed
 //       sound => gets filled with sound id to play
-int wl_grab_from_list(int from_list, int to_bank, int ship_slot, int *sound, net_player *pl)
+int wl_grab_from_list(int from_list, int to_bank, int ship_slot, interface_snd_id *sound, net_player *pl)
 {
 	int update=0;
 	wss_unit	*slot;
@@ -3687,13 +3687,13 @@ int wl_grab_from_list(int from_list, int to_bank, int ship_slot, int *sound, net
 	if ( (IS_LIST_PRIMARY(from_list) && IS_BANK_SECONDARY(to_bank)) || (IS_LIST_SECONDARY(from_list) && IS_BANK_PRIMARY(to_bank)) )
 	{
 		// do nothing
-		*sound=SND_ICON_DROP;
+		*sound=InterfaceSounds::ICON_DROP;
 		return 0;
 	}
 
 	// ensure that dest bank exists
 	if ( slot->wep_count[to_bank] < 0 ) {
-		*sound=SND_ICON_DROP;
+		*sound=InterfaceSounds::ICON_DROP;
 		return 0;
 	}
 
@@ -3754,7 +3754,7 @@ int wl_grab_from_list(int from_list, int to_bank, int ship_slot, int *sound, net
 	slot->wep[to_bank] = from_list;
 	slot->wep_count[to_bank] = max_fit;
 
-	*sound=SND_ICON_DROP_ON_WING;
+	*sound=InterfaceSounds::ICON_DROP_ON_WING;
 
 	return update;
 }
@@ -3762,7 +3762,7 @@ int wl_grab_from_list(int from_list, int to_bank, int ship_slot, int *sound, net
 // exit: 0 -> no data changed
 //			1 -> data changed
 //       sound => gets filled with sound id to play
-int wl_swap_list_slot(int from_list, int to_bank, int ship_slot, int *sound, net_player *pl)
+int wl_swap_list_slot(int from_list, int to_bank, int ship_slot, interface_snd_id *sound, net_player *pl)
 {
 	wss_unit	*slot;
 
@@ -3774,7 +3774,7 @@ int wl_swap_list_slot(int from_list, int to_bank, int ship_slot, int *sound, net
 	// ensure that the banks are both of the same class
 	if ( (IS_LIST_PRIMARY(from_list) && IS_BANK_SECONDARY(to_bank)) || (IS_LIST_SECONDARY(from_list) && IS_BANK_PRIMARY(to_bank)) ) {
 		// do nothing
-		*sound=SND_ICON_DROP;
+		*sound=InterfaceSounds::ICON_DROP;
 		return 0;
 	}
 
@@ -3843,7 +3843,7 @@ int wl_swap_list_slot(int from_list, int to_bank, int ship_slot, int *sound, net
 	slot->wep[to_bank] = from_list;
 	slot->wep_count[to_bank] = max_fit;
 
-	*sound=SND_ICON_DROP_ON_WING;
+	*sound=InterfaceSounds::ICON_DROP_ON_WING;
 	return 1;
 }
 
@@ -3858,7 +3858,7 @@ void wl_synch_interface()
 int wl_apply(int mode,int from_bank,int from_list,int to_bank,int to_list,int ship_slot,int player_index, bool dont_play_sound)
 {
 	int update=0;
-	int sound=-1;
+	interface_snd_id sound;
 	net_player *pl;
 
 	// get the appropriate net player
@@ -3888,7 +3888,7 @@ int wl_apply(int mode,int from_bank,int from_list,int to_bank,int to_list,int sh
 	}
 
 	// only play this sound if the move was done locally (by the host in other words)
-	if ( (sound >= 0) && (player_index == -1) && !dont_play_sound) {	
+	if ( (sound.isValid()) && (player_index == -1) && !dont_play_sound) {
 		gamesnd_play_iface(sound);	
 	}	
 
@@ -4092,7 +4092,7 @@ void wl_apply_current_loadout_to_all_ships_in_current_wing()
 	}
 
 	// play sound
-	gamesnd_play_iface(SND_ICON_DROP_ON_WING);
+	gamesnd_play_iface(InterfaceSounds::ICON_DROP_ON_WING);
 
 	// display error messages
 	if (error_flag)

--- a/code/missionui/redalert.cpp
+++ b/code/missionui/redalert.cpp
@@ -246,13 +246,13 @@ void red_alert_button_pressed(int n)
 			// TODO: make call to campaign code to set correct mission for loading
 			// mission_campaign_play_previous_mission(Red_alert_precursor_mission);
 			if ( !mission_campaign_previous_mission() ) {
-				gamesnd_play_iface(SND_GENERAL_FAIL);
+				gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 				break;
 			}
 
 			gameseq_post_event(GS_EVENT_START_GAME);
 		} else {
-			gamesnd_play_iface(SND_GENERAL_FAIL);
+			gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 		}
 		break;
 	}
@@ -1063,7 +1063,7 @@ void red_alert_start_mission()
 
 			// throw down a sound here to make the warning seem ultra-important
 			// gamesnd_play_iface(SND_USER_SELECT);
-			snd_play(gamesnd_get_game_sound(SND_DIRECTIVE_COMPLETE));
+			snd_play(gamesnd_get_game_sound(GameSounds::DIRECTIVE_COMPLETE));
 		}
 	}
 }

--- a/code/model/model.h
+++ b/code/model/model.h
@@ -15,6 +15,7 @@
 #include "globalincs/globals.h"	// for NAME_LENGTH
 #include "globalincs/pstypes.h"
 #include "graphics/2d.h"
+#include "gamesnd/gamesnd.h"
 #include "object/object.h"
 #include "ship/ship_flags.h"
 #include "model/model_flags.h"
@@ -145,16 +146,16 @@ public:
 	vec3d	turret_firing_point[MAX_TFP];		//	in parent object's reference frame, point from which to fire.
 	int		turret_gun_sobj;					// Which subobject in this model the firing points are linked to.
 	float	turret_turning_rate;				// How fast the turret turns. Read from ships.tbl
-	int		turret_base_rotation_snd;				// Sound to make when the turret moves
+	gamesnd_id	turret_base_rotation_snd;				// Sound to make when the turret moves
 	float	turret_base_rotation_snd_mult;			// Volume multiplier for the turret sounds
-	int		turret_gun_rotation_snd;				// Sound to make when the turret moves
+	gamesnd_id		turret_gun_rotation_snd;				// Sound to make when the turret moves
 	float	turret_gun_rotation_snd_mult;			// Volume multiplier for the turret sounds
 
 
 	//Sound stuff
-	int		alive_snd;		//Sound to make while the subsystem is not-dead
-	int		dead_snd;		//Sound to make when the subsystem is dead.
-	int		rotation_snd;	//Sound to make when the subsystem is rotating. (ie turrets)
+	gamesnd_id	alive_snd;		//Sound to make while the subsystem is not-dead
+	gamesnd_id	dead_snd;		//Sound to make when the subsystem is dead.
+	gamesnd_id	rotation_snd;	//Sound to make when the subsystem is rotating. (ie turrets)
 
 	// engine wash info
 	struct engine_wash_info		*engine_wash_pointer;					// index into Engine_wash_info

--- a/code/model/modelanim.cpp
+++ b/code/model/modelanim.cpp
@@ -97,7 +97,7 @@ void triggered_rotation::start(queued_animation *q)
 
 	nprintf(("ModelAnim", "Starting animation type %i at %i ...\n", q->type, timestamp()));
 
-	current_snd = -2;
+	current_snd = gamesnd_id();
 	current_snd_index = start_sound = q->start_sound;
 	loop_sound = q->loop_sound;
 	end_sound = q->end_sound;
@@ -194,11 +194,11 @@ void triggered_rotation::clear()
 	n_queue = 0;
 	instance = -1;
 	has_started = false;
-	start_sound = -1;
-	loop_sound = -1;
-	end_sound = -1;
-	current_snd = -1;
-	current_snd_index = -1;
+	start_sound = gamesnd_id();
+	loop_sound = gamesnd_id();
+	end_sound = gamesnd_id();
+	current_snd = gamesnd_id();
+	current_snd_index = gamesnd_id();
 	snd_rad = 0.0;
 	obj_num = -1;
 }
@@ -363,9 +363,9 @@ void queued_animation_init(queued_animation *qa)
 	qa->instance = -1;
 	qa->real_end_time = 0;
 
-	qa->start_sound = -1;
-	qa->loop_sound = -1;
-	qa->end_sound = -1;
+	qa->start_sound = gamesnd_id();
+	qa->loop_sound = gamesnd_id();
+	qa->end_sound = gamesnd_id();
 	qa->snd_rad = 0.0f;
 }
 

--- a/code/model/modelanim.h
+++ b/code/model/modelanim.h
@@ -70,9 +70,9 @@ struct queued_animation {
 	int instance;
 	int real_end_time;
 
-	int start_sound;
-	int loop_sound;
-	int end_sound;
+	gamesnd_id start_sound;
+	gamesnd_id loop_sound;
+	gamesnd_id end_sound;
 	float snd_rad;
 
 	char sub_name[NAME_LENGTH];
@@ -96,11 +96,11 @@ struct trigger_instance{
 class triggered_rotation
 {
 	private:
-		int start_sound;
-		int loop_sound;
-		int end_sound;
-		int current_snd;
-		int current_snd_index;
+		gamesnd_id start_sound;
+		gamesnd_id loop_sound;
+		gamesnd_id end_sound;
+		gamesnd_id current_snd;
+		gamesnd_id current_snd_index;
 		float snd_rad;
 		int obj_num;
 

--- a/code/model/modelread.cpp
+++ b/code/model/modelread.cpp
@@ -4033,7 +4033,7 @@ int model_rotate_gun(int model_num, model_subsystem *turret, matrix *orient, ang
 	base_delta = vm_interp_angle(&base_angles->h, desired_angles.h, step_size, limited_base_rotation);
 	gun_delta = vm_interp_angle(&gun_angles->p, desired_angles.p, step_size);
 
-	if (turret->turret_base_rotation_snd != -1)	
+	if (turret->turret_base_rotation_snd.isValid())
 	{
 		if (step_size > 0)
 		{
@@ -4044,7 +4044,7 @@ int model_rotate_gun(int model_num, model_subsystem *turret, matrix *orient, ang
 		}
 	}
 
-	if (turret->turret_gun_rotation_snd != -1)
+	if (turret->turret_gun_rotation_snd.isValid())
 	{
 		if (step_size > 0)
 		{
@@ -5853,14 +5853,14 @@ void model_subsystem::reset()
         it->xyz.x = it->xyz.y = it->xyz.z = 0.0f;
     turret_gun_sobj = 0;
     turret_turning_rate = 0;
-    turret_base_rotation_snd = 0;
+    turret_base_rotation_snd = gamesnd_id();
     turret_base_rotation_snd_mult = 0;
-    turret_gun_rotation_snd = 0;
+    turret_gun_rotation_snd = gamesnd_id();
     turret_gun_rotation_snd_mult = 0;
 
-    alive_snd = 0;
-    dead_snd = 0;
-    rotation_snd = 0;
+    alive_snd = gamesnd_id();
+    dead_snd = gamesnd_id();
+    rotation_snd = gamesnd_id();
 
     engine_wash_pointer = NULL;
     turn_rate = 0; 

--- a/code/nebula/neblightning.cpp
+++ b/code/nebula/neblightning.cpp
@@ -15,6 +15,7 @@
 #include "gamesnd/gamesnd.h"
 #include "globalincs/linklist.h"
 #include "io/timer.h"
+#include "mission/missionparse.h"
 #include "nebula/neb.h"
 #include "nebula/neblightning.h"
 #include "network/multi.h"
@@ -440,9 +441,9 @@ void nebl_render_all()
 							bang = 1.0f - (Nebl_bang / 400.0f);
 						}
 						if(frand_range(0.0f, 1.0f) < 0.5f){
-							snd_play(gamesnd_get_game_sound(SND_LIGHTNING_2), 0.0f, bang, SND_PRIORITY_DOUBLE_INSTANCE);
+							snd_play(gamesnd_get_game_sound(GameSounds::LIGHTNING_2), 0.0f, bang, SND_PRIORITY_DOUBLE_INSTANCE);
 						} else {
-							snd_play(gamesnd_get_game_sound(SND_LIGHTNING_1), 0.0f, bang, SND_PRIORITY_DOUBLE_INSTANCE);
+							snd_play(gamesnd_get_game_sound(GameSounds::LIGHTNING_1), 0.0f, bang, SND_PRIORITY_DOUBLE_INSTANCE);
 						}
 
 						// apply em pulse

--- a/code/network/multi_ingame.cpp
+++ b/code/network/multi_ingame.cpp
@@ -692,13 +692,13 @@ void multi_ingame_ship_list_process()
 
 	// if we currently don't have any ships selected, but we've got items on the list, select the first one
 	if((Multi_ingame_ship_selected == -1) && (Multi_ingame_num_avail > 0)){
-		gamesnd_play_iface(SND_USER_SELECT);
+		gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 		Multi_ingame_ship_selected = 0;
 	}
 
 	// if we currently have a ship selected, but it disappears, select the next ship (is possible0
 	if((Multi_ingame_ship_selected >= 0) && (Multi_ingame_ship_selected >= Multi_ingame_num_avail)){
-		gamesnd_play_iface(SND_USER_SELECT);
+		gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 		Multi_ingame_ship_selected = Multi_ingame_num_avail-1;
 	}
 	
@@ -711,7 +711,7 @@ void multi_ingame_ship_list_process()
 		if((select_index >= 0) && (select_index < Multi_ingame_num_avail)){
 			// if we're not selected the same item, play a sound
 			if(Multi_ingame_ship_selected != select_index){
-				gamesnd_play_iface(SND_USER_SELECT);
+				gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 			}
 
 			// select the item
@@ -751,7 +751,7 @@ void multi_ingame_join_button_pressed(int n)
 		if(Multi_ingame_join_sig == 0) {
 			// if he has a valid ship selected
 			if(Multi_ingame_ship_selected >= 0) {
-				gamesnd_play_iface(SND_USER_SELECT);
+				gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 			
 				// select the sig of this ship and send a request for it
 				Multi_ingame_join_sig = Multi_ingame_ship_sigs[Multi_ingame_ship_selected];
@@ -759,10 +759,10 @@ void multi_ingame_join_button_pressed(int n)
 				// send a request to the
 				send_ingame_ship_request_packet(INGAME_SR_REQUEST,Multi_ingame_join_sig);
 			} else {
-				gamesnd_play_iface(SND_GENERAL_FAIL);
+				gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 			}
 		} else {
-			gamesnd_play_iface(SND_GENERAL_FAIL);
+			gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 		}
 
 		break;
@@ -918,10 +918,10 @@ void multi_ingame_join_display_avail()
 void multi_ingame_scroll_select_up()
 {
 	if(Multi_ingame_ship_selected > 0){
-		gamesnd_play_iface(SND_USER_SELECT);
+		gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 		Multi_ingame_ship_selected--;
 	} else {
-		gamesnd_play_iface(SND_GENERAL_FAIL);
+		gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 	}	
 }
 
@@ -929,10 +929,10 @@ void multi_ingame_scroll_select_up()
 void multi_ingame_scroll_select_down()
 {
 	if(Multi_ingame_ship_selected < (Multi_ingame_num_avail - 1)){
-		gamesnd_play_iface(SND_USER_SELECT);
+		gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 		Multi_ingame_ship_selected++;
 	} else {
-		gamesnd_play_iface(SND_GENERAL_FAIL);
+		gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 	}
 }
 

--- a/code/network/multi_pinfo.cpp
+++ b/code/network/multi_pinfo.cpp
@@ -226,7 +226,7 @@ void multi_pinfo_popup(net_player *np)
 	Assert(np != NULL);	
 
 	// play the popup appear sound
-	gamesnd_play_iface(SND_POPUP_APPEAR);
+	gamesnd_play_iface(InterfaceSounds::POPUP_APPEAR);
 
 	// initialize the popup
 	multi_pinfo_popup_init(np);
@@ -241,7 +241,7 @@ void multi_pinfo_popup(net_player *np)
 	multi_pinfo_popup_close();
 
 	// play the popup disappear sound
-	gamesnd_play_iface(SND_POPUP_DISAPPEAR);
+	gamesnd_play_iface(InterfaceSounds::POPUP_DISAPPEAR);
 }
 
 // notify the popup that a player has left
@@ -603,32 +603,32 @@ void multi_pinfo_popup_button_pressed(int n)
 		break;
 
 	case MPI_MEDALS:
-		gamesnd_play_iface(SND_USER_SELECT);
+		gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 		multi_pinfo_do_medals();
 		break;
 
 	case MPI_SCROLL_STATS_UP:
 		swap = multi_pinfo_get_prev_player(Multi_pinfo_popup_player);
 		if(swap != NULL){
-			gamesnd_play_iface(SND_USER_SELECT);
+			gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 			multi_pinfo_reset_player(swap);
 		} else {
-			gamesnd_play_iface(SND_GENERAL_FAIL);
+			gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 		}
 		break;
 
 	case MPI_SCROLL_STATS_DOWN:
 		swap = multi_pinfo_get_next_player(Multi_pinfo_popup_player);
 		if(swap != NULL){
-			gamesnd_play_iface(SND_USER_SELECT);
+			gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 			multi_pinfo_reset_player(swap);
 		} else {
-			gamesnd_play_iface(SND_GENERAL_FAIL);
+			gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 		}
 		break;
 
 	default :
-		gamesnd_play_iface(SND_GENERAL_FAIL);
+		gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 		break;
 	}
 }

--- a/code/network/multi_pmsg.cpp
+++ b/code/network/multi_pmsg.cpp
@@ -38,7 +38,7 @@
 #define MULTI_MSG_KEYDOWN_WAIT				325							// in ms
 
 // sound to play before displaying incoming text messages in-mission
-#define MULTI_MSG_TEXT_SOUND					SND_CUE_VOICE
+#define MULTI_MSG_TEXT_SOUND					GameSounds::CUE_VOICE
 
 // max length of a string we'll allow players to send
 #define MULTI_MSG_MAX_LEN						75

--- a/code/network/multi_pxo.cpp
+++ b/code/network/multi_pxo.cpp
@@ -1367,7 +1367,7 @@ void multi_pxo_do_normal()
 	switch (k)
 	{
 		case KEY_ESC:
-			gamesnd_play_iface(SND_USER_SELECT);
+			gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 			gameseq_post_event(GS_EVENT_MAIN_MENU);
 			break;	
 	}		
@@ -1685,7 +1685,7 @@ void multi_pxo_button_pressed(int n)
 {
 	switch(n){
 	case MULTI_PXO_EXIT:
-		gamesnd_play_iface(SND_USER_SELECT);
+		gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 		gameseq_post_event(GS_EVENT_MAIN_MENU);
 		break;
 
@@ -1718,18 +1718,18 @@ void multi_pxo_button_pressed(int n)
 	case MULTI_PXO_JOIN:
 		// if there are no channels to join, let the user know
 		if((Multi_pxo_channel_count == 0) || (Multi_pxo_channels == NULL)){
-			gamesnd_play_iface(SND_GENERAL_FAIL);
+			gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 			multi_pxo_notify_add(XSTR("No channels!",944));
 			break;
 		}
 
 		// if we're not already trying to join, allow this
 		if(!SWITCHING_CHANNELS() && (Multi_pxo_channel_select != NULL)){
-			gamesnd_play_iface(SND_USER_SELECT);
+			gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 			multi_pxo_join_channel(Multi_pxo_channel_select);
 		} else {
 			multi_pxo_notify_add(XSTR("Already trying to join a channel!",945));
-			gamesnd_play_iface(SND_GENERAL_FAIL);
+			gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 		}
 		break;
 
@@ -1741,25 +1741,25 @@ void multi_pxo_button_pressed(int n)
 	case MULTI_PXO_JOIN_PRIV:
 		// if we're not already trying to join, allow this
 		if(!SWITCHING_CHANNELS()){
-			gamesnd_play_iface(SND_USER_SELECT);
+			gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 
 			// fire up the private join popup
 			multi_pxo_priv_popup();
 		} else {
 			multi_pxo_notify_add(XSTR("Already trying to join a channel!",945));
-			gamesnd_play_iface(SND_GENERAL_FAIL);
+			gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 		}		
 		break;
 
 	case MULTI_PXO_FIND:
-		gamesnd_play_iface(SND_USER_SELECT);
+		gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 
 		// fire up the find join popup
 		multi_pxo_find_popup();
 		break;
 
 	case MULTI_PXO_HELP:
-		gamesnd_play_iface(SND_USER_SELECT);
+		gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 		gameseq_post_event(GS_EVENT_PXO_HELP);
 		break;
 
@@ -1780,14 +1780,14 @@ void multi_pxo_button_pressed(int n)
 				popup(PF_USE_AFFIRMATIVE_ICON,1,POPUP_OK,stats);
 			}
 		} else {
-			gamesnd_play_iface(SND_GENERAL_FAIL);
+			gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 		}
 		break;
 
 	case MULTI_PXO_RANKINGS:		
 		// make sure he doesn't click it too many times
 		if((Multi_pxo_ranking_last < 0.0f) || ((f2fl(timer_get_fixed_seconds()) - Multi_pxo_ranking_last) > MULTI_PXO_RANK_TIME) ){
-			gamesnd_play_iface(SND_USER_SELECT);
+			gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 			
 			// fire up the url
 			multi_pxo_url(Multi_options_g.pxo_rank_url);
@@ -1795,7 +1795,7 @@ void multi_pxo_button_pressed(int n)
 			// mark the time down
 			Multi_pxo_ranking_last = f2fl(timer_get_fixed_seconds());
 		} else {
-			gamesnd_play_iface(SND_GENERAL_FAIL);
+			gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 		}
 		break;
 
@@ -2560,14 +2560,14 @@ void multi_pxo_scroll_channels_up()
 {		
 	// if we're already at the head of the list, do nothing
 	if((Multi_pxo_channel_start == NULL) || (Multi_pxo_channel_start == Multi_pxo_channels)){
-		gamesnd_play_iface(SND_GENERAL_FAIL);		
+		gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 		return;
 	}
 	
 	// otherwise move up one
 	Multi_pxo_channel_start = Multi_pxo_channel_start->prev;
 	Multi_pxo_channel_start_index--;
-	gamesnd_play_iface(SND_USER_SELECT);
+	gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 }
 
 /**
@@ -2577,20 +2577,20 @@ void multi_pxo_scroll_channels_down()
 {
 	// if we're already at the tail of the list, do nothing
 	if((Multi_pxo_channel_start == NULL) || (Multi_pxo_channel_start->next == Multi_pxo_channels)){
-		gamesnd_play_iface(SND_GENERAL_FAIL);
+		gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 		return;
 	}
 
 	// if we can't scroll further without going past the end of the viewable list, don't
 	if((Multi_pxo_channel_start_index + Multi_pxo_max_chan_display[gr_screen.res]) >= Multi_pxo_channel_count){
-		gamesnd_play_iface(SND_GENERAL_FAIL);
+		gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 		return;
 	}
 
 	// otherwise move down one
 	Multi_pxo_channel_start = Multi_pxo_channel_start->next;
 	Multi_pxo_channel_start_index++;
-	gamesnd_play_iface(SND_USER_SELECT);
+	gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 }
 
 /**
@@ -2970,14 +2970,14 @@ void multi_pxo_scroll_players_up()
 {
 	// if we're already at the head of the list, do nothing
 	if((Multi_pxo_player_start == NULL) || (Multi_pxo_player_start == Multi_pxo_players)){
-		gamesnd_play_iface(SND_GENERAL_FAIL);		
+		gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 		return;
 	}
 	
 	// otherwise move up one
 	Multi_pxo_player_start = Multi_pxo_player_start->prev;	
 
-	gamesnd_play_iface(SND_USER_SELECT);
+	gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 }
 
 /**
@@ -2991,7 +2991,7 @@ void multi_pxo_scroll_players_down()
 	// see if its okay to scroll down
 	lookup = Multi_pxo_player_start;
 	if(lookup == NULL ){
-		gamesnd_play_iface(SND_GENERAL_FAIL);
+		gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 		return;
 	}
 	count = 0;
@@ -3003,9 +3003,9 @@ void multi_pxo_scroll_players_down()
 	// if we can move down
 	if(count >= Multi_pxo_max_player_display[gr_screen.res]){
 		Multi_pxo_player_start = Multi_pxo_player_start->next;
-		gamesnd_play_iface(SND_USER_SELECT);
+		gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 	} else {
-		gamesnd_play_iface(SND_GENERAL_FAIL);
+		gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 	}	
 }
 
@@ -3369,7 +3369,7 @@ void multi_pxo_scroll_chat_up()
 {
 	// if we're already at the top of the list, don't do anything	
 	if ((Multi_pxo_chat_start == NULL) || (Multi_pxo_chat_start == Multi_pxo_chat)) {
-		gamesnd_play_iface(SND_GENERAL_FAIL);
+		gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 		return;
 	}
 
@@ -3378,7 +3378,7 @@ void multi_pxo_scroll_chat_up()
 
 	multi_pxo_chat_adjust_start();	
 	
-	gamesnd_play_iface(SND_USER_SELECT);
+	gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 }
 
 /**
@@ -3417,9 +3417,9 @@ void multi_pxo_scroll_chat_down()
 	if (multi_pxo_can_scroll_down()) {
 		Multi_pxo_chat_start = Multi_pxo_chat_start->next;		
 		multi_pxo_chat_adjust_start();	
-		gamesnd_play_iface(SND_USER_SELECT);
+		gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 	} else {
-		gamesnd_play_iface(SND_GENERAL_FAIL);
+		gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 	}
 }
 
@@ -4847,7 +4847,7 @@ void multi_pxo_help_do()
 	// process any keypresses
 	switch(k){
 	case KEY_ESC:
-		gamesnd_play_iface(SND_USER_SELECT);
+		gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 		gameseq_post_event(GS_EVENT_PXO);
 		break;
 	}		
@@ -5001,25 +5001,25 @@ void multi_pxo_help_button_pressed(int n)
 	case MULTI_PXO_HELP_PREV:
 		// if we're already at page 0, do nothing
 		if(Multi_pxo_help_cur == 0){
-			gamesnd_play_iface(SND_GENERAL_FAIL);			
+			gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 		} else {
 			Multi_pxo_help_cur--;
-			gamesnd_play_iface(SND_USER_SELECT);
+			gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 		}
 		break;
 
 	case MULTI_PXO_HELP_NEXT:
 		// if we're already at max pages, do nothing
 		if(Multi_pxo_help_cur == Multi_pxo_help_num_pages){
-			gamesnd_play_iface(SND_GENERAL_FAIL);
+			gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 		} else {
 			Multi_pxo_help_cur++;
-			gamesnd_play_iface(SND_USER_SELECT);
+			gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 		}
 		break;
 
 	case MULTI_PXO_HELP_CONTINUE:
-		gamesnd_play_iface(SND_USER_SELECT);
+		gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 		gameseq_post_event(GS_EVENT_PXO);
 		break;
 	}

--- a/code/network/multimsgs.cpp
+++ b/code/network/multimsgs.cpp
@@ -942,7 +942,7 @@ void process_join_packet(ubyte* data, header* hinfo)
 		case JOIN_QUERY_RESTRICTED :		
 			if(!(Game_mode & GM_STANDALONE_SERVER)){			
 				// notify the host of the event
-				snd_play(gamesnd_get_game_sound(SND_CUE_VOICE));
+				snd_play(gamesnd_get_game_sound(GameSounds::CUE_VOICE));
 			}
 
 			// set the query timestamp
@@ -3335,7 +3335,7 @@ void process_turret_fired_packet( ubyte *data, header *hinfo )
 
 	if (weapon_objnum != -1) {
 		wid = Weapons[Objects[weapon_objnum].instance].weapon_info_index;
-		if ( Weapon_info[wid].launch_snd != -1 ) {
+		if ( Weapon_info[wid].launch_snd.isValid() ) {
 			snd_play_3d( gamesnd_get_game_sound(Weapon_info[wid].launch_snd), &pos, &View_position );
 		}		
 	}
@@ -6865,7 +6865,7 @@ void process_host_restr_packet(ubyte *data, header *hinfo)
 			Multi_restr_query_timestamp = timestamp(MULTI_QUERY_RESTR_STAMP);
 
 			// notify the host of the event
-			gamesnd_play_iface(SND_BRIEF_STAGE_CHG_FAIL);
+			gamesnd_play_iface(InterfaceSounds::BRIEF_STAGE_CHG_FAIL);
 			HUD_printf(XSTR("Player %s has tried to join - allow (y/n) ?",736),callsign);
 			break;
 			
@@ -8140,7 +8140,7 @@ void process_flak_fired_packet(ubyte *data, header *hinfo)
 	weapon_objnum = weapon_create( &pos, &orient, wid, OBJ_INDEX(objp), -1, 1, 0, 0.0f, ssp);
 	if (weapon_objnum != -1) {
 		wid = Weapons[Objects[weapon_objnum].instance].weapon_info_index;
-		if ( Weapon_info[wid].launch_snd != -1 ) {
+		if ( Weapon_info[wid].launch_snd.isValid() ) {
 			snd_play_3d( gamesnd_get_game_sound(Weapon_info[wid].launch_snd), &pos, &View_position );
 		}
 

--- a/code/network/multiteamselect.cpp
+++ b/code/network/multiteamselect.cpp
@@ -437,10 +437,10 @@ int multi_ts_can_perform(int from_type,int from_index,int to_type,int to_index,i
 int multi_ts_get_dnd_type(int from_type,int from_index,int to_type,int to_index,int player_index = -1);
 
 // swap two player positions
-int multi_ts_swap_player_player(int from_index,int to_index,int *sound,int player_index = -1);
+int multi_ts_swap_player_player(int from_index,int to_index,interface_snd_id *sound,int player_index = -1);
 
 // move a player
-int multi_ts_move_player(int from_index,int to_index,int *sound,int player_index = -1);
+int multi_ts_move_player(int from_index,int to_index,interface_snd_id *sound,int player_index = -1);
 
 // get the ship class of the current index in the avail list or -1 if none exists
 int multi_ts_get_avail_ship_class(int index);
@@ -573,13 +573,13 @@ void multi_ts_do()
 	// process any keypresses
 	switch(k){
 	case KEY_ESC :		
-		gamesnd_play_iface(SND_USER_SELECT);
+		gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 		multi_quit_game(PROMPT_ALL);
 		break;	
 
 	// cycle to the weapon select screen
 	case KEY_TAB :
-		gamesnd_play_iface(SND_USER_SELECT);
+		gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 		Next_screen = ON_WEAPON_SELECT;
 		gameseq_post_event(GS_EVENT_WEAPON_SELECTION);
 		break;
@@ -1028,7 +1028,7 @@ void multi_ts_lock_pressed()
 {
 	// do nothing if the button has already been pressed
 	if(multi_ts_is_locked()){
-		gamesnd_play_iface(SND_GENERAL_FAIL);
+		gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 		return;
 	}
 	
@@ -1037,10 +1037,10 @@ void multi_ts_lock_pressed()
 	} else {
 		Assert(Net_player->flags & NETINFO_FLAG_GAME_HOST);
 	}
-	gamesnd_play_iface(SND_USER_SELECT);
+	gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 
 	// send a final player slot update packet		
-	send_pslot_update_packet(Net_player->p_info.team,TS_CODE_LOCK_TEAM,-1);				
+	send_pslot_update_packet(Net_player->p_info.team,TS_CODE_LOCK_TEAM, interface_snd_id());
 	Multi_ts_team[Net_player->p_info.team].multi_players_locked = 1;
 
 	// sync interface stuff
@@ -1100,17 +1100,17 @@ void multi_ts_button_pressed(int n)
 	switch(n){
 	// back to the briefing screen
 	case MULTI_TS_BRIEFING :
-		gamesnd_play_iface(SND_USER_SELECT);
+		gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 		Next_screen = ON_BRIEFING_SELECT;
 		gameseq_post_event( GS_EVENT_START_BRIEFING );
 		break;
 	// already on this screen
 	case MULTI_TS_SHIP_SELECT:
-		gamesnd_play_iface(SND_GENERAL_FAIL);
+		gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 		break;
 	// back to the weapon select screen
 	case MULTI_TS_WEAPON_SELECT:
-		gamesnd_play_iface(SND_USER_SELECT);
+		gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 		Next_screen = ON_WEAPON_SELECT;
 		gameseq_post_event(GS_EVENT_WEAPON_SELECTION);
 		break;
@@ -1139,7 +1139,7 @@ void multi_ts_button_pressed(int n)
 		Commit_pressed = 1;
 		break;
 	default :
-		gamesnd_play_iface(SND_GENERAL_FAIL);		
+		gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 		break;
 	}
 }
@@ -1793,10 +1793,10 @@ void multi_ts_init_flags()
 void multi_ts_avail_scroll_down()
 {	
 	if((Multi_ts_avail_count - Multi_ts_avail_start) > MULTI_TS_AVAIL_MAX_DISPLAY){
-		gamesnd_play_iface(SND_USER_SELECT);
+		gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 		Multi_ts_avail_start++;		
 	} else {
-		gamesnd_play_iface(SND_GENERAL_FAIL);
+		gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 	}
 }
 
@@ -1804,10 +1804,10 @@ void multi_ts_avail_scroll_down()
 void multi_ts_avail_scroll_up()
 {
 	if(Multi_ts_avail_start > 0){
-		gamesnd_play_iface(SND_USER_SELECT);
+		gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 		Multi_ts_avail_start--;		
 	} else {
-		gamesnd_play_iface(SND_GENERAL_FAIL);
+		gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 	}
 }
 
@@ -1866,7 +1866,7 @@ void multi_ts_handle_mouse()
 	switch(region_type){
 	case MULTI_TS_PLAYER_LIST:
 		if((Multi_ts_hotspot_index != region_index) && (region_index >= 0) && (Multi_ts_team[Net_player->p_info.team].multi_ts_player[region_index] != NULL)){
-			gamesnd_play_iface(SND_USER_SELECT);			
+			gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 		}
 		break;
 	}
@@ -2195,7 +2195,7 @@ int multi_ts_get_dnd_type(int from_type,int from_index,int to_type,int to_index,
 
 void multi_ts_apply(int from_type,int from_index,int to_type,int to_index,int ship_class,int player_index)
 {
-	int size,update,sound;
+	int size,update;
 	ubyte wss_data[MAX_PACKET_SIZE-20];	
 	net_player *pl;
 	
@@ -2212,7 +2212,7 @@ void multi_ts_apply(int from_type,int from_index,int to_type,int to_index,int sh
 	// set the proper pool pointers
 	common_set_team_pointers(pl->p_info.team);
 
-	sound = -1;
+	interface_snd_id sound;
 	switch(type){
 	case TS_SWAP_SLOT_SLOT :
 		nprintf(("Network","Apply swap slot slot %d %d\n",from_index,to_index));
@@ -2253,11 +2253,11 @@ void multi_ts_apply(int from_type,int from_index,int to_type,int to_index,int sh
 				send_wss_update_packet(pl->p_info.team,wss_data, size);			
 
 				// send a player slot update packet as well, so ship class information, etc is kept correct
-				send_pslot_update_packet(pl->p_info.team,TS_CODE_PLAYER_UPDATE,-1);				
+				send_pslot_update_packet(pl->p_info.team,TS_CODE_PLAYER_UPDATE, interface_snd_id());
 			}
 
 			// if the player index == -1, it means the action was done locally - so play a sound
-			if((player_index == -1) && (sound != -1)){
+			if((player_index == -1) && (sound.isValid())){
 				gamesnd_play_iface(sound);
 			}
 		}
@@ -2294,7 +2294,7 @@ void multi_ts_drop(int from_type,int from_index,int to_type,int to_index,int shi
 }
 
 // swap two player positions
-int multi_ts_swap_player_player(int from_index,int to_index,int *sound,int player_index)
+int multi_ts_swap_player_player(int from_index,int to_index,interface_snd_id *sound,int player_index)
 {
 	net_player *pl,*temp;
 
@@ -2341,17 +2341,17 @@ int multi_ts_swap_player_player(int from_index,int to_index,int *sound,int playe
 
 	// send an update packet to all players
 	if(Net_player->flags & NETINFO_FLAG_GAME_HOST){
-		send_pslot_update_packet(pl->p_info.team,TS_CODE_PLAYER_UPDATE,SND_ICON_DROP_ON_WING);
-		gamesnd_play_iface(SND_ICON_DROP_ON_WING);
+		send_pslot_update_packet(pl->p_info.team,TS_CODE_PLAYER_UPDATE,InterfaceSounds::ICON_DROP_ON_WING);
+		gamesnd_play_iface(InterfaceSounds::ICON_DROP_ON_WING);
 	}
 
-	*sound = SND_ICON_DROP;
+	*sound = InterfaceSounds::ICON_DROP;
 
 	return 1;
 }
 
 // move a player
-int multi_ts_move_player(int from_index,int to_index,int *sound,int player_index)
+int multi_ts_move_player(int from_index,int to_index,interface_snd_id *sound,int player_index)
 {
 	net_player *pl;
 
@@ -2397,11 +2397,11 @@ int multi_ts_move_player(int from_index,int to_index,int *sound,int player_index
 
 	// send an update packet to all players
 	if(Net_player->flags & NETINFO_FLAG_GAME_HOST){
-		send_pslot_update_packet(pl->p_info.team,TS_CODE_PLAYER_UPDATE,SND_ICON_DROP_ON_WING);
-		gamesnd_play_iface(SND_ICON_DROP_ON_WING);
+		send_pslot_update_packet(pl->p_info.team,TS_CODE_PLAYER_UPDATE,InterfaceSounds::ICON_DROP_ON_WING);
+		gamesnd_play_iface(InterfaceSounds::ICON_DROP_ON_WING);
 	}
 
-	*sound = SND_ICON_DROP;
+	*sound = InterfaceSounds::ICON_DROP;
 
 	return 1;
 }
@@ -2681,19 +2681,19 @@ void multi_ts_commit_pressed()
 
 	// player has not assigned all necessary ships
 	case 1: 	
-		gamesnd_play_iface(SND_GENERAL_FAIL);
+		gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 		popup(PF_USE_AFFIRMATIVE_ICON | PF_BODY_BIG,1,POPUP_OK, XSTR("You have not yet assigned all necessary ships",752));
 		break;
 	
 	// there are ships without primary weapons
 	case 2: 
-		gamesnd_play_iface(SND_GENERAL_FAIL);
+		gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 		popup(PF_USE_AFFIRMATIVE_ICON | PF_BODY_BIG,1,POPUP_OK, XSTR("There are ships without primary weapons!",753));
 		break;
 
 	// there are ships without secondary weapons
 	case 3: 
-		gamesnd_play_iface(SND_GENERAL_FAIL);
+		gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 		popup(PF_USE_AFFIRMATIVE_ICON | PF_BODY_BIG,1,POPUP_OK, XSTR("There are ships without secondary weapons!",754));
 		break;
 	}
@@ -2792,7 +2792,7 @@ void multi_ts_check_errors()
 //
 
 // send a player slot position update
-void send_pslot_update_packet(int team,int code,int sound)
+void send_pslot_update_packet(int team,int code, interface_snd_id sound)
 {
 	ubyte data[MAX_PACKET_SIZE],stop,val;
 	short s_sound;
@@ -2812,7 +2812,7 @@ void send_pslot_update_packet(int team,int code,int sound)
 	ADD_DATA(val);
 
 	// add the sound to play
-	s_sound = (short)sound;
+	s_sound = (short)sound.value();
 	ADD_SHORT(s_sound);
 	
 	// add data based upon the packet code
@@ -2894,7 +2894,7 @@ void process_pslot_update_packet(ubyte *data, header *hinfo)
 	int offset = HEADER_LENGTH;
 	int my_index;
 	int player_index,idx,team,code,objnum;
-	short sound;
+	short sound_id;
 	short player_id;
 	ubyte stop,val,slot_num,ship_class;
 
@@ -2917,7 +2917,8 @@ void process_pslot_update_packet(ubyte *data, header *hinfo)
 	team = (int)val;
 
 	// get the sound to play
-	GET_SHORT(sound);
+	GET_SHORT(sound_id);
+	auto sound = interface_snd_id(sound_id);
 
 	// process the different opcodes
 	switch(code){
@@ -3013,7 +3014,7 @@ void process_pslot_update_packet(ubyte *data, header *hinfo)
 			GET_DATA(stop);
 		}
 		// if we have a sound we're supposed to play
-		if((sound != -1) && !(Game_mode & GM_STANDALONE_SERVER) && (gameseq_get_state() == GS_STATE_TEAM_SELECT)){
+		if((sound.isValid()) && !(Game_mode & GM_STANDALONE_SERVER) && (gameseq_get_state() == GS_STATE_TEAM_SELECT)){
 			gamesnd_play_iface(sound);
 		}
 

--- a/code/network/multiteamselect.h
+++ b/code/network/multiteamselect.h
@@ -16,6 +16,7 @@
 // TEAM SELECT DEFINES/VARS
 //
 #include "globalincs/pstypes.h"
+#include "gamesnd/gamesnd.h"
 
 struct header;
 
@@ -92,7 +93,7 @@ void multi_ts_maybe_host_only_popup();
 //
 
 // send a player slot position update
-void send_pslot_update_packet(int team,int code,int sound = -1);
+void send_pslot_update_packet(int team,int code, interface_snd_id sound = interface_snd_id());
 
 // process a player slot position update
 void process_pslot_update_packet(ubyte *data, header *hinfo);

--- a/code/network/multiui.cpp
+++ b/code/network/multiui.cpp
@@ -122,10 +122,10 @@ void multi_common_scroll_text_up()
 	if ( Multi_common_top_text_line < 0 ) {
 		Multi_common_top_text_line = 0;
 		if ( !mouse_down(MOUSE_LEFT_BUTTON) )
-			gamesnd_play_iface(SND_GENERAL_FAIL);
+			gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 
 	} else {
-		gamesnd_play_iface(SND_SCROLL);
+		gamesnd_play_iface(InterfaceSounds::SCROLL);
 	}
 }
 
@@ -135,10 +135,10 @@ void multi_common_scroll_text_down()
 	if ( (Multi_common_num_text_lines - Multi_common_top_text_line) < Multi_common_text_max_display[gr_screen.res] ) {
 		Multi_common_top_text_line--;
 		if ( !mouse_down(MOUSE_LEFT_BUTTON) ){
-			gamesnd_play_iface(SND_GENERAL_FAIL);
+			gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 		}
 	} else {
-		gamesnd_play_iface(SND_SCROLL);
+		gamesnd_play_iface(InterfaceSounds::SCROLL);
 	}
 }
 
@@ -1046,7 +1046,7 @@ void multi_join_game_do_frame()
 			} else {
 				gameseq_post_event(GS_EVENT_MAIN_MENU);
 			}
-			gamesnd_play_iface(SND_USER_SELECT);
+			gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 		}
 		break;
 
@@ -1178,18 +1178,18 @@ void multi_join_button_pressed(int n)
 		} else {
 			gameseq_post_event(GS_EVENT_MAIN_MENU);
 		}
-		gamesnd_play_iface(SND_USER_SELECT);		
+		gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 		break;
 	case MJ_ACCEPT :
 		if(Active_game_count <= 0){
 			multi_common_add_notify(XSTR("No games found!",757));
-			gamesnd_play_iface(SND_GENERAL_FAIL);
+			gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 		} else if(Multi_join_list_selected == -1){
 			multi_common_add_notify(XSTR("No game selected!",758));
-			gamesnd_play_iface(SND_GENERAL_FAIL);
+			gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 		} else if((Multi_join_sent_stamp != -1) && !timestamp_elapsed(Multi_join_sent_stamp)){
 			multi_common_add_notify(XSTR("Still waiting on previous join request!",759));
-			gamesnd_play_iface(SND_GENERAL_FAIL);
+			gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 		} else {			
 			// otherwise, if he's already played PXO games, warn him	
 			
@@ -1206,7 +1206,7 @@ void multi_join_button_pressed(int n)
 			// send a join request packet
 			Multi_join_should_send = 0;			
 			
-			gamesnd_play_iface(SND_COMMIT_PRESSED);
+			gamesnd_play_iface(InterfaceSounds::COMMIT_PRESSED);
 		}
 		break;
 
@@ -1253,7 +1253,7 @@ void multi_join_button_pressed(int n)
 
 	// refresh the game/server list
 	case MJ_REFRESH:	
-		gamesnd_play_iface(SND_USER_SELECT);
+		gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 		broadcast_game_query();
 		break;
 
@@ -1261,26 +1261,26 @@ void multi_join_button_pressed(int n)
 	case MJ_JOIN_OBSERVER:
 		if(Active_game_count <= 0){
 			multi_common_add_notify(XSTR("No games found!",757));
-			gamesnd_play_iface(SND_GENERAL_FAIL);
+			gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 		} else if(Multi_join_list_selected == -1){
 			multi_common_add_notify(XSTR("No game selected!",758));
-			gamesnd_play_iface(SND_GENERAL_FAIL);
+			gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 		} else if((Multi_join_sent_stamp != -1) && !timestamp_elapsed(Multi_join_sent_stamp)){
 			multi_common_add_notify(XSTR("Still waiting on previous join request!",759));
-			gamesnd_play_iface(SND_GENERAL_FAIL);
+			gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 		} else {			
 			// send the join request here
 			Assert(Multi_join_selected_item != NULL);
 
 			Multi_join_should_send = 1;		
 
-			gamesnd_play_iface(SND_COMMIT_PRESSED);
+			gamesnd_play_iface(InterfaceSounds::COMMIT_PRESSED);
 		}
 		break;
 
 	default :
 		multi_common_add_notify(XSTR("Not implemented yet!",760));
-		gamesnd_play_iface(SND_GENERAL_FAIL);
+		gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 		break;
 	}
 }
@@ -1620,7 +1620,7 @@ void multi_join_process_select()
 		Multi_join_select_button.get_mouse_pos(NULL,&y);
 		item = y / line_height;
 		if(item + Multi_join_list_start < Active_game_count){		
-			gamesnd_play_iface(SND_IFACE_MOUSE_CLICK);
+			gamesnd_play_iface(InterfaceSounds::IFACE_MOUSE_CLICK);
 
 			Multi_join_list_selected = item + Multi_join_list_start;
 			Multi_join_selected_item = multi_join_get_game(Multi_join_list_selected);
@@ -1680,9 +1680,9 @@ void multi_join_list_scroll_up()
 		
 		MJ_LIST_START_DEC();		
 
-		gamesnd_play_iface(SND_SCROLL);
+		gamesnd_play_iface(InterfaceSounds::SCROLL);
 	} else {
-		gamesnd_play_iface(SND_GENERAL_FAIL);
+		gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 	}
 }
 
@@ -1694,9 +1694,9 @@ void multi_join_list_scroll_down()
 
 		MJ_LIST_START_INC();		
 
-		gamesnd_play_iface(SND_SCROLL);
+		gamesnd_play_iface(InterfaceSounds::SCROLL);
 	} else {
-		gamesnd_play_iface(SND_GENERAL_FAIL);
+		gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 	}
 }
 
@@ -1708,7 +1708,7 @@ void multi_join_list_page_up()
 
 		MJ_LIST_START_SET(0);
 
-		gamesnd_play_iface(SND_SCROLL);		
+		gamesnd_play_iface(InterfaceSounds::SCROLL);
 	} else {
 		// otherwise page the whole thing up
 		int idx;
@@ -1717,7 +1717,7 @@ void multi_join_list_page_up()
 
 			MJ_LIST_START_DEC();			
 		}
-		gamesnd_play_iface(SND_SCROLL);
+		gamesnd_play_iface(InterfaceSounds::SCROLL);
 	}
 }
 
@@ -1733,7 +1733,7 @@ void multi_join_list_page_down()
 		// next 
 		count++;
 	}	
-	gamesnd_play_iface(SND_SCROLL);	 
+	gamesnd_play_iface(InterfaceSounds::SCROLL);
 }
 
 void multi_join_cull_timeouts()
@@ -1975,7 +1975,7 @@ void multi_join_create_game()
 	}
 
 	gameseq_post_event(GS_EVENT_MULTI_START_GAME);
-	gamesnd_play_iface(SND_USER_SELECT);								
+	gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 }
 
 void multi_join_reset_join_stamp()
@@ -2419,7 +2419,7 @@ void multi_start_game_do()
 		if(help_overlay_active(Multi_sg_overlay_id)){
 			help_overlay_set_state(Multi_sg_overlay_id,gr_screen.res,0);
 		} else {
-			gamesnd_play_iface(SND_USER_SELECT);
+			gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 			multi_quit_game(PROMPT_NONE);
 		}
 		break;
@@ -2427,7 +2427,7 @@ void multi_start_game_do()
 	// same as ACCEPT
 	case KEY_LCTRL + KEY_ENTER :
 	case KEY_RCTRL + KEY_ENTER :		
-		gamesnd_play_iface(SND_COMMIT_PRESSED);
+		gamesnd_play_iface(InterfaceSounds::COMMIT_PRESSED);
 		gameseq_post_event(GS_EVENT_MULTI_HOST_SETUP);
 		break;
 	}	
@@ -2523,14 +2523,14 @@ void multi_sg_button_pressed(int n)
 		if(Multi_sg_netgame->mode != NG_MODE_OPEN){
 			Multi_sg_netgame->mode = NG_MODE_OPEN;
 
-			gamesnd_play_iface(SND_USER_SELECT);
+			gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 			
 			// release the password control if necessary
 			multi_sg_release_passwd();
 		}
 		// if its already selected
 		else {
-			gamesnd_play_iface(SND_GENERAL_FAIL);
+			gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 		}
 		break;
 
@@ -2556,7 +2556,7 @@ void multi_sg_button_pressed(int n)
 	case MSG_PASSWD_GAME:		
 		// if we selected it
 		if(Multi_sg_netgame->mode != NG_MODE_PASSWORD){
-			gamesnd_play_iface(SND_USER_SELECT);		
+			gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 
 			Multi_sg_game_passwd.enable();			
 			Multi_sg_game_passwd.unhide();
@@ -2567,7 +2567,7 @@ void multi_sg_button_pressed(int n)
 			// copy in the current network password
 			Multi_sg_game_passwd.set_text(Multi_sg_netgame->passwd);
 		} else {
-			gamesnd_play_iface(SND_GENERAL_FAIL);
+			gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 		}			
 		break;
 
@@ -2589,7 +2589,7 @@ void multi_sg_button_pressed(int n)
 	case MSG_RANK_SET_GAME:		
 		// if either is set, then turn then both off
 		if((Multi_sg_netgame->mode != NG_MODE_RANK_BELOW) && (Multi_sg_netgame->mode != NG_MODE_RANK_ABOVE)){
-			gamesnd_play_iface(SND_USER_SELECT);
+			gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 
 			// set it to the default case if we're turning it off
 			multi_sg_select_rank_default();
@@ -2600,7 +2600,7 @@ void multi_sg_button_pressed(int n)
 			// release the password control if necessary
 			multi_sg_release_passwd();
 		} else {
-			gamesnd_play_iface(SND_GENERAL_FAIL);
+			gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 		}		
 		break;
 
@@ -2614,9 +2614,9 @@ void multi_sg_button_pressed(int n)
 			Multi_sg_rank_start = Multi_sg_rank_select;
 
 			// play a sound
-			gamesnd_play_iface(SND_USER_SELECT);			
+			gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 		} else {
-			gamesnd_play_iface(SND_GENERAL_FAIL);
+			gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 		}
 		break;
 
@@ -2630,9 +2630,9 @@ void multi_sg_button_pressed(int n)
 			Multi_sg_rank_start = Multi_sg_rank_select;			
 
 			// play a sound
-			gamesnd_play_iface(SND_USER_SELECT);			
+			gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 		} else {
-			gamesnd_play_iface(SND_GENERAL_FAIL);
+			gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 		}	
 		break;
 
@@ -2649,11 +2649,11 @@ void multi_sg_button_pressed(int n)
 	// move to the create game screen
 	case MSG_ACCEPT:
 		gameseq_post_event(GS_EVENT_MULTI_HOST_SETUP);
-		gamesnd_play_iface(SND_COMMIT_PRESSED);
+		gamesnd_play_iface(InterfaceSounds::COMMIT_PRESSED);
 		break;
 
 	default :
-		gamesnd_play_iface(SND_GENERAL_FAIL);
+		gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 		multi_common_add_notify(XSTR("Not implemented yet!",760));		
 		break;
 	}
@@ -2813,9 +2813,9 @@ void multi_sg_rank_scroll_up()
 
 	if(Multi_sg_rank_start > 0){
 		Multi_sg_rank_start--;
-		gamesnd_play_iface(SND_SCROLL);
+		gamesnd_play_iface(InterfaceSounds::SCROLL);
 	} else {
-		gamesnd_play_iface(SND_GENERAL_FAIL);
+		gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 	}
 }
 
@@ -2828,9 +2828,9 @@ void multi_sg_rank_scroll_down()
 	
 	if((NUM_RANKS - Multi_sg_rank_start) > Multi_sg_rank_max_display[gr_screen.res]){
 		Multi_sg_rank_start++;
-		gamesnd_play_iface(SND_SCROLL);
+		gamesnd_play_iface(InterfaceSounds::SCROLL);
 	} else {
-		gamesnd_play_iface(SND_GENERAL_FAIL);
+		gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 	}	
 }
 
@@ -2893,14 +2893,14 @@ void multi_sg_rank_process_select()
 		if(item + Multi_sg_rank_start < NUM_RANKS){		
 			// evaluate whether this rank is valid for the guy to pick		
 			if(multi_sg_rank_select_valid(item + Multi_sg_rank_start)){
-				gamesnd_play_iface(SND_USER_SELECT);
+				gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 
 				Multi_sg_rank_select = item + Multi_sg_rank_start;						
 
 				// set the Netgame rank
 				Multi_sg_netgame->rank_base = Multi_sg_rank_select;
 			} else {
-				gamesnd_play_iface(SND_GENERAL_FAIL);
+				gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 
 				memset(string,0,255);
 				sprintf(string,XSTR("Illegal value for a host of your rank (%s)\n",784),Ranks[Net_player->m_player->stats.rank].name);
@@ -3680,7 +3680,7 @@ void multi_create_game_do()
 		}
 		else {
 			popup(PF_BODY_BIG | PF_USE_AFFIRMATIVE_ICON,1,POPUP_OK,XSTR(" Not a multi player-mission",9999)); //DTP startgame popup pilot error
-			gamesnd_play_iface(SND_GENERAL_FAIL);
+			gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 			Cmdline_almission = NULL; //DTP make sure this gets nullified.
 		
 		}
@@ -3769,7 +3769,7 @@ void multi_create_game_do()
 			if ( help_overlay_active(Multi_create_overlay_id) ) {
 				help_overlay_set_state(Multi_create_overlay_id, gr_screen.res, 0);
 			} else {		
-				gamesnd_play_iface(SND_USER_SELECT);		
+				gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 				multi_quit_game(PROMPT_HOST);		
 			}
 
@@ -3938,7 +3938,7 @@ void multi_create_button_pressed(int n)
 	
 	switch(n){
 	case MC_CANCEL :
-		gamesnd_play_iface(SND_USER_SELECT);		
+		gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 		multi_quit_game(PROMPT_HOST);		
 		break;
 	case MC_ACCEPT :	
@@ -3994,51 +3994,51 @@ void multi_create_button_pressed(int n)
 
 	// go to the options screen
 	case MC_OPTIONS:		
-		gamesnd_play_iface(SND_USER_SELECT);
+		gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 		gameseq_post_event(GS_EVENT_OPTIONS_MENU);
 		break;	
 
 	// show all missions
 	case MC_SHOW_ALL:
 		if(Multi_create_filter != MISSION_TYPE_MULTI){
-			gamesnd_play_iface(SND_USER_SELECT);
+			gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 			Multi_create_filter = MISSION_TYPE_MULTI;
 			multi_create_setup_list_data(Multi_create_list_mode);						// update the file list
 		} else {
-			gamesnd_play_iface(SND_GENERAL_FAIL);
+			gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 		}
 		break;
 
 	// show cooperative missions
 	case MC_SHOW_COOP:
 		if(Multi_create_filter != MISSION_TYPE_MULTI_COOP){
-			gamesnd_play_iface(SND_USER_SELECT);
+			gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 			Multi_create_filter = MISSION_TYPE_MULTI_COOP;			
 			multi_create_setup_list_data(Multi_create_list_mode);						// update the file list
 		} else {
-			gamesnd_play_iface(SND_GENERAL_FAIL);
+			gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 		}
 		break;
 
 	// show team vs. team missions
 	case MC_SHOW_TEAM:
 		if(Multi_create_filter != MISSION_TYPE_MULTI_TEAMS){
-			gamesnd_play_iface(SND_USER_SELECT);
+			gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 			Multi_create_filter = MISSION_TYPE_MULTI_TEAMS;	
 			multi_create_setup_list_data(Multi_create_list_mode);						// update the file list
 		} else {
-			gamesnd_play_iface(SND_GENERAL_FAIL);
+			gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 		}
 		break;	
 
 	// show dogfight missions
 	case MC_SHOW_DOGFIGHT:
 		if (Multi_create_filter != MISSION_TYPE_MULTI_DOGFIGHT){
-			gamesnd_play_iface(SND_USER_SELECT);
+			gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 			Multi_create_filter = MISSION_TYPE_MULTI_DOGFIGHT;
 			multi_create_setup_list_data(Multi_create_list_mode);						// update the file list
 		} else {
-			gamesnd_play_iface(SND_GENERAL_FAIL);
+			gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 		}
 		break;
 
@@ -4050,7 +4050,7 @@ void multi_create_button_pressed(int n)
 			Netgame.options.flags |= MLO_FLAG_TEMP_CLOSED;
 			multi_options_update_netgame();
 		}
-		gamesnd_play_iface(SND_USER_SELECT);
+		gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 		break;
 
 	// kick the currently selected player (if possible)
@@ -4070,12 +4070,12 @@ void multi_create_button_pressed(int n)
 		if(Multi_create_list_mode != MULTI_CREATE_SHOW_MISSIONS){
 			Netgame.campaign_mode = MP_SINGLE_MISSION;
 
-			gamesnd_play_iface(SND_USER_SELECT);												
+			gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 			
 			// update the file list
 			multi_create_setup_list_data(MULTI_CREATE_SHOW_MISSIONS);						
 		} else {
-			gamesnd_play_iface(SND_GENERAL_FAIL);
+			gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 		}
 		break;
 
@@ -4088,12 +4088,12 @@ void multi_create_button_pressed(int n)
 		if(Multi_create_list_mode != MULTI_CREATE_SHOW_CAMPAIGNS){
 			Netgame.campaign_mode = MP_CAMPAIGN;
 
-			gamesnd_play_iface(SND_USER_SELECT);			
+			gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 			
 			// update the file list
 			multi_create_setup_list_data(MULTI_CREATE_SHOW_CAMPAIGNS);						
 		} else {
-			gamesnd_play_iface(SND_GENERAL_FAIL);
+			gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 		}
 		break;
 
@@ -4120,7 +4120,7 @@ void multi_create_button_pressed(int n)
 
 	// go to the host options screen
 	case MC_HOST_OPTIONS:
-		gamesnd_play_iface(SND_USER_SELECT);
+		gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 		gameseq_post_event(GS_EVENT_MULTI_HOST_OPTIONS);
 		break;
 
@@ -4133,7 +4133,7 @@ void multi_create_button_pressed(int n)
 		break;
 
 	default :
-		gamesnd_play_iface(SND_GENERAL_FAIL);
+		gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 		multi_common_add_notify(XSTR("Not implemented yet!",760));		
 		break;
 	}
@@ -4162,13 +4162,13 @@ void multi_create_init_as_client()
 // scroll up through the player list
 void multi_create_plist_scroll_up()
 {	
-	gamesnd_play_iface(SND_GENERAL_FAIL);
+	gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 }
 
 // scroll down through the player list
 void multi_create_plist_scroll_down()
 {	
-	gamesnd_play_iface(SND_GENERAL_FAIL);
+	gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 }
 
 void multi_create_plist_process()
@@ -4409,9 +4409,9 @@ void multi_create_list_scroll_up()
 	if(Multi_create_list_start > 0){
 		Multi_create_list_start--;		
 
-		gamesnd_play_iface(SND_SCROLL);
+		gamesnd_play_iface(InterfaceSounds::SCROLL);
 	} else {
-		gamesnd_play_iface(SND_GENERAL_FAIL);
+		gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 	}
 }
 
@@ -4420,9 +4420,9 @@ void multi_create_list_scroll_down()
 	if((Multi_create_list_count - Multi_create_list_start) > Multi_create_list_max_display[gr_screen.res]){
 		Multi_create_list_start++;		
 
-		gamesnd_play_iface(SND_SCROLL);
+		gamesnd_play_iface(InterfaceSounds::SCROLL);
 	} else {
-		gamesnd_play_iface(SND_GENERAL_FAIL);
+		gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 	}
 }
 
@@ -4626,7 +4626,7 @@ void multi_create_list_do()
 
 			if(item < Multi_create_list_count){		
 				multi_create_list_select_item(item);
-				gamesnd_play_iface(SND_IFACE_MOUSE_CLICK);
+				gamesnd_play_iface(InterfaceSounds::IFACE_MOUSE_CLICK);
 			}		
 		}
 	}	
@@ -4916,10 +4916,10 @@ void multi_create_accept_hit()
 	// make sure all players have finished joining
 	if(!multi_netplayer_state_check(NETPLAYER_STATE_JOINED,1)){
 		popup(PF_BODY_BIG | PF_USE_AFFIRMATIVE_ICON,1,POPUP_OK,XSTR("Please wait until all clients have finished joining",788));
-		gamesnd_play_iface(SND_GENERAL_FAIL);
+		gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 		return;
 	} else {
-		gamesnd_play_iface(SND_COMMIT_PRESSED);
+		gamesnd_play_iface(InterfaceSounds::COMMIT_PRESSED);
 	}	
 	
 	// do single mission stuff
@@ -5035,10 +5035,10 @@ void multi_create_set_selected_team(int team)
 	
 	// if we don't currently have a player selected, don't do anything
 	if(!Multi_create_plist_select_flag){
-		gamesnd_play_iface(SND_GENERAL_FAIL);
+		gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 		return;
 	}
-	gamesnd_play_iface(SND_USER_SELECT);
+	gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 
 	// otherwise attempt to set the team for this guy	
 	player_index = find_player_id(Multi_create_plist_select_id);
@@ -5050,7 +5050,7 @@ void multi_create_set_selected_team(int team)
 void multi_create_handle_join(net_player *pl)
 {
 	// for now just play a bloop sound
-	gamesnd_play_iface(SND_ICON_DROP_ON_WING);
+	gamesnd_play_iface(InterfaceSounds::ICON_DROP_ON_WING);
 }
 
 // fill in net address of player the mouse is over, return player index (or -1 if none)
@@ -5306,7 +5306,7 @@ int multi_create_ok_to_commit()
 	// check to see if teams are assigned properly in a team vs. team situation
 	if(Netgame.type_flags & NG_TYPE_TEAM){
 		if(!multi_team_ok_to_commit()){
-			gamesnd_play_iface(SND_GENERAL_FAIL);
+			gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 			popup(PF_BODY_BIG | PF_USE_AFFIRMATIVE_ICON, 1, POPUP_OK, XSTR("Teams and/or team captains are not assigned properly", 793));			
 			return 0;
 		}
@@ -5314,7 +5314,7 @@ int multi_create_ok_to_commit()
 
 	// verify cd's	
 	if(!multi_create_verify_cds()){
-		gamesnd_play_iface(SND_GENERAL_FAIL);
+		gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 
 		popup(PF_BODY_BIG | PF_USE_AFFIRMATIVE_ICON, 1, POPUP_OK, XSTR("You need 1 CD for every 4 players!", 794));			
 
@@ -5913,7 +5913,7 @@ void multi_ho_update_sliders()
 	if (Game_skill_level != Multi_ho_sliders[gr_screen.res][MULTI_HO_SLIDER_SKILL].slider.pos) {
 		if ( !(Netgame.type_flags & NG_TYPE_TEAM) ){		
 			Game_skill_level = Multi_ho_sliders[gr_screen.res][MULTI_HO_SLIDER_SKILL].slider.pos;
-			gamesnd_play_iface(SND_USER_SELECT);
+			gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 		} else {	
 			Game_skill_level = NUM_SKILL_LEVELS / 2;
 		}
@@ -5922,13 +5922,13 @@ void multi_ho_update_sliders()
 	// get the voice qos options
 	if (Netgame.options.voice_qos != (ubyte)(Multi_ho_sliders[gr_screen.res][MULTI_HO_SLIDER_VOICE_QOS].slider.pos + 1)) {
 		Netgame.options.voice_qos = (ubyte)(Multi_ho_sliders[gr_screen.res][MULTI_HO_SLIDER_VOICE_QOS].slider.pos + 1);	
-		gamesnd_play_iface(SND_USER_SELECT);
+		gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 	}
 
 	// get the voice duration options
 	if (Netgame.options.voice_record_time != (int)(0.5f * (float)(Multi_ho_sliders[gr_screen.res][MULTI_HO_SLIDER_VOICE_DUR].slider.pos + 1) * 1000.0f)) {
 		Netgame.options.voice_record_time = (int)(0.5f * (float)(Multi_ho_sliders[gr_screen.res][MULTI_HO_SLIDER_VOICE_DUR].slider.pos + 1) * 1000.0f);
-		gamesnd_play_iface(SND_USER_SELECT);
+		gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 	}
 
 }
@@ -5948,7 +5948,7 @@ void multi_host_options_do()
 		break;
 	// same as ACCEPT
 	case KEY_CTRLED + KEY_ENTER :	
-		gamesnd_play_iface(SND_COMMIT_PRESSED);
+		gamesnd_play_iface(InterfaceSounds::COMMIT_PRESSED);
 		multi_ho_accept_hit();
 		break;
 	}
@@ -6039,7 +6039,7 @@ void multi_ho_button_pressed(int n)
 	switch(n){		
 	// clicked on the accept button
 	case MULTI_HO_ACCEPT:
-		gamesnd_play_iface(SND_COMMIT_PRESSED);
+		gamesnd_play_iface(InterfaceSounds::COMMIT_PRESSED);
 		multi_ho_accept_hit();
 		return;	
 	
@@ -6047,7 +6047,7 @@ void multi_ho_button_pressed(int n)
 	case MULTI_HO_HOST_MODIFIES:
 		// toggle it on or off
 		Multi_ho_host_modifies = !Multi_ho_host_modifies;
-		gamesnd_play_iface(SND_USER_SELECT);
+		gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 		return;
 	}
 
@@ -6065,10 +6065,10 @@ void multi_ho_button_pressed(int n)
 	if(radio_index < MULTI_HO_NUM_RADIO_BUTTONS){
 		// see if this value is already picked for this radio group
 		if(Multi_ho_radio_groups[Multi_ho_radio_info[radio_index][0]] != Multi_ho_radio_info[radio_index][1]){
-			gamesnd_play_iface(SND_USER_SELECT);
+			gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 			Multi_ho_radio_groups[Multi_ho_radio_info[radio_index][0]] = Multi_ho_radio_info[radio_index][1];
 		} else {
-			gamesnd_play_iface(SND_GENERAL_FAIL);
+			gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 		}
 	}
 }
@@ -6436,7 +6436,7 @@ void multi_ho_check_focus()
 		Multi_ho_voice_wait.clear_focus();			
 		Multi_ho_kill_limit.clear_focus();
 		Multi_ho_obs.clear_focus();
-		gamesnd_play_iface(SND_COMMIT_PRESSED);
+		gamesnd_play_iface(InterfaceSounds::COMMIT_PRESSED);
 		chatbox_set_focus();
 		Multi_ho_lastframe_input = 0;
 
@@ -6855,7 +6855,7 @@ void multi_game_client_setup_close()
 
 	// play a sound.
 	if(Netgame.game_state == NETGAME_STATE_MISSION_SYNC){
-		gamesnd_play_iface(SND_COMMIT_PRESSED);
+		gamesnd_play_iface(InterfaceSounds::COMMIT_PRESSED);
 	}
 }
 
@@ -6877,7 +6877,7 @@ void multi_jw_button_pressed(int n)
 {
 	switch(n){	
 	case MJW_CANCEL:
-		gamesnd_play_iface(SND_USER_SELECT);		
+		gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 		multi_quit_game(PROMPT_CLIENT);		
 		break;	
 	case MJW_SCROLL_PLAYERS_UP:
@@ -6895,13 +6895,13 @@ void multi_jw_button_pressed(int n)
 	
 	// request to set myself to team 0
 	case MJW_TEAM0:
-		gamesnd_play_iface(SND_USER_SELECT);
+		gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 		multi_team_set_team(Net_player,0);
 		break;
 
 	// request to set myself to team 1
 	case MJW_TEAM1:
-		gamesnd_play_iface(SND_USER_SELECT);
+		gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 		multi_team_set_team(Net_player,1);
 		break;
 
@@ -6923,13 +6923,13 @@ void multi_jw_do_netstuff()
 
 void multi_jw_scroll_players_up()
 {
-	gamesnd_play_iface(SND_GENERAL_FAIL);
+	gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 }
 
 // scroll down through the player list
 void multi_jw_scroll_players_down()
 {	
-	gamesnd_play_iface(SND_GENERAL_FAIL);
+	gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 }
 
 void multi_jw_plist_process()
@@ -7159,7 +7159,7 @@ void multi_jw_plist_blit_team()
 void multi_jw_handle_join(net_player *pl)
 {
 	// for now just play a bloop sound
-	gamesnd_play_iface(SND_ICON_DROP_ON_WING);
+	gamesnd_play_iface(InterfaceSounds::ICON_DROP_ON_WING);
 }
 
 short multi_jw_get_mouse_id()
@@ -7614,7 +7614,7 @@ void multi_sync_common_do()
 	switch(k){
 	case KEY_ESC :
 		// Sync_test = 1;
-		gamesnd_play_iface(SND_USER_SELECT);
+		gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 		multi_quit_game(PROMPT_ALL);		
 		break;	
 	}				
@@ -7826,7 +7826,7 @@ void multi_sync_button_pressed(int n)
 	switch(n){	
 	// exit the game
 	case MS_CANCEL:
-		gamesnd_play_iface(SND_USER_SELECT);		
+		gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 		multi_quit_game(PROMPT_ALL);		
 		break;	
 	
@@ -8463,7 +8463,7 @@ void multi_sync_start_countdown()
 
 	// if I'm the server, begin the countdown
 	if(Net_player->flags & NETINFO_FLAG_AM_MASTER){
-		gamesnd_play_iface(SND_COMMIT_PRESSED);
+		gamesnd_play_iface(InterfaceSounds::COMMIT_PRESSED);
 		Multi_sync_countdown_timer = 0.0f;
 		Multi_sync_countdown = MULTI_SYNC_COUNTDOWN_TIME;
 
@@ -8672,7 +8672,7 @@ void multi_debrief_do_frame()
 void multi_debrief_close()
 {	
 	if ( MULTIPLAYER_CLIENT && (Netgame.game_state == NETGAME_STATE_MISSION_SYNC) ){
-		gamesnd_play_iface( SND_COMMIT_PRESSED );
+		gamesnd_play_iface( InterfaceSounds::COMMIT_PRESSED );
 	}
 }
 
@@ -8711,7 +8711,7 @@ void multi_debrief_accept_hit()
 	// mark this so that we don't hit it again
 	Multi_debrief_accept_hit = 1;
 
-	gamesnd_play_iface(SND_COMMIT_PRESSED);
+	gamesnd_play_iface(InterfaceSounds::COMMIT_PRESSED);
 
 	if (MULTI_IS_TRACKER_GAME) {
 		int res = popup(PF_TITLE | PF_BODY_BIG | PF_USE_AFFIRMATIVE_ICON | PF_USE_NEGATIVE_ICON | PF_IGNORE_ESC, 3, XSTR("&Cancel", 779), XSTR("&Accept", 844), XSTR("&Toss", 845), XSTR("(Continue Netgame)\nDo you wish to accept these stats?", 846));
@@ -9183,13 +9183,13 @@ void multi_passwd_process_buttons()
 {
 	// if the accept button was pressed
 	if(Multi_pwd_buttons[gr_screen.res][MPWD_COMMIT].button.pressed()){
-		gamesnd_play_iface(SND_USER_SELECT);
+		gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 		Multi_passwd_done = 1;
 	}
 
 	// if the cancel button was pressed
 	if(Multi_pwd_buttons[gr_screen.res][MPWD_CANCEL].button.pressed()){
-		gamesnd_play_iface(SND_USER_SELECT);
+		gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 		Multi_passwd_done = 0;
 	}
 }

--- a/code/network/multiutil.cpp
+++ b/code/network/multiutil.cpp
@@ -1976,7 +1976,7 @@ int multi_eval_join_request(join_request *jr,net_addr *addr)
 					if( MULTIPLAYER_STANDALONE ) {
 						send_game_chat_packet(&Net_players[MY_NET_PLAYER_NUM],knock_message,MULTI_MSG_TARGET, Netgame.host, NULL, 1);
 					} else {
-						snd_play(gamesnd_get_game_sound(SND_CUE_VOICE));
+						snd_play(gamesnd_get_game_sound(GameSounds::CUE_VOICE));
 						HUD_sourced_printf(HUD_SOURCE_HIDDEN, "%s", knock_message);
 					}
 					break;

--- a/code/object/collideshipship.cpp
+++ b/code/object/collideshipship.cpp
@@ -893,7 +893,7 @@ static void mcp_1(object *player_objp, object *planet_objp)
 	if ((Missiontime - Last_planet_damage_time > F1_0) || (Missiontime < Last_planet_damage_time)) {
 		HUD_sourced_printf(HUD_SOURCE_HIDDEN, "%s", XSTR( "Too close to planet.  Taking damage!", 465));
 		Last_planet_damage_time = Missiontime;
-		snd_play_3d( gamesnd_get_game_sound(ship_get_sound(player_objp, SND_ABURN_ENGAGE)), &player_objp->pos, &View_position );
+		snd_play_3d( gamesnd_get_game_sound(ship_get_sound(player_objp, GameSounds::ABURN_ENGAGE)), &player_objp->pos, &View_position );
 	}
 
 }
@@ -969,15 +969,15 @@ void collide_ship_ship_do_sound(vec3d *world_hit_pos, object *A, object *B, int 
 	rel_speed = vm_vec_mag_quick(&rel_vel);
 
 	if ( rel_speed > MIN_REL_SPEED_FOR_LOUD_COLLISION ) {
-		snd_play_3d( gamesnd_get_game_sound(SND_SHIP_SHIP_HEAVY), world_hit_pos, &View_position );
+		snd_play_3d( gamesnd_get_game_sound(GameSounds::SHIP_SHIP_HEAVY), world_hit_pos, &View_position );
 	} else {
 		if ( player_involved ) {
 			if ( !snd_is_playing(Player_collide_sound) ) {
-				Player_collide_sound = snd_play_3d( gamesnd_get_game_sound(SND_SHIP_SHIP_LIGHT), world_hit_pos, &View_position );
+				Player_collide_sound = snd_play_3d( gamesnd_get_game_sound(GameSounds::SHIP_SHIP_LIGHT), world_hit_pos, &View_position );
 			}
 		} else {
 			if ( !snd_is_playing(AI_collide_sound) ) {
-				AI_collide_sound = snd_play_3d( gamesnd_get_game_sound(SND_SHIP_SHIP_LIGHT), world_hit_pos, &View_position );
+				AI_collide_sound = snd_play_3d( gamesnd_get_game_sound(GameSounds::SHIP_SHIP_LIGHT), world_hit_pos, &View_position );
 			}
 		}
 	}
@@ -986,11 +986,11 @@ void collide_ship_ship_do_sound(vec3d *world_hit_pos, object *A, object *B, int 
 	if ( (shield_get_strength(A) > 5) || (shield_get_strength(B) > 5) ) {
 		if ( player_involved ) {
 			if ( !snd_is_playing(Player_collide_sound) ) {
-				Player_collide_shield_sound = snd_play_3d( gamesnd_get_game_sound(SND_SHIP_SHIP_SHIELD), world_hit_pos, &View_position );
+				Player_collide_shield_sound = snd_play_3d( gamesnd_get_game_sound(GameSounds::SHIP_SHIP_SHIELD), world_hit_pos, &View_position );
 			}
 		} else {
 			if ( !snd_is_playing(Player_collide_sound) ) {
-				AI_collide_shield_sound = snd_play_3d( gamesnd_get_game_sound(SND_SHIP_SHIP_SHIELD), world_hit_pos, &View_position );
+				AI_collide_shield_sound = snd_play_3d( gamesnd_get_game_sound(GameSounds::SHIP_SHIP_SHIELD), world_hit_pos, &View_position );
 			}
 		}
 	}

--- a/code/object/objectshield.cpp
+++ b/code/object/objectshield.cpp
@@ -402,7 +402,7 @@ void shield_transfer(object *objp, int quadrant, float rate) {
 		return;
 	
 	} else if (objp == Player_obj) {
-		snd_play(gamesnd_get_game_sound(SND_SHIELD_XFER_OK));
+		snd_play(gamesnd_get_game_sound(GameSounds::SHIELD_XFER_OK));
 	}
 
 	float energy_avail = 0.0f;	// Energy available from the other quadrants that we can transfer

--- a/code/object/objectsnd.cpp
+++ b/code/object/objectsnd.cpp
@@ -36,7 +36,7 @@
 typedef struct _obj_snd {
 	_obj_snd	*next, *prev;
 	int		objnum;			// object index of object that contains this sound
-	int		id;				// Index into Snds[] array
+	gamesnd_id	id;				// Index into Snds[] array
 	int		instance;		// handle of currently playing sound (a ds3d handle if USES_DS3D flag set)
 	int		next_update;	// timestamp that marks next allowed vol/pan change
 	float		vol;				// volume of sound (range: 0.0 -> 1.0)
@@ -55,7 +55,7 @@ typedef struct _obj_snd {
 static int MAX_OBJ_SOUNDS_PLAYING = -1; // initialized in obj_snd_level_init()
 static int Num_obj_sounds_playing;
 
-#define OBJSND_CHANGE_FREQUENCY_THRESHOLD			10
+#define SND_CHANGE_FREQUENCY_THRESHOLD			10
 
 static	obj_snd	obj_snd_list;						// head of linked list of object sound structs
 static	int		Doppler_enabled = TRUE;
@@ -706,12 +706,12 @@ void obj_snd_do_frame()
 //										sound can be assigned per object).  
 //               >= 0			=> sound was successfully assigned
 //
-int obj_snd_assign(int objnum, int sndnum, vec3d *pos, int main, int flags, ship_subsys *associated_sub)
+int obj_snd_assign(int objnum, gamesnd_id sndnum, vec3d *pos, int main, int flags, ship_subsys *associated_sub)
 {
 	if(objnum < 0 || objnum > MAX_OBJECTS)
 		return -1;
 
-	if(sndnum < 0)
+	if(!sndnum.isValid())
 		return -1;
 
 	if ( Obj_snd_enabled == FALSE )
@@ -813,7 +813,7 @@ void obj_snd_delete(int objnum, int index)
 //								-1 to delete all persistent sounds on ship.
 //
 //
-void	obj_snd_delete_type(int objnum, int sndnum, ship_subsys *ss)
+void	obj_snd_delete_type(int objnum, gamesnd_id sndnum, ship_subsys *ss)
 {
 	object	*objp;
 	obj_snd	*osp;
@@ -836,7 +836,7 @@ void	obj_snd_delete_type(int objnum, int sndnum, ship_subsys *ss)
 		// if we're just deleting a specific sound type
 		// and this is not one of them. skip it.
 		//Also check if this is assigned to the right subsystem, if one has been given.
-		if(((sndnum != -1) && (osp->id != sndnum))
+		if(((sndnum.isValid()) && (osp->id != sndnum))
 			|| ((ss != NULL) && (osp->ss != ss))){
 			continue;
 		}

--- a/code/object/objectsnd.h
+++ b/code/object/objectsnd.h
@@ -9,8 +9,8 @@
 
 
 
-#ifndef __OBJECTSND_H__
-#define __OBJECTSND_H__
+#ifndef __OBJECTSNDS_H__
+#define __OBJECTSNDS_H__
 
 #define	OS_USED					(1<<0)
 #define	OS_DS3D					(1<<1)
@@ -36,13 +36,13 @@ void	obj_snd_do_frame();
 // model coords of the location of the engine
 // by passing vmd_zero_vector here, you get a sound centered directly on the object
 // NOTE : if main is true, the attentuation factors don't apply if you're within the radius of the object
-int	obj_snd_assign(int objnum, int sndnum, vec3d *pos, int main, int flags=0, ship_subsys *associated_sub=NULL);
+int	obj_snd_assign(int objnum, gamesnd_id sndnum, vec3d *pos, int main, int flags=0, ship_subsys *associated_sub=NULL);
 
 //Delete specific persistent sound on object
 void obj_snd_delete(int objnum, int index);
 
 // if sndnum is not -1, deletes all instances of the given sound within the object
-void	obj_snd_delete_type(int objnum, int sndnum = -1, ship_subsys *ss = NULL);
+void	obj_snd_delete_type(int objnum, gamesnd_id sndnum = gamesnd_id(), ship_subsys *ss = NULL);
 
 void	obj_snd_delete_all();
 void	obj_snd_stop_all();

--- a/code/playerman/playercontrol.cpp
+++ b/code/playerman/playercontrol.cpp
@@ -653,10 +653,10 @@ void read_keyboard_controls( control_info * ci, float frame_time, physics_info *
 			control_used(ONE_THIRD_THROTTLE);
 			player_clear_speed_matching();
 			if ( Player->ci.forward_cruise_percent < 33.3f ) {
-				snd_play( gamesnd_get_game_sound(ship_get_sound(Player_obj, SND_THROTTLE_UP)), 0.0f );
+				snd_play( gamesnd_get_game_sound(ship_get_sound(Player_obj, GameSounds::THROTTLE_UP)), 0.0f );
 
 			} else if ( Player->ci.forward_cruise_percent > 33.3f ) {
-				snd_play( gamesnd_get_game_sound(ship_get_sound(Player_obj, SND_THROTTLE_DOWN)), 0.0f );
+				snd_play( gamesnd_get_game_sound(ship_get_sound(Player_obj, GameSounds::THROTTLE_DOWN)), 0.0f );
 			}
 
 			Player->ci.forward_cruise_percent = 33.3f;
@@ -667,10 +667,10 @@ void read_keyboard_controls( control_info * ci, float frame_time, physics_info *
 			control_used(TWO_THIRDS_THROTTLE);
 			player_clear_speed_matching();
 			if ( Player->ci.forward_cruise_percent < 66.6f ) {
-				snd_play( gamesnd_get_game_sound(ship_get_sound(Player_obj, SND_THROTTLE_UP)), 0.0f );
+				snd_play( gamesnd_get_game_sound(ship_get_sound(Player_obj, GameSounds::THROTTLE_UP)), 0.0f );
 
 			} else if (Player->ci.forward_cruise_percent > 66.6f) {
-				snd_play( gamesnd_get_game_sound(ship_get_sound(Player_obj, SND_THROTTLE_DOWN)), 0.0f );
+				snd_play( gamesnd_get_game_sound(ship_get_sound(Player_obj, GameSounds::THROTTLE_DOWN)), 0.0f );
 			}
 
 			Player->ci.forward_cruise_percent = 66.6f;
@@ -695,7 +695,7 @@ void read_keyboard_controls( control_info * ci, float frame_time, physics_info *
 			control_used(ZERO_THROTTLE);
 			player_clear_speed_matching();
 			if ( ci->forward_cruise_percent > 0.0f && Player_obj->phys_info.fspeed > 0.5) {
-				snd_play( gamesnd_get_game_sound(ship_get_sound(Player_obj, SND_ZERO_THROTTLE)), 0.0f );
+				snd_play( gamesnd_get_game_sound(ship_get_sound(Player_obj, GameSounds::ZERO_THROTTLE)), 0.0f );
 			}
 
 			ci->forward_cruise_percent = 0.0f;
@@ -706,7 +706,7 @@ void read_keyboard_controls( control_info * ci, float frame_time, physics_info *
 			control_used(MAX_THROTTLE);
 			player_clear_speed_matching();
 			if ( ci->forward_cruise_percent < 100.0f ) {
-				snd_play( gamesnd_get_game_sound(ship_get_sound(Player_obj, SND_FULL_THROTTLE)), 0.0f );
+				snd_play( gamesnd_get_game_sound(ship_get_sound(Player_obj, GameSounds::FULL_THROTTLE)), 0.0f );
 			}
 
 			ci->forward_cruise_percent = 100.0f;
@@ -917,19 +917,19 @@ void read_keyboard_controls( control_info * ci, float frame_time, physics_info *
 						object_set_gliding(Player_obj, false);
 						ci->forward_cruise_percent = savedspeed;
 						press_glide = !press_glide;
-						snd_play( gamesnd_get_game_sound(ship_get_sound(Player_obj, SND_THROTTLE_UP)), 0.0f );
+						snd_play( gamesnd_get_game_sound(ship_get_sound(Player_obj, GameSounds::THROTTLE_UP)), 0.0f );
 					}
 				} else if ( !object_get_gliding(Player_obj) ) {
 					object_set_gliding(Player_obj, true);
 					savedspeed = ci->forward_cruise_percent;
 					ci->forward_cruise_percent = 0.0f;
 					override_analog_throttle = 1;
-					if (Ship_info[Player_ship->ship_info_index].glide_start_snd > 0) {
+					if (Ship_info[Player_ship->ship_info_index].glide_start_snd.isValid()) {
 						//If a custom glide start sound was specified, play it
 						snd_play( gamesnd_get_game_sound(Ship_info[Player_ship->ship_info_index].glide_start_snd), 0.0f );
 					} else {
 						//If glide_start_snd wasn't set (probably == 0), use the default throttle down sound
-						snd_play( gamesnd_get_game_sound(ship_get_sound(Player_obj, SND_THROTTLE_DOWN)), 0.0f );
+						snd_play( gamesnd_get_game_sound(ship_get_sound(Player_obj, GameSounds::THROTTLE_DOWN)), 0.0f );
 					}
 				}
 			}
@@ -940,12 +940,12 @@ void read_keyboard_controls( control_info * ci, float frame_time, physics_info *
 				if ( object_get_gliding(Player_obj) && !object_glide_forced(Player_obj) ) {
 					object_set_gliding(Player_obj, false);
 					ci->forward_cruise_percent = savedspeed;
-					if (Ship_info[Player_ship->ship_info_index].glide_end_snd > 0) {
+					if (Ship_info[Player_ship->ship_info_index].glide_end_snd.isValid()) {
 						//If a custom glide end sound was specified, play it
 						snd_play( gamesnd_get_game_sound(Ship_info[Player_ship->ship_info_index].glide_end_snd), 0.0f );
 					} else {
 						//If glide_end_snd wasn't set (probably == 0), use the default throttle up sound
-						snd_play( gamesnd_get_game_sound(ship_get_sound(Player_obj, SND_THROTTLE_UP)), 0.0f );
+						snd_play( gamesnd_get_game_sound(ship_get_sound(Player_obj, GameSounds::THROTTLE_UP)), 0.0f );
 					}
 				}
 			}
@@ -1035,7 +1035,7 @@ void read_player_controls(object *objp, float frametime)
 				// check if warp ability has been disabled
 				if (!(Warpout_forced) && (Ships[objp->instance].flags[Ship::Ship_Flags::Warp_broken] || Ships[objp->instance].flags[Ship::Ship_Flags::Warp_never]) ) {
 					HUD_sourced_printf(HUD_SOURCE_HIDDEN, "%s", XSTR( "Cannot warp out at this time.", 81));
-					snd_play(gamesnd_get_game_sound(SND_PLAYER_WARP_FAIL));
+					snd_play(gamesnd_get_game_sound(GameSounds::PLAYER_WARP_FAIL));
 					gameseq_post_event( GS_EVENT_PLAYER_WARPOUT_STOP );
 				} else {
 					if ( Warpout_forced ) {
@@ -1442,7 +1442,7 @@ void player_maybe_start_repair_sound()
 {
 	Assert(Player);
 	if ( Player->repair_sound_loop == -1 ) {
-		Player->repair_sound_loop = snd_play_looping( gamesnd_get_game_sound(SND_SHIP_REPAIR) );
+		Player->repair_sound_loop = snd_play_looping( gamesnd_get_game_sound(GameSounds::SHIP_REPAIR) );
 	}
 }
 
@@ -1465,7 +1465,7 @@ void player_maybe_start_cargo_scan_sound()
 {
 	Assert(Player);
 	if ( Player->cargo_scan_loop == -1 ) {
-		Player->cargo_scan_loop = snd_play_looping( gamesnd_get_game_sound(ship_get_sound(Player_obj, SND_CARGO_SCAN)) );
+		Player->cargo_scan_loop = snd_play_looping( gamesnd_get_game_sound(ship_get_sound(Player_obj, GameSounds::CARGO_SCAN)) );
 	}
 }
 
@@ -1624,7 +1624,7 @@ int player_inspect_cargo(float frametime, char *outstr)
 
 		if ( Player->cargo_inspect_time > cargo_sip->scan_time ) {
 			ship_do_cargo_revealed( cargo_sp );
-			snd_play( gamesnd_get_game_sound(SND_CARGO_REVEAL), 0.0f );
+			snd_play( gamesnd_get_game_sound(GameSounds::CARGO_REVEAL), 0.0f );
 			Player->cargo_inspect_time = 0;
 		}
 	} else {
@@ -1734,7 +1734,7 @@ int player_inspect_cap_subsys_cargo(float frametime, char *outstr)
 
 		if ( Player->cargo_inspect_time > cargo_sip->scan_time ) {
 			ship_do_cap_subsys_cargo_revealed( cargo_sp, subsys, 0);
-			snd_play( gamesnd_get_game_sound(SND_CARGO_REVEAL), 0.0f );
+			snd_play( gamesnd_get_game_sound(GameSounds::CARGO_REVEAL), 0.0f );
 			Player->cargo_inspect_time = 0;
 		}
 	} else {

--- a/code/popup/popup.cpp
+++ b/code/popup/popup.cpp
@@ -273,7 +273,7 @@ void popup_play_default_change_sound(popup_info *pi)
 		}
 
 		if (!mouse_over) {
-			gamesnd_play_iface(SND_USER_SELECT);
+			gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 		}
 	}
 }
@@ -554,7 +554,7 @@ void popup_close(popup_info *pi, int screen_id)
 {
 	int i;
 	
-	gamesnd_play_iface(SND_POPUP_DISAPPEAR); 	// play sound when popup disappears
+	gamesnd_play_iface(InterfaceSounds::POPUP_DISAPPEAR); 	// play sound when popup disappears
 
 	for (i=0; i<pi->nchoices; i++ )	{
 		if ( pi->button_text[i] != NULL ) {
@@ -1022,7 +1022,7 @@ int popup(int flags, int nchoices, ... )
 	va_end(args);
 	Popup_info.raw_text[sizeof(Popup_info.raw_text)-1] = '\0';
 	
-	gamesnd_play_iface(SND_POPUP_APPEAR); 	// play sound when popup appears
+	gamesnd_play_iface(InterfaceSounds::POPUP_APPEAR); 	// play sound when popup appears
 
 	io::mouse::CursorManager::get()->pushStatus();
 	io::mouse::CursorManager::get()->showCursor(true);
@@ -1079,7 +1079,7 @@ int popup_till_condition(int (*condition)(), ...)
 	va_end(args);
 	Popup_info.raw_text[sizeof(Popup_info.raw_text)-1] = '\0';
 
-	gamesnd_play_iface(SND_POPUP_APPEAR); 	// play sound when popup appears
+	gamesnd_play_iface(InterfaceSounds::POPUP_APPEAR); 	// play sound when popup appears
 
 	io::mouse::CursorManager::get()->pushStatus();
 	io::mouse::CursorManager::get()->showCursor(true);
@@ -1128,7 +1128,7 @@ char *popup_input(int flags, const char *caption, int max_output_len)
 	// zero the popup input text
 	memset(Popup_info.input_text, 0, POPUP_INPUT_MAX_CHARS);
 	
-	gamesnd_play_iface(SND_POPUP_APPEAR); 	// play sound when popup appears
+	gamesnd_play_iface(InterfaceSounds::POPUP_APPEAR); 	// play sound when popup appears
 
 	io::mouse::CursorManager::get()->showCursor(true);
 	Popup_is_active = 1;

--- a/code/popup/popupdead.cpp
+++ b/code/popup/popupdead.cpp
@@ -24,6 +24,7 @@
 #include "hud/hudmessage.h"
 #include "io/key.h"
 #include "io/timer.h"
+#include "mission/missionparse.h"
 #include "mission/missioncampaign.h"
 #include "network/multi.h"
 #include "network/multiutil.h"
@@ -271,7 +272,7 @@ void popupdead_play_default_change_sound()
 	}
 
 	if (!mouse_over) {
-		gamesnd_play_iface(SND_USER_SELECT);
+		gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 	}
 }
 
@@ -528,7 +529,7 @@ void popupdead_close()
 		return;
 	}
 
-	gamesnd_play_iface(SND_POPUP_DISAPPEAR);
+	gamesnd_play_iface(InterfaceSounds::POPUP_DISAPPEAR);
 	Popupdead_window.destroy();
 	game_flush();
 	

--- a/code/radar/radar.cpp
+++ b/code/radar/radar.cpp
@@ -336,7 +336,7 @@ void HudGaugeRadarStd::render(float frametime)
 		if ( Radar_static_playing ) {
 			drawBlipsSorted(1);	// passing 1 means to draw distorted
 			if ( Radar_static_looping == -1 ) {
-				Radar_static_looping = snd_play_looping(gamesnd_get_game_sound(SND_STATIC));
+				Radar_static_looping = snd_play_looping(gamesnd_get_game_sound(GameSounds::STATIC));
 			}
 		} else {
 			drawBlipsSorted(0);

--- a/code/radar/radardradis.cpp
+++ b/code/radar/radardradis.cpp
@@ -552,7 +552,7 @@ void HudGaugeRadarDradis::render(float frametime)
 			drawBlipsSorted(1);	// passing 1 means to draw distorted
 
 			if (Radar_static_looping == -1)
-				Radar_static_looping = snd_play_looping(gamesnd_get_game_sound(SND_STATIC));
+				Radar_static_looping = snd_play_looping(gamesnd_get_game_sound(GameSounds::STATIC));
 		}
 		else
 		{
@@ -591,7 +591,7 @@ void HudGaugeRadarDradis::pageIn()
 
 void HudGaugeRadarDradis::doLoopSnd()
 {
-	if (this->m_loop_snd < 0)
+	if (!this->m_loop_snd.isValid())
 	{
 		return;
 	}
@@ -623,10 +623,10 @@ void HudGaugeRadarDradis::doBeeps()
 		return;
 	}
 
-	if (arrival_beep_snd < 0 &&
-		departure_beep_snd < 0 &&
-		m_stealth_arrival_snd < 0 &&
-		stealth_departure_snd < 0)
+	if (!arrival_beep_snd.isValid() &&
+		!departure_beep_snd.isValid() &&
+		!m_stealth_arrival_snd.isValid() &&
+		!stealth_departure_snd.isValid())
 	{
 		return;
 	}
@@ -673,13 +673,13 @@ void HudGaugeRadarDradis::doBeeps()
 	
 	if (timestamp_elapsed(arrival_beep_next_check))
 	{
-		if (arrival_beep_snd >= 0 && arrival_happened)
+		if (arrival_beep_snd.isValid() && arrival_happened)
 		{
 			snd_play(gamesnd_get_game_sound(arrival_beep_snd));
 
 			arrival_beep_next_check = timestamp(arrival_beep_delay);
 		}
-		else if (m_stealth_arrival_snd >= 0 && stealth_arrival_happened)
+		else if (m_stealth_arrival_snd.isValid() && stealth_arrival_happened)
 		{
 			snd_play(gamesnd_get_game_sound(m_stealth_arrival_snd));
 
@@ -690,13 +690,13 @@ void HudGaugeRadarDradis::doBeeps()
 
 	if (timestamp_elapsed(departure_beep_next_check))
 	{
-		if (departure_beep_snd >= 0 && departure_happened)
+		if (departure_beep_snd.isValid() && departure_happened)
 		{
 			snd_play(gamesnd_get_game_sound(departure_beep_snd));
 
 			departure_beep_next_check = timestamp(departure_beep_delay);
 		}
-		else if (stealth_departure_snd >= 0 && stealth_departure_happened)
+		else if (stealth_departure_snd.isValid() && stealth_departure_happened)
 		{
 			snd_play(gamesnd_get_game_sound(stealth_departure_snd));
 
@@ -705,7 +705,7 @@ void HudGaugeRadarDradis::doBeeps()
 	}
 }
 
-void HudGaugeRadarDradis::initSound(int loop_snd, float _loop_snd_volume, int arrival_snd, int departure_snd, int stealth_arrival_snd, int stealth_departue_snd, float arrival_delay, float departure_delay)
+void HudGaugeRadarDradis::initSound(gamesnd_id loop_snd, float _loop_snd_volume, gamesnd_id arrival_snd, gamesnd_id departure_snd, gamesnd_id stealth_arrival_snd, gamesnd_id stealth_departue_snd, float arrival_delay, float departure_delay)
 {
 	this->m_loop_snd = loop_snd;
 	this->loop_sound_handle = -1;

--- a/code/radar/radardradis.h
+++ b/code/radar/radardradis.h
@@ -51,14 +51,14 @@ class HudGaugeRadarDradis: public HudGaugeRadar
 	bool sub_y_clip;
 
 	int loop_sound_handle;
-	int m_loop_snd;
+	gamesnd_id m_loop_snd;
 	float loop_sound_volume;
 
-	int arrival_beep_snd;
-	int departure_beep_snd;
+	gamesnd_id arrival_beep_snd;
+	gamesnd_id departure_beep_snd;
 
-	int m_stealth_arrival_snd;
-	int stealth_departure_snd;
+	gamesnd_id m_stealth_arrival_snd;
+	gamesnd_id stealth_departure_snd;
 
 	int arrival_beep_delay;
 	int departure_beep_delay;
@@ -70,7 +70,7 @@ protected:
 public:
 	HudGaugeRadarDradis();
 	void initBitmaps(char* fname_xy, char* fname_xz_yz, char* fname_sweep, char* fname_target_brackets, char* fname_unknown);
-	void initSound(int loop_snd, float _loop_sound_volume,  int arrival_snd, int departue_snd, int stealth_arrival_snd, int stealth_departue_snd, float arrival_delay, float departure_delay);
+	void initSound(gamesnd_id loop_snd, float _loop_sound_volume,  gamesnd_id arrival_snd, gamesnd_id departue_snd, gamesnd_id stealth_arrival_snd, gamesnd_id stealth_departue_snd, float arrival_delay, float departure_delay);
 
 	void blipDrawDistorted(blip *b, vec3d *pos, float alpha);
 	void blipDrawFlicker(blip *b, vec3d *pos, float alpha);

--- a/code/radar/radarorb.cpp
+++ b/code/radar/radarorb.cpp
@@ -500,7 +500,7 @@ void HudGaugeRadarOrb::render(float frametime)
 		if ( Radar_static_playing ) {
 			drawBlipsSorted(1);	// passing 1 means to draw distorted
 			if ( Radar_static_looping == -1 ) {
-				Radar_static_looping = snd_play_looping(gamesnd_get_game_sound(SND_STATIC));
+				Radar_static_looping = snd_play_looping(gamesnd_get_game_sound(GameSounds::STATIC));
 			}
 		} else {
 			drawBlipsSorted(0);

--- a/code/scripting/api/libs/audio.cpp
+++ b/code/scripting/api/libs/audio.cpp
@@ -22,7 +22,7 @@ ADE_LIB(l_Audio, "Audio", "ad", "Sound/Music Library");
 
 ADE_FUNC(getSoundentry, l_Audio, "string/number", "Return a sound entry matching the specified index or name. If you are using a number then the first valid index is 1", "soundentry", "soundentry or invalid handle on error")
 {
-	int index = -1;
+	gamesnd_id index;
 
 	if (lua_isnumber(L, 1))
 	{
@@ -44,7 +44,7 @@ ADE_FUNC(getSoundentry, l_Audio, "string/number", "Return a sound entry matching
 		index = gamesnd_get_by_name(s);
 	}
 
-	if (index < 0)
+	if (!index.isValid())
 	{
 		return ade_set_args(L, "o", l_SoundEntry.Set(sound_entry_h()));
 	}
@@ -138,7 +138,7 @@ ADE_FUNC(play3DSound, l_Audio, "soundentry[, vector source[, vector listener]]",
 
 ADE_FUNC(playGameSound, l_Audio, "Sound index, [Panning (-1.0 left to 1.0 right), Volume %, Priority 0-3, Voice Message?]", "Plays a sound from #Game Sounds in sounds.tbl. A priority of 0 indicates that the song must play; 1-3 will specify the maximum number of that sound that can be played", "boolean", "True if sound was played, false if not (Replaced with a sound instance object in the future)")
 {
-	int idx, gamesnd_idx;
+	int idx;
 	float pan=0.0f;
 	float vol=100.0f;
 	int pri=0;
@@ -155,30 +155,30 @@ ADE_FUNC(playGameSound, l_Audio, "Sound index, [Panning (-1.0 left to 1.0 right)
 	CLAMP(pan, -1.0f, 1.0f);
 	CLAMP(vol, 0.0f, 100.0f);
 
-	gamesnd_idx = gamesnd_get_by_tbl_index(idx);
+	auto gamesnd_idx = gamesnd_get_by_tbl_index(idx);
 
-	if (gamesnd_idx >= 0) {
+	if (gamesnd_idx.isValid()) {
 		int sound_handle = snd_play(gamesnd_get_game_sound(gamesnd_idx), pan, vol*0.01f, pri, voice_msg);
 		return ade_set_args(L, "b", sound_handle >= 0);
 	} else {
-		LuaError(L, "Invalid sound index %i (Snds[%i]) in playGameSound()", idx, gamesnd_idx);
+		LuaError(L, "Invalid sound index %i (Snds[%i]) in playGameSound()", idx, gamesnd_idx.value());
 		return ADE_RETURN_FALSE;
 	}
 }
 
 ADE_FUNC(playInterfaceSound, l_Audio, "Sound index", "Plays a sound from #Interface Sounds in sounds.tbl", "boolean", "True if sound was played, false if not")
 {
-	int idx, gamesnd_idx;
+	int idx;
 	if(!ade_get_args(L, "i", &idx))
 		return ade_set_error(L, "b", false);
 
-	gamesnd_idx = gamesnd_get_by_iface_tbl_index(idx);
+	auto gamesnd_idx = gamesnd_get_by_iface_tbl_index(idx);
 
-	if (gamesnd_idx >= 0) {
+	if (gamesnd_idx.isValid()) {
 		gamesnd_play_iface(gamesnd_idx);
 		return ade_set_args(L, "b", true);
 	} else {
-		LuaError(L, "Invalid sound index %i (Snds[%i]) in playInterfaceSound()", idx, gamesnd_idx);
+		LuaError(L, "Invalid sound index %i (Snds[%i]) in playInterfaceSound()", idx, gamesnd_idx.value());
 		return ADE_RETURN_FALSE;
 	}
 }

--- a/code/scripting/api/objs/sound.cpp
+++ b/code/scripting/api/objs/sound.cpp
@@ -10,9 +10,8 @@ namespace scripting {
 namespace api {
 
 sound_entry_h::sound_entry_h() {
-	idx = -1;
 }
-sound_entry_h::sound_entry_h(int n_idx) {
+sound_entry_h::sound_entry_h(gamesnd_id n_idx) {
 	idx = n_idx;
 }
 game_snd* sound_entry_h::Get() {
@@ -125,7 +124,7 @@ sound_h::sound_h() :sound_entry_h()
 {
 	sig=-1;
 }
-sound_h::sound_h(int n_gs_idx, int n_sig) : sound_entry_h(n_gs_idx)
+sound_h::sound_h(gamesnd_id n_gs_idx, int n_sig) : sound_entry_h(n_gs_idx)
 {
 	sig=n_sig;
 }
@@ -406,7 +405,7 @@ ADE_FUNC(play, l_Soundfile, "[number volume = 1.0[, number panning = 0.0]]", "Pl
 
 	int handle = snd_play_raw(snd_idx, panning, volume);
 
-	return ade_set_args(L, "o", l_Sound.Set(sound_h(-1, handle)));
+	return ade_set_args(L, "o", l_Sound.Set(sound_h(gamesnd_id(), handle)));
 }
 
 ADE_FUNC(isValid, l_Soundfile, NULL, "Checks if the soundfile handle is valid", "boolean", "true if valid, false otherwise")

--- a/code/scripting/api/objs/sound.h
+++ b/code/scripting/api/objs/sound.h
@@ -2,7 +2,7 @@
 
 #include <sound/ds.h>
 #include "scripting/ade_api.h"
-
+#include "gamesnd/gamesnd.h"
 #include "sound/sound.h"
 
 namespace scripting {
@@ -11,11 +11,11 @@ namespace api {
 
 struct sound_entry_h
 {
-	int idx;
+	gamesnd_id idx;
 
 	sound_entry_h();
 
-	explicit sound_entry_h(int n_idx);
+	explicit sound_entry_h(gamesnd_id n_idx);
 
 	game_snd *Get();
 
@@ -31,7 +31,7 @@ struct sound_h : public sound_entry_h
 
 	sound_h();
 
-	sound_h(int n_gs_idx, int n_sig);
+	sound_h(gamesnd_id n_gs_idx, int n_sig);
 
 	int getSignature();
 

--- a/code/ship/afterburner.cpp
+++ b/code/ship/afterburner.cpp
@@ -93,7 +93,7 @@ void afterburners_start(object *objp)
 		now = timer_get_milliseconds();
 
 		if ( (now - Player_afterburner_start_time) < 1300 ) {
-			snd_play( gamesnd_get_game_sound(ship_get_sound(objp, SND_ABURN_FAIL)) );
+			snd_play( gamesnd_get_game_sound(ship_get_sound(objp, GameSounds::ABURN_FAIL)) );
 			return;
 		}
 
@@ -117,7 +117,7 @@ void afterburners_start(object *objp)
 	// Check if there is enough afterburner fuel
 	if ( (shipp->afterburner_fuel < MIN_AFTERBURNER_FUEL_TO_ENGAGE) && !MULTIPLAYER_CLIENT ) {
 		if ( objp == Player_obj ) {
-			snd_play( gamesnd_get_game_sound(ship_get_sound(objp, SND_ABURN_FAIL)) );
+			snd_play( gamesnd_get_game_sound(ship_get_sound(objp, GameSounds::ABURN_FAIL)) );
 		}
 		return;
 	}
@@ -143,10 +143,10 @@ void afterburners_start(object *objp)
 			Player_afterburner_loop_delay = 0;
 		}
 
-		snd_play( gamesnd_get_game_sound(ship_get_sound(objp, SND_ABURN_ENGAGE)), 0.0f, 1.0f, SND_PRIORITY_MUST_PLAY );
+		snd_play( gamesnd_get_game_sound(ship_get_sound(objp, GameSounds::ABURN_ENGAGE)), 0.0f, 1.0f, SND_PRIORITY_MUST_PLAY );
 		joy_ff_afterburn_on();
 	} else {
-		snd_play_3d( gamesnd_get_game_sound(ship_get_sound(objp, SND_ABURN_ENGAGE)), &objp->pos, &View_position, objp->radius );
+		snd_play_3d( gamesnd_get_game_sound(ship_get_sound(objp, GameSounds::ABURN_ENGAGE)), &objp->pos, &View_position, objp->radius );
 	}
 
 	Script_system.SetHookObjects(1, "Ship", objp);
@@ -252,7 +252,7 @@ void afterburners_update(object *objp, float fl_frametime)
 			Player_afterburner_vol = AFTERBURNER_DEFAULT_VOL;
 			Player_afterburner_loop_delay = 0;
 			if ( Player_afterburner_loop_id == -1 ) {
-				Player_afterburner_loop_id = snd_play_looping( gamesnd_get_game_sound(ship_get_sound(objp, SND_ABURN_LOOP)), 0.0f , -1, -1);
+				Player_afterburner_loop_id = snd_play_looping( gamesnd_get_game_sound(ship_get_sound(objp, GameSounds::ABURN_LOOP)), 0.0f , -1, -1);
 				snd_set_volume(Player_afterburner_loop_id, Player_afterburner_vol);
 			}
 		}
@@ -314,7 +314,7 @@ void afterburners_stop(object *objp, int key_released)
 	if ( objp == Player_obj ) {
 
 		if ( !key_released ) {
-			snd_play( gamesnd_get_game_sound(ship_get_sound(objp, SND_ABURN_FAIL)) );
+			snd_play( gamesnd_get_game_sound(ship_get_sound(objp, GameSounds::ABURN_FAIL)) );
 		}
 
 		if ( Player_afterburner_loop_id > -1 )	{

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -1493,8 +1493,8 @@ ship_info::ship_info()
 
 	warpin_anim[0] = '\0';
 	warpin_radius = 0.0f;
-	warpin_snd_start = -1;
-	warpin_snd_end = -1;
+	warpin_snd_start = gamesnd_id();
+	warpin_snd_end = gamesnd_id();
 	warpin_speed = 0.0f;
 	warpin_time = 0;
 	warpin_decel_exp = 1;
@@ -1502,8 +1502,8 @@ ship_info::ship_info()
 
 	warpout_anim[0] = '\0';
 	warpout_radius = 0.0f;
-	warpout_snd_start = -1;
-	warpout_snd_end = -1;
+	warpout_snd_start = gamesnd_id();
+	warpout_snd_end = gamesnd_id();
 	warpout_engage_time = -1;
 	warpout_speed = 0.0f;
 	warpout_time = 0;
@@ -1526,7 +1526,7 @@ ship_info::ship_info()
 	collision_physics.friction = COLLISION_FRICTION_FACTOR;
 	collision_physics.rotation_factor = COLLISION_ROTATION_FACTOR;
 	collision_physics.reorient_mult = 1.0f;
-	collision_physics.landing_sound_idx = -1;
+	collision_physics.landing_sound_idx = gamesnd_id();
 
 	shockwave_create_info_init(&shockwave);
 	explosion_propagates = 0;
@@ -1758,10 +1758,10 @@ ship_info::ship_info()
 	topdown_offset_def = false;
 	vm_vec_zero(&topdown_offset);
 
-	engine_snd = -1;
+	engine_snd = gamesnd_id();
 	min_engine_vol = -1.0f;
-	glide_start_snd = -1;
-	glide_end_snd = -1;
+	glide_start_snd = gamesnd_id();
+	glide_end_snd = gamesnd_id();
 
 	ship_sounds.clear();
 
@@ -1981,45 +1981,45 @@ static int parse_ship_template()
 	return rtn;
 }
 
-static void parse_ship_sound(const char *name, GameSoundsIndex id, ship_info *sip)
+static void parse_ship_sound(const char *name, GameSounds id, ship_info *sip)
 {
 	Assert( name != NULL );
 
-	int temp_index = -1;
+	gamesnd_id temp_index;
 
-	parse_sound(name, &temp_index, sip->name);
+	parse_game_sound(name, &temp_index, sip->name);
 
-	if (temp_index >= 0)
-		sip->ship_sounds.insert(std::pair<GameSoundsIndex, int>(id, temp_index));
+	if (temp_index.isValid())
+		sip->ship_sounds.insert(std::make_pair(id, temp_index));
 }
 
 static void parse_ship_sounds(ship_info *sip)
 {
-	parse_ship_sound("$CockpitEngineSnd:",                SND_ENGINE, sip);
-	parse_ship_sound("$FullThrottleSnd:",                 SND_FULL_THROTTLE, sip);
-	parse_ship_sound("$ZeroThrottleSnd:",                 SND_ZERO_THROTTLE, sip);
-	parse_ship_sound("$ThrottleUpSnd:",                   SND_THROTTLE_UP, sip);
-	parse_ship_sound("$ThrottleDownSnd:",                 SND_THROTTLE_DOWN, sip);
-	parse_ship_sound("$AfterburnerSnd:",                  SND_ABURN_LOOP, sip);
-	parse_ship_sound("$AfterburnerEngageSnd:",            SND_ABURN_ENGAGE, sip);
-	parse_ship_sound("$AfterburnerFailedSnd:",            SND_ABURN_FAIL, sip);
-	parse_ship_sound("$MissileTrackingSnd:",              SND_MISSILE_TRACKING, sip);
-	parse_ship_sound("$MissileLockedSnd:",                SND_MISSILE_LOCK, sip);
-	parse_ship_sound("$PrimaryCycleSnd:",                 SND_PRIMARY_CYCLE, sip);
-	parse_ship_sound("$SecondaryCycleSnd:",               SND_SECONDARY_CYCLE, sip);
-	parse_ship_sound("$TargetAcquiredSnd:",               SND_TARGET_ACQUIRE, sip);
-	parse_ship_sound("$PrimaryFireFailedSnd:",            SND_OUT_OF_WEAPON_ENERGY, sip);
-	parse_ship_sound("$SecondaryFireFailedSnd:",          SND_OUT_OF_MISSLES, sip);
-	parse_ship_sound("$HeatSeekerLaunchWarningSnd:",      SND_HEATLOCK_WARN, sip);
-	parse_ship_sound("$AspectSeekerLaunchWarningSnd:",    SND_ASPECTLOCK_WARN, sip);
-	parse_ship_sound("$MissileLockWarningSnd:",           SND_THREAT_FLASH, sip);
-	parse_ship_sound("$HeatSeekerProximityWarningSnd:",   SND_PROXIMITY_WARNING, sip);
-	parse_ship_sound("$AspectSeekerProximityWarningSnd:", SND_PROXIMITY_ASPECT_WARNING, sip);
-	parse_ship_sound("$MissileEvadedSnd:",                SND_MISSILE_EVADED_POPUP, sip);
-	parse_ship_sound("$CargoScanningSnd:",                SND_CARGO_SCAN, sip);
+	parse_ship_sound("$CockpitEngineSnd:",                GameSounds::ENGINE, sip);
+	parse_ship_sound("$FullThrottleSnd:",                 GameSounds::FULL_THROTTLE, sip);
+	parse_ship_sound("$ZeroThrottleSnd:",                 GameSounds::ZERO_THROTTLE, sip);
+	parse_ship_sound("$ThrottleUpSnd:",                   GameSounds::THROTTLE_UP, sip);
+	parse_ship_sound("$ThrottleDownSnd:",                 GameSounds::THROTTLE_DOWN, sip);
+	parse_ship_sound("$AfterburnerSnd:",                  GameSounds::ABURN_LOOP, sip);
+	parse_ship_sound("$AfterburnerEngageSnd:",            GameSounds::ABURN_ENGAGE, sip);
+	parse_ship_sound("$AfterburnerFailedSnd:",            GameSounds::ABURN_FAIL, sip);
+	parse_ship_sound("$MissileTrackingSnd:",              GameSounds::MISSILE_TRACKING, sip);
+	parse_ship_sound("$MissileLockedSnd:",                GameSounds::MISSILE_LOCK, sip);
+	parse_ship_sound("$PrimaryCycleSnd:",                 GameSounds::PRIMARY_CYCLE, sip);
+	parse_ship_sound("$SecondaryCycleSnd:",               GameSounds::SECONDARY_CYCLE, sip);
+	parse_ship_sound("$TargetAcquiredSnd:",               GameSounds::TARGET_ACQUIRE, sip);
+	parse_ship_sound("$PrimaryFireFailedSnd:",            GameSounds::OUT_OF_WEAPON_ENERGY, sip);
+	parse_ship_sound("$SecondaryFireFailedSnd:",          GameSounds::OUT_OF_MISSLES, sip);
+	parse_ship_sound("$HeatSeekerLaunchWarningSnd:",      GameSounds::HEATLOCK_WARN, sip);
+	parse_ship_sound("$AspectSeekerLaunchWarningSnd:",    GameSounds::ASPECTLOCK_WARN, sip);
+	parse_ship_sound("$MissileLockWarningSnd:",           GameSounds::THREAT_FLASH, sip);
+	parse_ship_sound("$HeatSeekerProximityWarningSnd:",   GameSounds::PROXIMITY_WARNING, sip);
+	parse_ship_sound("$AspectSeekerProximityWarningSnd:", GameSounds::PROXIMITY_ASPECT_WARNING, sip);
+	parse_ship_sound("$MissileEvadedSnd:",                GameSounds::MISSILE_EVADED_POPUP, sip);
+	parse_ship_sound("$CargoScanningSnd:",                GameSounds::CARGO_SCAN, sip);
 
 	// Use SND_SHIP_EXPLODE_1 for custom explosion sounds
-	parse_ship_sound("$ExplosionSnd:",                    SND_SHIP_EXPLODE_1, sip);
+	parse_ship_sound("$ExplosionSnd:",                    GameSounds::SHIP_EXPLODE_1, sip);
 } 
 
 static void parse_ship_particle_effect(ship_info* sip, particle_effect* pe, const char *id_string)
@@ -2728,7 +2728,7 @@ static int parse_ship_values(ship_info* sip, const bool is_template, const bool 
 			stuff_float(&degrees);
 			sip->collision_physics.landing_rest_angle = cosf(fl_radians(90.0f - degrees));
 		}
-		parse_sound("+Landing Sound:", &sip->collision_physics.landing_sound_idx, sip->name);
+		parse_game_sound("+Landing Sound:", &sip->collision_physics.landing_sound_idx, sip->name);
 	}
 
 
@@ -2950,8 +2950,8 @@ static int parse_ship_values(ship_info* sip, const bool is_template, const bool 
 		}
 	}
 
-	parse_sound("$Warpin Start Sound:", &sip->warpin_snd_start, sip->name);
-	parse_sound("$Warpin End Sound:", &sip->warpin_snd_end, sip->name);
+	parse_game_sound("$Warpin Start Sound:", &sip->warpin_snd_start, sip->name);
+	parse_game_sound("$Warpin End Sound:", &sip->warpin_snd_end, sip->name);
 
 	if(optional_string("$Warpin speed:"))
 	{
@@ -3002,8 +3002,8 @@ static int parse_ship_values(ship_info* sip, const bool is_template, const bool 
 		}
 	}
 
-	parse_sound("$Warpout Start Sound:", &sip->warpout_snd_start, sip->name);
-	parse_sound("$Warpout End Sound:", &sip->warpout_snd_end, sip->name);
+	parse_game_sound("$Warpout Start Sound:", &sip->warpout_snd_start, sip->name);
+	parse_game_sound("$Warpout End Sound:", &sip->warpout_snd_end, sip->name);
 
 	if(optional_string("$Warpout engage time:"))
 	{
@@ -3592,16 +3592,16 @@ static int parse_ship_values(ship_info* sip, const bool is_template, const bool 
 		stuff_int(&sip->scan_time);
 
 	//Parse the engine sound
-	parse_sound("$EngineSnd:", &sip->engine_snd, sip->name);
+	parse_game_sound("$EngineSnd:", &sip->engine_snd, sip->name);
 
 	if(optional_string("$Minimum Engine Volume:"))
 		stuff_float(&sip->min_engine_vol);
 
 	//Parse optional sound to be used for beginning of a glide
-	parse_sound("$GlideStartSnd:", &sip->glide_start_snd, sip->name);
+	parse_game_sound("$GlideStartSnd:", &sip->glide_start_snd, sip->name);
 
 	//Parse optional sound to be used for end of a glide
-	parse_sound("$GlideEndSnd:", &sip->glide_end_snd, sip->name);
+	parse_game_sound("$GlideEndSnd:", &sip->glide_end_snd, sip->name);
 
 	parse_ship_sounds(sip);
 	
@@ -3993,9 +3993,9 @@ static int parse_ship_values(ship_info* sip, const bool is_template, const bool 
 			stuff_float(&mtp->length);
 		}
 
-		parse_sound("+StartSnd:", &mtp->start_snd, sip->name);
-		parse_sound("+LoopSnd:", &mtp->loop_snd, sip->name);
-		parse_sound("+StopSnd:", &mtp->stop_snd, sip->name);
+		parse_game_sound("+StartSnd:", &mtp->start_snd, sip->name);
+		parse_game_sound("+LoopSnd:", &mtp->loop_snd, sip->name);
+		parse_game_sound("+StopSnd:", &mtp->stop_snd, sip->name);
 	}
 
 	if (optional_string("$Glowpoint overrides:")) {
@@ -4237,12 +4237,12 @@ static int parse_ship_values(ship_info* sip, const bool is_template, const bool 
 
 				sp->engine_wash_pointer = NULL;
 				
-				sp->alive_snd = -1;
-				sp->dead_snd = -1;
-				sp->rotation_snd = -1;
-				sp->turret_gun_rotation_snd = -1;
+				sp->alive_snd = gamesnd_id();
+				sp->dead_snd = gamesnd_id();
+				sp->rotation_snd = gamesnd_id();
+				sp->turret_gun_rotation_snd = gamesnd_id();
 				sp->turret_gun_rotation_snd_mult = 1.0f;
-				sp->turret_base_rotation_snd = -1;
+				sp->turret_base_rotation_snd = gamesnd_id();
 				sp->turret_base_rotation_snd_mult = 1.0f;
 				
                 sp->flags.reset();
@@ -4329,11 +4329,11 @@ static int parse_ship_values(ship_info* sip, const bool is_template, const bool 
 					WarningEx(LOCATION,"Invalid engine wash name %s specified for subsystem %s in %s '%s'", name_tmp, sp->subobj_name, info_type_name, sip->name);
 			}
 
-			parse_sound("$AliveSnd:", &sp->alive_snd, sp->subobj_name);
-			parse_sound("$DeadSnd:", &sp->dead_snd, sp->subobj_name);
-			parse_sound("$RotationSnd:", &sp->rotation_snd, sp->subobj_name);
-			parse_sound("$Turret Base RotationSnd:", &sp->turret_base_rotation_snd, sp->subobj_name);
-			parse_sound("$Turret Gun RotationSnd:", &sp->turret_gun_rotation_snd, sp->subobj_name);
+			parse_game_sound("$AliveSnd:", &sp->alive_snd, sp->subobj_name);
+			parse_game_sound("$DeadSnd:", &sp->dead_snd, sp->subobj_name);
+			parse_game_sound("$RotationSnd:", &sp->rotation_snd, sp->subobj_name);
+			parse_game_sound("$Turret Base RotationSnd:", &sp->turret_base_rotation_snd, sp->subobj_name);
+			parse_game_sound("$Turret Gun RotationSnd:", &sp->turret_gun_rotation_snd, sp->subobj_name);
 
 			if (optional_string("$Turret BaseSnd Volume:"))
 				stuff_float(&sp->turret_base_rotation_snd_mult);
@@ -4649,18 +4649,18 @@ static int parse_ship_values(ship_info* sip, const bool is_template, const bool 
 							current_trigger->end = 0;
 
 						if(optional_string("$Sound:")){
-							parse_sound("+Start:", &current_trigger->start_sound, sip->name);
+							parse_game_sound("+Start:", &current_trigger->start_sound, sip->name);
 
-							parse_sound("+Loop:", &current_trigger->loop_sound, sip->name);
+							parse_game_sound("+Loop:", &current_trigger->loop_sound, sip->name);
 
-							parse_sound("+End:", &current_trigger->end_sound, sip->name);
+							parse_game_sound("+End:", &current_trigger->end_sound, sip->name);
 
 							required_string("+Radius:");
 							stuff_float(&current_trigger->snd_rad );
 						}else{
-							current_trigger->start_sound = -1;
-							current_trigger->loop_sound = -1;
-							current_trigger->end_sound = -1;
+							current_trigger->start_sound = gamesnd_id();
+							current_trigger->loop_sound = gamesnd_id();
+							current_trigger->end_sound = gamesnd_id();
 							current_trigger->snd_rad = 0;
 						}
 					}
@@ -6281,25 +6281,25 @@ void ship_recalc_subsys_strength( ship *shipp )
                 obj_snd_delete_type(shipp->objnum, ship_system->system_info->dead_snd, ship_system);
                 ship_system->subsys_snd_flags.set(Ship::Subsys_Sound_Flags::Dead, false);
             }
-            if ((ship_system->system_info->alive_snd != -1) && !(ship_system->subsys_snd_flags[Ship::Subsys_Sound_Flags::Alive]))
+            if ((ship_system->system_info->alive_snd.isValid()) && !(ship_system->subsys_snd_flags[Ship::Subsys_Sound_Flags::Alive]))
             {
                 obj_snd_assign(shipp->objnum, ship_system->system_info->alive_snd, &ship_system->system_info->pnt, 0, OS_SUBSYS_ALIVE, ship_system);
                 ship_system->subsys_snd_flags.set(Ship::Subsys_Sound_Flags::Alive);
             }
             if (!(ship_system->subsys_snd_flags[Ship::Subsys_Sound_Flags::Turret_rotation]))
             {
-                if (ship_system->system_info->turret_base_rotation_snd != -1)
+                if (ship_system->system_info->turret_base_rotation_snd.isValid())
                 {
                     obj_snd_assign(shipp->objnum, ship_system->system_info->turret_base_rotation_snd, &ship_system->system_info->pnt, 0, OS_TURRET_BASE_ROTATION, ship_system);
                     ship_system->subsys_snd_flags.set(Ship::Subsys_Sound_Flags::Turret_rotation);
                 }
-                if (ship_system->system_info->turret_gun_rotation_snd != -1)
+                if (ship_system->system_info->turret_gun_rotation_snd.isValid())
                 {
                     obj_snd_assign(shipp->objnum, ship_system->system_info->turret_gun_rotation_snd, &ship_system->system_info->pnt, 0, OS_TURRET_GUN_ROTATION, ship_system);
                     ship_system->subsys_snd_flags.set(Ship::Subsys_Sound_Flags::Turret_rotation);
                 }
             }
-            if ((ship_system->flags[Subsystem_Flags::Rotates]) && (ship_system->system_info->rotation_snd != -1) && !(ship_system->subsys_snd_flags[Ship::Subsys_Sound_Flags::Rotate]))
+            if ((ship_system->flags[Subsystem_Flags::Rotates]) && (ship_system->system_info->rotation_snd.isValid()) && !(ship_system->subsys_snd_flags[Ship::Subsys_Sound_Flags::Rotate]))
             {
                 obj_snd_assign(shipp->objnum, ship_system->system_info->rotation_snd, &ship_system->system_info->pnt, 0, OS_SUBSYS_ROTATION, ship_system);
                 ship_system->subsys_snd_flags.set(Ship::Subsys_Sound_Flags::Rotate);
@@ -6323,7 +6323,7 @@ void ship_recalc_subsys_strength( ship *shipp )
                 obj_snd_delete_type(shipp->objnum, ship_system->system_info->rotation_snd, ship_system);
                 ship_system->subsys_snd_flags.set(Ship::Subsys_Sound_Flags::Rotate, false);
             }
-            if ((ship_system->system_info->dead_snd != -1) && !(ship_system->subsys_snd_flags[Ship::Subsys_Sound_Flags::Dead]))
+            if ((ship_system->system_info->dead_snd.isValid()) && !(ship_system->subsys_snd_flags[Ship::Subsys_Sound_Flags::Dead]))
             {
                 obj_snd_assign(shipp->objnum, ship_system->system_info->dead_snd, &ship_system->system_info->pnt, 0, OS_SUBSYS_DEAD, ship_system);
                 ship_system->subsys_snd_flags.set(Ship::Subsys_Sound_Flags::Dead, false);
@@ -7785,7 +7785,7 @@ static void ship_dying_frame(object *objp, int ship_num)
 		if (shipp->flags[Ship_Flags::Vaporize]) {
 			if (timestamp_elapsed(shipp->final_death_time)) {
 				// play death sound
-				snd_play_3d( gamesnd_get_game_sound(SND_VAPORIZED), &objp->pos, &View_position, objp->radius, NULL, 0, 1.0f, SND_PRIORITY_MUST_PLAY  );
+				snd_play_3d( gamesnd_get_game_sound(GameSounds::VAPORIZED), &objp->pos, &View_position, objp->radius, NULL, 0, 1.0f, SND_PRIORITY_MUST_PLAY  );
 
 				// do joystick effect
 				if (objp == Player_obj) {
@@ -7964,21 +7964,21 @@ static void ship_dying_frame(object *objp, int ship_num)
 			shipp->final_death_time = timestamp(-1);	// never time out again
 			
 			// play ship explosion sound effect, pick appropriate explosion sound
-			int sound_index;
+			gamesnd_id sound_index;
 
-			if (ship_has_sound(objp, SND_SHIP_EXPLODE_1))
+			if (ship_has_sound(objp, GameSounds::SHIP_EXPLODE_1))
 			{
-				sound_index = ship_get_sound(objp, SND_SHIP_EXPLODE_1);
+				sound_index = ship_get_sound(objp, GameSounds::SHIP_EXPLODE_1);
 			}
 			else
 			{
 				if (sip->flags[Info_Flags::Capital] || sip->flags[Info_Flags::Knossos_device]) {
-					sound_index=SND_CAPSHIP_EXPLODE;
+					sound_index=GameSounds::CAPSHIP_EXPLODE;
 				} else {
 					 if ( OBJ_INDEX(objp) & 1 ) {
-						sound_index=SND_SHIP_EXPLODE_1;
+						sound_index=GameSounds::SHIP_EXPLODE_1;
 					} else {
-						sound_index=SND_SHIP_EXPLODE_2;
+						sound_index=GameSounds::SHIP_EXPLODE_2;
 					}
 				}
 			}
@@ -10360,7 +10360,7 @@ int ship_launch_countermeasure(object *objp, int rand_val)
 			} else if(shipp->cmeasure_count <= 0) {
 				HUD_sourced_printf(HUD_SOURCE_HIDDEN, "%s", XSTR( "No more countermeasure charges.", 485));
 			}
-			snd_play( gamesnd_get_game_sound(ship_get_sound(Player_obj, SND_OUT_OF_MISSLES)), 0.0f );
+			snd_play( gamesnd_get_game_sound(ship_get_sound(Player_obj, GameSounds::OUT_OF_MISSLES)), 0.0f );
 		}
 
 		// if we have a player ship, then send the fired packet anyway so that the player
@@ -10390,7 +10390,7 @@ int ship_launch_countermeasure(object *objp, int rand_val)
 
 		// Play sound effect for counter measure launch
 		Assert(shipp->current_cmeasure < Num_weapon_types);
-		if ( Weapon_info[shipp->current_cmeasure].launch_snd >= 0 ) {
+		if ( Weapon_info[shipp->current_cmeasure].launch_snd.isValid() ) {
 			snd_play_3d( gamesnd_get_game_sound(Weapon_info[shipp->current_cmeasure].launch_snd), &pos, &View_position );
 		}
 
@@ -10425,7 +10425,7 @@ void ship_maybe_play_primary_fail_sound()
 			stampval = 50;
 		}
 		Laser_energy_out_snd_timer = timestamp(stampval);
-		snd_play( gamesnd_get_game_sound(ship_get_sound(Player_obj, SND_OUT_OF_WEAPON_ENERGY)));
+		snd_play( gamesnd_get_game_sound(ship_get_sound(Player_obj, GameSounds::OUT_OF_WEAPON_ENERGY)));
 	}
 }
 
@@ -10443,7 +10443,7 @@ static int ship_maybe_play_secondary_fail_sound(weapon_info *wip)
 		} else {
 			Missile_out_snd_timer = timestamp(50);
 		}
-		snd_play( gamesnd_get_game_sound(ship_get_sound(Player_obj, SND_OUT_OF_MISSLES)) );
+		snd_play( gamesnd_get_game_sound(ship_get_sound(Player_obj, GameSounds::OUT_OF_MISSLES)) );
 		return 1;
 	}
 	return 0;
@@ -10639,7 +10639,7 @@ int ship_fire_primary(object * obj, int stream_weapons, int force)
 	float autoaim_fov = 0;			// autoaim limit
 	float dist_to_target = 0;		// distance to target, for autoaim & automatic convergence
 
-	int			sound_played;	// used to track what sound is played.  If the player is firing two banks
+	gamesnd_id		sound_played;	// used to track what sound is played.  If the player is firing two banks
 										// of the same laser, we only want to play one sound
 	Assert( obj != NULL );
 
@@ -10686,7 +10686,7 @@ int ship_fire_primary(object * obj, int stream_weapons, int force)
 		return 0;
 	}
 
-	sound_played = -1;
+	sound_played = gamesnd_id();
 
 	// Fire the correct primary bank.  If primaries are linked (SF_PRIMARY_LINKED set), then fire 
 	// both primary banks.
@@ -11317,7 +11317,7 @@ int ship_fire_primary(object * obj, int stream_weapons, int force)
 			if ( sound_played != winfo_p->launch_snd ) {
 				sound_played = winfo_p->launch_snd;
 				if ( obj == Player_obj ) {
-					if ( winfo_p->launch_snd != -1 ) {
+					if ( winfo_p->launch_snd.isValid() ) {
 						weapon_info *wip;
 						ship_weapon *sw_pl;
 
@@ -11327,14 +11327,14 @@ int ship_fire_primary(object * obj, int stream_weapons, int force)
 						}
 
 						//Check for pre-launch sound and play if relevant
-						if( (winfo_p->pre_launch_snd != -1)									//If this weapon type has a pre-fire sound
+						if( (winfo_p->pre_launch_snd.isValid())									//If this weapon type has a pre-fire sound
 							&& ((timestamp() - swp->last_primary_fire_sound_stamp[bank_to_fire]) >= winfo_p->pre_launch_snd_min_interval)	//and if we're past our minimum delay from the last cease-fire
 							&& (shipp->was_firing_last_frame[bank_to_fire] == 0)				//and if we are at the beginning of a firing stream
 						){ 
 							snd_play( gamesnd_get_game_sound(winfo_p->pre_launch_snd), 0.0f, 1.0f, SND_PRIORITY_MUST_PLAY); //play it
 						} else { //Otherwise, play normal firing sounds
 							// HACK
-							if(winfo_p->launch_snd == SND_AUTOCANNON_SHOT){
+							if(winfo_p->launch_snd == gamesnd_id(GameSounds::AUTOCANNON_SHOT)){
 								snd_play( gamesnd_get_game_sound(winfo_p->launch_snd), 0.0f, 1.0f, SND_PRIORITY_TRIPLE_INSTANCE );
 							} else {
 								snd_play( gamesnd_get_game_sound(winfo_p->launch_snd), 0.0f, 1.0f, SND_PRIORITY_MUST_PLAY );
@@ -11356,7 +11356,7 @@ int ship_fire_primary(object * obj, int stream_weapons, int force)
 						}
 					}
 				}else {
-					if ( winfo_p->launch_snd != -1 ) {
+					if ( winfo_p->launch_snd.isValid() ) {
 						snd_play_3d( gamesnd_get_game_sound(winfo_p->launch_snd), &obj->pos, &View_position );
 					}	
 				}
@@ -11758,7 +11758,7 @@ int ship_fire_secondary( object *obj, int allow_swarm )
 						HUD_sourced_printf(HUD_SOURCE_HIDDEN, XSTR( "Cannot fire %s without a lock", 488), missile_name);
 					}
 
-					snd_play( gamesnd_get_game_sound(ship_get_sound(Player_obj, SND_OUT_OF_MISSLES)) );
+					snd_play( gamesnd_get_game_sound(ship_get_sound(Player_obj, GameSounds::OUT_OF_MISSLES)) );
 					swp->next_secondary_fire_stamp[bank] = timestamp(800);	// to avoid repeating messages
 					return 0;
 				}
@@ -11781,7 +11781,7 @@ int ship_fire_secondary( object *obj, int allow_swarm )
 				if ( !Weapon_energy_cheat )
 				{
 					HUD_sourced_printf(HUD_SOURCE_HIDDEN, NOX("Cannot fire %s if target is not tagged"),wip->name);
-					snd_play( gamesnd_get_game_sound(ship_get_sound(Player_obj, SND_OUT_OF_MISSLES)) );
+					snd_play( gamesnd_get_game_sound(ship_get_sound(Player_obj, GameSounds::OUT_OF_MISSLES)) );
 					swp->next_secondary_fire_stamp[bank] = timestamp(800);	// to avoid repeating messages
 					return 0;
 				}
@@ -11984,7 +11984,7 @@ int ship_fire_secondary( object *obj, int allow_swarm )
 	}
 
 	if ( obj == Player_obj ) {
-		if ( Weapon_info[weapon_idx].launch_snd != -1 ) {
+		if ( Weapon_info[weapon_idx].launch_snd.isValid() ) {
 			snd_play( gamesnd_get_game_sound(Weapon_info[weapon_idx].launch_snd), 0.0f, 1.0f, SND_PRIORITY_MUST_PLAY );
 			swp = &Player_ship->weapons;
 			if (bank >= 0) {
@@ -11998,7 +11998,7 @@ int ship_fire_secondary( object *obj, int allow_swarm )
 		}
 
 	} else {
-		if ( Weapon_info[weapon_idx].launch_snd != -1 ) {
+		if ( Weapon_info[weapon_idx].launch_snd.isValid() ) {
 			snd_play_3d( gamesnd_get_game_sound(Weapon_info[weapon_idx].launch_snd), &obj->pos, &View_position );
 		}
 	}
@@ -12093,7 +12093,7 @@ done_secondary:
 			}
 						
 			if ( obj == Player_obj ) {
-				snd_play( gamesnd_get_game_sound(ship_get_sound(Player_obj, SND_SECONDARY_CYCLE)) );
+				snd_play( gamesnd_get_game_sound(ship_get_sound(Player_obj, GameSounds::SECONDARY_CYCLE)) );
 			}
 		}
 	}
@@ -12311,7 +12311,7 @@ int ship_select_next_primary(object *objp, int direction)
 	{
 		if ( objp == Player_obj )
 		{
-			snd_play( gamesnd_get_game_sound(ship_get_sound(objp, SND_PRIMARY_CYCLE)), 0.0f );
+			snd_play( gamesnd_get_game_sound(ship_get_sound(objp, GameSounds::PRIMARY_CYCLE)), 0.0f );
 		}
 		ship_primary_changed(shipp);
 		objp = &Objects[shipp->objnum];
@@ -12404,7 +12404,7 @@ int ship_select_next_secondary(object *objp)
 			swp->previous_secondary_bank = original_bank;
 			if ( objp == Player_obj )
 			{
-				snd_play( gamesnd_get_game_sound(ship_get_sound(Player_obj, SND_SECONDARY_CYCLE)), 0.0f );
+				snd_play( gamesnd_get_game_sound(ship_get_sound(Player_obj, GameSounds::SECONDARY_CYCLE)), 0.0f );
 			}
 			ship_secondary_changed(shipp);
 
@@ -13408,7 +13408,7 @@ float ship_calculate_rearm_duration( object *objp )
 			if (!found_first_empty && (swp->primary_bank_start_ammo[i] - swp->primary_bank_ammo[i]))
 			{
 				found_first_empty = true;
-				prim_rearm_time += gamesnd_get_max_duration(gamesnd_get_game_sound(SND_MISSILE_START_LOAD)) / 1000.0f;
+				prim_rearm_time += gamesnd_get_max_duration(gamesnd_get_game_sound(GameSounds::MISSILE_START_LOAD)) / 1000.0f;
 			}
 
 			prim_rearm_time += num_reloads * wip->rearm_rate;
@@ -13438,7 +13438,7 @@ float ship_calculate_rearm_duration( object *objp )
 			if (!found_first_empty && (swp->secondary_bank_start_ammo[i] - swp->secondary_bank_ammo[i]))
 			{
 				found_first_empty = true;
-				sec_rearm_time += gamesnd_get_max_duration(gamesnd_get_game_sound(SND_MISSILE_START_LOAD)) / 1000.0f;
+				sec_rearm_time += gamesnd_get_max_duration(gamesnd_get_game_sound(GameSounds::MISSILE_START_LOAD)) / 1000.0f;
 			}
 
 			sec_rearm_time += num_reloads * wip->rearm_rate;
@@ -13606,7 +13606,7 @@ int ship_do_rearm_frame( object *objp, float frametime )
 			// loading equipment moving into place
 			if ( aip->rearm_first_missile == TRUE )
 			{
-				swp->secondary_bank_rearm_time[i] = timestamp((int)gamesnd_get_max_duration(gamesnd_get_game_sound(SND_MISSILE_START_LOAD)));
+				swp->secondary_bank_rearm_time[i] = timestamp((int)gamesnd_get_max_duration(gamesnd_get_game_sound(GameSounds::MISSILE_START_LOAD)));
 			}
 			
 			if ( swp->secondary_bank_ammo[i] < swp->secondary_bank_start_ammo[i] )
@@ -13623,7 +13623,7 @@ int ship_do_rearm_frame( object *objp, float frametime )
 					rearm_time = Weapon_info[swp->secondary_bank_weapons[i]].rearm_rate;
 					swp->secondary_bank_rearm_time[i] = timestamp((int)(rearm_time * 1000.0f));
 					
-					snd_play_3d( gamesnd_get_game_sound(SND_MISSILE_LOAD), &objp->pos, &View_position );
+					snd_play_3d( gamesnd_get_game_sound(GameSounds::MISSILE_LOAD), &objp->pos, &View_position );
 					if (objp == Player_obj)
 						joy_ff_play_reload_effect();
 
@@ -13645,7 +13645,7 @@ int ship_do_rearm_frame( object *objp, float frametime )
 			if ((aip->rearm_first_missile == TRUE) && (i == swp->num_secondary_banks - 1))
 			{
 				if ((banks_full != swp->num_secondary_banks))
-					snd_play_3d( gamesnd_get_game_sound(SND_MISSILE_START_LOAD), &objp->pos, &View_position );
+					snd_play_3d( gamesnd_get_game_sound(GameSounds::MISSILE_START_LOAD), &objp->pos, &View_position );
 
 				aip->rearm_first_missile = FALSE;
 			}
@@ -13670,11 +13670,11 @@ int ship_do_rearm_frame( object *objp, float frametime )
 				if ( aip->rearm_first_ballistic_primary == TRUE )
 				{
 					// Goober5000
-					int sound_index;
-					if (gamesnd_game_sound_valid(SND_BALLISTIC_START_LOAD))
-						sound_index = SND_BALLISTIC_START_LOAD;
+					gamesnd_id sound_index;
+					if (gamesnd_game_sound_valid(GameSounds::BALLISTIC_START_LOAD))
+						sound_index = GameSounds::BALLISTIC_START_LOAD;
 					else
-						sound_index = SND_MISSILE_START_LOAD;
+						sound_index = GameSounds::MISSILE_START_LOAD;
 
 					swp->primary_bank_rearm_time[i] = timestamp((int)gamesnd_get_max_duration(gamesnd_get_game_sound(sound_index)));
 				}
@@ -13694,11 +13694,11 @@ int ship_do_rearm_frame( object *objp, float frametime )
 						swp->primary_bank_rearm_time[i] = timestamp( (int)(rearm_time * 1000.f) );
 	
 						// Goober5000
-						int sound_index;
-						if (gamesnd_game_sound_valid(SND_BALLISTIC_LOAD))
-							sound_index = SND_BALLISTIC_LOAD;
+						gamesnd_id sound_index;
+						if (gamesnd_game_sound_valid(GameSounds::BALLISTIC_LOAD))
+							sound_index = GameSounds::BALLISTIC_LOAD;
 						else
-							sound_index = SND_MISSILE_LOAD;
+							sound_index = GameSounds::MISSILE_LOAD;
 
 						snd_play_3d( gamesnd_get_game_sound(sound_index), &objp->pos, &View_position );
 	
@@ -13724,11 +13724,11 @@ int ship_do_rearm_frame( object *objp, float frametime )
 			{
 				if (primary_banks_full != swp->num_primary_banks) {
 					// Goober5000
-					int sound_index;
-					if (gamesnd_game_sound_valid(SND_BALLISTIC_START_LOAD))
-						sound_index = SND_BALLISTIC_START_LOAD;
+					gamesnd_id sound_index;
+					if (gamesnd_game_sound_valid(GameSounds::BALLISTIC_START_LOAD))
+						sound_index = GameSounds::BALLISTIC_START_LOAD;
 					else
-						sound_index = SND_MISSILE_START_LOAD;
+						sound_index = GameSounds::MISSILE_START_LOAD;
 
 					snd_play_3d( gamesnd_get_game_sound(sound_index), &objp->pos, &View_position );
 				}
@@ -13999,7 +13999,7 @@ void ship_assign_sound(ship *sp)
 	objp = &Objects[sp->objnum];
 	sip = &Ship_info[sp->ship_info_index];
 
-	if ( sip->engine_snd != -1 ) {
+	if ( sip->engine_snd.isValid() ) {
 		vm_vec_copy_scale(&engine_pos, &objp->orient.vec.fvec, -objp->radius/2.0f);		
 		
 		obj_snd_assign(sp->objnum, sip->engine_snd, &engine_pos, 1);
@@ -14010,30 +14010,30 @@ void ship_assign_sound(ship *sp)
 	while(moveup != END_OF_LIST(&sp->subsys_list)){
 		// Check for any engine sounds		
 		if(strstr(moveup->system_info->name, "enginelarge")){
-			obj_snd_assign(sp->objnum, SND_ENGINE_LOOP_LARGE, &moveup->system_info->pnt, 0);
+			obj_snd_assign(sp->objnum, GameSounds::ENGINE_LOOP_LARGE, &moveup->system_info->pnt, 0);
 		} else if(strstr(moveup->system_info->name, "enginehuge")){
-			obj_snd_assign(sp->objnum, SND_ENGINE_LOOP_HUGE, &moveup->system_info->pnt, 0);
+			obj_snd_assign(sp->objnum, GameSounds::ENGINE_LOOP_HUGE, &moveup->system_info->pnt, 0);
 		}
 
 		//Do any normal subsystem sounds
 		if(moveup->current_hits > 0.0f)
 		{
-			if(moveup->system_info->alive_snd != -1)
+			if(moveup->system_info->alive_snd.isValid())
 			{
 				obj_snd_assign(sp->objnum, moveup->system_info->alive_snd, &moveup->system_info->pnt, 0, OS_SUBSYS_ALIVE, moveup);
                 moveup->subsys_snd_flags.set(Ship::Subsys_Sound_Flags::Alive);
 			}
-			if(moveup->system_info->turret_base_rotation_snd != -1)
+			if(moveup->system_info->turret_base_rotation_snd.isValid())
 			{
 				obj_snd_assign(sp->objnum, moveup->system_info->turret_base_rotation_snd, &moveup->system_info->pnt, 0, OS_TURRET_BASE_ROTATION, moveup);
 				moveup->subsys_snd_flags.set(Ship::Subsys_Sound_Flags::Turret_rotation);
 			}
-			if(moveup->system_info->turret_gun_rotation_snd != -1)
+			if(moveup->system_info->turret_gun_rotation_snd.isValid())
 			{
 				obj_snd_assign(sp->objnum, moveup->system_info->turret_gun_rotation_snd, &moveup->system_info->pnt, 0, OS_TURRET_GUN_ROTATION, moveup);
 				moveup->subsys_snd_flags.set(Ship::Subsys_Sound_Flags::Turret_rotation);
 			}
-			if((moveup->system_info->rotation_snd != -1) && (moveup->flags[Ship::Subsystem_Flags::Rotates]))
+			if((moveup->system_info->rotation_snd.isValid()) && (moveup->flags[Ship::Subsystem_Flags::Rotates]))
 			{
 				obj_snd_assign(sp->objnum, moveup->system_info->rotation_snd, &moveup->system_info->pnt, 0, OS_SUBSYS_ROTATION, moveup);
 				moveup->subsys_snd_flags.set(Ship::Subsys_Sound_Flags::Rotate);
@@ -14041,7 +14041,7 @@ void ship_assign_sound(ship *sp)
 		} 
 		else 
 		{
-			if(moveup->system_info->dead_snd != -1)
+			if(moveup->system_info->dead_snd.isValid())
 			{
 				obj_snd_assign(sp->objnum, moveup->system_info->dead_snd, &moveup->system_info->pnt, 0, OS_SUBSYS_DEAD, moveup);
 				moveup->subsys_snd_flags.set(Ship::Subsys_Sound_Flags::Dead);
@@ -18396,29 +18396,29 @@ void init_path_metadata(path_metadata& metadata)
 	metadata.depart_speed_mult = FLT_MIN;
 }
 
-int ship_get_sound(object *objp, GameSoundsIndex id)
+gamesnd_id ship_get_sound(object *objp, GameSounds id)
 {
 	Assert( objp != NULL );
-	Assert( gamesnd_game_sound_valid(id) );
+	Assert( gamesnd_game_sound_valid(gamesnd_id(id)) );
 
 	// It's possible that this gets called when an object (in most cases the player) is dead or an observer
 	if (objp->type == OBJ_OBSERVER || objp->type == OBJ_GHOST)
-		return id;
+		return gamesnd_id(id);
 
 	Assertion(objp->type == OBJ_SHIP, "Expected a ship, got '%s'.", Object_type_names[objp->type]);
 
 	ship *shipp = &Ships[objp->instance];
 	ship_info *sip = &Ship_info[shipp->ship_info_index];
 
-	SCP_map<GameSoundsIndex, int>::iterator element = sip->ship_sounds.find(id);
+	SCP_map<GameSounds, gamesnd_id>::iterator element = sip->ship_sounds.find(id);
 
 	if (element == sip->ship_sounds.end())
-		return id;
+		return gamesnd_id(id);
 	else
 		return (*element).second;
 }
 
-bool ship_has_sound(object *objp, GameSoundsIndex id)
+bool ship_has_sound(object *objp, GameSounds id)
 {
 	Assert( objp != NULL );
 	Assert( gamesnd_game_sound_valid(id) );
@@ -18432,7 +18432,7 @@ bool ship_has_sound(object *objp, GameSoundsIndex id)
 	ship *shipp = &Ships[objp->instance];
 	ship_info *sip = &Ship_info[shipp->ship_info_index];
 
-	SCP_map<GameSoundsIndex, int>::iterator element = sip->ship_sounds.find(id);
+	auto element = sip->ship_sounds.find(id);
 
 	if (element == sip->ship_sounds.end())
 		return false;
@@ -18565,7 +18565,7 @@ void ship_render_batch_thrusters(object *obj)
 			//Handle sounds and stuff
 			if ( shipp->thrusters_start[i] <= 0 ) {
 				shipp->thrusters_start[i] = timestamp();
-				if(mtp->start_snd >= 0)
+				if(mtp->start_snd.isValid())
 					snd_play_3d( gamesnd_get_game_sound(mtp->start_snd), &mtp->pos, &Eye_position, 0.0f, &obj->phys_info.vel );
 			}
 
@@ -18574,9 +18574,9 @@ void ship_render_batch_thrusters(object *obj)
 			//it isn't assigned already
 			//start sound doesn't exist or has finished
 			if (!Cmdline_freespace_no_sound) {
-				if(mtp->loop_snd >= 0
+				if(mtp->loop_snd.isValid()
 					&& shipp->thrusters_sounds[i] < 0
-					&& (mtp->start_snd < 0 || (gamesnd_get_max_duration(gamesnd_get_game_sound(mtp->start_snd)) < timestamp() - shipp->thrusters_start[i]))
+					&& (!mtp->start_snd.isValid() || (gamesnd_get_max_duration(gamesnd_get_game_sound(mtp->start_snd)) < timestamp() - shipp->thrusters_start[i]))
 					)
 				{
 					shipp->thrusters_sounds[i] = obj_snd_assign(OBJ_INDEX(obj), mtp->loop_snd, &mtp->pos, 1);
@@ -18623,7 +18623,7 @@ void ship_render_batch_thrusters(object *obj)
 				shipp->thrusters_sounds[i] = -1;
 			}
 
-			if ( mtp->stop_snd >= 0 ) {
+			if ( mtp->stop_snd.isValid() ) {
 				//Get world pos
 				vec3d start;
 				vm_vec_unrotate(&start, &mtp->pos, &obj->orient);

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -835,9 +835,9 @@ class man_thruster {
     public:
 	flagset<Ship::Thruster_Flags> use_flags;
 
-	int start_snd;
-	int loop_snd;
-	int stop_snd;
+	gamesnd_id start_snd;
+	gamesnd_id loop_snd;
+	gamesnd_id stop_snd;
 
 	int tex_id;
 	int tex_nframes;
@@ -856,9 +856,9 @@ class man_thruster {
         tex_nframes = 0;
         use_flags.reset();
 
-        start_snd = -1;
-        loop_snd = -1;
-        stop_snd = -1;
+        start_snd = gamesnd_id();
+        loop_snd = gamesnd_id();
+        stop_snd = gamesnd_id();
         tex_id = -1;
     }
 };
@@ -906,7 +906,7 @@ typedef struct ship_collision_physics {
 	// Landing response parameters
 	float reorient_mult;		// How quickly the ship will reorient towards it's resting position
 	float landing_rest_angle;	// The vertical angle where the ship's orientation comes to rest
-	int landing_sound_idx;		//Sound to play on successful landing collisions
+	gamesnd_id landing_sound_idx;		//Sound to play on successful landing collisions
 
 } ship_collision_physics;
 
@@ -968,8 +968,8 @@ public:
 
 	char		warpin_anim[MAX_FILENAME_LEN];
 	float		warpin_radius;
-	int			warpin_snd_start;
-	int			warpin_snd_end;
+	gamesnd_id	warpin_snd_start;
+	gamesnd_id	warpin_snd_end;
 	float		warpin_speed;
 	int			warpin_time;	//in ms
 	float		warpin_decel_exp;
@@ -977,8 +977,8 @@ public:
 
 	char		warpout_anim[MAX_FILENAME_LEN];
 	float		warpout_radius;
-	int			warpout_snd_start;
-	int			warpout_snd_end;
+	gamesnd_id	warpout_snd_start;
+	gamesnd_id	warpout_snd_end;
 	int			warpout_engage_time;	//in ms
 	float		warpout_speed;
 	int			warpout_time;	//in ms
@@ -1175,12 +1175,12 @@ public:
 	bool topdown_offset_def;
 	vec3d topdown_offset;
 
-	int engine_snd;							// handle to engine sound for ship (-1 if no engine sound)
+	gamesnd_id engine_snd;							// handle to engine sound for ship (-1 if no engine sound)
 	float min_engine_vol;					// minimum volume modifier for engine sound when ship is stationary
-	int glide_start_snd;					// handle to sound to play at the beginning of a glide maneuver (default is 0 for regular throttle down sound)
-	int glide_end_snd;						// handle to sound to play at the end of a glide maneuver (default is 0 for regular throttle up sound)
+	gamesnd_id glide_start_snd;					// handle to sound to play at the beginning of a glide maneuver (default is 0 for regular throttle down sound)
+	gamesnd_id glide_end_snd;						// handle to sound to play at the end of a glide maneuver (default is 0 for regular throttle up sound)
 
-	SCP_map<GameSoundsIndex, int> ship_sounds;			// specifies ship-specific sound indexes
+	SCP_map<GameSounds, gamesnd_id> ship_sounds;			// specifies ship-specific sound indexes
 
 	int num_maneuvering;
 	man_thruster maneuvering[MAX_MAN_THRUSTERS];
@@ -1759,7 +1759,7 @@ extern SCP_vector<ship_effect> Ship_effects;
  *  
  *  @return An index into the Snds vector, if the specified index could not be found then the id itself will be returned
  */
-int ship_get_sound(object *objp, GameSoundsIndex id);
+gamesnd_id ship_get_sound(object *objp, GameSounds id);
 
 /**
  *  @brief Specifies if a ship has a custom sound for the specified id
@@ -1769,7 +1769,7 @@ int ship_get_sound(object *objp, GameSoundsIndex id);
  *  
  *  @return True if this object has the specified sound, false otherwise
  */
-bool ship_has_sound(object *objp, GameSoundsIndex id);
+bool ship_has_sound(object *objp, GameSounds id);
 
 /**
  * @brief Returns the index of the default player ship

--- a/code/ship/shipfx.cpp
+++ b/code/ship/shipfx.cpp
@@ -1695,7 +1695,7 @@ static void split_ship_init( ship* shipp, split_ship* split_shipp )
 	}
 
 	// play 3d sound for shockwave explosion
-	snd_play_3d( gamesnd_get_game_sound(SND_SHOCKWAVE_EXPLODE), &parent_ship_obj->pos, &View_position, 0.0f, NULL, 0, 1.0f, SND_PRIORITY_SINGLE_INSTANCE, NULL, 3.0f );
+	snd_play_3d( gamesnd_get_game_sound(GameSounds::SHOCKWAVE_EXPLODE), &parent_ship_obj->pos, &View_position, 0.0f, NULL, 0, 1.0f, SND_PRIORITY_SINGLE_INSTANCE, NULL, 3.0f );
 
 	// initialize both ships
 	split_shipp->front_ship.parent_obj = parent_ship_obj;
@@ -2099,13 +2099,13 @@ static int get_sound_time_played(int snd_id, int handle)
  */
 void do_sub_expl_sound(float radius, vec3d* sound_pos, int* sound_handle)
 {
-	int sound_index, handle;
+	int handle;
 	// multiplier for range (near and far distances) to apply attenuation
 	float sound_range = 1.0f + 0.0043f*radius;
 
 	int handle_index = rand()%NUM_SUB_EXPL_HANDLES;
 
-	sound_index = SND_SHIP_EXPLODE_1;
+	auto sound_index = GameSounds::SHIP_EXPLODE_1;
 	handle = sound_handle[handle_index];
 
 	if (handle == -1) {
@@ -2471,19 +2471,19 @@ void shipfx_do_damaged_arcs_frame( ship *shipp )
 			//Play a sound effect
 			if ( lifetime > 750 )	{
 				// 1.00 second effect
-				snd_play_3d( gamesnd_get_game_sound(SND_DEBRIS_ARC_05), &snd_pos, &View_position, obj->radius );
+				snd_play_3d( gamesnd_get_game_sound(GameSounds::DEBRIS_ARC_05), &snd_pos, &View_position, obj->radius );
 			} else if ( lifetime >  500 )	{
 				// 0.75 second effect
-				snd_play_3d( gamesnd_get_game_sound(SND_DEBRIS_ARC_04), &snd_pos, &View_position, obj->radius );
+				snd_play_3d( gamesnd_get_game_sound(GameSounds::DEBRIS_ARC_04), &snd_pos, &View_position, obj->radius );
 			} else if ( lifetime >  250 )	{
 				// 0.50 second effect
-				snd_play_3d( gamesnd_get_game_sound(SND_DEBRIS_ARC_03), &snd_pos, &View_position, obj->radius );
+				snd_play_3d( gamesnd_get_game_sound(GameSounds::DEBRIS_ARC_03), &snd_pos, &View_position, obj->radius );
 			} else if ( lifetime >  100 )	{
 				// 0.25 second effect
-				snd_play_3d( gamesnd_get_game_sound(SND_DEBRIS_ARC_02), &snd_pos, &View_position, obj->radius );
+				snd_play_3d( gamesnd_get_game_sound(GameSounds::DEBRIS_ARC_02), &snd_pos, &View_position, obj->radius );
 			} else {
 				// 0.10 second effect
-				snd_play_3d( gamesnd_get_game_sound(SND_DEBRIS_ARC_01), &snd_pos, &View_position, obj->radius );
+				snd_play_3d( gamesnd_get_game_sound(GameSounds::DEBRIS_ARC_01), &snd_pos, &View_position, obj->radius );
 			}
 		}
 	}
@@ -2974,16 +2974,16 @@ void engine_wash_ship_process(ship *shipp)
 		// if we had no wash before now, add the wash object sound
 		if(started_with_no_wash){
 			if(shipp != Player_ship){
-				obj_snd_assign(shipp->objnum, SND_ENGINE_WASH, &vmd_zero_vector, 1);
+				obj_snd_assign(shipp->objnum, GameSounds::ENGINE_WASH, &vmd_zero_vector, 1);
 			} else {				
-				Player_engine_wash_loop = snd_play_looping( gamesnd_get_game_sound(SND_ENGINE_WASH), 0.0f , -1, -1, 1.0f);
+				Player_engine_wash_loop = snd_play_looping( gamesnd_get_game_sound(GameSounds::ENGINE_WASH), 0.0f , -1, -1, 1.0f);
 			}
 		}
 	} 
 	// if we've got no wash, kill any wash object sounds from this guy
 	else {
 		if(shipp != Player_ship){
-			obj_snd_delete_type(shipp->objnum, SND_ENGINE_WASH);
+			obj_snd_delete_type(shipp->objnum, GameSounds::ENGINE_WASH);
 		} else {
 			snd_stop(Player_engine_wash_loop);
 			Player_engine_wash_loop = -1;
@@ -3021,14 +3021,11 @@ public:
 	static const int TYPE_STRING;
 private:
 	int Type;
-	union StorageUnion
-	{
-		float	su_Float;
-		int		su_Image;
-		int		su_Int;
-		int		su_Sound;
-		char	*su_String;
-	} StorageUnion;
+	float	su_Float;
+	int		su_Image;
+	int		su_Int;
+	gamesnd_id su_Sound;
+	char	*su_String;
 public:
 	//TYPE_NONE
 	CombinedVariable();
@@ -3036,8 +3033,10 @@ public:
 	CombinedVariable(float n_Float);
 	//TYPE_INT
 	CombinedVariable(int n_Int);
-	//TYPE_IMAGE, TYPE_SOUND
+	//TYPE_IMAGE
 	CombinedVariable(int n_Int, ubyte type_override);
+	//TYPE_SOUND
+	CombinedVariable(gamesnd_id n_snd);
 	//TYPE_STRING
 	CombinedVariable(char *n_String);
 	//All types
@@ -3052,7 +3051,7 @@ public:
 	//Returns 1 if buffer was successfully written to
 	int getInt(int *output);
 	//Returns handle, or < 0 on failure/wrong type
-	int getSound();
+	gamesnd_id getSound();
 	//Returns 1 if buffer was successfully written to
 	int getString(char *output, size_t output_max);
 
@@ -3077,13 +3076,13 @@ CombinedVariable::CombinedVariable()
 CombinedVariable::CombinedVariable(float n_Float)
 {
 	Type = TYPE_FLOAT;
-	StorageUnion.su_Float = n_Float;
+	su_Float = n_Float;
 }
 
 CombinedVariable::CombinedVariable(int n_Int)
 {
 	Type = TYPE_INT;
-	StorageUnion.su_Int = n_Int;
+	su_Int = n_Int;
 }
 
 CombinedVariable::CombinedVariable(int n_Int, ubyte type_override)
@@ -3091,32 +3090,31 @@ CombinedVariable::CombinedVariable(int n_Int, ubyte type_override)
 	if(type_override == TYPE_IMAGE)
 	{
 		Type = TYPE_IMAGE;
-		StorageUnion.su_Image = n_Int;
-	}
-	else if(type_override == TYPE_SOUND)
-	{
-		Type = TYPE_SOUND;
-		StorageUnion.su_Sound = n_Int;
+		su_Image = n_Int;
 	}
 	else
 	{
 		Type = TYPE_INT;
-		StorageUnion.su_Int = n_Int;
+		su_Int = n_Int;
 	}
+}
+CombinedVariable::CombinedVariable(gamesnd_id n_snd) {
+	Type = TYPE_SOUND;
+	su_Sound = n_snd;
 }
 
 CombinedVariable::CombinedVariable(char *n_String)
 {
 	Type = TYPE_STRING;
-	StorageUnion.su_String = (char *)vm_malloc(strlen(n_String)+1);
-	strcpy(StorageUnion.su_String, n_String);
+	su_String = (char *)vm_malloc(strlen(n_String)+1);
+	strcpy(su_String, n_String);
 }
 
 CombinedVariable::~CombinedVariable()
 {
 	if(Type == TYPE_STRING)
 	{
-		vm_free(StorageUnion.su_String);
+		vm_free(su_String);
 	}
 }
 
@@ -3124,27 +3122,22 @@ int CombinedVariable::getFloat(float *output)
 {
 	if(Type == TYPE_FLOAT)
 	{
-		*output  = StorageUnion.su_Float;
+		*output  = su_Float;
 		return 1;
 	}
 	if(Type == TYPE_IMAGE)
 	{
-		*output = i2fl(StorageUnion.su_Image);
+		*output = i2fl(su_Image);
 		return 1;
 	}
 	if(Type == TYPE_INT)
 	{
-		*output = i2fl(StorageUnion.su_Int);
-		return 1;
-	}
-	if(Type == TYPE_SOUND)
-	{
-		*output = i2fl(StorageUnion.su_Sound);
+		*output = i2fl(su_Int);
 		return 1;
 	}
 	if(Type == TYPE_STRING)
 	{
-		*output = (float)atof(StorageUnion.su_String);
+		*output = (float)atof(su_String);
 		return 1;
 	}
 	return 0;
@@ -3171,38 +3164,33 @@ int CombinedVariable::getInt(int *output)
 
 	if(Type == TYPE_FLOAT)
 	{
-		*output  = fl2i(StorageUnion.su_Float);
+		*output  = fl2i(su_Float);
 		return 1;
 	}
 	if(Type == TYPE_IMAGE)
 	{
-		*output = StorageUnion.su_Image;
+		*output = su_Image;
 		return 1;
 	}
 	if(Type == TYPE_INT)
 	{
-		*output = StorageUnion.su_Int;
-		return 1;
-	}
-	if(Type == TYPE_SOUND)
-	{
-		*output = StorageUnion.su_Sound;
+		*output = su_Int;
 		return 1;
 	}
 	if(Type == TYPE_STRING)
 	{
-		*output = atoi(StorageUnion.su_String);
+		*output = atoi(su_String);
 		return 1;
 	}
 
 	return 0;
 }
-int CombinedVariable::getSound()
+gamesnd_id CombinedVariable::getSound()
 {
 	if(Type == TYPE_SOUND)
-		return this->getHandle();
+		return su_Sound;
 	else
-		return -1;
+		return {};
 }
 int CombinedVariable::getString(char *output, size_t output_max)
 {
@@ -3211,30 +3199,30 @@ int CombinedVariable::getString(char *output, size_t output_max)
 
 	if(Type == TYPE_FLOAT)
 	{
-		snprintf(output, output_max, "%f", StorageUnion.su_Float);
+		snprintf(output, output_max, "%f", su_Float);
 		return 1;
 	}
 	if(Type == TYPE_IMAGE)
 	{
-		if(bm_is_valid(StorageUnion.su_Image))
-			snprintf(output, output_max, "%s", bm_get_filename(StorageUnion.su_Image));
+		if(bm_is_valid(su_Image))
+			snprintf(output, output_max, "%s", bm_get_filename(su_Image));
 		return 1;
 	}
 	if(Type == TYPE_INT)
 	{
-		snprintf(output, output_max, "%i", StorageUnion.su_Int);
+		snprintf(output, output_max, "%i", su_Int);
 		return 1;
 	}
 	if(Type == TYPE_SOUND)
 	{
 		Error(LOCATION, "Sound CombinedVariables are not supported yet.");
-		/*if(snd_is_valid(StorageUnion.su_Sound))
-			snprintf(output, output_max, "%s", snd_get_filename(StorageUnion.su_Sound));*/
+		/*if(snd_is_valid(su_Sound))
+			snprintf(output, output_max, "%s", snd_get_filename(su_Sound));*/
 		return 1;
 	}
 	if(Type == TYPE_STRING)
 	{
-		strncpy(output, StorageUnion.su_String, output_max);
+		strncpy(output, su_String, output_max);
 		return 1;
 	}
 	return 0;
@@ -3290,8 +3278,8 @@ void parse_combined_variable_list(CombinedVariable *dest, flag_def_list *src, si
 				{
 					char buf2[MAX_FILENAME_LEN];
 					stuff_string(buf2, F_NAME, MAX_FILENAME_LEN);
-					int idx = gamesnd_get_by_name(buf);
-					*dp = CombinedVariable(idx, CombinedVariable::TYPE_SOUND);
+					auto idx = gamesnd_get_by_name(buf);
+					*dp = CombinedVariable(idx);
 					break;
 				}
 				case CombinedVariable::TYPE_STRING:
@@ -3839,8 +3827,8 @@ int WE_BSG::warpStart()
         shipp->flags.set(Ship::Ship_Flags::Depart_warp);
 
 	//*****Sound
-	int gs_start_index = -1;
-	int gs_end_index = -1;
+	gamesnd_id gs_start_index;
+	gamesnd_id gs_end_index;
 	if(direction == WD_WARP_IN)
 	{
 		gs_start_index = sip->warpin_snd_start;
@@ -3857,12 +3845,12 @@ int WE_BSG::warpStart()
 		return 0;
 	}
 
-	if(gs_start_index > -1)
+	if(gs_start_index.isValid())
 	{
 		snd_start_gs = gamesnd_get_game_sound(gs_start_index);
 		snd_start = snd_play_3d(snd_start_gs, &objp->pos, &View_position, 0.0f, NULL, 0, 1, SND_PRIORITY_SINGLE_INSTANCE, NULL, snd_range_factor);
 	}
-	if(gs_end_index > -1)
+	if(gs_end_index.isValid())
 	{
 		snd_end_gs = gamesnd_get_game_sound(gs_end_index);
 		snd_end = -1;
@@ -4147,7 +4135,7 @@ int WE_Homeworld::warpStart()
 	width = width_full;
 	height = 0.0f;
 
-	int gs_index = -1;
+	gamesnd_id gs_index;
 	if(direction == WD_WARP_IN)
 	{
         shipp->flags.set(Ship::Ship_Flags::Arriving_stage_1);
@@ -4164,7 +4152,7 @@ int WE_Homeworld::warpStart()
 		return 0;
 	}
 
-	if(gs_index > -1)
+	if(gs_index.isValid())
 	{
 		snd_gs = gamesnd_get_game_sound(gs_index);
 		snd = snd_play_3d(snd_gs, &pos, &View_position, 0.0f, NULL, 0, 1, SND_PRIORITY_SINGLE_INSTANCE, NULL, snd_range_factor);

--- a/code/ship/shiphit.cpp
+++ b/code/ship/shiphit.cpp
@@ -235,7 +235,7 @@ void do_subobj_destroyed_stuff( ship *ship_p, ship_subsys *subsys, vec3d* hitpos
 		if ( ship_objp == Player_obj )
 		{
 			if (!no_explosion) {
-				snd_play( gamesnd_get_game_sound(SND_SUBSYS_DIE_1), 0.0f );
+				snd_play( gamesnd_get_game_sound(GameSounds::SUBSYS_DIE_1), 0.0f );
 			}
 			if (strlen(psub->alt_dmg_sub_name))
 				HUD_printf(XSTR( "Your %s subsystem has been destroyed", 499), psub->alt_dmg_sub_name);
@@ -280,13 +280,13 @@ void do_subobj_destroyed_stuff( ship *ship_p, ship_subsys *subsys, vec3d* hitpos
 
 	if (notify && !no_explosion) {
 		// play sound effect when subsys gets blown up
-		int sound_index=-1;
+		gamesnd_id sound_index;
 		if ( Ship_info[ship_p->ship_info_index].is_huge_ship() ) {
-			sound_index=SND_CAPSHIP_SUBSYS_EXPLODE;
+			sound_index=GameSounds::CAPSHIP_SUBSYS_EXPLODE;
 		} else if ( Ship_info[ship_p->ship_info_index].is_big_ship() ) {
-			sound_index=SND_SUBSYS_EXPLODE;
+			sound_index=GameSounds::SUBSYS_EXPLODE;
 		}
-		if ( sound_index >= 0 ) {
+		if ( sound_index.isValid() ) {
 			snd_play_3d( gamesnd_get_game_sound(sound_index), &g_subobj_pos, &View_position );
 		}
 	}
@@ -308,7 +308,7 @@ void do_subobj_destroyed_stuff( ship *ship_p, ship_subsys *subsys, vec3d* hitpos
 		obj_snd_delete_type(ship_p->objnum, subsys->system_info->rotation_snd, subsys);
 		subsys->subsys_snd_flags.remove(Ship::Subsys_Sound_Flags::Rotate);
 	}
-	if((subsys->system_info->dead_snd != -1) && !(subsys->subsys_snd_flags[Ship::Subsys_Sound_Flags::Dead]))
+	if((subsys->system_info->dead_snd.isValid()) && !(subsys->subsys_snd_flags[Ship::Subsys_Sound_Flags::Dead]))
 	{
 		obj_snd_assign(ship_p->objnum, subsys->system_info->dead_snd, &subsys->system_info->pnt, 0, OS_SUBSYS_DEAD, subsys);
 		subsys->subsys_snd_flags.remove(Ship::Subsys_Sound_Flags::Dead);
@@ -1464,7 +1464,7 @@ void ship_generic_kill_stuff( object *objp, float percent_killed )
 	ai_deathroll_start(objp);
 
 	// play death roll begin sound
-	sp->death_roll_snd = snd_play_3d( gamesnd_get_game_sound(SND_DEATH_ROLL), &objp->pos, &View_position, objp->radius );
+	sp->death_roll_snd = snd_play_3d( gamesnd_get_game_sound(GameSounds::DEATH_ROLL), &objp->pos, &View_position, objp->radius );
 	if (objp == Player_obj)
 		joy_ff_deathroll();
 

--- a/code/source_groups.cmake
+++ b/code/source_groups.cmake
@@ -1236,6 +1236,7 @@ set(file_root_utils
     utils/encoding.h
 	utils/HeapAllocator.cpp
 	utils/HeapAllocator.h
+	utils/id.h
 	utils/RandomRange.h
 	utils/strings.h
     utils/unicode.cpp

--- a/code/starfield/supernova.cpp
+++ b/code/starfield/supernova.cpp
@@ -193,11 +193,11 @@ void supernova_process()
 		// sound stuff
 		if((Supernova_time <= SUPERNOVA_SOUND_1_TIME) && !Supernova_sound_1_played) {
 			Supernova_sound_1_played = 1;
-			snd_play(gamesnd_get_game_sound(SND_SUPERNOVA_1), 0.0f, 1.0f, SND_PRIORITY_MUST_PLAY);
+			snd_play(gamesnd_get_game_sound(GameSounds::SUPERNOVA_1), 0.0f, 1.0f, SND_PRIORITY_MUST_PLAY);
 		}
 		if((Supernova_time <= SUPERNOVA_SOUND_2_TIME) && !Supernova_sound_2_played) {
 			Supernova_sound_2_played = 1;
-			snd_play(gamesnd_get_game_sound(SND_SUPERNOVA_2), 0.0f, 1.0f, SND_PRIORITY_MUST_PLAY);
+			snd_play(gamesnd_get_game_sound(GameSounds::SUPERNOVA_2), 0.0f, 1.0f, SND_PRIORITY_MUST_PLAY);
 		}
 
 		// if we've crossed from stage 1 to stage 2 kill all particles and stick a bunch on the player ship

--- a/code/stats/medals.cpp
+++ b/code/stats/medals.cpp
@@ -702,7 +702,7 @@ int medal_main_do()
 
 	// check to see if a button was pressed
 	if ( (k == (KEY_CTRLED|KEY_ENTER)) || (Medals_buttons[gr_screen.res][MEDALS_EXIT].button.pressed()) ) {
-		gamesnd_play_iface(SND_COMMIT_PRESSED);
+		gamesnd_play_iface(InterfaceSounds::COMMIT_PRESSED);
 		if (Medals_mode == MM_NORMAL) {
 			gameseq_post_event(GS_EVENT_PREVIOUS_STATE);
 		} else {

--- a/code/ui/button.cpp
+++ b/code/ui/button.cpp
@@ -205,11 +205,11 @@ void UI_BUTTON::process(int focus)
 
 		if (!hidden && !my_wnd->use_hack_to_get_around_stupid_problem_flag) {
 			if (mouse_on_me && B1_JUST_PRESSED){
-				gamesnd_play_iface(SND_GENERAL_FAIL);
+				gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 			}
 
 			if ( (hotkey >= 0) && (my_wnd->keypress == hotkey) ){
-				gamesnd_play_iface(SND_GENERAL_FAIL);
+				gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 			}
 		}
 

--- a/code/ui/slider.cpp
+++ b/code/ui/slider.cpp
@@ -94,14 +94,14 @@ void UI_DOT_SLIDER_NEW::process(int focus)
 	if (disabled_flag) {
 		if (!hidden && !my_wnd->use_hack_to_get_around_stupid_problem_flag) {
 			if (button.is_mouse_on() && B1_JUST_PRESSED) {
-				gamesnd_play_iface(SND_GENERAL_FAIL);
+				gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 			} else if (has_end_buttons && (up_button.is_mouse_on() || down_button.is_mouse_on())) {
-				gamesnd_play_iface(SND_GENERAL_FAIL);
+				gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 			}
 			
 
 			if ( (hotkey >= 0) && (my_wnd->keypress == hotkey) ){
-				gamesnd_play_iface(SND_GENERAL_FAIL);
+				gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 			}
 		}
 
@@ -138,7 +138,7 @@ void UI_DOT_SLIDER_NEW::process(int focus)
 			if (pos < num_pos-1){
 				pos++;
 			} else {
-				gamesnd_play_iface(SND_GENERAL_FAIL);
+				gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 			}
 		}
 
@@ -147,7 +147,7 @@ void UI_DOT_SLIDER_NEW::process(int focus)
 			if(pos){
 				pos--;
 			} else {
-				gamesnd_play_iface(SND_GENERAL_FAIL);
+				gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 			}
 		}
 	}
@@ -276,7 +276,7 @@ void UI_DOT_SLIDER::process(int focus)
 			if (pos < num_pos){
 				pos++;
 			} else {
-				gamesnd_play_iface(SND_GENERAL_FAIL);
+				gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 			}
 		}
 
@@ -285,7 +285,7 @@ void UI_DOT_SLIDER::process(int focus)
 			if (pos){
 				pos--;
 			} else {
-				gamesnd_play_iface(SND_GENERAL_FAIL);
+				gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 			}
 		}
 	}

--- a/code/utils/id.h
+++ b/code/utils/id.h
@@ -1,0 +1,49 @@
+#pragma once
+
+namespace util {
+
+/**
+ * @brief A generic class for creating type safe handle types
+ *
+ * This type should be used when a function returns a handle to an internal resource instead of using an int.
+ * Example:
+ * @code{.cpp}
+ * struct gamesnd_id_tag{};
+ * typedef util::ID<gamesnd_id_tag, int, -1> gamesnd_id;
+ * @endcode
+ *
+ * The implementation value should be very light-weight since this class is designed to be passed around by-value.
+ *
+ * @note This class was copied from http://www.ilikebigbits.com/blog/2014/5/6/type-safe-identifiers-in-c
+ *
+ * @tparam Tag A unique type tag which is used for distinguishing between two types which use the same Impl type
+ * @tparam Impl The internal representation of the handle.
+ * @tparam default_value The default value of the handle. If the handle has this value it is considered invalid.
+ */
+template<class Tag, class Impl, Impl default_value>
+class ID
+{
+public:
+	typedef Tag tag_type;
+	typedef Impl impl_type;
+
+	static ID invalid() { return ID(); }
+
+	// Defaults to ID::invalid()
+	ID() : m_val(default_value) { }
+
+	// Explicit constructor:
+	explicit ID(Impl val) : m_val(val) { }
+
+	inline Impl value() const { return m_val; }
+
+	friend bool operator==(ID a, ID b) { return a.m_val == b.m_val; }
+	friend bool operator!=(ID a, ID b) { return a.m_val != b.m_val; }
+
+	inline bool isValid() { return m_val != default_value; }
+
+private:
+	Impl m_val;
+};
+
+}

--- a/code/weapon/beam.cpp
+++ b/code/weapon/beam.cpp
@@ -1871,7 +1871,7 @@ void beam_start_warmup(beam *b)
 	b->warmup_stamp = timestamp(Weapon_info[b->weapon_info_index].b_info.beam_warmup);
 
 	// start playing warmup sound
-	if(!(Game_mode & GM_STANDALONE_SERVER) && (Weapon_info[b->weapon_info_index].b_info.beam_warmup_sound >= 0)){		
+	if(!(Game_mode & GM_STANDALONE_SERVER) && (Weapon_info[b->weapon_info_index].b_info.beam_warmup_sound.isValid())){
 		snd_play_3d(gamesnd_get_game_sound(Weapon_info[b->weapon_info_index].b_info.beam_warmup_sound), &b->last_start, &View_position);
 	}
 }
@@ -1914,11 +1914,11 @@ int beam_start_firing(beam *b)
 	}				
 
 	// start the beam firing sound now, if we haven't already		
-	if((b->beam_sound_loop == -1) && (Weapon_info[b->weapon_info_index].b_info.beam_loop_sound >= 0)){				
+	if((b->beam_sound_loop == -1) && (Weapon_info[b->weapon_info_index].b_info.beam_loop_sound.isValid())){
 		b->beam_sound_loop = snd_play_3d(gamesnd_get_game_sound(Weapon_info[b->weapon_info_index].b_info.beam_loop_sound), &b->last_start, &View_position, 0.0f, NULL, 1, 1.0, SND_PRIORITY_SINGLE_INSTANCE, NULL, 1.0f, 1);
 
 		// "shot" sound
-		if (Weapon_info[b->weapon_info_index].launch_snd >= 0)
+		if (Weapon_info[b->weapon_info_index].launch_snd.isValid())
 			snd_play_3d(gamesnd_get_game_sound(Weapon_info[b->weapon_info_index].launch_snd), &b->last_start, &View_position);
 		// niffwan - if launch_snd < 0, don't play any sound
 	}	
@@ -1938,7 +1938,7 @@ void beam_start_warmdown(beam *b)
 	b->warmdown_stamp = timestamp(Weapon_info[b->weapon_info_index].b_info.beam_warmdown);			
 
 	// start the warmdown sound
-	if(Weapon_info[b->weapon_info_index].b_info.beam_warmdown_sound >= 0){				
+	if(Weapon_info[b->weapon_info_index].b_info.beam_warmdown_sound.isValid()){
 		snd_play_3d(gamesnd_get_game_sound(Weapon_info[b->weapon_info_index].b_info.beam_warmdown_sound), &b->last_start, &View_position);
 	}
 
@@ -3073,7 +3073,7 @@ void beam_handle_collisions(beam *b)
 		r_coll_count++;		
 
 		// play the impact sound
-		if ( first_hit && (wi->impact_snd >= 0) ) {
+		if ( first_hit && (wi->impact_snd.isValid()) ) {
 			snd_play_3d( gamesnd_get_game_sound(wi->impact_snd), &b->f_collisions[idx].cinfo.hit_point_world, &Eye_position );
 		}
 

--- a/code/weapon/shockwave.cpp
+++ b/code/weapon/shockwave.cpp
@@ -351,7 +351,7 @@ void shockwave_move(object *shockwave_objp, float frametime)
 			} else {
 				vol_scale = 1.0f;
 			}
-			snd_play( gamesnd_get_game_sound(SND_SHOCKWAVE_IMPACT), 0.0f, vol_scale );
+			snd_play( gamesnd_get_game_sound(GameSounds::SHOCKWAVE_IMPACT), 0.0f, vol_scale );
 		}
 
 	}	// end for

--- a/code/weapon/weapon.h
+++ b/code/weapon/weapon.h
@@ -16,6 +16,7 @@
 #include "globalincs/systemvars.h"
 #include "graphics/2d.h"
 #include "graphics/generic.h"
+#include "gamesnd/gamesnd.h"
 #include "model/model.h"
 #include "weapon/shockwave.h"
 #include "weapon/trails.h"
@@ -170,9 +171,9 @@ typedef struct beam_weapon_info {
 	float beam_particle_angle;			// angle of beam particle spew cone
 	generic_anim beam_particle_ani;		// particle_ani
 	float beam_iff_miss_factor[MAX_IFFS][NUM_SKILL_LEVELS];	// magic # which makes beams miss more. by parent iff and player skill level
-	int beam_loop_sound;				// looping beam sound
-	int beam_warmup_sound;				// warmup sound
-	int beam_warmdown_sound;			// warmdown sound
+	gamesnd_id beam_loop_sound;				// looping beam sound
+	gamesnd_id beam_warmup_sound;				// warmup sound
+	gamesnd_id beam_warmdown_sound;			// warmdown sound
 	int beam_num_sections;				// the # of visible "sections" on the beam
 	generic_anim beam_glow;				// muzzle glow bitmap
 	float glow_length;					// (DahBlount) determines the length the muzzle glow when using a directional glow
@@ -317,12 +318,12 @@ typedef struct weapon_info {
 	// Seeker strength - for countermeasures overhaul.
 	float seeker_strength;
 
-	int pre_launch_snd;
+	gamesnd_id pre_launch_snd;
 	int	pre_launch_snd_min_interval;	//Minimum interval in ms between the last time the pre-launch sound was played and the next time it can play, as a limiter in case the player is pumping the trigger
-	int	launch_snd;
-	int	impact_snd;
-	int disarmed_impact_snd;
-	int	flyby_snd;							//	whizz-by sound, transmitted through weapon's portable atmosphere.
+	gamesnd_id	launch_snd;
+	gamesnd_id	impact_snd;
+	gamesnd_id disarmed_impact_snd;
+	gamesnd_id	flyby_snd;							//	whizz-by sound, transmitted through weapon's portable atmosphere.
 	
 	// Specific to weapons with TRAILS:
 	trail_info tr_info;			
@@ -454,9 +455,9 @@ typedef struct weapon_info {
 
 	int			score; //Optional score for destroying the weapon
 
-	int hud_tracking_snd; // Sound played when this weapon tracks a target
-	int hud_locked_snd; // Sound played when this weapon locked onto a target
-	int hud_in_flight_snd; // Sound played while the weapon is in flight
+	gamesnd_id hud_tracking_snd; // Sound played when this weapon tracks a target
+	gamesnd_id hud_locked_snd; // Sound played when this weapon locked onto a target
+	gamesnd_id hud_in_flight_snd; // Sound played while the weapon is in flight
 	InFlightSoundType in_flight_play_type; // The status when the sound should be played
 
 	decals::creation_info impact_decal;

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -1429,7 +1429,7 @@ int parse_weapon(int subtype, bool replace, const char *filename)
 		nprintf(("Warning", "Ignoring free flight speed for weapon '%s'\n", wip->name));
 	}
 	//Optional one-shot sound to play at the beginning of firing
-	parse_sound("$PreLaunchSnd:", &wip->pre_launch_snd, wip->name);
+	parse_game_sound("$PreLaunchSnd:", &wip->pre_launch_snd, wip->name);
 
 	//Optional delay for Pre-Launch sound
 	if(optional_string("+PreLaunchSnd Min Interval:"))
@@ -1438,21 +1438,21 @@ int parse_weapon(int subtype, bool replace, const char *filename)
 	}
 
 	//Launch sound
-	parse_sound("$LaunchSnd:", &wip->launch_snd, wip->name);
+	parse_game_sound("$LaunchSnd:", &wip->launch_snd, wip->name);
 
 	//Impact sound
-	parse_sound("$ImpactSnd:", &wip->impact_snd, wip->name);
+	parse_game_sound("$ImpactSnd:", &wip->impact_snd, wip->name);
 
 	//Disarmed impact sound
-	parse_sound("$Disarmed ImpactSnd:", &wip->impact_snd, wip->name);
+	parse_game_sound("$Disarmed ImpactSnd:", &wip->impact_snd, wip->name);
 
-	parse_sound("$FlyBySnd:", &wip->flyby_snd, wip->name);
+	parse_game_sound("$FlyBySnd:", &wip->flyby_snd, wip->name);
 
-	parse_sound("$TrackingSnd:", &wip->hud_tracking_snd, wip->name);
+	parse_game_sound("$TrackingSnd:", &wip->hud_tracking_snd, wip->name);
 	
-	parse_sound("$LockedSnd:", &wip->hud_locked_snd, wip->name);
+	parse_game_sound("$LockedSnd:", &wip->hud_locked_snd, wip->name);
 
-	parse_sound("$InFlightSnd:", &wip->hud_in_flight_snd, wip->name);
+	parse_game_sound("$InFlightSnd:", &wip->hud_in_flight_snd, wip->name);
 
 	if (optional_string("+Inflight sound type:"))
 	{
@@ -2117,13 +2117,13 @@ int parse_weapon(int subtype, bool replace, const char *filename)
 		}
 
 		// beam fire sound
-		parse_sound("+BeamSound:", &wip->b_info.beam_loop_sound, wip->name);
+		parse_game_sound("+BeamSound:", &wip->b_info.beam_loop_sound, wip->name);
 
 		// warmup sound
-		parse_sound("+WarmupSound:", &wip->b_info.beam_warmup_sound, wip->name);
+		parse_game_sound("+WarmupSound:", &wip->b_info.beam_warmup_sound, wip->name);
 
 		// warmdown sound
-		parse_sound("+WarmdownSound:", &wip->b_info.beam_warmdown_sound, wip->name);
+		parse_game_sound("+WarmdownSound:", &wip->b_info.beam_warmdown_sound, wip->name);
 
 		// glow bitmap
 		if (optional_string("+Muzzleglow:") ) {
@@ -3647,10 +3647,10 @@ void weapon_maybe_play_warning(weapon *wp)
 			// Possibly add an additional third sound later
 			if ( (Weapon_info[wp->weapon_info_index].wi_flags[Weapon::Info_Flags::Homing_heat]) ||
 				 (Weapon_info[wp->weapon_info_index].wi_flags[Weapon::Info_Flags::Homing_javelin]) ) {
-				snd_play(gamesnd_get_game_sound(ship_get_sound(Player_obj, SND_HEATLOCK_WARN)));
+				snd_play(gamesnd_get_game_sound(ship_get_sound(Player_obj, GameSounds::HEATLOCK_WARN)));
 			} else {
 				Assert(Weapon_info[wp->weapon_info_index].wi_flags[Weapon::Info_Flags::Homing_aspect]);
-				snd_play(gamesnd_get_game_sound(ship_get_sound(Player_obj, SND_ASPECTLOCK_WARN)));
+				snd_play(gamesnd_get_game_sound(ship_get_sound(Player_obj, GameSounds::ASPECTLOCK_WARN)));
 			}
 		}
 	}
@@ -4480,11 +4480,11 @@ void weapon_maybe_play_flyby_sound(object *weapon_objp, weapon *wp)
 			dot = vm_vec_dot(&vec_to_weapon, &weapon_objp->orient.vec.fvec);
 			
 			if ( (dot < -0.80) && (dot > -0.98) ) {
-				if(Weapon_info[wp->weapon_info_index].flyby_snd != -1) {
+				if(Weapon_info[wp->weapon_info_index].flyby_snd.isValid()) {
 					snd_play_3d( gamesnd_get_game_sound(Weapon_info[wp->weapon_info_index].flyby_snd), &weapon_objp->pos, &Eye_position );
 				} else {
 					if ( Weapon_info[wp->weapon_info_index].subtype == WP_LASER ) {
-						snd_play_3d( gamesnd_get_game_sound(SND_WEAPON_FLYBY), &weapon_objp->pos, &Eye_position );
+						snd_play_3d( gamesnd_get_game_sound(GameSounds::WEAPON_FLYBY), &weapon_objp->pos, &Eye_position );
 					}
 				}
 				Weapon_flyby_sound_timer = timestamp(200);
@@ -4871,7 +4871,7 @@ void weapon_process_post(object * obj, float frame_time)
 		}
 	}
 
-	if (wip->hud_in_flight_snd >= 0 && obj->parent_sig == Player_obj->signature)
+	if (wip->hud_in_flight_snd.isValid() && obj->parent_sig == Player_obj->signature)
 	{
 		bool play_sound = false;
 		switch (wip->in_flight_play_type)
@@ -5637,13 +5637,13 @@ void weapon_play_impact_sound(weapon_info *wip, vec3d *hitpos, bool is_armed)
 {
 	if(is_armed)
 	{
-		if(wip->impact_snd != -1) {
+		if(wip->impact_snd.isValid()) {
 			snd_play_3d( gamesnd_get_game_sound(wip->impact_snd), hitpos, &Eye_position );
 		}
 	}
 	else
 	{
-		if(wip->disarmed_impact_snd != -1) {
+		if(wip->disarmed_impact_snd.isValid()) {
 			snd_play_3d(gamesnd_get_game_sound(wip->disarmed_impact_snd), hitpos, &Eye_position);
 		}
 	}
@@ -5708,27 +5708,27 @@ void weapon_hit_do_sound(object *hit_obj, weapon_info *wip, vec3d *hitpos, bool 
 		if ( shield_str > 0.1f ) {
 			// Play a shield impact sound effect
 			if ( hit_obj == Player_obj ) {
-				snd_play_3d( gamesnd_get_game_sound(SND_SHIELD_HIT_YOU), hitpos, &Eye_position );
+				snd_play_3d( gamesnd_get_game_sound(GameSounds::SHIELD_HIT_YOU), hitpos, &Eye_position );
 				// AL 12-15-97: Add missile impact sound even when shield is hit
 				if ( wip->subtype == WP_MISSILE ) {
-					snd_play_3d( gamesnd_get_game_sound(SND_PLAYER_HIT_MISSILE), hitpos, &Eye_position);
+					snd_play_3d( gamesnd_get_game_sound(GameSounds::PLAYER_HIT_MISSILE), hitpos, &Eye_position);
 				}
 			} else {
-				snd_play_3d( gamesnd_get_game_sound(SND_SHIELD_HIT), hitpos, &Eye_position );
+				snd_play_3d( gamesnd_get_game_sound(GameSounds::SHIELD_HIT), hitpos, &Eye_position );
 			}
 		} else {
 			// Play a hull impact sound effect
 			switch ( wip->subtype ) {
 				case WP_LASER:
 					if ( hit_obj == Player_obj )
-						snd_play_3d( gamesnd_get_game_sound(SND_PLAYER_HIT_LASER), hitpos, &Eye_position );
+						snd_play_3d( gamesnd_get_game_sound(GameSounds::PLAYER_HIT_LASER), hitpos, &Eye_position );
 					else {
 						weapon_play_impact_sound(wip, hitpos, is_armed);
 					}
 					break;
 				case WP_MISSILE:
 					if ( hit_obj == Player_obj ) 
-						snd_play_3d( gamesnd_get_game_sound(SND_PLAYER_HIT_MISSILE), hitpos, &Eye_position);
+						snd_play_3d( gamesnd_get_game_sound(GameSounds::PLAYER_HIT_MISSILE), hitpos, &Eye_position);
 					else {
 						weapon_play_impact_sound(wip, hitpos, is_armed);
 					}
@@ -7551,13 +7551,13 @@ void weapon_info::reset()
 	// *Default is 150  -Et1
 	this->SwarmWait = SWARM_MISSILE_DELAY;
 
-	this->pre_launch_snd = -1;
+	this->pre_launch_snd = gamesnd_id();
 	this->pre_launch_snd_min_interval = 0;
 
-	this->launch_snd = -1;
-	this->impact_snd = -1;
-	this->disarmed_impact_snd = -1;
-	this->flyby_snd = -1;
+	this->launch_snd = gamesnd_id();
+	this->impact_snd = gamesnd_id();
+	this->disarmed_impact_snd = gamesnd_id();
+	this->flyby_snd = gamesnd_id();
 
 	this->rearm_rate = 1.0f;
 
@@ -7644,9 +7644,9 @@ void weapon_info::reset()
 	this->b_info.beam_particle_count = -1;
 	this->b_info.beam_particle_radius = 0.0f;
 	this->b_info.beam_particle_angle = 0.0f;
-	this->b_info.beam_loop_sound = -1;
-	this->b_info.beam_warmup_sound = -1;
-	this->b_info.beam_warmdown_sound = -1;
+	this->b_info.beam_loop_sound = gamesnd_id();
+	this->b_info.beam_warmup_sound = gamesnd_id();
+	this->b_info.beam_warmdown_sound = gamesnd_id();
 	this->b_info.beam_num_sections = 0;
 	this->b_info.glow_length = 0;
 	this->b_info.directional_glow = false;
@@ -7727,9 +7727,9 @@ void weapon_info::reset()
 
 	this->selection_effect = Default_weapon_select_effect;
 
-	this->hud_locked_snd = -1;
-	this->hud_tracking_snd = -1;
-	this->hud_in_flight_snd = -1;
+	this->hud_locked_snd = gamesnd_id();
+	this->hud_tracking_snd = gamesnd_id();
+	this->hud_in_flight_snd = gamesnd_id();
 
 	// Reset using default constructor
 	this->impact_decal = decals::creation_info();

--- a/fred2/sexp_tree.cpp
+++ b/fred2/sexp_tree.cpp
@@ -2423,18 +2423,18 @@ int sexp_tree::get_default_value(sexp_list_item *item, char *text_buf, int op, i
 
 		// Goober5000 - special cases that used to be numbers but are now hybrids
 		case OPF_GAME_SND:
-			int sound_index = -1;
+			gamesnd_id sound_index;
 
 			if ( (Operators[op].value == OP_EXPLOSION_EFFECT) )
 			{
-				sound_index = SND_SHIP_EXPLODE_1;
+				sound_index = GameSounds::SHIP_EXPLODE_1;
 			}
 			else if ( (Operators[op].value == OP_WARP_EFFECT) )
 			{
-				sound_index = (i == 8) ? SND_CAPITAL_WARP_IN : SND_CAPITAL_WARP_OUT;
+				sound_index = (i == 8) ? GameSounds::CAPITAL_WARP_IN : GameSounds::CAPITAL_WARP_OUT;
 			}
 
-			if (sound_index >= 0)
+			if (sound_index.isValid())
 			{
 				game_snd *snd = gamesnd_get_game_sound(sound_index);
 				if (can_construe_as_integer(snd->name.c_str()))

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -2629,7 +2629,7 @@ void game_tst_frame()
 		// tst y
 		tst_y = frand_range(0.0f, (float)gr_screen.max_h - h);
 
-		snd_play(gamesnd_get_game_sound(SND_VASUDAN_BUP));
+		snd_play(gamesnd_get_interface_sound(InterfaceSounds::VASUDAN_BUP));
 
 		// tst x and direction
 		tst_mode = 0;
@@ -2773,7 +2773,7 @@ void do_timing_test(float frame_time)
 
 		// start looping digital sounds
 		for ( i = 0; i < NUM_MIXED_SOUNDS; i++ )
-			snds[i] = snd_play_looping( gamesnd_get_game_sound(i), 0.0f, -1, -1);
+			snds[i] = snd_play_looping( gamesnd_get_game_sound(gamesnd_id(i)), 0.0f, -1, -1);
 	}
 	
 
@@ -5053,7 +5053,7 @@ void game_process_event( int current_state, int event )
 			// Same code as in GS_EVENT_PLAYER_WARPOUT_START only ignores current mode
 			Player->saved_viewer_mode = Viewer_mode;
 			Player->control_mode = PCM_WARPOUT_STAGE1;
-			Warpout_sound = snd_play(gamesnd_get_game_sound(SND_PLAYER_WARP_OUT));
+			Warpout_sound = snd_play(gamesnd_get_game_sound(GameSounds::PLAYER_WARP_OUT));
 			Warpout_time = 0.0f;			// Start timer!
 			break;
 
@@ -5063,7 +5063,7 @@ void game_process_event( int current_state, int event )
 			} else {
 				Player->saved_viewer_mode = Viewer_mode;
 				Player->control_mode = PCM_WARPOUT_STAGE1;
-				Warpout_sound = snd_play(gamesnd_get_game_sound(SND_PLAYER_WARP_OUT));
+				Warpout_sound = snd_play(gamesnd_get_game_sound(GameSounds::PLAYER_WARP_OUT));
 				Warpout_time = 0.0f;			// Start timer!
 				Warpout_forced = 0;				// If non-zero, bash the player to speed and go through effect
 			}
@@ -6990,7 +6990,7 @@ void game_do_training_checks()
 					Training_context_at_waypoint = i;
 					if (Training_context_goal_waypoint == i) {
 						Training_context_goal_waypoint++;
-						snd_play(gamesnd_get_game_sound(SND_CARGO_REVEAL), 0.0f);
+						snd_play(gamesnd_get_game_sound(GameSounds::CARGO_REVEAL), 0.0f);
 					}
 
 					break;
@@ -7439,11 +7439,11 @@ static int Subspace_ambient_right_channel = -1;
 void game_start_subspace_ambient_sound()
 {
 	if ( Subspace_ambient_left_channel < 0 ) {
-		Subspace_ambient_left_channel = snd_play_looping(gamesnd_get_game_sound(SND_SUBSPACE_LEFT_CHANNEL), -1.0f);
+		Subspace_ambient_left_channel = snd_play_looping(gamesnd_get_game_sound(GameSounds::SUBSPACE_LEFT_CHANNEL), -1.0f);
 	}
 
 	if ( Subspace_ambient_right_channel < 0 ) {
-		Subspace_ambient_right_channel = snd_play_looping(gamesnd_get_game_sound(SND_SUBSPACE_RIGHT_CHANNEL), 1.0f);
+		Subspace_ambient_right_channel = snd_play_looping(gamesnd_get_game_sound(GameSounds::SUBSPACE_RIGHT_CHANNEL), 1.0f);
 	}
 }
 

--- a/qtfred/src/ui/widgets/sexp_tree.cpp
+++ b/qtfred/src/ui/widgets/sexp_tree.cpp
@@ -1133,15 +1133,15 @@ int sexp_tree::get_default_value(sexp_list_item* item, char* text_buf, int op, i
 
 		// Goober5000 - special cases that used to be numbers but are now hybrids
 	case OPF_GAME_SND:
-		int sound_index = -1;
+		gamesnd_id sound_index;
 
 		if (Operators[op].value == OP_EXPLOSION_EFFECT) {
-			sound_index = SND_SHIP_EXPLODE_1;
+			sound_index = GameSounds::SHIP_EXPLODE_1;
 		} else if (Operators[op].value == OP_WARP_EFFECT) {
-			sound_index = (i == 8) ? SND_CAPITAL_WARP_IN : SND_CAPITAL_WARP_OUT;
+			sound_index = (i == 8) ? GameSounds::CAPITAL_WARP_IN : GameSounds::CAPITAL_WARP_OUT;
 		}
 
-		if (sound_index >= 0) {
+		if (sound_index.isValid()) {
 			game_snd* snd = gamesnd_get_game_sound(sound_index);
 			if (can_construe_as_integer(snd->name.c_str())) {
 				item->set_data(snd->name.c_str(), (SEXPT_NUMBER | SEXPT_VALID));


### PR DESCRIPTION
This adds a new class which allows to create type safe resource handle
types. At the moment, the engine uses ints pretty much everywhere for
providing handles to resources created by the specific subsystems. Since
all ints are the same to the C/C++ typesystem it is perfectly legal to
pass a sound handle to the graphics API as a buffer handle which will
obviously cause issues.

This adds a new type called "ID" which is a wrapper class for a generic
handle but with added type safety. An instance of this class cannot be
passed to a function expecting another type of handle which provided
compile-time type safety for these APIs.

As an initial test I converted the game sound handles to this new type.
I already found a bug in the mainhall system thanks to this new type.
The mainhall used the game sound handles as sound instance handles which
probably meant that that specific code never really worked right. I
removed the code since there was no better alternative for fixing it.