### PR TITLE
HDR color space conversion for spec maps is not applied correctly

### DIFF
--- a/code/def_files/data/effects/main-f.sdr
+++ b/code/def_files/data/effects/main-f.sdr
@@ -280,11 +280,11 @@ void main()
 	}
 	if(gammaSpec) {
 		specColor.rgb = max(specColor.rgb, vec3(0.03f)); // hardcoded minimum specular value. read John Hable's blog post titled 'Everything Is Shiny'. 
- #ifdef FLAG_HDR
-		specColor.rgb = srgb_to_linear(specColor.rgb);
- #endif
 		fresnelFactor = 1.0;
 	}
+	#ifdef FLAG_HDR
+		specColor.rgb = srgb_to_linear(specColor.rgb);
+	#endif
 #endif
 	baseColor.rgb *= aoFactors.y;
 	specColor.rgb *= aoFactors.y;

--- a/code/def_files/data/effects/main-f.sdr
+++ b/code/def_files/data/effects/main-f.sdr
@@ -282,9 +282,9 @@ void main()
 		specColor.rgb = max(specColor.rgb, vec3(0.03f)); // hardcoded minimum specular value. read John Hable's blog post titled 'Everything Is Shiny'. 
 		fresnelFactor = 1.0;
 	}
-	#ifdef FLAG_HDR
-		specColor.rgb = srgb_to_linear(specColor.rgb);
-	#endif
+   #ifdef FLAG_HDR
+	specColor.rgb = srgb_to_linear(specColor.rgb);
+   #endif
 #endif
 	baseColor.rgb *= aoFactors.y;
 	specColor.rgb *= aoFactors.y;


### PR DESCRIPTION
HDR color space conversion for spec maps only happened in one code path, not all of them. This fixes #1843 