### PR TITLE
fix bug introduced in pr #1736

### DIFF
--- a/code/missionui/missionweaponchoice.cpp
+++ b/code/missionui/missionweaponchoice.cpp
@@ -4082,8 +4082,7 @@ void wl_apply_current_loadout_to_all_ships_in_current_wing()
 			if ((result == 0) || (result == 2))
 			{
 				SCP_string temp;
-				sprintf(temp, XSTR("Insufficient %s available to arm %s", 1632),
-						Weapon_info[weapon_type_to_add].get_display_string());
+				sprintf(temp, XSTR("Insufficient %s available to arm %s", 1632), Weapon_info[weapon_type_to_add].get_display_string(), ship_name);
 				error_messages.push_back(temp);
 
 				error_flag = true;


### PR DESCRIPTION
In PR #1736, commit ae149b6061ba92949c34592da1f390f430dc4c7e, one of the arguments was accidentally removed from a varargs function.  This PR puts it back.

EDIT: This PR fixes issue #1829.