### PR TITLE
remove error bypass in subsys functions

### DIFF
--- a/code/hud/hudsquadmsg.cpp
+++ b/code/hud/hudsquadmsg.cpp
@@ -2483,7 +2483,7 @@ int hud_query_order_issued(char *to, char *order_name, char *target_name, int ti
 								continue;
 							}
                             
-							int subsys_index = ship_get_subsys_index(&Ships[target_ship], special_argument, 1); 
+							int subsys_index = ship_get_subsys_index(&Ships[target_ship], special_argument); 
 							// if the order is for s different subsystem
 							if (Squadmsg_history[i].special_index != subsys_index) {
 								continue;

--- a/code/network/multi_obj.cpp
+++ b/code/network/multi_obj.cpp
@@ -333,7 +333,7 @@ int multi_oo_pack_client_data(ubyte *data)
 
 		// locked targeted subsys index
 		if(Player->locking_subsys != NULL){
-			l_subsys = (char)ship_get_index_from_subsys( Player->locking_subsys, Player_ai->target_objnum, 1 );
+			l_subsys = (char)ship_get_index_from_subsys( Player->locking_subsys, Player_ai->target_objnum );
 		}
 	}
 

--- a/code/network/multimsgs.cpp
+++ b/code/network/multimsgs.cpp
@@ -7320,7 +7320,7 @@ void send_homing_weapon_info( int weapon_num )
 		if ( (homing_object->type == OBJ_SHIP) && (wp->homing_subsys != NULL) ) {
 			int s_index;
 
-			s_index = ship_get_index_from_subsys( wp->homing_subsys, OBJ_INDEX(homing_object), 1 );
+			s_index = ship_get_index_from_subsys( wp->homing_subsys, OBJ_INDEX(homing_object) );
 			Assert( s_index < CHAR_MAX );			// better be less than this!!!!
 			t_subsys = (char)s_index;
 		}
@@ -7708,7 +7708,7 @@ void send_beam_fired_packet(object *shooter, ship_subsys *turret, object *target
 		Assert( (bank_point >= 0) && (bank_point < UCHAR_MAX) );
 		subsys_index = (char)bank_point;
 	} else {
-		subsys_index = (char)ship_get_index_from_subsys(turret, OBJ_INDEX(shooter), 1);
+		subsys_index = (char)ship_get_index_from_subsys(turret, OBJ_INDEX(shooter));
 	}
 
 	Assert(subsys_index >= 0);

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -11469,7 +11469,7 @@ void sexp_sabotage_subsystem(int n)
 		}
 		else {
 			do_loop = false;
-			index = ship_get_subsys_index(shipp, subsystem, 1);	// Bypass any error since we supply one here
+			index = ship_get_subsys_index(shipp, subsystem);
 			if ( index == -1 ) {
 				nprintf(("Warning", "Couldn't find subsystem %s on ship %s for sabotage subsystem\n", subsystem, shipp->ship_name));
 				return;
@@ -11582,7 +11582,7 @@ void sexp_repair_subsystem(int n)
 		}
 		else {
 			do_loop = false;
-			index = ship_get_subsys_index(shipp, subsystem, 1);	// Bypass any error since we supply one here
+			index = ship_get_subsys_index(shipp, subsystem);
 			if ( index == -1 ) {
 				nprintf(("Warning", "Couldn't find subsystem %s on ship %s for repair subsystem\n", subsystem, shipp->ship_name));
 				return;
@@ -11701,7 +11701,7 @@ void sexp_set_subsystem_strength(int n)
 		}
 		else {
 			do_loop = false;
-			index = ship_get_subsys_index(shipp, subsystem, 1);	// Bypass any error since we supply one here
+			index = ship_get_subsys_index(shipp, subsystem);
 			if ( index == -1 ) {
 				nprintf(("Warning", "Couldn't find subsystem %s on ship %s for set subsystem strength\n", subsystem, shipp->ship_name));
 				return;
@@ -11782,7 +11782,7 @@ void sexp_destroy_subsys_instantly (int n)
 		{
 			// normal subsystems
 			ss = ship_get_subsys(shipp, subsystem);
-			index = ship_get_subsys_index(shipp, subsystem, 1);
+			index = ship_get_subsys_index(shipp, subsystem);
 			if ( index == -1 ) {
 				nprintf(("Warning", "Couldn't find subsystem %s on ship %s for destroy-subsys-instantly\n", subsystem, shipp->ship_name));
 				n = CDR(n);
@@ -20090,7 +20090,7 @@ void sexp_subsys_set_random(int node)
 
 	// get exclusion list
 	while( n != -1) {
-		int exclude_index = ship_get_subsys_index(shipp, CTEXT(n), 0);
+		int exclude_index = ship_get_subsys_index(shipp, CTEXT(n));
 		if (exclude_index >= 0) {
 			exclusion_list[exclude_index] = 1;
 		}

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -13345,7 +13345,7 @@ ship_subsys *ship_get_indexed_subsys( ship *sp, int index, vec3d *attacker_pos )
 /**
  * Given a pointer to a subsystem and an associated object, return the index.
  */
-int ship_get_index_from_subsys(ship_subsys *ssp, int objnum, int error_bypass)
+int ship_get_index_from_subsys(ship_subsys *ssp, int objnum)
 {
 	if (ssp == NULL)
 		return -1;
@@ -13367,8 +13367,7 @@ int ship_get_index_from_subsys(ship_subsys *ssp, int objnum, int error_bypass)
 			count++;
 			ss = GET_NEXT( ss );
 		}
-		if ( !error_bypass )
-			Int3();			// get allender -- turret ref didn't fixup correctly!!!!
+
 		return -1;
 	}
 }
@@ -13376,7 +13375,7 @@ int ship_get_index_from_subsys(ship_subsys *ssp, int objnum, int error_bypass)
 /**
  * Returns the index number of the ship_subsys parameter
  */
-int ship_get_subsys_index(ship *sp, const char* ss_name, int error_bypass)
+int ship_get_subsys_index(ship *sp, const char* ss_name)
 {
 	int count;
 	ship_subsys *ss;
@@ -13389,9 +13388,6 @@ int ship_get_subsys_index(ship *sp, const char* ss_name, int error_bypass)
 		count++;
 		ss = GET_NEXT( ss );
 	}
-
-	if (!error_bypass)
-		Int3();
 
 	return -1;
 }

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -1505,8 +1505,8 @@ extern void compute_slew_matrix(matrix *orient, angles *a);
 extern void ship_get_eye( vec3d *eye_pos, matrix *eye_orient, object *obj, bool do_slew = true, bool from_origin = false);		// returns in eye the correct viewing position for the given object
 //extern camid ship_get_followtarget_eye(object *obj);
 extern ship_subsys *ship_get_indexed_subsys( ship *sp, int index, vec3d *attacker_pos = NULL );	// returns index'th subsystem of this ship
-extern int ship_get_index_from_subsys(ship_subsys *ssp, int objnum, int error_bypass = 0);
-extern int ship_get_subsys_index(ship *sp, const char* ss_name, int error_bypass = 0);		// returns numerical index in linked list of subsystems
+extern int ship_get_index_from_subsys(ship_subsys *ssp, int objnum);
+extern int ship_get_subsys_index(ship *sp, const char* ss_name);		// returns numerical index in linked list of subsystems
 extern float ship_get_subsystem_strength( ship *shipp, int type );
 extern ship_subsys *ship_get_subsys(ship *shipp, const char *subsys_name);
 extern int ship_get_num_subsys(ship *shipp);

--- a/fred2/fredview.cpp
+++ b/fred2/fredview.cpp
@@ -3543,7 +3543,7 @@ char *error_check_initial_orders(ai_goal *goals, int ship, int wing)
 		switch (goals[i].ai_mode) {
 			case AI_GOAL_DESTROY_SUBSYSTEM:
 				Assert(flag == 2 && inst >= 0);
-				if (ship_get_subsys_index(&Ships[inst], goals[i].docker.name, 1) < 0)
+				if (ship_get_subsys_index(&Ships[inst], goals[i].docker.name) < 0)
 					return "Unknown subsystem type";
 
 				break;

--- a/fred2/shipgoalsdlg.cpp
+++ b/fred2/shipgoalsdlg.cpp
@@ -476,7 +476,7 @@ void ShipGoalsDlg::initialize(ai_goal *goals, int ship)
 			case AI_GOAL_DESTROY_SUBSYSTEM:
 				num = ship_name_lookup(goalp[item].target_name, 1);
 				if (num != -1)
-					m_subsys[item] = ship_get_subsys_index(&Ships[num], goalp[item].docker.name, 1);
+					m_subsys[item] = ship_get_subsys_index(&Ships[num], goalp[item].docker.name);
 
 				break;
 


### PR DESCRIPTION
The error_bypass has been a parameter in these functions since the original release of the source code.  However, its only function is to trigger an Int3().  Given that Int3() is considered harmful, and that the subsystem code no longer fails these tests, it can probably be removed.