### PR TITLE
Fix Appveyor Qt directory

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,11 +9,11 @@ environment:
     - BuildID: 0
       CMAKE_GENERATOR: Visual Studio 14 2015
       PlatformToolset: v140_xp
-      QT_DIR: C:\Qt\5.9.5\msvc2015
+      QT_DIR: C:\Qt\5.9\msvc2015
     - BuildID: 1
       CMAKE_GENERATOR: Visual Studio 14 2015 Win64
       PlatformToolset: v140_xp
-      QT_DIR: C:\Qt\5.9.5\msvc2015_64
+      QT_DIR: C:\Qt\5.9\msvc2015_64
 before_build:
   - git submodule update --init --recursive
 build_script:


### PR DESCRIPTION
They updated their Qt version and didn't update the documentation page.
This fixes the recent build errors by using the 5.9 symlink which is
linked to the most recent version.