### PR TITLE
Implement various translation features requested by Novachen

### DIFF
--- a/code/hud/hudbrackets.cpp
+++ b/code/hud/hudbrackets.cpp
@@ -1013,7 +1013,7 @@ void HudGaugeBrackets::renderBoundingBrackets(int x1, int y1, int x2, int y2, in
 				tinfo_name = XSTR("Debris", 348);
 				break;
 			case OBJ_WEAPON:
-				strcpy_s(temp_name, Weapon_info[Weapons[t_objp->instance].weapon_info_index].name);
+				strcpy_s(temp_name, Weapon_info[Weapons[t_objp->instance].weapon_info_index].get_display_name());
 				end_string_at_first_hash_symbol(temp_name);
 				tinfo_name = temp_name;
 				break;

--- a/code/hud/hudbrackets.cpp
+++ b/code/hud/hudbrackets.cpp
@@ -1013,7 +1013,7 @@ void HudGaugeBrackets::renderBoundingBrackets(int x1, int y1, int x2, int y2, in
 				tinfo_name = XSTR("Debris", 348);
 				break;
 			case OBJ_WEAPON:
-				strcpy_s(temp_name, Weapon_info[Weapons[t_objp->instance].weapon_info_index].get_display_name());
+				strcpy_s(temp_name, Weapon_info[Weapons[t_objp->instance].weapon_info_index].get_display_string());
 				end_string_at_first_hash_symbol(temp_name);
 				tinfo_name = temp_name;
 				break;

--- a/code/hud/hudtarget.cpp
+++ b/code/hud/hudtarget.cpp
@@ -6126,11 +6126,16 @@ void HudGaugeWeapons::render(float  /*frametime*/)
 
 		maybeFlashWeapon(np+i);
 
-		// HACK - make Cluster Bomb fit on the HUD.
-		if(!stricmp(wip->name,"cluster bomb")){
-			strcpy_s(weapon_name, NOX("Cluster"));
-		} else {
+		if (wip->has_display_name()) {
+			// Do not apply the cluster bomb hack if we have an alternate name to make translating that name possible
 			strcpy_s(weapon_name, wip->get_display_name());
+		} else {
+			// HACK - make Cluster Bomb fit on the HUD.
+			if(!stricmp(wip->name,"cluster bomb")){
+				strcpy_s(weapon_name, NOX("Cluster"));
+			} else {
+				strcpy_s(weapon_name, wip->get_display_name());
+			}
 		}
 
 		// get rid of #

--- a/code/hud/hudtarget.cpp
+++ b/code/hud/hudtarget.cpp
@@ -5754,7 +5754,7 @@ void HudGaugeWeaponEnergy::render(float  /*frametime*/)
 				// show all primary banks
 				for ( i = 0; i < Player_ship->weapons.num_primary_banks; i++ ) {
 					wip = &Weapon_info[sw->primary_bank_weapons[i]];
-					strcpy_s(buf, wip->get_display_name());
+					strcpy_s(buf, wip->get_display_string());
 
 					if ( Armed_alignment ) {
 						gr_get_string_size(&w, &h, buf);
@@ -5768,7 +5768,7 @@ void HudGaugeWeaponEnergy::render(float  /*frametime*/)
 				// just show the current armed bank
 				i = Player_ship->weapons.current_primary_bank;
 				wip = &Weapon_info[sw->primary_bank_weapons[i]];
-				strcpy_s(buf, wip->get_display_name());
+				strcpy_s(buf, wip->get_display_string());
 
 				if ( Armed_alignment ) {
 					gr_get_string_size(&w, &h, buf);
@@ -6058,7 +6058,7 @@ void HudGaugeWeapons::render(float  /*frametime*/)
 				renderBitmap(primary_last[ballistic_hud_index].first_frame, position[0] + frame_offset_x[ballistic_hud_index], y);
 		}
 
-		strcpy_s(name, Weapon_info[sw->primary_bank_weapons[i]].get_display_name());
+		strcpy_s(name, Weapon_info[sw->primary_bank_weapons[i]].get_display_string());
 		if (Lcl_gr && !Disable_built_in_translations) {
 			lcl_translate_wep_name_gr(name);
 		}
@@ -6126,15 +6126,15 @@ void HudGaugeWeapons::render(float  /*frametime*/)
 
 		maybeFlashWeapon(np+i);
 
-		if (wip->has_display_name()) {
+		if (wip->has_alternate_name()) {
 			// Do not apply the cluster bomb hack if we have an alternate name to make translating that name possible
-			strcpy_s(weapon_name, wip->get_display_name());
+			strcpy_s(weapon_name, wip->get_display_string());
 		} else {
 			// HACK - make Cluster Bomb fit on the HUD.
 			if(!stricmp(wip->name,"cluster bomb")){
 				strcpy_s(weapon_name, NOX("Cluster"));
 			} else {
-				strcpy_s(weapon_name, wip->get_display_name());
+				strcpy_s(weapon_name, wip->get_display_string());
 			}
 		}
 
@@ -6696,7 +6696,7 @@ void HudGaugeWarheadCount::render(float  /*frametime*/)
 	}
 
 	char weapon_name[NAME_LENGTH + 10];
-	strcpy_s(weapon_name, wip->get_display_name());
+	strcpy_s(weapon_name, wip->get_display_string());
 	end_string_at_first_hash_symbol(weapon_name);
 
 	setGaugeColor();
@@ -6933,7 +6933,7 @@ void HudGaugePrimaryWeapons::render(float  /*frametime*/)
 
 		renderBitmap(_background_entry.first_frame, position[0], position[1] + bg_y_offset);
 
-		strcpy_s(name, Weapon_info[sw->primary_bank_weapons[i]].get_display_name());
+		strcpy_s(name, Weapon_info[sw->primary_bank_weapons[i]].get_display_string());
 
 		if (Lcl_gr && !Disable_built_in_translations) {
 			lcl_translate_wep_name_gr(name);
@@ -7052,7 +7052,7 @@ void HudGaugeSecondaryWeapons::render(float  /*frametime*/)
 
 		maybeFlashWeapon(num_primaries+i);
 
-		strcpy_s(weapon_name, wip->get_display_name());
+		strcpy_s(weapon_name, wip->get_display_string());
 		end_string_at_first_hash_symbol(weapon_name);
 
 		if ( sw->current_secondary_bank == i ) {

--- a/code/hud/hudtarget.cpp
+++ b/code/hud/hudtarget.cpp
@@ -5297,11 +5297,13 @@ void hud_stuff_ship_name(char *ship_name_text, ship *shipp)
 		// handle hash symbol
 		end_string_at_first_hash_symbol(ship_name_text);
 
-		// handle translation
-		if (Lcl_gr) {
-			lcl_translate_targetbox_name_gr(ship_name_text);
-		} else if (Lcl_pl) {
-			lcl_translate_targetbox_name_pl(ship_name_text);
+		if (!Disable_built_in_translations) {
+			// handle translation
+			if (Lcl_gr) {
+				lcl_translate_targetbox_name_gr(ship_name_text);
+			} else if (Lcl_pl) {
+				lcl_translate_targetbox_name_pl(ship_name_text);
+			}
 		}
 	}
 }
@@ -5333,11 +5335,13 @@ void hud_stuff_ship_callsign(char *ship_callsign_text, ship *shipp)
 	// handle hash symbol
 	end_string_at_first_hash_symbol(ship_callsign_text);
 
-	// handle translation
-	if (Lcl_gr) {
-		lcl_translate_targetbox_name_gr(ship_callsign_text);
-	} else if (Lcl_pl) {
-		lcl_translate_targetbox_name_pl(ship_callsign_text);
+	if (!Disable_built_in_translations) {
+		// handle translation
+		if (Lcl_gr) {
+			lcl_translate_targetbox_name_gr(ship_callsign_text);
+		} else if (Lcl_pl) {
+			lcl_translate_targetbox_name_pl(ship_callsign_text);
+		}
 	}
 }
 
@@ -5362,11 +5366,13 @@ void hud_stuff_ship_class(char *ship_class_text, ship *shipp)
 	// handle hash symbol
 	end_string_at_first_hash_symbol(ship_class_text);
 
-	// handle translation
-	if (Lcl_gr) {
-		lcl_translate_targetbox_name_gr(ship_class_text);
-	} else if (Lcl_pl) {
-		lcl_translate_targetbox_name_pl(ship_class_text);
+	if (!Disable_built_in_translations) {
+		// handle translation
+		if (Lcl_gr) {
+			lcl_translate_targetbox_name_gr(ship_class_text);
+		} else if (Lcl_pl) {
+			lcl_translate_targetbox_name_pl(ship_class_text);
+		}
 	}
 }
 
@@ -6053,7 +6059,7 @@ void HudGaugeWeapons::render(float  /*frametime*/)
 		}
 
 		strcpy_s(name, Weapon_info[sw->primary_bank_weapons[i]].get_display_name());
-		if (Lcl_gr) {
+		if (Lcl_gr && !Disable_built_in_translations) {
 			lcl_translate_wep_name_gr(name);
 		}
 
@@ -6924,7 +6930,7 @@ void HudGaugePrimaryWeapons::render(float  /*frametime*/)
 
 		strcpy_s(name, Weapon_info[sw->primary_bank_weapons[i]].get_display_name());
 
-		if (Lcl_gr) {
+		if (Lcl_gr && !Disable_built_in_translations) {
 			lcl_translate_wep_name_gr(name);
 		}
 

--- a/code/hud/hudtarget.cpp
+++ b/code/hud/hudtarget.cpp
@@ -5626,10 +5626,11 @@ void HudGaugeWeaponEnergy::render(float  /*frametime*/)
 				setGaugeColor(HUD_C_NORMAL);
 			}
 			if(gr_screen.max_w_unscaled == 640) {
+				strcpy_s(shortened_name, Weapon_info[Player_ship->weapons.primary_bank_weapons[x]].get_display_string());
 				font::force_fit_string(shortened_name, NAME_LENGTH, 55);
 				renderString(currentx, currenty, shortened_name);
 			} else {
-				renderString(currentx, currenty, Weapon_info[Player_ship->weapons.primary_bank_weapons[x]].name);
+				renderString(currentx, currenty, Weapon_info[Player_ship->weapons.primary_bank_weapons[x]].get_display_string());
 			}
 
 			//Next 'line'
@@ -5747,7 +5748,7 @@ void HudGaugeWeaponEnergy::render(float  /*frametime*/)
 				// show all primary banks
 				for ( i = 0; i < Player_ship->weapons.num_primary_banks; i++ ) {
 					wip = &Weapon_info[sw->primary_bank_weapons[i]];
-					strcpy_s(buf, (wip->alt_name[0]) ? wip->alt_name : wip->name);
+					strcpy_s(buf, wip->get_display_name());
 
 					if ( Armed_alignment ) {
 						gr_get_string_size(&w, &h, buf);
@@ -5761,7 +5762,7 @@ void HudGaugeWeaponEnergy::render(float  /*frametime*/)
 				// just show the current armed bank
 				i = Player_ship->weapons.current_primary_bank;
 				wip = &Weapon_info[sw->primary_bank_weapons[i]];
-				strcpy_s(buf, (wip->alt_name[0]) ? wip->alt_name : wip->name);
+				strcpy_s(buf, wip->get_display_name());
 
 				if ( Armed_alignment ) {
 					gr_get_string_size(&w, &h, buf);
@@ -6051,7 +6052,7 @@ void HudGaugeWeapons::render(float  /*frametime*/)
 				renderBitmap(primary_last[ballistic_hud_index].first_frame, position[0] + frame_offset_x[ballistic_hud_index], y);
 		}
 
-		strcpy_s(name, (Weapon_info[sw->primary_bank_weapons[i]].alt_name[0]) ? Weapon_info[sw->primary_bank_weapons[i]].alt_name : Weapon_info[sw->primary_bank_weapons[i]].name);
+		strcpy_s(name, Weapon_info[sw->primary_bank_weapons[i]].get_display_name());
 		if (Lcl_gr) {
 			lcl_translate_wep_name_gr(name);
 		}
@@ -6123,7 +6124,7 @@ void HudGaugeWeapons::render(float  /*frametime*/)
 		if(!stricmp(wip->name,"cluster bomb")){
 			strcpy_s(weapon_name, NOX("Cluster"));
 		} else {
-			strcpy_s(weapon_name, (wip->alt_name[0]) ? wip->alt_name : wip->name);
+			strcpy_s(weapon_name, wip->get_display_name());
 		}
 
 		// get rid of #
@@ -6684,7 +6685,7 @@ void HudGaugeWarheadCount::render(float  /*frametime*/)
 	}
 
 	char weapon_name[NAME_LENGTH + 10];
-	strcpy_s(weapon_name, (wip->alt_name[0]) ? wip->alt_name : wip->name);
+	strcpy_s(weapon_name, wip->get_display_name());
 	end_string_at_first_hash_symbol(weapon_name);
 
 	setGaugeColor();
@@ -6921,7 +6922,7 @@ void HudGaugePrimaryWeapons::render(float  /*frametime*/)
 
 		renderBitmap(_background_entry.first_frame, position[0], position[1] + bg_y_offset);
 
-		strcpy_s(name, (Weapon_info[sw->primary_bank_weapons[i]].alt_name[0]) ? Weapon_info[sw->primary_bank_weapons[i]].alt_name : Weapon_info[sw->primary_bank_weapons[i]].name);
+		strcpy_s(name, Weapon_info[sw->primary_bank_weapons[i]].get_display_name());
 
 		if (Lcl_gr) {
 			lcl_translate_wep_name_gr(name);
@@ -7040,7 +7041,7 @@ void HudGaugeSecondaryWeapons::render(float  /*frametime*/)
 
 		maybeFlashWeapon(num_primaries+i);
 
-		strcpy_s(weapon_name, (wip->alt_name[0]) ? wip->alt_name : wip->name);
+		strcpy_s(weapon_name, wip->get_display_name());
 		end_string_at_first_hash_symbol(weapon_name);
 
 		if ( sw->current_secondary_bank == i ) {

--- a/code/hud/hudtargetbox.cpp
+++ b/code/hud/hudtargetbox.cpp
@@ -1008,7 +1008,7 @@ void HudGaugeTargetBox::renderTargetWeapon(object *target_objp)
 	setGaugeColor();
 
 	// print out the weapon class name
-	sprintf( outstr,"%s", target_wip->name );
+	sprintf( outstr,"%s", target_wip->get_display_string() );
 	gr_get_string_size(&w,&h,outstr);
 
 	// drop name past the # sign
@@ -2158,7 +2158,7 @@ void HudGaugeTargetBox::showTargetData(float  /*frametime*/)
 		gr_printf_no_resize(sx,sy,"%s", outstr);
 		sy += dy;
 		for ( i = 0; i < swp->num_primary_banks; i++ ) {
-			sprintf(outstr,"%d. %s", i+1, Weapon_info[swp->primary_bank_weapons[i]].name);
+			sprintf(outstr,"%d. %s", i+1, Weapon_info[swp->primary_bank_weapons[i]].get_display_string());
 			gr_printf_no_resize(sx,sy,"%s", outstr);
 			sy += dy;
 		}
@@ -2168,7 +2168,7 @@ void HudGaugeTargetBox::showTargetData(float  /*frametime*/)
 		gr_printf_no_resize(sx,sy,"%s", outstr);
 		sy += dy;
 		for ( i = 0; i < swp->num_secondary_banks; i++ ) {
-			sprintf(outstr,"%d. %s", i+1, Weapon_info[swp->secondary_bank_weapons[i]].name);
+			sprintf(outstr,"%d. %s", i+1, Weapon_info[swp->secondary_bank_weapons[i]].get_display_string());
 			gr_printf_no_resize(sx,sy,"%s", outstr);
 			sy += dy;
 		}

--- a/code/io/keycontrol.cpp
+++ b/code/io/keycontrol.cpp
@@ -977,7 +977,7 @@ void process_debug_keys(int k)
 			int *weap = &shipp->weapons.secondary_bank_weapons[shipp->weapons.current_secondary_bank];
 			*weap = get_next_weapon_looped(*weap, WP_MISSILE);
 
-			HUD_sourced_printf(HUD_SOURCE_HIDDEN, XSTR( "Secondary Weapon forced to %s", 18), Weapon_info[*weap].name);
+			HUD_sourced_printf(HUD_SOURCE_HIDDEN, XSTR( "Secondary Weapon forced to %s", 18), Weapon_info[*weap].get_display_string());
 			break;
 		}
 
@@ -990,7 +990,7 @@ void process_debug_keys(int k)
 			int *weap = &shipp->weapons.secondary_bank_weapons[shipp->weapons.current_secondary_bank];
 			*weap = get_prev_weapon_looped(*weap, WP_MISSILE);
 
-			HUD_sourced_printf(HUD_SOURCE_HIDDEN, XSTR( "Secondary Weapon forced to %s", 18), Weapon_info[*weap].name);
+			HUD_sourced_printf(HUD_SOURCE_HIDDEN, XSTR( "Secondary Weapon forced to %s", 18), Weapon_info[*weap].get_display_string());
 			break;
 		}
 		
@@ -1019,7 +1019,7 @@ void process_debug_keys(int k)
 			int *weap = &shipp->weapons.primary_bank_weapons[shipp->weapons.current_primary_bank];
 			*weap = get_next_weapon_looped(*weap, WP_LASER);
 			
-			HUD_sourced_printf(HUD_SOURCE_HIDDEN, XSTR( "Primary Weapon forced to %s", 19), Weapon_info[*weap].name);
+			HUD_sourced_printf(HUD_SOURCE_HIDDEN, XSTR( "Primary Weapon forced to %s", 19), Weapon_info[*weap].get_display_string());
 			break;
 		}
 
@@ -1031,7 +1031,7 @@ void process_debug_keys(int k)
 			int *weap = &shipp->weapons.primary_bank_weapons[shipp->weapons.current_primary_bank];
 			*weap = get_prev_weapon_looped(*weap, WP_LASER);
 		
-			HUD_sourced_printf(HUD_SOURCE_HIDDEN, XSTR( "Primary Weapon forced to %s", 19), Weapon_info[*weap].name);
+			HUD_sourced_printf(HUD_SOURCE_HIDDEN, XSTR( "Primary Weapon forced to %s", 19), Weapon_info[*weap].get_display_string());
 			break;
 		}
 

--- a/code/lab/lab.cpp
+++ b/code/lab/lab.cpp
@@ -920,7 +920,7 @@ void labviewer_update_variables_window()
 		Assert(Lab_selected_index < Num_weapon_types);
 		weapon_info *wip = &Weapon_info[Lab_selected_index];
 
-		VAR_SET_VALUE(wip->name);
+		VAR_SET_VALUE(wip->get_display_string());
 		VAR_SET_VALUE_SAVE(wip->subtype, Num_weapon_subtypes - 1);
 
 		VAR_SET_VALUE_SAVE(wip->mass, 0);
@@ -1257,7 +1257,7 @@ void labviewer_update_desc_window()
 			}
 		}
 		else if (Lab_mode == LAB_MODE_WEAPON) {
-			Lab_description_window->SetCaption(Weapon_info[Lab_selected_index].name);
+			Lab_description_window->SetCaption(Weapon_info[Lab_selected_index].get_display_string());
 
 			if (Weapon_info[Lab_selected_index].tech_desc != NULL) {
 				Lab_description_text->SetText(Weapon_info[Lab_selected_index].tech_desc);
@@ -1543,7 +1543,7 @@ void labviewer_make_weap_window(Button*  /*caller*/)
 			stip = type_nodes[Weapon_info[i].subtype];
 		}
 
-		cmp->AddItem(stip, Weapon_info[i].name, i, false, labviewer_change_weapon);
+		cmp->AddItem(stip, Weapon_info[i].get_display_string(), i, false, labviewer_change_weapon);
 
 		//if (Weapon_info[i].tech_model[0] != '\0') {
 		//	cmp->AddItem(cwip, "Tech Model", 0, false, labviewer_show_tech_model);

--- a/code/menuui/techmenu.cpp
+++ b/code/menuui/techmenu.cpp
@@ -436,7 +436,7 @@ void tech_common_render()
 		memset( buf, 0, sizeof(buf) );
 		strncpy(buf, Current_list[z].name, sizeof(buf) - 1);
 
-		if (Lcl_gr)
+		if (Lcl_gr && !Disable_built_in_translations)
 			lcl_translate_ship_name_gr(buf);
 
 		font::force_fit_string(buf, 255, Tech_list_coords[gr_screen.res][SHIP_W_COORD]);

--- a/code/menuui/techmenu.cpp
+++ b/code/menuui/techmenu.cpp
@@ -224,7 +224,7 @@ int Techroom_overlay_id;
 // out entry data struct & vars
 typedef struct {
 	int	index;		// index into the master table that its in (ie Ship_info[])
-	char* name;			// ptr to name string
+	const char* name;			// ptr to name string
 	char* desc;			// ptr to description string
 	char tech_anim_filename[MAX_FILENAME_LEN];	//duh
 	generic_anim animation;	// animation info
@@ -855,7 +855,7 @@ void techroom_change_tab(int num)
 						Weapon_list[Weapon_list_size].index = i;
 						Weapon_list[Weapon_list_size].desc = Weapon_info[i].tech_desc;
 						Weapon_list[Weapon_list_size].has_anim = 1;
-						Weapon_list[Weapon_list_size].name = *Weapon_info[i].tech_title ? Weapon_info[i].tech_title : Weapon_info[i].name;
+						Weapon_list[Weapon_list_size].name = *Weapon_info[i].tech_title ? Weapon_info[i].tech_title : Weapon_info[i].get_display_string();
 						Weapon_list[Weapon_list_size].bitmap = -1;
 						Weapon_list[Weapon_list_size].animation.num_frames = 0;
 						Weapon_list[Weapon_list_size].model_num = -1;

--- a/code/mission/missionbriefcommon.cpp
+++ b/code/mission/missionbriefcommon.cpp
@@ -1004,13 +1004,13 @@ void brief_render_icon(int stage_num, int icon_num, float frametime, int selecte
 				gr_string(bc - fl2i(w/2.0f), by - h, Players[Player_num].callsign, GR_RESIZE_MENU);
 			}
 			else {
-				if (Lcl_gr) {
+				if (Lcl_gr && !Disable_built_in_translations) {
 					char buf[128];
 					strcpy_s(buf, bi->label);
 					lcl_translate_brief_icon_name_gr(buf);
 					gr_get_string_size(&w, &h, buf);
 					gr_string(bc - fl2i(w/2.0f), by - h, buf, GR_RESIZE_MENU);
-				} else if (Lcl_pl) {
+				} else if (Lcl_pl && !Disable_built_in_translations) {
 					char buf[128];
 					strcpy_s(buf, bi->label);
 					lcl_translate_brief_icon_name_pl(buf);

--- a/code/missionui/missiondebrief.cpp
+++ b/code/missionui/missiondebrief.cpp
@@ -458,7 +458,7 @@ int Debrief_award_text_num_lines = 0;
 
 
 // prototypes, you know you love 'em
-void debrief_add_award_text(char *str);
+void debrief_add_award_text(const char *str);
 void debrief_award_text_clear();
 
 
@@ -483,7 +483,7 @@ const char *debrief_tooltip_handler(const char *str)
 
 	} else if (!stricmp(str, NOX("@Medal"))) {
 		if (Medal_bitmap >= 0){
-			return Medals[Player->stats.m_medal_earned].name;
+			return Medals[Player->stats.m_medal_earned].get_display_string();
 		}
 
 	} else if (!stricmp(str, NOX("@Rank"))) {
@@ -493,7 +493,7 @@ const char *debrief_tooltip_handler(const char *str)
 
 	} else if (!stricmp(str, NOX("@Badge"))) {
 		if (Badge_bitmap >= 0){
-			return Medals[Player->stats.m_badge_earned.back()].name;
+			return Medals[Player->stats.m_badge_earned.back()].get_display_string();
 		}
 	}
 
@@ -992,7 +992,7 @@ void debrief_award_init()
 		debrief_choose_medal_variant(buf, Player->stats.m_medal_earned, Player->stats.medal_counts[Player->stats.m_medal_earned] - 1);
 		Medal_bitmap = bm_load(buf);
 
-		debrief_add_award_text(Medals[Player->stats.m_medal_earned].name);
+		debrief_add_award_text(Medals[Player->stats.m_medal_earned].get_display_string());
 	}
 	
 	// handle promotions
@@ -1038,7 +1038,7 @@ void debrief_award_init()
 		// choose appropriate badge voice for this mission
 		debrief_choose_voice(Badge_stage.voice, Medals[Player->stats.m_badge_earned.back()].voice_base, persona_index);
 
-		debrief_add_award_text(Medals[Player->stats.m_badge_earned.back()].name);
+		debrief_add_award_text(Medals[Player->stats.m_badge_earned.back()].get_display_string());
 	}
 
 	if ((Rank_bitmap >= 0) || (Medal_bitmap >= 0) || (Badge_bitmap >= 0)) {
@@ -2247,7 +2247,7 @@ void debrief_award_text_clear() {
 }
 
 // this is the nastiest code I have ever written.  if you are modifying this, i feel bad for you.
-void debrief_add_award_text(char *str)
+void debrief_add_award_text(const char *str)
 {
 	Assert(Debrief_award_text_num_lines < AWARD_TEXT_MAX_LINES);
 	if (Debrief_award_text_num_lines >= AWARD_TEXT_MAX_LINES) {

--- a/code/missionui/missiondebrief.cpp
+++ b/code/missionui/missiondebrief.cpp
@@ -2260,11 +2260,13 @@ void debrief_add_award_text(const char *str)
 	// copy in the line
 	strcpy_s(Debrief_award_text[Debrief_award_text_num_lines], str);	
 
-	// maybe translate for displaying
-	if (Lcl_gr) {
-		lcl_translate_medal_name_gr(Debrief_award_text[Debrief_award_text_num_lines]);
-	} else if (Lcl_pl) {
-		lcl_translate_medal_name_pl(Debrief_award_text[Debrief_award_text_num_lines]);
+	if (!Disable_built_in_translations) {
+		// maybe translate for displaying
+		if (Lcl_gr) {
+			lcl_translate_medal_name_gr(Debrief_award_text[Debrief_award_text_num_lines]);
+		} else if (Lcl_pl) {
+			lcl_translate_medal_name_pl(Debrief_award_text[Debrief_award_text_num_lines]);
+		}
 	}
 
 	Debrief_award_text_num_lines++;

--- a/code/missionui/missionshipchoice.cpp
+++ b/code/missionui/missionshipchoice.cpp
@@ -1898,7 +1898,7 @@ void commit_pressed()
 			num_required_weapons++;
 			if (num_required_weapons > 1)
 				weapon_list.append(1, EOLN);
-			weapon_list.append(Weapon_info[j].name);
+			weapon_list.append(Weapon_info[j].get_display_string());
 
 			// see if it's carried by any ship
 			if (is_weapon_carried(j))

--- a/code/missionui/missionweaponchoice.cpp
+++ b/code/missionui/missionweaponchoice.cpp
@@ -2757,7 +2757,7 @@ void weapon_select_do(float frametime)
 				} else {
 					//Draw the weapon name, crappy last-ditch effort to not crash.
 					int half_x, half_y;
-					SCP_string print_name = Weapon_info[Carried_wl_icon.weapon_class].get_display_name();
+					SCP_string print_name = Weapon_info[Carried_wl_icon.weapon_class].get_display_string();
 
 					// Truncate the # and everything to the right. Zacam
 					end_string_at_first_hash_symbol(print_name);
@@ -2793,7 +2793,7 @@ void weapon_select_do(float frametime)
 				if (Lcl_gr && !Disable_built_in_translations)
 				{
 					char display_name[NAME_LENGTH];
-					strcpy_s(display_name, Weapon_info[Carried_wl_icon.weapon_class].get_display_name());
+					strcpy_s(display_name, Weapon_info[Carried_wl_icon.weapon_class].get_display_string());
 					lcl_translate_wep_name_gr(display_name);
 					popup(PF_USE_AFFIRMATIVE_ICON, 1, POPUP_OK, XSTR("A %s is unable to carry %s weaponry", 633), (Ship_info[ship_class].alt_name[0] != '\0') ? Ship_info[ship_class].alt_name : Ship_info[ship_class].name, display_name);
 				}
@@ -3002,7 +3002,7 @@ void wl_render_icon(int index, int x, int y, int num, int draw_num_flag, int hot
 		{
 			//Draw the weapon name, crappy last-ditch effort to not crash.
 			int half_x, half_y;
-			SCP_string print_name = Weapon_info[index].get_display_name();
+			SCP_string print_name = Weapon_info[index].get_display_string();
 
 			// Truncate the # and everything to the right. Zacam
 			end_string_at_first_hash_symbol(print_name);
@@ -3550,7 +3550,7 @@ int wl_swap_slot_slot(int from_bank, int to_bank, int ship_slot, interface_snd_i
 				char display_name[NAME_LENGTH];
 				char txt[39 + NAME_LENGTH];
 
-				strcpy_s(display_name, Weapon_info[slot->wep[from_bank]].get_display_name());
+				strcpy_s(display_name, Weapon_info[slot->wep[from_bank]].get_display_string());
 
 				// might have to get weapon name translation
 				if (Lcl_gr && !Disable_built_in_translations) {
@@ -3800,7 +3800,7 @@ int wl_swap_list_slot(int from_list, int to_bank, int ship_slot, interface_snd_i
 			char display_name[NAME_LENGTH];
 			char txt[39 + NAME_LENGTH];
 
-			strcpy_s(display_name, Weapon_info[from_list].get_display_name());
+			strcpy_s(display_name, Weapon_info[from_list].get_display_string());
 
 			// might have to get weapon name translation
 			if (Lcl_gr && !Disable_built_in_translations) {
@@ -4038,13 +4038,13 @@ void wl_apply_current_loadout_to_all_ships_in_current_wing()
 			const char* wep_display_name;
 			if (Lcl_gr && !Disable_built_in_translations)
 			{
-				strcpy_s(buf, Weapon_info[weapon_type_to_add].get_display_name());
+				strcpy_s(buf, Weapon_info[weapon_type_to_add].get_display_string());
 				lcl_translate_wep_name_gr(buf);
 				wep_display_name = buf;
 			}
 			else
 			{
-				wep_display_name = Weapon_info[weapon_type_to_add].get_display_name();
+				wep_display_name = Weapon_info[weapon_type_to_add].get_display_string();
 			}
 
 			// make sure this ship can accept this weapon
@@ -4082,7 +4082,8 @@ void wl_apply_current_loadout_to_all_ships_in_current_wing()
 			if ((result == 0) || (result == 2))
 			{
 				SCP_string temp;
-				sprintf(temp, XSTR("Insufficient %s available to arm %s", 1632), Weapon_info[weapon_type_to_add].get_display_name());
+				sprintf(temp, XSTR("Insufficient %s available to arm %s", 1632),
+						Weapon_info[weapon_type_to_add].get_display_string());
 				error_messages.push_back(temp);
 
 				error_flag = true;

--- a/code/missionui/missionweaponchoice.cpp
+++ b/code/missionui/missionweaponchoice.cpp
@@ -2757,16 +2757,16 @@ void weapon_select_do(float frametime)
 				} else {
 					//Draw the weapon name, crappy last-ditch effort to not crash.
 					int half_x, half_y;
-					char *print_name = (Weapon_info[Carried_wl_icon.weapon_class].alt_name[0]) ? Weapon_info[Carried_wl_icon.weapon_class].alt_name : Weapon_info[Carried_wl_icon.weapon_class].name;
+					SCP_string print_name = Weapon_info[Carried_wl_icon.weapon_class].get_display_name();
 
 					// Truncate the # and everything to the right. Zacam
 					end_string_at_first_hash_symbol(print_name);
 					
 					// Center-align and fit the text for display
-					gr_get_string_size(&half_x, &half_y, print_name);
+					gr_get_string_size(&half_x, &half_y, print_name.c_str());
 					half_x = sx +((56 - half_x) / 2);
 					half_y = sy +((28 - half_y) / 2); // Was ((24 - half_y) / 2) Zacam
-					gr_string(half_x, half_y, print_name, GR_RESIZE_MENU);
+					gr_string(half_x, half_y, print_name.c_str(), GR_RESIZE_MENU);
 				}
 			}
 		}
@@ -2793,13 +2793,13 @@ void weapon_select_do(float frametime)
 				if (Lcl_gr)
 				{
 					char display_name[NAME_LENGTH];
-					strcpy_s(display_name, (Weapon_info[Carried_wl_icon.weapon_class].alt_name[0] != '\0' ) ? Weapon_info[Carried_wl_icon.weapon_class].alt_name : Weapon_info[Carried_wl_icon.weapon_class].name);
+					strcpy_s(display_name, Weapon_info[Carried_wl_icon.weapon_class].get_display_name());
 					lcl_translate_wep_name_gr(display_name);
 					popup(PF_USE_AFFIRMATIVE_ICON, 1, POPUP_OK, XSTR("A %s is unable to carry %s weaponry", 633), (Ship_info[ship_class].alt_name[0] != '\0') ? Ship_info[ship_class].alt_name : Ship_info[ship_class].name, display_name);
 				}
 				else
 				{
-					popup(PF_USE_AFFIRMATIVE_ICON, 1, POPUP_OK, XSTR("A %s is unable to carry %s weaponry", 633), (Ship_info[ship_class].alt_name[0] != '\0') ? Ship_info[ship_class].alt_name : Ship_info[ship_class].name, Weapon_info[Carried_wl_icon.weapon_class].name);
+					popup(PF_USE_AFFIRMATIVE_ICON, 1, POPUP_OK, XSTR("A %s is unable to carry %s weaponry", 633), (Ship_info[ship_class].alt_name[0] != '\0') ? Ship_info[ship_class].alt_name : Ship_info[ship_class].name, Weapon_info[Carried_wl_icon.weapon_class].get_display_string());
 				}
 
 				wl_dump_carried_icon();
@@ -3002,16 +3002,16 @@ void wl_render_icon(int index, int x, int y, int num, int draw_num_flag, int hot
 		{
 			//Draw the weapon name, crappy last-ditch effort to not crash.
 			int half_x, half_y;
-			char *print_name = (Weapon_info[index].alt_name[0]) ? Weapon_info[index].alt_name : Weapon_info[index].name;
+			SCP_string print_name = Weapon_info[index].get_display_name();
 
 			// Truncate the # and everything to the right. Zacam
 			end_string_at_first_hash_symbol(print_name);
 
 			// Center-align and fit the text for display
-			gr_get_string_size(&half_x, &half_y, print_name);
+			gr_get_string_size(&half_x, &half_y, print_name.c_str());
 			half_x = x +((56 - half_x) / 2);
 			half_y = y +((28 - half_y) / 2); // Was ((24 - half_y) / 2) Zacam
-			gr_string(half_x, half_y, print_name, GR_RESIZE_MENU);
+			gr_string(half_x, half_y, print_name.c_str(), GR_RESIZE_MENU);
 		}
 	}
 
@@ -3550,7 +3550,7 @@ int wl_swap_slot_slot(int from_bank, int to_bank, int ship_slot, interface_snd_i
 				char display_name[NAME_LENGTH];
 				char txt[39 + NAME_LENGTH];
 
-				strcpy_s(display_name, (Weapon_info[slot->wep[from_bank]].alt_name[0]) ? Weapon_info[slot->wep[from_bank]].alt_name : Weapon_info[slot->wep[from_bank]].name);
+				strcpy_s(display_name, Weapon_info[slot->wep[from_bank]].get_display_name());
 
 				// might have to get weapon name translation
 				if (Lcl_gr) {
@@ -3714,7 +3714,7 @@ int wl_grab_from_list(int from_list, int to_bank, int ship_slot, interface_snd_i
 			char display_name[NAME_LENGTH];
 			char txt[39 + NAME_LENGTH];
 
-			strcpy_s(display_name, Weapon_info[from_list].name);
+			strcpy_s(display_name, Weapon_info[from_list].get_display_string());
 
 			// might have to get weapon name translation
 			if (Lcl_gr) {
@@ -3800,7 +3800,7 @@ int wl_swap_list_slot(int from_list, int to_bank, int ship_slot, interface_snd_i
 			char display_name[NAME_LENGTH];
 			char txt[39 + NAME_LENGTH];
 
-			strcpy_s(display_name, (Weapon_info[from_list].alt_name[0]) ? Weapon_info[from_list].alt_name : Weapon_info[from_list].name);
+			strcpy_s(display_name, Weapon_info[from_list].get_display_name());
 
 			// might have to get weapon name translation
 			if (Lcl_gr) {
@@ -3969,7 +3969,6 @@ void wl_apply_current_loadout_to_all_ships_in_current_wing()
 	ship_info *sip, *source_sip;
 
 	char ship_name[NAME_LENGTH];
-	char *wep_display_name;
 	char buf[NAME_LENGTH];
 
 	// error stuff
@@ -4036,15 +4035,16 @@ void wl_apply_current_loadout_to_all_ships_in_current_wing()
 			weapon_type_to_add = Wss_slots[source_wss_slot].wep[cur_bank];
 
 			// maybe localize
+			const char* wep_display_name;
 			if (Lcl_gr)
 			{
-				strcpy_s(buf, (Weapon_info[weapon_type_to_add].alt_name[0]) ? Weapon_info[weapon_type_to_add].alt_name : Weapon_info[weapon_type_to_add].name);
+				strcpy_s(buf, Weapon_info[weapon_type_to_add].get_display_name());
 				lcl_translate_wep_name_gr(buf);
 				wep_display_name = buf;
 			}
 			else
 			{
-				wep_display_name = (Weapon_info[weapon_type_to_add].alt_name[0]) ? Weapon_info[weapon_type_to_add].alt_name : Weapon_info[weapon_type_to_add].name;
+				wep_display_name = Weapon_info[weapon_type_to_add].get_display_name();
 			}
 
 			// make sure this ship can accept this weapon
@@ -4082,7 +4082,7 @@ void wl_apply_current_loadout_to_all_ships_in_current_wing()
 			if ((result == 0) || (result == 2))
 			{
 				SCP_string temp;
-				sprintf(temp, XSTR("Insufficient %s available to arm %s", 1632), (Weapon_info[weapon_type_to_add].alt_name[0]) ? Weapon_info[weapon_type_to_add].alt_name : Weapon_info[weapon_type_to_add].name, ship_name);
+				sprintf(temp, XSTR("Insufficient %s available to arm %s", 1632), Weapon_info[weapon_type_to_add].get_display_name());
 				error_messages.push_back(temp);
 
 				error_flag = true;

--- a/code/missionui/missionweaponchoice.cpp
+++ b/code/missionui/missionweaponchoice.cpp
@@ -2790,7 +2790,7 @@ void weapon_select_do(float frametime)
 				int ship_class = Wss_slots[Selected_wl_slot].ship_class;
 
 				// might have to get weapon name translation
-				if (Lcl_gr)
+				if (Lcl_gr && !Disable_built_in_translations)
 				{
 					char display_name[NAME_LENGTH];
 					strcpy_s(display_name, Weapon_info[Carried_wl_icon.weapon_class].get_display_name());
@@ -3553,7 +3553,7 @@ int wl_swap_slot_slot(int from_bank, int to_bank, int ship_slot, interface_snd_i
 				strcpy_s(display_name, Weapon_info[slot->wep[from_bank]].get_display_name());
 
 				// might have to get weapon name translation
-				if (Lcl_gr) {
+				if (Lcl_gr && !Disable_built_in_translations) {
 					lcl_translate_wep_name_gr(display_name);
 				}
 
@@ -3717,7 +3717,7 @@ int wl_grab_from_list(int from_list, int to_bank, int ship_slot, interface_snd_i
 			strcpy_s(display_name, Weapon_info[from_list].get_display_string());
 
 			// might have to get weapon name translation
-			if (Lcl_gr) {
+			if (Lcl_gr && !Disable_built_in_translations) {
 				lcl_translate_wep_name_gr(display_name);
 			}
 
@@ -3803,7 +3803,7 @@ int wl_swap_list_slot(int from_list, int to_bank, int ship_slot, interface_snd_i
 			strcpy_s(display_name, Weapon_info[from_list].get_display_name());
 
 			// might have to get weapon name translation
-			if (Lcl_gr) {
+			if (Lcl_gr && !Disable_built_in_translations) {
 				lcl_translate_wep_name_gr(display_name);
 			}
 
@@ -4036,7 +4036,7 @@ void wl_apply_current_loadout_to_all_ships_in_current_wing()
 
 			// maybe localize
 			const char* wep_display_name;
-			if (Lcl_gr)
+			if (Lcl_gr && !Disable_built_in_translations)
 			{
 				strcpy_s(buf, Weapon_info[weapon_type_to_add].get_display_name());
 				lcl_translate_wep_name_gr(buf);

--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -42,6 +42,7 @@ bool Unicode_text_mode;
 SCP_string Movie_subtitle_font;
 bool Enable_scripts_in_fred; // By default FRED does not initialize the scripting system
 SCP_string Window_icon_path;
+bool Disable_built_in_translations;
 
 void parse_mod_table(const char *filename)
 {
@@ -355,6 +356,10 @@ void parse_mod_table(const char *filename)
 			stuff_string(Movie_subtitle_font, F_NAME);
 		}
 
+		if (optional_string("$Disable built-in translations:")) {
+			stuff_boolean(&Disable_built_in_translations);
+		}
+
 		required_string("#END");
 	}
 	catch (const parse::ParseException& e)
@@ -411,4 +416,5 @@ void mod_table_reset() {
 	Movie_subtitle_font = "font01.vf";
 	Enable_scripts_in_fred = false;
 	Window_icon_path = "app_icon_sse";
+	Disable_built_in_translations = false;
 }

--- a/code/mod_table/mod_table.h
+++ b/code/mod_table/mod_table.h
@@ -35,6 +35,7 @@ extern bool Unicode_text_mode;
 extern SCP_string Movie_subtitle_font;
 extern bool Enable_scripts_in_fred;
 extern SCP_string Window_icon_path;
+extern bool Disable_built_in_translations;
 
 void mod_table_init();
 

--- a/code/network/multi_ingame.cpp
+++ b/code/network/multi_ingame.cpp
@@ -865,13 +865,13 @@ void multi_ingame_join_display_ship(object *objp,int y_start)
 	// blit the ship's primary weapons	
 	y_spacing = (Mi_spacing[gr_screen.res] - (wp->num_primary_banks * line_height)) / 2;
 	for(idx=0;idx<wp->num_primary_banks;idx++){
-		gr_string(Mi_primary_field[gr_screen.res][MI_FIELD_X], y_start + y_spacing + (idx * line_height), Weapon_info[wp->primary_bank_weapons[idx]].name, GR_RESIZE_MENU);
+		gr_string(Mi_primary_field[gr_screen.res][MI_FIELD_X], y_start + y_spacing + (idx * line_height), Weapon_info[wp->primary_bank_weapons[idx]].get_display_string(), GR_RESIZE_MENU);
 	}
 
 	// blit the ship's secondary weapons	
 	y_spacing = (Mi_spacing[gr_screen.res] - (wp->num_secondary_banks * line_height)) / 2;
 	for(idx=0;idx<wp->num_secondary_banks;idx++){
-		gr_string(Mi_secondary_field[gr_screen.res][MI_FIELD_X], y_start + y_spacing + (idx * line_height), Weapon_info[wp->secondary_bank_weapons[idx]].name, GR_RESIZE_MENU);
+		gr_string(Mi_secondary_field[gr_screen.res][MI_FIELD_X], y_start + y_spacing + (idx * line_height), Weapon_info[wp->secondary_bank_weapons[idx]].get_display_string(), GR_RESIZE_MENU);
 	}	
 
 	// blit the shield/hull integrity

--- a/code/playerman/playercontrol.cpp
+++ b/code/playerman/playercontrol.cpp
@@ -1780,7 +1780,7 @@ void player_generate_killer_weapon_name(int weapon_info_index, int killer_specie
 #else
 	if (killer_species == Ship_info[Player_ship->ship_info_index].species) {
 #endif
-		strcpy(weapon_name, Weapon_info[weapon_info_index].name);
+		strcpy(weapon_name, Weapon_info[weapon_info_index].get_display_string());
 	} else {
 		if ( Weapon_info[weapon_info_index].subtype == WP_MISSILE ) {
 			strcpy(weapon_name, XSTR( "missile", 90));

--- a/code/scripting/api/objs/object.cpp
+++ b/code/scripting/api/objs/object.cpp
@@ -52,7 +52,7 @@ ADE_FUNC(__tostring, l_Object, NULL, "Returns name of object (if any)", "string"
 			sprintf(buf, "%s", Ships[objh->objp->instance].ship_name);
 			break;
 		case OBJ_WEAPON:
-			sprintf(buf, "%s projectile", Weapon_info[Weapons[objh->objp->instance].weapon_info_index].name);
+			sprintf(buf, "%s projectile", Weapon_info[Weapons[objh->objp->instance].weapon_info_index].get_display_string());
 			break;
 		default:
 			sprintf(buf, "Object %d [%d]", OBJ_INDEX(objh->objp), objh->sig);

--- a/code/scripting/api/objs/weaponclass.cpp
+++ b/code/scripting/api/objs/weaponclass.cpp
@@ -22,7 +22,7 @@ ADE_FUNC(__tostring, l_Weaponclass, NULL, "Weapon class name", "string", "Weapon
 	if(idx < 0 || idx >= Num_weapon_types)
 		return ade_set_error(L, "s", "");
 
-	return ade_set_args(L, "s", Weapon_info[idx].name);
+	return ade_set_args(L, "s", Weapon_info[idx].get_display_string());
 }
 
 ADE_FUNC(__eq, l_Weaponclass, "weaponclass, weaponclass", "Checks if the two classes are equal", "boolean", "true if equal false otherwise")
@@ -40,8 +40,7 @@ ADE_FUNC(__eq, l_Weaponclass, "weaponclass, weaponclass", "Checks if the two cla
 	return ade_set_args(L, "b", idx1 == idx2);
 }
 
-ADE_VIRTVAR(Name, l_Weaponclass, "string", "Weapon class name", "string", "Weapon class name, or empty string if handle is invalid")
-
+ADE_VIRTVAR(Name, l_Weaponclass, "string", "Weapon class name. This is the possibly untranslated name. Use tostring(class) to get the string which should be shown to the user.", "string", "Weapon class name, or empty string if handle is invalid")
 {
 	int idx;
 	char *s = NULL;
@@ -56,6 +55,23 @@ ADE_VIRTVAR(Name, l_Weaponclass, "string", "Weapon class name", "string", "Weapo
 	}
 
 	return ade_set_args(L, "s", Weapon_info[idx].name);
+}
+
+ADE_VIRTVAR(AltName, l_Weaponclass, "string", "The alternate weapon class name.", "string", "Alternate weapon class name, or empty string if handle is invalid")
+{
+	int idx;
+	char *s = nullptr;
+	if(!ade_get_args(L, "o|s", l_Weaponclass.Get(&idx), &s))
+		return ade_set_error(L, "s", "");
+
+	if(idx < 0 || idx >= Num_weapon_types)
+		return ade_set_error(L, "s", "");
+
+	if(ADE_SETTING_VAR && s != nullptr) {
+		strncpy(Weapon_info[idx].alt_name, s, sizeof(Weapon_info[idx].alt_name)-1);
+	}
+
+	return ade_set_args(L, "s", Weapon_info[idx].alt_name);
 }
 
 ADE_VIRTVAR(Title, l_Weaponclass, "string", "Weapon class title", "string", "Weapon class title, or empty string if handle is invalid")

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -11753,7 +11753,7 @@ int ship_fire_secondary( object *obj, int allow_swarm )
 						HUD_sourced_printf(HUD_SOURCE_HIDDEN, "%s", XSTR( "Too far from target to acquire lock", 487));
 					} else {
 						char missile_name[NAME_LENGTH];
-						strcpy_s(missile_name, wip->name);
+						strcpy_s(missile_name, wip->get_display_string());
 						end_string_at_first_hash_symbol(missile_name);
 						HUD_sourced_printf(HUD_SOURCE_HIDDEN, XSTR( "Cannot fire %s without a lock", 488), missile_name);
 					}
@@ -11780,7 +11780,7 @@ int ship_fire_secondary( object *obj, int allow_swarm )
 			{
 				if ( !Weapon_energy_cheat )
 				{
-					HUD_sourced_printf(HUD_SOURCE_HIDDEN, NOX("Cannot fire %s if target is not tagged"),wip->name);
+					HUD_sourced_printf(HUD_SOURCE_HIDDEN, NOX("Cannot fire %s if target is not tagged"),wip->get_display_string());
 					snd_play( gamesnd_get_game_sound(ship_get_sound(Player_obj, GameSounds::OUT_OF_MISSLES)) );
 					swp->next_secondary_fire_stamp[bank] = timestamp(800);	// to avoid repeating messages
 					return 0;
@@ -11838,7 +11838,7 @@ int ship_fire_secondary( object *obj, int allow_swarm )
 			if ( obj == Player_obj ) 
 				if ( ship_maybe_play_secondary_fail_sound(wip) ) {
 					char missile_name[NAME_LENGTH];
-					strcpy_s(missile_name, Weapon_info[weapon_idx].name);
+					strcpy_s(missile_name, Weapon_info[weapon_idx].get_display_string());
 					end_string_at_first_hash_symbol(missile_name);
 					HUD_sourced_printf(HUD_SOURCE_HIDDEN, XSTR( "Cannot fire %s due to weapons system damage", 489), missile_name);
 				}
@@ -12177,7 +12177,7 @@ int ship_select_next_primary(object *objp, int direction)
 	{
 		if ( objp == Player_obj )
 		{
-			HUD_sourced_printf(HUD_SOURCE_HIDDEN, XSTR( "This ship has only one primary weapon: %s", 491),Weapon_info[swp->primary_bank_weapons[swp->current_primary_bank]].name, swp->current_primary_bank + 1);
+			HUD_sourced_printf(HUD_SOURCE_HIDDEN, XSTR( "This ship has only one primary weapon: %s", 491),Weapon_info[swp->primary_bank_weapons[swp->current_primary_bank]].get_display_string(), swp->current_primary_bank + 1);
 			gamesnd_play_error_beep();
 		}
 		return 0;
@@ -12375,7 +12375,7 @@ int ship_select_next_secondary(object *objp)
 	{
 		if ( objp == Player_obj )
 		{
-			HUD_sourced_printf(HUD_SOURCE_HIDDEN, XSTR( "This ship has only one secondary weapon: %s", 493), Weapon_info[swp->secondary_bank_weapons[swp->current_secondary_bank]].name, swp->current_secondary_bank + 1);
+			HUD_sourced_printf(HUD_SOURCE_HIDDEN, XSTR( "This ship has only one secondary weapon: %s", 493), Weapon_info[swp->secondary_bank_weapons[swp->current_secondary_bank]].get_display_string(), swp->current_secondary_bank + 1);
 			gamesnd_play_error_beep();
 		}
 		return 0;

--- a/code/stats/medals.cpp
+++ b/code/stats/medals.cpp
@@ -224,6 +224,13 @@ medal_stuff& medal_stuff::operator=(const medal_stuff &m)
 
 	return *this;
 }
+const char* medal_stuff::get_display_string() {
+	if (!alt_name.empty()) {
+		return alt_name.c_str();
+	} else {
+		return name;
+	}
+}
 
 void parse_medal_tbl()
 {
@@ -310,6 +317,10 @@ void parse_medal_tbl()
 			// is this rank?  if so, save it
 			if (!stricmp(temp_medal.name, "Rank"))
 				Rank_medal_index = Num_medals;
+
+			if (optional_string("$Alt Name:")) {
+				stuff_string(temp_medal.alt_name, F_NAME);
+			}
 
 			required_string("$Bitmap:");
 			stuff_string(temp_medal.bitmap, F_NAME, MAX_FILENAME_LEN);
@@ -600,7 +611,7 @@ void medal_main_init(player *pl, int mode)
 		Medals_window.set_mask_bmap(bitmap_buf);
 }
 
-void blit_label(char *label, int num)
+void blit_label(const char *label, int num)
 {
 	int x, y, sw;
 	char text[256];
@@ -736,7 +747,7 @@ int medal_main_do()
 
 		default:
 			if (Player_score->medal_counts[region] > 0) {
-				blit_label(Medals[region].name, Player_score->medal_counts[region]);
+				blit_label(Medals[region].get_display_string(), Player_score->medal_counts[region]);
 			}
 			break;
 	} // end switch

--- a/code/stats/medals.cpp
+++ b/code/stats/medals.cpp
@@ -620,7 +620,7 @@ void blit_label(const char *label, int num)
 
 	// translate medal names before displaying
 	// can't translate in table cuz the names are used in comparisons
-	// Medals no have alternate display names so this code can be disabled in the mod table
+	// Medals now have alternate display names so this code can be disabled in the mod table
 	if (Lcl_gr && !Disable_built_in_translations) {
 		char translated_label[256];
 		strcpy_s(translated_label, label);

--- a/code/stats/medals.cpp
+++ b/code/stats/medals.cpp
@@ -191,39 +191,6 @@ medal_stuff::medal_stuff()
 	voice_base[0] = '\0';
 }
 
-medal_stuff::~medal_stuff()
-{
-	promotion_text.clear();
-}
-
-medal_stuff::medal_stuff(const medal_stuff &m)
-{
-	clone(m);
-}
-
-void medal_stuff::clone(const medal_stuff &m)
-{
-	memcpy(name, m.name, NAME_LENGTH);
-	memcpy(bitmap, m.bitmap, MAX_FILENAME_LEN);
-	memcpy(debrief_bitmap, m.debrief_bitmap, MAX_FILENAME_LEN);
-	num_versions = m.num_versions;
-	version_starts_at_1 = m.version_starts_at_1;
-	available_from_start = m.available_from_start;
-	kills_needed = m.kills_needed;
-	memcpy(voice_base, m.voice_base, MAX_FILENAME_LEN);
-
-	promotion_text = m.promotion_text;
-}
-
-// assignment operator
-medal_stuff& medal_stuff::operator=(const medal_stuff &m)
-{
-	if (this != &m) {
-		clone(m);
-	}
-
-	return *this;
-}
 const char* medal_stuff::get_display_string() {
 	if (!alt_name.empty()) {
 		return alt_name.c_str();

--- a/code/stats/medals.cpp
+++ b/code/stats/medals.cpp
@@ -620,7 +620,8 @@ void blit_label(const char *label, int num)
 
 	// translate medal names before displaying
 	// can't translate in table cuz the names are used in comparisons
-	if (Lcl_gr) {
+	// Medals no have alternate display names so this code can be disabled in the mod table
+	if (Lcl_gr && !Disable_built_in_translations) {
 		char translated_label[256];
 		strcpy_s(translated_label, label);
 		lcl_translate_medal_name_gr(translated_label);
@@ -631,7 +632,7 @@ void blit_label(const char *label, int num)
 		} else {
 			sprintf( text, "%s", translated_label );
 		}
-	} else if (Lcl_pl) {
+	} else if (Lcl_pl && !Disable_built_in_translations) {
 		char translated_label[256];
 		strcpy_s(translated_label, label);
 		lcl_translate_medal_name_pl(translated_label);

--- a/code/stats/medals.h
+++ b/code/stats/medals.h
@@ -29,6 +29,7 @@ class medal_stuff
 {
 public:
 	char	name[NAME_LENGTH];
+	SCP_string alt_name;
 	char	bitmap[MAX_FILENAME_LEN];
 	char	debrief_bitmap[MAX_FILENAME_LEN];
 	int	num_versions;
@@ -45,6 +46,8 @@ public:
 
 	medal_stuff(const medal_stuff &m);
 	medal_stuff& operator=(const medal_stuff &m);
+
+	const char* get_display_string();
 
 private:
 	void clone(const medal_stuff &m);

--- a/code/stats/medals.h
+++ b/code/stats/medals.h
@@ -42,15 +42,8 @@ public:
 	SCP_map<int, SCP_string> promotion_text;
 
 	medal_stuff();
-	~medal_stuff();
-
-	medal_stuff(const medal_stuff &m);
-	medal_stuff& operator=(const medal_stuff &m);
 
 	const char* get_display_string();
-
-private:
-	void clone(const medal_stuff &m);
 };
 
 extern SCP_vector<medal_stuff> Medals;

--- a/code/weapon/emp.cpp
+++ b/code/weapon/emp.cpp
@@ -544,7 +544,7 @@ void emp_maybe_reformat_text(char *text, int  /*max_len*/, int gauge_id)
 		case EG_WEAPON_TITLE: case EG_WEAPON_P1: case EG_WEAPON_P2: case EG_WEAPON_P3: case EG_WEAPON_S1: case EG_WEAPON_S2:			
 			int wep_index;
 			wep_index = (int)frand_range(0.0f, (float)(MAX_WEAPON_TYPES - 1));
-			strcpy_s(wt->str, Weapon_info[ wep_index >= MAX_WEAPON_TYPES ? 0 : wep_index ].name);			
+			strcpy_s(wt->str, Weapon_info[ wep_index >= MAX_WEAPON_TYPES ? 0 : wep_index ].get_display_string());
 			break;		
 
 		// escort list

--- a/code/weapon/weapon.h
+++ b/code/weapon/weapon.h
@@ -470,7 +470,9 @@ public:
     inline bool hurts_big_ships()  { return wi_flags[Weapon::Info_Flags::Bomb, Weapon::Info_Flags::Beam, Weapon::Info_Flags::Huge, Weapon::Info_Flags::Big_only]; }
     inline bool is_interceptable() { return wi_flags[Weapon::Info_Flags::Fighter_Interceptable, Weapon::Info_Flags::Turret_Interceptable]; }
 
-    const char* get_display_name();
+	const char* get_display_name();
+
+	bool has_display_name();
 
 	void reset();
 } weapon_info;

--- a/code/weapon/weapon.h
+++ b/code/weapon/weapon.h
@@ -470,9 +470,9 @@ public:
     inline bool hurts_big_ships()  { return wi_flags[Weapon::Info_Flags::Bomb, Weapon::Info_Flags::Beam, Weapon::Info_Flags::Huge, Weapon::Info_Flags::Big_only]; }
     inline bool is_interceptable() { return wi_flags[Weapon::Info_Flags::Fighter_Interceptable, Weapon::Info_Flags::Turret_Interceptable]; }
 
-	const char* get_display_name();
+	const char* get_display_string();
 
-	bool has_display_name();
+	bool has_alternate_name();
 
 	void reset();
 } weapon_info;

--- a/code/weapon/weapon.h
+++ b/code/weapon/weapon.h
@@ -470,6 +470,8 @@ public:
     inline bool hurts_big_ships()  { return wi_flags[Weapon::Info_Flags::Bomb, Weapon::Info_Flags::Beam, Weapon::Info_Flags::Huge, Weapon::Info_Flags::Big_only]; }
     inline bool is_interceptable() { return wi_flags[Weapon::Info_Flags::Fighter_Interceptable, Weapon::Info_Flags::Turret_Interceptable]; }
 
+    const char* get_display_name();
+
 	void reset();
 } weapon_info;
 

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -7780,9 +7780,12 @@ void weapon_info::reset()
 	this->impact_decal = decals::creation_info();
 }
 const char* weapon_info::get_display_name() {
-	if (alt_name[0] != '\0') {
+	if (has_display_name()) {
 		return alt_name;
 	} else {
 		return name;
 	}
+}
+bool weapon_info::has_display_name() {
+	return alt_name[0] != '\0';
 }

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -7779,13 +7779,13 @@ void weapon_info::reset()
 	// Reset using default constructor
 	this->impact_decal = decals::creation_info();
 }
-const char* weapon_info::get_display_name() {
-	if (has_display_name()) {
+const char* weapon_info::get_display_string() {
+	if (has_alternate_name()) {
 		return alt_name;
 	} else {
 		return name;
 	}
 }
-bool weapon_info::has_display_name() {
+bool weapon_info::has_alternate_name() {
 	return alt_name[0] != '\0';
 }

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -48,6 +48,8 @@
 #include "particle/effects/ParticleEmitterEffect.h"
 #include "tracing/Monitor.h"
 #include "tracing/tracing.h"
+#include "weapon.h"
+
 
 // Since SSMs are parsed after weapons, if we want to allow SSM strikes to be specified by name, we need to store those names until after SSMs are parsed.
 typedef struct delayed_ssm_data {
@@ -7503,6 +7505,7 @@ void weapon_info::reset()
 	this->render_type = WRT_NONE;
 
 	memset(this->name, 0, sizeof(this->name));
+	memset(this->alt_name, 0, sizeof(this->alt_name));
 	memset(this->title, 0, sizeof(this->title));
 	this->desc = NULL;
 
@@ -7775,4 +7778,11 @@ void weapon_info::reset()
 
 	// Reset using default constructor
 	this->impact_decal = decals::creation_info();
+}
+const char* weapon_info::get_display_name() {
+	if (alt_name[0] != '\0') {
+		return alt_name;
+	} else {
+		return name;
+	}
 }

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -2895,7 +2895,7 @@ void say_view_target()
 				}
 				break;
 			case OBJ_WEAPON:
-				strcpy_s(view_target_name, Weapon_info[Weapons[Objects[Player_ai->target_objnum].instance].weapon_info_index].name);
+				strcpy_s(view_target_name, Weapon_info[Weapons[Objects[Player_ai->target_objnum].instance].weapon_info_index].get_display_string());
 				Viewer_mode &= ~VM_OTHER_SHIP;
 				break;
 			case OBJ_JUMP_NODE: {


### PR DESCRIPTION
This fixes or implements a few things requested in #1730.

New features:
- Alternative name for medals that is only used for displaying their name. This allows them to be translated without causing issues with the medal SEXPs.
- A game_settings option for disabling all currently built-in translations. Since the parts of the engine where this was used have been updated with proper translation support, the built-in translations are not needed anymore. They can be disabled with a game_settings option so that backwards compatibility is not broken.