### PR TITLE
Add SignalBlockers to qtFRED

### DIFF
--- a/qtfred/source_groups.cmake
+++ b/qtfred/source_groups.cmake
@@ -97,6 +97,8 @@ add_file_folder("Source/UI/Dialogs"
 add_file_folder("Source/UI/Util"
 	src/ui/util/menu.cpp
 	src/ui/util/menu.h
+	src/ui/util/SignalBlockers.cpp
+	src/ui/util/SignalBlockers.h
 )
 
 add_file_folder("Source/UI/Widgets"

--- a/qtfred/src/ui/dialogs/MissionSpecDialog.cpp
+++ b/qtfred/src/ui/dialogs/MissionSpecDialog.cpp
@@ -2,6 +2,7 @@
 
 #include "ui_MissionSpecDialog.h"
 
+#include <ui/util/SignalBlockers.h>
 
 #include <QCloseEvent>
 #include <QFileDialog>
@@ -120,6 +121,8 @@ void MissionSpecDialog::closeEvent(QCloseEvent* event) {
 }
 
 void MissionSpecDialog::updateUI() {
+	util::SignalBlockers blockers(this);
+
 	ui->missionTitle->setText(_model->getMissionTitle().c_str());
 	ui->missionDesigner->setText(_model->getDesigner().c_str());
 
@@ -296,8 +299,6 @@ void MissionSpecDialog::respawnDelayChanged(int value) {
 }
 
 void MissionSpecDialog::squadronNameChanged(const QString & string) {
-	QSignalBlocker blocker(ui->squadronName);
-
 	_model->setSquadronName(string.toStdString());
 }
 
@@ -348,29 +349,21 @@ void MissionSpecDialog::minTrailDisplaySpeedChanged(int value) {
 }
 
 void MissionSpecDialog::cmdSenderChanged(int index) {
-	QSignalBlocker blocker(ui->senderCombBox);
-
 	auto sender = ui->senderCombBox->itemData(index).value<QString>().toStdString();
 	_model->setCommandSender(sender);
 }
 
 void MissionSpecDialog::cmdPersonaChanged(int index) {
-	QSignalBlocker blocker(ui->personaComboBox);
-
 	auto cmdPIndex = ui->personaComboBox->itemData(index).value<int>();
 	_model->setCommandPersona(cmdPIndex);
 }
 
 void MissionSpecDialog::eventMusicChanged(int index) {
-	QSignalBlocker blocker(ui->defaultMusicCombo);
-
 	auto defMusicIdx = ui->defaultMusicCombo->itemData(index).value<int>();
 	_model->setEventMusic(defMusicIdx);
 }
 
 void MissionSpecDialog::subEventMusicChanged(int index) {
-	QSignalBlocker blocker(ui->musicPackCombo);
-
 	auto subMusic = ui->musicPackCombo->itemData(index).value<QString>().toStdString();
 	_model->setSubEventMusic(subMusic);
 }
@@ -380,20 +373,14 @@ void MissionSpecDialog::flagToggled(bool enabled, Mission::Mission_Flags flag) {
 }
 
 void MissionSpecDialog::missionDescChanged() {
-	QSignalBlocker blocker(ui->missionDescEditor);
-
 	_model->setMissionDescText(ui->missionDescEditor->document()->toPlainText().toStdString());
 }
 
 void MissionSpecDialog::designerNotesChanged() {
-	QSignalBlocker blocker(ui->designerNoteEditor);
-
 	_model->setDesignerNoteText(ui->designerNoteEditor->document()->toPlainText().toStdString());
 }
 
 void MissionSpecDialog::aiProfileIndexChanged(int index) {
-	QSignalBlocker blocker(ui->aiProfileCombo);
-
 	auto aipIndex = ui->aiProfileCombo->itemData(index).value<int>();
 	_model->setAIProfileIndex(aipIndex);
 }

--- a/qtfred/src/ui/dialogs/ObjectOrientEditorDialog.cpp
+++ b/qtfred/src/ui/dialogs/ObjectOrientEditorDialog.cpp
@@ -5,6 +5,8 @@
 
 #include "ui_ObjectOrientationDialog.h"
 
+#include <ui/util/SignalBlockers.h>
+
 #include <QCloseEvent>
 
 namespace fso {
@@ -85,6 +87,8 @@ void ObjectOrientEditorDialog::closeEvent(QCloseEvent* event) {
 }
 
 void ObjectOrientEditorDialog::updateUI() {
+	util::SignalBlockers blockers(this);
+
 	ui->position_x->setValue(_model->getPosition().xyz.x);
 	ui->position_y->setValue(_model->getPosition().xyz.y);
 	ui->position_z->setValue(_model->getPosition().xyz.z);
@@ -128,8 +132,6 @@ void ObjectOrientEditorDialog::updateComboBox() {
 	ui->objectComboBox->setCurrentIndex(ui->objectComboBox->findData(_model->getObjectIndex()));
 }
 void ObjectOrientEditorDialog::objectSelectionChanged(int index) {
-	QSignalBlocker blocker(ui->objectComboBox);
-
 	auto objNum = ui->objectComboBox->itemData(index).value<int>();
 	_model->setSelectedObjectNum(objNum);
 }

--- a/qtfred/src/ui/dialogs/SelectionDialog.cpp
+++ b/qtfred/src/ui/dialogs/SelectionDialog.cpp
@@ -7,6 +7,8 @@
 
 #include "ui_SelectionDialog.h"
 
+#include <ui/util/SignalBlockers.h>
+
 #include <QtDebug>
 
 namespace fso {
@@ -67,6 +69,7 @@ SelectionDialog::~SelectionDialog() {
 
 }
 void SelectionDialog::updateUI() {
+	util::SignalBlockers blockers(this);
 	// Update check boxes
 	ui->checkPlayerStarts->setChecked(_model->isFilterStarts());
 	ui->checkWaypoints->setChecked(_model->isFilterWaypoints());
@@ -77,7 +80,6 @@ void SelectionDialog::updateUI() {
 	}
 
 	// Update ship list
-	QSignalBlocker shipBlocker(ui->shipSelectionList);
 	ui->shipSelectionList->clear();
 	for (auto& entry : _model->getObjectList()) {
 		auto item = new QListWidgetItem(QString::fromStdString(entry.name));
@@ -86,7 +88,6 @@ void SelectionDialog::updateUI() {
 	}
 
 	// Update wing and waypoint list
-	QSignalBlocker wingBlocker(ui->wingSelectionList);
 	ui->wingSelectionList->clear();
 	for (auto& entry : _model->getWingList()) {
 		auto item = new QListWidgetItem(QString::fromStdString(entry.name));

--- a/qtfred/src/ui/dialogs/WaypointEditorDialog.cpp
+++ b/qtfred/src/ui/dialogs/WaypointEditorDialog.cpp
@@ -2,7 +2,7 @@
 #include <jumpnode/jumpnode.h>
 #include <QtWidgets/QTextEdit>
 #include "ui/dialogs/WaypointEditorDialog.h"
-
+#include "ui/util/SignalBlockers.h"
 #include "ui_WaypointEditorDialog.h"
 
 namespace fso {
@@ -49,8 +49,6 @@ void WaypointEditorDialog::reject() {
 	accept();
 }
 void WaypointEditorDialog::updateComboBox() {
-	QSignalBlocker blocker(ui->pathSelection);
-
 	// Remove all previous entries
 	ui->pathSelection->clear();
 
@@ -64,9 +62,7 @@ void WaypointEditorDialog::updateComboBox() {
 	ui->pathSelection->setEnabled(ui->pathSelection->count() > 0);
 }
 void WaypointEditorDialog::updateUI() {
-	// We need to block signals here or else updating the combobox would lead to and update of the model
-	// which would call this function again
-	QSignalBlocker blocker(this);
+	util::SignalBlockers blockers(this);
 
 	updateComboBox();
 

--- a/qtfred/src/ui/util/SignalBlockers.cpp
+++ b/qtfred/src/ui/util/SignalBlockers.cpp
@@ -1,0 +1,17 @@
+#include "SignalBlockers.h"
+
+#include <QWidget>
+
+namespace fso {
+namespace fred {
+namespace util {
+
+SignalBlockers::SignalBlockers(QObject* parent) {
+	_blockers.emplace_back(parent);
+	for (QWidget* widget : parent->findChildren<QWidget*>()) {
+		_blockers.emplace_back(widget);
+	}
+}
+}
+}
+}

--- a/qtfred/src/ui/util/SignalBlockers.h
+++ b/qtfred/src/ui/util/SignalBlockers.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <QSignalBlocker>
+#include <vector>
+
+namespace fso {
+namespace fred {
+namespace util {
+
+class SignalBlockers {
+public:
+	SignalBlockers(QObject* parent);
+	~SignalBlockers() = default;
+	SignalBlockers() = delete;
+	SignalBlockers(const SignalBlockers&) = delete;
+	SignalBlockers& operator=(const SignalBlockers&) = delete;
+private:
+	std::vector<QSignalBlocker> _blockers;
+};
+
+}
+}
+}

--- a/qtfred/src/ui/widgets/sexp_tree.cpp
+++ b/qtfred/src/ui/widgets/sexp_tree.cpp
@@ -44,6 +44,7 @@
 #include "ship/ship.h"
 
 #include <ui/util/menu.h>
+#include <ui/util/SignalBlockers.h>
 
 #include <QtWidgets/QMessageBox>
 #include <QtWidgets/QMenu>
@@ -2314,8 +2315,7 @@ QTreeWidgetItem* sexp_tree::insertWithIcon(const QString& lpszItem,
 										   const QIcon& image,
 										   QTreeWidgetItem* hParent,
 										   QTreeWidgetItem* hInsertAfter) {
-	// We block the signals in this function since it would otherwise trigger the "item was edited" code
-	QSignalBlocker dataChangedBlocker(this);
+	util::SignalBlockers blockers(this);
 
 	QTreeWidgetItem* item = nullptr;
 	if (hParent == nullptr) {


### PR DESCRIPTION
SignalBlockers provides an easy way to block all Qt signals from a widget and all of the widget's descendants. Its intended use is to block signals in qtFRED dialogs' UI update functions.