### PR TITLE
Properly handle invalid UTF-8 sequences in NanoVG

### DIFF
--- a/code/graphics/paths/NanoVGRenderer.cpp
+++ b/code/graphics/paths/NanoVGRenderer.cpp
@@ -270,6 +270,12 @@ void NanoVGRenderer::renderFill(NVGpaint* paint,
 								const float* bounds,
 								const NVGpath* paths,
 								int npaths) {
+	if (npaths <= 0) {
+		// Ignore irrelevant render calls
+		mprintf(("NanoVG asked us to render filled triangles but no paths were supplied!\n"));
+		return;
+	}
+
 	auto call = addDrawCall();
 
 	call->type = CallType::Fill;
@@ -331,6 +337,12 @@ void NanoVGRenderer::renderFill(NVGpaint* paint,
 	}
 }
 void NanoVGRenderer::renderTriangles(NVGpaint* paint, NVGscissor* scissor, const NVGvertex* verts, int nverts) {
+	if (nverts <= 0) {
+		// Ignore irrelevant render calls
+		mprintf(("NanoVG asked us to render triangles but no vertices were supplied!\n"));
+		return;
+	}
+
 	_vertices.insert(_vertices.end(), verts, verts + nverts);
 
 	auto call = addDrawCall();
@@ -354,6 +366,12 @@ void NanoVGRenderer::renderStroke(NVGpaint* paint,
 								  float strokeWidth,
 								  const NVGpath* paths,
 								  int npaths) {
+	if (npaths <= 0) {
+		// Ignore irrelevant render calls
+		mprintf(("NanoVG asked us to render stroke triangles but no paths were supplied!\n"));
+		return;
+	}
+
 	auto call = addDrawCall();
 
 	call->type = CallType::Stroke;

--- a/code/graphics/paths/nanovg/fontstash.h
+++ b/code/graphics/paths/nanovg/fontstash.h
@@ -1333,13 +1333,15 @@ int fonsTextIterNext(FONScontext* stash, FONStextIter* iter, FONSquad* quad)
 {
 	FONSglyph* glyph = NULL;
 	const char* str = iter->next;
+	unsigned int last_dec_status = FONS_UTF8_ACCEPT;
 	iter->str = iter->next;
 
 	if (str == iter->end)
 		return 0;
 
 	for (; str != iter->end; str++) {
-		if (fons__decutf8(&iter->utf8state, &iter->codepoint, *(const unsigned char*)str))
+		last_dec_status = fons__decutf8(&iter->utf8state, &iter->codepoint, *(const unsigned char*)str);
+		if (last_dec_status)
 			continue;
 		str++;
 		// Get glyph and quad
@@ -1352,6 +1354,12 @@ int fonsTextIterNext(FONScontext* stash, FONStextIter* iter, FONSquad* quad)
 		break;
 	}
 	iter->next = str;
+
+	if (last_dec_status) {
+		// If we are here then the iterator reached the end of the string and UTF-8 encoding failed
+		// In this case we do not have a valid code point so we need to return false
+		return 0;
+	}
 
 	return 1;
 }

--- a/code/graphics/paths/nanovg/nanovg.c
+++ b/code/graphics/paths/nanovg/nanovg.c
@@ -2316,12 +2316,12 @@ float nvgText(NVGcontext* ctx, float x, float y, const char* string, const char*
 	while (fonsTextIterNext(ctx->fs, &iter, &q)) {
 		float c[4*2];
 		if (iter.prevGlyphIndex == -1) { // can not retrieve glyph?
-			if (!nvg__allocTextAtlas(ctx))
-				break; // no memory :(
 			if (nverts != 0) {
 				nvg__renderText(ctx, verts, nverts);
 				nverts = 0;
 			}
+			if (!nvg__allocTextAtlas(ctx))
+				break; // no memory :(
 			iter = prevIter;
 			fonsTextIterNext(ctx->fs, &iter, &q); // try again
 			if (iter.prevGlyphIndex == -1) // still can not find glyph?


### PR DESCRIPTION
The original issue was reported by Novachen in #1754 where a significant
slowdown was encountered in the controls menu (Ship and Misc tabs). I
traced the cause of the slowdown to repeated uploads of the NanoVG font
atlas texture even though no changes were necessary.

The root cause of the issue was that NanoVG did not handle invalid UTF-8
sequences at the end of a string properly. The UTF-8 decoder returned a
success code even though no code point was decoded which lead the rest
of the code to believe that the font atlas needed to be recreated.

This fixes #1754 by properly handling that case.

This also fixed an assertion failure if NanoVG was asked to render
2D elements without any vertices.