### PR TITLE
Fix vm_vec_random_cone/sphere functions

### DIFF
--- a/code/hud/hudartillery.cpp
+++ b/code/hud/hudartillery.cpp
@@ -224,7 +224,7 @@ void ssm_get_random_start_pos(vec3d *out, vec3d *start, matrix *orient, size_t s
 	switch (s->shape) {
 	case SSM_SHAPE_SPHERE:
 		// get a random vector in a sphere around the target
-		vm_vec_random_in_sphere(&temp, start, orient, radius, 1);
+		vm_vec_random_in_sphere(&temp, start, radius, 1);
 		break;
 	case SSM_SHAPE_CIRCLE:
 		// get a random vector in the circle of the firing plane

--- a/code/math/vecmat.cpp
+++ b/code/math/vecmat.cpp
@@ -15,6 +15,7 @@
 #endif
 
 #include "math/vecmat.h"
+#include "utils/RandomRange.h"
 
 
 #define	SMALL_NUM	1e-7
@@ -2371,7 +2372,7 @@ void vm_vec_interp_constant(vec3d *out, const vec3d *v0, const vec3d *v1, float 
 // randomly perturb a vector around a given (normalized vector) or optional orientation matrix
 void vm_vec_random_cone(vec3d *out, const vec3d *in, float max_angle, const matrix *orient)
 {
-	vec3d t1, t2;
+	vec3d temp;
 	const matrix *rot;
 	matrix m;
 
@@ -2382,19 +2383,17 @@ void vm_vec_random_cone(vec3d *out, const vec3d *in, float max_angle, const matr
 		vm_vector_2_matrix(&m, in, NULL, NULL);
 		rot = &m;
 	}
-	
-	// axis 1
-	vm_rot_point_around_line(&t1, in, fl_radians(frand_range(-max_angle, max_angle)), &vmd_zero_vector, &rot->vec.fvec);
-	
-	// axis 2
-	vm_rot_point_around_line(&t2, &t1, fl_radians(frand_range(-max_angle, max_angle)), &vmd_zero_vector, &rot->vec.rvec);
 
-	// axis 3
-	vm_rot_point_around_line(out, &t2, fl_radians(frand_range(-max_angle, max_angle)), &vmd_zero_vector, &rot->vec.uvec);
+	// Get properly distributed spherical coordinates (DahBlount)
+	float z = util::UniformFloatRange(cosf(fl_radians(max_angle)), 1.0f).next(); // Take a 2-sphere slice
+	float phi = util::UniformFloatRange(0.0f, PI2).next();
+	vm_vec_make( &temp, sqrtf(1.0f - z*z)*cosf(phi), sqrtf(1.0f - z*z)*sinf(phi), z ); // Using the z-vec as the starting point
+
+	vm_vec_unrotate(out, &temp, rot); // We find the final vector by rotating temp to the correct orientation
 }
 
 void vm_vec_random_cone(vec3d *out, const vec3d *in, float min_angle, float max_angle, const matrix *orient){
-	vec3d t1, t2;
+	vec3d temp;
 	const matrix *rot;
 	matrix m;
 
@@ -2405,28 +2404,14 @@ void vm_vec_random_cone(vec3d *out, const vec3d *in, float min_angle, float max_
 		vm_vector_2_matrix(&m, in, NULL, NULL);
 		rot = &m;
 	}
-	float dif_angle = max_angle - min_angle;
 	
-	// axis 1
-	float temp_ang = (frand_range(-dif_angle, dif_angle));
-	if(temp_ang < 0)temp_ang -= (min_angle);
-	else temp_ang += (min_angle);
+	// Get properly distributed spherical coordinates (DahBlount)
+	// This might not seem intuitive, but the min_angle is the angle that will have a larger z coordinate
+	float z = util::UniformFloatRange(cosf(fl_radians(max_angle)), cosf(fl_radians(min_angle))).next(); // Take a 2-sphere slice
+	float phi = util::UniformFloatRange(0.0f, PI2).next();
+	vm_vec_make( &temp, sqrtf(1.0f - z*z)*cosf(phi), sqrtf(1.0f - z*z)*sinf(phi), z ); // Using the z-vec as the starting point
 
-	vm_rot_point_around_line(&t1, in, fl_radians(temp_ang), &vmd_zero_vector, &rot->vec.fvec);
-	
-	// axis 2
-	temp_ang = (frand_range(-dif_angle, dif_angle));
-	if(temp_ang < 0)temp_ang -= (min_angle);
-	else temp_ang += (min_angle);
-
-	vm_rot_point_around_line(&t2, &t1, fl_radians(temp_ang), &vmd_zero_vector, &rot->vec.rvec);
-
-	// axis 3
-	temp_ang = (frand_range(-dif_angle, dif_angle));
-	if(temp_ang < 0)temp_ang -= (min_angle);
-	else temp_ang += (min_angle);
-
-	vm_rot_point_around_line(out, &t2, fl_radians(temp_ang), &vmd_zero_vector, &rot->vec.uvec);
+	vm_vec_unrotate(out, &temp, rot); // We find the final vector by rotating temp to the correct orientation
 }
 
 
@@ -2445,11 +2430,15 @@ void vm_vec_random_in_circle(vec3d *out, const vec3d *in, const matrix *orient, 
 
 // given a start vector, an orientation, and a radius, give a point in a spherical volume
 // if on_edge is 1, the point is on the very edge of the sphere
-void vm_vec_random_in_sphere(vec3d *out, const vec3d *in, const matrix *orient, float radius, int on_edge)
+void vm_vec_random_in_sphere(vec3d *out, const vec3d *in, float radius, int on_edge)
 {
 	vec3d temp;
-	vm_vec_random_in_circle(&temp, in, orient, radius, on_edge);
-	vm_rot_point_around_line(out, &temp, fl_radians(frand_range(0.0f, 359.0f)), in, &orient->vec.rvec);
+	// Uniformly distributing each coordinate of a vector then normalizing results in a uniform sphere distribution
+	util::UniformFloatRange coords(-1.0f,1.0f);
+	vm_vec_make( &temp, coords.next(), coords.next(), coords.next() );
+	vm_vec_normalize(&temp);
+	// We then add the scaled result to the initial position to get the final position
+	vm_vec_scale_add(out, in, &temp, on_edge ? radius : util::UniformFloatRange(0.0f,radius).next());
 }
 
 // find the nearest point on the line to p. if dist is non-NULL, it is filled in

--- a/code/math/vecmat.h
+++ b/code/math/vecmat.h
@@ -445,7 +445,7 @@ void vm_vec_random_in_circle(vec3d *out, const vec3d *in, const matrix *orient, 
 
 // given a start vector, an orientation, and a radius, give a point in a spherical volume
 // if on_edge is 1, the point is on the very edge of the sphere
-void vm_vec_random_in_sphere(vec3d *out, const vec3d *in, const matrix *orient, float radius, int on_edge);
+void vm_vec_random_in_sphere(vec3d *out, const vec3d *in, float radius, int on_edge);
 
 // find the nearest point on the line to p. if dist is non-NULL, it is filled in
 // returns 0 if the point is inside the line segment, -1 if "before" the line segment and 1 ir "after" the line segment


### PR DESCRIPTION
This contains a fix for `vm_vec_random_cone` and a more efficient version of the sphere equivalent.

The primary issue with the original `vm_vec_random_cone` function was it's use of 3 rotations of the input vector in an arbitrary order that results in a square cone output as opposed to the assumed circular cone output. The new version generates a unit vector in the correct half angle region, then rotates it into the orientation provided or constructed from the input vector.

This is a fix for #1812 