### PR TITLE
Add Lua state destruction event

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -47,6 +47,7 @@ Cpp11BracedListStyle: true
 DerivePointerAlignment: false
 DisableFormat:   false
 ForEachMacros:   [ foreach, Q_FOREACH, BOOST_FOREACH ]
+IncludeBlocks: Regroup
 IncludeCategories:
   - Regex:           '^(<.*\.(h|hh|hpp)>)$' # Includes of external libraries
     Priority:        4

--- a/code/scripting/scripting.cpp
+++ b/code/scripting/scripting.cpp
@@ -738,6 +738,8 @@ void script_state::Clear()
 	ConditionalHooks.clear();
 
 	if(LuaState != NULL) {
+		OnStateDestroy(LuaState);
+
 		lua_close(LuaState);
 	}
 

--- a/code/scripting/scripting.h
+++ b/code/scripting/scripting.h
@@ -6,6 +6,7 @@
 #include "graphics/2d.h"
 #include "scripting/ade_args.h"
 #include "scripting/lua/LuaFunction.h"
+#include "utils/event.h"
 
 #include <cstdio>
 
@@ -235,6 +236,8 @@ public:
 
 	//*****Other functions
 	void EndFrame();
+
+	util::event<void, lua_State*> OnStateDestroy;
 };
 
 template<typename T>


### PR DESCRIPTION
This can be used by the various subsystems for cleaning up Lua
references before the Lua state is destroyed. This avoids having
dangling references to the Lua state which would cause segfaults later
on.

The first subsystem to use this is the dynamic SEXP system which had
dangling references due to keeping Lua references to the SEXP functions.

This fixes #1954.