### PR TITLE
add game_settings feature to ignore single missions

### DIFF
--- a/code/menuui/readyroom.cpp
+++ b/code/menuui/readyroom.cpp
@@ -22,6 +22,7 @@
 #include "menuui/mainhallmenu.h"
 #include "menuui/readyroom.h"
 #include "menuui/techmenu.h"	// for tech menu reset stuff
+#include "mission/missionload.h"
 #include "mission/missionparse.h"
 #include "mission/missioncampaign.h"
 #include "missionui/missionscreencommon.h"
@@ -471,7 +472,9 @@ int build_standalone_mission_list_do_frame()
 
 			// tack on an extension
 			strcat_s(filename, FS_MISSION_FILE_EXT);
-			if (!get_mission_info(filename)) {			
+
+			// check if we can list the mission and if loading basic info didn't return an error code
+			if (!mission_is_ignored(filename) && !get_mission_info(filename)) {
 				Standalone_mission_names[Num_standalone_missions_with_info] = vm_strdup(The_mission.name);
 				Standalone_mission_flags[Num_standalone_missions_with_info] = The_mission.game_type;
 				int y = Num_lines * (font_height + 2);
@@ -481,7 +484,7 @@ int build_standalone_mission_list_do_frame()
 				fs_builtin_mission *fb = game_find_builtin_mission(filename);				
 				if((fb != NULL) && (fb->flags & FSB_FROM_VOLITION)){
 					flags |= READYROOM_FLAG_FROM_VOLITION;
-				}				
+				}
 
 				// add the line
 				sim_room_line_add(READYROOM_LINE_MISSION, Standalone_mission_names[Num_standalone_missions_with_info], Mission_filenames[Num_standalone_missions_with_info], list_x1 + M_TEXT_X, y, flags);			

--- a/code/mission/missioncampaign.cpp
+++ b/code/mission/missioncampaign.cpp
@@ -1659,9 +1659,10 @@ bool campaign_is_ignored(const char *filename)
 {
 	SCP_string filename_no_ext = filename;
 	drop_extension(filename_no_ext);
+	std::transform(filename_no_ext.begin(), filename_no_ext.end(), filename_no_ext.begin(), ::tolower);
 
-	for (SCP_vector<SCP_string>::iterator ii = Ignored_campaigns.begin(); ii != Ignored_campaigns.end(); ++ii) {
-		if (*ii == filename_no_ext) {
+	for (auto &ii: Ignored_campaigns) {
+		if (ii == filename_no_ext) {
 			return true;
 		}
 	}

--- a/code/mission/missionload.cpp
+++ b/code/mission/missionload.cpp
@@ -29,6 +29,8 @@ extern mission The_mission;  // need to send this info to the briefing
 extern int shifted_ascii_table[];
 extern int ascii_table[];
 
+SCP_vector<SCP_string> Ignored_missions;
+
 // -----------------------------------------------
 // For recording most recent missions played
 // -----------------------------------------------
@@ -76,6 +78,20 @@ void ml_update_recent_missions(char *filename)
 	Assert(Num_recent_missions <= MAX_RECENT_MISSIONS);
 }
 
+bool mission_is_ignored(const char *filename)
+{
+	SCP_string filename_no_ext = filename;
+	drop_extension(filename_no_ext);
+
+	for (SCP_vector<SCP_string>::iterator ii = Ignored_missions.begin(); ii != Ignored_missions.end(); ++ii) {
+		if (*ii == filename_no_ext) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
 // Mission_load takes no parameters.
 // It sets the following global variables
 //   Game_current_mission_filename
@@ -98,6 +114,11 @@ int mission_load(char *filename_ext)
 	if (ext) {
 		mprintf(( "Hmmm... Extension passed to mission_load...\n" ));
 		*ext = 0;				// remove any extension!
+	}
+
+	if (mission_is_ignored(filename)) {
+		mprintf(("MISSION LOAD: Tried to load an ignored mission!  Aborting..."));
+		return -1;
 	}
 
 	strcat_s(filename, FS_MISSION_FILE_EXT);

--- a/code/mission/missionload.cpp
+++ b/code/mission/missionload.cpp
@@ -83,8 +83,8 @@ bool mission_is_ignored(const char *filename)
 	SCP_string filename_no_ext = filename;
 	drop_extension(filename_no_ext);
 
-	for (SCP_vector<SCP_string>::iterator ii = Ignored_missions.begin(); ii != Ignored_missions.end(); ++ii) {
-		if (*ii == filename_no_ext) {
+	for (auto &ii: Ignored_missions) {
+		if (ii == filename_no_ext) {
 			return true;
 		}
 	}

--- a/code/mission/missionload.cpp
+++ b/code/mission/missionload.cpp
@@ -82,6 +82,7 @@ bool mission_is_ignored(const char *filename)
 {
 	SCP_string filename_no_ext = filename;
 	drop_extension(filename_no_ext);
+	std::transform(filename_no_ext.begin(), filename_no_ext.end(), filename_no_ext.begin(), ::tolower);
 
 	for (auto &ii: Ignored_missions) {
 		if (ii == filename_no_ext) {

--- a/code/mission/missionload.h
+++ b/code/mission/missionload.h
@@ -21,11 +21,16 @@
 extern	char	Recent_missions[MAX_RECENT_MISSIONS][MAX_FILENAME_LEN];
 extern	int	Num_recent_missions;
 
+extern SCP_vector<SCP_string> Ignored_missions;
+
 // Mission_load takes no parameters.
 // It sets the following global variables:
 // Game_current_mission_filename
 
 int mission_load(char *filename_ext);
+
+bool mission_is_ignored(const char *filename);
+
 
 // Functions for mission load menu
 void mission_load_menu_init();

--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -9,6 +9,7 @@
 #include "globalincs/version.h"
 #include "localization/localize.h"
 #include "mission/missioncampaign.h"
+#include "mission/missionload.h"
 #include "mission/missionmessage.h"
 #include "missionui/fictionviewer.h"
 #include "mod_table/mod_table.h"
@@ -122,6 +123,22 @@ void parse_mod_table(const char *filename)
 				}
 
 				Ignored_campaigns.push_back(campaign_name);
+			}
+		}
+
+		// Note: this feature does not ignore missions that are contained in campaigns
+		if (optional_string("#Ignored Mission File Names")) {
+			SCP_string mission_name;
+
+			while (optional_string("$Mission File Name:")) {
+				stuff_string(mission_name, F_NAME);
+
+				// remove extension?
+				if (drop_extension(mission_name)) {
+					mprintf(("Game Settings Table: Removed extension on ignored mission file name %s\n", mission_name.c_str()));
+				}
+
+				Ignored_missions.push_back(mission_name);
 			}
 		}
 

--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -122,6 +122,9 @@ void parse_mod_table(const char *filename)
 					mprintf(("Game Settings Table: Removed extension on ignored campaign file name %s\n", campaign_name.c_str()));
 				}
 
+				// we want case-insensitive matching, so make this lowercase
+				std::transform(campaign_name.begin(), campaign_name.end(), campaign_name.begin(), ::tolower);
+
 				Ignored_campaigns.push_back(campaign_name);
 			}
 		}
@@ -137,6 +140,9 @@ void parse_mod_table(const char *filename)
 				if (drop_extension(mission_name)) {
 					mprintf(("Game Settings Table: Removed extension on ignored mission file name %s\n", mission_name.c_str()));
 				}
+
+				// we want case-insensitive matching, so make this lowercase
+				std::transform(mission_name.begin(), mission_name.end(), mission_name.begin(), ::tolower);
 
 				Ignored_missions.push_back(mission_name);
 			}

--- a/code/network/multiui.cpp
+++ b/code/network/multiui.cpp
@@ -32,6 +32,7 @@
 #include "network/stand_gui.h"
 #include "network/multiteamselect.h"
 #include "mission/missioncampaign.h"
+#include "mission/missionload.h"
 #include "graphics/font.h"
 #include "io/mouse.h"
 #include "gamesnd/gamesnd.h"
@@ -4467,11 +4468,11 @@ void multi_create_list_load_missions()
 			std_gen_set_text(filename, 2);
 		}
 
-		flags = mission_parse_is_multi(filename, mission_name);		
+		flags = mission_parse_is_multi(filename, mission_name);
 
-		// if the mission is a multiplayer mission, then add it to the mission list
-		if ( flags ) {
-			max_players = mission_parse_get_multi_mission_info( filename );				
+		// if the mission is a multiplayer mission, and we can list it, then add it to the mission list
+		if (flags && !mission_is_ignored(filename)) {
+			max_players = mission_parse_get_multi_mission_info( filename );
 			m_respawn = The_mission.num_respawns;
 
 			multi_create_info mcip;


### PR DESCRIPTION
This works just like `#Ignored Campaign File Names`, just with missions.

```
#Ignored Mission File Names
$Mission File Name: 1.fs2
$Mission File Name: 2.fs2
```
etc.

This will only ignore standalone missions, not missions that are included in campaigns.  It works for both single-player and multiplayer.  I have tested it in both the tech room and the multiplayer "create game" screen.  Based on code searches, these are the only two places in the code where standalone missions are listed.

This PR addresses #1666 and its duplicate #1826.