### PR TITLE
Custom warp glows, balls, and models

### DIFF
--- a/code/fireball/fireballs.cpp
+++ b/code/fireball/fireballs.cpp
@@ -416,7 +416,7 @@ void fireball_load_data()
 
 		if (strlen(fd->warp_model) > 0 && cf_exists_full(fd->warp_model, CF_TYPE_MODELS)) {
 			mprintf(("Loading warp model '%s'\n", fd->warp_model));
-			fd->warp_model_id = model_load(fd->warp_model, 0, NULL, 0);
+			fd->warp_model_id = model_load(fd->warp_model, 0, nullptr, 0);
 		} else {
 			fd->warp_model_id = -1;
 		}

--- a/code/fireball/fireballs.cpp
+++ b/code/fireball/fireballs.cpp
@@ -183,7 +183,7 @@ static void fireball_set_default_color(int idx)
 	}
 }
 
-static void fireball_set_default_warp_stuff(int idx)
+static void fireball_set_default_warp_attributes(int idx)
 {
 	Assert((idx >= 0) && (idx < MAX_FIREBALL_TYPES));
 
@@ -206,8 +206,8 @@ void fireball_info_clear(fireball_info *fb)
 	for (int i = 0; i < MAX_FIREBALL_LOD; ++i)
 		fb->lod[i].bitmap_id = -1;
 
-	fb->warp_ball_bitmap = -1;
 	fb->warp_glow_bitmap = -1;
+	fb->warp_ball_bitmap = -1;
 	fb->warp_model_id = -1;
 }
 
@@ -303,6 +303,7 @@ static void parse_fireball_tbl(const char *table_filename)
 
 				// Set remaining fireball defaults
 				fireball_set_default_color(Num_fireball_types);
+				fireball_set_default_warp_attributes(Num_fireball_types);
 
 				Num_fireball_types++;
 			}
@@ -1066,7 +1067,7 @@ void fireball_render(object* obj, model_draw_list *scene)
 			float rad = obj->radius * fireball_wormhole_intensity(fb);
 
 			fireball_info *fi = &Fireball_info[fb->fireball_info_index];
-			warpin_queue_render(scene, obj, &obj->orient, &obj->pos, fb->current_bitmap, rad, percent_life, obj->radius, (fb->flags & FBF_WARP_3D), fi->warp_glow_bitmap, fi->warp_ball_bitmap, fi->warp_model_id);
+			warpin_queue_render(scene, obj, &obj->orient, &obj->pos, fb->current_bitmap, rad, percent_life, obj->radius, (fb->flags & FBF_WARP_3D) != 0, fi->warp_glow_bitmap, fi->warp_ball_bitmap, fi->warp_model_id);
 		}
 		break;
 

--- a/code/fireball/fireballs.cpp
+++ b/code/fireball/fireballs.cpp
@@ -232,7 +232,7 @@ static void parse_fireball_tbl(const char *table_filename)
 
 		required_string("#Start");
 
-		while (required_string_either("#End", "$Name:"))
+		while (required_string_one_of(3, "#End", "$Name:", "$Unique ID:"))
 		{
 			fireball_info *fi;
 			int existing_idx = -1;
@@ -935,9 +935,9 @@ void fireballs_page_in()
 	fireball_info	*fd;
 
 	for ( i = 0; i < Num_fireball_types; i++ ) {
-		if((i < NUM_DEFAULT_FIREBALLS) || fireball_used[i]){
-			fd = &Fireball_info[i];
+		fd = &Fireball_info[i];
 
+		if((i < NUM_DEFAULT_FIREBALLS) || fireball_used[i]) {
 			// if this is a Knossos ani, only load if Knossos_warp_ani_used is true
 			if ( (i == FIREBALL_KNOSSOS) && !Knossos_warp_ani_used)
 				continue;

--- a/code/fireball/fireballs.h
+++ b/code/fireball/fireballs.h
@@ -55,6 +55,13 @@ typedef struct fireball_info {
 	int					lod_count;
 	fireball_lod		lod[MAX_FIREBALL_LOD];
 	float				exp_color[3];	// red, green, blue
+
+	char	warp_glow[NAME_LENGTH];
+	int		warp_glow_bitmap;
+	char	warp_ball[NAME_LENGTH];
+	int		warp_ball_bitmap;
+	char	warp_model[NAME_LENGTH];
+	int		warp_model_id;
 } fireball_info;
 
 extern fireball_info Fireball_info[MAX_FIREBALL_TYPES];
@@ -126,13 +133,6 @@ int fireball_asteroid_explosion_type(asteroid_info *aip);
 
 // returns the intensity of a wormhole
 float fireball_wormhole_intensity( fireball *fb );
-
-// internal function to draw warp grid.
-extern void warpin_render(object *obj, matrix *orient, vec3d *pos, int texture_bitmap_num, float radius, float life_percent, float max_radius, int warp_3d = 0 );
-
-extern void warpin_queue_render(model_draw_list *scene, object *obj, matrix *orient, vec3d *pos, int texture_bitmap_num, float radius, float life_percent, float max_radius, int warp_3d);
-
-extern int Warp_model;
 
 // Goober5000
 extern int Knossos_warp_ani_used;

--- a/code/fireball/warpineffect.cpp
+++ b/code/fireball/warpineffect.cpp
@@ -21,10 +21,6 @@
 #include "render/batching.h"
 #include "ship/ship.h"
 
-extern int Warp_model;
-extern int Warp_glow_bitmap;
-extern int Warp_ball_bitmap;
-
 void warpin_batch_draw_face( int texture, vertex *v1, vertex *v2, vertex *v3 )
 {
 	vec3d norm;
@@ -45,7 +41,7 @@ void warpin_batch_draw_face( int texture, vertex *v1, vertex *v2, vertex *v3 )
 	batching_add_tri(texture, vertlist); // TODO render as emissive
 }
 
-void warpin_queue_render(model_draw_list *scene, object *obj, matrix *orient, vec3d *pos, int texture_bitmap_num, float radius, float life_percent, float max_radius, int warp_3d)
+void warpin_queue_render(model_draw_list *scene, object *obj, matrix *orient, vec3d *pos, int texture_bitmap_num, float radius, float life_percent, float max_radius, bool warp_3d, int warp_glow_bitmap, int warp_ball_bitmap, int warp_model_id)
 {
 	vec3d center;
 	vec3d vecs[5];
@@ -60,7 +56,7 @@ void warpin_queue_render(model_draw_list *scene, object *obj, matrix *orient, ve
 
 	verts[1] = verts[2] = verts[3] = verts[4] = verts[0];
 
-	if (Warp_glow_bitmap >= 0) {
+	if (warp_glow_bitmap >= 0) {
 		float r = radius;
 		bool render_it = true;
 
@@ -99,12 +95,12 @@ void warpin_queue_render(model_draw_list *scene, object *obj, matrix *orient, ve
 
 			float alpha = (The_mission.flags[Mission::Mission_Flags::Fullneb]) ? (1.0f - neb2_get_fog_intensity(obj)) : 1.0f;
 
-			//batch_add_bitmap(Warp_glow_bitmap, TMAP_FLAG_TEXTURED | TMAP_HTL_3D_UNLIT, &verts[4], 0, r, alpha);
-			batching_add_bitmap(Warp_glow_bitmap, &verts[4], 0, r, alpha);
+			//batch_add_bitmap(warp_glow_bitmap, TMAP_FLAG_TEXTURED | TMAP_HTL_3D_UNLIT, &verts[4], 0, r, alpha);
+			batching_add_bitmap(warp_glow_bitmap, &verts[4], 0, r, alpha);
 		}
 	}
 
-	if ( (Warp_model >= 0) && (warp_3d || Cmdline_3dwarp) ) {
+	if ( (warp_model_id >= 0) && (warp_3d || Cmdline_3dwarp) ) {
 		model_render_params render_info;
 
 		float scale = radius / 25.0f;
@@ -119,7 +115,7 @@ void warpin_queue_render(model_draw_list *scene, object *obj, matrix *orient, ve
 		render_info.set_detail_level_lock((int)(dist / (radius * 10.0f)));
 		render_info.set_flags(MR_NO_LIGHTING | MR_NORMAL | MR_NO_FOGGING | MR_NO_CULL | MR_NO_BATCH);
 
-		model_render_queue( &render_info, scene, Warp_model, orient, pos);
+		model_render_queue( &render_info, scene, warp_model_id, orient, pos);
 	} else {
 		float Grid_depth = radius/2.5f;
 
@@ -171,14 +167,14 @@ void warpin_queue_render(model_draw_list *scene, object *obj, matrix *orient, ve
 		warpin_batch_draw_face( texture_bitmap_num, &verts[0], &verts[3], &verts[4] );
 	}
 
-	if (Warp_ball_bitmap > -1 && Cmdline_warp_flash == 1) {
+	if (warp_ball_bitmap >= 0 && Cmdline_warp_flash) {
 		flash_ball warp_ball(20, .1f,.25f, &orient->vec.fvec, pos, 4.0f, 0.5f);
 
 		float adg = (2.0f * life_percent) - 1.0f;
 		float pct = (powf(adg, 4.0f) - powf(adg, 128.0f)) * 4.0f;
 
 		if (pct > 0.00001f) {
-			warp_ball.render(Warp_ball_bitmap, max_radius * pct * 0.5f, adg * adg, adg * adg * 6.0f);
+			warp_ball.render(warp_ball_bitmap, max_radius * pct * 0.5f, adg * adg, adg * adg * 6.0f);
 		}
 	}
 }


### PR DESCRIPTION
This allows different fireball.tbl entries to have different auxiliary warp effects.  There is actually a warpglow02 bitmap specified in the retail VPs, so the Knossos entry can now be edited to use that bitmap if desired.  (This is not done in the new code for compatibility reasons; the MVPs currently do not specify a replacement warpglow02.)  In the same way, the Knossos entry (or any new entries) can have different "warp balls" and warp models.

This also fixes a small bug in #1865, where `$Unique ID:` was inadvertently not allowed because it is parsed before `$Name:`.  