### PR TITLE
Don't make invalid data in campaign file fatal

### DIFF
--- a/code/pilotfile/csg.cpp
+++ b/code/pilotfile/csg.cpp
@@ -145,7 +145,8 @@ void pilotfile::csg_read_info()
 			if (ship_list[idx].index >= 0) {
 				Campaign.ships_allowed[ship_list[idx].index] = 1;
 			} else {
-				m_data_invalid = true;
+				mprintf(
+				    ("Found invalid ship \"%s\" in campaign save file. Skipping...\n", ship_list[idx].name.c_str()));
 			}
 		}
 	}
@@ -159,7 +160,8 @@ void pilotfile::csg_read_info()
 			if (weapon_list[idx].index >= 0) {
 				Campaign.weapons_allowed[weapon_list[idx].index] = 1;
 			} else {
-				m_data_invalid = true;
+				mprintf(("Found invalid weapon \"%s\" in campaign save file. Skipping...\n",
+				         weapon_list[idx].name.c_str()));
 			}
 		}
 	}
@@ -433,7 +435,9 @@ void pilotfile::csg_read_techroom()
 			if (ship_list[idx].index >= 0) {
 				Ship_info[ship_list[idx].index].flags.set(Ship::Info_Flags::In_tech_database);
 			} else {
-				m_data_invalid = true;
+				mprintf(("Found invalid ship \"%s\" in campaign save file. "
+				         "Skipping...\n",
+				         ship_list[idx].name.c_str()));
 			}
 		}
 	}
@@ -447,7 +451,8 @@ void pilotfile::csg_read_techroom()
 			if (weapon_list[idx].index >= 0) {
                 Weapon_info[weapon_list[idx].index].wi_flags.set(Weapon::Info_Flags::In_tech_database);
 			} else {
-				m_data_invalid = true;
+				mprintf(("Found invalid weapon \"%s\" in campaign save file. Skipping...\n",
+				         weapon_list[idx].name.c_str()));
 			}
 		}
 	}
@@ -461,7 +466,8 @@ void pilotfile::csg_read_techroom()
 			if (intel_list[idx].index >= 0) {
 				Intel_info[intel_list[idx].index].flags |= IIF_IN_TECH_DATABASE;
 			} else {
-				m_data_invalid = true;
+				mprintf(("Found invalid intel entry \"%s\" in campaign save file. Skipping...\n",
+				         intel_list[idx].name.c_str()));
 			}
 		}
 	}


### PR DESCRIPTION
The previous code simply set a boolean flag to indicate that the data is
"invalid" which failed the campaign loading operation. With these
changes, those entries will simply be skipped. That can happen if a mod
added or removed a ship or weapon class or if two campaigns share the
same campaign name.