### PR TITLE
Improve parsing of mission info text fields

### DIFF
--- a/fred2/customwingnames.cpp
+++ b/fred2/customwingnames.cpp
@@ -5,6 +5,7 @@
 #include "fred.h"
 #include "CustomWingNames.h"
 #include "ship/ship.h"
+#include "management.h"
 
 #ifdef _DEBUG
 #undef THIS_FILE
@@ -86,6 +87,19 @@ void CustomWingNames::OnOK()
 {
 	UpdateData(TRUE);
 
+	strip_quotation_marks(m_starting_1);
+	strip_quotation_marks(m_starting_2);
+	strip_quotation_marks(m_starting_3);
+
+	strip_quotation_marks(m_squadron_1);
+	strip_quotation_marks(m_squadron_2);
+	strip_quotation_marks(m_squadron_3);
+	strip_quotation_marks(m_squadron_4);
+	strip_quotation_marks(m_squadron_5);
+
+	strip_quotation_marks(m_tvt_1);
+	strip_quotation_marks(m_tvt_2);
+
 	if (strcmp(m_starting_1, m_tvt_1))
 	{
 		MessageBox("The first starting wing and the first team-versus-team wing must have the same wing name.");
@@ -113,7 +127,6 @@ void CustomWingNames::OnOK()
 		MessageBox("Duplicate wing names in team-versus-team wing list.");
 		return;
 	}
-
 
 	// copy starting wings
 	strcpy_s(Starting_wing_names[0], m_starting_1);

--- a/fred2/management.cpp
+++ b/fred2/management.cpp
@@ -205,6 +205,18 @@ void deconvert_multiline_string(SCP_string &dest, const CString &str)
 	replace_all(dest, "\r\n", "\n");
 }
 
+void strip_quotation_marks(CString& str) { str.Remove('\"'); }
+
+void pad_with_newline(CString& str, int max_size) {
+	int len = str.GetLength();
+	if (!len) {
+		len = 1;
+	}
+	if (str[len - 1] != '\n' && len < max_size) {
+		str += _T("\n");
+	}
+}
+
 // medal_stuff Medals[NUM_MEDALS];
 /*
 void parse_medal_tbl()

--- a/fred2/management.h
+++ b/fred2/management.h
@@ -1,34 +1,31 @@
 /*
  * Copyright (C) Volition, Inc. 1999.  All rights reserved.
  *
- * All source code herein is the property of Volition, Inc. You may not sell 
- * or otherwise commercially exploit the source or things you created based on the 
+ * All source code herein is the property of Volition, Inc. You may not sell
+ * or otherwise commercially exploit the source or things you created based on the
  * source.
  *
-*/
-
-
+ */
 
 #ifndef __MANAGEMENT_H__
 #define __MANAGEMENT_H__
 
-#include <afxmt.h>
-#include "globalincs/pstypes.h"
-#include "ship/ship.h"
 #include "ai/aigoals.h"
+#include "globalincs/pstypes.h"
 #include "jumpnode/jumpnode.h"
+#include "ship/ship.h"
+#include <afxmt.h>
 
-
-#define SHIP_FILTER_PLAYERS	(1<<0)  // set: add players to list as well
-#define SHIP_FILTER_FLYABLE	(1<<1)  // set: filter out non-flyable ships
+#define SHIP_FILTER_PLAYERS (1 << 0) // set: add players to list as well
+#define SHIP_FILTER_FLYABLE (1 << 1) // set: filter out non-flyable ships
 
 extern int cur_object_index;
 extern int cur_ship;
 extern int cur_wing;
 extern int cur_wing_index;
 extern int cur_model_index;
-extern waypoint *cur_waypoint;
-extern waypoint_list *cur_waypoint_list;
+extern waypoint* cur_waypoint;
+extern waypoint_list* cur_waypoint_list;
 extern int Update_ship;
 extern int Update_wing;
 
@@ -36,12 +33,12 @@ extern ai_goal_list Ai_goal_list[];
 extern int Ai_goal_list_size;
 
 // alternate ship name and callsign stuff
-extern char Fred_alt_names[MAX_SHIPS][NAME_LENGTH+1];
-extern char Fred_callsigns[MAX_SHIPS][NAME_LENGTH+1];
+extern char Fred_alt_names[MAX_SHIPS][NAME_LENGTH + 1];
+extern char Fred_callsigns[MAX_SHIPS][NAME_LENGTH + 1];
 
-extern int	wing_objects[MAX_WINGS][MAX_SHIPS_PER_WING];
+extern int wing_objects[MAX_WINGS][MAX_SHIPS_PER_WING];
 
-extern char	*Docking_bay_list[];
+extern char* Docking_bay_list[];
 
 extern char Fred_exe_dir[512];
 extern char Fred_base_dir[512];
@@ -62,85 +59,87 @@ extern bool Show_iff[];
 
 extern CCriticalSection CS_cur_object_index;
 
-void	string_copy(char *dest, const CString &src, size_t max_len, int modify = 0);
-void	string_copy(SCP_string &dest, const CString &src, int modify = 0);
-void	convert_multiline_string(CString &dest, const SCP_string &src);
-void	convert_multiline_string(CString &dest, const char *src);
-void	deconvert_multiline_string(char *dest, const CString &str, int max_len);
-void	deconvert_multiline_string(SCP_string &dest, const CString &str);
+void string_copy(char* dest, const CString& src, size_t max_len, int modify = 0);
+void string_copy(SCP_string& dest, const CString& src, int modify = 0);
+void convert_multiline_string(CString& dest, const SCP_string& src);
+void convert_multiline_string(CString& dest, const char* src);
+void deconvert_multiline_string(char* dest, const CString& str, int max_len);
+void deconvert_multiline_string(SCP_string& dest, const CString& str);
+void strip_quotation_marks(CString& str);
+void pad_with_newline(CString& str, int max_size);
 
-bool	fred_init(std::unique_ptr<os::GraphicsOperations>&& graphicsOps);
-void	set_physics_controls();
-int	dup_object(object *objp);
-int	create_object_on_grid(int waypoint_instance = -1);
-int	create_object(vec3d *pos, int waypoint_instance = -1);
-int	create_player(int num, vec3d *pos, matrix *orient, int type = -1, int init = 1);
-void	create_new_mission();
-void	reset_mission();
-void	clear_mission();
-int	query_valid_object(int index = cur_object_index);
-int	query_valid_ship(int index = cur_object_index);
-int	query_valid_waypoint(int index = cur_object_index);
-void	set_cur_indices(int obj = -1);
-void	set_cur_object_index(int obj = -1);
-int	delete_object(int obj);
-int	delete_object(object *ptr);
-int	delete_ship(int ship);
-void	delete_marked();
-void	delete_reinforcement(int num);
-int	delete_ship_from_wing(int ship = cur_ship);
-int	find_free_wing();
-int	query_object_in_wing(int obj = cur_object_index);
-void	mark_object(int obj);
-void	unmark_object(int obj);
-void	unmark_all();
-void	clear_menu(CMenu *ptr);
-void	generate_wing_popup_menu(CMenu *mptr, int first_id, int state);
-void	generate_ship_popup_menu(CMenu *mptr, int first_id, int state, int filter = 0);
-int	string_lookup(const CString &str1, char *strlist[], int max);
-int	update_dialog_boxes();
-void	set_cur_wing(int wing);
-int	gray_menu_tree(CMenu *base);
-int	query_initial_orders_conflict(int wing);
-int	query_initial_orders_empty(ai_goal *ai_goals);
-int	set_reinforcement(char *name, int state);
-int	get_docking_list(int model_index);
-int	rename_ship(int ship, char *name);
-void	fix_ship_name(int ship);
-int	internal_integrity_check();
-void	correct_marking();
-int	get_ship_from_obj(int obj);
-int	get_ship_from_obj(object *objp);
-void	set_valid_dock_points(int ship, int type, CComboBox *box);
-void	ai_update_goal_references(int type, const char *old_name, const char *new_name);
-int	query_referenced_in_ai_goals(int type, const char *name);
-int	advanced_stricmp(char *one, char *two);
-int	reference_handler(char *name, int type, int obj);
-int	orders_reference_handler(int code, char *msg);
-int	sexp_reference_handler(int node, int code, char *msg);
-char	*object_name(int obj);
+bool fred_init(std::unique_ptr<os::GraphicsOperations>&& graphicsOps);
+void set_physics_controls();
+int dup_object(object* objp);
+int create_object_on_grid(int waypoint_instance = -1);
+int create_object(vec3d* pos, int waypoint_instance = -1);
+int create_player(int num, vec3d* pos, matrix* orient, int type = -1, int init = 1);
+void create_new_mission();
+void reset_mission();
+void clear_mission();
+int query_valid_object(int index = cur_object_index);
+int query_valid_ship(int index = cur_object_index);
+int query_valid_waypoint(int index = cur_object_index);
+void set_cur_indices(int obj = -1);
+void set_cur_object_index(int obj = -1);
+int delete_object(int obj);
+int delete_object(object* ptr);
+int delete_ship(int ship);
+void delete_marked();
+void delete_reinforcement(int num);
+int delete_ship_from_wing(int ship = cur_ship);
+int find_free_wing();
+int query_object_in_wing(int obj = cur_object_index);
+void mark_object(int obj);
+void unmark_object(int obj);
+void unmark_all();
+void clear_menu(CMenu* ptr);
+void generate_wing_popup_menu(CMenu* mptr, int first_id, int state);
+void generate_ship_popup_menu(CMenu* mptr, int first_id, int state, int filter = 0);
+int string_lookup(const CString& str1, char* strlist[], int max);
+int update_dialog_boxes();
+void set_cur_wing(int wing);
+int gray_menu_tree(CMenu* base);
+int query_initial_orders_conflict(int wing);
+int query_initial_orders_empty(ai_goal* ai_goals);
+int set_reinforcement(char* name, int state);
+int get_docking_list(int model_index);
+int rename_ship(int ship, char* name);
+void fix_ship_name(int ship);
+int internal_integrity_check();
+void correct_marking();
+int get_ship_from_obj(int obj);
+int get_ship_from_obj(object* objp);
+void set_valid_dock_points(int ship, int type, CComboBox* box);
+void ai_update_goal_references(int type, const char* old_name, const char* new_name);
+int query_referenced_in_ai_goals(int type, const char* name);
+int advanced_stricmp(char* one, char* two);
+int reference_handler(char* name, int type, int obj);
+int orders_reference_handler(int code, char* msg);
+int sexp_reference_handler(int node, int code, char* msg);
+char* object_name(int obj);
 const char* get_order_name(int order);
-void	object_moved(object *ptr);
-int	invalidate_references(char *name, int type);
-int	query_whole_wing_marked(int wing);
-void	generate_weaponry_usage_list(int team, int *arr);
-void	generate_weaponry_usage_list(int *arr, int wing);
-void	generate_ship_usage_list(int *arr, int wing);
+void object_moved(object* ptr);
+int invalidate_references(char* name, int type);
+int query_whole_wing_marked(int wing);
+void generate_weaponry_usage_list(int team, int* arr);
+void generate_weaponry_usage_list(int* arr, int wing);
+void generate_ship_usage_list(int* arr, int wing);
 
-CJumpNode *jumpnode_get_by_name(const CString& name);
+CJumpNode* jumpnode_get_by_name(const CString& name);
 
 // function and defines to use when adding ships to combo boxes
-#define SHIPS_2_COMBO_SPECIAL					(1<<0)
-#define SHIPS_2_COMBO_ALL_SHIPS				(1<<1)
-#define SHIPS_2_COMBO_DOCKING_BAY_ONLY		(1<<2)
+#define SHIPS_2_COMBO_SPECIAL (1 << 0)
+#define SHIPS_2_COMBO_ALL_SHIPS (1 << 1)
+#define SHIPS_2_COMBO_DOCKING_BAY_ONLY (1 << 2)
 
-extern void management_add_ships_to_combo( CComboBox *box, int flags );
+extern void management_add_ships_to_combo(CComboBox* box, int flags);
 
 // Goober5000
 extern int wing_is_player_wing(int wing);
 extern void update_custom_wing_indexes();
-extern void stuff_special_arrival_anchor_name(char *buf, int iff_index, int restrict_to_players, int retail_format);
-extern void stuff_special_arrival_anchor_name(char *buf, int anchor_num, int retail_format);
-extern void update_texture_replacements(const char *old_name, const char *new_name);
+extern void stuff_special_arrival_anchor_name(char* buf, int iff_index, int restrict_to_players, int retail_format);
+extern void stuff_special_arrival_anchor_name(char* buf, int anchor_num, int retail_format);
+extern void update_texture_replacements(const char* old_name, const char* new_name);
 
 #endif

--- a/fred2/missionnotesdlg.cpp
+++ b/fred2/missionnotesdlg.cpp
@@ -296,6 +296,18 @@ void CMissionNotesDlg::OnOK()
 		set_modified();
 	}
 
+	//if there's a odd number of quotation marks, the mission won't parse
+	//If there are an even number, nothing after the first one appears
+	//So just get rid of them
+	strip_quotation_marks(m_mission_title);
+	strip_quotation_marks(m_designer_name);
+	strip_quotation_marks(m_mission_notes);
+	strip_quotation_marks(m_mission_desc);
+	strip_quotation_marks(m_squad_name);
+
+	// puts "$End Notes:" on a different line to ensure it's not interpreted as part of a comment
+	pad_with_newline(m_mission_notes, NOTES_LENGTH - 1);
+
 	string_copy(The_mission.name, m_mission_title, NAME_LENGTH, 1);
 	string_copy(The_mission.author, m_designer_name, NAME_LENGTH, 1);
 	string_copy(The_mission.loading_screen[GR_640], m_loading_640, NAME_LENGTH,1);

--- a/fred2/missionsave.cpp
+++ b/fred2/missionsave.cpp
@@ -2165,7 +2165,7 @@ int CFred_mission_save::save_mission_info() {
 
 	required_string_fred("$Notes:");
 	parse_comments();
-	fout("\n%s\n", The_mission.notes);
+	fout("\n%s", The_mission.notes);
 
 	required_string_fred("$End Notes:");
 	parse_comments(0);

--- a/qtfred/src/mission/Editor.cpp
+++ b/qtfred/src/mission/Editor.cpp
@@ -3190,7 +3190,7 @@ void Editor::strip_quotation_marks(SCP_string& str) {
 	}
 }
 
-void Editor::pad_with_newline(SCP_string& str, int max_size) {
+void Editor::pad_with_newline(SCP_string& str, SCP_string::size_type max_size) {
 	if (str.back() != '\n' && str.size() < max_size) {
 		str += "\n";
 	}

--- a/qtfred/src/mission/Editor.cpp
+++ b/qtfred/src/mission/Editor.cpp
@@ -1,47 +1,46 @@
 #include "Editor.h"
 
 #include <array>
-#include <clocale>
-#include <stdexcept>
 #include <vector>
+#include <stdexcept>
+#include <clocale>
 
 #include <SDL.h>
-#include <ai/aigoals.h>
-#include <asteroid/asteroid.h>
-#include <gamesnd/eventmusic.h>
-#include <jumpnode/jumpnode.h>
-#include <localization/fhash.h>
-#include <mission/missiongoals.h>
-#include <mission/missionmessage.h>
-#include <missionui/fictionviewer.h>
-#include <object/objectdock.h>
-#include <parse/parselo.h>
 #include <sound/audiostr.h>
-#include <starfield/nebula.h>
+#include <parse/parselo.h>
+#include <missionui/fictionviewer.h>
+#include <mission/missiongoals.h>
+#include <asteroid/asteroid.h>
+#include <jumpnode/jumpnode.h>
 #include <util.h>
+#include <mission/missionmessage.h>
+#include <gamesnd/eventmusic.h>
+#include <starfield/nebula.h>
+#include <object/objectdock.h>
+#include <ai/aigoals.h>
+#include <localization/fhash.h>
 
-#include "globalincs/linklist.h"
-#include "hud/hudsquadmsg.h"
-#include "iff_defs/iff_defs.h"         // iff_init
-#include "nebula/neb.h"                // neb2_init
-#include "object/object.h"             // obj_init
+#include "iff_defs/iff_defs.h" // iff_init
+#include "object/object.h" // obj_init
 #include "species_defs/species_defs.h" // species_init
-#include "starfield/starfield.h"       // stars_init, stars_pre_level_init, stars_post_level_init
-#include "weapon/weapon.h"             // weapon_init
+#include "weapon/weapon.h" // weapon_init
+#include "nebula/neb.h" // neb2_init
+#include "starfield/starfield.h" // stars_init, stars_pre_level_init, stars_post_level_init
+#include "hud/hudsquadmsg.h"
+#include "globalincs/linklist.h"
 
 #include "ui/QtGraphicsOperations.h"
 
-#include "FredApplication.h"
-#include "management.h"
 #include "object.h"
+#include "management.h"
+#include "FredApplication.h"
 
 namespace {
 
-int query_referenced_in_ai_goals(int type, const char* name)
-{
+int query_referenced_in_ai_goals(int type, const char* name) {
 	int i;
 
-	for (i = 0; i < MAX_AI_INFO; i++) { // loop through all Ai_info entries
+	for (i = 0; i < MAX_AI_INFO; i++) {  // loop through all Ai_info entries
 		if (Ai_info[i].shipnum >= 0) {  // skip if unused
 			if (query_referenced_in_ai_goals(Ai_info[i].goals, type, name)) {
 				return Ai_info[i].shipnum | SRC_SHIP_ORDER;
@@ -61,30 +60,31 @@ int query_referenced_in_ai_goals(int type, const char* name)
 }
 
 // Used in the FRED drop-down menu and in error_check_initial_orders
-// NOTE: Certain goals (Form On Wing, Rearm, Chase Weapon, Fly To Ship) aren't listed here.  This may or may not be
-// intentional, but if they are added in the future, it will be necessary to verify correct functionality in the various
-// FRED dialog functions.
-ai_goal_list Ai_goal_list[] = {{"Waypoints", AI_GOAL_WAYPOINTS, 0},
-                               {"Waypoints once", AI_GOAL_WAYPOINTS_ONCE, 0},
-                               {"Attack", AI_GOAL_CHASE | AI_GOAL_CHASE_WING, 0},
-                               {"Attack any ship", AI_GOAL_CHASE_ANY, 0},
-                               {"Attack ship class", AI_GOAL_CHASE_SHIP_CLASS, 0},
-                               {"Guard", AI_GOAL_GUARD | AI_GOAL_GUARD_WING, 0},
-                               {"Disable ship", AI_GOAL_DISABLE_SHIP, 0},
-                               {"Disarm ship", AI_GOAL_DISARM_SHIP, 0},
-                               {"Destroy subsystem", AI_GOAL_DESTROY_SUBSYSTEM, 0},
-                               {"Dock", AI_GOAL_DOCK, 0},
-                               {"Undock", AI_GOAL_UNDOCK, 0},
-                               {"Warp", AI_GOAL_WARP, 0},
-                               {"Evade ship", AI_GOAL_EVADE_SHIP, 0},
-                               {"Ignore ship", AI_GOAL_IGNORE, 0},
-                               {"Ignore ship (new)", AI_GOAL_IGNORE_NEW, 0},
-                               {"Stay near ship", AI_GOAL_STAY_NEAR_SHIP, 0},
-                               {"Keep safe distance", AI_GOAL_KEEP_SAFE_DISTANCE, 0},
-                               {"Stay still", AI_GOAL_STAY_STILL, 0},
-                               {"Play dead", AI_GOAL_PLAY_DEAD, 0}};
+// NOTE: Certain goals (Form On Wing, Rearm, Chase Weapon, Fly To Ship) aren't listed here.  This may or may not be intentional,
+// but if they are added in the future, it will be necessary to verify correct functionality in the various FRED dialog functions.
+ai_goal_list Ai_goal_list[] = {
+	{ "Waypoints",				AI_GOAL_WAYPOINTS,			0 },
+	{ "Waypoints once",			AI_GOAL_WAYPOINTS_ONCE,		0 },
+	{ "Attack",					AI_GOAL_CHASE | AI_GOAL_CHASE_WING,	0 },
+	{ "Attack any ship",		AI_GOAL_CHASE_ANY,			0 },
+	{ "Attack ship class",		AI_GOAL_CHASE_SHIP_CLASS,	0 },
+	{ "Guard",					AI_GOAL_GUARD | AI_GOAL_GUARD_WING, 0 },
+	{ "Disable ship",			AI_GOAL_DISABLE_SHIP,		0 },
+	{ "Disarm ship",			AI_GOAL_DISARM_SHIP,		0 },
+	{ "Destroy subsystem",		AI_GOAL_DESTROY_SUBSYSTEM,	0 },
+	{ "Dock",					AI_GOAL_DOCK,				0 },
+	{ "Undock",					AI_GOAL_UNDOCK,				0 },
+	{ "Warp",					AI_GOAL_WARP,				0 },
+	{ "Evade ship",				AI_GOAL_EVADE_SHIP,			0 },
+	{ "Ignore ship",			AI_GOAL_IGNORE,				0 },
+	{ "Ignore ship (new)",		AI_GOAL_IGNORE_NEW,			0 },
+	{ "Stay near ship",			AI_GOAL_STAY_NEAR_SHIP,		0 },
+	{ "Keep safe distance",		AI_GOAL_KEEP_SAFE_DISTANCE,	0 },
+	{ "Stay still",				AI_GOAL_STAY_STILL,			0 },
+	{ "Play dead",				AI_GOAL_PLAY_DEAD,			0 }
+};
 
-} // namespace
+}
 
 char Fred_callsigns[MAX_SHIPS][NAME_LENGTH + 1];
 char Fred_alt_names[MAX_SHIPS][NAME_LENGTH + 1];
@@ -98,9 +98,8 @@ extern int Nmodel_bitmap;
 
 namespace fso {
 namespace fred {
-
-Editor::Editor() : currentObject{-1}, Shield_sys_teams(MAX_IFFS, 0), Shield_sys_types(MAX_SHIP_CLASSES, 0)
-{
+	
+Editor::Editor() : currentObject{ -1 }, Shield_sys_teams(MAX_IFFS, 0), Shield_sys_types(MAX_SHIP_CLASSES, 0) {
 	connect(fredApp, &FredApplication::onIdle, this, &Editor::update);
 
 	// When the mission changes we need to update all renderers
@@ -112,8 +111,7 @@ Editor::Editor() : currentObject{-1}, Shield_sys_teams(MAX_IFFS, 0), Shield_sys_
 	fredApp->runAfterInit([this]() { initialSetup(); });
 }
 
-EditorViewport* Editor::createEditorViewport(os::Viewport* renderView)
-{
+EditorViewport* Editor::createEditorViewport(os::Viewport* renderView) {
 	std::unique_ptr<FredRenderer> renderer(new FredRenderer(renderView));
 	std::unique_ptr<EditorViewport> viewport(new EditorViewport(this, std::move(renderer)));
 
@@ -123,17 +121,15 @@ EditorViewport* Editor::createEditorViewport(os::Viewport* renderView)
 	return ptr;
 }
 
-void Editor::update()
-{
+void Editor::update() {
 	// Do updates for all renderers
 	for (auto& viewport : _viewports) {
 		viewport->game_do_frame(currentObject);
 	}
 }
 
-bool Editor::loadMission(const std::string& mission_name, int flags)
-{
-	char name[512], *old_name;
+bool Editor::loadMission(const std::string& mission_name, int flags) {
+	char name[512], * old_name;
 	int i, j, k, ob;
 	int used_pool[MAX_WEAPON_TYPES];
 	object* objp;
@@ -146,8 +142,7 @@ bool Editor::loadMission(const std::string& mission_name, int flags)
 	std::string filepath = mission_name;
 	char fullpath[MAX_PATH_LEN];
 	size_t pack_offset;
-	if (cf_find_file_location(filepath.c_str(), CF_TYPE_MISSIONS, sizeof(fullpath) - 1, fullpath, nullptr,
-	                          &pack_offset)) {
+	if (cf_find_file_location(filepath.c_str(), CF_TYPE_MISSIONS, sizeof(fullpath) - 1, fullpath, nullptr, &pack_offset)) {
 		// We found this file in the CFile system
 		if (pack_offset == 0) {
 			// This is a "real" file. Since we now have an absolute path we can use that to make sure we only deal with
@@ -161,13 +156,17 @@ bool Editor::loadMission(const std::string& mission_name, int flags)
 			SCP_string msg;
 			sprintf(msg, "Unable to import the file \"%s\".", filepath.c_str());
 
-			_lastActiveViewport->dialogProvider->showButtonDialog(DialogType::Error, "Load Error", msg,
-			                                                      {DialogButton::Ok});
+			_lastActiveViewport->dialogProvider->showButtonDialog(DialogType::Error,
+																  "Load Error",
+																  msg,
+																  { DialogButton::Ok });
 		} else {
 			SCP_string msg;
 			sprintf(msg, "Unable to load the file \"%s\".", filepath.c_str());
-			_lastActiveViewport->dialogProvider->showButtonDialog(DialogType::Error, "Load Error", msg,
-			                                                      {DialogButton::Ok});
+			_lastActiveViewport->dialogProvider->showButtonDialog(DialogType::Error,
+																  "Load Error",
+																  msg,
+																  { DialogButton::Ok });
 		}
 		createNewMission();
 
@@ -178,18 +177,19 @@ bool Editor::loadMission(const std::string& mission_name, int flags)
 		if (flags & MPF_IMPORT_FSM) {
 			SCP_string msg;
 			sprintf(msg,
-			        "Fred encountered unknown ship/weapon classes when importing \"%s\" (path \"%s\"). You will have "
-			        "to manually edit the converted mission to correct this.",
-			        The_mission.name, filepath.c_str());
+					"Fred encountered unknown ship/weapon classes when importing \"%s\" (path \"%s\"). You will have to manually edit the converted mission to correct this.",
+					The_mission.name,
+					filepath.c_str());
 
-			_lastActiveViewport->dialogProvider->showButtonDialog(DialogType::Warning, "Unknown Ship classes", msg,
-			                                                      {DialogButton::Ok});
+			_lastActiveViewport->dialogProvider->showButtonDialog(DialogType::Warning,
+																  "Unknown Ship classes",
+																  msg,
+																  { DialogButton::Ok });
 		} else {
-			_lastActiveViewport->dialogProvider->showButtonDialog(DialogType::Warning, "Unknown Ship classes",
-			                                                      "Fred encountered unknown ship/weapon classes when "
-			                                                      "parsing the mission file. This may be due to "
-			                                                      "mission disk data you do not have.",
-			                                                      {DialogButton::Ok});
+			_lastActiveViewport->dialogProvider->showButtonDialog(DialogType::Warning,
+																  "Unknown Ship classes",
+																  "Fred encountered unknown ship/weapon classes when parsing the mission file. This may be due to mission disk data you do not have.",
+																  { DialogButton::Ok });
 		}
 	}
 
@@ -207,19 +207,19 @@ bool Editor::loadMission(const std::string& mission_name, int flags)
 
 	for (i = 0; i < Num_wings; i++) {
 		for (j = 0; j < Wings[i].wave_count; j++) {
-			ob                                        = Ships[Wings[i].ship_index[j]].objnum;
-			wing_objects[i][j]                        = ob;
-			Ships[Wings[i].ship_index[j]].wingnum     = i;
+			ob = Ships[Wings[i].ship_index[j]].objnum;
+			wing_objects[i][j] = ob;
+			Ships[Wings[i].ship_index[j]].wingnum = i;
 			Ships[Wings[i].ship_index[j]].arrival_cue = Locked_sexp_false;
 		}
 
 		// fix old ship names for ships in wings if needed
 		while (j--) {
-			if ((Objects[wing_objects[i][j]].type == OBJ_SHIP) ||
-			    (Objects[wing_objects[i][j]].type == OBJ_START)) { // don't change player ship names
+			if ((Objects[wing_objects[i][j]].type == OBJ_SHIP)
+				|| (Objects[wing_objects[i][j]].type == OBJ_START)) {  // don't change player ship names
 				wing_bash_ship_name(name, Wings[i].name, j + 1);
 				old_name = Ships[Wings[i].ship_index[j]].ship_name;
-				if (stricmp(name, old_name) != 0) { // need to fix name
+				if (stricmp(name, old_name) != 0) {  // need to fix name
 					update_sexp_references(old_name, name);
 					ai_update_goal_references(REF_TYPE_SHIP, old_name, name);
 					update_texture_replacements(old_name, name);
@@ -239,10 +239,9 @@ bool Editor::loadMission(const std::string& mission_name, int flags)
 	for (i = 0; i < Num_teams; i++) {
 		generate_team_weaponry_usage_list(i, used_pool);
 		for (j = 0; j < Team_data[i].num_weapon_choices; j++) {
-			// The amount used in wings is always set by a static loadout entry so skip any that were set by Sexp
-			// variables
-			if ((!strlen(Team_data[i].weaponry_pool_variable[j])) &&
-			    (!strlen(Team_data[i].weaponry_amount_variable[j]))) {
+			// The amount used in wings is always set by a static loadout entry so skip any that were set by Sexp variables
+			if ((!strlen(Team_data[i].weaponry_pool_variable[j]))
+				&& (!strlen(Team_data[i].weaponry_amount_variable[j]))) {
 				// convert weaponry_pool to be extras available beyond the current ships weapons
 				Team_data[i].weaponry_count[j] -= used_pool[Team_data[i].weaponry_pool[j]];
 				if (Team_data[i].weaponry_count[j] < 0) {
@@ -256,11 +255,13 @@ bool Editor::loadMission(const std::string& mission_name, int flags)
 		// double check the used pool is empty
 		for (j = 0; j < MAX_WEAPON_TYPES; j++) {
 			if (used_pool[j] != 0) {
-				Warning(LOCATION, "%s is used in wings of team %d but was not in the loadout. Fixing now",
-				        Weapon_info[j].name, i + 1);
+				Warning(LOCATION,
+						"%s is used in wings of team %d but was not in the loadout. Fixing now",
+						Weapon_info[j].name,
+						i + 1);
 
 				// add the weapon as a new entry
-				Team_data[i].weaponry_pool[Team_data[i].num_weapon_choices]  = j;
+				Team_data[i].weaponry_pool[Team_data[i].num_weapon_choices] = j;
 				Team_data[i].weaponry_count[Team_data[i].num_weapon_choices] = used_pool[j];
 				strcpy_s(Team_data[i].weaponry_amount_variable[Team_data[i].num_weapon_choices], "");
 				strcpy_s(Team_data[i].weaponry_pool_variable[Team_data[i].num_weapon_choices++], "");
@@ -285,7 +286,7 @@ bool Editor::loadMission(const std::string& mission_name, int flags)
 
 			if (Ships[objp->instance].callsign_index >= 0) {
 				mission_parse_lookup_callsign_index(Ships[objp->instance].callsign_index,
-				                                    Fred_callsigns[objp->instance]);
+													Fred_callsigns[objp->instance]);
 
 				// also zero it
 				Ships[objp->instance].callsign_index = -1;
@@ -297,7 +298,7 @@ bool Editor::loadMission(const std::string& mission_name, int flags)
 
 	for (auto& viewport : _viewports) {
 		viewport->view_orient = Parse_viewer_orient;
-		viewport->view_pos    = Parse_viewer_pos;
+		viewport->view_pos = Parse_viewer_pos;
 	}
 	stars_post_level_init();
 
@@ -305,8 +306,7 @@ bool Editor::loadMission(const std::string& mission_name, int flags)
 
 	return true;
 }
-void Editor::unmark_all()
-{
+void Editor::unmark_all() {
 	if (numMarked > 0) {
 		for (auto i = 0; i < MAX_OBJECTS; i++) {
 			Objects[i].flags.remove(Object::Object_Flags::Marked);
@@ -322,11 +322,10 @@ void Editor::unmark_all()
 		missionChanged();
 	}
 }
-void Editor::markObject(int obj)
-{
+void Editor::markObject(int obj) {
 	Assert(query_valid_object(obj));
 	if (!(Objects[obj].flags[Object::Object_Flags::Marked])) {
-		Objects[obj].flags.set(Object::Object_Flags::Marked); // set as marked
+		Objects[obj].flags.set(Object::Object_Flags::Marked);  // set as marked
 		objectMarkingChanged(obj, true);
 		numMarked++;
 
@@ -337,36 +336,34 @@ void Editor::markObject(int obj)
 		updateAllViewports();
 	}
 }
-void Editor::unmarkObject(int obj)
-{
+void Editor::unmarkObject(int obj) {
 	Assert(query_valid_object(obj));
 	if (Objects[obj].flags[Object::Object_Flags::Marked]) {
 		Objects[obj].flags.remove(Object::Object_Flags::Marked);
 		objectMarkingChanged(obj, false);
 		numMarked--;
-		if (obj == currentObject) { // need to find a new index
+		if (obj == currentObject) {  // need to find a new index
 			object* ptr;
 
 			ptr = GET_FIRST(&obj_used_list);
 			while (ptr != END_OF_LIST(&obj_used_list)) {
 				if (ptr->flags[Object::Object_Flags::Marked]) {
-					setupCurrentObjectIndices(OBJ_INDEX(ptr)); // found one
+					setupCurrentObjectIndices(OBJ_INDEX(ptr));  // found one
 					return;
 				}
 
 				ptr = GET_NEXT(ptr);
 			}
 
-			setupCurrentObjectIndices(-1); // can't find one; nothing is marked.
+			setupCurrentObjectIndices(-1);  // can't find one; nothing is marked.
 		}
 
 		missionChanged();
 	}
 }
 
-void Editor::clearMission()
-{
-// clean up everything we need to before we reset back to defaults.
+void Editor::clearMission() {
+	// clean up everything we need to before we reset back to defaults.
 #if 0
     if (Briefing_dialog){
         Briefing_dialog->reset_editor();
@@ -380,15 +377,15 @@ void Editor::clearMission()
 	cmd_brief_reset();
 	mission_event_shutdown();
 
-	Asteroid_field.num_initial_asteroids = 0; // disable asteroid field by default.
-	Asteroid_field.speed                 = 0.0f;
+	Asteroid_field.num_initial_asteroids = 0;  // disable asteroid field by default.
+	Asteroid_field.speed = 0.0f;
 	vm_vec_make(&Asteroid_field.min_bound, -1000.0f, -1000.0f, -1000.0f);
 	vm_vec_make(&Asteroid_field.max_bound, 1000.0f, 1000.0f, 1000.0f);
 	vm_vec_make(&Asteroid_field.inner_min_bound, -500.0f, -500.0f, -500.0f);
 	vm_vec_make(&Asteroid_field.inner_max_bound, 500.0f, 500.0f, 500.0f);
-	Asteroid_field.has_inner_bound      = 0;
-	Asteroid_field.field_type           = FT_ACTIVE;
-	Asteroid_field.debris_genre         = DG_ASTEROID;
+	Asteroid_field.has_inner_bound = 0;
+	Asteroid_field.field_type = FT_ACTIVE;
+	Asteroid_field.debris_genre = DG_ASTEROID;
 	Asteroid_field.field_debris_type[0] = -1;
 	Asteroid_field.field_debris_type[1] = -1;
 	Asteroid_field.field_debris_type[2] = -1;
@@ -396,7 +393,7 @@ void Editor::clearMission()
 	strcpy_s(Mission_parse_storm_name, "none");
 
 	obj_init();
-	model_free_all(); // Free all existing models
+	model_free_all();                // Free all existing models
 	ai_init();
 	ai_profiles_init();
 	ship_init();
@@ -405,12 +402,12 @@ void Editor::clearMission()
 
 	Num_wings = 0;
 	for (auto i = 0; i < MAX_WINGS; i++) {
-		Wings[i].wave_count             = 0;
+		Wings[i].wave_count = 0;
 		Wings[i].wing_squad_filename[0] = '\0';
-		Wings[i].wing_insignia_texture  = -1;
+		Wings[i].wing_insignia_texture = -1;
 	}
 
-	Num_ai_dock_names  = 0;
+	Num_ai_dock_names = 0;
 	Num_reinforcements = 0;
 	setupCurrentObjectIndices(-1);
 
@@ -432,11 +429,11 @@ void Editor::clearMission()
 	The_mission.game_type = MISSION_TYPE_SINGLE;
 	strcpy_s(The_mission.squad_name, "");
 	strcpy_s(The_mission.squad_filename, "");
-	The_mission.num_respawns      = 3;
+	The_mission.num_respawns = 3;
 	The_mission.max_respawn_delay = -1;
 
 	Player_starts = 0;
-	Num_teams     = 1;
+	Num_teams = 1;
 
 	// reset alternate name & callsign stuff
 	for (auto i = 0; i < MAX_SHIPS; i++) {
@@ -482,10 +479,10 @@ void Editor::clearMission()
 
 	waypoint_parse_init();
 	Num_mission_events = 0;
-	Num_goals          = 0;
+	Num_goals = 0;
 	unmark_all();
 	obj_init();
-	model_free_all(); // Free all existing models
+	model_free_all();                // Free all existing models
 
 	for (auto& viewport : _viewports) {
 		viewport->resetView();
@@ -499,7 +496,7 @@ void Editor::clearMission()
 	event_music_reset_choices();
 	clear_texture_replacements();
 
-	mission_parse_reset_alt(); // alternate ship type names
+	mission_parse_reset_alt();        // alternate ship type names
 	mission_parse_reset_callsign();
 
 	strcpy(Cargo_names[0], "Nothing");
@@ -510,20 +507,20 @@ void Editor::clearMission()
 
 	// reset background bitmaps and suns
 	stars_pre_level_init();
-	Nebula_index    = 0;
+	Nebula_index = 0;
 	Mission_palette = 1;
-	Nebula_pitch    = (int)((float)(rand() & 0x0fff) * 360.0f / 4096.0f);
-	Nebula_bank     = (int)((float)(rand() & 0x0fff) * 360.0f / 4096.0f);
-	Nebula_heading  = (int)((float)(rand() & 0x0fff) * 360.0f / 4096.0f);
-	Neb2_awacs      = -1.0f;
+	Nebula_pitch = (int) ((float) (rand() & 0x0fff) * 360.0f / 4096.0f);
+	Nebula_bank = (int) ((float) (rand() & 0x0fff) * 360.0f / 4096.0f);
+	Nebula_heading = (int) ((float) (rand() & 0x0fff) * 360.0f / 4096.0f);
+	Neb2_awacs = -1.0f;
 	Neb2_poof_flags = 0;
 	strcpy_s(Neb2_texture_name, "");
 	for (auto i = 0; i < MAX_NEB2_POOFS; i++) {
 		Neb2_poof_flags |= (1 << i);
 	}
 
-	Nmodel_flags        = DEFAULT_NMODEL_FLAGS;
-	Nmodel_num          = -1;
+	Nmodel_flags = DEFAULT_NMODEL_FLAGS;
+	Nmodel_num = -1;
 	Nmodel_instance_num = -1;
 	vm_set_identity(&Nmodel_orient);
 	Nmodel_bitmap = -1;
@@ -536,10 +533,10 @@ void Editor::clearMission()
 
 	// Goober5000: reset ALL mission flags, not just nebula!
 	The_mission.flags.reset();
-	The_mission.support_ships.max_support_ships     = -1; // negative means infinite
-	The_mission.support_ships.max_hull_repair_val   = 0.0f;
+	The_mission.support_ships.max_support_ships = -1;    // negative means infinite
+	The_mission.support_ships.max_hull_repair_val = 0.0f;
 	The_mission.support_ships.max_subsys_repair_val = 100.0f;
-	The_mission.ai_profile                          = &Ai_profiles[Default_ai_profile];
+	The_mission.ai_profile = &Ai_profiles[Default_ai_profile];
 
 	nebula_init(Nebula_filenames[Nebula_index], Nebula_pitch, Nebula_bank, Nebula_heading);
 
@@ -558,25 +555,23 @@ void Editor::clearMission()
 	missionLoaded("");
 }
 
-void Editor::initialSetup()
-{
+void Editor::initialSetup() {
 	// Get the default player ship
 	Default_player_model = get_default_player_ship_index();
 
-	Id_select_type_jump_node = (int)(Ship_info.size() + 1);
-	Id_select_type_waypoint  = (int)(Ship_info.size());
+	Id_select_type_jump_node = (int) (Ship_info.size() + 1);
+	Id_select_type_waypoint = (int) (Ship_info.size());
 
 	createNewMission();
 }
 
-void Editor::setupCurrentObjectIndices(int selectedObj)
-{
+void Editor::setupCurrentObjectIndices(int selectedObj) {
 	if (query_valid_object(selectedObj)) {
 		currentObject = selectedObj;
 
 		cur_ship = cur_wing = -1;
-		cur_waypoint_list   = NULL;
-		cur_waypoint        = NULL;
+		cur_waypoint_list = NULL;
+		cur_waypoint = NULL;
 
 		if ((Objects[selectedObj].type == OBJ_SHIP) || (Objects[selectedObj].type == OBJ_START)) {
 			cur_ship = Objects[selectedObj].instance;
@@ -601,8 +596,8 @@ void Editor::setupCurrentObjectIndices(int selectedObj)
 
 	if (selectedObj == -1 || !Num_objects) {
 		currentObject = cur_ship = cur_wing = -1;
-		cur_waypoint_list                   = NULL;
-		cur_waypoint                        = NULL;
+		cur_waypoint_list = NULL;
+		cur_waypoint = NULL;
 
 		currentObjectChanged(currentObject);
 		return;
@@ -624,8 +619,8 @@ void Editor::setupCurrentObjectIndices(int selectedObj)
 	Assert(ptr->type != OBJ_NONE);
 
 	cur_ship = cur_wing = -1;
-	cur_waypoint_list   = NULL;
-	cur_waypoint        = NULL;
+	cur_waypoint_list = NULL;
+	cur_waypoint = NULL;
 
 	if (ptr->type == OBJ_SHIP) {
 		cur_ship = ptr->instance;
@@ -644,20 +639,18 @@ void Editor::setupCurrentObjectIndices(int selectedObj)
 
 	currentObjectChanged(currentObject);
 }
-void Editor::selectObject(int objId)
-{
+void Editor::selectObject(int objId) {
 	if (objId < 0) {
 		unmark_all();
 	} else {
 		markObject(objId);
 	}
 
-	setupCurrentObjectIndices(objId); // select the new object
+	setupCurrentObjectIndices(objId);  // select the new object
 
 	missionChanged();
 }
-void Editor::updateAllViewports()
-{
+void Editor::updateAllViewports() {
 	// This takes all renderers and issues an update request for each of them. For now that is only one but this allows
 	// us to expand FRED to multiple view ports in the future.
 	for (auto& viewport : _viewports) {
@@ -665,8 +658,7 @@ void Editor::updateAllViewports()
 	}
 }
 
-int Editor::create_player(int /*num*/, vec3d* pos, matrix* orient, int type, int /*init*/)
-{
+int Editor::create_player(int  /*num*/, vec3d* pos, matrix* orient, int type, int  /*init*/) {
 	int obj;
 
 	if (type == -1) {
@@ -676,11 +668,11 @@ int Editor::create_player(int /*num*/, vec3d* pos, matrix* orient, int type, int
 	Assert(type >= 0);
 	Assert(Player_starts < MAX_PLAYERS);
 	Player_starts++;
-	obj               = create_ship(orient, pos, type);
+	obj = create_ship(orient, pos, type);
 	Objects[obj].type = OBJ_START;
 
 	// be sure arrival/departure cues are set
-	Ships[Objects[obj].instance].arrival_cue   = Locked_sexp_true;
+	Ships[Objects[obj].instance].arrival_cue = Locked_sexp_true;
 	Ships[Objects[obj].instance].departure_cue = Locked_sexp_false;
 	obj_merge_created_list();
 
@@ -689,8 +681,7 @@ int Editor::create_player(int /*num*/, vec3d* pos, matrix* orient, int type, int
 	return obj;
 }
 
-int Editor::create_ship(matrix* orient, vec3d* pos, int ship_type)
-{
+int Editor::create_ship(matrix* orient, vec3d* pos, int ship_type) {
 	int obj, z1, z2;
 	float temp_max_hull_strength;
 	ship_info* sip;
@@ -703,7 +694,7 @@ int Editor::create_ship(matrix* orient, vec3d* pos, int ship_type)
 	Objects[obj].phys_info.speed = 33.0f;
 
 	ship* shipp = &Ships[Objects[obj].instance];
-	sip         = &Ship_info[shipp->ship_info_index];
+	sip = &Ship_info[shipp->ship_info_index];
 
 	if (query_ship_name_duplicate(Objects[obj].instance)) {
 		fix_ship_name(Objects[obj].instance);
@@ -729,7 +720,7 @@ int Editor::create_ship(matrix* orient, vec3d* pos, int ship_type)
 
 		// find the first player ship
 		for (temp_objp = GET_FIRST(&obj_used_list); temp_objp != END_OF_LIST(&obj_used_list);
-		     temp_objp = GET_NEXT(temp_objp)) {
+			 temp_objp = GET_NEXT(temp_objp)) {
 			if (temp_objp->type == OBJ_START) {
 				temp_shipp = &Ships[temp_objp->instance];
 				break;
@@ -751,20 +742,19 @@ int Editor::create_ship(matrix* orient, vec3d* pos, int ship_type)
 
 	// calc kamikaze stuff
 	if (shipp->use_special_explosion) {
-		temp_max_hull_strength = (float)shipp->special_exp_blast;
+		temp_max_hull_strength = (float) shipp->special_exp_blast;
 	} else {
 		temp_max_hull_strength = sip->max_hull_strength;
 	}
 
-	Ai_info[shipp->ai_index].kamikaze_damage = (int)std::min(1000.0f, 200.0f + (temp_max_hull_strength / 4.0f));
+	Ai_info[shipp->ai_index].kamikaze_damage = (int) std::min(1000.0f, 200.0f + (temp_max_hull_strength / 4.0f));
 
 	missionChanged();
 
 	return obj;
 }
 
-bool Editor::query_ship_name_duplicate(int ship)
-{
+bool Editor::query_ship_name_duplicate(int ship) {
 	int i;
 
 	for (i = 0; i < MAX_SHIPS; i++) {
@@ -778,8 +768,7 @@ bool Editor::query_ship_name_duplicate(int ship)
 	return false;
 }
 
-void Editor::fix_ship_name(int ship)
-{
+void Editor::fix_ship_name(int ship) {
 	int i = 1;
 
 	do {
@@ -787,13 +776,11 @@ void Editor::fix_ship_name(int ship)
 	} while (query_ship_name_duplicate(ship));
 }
 
-void Editor::createNewMission()
-{
+void Editor::createNewMission() {
 	clearMission();
 	create_player(0, &vmd_zero_vector, &vmd_identity_matrix);
 }
-void Editor::hideMarkedObjects()
-{
+void Editor::hideMarkedObjects() {
 	object* ptr;
 
 	ptr = GET_FIRST(&obj_used_list);
@@ -808,8 +795,7 @@ void Editor::hideMarkedObjects()
 
 	updateAllViewports();
 }
-void Editor::showHiddenObjects()
-{
+void Editor::showHiddenObjects() {
 	object* ptr;
 
 	ptr = GET_FIRST(&obj_used_list);
@@ -820,22 +806,22 @@ void Editor::showHiddenObjects()
 
 	updateAllViewports();
 }
-int Editor::create_waypoint(vec3d* pos, int waypoint_instance)
-{
+int Editor::create_waypoint(vec3d* pos, int waypoint_instance) {
 	int obj = waypoint_add(pos, waypoint_instance);
 
 	missionChanged();
 
 	return obj;
 }
-int Editor::getNumMarked() { return numMarked; }
-int Editor::dup_object(object* objp)
-{
+int Editor::getNumMarked() {
+	return numMarked;
+}
+int Editor::dup_object(object* objp) {
 
 	int i, j, n, inst, obj = -1;
-	ai_info *aip1, *aip2;
-	object *objp1, *objp2;
-	ship_subsys *subp1, *subp2;
+	ai_info* aip1, * aip2;
+	object* objp1, * objp2;
+	ship_subsys* subp1, * subp2;
 	static int waypoint_instance(-1);
 
 	if (!objp) {
@@ -850,20 +836,20 @@ int Editor::dup_object(object* objp)
 			return -1;
 		}
 
-		n                           = Objects[obj].instance;
-		Ships[n].team               = Ships[inst].team;
-		Ships[n].arrival_cue        = dup_sexp_chain(Ships[inst].arrival_cue);
-		Ships[n].departure_cue      = dup_sexp_chain(Ships[inst].departure_cue);
-		Ships[n].cargo1             = Ships[inst].cargo1;
-		Ships[n].arrival_location   = Ships[inst].arrival_location;
+		n = Objects[obj].instance;
+		Ships[n].team = Ships[inst].team;
+		Ships[n].arrival_cue = dup_sexp_chain(Ships[inst].arrival_cue);
+		Ships[n].departure_cue = dup_sexp_chain(Ships[inst].departure_cue);
+		Ships[n].cargo1 = Ships[inst].cargo1;
+		Ships[n].arrival_location = Ships[inst].arrival_location;
 		Ships[n].departure_location = Ships[inst].departure_location;
-		Ships[n].arrival_delay      = Ships[inst].arrival_delay;
-		Ships[n].departure_delay    = Ships[inst].departure_delay;
-		Ships[n].weapons            = Ships[inst].weapons;
-		Ships[n].hotkey             = Ships[inst].hotkey;
+		Ships[n].arrival_delay = Ships[inst].arrival_delay;
+		Ships[n].departure_delay = Ships[inst].departure_delay;
+		Ships[n].weapons = Ships[inst].weapons;
+		Ships[n].hotkey = Ships[inst].hotkey;
 
-		aip1           = &Ai_info[Ships[n].ai_index];
-		aip2           = &Ai_info[Ships[inst].ai_index];
+		aip1 = &Ai_info[Ships[n].ai_index];
+		aip2 = &Ai_info[Ships[inst].ai_index];
 		aip1->behavior = aip2->behavior;
 		aip1->ai_class = aip2->ai_class;
 		for (i = 0; i < MAX_AI_GOALS; i++) {
@@ -879,11 +865,11 @@ int Editor::dup_object(object* objp)
 
 		aip1->kamikaze_damage = aip2->kamikaze_damage;
 
-		objp1                     = &Objects[obj];
-		objp2                     = &Objects[Ships[inst].objnum];
-		objp1->phys_info.speed    = objp2->phys_info.speed;
-		objp1->phys_info.fspeed   = objp2->phys_info.fspeed;
-		objp1->hull_strength      = objp2->hull_strength;
+		objp1 = &Objects[obj];
+		objp2 = &Objects[Ships[inst].objnum];
+		objp1->phys_info.speed = objp2->phys_info.speed;
+		objp1->phys_info.fspeed = objp2->phys_info.fspeed;
+		objp1->hull_strength = objp2->hull_strength;
 		objp1->shield_quadrant[0] = objp2->shield_quadrant[0];
 
 		subp1 = GET_FIRST(&Ships[n].subsys_list);
@@ -891,8 +877,8 @@ int Editor::dup_object(object* objp)
 		while (subp1 != END_OF_LIST(&Ships[n].subsys_list)) {
 			Assert(subp2 != END_OF_LIST(&Ships[inst].subsys_list));
 			subp1->current_hits = subp2->current_hits;
-			subp1               = GET_NEXT(subp1);
-			subp2               = GET_NEXT(subp2);
+			subp1 = GET_NEXT(subp1);
+			subp2 = GET_NEXT(subp2);
 		}
 
 		for (i = 0; i < Num_reinforcements; i++) {
@@ -909,7 +895,7 @@ int Editor::dup_object(object* objp)
 		}
 
 	} else if (objp->type == OBJ_WAYPOINT) {
-		obj               = create_waypoint(&objp->pos, waypoint_instance);
+		obj = create_waypoint(&objp->pos, waypoint_instance);
 		waypoint_instance = Objects[obj].instance;
 	}
 
@@ -917,15 +903,14 @@ int Editor::dup_object(object* objp)
 		return -1;
 	}
 
-	Objects[obj].pos    = objp->pos;
+	Objects[obj].pos = objp->pos;
 	Objects[obj].orient = objp->orient;
 	Objects[obj].flags.set(Object::Object_Flags::Temp_marked);
 	return obj;
 }
 
-int Editor::common_object_delete(int obj)
-{
-	char msg[255], *name;
+int Editor::common_object_delete(int obj) {
+	char msg[255], * name;
 	int i, z, r, type;
 	object* objp;
 	SCP_list<CJumpNode>::iterator jnp;
@@ -933,9 +918,11 @@ int Editor::common_object_delete(int obj)
 	type = Objects[obj].type;
 	if (type == OBJ_START) {
 		i = Objects[obj].instance;
-		if (Player_starts < 2) { // player 1 start
-			_lastActiveViewport->dialogProvider->showButtonDialog(
-			    DialogType::Error, "Error", "Must have at least 1 player starting point!", {DialogButton::Ok});
+		if (Player_starts < 2) {  // player 1 start
+			_lastActiveViewport->dialogProvider->showButtonDialog(DialogType::Error,
+																  "Error",
+																  "Must have at least 1 player starting point!",
+																  { DialogButton::Ok });
 
 			unmarkObject(obj);
 			return 1;
@@ -944,7 +931,7 @@ int Editor::common_object_delete(int obj)
 		Assert((i >= 0) && (i < MAX_SHIPS));
 		sprintf(msg, "Player %d", i + 1);
 		name = msg;
-		r    = reference_handler(name, REF_TYPE_PLAYER, obj);
+		r = reference_handler(name, REF_TYPE_PLAYER, obj);
 		if (r) {
 			return r;
 		}
@@ -956,7 +943,7 @@ int Editor::common_object_delete(int obj)
 			}
 		}
 
-		Objects[obj].type = OBJ_SHIP; // was allocated as a ship originally, so remove as such.
+		Objects[obj].type = OBJ_SHIP;  // was allocated as a ship originally, so remove as such.
 		invalidate_references(name, REF_TYPE_PLAYER);
 
 		// check if any ship is docked with this ship and break dock if so
@@ -964,7 +951,7 @@ int Editor::common_object_delete(int obj)
 			ai_do_objects_undocked_stuff(&Objects[obj], dock_get_first_docked_object(&Objects[obj]));
 		}
 
-		if (Player_start_shipnum == i) { // need a new single player start.
+		if (Player_start_shipnum == i) {  // need a new single player start.
 			objp = GET_FIRST(&obj_used_list);
 			while (objp != END_OF_LIST(&obj_used_list)) {
 				if (objp->type == OBJ_START) {
@@ -982,13 +969,13 @@ int Editor::common_object_delete(int obj)
 		waypoint* wpt = find_waypoint_with_instance(Objects[obj].instance);
 		Assert(wpt != NULL);
 		waypoint_list* wp_list = wpt->get_parent_list();
-		int index              = calc_waypoint_list_index(Objects[obj].instance);
-		int count              = (int)wp_list->get_waypoints().size();
+		int index = calc_waypoint_list_index(Objects[obj].instance);
+		int count = (int) wp_list->get_waypoints().size();
 
 		// we'll end up deleting the path, so check for path references
 		if (count == 1) {
 			name = wp_list->get_name();
-			r    = reference_handler(name, REF_TYPE_PATH, obj);
+			r = reference_handler(name, REF_TYPE_PATH, obj);
 			if (r) {
 				return r;
 			}
@@ -997,7 +984,7 @@ int Editor::common_object_delete(int obj)
 		// check for waypoint references
 		sprintf(msg, "%s:%d", wp_list->get_name(), index + 1);
 		name = msg;
-		r    = reference_handler(name, REF_TYPE_WAYPOINT, obj);
+		r = reference_handler(name, REF_TYPE_WAYPOINT, obj);
 		if (r) {
 			return r;
 		}
@@ -1014,7 +1001,7 @@ int Editor::common_object_delete(int obj)
 
 	} else if (type == OBJ_SHIP) {
 		name = Ships[Objects[obj].instance].ship_name;
-		r    = reference_handler(name, REF_TYPE_SHIP, obj);
+		r = reference_handler(name, REF_TYPE_SHIP, obj);
 		if (r) {
 			return r;
 		}
@@ -1078,29 +1065,29 @@ int Editor::common_object_delete(int obj)
 
 	unmarkObject(obj);
 
-	// we need to call obj_delete() even if obj is a jump node
-	// the statement "delete Objects[obj].jnp" deletes the jnp object
-	// obj_delete() frees up the object slot where the node used to reside.
-	// if we don't call this then the node will still show up in fred and you can try to delete it twice
-	// this causes an ugly crash.
+	//we need to call obj_delete() even if obj is a jump node
+	//the statement "delete Objects[obj].jnp" deletes the jnp object
+	//obj_delete() frees up the object slot where the node used to reside.
+	//if we don't call this then the node will still show up in fred and you can try to delete it twice
+	//this causes an ugly crash.
 	obj_delete(obj);
 
 	missionChanged();
 	return 0;
 }
 
-int Editor::delete_object(int obj)
-{
+int Editor::delete_object(int obj) {
 	int r;
 
 	r = common_object_delete(obj);
 	return r;
 }
 
-void Editor::setActiveViewport(EditorViewport* viewport) { _lastActiveViewport = viewport; }
+void Editor::setActiveViewport(EditorViewport* viewport) {
+	_lastActiveViewport = viewport;
+}
 
-int Editor::reference_handler(const char* name, int type, int obj)
-{
+int Editor::reference_handler(const char* name, int type, int obj) {
 
 	char msg[2048], text[128], type_name[128];
 	int r, n, node;
@@ -1176,21 +1163,17 @@ int Editor::reference_handler(const char* name, int type, int obj)
 			sprintf(text, "briefing #%d", n);
 			break;
 
-		default: // very bad.  Someone added an sexp somewhere and didn't change this.
-			Warning(LOCATION,
-			        "\"%s\" referenced by an unknown sexp source!  "
-			        "Run for the hills and let Hoffoss know right now!",
-			        name);
+		default:  // very bad.  Someone added an sexp somewhere and didn't change this.
+			Warning(LOCATION, "\"%s\" referenced by an unknown sexp source!  "
+				"Run for the hills and let Hoffoss know right now!", name);
 
 			delete_flag = 1;
 			return 2;
 		}
 
-		sprintf(msg,
-		        "%s is referenced by %s (possibly more sexps).\n"
-		        "Do you want to delete it anyway?\n\n"
-		        "(click Cancel to go to the reference)",
-		        type_name, text);
+		sprintf(msg, "%s is referenced by %s (possibly more sexps).\n"
+			"Do you want to delete it anyway?\n\n"
+			"(click Cancel to go to the reference)", type_name, text);
 
 		r = sexp_reference_handler(node, r, msg);
 		if (r == 1) {
@@ -1219,18 +1202,14 @@ int Editor::reference_handler(const char* name, int type, int obj)
 			sprintf(text, "wing \"%s\"", Wings[n].name);
 			break;
 
-		default: // very bad.  Someone added an sexp somewhere and didn't change this.
-			Error(LOCATION,
-			      "\"%s\" referenced by an unknown initial orders source!  "
-			      "Run for the hills and let Hoffoss know right now!",
-			      name);
+		default:  // very bad.  Someone added an sexp somewhere and didn't change this.
+			Error(LOCATION, "\"%s\" referenced by an unknown initial orders source!  "
+				"Run for the hills and let Hoffoss know right now!", name);
 		}
 
-		sprintf(msg,
-		        "%s is referenced by the initial orders of %s (possibly \n"
-		        "more initial orders).  Do you want to delete it anyway?\n\n"
-		        "(click Cancel to go to the reference)",
-		        type_name, text);
+		sprintf(msg, "%s is referenced by the initial orders of %s (possibly \n"
+			"more initial orders).  Do you want to delete it anyway?\n\n"
+			"(click Cancel to go to the reference)", type_name, text);
 
 		r = orders_reference_handler(r, msg);
 		if (r == 1) {
@@ -1258,12 +1237,10 @@ int Editor::reference_handler(const char* name, int type, int obj)
 	}
 
 	if (n < Num_reinforcements) {
-		sprintf(msg,
-		        "Ship \"%s\" is a reinforcement unit.\n"
-		        "Do you want to delete it anyway?",
-		        name);
+		sprintf(msg, "Ship \"%s\" is a reinforcement unit.\n"
+			"Do you want to delete it anyway?", name);
 
-		_lastActiveViewport->dialogProvider->showButtonDialog(DialogType::Error, "Error", msg, {DialogButton::Ok});
+		_lastActiveViewport->dialogProvider->showButtonDialog(DialogType::Error, "Error", msg, { DialogButton::Ok });
 		r = 0; // TODO: Make this a Yes/No choice once we have a generic dialog interface
 		if (r == 0) {
 			if (obj >= 0) {
@@ -1277,10 +1254,13 @@ int Editor::reference_handler(const char* name, int type, int obj)
 	return 0;
 }
 
-int Editor::orders_reference_handler(int /*code*/, char* msg)
-{
-	auto r = _lastActiveViewport->dialogProvider->showButtonDialog(
-	    DialogType::Warning, "Warning", msg, {DialogButton::Yes, DialogButton::No, DialogButton::Cancel});
+int Editor::orders_reference_handler(int  /*code*/, char* msg) {
+	auto r = _lastActiveViewport->dialogProvider->showButtonDialog(DialogType::Warning,
+																   "Warning",
+																   msg,
+																   { DialogButton::Yes,
+																	 DialogButton::No,
+																	 DialogButton::Cancel });
 	if (r == DialogButton::No) {
 		return 1;
 	}
@@ -1296,40 +1276,43 @@ int Editor::orders_reference_handler(int /*code*/, char* msg)
 	auto n = code & SRC_DATA_MASK;
 	switch (code & SRC_MASK) {
 	case SRC_SHIP_ORDER:
-	    unmark_all();
-	    mark_object(Ships[n].objnum);
+		unmark_all();
+		mark_object(Ships[n].objnum);
 
-	    dlg_goals.self_ship = n;
-	    dlg_goals.DoModal();
-	    if (!query_initial_orders_empty(Ai_info[Ships[n].ai_index].goals))
-	        if ((Ships[n].wingnum >= 0) && (query_initial_orders_conflict(Ships[n].wingnum)))
-	            Fred_main_wnd->MessageBox("This ship's wing also has initial orders", "Possible conflict");
+		dlg_goals.self_ship = n;
+		dlg_goals.DoModal();
+		if (!query_initial_orders_empty(Ai_info[Ships[n].ai_index].goals))
+			if ((Ships[n].wingnum >= 0) && (query_initial_orders_conflict(Ships[n].wingnum)))
+				Fred_main_wnd->MessageBox("This ship's wing also has initial orders", "Possible conflict");
 
-	    break;
+		break;
 
 	case SRC_WING_ORDER:
-	    unmark_all();
-	    mark_wing(n);
+		unmark_all();
+		mark_wing(n);
 
-	    dlg_goals.self_wing = n;
-	    dlg_goals.DoModal();
-	    if (query_initial_orders_conflict(n))
-	        Fred_main_wnd->MessageBox("One or more ships of this wing also has initial orders", "Possible conflict");
+		dlg_goals.self_wing = n;
+		dlg_goals.DoModal();
+		if (query_initial_orders_conflict(n))
+			Fred_main_wnd->MessageBox("One or more ships of this wing also has initial orders", "Possible conflict");
 
-	    break;
+		break;
 
 	default:  // very bad.  Someone added an sexp somewhere and didn't change this.
-	    Error(LOCATION, "Unknown initial order reference source");
+		Error(LOCATION, "Unknown initial order reference source");
 	}
 	*/
 
 	delete_flag = 1;
 	return 2;
 }
-int Editor::sexp_reference_handler(int /*node*/, int /*code*/, const char* msg)
-{
-	auto r = _lastActiveViewport->dialogProvider->showButtonDialog(
-	    DialogType::Warning, "Warning", msg, {DialogButton::Yes, DialogButton::No, DialogButton::Cancel});
+int Editor::sexp_reference_handler(int  /*node*/, int  /*code*/, const char* msg) {
+	auto r = _lastActiveViewport->dialogProvider->showButtonDialog(DialogType::Warning,
+																   "Warning",
+																   msg,
+																   { DialogButton::Yes,
+																	 DialogButton::No,
+																	 DialogButton::Cancel });
 	if (r == DialogButton::No) {
 		return 1;
 	}
@@ -1343,87 +1326,86 @@ int Editor::sexp_reference_handler(int /*node*/, int /*code*/, const char* msg)
 	switch (code & SRC_MASK) {
 	case SRC_SHIP_ARRIVAL:
 	case SRC_SHIP_DEPARTURE:
-	    if (!Ship_editor_dialog.GetSafeHwnd())
-	        Ship_editor_dialog.Create();
+		if (!Ship_editor_dialog.GetSafeHwnd())
+			Ship_editor_dialog.Create();
 
-	    Ship_editor_dialog.SetWindowPos(&Fred_main_wnd->wndTop, 0, 0, 0, 0,
-	                                    SWP_SHOWWINDOW | SWP_NOMOVE | SWP_NOSIZE);
-	    Ship_editor_dialog.ShowWindow(SW_RESTORE);
+		Ship_editor_dialog.SetWindowPos(&Fred_main_wnd->wndTop, 0, 0, 0, 0,
+										SWP_SHOWWINDOW | SWP_NOMOVE | SWP_NOSIZE);
+		Ship_editor_dialog.ShowWindow(SW_RESTORE);
 
-	    Ship_editor_dialog.select_sexp_node = node;
-	    unmark_all();
-	    mark_object(Ships[code & SRC_DATA_MASK].objnum);
-	    break;
+		Ship_editor_dialog.select_sexp_node = node;
+		unmark_all();
+		mark_object(Ships[code & SRC_DATA_MASK].objnum);
+		break;
 
 	case SRC_WING_ARRIVAL:
 	case SRC_WING_DEPARTURE:
-	    if (!Wing_editor_dialog.GetSafeHwnd())
-	        Wing_editor_dialog.Create();
+		if (!Wing_editor_dialog.GetSafeHwnd())
+			Wing_editor_dialog.Create();
 
-	    Wing_editor_dialog.SetWindowPos(&Fred_main_wnd->wndTop, 0, 0, 0, 0,
-	                                    SWP_SHOWWINDOW | SWP_NOMOVE | SWP_NOSIZE);
-	    Wing_editor_dialog.ShowWindow(SW_RESTORE);
+		Wing_editor_dialog.SetWindowPos(&Fred_main_wnd->wndTop, 0, 0, 0, 0,
+										SWP_SHOWWINDOW | SWP_NOMOVE | SWP_NOSIZE);
+		Wing_editor_dialog.ShowWindow(SW_RESTORE);
 
-	    Wing_editor_dialog.select_sexp_node = node;
-	    unmark_all();
-	    mark_wing(code & SRC_DATA_MASK);
-	    break;
+		Wing_editor_dialog.select_sexp_node = node;
+		unmark_all();
+		mark_wing(code & SRC_DATA_MASK);
+		break;
 
 	case SRC_EVENT:
-	    if (Message_editor_dlg) {
-	        Fred_main_wnd->MessageBox("You must close the message editor before the event editor can be opened");
-	        break;
-	    }
+		if (Message_editor_dlg) {
+			Fred_main_wnd->MessageBox("You must close the message editor before the event editor can be opened");
+			break;
+		}
 
-	    if (!Event_editor_dlg) {
-	        Event_editor_dlg = new event_editor;
-	        Event_editor_dlg->select_sexp_node = node;
-	        Event_editor_dlg->Create(event_editor::IDD);
-	    }
+		if (!Event_editor_dlg) {
+			Event_editor_dlg = new event_editor;
+			Event_editor_dlg->select_sexp_node = node;
+			Event_editor_dlg->Create(event_editor::IDD);
+		}
 
-	    Event_editor_dlg->SetWindowPos(&CWnd::wndTop, 0, 0, 0, 0, SWP_SHOWWINDOW | SWP_NOMOVE | SWP_NOSIZE);
-	    Event_editor_dlg->ShowWindow(SW_RESTORE);
-	    break;
+		Event_editor_dlg->SetWindowPos(&CWnd::wndTop, 0, 0, 0, 0, SWP_SHOWWINDOW | SWP_NOMOVE | SWP_NOSIZE);
+		Event_editor_dlg->ShowWindow(SW_RESTORE);
+		break;
 
 	case SRC_MISSION_GOAL: {
-	    CMissionGoalsDlg dlg;
+		CMissionGoalsDlg dlg;
 
-	    dlg.select_sexp_node = node;
-	    dlg.DoModal();
-	    break;
+		dlg.select_sexp_node = node;
+		dlg.DoModal();
+		break;
 	}
 
 	case SRC_DEBRIEFING: {
-	    debriefing_editor_dlg dlg;
+		debriefing_editor_dlg dlg;
 
-	    dlg.select_sexp_node = node;
-	    dlg.DoModal();
-	    break;
+		dlg.select_sexp_node = node;
+		dlg.DoModal();
+		break;
 	}
 
 	case SRC_BRIEFING: {
-	    if (!Briefing_dialog) {
-	        Briefing_dialog = new briefing_editor_dlg;
-	        Briefing_dialog->create();
-	    }
+		if (!Briefing_dialog) {
+			Briefing_dialog = new briefing_editor_dlg;
+			Briefing_dialog->create();
+		}
 
-	    Briefing_dialog->SetWindowPos(&Briefing_dialog->wndTop, 0, 0, 0, 0,
-	                                  SWP_SHOWWINDOW | SWP_NOMOVE | SWP_NOSIZE);
-	    Briefing_dialog->ShowWindow(SW_RESTORE);
-	    Briefing_dialog->focus_sexp(node);
-	    break;
+		Briefing_dialog->SetWindowPos(&Briefing_dialog->wndTop, 0, 0, 0, 0,
+									  SWP_SHOWWINDOW | SWP_NOMOVE | SWP_NOSIZE);
+		Briefing_dialog->ShowWindow(SW_RESTORE);
+		Briefing_dialog->focus_sexp(node);
+		break;
 	}
 
 	default:  // very bad.  Someone added an sexp somewhere and didn't change this.
-	    Error(LOCATION, "Unknown sexp reference source");
+		Error(LOCATION, "Unknown sexp reference source");
 	}
 	 */
 
 	delete_flag = 1;
 	return 2;
 }
-int Editor::delete_ship_from_wing(int ship)
-{
+int Editor::delete_ship_from_wing(int ship) {
 	char name[NAME_LENGTH];
 	int i, r, wing, end;
 
@@ -1431,7 +1413,7 @@ int Editor::delete_ship_from_wing(int ship)
 	if (wing >= 0) {
 		if (Wings[wing].wave_count == 1) {
 			cur_wing = -1;
-			r        = delete_wing(wing, 1);
+			r = delete_wing(wing, 1);
 			if (r) {
 				if (r == 2) {
 					delete_flag = 1;
@@ -1441,7 +1423,7 @@ int Editor::delete_ship_from_wing(int ship)
 			}
 
 		} else {
-			i   = Wings[wing].wave_count;
+			i = Wings[wing].wave_count;
 			end = i - 1;
 			while (i--) {
 				if (wing_objects[wing][i] == Ships[ship].objnum) {
@@ -1449,7 +1431,7 @@ int Editor::delete_ship_from_wing(int ship)
 				}
 			}
 
-			Assert(i != -1); // Error, object should be in wing.
+			Assert(i != -1);  // Error, object should be in wing.
 			if (Wings[wing].special_ship == i) {
 				Wings[wing].special_ship = 0;
 			} else if (Wings[wing].special_ship > i) {
@@ -1457,7 +1439,7 @@ int Editor::delete_ship_from_wing(int ship)
 			}
 
 			if (i != end) {
-				wing_objects[wing][i]     = wing_objects[wing][end];
+				wing_objects[wing][i] = wing_objects[wing][end];
 				Wings[wing].ship_index[i] = Wings[wing].ship_index[end];
 				if (Objects[wing_objects[wing][i]].type == OBJ_SHIP) {
 					wing_bash_ship_name(name, Wings[wing].name, i + 1);
@@ -1479,8 +1461,7 @@ int Editor::delete_ship_from_wing(int ship)
 	missionChanged();
 	return 0;
 }
-int Editor::invalidate_references(const char* name, int type)
-{
+int Editor::invalidate_references(const char* name, int type) {
 	char new_name[512];
 	int i;
 
@@ -1496,12 +1477,11 @@ int Editor::invalidate_references(const char* name, int type)
 
 	return 0;
 }
-void Editor::ai_update_goal_references(int type, const char* old_name, const char* new_name)
-{
+void Editor::ai_update_goal_references(int type, const char* old_name, const char* new_name) {
 	int i;
 
-	for (i = 0; i < MAX_AI_INFO; i++) { // loop through all Ai_info entries
-		if (Ai_info[i].shipnum != -1) { // skip if unused
+	for (i = 0; i < MAX_AI_INFO; i++) {  // loop through all Ai_info entries
+		if (Ai_info[i].shipnum != -1) {  // skip if unused
 			::ai_update_goal_references(Ai_info[i].goals, type, old_name, new_name);
 		}
 	}
@@ -1512,16 +1492,14 @@ void Editor::ai_update_goal_references(int type, const char* old_name, const cha
 		}
 	}
 }
-void Editor::update_texture_replacements(const char* old_name, const char* new_name)
-{
+void Editor::update_texture_replacements(const char* old_name, const char* new_name) {
 	for (SCP_vector<texture_replace>::iterator ii = Fred_texture_replacements.begin();
-	     ii != Fred_texture_replacements.end(); ++ii) {
+		 ii != Fred_texture_replacements.end(); ++ii) {
 		if (!stricmp(ii->ship_name, old_name))
 			strcpy_s(ii->ship_name, new_name);
 	}
 }
-int Editor::rename_ship(int ship, char* name)
-{
+int Editor::rename_ship(int ship, char* name) {
 	int i;
 
 	Assert(ship >= 0);
@@ -1542,8 +1520,7 @@ int Editor::rename_ship(int ship, char* name)
 
 	return 0;
 }
-void Editor::delete_reinforcement(int num)
-{
+void Editor::delete_reinforcement(int num) {
 	int i;
 
 	for (i = num; i < Num_reinforcements - 1; i++) {
@@ -1553,13 +1530,11 @@ void Editor::delete_reinforcement(int num)
 	Num_reinforcements--;
 	missionChanged();
 }
-int Editor::check_wing_dependencies(int wing_num)
-{
+int Editor::check_wing_dependencies(int wing_num) {
 	const char* name = Wings[wing_num].name;
 	return reference_handler(name, REF_TYPE_WING, -1);
 }
-int Editor::set_reinforcement(const char* name, int state)
-{
+int Editor::set_reinforcement(const char* name, int state) {
 	int i, index, cur = -1;
 
 	for (i = 0; i < Num_reinforcements; i++) {
@@ -1583,7 +1558,7 @@ int Editor::set_reinforcement(const char* name, int state)
 			}
 		}
 		if (index == -1) {
-			Int3(); // get allender -- coudln't find ship/wing for clearing reinforcement flag
+			Int3();                // get allender -- coudln't find ship/wing for clearing reinforcement flag
 		}
 
 		missionChanged();
@@ -1593,7 +1568,7 @@ int Editor::set_reinforcement(const char* name, int state)
 	if (state && (cur == -1) && (Num_reinforcements < MAX_REINFORCEMENTS)) {
 		Assert(strlen(name) < NAME_LENGTH);
 		strcpy_s(Reinforcements[Num_reinforcements].name, name);
-		Reinforcements[Num_reinforcements].uses          = 1;
+		Reinforcements[Num_reinforcements].uses = 1;
 		Reinforcements[Num_reinforcements].arrival_delay = 0;
 		memset(Reinforcements[Num_reinforcements].no_messages, 0, MAX_REINFORCEMENT_MESSAGES * NAME_LENGTH);
 		memset(Reinforcements[Num_reinforcements].yes_messages, 0, MAX_REINFORCEMENT_MESSAGES * NAME_LENGTH);
@@ -1610,7 +1585,7 @@ int Editor::set_reinforcement(const char* name, int state)
 			}
 		}
 		if (index == -1) {
-			Int3(); // get allender -- coudln't find ship/wing for setting reinforcement flag
+			Int3();                // get allender -- coudln't find ship/wing for setting reinforcement flag
 		}
 
 		missionChanged();
@@ -1631,14 +1606,13 @@ int Editor::set_reinforcement(const char* name, int state)
 		}
 		missionChanged();
 		if (index == -1) {
-			Int3(); // get allender -- coudln't find ship/wing for setting reinforcement flag
+			Int3();                // get allender -- coudln't find ship/wing for setting reinforcement flag
 		}
 	}
 
 	return 0;
 }
-void Editor::remove_wing(int wing_num)
-{
+void Editor::remove_wing(int wing_num) {
 
 	int i, total;
 	object* ptr;
@@ -1659,12 +1633,12 @@ void Editor::remove_wing(int wing_num)
 
 	Assert(!Wings[wing_num].wave_count);
 
-	Wings[wing_num].wave_count             = 0;
+	Wings[wing_num].wave_count = 0;
 	Wings[wing_num].wing_squad_filename[0] = '\0';
-	Wings[wing_num].wing_insignia_texture  = -1;
+	Wings[wing_num].wing_insignia_texture = -1;
 
 	if (cur_wing == wing_num) {
-		set_cur_wing(cur_wing = -1); // yes, one '=' is correct.
+		set_cur_wing(cur_wing = -1);  // yes, one '=' is correct.
 	}
 
 	free_sexp2(Wings[wing_num].arrival_cue);
@@ -1676,8 +1650,7 @@ void Editor::remove_wing(int wing_num)
 
 	missionChanged();
 }
-void Editor::generate_wing_weaponry_usage_list(int* arr, int wing)
-{
+void Editor::generate_wing_weaponry_usage_list(int* arr, int wing) {
 	int i, j;
 	ship_weapon* swp;
 
@@ -1688,7 +1661,7 @@ void Editor::generate_wing_weaponry_usage_list(int* arr, int wing)
 	i = Wings[wing].wave_count;
 	while (i--) {
 		swp = &Ships[Wings[wing].ship_index[i]].weapons;
-		j   = swp->num_primary_banks;
+		j = swp->num_primary_banks;
 		while (j--) {
 			if (swp->primary_bank_weapons[j] >= 0 && swp->primary_bank_weapons[j] < MAX_WEAPON_TYPES) {
 				arr[swp->primary_bank_weapons[j]]++;
@@ -1698,16 +1671,14 @@ void Editor::generate_wing_weaponry_usage_list(int* arr, int wing)
 		j = swp->num_secondary_banks;
 		while (j--) {
 			if (swp->secondary_bank_weapons[j] >= 0 && swp->secondary_bank_weapons[j] < MAX_WEAPON_TYPES) {
-				arr[swp->secondary_bank_weapons[j]] +=
-				    (int)floor((swp->secondary_bank_ammo[j] * swp->secondary_bank_capacity[j] / 100.0f /
-				                Weapon_info[swp->secondary_bank_weapons[j]].cargo_size) +
-				               0.5f);
+				arr[swp->secondary_bank_weapons[j]] += (int) floor(
+					(swp->secondary_bank_ammo[j] * swp->secondary_bank_capacity[j] / 100.0f
+						/ Weapon_info[swp->secondary_bank_weapons[j]].cargo_size) + 0.5f);
 			}
 		}
 	}
 }
-void Editor::generate_team_weaponry_usage_list(int team, int* arr)
-{
+void Editor::generate_team_weaponry_usage_list(int team, int* arr) {
 	int i;
 
 	for (i = 0; i < MAX_WEAPON_TYPES; i++) {
@@ -1715,7 +1686,7 @@ void Editor::generate_team_weaponry_usage_list(int team, int* arr)
 	}
 
 	if (The_mission.game_type & MISSION_TYPE_MULTI_TEAMS) {
-		Assert(team >= 0 && team < MAX_TVT_TEAMS);
+		Assert (team >= 0 && team < MAX_TVT_TEAMS);
 
 		for (i = 0; i < MAX_TVT_WINGS_PER_TEAM; i++) {
 			generate_wing_weaponry_usage_list(arr, TVT_wings[(team * MAX_TVT_WINGS_PER_TEAM) + i]);
@@ -1726,16 +1697,15 @@ void Editor::generate_team_weaponry_usage_list(int team, int* arr)
 		}
 	}
 }
-void Editor::delete_marked()
-{
-	object *ptr, *next;
+void Editor::delete_marked() {
+	object* ptr, * next;
 
 	delete_flag = 0;
-	ptr         = GET_FIRST(&obj_used_list);
+	ptr = GET_FIRST(&obj_used_list);
 	while (ptr != END_OF_LIST(&obj_used_list)) {
 		next = GET_NEXT(ptr);
 		if (ptr->flags[Object::Object_Flags::Marked]) {
-			if (delete_object(OBJ_INDEX(ptr)) == 2) { // user went to a reference, so don't get in the way.
+			if (delete_object(OBJ_INDEX(ptr)) == 2) {  // user went to a reference, so don't get in the way.
 				break;
 			}
 		}
@@ -1749,8 +1719,7 @@ void Editor::delete_marked()
 
 	missionChanged();
 }
-void Editor::select_next_subsystem()
-{
+void Editor::select_next_subsystem() {
 
 	object* objp;
 
@@ -1780,7 +1749,7 @@ void Editor::select_next_subsystem()
 
 			// set up new and advance to first
 			Render_subsys.do_render = true;
-			Render_subsys.ship_obj  = objp;
+			Render_subsys.ship_obj = objp;
 			if (!get_next_visible_subsys(&Ships[objp->instance], &Render_subsys.cur_subsys)) {
 				cancel_select_subsystem();
 			}
@@ -1790,14 +1759,13 @@ void Editor::select_next_subsystem()
 		cancel_select_subsystem();
 	}
 }
-void Editor::select_previous_subsystem()
-{
+void Editor::select_previous_subsystem() {
 	if (!Render_subsys.do_render) {
 		return;
 	}
 
-	if ((currentObject < 0) || (Objects[currentObject].type != OBJ_SHIP) ||
-	    (&Objects[currentObject] != Render_subsys.ship_obj)) {
+	if ((currentObject < 0) || (Objects[currentObject].type != OBJ_SHIP)
+		|| (&Objects[currentObject] != Render_subsys.ship_obj)) {
 		cancel_select_subsystem();
 		return;
 	}
@@ -1805,21 +1773,20 @@ void Editor::select_previous_subsystem()
 	if (!get_prev_visible_subsys(&Ships[Objects[currentObject].instance], &Render_subsys.cur_subsys)) {
 		cancel_select_subsystem();
 	}
+
 }
-void Editor::cancel_select_subsystem()
-{
-	Render_subsys.do_render  = false;
-	Render_subsys.ship_obj   = NULL;
+void Editor::cancel_select_subsystem() {
+	Render_subsys.do_render = false;
+	Render_subsys.ship_obj = NULL;
 	Render_subsys.cur_subsys = NULL;
 	updateAllViewports();
 }
-int Editor::get_visible_sub_system_count(ship* shipp)
-{
+int Editor::get_visible_sub_system_count(ship * shipp) {
 	int count = 0;
 	ship_subsys* cur_subsys;
 
 	for (cur_subsys = GET_FIRST(&shipp->subsys_list); cur_subsys != END_OF_LIST(&shipp->subsys_list);
-	     cur_subsys = GET_NEXT(cur_subsys)) {
+		 cur_subsys = GET_NEXT(cur_subsys)) {
 		if (cur_subsys->system_info->subobj_num != -1) {
 			count++;
 		}
@@ -1827,8 +1794,7 @@ int Editor::get_visible_sub_system_count(ship* shipp)
 
 	return count;
 }
-int Editor::get_next_visible_subsys(ship* shipp, ship_subsys** next_subsys)
-{
+int Editor::get_next_visible_subsys(ship * shipp, ship_subsys * *next_subsys) {
 	int count = get_visible_sub_system_count(shipp);
 
 	// return don't try to display
@@ -1843,7 +1809,7 @@ int Editor::get_next_visible_subsys(ship* shipp, ship_subsys** next_subsys)
 
 	// look before wrap
 	for (*next_subsys = GET_NEXT(*next_subsys); *next_subsys != END_OF_LIST(&shipp->subsys_list);
-	     *next_subsys = GET_NEXT(*next_subsys)) {
+		 *next_subsys = GET_NEXT(*next_subsys)) {
 		if ((*next_subsys)->system_info->subobj_num != -1) {
 			updateAllViewports();
 			return 1;
@@ -1852,18 +1818,17 @@ int Editor::get_next_visible_subsys(ship* shipp, ship_subsys** next_subsys)
 
 	// look for first after wrap
 	for (*next_subsys = GET_FIRST(&shipp->subsys_list); *next_subsys != END_OF_LIST(&shipp->subsys_list);
-	     *next_subsys = GET_NEXT(*next_subsys)) {
+		 *next_subsys = GET_NEXT(*next_subsys)) {
 		if ((*next_subsys)->system_info->subobj_num != -1) {
 			updateAllViewports();
 			return 1;
 		}
 	}
 
-	Int3(); // should be impossible to miss
+	Int3();    // should be impossible to miss
 	return 0;
 }
-int Editor::get_prev_visible_subsys(ship* shipp, ship_subsys** prev_subsys)
-{
+int Editor::get_prev_visible_subsys(ship * shipp, ship_subsys * *prev_subsys) {
 	int count = get_visible_sub_system_count(shipp);
 
 	// return don't try to display
@@ -1876,7 +1841,7 @@ int Editor::get_prev_visible_subsys(ship* shipp, ship_subsys** prev_subsys)
 
 	// look before wrap
 	for (*prev_subsys = GET_PREV(*prev_subsys); *prev_subsys != END_OF_LIST(&shipp->subsys_list);
-	     *prev_subsys = GET_PREV(*prev_subsys)) {
+		 *prev_subsys = GET_PREV(*prev_subsys)) {
 		if ((*prev_subsys)->system_info->subobj_num != -1) {
 			updateAllViewports();
 			return 1;
@@ -1885,24 +1850,25 @@ int Editor::get_prev_visible_subsys(ship* shipp, ship_subsys** prev_subsys)
 
 	// look for first after wrap
 	for (*prev_subsys = GET_LAST(&shipp->subsys_list); *prev_subsys != END_OF_LIST(&shipp->subsys_list);
-	     *prev_subsys = GET_PREV(*prev_subsys)) {
+		 *prev_subsys = GET_PREV(*prev_subsys)) {
 		if ((*prev_subsys)->system_info->subobj_num != -1) {
 			updateAllViewports();
 			return 1;
 		}
 	}
 
-	Int3(); // should be impossible to miss
+	Int3();    // should be impossible to miss
 	return 0;
 }
-bool Editor::global_error_check()
-{
+bool Editor::global_error_check() {
 	int z;
 
 	z = global_error_check_impl();
 	if (!z) {
-		_lastActiveViewport->dialogProvider->showButtonDialog(
-		    DialogType::Information, "Woohoo!", "No errors were detected in this mission", {DialogButton::Ok});
+		_lastActiveViewport->dialogProvider->showButtonDialog(DialogType::Information,
+															  "Woohoo!",
+															  "No errors were detected in this mission",
+															  { DialogButton::Ok });
 	}
 
 	for (z = 0; z < obj_count; z++) {
@@ -1915,8 +1881,7 @@ bool Editor::global_error_check()
 
 	return !z;
 }
-int Editor::global_error_check_impl()
-{
+int Editor::global_error_check_impl() {
 
 	char buf[256];
 	const char* str;
@@ -1929,17 +1894,17 @@ int Editor::global_error_check_impl()
 		multi = 1;
 	}
 
-	//	if (!stricmp(The_mission.name, "Untitled"))
-	//		if (error("You haven't given this mission a title yet.\nThis is done from the Mission Specs Editor
-	//(Shift-N).")) 			return 1;
+//	if (!stricmp(The_mission.name, "Untitled"))
+//		if (error("You haven't given this mission a title yet.\nThis is done from the Mission Specs Editor (Shift-N)."))
+//			return 1;
 
 	// cycle though all the objects and verify every possible aspect of them
 	obj_count = t = 0;
-	ptr           = GET_FIRST(&obj_used_list);
+	ptr = GET_FIRST(&obj_used_list);
 	while (ptr != END_OF_LIST(&obj_used_list)) {
-		names[obj_count]     = NULL;
+		names[obj_count] = NULL;
 		err_flags[obj_count] = 0;
-		i                    = ptr->instance;
+		i = ptr->instance;
 		if ((ptr->type == OBJ_SHIP) || (ptr->type == OBJ_START)) {
 			if (i < 0 || i >= MAX_SHIPS) {
 				return internal_error("An object has an illegal ship index");
@@ -1985,9 +1950,9 @@ int Editor::global_error_check_impl()
 			}
 
 			names[obj_count] = Ships[i].ship_name;
-			wing             = Ships[i].wingnum;
-			if (wing >= 0) {                         // ship is part of a wing, so check this
-				if (wing < 0 || wing >= MAX_WINGS) { // completely out of range?
+			wing = Ships[i].wingnum;
+			if (wing >= 0) {  // ship is part of a wing, so check this
+				if (wing < 0 || wing >= MAX_WINGS) {  // completely out of range?
 					return internal_error("A ship has an illegal wing index");
 				}
 
@@ -2001,7 +1966,7 @@ int Editor::global_error_check_impl()
 				}
 
 				while (j--) {
-					if (wing_objects[wing][j] == OBJ_INDEX(ptr)) { // look for object in wing's table
+					if (wing_objects[wing][j] == OBJ_INDEX(ptr)) {  // look for object in wing's table
 						break;
 					}
 				}
@@ -2019,8 +1984,8 @@ int Editor::global_error_check_impl()
 						}
 					} else {
 						if (ptr->type == OBJ_START) {
-							if (error("A squad logo was assigned to the player's wing.  The player's squad logo will "
-							          "be displayed instead of the wing squad logo on ships in this wing.")) {
+							if (error(
+								"A squad logo was assigned to the player's wing.  The player's squad logo will be displayed instead of the wing squad logo on ships in this wing.")) {
 								return 1;
 							}
 						}
@@ -2047,7 +2012,7 @@ int Editor::global_error_check_impl()
 				return internal_error("Object references an illegal waypoint path number");
 			}
 
-			if (waypoint_num < 0 || (uint)waypoint_num >= wp_list->get_waypoints().size()) {
+			if (waypoint_num < 0 || (uint) waypoint_num >= wp_list->get_waypoints().size()) {
 				return internal_error("Object references an illegal waypoint number in path");
 			}
 
@@ -2059,13 +2024,13 @@ int Editor::global_error_check_impl()
 			// TODO: Fix this once the briefing dialog exists
 			/*
 			if (!Briefing_dialog) {
-			    return internal_error("Briefing icon detected when not in briefing edit mode");
+				return internal_error("Briefing icon detected when not in briefing edit mode");
 			}
 			 */
-			// Shouldn't be needed anymore.
-			// If we really do need it, call me and I'll write a is_valid function for jumpnodes -WMC
+			//Shouldn't be needed anymore.
+			//If we really do need it, call me and I'll write a is_valid function for jumpnodes -WMC
 		} else if (ptr->type == OBJ_JUMP_NODE) {
-			// nothing needs to be done here, we just need to make sure the else doesn't occur
+			//nothing needs to be done here, we just need to make sure the else doesn't occur
 		} else {
 			return internal_error("An unknown object type (%d) was detected", ptr->type);
 		}
@@ -2092,7 +2057,7 @@ int Editor::global_error_check_impl()
 
 	count = 0;
 	for (i = 0; i < MAX_SHIPS; i++) {
-		if (Ships[i].objnum >= 0) { // is ship being used?
+		if (Ships[i].objnum >= 0) {  // is ship being used?
 			count++;
 			if (!query_valid_object(Ships[i].objnum)) {
 				return internal_error("Ship uses an unused object");
@@ -2146,8 +2111,9 @@ int Editor::global_error_check_impl()
 				}
 			}
 
+
 			for (dock_instance* dock_ptr = Objects[Ships[i].objnum].dock_list; dock_ptr != NULL;
-			     dock_ptr                = dock_ptr->next) {
+				 dock_ptr = dock_ptr->next) {
 				obj = OBJ_INDEX(dock_ptr->docked_objp);
 
 				if (!query_valid_object(obj)) {
@@ -2161,25 +2127,28 @@ int Editor::global_error_check_impl()
 				ship = get_ship_from_obj(obj);
 				if (!ship_docking_valid(i, ship) && !ship_docking_valid(ship, i)) {
 					return internal_error("Docking illegal between \"%s\" and \"%s\" (initially docked)",
-					                      Ships[i].ship_name, Ships[ship].ship_name);
+										  Ships[i].ship_name,
+										  Ships[ship].ship_name);
 				}
 
 				auto dock_list = get_docking_list(Ship_info[Ships[i].ship_info_index].model_num);
-				point          = dock_ptr->dockpoint_used;
+				point = dock_ptr->dockpoint_used;
 				if (point < 0 || point >= (int)dock_list.size()) {
-					internal_error("Invalid docker point (\"%s\" initially docked with \"%s\")", Ships[i].ship_name,
-					               Ships[ship].ship_name);
+					internal_error("Invalid docker point (\"%s\" initially docked with \"%s\")",
+								   Ships[i].ship_name,
+								   Ships[ship].ship_name);
 				}
 
 				dock_list = get_docking_list(Ship_info[Ships[ship].ship_info_index].model_num);
-				point     = dock_find_dockpoint_used_by_object(dock_ptr->docked_objp, &Objects[Ships[i].objnum]);
+				point = dock_find_dockpoint_used_by_object(dock_ptr->docked_objp, &Objects[Ships[i].objnum]);
 				if (point < 0 || point >= (int)dock_list.size()) {
-					internal_error("Invalid dockee point (\"%s\" initially docked with \"%s\")", Ships[i].ship_name,
-					               Ships[ship].ship_name);
+					internal_error("Invalid dockee point (\"%s\" initially docked with \"%s\")",
+								   Ships[i].ship_name,
+								   Ships[ship].ship_name);
 				}
 			}
 
-			wing                      = Ships[i].wingnum;
+			wing = Ships[i].wingnum;
 			bool is_in_loadout_screen = (ptr->type == OBJ_START);
 			if (!is_in_loadout_screen && wing >= 0) {
 				if (multi && The_mission.game_type & MISSION_TYPE_MULTI_TEAMS) {
@@ -2200,17 +2169,17 @@ int Editor::global_error_check_impl()
 			}
 			if (is_in_loadout_screen) {
 				int illegal = 0;
-				z           = Ships[i].ship_info_index;
+				z = Ships[i].ship_info_index;
 				for (n = 0; n < MAX_SHIP_PRIMARY_BANKS; n++) {
-					if (Ships[i].weapons.primary_bank_weapons[n] >= 0 &&
-					    !Ship_info[z].allowed_weapons[Ships[i].weapons.primary_bank_weapons[n]]) {
+					if (Ships[i].weapons.primary_bank_weapons[n] >= 0
+						&& !Ship_info[z].allowed_weapons[Ships[i].weapons.primary_bank_weapons[n]]) {
 						illegal++;
 					}
 				}
 
 				for (n = 0; n < MAX_SHIP_SECONDARY_BANKS; n++) {
-					if (Ships[i].weapons.secondary_bank_weapons[n] >= 0 &&
-					    !Ship_info[z].allowed_weapons[Ships[i].weapons.secondary_bank_weapons[n]]) {
+					if (Ships[i].weapons.secondary_bank_weapons[n] >= 0
+						&& !Ship_info[z].allowed_weapons[Ships[i].weapons.secondary_bank_weapons[n]]) {
 						illegal++;
 					}
 				}
@@ -2229,8 +2198,8 @@ int Editor::global_error_check_impl()
 	count = 0;
 	for (i = 0; i < MAX_WINGS; i++) {
 		team = -1;
-		j    = Wings[i].wave_count;
-		if (j) { // is wing being used?
+		j = Wings[i].wave_count;
+		if (j) {  // is wing being used?
 			count++;
 			if (j < 0 || j > MAX_SHIPS_PER_WING) {
 				return internal_error("Invalid number of ships in wing \"%s\"", Wings[i].name);
@@ -2246,16 +2215,17 @@ int Editor::global_error_check_impl()
 					return internal_error("Wing_objects references an unused object");
 				}
 
-				// Now, at this point, we can assume several things.  We have a valid object because
-				// we passed query_valid_object(), and all valid objects were already checked above,
-				// so this object has valid information, such as the instance.
+// Now, at this point, we can assume several things.  We have a valid object because
+// we passed query_valid_object(), and all valid objects were already checked above,
+// so this object has valid information, such as the instance.
 
 				if ((Objects[obj].type == OBJ_SHIP) || (Objects[obj].type == OBJ_START)) {
 					ship = Objects[obj].instance;
 					wing_bash_ship_name(buf, Wings[i].name, j + 1);
 					if (stricmp(buf, Ships[ship].ship_name) != 0) {
-						return internal_error("Ship \"%s\" in wing should be called \"%s\"", Ships[ship].ship_name,
-						                      buf);
+						return internal_error("Ship \"%s\" in wing should be called \"%s\"",
+											  Ships[ship].ship_name,
+											  buf);
 					}
 
 					int ship_type = ship_query_general_type(ship);
@@ -2299,8 +2269,9 @@ int Editor::global_error_check_impl()
 
 			if (Wings[i].threshold + Wings[i].wave_count > MAX_SHIPS_PER_WING) {
 				Wings[i].threshold = MAX_SHIPS_PER_WING - Wings[i].wave_count;
-				if (error("Threshold for wing \"%s\" is higher than allowed.  Reset to %d", Wings[i].name,
-				          Wings[i].threshold)) {
+				if (error("Threshold for wing \"%s\" is higher than allowed.  Reset to %d",
+						  Wings[i].name,
+						  Wings[i].threshold)) {
 					return 1;
 				}
 			}
@@ -2346,6 +2317,7 @@ int Editor::global_error_check_impl()
 					return 1;
 				}
 			}
+
 		}
 	}
 
@@ -2363,7 +2335,7 @@ int Editor::global_error_check_impl()
 			}
 		}
 
-		for (j = 0; (uint)j < ii->get_waypoints().size(); j++) {
+		for (j = 0; (uint) j < ii->get_waypoints().size(); j++) {
 			sprintf(buf, "%s:%d", ii->get_name(), j + 1);
 			for (z = 0; z < obj_count; z++) {
 				if (names[z]) {
@@ -2414,24 +2386,24 @@ int Editor::global_error_check_impl()
 		}
 	}
 
-	/*	for (i=0; i<num_messages; i++) {
-	        if (Messages[i].num_times < 0)
-	            return internal_error("Number of times to play message is negative");
+/*	for (i=0; i<num_messages; i++) {
+		if (Messages[i].num_times < 0)
+			return internal_error("Number of times to play message is negative");
 
-	        z = Messages[i].who_from;
-	        if (z < -1 || z >= MAX_SHIPS)  // hacked!  -1 should be illegal..
-	            return internal_error("Message originator index is out of range");
+		z = Messages[i].who_from;
+		if (z < -1 || z >= MAX_SHIPS)  // hacked!  -1 should be illegal..
+			return internal_error("Message originator index is out of range");
 
-	        if (Ships[z].objnum == -1)
-	            return internal_error("Message originator points to nonexistant ship");
+		if (Ships[z].objnum == -1)
+			return internal_error("Message originator points to nonexistant ship");
 
-	        if (fred_check_sexp(Messages[i].sexp, OPR_BOOL,
-	            "Message formula from \"%s\"", Ships[Messages[i].who_from].ship_name))
-	                return -1;
-	    }*/
+		if (fred_check_sexp(Messages[i].sexp, OPR_BOOL,
+			"Message formula from \"%s\"", Ships[Messages[i].who_from].ship_name))
+				return -1;
+	}*/
 
-	Assert((Player_start_shipnum >= 0) && (Player_start_shipnum < MAX_SHIPS) &&
-	       (Ships[Player_start_shipnum].objnum >= 0));
+	Assert(
+		(Player_start_shipnum >= 0) && (Player_start_shipnum < MAX_SHIPS) && (Ships[Player_start_shipnum].objnum >= 0));
 	i = global_error_check_player_wings(multi);
 	if (i) {
 		return i;
@@ -2452,7 +2424,7 @@ int Editor::global_error_check_impl()
 	for (bs = 0; bs < Num_teams; bs++) {
 		for (s = 0; s < Briefings[bs].num_stages; s++) {
 			sp = &Briefings[bs].stages[s];
-			t  = sp->num_icons;
+			t = sp->num_icons;
 			for (i = 0; i < t - 1; i++) {
 				for (j = i + 1; j < t; j++) {
 					if ((sp->icons[i].id > 0) && (sp->icons[i].id == sp->icons[j].id)) {
@@ -2487,10 +2459,10 @@ int Editor::global_error_check_impl()
 
 		// first, be sure this isn't a reinforcement wing.
 		if (starting_wing && (Wings[i].flags[Ship::Wing_Flags::Reinforcement])) {
-			if (error("Starting Wing %s marked as reinforcement.  This wing\nshould either be renamed, or unmarked as "
-			          "reinforcement.",
-			          Wings[i].name)) {
-				// Goober5000				return 1;
+			if (error(
+				"Starting Wing %s marked as reinforcement.  This wing\nshould either be renamed, or unmarked as reinforcement.",
+				Wings[i].name)) {
+// Goober5000				return 1;
 			}
 		}
 
@@ -2502,44 +2474,43 @@ int Editor::global_error_check_impl()
 			if (j == 0) {
 				default_orders = orders;
 			} else if (default_orders != orders) {
-				if (error("%s and %s will accept different orders. All ships in a wing must accept the same Player "
-				          "Orders.",
-				          Ships[Wings[i].ship_index[j]].ship_name, Ships[Wings[i].ship_index[0]].ship_name)) {
+				if (error(
+					"%s and %s will accept different orders. All ships in a wing must accept the same Player Orders.",
+					Ships[Wings[i].ship_index[j]].ship_name,
+					Ships[Wings[i].ship_index[0]].ship_name)) {
 					return 1;
 				}
 			}
 		}
 
-		/* Goober5000 - this is not necessary
-		        // make sure that these ignored orders are the same for all starting wings of the player
-		        if ( starting_wing ) {
-		            if ( starting_orders == -1 ) {
-		                starting_orders = default_orders;
-		            } else {
-		                if ( starting_orders != default_orders ) {
-		                    if ( error("Player starting wing %s has orders which don't match other starting wings\n",
-		Wings[i].name) ){
-		// Goober5000						return 1;
-		                    }
-		                }
-		            }
-		        }
-		*/
+/* Goober5000 - this is not necessary
+		// make sure that these ignored orders are the same for all starting wings of the player
+		if ( starting_wing ) {
+			if ( starting_orders == -1 ) {
+				starting_orders = default_orders;
+			} else {
+				if ( starting_orders != default_orders ) {
+					if ( error("Player starting wing %s has orders which don't match other starting wings\n", Wings[i].name) ){
+// Goober5000						return 1;
+					}
+				}
+			}
+		}
+*/
 	}
 
-	// This should never ever be a problem -WMC
+	//This should never ever be a problem -WMC
 	/*
 	if (Num_jump_nodes < 0){
-	    return internal_error("Jump node count is illegal");
+		return internal_error("Jump node count is illegal");
 	}*/
 
 	// FIXME: This call was in the original function but the code of that function was entirely commented out
-	// fred_check_message_personas();
+	//fred_check_message_personas();
 
 	return g_err;
 }
-int Editor::error(const char* msg, ...)
-{
+int Editor::error(const char* msg, ...) {
 	char buf[2048];
 	va_list args;
 
@@ -2549,15 +2520,17 @@ int Editor::error(const char* msg, ...)
 	buf[sizeof(buf) - 1] = '\0';
 
 	g_err = 1;
-	if (_lastActiveViewport->dialogProvider->showButtonDialog(
-	        DialogType::Error, "Error", buf, {DialogButton::Ok, DialogButton::Cancel}) == DialogButton::Ok) {
+	if (_lastActiveViewport->dialogProvider->showButtonDialog(DialogType::Error,
+															  "Error",
+															  buf,
+															  { DialogButton::Ok, DialogButton::Cancel })
+		== DialogButton::Ok) {
 		return 0;
 	}
 
 	return 1;
 }
-int Editor::internal_error(const char* msg, ...)
-{
+int Editor::internal_error(const char* msg, ...) {
 	char buf[2048];
 	va_list args;
 
@@ -2571,24 +2544,23 @@ int Editor::internal_error(const char* msg, ...)
 #ifndef NDEBUG
 	char buf2[2048];
 
-	sprintf_safe(buf2,
-	             "%s\n\nThis is an internal error.  Please let Jason\n"
-	             "know about this so he can fix it.  Click cancel to debug.",
-	             buf);
+	sprintf_safe(buf2, "%s\n\nThis is an internal error.  Please let Jason\n"
+		"know about this so he can fix it.  Click cancel to debug.", buf);
 
-	if (_lastActiveViewport->dialogProvider->showButtonDialog(DialogType::Error, "Internal Error", buf2,
-	                                                          {DialogButton::Ok, DialogButton::Cancel}) ==
-	    DialogButton::Cancel)
-		Int3(); // drop to debugger so the problem can be analyzed.
+	if (_lastActiveViewport->dialogProvider->showButtonDialog(DialogType::Error,
+															  "Internal Error",
+															  buf2,
+															  { DialogButton::Ok, DialogButton::Cancel })
+		== DialogButton::Cancel)
+		Int3();  // drop to debugger so the problem can be analyzed.
 
 #else
-	_lastActiveViewport->dialogProvider->showButtonDialog(DialogType::Error, "Error", buf, {DialogButton::Ok});
+	_lastActiveViewport->dialogProvider->showButtonDialog(DialogType::Error, "Error", buf, { DialogButton::Ok });
 #endif
 
 	return -1;
 }
-int Editor::fred_check_sexp(int sexp, int type, const char* msg, ...)
-{
+int Editor::fred_check_sexp(int sexp, int type, const char* msg, ...) {
 	SCP_string buf, sexp_buf, error_buf;
 	int err = 0, z, faulty_node;
 	va_list args;
@@ -2606,8 +2578,12 @@ int Editor::fred_check_sexp(int sexp, int type, const char* msg, ...)
 
 	convert_sexp_to_string(sexp_buf, sexp, SEXP_ERROR_CHECK_MODE);
 	truncate_message_lines(sexp_buf, 30);
-	sprintf(error_buf, "Error in %s: %s\n\nIn sexpression: %s\n\n(Error appears to be: %s)", buf.c_str(),
-	        sexp_error_message(z), sexp_buf.c_str(), Sexp_nodes[faulty_node].text);
+	sprintf(error_buf,
+			"Error in %s: %s\n\nIn sexpression: %s\n\n(Error appears to be: %s)",
+			buf.c_str(),
+			sexp_error_message(z),
+			sexp_buf.c_str(),
+			Sexp_nodes[faulty_node].text);
 
 	if (z < 0 && z > -100)
 		err = 1;
@@ -2620,16 +2596,15 @@ int Editor::fred_check_sexp(int sexp, int type, const char* msg, ...)
 
 	return 0;
 }
-const char* Editor::error_check_initial_orders(ai_goal* goals, int ship, int wing)
-{
-	char* source;
+const char* Editor::error_check_initial_orders(ai_goal* goals, int ship, int wing) {
+	char *source;
 	int i, j, flag, found, inst, team, team2;
-	object* ptr;
+	object *ptr;
 
 	if (ship >= 0) {
 		source = Ships[ship].ship_name;
-		team   = Ships[ship].team;
-		for (i = 0; i < MAX_AI_GOALS; i++)
+		team = Ships[ship].team;
+		for (i=0; i<MAX_AI_GOALS; i++)
 			if (!ai_query_goal_valid(ship, goals[i].ai_mode)) {
 				if (error("Order \"%s\" isn't allowed for ship \"%s\"", get_order_name(goals[i].ai_mode), source))
 					return "!";
@@ -2639,17 +2614,17 @@ const char* Editor::error_check_initial_orders(ai_goal* goals, int ship, int win
 		Assert(wing >= 0);
 		Assert(Wings[wing].wave_count > 0);
 		source = Wings[wing].name;
-		team   = Ships[Objects[wing_objects[wing][0]].instance].team;
-		for (j = 0; j < Wings[wing].wave_count; j++)
-			for (i = 0; i < MAX_AI_GOALS; i++)
+		team = Ships[Objects[wing_objects[wing][0]].instance].team;
+		for (j=0; j<Wings[wing].wave_count; j++)
+			for (i=0; i<MAX_AI_GOALS; i++)
 				if (!ai_query_goal_valid(Wings[wing].ship_index[j], goals[i].ai_mode)) {
 					if (error("Order \"%s\" isn't allowed for ship \"%s\"", get_order_name(goals[i].ai_mode),
-					          Ships[Wings[wing].ship_index[j]].ship_name))
+											 Ships[Wings[wing].ship_index[j]].ship_name))
 						return "!";
 				}
 	}
 
-	for (i = 0; i < MAX_AI_GOALS; i++) {
+	for (i=0; i<MAX_AI_GOALS; i++) {
 		switch (goals[i].ai_mode) {
 		case AI_GOAL_NONE:
 		case AI_GOAL_CHASE_ANY:
@@ -2710,11 +2685,11 @@ const char* Editor::error_check_initial_orders(ai_goal* goals, int ship, int win
 		}
 
 		inst = team2 = -1;
-		if (flag == 1) { // target waypoint required
+		if (flag == 1) {  // target waypoint required
 			if (find_matching_waypoint_list(goals[i].target_name) == NULL)
 				return "*Invalid target waypoint path name";
 
-		} else if (flag == 2) { // target ship required
+		} else if (flag == 2) {  // target ship required
 			ptr = GET_FIRST(&obj_used_list);
 			while (ptr != END_OF_LIST(&obj_used_list)) {
 				if (ptr->type == OBJ_SHIP || ptr->type == OBJ_START) {
@@ -2731,22 +2706,22 @@ const char* Editor::error_check_initial_orders(ai_goal* goals, int ship, int win
 			if (!found)
 				return "*Invalid target ship name";
 
-			if (wing >= 0) { // check if target ship is in wing
+			if (wing >= 0) {  // check if target ship is in wing
 				if (Ships[inst].wingnum == wing && Objects[Ships[inst].objnum].type != OBJ_START)
 					return "Target ship of wing's goal is within said wing";
 			}
 
 			team2 = Ships[inst].team;
 
-		} else if (flag == 3) { // target wing required
-			for (j = 0; j < MAX_WINGS; j++)
+		} else if (flag == 3) {  // target wing required
+			for (j=0; j<MAX_WINGS; j++)
 				if (Wings[j].wave_count && !stricmp(Wings[j].name, goals[i].target_name))
 					break;
 
 			if (j >= MAX_WINGS)
 				return "*Invalid target wing name";
 
-			if (ship >= 0) { // check if ship is in target wing
+			if (ship >= 0) {  // check if ship is in target wing
 				if (Ships[ship].wingnum == j)
 					return "Target wing of ship's goal is same wing said ship is part of";
 			}
@@ -2777,7 +2752,7 @@ const char* Editor::error_check_initial_orders(ai_goal* goals, int ship, int win
 				return "*Invalid target ship or waypoint name";
 
 			if (found == 2) {
-				if (wing >= 0) { // check if target ship is in wing
+				if (wing >= 0) {  // check if target ship is in wing
 					if (Ships[inst].wingnum == wing && Objects[Ships[inst].objnum].type != OBJ_START)
 						return "Target ship of wing's goal is within said wing";
 				}
@@ -2801,7 +2776,7 @@ const char* Editor::error_check_initial_orders(ai_goal* goals, int ship, int win
 			if (!ship_docking_valid(ship, inst))
 				return "Docking illegal between given ship types";
 
-			model1           = Ship_info[Ships[ship].ship_info_index].model_num;
+			model1 = Ship_info[Ships[ship].ship_info_index].model_num;
 			auto model1Docks = get_docking_list(model1);
 			for (j = 0; j < (int)model1Docks.size(); ++j) {
 				if (!stricmp(goals[i].docker.name, model1Docks[j].c_str())) {
@@ -2810,7 +2785,7 @@ const char* Editor::error_check_initial_orders(ai_goal* goals, int ship, int win
 				}
 			}
 
-			model2           = Ship_info[Ships[inst].ship_info_index].model_num;
+			model2 = Ship_info[Ships[inst].ship_info_index].model_num;
 			auto model2Docks = get_docking_list(model2);
 			for (j = 0; j < (int)model2Docks.size(); ++j) {
 				if (!stricmp(goals[i].dockee.name, model2Docks[j].c_str())) {
@@ -2826,7 +2801,7 @@ const char* Editor::error_check_initial_orders(ai_goal* goals, int ship, int win
 				return "Invalid dockee point";
 
 			if ((dock1 >= 0) && (dock2 >= 0)) {
-				if (!(model_get_dock_index_type(model1, dock1) & model_get_dock_index_type(model2, dock2)))
+				if ( !(model_get_dock_index_type(model1, dock1) & model_get_dock_index_type(model2, dock2)) )
 					return "Dock points are incompatible";
 			}
 
@@ -2837,7 +2812,7 @@ const char* Editor::error_check_initial_orders(ai_goal* goals, int ship, int win
 		switch (goals[i].ai_mode) {
 		case AI_GOAL_GUARD:
 		case AI_GOAL_GUARD_WING:
-			if (team != team2) { //	MK, added support for TEAM_NEUTRAL.  Won't this work?
+			if (team != team2) {	//	MK, added support for TEAM_NEUTRAL.  Won't this work?
 				if (ship >= 0)
 					return "Ship assigned to guard a different team";
 				else
@@ -2864,9 +2839,8 @@ const char* Editor::error_check_initial_orders(ai_goal* goals, int ship, int win
 
 	return NULL;
 }
-const char* Editor::get_order_name(int order)
-{
-	if (order == AI_GOAL_NONE) // special case
+const char* Editor::get_order_name(int order) {
+	if (order == AI_GOAL_NONE)  // special case
 		return "None";
 
 	for (auto& entry : Ai_goal_list)
@@ -2875,61 +2849,68 @@ const char* Editor::get_order_name(int order)
 
 	return "???";
 }
-SCP_vector<SCP_string> Editor::get_docking_list(int model_index)
-{
+SCP_vector<SCP_string> Editor::get_docking_list(int model_index) {
 	int i;
-	polymodel* pm;
+	polymodel *pm;
 	SCP_vector<SCP_string> out;
 
 	pm = model_get(model_index);
 	out.reserve(pm->n_docks);
 
-	for (i = 0; i < pm->n_docks; i++)
+	for (i=0; i<pm->n_docks; i++)
 		out.push_back(pm->docking_bays[i].name);
 
 	return out;
 }
-int Editor::global_error_check_player_wings(int multi)
-{
+int Editor::global_error_check_player_wings(int multi) {
 	int i, z, err;
 	int starting_wing_count[MAX_STARTING_WINGS];
 	int tvt_wing_count[MAX_TVT_WINGS];
 
-	object* ptr;
+	object *ptr;
 	SCP_string starting_wing_list = "";
-	SCP_string tvt_wing_list      = "";
+	SCP_string tvt_wing_list = "";
 
 	// check team wings in tvt
-	if (multi && The_mission.game_type & MISSION_TYPE_MULTI_TEAMS) {
-		for (i = 0; i < MAX_TVT_WINGS; i++) {
-			if (ship_tvt_wing_lookup(TVT_wing_names[i]) == -1) {
+	if ( multi && The_mission.game_type & MISSION_TYPE_MULTI_TEAMS )
+	{
+		for (i=0; i<MAX_TVT_WINGS; i++)
+		{
+			if (ship_tvt_wing_lookup(TVT_wing_names[i]) == -1)
+			{
 				if (error("%s wing is required for multiplayer team vs. team missions", TVT_wing_names[i]))
 					return 1;
 			}
 		}
 	}
 
-	//	// player's wing must have a true arrival
-	//	free_sexp2(Wings[z].arrival_cue);
-	//	Wings[z].arrival_cue = Locked_sexp_true;
+//	// player's wing must have a true arrival
+//	free_sexp2(Wings[z].arrival_cue);
+//	Wings[z].arrival_cue = Locked_sexp_true;
 
 	// Check to be sure that any player wing doesn't have > 1 wave for multiplayer
-	if (multi) {
-		if (The_mission.game_type & MISSION_TYPE_MULTI_TEAMS) {
-			for (i = 0; i < MAX_TVT_WINGS; i++) {
-				if (TVT_wings[i] >= 0 && Wings[TVT_wings[i]].num_waves > 1) {
+	if ( multi )
+	{
+		if ( The_mission.game_type & MISSION_TYPE_MULTI_TEAMS )
+		{
+			for (i=0; i<MAX_TVT_WINGS; i++)
+			{
+				if (TVT_wings[i] >= 0 && Wings[TVT_wings[i]].num_waves > 1)
+				{
 					Wings[TVT_wings[i]].num_waves = 1;
-					if (error("%s wing must contain only 1 wave.\nThis change has been made for you.",
-					          TVT_wing_names[i]))
+					if (error("%s wing must contain only 1 wave.\nThis change has been made for you.", TVT_wing_names[i]))
 						return 1;
 				}
 			}
-		} else {
-			for (i = 0; i < MAX_STARTING_WINGS; i++) {
-				if (Starting_wings[i] >= 0 && Wings[Starting_wings[i]].num_waves > 1) {
+		}
+		else
+		{
+			for (i=0; i<MAX_STARTING_WINGS; i++)
+			{
+				if (Starting_wings[i] >= 0 && Wings[Starting_wings[i]].num_waves > 1)
+				{
 					Wings[Starting_wings[i]].num_waves = 1;
-					if (error("%s wing must contain only 1 wave.\nThis change has been made for you.",
-					          Starting_wing_names[i]))
+					if (error("%s wing must contain only 1 wave.\nThis change has been made for you.", Starting_wing_names[i]))
 						return 1;
 				}
 			}
@@ -2937,16 +2918,23 @@ int Editor::global_error_check_player_wings(int multi)
 	}
 
 	// check number of ships in player wing
-	if (multi && The_mission.game_type & MISSION_TYPE_MULTI_TEAMS) {
-		for (i = 0; i < MAX_TVT_WINGS; i++) {
-			if (TVT_wings[i] >= 0 && Wings[TVT_wings[i]].wave_count > 4) {
+	if ( multi && The_mission.game_type & MISSION_TYPE_MULTI_TEAMS )
+	{
+		for (i=0; i<MAX_TVT_WINGS; i++)
+		{
+			if (TVT_wings[i] >= 0 && Wings[TVT_wings[i]].wave_count > 4)
+			{
 				if (error("%s wing has too many ships.  Should only have 4 max.", TVT_wing_names[i]))
 					return 1;
 			}
 		}
-	} else {
-		for (i = 0; i < MAX_STARTING_WINGS; i++) {
-			if (Starting_wings[i] >= 0 && Wings[Starting_wings[i]].wave_count > 4) {
+	}
+	else
+	{
+		for (i=0; i<MAX_STARTING_WINGS; i++)
+		{
+			if (Starting_wings[i] >= 0 && Wings[Starting_wings[i]].wave_count > 4)
+			{
 				if (error("%s wing has too many ships.  Should only have 4 max.", Starting_wing_names[i]))
 					return 1;
 			}
@@ -2954,9 +2942,12 @@ int Editor::global_error_check_player_wings(int multi)
 	}
 
 	// check arrival delay in tvt
-	if (multi && The_mission.game_type & MISSION_TYPE_MULTI_TEAMS) {
-		for (i = 0; i < MAX_TVT_WINGS; i++) {
-			if (TVT_wings[i] >= 0 && Wings[TVT_wings[i]].arrival_delay > 0) {
+	if ( multi && The_mission.game_type & MISSION_TYPE_MULTI_TEAMS )
+	{
+		for (i=0; i<MAX_TVT_WINGS; i++)
+		{
+			if (TVT_wings[i] >= 0 && Wings[TVT_wings[i]].arrival_delay > 0)
+			{
 				if (error("%s wing shouldn't have a non-zero arrival delay", TVT_wing_names[i]))
 					return 1;
 			}
@@ -2964,17 +2955,25 @@ int Editor::global_error_check_player_wings(int multi)
 	}
 
 	// check mixed-species in a wing for multi missions
-	if (multi) {
-		if (The_mission.game_type & MISSION_TYPE_MULTI_TEAMS) {
-			for (i = 0; i < MAX_TVT_WINGS; i++) {
-				if (TVT_wings[i] >= 0) {
+	if (multi)
+	{
+		if ( The_mission.game_type & MISSION_TYPE_MULTI_TEAMS )
+		{
+			for (i=0; i<MAX_TVT_WINGS; i++)
+			{
+				if (TVT_wings[i] >= 0)
+				{
 					if (global_error_check_mixed_player_wing(TVT_wings[i]))
 						return 1;
 				}
 			}
-		} else {
-			for (i = 0; i < MAX_STARTING_WINGS; i++) {
-				if (Starting_wings[i] >= 0) {
+		}
+		else
+		{
+			for (i=0; i<MAX_STARTING_WINGS; i++)
+			{
+				if (Starting_wings[i] >= 0)
+				{
 					if (global_error_check_mixed_player_wing(Starting_wings[i]))
 						return 1;
 				}
@@ -2982,28 +2981,36 @@ int Editor::global_error_check_player_wings(int multi)
 		}
 	}
 
-	for (i = 0; i < MAX_STARTING_WINGS; i++) {
+	for (i=0; i<MAX_STARTING_WINGS; i++)
+	{
 		starting_wing_count[i] = 0;
 
-		if (i < MAX_STARTING_WINGS - 1) {
+		if (i < MAX_STARTING_WINGS - 1)
+		{
 			starting_wing_list += Starting_wing_names[i];
 			if (MAX_STARTING_WINGS > 2)
 				starting_wing_list += ",";
 			starting_wing_list += " ";
-		} else {
+		}
+		else
+		{
 			starting_wing_list += "or ";
 			starting_wing_list += Starting_wing_names[i];
 		}
 	}
-	for (i = 0; i < MAX_TVT_WINGS; i++) {
+	for (i=0; i<MAX_TVT_WINGS; i++)
+	{
 		tvt_wing_count[i] = 0;
 
-		if (i < MAX_TVT_WINGS - 1) {
+		if (i < MAX_TVT_WINGS - 1)
+		{
 			tvt_wing_list += TVT_wing_names[i];
 			if (MAX_TVT_WINGS > 2)
 				tvt_wing_list += ",";
 			tvt_wing_list += " ";
-		} else {
+		}
+		else
+		{
 			tvt_wing_list += "or ";
 			tvt_wing_list += TVT_wing_names[i];
 		}
@@ -3011,54 +3018,70 @@ int Editor::global_error_check_player_wings(int multi)
 
 	// check players in wings
 	ptr = GET_FIRST(&obj_used_list);
-	while (ptr != END_OF_LIST(&obj_used_list)) {
+	while (ptr != END_OF_LIST(&obj_used_list))
+	{
 		int ship_instance = ptr->instance;
-		err               = 0;
+		err = 0;
 
 		// this ship is a player?
-		if (ptr->type == OBJ_START) {
+		if (ptr->type == OBJ_START)
+		{
 			// check if this ship is in a wing
 			z = Ships[ship_instance].wingnum;
-			if (z < 0) {
+			if (z < 0)
+			{
 				err = 1;
-			} else {
+			}
+			else
+			{
 				int in_starting_wing = 0;
-				int in_tvt_wing      = 0;
+				int in_tvt_wing = 0;
 
 				// check which wing the player is in
-				for (i = 0; i < MAX_STARTING_WINGS; i++) {
-					if (Starting_wings[i] == z) {
+				for (i=0; i<MAX_STARTING_WINGS; i++)
+				{
+					if (Starting_wings[i] == z)
+					{
 						in_starting_wing = 1;
 						starting_wing_count[i]++;
 					}
 				}
-				for (i = 0; i < MAX_TVT_WINGS; i++) {
-					if (TVT_wings[i] == z) {
+				for (i=0; i<MAX_TVT_WINGS; i++)
+				{
+					if (TVT_wings[i] == z)
+					{
 						in_tvt_wing = 1;
 						tvt_wing_count[i]++;
 					}
 				}
 
 				// make sure the player belongs to his proper wing
-				if (The_mission.game_type & MISSION_TYPE_MULTI_TEAMS) {
-					if (!in_tvt_wing) {
+				if (The_mission.game_type & MISSION_TYPE_MULTI_TEAMS)
+				{
+					if (!in_tvt_wing)
+					{
 						err = 1;
 					}
-				} else {
-					if (!in_starting_wing) {
+				}
+				else
+				{
+					if (!in_starting_wing)
+					{
 						err = 1;
 					}
 				}
 			}
 
-			if (err) {
-				if (The_mission.game_type & MISSION_TYPE_MULTI_TEAMS) {
-					if (error("Player %s should be part of %s wing", Ships[ship_instance].ship_name,
-					          tvt_wing_list.c_str()))
+			if (err)
+			{
+				if (The_mission.game_type & MISSION_TYPE_MULTI_TEAMS)
+				{
+					if (error("Player %s should be part of %s wing", Ships[ship_instance].ship_name, tvt_wing_list.c_str()))
 						return 1;
-				} else {
-					if (error("Player %s should be part of %s wing", Ships[ship_instance].ship_name,
-					          starting_wing_list.c_str()))
+				}
+				else
+				{
+					if (error("Player %s should be part of %s wing", Ships[ship_instance].ship_name, starting_wing_list.c_str()))
 						return 1;
 				}
 			}
@@ -3068,9 +3091,12 @@ int Editor::global_error_check_player_wings(int multi)
 	}
 
 	// check all wings in tvt have players
-	if (The_mission.game_type & MISSION_TYPE_MULTI_TEAMS) {
-		for (i = 0; i < MAX_TVT_WINGS; i++) {
-			if (!tvt_wing_count[i]) {
+	if (The_mission.game_type & MISSION_TYPE_MULTI_TEAMS)
+	{
+		for (i=0; i<MAX_TVT_WINGS; i++)
+		{
+			if (!tvt_wing_count[i])
+			{
 				if (error("%s wing doesn't contain any players (which it should)", TVT_wing_names[i]))
 					return 1;
 			}
@@ -3079,11 +3105,10 @@ int Editor::global_error_check_player_wings(int multi)
 
 	return 0;
 }
-int Editor::global_error_check_mixed_player_wing(int w)
-{
+int Editor::global_error_check_mixed_player_wing(int w) {
 	int i, s, species = -1, mixed = 0;
 
-	for (i = 0; i < Wings[w].wave_count; i++) {
+	for (i=0; i<Wings[w].wave_count; i++) {
 		s = Wings[w].ship_index[i];
 		if (species < 0)
 			species = Ship_info[Ships[s].ship_info_index].species;
@@ -3098,22 +3123,19 @@ int Editor::global_error_check_mixed_player_wing(int w)
 	return 0;
 }
 
-bool Editor::compareShieldSysData(const std::vector<int>& teams, const std::vector<int>& types) const
-{
+bool Editor::compareShieldSysData(const std::vector<int>& teams, const std::vector<int>& types) const {
 	Assert(Shield_sys_teams.size() == teams.size());
 	Assert(Shield_sys_types.size() == types.size());
 
 	return (Shield_sys_teams == teams) && (Shield_sys_types == types);
 }
 
-void Editor::exportShieldSysData(std::vector<int>& teams, std::vector<int>& types) const
-{
+void Editor::exportShieldSysData(std::vector<int>& teams, std::vector<int>& types) const {
 	teams = Shield_sys_teams;
 	types = Shield_sys_types;
 }
 
-void Editor::importShieldSysData(const std::vector<int>& teams, const std::vector<int>& types)
-{
+void Editor::importShieldSysData(const std::vector<int>& teams, const std::vector<int>& types) {
 	Assert(Shield_sys_teams.size() == teams.size());
 	Assert(Shield_sys_types.size() == types.size());
 
@@ -3138,8 +3160,7 @@ void Editor::importShieldSysData(const std::vector<int>& teams, const std::vecto
 
 // adapted from shield_sys_dlg OnInitDialog()
 // 0 = has shields, 1 = no shields, 2 = conflict/inconsistent
-void Editor::normalizeShieldSysData()
-{
+void Editor::normalizeShieldSysData() {
 	std::vector<int> teams(MAX_IFFS, 0);
 	std::vector<int> types(MAX_SHIP_CLASSES, 0);
 
@@ -3162,21 +3183,20 @@ void Editor::normalizeShieldSysData()
 	}
 }
 
-void Editor::strip_quotation_marks(SCP_string& str)
-{
+void Editor::strip_quotation_marks(SCP_string& str) {
 	SCP_string::size_type idx = 0;
 	while ((idx = str.find('\"', idx)) != SCP_string::npos) {
 		str.erase(idx, 1);
 	}
 }
 
-void Editor::pad_with_newline(SCP_string& str, size_t max_size)
-{
+void Editor::pad_with_newline(SCP_string& str, size_t max_size) {
 	size_t len = str.size();
 	if (!len || (str.back() != '\n' && len < max_size)) {
 		str += "\n";
 	}
 }
+
 
 } // namespace fred
 } // namespace fso

--- a/qtfred/src/mission/Editor.cpp
+++ b/qtfred/src/mission/Editor.cpp
@@ -3183,6 +3183,19 @@ void Editor::normalizeShieldSysData() {
 	}
 }
 
+void Editor::strip_quotation_marks(SCP_string& str) {
+	SCP_string::size_type idx = 0;
+	while ((idx = str.find('\"', idx)) != SCP_string::npos) {
+		str.erase(idx, 1);
+	}
+}
+
+void Editor::pad_with_newline(SCP_string& str, int max_size) {
+	if (str.back() != '\n' && str.size() < max_size) {
+		str += "\n";
+	}
+}
+
 
 } // namespace fred
 } // namespace fso

--- a/qtfred/src/mission/Editor.h
+++ b/qtfred/src/mission/Editor.h
@@ -272,6 +272,9 @@ class Editor: public QObject {
 	int global_error_check_player_wings(int multi);
 
 	const char *get_order_name(int order);
+	
+	void strip_quotation_marks(SCP_string& str);
+	void pad_with_newline(SCP_string& str, int max_size);
 };
 
 } // namespace fred

--- a/qtfred/src/mission/Editor.h
+++ b/qtfred/src/mission/Editor.h
@@ -174,6 +174,9 @@ class Editor: public QObject {
 	void exportShieldSysData(std::vector<int>& teams, std::vector<int>& types) const;
 	void importShieldSysData(const std::vector<int>& teams, const std::vector<int>& types);
 	void normalizeShieldSysData();
+
+	static void strip_quotation_marks(SCP_string& str);
+	static void pad_with_newline(SCP_string& str, size_t max_size);
  private:
 	void clearMission();
 
@@ -272,9 +275,6 @@ class Editor: public QObject {
 	int global_error_check_player_wings(int multi);
 
 	const char *get_order_name(int order);
-	
-	void strip_quotation_marks(SCP_string& str);
-	void pad_with_newline(SCP_string& str, SCP_string::size_type max_size);
 };
 
 } // namespace fred

--- a/qtfred/src/mission/Editor.h
+++ b/qtfred/src/mission/Editor.h
@@ -274,7 +274,7 @@ class Editor: public QObject {
 	const char *get_order_name(int order);
 	
 	void strip_quotation_marks(SCP_string& str);
-	void pad_with_newline(SCP_string& str, int max_size);
+	void pad_with_newline(SCP_string& str, SCP_string::size_type max_size);
 };
 
 } // namespace fred

--- a/qtfred/src/mission/dialogs/CustomWingNamesDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/CustomWingNamesDialogModel.cpp
@@ -13,16 +13,17 @@ CustomWingNamesDialogModel::CustomWingNamesDialogModel(QObject * parent, EditorV
 
 bool CustomWingNamesDialogModel::apply() {
 	int i;
-	for (i = 0; i < MAX_STARTING_WINGS; i++) {
-		Editor::strip_quotation_marks(_m_starting[i]);
+
+	for (auto wing : _m_starting) {
+		Editor::strip_quotation_marks(wing);
 	}
 
-	for (i = 0; i < MAX_SQUADRON_WINGS; i++) {
-		Editor::strip_quotation_marks(_m_squadron[i]);
+	for (auto wing : _m_squadron) {
+		Editor::strip_quotation_marks(wing);
 	}
 
-	for (i = 0; i < MAX_TVT_WINGS; i++) {
-		Editor::strip_quotation_marks(_m_tvt[i]);
+	for (auto wing : _m_squadron) {
+		Editor::strip_quotation_marks(wing);
 	}
 	
 	if (strcmp(_m_starting[0].c_str(), _m_tvt[0].c_str()) != 0)

--- a/qtfred/src/mission/dialogs/CustomWingNamesDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/CustomWingNamesDialogModel.cpp
@@ -14,15 +14,15 @@ CustomWingNamesDialogModel::CustomWingNamesDialogModel(QObject * parent, EditorV
 bool CustomWingNamesDialogModel::apply() {
 	int i;
 	for (i = 0; i < MAX_STARTING_WINGS; i++) {
-		strip_quotation_marks(_m_starting[i]);
+		Editor::strip_quotation_marks(_m_starting[i]);
 	}
 
 	for (i = 0; i < MAX_SQUADRON_WINGS; i++) {
-		strip_quotation_marks(_m_squadron[i]);
+		Editor::strip_quotation_marks(_m_squadron[i]);
 	}
 
 	for (i = 0; i < MAX_TVT_WINGS; i++) {
-		strip_quotation_marks(_m_tvt[i]);
+		Editor::strip_quotation_marks(_m_tvt[i]);
 	}
 	
 	if (strcmp(_m_starting[0].c_str(), _m_tvt[0].c_str()) != 0)

--- a/qtfred/src/mission/dialogs/CustomWingNamesDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/CustomWingNamesDialogModel.cpp
@@ -13,6 +13,18 @@ CustomWingNamesDialogModel::CustomWingNamesDialogModel(QObject * parent, EditorV
 
 bool CustomWingNamesDialogModel::apply() {
 	int i;
+	for (i = 0; i < MAX_STARTING_WINGS; i++) {
+		strip_quotation_marks(_m_starting[i]);
+	}
+
+	for (i = 0; i < MAX_SQUADRON_WINGS; i++) {
+		strip_quotation_marks(_m_squadron[i]);
+	}
+
+	for (i = 0; i < MAX_TVT_WINGS; i++) {
+		strip_quotation_marks(_m_tvt[i]);
+	}
+	
 	if (strcmp(_m_starting[0].c_str(), _m_tvt[0].c_str()) != 0)
 	{
 		auto button = _viewport->dialogProvider->showButtonDialog(DialogType::Error, "Custom Wing Error", "The first starting wing and the first team-versus-team wing must have the same wing name.",

--- a/qtfred/src/mission/dialogs/CustomWingNamesDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/CustomWingNamesDialogModel.cpp
@@ -22,7 +22,7 @@ bool CustomWingNamesDialogModel::apply() {
 		Editor::strip_quotation_marks(wing);
 	}
 
-	for (auto wing : _m_squadron) {
+	for (auto wing : _m_tvt) {
 		Editor::strip_quotation_marks(wing);
 	}
 	

--- a/qtfred/src/mission/dialogs/MissionSpecDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/MissionSpecDialogModel.cpp
@@ -95,6 +95,18 @@ bool MissionSpecDialogModel::apply() {
 	} else {
 		The_mission.contrail_threshold = CONTRAIL_THRESHOLD_DEFAULT;
 	}
+	
+	//if there's a odd number of quotation marks, the mission won't parse
+	//If there are an even number, nothing after the first one appears
+	//So just get rid of them
+	strip_quotation_marks(_m_mission_title);
+	strip_quotation_marks(_m_designer_name);
+	strip_quotation_marks(_m_mission_notes);
+	strip_quotation_marks(_m_mission_desc);
+	strip_quotation_marks(_m_squad_name);
+
+	// puts "$End Notes:" on a different line to ensure it's not interpreted as part of a comment
+	pad_with_newline(_m_mission_notes, NOTES_LENGTH - 1);
 
 	strncpy(The_mission.name, _m_mission_title.c_str(), NAME_LENGTH-1);
 	strncpy(The_mission.author, _m_designer_name.c_str(), NAME_LENGTH-1);

--- a/qtfred/src/mission/dialogs/MissionSpecDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/MissionSpecDialogModel.cpp
@@ -99,14 +99,14 @@ bool MissionSpecDialogModel::apply() {
 	//if there's a odd number of quotation marks, the mission won't parse
 	//If there are an even number, nothing after the first one appears
 	//So just get rid of them
-	strip_quotation_marks(_m_mission_title);
-	strip_quotation_marks(_m_designer_name);
-	strip_quotation_marks(_m_mission_notes);
-	strip_quotation_marks(_m_mission_desc);
-	strip_quotation_marks(_m_squad_name);
+	Editor::strip_quotation_marks(_m_mission_title);
+	Editor::strip_quotation_marks(_m_designer_name);
+	Editor::strip_quotation_marks(_m_mission_notes);
+	Editor::strip_quotation_marks(_m_mission_desc);
+	Editor::strip_quotation_marks(_m_squad_name);
 
 	// puts "$End Notes:" on a different line to ensure it's not interpreted as part of a comment
-	pad_with_newline(_m_mission_notes, NOTES_LENGTH - 1);
+	Editor::pad_with_newline(_m_mission_notes, NOTES_LENGTH - 1);
 
 	strncpy(The_mission.name, _m_mission_title.c_str(), NAME_LENGTH-1);
 	strncpy(The_mission.author, _m_designer_name.c_str(), NAME_LENGTH-1);

--- a/qtfred/src/mission/missionsave.cpp
+++ b/qtfred/src/mission/missionsave.cpp
@@ -1995,7 +1995,7 @@ int CFred_mission_save::save_mission_info() {
 
 	required_string_fred("$Notes:");
 	parse_comments();
-	fout("\n%s\n", The_mission.notes);
+	fout("\n%s", The_mission.notes);
 
 	required_string_fred("$End Notes:");
 	parse_comments(0);


### PR DESCRIPTION
Currently, quotation marks play havoc when entered into mission info text fields like title, author name, etc.  An odd number of them renders the mission invalid (and FRED does not give a helpful error, so it can be confusing what the problem is) and an even number causes the game and FRED to ignore everything after the first mark.  Because of this, I don't think there's any problem is just stripping them, which is what this PR does.
Also, I improved handling of #1802 (the designer notes semicolon issue) by writing a newline only if necessary.  This prevents a bunch of useless newlines from accumulating every time the mission is saved.
Finally, the git diff for `management.h` is a mess because of the clang formatter, but I only added the prototypes for `strip_quotation_marks` and `pad_with_newline` at lines 68 and 69.