### PR TITLE
Copy original FRED initialization code

### DIFF
--- a/qtfred/src/main.cpp
+++ b/qtfred/src/main.cpp
@@ -1,9 +1,6 @@
 #include <unordered_map>
 #include <memory>
-#include <utility>
 #include <functional>
-
-#include <stdlib.h>
 
 #include <QApplication>
 #include <QDir>
@@ -15,13 +12,10 @@
 #include "globalincs/mspdb_callstack.h"
 #endif
 
-#include "globalincs/globals.h" // MAX_SHIPS, NAME_LENGTH
-
 #include "mission/Editor.h"
 #include "mission/management.h"
 
 #include "ui/FredView.h"
-#include "FredApplication.h"
 #include "FredApplication.h"
 
 #include <signal.h>
@@ -119,37 +113,59 @@ int main(int argc, char* argv[]) {
 
 	auto baseDir = QDir::toNativeSeparators(QDir::current().absolutePath());
 
-	std::unordered_map<SubSystem, QString> initializers = {{ SubSystem::OS,           app.tr("Initializing OS interface") },
-														   { SubSystem::CommandLine,  app.tr("Parsing command line") },
-														   { SubSystem::Timer,        app.tr("Initializing Timer") },
-														   { SubSystem::CFile,        app.tr("Initializing CFile") },
-														   { SubSystem::Locale,       app.tr("Initialization locale") },
-														   { SubSystem::Graphics,     app.tr("Initializing graphics") },
-														   { SubSystem::Fonts,        app.tr("Initializing Fonts") },
-														   { SubSystem::Keyboard,     app.tr("Initializing keyboard") },
-														   { SubSystem::Mouse,        app.tr("Initializing mouse") },
-														   { SubSystem::Particles,    app.tr("Initializing particles") },
-														   { SubSystem::Iff,          app.tr("Initializing IFF") },
-														   { SubSystem::Objects,      app.tr("Initializing objects") },
-														   { SubSystem::Species,      app.tr("Initializing species") },
-														   { SubSystem::MissionBrief, app.tr("Initializing briefings") },
-														   { SubSystem::AI,           app.tr("Initializing AI") },
-														   { SubSystem::AIProfiles,   app.tr("Initializing AI profiles") },
-														   { SubSystem::Armor,        app.tr("Initializing armors") },
-														   { SubSystem::Weapon,       app.tr("Initializing weaponry") },
-														   { SubSystem::Medals,       app.tr("Initializing medals") },
-														   { SubSystem::Ships,        app.tr("Initializing ships") },
-														   { SubSystem::Parse,        app.tr("Initializing parser") },
-														   { SubSystem::Nebulas,      app.tr("Initializing nebulas") },
-														   { SubSystem::Stars,        app.tr("Initializing stars") },
-														   { SubSystem::View,         app.tr("Setting view") }};
+	typedef std::unordered_map<SubSystem, QString> SubsystemMap;
+	SubsystemMap initializers = {{ SubSystem::OS,                app.tr("Initializing OS interface") },
+								 { SubSystem::CommandLine,       app.tr("Parsing command line") },
+								 { SubSystem::Timer,             app.tr("Initializing Timer") },
+								 { SubSystem::CFile,             app.tr("Initializing CFile") },
+								 { SubSystem::Locale,            app.tr("Initializing locale") },
+								 { SubSystem::Sound,             app.tr("Initializing sound") },
+								 { SubSystem::Graphics,          app.tr("Initializing graphics") },
+								 { SubSystem::Scripting,         app.tr("Initializing scripting") },
+								 { SubSystem::Fonts,             app.tr("Initializing Fonts") },
+								 { SubSystem::Keyboard,          app.tr("Initializing keyboard") },
+								 { SubSystem::Mouse,             app.tr("Initializing mouse") },
+								 { SubSystem::Particles,         app.tr("Initializing particles") },
+								 { SubSystem::Iff,               app.tr("Initializing IFF") },
+								 { SubSystem::Objects,           app.tr("Initializing objects") },
+								 { SubSystem::Models,            app.tr("Initializing model system") },
+								 { SubSystem::Species,           app.tr("Initializing species") },
+								 { SubSystem::BriefingIcons,     app.tr("Initializing briefing icons") },
+								 { SubSystem::HudCommOrders,     app.tr("Initializing HUD comm orders") },
+								 { SubSystem::AlphaColors,       app.tr("Initializing alpha colors") },
+								 { SubSystem::GameSound,         app.tr("Initializing briefing icons") },
+								 { SubSystem::MissionBrief,      app.tr("Initializing briefings") },
+								 { SubSystem::AI,                app.tr("Initializing AI") },
+								 { SubSystem::AIProfiles,        app.tr("Initializing AI profiles") },
+								 { SubSystem::Armor,             app.tr("Initializing armors") },
+								 { SubSystem::Weapon,            app.tr("Initializing weaponry") },
+								 { SubSystem::Medals,            app.tr("Initializing medals") },
+								 { SubSystem::Glowpoints,        app.tr("Initializing glow points") },
+								 { SubSystem::Ships,             app.tr("Initializing ships") },
+								 { SubSystem::Parse,             app.tr("Initializing parser") },
+								 { SubSystem::TechroomIntel,     app.tr("Initializing techroom intel") },
+								 { SubSystem::Nebulas,           app.tr("Initializing nebulas") },
+								 { SubSystem::Stars,             app.tr("Initializing stars") },
+								 { SubSystem::Ssm,               app.tr("Initializing SSMs") },
+								 { SubSystem::EventMusic,        app.tr("Initializing event music") },
+								 { SubSystem::FictionViewer,     app.tr("Initializing fiction viewer") },
+								 { SubSystem::CommandBriefing,   app.tr("Initializing command briefing") },
+								 { SubSystem::Campaign,          app.tr("Initializing campaign system") },
+								 { SubSystem::NebulaLightning,   app.tr("Initializing nebula lightning") },
+								 { SubSystem::FFmpeg,            app.tr("Initializing FFmpeg") },
+								 { SubSystem::DynamicSEXPs,      app.tr("Initializing dynamic SEXP system") },
+								 { SubSystem::ScriptingInitHook, app.tr("Running game init scripting hook") }, };
 
-	fso::fred::initialize(baseDir.toStdString(), argc, argv, fred.get(), [&](const SubSystem& which) {
+	auto initSuccess = fso::fred::initialize(baseDir.toStdString(), argc, argv, fred.get(), [&](const SubSystem& which) {
 		if (initializers.count(which)) {
 			splash.showMessage(initializers.at(which), Qt::AlignHCenter | Qt::AlignBottom, Qt::white);
 		}
 		qGuiApp->processEvents();
 	});
+
+	if (!initSuccess) {
+		return -1;
+	}
 
 	splash.showMessage(app.tr("Showing editor window"), Qt::AlignHCenter | Qt::AlignBottom, Qt::white);
 	splash.finish(qApp->activeWindow());

--- a/qtfred/src/mission/management.cpp
+++ b/qtfred/src/mission/management.cpp
@@ -3,20 +3,29 @@
 
 #include "object.h"
 
-#include <object/waypoint.h>
-#include <object/object.h>
-#include <ship/ship.h>
 #include <localization/localize.h>
 #include <ui/QtGraphicsOperations.h>
 #include <io/key.h>
 #include <io/mouse.h>
-#include <mod_table/mod_table.h>
 #include <iff_defs/iff_defs.h>
 #include <weapon/weapon.h>
 #include <stats/medals.h>
 #include <nebula/neb.h>
 #include <starfield/starfield.h>
 #include <sound/audiostr.h>
+#include <project.h>
+#include <scripting/scripting.h>
+#include <hud/hudsquadmsg.h>
+#include <globalincs/alphacolors.h>
+
+#include <menuui/techmenu.h>
+#include <localization/fhash.h>
+#include <gamesnd/eventmusic.h>
+#include <missionui/fictionviewer.h>
+#include <mission/missioncampaign.h>
+#include <nebula/neblightning.h>
+#include <libs/ffmpeg/FFmpeg.h>
+#include <parse/sexp/sexp_lookup.h>
 
 #include <clocale>
 
@@ -26,75 +35,215 @@ extern void allocate_mission_text(size_t size);
 
 extern void parse_init(bool basic = false);
 
+extern void brief_init_colors();
+
+extern void ssm_init();    // Need this to populate Ssm_info so OPF_SSM_CLASS does something. -MageKing17
+
+extern void cmdline_debug_print_cmdline();
+
 namespace fso {
 namespace fred {
 
+void fred_preload_all_briefing_icons() {
+	for (auto& ii : Briefing_icon_info) {
+		generic_anim_load(&ii.regular);
+		hud_anim_load(&ii.fade);
+		hud_anim_load(&ii.highlight);
+	}
+}
 
-void initialize(const std::string& cfilepath, int argc, char* argv[], Editor* editor, InitializerCallback listener) {
+bool
+initialize(const std::string& cfilepath, int argc, char* argv[], Editor* editor, const InitializerCallback& listener) {
+	std::setlocale(LC_ALL, "C");
+
+	srand((unsigned) time(NULL));
+
+	listener(SubSystem::OS);
+	os_init(Osreg_class_name, Osreg_app_name);
+
+	listener(SubSystem::Timer);
+	timer_init();
+
+	listener(SubSystem::CommandLine);
+	// this should enable mods - Kazan
+	parse_cmdline(argc, argv);
 
 #ifndef NDEBUG
-	outwnd_init();
+#if FS_VERSION_REVIS == 0
+	mprintf(("qtFred Open version: %i.%i.%i\n", FS_VERSION_MAJOR, FS_VERSION_MINOR, FS_VERSION_BUILD));
+#else
+	mprintf(("qtFred Open version: %i.%i.%i.%i\n", FS_VERSION_MAJOR, FS_VERSION_MINOR, FS_VERSION_BUILD, FS_VERSION_REVIS));
+#endif
 
+	cmdline_debug_print_cmdline();
+#endif
+
+	// d'oh
+	// cfile needs a file path...
+	auto file_path = cfilepath + DIR_SEPARATOR_STR + "qtfred.exe";
+
+	listener(SubSystem::CFile);
+	if (cfile_init(file_path.c_str())) {
+		return false;
+	}
+
+	listener(SubSystem::ModTable);
+	// Load game_settings.tbl
+	mod_table_init();
+
+	listener(SubSystem::Locale);
+	// initialize localization module. Make sure this is done AFTER initialzing OS.
+	// NOTE : Fred should ALWAYS run in English. Otherwise it might swap in another language
+	// when saving - which would cause inconsistencies when externalizing to tstrings.tbl via Exstr
+	// trust me on this :)
+	lcl_init(FS2_OPEN_DEFAULT_LANGUAGE);
+
+	// Goober5000 - force init XSTRs (so they work, but only work in English, based on above comment)
+	Xstr_inited = 1;
+
+#ifndef NDEBUG
 	load_filter_info();
 #endif
 
-	std::setlocale(LC_ALL, "C");
+	listener(SubSystem::Sound);
+	snd_init();
 
-	std::vector<std::pair<std::function<void(void)>, SubSystem>> initializers =
-		{{ std::bind(os_init, Osreg_company_name, Osreg_app_name, nullptr),          SubSystem::OS },
-		 { timer_init,                                                               SubSystem::Timer },
-		 { [&]() {
-			 // this should enable mods - Kazan
-			 parse_cmdline(argc, argv);
-		 },                                                                          SubSystem::CommandLine },
-		 { [&cfilepath](void) {
-			 // cfile needs a file path...
-			 auto file_path = cfilepath + DIR_SEPARATOR_STR + "qtfred.exe";
+	listener(SubSystem::Graphics);
+	// Not ready for this yet
+	//	Cmdline_nospec = 1;
+	// 	Cmdline_noglow = 1;
+	Cmdline_window = 1;
 
-			 cfile_init(file_path.c_str());
-		 },                                                                          SubSystem::CFile },
-		 {[]()
-		 {
-			 mod_table_init();
-		 },                                                                          SubSystem::ModTable },
-		 { []() {
-			 lcl_init(FS2_OPEN_DEFAULT_LANGUAGE);
+	std::unique_ptr<QtGraphicsOperations> graphicsOps(new QtGraphicsOperations(editor));
+	gr_init(std::move(graphicsOps));
 
-			 // Goober5000 - force init XSTRs (so they work, but only work in English, based on above comment)
-			 Xstr_inited = 1;
-		 },                                                                          SubSystem::Locale },
-		 { [=]() {
-			 std::unique_ptr<QtGraphicsOperations> graphicsOps(new QtGraphicsOperations(editor));
-			 gr_init(std::move(graphicsOps));
-		 },                                                                          SubSystem::Graphics },
-		 { font::init,                                                               SubSystem::Fonts },
-		 { key_init,                                                                 SubSystem::Keyboard },
-		 { mouse_init,                                                               SubSystem::Mouse },
-		 { particle::ParticleManager::init,                                          SubSystem::Particles },
-		 { iff_init,                                                                 SubSystem::Iff },
-		 { obj_init,                                                                 SubSystem::Objects },
-		 { species_init,                                                             SubSystem::Species },
-		 { mission_brief_common_init,                                                SubSystem::MissionBrief },
-		 { ai_init,                                                                  SubSystem::AI },
-		 { ai_profiles_init,                                                         SubSystem::AIProfiles },
-		 { armor_init,                                                               SubSystem::Armor },
-		 { weapon_init,                                                              SubSystem::Weapon },
-		 { parse_medal_tbl,                                                          SubSystem::Medals },
-		 { ship_init,                                                                SubSystem::Ships },
-		 { []() { parse_init(); },                                                   SubSystem::Parse },
-		 { neb2_init,                                                                SubSystem::Nebulas },
-		 { []() {
-			 stars_init();
-			 stars_pre_level_init(true);
-			 stars_post_level_init();
-		 },                                                                          SubSystem::Stars }};
+	io::mouse::CursorManager::get()->showCursor(false);
 
-	for (const auto& initializer : initializers) {
-		const auto& init_function = initializer.first;
-		const auto& which = initializer.second;
-		listener(which);
-		init_function();
+	// To avoid breaking current mods which do not support scripts in FRED we only initialize the scripting
+	// system if a special mod_table option is set
+	if (Enable_scripts_in_fred) {
+		listener(SubSystem::Scripting);
+		script_init();            //WMC
 	}
+
+	listener(SubSystem::Fonts);
+	font::init();                    // loads up all fonts
+
+	gr_set_gamma(3.0f);
+
+	listener(SubSystem::Keyboard);
+	key_init();
+
+	listener(SubSystem::Mouse);
+	mouse_init();
+
+	listener(SubSystem::Particles);
+	particle::ParticleManager::init();
+
+	listener(SubSystem::Iff);
+	iff_init();            // Goober5000
+
+	listener(SubSystem::Species);
+	species_init();        // Kazan
+
+	listener(SubSystem::BriefingIcons);
+	brief_parse_icon_tbl();
+
+	// for fred specific replacement texture stuff
+	Fred_texture_replacements.clear();
+
+	listener(SubSystem::HudCommOrders);
+	hud_init_comm_orders();        // Goober5000
+
+	listener(SubSystem::AlphaColors);
+	alpha_colors_init();
+
+	listener(SubSystem::GameSound);
+	gamesnd_parse_soundstbl();        // needs to be loaded after species stuff but before interface/weapon/ship stuff - taylor
+
+	listener(SubSystem::MissionBrief);
+	mission_brief_common_init();
+
+	listener(SubSystem::Objects);
+	obj_init();
+
+	listener(SubSystem::Models);
+	model_init();
+	model_free_all();                // Free all existing models
+
+	listener(SubSystem::AI);
+	ai_init();
+
+	listener(SubSystem::AIProfiles);
+	ai_profiles_init();
+
+	listener(SubSystem::Armor);
+	armor_init();
+
+	listener(SubSystem::Weapon);
+	weapon_init();
+
+	listener(SubSystem::Medals);
+	parse_medal_tbl();            // get medal names for sexpression usage
+
+	listener(SubSystem::Glowpoints);
+	glowpoint_init();
+
+	listener(SubSystem::Ships);
+	ship_init();
+
+	listener(SubSystem::Parse);
+	parse_init();
+
+	listener(SubSystem::TechroomIntel);
+	techroom_intel_init();
+
+	// initialize and activate external string hash table
+	// make sure to do here so that we don't parse the table files into the hash table - waste of space
+	fhash_init();
+	fhash_activate();
+
+	listener(SubSystem::Nebulas);
+	neb2_init();                        // fullneb stuff
+
+	listener(SubSystem::Stars);
+	stars_init();
+
+	listener(SubSystem::Ssm);
+	ssm_init();        // The game calls this after stars_init(), and we need Ssm_info initialized for OPF_SSM_CLASS. -MageKing17
+
+	brief_init_colors();
+	fred_preload_all_briefing_icons(); //phreak.  This needs to be done or else the briefing icons won't show up
+
+	listener(SubSystem::EventMusic);
+	event_music_init();
+
+	listener(SubSystem::FictionViewer);
+	fiction_viewer_reset();
+
+	listener(SubSystem::CommandBriefing);
+	cmd_brief_reset();
+	Show_waypoints = TRUE;
+
+	listener(SubSystem::Campaign);
+	mission_campaign_clear();
+
+	stars_post_level_init();
+
+	// neb lightning
+	listener(SubSystem::NebulaLightning);
+	nebl_init();
+
+	listener(SubSystem::FFmpeg);
+	libs::ffmpeg::initialize();
+
+	listener(SubSystem::DynamicSEXPs);
+	sexp::dynamic_sexp_init();
+
+	listener(SubSystem::ScriptingInitHook);
+	Script_system.RunCondition(CHA_GAMEINIT);
+
+	return true;
 }
 
 void shutdown() {

--- a/qtfred/src/mission/management.h
+++ b/qtfred/src/mission/management.h
@@ -14,25 +14,42 @@ enum class SubSystem {
 	CFile,
 	ModTable,
 	Locale,
+	Sound,
 	Graphics,
+	Scripting,
 	Fonts,
 	Keyboard,
 	Mouse,
 	Particles,
 	Iff,
 	Objects,
+	Models,
 	Species,
+	BriefingIcons,
+	HudCommOrders,
+	AlphaColors,
+	GameSound,
 	MissionBrief,
 	AI,
 	AIProfiles,
 	Armor,
 	Weapon,
 	Medals,
+	Glowpoints,
 	Ships,
 	Parse,
+	TechroomIntel,
 	Nebulas,
 	Stars,
-	View,
+	Ssm,
+	EventMusic,
+	FictionViewer,
+	CommandBriefing,
+	Campaign,
+	NebulaLightning,
+	FFmpeg,
+	DynamicSEXPs,
+	ScriptingInitHook,
 };
 
 typedef std::function<void(const SubSystem&)> InitializerCallback;
@@ -46,14 +63,16 @@ class Editor;
  * This enable the developer to provide information about the startup
  * sequence.
  *
- * \param[in]   cfilepath   CFile root directory.
- * \param[in]   listener    A callback function called after each initializer.
+ * @param[in]   cfilepath   CFile root directory.
+ * @param[in]   listener    A callback function called after each initializer.
+ *
+ * @return @c true if initialization was successfull, @c false otherwise
  */
-void initialize(const std::string& cfilepath,
+bool initialize(const std::string& cfilepath,
 				int argc,
 				char* argv[],
 				Editor* editor,
-				InitializerCallback listener = [](const SubSystem&) {});
+				const InitializerCallback& listener = [](const SubSystem&) {});
 
 void shutdown();
 


### PR DESCRIPTION
This copies the original FRED code for initializing the individual game
systems to qtFRED. This should fix the various issues caused by missing
game system initialization calls.