### PR TITLE
Add support for external subtitle files

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -24,7 +24,7 @@ BraceWrapping:
   AfterClass:      false
   AfterControlStatement: false
   AfterEnum:       false
-  AfterFunction:   false
+  AfterFunction:   true
   AfterNamespace:  false
   AfterObjCDeclaration: false
   AfterStruct:     false
@@ -33,7 +33,7 @@ BraceWrapping:
   BeforeElse:      false
   IndentBraces:    false
 BreakBeforeBinaryOperators: None
-BreakBeforeBraces: Attach
+BreakBeforeBraces: Custom
 BreakBeforeTernaryOperators: true
 BreakConstructorInitializersBeforeComma: false
 BreakAfterJavaFieldAnnotations: false

--- a/code/cfile/cfile.cpp
+++ b/code/cfile/cfile.cpp
@@ -43,11 +43,12 @@ char Cfile_user_dir_legacy[CFILE_ROOT_DIRECTORY_LEN] = "";
 #endif
 
 // During cfile_init, verify that Pathtypes[n].index == n for each item
-// Each path must have a valid parent that can be tracable all the way back to the root 
+// Each path must have a valid parent that can be tracable all the way back to the root
 // so that we can create directories when we need to.
 //
 // Please make sure extensions are all lower-case, or we'll break unix compatibility
 //
+// clang-format off
 cf_pathtype Pathtypes[CF_MAX_PATH_TYPES]  = {
 	// What type this is          Path																			Extensions        					Parent type
 	{ CF_TYPE_INVALID,				NULL,																		NULL,								CF_TYPE_INVALID },
@@ -69,7 +70,7 @@ cf_pathtype Pathtypes[CF_MAX_PATH_TYPES]  = {
 	{ CF_TYPE_VOICE_SPECIAL,		"data" DIR_SEPARATOR_STR "voice" DIR_SEPARATOR_STR "special",				".wav .ogg",						CF_TYPE_VOICE	},
 	{ CF_TYPE_VOICE_TRAINING,		"data" DIR_SEPARATOR_STR "voice" DIR_SEPARATOR_STR "training",				".wav .ogg",						CF_TYPE_VOICE	},
 	{ CF_TYPE_MUSIC,				"data" DIR_SEPARATOR_STR "music",											".wav .ogg",						CF_TYPE_DATA	},
-	{ CF_TYPE_MOVIES,				"data" DIR_SEPARATOR_STR "movies",											".mve .msb .ogg .mp4",				CF_TYPE_DATA	},
+	{ CF_TYPE_MOVIES,				"data" DIR_SEPARATOR_STR "movies",											".mve .msb .ogg .mp4 .srt",			CF_TYPE_DATA	},
 	{ CF_TYPE_INTERFACE,			"data" DIR_SEPARATOR_STR "interface",										".pcx .ani .dds .tga .eff .png .jpg",	CF_TYPE_DATA	},
 	{ CF_TYPE_FONT,					"data" DIR_SEPARATOR_STR "fonts",											".vf .ttf",							CF_TYPE_DATA	},
 	{ CF_TYPE_EFFECTS,				"data" DIR_SEPARATOR_STR "effects",											".ani .eff .pcx .neb .tga .jpg .png .dds .sdr",	CF_TYPE_DATA	},
@@ -90,7 +91,7 @@ cf_pathtype Pathtypes[CF_MAX_PATH_TYPES]  = {
 	{ CF_TYPE_FICTION,				"data" DIR_SEPARATOR_STR "fiction",											".txt",								CF_TYPE_DATA	}, 
 	{ CF_TYPE_FREDDOCS,				"data" DIR_SEPARATOR_STR "freddocs",										".html",							CF_TYPE_DATA	},
 };
-
+// clang-format on
 
 #define CFILE_STACK_MAX	8
 

--- a/code/cutscene/Decoder.h
+++ b/code/cutscene/Decoder.h
@@ -105,7 +105,7 @@ class Decoder {
 	 * @brief Returns the properties of the video
 	 * @return The properties
 	 */
-	virtual MovieProperties getProperties() = 0;
+	virtual MovieProperties getProperties() const = 0;
 
 	/**
 	 * @brief Starts decoding the video
@@ -116,9 +116,9 @@ class Decoder {
 	 * @brief Determines if the video has audio
 	 * @return @c true if audio is included in the video
 	 */
-	virtual bool hasAudio() = 0;
+	virtual bool hasAudio() const = 0;
 
-	virtual bool hasSubtitles() = 0;
+	virtual bool hasSubtitles() const = 0;
 
 	/**
 	 * @brief Ends decoding of the video file

--- a/code/cutscene/ffmpeg/FFMPEGDecoder.cpp
+++ b/code/cutscene/ffmpeg/FFMPEGDecoder.cpp
@@ -11,6 +11,7 @@
 #include "cutscene/ffmpeg/VideoDecoder.h"
 #include "cutscene/ffmpeg/SubtitleDecoder.h"
 
+#include "FFMPEGDecoder.h"
 #include "localization/localize.h"
 
 using namespace libs::ffmpeg;
@@ -39,6 +40,8 @@ const char* CHECKED_EXTENSIONS[] = {
 	"mve"
 };
 
+const char* CHECKED_SUBT_EXTENSIONS[] = {"srt"};
+
 double getFrameRate(AVStream* stream, AVCodecContext* codecCtx) {
 	auto fps = av_q2d(av_stream_get_r_frame_rate(stream));
 
@@ -58,45 +61,45 @@ double getFrameRate(AVStream* stream, AVCodecContext* codecCtx) {
 CodecContextParameters getCodecParameters(AVStream* stream) {
 	CodecContextParameters paras;
 #if LIBAVCODEC_VERSION_INT > AV_VERSION_INT(57, 24, 255)
-	paras.width = stream->codecpar->width;
-	paras.height = stream->codecpar->height;
+	paras.width        = stream->codecpar->width;
+	paras.height       = stream->codecpar->height;
 	paras.pixel_format = (AVPixelFormat)stream->codecpar->format;
 
 	paras.channel_layout = stream->codecpar->channel_layout;
-	paras.sample_rate = stream->codecpar->sample_rate;
-	paras.audio_format = (AVSampleFormat)stream->codecpar->format;
+	paras.sample_rate    = stream->codecpar->sample_rate;
+	paras.audio_format   = (AVSampleFormat)stream->codecpar->format;
 
-    paras.codec_id = stream->codecpar->codec_id;
+	paras.codec_id = stream->codecpar->codec_id;
 #else
-    paras.width = stream->codec->width;
-	paras.height = stream->codec->height;
+	paras.width        = stream->codec->width;
+	paras.height       = stream->codec->height;
 	paras.pixel_format = stream->codec->pix_fmt;
 
 	paras.channel_layout = stream->codec->channel_layout;
-	paras.sample_rate = stream->codec->sample_rate;
-	paras.audio_format = stream->codec->sample_fmt;
+	paras.sample_rate    = stream->codec->sample_rate;
+	paras.audio_format   = stream->codec->sample_fmt;
 
-    paras.codec_id = stream->codec->codec_id;
+	paras.codec_id = stream->codec->codec_id;
 #endif
-    return paras;
+	return paras;
 }
 
 SCP_string normalizeLanguage(const char* langauge_name) {
-    if (!stricmp(langauge_name, "eng")) {
-        return "English";
-    }
-    if (!stricmp(langauge_name, "ger")) {
-        return "German";
-    }
-    if (!stricmp(langauge_name, "spa")) {
-        return "Spanish";
-    }
+	if (!stricmp(langauge_name, "eng")) {
+		return "English";
+	}
+	if (!stricmp(langauge_name, "ger")) {
+		return "German";
+	}
+	if (!stricmp(langauge_name, "spa")) {
+		return "Spanish";
+	}
 
-    // Print to log so that we can find the actual value more easily later
-    mprintf(("FFmpeg log: Found unknown language value '%s'!\n", langauge_name));
+	// Print to log so that we can find the actual value more easily later
+	mprintf(("FFmpeg log: Found unknown language value '%s'!\n", langauge_name));
 
-    // Default to english for everything else
-    return "English";
+	// Default to english for everything else
+	return "English";
 }
 }
 
@@ -143,7 +146,9 @@ std::unique_ptr<InputStream> openStream(const SCP_string& name) {
 	return input;
 }
 
-std::unique_ptr<DecoderStatus> initializeStatus(std::unique_ptr<InputStream>& stream) {
+std::unique_ptr<DecoderStatus> initializeStatus(std::unique_ptr<InputStream>& stream,
+                                                std::unique_ptr<InputStream>& subt)
+{
 	std::unique_ptr<DecoderStatus> status(new DecoderStatus());
 
 	auto ctx = stream->m_ctx->ctx();
@@ -165,7 +170,7 @@ std::unique_ptr<DecoderStatus> initializeStatus(std::unique_ptr<InputStream>& st
 	if (audioStream < 0) {
 		if (audioStream == AVERROR_STREAM_NOT_FOUND) {
 			mprintf(("FFmpeg: No audio stream found in file!\n"));
-		} else if (videoStream == AVERROR_DECODER_NOT_FOUND) {
+		} else if (audioStream == AVERROR_DECODER_NOT_FOUND) {
 			mprintf(("FFmpeg: Codec for audio stream could not be found!\n"));
 		} else {
 			mprintf(("FFmpeg: Unknown error while finding audio stream!\n"));
@@ -180,28 +185,50 @@ std::unique_ptr<DecoderStatus> initializeStatus(std::unique_ptr<InputStream>& st
 		status->audioStream = ctx->streams[audioStream];
 	}
 
-	auto& current_language = Lcl_languages[Lcl_current_lang];
-	for (uint32_t i = 0; i < ctx->nb_streams; ++i) {
-		auto test_stream = ctx->streams[i];
+	if (subt) {
+		auto subtCtx = subt->m_ctx->ctx();
+
+		auto subtStream = av_find_best_stream(subtCtx, AVMEDIA_TYPE_SUBTITLE, -1, -1, nullptr, 0);
+		if (subtStream < 0) {
+			if (subtStream == AVERROR_STREAM_NOT_FOUND) {
+				mprintf(("FFmpeg: No subtitle stream found in subtitle file!\n"));
+			} else if (subtStream == AVERROR_DECODER_NOT_FOUND) {
+				mprintf(("FFmpeg: Codec for subtitle stream could not be found!\n"));
+			} else {
+				mprintf(("FFmpeg: Unknown error while finding subtitle stream!\n"));
+			}
+		} else {
+			status->subtitleStream      = subtCtx->streams[subtStream];
+			status->externalSubtitles   = true;
+			status->subtitleStreamIndex = subtStream;
+		}
+	}
+
+	if (status->subtitleStream == nullptr) {
+		// We don't have an external subtitle stream or loading from that file has failed
+		auto& current_language = Lcl_languages[Lcl_current_lang];
+		for (uint32_t i = 0; i < ctx->nb_streams; ++i) {
+			auto test_stream = ctx->streams[i];
 
 #if LIBAVCODEC_VERSION_INT > AV_VERSION_INT(57, 24, 255)
-		auto& pars = test_stream->codecpar;
+			auto& pars = test_stream->codecpar;
 
-		if (!(pars->codec_type == AVMEDIA_TYPE_SUBTITLE)) {
-			continue;
-		}
+			if (!(pars->codec_type == AVMEDIA_TYPE_SUBTITLE)) {
+				continue;
+			}
 #endif
-		AVDictionaryEntry* tag = nullptr;
-		if ((tag = av_dict_get(test_stream->metadata, "language", nullptr, 0)) == nullptr) {
-			continue;
-		}
+			AVDictionaryEntry* tag = nullptr;
+			if ((tag = av_dict_get(test_stream->metadata, "language", nullptr, 0)) == nullptr) {
+				continue;
+			}
 
-		auto normalized_language = normalizeLanguage(tag->value);
+			auto normalized_language = normalizeLanguage(tag->value);
 
-		if (!stricmp(normalized_language.c_str(), current_language.lang_name)) {
-			status->subtitleStreamIndex = i;
-			status->subtitleStream = test_stream;
-			break;
+			if (!stricmp(normalized_language.c_str(), current_language.lang_name)) {
+				status->subtitleStreamIndex = i;
+				status->subtitleStream      = test_stream;
+				break;
+			}
 		}
 	}
 
@@ -263,36 +290,37 @@ std::unique_ptr<DecoderStatus> initializeStatus(std::unique_ptr<InputStream>& st
 			status->audioCodec->name ? status->audioCodec->name : "<Unknown>"));
 	}
 
-    if (status->subtitleStreamIndex >= 0) {
-        // Not really sure if this makes sense for subtitles but it shouldn't break anything...
-        status->subtitleCodecPars = getCodecParameters(status->subtitleStream);
+	if (status->subtitleStream != nullptr) {
+		// Not really sure if this makes sense for subtitles but it shouldn't break anything...
+		status->subtitleCodecPars = getCodecParameters(status->subtitleStream);
 
-        status->subtitleCodec = avcodec_find_decoder(status->subtitleCodecPars.codec_id);
+		status->subtitleCodec = avcodec_find_decoder(status->subtitleCodecPars.codec_id);
 
 #if LIBAVCODEC_VERSION_INT > AV_VERSION_INT(57, 24, 255)
-        status->subtitleCodecCtx = avcodec_alloc_context3(status->subtitleCodec);
+		status->subtitleCodecCtx = avcodec_alloc_context3(status->subtitleCodec);
 
-        err = avcodec_parameters_to_context(status->subtitleCodecCtx, status->subtitleStream->codecpar);
-        if (err < 0) {
-            char errorStr[512];
-            av_strerror(err, errorStr, sizeof(errorStr));
-            mprintf(("FFMPEG: Failed to copy context parameters! Error: %s\n", errorStr));
-            return nullptr;
-        }
+		err = avcodec_parameters_to_context(status->subtitleCodecCtx, status->subtitleStream->codecpar);
+		if (err < 0) {
+			char errorStr[512];
+			av_strerror(err, errorStr, sizeof(errorStr));
+			mprintf(("FFMPEG: Failed to copy context parameters! Error: %s\n", errorStr));
+			return nullptr;
+		}
 #else
-        status->subtitleCodecCtx = status->subtitleStream->codec;
+		status->subtitleCodecCtx = status->subtitleStream->codec;
 #endif
 
-        err = avcodec_open2(status->subtitleCodecCtx, status->subtitleCodec, nullptr);
-        if (err < 0) {
-            char errorStr[512];
-            av_strerror(err, errorStr, sizeof(errorStr));
-            mprintf(("FFMPEG: Failed to open subtitle codec! Error: %s\n", errorStr));
-        }
+		err = avcodec_open2(status->subtitleCodecCtx, status->subtitleCodec, nullptr);
+		if (err < 0) {
+			char errorStr[512];
+			av_strerror(err, errorStr, sizeof(errorStr));
+			mprintf(("FFMPEG: Failed to open subtitle codec! Error: %s\n", errorStr));
+		}
 
-        mprintf(("FFmpeg: Using subtitle codec %s (%s).\n", status->subtitleCodec->long_name ? status->subtitleCodec->long_name : "<Unknown>",
-            status->subtitleCodec->name ? status->subtitleCodec->name : "<Unknown>"));
-    }
+		mprintf(("FFmpeg: Using subtitle codec %s (%s).\n",
+		         status->subtitleCodec->long_name ? status->subtitleCodec->long_name : "<Unknown>",
+		         status->subtitleCodec->name ? status->subtitleCodec->name : "<Unknown>"));
+	}
 
 	return status;
 }
@@ -302,6 +330,28 @@ std::unique_ptr<InputStream> openInputStream(const SCP_string& name) {
 	// The actual format of the file may be whatever FFmpeg supports
 	for (auto ext : CHECKED_EXTENSIONS) {
 		auto fileName = name + "." + ext;
+
+		auto input = openStream(fileName);
+
+		if (input) {
+			return input;
+		}
+	}
+
+	return nullptr;
+}
+
+std::unique_ptr<InputStream> openSubtitleStream(const SCP_string& name)
+{
+	auto& current_language = Lcl_languages[Lcl_current_lang];
+
+	for (auto ext : CHECKED_SUBT_EXTENSIONS) {
+		SCP_string fileName;
+		if (strlen(current_language.lang_ext) == 0) {
+			fileName = name + "." + ext;
+		} else {
+			fileName = name + "-" + current_language.lang_ext + "." + ext;
+		}
 
 		auto input = openStream(fileName);
 
@@ -331,8 +381,10 @@ bool FFMPEGDecoder::initialize(const SCP_string& fileName) {
 		return false;
 	}
 
+	auto subt = openSubtitleStream(movieName);
+
 	// We now have a valid input stream, try to find the correct streams
-	auto status = initializeStatus(input);
+	auto status = initializeStatus(input, subt);
 	if (!status) {
 		return false;
 	}
@@ -342,11 +394,13 @@ bool FFMPEGDecoder::initialize(const SCP_string& fileName) {
 
 	// We're done, now just put the pointer into this
 	std::swap(m_input, input);
+	std::swap(m_subtitleInput, subt);
 	std::swap(m_status, status);
 	return true;
 }
 
-MovieProperties FFMPEGDecoder::getProperties() {
+MovieProperties FFMPEGDecoder::getProperties() const
+{
 	MovieProperties props;
 	props.size.width = static_cast<size_t>(m_status->videoCodecPars.width);
 	props.size.height = static_cast<size_t>(m_status->videoCodecPars.height);
@@ -360,14 +414,22 @@ void FFMPEGDecoder::startDecoding() {
 	std::unique_ptr<VideoDecoder> videoDecoder(new VideoDecoder(m_status.get()));
 
 	std::unique_ptr<AudioDecoder> audioDecoder;
-    std::unique_ptr<SubtitleDecoder> subtitleDecoder;
+	std::unique_ptr<SubtitleDecoder> subtitleDecoder;
 
 	if (hasAudio()) {
 		audioDecoder.reset(new AudioDecoder(m_status.get()));
 	}
-    if (hasSubtitles()) {
-        subtitleDecoder.reset(new SubtitleDecoder(m_status.get()));
-    }
+	if (hasSubtitles()) {
+		subtitleDecoder.reset(new SubtitleDecoder(m_status.get()));
+	}
+
+	std::unique_ptr<std::thread> subtitle_thread;
+	if (hasExternalSubtitle()) {
+		// Start a new thread for the subtitles since otherwise we would need to make sure that neither of the input
+		// streames starves while the other waits for more space in the queues
+		subtitle_thread.reset(
+		    new std::thread([this, &subtitleDecoder]() { runSubtitleDecoder(subtitleDecoder.get()); }));
+	}
 
 	auto ctx = m_input->m_ctx->ctx();
 	AVPacket packet;
@@ -375,12 +437,12 @@ void FFMPEGDecoder::startDecoding() {
 		auto read_err = av_read_frame(ctx, &packet);
 		AVPacketScope scope(&packet);
 
-		if (avio_feof(ctx->pb) != 0) {
-			// EOF!!
-			break;
-		} else if (read_err < 0) {
+		if (read_err < 0) {
 			if (read_err == AVERROR_EOF) {
 				// Finished reading -> break out of loop
+				break;
+			} else if (avio_feof(ctx->pb) != 0) {
+				// Also EOF!
 				break;
 			} else {
 				// Some kind of other error, try to continue reading
@@ -408,13 +470,13 @@ void FFMPEGDecoder::startDecoding() {
 				pushAudioData(std::move(ptr));
 			}
 		} else if (subtitleDecoder && packet.stream_index == m_status->subtitleStreamIndex) {
-            subtitleDecoder->decodePacket(&packet);
+			subtitleDecoder->decodePacket(&packet);
 
-            SubtitleFramePtr ptr;
-            while((ptr = subtitleDecoder->getFrame()) != nullptr) {
-                pushSubtitleData(std::move(ptr));
-            }
-        }
+			SubtitleFramePtr ptr;
+			while ((ptr = subtitleDecoder->getFrame()) != nullptr) {
+				pushSubtitleData(std::move(ptr));
+			}
+		}
 	}
 
 	if (isDecoding()) {
@@ -434,16 +496,18 @@ void FFMPEGDecoder::startDecoding() {
 		}
 	}
 
+	if (subtitle_thread) {
+		subtitle_thread->join();
+	}
+
 	stopDecoder();
 }
 
-bool FFMPEGDecoder::hasAudio() {
-	return m_status->audioStreamIndex >= 0;
-}
+bool FFMPEGDecoder::hasAudio() const { return m_status->audioStreamIndex >= 0; }
 
-bool FFMPEGDecoder::hasSubtitles() {
-	return m_status->subtitleStreamIndex >= 0;
-}
+bool FFMPEGDecoder::hasSubtitles() const { return m_status->subtitleStream != nullptr; }
+
+bool FFMPEGDecoder::hasExternalSubtitle() const { return m_status->externalSubtitles; }
 
 void FFMPEGDecoder::close() {
 	if (m_status) {
@@ -453,6 +517,56 @@ void FFMPEGDecoder::close() {
 	if (m_input) {
 		// This will delete the InputStream pointer and free all data
 		m_input = nullptr;
+	}
+
+	if (m_subtitleInput) {
+		m_subtitleInput = nullptr;
+	}
+}
+void FFMPEGDecoder::runSubtitleDecoder(SubtitleDecoder* decoder)
+{
+	auto ctx = m_subtitleInput->m_ctx->ctx();
+	AVPacket packet;
+
+	while (isDecoding()) {
+		auto read_err = av_read_frame(ctx, &packet);
+		AVPacketScope scope(&packet);
+
+		if (read_err < 0) {
+			if (read_err == AVERROR_EOF) {
+				// Finished reading -> break out of loop
+				break;
+			} else if (avio_feof(ctx->pb) != 0) {
+				// Also EOF!
+				break;
+			} else {
+				// Some kind of other error, try to continue reading
+				char errorStr[512];
+				av_strerror(read_err, errorStr, sizeof(errorStr));
+				mprintf(("FFMPEG: Failed to read frame! Error: %s\n", errorStr));
+
+				// Skip packet
+				continue;
+			}
+		}
+
+		if (packet.stream_index == m_status->subtitleStreamIndex) {
+			decoder->decodePacket(&packet);
+
+			SubtitleFramePtr ptr;
+			while ((ptr = decoder->getFrame()) != nullptr) {
+				pushSubtitleData(std::move(ptr));
+			}
+		}
+	}
+	if (isDecoding()) {
+		// If we are still alive then read the last frames from the decoders
+		decoder->finishDecoding();
+
+		SubtitleFramePtr ptr;
+		while ((ptr = decoder->getFrame()) != nullptr) {
+			pushSubtitleData(std::move(ptr));
+		}
 	}
 }
 }

--- a/code/cutscene/ffmpeg/FFMPEGDecoder.h
+++ b/code/cutscene/ffmpeg/FFMPEGDecoder.h
@@ -8,26 +8,34 @@ struct InputStream;
 
 struct DecoderStatus;
 
+class SubtitleDecoder;
+
 class FFMPEGDecoder: public Decoder {
  private:
 	std::unique_ptr<InputStream> m_input;
 
+	std::unique_ptr<InputStream> m_subtitleInput;
+
 	std::unique_ptr<DecoderStatus> m_status;
 
- public:
+	bool hasExternalSubtitle() const;
+
+	void runSubtitleDecoder(SubtitleDecoder* decoder);
+
+  public:
 	FFMPEGDecoder();
 
 	~FFMPEGDecoder() override;
 
 	bool initialize(const SCP_string& fileName) override;
 
-	MovieProperties getProperties() override;
+	MovieProperties getProperties() const override;
 
 	void startDecoding() override;
 
-	bool hasAudio() override;
+	bool hasAudio() const override;
 
-	bool hasSubtitles() override;
+	bool hasSubtitles() const override;
 
 	void close() override;
 };

--- a/code/cutscene/ffmpeg/SubtitleDecoder.cpp
+++ b/code/cutscene/ffmpeg/SubtitleDecoder.cpp
@@ -31,7 +31,25 @@ void SubtitleDecoder::decodePacket(AVPacket* packet) {
 	}
 }
 void SubtitleDecoder::finishDecoding() {
+	// Handle those decoders that have a delay
+	AVPacket nullPacket;
+	memset(&nullPacket, 0, sizeof(nullPacket));
+	nullPacket.data = nullptr;
+	nullPacket.size = 0;
 
+	AVSubtitle subtitle;
+	while (true) {
+		int finishedFrame = 1;
+		auto err = avcodec_decode_subtitle2(m_status->subtitleCodecCtx, &subtitle, &finishedFrame, &nullPacket);
+
+		if (err < 0 || !finishedFrame) {
+			break;
+		}
+
+		pushSubtitleFrame(&nullPacket, &subtitle);
+
+		avsubtitle_free(&subtitle);
+	}
 }
 void SubtitleDecoder::pushSubtitleFrame(AVPacket* packet, AVSubtitle* subtitle) {
 	if (subtitle->format != 1) {

--- a/code/cutscene/ffmpeg/internal.h
+++ b/code/cutscene/ffmpeg/internal.h
@@ -33,6 +33,8 @@ struct DecoderStatus {
 	AVCodec* audioCodec = nullptr;
 	AVCodecContext* audioCodecCtx = nullptr;
 
+	// Subtitles are a bit different since they max come from a different file
+	bool externalSubtitles   = false;
 	int subtitleStreamIndex = -1;
 	AVStream* subtitleStream = nullptr;
 	CodecContextParameters subtitleCodecPars;


### PR DESCRIPTION
This allows to use external subtile files (currently only SRT is
configured) for providing subtitles for movie files. This should be more
universal since it also supports container formats with no support for
subtitle streams.

To use this code the srt file needs to be named
`<movie name>-<language code>.srt` where the language code is the file
extension name specified in the localization table. For english the
`-...` part can be omitted.