### PR TITLE
Strings.tbl translation adjustments

### DIFF
--- a/code/ai/aigoals.cpp
+++ b/code/ai/aigoals.cpp
@@ -125,7 +125,7 @@ const char *Ai_goal_text(int goal)
 	case AI_GOAL_REARM_REPAIR:
 		return XSTR( "rearm ", 484);
 	case AI_GOAL_FLY_TO_SHIP:
-		return XSTR( "rendezvous with ", -1);
+		return XSTR( "rendezvous with ", 1597);
 	}
 
 	// Avoid compiler warning

--- a/code/fs2netd/fs2netd_client.cpp
+++ b/code/fs2netd/fs2netd_client.cpp
@@ -1101,7 +1101,7 @@ void fs2netd_store_stats()
 	if (Duplicate_login_detected) {
 		Duplicate_login_detected = false;
 		multi_display_chat_msg( XSTR("<Duplicate login detected - stats have been tossed>", 1582), 0, 0 );
-		ml_string( XSTR("<Duplicate login detected - stats have been tossed>", 1583) );
+		ml_string( XSTR("<Duplicate login detected - stats have been tossed>", 1582) );
 		fs2netd_store_stats_results();
 		return;
 	}

--- a/code/hud/hud.cpp
+++ b/code/hud/hud.cpp
@@ -2895,7 +2895,7 @@ void HudGaugeSupport::render(float  /*frametime*/)
 			}
 			else
 			{
-				sprintf(outstr, "Waiting...");
+				sprintf(outstr, XSTR("Waiting...", 1603));
 			}	
 		}
 		renderStringAlignCenter(position[0], position[1] + text_val_offset_y, w, outstr);

--- a/code/hud/hud.cpp
+++ b/code/hud/hud.cpp
@@ -2895,7 +2895,7 @@ void HudGaugeSupport::render(float  /*frametime*/)
 			}
 			else
 			{
-				sprintf(outstr, XSTR("Waiting...", 1603));
+				strcpy_s(outstr, XSTR("Waiting...", 1603));
 			}	
 		}
 		renderStringAlignCenter(position[0], position[1] + text_val_offset_y, w, outstr);

--- a/code/hud/hudtargetbox.cpp
+++ b/code/hud/hudtargetbox.cpp
@@ -1034,7 +1034,7 @@ void HudGaugeTargetBox::renderTargetWeapon(object *target_objp)
 		dist = vm_vec_dist(&target_objp->pos, &wp->homing_pos);
 		
 		if ( speed > 0 ) {
-			sprintf(outstr, NOX("impact: %.1f sec"), dist/speed);
+			sprintf(outstr, XSTR("impact: %.1f sec", 1596), dist/speed);
 		} else {
 			strcpy_s(outstr, XSTR( "unknown", 349));
 		}

--- a/code/io/keycontrol.cpp
+++ b/code/io/keycontrol.cpp
@@ -1066,12 +1066,12 @@ void process_debug_keys(int k)
 
 			if (is_support_allowed(obj_to_rearm))
 			{
-				HUD_sourced_printf(HUD_SOURCE_HIDDEN, XSTR("Issuing rearm request for %s", -1), Ships[obj_to_rearm->instance].ship_name);
+				HUD_sourced_printf(HUD_SOURCE_HIDDEN, XSTR("Issuing rearm request for %s", 1610), Ships[obj_to_rearm->instance].ship_name);
 				ai_issue_rearm_request(obj_to_rearm);
 			}
 			else
 			{
-				HUD_sourced_printf(HUD_SOURCE_HIDDEN, XSTR("Cannot issue rearm request for %s", -1), Ships[obj_to_rearm->instance].ship_name);
+				HUD_sourced_printf(HUD_SOURCE_HIDDEN, XSTR("Cannot issue rearm request for %s", 1611), Ships[obj_to_rearm->instance].ship_name);
 			}
 
 			break;
@@ -2423,10 +2423,10 @@ int button_function(int n)
 				HUD_printf("%s", XSTR("Engine failure.  Cannot engage subspace drive.", 40));
 			} else if (!ship_navigation_ok_to_warp(Player_ship)) {
 				gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
-				HUD_printf("%s", XSTR("Navigation failure.  Cannot engage subspace drive.", 1596));
+				HUD_printf("%s", XSTR("Navigation failure.  Cannot engage subspace drive.", 1572));
 			} else if ( (Player_obj != NULL) && object_get_gliding(Player_obj)) {
 				gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
-				HUD_printf("%s", XSTR("Cannot engage subspace drive while gliding.", 1597));
+				HUD_printf("%s", XSTR("Cannot engage subspace drive while gliding.", 1573));
 			} else {
 				gameseq_post_event( GS_EVENT_PLAYER_WARPOUT_START );
 			}

--- a/code/menuui/barracks.cpp
+++ b/code/menuui/barracks.cpp
@@ -433,7 +433,7 @@ void barracks_init_stats(scoring_struct *stats)
 	Num_stat_lines++;
 
 	Assert(Num_stat_lines < Max_stat_lines);
-	STRCPY1(Stat_labels[Num_stat_lines], "Current Score:");
+	STRCPY1(Stat_labels[Num_stat_lines], XSTR( "Current Score:", 1583));
 	sprintf(Stats[Num_stat_lines], "%d", stats->score);
 	Num_stat_lines++;
 

--- a/code/menuui/barracks.cpp
+++ b/code/menuui/barracks.cpp
@@ -433,7 +433,7 @@ void barracks_init_stats(scoring_struct *stats)
 	Num_stat_lines++;
 
 	Assert(Num_stat_lines < Max_stat_lines);
-	STRCPY1(Stat_labels[Num_stat_lines], XSTR( "Current Score:", 1583));
+	strcpy_s(Stat_labels[Num_stat_lines], XSTR( "Current Score:", 1583));
 	sprintf(Stats[Num_stat_lines], "%d", stats->score);
 	Num_stat_lines++;
 

--- a/code/menuui/playermenu.cpp
+++ b/code/menuui/playermenu.cpp
@@ -648,7 +648,7 @@ void player_select_button_pressed(int n)
 			if (Player_select_mode == PLAYER_SELECT_MODE_MULTI) {
 				popup(PF_TITLE_BIG | PF_TITLE_RED | PF_USE_AFFIRMATIVE_ICON, 1, POPUP_OK, XSTR("Disabled!\n\nMulti and single player pilots are now identical. "
 							"Deleting a multi-player pilot will also delete all single-player data for that pilot.\n\nAs a safety precaution, pilots can only be "
-							"deleted from the single-player menu.", 1610));
+							"deleted from the single-player menu.", 1598));
 			} else {
 				// display a popup requesting confirmation
 				ret = popup(PF_TITLE_BIG | PF_TITLE_RED, 2, POPUP_NO, POPUP_YES, XSTR( "Warning!\n\nAre you sure you wish to delete this pilot?", 382));

--- a/code/network/multi.cpp
+++ b/code/network/multi.cpp
@@ -1429,7 +1429,7 @@ void standalone_main_init()
 	// if we failed to startup on our desired protocol, fail
 	if ((Multi_options_g.protocol == NET_TCP) && !Tcp_active){
 		if (Tcp_failure_code == WSAEADDRINUSE) {
-			os::dialogs::Message(os::dialogs::MESSAGEBOX_ERROR, XSTR("You have selected TCP/IP for multiplayer FreeSpace, but the TCP socket is already in use.  Check for another instance and/or use the \"-port <port_num>\" command line option to select an available port.", 1620));
+			os::dialogs::Message(os::dialogs::MESSAGEBOX_ERROR, XSTR("You have selected TCP/IP for multiplayer FreeSpace, but the TCP socket is already in use.  Check for another instance and/or use the \"-port <port_num>\" command line option to select an available port.", 1604));
 		}
 		else {
 			os::dialogs::Message(os::dialogs::MESSAGEBOX_ERROR, XSTR("You have selected TCP/IP for multiplayer FreeSpace, but the TCP/IP protocol was not detected on your machine.", 362));

--- a/code/network/multiui.cpp
+++ b/code/network/multiui.cpp
@@ -4976,7 +4976,7 @@ void multi_create_accept_hit()
 								XSTR("A time limit is being used in a co-op game.\r\n"
 									"  Select \'Cancel\' to go back to the mission select screen.\r\n"
 									"  Select \'Yes\' to continue with this time limit.\r\n"
-									"  Select \'No\' to continue without this time limit.", -1));
+									"  Select \'No\' to continue without this time limit.", 1620));
 
 			if (popup_choice == 0) {
 				return;
@@ -4991,7 +4991,7 @@ void multi_create_accept_hit()
 								XSTR("A kill limit is being used in a co-op game.\r\n"
 									"  Select \'Cancel\' to go back to the mission select screen.\r\n"
 									"  Select \'Yes\' to continue with this kill limit.\r\n"
-									"  Select \'No\' to continue without this kill limit.", -1));
+									"  Select \'No\' to continue without this kill limit.", 1621));
 
 			if (popup_choice == 0) {
 				return;


### PR DESCRIPTION
In the code there are some strings from features added by the SCP that uses two different IDs for the same string. This PR cleans them up, so that only one ID is used.

The IDs that were occupied by duplicates aswell IDs that were already unused before are now replaced by previously untranslated strings, that are now translateable through the strings.tbl.

This contain all requests i made in #1738. except from the bindable controls.