### PR TITLE
ship-invisible doesn't turn off autotargeting

### DIFF
--- a/code/hud/hudtarget.cpp
+++ b/code/hud/hudtarget.cpp
@@ -4383,6 +4383,13 @@ void hud_cease_subsystem_targeting(int print_message)
 	hud_lock_reset();
 }
 
+//like hud_cease_targeting but doesn't turn off auto-targeting
+void hud_cease_targeting_ship() {
+	set_target_objnum(Player_ai, -1);
+	hud_cease_subsystem_targeting(0);
+	//don't need to call hud_lock_reset because hud_cease_subsystem_targeting already does
+}
+
 // hud_cease_targeting() will cease all targeting (main target and subsystem)
 //
 void hud_cease_targeting()

--- a/code/hud/hudtarget.cpp
+++ b/code/hud/hudtarget.cpp
@@ -4364,7 +4364,7 @@ void HudGaugeLeadSight::render(float  /*frametime*/)
 
 // hud_cease_subsystem_targeting() will cease targeting the current targets subsystems
 //
-void hud_cease_subsystem_targeting(int print_message)
+void hud_cease_subsystem_targeting(bool print_message)
 {
 	int ship_index;
 
@@ -4383,22 +4383,17 @@ void hud_cease_subsystem_targeting(int print_message)
 	hud_lock_reset();
 }
 
-//like hud_cease_targeting but doesn't turn off auto-targeting
-void hud_cease_targeting_ship() {
-	set_target_objnum(Player_ai, -1);
-	hud_cease_subsystem_targeting(0);
-	//don't need to call hud_lock_reset because hud_cease_subsystem_targeting already does
-}
-
-// hud_cease_targeting() will cease all targeting (main target and subsystem)
-//
-void hud_cease_targeting()
+// hud_cease_targeting() will cease targeting main target and subsystem
+// with default param, also turns off auto-targeting
+void hud_cease_targeting(bool deliberate)
 {
 	set_target_objnum( Player_ai, -1 );
-	Players[Player_num].flags &= ~PLAYER_FLAGS_AUTO_TARGETING;
-	hud_cease_subsystem_targeting(0);
-	HUD_sourced_printf(HUD_SOURCE_HIDDEN, "%s", XSTR( "Deactivating targeting system", 325));
-	hud_lock_reset();
+	hud_cease_subsystem_targeting(false);
+
+	if (deliberate) {
+		Players[Player_num].flags &= ~PLAYER_FLAGS_AUTO_TARGETING;
+		HUD_sourced_printf(HUD_SOURCE_HIDDEN, "%s", XSTR("Deactivating targeting system", 325));
+	}
 }
 
 // hud_restore_subsystem_target() will remember the last targeted subsystem

--- a/code/hud/hudtarget.cpp
+++ b/code/hud/hudtarget.cpp
@@ -4384,7 +4384,7 @@ void hud_cease_subsystem_targeting(bool print_message)
 }
 
 // hud_cease_targeting() will cease targeting main target and subsystem
-// with default param, also turns off auto-targeting
+// does not turn off auto-targeting by default
 void hud_cease_targeting(bool deliberate)
 {
 	set_target_objnum( Player_ai, -1 );

--- a/code/hud/hudtarget.h
+++ b/code/hud/hudtarget.h
@@ -115,6 +115,7 @@ void hud_target_random_ship();
 void	hud_target_next_subobject();
 void	hud_target_prev_subobject();
 void	hud_cease_subsystem_targeting(int print_message=1);
+void	hud_cease_targeting_ship();
 void	hud_cease_targeting();
 void	hud_restore_subsystem_target(ship* shipp);
 int	subsystem_in_sight(object* objp, ship_subsys* subsys, vec3d *eye, vec3d* subsystem);

--- a/code/hud/hudtarget.h
+++ b/code/hud/hudtarget.h
@@ -114,9 +114,8 @@ void hud_target_random_ship();
 
 void	hud_target_next_subobject();
 void	hud_target_prev_subobject();
-void	hud_cease_subsystem_targeting(int print_message=1);
-void	hud_cease_targeting_ship();
-void	hud_cease_targeting();
+void	hud_cease_subsystem_targeting(bool print_message = true);
+void	hud_cease_targeting(bool deliberate = true);
 void	hud_restore_subsystem_target(ship* shipp);
 int	subsystem_in_sight(object* objp, ship_subsys* subsys, vec3d *eye, vec3d* subsystem);
 vec3d* get_subsystem_world_pos(object* parent_obj, ship_subsys* subsys, vec3d* world_pos);

--- a/code/hud/hudtarget.h
+++ b/code/hud/hudtarget.h
@@ -115,7 +115,7 @@ void hud_target_random_ship();
 void	hud_target_next_subobject();
 void	hud_target_prev_subobject();
 void	hud_cease_subsystem_targeting(bool print_message = true);
-void	hud_cease_targeting(bool deliberate = true);
+void	hud_cease_targeting(bool deliberate = false);
 void	hud_restore_subsystem_target(ship* shipp);
 int	subsystem_in_sight(object* objp, ship_subsys* subsys, vec3d *eye, vec3d* subsystem);
 vec3d* get_subsystem_world_pos(object* parent_obj, ship_subsys* subsys, vec3d* world_pos);

--- a/code/io/keycontrol.cpp
+++ b/code/io/keycontrol.cpp
@@ -2667,7 +2667,7 @@ int button_function(int n)
 
 		// stop targeting ship
 		case STOP_TARGETING_SHIP:
-			hud_cease_targeting();
+			hud_cease_targeting(true);
 			break;
 
 		// stop targeting subsystems on ship

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -13017,7 +13017,7 @@ void multi_sexp_deal_with_ship_flag()
 			if (ship_flag == (int)Ship::Ship_Flags::Hidden_from_sensors) {
 				if (set_it) {
 					if (Player_ai->target_objnum == shipp->objnum) {
-						hud_cease_targeting_ship(); 
+						hud_cease_targeting(false); 
 					}
 				}
 				else {
@@ -14194,7 +14194,7 @@ void sexp_ships_visible(int n, bool visible)
 			continue;
 
 		if (!visible && Player_ai->target_objnum == Ships[shipnum].objnum) {
-			hud_cease_targeting_ship(); 
+			hud_cease_targeting(false); 
 		}
 		else if (visible && (Ships[shipnum].flags[Ship::Ship_Flags::Escort])) {
 			hud_add_ship_to_escort(Ships[shipnum].objnum, 1);

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -13017,7 +13017,7 @@ void multi_sexp_deal_with_ship_flag()
 			if (ship_flag == (int)Ship::Ship_Flags::Hidden_from_sensors) {
 				if (set_it) {
 					if (Player_ai->target_objnum == shipp->objnum) {
-						hud_cease_targeting(false); 
+						hud_cease_targeting(); 
 					}
 				}
 				else {
@@ -14194,7 +14194,7 @@ void sexp_ships_visible(int n, bool visible)
 			continue;
 
 		if (!visible && Player_ai->target_objnum == Ships[shipnum].objnum) {
-			hud_cease_targeting(false); 
+			hud_cease_targeting(); 
 		}
 		else if (visible && (Ships[shipnum].flags[Ship::Ship_Flags::Escort])) {
 			hud_add_ship_to_escort(Ships[shipnum].objnum, 1);

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -13017,7 +13017,7 @@ void multi_sexp_deal_with_ship_flag()
 			if (ship_flag == (int)Ship::Ship_Flags::Hidden_from_sensors) {
 				if (set_it) {
 					if (Player_ai->target_objnum == shipp->objnum) {
-						hud_cease_targeting(); 
+						hud_cease_targeting_ship(); 
 					}
 				}
 				else {
@@ -14194,7 +14194,7 @@ void sexp_ships_visible(int n, bool visible)
 			continue;
 
 		if (!visible && Player_ai->target_objnum == Ships[shipnum].objnum) {
-			hud_cease_targeting(); 
+			hud_cease_targeting_ship(); 
 		}
 		else if (visible && (Ships[shipnum].flags[Ship::Ship_Flags::Escort])) {
 			hud_add_ship_to_escort(Ships[shipnum].objnum, 1);


### PR DESCRIPTION
Fixes #1855 
From the comment, `hud-cease-targeting` turning off autotargeting may be intentional.  For safety's sake, I created a new function for the SEXPs, but since `hud-cease-targeting` is only used otherwise as a default case when rendering the target box and when the `STOP-TARGETING-SHIP` key is pressed, changing it might be preferable.