### PR TITLE
Strings.tbl translation adjustments AddOn

### DIFF
--- a/code/hud/hudtarget.cpp
+++ b/code/hud/hudtarget.cpp
@@ -5599,7 +5599,7 @@ void HudGaugeWeaponEnergy::render(float  /*frametime*/)
 			setGaugeColor(HUD_C_BRIGHT);
 
 		//Draw name
-		renderString(currentx, currenty, "Energy");
+		renderString(currentx, currenty, XSTR("Energy", 1616));
 		currenty += line_height;
 
 		//Draw background


### PR DESCRIPTION
Well, during #1795 i simply overlooked the string for the Energy Display in the Ballistic Weapon Gauge
This change made it translateable through the strings.tbl aswell.

This entry uses ID 1616, that means, that all additional possible IDs  from 1570 to 1637 are now used with an unique string.