### PR TITLE
Make particle rendering parallel-processed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -182,6 +182,13 @@ IF(MSVC_USE_RUNTIME_DLL)
 	INCLUDE(InstallRequiredSystemLibraries)
 ENDIF(MSVC_USE_RUNTIME_DLL)
 
+find_package(OpenMP)
+if (OPENMP_FOUND)
+    set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")
+    set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
+    set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${OpenMP_EXE_LINKER_FLAGS}")
+endif()
+
 include(package)
 
 include(doxygen)

--- a/code/particle/particle.cpp
+++ b/code/particle/particle.cpp
@@ -19,6 +19,7 @@
 #include "render/batching.h"
 #include "tracing/tracing.h"
 #include "tracing/Monitor.h"
+#include <omp.h>
 
 using namespace particle;
 
@@ -460,12 +461,14 @@ namespace particle
 		if (Persistent_particles.empty() && Particles.empty())
 			return;
 
+		#pragma omp parallel for
 		for (auto& part : Persistent_particles) {
 			if (render_particle(part.get())) {
 				render_batch = true;
 			}
 		}
 
+		#pragma omp parallel for
 		for (auto& part : Particles) {
 			if (render_particle(&part)) {
 				render_batch = true;


### PR DESCRIPTION
Use OpenMP to parallelize particle render all. As particles are
not Z-sorted, this should accellerate scenes with lots of flack
on multi-core systems.

Signed-off-by: Matthew Khouzam <matthew.khouzam@gmail.com>