### PR TITLE
Barracks stats adaptation for longer Unicode strings.

### DIFF
--- a/code/menuui/barracks.cpp
+++ b/code/menuui/barracks.cpp
@@ -37,7 +37,7 @@
 
 // stats defines
 //#define NUM_STAT_LINES (21 + MAX_SHIP_CLASSES)	// Goober5000
-#define STAT_COLUMN1_W 40
+#define STAT_COLUMN1_W 40*2							// as we might use Unicode //ksotar
 #define STAT_COLUMN2_W 10
 
 static int Stat_column1_w[GR_NUM_RESOLUTIONS] =
@@ -76,7 +76,7 @@ static int Barracks_stats_coords[GR_NUM_RESOLUTIONS][4] = {
 		32, 212, 240, 250
 	},
 	{ // GR_1024
-		42, 351, 240, 400
+		42, 351, 350, 400
 	}
 };
 
@@ -85,7 +85,7 @@ static int Barracks_stats2_coords[GR_NUM_RESOLUTIONS][3] = {
 		276, 212, 81		// X2, , W2
 	},
 	{ // GR_1024
-		286, 351, 81		// X2, , W2
+		396, 351, 81		// X2, , W2
 	}
 };
 


### PR DESCRIPTION
Originally there is many unused space for stats listing even in 1024 resolution.

![2018-10-08 23 54 51](https://user-images.githubusercontent.com/21180686/46746187-2a909500-ccb7-11e8-91cc-8f5d34da4764.png)

This change widens used space, so more wide languages can fit there too. Also it uses 2x space to store those strings. Result is like that: 

![2018-10-08 23 49 12](https://user-images.githubusercontent.com/21180686/46746284-717e8a80-ccb7-11e8-8938-58173f01e8cc.png)

Original also appears in more centrist view:

![2018-10-10 17 43 44](https://user-images.githubusercontent.com/21180686/46746501-d9cd6c00-ccb7-11e8-91d6-9c049e5f0bc5.png)




