### PR TITLE
Downgrade null vec3d warning to a log print

### DIFF
--- a/code/math/vecmat.cpp
+++ b/code/math/vecmat.cpp
@@ -428,12 +428,9 @@ float vm_vec_copy_normalize(vec3d *dest, const vec3d *src)
 
 	//	Mainly here to trap attempts to normalize a null vector.
 	if (m <= 0.0f) {
-//		static int been_warned2 = false;//added this so the warning could be sounded and you can still get on with playing-Bobboau
-//		if(!been_warned2)
 		{
-			Warning(LOCATION, "Null vec3d in vec3d normalize.\n"
-							  "Trace out of vecmat.cpp and find offending code.\n");
-//			been_warned2 = true;
+			mprintf(("Null vec3d in vec3d normalize.\n"
+							  "Trace out of vecmat.cpp and find offending code.\n"));
 		}
 
 		dest->xyz.x = 1.0f;

--- a/code/math/vecmat.cpp
+++ b/code/math/vecmat.cpp
@@ -428,10 +428,8 @@ float vm_vec_copy_normalize(vec3d *dest, const vec3d *src)
 
 	//	Mainly here to trap attempts to normalize a null vector.
 	if (m <= 0.0f) {
-		{
-			mprintf(("Null vec3d in vec3d normalize.\n"
-							  "Trace out of vecmat.cpp and find offending code.\n"));
-		}
+		mprintf(("Null vec3d in vec3d normalize.\n"
+				 "Trace out of vecmat.cpp and find offending code.\n"));
 
 		dest->xyz.x = 1.0f;
 		dest->xyz.y = 0.0f;


### PR DESCRIPTION
This is definitely open for discussion, but here's my reasoning:

1. This warning is something a modder cannot do anything about
2. Even for coders, it is hard to impossible to actually figure out the cause of most of these
3. Therefore, interrupting gameplay during debugging for this is not warranted, in my opinion.