### PR TITLE
Fix nebula background rendering

### DIFF
--- a/code/def_files/data/effects/fog-f.sdr
+++ b/code/def_files/data/effects/fog-f.sdr
@@ -24,11 +24,15 @@ void main()
 	// Now we compute the depth value in projection space using the clipping plane information
 	float view_depth = 2.0 * zNear * zFar / (zFar + zNear - depth_normalized * (zFar - zNear));
 
-	// This is the same formula that is also used by the main shader
-	float fog_dist = isinf(view_depth) ? 1.0 : clamp((view_depth - fog_start) * 0.75 * fog_scale, 0.0, 1.0);
+	if (isinf(view_depth)) {
+		fragOut0.rgb = color_in.rgb;
+	} else {
+		// This is the same formula that is also used by the main shader
+		float fog_dist = clamp((view_depth - fog_start) * 0.75 * fog_scale, 0.0, 1.0);
 
-	vec3 finalFogColor = srgb_to_linear(fog_color);
+		vec3 finalFogColor = srgb_to_linear(fog_color);
 
-	fragOut0.rgb = mix(color_in.rgb, finalFogColor, fog_dist);
+		fragOut0.rgb = mix(color_in.rgb, finalFogColor, fog_dist);
+	}
 	fragOut0.a = 1.0;
 }


### PR DESCRIPTION
This makes the deferred fog rendering code use the nebula background
instead of the single fog color for the background.

This is not an ideal solution since objects fade to the fog color
instead of the color of the background but it's better than rendering no
background.