### PR TITLE
objectsort: Move nebula detection to common area

### DIFF
--- a/code/object/objectsort.cpp
+++ b/code/object/objectsort.cpp
@@ -30,7 +30,6 @@
 #include "weapon/weapon.h"
 #include "decals/decals.h"
 
-
 class sorted_obj
 {
 public:
@@ -168,6 +167,12 @@ inline bool obj_render_is_model(object *obj)
 		|| obj->type == OBJ_JUMP_NODE;
 }
 
+// Are there reasons to hide objects base on distance?
+bool is_full_nebula()
+{
+	return (The_mission.flags[Mission::Mission_Flags::Fullneb]) && (Neb2_render_mode != NEB2_RENDER_NONE) && !Fred_running;
+}
+
 // Sorts all the objects by Z and renders them
 void obj_render_all(const std::function<void(object*)>& render_function, bool *draw_viewer_last )
 {
@@ -239,7 +244,7 @@ void obj_render_all(const std::function<void(object*)>& render_function, bool *d
 
 	gr_zbuffer_set( GR_ZBUFF_FULL );	
 
-	bool full_neb = ((The_mission.flags[Mission::Mission_Flags::Fullneb]) && (Neb2_render_mode != NEB2_RENDER_NONE) && !Fred_running);
+	bool full_neb = is_full_nebula();
 	bool c_viewer = (!Viewer_mode || (Viewer_mode & VM_PADLOCK_ANY) || (Viewer_mode & VM_OTHER_SHIP) || (Viewer_mode & VM_TRACK));
 
 	// now draw them
@@ -298,7 +303,7 @@ void obj_render_all(const std::function<void(object*)>& render_function, bool *d
 			continue;
 
 		// if we're fullneb, fire up the fog - this also generates a fog table
-		if((The_mission.flags[Mission::Mission_Flags::Fullneb]) && (Neb2_render_mode != NEB2_RENDER_NONE) && !Fred_running){
+		if(full_neb){
 			// get the fog values
 			neb2_get_adjusted_fog_values(&fog_near, &fog_far, obj);
 
@@ -332,6 +337,8 @@ void obj_render_queue_all()
 
 	scene.init();
 
+	bool full_neb = is_full_nebula();
+
 	for ( i = 0; i <= Highest_object_index; i++,objp++ ) {
 		if ( (objp->type != OBJ_NONE) && ( objp->flags [Object::Object_Flags::Renders] ) )	{
             objp->flags.remove(Object::Object_Flags::Was_rendered);
@@ -340,7 +347,7 @@ void obj_render_queue_all()
 				continue;
 			}
 
-			if ( (The_mission.flags[Mission::Mission_Flags::Fullneb]) && (Neb2_render_mode != NEB2_RENDER_NONE) && !Fred_running ) {
+			if ( full_neb ) {
 				vec3d to_obj;
 				vm_vec_sub( &to_obj, &objp->pos, &Eye_position );
 				float z = vm_vec_dot( &Eye_matrix.vec.fvec, &to_obj );


### PR DESCRIPTION
Run nebula test once per frame rather than once
per object.

Use a common function to avoid drifting errors.