### PR TITLE
AI profile flag for support to not equip new primary

### DIFF
--- a/code/ai/ai_flags.h
+++ b/code/ai/ai_flags.h
@@ -110,7 +110,7 @@ namespace AI {
         Smart_shield_management,
         Smart_subsystem_targeting_for_turrets,
         Strict_turred_tagged_only_targeting,
-		Support_dont_add_primaries,
+		Support_dont_add_primaries, //Prevents support ship from equipping new primary as requested in http://scp.indiegames.us/mantis/view.php?id=3198
         Turrets_ignore_target_radius,
         Use_actual_primary_range,
         Use_additive_weapon_velocity,

--- a/code/ai/ai_flags.h
+++ b/code/ai/ai_flags.h
@@ -110,6 +110,7 @@ namespace AI {
         Smart_shield_management,
         Smart_subsystem_targeting_for_turrets,
         Strict_turred_tagged_only_targeting,
+		Support_dont_add_primaries,
         Turrets_ignore_target_radius,
         Use_actual_primary_range,
         Use_additive_weapon_velocity,

--- a/code/ai/ai_profiles.cpp
+++ b/code/ai/ai_profiles.cpp
@@ -435,6 +435,8 @@ void parse_ai_profiles_tbl(const char *filename)
 
 				set_flag(profile, "$ai guards specific ship in wing:", AI::Profile_Flags::Ai_guards_specific_ship_in_wing);
 
+				set_flag(profile, "$support don't add primaries:", AI::Profile_Flags::Support_dont_add_primaries);
+
 				profile->ai_path_mode = AI_PATH_MODE_NORMAL;
 				if (optional_string("$ai path mode:"))
 				{

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -13650,7 +13650,8 @@ int ship_do_rearm_frame( object *objp, float frametime )
 	// AL 10-31-97: Add missing primary weapons to the ship.  This is required since designers
 	//              want to have ships that start with no primaries, but can get them through
 	//					 rearm/repair
-	if ( swp->num_primary_banks < sip->num_primary_banks ) {
+	// plieblang - skip this if the ai profile flag is set
+	if ( swp->num_primary_banks < sip->num_primary_banks && !aip->ai_profile_flags[AI::Profile_Flags::Support_dont_add_primaries] ) {
 		for ( i = swp->num_primary_banks; i < sip->num_primary_banks; i++ ) {
 			swp->primary_bank_weapons[i] = sip->primary_bank_weapons[i];
 		}


### PR DESCRIPTION
Implements [Mantis 3198](http://scp.indiegames.us/mantis/view.php?id=3198).
This does pretty much what the title says:  currently if a primary bank is unequipped, rearming will result the player having a new weapon.  Because this is intentional from retail, this PR adds an AI flag to disable that behavior.