### PR TITLE
Write full log path and add legacy mode reason to log file

### DIFF
--- a/code/osapi/osapi.cpp
+++ b/code/osapi/osapi.cpp
@@ -349,6 +349,8 @@ static time_t get_file_modification_time(const SCP_string& path) {
 #endif
 }
 
+const char* Osapi_legacy_mode_reason = nullptr;
+
 bool os_is_legacy_mode()
 {
 	// Make this check a little faster by caching the result
@@ -361,6 +363,8 @@ bool os_is_legacy_mode()
 		// When the portable mode option is given, non-legacy is implied
 		legacyMode = false;
 		checkedLegacyMode = true;
+
+		Osapi_legacy_mode_reason = "Legacy mode disabled since portable mode was enabled.";
 	}
 	else {
 		SCP_stringstream path_stream;
@@ -407,15 +411,27 @@ bool os_is_legacy_mode()
 			// if the old config was modified more recently than the new config then we use the legacy mode since the
 			// user probably used an outdated launcher after using a more recent one
 			legacyMode = old_config_time > new_config_time;
+
+			if (legacyMode) {
+				Osapi_legacy_mode_reason = "Legacy mode enabled since the old config location was used more recently than the new location.";
+			} else {
+				Osapi_legacy_mode_reason = "Legacy mode disabled since the new config location was used more recently than the old location.";
+			}
 		} else if (new_config_exists) {
 			// If the new config exists and the old one doesn't then we can safely disable the legacy mode
 			legacyMode = false;
+
+			Osapi_legacy_mode_reason = "Legacy mode disabled since the old config does not exist while the new config exists.";
 		} else if (old_config_exists) {
 			// Old config exists but new doesn't -> use legacy mode
 			legacyMode = true;
+
+			Osapi_legacy_mode_reason = "Legacy mode enabled since the old config exists while the new config does not exist.";
 		} else {
 			// Neither old nor new config exists -> this is a new install
 			legacyMode = false;
+
+			Osapi_legacy_mode_reason = "Legacy mode disabled since no existing config was detected.";
 		}
 	}
 

--- a/code/osapi/outwnd.cpp
+++ b/code/osapi/outwnd.cpp
@@ -253,12 +253,14 @@ void outwnd_init()
 		memset( pathname, 0, sizeof(pathname) );
 		snprintf( pathname, MAX_PATH_LEN, "%s/%s", Pathtypes[CF_TYPE_DATA].path, FreeSpace_logfilename);
 
-		Log_fp = fopen(os_get_config_path(pathname).c_str(), "wb");
+		auto logpath = os_get_config_path(pathname);
+
+		Log_fp = fopen(logpath.c_str(), "wb");
 
 		outwnd_inited = Log_fp != nullptr;
 
 		if (Log_fp == NULL) {
-			fprintf(stderr, "Error opening %s\n", pathname);
+			fprintf(stderr, "Error opening %s\n", logpath.c_str());
 		} else {
 			time_t timedate = time(NULL);
 			char datestr[50];
@@ -266,7 +268,7 @@ void outwnd_init()
 			memset(datestr, 0, sizeof(datestr));
 			strftime(datestr, sizeof(datestr) - 1, "%a %b %d %H:%M:%S %Y", localtime(&timedate));
 
-			outwnd_printf("General", "Opened log '%s', %s ...\n", pathname, datestr);
+			outwnd_printf("General", "Opened log '%s', %s ...\n", logpath.c_str(), datestr);
 		}
 	}
 }

--- a/code/osapi/outwnd.cpp
+++ b/code/osapi/outwnd.cpp
@@ -229,6 +229,8 @@ void outwnd_print(const char *id, const char *tmp)
 	}
 }
 
+extern const char* Osapi_legacy_mode_reason; // This was not exported in a header since it's not intended for general use
+
 void outwnd_init()
 {
 	if (outwnd_inited)
@@ -269,6 +271,8 @@ void outwnd_init()
 			strftime(datestr, sizeof(datestr) - 1, "%a %b %d %H:%M:%S %Y", localtime(&timedate));
 
 			outwnd_printf("General", "Opened log '%s', %s ...\n", logpath.c_str(), datestr);
+			mprintf(("Legacy config mode is %s.\nReason: %s\n", os_is_legacy_mode() ? "ENABLED" : "DISABLED",
+			         Osapi_legacy_mode_reason));
 		}
 	}
 }


### PR DESCRIPTION
This should make it a bit easier to determine if FSO is using the new
config file or the old one from only a log file.

This also adds a log line which states the reason for why the legacy or
new config location was chosen which will make it easier to debug issues
with that code.