### PR TITLE
Only play UI sounds if the event is triggered on the element where the property is set.

### DIFF
--- a/code/scpui/SoundPlugin.cpp
+++ b/code/scpui/SoundPlugin.cpp
@@ -169,6 +169,9 @@ bool SoundPlugin::PlayElementSound(Element* element, const String& event, const 
 
 void SoundPlugin::SoundEventHandler::ProcessEvent(Event& event)
 {
-	SoundPlugin::instance()->PlayElementSound(event.GetCurrentElement(), event.GetType());
+	// Hover events bubble up so ignore any mouse movement events that aren't caused by the target element
+	if ((event.GetType() != "mouseover" && event.GetType() != "mouseout") || event.GetPhase() == Event::PHASE_TARGET) {
+		SoundPlugin::instance()->PlayElementSound(event.GetCurrentElement(), event.GetType());
+	}
 }
 } // namespace scpui


### PR DESCRIPTION
Currently if an element consists of multiple parts, the hover sound will be played even while moving between these parts.
For example if you move between the text label and icon on the pilot select screen, you'll hear the hover sound even though you never leave the button.

This PR fixes this by only acting on events that are triggered on the element where the sound property is set and ignoring any other events that propagate from children.