### PR TITLE
Minor clean up

### DIFF
--- a/code/asteroid/asteroid.cpp
+++ b/code/asteroid/asteroid.cpp
@@ -1418,35 +1418,6 @@ void asteroid_level_close()
 DCF_BOOL2(asteroids, Asteroids_enabled, "enables or disables asteroids", "Usage: asteroids [bool]\nTurns asteroid system on/off.  If nothing passed, then toggles it.\n");
 
 
-static void hud_target_asteroid()
-{
-	int	i;
-	int	start_index = 0, end_index = MAX_ASTEROIDS;
-
-	if (Player_ai->target_objnum != -1) {
-		if (Objects[Player_ai->target_objnum].type == OBJ_ASTEROID) {
-			start_index = Objects[Player_ai->target_objnum].instance+1;
-			end_index = start_index-1;
-			if (end_index < 0)
-				end_index = MAX_ASTEROIDS;
-		}
-	}
-
-	i = start_index;
-	while (i != end_index) {
-		if (i == MAX_ASTEROIDS)
-			i = 0;
-
-		if (Asteroids[i].flags & AF_USED) {
-			Assert(Objects[Asteroids[i].objnum].type == OBJ_ASTEROID);
-			set_target_objnum( Player_ai, Asteroids[i].objnum);
-			break;
-		}
-
-		i++;
-	}
-}
-
 /**
  * Return the number of active asteroids
  */

--- a/code/asteroid/asteroid.cpp
+++ b/code/asteroid/asteroid.cpp
@@ -488,20 +488,6 @@ static void asteroid_load(int asteroid_info_index, int asteroid_subtype)
 }
 
 /**
- * Randomly choose a debris model within the current group
- */
-int get_debris_from_same_group(int index) {
-	int group_base, group_offset;
-
-	group_base = (index / NUM_DEBRIS_SIZES) * NUM_DEBRIS_SIZES;
-	group_offset = index - group_base;
-
-	// group base + offset
-	// offset is formed by adding 1 or 2 (since 3 in model group) and mapping back in the 0-2 range
-	return group_base + ((group_offset + rand()%(NUM_DEBRIS_SIZES-1) + 1) % NUM_DEBRIS_SIZES);
-}
-
-/**
  * Returns a weight that depends on asteroid size.
  *
  * The weight is then used to determine the frequencty of different sizes of ship debris
@@ -1593,25 +1579,6 @@ static void asteroid_maybe_break_up(object *pasteroid_obj)
 		Script_system.RunCondition(CHA_DEATH, '\0', NULL, pasteroid_obj);
 		Script_system.RemHookVar("Self");
 	}
-}
-
-int asteroid_get_random_in_cone(vec3d *pos, vec3d *dir, float ang, int danger)
-{
-	int idx;
-	vec3d asteroid_dir;
-
-	// just pick the first asteroid which satisfies our condition
-	for(idx=0; idx<Num_asteroids; idx++){
-		vm_vec_sub(&asteroid_dir, &Objects[Asteroids[idx].objnum].pos, pos);
-		vm_vec_normalize_quick(&asteroid_dir);
-
-		// if it satisfies the condition
-		if(vm_vec_dot(dir, &asteroid_dir) >= ang){
-			return idx;
-		}
-	}
-
-	return -1;
 }
 
 static void asteroid_test_collide(object *pasteroid_obj, object *pship_obj, mc_info *mc, bool lazy = false)

--- a/code/asteroid/asteroid.cpp
+++ b/code/asteroid/asteroid.cpp
@@ -76,7 +76,7 @@ float	Asteroid_icon_closeup_zoom;
 /**
  * Force updating of pair stuff for asteroid *objp.
  */
-void asteroid_update_collide(object *objp)
+static void asteroid_update_collide(object *objp)
 {
 	// Asteroid has wrapped, update collide objnum and flags
 	Asteroids[objp->instance].collide_objnum = -1;
@@ -87,7 +87,7 @@ void asteroid_update_collide(object *objp)
 /**
  * Clear out the ::Asteroid_obj_list
  */
-void asteroid_obj_list_init()
+static void asteroid_obj_list_init()
 {
 	int i;
 
@@ -101,7 +101,7 @@ void asteroid_obj_list_init()
  * Add a node from the Asteroid_obj_list.  
  * Only called from ::weapon_create()
  */
-int asteroid_obj_list_add(int objnum)
+static int asteroid_obj_list_add(int objnum)
 {
 	int index;
 
@@ -123,7 +123,7 @@ int asteroid_obj_list_add(int objnum)
  * Remove a node from the Asteroid_obj_list.  
  * Only called from ::weapon_delete()
  */
-void asteroid_obj_list_remove(object * obj)
+static void asteroid_obj_list_remove(object * obj)
 {
 	int index = obj->instance;
 
@@ -138,7 +138,7 @@ void asteroid_obj_list_remove(object * obj)
 /**
  * Prevent speed from getting too huge so it's hard to catch up to an asteroid.
  */
-float asteroid_cap_speed(int asteroid_info_index, float speed)
+static float asteroid_cap_speed(int asteroid_info_index, float speed)
 {
 	float max, double_max;
 
@@ -164,7 +164,7 @@ float asteroid_cap_speed(int asteroid_info_index, float speed)
  * Sum together the following: 1 inside x, 2 inside y, 4 inside z
  * inside only when sum = 7
  */
-int asteroid_in_inner_bound_with_axes(asteroid_field *asfieldp, vec3d *pos, float delta)
+static int asteroid_in_inner_bound_with_axes(asteroid_field *asfieldp, vec3d *pos, float delta)
 {
 	Assert(asfieldp->has_inner_bound);
 
@@ -188,7 +188,7 @@ int asteroid_in_inner_bound_with_axes(asteroid_field *asfieldp, vec3d *pos, floa
  * Check if asteroid is within inner bound
  * @return 0 if not inside or no inner bound, 1 if inside inner bound
  */
-int asteroid_in_inner_bound(asteroid_field *asfieldp, vec3d *pos, float delta) {
+static int asteroid_in_inner_bound(asteroid_field *asfieldp, vec3d *pos, float delta) {
 
 	if (!asfieldp->has_inner_bound) {
 		return 0;
@@ -202,7 +202,7 @@ int asteroid_in_inner_bound(asteroid_field *asfieldp, vec3d *pos, float delta) {
  *
  * Moves to the other side of the inner box a distance delta from edge of box
  */
-void inner_bound_pos_fixup(asteroid_field *asfieldp, vec3d *pos)
+static void inner_bound_pos_fixup(asteroid_field *asfieldp, vec3d *pos)
 {
 	if (!asteroid_in_inner_bound(asfieldp, pos, 0)) {
 		return;
@@ -446,7 +446,7 @@ void asteroid_sub_create(object *parent_objp, int asteroid_type, vec3d *relvec)
 /**
  * Load in an asteroid model
  */
-void asteroid_load(int asteroid_info_index, int asteroid_subtype)
+static void asteroid_load(int asteroid_info_index, int asteroid_subtype)
 {
 	int i;
 	asteroid_info	*asip;
@@ -506,7 +506,7 @@ int get_debris_from_same_group(int index) {
  *
  * The weight is then used to determine the frequencty of different sizes of ship debris
  */
-int get_debris_weight(int ship_debris_index)
+static int get_debris_weight(int ship_debris_index)
 {
 	int size = ship_debris_index % NUM_DEBRIS_SIZES;
 	switch (size)
@@ -645,7 +645,7 @@ void asteroid_level_init()
  *
  * @return !0 if asteroid should be wrapped, 0 otherwise.  
  */
-int asteroid_should_wrap(object *objp, asteroid_field *asfieldp)
+static int asteroid_should_wrap(object *objp, asteroid_field *asfieldp)
 {
 	if ( MULTIPLAYER_CLIENT )
 		return 0;
@@ -690,7 +690,7 @@ int asteroid_should_wrap(object *objp, asteroid_field *asfieldp)
 /**
  * Wrap an asteroid from one end of the asteroid field to the other
  */
-void asteroid_wrap_pos(object *objp, asteroid_field *asfieldp)
+static void asteroid_wrap_pos(object *objp, asteroid_field *asfieldp)
 {
 	if (objp->pos.xyz.x < asfieldp->min_bound.xyz.x) {
 		objp->pos.xyz.x = asfieldp->max_bound.xyz.x + (objp->pos.xyz.x - asfieldp->min_bound.xyz.x);
@@ -727,7 +727,7 @@ void asteroid_wrap_pos(object *objp, asteroid_field *asfieldp)
  *
  * @return !0 if this asteroid is a target for any ship, otherwise return 0
  */
-int asteroid_is_targeted(object *objp)
+static int asteroid_is_targeted(object *objp)
 {
 	ship_obj	*so;
 	object	*ship_objp;
@@ -748,7 +748,7 @@ int asteroid_is_targeted(object *objp)
 /**
  * Create an asteroid that will hit object *objp in delta_time seconds
  */
-void asteroid_aim_at_target(object *objp, object *asteroid_objp, float delta_time)
+static void asteroid_aim_at_target(object *objp, object *asteroid_objp, float delta_time)
 {
 	vec3d	predicted_center_pos;
 	vec3d	rand_vec;
@@ -776,7 +776,7 @@ void asteroid_aim_at_target(object *objp, object *asteroid_objp, float delta_tim
  *
  * @param count asteroids already targeted on
  */
-void maybe_throw_asteroid(int count)
+static void maybe_throw_asteroid(int count)
 {
 	if (!timestamp_elapsed(Next_asteroid_throw)) {
 		return;
@@ -850,7 +850,7 @@ void asteroid_delete( object * obj )
  * See if we should reposition the asteroid.  
  * Only reposition if oustide the bounding volume and the player isn't looking towards the asteroid.
  */
-void asteroid_maybe_reposition(object *objp, asteroid_field *asfieldp)
+static void asteroid_maybe_reposition(object *objp, asteroid_field *asfieldp)
 {
 	// passive field does not wrap
 	if (asfieldp->field_type == FT_PASSIVE) {
@@ -903,7 +903,7 @@ void asteroid_maybe_reposition(object *objp, asteroid_field *asfieldp)
 	}
 }
 
-void lerp(float *goal, float f1, float f2, float scale)
+static void lerp(float *goal, float f1, float f2, float scale)
 {
 	*goal = (f2 - f1) * scale + f1;
 }
@@ -1207,7 +1207,7 @@ void asteroid_render(object * obj, model_draw_list *scene)
 /**
  * Create a normalized vector generally in the direction from *hitpos to other_obj->pos
  */
-void asc_get_relvec(vec3d *relvec, object *other_obj, vec3d *hitpos)
+static void asc_get_relvec(vec3d *relvec, object *other_obj, vec3d *hitpos)
 {
 	vec3d	tvec, rand_vec;
 	int		count = 0;
@@ -1229,7 +1229,7 @@ void asc_get_relvec(vec3d *relvec, object *other_obj, vec3d *hitpos)
 /**
  * Return multiplier on asteroid radius for fireball
  */
-float asteroid_get_fireball_scale_multiplier(int num)
+static float asteroid_get_fireball_scale_multiplier(int num)
 {
 	if (Asteroids[num].flags & AF_USED) {
 		asteroid_info *asip = &Asteroid_info[Asteroids[num].asteroid_type];
@@ -1258,7 +1258,7 @@ float asteroid_get_fireball_scale_multiplier(int num)
  * Create asteroid explosion
  * @return expected time for explosion anim to last, in seconds
  */
-float asteroid_create_explosion(object *objp)
+static float asteroid_create_explosion(object *objp)
 {
 	int	fireball_objnum;
 	float	explosion_life, fireball_scale_multiplier;
@@ -1290,7 +1290,7 @@ float asteroid_create_explosion(object *objp)
 /**
  * Play sound when asteroid explodes
  */
-void asteriod_explode_sound(object *objp, int type, int play_loud)
+static void asteriod_explode_sound(object *objp, int type, int play_loud)
 {
 	int	sound_index = -1;
 	float range_factor = 1.0f;		// how many times sound should traver farther than normal
@@ -1320,7 +1320,7 @@ void asteriod_explode_sound(object *objp, int type, int play_loud)
  *
  * @param asteroid_objp	object pointer to asteriod causing explosion
  */
-void asteroid_do_area_effect(object *asteroid_objp)
+static void asteroid_do_area_effect(object *asteroid_objp)
 {
 	object			*ship_objp;
 	float				damage, blast;
@@ -1432,7 +1432,7 @@ void asteroid_level_close()
 DCF_BOOL2(asteroids, Asteroids_enabled, "enables or disables asteroids", "Usage: asteroids [bool]\nTurns asteroid system on/off.  If nothing passed, then toggles it.\n");
 
 
-void hud_target_asteroid()
+static void hud_target_asteroid()
 {
 	int	i;
 	int	start_index = 0, end_index = MAX_ASTEROIDS;
@@ -1473,7 +1473,7 @@ int asteroid_count()
  * See if asteroid should split up.  
  * We delay splitting up to allow the explosion animation to play for a bit.
  */
-void asteroid_maybe_break_up(object *pasteroid_obj)
+static void asteroid_maybe_break_up(object *pasteroid_obj)
 {
 	asteroid *asp;
 	asteroid_info *asip;
@@ -1614,7 +1614,7 @@ int asteroid_get_random_in_cone(vec3d *pos, vec3d *dir, float ang, int danger)
 	return -1;
 }
 
-void asteroid_test_collide(object *pasteroid_obj, object *pship_obj, mc_info *mc, bool lazy = false)
+static void asteroid_test_collide(object *pasteroid_obj, object *pship_obj, mc_info *mc, bool lazy = false)
 {
 	float		asteroid_ray_dist;
 	vec3d	asteroid_fvec, terminus;
@@ -1656,7 +1656,7 @@ void asteroid_test_collide(object *pasteroid_obj, object *pship_obj, mc_info *mc
  *
  * @return !0 if the asteroid will collide with the escort
  */
-int asteroid_will_collide(object *pasteroid_obj, object *escort_objp)
+static int asteroid_will_collide(object *pasteroid_obj, object *escort_objp)
 {
 	mc_info	mc;
 	mc_info_init(&mc);
@@ -1674,7 +1674,7 @@ int asteroid_will_collide(object *pasteroid_obj, object *escort_objp)
  * Warn if asteroid on collision path with ship
  * @return !0 if we should warn about asteroid hitting ship, otherwise return 0
  */
-int asteroid_valid_ship_to_warn_collide(ship *shipp)
+static int asteroid_valid_ship_to_warn_collide(ship *shipp)
 {
 	if ( !(Ship_info[shipp->ship_info_index].is_big_or_huge()) ) {
 		return 0;
@@ -1696,7 +1696,7 @@ int asteroid_valid_ship_to_warn_collide(ship *shipp)
  * See if asteroid will collide with a large ship on the escort list in the next
  * ASTEROID_MIN_COLLIDE_TIME seconds.
  */
-void asteroid_update_collide_flag(object *asteroid_objp)
+static void asteroid_update_collide_flag(object *asteroid_objp)
 {
 	int		i, num_escorts, escort_objnum, will_collide=0;
 	ship		*escort_shipp;
@@ -1735,7 +1735,7 @@ void asteroid_update_collide_flag(object *asteroid_objp)
 /**
  * Ensure that the collide objnum for the asteroid is still valid
  */
-void asteroid_verify_collide_objnum(asteroid *asp)
+static void asteroid_verify_collide_objnum(asteroid *asp)
 {
 	if ( asp->collide_objnum >= 0 ) {
 		if ( Objects[asp->collide_objnum].signature != asp->collide_objsig ) {
@@ -1815,7 +1815,7 @@ float asteroid_time_to_impact(object *asteroid_objp)
 /**
  * Read in a single asteroid section from asteroid.tbl
  */
-void asteroid_parse_section(asteroid_info *asip)
+static void asteroid_parse_section(asteroid_info *asip)
 {
 	required_string("$Name:");
 	stuff_string(asip->name, F_NAME, NAME_LENGTH);
@@ -1915,7 +1915,7 @@ to do with the debris of ships that explode, however these
 are the same debris and asteroids that get flung at a ship
 that is being protected.
 */
-void asteroid_parse_tbl()
+static void asteroid_parse_tbl()
 {
 	char impact_ani_file[MAX_FILENAME_LEN];
 
@@ -2066,7 +2066,7 @@ void asteroid_parse_tbl()
 /**
  * Return number of asteroids expected to collide with a ship.
  */
-int count_incident_asteroids()
+static int count_incident_asteroids()
 {
 	object	*asteroid_objp;
 	int		count;
@@ -2090,7 +2090,7 @@ int count_incident_asteroids()
  * Pick object to throw asteroids at.
  * Pick any capital or big ship inside the bounds of the asteroid field.
  */
-int set_asteroid_throw_objnum()
+static int set_asteroid_throw_objnum()
 {
 	if (Asteroid_field.num_initial_asteroids < 1)
 		return -1;

--- a/code/asteroid/asteroid.cpp
+++ b/code/asteroid/asteroid.cpp
@@ -626,7 +626,7 @@ void asteroid_create_all()
 }
 
 /**
- * Init asteriod system for the level, called from ::game_level_init()
+ * Init asteroid system for the level, called from ::game_level_init()
  */
 void asteroid_level_init()
 {
@@ -1290,7 +1290,7 @@ static float asteroid_create_explosion(object *objp)
 /**
  * Play sound when asteroid explodes
  */
-static void asteriod_explode_sound(object *objp, int type, int play_loud)
+static void asteroid_explode_sound(object *objp, int type, int play_loud)
 {
 	int	sound_index = -1;
 	float range_factor = 1.0f;		// how many times sound should traver farther than normal
@@ -1318,7 +1318,7 @@ static void asteriod_explode_sound(object *objp, int type, int play_loud)
 /**
  * Do the area effect for an asteroid exploding
  *
- * @param asteroid_objp	object pointer to asteriod causing explosion
+ * @param asteroid_objp	object pointer to asteroid causing explosion
  */
 static void asteroid_do_area_effect(object *asteroid_objp)
 {
@@ -1382,7 +1382,7 @@ void asteroid_hit( object * pasteroid_obj, object * other_obj, vec3d * hitpos, f
 
 			explosion_life = asteroid_create_explosion(pasteroid_obj);
 
-			asteriod_explode_sound(pasteroid_obj, asp->asteroid_type, play_loud_collision);
+			asteroid_explode_sound(pasteroid_obj, asp->asteroid_type, play_loud_collision);
 			asteroid_do_area_effect(pasteroid_obj);
 
 			asp->final_death_time = timestamp( fl2i(explosion_life*1000.0f)/5 );	// Wait till 30% of vclip time before breaking the asteroid up.

--- a/code/asteroid/asteroid.h
+++ b/code/asteroid/asteroid.h
@@ -163,7 +163,6 @@ int	asteroid_collide_objnum(object *asteroid_objp);
 float asteroid_time_to_impact(object *asteroid_objp);
 void	asteroid_show_brackets();
 void	asteroid_target_closest_danger();
-int	asteroid_get_random_in_cone(vec3d *pos, vec3d *dir, float ang, int danger = 0);
 
 // need to extern for multiplayer
 void asteroid_sub_create(object *parent_objp, int asteroid_type, vec3d *relvec);

--- a/code/io/keycontrol.cpp
+++ b/code/io/keycontrol.cpp
@@ -613,7 +613,6 @@ void debug_change_song(int delta)
 	}
 }
 
-extern void hud_target_asteroid();
 extern int Framerate_delay;
 
 extern void snd_stop_any_sound();

--- a/code/object/collideshipship.cpp
+++ b/code/object/collideshipship.cpp
@@ -35,7 +35,7 @@
 
 // GENERAL COLLISIONS FUNCTIONS
 // calculates the inverse moment of inertia matrix in world coordinates
-void get_I_inv (matrix* I_inv, matrix* I_inv_body, matrix* orient);
+static void get_I_inv (matrix* I_inv, matrix* I_inv_body, matrix* orient);
 
 // calculate the physics of extended two body collisions
 void calculate_ship_ship_collision_physics(collision_info_struct *ship_ship_hit_info);
@@ -54,7 +54,7 @@ static int Player_collide_shield_sound, AI_collide_shield_sound;
 /**
  * Return true if two ships are docking.
  */
-int ships_are_docking(object *objp1, object *objp2)
+static int ships_are_docking(object *objp1, object *objp2)
 {
 	ai_info	*aip1, *aip2;
 	ship		*shipp1, *shipp2;
@@ -88,7 +88,7 @@ int ships_are_docking(object *objp1, object *objp2)
 /**
  * If light_obj emerging from or departing to dock bay in heavy_obj, no collision detection.
  */
-int bay_emerge_or_depart(object *heavy_objp, object *light_objp)
+static int bay_emerge_or_depart(object *heavy_objp, object *light_objp)
 {
 	if (light_objp->type != OBJ_SHIP)
 		return 0;
@@ -457,7 +457,7 @@ int ship_ship_check_collision(collision_info_struct *ship_ship_hit_info, vec3d *
  * modified mass is 10x, 4x, or 2x larger than asteroid mass
  * @return 1 if modified mass is larger than given mass, 0 otherwise 
  */
-int check_special_cruiser_asteroid_collision(object *heavy, object *lighter, float *cruiser_mass, int *cruiser_light)
+static int check_special_cruiser_asteroid_collision(object *heavy, object *lighter, float *cruiser_mass, int *cruiser_light)
 {
 	int asteroid_type;
 
@@ -504,7 +504,7 @@ int check_special_cruiser_asteroid_collision(object *heavy, object *lighter, flo
 /**
  * Find the subobject corresponding to the submodel hit
  */
-bool check_subsystem_landing_allowed(ship_info *heavy_sip, collision_info_struct *ship_ship_hit_info) {
+static bool check_subsystem_landing_allowed(ship_info *heavy_sip, collision_info_struct *ship_ship_hit_info) {
 	if (!(heavy_sip->flags[Ship::Info_Flags::Allow_landings]))
 		return false;
 
@@ -855,7 +855,7 @@ void calculate_ship_ship_collision_physics(collision_info_struct *ship_ship_hit_
 //
 // calculates the inverse moment of inertia matrix from the body matrix and oreint matrix
 //
-void get_I_inv (matrix* I_inv, matrix* I_inv_body, matrix* orient)
+static void get_I_inv (matrix* I_inv, matrix* I_inv_body, matrix* orient)
 {
 	matrix Mtemp1, Mtemp2;
 	// I_inv = (Rt)(I_inv_body)(R)
@@ -877,7 +877,7 @@ extern void hud_start_text_flash(char *txt, int t, int interval);
  * Procss player_ship:planet damage.
  *	If within range of planet, apply damage to ship.
  */
-void mcp_1(object *player_objp, object *planet_objp)
+static void mcp_1(object *player_objp, object *planet_objp)
 {
 	float	planet_radius;
 	float	dist;
@@ -902,7 +902,7 @@ void mcp_1(object *player_objp, object *planet_objp)
  * Return true if *objp is a planet, else return false.
  *	Hack: Just checking first six letters of name.
  */
-int is_planet(object *objp)
+static int is_planet(object *objp)
 {
 	return (strnicmp(Ships[objp->instance].ship_name, NOX("planet"), 6) == 0);
 }
@@ -912,7 +912,7 @@ int is_planet(object *objp)
  * If exactly one of these is a planet and the other is a player ship, do something special.
  * @return true if this was a ship:planet (or planet_ship) collision and we processed it. Else return false.
  */
-int maybe_collide_planet (object *obj1, object *obj2)
+static int maybe_collide_planet (object *obj1, object *obj2)
 {
 	ship_info	*sip1, *sip2;
 
@@ -1000,7 +1000,7 @@ void collide_ship_ship_do_sound(vec3d *world_hit_pos, object *A, object *B, int 
  * obj1 and obj2 collided.
  * If different teams, kamikaze bit set and other ship is large, auto-explode!
  */
-void do_kamikaze_crash(object *obj1, object *obj2)
+static void do_kamikaze_crash(object *obj1, object *obj2)
 {
 	ai_info	*aip1, *aip2;
 	ship		*ship1, *ship2;
@@ -1029,7 +1029,7 @@ void do_kamikaze_crash(object *obj1, object *obj2)
 /**
  * Response when hit by fast moving cap ship
  */
-void maybe_push_little_ship_from_fast_big_ship(object *big_obj, object *small_obj, float impulse, vec3d *normal)
+static void maybe_push_little_ship_from_fast_big_ship(object *big_obj, object *small_obj, float impulse, vec3d *normal)
 {
 	// Move player out of the way of a BIG|HUGE ship warping in or out
 	int big_class = Ship_info[Ships[big_obj->instance].ship_info_index].class_type;

--- a/code/object/collideshipweapon.cpp
+++ b/code/object/collideshipweapon.cpp
@@ -26,8 +26,7 @@
 
 
 extern float ai_endangered_time(object *ship_objp, object *weapon_objp);
-int check_inside_radius_for_big_ships( object *ship, object *weapon_obj, obj_pair *pair );
-float estimate_ship_speed_upper_limit( object *ship, float time );
+static int check_inside_radius_for_big_ships( object *ship, object *weapon_obj, obj_pair *pair );
 extern float flFrametime;
 
 
@@ -35,7 +34,7 @@ extern float flFrametime;
  * If weapon_obj is likely to hit ship_obj sooner than current aip->danger_weapon_objnum,
  * then update danger_weapon_objnum.
  */
-void update_danger_weapon(object *pship_obj, object *weapon_obj)
+static void update_danger_weapon(object *pship_obj, object *weapon_obj)
 {
 	ai_info	*aip;
 
@@ -63,7 +62,7 @@ void update_danger_weapon(object *pship_obj, object *weapon_obj)
  * Deal with weapon-ship hit stuff.  
  * Separated from check_collision routine below because of multiplayer reasons.
  */
-void ship_weapon_do_hit_stuff(object *pship_obj, object *weapon_obj, vec3d *world_hitpos, vec3d *hitpos, int quadrant_num, int submodel_num, vec3d /*not a pointer intentionaly*/ hit_dir)
+static void ship_weapon_do_hit_stuff(object *pship_obj, object *weapon_obj, vec3d *world_hitpos, vec3d *hitpos, int quadrant_num, int submodel_num, vec3d /*not a pointer intentionaly*/ hit_dir)
 {
 	weapon	*wp = &Weapons[weapon_obj->instance];
 	weapon_info *wip = &Weapon_info[wp->weapon_info_index];
@@ -130,7 +129,7 @@ void ship_weapon_do_hit_stuff(object *pship_obj, object *weapon_obj, vec3d *worl
 
 extern int Framecount;
 
-int ship_weapon_check_collision(object *ship_objp, object *weapon_objp, float time_limit = 0.0f, int *next_hit = NULL)
+static int ship_weapon_check_collision(object *ship_objp, object *weapon_objp, float time_limit = 0.0f, int *next_hit = NULL)
 {
 	mc_info mc, mc_shield, mc_hull;
 	ship	*shipp;
@@ -525,7 +524,7 @@ int collide_ship_weapon( obj_pair * pair )
 /**
  * Upper limit estimate ship speed at end of time
  */
-float estimate_ship_speed_upper_limit( object *ship, float time ) 
+static float estimate_ship_speed_upper_limit( object *ship, float time ) 
 {
 	float exponent;
 	float delta_v;
@@ -553,7 +552,7 @@ float estimate_ship_speed_upper_limit( object *ship, float time )
  * @return 1 if pair can be culled
  * @return 0 if pair can not be culled
  */
-int check_inside_radius_for_big_ships( object *ship, object *weapon_obj, obj_pair *pair )
+static int check_inside_radius_for_big_ships( object *ship, object *weapon_obj, obj_pair *pair )
 {
 	vec3d error_vel;		// vel perpendicular to laser
 	float error_vel_mag;	// magnitude of error_vel

--- a/code/object/objcollide.cpp
+++ b/code/object/objcollide.cpp
@@ -24,7 +24,7 @@
 
 //#define MAX_PAIRS 10000	//	Bumped back to 10,000 by WMC
 			//	Reduced from 10,000 to 6,000 by MK on 4/1/98.
-			//	Most I saw was 3400 in sm1-06a, the asteriod mission.  No other mission came close.
+			//	Most I saw was 3400 in sm1-06a, the asteroid mission.  No other mission came close.
 #define MIN_PAIRS	2500	// start out with this many pairs
 #define PAIRS_BUMP	1000		// increase by this many avialable pairs when more are needed
 

--- a/code/object/objcollide.h
+++ b/code/object/objcollide.h
@@ -117,7 +117,6 @@ int collide_weapon_weapon( obj_pair * pair );
 // Returns 1 if all future collisions between these can be ignored
 // CODE is locatated in CollideShipWeapon.cpp
 int collide_ship_weapon( obj_pair * pair );
-void ship_weapon_do_hit_stuff(object *pship_obj, object *weapon_obj, vec3d *world_hitpos, vec3d *hitpos, int quadrant_num, int submodel_num = -1);
 
 // Checks debris-weapon collisions.  pair->a is debris and pair->b is weapon.
 // Returns 1 if all future collisions between these can be ignored

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -11602,38 +11602,6 @@ static int ship_fire_secondary_detonate(object *obj, ship_weapon *swp)
 	return 0;
 }
 
-/**
- * Try to switch to a secondary bank that has ammo
- *
- * @note: not currently used - mark for removal?
- */
-static int ship_select_next_valid_secondary_bank(ship_weapon *swp)
-{
-	int cycled=0;
-
-	int ns = swp->num_secondary_banks;
-
-	if ( ns > 1 ) {
-		int i,j=swp->current_secondary_bank+1;
-		for (i=0; i<ns; i++) {
-			if ( j >= ns ) {
-				j=0;
-			}
-
-			if ( swp->secondary_bank_ammo[j] > 0 ) {
-				swp->current_secondary_bank=j;
-				cycled = 1;
-				break;
-			}
-
-			j++;
-		}
-	}
-
-	return cycled;
-}
-
-
 extern void ai_maybe_announce_shockwave_weapon(object *firing_objp, int weapon_index);
 
 //	Object *obj fires its secondary weapon, if it can.
@@ -12117,8 +12085,6 @@ done_secondary:
 	//
 	// niffiwan: only try to switch banks if object has multiple banks, and firing bank is the current bank
 	if ( (obj->flags[Object::Object_Flags::Player_ship]) && (swp->secondary_bank_ammo[bank] <= 0) && (swp->num_secondary_banks >= 2) && (bank == swp->current_secondary_bank) ) {
-		// niffiwan: call ship_select_next_secondary instead of ship_select_next_valid_secondary_bank
-		// ensures all "extras" are dealt with, like animations, scripting hooks, etc
 		if (ship_select_next_secondary(obj) ) {			//DTP here we switch to the next valid bank, but we can't call weapon_info on next fire_wait
 
 			if ( timestamp_elapsed(shipp->weapons.next_secondary_fire_stamp[shipp->weapons.current_secondary_bank]) ) {	//DTP, this is simply a copy of the manual cycle functions

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -145,12 +145,24 @@ char Squadron_wing_names[MAX_SQUADRON_WINGS][NAME_LENGTH];
 char TVT_wing_names[MAX_TVT_WINGS][NAME_LENGTH];
 
 SCP_vector<engine_wash_info> Engine_wash_info;
-engine_wash_info *get_engine_wash_pointer(char* engine_wash_name);
+
+static engine_wash_info *get_engine_wash_pointer(char* engine_wash_name);
+static int subsys_set(int objnum, int ignore_subsys_info = 0);
+static void ship_add_cockpit_display(cockpit_display_info *display, int cockpit_model_num);
+static void ship_set_hud_cockpit_targets();
+static int thruster_glow_anim_load(generic_anim *ga);
+static int ship_get_exp_propagates(ship *sp);
+static bool ship_subsys_is_fighterbay(ship_subsys *ss);
+static int ship_template_lookup(const char *token);
+static void ship_set_eye(object *obj, int eye_index);
+static void ship_start_targeting_laser(ship *shipp);
+static void ship_add_ship_type_kill_count(int ship_info_index);
+static int ship_info_lookup_sub(const char *token);
 
 void ship_reset_disabled_physics(object *objp, int ship_class);
 
 // forward declaring for parse_ship()
-int ship_info_lookup_sub(const char *token);
+static int parse_ship_values(ship_info* sip, const bool is_template, const bool first_time, const bool replace);
 
 // information for ships which have exited the game
 SCP_vector<exited_ship> Ships_exited;
@@ -528,7 +540,7 @@ static int Ship_cargo_check_timer;
 
 static int Thrust_anim_inited = 0;
 
-int ship_get_subobj_model_num(ship_info* sip, char* subobj_name);
+static int ship_get_subobj_model_num(ship_info* sip, char* subobj_name);
 
 SCP_vector<ship_effect> Ship_effects;
 
@@ -536,7 +548,7 @@ int ship_render_mode = MODEL_RENDER_ALL;
 /**
  * Set the ship_obj struct fields to default values
  */
-void ship_obj_list_reset_slot(int index)
+static void ship_obj_list_reset_slot(int index)
 {
 	Ship_objs[index].flags = 0;
 	Ship_objs[index].next = NULL;
@@ -546,7 +558,7 @@ void ship_obj_list_reset_slot(int index)
 /**
  * If the given ship is in my squadron wings
  */
-int ship_in_my_squadron(ship *shipp)
+static int ship_in_my_squadron(ship *shipp)
 {
 	int i;
 
@@ -569,7 +581,7 @@ int ship_in_my_squadron(ship *shipp)
 /**
  * Initialise Ship_obj_list
  */
-void ship_obj_list_init()
+static void ship_obj_list_init()
 {
 	int i;
 
@@ -583,7 +595,7 @@ void ship_obj_list_init()
  * Function to add a node to the Ship_obj_list.  Only
  * called from ::ship_create()
  */
-int ship_obj_list_add(int objnum)
+static int ship_obj_list_add(int objnum)
 {
 	int i;
 
@@ -608,7 +620,7 @@ int ship_obj_list_add(int objnum)
  * Function to remove a node from the Ship_obj_list.  Only
  * called from ::ship_delete()
  */
-void ship_obj_list_remove(int index)
+static void ship_obj_list_remove(int index)
 {
 	Assert(index >= 0 && index < MAX_SHIP_OBJS);
 	list_remove( Ship_obj_list, &Ship_objs[index]);	
@@ -652,7 +664,7 @@ int ship_get_num_ships()
 	return count;
 }
 
-void engine_wash_info_init(engine_wash_info *ewi)
+static void engine_wash_info_init(engine_wash_info *ewi)
 {
 	ewi->name[0] = '\0';
 	ewi->angle = PI / 10.0f;
@@ -664,7 +676,7 @@ void engine_wash_info_init(engine_wash_info *ewi)
 /**
  * Parse an engine wash info record
  */
-void parse_engine_wash(bool replace)
+static void parse_engine_wash(bool replace)
 {
 	engine_wash_info ewt;
 	engine_wash_info_init(&ewt);
@@ -736,7 +748,7 @@ void parse_engine_wash(bool replace)
 	}
 }
 
-const char *Warp_types[] = {
+static const char *Warp_types[] = {
 	"Default",
 	"Knossos",
 	"Babylon5",
@@ -745,9 +757,9 @@ const char *Warp_types[] = {
 	"Hyperspace",
 };
 
-int Num_warp_types = sizeof(Warp_types)/sizeof(char*);
+static int Num_warp_types = sizeof(Warp_types)/sizeof(char*);
 
-int warptype_match(char *p)
+static int warptype_match(char *p)
 {
 	int i;
 	for(i = 0; i < Num_warp_types; i++)
@@ -759,14 +771,14 @@ int warptype_match(char *p)
 	return -1;
 }
 
-const char *Lightning_types[] = {
+static const char *Lightning_types[] = {
 	"None",
 	"Default",
 };
 
-int Num_lightning_types = sizeof(Lightning_types)/sizeof(char*);
+static int Num_lightning_types = sizeof(Lightning_types)/sizeof(char*);
 
-int lightningtype_match(char *p)
+static int lightningtype_match(char *p)
 {
 	int i;
 	for(i = 0; i < Num_lightning_types; i++)
@@ -1814,7 +1826,7 @@ ship_info::~ship_info()
 /**
  * Parse the information for a specific ship type.
  */
-int parse_ship(const char *filename, bool replace)
+static int parse_ship(const char *filename, bool replace)
 {
 	char buf[SHIP_MULTITEXT_LENGTH];
 	ship_info *sip = nullptr;
@@ -1914,7 +1926,7 @@ int parse_ship(const char *filename, bool replace)
 /**
  * Parse the information for a specific ship type template.
  */
-int parse_ship_template()
+static int parse_ship_template()
 {
 	char buf[SHIP_MULTITEXT_LENGTH];
 	ship_info *sip;
@@ -1969,7 +1981,7 @@ int parse_ship_template()
 	return rtn;
 }
 
-void parse_ship_sound(const char *name, GameSoundsIndex id, ship_info *sip)
+static void parse_ship_sound(const char *name, GameSoundsIndex id, ship_info *sip)
 {
 	Assert( name != NULL );
 
@@ -1981,7 +1993,7 @@ void parse_ship_sound(const char *name, GameSoundsIndex id, ship_info *sip)
 		sip->ship_sounds.insert(std::pair<GameSoundsIndex, int>(id, temp_index));
 }
 
-void parse_ship_sounds(ship_info *sip)
+static void parse_ship_sounds(ship_info *sip)
 {
 	parse_ship_sound("$CockpitEngineSnd:",                SND_ENGINE, sip);
 	parse_ship_sound("$FullThrottleSnd:",                 SND_FULL_THROTTLE, sip);
@@ -2010,7 +2022,7 @@ void parse_ship_sounds(ship_info *sip)
 	parse_ship_sound("$ExplosionSnd:",                    SND_SHIP_EXPLODE_1, sip);
 } 
 
-void parse_ship_particle_effect(ship_info* sip, particle_effect* pe, const char *id_string)
+static void parse_ship_particle_effect(ship_info* sip, particle_effect* pe, const char *id_string)
 {
 	float tempf;
 	int temp;
@@ -2113,7 +2125,7 @@ void parse_ship_particle_effect(ship_info* sip, particle_effect* pe, const char 
 	}
 }
 
-void parse_allowed_weapons(ship_info *sip, const bool is_primary, const bool is_dogfight, const bool first_time)
+static void parse_allowed_weapons(ship_info *sip, const bool is_primary, const bool is_dogfight, const bool first_time)
 {
 	int i, num_allowed;
 	int allowed_weapons[MAX_WEAPON_TYPES];
@@ -2182,7 +2194,7 @@ void parse_allowed_weapons(ship_info *sip, const bool is_primary, const bool is_
  * Common method for parsing ship/subsystem primary/secondary weapons so that the parser doesn't flip out in the event of a problem.
  *
  */
-void parse_weapon_bank(ship_info *sip, bool is_primary, int *num_banks, int *bank_default_weapons, int *bank_capacities)
+static void parse_weapon_bank(ship_info *sip, bool is_primary, int *num_banks, int *bank_default_weapons, int *bank_capacities)
 {
 	Assert(sip != NULL);
 	Assert(bank_default_weapons != NULL);
@@ -2229,7 +2241,7 @@ void parse_weapon_bank(ship_info *sip, bool is_primary, int *num_banks, int *ban
 /**
  * Common method for parsing briefing icon info.
  */
-int parse_and_add_briefing_icon_info()
+static int parse_and_add_briefing_icon_info()
 {
 	int bii_index = -1;
 	size_t icon;
@@ -2274,7 +2286,7 @@ int parse_and_add_briefing_icon_info()
 /**
  * Puts values into a ship_info.
  */
-int parse_ship_values(ship_info* sip, const bool is_template, const bool first_time, const bool replace)
+static int parse_ship_values(ship_info* sip, const bool is_template, const bool first_time, const bool replace)
 {
 	char buf[SHIP_MULTITEXT_LENGTH];
 	const char* info_type_name;
@@ -4705,7 +4717,7 @@ int parse_ship_values(ship_info* sip, const bool is_template, const bool first_t
 	return rtn;	//0 for success
 }
 
-engine_wash_info *get_engine_wash_pointer(char *engine_wash_name)
+static engine_wash_info *get_engine_wash_pointer(char *engine_wash_name)
 {
 	for(int i = 0; i < Num_engine_wash_types; i++)
 	{
@@ -4719,7 +4731,7 @@ engine_wash_info *get_engine_wash_pointer(char *engine_wash_name)
 	return NULL;
 }
 
-void parse_ship_type()
+static void parse_ship_type()
 {
 	char name_buf[NAME_LENGTH];
 	bool nocreate = false;
@@ -4944,7 +4956,7 @@ void parse_ship_type()
 		Ship_types.push_back(stp_buf);
 }
 
-void parse_shiptype_tbl(const char *filename)
+static void parse_shiptype_tbl(const char *filename)
 {
 	try
 	{
@@ -5005,7 +5017,7 @@ int get_default_player_ship_index()
 }
 
 // Goober5000 - this works better in its own function
-void ship_set_default_player_ship()
+static void ship_set_default_player_ship()
 {
 	// already have one
 	if(strlen(default_player_ship))
@@ -5038,7 +5050,7 @@ void ship_set_default_player_ship()
 	}
 }
 
-void parse_shiptbl(const char *filename)
+static void parse_shiptbl(const char *filename)
 {
 	try
 	{
@@ -5108,7 +5120,7 @@ int ship_show_velocity_dot = 0;
 
 DCF_BOOL( show_velocity_dot, ship_show_velocity_dot )
 
-bool ballistic_possible_for_this_ship(const ship_info *sip)
+static bool ballistic_possible_for_this_ship(const ship_info *sip)
 {
 	for (int i = 0; i < MAX_SHIP_PRIMARY_BANKS; i++)
 	{
@@ -5125,7 +5137,7 @@ bool ballistic_possible_for_this_ship(const ship_info *sip)
 /**
  * Clean up ship entries, making sure various flags and settings are correct
  */
-void ship_parse_post_cleanup()
+static void ship_parse_post_cleanup()
 {
 	int j;
 	char name_tmp[NAME_LENGTH];
@@ -5316,7 +5328,7 @@ void ship_init()
 	ship_level_init();	// needed for FRED
 }
 
-int Man_thruster_reset_timestamp = 0;
+static int Man_thruster_reset_timestamp = 0;
 
 static void ship_clear_subsystems()
 {
@@ -5652,7 +5664,7 @@ vec3d get_submodel_offset(int model, int submodel){
 
 }
 
-void ship_set_warp_effects(object *objp, ship_info *sip)
+static void ship_set_warp_effects(object *objp, ship_info *sip)
 {
 	ship *shipp = &Ships[objp->instance];
 
@@ -6078,7 +6090,7 @@ ship_weapon::ship_weapon() {
 }
 
 // NOTE: Now that the clear() member function exists, this function only sets the stuff associated with the object and ship class.
-void ship_set(int ship_index, int objnum, int ship_type)
+static void ship_set(int ship_index, int objnum, int ship_type)
 {
 	int i;
 	ship		*shipp = &Ships[ship_index];
@@ -6333,7 +6345,7 @@ void ship_recalc_subsys_strength( ship *shipp )
  * Fixup the model subsystem information for this ship pointer.
  * Needed when ships share the same model.
  */
-void ship_copy_subsystem_fixup(ship_info *sip)
+static void ship_copy_subsystem_fixup(ship_info *sip)
 {
 	int model_num;
 
@@ -6465,7 +6477,7 @@ void ship_subsys::clear()
  * @param objnum				Object number (used as index into Objects[])
  * @param ignore_subsys_info	Default parameter with value of 0.  This is only set to 1 by the save/restore code
  */
-int subsys_set(int objnum, int ignore_subsys_info)
+static int subsys_set(int objnum, int ignore_subsys_info)
 {	
 	ship	*shipp = &Ships[Objects[objnum].instance];
 	ship_info	*sinfo = &Ship_info[Ships[Objects[objnum].instance].ship_info_index];
@@ -6844,7 +6856,7 @@ DCF_BOOL( show_paths, Show_paths )
 int Show_fpaths = 0;
 DCF_BOOL( show_fpaths, Show_fpaths )
 
-void ship_find_warping_ship_helper(object *objp, dock_function_info *infop)
+static void ship_find_warping_ship_helper(object *objp, dock_function_info *infop)
 {
 	// only check ships
 	if (objp->type != OBJ_SHIP)
@@ -7007,7 +7019,7 @@ void ship_clear_cockpit_displays()
 	}
 }
 
-void ship_add_cockpit_display(cockpit_display_info *display, int cockpit_model_num)
+static void ship_add_cockpit_display(cockpit_display_info *display, int cockpit_model_num)
 {
 	if ( strlen(display->filename) <= 0 ) {
 		return;
@@ -7077,7 +7089,7 @@ void ship_add_cockpit_display(cockpit_display_info *display, int cockpit_model_n
 	Player_displays.push_back(new_display);
 }
 
-void ship_set_hud_cockpit_targets()
+static void ship_set_hud_cockpit_targets()
 {
 	if ( !Ship_info[Player_ship->ship_info_index].hud_enabled ) {
 		return;
@@ -7169,7 +7181,7 @@ void ship_end_render_cockpit_display(size_t cockpit_display_num)
 	gr_pop_debug_group();
 }
 
-void ship_subsystems_delete(ship *shipp)
+static void ship_subsystems_delete(ship *shipp)
 {
 	if ( NOT_EMPTY(&shipp->subsys_list) )
 	{
@@ -7334,7 +7346,7 @@ void ship_wing_cleanup( int shipnum, wing *wingp )
 // functions to do management, like log entries and wing cleanup after a ship has been destroyed
 
 // Goober5000
-void ship_actually_depart_helper(object *objp, dock_function_info *infop)
+static void ship_actually_depart_helper(object *objp, dock_function_info *infop)
 {
 	// do standard departure stuff first
 	objp->flags.set(Object::Object_Flags::Should_be_dead);
@@ -7578,7 +7590,7 @@ static const float MAX_SHOCK_ANGLE_RANGE = 1.99f * PI;
  *
  * @param exp_objp			ship object pointers
  */
-void ship_blow_up_area_apply_blast( object *exp_objp)
+static void ship_blow_up_area_apply_blast( object *exp_objp)
 {
 	ship *shipp;
 	ship_info *sip;
@@ -7689,7 +7701,7 @@ void ship_blow_up_area_apply_blast( object *exp_objp)
  * This function relies on the "dead dock" list, which replaces the dock_objnum_when_dead
  * used in retail.
  */
-void do_dying_undock_physics(object *dying_objp, ship *dying_shipp) 
+static void do_dying_undock_physics(object *dying_objp, ship *dying_shipp) 
 {
 	// this function should only be called for an object that was docked...
 	// no harm in calling it if it wasn't, but we want to enforce this
@@ -7753,7 +7765,7 @@ void do_dying_undock_physics(object *dying_objp, ship *dying_shipp)
 /**
  * Do the stuff we do in a frame for a ship that's in its death throes.
  */
-void ship_dying_frame(object *objp, int ship_num)
+static void ship_dying_frame(object *objp, int ship_num)
 {
 	ship *shipp = &Ships[ship_num];
 
@@ -8125,7 +8137,7 @@ void ship_dying_frame(object *objp, int ship_num)
 	}
 }
 
-void ship_chase_shield_energy_targets(ship *shipp, object *obj, float frametime)
+static void ship_chase_shield_energy_targets(ship *shipp, object *obj, float frametime)
 {
 	float delta;
 	ship_info *sip;
@@ -8170,7 +8182,7 @@ void ship_chase_shield_energy_targets(ship *shipp, object *obj, float frametime)
 
 }
 
-int thruster_glow_anim_load(generic_anim *ga)
+static int thruster_glow_anim_load(generic_anim *ga)
 {
 	if ( !VALID_FNAME(ga->filename) )
 		return -1;
@@ -8194,7 +8206,7 @@ int thruster_glow_anim_load(generic_anim *ga)
 /**
  * Loads the animations for ship's afterburners
  */
-void ship_init_thrusters()
+static void ship_init_thrusters()
 {
 	if ( Thrust_anim_inited == 1 )
 		return;
@@ -8231,7 +8243,7 @@ void ship_init_thrusters()
  * ::ship_render() needs to have shipp->thruster_bitmap set to
  * a valid bitmap number, or -1 if we shouldn't render thrusters.
  */
-void ship_do_thruster_frame( ship *shipp, object *objp, float frametime )
+static void ship_do_thruster_frame( ship *shipp, object *objp, float frametime )
 {
 	float rate;
 	int framenum;
@@ -8385,7 +8397,7 @@ void ship_do_weapon_thruster_frame( weapon *weaponp, object *objp, float frameti
 // element.
 #define SHIP_REPAIR_SUBSYSTEM_RATE	0.01f	// percent repair per second for a subsystem
 #define SUBSYS_REPAIR_THRESHOLD		0.1	// only repair subsystems that have > 10% strength
-void ship_auto_repair_frame(int shipnum, float frametime)
+static void ship_auto_repair_frame(int shipnum, float frametime)
 {
 	ship_subsys		*ssp;
 	ship_subsys_info	*ssip;
@@ -8487,7 +8499,7 @@ void ship_auto_repair_frame(int shipnum, float frametime)
 #define PLAYER_WARN_DELTA_TIME			10000			//ms
 #define PLAYER_DEATH_DELTA_TIME			5000			//ms
 
-void ship_check_player_distance_sub(player *p, int multi_target=-1)
+static void ship_check_player_distance_sub(player *p, int multi_target=-1)
 {
 	// only check distance for ships
 	if ( p->control_mode != PCM_NORMAL )	{
@@ -8548,7 +8560,7 @@ void ship_check_player_distance_sub(player *p, int multi_target=-1)
 	}
 }
 
-void ship_check_player_distance()
+static void ship_check_player_distance()
 {
 	int idx;
 
@@ -8613,7 +8625,7 @@ void ship_reset_disabled_physics(object *objp, int ship_class)
 /**
  * Clear/set the subsystem disrupted flags
  */
-void ship_subsys_disrupted_check(ship *sp)
+static void ship_subsys_disrupted_check(ship *sp)
 {
 	ship_subsys *ss;
 	int engines_disabled=0;
@@ -8644,7 +8656,7 @@ void ship_subsys_disrupted_check(ship *sp)
 /**
  * Maybe check ship subsystems for disruption, and set/clear flags
  */
-void ship_subsys_disrupted_maybe_check(ship *shipp)
+static void ship_subsys_disrupted_maybe_check(ship *shipp)
 {
 	if ( timestamp_elapsed(shipp->subsys_disrupted_check_timestamp) ) {
 		ship_subsys_disrupted_check(shipp);
@@ -8731,7 +8743,7 @@ DCF(lethality_decay, "Sets ship lethality_decay, or the time in sec to go from 1
 
 float min_lethality = 0.0f;
 
-void lethality_decay(ai_info *aip)
+static void lethality_decay(ai_info *aip)
 {
 	float decay_rate = Decay_rate;
 	aip->lethality -= 100.0f * decay_rate * flFrametime;
@@ -8761,7 +8773,7 @@ void ship_process_pre(object *objp, float frametime)
 
 MONITOR( NumShips )
 
-void ship_radar_process( object * obj, ship * shipp, ship_info * sip ) 
+static void ship_radar_process( object * obj, ship * shipp, ship_info * sip ) 
 {
 	Assert( obj != NULL);
 	Assert( shipp != NULL );
@@ -9015,7 +9027,7 @@ void ship_process_post(object * obj, float frametime)
  * Weapon assignments are checked against the model to ensure the models
  * and the ship info weapon data are in synch.
  */
-void ship_set_default_weapons(ship *shipp, ship_info *sip)
+static void ship_set_default_weapons(ship *shipp, ship_info *sip)
 {
 	int			i, j;
 	polymodel	*pm;
@@ -9173,7 +9185,7 @@ int ship_check_collision_fast( object * obj, object * other_obj, vec3d * hitpos)
 /**
  * Ensure create time for ship is unique
  */
-void ship_make_create_time_unique(ship *shipp)
+static void ship_make_create_time_unique(ship *shipp)
 {
 	static int last_smctu_initial_time = -1;
 	static int last_smctu_final_time = -1;
@@ -9229,7 +9241,7 @@ void ship_make_create_time_unique(ship *shipp)
 
 int	Ship_subsys_hwm = 0;
 
-void show_ship_subsys_count()
+static void show_ship_subsys_count()
 {
 	object	*objp;
 	int		count = 0;	
@@ -9247,7 +9259,7 @@ void show_ship_subsys_count()
 	}
 }
 
-void ship_init_afterburners(ship *shipp)
+static void ship_init_afterburners(ship *shipp)
 {
 	Assert( shipp );
 
@@ -9512,7 +9524,7 @@ int ship_create(matrix *orient, vec3d *pos, int ship_type, char *ship_name)
  * @param n			index of ship in ::Ships[] array
  * @param ship_type	ship class (index into ::Ship_info vector)
  */
-void ship_model_change(int n, int ship_type)
+static void ship_model_change(int n, int ship_type)
 {
 	int			i;
 	ship_info	*sip;
@@ -10420,7 +10432,7 @@ void ship_maybe_play_primary_fail_sound()
 /**
  * See if enough time has elapsed to play secondary fail sound again
  */
-int ship_maybe_play_secondary_fail_sound(weapon_info *wip)
+static int ship_maybe_play_secondary_fail_sound(weapon_info *wip)
 {
 	hud_start_flash_weapon(Player_ship->weapons.num_primary_banks + Player_ship->weapons.current_secondary_bank);
 
@@ -10442,7 +10454,7 @@ int ship_maybe_play_secondary_fail_sound(weapon_info *wip)
  *
  * @return 1 if weapon failed to fire, 0 if weapon can fire
  */
-int ship_weapon_maybe_fail(ship *sp)
+static int ship_weapon_maybe_fail(ship *sp)
 {
 	int	rval;
 	float	weapons_subsys_str;
@@ -10521,7 +10533,7 @@ DCF(t_max, "")
 /**
  * Stops a single primary bank
  */
-int ship_stop_fire_primary_bank(object * obj, int bank_to_stop)
+static int ship_stop_fire_primary_bank(object * obj, int bank_to_stop)
 {
 	ship			*shipp;
 	ship_weapon	*swp;
@@ -11401,7 +11413,7 @@ int ship_fire_primary(object * obj, int stream_weapons, int force)
 	return num_fired;
 }
 
-void ship_start_targeting_laser(ship *shipp)
+static void ship_start_targeting_laser(ship *shipp)
 {	
 	int bank0_laser = 0;
 	int bank1_laser = 0;
@@ -11438,7 +11450,7 @@ void ship_start_targeting_laser(ship *shipp)
 	}
 }
 
-void ship_stop_targeting_laser(ship *shipp)
+static void ship_stop_targeting_laser(ship *shipp)
 {
 	shipp->targeting_laser_bank = -1;
 	shipp->targeting_laser_objnum = -1; // erase old laser obj num if it has any -Bobboau
@@ -11513,7 +11525,7 @@ void ship_process_targeting_lasers()
  *	Calls ::weapon_hit(), indirectly via ::weapon_detonate(), to detonate weapon.
  *	If it's a weapon that spawns particles, those will be released.
  */
-int maybe_detonate_weapon(ship_weapon *swp, object *src)
+static int maybe_detonate_weapon(ship_weapon *swp, object *src)
 {
 	int			objnum = swp->last_fired_weapon_index;
 	object		*objp;
@@ -11562,7 +11574,7 @@ int maybe_detonate_weapon(ship_weapon *swp, object *src)
  * Maybe detonate secondary weapon that's already out.
  * @return Return true if we detonate it, false if not.
  */
-int ship_fire_secondary_detonate(object *obj, ship_weapon *swp)
+static int ship_fire_secondary_detonate(object *obj, ship_weapon *swp)
 {
 	if (swp->last_fired_weapon_index != -1)
 		if (timestamp_elapsed(swp->detonate_weapon_time)) {
@@ -11595,7 +11607,7 @@ int ship_fire_secondary_detonate(object *obj, ship_weapon *swp)
  *
  * @note: not currently used - mark for removal?
  */
-int ship_select_next_valid_secondary_bank(ship_weapon *swp)
+static int ship_select_next_valid_secondary_bank(ship_weapon *swp)
 {
 	int cycled=0;
 
@@ -12124,7 +12136,7 @@ done_secondary:
 }
 
 // Goober5000
-int primary_out_of_ammo(ship_weapon *swp, int bank)
+static int primary_out_of_ammo(ship_weapon *swp, int bank)
 {
 	// true if both ballistic and ammo <= 0,
 	// false if not ballistic or if ballistic and ammo > 0
@@ -12141,7 +12153,7 @@ int primary_out_of_ammo(ship_weapon *swp, int bank)
 	return 0;
 }
 
-bool ship_has_a_ballistic_primary(const ship *shipp)
+static bool ship_has_a_ballistic_primary(const ship *shipp)
 {
 	const ship_weapon *swp = &shipp->weapons;
 
@@ -12566,7 +12578,7 @@ int wing_lookup(const char *name)
 /**
  * Return the index of Ship_info[].name that is *token.
  */
-int ship_info_lookup_sub(const char *token)
+static int ship_info_lookup_sub(const char *token)
 {
 	for (auto it = Ship_info.cbegin(); it != Ship_info.cend(); ++it)
 		if (!stricmp(token, it->name))
@@ -12578,7 +12590,7 @@ int ship_info_lookup_sub(const char *token)
 /**
  * Return the index of Ship_templates[].name that is *token.
  */
-int ship_template_lookup(const char *token)
+static int ship_template_lookup(const char *token)
 {
 	for ( auto it = Ship_templates.cbegin(); it != Ship_templates.cend(); ++it ) {
 		if ( !stricmp(token, it->name) ) {
@@ -13014,7 +13026,7 @@ int ship_find_num_turrets(object *objp)
 }
 
 //WMC
-void ship_set_eye( object *obj, int eye_index)
+static void ship_set_eye( object *obj, int eye_index)
 {
 	if(obj->type != OBJ_SHIP)
 		return;
@@ -14277,7 +14289,7 @@ void ship_add_ship_type_count( int ship_info_index, int num )
 	Ship_type_counts[type].total += num;
 }
 
-void ship_add_ship_type_kill_count( int ship_info_index )
+static void ship_add_ship_type_kill_count( int ship_info_index )
 {
 	int type = ship_class_query_general_type(ship_info_index);
 
@@ -14892,7 +14904,7 @@ int ship_dumbfire_threat(ship *sp)
 }
 
 // Return !0 if there is a missile in the air homing on shipp
-int ship_has_homing_missile_locked(ship *shipp)
+static int ship_has_homing_missile_locked(ship *shipp)
 {
 	object		*locked_objp, *A;
 	weapon		*wp;
@@ -14929,7 +14941,7 @@ int ship_has_homing_missile_locked(ship *shipp)
 }
 
 // Return !0 if there is some ship attempting to lock onto shipp
-int ship_is_getting_locked(ship *shipp)
+static int ship_is_getting_locked(ship *shipp)
 {
 	ship_obj	*so;
 	object	*objp;
@@ -15441,7 +15453,7 @@ void ship_maybe_praise_self(ship *deader_sp, ship *killer_sp)
 #define AWACS_HELP_HULL_LOW				0.25		// percent hull at which ship will ask for help
 
 // -----------------------------------------------------------------------------
-void awacs_maybe_ask_for_help(ship *sp, int multi_team_filter)
+static void awacs_maybe_ask_for_help(ship *sp, int multi_team_filter)
 {
 	// Goober5000 - bail if not in main fs2 campaign
 	// (stupid coders... it's the FREDder's responsibility to add this message)
@@ -16786,7 +16798,7 @@ float ship_get_exp_damage(object* objp)
 	return damage;
 }
 
-int ship_get_exp_propagates(ship *sp)
+static int ship_get_exp_propagates(ship *sp)
 {
 	return Ship_info[sp->ship_info_index].explosion_propagates;
 }
@@ -17335,7 +17347,7 @@ bool ship_fighterbays_all_destroyed(ship *shipp)
 }
 
 // moved here by Goober5000
-bool ship_subsys_is_fighterbay(ship_subsys *ss)
+static bool ship_subsys_is_fighterbay(ship_subsys *ss)
 {
 	Assert(ss);
 
@@ -17474,7 +17486,7 @@ int ship_tvt_wing_lookup(const char *wing_name)
 }
 
 // Goober5000
-int ship_class_get_priority(int ship_class)
+static int ship_class_get_priority(int ship_class)
 {
 	ship_info *sip = &Ship_info[ship_class];
 
@@ -17536,7 +17548,7 @@ int ship_class_compare(int ship_class_1, int ship_class_2)
  * Gives the index into the Damage_types[] vector of a specified damage type name
  * @return -1 if not found
  */
-int damage_type_get_idx(char *name)
+static int damage_type_get_idx(char *name)
 {
 	//This should never be bigger than INT_MAX anyway
 	for(int i = 0; i < (int)Damage_types.size(); i++)
@@ -17591,7 +17603,7 @@ flag_def_list	PiercingTypes[] = {
 
 const int Num_piercing_effect_types = sizeof(PiercingTypes)/sizeof(flag_def_list);
 
-int piercing_type_get(char *str)
+static int piercing_type_get(char *str)
 {
 	int i;
 	for(i = 0; i < Num_piercing_effect_types; i++)
@@ -17613,7 +17625,7 @@ flag_def_list	DifficultyScaleTypes[] = {
 
 const int Num_difficulty_scale_types = sizeof(DifficultyScaleTypes)/sizeof(flag_def_list);
 
-int difficulty_scale_type_get(char *str) {
+static int difficulty_scale_type_get(char *str) {
 	int i;
 	for(i = 0; i < Num_difficulty_scale_types; i++){
 		if (!stricmp(DifficultyScaleTypes[i].name, str))
@@ -17635,7 +17647,7 @@ flag_def_list	ArmorTypeConstants[] = {
 
 const int Num_armor_type_constants = sizeof(ArmorTypeConstants)/sizeof(flag_def_list);
 
-int armor_type_constants_get(char *str){
+static int armor_type_constants_get(char *str){
 	int i;
 	for (i = 0; i < Num_armor_type_constants; i++){
 		if (!stricmp(ArmorTypeConstants[i].name, str))
@@ -18401,7 +18413,7 @@ void parse_weapon_targeting_priorities()
 	}
 }
 
-int ship_get_subobj_model_num(ship_info* sip, char* subobj_name) 
+static int ship_get_subobj_model_num(ship_info* sip, char* subobj_name) 
 {
 	for (int i = 0; i < sip->n_subsystems; i++) {
 		if (!subsystem_stricmp(sip->subsystems[i].subobj_name, subobj_name))

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -1367,7 +1367,6 @@ extern void ship_level_init();		// called before the start of each level
 //returns -1 if failed
 extern int ship_create(matrix * orient, vec3d * pos, int ship_type, char *ship_name = NULL);
 extern void change_ship_type(int n, int ship_type, int by_sexp = 0);
-extern void ship_model_change(int n, int ship_type);
 extern void ship_process_pre( object * objp, float frametime );
 extern void ship_process_post( object * objp, float frametime );
 extern void ship_render( object * obj, model_draw_list * scene );
@@ -1410,8 +1409,6 @@ extern int ship_fire_secondary(object * objp, int allow_swarm = 0 );
 extern int ship_launch_countermeasure(object *objp, int rand_val = -1);
 
 // for special targeting lasers
-extern void ship_start_targeting_laser(ship *shipp);
-extern void ship_stop_targeting_laser(ship *shipp);
 extern void ship_process_targeting_lasers();
 
 extern int ship_select_next_primary(object *objp, int direction);
@@ -1422,7 +1419,6 @@ extern int get_available_primary_weapons(object *objp, int *outlist, int *outban
 
 extern int get_available_secondary_weapons(object *objp, int *outlist, int *outbanklist);
 extern void ship_recalc_subsys_strength( ship *shipp );
-extern int subsys_set(int objnum, int ignore_subsys_info = 0);
 extern void physics_ship_init(object *objp);
 
 //	Note: This is not a general purpose routine.
@@ -1431,10 +1427,6 @@ extern void physics_ship_init(object *objp);
 //	Return true/false for subsystem found/not found.
 //	Stuff vector *pos with absolute position.
 extern int get_subsystem_pos(vec3d *pos, object *objp, ship_subsys *subsysp);
-
-int parse_ship_values(ship_info* sip, const bool is_template, const bool first_time, const bool replace);
-int ship_template_lookup(const char *name = NULL);
-void parse_ship_particle_effect(ship_info* sip, particle_effect* pe, char *id_string);
 
 extern int ship_info_lookup(const char *name = NULL);
 extern int ship_name_lookup(const char *name, int inc_players = 0);	// returns the index into Ship array of name
@@ -1495,8 +1487,6 @@ extern int ship_find_num_crewpoints(object *objp);
 extern int ship_find_num_turrets(object *objp);
 
 extern void compute_slew_matrix(matrix *orient, angles *a);
-//extern camid ship_set_eye( object *obj, int eye_index);
-extern void ship_set_eye(object *obj, int eye_index);
 extern void ship_get_eye( vec3d *eye_pos, matrix *eye_orient, object *obj, bool do_slew = true, bool from_origin = false);		// returns in eye the correct viewing position for the given object
 //extern camid ship_get_followtarget_eye(object *obj);
 extern ship_subsys *ship_get_indexed_subsys( ship *sp, int index, vec3d *attacker_pos = NULL );	// returns index'th subsystem of this ship
@@ -1530,7 +1520,6 @@ extern void ship_assign_sound(ship *sp);
 
 extern void ship_clear_ship_type_counts();
 extern void ship_add_ship_type_count( int ship_info_index, int num );
-extern void ship_add_ship_type_kill_count( int ship_info_index );
 
 extern int ship_get_type(char* output, ship_info* sip);
 extern int ship_get_default_orders_accepted( ship_info *sip );
@@ -1578,7 +1567,6 @@ extern int Ship_auto_repair;	// flag to indicate auto-repair of subsystem should
 #endif
 
 void ship_subsystem_delete(ship *shipp);
-void ship_set_default_weapons(ship *shipp, ship_info *sip);
 float ship_quadrant_shield_strength(object *hit_objp, int quadrant_num);
 
 int ship_dumbfire_threat(ship *sp);
@@ -1616,7 +1604,6 @@ extern void ship_do_cap_subsys_cargo_hidden( ship *shipp, ship_subsys *subsys, i
 float ship_get_secondary_weapon_range(ship *shipp);
 
 // Goober5000
-int primary_out_of_ammo(ship_weapon *swp, int bank);
 int get_max_ammo_count_for_primary_bank(int ship_class, int bank, int ammo_type);
 
 int get_max_ammo_count_for_bank(int ship_class, int bank, int ammo_type);
@@ -1656,9 +1643,6 @@ void object_jettison_cargo(object *objp, object *cargo_objp, float jettison_spee
 
 // get damage done by exploding ship, takes into account mods for individual ship
 float ship_get_exp_damage(object* objp);
-
-// get whether ship has shockwave, takes into account mods for individual ship
-int ship_get_exp_propagates(ship *sp);
 
 // get outer radius of damage, takes into account mods for individual ship
 float ship_get_exp_outer_rad(object *ship_objp);
@@ -1720,9 +1704,6 @@ extern bool ship_has_dock_bay(int shipnum);
 extern bool ship_useful_for_departure(int shipnum, int path_mask = 0);
 extern int ship_get_ship_for_departure(int team);
 
-// Goober5000 - moved here from hudbrackets.cpp
-extern bool ship_subsys_is_fighterbay(ship_subsys *ss);
-
 // Goober5000
 extern bool ship_fighterbays_all_destroyed(ship *shipp);
 
@@ -1741,14 +1722,9 @@ extern int ship_has_engine_power(ship *shipp);
 
 // Swifty - Cockpit displays
 void ship_init_cockpit_displays(ship *shipp);
-void ship_add_cockpit_display(cockpit_display_info *display, int cockpit_model_num);
-void ship_set_hud_cockpit_targets();
 void ship_clear_cockpit_displays();
 int ship_start_render_cockpit_display(size_t cockpit_display_num);
 void ship_end_render_cockpit_display(size_t cockpit_display_num);
-
-//WMC - Warptype stuff
-int warptype_match(char *p);
 
 // Goober5000
 int ship_starting_wing_lookup(const char *wing_name);
@@ -1761,8 +1737,6 @@ int ship_class_compare(int ship_class_1, int ship_class_2);
 int armor_type_get_idx(char* name);
 
 void armor_init();
-
-int thruster_glow_anim_load(generic_anim *ga);
 
 // Sushi - Path metadata
 void init_path_metadata(path_metadata& metadata);

--- a/code/ship/shipfx.cpp
+++ b/code/ship/shipfx.cpp
@@ -57,7 +57,7 @@ int Player_engine_wash_loop = -1;
 
 extern float splode_level;
 
-void shipfx_remove_submodel_ship_sparks(ship *shipp, int submodel_num)
+static void shipfx_remove_submodel_ship_sparks(ship *shipp, int submodel_num)
 {
 	Assert(submodel_num != -1);
 
@@ -80,7 +80,7 @@ void model_get_rotating_submodel_axis(vec3d *model_axis, vec3d *world_axis, int 
  *
  * DKA: 5/26/99 make velocity of debris scale according to size of debris subobject (at least for large subobjects)
  */
-void shipfx_subsystem_maybe_create_live_debris(object *ship_objp, ship *ship_p, ship_subsys *subsys, vec3d *exp_center, float exp_mag)
+static void shipfx_subsystem_maybe_create_live_debris(object *ship_objp, ship *ship_p, ship_subsys *subsys, vec3d *exp_center, float exp_mag)
 {
 	// initializations
 	ship *shipp = &Ships[ship_objp->instance];
@@ -213,7 +213,7 @@ void shipfx_subsystem_maybe_create_live_debris(object *ship_objp, ship *ship_p, 
 	}
 }
 
-void set_ship_submodel_as_blown_off(ship *shipp, const char *name)
+static void set_ship_submodel_as_blown_off(ship *shipp, const char *name)
 {
 	int found =	FALSE;
 
@@ -238,7 +238,7 @@ void set_ship_submodel_as_blown_off(ship *shipp, const char *name)
  * Create debris for ship submodel which has live debris (at ship death)
  * when ship submodel has not already been blown off (and hence liberated live debris)
  */
-void shipfx_maybe_create_live_debris_at_ship_death( object *ship_objp )
+static void shipfx_maybe_create_live_debris_at_ship_death( object *ship_objp )
 {
 	// if ship has live debris, detonate that subsystem now
 	// search for any live debris
@@ -323,7 +323,7 @@ void shipfx_blow_off_subsystem(object *ship_objp, ship *ship_p,ship_subsys *subs
 }
 
 
-void shipfx_blow_up_hull(object *obj, int model, vec3d *exp_center)
+static void shipfx_blow_up_hull(object *obj, int model, vec3d *exp_center)
 {
 	int i;
 	polymodel * pm;
@@ -534,7 +534,7 @@ void shipfx_actually_warpin(ship *shipp, object *objp)
 }
 
 // Validate reference_objnum
-int shipfx_special_warp_objnum_valid(int objnum)
+static int shipfx_special_warp_objnum_valid(int objnum)
 {
 	object *special_objp;
 
@@ -617,14 +617,14 @@ void shipfx_warpin_frame( object *objp, float frametime )
 // This is called to actually warp this object out
 // after all the flashy fx are done, or if the flashy fx
 // don't work for some reason.  OR to skip the flashy fx.
-void shipfx_actually_warpout(int shipnum)
+static void shipfx_actually_warpout(int shipnum)
 {
 	// Once we get through effect, make the ship go away
 	ship_actually_depart(shipnum);
 }
 
 // compute_special_warpout_stuff();
-int compute_special_warpout_stuff(object *objp, float *speed, float *warp_time, vec3d *warp_pos)
+static int compute_special_warpout_stuff(object *objp, float *speed, float *warp_time, vec3d *warp_pos)
 {
 	object	*sp_objp = NULL;
 	ship_info	*sip;
@@ -707,7 +707,7 @@ int compute_special_warpout_stuff(object *objp, float *speed, float *warp_time, 
 }
 
 
-void compute_warpout_stuff(object *objp, float *speed, float *warp_time, vec3d *warp_pos)
+static void compute_warpout_stuff(object *objp, float *speed, float *warp_time, vec3d *warp_pos)
 {
 	Assert(objp);	// Goober5000
 	ship *shipp = &Ships[objp->instance];
@@ -2055,7 +2055,7 @@ void shipfx_debris_limit_speed(debris *db, ship *shipp)
 // ----------------------------------------------------------------------------
 // uses list of model z values with constant increment to find the radius of the 
 // cross section at the current model z value
-float get_model_cross_section_at_z(float z, polymodel* pm)
+static float get_model_cross_section_at_z(float z, polymodel* pm)
 {
 	if (pm->num_xc < 2) {
 		return 0.0f;
@@ -2079,7 +2079,7 @@ float get_model_cross_section_at_z(float z, polymodel* pm)
 /**
  * Returns how long sound has been playing
  */
-int get_sound_time_played(int snd_id, int handle)
+static int get_sound_time_played(int snd_id, int handle)
 {
 	if (handle == -1 || snd_id == -1) {
 		return 100000;

--- a/code/ship/shipfx.h
+++ b/code/ship/shipfx.h
@@ -39,10 +39,6 @@ extern void shipfx_blow_off_subsystem(object *ship_obj,ship *ship_p,ship_subsys 
 // ship's model.
 extern void shipfx_blow_up_model(object *obj,int model, int submodel, int ndebris, vec3d *exp_center);
 
-// put here for multiplayer purposes
-void shipfx_blow_up_hull(object *obj,int model, vec3d *exp_center );
-
-
 // =================================================
 //          SHIP WARP IN EFFECT STUFF
 // =================================================

--- a/code/ship/shiphit.cpp
+++ b/code/ship/shiphit.cpp
@@ -83,7 +83,7 @@ camid dead_get_camera()
 }
 */
 
-bool is_subsys_destroyed(ship *shipp, int submodel)
+static bool is_subsys_destroyed(ship *shipp, int submodel)
 {
 	ship_subsys *subsys;
 
@@ -319,7 +319,7 @@ void do_subobj_destroyed_stuff( ship *ship_p, ship_subsys *subsys, vec3d* hitpos
 // input:	damaging_objp		=>	object pointer responsible for damage
 //	exit:		-1		=>	no weapon type is associated with damage object
 //				>=0	=>	weapon type associated with damage object
-int shiphit_get_damage_weapon(object *damaging_objp)
+static int shiphit_get_damage_weapon(object *damaging_objp)
 {
 	int weapon_info_index = -1;
 
@@ -347,7 +347,7 @@ int shiphit_get_damage_weapon(object *damaging_objp)
 
 //	Return range at which this object can apply damage.
 //	Based on object type and subsystem type.
-float subsys_get_range(object *other_obj, ship_subsys *subsys)
+static float subsys_get_range(object *other_obj, ship_subsys *subsys)
 {
 	float	range;
 
@@ -368,7 +368,7 @@ float subsys_get_range(object *other_obj, ship_subsys *subsys)
 
 // Make some random debris particles.  Previous way was not very random.  Create debris 75% of the time.
 // Don't worry about multiplayer since this debris is the small stuff that cannot collide
-void create_subsys_debris(object *ship_objp, vec3d *hitpos)
+static void create_subsys_debris(object *ship_objp, vec3d *hitpos)
 {
 	float show_debris = frand();
 	
@@ -387,7 +387,7 @@ void create_subsys_debris(object *ship_objp, vec3d *hitpos)
 	}
 }
 
-void create_vaporize_debris(object *ship_objp, vec3d *hitpos)
+static void create_vaporize_debris(object *ship_objp, vec3d *hitpos)
 {
 	int ndebris;
 	float show_debris = frand();
@@ -779,7 +779,7 @@ float do_subobj_hit_stuff(object *ship_objp, object *other_obj, vec3d *hitpos, i
 }
 
 // Store who/what killed the player, so we can tell the player how he died
-void shiphit_record_player_killer(object *killer_objp, player *p)
+static void shiphit_record_player_killer(object *killer_objp, player *p)
 {
 	switch (killer_objp->type) {
 
@@ -911,7 +911,7 @@ void shiphit_record_player_killer(object *killer_objp, player *p)
 }
 
 //	Say dead stuff.
-void show_dead_message(object *ship_objp, object *other_obj)
+static void show_dead_message(object *ship_objp, object *other_obj)
 {
 	player *player_p;
 
@@ -974,7 +974,7 @@ float apply_damage_to_ship(object *objp, float damage)
 */
 
 //	Do music processing for a ship hit.
-void ship_hit_music(object *ship_objp, object *other_obj)
+static void ship_hit_music(object *ship_objp, object *other_obj)
 {
 	Assert(ship_objp);	// Goober5000
 	Assert(other_obj);	// Goober5000
@@ -1090,7 +1090,7 @@ int get_max_sparks(object* ship_objp)
 
 
 // helper function to std::sort, sorting spark pairs by distance
-int spark_compare(const spark_pair &pair1, const spark_pair &pair2)
+static int spark_compare(const spark_pair &pair1, const spark_pair &pair2)
 {
 	Assert(pair1.dist >= 0);
 	Assert(pair2.dist >= 0);
@@ -1099,7 +1099,7 @@ int spark_compare(const spark_pair &pair1, const spark_pair &pair2)
 }
 
 // for big ships, when all spark slots are filled, make intelligent choice of one to be recycled
-int choose_next_spark(object *ship_objp, vec3d *hitpos)
+static int choose_next_spark(object *ship_objp, vec3d *hitpos)
 {
 	int i, j, count, num_sparks, num_spark_pairs, spark_num;
 	vec3d world_hitpos[MAX_SHIP_HITS];
@@ -1193,7 +1193,7 @@ int choose_next_spark(object *ship_objp, vec3d *hitpos)
 
 
 //	Make sparks fly off a ship.
-void ship_hit_create_sparks(object *ship_objp, vec3d *hitpos, int submodel_num)
+static void ship_hit_create_sparks(object *ship_objp, vec3d *hitpos, int submodel_num)
 {
 	vec3d	tempv;
 	ship	*shipp = &Ships[ship_objp->instance];
@@ -1267,7 +1267,7 @@ void ship_hit_create_sparks(object *ship_objp, vec3d *hitpos, int submodel_num)
 }
 
 //	Called from ship_hit_kill() when we detect the player has been killed.
-void player_died_start(object *killer_objp)
+static void player_died_start(object *killer_objp)
 {
 	nprintf(("Network", "starting my player death\n"));
 	gameseq_post_event(GS_EVENT_DEATH_DIED);	
@@ -1359,7 +1359,7 @@ void player_died_start(object *killer_objp)
 #define	DEATHROLL_VELOCITY_STANDARD	70				// deathroll rotvel is scaled according to ship velocity
 #define	DEATHROLL_ROTVEL_SCALE			4				// constant determines how quickly deathroll rotvel is ramped up  (smaller is faster)
 
-void saturate_fabs(float *f, float max)
+static void saturate_fabs(float *f, float max)
 {
 	if ( fl_abs(*f) > max) {
 		if (*f > 0.0f)
@@ -1520,7 +1520,7 @@ void ship_generic_kill_stuff( object *objp, float percent_killed )
 }
 
 // called from ship_hit_kill if the ship is vaporized
-void ship_vaporize(ship *shipp)
+static void ship_vaporize(ship *shipp)
 {
 	object *ship_objp;
 
@@ -1785,7 +1785,7 @@ void ship_apply_whack(vec3d *force, vec3d *hit_pos, object *objp)
 
 // If a ship is dying and it gets hit, shorten its deathroll.
 //	But, if it's a player, don't decrease below MIN_PLAYER_DEATHROLL_TIME
-void shiphit_hit_after_death(object *ship_objp, float damage)
+static void shiphit_hit_after_death(object *ship_objp, float damage)
 {
 	float	percent_killed;
 	int	delta_time, time_remaining;
@@ -1838,7 +1838,7 @@ void shiphit_hit_after_death(object *ship_objp, float damage)
 MONITOR( ShipHits )
 MONITOR( ShipNumDied )
 
-int maybe_shockwave_damage_adjust(object *ship_objp, object *other_obj, float *damage)
+static int maybe_shockwave_damage_adjust(object *ship_objp, object *other_obj, float *damage)
 {
 	ship_subsys *subsys;
 	ship *shipp;


### PR DESCRIPTION
For your consideration, these patches contain various minor tweaks to help tidy up the code base.

For several files, the 'static' keyword has been applied to various routines.  On my local development machine, applying these patches reduces the size of the resulting image by about 8 kB (Ubuntu 16.04 with gcc version 5.4). Admittedly, this is pretty minor in the larger scheme of things, and mileage with other compilers may vary.

A few routines were discovered to not be in use (for several years if my searches were done correctly) and thus this set includes a patch to remove them.
