### PR TITLE
fix issue #1869

### DIFF
--- a/code/fireball/fireballs.cpp
+++ b/code/fireball/fireballs.cpp
@@ -413,13 +413,6 @@ void fireball_load_data()
 		} else {
 			fd->warp_ball_bitmap = -1;
 		}
-
-		if (strlen(fd->warp_model) > 0 && cf_exists_full(fd->warp_model, CF_TYPE_MODELS)) {
-			mprintf(("Loading warp model '%s'\n", fd->warp_model));
-			fd->warp_model_id = model_load(fd->warp_model, 0, nullptr, 0);
-		} else {
-			fd->warp_model_id = -1;
-		}
 	}
 }
 
@@ -954,6 +947,14 @@ void fireballs_page_in()
 		// page in glow and ball bitmaps, if we have any
 		bm_page_in_texture(fd->warp_glow_bitmap);
 		bm_page_in_texture(fd->warp_ball_bitmap);
+
+		// load the warp model, if we have one
+		if (strlen(fd->warp_model) > 0 && cf_exists_full(fd->warp_model, CF_TYPE_MODELS)) {
+			mprintf(("Loading warp model '%s'\n", fd->warp_model));
+			fd->warp_model_id = model_load(fd->warp_model, 0, nullptr, 0);
+		} else {
+			fd->warp_model_id = -1;
+		}
 	}
 }
 


### PR DESCRIPTION
Previously, `Warp_model` was loaded each time a level was loaded.  The fireball.tbl rewrite changed this to loading once per game session, but this PR changes it back.

This should fix #1869.