### PR TITLE
Make parse_weapon_targeting_priorities() work when weapon missing.

### DIFF
--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -18364,7 +18364,7 @@ void parse_weapon_targeting_priorities()
 			}
 		}
 		if(k == MAX_WEAPON_TYPES) {
-			Warning(LOCATION, "Unrecognized weapon '%s' found when setting weapon targeting priorities.\n", tempname);
+			error_display(0, "Unrecognized weapon '%s' found when setting weapon targeting priorities.\n", tempname);
 			if (optional_string("+Target Priority:")) {		// consume the data to avoid parsing errors
 				SCP_vector<SCP_string> dummy;
 				stuff_string_list(dummy);
@@ -18383,7 +18383,7 @@ void parse_weapon_targeting_priorities()
 				if (num_strings > 32)
 					num_strings = 32;
 
-				int num_groups = (int)Ai_tp_list.size();
+				auto num_groups = static_cast<int>(Ai_tp_list.size());
 
 				for(i = 0; i < num_strings; i++) {
 					for(j = 0; j < num_groups; j++) {
@@ -18394,7 +18394,7 @@ void parse_weapon_targeting_priorities()
 						}
 					}
 					if(j == num_groups)
-						Warning(LOCATION, "Unrecognized string '%s' found when setting weapon targeting priorities.\n", tgt_priorities[i].c_str());
+						error_display(0, "Unrecognized string '%s' found when setting weapon targeting priorities.\n", tgt_priorities[i].c_str());
 				}
 			}
 		}

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -18359,39 +18359,45 @@ void parse_weapon_targeting_priorities()
 		for(k = 0; k < MAX_WEAPON_TYPES ; k++) {
 			if ( !stricmp(Weapon_info[k].name, tempname) ) {
 				// found weapon, yay!
-				// reset the list
-
-				weapon_info *wip = &Weapon_info[k];
-				
-				wip->num_targeting_priorities = 0;
-
-				if (optional_string("+Target Priority:")) {
-					SCP_vector <SCP_string> tgt_priorities;
-					int num_strings = stuff_string_list(tgt_priorities);
-
-					if (num_strings > 32)
-						num_strings = 32;
-
-					int num_groups = (int)Ai_tp_list.size();
-
-					for(i = 0; i < num_strings; i++) {
-						for(j = 0; j < num_groups; j++) {
-							if ( !stricmp(Ai_tp_list[j].name, tgt_priorities[i].c_str()))  {
-								wip->targeting_priorities[i] = j;
-								wip->num_targeting_priorities++;
-								break;
-							}
-						}
-						if(j == num_groups)
-							Warning(LOCATION, "Unrecognized string '%s' found when setting weapon targeting priorities.\n", tgt_priorities[i].c_str());
-					}
-				}
 				// no need to keep searching for more
 				break;
 			}
 		}
-		if(k == MAX_WEAPON_TYPES)
+		if(k == MAX_WEAPON_TYPES) {
 			Warning(LOCATION, "Unrecognized weapon '%s' found when setting weapon targeting priorities.\n", tempname);
+			if (optional_string("+Target Priority:")) {		// consume the data to avoid parsing errors
+				SCP_vector<SCP_string> dummy;
+				stuff_string_list(dummy);
+			}
+		} else {
+			// reset the list
+
+			weapon_info *wip = &Weapon_info[k];
+			
+			wip->num_targeting_priorities = 0;
+
+			if (optional_string("+Target Priority:")) {
+				SCP_vector <SCP_string> tgt_priorities;
+				int num_strings = stuff_string_list(tgt_priorities);
+
+				if (num_strings > 32)
+					num_strings = 32;
+
+				int num_groups = (int)Ai_tp_list.size();
+
+				for(i = 0; i < num_strings; i++) {
+					for(j = 0; j < num_groups; j++) {
+						if ( !stricmp(Ai_tp_list[j].name, tgt_priorities[i].c_str()))  {
+							wip->targeting_priorities[i] = j;
+							wip->num_targeting_priorities++;
+							break;
+						}
+					}
+					if(j == num_groups)
+						Warning(LOCATION, "Unrecognized string '%s' found when setting weapon targeting priorities.\n", tgt_priorities[i].c_str());
+				}
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
Previously, if `parse_weapon_targeting_priorities()` couldn't find a weapon matching the name, it wouldn't parse the "+Target Priority:" line, so it would cause a parsing error when the parser failed to find "$Name:" or "#End" there. Now, the "match not found" codepath still parses it so that no mismatch occurs. Also, I reordered the function so that the parsing wasn't happening in the middle of a loop through the list of weapon types, because it made me cringe.