### PR TITLE
clarify documentation in cap-waypoint-speed

### DIFF
--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -32921,7 +32921,7 @@ SCP_vector<sexp_help_struct> Sexp_help = {
 	{ OP_CAP_WAYPOINT_SPEED, "cap-waypoint-speed\r\n"
 		"\tSets the maximum speed of a ship while flying waypoints.\r\n"
 		"\t1: Ship name\r\n"
-		"\t2: Maximum speed while flying waypoints\r\n"
+		"\t2: Maximum speed while flying waypoints (must be greater than 0)\r\n"
 		"\tNOTE: This will only work if the ship is already in the game\r\n"
 		"\tNOTE: Set to -1 to reset\r\n"},
 

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -15092,7 +15092,7 @@ char *ship_return_time_to_goal(char *outbuf, ship *sp)
 	min_speed = objp->phys_info.speed;
 
 	// Goober5000 - handle cap
-	if (aip->waypoint_speed_cap >= 0)
+	if (aip->waypoint_speed_cap > 0)
 		max_speed = MIN(sp->current_max_speed, aip->waypoint_speed_cap);
 	else
 		max_speed = sp->current_max_speed;


### PR DESCRIPTION
The `cap-waypoint-speed` sexp only works for speeds above 0; this PR changes the documentation to clarify that.

I also tweaked an if() block in `ship_return_time_to_goal` because it used a >=0 comparison whereas every other comparison used >0.  (This is only for consistency, because the >0 check is used before this point would be reached.)

This fixes #1758.