### PR TITLE
Shockwaves caused by weapons respect big ship flags while calculating damage

### DIFF
--- a/code/ship/shiphit.cpp
+++ b/code/ship/shiphit.cpp
@@ -1842,6 +1842,8 @@ static int maybe_shockwave_damage_adjust(object *ship_objp, object *other_obj, f
 {
 	ship_subsys *subsys;
 	ship *shipp;
+	weapon_info *wip;
+	ship_info *sip;
 	float dist, nearest_dist = FLT_MAX;
 	vec3d g_subobj_pos;
 	float max_damage;
@@ -1860,11 +1862,12 @@ static int maybe_shockwave_damage_adjust(object *ship_objp, object *other_obj, f
 		return 0;
 	}
 
-	if (!(Ship_info[Ships[ship_objp->instance].ship_info_index].is_huge_ship())) {
+	shipp = &Ships[ship_objp->instance];
+	sip = &Ship_info[shipp->ship_info_index];
+
+	if (!sip->is_huge_ship()) {
 		return 0;
 	}
-
-	shipp = &Ships[ship_objp->instance];
 
 	// find closest subsystem distance to shockwave origin
 	for (subsys=GET_FIRST(&shipp->subsys_list); subsys != END_OF_LIST(&shipp->subsys_list); subsys = GET_NEXT(subsys) ) {
@@ -1880,6 +1883,39 @@ static int maybe_shockwave_damage_adjust(object *ship_objp, object *other_obj, f
 	max_damage = shockwave_get_damage(other_obj->instance);
 	if (shockwave_get_flags(other_obj->instance) & SW_WEAPON_KILL) {
 		max_damage *= 4.0f;
+	}
+
+	// If the shockwave was caused by a weapon, then check if the weapon can deal lethal damage to the ship.
+	// If it cannot, then neither should the shockwave caused by the weapon be able to do the same.
+	// The code for this is copied from part of weapon_get_damage_scale.
+	int wp_index = shockwave_get_weapon_index(other_obj->instance);
+	if (wp_index >= 0) {
+		wip = &Weapon_info[wp_index];
+
+		float hull_pct = get_hull_pct(ship_objp);
+
+		// First handle Supercap ships.
+		if ((sip->flags[Ship::Info_Flags::Supercap]) && !(wip->wi_flags[Weapon::Info_Flags::Supercap])) {
+			if (hull_pct <= 0.75f) {
+				*damage = 0.0f;
+				return 1;
+			} else {
+				// If hull isn't below 3/4, then allow damage to be applied just like in weapon_get_damage_scale.
+				// Magic constant is SUPERCAP_DAMAGE_SCALE from weapons.cpp.
+				max_damage *= 0.25f;
+			}
+		}
+
+		// Next handle big damage ships.
+		bool is_big_damage_ship = (sip->flags[Ship::Info_Flags::Big_damage]);
+		if (is_big_damage_ship && !(wip->hurts_big_ships())) {
+			if (hull_pct > 0.1f) {
+				max_damage *= hull_pct;
+			} else {
+				*damage = 0.0f;
+				return 1;
+			}
+		}
 	}
 
 	outer_radius = shockwave_get_max_radius(other_obj->instance);


### PR DESCRIPTION
Shockwaves caused by weapons will no longer deal lethal damage if the weapon that caused the shockwave isn't flagged as being able to deal lethal damage to the ship in question. This is accomplished in the same way it is accomplished in weapon_get_damage_scale from weapons.cpp; if the ship's hull drops below a certain threshold (75% for supercap ships, 10% for all other big damage ships), the maybe_shockwave_damage_adjust function sets the damage that should be applied to zero. There is also some damage scaling that goes on that mirrors the damage scaling done in weapon_get_damage_scale.

For instance this means it's no longer possible to kill a Sathanas with helios torpedoes. It is also impossible to kill smaller ships with the big damage flag (such as corvettes) with smaller missiles that happen to cause shockwaves but aren't bombs (such as the EMP Adv.). Before this was supposed to be impossible, but in reality just took a really long time.

These changes do not affect shockwaves that aren't caused by weapons (such as ship explosions). So kamikaze ships that cause shockwaves and meson bomb explosions will still work as they did before.