### PR TITLE
Swap back return values for lua setButtonControlMode() function.

### DIFF
--- a/code/scripting/api/libs/base.cpp
+++ b/code/scripting/api/libs/base.cpp
@@ -213,11 +213,11 @@ ADE_FUNC(setButtonControlMode, l_Base, "NIL or enumeration LE_*_BUTTON_CONTROL",
 		case LE_LUA_ADDITIVE_BUTTON_CONTROL:
 			lua_game_control |= LGC_B_ADDITIVE;
 			lua_game_control &= ~(LGC_B_NORMAL|LGC_B_OVERRIDE);
-			return ade_set_args(L, "s", "LUA OVERRIDE BUTTON CONTROL");
+			return ade_set_args(L, "s", "LUA ADDITIVE BUTTON CONTROL");
 		case LE_LUA_OVERRIDE_BUTTON_CONTROL:
 			lua_game_control |= LGC_B_OVERRIDE;
 			lua_game_control &= ~(LGC_B_ADDITIVE|LGC_B_NORMAL);
-			return ade_set_args(L, "s", "LUA ADDITIVE BUTTON CONTROL");
+			return ade_set_args(L, "s", "LUA OVERRIDE BUTTON CONTROL");
 		default:
 			return ade_set_error(L, "s", "");
 	}


### PR DESCRIPTION
When setting `LUA_ADDITIVE_BUTTON_CONTROL`, the `setButtonControlMode()` function (in `l_Base`) would return "LUA OVERRIDE BUTTON CONTROL", and when setting `LUA_OVERRIDE_BUTTON_CONTROL`, "LUA ADDITIVE BUTTON CONTROL" would be returned. This commit simply swaps these back so that the appropriate return value is with the corresponding enum value.

I'm assuming this won't break any existing scripts (because there's rarely a reason to look at the return value when setting the button control mode), but it's theoretically possible it might.