### PR TITLE
Add mod table options for specifying lighting preset

### DIFF
--- a/code/cmdline/cmdline.h
+++ b/code/cmdline/cmdline.h
@@ -53,14 +53,8 @@ extern char *Cmdline_center_res;
 // FSO OPTIONS -------------------------------------------------
 
 // Graphics related
-extern double specular_exponent_value;
 extern float Cmdline_clip_dist;
 extern float Cmdline_fov;
-extern float Cmdline_ogl_spec;
-extern float static_light_factor;
-extern float static_point_factor;
-extern float static_tube_factor;
-extern int Cmdline_ambient_factor;
 extern int Cmdline_env;
 extern int Cmdline_glow;
 extern int Cmdline_nomotiondebris;
@@ -71,7 +65,6 @@ extern int Cmdline_height;
 extern int Cmdline_enable_3d_shockwave;
 extern int Cmdline_softparticles;
 extern int Cmdline_postprocess;
-extern int Cmdline_bloom_intensity;
 extern bool Cmdline_fxaa;
 extern int Cmdline_fxaa_preset;
 extern bool Cmdline_fb_explosions;

--- a/code/graphics/light.cpp
+++ b/code/graphics/light.cpp
@@ -13,6 +13,7 @@
 #include "graphics/2d.h"
 #include "light.h"
 #include "matrix.h"
+#include "mod_table/mod_table.h"
 #include "render/3d.h"
 
 // Structures
@@ -71,7 +72,7 @@ void FSLight2GLLight(light* FSLight, gr_light* GLLight) {
 	GLLight->SpotDir.xyz.y = 0.0f;
 	GLLight->SpotDir.xyz.z = -1.0f;
 	// spot exponent
-	GLLight->SpotExp = Cmdline_ogl_spec * 0.5f;
+	GLLight->SpotExp = Ogl_spec * 0.5f;
 	// spot cutoff
 	GLLight->SpotCutOff = 180.0f; // special value, light in all directions
 	// defaults to disable attenuation
@@ -91,9 +92,9 @@ void FSLight2GLLight(light* FSLight, gr_light* GLLight) {
 		GLLight->ConstantAtten = 1.0f;
 		GLLight->LinearAtten = (1.0f / MAX(FSLight->rada, FSLight->radb)) * 1.25f;
 
-		GLLight->Specular.xyzw.x *= static_point_factor;
-		GLLight->Specular.xyzw.y *= static_point_factor;
-		GLLight->Specular.xyzw.z *= static_point_factor;
+		GLLight->Specular.xyzw.x *= Point_light_spec_factor;
+		GLLight->Specular.xyzw.y *= Point_light_spec_factor;
+		GLLight->Specular.xyzw.z *= Point_light_spec_factor;
 
 		break;
 	}
@@ -103,9 +104,9 @@ void FSLight2GLLight(light* FSLight, gr_light* GLLight) {
 		GLLight->LinearAtten = (1.0f / MAX(FSLight->rada, FSLight->radb)) * 1.25f;
 		GLLight->QuadraticAtten = (1.0f / MAX(FSLight->rada_squared, FSLight->radb_squared)) * 1.25f;
 
-		GLLight->Specular.xyzw.x *= static_tube_factor;
-		GLLight->Specular.xyzw.y *= static_tube_factor;
-		GLLight->Specular.xyzw.z *= static_tube_factor;
+		GLLight->Specular.xyzw.x *= Tube_light_spec_factor;
+		GLLight->Specular.xyzw.y *= Tube_light_spec_factor;
+		GLLight->Specular.xyzw.z *= Tube_light_spec_factor;
 
 		GLLight->Position.xyzw.x = FSLight->vec2.xyz.x; // Valathil: Use endpoint of tube as light position
 		GLLight->Position.xyzw.y = FSLight->vec2.xyz.y;
@@ -128,9 +129,9 @@ void FSLight2GLLight(light* FSLight, gr_light* GLLight) {
 		GLLight->Position.xyzw.z = -FSLight->vec.xyz.z;
 		GLLight->Position.xyzw.w = 0.0f; // This is a direction so the w part must be 0
 
-		GLLight->Specular.xyzw.x *= static_light_factor;
-		GLLight->Specular.xyzw.y *= static_light_factor;
-		GLLight->Specular.xyzw.z *= static_light_factor;
+		GLLight->Specular.xyzw.x *= Static_light_spec_factor;
+		GLLight->Specular.xyzw.y *= Static_light_spec_factor;
+		GLLight->Specular.xyzw.z *= Static_light_spec_factor;
 
 		break;
 	}
@@ -256,7 +257,7 @@ void gr_set_center_alpha(int type) {
 	glight.SpotDir.xyz.x = 0.0f;
 	glight.SpotDir.xyz.y = 0.0f;
 	glight.SpotDir.xyz.z = -1.0f;
-	glight.SpotExp = Cmdline_ogl_spec * 0.5f;
+	glight.SpotExp = Ogl_spec * 0.5f;
 	glight.SpotCutOff = 180.0f;
 	glight.ConstantAtten = 1.0f;
 	glight.LinearAtten = 0.0f;
@@ -278,8 +279,8 @@ void gr_reset_lighting() {
 	Num_active_gr_lights = 0;
 }
 
-void gr_calculate_ambient_factor(int ambient_factor) {
-	gr_user_ambient = (float) ((ambient_factor * 2) - 255) / 255.0f;
+void gr_calculate_ambient_factor(int factor) {
+	gr_user_ambient = (float) ((factor * 2) - 255) / 255.0f;
 }
 
 void gr_light_shutdown() {

--- a/code/graphics/light.h
+++ b/code/graphics/light.h
@@ -3,6 +3,7 @@
 
 #include "globalincs/pstypes.h"
 #include "lighting/lighting.h"
+#include "mod_table/mod_table.h"
 #include "graphics/util/uniform_structs.h"
 
 //Variables
@@ -24,7 +25,7 @@ void gr_set_lighting(bool set, bool state);
 void gr_set_center_alpha(int type);
 void gr_set_ambient_light(int red, int green, int blue);
 
-void gr_calculate_ambient_factor(int ambient_factor = Cmdline_ambient_factor);
+void gr_calculate_ambient_factor(int factor = Ambient_factor);
 
 void gr_light_init();
 void gr_light_shutdown();

--- a/code/graphics/opengl/gropengldeferred.cpp
+++ b/code/graphics/opengl/gropengldeferred.cpp
@@ -87,9 +87,9 @@ void gr_opengl_deferred_lighting_end()
 
 extern SCP_vector<light> Lights;
 extern int Num_lights;
-extern float static_point_factor;
-extern float static_light_factor;
-extern float static_tube_factor;
+extern float Point_light_spec_factor;
+extern float Static_light_spec_factor;
+extern float Tube_light_spec_factor;
 
 void gr_opengl_deferred_lighting_finish()
 {
@@ -149,7 +149,7 @@ void gr_opengl_deferred_lighting_finish()
 
 		header->invScreenWidth = 1.0f / gr_screen.max_w;
 		header->invScreenHeight = 1.0f / gr_screen.max_h;
-		header->specFactor = Cmdline_ogl_spec;
+		header->specFactor = Ogl_spec;
 
 		// Only the first directional light uses shaders so we need to know when we already saw that light
 		bool first_directional = true;
@@ -189,7 +189,7 @@ void gr_opengl_deferred_lighting_finish()
 				light_data->lightDir.xyz.y = view_dir.xyzw.y;
 				light_data->lightDir.xyz.z = view_dir.xyzw.z;
 
-				vm_vec_scale(&light_data->specLightColor, static_light_factor);
+				vm_vec_scale(&light_data->specLightColor, Static_light_spec_factor);
 
 				first_directional = false;
 				break;
@@ -203,7 +203,7 @@ void gr_opengl_deferred_lighting_finish()
 				light_data->diffuseLightColor = diffuse;
 				light_data->specLightColor = spec;
 
-				vm_vec_scale(&light_data->specLightColor, static_point_factor);
+				vm_vec_scale(&light_data->specLightColor, Point_light_spec_factor);
 
 				light_data->lightRadius = MAX(l.rada, l.radb) * 1.25f;
 				light_data->scale.xyz.x = MAX(l.rada, l.radb) * 1.28f;
@@ -223,14 +223,14 @@ void gr_opengl_deferred_lighting_finish()
 				light_data->scale.xyz.y = l.radb * 1.53f;
 				light_data->scale.xyz.z = length;
 
-				vm_vec_scale(&light_data->specLightColor, static_tube_factor);
+				vm_vec_scale(&light_data->specLightColor, Tube_light_spec_factor);
 
 				// Tube lights consist of two different types of lights with almost the same properties
 				light_data = uniformAligner.addTypedElement<deferred_light_data>();
 				light_data->diffuseLightColor = diffuse;
 				light_data->specLightColor = spec;
 
-				vm_vec_scale(&light_data->specLightColor, static_tube_factor);
+				vm_vec_scale(&light_data->specLightColor, Tube_light_spec_factor);
 
 				light_data->lightRadius = l.radb * 1.5f;
 				light_data->lightType = LT_POINT;

--- a/code/graphics/opengl/gropenglpostprocessing.cpp
+++ b/code/graphics/opengl/gropenglpostprocessing.cpp
@@ -185,7 +185,7 @@ void opengl_post_pass_bloom()
 
 		Current_shader->program->Uniforms.setUniformi("tex", 0);
 		Current_shader->program->Uniforms.setUniformi("levels", MAX_MIP_BLUR_LEVELS);
-		Current_shader->program->Uniforms.setUniformf("bloom_intensity", Cmdline_bloom_intensity / 100.0f);
+		Current_shader->program->Uniforms.setUniformf("bloom_intensity", Bloom_intensity / 100.0f);
 
 		GL_state.Texture.Enable(0, GL_TEXTURE_2D, Bloom_textures[0]);
 
@@ -819,7 +819,7 @@ bool opengl_post_init_shaders()
 		gr_opengl_maybe_create_shader(SDR_TYPE_POST_PROCESS_BLUR, SDR_FLAG_BLUR_VERTICAL) < 0 ||
 		gr_opengl_maybe_create_shader(SDR_TYPE_POST_PROCESS_BLOOM_COMP, 0) < 0) {
 		// disable bloom if we don't have those shaders available
-		Cmdline_bloom_intensity = 0;
+		Bloom_intensity = 0;
 	}
 
 	if ( gr_opengl_maybe_create_shader(SDR_TYPE_POST_PROCESS_FXAA, 0) < 0 ||

--- a/code/lab/lab.cpp
+++ b/code/lab/lab.cpp
@@ -1006,11 +1006,11 @@ void labviewer_render_options_set_ambient_factor(Slider *caller) {
 }
 
 void labviewer_render_options_set_static_light_factor(Slider *caller) {
-	static_light_factor = caller->GetSliderValue();
+	Static_light_spec_factor = caller->GetSliderValue();
 }
 
 void labviewer_render_options_set_bloom(Slider *caller) {
-	Cmdline_bloom_intensity = fl2i(caller->GetSliderValue());
+	Bloom_intensity = fl2i(caller->GetSliderValue());
 }
 
 void labviewer_make_render_options_window(Button * /*caller*/)
@@ -2184,7 +2184,7 @@ void lab_close()
 	Detail.hardware_textures = Lab_detail_texture_save;
 
 	//Reset ambient factor
-	gr_calculate_ambient_factor(Cmdline_ambient_factor);
+	gr_calculate_ambient_factor(Ambient_factor);
 
 	weapon_unpause_sounds();
 	//audiostream_unpause_all();

--- a/code/lighting/lighting.cpp
+++ b/code/lighting/lighting.cpp
@@ -342,12 +342,6 @@ int light_get_global_dir(vec3d *pos, int n)
 	return 1;
 }
 
-float static_light_factor = 1.0f;
-float static_tube_factor = 1.0f;
-float static_point_factor = 1.0f;
-
-double specular_exponent_value = 16.0;
-
 void light_apply_rgb( ubyte *param_r, ubyte *param_g, ubyte *param_b, const vec3d *pos, const vec3d *norm, float static_light_level )
 {
 	int idx;

--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -44,6 +44,25 @@ bool Enable_scripts_in_fred; // By default FRED does not initialize the scriptin
 SCP_string Window_icon_path;
 bool Disable_built_in_translations;
 
+int Ambient_factor = 128;
+float Static_light_spec_factor = 1.0f;
+float Tube_light_spec_factor = 1.0f;
+float Point_light_spec_factor = 1.0f;
+float Ogl_spec = 80.0f;
+int Bloom_intensity = 75;
+
+template<typename T>
+static void parse_and_clamp(T& dest) {
+	T min_max[2];
+	auto n = stuff_number_list(min_max, 2);
+	if (n == 1) {
+		// No range specified
+		dest = min_max[0];
+	} else {
+		CAP(dest, min_max[0], min_max[1]);
+	}
+}
+
 void parse_mod_table(const char *filename)
 {
 	// SCP_vector<SCP_string> lines;
@@ -281,6 +300,24 @@ void parse_mod_table(const char *filename)
 			else {
 				mprintf(("Game Settings Table: FRED - Scripts will not be executed when running FRED.\n"));
 			}
+		}
+
+		optional_string("#LIGHTING SETTINGS");
+
+		if (optional_string("$Ambient factor:")) {
+			parse_and_clamp(Ambient_factor);
+		}
+		if (optional_string("$Static light specular factor:")) {
+			parse_and_clamp(Static_light_spec_factor);
+		}
+		if (optional_string("$Tube light specular factor:")) {
+			parse_and_clamp(Tube_light_spec_factor);
+		}
+		if (optional_string("$Point light specular factor:")) {
+			parse_and_clamp(Point_light_spec_factor);
+		}
+		if (optional_string("$Bloom factor:")) {
+			parse_and_clamp(Bloom_intensity);
 		}
 
 		optional_string("#OTHER SETTINGS");

--- a/code/mod_table/mod_table.h
+++ b/code/mod_table/mod_table.h
@@ -37,6 +37,13 @@ extern bool Enable_scripts_in_fred;
 extern SCP_string Window_icon_path;
 extern bool Disable_built_in_translations;
 
+extern int Ambient_factor;
+extern float Static_light_spec_factor;
+extern float Point_light_spec_factor;
+extern float Tube_light_spec_factor;
+extern float Ogl_spec;
+extern int Bloom_intensity;
+
 void mod_table_init();
 
 /**

--- a/code/parse/parselo.h
+++ b/code/parse/parselo.h
@@ -147,6 +147,10 @@ extern int stuff_string_list(SCP_vector<SCP_string>& slp);
 extern int stuff_string_list(char slp[][NAME_LENGTH], int max_strings);
 extern int parse_string_flag_list(int *dest, flag_def_list defs[], int defs_size);
 
+// Overloads to make templated parsing functions easier to implement
+inline void stuff_number(float* f) { stuff_float(f); }
+inline void stuff_number(int* i) { stuff_int(i); }
+inline void stuff_number(ubyte* i) { stuff_ubyte(i); }
 
 // A templated version of parse_string_flag_list, to go along with the templated flag_def_list_new.
 // If the "is_special" flag is set, or a string was not found in the def list, it will be added to the unparsed_or_special_strings Vector
@@ -225,6 +229,10 @@ extern void stuff_parenthesized_vec3d(vec3d *vp);
 extern void stuff_boolean(int *i, bool a_to_eol=true);
 extern void stuff_boolean(bool *b, bool a_to_eol=true);
 extern void stuff_boolean_flag(int *i, int flag, bool a_to_eol=true);
+
+// Overloads to make templated parsing functions easier
+inline size_t stuff_number_list(int* l, size_t max) { return static_cast<size_t>(stuff_int_list(l, max)); }
+inline size_t stuff_number_list(float* l, size_t max) { return stuff_float_list(l, max); }
 
 int string_lookup(const char *str1, const char* const *strlist, size_t max, const char *description = NULL, bool say_errors = false);
 


### PR DESCRIPTION
This will make it possible to specify the lighting parameters from a mod
which will then override the values specified on the command line. This
is meant to be used by mods which have some specific requirements on how
the lighting should look like.

One possible issue here is that this might make changes to the lighting system
break backwards compatibility since the lighting options can now be set in
a table. I don't think that this is a big issue but I wanted to mention it here.