### PR TITLE
Port goal editor dialog code to qtFRED

### DIFF
--- a/qtfred/source_groups.cmake
+++ b/qtfred/source_groups.cmake
@@ -54,6 +54,8 @@ add_file_folder("Source/Mission/Dialogs"
     src/mission/dialogs/FictionViewerDialogModel.h
 	src/mission/dialogs/FormWingDialogModel.cpp
 	src/mission/dialogs/FormWingDialogModel.h
+	src/mission/dialogs/MissionGoalsDialogModel.cpp
+	src/mission/dialogs/MissionGoalsDialogModel.h
 	src/mission/dialogs/MissionSpecDialogModel.cpp
 	src/mission/dialogs/MissionSpecDialogModel.h
 	src/mission/dialogs/ObjectOrientEditorDialogModel.cpp

--- a/qtfred/src/mission/dialogs/MissionGoalsDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/MissionGoalsDialogModel.cpp
@@ -1,0 +1,235 @@
+//
+//
+
+#include "MissionGoalsDialogModel.h"
+
+
+namespace fso {
+namespace fred {
+namespace dialogs {
+
+MissionGoalsDialogModel::MissionGoalsDialogModel(QObject* parent, fso::fred::EditorViewport* viewport) :
+	AbstractDialogModel(parent, viewport) {
+}
+bool MissionGoalsDialogModel::apply() {
+	char buf[256], names[2][MAX_GOALS][NAME_LENGTH];
+	int i, count;
+
+	for (i=0; i<Num_goals; i++)
+		free_sexp2(Mission_goals[i].formula);
+
+	auto changes_detected = query_modified();
+
+	count = 0;
+	for (i=0; i<Num_goals; i++)
+		Mission_goals[i].satisfied = 0;  // use this as a processed flag
+
+	// rename all sexp references to old events
+	for (i=0; i<m_num_goals; i++)
+		if (m_sig[i] >= 0) {
+			strcpy_s(names[0][count], Mission_goals[m_sig[i]].name);
+			strcpy_s(names[1][count], m_goals[i].name);
+			count++;
+			Mission_goals[m_sig[i]].satisfied = 1;
+		}
+
+	// invalidate all sexp references to deleted events.
+	for (i=0; i<Num_goals; i++)
+		if (!Mission_goals[i].satisfied) {
+			sprintf(buf, "<%s>", Mission_goals[i].name);
+			strcpy(buf + NAME_LENGTH - 2, ">");  // force it to be not too long
+			strcpy_s(names[0][count], Mission_goals[i].name);
+			strcpy_s(names[1][count], buf);
+			count++;
+		}
+
+	Num_goals = m_num_goals;
+	for (i=0; i<Num_goals; i++) {
+		Mission_goals[i] = m_goals[i];
+		Mission_goals[i].formula = _sexp_tree->save_tree(Mission_goals[i].formula);
+		if ( The_mission.game_type & MISSION_TYPE_MULTI_TEAMS ) {
+			Assert( Mission_goals[i].team != -1 );
+		}
+	}
+
+	// now update all sexp references
+	while (count--)
+		update_sexp_references(names[0][count], names[1][count], OPF_GOAL_NAME);
+
+	// Only fire the signal after the changes have been applied to make sure the other parts of the code see the updated
+	// state
+	if (changes_detected) {
+		_editor->missionChanged();
+	}
+
+	return true;
+}
+void MissionGoalsDialogModel::reject() {
+	// Nothing to do here
+}
+mission_goal& MissionGoalsDialogModel::getCurrentGoal() {
+	Assertion(cur_goal >= 0 && cur_goal < m_num_goals, "Current goal index is not valid!");
+
+	return m_goals[cur_goal];
+}
+bool MissionGoalsDialogModel::isCurrentGoalValid() const {
+	return cur_goal >= 0 && cur_goal < m_num_goals;
+}
+void MissionGoalsDialogModel::initializeData() {
+	m_num_goals = Num_goals;
+	for (auto i = 0; i < Num_goals; i++) {
+		m_goals[i] = Mission_goals[i];
+		m_sig[i] = i;
+		if (strlen(m_goals[i].name) <= 0) {
+			strcpy_s(m_goals[i].name, "<unnamed>");
+		}
+	}
+	cur_goal = -1;
+
+	modelChanged();
+}
+std::array<mission_goal, MAX_GOALS>& MissionGoalsDialogModel::getGoals() {
+	return m_goals;
+}
+void MissionGoalsDialogModel::setCurrentGoal(int index) {
+	cur_goal = index;
+
+	modelChanged();
+}
+bool MissionGoalsDialogModel::isGoalVisible(const mission_goal& goal) const {
+	return (goal.type & GOAL_TYPE_MASK) == m_display_goal_types;
+}
+int MissionGoalsDialogModel::getNumGoals() const {
+	return m_num_goals;
+}
+void MissionGoalsDialogModel::setGoalDisplayType(int type) {
+	m_display_goal_types = type;
+}
+bool MissionGoalsDialogModel::query_modified() {
+	int i;
+
+	if (modified)
+		return true;
+
+	if (Num_goals != m_num_goals)
+		return true;
+
+	for (i=0; i<Num_goals; i++) {
+		if (stricmp(Mission_goals[i].name, m_goals[i].name))
+			return true;
+		if (stricmp(Mission_goals[i].message, m_goals[i].message))
+			return true;
+		if (Mission_goals[i].type != m_goals[i].type)
+			return true;
+		if ( Mission_goals[i].score != m_goals[i].score )
+			return true;
+		if ( Mission_goals[i].team != m_goals[i].team )
+			return true;
+	}
+
+	return false;
+}
+void MissionGoalsDialogModel::setTreeControl(sexp_tree* tree) {
+	_sexp_tree = tree;
+}
+void MissionGoalsDialogModel::deleteGoal(int formula) {
+	int goal;
+	for (goal=0; goal<m_num_goals; goal++){
+		if (m_goals[goal].formula == formula){
+			break;
+		}
+	}
+
+	Assert(goal < m_num_goals);
+	while (goal < m_num_goals - 1) {
+		m_goals[goal] = m_goals[goal + 1];
+		m_sig[goal] = m_sig[goal + 1];
+		goal++;
+	}
+	m_num_goals--;
+
+	modelChanged();
+}
+void MissionGoalsDialogModel::changeFormula(int old_form, int new_form) {
+	int i;
+
+	for (i=0; i<m_num_goals; i++){
+		if (m_goals[i].formula == old_form){
+			break;
+		}
+	}
+
+	Assert(i < m_num_goals);
+	m_goals[i].formula = new_form;
+
+	modelChanged();
+}
+mission_goal& MissionGoalsDialogModel::createNewGoal() {
+	Assert(m_num_goals < MAX_GOALS);
+	m_goals[m_num_goals].type = m_display_goal_types;			// this also marks the goal as valid since bit not set
+	m_sig[m_num_goals] = -1;
+	strcpy_s(m_goals[m_num_goals].name, "Goal name");
+	strcpy_s(m_goals[m_num_goals].message, "Mission goal text");
+	m_goals[m_num_goals].score = 0;
+		// team defaults to the first team.
+	m_goals[m_num_goals].team = 0;
+
+	auto new_goal = m_num_goals++;
+
+	return m_goals[new_goal];
+}
+void MissionGoalsDialogModel::setCurrentGoalMessage(const char* text) {
+	Assertion(isCurrentGoalValid(), "Current goal is not valid!");
+	strcpy_s(getCurrentGoal().message, text);
+
+	modelChanged();
+}
+void MissionGoalsDialogModel::setCurrentGoalCategory(int type) {
+	// change the type being sure to keep the invalid bit if set
+	auto otype = m_goals[cur_goal].type;
+	m_goals[cur_goal].type = type;
+	if ( otype & INVALID_GOAL ){
+		m_goals[cur_goal].type |= INVALID_GOAL;
+	}
+
+	modelChanged();
+}
+void MissionGoalsDialogModel::setCurrentGoalScore(int value) {
+	Assertion(isCurrentGoalValid(), "Current goal is not valid!");
+	getCurrentGoal().score = value;
+
+	modelChanged();
+}
+void MissionGoalsDialogModel::setCurrentGoalName(const char* name) {
+	Assertion(isCurrentGoalValid(), "Current goal is not valid!");
+	strcpy_s(getCurrentGoal().name, name);
+
+	modelChanged();
+}
+void MissionGoalsDialogModel::setCurrentGoalInvalid(bool invalid) {
+	Assertion(isCurrentGoalValid(), "Current goal is not valid!");
+
+	if (invalid) {
+		getCurrentGoal().type |= INVALID_GOAL;
+	} else {
+		getCurrentGoal().type &= ~INVALID_GOAL;
+	}
+}
+void MissionGoalsDialogModel::setCurrentGoalNoMusic(bool noMusic) {
+	Assertion(isCurrentGoalValid(), "Current goal is not valid!");
+
+	if (noMusic) {
+		getCurrentGoal().type |= MGF_NO_MUSIC;
+	} else {
+		getCurrentGoal().type &= ~MGF_NO_MUSIC;
+	}
+}
+void MissionGoalsDialogModel::setCurrentGoalTeam(int team) {
+	Assertion(isCurrentGoalValid(), "Current goal is not valid!");
+
+	getCurrentGoal().team = team;
+}
+
+}
+}
+}

--- a/qtfred/src/mission/dialogs/MissionGoalsDialogModel.h
+++ b/qtfred/src/mission/dialogs/MissionGoalsDialogModel.h
@@ -1,0 +1,68 @@
+#pragma once
+
+#include "AbstractDialogModel.h"
+
+#include <mission/missiongoals.h>
+
+#include "ui/widgets/sexp_tree.h"
+
+namespace fso {
+namespace fred {
+namespace dialogs {
+
+class MissionGoalsDialogModel: public AbstractDialogModel {
+ public:
+	MissionGoalsDialogModel(QObject* parent, EditorViewport* viewport);
+
+	bool apply() override;
+	void reject() override;
+
+	mission_goal& getCurrentGoal();
+
+	bool isCurrentGoalValid() const;
+
+	void setCurrentGoal(int index);
+
+	void initializeData();
+
+	int getNumGoals() const;
+	std::array<mission_goal, MAX_GOALS>& getGoals();
+
+	bool isGoalVisible(const mission_goal& goal) const;
+
+	void setGoalDisplayType(int type);
+
+	void deleteGoal(int formula);
+
+	void changeFormula(int old_form, int new_form);
+
+	mission_goal& createNewGoal();
+
+	bool query_modified();
+
+	void setCurrentGoalMessage(const char* text);
+	void setCurrentGoalScore(int value);
+	void setCurrentGoalCategory(int type);
+	void setCurrentGoalName(const char* name);
+	void setCurrentGoalInvalid(bool invalid);
+	void setCurrentGoalNoMusic(bool noMusic);
+	void setCurrentGoalTeam(int team);
+
+	// HACK: This does not belong here since it is a UI specific control. Once the model based SEXP tree is implemented
+	// this should be replaced
+	void setTreeControl(sexp_tree* tree);
+ public:
+	int cur_goal = -1;
+	int m_num_goals = 0;
+	int m_sig[MAX_GOALS];
+	std::array<mission_goal, MAX_GOALS> m_goals;
+	bool modified = false;
+
+	int m_display_goal_types;
+
+	sexp_tree* _sexp_tree = nullptr;
+};
+
+}
+}
+}

--- a/qtfred/src/ui/FredView.cpp
+++ b/qtfred/src/ui/FredView.cpp
@@ -15,6 +15,7 @@
 #include <ui/dialogs/EventEditorDialog.h>
 #include <ui/dialogs/BriefingEditorDialog.h>
 #include <ui/dialogs/WaypointEditorDialog.h>
+#include <ui/dialogs/MissionGoalsDialog.h>
 #include <ui/dialogs/ObjectOrientEditorDialog.h>
 #include <ui/dialogs/MissionSpecDialog.h>
 #include <ui/dialogs/FormWingDialog.h>
@@ -1052,6 +1053,10 @@ void FredView::on_actionShield_System_triggered(bool) {
 
 void FredView::on_actionVoice_Acting_Manager_triggered(bool) {
 	dialogs::VoiceActingManager dialog(this, _viewport);
+	dialog.exec();
+}
+void FredView::on_actionMission_Objectives_triggered(bool) {
+	dialogs::MissionGoalsDialog dialog(this, _viewport);
 	dialog.exec();
 }
 

--- a/qtfred/src/ui/FredView.h
+++ b/qtfred/src/ui/FredView.h
@@ -122,6 +122,7 @@ class FredView: public QMainWindow, public IDialogProvider {
 	void on_actionShield_System_triggered(bool);
 	void on_actionVoice_Acting_Manager_triggered(bool);
 	void on_actionFiction_Viewer_triggered(bool);
+	void on_actionMission_Objectives_triggered(bool);
  signals:
 	/**
 	 * @brief Special version of FredApplication::onIdle which is limited to the lifetime of this object

--- a/qtfred/src/ui/dialogs/MissionGoalsDialog.cpp
+++ b/qtfred/src/ui/dialogs/MissionGoalsDialog.cpp
@@ -1,20 +1,230 @@
+#include <QtWidgets/QMessageBox>
 #include "MissionGoalsDialog.h"
+
+#include "ui/util/SignalBlockers.h"
+
 #include "ui_MissionGoalsDialog.h"
 
 namespace fso {
 namespace fred {
 namespace dialogs {
 
-MissionGoalsDialog::MissionGoalsDialog(QWidget *parent) :
-    QDialog(parent),
-    ui(new Ui::MissionGoalsDialog)
+MissionGoalsDialog::MissionGoalsDialog(QWidget* parent, EditorViewport* viewport) :
+	QDialog(parent),
+	SexpTreeEditorInterface({ TreeFlags::LabeledRoot, TreeFlags::RootDeletable }),
+	ui(new Ui::MissionGoalsDialog()),
+	_model(new MissionGoalsDialogModel(this, viewport)),
+	_viewport(viewport)
 {
     ui->setupUi(this);
-}
 
+    ui->goalEventTree->initializeEditor(viewport->editor, this);
+    _model->setTreeControl(ui->goalEventTree);
+
+	ui->goalDescription->setMaxLength(MAX_GOAL_TEXT - 1);
+	ui->goalName->setMaxLength(NAME_LENGTH - 1);
+
+	ui->helpTextBox->setFont(QFontDatabase::systemFont(QFontDatabase::FixedFont));
+
+	connect(this, &QDialog::accepted, _model.get(), &MissionGoalsDialogModel::apply);
+	connect(this, &QDialog::rejected, _model.get(), &MissionGoalsDialogModel::reject);
+
+	connect(_model.get(), &MissionGoalsDialogModel::modelChanged, this, &MissionGoalsDialog::updateUI);
+
+	connect(ui->displayTypeCombo, QOverload<int>::of(&QComboBox::currentIndexChanged), this, [this](int index) {
+		_model->setGoalDisplayType(index);
+		recreate_tree();
+	});
+
+	connect(ui->goalEventTree, &sexp_tree::selectedRootChanged, this, [this](int forumla) {
+		for (auto i = 0; i < _model->getNumGoals(); ++i) {
+			auto& goal = _model->getGoals()[i];
+			if (goal.formula == forumla) {
+				_model->setCurrentGoal(i);
+				break;
+			}
+		}
+	});
+	connect(ui->goalEventTree, &sexp_tree::rootNodeDeleted, this, [this](int node) {
+		_model->deleteGoal(node);
+		ui->newObjectiveBtn->setEnabled(true);
+	});
+	connect(ui->goalEventTree, &sexp_tree::rootNodeFormulaChanged, this, [this](int old, int node) {
+		_model->changeFormula(old, node);
+	});
+	connect(ui->goalEventTree, &sexp_tree::helpChanged, this, [this](const QString& help) {
+		ui->helpTextBox->setPlainText(help);
+	});
+
+	connect(ui->newObjectiveBtn, &QPushButton::clicked, this, [this](bool) {
+		createNewObjective();
+	});
+
+	connect(ui->goalDescription, &QLineEdit::textChanged, this, [this](const QString& text) {
+		if (_model->isCurrentGoalValid()) {
+			_model->setCurrentGoalMessage(text.toUtf8().constData());
+		}
+	});
+
+	connect(ui->goalScore, QOverload<int>::of(&QSpinBox::valueChanged), this, [this](int value) {
+		if (_model->isCurrentGoalValid()) {
+			_model->setCurrentGoalScore(value);
+		}
+	});
+
+	connect(ui->goalTypeCombo,
+			QOverload<int>::of(&QComboBox::currentIndexChanged),
+			this,
+			&MissionGoalsDialog::changeGoalCategory);
+
+	connect(ui->goalName, &QLineEdit::textChanged, this, [this](const QString& text) {
+		if (_model->isCurrentGoalValid()) {
+			_model->setCurrentGoalName(text.toUtf8().constData());
+
+			auto item = ui->goalEventTree->currentItem();
+			while (item->parent() != nullptr) {
+				item = item->parent();
+			}
+
+			item->setText(0, text);
+		}
+	});
+
+	connect(ui->objectiveInvalidCheck, &QCheckBox::stateChanged, this, [this](int state) {
+		bool checked = state == Qt::Checked;
+
+		if (_model->isCurrentGoalValid()) {
+			_model->setCurrentGoalInvalid(checked);
+		}
+	});
+	connect(ui->noCompletionMusicCheck, &QCheckBox::stateChanged, this, [this](int state) {
+		bool checked = state == Qt::Checked;
+
+		if (_model->isCurrentGoalValid()) {
+			_model->setCurrentGoalNoMusic(checked);
+		}
+	});
+
+	connect(ui->goalTeamCombo, QOverload<int>::of(&QComboBox::currentIndexChanged), this, [this](int team) {
+		if (_model->isCurrentGoalValid()) {
+			_model->setCurrentGoalTeam(team);
+		}
+	});
+
+	_model->initializeData();
+
+	load_tree();
+
+	recreate_tree();
+}
 MissionGoalsDialog::~MissionGoalsDialog()
 {
-    delete ui;
+}
+void MissionGoalsDialog::updateUI() {
+	// Avoid infinite recursion by blocking signal calls caused by our changes here
+	util::SignalBlockers blocker(this);
+
+	if (!_model->isCurrentGoalValid()) {
+		ui->goalName->setText(QString());
+		ui->goalDescription->setText(QString());
+		ui->goalTypeCombo->setCurrentIndex(-1);
+		ui->goalTeamCombo->setCurrentIndex(0);
+
+		ui->goalTypeCombo->setEnabled(false);
+		ui->goalName->setEnabled(false);
+		ui->goalDescription->setEnabled(false);
+		ui->objectiveInvalidCheck->setEnabled(false);
+		ui->goalScore->setEnabled(false);
+		ui->noCompletionMusicCheck->setEnabled(false);
+		ui->goalTeamCombo->setEnabled(false);
+
+		return;
+	}
+
+	auto& goal = _model->getCurrentGoal();
+
+	ui->goalName->setText(QString::fromUtf8(goal.name));
+	ui->goalDescription->setText(QString::fromUtf8(goal.message));
+	ui->goalTypeCombo->setCurrentIndex(goal.type & GOAL_TYPE_MASK);
+	ui->objectiveInvalidCheck->setChecked((goal.type & INVALID_GOAL) != 0);
+	ui->noCompletionMusicCheck->setChecked((goal.type & MGF_NO_MUSIC) != 0);
+	ui->goalScore->setValue(goal.score);
+	ui->goalTeamCombo->setCurrentIndex(goal.team);
+
+	ui->goalTypeCombo->setEnabled(true);
+	ui->goalName->setEnabled(true);
+	ui->goalDescription->setEnabled(true);
+	ui->objectiveInvalidCheck->setEnabled(true);
+	ui->goalScore->setEnabled(true);
+	ui->noCompletionMusicCheck->setEnabled(true);
+	ui->goalTeamCombo->setEnabled((The_mission.game_type & MISSION_TYPE_MULTI_TEAMS) != 0);
+}
+void MissionGoalsDialog::load_tree() {
+	ui->goalEventTree->clear_tree();
+	for (auto i = 0; i < _model->getNumGoals(); ++i) {
+		auto& goal = _model->getGoals()[i];
+		goal.formula = ui->goalEventTree->load_sub_tree(goal.formula, true, "true");
+	}
+	ui->goalEventTree->post_load();
+}
+void MissionGoalsDialog::recreate_tree() {
+	ui->goalEventTree->clear();
+	for (auto i = 0; i < _model->getNumGoals(); ++i) {
+		const auto& goal = _model->getGoals()[i];
+		if (!_model->isGoalVisible(goal)) {
+			continue;
+		}
+
+		auto h = ui->goalEventTree->insert(goal.name);
+		h->setData(0, sexp_tree::FormulaDataRole, goal.formula);
+		ui->goalEventTree->add_sub_tree(goal.formula, h);
+	}
+
+	_model->setCurrentGoal(-1);
+}
+void MissionGoalsDialog::createNewObjective() {
+	auto& goal = _model->createNewGoal();
+
+	auto h = ui->goalEventTree->insert(goal.name);
+
+	ui->goalEventTree->setCurrentItemIndex(-1);
+	ui->goalEventTree->add_operator("true", h);
+	auto index = goal.formula = ui->goalEventTree->getCurrentItemIndex();
+	h->setData(0, sexp_tree::FormulaDataRole, index);
+
+	if (_model->getNumGoals() >= MAX_GOALS) {
+		ui->newObjectiveBtn->setEnabled(false);
+	}
+
+	ui->goalEventTree->setCurrentItem(h);
+}
+void MissionGoalsDialog::changeGoalCategory(int type) {
+	if (_model->isCurrentGoalValid()) {
+		_model->setCurrentGoalCategory(type);
+		recreate_tree();
+	}
+}
+void MissionGoalsDialog::closeEvent(QCloseEvent* event) {
+	if (_model->query_modified()) {
+		auto result = QMessageBox::question(this,
+											"Close",
+											"Do you want to keep your changes?",
+											QMessageBox::Yes | QMessageBox::No | QMessageBox::Cancel,
+											QMessageBox::Cancel);
+
+		if (result == QMessageBox::Cancel) {
+			event->ignore();
+			return;
+		}
+
+		if (result == QMessageBox::Yes) {
+			accept();
+			event->accept();
+			return;
+		}
+	}
+
+	QDialog::closeEvent(event);
 }
 
 }

--- a/qtfred/src/ui/dialogs/MissionGoalsDialog.h
+++ b/qtfred/src/ui/dialogs/MissionGoalsDialog.h
@@ -3,6 +3,13 @@
 
 #include <QDialog>
 
+#include "mission/EditorViewport.h"
+#include "mission/dialogs/MissionGoalsDialogModel.h"
+
+#include "ui/widgets/sexp_tree.h"
+
+#include <memory>
+
 namespace fso {
 namespace fred {
 namespace dialogs {
@@ -11,16 +18,30 @@ namespace Ui {
 class MissionGoalsDialog;
 }
 
-class MissionGoalsDialog : public QDialog
+class MissionGoalsDialog : public QDialog, public SexpTreeEditorInterface
 {
     Q_OBJECT
 
 public:
-    explicit MissionGoalsDialog(QWidget *parent = 0);
+    explicit MissionGoalsDialog(QWidget *parent, EditorViewport* viewport);
     ~MissionGoalsDialog() override;
 
-private:
-    Ui::MissionGoalsDialog *ui;
+ protected:
+	void closeEvent(QCloseEvent* event) override;
+
+ private:
+	void updateUI();
+
+	void createNewObjective();
+
+	void changeGoalCategory(int type);
+
+    std::unique_ptr<Ui::MissionGoalsDialog> ui;
+    std::unique_ptr<MissionGoalsDialogModel> _model;
+
+    EditorViewport* _viewport = nullptr;
+	void load_tree();
+	void recreate_tree();
 };
 
 }

--- a/qtfred/src/ui/widgets/sexp_tree.cpp
+++ b/qtfred/src/ui/widgets/sexp_tree.cpp
@@ -200,6 +200,8 @@ sexp_tree::sexp_tree(QWidget* parent) : QTreeWidget(parent) {
 
 	setContextMenuPolicy(Qt::CustomContextMenu);
 
+	setHeaderHidden(true);
+
 	select_sexp_node = -1;
 	root_item = -1;
 	clear_tree();
@@ -1845,6 +1847,7 @@ void sexp_tree::hilite_item(int node) {
 	ensure_visible(node);
 	clearSelection();
 	setCurrentItem(tree_nodes[node].handle);
+	scrollToItem(tree_nodes[node].handle);
 }
 
 // because the MFC function EnsureVisible() doesn't do what it says it does, I wrote this.
@@ -5751,6 +5754,9 @@ void sexp_tree::handleNewItemSelected() {
 }
 void sexp_tree::deleteCurrentItem() {
 	deleteActionHandler();
+}
+int sexp_tree::getCurrentItemIndex() const {
+	return item_index;
 }
 
 }

--- a/qtfred/src/ui/widgets/sexp_tree.h
+++ b/qtfred/src/ui/widgets/sexp_tree.h
@@ -327,6 +327,7 @@ class sexp_tree: public QTreeWidget {
 	sexp_list_item* get_listing_opf_game_snds();
 
 
+	int getCurrentItemIndex() const;
 	void setCurrentItemIndex(int index);
 	int select_sexp_node;  // used to select an sexp item on dialog box open.
 

--- a/qtfred/ui/EventEditorDialog.ui
+++ b/qtfred/ui/EventEditorDialog.ui
@@ -524,8 +524,8 @@
    <slot>reject()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>673</x>
-     <y>570</y>
+     <x>917</x>
+     <y>636</y>
     </hint>
     <hint type="destinationlabel">
      <x>530</x>
@@ -540,8 +540,8 @@
    <slot>accept()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>782</x>
-     <y>568</y>
+     <x>917</x>
+     <y>636</y>
     </hint>
     <hint type="destinationlabel">
      <x>504</x>

--- a/qtfred/ui/FredView.ui
+++ b/qtfred/ui/FredView.ui
@@ -20,7 +20,7 @@
      <x>0</x>
      <y>0</y>
      <width>926</width>
-     <height>21</height>
+     <height>28</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuFile">
@@ -160,6 +160,7 @@
     <addaction name="actionWings"/>
     <addaction name="actionObjects"/>
     <addaction name="actionWaypoint_Paths"/>
+    <addaction name="actionMission_Objectives"/>
     <addaction name="actionEvents"/>
     <addaction name="actionTeam_Loadout"/>
     <addaction name="actionBackground"/>
@@ -1392,6 +1393,14 @@
   <action name="actionEmpty">
    <property name="text">
     <string>&amp;Empty</string>
+   </property>
+  </action>
+  <action name="actionMission_Objectives">
+   <property name="text">
+    <string>Mission Objectives</string>
+   </property>
+   <property name="shortcut">
+    <string>Shift+G</string>
    </property>
   </action>
  </widget>

--- a/qtfred/ui/MissionGoalsDialog.ui
+++ b/qtfred/ui/MissionGoalsDialog.ui
@@ -2,423 +2,290 @@
 <ui version="4.0">
  <class>fso::fred::dialogs::MissionGoalsDialog</class>
  <widget class="QDialog" name="fso::fred::dialogs::MissionGoalsDialog">
+  <property name="windowModality">
+   <enum>Qt::WindowModal</enum>
+  </property>
   <property name="geometry">
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>640</width>
-    <height>480</height>
+    <width>578</width>
+    <height>579</height>
    </rect>
   </property>
-  <property name="minimumSize">
-   <size>
-    <width>640</width>
-    <height>480</height>
-   </size>
-  </property>
   <property name="windowTitle">
-   <string>Dialog</string>
+   <string>Mission Objectives</string>
   </property>
-  <property name="sizeGripEnabled">
-   <bool>true</bool>
-  </property>
-  <property name="modal">
-   <bool>true</bool>
-  </property>
-  <layout class="QGridLayout" name="mainLayout">
-   <property name="horizontalSpacing">
-    <number>3</number>
-   </property>
-   <property name="verticalSpacing">
-    <number>11</number>
-   </property>
-   <item row="0" column="1">
-    <layout class="QVBoxLayout" name="editSectionLayout">
-     <property name="spacing">
-      <number>6</number>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QSplitter" name="splitter_2">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
      </property>
-     <property name="sizeConstraint">
-      <enum>QLayout::SetFixedSize</enum>
+     <property name="childrenCollapsible">
+      <bool>false</bool>
      </property>
-     <property name="leftMargin">
-      <number>6</number>
-     </property>
-     <item>
-      <layout class="QFormLayout" name="displayTypeLayout">
-       <property name="sizeConstraint">
-        <enum>QLayout::SetFixedSize</enum>
-       </property>
-       <property name="formAlignment">
-        <set>Qt::AlignRight|Qt::AlignTop|Qt::AlignTrailing</set>
-       </property>
-       <property name="horizontalSpacing">
-        <number>6</number>
-       </property>
-       <property name="rightMargin">
-        <number>6</number>
-       </property>
-       <item row="0" column="0">
-        <widget class="QLabel" name="displayTypeLabel">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="minimumSize">
-          <size>
-           <width>100</width>
-           <height>0</height>
-          </size>
-         </property>
-         <property name="text">
-          <string>Display Types</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-         </property>
-        </widget>
-       </item>
-       <item row="0" column="1">
-        <widget class="QComboBox" name="displayTypeCombo">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="minimumSize">
-          <size>
-           <width>80</width>
-           <height>0</height>
-          </size>
-         </property>
-        </widget>
-       </item>
-      </layout>
-     </item>
-     <item>
-      <widget class="QGroupBox" name="currentObjBox">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="minimumSize">
-        <size>
-         <width>243</width>
-         <height>199</height>
-        </size>
-       </property>
-       <property name="title">
-        <string>Current Objective</string>
-       </property>
-       <layout class="QVBoxLayout" name="verticalLayout">
-        <property name="sizeConstraint">
-         <enum>QLayout::SetDefaultConstraint</enum>
-        </property>
-        <property name="topMargin">
-         <number>5</number>
-        </property>
-        <property name="bottomMargin">
-         <number>5</number>
-        </property>
-        <item>
-         <layout class="QFormLayout" name="objTypeForm">
-          <property name="formAlignment">
-           <set>Qt::AlignRight|Qt::AlignTop|Qt::AlignTrailing</set>
-          </property>
-          <property name="rightMargin">
-           <number>6</number>
-          </property>
-          <item row="0" column="0">
-           <widget class="QLabel" name="typeLabel">
-            <property name="minimumSize">
-             <size>
-              <width>0</width>
-              <height>0</height>
-             </size>
-            </property>
-            <property name="text">
-             <string>Type</string>
-            </property>
-            <property name="alignment">
-             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="1">
-           <widget class="QComboBox" name="typeCombo">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="minimumSize">
-             <size>
-              <width>100</width>
-              <height>0</height>
-             </size>
-            </property>
-            <property name="frame">
-             <bool>true</bool>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </item>
-        <item>
-         <layout class="QFormLayout" name="objNameForm">
-          <property name="formAlignment">
-           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-          </property>
-          <property name="rightMargin">
-           <number>6</number>
-          </property>
-          <item row="0" column="0">
-           <widget class="QLabel" name="nameLabel">
-            <property name="minimumSize">
-             <size>
-              <width>0</width>
-              <height>0</height>
-             </size>
-            </property>
-            <property name="text">
-             <string>Name</string>
-            </property>
-            <property name="alignment">
-             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="1">
-           <widget class="QLineEdit" name="nameEdit">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="minimumSize">
-             <size>
-              <width>100</width>
-              <height>0</height>
-             </size>
-            </property>
-            <property name="maximumSize">
-             <size>
-              <width>100</width>
-              <height>16777215</height>
-             </size>
-            </property>
-            <property name="text">
-             <string>Goal name</string>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </item>
-        <item>
-         <widget class="QLineEdit" name="missionGoalText">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="text">
-           <string>Mission goal text</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <layout class="QFormLayout" name="objScoreLayout">
-          <property name="formAlignment">
-           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-          </property>
-          <property name="rightMargin">
-           <number>6</number>
-          </property>
-          <item row="0" column="0">
-           <widget class="QLabel" name="scoreLabel">
-            <property name="minimumSize">
-             <size>
-              <width>80</width>
-              <height>0</height>
-             </size>
-            </property>
-            <property name="text">
-             <string>Score</string>
-            </property>
-            <property name="alignment">
-             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="1">
-           <widget class="QLineEdit" name="scoreEdit">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="maximumSize">
-             <size>
-              <width>100</width>
-              <height>16777215</height>
-             </size>
-            </property>
-            <property name="text">
-             <string>0</string>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </item>
-        <item>
-         <layout class="QFormLayout" name="objTeamLayout">
-          <property name="formAlignment">
-           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-          </property>
-          <property name="rightMargin">
-           <number>6</number>
-          </property>
-          <item row="0" column="0">
-           <widget class="QLabel" name="teamLabel">
-            <property name="minimumSize">
-             <size>
-              <width>80</width>
-              <height>0</height>
-             </size>
-            </property>
-            <property name="text">
-             <string>Team</string>
-            </property>
-            <property name="alignment">
-             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="1">
-           <widget class="QComboBox" name="teamCombo">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </item>
-        <item>
-         <layout class="QVBoxLayout" name="objCheckLayout">
-          <property name="spacing">
-           <number>0</number>
-          </property>
-          <item>
-           <widget class="QCheckBox" name="objInvalid">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="text">
-             <string>Objective Invalid</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QCheckBox" name="noCompletionMusic">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="text">
-             <string>Don't Play Completion Music</string>
-            </property>
-            <property name="tristate">
-             <bool>false</bool>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </item>
-       </layout>
-      </widget>
-     </item>
-     <item>
+     <widget class="QWidget" name="widget" native="true">
       <layout class="QHBoxLayout" name="horizontalLayout">
        <property name="spacing">
-        <number>6</number>
-       </property>
-       <property name="sizeConstraint">
-        <enum>QLayout::SetFixedSize</enum>
+        <number>0</number>
        </property>
        <property name="leftMargin">
-        <number>3</number>
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
        </property>
        <property name="rightMargin">
-        <number>3</number>
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
+        <number>0</number>
        </property>
        <item>
-        <widget class="QPushButton" name="newObjButton">
-         <property name="text">
-          <string>New Obj.</string>
-         </property>
-         <property name="autoDefault">
-          <bool>false</bool>
-         </property>
-        </widget>
+        <widget class="fso::fred::sexp_tree" name="goalEventTree"/>
        </item>
-       <item>
-        <widget class="QDialogButtonBox" name="buttonBox">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
+       <item alignment="Qt::AlignTop">
+        <widget class="QWidget" name="widget_2" native="true">
+         <property name="enabled">
+          <bool>true</bool>
          </property>
-         <property name="standardButtons">
-          <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
-         </property>
+         <layout class="QGridLayout" name="gridLayout">
+          <property name="sizeConstraint">
+           <enum>QLayout::SetFixedSize</enum>
+          </property>
+          <item row="1" column="0" colspan="2">
+           <widget class="QGroupBox" name="groupBox">
+            <property name="title">
+             <string>Current Objective</string>
+            </property>
+            <layout class="QFormLayout" name="formLayout">
+             <property name="sizeConstraint">
+              <enum>QLayout::SetMinAndMaxSize</enum>
+             </property>
+             <property name="fieldGrowthPolicy">
+              <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
+             </property>
+             <property name="labelAlignment">
+              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+             </property>
+             <property name="formAlignment">
+              <set>Qt::AlignJustify|Qt::AlignTop</set>
+             </property>
+             <item row="0" column="0">
+              <widget class="QLabel" name="label_2">
+               <property name="text">
+                <string>T&amp;ype</string>
+               </property>
+               <property name="buddy">
+                <cstring>goalTypeCombo</cstring>
+               </property>
+              </widget>
+             </item>
+             <item row="0" column="1">
+              <widget class="QComboBox" name="goalTypeCombo">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <item>
+                <property name="text">
+                 <string>Primary Goal</string>
+                </property>
+               </item>
+               <item>
+                <property name="text">
+                 <string>Secondary Goal</string>
+                </property>
+               </item>
+               <item>
+                <property name="text">
+                 <string>Bonus Goal</string>
+                </property>
+               </item>
+              </widget>
+             </item>
+             <item row="3" column="1">
+              <widget class="QSpinBox" name="goalScore"/>
+             </item>
+             <item row="4" column="1">
+              <widget class="QComboBox" name="goalTeamCombo">
+               <item>
+                <property name="text">
+                 <string>Team 1</string>
+                </property>
+               </item>
+               <item>
+                <property name="text">
+                 <string>Team 2</string>
+                </property>
+               </item>
+               <item>
+                <property name="text">
+                 <string>None</string>
+                </property>
+               </item>
+              </widget>
+             </item>
+             <item row="5" column="0" colspan="2">
+              <widget class="QCheckBox" name="objectiveInvalidCheck">
+               <property name="text">
+                <string>Objective Invalid</string>
+               </property>
+              </widget>
+             </item>
+             <item row="6" column="0" colspan="2">
+              <widget class="QCheckBox" name="noCompletionMusicCheck">
+               <property name="text">
+                <string>Don't Play Completion Music</string>
+               </property>
+              </widget>
+             </item>
+             <item row="1" column="0">
+              <widget class="QLabel" name="label_3">
+               <property name="text">
+                <string>Name</string>
+               </property>
+               <property name="buddy">
+                <cstring>goalName</cstring>
+               </property>
+              </widget>
+             </item>
+             <item row="3" column="0">
+              <widget class="QLabel" name="label_4">
+               <property name="text">
+                <string>Score</string>
+               </property>
+               <property name="buddy">
+                <cstring>goalScore</cstring>
+               </property>
+              </widget>
+             </item>
+             <item row="4" column="0">
+              <widget class="QLabel" name="label_5">
+               <property name="text">
+                <string>Team</string>
+               </property>
+               <property name="buddy">
+                <cstring>goalTeamCombo</cstring>
+               </property>
+              </widget>
+             </item>
+             <item row="1" column="1">
+              <widget class="QLineEdit" name="goalName"/>
+             </item>
+             <item row="2" column="0" colspan="2">
+              <widget class="QLineEdit" name="goalDescription">
+               <property name="placeholderText">
+                <string>Mission goal text</string>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="QDialogButtonBox" name="buttonBox">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="standardButtons">
+             <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QPushButton" name="newObjectiveBtn">
+            <property name="text">
+             <string>New Obj.</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QComboBox" name="displayTypeCombo">
+            <item>
+             <property name="text">
+              <string>Primary Goals</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Secondary Goals</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Bonus Goals</string>
+             </property>
+            </item>
+           </widget>
+          </item>
+          <item row="0" column="0">
+           <widget class="QLabel" name="label">
+            <property name="text">
+             <string>Display &amp;Types</string>
+            </property>
+            <property name="buddy">
+             <cstring>displayTypeCombo</cstring>
+            </property>
+           </widget>
+          </item>
+         </layout>
         </widget>
        </item>
       </layout>
-     </item>
-    </layout>
-   </item>
-   <item row="0" column="0">
-    <widget class="QTreeView" name="objectiveTreeView">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="minimumSize">
-      <size>
-       <width>370</width>
-       <height>260</height>
-      </size>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="0" colspan="2">
-    <widget class="QPlainTextEdit" name="objText">
-     <property name="verticalScrollBarPolicy">
-      <enum>Qt::ScrollBarAlwaysOn</enum>
-     </property>
+     </widget>
+     <widget class="QPlainTextEdit" name="helpTextBox">
+      <property name="readOnly">
+       <bool>true</bool>
+      </property>
+     </widget>
     </widget>
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>fso::fred::sexp_tree</class>
+   <extends>QTreeView</extends>
+   <header>ui/widgets/sexp_tree.h</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
- <connections/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>fso::fred::dialogs::MissionGoalsDialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>506</x>
+     <y>119</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>fso::fred::dialogs::MissionGoalsDialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>506</x>
+     <y>113</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
 </ui>


### PR DESCRIPTION
The sexp_tree widget makes the model based dialog a bit ugly here since
it is required for some model operations even though it is a UI
component. In the future it could be split into a model component and an
UI component to allow better separation between model and UI.

This fixes #1698.