### PR TITLE
Add support for looping movies

### DIFF
--- a/code/cutscene/Decoder.h
+++ b/code/cutscene/Decoder.h
@@ -73,6 +73,11 @@ struct SubtitleFrame {
 };
 typedef std::unique_ptr<SubtitleFrame> SubtitleFramePtr;
 
+struct PlaybackProperties {
+	bool with_audio = true;
+	bool looping = false;
+};
+
 /**
  * @brief Abstract class for decoding a video or audio stream
  *
@@ -106,7 +111,7 @@ class Decoder {
 	 * @param fileName The name of the file that should be opened
 	 * @return @c true if the initialization was successfull, @c false otherwise
 	 */
-	virtual bool initialize(const SCP_string& fileName) = 0;
+	virtual bool initialize(const SCP_string& fileName, const PlaybackProperties& properties) = 0;
 
 	/**
 	 * @brief Returns the properties of the video

--- a/code/cutscene/ffmpeg/AudioDecoder.cpp
+++ b/code/cutscene/ffmpeg/AudioDecoder.cpp
@@ -223,5 +223,8 @@ void AudioDecoder::finishDecoding() {
 	// Push the last bits of audio data into the queue
 	flushAudioBuffer();
 }
+void AudioDecoder::flushBuffers() {
+	avcodec_flush_buffers(m_status->audioCodecCtx);
+}
 }
 }

--- a/code/cutscene/ffmpeg/AudioDecoder.h
+++ b/code/cutscene/ffmpeg/AudioDecoder.h
@@ -30,6 +30,8 @@ class AudioDecoder: public FFMPEGStreamDecoder<AudioFrame> {
 	void decodePacket(AVPacket* packet) override;
 
 	void finishDecoding() override;
+
+	void flushBuffers() override;
 };
 }
 }

--- a/code/cutscene/ffmpeg/FFMPEGDecoder.h
+++ b/code/cutscene/ffmpeg/FFMPEGDecoder.h
@@ -18,6 +18,8 @@ class FFMPEGDecoder: public Decoder {
 
 	std::unique_ptr<DecoderStatus> m_status;
 
+	PlaybackProperties m_properties;
+
 	bool hasExternalSubtitle() const;
 
 	void runSubtitleDecoder(SubtitleDecoder* decoder);
@@ -27,7 +29,7 @@ class FFMPEGDecoder: public Decoder {
 
 	~FFMPEGDecoder() override;
 
-	bool initialize(const SCP_string& fileName) override;
+	bool initialize(const SCP_string& fileName, const PlaybackProperties& properties) override;
 
 	MovieProperties getProperties() const override;
 

--- a/code/cutscene/ffmpeg/SubtitleDecoder.cpp
+++ b/code/cutscene/ffmpeg/SubtitleDecoder.cpp
@@ -129,6 +129,9 @@ void SubtitleDecoder::pushSubtitleFrame(AVPacket* packet, AVSubtitle* subtitle) 
 
 	pushFrame(std::move(frame));
 }
+void SubtitleDecoder::flushBuffers() {
+	avcodec_flush_buffers(m_status->subtitleCodecCtx);
+}
 
 }
 }

--- a/code/cutscene/ffmpeg/SubtitleDecoder.h
+++ b/code/cutscene/ffmpeg/SubtitleDecoder.h
@@ -16,6 +16,7 @@ class SubtitleDecoder: public FFMPEGStreamDecoder<SubtitleFrame> {
 
 	void finishDecoding() override;
     void pushSubtitleFrame(AVPacket* subtitle, AVSubtitle* pSubtitle);
+	void flushBuffers() override;
 };
 
 }

--- a/code/cutscene/ffmpeg/VideoDecoder.cpp
+++ b/code/cutscene/ffmpeg/VideoDecoder.cpp
@@ -158,5 +158,8 @@ void VideoDecoder::finishDecoding() {
 	}
 #endif
 }
+void VideoDecoder::flushBuffers() {
+	avcodec_flush_buffers(m_status->videoCodecCtx);
+}
 }
 }

--- a/code/cutscene/ffmpeg/VideoDecoder.h
+++ b/code/cutscene/ffmpeg/VideoDecoder.h
@@ -21,6 +21,8 @@ class VideoDecoder: public FFMPEGStreamDecoder<VideoFrame> {
 	void decodePacket(AVPacket* packet) override;
 
 	void finishDecoding() override;
+
+	void flushBuffers() override;
 };
 }
 }

--- a/code/cutscene/ffmpeg/internal.h
+++ b/code/cutscene/ffmpeg/internal.h
@@ -74,6 +74,8 @@ class FFMPEGStreamDecoder {
 
 	virtual void finishDecoding() = 0;
 
+	virtual void flushBuffers() = 0;
+
 	virtual FramePtr<frame_type> getFrame();
 };
 

--- a/code/cutscene/player.h
+++ b/code/cutscene/player.h
@@ -64,9 +64,8 @@ class Player {
   private:
 	void decoderThread();
 
+	Player(std::unique_ptr<Decoder>&& decoder, const PlaybackProperties& properties);
   public:
-	explicit Player(std::unique_ptr<Decoder>&& decoder, bool enable_audio = true);
-
 	~Player();
 
 	Player(const Player&) = delete;
@@ -130,9 +129,9 @@ class Player {
 	 * @brief Creates a player
 	 * The player is configured to play the movie with the specified name
 	 * @param name The movie to play
-	 * @param enable_audio Enable audio for this player instance
+	 * @param properties A structure describing how the movie will be used
 	 * @return @c nullptr if the specified movie could not be opened, a valid Player pointer otherwise
 	 */
-	static std::unique_ptr<Player> newPlayer(const SCP_string& name, bool enable_audio = true);
+	static std::unique_ptr<Player> newPlayer(const SCP_string& name, const PlaybackProperties& properties = PlaybackProperties());
 };
 }

--- a/code/scripting/api/libs/graphics.cpp
+++ b/code/scripting/api/libs/graphics.cpp
@@ -1541,18 +1541,23 @@ ADE_FUNC(resetClip, l_Graphics, NULL, "Resets the clipping region that might hav
 	return ADE_RETURN_TRUE;
 }
 
-ADE_FUNC(openMovie, l_Graphics, "string name",
+ADE_FUNC(openMovie, l_Graphics, "string name, boolean looping = false",
          "Opens the movie with the specified name. If the name has an extension it will be removed. This function will "
          "try all movie formats supported by the engine and use the first that is found.",
          "movie_player", "The cutscene player handle or invalid handle if cutscene could not be opened.")
 {
 	const char* name = nullptr;
-	if (!ade_get_args(L, "s", &name)) {
+	bool looping = false;
+	if (!ade_get_args(L, "s|b", &name, &looping)) {
 		return ade_set_error(L, "o", l_MoviePlayer.Set(nullptr));
 	}
 
 	// Audio is disabled for scripted movies at the moment
-	auto player = cutscene::Player::newPlayer(name, false);
+	cutscene::PlaybackProperties props;
+	props.with_audio = false;
+	props.looping = looping;
+
+	auto player = cutscene::Player::newPlayer(name, props);
 
 	if (!player) {
 		return ade_set_args(L, "o", l_MoviePlayer.Set(nullptr));


### PR DESCRIPTION
This adds a playback property for making the movie loop to the start
when the end is reached. The way this is done is by simply keeping the
decoder running even if the end of the movie is reached. Then the movie
is reset to the beginning and decoding continues. The player detects
this reset by examining the frame times which keeps the playback
constant.

This also includes support for this in the movie scripting API.