### PR TITLE
fix comment rot in speech.h

### DIFF
--- a/code/sound/speech.h
+++ b/code/sound/speech.h
@@ -29,8 +29,6 @@ SCP_vector<SCP_string> speech_enumerate_voices();
 
 #else
 
-// Goober5000: see, the *real* way to do stubs (avoiding the warnings)
-// is to just use #defines (c.f. NO_SOUND)
 inline bool speech_init() { return false; }
 inline void speech_deinit() {}
 inline bool speech_play(const char* /*text*/) { return false; }


### PR DESCRIPTION
To everyone, but especially @asarium: if you change the code in such a way that it renders an old comment obsolete, please don't forget to update or remove the comment.

This fixes 27e91d8f6c8a3fdbbf51ba73b20e6d110f23ca25 from #1923.