### PR TITLE
Write EFX support information to JSON output

### DIFF
--- a/code/cmdline/cmdline.cpp
+++ b/code/cmdline/cmdline.cpp
@@ -1391,6 +1391,15 @@ static json_t* json_get_v1() {
 
 			json_object_set_new(openal_obj, "capture_devices", capture_array);
 		}
+		{
+			auto efx_support_obj = json_object();
+
+			for (auto& pair : openal_info.efx_support) {
+				json_object_set_new(efx_support_obj, pair.first.c_str(), json_boolean(pair.second));
+			}
+
+			json_object_set_new(openal_obj, "efx_support", efx_support_obj);
+		}
 
 		json_object_set_new(root, "openal", openal_obj);
 	}

--- a/code/sound/openal.h
+++ b/code/sound/openal.h
@@ -28,6 +28,8 @@ struct OpenALInformation {
 
 	SCP_vector<SCP_string> playback_devices;
 	SCP_vector<SCP_string> capture_devices;
+
+	SCP_vector<std::pair<SCP_string, bool>> efx_support;
 };
 
 OpenALInformation openal_get_platform_information();


### PR DESCRIPTION
The initial JSON flags output lacked this information but it is needed
for proper support by the launcher. This adds a new entry in the JSON
structure without changing anything else so it does not require a new
output version.