### PR TITLE
Render hardpoint model outlines using geometry shaders

### DIFF
--- a/code/def_files/data/effects/main-f.sdr
+++ b/code/def_files/data/effects/main-f.sdr
@@ -33,7 +33,7 @@ layout (std140) uniform modelData {
 
 	model_light lights[MAX_LIGHTS];
 
-	float extrudeWidth;
+	float outlineWidth;
 	float fogStart;
 	float fogScale;
 	int buffer_matrix_offset;
@@ -426,6 +426,7 @@ void main()
 	// emissive colors won't be added later when we are using forward rendering so we need to do that here
 	baseColor.rgb += emissiveColor.rgb;
 #endif
+
 	fragOut0 = baseColor;
 #ifdef FLAG_DEFERRED
 	fragOut1 = vec4(vertIn.position.xyz, 1.0);

--- a/code/def_files/data/effects/main-g.sdr
+++ b/code/def_files/data/effects/main-g.sdr
@@ -1,9 +1,18 @@
 #extension GL_ARB_gpu_shader5: enable
 
+#ifdef FLAG_THICK_OUTLINE
+layout (triangles) in;
+// For every triangle line we generate 2 triangles which can be done with 4 vertices so in total we will need 12 vertices
+layout (triangle_strip, max_vertices = 12) out;
+#else
 layout (triangles) in;
 layout (triangle_strip, max_vertices = 3) out;
-#ifdef GL_ARB_gpu_shader5
+#endif
+
+#ifdef FLAG_SHADOW_MAP
+ #ifdef GL_ARB_gpu_shader5
 layout(invocations = 4) in;
+ #endif
 #endif
 
 #define MAX_LIGHTS 8
@@ -33,7 +42,7 @@ layout (std140) uniform modelData {
 
 	model_light lights[MAX_LIGHTS];
 
-	float extrudeWidth;
+	float outlineWidth;
 	float fogStart;
 	float fogScale;
 	int buffer_matrix_offset;
@@ -150,6 +159,7 @@ out VertexOutput {
 #endif
 } vertOut;
 
+#ifdef FLAG_SHADOW_MAP
 void main(void)
 {
 #ifdef GL_ARB_gpu_shader5
@@ -167,6 +177,7 @@ void main(void)
 		vertOut.texCoord = vertIn[vert].texCoord;
 
 		gl_Layer = instanceID;
+
 #ifdef FLAG_ENV_MAP
 		vertOut.envReflect = vertIn[vert].envReflect;
 #endif
@@ -199,3 +210,68 @@ void main(void)
 	}
 	EndPrimitive();
 }
+#elif defined(FLAG_THICK_OUTLINE)
+const vec2 pixelOffsetDir[4] = vec2[](
+	vec2(0.0, 1.0),
+	vec2(1.0, 1.0),
+	vec2(1.0, -1.0),
+	vec2(0.0, -1.0)
+);
+void main(void)
+{
+	for(int vert = 0; vert < gl_in.length(); vert++)
+	{
+		int nextVert = (vert + 1) % gl_in.length();
+		vec4 clip = gl_in[vert].gl_Position;
+		vec4 diff = gl_in[nextVert].gl_Position - clip; // vector from vert to the next vertex in the list
+		vec2 normal = normalize(vec2(diff.y, -diff.x)); // Computing the normal of a 2D vector is actually rather simple...
+		for (int lineVert = 0; lineVert < 4; ++lineVert)
+		{
+			// This is the pixel offset along the normal axis
+			vec2 yOffPixel = pixelOffsetDir[lineVert].y * normal * (outlineWidth / 2.0);
+			// This is the offset of the vertex along the vector between this vertex and the next one in the triangle
+			vec2 xOff = pixelOffsetDir[lineVert].x * diff.xy;
+
+			// This is the final offset in clip space
+			vec2 finalOffset = xOff + yOffPixel * vec2(vpwidth, vpheight) * clip.w;
+
+			gl_Position = vec4(clip.xyz + vec3(finalOffset, 0.0), clip.w);
+			vertOut.position = vertIn[vert].position;
+			vertOut.normal = vertIn[vert].normal;
+			vertOut.texCoord = vertIn[vert].texCoord;
+
+#ifdef FLAG_ENV_MAP
+			vertOut.envReflect = vertIn[vert].envReflect;
+#endif
+#ifdef FLAG_NORMAL_MAP
+			vertOut.tangentMatrix = vertIn[vert].tangentMatrix;
+#endif
+#ifdef FLAG_FOG
+			vertOut.fogDist = vertIn[vert].fogDist;
+#endif
+#ifdef FLAG_SHADOWS
+			vertOut.shadowUV[0] = vertIn[vert].shadowUV[0];
+			vertOut.shadowUV[1] = vertIn[vert].shadowUV[1];
+			vertOut.shadowUV[2] = vertIn[vert].shadowUV[2];
+			vertOut.shadowUV[3] = vertIn[vert].shadowUV[3];
+			vertOut.shadowPos = vertIn[vert].shadowPos;
+#endif
+#ifdef WORKAROUND_CLIPPING_PLANES
+ #ifdef FLAG_TRANSFORM
+			vertOut.notVisible = vertIn[vert].notVisible;
+ #endif
+ #ifdef FLAG_CLIP
+			gl_ClipDistance[0] = gl_in[vert].gl_ClipDistance[0];
+ #endif
+#else
+ #if defined(FLAG_CLIP) || defined(FLAG_TRANSFORM)
+			gl_ClipDistance[0] = gl_in[vert].gl_ClipDistance[0];
+ #endif
+#endif
+			EmitVertex();
+		}
+
+		EndPrimitive();
+	}
+}
+#endif

--- a/code/def_files/data/effects/main-v.sdr
+++ b/code/def_files/data/effects/main-v.sdr
@@ -36,7 +36,7 @@ layout (std140) uniform modelData {
 
 	model_light lights[MAX_LIGHTS];
 
-	float extrudeWidth;
+	float outlineWidth;
 	float fogStart;
 	float fogScale;
 	int buffer_matrix_offset;
@@ -187,9 +187,6 @@ void main()
   #endif
  #else
 	gl_Position = projMatrix * position;
- #endif
- #ifdef FLAG_NORMAL_EXTRUDE
-	gl_Position.xy += (mat3(projMatrix) * normal.xyz).xy * gl_Position.z * extrudeWidth;
  #endif
  #ifdef FLAG_SHADOWS
 	vec4 shadowPos = shadow_mv_matrix * modelMatrix * orient * vertPosition;

--- a/code/graphics/2d.h
+++ b/code/graphics/2d.h
@@ -186,7 +186,7 @@ enum shader_type {
 #define SDR_FLAG_MODEL_HDR			(1<<18)
 #define SDR_FLAG_MODEL_AMBIENT_MAP	(1<<19)
 #define SDR_FLAG_MODEL_NORMAL_ALPHA	(1<<20)
-#define SDR_FLAG_MODEL_NORMAL_EXTRUDE (1<<21)
+#define SDR_FLAG_MODEL_THICK_OUTLINES (1<<21) // Renders the model geometry as an outline with configurable line width
 
 #define SDR_FLAG_PARTICLE_POINT_GEN			(1<<0)
 

--- a/code/graphics/material.cpp
+++ b/code/graphics/material.cpp
@@ -635,27 +635,6 @@ float model_material::get_normal_alpha_max() const
 	return Normal_alpha_max;
 }
 
-void model_material::set_normal_extrude(float width)
-{
-	Normal_extrude = true;
-	Normal_extrude_width = width;
-}
-
-void model_material::set_normal_extrude()
-{
-	Normal_extrude = false;
-}
-
-bool model_material::is_normal_extrude_active() const
-{
-	return Normal_extrude;
-}
-
-float model_material::get_normal_extrude_width() const
-{
-	return Normal_extrude_width;
-}
-
 void model_material::set_fog(int r, int g, int b, float _near, float _far)
 {
 	Fog_params.enabled = true;
@@ -679,6 +658,16 @@ bool model_material::is_fogged() const
 const model_material::fog& model_material::get_fog() const
 {
 	return Fog_params;
+}
+
+void model_material::set_outline_thickness(float thickness) {
+	Outline_thickness = thickness;
+}
+float model_material::get_outline_thickness() const {
+	return Outline_thickness;
+}
+bool model_material::uses_thick_outlines() const {
+	return Outline_thickness > 0.0f;
 }
 
 uint model_material::get_shader_flags() const
@@ -768,8 +757,8 @@ uint model_material::get_shader_flags() const
 		Shader_flags |= SDR_FLAG_MODEL_NORMAL_ALPHA;
 	}
 
-	if ( Normal_extrude ) {
-		Shader_flags |= SDR_FLAG_MODEL_NORMAL_EXTRUDE;
+	if ( uses_thick_outlines() ) {
+		Shader_flags |= SDR_FLAG_MODEL_THICK_OUTLINES;
 	}
 
 	return Shader_flags;

--- a/code/graphics/material.h
+++ b/code/graphics/material.h
@@ -200,10 +200,10 @@ class model_material : public material
 	float Normal_alpha_min = 0.0f;
 	float Normal_alpha_max = 1.0f;
 
-	bool Normal_extrude = false;
-	float Normal_extrude_width = -1.0f;
-
 	fog Fog_params;
+
+	float Outline_thickness = -1.0f;
+
 public:
 	model_material();
 
@@ -246,10 +246,9 @@ public:
 	float get_normal_alpha_min() const;
 	float get_normal_alpha_max() const;
 
-	void set_normal_extrude(float width);
-	void set_normal_extrude();
-	bool is_normal_extrude_active() const;
-	float get_normal_extrude_width() const;
+	void set_outline_thickness(float thickness = -1.0f);
+	float get_outline_thickness() const;
+	bool uses_thick_outlines() const;
 
 	void set_batching(bool enabled);
 	bool is_batched() const;

--- a/code/graphics/opengl/gropengl.cpp
+++ b/code/graphics/opengl/gropengl.cpp
@@ -29,6 +29,7 @@
 #include "math/floating.h"
 #include "model/model.h"
 #include "nebula/neb.h"
+#include "libs/renderdoc/renderdoc.h"
 #include "osapi/osapi.h"
 #include "osapi/osregistry.h"
 #include "render/3d.h"
@@ -1389,6 +1390,9 @@ bool gr_opengl_init(std::unique_ptr<os::GraphicsOperations>&& graphicsOps)
 		  gr_screen.max_w,
 		  gr_screen.max_h,
 		  gr_screen.bits_per_pixel ));
+
+	// Load the RenderDoc API if available before doing anything with OpenGL
+	renderdoc::loadApi();
 
 	graphic_operations = std::move(graphicsOps);
 

--- a/code/graphics/uniforms.cpp
+++ b/code/graphics/uniforms.cpp
@@ -47,11 +47,11 @@ void convert_model_material(model_uniform_data* data_out,
 
 	data_out->color = material.get_color();
 
+	data_out->vpwidth = 1.0f / i2fl(gr_screen.max_w);
+	data_out->vpheight = 1.0f / i2fl(gr_screen.max_h);
 	if (shader_flags & SDR_FLAG_MODEL_ANIMATED) {
 		data_out->anim_timer = material.get_animated_effect_time();
 		data_out->effect_num = material.get_animated_effect();
-		data_out->vpwidth = 1.0f / i2fl(gr_screen.max_w);
-		data_out->vpheight = 1.0f / i2fl(gr_screen.max_h);
 	}
 
 	if (shader_flags & SDR_FLAG_MODEL_CLIP) {
@@ -267,8 +267,8 @@ void convert_model_material(model_uniform_data* data_out,
 		data_out->normalAlphaMinMax.y = material.get_normal_alpha_max();
 	}
 
-	if (shader_flags & SDR_FLAG_MODEL_NORMAL_EXTRUDE) {
-		data_out->extrudeWidth = material.get_normal_extrude_width();
+	if ( shader_flags & SDR_FLAG_MODEL_THICK_OUTLINES ) {
+		data_out->outlineWidth = material.get_outline_thickness();
 	}
 }
 

--- a/code/graphics/util/uniform_structs.h
+++ b/code/graphics/util/uniform_structs.h
@@ -80,7 +80,7 @@ struct model_uniform_data {
 
 	model_light lights[MAX_UNIFORM_LIGHTS];
 
-	float extrudeWidth;
+	float outlineWidth;
 	float fogStart;
 	float fogScale;
 	int buffer_matrix_offset;

--- a/code/hud/hudtarget.cpp
+++ b/code/hud/hudtarget.cpp
@@ -37,6 +37,7 @@
 #include "network/multi.h"
 #include "network/multiutil.h"
 #include "object/object.h"
+#include "libs/renderdoc/renderdoc.h"
 #include "parse/parselo.h"
 #include "playerman/player.h"
 #include "render/3dinternal.h"
@@ -7194,7 +7195,8 @@ void HudGaugeHardpoints::render(float  /*frametime*/)
 
 	render_info.set_color(gauge_color);
 	render_info.set_flags(MR_NO_LIGHTING | MR_AUTOCENTER | MR_NO_FOGGING | MR_NO_TEXTURING | MR_NO_ZBUFFER | MR_NO_CULL | MR_STENCIL_READ);
-	render_info.set_normal_extrude_width(_line_width * 0.01f);
+	// Factor was chosen pretty arbitrarily to make outline feature work with existing data
+	render_info.set_outline_thickness(15.f * _line_width);
 
 	model_render_immediate(
 		&render_info,

--- a/code/libs/renderdoc/renderdoc.cpp
+++ b/code/libs/renderdoc/renderdoc.cpp
@@ -1,0 +1,83 @@
+
+#include "renderdoc.h"
+#include "renderdoc_app.h"
+
+#include "globalincs/pstypes.h"
+
+#ifdef SCP_UNIX
+#include <dlfcn.h>
+#endif
+
+namespace {
+bool api_loaded = false;
+RENDERDOC_API_1_1_1* api = nullptr;
+
+pRENDERDOC_GetAPI load_getAPI() {
+#ifdef SCP_UNIX
+	auto handle = dlopen("librenderdoc.so", RTLD_NOLOAD);
+	auto symbol = dlsym(handle, "RENDERDOC_GetAPI");
+
+	if (handle != nullptr) {
+		dlclose(handle);
+	}
+
+	return (pRENDERDOC_GetAPI)symbol;
+#else
+	// Renderdoc API loading is not implemented for this platform yet!
+	return nullptr;
+#endif
+}
+
+}
+
+namespace renderdoc {
+
+bool loadApi() {
+	if (api_loaded) {
+		return true;
+	}
+
+	auto getAPI = load_getAPI();
+
+	if (getAPI == nullptr) {
+		return false;
+	}
+
+	auto res = getAPI(eRENDERDOC_API_Version_1_1_1, reinterpret_cast<void**>(&api));
+
+	if (res != 1) {
+		return false;
+	}
+
+	api_loaded = true;
+
+	return true;
+}
+
+void triggerCapture() {
+	if (!api_loaded) {
+		// Do nothing if API is not available
+		return;
+	}
+
+	api->TriggerCapture();
+}
+void startCapture() {
+	if (api_loaded) {
+		api->StartFrameCapture(nullptr, nullptr);
+	}
+}
+bool isCapturing() {
+	if (api_loaded) {
+		return api->IsFrameCapturing() == 1;
+	}
+
+	return false;
+}
+void endCapture() {
+	if (api_loaded) {
+		api->EndFrameCapture(nullptr, nullptr);
+	}
+}
+
+}

--- a/code/libs/renderdoc/renderdoc.h
+++ b/code/libs/renderdoc/renderdoc.h
@@ -1,0 +1,15 @@
+#pragma once
+
+namespace renderdoc {
+
+bool loadApi();
+
+void triggerCapture();
+
+void startCapture();
+
+bool isCapturing();
+
+void endCapture();
+
+}

--- a/code/libs/renderdoc/renderdoc_app.h
+++ b/code/libs/renderdoc/renderdoc_app.h
@@ -1,0 +1,617 @@
+/******************************************************************************
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2017 Baldur Karlsson
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ ******************************************************************************/
+
+#pragma once
+
+//////////////////////////////////////////////////////////////////////////////////////////////////
+//
+// Documentation for the API is available at https://renderdoc.org/docs/in_application_api.html
+//
+
+#if !defined(RENDERDOC_NO_STDINT)
+#include <cstdint>
+#endif
+
+#if defined(WIN32)
+#define RENDERDOC_CC __cdecl
+#elif defined(__linux__)
+#define RENDERDOC_CC
+#elif defined(__APPLE__)
+#define RENDERDOC_CC
+#else
+#error "Unknown platform"
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+//////////////////////////////////////////////////////////////////////////////////////////////////
+// Constants not used directly in below API
+
+// This is a GUID/magic value used for when applications pass a path where shader debug
+// information can be found to match up with a stripped shader.
+// the define can be used like so: const GUID RENDERDOC_ShaderDebugMagicValue =
+// RENDERDOC_ShaderDebugMagicValue_value
+#define RENDERDOC_ShaderDebugMagicValue_struct                                \
+  {                                                                           \
+    0xeab25520, 0x6670, 0x4865, 0x84, 0x29, 0x6c, 0x8, 0x51, 0x54, 0x00, 0xff \
+  }
+
+// as an alternative when you want a byte array (assuming x86 endianness):
+#define RENDERDOC_ShaderDebugMagicValue_bytearray                                                 \
+  {                                                                                               \
+    0x20, 0x55, 0xb2, 0xea, 0x70, 0x66, 0x65, 0x48, 0x84, 0x29, 0x6c, 0x8, 0x51, 0x54, 0x00, 0xff \
+  }
+
+// truncated version when only a uint64_t is available (e.g. Vulkan tags):
+#define RENDERDOC_ShaderDebugMagicValue_truncated 0x48656670eab25520ULL
+
+//////////////////////////////////////////////////////////////////////////////////////////////////
+// RenderDoc capture options
+//
+
+typedef enum {
+  // Allow the application to enable vsync
+  //
+  // Default - enabled
+  //
+  // 1 - The application can enable or disable vsync at will
+  // 0 - vsync is force disabled
+  eRENDERDOC_Option_AllowVSync = 0,
+
+  // Allow the application to enable fullscreen
+  //
+  // Default - enabled
+  //
+  // 1 - The application can enable or disable fullscreen at will
+  // 0 - fullscreen is force disabled
+  eRENDERDOC_Option_AllowFullscreen = 1,
+
+  // Record API debugging events and messages
+  //
+  // Default - disabled
+  //
+  // 1 - Enable built-in API debugging features and records the results into
+  //     the capture logfile, which is matched up with events on replay
+  // 0 - no API debugging is forcibly enabled
+  eRENDERDOC_Option_APIValidation = 2,
+  eRENDERDOC_Option_DebugDeviceMode = 2,    // deprecated name of this enum
+
+  // Capture CPU callstacks for API events
+  //
+  // Default - disabled
+  //
+  // 1 - Enables capturing of callstacks
+  // 0 - no callstacks are captured
+  eRENDERDOC_Option_CaptureCallstacks = 3,
+
+  // When capturing CPU callstacks, only capture them from drawcalls.
+  // This option does nothing without the above option being enabled
+  //
+  // Default - disabled
+  //
+  // 1 - Only captures callstacks for drawcall type API events.
+  //     Ignored if CaptureCallstacks is disabled
+  // 0 - Callstacks, if enabled, are captured for every event.
+  eRENDERDOC_Option_CaptureCallstacksOnlyDraws = 4,
+
+  // Specify a delay in seconds to wait for a debugger to attach, after
+  // creating or injecting into a process, before continuing to allow it to run.
+  //
+  // 0 indicates no delay, and the process will run immediately after injection
+  //
+  // Default - 0 seconds
+  //
+  eRENDERDOC_Option_DelayForDebugger = 5,
+
+  // Verify any writes to mapped buffers, by checking the memory after the
+  // bounds of the returned pointer to detect any modification.
+  //
+  // Default - disabled
+  //
+  // 1 - Verify any writes to mapped buffers
+  // 0 - No verification is performed, and overwriting bounds may cause
+  //     crashes or corruption in RenderDoc
+  eRENDERDOC_Option_VerifyMapWrites = 6,
+
+  // Hooks any system API calls that create child processes, and injects
+  // RenderDoc into them recursively with the same options.
+  //
+  // Default - disabled
+  //
+  // 1 - Hooks into spawned child processes
+  // 0 - Child processes are not hooked by RenderDoc
+  eRENDERDOC_Option_HookIntoChildren = 7,
+
+  // By default RenderDoc only includes resources in the final logfile necessary
+  // for that frame, this allows you to override that behaviour.
+  //
+  // Default - disabled
+  //
+  // 1 - all live resources at the time of capture are included in the log
+  //     and available for inspection
+  // 0 - only the resources referenced by the captured frame are included
+  eRENDERDOC_Option_RefAllResources = 8,
+
+  // By default RenderDoc skips saving initial states for resources where the
+  // previous contents don't appear to be used, assuming that writes before
+  // reads indicate previous contents aren't used.
+  //
+  // Default - disabled
+  //
+  // 1 - initial contents at the start of each captured frame are saved, even if
+  //     they are later overwritten or cleared before being used.
+  // 0 - unless a read is detected, initial contents will not be saved and will
+  //     appear as black or empty data.
+  eRENDERDOC_Option_SaveAllInitials = 9,
+
+  // In APIs that allow for the recording of command lists to be replayed later,
+  // RenderDoc may choose to not capture command lists before a frame capture is
+  // triggered, to reduce overheads. This means any command lists recorded once
+  // and replayed many times will not be available and may cause a failure to
+  // capture.
+  //
+  // Note this is only true for APIs where multithreading is difficult or
+  // discouraged. Newer APIs like Vulkan and D3D12 will ignore this option
+  // and always capture all command lists since the API is heavily oriented
+  // around it and the overheads have been reduced by API design.
+  //
+  // 1 - All command lists are captured from the start of the application
+  // 0 - Command lists are only captured if their recording begins during
+  //     the period when a frame capture is in progress.
+  eRENDERDOC_Option_CaptureAllCmdLists = 10,
+
+  // Mute API debugging output when the API validation mode option is enabled
+  //
+  // Default - enabled
+  //
+  // 1 - Mute any API debug messages from being displayed or passed through
+  // 0 - API debugging is displayed as normal
+  eRENDERDOC_Option_DebugOutputMute = 11,
+
+} RENDERDOC_CaptureOption;
+
+// Sets an option that controls how RenderDoc behaves on capture.
+//
+// Returns 1 if the option and value are valid
+// Returns 0 if either is invalid and the option is unchanged
+typedef int(RENDERDOC_CC *pRENDERDOC_SetCaptureOptionU32)(RENDERDOC_CaptureOption opt, uint32_t val);
+typedef int(RENDERDOC_CC *pRENDERDOC_SetCaptureOptionF32)(RENDERDOC_CaptureOption opt, float val);
+
+// Gets the current value of an option as a uint32_t
+//
+// If the option is invalid, 0xffffffff is returned
+typedef uint32_t(RENDERDOC_CC *pRENDERDOC_GetCaptureOptionU32)(RENDERDOC_CaptureOption opt);
+
+// Gets the current value of an option as a float
+//
+// If the option is invalid, -FLT_MAX is returned
+typedef float(RENDERDOC_CC *pRENDERDOC_GetCaptureOptionF32)(RENDERDOC_CaptureOption opt);
+
+typedef enum {
+  // '0' - '9' matches ASCII values
+  eRENDERDOC_Key_0 = 0x30,
+  eRENDERDOC_Key_1 = 0x31,
+  eRENDERDOC_Key_2 = 0x32,
+  eRENDERDOC_Key_3 = 0x33,
+  eRENDERDOC_Key_4 = 0x34,
+  eRENDERDOC_Key_5 = 0x35,
+  eRENDERDOC_Key_6 = 0x36,
+  eRENDERDOC_Key_7 = 0x37,
+  eRENDERDOC_Key_8 = 0x38,
+  eRENDERDOC_Key_9 = 0x39,
+
+  // 'A' - 'Z' matches ASCII values
+  eRENDERDOC_Key_A = 0x41,
+  eRENDERDOC_Key_B = 0x42,
+  eRENDERDOC_Key_C = 0x43,
+  eRENDERDOC_Key_D = 0x44,
+  eRENDERDOC_Key_E = 0x45,
+  eRENDERDOC_Key_F = 0x46,
+  eRENDERDOC_Key_G = 0x47,
+  eRENDERDOC_Key_H = 0x48,
+  eRENDERDOC_Key_I = 0x49,
+  eRENDERDOC_Key_J = 0x4A,
+  eRENDERDOC_Key_K = 0x4B,
+  eRENDERDOC_Key_L = 0x4C,
+  eRENDERDOC_Key_M = 0x4D,
+  eRENDERDOC_Key_N = 0x4E,
+  eRENDERDOC_Key_O = 0x4F,
+  eRENDERDOC_Key_P = 0x50,
+  eRENDERDOC_Key_Q = 0x51,
+  eRENDERDOC_Key_R = 0x52,
+  eRENDERDOC_Key_S = 0x53,
+  eRENDERDOC_Key_T = 0x54,
+  eRENDERDOC_Key_U = 0x55,
+  eRENDERDOC_Key_V = 0x56,
+  eRENDERDOC_Key_W = 0x57,
+  eRENDERDOC_Key_X = 0x58,
+  eRENDERDOC_Key_Y = 0x59,
+  eRENDERDOC_Key_Z = 0x5A,
+
+  // leave the rest of the ASCII range free
+  // in case we want to use it later
+  eRENDERDOC_Key_NonPrintable = 0x100,
+
+  eRENDERDOC_Key_Divide,
+  eRENDERDOC_Key_Multiply,
+  eRENDERDOC_Key_Subtract,
+  eRENDERDOC_Key_Plus,
+
+  eRENDERDOC_Key_F1,
+  eRENDERDOC_Key_F2,
+  eRENDERDOC_Key_F3,
+  eRENDERDOC_Key_F4,
+  eRENDERDOC_Key_F5,
+  eRENDERDOC_Key_F6,
+  eRENDERDOC_Key_F7,
+  eRENDERDOC_Key_F8,
+  eRENDERDOC_Key_F9,
+  eRENDERDOC_Key_F10,
+  eRENDERDOC_Key_F11,
+  eRENDERDOC_Key_F12,
+
+  eRENDERDOC_Key_Home,
+  eRENDERDOC_Key_End,
+  eRENDERDOC_Key_Insert,
+  eRENDERDOC_Key_Delete,
+  eRENDERDOC_Key_PageUp,
+  eRENDERDOC_Key_PageDn,
+
+  eRENDERDOC_Key_Backspace,
+  eRENDERDOC_Key_Tab,
+  eRENDERDOC_Key_PrtScrn,
+  eRENDERDOC_Key_Pause,
+
+  eRENDERDOC_Key_Max,
+} RENDERDOC_InputButton;
+
+// Sets which key or keys can be used to toggle focus between multiple windows
+//
+// If keys is NULL or num is 0, toggle keys will be disabled
+typedef void(RENDERDOC_CC *pRENDERDOC_SetFocusToggleKeys)(RENDERDOC_InputButton *keys, int num);
+
+// Sets which key or keys can be used to capture the next frame
+//
+// If keys is NULL or num is 0, captures keys will be disabled
+typedef void(RENDERDOC_CC *pRENDERDOC_SetCaptureKeys)(RENDERDOC_InputButton *keys, int num);
+
+typedef enum {
+  // This single bit controls whether the overlay is enabled or disabled globally
+  eRENDERDOC_Overlay_Enabled = 0x1,
+
+  // Show the average framerate over several seconds as well as min/max
+  eRENDERDOC_Overlay_FrameRate = 0x2,
+
+  // Show the current frame number
+  eRENDERDOC_Overlay_FrameNumber = 0x4,
+
+  // Show a list of recent captures, and how many captures have been made
+  eRENDERDOC_Overlay_CaptureList = 0x8,
+
+  // Default values for the overlay mask
+  eRENDERDOC_Overlay_Default = (eRENDERDOC_Overlay_Enabled | eRENDERDOC_Overlay_FrameRate |
+                                eRENDERDOC_Overlay_FrameNumber | eRENDERDOC_Overlay_CaptureList),
+
+  // Enable all bits
+  eRENDERDOC_Overlay_All = ~0U,
+
+  // Disable all bits
+  eRENDERDOC_Overlay_None = 0,
+} RENDERDOC_OverlayBits;
+
+// returns the overlay bits that have been set
+typedef uint32_t(RENDERDOC_CC *pRENDERDOC_GetOverlayBits)();
+// sets the overlay bits with an and & or mask
+typedef void(RENDERDOC_CC *pRENDERDOC_MaskOverlayBits)(uint32_t And, uint32_t Or);
+
+// this function will attempt to shut down RenderDoc.
+//
+// Note: that this will only work correctly if done immediately after
+// the dll is loaded, before any API work happens. RenderDoc will remove its
+// injected hooks and shut down. Behaviour is undefined if this is called
+// after any API functions have been called.
+typedef void(RENDERDOC_CC *pRENDERDOC_Shutdown)();
+
+// This function will unload RenderDoc's crash handler.
+//
+// If you use your own crash handler and don't want RenderDoc's handler to
+// intercede, you can call this function to unload it and any unhandled
+// exceptions will pass to the next handler.
+typedef void(RENDERDOC_CC *pRENDERDOC_UnloadCrashHandler)();
+
+// Sets the logfile path template
+//
+// logfile is a UTF-8 string that gives a template for how captures will be named
+// and where they will be saved.
+//
+// Any extension is stripped off the path, and captures are saved in the directory
+// specified, and named with the filename and the frame number appended. If the
+// directory does not exist it will be created, including any parent directories.
+//
+// If pathtemplate is NULL, the template will remain unchanged
+//
+// Example:
+//
+// SetLogFilePathTemplate("my_captures/example");
+//
+// Capture #1 -> my_captures/example_frame123.rdc
+// Capture #2 -> my_captures/example_frame456.rdc
+typedef void(RENDERDOC_CC *pRENDERDOC_SetLogFilePathTemplate)(const char *pathtemplate);
+
+// returns the current logfile template, see SetLogFileTemplate above, as a UTF-8 string
+typedef const char *(RENDERDOC_CC *pRENDERDOC_GetLogFilePathTemplate)();
+
+// returns the number of captures that have been made
+typedef uint32_t(RENDERDOC_CC *pRENDERDOC_GetNumCaptures)();
+
+// This function returns the details of a capture, by index. New captures are added
+// to the end of the list.
+//
+// logfile will be filled with the absolute path to the capture file, as a UTF-8 string
+// pathlength will be written with the length in bytes of the logfile string
+// timestamp will be written with the time of the capture, in seconds since the Unix epoch
+//
+// Any of the parameters can be NULL and they'll be skipped.
+//
+// The function will return 1 if the capture index is valid, or 0 if the index is invalid
+// If the index is invalid, the values will be unchanged
+//
+// Note: when captures are deleted in the UI they will remain in this list, so the
+// logfile path may not exist anymore.
+typedef uint32_t(RENDERDOC_CC *pRENDERDOC_GetCapture)(uint32_t idx, char *logfile,
+                                                      uint32_t *pathlength, uint64_t *timestamp);
+
+// returns 1 if the RenderDoc UI is connected to this application, 0 otherwise
+// This was renamed to IsTargetControlConnected in API 1.1.1, the old typedef is kept here for
+// backwards compatibility with old code, it is castable either way since it's ABI compatible
+// as the same function pointer type.
+typedef uint32_t(RENDERDOC_CC *pRENDERDOC_IsRemoteAccessConnected)();
+typedef uint32_t(RENDERDOC_CC *pRENDERDOC_IsTargetControlConnected)();
+
+// This function will launch the Replay UI associated with the RenderDoc library injected
+// into the running application.
+//
+// if connectTargetControl is 1, the Replay UI will be launched with a command line parameter
+// to connect to this application
+// cmdline is the rest of the command line, as a UTF-8 string. E.g. a captures to open
+// if cmdline is NULL, the command line will be empty.
+//
+// returns the PID of the replay UI if successful, 0 if not successful.
+typedef uint32_t(RENDERDOC_CC *pRENDERDOC_LaunchReplayUI)(uint32_t connectTargetControl,
+                                                          const char *cmdline);
+
+// RenderDoc can return a higher version than requested if it's backwards compatible,
+// this function returns the actual version returned. If a parameter is NULL, it will be
+// ignored and the others will be filled out.
+typedef void(RENDERDOC_CC *pRENDERDOC_GetAPIVersion)(int *major, int *minor, int *patch);
+
+//////////////////////////////////////////////////////////////////////////
+// Capturing functions
+//
+
+// A device pointer is a pointer to the API's root handle.
+//
+// This would be an ID3D11Device, HGLRC/GLXContext, ID3D12Device, etc
+typedef void *RENDERDOC_DevicePointer;
+
+// A window handle is the OS's native window handle
+//
+// This would be an HWND, GLXDrawable, etc
+typedef void *RENDERDOC_WindowHandle;
+
+// This sets the RenderDoc in-app overlay in the API/window pair as 'active' and it will
+// respond to keypresses. Neither parameter can be NULL
+typedef void(RENDERDOC_CC *pRENDERDOC_SetActiveWindow)(RENDERDOC_DevicePointer device,
+                                                       RENDERDOC_WindowHandle wndHandle);
+
+// capture the next frame on whichever window and API is currently considered active
+typedef void(RENDERDOC_CC *pRENDERDOC_TriggerCapture)();
+
+// capture the next N frames on whichever window and API is currently considered active
+typedef void(RENDERDOC_CC *pRENDERDOC_TriggerMultiFrameCapture)(uint32_t numFrames);
+
+// When choosing either a device pointer or a window handle to capture, you can pass NULL.
+// Passing NULL specifies a 'wildcard' match against anything. This allows you to specify
+// any API rendering to a specific window, or a specific API instance rendering to any window,
+// or in the simplest case of one window and one API, you can just pass NULL for both.
+//
+// In either case, if there are two or more possible matching (device,window) pairs it
+// is undefined which one will be captured.
+//
+// Note: for headless rendering you can pass NULL for the window handle and either specify
+// a device pointer or leave it NULL as above.
+
+// Immediately starts capturing API calls on the specified device pointer and window handle.
+//
+// If there is no matching thing to capture (e.g. no supported API has been initialised),
+// this will do nothing.
+//
+// The results are undefined (including crashes) if two captures are started overlapping,
+// even on separate devices and/oror windows.
+typedef void(RENDERDOC_CC *pRENDERDOC_StartFrameCapture)(RENDERDOC_DevicePointer device,
+                                                         RENDERDOC_WindowHandle wndHandle);
+
+// Returns whether or not a frame capture is currently ongoing anywhere.
+//
+// This will return 1 if a capture is ongoing, and 0 if there is no capture running
+typedef uint32_t(RENDERDOC_CC *pRENDERDOC_IsFrameCapturing)();
+
+// Ends capturing immediately.
+//
+// This will return 1 if the capture succeeded, and 0 if there was an error capturing.
+typedef uint32_t(RENDERDOC_CC *pRENDERDOC_EndFrameCapture)(RENDERDOC_DevicePointer device,
+                                                           RENDERDOC_WindowHandle wndHandle);
+
+//////////////////////////////////////////////////////////////////////////////////////////////////
+// RenderDoc API versions
+//
+
+// RenderDoc uses semantic versioning (http://semver.org/).
+//
+// MAJOR version is incremented when incompatible API changes happen.
+// MINOR version is incremented when functionality is added in a backwards-compatible manner.
+// PATCH version is incremented when backwards-compatible bug fixes happen.
+//
+// Note that this means the API returned can be higher than the one you might have requested.
+// e.g. if you are running against a newer RenderDoc that supports 1.0.1, it will be returned
+// instead of 1.0.0. You can check this with the GetAPIVersion entry point
+typedef enum {
+  eRENDERDOC_API_Version_1_0_0 = 10000,    // RENDERDOC_API_1_0_0 = 1 00 00
+  eRENDERDOC_API_Version_1_0_1 = 10001,    // RENDERDOC_API_1_0_1 = 1 00 01
+  eRENDERDOC_API_Version_1_0_2 = 10002,    // RENDERDOC_API_1_0_2 = 1 00 02
+  eRENDERDOC_API_Version_1_1_0 = 10100,    // RENDERDOC_API_1_1_0 = 1 01 00
+  eRENDERDOC_API_Version_1_1_1 = 10101,    // RENDERDOC_API_1_1_1 = 1 01 01
+} RENDERDOC_Version;
+
+// API version changelog:
+//
+// 1.0.0 - initial release
+// 1.0.1 - Bugfix: IsFrameCapturing() was returning false for captures that were triggered
+//         by keypress or TriggerCapture, instead of Start/EndFrameCapture.
+// 1.0.2 - Refactor: Renamed eRENDERDOC_Option_DebugDeviceMode to eRENDERDOC_Option_APIValidation
+// 1.1.0 - Add feature: TriggerMultiFrameCapture(). Backwards compatible with 1.0.x since the new
+//         function pointer is added to the end of the struct, the original layout is identical
+// 1.1.1 - Refactor: Renamed remote access to target control (to better disambiguate from remote
+//         replay/remote server concept in replay UI)
+
+// eRENDERDOC_API_Version_1_1_0
+typedef struct
+{
+  pRENDERDOC_GetAPIVersion GetAPIVersion;
+
+  pRENDERDOC_SetCaptureOptionU32 SetCaptureOptionU32;
+  pRENDERDOC_SetCaptureOptionF32 SetCaptureOptionF32;
+
+  pRENDERDOC_GetCaptureOptionU32 GetCaptureOptionU32;
+  pRENDERDOC_GetCaptureOptionF32 GetCaptureOptionF32;
+
+  pRENDERDOC_SetFocusToggleKeys SetFocusToggleKeys;
+  pRENDERDOC_SetCaptureKeys SetCaptureKeys;
+
+  pRENDERDOC_GetOverlayBits GetOverlayBits;
+  pRENDERDOC_MaskOverlayBits MaskOverlayBits;
+
+  pRENDERDOC_Shutdown Shutdown;
+  pRENDERDOC_UnloadCrashHandler UnloadCrashHandler;
+
+  pRENDERDOC_SetLogFilePathTemplate SetLogFilePathTemplate;
+  pRENDERDOC_GetLogFilePathTemplate GetLogFilePathTemplate;
+
+  pRENDERDOC_GetNumCaptures GetNumCaptures;
+  pRENDERDOC_GetCapture GetCapture;
+
+  pRENDERDOC_TriggerCapture TriggerCapture;
+
+  pRENDERDOC_IsRemoteAccessConnected IsRemoteAccessConnected;
+  pRENDERDOC_LaunchReplayUI LaunchReplayUI;
+
+  pRENDERDOC_SetActiveWindow SetActiveWindow;
+
+  pRENDERDOC_StartFrameCapture StartFrameCapture;
+  pRENDERDOC_IsFrameCapturing IsFrameCapturing;
+  pRENDERDOC_EndFrameCapture EndFrameCapture;
+
+  pRENDERDOC_TriggerMultiFrameCapture TriggerMultiFrameCapture;
+} RENDERDOC_API_1_1_0;
+
+typedef RENDERDOC_API_1_1_0 RENDERDOC_API_1_0_0;
+typedef RENDERDOC_API_1_1_0 RENDERDOC_API_1_0_1;
+typedef RENDERDOC_API_1_1_0 RENDERDOC_API_1_0_2;
+
+// although this structure is identical to RENDERDOC_API_1_1_0, the member
+// IsRemoteAccessConnected was renamed to IsTargetControlConnected. So that
+// old code can still compile with a new header, we must declare a new struct
+// type. It can be casted back and forth though, so we will still return a
+// pointer to this type for all previous API versions - the above struct is
+// purely legacy for compilation compatibility
+
+// eRENDERDOC_API_Version_1_1_1
+typedef struct
+{
+  pRENDERDOC_GetAPIVersion GetAPIVersion;
+
+  pRENDERDOC_SetCaptureOptionU32 SetCaptureOptionU32;
+  pRENDERDOC_SetCaptureOptionF32 SetCaptureOptionF32;
+
+  pRENDERDOC_GetCaptureOptionU32 GetCaptureOptionU32;
+  pRENDERDOC_GetCaptureOptionF32 GetCaptureOptionF32;
+
+  pRENDERDOC_SetFocusToggleKeys SetFocusToggleKeys;
+  pRENDERDOC_SetCaptureKeys SetCaptureKeys;
+
+  pRENDERDOC_GetOverlayBits GetOverlayBits;
+  pRENDERDOC_MaskOverlayBits MaskOverlayBits;
+
+  pRENDERDOC_Shutdown Shutdown;
+  pRENDERDOC_UnloadCrashHandler UnloadCrashHandler;
+
+  pRENDERDOC_SetLogFilePathTemplate SetLogFilePathTemplate;
+  pRENDERDOC_GetLogFilePathTemplate GetLogFilePathTemplate;
+
+  pRENDERDOC_GetNumCaptures GetNumCaptures;
+  pRENDERDOC_GetCapture GetCapture;
+
+  pRENDERDOC_TriggerCapture TriggerCapture;
+
+  pRENDERDOC_IsTargetControlConnected IsTargetControlConnected;
+  pRENDERDOC_LaunchReplayUI LaunchReplayUI;
+
+  pRENDERDOC_SetActiveWindow SetActiveWindow;
+
+  pRENDERDOC_StartFrameCapture StartFrameCapture;
+  pRENDERDOC_IsFrameCapturing IsFrameCapturing;
+  pRENDERDOC_EndFrameCapture EndFrameCapture;
+
+  pRENDERDOC_TriggerMultiFrameCapture TriggerMultiFrameCapture;
+} RENDERDOC_API_1_1_1;
+
+//////////////////////////////////////////////////////////////////////////////////////////////////
+// RenderDoc API entry point
+//
+// This entry point can be obtained via GetProcAddress/dlsym if RenderDoc is available.
+//
+// The name is the same as the typedef - "RENDERDOC_GetAPI"
+//
+// This function is not thread safe, and should not be called on multiple threads at once.
+// Ideally, call this once as early as possible in your application's startup, before doing
+// any API work, since some configuration functionality etc has to be done also before
+// initialising any APIs.
+//
+// Parameters:
+//   version is a single value from the RENDERDOC_Version above.
+//
+//   outAPIPointers will be filled out with a pointer to the corresponding struct of function
+//   pointers.
+//
+// Returns:
+//   1 - if the outAPIPointers has been filled with a pointer to the API struct requested
+//   0 - if the requested version is not supported or the arguments are invalid.
+//
+typedef int(RENDERDOC_CC *pRENDERDOC_GetAPI)(RENDERDOC_Version version, void **outAPIPointers);
+
+#ifdef __cplusplus
+}    // extern "C"
+#endif

--- a/code/model/modelrender.cpp
+++ b/code/model/modelrender.cpp
@@ -65,8 +65,7 @@ model_render_params::model_render_params() :
 	Animated_effect(-1),
 	Animated_timer(0.0f),
 	Thruster_info(),
-	Normal_alpha(false),
-	Normal_extrude(false)
+	Normal_alpha(false)
 {
 	Warp_scale.xyz.x = 1.0f;
 	Warp_scale.xyz.y = 1.0f;
@@ -332,20 +331,14 @@ float model_render_params::get_normal_alpha_max()
 	return Normal_alpha_max;
 }
 
-void model_render_params::set_normal_extrude_width(float width)
-{
-	Normal_extrude = true;
-	Normal_extrude_width = width;
+void model_render_params::set_outline_thickness(float thickness) {
+	Outline_thickness = thickness;
 }
-
-bool model_render_params::is_normal_extrude_set()
-{
-	return Normal_extrude;
+float model_render_params::get_outline_thickness() {
+	return Outline_thickness;
 }
-
-float model_render_params::get_normal_extrude_width()
-{
-	return Normal_extrude_width;
+bool model_render_params::uses_thick_outlines() {
+	return Outline_thickness > 0.0f;
 }
 
 void model_batch_buffer::reset()
@@ -2737,8 +2730,8 @@ void model_render_queue(model_render_params *interp, model_draw_list *scene, int
 		rendering_material.set_normal_alpha(interp->get_normal_alpha_min(), interp->get_normal_alpha_max());
 	}
 
-	if ( interp->is_normal_extrude_set() ) {
-		rendering_material.set_normal_extrude(interp->get_normal_extrude_width());
+	if ( interp->uses_thick_outlines() ) {
+		rendering_material.set_outline_thickness(interp->get_outline_thickness());
 	}
 
 	if ( ( model_flags & MR_NO_CULL ) || ( model_flags & MR_ALL_XPARENT ) || ( interp->get_warp_bitmap() >= 0 ) ) {

--- a/code/model/modelrender.h
+++ b/code/model/modelrender.h
@@ -97,8 +97,7 @@ class model_render_params
 	float Normal_alpha_min;
 	float Normal_alpha_max;
 
-	bool Normal_extrude;
-	float Normal_extrude_width;
+	float Outline_thickness = -1.0f;
 
 	model_render_params(const model_render_params&) = delete;
 	model_render_params& operator=(const model_render_params&) = delete;
@@ -125,12 +124,12 @@ public:
 	void set_animated_effect(int effect_num, float timer);
 	void set_thruster_info(mst_info &info);
 	void set_normal_alpha(float min, float max);
-	void set_normal_extrude_width(float width);
+	void set_outline_thickness(float thick);
 
 	bool is_clip_plane_set();
 	bool is_team_color_set();
 	bool is_normal_alpha_set();
-	bool is_normal_extrude_set();
+	bool uses_thick_outlines();
 
 	uint get_model_flags();
 	uint get_debug_flags();
@@ -153,7 +152,7 @@ public:
 	const mst_info& get_thruster_info();
 	float get_normal_alpha_min();
 	float get_normal_alpha_max();
-	float get_normal_extrude_width();
+	float get_outline_thickness();
 };
 
 struct arc_effect

--- a/code/source_groups.cmake
+++ b/code/source_groups.cmake
@@ -571,6 +571,12 @@ set(file_root_libs_ffmpeg
 	libs/ffmpeg/FFmpegHeaders.h
 )
 
+set(file_root_lbs_renderdoc
+	libs/renderdoc/renderdoc.cpp
+	libs/renderdoc/renderdoc.h
+	libs/renderdoc/renderdoc_app.h
+)
+
 # Lighting files
 set (file_root_lighting
 	lighting/lighting.cpp
@@ -1339,6 +1345,7 @@ source_group("JumpNode"                           FILES ${file_root_jumpnode})
 source_group("Lab"                                FILES ${file_root_lab})
 source_group("Libs"                               FILES ${file_root_libs})
 source_group("Libs\\FFmpeg"                       FILES ${file_root_libs_ffmpeg})
+source_group("Libs\\RenderDoc"                    FILES ${file_root_lbs_renderdoc})
 source_group("Lighting"                           FILES ${file_root_lighting})
 source_group("Localization"                       FILES ${file_root_localization})
 source_group("Math"                               FILES ${file_root_math})
@@ -1439,6 +1446,7 @@ set (file_root
 	${file_root_lab}
 	${file_root_libs}
 	${file_root_libs_ffmpeg}
+	${file_root_lbs_renderdoc}
 	${file_root_lighting}
 	${file_root_localization}
 	${file_root_math}


### PR DESCRIPTION
This adds support for rendering models using thick lines (that means
lines wider than 1 pixel) which is required by the hardpoint HUD gauge.
This feature was present before the switch to OpenGL code and had to be
removed since the core profile does not support rendering lines wider
than 1 pixel.

This uses a geometry shader for converting all the triangles from a
model to 3 quads along the triangle lines which are as thick as set by
the model renderer. Geometry shaders are quite slow if they generate a
lot of geometry (and this generates 4 times the usual amount of geometry
in the shader) so it's probably not a very fast rendering operation but
it is only needed once per frame so it shouldn't be too bad.

I also added support for the RenderDoc API since I needed that for
debugging and it might be useful in the future. It will only become
active if RenderDoc is actually attached to the process so in most cases
the new code will do nothing.