### PR TITLE
Fix scrambling unicode messages

### DIFF
--- a/code/globalincs/pstypes.h
+++ b/code/globalincs/pstypes.h
@@ -261,14 +261,14 @@ extern int Global_error_count;
 // Disabling this functionality is dangerous, crazy values can run rampent unchecked and the longer its disabled
 // the more likely you are to have problems getting it working again.
 #if defined(NDEBUG)
-#	define Assert(expr) do { ASSUME(expr); } while (0)
+#	define Assert(expr) do { ASSUME(expr); } while (false)
 #else
 #	define Assert(expr) do {\
 		if (!(expr)) {\
 			os::dialogs::AssertMessage(#expr,__FILE__,__LINE__);\
 		}\
 		ASSUME( expr );\
-	} while (0)
+	} while (false)
 #endif
 /*******************NEVER COMMENT Assert ************************************************/
 

--- a/code/globalincs/toolchain/clang.h
+++ b/code/globalincs/toolchain/clang.h
@@ -32,7 +32,7 @@
 #define ASSUME(x)
 
 #if defined(NDEBUG)
-#	define Assertion(expr, msg, ...)  do { } while (0)
+#	define Assertion(expr, msg, ...)  do { } while (false)
 #else
 /*
  * NOTE: Assertion() can only use its proper functionality in compilers
@@ -43,7 +43,7 @@
 			if (!(expr)) {                                                \
 				os::dialogs::AssertMessage(#expr, __FILE__, __LINE__, msg, ##__VA_ARGS__); \
 			}                                                             \
-		} while (0)
+		} while (false)
 #endif
 
 /* C++11 Standard Detection */

--- a/code/globalincs/toolchain/gcc.h
+++ b/code/globalincs/toolchain/gcc.h
@@ -32,7 +32,7 @@
 #define ASSUME(x)
 
 #if defined(NDEBUG)
-#	define Assertion(expr, msg, ...)  do {} while (0)
+#	define Assertion(expr, msg, ...)  do {} while (false)
 #else
 /*
  * NOTE: Assertion() can only use its proper functionality in compilers
@@ -43,7 +43,7 @@
 			if (!(expr)) {                                                \
 				os::dialogs::AssertMessage(#expr, __FILE__, __LINE__, msg, ##__VA_ARGS__); \
 			}                                                             \
-		} while (0)
+		} while (false)
 #endif
 
 /* C++11 Standard Detection */

--- a/code/globalincs/toolchain/mingw.h
+++ b/code/globalincs/toolchain/mingw.h
@@ -34,7 +34,7 @@
 #define ASSUME(x)
 
 #if defined(NDEBUG)
-#	define Assertion(expr, msg, ...)  do {} while (0)
+#	define Assertion(expr, msg, ...)  do {} while (false)
 #else
 /*
  * NOTE: Assertion() can only use its proper functionality in compilers
@@ -45,7 +45,7 @@
 			if (!(expr)) {                                                \
 				os::dialogs::AssertMessage(#expr, __FILE__, __LINE__, msg, ##__VA_ARGS__); \
 			}                                                             \
-		} while (0)
+		} while (false)
 #endif
 
 /* C++11 Standard Detection */

--- a/code/globalincs/toolchain/msvc.h
+++ b/code/globalincs/toolchain/msvc.h
@@ -38,9 +38,9 @@
 
 #if defined(NDEBUG)
 #	if _MSC_VER >= 1400  /* MSVC 2005 or newer */
-#		define Assertion(expr, msg, ...)  do { ASSUME(expr); } while (0)
+#		define Assertion(expr, msg, ...)  do { ASSUME(expr); } while (false)
 #	else
-#		define Assertion(expr, msg)  do {} while (0)
+#		define Assertion(expr, msg)  do {} while (false)
 #	endif
 #else
 	/*
@@ -53,13 +53,13 @@
 				if (!(expr)) {                                              \
 					os::dialogs::AssertMessage(#expr, __FILE__, __LINE__, msg, __VA_ARGS__); \
 				}                                                           \
-			} while (0)
+			} while (false)
 #	else                 /* Older MSVC compilers */
 #		define Assertion(expr, msg)                        \
 			do {                                           \
 				if (!(expr)) {                             \
 					os::dialogs::AssertMessage(#expr, __FILE__, __LINE__);  \
-			} while (0)
+			} while (false)
 #	endif
 #endif
 

--- a/code/mission/missionmessage.cpp
+++ b/code/mission/missionmessage.cpp
@@ -2221,26 +2221,40 @@ void message_maybe_distort_text(char *text, int shipnum)
 {
 	int voice_duration;
 
-	if ( comm_between_player_and_ship(shipnum) == COMM_OK ) { 
+	if (comm_between_player_and_ship(shipnum) == COMM_OK) {
 		return;
 	}
 
-	auto len = strlen(text);
-	if ( Message_wave_duration == 0 ) {
-		size_t next_distort = 5+myrand()%5;
-		for ( size_t i = 0; i < len; i++ ) {
-			if ( i == next_distort ) {
-				size_t run = 3+myrand()%5;
-				if ( i+run > len )
-					run = len-i;
-				for ( size_t j = 0; j < run; j++) {
-					text[i++] = '-';
-					if ( i >= len )
-						break;
-				}
-				next_distort = i + (5+myrand()%5);
+	auto buffer_size = strlen(text);
+	auto len         = unicode::num_codepoints(text, text + buffer_size);
+	if (Message_wave_duration == 0) {
+		SCP_string result_str;
+
+		size_t next_distort = 5 + myrand() % 5;
+		size_t i            = 0;
+		size_t run = 0;
+		for (auto cp : unicode::codepoint_range(text)) {
+			if (i == next_distort) {
+				run = 3 + myrand() % 5;
+				if (i + run > len)
+					run = len - i;
 			}
+
+			if (run > 0) {
+				unicode::encode(UNICODE_CHAR('-'), std::back_inserter(result_str));
+				--run;
+
+				if (run <= 0) {
+					next_distort = i + (5+myrand()%5);
+				}
+			} else {
+				unicode::encode(cp, std::back_inserter(result_str));
+			}
+
+			++i;
 		}
+		Assertion(result_str.size() <= buffer_size, "Buffer after scrambling message is bigger than before!");
+		strcpy(text, result_str.c_str());
 		return;
 	}
 
@@ -2249,19 +2263,31 @@ void message_maybe_distort_text(char *text, int shipnum)
 	// distort text
 	Distort_num = myrand()%MAX_DISTORT_PATTERNS;
 	Distort_next = 0;
+	unicode::codepoint_range range(text);
+	auto curr_iter = range.begin();
 	size_t curr_offset = 0;
+	SCP_string result_str;
 	while (voice_duration > 0) {
 		size_t run = fl2i(Distort_patterns[Distort_num][Distort_next] * len);
+		auto upper_limit = std::min(len, curr_offset + run);
+		auto num_chars = upper_limit - curr_offset;
 		if (Distort_next & 1) {
-			size_t i;
-			for ( i = curr_offset; i < MIN(len, curr_offset+run); i++ ) {
-				if ( text[i] != ' ' ) 
-					text[i] = '-';
+			for (size_t i = 0; i < num_chars; ++i, ++curr_iter) {
+				if (*curr_iter != UNICODE_CHAR(' ')) {
+					unicode::encode(UNICODE_CHAR('-'), std::back_inserter(result_str));
+				} else {
+					unicode::encode(UNICODE_CHAR(' '), std::back_inserter(result_str));
+				}
 			}
-			curr_offset = i;
-			if ( i >= len )
+
+			curr_offset += num_chars;
+			if ( upper_limit >= len )
 				break;
 		} else {
+			for (size_t i = 0; i < num_chars; ++i) {
+				unicode::encode(*curr_iter, std::back_inserter(result_str));
+				++curr_iter;
+			}
 			curr_offset += run;
 		}
 
@@ -2269,7 +2295,9 @@ void message_maybe_distort_text(char *text, int shipnum)
 		Distort_next++;
 		if ( Distort_next >= MAX_DISTORT_LEVELS )
 			Distort_next = 0;
-	};
+	}
+	Assertion(result_str.size() <= buffer_size, "Buffer after scrambling message is bigger than before!");
+	strcpy(text, result_str.c_str());
 	
 	Distort_next = 0;
 }

--- a/code/parse/parselo.cpp
+++ b/code/parse/parselo.cpp
@@ -3521,7 +3521,7 @@ int split_str(const char *src, int max_pixel_w, int *n_chars, const char **p_str
 	// as a line splitting point if necessary
 	unicode::codepoint_range range(src);
 	auto end_iter = std::end(range);
-	unicode::text_iterator iter = std::begin(range);
+	auto iter = std::begin(range);
 	for (; iter != end_iter; ++iter) {
 		auto cp = *iter;
 
@@ -3593,7 +3593,7 @@ int split_str(const char *src, int max_pixel_w, int *n_chars, const char **p_str
 
 			if (breakpoint) {
 				end = breakpoint;
-				iter = unicode::text_iterator(breakpoint, src);
+				iter = unicode::text_iterator(breakpoint, src, src + strlen(src));
 
 			} else {
 				end = iter.pos();  // force a split here since to whitespace
@@ -3646,7 +3646,7 @@ int split_str(const char *src, int max_pixel_w, SCP_vector<int> &n_chars, SCP_ve
 	// as a line splitting point if necessary
 	unicode::codepoint_range range(src);
 	auto end_iter = std::end(range);
-	unicode::text_iterator iter = std::begin(range);
+	auto iter = std::begin(range);
 	for (; iter != end_iter; ++iter) {
 		auto cp = *iter;
 
@@ -3716,7 +3716,7 @@ int split_str(const char *src, int max_pixel_w, SCP_vector<int> &n_chars, SCP_ve
 
 			if (breakpoint) {
 				end = breakpoint;
-				iter = unicode::text_iterator(breakpoint, src);
+				iter = unicode::text_iterator(breakpoint, src, src + strlen(src));
 
 			} else {
 				end = iter.pos();  // force a split here since to whitespace

--- a/code/utils/unicode.cpp
+++ b/code/utils/unicode.cpp
@@ -8,7 +8,15 @@ namespace unicode {
 text_iterator::text_iterator(const char* in_current_byte, const char* in_range_start_byte, const char* in_range_end_byte) :
 	current_byte(in_current_byte), range_end_byte(in_range_end_byte), range_start_byte(in_range_start_byte) {
 	if (range_end_byte == nullptr) {
-		range_end_byte = current_byte + strlen(current_byte);
+#if SCP_COMPILER_IS_GNU
+#pragma GCC diagnostic push
+// This suppresses a GCC bug where it thinks that in_current_byte is null in release builds
+#pragma GCC diagnostic ignored "-Wnonnull"
+#endif
+		range_end_byte = in_current_byte + strlen(in_current_byte);
+#if SCP_COMPILER_IS_GNU
+#pragma GCC diagnostic pop
+#endif
 	}
 }
 text_iterator& unicode::text_iterator::operator++() {
@@ -90,10 +98,28 @@ bool text_iterator::operator>=(const text_iterator& rhs) const {
 	return !(*this < rhs);
 }
 text_iterator text_iterator::operator+(ptrdiff_t diff) const {
-	return text_iterator(current_byte + diff, range_start_byte, range_end_byte);
+	if (diff < 0) {
+		// Use minus operator to avoid duplicating code
+		return operator-(-diff);
+	}
+
+	auto iter = *this;
+	for (ptrdiff_t i = 0; i < diff; ++i) {
+		++iter;
+	}
+	return iter;
 }
 text_iterator text_iterator::operator-(ptrdiff_t diff) const {
-	return text_iterator(current_byte - diff, range_start_byte, range_end_byte);
+	if (diff < 0) {
+		// Use plus operator to avoid duplicating code
+		return operator+(-diff);
+	}
+
+	auto iter = *this;
+	for (ptrdiff_t i = 0; i < diff; ++i) {
+		--iter;
+	}
+	return iter;
 }
 bool text_iterator::is_from_same_range(const text_iterator& other) const {
 	return range_start_byte == other.range_start_byte && range_end_byte == other.range_end_byte;


### PR DESCRIPTION
The code did not account for unicode escape sequences when inserting
scrambling characters which distorted the text and fequently caused
invalid UTF-8 sequences to appear in the text. This fixes that by
using the text iterators already present in the game code. I needed to
rewrite the logic of this block a bit since the previous logic could not
be converted to the way we need to handle unicode sequences at the
moment.

This fixes #1720.