### PR TITLE
Set initial slider values to the command line parameters and add functionality to reset view

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,11 +9,11 @@ environment:
     - BuildID: 0
       CMAKE_GENERATOR: Visual Studio 14 2015
       PlatformToolset: v140_xp
-      QT_DIR: C:\Qt\5.9.5\msvc2015
+      QT_DIR: C:\Qt\5.9\msvc2015
     - BuildID: 1
       CMAKE_GENERATOR: Visual Studio 14 2015 Win64
       PlatformToolset: v140_xp
-      QT_DIR: C:\Qt\5.9.5\msvc2015_64
+      QT_DIR: C:\Qt\5.9\msvc2015_64
 before_build:
   - git submodule update --init --recursive
 build_script:

--- a/code/ai/aiturret.cpp
+++ b/code/ai/aiturret.cpp
@@ -1290,7 +1290,9 @@ void ship_get_global_turret_gun_info(object *objp, ship_subsys *ssp, vec3d *gpos
 		model_instance_find_world_point(&tmp_pos, &avg, Ships[objp->instance].model_instance_num, tp->turret_gun_sobj, &objp->orient, &objp->pos);
 
 		if (targetp == nullptr) {
-            Assertion(ssp->turret_enemy_objnum >= 0, "The turret enemy object number %d for %s on ship number %d is invalid.", ssp->turret_enemy_objnum, ssp->sub_name, ssp->parent_objnum);
+			ship* shipp = &Ships[Objects[ssp->parent_objnum].instance];
+            Assertion(ssp->turret_enemy_objnum >= 0, "The turret enemy object number %d for %s on ship name %s is invalid.", ssp->turret_enemy_objnum, ssp->sub_name, 
+																								(shipp->has_display_name()) ? shipp->display_name.c_str() : shipp->ship_name);
             object *lep = &Objects[ssp->turret_enemy_objnum];
 
 			int best_weapon_tidx = turret_select_best_weapon(ssp, lep);
@@ -1301,9 +1303,9 @@ void ship_get_global_turret_gun_info(object *objp, ship_subsys *ssp, vec3d *gpos
 
 			weapon_info *wip = get_turret_weapon_wip(&ssp->weapons, best_weapon_tidx);
 
-			float weapon_system_strength = ship_get_subsystem_strength(&Ships[ssp->parent_objnum], SUBSYSTEM_WEAPONS);
+			float weapon_system_strength = ship_get_subsystem_strength(shipp, SUBSYSTEM_WEAPONS);
 
-            turret_ai_update_aim(&Ai_info[Ships[ssp->parent_objnum].ai_index], &Objects[ssp->turret_enemy_objnum], ssp);
+            turret_ai_update_aim(&Ai_info[shipp->ai_index], &Objects[ssp->turret_enemy_objnum], ssp);
 
 			if ((ssp->targeted_subsys != nullptr) && !(ssp->flags[Ship::Subsystem_Flags::No_SS_targeting])) {
 				vm_vec_unrotate(&enemy_point, &ssp->targeted_subsys->system_info->pnt, &Objects[ssp->turret_enemy_objnum].orient);

--- a/code/autopilot/autopilot.cpp
+++ b/code/autopilot/autopilot.cpp
@@ -1053,11 +1053,7 @@ void nav_warp(bool prewarp=false)
 	}
 
 	// retime all collision pairs
-	if ( Cmdline_old_collision_sys ) {
-		obj_all_collisions_retime();
-	} else {
-		obj_collide_retime_cached_pairs();
-	}
+	obj_collide_retime_cached_pairs();
 }
 
 // ********************************************************************************************

--- a/code/cmdline/cmdline.cpp
+++ b/code/cmdline/cmdline.cpp
@@ -211,7 +211,6 @@ Flag exe_params[] =
 	{ "-no_3d_sound",		"Use only 2D/stereo for sound effects",		true,	0,					EASY_DEFAULT,		"Troubleshoot",	"http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-no_3d_sound", },
 	{ "-mipmap",			"Enable mipmapping",						true,	0,					EASY_DEFAULT_MEM,	"Troubleshoot",	"http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-mipmap", },
 	{ "-use_gldrawelements","Don't use glDrawRangeElements",			true,	0,					EASY_DEFAULT,		"Troubleshoot",	"http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-use_gldrawelements", },
-	{ "-old_collision",		"Use old collision detection system",		true,	EASY_DEFAULT,		EASY_ALL_ON,		"Troubleshoot",	"http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-old_collision", },
 	{ "-gl_finish",			"Fix input lag on some ATI+Linux systems",	true,	0,					EASY_DEFAULT,		"Troubleshoot", "http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-gl_finish", },
 	{ "-no_geo_effects",	"Disable geometry shader for effects",		true,	0,					EASY_DEFAULT,		"Troubleshoot", "", },
 	{ "-set_cpu_affinity",	"Sets processor affinity to config value",	true,	0,					EASY_DEFAULT,		"Troubleshoot", "", },
@@ -435,7 +434,6 @@ cmdline_parm atiswap_arg("-ati_swap", NULL, AT_NONE);        // Cmdline_atiswap 
 cmdline_parm no3dsound_arg("-no_3d_sound", NULL, AT_NONE);		// Cmdline_no_3d_sound - Disable use of full 3D sounds
 cmdline_parm no_drawrangeelements("-use_gldrawelements", NULL, AT_NONE); // Cmdline_drawelements -- Uses glDrawElements instead of glDrawRangeElements
 cmdline_parm keyboard_layout("-keyboard_layout", "Specify keyboard layout (qwertz or azerty)", AT_STRING);
-cmdline_parm old_collision_system("-old_collision", NULL, AT_NONE); // Cmdline_old_collision_sys
 cmdline_parm gl_finish ("-gl_finish", NULL, AT_NONE);
 cmdline_parm no_geo_sdr_effects("-no_geo_effects", NULL, AT_NONE);
 cmdline_parm set_cpu_affinity("-set_cpu_affinity", NULL, AT_NONE);
@@ -492,7 +490,6 @@ cmdline_parm debug_window_arg("-debug_window", NULL, AT_NONE);	// Cmdline_debug_
 
 
 char *Cmdline_start_mission = NULL;
-int Cmdline_old_collision_sys = 0;
 int Cmdline_dis_collisions = 0;
 int Cmdline_dis_weapons = 0;
 bool Cmdline_output_sexp_info = false;
@@ -1957,9 +1954,6 @@ bool SetCmdlineParams()
 	if ( ballistic_gauge.found() ) {
 		Cmdline_ballistic_gauge = 1;
 	}
-
-	if(old_collision_system.found())
-		Cmdline_old_collision_sys = 1;
 
 	if(dis_collisions.found())
 		Cmdline_dis_collisions = 1;

--- a/code/cmdline/cmdline.cpp
+++ b/code/cmdline/cmdline.cpp
@@ -204,7 +204,6 @@ Flag exe_params[] =
 	{ "-no_set_gamma",		"Disable setting of gamma",					true,	0,					EASY_DEFAULT,		"Troubleshoot",	"http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-no_set_gamma", },
 	{ "-nomovies",			"Disable video playback",					true,	0,					EASY_DEFAULT,		"Troubleshoot",	"http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-nomovies", },
 	{ "-noparseerrors",		"Disable parsing errors",					true,	0,					EASY_DEFAULT,		"Troubleshoot",	"http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-noparseerrors", },
-	{ "-query_speech",		"Check if this build has speech",			true,	0,					EASY_DEFAULT,		"Troubleshoot",	"http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-query_speech", },
 	{ "-loadallweps",		"Load all weapons, even those not used",	true,	0,					EASY_DEFAULT,		"Troubleshoot",	"http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-loadallweps", },
 	{ "-disable_fbo",		"Disable OpenGL RenderTargets",				true,	0,					EASY_DEFAULT,		"Troubleshoot",	"http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-disable_fbo", },
 	{ "-disable_pbo",		"Disable OpenGL Pixel Buffer Objects",		true,	0,					EASY_DEFAULT,		"Troubleshoot",	"http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-disable_pbo", },
@@ -395,10 +394,8 @@ int Cmdline_autopilot_interruptable = 1;
 int Cmdline_stretch_menu = 0;
 
 // Audio related
-cmdline_parm query_speech_arg("-query_speech", NULL, AT_NONE);	// Cmdline_query_speech
 cmdline_parm voice_recognition_arg("-voicer", NULL, AT_NONE);	// Cmdline_voice_recognition
 
-int Cmdline_query_speech = 0;
 int Cmdline_voice_recognition = 0;
 int Cmdline_no_enhanced_sound = 0;
 
@@ -1878,9 +1875,6 @@ bool SetCmdlineParams()
 
 	if ( glow_arg.found() )
 		Cmdline_glow = 0;
-
-	if ( query_speech_arg.found() )
-		Cmdline_query_speech = 1;
 
 	if ( ship_choice_3d_arg.found() )
 		Cmdline_ship_choice_3d = 1;

--- a/code/cmdline/cmdline.h
+++ b/code/cmdline/cmdline.h
@@ -139,7 +139,6 @@ extern bool Cmdline_alternate_registry_path;
 
 // Developer/Testing related
 extern char *Cmdline_start_mission;
-extern int Cmdline_old_collision_sys;
 extern int Cmdline_dis_collisions;
 extern int Cmdline_dis_weapons;
 extern bool Cmdline_output_sexp_info;

--- a/code/cmdline/cmdline.h
+++ b/code/cmdline/cmdline.h
@@ -101,7 +101,6 @@ extern int Cmdline_autopilot_interruptable;
 extern int Cmdline_stretch_menu;
 
 // Audio related
-extern int Cmdline_query_speech;
 extern int Cmdline_voice_recognition;
 extern int Cmdline_no_enhanced_sound;
 

--- a/code/debris/debris.cpp
+++ b/code/debris/debris.cpp
@@ -270,13 +270,8 @@ void debris_process_post(object * obj, float frame_time)
 
 			vec3d v1, v2, v3, v4;
 
-			if ( Cmdline_old_collision_sys ) {
-				submodel_get_two_random_points( db->model_num, db->submodel_num, &v1, &v2 );
-				submodel_get_two_random_points( db->model_num, db->submodel_num, &v3, &v4 );
-			} else {
-				submodel_get_two_random_points_better( db->model_num, db->submodel_num, &v1, &v2 );
-				submodel_get_two_random_points_better( db->model_num, db->submodel_num, &v3, &v4 );
-			}
+			submodel_get_two_random_points_better(db->model_num, db->submodel_num, &v1, &v2);
+			submodel_get_two_random_points_better(db->model_num, db->submodel_num, &v3, &v4);
 
 			n = 0;
 
@@ -352,12 +347,8 @@ void debris_process_post(object * obj, float frame_time)
 				if ( mr < RAND_MAX/5 )	{
 					vec3d v1, v2;
 
-					if ( Cmdline_old_collision_sys ) {
-						submodel_get_two_random_points( db->model_num, db->submodel_num, &v1, &v2 );
-					} else {
-						submodel_get_two_random_points_better( db->model_num, db->submodel_num, &v1, &v2 );
-					}
-					
+					submodel_get_two_random_points_better(db->model_num, db->submodel_num, &v1, &v2);
+
 					db->arc_pts[i][mr % 2] = v1;
 				}
 			}

--- a/code/lab/lab.cpp
+++ b/code/lab/lab.cpp
@@ -2113,9 +2113,11 @@ void lab_init()
 
 	// the default insignia bitmap
 	Lab_insignia_index = 0;
-	Assert((Lab_insignia_index < Num_pilot_squad_images));
+	if (Num_pilot_squad_images > 0) {
+		Assert((Lab_insignia_index < Num_pilot_squad_images));
 
-	Lab_insignia_bitmap = bm_load_duplicate(Pilot_squad_image_names[Lab_insignia_index]);
+		Lab_insignia_bitmap = bm_load_duplicate(Pilot_squad_image_names[Lab_insignia_index]);
+	}
 
 	// enable post-processing by default in the lab
 	PostProcessing_override = false;
@@ -2201,7 +2203,7 @@ void lab_do_frame(float frametime)
 		switch (key) {
 			// switch between the current insignia bitmap to render with
 		case KEY_DIVIDE: {
-			if (!(Lab_viewer_flags & LAB_FLAG_SHOW_INSIGNIA)) {
+			if (!(Lab_viewer_flags & LAB_FLAG_SHOW_INSIGNIA) || (Num_pilot_squad_images == 0)) {
 				break;
 			}
 

--- a/code/lab/lab.cpp
+++ b/code/lab/lab.cpp
@@ -1,20 +1,18 @@
 /*
-* lab.cpp
-* created by WMCoolmon
-*
-* You may not sell or otherwise commercially exploit the source or things you
-* create based on the source.
-*
-*/
+ * lab.cpp
+ * created by WMCoolmon
+ *
+ * You may not sell or otherwise commercially exploit the source or things you
+ * create based on the source.
+ *
+ */
 
-
-
-#include "cmdline/cmdline.h"
 #include "freespace.h"
+#include "cmdline/cmdline.h"
 #include "gamesequence/gamesequence.h"
+#include "graphics/light.h"
 #include "graphics/matrix.h"
 #include "graphics/shadows.h"
-#include "graphics/light.h"
 #include "hud/hudshield.h"
 #include "io/key.h"
 #include "io/timer.h"
@@ -23,69 +21,68 @@
 #include "mission/missionparse.h"
 #include "missionui/missionscreencommon.h"
 #include "model/model.h"
+#include "model/modelrender.h"
+#include "nebula/neb.h"
 #include "object/objectsnd.h"
 #include "playerman/managepilot.h"
 #include "render/3d.h"
 #include "render/batching.h"
 #include "ship/ship.h"
 #include "species_defs/species_defs.h"
+#include "starfield/nebula.h"
+#include "starfield/starfield.h"
+#include "tracing/tracing.h"
 #include "weapon/beam.h"
 #include "weapon/weapon.h"
-#include "starfield/starfield.h"
-#include "starfield/nebula.h"
-#include "nebula/neb.h"
-#include "model/modelrender.h"
-#include "tracing/tracing.h"
 #include <utility>
 
 // flags
-#define LAB_FLAG_NORMAL				(0)		// default
-#define LAB_FLAG_NO_ROTATION		(1<<0)	// don't rotate models
-#define LAB_FLAG_SHOW_INSIGNIA		(1<<1)	// show ships with insignia applied
-#define LAB_FLAG_SHOW_DEBRIS		(1<<2)	// render debris instead of normal LOD
-#define LAB_FLAG_SUBMODEL_ROTATE	(1<<3)	// do rotation for any rotating ship subobjects
-#define LAB_FLAG_LIGHTNING_ARCS		(1<<4)	// show damage lightning
-#define LAB_FLAG_UNUSED				(1<<5)	// feel free to change that to something you need - Valathil
-#define LAB_FLAG_SHOW_WEAPONS		(1<<6)	// determines if external weapons models are displayed
-#define LAB_FLAG_INITIAL_ROTATION	(1<<7)	// initial rotation setting
-#define LAB_FLAG_DESTROYED_SUBSYSTEMS	(1<<8)	// render model as if all subsystems are destroyed
+#define LAB_FLAG_NORMAL (0)                    // default
+#define LAB_FLAG_NO_ROTATION (1 << 0)          // don't rotate models
+#define LAB_FLAG_SHOW_INSIGNIA (1 << 1)        // show ships with insignia applied
+#define LAB_FLAG_SHOW_DEBRIS (1 << 2)          // render debris instead of normal LOD
+#define LAB_FLAG_SUBMODEL_ROTATE (1 << 3)      // do rotation for any rotating ship subobjects
+#define LAB_FLAG_LIGHTNING_ARCS (1 << 4)       // show damage lightning
+#define LAB_FLAG_UNUSED (1 << 5)               // feel free to change that to something you need - Valathil
+#define LAB_FLAG_SHOW_WEAPONS (1 << 6)         // determines if external weapons models are displayed
+#define LAB_FLAG_INITIAL_ROTATION (1 << 7)     // initial rotation setting
+#define LAB_FLAG_DESTROYED_SUBSYSTEMS (1 << 8) // render model as if all subsystems are destroyed
 
 // modes
-#define LAB_MODE_NONE		0	// not showing anything
-#define LAB_MODE_SHIP		1	// dealing with ships
-#define LAB_MODE_WEAPON		2	// dealing with weapons
-
+#define LAB_MODE_NONE 0   // not showing anything
+#define LAB_MODE_SHIP 1   // dealing with ships
+#define LAB_MODE_WEAPON 2 // dealing with weapons
 
 // variables
-static GUIScreen *Lab_screen = NULL;
-static Window *Lab_toolbar = NULL;
-static Window *Lab_class_window = NULL;
-static Window *Lab_class_toolbar = NULL;
-static Window *Lab_flags_window = NULL;
-static Window *Lab_render_options_window = NULL;
-static Window *Lab_material_override_window = NULL;
-static Window *Lab_variables_window = NULL;
-static Window *Lab_description_window = NULL;
-static Window *Lab_background_window = NULL;
-static Text *Lab_description_text = NULL;
-static TreeItem **Lab_species_nodes = NULL;
+static GUIScreen* Lab_screen                = nullptr;
+static Window* Lab_toolbar                  = nullptr;
+static Window* Lab_class_window             = nullptr;
+static Window* Lab_class_toolbar            = nullptr;
+static Window* Lab_flags_window             = nullptr;
+static Window* Lab_render_options_window    = nullptr;
+static Window* Lab_material_override_window = nullptr;
+static Window* Lab_variables_window         = nullptr;
+static Window* Lab_description_window       = nullptr;
+static Window* Lab_background_window        = nullptr;
+static Text* Lab_description_text           = nullptr;
+static TreeItem** Lab_species_nodes         = nullptr;
 
-static Tree *ship_tree = nullptr;
-static Tree *weap_tree = nullptr;
+static Tree* ship_tree = nullptr;
+static Tree* weap_tree = nullptr;
 
-//holds the beginning and ending indices of each specie/type of ship/weapon
+// holds the beginning and ending indices of each specie/type of ship/weapon
 static SCP_vector<std::pair<TreeItem*, TreeItem*>> ship_list_endpoints;
 static SCP_vector<std::pair<TreeItem*, TreeItem*>> weap_list_endpoints;
 
-static TreeItem *Lab_last_selected_object = nullptr;
+static TreeItem* Lab_last_selected_object = nullptr;
 
 static int Lab_insignia_bitmap = -1;
-static int Lab_insignia_index = -1;
+static int Lab_insignia_index  = -1;
 
-static ubyte Lab_mode = LAB_MODE_NONE;
-static int Lab_selected_index = -1;
-static int Lab_last_selected_ship = -1;
-static int Lab_selected_object = -1;
+static ubyte Lab_mode               = LAB_MODE_NONE;
+static int Lab_selected_index       = -1;
+static int Lab_last_selected_ship   = -1;
+static int Lab_selected_object      = -1;
 static int Lab_last_selected_weapon = -1;
 
 static int Lab_model_num = -1;
@@ -97,77 +94,81 @@ static char Lab_weaponmodel_filename[MAX_SHIP_WEAPONS][MAX_FILENAME_LEN];
 static vec3d Lab_model_pos = ZERO_VECTOR;
 
 static matrix Lab_model_orient = vmd_identity_matrix;
-static int Lab_viewer_flags = LAB_MODE_NONE;
+static int Lab_viewer_flags    = LAB_MODE_NONE;
 
 static int Lab_detail_texture_save = 0;
 
 SCP_string Lab_selected_mission = "None";
-matrix Lab_skybox_orientation = vmd_identity_matrix;
+matrix Lab_skybox_orientation   = vmd_identity_matrix;
 
 static int anim_timer_start = 0;
 
-static float Lab_thrust_len = 1.0f;
+static float Lab_thrust_len      = 1.0f;
 static bool Lab_thrust_afterburn = false;
+
+enum class Lab_rotation_modes { Both, Yaw, Pitch, Roll };
+static Lab_rotation_modes Lab_rotation_mode    = Lab_rotation_modes::Both;
+static float Lab_manual_rotation_speed_divisor = 100.f;
 
 // Trackball_mode:
 //   1  ==  rotate	(left-mouse)
 //   2  ==  pan		(shift-left-mouse)
 //   3  ==  zoom	(right-mouse)
-static int Trackball_mode = 1;
+static int Trackball_mode   = 1;
 static int Trackball_active = 0;
 
 SCP_string Lab_team_color = "<none>";
 
 camid Lab_cam;
 float lab_cam_distance = 100.0f;
-float lab_cam_phi = 1.24f; // Values chosen to approximate the initial rotation used previously
-float lab_cam_theta = 2.25f;
-bool Lab_render_wireframe = false;
-bool Lab_render_without_light = false;
+float lab_cam_phi      = 0;
+float lab_cam_theta	   = 0;
+bool Lab_render_wireframe      = false;
+bool Lab_render_without_light  = false;
 bool Lab_render_show_thrusters = false;
-bool Lab_render_show_detail = false;
-bool Lab_render_show_shields = false;
-bool Lab_rotate_subobjects = true;
+bool Lab_render_show_detail    = false;
+bool Lab_render_show_shields   = false;
+bool Lab_rotate_subobjects     = true;
 
-bool Lab_Basemap_override    = false;
-bool Lab_Glowmap_override	 = false;
-bool Lab_Specmap_override	 = false;
-bool Lab_Envmap_override	 = false;
-bool Lab_Normalmap_override	 = false;
-bool Lab_Heightmap_override	 = false;
-bool Lab_Miscmap_override    = false;
+bool Lab_Basemap_override        = false;
+bool Lab_Glowmap_override        = false;
+bool Lab_Specmap_override        = false;
+bool Lab_Envmap_override         = false;
+bool Lab_Normalmap_override      = false;
+bool Lab_Heightmap_override      = false;
+bool Lab_Miscmap_override        = false;
 bool Lab_emissive_light_override = !Cmdline_no_emissive;
 
 fix Lab_Save_Missiontime;
 
 // functions
-void labviewer_change_ship_lod(Tree *caller);
-void labviewer_change_ship(Tree *caller);
-void labviewer_make_desc_window(Button *caller);
+void labviewer_change_ship_lod(Tree* caller);
+void labviewer_change_ship(Tree* caller);
+void labviewer_make_desc_window(Button* caller);
 void labviewer_update_flags_window();
-
 
 // ---------------------- General/Utility Functions ----------------------------
 
 void rotate_view(int dx, int dy)
 {
-	if (dx == 0 && dy == 0) return;
+	if (dx == 0 && dy == 0)
+		return;
 
 	lab_cam_theta += dx / 100.0f;
 	lab_cam_phi += dy / 100.0f;
-	
+
 	CLAMP(lab_cam_phi, 0.01f, PI - 0.01f);
 }
 
-void labviewer_change_model(char *model_fname, int lod = 0, int sel_index = -1)
+void labviewer_change_model(char* model_fname, int lod = 0, int sel_index = -1)
 {
 	bool change_model = true;
 	int j, l;
-	ship_info *sip = NULL;
+	ship_info* sip = nullptr;
 
 	anim_timer_start = timer_get_milliseconds();
 
-	if ((model_fname != NULL) && (Lab_mode == LAB_MODE_SHIP)) {
+	if ((model_fname != nullptr) && (Lab_mode == LAB_MODE_SHIP)) {
 		if ((Lab_selected_index >= 0) && (Lab_selected_index == sel_index)) {
 			change_model = false;
 		}
@@ -197,10 +198,11 @@ void labviewer_change_model(char *model_fname, int lod = 0, int sel_index = -1)
 		}
 
 		// only load a new model if we are supposed to (so that we can use this function to reset states)
-		if (model_fname != NULL) {
-			model_subsystem *subsystems = NULL;
-			
-			Lab_model_num = model_load(model_fname, (valid_ship) ? Ship_info[sel_index].n_subsystems : 0, subsystems, 0);
+		if (model_fname != nullptr) {
+			model_subsystem* subsystems = nullptr;
+
+			Lab_model_num =
+			    model_load(model_fname, (valid_ship) ? Ship_info[sel_index].n_subsystems : 0, subsystems, 0);
 
 			if (valid_ship) {
 				if (Lab_model_num >= 0) {
@@ -211,43 +213,40 @@ void labviewer_change_model(char *model_fname, int lod = 0, int sel_index = -1)
 			// do the same for weapon models if necessary
 			if (Lab_mode == LAB_MODE_SHIP) {
 				sip = &Ship_info[Lab_selected_index];
-				l = 0;
+				l   = 0;
 				for (j = 0; j < sip->num_primary_banks; j++) {
-					weapon_info *wip = &Weapon_info[sip->primary_bank_weapons[j]];
+					weapon_info* wip = &Weapon_info[sip->primary_bank_weapons[j]];
 					if (!sip->draw_primary_models[j])
 						continue;
 					Lab_weaponmodel_num[l] = -1;
 					if (strlen(wip->external_model_name)) {
-						Lab_weaponmodel_num[l] = model_load(wip->external_model_name, 0, NULL);
+						Lab_weaponmodel_num[l] = model_load(wip->external_model_name, 0, nullptr);
 					}
 					if (Lab_weaponmodel_num[l] >= 0) {
 						strcpy_s(Lab_weaponmodel_filename[l], wip->external_model_name);
-					}
-					else {
+					} else {
 						memset(Lab_weaponmodel_filename[l], 0, sizeof(Lab_weaponmodel_filename[l]));
 					}
 					l++;
 				}
 
 				for (j = 0; j < sip->num_secondary_banks; j++) {
-					weapon_info *wip = &Weapon_info[sip->secondary_bank_weapons[j]];
+					weapon_info* wip = &Weapon_info[sip->secondary_bank_weapons[j]];
 					if (!sip->draw_secondary_models[j])
 						continue;
 					Lab_weaponmodel_num[l] = -1;
 					if (strlen(wip->external_model_name)) {
-						Lab_weaponmodel_num[l] = model_load(wip->external_model_name, 0, NULL);
+						Lab_weaponmodel_num[l] = model_load(wip->external_model_name, 0, nullptr);
 					}
 					if (Lab_weaponmodel_num[l] >= 0) {
 						strcpy_s(Lab_weaponmodel_filename[l], wip->external_model_name);
-					}
-					else {
+					} else {
 						memset(Lab_weaponmodel_filename[l], 0, sizeof(Lab_weaponmodel_filename[l]));
 					}
 					l++;
 				}
 			}
-		}
-		else {
+		} else {
 			// clear out the model filename
 			memset(Lab_model_filename, 0, sizeof(Lab_model_filename));
 			if (Lab_weaponmodel_num[0] >= 0) {
@@ -261,13 +260,12 @@ void labviewer_change_model(char *model_fname, int lod = 0, int sel_index = -1)
 	if (lod == 99) {
 		Lab_model_LOD = 0;
 		Lab_viewer_flags |= LAB_FLAG_SHOW_DEBRIS;
-	}
-	else {
+	} else {
 		Lab_model_LOD = lod;
 		Lab_viewer_flags &= ~LAB_FLAG_SHOW_DEBRIS;
 	}
 
-	if (model_fname == NULL) {
+	if (model_fname == nullptr) {
 		Lab_last_selected_ship = -1;
 	}
 
@@ -295,8 +293,7 @@ void labviewer_render_model(float frametime)
 {
 	angles rot_angles;
 	float rev_rate;
-
-	ship_info *sip = NULL;
+	ship_info* sip = nullptr;
 
 	if (Lab_selected_object != -1 && (Objects[Lab_selected_object].type == OBJ_SHIP) && (Lab_selected_index >= 0)) {
 		sip = &Ship_info[Lab_selected_index];
@@ -307,11 +304,10 @@ void labviewer_render_model(float frametime)
 	// get correct revolution rate
 	rev_rate = REVOLUTION_RATE;
 
-	if (sip != NULL) {
+	if (sip != nullptr) {
 		if (sip->is_big_ship()) {
 			rev_rate *= 1.7f;
-		}
-		else if (sip->is_huge_ship()) {
+		} else if (sip->is_huge_ship()) {
 			rev_rate *= 3.0f;
 		}
 	}
@@ -319,30 +315,51 @@ void labviewer_render_model(float frametime)
 	// rotate/pan/zoom the model as much as required for this frame
 	if (Trackball_active) {
 		int dx, dy;
-		matrix mat1, mat2;
 
 		mouse_get_delta(&dx, &dy);
 
 		if (dx || dy) {
 			// Rotate the ship
-			if (Trackball_mode == 1)
-			{
-				vm_trackball(-dx, -dy, &mat1);
-				vm_matrix_x_matrix(&mat2, &mat1, &Lab_model_orient);
+			if (Trackball_mode == 1) {
+				angles rot_angle;
+				vm_extract_angles_matrix_alternate(&rot_angle, &Lab_model_orient);
 
-				Lab_model_orient = mat2;
+				if (Lab_rotation_mode == Lab_rotation_modes::Yaw) {
+					rot_angle.h += dx / Lab_manual_rotation_speed_divisor;
+				}
+				if (Lab_rotation_mode == Lab_rotation_modes::Pitch) {
+					rot_angle.p += dy / Lab_manual_rotation_speed_divisor;
+				}
+				if (Lab_rotation_mode == Lab_rotation_modes::Both) {
+					rot_angle.h += dx / Lab_manual_rotation_speed_divisor;
+					rot_angle.p += dy / Lab_manual_rotation_speed_divisor;
+				}
+				if (Lab_rotation_mode == Lab_rotation_modes::Roll) {
+					rot_angle.b += dx / Lab_manual_rotation_speed_divisor;
+				}
 
+				if (rot_angle.h < -PI)
+					rot_angle.h = PI - 0.001f;
+				if (rot_angle.h > PI)
+					rot_angle.h = -PI + 0.001f;
+
+				CLAMP(rot_angle.p, -PI_2, PI_2);
+
+				if (rot_angle.b < -PI)
+					rot_angle.b = PI - 0.001f;
+				if (rot_angle.b > PI)
+					rot_angle.b = -PI + 0.001f;
+
+				vm_angles_2_matrix(&Lab_model_orient, &rot_angle);
 			}
 			// zoom in/out
-			else if (Trackball_mode == 2)
-			{
+			else if (Trackball_mode == 2) {
 				lab_cam_distance *= 1.0f + (dy / 20.0f);
 				if (lab_cam_distance < 1.0f)
 					lab_cam_distance = 1.0f;
 			}
 			// rotate background
-			else if (Trackball_mode == 3)
-			{
+			else if (Trackball_mode == 3) {
 				rotate_view(dx, dy);
 			}
 
@@ -350,31 +367,29 @@ void labviewer_render_model(float frametime)
 		}
 	}
 	// otherwise do orient/rotation calculation, if we are supposed to
-	else if (!(Lab_viewer_flags & LAB_FLAG_NO_ROTATION))
-	{
+	else if (!(Lab_viewer_flags & LAB_FLAG_NO_ROTATION)) {
 		rot_angles.p = 0.0f;
 		rot_angles.b = 0.0f;
 		rot_angles.h = PI2 * frametime / rev_rate;
 		vm_rotate_matrix_by_angles(&Lab_model_orient, &rot_angles);
 	}
 
-	if (Lab_selected_object != -1)
-	{
-		auto lab_render_light_save = Lab_render_without_light;
+	if (Lab_selected_object != -1) {
+		auto lab_render_light_save    = Lab_render_without_light;
 		auto lab_debris_override_save = Cmdline_nomotiondebris;
 		auto lab_envmap_override_save = Envmap_override;
-		auto lab_emissive_light_save = Cmdline_no_emissive;
+		auto lab_emissive_light_save  = Cmdline_no_emissive;
 
 		if (Lab_selected_mission == "None") {
 			Lab_render_without_light = true;
-			Cmdline_nomotiondebris = 1;
+			Cmdline_nomotiondebris   = 1;
 		}
 
 		Cmdline_no_emissive = !Lab_emissive_light_override;
 
 		object* obj = &Objects[Lab_selected_object];
 
-		obj->pos = Lab_model_pos;
+		obj->pos    = Lab_model_pos;
 		obj->orient = Lab_model_orient;
 
 		Envmap_override = Lab_Envmap_override;
@@ -396,9 +411,6 @@ void labviewer_render_model(float frametime)
 
 			Ships[obj->instance].team_name = Lab_team_color;
 		}
-		else if (obj->type == OBJ_WEAPON) 
-		{
-		}
 
 		if (Lab_render_wireframe)
 			model_render_set_wireframe_color(&Color_white);
@@ -411,8 +423,7 @@ void labviewer_render_model(float frametime)
 				obj->phys_info.flags |= PF_AFTERBURNER_ON;
 			else
 				obj->phys_info.flags &= ~PF_AFTERBURNER_ON;
-		}
-		else {
+		} else {
 			obj->phys_info.forward_thrust = 0.0f;
 
 			if (obj->type == OBJ_SHIP)
@@ -424,17 +435,49 @@ void labviewer_render_model(float frametime)
 		Trail_render_override = false;
 
 		Lab_render_without_light = lab_render_light_save;
-		Cmdline_nomotiondebris = lab_debris_override_save;
-		Envmap_override = lab_envmap_override_save;
-		Cmdline_no_emissive = lab_emissive_light_save;
+		Cmdline_nomotiondebris   = lab_debris_override_save;
+		Envmap_override          = lab_envmap_override_save;
+		Cmdline_no_emissive      = lab_emissive_light_save;
 
 		gr_reset_clip();
 		gr_set_color_fast(&HUD_color_debug);
 		if (Cmdline_frame_profile) {
 			tracing::frame_profile_process_frame();
 			gr_string(gr_screen.center_offset_x + 20, gr_screen.center_offset_y + 100 + gr_get_font_height() + 1,
-				tracing::get_frame_profile_output().c_str(), GR_RESIZE_NONE);
+			          tracing::get_frame_profile_output().c_str(), GR_RESIZE_NONE);
 		}
+	}
+}
+
+SCP_string get_rot_mode_string(Lab_rotation_modes rotmode)
+{
+	switch (rotmode) {
+	case Lab_rotation_modes::Both:
+		return "Manual rotation mode: Pitch and Yaw";
+	case Lab_rotation_modes::Pitch:
+		return "Manual rotation mode: Pitch";
+	case Lab_rotation_modes::Yaw:
+		return "Manual rotation mode: Yaw";
+	case Lab_rotation_modes::Roll:
+		return "Manual rotation mode: Roll";
+	default:
+		return "HOW DID THIS HAPPEN? Ask a coder!";
+	}
+}
+
+SCP_string get_rot_speed_string(float speed_divisor)
+{
+	auto exp = std::lroundf(log10f(speed_divisor));
+
+	switch (exp) {
+	case 2:
+		return "Fast";
+	case 3:
+		return "Slow";
+	case 4:
+		return "Slowest";
+	default:
+		return "HOW DID THIS HAPPEN? Ask a coder!";
 	}
 }
 
@@ -452,7 +495,8 @@ void labviewer_do_render(float frametime)
 		if (strlen(Lab_model_filename)) {
 			gr_get_string_size(&w, &h, Lab_model_filename);
 			gr_set_color_fast(&Color_white);
-			gr_string(gr_screen.center_offset_x + gr_screen.center_w - w, gr_screen.center_offset_y + gr_screen.center_h - h, Lab_model_filename, GR_RESIZE_NONE);
+			gr_string(gr_screen.center_offset_x + gr_screen.center_w - w,
+			          gr_screen.center_offset_y + gr_screen.center_h - h, Lab_model_filename, GR_RESIZE_NONE);
 		}
 	}
 
@@ -466,25 +510,45 @@ void labviewer_do_render(float frametime)
 	gr_set_color_fast(&Color_white);
 
 	if (frametotal != 0.0f) {
-		gr_printf_no_resize(gr_screen.center_offset_x + 2, gr_screen.center_offset_y + gr_screen.center_h - gr_get_font_height(), "FPS: %3i Camera Distance: %4f", (int)std::lround(Framerate), lab_cam_distance);
-	}
-	else {
-		gr_string(gr_screen.center_offset_x + 10, gr_screen.center_offset_y + gr_screen.center_h - gr_get_font_height(), "FPS: ?", GR_RESIZE_NONE);
+		gr_printf_no_resize(gr_screen.center_offset_x + 2,
+		                    gr_screen.center_offset_y + gr_screen.center_h - gr_get_font_height(),
+		                    "FPS: %3i Camera Distance: %4f", (int)std::lround(Framerate), lab_cam_distance);
+	} else {
+		gr_string(gr_screen.center_offset_x + 10, gr_screen.center_offset_y + gr_screen.center_h - gr_get_font_height(),
+		          "FPS: ?", GR_RESIZE_NONE);
 	}
 
-	//Print FXAA preset
+	// Print FXAA preset
 	if (Cmdline_fxaa && !PostProcessing_override)
-		gr_printf_no_resize(gr_screen.center_offset_x + 2, gr_screen.center_offset_y + gr_screen.center_h - (gr_get_font_height() * 2) - 3, "FXAA Preset: %i", Cmdline_fxaa_preset);
-	
-	//Print current Team Color setting, if any
-	if (Lab_team_color != "<none>")
-		gr_printf_no_resize(gr_screen.center_offset_x + 2, gr_screen.center_offset_y + gr_screen.center_h - (gr_get_font_height() * 3) - 3, "Use T and Y to cycle through available Team Color settings. Current: %s", Lab_team_color.c_str());
+		gr_printf_no_resize(gr_screen.center_offset_x + 2,
+		                    gr_screen.center_offset_y + gr_screen.center_h - (gr_get_font_height() * 2) - 3,
+		                    "FXAA Preset: %i", Cmdline_fxaa_preset);
 
-	//Camera usage info
-	gr_printf_no_resize(gr_screen.center_offset_x + 2, gr_screen.center_offset_y + gr_screen.center_h - (gr_get_font_height() * 4) - 3, "Hold LMB to rotate the ship or weapon. Hold RMB to rotate the Camera. Hold Shift + LMB to zoom in or out. Use number keys to switch between FXAA presets.");
+	// Print current Team Color setting, if any
+	if (Lab_team_color != "<none>")
+		gr_printf_no_resize(gr_screen.center_offset_x + 2,
+		                    gr_screen.center_offset_y + gr_screen.center_h - (gr_get_font_height() * 3) - 3,
+		                    "Use T and Y to cycle through available Team Color settings. Current: %s",
+		                    Lab_team_color.c_str());
+
+	// Camera usage info
+	gr_printf_no_resize(gr_screen.center_offset_x + 2,
+	                    gr_screen.center_offset_y + gr_screen.center_h - (gr_get_font_height() * 4) - 3,
+	                    "Hold LMB to rotate the ship or weapon. Hold RMB to rotate the Camera. Hold Shift + LMB to "
+	                    "zoom in or out. Use number keys to switch between FXAA presets. R to cycle model rotation "
+	                    "modes, S to cycle model rotation speeds.");
+
+	// Rotation mode
+	angles rot_angle;
+	vm_extract_angles_matrix(&rot_angle, &Lab_model_orient);
+	SCP_string text = get_rot_mode_string(Lab_rotation_mode);
+	gr_printf_no_resize(gr_screen.center_offset_x + 2,
+	                    gr_screen.center_offset_y + gr_screen.center_h - (gr_get_font_height() * 5) - 3,
+	                    "%s Rotation speed: %s", get_rot_mode_string(Lab_rotation_mode).c_str(),
+	                    get_rot_speed_string(Lab_manual_rotation_speed_divisor).c_str());
 }
 
-void labviewer_exit(Button * /*caller*/)
+void labviewer_exit(Button* /*caller*/)
 {
 	if (Lab_selected_object != -1) {
 		obj_delete(Lab_selected_object);
@@ -493,29 +557,32 @@ void labviewer_exit(Button * /*caller*/)
 }
 
 // ----------------------------  Class Window ----------------------------------
-void labviewer_close_class_window(GUIObject * /*caller*/)
+void labviewer_close_class_window(GUIObject* /*caller*/)
 {
 	if (Lab_class_toolbar) {
 		Lab_class_toolbar->DeleteChildren();
 	}
 
-	Lab_class_window = NULL;
+	Lab_class_window = nullptr;
 
 	Lab_mode = LAB_MODE_NONE;
 
 	// reset any existing model/bitmap that is showing
-	labviewer_change_model(NULL);
+	labviewer_change_model(nullptr);
 }
 
 void labviewer_set_class_window(int mode)
 {
-	if (Lab_class_window == NULL) {
-		Lab_class_window = (Window*)Lab_screen->Add(new Window("Class Window", gr_screen.center_offset_x + 50, gr_screen.center_offset_y + 50));
+	if (Lab_class_window == nullptr) {
+		Lab_class_window = (Window*)Lab_screen->Add(
+		    new Window("Class Window", gr_screen.center_offset_x + 50, gr_screen.center_offset_y + 50));
 		Lab_class_window->SetCloseFunction(labviewer_close_class_window);
 	}
 
-	if (Lab_class_toolbar == NULL) {
-		Lab_class_toolbar = (Window*)Lab_screen->Add(new Window("Class Toolbar", gr_screen.center_offset_x + 0, gr_screen.center_offset_y + Lab_toolbar->GetHeight(), -1, -1, WS_NOTITLEBAR | WS_NONMOVEABLE));
+	if (Lab_class_toolbar == nullptr) {
+		Lab_class_toolbar = (Window*)Lab_screen->Add(new Window("Class Toolbar", gr_screen.center_offset_x + 0,
+		                                                        gr_screen.center_offset_y + Lab_toolbar->GetHeight(),
+		                                                        -1, -1, WS_NOTITLEBAR | WS_NONMOVEABLE));
 	}
 
 	// clear out all existing children
@@ -525,18 +592,16 @@ void labviewer_set_class_window(int mode)
 	// set our new title
 	if (mode == LAB_MODE_SHIP) {
 		Lab_class_window->SetCaption("Ship Classes");
-	}
-	else if (mode == LAB_MODE_WEAPON) {
+	} else if (mode == LAB_MODE_WEAPON) {
 		Lab_class_window->SetCaption("Weapon Classes");
 	}
 
 	// reset any existing model/bitmap that is showing
-	labviewer_change_model(NULL);
+	labviewer_change_model(nullptr);
 }
 
-
 // ------------------------------  Flags Window --------------------------------
-template<class T>
+template <class T>
 struct lab_flag {
 	Checkbox* cb;
 	T flag;
@@ -547,7 +612,7 @@ static SCP_vector<lab_flag<Weapon::Info_Flags>> Weapon_Class_Flags;
 
 void labviewer_flags_clear()
 {
-	if (Lab_flags_window != NULL) {
+	if (Lab_flags_window != nullptr) {
 		Lab_flags_window->DeleteChildren();
 	}
 
@@ -556,11 +621,11 @@ void labviewer_flags_clear()
 }
 
 template <class T>
-void labviewer_flags_add(int* X, int* Y, const char *flag_name, T flag, SCP_vector<lab_flag<T>>& flag_list)
+void labviewer_flags_add(int* X, int* Y, const char* flag_name, T flag, SCP_vector<lab_flag<T>>& flag_list)
 {
 	int x = 0, y = 0;
 
-	Assert((Lab_flags_window != NULL) && (flag_name != NULL));
+	Assert((Lab_flags_window != nullptr) && (flag_name != nullptr));
 
 	lab_flag<T> new_flag;
 
@@ -572,7 +637,7 @@ void labviewer_flags_add(int* X, int* Y, const char *flag_name, T flag, SCP_vect
 		y = *Y;
 	}
 
-	new_flag.cb = (Checkbox*)Lab_flags_window->AddChild(new Checkbox(flag_name, x, y));
+	new_flag.cb   = (Checkbox*)Lab_flags_window->AddChild(new Checkbox(flag_name, x, y));
 	new_flag.flag = flag;
 	flag_list.push_back(new_flag);
 
@@ -591,7 +656,7 @@ void labviewer_populate_flags_window()
 		return;
 	}
 
-	if (Lab_flags_window == NULL) {
+	if (Lab_flags_window == nullptr) {
 		return;
 	}
 
@@ -602,16 +667,15 @@ void labviewer_populate_flags_window()
 
 	// ship flags ...
 	if (Lab_mode == LAB_MODE_SHIP) {
-		for (size_t i = 0; i < Num_ship_flags; ++i)
-		{
+		for (size_t i = 0; i < Num_ship_flags; ++i) {
 			labviewer_flags_add<Ship::Info_Flags>(nullptr, &y, Ship_flags[i].name, Ship_flags[i].def, Ship_Class_Flags);
 		}
 	}
 	// weapon flags ...
 	else if (Lab_mode == LAB_MODE_WEAPON) {
-		for (size_t i = 0; i < num_weapon_info_flags; ++i)
-		{
-			labviewer_flags_add<Weapon::Info_Flags>(nullptr, &y, Weapon_Info_Flags[i].name, Weapon_Info_Flags[i].def, Weapon_Class_Flags);
+		for (size_t i = 0; i < num_weapon_info_flags; ++i) {
+			labviewer_flags_add<Weapon::Info_Flags>(nullptr, &y, Weapon_Info_Flags[i].name, Weapon_Info_Flags[i].def,
+			                                        Weapon_Class_Flags);
 		}
 	}
 }
@@ -625,43 +689,42 @@ void labviewer_update_flags_window()
 	if (Lab_mode == LAB_MODE_SHIP) {
 		auto sip = &Ship_info[Lab_selected_index];
 
-		for (auto flag_def : Ship_Class_Flags)
-		{
-			if (flag_def.flag == Ship::Info_Flags::NUM_VALUES) continue;
+		for (auto flag_def : Ship_Class_Flags) {
+			if (flag_def.flag == Ship::Info_Flags::NUM_VALUES)
+				continue;
 			flag_def.cb->SetFlag(sip->flags, flag_def.flag, sip);
 		}
-	}
-	else if (Lab_mode == LAB_MODE_WEAPON) {
+	} else if (Lab_mode == LAB_MODE_WEAPON) {
 		auto wip = &Weapon_info[Lab_selected_index];
 
-		for (auto flag_def : Weapon_Class_Flags)
-		{
-			if (flag_def.flag == Weapon::Info_Flags::NUM_VALUES) continue;
+		for (auto flag_def : Weapon_Class_Flags) {
+			if (flag_def.flag == Weapon::Info_Flags::NUM_VALUES)
+				continue;
 			flag_def.cb->SetFlag(wip->wi_flags, flag_def.flag, wip);
 		}
 	}
 }
 
-void labviewer_close_flags_window(GUIObject * /*caller*/)
+void labviewer_close_flags_window(GUIObject* /*caller*/)
 {
-	Lab_flags_window = NULL;
+	Lab_flags_window = nullptr;
 
 	Ship_Class_Flags.empty();
 	Weapon_Class_Flags.empty();
 }
 
-void labviewer_make_flags_window(Button * /*caller*/)
+void labviewer_make_flags_window(Button* /*caller*/)
 {
-	if (Lab_flags_window == NULL) {
-		Lab_flags_window = (Window*)Lab_screen->Add(new Window("Flags Window", gr_screen.center_offset_x + gr_screen.center_w - 205, gr_screen.center_offset_y + 200));
+	if (Lab_flags_window == nullptr) {
+		Lab_flags_window = (Window*)Lab_screen->Add(new Window(
+		    "Flags Window", gr_screen.center_offset_x + gr_screen.center_w - 205, gr_screen.center_offset_y + 200));
 		Lab_flags_window->SetCloseFunction(labviewer_close_flags_window);
 	}
 
 	// set our new title
 	if (Lab_mode == LAB_MODE_SHIP) {
 		Lab_flags_window->SetCaption("Ship Flags");
-	}
-	else if (Lab_mode == LAB_MODE_WEAPON) {
+	} else if (Lab_mode == LAB_MODE_WEAPON) {
 		Lab_flags_window->SetCaption("Weapon Flags");
 	}
 
@@ -673,39 +736,41 @@ void labviewer_make_flags_window(Button * /*caller*/)
 }
 
 // -----------------------   Variables Window   --------------------------------
-#define VAR_POS_LEFTWIDTH		150
-#define VAR_POS_RIGHTWIDTH		100
-#define VAR_POS_RIGHTX			160
+#define VAR_POS_LEFTWIDTH 150
+#define VAR_POS_RIGHTWIDTH 100
+#define VAR_POS_RIGHTX 160
 
-#define VAR_ADD_HEADER(name) {	\
-	ntp = (Text*)Lab_variables_window->AddChild(new Text((name), (name), VAR_POS_RIGHTX/2, y + 8, VAR_POS_RIGHTWIDTH));	\
-	y += ntp->GetHeight() + 10;	\
-}
+#define VAR_ADD_HEADER(name)                                                                                           \
+	{                                                                                                                  \
+		ntp = (Text*)Lab_variables_window->AddChild(                                                                   \
+		    new Text((name), (name), VAR_POS_RIGHTX / 2, y + 8, VAR_POS_RIGHTWIDTH));                                  \
+		y += ntp->GetHeight() + 10;                                                                                    \
+	}
 
 static SCP_vector<Text*> Lab_variables;
 
-void labviewer_close_variables_window(GUIObject * /*caller*/)
+void labviewer_close_variables_window(GUIObject* /*caller*/)
 {
-	Lab_variables_window = NULL;
+	Lab_variables_window = nullptr;
 
 	Lab_variables.clear();
 }
 
 void labviewer_variables_clear()
 {
-	if (Lab_variables_window != NULL) {
+	if (Lab_variables_window != nullptr) {
 		Lab_variables_window->DeleteChildren();
 	}
 
 	Lab_variables.clear();
 }
 
-void labviewer_variables_add(int *Y, const char *var_name)
+void labviewer_variables_add(int* Y, const char* var_name)
 {
 	int y = 0;
-	Text *new_text;
+	Text* new_text;
 
-	Assert((Lab_variables_window != NULL) && (var_name != NULL));
+	Assert((Lab_variables_window != nullptr) && (var_name != nullptr));
 
 	if (Y) {
 		y = *Y;
@@ -714,7 +779,8 @@ void labviewer_variables_add(int *Y, const char *var_name)
 	// variable
 	Lab_variables_window->AddChild(new Text((var_name), (var_name), 0, y, VAR_POS_LEFTWIDTH));
 	// edit box
-	new_text = (Text*)Lab_variables_window->AddChild(new Text(SCP_string((var_name)) + SCP_string("Editbox"), "", VAR_POS_RIGHTX, y, VAR_POS_RIGHTWIDTH, 12, T_EDITTABLE));
+	new_text = (Text*)Lab_variables_window->AddChild(new Text(SCP_string((var_name)) + SCP_string("Editbox"), "",
+	                                                          VAR_POS_RIGHTX, y, VAR_POS_RIGHTWIDTH, 12, T_EDITTABLE));
 
 	if (Y) {
 		*Y += new_text->GetHeight() + 2;
@@ -725,14 +791,14 @@ void labviewer_variables_add(int *Y, const char *var_name)
 
 void labviewer_populate_variables_window()
 {
-	Text *ntp;
+	Text* ntp;
 	int y;
 
 	if (Lab_mode == LAB_MODE_NONE) {
 		return;
 	}
 
-	if (Lab_variables_window == NULL) {
+	if (Lab_variables_window == nullptr) {
 		return;
 	}
 
@@ -833,23 +899,25 @@ void labviewer_populate_variables_window()
 	}
 }
 
-#define VAR_SET_VALUE(value) {	\
-	Assert( i < Lab_variables.size() );	\
-	Lab_variables[i]->SetText((value));	\
-	i++;	\
-}
+#define VAR_SET_VALUE(value)                                                                                           \
+	{                                                                                                                  \
+		Assert(i < Lab_variables.size());                                                                              \
+		Lab_variables[i]->SetText((value));                                                                            \
+		i++;                                                                                                           \
+	}
 
-#define VAR_SET_VALUE_SAVE(value, max_size) {	\
-	Assert( i < Lab_variables.size() );	\
-	Lab_variables[i]->SetText((value));	\
-	if ((max_size) < 1) {	\
-		Assert( (max_size) == 0 );	\
-		Lab_variables[i]->SetSaveLoc(&(value), T_ST_ONENTER);	\
-	} else {	\
-		Lab_variables[i]->SetSaveLoc(&(value), T_ST_ONENTER, (max_size), 0);	\
-	}	\
-	i++;	\
-}
+#define VAR_SET_VALUE_SAVE(value, max_size)                                                                            \
+	{                                                                                                                  \
+		Assert(i < Lab_variables.size());                                                                              \
+		Lab_variables[i]->SetText((value));                                                                            \
+		if ((max_size) < 1) {                                                                                          \
+			Assert((max_size) == 0);                                                                                   \
+			Lab_variables[i]->SetSaveLoc(&(value), T_ST_ONENTER);                                                      \
+		} else {                                                                                                       \
+			Lab_variables[i]->SetSaveLoc(&(value), T_ST_ONENTER, (max_size), 0);                                       \
+		}                                                                                                              \
+		i++;                                                                                                           \
+	}
 extern SCP_vector<SCP_string> Hud_shield_filenames;
 
 void labviewer_update_variables_window()
@@ -860,7 +928,7 @@ void labviewer_update_variables_window()
 		return;
 	}
 
-	if (Lab_variables_window == NULL) {
+	if (Lab_variables_window == nullptr) {
 		return;
 	}
 
@@ -872,7 +940,7 @@ void labviewer_update_variables_window()
 	// ship variables ...
 	if (Lab_mode == LAB_MODE_SHIP) {
 		Assert(Lab_selected_index < static_cast<int>(Ship_info.size()));
-		ship_info *sip = &Ship_info[Lab_selected_index];
+		ship_info* sip = &Ship_info[Lab_selected_index];
 
 		VAR_SET_VALUE(sip->name);
 		VAR_SET_VALUE_SAVE(sip->species, (int)(Species_info.size() - 1));
@@ -921,7 +989,7 @@ void labviewer_update_variables_window()
 	// weapon variables ...
 	else if (Lab_mode == LAB_MODE_WEAPON) {
 		Assert(Lab_selected_index < Num_weapon_types);
-		weapon_info *wip = &Weapon_info[Lab_selected_index];
+		weapon_info* wip = &Weapon_info[Lab_selected_index];
 
 		VAR_SET_VALUE(wip->get_display_string());
 		VAR_SET_VALUE_SAVE(wip->subtype, Num_weapon_subtypes - 1);
@@ -953,19 +1021,20 @@ void labviewer_update_variables_window()
 	}
 }
 
-void labviewer_make_variables_window(Button * /*caller*/)
+void labviewer_make_variables_window(Button* /*caller*/)
 {
-	if (Lab_variables_window != NULL) {
+	if (Lab_variables_window != nullptr) {
 		return;
 	}
 
-	Lab_variables_window = (Window*)Lab_screen->Add(new Window("Class Variables", gr_screen.center_offset_x + gr_screen.center_w - (VAR_POS_RIGHTX + VAR_POS_RIGHTWIDTH + 25), gr_screen.center_offset_y + 200));
+	Lab_variables_window = (Window*)Lab_screen->Add(new Window(
+	    "Class Variables", gr_screen.center_offset_x + gr_screen.center_w - (VAR_POS_RIGHTX + VAR_POS_RIGHTWIDTH + 25),
+	    gr_screen.center_offset_y + 200));
 
 	// set our new title
 	if (Lab_mode == LAB_MODE_SHIP) {
 		Lab_variables_window->SetCaption("Ship Variables");
-	}
-	else if (Lab_mode == LAB_MODE_WEAPON) {
+	} else if (Lab_mode == LAB_MODE_WEAPON) {
 		Lab_variables_window->SetCaption("Weapon Variables");
 	}
 
@@ -979,7 +1048,7 @@ void labviewer_make_variables_window(Button * /*caller*/)
 }
 
 // --------------------   Render Options Window   ------------------------------
-void labviewer_change_detail_texture(Tree *caller)
+void labviewer_change_detail_texture(Tree* caller)
 {
 	int slider_pos = (int)(caller->GetSelectedItem()->GetData());
 	Assert((slider_pos >= 0) && (slider_pos <= MAX_DETAIL_LEVEL));
@@ -987,48 +1056,48 @@ void labviewer_change_detail_texture(Tree *caller)
 	Detail.hardware_textures = slider_pos;
 }
 
-void labviewer_close_render_options_window(GUIObject * /*caller*/)
+void labviewer_close_render_options_window(GUIObject* /*caller*/) { Lab_render_options_window = nullptr; }
+
+#define ADD_RENDER_FLAG(text, flag, var)                                                                               \
+	{                                                                                                                  \
+		cbp = (Checkbox*)Lab_render_options_window->AddChild(new Checkbox((text), 2, y));                              \
+		cbp->SetFlag(&(flag), (var));                                                                                  \
+		y += cbp->GetHeight() + 2;                                                                                     \
+	}
+
+#define ADD_RENDER_BOOL(text, flag)                                                                                    \
+	{                                                                                                                  \
+		cbp = (Checkbox*)Lab_render_options_window->AddChild(new Checkbox((text), 2, y));                              \
+		cbp->SetBool(&(flag));                                                                                         \
+		y += cbp->GetHeight() + 1;                                                                                     \
+	}
+
+void labviewer_render_options_set_ambient_factor(Slider* caller)
 {
-	Lab_render_options_window = NULL;
+	gr_calculate_ambient_factor(fl2i(caller->GetSliderValue()));
 }
 
-#define ADD_RENDER_FLAG(text, flag, var) {	\
-	cbp = (Checkbox*)Lab_render_options_window->AddChild(new Checkbox((text), 2, y));	\
-	cbp->SetFlag(&(flag), (var));	\
-	y += cbp->GetHeight() + 2;	\
-}
-
-#define ADD_RENDER_BOOL(text, flag) {	\
-	cbp = (Checkbox*)Lab_render_options_window->AddChild(new Checkbox((text), 2, y));	\
-	cbp->SetBool(&(flag));	\
-	y += cbp->GetHeight() + 1;	\
-}
-
-void labviewer_render_options_set_ambient_factor(Slider *caller) {
-	gr_calculate_ambient_factor(fl2i( caller->GetSliderValue()));
-}
-
-void labviewer_render_options_set_static_light_factor(Slider *caller) {
+void labviewer_render_options_set_static_light_factor(Slider* caller)
+{
 	static_light_factor = caller->GetSliderValue();
 }
 
-void labviewer_render_options_set_bloom(Slider *caller) {
-	Cmdline_bloom_intensity = fl2i(caller->GetSliderValue());
-}
+void labviewer_render_options_set_bloom(Slider* caller) { Cmdline_bloom_intensity = fl2i(caller->GetSliderValue()); }
 
-void labviewer_make_render_options_window(Button * /*caller*/)
+void labviewer_make_render_options_window(Button* /*caller*/)
 {
-	Checkbox *cbp;
-	Tree *cmp;
-	TreeItem *ctip;
+	Checkbox* cbp;
+	Tree* cmp;
+	TreeItem* ctip;
 	int y = 0;
 
-	if (Lab_render_options_window != NULL) {
+	if (Lab_render_options_window != nullptr) {
 		return;
 	}
 
-	Lab_render_options_window = (Window*)Lab_screen->Add(new Window("Render Options", gr_screen.center_offset_x + gr_screen.center_w - 300, gr_screen.center_offset_y + 200));
-	Assert(Lab_render_options_window != NULL);
+	Lab_render_options_window = (Window*)Lab_screen->Add(new Window(
+	    "Render Options", gr_screen.center_offset_x + gr_screen.center_w - 300, gr_screen.center_offset_y + 200));
+	Assert(Lab_render_options_window != nullptr);
 
 	// add all of the flags that we want/need...
 
@@ -1071,18 +1140,24 @@ void labviewer_make_render_options_window(Button * /*caller*/)
 	ADD_RENDER_FLAG("Show Destroyed Subsystems", Lab_viewer_flags, LAB_FLAG_DESTROYED_SUBSYSTEMS);
 
 	ADD_RENDER_BOOL("Emissive Lighting", Lab_emissive_light_override);
-	Slider* sldr = (Slider*)Lab_render_options_window->AddChild(new Slider("Ambient Factor", 0, 128, 0, y + 2, labviewer_render_options_set_ambient_factor, Lab_render_options_window->GetWidth()));
+	Slider* sldr = (Slider*)Lab_render_options_window->AddChild(new Slider("Ambient Factor", 0, 128, 0, y + 2,
+	                                                                       labviewer_render_options_set_ambient_factor,
+	                                                                       Lab_render_options_window->GetWidth()));
 	y += sldr->GetHeight() + 1;
-	sldr = (Slider*)Lab_render_options_window->AddChild(new Slider("Direct. Lights", 0.0f, 2.0f, 0, y + 2, labviewer_render_options_set_static_light_factor, Lab_render_options_window->GetWidth()));
+	sldr = (Slider*)Lab_render_options_window->AddChild(new Slider("Direct. Lights", 0.0f, 2.0f, 0, y + 2,
+	                                                               labviewer_render_options_set_static_light_factor,
+	                                                               Lab_render_options_window->GetWidth()));
 	y += sldr->GetHeight() + 1;
-	sldr = (Slider*)Lab_render_options_window->AddChild(new Slider("Bloom", 0, 200, 0, y + 2, labviewer_render_options_set_bloom, Lab_render_options_window->GetWidth()));
+	sldr = (Slider*)Lab_render_options_window->AddChild(new Slider(
+	    "Bloom", 0, 200, 0, y + 2, labviewer_render_options_set_bloom, Lab_render_options_window->GetWidth()));
 	y += sldr->GetHeight() + 1;
 
 	// start tree
-	cmp = (Tree*)Lab_render_options_window->AddChild(new Tree("Detail Options Tree", 0, y + 2, NULL, Lab_render_options_window->GetWidth()));
+	cmp = (Tree*)Lab_render_options_window->AddChild(
+	    new Tree("Detail Options Tree", 0, y + 2, nullptr, Lab_render_options_window->GetWidth()));
 
 	// 3d hardware texture slider options
-	ctip = cmp->AddItem(NULL, "3D Hardware Textures", 0, false);
+	ctip = cmp->AddItem(nullptr, "3D Hardware Textures", 0, false);
 
 	cmp->AddItem(ctip, "Minimum", 0, false, labviewer_change_detail_texture);
 	cmp->AddItem(ctip, "Low", 1, false, labviewer_change_detail_texture);
@@ -1095,88 +1170,89 @@ void labviewer_make_render_options_window(Button * /*caller*/)
 }
 // -------------------------  Material Override Window  ------------------------------
 
-void labviewer_close_material_override_window(GUIObject * /*caller*/)
+void labviewer_close_material_override_window(GUIObject* /*caller*/)
 {
-	Lab_material_override_window = NULL;
+	Lab_material_override_window = nullptr;
 
 	Basemap_color_override_set = false;
-	Basemap_color_override[0] = 0.0f;
-	Basemap_color_override[1] = 0.0f;
-	Basemap_color_override[2] = 0.0f;
-	Basemap_color_override[3] = 1.0f;
+	Basemap_color_override[0]  = 0.0f;
+	Basemap_color_override[1]  = 0.0f;
+	Basemap_color_override[2]  = 0.0f;
+	Basemap_color_override[3]  = 1.0f;
 
 	Glowmap_color_override_set = false;
-	Glowmap_color_override[0] = 0.0f;
-	Glowmap_color_override[1] = 0.0f;
-	Glowmap_color_override[2] = 0.0f;
+	Glowmap_color_override[0]  = 0.0f;
+	Glowmap_color_override[1]  = 0.0f;
+	Glowmap_color_override[2]  = 0.0f;
 
 	Specmap_color_override_set = false;
-	Specmap_color_override[0] = 0.0f;
-	Specmap_color_override[1] = 0.0f;
-	Specmap_color_override[2] = 0.0f;
+	Specmap_color_override[0]  = 0.0f;
+	Specmap_color_override[1]  = 0.0f;
+	Specmap_color_override[2]  = 0.0f;
 }
 
-void labviewer_set_material_override_diffuse_red(Slider *caller)
+void labviewer_set_material_override_diffuse_red(Slider* caller)
 {
 	Basemap_color_override[0] = caller->GetSliderValue() / 255.0f;
 }
 
-void labviewer_set_material_override_diffuse_green(Slider *caller)
+void labviewer_set_material_override_diffuse_green(Slider* caller)
 {
 	Basemap_color_override[1] = caller->GetSliderValue() / 255.0f;
 }
 
-void labviewer_set_material_override_diffuse_blue(Slider *caller)
+void labviewer_set_material_override_diffuse_blue(Slider* caller)
 {
 	Basemap_color_override[2] = caller->GetSliderValue() / 255.0f;
 }
-void labviewer_set_material_override_glow_red(Slider *caller)
+void labviewer_set_material_override_glow_red(Slider* caller)
 {
 	Glowmap_color_override[0] = caller->GetSliderValue() / 255.0f;
 }
 
-void labviewer_set_material_override_glow_green(Slider *caller)
+void labviewer_set_material_override_glow_green(Slider* caller)
 {
 	Glowmap_color_override[1] = caller->GetSliderValue() / 255.0f;
 }
 
-void labviewer_set_material_override_glow_blue(Slider *caller)
+void labviewer_set_material_override_glow_blue(Slider* caller)
 {
 	Glowmap_color_override[2] = caller->GetSliderValue() / 255.0f;
 }
 
-void labviewer_set_material_override_specular_red(Slider *caller)
+void labviewer_set_material_override_specular_red(Slider* caller)
 {
 	Specmap_color_override[0] = caller->GetSliderValue() / 255.0f;
 }
 
-void labviewer_set_material_override_specular_green(Slider *caller)
+void labviewer_set_material_override_specular_green(Slider* caller)
 {
 	Specmap_color_override[1] = caller->GetSliderValue() / 255.0f;
 }
 
-void labviewer_set_material_override_specular_blue(Slider *caller)
+void labviewer_set_material_override_specular_blue(Slider* caller)
 {
 	Specmap_color_override[2] = caller->GetSliderValue() / 255.0f;
 }
 
-void labviewer_set_material_override_specular_gloss(Slider *caller)
+void labviewer_set_material_override_specular_gloss(Slider* caller)
 {
 	Gloss_override = caller->GetSliderValue() / 255.0f;
 }
 
-void labviewer_make_material_override_window(Button * /*caller*/)
+void labviewer_make_material_override_window(Button* /*caller*/)
 {
-	Checkbox *cbp;
-	Slider *sldr;
+	Checkbox* cbp;
+	Slider* sldr;
 	int y = 0;
 
-	if (Lab_material_override_window != NULL) {
+	if (Lab_material_override_window != nullptr) {
 		return;
 	}
 
-	Lab_material_override_window = (Window*)Lab_screen->Add(new Window("Material Override", gr_screen.max_w - 300, 200));
-	Assert(Lab_material_override_window != NULL);
+	Lab_material_override_window =
+	    (Window*)Lab_screen->Add(new Window("Material Override", gr_screen.max_w - 300, 200));
+	Assert(Lab_material_override_window != nullptr);
 
 	// add all of the flags that we want/need...
 
@@ -1186,13 +1262,16 @@ void labviewer_make_material_override_window(Button * /*caller*/)
 	cbp->SetBool(&Basemap_color_override_set);
 	y += cbp->GetHeight() + 1;
 
-	sldr = (Slider*)Lab_material_override_window->AddChild(new Slider("Red", 0.0f, 255.0f, 0, y + 2, labviewer_set_material_override_diffuse_red, 275));
+	sldr = (Slider*)Lab_material_override_window->AddChild(
+	    new Slider("Red", 0.0f, 255.0f, 0, y + 2, labviewer_set_material_override_diffuse_red, 275));
 	y += sldr->GetHeight() + 1;
 
-	sldr = (Slider*)Lab_material_override_window->AddChild(new Slider("Green", 0.0f, 255.0f, 0, y + 2, labviewer_set_material_override_diffuse_green, 275));
+	sldr = (Slider*)Lab_material_override_window->AddChild(
+	    new Slider("Green", 0.0f, 255.0f, 0, y + 2, labviewer_set_material_override_diffuse_green, 275));
 	y += sldr->GetHeight() + 1;
 
-	sldr = (Slider*)Lab_material_override_window->AddChild(new Slider("Blue", 0.0f, 255.0f, 0, y + 2, labviewer_set_material_override_diffuse_blue, 275));
+	sldr = (Slider*)Lab_material_override_window->AddChild(
+	    new Slider("Blue", 0.0f, 255.0f, 0, y + 2, labviewer_set_material_override_diffuse_blue, 275));
 	y += sldr->GetHeight() + 1;
 
 	if (Cmdline_glow) {
@@ -1200,13 +1279,16 @@ void labviewer_make_material_override_window(Button * /*caller*/)
 		cbp->SetBool(&Glowmap_color_override_set);
 		y += cbp->GetHeight() + 1;
 
-		sldr = (Slider*)Lab_material_override_window->AddChild(new Slider("Red", 0.0f, 255.0f, 0, y + 2, labviewer_set_material_override_glow_red, 275));
+		sldr = (Slider*)Lab_material_override_window->AddChild(
+		    new Slider("Red", 0.0f, 255.0f, 0, y + 2, labviewer_set_material_override_glow_red, 275));
 		y += sldr->GetHeight() + 1;
 
-		sldr = (Slider*)Lab_material_override_window->AddChild(new Slider("Green", 0.0f, 255.0f, 0, y + 2, labviewer_set_material_override_glow_green, 275));
+		sldr = (Slider*)Lab_material_override_window->AddChild(
+		    new Slider("Green", 0.0f, 255.0f, 0, y + 2, labviewer_set_material_override_glow_green, 275));
 		y += sldr->GetHeight() + 1;
 
-		sldr = (Slider*)Lab_material_override_window->AddChild(new Slider("Blue", 0.0f, 255.0f, 0, y + 2, labviewer_set_material_override_glow_blue, 275));
+		sldr = (Slider*)Lab_material_override_window->AddChild(
+		    new Slider("Blue", 0.0f, 255.0f, 0, y + 2, labviewer_set_material_override_glow_blue, 275));
 		y += sldr->GetHeight() + 1;
 	}
 	if (Cmdline_spec) {
@@ -1214,20 +1296,24 @@ void labviewer_make_material_override_window(Button * /*caller*/)
 		cbp->SetBool(&Specmap_color_override_set);
 		y += cbp->GetHeight() + 1;
 
-		sldr = (Slider*)Lab_material_override_window->AddChild(new Slider("Red", 0.0f, 255.0f, 0, y + 2, labviewer_set_material_override_specular_red, 275));
+		sldr = (Slider*)Lab_material_override_window->AddChild(
+		    new Slider("Red", 0.0f, 255.0f, 0, y + 2, labviewer_set_material_override_specular_red, 275));
 		y += sldr->GetHeight() + 1;
 
-		sldr = (Slider*)Lab_material_override_window->AddChild(new Slider("Green", 0.0f, 255.0f, 0, y + 2, labviewer_set_material_override_specular_green, 275));
+		sldr = (Slider*)Lab_material_override_window->AddChild(
+		    new Slider("Green", 0.0f, 255.0f, 0, y + 2, labviewer_set_material_override_specular_green, 275));
 		y += sldr->GetHeight() + 1;
 
-		sldr = (Slider*)Lab_material_override_window->AddChild(new Slider("Blue", 0.0f, 255.0f, 0, y + 2, labviewer_set_material_override_specular_blue, 275));
+		sldr = (Slider*)Lab_material_override_window->AddChild(
+		    new Slider("Blue", 0.0f, 255.0f, 0, y + 2, labviewer_set_material_override_specular_blue, 275));
 		y += sldr->GetHeight() + 1;
 
 		cbp = (Checkbox*)Lab_material_override_window->AddChild(new Checkbox("Override Gloss", 2, y));
 		cbp->SetBool(&Gloss_override_set);
 		y += cbp->GetHeight() + 1;
 
-		sldr = (Slider*)Lab_material_override_window->AddChild(new Slider("Gloss", 0.0f, 255.0f, 0, y + 2, labviewer_set_material_override_specular_gloss, 275));
+		sldr = (Slider*)Lab_material_override_window->AddChild(
+		    new Slider("Gloss", 0.0f, 255.0f, 0, y + 2, labviewer_set_material_override_specular_gloss, 275));
 		y += sldr->GetHeight() + 1;
 	}
 
@@ -1236,15 +1322,15 @@ void labviewer_make_material_override_window(Button * /*caller*/)
 }
 
 // -------------------------  Description Window  ------------------------------
-void labviewer_close_desc_window(GUIObject * /*caller*/)
+void labviewer_close_desc_window(GUIObject* /*caller*/)
 {
-	Lab_description_text = NULL;
-	Lab_description_window = NULL;
+	Lab_description_text   = nullptr;
+	Lab_description_window = nullptr;
 }
 
 void labviewer_update_desc_window()
 {
-	if ((Lab_description_window == NULL) || (Lab_description_text == NULL)) {
+	if ((Lab_description_window == nullptr) || (Lab_description_text == nullptr)) {
 		return;
 	}
 
@@ -1252,36 +1338,35 @@ void labviewer_update_desc_window()
 		if (Lab_mode == LAB_MODE_SHIP) {
 			Lab_description_window->SetCaption(Ship_info[Lab_selected_index].name);
 
-			if (Ship_info[Lab_selected_index].tech_desc != NULL) {
+			if (Ship_info[Lab_selected_index].tech_desc != nullptr) {
 				Lab_description_text->SetText(Ship_info[Lab_selected_index].tech_desc);
-			}
-			else {
+			} else {
 				Lab_description_text->SetText("No description available.");
 			}
-		}
-		else if (Lab_mode == LAB_MODE_WEAPON) {
+		} else if (Lab_mode == LAB_MODE_WEAPON) {
 			Lab_description_window->SetCaption(Weapon_info[Lab_selected_index].get_display_string());
 
-			if (Weapon_info[Lab_selected_index].tech_desc != NULL) {
+			if (Weapon_info[Lab_selected_index].tech_desc != nullptr) {
 				Lab_description_text->SetText(Weapon_info[Lab_selected_index].tech_desc);
-			}
-			else {
+			} else {
 				Lab_description_text->SetText("No description available.");
 			}
 		}
 	}
 }
 
-void labviewer_make_desc_window(Button * /*caller*/)
+void labviewer_make_desc_window(Button* /*caller*/)
 {
-	if (Lab_description_window != NULL) {
+	if (Lab_description_window != nullptr) {
 		return;
 	}
 
-	Lab_description_window = (Window*)Lab_screen->Add(new Window("Description", gr_screen.center_offset_x + gr_screen.center_w - gr_screen.center_w / 3 - 50,
-		gr_screen.center_offset_y + gr_screen.center_h - gr_screen.center_h / 6 - 50, gr_screen.center_w / 3,
-		gr_screen.center_h / 6));
-	Lab_description_text = (Text*)Lab_description_window->AddChild(new Text("Description Text", "No ship selected.", 0, 0));
+	Lab_description_window = (Window*)Lab_screen->Add(
+	    new Window("Description", gr_screen.center_offset_x + gr_screen.center_w - gr_screen.center_w / 3 - 50,
+	               gr_screen.center_offset_y + gr_screen.center_h - gr_screen.center_h / 6 - 50, gr_screen.center_w / 3,
+	               gr_screen.center_h / 6));
+	Lab_description_text =
+	    (Text*)Lab_description_window->AddChild(new Text("Description Text", "No ship selected.", 0, 0));
 
 	labviewer_update_desc_window();
 
@@ -1289,29 +1374,27 @@ void labviewer_make_desc_window(Button * /*caller*/)
 }
 
 // ------------------------   Ships Window   -----------------------------------
-void labviewer_make_ship_window(Button * /*caller*/)
+void labviewer_make_ship_window(Button* /*caller*/)
 {
-	GUIObject *cbp;
-	TreeItem *stip;
+	GUIObject* cbp;
+	TreeItem* stip;
 	int x, idx;
 
 	if (Lab_mode == LAB_MODE_SHIP) {
 		return;
 	}
 
-
 	// switch the class window to ship mode
 	labviewer_set_class_window(LAB_MODE_SHIP);
 
-	if ((Lab_class_window == NULL) || (Lab_class_toolbar == NULL)) {
+	if ((Lab_class_window == nullptr) || (Lab_class_toolbar == nullptr)) {
 		Int3();
 		Lab_mode = LAB_MODE_SHIP;
 		return;
 	}
 
-
 	// populate the class toolbar
-	x = 0;
+	x   = 0;
 	cbp = Lab_class_toolbar->AddChild(new Button("Class Description", x, 0, labviewer_make_desc_window));
 
 	x += cbp->GetWidth() + 10;
@@ -1320,20 +1403,19 @@ void labviewer_make_ship_window(Button * /*caller*/)
 	x += cbp->GetWidth() + 10;
 	cbp = Lab_class_toolbar->AddChild(new Button("Class Variables", x, 0, labviewer_make_variables_window));
 
-
 	// populate ship class window
 	ship_tree = (Tree*)Lab_class_window->AddChild(new Tree("Ship Tree", 0, 0));
 
-	if (Lab_species_nodes != NULL) {
+	if (Lab_species_nodes != nullptr) {
 		for (idx = 0; idx < (int)Species_info.size(); idx++) {
 			Lab_species_nodes[idx]->ClearAllItems();
 		}
 
 		delete[] Lab_species_nodes;
-		Lab_species_nodes = NULL;
+		Lab_species_nodes = nullptr;
 	}
 
-	//in case the window had already been opened
+	// in case the window had already been opened
 	ship_list_endpoints.clear();
 	for (int i = 0; i < (int)Species_info.size(); i++) {
 		ship_list_endpoints.emplace_back(std::make_pair(nullptr, nullptr));
@@ -1353,17 +1435,17 @@ void labviewer_make_ship_window(Button * /*caller*/)
 	for (auto it = Ship_info.cbegin(); it != Ship_info.cend(); ++it) {
 		if ((it->species >= 0) && (it->species < (int)Species_info.size())) {
 			stip = Lab_species_nodes[it->species];
-		}
-		else {
+		} else {
 			stip = Lab_species_nodes[Species_info.size()];
 		}
 
-		TreeItem *new_ship_item = ship_tree->AddItem(stip, it->name, (int)std::distance(Ship_info.cbegin(), it), false, labviewer_change_ship);
+		TreeItem* new_ship_item = ship_tree->AddItem(stip, it->name, (int)std::distance(Ship_info.cbegin(), it), false,
+		                                             labviewer_change_ship);
 		if (ship_list_endpoints[it->species].first == nullptr) {
 			ship_list_endpoints[it->species].first = new_ship_item;
 		}
 		ship_list_endpoints[it->species].second = new_ship_item;
-		//cmp->AddItem(ctip, "Debris", 99, false, labviewer_change_ship_lod);
+		// cmp->AddItem(ctip, "Debris", 99, false, labviewer_change_ship_lod);
 	}
 
 	// if any nodes are empty, just add a single "<none>" entry so we know that species doesn't have anything yet
@@ -1378,24 +1460,24 @@ void labviewer_make_ship_window(Button * /*caller*/)
 	if (!Lab_species_nodes[Species_info.size()]->HasChildren()) {
 		delete Lab_species_nodes[Species_info.size()];
 	}
-	
+
 	// and... we're done!
 	Lab_mode = LAB_MODE_SHIP;
 
 	// populate the flags window, if it exists
 	// (NOTE: must be done *after* Lab_mode is set properly)
-	if (Lab_flags_window != NULL) {
+	if (Lab_flags_window != nullptr) {
 		Lab_flags_window->SetCaption("Ship Flags");
 
 		labviewer_populate_flags_window();
 		labviewer_update_flags_window();
 	}
 
-	if (Lab_description_window != NULL) {
+	if (Lab_description_window != nullptr) {
 		labviewer_update_desc_window();
 	}
 
-	if (Lab_variables_window != NULL) {
+	if (Lab_variables_window != nullptr) {
 		Lab_variables_window->SetCaption("Ship Variables");
 
 		labviewer_populate_variables_window();
@@ -1409,21 +1491,19 @@ void labviewer_change_ship_lod(Tree* caller)
 		return;
 	}
 	int ship_index = caller->GetSelectedItem()->GetData();
-	
+
 	Assert(ship_index >= 0);
 
-	if (Lab_selected_object == -1)
-	{
-		// Goober5000 - The lab loads subsystems into its special lab-specific vector, but normally subsystems are loaded into the Ship_info
-		// entry.  Note also that models are only loaded once each.  If a lab model was previously loaded using the "lightweight" method,
-		// ship_create will not find any of the subsystems it is looking for.  So we have to make sure the model is only loaded for the purposes
-		// of error-checking and then immediately cleared so that it can be subsequently loaded the lab way.
+	if (Lab_selected_object == -1) {
+		// Goober5000 - The lab loads subsystems into its special lab-specific vector, but normally subsystems are
+		// loaded into the Ship_info entry.  Note also that models are only loaded once each.  If a lab model was
+		// previously loaded using the "lightweight" method, ship_create will not find any of the subsystems it is
+		// looking for.  So we have to make sure the model is only loaded for the purposes of error-checking and then
+		// immediately cleared so that it can be subsequently loaded the lab way.
 
 		// reset any existing model/bitmap that is showing
-		labviewer_change_model(NULL);
-	}
-	else
-	{
+		labviewer_change_model(nullptr);
+	} else {
 		obj_delete(Lab_selected_object);
 	}
 
@@ -1435,19 +1515,17 @@ void labviewer_change_ship_lod(Tree* caller)
 	Lab_last_selected_ship = Lab_selected_index;
 	labviewer_change_model(Ship_info[ship_index].pof_file, ship_index, ship_index);
 
-	//update the displayed POF filename
-	//moved out of labviewer_change_model which doesn't necessarily do much of anything after the first ship is loaded
+	// update the displayed POF filename
+	// moved out of labviewer_change_model which doesn't necessarily do much of anything after the first ship is loaded
 	if (Lab_model_num >= 0) {
 		strcpy_s(Lab_model_filename, Ship_info[ship_index].pof_file);
-	}
-	else {
+	} else {
 		memset(Lab_model_filename, 0, sizeof(Lab_model_filename));
 	}
 
 	if (Ship_info[ship_index].uses_team_colors) {
 		Lab_team_color = Ship_info[ship_index].default_team_name;
-	}
-	else {
+	} else {
 		Lab_team_color = "<none>";
 	}
 
@@ -1457,16 +1535,16 @@ void labviewer_change_ship_lod(Tree* caller)
 	labviewer_recalc_camera();
 }
 
-void labviewer_change_ship(Tree *caller)
+void labviewer_change_ship(Tree* caller)
 {
-	Lab_selected_index = caller->GetSelectedItem()->GetData();
+	Lab_selected_index       = caller->GetSelectedItem()->GetData();
 	Lab_last_selected_object = caller->GetSelectedItem();
 
 	labviewer_change_ship_lod(caller);
 }
 
 // ---------------------------  Weapons Window  --------------------------------
-void labviewer_show_tech_model(Tree *caller)
+void labviewer_show_tech_model(Tree* caller)
 {
 	int weap_index = (int)(caller->GetSelectedItem()->GetParentItem()->GetData());
 	Assert(weap_index >= 0);
@@ -1474,24 +1552,25 @@ void labviewer_show_tech_model(Tree *caller)
 	labviewer_change_model(Weapon_info[weap_index].tech_model, caller->GetSelectedItem()->GetData(), weap_index);
 }
 
-void labviewer_show_external_model(Tree *caller)
+void labviewer_show_external_model(Tree* caller)
 {
 	int weap_index = (int)(caller->GetSelectedItem()->GetParentItem()->GetData());
 	Assert(weap_index >= 0);
 
-	labviewer_change_model(Weapon_info[weap_index].external_model_name, caller->GetSelectedItem()->GetData(), weap_index);
+	labviewer_change_model(Weapon_info[weap_index].external_model_name, caller->GetSelectedItem()->GetData(),
+	                       weap_index);
 }
 
 extern void weapon_load_bitmaps(int weapon_index);
-void labviewer_change_weapon(Tree *caller)
+void labviewer_change_weapon(Tree* caller)
 {
 	if (caller == nullptr) {
 		return;
 	}
 
-	int weap_index = caller->GetSelectedItem()->GetData();
+	int weap_index           = caller->GetSelectedItem()->GetData();
 	Lab_last_selected_object = caller->GetSelectedItem();
-	
+
 	Assert(weap_index >= 0);
 
 	if (Lab_selected_object != -1)
@@ -1503,7 +1582,7 @@ void labviewer_change_weapon(Tree *caller)
 
 	lab_cam_distance = Objects[Lab_selected_object].radius * 20.0f;
 
-	Lab_selected_index = weap_index;
+	Lab_selected_index       = weap_index;
 	Lab_last_selected_weapon = Lab_selected_index;
 
 	labviewer_update_desc_window();
@@ -1513,29 +1592,27 @@ void labviewer_change_weapon(Tree *caller)
 }
 
 // weapon window create function
-void labviewer_make_weap_window(Button*  /*caller*/)
+void labviewer_make_weap_window(Button* /*caller*/)
 {
-	GUIObject *cbp;
-	TreeItem *stip;
+	GUIObject* cbp;
+	TreeItem* stip;
 	int x;
 
 	if (Lab_mode == LAB_MODE_WEAPON) {
 		return;
 	}
 
-
 	// switch the class window to weapon mode
 	labviewer_set_class_window(LAB_MODE_WEAPON);
 
-	if ((Lab_class_window == NULL) || (Lab_class_toolbar == NULL)) {
+	if ((Lab_class_window == nullptr) || (Lab_class_toolbar == nullptr)) {
 		Int3();
 		Lab_mode = LAB_MODE_WEAPON;
 		return;
 	}
 
-
 	// populate the weapons toolbar
-	x = 0;
+	x   = 0;
 	cbp = Lab_class_toolbar->AddChild(new Button("Class Description", x, 0, labviewer_make_desc_window));
 
 	x += cbp->GetWidth() + 10;
@@ -1552,7 +1629,7 @@ void labviewer_make_weap_window(Button*  /*caller*/)
 	// populate the weapons window
 	weap_tree = (Tree*)Lab_class_window->AddChild(new Tree("Weapon Tree", 0, 0));
 	// Unfortunately these are hardcoded
-	TreeItem **type_nodes = new TreeItem*[Num_weapon_subtypes];
+	auto type_nodes = new TreeItem*[Num_weapon_subtypes];
 	int i;
 
 	// Add type nodes
@@ -1564,30 +1641,29 @@ void labviewer_make_weap_window(Button*  /*caller*/)
 	for (i = 0; i < Num_weapon_types; i++) {
 		if (Weapon_info[i].subtype == WP_UNUSED) {
 			continue;
-		}
-		else if (Weapon_info[i].subtype >= Num_weapon_subtypes) {
+		} else if (Weapon_info[i].subtype >= Num_weapon_subtypes) {
 			Warning(LOCATION, "Invalid weapon subtype found on weapon %s", Weapon_info[i].name);
 			continue;
 		}
 
 		if (Weapon_info[i].wi_flags[Weapon::Info_Flags::Beam]) {
 			stip = type_nodes[WP_BEAM];
-		}
-		else {
+		} else {
 			stip = type_nodes[Weapon_info[i].subtype];
 		}
 
-		TreeItem *new_weap_item = weap_tree->AddItem(stip, Weapon_info[i].get_display_string(), i, false, labviewer_change_weapon);
+		TreeItem* new_weap_item =
+		    weap_tree->AddItem(stip, Weapon_info[i].get_display_string(), i, false, labviewer_change_weapon);
 
 		if (weap_list_endpoints[Weapon_info[i].subtype].first == nullptr) {
 			weap_list_endpoints[Weapon_info[i].subtype].first = new_weap_item;
 		}
 		weap_list_endpoints[Weapon_info[i].subtype].second = new_weap_item;
 
-		//if (Weapon_info[i].tech_model[0] != '\0') {
+		// if (Weapon_info[i].tech_model[0] != '\0') {
 		//	cmp->AddItem(cwip, "Tech Model", 0, false, labviewer_show_tech_model);
 		//}
-		//if (Weapon_info[i].external_model_name[0] != '\0') {
+		// if (Weapon_info[i].external_model_name[0] != '\0') {
 		//	cmp->AddItem(cwip, "External Model", 0, false, labviewer_show_external_model);
 		//}
 	}
@@ -1604,18 +1680,18 @@ void labviewer_make_weap_window(Button*  /*caller*/)
 
 	// populate the flags window, if it exists
 	// (NOTE: must be done *after* Lab_mode is set properly)
-	if (Lab_flags_window != NULL) {
+	if (Lab_flags_window != nullptr) {
 		Lab_flags_window->SetCaption("Weapon Flags");
 
 		labviewer_populate_flags_window();
 		labviewer_update_flags_window();
 	}
 
-	if (Lab_description_window != NULL) {
+	if (Lab_description_window != nullptr) {
 		labviewer_update_desc_window();
 	}
 
-	if (Lab_variables_window != NULL) {
+	if (Lab_variables_window != nullptr) {
 		Lab_variables_window->SetCaption("Weapon Variables");
 
 		labviewer_populate_variables_window();
@@ -1625,18 +1701,18 @@ void labviewer_make_weap_window(Button*  /*caller*/)
 
 // ----------------------------- Backgrounds -----------------------------------
 
-static TreeItem** Mission_directories = NULL;
-size_t Num_mission_directories = 0;
+static TreeItem** Mission_directories = nullptr;
+size_t Num_mission_directories        = 0;
 
 char skybox_model[MAX_FILENAME_LEN];
 int skybox_flags;
 
 int ambient_light_level;
-extern const char *Neb2_filenames[];
+extern const char* Neb2_filenames[];
 
 char envmap_name[MAX_FILENAME_LEN];
 
-const char* mission_ext_list[] = { ".fs2" };
+const char* mission_ext_list[] = {".fs2"};
 
 SCP_string get_directory_or_vp(const char* path)
 {
@@ -1645,7 +1721,7 @@ SCP_string get_directory_or_vp(const char* path)
 	// Is this a mission in a directory?
 	size_t found = result.find("data" DIR_SEPARATOR_STR "missions");
 
-	if (found == std::string::npos)  // Guess not
+	if (found == std::string::npos) // Guess not
 	{
 		found = result.find(".vp");
 	}
@@ -1655,9 +1731,8 @@ SCP_string get_directory_or_vp(const char* path)
 	result = result.substr(directory_name_pos, found - directory_name_pos);
 
 	found = result.find(DIR_SEPARATOR_CHAR);
-	//Strip directory separators
-	while (found != std::string::npos)
-	{
+	// Strip directory separators
+	while (found != std::string::npos) {
 		result.erase(found, strlen(DIR_SEPARATOR_STR));
 		found = result.find(DIR_SEPARATOR_CHAR);
 	}
@@ -1675,8 +1750,7 @@ void labviewer_change_background_actual()
 	// (DahBlount) - Remember to load the debris anims
 	stars_load_debris(false);
 
-	if (Lab_selected_mission != "None")
-	{
+	if (Lab_selected_mission != "None") {
 		read_file_text((Lab_selected_mission + ".fs2").c_str(), CF_TYPE_MISSIONS);
 		reset_parse();
 
@@ -1689,31 +1763,27 @@ void labviewer_change_background_actual()
 		skip_to_start_of_string_either("$Skybox Model:", "#Background bitmaps");
 
 		strcpy_s(skybox_model, "");
-		if (optional_string("$Skybox Model:"))
-		{
+		if (optional_string("$Skybox Model:")) {
 			stuff_string(skybox_model, F_NAME, MAX_FILENAME_LEN);
 
-			if (optional_string("+Skybox Orientation:"))
-			{
+			if (optional_string("+Skybox Orientation:")) {
 				stuff_matrix(&skybox_orientation);
 			}
 
 			if (optional_string("+Skybox Flags:")) {
 				skybox_flags = 0;
 				stuff_int(&skybox_flags);
-			}
-			else {
+			} else {
 				skybox_flags = DEFAULT_NMODEL_FLAGS;
 			}
 
-			stars_set_background_model(skybox_model, NULL, skybox_flags);
+			stars_set_background_model(skybox_model, nullptr, skybox_flags);
 			stars_set_background_orientation(&skybox_orientation);
 
 			skip_to_start_of_string("#Background bitmaps");
 		}
 
-		if (optional_string("#Background bitmaps"))
-		{
+		if (optional_string("#Background bitmaps")) {
 			required_string("$Num stars:");
 			stuff_int(&Num_stars);
 			if (Num_stars >= MAX_STARS)
@@ -1722,14 +1792,12 @@ void labviewer_change_background_actual()
 			required_string("$Ambient light level:");
 			stuff_int(&ambient_light_level);
 
-			if (ambient_light_level == 0)
-			{
+			if (ambient_light_level == 0) {
 				ambient_light_level = DEFAULT_AMBIENT_LIGHT_LEVEL;
 			}
 
-			gr_set_ambient_light(ambient_light_level & 0xff,
-				(ambient_light_level >> 8) & 0xff,
-				(ambient_light_level >> 16) & 0xff);
+			gr_set_ambient_light(ambient_light_level & 0xff, (ambient_light_level >> 8) & 0xff,
+			                     (ambient_light_level >> 16) & 0xff);
 
 			strcpy_s(Neb2_texture_name, "Eraseme3");
 			Neb2_poof_flags = ((1 << 0) | (1 << 1) | (1 << 2) | (1 << 3) | (1 << 4) | (1 << 5));
@@ -1747,24 +1815,21 @@ void labviewer_change_background_actual()
 			if (flags[Mission::Mission_Flags::Fullneb]) {
 				// no regular nebula stuff
 				nebula_close();
-			}
-			else
-			{
+			} else {
 				Nebula_index = -1;
 				if (optional_string("+Nebula:")) {
 					char str[MAX_FILENAME_LEN];
 					int z;
 					stuff_string(str, F_NAME, MAX_FILENAME_LEN);
 
-					// parse the proper nebula type (full or not)	
+					// parse the proper nebula type (full or not)
 					for (z = 0; z < NUM_NEBULAS; z++) {
 						if (flags[Mission::Mission_Flags::Fullneb]) {
 							if (!stricmp(str, Neb2_filenames[z])) {
 								Nebula_index = z;
 								break;
 							}
-						}
-						else {
+						} else {
 							if (!stricmp(str, Nebula_filenames[z])) {
 								Nebula_index = z;
 								break;
@@ -1790,30 +1855,26 @@ void labviewer_change_background_actual()
 
 					if (optional_string("+Pitch:")) {
 						stuff_int(&Nebula_pitch);
-					}
-					else {
+					} else {
 						Nebula_pitch = 0;
 					}
 
 					if (optional_string("+Bank:")) {
 						stuff_int(&Nebula_bank);
-					}
-					else {
+					} else {
 						Nebula_bank = 0;
 					}
 
 					if (optional_string("+Heading:")) {
 						stuff_int(&Nebula_heading);
-					}
-					else {
+					} else {
 						Nebula_heading = 0;
 					}
 				}
 
 				if (Nebula_index >= 0) {
 					nebula_init(Nebula_filenames[Nebula_index], Nebula_pitch, Nebula_bank, Nebula_heading);
-				}
-				else {
+				} else {
 					nebula_close();
 				}
 			}
@@ -1821,12 +1882,10 @@ void labviewer_change_background_actual()
 			stars_load_debris(flags[Mission::Mission_Flags::Fullneb]);
 
 			Num_backgrounds = 0;
-			extern void parse_one_background(background_t* background);
-			while (optional_string("$Bitmap List:") || check_for_string("$Sun:") || check_for_string("$Starbitmap:"))
-			{
+			extern void parse_one_background(background_t * background);
+			while (optional_string("$Bitmap List:") || check_for_string("$Sun:") || check_for_string("$Starbitmap:")) {
 				// don't allow overflow; just make sure the last background is the last read
-				if (Num_backgrounds >= MAX_BACKGROUNDS)
-				{
+				if (Num_backgrounds >= MAX_BACKGROUNDS) {
 					Warning(LOCATION, "Too many backgrounds in mission!  Max is %d.", MAX_BACKGROUNDS);
 					Num_backgrounds = MAX_BACKGROUNDS - 1;
 				}
@@ -1841,11 +1900,10 @@ void labviewer_change_background_actual()
 				stuff_string(envmap_name, F_NAME, MAX_FILENAME_LEN);
 			}
 		}
-	}
-	else {
+	} else {
 		// (DahBlount) - This spot should be used to disable rendering features that only apply to missions.
 		Motion_debris_override = true;
-		Num_stars = 0;
+		Num_stars              = 0;
 	}
 }
 
@@ -1856,16 +1914,15 @@ void labviewer_change_background(Tree* caller)
 	labviewer_change_background_actual();
 }
 
-void lab_background_window_close(GUIObject*  /*caller*/) 
-{
-	Lab_background_window = NULL;
-}
+void lab_background_window_close(GUIObject* /*caller*/) { Lab_background_window = nullptr; }
 
-void labviewer_make_background_window(Button*  /*caller*/)
+void labviewer_make_background_window(Button* /*caller*/)
 {
-	if (Lab_background_window != NULL) return;
+	if (Lab_background_window != nullptr)
+		return;
 
-	Lab_background_window = (Window*)Lab_screen->Add(new Window("Mission Backgrounds", gr_screen.center_offset_x + 250, gr_screen.center_offset_y + 50));
+	Lab_background_window = (Window*)Lab_screen->Add(
+	    new Window("Mission Backgrounds", gr_screen.center_offset_x + 250, gr_screen.center_offset_y + 50));
 	Lab_background_window->SetCloseFunction(lab_background_window_close);
 	SCP_vector<SCP_string> missions;
 
@@ -1884,26 +1941,25 @@ void labviewer_make_background_window(Button*  /*caller*/)
 	}
 
 	Num_mission_directories = directories.size();
-	Mission_directories = new TreeItem*[Num_mission_directories];
+	Mission_directories     = new TreeItem*[Num_mission_directories];
 
 	Tree* missiontree = (Tree*)Lab_background_window->AddChild(new Tree("Missions", 0, 0));
-	missiontree->AddItem(NULL, "None", 0, true, labviewer_change_background);
+	missiontree->AddItem(nullptr, "None", 0, true, labviewer_change_background);
 
 	int i = 0;
-	for (auto directory : directories)
-	{
+	for (auto directory : directories) {
 		auto directoryItem = Mission_directories[i];
-		directoryItem = missiontree->AddItem(NULL, directory.first);
+		directoryItem      = missiontree->AddItem(nullptr, directory.first);
 
-		for (const auto& Lab_mission : directory.second)
-		{
+		for (const auto& Lab_mission : directory.second) {
 			missiontree->AddItem(directoryItem, Lab_mission, 0, true, labviewer_change_background);
 		}
 	}
 }
 
 // ----------------------------- Lab functions ---------------------------------
-bool is_same_obj_type(int curr, int next) {
+bool is_same_obj_type(int curr, int next)
+{
 	if (Lab_mode == LAB_MODE_SHIP) {
 		if (Ship_info[curr].species == Ship_info[next].species) {
 			return true;
@@ -1920,18 +1976,18 @@ bool is_same_obj_type(int curr, int next) {
 	return false;
 }
 
-int lab_get_type_idx() {
+int lab_get_type_idx()
+{
 	if (Lab_mode == LAB_MODE_SHIP) {
-		ship_info *si = &Ship_info[Lab_last_selected_object->GetData()];
+		ship_info* si = &Ship_info[Lab_last_selected_object->GetData()];
 		for (int i = 0; i < (int)Species_info.size(); i++) {
 			species_info specie = Species_info[i];
 			if (!strncmp(specie.species_name, Species_info[si->species].species_name, NAME_LENGTH)) {
 				return i;
 			}
 		}
-	}
-	else if (Lab_mode == LAB_MODE_WEAPON) {
-		weapon_info *wi = &Weapon_info[Lab_last_selected_object->GetData()];
+	} else if (Lab_mode == LAB_MODE_WEAPON) {
+		weapon_info* wi = &Weapon_info[Lab_last_selected_object->GetData()];
 		for (int i = 0; i < Num_weapon_subtypes; i++) {
 			if (i == wi->subtype) {
 				return i;
@@ -1942,19 +1998,19 @@ int lab_get_type_idx() {
 	return -1;
 }
 
-//plieblang - scroll through entries with the arrow keys
-void lab_scroll_up() {
+// plieblang - scroll through entries with the arrow keys
+void lab_scroll_up()
+{
 	if (Lab_last_selected_object == nullptr) {
 		return;
 	}
 
-	//if we're at the beginning of the list, don't do anything
+	// if we're at the beginning of the list, don't do anything
 	if (Lab_mode == LAB_MODE_SHIP) {
 		if (Lab_last_selected_object == ship_list_endpoints[lab_get_type_idx()].first) {
 			return;
 		}
-	}
-	else if (Lab_mode == LAB_MODE_WEAPON) {
+	} else if (Lab_mode == LAB_MODE_WEAPON) {
 		if (Lab_last_selected_object == weap_list_endpoints[lab_get_type_idx()].first) {
 			return;
 		}
@@ -1964,30 +2020,29 @@ void lab_scroll_up() {
 	int prev_obj_idx = ((TreeItem*)Lab_last_selected_object->prev)->GetData();
 	do {
 		Lab_last_selected_object = (TreeItem*)Lab_last_selected_object->prev;
-		curr_obj_idx = prev_obj_idx;
-		prev_obj_idx = Lab_last_selected_object->GetData();
+		curr_obj_idx             = prev_obj_idx;
+		prev_obj_idx             = Lab_last_selected_object->GetData();
 	} while (!is_same_obj_type(curr_obj_idx, prev_obj_idx));
 
 	if (Lab_mode == LAB_MODE_SHIP) {
 		ship_tree->SetSelectedItem(Lab_last_selected_object);
-	}
-	else if (Lab_mode == LAB_MODE_WEAPON) {
+	} else if (Lab_mode == LAB_MODE_WEAPON) {
 		weap_tree->SetSelectedItem(Lab_last_selected_object);
 	}
 }
 
-void lab_scroll_down() {
+void lab_scroll_down()
+{
 	if (Lab_last_selected_object == nullptr) {
 		return;
 	}
 
-	//if we're at the end of the list, don't do anything
+	// if we're at the end of the list, don't do anything
 	if (Lab_mode == LAB_MODE_SHIP) {
 		if (Lab_last_selected_object == ship_list_endpoints[lab_get_type_idx()].second) {
 			return;
 		}
-	}
-	else if (Lab_mode == LAB_MODE_WEAPON) {
+	} else if (Lab_mode == LAB_MODE_WEAPON) {
 		if (Lab_last_selected_object == weap_list_endpoints[lab_get_type_idx()].second) {
 			return;
 		}
@@ -1997,37 +2052,36 @@ void lab_scroll_down() {
 	int next_obj_idx = ((TreeItem*)Lab_last_selected_object->next)->GetData();
 	do {
 		Lab_last_selected_object = (TreeItem*)Lab_last_selected_object->next;
-		curr_obj_idx = next_obj_idx;
-		next_obj_idx = Lab_last_selected_object->GetData();
+		curr_obj_idx             = next_obj_idx;
+		next_obj_idx             = Lab_last_selected_object->GetData();
 	} while (!is_same_obj_type(curr_obj_idx, next_obj_idx));
 
 	if (Lab_mode == LAB_MODE_SHIP) {
 		ship_tree->SetSelectedItem(Lab_last_selected_object);
-	}
-	else if (Lab_mode == LAB_MODE_WEAPON) {
+	} else if (Lab_mode == LAB_MODE_WEAPON) {
 		weap_tree->SetSelectedItem(Lab_last_selected_object);
 	}
 }
 
 void lab_init()
 {
-	GUIObject *cbp;
+	GUIObject* cbp;
 	int x, i;
 
 	weapon_pause_sounds();
 
 	gr_set_clear_color(0, 0, 0);
 
-
-	//We start by creating the screen/toolbar
+	// We start by creating the screen/toolbar
 	Lab_screen = GUI_system.PushScreen(new GUIScreen("Lab"));
 
-	Lab_toolbar = (Window*)Lab_screen->Add(new Window("Toolbar", gr_screen.center_offset_x, gr_screen.center_offset_y, -1, -1, WS_NOTITLEBAR | WS_NONMOVEABLE));
+	Lab_toolbar = (Window*)Lab_screen->Add(new Window("Toolbar", gr_screen.center_offset_x, gr_screen.center_offset_y,
+	                                                  -1, -1, WS_NOTITLEBAR | WS_NONMOVEABLE));
 
 	// start filling the main toolbar
-	x = 0;
+	x   = 0;
 	cbp = Lab_toolbar->AddChild(new Button("Ships", x, 0, labviewer_make_ship_window));
-	
+
 	x += cbp->GetWidth() + 10;
 	cbp = Lab_toolbar->AddChild(new Button("Weapons", x, 0, labviewer_make_weap_window));
 
@@ -2043,11 +2097,10 @@ void lab_init()
 	x += cbp->GetWidth() + 20;
 	cbp = Lab_toolbar->AddChild(new Button("Exit", x, 0, labviewer_exit));
 
-
 	// reset some defaults, just to be sure
-	Lab_model_pos = vmd_zero_vector;
-	Lab_mode = LAB_MODE_NONE;
-	Lab_thrust_len = 1.0f;
+	Lab_model_pos        = vmd_zero_vector;
+	Lab_mode             = LAB_MODE_NONE;
+	Lab_thrust_len       = 1.0f;
 	Lab_thrust_afterburn = false;
 	for (i = 0; i < MAX_SHIP_WEAPONS; i++) {
 		Lab_weaponmodel_num[i] = -1;
@@ -2072,7 +2125,7 @@ void lab_init()
 
 	obj_init();
 
-	//Reset the background
+	// Reset the background
 	labviewer_change_background_actual();
 
 	flagset<Object::Object_Flags> obs_flags;
@@ -2093,21 +2146,21 @@ void lab_init()
 		The_mission.ai_profile = &Ai_profiles[Default_ai_profile];
 
 	lab_cam_distance = 100.0f;
-	lab_cam_phi = 1.24f;
-	lab_cam_theta = 2.25f;
+	lab_cam_phi      = 1.24f;
+	lab_cam_theta    = 2.25f;
 
-	Lab_selected_index = -1;
-	Lab_last_selected_ship = -1;
-	Lab_selected_object = -1;
+	Lab_selected_index       = -1;
+	Lab_last_selected_ship   = -1;
+	Lab_selected_object      = -1;
 	Lab_last_selected_weapon = -1;
-	Lab_model_num = -1;
+	Lab_model_num            = -1;
 
-	Lab_selected_mission = "None";
+	Lab_selected_mission   = "None";
 	Lab_skybox_orientation = vmd_identity_matrix;
 }
 
-#include "controlconfig/controlsconfig.h"
 #include "lab.h"
+#include "controlconfig/controlsconfig.h"
 void lab_do_frame(float frametime)
 {
 	GR_DEBUG_SCOPE("Lab Frame");
@@ -2122,29 +2175,27 @@ void lab_do_frame(float frametime)
 	bool test1 = (GUI_system.OnFrame(frametime, !(Trackball_active) ? true : false, false) == GSOF_NOTHINGPRESSED);
 
 	if (test1) {
-		int key = GUI_system.GetKeyPressed();
+		int key    = GUI_system.GetKeyPressed();
 		int status = GUI_system.GetStatus();
 
 		// set trackball modes
 		if (status & GST_MOUSE_LEFT_BUTTON) {
 			Trackball_active = 1;
-			Trackball_mode = 1;	// rotate viewed object
+			Trackball_mode   = 1; // rotate viewed object
 
 			if (key_get_shift_status() & KEY_SHIFTED) {
-				Trackball_mode = 2;	// zoom
+				Trackball_mode = 2; // zoom
 			}
-		}
-		else if (status & GST_MOUSE_RIGHT_BUTTON) {
+		} else if (status & GST_MOUSE_RIGHT_BUTTON) {
 			Trackball_active = 1;
-			Trackball_mode = 3;	// rotate camera
-		}
-		else if (!mouse_down(MOUSE_LEFT_BUTTON | MOUSE_RIGHT_BUTTON)) {
+			Trackball_mode   = 3; // rotate camera
+		} else if (!mouse_down(MOUSE_LEFT_BUTTON | MOUSE_RIGHT_BUTTON)) {
 			// reset trackball modes
 			Trackball_active = 0;
-			Trackball_mode = 0;
+			Trackball_mode   = 0;
 		}
 
-		//Due to switch scoping rules, this has to be declared here
+		// Due to switch scoping rules, this has to be declared here
 		SCP_map<SCP_string, team_color>::iterator color_itr = Team_Colors.find(Lab_team_color);
 		// handle any key presses
 		switch (key) {
@@ -2167,7 +2218,7 @@ void lab_do_frame(float frametime)
 			break;
 		}
 
-						 // change between damage lightning effects
+			// change between damage lightning effects
 		case KEY_L:
 			// REIMPLEMENT
 			break;
@@ -2216,10 +2267,9 @@ void lab_do_frame(float frametime)
 
 		case KEY_T:
 			if (color_itr == Team_Colors.begin()) {
-				color_itr = --Team_Colors.end();
+				color_itr      = --Team_Colors.end();
 				Lab_team_color = color_itr->first;
-			}
-			else {
+			} else {
 				--color_itr;
 				Lab_team_color = color_itr->first;
 			}
@@ -2240,9 +2290,32 @@ void lab_do_frame(float frametime)
 			lab_scroll_down();
 			break;
 
+		case KEY_R:
+			switch (Lab_rotation_mode) {
+			case Lab_rotation_modes::Both:
+				Lab_rotation_mode = Lab_rotation_modes::Yaw;
+				break;
+			case Lab_rotation_modes::Yaw:
+				Lab_rotation_mode = Lab_rotation_modes::Pitch;
+				break;
+			case Lab_rotation_modes::Pitch:
+				Lab_rotation_mode = Lab_rotation_modes::Roll;
+				break;
+			case Lab_rotation_modes::Roll:
+				Lab_rotation_mode = Lab_rotation_modes::Both;
+				break;
+			}
+
+			break;
+		case KEY_S:
+			Lab_manual_rotation_speed_divisor *= 10.f;
+			if (Lab_manual_rotation_speed_divisor > 10000.f)
+				Lab_manual_rotation_speed_divisor = 100.f;
+			break;
+
 			// bail...
 		case KEY_ESC:
-			labviewer_exit(NULL);
+			labviewer_exit(nullptr);
 			break;
 
 		default: {
@@ -2271,25 +2344,24 @@ void lab_close()
 {
 	int i;
 
-	Lab_toolbar = NULL;
-	Lab_class_toolbar = NULL;
-	Lab_class_window = NULL;
-	Lab_flags_window = NULL;
-	Lab_render_options_window = NULL;
-	Lab_background_window = NULL;
+	Lab_toolbar               = nullptr;
+	Lab_class_toolbar         = nullptr;
+	Lab_class_window          = nullptr;
+	Lab_flags_window          = nullptr;
+	Lab_render_options_window = nullptr;
+	Lab_background_window     = nullptr;
 
 	delete Lab_screen;
 
-	Lab_screen = NULL;
+	Lab_screen = nullptr;
 
-
-	if (Lab_species_nodes != NULL) {
+	if (Lab_species_nodes != nullptr) {
 		for (i = 0; i < (int)Species_info.size(); i++) {
 			delete Lab_species_nodes[i];
 		}
 
 		delete[] Lab_species_nodes;
-		Lab_species_nodes = NULL;
+		Lab_species_nodes = nullptr;
 	}
 
 	if (Lab_insignia_bitmap >= 0) {
@@ -2318,29 +2390,29 @@ void lab_close()
 
 	memset(Lab_model_filename, 0, sizeof(Lab_model_filename));
 
-	Basemap_override = false;
-	Envmap_override = false;
-	Specmap_override = false;
-	Normalmap_override = false;
-	Heightmap_override = false;
-	Glowpoint_override = false;
+	Basemap_override        = false;
+	Envmap_override         = false;
+	Specmap_override        = false;
+	Normalmap_override      = false;
+	Heightmap_override      = false;
+	Glowpoint_override      = false;
 	PostProcessing_override = false;
 
-	Lab_Basemap_override = false;
-	Lab_Glowmap_override = false;
-	Lab_Specmap_override = false;
-	Lab_Envmap_override = false;
+	Lab_Basemap_override   = false;
+	Lab_Glowmap_override   = false;
+	Lab_Specmap_override   = false;
+	Lab_Envmap_override    = false;
 	Lab_Normalmap_override = false;
 	Lab_Heightmap_override = false;
 
 	// reset detail levels to default
 	Detail.hardware_textures = Lab_detail_texture_save;
 
-	//Reset ambient factor
+	// Reset ambient factor
 	gr_calculate_ambient_factor(Cmdline_ambient_factor);
 
 	weapon_unpause_sounds();
-	//audiostream_unpause_all();
+	// audiostream_unpause_all();
 	game_flush();
 
 	cam_delete(Lab_cam);

--- a/code/lab/lab.cpp
+++ b/code/lab/lab.cpp
@@ -75,6 +75,11 @@ static Slider* ambient_sldr = nullptr;
 static Slider* direct_sldr = nullptr;
 static Slider* bloom_sldr = nullptr;
 
+//these are here unfortunately because otherwise there's no way to reset them
+static Slider *ambient_sldr = nullptr;
+static Slider *direct_sldr = nullptr;
+static Slider *bloom_sldr = nullptr;
+
 //holds the beginning and ending indices of each specie/type of ship/weapon
 static SCP_vector<std::pair<TreeItem*, TreeItem*>> ship_list_endpoints;
 static SCP_vector<std::pair<TreeItem*, TreeItem*>> weap_list_endpoints;
@@ -176,7 +181,7 @@ void reset_view() {
 	Lab_model_orient = vmd_identity_matrix;
 
 	//reset lighting
-	//if the rendering options window is closed, these sliders are null
+	//if the rendering options window is close, these sliders are null
 	//we still want to be able to reset lighting in this situation though, so just set the values directly
 	if (ambient_sldr == nullptr) {
 		gr_calculate_ambient_factor(orig_cmdline_ambient);

--- a/code/lab/lab.cpp
+++ b/code/lab/lab.cpp
@@ -176,7 +176,7 @@ void reset_view() {
 	Lab_model_orient = vmd_identity_matrix;
 
 	//reset lighting
-	//if the rendering options window is close, these sliders are null
+	//if the rendering options window is closed, these sliders are null
 	//we still want to be able to reset lighting in this situation though, so just set the values directly
 	if (ambient_sldr == nullptr) {
 		gr_calculate_ambient_factor(orig_cmdline_ambient);
@@ -1085,7 +1085,12 @@ void labviewer_change_detail_texture(Tree* caller)
 	Detail.hardware_textures = slider_pos;
 }
 
-void labviewer_close_render_options_window(GUIObject* /*caller*/) { Lab_render_options_window = nullptr; }
+void labviewer_close_render_options_window(GUIObject* /*caller*/) {
+	ambient_sldr = nullptr;
+	bloom_sldr = nullptr;
+	direct_sldr = nullptr;
+	Lab_render_options_window = nullptr;
+}
 
 #define ADD_RENDER_FLAG(text, flag, var)                                                                               \
 	{                                                                                                                  \

--- a/code/lab/lab.cpp
+++ b/code/lab/lab.cpp
@@ -176,9 +176,17 @@ void reset_view() {
 	Lab_model_orient = vmd_identity_matrix;
 
 	//reset lighting
-	ambient_sldr->SetSliderValue((float)orig_cmdline_ambient);
-	direct_sldr->SetSliderValue(orig_cmdline_direct);
-	bloom_sldr->SetSliderValue((float)orig_cmdline_bloom);
+	//if the rendering options window is close, these sliders are null
+	//we still want to be able to reset lighting in this situation though, so just set the values directly
+	if (ambient_sldr == nullptr) {
+		gr_calculate_ambient_factor(orig_cmdline_ambient);
+		static_light_factor = orig_cmdline_direct;
+		Cmdline_bloom_intensity = orig_cmdline_bloom;
+	} else {
+		ambient_sldr->SetSliderValue((float)orig_cmdline_ambient);
+		direct_sldr->SetSliderValue(orig_cmdline_direct);
+		bloom_sldr->SetSliderValue((float)orig_cmdline_bloom);
+	}
 }
 
 void labviewer_change_model(char* model_fname, int lod = 0, int sel_index = -1)
@@ -2419,13 +2427,6 @@ void lab_close()
 			Lab_weaponmodel_num[i] = -1;
 		}
 	}
-
-	delete ambient_sldr;
-	ambient_sldr = nullptr;
-	delete direct_sldr;
-	direct_sldr = nullptr;
-	delete bloom_sldr;
-	bloom_sldr = nullptr;
 
 	Lab_selected_mission = "None";
 	stars_pre_level_init(true);

--- a/code/lab/lab.cpp
+++ b/code/lab/lab.cpp
@@ -70,7 +70,12 @@ static TreeItem** Lab_species_nodes         = nullptr;
 static Tree* ship_tree = nullptr;
 static Tree* weap_tree = nullptr;
 
-// holds the beginning and ending indices of each specie/type of ship/weapon
+//these are here unfortunately because otherwise there's no way to reset them
+static Slider* ambient_sldr = nullptr;
+static Slider* direct_sldr = nullptr;
+static Slider* bloom_sldr = nullptr;
+
+//holds the beginning and ending indices of each specie/type of ship/weapon
 static SCP_vector<std::pair<TreeItem*, TreeItem*>> ship_list_endpoints;
 static SCP_vector<std::pair<TreeItem*, TreeItem*>> weap_list_endpoints;
 
@@ -119,6 +124,11 @@ static int Trackball_active = 0;
 
 SCP_string Lab_team_color = "<none>";
 
+//save the original cmdline values in case we need to reset to them
+int orig_cmdline_ambient;
+float orig_cmdline_direct;
+int orig_cmdline_bloom;
+
 camid Lab_cam;
 float lab_cam_distance = 100.0f;
 float lab_cam_phi      = 0;
@@ -158,6 +168,17 @@ void rotate_view(int dx, int dy)
 	lab_cam_phi += dy / 100.0f;
 
 	CLAMP(lab_cam_phi, 0.01f, PI - 0.01f);
+}
+
+void reset_view() {
+	//reset position
+	Lab_model_pos = ZERO_VECTOR;
+	Lab_model_orient = vmd_identity_matrix;
+
+	//reset lighting
+	ambient_sldr->SetSliderValue((float)orig_cmdline_ambient);
+	direct_sldr->SetSliderValue(orig_cmdline_direct);
+	bloom_sldr->SetSliderValue((float)orig_cmdline_bloom);
 }
 
 void labviewer_change_model(char* model_fname, int lod = 0, int sel_index = -1)
@@ -1140,17 +1161,21 @@ void labviewer_make_render_options_window(Button* /*caller*/)
 	ADD_RENDER_FLAG("Show Destroyed Subsystems", Lab_viewer_flags, LAB_FLAG_DESTROYED_SUBSYSTEMS);
 
 	ADD_RENDER_BOOL("Emissive Lighting", Lab_emissive_light_override);
-	Slider* sldr = (Slider*)Lab_render_options_window->AddChild(new Slider("Ambient Factor", 0, 128, 0, y + 2,
-	                                                                       labviewer_render_options_set_ambient_factor,
-	                                                                       Lab_render_options_window->GetWidth()));
-	y += sldr->GetHeight() + 1;
-	sldr = (Slider*)Lab_render_options_window->AddChild(new Slider("Direct. Lights", 0.0f, 2.0f, 0, y + 2,
-	                                                               labviewer_render_options_set_static_light_factor,
-	                                                               Lab_render_options_window->GetWidth()));
-	y += sldr->GetHeight() + 1;
-	sldr = (Slider*)Lab_render_options_window->AddChild(new Slider(
-	    "Bloom", 0, 200, 0, y + 2, labviewer_render_options_set_bloom, Lab_render_options_window->GetWidth()));
-	y += sldr->GetHeight() + 1;
+
+	ambient_sldr = new Slider("Ambient Factor", 0, 128, 0, y + 2, labviewer_render_options_set_ambient_factor, Lab_render_options_window->GetWidth());
+	ambient_sldr->SetSliderValue((float)Cmdline_ambient_factor);
+	Lab_render_options_window->AddChild(ambient_sldr);
+	y += ambient_sldr->GetHeight() + 1;
+
+	direct_sldr = new Slider("Direct. Lights", 0.0f, 2.0f, 0, y + 2, labviewer_render_options_set_static_light_factor, Lab_render_options_window->GetWidth());
+	direct_sldr->SetSliderValue(static_light_factor);
+	Lab_render_options_window->AddChild(direct_sldr);
+	y += direct_sldr->GetHeight() + 1;
+
+	bloom_sldr = new Slider("Bloom", 0, 200, 0, y + 2, labviewer_render_options_set_bloom, Lab_render_options_window->GetWidth());
+	bloom_sldr->SetSliderValue((float)Cmdline_bloom_intensity);
+	Lab_render_options_window->AddChild(bloom_sldr);
+	y += bloom_sldr->GetHeight() + 1;
 
 	// start tree
 	cmp = (Tree*)Lab_render_options_window->AddChild(
@@ -2106,6 +2131,10 @@ void lab_init()
 		Lab_weaponmodel_num[i] = -1;
 	}
 
+	orig_cmdline_ambient = Cmdline_ambient_factor;
+	orig_cmdline_direct = static_light_factor;
+	orig_cmdline_bloom = Cmdline_bloom_intensity;
+
 	// save detail options
 	Lab_detail_texture_save = Detail.hardware_textures;
 	// load up the list of insignia that we might use on the ships
@@ -2284,6 +2313,10 @@ void lab_do_frame(float frametime)
 			Lab_team_color = color_itr->first;
 			break;
 
+		case KEY_V:
+			reset_view();
+			break;
+
 		case KEY_UP:
 			lab_scroll_up();
 			break;
@@ -2386,6 +2419,13 @@ void lab_close()
 			Lab_weaponmodel_num[i] = -1;
 		}
 	}
+
+	delete ambient_sldr;
+	ambient_sldr = nullptr;
+	delete direct_sldr;
+	direct_sldr = nullptr;
+	delete bloom_sldr;
+	bloom_sldr = nullptr;
 
 	Lab_selected_mission = "None";
 	stars_pre_level_init(true);

--- a/code/lab/wmcgui.cpp
+++ b/code/lab/wmcgui.cpp
@@ -2707,7 +2707,7 @@ void Slider::UpdateSlider(int x)
 
 	CLAMP(SliderScale, 0.0, 1.0f);
 
-	if ( function != NULL ) {
+	if ( function != nullptr ) {
 		function(this);
 	}
 }
@@ -2718,7 +2718,7 @@ float Slider::GetSliderValue()
 }
 
 void Slider::SetSliderValue(float raw_val) {
-	SliderScale = raw_val / Max + Min;
+	SliderScale = (raw_val - Min) / Max + Min;
 	//we don't want to actually change it here
 	UpdateSlider(-1);
 }

--- a/code/lab/wmcgui.cpp
+++ b/code/lab/wmcgui.cpp
@@ -2701,7 +2701,9 @@ float Slider::GetSliderPos(int x)
 
 void Slider::UpdateSlider(int x)
 {
-	SliderScale = GetSliderPos(x);
+	if (x >= 0) {
+		SliderScale = GetSliderPos(x);
+	}
 
 	CLAMP(SliderScale, 0.0, 1.0f);
 
@@ -2713,6 +2715,12 @@ void Slider::UpdateSlider(int x)
 float Slider::GetSliderValue()
 {
 	return (SliderScale * (Max - Min) + Min);
+}
+
+void Slider::SetSliderValue(float raw_val) {
+	SliderScale = raw_val / Max + Min;
+	//we don't want to actually change it here
+	UpdateSlider(-1);
 }
 
 void Slider::DoMove(int dx, int dy)

--- a/code/lab/wmcgui.h
+++ b/code/lab/wmcgui.h
@@ -765,6 +765,7 @@ public:
 	Slider(const SCP_string &in_label, float min, float max, int x_coord, int y_coord, void(*in_function)(Slider *caller) = NULL, int x_width = -1, int y_height = DEFAULT_BUTTON_HEIGHT, int in_style = 0);
 
 	float GetSliderValue();
+	void SetSliderValue(float raw_val);
 };
 
 //*****************************GLOBALS*******************************

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -2377,11 +2377,7 @@ int parse_create_object_sub(p_object *p_objp)
 			vec3d v1, v2;
 
 			// DA 10/20/98 - sparks must be chosen on the hull and not any submodel
-			if ( Cmdline_old_collision_sys ) {
-				submodel_get_two_random_points(sip->model_num, pm->detail[0], &v1, &v2);
-			} else {
-				submodel_get_two_random_points_better(sip->model_num, pm->detail[0], &v1, &v2);
-			}
+			submodel_get_two_random_points_better(sip->model_num, pm->detail[0], &v1, &v2);
 			ship_hit_sparks_no_rotate(&Objects[objnum], &v1);
 		}
 	}

--- a/code/model/modelcollide.cpp
+++ b/code/model/modelcollide.cpp
@@ -1132,25 +1132,22 @@ void mc_check_subobj( int mn )
 		} else {
 			// The ray intersects this bounding box, so we have to check all the
 			// polygons in this submodel.
-			if ( Cmdline_old_collision_sys ) {
-				model_collide_sub(sm->bsp_data);
-			} else {
-				if (Mc->lod > 0 && sm->num_details > 0) {
-					bsp_info *lod_sm = sm;
+			if (Mc->lod > 0 && sm->num_details > 0) {
+				bsp_info* lod_sm = sm;
 
-					for (i = Mc->lod - 1; i >= 0; i--) {
-						if (sm->details[i] != -1) {
-							lod_sm = &Mc_pm->submodel[sm->details[i]];
+				for (i = Mc->lod - 1; i >= 0; i--) {
+					if (sm->details[i] != -1) {
+						lod_sm = &Mc_pm->submodel[sm->details[i]];
 
-							//mprintf(("Checking %s collision for %s using %s instead\n", Mc_pm->filename, sm->name, lod_sm->name));
-							break;
-						}
+						// mprintf(("Checking %s collision for %s using %s instead\n", Mc_pm->filename, sm->name,
+						// lod_sm->name));
+						break;
 					}
-
-					model_collide_bsp(model_get_bsp_collision_tree(lod_sm->collision_tree_index), 0);
-				} else {
-					model_collide_bsp(model_get_bsp_collision_tree(sm->collision_tree_index), 0);
 				}
+
+				model_collide_bsp(model_get_bsp_collision_tree(lod_sm->collision_tree_index), 0);
+			} else {
+				model_collide_bsp(model_get_bsp_collision_tree(sm->collision_tree_index), 0);
 			}
 		}
 	}

--- a/code/model/modelread.cpp
+++ b/code/model/modelread.cpp
@@ -2852,15 +2852,13 @@ int model_load(const  char *filename, int n_subsystems, model_subsystem *subsyst
 
 	model_octant_create( pm );
 
-	if ( !Cmdline_old_collision_sys ) {
-		TRACE_SCOPE(tracing::ModelParseAllBSPTrees);
+	TRACE_SCOPE(tracing::ModelParseAllBSPTrees);
 
-		for ( i = 0; i < pm->n_models; ++i ) {
-			if ( !(pm->submodel[i].nocollide_this_only || pm->submodel[i].no_collisions) ) {
-				pm->submodel[i].collision_tree_index = model_create_bsp_collision_tree();
-				bsp_collision_tree *tree = model_get_bsp_collision_tree(pm->submodel[i].collision_tree_index);
-				model_collide_parse_bsp(tree, pm->submodel[i].bsp_data, pm->version);
-			}
+	for (i = 0; i < pm->n_models; ++i) {
+		if (!(pm->submodel[i].nocollide_this_only || pm->submodel[i].no_collisions)) {
+			pm->submodel[i].collision_tree_index = model_create_bsp_collision_tree();
+			bsp_collision_tree* tree             = model_get_bsp_collision_tree(pm->submodel[i].collision_tree_index);
+			model_collide_parse_bsp(tree, pm->submodel[i].bsp_data, pm->version);
 		}
 	}
 

--- a/code/object/objcollide.h
+++ b/code/object/objcollide.h
@@ -62,25 +62,16 @@ typedef struct obj_pair	{
 
 #define COLLISION_OF(a,b) (((a)<<8)|(b))
 
-#define COLLISION_TYPE_NONE	0	
-#define COLLISION_TYPE_OLD		1	// checks all n objects with each other each frame
-#define COLLISION_TYPE_NEW		2	// keeps track of collision pairs.  throws out collisions that won't happen.
-
-extern int collision_type;
-
 #define SUBMODEL_NO_ROT_HIT	0
 #define SUBMODEL_ROT_HIT		1
 void set_hit_struct_info(collision_info_struct *hit, mc_info *mc, int submodel_rot_hit);
 
-void obj_pairs_close();
-void obj_reset_pairs();
 void obj_add_pair( object *A, object *B, int check_time = -1, int add_to_end = 0 );
 
 void obj_add_collider(int obj_index);
 void obj_remove_collider(int obj_index);
 void obj_reset_colliders();
 
-void obj_check_all_collisions();
 void obj_sort_and_collide();
 void obj_quicksort_colliders(SCP_vector<int> *list, int left, int right, int axis);
 void obj_find_overlap_colliders(SCP_vector<int> *overlap_list_out, SCP_vector<int> *list, int axis, bool collide);
@@ -88,7 +79,6 @@ float obj_get_collider_endpoint(int obj_num, int axis, bool min);
 void obj_collide_pair(object *A, object *B);
 
 // retimes all collision pairs to be checked (in 25ms by default)
-void obj_all_collisions_retime(int checkdly=25);
 void obj_collide_retime_cached_pairs(int checkdly=25);
 
 // Returns TRUE if the weapon will never hit the other object.

--- a/code/object/object.cpp
+++ b/code/object/object.cpp
@@ -352,11 +352,7 @@ void obj_init()
 	Num_objects = 0;
 	Highest_object_index = 0;
 
-	if ( Cmdline_old_collision_sys ) {
-		obj_reset_pairs();
-	} else {
-		obj_reset_colliders();
-	}
+	obj_reset_colliders();
 }
 
 void obj_shutdown()
@@ -559,12 +555,8 @@ void obj_delete(int objnum)
 	};	
 
 	// Remove all object pairs
-	if ( Cmdline_old_collision_sys ) {
-		obj_remove_pairs( objp );
-	} else {
-		obj_remove_collider(objnum);
-	}
-	
+	obj_remove_collider(objnum);
+
 	switch( objp->type )	{
 	case OBJ_WEAPON:
 		weapon_delete( objp );
@@ -685,11 +677,7 @@ void obj_merge_created_list(void)
 		list_remove( obj_create_list, objp );
 
 		// Add it to the object pairs array
-		if ( Cmdline_old_collision_sys ) {
-			obj_add_pairs(OBJ_INDEX(objp));
-		} else {
-			obj_add_collider(OBJ_INDEX(objp));
-		}
+		obj_add_collider(OBJ_INDEX(objp));
 
 		// Then add it to the object used list
 		list_append( &obj_used_list, objp );
@@ -1033,11 +1021,7 @@ void obj_set_flags( object *obj, const flagset<Object::Object_Flags>& new_flags 
 	// turning collision detection off
 	if ( (obj->flags[Object::Object_Flags::Collides]) && (!(new_flags[Object::Object_Flags::Collides])))	{
 		// Remove all object pairs
-		if ( Cmdline_old_collision_sys ) {
-			obj_remove_pairs( obj );
-		} else {
-			obj_remove_collider(objnum);
-		}
+		obj_remove_collider(objnum);
 
 		// update object flags properly		
 		obj->flags = new_flags;
@@ -1063,12 +1047,8 @@ void obj_set_flags( object *obj, const flagset<Object::Object_Flags>& new_flags 
 		obj->flags.set(Object::Object_Flags::Collides);
 
 		// Turn on collision detection
-		if ( Cmdline_old_collision_sys ) {
-			obj_add_pairs(objnum);
-		} else {
-			obj_add_collider(objnum);
-		}
-				
+		obj_add_collider(objnum);
+
 		obj->flags = new_flags;
         obj->flags.remove(Object::Object_Flags::Not_in_coll);
 #ifdef OBJECT_CHECK
@@ -1581,11 +1561,7 @@ void obj_move_all(float frametime)
 
 	if ( Collisions_enabled ) {
 		TRACE_SCOPE(tracing::CollisionDetection);
-		if ( Cmdline_old_collision_sys ) {
-			obj_check_all_collisions();
-		} else {
-			obj_sort_and_collide();
-		}
+		obj_sort_and_collide();
 	}
 
 	turret_swarm_check_validity();
@@ -1770,11 +1746,7 @@ void obj_client_post_interpolate()
 	}	
 
 	// check collisions
-	if ( Cmdline_old_collision_sys ) {
-		obj_check_all_collisions();
-	} else {
-		obj_sort_and_collide();
-	}
+	obj_sort_and_collide();
 
 	// do post-collision stuff for beam weapons
 	beam_move_all_post();
@@ -1985,11 +1957,7 @@ void obj_reset_all_collisions()
 #endif
 
 	// clear object pairs
-	if ( Cmdline_old_collision_sys ) {
-		obj_reset_pairs();
-	} else {
-		obj_reset_colliders();
-	}
+	obj_reset_colliders();
 
 	// now add every object back into the object collision pairs
 	object *moveup;
@@ -1999,11 +1967,7 @@ void obj_reset_all_collisions()
 		moveup->flags.set(Object::Object_Flags::Not_in_coll);
 
 		// recalc pairs for this guy
-		if ( Cmdline_old_collision_sys ) {
-			obj_add_pairs(OBJ_INDEX(moveup));
-		} else {
-			obj_add_collider(OBJ_INDEX(moveup));
-		}
+		obj_add_collider(OBJ_INDEX(moveup));
 
 		// next
 		moveup = GET_NEXT(moveup);

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -7004,11 +7004,7 @@ void sexp_set_object_position(int n)
 	// Goober5000 - only if we have a valid object (don't do this for departed ships, waypoints, etc.)
 	if (oswpt.type == OSWPT_TYPE_SHIP || oswpt.type == OSWPT_TYPE_WING)
 	{
-		if ( Cmdline_old_collision_sys ) {
-			obj_all_collisions_retime();
-		} else {
-			obj_collide_retime_cached_pairs();
-		}
+		obj_collide_retime_cached_pairs();
 	}
 
 	// if this is a nebula mission and a player is being moved far enough,
@@ -7110,11 +7106,7 @@ void sexp_set_object_orientation(int n)
 	// Goober5000 - only if we have a valid object (don't do this for departed ships, waypoints, etc.)
 	if (oswpt.type == OSWPT_TYPE_SHIP || oswpt.type == OSWPT_TYPE_WING)
 	{
-		if ( Cmdline_old_collision_sys ) {
-			obj_all_collisions_retime();
-		} else {
-			obj_collide_retime_cached_pairs();
-		}
+		obj_collide_retime_cached_pairs();
 	}
 
 	switch (oswpt.type)

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -7916,11 +7916,7 @@ static void ship_dying_frame(object *objp, int ship_num)
 				polymodel *pm = model_get(sip->model_num);
 
 				// Gets two random points on the surface of a submodel
-				if ( Cmdline_old_collision_sys ) {
-					submodel_get_two_random_points(pm->id, pm->detail[0], &pnt1, &pnt2 );
-				} else {
-					submodel_get_two_random_points_better(pm->id, pm->detail[0], &pnt1, &pnt2 );
-				}
+				submodel_get_two_random_points_better(pm->id, pm->detail[0], &pnt1, &pnt2);
 
 				model_find_world_point(&outpnt, &pnt1, sip->model_num, pm->detail[0], &objp->orient, &objp->pos );
 
@@ -8030,11 +8026,7 @@ static void ship_dying_frame(object *objp, int ship_num)
 				vec3d tmp, outpnt, pnt1, pnt2;
 
 				// Gets two random points on the surface of a submodel [KNOSSOS]
-				if ( Cmdline_old_collision_sys ) {
-					submodel_get_two_random_points(pm->id, pm->detail[0], &pnt1, &pnt2 );
-				} else {
-					submodel_get_two_random_points_better(pm->id, pm->detail[0], &pnt1, &pnt2 );
-				}
+				submodel_get_two_random_points_better(pm->id, pm->detail[0], &pnt1, &pnt2);
 
 				vm_vec_avg( &tmp, &pnt1, &pnt2 );
 				model_find_world_point(&outpnt, &tmp, pm->id, pm->detail[0], &objp->orient, &objp->pos );
@@ -10282,13 +10274,8 @@ void change_ship_type(int n, int ship_type, int by_sexp)
 	sp->model_instance_num = model_create_instance(true, sip->model_num);
 
 	// Valathil - Reinitialize collision checks
-	if ( Cmdline_old_collision_sys ) {
-		obj_remove_pairs(objp);
-		obj_add_pairs(OBJ_INDEX(objp));
-	} else {
-		obj_remove_collider(OBJ_INDEX(objp));
-		obj_add_collider(OBJ_INDEX(objp));
-	}
+	obj_remove_collider(OBJ_INDEX(objp));
+	obj_add_collider(OBJ_INDEX(objp));
 
 	// The E - If we're switching during gameplay, make sure we get valid primary/secondary selections
 	if ( by_sexp ) {

--- a/code/ship/shipfx.cpp
+++ b/code/ship/shipfx.cpp
@@ -392,11 +392,7 @@ void shipfx_blow_up_model(object *obj,int model, int submodel, int ndebris, vec3
 		vec3d pnt1, pnt2;
 
 		// Gets two random points on the surface of a submodel
-		if ( Cmdline_old_collision_sys ) {
-			submodel_get_two_random_points(model, submodel, &pnt1, &pnt2 );
-		} else {
-			submodel_get_two_random_points_better(model, submodel, &pnt1, &pnt2 );
-		}
+		submodel_get_two_random_points_better(model, submodel, &pnt1, &pnt2);
 
 		vec3d tmp, outpnt;
 
@@ -2387,13 +2383,8 @@ void shipfx_do_damaged_arcs_frame( ship *shipp )
 		int n, n_arcs = ((rand()>>5) % 3)+1;		// Create 1-3 sparks
 
 		vec3d v1, v2, v3, v4;
-		if ( Cmdline_old_collision_sys ) {
-			submodel_get_two_random_points(model_num, -1, &v1, &v2);
-			submodel_get_two_random_points(model_num, -1, &v3, &v4);
-		} else {
-			submodel_get_two_random_points_better(model_num, -1, &v1, &v2);
-			submodel_get_two_random_points_better(model_num, -1, &v3, &v4);
-		}
+		submodel_get_two_random_points_better(model_num, -1, &v1, &v2);
+		submodel_get_two_random_points_better(model_num, -1, &v3, &v4);
 
 		// For large ships, cap the length to be 25% of max radius
 		if ( obj->radius > 200.0f )	{
@@ -2503,11 +2494,7 @@ void shipfx_do_damaged_arcs_frame( ship *shipp )
 				int mr = myrand();
 				if ( mr < RAND_MAX/5 )	{
 					vec3d v1, v2;
-					if ( Cmdline_old_collision_sys ) {
-						submodel_get_two_random_points(model_num, -1, &v1, &v2);
-					} else {
-						submodel_get_two_random_points_better(model_num, -1, &v1, &v2);
-					}
+					submodel_get_two_random_points_better(model_num, -1, &v1, &v2);
 
 					vec3d static_one;
 

--- a/code/sound/fsspeech.cpp
+++ b/code/sound/fsspeech.cpp
@@ -6,17 +6,6 @@
  *
 */ 
 
-
-
-
-
-#ifdef FS2_SPEECH
-
-
-#ifdef _WIN32
-#include <windows.h>
-#endif
-
 #include "globalincs/pstypes.h"
 #include "osapi/osregistry.h"
 #include "sound/fsspeech.h"
@@ -30,7 +19,7 @@ const size_t MAX_SPEECH_BUFFER_LEN = 4096;
 static int speech_inited = 0;
 
 bool FSSpeech_play_from[FSSPEECH_FROM_MAX];
-char *FSSpeech_play_id[FSSPEECH_FROM_MAX] =
+const char *FSSpeech_play_id[FSSPEECH_FROM_MAX] =
 {
 	"SpeechTechroom",
 	"SpeechBriefings",
@@ -168,5 +157,3 @@ bool fsspeech_playing()
 
 	return speech_is_speaking();
 }
-
-#endif	// FS2_SPEECH defined

--- a/code/sound/fsspeech.h
+++ b/code/sound/fsspeech.h
@@ -18,8 +18,6 @@ enum
 	FSSPEECH_FROM_MAX
 };
 
-#ifdef FS2_SPEECH
-
 bool fsspeech_init();
 void fsspeech_deinit();
 void fsspeech_play(int type, const char *text);
@@ -32,27 +30,5 @@ void fsspeech_play_buffer(int type);
 
 bool fsspeech_play_from(int type);
 bool fsspeech_playing();
-
-inline bool fsspeech_was_compiled() { return true; }
-
-#else
-
-// stub functions (c.f. NO_SOUND)
-
-inline bool fsspeech_init() { return false; }
-inline void fsspeech_deinit() {}
-inline void fsspeech_play(int  /*type*/, const char * /*text*/) { }
-inline void fsspeech_stop() {}
-inline void fsspeech_pause(bool  /*playing*/) { }
-
-inline void fsspeech_start_buffer() {}
-inline void fsspeech_stuff_buffer(const char * /*text*/) { }
-inline void fsspeech_play_buffer(int  /*type*/) {}
-
-inline bool fsspeech_play_from(int  /*type*/) { return false; }
-inline bool fsspeech_playing() { return false; }
-inline bool fsspeech_was_compiled( ) { return false; }
-
-#endif
 
 #endif	// header define

--- a/code/sound/speech.h
+++ b/code/sound/speech.h
@@ -31,15 +31,15 @@ SCP_vector<SCP_string> speech_enumerate_voices();
 
 // Goober5000: see, the *real* way to do stubs (avoiding the warnings)
 // is to just use #defines (c.f. NO_SOUND)
-#define speech_init() (false)
-#define speech_deinit()
-#define speech_play(text) ((text), false)
-#define speech_pause() (false)
-#define speech_resume() (false)
-#define speech_stop() (false)
-#define speech_set_volume(volume) ((volume), false)
-#define speech_set_voice(voice) ((voice), false)
-#define speech_is_speaking() (false)
+inline bool speech_init() { return false; }
+inline void speech_deinit() {}
+inline bool speech_play(const char* /*text*/) { return false; }
+inline bool speech_pause() { return false; }
+inline bool speech_resume() { return false; }
+inline bool speech_stop() { return false; }
+inline bool speech_set_volume(unsigned short /*volume*/) { return false; }
+inline bool speech_set_voice(int /*voice*/) { return false; }
+inline bool speech_is_speaking() { return false; }
 
 inline SCP_vector<SCP_string> speech_enumerate_voices() {
 	return SCP_vector<SCP_string>();

--- a/code/starfield/supernova.cpp
+++ b/code/starfield/supernova.cpp
@@ -153,11 +153,7 @@ void supernova_do_particles()
 
 		// emit
 		for(idx=0; idx<10; idx++) {
-			if ( Cmdline_old_collision_sys ) {
-				submodel_get_two_random_points(Ship_info[Player_ship->ship_info_index].model_num, 0, &ta, &tb);
-			} else {
-				submodel_get_two_random_points_better(Ship_info[Player_ship->ship_info_index].model_num, 0, &ta, &tb);
-			}
+			submodel_get_two_random_points_better(Ship_info[Player_ship->ship_info_index].model_num, 0, &ta, &tb);
 
 			// rotate into world space
 			vm_vec_unrotate(&a, &ta, &Player_obj->orient);

--- a/code/weapon/beam.cpp
+++ b/code/weapon/beam.cpp
@@ -2057,11 +2057,7 @@ void beam_get_binfo(beam *b, float accuracy, int num_shots)
 			vm_vec_zero(&b->binfo.dir_b);
 		} else {
 			// get random model points, this is useful for big ships, because we never miss when shooting at them
-			if ( Cmdline_old_collision_sys ) {
-				submodel_get_two_random_points(model_num, 0, &b->binfo.dir_a, &b->binfo.dir_b);
-			} else {
-				submodel_get_two_random_points_better(model_num, 0, &b->binfo.dir_a, &b->binfo.dir_b);
-			}
+			submodel_get_two_random_points_better(model_num, 0, &b->binfo.dir_a, &b->binfo.dir_b);
 		}
 		break;
 

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -1791,20 +1791,8 @@ void game_init()
 		snd_init();
 	}
 
-	if(fsspeech_init() == false) {
+	if(!fsspeech_init()) {
 		mprintf(("Failed to init speech\n"));
-
-		if(Cmdline_query_speech)
-		{
-			if (!fsspeech_was_compiled())
-				os::dialogs::Message(os::dialogs::MESSAGEBOX_WARNING, "Speech is not compiled in this build in code.lib");
-			else
-				os::dialogs::Message(os::dialogs::MESSAGEBOX_WARNING, "Speech is compiled, but failed to init");
-		}
-	} else if(Cmdline_query_speech) {
-		// Its bad practice to use a negative type, this is an exceptional case
-		fsspeech_play(-1,"Welcome to FS2 open");
-		os::dialogs::Message(os::dialogs::MESSAGEBOX_INFORMATION, "Speech is compiled and initialised and should be working");
 	}
 
 /////////////////////////////

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -6923,11 +6923,7 @@ void game_shutdown(void)
 	// Free SEXP resources
 	sexp_shutdown();
 
-	if ( Cmdline_old_collision_sys ) {
-		obj_pairs_close();		// free memory from object collision pairs
-	} else {
-		obj_reset_colliders();
-	}
+	obj_reset_colliders();
 	stars_close();			// clean out anything used by stars code
 
 	// the menu close functions will unload the bitmaps if they were displayed during the game


### PR DESCRIPTION
Currently, the rendering options sliders in the lab for ambient, static and bloom are initially set to 0 by default, even though the actual values are what is passed in on the command line.  This PR changes that so that the sliders accurately reflect the true values.
This also adds the ability to reset a ship to the default position, rotation and lighting when 'v' is pressed.
These changes should improve the experience of trying out different lighting settings.