### PR TITLE
Use strongly-typed handles for sound entries

### DIFF
--- a/code/gamesnd/gamesnd.cpp
+++ b/code/gamesnd/gamesnd.cpp
@@ -565,9 +565,9 @@ void gamesnd_unload_gameplay_sounds()
 	Assert( Snds.size() <= INT_MAX );
 	for (SCP_vector<game_snd>::iterator gs = Snds.begin(); gs != Snds.end(); ++gs) {
 		for (auto& entry : gs->sound_entries) {
-			if (entry.id != -1) {
+			if (entry.id.isValid()) {
 				snd_unload(entry.id);
-				entry.id = -1;
+				entry.id = sound_load_id::invalid();
 			}
 		}
 	}
@@ -599,9 +599,9 @@ void gamesnd_unload_interface_sounds()
 	Assert( Snds_iface.size() < INT_MAX );
 	for (SCP_vector<game_snd>::iterator si = Snds_iface.begin(); si != Snds_iface.end(); ++si) {
 		for (auto& entry : si->sound_entries) {
-			if ( entry.id != -1 ) {
+			if (entry.id.isValid()) {
 				snd_unload( entry.id );
-				entry.id = -1;
+				entry.id     = sound_load_id::invalid();
 				entry.id_sig = -1;
 			}
 		}
@@ -1322,7 +1322,7 @@ float gamesnd_get_max_duration(game_snd* gs) {
 	int max_length = 0;
 
 	for (auto& entry : gs->sound_entries) {
-		if (entry.id < 0) {
+		if (!entry.id.isValid()) {
 			// Lazily load unloaded sound entries when required
 			entry.id = snd_load(&entry, gs->flags);
 		}

--- a/code/menuui/optionsmenu.cpp
+++ b/code/menuui/optionsmenu.cpp
@@ -465,8 +465,6 @@ UI_XSTR Options_text[GR_NUM_RESOLUTIONS][OPTIONS_NUM_TEXT] = {
 
 void options_play_voice_clip()
 {
-	int snd_id;
-
 	if ( snd_is_playing(Voice_vol_handle) ) {
 		snd_stop(Voice_vol_handle);
 		Voice_vol_handle=-1;
@@ -474,7 +472,7 @@ void options_play_voice_clip()
 	auto gs = gamesnd_get_interface_sound(InterfaceSounds::VOICE_SLIDER_CLIP);
 	auto entry = gamesnd_choose_entry(gs);
 
-	snd_id = snd_load(entry, gs->flags, 0);
+	auto snd_id = snd_load(entry, gs->flags, 0);
 
 	Voice_vol_handle = snd_play_raw( snd_id, 0.0f, 1.0f, SND_PRIORITY_SINGLE_INSTANCE );
 }

--- a/code/mission/missionmessage.cpp
+++ b/code/mission/missionmessage.cpp
@@ -322,7 +322,7 @@ int add_avi( char *avi_name )
 	// would have returned if a slot existed.
 	generic_anim_init( &extra.anim_data, avi_name );
 	strcpy_s( extra.name, avi_name );
-	extra.num = -1;
+	extra.num    = sound_load_id::invalid();
 	extra.exists = (generic_anim_load(&extra.anim_data) == 0); // load only to validate the anim
 	generic_anim_unload(&extra.anim_data); // unload to not waste bmpman slots
 	Message_avis.push_back(extra); 
@@ -345,7 +345,7 @@ int add_wave( const char *wave_name )
 
 	generic_anim_init( &extra.anim_data );
 	strcpy_s( extra.name, wave_name );
-	extra.num = -1;
+	extra.num = sound_load_id::invalid();
 	Message_waves.push_back(extra);
 	Num_message_waves++;
 	return ((int)Message_waves.size() - 1);
@@ -710,7 +710,7 @@ void messages_init()
 	}
 
 	for (i = 0; i < Num_builtin_waves; i++ ){
-		Message_waves[i].num = -1;
+		Message_waves[i].num = sound_load_id::invalid();
 	}
 
 	Message_shipnum = -1;
@@ -767,7 +767,7 @@ void message_mission_shutdown()
 
 	// remove the wave sounds from memory
 	for (i = 0; i < Num_message_waves; i++ ) {
-		if ( Message_waves[i].num != -1 ){
+		if (Message_waves[i].num.isValid()) {
 			snd_unload( Message_waves[i].num );
 		}
 	}
@@ -996,12 +996,12 @@ void message_load_wave(int index, const char *filename)
 {
 	Assertion(index >= 0, "Invalid index passed!");
 
-	if ( Message_waves[index].num >= 0) {
+	if (Message_waves[index].num.isValid()) {
 		return;
 	}
 
 	if ( !Sound_enabled ) {
-		Message_waves[index].num = -1;
+		Message_waves[index].num = sound_load_id::invalid();
 		return;
 	}
 
@@ -1009,7 +1009,7 @@ void message_load_wave(int index, const char *filename)
 	strcpy_s( tmp_gs.filename, filename );
 	Message_waves[index].num = snd_load( &tmp_gs, 0, 0 );
 
-	if (Message_waves[index].num == -1)
+	if (!Message_waves[index].num.isValid())
 		nprintf(("messaging", "Cannot load message wave: %s.  Will not play\n", Message_waves[index].name));
 }
 
@@ -1063,7 +1063,7 @@ bool message_play_wave( message_q *q )
 		if ( q->flags & MQF_CONVERT_TO_COMMAND ) {
 			char *p, new_filename[MAX_FILENAME_LEN];
 
-			Message_waves[index].num = -1;					// forces us to reload the message
+			Message_waves[index].num = sound_load_id::invalid(); // forces us to reload the message
 
 			// bash the filename here. Look for "[1-6]_" at the front of the message.  If found, then
 			// convert to TC_*
@@ -1082,7 +1082,7 @@ bool message_play_wave( message_q *q )
 
 		// load the sound file into memory
 		message_load_wave(index, filename);
-		if ( Message_waves[index].num == -1 ) {
+		if (!Message_waves[index].num.isValid()) {
 			m->wave_info.index = -1;
 		}
 

--- a/code/mission/missionmessage.h
+++ b/code/mission/missionmessage.h
@@ -15,6 +15,7 @@
 #include "anim/packunpack.h"
 #include "globalincs/globals.h"		// include so that we can gets defs for lengths of tokens
 #include "graphics/generic.h"
+#include "sound/sound.h"
 
 class ship;
 
@@ -26,7 +27,7 @@ class ship;
 
 typedef struct message_extra {
 	char				name[MAX_FILENAME_LEN];
-	int				num;
+	sound_load_id num;
 	generic_anim		anim_data;
 	bool				exists;
 } message_extra;

--- a/code/mission/missiontraining.cpp
+++ b/code/mission/missiontraining.cpp
@@ -746,7 +746,7 @@ int message_play_training_voice(int index)
 		return -1;
 	}
 
-	if (Message_waves[index].num < 0) {
+	if (!Message_waves[index].num.isValid()) {
 		fp = cfopen(Message_waves[index].name, "rb");
 		if (!fp)
 			return -1;
@@ -786,7 +786,7 @@ int message_play_training_voice(int index)
 			game_snd_entry tmp_gs;
 			strcpy_s(tmp_gs.filename, Message_waves[index].name);
 			Message_waves[index].num = snd_load(&tmp_gs, 0, 0);
-			if (Message_waves[index].num < 0) {
+			if (!Message_waves[index].num.isValid()) {
 				nprintf(("Warning", "Cannot load message wave: %s.  Will not play\n", Message_waves[index].name));
 				return -1;
 			}
@@ -803,7 +803,7 @@ int message_play_training_voice(int index)
 	}
 
 	Training_voice = index;
-	if (Message_waves[index].num >= 0)
+	if (Message_waves[index].num.isValid())
 		Training_voice_handle = snd_play_raw(Message_waves[index].num, 0.0f);
 	else
 		Training_voice_handle = -1;

--- a/code/network/multi_voice.cpp
+++ b/code/network/multi_voice.cpp
@@ -254,7 +254,7 @@ void multi_voice_client_send_pending();
 // initialize the multiplayer voice system
 void multi_voice_init()
 {
-	int idx,s_idx,pre_size,pre_sound;
+	int idx, s_idx, pre_size;
 
 	// if the voice system is already initialized, just reset some stuff
 	if(Multi_voice_inited){
@@ -319,8 +319,8 @@ void multi_voice_init()
 
 		// attempt to copy in the "pre" voice sound
 		auto gs = gamesnd_get_game_sound(MULTI_VOICE_PRE_SOUND);
-		pre_sound = snd_load(gamesnd_choose_entry(gs), gs->flags, 0);
-		if(pre_sound != -1){
+		auto pre_sound = snd_load(gamesnd_choose_entry(gs), gs->flags, 0);
+		if (pre_sound.isValid()) {
 			// get the pre-sound size
 			if((snd_size(pre_sound,&pre_size) != -1) && (pre_size < MULTI_VOICE_MAX_BUFFER_SIZE)){
 				snd_get_data(pre_sound,Multi_voice_playback_buffer);
@@ -1415,7 +1415,7 @@ int multi_voice_mix(gamesnd_id post_sound,char *data,int cur_size,int max_size)
 	// post sound
 	auto gs = gamesnd_get_game_sound(post_sound);
 	auto post_sound_handle = snd_load(gamesnd_choose_entry(gs), gs->flags, 0);
-	if(post_sound_handle >= 0){
+	if (post_sound_handle.isValid()) {
 		if(snd_size(post_sound_handle, &post_size) == -1){
 			post_size = 0;
 		}

--- a/code/scripting/api/libs/audio.cpp
+++ b/code/scripting/api/libs/audio.cpp
@@ -59,11 +59,11 @@ ADE_FUNC(loadSoundfile, l_Audio, "string filename", "Loads the specified sound f
 	char* fileName = NULL;
 
 	if (!ade_get_args(L, "s", &fileName))
-		return ade_set_error(L, "o", l_Soundfile.Set(-1));
+		return ade_set_error(L, "o", l_Soundfile.Set(sound_load_id::invalid()));
 
 	game_snd_entry tmp_gs;
 	strcpy_s( tmp_gs.filename, fileName );
-	int n = snd_load( &tmp_gs, 0, 0 );
+	auto n = snd_load(&tmp_gs, 0, 0);
 
 	return ade_set_error(L, "o", l_Soundfile.Set(n));
 }

--- a/code/scripting/api/objs/message.cpp
+++ b/code/scripting/api/objs/message.cpp
@@ -83,20 +83,19 @@ ADE_VIRTVAR(Message, l_Message, "string", "The unaltered text of the message, se
 ADE_VIRTVAR(VoiceFile, l_Message, "soundfile", "The voice file of the message", "soundfile", "The voice file handle or invalid handle when not present")
 {
 	int idx = -1;
-	int sndIdx = -1;
+	auto sndIdx = sound_load_id::invalid();
 
 	if (!ade_get_args(L, "o|o", l_Message.Get(&idx), l_Soundfile.Get(&sndIdx)))
-		return ade_set_error(L, "o", l_Soundfile.Set(-1));
+		return ade_set_error(L, "o", l_Soundfile.Set(sound_load_id::invalid()));
 
 	if (idx < 0 && idx >= (int) Messages.size())
-		return ade_set_error(L, "o", l_Soundfile.Set(-1));
+		return ade_set_error(L, "o", l_Soundfile.Set(sound_load_id::invalid()));
 
 	MissionMessage* msg = &Messages[idx];
 
 	if (ADE_SETTING_VAR)
 	{
-		if (sndIdx >= 0)
-		{
+		if (sndIdx.isValid()) {
 			const char* newFilename = snd_get_filename(sndIdx);
 
 			msg->wave_info.index = add_wave(newFilename);
@@ -109,7 +108,7 @@ ADE_VIRTVAR(VoiceFile, l_Message, "soundfile", "The voice file of the message", 
 
 	if (msg->wave_info.index < 0)
 	{
-		return ade_set_args(L, "o", l_Soundfile.Set(-1));
+		return ade_set_args(L, "o", l_Soundfile.Set(sound_load_id::invalid()));
 	}
 	else
 	{
@@ -127,10 +126,10 @@ ADE_VIRTVAR(Persona, l_Message, "persona", "The persona of the message", "person
 	int newPersona = -1;
 
 	if (!ade_get_args(L, "o|o", l_Message.Get(&idx), l_Persona.Get(&newPersona)))
-		return ade_set_error(L, "o", l_Soundfile.Set(-1));
+		return ade_set_error(L, "o", l_Soundfile.Set(sound_load_id::invalid()));
 
 	if (idx < 0 && idx >= (int) Messages.size())
-		return ade_set_error(L, "o", l_Soundfile.Set(-1));
+		return ade_set_error(L, "o", l_Soundfile.Set(sound_load_id::invalid()));
 
 	if (ADE_SETTING_VAR && newPersona >= 0 && newPersona < Num_personas)
 	{

--- a/code/scripting/api/objs/sound.cpp
+++ b/code/scripting/api/objs/sound.cpp
@@ -352,16 +352,16 @@ ADE_FUNC(updatePosition, l_Sound3D, "vector Position[, number radius = 0.0]", "U
 
 
 //**********HANDLE: Soundfile
-ADE_OBJ(l_Soundfile, int, "soundfile", "Handle to a sound file");
+ADE_OBJ(l_Soundfile, sound_load_id, "soundfile", "Handle to a sound file");
 
 ADE_VIRTVAR(Duration, l_Soundfile, "number", "The duration of the sound file, in seconds", "number", "The duration or -1 on error")
 {
-	int snd_idx = -1;
+	auto snd_idx = sound_load_id::invalid();
 
 	if (!ade_get_args(L, "o", l_Soundfile.Get(&snd_idx)))
 		return ade_set_error(L, "f", -1.0f);
 
-	if (snd_idx < 0)
+	if (!snd_idx.isValid())
 		return ade_set_error(L, "f", -1.0f);
 
 	int duration = snd_get_duration(snd_idx);
@@ -371,12 +371,12 @@ ADE_VIRTVAR(Duration, l_Soundfile, "number", "The duration of the sound file, in
 
 ADE_VIRTVAR(Filename, l_Soundfile, "string", "The filename of the file", "string", "The file name or empty string on error")
 {
-	int snd_idx = -1;
+	auto snd_idx = sound_load_id::invalid();
 
 	if (!ade_get_args(L, "o", l_Soundfile.Get(&snd_idx)))
 		return ade_set_error(L, "s", "");
 
-	if (snd_idx < 0)
+	if (!snd_idx.isValid())
 		return ade_set_error(L, "s", "");
 
 	const char* filename = snd_get_filename(snd_idx);
@@ -387,14 +387,14 @@ ADE_VIRTVAR(Filename, l_Soundfile, "string", "The filename of the file", "string
 
 ADE_FUNC(play, l_Soundfile, "[number volume = 1.0[, number panning = 0.0]]", "Plays the sound", "sound", "A sound handle or invalid handle on error")
 {
-	int snd_idx = -1;
+	auto snd_idx  = sound_load_id::invalid();
 	float volume = 1.0f;
 	float panning = 0.0f;
 
 	if (!ade_get_args(L, "o|ff", l_Soundfile.Get(&snd_idx)))
 		return ade_set_error(L, "o", l_Sound.Set(sound_h()));
 
-	if (snd_idx < 0)
+	if (!snd_idx.isValid())
 		return ade_set_error(L, "o", l_Sound.Set(sound_h()));
 
 	if (volume < 0.0f)
@@ -410,11 +410,12 @@ ADE_FUNC(play, l_Soundfile, "[number volume = 1.0[, number panning = 0.0]]", "Pl
 
 ADE_FUNC(isValid, l_Soundfile, NULL, "Checks if the soundfile handle is valid", "boolean", "true if valid, false otherwise")
 {
-	int idx = -1;
+	auto idx = sound_load_id::invalid();
+
 	if (!ade_get_args(L, "o", l_Soundfile.Get(&idx)))
 		return ADE_RETURN_FALSE;
 
-	return ade_set_args(L, "b", idx >= 0);
+	return ade_set_args(L, "b", idx.isValid());
 }
 
 

--- a/code/scripting/api/objs/sound.h
+++ b/code/scripting/api/objs/sound.h
@@ -48,8 +48,7 @@ DECLARE_ADE_OBJ(l_Sound3D, sound_h);
 
 
 //**********HANDLE: Soundfile
-DECLARE_ADE_OBJ(l_Soundfile, int);
-
+DECLARE_ADE_OBJ(l_Soundfile, sound_load_id);
 }
 }
 

--- a/code/ship/shipfx.cpp
+++ b/code/ship/shipfx.cpp
@@ -2079,9 +2079,9 @@ static float get_model_cross_section_at_z(float z, polymodel* pm)
 /**
  * Returns how long sound has been playing
  */
-static int get_sound_time_played(int snd_id, int handle)
+static int get_sound_time_played(sound_load_id snd_id, int handle)
 {
-	if (handle == -1 || snd_id == -1) {
+	if (handle == -1 || !snd_id.isValid()) {
 		return 100000;
 	}
 

--- a/code/sound/channel.h
+++ b/code/sound/channel.h
@@ -12,6 +12,7 @@
 #define __CHANNEL_H__
 
 #include "sound/openal.h"
+#include "sound/sound.h"
 
 typedef struct channel
 {

--- a/code/sound/ds.h
+++ b/code/sound/ds.h
@@ -14,6 +14,7 @@
 
 #include "globalincs/pstypes.h"
 #include "sound/ffmpeg/WaveFile.h"
+#include "sound/sound.h"
 
 // Constants that DirectSound should assign, but doesn't
 #define MIN_PITCH		100

--- a/code/sound/sound.h
+++ b/code/sound/sound.h
@@ -15,6 +15,7 @@
 #include "globalincs/pstypes.h"
 
 #include "utils/RandomRange.h"
+#include "utils/id.h"
 
 // Used for keeping track which low-level sound library is being used
 #define SOUND_LIB_DIRECTSOUND		0
@@ -58,10 +59,14 @@ extern const unsigned int SND_ENHANCED_MAX_LIMIT;
 #define AAV_VOICE		1
 #define AAV_EFFECTS		2
 
+struct sound_load_tag {
+};
+using sound_load_id = ::util::ID<sound_load_tag, int, -1>;
+
 struct game_snd_entry {
 	char filename[MAX_FILENAME_LEN];
-	int	id = -1;					//!< index into Sounds[], where sound data is stored
-	int	id_sig = -1;				//!< signature of Sounds[] element
+	sound_load_id id = sound_load_id::invalid(); //!< index into Sounds[], where sound data is stored
+	int id_sig       = -1;                       //!< signature of Sounds[] element
 
 	game_snd_entry();
 };
@@ -115,9 +120,9 @@ extern float aav_music_volume;
 extern float aav_effect_volume;
 
 //int	snd_load( char *filename, int hardware=0, int three_d=0, int *sig=NULL );
-int	snd_load( game_snd_entry *entry, int flags, int allow_hardware_load = 0);
+sound_load_id snd_load(game_snd_entry* entry, int flags, int allow_hardware_load = 0);
 
-int	snd_unload( int sndnum );
+int snd_unload(sound_load_id sndnum);
 void	snd_unload_all();
 
 // Plays a sound with volume between 0 and 1.0, where 0 is the
@@ -127,7 +132,7 @@ int snd_play( game_snd *gs, float pan=0.0f, float vol_scale=1.0f, int priority =
 
 // Play a sound directly from index returned from snd_load().  Bypasses
 // the sound management process of using game_snd.
-int snd_play_raw( int soundnum, float pan, float vol_scale=1.0f, int priority = SND_PRIORITY_MUST_PLAY );
+int snd_play_raw(sound_load_id soundnum, float pan, float vol_scale = 1.0f, int priority = SND_PRIORITY_MUST_PLAY);
 
 // Plays a sound with volume between 0 and 1.0, where 0 is the
 // inaudible and 1.0 is the loudest sound in the game.  It scales
@@ -168,10 +173,10 @@ int	snd_is_playing( int snd_handle );
 void	snd_chg_loop_status(int snd_handle, int loop);
 
 // return the time in ms for the duration of the sound
-int snd_get_duration(int snd_id);
+int snd_get_duration(sound_load_id snd_id);
 
 // Get the file name of the specified sound
-const char *snd_get_filename(int snd_id);
+const char* snd_get_filename(sound_load_id snd_id);
 
 // get a 3D vol and pan for a particular sound
 int	snd_get_3d_vol_and_pan(game_snd *gs, vec3d *pos, float* vol, float *pan, float radius=0.0f, float range_factor=1.0f);
@@ -188,8 +193,8 @@ void 	snd_use_lib(int lib_id);
 
 int snd_num_playing();
 
-int snd_get_data(int handle, char *data);
-int snd_size(int handle, int *size);
+int snd_get_data(sound_load_id handle, char* data);
+int snd_size(sound_load_id handle, int* size);
 void snd_do_frame();
 void snd_adjust_audio_volume(int type, float percent, int time);
 
@@ -198,15 +203,15 @@ void snd_rewind(int snd_handle, float seconds);					// rewind N seconds from the
 void snd_ffwd(int snd_handle, float seconds);						// fast forward N seconds from the current position
 void snd_set_pos(int snd_handle, float val,int as_pct);		// set the position val as either a percentage (if as_pct) or as a # of seconds into the sound
 
-void snd_get_format(int handle, int *bits_per_sample, int *frequency);
+void snd_get_format(sound_load_id handle, int* bits_per_sample, int* frequency);
 int snd_time_remaining(int handle);
 
 /**
  * @brief Get the sound id that was used to start the sound with the specified handle
  * @param snd_handle The sound handle to query the id from
- * @return The loaded sound handle or -1 on error
+ * @return The loaded sound handle or invalid handle on error
  */
-int snd_get_sound_id(int snd_handle);
+sound_load_id snd_get_sound_id(int snd_handle);
 
 // sound environment
 extern unsigned int SND_ENV_DEFAULT;


### PR DESCRIPTION
This converts the previous int handles to a strongly-typed wrapper
handle which will make the API more self-documenting and will ensure
that wrongly used handles are detected at compile time.

I already found a few mistakes with these changes which I also fixed
here.