### PR TITLE
Fix missing HUD bug

### DIFF
--- a/code/hud/hudconfig.cpp
+++ b/code/hud/hudconfig.cpp
@@ -1633,6 +1633,7 @@ void hud_config_as_observer(ship *shipp,ai_info *aif)
 
 void hud_config_as_player()
 {
+	hud_config_restore();
 } 
 
 // ---------------------------------------------------------------------------------------------------------------

--- a/code/network/multi_endgame.cpp
+++ b/code/network/multi_endgame.cpp
@@ -22,7 +22,8 @@
 #include "network/multiui.h"
 #include "network/multiutil.h"
 #include "network/multi_pmsg.h"
-#include "network/multi_observer.h"
+#include "hud/hudconfig.h"
+//#include "network/multi_observer.h"
 #include "fs2netd/fs2netd_client.h"
 
 
@@ -323,8 +324,8 @@ void multi_endgame_cleanup()
 {
 	int idx;
 
-	if (Player_obj->type == OBJ_OBSERVER) {		// Do not forget restore players HUD
-		multi_obs_restore_hud();
+	if (HUD_config.is_observer) {		// Do not forget restore players HUD
+		hud_config_restore();
 	}
 
 	send_leave_game_packet();			

--- a/code/network/multi_endgame.cpp
+++ b/code/network/multi_endgame.cpp
@@ -22,6 +22,7 @@
 #include "network/multiui.h"
 #include "network/multiutil.h"
 #include "network/multi_pmsg.h"
+#include "network/multi_observer.h"
 #include "fs2netd/fs2netd_client.h"
 
 
@@ -321,6 +322,10 @@ int multi_quit_game(int prompt, int notify_code, int err_code, int wsa_error)
 void multi_endgame_cleanup()
 {
 	int idx;
+
+	if (Player_obj->type == OBJ_OBSERVER) {		// Do not forget restore players HUD
+		multi_obs_restore_hud();
+	}
 
 	send_leave_game_packet();			
 

--- a/code/network/multi_observer.cpp
+++ b/code/network/multi_observer.cpp
@@ -216,3 +216,7 @@ void multi_obs_zoom_to_target()
 	// move
 	vm_vec_add2(&Player_obj->pos,&direct);
 }
+
+void multi_obs_restore_hud() {
+	hud_config_restore();
+}

--- a/code/network/multi_observer.cpp
+++ b/code/network/multi_observer.cpp
@@ -216,7 +216,3 @@ void multi_obs_zoom_to_target()
 	// move
 	vm_vec_add2(&Player_obj->pos,&direct);
 }
-
-void multi_obs_restore_hud() {
-	hud_config_restore();
-}

--- a/code/network/multi_observer.h
+++ b/code/network/multi_observer.h
@@ -42,4 +42,6 @@ void multi_obs_level_init();
 // if i'm an observer, zoom to near my targted object (if any)
 void multi_obs_zoom_to_target();
 
+void multi_obs_restore_hud();
+
 #endif

--- a/code/network/multi_observer.h
+++ b/code/network/multi_observer.h
@@ -42,6 +42,4 @@ void multi_obs_level_init();
 // if i'm an observer, zoom to near my targted object (if any)
 void multi_obs_zoom_to_target();
 
-void multi_obs_restore_hud();
-
 #endif

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -5760,6 +5760,9 @@ void game_enter_state( int old_state, int new_state )
 		case GS_STATE_DEBRIEF:
 			game_stop_looped_sounds();
 			mission_goal_fail_incomplete();				// fail all incomplete goals before entering debriefing
+			if (HUD_config.is_observer) {				// restore player's HUD if it was observer
+				hud_config_restore();
+			}
 			if ( (old_state != GS_STATE_VIEW_MEDALS) && (old_state != GS_STATE_OPTIONS_MENU) ){
 				common_maybe_play_cutscene(MOVIE_PRE_DEBRIEF); 	
 				debrief_init();


### PR DESCRIPTION
It appears that HUD_backup mechanics was implemented (to save players HUD before turning everything off for Observer). But restore was never used. That addresses #1842 , and some requests at HLP forums.