### PR TITLE
Add CFile API for specifying the file location

### DIFF
--- a/code/bmpman/bmpman.cpp
+++ b/code/bmpman/bmpman.cpp
@@ -1876,24 +1876,19 @@ int bm_load_sub_fast(const char *real_filename, int *handle, int dir_type, bool 
 }
 
 int bm_load_sub_slow(const char *real_filename, const int num_ext, const char **ext_list, CFILE **img_cfp, int dir_type) {
-	char full_path[MAX_PATH];
-	size_t size = 0, offset = 0;
-	int rval = -1;
-	const void* file_data = nullptr;
-
-	rval = cf_find_file_location_ext(real_filename, num_ext, ext_list, dir_type, sizeof(full_path) - 1, full_path, &size, &offset, 0, &file_data);
+	auto res = cf_find_file_location_ext(real_filename, num_ext, ext_list, dir_type, false);
 
 	// could not be found, or is invalid for some reason
-	if ((rval < 0) || (rval >= num_ext))
+	if (!res.found)
 		return -1;
 
-	CFILE *test = cfopen_special(full_path, "rb", size, offset, file_data, dir_type);
+	CFILE *test = cfopen_special(res.full_name.c_str(), "rb", res.size, res.offset, res.data_ptr, dir_type);
 
 	if (test != NULL) {
 		if (img_cfp != NULL)
 			*img_cfp = test;
 
-		return rval;
+		return res.extension_index;
 	}
 
 	// umm, that's not good...

--- a/code/cfile/cfile.cpp
+++ b/code/cfile/cfile.cpp
@@ -633,7 +633,7 @@ void cf_create_directory(int dir_type, uint32_t location_flags)
 	int i;
 
 	for (i=num_dirs-1; i>=0; i-- )	{
-		cf_create_default_path_string(longname, sizeof(longname) - 1, dir_tree[i], NULL, false, location_flags);
+		cf_create_default_path_string(longname, sizeof(longname) - 1, dir_tree[i], nullptr, false, location_flags);
 		if (stat(longname, &statbuf) != 0) {
 			mprintf(( "CFILE: Creating new directory '%s'\n", longname ));
 			mkdir_recursive(longname);

--- a/code/cfile/cfile.h
+++ b/code/cfile/cfile.h
@@ -367,8 +367,11 @@ int cfwrite_string_len(const char *buf, CFILE *file);
 
 int cf_get_file_list(SCP_vector<SCP_string>& list, int pathtype, const char* filter, int sort = CF_SORT_NONE,
                      SCP_vector<file_list_info>* info = NULL, uint32_t location_flags = CF_LOCATION_ALL);
-int cf_get_file_list( int max, char **list, int type, const char *filter, int sort = CF_SORT_NONE, file_list_info *info = NULL );
-int cf_get_file_list_preallocated( int max, char arr[][MAX_FILENAME_LEN], char **list, int type, const char *filter, int sort = CF_SORT_NONE, file_list_info *info = NULL );
+int cf_get_file_list(int max, char** list, int type, const char* filter, int sort = CF_SORT_NONE,
+                     file_list_info* info = NULL, uint32_t location_flags = CF_LOCATION_ALL);
+int cf_get_file_list_preallocated(int max, char arr[][MAX_FILENAME_LEN], char** list, int type, const char* filter,
+                                  int sort = CF_SORT_NONE, file_list_info* info = NULL,
+                                  uint32_t location_flags = CF_LOCATION_ALL);
 void cf_sort_filenames( int n, char **list, int sort, file_list_info *info = NULL );
 void cf_sort_filenames( SCP_vector<SCP_string> &list, int sort, SCP_vector<file_list_info> *info = NULL );
 

--- a/code/cfile/cfile.h
+++ b/code/cfile/cfile.h
@@ -314,6 +314,16 @@ int cf_get_file_list_preallocated( int max, char arr[][MAX_FILENAME_LEN], char *
 void cf_sort_filenames( int n, char **list, int sort, file_list_info *info = NULL );
 void cf_sort_filenames( SCP_vector<SCP_string> &list, int sort, SCP_vector<file_list_info> *info = NULL );
 
+struct CFileLocation {
+	bool found = false;
+	SCP_string full_name;
+	size_t size          = 0;
+	size_t offset        = 0;
+	const void* data_ptr = nullptr;
+
+	explicit CFileLocation(bool found_in = false) : found(found_in) {}
+};
+
 // Searches for a file.   Follows all rules and precedence and searches
 // CD's and pack files.
 // Input:  filespace   - Filename & extension
@@ -323,7 +333,16 @@ void cf_sort_filenames( SCP_vector<SCP_string> &list, int sort, SCP_vector<file_
 //         size        - File size
 //         offset      - Offset into pack file.  0 if not a packfile.
 // Returns: If not found returns 0.
-int cf_find_file_location( const char *filespec, int pathtype, int max_out, char *pack_filename, size_t *size, size_t *offset, bool localize = false, const void** data_out = nullptr);
+CFileLocation cf_find_file_location(const char* filespec, int pathtype, bool localize = false);
+
+struct CFileLocationExt : public CFileLocation {
+	int extension_index = -1;
+
+	explicit CFileLocationExt(int extension_index_in = -1)
+	    : CFileLocation(extension_index_in >= 0), extension_index(extension_index_in)
+	{
+	}
+};
 
 // Searches for a file.   Follows all rules and precedence and searches
 // CD's and pack files.  Searches all locations in order for first filename using ext filter list.
@@ -337,7 +356,8 @@ int cf_find_file_location( const char *filespec, int pathtype, int max_out, char
 //         offset      - Offset into pack file.  0 if not a packfile.
 // Returns: If not found returns -1, else returns offset into ext_list.
 // (NOTE: This function is exponentially slow, so don't use it unless truely needed!!)
-int cf_find_file_location_ext(const char *filename, const int ext_num, const char **ext_list, int pathtype, int max_out = 0, char *pack_filename = NULL, size_t *size = NULL, size_t *offset = NULL, bool localize = false, const void** data_out = nullptr);
+CFileLocationExt cf_find_file_location_ext(const char* filename, const int ext_num, const char** ext_list, int pathtype,
+                                           bool localize = false);
 
 // Functions to change directories
 int cfile_chdir(const char *dir);

--- a/code/cfile/cfile.h
+++ b/code/cfile/cfile.h
@@ -366,11 +366,11 @@ int cfwrite_string(const char *buf, CFILE *file);
 int cfwrite_string_len(const char *buf, CFILE *file);
 
 int cf_get_file_list(SCP_vector<SCP_string>& list, int pathtype, const char* filter, int sort = CF_SORT_NONE,
-                     SCP_vector<file_list_info>* info = NULL, uint32_t location_flags = CF_LOCATION_ALL);
+                     SCP_vector<file_list_info>* info = nullptr, uint32_t location_flags = CF_LOCATION_ALL);
 int cf_get_file_list(int max, char** list, int type, const char* filter, int sort = CF_SORT_NONE,
-                     file_list_info* info = NULL, uint32_t location_flags = CF_LOCATION_ALL);
+                     file_list_info* info = nullptr, uint32_t location_flags = CF_LOCATION_ALL);
 int cf_get_file_list_preallocated(int max, char arr[][MAX_FILENAME_LEN], char** list, int type, const char* filter,
-                                  int sort = CF_SORT_NONE, file_list_info* info = NULL,
+                                  int sort = CF_SORT_NONE, file_list_info* info = nullptr,
                                   uint32_t location_flags = CF_LOCATION_ALL);
 void cf_sort_filenames( int n, char **list, int sort, file_list_info *info = NULL );
 void cf_sort_filenames( SCP_vector<SCP_string> &list, int sort, SCP_vector<file_list_info> *info = NULL );

--- a/code/cfile/cfilesystem.cpp
+++ b/code/cfile/cfilesystem.cpp
@@ -1847,7 +1847,7 @@ int cf_get_file_list(int max, char** list, int pathtype, const char* filter, int
 	}
 
 #elif defined SCP_UNIX
-	cf_create_default_path_string(filespec, sizeof(filespec) - 1, pathtype, NULL, false, location_flags);
+	cf_create_default_path_string(filespec, sizeof(filespec) - 1, pathtype, nullptr, false, location_flags);
 
 	DIR *dirp;
 	struct dirent *dir;
@@ -2084,7 +2084,7 @@ int cf_get_file_list_preallocated(int max, char arr[][MAX_FILENAME_LEN], char** 
 	}
 
 #elif defined SCP_UNIX
-	cf_create_default_path_string(filespec, sizeof(filespec) - 1, pathtype, NULL, false, location_flags);
+	cf_create_default_path_string(filespec, sizeof(filespec) - 1, pathtype, nullptr, false, location_flags);
 
 	DIR *dirp;
 	struct dirent *dir;

--- a/code/cfile/cfilesystem.h
+++ b/code/cfile/cfilesystem.h
@@ -41,9 +41,9 @@ bool cf_check_location_flags(uint32_t check_flags, uint32_t desired_flags);
 //          filename  - optional, if set, tacks the filename onto end of path.
 // Output:  path      - Fully qualified pathname.
 //Returns 0 if result would be too long (invalid result)
-int cf_create_default_path_string(char* path, uint path_max, int pathtype, const char* filename = NULL,
+int cf_create_default_path_string(char* path, uint path_max, int pathtype, const char* filename = nullptr,
                                   bool localize = false, uint32_t location_flags = CF_LOCATION_ALL);
-int cf_create_default_path_string(SCP_string& path, int pathtype, const char* filename = NULL, bool localize = false,
+int cf_create_default_path_string(SCP_string& path, int pathtype, const char* filename = nullptr, bool localize = false,
                                   uint32_t location_flags = CF_LOCATION_ALL);
 
 #endif	//_CFILESYSTEM_H

--- a/code/cfile/cfilesystem.h
+++ b/code/cfile/cfilesystem.h
@@ -29,6 +29,8 @@ typedef struct cf_pathtype {
 // During cfile_init, verify that Pathtypes[n].index == n for each item
 extern cf_pathtype Pathtypes[CF_MAX_PATH_TYPES];
 
+bool cf_check_location_flags(uint32_t check_flags, uint32_t desired_flags);
+
 // Returns the default storage path for files given a 
 // particular pathtype.   In other words, the path to 
 // the unpacked, non-cd'd, stored on hard drive path.
@@ -39,7 +41,9 @@ extern cf_pathtype Pathtypes[CF_MAX_PATH_TYPES];
 //          filename  - optional, if set, tacks the filename onto end of path.
 // Output:  path      - Fully qualified pathname.
 //Returns 0 if result would be too long (invalid result)
-int cf_create_default_path_string( char *path, uint path_max, int pathtype, const char *filename=NULL, bool localize = false);
-int cf_create_default_path_string( SCP_string &path, int pathtype, const char *filename=NULL, bool localize = false );
+int cf_create_default_path_string(char* path, uint path_max, int pathtype, const char* filename = NULL,
+                                  bool localize = false, uint32_t location_flags = CF_LOCATION_ALL);
+int cf_create_default_path_string(SCP_string& path, int pathtype, const char* filename = NULL, bool localize = false,
+                                  uint32_t location_flags = CF_LOCATION_ALL);
 
 #endif	//_CFILESYSTEM_H

--- a/code/graphics/generic.cpp
+++ b/code/graphics/generic.cpp
@@ -158,32 +158,28 @@ int generic_anim_stream(generic_anim *ga, const bool cache)
 {
 	CFILE *img_cfp = NULL;
 	int anim_fps = 0;
-	char full_path[MAX_PATH];
-	size_t size = 0, offset = 0;
-	const void* file_data = nullptr;
 	const int NUM_TYPES = 3;
 	const ubyte type_list[NUM_TYPES] = {BM_TYPE_EFF, BM_TYPE_ANI, BM_TYPE_PNG};
 	const char *ext_list[NUM_TYPES] = {".eff", ".ani", ".png"};
-	int rval = -1;
 	int bpp;
 
 	ga->type = BM_TYPE_NONE;
 
-	rval = cf_find_file_location_ext(ga->filename, NUM_TYPES, ext_list, CF_TYPE_ANY, sizeof(full_path) - 1, full_path, &size, &offset, 0, &file_data);
+	auto res = cf_find_file_location_ext(ga->filename, NUM_TYPES, ext_list, CF_TYPE_ANY, false);
 
 	// could not be found, or is invalid for some reason
-	if ( (rval < 0) || (rval >= NUM_TYPES) )
+	if ( !res.found )
 		return -1;
 
 	//make sure we can open it
-	img_cfp = cfopen_special(full_path, "rb", size, offset, file_data, CF_TYPE_ANY);
+	img_cfp = cfopen_special(res.full_name.c_str(), "rb", res.size, res.offset, res.data_ptr, CF_TYPE_ANY);
 
 	if (img_cfp == NULL) {
 		return -1;
 	}
 
-	strcat_s(ga->filename, ext_list[rval]);
-	ga->type = type_list[rval];
+	strcat_s(ga->filename, ext_list[res.extension_index]);
+	ga->type = type_list[res.extension_index];
 	//seek to the end
 	cfseek(img_cfp, 0, CF_SEEK_END);
 

--- a/code/hud/hudconfig.cpp
+++ b/code/hud/hudconfig.cpp
@@ -1642,7 +1642,8 @@ void hud_config_as_player()
 void hud_config_color_save(char *name)
 {
 	int idx;
-	CFILE *out = cfopen(name, "wt", CFILE_NORMAL, CF_TYPE_PLAYERS);
+	CFILE* out     = cfopen(name, "wt", CFILE_NORMAL, CF_TYPE_PLAYERS, false,
+                        CF_LOCATION_ROOT_USER | CF_LOCATION_ROOT_GAME | CF_LOCATION_TYPE_ROOT);
 	char vals[255] = "";
 
 	// bad
@@ -1843,7 +1844,8 @@ void hud_config_color_init()
 
 	// get a list of all hcf files
 	memset(HC_filenames, 0, sizeof(char*) * MAX_HCF_FILES);
-	HC_num_files = cf_get_file_list(MAX_HCF_FILES, HC_filenames, CF_TYPE_PLAYERS, "*.hcf", CF_SORT_NAME);
+	HC_num_files = cf_get_file_list(MAX_HCF_FILES, HC_filenames, CF_TYPE_PLAYERS, "*.hcf", CF_SORT_NAME, nullptr,
+	                                CF_LOCATION_ROOT_USER | CF_LOCATION_ROOT_GAME | CF_LOCATION_TYPE_ROOT);
 }
 
 void hud_config_color_close()

--- a/code/lab/lab.cpp
+++ b/code/lab/lab.cpp
@@ -1599,7 +1599,7 @@ char envmap_name[MAX_FILENAME_LEN];
 
 const char* mission_ext_list[] = { ".fs2" };
 
-SCP_string get_directory_or_vp(char* path)
+SCP_string get_directory_or_vp(const char* path)
 {
 	SCP_string result(path);
 
@@ -1833,14 +1833,15 @@ void labviewer_make_background_window(Button*  /*caller*/)
 	cf_get_file_list(missions, CF_TYPE_MISSIONS, NOX("*.fs2"));
 
 	SCP_map<SCP_string, SCP_vector<SCP_string>> directories;
-	char fullpath[MAX_PATH_LEN];
 
-	for (const auto& filename : missions)
-	{
-		cf_find_file_location((filename + ".fs2").c_str(), CF_TYPE_MISSIONS, sizeof(fullpath) - 1, fullpath, NULL, NULL);
-		auto location = get_directory_or_vp(fullpath);
+	for (const auto& filename : missions) {
+		auto res = cf_find_file_location((filename + ".fs2").c_str(), CF_TYPE_MISSIONS);
 
-		directories[location].push_back(filename);
+		if (res.found) {
+			auto location = get_directory_or_vp(res.full_name.c_str());
+
+			directories[location].push_back(filename);
+		}
 	}
 
 	Num_mission_directories = directories.size();

--- a/code/menuui/barracks.cpp
+++ b/code/menuui/barracks.cpp
@@ -952,7 +952,9 @@ void barracks_init_player_stuff(int mode)
 	Num_pilots = 0;
 	Get_file_list_filter = barracks_pilot_filter;
 
-	Num_pilots = cf_get_file_list_preallocated(MAX_PILOTS, Pilots_arr, Pilots, CF_TYPE_PLAYERS, NOX("*.plr"), CF_SORT_TIME);
+	Num_pilots =
+	    cf_get_file_list_preallocated(MAX_PILOTS, Pilots_arr, Pilots, CF_TYPE_PLAYERS, NOX("*.plr"), CF_SORT_TIME,
+	                                  nullptr, CF_LOCATION_ROOT_USER | CF_LOCATION_ROOT_GAME | CF_LOCATION_TYPE_ROOT);
 
 	int ranks[MAX_PILOTS];
 

--- a/code/menuui/playermenu.cpp
+++ b/code/menuui/playermenu.cpp
@@ -852,7 +852,9 @@ int player_select_get_last_pilot()
 
 		Get_file_list_filter = player_select_pilot_file_filter;
 
-		Player_select_num_pilots = cf_get_file_list_preallocated(MAX_PILOTS, Pilots_arr, Pilots, CF_TYPE_PLAYERS, NOX("*.plr"), CF_SORT_TIME);
+		Player_select_num_pilots = cf_get_file_list_preallocated(
+		    MAX_PILOTS, Pilots_arr, Pilots, CF_TYPE_PLAYERS, NOX("*.plr"), CF_SORT_TIME, nullptr,
+		    CF_LOCATION_ROOT_USER | CF_LOCATION_ROOT_GAME | CF_LOCATION_TYPE_ROOT);
 
 		Player_select_pilot = -1;
 		idx = 0;
@@ -890,7 +892,9 @@ void player_select_init_player_stuff(int mode)
 	// load up the list of players based upon the Player_select_mode (single or multiplayer)
 	Get_file_list_filter = player_select_pilot_file_filter;
 
-	Player_select_num_pilots = cf_get_file_list_preallocated(MAX_PILOTS, Pilots_arr, Pilots, CF_TYPE_PLAYERS, NOX("*.plr"), CF_SORT_TIME);
+	Player_select_num_pilots =
+	    cf_get_file_list_preallocated(MAX_PILOTS, Pilots_arr, Pilots, CF_TYPE_PLAYERS, NOX("*.plr"), CF_SORT_TIME,
+	                                  nullptr, CF_LOCATION_ROOT_USER | CF_LOCATION_ROOT_GAME | CF_LOCATION_TYPE_ROOT);
 
 	// if we have a "last_player", and they're in the list, bash them to the top of the list
 	if (Player_select_last_pilot[0] != '\0') {

--- a/code/mission/missioncampaign.cpp
+++ b/code/mission/missioncampaign.cpp
@@ -849,7 +849,7 @@ void mission_campaign_savefile_delete( char *cfilename )
 	// only support the new filename here - taylor
 	sprintf_safe( filename, NOX("%s.%s.csg"), Player->callsign, base );
 
-	cf_delete( filename, CF_TYPE_PLAYERS );
+	cf_delete(filename, CF_TYPE_PLAYERS, CF_LOCATION_ROOT_USER | CF_LOCATION_ROOT_GAME | CF_LOCATION_TYPE_ROOT);
 }
 
 void campaign_delete_save( char *cfn, char *pname)
@@ -881,13 +881,14 @@ void mission_campaign_delete_all_savefiles(char *pilot_name)
 	// be.  I have to save any file filters
 	filter_save = Get_file_list_filter;
 	Get_file_list_filter = NULL;
-	num_files = cf_get_file_list(names, dir_type, file_spec);
+	num_files            = cf_get_file_list(names, dir_type, file_spec, CF_SORT_NONE, nullptr,
+                                 CF_LOCATION_ROOT_USER | CF_LOCATION_ROOT_GAME | CF_LOCATION_TYPE_ROOT);
 	Get_file_list_filter = filter_save;
 
 	for (i = 0; i < num_files; i++) {
 		strcpy_s(filename, names[i].c_str());
 		strcat_s(filename, ext);
-		cf_delete(filename, dir_type);
+		cf_delete(filename, dir_type, CF_LOCATION_ROOT_USER | CF_LOCATION_ROOT_GAME | CF_LOCATION_TYPE_ROOT);
 	}
 }
 

--- a/code/pilotfile/csg.cpp
+++ b/code/pilotfile/csg.cpp
@@ -1379,7 +1379,8 @@ bool pilotfile::load_savefile(const char *campaign)
 	m_data_invalid = false;
 
 	// open it, hopefully...
-	cfp = cfopen((char*)filename.c_str(), "rb", CFILE_NORMAL, CF_TYPE_PLAYERS);
+	cfp = cfopen(filename.c_str(), "rb", CFILE_NORMAL, CF_TYPE_PLAYERS, false,
+	             CF_LOCATION_ROOT_USER | CF_LOCATION_ROOT_GAME | CF_LOCATION_TYPE_ROOT);
 
 	if ( !cfp ) {
 		mprintf(("CSG => Unable to open '%s' for reading!\n", filename.c_str()));
@@ -1557,7 +1558,8 @@ bool pilotfile::save_savefile()
 	Assertion(Red_alert_wingman_status.size() <= MAX_SHIPS, "Invalid number of Red_alert_wingman_status entries: " SIZE_T_ARG "\n", Red_alert_wingman_status.size());
 
 	// open it, hopefully...
-	cfp = cfopen((char*)filename.c_str(), "wb", CFILE_NORMAL, CF_TYPE_PLAYERS);
+	cfp = cfopen(filename.c_str(), "wb", CFILE_NORMAL, CF_TYPE_PLAYERS, false,
+	             CF_LOCATION_ROOT_USER | CF_LOCATION_ROOT_GAME | CF_LOCATION_TYPE_ROOT);
 
 	if ( !cfp ) {
 		mprintf(("CSG => Unable to open '%s' for saving!\n", filename.c_str()));
@@ -1620,7 +1622,8 @@ bool pilotfile::get_csg_rank(int *rank)
 	p = &t_csg;
 
 	// filename has already been set
-	cfp = cfopen((char*)filename.c_str(), "rb", CFILE_NORMAL, CF_TYPE_PLAYERS);
+	cfp = cfopen(filename.c_str(), "rb", CFILE_NORMAL, CF_TYPE_PLAYERS, false,
+	             CF_LOCATION_ROOT_USER | CF_LOCATION_ROOT_GAME | CF_LOCATION_TYPE_ROOT);
 
 	if ( !cfp ) {
 		mprintf(("CSG => Unable to open '%s'!\n", filename.c_str()));

--- a/code/pilotfile/csg_convert.cpp
+++ b/code/pilotfile/csg_convert.cpp
@@ -1165,7 +1165,8 @@ bool pilotfile_convert::csg_convert(const char *fname, bool inferno)
 
 	filename.reserve(200);
 
-	cf_create_default_path_string(filename, CF_TYPE_SINGLE_PLAYERS, (inferno) ? "inferno" : NULL);
+	cf_create_default_path_string(filename, CF_TYPE_SINGLE_PLAYERS, (inferno) ? "inferno" : NULL, false,
+	                              CF_LOCATION_ROOT_USER | CF_LOCATION_ROOT_GAME | CF_LOCATION_TYPE_ROOT);
 
 	if (inferno) {
 		filename.append(DIR_SEPARATOR_STR);
@@ -1206,7 +1207,8 @@ bool pilotfile_convert::csg_convert(const char *fname, bool inferno)
 	filename.assign(fname);
 	filename.append(".csg");
 
-	cfp = cfopen(filename.c_str(), "wb", CFILE_NORMAL, CF_TYPE_PLAYERS);
+	cfp = cfopen(filename.c_str(), "wb", CFILE_NORMAL, CF_TYPE_PLAYERS, false,
+	             CF_LOCATION_ROOT_USER | CF_LOCATION_ROOT_GAME | CF_LOCATION_TYPE_ROOT);
 
 	if ( !cfp ) {
 		mprintf(("    CSG => Unable to open '%s' for export!\n", fname));

--- a/code/pilotfile/csg_convert.cpp
+++ b/code/pilotfile/csg_convert.cpp
@@ -1165,7 +1165,7 @@ bool pilotfile_convert::csg_convert(const char *fname, bool inferno)
 
 	filename.reserve(200);
 
-	cf_create_default_path_string(filename, CF_TYPE_SINGLE_PLAYERS, (inferno) ? "inferno" : NULL, false,
+	cf_create_default_path_string(filename, CF_TYPE_SINGLE_PLAYERS, (inferno) ? "inferno" : nullptr, false,
 	                              CF_LOCATION_ROOT_USER | CF_LOCATION_ROOT_GAME | CF_LOCATION_TYPE_ROOT);
 
 	if (inferno) {

--- a/code/pilotfile/pilotfile_convert.cpp
+++ b/code/pilotfile/pilotfile_convert.cpp
@@ -75,13 +75,16 @@ void convert_pilot_files()
 	SCP_vector<SCP_string> old_files;
 
 	// get list of pilots which already exist (new or converted already)
-	cf_get_file_list(existing, CF_TYPE_PLAYERS, "*.plr");
+	cf_get_file_list(existing, CF_TYPE_PLAYERS, "*.plr", CF_SORT_NONE, nullptr,
+	                 CF_LOCATION_ROOT_USER | CF_LOCATION_ROOT_GAME | CF_LOCATION_TYPE_ROOT);
 
 	// get list of old pilots which may need converting, starting with inferno pilots
 	Get_file_list_child = "inferno";
-	cf_get_file_list(old_files, CF_TYPE_SINGLE_PLAYERS, "*.pl2");
+	cf_get_file_list(old_files, CF_TYPE_SINGLE_PLAYERS, "*.pl2", CF_SORT_NONE, nullptr,
+	                 CF_LOCATION_ROOT_USER | CF_LOCATION_ROOT_GAME | CF_LOCATION_TYPE_ROOT);
 	inf_count = old_files.size();
-	cf_get_file_list(old_files, CF_TYPE_SINGLE_PLAYERS, "*.pl2");
+	cf_get_file_list(old_files, CF_TYPE_SINGLE_PLAYERS, "*.pl2", CF_SORT_NONE, nullptr,
+	                 CF_LOCATION_ROOT_USER | CF_LOCATION_ROOT_GAME | CF_LOCATION_TYPE_ROOT);
 
 	if ( old_files.empty() ) {
 		return;
@@ -135,7 +138,8 @@ void convert_pilot_files()
 				Get_file_list_child = "inferno";
 			}
 
-			cf_get_file_list(savefiles, CF_TYPE_SINGLE_PLAYERS, wildcard.c_str());
+			cf_get_file_list(savefiles, CF_TYPE_SINGLE_PLAYERS, wildcard.c_str(), CF_SORT_NONE, nullptr,
+			                 CF_LOCATION_ROOT_USER | CF_LOCATION_ROOT_GAME | CF_LOCATION_TYPE_ROOT);
 
 			for (j = 0; j < savefiles.size(); j++) {
 				pcon->csg_convert(savefiles[j].c_str(), inferno);

--- a/code/pilotfile/plr.cpp
+++ b/code/pilotfile/plr.cpp
@@ -820,7 +820,8 @@ bool pilotfile::load_player(const char *callsign, player *_p)
 		return false;
 	}
 
-	cfp = cfopen((char*)filename.c_str(), "rb", CFILE_NORMAL, CF_TYPE_PLAYERS);
+	cfp = cfopen(filename.c_str(), "rb", CFILE_NORMAL, CF_TYPE_PLAYERS, false,
+	             CF_LOCATION_ROOT_USER | CF_LOCATION_ROOT_GAME | CF_LOCATION_TYPE_ROOT);
 
 	if ( !cfp ) {
 		mprintf(("PLR => Unable to open '%s' for reading!\n", filename.c_str()));
@@ -985,7 +986,8 @@ bool pilotfile::save_player(player *_p)
 	}
 
 	// open it, hopefully...
-	auto fp = cfopen((char*)filename.c_str(), "wb", CFILE_NORMAL, CF_TYPE_PLAYERS);
+	auto fp = cfopen(filename.c_str(), "wb", CFILE_NORMAL, CF_TYPE_PLAYERS, false,
+	                 CF_LOCATION_ROOT_USER | CF_LOCATION_ROOT_GAME | CF_LOCATION_TYPE_ROOT);
 
 	if ( !fp ) {
 		mprintf(("PLR => Unable to open '%s' for saving!\n", filename.c_str()));
@@ -1050,7 +1052,8 @@ bool pilotfile::verify(const char *fname, int *rank, char *valid_language)
 		return false;
 	}
 
-	cfp = cfopen((char*)filename.c_str(), "rb", CFILE_NORMAL, CF_TYPE_PLAYERS);
+	cfp = cfopen(filename.c_str(), "rb", CFILE_NORMAL, CF_TYPE_PLAYERS, false,
+	             CF_LOCATION_ROOT_USER | CF_LOCATION_ROOT_GAME | CF_LOCATION_TYPE_ROOT);
 
 	if ( !cfp ) {
 		mprintf(("PLR => Unable to open '%s'!\n", filename.c_str()));

--- a/code/pilotfile/plr_convert.cpp
+++ b/code/pilotfile/plr_convert.cpp
@@ -861,7 +861,8 @@ bool pilotfile_convert::plr_convert(const char *fname, bool inferno)
 
 	filename.reserve(200);
 
-	cf_create_default_path_string(filename, CF_TYPE_SINGLE_PLAYERS, (inferno) ? "inferno" : NULL);
+	cf_create_default_path_string(filename, CF_TYPE_SINGLE_PLAYERS, (inferno) ? "inferno" : NULL, false,
+	                              CF_LOCATION_ROOT_USER | CF_LOCATION_ROOT_GAME | CF_LOCATION_TYPE_ROOT);
 
 	if (inferno) {
 		filename.append(DIR_SEPARATOR_STR);
@@ -896,7 +897,8 @@ bool pilotfile_convert::plr_convert(const char *fname, bool inferno)
 	filename.assign(fname);
 	filename.append(".plr");
 
-	cfp = cfopen(filename.c_str(), "wb", CFILE_NORMAL, CF_TYPE_PLAYERS);
+	cfp = cfopen(filename.c_str(), "wb", CFILE_NORMAL, CF_TYPE_PLAYERS, false,
+	             CF_LOCATION_ROOT_USER | CF_LOCATION_ROOT_GAME | CF_LOCATION_TYPE_ROOT);
 
 	if ( !cfp ) {
 		mprintf(("  PLR => Unable to open '%s' for export!\n", fname));

--- a/code/pilotfile/plr_convert.cpp
+++ b/code/pilotfile/plr_convert.cpp
@@ -861,7 +861,7 @@ bool pilotfile_convert::plr_convert(const char *fname, bool inferno)
 
 	filename.reserve(200);
 
-	cf_create_default_path_string(filename, CF_TYPE_SINGLE_PLAYERS, (inferno) ? "inferno" : NULL, false,
+	cf_create_default_path_string(filename, CF_TYPE_SINGLE_PLAYERS, (inferno) ? "inferno" : nullptr, false,
 	                              CF_LOCATION_ROOT_USER | CF_LOCATION_ROOT_GAME | CF_LOCATION_TYPE_ROOT);
 
 	if (inferno) {

--- a/code/playerman/managepilot.cpp
+++ b/code/playerman/managepilot.cpp
@@ -63,7 +63,8 @@ int delete_pilot_file(char *pilot_name)
 	strcpy_s( filename, basename );
 	strcat_s( filename, NOX(".plr") );
 
-	delreturn = cf_delete(filename, CF_TYPE_PLAYERS);
+	delreturn =
+	    cf_delete(filename, CF_TYPE_PLAYERS, CF_LOCATION_ROOT_USER | CF_LOCATION_ROOT_GAME | CF_LOCATION_TYPE_ROOT);
 
 	// we must try and delete the campaign save files for a pilot as well.
 	if (delreturn) {

--- a/fred2/campaigneditordlg.cpp
+++ b/fred2/campaigneditordlg.cpp
@@ -129,9 +129,6 @@ void campaign_editor::OnUpdate(CView* pSender, LPARAM lHint, CObject* pHint)
 
 void campaign_editor::OnLoad() 
 {
-	char buf[512];
-	size_t size, offset;
-
 	if (Cur_campaign_mission < 0){
 		return;
 	}
@@ -142,9 +139,11 @@ void campaign_editor::OnLoad()
 		}
 	}
 
-	cf_find_file_location(Campaign.missions[Cur_campaign_mission].name, CF_TYPE_MISSIONS, 512, buf, &size, &offset, false);
+	auto res = cf_find_file_location(Campaign.missions[Cur_campaign_mission].name, CF_TYPE_MISSIONS, false);
 
-	FREDDoc_ptr->SetPathName(buf);
+	if (res.found) {
+		FREDDoc_ptr->SetPathName(res.full_name.c_str());
+	}
 	Campaign_wnd->DestroyWindow();
 
 //		if (FREDDoc_ptr->OnOpenDocument(Campaign.missions[Cur_campaign_mission].name)) {

--- a/fred2/mainfrm.cpp
+++ b/fred2/mainfrm.cpp
@@ -83,7 +83,7 @@ CPoint Global_point2;
 /**
  * @brief Launches the default browser to open the given URL
  */
-void url_launch(char *url);
+void url_launch(const char *url);
 
 
 #ifdef _DEBUG
@@ -237,23 +237,20 @@ void CMainFrame::OnFileMissionnotes() {
 }
 
 void CMainFrame::OnFredHelp() {
-	char buffer[_MAX_PATH];
-
-	size_t size;
-	size_t offset;
-	if (!cf_find_file_location("index.html", CF_TYPE_FREDDOCS, _MAX_PATH, buffer, &size, &offset)) {
+	auto res = cf_find_file_location("index.html", CF_TYPE_FREDDOCS);
+	if (!res.found) {
 		ReleaseWarning(LOCATION, "Could not find FRED help files!");
 		return;
 	}
 
-	if (offset != 0) {
+	if (res.offset != 0) {
 		// We need an actual file location so VP files are not valid
 		Error(LOCATION, "The FRED documentation was found in a pack (VP) file. This is not valid!");
 		return;
 	}
 
 	// shell_open url
-	url_launch(buffer);
+	url_launch(res.full_name.c_str());
 }
 
 void CMainFrame::OnHelpInputInterface() {
@@ -491,7 +488,7 @@ int color_combo_box::SetCurSelNEW(int model_index) {
 }
 
 
-void url_launch(char *url) {
+void url_launch(const char *url) {
 	int r;
 
 	r = (int) ShellExecute(NULL, "open", url, NULL, NULL, SW_SHOW);

--- a/qtfred/src/mission/Editor.cpp
+++ b/qtfred/src/mission/Editor.cpp
@@ -140,14 +140,13 @@ bool Editor::loadMission(const std::string& mission_name, int flags) {
 	clearMission();
 
 	std::string filepath = mission_name;
-	char fullpath[MAX_PATH_LEN];
-	size_t pack_offset;
-	if (cf_find_file_location(filepath.c_str(), CF_TYPE_MISSIONS, sizeof(fullpath) - 1, fullpath, nullptr, &pack_offset)) {
+	auto res = cf_find_file_location(filepath.c_str(), CF_TYPE_MISSIONS);
+	if (res.found) {
 		// We found this file in the CFile system
-		if (pack_offset == 0) {
+		if (res.offset == 0) {
 			// This is a "real" file. Since we now have an absolute path we can use that to make sure we only deal with
 			// absolute paths which makes sure that the "recent mission" menu has correct file names
-			filepath = fullpath;
+			filepath = res.full_name;
 		}
 	}
 

--- a/test/src/cfile/cfile.cpp
+++ b/test/src/cfile/cfile.cpp
@@ -1,6 +1,7 @@
 
-#include <gtest/gtest.h>
+#include <cfile/cfilesystem.h>
 #include <graphics/font.h>
+#include <gtest/gtest.h>
 
 #include "util/FSTestFixture.h"
 
@@ -111,4 +112,18 @@ TEST_F(CFileTest, override_default_file) {
 	ASSERT_EQ(66, cfilelength(fp));
 
 	cfclose(fp);
+}
+
+TEST(CFileStandalone, test_check_location_flags)
+{
+	ASSERT_FALSE(cf_check_location_flags(CF_LOCATION_ROOT_GAME | CF_LOCATION_TYPE_ROOT, CF_LOCATION_ROOT_USER));
+	ASSERT_TRUE(cf_check_location_flags(CF_LOCATION_ROOT_GAME | CF_LOCATION_TYPE_ROOT, CF_LOCATION_ROOT_GAME));
+	ASSERT_TRUE(cf_check_location_flags(CF_LOCATION_ROOT_GAME | CF_LOCATION_TYPE_ROOT, CF_LOCATION_TYPE_ROOT));
+	ASSERT_FALSE(cf_check_location_flags(CF_LOCATION_ROOT_GAME | CF_LOCATION_TYPE_ROOT, CF_LOCATION_TYPE_PRIMARY_MOD));
+	ASSERT_FALSE(
+	    cf_check_location_flags(CF_LOCATION_ROOT_GAME | CF_LOCATION_TYPE_ROOT, CF_LOCATION_TYPE_SECONDARY_MODS));
+	ASSERT_FALSE(cf_check_location_flags(CF_LOCATION_ROOT_GAME | CF_LOCATION_TYPE_ROOT,
+	                                     CF_LOCATION_ROOT_GAME | CF_LOCATION_TYPE_PRIMARY_MOD));
+	ASSERT_TRUE(cf_check_location_flags(CF_LOCATION_ROOT_GAME | CF_LOCATION_TYPE_ROOT,
+	                                    CF_LOCATION_ROOT_GAME | CF_LOCATION_TYPE_ROOT));
 }


### PR DESCRIPTION
Some usages of CFile require that operations only operate on a specific set of files instead of operating on the entire CFile system. This was already hacked-in for the player files which need to be in the root directory instead of in the mod directory.

With these changes that hack could be removed and replaced. This also allows moving the shader cache from a per-mod cache to a global cache in the top-level user directory (which was actually the reason why I began working on this).