### PR TITLE
Fix crash on game shutdown if Lua object callbacks are used

### DIFF
--- a/code/object/object.cpp
+++ b/code/object/object.cpp
@@ -359,6 +359,13 @@ void obj_init()
 	}
 }
 
+void obj_shutdown()
+{
+	for (auto& obj : Objects) {
+		obj.clear();
+	}
+}
+
 static int num_objects_hwm = 0;
 
 /** 

--- a/code/object/object.h
+++ b/code/object/object.h
@@ -224,6 +224,8 @@ extern object *Player_obj;	// Which object is the player. Has to be valid.
 //do whatever setup needs to be done
 void obj_init();
 
+void obj_shutdown();
+
 //initialize a new object.  adds to the list for the given segment.
 //returns the object number.  The object will be a non-rendering, non-physics
 //object.  Returns 0 if failed, otherwise object index.

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -6907,6 +6907,8 @@ void game_shutdown(void)
 	gamesnd_close();		// close out gamesnd, needs to happen *after* other sounds are closed
 	psnet_close();
 
+	obj_shutdown();
+
 	model_free_all();
 	bm_unload_all();			// unload/free bitmaps, has to be called *after* model_free_all()!
 


### PR DESCRIPTION
The `Objects` array is destroyed when the game exits at which point the Lua state object which was used by the callbacks doesn't exist anymore. This causes a crash since the event code tries to deallocate the Lua function reference with an invalid Lua state pointer.

This fixes that by clearing all object array elements when the game closes, before the Lua state is destroyed.