### PR TITLE
Add macro for marking unreachable code

### DIFF
--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -15441,7 +15441,7 @@ int ai_issue_rearm_request(object *requester_objp)
 	// we aren't able to do anything!
 	else {
 		Assert(result == 4);
-		Assertion(false, "This case should have already been caught by the is_support_allowed precheck!");
+		UNREACHABLE("This case should have already been caught by the is_support_allowed precheck!");
 		return -1;
 	}
 }

--- a/code/bmpman/bmpman.cpp
+++ b/code/bmpman/bmpman.cpp
@@ -1155,7 +1155,7 @@ static int bm_load_info(BM_TYPE type, const char *filename, CFILE *img_cfp, int 
 		}
 	}
 	else {
-		Assertion(false, "Unknown file type specified! This is probably a coding error.");
+		UNREACHABLE("Unknown file type specified! This is probably a coding error.");
 
 		return -1;
 	}

--- a/code/cfile/cfile.cpp
+++ b/code/cfile/cfile.cpp
@@ -902,7 +902,7 @@ static int cfget_cfile_block()
 	mprintf(("Out of cfile blocks! Currently opened files:\n"));
 	dump_opened_files();
 
-	Assertion(false, "There are no more free cfile blocks. This means that there are too many files opened by FSO.\n"
+	UNREACHABLE("There are no more free cfile blocks. This means that there are too many files opened by FSO.\n"
 		"This is probably caused by a programming or scripting error where a file does not get closed."); // out of free cfile blocks
 	return -1;			
 }

--- a/code/gamehelp/contexthelp.cpp
+++ b/code/gamehelp/contexthelp.cpp
@@ -483,7 +483,7 @@ void parse_helptbl(const char *filename)
 					break;
 				case 4: // $end
 				default:
-					Assertion(false, "This should never happen.\n");
+					UNREACHABLE("This should never happen.\n");
 					break;
 				}
 			}		// end while

--- a/code/globalincs/alphacolors.cpp
+++ b/code/globalincs/alphacolors.cpp
@@ -578,7 +578,7 @@ void parse_everything_else(const char *filename)
 					}
 					break;
 				default:
-					Assertion(false, "MageKing17 made a coding error somewhere, and you should laugh at him (and report this error).\n");
+					UNREACHABLE("MageKing17 made a coding error somewhere, and you should laugh at him (and report this error).\n");
 					break;
 				}
 			}

--- a/code/globalincs/toolchain/clang.h
+++ b/code/globalincs/toolchain/clang.h
@@ -81,3 +81,12 @@
 #define CLANG_ANALYZER_NORETURN
 #endif
 #endif
+
+#ifndef NDEBUG
+#define UNREACHABLE(msg, ...)                                                                                          \
+	do {                                                                                                               \
+		os::dialogs::Error(__FILE__, __LINE__, msg, ##__VA_ARGS__);                                                    \
+	} while (false)
+#else
+#define UNREACHABLE(msg, ...) __builtin_unreachable()
+#endif

--- a/code/globalincs/toolchain/doxygen.h
+++ b/code/globalincs/toolchain/doxygen.h
@@ -63,3 +63,10 @@
  * @brief Specifies that an analyzer should consider this function as no-return
  */
 #define CLANG_ANALYZER_NORETURN
+
+/**
+ * @brief Specifies that the code at which point this macro appears at is unreachable
+ * @param msg The message to display in debug mode
+ * @param ... Format arguments for the message
+ */
+#define UNREACHABLE(msg, ...)

--- a/code/globalincs/toolchain/gcc.h
+++ b/code/globalincs/toolchain/gcc.h
@@ -72,3 +72,12 @@
 #endif
 
 #define CLANG_ANALYZER_NORETURN
+
+#ifndef NDEBUG
+#define UNREACHABLE(msg, ...)                                                                                          \
+	do {                                                                                                               \
+		os::dialogs::Error(__FILE__, __LINE__, msg, ##__VA_ARGS__);                                                    \
+	} while (false)
+#else
+#define UNREACHABLE(msg, ...) __builtin_unreachable()
+#endif

--- a/code/globalincs/toolchain/mingw.h
+++ b/code/globalincs/toolchain/mingw.h
@@ -69,3 +69,12 @@
 #endif
 
 #define CLANG_ANALYZER_NORETURN
+
+#ifndef NDEBUG
+#define UNREACHABLE(msg, ...)                                                                                          \
+	do {                                                                                                               \
+		os::dialogs::Error(__FILE__, __LINE__, msg, ##__VA_ARGS__);                                                    \
+	} while (false)
+#else
+#define UNREACHABLE(msg, ...) __builtin_unreachable()
+#endif

--- a/code/globalincs/toolchain/msvc.h
+++ b/code/globalincs/toolchain/msvc.h
@@ -82,3 +82,13 @@
 #define FALLTHROUGH
 
 #define CLANG_ANALYZER_NORETURN
+
+
+#ifndef NDEBUG
+#define UNREACHABLE(msg, ...)                                                                                          \
+	do {                                                                                                               \
+		os::dialogs::Error(__FILE__, __LINE__, msg, ##__VA_ARGS__);                                                    \
+	} while (false)
+#else
+#define UNREACHABLE(msg, ...) __assume(false)
+#endif

--- a/code/graphics/opengl/ShaderProgram.cpp
+++ b/code/graphics/opengl/ShaderProgram.cpp
@@ -137,7 +137,7 @@ GLenum get_gl_shader_stage(opengl::ShaderStage stage) {
 		case opengl::STAGE_FRAGMENT:
 			return GL_FRAGMENT_SHADER;
 		default:
-			Assertion(false, "Unhandled shader type found!");
+			UNREACHABLE("Unhandled shader type found!");
 			return GL_NONE;
 	}
 }

--- a/code/graphics/opengl/gropenglquery.cpp
+++ b/code/graphics/opengl/gropenglquery.cpp
@@ -50,7 +50,7 @@ void gr_opengl_query_value(int obj, QueryType type) {
 			glQueryCounter(slot.name, GL_TIMESTAMP);
 			break;
 		default:
-			Assertion(false, "Unhandled enum value!");
+			UNREACHABLE("Unhandled enum value!");
 			break;
 	}
 }

--- a/code/graphics/opengl/gropengltnl.cpp
+++ b/code/graphics/opengl/gropengltnl.cpp
@@ -106,7 +106,7 @@ static GLenum convertBufferType(BufferType type) {
 		case BufferType::Uniform:
 			return GL_UNIFORM_BUFFER;
 		default:
-			Assertion(false, "Unhandled enum value!");
+			UNREACHABLE("Unhandled enum value!");
 			return GL_INVALID_ENUM;
 	}
 }
@@ -120,7 +120,7 @@ static GLenum convertUsageHint(BufferUsageHint usage) {
 		case BufferUsageHint::Streaming:
 			return GL_STREAM_DRAW;
 		default:
-			Assertion(false, "Unhandled enum value!");
+			UNREACHABLE("Unhandled enum value!");
 			return GL_INVALID_ENUM;
 	}
 }
@@ -144,7 +144,7 @@ static GLenum convertStencilOp(const StencilOperation stencil_op) {
 	case StencilOperation::Invert:
 		return GL_INVERT;
 	default:
-		Assertion(false, "Unhandled enum value encountered!");
+		UNREACHABLE("Unhandled enum value encountered!");
 		return GL_NONE;
 	}
 }
@@ -177,7 +177,7 @@ static GLenum convertComparisionFunction(ComparisionFunction func) {
 		mode = GL_NOTEQUAL;
 		break;
 	default:
-		Assertion(false, "Unhandled comparision function value!");
+		UNREACHABLE("Unhandled comparision function value!");
 		mode = GL_ALWAYS;
 		break;
 	}

--- a/code/graphics/util/GPUMemoryHeap.cpp
+++ b/code/graphics/util/GPUMemoryHeap.cpp
@@ -12,7 +12,7 @@ BufferType getBufferType(GpuHeap heap_type) {
 		return BufferType::Index;
 	case GpuHeap::NUM_VALUES:
 	default:
-		Assertion(false, "Invalid heap type detected!");
+		UNREACHABLE("Invalid heap type detected!");
 		return BufferType::Vertex;
 	}
 }

--- a/code/graphics/util/UniformBufferManager.cpp
+++ b/code/graphics/util/UniformBufferManager.cpp
@@ -17,7 +17,7 @@ size_t getElementSize(uniform_block_type type) {
 		return sizeof(graphics::decal_info);
 	case uniform_block_type::NUM_BLOCK_TYPES:
 	default:
-		Assertion(false, "Invalid block type encountered!");
+		UNREACHABLE("Invalid block type encountered!");
 		return 0;
 	}
 }
@@ -33,7 +33,7 @@ size_t getHeaderSize(uniform_block_type type) {
 		return 0;
 	case uniform_block_type::NUM_BLOCK_TYPES:
 	default:
-		Assertion(false, "Invalid block type encountered!");
+		UNREACHABLE("Invalid block type encountered!");
 		return 0;
 	}
 }

--- a/code/hud/hudartillery.cpp
+++ b/code/hud/hudartillery.cpp
@@ -153,7 +153,7 @@ void parse_ssm(const char *filename)
 					s.shape = SSM_SHAPE_SPHERE;
 					break;
 				default:
-					Assertion(false, "Impossible return value from required_string_one_of(); get a coder!\n");
+					UNREACHABLE("Impossible return value from required_string_one_of(); get a coder!\n");
 				}
 			} else {
 				s.shape = SSM_SHAPE_CIRCLE;
@@ -235,7 +235,7 @@ void ssm_get_random_start_pos(vec3d *out, vec3d *start, matrix *orient, size_t s
 		vm_vec_scale_add(&temp, start, &orient->vec.fvec, radius);
 		break;
 	default:
-		Assertion(false, "Unknown shape '%d' in SSM type #" SIZE_T_ARG " ('%s'). This should not be possible; get a coder!\n", s->shape, ssm_index, s->name);
+		UNREACHABLE("Unknown shape '%d' in SSM type #" SIZE_T_ARG " ('%s'). This should not be possible; get a coder!\n", s->shape, ssm_index, s->name);
 		break;
 	}
 

--- a/code/io/keycontrol.cpp
+++ b/code/io/keycontrol.cpp
@@ -140,7 +140,7 @@ size_t factor_table::getNext(size_t n, size_t current)
 		}
 	}
 
-	Assertion(false, "For some reason, factor_table::getNext() was unable to locate the current factor. This should never happen; get a coder!\n");
+	UNREACHABLE("For some reason, factor_table::getNext() was unable to locate the current factor. This should never happen; get a coder!\n");
 	return 1;
 }
 

--- a/code/missionui/redalert.cpp
+++ b/code/missionui/redalert.cpp
@@ -794,7 +794,7 @@ void red_alert_delete_ship(int shipnum, int ship_state)
 		cleanup_mode = SHIP_DEPARTED_REDALERT;
 		break;
 	default:
-		Assertion(false, "Red-alert: Unknown delete state '%i'\n", ship_state);
+		UNREACHABLE("Red-alert: Unknown delete state '%i'\n", ship_state);
 		cleanup_mode = SHIP_VANISHED;
 		break;
 	}

--- a/code/object/deadobjectdock.cpp
+++ b/code/object/deadobjectdock.cpp
@@ -147,7 +147,7 @@ void dead_dock_remove_instance(object *objp, object *other_objp)
 	else
 	{
 		// Trigger assertion. We can recover from this, thankfully
-		Assertion(false, "Tried to undock an object that isn't dead docked!\n");
+		UNREACHABLE("Tried to undock an object that isn't dead docked!\n");
 	}
 }
 

--- a/code/object/objectdock.cpp
+++ b/code/object/objectdock.cpp
@@ -437,7 +437,7 @@ void dock_move_docked_objects(object *objp)
 			fastest_objp = objp;
 	}
 	
-	// start a tree with that object as the parent... do NOT use the überfunction for this,
+	// start a tree with that object as the parent... do NOT use the Ã¼berfunction for this,
 	// because we must use a tree for the parent ancestry to work correctly
 
 	// we don't need a bit array because OF_DOCKED_ALREADY_HANDLED takes care of it
@@ -632,7 +632,7 @@ void dock_find_max_speed_helper(object *objp, dock_function_info *infop)
 	}
 }
 // ---------------------------------------------------------------------------------------------------------------
-// end of über code block ----------------------------------------------------------------------------------------
+// end of Ã¼ber code block ----------------------------------------------------------------------------------------
 
 // dock management functions -------------------------------------------------------------------------------------
 void dock_dock_objects(object *objp1, int dockpoint1, object *objp2, int dockpoint2)
@@ -769,7 +769,7 @@ void dock_remove_instance(object *objp, object *other_objp)
 	else
 	{
 		// Trigger an assertion, we can recover from this one, thankfully.
-		Assertion(false, "Tried to undock an object that isn't docked!\n");
+		UNREACHABLE("Tried to undock an object that isn't docked!\n");
 	}
 }
 

--- a/code/parse/parselo.cpp
+++ b/code/parse/parselo.cpp
@@ -4308,7 +4308,7 @@ int parse_modular_table(const char *name_check, void (*parse_callback)(const cha
 	int i, num_files = 0;
 
 	if ( (name_check == NULL) || (parse_callback == NULL) || ((*name_check) != '*') ) {
-		Assertion(false, "parse_modular_table() called with invalid arguments; get a coder!\n");
+		UNREACHABLE("parse_modular_table() called with invalid arguments; get a coder!\n");
 		return 0;
 	}
 

--- a/code/parse/sexp/LuaSEXP.cpp
+++ b/code/parse/sexp/LuaSEXP.cpp
@@ -204,8 +204,7 @@ luacpp::LuaValue LuaSEXP::sexpToLua(int node, int argnum) const {
 		return LuaValue::createValue(_action.getLuaState(), text);
 	}
 	default:
-		Assertion(false,
-				  "Unhandled argument type! Someone added an argument type but didn't add handling code to execute().");
+		UNREACHABLE("Unhandled argument type! Someone added an argument type but didn't add handling code to execute().");
 		return LuaValue::createNil(_action.getLuaState());
 	}
 }

--- a/code/particle/effects/CompositeEffect.cpp
+++ b/code/particle/effects/CompositeEffect.cpp
@@ -8,8 +8,7 @@ namespace effects {
 CompositeEffect::CompositeEffect(const SCP_string& name) : ParticleEffect(name) {}
 
 bool CompositeEffect::processSource(const ParticleSource*) {
-	Assertion(false,
-			  "Processing a composite source is not supported! This was caused by a coding error, get a coder!");
+	UNREACHABLE("Processing a composite source is not supported! This was caused by a coding error, get a coder!");
 	return false;
 }
 

--- a/code/pilotfile/JSONFileHandler.cpp
+++ b/code/pilotfile/JSONFileHandler.cpp
@@ -37,7 +37,7 @@ const char* lookupSectionName(Section s) {
 			return pair.second;
 		}
 	}
-	Assertion(false, "Unknown section!");
+	UNREACHABLE("Unknown section!");
 	return nullptr;
 }
 
@@ -47,7 +47,7 @@ Section lookupSectionValue(const char* name) {
 			return pair.first;
 		}
 	}
-	Assertion(false, "Unknown section name!");
+	UNREACHABLE("Unknown section name!");
 	return Section::Unnamed;
 }
 }

--- a/code/pilotfile/pilotfile.cpp
+++ b/code/pilotfile/pilotfile.cpp
@@ -290,7 +290,7 @@ void pilotfile::update_stats_backout(scoring_struct *stats, bool training)
 			if (j >= 0) {
 				p_stats->ship_kills[j].val -= stats->m_okKills[i];
 			} else {
-				Assertion(false, "Ship kills of '%s' not found, should have been added by pilotfile::update_stats.", Ship_info[i].name);
+				UNREACHABLE("Ship kills of '%s' not found, should have been added by pilotfile::update_stats.", Ship_info[i].name);
 			}
 		}
 	}

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -4682,7 +4682,7 @@ static int parse_ship_values(ship_info* sip, const bool is_template, const bool 
 		case -1:	// Possible return value if -noparseerrors is used
 			break;
 		default:
-			Assertion(false, "This should never happen.\n");	// Impossible return value from required_string_one_of.
+			UNREACHABLE("This should never happen.\n");	// Impossible return value from required_string_one_of.
 		}
 	}	
 
@@ -7429,7 +7429,7 @@ void ship_cleanup(int shipnum, int cleanup_mode)
 		break;
 	default:
 		// Can't Happen
-		Assertion(false, "Unknown cleanup_mode '%i' passed to ship_cleanup!", cleanup_mode);
+		UNREACHABLE("Unknown cleanup_mode '%i' passed to ship_cleanup!", cleanup_mode);
 		break;
 	}
 
@@ -7479,7 +7479,7 @@ void ship_cleanup(int shipnum, int cleanup_mode)
 		break;
 	default:
 		// Can't Happen, but we should've already caught this
-		Assertion(false, "Unknown cleanup_mode '%i' passed to ship_cleanup!", cleanup_mode);
+		UNREACHABLE("Unknown cleanup_mode '%i' passed to ship_cleanup!", cleanup_mode);
 		break;
 	}
 #endif
@@ -7502,7 +7502,7 @@ void ship_cleanup(int shipnum, int cleanup_mode)
 			break;
 		default:
 			// Can't Happen, but we should've already caught this
-			Assertion(false, "Unknown cleanup_mode '%i' passed to ship_cleanup!", cleanup_mode);
+			UNREACHABLE("Unknown cleanup_mode '%i' passed to ship_cleanup!", cleanup_mode);
 			break;
 		}
 	}
@@ -7527,7 +7527,7 @@ void ship_cleanup(int shipnum, int cleanup_mode)
 			break;
 		default:
 			// Can't Happen, but we should've already caught this
-			Assertion(false, "Unknown cleanup_mode '%i' passed to ship_cleanup!", cleanup_mode);
+			UNREACHABLE("Unknown cleanup_mode '%i' passed to ship_cleanup!", cleanup_mode);
 			break;
 		}
 		ship_wing_cleanup(shipnum, wingp);

--- a/code/sound/ffmpeg/WaveFile.cpp
+++ b/code/sound/ffmpeg/WaveFile.cpp
@@ -73,7 +73,7 @@ AudioProperties getAdjustedAudioProps(const AudioProperties& baseProps) {
 			adjusted.format = AV_SAMPLE_FMT_FLT;
 			break;
 		default:
-			Assertion(false, "Unhandled switch value!");
+			UNREACHABLE("Unhandled switch value!");
 			adjusted.format = AV_SAMPLE_FMT_NONE;
 			break;
 	}

--- a/code/tracing/TraceEventWriter.cpp
+++ b/code/tracing/TraceEventWriter.cpp
@@ -24,7 +24,7 @@ const char* getTypeStr(tracing::EventType type) {
 		case EventType::Counter:
 			return "C";
 		default: 
-			Assertion(false, "Invalid enum value!");
+			UNREACHABLE("Invalid enum value!");
 			return "";
 	}
 }
@@ -114,7 +114,7 @@ void TraceEventWriter::processEvent(const trace_event* event) {
 			break;
 		}
 		default:
-			Assertion(false, "Unhandled enum value! This function should not have been called with this value!");
+			UNREACHABLE("Unhandled enum value! This function should not have been called with this value!");
 			break;
 	}
 

--- a/code/tracing/tracing.cpp
+++ b/code/tracing/tracing.cpp
@@ -187,7 +187,7 @@ void process_gpu_events() {
 				}
 				break;
 			default:
-				Assertion(false, "Invalid event type!");
+				UNREACHABLE("Invalid event type!");
 				gpu_events.pop();
 				break;
 		}

--- a/code/weapon/beam.cpp
+++ b/code/weapon/beam.cpp
@@ -306,14 +306,14 @@ int beam_fire(beam_fire_info *fire_info)
 
 	// make sure the beam_info_index is valid
 	if ((fire_info->beam_info_index < 0) || (fire_info->beam_info_index >= Num_weapon_types) || !(Weapon_info[fire_info->beam_info_index].wi_flags[Weapon::Info_Flags::Beam])) {
-		Assertion(false, "beam_info_index (%d) invalid (either <0, >= %d, or not actually a beam)!\n", fire_info->beam_info_index, Num_weapon_types);
+		UNREACHABLE("beam_info_index (%d) invalid (either <0, >= %d, or not actually a beam)!\n", fire_info->beam_info_index, Num_weapon_types);
 		return -1;
 	}
 
 	wip = &Weapon_info[fire_info->beam_info_index];	
 	// make sure a ship is firing this
 	if (!(fire_info->bfi_flags & BFIF_FLOATING_BEAM) && ((fire_info->shooter->type != OBJ_SHIP) || (fire_info->shooter->instance < 0) || (fire_info->shooter->instance >= MAX_SHIPS)) ) {
-		Assertion(false, "Fixed beam fired without a valid ship!\n");
+		UNREACHABLE("Fixed beam fired without a valid ship!\n");
 		return -1;
 	}
 	if (fire_info->shooter != NULL) {
@@ -2270,7 +2270,7 @@ void beam_aim(beam *b)
 		break;
 
 	default:
-		Assertion(false, "Impossible beam type (%d); get a coder!\n", b->type);
+		UNREACHABLE("Impossible beam type (%d); get a coder!\n", b->type);
 	}
 
 	// recalculate object pairs

--- a/freespace2/SDLGraphicsOperations.cpp
+++ b/freespace2/SDLGraphicsOperations.cpp
@@ -34,7 +34,7 @@ void setOGLProperties(const os::ViewPortProperties& props) {
 			profile = SDL_GL_CONTEXT_PROFILE_COMPATIBILITY;
 			break;
 		default:
-			Assertion(false, "Unhandled profile value!");
+			UNREACHABLE("Unhandled profile value!");
 			return;
 	}
 	SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, profile);
@@ -113,7 +113,7 @@ class SDLWindowViewPort: public os::Viewport {
 				SDL_SetWindowFullscreen(_window, SDL_WINDOW_FULLSCREEN);
 				break;
 			default:
-				Assertion(false, "Invalid window state!");
+				UNREACHABLE("Invalid window state!");
 				break;
 		}
 	}

--- a/qtfred/src/ui/FredView.cpp
+++ b/qtfred/src/ui/FredView.cpp
@@ -770,7 +770,7 @@ void FredView::handleObjectEditor(int objNum) {
 		} else if (Objects[objNum].type == OBJ_POINT) {
 			return;
 		} else {
-			Assertion(false, "Unhandled object type!");
+			UNREACHABLE("Unhandled object type!");
 		}
 	}
 }


### PR DESCRIPTION
This can be used for mark parts of the code which should be unreachable
in normal execution. In debug mode, if such a statement is reached an
Error dialog is shown which aborts the execution. In release mode the
macro is replaced with a compiler specific expression that lets the
compiler know that this part is unreachable which allows it to optimize
the code better.