### PR TITLE
Remember to initialize Replacement_textures array after allocation.

### DIFF
--- a/code/model/modelrender.cpp
+++ b/code/model/modelrender.cpp
@@ -223,6 +223,10 @@ void model_render_params::set_replacement_textures(int *textures)
 void model_render_params::set_replacement_textures(int modelnum, SCP_vector<texture_replace>& replacement_textures)
 {
 	Replacement_textures = (int*)vm_malloc(MAX_REPLACEMENT_TEXTURES * sizeof(int));
+
+	for (int i = 0; i < MAX_REPLACEMENT_TEXTURES; i++)
+		Replacement_textures[i] = -1;
+
 	Manage_replacement_textures = true;
 
 	polymodel* pm = model_get(modelnum);


### PR DESCRIPTION
In commit 9e4c6df219d007b8ee78888fbed6a4bc00e7ebd7 (PR #1265), the `model_render_params::set_replacement_textures()` override that accepts a vector of texture replacements was added, which includes allocating its own `Replacement_textures` array. However, unlike its counterpart from missionparse.cpp, this array doesn't then have all of its elements set to -1. Since it works just fine there, I copied that code here so both versions should behave the same.

This *should* fix #1919.