### PR TITLE
Fix for incomplete attachment in shadow framebuffer

### DIFF
--- a/code/graphics/opengl/gropengltnl.cpp
+++ b/code/graphics/opengl/gropengltnl.cpp
@@ -421,6 +421,8 @@ static bool opengl_init_shadow_framebuffer(int size, GLenum color_format)
 
 	glGenTextures(1, &Shadow_map_depth_texture);
 
+	GL_state.Texture.SetActiveUnit(0);
+	GL_state.Texture.SetTarget(GL_TEXTURE_2D_ARRAY);
 	GL_state.Texture.Enable(Shadow_map_depth_texture);
 
 	glTexParameteri(GL_TEXTURE_2D_ARRAY, GL_TEXTURE_MIN_FILTER, GL_LINEAR);


### PR DESCRIPTION
Fix for:

```
Trying to create 1024x1024 32-bit shadow framebuffer
Failed to create framebuffer: Incomplete framebuffer attachment
Trying to create 1024x1024 16-bit shadow framebuffer
Shadow framebuffer created successfully.
```

Tested on Intel, Nvidia and it works:

```
Trying to create 1024x1024 32-bit shadow framebuffer
Shadow framebuffer created successfully.
```

But I have no knowledge about OpenGL, so please check it. ;)