### PR TITLE
Fix Appveyor Qt build issue

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,5 @@
 version: 1.0.0.{build}
+image: Visual Studio 2015
 configuration:
   - Debug
   - Release
@@ -6,13 +7,13 @@ clone_depth: 10
 environment:
   matrix:
     - BuildID: 0
-      CMAKE_GENERATOR: Visual Studio 12 2013
-      PlatformToolset: v120_xp
-      QT_DIR: C:\Qt\5.7\msvc2013
+      CMAKE_GENERATOR: Visual Studio 14 2015
+      PlatformToolset: v140_xp
+      QT_DIR: C:\Qt\5.9.5\msvc2015
     - BuildID: 1
       CMAKE_GENERATOR: Visual Studio 14 2015 Win64
       PlatformToolset: v140_xp
-      QT_DIR: C:\Qt\5.7\msvc2015_64
+      QT_DIR: C:\Qt\5.9.5\msvc2015_64
 before_build:
   - git submodule update --init --recursive
 build_script:

--- a/ci/appveyor/build.ps1
+++ b/ci/appveyor/build.ps1
@@ -14,7 +14,7 @@ $NightlyConfigurations = @(
 		PackageType="Win64";
 		Toolset="v140_xp";
 		SimdType="SSE2";
-		QtDir="C:\Qt\5.7\msvc2015_64";
+		QtDir="C:\Qt\5.9.5\msvc2015_64";
 		SourcePackage=$false;
 	},
 	[BuildConfig]@{ 
@@ -22,7 +22,7 @@ $NightlyConfigurations = @(
 		PackageType="Win32";
 		Toolset="v140_xp";
 		SimdType="SSE2";
-		QtDir="C:\Qt\5.7\msvc2015";
+		QtDir="C:\Qt\5.9.5\msvc2015";
 		SourcePackage=$false;
 	}
 )
@@ -32,7 +32,7 @@ $ReleaseConfigurations = @(
 		PackageType="Win32";
 		Toolset="v140_xp";
 		SimdType="SSE2";
-		QtDir="C:\Qt\5.7\msvc2015";
+		QtDir="C:\Qt\5.9.5\msvc2015";
 		SourcePackage=$true;
 	}
 	[BuildConfig]@{
@@ -40,7 +40,7 @@ $ReleaseConfigurations = @(
 		PackageType="Win32-AVX";
 		Toolset="v140_xp";
 		SimdType="AVX";
-		QtDir="C:\Qt\5.7\msvc2015";
+		QtDir="C:\Qt\5.9.5\msvc2015";
 		SourcePackage=$false;
 	}
 	[BuildConfig]@{
@@ -48,7 +48,7 @@ $ReleaseConfigurations = @(
 		PackageType="Win64";
 		Toolset="v140_xp";
 		SimdType="SSE2";
-		QtDir="C:\Qt\5.7\msvc2015_64";
+		QtDir="C:\Qt\5.9.5\msvc2015_64";
 		SourcePackage=$false;
 	}
 	[BuildConfig]@{
@@ -56,7 +56,7 @@ $ReleaseConfigurations = @(
 		PackageType="Win64-AVX";
 		Toolset="v140_xp";
 		SimdType="AVX";
-		QtDir="C:\Qt\5.7\msvc2015_64";
+		QtDir="C:\Qt\5.9.5\msvc2015_64";
 		SourcePackage=$false;
 	}
 )


### PR DESCRIPTION
Apparently, Appveyor has removed the Qt version 5.7 from their servers
which was used by FSO previously. I have updated the paths to use Qt
5.9.5 instead but there is a problem with Visual Studio 2013 since
there is no 32-bit Qt version for that compiler installed in the
Appveyor system.

For that reason, I decided to use Visual Studio 2015 instead for the
32-bit builds which means that Visual Studio 2013 will not be tested by
Appveyor anymore. Since no one is using that compiler version anymore
that shouldn't be a big issue.

This should fix the CI issues seen on recent PRs and commits.