### PR TITLE
Add '$On Ship Depart' Conditional Hook

### DIFF
--- a/code/scripting/scripting.cpp
+++ b/code/scripting/scripting.cpp
@@ -86,6 +86,7 @@ flag_def_list Script_actions[] =
 	{ "On Simulation",			CHA_SIMULATION,		0 },
 	{ "On Load Screen",			CHA_LOADSCREEN,		0 },
 	{ "On Campaign Mission Accept", 	CHA_CMISSIONACCEPT,	0 },
+    { "On Ship Depart",			CHA_ONSHIPDEPART,	0 },
 };
 
 int Num_script_actions = sizeof(Script_actions)/sizeof(flag_def_list);

--- a/code/scripting/scripting.h
+++ b/code/scripting/scripting.h
@@ -101,6 +101,7 @@ extern bool script_hook_valid(script_hook *hook);
 #define CHA_SIMULATION      39
 #define CHA_LOADSCREEN      40
 #define CHA_CMISSIONACCEPT  41
+#define CHA_ONSHIPDEPART	42
 
 // management stuff
 void scripting_state_init();

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -7412,17 +7412,48 @@ static void ship_actually_depart_helper(object *objp, dock_function_info *infop)
 		gameseq_post_event(GS_EVENT_PLAYER_WARPOUT_DONE);
 }
 
+// convert the departure int method to a string --wookieejedi
+static const char* get_departure_name(int method)
+{
+	const char* departname;
+	switch (method) {
+	case SHIP_DEPARTED_WARP: {
+		departname = "SHIP_DEPARTED_WARP";
+		break;
+	};
+	case SHIP_DEPARTED_BAY: {
+		departname = "SHIP_DEPARTED_BAY";
+		break;
+	};
+	case SHIP_VANISHED: {
+		departname = "SHIP_VANISHED";
+		break;
+	};
+	case SHIP_DEPARTED_REDALERT: {
+		departname = "SHIP_DEPARTED_REDALERT";
+		break;
+	};
+	// assume SHIP_DEPARTED
+	default:
+		departname = "SHIP_DEPARTED";
+	};
+	return departname;
+}
+
 /**
  * Used to actually remove a ship, plus all the ships it's docked to, from the mission
  */
 void ship_actually_depart(int shipnum, int method)
 {
 	
+	const char* departmethod = get_departure_name(method);
 	// run "On Ship Depart" conditional hook variable. This hook accounts for all departure types.
+	// Departure types include: SHIP_DEPARTED_BAY, SHIP_VANISHED, SHIP_DEPARTED_REDALERT, and SHIP_DEPARTED_WARP
 	// it is not limited to only warping --wookieejedi
 	Script_system.SetHookObject("Ship", &Objects[Ships[shipnum].objnum]);
+	Script_system.SetHookVar("Method", 's', departmethod);
 	Script_system.RunCondition(CHA_ONSHIPDEPART);
-	Script_system.RemHookVar("Ship");
+	Script_system.RemHookVars(2, "Ship", "Method");
 	
 	dock_function_info dfi;
 	dfi.parameter_variables.bool_value = (method == SHIP_VANISHED ? true:false);

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -7417,6 +7417,13 @@ static void ship_actually_depart_helper(object *objp, dock_function_info *infop)
  */
 void ship_actually_depart(int shipnum, int method)
 {
+	
+	// run "On Ship Depart" conditional hook variable. This hook accounts for all departure types.
+	// it is not limited to only warping --wookieejedi
+	Script_system.SetHookObject("Ship", &Objects[Ships[shipnum].objnum]);
+	Script_system.RunCondition(CHA_ONSHIPDEPART);
+	Script_system.RemHookVar("Ship");
+	
 	dock_function_info dfi;
 	dfi.parameter_variables.bool_value = (method == SHIP_VANISHED ? true:false);
 	dock_evaluate_all_docked_objects(&Objects[Ships[shipnum].objnum], &dfi, ship_actually_depart_helper);


### PR DESCRIPTION
Previously there were no hooks that could be used to tell if a ship departed via docking bay, because the only departure related hook, "On Warp Out", only triggered when a ship departed via hyperspace. This PR adds a conditional hook that executes when a ship departs via any departure method (ie docking bay). It is called with "$On Ship Depart".