### PR TITLE
Add a cache map for shaders in order to accelerate shader lookup

### DIFF
--- a/code/graphics/opengl/gropenglshader.cpp
+++ b/code/graphics/opengl/gropenglshader.cpp
@@ -338,7 +338,7 @@ void opengl_delete_shader(int sdr_handle)
 	Assert(sdr_handle >= 0);
 	Assert(sdr_handle < (int)GL_shader.size());
 	opengl_shader_t &victim = GL_shader[sdr_handle];
-	GL_shader_map.erase(std::make_pair(victim.shader, victim.flags));
+	GL_shader_map.erase(shader_descriptor_t(victim.shader, victim.flags));
 
 	GL_shader[sdr_handle].program.reset();
 	

--- a/code/graphics/opengl/gropenglshader.cpp
+++ b/code/graphics/opengl/gropenglshader.cpp
@@ -863,7 +863,7 @@ int opengl_compile_shader(shader_type sdr, uint flags)
 		sdr_index = (int)GL_shader.size();
 		GL_shader.push_back(std::move(new_shader));
 	}
-	GL_shader_map[std::make_pair(new_shader_shader, new_shader_flags)] = sdr_index;
+	GL_shader_map[shader_descriptor_t(new_shader_shader, new_shader_flags)] = sdr_index;
 	return sdr_index;
 }
 

--- a/code/graphics/opengl/gropenglshader.cpp
+++ b/code/graphics/opengl/gropenglshader.cpp
@@ -854,7 +854,7 @@ int opengl_compile_shader(shader_type sdr, uint flags)
 	}
 
 	int new_shader_shader = new_shader.shader;
-	unsigned int new_shader_flags = new_shader.flags;
+	uint32_t new_shader_flags = new_shader.flags;
 	// then insert it at an empty slot or at the end
 	if ( empty_idx >= 0 ) {
 		GL_shader[empty_idx] = std::move(new_shader);


### PR DESCRIPTION
Shaders lookup in opengl_get_shader_idx performance reduces from
O(n) shader to O(1).

Signed-off-by: Matthew Khouzam <matthew.khouzam@gmail.com>