### PR TITLE
is-in-turret-fov sexp

### DIFF
--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -18319,7 +18319,10 @@ int sexp_is_in_turret_fov(int node)
 
 	// find the turret
 	turret_subsys = ship_get_subsys(&Ships[turret_shipnum], turret_subsys_name);
-	Assertion(turret_subsys != nullptr, "Couldn't find turret subsystem '%s' on ship '%s' in sexp_is_in_turret_fov!", turret_subsys_name, turret_ship_name);
+	if (turret_subsys == nullptr) {
+		Warning(LOCATION, "Couldn't find turret subsystem '%s' on ship '%s' in sexp_is_in_turret_fov!", turret_subsys_name, turret_ship_name);
+		return SEXP_FALSE;
+	}
 
 	// find out where the turret is
 	ship_get_global_turret_info(turret_objp, turret_subsys->system_info, &tpos, &tvec);

--- a/code/parse/sexp.h
+++ b/code/parse/sexp.h
@@ -388,6 +388,7 @@ class waypoint_list;
 
 #define OP_TURRET_GET_SECONDARY_AMMO		(0x0050 | OP_CATEGORY_STATUS | OP_NONCAMPAIGN_FLAG)	// DahBlount, part of the turret ammo code
 #define OP_IS_DOCKED						(0x0051 | OP_CATEGORY_STATUS | OP_NONCAMPAIGN_FLAG)	// Goober5000
+#define OP_IS_IN_TURRET_FOV					(0x0052 | OP_CATEGORY_STATUS | OP_NONCAMPAIGN_FLAG)	// Goober5000
 
 // conditional sexpressions
 #define OP_WHEN								(0x0000 | OP_CATEGORY_CONDITIONAL)

--- a/fred2/sexp_tree.cpp
+++ b/fred2/sexp_tree.cpp
@@ -4838,6 +4838,7 @@ sexp_list_item *sexp_tree::get_listing_opf_subsystem(int parent_node, int arg_in
 		case OP_IS_AI_CLASS:
 		case OP_MISSILE_LOCKED:
 		case OP_SHIP_SUBSYS_GUARDIAN_THRESHOLD:
+		case OP_IS_IN_TURRET_FOV:
 			// iterate to the next field
 			child = tree_nodes[child].next;
 			break;

--- a/qtfred/src/ui/widgets/sexp_tree.cpp
+++ b/qtfred/src/ui/widgets/sexp_tree.cpp
@@ -3306,6 +3306,7 @@ sexp_list_item* sexp_tree::get_listing_opf_subsystem(int parent_node, int arg_in
 	case OP_IS_AI_CLASS:
 	case OP_MISSILE_LOCKED:
 	case OP_SHIP_SUBSYS_GUARDIAN_THRESHOLD:
+	case OP_IS_IN_TURRET_FOV:
 		// iterate to the next field
 		child = tree_nodes[child].next;
 		break;


### PR DESCRIPTION
Returns true if the ship is in a turret's FOV, false otherwise.  Requested by JSRNerdo.  Uses the object_in_turret_fov internal function which is the same one used by the turret code when it checks whether it can fire.  Optionally uses an argument for distance/range.