### PR TITLE
Remodularize fireball.tbl

### DIFF
--- a/code/fireball/fireballs.cpp
+++ b/code/fireball/fireballs.cpp
@@ -107,42 +107,45 @@ void fireball_play_warphole_close_sound(fireball *fb)
 	snd_play_3d(gamesnd_get_game_sound(sound_index), &fireball_objp->pos, &Eye_position, fireball_objp->radius); // play warp sound effect
 }
 
-static void fireball_generate_unique_id(char *unique_id, int idx)
+static void fireball_generate_unique_id(char *unique_id, int buffer_len, int fireball_index)
 {
-	Assert((idx >= 0) && (idx < MAX_FIREBALL_TYPES));
+	Assert((fireball_index >= 0) && (fireball_index < MAX_FIREBALL_TYPES));
 
-	switch (idx)
+	switch (fireball_index)
 	{
 		// use sensible names for the fireball.tbl default entries
 		case FIREBALL_EXPLOSION_MEDIUM:
-			strcpy(unique_id, "Medium Explosion");
+			strncpy(unique_id, "Medium Explosion", buffer_len);
 			break;
 
 		case FIREBALL_WARP:
-			strcpy(unique_id, "Warp Effect");
+			strncpy(unique_id, "Warp Effect", buffer_len);
 			break;
 
 		case FIREBALL_KNOSSOS:
-			strcpy(unique_id, "Knossos Effect");
+			strncpy(unique_id, "Knossos Effect", buffer_len);
 			break;
 
 		case FIREBALL_ASTEROID:
-			strcpy(unique_id, "Asteroid Explosion");
+			strncpy(unique_id, "Asteroid Explosion", buffer_len);
 			break;
 
 		case FIREBALL_EXPLOSION_LARGE1:
-			strcpy(unique_id, "Large Explosion 1");
+			strncpy(unique_id, "Large Explosion 1", buffer_len);
 			break;
 
 		case FIREBALL_EXPLOSION_LARGE2:
-			strcpy(unique_id, "Large Explosion 2");
+			strncpy(unique_id, "Large Explosion 2", buffer_len);
 			break;
 
 		// base the id on the index
 		default:
-			sprintf(unique_id, "Custom Fireball %d", idx - NUM_DEFAULT_FIREBALLS + 1);
+			snprintf(unique_id, buffer_len, "Custom Fireball %d", fireball_index - NUM_DEFAULT_FIREBALLS + 1);
 			break;
 	}
+
+	// null-terminate
+	unique_id[buffer_len - 1] = '\0';
 }
 
 /**
@@ -205,7 +208,7 @@ int fireball_info_lookup(const char *unique_id)
 /**
  * Parse fireball tbl
  */
-void parse_fireball_tbl(const char *table_filename)
+static void parse_fireball_tbl(const char *table_filename)
 {
 	try
 	{
@@ -272,7 +275,7 @@ void parse_fireball_tbl(const char *table_filename)
 				// make sure we don't exceed the max
 				if (Num_fireball_types >= MAX_FIREBALL_TYPES)
 				{
-					Warning(LOCATION, "Too many fireball entries!  Max is %d", MAX_FIREBALL_TYPES);
+					error_display(0, "Too many fireball entries!  Max is %d", MAX_FIREBALL_TYPES);
 					return;
 				}
 
@@ -281,7 +284,7 @@ void parse_fireball_tbl(const char *table_filename)
 
 				// If the table didn't specify a unique ID, generate one.  This will be assigned a few lines later.
 				if (strlen(unique_id) == 0)
-					fireball_generate_unique_id(unique_id, Num_fireball_types);
+					fireball_generate_unique_id(unique_id, NAME_LENGTH, Num_fireball_types);
 
 				// Set remaining fireball defaults
 				fireball_set_default_color(Num_fireball_types);

--- a/code/fireball/fireballs.cpp
+++ b/code/fireball/fireballs.cpp
@@ -36,8 +36,6 @@ int Knossos_warp_ani_used;
 
 #define WARPHOLE_GROW_TIME		(2.35f)	// time for warphole to reach max size (also time to shrink to nothing once it begins to shrink)
 
-#define MAX_FIREBALL_LOD						4
-
 #define MAX_FIREBALLS	200
 
 #define MAX_WARP_LOD	0
@@ -153,71 +151,124 @@ static void fireball_set_default_color(int idx)
 	}
 }
 
+void fireball_info_clear(fireball_info *fb)
+{
+	Assert(fb != nullptr);
+	memset(fb, 0, sizeof(fireball_info));
+
+	for (int i = 0; i < MAX_FIREBALL_LOD; ++i)
+		fb->lod[i].bitmap_id = -1;
+}
+
+int fireball_info_lookup(const char *unique_id)
+{
+	for (int i = 0; i < Num_fireball_types; ++i)
+		if (!stricmp(Fireball_info[i].unique_id, unique_id))
+			return i;
+
+	return -1;
+}
+
 /**
  * Parse fireball tbl
- *
- * NOTE: we can't be too trusting here so a tbm will only modify the LOD count, not add an entry
  */
-void parse_fireball_tbl(const char *filename)
+void parse_fireball_tbl(const char *table_filename)
 {
-	lod_checker lod_check;
-	color fb_color;
-
 	try
 	{
-		read_file_text(filename, CF_TYPE_TABLES);
+		read_file_text(table_filename, CF_TYPE_TABLES);
 		reset_parse();
 
 		required_string("#Start");
 
-		while (required_string_either("#End", "$Name:")) {
-			memset(&lod_check, 0, sizeof(lod_checker));
+		while (required_string_either("#End", "$Name:"))
+		{
+			fireball_info *fi;
+			int existing_idx = -1;
+			char unique_id[NAME_LENGTH];
+			char fireball_filename[MAX_FILENAME_LEN];
+
+			// unique ID, because indexes are unpredictable
+			*unique_id = '\0';
+			if (optional_string("$Unique ID:"))
+				stuff_string(unique_id, F_NAME, NAME_LENGTH);
 
 			// base filename
 			required_string("$Name:");
-			stuff_string(lod_check.filename, F_NAME, MAX_FILENAME_LEN);
+			stuff_string(fireball_filename, F_NAME, MAX_FILENAME_LEN);
 
-			lod_check.override = -1;
+			// find out if we are overriding a previous entry;
+			// per precedent, these strings should only be in TBMs
+			// UNLIKE precedent, we can now add fireballs in modular tables, not just replace them
+			if (Parsing_modular_table)
+			{
+				if (optional_string("+Explosion_Medium"))
+					existing_idx = FIREBALL_EXPLOSION_MEDIUM;
+				else if (optional_string("+Warp_Effect"))
+					existing_idx = FIREBALL_WARP;
+				else if (optional_string("+Knossos_Effect"))
+					existing_idx = FIREBALL_KNOSSOS;
+				else if (optional_string("+Asteroid"))
+					existing_idx = FIREBALL_ASTEROID;
+				else if (optional_string("+Explosion_Large1"))
+					existing_idx = FIREBALL_EXPLOSION_LARGE1;
+				else if (optional_string("+Explosion_Large2"))
+					existing_idx = FIREBALL_EXPLOSION_LARGE2;
+				else if (optional_string("+Custom_Fireball"))
+					stuff_int(&existing_idx);
 
-			// these entries should only be in TBMs, and it has to include at least one
-			if (Parsing_modular_table) {
-				if (optional_string("+Explosion_Medium")) {
-					lod_check.override = FIREBALL_EXPLOSION_MEDIUM;
-				}
-				else if (optional_string("+Warp_Effect")) {
-					lod_check.override = FIREBALL_WARP;
-				}
-				else if (optional_string("+Knossos_Effect")) {
-					lod_check.override = FIREBALL_KNOSSOS;
-				}
-				else if (optional_string("+Asteroid")) {
-					lod_check.override = FIREBALL_ASTEROID;
-				}
-				else if (optional_string("+Explosion_Large1")) {
-					lod_check.override = FIREBALL_EXPLOSION_LARGE1;
-				}
-				else if (optional_string("+Explosion_Large2")){
-					lod_check.override = FIREBALL_EXPLOSION_LARGE2;
-				}
-				else {
-					required_string("+Custom_Fireball");
-					stuff_int(&lod_check.override);
+				// we can ALSO override a previous entry by specifying a previously used unique ID
+				// either way will work, but if both are specified, unique ID takes precedence
+				if (*unique_id)
+				{
+					int temp_idx = fireball_info_lookup(unique_id);
+					if (temp_idx >= 0)
+						existing_idx = temp_idx;
 				}
 			}
 
-			lod_check.num_lods = 1;
+			// now select our entry accordingly...
+			// are we using a previous entry?
+			if (existing_idx >= 0)
+			{
+				fi = &Fireball_info[existing_idx];
+			}
+			// we are creating a new entry, so set some defaults
+			else
+			{
+				// make sure we don't exceed the max
+				if (Num_fireball_types >= MAX_FIREBALL_TYPES)
+				{
+					Warning(LOCATION, "Too many fireball entries!  Max is %d", MAX_FIREBALL_TYPES);
+					return;
+				}
 
-			// Do we have an LOD num
-			if (optional_string("$LOD:")) {
-				stuff_int(&lod_check.num_lods);
+				fi = &Fireball_info[Num_fireball_types];
+				fireball_info_clear(fi);
+
+				fireball_set_default_color(Num_fireball_types);
+
+				Num_fireball_types++;
 			}
 
-			if (lod_check.num_lods > MAX_FIREBALL_LOD) {
-				lod_check.num_lods = MAX_FIREBALL_LOD;
+			// copy over what we already parsed
+			// (copying the unique ID is okay because the default fireball.tbl doesn't HAVE a unique ID)
+			if (*unique_id)
+				strcpy_s(fi->unique_id, unique_id);
+			strcpy_s(fi->lod[0].filename, fireball_filename);
+
+			// Do we have a LOD num?
+			if (optional_string("$LOD:"))
+			{
+				stuff_int(&fi->lod_count);
+
+				if (fi->lod_count > MAX_FIREBALL_LOD)
+					fi->lod_count = MAX_FIREBALL_LOD;
 			}
 
 			// check for particular lighting color
-			if (optional_string("$Light color:")) {
+			if (optional_string("$Light color:"))
+			{
 				int r, g, b;
 
 				stuff_int(&r);
@@ -228,89 +279,39 @@ void parse_fireball_tbl(const char *filename)
 				CLAMP(g, 0, 255);
 				CLAMP(b, 0, 255);
 
-				gr_init_color(&fb_color, r, g, b);
+				fi->exp_color[0] = (r / 255.0f);
+				fi->exp_color[1] = (g / 255.0f);
+				fi->exp_color[2] = (b / 255.0f);
 			}
-			else {
-				// to keep things simple, we just use 0 alpha to indicate that a default value should be used
-				memset(&fb_color, 0, sizeof(color));
-			}
-
-			// we may use one filename for multiple entries so we'll have to handle dupes post parse
-			LOD_checker.push_back(lod_check);
-			LOD_color.push_back(fb_color);
 		}
 
 		required_string("#End");
 	}
 	catch (const parse::ParseException& e)
 	{
-		mprintf(("TABLES: Unable to parse '%s'!  Error message = %s.\n", filename, e.what()));
+		mprintf(("TABLES: Unable to parse '%s'!  Error message = %s.\n", table_filename, e.what()));
 		return;
 	}
 }
 
 void fireball_parse_tbl()
 {
-	int i = 0, j;
-	SCP_vector<lod_checker>::iterator lod;
-
-	memset( &Fireball_info, 0, sizeof(fireball_info) * MAX_FIREBALL_TYPES );
-
+	// every newly parsed fireball_info will get cleared before being added
+	// must do this outside of parse_fireball_tbl because it's called twice
+	Num_fireball_types = 0;
 
 	parse_fireball_tbl("fireball.tbl");
 
 	// look for any modular tables
 	parse_modular_table(NOX("*-fbl.tbm"), parse_fireball_tbl);
 
-	// we've got our list so pass it off for final checking and loading.
-	// we assume that entries in fireball.tbl are in the correct order
-	for (lod = LOD_checker.begin(); lod != LOD_checker.end(); ++lod) {
-		if ( (i < MAX_FIREBALL_TYPES) && (lod->override < 0) ) {
-			strcpy_s( Fireball_info[i].lod[0].filename, lod->filename );
-			Fireball_info[i].lod_count = lod->num_lods;
-			Num_fireball_types++;
-
-			if (LOD_color[i].alpha == 255) {
-				Fireball_info[i].exp_color[0] = (LOD_color[i].red / 255.0f);
-				Fireball_info[i].exp_color[1] = (LOD_color[i].green / 255.0f);
-				Fireball_info[i].exp_color[2] = (LOD_color[i].blue / 255.0f);
-			} else {
-				fireball_set_default_color(i);
-			}
-		}
-		i++;
-	}
-
-	// having to do this twice is less than optimal, but less error prone too.
-	// this handles (and should only have to handle) TBM related entries
-	i = 0;
-	for (lod = LOD_checker.begin(); lod != LOD_checker.end(); ++lod) {
-		// try entry replacement
-		if ( (lod->override >= 0) && (lod->override < Num_fireball_types) ) {
-			strcpy_s( Fireball_info[lod->override].lod[0].filename, lod->filename );
-			Fireball_info[lod->override].lod_count = lod->num_lods;
-
-			if (LOD_color[i].alpha == 255) {
-				Fireball_info[lod->override].exp_color[0] = (LOD_color[i].red / 255.0f);
-				Fireball_info[lod->override].exp_color[1] = (LOD_color[i].green / 255.0f);
-				Fireball_info[lod->override].exp_color[2] = (LOD_color[i].blue / 255.0f);
-			} else {
-				fireball_set_default_color(lod->override);
-			}
-		}
-	}
-
 	// fill in extra LOD filenames
-	for (i = 0; i < Num_fireball_types; i++) {
-		for (j = 1; j < Fireball_info[i].lod_count; j++) {
+	for (int i = 0; i < Num_fireball_types; i++)
+	{
+		for (int j = 1; j < Fireball_info[i].lod_count; j++)
 			sprintf( Fireball_info[i].lod[j].filename, "%s_%d", Fireball_info[i].lod[0].filename, j);
-		}
 	}
-
-	// done
-	LOD_checker.clear();
 }
-
 
 void fireball_load_data()
 {

--- a/code/fireball/fireballs.cpp
+++ b/code/fireball/fireballs.cpp
@@ -26,11 +26,6 @@
 #include <cstdlib>
 
 
-// make use of the LOD checker for tbl/tbm parsing (from weapons.cpp)
-extern SCP_vector<lod_checker> LOD_checker;
-
-static SCP_vector<color> LOD_color;
-
 int Warp_model;
 int Knossos_warp_ani_used;
 
@@ -114,6 +109,8 @@ void fireball_play_warphole_close_sound(fireball *fb)
 
 static void fireball_generate_unique_id(char *unique_id, int idx)
 {
+	Assert((idx >= 0) && (idx < MAX_FIREBALL_TYPES));
+
 	switch (idx)
 	{
 		// use sensible names for the fireball.tbl default entries
@@ -153,7 +150,7 @@ static void fireball_generate_unique_id(char *unique_id, int idx)
  */
 static void fireball_set_default_color(int idx)
 {
-	Assert( (idx >= 0) && (idx < MAX_FIREBALL_TYPES) );
+	Assert((idx >= 0) && (idx < MAX_FIREBALL_TYPES));
 
 	switch (idx)
 	{

--- a/code/fireball/fireballs.cpp
+++ b/code/fireball/fireballs.cpp
@@ -112,6 +112,42 @@ void fireball_play_warphole_close_sound(fireball *fb)
 	snd_play_3d(gamesnd_get_game_sound(sound_index), &fireball_objp->pos, &Eye_position, fireball_objp->radius); // play warp sound effect
 }
 
+static void fireball_generate_unique_id(char *unique_id, int idx)
+{
+	switch (idx)
+	{
+		// use sensible names for the fireball.tbl default entries
+		case FIREBALL_EXPLOSION_MEDIUM:
+			strcpy(unique_id, "Medium Explosion");
+			break;
+
+		case FIREBALL_WARP:
+			strcpy(unique_id, "Warp Effect");
+			break;
+
+		case FIREBALL_KNOSSOS:
+			strcpy(unique_id, "Knossos Effect");
+			break;
+
+		case FIREBALL_ASTEROID:
+			strcpy(unique_id, "Asteroid Explosion");
+			break;
+
+		case FIREBALL_EXPLOSION_LARGE1:
+			strcpy(unique_id, "Large Explosion 1");
+			break;
+
+		case FIREBALL_EXPLOSION_LARGE2:
+			strcpy(unique_id, "Large Explosion 2");
+			break;
+
+		// base the id on the index
+		default:
+			sprintf(unique_id, "Custom Fireball %d", idx - NUM_DEFAULT_FIREBALLS + 1);
+			break;
+	}
+}
+
 /**
  * Set default colors for each explosion type (original values from object.cpp)
  */
@@ -189,7 +225,7 @@ void parse_fireball_tbl(const char *table_filename)
 			char fireball_filename[MAX_FILENAME_LEN];
 
 			// unique ID, because indexes are unpredictable
-			*unique_id = '\0';
+			memset(unique_id, 0, NAME_LENGTH);
 			if (optional_string("$Unique ID:"))
 				stuff_string(unique_id, F_NAME, NAME_LENGTH);
 
@@ -219,7 +255,7 @@ void parse_fireball_tbl(const char *table_filename)
 
 				// we can ALSO override a previous entry by specifying a previously used unique ID
 				// either way will work, but if both are specified, unique ID takes precedence
-				if (*unique_id)
+				if (strlen(unique_id) > 0)
 				{
 					int temp_idx = fireball_info_lookup(unique_id);
 					if (temp_idx >= 0)
@@ -246,14 +282,18 @@ void parse_fireball_tbl(const char *table_filename)
 				fi = &Fireball_info[Num_fireball_types];
 				fireball_info_clear(fi);
 
+				// If the table didn't specify a unique ID, generate one.  This will be assigned a few lines later.
+				if (strlen(unique_id) == 0)
+					fireball_generate_unique_id(unique_id, Num_fireball_types);
+
+				// Set remaining fireball defaults
 				fireball_set_default_color(Num_fireball_types);
 
 				Num_fireball_types++;
 			}
 
 			// copy over what we already parsed
-			// (copying the unique ID is okay because the default fireball.tbl doesn't HAVE a unique ID)
-			if (*unique_id)
+			if (strlen(unique_id) > 0)
 				strcpy_s(fi->unique_id, unique_id);
 			strcpy_s(fi->lod[0].filename, fireball_filename);
 

--- a/code/fireball/fireballs.h
+++ b/code/fireball/fireballs.h
@@ -36,6 +36,8 @@ class asteroid_info;
 #define MAX_FIREBALL_TYPES			32		// The maximum number of fireballs that can be defined
 #define NUM_DEFAULT_FIREBALLS		6
 
+#define MAX_FIREBALL_LOD						4
+
 #define FIREBALL_NUM_LARGE_EXPLOSIONS 2
 
 extern int fireball_used[MAX_FIREBALL_TYPES];
@@ -50,9 +52,10 @@ typedef struct fireball_lod {
 } fireball_lod;
 
 typedef struct fireball_info {
+	char				unique_id[NAME_LENGTH];
 	int					lod_count;
-	float				exp_color[3];
-	fireball_lod		lod[4];
+	fireball_lod		lod[MAX_FIREBALL_LOD];
+	float				exp_color[3];	// red, green, blue
 } fireball_info;
 
 // flag values for fireball struct flags member
@@ -85,6 +88,8 @@ void fireball_init();
 void fireball_render(object* obj, model_draw_list *scene);
 void fireball_delete( object * obj );
 void fireball_process_post(object * obj, float frame_time);
+
+int fireball_info_lookup(const char *unique_id);
 
 // reversed is for warp_in/out effects
 // Velocity: If not NULL, the fireball will move at a constant velocity.

--- a/code/fireball/fireballs.h
+++ b/code/fireball/fireballs.h
@@ -41,7 +41,6 @@ class asteroid_info;
 #define FIREBALL_NUM_LARGE_EXPLOSIONS 2
 
 extern int fireball_used[MAX_FIREBALL_TYPES];
-extern int Num_fireball_types;
 
 // all this moved here by Goober5000 because it makes more sense in the H file
 typedef struct fireball_lod {
@@ -57,6 +56,9 @@ typedef struct fireball_info {
 	fireball_lod		lod[MAX_FIREBALL_LOD];
 	float				exp_color[3];	// red, green, blue
 } fireball_info;
+
+extern fireball_info Fireball_info[MAX_FIREBALL_TYPES];
+extern int Num_fireball_types;
 
 // flag values for fireball struct flags member
 #define	FBF_WARP_CLOSE_SOUND_PLAYED		(1<<0)
@@ -88,6 +90,9 @@ void fireball_init();
 void fireball_render(object* obj, model_draw_list *scene);
 void fireball_delete( object * obj );
 void fireball_process_post(object * obj, float frame_time);
+
+// This does not load all the data, just the filenames and such.  Only used by FRED.
+void fireball_parse_tbl();
 
 int fireball_info_lookup(const char *unique_id);
 

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -1858,6 +1858,9 @@ int check_sexp_syntax(int node, int return_type, int recursive, int *bad_node, i
 				break;
 
                 case OPF_AMBIGUOUS:
+				case OPF_GAME_SND:
+				case OPF_FIREBALL:
+				case OPF_WEAPON_BANK_NUMBER:
                     break;
 
 				default: 

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -3187,6 +3187,24 @@ int check_sexp_syntax(int node, int return_type, int recursive, int *bad_node, i
 				}
 				break;
 
+			case OPF_FIREBALL:
+				if (type2 == SEXP_ATOM_NUMBER)
+				{
+					int num = atoi(CTEXT(node));
+					if (num < 0 || num >= Num_fireball_types)
+					{
+						return SEXP_CHECK_NUM_RANGE_INVALID;
+					}
+				}
+				else if (type2 == SEXP_ATOM_STRING)
+				{
+					if (fireball_info_lookup(CTEXT(node)) < 0)
+					{
+						return SEXP_CHECK_INVALID_FIREBALL;
+					}
+				}
+				break;
+
 			default:
 				Error(LOCATION, "Unhandled argument format");
 		}
@@ -10793,29 +10811,49 @@ void sexp_explosion_effect(int n)
 	n = CDR(n);
 
 	// fireball type
-	num = eval_num(n);
-	if (num == 0)
+	// -------------
+
+	// this node is another SEXP operator or a plain number
+	if (CAR(n) != -1 || Sexp_nodes[n].subtype == SEXP_ATOM_NUMBER)
 	{
-		fireball_type = FIREBALL_EXPLOSION_MEDIUM;
+		num = eval_num(n);
+		if (num == 0)
+		{
+			fireball_type = FIREBALL_EXPLOSION_MEDIUM;
+		}
+		else if (num == 1)
+		{
+			fireball_type = FIREBALL_EXPLOSION_LARGE1;
+		}
+		else if (num == 2)
+		{
+			fireball_type = FIREBALL_EXPLOSION_LARGE2;
+		}
+		else if (num >= Num_fireball_types)
+		{
+			Warning(LOCATION, "explosion-effect fireball type is out of range; quitting the explosion...\n");
+			return;
+		}
+		else
+		{
+			fireball_type = num;
+		}
 	}
-	else if (num == 1)
-	{
-		fireball_type = FIREBALL_EXPLOSION_LARGE1;
-	}
-	else if (num == 2)
-	{
-		fireball_type = FIREBALL_EXPLOSION_LARGE2;
-	}
-	else if (num >= Num_fireball_types)
-	{
-		Warning(LOCATION, "explosion-effect fireball type is out of range; quitting the explosion...\n");
-		return;
-	}
+	// it's gotta be a name
 	else
 	{
-		fireball_type = num;
+		const char *unique_id = CTEXT(n);
+		fireball_type = fireball_info_lookup(unique_id);
+
+		if (fireball_type < 0)
+		{
+			Warning(LOCATION, "unrecognized fireball entry \'%s\'; quitting the explosion...\n", unique_id);
+			return;
+		}
 	}
 	n = CDR(n);
+
+	// -------------
 
 	auto sound_index = sexp_get_sound_index(n);
 	n = CDR(n);
@@ -10972,25 +11010,45 @@ void sexp_warp_effect(int n)
 	n = CDR(n);
 
 	// fireball type
-	num = eval_num(n);
-	if (num == 0)
+	// -------------
+
+	// this node is another SEXP operator or a plain number
+	if (CAR(n) != -1 || Sexp_nodes[n].subtype == SEXP_ATOM_NUMBER)
 	{
-		fireball_type = FIREBALL_WARP;
+		num = eval_num(n);
+		if (num == 0)
+		{
+			fireball_type = FIREBALL_WARP;
+		}
+		else if (num == 1)
+		{
+			fireball_type = FIREBALL_KNOSSOS;
+		}
+		else if (num >= Num_fireball_types)
+		{
+			Warning(LOCATION, "warp-effect fireball type is out of range; quitting the warp...\n");
+			return;
+		}
+		else
+		{
+			fireball_type = num;
+		}
 	}
-	else if (num == 1)
-	{
-		fireball_type = FIREBALL_KNOSSOS;
-	}
-	else if (num >= Num_fireball_types)
-	{
-		Warning(LOCATION, "warp-effect fireball type is out of range; quitting the warp...\n");
-		return;
-	}
+	// it's gotta be a name
 	else
 	{
-		fireball_type = num;
+		const char *unique_id = CTEXT(n);
+		fireball_type = fireball_info_lookup(unique_id);
+
+		if (fireball_type < 0)
+		{
+			Warning(LOCATION, "unrecognized fireball entry \'%s\'; quitting the warp...\n", unique_id);
+			return;
+		}
 	}
 	n = CDR(n);
+
+	// -------------
 
 	// shape
 	if (eval_num(n) == 0)
@@ -27264,6 +27322,8 @@ int query_operator_argument_type(int op, int argnum)
 		case OP_EXPLOSION_EFFECT:
 			if (argnum <= 2)
 				return OPF_NUMBER;
+			else if (argnum == 9)
+				return OPF_FIREBALL;
 			else if (argnum == 10)
 				return OPF_GAME_SND;
 			else
@@ -27274,6 +27334,8 @@ int query_operator_argument_type(int op, int argnum)
 				return OPF_NUMBER;
 			else if (argnum == 8 || argnum == 9)
 				return OPF_GAME_SND;
+			else if (argnum == 10)
+				return OPF_FIREBALL;
 			else
 				return OPF_POSITIVE;
 
@@ -29027,6 +29089,9 @@ const char *sexp_error_message(int num)
 
 		case SEXP_CHECK_INVALID_SSM_CLASS:
 			return "Invalid SSM class";
+
+		case SEXP_CHECK_INVALID_FIREBALL:
+			return "Invalid fireball";
 
 		default:
 			Warning(LOCATION, "Unhandled sexp error code %d!", num);
@@ -31622,7 +31687,7 @@ SCP_vector<sexp_help_struct> Sexp_help = {
 		"\t7:  Inner radius to apply damage (if 0, explosion will not be visible)\r\n"
 		"\t8:  Outer radius to apply damage (if 0, explosion will not be visible)\r\n"
 		"\t9:  Shockwave speed (if 0, there will be no shockwave)\r\n"
-		"\t10: Type (0 = medium, 1 = large1 [4th in table], 2 = large2 [5th in table], 3 or greater link to respective entry in fireball.tbl)\r\n"
+		"\t10: Fireball Type (unique ID of a fireball entry, OR a number: 0 = medium explosion [default, 1st in table], 1 = large explosion 1 [4th in table], 2 = large explosion 2 [5th in table], 3 or greater the respective entry in fireball.tbl)\r\n"
 		"\t11: Sound (index into sounds.tbl or name of the sound entry)\r\n"
 		"\t12: EMP intensity (optional)\r\n"
 		"\t13: EMP duration in seconds (optional)\r\n"
@@ -31642,7 +31707,7 @@ SCP_vector<sexp_help_struct> Sexp_help = {
 		"\t8:  Duration in seconds (values smaller than 4 are ignored)\r\n"
 		"\t9:  Warp opening sound (index into sounds.tbl or name of the sound entry)\r\n"
 		"\t10: Warp closing sound (index into sounds.tbl or name of the sound entry)\r\n"
-		"\t11: Type (0 for standard blue [default], 1 for Knossos green, 2 or greater link to respective entry in fireball.tbl)\r\n"
+		"\t11: Fireball Type (unique ID of a fireball entry, OR a number: 0 for standard blue [default], 1 for Knossos green, 2 or greater the respective entry in fireball.tbl)\r\n"
 		"\t12: Shape (0 for 2-D [default], 1 for 3-D)\r\n"
 		"\t13: Duration of the opening effect, in milliseconds (and also the closing effect if the next argument is not specified)\r\n"
 		"\t14: Duration of the closing effect, in milliseconds\r\n"	},

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -1782,6 +1782,13 @@ int check_sexp_syntax(int node, int return_type, int recursive, int *bad_node, i
 						t = OPR_AMBIGUOUS;
 						break;
 
+					// these types can accept either lists of strings or indexes
+					case OPF_GAME_SND:
+					case OPF_FIREBALL:
+					case OPF_WEAPON_BANK_NUMBER:
+						t = OPR_POSITIVE;
+						break;
+
 					default:
 						return SEXP_CHECK_UNKNOWN_TYPE;  // no other return types available
 				}
@@ -3188,7 +3195,7 @@ int check_sexp_syntax(int node, int return_type, int recursive, int *bad_node, i
 				break;
 
 			case OPF_FIREBALL:
-				if (type2 == SEXP_ATOM_NUMBER)
+				if (type2 == SEXP_ATOM_NUMBER || can_construe_as_integer(CTEXT(node)))
 				{
 					int num = atoi(CTEXT(node));
 					if (num < 0 || num >= Num_fireball_types)
@@ -10814,9 +10821,15 @@ void sexp_explosion_effect(int n)
 	// -------------
 
 	// this node is another SEXP operator or a plain number
+	num = -1;
 	if (CAR(n) != -1 || Sexp_nodes[n].subtype == SEXP_ATOM_NUMBER)
-	{
 		num = eval_num(n);
+	else if (can_construe_as_integer(CTEXT(n)))
+		num = atoi(CTEXT(n));
+
+	// is it a number?
+	if (num >= 0)
+	{
 		if (num == 0)
 		{
 			fireball_type = FIREBALL_EXPLOSION_MEDIUM;
@@ -11013,7 +11026,14 @@ void sexp_warp_effect(int n)
 	// -------------
 
 	// this node is another SEXP operator or a plain number
+	num = -1;
 	if (CAR(n) != -1 || Sexp_nodes[n].subtype == SEXP_ATOM_NUMBER)
+		num = eval_num(n);
+	else if (can_construe_as_integer(CTEXT(n)))
+		num = atoi(CTEXT(n));
+
+	// is it a number?
+	if (num >= 0)
 	{
 		num = eval_num(n);
 		if (num == 0)

--- a/code/parse/sexp.h
+++ b/code/parse/sexp.h
@@ -113,6 +113,7 @@ class waypoint_list;
 #define OPF_NEBULA_PATTERN		86		// Axem - Full Nebula Background Patterns, as defined in nebula.tbl
 #define OPF_SKYBOX_FLAGS		87		// niffiwan - valid skybox flags
 #define OPF_GAME_SND			88		// m!m - A game sound
+#define OPF_FIREBALL			89		// Goober5000 - an entry in fireball.tbl
 
 // Operand return types
 #define	OPR_NUMBER				1	// returns number
@@ -1020,6 +1021,7 @@ char *CTEXT(int n);
 #define SEXP_CHECK_INVALID_SKYBOX_FLAG			-158
 #define SEXP_CHECK_INVALID_GAME_SND				-159
 #define SEXP_CHECK_INVALID_SSM_CLASS			-160
+#define SEXP_CHECK_INVALID_FIREBALL				-161
 
 #define TRAINING_CONTEXT_SPEED		(1<<0)
 #define TRAINING_CONTEXT_FLY_PATH	(1<<1)

--- a/fred2/management.cpp
+++ b/fred2/management.cpp
@@ -417,6 +417,11 @@ bool fred_init(std::unique_ptr<os::GraphicsOperations>&& graphicsOps)
 	parse_init();
 	techroom_intel_init();
 
+	// get fireball IDs for sexpression usage
+	// (we don't need to init the entire system via fireball_init, we just need the information)
+	extern void fireball_parse_tbl();
+	fireball_parse_tbl();
+
 	// initialize and activate external string hash table
 	// make sure to do here so that we don't parse the table files into the hash table - waste of space
 	fhash_init();

--- a/fred2/management.cpp
+++ b/fred2/management.cpp
@@ -419,7 +419,6 @@ bool fred_init(std::unique_ptr<os::GraphicsOperations>&& graphicsOps)
 
 	// get fireball IDs for sexpression usage
 	// (we don't need to init the entire system via fireball_init, we just need the information)
-	extern void fireball_parse_tbl();
 	fireball_parse_tbl();
 
 	// initialize and activate external string hash table

--- a/fred2/sexp_tree.cpp
+++ b/fred2/sexp_tree.cpp
@@ -717,7 +717,7 @@ void sexp_tree::right_clicked(int mode)
 						}
 
 						// Goober5000 - certain types accept both integers and a list of strings
-						if (op_type == OPF_GAME_SND || op_type == OPF_WEAPON_BANK_NUMBER)
+						if (op_type == OPF_GAME_SND || op_type == OPF_FIREBALL || op_type == OPF_WEAPON_BANK_NUMBER)
 						{
 							type = SEXPT_NUMBER | SEXPT_STRING;
 						}
@@ -1115,7 +1115,7 @@ void sexp_tree::right_clicked(int mode)
 				replace_type = OPR_FLEXIBLE_ARGUMENT;
 			}
 			// Goober5000
-			else if (type == OPF_GAME_SND || type == OPF_WEAPON_BANK_NUMBER) {
+			else if (type == OPF_GAME_SND || type == OPF_FIREBALL || type == OPF_WEAPON_BANK_NUMBER) {
 				// enable number even though we are also going to default to string
 				menu.EnableMenuItem(ID_REPLACE_NUMBER, MF_ENABLED);
 			}
@@ -2431,13 +2431,14 @@ int sexp_tree::get_default_value(sexp_list_item *item, char *text_buf, int op, i
 
 		// Goober5000 - special cases that used to be numbers but are now hybrids
 		case OPF_GAME_SND:
+		{
 			gamesnd_id sound_index;
 
-			if ( (Operators[op].value == OP_EXPLOSION_EFFECT) )
+			if ((Operators[op].value == OP_EXPLOSION_EFFECT))
 			{
 				sound_index = GameSounds::SHIP_EXPLODE_1;
 			}
-			else if ( (Operators[op].value == OP_WARP_EFFECT) )
+			else if ((Operators[op].value == OP_WARP_EFFECT))
 			{
 				sound_index = (i == 8) ? GameSounds::CAPITAL_WARP_IN : GameSounds::CAPITAL_WARP_OUT;
 			}
@@ -2454,6 +2455,41 @@ int sexp_tree::get_default_value(sexp_list_item *item, char *text_buf, int op, i
 
 			// if no hardcoded default, just use the listing default
 			break;
+		}
+
+		// Goober5000 - ditto
+		case OPF_FIREBALL:
+		{
+			int fireball_index = -1;
+
+			if (Operators[op].value == OP_EXPLOSION_EFFECT)
+			{
+				fireball_index = FIREBALL_MEDIUM_EXPLOSION;
+			}
+			else if (Operators[op].value == OP_WARP_EFFECT)
+			{
+				fireball_index = FIREBALL_WARP;
+			}
+
+			if (fireball_index >= 0)
+			{
+				extern fireball_info Fireball_info[MAX_FIREBALL_TYPES];
+
+				char *unique_id = Fireball_info[fireball_index].unique_id;
+				if (strlen(unique_id) > 0)
+					item->set_data(unique_id, (SEXPT_STRING | SEXPT_VALID));
+				else
+				{
+					char num_str[NAME_LENGTH];
+					sprintf(num_str, "%d", fireball_index);
+					item->set_data(num_str, (SEXPT_NUMBER | SEXPT_VALID));
+				}
+				return 0;
+			}
+
+			// if no hardcoded default, just use the listing default
+			break;
+		}
 	}
 
 	list = get_listing_opf(type, index, i);
@@ -2698,6 +2734,7 @@ int sexp_tree::query_default_argument_available(int op, int i)
 		case OPF_NAV_POINT:
 		case OPF_TEAM_COLOR:
 		case OPF_GAME_SND:
+		case OPF_FIREBALL:
 			return 1;
 
 		case OPF_SHIP:
@@ -4458,6 +4495,10 @@ sexp_list_item *sexp_tree::get_listing_opf(int opf, int parent_node, int arg_ind
 			list = get_listing_opf_game_snds();
 			break;
 
+		case OPF_FIREBALL:
+			list = get_listing_opf_fireball();
+			break;
+
 		default:
 			Int3();  // unknown OPF code
 			list = NULL;
@@ -6035,6 +6076,22 @@ sexp_list_item *sexp_tree::get_listing_opf_game_snds()
 		if (!can_construe_as_integer(iter->name.c_str())) {
 			head.add_data(iter->name.c_str());
 		}
+	}
+
+	return head.next;
+}
+
+sexp_list_item *sexp_tree::get_listing_opf_fireball()
+{
+	extern fireball_info Fireball_info[MAX_FIREBALL_TYPES];
+	sexp_list_item head;
+
+	for (int i = 0; i < Num_fireball_types; ++i)
+	{
+		char *unique_id = Fireball_info[i].unique_id;
+
+		if (strlen(unique_id) > 0)
+			head.add_data(unique_id);
 	}
 
 	return head.next;

--- a/fred2/sexp_tree.cpp
+++ b/fred2/sexp_tree.cpp
@@ -2474,8 +2474,6 @@ int sexp_tree::get_default_value(sexp_list_item *item, char *text_buf, int op, i
 
 			if (fireball_index >= 0)
 			{
-				extern fireball_info Fireball_info[MAX_FIREBALL_TYPES];
-
 				char *unique_id = Fireball_info[fireball_index].unique_id;
 				if (strlen(unique_id) > 0)
 					item->set_data(unique_id, (SEXPT_STRING | SEXPT_VALID));
@@ -6084,7 +6082,6 @@ sexp_list_item *sexp_tree::get_listing_opf_game_snds()
 
 sexp_list_item *sexp_tree::get_listing_opf_fireball()
 {
-	extern fireball_info Fireball_info[MAX_FIREBALL_TYPES];
 	sexp_list_item head;
 
 	for (int i = 0; i < Num_fireball_types; ++i)

--- a/fred2/sexp_tree.cpp
+++ b/fred2/sexp_tree.cpp
@@ -1116,7 +1116,8 @@ void sexp_tree::right_clicked(int mode)
 			}
 			// Goober5000
 			else if (type == OPF_GAME_SND || type == OPF_FIREBALL || type == OPF_WEAPON_BANK_NUMBER) {
-				// enable number even though we are also going to default to string
+				// even though these default to strings, we allow replacing them with index values
+				replace_type = OPR_POSITIVE;
 				menu.EnableMenuItem(ID_REPLACE_NUMBER, MF_ENABLED);
 			}
 

--- a/fred2/sexp_tree.h
+++ b/fred2/sexp_tree.h
@@ -277,6 +277,7 @@ public:
 	sexp_list_item *get_listing_opf_team_colors();
 	sexp_list_item *get_listing_opf_nebula_patterns();
 	sexp_list_item *get_listing_opf_game_snds();
+	sexp_list_item *get_listing_opf_fireball();
 
 	int m_mode;
 	int item_index;

--- a/qtfred/src/main.cpp
+++ b/qtfred/src/main.cpp
@@ -160,7 +160,8 @@ int main(int argc, char* argv[]) {
 								 { SubSystem::NebulaLightning,   app.tr("Initializing nebula lightning") },
 								 { SubSystem::FFmpeg,            app.tr("Initializing FFmpeg") },
 								 { SubSystem::DynamicSEXPs,      app.tr("Initializing dynamic SEXP system") },
-								 { SubSystem::ScriptingInitHook, app.tr("Running game init scripting hook") }, };
+								 { SubSystem::ScriptingInitHook, app.tr("Running game init scripting hook") },
+	};
 
 	auto initSuccess = fso::fred::initialize(baseDir.toStdString(), argc, argv, fred.get(), [&](const SubSystem& which) {
 		if (initializers.count(which)) {

--- a/qtfred/src/mission/management.cpp
+++ b/qtfred/src/mission/management.cpp
@@ -201,6 +201,10 @@ initialize(const std::string& cfilepath, int argc, char* argv[], Editor* editor,
 	listener(SubSystem::TechroomIntel);
 	techroom_intel_init();
 
+	// get fireball IDs for sexpression usage
+	// (we don't need to init the entire system via fireball_init, we just need the information)
+	fireball_parse_tbl();
+
 	// initialize and activate external string hash table
 	// make sure to do here so that we don't parse the table files into the hash table - waste of space
 	fhash_init();

--- a/qtfred/src/ui/widgets/sexp_tree.cpp
+++ b/qtfred/src/ui/widgets/sexp_tree.cpp
@@ -1175,8 +1175,6 @@ int sexp_tree::get_default_value(sexp_list_item* item, char* text_buf, int op, i
 
 			if (fireball_index >= 0)
 			{
-				extern fireball_info Fireball_info[MAX_FIREBALL_TYPES];
-
 				char *unique_id = Fireball_info[fireball_index].unique_id;
 				if (strlen(unique_id) > 0)
 					item->set_data(unique_id, (SEXPT_STRING | SEXPT_VALID));
@@ -4523,7 +4521,6 @@ sexp_list_item* sexp_tree::get_listing_opf_game_snds() {
 
 sexp_list_item *sexp_tree::get_listing_opf_fireball()
 {
-	extern fireball_info Fireball_info[MAX_FIREBALL_TYPES];
 	sexp_list_item head;
 
 	for (int i = 0; i < Num_fireball_types; ++i)

--- a/qtfred/src/ui/widgets/sexp_tree.cpp
+++ b/qtfred/src/ui/widgets/sexp_tree.cpp
@@ -5269,7 +5269,8 @@ std::unique_ptr<QMenu> sexp_tree::buildContextMenu(QTreeWidgetItem* h) {
 		}
 			// Goober5000
 		else if (type == OPF_GAME_SND || type == OPF_FIREBALL || type == OPF_WEAPON_BANK_NUMBER) {
-			// enable number even though we are also going to default to string
+			// even though these default to strings, we allow replacing them with index values
+			replace_type = OPR_POSITIVE;
 			replace_number_act->setEnabled(true);
 		}
 

--- a/qtfred/src/ui/widgets/sexp_tree.h
+++ b/qtfred/src/ui/widgets/sexp_tree.h
@@ -325,6 +325,7 @@ class sexp_tree: public QTreeWidget {
 	sexp_list_item* get_listing_opf_team_colors();
 	sexp_list_item* get_listing_opf_nebula_patterns();
 	sexp_list_item* get_listing_opf_game_snds();
+	sexp_list_item* get_listing_opf_fireball();
 
 
 	int getCurrentItemIndex() const;


### PR DESCRIPTION
This is a minor overhaul of fireball.tbl, with improvements in both sexps and modular tables.

Modular tables now work as one would expect -- the default fireball.tbl defines values and -fbl.tbm can override them or add new ones.  Previously new fireballs could not be added, and the old way of reconciling the modular table was hard to understand and even harder to adapt for new options.

Each fireball entry can now have a unique ID, which is generated if not specified by the table.  This can be used by the `explosion-effect` and `warp-effect` SEXPs to specify the fireball, rather than the old way of specifying the index.  (The old way still works.)  The unique ID is also another way of overriding a tbl entry via tbm.

This PR also, incidentally, fixes a couple of minor UI problems when referencing tbl indexes for `OPF_GAME_SND` and `OPF_WEAPON_BANK_NUMBER`, since the new `OPF_FIREBALL` needs the same functionality.