### PR TITLE
Enable cache bitmaps by default and remove option

### DIFF
--- a/code/bmpman/bmpman.cpp
+++ b/code/bmpman/bmpman.cpp
@@ -2590,9 +2590,6 @@ void bm_page_in_start() {
 		for (auto& slot : block) {
 			auto& entry = slot.entry;
 
-			if (!Cmdline_cache_bitmaps && (entry.type != BM_TYPE_NONE)) {
-				bm_unload_fast(entry.handle);
-			}
 			entry.preloaded = 0;
 			entry.preload_count = 0;
 #ifdef BMPMAN_NDEBUG

--- a/code/cmdline/cmdline.cpp
+++ b/code/cmdline/cmdline.cpp
@@ -173,7 +173,6 @@ Flag exe_params[] =
 	{ "-no_deferred",		"Disable Deferred Lighting",				true,	EASY_DEFAULT_MEM,	EASY_DEFAULT,		"Graphics",		"http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-no_deferred"},
 	{ "-enable_shadows",	"Enable Shadows",							true,	EASY_MEM_ALL_ON,	EASY_DEFAULT,		"Graphics",		"http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-no_shadows"},
 	{ "-no_vsync",			"Disable vertical sync",					true,	0,					EASY_DEFAULT,		"Game Speed",	"http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-no_vsync", },
-	{ "-cache_bitmaps",		"Cache bitmaps between missions",			true,	0,					EASY_DEFAULT_MEM,	"Game Speed",	"http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-cache_bitmaps", },
 
 	{ "-dualscanlines",		"Add another pair of scanning lines",		true,	0,					EASY_DEFAULT,		"HUD",			"http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-dualscanlines", },
 	{ "-targetinfo",		"Enable info next to target",				true,	0,					EASY_DEFAULT,		"HUD",			"http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-targetinfo", },
@@ -363,11 +362,9 @@ int Cmdline_no_deferred_lighting = 0;
 int Cmdline_aniso_level = 0;
 
 // Game Speed related
-cmdline_parm cache_bitmaps_arg("-cache_bitmaps", NULL, AT_NONE);	// Cmdline_cache_bitmaps
 cmdline_parm no_fpscap("-no_fps_capping", "Don't limit frames-per-second", AT_NONE);	// Cmdline_NoFPSCap
 cmdline_parm no_vsync_arg("-no_vsync", NULL, AT_NONE);		// Cmdline_no_vsync
 
-int Cmdline_cache_bitmaps = 0;	// caching of bitmaps between missions (faster loads, can hit swap on reload with <512 Meg RAM though) - taylor
 int Cmdline_NoFPSCap = 0; // Disable FPS capping - kazan
 int Cmdline_no_vsync = 0;
 
@@ -546,6 +543,7 @@ cmdline_parm deprecated_htl_arg("-nohtl", "Deprecated", AT_NONE);
 cmdline_parm deprecated_brieflighting_arg("-brief_lighting", "Deprecated", AT_NONE);
 cmdline_parm deprecated_sndpreload_arg("-snd_preload", "Deprecated", AT_NONE);
 cmdline_parm deprecated_missile_lighting_arg("-missile_lighting", "Deprecated", AT_NONE);
+cmdline_parm deprecated_cache_bitmaps_arg("-cache_bitmaps", "Deprecated", AT_NONE);
 
 int Cmdline_deprecated_spec = 0;
 int Cmdline_deprecated_glow = 0;
@@ -556,6 +554,7 @@ int Cmdline_deprecated_jpgtga = 0;
 int Cmdline_deprecated_nohtl = 0;
 bool Cmdline_deprecated_brief_lighting = 0;
 bool Cmdline_deprecated_missile_lighting = false;
+bool Cmdline_deprecated_cache_bitmaps = false;
 
 #ifndef NDEBUG
 // NOTE: this assumes that os_init() has already been called but isn't a fatal error if it hasn't
@@ -625,6 +624,10 @@ void cmdline_debug_print_cmdline()
 	if (Cmdline_deprecated_missile_lighting) 
 	{
 		mprintf(("Deprecated flag '-missile_lighting' found. Please remove from your cmdline.\n"));
+	}
+
+	if (Cmdline_deprecated_cache_bitmaps) {
+		mprintf(("Deprecated flag '-cache_bitmaps' found. Please remove from your cmdline.\n"));
 	}
 }
 #endif
@@ -1965,10 +1968,6 @@ bool SetCmdlineParams()
 		Cmdline_ballistic_gauge = 1;
 	}
 
-	if ( cache_bitmaps_arg.found() ) {
-		Cmdline_cache_bitmaps = 1;
-	}
-
 	if(old_collision_system.found())
 		Cmdline_old_collision_sys = 1;
 
@@ -2157,6 +2156,10 @@ bool SetCmdlineParams()
 	if (deprecated_missile_lighting_arg.found())
 	{
 		Cmdline_deprecated_missile_lighting = true;
+	}
+
+	if (deprecated_cache_bitmaps_arg.found()) {
+		Cmdline_deprecated_cache_bitmaps = true;
 	}
 
 	return true; 

--- a/code/cmdline/cmdline.h
+++ b/code/cmdline/cmdline.h
@@ -82,7 +82,6 @@ extern int Cmdline_no_emissive;
 extern int Cmdline_aniso_level;
 
 // Game Speed related
-extern int Cmdline_cache_bitmaps;
 extern int Cmdline_NoFPSCap;
 extern int Cmdline_no_vsync;
 


### PR DESCRIPTION
Caching bitmaps between missions is no longer a problem for modern
system and this will improve the default load times when playing more
than one mission.