### PR TITLE
Improve particle parsing code

### DIFF
--- a/code/particle/effects/GenericShapeEffect.h
+++ b/code/particle/effects/GenericShapeEffect.h
@@ -163,11 +163,24 @@ class GenericShapeEffect : public ParticleEffect {
 			}
 		}
 
+		bool saw_deprecated_effect_location = false;
 		if (optional_string("+Trail effect:")) {
+			// This is the deprecated location since this introduces ambiguities in the parsing process
 			m_particleTrail = internal::parseEffectElement();
+			saw_deprecated_effect_location = true;
 		}
 
 		m_timing = util::EffectTiming::parseTiming();
+
+		if (optional_string("+Trail effect:")) {
+			// This is the new and correct location. This might create duplicate effects but the warning should be clear
+			// enough to avoid that
+			if (saw_deprecated_effect_location) {
+				error_display(0, "Found two trail effect options! Specifying '+Trail effect:' before '+Duration:' is "
+				                 "deprecated since that can cause issues with conflicting effect options.");
+			}
+			m_particleTrail = internal::parseEffectElement();
+		}
 	}
 
 	void initializeSource(ParticleSource& source) override {

--- a/code/utils/RandomRange.h
+++ b/code/utils/RandomRange.h
@@ -26,6 +26,18 @@ namespace {
  */
 template<typename T, size_t N>
 size_t parse_number_list(T (& list)[N]) {
+	ignore_white_space();
+
+	if (*Mp != '(')
+	{
+		// Probably one a single value so stuff that and don't parse a list. This makes it easier to specify single values
+		float val;
+		stuff_float(&val);
+
+		list[0] = static_cast<T>(val);
+		return 1;
+	}
+
 	float helpList[N];
 	auto num = stuff_float_list(helpList, N);
 


### PR DESCRIPTION
This makes some general changes to the particle parsing code. It moves
the trail effect option to the end of the options list to remove an
ambiguity in the resulting parsing code. This is done in a backwards
compatible manner so existing tables will not be broken by this.

This also introduces support for specifying single number ranges
without the parentheses to make that easier to use.