### PR TITLE
Stop accessing Ships[] array with an objnum.

### DIFF
--- a/code/scripting/api/objs/ship.cpp
+++ b/code/scripting/api/objs/ship.cpp
@@ -632,7 +632,7 @@ ADE_VIRTVAR(TargetSubsystem, l_Ship, "subsystem", "Target subsystem of ship.", "
 				if (aip->target_signature != newh->sig)
 					hud_shield_hit_reset(newh->objp);
 
-				Ships[newh->ss->parent_objnum].last_targeted_subobject[Player_num] = newh->ss;
+				Ships[Objects[newh->ss->parent_objnum].instance].last_targeted_subobject[Player_num] = newh->ss;
 			}
 
 			aip->target_objnum = OBJ_INDEX(newh->objp);


### PR DESCRIPTION
Lua's `Ship.TargetSubsystem` VIRTVAR, when set, would write to an attribute of the `Ships[]` array based on an objnum instead of a ship instance index. Since `MAX_OBJECTS` is drastically higher than `MAX_SHIPS`, then depending on how many objects happen to be in the mission, an out-of-bounds array access can be easily generated. This commit makes sure to use the objnum instead as an index to the `Objects[]` array, and then retrieve the ship instance from it.