### PR TITLE
Fix inverted validity check in snd_time_remaining().

### DIFF
--- a/code/sound/sound.cpp
+++ b/code/sound/sound.cpp
@@ -1293,7 +1293,7 @@ int snd_time_remaining(int handle)
 
 	auto sdx = snd_get_sound_id(handle);
 
-	if (sdx.isValid()) {
+	if (!sdx.isValid()) {
 		Int3();
 		return 0;
 	}


### PR DESCRIPTION
Overlooked mistake from PR #1777.

The issue was reported by @plieblang and the incorrect conditional was spotted by @ngld.