### PR TITLE
Terminate FRED/qtFRED when command line demands it

### DIFF
--- a/fred2/management.cpp
+++ b/fred2/management.cpp
@@ -308,7 +308,10 @@ bool fred_init(std::unique_ptr<os::GraphicsOperations>&& graphicsOps)
 	cfile_chdir(Fred_base_dir);
 
 	// this should enable mods - Kazan
-	parse_cmdline(__argc, __argv);
+	if (!parse_cmdline(__argc, __argv)) {
+		// Command line contained an option that terminates the program immediately
+		exit(1);
+	}
 
 #ifndef NDEBUG
 	#if FS_VERSION_REVIS == 0

--- a/qtfred/src/mission/management.cpp
+++ b/qtfred/src/mission/management.cpp
@@ -66,7 +66,10 @@ initialize(const std::string& cfilepath, int argc, char* argv[], Editor* editor,
 
 	listener(SubSystem::CommandLine);
 	// this should enable mods - Kazan
-	parse_cmdline(argc, argv);
+	if (!parse_cmdline(argc, argv)) {
+		// Command line contained an option that terminates the program immediately
+		return false;
+	}
 
 #ifndef NDEBUG
 #if FS_VERSION_REVIS == 0


### PR DESCRIPTION
This was reported by @ngld who experienced issues with Knossos since FRED
did not terminate properly when asked to provide the command line flags.
This should fix that.