### PR TITLE
Fix texture detail errors

### DIFF
--- a/code/graphics/opengl/gropengltexture.cpp
+++ b/code/graphics/opengl/gropengltexture.cpp
@@ -403,34 +403,13 @@ int opengl_texture_set_level(int bitmap_handle,
 	switch (bitmap_type) {
 		case TCACHE_TYPE_COMPRESSED: {
 			if (block_size > 0) {
-				// size of data block (4x4)
-				dsize = ((mipmap_h + 3) / 4) * ((mipmap_w + 3) / 4) * block_size;
+				for (auto i = 0; i < mipmap_levels; i++) {
 
-				// if we are skipping mipmap levels in order to resize then we have to calc the new offset
-				doffset = 0;
-				for (auto i = 0; i < base_level; i++) {
-					doffset += dsize;
-
-					mipmap_w >>= 1;
-					mipmap_h >>= 1;
-
-					if (mipmap_w <= 0) {
-						mipmap_w = 1;
-					}
-
-					if (mipmap_h <= 0) {
-						mipmap_h = 1;
-					}
-
+					// size of data block (4x4)
 					dsize = ((mipmap_h + 3) / 4) * ((mipmap_w + 3) / 4) * block_size;
-				}
 
-				skip_size = doffset;
+					glCompressedTexSubImage3D(tSlot->texture_target, i, 0, 0, tSlot->array_index, mipmap_w, mipmap_h, 1, intFormat, dsize, bmp_data + doffset);
 
-				glCompressedTexSubImage3D(tSlot->texture_target, 0, 0, 0, tSlot->array_index, mipmap_w, mipmap_h, 1, intFormat, dsize, bmp_data + doffset);
-
-				// now that the base image is done handle any mipmap levels
-				for (auto i = 1; i < (mipmap_levels - base_level); i++) {
 					// adjust the data offset for the next block
 					doffset += dsize;
 
@@ -445,11 +424,6 @@ int opengl_texture_set_level(int bitmap_handle,
 					if (mipmap_h <= 0) {
 						mipmap_h = 1;
 					}
-
-					// size of data block (4x4)
-					dsize = ((mipmap_h + 3) / 4) * ((mipmap_w + 3) / 4) * block_size;
-
-					glCompressedTexSubImage3D(tSlot->texture_target, i, 0, 0, tSlot->array_index, mipmap_w, mipmap_h, 1, intFormat, dsize, bmp_data + doffset);
 				}
 			} else {
 				Int3();
@@ -644,13 +618,16 @@ int opengl_texture_set_level(int bitmap_handle,
 				Assert( texmem == NULL );
 			}
 
-			dsize = mipmap_h * mipmap_w * byte_mult;
+			for (auto i = 0; i < mipmap_levels; i++) {
+				// size of data block (4x4)
+				dsize = mipmap_h * mipmap_w * byte_mult;
 
-			// if we are skipping mipmap levels in order to resize then we have to calc the new offset
-			doffset = 0;
-			for (auto i = 0; i < base_level; i++) {
+				glTexSubImage3D (tSlot->texture_target, i, 0, 0, tSlot->array_index, mipmap_w, mipmap_h, 1, glFormat, texFormat, (texmem != NULL) ? texmem : bmp_data + doffset);
+
+				// adjust the data offset for the next block
 				doffset += dsize;
 
+				// reduce size by half for the next pass
 				mipmap_w >>= 1;
 				mipmap_h >>= 1;
 
@@ -661,31 +638,6 @@ int opengl_texture_set_level(int bitmap_handle,
 				if (mipmap_h <= 0) {
 					mipmap_h = 1;
 				}
-
-				dsize = mipmap_h * mipmap_w * byte_mult;
-			}
-
-			skip_size = doffset;
-
-			glTexSubImage3D (tSlot->texture_target, 0, 0, 0, tSlot->array_index, mipmap_w, mipmap_h, 1, glFormat, texFormat, (texmem != NULL) ? texmem : bmp_data + doffset);
-
-			// base image is done so now take care of any mipmap levels
-			for (auto i = 1; i < (mipmap_levels - base_level); i++) {
-				doffset += dsize;
-				mipmap_w >>= 1;
-				mipmap_h >>= 1;
-
-				if (mipmap_w <= 0) {
-					mipmap_w = 1;
-				}
-
-				if (mipmap_h <= 0) {
-					mipmap_h = 1;
-				}
-
-				dsize = mipmap_h * mipmap_w * byte_mult;
-
-				glTexSubImage3D (tSlot->texture_target, i, 0, 0, tSlot->array_index, mipmap_w, mipmap_h, 1, glFormat, texFormat, bmp_data + doffset);
 			}
 
 			if (texmem != NULL) {
@@ -972,6 +924,9 @@ int opengl_create_texture(int bitmap_handle, int bitmap_type, tcache_slot_opengl
 		}
 	}
 
+	if (base_level != 0) {
+		glTexParameteri(tslot->texture_target, GL_TEXTURE_BASE_LEVEL, base_level);
+	}
 	glTexParameteri(tslot->texture_target, GL_TEXTURE_MAX_LEVEL, mipmap_levels);
 	glTexParameteri(tslot->texture_target, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
 	glTexParameteri(tslot->texture_target, GL_TEXTURE_MIN_FILTER, min_filter);


### PR DESCRIPTION
When I made the texture array changes I forgot to test the texture
detail feature which caused some visual corruption when using a texture
detail which was less than the maximum. This should fix that.