### PR TITLE
Remove unused parameters

### DIFF
--- a/code/ai/aibig.cpp
+++ b/code/ai/aibig.cpp
@@ -1698,7 +1698,7 @@ void ai_big_strafe()
 //
 // Check if weapon_objnum was fired by Pl_objp's target, and whether Pl_objp's target is a big ship, if
 // so, enter AIM_STRAFE
-int ai_big_maybe_enter_strafe_mode(object *pl_objp, int weapon_objnum, int  /*consider_target_only*/)
+int ai_big_maybe_enter_strafe_mode(const object *pl_objp, int weapon_objnum)
 {
 	ai_info		*aip;
 	ship_info	*sip;

--- a/code/ai/aibig.cpp
+++ b/code/ai/aibig.cpp
@@ -1772,7 +1772,7 @@ int ai_big_maybe_enter_strafe_mode(object *pl_objp, int weapon_objnum, int  /*co
 // Consider attacking a turret, if a turret actually fired the weapon
 // input:	ship_objp	=>	ship that will attack the turret
 //				weapon_objp	=>	
-void ai_big_strafe_maybe_attack_turret(object *ship_objp, object *weapon_objp)
+void ai_big_strafe_maybe_attack_turret(const object *ship_objp, const object *weapon_objp)
 {
 	ai_info	*aip;
 	object	*parent_objp;

--- a/code/ai/aibig.cpp
+++ b/code/ai/aibig.cpp
@@ -64,6 +64,7 @@ void	ai_big_chase_attack(ai_info *aip, ship_info *sip, vec3d *enemy_pos, float d
 void	ai_big_avoid_ship();
 int	ai_big_maybe_follow_subsys_path(int do_dot_check=1);
 void ai_big_strafe_position();
+static int ai_big_strafe_maybe_retreat(const vec3d *target_pos);
 
 extern int model_which_octant_distant_many( vec3d *pnt, int model_num,matrix *model_orient, vec3d * model_pos, polymodel **pm, int *octs);
 extern void compute_desired_rvec(vec3d *rvec, vec3d *goal_pos, vec3d *cur_pos);
@@ -845,8 +846,6 @@ void ai_big_switch_to_chase_mode(ai_info *aip)
 	aip->submode_start_time = Missiontime;
 }
 
-extern int ai_big_strafe_maybe_retreat(float dist, vec3d *target_pos);
-
 // Make object Pl_objp chase object En_objp, which is a big ship, not a small ship.
 void ai_big_chase()
 {
@@ -882,7 +881,7 @@ void ai_big_chase()
 	dot_to_enemy = vm_vec_dot(&vec_to_enemy, &Pl_objp->orient.vec.fvec);
 
 	if (aip->ai_flags[AI::AI_Flags::Target_collision]) {
-		if ( ai_big_strafe_maybe_retreat(dist_to_enemy, &enemy_pos) ) {
+		if ( ai_big_strafe_maybe_retreat(&enemy_pos) ) {
 			aip->mode = AIM_STRAFE;
 			aip->submode_parm0 = Missiontime;	// use parm0 as time strafe mode entered (i.e. MODE start time)
 			aip->submode = AIS_STRAFE_AVOID;
@@ -1223,7 +1222,7 @@ void ai_big_attack_get_data(vec3d *enemy_pos, float *dist_to_enemy, float *dot_t
 
 // check to see if Pl_objp has gotten too close to attacking point.. if so, break off by entering
 // AIS_STRAFE_RETREAT
-int ai_big_strafe_maybe_retreat(float  /*dist*/, vec3d *target_pos)
+static int ai_big_strafe_maybe_retreat(const vec3d *target_pos)
 {
 	ai_info	*aip;
 	aip = &Ai_info[Ships[Pl_objp->instance].ai_index];
@@ -1293,7 +1292,7 @@ void ai_big_strafe_attack()
 	}
 
 	ai_big_attack_get_data(&target_pos, &target_dist, &target_dot);
-	if ( ai_big_strafe_maybe_retreat(target_dist, &target_pos) )
+	if ( ai_big_strafe_maybe_retreat(&target_pos) )
 		return;
 
 	if (aip->ai_flags[AI::AI_Flags::Kamikaze]) {
@@ -1512,7 +1511,7 @@ void ai_big_strafe_avoid()
 	mode_time = Missiontime - aip->submode_start_time;
 
 	ai_big_attack_get_data(&target_pos, &target_dist, &target_dot);
-	if ( ai_big_strafe_maybe_retreat(target_dist, &target_pos) )
+	if ( ai_big_strafe_maybe_retreat(&target_pos) )
 		return;
 
 	if ( mode_time > fl2f(0.5)) {

--- a/code/ai/aibig.cpp
+++ b/code/ai/aibig.cpp
@@ -1153,11 +1153,6 @@ void ai_big_chase()
 	}
 }
 
-void ai_big_ship(object * /*objp*/)
-{
-	// do nothing
-}
-
 // all three parms are output parameters
 //	Enemy object is En_objp
 // pos	=>		world pos of attack point

--- a/code/ai/aibig.cpp
+++ b/code/ai/aibig.cpp
@@ -714,7 +714,7 @@ extern void maybe_cheat_fire_synaptic(object *objp, ai_info *aip);
 // dist_to_enemy	=>		distance (in m) to attack point on current target
 // dot_to_enemy	=>		dot product between fvec of Pl_objp and vector from Pl_objp to attack point
 //
-void ai_big_maybe_fire_weapons(float dist_to_enemy, float dot_to_enemy, vec3d * /*firing_pos*/, vec3d * /*enemy_pos*/, vec3d * /*enemy_vel*/)
+static void ai_big_maybe_fire_weapons(float dist_to_enemy, float dot_to_enemy)
 {
 	ai_info		*aip;
 	ship_weapon	*swp;
@@ -1144,7 +1144,7 @@ void ai_big_chase()
 	//		 TODO: investigate why ships fire (and aren't close to hitting ship) when following a path near
 	//				 a big ship
 	if (aip->mode != AIM_EVADE && aip->path_start == -1 ) {
-		ai_big_maybe_fire_weapons(dist_to_enemy, dot_to_enemy, &player_pos, &predicted_enemy_pos, &En_objp->phys_info.vel);
+		ai_big_maybe_fire_weapons(dist_to_enemy, dot_to_enemy);
 	} else {
 		if (flFrametime < 1.0f)
 			aip->time_enemy_in_range *= (1.0f - flFrametime);
@@ -1347,7 +1347,7 @@ void ai_big_strafe_attack()
 	}
 
 	// maybe fire weapons at target
-	ai_big_maybe_fire_weapons(target_dist, target_dot, &Pl_objp->pos, &En_objp->pos, &En_objp->phys_info.vel);
+	ai_big_maybe_fire_weapons(target_dist, target_dot);
 	turn_towards_point(Pl_objp, &target_pos, NULL, 0.0f);
 
 	fix last_hit = Missiontime - aip->last_hit_time;
@@ -1493,7 +1493,7 @@ void ai_big_strafe_glide_attack()
 		vm_vec_sub2(&target_pos, &En_objp->pos);
 
 		turn_towards_point(Pl_objp, &target_pos, NULL, 0.0f);
-		ai_big_maybe_fire_weapons(target_dist, target_dot, &Pl_objp->pos, &En_objp->pos, &En_objp->phys_info.vel);
+		ai_big_maybe_fire_weapons(target_dist, target_dot);
 	}
 
 	// if haven't been hit in quite a while, leave strafe mode

--- a/code/ai/aibig.h
+++ b/code/ai/aibig.h
@@ -23,7 +23,7 @@ void	ai_big_subsys_path_cleanup(ai_info *aip);
 // strafe functions
 void	ai_big_strafe();
 int	ai_big_maybe_enter_strafe_mode(object *objp, int weapon_objnum, int consider_target_only=0);
-void	ai_big_strafe_maybe_attack_turret(object *ship_objp, object *weapon_objp);
+void	ai_big_strafe_maybe_attack_turret(const object *ship_objp, const object *weapon_objp);
 void ai_big_pick_attack_point(object *objp, object *attacker_objp, vec3d *attack_point, float fov=1.0f);
 void ai_big_pick_attack_point_turret(object *objp, ship_subsys *ssp, vec3d *gpos, vec3d *gvec, vec3d *attack_point, float weapon_travel_dist, float fov=1.0f);
 

--- a/code/ai/aibig.h
+++ b/code/ai/aibig.h
@@ -22,7 +22,7 @@ void	ai_big_subsys_path_cleanup(ai_info *aip);
 
 // strafe functions
 void	ai_big_strafe();
-int	ai_big_maybe_enter_strafe_mode(object *objp, int weapon_objnum, int consider_target_only=0);
+int	ai_big_maybe_enter_strafe_mode(const object *objp, int weapon_objnum);
 void	ai_big_strafe_maybe_attack_turret(const object *ship_objp, const object *weapon_objp);
 void ai_big_pick_attack_point(object *objp, object *attacker_objp, vec3d *attack_point, float fov=1.0f);
 void ai_big_pick_attack_point_turret(object *objp, ship_subsys *ssp, vec3d *gpos, vec3d *gvec, vec3d *attack_point, float weapon_travel_dist, float fov=1.0f);

--- a/code/ai/aibig.h
+++ b/code/ai/aibig.h
@@ -17,7 +17,6 @@ struct ai_info;
 struct vec3d;
 class ship_subsys;
 
-void	ai_big_ship(object *objp);
 void	ai_big_chase();
 void	ai_big_subsys_path_cleanup(ai_info *aip);
 

--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -13070,7 +13070,6 @@ void ai_execute_behavior(ai_info *aip)
 	case AIM_NONE:
 		break;
 	case AIM_BIGSHIP:
-		ai_big_ship(Pl_objp);
 		break;
 	case AIM_PATH: {
 		int path_num;

--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -15072,7 +15072,7 @@ void ai_ship_hit(object *objp_ship, object *hit_objp, vec3d *hitpos, int  /*shie
 			return;
 
 		if ( (hit_objp->type == OBJ_WEAPON) && !(aip->ai_flags[AI::AI_Flags::No_dynamic]) ) {
-			if ( ai_big_maybe_enter_strafe_mode(objp_ship, OBJ_INDEX(hit_objp), 1) )
+			if ( ai_big_maybe_enter_strafe_mode(objp_ship, OBJ_INDEX(hit_objp)) )
 				return;
 		}
 		break;


### PR DESCRIPTION
I am starting to get a little more free time for a little while, so I thought that I would take a crack again at trying to clean up some the APIs--specifically those in aibig.cpp that are known to have unused parameters.

For those few routines, I ...
  1. applied the 'static' keyword to the routine when it seemed appropriate.
  2. applied the 'const' keyword to parameters where it seemed appropriate.
  3. updated the arguments where those routines were called.

In theory, these changes should result in fractionally more efficient code as those unused parameters no longer need to be processed by the caller.

Hopefully these proposed changes are met with your satisfaction.