### PR TITLE
Check source code formatting with clang-format and Travis CI

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,99 @@
+---
+Language:        Cpp
+# BasedOnStyle:  LLVM
+AccessModifierOffset: -2
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: true
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlinesLeft: false
+AlignOperands:   true
+AlignTrailingComments: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: false
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:   
+  AfterClass:      false
+  AfterControlStatement: false
+  AfterEnum:       false
+  AfterFunction:   false
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  BeforeCatch:     false
+  BeforeElse:      false
+  IndentBraces:    false
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Attach
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:     120
+CommentPragmas:  '^ IWYU pragma:'
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DerivePointerAlignment: false
+DisableFormat:   false
+ForEachMacros:   [ foreach, Q_FOREACH, BOOST_FOREACH ]
+IncludeCategories:
+  - Regex:           '^(<.*\.(h|hh|hpp)>)$' # Includes of external libraries
+    Priority:        4
+  - Regex:           '^(<.*>)$' # standard library includes (won't match deprecated C headers)
+    Priority:        5
+  - Regex:           '^"[^/]*\.(h)"$' # Local includes
+    Priority:        1
+  - Regex:           '^".*\.(h)"$' # standard engine includes
+    Priority:        2
+  - Regex:           '.*' # Catch all in case something is unhandled above
+    Priority:        3
+IncludeIsMainRegex: '$'
+IndentCaseLabels: false
+IndentWidth:     4
+IndentWrappedFunctionNames: false
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: true
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBlockIndentWidth: 2
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 60
+PointerAlignment: Left
+ReflowComments:  true
+SortIncludes:    true
+SpaceAfterCStyleCast: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard:        Cpp11
+TabWidth:        4
+UseTab:          ForIndentation
+...
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -138,6 +138,18 @@ matrix:
                       - libc++-dev
         - os: osx
           env: CONFIGURATION="Release"
+
+        - os: linux
+          env: CMAKE_OPTIONS="-DCMAKE_EXPORT_COMPILE_COMMANDS=ON"
+          addons:
+              apt:
+                  sources:
+                      - llvm-toolchain-trusty-4.0
+                  packages:
+                      - clang-format-4.0
+          before_script:
+            - echo # This stage is not needed for this check
+          script: ./ci/travis/clang_format.sh && exit $? # Call script and exit with same code
 before_install:
     # ugly hack; if running a coverity scan abort all except the 1st build
     # see note re gcc compiler above needing to be 1st

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,6 +146,7 @@ if(FSO_BUILD_APPIMAGE)
 endif()
 
 include(clang-tidy)
+include(clang-format)
 
 # This includes source code for some tools, either used in the build or also for something else
 ADD_SUBDIRECTORY(tools)

--- a/ci/travis/check_release.sh
+++ b/ci/travis/check_release.sh
@@ -54,7 +54,7 @@ if [ "$BUILD_DEPLOYMENT" = true ]; then
         exit 0;
     fi
 
-    if ([[ "$CONFIGURATION" == "Debug" ]]); then
+    if ([[ "$CONFIGURATION" != "Release" ]]); then
         echo "Skipping non-release configuration";
         exit 0;
     fi

--- a/ci/travis/clang_format.sh
+++ b/ci/travis/clang_format.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -e
+
+if ! git rev-list $TRAVIS_COMMIT_RANGE 2>1 >/dev/null; then
+    echo "\$TRAVIS_COMMIT_RANGE ($TRAVIS_COMMIT_RANGE) is not valid for this build (probably caused by a rebase)."
+    exit 0
+fi
+
+cd "$TRAVIS_BUILD_DIR"
+
+git diff -U0 --no-color $TRAVIS_COMMIT_RANGE | clang-format-diff-4.0 -p1 -i -sort-includes
+
+if [[ -n $(git diff) ]]; then
+    echo "Code style is not consistent with clang-format configuration! The following files were formatted incorrectly:"
+    git diff --name-only
+    exit 1
+else
+    echo -e "\033[1;32m\xE2\x9C\x93 passed:\033[0m Formatting test succeeded";
+fi

--- a/cmake/clang-format.cmake
+++ b/cmake/clang-format.cmake
@@ -1,0 +1,57 @@
+option(ENABLE_CLANG_FORMAT "Enable source code formatting using clang-format." OFF)
+
+find_program(
+        CLANG_FORMAT_EXE
+        NAMES "clang-format"
+        DOC "Path to clang-format executable"
+)
+
+function(enable_clang_format target)
+    # Not enabled in this configuration
+endfunction()
+
+if(NOT ENABLE_CLANG_FORMAT)
+    return()
+endif()
+
+if(NOT EXISTS "${CLANG_FORMAT_EXE}")
+    message(SEND_ERROR "clang-format: Could not find clang-format executable (value of variable is \"${CLANG_FORMAT_EXE}\".")
+    return()
+endif()
+
+message(STATUS "clang-tidy: Using \"${CLANG_FORMAT_EXE}\"")
+
+# This dummy target serves as the common dependency for all clang-format targets
+add_custom_target(clang-format)
+
+function(enable_clang_format target)
+    get_target_property(TARGET_SOURCE_DIR ${target} SOURCE_DIR)
+    get_target_property(TARGET_BINARY_DIR ${target} BINARY_DIR)
+    get_target_property(TARGET_SOURCES ${target} SOURCES)
+
+    set(RESOLVED_SOURCES)
+    foreach (source ${TARGET_SOURCES})
+        # This should match what CMake does
+        if (IS_ABSOLUTE "${source}")
+            set(ABSOLUTE_PATH "${source}")
+        else()
+            set(ABSOLUTE_PATH "${TARGET_SOURCE_DIR}/${source}")
+        endif()
+
+        file(RELATIVE_PATH SOURCE_RELATIVE "${TARGET_SOURCE_DIR}" "${ABSOLUTE_PATH}")
+
+        get_source_file_property(LANGUAGE "${TARGET_SOURCE_DIR}/${source}" LANGUAGE)
+
+        # This should exclude most generated files that are not relevant here
+        if (NOT ("${SOURCE_RELATIVE}" MATCHES "^\\.\\.") AND "${source}" MATCHES "(\\.h|\\.cpp)$")
+            set(RESOLVED_SOURCES ${RESOLVED_SOURCES} "${ABSOLUTE_PATH}")
+        endif()
+    endforeach ()
+
+    add_custom_target(clang-format-${target}
+            COMMAND ${CLANG_FORMAT_EXE} -i -sort-includes ${RESOLVED_SOURCES}
+            COMMENT "Formatting code of ${target} using clang-format"
+            VERBATIM)
+    add_dependencies(clang-format clang-format-${target})
+endfunction()
+

--- a/code/CMakeLists.txt
+++ b/code/CMakeLists.txt
@@ -38,6 +38,7 @@ TARGET_LINK_LIBRARIES(code PUBLIC compiler)
 target_link_libraries(code PUBLIC md5)
 
 enable_clang_tidy(code)
+enable_clang_format(code)
 
 IF (FSO_USE_SPEECH)
 	find_package(Speech REQUIRED)

--- a/freespace2/CMakeLists.txt
+++ b/freespace2/CMakeLists.txt
@@ -60,7 +60,6 @@ if (FSO_INSTALL_DEBUG_FILES)
 endif()
 
 enable_clang_tidy(Freespace2)
-enable_clang_format(Freespace2)
 
 INCLUDE(util)
 COPY_FILES_TO_TARGET(Freespace2)

--- a/freespace2/CMakeLists.txt
+++ b/freespace2/CMakeLists.txt
@@ -60,6 +60,7 @@ if (FSO_INSTALL_DEBUG_FILES)
 endif()
 
 enable_clang_tidy(Freespace2)
+enable_clang_format(Freespace2)
 
 INCLUDE(util)
 COPY_FILES_TO_TARGET(Freespace2)

--- a/qtfred/CMakeLists.txt
+++ b/qtfred/CMakeLists.txt
@@ -69,6 +69,7 @@ INSTALL(
 COPY_FILES_TO_TARGET(qtfred)
 
 enable_clang_tidy(qtfred)
+enable_clang_format(qtfred)
 
 if (WIN32)
     set(additional_dlls

--- a/tools/embedfile/CMakeLists.txt
+++ b/tools/embedfile/CMakeLists.txt
@@ -12,6 +12,7 @@ IF(NOT CMAKE_CROSSCOMPILING)
 	)
 
 	enable_clang_tidy(embedfile)
+	enable_clang_format(embedfile)
 
 	EXPORT(TARGETS embedfile FILE ${CMAKE_BINARY_DIR}/ImportExecutables.cmake)
 ENDIF(NOT CMAKE_CROSSCOMPILING)


### PR DESCRIPTION
This uses clang-format-diff for detecting improperly formatted lines on
the CI servers. The check is only applied to lines that were changed in
a pull request so this does not require a full source code reformatting
but still ensures that the style set by clang-format is used by new
commits.