### PR TITLE
ignore multiplayer as well as singleplayer campaigns

### DIFF
--- a/code/mission/missioncampaign.cpp
+++ b/code/mission/missioncampaign.cpp
@@ -91,8 +91,6 @@ LOCAL UI_BUTTON Campaign_okb, Campaign_cancelb;
 campaign Campaign;
 
 
-bool campaign_is_ignored(const char *filename);
-
 /**
  * Returns a string (which is malloced in this routine) of the name of the given freespace campaign file.  
  * In the type field, we return if the campaign is a single player or multiplayer campaign.  
@@ -247,10 +245,10 @@ int mission_campaign_maybe_add(const char *filename)
 	char *desc = NULL;
 	int type, max_players;
 
-		// don't add ignored campaigns
-		if (campaign_is_ignored(filename)) {
-			return 0;
-		}
+	// don't add ignored campaigns
+	if (campaign_is_ignored(filename)) {
+		return 0;
+	}
 
 	if ( mission_campaign_get_info( filename, name, &type, &max_players, &desc) ) {
 		if ( !MC_multiplayer && (type == CAMPAIGN_TYPE_SINGLE) ) {

--- a/code/mission/missioncampaign.h
+++ b/code/mission/missioncampaign.h
@@ -182,6 +182,8 @@ int mission_campaign_load_by_name_csfe( char *filename, char *callsign );
 // load up and initialize a new campaign
 int mission_campaign_load( char *filename, player *pl = NULL, int load_savefile = 1, bool reset_stats = true );
 
+bool campaign_is_ignored(const char *filename);
+
 // function to save the state of the campaign between missions or to load a campaign save file
 extern int mission_campaign_save( void );
 

--- a/code/network/multiui.cpp
+++ b/code/network/multiui.cpp
@@ -4553,9 +4553,10 @@ void multi_create_list_load_campaigns()
 			std_gen_set_text(filename, 2);
 		}
 
-		// if the campaign is a multiplayer campaign, then add the data to the campaign list items
 		flags = mission_campaign_parse_is_multi( filename, name );
-		if( flags != CAMPAIGN_TYPE_SINGLE && mission_campaign_get_info(filename,title,&campaign_type,&max_players)) {
+
+		// if the campaign is a multiplayer campaign, and we can list it, and we can get its info, then add the data to the campaign list items
+		if( flags != CAMPAIGN_TYPE_SINGLE && !campaign_is_ignored(filename) && mission_campaign_get_info(filename, title, &campaign_type, &max_players)) {
 			multi_create_info mcip;
 
 			strcpy_s(mcip.filename, filename );


### PR DESCRIPTION
Since multiplayer and singleplayer campaign lists are generated in two different functions, the `#Ignored Campaign File Names` feature never ignored multiplayer campaigns.

This fixes #1838.