### PR TITLE
Fixes Bug with Docked Ships and Warpin

### DIFF
--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -2458,7 +2458,8 @@ int parse_create_object_sub(p_object *p_objp)
 		if (object_is_docked(p_objp) && !(p_objp->flags[Mission::Parse_Object_Flags::SF_Dock_leader])) {
 			object* objp;
 			objp = p_objp->created_object;
-			shipfx_warpin_start(objp);		
+			shipfx_warpin_start(objp);	
+		}			
 	}
 
 	return objnum;

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -2452,6 +2452,13 @@ int parse_create_object_sub(p_object *p_objp)
 
 		Script_system.RunCondition(CHA_ONSHIPARRIVE, &Objects[objnum]);
 		Script_system.RemHookVars(2, "Ship", "Parent");
+		
+		// This ensures that a docked ship will not arrive instantly if the ship it is docked to is using a warpin effect
+		// The parent conditions in this 'if' block accounts for both docked ships not in wings and docked ships in wings --wookieejedi
+		if (object_is_docked(p_objp) && !(p_objp->flags[Mission::Parse_Object_Flags::SF_Dock_leader])) {
+			object* objp;
+			objp = p_objp->created_object;
+			shipfx_warpin_start(objp);		
 	}
 
 	return objnum;


### PR DESCRIPTION
Fixes issue #1867. This ensures that a docked ship will not arrive instantly if the ship it is docked to is using a warpin effect. The parent conditions of this 'if' block accounts for both docked ships not in wings and docked ships in wings. I have test this with retail and it doesn't cause any issues. 