### PR TITLE
Discard submodels by generating clipped vertices

### DIFF
--- a/code/def_files/data/effects/main-f.sdr
+++ b/code/def_files/data/effects/main-f.sdr
@@ -106,11 +106,6 @@ in VertexOutput {
 #ifdef FLAG_FOG
 	float fogDist;
 #endif
-#ifdef WORKAROUND_CLIPPING_PLANES
- #ifdef FLAG_TRANSFORM
-	float notVisible;
- #endif
-#endif
 	vec4 position;
 	vec3 normal;
 	vec4 texCoord;
@@ -215,11 +210,6 @@ vec3 CalculateLighting(vec3 normal, vec3 diffuseMaterial, vec3 specularMaterial,
 
 void main()
 {
-#ifdef WORKAROUND_CLIPPING_PLANES
- #ifdef FLAG_TRANSFORM
-	if(vertIn.notVisible >= 0.9) { discard; }
- #endif
-#endif
 #ifdef FLAG_SHADOW_MAP
 	// need depth and depth squared for variance shadow maps
 	fragOut0 = vec4(vertIn.position.z, vertIn.position.z * vertIn.position.z * VARIANCE_SHADOW_SCALE_INV, 0.0, 1.0);

--- a/code/def_files/data/effects/main-g.sdr
+++ b/code/def_files/data/effects/main-g.sdr
@@ -115,14 +115,12 @@ in VertexOutput {
 #ifdef FLAG_FOG
 	float fogDist;
 #endif
-#ifdef WORKAROUND_CLIPPING_PLANES
- #ifdef FLAG_TRANSFORM
-	float notVisible;
- #endif
-#endif
 #ifdef FLAG_SHADOW_MAP
  #if !defined(GL_ARB_gpu_shader5)
 	float instance;
+ #endif
+ #ifdef FLAG_TRANSFORM
+	float clipModel;
  #endif
 #else
 	vec4 position;
@@ -145,11 +143,6 @@ out VertexOutput {
 #ifdef FLAG_FOG
 	float fogDist;
 #endif
-#ifdef WORKAROUND_CLIPPING_PLANES
- #ifdef FLAG_TRANSFORM
-	float notVisible;
- #endif
-#endif
 	vec4 position;
 	vec3 normal;
 	vec4 texCoord;
@@ -169,9 +162,19 @@ void main(void)
 #endif
 	for(int vert = 0; vert < gl_in.length(); vert++)
 	{
+#ifdef FLAG_TRANSFORM
+		if (vertIn[vert].clipModel > 0.9) {
+			// If the model was clipped in the vertex shader then we do not apply the shadow projection matrix here
+			gl_Position = gl_in[vert].gl_Position;
+		} else {
+			gl_Position = shadow_proj_matrix[instanceID] * gl_in[vert].gl_Position;
+		}
+#else
 		gl_Position = shadow_proj_matrix[instanceID] * gl_in[vert].gl_Position;
+#endif
 		if(gl_Position.z < -1.0)
 			gl_Position.z = -1.0;
+
 		vertOut.position = gl_in[vert].gl_Position;
 		vertOut.normal = vertIn[vert].normal;
 		vertOut.texCoord = vertIn[vert].texCoord;
@@ -194,17 +197,8 @@ void main(void)
 		vertOut.shadowUV[3] = vertIn[vert].shadowUV[3];
 		vertOut.shadowPos = vertIn[vert].shadowPos;
 #endif
-#ifdef WORKAROUND_CLIPPING_PLANES
- #ifdef FLAG_TRANSFORM
-		vertOut.notVisible = vertIn[vert].notVisible;
- #endif
- #ifdef FLAG_CLIP
+#if defined(FLAG_CLIP)
 		gl_ClipDistance[0] = gl_in[vert].gl_ClipDistance[0];
- #endif
-#else
- #if defined(FLAG_CLIP) || defined(FLAG_TRANSFORM)
-		gl_ClipDistance[0] = gl_in[vert].gl_ClipDistance[0];
- #endif
 #endif
 		EmitVertex();
 	}
@@ -256,17 +250,8 @@ void main(void)
 			vertOut.shadowUV[3] = vertIn[vert].shadowUV[3];
 			vertOut.shadowPos = vertIn[vert].shadowPos;
 #endif
-#ifdef WORKAROUND_CLIPPING_PLANES
- #ifdef FLAG_TRANSFORM
-			vertOut.notVisible = vertIn[vert].notVisible;
- #endif
- #ifdef FLAG_CLIP
+#if defined(FLAG_CLIP)
 			gl_ClipDistance[0] = gl_in[vert].gl_ClipDistance[0];
- #endif
-#else
- #if defined(FLAG_CLIP) || defined(FLAG_TRANSFORM)
-			gl_ClipDistance[0] = gl_in[vert].gl_ClipDistance[0];
- #endif
 #endif
 			EmitVertex();
 		}

--- a/code/def_files/data/effects/main-v.sdr
+++ b/code/def_files/data/effects/main-v.sdr
@@ -113,14 +113,14 @@ out VertexOutput {
 #ifdef FLAG_FOG
 	float fogDist;
 #endif
-#ifdef WORKAROUND_CLIPPING_PLANES
- #ifdef FLAG_TRANSFORM
-	float notVisible;
- #endif
-#endif
 #ifdef FLAG_SHADOW_MAP
  #if !defined(GL_ARB_gpu_shader5)
 	float instance;
+ #endif
+ #ifdef FLAG_TRANSFORM
+	// This flag is needed to let the geometry shader know that it doesn't need to apply the
+	// shadow projection to gl_Position
+	float clipModel;
  #endif
 #else
 	vec4 position;
@@ -152,19 +152,9 @@ void main()
 	vec4 texCoord;
 	mat4 orient = mat4(1.0);
 	mat4 scale = mat4(1.0);
-#ifdef WORKAROUND_CLIPPING_PLANES
- #ifdef FLAG_TRANSFORM
+#ifdef FLAG_TRANSFORM
 	bool clipModel;
 	getModelTransform(orient, clipModel, int(vertModelID), buffer_matrix_offset);
-	vertOut.notVisible = clipModel ? 1.0 : 0.0;
- #endif
-#else
- #ifdef FLAG_TRANSFORM
-	bool clipModel;
-	getModelTransform(orient, clipModel, int(vertModelID), buffer_matrix_offset);
- #else
-	bool clipModel = false;
- #endif
 #endif
 	texCoord = textureMatrix * vertTexCoord;
 	vec4 vertex = vertPosition;
@@ -210,31 +200,28 @@ void main()
  #ifdef FLAG_FOG
 	vertOut.fogDist = clamp((gl_Position.z - fogStart) * 0.75 * fogScale, 0.0, 1.0);
  #endif
-#ifdef WORKAROUND_CLIPPING_PLANES
-	if(use_clip_plane) {
- 		gl_ClipDistance[0] = dot(clip_equation, modelMatrix * orient * vertex);
- 	} else {
-		gl_ClipDistance[0] = 1.0;
- 	}
-#else
- #ifdef FLAG_CLIP
+#ifdef FLAG_TRANSFORM
 	if (clipModel) {
-		gl_ClipDistance[0] = -1.0;
-	} else if(use_clip_plane) {
+		// Clip this model by moving all vertices outside the clip volume
+		gl_Position = vec4(vec3(-2.0), 1.0);
+	}
+ #ifdef FLAG_SHADOW_MAP
+	vertOut.clipModel = clipModel ? 1.0 : 0.0;
+ #endif
+#endif
+#ifdef FLAG_CLIP
+	if(use_clip_plane) {
 		gl_ClipDistance[0] = dot(clip_equation, modelMatrix * orient * vertex);
 	} else {
 		gl_ClipDistance[0] = 1.0;
 	}
- #elif defined(FLAG_TRANSFORM)
-	gl_ClipDistance[0] = clipModel ? -1.0 : 1.0;
- #endif
 #endif
- #ifndef FLAG_SHADOW_MAP
+#ifndef FLAG_SHADOW_MAP
 	vertOut.position = position;
 	vertOut.normal = normal;
 	vertOut.texCoord = texCoord;
- #else
+#else
 	vertOut.normal = normal;
 	vertOut.texCoord = texCoord;
- #endif
+#endif
 }

--- a/code/graphics/opengl/gropengl.cpp
+++ b/code/graphics/opengl/gropengl.cpp
@@ -91,8 +91,6 @@ static GLenum GL_read_format = GL_BGRA;
 
 GLuint GL_vao = 0;
 
-bool GL_workaround_clipping_planes = false;
-
 static std::unique_ptr<os::OpenGLContext> GL_context = nullptr;
 
 static std::unique_ptr<os::GraphicsOperations> graphic_operations = nullptr;
@@ -1366,19 +1364,6 @@ static void init_extensions() {
 	}
 }
 
-static void opengl_do_workaround_checks() {
-	auto vendor = glGetString(GL_VENDOR);
-
-	if (strstr((const char*) vendor, "NVIDIA")) {
-		// Nvidia has some weird issues with clipping planes. Check #1579 for more information.
-		GL_workaround_clipping_planes = true;
-		mprintf(("  Applying clipping plane workaround for NVIDIA hardware.\n"));
-	} else {
-		// Assume everone else has proper support for this
-		GL_workaround_clipping_planes = false;
-	}
-}
-
 bool gr_opengl_init(std::unique_ptr<os::GraphicsOperations>&& graphicsOps)
 {
 	if (GL_initted) {
@@ -1449,8 +1434,6 @@ bool gr_opengl_init(std::unique_ptr<os::GraphicsOperations>&& graphicsOps)
 	mprintf(( "  OpenGL Renderer  : %s\n", glGetString(GL_RENDERER) ));
 	mprintf(( "  OpenGL Version   : %s\n", glGetString(GL_VERSION) ));
 	mprintf(( "\n" ));
-
-	opengl_do_workaround_checks();
 
 	if (Cmdline_fullscreen_window || Cmdline_window) {
 		opengl_go_windowed();

--- a/code/graphics/opengl/gropengl.h
+++ b/code/graphics/opengl/gropengl.h
@@ -58,6 +58,4 @@ extern GLuint GL_vao;
 
 extern float GL_alpha_threshold;
 
-extern bool GL_workaround_clipping_planes; //!< If set then clipping planes can not be used for batched model rendering
-
 #endif

--- a/code/graphics/opengl/gropenglshader.cpp
+++ b/code/graphics/opengl/gropenglshader.cpp
@@ -342,10 +342,6 @@ static SCP_string opengl_shader_get_header(shader_type type_id, int flags, bool 
 
 	sflags << "#version " << GLSL_version << " core\n";
 
-	if (GL_workaround_clipping_planes) {
-		sflags << "#define WORKAROUND_CLIPPING_PLANES\n";
-	}
-
 	if (Detail.lighting < 3) {
 		sflags << "#define FLAG_LIGHT_MODEL_BLINN_PHONG\n";
 	}

--- a/code/graphics/opengl/gropengltnl.cpp
+++ b/code/graphics/opengl/gropengltnl.cpp
@@ -758,18 +758,10 @@ void opengl_tnl_set_model_material(model_material *material_info)
 
 	GL_state.Texture.SetShaderMode(GL_TRUE);
 
-	if (GL_workaround_clipping_planes) {
-		if (Current_shader->flags & SDR_FLAG_MODEL_CLIP) {
-			GL_state.ClipDistance(0, true);
-		} else {
-			GL_state.ClipDistance(0, false);
-		}
+	if (Current_shader->flags & SDR_FLAG_MODEL_CLIP) {
+		GL_state.ClipDistance(0, true);
 	} else {
-		if (Current_shader->flags & SDR_FLAG_MODEL_CLIP || Current_shader->flags & SDR_FLAG_MODEL_TRANSFORM) {
-			GL_state.ClipDistance(0, true);
-		} else {
-			GL_state.ClipDistance(0, false);
-		}
+		GL_state.ClipDistance(0, false);
 	}
 
 	uint32_t array_index;


### PR DESCRIPTION
This removes the clipping plane submodel removal code and replaces it
with shader code that generates vertices outside the clipping volume if
a model should not be rendered. This even improved performance since
clipping no longer needs to be active for all model rendering
operations.

This finally fixes #1579.