### PR TITLE
Don't repeatedly set selection_effect in parse_ship_values().

### DIFF
--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -2437,7 +2437,6 @@ static int parse_ship_values(ship_info* sip, const bool is_template, const bool 
 	}
 
 	// Ship fadein effect, used when no ani is specified or ship_select_3d is active
-	sip->selection_effect = Default_ship_select_effect; //By default, use the FS2 effect
 	if(optional_string("$Selection Effect:")) {
 		char effect[NAME_LENGTH];
 		stuff_string(effect, F_NAME, NAME_LENGTH);


### PR DESCRIPTION
Every time an entry for a ship was parsed (e.g. every time it showed up in a .tbm), the selection effect would be reset to the default. Since it's already set to the default in the `ship_info` constructor, this was both redundant and would make it extremely difficult to actually use a selection effect other than the default without constantly setting it in every .tbm.