### PR TITLE
Remove hack for On Frame scripting hook and quit mission popup

### DIFF
--- a/code/graphics/2d.cpp
+++ b/code/graphics/2d.cpp
@@ -19,17 +19,17 @@
 
 #include "cmdline/cmdline.h"
 #include "debugconsole/console.h"
-#include "gamesequence/gamesequence.h"	//WMC - for scripting hooks in gr_flip()
+#include "gamesequence/gamesequence.h" //WMC - for scripting hooks in gr_flip()
 #include "globalincs/systemvars.h"
 #include "graphics/2d.h"
-#include "graphics/matrix.h"
-#include "graphics/light.h"
 #include "graphics/font.h"
 #include "graphics/grbatch.h"
 #include "graphics/grinternal.h"
+#include "graphics/grstub.h"
+#include "graphics/light.h"
+#include "graphics/matrix.h"
 #include "graphics/opengl/gropengl.h"
 #include "graphics/opengl/gropengldraw.h"
-#include "graphics/grstub.h"
 #include "graphics/paths/PathRenderer.h"
 #include "graphics/util/GPUMemoryHeap.h"
 #include "graphics/util/UniformBuffer.h"
@@ -37,9 +37,10 @@
 #include "io/keycontrol.h" // m!m
 #include "io/timer.h"
 #include "osapi/osapi.h"
-#include "scripting/scripting.h"
 #include "parse/parselo.h"
+#include "popup/popup.h"
 #include "render/3d.h"
+#include "scripting/scripting.h"
 #include "tracing/tracing.h"
 #include "utils/boost/hash_combine.h"
 
@@ -2152,8 +2153,7 @@ void gr_set_bitmap(int bitmap_num, int alphablend_mode, int bitblt_mode, float a
 void gr_flip(bool execute_scripting)
 {
 	// m!m avoid running CHA_ONFRAME when the "Quit mission" popup is shown. See mantis 2446 for reference
-	if (execute_scripting && !quit_mission_popup_shown)
-	{
+	if (execute_scripting && !popup_active()) {
 		TRACE_SCOPE(tracing::LuaOnFrame);
 
 		//WMC - Do conditional hooks. Yippee!

--- a/code/io/keycontrol.cpp
+++ b/code/io/keycontrol.cpp
@@ -211,7 +211,6 @@ static struct Cheat cheatsTable[] = {
 
 int Tool_enabled = 0;
 bool Perspective_locked=false;
-bool quit_mission_popup_shown = false;
 
 extern int AI_watch_object;
 extern int Countermeasures_enabled;
@@ -1442,8 +1441,6 @@ void game_do_end_mission_popup()
 		game_stop_looped_sounds();
 		snd_stop_all();
 
-		quit_mission_popup_shown = true;
-
 		pf_flags = PF_BODY_BIG | PF_USE_AFFIRMATIVE_ICON | PF_USE_NEGATIVE_ICON;
 		choice = popup(pf_flags, 3, POPUP_NO, XSTR( "&Yes, Quit", 28), XSTR( "Yes, &Restart", 29), XSTR( "Do you really want to end the mission?", 30));
 
@@ -1459,7 +1456,6 @@ void game_do_end_mission_popup()
 		default:
 			break;  // do nothing
 		}
-		quit_mission_popup_shown = false;
 
 		game_start_time();
 		game_flush();

--- a/code/io/keycontrol.h
+++ b/code/io/keycontrol.h
@@ -23,8 +23,6 @@ extern bool Perspective_locked;
 
 extern int Ignored_keys[];
 
-extern bool quit_mission_popup_shown;
-
 typedef struct button_info
 {
 	int status[NUM_BUTTON_FIELDS];


### PR DESCRIPTION
I added this hack a long time ago and it always bothered me why I didn't
come up with a better solution. This is the better solution which uses
the popup_active function for determining if gr_flip is called within a
popup.