### PR TITLE
minor sexp subsystem cleanup

### DIFF
--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -2072,7 +2072,7 @@ int check_sexp_syntax(int node, int return_type, int recursive, int *bad_node, i
 						ship_index = CDDDDDR(CDDDDR(op_node));
 						break;
 
-					default :
+					default:
 						ship_index = CDR(op_node);
 						break;
 				}

--- a/fred2/sexp_tree.cpp
+++ b/fred2/sexp_tree.cpp
@@ -4816,6 +4816,7 @@ sexp_list_item *sexp_tree::get_listing_opf_subsystem(int parent_node, int arg_in
 			{
 				special_subsys = OPS_STRENGTH;
 
+				// iterate to the next field two times
 				child = tree_nodes[child].next;
 				Assert(child >= 0);			
 				child = tree_nodes[child].next;			
@@ -4844,6 +4845,23 @@ sexp_list_item *sexp_tree::get_listing_opf_subsystem(int parent_node, int arg_in
 
 		// this sexp checks the subsystem of the *fourth entry* on the list
 		case OP_QUERY_ORDERS:
+			// iterate to the next field three times
+			child = tree_nodes[child].next;
+			Assert(child >= 0);
+			child = tree_nodes[child].next;
+			Assert(child >= 0);
+			child = tree_nodes[child].next;
+			break;
+
+		// this sexp checks the subsystem of the *seventh entry* on the list
+		case OP_BEAM_FLOATING_FIRE:
+			// iterate to the next field six times
+			child = tree_nodes[child].next;
+			Assert(child >= 0);
+			child = tree_nodes[child].next;
+			Assert(child >= 0);
+			child = tree_nodes[child].next;
+			Assert(child >= 0);
 			child = tree_nodes[child].next;
 			Assert(child >= 0);
 			child = tree_nodes[child].next;


### PR DESCRIPTION
Synchronize the two subsystem-of-ship checks in sexp.cpp and sexp_tree.cpp.  Mostly this is just adding OP_BEAM_FLOATING_FIRE to sexp_tree.cpp because whoever added that sexp forgot to add it there.