### PR TITLE
Fix bounds check and string->int conversion in lua ship classes API

### DIFF
--- a/code/scripting/api/libs/tables.cpp
+++ b/code/scripting/api/libs/tables.cpp
@@ -35,11 +35,17 @@ ADE_INDEXER(l_Tables_ShipClasses, "number Index/string Name", "Array of ship cla
 	int idx = ship_info_lookup(name);
 
 	if(idx < 0) {
-		idx = atoi(name);
-		if(idx < 1 || idx >= static_cast<int>(Ship_info.size()))
+		try {
+			idx = std::stoi(name);
+			idx--; // Lua->FS2
+		} catch (const std::exception&) {
+			// Not a number
 			return ade_set_error(L, "o", l_Shipclass.Set(-1));
+		}
 
-		idx--;	//Lua->FS2
+		if (idx < 0 || idx >= static_cast<int>(Ship_info.size())) {
+			return ade_set_error(L, "o", l_Shipclass.Set(-1));
+		}
 	}
 
 	return ade_set_args(L, "o", l_Shipclass.Set(idx));


### PR DESCRIPTION
The bounds check was not correct for 1-based indices. I moved the
Lua->C++ index conversion before the bounds check so that it makes
more sense.
Also, atoi isn't a reliable way for converting a string to an integer.