### PR TITLE
Make player warpout settings customizable

### DIFF
--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -15,6 +15,7 @@
 #include "mod_table/mod_table.h"
 #include "parse/parselo.h"
 #include "sound/sound.h"
+#include "playerman/player.h"
 
 int Directive_wait_time;
 bool True_loop_argument_sexps;
@@ -397,6 +398,18 @@ void parse_mod_table(const char *filename)
 			} else {
 				mprintf(("Game Settings Table: Disabled external default scripts.\n"));
 			}
+		}
+
+		if (optional_string("$Player warpout speed:")) {
+			stuff_float(&Player_warpout_speed);
+		}
+		
+		if (optional_string("$Target warpout match percent:")) {
+			stuff_float(&Target_warpout_match_percent);
+		}
+
+		if (optional_string("$Minimum player warpout time:")) {
+			stuff_float(&Minimum_player_warpout_time);
 		}
 
 		required_string("#END");

--- a/code/playerman/player.h
+++ b/code/playerman/player.h
@@ -279,9 +279,9 @@ camid player_get_cam();
 
 //=============================================================
 //===================== PLAYER WARPOUT STUFF ==================
-#define PLAYER_WARPOUT_SPEED 40.0f		// speed you need to be going to warpout
-#define TARGET_WARPOUT_MATCH_PERCENT 0.05f	// how close to TARGET_WARPOUT_SPEED you need to be
-#define MINIMUM_PLAYER_WARPOUT_TIME	3.0f		// How long before you can press 'ESC' to abort warpout
+extern float Player_warpout_speed;	// speed you need to be going to warpout
+extern float Target_warpout_match_percent;	// how close to TARGET_WARPOUT_SPEED you need to be
+extern float Minimum_player_warpout_time;		// How long before you can press 'ESC' to abort warpout
 
 extern float Warpout_time;							// Declared in freespace.cpp
 extern int Warpout_forced;							// If non-zero, bash the player to speed and go through effect

--- a/code/playerman/playercontrol.cpp
+++ b/code/playerman/playercontrol.cpp
@@ -68,6 +68,10 @@ int press_glide = 0;
 ////////////////////////////////////////////////////////////
 static int Player_all_alone_msg_inited=0;	// flag used for initializing a player-specific voice msg
 
+float Player_warpout_speed = 40.0f;
+float Target_warpout_match_percent = 0.05f;
+float Minimum_player_warpout_time = 3.0f;
+
 #ifndef NDEBUG
 	int Show_killer_weapon = 0;
 	DCF_BOOL( show_killer_weapon, Show_killer_weapon )
@@ -1060,7 +1064,7 @@ void read_player_controls(object *objp, float frametime)
 					if (sip->warpout_engage_time >= 0)
 						warpout_delay = sip->warpout_engage_time / 1000.0f;
 					else
-						warpout_delay = MINIMUM_PLAYER_WARPOUT_TIME;
+						warpout_delay = Minimum_player_warpout_time;
 
 					// Wait at least 3 seconds before making sure warp speed is set.
 					if ( Warpout_time > warpout_delay) {
@@ -1069,7 +1073,7 @@ void read_player_controls(object *objp, float frametime)
 						if(target_warpout_speed != 0.0f) {
 							diffSpeed = fl_abs(objp->phys_info.fspeed - target_warpout_speed )/target_warpout_speed;
 						}
-						if ( diffSpeed < TARGET_WARPOUT_MATCH_PERCENT )	{
+						if ( diffSpeed < Target_warpout_match_percent)	{
 							gameseq_post_event( GS_EVENT_PLAYER_WARPOUT_DONE_STAGE1 );
 						}
 					}

--- a/code/ship/shipfx.cpp
+++ b/code/ship/shipfx.cpp
@@ -495,7 +495,7 @@ float shipfx_calculate_warp_time(object *objp, int warp_dir)
 			return ship_class_get_length(sip) / sip->warpout_player_speed;
 		//Player warpout not defined
 		} else if ( (warp_dir == WD_WARP_OUT) && (objp == Player_obj) ) {
-			return ship_class_get_length(sip) / PLAYER_WARPOUT_SPEED;
+			return ship_class_get_length(sip) / Player_warpout_speed;
 		}
 
 	}


### PR DESCRIPTION
This converts the player warpout defines into variables that can be set from the mod_settings.tbl.
This was done at the request of Spoon and Axem because the exponential thrust curve screws over a fair chunk of ships from WoD, making them take an egregious amount of time to warp out.