### PR TITLE
Training messages fix.

### DIFF
--- a/code/mission/missiontraining.cpp
+++ b/code/mission/missiontraining.cpp
@@ -839,9 +839,9 @@ void message_training_setup(int m, int length, char *special_message)
 	training_process_message(Training_buf);
 	Training_num_lines = split_str(Training_buf, TRAINING_LINE_WIDTH, Training_line_lengths, Training_lines, MAX_TRAINING_MESSAGE_LINES);
 
-	Assert( Training_num_lines >= 0 );
+	Assert(Training_num_lines >= 0);
 
-	if (message_play_training_voice(Messages[m].wave_info.index) < 0) {
+	if ((message_play_training_voice(Messages[m].wave_info.index) < 0) || (Master_voice_volume <= 0)) {
 		if (length > 0)
 			Training_message_timestamp = timestamp(length * 1000);
 		else


### PR DESCRIPTION
There is a following bug: if you set Voice volume level to zero, messages in some training missions will skip too fast (2 sec). For example in FSPort mission "Basic Training Stage 4" file btm-04.fs2

It is because with zero volume message timing is not recalculated.

I tested it and now all is OK.