### PR TITLE
enable Warnings for unused functions

### DIFF
--- a/cmake/toolchain-apple-clang.cmake
+++ b/cmake/toolchain-apple-clang.cmake
@@ -9,8 +9,6 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -funroll-loops -fsigned-char -Wno-
 # Omit "conversion from string literal to 'char *' is deprecated" warnings.
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-write-strings")
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-function")
-
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated -Wno-char-subscripts")
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fcolor-diagnostics")

--- a/cmake/toolchain-clang.cmake
+++ b/cmake/toolchain-clang.cmake
@@ -66,8 +66,6 @@ set(COMPILER_FLAGS "${COMPILER_FLAGS} ${SANITIZE_FLAGS}")
 
 set(COMPILER_FLAGS "${COMPILER_FLAGS} -Wformat-security")
 
-set(COMPILER_FLAGS "${COMPILER_FLAGS} -Wno-unused-function")
-
 # Dear Clang, please tell us if a function does not return a value since that part of the standard is stupid!
 set(COMPILER_FLAGS "${COMPILER_FLAGS} -Wreturn-type")
 

--- a/cmake/toolchain-gcc.cmake
+++ b/cmake/toolchain-gcc.cmake
@@ -78,8 +78,6 @@ set(COMPILER_FLAGS "${COMPILER_FLAGS} ${SANITIZE_FLAGS}")
 
 set(COMPILER_FLAGS "${COMPILER_FLAGS} -Wformat-security")
 
-set(COMPILER_FLAGS "${COMPILER_FLAGS} -Wno-unused-function")
-
 # Dear GCC, please tell us if a function does not return a value since that part of the standard is stupid!
 set(COMPILER_FLAGS "${COMPILER_FLAGS} -Wreturn-type")
 

--- a/code/graphics/opengl/gropenglbmpman.cpp
+++ b/code/graphics/opengl/gropenglbmpman.cpp
@@ -27,12 +27,6 @@
 
 
 
-static inline int is_power_of_two(int w, int h)
-{
-	// NOTE: OpenGL texture code has a min tex size of 16 (currently), so we need to be at least
-	//       the min size here to qualify as power-of-2 and not get resized later on
-	return ( ((w >= GL_min_texture_width) && !(w & (w-1))) && ((h >= GL_min_texture_height) && !(h & (h-1))) );
-}
 
 int get_num_mipmap_levels(int w, int h)
 {

--- a/code/io/joy-sdl.cpp
+++ b/code/io/joy-sdl.cpp
@@ -20,14 +20,6 @@ Joystick *currentJoystick = nullptr;
 bool initialized = false;
 
 /**
- * @brief Compatibility conversion from HatPosition to array index
- */
-inline
-int hatEnumToIdx(HatPosition in) {
-	return static_cast<int>(in - JOY_NUM_BUTTONS);
-}
-
-/**
 * @brief Compatibility conversion from Button index to HatPosition
 */
 inline

--- a/code/libs/ffmpeg/FFmpeg.cpp
+++ b/code/libs/ffmpeg/FFmpeg.cpp
@@ -8,6 +8,7 @@ const int MIN_LOG_LEVEL = AV_LOG_WARNING;
 
 bool initialized = false;
 
+#ifndef NDEBUG
 void log_callback_report(void* ptr, int level, const char* fmt, va_list vl) {
 	if (level > MIN_LOG_LEVEL) {
 		return;
@@ -19,6 +20,7 @@ void log_callback_report(void* ptr, int level, const char* fmt, va_list vl) {
 
 	mprintf(("FFMPEG Log: %s", buffer)); // no \n, ffmpeg handles that
 }
+#endif
 
 void check_version(const char* libname, uint32_t current, uint32_t compiled)
 {

--- a/qtfred/src/mission/FredRenderer.cpp
+++ b/qtfred/src/mission/FredRenderer.cpp
@@ -141,45 +141,6 @@ void draw_asteroid_field() {
 	}
 }
 
-vec3d* get_subsystem_world_pos2(object* parent_obj, ship_subsys* subsys, vec3d* world_pos) {
-	if (subsys == NULL) {
-		*world_pos = parent_obj->pos;
-		return world_pos;
-	}
-
-	vm_vec_unrotate(world_pos, &subsys->system_info->pnt, &parent_obj->orient);
-	vm_vec_add2(world_pos, &parent_obj->pos);
-
-	return world_pos;
-}
-
-int get_subsys_bounding_rect(object* ship_obj, ship_subsys* subsys, int* x1, int* x2, int* y1, int* y2) {
-	if (subsys != NULL) {
-		vertex subobj_vertex;
-		vec3d subobj_pos;
-
-		get_subsystem_world_pos2(ship_obj, subsys, &subobj_pos);
-
-		g3_rotate_vertex(&subobj_vertex, &subobj_pos);
-
-		g3_project_vertex(&subobj_vertex);
-		if (subobj_vertex.flags & PF_OVERFLOW) { // if overflow, no point in drawing brackets
-			return 0;
-		}
-
-		int bound_rc;
-
-		bound_rc = subobj_find_2d_bound(subsys->system_info->radius, &ship_obj->orient, &subobj_pos, x1, y1, x2, y2);
-		if (bound_rc != 0) {
-			return 0;
-		}
-
-		return 1;
-	}
-
-	return 0;
-}
-
 void fredhtl_render_subsystem_bounding_box(subsys_to_render* s2r, subsys_to_render& Render_subsys) {
 	vertex text_center;
 	polymodel* pm = model_get(Ship_info[Ships[s2r->ship_obj->instance].ship_info_index].model_num);
@@ -561,33 +522,6 @@ void FredRenderer::display_active_ship_subsystem(subsys_to_render& Render_subsys
 			}
 		}
 	}
-}
-
-int get_subsys_bounding_rect(object* ship_obj, ship_subsys* subsys, int* x1, int* x2, int* y1, int* y2) {
-	if (subsys != NULL) {
-		vertex subobj_vertex;
-		vec3d subobj_pos;
-
-		get_subsystem_world_pos2(ship_obj, subsys, &subobj_pos);
-
-		g3_rotate_vertex(&subobj_vertex, &subobj_pos);
-
-		g3_project_vertex(&subobj_vertex);
-		if (subobj_vertex.flags & PF_OVERFLOW) { // if overflow, no point in drawing brackets
-			return 0;
-		}
-
-		int bound_rc;
-
-		bound_rc = subobj_find_2d_bound(subsys->system_info->radius, &ship_obj->orient, &subobj_pos, x1, y1, x2, y2);
-		if (bound_rc != 0) {
-			return 0;
-		}
-
-		return 1;
-	}
-
-	return 0;
 }
 
 void FredRenderer::render_compass() {


### PR DESCRIPTION
Enable compiler warnings for unused functions in gcc and clang toolchain files.

fixes #1955 