### PR TITLE
Fix GCC8 and FFmpeg warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -76,14 +76,14 @@ matrix:
                       - *global_deps
                       - g++-5
         - os: linux
-          env: CONFIGURATION="Debug" CC=gcc-7 CXX=g++-7
+          env: CONFIGURATION="Debug" CC=gcc-8 CXX=g++-8
           addons:
               apt:
                   sources:
                       - ubuntu-toolchain-r-test
                       - sourceline: 'ppa:beineri/opt-qt571-trusty'
                   packages:
-                      - g++-7
+                      - g++-8
                       - *global_deps
         - os: linux
           env: CONFIGURATION="Debug" CC=clang-4.0 CXX=clang++-4.0 CMAKE_OPTIONS="-DCMAKE_EXPORT_COMPILE_COMMANDS=ON"
@@ -115,14 +115,14 @@ matrix:
                       - *global_deps
                       - g++-5
         - os: linux
-          env: CONFIGURATION="Release" CC=gcc-7 CXX=g++-7
+          env: CONFIGURATION="Release" CC=gcc-8 CXX=g++-8
           addons:
               apt:
                   sources:
                       - ubuntu-toolchain-r-test
                       - sourceline: 'ppa:beineri/opt-qt571-trusty'
                   packages:
-                      - g++-7
+                      - g++-8
                       - *global_deps
         - os: linux
           env: CONFIGURATION="Release" CC=clang-4.0 CXX=clang++-4.0

--- a/cmake/toolchain-gcc.cmake
+++ b/cmake/toolchain-gcc.cmake
@@ -85,6 +85,17 @@ set(COMPILER_FLAGS "${COMPILER_FLAGS} -Wreturn-type")
 
 set(COMPILER_FLAGS "${COMPILER_FLAGS} -Wno-deprecated -Wno-char-subscripts")
 
+# These two warnings cause a lot of false-positives in the FSO code base
+check_cxx_compiler_flag(-Wstringop-truncation SUPPORTS_STRINGOP_TRUNCATION)
+if(SUPPORTS_STRINGOP_TRUNCATION)
+	set(COMPILER_FLAGS "${COMPILER_FLAGS} -Wno-stringop-truncation")
+endif()
+
+check_cxx_compiler_flag(-Wstringop-overflow SUPPORTS_STRINGOP_OVERFLOW)
+if(SUPPORTS_STRINGOP_TRUNCATION)
+	set(COMPILER_FLAGS "${COMPILER_FLAGS} -Wno-stringop-overflow")
+endif()
+
 set(COMPILER_FLAGS_RELEASE "-O2 -Wno-unused-variable -Wno-unused-but-set-variable -Wno-array-bounds -Wno-empty-body -Wno-clobbered  -Wno-unused-parameter")
 
 set(COMPILER_FLAGS_DEBUG "-O0 -g -Wshadow")

--- a/code/bmpman/bmpman.cpp
+++ b/code/bmpman/bmpman.cpp
@@ -591,7 +591,7 @@ int bm_create(int bpp, int w, int h, void *data, int flags) {
 
 	memset(entry, 0, sizeof(bitmap_entry));
 
-	sprintf(entry->filename, "TMP%dx%d+%d", w, h, bpp);
+	sprintf_safe(entry->filename, "TMP%dx%d+%d", w, h, bpp);
 	entry->type = BM_TYPE_USER;
 	entry->comp_type = BM_TYPE_NONE;
 	entry->palette_checksum = 0;
@@ -1253,7 +1253,7 @@ int bm_load(const char *real_filename) {
 
 	// Mark the slot as filled, because cf_read might load a new bitmap
 	// into this slot.
-	strncpy(entry->filename, filename, MAX_FILENAME_LEN - 1);
+	strcpy_s(entry->filename, filename);
 	entry->type = type;
 	entry->comp_type = c_type;
 	entry->signature = Bm_next_signature++;
@@ -1681,7 +1681,7 @@ int bm_load_animation(const char *real_filename, int *nframes, int *fps, int *ke
 
 		if (type == BM_TYPE_EFF) {
 			entry->info.ani.eff.type = eff_type;
-			sprintf(entry->info.ani.eff.filename, "%s_%.4d", clean_name, i);
+			sprintf_safe(entry->info.ani.eff.filename, "%s_%.4d", clean_name, i);
 
 			// bm_load_info() returns non-0 on failure
 			if (bm_load_info(eff_type, entry->info.ani.eff.filename,
@@ -1744,13 +1744,13 @@ int bm_load_animation(const char *real_filename, int *nframes, int *fps, int *ke
 		entry->load_count++;
 
 		if (i == 0) {
-			sprintf(entry->filename, "%s", filename);
+			sprintf_safe(entry->filename, "%s", filename);
 		} else {
 			if (type == BM_TYPE_PNG) {
-				sprintf(entry->filename, "%s_%04d", filename, i);
+				sprintf_safe(entry->filename, "%s_%04d", filename, i);
 			}
 			else {
-				sprintf(entry->filename, "%s[%d]", filename, i);
+				sprintf_safe(entry->filename, "%s[%d]", filename, i);
 			}
 		}
 
@@ -2527,7 +2527,7 @@ int bm_make_render_target(int width, int height, int flags) {
 
 	entry->type = (flags & BMP_FLAG_RENDER_TARGET_STATIC) ? BM_TYPE_RENDER_TARGET_STATIC : BM_TYPE_RENDER_TARGET_DYNAMIC;
 	entry->signature = Bm_next_signature++;
-	sprintf(entry->filename, "RT_%dx%d+%d", w, h, bpp);
+	sprintf_safe(entry->filename, "RT_%dx%d+%d", w, h, bpp);
 	entry->bm.w = (short)w;
 	entry->bm.h = (short)h;
 	entry->bm.rowsize = (short)w;

--- a/code/cfile/cfile.cpp
+++ b/code/cfile/cfile.cpp
@@ -222,8 +222,8 @@ int cfile_init(const char *exe_dir, const char *cdrom_dir)
 	cfile_chdir(buf);
 
 	// set root directory
-	strncpy(Cfile_root_dir, buf, CFILE_ROOT_DIRECTORY_LEN-1);
-	strncpy(Cfile_user_dir, os_get_config_path().c_str(), CFILE_ROOT_DIRECTORY_LEN-1);
+	strcpy_s(Cfile_root_dir, buf);
+	strcpy_s(Cfile_user_dir, os_get_config_path().c_str());
 
 	for (i = 0; i < MAX_CFILE_BLOCKS; i++) {
 		Cfile_block_list[i].type = CFILE_BLOCK_UNUSED;
@@ -348,8 +348,7 @@ int cfile_push_chdir(int type)
 		return -1;
 	}
 
-	strncpy(Cfile_stack[Cfile_stack_pos++], OriginalDirectory,
-	        CFILE_ROOT_DIRECTORY_LEN - 1);
+	strcpy_s(Cfile_stack[Cfile_stack_pos++], OriginalDirectory);
 
 	cf_create_default_path_string(dir, sizeof(dir) - 1, type, NULL);
 

--- a/code/cfile/cfilesystem.cpp
+++ b/code/cfile/cfilesystem.cpp
@@ -455,7 +455,7 @@ void cf_build_root_list(const char *cdrom_dir)
 		// =========================================================================
 		// set users HOME directory as default for loading and saving files
 		root = cf_create_root();
-		strncpy(root->path, Cfile_user_dir, CF_MAX_PATHNAME_LENGTH - 1);
+		strcpy_s(root->path, Cfile_user_dir);
 
 		// do we already have a slash? as in the case of a root directory install
 		if ((strlen(root->path) < (CF_MAX_PATHNAME_LENGTH - 1)) && (root->path[strlen(root->path) - 1] != DIR_SEPARATOR_CHAR)) {
@@ -2121,7 +2121,7 @@ int cf_get_file_list_preallocated( int max, char arr[][MAX_FILENAME_LEN], char *
 
 			if ( !Get_file_list_filter || (*Get_file_list_filter)(dir->d_name) ) {
 
-				strncpy(arr[num_files], dir->d_name, MAX_FILENAME_LEN - 1 );
+				strcpy_s(arr[num_files], dir->d_name );
 				char *ptr = strrchr(arr[num_files], '.');
 				if ( ptr ) {
 					*ptr = 0;

--- a/code/cutscene/ffmpeg/FFMPEGDecoder.cpp
+++ b/code/cutscene/ffmpeg/FFMPEGDecoder.cpp
@@ -43,7 +43,11 @@ const char* CHECKED_EXTENSIONS[] = {
 const char* CHECKED_SUBT_EXTENSIONS[] = {"srt"};
 
 double getFrameRate(AVStream* stream, AVCodecContext* codecCtx) {
+#if LIBAVCODEC_VERSION_INT > AV_VERSION_INT(58, 3, 102)
+	auto fps = av_q2d(stream->r_frame_rate);
+#else
 	auto fps = av_q2d(av_stream_get_r_frame_rate(stream));
+#endif
 
 	if (fps < 0.000001)
 	{

--- a/code/cutscene/ffmpeg/VideoDecoder.cpp
+++ b/code/cutscene/ffmpeg/VideoDecoder.cpp
@@ -89,7 +89,11 @@ void VideoDecoder::convertAndPushPicture(const AVFrame* frame) {
 	}
 
 	videoFramePtr->id = ++m_frameId;
+#if LIBAVCODEC_VERSION_INT > AV_VERSION_INT(58, 3, 102)
+	videoFramePtr->frameTime = getFrameTime(frame->best_effort_timestamp, m_status->videoStream->time_base);
+#else
 	videoFramePtr->frameTime = getFrameTime(av_frame_get_best_effort_timestamp(frame), m_status->videoStream->time_base);
+#endif
 	videoFramePtr->frame = yuvFrame;
 
 	videoFramePtr->ySize.height = static_cast<size_t>(m_status->videoCodecPars.height);

--- a/code/libs/ffmpeg/FFmpeg.cpp
+++ b/code/libs/ffmpeg/FFmpeg.cpp
@@ -55,7 +55,10 @@ void initialize() {
 		return;
 	}
 
+	// This is deprecated since 58.9.100 and not needed anymore
+#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(58, 9, 100)
 	av_register_all();
+#endif
 
 	check_version("libavcodec", avcodec_version(), LIBAVCODEC_VERSION_INT);
 	check_version("libavformat", avformat_version(), LIBAVFORMAT_VERSION_INT);

--- a/code/mission/missioncampaign.cpp
+++ b/code/mission/missioncampaign.cpp
@@ -458,7 +458,7 @@ int mission_campaign_load( char *filename, player *pl, int load_savefile, bool r
 		auto len = strlen(filename) - 4;
 		Assert(len < MAX_FILENAME_LEN);
 		strncpy(Campaign.filename, filename, len);
-		Campaign.filename[len] = 0;
+		Campaign.filename[len] = '\0';
 
 		required_string("$Name:");
 		stuff_string( name, F_NAME, NAME_LENGTH );
@@ -846,7 +846,8 @@ void mission_campaign_savefile_delete( char *cfilename )
 		return;	// no such thing as a multiplayer campaign savefile
 	}
 
-	sprintf( filename, NOX("%s.%s.csg"), Player->callsign, base ); // only support the new filename here - taylor
+	// only support the new filename here - taylor
+	sprintf_safe( filename, NOX("%s.%s.csg"), Player->callsign, base );
 
 	cf_delete( filename, CF_TYPE_PLAYERS );
 }

--- a/code/mission/missionmessage.cpp
+++ b/code/mission/missionmessage.cpp
@@ -1207,7 +1207,7 @@ void message_play_anim( message_q *q )
 					rand_index = ((int) Missiontime % MAX_WINGMAN_HEADS);
 				}
 				strcpy_s(temp, ani_name);
-				sprintf(ani_name, "%s%c", temp, 'a'+rand_index);
+				sprintf_safe(ani_name, "%s%c", temp, 'a'+rand_index);
 				subhead_selected = TRUE;
 			} else if ( Personas[persona_index].flags & (PERSONA_FLAG_COMMAND | PERSONA_FLAG_LARGE) ) {
 				// get a random head
@@ -1221,7 +1221,7 @@ void message_play_anim( message_q *q )
 				}
 
 				strcpy_s(temp, ani_name);
-				sprintf(ani_name, "%s%c", temp, 'a'+rand_index);
+				sprintf_safe(ani_name, "%s%c", temp, 'a'+rand_index);
 				subhead_selected = TRUE;
 			} else {
 				mprintf(("message '%s' uses an unrecognized persona type\n", m->name));
@@ -1232,7 +1232,7 @@ void message_play_anim( message_q *q )
 			// choose between a and b
 			rand_index = ((int) Missiontime % MAX_WINGMAN_HEADS);
 			strcpy_s(temp, ani_name);
-			sprintf(ani_name, "%s%c", temp, 'a'+rand_index);
+			sprintf_safe(ani_name, "%s%c", temp, 'a'+rand_index);
 			mprintf(("message '%s' with invalid head.  Fix by assigning persona to the message.\n", m->name));
 		}
 		nprintf(("Messaging", "playing head %s for %s\n", ani_name, q->who_from));

--- a/code/network/chat_api.cpp
+++ b/code/network/chat_api.cpp
@@ -64,13 +64,6 @@ Chat_user *Firstuser,*Curruser;
 Chat_command *Firstcommand,*Currcommand;
 Chat_channel *Firstchannel,*Currchannel;
 
-// Unix version of snprintf always adds nul, but the windows version doesn't
-#ifdef _WIN32
-#define SSIZE(x) (sizeof((x))-1)
-#else
-#define SSIZE(x) (sizeof((x)))
-#endif
-
 void ChatInit(void)
 {
 	Socket_connecting = 0;
@@ -234,9 +227,9 @@ int ConnectToChatServer(char *serveraddr, char *nickname, char *trackerid)
 
 				Socket_connected = 1;
 				memset(signon_str, 0, sizeof(signon_str));
-				snprintf(signon_str, SSIZE(signon_str), NOX("/USER %s %s %s :%s"), NOX("user"), NOX("user"), NOX("user"), Chat_tracker_id);
+				sprintf_safe(signon_str, NOX("/USER %s %s %s :%s"), NOX("user"), NOX("user"), NOX("user"), Chat_tracker_id);
 				SendChatString(signon_str, 1);
-				snprintf(signon_str, SSIZE(signon_str), NOX("/NICK %s"), Nick_name);
+				sprintf_safe(signon_str, NOX("/NICK %s"), Nick_name);
 				SendChatString(signon_str,1);
 				return 0;
 				//Now we are waiting for Chat_server_connected
@@ -319,7 +312,7 @@ const char * SendChatString(const char *line,int raw)
 		if(stricmp(szCmd,NOX("msg"))==0)
 		{
 			strncpy(szTarget, GetWordNum(1, line+1), sizeof(szTarget)-1);
-			snprintf(szCmd, SSIZE(szCmd), NOX("PRIVMSG %s :%s\n\r"), szTarget, line+strlen(NOX("/msg "))+strlen(szTarget)+1);
+			sprintf_safe(szCmd, NOX("PRIVMSG %s :%s\n\r"), szTarget, line+strlen(NOX("/msg "))+strlen(szTarget)+1);
 			send(Chatsock,szCmd,(int)strlen(szCmd),0);
 			szCmd[strlen(szCmd)-2] = '\0';
 			return ParseIRCMessage(szCmd,MSG_LOCAL);
@@ -327,7 +320,7 @@ const char * SendChatString(const char *line,int raw)
 		}
 		if(stricmp(szCmd,NOX("me"))==0)
 		{
-			snprintf(szCmd, SSIZE(szCmd), NOX("PRIVMSG %s :\001ACTION %s\001\n\r"), szChat_channel,line+strlen(NOX("/me ")));
+			sprintf_safe(szCmd, NOX("PRIVMSG %s :\001ACTION %s\001\n\r"), szChat_channel,line+strlen(NOX("/me ")));
 			send(Chatsock,szCmd,(int)strlen(szCmd),0);
 			szCmd[strlen(szCmd)-2] = '\0';
 			return ParseIRCMessage(szCmd,MSG_LOCAL);
@@ -336,19 +329,19 @@ const char * SendChatString(const char *line,int raw)
 		if(stricmp(szCmd,NOX("xyz"))==0)
 		{
 			//Special command to send raw irc commands
-			snprintf(szCmd, SSIZE(szCmd), "%s\n\r", line+strlen(NOX("/xyz ")));
+			sprintf_safe(szCmd, "%s\n\r", line+strlen(NOX("/xyz ")));
 			send(Chatsock,szCmd,(int)strlen(szCmd),0);
 			return NULL;
 		}
 		if(stricmp(szCmd,NOX("list"))==0)
 		{
-			snprintf(szCmd, SSIZE(szCmd), "%s\n\r", line+1);
+			sprintf_safe(szCmd, "%s\n\r", line+1);
 			send(Chatsock,szCmd,(int)strlen(szCmd),0);
 			return NULL;
 		}
 		if(raw)
 		{
-			snprintf(szCmd, SSIZE(szCmd), "%s\n\r", line+1);
+			sprintf_safe(szCmd, "%s\n\r", line+1);
 			send(Chatsock,szCmd,(int)strlen(szCmd),0);
 			return NULL;
 		}
@@ -359,7 +352,7 @@ const char * SendChatString(const char *line,int raw)
 	{
 		if(szChat_channel[0])
 		{
-			snprintf(szCmd, SSIZE(szCmd), NOX("PRIVMSG %s :%s\n\r"), szChat_channel, line);
+			sprintf_safe(szCmd, NOX("PRIVMSG %s :%s\n\r"), szChat_channel, line);
 			send(Chatsock,szCmd,(int)strlen(szCmd),0);
 			if(strlen(szCmd) >= 2){
 				szCmd[strlen(szCmd)-2] = '\0';
@@ -453,11 +446,11 @@ int SetNewChatChannel(char *channel)
 	{
 		if(szChat_channel[0])
 		{
-			snprintf(partstr, SSIZE(partstr), NOX("/PART %s"), szChat_channel);
+			sprintf_safe(partstr, NOX("/PART %s"), szChat_channel);
 			SendChatString(partstr,1);
 		}
 		strncpy(szChat_channel, channel, sizeof(szChat_channel)-1);
-		snprintf(partstr, SSIZE(partstr), NOX("/JOIN %s"), szChat_channel);
+		sprintf_safe(partstr, NOX("/JOIN %s"), szChat_channel);
 		SendChatString(partstr,1);
 		Joining_channel = 1;
 		Joined_channel = 0;
@@ -742,19 +735,19 @@ char * ParseIRCMessage(char *Line, int iMode)
 			if(stricmp(szCTCPCmd+1,NOX("ACTION"))==0)
 			{
 				//Posture
-				snprintf(szResponse, SSIZE(szResponse), "* %s %s", szNick, szRemLine);								
+				sprintf_safe(szResponse, "* %s %s", szNick, szRemLine);
 				return szResponse;
 			}
 			if(iMode==MSG_LOCAL)
 			{
 				strncpy(szHackPrefix, Line+iPrefixLen+strlen(szCmd)+strlen(szTarget)+4, sizeof(szHackPrefix)-1);
 				szRemLine[strlen(szRemLine)-1] = '\0';
-				snprintf(szResponse, SSIZE(szResponse), NOX("** CTCP %s %s %s"), szTarget, szCTCPCmd+1, szRemLine);
+				sprintf_safe(szResponse, NOX("** CTCP %s %s %s"), szTarget, szCTCPCmd+1, szRemLine);
 				return szResponse;
 			}
 			if(stricmp(szCTCPCmd+1,NOX("PING"))==0)
 			{
-				snprintf(szResponse, SSIZE(szResponse), NOX("/NOTICE %s :\001PING %s\001"), szNick, szRemLine);//Don't need the trailing \001 because szremline has it.
+				sprintf_safe(szResponse, NOX("/NOTICE %s :\001PING %s\001"), szNick, szRemLine);//Don't need the trailing \001 because szremline has it.
 				SendChatString(szResponse,1);
 				return NULL;
 			}
@@ -764,7 +757,7 @@ char * ParseIRCMessage(char *Line, int iMode)
 			}
 			strncpy(szRemLine, 1 + GetWordNum(0,Line+iPrefixLen+strlen(szCmd)+strlen(szTarget)+4), sizeof(szRemLine)-1);
 			szRemLine[strlen(szRemLine)-1] = '\0';
-			snprintf(szResponse, SSIZE(szResponse), NOX("** CTCP Message from %s (%s)"), szNick, szRemLine);
+			sprintf_safe(szResponse, NOX("** CTCP Message from %s (%s)"), szNick, szRemLine);
 			return szResponse;
 
 		}
@@ -772,7 +765,7 @@ char * ParseIRCMessage(char *Line, int iMode)
 		if(szTarget[0]=='#')
 		{
 			pszTempStr=GetWordNum(0,szRemLine);
-			snprintf(szResponse, SSIZE(szResponse), "[%s] %s", szNick, pszTempStr);			
+			sprintf_safe(szResponse, "[%s] %s", szNick, pszTempStr);
 			return szResponse;
 		}
 		else
@@ -780,12 +773,12 @@ char * ParseIRCMessage(char *Line, int iMode)
 			if(iMode == MSG_LOCAL)
 			{
 				pszTempStr=GetWordNum(0,szRemLine);
-				snprintf(szResponse, SSIZE(szResponse), NOX("Private Message to <%s>: %s"), szNick, pszTempStr);			
+				sprintf_safe(szResponse, NOX("Private Message to <%s>: %s"), szNick, pszTempStr);
 			}
 			else
 			{
 				pszTempStr=GetWordNum(0,szRemLine);
-				snprintf(szResponse, SSIZE(szResponse), NOX("Private Message from <%s>: %s"), szNick, pszTempStr);			
+				sprintf_safe(szResponse, NOX("Private Message from <%s>: %s"), szNick, pszTempStr);
 			}
 			return szResponse;
 		}
@@ -828,11 +821,11 @@ char * ParseIRCMessage(char *Line, int iMode)
 			//Default message
 			strncpy(szRemLine, 1 + GetWordNum(0,Line+iPrefixLen+strlen(szCmd)+strlen(szTarget)+4), sizeof(szRemLine)-1);
 			szRemLine[strlen(szRemLine)-1] = '\0';
-			snprintf(szResponse, SSIZE(szResponse), XSTR("** CTCP Message from %s (%s)", 635), szNick, szRemLine);
+			sprintf_safe(szResponse, XSTR("** CTCP Message from %s (%s)", 635), szNick, szRemLine);
 			return szResponse;
 			
 		}
-		snprintf(szResponse, SSIZE(szResponse), "%s", szRemLine);
+		sprintf_safe(szResponse, "%s", szRemLine);
 		return NULL;
 	}
 	if(stricmp(szCmd,NOX("JOIN"))==0)
@@ -853,7 +846,7 @@ char * ParseIRCMessage(char *Line, int iMode)
 		strncpy(szTarget, pszTempStr, sizeof(szTarget)-1);
 
 		AddChatUser(szNick);
-		snprintf(szResponse, SSIZE(szResponse), XSTR("** %s has joined %s", 636), szNick, szTarget);
+		sprintf_safe(szResponse, XSTR("** %s has joined %s", 636), szNick, szTarget);
 		return NULL;//szResponse;
 		//Add them to the userlist too!
 	}
@@ -887,7 +880,7 @@ char * ParseIRCMessage(char *Line, int iMode)
 			AddChatCommandToQueue(CC_KICKED,NULL,0);			
 			RemoveAllChatUsers();
 		}
-		snprintf(szResponse, SSIZE(szResponse), XSTR("*** %s has kicked %s from channel %s (%s)", 637), szNick, szHackPrefix, szTarget, pszTempStr);
+		sprintf_safe(szResponse, XSTR("*** %s has kicked %s from channel %s (%s)", 637), szNick, szHackPrefix, szTarget, pszTempStr);
 		//Remove them to the userlist too!
 		RemoveChatUser(szNick);
 		return szResponse;
@@ -902,17 +895,17 @@ char * ParseIRCMessage(char *Line, int iMode)
 			strncpy(Nick_name, GetWordNum(0,szRemLine), sizeof(Nick_name)-1);
 		}
 		char nicks[70];
-		snprintf(nicks, SSIZE(nicks), "%s %s", szNick, GetWordNum(0, szRemLine));
+		sprintf_safe(nicks, "%s %s", szNick, GetWordNum(0, szRemLine));
 		AddChatCommandToQueue(CC_NICKCHANGED,nicks,strlen(nicks)+1);
 		RemoveChatUser(szNick);
 		AddChatUser(GetWordNum(0,szRemLine));
-		snprintf(szResponse, SSIZE(szResponse), XSTR("*** %s is now known as %s", 638), szNick, GetWordNum(0, szRemLine));
+		sprintf_safe(szResponse, XSTR("*** %s is now known as %s", 638), szNick, GetWordNum(0, szRemLine));
 		return szResponse;
 	}
 	if(stricmp(szCmd,NOX("PING"))==0)
 	{
 		//respond with pong (GetWordNum(0,szRemLine))
-		snprintf(szResponse, SSIZE(szResponse), NOX("/PONG :%s"), GetWordNum(0, szRemLine));
+		sprintf_safe(szResponse, NOX("/PONG :%s"), GetWordNum(0, szRemLine));
 		SendChatString(szResponse,1);
 		return NULL;
 	}
@@ -937,9 +930,9 @@ char * ParseIRCMessage(char *Line, int iMode)
 		memset(szWhoisUser, 0, sizeof(szWhoisUser));
 		strncpy(szWhoisUser, GetWordNum(1,szRemLine), sizeof(szWhoisUser)-1);
 		Getting_user_tracker_error = 1;			
-		Getting_user_channel_error = 1;				
-						
-		snprintf(szResponse, SSIZE(szResponse), XSTR("**Error: %s is not online!", 639), szWhoisUser);
+		Getting_user_channel_error = 1;
+
+		sprintf_safe(szResponse, XSTR("**Error: %s is not online!", 639), szWhoisUser);
 		return szResponse;
 
 	}
@@ -1048,8 +1041,8 @@ char * ParseIRCMessage(char *Line, int iMode)
 		(stricmp(szCmd,"372")==0))
 	{
 		//Stip the message, and display it.
-		pszTempStr=GetWordNum(3,Line);		
-		snprintf(szResponse, SSIZE(szResponse), "%s%s", PXO_CHAT_MOTD_PREFIX, pszTempStr);
+		pszTempStr=GetWordNum(3,Line);
+		sprintf_safe(szResponse, "%s%s", PXO_CHAT_MOTD_PREFIX, pszTempStr);
 		return szResponse;
 	}
 	//Ignore these messages
@@ -1105,7 +1098,7 @@ char * ParseIRCMessage(char *Line, int iMode)
 	if(stricmp(szCmd,"432")==0)
 	{
 		//Channel Mode info
-		snprintf(szResponse, SSIZE(szResponse), "%s", XSTR("Your nickname contains invalid characters", 640));
+		sprintf_safe(szResponse, "%s", XSTR("Your nickname contains invalid characters", 640));
 		AddChatCommandToQueue(CC_DISCONNECTED,NULL,0);
 		return szResponse;
 	}
@@ -1113,10 +1106,10 @@ char * ParseIRCMessage(char *Line, int iMode)
 	{
 		//Channel Mode info
 		char new_nick[33];
-		snprintf(new_nick, SSIZE(new_nick), "%s%d", Orignial_nick_name, Nick_variety);
+		sprintf_safe(new_nick, "%s%d", Orignial_nick_name, Nick_variety);
 		strncpy(Nick_name, new_nick, sizeof(Nick_name)-1);
 		Nick_variety++;
-		snprintf(szResponse, SSIZE(szResponse), NOX("/NICK %s"), new_nick);
+		sprintf_safe(szResponse, NOX("/NICK %s"), new_nick);
 		SendChatString(szResponse,1);
 		return NULL;
 	}
@@ -1290,7 +1283,7 @@ char *GetTrackerIdByUser(char *nickname)
 	else
 	{
 		strncpy(Getting_user_tracker_info_for, nickname, sizeof(Getting_user_tracker_info_for)-1);
-		snprintf(szWhoisCmd, SSIZE(szWhoisCmd), NOX("/WHOIS %s"), nickname);
+		sprintf_safe(szWhoisCmd, NOX("/WHOIS %s"), nickname);
 		User_req_tracker_id[0] = '\0';
 		SendChatString(szWhoisCmd,1);		
 		GettingUserTID = 1;
@@ -1320,7 +1313,7 @@ char *GetChannelByUser(char *nickname)
 	{
 		strncpy(Getting_user_channel_info_for, nickname, sizeof(Getting_user_channel_info_for)-1);
 		User_req_channel[0] = '\0';
-		snprintf(szWhoisCmd, SSIZE(szWhoisCmd), NOX("/WHOIS %s"), nickname);
+		sprintf_safe(szWhoisCmd, NOX("/WHOIS %s"), nickname);
 		SendChatString(szWhoisCmd,1);
 		GettingUserChannel = 1;
 	}

--- a/code/network/multi_pxo.cpp
+++ b/code/network/multi_pxo.cpp
@@ -1823,7 +1823,7 @@ int multi_pxo_connect_do()
 
 		// build the tracker id string
 		memset(id_string, 0, MAX_PXO_TEXT_LEN);
-		sprintf(id_string, "%s %s", Multi_tracker_id_string, Player->callsign);
+		sprintf_safe(id_string, "%s %s", Multi_tracker_id_string, Player->callsign);
 
 		// build the ip string
 		memset(ip_string, 0, MAX_PXO_TEXT_LEN);
@@ -5343,14 +5343,14 @@ void multi_pxo_ban_parse_banner_file(int choose_existing)
 		}
 
 		// base filename
-		strncpy(Multi_pxo_banner.ban_file, banners[idx], MAX_FILENAME_LEN);
+		strcpy_s(Multi_pxo_banner.ban_file, banners[idx]);
 
 		// get the full file url
-		strncpy(Multi_pxo_banner.ban_file_url, file_url, MULTI_OPTIONS_STRING_LEN);
-		strncat(Multi_pxo_banner.ban_file_url, banners[idx], MULTI_OPTIONS_STRING_LEN);
+		strcpy_s(Multi_pxo_banner.ban_file_url, file_url);
+		strcat_s(Multi_pxo_banner.ban_file_url, banners[idx]);
 
 		// url of where to go to when clicked
-		strncpy(Multi_pxo_banner.ban_url, urls[idx], MULTI_OPTIONS_STRING_LEN);		
+		strcpy_s(Multi_pxo_banner.ban_url, urls[idx]);
 	}
 }
 

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -10454,7 +10454,7 @@ void sexp_play_sound_from_file(int n)
 void multi_sexp_play_sound_from_file()
 {
 	char filename[NAME_LENGTH];
-	bool (loop);
+	bool loop;
 	if (!Current_sexp_network_packet.get_string(filename)) {
 		return;
 	}
@@ -27636,6 +27636,9 @@ int query_operator_argument_type(int op, int argnum)
 					return OPF_SUBSYSTEM;
 				case 4:
 					return OPF_BOOL;
+				default:
+					UNREACHABLE("Invalid argnum %d detected!", argnum);
+					return OPF_NULL;
 			}
 
 		case OP_BEAM_FIRE_COORDS:

--- a/code/pilotfile/plr.cpp
+++ b/code/pilotfile/plr.cpp
@@ -1127,7 +1127,7 @@ bool pilotfile::verify(const char *fname, int *rank, char *valid_language)
 	}
 
 	if (valid_language) {
-		strncpy(valid_language, p->language, sizeof(p->language));
+		strcpy(valid_language, p->language);
 	}
 
 	// need to cleanup early to ensure everything is OK for use in the CSG next

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -1520,7 +1520,7 @@ ship_info::ship_info()
 
 	collision_damage_type_idx = -1;
 	// Retail default collision physics and default landing parameters
-	memset(&collision_physics, 0, sizeof(ship_collision_physics));
+	collision_physics = ship_collision_physics();
 	collision_physics.both_small_bounce = 5.0;
 	collision_physics.bounce = 5.0;
 	collision_physics.friction = COLLISION_FRICTION_FACTOR;
@@ -12669,7 +12669,7 @@ int ship_info_lookup(const char *token)
 			return -1;
 		}
 		// assemble using parentheses
-		sprintf(name, "%s (%s)", temp1, temp2);
+		sprintf_safe(name, "%s (%s)", temp1, temp2);
 	}
 	// found a parenthesis
 	else if (*p == '(')
@@ -12679,7 +12679,7 @@ int ship_info_lookup(const char *token)
 		*p2 = '\0';
 
 		// assemble using hash
-		sprintf(name, "%s#%s", temp1, temp2);
+		sprintf_safe(name, "%s#%s", temp1, temp2);
 	}
 	// oops
 	else

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -875,37 +875,37 @@ class man_thruster {
 // Most of this only really applies properly to small ships
 typedef struct ship_collision_physics {
 	// Collision physics definitions: how a ship responds to collisions
-	float both_small_bounce;	// Bounce factor when both ships are small
+	float both_small_bounce{};	// Bounce factor when both ships are small
 								// This currently only comes into play if one ship is the player... 
 								// blame retail for that.
-	float bounce;				// Bounce factor for all other cases
-	float friction;				// Controls lateral velocity lost when colliding with a large ship
-	float rotation_factor;		// Affects the rotational energy of collisions... TBH not sure how. 
+	float bounce{};				// Bounce factor for all other cases
+	float friction{};				// Controls lateral velocity lost when colliding with a large ship
+	float rotation_factor{};		// Affects the rotational energy of collisions... TBH not sure how.
 
 	// Speed & angle constraints for a smooth landing
 	// Note that all angles are stored as a dotproduct between normalized vectors instead. This saves us from having
 	// to do a lot of dot product calculations later.
-	float landing_max_z;		
-	float landing_min_z;
-	float landing_min_y;
-	float landing_max_x;
-	float landing_max_angle;
-	float landing_min_angle;
-	float landing_max_rot_angle;
+	float landing_max_z{};
+	float landing_min_z{};
+	float landing_min_y{};
+	float landing_max_x{};
+	float landing_max_angle{};
+	float landing_min_angle{};
+	float landing_max_rot_angle{};
 
 	// Speed & angle constraints for a "rough" landing (one with normal collision consequences, but where 
 	// the ship is still reoriented towards its resting orientation)
-	float reorient_max_z;
-	float reorient_min_z;
-	float reorient_min_y;
-	float reorient_max_x;
-	float reorient_max_angle;
-	float reorient_min_angle;
-	float reorient_max_rot_angle;
+	float reorient_max_z{};
+	float reorient_min_z{};
+	float reorient_min_y{};
+	float reorient_max_x{};
+	float reorient_max_angle{};
+	float reorient_min_angle{};
+	float reorient_max_rot_angle{};
 
 	// Landing response parameters
-	float reorient_mult;		// How quickly the ship will reorient towards it's resting position
-	float landing_rest_angle;	// The vertical angle where the ship's orientation comes to rest
+	float reorient_mult{};		// How quickly the ship will reorient towards it's resting position
+	float landing_rest_angle{};	// The vertical angle where the ship's orientation comes to rest
 	gamesnd_id landing_sound_idx;		//Sound to play on successful landing collisions
 
 } ship_collision_physics;

--- a/code/stats/medals.cpp
+++ b/code/stats/medals.cpp
@@ -595,9 +595,9 @@ void blit_label(const char *label, int num)
 
 		// set correct string
 		if ( num > 1 ) {
-			sprintf( text, NOX("%s (%d)"), translated_label, num );
+			sprintf_safe( text, NOX("%s (%d)"), translated_label, num );
 		} else {
-			sprintf( text, "%s", translated_label );
+			sprintf_safe( text, "%s", translated_label );
 		}
 	} else if (Lcl_pl && !Disable_built_in_translations) {
 		char translated_label[256];
@@ -606,16 +606,16 @@ void blit_label(const char *label, int num)
 
 		// set correct string
 		if ( num > 1 ) {
-			sprintf( text, NOX("%s (%d)"), translated_label, num );
+			sprintf_safe( text, NOX("%s (%d)"), translated_label, num );
 		} else {
-			sprintf( text, "%s", translated_label );
+			sprintf_safe( text, "%s", translated_label );
 		}
 	} else {
 		// set correct string
 		if ( num > 1 ) {
-			sprintf( text, NOX("%s (%d)"), label, num );
+			sprintf_safe( text, NOX("%s (%d)"), label, num );
 		} else {
-			sprintf( text, "%s", label );
+			sprintf_safe( text, "%s", label );
 		}
 	}
 
@@ -790,12 +790,12 @@ void init_medal_bitmaps()
 				// has no character. next version is a, then b, etc.
 				char temp[MAX_FILENAME_LEN];
 				strcpy_s(temp, base);
-				sprintf( base, "%s%c", temp, (num_medals-2)+'a');
+				sprintf_safe( base, "%s%c", temp, (num_medals-2)+'a');
 			}
 
 			// hi-res support
 			if (gr_screen.res == GR_1024) {
-				sprintf( filename, "2_%s", base );
+				sprintf_safe( filename, "2_%s", base );
 			}
 
 			// base now contains the actual medal bitmap filename needed to load

--- a/code/tracing/FrameProfiler.cpp
+++ b/code/tracing/FrameProfiler.cpp
@@ -269,7 +269,7 @@ void FrameProfiler::dump_output(SCP_stringstream& out,
 		indented_name += samples[i].name;
 
 		char line[256];
-		sprintf(line, "%5s : %5s : %5s : %3s : ", avg, min, max, num);
+		sprintf_safe(line, "%5s : %5s : %5s : %3s : ", avg, min, max, num);
 
 		out << line + indented_name + "\n";
 	}

--- a/code/utils/strings.h
+++ b/code/utils/strings.h
@@ -6,6 +6,8 @@
 
 #include "platformChecks.h"
 
+#include <utility>
+
 #if HAVE_STRCASECMP || HAVE_STRNCASECMP
 #if HAVE_STRINGS_H
 #include <strings.h>
@@ -61,5 +63,19 @@ inline void strlwr(char *s) {
 #error No support for snprintf detected!
 #endif
 #endif
+
+template<size_t SIZE, typename... Args>
+inline int sprintf_safe(char (&dest)[SIZE], const char* format, Args&&... args) {
+	auto written = snprintf(dest, SIZE, format, std::forward<Args>(args)...);
+
+	if (written < 0) {
+		return written;
+	}
+
+	if ((size_t)written >= SIZE) {
+		dest[SIZE - 1] = '\0';
+	}
+	return written;
+}
 
 #endif //FS2_OPEN_CASECMP_H

--- a/lib/opengl/gl/CMakeLists.txt
+++ b/lib/opengl/gl/CMakeLists.txt
@@ -5,10 +5,7 @@ add_library(glad STATIC
 	"glad/src/glad.c")
 target_include_directories(glad SYSTEM PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/glad/include")
 set_target_properties(glad PROPERTIES FOLDER "3rdparty")
-if (MSVC)
-	# Suppress some warnings
-	target_compile_options(glad PRIVATE "/w")
-endif()
+suppress_warnings(glad)
 
 
 add_library(OpenGL INTERFACE)
@@ -22,10 +19,7 @@ if (WIN32)
 	target_include_directories(glad_wgl SYSTEM PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/glad_wgl/include")
 	set_target_properties(glad_wgl PROPERTIES FOLDER "3rdparty")
 	target_link_libraries(glad_wgl PUBLIC glad)
-	if (MSVC)
-		# Suppress some warnings
-		target_compile_options(glad_wgl PRIVATE "/w")
-	endif()
+	suppress_warnings(glad_wgl)
 	
 	# On Windows we need WGL which requires the OpenGL libraries
 	find_package(OpenGL)

--- a/qtfred/src/mission/Editor.cpp
+++ b/qtfred/src/mission/Editor.cpp
@@ -2544,7 +2544,7 @@ int Editor::internal_error(const char* msg, ...) {
 #ifndef NDEBUG
 	char buf2[2048];
 
-	sprintf(buf2, "%s\n\nThis is an internal error.  Please let Jason\n"
+	sprintf_safe(buf2, "%s\n\nThis is an internal error.  Please let Jason\n"
 		"know about this so he can fix it.  Click cancel to debug.", buf);
 
 	if (_lastActiveViewport->dialogProvider->showButtonDialog(DialogType::Error,

--- a/qtfred/src/mission/missionsave.cpp
+++ b/qtfred/src/mission/missionsave.cpp
@@ -172,7 +172,7 @@ int CFred_mission_save::fout_ext(const char* pre_str, const char* format, ...) {
 		// _does_ exist, so just write it out as it is
 	else {
 		char buf[10];
-		sprintf(buf, "%d", str_id);
+		sprintf_safe(buf, "%d", str_id);
 
 		str_out_scp += " XSTR(\"";
 		str_out_scp += str_scp;


### PR DESCRIPTION
GCC 8 has a few new warnings that were triggered in the FSO source code. This fixes those issues. The most common issue was a possible buffer overflow when using `sprintf`. I fixed that by introducing a safe variant of the function which uses `snprintf` for ensuring that no buffer overflow occurs. To make the transition easier I added a template function which automatically deduces the size of the output array. This also upgrades the GCC version used by Travis to 8 to ensure no new warnings are added.

There were also a few deprecation warnings when using FFmpeg 4.0. I solved those by adding version checks and using the appropriate new code.