### PR TITLE
Change Warning about missing 640x480 interface art to a log statement

### DIFF
--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -424,11 +424,11 @@ void parse_custom_bitmap(const char *expected_string_640, const char *expected_s
 	// error testing
 	if (Fred_running && (found640) && !(found1024))
 	{
-		Warning(LOCATION, "Mission: found an entry for %s but not a corresponding entry for %s!", expected_string_640, expected_string_1024);
+		nprintf(("General", "Mission: found an entry for %s but not a corresponding entry for %s!", expected_string_640, expected_string_1024));
 	}
 	if (Fred_running && !(found640) && (found1024))
 	{
-		Warning(LOCATION, "Mission: found an entry for %s but not a corresponding entry for %s!", expected_string_1024, expected_string_640);
+		nprintf(("General", "Mission: found an entry for %s but not a corresponding entry for %s!", expected_string_1024, expected_string_640));
 	}
 }
 

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -424,11 +424,11 @@ void parse_custom_bitmap(const char *expected_string_640, const char *expected_s
 	// error testing
 	if (Fred_running && (found640) && !(found1024))
 	{
-		nprintf(("General", "Mission: found an entry for %s but not a corresponding entry for %s!", expected_string_640, expected_string_1024));
+		mprintf(("Mission: found an entry for %s but not a corresponding entry for %s!", expected_string_640, expected_string_1024));
 	}
 	if (Fred_running && !(found640) && (found1024))
 	{
-		nprintf(("General", "Mission: found an entry for %s but not a corresponding entry for %s!", expected_string_1024, expected_string_640));
+		mprintf(("Mission: found an entry for %s but not a corresponding entry for %s!", expected_string_1024, expected_string_640));
 	}
 }
 


### PR DESCRIPTION
This turns the Warning about missing 640 interface art into a log print.  This applies to all instances of 640/1024 interface art that can be specified in FRED, e.g. loading screens, cbrief and briefing backgrounds, and ship/weapon selection backgrounds.

This fixes #1601.