### PR TITLE
Write newline after mission notes

### DIFF
--- a/fred2/missionsave.cpp
+++ b/fred2/missionsave.cpp
@@ -2165,7 +2165,7 @@ int CFred_mission_save::save_mission_info() {
 
 	required_string_fred("$Notes:");
 	parse_comments();
-	fout("\n%s", The_mission.notes);
+	fout("\n%s\n", The_mission.notes);
 
 	required_string_fred("$End Notes:");
 	parse_comments(0);

--- a/qtfred/src/mission/missionsave.cpp
+++ b/qtfred/src/mission/missionsave.cpp
@@ -1995,7 +1995,7 @@ int CFred_mission_save::save_mission_info() {
 
 	required_string_fred("$Notes:");
 	parse_comments();
-	fout("\n%s", The_mission.notes);
+	fout("\n%s\n", The_mission.notes);
 
 	required_string_fred("$End Notes:");
 	parse_comments(0);


### PR DESCRIPTION
This solves #1802 by always writing a newline after the mission notes and before `$End Notes:`, to ensure that `$End Notes:` won't be parsed as a comment.