### PR TITLE
Add AI profile flag to allow primary weapons to consider range.

### DIFF
--- a/code/ai/ai_flags.h
+++ b/code/ai/ai_flags.h
@@ -110,6 +110,7 @@ namespace AI {
         Smart_subsystem_targeting_for_turrets,
         Strict_turred_tagged_only_targeting,
         Turrets_ignore_target_radius,
+        Use_actual_primary_range,
         Use_additive_weapon_velocity,
         Use_newtonian_dampening,
         Use_only_single_fov_for_turrets,

--- a/code/ai/ai_profiles.cpp
+++ b/code/ai/ai_profiles.cpp
@@ -458,6 +458,8 @@ void parse_ai_profiles_tbl(const char *filename)
 
 				set_flag(profile, "$ai can slow down when attacking big ships:", AI::Profile_Flags::Ai_can_slow_down_attacking_big_ships);
 
+				set_flag(profile, "$use actual primary range:", AI::Profile_Flags::Use_actual_primary_range);
+
 				profile->bay_arrive_speed_mult = 1.0f;
 				profile->bay_depart_speed_mult = 1.0f;
 				if (optional_string("$bay arrive speed multiplier:")) {

--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -764,6 +764,8 @@ void parse_ai_class()
 	set_aic_flag(aicp, "$all ships manage shields:", AI::Profile_Flags::All_ships_manage_shields);
 
 	set_aic_flag(aicp, "$ai can slow down when attacking big ships:", AI::Profile_Flags::Ai_can_slow_down_attacking_big_ships);
+
+	set_aic_flag(aicp, "$use actual primary range:", AI::Profile_Flags::Use_actual_primary_range);
 }
 
 void reset_ai_class_names()
@@ -8768,7 +8770,11 @@ void ai_chase()
 						scale = (scale - 0.6f) * 1.5f;
 					else
 						scale = 0.0f;
-					if (dist_to_enemy < pwip->max_speed * (1.0f + scale)) {
+					float range = pwip->max_speed * (1.0f + scale);
+					if (aip->ai_profile_flags[AI::Profile_Flags::Use_actual_primary_range]) {
+						range = std::min( {range, pwip->max_speed * pwip->lifetime, pwip->weapon_range} );
+					}
+					if (dist_to_enemy < range) {
 						if(ai_fire_primary_weapon(Pl_objp) == 1){
 							has_fired = 1;
 						}else{


### PR DESCRIPTION
By enabling the "$Use Actual Primary Range:" profile flag (which can also be set on a per-AI-class basis), the code to determine if the AI should fire its primary weapons will not only perform its current "range based on speed of weapon and target" calculation, but it will also compute the weapon's actual range and not fire if the target is outside of it.