### PR TITLE
Fixes missing "On Ship Arrive" with Docked Wings

### DIFF
--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -2491,16 +2491,18 @@ void parse_bring_in_docked_wing(p_object *p_objp, int wingnum, int shipnum)
 
 	//fixes bug where docked wings are not called with the 'On Ship Arrive' hook variable --wookieejedi
 	int num_ships = wingp->current_count;
-	int anchor_objnum = -1;
-	anchor_objnum = mission_set_arrival_location(wingp->arrival_anchor, wingp->arrival_location, wingp->arrival_distance, OBJ_INDEX(leader_objp), wingp->arrival_path_mask, &pos, &orient);
 	if (num_ships > 0 && Game_mode & GM_IN_MISSION) {
-		for ( index = wingp->current_count - num_ships; index < wingp->current_count; index ++ ) {
+		int anchor_objnum = -1;
+		int shipnum;
+		shipnum = ship_name_lookup(Parse_names[wingp->arrival_anchor]);
+		anchor_objnum = Ships[shipnum].objnum;
+		for ( index = 0; index < num_ships; index ++ ) {
 			object *objp = &Objects[Ships[wingp->ship_index[index]].objnum];
 
 			if (anchor_objnum >= 0)
 				Script_system.SetHookObjects(2, "Ship", objp, "Parent", &Objects[anchor_objnum]);
 			else
-				Script_system.SetHookObjects(2, "Ship", objp, "Parent", NULL);
+				Script_system.SetHookObjects(2, "Ship", objp, "Parent", nullptr);
 
 			Script_system.RunCondition(CHA_ONSHIPARRIVE, objp);
 			Script_system.RemHookVars(2, "Ship", "Parent");

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -2449,6 +2449,13 @@ int parse_create_object_sub(p_object *p_objp)
 		Script_system.RemHookVars(2, "Ship", "Parent");
 	}
 
+	// The ship is in a wing, but is docked. Adding this block ensures that docked ships actually execute "On Ship Arrive". --wookieejedi
+	if (Game_mode & GM_IN_MISSION && shipp->wingnum != -1 && object_is_docked(pobjp)) {
+		Script_system.SetHookObjects(2, "Ship", &Objects[objnum], "Parent", nullptr);
+		Script_system.RunCondition(CHA_ONSHIPARRIVE, &Objects[objnum]);
+		Script_system.RemHookVars(2, "Ship", "Parent");
+	}	
+
 	return objnum;
 }
 
@@ -2489,26 +2496,6 @@ void parse_bring_in_docked_wing(p_object *p_objp, int wingnum, int shipnum)
 	// make sure we haven't created too many ships
 	Assert(wingp->current_count <= MAX_SHIPS_PER_WING);
 
-	//fixes bug where docked wings are not called with the 'On Ship Arrive' hook variable --wookieejedi
-	int num_ships = wingp->current_count;
-	if (num_ships > 0 && Game_mode & GM_IN_MISSION) {
-		int anchor_objnum = -1;
-		int shipnum;
-		shipnum = ship_name_lookup(Parse_names[wingp->arrival_anchor]);
-		anchor_objnum = Ships[shipnum].objnum;
-		for ( index = 0; index < num_ships; index ++ ) {
-			object *objp = &Objects[Ships[wingp->ship_index[index]].objnum];
-
-			if (anchor_objnum >= 0)
-				Script_system.SetHookObjects(2, "Ship", objp, "Parent", &Objects[anchor_objnum]);
-			else
-				Script_system.SetHookObjects(2, "Ship", objp, "Parent", nullptr);
-
-			Script_system.RunCondition(CHA_ONSHIPARRIVE, objp);
-			Script_system.RemHookVars(2, "Ship", "Parent");
-		}
-	}
-	
 	// at this point the wing has arrived, so handle the stuff for this particular ship
 
 	// set up wingman status index

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -2444,7 +2444,7 @@ int parse_create_object_sub(p_object *p_objp)
 
 	// If the ship is in a wing, this will be done in mission_set_wing_arrival_location() instead
 	// If the ship is in a wing, but the wing is docked then addition of bool brought_in_docked_wing accounts for that status --wookieejedi
-	if (Game_mode & GM_IN_MISSION && ((shipp->wingnum == -1) || (brought_in_docked_wing == true))) {
+	if (Game_mode & GM_IN_MISSION && ((shipp->wingnum == -1) || (brought_in_docked_wing))) {
 		if (anchor_objnum >= 0)
 			Script_system.SetHookObjects(2, "Ship", &Objects[objnum], "Parent", &Objects[anchor_objnum]);
 		else

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -2450,7 +2450,7 @@ int parse_create_object_sub(p_object *p_objp)
 	}
 
 	// The ship is in a wing, but is docked. Adding this block ensures that docked ships actually execute "On Ship Arrive". --wookieejedi
-	if (Game_mode & GM_IN_MISSION && shipp->wingnum != -1 && object_is_docked(pobjp)) {
+	if (Game_mode & GM_IN_MISSION && shipp->wingnum != -1 && object_is_docked(p_objp)) {
 		Script_system.SetHookObjects(2, "Ship", &Objects[objnum], "Parent", nullptr);
 		Script_system.RunCondition(CHA_ONSHIPARRIVE, &Objects[objnum]);
 		Script_system.RemHookVars(2, "Ship", "Parent");

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -2444,7 +2444,7 @@ int parse_create_object_sub(p_object *p_objp)
 
 	// If the ship is in a wing, this will be done in mission_set_wing_arrival_location() instead
 	// If the ship is in a wing, but the wing is docked then addition of bool brought_in_docked_wing accounts for that status --wookieejedi
-	if (Game_mode & GM_IN_MISSION && (shipp->wingnum == -1 || brought_in_docked_wing)) {
+	if (Game_mode & GM_IN_MISSION && (shipp->wingnum == -1 || brought_in_docked_wing == true )) {
 		if (anchor_objnum >= 0)
 			Script_system.SetHookObjects(2, "Ship", &Objects[objnum], "Parent", &Objects[anchor_objnum]);
 		else

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -2444,7 +2444,7 @@ int parse_create_object_sub(p_object *p_objp)
 
 	// If the ship is in a wing, this will be done in mission_set_wing_arrival_location() instead
 	// If the ship is in a wing, but the wing is docked then addition of bool brought_in_docked_wing accounts for that status --wookieejedi
-	if (Game_mode & GM_IN_MISSION && (shipp->wingnum == -1 || brought_in_docked_wing == true )) {
+	if (Game_mode & GM_IN_MISSION && ((shipp->wingnum == -1) || (brought_in_docked_wing == true))) {
 		if (anchor_objnum >= 0)
 			Script_system.SetHookObjects(2, "Ship", &Objects[objnum], "Parent", &Objects[anchor_objnum]);
 		else


### PR DESCRIPTION
Fixes bug by adding the conditional hook call "On Ship Arrive" to docked wings that arrive. Previously, ships in a docked wing that would arrive would not trigger the "On Ship Arrive" hook variable. 