### PR TITLE
Lua's createShip() function now checks for a valid ship class.

### DIFF
--- a/code/scripting/api/libs/mission.cpp
+++ b/code/scripting/api/libs/mission.cpp
@@ -807,6 +807,10 @@ ADE_FUNC(createShip, l_Mission, "[string Name, shipclass Class=Shipclass[1], ori
 		real_orient = orient->GetMatrix();
 	}
 
+	if (sclass == -1) {
+		return ade_set_error(L, "o", l_Ship.Set(object_h()));
+	}
+
 	int obj_idx = ship_create(real_orient, &pos, sclass, name);
 
 	if(obj_idx > -1) {

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -9359,7 +9359,7 @@ int ship_create(matrix *orient, vec3d *pos, int ship_type, char *ship_name)
 		return -1;
 	}
 
-	Assert((ship_type >= 0) && (ship_type < static_cast<int>(Ship_info.size())));
+	Assertion((ship_type >= 0) && (ship_type < static_cast<int>(Ship_info.size())), "Invalid ship_type %d passed to ship_create() (expected value in the range 0-%d)\n", ship_type, static_cast<int>(Ship_info.size())-1);
 	sip = &(Ship_info[ship_type]);
 	shipp = &Ships[n];
 	shipp->clear();


### PR DESCRIPTION
Ideally it wouldn't be an optional argument at all, but that would break backwards-compatibility, so instead it'll just return an invalid ship handle instead of calling `ship_create()` with a class of `-1`. In addition, the `Assert` from `ship_create()` meant to guard against invalid `ship_type` values is now an `Assertion` that actually says what the invalid value of `ship_type` was, to make future debugging easier.