### PR TITLE
Check optional scripting parameters before using them

### DIFF
--- a/code/scripting/api/objs/model.cpp
+++ b/code/scripting/api/objs/model.cpp
@@ -318,7 +318,7 @@ ADE_INDEXER(l_ModelTextures, "texture", "number Index/string TextureName", "text
 	if(tinfo == NULL)
 		return ade_set_error(L, "o", l_Texture.Set(texture_h()));
 
-	if (ADE_SETTING_VAR) {
+	if (ADE_SETTING_VAR && new_tex != nullptr) {
 		tinfo->SetTexture(new_tex->handle);
 	}
 

--- a/code/scripting/api/objs/particle.cpp
+++ b/code/scripting/api/objs/particle.cpp
@@ -188,7 +188,7 @@ ADE_VIRTVAR(AttachedObject, l_Particle, "object", "The object this particle is a
 
 	if (ADE_SETTING_VAR)
 	{
-		if (newObj->IsValid())
+		if (newObj != nullptr && newObj->IsValid())
 			ph->Get().lock()->attached_objnum = newObj->objp->signature;
 	}
 

--- a/code/scripting/api/objs/ship.cpp
+++ b/code/scripting/api/objs/ship.cpp
@@ -111,10 +111,12 @@ ADE_INDEXER(l_ShipTextures, "number Index/string TextureFilename", "Array of shi
 				shipp->ship_replacement_textures[i] = -1;
 		}
 
-		if(tdx->isValid())
-			shipp->ship_replacement_textures[final_index] = tdx->handle;
-		else
-			shipp->ship_replacement_textures[final_index] = -1;
+		if (tdx != nullptr) {
+			if (tdx->isValid())
+				shipp->ship_replacement_textures[final_index] = tdx->handle;
+			else
+				shipp->ship_replacement_textures[final_index] = -1;
+		}
 	}
 
 	if (shipp->ship_replacement_textures != NULL && shipp->ship_replacement_textures[final_index] >= 0)

--- a/code/scripting/api/objs/texturemap.cpp
+++ b/code/scripting/api/objs/texturemap.cpp
@@ -77,7 +77,7 @@ ADE_VIRTVAR(BaseMap, l_TextureMap, "texture", "Base texture", "texture", "Base t
 	if(tmap == NULL)
 		return ade_set_error(L, "o", l_Texture.Set(texture_h()));
 
-	if(ADE_SETTING_VAR && new_tex->isValid()) {
+	if (ADE_SETTING_VAR && new_tex != nullptr && new_tex->isValid()) {
 		tmap->textures[TM_BASE_TYPE].SetTexture(new_tex->handle);
 	}
 
@@ -95,7 +95,7 @@ ADE_VIRTVAR(GlowMap, l_TextureMap, "texture", "Glow texture", "texture", "Glow t
 	if(tmap == NULL)
 		return ade_set_error(L, "o", l_Texture.Set(texture_h()));
 
-	if(ADE_SETTING_VAR && new_tex->isValid()) {
+	if (ADE_SETTING_VAR && new_tex != nullptr && new_tex->isValid()) {
 		tmap->textures[TM_GLOW_TYPE].SetTexture(new_tex->handle);
 	}
 
@@ -113,7 +113,7 @@ ADE_VIRTVAR(SpecularMap, l_TextureMap, "texture", "Specular texture", "texture",
 	if(tmap == NULL)
 		return ade_set_error(L, "o", l_Texture.Set(texture_h()));
 
-	if(ADE_SETTING_VAR && new_tex->isValid()) {
+	if (ADE_SETTING_VAR && new_tex != nullptr && new_tex->isValid()) {
 		tmap->textures[TM_SPECULAR_TYPE].SetTexture(new_tex->handle);
 	}
 


### PR DESCRIPTION
These were all cases where the parameter was the new value when setting
a variable. The variables should always be initialized when that code is
reached but it is still better to check the pointers before using them.

These were found by @niffiwan.