### PR TITLE
Add scripting file handle auto-closing and error message 

### DIFF
--- a/code/cfile/cfile.h
+++ b/code/cfile/cfile.h
@@ -13,10 +13,11 @@
 #define __CFILE_H__
 
 
-#include <ctime>
 #include "globalincs/pstypes.h"
 
+#include <ctime>
 #include <stdexcept>
+#include <memory>
 
 
 #define CF_EOF (-1)
@@ -461,5 +462,18 @@ namespace cfile
 	};
 
 }
+
+// This allows to use std::unique_ptr with CFILE
+namespace std {
+template <>
+struct default_delete<CFILE> {
+	void operator()(CFILE* ptr)
+	{
+		if (cf_is_valid(ptr)) {
+			cfclose(ptr);
+		}
+	}
+};
+} // namespace std
 
 #endif	/* __CFILE_H__ */

--- a/code/scripting/api/libs/cfile.cpp
+++ b/code/scripting/api/libs/cfile.cpp
@@ -112,7 +112,7 @@ ADE_FUNC(openFile, l_CFile, "string Filename, [string Mode=\"r\", string Path = 
 	const char *n_mode = "r";
 	const char *n_path = "";
 	if(!ade_get_args(L, "s|ss", &n_filename, &n_mode, &n_path))
-		return ade_set_error(L, "o", l_File.Set(NULL));
+		return ade_set_error(L, "o", l_File.Set(cfile_h()));
 
 	int type = CFILE_NORMAL;
 
@@ -121,19 +121,19 @@ ADE_FUNC(openFile, l_CFile, "string Filename, [string Mode=\"r\", string Path = 
 		path = cfile_get_path_type(n_path);
 
 	if(path == CF_TYPE_INVALID)
-		return ade_set_error(L, "o", l_File.Set(NULL));
+		return ade_set_error(L, "o", l_File.Set(cfile_h()));
 
 	CFILE *cfp = cfopen(n_filename, n_mode, type, path);
 
 	if(!cf_is_valid(cfp))
-		return ade_set_error(L, "o", l_File.Set(NULL));
+		return ade_set_error(L, "o", l_File.Set(cfile_h()));
 
-	return ade_set_args(L, "o", l_File.Set(cfp));
+	return ade_set_args(L, "o", l_File.Set(cfile_h(cfp)));
 }
 
 ADE_FUNC(openTempFile, l_CFile, NULL, "Opens a temp file that is automatically deleted when closed", "file", "File handle, or invalid file handle if tempfile couldn't be created")
 {
-	return ade_set_args(L, "o", l_File.Set(ctmpfile()));
+	return ade_set_args(L, "o", l_File.Set(cfile_h(ctmpfile())));
 }
 
 ADE_FUNC(renameFile, l_CFile, "string CurrentFilename, string NewFilename, string Path", "Renames given file. Path must be specified. Use a slash for the root directory.", "boolean", "True if file was renamed, otherwise false")

--- a/code/scripting/api/objs/file.cpp
+++ b/code/scripting/api/objs/file.cpp
@@ -6,16 +6,30 @@ extern int cfread_lua_number(double *buf, CFILE *cfile);
 namespace scripting {
 namespace api {
 
+cfile_h::cfile_h(CFILE* cfp) : _cfp(cfp) {}
+cfile_h::~cfile_h()
+{
+	if (_cfp && cf_is_valid(_cfp.get())) {
+		Error(LOCATION, "Lua file handle has been left open!\n\nSorry, I can't say anything more than that...");
+	}
+}
+bool cfile_h::isValid() const { return _cfp != nullptr; }
+CFILE* cfile_h::get() const { return _cfp.get(); }
+void cfile_h::close()
+{
+	_cfp = nullptr; // Automatically closes the handle
+}
+
 //**********HANDLE: File
-ADE_OBJ(l_File, CFILE*, "file", "File handle");
+ADE_OBJ(l_File, cfile_h, "file", "File handle");
 
 ADE_FUNC(isValid, l_File, NULL, "Detects whether handle is valid", "boolean", "true if valid, false if handle is invalid, nil if a syntax/type error occurs")
 {
-	CFILE *cfp = NULL;
-	if (!ade_get_args(L, "o", l_File.Get(&cfp)))
+	cfile_h* cfp = nullptr;
+	if (!ade_get_args(L, "o", l_File.GetPtr(&cfp)))
 		return ADE_RETURN_NIL;
 
-	if (!cf_is_valid(cfp))
+	if (cfp == nullptr || !cfp->isValid())
 		return ADE_RETURN_FALSE;
 
 	return ADE_RETURN_TRUE;
@@ -23,46 +37,41 @@ ADE_FUNC(isValid, l_File, NULL, "Detects whether handle is valid", "boolean", "t
 
 ADE_FUNC(close, l_File, NULL, "Instantly closes file and invalidates all file handles", NULL, NULL)
 {
-	CFILE *cfp;
-	if (!ade_get_args(L, "o", l_File.Get(&cfp)))
+	cfile_h* cfp = nullptr;
+	if (!ade_get_args(L, "o", l_File.GetPtr(&cfp)))
 		return ADE_RETURN_FALSE;
 
-	if (!cf_is_valid(cfp))
+	if (cfp == nullptr || !cfp->isValid())
 		return ADE_RETURN_FALSE;
 
-	int rval = cfclose(cfp);
-	if (rval != 0)
-	{
-		LuaError(L, "Attempt to close file resulted in error %d", rval);
-		return ADE_RETURN_FALSE;
-	}
+	cfp->close();
 	return ADE_RETURN_TRUE;
 }
 
 ADE_FUNC(flush, l_File, NULL, "Flushes file buffer to disk.", "boolean", "True for success, false on failure")
 {
-	CFILE *cfp = NULL;
-	if (!ade_get_args(L, "o", l_File.Get(&cfp)))
+	cfile_h* cfp = nullptr;
+	if (!ade_get_args(L, "o", l_File.GetPtr(&cfp)))
 		return ADE_RETURN_FALSE;
 
-	if (!cf_is_valid(cfp))
+	if (cfp == nullptr || !cfp->isValid())
 		return ADE_RETURN_FALSE;
 
 	//WMC - this looks reversed, yes, it's right. Look at cflush.
-	int cf_result = cflush(cfp);
+	int cf_result = cflush(cfp->get());
 	return ade_set_args(L, "b", cf_result ? false : true);
 }
 
 ADE_FUNC(getPath, l_File, NULL, "Determines path of the given file", "string", "Path string of the file handle, or an empty string if it doesn't have one, or the handle is invalid")
 {
-	CFILE *cfp = NULL;
-	if (!ade_get_args(L, "o", l_File.Get(&cfp)))
+	cfile_h* cfp = nullptr;
+	if (!ade_get_args(L, "o", l_File.GetPtr(&cfp)))
 		return ade_set_error(L, "s", "");
 
-	if (!cf_is_valid(cfp))
+	if (cfp == nullptr || !cfp->isValid())
 		return ade_set_error(L, "s", "");
 
-	int id = cf_get_dir_type(cfp);
+	int id = cf_get_dir_type(cfp->get());
 	if (Pathtypes[id].path != NULL)
 		return ade_set_args(L, "s", Pathtypes[id].path);
 	else
@@ -79,11 +88,11 @@ ADE_FUNC(read, l_File, "number or string, ...",
 	"number or string, ...",
 	"Requested data, or nil if the function fails")
 {
-	CFILE *cfp = NULL;
-	if (!ade_get_args(L, "o", l_File.Get(&cfp)))
+	cfile_h* cfp = nullptr;
+	if (!ade_get_args(L, "o", l_File.GetPtr(&cfp)))
 		return ADE_RETURN_NIL;
 
-	if (!cf_is_valid(cfp))
+	if (cfp == nullptr || !cfp->isValid())
 		return ADE_RETURN_NIL;
 
 	int i;
@@ -104,7 +113,7 @@ ADE_FUNC(read, l_File, "number or string, ...",
 			if (!stricmp(fmt, "*n"))
 			{
 				double d = 0.0f;
-				if (cfread_lua_number(&d, cfp) == EOF)
+				if (cfread_lua_number(&d, cfp->get()) == EOF)
 					return ADE_RETURN_NIL;
 
 				lua_pushnumber(L, d);
@@ -112,15 +121,15 @@ ADE_FUNC(read, l_File, "number or string, ...",
 			}
 			else if (!stricmp(fmt, "*a"))
 			{
-				int tell_res = cftell(cfp);
+				int tell_res = cftell(cfp->get());
 				if (tell_res < 0)
 				{
 					Error(LOCATION, "Critical error reading Lua file; could not cftell.");
 				}
-				int read_len = cfilelength(cfp) - tell_res;
+				int read_len = cfilelength(cfp->get()) - tell_res;
 
 				char *buf = (char *)vm_malloc(read_len + 1);
-				int final_len = cfread(buf, 1, read_len, cfp);
+				int final_len = cfread(buf, 1, read_len, cfp->get());
 				buf[final_len] = '\0';
 
 				lua_pushstring(L, buf);
@@ -131,7 +140,7 @@ ADE_FUNC(read, l_File, "number or string, ...",
 			{
 				char buf[10240];
 				size_t idx;
-				if (cfgets(buf, (int)(sizeof(buf) / sizeof(char)), cfp) == NULL)
+				if (cfgets(buf, (int)(sizeof(buf) / sizeof(char)), cfp->get()) == nullptr)
 				{
 					lua_pushnil(L);
 				}
@@ -161,14 +170,14 @@ ADE_FUNC(read, l_File, "number or string, ...",
 
 			if (num < 1)
 			{
-				if (cfeof(cfp))
+				if (cfeof(cfp->get()))
 					lua_pushstring(L, "");
 				else
 					lua_pushnil(L);
 			}
 
 			char *buf = (char*)vm_malloc(num + 1);
-			int total_read = cfread(buf, 1, num, cfp);
+			int total_read = cfread(buf, 1, num, cfp->get());
 			if (total_read)
 			{
 				buf[total_read] = '\0';
@@ -200,11 +209,11 @@ ADE_FUNC(seek, l_File, "[string Whence=\"cur\", number Offset=0]",
 	const char* w = nullptr;
 	int o = 0;
 
-	CFILE *cfp = NULL;
-	if (!ade_get_args(L, "o|si", l_File.Get(&cfp), &w, &o))
+	cfile_h* cfp = nullptr;
+	if (!ade_get_args(L, "o|si", l_File.GetPtr(&cfp), &w, &o))
 		return ADE_RETURN_NIL;
 
-	if (!cf_is_valid(cfp))
+	if (cfp == nullptr || !cfp->isValid())
 		return ADE_RETURN_NIL;
 
 	if (!(w == NULL || (!stricmp(w, "cur") && o != 0)))
@@ -219,11 +228,11 @@ ADE_FUNC(seek, l_File, "[string Whence=\"cur\", number Offset=0]",
 		else
 			LuaError(L, "Invalid where argument passed to seek() - '%s'", w);
 
-		if (cfseek(cfp, o, seek_type))
+		if (cfseek(cfp->get(), o, seek_type))
 			return ADE_RETURN_FALSE;
 	}
 
-	int res = cftell(cfp);
+	int res = cftell(cfp->get());
 	if (res >= 0)
 		return ade_set_args(L, "i", res);
 	else
@@ -233,11 +242,11 @@ ADE_FUNC(seek, l_File, "[string Whence=\"cur\", number Offset=0]",
 ADE_FUNC(write, l_File, "string or number, ...",
 	"Writes a series of Lua strings or numbers to the current file.", "number", "Number of items successfully written.")
 {
-	CFILE *cfp = NULL;
-	if (!ade_get_args(L, "o", l_File.Get(&cfp)))
+	cfile_h* cfp = nullptr;
+	if (!ade_get_args(L, "o", l_File.GetPtr(&cfp)))
 		return ade_set_error(L, "i", 0);
 
-	if (!cf_is_valid(cfp))
+	if (cfp == nullptr || !cfp->isValid())
 		return ade_set_error(L, "i", 0);
 
 	int l_pos = 2;
@@ -249,7 +258,7 @@ ADE_FUNC(write, l_File, "string or number, ...",
 		if (type == LUA_TSTRING)
 		{
 			auto s = lua_tostring(L, l_pos);
-			if (cfwrite(s, (int)sizeof(char), (int)strlen(s), cfp))
+			if (cfwrite(s, (int)sizeof(char), (int)strlen(s), cfp->get()))
 				num_successful++;
 		}
 		else if (type == LUA_TNUMBER)
@@ -257,7 +266,7 @@ ADE_FUNC(write, l_File, "string or number, ...",
 			double d = lua_tonumber(L, l_pos);
 			char buf[32] = { 0 };
 			sprintf(buf, LUA_NUMBER_FMT, d);
-			if (cfwrite(buf, (int)sizeof(char), (int)strlen(buf), cfp))
+			if (cfwrite(buf, (int)sizeof(char), (int)strlen(buf), cfp->get()))
 				num_successful++;
 		}
 

--- a/code/scripting/api/objs/file.h
+++ b/code/scripting/api/objs/file.h
@@ -5,7 +5,26 @@
 #include "cfile/cfile.h"
 
 namespace scripting {
-	namespace api {
-		DECLARE_ADE_OBJ(l_File, CFILE*);
-	}
-}
+namespace api {
+
+class cfile_h {
+	std::unique_ptr<CFILE> _cfp;
+
+  public:
+	explicit cfile_h(CFILE* cfp = nullptr);
+	~cfile_h();
+
+	cfile_h(cfile_h&& other) noexcept = default; // NOLINT
+	cfile_h& operator=(cfile_h&& other) noexcept = default; // NOLINT
+
+	void close();
+
+	bool isValid() const;
+
+	CFILE* get() const;
+};
+
+DECLARE_ADE_OBJ(l_File, cfile_h);
+
+} // namespace api
+} // namespace scripting


### PR DESCRIPTION
This adds some auto-closing code to the scripting API of the CFile
system. If a file has to be auto-closed then an error will be displayed
to let the the script writer know that something is wrong.

This should not break existing scripts since causing file handle leaks
should never happen and if it does, this will make it easier to find
these issues.

This depends on the changes of #1881.