### PR TITLE
Respect trailing white space in tstrings.tbl strings

### DIFF
--- a/code/localization/localize.cpp
+++ b/code/localization/localize.cpp
@@ -278,7 +278,6 @@ void parse_stringstbl_common(const char *filename, const bool external)
 			if (external) {
 				ignore_white_space();
 				get_string(buf, sizeof(buf));
-				drop_trailing_white_space(buf);
 			} else {
 				stuff_string(buf, F_RAW, sizeof(buf));
 			}


### PR DESCRIPTION
The current code drops trailing white space which can cause issues if
the translated string is used in concatenations. The retail tstrings.tbl
has some entries with white space at the end but since those strings are
not used for concatenations (or else this issue would have been found
earlier) this change should not cause issues there.

This fixes #1739.