### PR TITLE
Fix move constructor of streaminganim_h

### DIFF
--- a/code/scripting/api/objs/streaminganim.cpp
+++ b/code/scripting/api/objs/streaminganim.cpp
@@ -20,12 +20,16 @@ streaminganim_h::~streaminganim_h() {
 	generic_anim_unload(&ga);
 }
 streaminganim_h::streaminganim_h(streaminganim_h&& other) noexcept {
-	*this = std::move(other);
+	// Copy the other data over to us
+	ga = other.ga;
+
+	// Reset the other instance so that we own the only instance
+	generic_anim_init(&other.ga, nullptr);
 }
 streaminganim_h& streaminganim_h::operator=(streaminganim_h&& other) noexcept {
 	generic_anim_unload(&ga);
 
-	memcpy(&ga, &other.ga, sizeof(ga));
+	ga = other.ga;
 
 	// Reset the other instance so that we own the only instance
 	generic_anim_init(&other.ga, nullptr);


### PR DESCRIPTION
The move constructor was written wrongly which caused issues when moving
the value into the Lua memory. This fixes that issue.

This fixes #1944.