### PR TITLE
Don't reset mission file name on mission end

### DIFF
--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -944,9 +944,6 @@ void game_level_close()
 	}
 
 	Script_system.RunCondition(CHA_MISSIONEND);
-
-	// Clear mission file name again
-	Game_current_mission_filename[0] = '\0';
 }
 
 uint load_gl_init;


### PR DESCRIPTION
This was needed by the restart dialog action and got removed since the
Discord changes needed to know if a mission was active or not.

I removed the code which changed the mission file name and replaced it
with some internal handling in the discord code which should now handle
mission restarts better.

This fixes #1815.