### PR TITLE
add additional parameters to warp-effect

### DIFF
--- a/code/fireball/fireballs.h
+++ b/code/fireball/fireballs.h
@@ -72,8 +72,12 @@ typedef struct fireball {
 	char	lod;					// current LOD
 	float	time_elapsed;			// in seconds
 	float	total_time;				// total lifetime of animation in seconds
-	gamesnd_id warp_open_sound_index;		// for warp-effect - Goober5000
-	gamesnd_id warp_close_sound_index;		// for warp-effect - Goober5000
+
+	// for warp-effect - Goober5000
+	gamesnd_id warp_open_sound_index;		
+	gamesnd_id warp_close_sound_index;
+	float	warp_open_duration;
+	float	warp_close_duration;
 } fireball;
 // end move
 
@@ -85,7 +89,7 @@ void fireball_process_post(object * obj, float frame_time);
 // reversed is for warp_in/out effects
 // Velocity: If not NULL, the fireball will move at a constant velocity.
 // warp_lifetime: If warp_lifetime > 0.0f then makes the explosion loop so it lasts this long.  Only works for warp effect
-int fireball_create(vec3d *pos, int fireball_type, int render_type, int parent_obj, float size, int reversed=0, vec3d *velocity=NULL, float warp_lifetime=0.0f, int ship_class=-1, matrix *orient=NULL, int low_res=0, int extra_flags=0, gamesnd_id warp_open_sound=gamesnd_id(), gamesnd_id warp_close_sound=gamesnd_id());
+int fireball_create(vec3d *pos, int fireball_type, int render_type, int parent_obj, float size, int reversed=0, vec3d *velocity=NULL, float warp_lifetime=0.0f, int ship_class=-1, matrix *orient=NULL, int low_res=0, int extra_flags=0, gamesnd_id warp_open_sound=gamesnd_id(), gamesnd_id warp_close_sound=gamesnd_id(), float warp_open_duration=-1.0f, float warp_close_duration=-1.0f);
 void fireball_render_plane(int plane);
 void fireball_close();
 
@@ -111,7 +115,7 @@ int fireball_ship_explosion_type(ship_info *sip);
 int fireball_asteroid_explosion_type(asteroid_info *aip);
 
 // returns the intensity of a wormhole
-float fireball_wormhole_intensity( object *obj );
+float fireball_wormhole_intensity( fireball *fb );
 
 // internal function to draw warp grid.
 extern void warpin_render(object *obj, matrix *orient, vec3d *pos, int texture_bitmap_num, float radius, float life_percent, float max_radius, int warp_3d = 0 );

--- a/code/fireball/fireballs.h
+++ b/code/fireball/fireballs.h
@@ -89,7 +89,7 @@ void fireball_process_post(object * obj, float frame_time);
 // reversed is for warp_in/out effects
 // Velocity: If not NULL, the fireball will move at a constant velocity.
 // warp_lifetime: If warp_lifetime > 0.0f then makes the explosion loop so it lasts this long.  Only works for warp effect
-int fireball_create(vec3d *pos, int fireball_type, int render_type, int parent_obj, float size, int reversed=0, vec3d *velocity=NULL, float warp_lifetime=0.0f, int ship_class=-1, matrix *orient=NULL, int low_res=0, int extra_flags=0, gamesnd_id warp_open_sound=gamesnd_id(), gamesnd_id warp_close_sound=gamesnd_id(), float warp_open_duration=-1.0f, float warp_close_duration=-1.0f);
+int fireball_create(vec3d *pos, int fireball_type, int render_type, int parent_obj, float size, int reversed=0, vec3d *velocity=nullptr, float warp_lifetime=0.0f, int ship_class=-1, matrix *orient=nullptr, int low_res=0, int extra_flags=0, gamesnd_id warp_open_sound=gamesnd_id(), gamesnd_id warp_close_sound=gamesnd_id(), float warp_open_duration=-1.0f, float warp_close_duration=-1.0f);
 void fireball_render_plane(int plane);
 void fireball_close();
 

--- a/code/object/object.cpp
+++ b/code/object/object.cpp
@@ -1321,9 +1321,9 @@ void obj_move_all_post(object *objp, float frametime)
 					float rad = p * (1.0f + frand() * 0.05f) * objp->radius;
 					
 					float intensity = 1.0f;
-					if(fireball_is_warp(objp))
+					if (fireball_is_warp(objp))
 					{
-						intensity = fireball_wormhole_intensity(objp); // Valathil: Get wormhole radius for lighting
+						intensity = fireball_wormhole_intensity(&Fireballs[objp->instance]); // Valathil: Get wormhole radius for lighting
 						rad = objp->radius;
 					}
 					// P goes from 0 to 1 to 0 over the life of the explosion

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -11042,7 +11042,7 @@ void sexp_warp_effect(int n)
 
 	// create fireball -----------------------------
 
-	fireball_create(&origin, fireball_type, FIREBALL_WARP_EFFECT, -1, radius, 0, NULL, duration, -1, &m_orient, 0, extra_flags, warp_open_sound_index, warp_close_sound_index, warp_open_duration, warp_close_duration);
+	fireball_create(&origin, fireball_type, FIREBALL_WARP_EFFECT, -1, radius, 0, nullptr, duration, -1, &m_orient, 0, extra_flags, warp_open_sound_index, warp_close_sound_index, warp_open_duration, warp_close_duration);
 }
 
 // this function get called by send-message or send-message random with the name of the message, sender,

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -670,7 +670,7 @@ SCP_vector<sexp_oper> Operators = {
 	{ "ship-no-vaporize",				OP_SHIP_NO_VAPORIZE,					1,	INT_MAX,	SEXP_ACTION_OPERATOR,	},	// Goober5000
 	{ "set-explosion-option",			OP_SET_EXPLOSION_OPTION,				3,	INT_MAX,	SEXP_ACTION_OPERATOR,	},	// Goober5000
 	{ "explosion-effect",				OP_EXPLOSION_EFFECT,					11,	14,			SEXP_ACTION_OPERATOR,	},	// Goober5000
-	{ "warp-effect",					OP_WARP_EFFECT,							12, 12,			SEXP_ACTION_OPERATOR,	},	// Goober5000
+	{ "warp-effect",					OP_WARP_EFFECT,							12, 14,			SEXP_ACTION_OPERATOR,	},	// Goober5000
 	{ "remove-weapons",					OP_REMOVE_WEAPONS,						0,	1,			SEXP_ACTION_OPERATOR,	},	// Karajorma
 	{ "set-time-compression",			OP_CUTSCENES_SET_TIME_COMPRESSION,		1,	3,			SEXP_ACTION_OPERATOR,	},
 	{ "reset-time-compression",			OP_CUTSCENES_RESET_TIME_COMPRESSION,	0,	0,			SEXP_ACTION_OPERATOR,	},
@@ -3527,8 +3527,8 @@ int get_sexp()
 				// set flag for taylor
 				if (CAR(n) != -1 || !strcmp(Sexp_nodes[n].text, SEXP_ARGUMENT_STRING))	// if it's evaluating a sexp or a special argument
 					Knossos_warp_ani_used = 1;												// set flag just in case
-				else if (atoi(CTEXT(n)) == 1)											// if it's the Knossos type
-					Knossos_warp_ani_used = 1;												// set flag for sure
+				else if (atoi(CTEXT(n)) != 0)											// if it's not the default 0
+					Knossos_warp_ani_used = 1;												// set flag just in case
 				break;
 
 			case OP_SET_SKYBOX_MODEL:
@@ -10756,30 +10756,10 @@ void sexp_set_explosion_option(int node)
 }
 
 // Goober5000
-void sexp_explosion_effect(int n)
-/* From the SEXP help...
-	{ OP_EXPLOSION_EFFECT, "explosion-effect\r\n"
-		"\tCauses an explosion at a given origin, with the given parameters.  "
-		"Takes 11 to 14 arguments...\r\n"
-		"\t1:  Origin X\r\n"
-		"\t2:  Origin Y\r\n"
-		"\t3:  Origin Z\r\n"
-		"\t4:  Damage\r\n"
-		"\t5:  Blast force\r\n"
-		"\t6:  Size of explosion (if 0, explosion will not be visible)\r\n"
-		"\t7:  Inner radius to apply damage (if 0, explosion will not be visible)\r\n"
-		"\t8:  Outer radius to apply damage (if 0, explosion will not be visible)\r\n"
-		"\t9:  Shockwave speed (if 0, there will be no shockwave)\r\n"
-		"\t10: Type - For backward compatibility 0 = medium, 1 = large1 (4th in table), 2 = large2 (5th in table)\r\n"
-		"           3 or greater link to respctive entry in fireball.tbl\r\n"
-		"\t11: Sound (index into sounds.tbl or name of the sound entry)\r\n"
-		"\t12: EMP intensity (optional)\r\n"
-		"\t13: EMP duration in seconds (optional)\r\n"
-		"\t14: Whether to use the full EMP time for capship turrets (optional, defaults to false)" },
-*/
 // Basically, this function pretends that there's a ship at the origin that's blowing up, and
 // it does stuff accordingly.  In some places, it has to tiptoe around a little because the
 // code often expects a parent object when in fact there is none. <.<  >.>
+void sexp_explosion_effect(int n)
 {
 	vec3d origin;
 	int max_damage, max_blast, explosion_size, inner_radius, outer_radius, shockwave_speed, num, fireball_type;
@@ -10955,27 +10935,11 @@ void sexp_explosion_effect(int n)
 
 // Goober5000
 void sexp_warp_effect(int n)
-/* From the SEXP help...
-	{ OP_WARP_EFFECT, "warp-effect\r\n"
-		"\tCauses a subspace warp effect at a given origin, facing toward a given location, with the given parameters.  "
-		"Takes 12 arguments...\r\n"
-		"\t1:  Origin X\r\n"
-		"\t2:  Origin Y\r\n"
-		"\t3:  Origin Z\r\n"
-		"\t4:  Location X\r\n"
-		"\t5:  Location Y\r\n"
-		"\t6:  Location Z\r\n"
-		"\t7:  Radius\r\n"
-		"\t8:  Duration in seconds\r\n"
-		"\t9:  Warp opening sound (index into sounds.tbl)\r\n"
-		"\t10: Warp closing sound (index into sounds.tbl)\r\n"
-		"\t11: Type (0 for standard blue [default], 1 for Knossos green)\r\n"
-		"\t12: Shape (0 for 2-D [default], 1 for 3-D)" },
-*/
 {
 	vec3d origin, location, v_orient;
 	matrix m_orient;
-	int radius, duration, fireball_type, extra_flags;
+	int num, fireball_type, extra_flags;
+	float radius, duration, warp_open_duration, warp_close_duration;
 	extra_flags = FBF_WARP_VIA_SEXP;
 
 	// read in data --------------------------------
@@ -10993,11 +10957,13 @@ void sexp_warp_effect(int n)
 	location.xyz.z = (float)eval_num(n);
 	n = CDR(n);
 
-	radius = eval_num(n);
+	radius = (float)eval_num(n);
 	n = CDR(n);
-	duration = eval_num(n);
-	if (duration < 4) duration = 4;
+	duration = (float)eval_num(n);
 	n = CDR(n);
+
+	if (duration < 4.0f)
+		duration = 4.0f;
 
 	auto warp_open_sound_index = sexp_get_sound_index(n);
 	n = CDR(n);
@@ -11005,18 +10971,23 @@ void sexp_warp_effect(int n)
 	n = CDR(n);
 
 	// fireball type
-	if (eval_num(n) == 0)
+	num = eval_num(n);
+	if (num == 0)
 	{
 		fireball_type = FIREBALL_WARP;
 	}
-	else if (eval_num(n) == 1)
+	else if (num == 1)
 	{
 		fireball_type = FIREBALL_KNOSSOS;
 	}
+	else if (num >= Num_fireball_types)
+	{
+		Warning(LOCATION, "warp-effect fireball type is out of range; quitting the warp...\n");
+		return;
+	}
 	else
 	{
-		Warning(LOCATION, "warp-effect type is out of range; quitting the warp...\n");
-		return;
+		fireball_type = num;
 	}
 	n = CDR(n);
 
@@ -11034,6 +11005,27 @@ void sexp_warp_effect(int n)
 		Warning(LOCATION, "warp-effect shape is out of range; quitting the warp...\n");
 		return;
 	}
+	n = CDR(n);
+
+	// opening and closing durations
+	warp_open_duration = warp_close_duration = -1.0f;
+	if (n >= 0)
+	{
+		warp_open_duration = warp_close_duration = ((float)eval_num(n)) / 1000.0f;
+		n = CDR(n);
+	}
+	if (n >= 0)
+	{
+		warp_close_duration = ((float)eval_num(n)) / 1000.0f;
+		n = CDR(n);
+	}
+
+	// sanity check, if these were specified
+	if (duration < warp_open_duration + warp_close_duration)
+	{
+		Warning(LOCATION, "Both warp opening and warp closing must occur within the duration of the warp effect.  Adjusting opening and closing durations to fit.");
+		warp_open_duration = warp_close_duration = duration / 2.0f;
+	}
 
 
 	// calculate orientation matrix ----------------
@@ -11050,7 +11042,7 @@ void sexp_warp_effect(int n)
 
 	// create fireball -----------------------------
 
-	fireball_create(&origin, fireball_type, FIREBALL_WARP_EFFECT, -1, (float)radius, 0, NULL, (float)duration, -1, &m_orient, 0, extra_flags, warp_open_sound_index, warp_close_sound_index);
+	fireball_create(&origin, fireball_type, FIREBALL_WARP_EFFECT, -1, radius, 0, NULL, duration, -1, &m_orient, 0, extra_flags, warp_open_sound_index, warp_close_sound_index, warp_open_duration, warp_close_duration);
 }
 
 // this function get called by send-message or send-message random with the name of the message, sender,
@@ -31616,8 +31608,7 @@ SCP_vector<sexp_help_struct> Sexp_help = {
 		"\t7:  Inner radius to apply damage (if 0, explosion will not be visible)\r\n"
 		"\t8:  Outer radius to apply damage (if 0, explosion will not be visible)\r\n"
 		"\t9:  Shockwave speed (if 0, there will be no shockwave)\r\n"
-		"\t10: Type - For backward compatibility 0 = medium, 1 = large1 (4th in table), 2 = large2 (5th in table)\r\n"
-		"           3 or greater link to respctive entry in fireball.tbl\r\n"
+		"\t10: Type (0 = medium, 1 = large1 [4th in table], 2 = large2 [5th in table], 3 or greater link to respective entry in fireball.tbl)\r\n"
 		"\t11: Sound (index into sounds.tbl or name of the sound entry)\r\n"
 		"\t12: EMP intensity (optional)\r\n"
 		"\t13: EMP duration in seconds (optional)\r\n"
@@ -31626,7 +31617,7 @@ SCP_vector<sexp_help_struct> Sexp_help = {
 	// Goober5000
 	{ OP_WARP_EFFECT, "warp-effect\r\n"
 		"\tCauses a subspace warp effect at a given origin, facing toward a given location, with the given parameters.\r\n"
-		"Takes 12 arguments...\r\n"
+		"Takes 12 to 14 arguments...\r\n"
 		"\t1:  Origin X\r\n"
 		"\t2:  Origin Y\r\n"
 		"\t3:  Origin Z\r\n"
@@ -31637,8 +31628,10 @@ SCP_vector<sexp_help_struct> Sexp_help = {
 		"\t8:  Duration in seconds (values smaller than 4 are ignored)\r\n"
 		"\t9:  Warp opening sound (index into sounds.tbl or name of the sound entry)\r\n"
 		"\t10: Warp closing sound (index into sounds.tbl or name of the sound entry)\r\n"
-		"\t11: Type (0 for standard blue [default], 1 for Knossos green)\r\n"
-		"\t12: Shape (0 for 2-D [default], 1 for 3-D)" },
+		"\t11: Type (0 for standard blue [default], 1 for Knossos green, 2 or greater link to respective entry in fireball.tbl)\r\n"
+		"\t12: Shape (0 for 2-D [default], 1 for 3-D)\r\n"
+		"\t13: Duration of the opening effect, in milliseconds (and also the closing effect if the next argument is not specified)\r\n"
+		"\t14: Duration of the closing effect, in milliseconds\r\n"	},
 
 	// Goober5000
 	{ OP_SET_OBJECT_FACING, "set-object-facing\r\n"

--- a/code/ship/shipfx.cpp
+++ b/code/ship/shipfx.cpp
@@ -2174,7 +2174,7 @@ static void maybe_fireball_wipe(clip_ship* half_ship, sound_handle* handle_array
 				fireball_type = FIREBALL_EXPLOSION_LARGE1 + rand()%FIREBALL_NUM_LARGE_EXPLOSIONS;
 			}
 			int low_res_fireballs = Bs_exp_fire_low;
-			fireball_create(&model_clip_plane_pt, fireball_type, FIREBALL_LARGE_EXPLOSION, OBJ_INDEX(half_ship->parent_obj), rad, 0, &half_ship->parent_obj->phys_info.vel, 0.0f, -1, NULL, low_res_fireballs);
+			fireball_create(&model_clip_plane_pt, fireball_type, FIREBALL_LARGE_EXPLOSION, OBJ_INDEX(half_ship->parent_obj), rad, 0, &half_ship->parent_obj->phys_info.vel, 0.0f, -1, nullptr, low_res_fireballs);
 
 			// start the next fireball up (3-4 per frame) + 30%
 			int time_low, time_high;
@@ -3442,7 +3442,7 @@ int WE_Default::warpStart()
 		HUD_printf(NOX("Subspace drive engaged"));
 	}
 
-	portal_objp = NULL;
+	portal_objp = nullptr;
 	if ((direction == WD_WARP_IN) && shipfx_special_warp_objnum_valid(shipp->special_warpin_objnum))
 	{
 		portal_objp = &Objects[shipp->special_warpin_objnum];
@@ -3457,7 +3457,7 @@ int WE_Default::warpStart()
 	if(direction == WD_WARP_IN)
 	{
 		polymodel *pm = model_get(sip->model_num);
-		vm_vec_scale_add( &pos, &objp->pos, &objp->orient.vec.fvec, (pm != NULL) ? -pm->mins.xyz.z : objp->radius );
+		vm_vec_scale_add( &pos, &objp->pos, &objp->orient.vec.fvec, (pm != nullptr) ? -pm->mins.xyz.z : objp->radius );
 
 		// Effect time is 'SHIPFX_WARP_DELAY' (1.5 secs) seconds to start, 'shipfx_calculate_warp_time' 
 		// for ship to go thru, and 'SHIPFX_WARP_DELAY' (1.5 secs) to go away.
@@ -3471,7 +3471,7 @@ int WE_Default::warpStart()
 
 	radius = shipfx_calculate_effect_radius(objp, direction);
 	// cap radius to size of knossos
-	if(portal_objp != NULL)
+	if (portal_objp != nullptr)
 	{
 		// cap radius to size of knossos
 		radius = MIN(radius, 0.8f*portal_objp->radius);
@@ -3481,18 +3481,18 @@ int WE_Default::warpStart()
 	if (direction == WD_WARP_OUT)
 	{
 		// maybe special warpout
-		int fireball_type = ((portal_objp != NULL) || (sip->warpout_type == WT_KNOSSOS) || (sip->warpout_type == WT_DEFAULT_THEN_KNOSSOS)) ? FIREBALL_KNOSSOS : FIREBALL_WARP;
+		int fireball_type = ((portal_objp != nullptr) || (sip->warpout_type == WT_KNOSSOS) || (sip->warpout_type == WT_DEFAULT_THEN_KNOSSOS)) ? FIREBALL_KNOSSOS : FIREBALL_WARP;
 
 		// create fireball
-		warp_objnum = fireball_create(&pos, fireball_type, FIREBALL_WARP_EFFECT, OBJ_INDEX(objp), radius, 1, NULL, warp_time, shipp->ship_info_index, NULL, 0, 0, sip->warpout_snd_start, sip->warpout_snd_end);
+		warp_objnum = fireball_create(&pos, fireball_type, FIREBALL_WARP_EFFECT, OBJ_INDEX(objp), radius, 1, nullptr, warp_time, shipp->ship_info_index, nullptr, 0, 0, sip->warpout_snd_start, sip->warpout_snd_end);
 	}
 	else if (direction == WD_WARP_IN)
 	{
 		// maybe special warpin
-		int fireball_type = ((portal_objp != NULL) || (sip->warpin_type == WT_KNOSSOS)) ? FIREBALL_KNOSSOS : FIREBALL_WARP;
+		int fireball_type = ((portal_objp != nullptr) || (sip->warpin_type == WT_KNOSSOS)) ? FIREBALL_KNOSSOS : FIREBALL_WARP;
 
 		// create fireball
-		warp_objnum = fireball_create(&pos, fireball_type, FIREBALL_WARP_EFFECT, OBJ_INDEX(objp), radius, 0, NULL, warp_time, shipp->ship_info_index, NULL, 0, 0, sip->warpin_snd_start, sip->warpin_snd_end);
+		warp_objnum = fireball_create(&pos, fireball_type, FIREBALL_WARP_EFFECT, OBJ_INDEX(objp), radius, 0, nullptr, warp_time, shipp->ship_info_index, nullptr, 0, 0, sip->warpin_snd_start, sip->warpin_snd_end);
 	}
 	else
 	{


### PR DESCRIPTION
The warp-effect SEXP can now specify other animations from fireball.tbl that are not necessarily the standard or Knossos animations.  Additionally, the SEXP can now specify the duration for the opening and closing of the warp effect.