### PR TITLE
Enable legacy config mode if legacy config is newer

### DIFF
--- a/code/cfile/cfile.cpp
+++ b/code/cfile/cfile.cpp
@@ -38,9 +38,6 @@
 
 char Cfile_root_dir[CFILE_ROOT_DIRECTORY_LEN] = "";
 char Cfile_user_dir[CFILE_ROOT_DIRECTORY_LEN] = "";
-#ifdef SCP_UNIX
-char Cfile_user_dir_legacy[CFILE_ROOT_DIRECTORY_LEN] = "";
-#endif
 
 // During cfile_init, verify that Pathtypes[n].index == n for each item
 // Each path must have a valid parent that can be tracable all the way back to the root 
@@ -226,12 +223,6 @@ int cfile_init(const char *exe_dir, const char *cdrom_dir)
 	// set root directory
 	strncpy(Cfile_root_dir, buf, CFILE_ROOT_DIRECTORY_LEN-1);
 	strncpy(Cfile_user_dir, os_get_config_path().c_str(), CFILE_ROOT_DIRECTORY_LEN-1);
-	
-#ifdef SCP_UNIX
-	// Initialize path of old pilot files
-	extern const char* Osreg_user_dir_legacy;
-	snprintf(Cfile_user_dir_legacy, CFILE_ROOT_DIRECTORY_LEN-1, "%s/%s/", getenv("HOME"), Osreg_user_dir_legacy);
-#endif
 
 	for (i = 0; i < MAX_CFILE_BLOCKS; i++) {
 		Cfile_block_list[i].type = CFILE_BLOCK_UNUSED;

--- a/code/cfile/cfile.h
+++ b/code/cfile/cfile.h
@@ -111,9 +111,6 @@ extern const char *Get_file_list_child;
 #define CFILE_ROOT_DIRECTORY_LEN			256
 extern char Cfile_root_dir[CFILE_ROOT_DIRECTORY_LEN];
 extern char Cfile_user_dir[CFILE_ROOT_DIRECTORY_LEN];
-#ifdef SCP_UNIX
-extern char Cfile_user_dir_legacy[CFILE_ROOT_DIRECTORY_LEN];
-#endif
 
 //================= LOW-LEVEL FUNCTIONS ==================
 int cfile_init(const char *exe_dir, const char *cdrom_dir=NULL);

--- a/code/cfile/cfilesystem.cpp
+++ b/code/cfile/cfilesystem.cpp
@@ -425,10 +425,10 @@ void cf_build_root_list(const char *cdrom_dir)
 #ifdef WIN32
 		// Nothing to do here, Windows uses the current directory as the base
 #else
-		cf_add_mod_roots(Cfile_user_dir_legacy);
+		cf_add_mod_roots(os_get_legacy_user_dir());
 
 		root = cf_create_root();
-		strncpy(root->path, Cfile_user_dir_legacy, CF_MAX_PATHNAME_LENGTH - 1);
+		strncpy(root->path, os_get_legacy_user_dir(), CF_MAX_PATHNAME_LENGTH - 1);
 
 		// do we already have a slash? as in the case of a root directory install
 		if ((strlen(root->path) < (CF_MAX_PATHNAME_LENGTH - 1)) && (root->path[strlen(root->path) - 1] != DIR_SEPARATOR_CHAR)) {

--- a/code/osapi/osapi.cpp
+++ b/code/osapi/osapi.cpp
@@ -7,20 +7,19 @@
  *
 */
 
-#include <cstdio>
 #include <fcntl.h>
-#include <cstdarg>
-#include <algorithm>
 
 #include "globalincs/pstypes.h"
 #include "gamesequence/gamesequence.h"
 #include "freespace.h"
-#include "osapi/osregistry.h"
-#include "cmdline/cmdline.h"
-#include "osapi/osapi.h"
+#include "parse/parselo.h"
 
-#include <fstream>
-#include <algorithm>
+#ifdef SCP_UNIX
+#include <sys/stat.h>
+#elif defined(WIN32)
+#include <sys/types.h>
+#include <sys/stat.h>
+#endif
 
 namespace
 {
@@ -205,6 +204,23 @@ static SCP_vector<SDL_Event> buffered_events;
 
 int Os_debugger_running = 0;
 
+#ifdef SCP_UNIX
+static bool user_dir_initialized = false;
+static SCP_string Os_user_dir_legacy;
+
+const char* os_get_legacy_user_dir() {
+	if (user_dir_initialized) {
+		return Os_user_dir_legacy.c_str();
+	}
+
+	extern const char* Osreg_user_dir_legacy;
+	sprintf(Os_user_dir_legacy, "%s/%s", getenv("HOME"), Osreg_user_dir_legacy);
+	user_dir_initialized = true;
+
+	return Os_user_dir_legacy.c_str();
+}
+#endif
+
 // ----------------------------------------------------------------------------------------------------
 // OSAPI FORWARD DECLARATIONS
 //
@@ -314,6 +330,25 @@ static bool file_exists(const SCP_string& path) {
 	return str.good();
 }
 
+static time_t get_file_modification_time(const SCP_string& path) {
+#ifdef SCP_UNIX
+	struct stat file_stats{};
+	if(stat(path.c_str(), &file_stats) < 0) {
+		return 0;
+	}
+
+	return file_stats.st_mtime;
+#elif defined(WIN32)
+	struct _stat buf{};
+	if (_stat(path.c_str(), &buf) != 0) {
+		return 0;
+	}
+	return buf.st_mtime;
+#else
+#error Unsupported platform!
+#endif
+}
+
 bool os_is_legacy_mode()
 {
 	// Make this check a little faster by caching the result
@@ -328,25 +363,52 @@ bool os_is_legacy_mode()
 		checkedLegacyMode = true;
 	}
 	else {
-		bool old_config_exists = false;
-		bool new_config_exists = false;
-
 		SCP_stringstream path_stream;
-		path_stream << getPreferencesPath() << DIR_SEPARATOR_CHAR << Osreg_config_file_name;
+		path_stream << getPreferencesPath() << Osreg_config_file_name;
 
-		new_config_exists = file_exists(path_stream.str());
+		auto new_config_exists = file_exists(path_stream.str());
+		time_t new_config_time = 0;
+		if (new_config_exists) {
+			new_config_time = get_file_modification_time(path_stream.str());
+		}
+
+		// Also check the modification times of the command line files in case the launcher did not change the settings
+		// file
+		path_stream.str("");
+		path_stream << getPreferencesPath() << "data" << DIR_SEPARATOR_CHAR << "cmdline_fso.cfg";
+		new_config_time = std::max(new_config_time, get_file_modification_time(path_stream.str()));
 #ifdef SCP_UNIX
         path_stream.str("");
-		path_stream << Cfile_user_dir_legacy << DIR_SEPARATOR_CHAR << Osreg_config_file_name;
+		path_stream << os_get_legacy_user_dir() << DIR_SEPARATOR_CHAR << Osreg_config_file_name;
 
-		old_config_exists = file_exists(path_stream.str());
+		auto old_config_exists = file_exists(path_stream.str());
+		time_t old_config_time = 0;
+		if (old_config_exists) {
+			old_config_time = get_file_modification_time(path_stream.str());
+		}
+
+		path_stream.str("");
+		path_stream << os_get_legacy_user_dir() << DIR_SEPARATOR_CHAR << "data" << DIR_SEPARATOR_CHAR
+					<< "cmdline_fso.cfg";
+		old_config_time = std::max(old_config_time, get_file_modification_time(path_stream.str()));
 #else
 		// At this point we can't determine if the old config exists so just assume that it does
-		old_config_exists = true;
+		auto old_config_exists = true;
+		time_t old_config_time = os_registry_get_last_modification_time();
+
+		// On Windows the cmdline_fso file was stored in the game root directory which should be in the current directory
+		path_stream.str("");
+		path_stream << "." << DIR_SEPARATOR_CHAR << "data" << DIR_SEPARATOR_CHAR << "cmdline_fso.cfg";
+		old_config_time = std::max(old_config_time, get_file_modification_time(path_stream.str()));
 #endif
 
-		if (new_config_exists) {
-			// If the new config exists then we never use the lagacy mode
+		if (new_config_exists && old_config_exists) {
+			// Both config files exists so we need to decide which to use based on their last modification times
+			// if the old config was modified more recently than the new config then we use the legacy mode since the
+			// user probably used an outdated launcher after using a more recent one
+			legacyMode = old_config_time > new_config_time;
+		} else if (new_config_exists) {
+			// If the new config exists and the old one doesn't then we can safely disable the legacy mode
 			legacyMode = false;
 		} else if (old_config_exists) {
 			// Old config exists but new doesn't -> use legacy mode

--- a/code/osapi/osapi.h
+++ b/code/osapi/osapi.h
@@ -36,6 +36,10 @@
 // set if running under MsDev - done after os_init(...) has returned
 extern int Os_debugger_running;
 
+#ifdef SCP_UNIX
+const char* os_get_legacy_user_dir();
+#endif
+
 // --------------------------------------------------------------------------------------------------
 // OSAPI FUNCTIONS
 //

--- a/code/osapi/osregistry.h
+++ b/code/osapi/osregistry.h
@@ -29,6 +29,9 @@ extern const char *Osreg_config_file_name;
 // REGISTRY FUNCTIONS
 //
 
+#ifdef WIN32
+time_t os_registry_get_last_modification_time();
+#endif
 
 // initialize the registry. setup default keys to use
 void os_init_registry_stuff( const char *company, const char *app);

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -1703,7 +1703,7 @@ void game_init()
 #endif
 
 	// init os stuff next
-	if ( !Is_standalone ) {		
+	if ( !Is_standalone ) {
 		os_init( Osreg_class_name, Window_title.c_str(), Osreg_app_name );
 	}
 	else {
@@ -7959,9 +7959,6 @@ int actual_main(int argc, char *argv[])
         SDL_free(path_name);
     }
 #endif
-
-	// create user's directory	
-	_mkdir(os_get_config_path().c_str());
 #endif
 
 #if defined(GAME_ERRORLOG_TXT) && defined(_MSC_VER)


### PR DESCRIPTION
There were some reports that using a newer launcher together with an
outdated launcher was causing some issues since the new launcher would
write the new config file which would cause FSO to ignore the changes of
the old launcher since the new config file already exists.

This fixes that by adding a check for when the config locations were
last modified. On Linux and Mac it checks when the old config locations
were modified last while on Windows it checks the registry to determine
if there was a change after the new config file was created.