### PR TITLE
 some tweaks and minor improvements to ship initialization

### DIFF
--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -1345,6 +1345,7 @@ void ai_object_init(object * obj, int ai_index)
 	aip->wing = -1;		//	Member of what wing? -1 means none.
 	aip->ai_class = Ship_info[Ships[obj->instance].ship_info_index].ai_class;
 	aip->behavior = AIM_NONE;
+	aip->mode = aip->behavior;
 }
 
 /**

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -1966,11 +1966,6 @@ int parse_create_object_sub(p_object *p_objp)
 		}
 	}
 
-	if (!Fred_running)
-	{
-		ship_assign_sound(&Ships[shipnum]);
-	}
-
 	// alternate stuff
 	shipp->alt_type_index = p_objp->alt_type_index;
 	shipp->callsign_index = p_objp->callsign_index;

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -1859,7 +1859,6 @@ int parse_create_object(p_object *pobjp)
 }
 
 void parse_bring_in_docked_wing(p_object *p_objp, int wingnum, int shipnum);
-void ship_set_warp_effects(object *objp);
 
 /**
  * Given a stuffed p_object struct, create an object and fill in the necessary fields.
@@ -1906,7 +1905,6 @@ int parse_create_object_sub(p_object *p_objp)
 
 	shipp->group = p_objp->group;
 	shipp->team = p_objp->team;
-	strcpy_s(shipp->ship_name, p_objp->name);
 	shipp->display_name = p_objp->display_name;
 	shipp->escort_priority = p_objp->escort_priority;
 	shipp->use_special_explosion = p_objp->use_special_explosion;
@@ -1973,18 +1971,12 @@ int parse_create_object_sub(p_object *p_objp)
 		ship_assign_sound(&Ships[shipnum]);
 	}
 
-	aip = &(Ai_info[shipp->ai_index]);
-	aip->behavior = p_objp->behavior;
-	aip->mode = aip->behavior;
-
-	// make sure aim_safety has its submode defined
-	if (aip->mode == AIM_SAFETY) {
-		aip->submode = AISS_1;
-	}
-
 	// alternate stuff
 	shipp->alt_type_index = p_objp->alt_type_index;
 	shipp->callsign_index = p_objp->callsign_index;
+
+	// AI stuff.  Note a lot of the AI was already initialized in ship_create.
+	aip = &(Ai_info[shipp->ai_index]);
 
 	aip->ai_class = p_objp->ai_class;
 	shipp->weapons.ai_class = p_objp->ai_class;  // Fred uses this instead of above.
@@ -1992,13 +1984,12 @@ int parse_create_object_sub(p_object *p_objp)
 	if (The_mission.ai_profile->flags[AI::Profile_Flags::Fix_ai_class_bug])
 		ship_set_new_ai_class(shipnum, p_objp->ai_class);
 
-	// must reset the number of ai goals when the object is created
-	for (i = 0; i < MAX_AI_GOALS; i++)
-	{
-		aip->goals[i].ai_mode = AI_GOAL_NONE;
-		aip->goals[i].signature = -1;
-		aip->goals[i].priority = -1;
-		aip->goals[i].flags.reset();
+	aip->behavior = p_objp->behavior;
+	aip->mode = aip->behavior;
+
+	// make sure aim_safety has its submode defined
+	if (aip->mode == AIM_SAFETY) {
+		aip->submode = AISS_1;
 	}
 
 	shipp->cargo1 = p_objp->cargo1;
@@ -2259,11 +2250,13 @@ int parse_create_object_sub(p_object *p_objp)
 				}
 			}
 
+			// skip the rest because the Pilot subsystem is special
 			continue;
 		}
 
-		ptr = GET_FIRST(&shipp->subsys_list);
-		while (ptr != END_OF_LIST(&shipp->subsys_list))
+		// find the subsystem in the ship list that corresponds to the parsed subsystem
+		ptr = ship_get_subsys(shipp, sssp->name);
+		if (ptr != nullptr)
 		{
 			// check the mission flag to possibly free all beam weapons - Goober5000, taken from SEXP.CPP
 			if (The_mission.flags[Mission::Mission_Flags::Beam_free_all_by_default])
@@ -2285,81 +2278,80 @@ int parse_create_object_sub(p_object *p_objp)
 				}
 			}
 
-			if (!subsystem_stricmp(ptr->system_info->subobj_name, sssp->name))
+			if (Fred_running)
 			{
-				if (Fred_running)
+				ptr->current_hits = sssp->percent;
+				ptr->max_hits = 100.0f;
+			}
+			else
+			{
+				ptr->max_hits = ptr->system_info->max_subsys_strength * (shipp->ship_max_hull_strength / sip->max_hull_strength);
+
+				float new_hits = ptr->max_hits * (100.0f - sssp->percent) / 100.f;
+				if (!(ptr->flags[Ship::Subsystem_Flags::No_aggregate])) {
+					shipp->subsys_info[ptr->system_info->type].aggregate_current_hits -= (ptr->max_hits - new_hits);
+				}
+
+				if ((100.0f - sssp->percent) < 0.5)
 				{
-					ptr->current_hits = sssp->percent;
-					ptr->max_hits = 100.0f;
+					ptr->current_hits = 0.0f;
+					ptr->submodel_info_1.blown_off = 1;
 				}
 				else
 				{
-					ptr->max_hits = ptr->system_info->max_subsys_strength * (shipp->ship_max_hull_strength / sip->max_hull_strength);
-
-					float new_hits = ptr->max_hits * (100.0f - sssp->percent) / 100.f;
-					if (!(ptr->flags[Ship::Subsystem_Flags::No_aggregate])) {
-						shipp->subsys_info[ptr->system_info->type].aggregate_current_hits -= (ptr->max_hits - new_hits);
-					}
-
-					if ((100.0f - sssp->percent) < 0.5)
-					{
-						ptr->current_hits = 0.0f;
-						ptr->submodel_info_1.blown_off = 1;
-					}
-					else
-					{
-						ptr->current_hits = new_hits;
-					}
+					ptr->current_hits = new_hits;
 				}
-
-				if (sssp->primary_banks[0] != SUBSYS_STATUS_NO_CHANGE)
-					for (j=0; j<MAX_SHIP_PRIMARY_BANKS; j++)
-						ptr->weapons.primary_bank_weapons[j] = sssp->primary_banks[j];
-
-				if (sssp->secondary_banks[0] != SUBSYS_STATUS_NO_CHANGE)
-					for (j=0; j<MAX_SHIP_SECONDARY_BANKS; j++)
-						ptr->weapons.secondary_bank_weapons[j] = sssp->secondary_banks[j];
-
-				// Goober5000
-				for (j = 0; j < ptr->weapons.num_primary_banks; j++)
-				{
-					if (Fred_running) {
-						ptr->weapons.primary_bank_ammo[j] = sssp->primary_ammo[j];
-					} else if (ptr->weapons.primary_bank_weapons[j] >= 0 && Weapon_info[ptr->weapons.primary_bank_weapons[j]].wi_flags[Weapon::Info_Flags::Ballistic]) {
-						Assertion(Weapon_info[ptr->weapons.primary_bank_weapons[j]].cargo_size > 0.0f,
-								"Primary weapon cargo size <= 0. Ship (%s) Subsystem (%s) Bank (%i) Weapon (%s)",
-								shipp->ship_name, sssp->name, j, Weapon_info[ptr->weapons.primary_bank_weapons[j]].name);
-
-						int capacity = (int)std::lround(sssp->primary_ammo[j]/100.0f * ptr->weapons.primary_bank_capacity[j]);
-						ptr->weapons.primary_bank_ammo[j] = (int)std::lround(capacity / Weapon_info[ptr->weapons.primary_bank_weapons[j]].cargo_size);
-					}
-				}
-
-				for (j = 0; j < ptr->weapons.num_secondary_banks; j++)
-				{
-					if (Fred_running) {
-						ptr->weapons.secondary_bank_ammo[j] = sssp->secondary_ammo[j];
-					} else if (ptr->weapons.secondary_bank_weapons[j] >= 0) {
-						Assertion(Weapon_info[ptr->weapons.secondary_bank_weapons[j]].cargo_size > 0.0f,
-								"Secondary weapon cargo size <= 0. Ship (%s) Subsystem (%s) Bank (%i) Weapon (%s)",
-								shipp->ship_name, sssp->name, j, Weapon_info[ptr->weapons.secondary_bank_weapons[j]].name);
-
-						int capacity = (int)std::lround(sssp->secondary_ammo[j]/100.0f * ptr->weapons.secondary_bank_capacity[j]);
-						ptr->weapons.secondary_bank_ammo[j] = (int)std::lround(capacity / Weapon_info[ptr->weapons.secondary_bank_weapons[j]].cargo_size);
-					}
-				}
-
-				ptr->subsys_cargo_name = sssp->subsys_cargo_name;
-
-				if (sssp->ai_class != SUBSYS_STATUS_NO_CHANGE)
-					ptr->weapons.ai_class = sssp->ai_class;
-
-				ptr->turret_best_weapon = -1;
-				ptr->turret_animation_position = MA_POS_NOT_SET;	// model animation position is not set
-				ptr->turret_animation_done_time = 0;
 			}
 
-			ptr = GET_NEXT(ptr);
+			if (sssp->primary_banks[0] != SUBSYS_STATUS_NO_CHANGE)
+				for (j=0; j<MAX_SHIP_PRIMARY_BANKS; j++)
+					ptr->weapons.primary_bank_weapons[j] = sssp->primary_banks[j];
+
+			if (sssp->secondary_banks[0] != SUBSYS_STATUS_NO_CHANGE)
+				for (j=0; j<MAX_SHIP_SECONDARY_BANKS; j++)
+					ptr->weapons.secondary_bank_weapons[j] = sssp->secondary_banks[j];
+
+			// Goober5000
+			for (j = 0; j < ptr->weapons.num_primary_banks; j++)
+			{
+				if (Fred_running) {
+					ptr->weapons.primary_bank_ammo[j] = sssp->primary_ammo[j];
+				} else if (ptr->weapons.primary_bank_weapons[j] >= 0 && Weapon_info[ptr->weapons.primary_bank_weapons[j]].wi_flags[Weapon::Info_Flags::Ballistic]) {
+					Assertion(Weapon_info[ptr->weapons.primary_bank_weapons[j]].cargo_size > 0.0f,
+							"Primary weapon cargo size <= 0. Ship (%s) Subsystem (%s) Bank (%i) Weapon (%s)",
+							shipp->ship_name, sssp->name, j, Weapon_info[ptr->weapons.primary_bank_weapons[j]].name);
+
+					int capacity = (int)std::lround(sssp->primary_ammo[j]/100.0f * ptr->weapons.primary_bank_capacity[j]);
+					ptr->weapons.primary_bank_ammo[j] = (int)std::lround(capacity / Weapon_info[ptr->weapons.primary_bank_weapons[j]].cargo_size);
+				}
+			}
+
+			for (j = 0; j < ptr->weapons.num_secondary_banks; j++)
+			{
+				if (Fred_running) {
+					ptr->weapons.secondary_bank_ammo[j] = sssp->secondary_ammo[j];
+				} else if (ptr->weapons.secondary_bank_weapons[j] >= 0) {
+					Assertion(Weapon_info[ptr->weapons.secondary_bank_weapons[j]].cargo_size > 0.0f,
+							"Secondary weapon cargo size <= 0. Ship (%s) Subsystem (%s) Bank (%i) Weapon (%s)",
+							shipp->ship_name, sssp->name, j, Weapon_info[ptr->weapons.secondary_bank_weapons[j]].name);
+
+					int capacity = (int)std::lround(sssp->secondary_ammo[j]/100.0f * ptr->weapons.secondary_bank_capacity[j]);
+					ptr->weapons.secondary_bank_ammo[j] = (int)std::lround(capacity / Weapon_info[ptr->weapons.secondary_bank_weapons[j]].cargo_size);
+				}
+			}
+
+			ptr->subsys_cargo_name = sssp->subsys_cargo_name;
+
+			if (sssp->ai_class != SUBSYS_STATUS_NO_CHANGE)
+				ptr->weapons.ai_class = sssp->ai_class;
+
+			ptr->turret_best_weapon = -1;
+			ptr->turret_animation_position = MA_POS_NOT_SET;	// model animation position is not set
+			ptr->turret_animation_done_time = 0;
+		}
+		else
+		{
+			Warning(LOCATION, "Unable to find '%s' in ship subsys_list!", sssp->name);
 		}
 	}
 	

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -14677,6 +14677,8 @@ void sexp_ship_create(int n)
 	ship *shipp = &Ships[shipnum];
 	ship_info *sip = &Ship_info[shipp->ship_info_index];
 
+	model_page_in_textures(Ship_info[new_ship_class].model_num, new_ship_class);
+
 	ship_set_warp_effects(&Objects[objnum]);
 
 	if (sip->flags[Ship::Info_Flags::Intrinsic_no_shields])

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -14686,15 +14686,9 @@ void sexp_ship_create(int n)
 
 	mission_log_add_entry(LOG_SHIP_ARRIVED, shipp->ship_name, NULL);
 
-	// If the ship is in a wing, this will be done in mission_set_wing_arrival_location() instead
-	// If the ship is in a wing, but the wing is docked then addition of bool brought_in_docked_wing accounts for that status --wookieejedi
-	if (Game_mode & GM_IN_MISSION)
-	{
-		Script_system.SetHookObjects(2, "Ship", &Objects[objnum], "Parent", NULL);
-
-		Script_system.RunCondition(CHA_ONSHIPARRIVE, &Objects[objnum]);
-		Script_system.RemHookVars(2, "Ship", "Parent");
-	}
+	Script_system.SetHookObjects(2, "Ship", &Objects[objnum], "Parent", NULL);
+	Script_system.RunCondition(CHA_ONSHIPARRIVE, &Objects[objnum]);
+	Script_system.RemHookVars(2, "Ship", "Parent");
 }
 
 // Goober5000

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -14677,8 +14677,6 @@ void sexp_ship_create(int n)
 	ship *shipp = &Ships[shipnum];
 	ship_info *sip = &Ship_info[shipp->ship_info_index];
 
-	ship_assign_sound(shipp);
-
 	ship_set_warp_effects(&Objects[objnum]);
 
 	if (sip->flags[Ship::Info_Flags::Intrinsic_no_shields])

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -14677,8 +14677,6 @@ void sexp_ship_create(int n)
 	ship *shipp = &Ships[shipnum];
 	ship_info *sip = &Ship_info[shipp->ship_info_index];
 
-	model_page_in_textures(Ship_info[new_ship_class].model_num, new_ship_class);
-
 	ship_set_warp_effects(&Objects[objnum]);
 
 	if (sip->flags[Ship::Info_Flags::Intrinsic_no_shields])

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -14684,7 +14684,7 @@ void sexp_ship_create(int n)
 	if (sip->flags[Ship::Info_Flags::Intrinsic_no_shields])
 		Objects[objnum].flags.set(Object::Object_Flags::No_shields);
 
-	mission_log_add_entry(LOG_SHIP_ARRIVED, shipp->ship_name, NULL);
+	mission_log_add_entry(LOG_SHIP_ARRIVED, shipp->ship_name, nullptr);
 
 	Script_system.SetHookObjects(2, "Ship", &Objects[objnum], "Parent", NULL);
 	Script_system.RunCondition(CHA_ONSHIPARRIVE, &Objects[objnum]);

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -5605,64 +5605,6 @@ vec3d get_submodel_offset(int model, int submodel){
 
 }
 
-void ship_set_warp_effects(object *objp)
-{
-	ship *shipp = &Ships[objp->instance];
-	int warpin_type = Warp_params[shipp->warpin_params_index].warp_type;
-	int warpout_type = Warp_params[shipp->warpout_params_index].warp_type;
-
-	if (warpin_type & WT_DEFAULT_WITH_FIREBALL)
-		warpin_type = WT_DEFAULT;
-	if (warpout_type & WT_DEFAULT_WITH_FIREBALL)
-		warpout_type = WT_DEFAULT;
-
-	if (shipp->warpin_effect != nullptr)
-		delete shipp->warpin_effect;
-
-	switch (warpin_type)
-	{
-		case WT_DEFAULT:
-		case WT_KNOSSOS:
-		case WT_DEFAULT_THEN_KNOSSOS:
-			shipp->warpin_effect = new WE_Default(objp, WarpDirection::WARP_IN);
-			break;
-		case WT_IN_PLACE_ANIM:
-			shipp->warpin_effect = new WE_BSG(objp, WarpDirection::WARP_IN);
-			break;
-		case WT_SWEEPER:
-			shipp->warpin_effect = new WE_Homeworld(objp, WarpDirection::WARP_IN);
-			break;
-		case WT_HYPERSPACE:
-			shipp->warpin_effect = new WE_Hyperspace(objp, WarpDirection::WARP_IN);
-			break;
-		default:
-			shipp->warpin_effect = new WarpEffect();
-	}
-
-	if (shipp->warpout_effect != nullptr)
-		delete shipp->warpout_effect;
-
-	switch (warpout_type)
-	{
-		case WT_DEFAULT:
-		case WT_KNOSSOS:
-		case WT_DEFAULT_THEN_KNOSSOS:
-			shipp->warpout_effect = new WE_Default(objp, WarpDirection::WARP_OUT);
-			break;
-		case WT_IN_PLACE_ANIM:
-			shipp->warpout_effect = new WE_BSG(objp, WarpDirection::WARP_OUT);
-			break;
-		case WT_SWEEPER:
-			shipp->warpout_effect = new WE_Homeworld(objp, WarpDirection::WARP_OUT);
-			break;
-		case WT_HYPERSPACE:
-			shipp->warpout_effect = new WE_Hyperspace(objp, WarpDirection::WARP_OUT);
-			break;
-		default:
-			shipp->warpout_effect = new WarpEffect();
-	}
-}
-
 // Reset all ship values to empty/unused.
 void ship::clear()
 {

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -9375,13 +9375,9 @@ int ship_create(matrix* orient, vec3d* pos, int ship_type, const char* ship_name
 		sip->flags.set(Ship::Info_Flags::Path_fixup);
 	}
 
-	// Add this ship to Ship_obj_list
-	shipp->ship_list_index = ship_obj_list_add(objnum);
-
-	// Set time when ship is created
-	shipp->create_time = timer_get_milliseconds();
-
-	ship_make_create_time_unique(shipp);
+	// this used to be done in parse_create_object_sub
+	if (!Fred_running)
+		ship_assign_sound(shipp);
 
 	// first try at ABtrails -Bobboau
 	ship_init_afterburners(shipp);
@@ -9392,6 +9388,14 @@ int ship_create(matrix* orient, vec3d* pos, int ship_type, const char* ship_name
 	model_anim_set_initial_states(shipp);
 
 	shipp->model_instance_num = model_create_instance(true, sip->model_num);
+
+	// Add this ship to Ship_obj_list
+	shipp->ship_list_index = ship_obj_list_add(objnum);
+
+	// Set time when ship is created
+	shipp->create_time = timer_get_milliseconds();
+
+	ship_make_create_time_unique(shipp);
 
 	shipp->time_created = Missiontime;
 
@@ -10072,7 +10076,8 @@ void change_ship_type(int n, int ship_type, int by_sexp)
 	model_anim_set_initial_states(sp);
 
 	//Reassign sound stuff
-	ship_assign_sound(sp);
+	if (!Fred_running)
+		ship_assign_sound(sp);
 	
 	// create new model instance data
 	sp->model_instance_num = model_create_instance(true, sip->model_num);

--- a/code/ship/shipfx.cpp
+++ b/code/ship/shipfx.cpp
@@ -3125,6 +3125,64 @@ int warptype_match(const char *p)
 	return -1;
 }
 
+void ship_set_warp_effects(object *objp)
+{
+	ship *shipp = &Ships[objp->instance];
+	int warpin_type = Warp_params[shipp->warpin_params_index].warp_type;
+	int warpout_type = Warp_params[shipp->warpout_params_index].warp_type;
+
+	if (warpin_type & WT_DEFAULT_WITH_FIREBALL)
+		warpin_type = WT_DEFAULT;
+	if (warpout_type & WT_DEFAULT_WITH_FIREBALL)
+		warpout_type = WT_DEFAULT;
+
+	if (shipp->warpin_effect != nullptr)
+		delete shipp->warpin_effect;
+
+	switch (warpin_type)
+	{
+		case WT_DEFAULT:
+		case WT_KNOSSOS:
+		case WT_DEFAULT_THEN_KNOSSOS:
+			shipp->warpin_effect = new WE_Default(objp, WarpDirection::WARP_IN);
+			break;
+		case WT_IN_PLACE_ANIM:
+			shipp->warpin_effect = new WE_BSG(objp, WarpDirection::WARP_IN);
+			break;
+		case WT_SWEEPER:
+			shipp->warpin_effect = new WE_Homeworld(objp, WarpDirection::WARP_IN);
+			break;
+		case WT_HYPERSPACE:
+			shipp->warpin_effect = new WE_Hyperspace(objp, WarpDirection::WARP_IN);
+			break;
+		default:
+			shipp->warpin_effect = new WarpEffect();
+	}
+
+	if (shipp->warpout_effect != nullptr)
+		delete shipp->warpout_effect;
+
+	switch (warpout_type)
+	{
+		case WT_DEFAULT:
+		case WT_KNOSSOS:
+		case WT_DEFAULT_THEN_KNOSSOS:
+			shipp->warpout_effect = new WE_Default(objp, WarpDirection::WARP_OUT);
+			break;
+		case WT_IN_PLACE_ANIM:
+			shipp->warpout_effect = new WE_BSG(objp, WarpDirection::WARP_OUT);
+			break;
+		case WT_SWEEPER:
+			shipp->warpout_effect = new WE_Homeworld(objp, WarpDirection::WARP_OUT);
+			break;
+		case WT_HYPERSPACE:
+			shipp->warpout_effect = new WE_Hyperspace(objp, WarpDirection::WARP_OUT);
+			break;
+		default:
+			shipp->warpout_effect = new WarpEffect();
+	}
+}
+
 
 //********************-----CLASS: WarpEffect-----********************//
 WarpEffect::WarpEffect()

--- a/code/ship/shipfx.h
+++ b/code/ship/shipfx.h
@@ -61,6 +61,8 @@ extern const char *Warp_types[];
 extern int Num_warp_types;
 extern int warptype_match(const char *p);
 
+extern void ship_set_warp_effects(object *objp);
+
 enum class WarpDirection { NONE, WARP_IN, WARP_OUT };
 
 


### PR DESCRIPTION
The core bug fixed here is #1982.  After ship_create sets up the ship, parse_object_create_sub does further initialization by copying some values from the parse object.  In most cases there are sensible defaults, but a few special cases require some post-processing...

- ship sounds
- the new way of initializing warp effects to allow per-ship customization
- intrinsic-no-shields
- an arrival entry in the mission log
- script hooks

I also took a further look at normal ship creation and tweaked some things...

- initialize ai mode in ai_object_init
- remove redundant assigment of ship name from parse_object_create_sub (it's also done in ship_create)
- remove redundant goal clearing from parse_object_create_sub (it's also done in ai_clear_ship_goals via ship_create)
- avoid overwriting the initial ai mode if the fix-ai-class-bug flag is set
- make the code slightly more efficient by not redundantly setting flags while searching for subsystems

This should fix #1982.