### PR TITLE
Use byte offset into immediate buffer for movie rendering

### DIFF
--- a/code/cutscene/VideoPresenter.cpp
+++ b/code/cutscene/VideoPresenter.cpp
@@ -124,13 +124,13 @@ void VideoPresenter::displayFrame(float x1, float y1, float x2, float y2) {
 	auto offset = gr_add_to_immediate_buffer(sizeof(vertex_data), vertex_data);
 
 	vertex_layout layout;
-	layout.add_vertex_component(vertex_format_data::POSITION2, sizeof(vertex_data[0]), offset + offsetof(movie_vertex, pos));
-	layout.add_vertex_component(vertex_format_data::TEX_COORD2, sizeof(vertex_data[0]), offset + offsetof(movie_vertex, uv));
+	layout.add_vertex_component(vertex_format_data::POSITION2, sizeof(vertex_data[0]), offsetof(movie_vertex, pos));
+	layout.add_vertex_component(vertex_format_data::TEX_COORD2, sizeof(vertex_data[0]), offsetof(movie_vertex, uv));
 
 	if (_properties.pixelFormat == FramePixelFormat::YUV420) {
-		gr_render_movie(&_movie_material, PRIM_TYPE_TRISTRIP, &layout, 4, gr_immediate_buffer_handle);
+		gr_render_movie(&_movie_material, PRIM_TYPE_TRISTRIP, &layout, 4, gr_immediate_buffer_handle, offset);
 	} else {
-		gr_render_primitives(&_rgb_material, PRIM_TYPE_TRISTRIP, &layout, 0, 4, gr_immediate_buffer_handle);
+		gr_render_primitives(&_rgb_material, PRIM_TYPE_TRISTRIP, &layout, 0, 4, gr_immediate_buffer_handle, offset);
 	}
 }
 

--- a/code/graphics/2d.h
+++ b/code/graphics/2d.h
@@ -776,7 +776,7 @@ typedef struct screen {
 	void (*gf_render_primitives)(material* material_info, primitive_type prim_type, vertex_layout* layout, int offset, int n_verts, int buffer_handle, size_t buffer_offset);
 	void (*gf_render_primitives_particle)(particle_material* material_info, primitive_type prim_type, vertex_layout* layout, int offset, int n_verts, int buffer_handle);
 	void (*gf_render_primitives_distortion)(distortion_material* material_info, primitive_type prim_type, vertex_layout* layout, int offset, int n_verts, int buffer_handle);
-	void (*gf_render_movie)(movie_material* material_info, primitive_type prim_type, vertex_layout* layout, int n_verts, int buffer);
+	void (*gf_render_movie)(movie_material* material_info, primitive_type prim_type, vertex_layout* layout, int n_verts, int buffer, size_t buffer_offset);
 	void (*gf_render_primitives_batched)(batched_bitmap_material* material_info, primitive_type prim_type, vertex_layout* layout, int offset, int n_verts, int buffer_handle);
 	void (*gf_render_nanovg)(nanovg_material* material_info, primitive_type prim_type, vertex_layout* layout, int offset, int n_verts, int buffer_handle);
 	void (*gf_render_decals)(decal_material* material_info, primitive_type prim_type, vertex_layout* layout, int num_elements, const indexed_vertex_source& buffers);
@@ -1029,9 +1029,9 @@ __inline void gr_render_primitives_distortion(distortion_material* material_info
 	(*gr_screen.gf_render_primitives_distortion)(material_info, prim_type, layout, offset, n_verts, buffer_handle);
 }
 
-inline void gr_render_movie(movie_material* material_info, primitive_type prim_type, vertex_layout* layout, int n_verts, int buffer)
+inline void gr_render_movie(movie_material* material_info, primitive_type prim_type, vertex_layout* layout, int n_verts, int buffer, size_t buffer_offset = 0)
 {
-	(*gr_screen.gf_render_movie)(material_info, prim_type, layout, n_verts, buffer);
+	(*gr_screen.gf_render_movie)(material_info, prim_type, layout, n_verts, buffer, buffer_offset);
 }
 
 __inline void gr_render_model(model_material* material_info, indexed_vertex_source *vert_source, vertex_buffer* bufferp, size_t texi)

--- a/code/graphics/grstub.cpp
+++ b/code/graphics/grstub.cpp
@@ -335,7 +335,7 @@ void gr_stub_render_primitives_distortion(distortion_material*  /*material_info*
 {
 
 }
-void gr_stub_render_movie(movie_material*  /*material_info*/, primitive_type  /*prim_type*/, vertex_layout*  /*layout*/, int  /*n_verts*/, int  /*buffer*/)
+void gr_stub_render_movie(movie_material*  /*material_info*/, primitive_type  /*prim_type*/, vertex_layout*  /*layout*/, int  /*n_verts*/, int  /*buffer*/, size_t /*buffer_offset*/)
 {
 }
 

--- a/code/graphics/opengl/gropengldraw.cpp
+++ b/code/graphics/opengl/gropengldraw.cpp
@@ -786,18 +786,16 @@ void gr_opengl_render_primitives_distortion(distortion_material* material_info, 
 	GL_CHECK_FOR_ERRORS("start of gr_opengl_render_primitives_distortion()");
 }
 
-void gr_opengl_render_movie(movie_material* material_info,
-							primitive_type prim_type,
-							vertex_layout* layout,
-							int n_verts,
-							int buffer) {
+void gr_opengl_render_movie(movie_material* material_info, primitive_type prim_type, vertex_layout* layout, int n_verts,
+                            int buffer, size_t buffer_offset)
+{
 	GR_DEBUG_SCOPE("Render movie frame");
 
 	gr_set_2d_matrix();
 
 	opengl_tnl_set_material_movie(material_info);
 
-	opengl_render_primitives(prim_type, layout, n_verts, buffer, 0, 0);
+	opengl_render_primitives(prim_type, layout, n_verts, buffer, 0, buffer_offset);
 
 	gr_end_2d_matrix();
 }

--- a/code/graphics/opengl/gropengldraw.h
+++ b/code/graphics/opengl/gropengldraw.h
@@ -55,7 +55,7 @@ void gr_opengl_render_primitives(material* material_info, primitive_type prim_ty
 void gr_opengl_render_primitives_particle(particle_material* material_info, primitive_type prim_type, vertex_layout* layout, int offset, int n_verts, int buffer_handle);
 void gr_opengl_render_primitives_batched(batched_bitmap_material* material_info, primitive_type prim_type, vertex_layout* layout, int offset, int n_verts, int buffer_handle);
 void gr_opengl_render_primitives_distortion(distortion_material* material_info, primitive_type prim_type, vertex_layout* layout, int offset, int n_verts, int buffer_handle);
-void gr_opengl_render_movie(movie_material* material_info, primitive_type prim_type, vertex_layout* layout, int n_verts, int buffer);
+void gr_opengl_render_movie(movie_material* material_info, primitive_type prim_type, vertex_layout* layout, int n_verts, int buffer, size_t buffer_offset);
 void gr_opengl_render_nanovg(nanovg_material* material_info, primitive_type prim_type, vertex_layout* layout, int offset, int n_verts, int buffer_handle);
 void gr_opengl_render_decals(decal_material* material_info, primitive_type prim_type, vertex_layout* layout, int num_elements, const indexed_vertex_source& binding);
 


### PR DESCRIPTION
This was causing issues when using the new scripting API in JAD where
there were a lot of 2D operations which filled up the immediate mode
buffer. The reason was that GL_ARB_vertex_attrib_binding the relative
offset is limited and the movie code adds the immediate buffer offset to
the vertex layout which then hit the offset limit set by OpenGL.

This fixes that by using the normal byte offset method which is already
used by the render_primitives functions.