### PR TITLE
Add proper class support to Lua API

### DIFF
--- a/code/scripting/ade.h
+++ b/code/scripting/ade.h
@@ -70,8 +70,7 @@ struct ade_odata_setter {
 	size_t idx;
 	T value;
 
-	ade_odata_setter(size_t idx_in, T&& value_in) : idx(idx_in), value(std::move(value_in)) {}
-	ade_odata_setter(size_t idx_in, const T& value_in) : idx(idx_in), value(value_in) {}
+	ade_odata_setter(size_t idx_in, T value_in) : idx(idx_in), value(std::move(value_in)) {}
 };
 
 //WMC - 'Type' is the same as ade_set_args,

--- a/code/scripting/ade.h
+++ b/code/scripting/ade.h
@@ -41,12 +41,8 @@ void ade_stackdump(lua_State* L, char* stackdump);
 int ade_friendly_error(lua_State* L);
 
 //*************************Lua types*************************
-
-//WMC - Define to say that this is to store just a pointer.
-typedef uint32_t ODATA_SIG_TYPE; //WMC - Please don't touch.
+// Value fo ade_odata::size for when buf contains a pointer
 const size_t ODATA_PTR_SIZE = (size_t) -1;
-const ODATA_SIG_TYPE ODATA_SIG_DEFAULT = 0;
-
 
 const int ADE_FUNCNAME_UPVALUE_INDEX = 1;
 const int ADE_SETTING_UPVALUE_INDEX = 2;
@@ -61,7 +57,6 @@ const int ADE_SETTING_UPVALUE_INDEX = 2;
 struct ade_odata {
 	//ade_id aid;
 	size_t idx;
-	ODATA_SIG_TYPE* sig;
 	void* buf;
 	size_t size;
 	//ade_odata(){idx=UINT_MAX;sig=NULL;buf=NULL;size=0;}
@@ -109,20 +104,10 @@ class ade_table_entry {
 	//Type-specific
 	bool Instanced;                //Is this a single instance?
 	char Type;
-	union {
-		//Variables
-		bool varBool;
-		double varDouble;
-		float varFloat;
-		int varInt;
-		char* varString;
 
-		//Functions/virtfuncs
-		lua_CFunction Function;
+	//Functions/virtfuncs
+	lua_CFunction Function;
 
-		//Objects
-		ade_odata Object;
-	} Value;
 	size_t Size;
 
 	//Metadata
@@ -217,28 +202,23 @@ class ade_obj: public ade_lib_handle {
 		}
 		ate.Type = 'o';
 		ate.Description = in_desc;
-		ate.Value.Object.idx = ade_manager::getInstance()->getNumEntries();
-		ate.Value.Object.sig = NULL;
-		ate.Value.Object.size = sizeof(StoreType);
 
 		LibIdx = ade_manager::getInstance()->addTableEntry(ate);
 	}
 
 	//WMC - Use this to store object data for return, or for setting as a global
-	ade_odata Set(const StoreType& obj, ODATA_SIG_TYPE n_sig = ODATA_SIG_DEFAULT) const {
+	ade_odata Set(const StoreType& obj) const {
 		ade_odata od;
 		od.idx = LibIdx;
-		od.sig = &n_sig;
 		od.buf = (void*) &obj;
 		od.size = sizeof(StoreType);
 		return od;
 	}
 
 	//WMC - Use this to copy object data, for modification or whatever
-	ade_odata Get(StoreType* ptr, uint* n_sig = NULL) const {
+	ade_odata Get(StoreType* ptr) const {
 		ade_odata od;
 		od.idx = LibIdx;
-		od.sig = n_sig;
 		od.buf = ptr;
 		od.size = sizeof(StoreType);
 		return od;
@@ -251,7 +231,6 @@ class ade_obj: public ade_lib_handle {
 	ade_odata GetPtr(StoreType** ptr) const {
 		ade_odata od;
 		od.idx = LibIdx;
-		od.sig = NULL;
 		od.buf = (void**) ptr;
 		od.size = ODATA_PTR_SIZE;
 		return od;

--- a/code/scripting/ade_api.h
+++ b/code/scripting/ade_api.h
@@ -75,8 +75,10 @@ class ade_obj : public ade_lib_handle {
 	{
 		return ade_odata_setter<StoreType>(LibIdx, std::move(obj));
 	}
-
-	ade_odata_setter<StoreType> Set(const StoreType& obj) const { return ade_odata_setter<StoreType>(LibIdx, obj); }
+	ade_odata_setter<StoreType> Set(const StoreType& obj) const
+	{
+		return ade_odata_setter<StoreType>(LibIdx, obj);
+	}
 
 	// WMC - Use this to copy object data, for modification or whatever
 	ade_odata_getter<StoreType> Get(StoreType* ptr) const { return ade_odata_getter<StoreType>(LibIdx, ptr); }

--- a/code/scripting/ade_api.h
+++ b/code/scripting/ade_api.h
@@ -19,7 +19,7 @@ class ade_lib_handle {
 	size_t LibIdx;
 
   public:
-	ade_lib_handle() {}
+	ade_lib_handle() = default;
 
 	size_t GetIdx() const { return LibIdx; }
 };
@@ -31,8 +31,8 @@ template <class StoreType>
 class ade_obj : public ade_lib_handle {
 	static int lua_destructor(lua_State* L)
 	{
-		ade_obj<StoreType>* obj = reinterpret_cast<ade_obj<StoreType>*>(
-		    lua_touserdata(L, lua_upvalueindex(ADE_DESTRUCTOR_OBJ_UPVALUE_INDEX)));
+		auto* obj =
+		    static_cast<ade_obj<StoreType>*>(lua_touserdata(L, lua_upvalueindex(ADE_DESTRUCTOR_OBJ_UPVALUE_INDEX)));
 		StoreType* value = nullptr;
 		if (!ade_get_args(L, "o", obj->GetPtr(&value))) {
 			return 0;
@@ -47,13 +47,13 @@ class ade_obj : public ade_lib_handle {
 	}
 
   public:
-	ade_obj(const char* in_name, const char* in_desc, const ade_lib_handle* in_deriv = NULL)
+	ade_obj(const char* in_name, const char* in_desc, const ade_lib_handle* in_deriv = nullptr)
 	{
 		ade_table_entry ate;
 
 		// WMC - object metadata are uninstanced library types
 		ate.Name = in_name;
-		if (in_deriv != NULL) {
+		if (in_deriv != nullptr) {
 			ate.DerivatorIdx = in_deriv->GetIdx();
 		}
 		ate.Type        = 'o';
@@ -156,8 +156,8 @@ class ade_obj : public ade_lib_handle {
  */
 class ade_lib : public ade_lib_handle {
   public:
-	explicit ade_lib(const char* in_name, const ade_lib_handle* parent = NULL, const char* in_shortname = NULL,
-	                 const char* in_desc = NULL);
+	explicit ade_lib(const char* in_name, const ade_lib_handle* parent = nullptr, const char* in_shortname = nullptr,
+	                 const char* in_desc = nullptr);
 
 	const char* GetName() const;
 };
@@ -225,8 +225,8 @@ class ade_lib : public ade_lib_handle {
  */
 class ade_func : public ade_lib_handle {
   public:
-	ade_func(const char* name, lua_CFunction func, const ade_lib_handle& parent, const char* args = NULL,
-	         const char* desc = NULL, const char* ret_type = NULL, const char* ret_desc = NULL);
+	ade_func(const char* name, lua_CFunction func, const ade_lib_handle& parent, const char* args = nullptr,
+	         const char* desc = nullptr, const char* ret_type = nullptr, const char* ret_desc = nullptr);
 };
 
 /**
@@ -253,8 +253,8 @@ class ade_func : public ade_lib_handle {
  */
 class ade_virtvar : public ade_lib_handle {
   public:
-	ade_virtvar(const char* name, lua_CFunction func, const ade_lib_handle& parent, const char* args = NULL,
-	            const char* desc = NULL, const char* ret_type = NULL, const char* ret_desc = NULL);
+	ade_virtvar(const char* name, lua_CFunction func, const ade_lib_handle& parent, const char* args = nullptr,
+	            const char* desc = nullptr, const char* ret_type = nullptr, const char* ret_desc = nullptr);
 };
 
 /**
@@ -282,8 +282,8 @@ class ade_virtvar : public ade_lib_handle {
  */
 class ade_indexer : public ade_lib_handle {
   public:
-	ade_indexer(lua_CFunction func, const ade_lib_handle& parent, const char* args = NULL, const char* desc = NULL,
-	            const char* ret_type = NULL, const char* ret_desc = NULL);
+	ade_indexer(lua_CFunction func, const ade_lib_handle& parent, const char* args = nullptr,
+	            const char* desc = nullptr, const char* ret_type = nullptr, const char* ret_desc = nullptr);
 };
 
 /**

--- a/code/scripting/ade_api.h
+++ b/code/scripting/ade_api.h
@@ -12,72 +12,96 @@ namespace scripting {
 const size_t INVALID_ID = (size_t) -1; // Use -1 to get highest possible unsigned number
 
 /**
- * @brief Declare an API function
- *
- * Immediately after this macro the function body should follow.
- *
- * @param name The name of the function, this may not be a string
- * @param parent The library or object containing this function
- * @param args Documentation for parameters of the function
- * @param desc Description of what the function does
- * @param ret_type The type of the returned value
- * @param ret_desc Documentation for the returned value
- *
  * @ingroup ade_api
  */
-#define ADE_FUNC(name, parent, args, desc, ret_type, ret_desc)	\
-	static int parent##_##name##_f(lua_State *L);	\
-	::scripting::ade_func parent##_##name(#name, parent##_##name##_f, parent, args, desc, ret_type, ret_desc);	\
-	static int parent##_##name##_f(lua_State *L)
+class ade_lib_handle {
+  protected:
+	size_t LibIdx;
+
+  public:
+	ade_lib_handle() {}
+
+	size_t GetIdx() const { return LibIdx; }
+};
 
 /**
- * @brief Declare an API variable
- *
- * Use this to handle forms of type vec.x and vec['x']. Basically an indexer for a specific variable. Format string
- * should be "o*%", where * is indexing value, and % is the value to set to when LUA_SETTTING_VAR is set
- *
- * @param name The name of the variable, this may not be a string
- * @param parent The library or object containing this field
- * @param args Documentation for the type of the value that may be assigned
- * @param desc Description of what the variable does
- * @param ret_type The type of the returned value
- * @param ret_desc Documentation for the returned value
- *
  * @ingroup ade_api
  */
-#define ADE_VIRTVAR(name, parent, args, desc, ret_type, ret_desc)			\
-	static int parent##_##name##_f(lua_State *L);	\
-	::scripting::ade_virtvar parent##_##name(#name, parent##_##name##_f, parent, args, desc, ret_type, ret_desc);	\
-	static int parent##_##name##_f(lua_State *L)
+template <class StoreType>
+class ade_obj : public ade_lib_handle {
+	static int lua_destructor(lua_State* L)
+	{
+		ade_obj<StoreType>* obj = reinterpret_cast<ade_obj<StoreType>*>(
+		    lua_touserdata(L, lua_upvalueindex(ADE_DESTRUCTOR_OBJ_UPVALUE_INDEX)));
+		StoreType* value = nullptr;
+		if (!ade_get_args(L, "o", obj->GetPtr(&value))) {
+			return 0;
+		}
 
-/**
- * @brief Declare an indexer of an object
- *
- * Use this with objects to deal with forms such as vec.x, vec['x'], vec[0]. Format string should be "o*%", where * is
- * indexing value, and % is the value to set to when LUA_SETTTING_VAR is set
- *
- * @param parent The library or object containing the indexer
- * @param args Documentation for the type of the value that may be assigned
- * @param desc Description of what the variable does
- * @param ret_type The type of the returned value
- * @param ret_desc Documentation for the returned value
- *
- * @ingroup ade_api
- */
-#define ADE_INDEXER(parent, args, desc, ret_type, ret_desc)			\
-	static int parent##___indexer_f(lua_State *L);		\
-	::scripting::ade_indexer parent##___indexer(parent##___indexer_f, parent, args, desc, ret_type, ret_desc);	\
-	static int parent##___indexer_f(lua_State *L)
+		if (value == nullptr) {
+			return 0;
+		}
+
+		value->~StoreType();
+		return 0;
+	}
+
+  public:
+	ade_obj(const char* in_name, const char* in_desc, const ade_lib_handle* in_deriv = NULL)
+	{
+		ade_table_entry ate;
+
+		// WMC - object metadata are uninstanced library types
+		ate.Name = in_name;
+		if (in_deriv != NULL) {
+			ate.DerivatorIdx = in_deriv->GetIdx();
+		}
+		ate.Type        = 'o';
+		ate.Description = in_desc;
+
+		if (!std::is_trivially_destructible<StoreType>::value) {
+			// If this type is not trivial then we need to have a destructor
+			// This is mildly dangerous since "this" will only remain valid if it was constructed statically. Since this
+			// value is only used once at program startup it should be relatively safe
+			ate.Destructor_upvalue = static_cast<void*>(this);
+			ate.Destructor         = lua_destructor;
+		}
+
+		LibIdx = ade_manager::getInstance()->addTableEntry(ate);
+	}
+
+	// WMC - Use this to store object data for return, or for setting as a global
+	ade_odata_setter<StoreType> Set(StoreType&& obj) const
+	{
+		return ade_odata_setter<StoreType>(LibIdx, std::move(obj));
+	}
+
+	ade_odata_setter<StoreType> Set(const StoreType& obj) const { return ade_odata_setter<StoreType>(LibIdx, obj); }
+
+	// WMC - Use this to copy object data, for modification or whatever
+	ade_odata_getter<StoreType> Get(StoreType* ptr) const { return ade_odata_getter<StoreType>(LibIdx, ptr); }
+
+	// WMC - Use this to get a pointer to Lua object data.
+	// Use >ONLY< when:
+	// 1 - You are setting the data of an object (ie 'x' component of vector)
+	// 2 - To speed up read-only calcs (ie computing dot product of vectors)
+	// 3 - To get a reference to a move-only type stored in Lua memory
+	ade_odata_ptr_getter<StoreType> GetPtr(StoreType** ptr) const
+	{
+		return ade_odata_ptr_getter<StoreType>(LibIdx, ptr);
+	}
+};
 
 /**
  * @warning Utility macro. DO NOT USE!
  */
-#define ADE_OBJ_DERIV_IMPL(field, type, name, desc, deriv) \
-const ::scripting::ade_obj<type>& SCP_TOKEN_CONCAT(get_, field)() { \
-	static ::scripting::ade_obj<type> obj(name, desc, deriv);\
-	return obj;\
-} \
-const ::scripting::ade_obj<type>& field = SCP_TOKEN_CONCAT(get_, field)()
+#define ADE_OBJ_DERIV_IMPL(field, type, name, desc, deriv)                                                             \
+	const ::scripting::ade_obj<type>& SCP_TOKEN_CONCAT(get_, field)()                                                  \
+	{                                                                                                                  \
+		static ::scripting::ade_obj<type> obj(name, desc, deriv);                                                      \
+		return obj;                                                                                                    \
+	}                                                                                                                  \
+	const ::scripting::ade_obj<type>& field = SCP_TOKEN_CONCAT(get_, field)()
 
 /**
  * @brief Define an API object
@@ -107,7 +131,8 @@ const ::scripting::ade_obj<type>& field = SCP_TOKEN_CONCAT(get_, field)()
  *
  * @ingroup ade_api
  */
-#define ADE_OBJ_DERIV(field, type, name, desc, deriv) ADE_OBJ_DERIV_IMPL(field, type, name, desc, &SCP_TOKEN_CONCAT(get_, deriv)())
+#define ADE_OBJ_DERIV(field, type, name, desc, deriv)                                                                  \
+	ADE_OBJ_DERIV_IMPL(field, type, name, desc, &SCP_TOKEN_CONCAT(get_, deriv)())
 
 /**
  * @brief Declare an API object but don't define it
@@ -119,19 +144,33 @@ const ::scripting::ade_obj<type>& field = SCP_TOKEN_CONCAT(get_, field)()
  *
  * @ingroup ade_api
  */
-#define DECLARE_ADE_OBJ(field, type) \
-extern const ::scripting::ade_obj<type>& SCP_TOKEN_CONCAT(get_, field)(); \
-extern const ::scripting::ade_obj<type>& field
+#define DECLARE_ADE_OBJ(field, type)                                                                                   \
+	extern const ::scripting::ade_obj<type>& SCP_TOKEN_CONCAT(get_, field)();                                          \
+	extern const ::scripting::ade_obj<type>& field
 
+/**
+ * Library class
+ * This is what you define a variable of to make new libraries
+ *
+ * @ingroup ade_api
+ */
+class ade_lib : public ade_lib_handle {
+  public:
+	explicit ade_lib(const char* in_name, const ade_lib_handle* parent = NULL, const char* in_shortname = NULL,
+	                 const char* in_desc = NULL);
+
+	const char* GetName() const;
+};
 /**
  * @warning Utility macro. DO NOT USE!
  */
-#define ADE_LIB_IMPL(field, name, short_name, desc, parent) \
-const ::scripting::ade_lib& SCP_TOKEN_CONCAT(get_, field)() { \
-	static ::scripting::ade_lib lib(name, parent, short_name, desc);\
-	return lib;\
-} \
-const ::scripting::ade_lib& field = SCP_TOKEN_CONCAT(get_, field)()
+#define ADE_LIB_IMPL(field, name, short_name, desc, parent)                                                            \
+	const ::scripting::ade_lib& SCP_TOKEN_CONCAT(get_, field)()                                                        \
+	{                                                                                                                  \
+		static ::scripting::ade_lib lib(name, parent, short_name, desc);                                               \
+		return lib;                                                                                                    \
+	}                                                                                                                  \
+	const ::scripting::ade_lib& field = SCP_TOKEN_CONCAT(get_, field)()
 
 /**
  * @brief Define an API library
@@ -164,7 +203,7 @@ const ::scripting::ade_lib& field = SCP_TOKEN_CONCAT(get_, field)()
  *
  * @ingroup ade_api
  */
-#define ADE_LIB_DERIV(field, name, short_name, desc, parent) \
+#define ADE_LIB_DERIV(field, name, short_name, desc, parent)                                                           \
 	ADE_LIB_IMPL(field, name, short_name, desc, &SCP_TOKEN_CONCAT(get_, parent)())
 
 /**
@@ -176,11 +215,95 @@ const ::scripting::ade_lib& field = SCP_TOKEN_CONCAT(get_, field)()
  *
  * @ingroup ade_api
  */
-#define DECLARE_ADE_LIB(field) \
-extern const ::scripting::ade_lib& SCP_TOKEN_CONCAT(get_, field)(); \
-extern const ::scripting::ade_lib& field; \
-static const ::scripting::ade_lib* SCP_TOKEN_CONCAT(field, reference_dummy) USED_VARIABLE = &(field)
+#define DECLARE_ADE_LIB(field)                                                                                         \
+	extern const ::scripting::ade_lib& SCP_TOKEN_CONCAT(get_, field)();                                                \
+	extern const ::scripting::ade_lib& field;                                                                          \
+	static const ::scripting::ade_lib* SCP_TOKEN_CONCAT(field, reference_dummy) USED_VARIABLE = &(field)
 
+/**
+ * @ingroup ade_api
+ */
+class ade_func : public ade_lib_handle {
+  public:
+	ade_func(const char* name, lua_CFunction func, const ade_lib_handle& parent, const char* args = NULL,
+	         const char* desc = NULL, const char* ret_type = NULL, const char* ret_desc = NULL);
+};
+
+/**
+ * @brief Declare an API function
+ *
+ * Immediately after this macro the function body should follow.
+ *
+ * @param name The name of the function, this may not be a string
+ * @param parent The library or object containing this function
+ * @param args Documentation for parameters of the function
+ * @param desc Description of what the function does
+ * @param ret_type The type of the returned value
+ * @param ret_desc Documentation for the returned value
+ *
+ * @ingroup ade_api
+ */
+#define ADE_FUNC(name, parent, args, desc, ret_type, ret_desc)                                                         \
+	static int parent##_##name##_f(lua_State* L);                                                                      \
+	::scripting::ade_func parent##_##name(#name, parent##_##name##_f, parent, args, desc, ret_type, ret_desc);         \
+	static int parent##_##name##_f(lua_State* L)
+
+/**
+ * @ingroup ade_api
+ */
+class ade_virtvar : public ade_lib_handle {
+  public:
+	ade_virtvar(const char* name, lua_CFunction func, const ade_lib_handle& parent, const char* args = NULL,
+	            const char* desc = NULL, const char* ret_type = NULL, const char* ret_desc = NULL);
+};
+
+/**
+ * @brief Declare an API variable
+ *
+ * Use this to handle forms of type vec.x and vec['x']. Basically an indexer for a specific variable. Format string
+ * should be "o*%", where * is indexing value, and % is the value to set to when LUA_SETTTING_VAR is set
+ *
+ * @param name The name of the variable, this may not be a string
+ * @param parent The library or object containing this field
+ * @param args Documentation for the type of the value that may be assigned
+ * @param desc Description of what the variable does
+ * @param ret_type The type of the returned value
+ * @param ret_desc Documentation for the returned value
+ *
+ * @ingroup ade_api
+ */
+#define ADE_VIRTVAR(name, parent, args, desc, ret_type, ret_desc)                                                      \
+	static int parent##_##name##_f(lua_State* L);                                                                      \
+	::scripting::ade_virtvar parent##_##name(#name, parent##_##name##_f, parent, args, desc, ret_type, ret_desc);      \
+	static int parent##_##name##_f(lua_State* L)
+
+/**
+ * @ingroup ade_api
+ */
+class ade_indexer : public ade_lib_handle {
+  public:
+	ade_indexer(lua_CFunction func, const ade_lib_handle& parent, const char* args = NULL, const char* desc = NULL,
+	            const char* ret_type = NULL, const char* ret_desc = NULL);
+};
+
+/**
+ * @brief Declare an indexer of an object
+ *
+ * Use this with objects to deal with forms such as vec.x, vec['x'], vec[0]. Format string should be "o*%", where * is
+ * indexing value, and % is the value to set to when LUA_SETTTING_VAR is set
+ *
+ * @param parent The library or object containing the indexer
+ * @param args Documentation for the type of the value that may be assigned
+ * @param desc Description of what the variable does
+ * @param ret_type The type of the returned value
+ * @param ret_desc Documentation for the returned value
+ *
+ * @ingroup ade_api
+ */
+#define ADE_INDEXER(parent, args, desc, ret_type, ret_desc)                                                            \
+	static int parent##___indexer_f(lua_State* L);                                                                     \
+	::scripting::ade_indexer parent##___indexer(parent##___indexer_f, parent, args, desc, ret_type, ret_desc);         \
+	static int parent##___indexer_f(lua_State* L)
 
 //*************************Lua return values*************************
 /**

--- a/code/scripting/ade_args.cpp
+++ b/code/scripting/ade_args.cpp
@@ -127,12 +127,6 @@ void set_single_arg(lua_State* L, char fmt, const char* s)
 	// WMC - Isn't working with HookVar for some strange reason
 	lua_pushstring(L, s);
 }
-void set_single_arg(lua_State* L, char fmt, ade_odata od)
-{
-	Assertion(fmt == 'o', "Invalid format character '%c' for object type!", fmt);
-	// Use the common helper method
-	luacpp::convert::pushValue(L, od);
-}
 void set_single_arg(lua_State*, char fmt, luacpp::LuaTable* table)
 {
 	Assertion(fmt == 't', "Invalid format character '%c' for table type!", fmt);

--- a/code/scripting/ade_args.cpp
+++ b/code/scripting/ade_args.cpp
@@ -75,25 +75,6 @@ bool get_single_arg(lua_State* L, const get_args_state& state, char fmt, const c
 	}
 	return true;
 }
-bool get_single_arg(lua_State* L, const get_args_state& state, char fmt, ade_odata od)
-{
-	Assertion(fmt == 'o', "Invalid character '%c' for object type!", fmt);
-
-	if (lua_isuserdata(L, state.nargs)) {
-		// Use the helper function
-		if (!luacpp::convert::popValue(L, od, state.nargs, false)) {
-			return false;
-		}
-	} else if (lua_isnil(L, state.nargs) && state.optional_args) {
-		// WMC - Modder has chosen to ignore this argument
-	} else {
-		LuaError(L, "%s: Argument %d is an invalid type '%s'; type '%s' expected", state.funcname, state.nargs,
-		         ade_get_type_string(L, state.nargs), internal::getTableEntry(od.idx).GetName());
-		return false;
-	}
-
-	return true;
-}
 bool get_single_arg(lua_State* L, const get_args_state& state, char fmt, luacpp::LuaTable* t)
 {
 	Assertion(fmt == 't', "Invalid character '%c' for table type!", fmt);

--- a/code/scripting/ade_args.h
+++ b/code/scripting/ade_args.h
@@ -296,7 +296,7 @@ void set_single_arg(lua_State* L, char fmt, ade_odata_setter<T>&& od)
 {
 	Assertion(fmt == 'o', "Invalid format character '%c' for object type!", fmt);
 	// Use the common helper method
-	luacpp::convert::pushValue(L, std::move(od));
+	luacpp::convert::pushValue(L, std::forward<ade_odata_setter<T>>(od));
 }
 void set_single_arg(lua_State* /*L*/, char fmt, luacpp::LuaTable* table);
 void set_single_arg(lua_State* /*L*/, char fmt, luacpp::LuaFunction* func);

--- a/code/scripting/ade_args.h
+++ b/code/scripting/ade_args.h
@@ -261,7 +261,13 @@ set_single_arg(lua_State* L, char fmt, T i)
 	}
 }
 void set_single_arg(lua_State* L, char fmt, const char* s);
-void set_single_arg(lua_State* L, char fmt, ade_odata od);
+template<typename T>
+void set_single_arg(lua_State* L, char fmt, ade_odata_setter<T>&& od)
+{
+	Assertion(fmt == 'o', "Invalid format character '%c' for object type!", fmt);
+	// Use the common helper method
+	luacpp::convert::pushValue(L, std::move(od));
+}
 void set_single_arg(lua_State* /*L*/, char fmt, luacpp::LuaTable* table);
 void set_single_arg(lua_State* /*L*/, char fmt, luacpp::LuaFunction* func);
 
@@ -272,7 +278,7 @@ inline void set_args_actual(lua_State* /*L*/, set_args_state& /*state*/, const c
 }
 
 template <typename T, typename... Args>
-void set_args_actual(lua_State* L, set_args_state& state, const char* fmt, T current, Args... args)
+void set_args_actual(lua_State* L, set_args_state& state, const char* fmt, T&& current, Args&&... args)
 {
 	Assertion(strlen(fmt) > 0, "Format was empty but there were still parameters in the argument list!");
 
@@ -302,7 +308,7 @@ void set_args_actual(lua_State* L, set_args_state& state, const char* fmt, T cur
 // NOTE: You can also use this to push arguments
 // on to the stack in series. See script_state::SetHookVar
 template <typename... Args>
-int ade_set_args(lua_State* L, const char* fmt, Args... args)
+int ade_set_args(lua_State* L, const char* fmt, Args&&... args)
 {
 	// Start throught
 	internal::set_args_state state{};

--- a/code/scripting/api/libs/mission.cpp
+++ b/code/scripting/api/libs/mission.cpp
@@ -137,7 +137,7 @@ ADE_INDEXER(l_Mission_Asteroids, "number Index", "Gets asteroid", "asteroid", "A
 	}
 	if( idx > -1 && idx < asteroid_count() ) {
 		idx--; //Convert from Lua to C, as lua indices start from 1, not 0
-		return ade_set_args( L, "o", l_Asteroid.Set( object_h( &Objects[Asteroids[idx].objnum] ), Objects[Asteroids[idx].objnum].signature ) );
+		return ade_set_args(L, "o", l_Asteroid.Set(object_h(&Objects[Asteroids[idx].objnum])));
 	}
 
 	return ade_set_error(L, "o", l_Asteroid.Set( object_h() ) );
@@ -167,7 +167,7 @@ ADE_INDEXER(l_Mission_Debris, "number Index", "Array of debris in the current mi
 		idx--; // Lua -> C
 		if (Debris[idx].objnum == -1) //Somehow accessed an invalid debris piece
 			return ade_set_error(L, "o", l_Debris.Set(object_h()));
-		return ade_set_args(L, "o", l_Debris.Set(object_h(&Objects[Debris[idx].objnum]), Objects[Debris[idx].objnum].signature));
+		return ade_set_args(L, "o", l_Debris.Set(object_h(&Objects[Debris[idx].objnum])));
 	}
 
 	return ade_set_error(L, "o", l_Debris.Set(object_h()));
@@ -303,7 +303,7 @@ ADE_INDEXER(l_Mission_Ships, "number Index/string Name", "Gets ship", "ship", "S
 
 	if(idx > -1)
 	{
-		return ade_set_args(L, "o", l_Ship.Set(object_h(&Objects[Ships[idx].objnum]), Objects[Ships[idx].objnum].signature));
+		return ade_set_args(L, "o", l_Ship.Set(object_h(&Objects[Ships[idx].objnum])));
 	}
 	else
 	{
@@ -318,7 +318,7 @@ ADE_INDEXER(l_Mission_Ships, "number Index/string Name", "Gets ship", "ship", "S
 					continue;
 
 				if(count == idx) {
-					return ade_set_args(L, "o", l_Ship.Set(object_h(&Objects[Ships[i].objnum]), Objects[Ships[i].objnum].signature));
+					return ade_set_args(L, "o", l_Ship.Set(object_h(&Objects[Ships[i].objnum])));
 				}
 
 				count++;
@@ -816,7 +816,7 @@ ADE_FUNC(createShip, l_Mission, "[string Name, shipclass Class=Shipclass[1], ori
 	if(obj_idx > -1) {
 		model_page_in_textures(Ship_info[sclass].model_num, sclass);
 
-		return ade_set_args(L, "o", l_Ship.Set(object_h(&Objects[obj_idx]), Objects[obj_idx].signature));
+		return ade_set_args(L, "o", l_Ship.Set(object_h(&Objects[obj_idx])));
 	} else
 		return ade_set_error(L, "o", l_Ship.Set(object_h()));
 }
@@ -871,7 +871,7 @@ ADE_FUNC(createWeapon, l_Mission, "[weaponclass Class=WeaponClass[1], orientatio
 	int obj_idx = weapon_create(&pos, real_orient, wclass, parent_idx, group);
 
 	if(obj_idx > -1)
-		return ade_set_args(L, "o", l_Weapon.Set(object_h(&Objects[obj_idx]), Objects[obj_idx].signature));
+		return ade_set_args(L, "o", l_Weapon.Set(object_h(&Objects[obj_idx])));
 	else
 		return ade_set_error(L, "o", l_Weapon.Set(object_h()));
 }

--- a/code/scripting/api/libs/testing.cpp
+++ b/code/scripting/api/libs/testing.cpp
@@ -76,7 +76,9 @@ ADE_FUNC(createParticle, l_Testing, "vector Position, vector Velocity, number Li
 	enum_h *type = NULL;
 	bool rev=false;
 	object_h *objh=NULL;
-	if(!ade_get_args(L, "ooffo|fboo", l_Vector.Get(&pi.pos), l_Vector.Get(&pi.vel), &pi.lifetime, &pi.rad, l_Enum.GetPtr(&type), &temp, &rev, l_Texture.Get((int*)&pi.optional_data), l_Object.GetPtr(&objh)))
+	texture_h* texture = nullptr;
+	if (!ade_get_args(L, "ooffo|fboo", l_Vector.Get(&pi.pos), l_Vector.Get(&pi.vel), &pi.lifetime, &pi.rad,
+	                  l_Enum.GetPtr(&type), &temp, &rev, l_Texture.GetPtr(&texture), l_Object.GetPtr(&objh)))
 		return ADE_RETURN_NIL;
 
 	if(type != NULL)
@@ -96,13 +98,14 @@ ADE_FUNC(createParticle, l_Testing, "vector Position, vector Velocity, number Li
 				pi.type = particle::PARTICLE_SMOKE2;
 				break;
 			case LE_PARTICLE_BITMAP:
-				if (pi.optional_data < 0)
-				{
-					LuaError(L, "Invalid texture specified for createParticle()!");
-				}
-
-				pi.type = particle::PARTICLE_BITMAP;
-				break;
+			    if (texture == nullptr || !texture->isValid()) {
+				    LuaError(L, "Invalid texture specified for createParticle()!");
+				    return ADE_RETURN_NIL;
+			    } else {
+				    pi.optional_data = texture->handle;
+				    pi.type          = particle::PARTICLE_BITMAP;
+			    }
+			    break;
 		}
 	}
 
@@ -118,7 +121,7 @@ ADE_FUNC(createParticle, l_Testing, "vector Position, vector Velocity, number Li
 	particle::WeakParticlePtr p = particle::createPersistent(&pi);
 
 	if (!p.expired())
-		return ade_set_args(L, "o", l_Particle.Set(new particle_h(p)));
+		return ade_set_args(L, "o", l_Particle.Set(particle_h(p)));
 	else
 		return ADE_RETURN_NIL;
 }

--- a/code/scripting/api/objs/beam.cpp
+++ b/code/scripting/api/objs/beam.cpp
@@ -274,7 +274,7 @@ ADE_FUNC(getCollisionInformation, l_Beam, "number", "Get the collision informati
 		return ade_set_error(L, "o", l_ColInfo.Set(mc_info_h()));
 
 	// so we have valid beam and valid indexer
-	return ade_set_args(L, "o", l_ColInfo.Set(mc_info_h(new mc_info(bp->f_collisions[idx].cinfo))));
+	return ade_set_args(L, "o", l_ColInfo.Set(mc_info_h(bp->f_collisions[idx].cinfo)));
 }
 
 ADE_FUNC(getCollisionObject, l_Beam, "number", "Get the target of the defined collision.", "object", "Object the beam collided with")

--- a/code/scripting/api/objs/cockpit_display.cpp
+++ b/code/scripting/api/objs/cockpit_display.cpp
@@ -233,10 +233,10 @@ ADE_FUNC(startRendering, l_CockpitDisplay, "[boolean setClip = true]", "Starts r
 	bool setClip = true;
 
 	if (!ade_get_args(L, "o|b", l_CockpitDisplay.GetPtr(&cdh), &setClip))
-		return ade_set_error(L, "o", l_Texture.Set(-1));
+		return ade_set_error(L, "o", l_Texture.Set(texture_h()));
 
 	if (!cdh->isValid())
-		return ade_set_error(L, "o", l_Texture.Set(-1));
+		return ade_set_error(L, "o", l_Texture.Set(texture_h()));
 
 	int bm_handle = ship_start_render_cockpit_display(cdh->GetId());
 
@@ -246,7 +246,7 @@ ADE_FUNC(startRendering, l_CockpitDisplay, "[boolean setClip = true]", "Starts r
 		gr_set_clip(cd->offset[0], cd->offset[1], cd->size[0], cd->size[1], GR_RESIZE_NONE);
 	}
 
-	return ade_set_args(L, "o", l_Texture.Set(bm_handle));
+	return ade_set_args(L, "o", l_Texture.Set(texture_h(bm_handle)));
 }
 
 ADE_FUNC(stopRendering, l_CockpitDisplay, NULL, "Stops rendering to this cockpit display", "boolean", "true if successfull, false otherwise")
@@ -270,17 +270,17 @@ ADE_FUNC(getBackgroundTexture, l_CockpitDisplay, NULL, "Gets the background text
 	cockpit_display_h *cdh = NULL;
 
 	if (!ade_get_args(L, "o", l_CockpitDisplay.GetPtr(&cdh)))
-		return ade_set_error(L, "o", l_Texture.Set(-1));
+		return ade_set_error(L, "o", l_Texture.Set(texture_h()));
 
 	if (!cdh->isValid())
-		return ade_set_error(L, "o", l_Texture.Set(-1));
+		return ade_set_error(L, "o", l_Texture.Set(texture_h()));
 
 	cockpit_display *cd = cdh->Get();
 
 	if (cd == NULL)
-		return ade_set_error(L, "o", l_Texture.Set(-1));
+		return ade_set_error(L, "o", l_Texture.Set(texture_h()));
 
-	return ade_set_args(L, "o", l_Texture.Set(cd->background));
+	return ade_set_args(L, "o", l_Texture.Set(texture_h(cd->background)));
 }
 
 ADE_FUNC(getForegroundTexture, l_CockpitDisplay, NULL, "Gets the foreground texture handle of this cockpit display<br>"
@@ -289,17 +289,17 @@ ADE_FUNC(getForegroundTexture, l_CockpitDisplay, NULL, "Gets the foreground text
 	cockpit_display_h *cdh = NULL;
 
 	if (!ade_get_args(L, "o", l_CockpitDisplay.GetPtr(&cdh)))
-		return ade_set_error(L, "o", l_Texture.Set(-1));
+		return ade_set_error(L, "o", l_Texture.Set(texture_h()));
 
 	if (!cdh->isValid())
-		return ade_set_error(L, "o", l_Texture.Set(-1));
+		return ade_set_error(L, "o", l_Texture.Set(texture_h()));
 
 	cockpit_display *cd = cdh->Get();
 
 	if (cd == NULL)
-		return ade_set_error(L, "o", l_Texture.Set(-1));
+		return ade_set_error(L, "o", l_Texture.Set(texture_h()));
 
-	return ade_set_args(L, "o", l_Texture.Set(cd->foreground));
+	return ade_set_args(L, "o", l_Texture.Set(texture_h(cd->foreground)));
 }
 
 ADE_FUNC(getSize, l_CockpitDisplay, NULL, "Gets the size of this cockpit display", "number, number", "Width and height of the display or -1, -1 on error")

--- a/code/scripting/api/objs/mc_info.cpp
+++ b/code/scripting/api/objs/mc_info.cpp
@@ -10,7 +10,7 @@ namespace api {
 
 mc_info_h::mc_info_h(const mc_info& val) : info(val), valid(true) {}
 
-mc_info_h::mc_info_h() : valid(false) {}
+mc_info_h::mc_info_h() = default;
 
 mc_info* mc_info_h::Get() { return &info; }
 bool mc_info_h::IsValid() { return valid; }

--- a/code/scripting/api/objs/mc_info.cpp
+++ b/code/scripting/api/objs/mc_info.cpp
@@ -8,41 +8,15 @@
 namespace scripting {
 namespace api {
 
-mc_info_h::mc_info_h(mc_info* val) : info(val) {}
+mc_info_h::mc_info_h(const mc_info& val) : info(val), valid(true) {}
 
-mc_info_h::mc_info_h() : info(NULL) {}
+mc_info_h::mc_info_h() : valid(false) {}
 
-mc_info* mc_info_h::Get() {
-	return info;
-}
-void mc_info_h::deleteInfo() {
-	if (!this->IsValid())
-		return;
-
-	delete info;
-
-	info = NULL;
-}
-
-bool mc_info_h::IsValid() {
-	return info != NULL;
-}
+mc_info* mc_info_h::Get() { return &info; }
+bool mc_info_h::IsValid() { return valid; }
 
 //**********HANDLE: Collision info
 ADE_OBJ(l_ColInfo, mc_info_h, "collision info", "Information about a collision");
-
-ADE_FUNC(__gc, l_ColInfo, NULL, "Removes the allocated reference of this handle", NULL, NULL)
-{
-	mc_info_h* info;
-
-	if(!ade_get_args(L, "o", l_ColInfo.GetPtr(&info)))
-		return ADE_RETURN_NIL;
-
-	if (info->IsValid())
-		info->deleteInfo();
-
-	return ADE_RETURN_NIL;
-}
 
 ADE_VIRTVAR(Model, l_ColInfo, "model", "The model this collision info is about", "model", "The model")
 {

--- a/code/scripting/api/objs/mc_info.h
+++ b/code/scripting/api/objs/mc_info.h
@@ -10,8 +10,9 @@ class mc_info_h
 {
  protected:
 	mc_info info;
-	bool valid;
- public:
+	bool valid = false;
+
+  public:
 	explicit mc_info_h(const mc_info& val);
 	mc_info_h();
 

--- a/code/scripting/api/objs/mc_info.h
+++ b/code/scripting/api/objs/mc_info.h
@@ -9,15 +9,13 @@ namespace api {
 class mc_info_h
 {
  protected:
-	mc_info* info;
+	mc_info info;
+	bool valid;
  public:
-	explicit mc_info_h(mc_info* val);
-
+	explicit mc_info_h(const mc_info& val);
 	mc_info_h();
 
 	mc_info *Get();
-
-	void deleteInfo();
 
 	bool IsValid();
 };

--- a/code/scripting/api/objs/model.cpp
+++ b/code/scripting/api/objs/model.cpp
@@ -277,16 +277,16 @@ ADE_FUNC(__len, l_ModelTextures, NULL, "Number of textures on model", "number", 
 ADE_INDEXER(l_ModelTextures, "texture", "number Index/string TextureName", "texture", "Model textures, or invalid modeltextures handle if model handle is invalid")
 {
 	modeltextures_h *mth = NULL;
-	int new_tex = -1;
+	texture_h* new_tex   = nullptr;
 	const char* s        = nullptr;
 
-	if (!ade_get_args(L, "os|o", l_ModelTextures.GetPtr(&mth), &s, l_Texture.Get(&new_tex)))
-		return ade_set_error(L, "o", l_Texture.Set(-1));
+	if (!ade_get_args(L, "os|o", l_ModelTextures.GetPtr(&mth), &s, l_Texture.GetPtr(&new_tex)))
+		return ade_set_error(L, "o", l_Texture.Set(texture_h()));
 
 	polymodel *pm = mth->Get();
 
 	if (!mth->IsValid() || s == NULL || pm == NULL)
-		return ade_set_error(L, "o", l_Texture.Set(-1));
+		return ade_set_error(L, "o", l_Texture.Set(texture_h()));
 
 	texture_info *tinfo = NULL;
 	texture_map *tmap = NULL;
@@ -297,7 +297,7 @@ ADE_INDEXER(l_ModelTextures, "texture", "number Index/string TextureName", "text
 		int idx = atoi(s) - 1;	//Lua->FS2
 
 		if (idx < 0 || idx >= num_textures)
-			return ade_set_error(L, "o", l_Texture.Set(-1));
+			return ade_set_error(L, "o", l_Texture.Set(texture_h()));
 
 		tmap = &pm->maps[idx / TM_NUM_TYPES];
 		tinfo = &tmap->textures[idx % TM_NUM_TYPES];
@@ -316,13 +316,13 @@ ADE_INDEXER(l_ModelTextures, "texture", "number Index/string TextureName", "text
 	}
 
 	if(tinfo == NULL)
-		return ade_set_error(L, "o", l_Texture.Set(-1));
+		return ade_set_error(L, "o", l_Texture.Set(texture_h()));
 
 	if (ADE_SETTING_VAR) {
-		tinfo->SetTexture(new_tex);
+		tinfo->SetTexture(new_tex->handle);
 	}
 
-	return ade_set_args(L, "o", l_Texture.Set(tinfo->GetTexture()));
+	return ade_set_args(L, "o", l_Texture.Set(texture_h(tinfo->GetTexture())));
 }
 
 ADE_FUNC(isValid, l_ModelTextures, NULL, "Detects whether handle is valid", "boolean", "true if valid, false if handle is invalid, nil if a syntax/type error occurs")

--- a/code/scripting/api/objs/movie_player.cpp
+++ b/code/scripting/api/objs/movie_player.cpp
@@ -5,34 +5,18 @@
 namespace scripting {
 namespace api {
 
+movie_player_h::movie_player_h() = default;
 movie_player_h::movie_player_h(std::unique_ptr<cutscene::Player>&& player) : _player(std::move(player)) {}
 bool movie_player_h::isValid() const { return (bool)_player; }
 cutscene::Player* movie_player_h::player() { return _player.get(); }
 
-ADE_OBJ(l_MoviePlayer, movie_player_h*, "movie_player", "A movie player instance");
-
-ADE_FUNC(__gc, l_MoviePlayer, nullptr, "Cleans up the allocated resources. Should only be used by Lua.", "nothing",
-         nullptr)
-{
-	movie_player_h* ph = nullptr;
-	if (!ade_get_args(L, "o", l_MoviePlayer.Get(&ph)))
-		return ADE_RETURN_NIL;
-
-	if (ph == nullptr) {
-		return ADE_RETURN_NIL;
-	}
-
-	// Clean up the pointer
-	delete ph;
-
-	return ADE_RETURN_NIL;
-}
+ADE_OBJ(l_MoviePlayer, movie_player_h, "movie_player", "A movie player instance");
 
 ADE_VIRTVAR(Width, l_MoviePlayer, "number", "Determines the width in pixels of this movie <b>Read-only</b>", "number",
             "The width of the movie or -1 if handle is invalid")
 {
 	movie_player_h* ph = nullptr;
-	if (!ade_get_args(L, "o", l_MoviePlayer.Get(&ph)))
+	if (!ade_get_args(L, "o", l_MoviePlayer.GetPtr(&ph)))
 		return ade_set_args(L, "i", -1);
 
 	if (ph == nullptr || !ph->isValid()) {
@@ -50,7 +34,7 @@ ADE_VIRTVAR(Height, l_MoviePlayer, "number", "Determines the height in pixels of
             "The height of the movie or -1 if handle is invalid")
 {
 	movie_player_h* ph = nullptr;
-	if (!ade_get_args(L, "o", l_MoviePlayer.Get(&ph)))
+	if (!ade_get_args(L, "o", l_MoviePlayer.GetPtr(&ph)))
 		return ade_set_args(L, "i", -1);
 
 	if (ph == nullptr || !ph->isValid()) {
@@ -68,7 +52,7 @@ ADE_VIRTVAR(FPS, l_MoviePlayer, "number", "Determines the frames per second of t
             "The FPS of the movie or -1 if handle is invalid")
 {
 	movie_player_h* ph = nullptr;
-	if (!ade_get_args(L, "o", l_MoviePlayer.Get(&ph)))
+	if (!ade_get_args(L, "o", l_MoviePlayer.GetPtr(&ph)))
 		return ade_set_args(L, "i", -1);
 
 	if (ph == nullptr || !ph->isValid()) {
@@ -88,7 +72,7 @@ ADE_FUNC(update, l_MoviePlayer, "timespan step_time",
 {
 	movie_player_h* ph = nullptr;
 	int64_t time_diff  = 0;
-	if (!ade_get_args(L, "oo", l_MoviePlayer.Get(&ph), l_TimeSpan.Get(&time_diff)))
+	if (!ade_get_args(L, "oo", l_MoviePlayer.GetPtr(&ph), l_TimeSpan.Get(&time_diff)))
 		return ADE_RETURN_FALSE;
 
 	if (ph == nullptr || !ph->isValid()) {
@@ -107,7 +91,7 @@ ADE_FUNC(isPlaybackReady, l_MoviePlayer, nullptr,
          "boolean", "true if playback is ready, false otherwise")
 {
 	movie_player_h* ph = nullptr;
-	if (!ade_get_args(L, "o", l_MoviePlayer.Get(&ph)))
+	if (!ade_get_args(L, "o", l_MoviePlayer.GetPtr(&ph)))
 		return ADE_RETURN_FALSE;
 
 	if (ph == nullptr || !ph->isValid()) {
@@ -128,7 +112,7 @@ ADE_FUNC(drawMovie, l_MoviePlayer, "number x1, number y1[, number x2, number y2]
 	float x2 = -1.f;
 	float y2 = -1.f;
 
-	if (!ade_get_args(L, "off|ff", l_MoviePlayer.Get(&ph), &x1, &y1, &x2, &y2))
+	if (!ade_get_args(L, "off|ff", l_MoviePlayer.GetPtr(&ph), &x1, &y1, &x2, &y2))
 		return ADE_RETURN_NIL;
 
 	if (ph == nullptr || !ph->isValid()) {
@@ -156,7 +140,7 @@ ADE_FUNC(stop, l_MoviePlayer, nullptr,
          "nothing", "Returns nothing")
 {
 	movie_player_h* ph = nullptr;
-	if (!ade_get_args(L, "o", l_MoviePlayer.Get(&ph)))
+	if (!ade_get_args(L, "o", l_MoviePlayer.GetPtr(&ph)))
 		return ADE_RETURN_NIL;
 
 	if (ph == nullptr || !ph->isValid()) {
@@ -172,7 +156,7 @@ ADE_FUNC(isValid, l_MoviePlayer, nullptr, "Determines if this handle is valid", 
          "true if valid, false otherwise")
 {
 	movie_player_h* ph = nullptr;
-	if (!ade_get_args(L, "o", l_MoviePlayer.Get(&ph)))
+	if (!ade_get_args(L, "o", l_MoviePlayer.GetPtr(&ph)))
 		return ADE_RETURN_FALSE;
 
 	if (ph == nullptr) {

--- a/code/scripting/api/objs/movie_player.h
+++ b/code/scripting/api/objs/movie_player.h
@@ -11,6 +11,7 @@ class movie_player_h {
 	std::unique_ptr<cutscene::Player> _player;
 
   public:
+	movie_player_h();
 	explicit movie_player_h(std::unique_ptr<cutscene::Player>&& player);
 
 	cutscene::Player* player();
@@ -18,7 +19,7 @@ class movie_player_h {
 	bool isValid() const;
 };
 
-DECLARE_ADE_OBJ(l_MoviePlayer, movie_player_h*);
+DECLARE_ADE_OBJ(l_MoviePlayer, movie_player_h);
 
 } // namespace api
 } // namespace scripting

--- a/code/scripting/api/objs/object.cpp
+++ b/code/scripting/api/objs/object.cpp
@@ -404,9 +404,9 @@ ADE_FUNC(checkRayCollision, l_Object, "vector Start Point, vector End Point, [bo
 	}
 
 	if (local)
-		return ade_set_args(L, "oo", l_Vector.Set(hull_check.hit_point), l_ColInfo.Set(mc_info_h(new mc_info(hull_check))));
+		return ade_set_args(L, "oo", l_Vector.Set(hull_check.hit_point), l_ColInfo.Set(mc_info_h(hull_check)));
 	else
-		return ade_set_args(L, "oo", l_Vector.Set(hull_check.hit_point_world),  l_ColInfo.Set(mc_info_h(new mc_info(hull_check))));
+		return ade_set_args(L, "oo", l_Vector.Set(hull_check.hit_point_world),  l_ColInfo.Set(mc_info_h(hull_check)));
 }
 
 ADE_FUNC(addPreMoveHook, l_Object, "function(object) callback",

--- a/code/scripting/api/objs/particle.cpp
+++ b/code/scripting/api/objs/particle.cpp
@@ -22,32 +22,13 @@ bool particle_h::isValid() {
 
 
 //**********HANDLE: Particle
-ADE_OBJ(l_Particle, particle_h*, "particle", "Handle to a particle");
-
-ADE_FUNC(__gc, l_Particle, NULL, "Removes the allocated reference of this handle", NULL, NULL)
-{
-	particle_h *ph = NULL;
-	if (!ade_get_args(L, "o", l_Particle.Get(&ph)))
-		return ADE_RETURN_NIL;
-
-	if (ph == NULL)
-		return ADE_RETURN_NIL;
-
-	if (!ph->isValid()) {
-		return ADE_RETURN_NIL;
-	}
-
-	// Clean up the pointer
-	delete ph;
-
-	return ADE_RETURN_NIL;
-}
+ADE_OBJ(l_Particle, particle_h, "particle", "Handle to a particle");
 
 ADE_VIRTVAR(Position, l_Particle, "vector", "The current position of the particle (world vector)", "vector", "The current position")
 {
 	particle_h *ph = NULL;
 	vec3d newVec = vmd_zero_vector;
-	if (!ade_get_args(L, "o|o", l_Particle.Get(&ph), l_Vector.Get(&newVec)))
+	if (!ade_get_args(L, "o|o", l_Particle.GetPtr(&ph), l_Vector.Get(&newVec)))
 		return ade_set_error(L, "o", l_Vector.Set(vmd_zero_vector));
 
 	if (ph == NULL)
@@ -68,7 +49,7 @@ ADE_VIRTVAR(Velocity, l_Particle, "vector", "The current velocity of the particl
 {
 	particle_h *ph = NULL;
 	vec3d newVec = vmd_zero_vector;
-	if (!ade_get_args(L, "o|o", l_Particle.Get(&ph), l_Vector.Get(&newVec)))
+	if (!ade_get_args(L, "o|o", l_Particle.GetPtr(&ph), l_Vector.Get(&newVec)))
 		return ade_set_error(L, "o", l_Vector.Set(vmd_zero_vector));
 
 	if (ph == NULL)
@@ -89,7 +70,7 @@ ADE_VIRTVAR(Age, l_Particle, "number", "The time this particle already lives", "
 {
 	particle_h *ph = NULL;
 	float newAge = -1.0f;
-	if (!ade_get_args(L, "o|f", l_Particle.Get(&ph), &newAge))
+	if (!ade_get_args(L, "o|f", l_Particle.GetPtr(&ph), &newAge))
 		return ade_set_error(L, "f", -1.0f);
 
 	if (ph == NULL)
@@ -111,7 +92,7 @@ ADE_VIRTVAR(MaximumLife, l_Particle, "number", "The time this particle can live"
 {
 	particle_h *ph = NULL;
 	float newLife = -1.0f;
-	if (!ade_get_args(L, "o|f", l_Particle.Get(&ph), &newLife))
+	if (!ade_get_args(L, "o|f", l_Particle.GetPtr(&ph), &newLife))
 		return ade_set_error(L, "f", -1.0f);
 
 	if (ph == NULL)
@@ -157,7 +138,7 @@ ADE_VIRTVAR(Radius, l_Particle, "number", "The radius of the particle", "number"
 {
 	particle_h *ph = NULL;
 	float newRadius = -1.0f;
-	if (!ade_get_args(L, "o|f", l_Particle.Get(&ph), &newRadius))
+	if (!ade_get_args(L, "o|f", l_Particle.GetPtr(&ph), &newRadius))
 		return ade_set_error(L, "f", -1.0f);
 
 	if (ph == NULL)
@@ -179,7 +160,7 @@ ADE_VIRTVAR(TracerLength, l_Particle, "number", "The tracer legth of the particl
 {
 	particle_h *ph = NULL;
 	float newTracer = -1.0f;
-	if (!ade_get_args(L, "o|f", l_Particle.Get(&ph), &newTracer))
+	if (!ade_get_args(L, "o|f", l_Particle.GetPtr(&ph), &newTracer))
 		return ade_set_error(L, "f", -1.0f);
 
 	if (ph == NULL)
@@ -196,7 +177,7 @@ ADE_VIRTVAR(AttachedObject, l_Particle, "object", "The object this particle is a
 {
 	particle_h *ph = NULL;
 	object_h *newObj = nullptr;
-	if (!ade_get_args(L, "o|o", l_Particle.Get(&ph), l_Object.GetPtr(&newObj)))
+	if (!ade_get_args(L, "o|o", l_Particle.GetPtr(&ph), l_Object.GetPtr(&newObj)))
 		return ade_set_error(L, "o", l_Object.Set(object_h()));
 
 	if (ph == NULL)
@@ -217,7 +198,7 @@ ADE_VIRTVAR(AttachedObject, l_Particle, "object", "The object this particle is a
 ADE_FUNC(isValid, l_Particle, NULL, "Detects whether this handle is valid", "boolean", "true if valid false if not")
 {
 	particle_h *ph = NULL;
-	if (!ade_get_args(L, "o", l_Particle.Get(&ph)))
+	if (!ade_get_args(L, "o", l_Particle.GetPtr(&ph)))
 		return ADE_RETURN_FALSE;
 
 	if (ph == NULL)

--- a/code/scripting/api/objs/particle.cpp
+++ b/code/scripting/api/objs/particle.cpp
@@ -118,7 +118,7 @@ ADE_VIRTVAR(Looping, l_Particle, "boolean",
 {
 	particle_h* ph = nullptr;
 	bool newloop   = false;
-	if (!ade_get_args(L, "o|b", l_Particle.Get(&ph), &newloop))
+	if (!ade_get_args(L, "o|b", l_Particle.GetPtr(&ph), &newloop))
 		return ADE_RETURN_FALSE;
 
 	if (ph == nullptr)

--- a/code/scripting/api/objs/particle.h
+++ b/code/scripting/api/objs/particle.h
@@ -20,7 +20,7 @@ class particle_h
 	bool isValid();
 };
 
-DECLARE_ADE_OBJ(l_Particle, particle_h*);
+DECLARE_ADE_OBJ(l_Particle, particle_h);
 
 }
 }

--- a/code/scripting/api/objs/player.cpp
+++ b/code/scripting/api/objs/player.cpp
@@ -22,26 +22,21 @@ player_h::player_h(const player& plr)
 }
 bool player_h::isValid() const { return _plr != nullptr; }
 player* player_h::get() { return _plr; }
-void player_h::cleanup()
+player_h::~player_h()
 {
 	delete _plr;
 	_plr = nullptr;
+}
+player_h::player_h(player_h&& other) noexcept { *this = std::move(other); }
+player_h& player_h::operator=(player_h&& other) noexcept
+{
+	std::swap(_plr, other._plr);
+	return *this;
 }
 
 //**********HANDLE: Player
 ADE_OBJ(l_Player, player_h, "player", "Player handle");
 
-ADE_FUNC(__gc, l_Player, nullptr, "Deletes the underlying resources", "nothing", "nothing") {
-	player_h* plr;
-	if (!ade_get_args(L, "o", l_Player.GetPtr(&plr)))
-		return ADE_RETURN_NIL;
-
-	if (!plr->isValid())
-		return ADE_RETURN_NIL;
-
-	plr->cleanup();
-	return ADE_RETURN_NIL;
-}
 
 ADE_VIRTVAR(Stats, l_Player, "scoring_stats stats", "The scoring stats of this player (read-only)", "scoring_stats", "The player stats or invalid handle") {
 	player_h* plr;

--- a/code/scripting/api/objs/player.h
+++ b/code/scripting/api/objs/player.h
@@ -12,11 +12,17 @@ class player_h {
 	player_h();
 	player_h(const player& plr);
 
+	player_h(const player_h&) = delete;
+	player_h& operator=(const player_h&) = delete;
+
+	player_h(player_h&&) noexcept;
+	player_h& operator=(player_h&&) noexcept;
+
+	~player_h();
+
 	bool isValid() const;
 
 	player* get();
-
-	void cleanup();
 };
 
 DECLARE_ADE_OBJ(l_Player, player_h);

--- a/code/scripting/api/objs/ship.cpp
+++ b/code/scripting/api/objs/ship.cpp
@@ -56,12 +56,12 @@ ADE_INDEXER(l_ShipTextures, "number Index/string TextureFilename", "Array of shi
 {
 	object_h *oh;
 	const char* s;
-	int tdx=-1;
-	if (!ade_get_args(L, "os|o", l_ShipTextures.GetPtr(&oh), &s, l_Texture.Get(&tdx)))
-		return ade_set_error(L, "o", l_Texture.Set(-1));
+	texture_h* tdx = nullptr;
+	if (!ade_get_args(L, "os|o", l_ShipTextures.GetPtr(&oh), &s, l_Texture.GetPtr(&tdx)))
+		return ade_set_error(L, "o", l_Texture.Set(texture_h()));
 
 	if (!oh->IsValid() || s==NULL)
-		return ade_set_error(L, "o", l_Texture.Set(-1));
+		return ade_set_error(L, "o", l_Texture.Set(texture_h()));
 
 	ship *shipp = &Ships[oh->objp->instance];
 	polymodel *pm = model_get(Ship_info[shipp->ship_info_index].model_num);
@@ -100,7 +100,7 @@ ADE_INDEXER(l_ShipTextures, "number Index/string TextureFilename", "Array of shi
 		final_index = atoi(s) - 1;	//Lua->FS2
 
 		if (final_index < 0 || final_index >= MAX_REPLACEMENT_TEXTURES)
-			return ade_set_error(L, "o", l_Texture.Set(-1));
+			return ade_set_error(L, "o", l_Texture.Set(texture_h()));
 	}
 
 	if (ADE_SETTING_VAR) {
@@ -111,16 +111,16 @@ ADE_INDEXER(l_ShipTextures, "number Index/string TextureFilename", "Array of shi
 				shipp->ship_replacement_textures[i] = -1;
 		}
 
-		if(bm_is_valid(tdx))
-			shipp->ship_replacement_textures[final_index] = tdx;
+		if(tdx->isValid())
+			shipp->ship_replacement_textures[final_index] = tdx->handle;
 		else
 			shipp->ship_replacement_textures[final_index] = -1;
 	}
 
 	if (shipp->ship_replacement_textures != NULL && shipp->ship_replacement_textures[final_index] >= 0)
-		return ade_set_args(L, "o", l_Texture.Set(shipp->ship_replacement_textures[final_index]));
+		return ade_set_args(L, "o", l_Texture.Set(texture_h(shipp->ship_replacement_textures[final_index])));
 	else
-		return ade_set_args(L, "o", l_Texture.Set(pm->maps[final_index / TM_NUM_TYPES].textures[final_index % TM_NUM_TYPES].GetTexture()));
+		return ade_set_args(L, "o", l_Texture.Set(texture_h(pm->maps[final_index / TM_NUM_TYPES].textures[final_index % TM_NUM_TYPES].GetTexture())));
 }
 
 ADE_FUNC(isValid, l_ShipTextures, NULL, "Detects whether handle is valid", "boolean", "true if valid, false if handle is invalid, nil if a syntax/type error occurs")

--- a/code/scripting/api/objs/streaminganim.cpp
+++ b/code/scripting/api/objs/streaminganim.cpp
@@ -19,10 +19,10 @@ streaminganim_h::~streaminganim_h() {
 	// generic_anim_unload has safety checks
 	generic_anim_unload(&ga);
 }
-streaminganim_h::streaminganim_h(streaminganim_h&& other) {
+streaminganim_h::streaminganim_h(streaminganim_h&& other) noexcept {
 	*this = std::move(other);
 }
-streaminganim_h& streaminganim_h::operator=(streaminganim_h&& other) {
+streaminganim_h& streaminganim_h::operator=(streaminganim_h&& other) noexcept {
 	generic_anim_unload(&ga);
 
 	memcpy(&ga, &other.ga, sizeof(ga));

--- a/code/scripting/api/objs/streaminganim.cpp
+++ b/code/scripting/api/objs/streaminganim.cpp
@@ -14,24 +14,27 @@ bool streaminganim_h::IsValid() {
 streaminganim_h::streaminganim_h(const char* filename) {
 	generic_anim_init(&ga, filename);
 }
+streaminganim_h::~streaminganim_h() {
+	// don't bother to check if valid before unloading
+	// generic_anim_unload has safety checks
+	generic_anim_unload(&ga);
+}
+streaminganim_h::streaminganim_h(streaminganim_h&& other) {
+	*this = std::move(other);
+}
+streaminganim_h& streaminganim_h::operator=(streaminganim_h&& other) {
+	generic_anim_unload(&ga);
+
+	memcpy(&ga, &other.ga, sizeof(ga));
+
+	// Reset the other instance so that we own the only instance
+	generic_anim_init(&other.ga, nullptr);
+
+	return *this;
+}
 
 //**********HANDLE: streamingAnimation
 ADE_OBJ(l_streaminganim, streaminganim_h, "streaminganim", "Streaming Animation handle");
-
-ADE_FUNC(__gc, l_streaminganim, NULL, "Auto-deletes streaming animation", NULL, NULL)
-{
-	// NOTE: very similar to the l_streaminganim ADE_FUNC unload
-	streaminganim_h* sah;
-
-	if(!ade_get_args(L, "o", l_streaminganim.GetPtr(&sah)))
-		return ADE_RETURN_NIL;
-
-	// don't bother to check if valid before unloading
-	// generic_anim_unload has safety checks
-	generic_anim_unload(&sah->ga);
-
-	return ADE_RETURN_NIL;
-}
 
 ADE_VIRTVAR(Loop, l_streaminganim, "[boolean loop]", "Make the streaming animation loop.", "boolean", "Is the animation looping, or nil if anim invalid")
 {

--- a/code/scripting/api/objs/streaminganim.h
+++ b/code/scripting/api/objs/streaminganim.h
@@ -14,6 +14,13 @@ class streaminganim_h {
 
 	bool IsValid();
 	explicit streaminganim_h (const char* filename);
+	~streaminganim_h();
+
+	streaminganim_h(const streaminganim_h&) = delete;
+	streaminganim_h& operator=(const streaminganim_h&) = delete;
+
+	streaminganim_h(streaminganim_h&&);
+	streaminganim_h& operator=(streaminganim_h&&);
 };
 
 DECLARE_ADE_OBJ(l_streaminganim, streaminganim_h);

--- a/code/scripting/api/objs/streaminganim.h
+++ b/code/scripting/api/objs/streaminganim.h
@@ -19,8 +19,8 @@ class streaminganim_h {
 	streaminganim_h(const streaminganim_h&) = delete;
 	streaminganim_h& operator=(const streaminganim_h&) = delete;
 
-	streaminganim_h(streaminganim_h&&);
-	streaminganim_h& operator=(streaminganim_h&&);
+	streaminganim_h(streaminganim_h&&) noexcept;
+	streaminganim_h& operator=(streaminganim_h&&) noexcept;
 };
 
 DECLARE_ADE_OBJ(l_streaminganim, streaminganim_h);

--- a/code/scripting/api/objs/texture.cpp
+++ b/code/scripting/api/objs/texture.cpp
@@ -10,37 +10,45 @@
 namespace scripting {
 namespace api {
 
-
-//**********HANDLE: Texture
-ADE_OBJ(l_Texture, int, "texture", "Texture handle");
-
-//WMC - int should NEVER EVER be an invalid handle. Return Nil instead. Nil FTW.
-
-ADE_FUNC(__gc, l_Texture, NULL, "Auto-deletes texture", NULL, NULL)
+texture_h::texture_h() = default;
+texture_h::texture_h(int bm) : handle(bm) {}
+texture_h::~texture_h()
 {
-	int idx;
-
-	if(!ade_get_args(L, "o", l_Texture.Get(&idx)))
-		return ADE_RETURN_NIL;
+	if (!isValid()) {
+		// There is nothing to release
+		return;
+	}
 
 	// Note: due to some unknown reason, in some circumstances this function
 	// might get called even for handles to bitmaps which are actually still in
 	// use, and in order to prevent that we want to double-check the load count
 	// here before unloading the bitmap. -zookeeper
-	if(idx > -1 && bm_is_valid(idx) && bm_get_entry(idx)->load_count < 1)
-		bm_release(idx);
-
-	return ADE_RETURN_NIL;
+	if (bm_get_entry(handle)->load_count < 1)
+		bm_release(handle);
 }
+bool texture_h::isValid() const { return bm_is_valid(handle) != 0; }
+texture_h::texture_h(texture_h&& other) {
+	*this = std::move(other);
+}
+texture_h& texture_h::operator=(texture_h&& other) {
+	std::swap(handle, other.handle);
+	return *this;
+}
+
+//**********HANDLE: Texture
+ADE_OBJ(l_Texture, texture_h, "texture", "Texture handle");
+
+//WMC - int should NEVER EVER be an invalid handle. Return Nil instead. Nil FTW.
 
 ADE_FUNC(__eq, l_Texture, "texture, texture", "Checks if two texture handles refer to the same texture", "boolean", "True if textures are equal")
 {
-	int idx,idx2;
+	texture_h* th;
+	texture_h* th2;
 
-	if(!ade_get_args(L, "oo", l_Texture.Get(&idx), l_Texture.Get(&idx2)))
+	if (!ade_get_args(L, "oo", l_Texture.GetPtr(&th), l_Texture.GetPtr(&th2)))
 		return ADE_RETURN_NIL;
 
-	if(idx == idx2)
+	if (th->handle == th2->handle)
 		return ADE_RETURN_TRUE;
 
 	return ADE_RETURN_FALSE;
@@ -53,83 +61,86 @@ ADE_INDEXER(l_Texture, "number",
 			"texture",
 			"Texture handle, or invalid texture handle if index is invalid")
 {
-	int idx;
+	texture_h* th;
 	int frame=-1;
 	int newframe=-1;	//WMC - Ignore for now
-	if(!ade_get_args(L, "oi|i", l_Texture.Get(&idx), &frame, &newframe))
-		return ade_set_error(L, "o", l_Texture.Set(-1));
+	if (!ade_get_args(L, "oi|i", l_Texture.GetPtr(&th), &frame, &newframe))
+		return ade_set_error(L, "o", l_Texture.Set(texture_h()));
 
 	if(frame < 1)
-		return ade_set_error(L, "o", l_Texture.Set(-1));
+		return ade_set_error(L, "o", l_Texture.Set(texture_h()));
+
+	if (!th->isValid()) {
+		return ade_set_error(L, "o", l_Texture.Set(texture_h()));
+	}
 
 	//Get me some info
 	int num=-1;
-	int first=-1;
-	first = bm_get_info(idx, NULL, NULL, NULL, &num);
+	int first = bm_get_info(th->handle, NULL, NULL, NULL, &num);
 
 	//Check it's a valid one
 	if(first < 0 || frame > num)
-		return ade_set_error(L, "o", l_Texture.Set(-1));
+		return ade_set_error(L, "o", l_Texture.Set(texture_h()));
 
 	frame--; //Lua->FS2
 
 	//Get actual texture handle
 	frame = first + frame;
 
-	return ade_set_args(L, "o", l_Texture.Set(frame));
+	return ade_set_args(L, "o", l_Texture.Set(texture_h(frame)));
 }
 
 ADE_FUNC(isValid, l_Texture, NULL, "Detects whether handle is valid", "boolean", "true if valid, false if handle is invalid, nil if a syntax/type error occurs")
 {
-	int idx;
-	if(!ade_get_args(L, "o", l_Texture.Get(&idx)))
+	texture_h* th;
+	if (!ade_get_args(L, "o", l_Texture.GetPtr(&th)))
 		return ADE_RETURN_NIL;
 
-	return ade_set_args(L, "b", bm_is_valid(idx) != 0);
+	return ade_set_args(L, "b", th->isValid());
 }
 
 ADE_FUNC(unload, l_Texture, NULL, "Unloads a texture from memory", NULL, NULL)
 {
-	int *idx;
+	texture_h* th;
 
-	if(!ade_get_args(L, "o", l_Texture.GetPtr(&idx)))
+	if (!ade_get_args(L, "o", l_Texture.GetPtr(&th)))
 		return ADE_RETURN_NIL;
 
-	if(!bm_is_valid(*idx))
+	if (!th->isValid())
 		return ADE_RETURN_NIL;
 
-	bm_release(*idx);
+	bm_release(th->handle);
 
 	//WMC - invalidate this handle
-	*idx = -1;
+	th->handle = -1;
 
 	return ADE_RETURN_NIL;
 }
 
 ADE_FUNC(getFilename, l_Texture, NULL, "Returns filename for texture", "string", "Filename, or empty string if handle is invalid")
 {
-	int idx;
-	if(!ade_get_args(L, "o", l_Texture.Get(&idx)))
+	texture_h* th;
+	if (!ade_get_args(L, "o", l_Texture.GetPtr(&th)))
 		return ade_set_error(L, "s", "");
 
-	if(!bm_is_valid(idx))
+	if (!th->isValid())
 		return ade_set_error(L, "s", "");
 
-	return ade_set_args(L, "s", bm_get_filename(idx));
+	return ade_set_args(L, "s", bm_get_filename(th->handle));
 }
 
 ADE_FUNC(getWidth, l_Texture, NULL, "Gets texture width", "number", "Texture width, or 0 if handle is invalid")
 {
-	int idx;
-	if(!ade_get_args(L, "o", l_Texture.Get(&idx)))
+	texture_h* th;
+	if (!ade_get_args(L, "o", l_Texture.GetPtr(&th)))
 		return ade_set_error(L, "i", 0);
 
-	if(!bm_is_valid(idx))
+	if (!th->isValid())
 		return ade_set_error(L, "i", 0);
 
 	int w = -1;
 
-	if(bm_get_info(idx, &w) < 0)
+	if (bm_get_info(th->handle, &w) < 0)
 		return ade_set_error(L, "i", 0);
 
 	return ade_set_args(L, "i", w);
@@ -137,16 +148,16 @@ ADE_FUNC(getWidth, l_Texture, NULL, "Gets texture width", "number", "Texture wid
 
 ADE_FUNC(getHeight, l_Texture, NULL, "Gets texture height", "number", "Texture height, or 0 if handle is invalid")
 {
-	int idx;
-	if(!ade_get_args(L, "o", l_Texture.Get(&idx)))
+	texture_h* th;
+	if (!ade_get_args(L, "o", l_Texture.GetPtr(&th)))
 		return ade_set_error(L, "i", 0);
 
-	if(!bm_is_valid(idx))
+	if (!th->isValid())
 		return ade_set_error(L, "i", 0);
 
 	int h=-1;
 
-	if(bm_get_info(idx, NULL, &h) < 0)
+	if (bm_get_info(th->handle, NULL, &h) < 0)
 		return ade_set_error(L, "i", 0);
 
 	return ade_set_args(L, "i", h);
@@ -154,16 +165,16 @@ ADE_FUNC(getHeight, l_Texture, NULL, "Gets texture height", "number", "Texture h
 
 ADE_FUNC(getFPS, l_Texture, NULL,"Gets frames-per-second of texture", "number", "Texture FPS, or 0 if handle is invalid")
 {
-	int idx;
-	if(!ade_get_args(L, "o", l_Texture.Get(&idx)))
+	texture_h* th;
+	if (!ade_get_args(L, "o", l_Texture.GetPtr(&th)))
 		return ade_set_error(L, "i", 0);
 
-	if(!bm_is_valid(idx))
+	if (!th->isValid())
 		return ade_set_error(L, "i", 0);
 
 	int fps=-1;
 
-	if(bm_get_info(idx, NULL, NULL, NULL, NULL, &fps) < 0)
+	if (bm_get_info(th->handle, NULL, NULL, NULL, NULL, &fps) < 0)
 		return ade_set_error(L, "i", 0);
 
 	return ade_set_args(L, "i", fps);
@@ -171,16 +182,16 @@ ADE_FUNC(getFPS, l_Texture, NULL,"Gets frames-per-second of texture", "number", 
 
 ADE_FUNC(getFramesLeft, l_Texture, NULL, "Gets number of frames left, from handle's position in animation", "number", "Frames left, or 0 if handle is invalid")
 {
-	int idx;
-	if(!ade_get_args(L, "o", l_Texture.Get(&idx)))
+	texture_h* th;
+	if (!ade_get_args(L, "o", l_Texture.GetPtr(&th)))
 		return ADE_RETURN_NIL;
 
-	if(!bm_is_valid(idx))
+	if (!th->isValid())
 		return ADE_RETURN_NIL;
 
 	int num=-1;
 
-	if(bm_get_info(idx, NULL, NULL, NULL, &num) < 0)
+	if (bm_get_info(th->handle, NULL, NULL, NULL, &num) < 0)
 		return ade_set_error(L, "i", 0);
 
 	return ade_set_args(L, "i", num);
@@ -193,22 +204,22 @@ ADE_FUNC(getFrame, l_Texture, "number Elapsed time (secs), [boolean Loop]",
 		 "integer",
 		 "Frame number")
 {
-	int idx, frame = 0;
+	texture_h* th;
+	int frame = 0;
 	float elapsed_time;
 	bool loop = false;
 
-	if (!ade_get_args(L, "of|b", l_Texture.Get(&idx), &elapsed_time, &loop))
+	if (!ade_get_args(L, "of|b", l_Texture.GetPtr(&th), &elapsed_time, &loop))
 		return ADE_RETURN_NIL;
 
-	if (!bm_is_valid(idx))
+	if (!th->isValid())
 		return ADE_RETURN_NIL;
 
-	frame = bm_get_anim_frame(idx, elapsed_time, 0.0f, loop);
+	frame = bm_get_anim_frame(th->handle, elapsed_time, 0.0f, loop);
 	frame++;  // C++ to LUA array idx
 
 	return ade_set_args(L, "i", frame);
 }
-
 
 }
 }

--- a/code/scripting/api/objs/texture.cpp
+++ b/code/scripting/api/objs/texture.cpp
@@ -27,10 +27,10 @@ texture_h::~texture_h()
 		bm_release(handle);
 }
 bool texture_h::isValid() const { return bm_is_valid(handle) != 0; }
-texture_h::texture_h(texture_h&& other) {
+texture_h::texture_h(texture_h&& other) noexcept {
 	*this = std::move(other);
 }
-texture_h& texture_h::operator=(texture_h&& other) {
+texture_h& texture_h::operator=(texture_h&& other) noexcept {
 	std::swap(handle, other.handle);
 	return *this;
 }
@@ -76,7 +76,7 @@ ADE_INDEXER(l_Texture, "number",
 
 	//Get me some info
 	int num=-1;
-	int first = bm_get_info(th->handle, NULL, NULL, NULL, &num);
+	int first = bm_get_info(th->handle, nullptr, nullptr, nullptr, &num);
 
 	//Check it's a valid one
 	if(first < 0 || frame > num)
@@ -157,7 +157,7 @@ ADE_FUNC(getHeight, l_Texture, NULL, "Gets texture height", "number", "Texture h
 
 	int h=-1;
 
-	if (bm_get_info(th->handle, NULL, &h) < 0)
+	if (bm_get_info(th->handle, nullptr, &h) < 0)
 		return ade_set_error(L, "i", 0);
 
 	return ade_set_args(L, "i", h);
@@ -174,7 +174,7 @@ ADE_FUNC(getFPS, l_Texture, NULL,"Gets frames-per-second of texture", "number", 
 
 	int fps=-1;
 
-	if (bm_get_info(th->handle, NULL, NULL, NULL, NULL, &fps) < 0)
+	if (bm_get_info(th->handle, nullptr, nullptr, nullptr, nullptr, &fps) < 0)
 		return ade_set_error(L, "i", 0);
 
 	return ade_set_args(L, "i", fps);
@@ -191,7 +191,7 @@ ADE_FUNC(getFramesLeft, l_Texture, NULL, "Gets number of frames left, from handl
 
 	int num=-1;
 
-	if (bm_get_info(th->handle, NULL, NULL, NULL, &num) < 0)
+	if (bm_get_info(th->handle, nullptr, nullptr, nullptr, &num) < 0)
 		return ade_set_error(L, "i", 0);
 
 	return ade_set_args(L, "i", num);

--- a/code/scripting/api/objs/texture.h
+++ b/code/scripting/api/objs/texture.h
@@ -7,7 +7,24 @@
 namespace scripting {
 namespace api {
 
-DECLARE_ADE_OBJ(l_Texture, int);
+struct texture_h {
+	int handle = -1;
+
+	texture_h();
+	explicit texture_h(int bm);
+
+	~texture_h();
+
+	texture_h(const texture_h&) = delete;
+	texture_h& operator=(const texture_h&) = delete;
+
+	texture_h(texture_h&&);
+	texture_h& operator=(texture_h&&);
+
+	bool isValid() const;
+};
+
+DECLARE_ADE_OBJ(l_Texture, texture_h);
 
 }
 }

--- a/code/scripting/api/objs/texture.h
+++ b/code/scripting/api/objs/texture.h
@@ -18,8 +18,8 @@ struct texture_h {
 	texture_h(const texture_h&) = delete;
 	texture_h& operator=(const texture_h&) = delete;
 
-	texture_h(texture_h&&);
-	texture_h& operator=(texture_h&&);
+	texture_h(texture_h&&) noexcept;
+	texture_h& operator=(texture_h&&) noexcept;
 
 	bool isValid() const;
 };

--- a/code/scripting/api/objs/texturemap.cpp
+++ b/code/scripting/api/objs/texturemap.cpp
@@ -69,55 +69,55 @@ ADE_OBJ(l_TextureMap, texture_map_h, "material", "Texture map, including diffuse
 ADE_VIRTVAR(BaseMap, l_TextureMap, "texture", "Base texture", "texture", "Base texture, or invalid texture handle if material handle is invalid")
 {
 	texture_map_h *tmh = NULL;
-	int new_tex = -1;
-	if(!ade_get_args(L, "o|o", l_TextureMap.GetPtr(&tmh), l_Texture.Get(&new_tex)))
-		return ade_set_error(L, "o", l_Texture.Set(-1));
+	texture_h* new_tex = nullptr;
+	if(!ade_get_args(L, "o|o", l_TextureMap.GetPtr(&tmh), l_Texture.GetPtr(&new_tex)))
+		return ade_set_error(L, "o", l_Texture.Set(texture_h()));
 
 	texture_map *tmap = tmh->Get();
 	if(tmap == NULL)
-		return ade_set_error(L, "o", l_Texture.Set(-1));
+		return ade_set_error(L, "o", l_Texture.Set(texture_h()));
 
-	if(ADE_SETTING_VAR && new_tex > -1) {
-		tmap->textures[TM_BASE_TYPE].SetTexture(new_tex);
+	if(ADE_SETTING_VAR && new_tex->isValid()) {
+		tmap->textures[TM_BASE_TYPE].SetTexture(new_tex->handle);
 	}
 
-	return ade_set_args(L, "o", l_Texture.Set(tmap->textures[TM_BASE_TYPE].GetTexture()));
+	return ade_set_args(L, "o", l_Texture.Set(texture_h(tmap->textures[TM_BASE_TYPE].GetTexture())));
 }
 
 ADE_VIRTVAR(GlowMap, l_TextureMap, "texture", "Glow texture", "texture", "Glow texture, or invalid texture handle if material handle is invalid")
 {
 	texture_map_h *tmh = NULL;
-	int new_tex = -1;
-	if(!ade_get_args(L, "o|o", l_TextureMap.GetPtr(&tmh), l_Texture.Get(&new_tex)))
-		return ade_set_error(L, "o", l_Texture.Set(-1));
+	texture_h* new_tex = nullptr;
+	if(!ade_get_args(L, "o|o", l_TextureMap.GetPtr(&tmh), l_Texture.GetPtr(&new_tex)))
+		return ade_set_error(L, "o", l_Texture.Set(texture_h()));
 
 	texture_map *tmap = tmh->Get();
 	if(tmap == NULL)
-		return ade_set_error(L, "o", l_Texture.Set(-1));
+		return ade_set_error(L, "o", l_Texture.Set(texture_h()));
 
-	if(ADE_SETTING_VAR && new_tex > -1) {
-		tmap->textures[TM_GLOW_TYPE].SetTexture(new_tex);
+	if(ADE_SETTING_VAR && new_tex->isValid()) {
+		tmap->textures[TM_GLOW_TYPE].SetTexture(new_tex->handle);
 	}
 
-	return ade_set_args(L, "o", l_Texture.Set(tmap->textures[TM_GLOW_TYPE].GetTexture()));
+	return ade_set_args(L, "o", l_Texture.Set(texture_h(tmap->textures[TM_GLOW_TYPE].GetTexture())));
 }
 
 ADE_VIRTVAR(SpecularMap, l_TextureMap, "texture", "Specular texture", "texture", "Texture handle, or invalid texture handle if material handle is invalid")
 {
 	texture_map_h *tmh = NULL;
-	int new_tex = -1;
-	if(!ade_get_args(L, "o|o", l_TextureMap.GetPtr(&tmh), l_Texture.Get(&new_tex)))
-		return ade_set_error(L, "o", l_Texture.Set(-1));
+	texture_h* new_tex = nullptr;
+	if(!ade_get_args(L, "o|o", l_TextureMap.GetPtr(&tmh), l_Texture.GetPtr(&new_tex)))
+		return ade_set_error(L, "o", l_Texture.Set(texture_h()));
 
 	texture_map *tmap = tmh->Get();
 	if(tmap == NULL)
-		return ade_set_error(L, "o", l_Texture.Set(-1));
+		return ade_set_error(L, "o", l_Texture.Set(texture_h()));
 
-	if(ADE_SETTING_VAR && new_tex > -1) {
-		tmap->textures[TM_SPECULAR_TYPE].SetTexture(new_tex);
+	if(ADE_SETTING_VAR && new_tex->isValid()) {
+		tmap->textures[TM_SPECULAR_TYPE].SetTexture(new_tex->handle);
 	}
 
-	return ade_set_args(L, "o", l_Texture.Set(tmap->textures[TM_SPECULAR_TYPE].GetTexture()));
+	return ade_set_args(L, "o", l_Texture.Set(texture_h(tmap->textures[TM_SPECULAR_TYPE].GetTexture())));
 }
 
 }

--- a/code/scripting/api/objs/waypoint.cpp
+++ b/code/scripting/api/objs/waypoint.cpp
@@ -73,7 +73,7 @@ ADE_INDEXER(l_WaypointList, "number Index", "Array of waypoints that are part of
 	sprintf(wpname, "%s:%d", wlh->wlp->get_name(), calc_waypoint_index(idx) + 1);
 	waypoint *wpt = find_matching_waypoint( wpname );
 	if( (idx >= 0) && ((uint) idx < wlh->wlp->get_waypoints().size()) && (wpt != NULL) && (wpt->get_objnum() >= 0) ) {
-		return ade_set_args( L, "o", l_Waypoint.Set( object_h( &Objects[wpt->get_objnum()] ), Objects[wpt->get_objnum()].signature ) );
+		return ade_set_args(L, "o", l_Waypoint.Set(object_h(&Objects[wpt->get_objnum()])));
 	}
 
 	return ade_set_error(L, "o", l_Waypoint.Set( object_h() ) );

--- a/code/scripting/api/objs/weapon.cpp
+++ b/code/scripting/api/objs/weapon.cpp
@@ -323,7 +323,7 @@ ADE_FUNC(getCollisionInformation, l_Weapon, NULL, "Returns the collision informa
 	weapon *wp = &Weapons[oh->objp->instance];
 
 	if (wp->collisionInfo != nullptr)
-		return ade_set_args(L, "o", l_ColInfo.Set(mc_info_h(new mc_info(*(wp->collisionInfo)))));
+		return ade_set_args(L, "o", l_ColInfo.Set(mc_info_h(*wp->collisionInfo)));
 	else
 		return ade_set_args(L, "o", l_ColInfo.Set(mc_info_h()));
 }

--- a/code/scripting/lua/LuaConvert.cpp
+++ b/code/scripting/lua/LuaConvert.cpp
@@ -13,6 +13,32 @@ bool isValidIndex(lua_State* state, int index) {
 	}
 }
 
+bool ade_odata_helper(lua_State* L, int stackposition, size_t idx) {
+	// WMC - Get metatable
+	lua_getmetatable(L, stackposition);
+	int mtb_ldx = lua_gettop(L);
+	Assert(!lua_isnil(L, -1));
+
+	// Get ID
+	lua_pushstring(L, "__adeid");
+	lua_rawget(L, mtb_ldx);
+
+	if (lua_tonumber(L, -1) != idx) {
+		lua_pushstring(L, "__adederivid");
+		lua_rawget(L, mtb_ldx);
+		if ((size_t)lua_tointeger(L, -1) != idx) {
+			// Issue the LuaError here since this is the only place where we have all relevant information
+			LuaError(L, "Argument %d is the wrong type of userdata; '%s' given, but '%s' expected", stackposition,
+			         ::scripting::internal::getTableEntry((size_t)lua_tointeger(L, -2)).Name,
+			         ::scripting::internal::getTableEntry(idx).GetName());
+			return false;
+		}
+		lua_pop(L, 1);
+	}
+	lua_pop(L, 2);
+	return true;
+}
+
 }
 
 void pushValue(lua_State* luaState, const double& value) {
@@ -138,44 +164,6 @@ bool popValue(lua_State* luaState, lua_CFunction& target, int stackposition, boo
 
 		return true;
 	}
-}
-
-bool popValue(lua_State* L, scripting::ade_odata& od, int stackposition, bool remove) {
-	//WMC - Get metatable
-	lua_getmetatable(L, stackposition);
-	int mtb_ldx = lua_gettop(L);
-	Assert(!lua_isnil(L, -1));
-
-	//Get ID
-	lua_pushstring(L, "__adeid");
-	lua_rawget(L, mtb_ldx);
-
-	if (lua_tonumber(L, -1) != od.idx)
-	{
-		lua_pushstring(L, "__adederivid");
-		lua_rawget(L, mtb_ldx);
-		if ((size_t)lua_tointeger(L, -1) != od.idx) {
-			// Issue the LuaError here since this is the only place where we have all relevant information
-			LuaError(L, "Argument %d is the wrong type of userdata; '%s' given, but '%s' expected", stackposition,
-			         ::scripting::internal::getTableEntry((size_t)lua_tointeger(L, -2)).Name,
-			         ::scripting::internal::getTableEntry(od.idx).GetName());
-			return false;
-		}
-		lua_pop(L, 1);
-	}
-	lua_pop(L, 2);
-	if (od.size != scripting::ODATA_PTR_SIZE) {
-		memcpy(od.buf, lua_touserdata(L, stackposition), od.size);
-	}
-	else {
-		*(void**)od.buf = lua_touserdata(L, stackposition);
-	}
-
-	if (remove) {
-		lua_remove(L, stackposition);
-	}
-
-	return true;
 }
 
 }

--- a/code/scripting/lua/LuaConvert.h
+++ b/code/scripting/lua/LuaConvert.h
@@ -49,7 +49,24 @@ void pushValue(lua_State* luaState, const bool& value);
 
 void pushValue(lua_State* luaState, const lua_CFunction& value);
 
-void pushValue(lua_State* L, const scripting::ade_odata& value);
+template<typename T>
+void pushValue(lua_State* L, scripting::ade_odata_setter<T>&& value) {
+	using namespace scripting;
+
+	//WMC - char must be 1 byte, foo.
+	static_assert(sizeof(char) == 1, "char must be 1 byte!");
+	//WMC - step by step
+
+	//Create new LUA object and get handle
+	char *newod = (char*)lua_newuserdata(L, sizeof(T));
+	//Create or get object metatable
+	luaL_getmetatable(L, ::scripting::internal::getTableEntry(value.idx).Name);
+	//Set the metatable for the object
+	lua_setmetatable(L, -2);
+
+	//Copy the actual object data to the Lua object
+	new(newod) T(std::move(value.value));
+}
 
 /**
  * @brief Convenience function for string literals

--- a/code/scripting/lua/LuaConvert.h
+++ b/code/scripting/lua/LuaConvert.h
@@ -58,7 +58,7 @@ void pushValue(lua_State* L, scripting::ade_odata_setter<T>&& value) {
 	//WMC - step by step
 
 	//Create new LUA object and get handle
-	char *newod = (char*)lua_newuserdata(L, sizeof(T));
+	auto newod = (char*)lua_newuserdata(L, sizeof(T));
 	//Create or get object metatable
 	luaL_getmetatable(L, ::scripting::internal::getTableEntry(value.idx).Name);
 	//Set the metatable for the object

--- a/code/scripting/lua/LuaValue.h
+++ b/code/scripting/lua/LuaValue.h
@@ -47,10 +47,10 @@ class LuaValue {
      * @return luacpp::LuaValue A new LuaValue instance which references the specified value
      */
 	template<class ValueType>
-	static LuaValue createValue(lua_State* state, const ValueType& value) {
+	static LuaValue createValue(lua_State* state, ValueType&& value) {
 		LuaValue retVal(state);
 
-		convert::pushValue(state, value);
+		convert::pushValue(state, std::forward<ValueType>(value));
 
 		retVal.setReference(UniqueLuaReference::create(state));
 

--- a/code/scripting/scripting.h
+++ b/code/scripting/scripting.h
@@ -209,7 +209,7 @@ public:
 	//void MoveData(script_state &in);
 
 	template<typename T>
-	void SetHookVar(const char *name, char format, T value);
+	void SetHookVar(const char *name, char format, T&& value);
 	void SetHookObject(const char *name, object *objp);
 	void SetHookObjects(int num, ...);
 	void RemHookVar(const char *name);
@@ -237,7 +237,7 @@ public:
 };
 
 template<typename T>
-void script_state::SetHookVar(const char *name, char format, T value)
+void script_state::SetHookVar(const char *name, char format, T&& value)
 {
 	if(format == '\0')
 		return;
@@ -250,7 +250,7 @@ void script_state::SetHookVar(const char *name, char format, T value)
 		{
 			int amt_ldx = lua_gettop(LuaState);
 			lua_pushstring(LuaState, name);
-			scripting::ade_set_args(LuaState, fmt, value);
+			scripting::ade_set_args(LuaState, fmt, std::forward<T>(value));
 			//--------------------
 			//WMC - This was a separate function
 			//lua_set_arg(LuaState, format, data);


### PR DESCRIPTION
The current situation is that the scripting API depends on a lot of undefined behavior for making it work. For example, the C++ objects were moved into Lua objects by using `memcpy` which caused issues if the C++ object was not trivially copyable.

The reason for this was that the `ade_set_args`/`ade_get_args` functions did not have access to the C++ type information since it used the C-style varargs for passing a variable number of parameters to Lua. Since C++11 has "proper" support for variadic arguments with full type information, that can be used for improving the C++/Lua API so that non-trivial objects can also be used.

The way this works is that when a C++ object is passed to Lua via `ade_obj.Set` it is copied or moved into an internal variable. The returned object is typed so when it is passed to `ade_set_args`, the Lua API still has access to the type information of the contained object. Then `lua_newuserdata` is used for allocating raw storage for the object. This storage is used for constructing a new instance of the underlying C++ object by using placement-new. Again, the object previously passed to the Lua argument API is moved or copied into the memory provided by Lua at which point the C++ object is entirely inside the Lua state without the usage of undefined behavior. This also allows to use move-only types with the Lua API.

Getting arguments is much easier than setting them so I won't go into detail how that works here.