### PR TITLE
Fix cubemap offset computation for texture uploads

### DIFF
--- a/code/graphics/opengl/gropengltexture.cpp
+++ b/code/graphics/opengl/gropengltexture.cpp
@@ -503,8 +503,6 @@ static int opengl_texture_set_level(int bitmap_handle, int bitmap_type, int bmap
 			auto mipmap_w = bmap_w;
 			auto mipmap_h = bmap_h;
 
-			doffset += dsize;
-
 			// check if it's a compressed cubemap first
 			if (block_size > 0) {
 				for (auto level = 0; level < mipmap_levels + base_level; level++) {


### PR DESCRIPTION
The changes from #1752 changed how the offset was computed but the
cubemap code did not update the initial offset computation to account
for this.

This fixes #1921.