### PR TITLE
simple optimization for obj_sort_and_collide

### DIFF
--- a/code/object/objcollide.cpp
+++ b/code/object/objcollide.cpp
@@ -1043,8 +1043,8 @@ void obj_sort_and_collide()
 	if ( !(Game_detail_flags & DETAIL_FLAG_COLLISION) )
 		return;
 
-	SCP_vector<int> sort_list_y;
-	SCP_vector<int> sort_list_z;
+	static SCP_vector<int> sort_list_y;
+	static SCP_vector<int> sort_list_z;
 
 	sort_list_y.clear();
 	{

--- a/code/object/objcollide.cpp
+++ b/code/object/objcollide.cpp
@@ -1035,6 +1035,10 @@ void obj_collide_retime_cached_pairs(int checkdly)
 	}
 }
 
+// used only in obj_sort_and_collide()
+static SCP_vector<int> sort_list_y;
+static SCP_vector<int> sort_list_z;
+
 void obj_sort_and_collide()
 {
 	if (Cmdline_dis_collisions)
@@ -1042,9 +1046,6 @@ void obj_sort_and_collide()
 
 	if ( !(Game_detail_flags & DETAIL_FLAG_COLLISION) )
 		return;
-
-	static SCP_vector<int> sort_list_y;
-	static SCP_vector<int> sort_list_z;
 
 	sort_list_y.clear();
 	{


### PR DESCRIPTION
This PR is based on some Discord discussion.  Apparently this is a known optimization but nobody has bothered to submit a PR yet. :p

From comments by @TRBlount:

> Turns out
if you make the vectors in that function static
that function goes from 1.5ms
to 0.2ms

> by making the vectors static, you no longer have to worry about reallocating unless you add even MORE objects to the scene

> the speedup is basically taking advantage of the fact that the data pointer inside the vector isn't being moved around as often

