### PR TITLE
Add On Weapon Created Hook

### DIFF
--- a/code/scripting/scripting.cpp
+++ b/code/scripting/scripting.cpp
@@ -317,7 +317,7 @@ bool ConditionedHook::ConditionsValid(int action, object *objp, int more_data)
 					} else if(objp == NULL || objp->type != OBJ_SHIP) {
 						return false;
 					} else if (action == CHA_ONWEAPONCREATED) {
-						if (objp == NULL || objp->type != OBJ_WEAPON)
+						if (objp == nullptr || objp->type != OBJ_WEAPON)
 							return false;
 					} else {
 

--- a/code/scripting/scripting.cpp
+++ b/code/scripting/scripting.cpp
@@ -87,6 +87,7 @@ flag_def_list Script_actions[] =
 	{ "On Load Screen",			CHA_LOADSCREEN,		0 },
 	{ "On Campaign Mission Accept", 	CHA_CMISSIONACCEPT,	0 },
     { "On Ship Depart",			CHA_ONSHIPDEPART,	0 },
+	{ "On Weapon Created",		CHA_ONWEAPONCREATED, 0},
 };
 
 int Num_script_actions = sizeof(Script_actions)/sizeof(flag_def_list);
@@ -315,6 +316,9 @@ bool ConditionedHook::ConditionsValid(int action, object *objp, int more_data)
 							return false;
 					} else if(objp == NULL || objp->type != OBJ_SHIP) {
 						return false;
+					} else if (action == CHA_ONWEAPONCREATED) {
+						if (objp == NULL || objp->type != OBJ_WEAPON)
+							return false;
 					} else {
 
 						// Okay, if we're still here, then objp is both valid and a ship

--- a/code/scripting/scripting.h
+++ b/code/scripting/scripting.h
@@ -102,6 +102,7 @@ extern bool script_hook_valid(script_hook *hook);
 #define CHA_LOADSCREEN      40
 #define CHA_CMISSIONACCEPT  41
 #define CHA_ONSHIPDEPART	42
+#define CHA_ONWEAPONCREATED	43
 
 // management stuff
 void scripting_state_init();

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -5524,6 +5524,11 @@ int weapon_create( vec3d * pos, matrix * porient, int weapon_type, int parent_ob
 
 	weapon_update_state(wp);
 
+	object* weapon_obj = &Objects[objnum];
+	Script_system.SetHookObjects(1, "Weapon", weapon_obj);
+	Script_system.RunCondition(CHA_ONWEAPONCREATED, weapon_obj);
+	Script_system.RemHookVars(1, "Weapon");
+
 	return objnum;
 }
 


### PR DESCRIPTION
This hook is distinct from `$On Weapon Fired:` in that it triggers each time `weapon_create` is called by the engine. Additionally, the weapon object itself is included as a hookvar `Weapon`. 