### PR TITLE
make the set-bit and is-bit-set operators fail gracefully

### DIFF
--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -4262,8 +4262,9 @@ int sexp_set_bit(int node, bool set_it)
 
 	if (bit_index < 0 || bit_index > 31)
 	{
-		Warning(LOCATION, "Bit index %d out of range!  Must be between 0 and 31.", bit_index);
-		return SEXP_NAN;
+		// out of range, so just return the original value
+		// (we used to warn, but it's more convenient to FREDders to fail gracefully)
+		return val;
 	}
 
 	if (set_it)
@@ -4280,8 +4281,9 @@ int sexp_is_bit_set(int node)
 
 	if (bit_index < 0 || bit_index > 31)
 	{
-		Warning(LOCATION, "Bit index %d out of range!  Must be between 0 and 31.", bit_index);
-		return SEXP_NAN;
+		// out of range, so just return false
+		// (we used to warn, but it's more convenient to FREDders to fail gracefully)
+		return SEXP_FALSE;
 	}
 
 	if (val & (1<<bit_index))


### PR DESCRIPTION
These operators used to warn and return NAN if they were given a bit index out of range.  For FREDding convenience, out-of-range bit indexes are now a no-op.  This is particularly helpful in the situation where a FREDder needs to evaluate an extended bit array, one 32-bit chunk at a time, e.g.

0-31 bits: offset 0
32-63 bits: offset -32
64-95 bits: offset -64
96-127 bits: offset -96

Because the sexp system always evaluates every argument, three out of four branches were always evaluated with invalid bit indexes (negative or too large) even if the sexp logic only used one branch.  The new method silently bypasses this behavior.