### PR TITLE
Fix rsequence being reset twice and ssequence not being reset at all

### DIFF
--- a/code/network/psnet2.cpp
+++ b/code/network/psnet2.cpp
@@ -1035,7 +1035,7 @@ void psnet_rel_close_socket( PSNET_SOCKET_RELIABLE *sockp )
 				vm_free(Reliable_sockets[*sockp].sbuffers[i]);
 			}
 			Reliable_sockets[*sockp].sbuffers[i] = NULL;
-			Reliable_sockets[*sockp].rsequence[i] = 0;
+			Reliable_sockets[*sockp].ssequence[i] = 0;
 		}
 	}
 


### PR DESCRIPTION
Copy/paste error in `psnet_rel_close_socket` in `psnet2.cpp`.