### PR TITLE
Fixes issue #1935

### DIFF
--- a/code/scripting/api/libs/graphics.cpp
+++ b/code/scripting/api/libs/graphics.cpp
@@ -439,7 +439,12 @@ ADE_FUNC(setTarget, l_Graphics, "[texture Texture]",
 	texture_h* idx = nullptr;
 	ade_get_args(L, "|o", l_Texture.GetPtr(&idx));
 
-	return ade_set_args(L, "b", bm_set_render_target(idx->isValid() ? idx->handle : -1, 0));
+	if (idx == nullptr) {
+		return ade_set_args(L, "b", bm_set_render_target(-1, 0));
+	}
+	else {
+		return ade_set_args(L, "b", bm_set_render_target(idx->isValid() ? idx->handle : -1, 0));
+	}
 }
 
 ADE_FUNC(setCamera, l_Graphics, "[camera handle Camera]", "Sets current camera, or resets camera if none specified", "boolean", "true if successful, false or nil otherwise")


### PR DESCRIPTION
If the optional arg isn't present; just pass -1 to bm_set_render_target

@asarium not trying to steal the issue :grinning: happy for you to jump in if you have a better solution.