### PR TITLE
add per-ship-class scanning range feature

### DIFF
--- a/code/hud/hudtarget.h
+++ b/code/hud/hudtarget.h
@@ -26,6 +26,7 @@ struct weapon_info;
 #define MATCH_SPEED_THRESHOLD				0.1f		// minimum speed target must be moving for match speed to apply
 #define CARGO_RADIUS_DELTA					100		// distance added to radius required for cargo scanning
 #define CAPITAL_CARGO_RADIUS_DELTA		250		// distance added to radius required for cargo scanning
+static const int CARGO_RADIUS_REAL_DELTA = 50;
 #define CARGO_REVEAL_MIN_DIST				150		// minimum distance for reveal cargo (used if radius+CARGO_RADIUS_DELTA < CARGO_REVEAL_MIN_DIST)
 #define CAP_CARGO_REVEAL_MIN_DIST		300		// minimum distance for reveal cargo (used if radius+CARGO_RADIUS_DELTA < CARGO_REVEAL_MIN_DIST)
 #define CARGO_MIN_DOT_TO_REVEAL			0.95		// min dot to proceed to have cargo scanning take place

--- a/code/hud/hudtarget.h
+++ b/code/hud/hudtarget.h
@@ -26,7 +26,7 @@ struct weapon_info;
 #define MATCH_SPEED_THRESHOLD				0.1f		// minimum speed target must be moving for match speed to apply
 #define CARGO_RADIUS_DELTA					100		// distance added to radius required for cargo scanning
 #define CAPITAL_CARGO_RADIUS_DELTA		250		// distance added to radius required for cargo scanning
-static const int CARGO_RADIUS_REAL_DELTA = 50;
+const int CARGO_RADIUS_REAL_DELTA = 50;         // difference in distances used for cargo scanning of subsystems (which also uses object radius), vs whole-ship scanning
 #define CARGO_REVEAL_MIN_DIST				150		// minimum distance for reveal cargo (used if radius+CARGO_RADIUS_DELTA < CARGO_REVEAL_MIN_DIST)
 #define CAP_CARGO_REVEAL_MIN_DIST		300		// minimum distance for reveal cargo (used if radius+CARGO_RADIUS_DELTA < CARGO_REVEAL_MIN_DIST)
 #define CARGO_MIN_DOT_TO_REVEAL			0.95		// min dot to proceed to have cargo scanning take place

--- a/code/playerman/playercontrol.cpp
+++ b/code/playerman/playercontrol.cpp
@@ -1597,7 +1597,8 @@ int player_inspect_cargo(float frametime, char *outstr)
 	}
 
 	// see if player is within inspection range
-	if ( Player_ai->current_target_distance < MAX(CARGO_REVEAL_MIN_DIST, (cargo_objp->radius+CARGO_RADIUS_DELTA)) ) {
+	ship_info* player_sip = &Ship_info[Player_ship->ship_info_index];
+	if ( Player_ai->current_target_distance < MAX(player_sip->scan_range_normal, (cargo_objp->radius + player_sip->scan_range_normal - CARGO_RADIUS_REAL_DELTA)) ) {
 
 		// check if player is facing cargo, do not proceed with inspection if not
 		vm_vec_normalized_dir(&vec_to_cargo, &cargo_objp->pos, &Player_obj->pos);
@@ -1698,10 +1699,11 @@ int player_inspect_cap_subsys_cargo(float frametime, char *outstr)
 	subsys_rad = subsys->system_info->radius;
 
 	// Goober5000
+	ship_info* player_sip = &Ship_info[Player_ship->ship_info_index];
     if (cargo_sip->is_huge_ship()) {
-		scan_dist = MAX(CAP_CARGO_REVEAL_MIN_DIST, (subsys_rad + CAPITAL_CARGO_RADIUS_DELTA));
+		scan_dist = MAX(player_sip->scan_range_capital, (subsys_rad + player_sip->scan_range_capital - CARGO_RADIUS_REAL_DELTA));
 	} else {
-		scan_dist = MAX(CARGO_REVEAL_MIN_DIST, (subsys_rad + CARGO_RADIUS_DELTA));
+		scan_dist = MAX(player_sip->scan_range_normal, (subsys_rad + player_sip->scan_range_normal - CARGO_RADIUS_REAL_DELTA));
 	}
 
 	if ( Player_ai->current_target_distance < scan_dist ) {

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -1016,6 +1016,8 @@ void ship_info::clone(const ship_info& other)
 	score = other.score;
 
 	scan_time = other.scan_time;
+	scan_range_normal = other.scan_range_normal;
+	scan_range_capital = other.scan_range_capital;
 
 	memcpy(ct_info, other.ct_info, sizeof(trail_info) * MAX_SHIP_CONTRAILS);
 	ct_count = other.ct_count;
@@ -1307,6 +1309,8 @@ void ship_info::move(ship_info&& other)
 	score = other.score;
 
 	scan_time = other.scan_time;
+	scan_range_normal = other.scan_range_normal;
+	scan_range_capital = other.scan_range_capital;
 
 	std::swap(ct_info, other.ct_info);
 	ct_count = other.ct_count;
@@ -1700,6 +1704,8 @@ ship_info::ship_info()
 	score = 0;
 
 	scan_time = 2000;
+	scan_range_normal = 150.0f;
+	scan_range_capital = 300.0f;
 
 	memset(&ct_info, 0, sizeof(trail_info) * MAX_SHIP_CONTRAILS);
 	ct_count = 0;
@@ -3601,6 +3607,12 @@ static int parse_ship_values(ship_info* sip, const bool is_template, const bool 
 
 	if(optional_string("$Scan time:"))
 		stuff_int(&sip->scan_time);
+
+	if(optional_string("$Scan range Normal:"))
+		stuff_float(&sip->scan_range_normal);
+
+	if(optional_string("$Scan range Capital:"))
+		stuff_float(&sip->scan_range_capital);
 
 	//Parse the engine sound
 	parse_game_sound("$EngineSnd:", &sip->engine_snd);

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -1704,8 +1704,8 @@ ship_info::ship_info()
 	score = 0;
 
 	scan_time = 2000;
-	scan_range_normal = 150.0f;
-	scan_range_capital = 300.0f;
+	scan_range_normal = CARGO_REVEAL_MIN_DIST;
+	scan_range_capital = CAP_CARGO_REVEAL_MIN_DIST;
 
 	memset(&ct_info, 0, sizeof(trail_info) * MAX_SHIP_CONTRAILS);
 	ct_count = 0;

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -1117,6 +1117,8 @@ public:
 	int	score;								// default score for this ship
 
 	int	scan_time;							// time to scan this ship (in ms)
+	float scan_range_normal;                // this ship can scan other normal/small ships at this range
+	float scan_range_capital;               // this ship can scan other capital/large ships at this range
 
 	// contrail info
 	trail_info ct_info[MAX_SHIP_CONTRAILS];	


### PR DESCRIPTION
Requested for FotG - allow dedicated scanning ship options
e.g. Y-wing Longprobe & TIE/rc