### PR TITLE
Add support for "Effects per second" feature

### DIFF
--- a/code/particle/ParticleEffect.h
+++ b/code/particle/ParticleEffect.h
@@ -79,7 +79,7 @@ class ParticleEffect {
 	 * @param source The source to process
 	 * @return @c true if the effect should continue to be processed, @c false if the effect is done.
 	 */
-	virtual bool processSource(const ParticleSource* source) = 0;
+	virtual bool processSource(ParticleSource* source) = 0;
 
 	/**
 	 * @brief Initializes the source for this effect

--- a/code/particle/ParticleSource.cpp
+++ b/code/particle/ParticleSource.cpp
@@ -216,6 +216,7 @@ SourceTiming::SourceTiming() : m_creationTimestamp(timestamp(-1)), m_beginTimest
 
 void SourceTiming::setCreationTimestamp(int time) {
 	m_creationTimestamp = time;
+	m_nextCreation      = time;
 }
 
 void SourceTiming::setLifetime(int begin, int end) {
@@ -271,6 +272,8 @@ float SourceTiming::getLifeTimeProgress() const {
 
 	return done / (float) total;
 }
+bool SourceTiming::nextCreationTimeExpired() const { return timestamp_elapsed(m_nextCreation); }
+void SourceTiming::incrementNextCreationTime(int time_diff) { m_nextCreation += time_diff; }
 
 ParticleSource::ParticleSource() : m_effect(nullptr), m_processingCount(0) {}
 

--- a/code/particle/ParticleSource.h
+++ b/code/particle/ParticleSource.h
@@ -196,6 +196,7 @@ class SourceOrientation {
 class SourceTiming {
  private:
 	int m_creationTimestamp;
+	int m_nextCreation; //! The next time the source should generate a particle. Controlled by the effect of the source.
 
 	int m_beginTimestamp;
 	int m_endTimestamp;
@@ -237,6 +238,23 @@ class SourceTiming {
 	 * @return The progress of the source through its lifetime
 	 */
 	float getLifeTimeProgress() const;
+
+	/**
+	 * @brief Determine if the timestamp for the next particle creation has expired
+	 * @return @c true if the timestamp has expired, false otherwise
+	 */
+	bool nextCreationTimeExpired() const;
+
+	/**
+	 * @brief Move the internal timestamp for the next creation forward
+	 *
+	 * Use this for achieving a consistent amount of created particles regardless of FPS by setting time_diff_ms to a
+	 * constant time and call nextCreationTimeExpired() until that returns false. Then all particles for that frame have
+	 * been created.
+	 *
+	 * @param time_diff_ms
+	 */
+	void incrementNextCreationTime(int time_diff_ms);
 
 	friend class ParticleSource;
 };

--- a/code/particle/ParticleSourceWrapper.h
+++ b/code/particle/ParticleSourceWrapper.h
@@ -34,7 +34,7 @@ namespace particle
 
 		ParticleSourceWrapper& operator=(const ParticleSourceWrapper&) SCP_DELETED_FUNCTION;
 
-		ParticleSourceWrapper() {}
+		ParticleSourceWrapper() = default;
 		explicit ParticleSourceWrapper(SCP_vector<ParticleSource*>&& sources);
 		explicit ParticleSourceWrapper(ParticleSource* source);
 

--- a/code/particle/effects/BeamPiercingEffect.cpp
+++ b/code/particle/effects/BeamPiercingEffect.cpp
@@ -8,7 +8,7 @@
 
 namespace particle {
 namespace effects {
-bool BeamPiercingEffect::processSource(const ParticleSource* source) {
+bool BeamPiercingEffect::processSource(ParticleSource* source) {
 	particle_info info;
 
 	source->getOrigin()->applyToParticleInfo(info);

--- a/code/particle/effects/BeamPiercingEffect.h
+++ b/code/particle/effects/BeamPiercingEffect.h
@@ -23,7 +23,7 @@ class BeamPiercingEffect: public ParticleEffect {
  public:
 	BeamPiercingEffect() : ParticleEffect("") {}
 
-	bool processSource(const ParticleSource* source) override;
+	bool processSource(ParticleSource* source) override;
 
 	void parseValues(bool nocreate) override;
 

--- a/code/particle/effects/CompositeEffect.cpp
+++ b/code/particle/effects/CompositeEffect.cpp
@@ -7,7 +7,7 @@ namespace particle {
 namespace effects {
 CompositeEffect::CompositeEffect(const SCP_string& name) : ParticleEffect(name) {}
 
-bool CompositeEffect::processSource(const ParticleSource*) {
+bool CompositeEffect::processSource(ParticleSource*) {
 	UNREACHABLE("Processing a composite source is not supported! This was caused by a coding error, get a coder!");
 	return false;
 }

--- a/code/particle/effects/CompositeEffect.h
+++ b/code/particle/effects/CompositeEffect.h
@@ -19,7 +19,7 @@ class CompositeEffect: public ParticleEffect {
  public:
 	explicit CompositeEffect(const SCP_string& name);
 
-	bool processSource(const ParticleSource* source) override;
+	bool processSource(ParticleSource* source) override;
 
 	void parseValues(bool nocreate) override;
 

--- a/code/particle/effects/ParticleEmitterEffect.cpp
+++ b/code/particle/effects/ParticleEmitterEffect.cpp
@@ -10,7 +10,7 @@ ParticleEmitterEffect::ParticleEmitterEffect() : ParticleEffect("") {
 	memset(&m_emitter, 0, sizeof(m_emitter));
 }
 
-bool ParticleEmitterEffect::processSource(const ParticleSource* source) {
+bool ParticleEmitterEffect::processSource(ParticleSource* source) {
 	particle_emitter emitter = m_emitter;
 	source->getOrigin()->getGlobalPosition(&emitter.pos);
 	emitter.normal = source->getOrientation()->getDirectionVector(source->getOrigin());

--- a/code/particle/effects/ParticleEmitterEffect.h
+++ b/code/particle/effects/ParticleEmitterEffect.h
@@ -19,7 +19,7 @@ class ParticleEmitterEffect: public ParticleEffect {
  public:
 	ParticleEmitterEffect();
 
-	bool processSource(const ParticleSource* source) override;
+	bool processSource(ParticleSource* source) override;
 
 	void parseValues(bool nocreate) override;
 

--- a/code/particle/effects/SingleParticleEffect.cpp
+++ b/code/particle/effects/SingleParticleEffect.cpp
@@ -16,17 +16,22 @@ namespace effects {
 SingleParticleEffect::SingleParticleEffect(const SCP_string& name)
 	: ParticleEffect(name) {}
 
-bool SingleParticleEffect::processSource(const ParticleSource* source) {
+bool SingleParticleEffect::processSource(ParticleSource* source) {
 	if (!m_timing.continueProcessing(source)) {
 		return false;
 	}
 
-	particle_info info;
+	// This uses the internal features of the timing class for determining if and how many effects should be triggered
+	// this frame
+	util::EffectTiming::TimingState time_state;
+	while (m_timing.shouldCreateEffect(source, time_state)) {
+		particle_info info;
 
-	source->getOrigin()->applyToParticleInfo(info);
-	info.vel = vmd_zero_vector;
+		source->getOrigin()->applyToParticleInfo(info);
+		info.vel = vmd_zero_vector;
 
-	m_particleProperties.createParticle(info);
+		m_particleProperties.createParticle(info);
+	}
 
 	// Continue processing this source
 	return true;

--- a/code/particle/effects/SingleParticleEffect.h
+++ b/code/particle/effects/SingleParticleEffect.h
@@ -22,7 +22,7 @@ class SingleParticleEffect: public ParticleEffect {
  public:
 	explicit SingleParticleEffect(const SCP_string& name);
 
-	bool processSource(const ParticleSource* source) override;
+	bool processSource(ParticleSource* source) override;
 
 	void parseValues(bool nocreate) override;
 

--- a/code/particle/util/EffectTiming.h
+++ b/code/particle/util/EffectTiming.h
@@ -37,21 +37,36 @@ class EffectTiming {
 	Duration m_duration;
 	::util::UniformFloatRange m_delayRange;
 	::util::UniformFloatRange m_durationRange;
+
+	float m_particlesPerSecond = -1.f;
  public:
+	struct TimingState {
+		bool initial = true;
+	};
+
 	EffectTiming();
 
 	/**
      * @brief Applies the timing information to a specific source
      * @param source The source to be modified
      */
-	void applyToSource(ParticleSource* source);
+	void applyToSource(ParticleSource* source) const;
 
 	/**
      * @brief Determines if processing should continue
      * @param source The source which should be checked
      * @return @c true if processing should contine, @c false otherwise
      */
-	bool continueProcessing(const ParticleSource* source);
+	bool continueProcessing(const ParticleSource* source) const;
+
+	/**
+	 * @brief Given the properties of this timing structure, determine if a new effect should be created for a source.
+	 * @param source The source to check.
+	 * @param localState Internal state used by this function that is needed multiple times. Default construct
+	 * TimingState and then pass it to this function.
+	 * @return @c true if a new effect should be created, @c false. This might return @c true multiple times per frame.
+	 */
+	bool shouldCreateEffect(ParticleSource* source, TimingState& localState) const;
 
 	/**
      * @brief Parses an effect timing class

--- a/code/utils/RandomRange.h
+++ b/code/utils/RandomRange.h
@@ -65,8 +65,8 @@ class RandomRange {
 	typedef Value ValueType;
 
  private:
-	GeneratorType m_generator;
-	DistributionType m_distribution;
+	mutable GeneratorType m_generator;
+	mutable DistributionType m_distribution;
 
 	bool m_constant;
 	ValueType m_minValue;
@@ -100,7 +100,7 @@ class RandomRange {
 	 * @brief Determines the next random number of this range
 	 * @return The random number
 	 */
-	ValueType next() {
+	ValueType next() const {
 		if (m_constant) {
 			return m_minValue;
 		}


### PR DESCRIPTION
This allows specifying how many times per second an effect should be
triggered for a particle source instead of triggering the effect every
frame. This will allow modders to achieve more consistent particle
effects regardless of FPS.