### PR TITLE
Add option for disabling spark spawning for subsystem

### DIFF
--- a/code/model/model_flags.h
+++ b/code/model/model_flags.h
@@ -47,7 +47,8 @@ namespace Model {
         Autorepair_if_disabled,		// Allows the subsystem to repair itself even if disabled (MageKing17)
         No_autorepair_if_disabled,	// Inversion of the previous; disallows this particular subsystem if the ship-wide flag is set (MageKing17)
         Share_fire_direction,		// (DahBlount) Whenever the turret fires, make all firing points fire in the same direction.
-		
+        No_sparks,          // Subsystem does not generate sparks if hit - m!m
+
         NUM_VALUES
 	};
 
@@ -65,14 +66,14 @@ namespace Model {
 		No_texturing,			// Draw textures as flat-shaded polygons.
 		No_correct,				// Don't to correct texture mapping
 		No_smoothing,			// Don't perform smoothing on vertices.
-		Is_asteroid,			// When set, treat this as an asteroid.  
+		Is_asteroid,			// When set, treat this as an asteroid.
 		Is_missile,				// When set, treat this as a missilie.  No lighting, small thrusters.
-		Show_outline_preset,	// Draw the object in outline mode. Color assumed to be set already.	
+		Show_outline_preset,	// Draw the object in outline mode. Color assumed to be set already.
 		Show_invisible_faces,	// Show invisible faces as green...
 		Autocenter,				// Always use the center of the hull bounding box as the center, instead of the pivot point
 		Bay_paths,				// draw bay paths
 		All_xparent,			// render it fully transparent
-		No_zbuffer,				// switch z-buffering off completely 
+		No_zbuffer,				// switch z-buffering off completely
 		No_cull,				// don't cull backfacing poly's
 		Force_texture,			// force a given texture to always be used
 		Force_lower_detail,		// force the model to draw 1 LOD lower, if possible
@@ -84,7 +85,7 @@ namespace Model {
 		Full_detail,			// render all valid objects, particularly ones that are otherwise in/out of render boxes - taylor
 		Force_clamp,			// force clamp - Hery
 		Animated_shader,		// Use a animated Shader - Valathil
-		
+
 		NUM_VALUES
 	};
 }

--- a/code/model/model_flags.h
+++ b/code/model/model_flags.h
@@ -48,6 +48,7 @@ namespace Model {
         No_autorepair_if_disabled,	// Inversion of the previous; disallows this particular subsystem if the ship-wide flag is set (MageKing17)
         Share_fire_direction,		// (DahBlount) Whenever the turret fires, make all firing points fire in the same direction.
         No_sparks,          // Subsystem does not generate sparks if hit - m!m
+		No_impact_debris,    // Don't spawn the small debris on impact - m!m
 
         NUM_VALUES
 	};

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -278,7 +278,8 @@ flag_def_list_new<Model::Subsystem_Flags> Subsystem_flags[] = {
 	{ "turret use ammo",		    Model::Subsystem_Flags::Turret_use_ammo,                    true, false },
 	{ "autorepair if disabled",	    Model::Subsystem_Flags::Autorepair_if_disabled,             true, false },
 	{ "don't autorepair if disabled", Model::Subsystem_Flags::No_autorepair_if_disabled,        true, false },
-	{ "share fire direction",       Model::Subsystem_Flags::Share_fire_direction,               true, false }
+	{ "share fire direction",       Model::Subsystem_Flags::Share_fire_direction,               true, false },
+	{ "no damage spew",             Model::Subsystem_Flags::No_sparks,                          true, false },
 };
 
 const size_t Num_subsystem_flags = sizeof(Subsystem_flags)/sizeof(flag_def_list_new<Model::Subsystem_Flags>);
@@ -19164,4 +19165,22 @@ void toggle_ignore_list_flag(Ship::Ship_Flags flag) {
 		Ignore_List.remove(flag);
 	else
 		Ignore_List.set(flag);
+}
+
+ship_subsys* ship_get_subsys_for_submodel(ship* shipp, int submodel)
+{
+	ship_subsys* subsys;
+
+	if (submodel == -1) {
+		return nullptr;
+	}
+
+	for (subsys = GET_FIRST(&shipp->subsys_list); subsys != END_OF_LIST(&shipp->subsys_list);
+	     subsys = GET_NEXT(subsys)) {
+		if (subsys->system_info->subobj_num == submodel) {
+			return subsys;
+		}
+	}
+
+	return nullptr;
 }

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -280,6 +280,7 @@ flag_def_list_new<Model::Subsystem_Flags> Subsystem_flags[] = {
 	{ "don't autorepair if disabled", Model::Subsystem_Flags::No_autorepair_if_disabled,        true, false },
 	{ "share fire direction",       Model::Subsystem_Flags::Share_fire_direction,               true, false },
 	{ "no damage spew",             Model::Subsystem_Flags::No_sparks,                          true, false },
+	{ "no impact debris",           Model::Subsystem_Flags::No_impact_debris,                    true, false },
 };
 
 const size_t Num_subsystem_flags = sizeof(Subsystem_flags)/sizeof(flag_def_list_new<Model::Subsystem_Flags>);

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -1814,4 +1814,6 @@ extern void set_default_ignore_list();
 
 extern void toggle_ignore_list_flag(Ship::Ship_Flags flag);
 
+ship_subsys* ship_get_subsys_for_submodel(ship* shipp, int submodel);
+
 #endif

--- a/code/ship/shiphit.cpp
+++ b/code/ship/shiphit.cpp
@@ -451,7 +451,6 @@ float do_subobj_hit_stuff(object *ship_objp, object *other_obj, vec3d *hitpos, i
 	vec3d			g_subobj_pos;
 	float				damage_left, damage_if_hull;
 	int				weapon_info_index;
-	ship_subsys		*subsys;
 	ship				*ship_p;
 	sublist			subsys_list[MAX_SUBSYS_LIST];
 	int				subsys_hit_first = -1; // the subsys which should be hit first and take most of the damage; index into subsys_list
@@ -514,13 +513,17 @@ float do_subobj_hit_stuff(object *ship_objp, object *other_obj, vec3d *hitpos, i
 #endif
 
 	if (!global_damage) {
-		create_subsys_debris(ship_objp, hitpos);
+		auto subsys = ship_get_subsys_for_submodel(ship_p, submodel_num);
+
+		if (subsys == nullptr || !subsys->system_info->flags[Model::Subsystem_Flags::No_impact_debris]) {
+			create_subsys_debris(ship_objp, hitpos);
+		}
 	}
 
 	//	First, create a list of the N subsystems within range.
 	//	Then, one at a time, process them in order.
 	int	count = 0;
-	for ( subsys=GET_FIRST(&ship_p->subsys_list); subsys != END_OF_LIST(&ship_p->subsys_list); subsys = GET_NEXT(subsys) )
+	for ( auto subsys=GET_FIRST(&ship_p->subsys_list); subsys != END_OF_LIST(&ship_p->subsys_list); subsys = GET_NEXT(subsys) )
 	{
 		model_subsystem *mss = subsys->system_info;
 

--- a/code/ship/shiphit.cpp
+++ b/code/ship/shiphit.cpp
@@ -2496,6 +2496,15 @@ void ship_apply_local_damage(object *ship_objp, object *other_obj, vec3d *hitpos
 			}
 
 			if (create_sparks) {
+				auto subsys = ship_get_subsys_for_submodel(ship_p, submodel_num);
+
+				if (subsys != nullptr && subsys->system_info->flags[Model::Subsystem_Flags::No_sparks]) {
+					// Spark creation was explicitly disabled for this subsystem
+					create_sparks = false;
+				}
+			}
+
+			if (create_sparks) {
 				ship_hit_create_sparks(ship_objp, hitpos, submodel_num);
 			}
 		}


### PR DESCRIPTION
This adds the "no sparks" flag for subsystems which disables the
generation of spark sources for that subsystem when it is hit.

This was requested by Axem.