### PR TITLE
Cleanup the speech API code a bit

### DIFF
--- a/code/cmdline/cmdline.cpp
+++ b/code/cmdline/cmdline.cpp
@@ -204,7 +204,6 @@ Flag exe_params[] =
 	{ "-no_set_gamma",		"Disable setting of gamma",					true,	0,					EASY_DEFAULT,		"Troubleshoot",	"http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-no_set_gamma", },
 	{ "-nomovies",			"Disable video playback",					true,	0,					EASY_DEFAULT,		"Troubleshoot",	"http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-nomovies", },
 	{ "-noparseerrors",		"Disable parsing errors",					true,	0,					EASY_DEFAULT,		"Troubleshoot",	"http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-noparseerrors", },
-	{ "-query_speech",		"Check if this build has speech",			true,	0,					EASY_DEFAULT,		"Troubleshoot",	"http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-query_speech", },
 	{ "-loadallweps",		"Load all weapons, even those not used",	true,	0,					EASY_DEFAULT,		"Troubleshoot",	"http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-loadallweps", },
 	{ "-disable_fbo",		"Disable OpenGL RenderTargets",				true,	0,					EASY_DEFAULT,		"Troubleshoot",	"http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-disable_fbo", },
 	{ "-disable_pbo",		"Disable OpenGL Pixel Buffer Objects",		true,	0,					EASY_DEFAULT,		"Troubleshoot",	"http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-disable_pbo", },
@@ -395,10 +394,8 @@ int Cmdline_autopilot_interruptable = 1;
 int Cmdline_stretch_menu = 0;
 
 // Audio related
-cmdline_parm query_speech_arg("-query_speech", NULL, AT_NONE);	// Cmdline_query_speech
 cmdline_parm voice_recognition_arg("-voicer", NULL, AT_NONE);	// Cmdline_voice_recognition
 
-int Cmdline_query_speech = 0;
 int Cmdline_voice_recognition = 0;
 int Cmdline_no_enhanced_sound = 0;
 
@@ -1878,9 +1875,6 @@ bool SetCmdlineParams()
 
 	if ( glow_arg.found() )
 		Cmdline_glow = 0;
-
-	if ( query_speech_arg.found() )
-		Cmdline_query_speech = 1;
 
 	if ( ship_choice_3d_arg.found() )
 		Cmdline_ship_choice_3d = 1;

--- a/code/cmdline/cmdline.h
+++ b/code/cmdline/cmdline.h
@@ -101,7 +101,6 @@ extern int Cmdline_autopilot_interruptable;
 extern int Cmdline_stretch_menu;
 
 // Audio related
-extern int Cmdline_query_speech;
 extern int Cmdline_voice_recognition;
 extern int Cmdline_no_enhanced_sound;
 

--- a/code/sound/fsspeech.cpp
+++ b/code/sound/fsspeech.cpp
@@ -6,17 +6,6 @@
  *
 */ 
 
-
-
-
-
-#ifdef FS2_SPEECH
-
-
-#ifdef _WIN32
-#include <windows.h>
-#endif
-
 #include "globalincs/pstypes.h"
 #include "osapi/osregistry.h"
 #include "sound/fsspeech.h"
@@ -30,7 +19,7 @@ const size_t MAX_SPEECH_BUFFER_LEN = 4096;
 static int speech_inited = 0;
 
 bool FSSpeech_play_from[FSSPEECH_FROM_MAX];
-char *FSSpeech_play_id[FSSPEECH_FROM_MAX] =
+const char *FSSpeech_play_id[FSSPEECH_FROM_MAX] =
 {
 	"SpeechTechroom",
 	"SpeechBriefings",
@@ -168,5 +157,3 @@ bool fsspeech_playing()
 
 	return speech_is_speaking();
 }
-
-#endif	// FS2_SPEECH defined

--- a/code/sound/fsspeech.h
+++ b/code/sound/fsspeech.h
@@ -18,8 +18,6 @@ enum
 	FSSPEECH_FROM_MAX
 };
 
-#ifdef FS2_SPEECH
-
 bool fsspeech_init();
 void fsspeech_deinit();
 void fsspeech_play(int type, const char *text);
@@ -32,27 +30,5 @@ void fsspeech_play_buffer(int type);
 
 bool fsspeech_play_from(int type);
 bool fsspeech_playing();
-
-inline bool fsspeech_was_compiled() { return true; }
-
-#else
-
-// stub functions (c.f. NO_SOUND)
-
-inline bool fsspeech_init() { return false; }
-inline void fsspeech_deinit() {}
-inline void fsspeech_play(int  /*type*/, const char * /*text*/) { }
-inline void fsspeech_stop() {}
-inline void fsspeech_pause(bool  /*playing*/) { }
-
-inline void fsspeech_start_buffer() {}
-inline void fsspeech_stuff_buffer(const char * /*text*/) { }
-inline void fsspeech_play_buffer(int  /*type*/) {}
-
-inline bool fsspeech_play_from(int  /*type*/) { return false; }
-inline bool fsspeech_playing() { return false; }
-inline bool fsspeech_was_compiled( ) { return false; }
-
-#endif
 
 #endif	// header define

--- a/code/sound/speech.h
+++ b/code/sound/speech.h
@@ -31,15 +31,15 @@ SCP_vector<SCP_string> speech_enumerate_voices();
 
 // Goober5000: see, the *real* way to do stubs (avoiding the warnings)
 // is to just use #defines (c.f. NO_SOUND)
-#define speech_init() (false)
-#define speech_deinit()
-#define speech_play(text) ((text), false)
-#define speech_pause() (false)
-#define speech_resume() (false)
-#define speech_stop() (false)
-#define speech_set_volume(volume) ((volume), false)
-#define speech_set_voice(voice) ((voice), false)
-#define speech_is_speaking() (false)
+inline bool speech_init() { return false; }
+inline void speech_deinit() {}
+inline bool speech_play(const char* /*text*/) { return false; }
+inline bool speech_pause() { return false; }
+inline bool speech_resume() { return false; }
+inline bool speech_stop() { return false; }
+inline bool speech_set_volume(unsigned short /*volume*/) { return false; }
+inline bool speech_set_voice(int /*voice*/) { return false; }
+inline bool speech_is_speaking() { return false; }
 
 inline SCP_vector<SCP_string> speech_enumerate_voices() {
 	return SCP_vector<SCP_string>();

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -1791,20 +1791,8 @@ void game_init()
 		snd_init();
 	}
 
-	if(fsspeech_init() == false) {
+	if(!fsspeech_init()) {
 		mprintf(("Failed to init speech\n"));
-
-		if(Cmdline_query_speech)
-		{
-			if (!fsspeech_was_compiled())
-				os::dialogs::Message(os::dialogs::MESSAGEBOX_WARNING, "Speech is not compiled in this build in code.lib");
-			else
-				os::dialogs::Message(os::dialogs::MESSAGEBOX_WARNING, "Speech is compiled, but failed to init");
-		}
-	} else if(Cmdline_query_speech) {
-		// Its bad practice to use a negative type, this is an exceptional case
-		fsspeech_play(-1,"Welcome to FS2 open");
-		os::dialogs::Message(os::dialogs::MESSAGEBOX_INFORMATION, "Speech is compiled and initialised and should be working");
 	}
 
 /////////////////////////////


### PR DESCRIPTION
This replaces the previously used defines with inline functions which
fixes a few warnings if the macros were ever used. This also changes
fsspeech.cpp so it is compiled always since it has no dependency on the
underlying speech system.