### PR TITLE
objectsort: remove useless check

### DIFF
--- a/code/object/objectsort.cpp
+++ b/code/object/objectsort.cpp
@@ -317,6 +317,7 @@ void obj_render_all(const std::function<void(object*)>& render_function, bool *d
 	}
 
 	Sorted_objects.clear();
+
 	batching_render_all();
 	batching_render_all(true);
 }
@@ -366,6 +367,7 @@ void obj_render_queue_all()
 			obj_queue_render(objp, &scene);
 		}
 	}
+
 	scene.init_render();
 
 	scene.render_all(ZBUFFER_TYPE_FULL);

--- a/code/object/objectsort.cpp
+++ b/code/object/objectsort.cpp
@@ -357,18 +357,16 @@ void obj_render_queue_all()
 				}
 			}
 
-			if ( obj_render_is_model(objp) ) {
-				if( (objp->type == OBJ_SHIP) && Ships[objp->instance].shader_effect_active ) {
-					effect_ships.push_back(objp);
-					continue;
-				}
+
+			if( (objp->type == OBJ_SHIP) && Ships[objp->instance].shader_effect_active ) {
+				effect_ships.push_back(objp);
+				continue;
 			}
 
             objp->flags.set(Object::Object_Flags::Was_rendered);
 			obj_queue_render(objp, &scene);
 		}
 	}
-
 	scene.init_render();
 
 	scene.render_all(ZBUFFER_TYPE_FULL);

--- a/code/object/objectsort.cpp
+++ b/code/object/objectsort.cpp
@@ -317,7 +317,7 @@ void obj_render_all(const std::function<void(object*)>& render_function, bool *d
 	}
 
 	Sorted_objects.clear();
-
+	
 	batching_render_all();
 	batching_render_all(true);
 }

--- a/code/object/objectsort.cpp
+++ b/code/object/objectsort.cpp
@@ -358,7 +358,7 @@ void obj_render_queue_all()
 			}
 
 
-			if( (objp->type == OBJ_SHIP) && Ships[objp->instance].shader_effect_active ) {
+			if ( (objp->type == OBJ_SHIP) && Ships[objp->instance].shader_effect_active ) {
 				effect_ships.push_back(objp);
 				continue;
 			}

--- a/code/object/objectsort.cpp
+++ b/code/object/objectsort.cpp
@@ -317,7 +317,6 @@ void obj_render_all(const std::function<void(object*)>& render_function, bool *d
 	}
 
 	Sorted_objects.clear();
-	
 	batching_render_all();
 	batching_render_all(true);
 }


### PR DESCRIPTION
if an object is a ship, it is a model. No need
to check twice.