### PR TITLE
Avoid ship name lookup when sending "special" messages.

### DIFF
--- a/code/mission/missionmessage.cpp
+++ b/code/mission/missionmessage.cpp
@@ -1500,8 +1500,8 @@ void message_queue_process()
 		return;
 
 	// Goober5000 - argh, don't conflate special sources with ships!
-	// NOTA BENE: don't check for != MESSAGE_SOURCE_COMMAND, because with the new command persona code, Command could be a ship
-	if ( q->source != MESSAGE_SOURCE_SPECIAL ) {
+	// NOTA BENE: don't check for != HUD_SOURCE_TERRAN_CMD, because with the new command persona code, Command could be a ship
+	if ( q->source != HUD_SOURCE_IMPORTANT ) {
 		Message_shipnum = ship_name_lookup( q->who_from );
 
 		// see if we need to check if sending ship is alive
@@ -1859,7 +1859,7 @@ void message_send_unique_to_player( char *id, void *data, int m_source, int prio
 				source = HUD_SOURCE_TERRAN_CMD;
 			} else if ( m_source == MESSAGE_SOURCE_SPECIAL ) {
 				who_from = (char *)data;
-				source = HUD_SOURCE_TERRAN_CMD;
+				source = HUD_SOURCE_IMPORTANT;
 			} else if ( m_source == MESSAGE_SOURCE_WINGMAN ) {
 				int m_persona, ship_index;
 


### PR DESCRIPTION
`MESSAGE_SOURCE_SPECIAL` indicates messages whose sender starts with "#", indicating that it's not a ship; however, the code was looking up the source as a ship name regardless, and if the message had a persona set, failing to find that ship name would result in the message failing to send. Commit f67596bc5e6b0253a70bfc6f8d389396b204f5c7 (a.k.a. SVN revision 5383) was supposed to fix this, however it was checking if `q->source` was `MESSAGE_SOURCE_SPECIAL` when `q->source` was one of the `HUD_SOURCE_*` #defines (specifically, `MESSAGE_SOURCE_SPECIAL` resulted in `HUD_SOURCE_TERRAN_CMD`). It turned out there was an unused `HUD_SOURCE_*` #define which behaves identically to `HUD_SOURCE_TERRAN_CMD`, namely `HUD_SOURCE_IMPORTANT`. By making `MESSAGE_SOURCE_SPECIAL` use `HUD_SOURCE_IMPORTANT` and changing the conditional to compare `q->source` to `HUD_SOURCE_IMPORTANT`, the intent behind the original fix can be carried out with minimal effort.

This also fixes issue #1706, which is basically the same as the [original mantis issue](http://scp.indiegames.us/mantis/view.php?id=1874).