### PR TITLE
Fix MSVC linking issue in new Discord Code

### DIFF
--- a/lib/discord/src/CMakeLists.txt
+++ b/lib/discord/src/CMakeLists.txt
@@ -52,6 +52,8 @@ endif(UNIX)
 
 target_link_libraries(discord-rpc PUBLIC Threads::Threads)
 
+target_link_libraries(discord-rpc PUBLIC compiler)
+
 suppress_warnings(discord-rpc)
 
 target_include_directories(discord-rpc PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/../thirdparty")


### PR DESCRIPTION
The CMake file did not contain the required target_link_libraries which
made the build fail when compiling it for the FastDebug configuration.