### PR TITLE
Use modulo instead of division in Lua useButtonControl() function.

### DIFF
--- a/code/scripting/api/objs/control_info.cpp
+++ b/code/scripting/api/objs/control_info.cpp
@@ -353,7 +353,7 @@ ADE_FUNC(useButtonControl, l_Control_Info, "number, string", "Adds the defined b
 		for(i=0; i<num_plr_commands; i++) {
 			if(!(strcmp(buf, plr_commands[i].name))) {
 				int a;
-				a = plr_commands[i].def / 32;
+				a = plr_commands[i].def % 32;
 				Player->lua_bi.status[plr_commands[i].var] |= (1<<a);
 				break;
 			}


### PR DESCRIPTION
When using a string to define the appropriate control in the `useButtonControl()` function (in `l_Control_Info`), the command definition was being divided by 32 when the appropriate mathematical operator was modulo; as a result, the only controls that could actually wind up being referenced are these four: `TARGET_NEXT`, `MAX_THROTTLE`, `END_MISSION`, and `MULTI_MESSAGE_HOSTILE`. By using the modulo operator, the string lookup now appropriately references the relevant button.