### PR TITLE
Add support for movies with RGB(A) pixel format

### DIFF
--- a/code/cfile/cfile.cpp
+++ b/code/cfile/cfile.cpp
@@ -67,7 +67,7 @@ cf_pathtype Pathtypes[CF_MAX_PATH_TYPES]  = {
 	{ CF_TYPE_VOICE_SPECIAL,		"data" DIR_SEPARATOR_STR "voice" DIR_SEPARATOR_STR "special",				".wav .ogg",						CF_TYPE_VOICE	},
 	{ CF_TYPE_VOICE_TRAINING,		"data" DIR_SEPARATOR_STR "voice" DIR_SEPARATOR_STR "training",				".wav .ogg",						CF_TYPE_VOICE	},
 	{ CF_TYPE_MUSIC,				"data" DIR_SEPARATOR_STR "music",											".wav .ogg",						CF_TYPE_DATA	},
-	{ CF_TYPE_MOVIES,				"data" DIR_SEPARATOR_STR "movies",											".mve .msb .ogg .mp4 .srt",			CF_TYPE_DATA	},
+	{ CF_TYPE_MOVIES,				"data" DIR_SEPARATOR_STR "movies",											".mve .msb .ogg .mp4 .srt .webm .png",CF_TYPE_DATA	},
 	{ CF_TYPE_INTERFACE,			"data" DIR_SEPARATOR_STR "interface",										".pcx .ani .dds .tga .eff .png .jpg",	CF_TYPE_DATA	},
 	{ CF_TYPE_FONT,					"data" DIR_SEPARATOR_STR "fonts",											".vf .ttf",							CF_TYPE_DATA	},
 	{ CF_TYPE_EFFECTS,				"data" DIR_SEPARATOR_STR "effects",											".ani .eff .pcx .neb .tga .jpg .png .dds .sdr",	CF_TYPE_DATA	},

--- a/code/cutscene/Decoder.cpp
+++ b/code/cutscene/Decoder.cpp
@@ -3,6 +3,12 @@
 #include <memory>
 
 namespace cutscene {
+FrameSize::FrameSize(size_t in_width, size_t in_height, size_t in_stride)
+    : width(in_width), height(in_height), stride(in_stride)
+{
+}
+FrameSize::FrameSize() = default;
+
 Decoder::Decoder() : m_decoding(true) {
 }
 

--- a/code/cutscene/Decoder.h
+++ b/code/cutscene/Decoder.h
@@ -10,28 +10,26 @@ struct FrameSize {
 	size_t width = 0;
 	size_t height = 0;
 	size_t stride = 0;
+
+	FrameSize(size_t width, size_t in_height, size_t in_stride);
+	FrameSize();
 };
 
 class VideoFrame {
  protected:
-	VideoFrame() {}
+	VideoFrame() = default;
 
- public:
-	virtual ~VideoFrame() {}
+  public:
+	virtual ~VideoFrame() = default;
 
 	double frameTime = -1.0;
 	int id = -1;
 
-	FrameSize ySize;
-	FrameSize uvSize;
+	virtual size_t getPlaneNumber() = 0;
 
-	struct DataPointers {
-		ubyte* y;
-		ubyte* u;
-		ubyte* v;
-	};
+	virtual FrameSize getPlaneSize(size_t plane) = 0;
 
-	virtual DataPointers getDataPointers() = 0;
+	virtual void* getPlaneData(size_t plane) = 0;
 };
 
 /**
@@ -43,10 +41,19 @@ using FramePtr = std::unique_ptr<T>;
 
 typedef std::unique_ptr<VideoFrame> VideoFramePtr;
 
+enum class FramePixelFormat {
+	Invalid,
+	YUV420,
+	BGR,
+	BGRA
+};
+
 struct MovieProperties {
 	FrameSize size;
 
 	float fps = -1.0f;
+
+	FramePixelFormat pixelFormat = FramePixelFormat::Invalid;
 };
 
 struct AudioFrame {

--- a/code/cutscene/VideoPresenter.h
+++ b/code/cutscene/VideoPresenter.h
@@ -12,16 +12,13 @@ namespace cutscene {
 namespace player {
 
 class VideoPresenter {
-	int _ytex = -1;
-	std::unique_ptr<uint8_t[]> _yTexBuffer;
+	MovieProperties _properties;
 
-	int _utex = -1;
-	std::unique_ptr<uint8_t[]> _uTexBuffer;
+	std::array<int, 3> _planeTextureHandles;
+	std::array<std::unique_ptr<uint8_t[]>, 3> _planeTextureBuffers;
 
-	int _vtex = -1;
-	std::unique_ptr<uint8_t[]> _vTexBuffer;
-
-	movie_material _render_material;
+	movie_material _movie_material;
+	material _rgb_material; // Material used when a RGB/RGBA movie is played
  public:
 	explicit VideoPresenter(const MovieProperties& props);
 

--- a/code/cutscene/ffmpeg/VideoDecoder.h
+++ b/code/cutscene/ffmpeg/VideoDecoder.h
@@ -9,11 +9,12 @@ class VideoDecoder: public FFMPEGStreamDecoder<VideoFrame> {
  private:
 	int m_frameId;
 	SwsContext* m_swsCtx;
+	AVPixelFormat m_destinationFormat;
 
 	void convertAndPushPicture(const AVFrame* frame);
 
  public:
-	explicit VideoDecoder(DecoderStatus* status);
+	explicit VideoDecoder(DecoderStatus* status, AVPixelFormat destination_fmt);
 
 	~VideoDecoder() override;
 


### PR DESCRIPTION
This allows to directly display RGB(A) movies without transcoding them
to YUV first. This allows the movie player to support APNG files (which
are supported natively by FFmpeg) with an alpha channel and without
converting them to YUV first.