### PR TITLE
Add ship display name feature

### DIFF
--- a/code/hud/hudescort.cpp
+++ b/code/hud/hudescort.cpp
@@ -372,7 +372,7 @@ void HudGaugeEscort::renderIcon(int x, int y, int index)
 	}
 
 	// print out ship name
-	strcpy_s(buf, sp->ship_name);
+	strcpy_s(buf, sp->get_display_string());
 	font::force_fit_string(buf, 255, ship_name_max_width);
 	
     end_string_at_first_hash_symbol(buf);

--- a/code/hud/hudmessage.cpp
+++ b/code/hud/hudmessage.cpp
@@ -558,7 +558,7 @@ void HUD_ship_sent_printf(int sh, const char *format, ...)
 	tmp[sizeof(tmp)-1] = '\0';
 	size_t len;
 
-	snprintf(tmp, sizeof(tmp)-1, NOX("%s: "), Ships[sh].ship_name);
+	snprintf(tmp, sizeof(tmp)-1, NOX("%s: "), Ships[sh].get_display_string());
 	len = strlen(tmp);
 
 	va_start(args, format);

--- a/code/hud/hudobserver.cpp
+++ b/code/hud/hudobserver.cpp
@@ -30,6 +30,7 @@ void hud_observer_init(ship *shipp, ai_info *aip)
 	// (we used to do a memcpy here, but that doesn't work any longer, so let's just assign the values we need)
 	Hud_obs_ship.clear();
 	strcpy_s(Hud_obs_ship.ship_name, shipp->ship_name);
+	Hud_obs_ship.display_name = shipp->display_name;
 	Hud_obs_ship.team = shipp->team;
 	Hud_obs_ship.ai_index = shipp->ai_index;
 	Hud_obs_ship.flags = shipp->flags;

--- a/code/hud/hudsquadmsg.cpp
+++ b/code/hud/hudsquadmsg.cpp
@@ -404,7 +404,7 @@ int hud_squadmsg_count_ships(int add_to_menu)
 		if (add_to_menu)
 		{
 			Assert ( Num_menu_items < MAX_MENU_ITEMS );
-			strcpy_s( MsgItems[Num_menu_items].text, shipp->ship_name );
+			strcpy_s( MsgItems[Num_menu_items].text, shipp->get_display_string() );
 			end_string_at_first_hash_symbol(MsgItems[Num_menu_items].text); // truncate the name if it has a # in it
 			MsgItems[Num_menu_items].instance = SHIP_INDEX(shipp);
 			MsgItems[Num_menu_items].active = 1;

--- a/code/hud/hudtarget.cpp
+++ b/code/hud/hudtarget.cpp
@@ -5293,7 +5293,7 @@ void hud_stuff_ship_name(char *ship_name_text, ship *shipp)
 	if ( ((Iff_info[shipp->team].flags & IFFF_WING_NAME_HIDDEN) && (shipp->wingnum != -1)) || (shipp->flags[Ship::Ship_Flags::Hide_ship_name]) ) {
 		*ship_name_text = 0;
 	} else {
-		strcpy(ship_name_text, shipp->ship_name);
+		strcpy(ship_name_text, shipp->get_display_string());
 
 		// handle hash symbol
 		end_string_at_first_hash_symbol(ship_name_text);

--- a/code/hud/hudtargetbox.cpp
+++ b/code/hud/hudtargetbox.cpp
@@ -1405,7 +1405,7 @@ void HudGaugeExtraTargetData::pageIn()
  */
 void HudGaugeExtraTargetData::render(float  /*frametime*/)
 {
-	char outstr[256], tmpbuf[256];
+	char tmpbuf[256];
 	int has_orders = 0;
 	int not_training;
 	int extra_data_shown=0;
@@ -1440,17 +1440,22 @@ void HudGaugeExtraTargetData::render(float  /*frametime*/)
 				!(Iff_info[target_shipp->team].flags & IFFF_ORDERS_HIDDEN)))
 			&& Ship_info[target_shipp->ship_info_index].is_flyable()) {
 			extra_data_shown = 1;
-			if (ship_return_orders(outstr, target_shipp)) {
+			auto orders = ship_return_orders(target_shipp);
+			if (!orders.empty()) {
+				char outstr[256];
+				strcpy_s(outstr, orders.c_str());
 				font::force_fit_string(outstr, 255, order_max_w);
+				orders = outstr;
 				has_orders = 1;
 			} else {
-				strcpy_s(outstr, XSTR("no orders", 337));
+				orders = XSTR("no orders", 337);
 			}
 
-			renderString(position[0] + order_offsets[0], position[1] + order_offsets[1], EG_TBOX_EXTRA1, outstr);
+			renderString(position[0] + order_offsets[0], position[1] + order_offsets[1], EG_TBOX_EXTRA1, orders.c_str());
 		}
 
 		if ( has_orders ) {
+			char outstr[256];
 			strcpy_s(outstr, XSTR( "time to: ", 338));
 			if ( ship_return_time_to_goal(tmpbuf, target_shipp) ) {
 				strcat_s(outstr, tmpbuf);
@@ -1471,10 +1476,11 @@ void HudGaugeExtraTargetData::render(float  /*frametime*/)
 		// count the objects directly docked to me
 		int dock_count = dock_count_direct_docked_objects(target_objp);
 
+		char outstr[256];
 		// docked to only one object
 		if (dock_count == 1)
 		{
-			sprintf(outstr, XSTR("Docked: %s", 339), Ships[dock_get_first_docked_object(target_objp)->instance].ship_name);
+			sprintf(outstr, XSTR("Docked: %s", 339), Ships[dock_get_first_docked_object(target_objp)->instance].get_display_string());
 			end_string_at_first_hash_symbol(outstr);
 		}
 		// docked to multiple objects
@@ -2040,10 +2046,10 @@ void HudGaugeTargetBox::showTargetData(float  /*frametime*/)
 				float	dot, dist;
 				vec3d	v2t;
 
-				if (aip->target_objnum == Player_obj-Objects)
+				if (aip->target_objnum == OBJ_INDEX(Player_obj))
 					strcpy_s(target_str, "Player!");
 				else
-					sprintf(target_str, "%s", Ships[Objects[aip->target_objnum].instance].ship_name);
+					sprintf(target_str, "%s", Ships[Objects[aip->target_objnum].instance].get_display_string());
 
 				gr_printf_no_resize(sx, sy, "Targ: %s", target_str);
 				sy += dy;
@@ -2091,14 +2097,14 @@ void HudGaugeTargetBox::showTargetData(float  /*frametime*/)
 						eshipp = &Ships[Enemy_attacker->instance];
 						eaip = &Ai_info[eshipp->ai_index];
 
-						if (eaip->target_objnum == Player_obj-Objects) {
+						if (eaip->target_objnum == OBJ_INDEX(Player_obj)) {
 							found = 1;
 							dist = vm_vec_dist_quick(&Enemy_attacker->pos, &Player_obj->pos);
 							vm_vec_normalized_dir(&v2t,&Objects[eaip->target_objnum].pos, &Enemy_attacker->pos);
 
 							dot = vm_vec_dot(&v2t, &Enemy_attacker->orient.vec.fvec);
 
-							gr_printf_no_resize(sx, sy, "#%i: %s", OBJ_INDEX(Enemy_attacker), Ships[Enemy_attacker->instance].ship_name);
+							gr_printf_no_resize(sx, sy, "#%i: %s", OBJ_INDEX(Enemy_attacker), Ships[Enemy_attacker->instance].get_display_string());
 							sy += dy;
 							gr_printf_no_resize(sx, sy, "Targ dist: %5.1f", dist);
 							sy += dy;

--- a/code/io/keycontrol.cpp
+++ b/code/io/keycontrol.cpp
@@ -896,7 +896,7 @@ void process_debug_keys(int k)
 				object	*objp = &Objects[Player_ai->target_objnum];
 
 				objp->flags.toggle(Object::Object_Flags::Invulnerable);
-				HUD_sourced_printf(HUD_SOURCE_HIDDEN, XSTR( "Player's target [%s] is %s", 13), Ships[objp->instance].ship_name, objp->flags[Object::Object_Flags::Invulnerable] ? XSTR( "now INVULNERABLE!", 11) : XSTR( "no longer invulnerable...", 12));
+				HUD_sourced_printf(HUD_SOURCE_HIDDEN, XSTR( "Player's target [%s] is %s", 13), Ships[objp->instance].get_display_string(), objp->flags[Object::Object_Flags::Invulnerable] ? XSTR( "now INVULNERABLE!", 11) : XSTR( "no longer invulnerable...", 12));
 			}
 			break;
 
@@ -1066,12 +1066,12 @@ void process_debug_keys(int k)
 
 			if (is_support_allowed(obj_to_rearm))
 			{
-				HUD_sourced_printf(HUD_SOURCE_HIDDEN, XSTR("Issuing rearm request for %s", 1610), Ships[obj_to_rearm->instance].ship_name);
+				HUD_sourced_printf(HUD_SOURCE_HIDDEN, XSTR("Issuing rearm request for %s", 1610), Ships[obj_to_rearm->instance].get_display_string());
 				ai_issue_rearm_request(obj_to_rearm);
 			}
 			else
 			{
-				HUD_sourced_printf(HUD_SOURCE_HIDDEN, XSTR("Cannot issue rearm request for %s", 1611), Ships[obj_to_rearm->instance].ship_name);
+				HUD_sourced_printf(HUD_SOURCE_HIDDEN, XSTR("Cannot issue rearm request for %s", 1611), Ships[obj_to_rearm->instance].get_display_string());
 			}
 
 			break;
@@ -1325,7 +1325,7 @@ void ppsk_hotkeys(int k)
 				HUD_sourced_printf(HUD_SOURCE_HIDDEN, XSTR( "No target to add/remove from set %d.", 26), hotkey_set+1);
 			else  {
 				hud_target_hotkey_add_remove( hotkey_set, &Objects[Player_ai->target_objnum], HOTKEY_USER_ADDED);
-				HUD_sourced_printf(HUD_SOURCE_HIDDEN, XSTR( "%s added to set %d. (F%d)", 27), Ships[Objects[Player_ai->target_objnum].instance].ship_name, hotkey_set, 4+hotkey_set+1);
+				HUD_sourced_printf(HUD_SOURCE_HIDDEN, XSTR( "%s added to set %d. (F%d)", 27), Ships[Objects[Player_ai->target_objnum].instance].get_display_string(), hotkey_set, 4+hotkey_set+1);
 			}
 
 			break;
@@ -1569,6 +1569,7 @@ void game_process_cheats(int k)
 
 		ship *shipp = &Ships[Objects[objnum].instance];
 		shipp->ship_name[0] = '\0';
+		shipp->display_name.clear();
 		shipp->orders_accepted = (1<<NUM_COMM_ORDER_ITEMS)-1;
 
 		// Goober5000 - stolen from support ship creation

--- a/code/mission/missionhotkey.cpp
+++ b/code/mission/missionhotkey.cpp
@@ -260,7 +260,7 @@ static UI_XSTR Hotkey_text[GR_NUM_RESOLUTIONS][HOTKEY_NUM_TEXT] = {
 
 
 static struct {
-	const char *label;
+	SCP_string label;
 	int type;
 	int index;
 	int y;  // Y coordinate of line
@@ -524,7 +524,7 @@ int hotkey_line_add(const char *text, int type, int index, int y)
 }
 
 // insert a line of hotkey smuck before line 'n'.
-int hotkey_line_insert(int n, char *text, int type, int index)
+int hotkey_line_insert(int n, const char *text, int type, int index)
 {
 	int z;
 
@@ -545,7 +545,7 @@ int hotkey_line_insert(int n, char *text, int type, int index)
 
 // insert a line of hotkey smuck somewhere between 'start' and end of list such that it is
 // sorted by name
-int hotkey_line_add_sorted(char *text, int type, int index, int start)
+int hotkey_line_add_sorted(const char *text, int type, int index, int start)
 {
 	int z;
 
@@ -553,7 +553,7 @@ int hotkey_line_add_sorted(char *text, int type, int index, int start)
 		return -1;
 
 	z = Num_lines - 1;
-	while ((z >= start) && ((Hotkey_lines[z].type == HOTKEY_LINE_SUBSHIP) || (stricmp(text, Hotkey_lines[z].label) < 0)))
+	while ((z >= start) && ((Hotkey_lines[z].type == HOTKEY_LINE_SUBSHIP) || (stricmp(text, Hotkey_lines[z].label.c_str()) < 0)))
 		z--;
 
 	z++;
@@ -620,7 +620,7 @@ int hotkey_build_team_listing(int enemy_team_mask, int y, bool list_enemies)
 
 		// be sure this ship isn't in a wing, and that the teams match
 		if ( iff_matches_mask(Ships[shipnum].team, team_mask) && (Ships[shipnum].wingnum < 0) ) {
-			hotkey_line_add_sorted(Ships[shipnum].ship_name, HOTKEY_LINE_SHIP, shipnum, start);
+			hotkey_line_add_sorted(Ships[shipnum].get_display_string(), HOTKEY_LINE_SHIP, shipnum, start);
 		}
 	}
 
@@ -652,7 +652,7 @@ int hotkey_build_team_listing(int enemy_team_mask, int y, bool list_enemies)
 			if (Wings[i].flags[Ship::Wing_Flags::Expanded]) {
 				for (j=0; j<Wings[i].current_count; j++) {
 					s = Wings[i].ship_index[j];
-					z = hotkey_line_insert(z + 1, Ships[s].ship_name, HOTKEY_LINE_SUBSHIP, s);
+					z = hotkey_line_insert(z + 1, Ships[s].get_display_string(), HOTKEY_LINE_SUBSHIP, s);
 				}
 			}
 		}
@@ -1172,7 +1172,7 @@ void mission_hotkey_do_frame(float  /*frametime*/)
 			case HOTKEY_LINE_HEADING:
 				gr_set_color_fast(&Color_text_heading);
 
-				gr_get_string_size(&w, &h, Hotkey_lines[line].label);
+				gr_get_string_size(&w, &h, Hotkey_lines[line].label.c_str());
 				i = y + h / 2 - 1;
 				gr_line(Hotkey_list_coords[gr_screen.res][0], i, Hotkey_ship_x[gr_screen.res] - 2, i, GR_RESIZE_MENU);
 				gr_line(Hotkey_ship_x[gr_screen.res] + w + 1, i, Hotkey_list_coords[gr_screen.res][0] + Hotkey_list_coords[gr_screen.res][2], i, GR_RESIZE_MENU);
@@ -1251,7 +1251,7 @@ void mission_hotkey_do_frame(float  /*frametime*/)
 		}
 	
 		// draw ship/wing name
-		strcpy_s(buf, Hotkey_lines[line].label);
+		strcpy_s(buf, Hotkey_lines[line].label.c_str());
 		end_string_at_first_hash_symbol(buf);
 		if (Hotkey_lines[line].type == HOTKEY_LINE_SUBSHIP) {
 			// indent

--- a/code/mission/missionlog.h
+++ b/code/mission/missionlog.h
@@ -17,26 +17,28 @@
 
 // defined for different mission log entries
 
-#define LOG_SHIP_DESTROYED					1
-#define LOG_WING_DESTROYED					2
-#define LOG_SHIP_ARRIVED					3
-#define LOG_WING_ARRIVED					4
-#define LOG_SHIP_DEPARTED					5
-#define LOG_WING_DEPARTED					6
-#define LOG_SHIP_DOCKED						7
-#define LOG_SHIP_SUBSYS_DESTROYED			8
-#define LOG_SHIP_UNDOCKED					9
-#define LOG_SHIP_DISABLED					10
-#define LOG_SHIP_DISARMED					11
-#define LOG_PLAYER_CALLED_FOR_REARM			12
-#define LOG_PLAYER_CALLED_FOR_REINFORCEMENT	13
-#define LOG_GOAL_SATISFIED					14
-#define LOG_GOAL_FAILED						15
-#define LOG_PLAYER_ABORTED_REARM			16
-#define LOG_WAYPOINTS_DONE					17
-#define LOG_CARGO_REVEALED					18
-#define LOG_CAP_SUBSYS_CARGO_REVEALED		19
-#define LOG_SELF_DESTRUCTED					20
+enum LogType {
+	LOG_SHIP_DESTROYED                  = 1,
+	LOG_WING_DESTROYED                  = 2,
+	LOG_SHIP_ARRIVED                    = 3,
+	LOG_WING_ARRIVED                    = 4,
+	LOG_SHIP_DEPARTED                   = 5,
+	LOG_WING_DEPARTED                   = 6,
+	LOG_SHIP_DOCKED                     = 7,
+	LOG_SHIP_SUBSYS_DESTROYED           = 8,
+	LOG_SHIP_UNDOCKED                   = 9,
+	LOG_SHIP_DISABLED                   = 10,
+	LOG_SHIP_DISARMED                   = 11,
+	LOG_PLAYER_CALLED_FOR_REARM         = 12,
+	LOG_PLAYER_CALLED_FOR_REINFORCEMENT = 13,
+	LOG_GOAL_SATISFIED                  = 14,
+	LOG_GOAL_FAILED                     = 15,
+	LOG_PLAYER_ABORTED_REARM            = 16,
+	LOG_WAYPOINTS_DONE                  = 17,
+	LOG_CARGO_REVEALED                  = 18,
+	LOG_CAP_SUBSYS_CARGO_REVEALED       = 19,
+	LOG_SELF_DESTRUCTED                 = 20,
+};
 
 // structure definition for log entries
 
@@ -44,21 +46,22 @@
 #define MLF_OBSOLETE						(1 << 1)	// this entry is obsolete and will be removed
 #define MLF_HIDDEN							(1 << 2)	// entry doesn't show up in displayed log.
 
-typedef struct {
-	int		type;										// one of the log #defines in MissionLog.h
-	int		flags;										// flags used for status of this log entry
-	fix		timestamp;									// time in fixed seconds when entry was made from beginning of mission
-	char	pname[NAME_LENGTH];							// name of primary object of this action
-	char	sname[NAME_LENGTH];							// name of secondary object of this action
-	int		index;										// a generic entry which can contain things like wave # (for wing arrivals), goal #, etc
+struct log_entry {
+	LogType type;            // one of the log #defines in MissionLog.h
+	int flags;               // flags used for status of this log entry
+	fix timestamp;           // time in fixed seconds when entry was made from beginning of mission
+	char pname[NAME_LENGTH]; // name of primary object of this action
+	char sname[NAME_LENGTH]; // name of secondary object of this action
+	int index;               // a generic entry which can contain things like wave # (for wing arrivals), goal #, etc
 
 	// Goober5000
 	int primary_team;
 	int secondary_team;
-} log_entry;
 
-extern log_entry log_entries[];
-extern int last_entry;
+	SCP_string pname_display;
+	SCP_string sname_display;
+};
+
 extern int Num_log_lines;
 
 // function prototypes
@@ -68,22 +71,19 @@ extern void mission_log_init();
 
 // adds an entry to the mission log.  The name is a string identifier that is the object
 // of the event.  The multiplayer version of this takes the actual entry number to modify.
-extern void mission_log_add_entry(int type, const char *pname, const char *sname, int index = -1);
-extern void mission_log_add_entry_multi( int type, const char *pname, const char *sname, int index, fix timestamp, int flags);
+extern void mission_log_add_entry(LogType type, const char *pname, const char *sname, int index = -1);
+extern void mission_log_add_entry_multi(LogType type, const char *pname, const char *sname, int index, fix timestamp,
+                                        int flags);
 
 // function to determine if event happened and what time it happened
-extern int mission_log_get_time( int type, const char *name, const char *sname, fix *time);
+extern int mission_log_get_time(LogType type, const char *name, const char *sname, fix *time);
 
 // function to determine if event happend count times and return time that the count event
 // happened
-extern int mission_log_get_time_indexed( int type, const char *name, const char *sname, int count, fix *time);
+extern int mission_log_get_time_indexed(LogType type, const char *name, const char *sname, int count, fix *time);
 
 // get the number of times an event happened
-extern int mission_log_get_count( int type, const char *pname, const char *sname ); 
-
-// function to show all message log entries during or after mission
-// (code stolen liberally from Alan!)
-extern void mission_log_scrollback(float frametime);
+extern int mission_log_get_count(LogType type, const char *pname, const char *sname);
 
 void message_log_init_scrollback(int pw);
 void message_log_shutdown_scrollback();

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -75,6 +75,8 @@
 #include "starfield/starfield.h"
 #include "weapon/weapon.h"
 #include "tracing/Monitor.h"
+#include "missionparse.h"
+
 
 LOCAL struct {
 	char docker[NAME_LENGTH];
@@ -1877,6 +1879,7 @@ int parse_create_object_sub(p_object *p_objp)
 	shipp->group = p_objp->group;
 	shipp->team = p_objp->team;
 	strcpy_s(shipp->ship_name, p_objp->name);
+	shipp->display_name = p_objp->display_name;
 	shipp->escort_priority = p_objp->escort_priority;
 	shipp->use_special_explosion = p_objp->use_special_explosion;
 	shipp->special_exp_damage = p_objp->special_exp_damage;
@@ -2737,6 +2740,16 @@ p_object::~p_object()
 {
 	dock_free_dock_list(this);
 }
+const char* p_object::get_display_string() {
+	if (has_display_string()) {
+		return display_name.c_str();
+	} else {
+		return name;
+	}
+}
+bool p_object::has_display_string() {
+	return !display_name.empty();
+}
 
 /**
  * Mp points at the text of an object, which begins with the "$Name:" field.
@@ -2764,6 +2777,9 @@ int parse_object(mission *pm, int  /*flag*/, p_object *p_objp)
 	if (mission_parse_get_parse_object(p_objp->name))
 		error_display(0, NOX("Redundant ship name: %s\n"), p_objp->name);
 
+	if (optional_string("$Display Name:")) {
+		stuff_string(p_objp->display_name, F_NAME);
+	}
 
 	find_and_stuff("$Class:", &p_objp->ship_class, F_NAME, Ship_class_names, Ship_info.size(), "ship class");
 	if (p_objp->ship_class < 0)

--- a/code/mission/missionparse.h
+++ b/code/mission/missionparse.h
@@ -322,6 +322,7 @@ class p_object
 {
 public:
 	char	name[NAME_LENGTH];
+	SCP_string display_name;
 	p_object *next, *prev;
 
 	vec3d	pos;
@@ -413,6 +414,9 @@ public:
 
 	p_object();
 	~p_object();
+
+	const char* get_display_string();
+	bool has_display_string();
 };
 
 // Goober5000 - this is now dynamic

--- a/code/network/multi_pmsg.cpp
+++ b/code/network/multi_pmsg.cpp
@@ -467,7 +467,7 @@ void multi_msg_show_squadmsg(net_player *source,int command,ushort target_sig,in
 	// attack my target
 	case ATTACK_TARGET_ITEM :
 		if((target_obj != NULL) && (target_obj->type == OBJ_SHIP)){
-			sprintf(temp_string,XSTR("Attack %s",700),Ships[target_obj->instance].ship_name);
+			sprintf(temp_string,XSTR("Attack %s",700),Ships[target_obj->instance].get_display_string());
 			strcat_s(hud_string,temp_string);
 		} else {
 			should_display = 0;
@@ -477,7 +477,7 @@ void multi_msg_show_squadmsg(net_player *source,int command,ushort target_sig,in
 	// disable my target
 	case DISABLE_TARGET_ITEM:
 		if((target_obj != NULL) && (target_obj->type == OBJ_SHIP)){
-			sprintf(temp_string,XSTR("Disable %s",701),Ships[target_obj->instance].ship_name);
+			sprintf(temp_string,XSTR("Disable %s",701),Ships[target_obj->instance].get_display_string());
 			strcat_s(hud_string,temp_string);
 		} else {
 			should_display = 0;
@@ -487,7 +487,7 @@ void multi_msg_show_squadmsg(net_player *source,int command,ushort target_sig,in
 	// protect my target
 	case PROTECT_TARGET_ITEM:
 		if((target_obj != NULL) && (target_obj->type == OBJ_SHIP)){
-			sprintf(temp_string,XSTR("Protect %s",702),Ships[target_obj->instance].ship_name);
+			sprintf(temp_string,XSTR("Protect %s",702),Ships[target_obj->instance].get_display_string());
 			strcat_s(hud_string,temp_string);
 		} else {
 			should_display = 0;
@@ -497,7 +497,7 @@ void multi_msg_show_squadmsg(net_player *source,int command,ushort target_sig,in
 	// ignore my target
 	case IGNORE_TARGET_ITEM:
 		if((target_obj != NULL) && (target_obj->type == OBJ_SHIP)){
-			sprintf(temp_string,XSTR("Ignore %s",703),Ships[target_obj->instance].ship_name);
+			sprintf(temp_string,XSTR("Ignore %s",703),Ships[target_obj->instance].get_display_string());
 			strcat_s(hud_string,temp_string);
 		} else {
 			should_display = 0;
@@ -507,7 +507,7 @@ void multi_msg_show_squadmsg(net_player *source,int command,ushort target_sig,in
 	// disarm my target
 	case DISARM_TARGET_ITEM:
 		if((target_obj != NULL) && (target_obj->type == OBJ_SHIP)){
-			sprintf(temp_string,XSTR("Disarm %s",704),Ships[target_obj->instance].ship_name);
+			sprintf(temp_string,XSTR("Disarm %s",704),Ships[target_obj->instance].get_display_string());
 			strcat_s(hud_string,temp_string);
 		} else {
 			should_display = 0;
@@ -517,7 +517,7 @@ void multi_msg_show_squadmsg(net_player *source,int command,ushort target_sig,in
 	// disable subsystem on my target
 	case DISABLE_SUBSYSTEM_ITEM:
 		if((target_obj != NULL) && (target_obj->type == OBJ_SHIP) && (subsys_type != -1) && (subsys_type != 0)){
-			sprintf(temp_string,XSTR("Disable subsystem %s on %s",705),Multi_msg_subsys_name[subsys_type],Ships[target_obj->instance].ship_name);
+			sprintf(temp_string,XSTR("Disable subsystem %s on %s",705),Multi_msg_subsys_name[subsys_type],Ships[target_obj->instance].get_display_string());
 			strcat_s(hud_string,temp_string);
 		} else {
 			should_display = 0;

--- a/code/network/multimsgs.cpp
+++ b/code/network/multimsgs.cpp
@@ -3342,18 +3342,16 @@ void process_turret_fired_packet( ubyte *data, header *hinfo )
 }
 
 // send a mission log item packet
-void send_mission_log_packet( int num )
+void send_mission_log_packet( log_entry* entry )
 {
 	int packet_size;
 	ubyte data[MAX_PACKET_SIZE];
 	ubyte type;
 	int sindex;
-	log_entry *entry;
 
 	Assert ( MULTIPLAYER_MASTER );
 
 	// get the data from the log
-	entry = &log_entries[num];
 	type = (ubyte)entry->type;			// do the type casting thing to save on packet space
 	sindex = entry->index;
 
@@ -3390,7 +3388,7 @@ void process_mission_log_packet( ubyte *data, header *hinfo )
 
 	PACKET_SET_SIZE();
 
-	mission_log_add_entry_multi( type, pname, sname, sindex, timestamp, flags );
+	mission_log_add_entry_multi( static_cast<LogType>(type), pname, sname, sindex, timestamp, flags );
 }
 
 // send a mission message packet

--- a/code/network/multimsgs.h
+++ b/code/network/multimsgs.h
@@ -27,6 +27,7 @@ struct button_info;
 struct header;
 struct beam_info;
 class ship_subsys;
+struct log_entry;
 
 // macros for building up packets -- to save on time and typing.  Important to note that local variables
 // must be named correctly
@@ -297,7 +298,7 @@ void send_ship_create_packet( object *objp, int is_support = 0 );
 void send_ship_depart_packet( object *objp, int method = -1 );
 
 // send a mission log item packet
-void send_mission_log_packet( int entry );
+void send_mission_log_packet( log_entry* entry );
 
 // send a mission message packet
 void send_mission_message_packet(int id, const char *who_from, int priority, int timing, int source, int builtin_type, int multi_target, int multi_team_filter, int delay = 0);

--- a/code/scripting/api/objs/ship.cpp
+++ b/code/scripting/api/objs/ship.cpp
@@ -231,7 +231,7 @@ ADE_VIRTVAR(ArmorClass, l_Ship, "string", "Current Armor class", "string", "Armo
 	return ade_set_args(L, "s", name);
 }
 
-ADE_VIRTVAR(Name, l_Ship, "string", "Ship name", "string", "Ship name, or empty string if handle is invalid")
+ADE_VIRTVAR(Name, l_Ship, "string", "Ship name. This is the actual name of the ship. Use <i>getDisplayString</i> to get the string which should be displayed to the player.", "string", "Ship name, or empty string if handle is invalid")
 {
 	object_h *objh;
 	char *s = NULL;
@@ -248,6 +248,25 @@ ADE_VIRTVAR(Name, l_Ship, "string", "Ship name", "string", "Ship name, or empty 
 	}
 
 	return ade_set_args(L, "s", shipp->ship_name);
+}
+
+ADE_VIRTVAR(DisplayName, l_Ship, "string", "Ship display name", "string", "The display name of the ship or empty if there is no display string")
+{
+	object_h *objh;
+	char *s = nullptr;
+	if(!ade_get_args(L, "o|s", l_Ship.GetPtr(&objh), &s))
+		return ade_set_error(L, "s", "");
+
+	if(!objh->IsValid())
+		return ade_set_error(L, "s", "");
+
+	ship *shipp = &Ships[objh->objp->instance];
+
+	if(ADE_SETTING_VAR && s != nullptr) {
+		shipp->display_name = s;
+	}
+
+	return ade_set_args(L, "s", shipp->display_name.c_str());
 }
 
 ADE_VIRTVAR(AfterburnerFuelLeft, l_Ship, "number", "Afterburner fuel left", "number", "Afterburner fuel left, or 0 if handle is invalid")
@@ -1629,6 +1648,21 @@ ADE_FUNC(getWing, l_Ship, NULL, "Returns the ship's wing", "wing", "Wing handle,
 
 	shipp = &Ships[objh->objp->instance];
 	return ade_set_args(L, "o", l_Wing.Set(shipp->wingnum));
+}
+
+ADE_FUNC(getDisplayString, l_Ship, nullptr, "Returns the string which should be used when displaying the name of the ship to the player", "string", "The display string or empty if handle is invalid")
+{
+	object_h *objh = nullptr;
+	ship *shipp = nullptr;
+
+	if (!ade_get_args(L, "o", l_Ship.GetPtr(&objh)))
+		return ade_set_error(L, "s", "");
+
+	if(!objh->IsValid())
+		return ade_set_error(L, "s", "");
+
+	shipp = &Ships[objh->objp->instance];
+	return ade_set_args(L, "s", shipp->get_display_string());
 }
 
 

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -494,6 +494,7 @@ public:
 
 
 	char	ship_name[NAME_LENGTH];
+	SCP_string display_name;
 
 	int	team;				//	Which team it's on, HOSTILE, FRIENDLY, UNKNOWN, NEUTRAL
 	
@@ -715,6 +716,9 @@ public:
     inline bool is_departing() { return flags[Ship::Ship_Flags::Depart_warp, Ship::Ship_Flags::Depart_dockbay]; }
     inline bool cannot_warp() { return flags[Ship::Ship_Flags::Warp_broken, Ship::Ship_Flags::Warp_never, Ship::Ship_Flags::Disabled]; }
     inline bool is_dying_or_departing() { return is_departing() || flags[Ship::Ship_Flags::Dying]; }
+
+	bool has_display_name();
+	const char* get_display_string();
 };
 
 struct ai_target_priority {
@@ -741,6 +745,7 @@ ai_target_priority init_ai_target_priorities();
 
 typedef struct exited_ship {
 	char	ship_name[NAME_LENGTH];
+	SCP_string display_string;
 	int		obj_signature;
 	int		ship_class;
 	int		team;
@@ -1573,7 +1578,7 @@ int ship_dumbfire_threat(ship *sp);
 int ship_lock_threat(ship *sp);
 
 int	bitmask_2_bitnum(int num);
-char	*ship_return_orders(char *outbuf, ship *sp);
+SCP_string ship_return_orders(ship *sp);
 char	*ship_return_time_to_goal(char *outbuf, ship *sp);
 
 void	ship_maybe_warn_player(ship *enemy_sp, float dist);

--- a/fred2/missionsave.cpp
+++ b/fred2/missionsave.cpp
@@ -2672,6 +2672,14 @@ int CFred_mission_save::save_objects() {
 		parse_comments(z ? 2 : 1);
 		fout(" %s\t\t;! Object #%d\n", shipp->ship_name, i);
 
+		// Display name
+		if (Format_fs2_open != FSO_FORMAT_RETAIL && shipp->has_display_name()) {
+			// The display name is only written if there was one at the start to avoid introducing inconsistencies
+			fout("\n$Display name:");
+			fout_ext(" ", "%s", shipp->display_name.c_str());
+			fout("\n");
+		}
+
 		required_string_fred("$Class:");
 		parse_comments(0);
 		fout(" %s", Ship_info[shipp->ship_info_index].name);

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -2894,7 +2894,7 @@ void say_view_target()
 				if (Ships[Objects[Player_ai->target_objnum].instance].flags[Ship::Ship_Flags::Hide_ship_name]) {
 					strcpy_s(view_target_name, "targeted ship");
 				} else {
-					strcpy_s(view_target_name, Ships[Objects[Player_ai->target_objnum].instance].ship_name);
+					strcpy_s(view_target_name, Ships[Objects[Player_ai->target_objnum].instance].get_display_string());
 				}
 				break;
 			case OBJ_WEAPON:

--- a/qtfred/src/mission/missionsave.cpp
+++ b/qtfred/src/mission/missionsave.cpp
@@ -2523,6 +2523,14 @@ int CFred_mission_save::save_objects() {
 		parse_comments(z ? 2 : 1);
 		fout(" %s\t\t;! Object #%d\n", shipp->ship_name, i);
 
+		// Display name
+		if (save_format != MissionFormat::RETAIL && shipp->has_display_name()) {
+			// The display name is only written if there was one at the start to avoid introducing inconsistencies
+			fout("\n$Display name:");
+			fout_ext(" ", "%s", shipp->display_name.c_str());
+			fout("\n");
+		}
+
 		required_string_fred("$Class:");
 		parse_comments(0);
 		fout(" %s", Ship_info[shipp->ship_info_index].name);


### PR DESCRIPTION
This adds a mission file option for ships which allows specifying a
different string which should be used for displaying the name of the
ship to the user. This name will not be used in SEXPs or other ship
lookup functions so it can be freely translated and two ships can also
have the same display name.

The new feature can be used by adding `$Display name: <string>` after `$Name`
for a ship in a mission file. I think I added proper support for FRED
(and qtFRED) so that this new value is properly saved but it would be
great if someone could test that.

This implements one of the features requested in #1730.

Display name support is still missing from the events screen since
the same data is also used by various SEXPs where the actual ship name
is used.