### PR TITLE
fix some bugs with the per_ship_warp_type feature

### DIFF
--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -1859,6 +1859,7 @@ int parse_create_object(p_object *pobjp)
 }
 
 void parse_bring_in_docked_wing(p_object *p_objp, int wingnum, int shipnum);
+void ship_set_warp_effects(object *objp);
 
 /**
  * Given a stuffed p_object struct, create an object and fill in the necessary fields.
@@ -2025,6 +2026,11 @@ int parse_create_object_sub(p_object *p_objp)
 		shipp->warpin_params_index = p_objp->warpin_params_index;
 	if (p_objp->warpout_params_index >= 0)
 		shipp->warpout_params_index = p_objp->warpout_params_index;
+
+	// now that we have our correct warpout params, set the warp effect
+	if (!Fred_running) {
+		ship_set_warp_effects(&Objects[objnum]);
+	}
 
 	// reset texture animations
 	shipp->base_texture_anim_frametime = game_get_overall_frametime();

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -2027,7 +2027,7 @@ int parse_create_object_sub(p_object *p_objp)
 	if (p_objp->warpout_params_index >= 0)
 		shipp->warpout_params_index = p_objp->warpout_params_index;
 
-	// now that we have our correct warpout params, set the warp effect
+	// now that we have our correct warpout params, set the warp effects
 	if (!Fred_running) {
 		ship_set_warp_effects(&Objects[objnum]);
 	}

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -5604,7 +5604,7 @@ vec3d get_submodel_offset(int model, int submodel){
 
 }
 
-static void ship_set_warp_effects(object *objp)
+void ship_set_warp_effects(object *objp)
 {
 	ship *shipp = &Ships[objp->instance];
 	int warpin_type = Warp_params[shipp->warpin_params_index].warp_type;
@@ -6072,10 +6072,6 @@ static void ship_set(int ship_index, int objnum, int ship_type)
 
 	ai_object_init(objp, shipp->ai_index);
 	physics_ship_init(objp);
-
-	if ( !Fred_running ) {
-		ship_set_warp_effects(objp);
-	}
 
 	if (Fred_running){
 		shipp->ship_max_hull_strength = 100.0f;
@@ -9803,6 +9799,14 @@ void change_ship_type(int n, int ship_type, int by_sexp)
 	// point to new ship data
 	ship_model_change(n, ship_type);
 	sp->ship_info_index = ship_type;
+
+	// if we have the same warp parameters as the ship class, we will need to update them to point to the new class
+	if (sp->warpin_params_index == sip_orig->warpin_params_index) {
+		sp->warpin_params_index = sip->warpin_params_index;
+	}
+	if (sp->warpout_params_index == sip_orig->warpout_params_index) {
+		sp->warpout_params_index = sip->warpout_params_index;
+	}
 
 	if (!Fred_running) {
 		//WMC - set warp effects

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -2993,8 +2993,10 @@ static int parse_ship_values(ship_info* sip, const bool is_template, const bool 
 	}
 
 	// get ship parameters for warpin and warpout
-	sip->warpin_params_index = parse_warp_params(nullptr, WarpDirection::WARP_IN, info_type_name, sip->name);
-	sip->warpout_params_index = parse_warp_params(nullptr, WarpDirection::WARP_OUT, info_type_name, sip->name);
+	// Note: if the index is not -1, we must have already assigned warp parameters, probably because we are now
+	// parsing a TBM.  In that case, inherit from ourselves.
+	sip->warpin_params_index = parse_warp_params(sip->warpin_params_index >= 0 ? &Warp_params[sip->warpin_params_index] : nullptr, WarpDirection::WARP_IN, info_type_name, sip->name);
+	sip->warpout_params_index = parse_warp_params(sip->warpout_params_index >= 0 ? &Warp_params[sip->warpout_params_index] : nullptr, WarpDirection::WARP_OUT, info_type_name, sip->name);
 
 	// get ship explosion info
 	shockwave_create_info *sci = &sip->shockwave;


### PR DESCRIPTION
Since FRED and FS2 load mission data slightly differently, the warp effect loading code had to be slightly reorganized in order for the warp effects to not be based on invalid data.  Additionally, the warp effects had to be initialized a little bit later so that it could accommodate a new set of warp parameters from the parse object.  As a bonus, this PR also handles warp effects being reassigned in change_ship_class.

EDIT: This PR now also properly accommodates .tbm parsing.

This fixes #1969.