### PR TITLE
Fix fog rendering in forward renderer

### DIFF
--- a/code/def_files/data/effects/main-f.sdr
+++ b/code/def_files/data/effects/main-f.sdr
@@ -381,8 +381,10 @@ void main()
  #ifdef FLAG_DIFFUSE_MAP
 	if(blend_alpha == 1) finalFogColor *= baseColor.a;
  #endif
-	baseColor.rgb = mix(baseColor.rgb, finalFogColor, vertIn.fogDist);
-	emissiveColor.rgb = mix(emissiveColor.rgb, finalFogColor, vertIn.fogDist);
+	// This code will only be used by the forward renderer so we apply the fog effect to both the emissive and the base
+	// color.
+	baseColor.rgb = mix(emissiveColor.rgb + baseColor.rgb, finalFogColor, vertIn.fogDist);
+	emissiveColor.rgb = vec3(0.0); // Zero the emissive color since it has already been added by the previous line
 	specColor.rgb *= vertIn.fogDist;
 #endif
 

--- a/code/model/modelrender.cpp
+++ b/code/model/modelrender.cpp
@@ -495,7 +495,8 @@ void model_draw_list::add_buffer_draw(model_material *render_material, indexed_v
 		// If the zbuffer type is FULL then this buffer may be drawn in the deferred lighting part otherwise we need to
 		// make sure that the deferred flag is disabled or else some parts of the rendered colors go missing
 		// TODO: This should really be handled somewhere else. This feels like a crude hack...
-		auto possibly_deferred = draw_data.render_material.get_depth_mode() == ZBUFFER_TYPE_FULL;
+		auto possibly_deferred = draw_data.render_material.get_depth_mode() == ZBUFFER_TYPE_FULL
+			&& gr_is_capable(CAPABILITY_DEFERRED_LIGHTING) && !Cmdline_no_deferred_lighting;
 
 		if (possibly_deferred) {
 			// Fog is handled differently in deferred shader situations


### PR DESCRIPTION
There were actually two bugs here that were fixed:
1. The model draw list code disabled the fog rendering when it thought
it was it deferred rendering mode but did not account for explicitly
disabling the deferred renderer.
2. The fog effect was applied to both the emissive color and the base
color simultaneously which caused visual errors when rendering fogged
objects using the deferred renderer.

This fixes #1717.