### PR TITLE
Add more generic scripting callback system

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -17,7 +17,7 @@ AllowShortLoopsOnASingleLine: false
 AlwaysBreakAfterDefinitionReturnType: None
 AlwaysBreakAfterReturnType: None
 AlwaysBreakBeforeMultilineStrings: false
-AlwaysBreakTemplateDeclarations: false
+AlwaysBreakTemplateDeclarations: true
 BinPackArguments: true
 BinPackParameters: true
 BraceWrapping:   

--- a/code/object/object.cpp
+++ b/code/object/object.cpp
@@ -149,6 +149,9 @@ void object::clear()
 	objsnd_num.clear();
 	net_signature = 0;
 
+	pre_move_event.clear();
+	post_move_event.clear();
+
 	// just in case nobody called obj_delete last mission
 	dock_free_dock_list(this);
 	dock_free_dead_dock_list(this);
@@ -513,6 +516,7 @@ int obj_create(ubyte type,int parent_obj,int instance, matrix * orient,
 
 	obj->n_quadrants = DEFAULT_SHIELD_SECTIONS; // Might be changed by the ship creation code
 	obj->shield_quadrant.resize(obj->n_quadrants);
+
 	return objnum;
 }
 
@@ -1165,8 +1169,10 @@ void obj_move_all_pre(object *objp, float frametime)
 		Int3();
 		break;
 	default:
-		Error( LOCATION, "Unhandled object type %d in obj_move_one\n", objp->type );
-	}	
+		Error(LOCATION, "Unhandled object type %d in obj_move_all_pre\n", objp->type);
+	}
+
+	objp->pre_move_event(objp);
 }
 
 // Used to tell if a particular group of lasers has cast light yet.
@@ -1396,8 +1402,10 @@ void obj_move_all_post(object *objp, float frametime)
 			break;
 
 		default:
-			Error( LOCATION, "Unhandled object type %d in obj_move_one\n", objp->type );
-	}	
+		    Error(LOCATION, "Unhandled object type %d in obj_move_all_post\n", objp->type);
+	    }
+
+	    objp->post_move_event(objp);
 }
 
 

--- a/code/object/object.h
+++ b/code/object/object.h
@@ -15,8 +15,9 @@
 #include "globalincs/globals.h"
 #include "globalincs/pstypes.h"
 #include "math/vecmat.h"
-#include "physics/physics.h"
 #include "object/object_flags.h"
+#include "physics/physics.h"
+#include "utils/event.h"
 
 #include <functional>
 
@@ -144,6 +145,9 @@ public:
 
 	int				collision_group_id; // This is a bitfield. Collision checks will be skipped if A->collision_group_id & B->collision_group_id returns nonzero
 
+	util::event<void, object*> pre_move_event;
+	util::event<void, object*> post_move_event;
+
 	object();
 	~object();
 	void clear();
@@ -236,9 +240,6 @@ void obj_render_all(const std::function<void(object*)>& render_function, bool* r
 
 //move all objects for the current frame
 void obj_move_all(float frametime);		// moves all objects
-
-//move an object for the current frame
-void obj_move_one(object * obj, float frametime);
 
 // function to delete an object -- should probably only be called directly from editor code
 void obj_delete(int objnum);

--- a/code/scripting/ade.cpp
+++ b/code/scripting/ade.cpp
@@ -5,13 +5,14 @@
 #include "ship/ship.h"
 #include "ade_api.h"
 
+#include "ade.h"
+#include "scripting/api/objs/asteroid.h"
+#include "scripting/api/objs/beam.h"
+#include "scripting/api/objs/debris.h"
 #include "scripting/api/objs/object.h"
 #include "scripting/api/objs/ship.h"
-#include "scripting/api/objs/asteroid.h"
-#include "scripting/api/objs/debris.h"
 #include "scripting/api/objs/waypoint.h"
 #include "scripting/api/objs/weapon.h"
-#include "scripting/api/objs/beam.h"
 
 namespace {
 using namespace scripting;
@@ -977,26 +978,26 @@ int ade_set_object_with_breed(lua_State *L, int obj_idx)
 	using namespace scripting::api;
 
 	if(obj_idx < 0 || obj_idx >= MAX_OBJECTS)
-		return ade_set_error(L, "o", l_Object.Set(object_h()));
+		return ade_set_args(L, "o", l_Object.Set(object_h()));
 
 	object *objp = &Objects[obj_idx];
 
 	switch(objp->type)
 	{
-		case OBJ_SHIP:
-			return ade_set_args(L, "o", l_Ship.Set(object_h(objp)));
-		case OBJ_ASTEROID:
-			return ade_set_args(L, "o", l_Asteroid.Set(object_h(objp)));
-		case OBJ_DEBRIS:
-			return ade_set_args(L, "o", l_Debris.Set(object_h(objp)));
-		case OBJ_WAYPOINT:
-			return ade_set_args(L, "o", l_Waypoint.Set(object_h(objp)));
-		case OBJ_WEAPON:
-			return ade_set_args(L, "o", l_Weapon.Set(object_h(objp)));
-		case OBJ_BEAM:
-			return ade_set_args(L, "o", l_Beam.Set(object_h(objp)));
-		default:
-			return ade_set_args(L, "o", l_Object.Set(object_h(objp)));
+	case OBJ_SHIP:
+		return ade_set_args(L, "o", l_Ship.Set(object_h(objp)));
+	case OBJ_ASTEROID:
+		return ade_set_args(L, "o", l_Asteroid.Set(object_h(objp)));
+	case OBJ_DEBRIS:
+		return ade_set_args(L, "o", l_Debris.Set(object_h(objp)));
+	case OBJ_WAYPOINT:
+		return ade_set_args(L, "o", l_Waypoint.Set(object_h(objp)));
+	case OBJ_WEAPON:
+		return ade_set_args(L, "o", l_Weapon.Set(object_h(objp)));
+	case OBJ_BEAM:
+		return ade_set_args(L, "o", l_Beam.Set(object_h(objp)));
+	default:
+		return ade_set_args(L, "o", l_Object.Set(object_h(objp)));
 	}
 }
 

--- a/code/scripting/api/LuaEventCallback.cpp
+++ b/code/scripting/api/LuaEventCallback.cpp
@@ -1,0 +1,24 @@
+//
+//
+
+#include "LuaEventCallback.h"
+#include "scripting/lua/LuaConvert.h"
+
+using namespace luacpp;
+
+namespace scripting {
+namespace api {
+namespace util {
+
+void convert_arg(lua_State* L, luacpp::LuaValueList& out, object* objp)
+{
+	LuaValue val;
+	ade_set_object_with_breed(L, OBJ_INDEX(objp));
+	convert::popValue(L, val);
+
+	out.push_back(val);
+}
+
+} // namespace util
+} // namespace api
+} // namespace scripting

--- a/code/scripting/api/LuaEventCallback.h
+++ b/code/scripting/api/LuaEventCallback.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include "object/object.h"
+#include "scripting/lua/LuaFunction.h"
+
+namespace scripting {
+namespace api {
+namespace util {
+
+void convert_arg(lua_State* L, luacpp::LuaValueList& out, object* objp);
+}
+
+template <typename Ret, typename... Args>
+class LuaEventCallback {
+	luacpp::LuaFunction _func;
+
+	void convert_args(lua_State* /*L*/, luacpp::LuaValueList& /*out*/) {}
+
+	template <typename T, typename... A>
+	void convert_args(lua_State* L, luacpp::LuaValueList& out, T t, A... args)
+	{
+		util::convert_arg(L, out, t);
+
+		convert_args(L, out, args...);
+	}
+
+  public:
+	explicit LuaEventCallback(const luacpp::LuaFunction& func) : _func(func) {}
+
+	void operator()(Args... args)
+	{
+		using namespace luacpp;
+
+		LuaValueList lua_args;
+		convert_args(_func.getLuaState(), lua_args, args...);
+
+		_func(lua_args);
+	}
+};
+
+template <typename Ret, typename... Args>
+std::function<Ret(Args...)> make_lua_callback(const luacpp::LuaFunction& func)
+{
+	return std::function<Ret(Args...)>(LuaEventCallback<Ret, Args...>(func));
+}
+
+} // namespace api
+} // namespace scripting

--- a/code/source_groups.cmake
+++ b/code/source_groups.cmake
@@ -982,6 +982,11 @@ set(file_root_scripting
 	scripting/scripting.h
 )
 
+set(file_root_scripting_api
+	scripting/api/LuaEventCallback.cpp
+	scripting/api/LuaEventCallback.h
+)
+
 set(file_root_scripting_api_libs
 	scripting/api/libs/audio.cpp
 	scripting/api/libs/audio.h
@@ -1240,6 +1245,7 @@ set (file_root_ui
 set(file_root_utils
 	utils/encoding.cpp
     utils/encoding.h
+    utils/event.h
 	utils/HeapAllocator.cpp
 	utils/HeapAllocator.h
 	utils/id.h
@@ -1373,6 +1379,7 @@ source_group("Popup"                              FILES ${file_root_popup})
 source_group("Radar"                              FILES ${file_root_radar})
 source_group("Render"                             FILES ${file_root_render})
 source_group("Scripting"                          FILES ${file_root_scripting})
+source_group("Scripting\\Api"                     FILES ${file_root_scripting_api})
 source_group("Scripting\\Api\\Libs"               FILES ${file_root_scripting_api_libs})
 source_group("Scripting\\Api\\Objs"               FILES ${file_root_scripting_api_objs})
 source_group("Scripting\\Lua"                     FILES ${file_root_scripting_lua})
@@ -1474,6 +1481,7 @@ set (file_root
 	${file_root_radar}
 	${file_root_render}
 	${file_root_scripting}
+	${file_root_scripting_api}
 	${file_root_scripting_api_libs}
 	${file_root_scripting_api_objs}
 	${file_root_scripting_lua}

--- a/code/utils/event.h
+++ b/code/utils/event.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include "globalincs/pstypes.h"
+
+#include <functional>
+
+namespace util {
+
+template <typename Ret, typename... Args>
+class event final {
+  public:
+	using callback_type = std::function<Ret(Args...)>;
+
+	event()  = default;
+	~event() = default;
+
+	void add(callback_type func) { _listeners.push_back(func); }
+
+	void clear() { _listeners.clear(); }
+
+	// This variant is used if the listeners return no values
+	template <typename Dummy = void>
+	inline typename std::enable_if<std::is_same<Ret, void>::value, Dummy>::type operator()(Args... args) const
+	{
+		for (const auto& l : _listeners) {
+			l(args...);
+		}
+	}
+
+	// In this case we collect the return values and return them to the caller
+	template <typename Dummy = SCP_vector<Ret>>
+	inline typename std::enable_if<!std::is_same<Ret, void>::value, Dummy>::type operator()(Args... args) const
+	{
+		SCP_vector<Ret> vals;
+
+		for (const auto& l : _listeners) {
+			vals.push_back(l(args...));
+		}
+
+		return vals;
+	}
+
+  private:
+	SCP_vector<callback_type> _listeners;
+};
+
+} // namespace util


### PR DESCRIPTION
The current scripting hook is pretty simple and straight forward but it
makes a couple of scripting applications harder to implement than
needed.

For example, a lot of scripts need to do some work every frame
for all or some objects. The script needs to manage an internal list of
all the objects that are affected by that list which includes removing
invalid objects to conserve resources. This effectively mirrors what the
engine already does and adds unnecessary overhead.

In these changes I added a generic event system which can be used by any
part of the code for providing callbacks when a specific event occurs.
As an example, I added hooks for the pre- and post-move events to the
object class which are called before and after physics are applied to an
object.

I integrated that feature into the scripting system so now a script can
simply register a function as a callback which will be called whenever
the target event is executed.