### PR TITLE
Nolink ballistic primaries no longer disallow linking when depleted.

### DIFF
--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -12253,7 +12253,7 @@ int ship_select_next_primary(object *objp, int direction)
 		{
 			for (i = 0; i < swp->num_primary_banks; i++)
 			{
-				if (primary_out_of_ammo(swp, i))
+				if (!Weapon_info[swp->primary_bank_weapons[i]].wi_flags[Weapon::Info_Flags::Nolink] && primary_out_of_ammo(swp, i)) // We only care if linkable primaries are out of ammo.
 				{
 					shipp->flags.remove(Ship_Flags::Primary_linked);
 					


### PR DESCRIPTION
When a ship with three primary banks has a `Nolink` weapon in one bank, the other two banks are still allowed to link; if that `Nolink` weapon has a limited ammo supply, however, depleting that ammo supply would disallow primary linking even though the weapon never contributed to primary linking in the first place. This commit changes the logic to only care if the depleted weapon doesn't have the `Nolink` flag. The ideal solution is probably to change how primary linking works so that even if the weapon doesn't have the `Nolink` flag the remaining primaries can still link, but that would be much more involved.