### PR TITLE
fix some flag information

### DIFF
--- a/code/hud/hudtargetbox.cpp
+++ b/code/hud/hudtargetbox.cpp
@@ -1435,10 +1435,9 @@ void HudGaugeExtraTargetData::render(float  /*frametime*/)
 		// Print out current orders if the targeted ship is friendly
 		// AL 12-26-97: only show orders and time to target for friendly ships
 		// Backslash: actually let's consult the IFF table.  Maybe we want to show orders for certain teams, or hide orders for friendlies
-		if (((Player_ship->team == target_shipp->team) ||
-			((Iff_info[target_shipp->team].flags & IFFF_ORDERS_SHOWN) &&
-				!(Iff_info[target_shipp->team].flags & IFFF_ORDERS_HIDDEN)))
-			&& Ship_info[target_shipp->ship_info_index].is_flyable()) {
+		if (	((Player_ship->team == target_shipp->team) ||
+					((Iff_info[target_shipp->team].flags & IFFF_ORDERS_SHOWN) && !(Iff_info[target_shipp->team].flags & IFFF_ORDERS_HIDDEN)))
+				&& Ship_info[target_shipp->ship_info_index].is_flyable() ) {
 			extra_data_shown = 1;
 			auto orders = ship_return_orders(target_shipp);
 			if (!orders.empty()) {

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -1214,8 +1214,8 @@ public:
     inline bool is_small_ship() const { return flags[Ship::Info_Flags::Fighter, Ship::Info_Flags::Bomber, Ship::Info_Flags::Support, Ship::Info_Flags::Escapepod]; }
     inline bool is_big_ship() const { return flags[Ship::Info_Flags::Cruiser, Ship::Info_Flags::Freighter, Ship::Info_Flags::Transport, Ship::Info_Flags::Corvette, Ship::Info_Flags::Gas_miner, Ship::Info_Flags::Awacs]; }
     inline bool is_huge_ship() const  { return flags[Ship::Info_Flags::Capital, Ship::Info_Flags::Supercap, Ship::Info_Flags::Drydock, Ship::Info_Flags::Knossos_device]; }
-    inline bool is_flyable() const { return !(flags[Ship::Info_Flags::Cargo, Ship::Info_Flags::Navbuoy, Ship::Info_Flags::Escapepod]); }
-    inline bool is_harmless() const { return !is_flyable(); }
+    inline bool is_flyable() const { return !(flags[Ship::Info_Flags::Cargo, Ship::Info_Flags::Navbuoy, Ship::Info_Flags::Sentrygun]); }
+    inline bool is_harmless() const { return flags[Ship::Info_Flags::Cargo, Ship::Info_Flags::Navbuoy, Ship::Info_Flags::Escapepod]; }	// note: code which previously used this now uses several flags defined in objecttypes.tbl
     inline bool is_fighter_bomber() const { return flags[Ship::Info_Flags::Fighter, Ship::Info_Flags::Bomber]; }
     inline bool is_big_or_huge() const { return is_big_ship() || is_huge_ship(); }
     inline bool avoids_shockwaves() const { return is_small_ship(); }

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -1215,7 +1215,7 @@ public:
     inline bool is_big_ship() const { return flags[Ship::Info_Flags::Cruiser, Ship::Info_Flags::Freighter, Ship::Info_Flags::Transport, Ship::Info_Flags::Corvette, Ship::Info_Flags::Gas_miner, Ship::Info_Flags::Awacs]; }
     inline bool is_huge_ship() const  { return flags[Ship::Info_Flags::Capital, Ship::Info_Flags::Supercap, Ship::Info_Flags::Drydock, Ship::Info_Flags::Knossos_device]; }
     inline bool is_flyable() const { return !(flags[Ship::Info_Flags::Cargo, Ship::Info_Flags::Navbuoy, Ship::Info_Flags::Sentrygun]); }
-    inline bool is_harmless() const { return flags[Ship::Info_Flags::Cargo, Ship::Info_Flags::Navbuoy, Ship::Info_Flags::Escapepod]; }	// note: code which previously used this now uses several flags defined in objecttypes.tbl
+    // note: code which previously used is_harmless() / SIF_HARMLESS now uses several flags defined in objecttypes.tbl
     inline bool is_fighter_bomber() const { return flags[Ship::Info_Flags::Fighter, Ship::Info_Flags::Bomber]; }
     inline bool is_big_or_huge() const { return is_big_ship() || is_huge_ship(); }
     inline bool avoids_shockwaves() const { return is_small_ship(); }

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -1214,8 +1214,9 @@ public:
     inline bool is_small_ship() const { return flags[Ship::Info_Flags::Fighter, Ship::Info_Flags::Bomber, Ship::Info_Flags::Support, Ship::Info_Flags::Escapepod]; }
     inline bool is_big_ship() const { return flags[Ship::Info_Flags::Cruiser, Ship::Info_Flags::Freighter, Ship::Info_Flags::Transport, Ship::Info_Flags::Corvette, Ship::Info_Flags::Gas_miner, Ship::Info_Flags::Awacs]; }
     inline bool is_huge_ship() const  { return flags[Ship::Info_Flags::Capital, Ship::Info_Flags::Supercap, Ship::Info_Flags::Drydock, Ship::Info_Flags::Knossos_device]; }
-    inline bool is_flyable() const { return !(flags[Ship::Info_Flags::Cargo, Ship::Info_Flags::Navbuoy, Ship::Info_Flags::Sentrygun]); }
-    // note: code which previously used is_harmless() / SIF_HARMLESS now uses several flags defined in objecttypes.tbl
+    inline bool is_flyable() const { return !(flags[Ship::Info_Flags::Cargo, Ship::Info_Flags::Navbuoy, Ship::Info_Flags::Sentrygun]); }	// AL 11-24-97: this useful to know for targeting reasons
+// note: code that previously used is_harmless() / SIF_HARMLESS now uses several flags defined in objecttypes.tbl
+//	inline bool is_harmless() const { return flags[Ship::Info_Flags::Cargo, Ship::Info_Flags::Navbuoy, Ship::Info_Flags::Escapepod]; }		// AL 12-3-97: ships that are not a threat
     inline bool is_fighter_bomber() const { return flags[Ship::Info_Flags::Fighter, Ship::Info_Flags::Bomber]; }
     inline bool is_big_or_huge() const { return is_big_ship() || is_huge_ship(); }
     inline bool avoids_shockwaves() const { return is_small_ship(); }

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -3760,7 +3760,7 @@ void find_homing_object(object *weapon_objp, int num)
                     //if the homing weapon is a huge weapon and the ship that is being
                     //looked at is not huge, then don't home
                     if ((wip->wi_flags[Weapon::Info_Flags::Huge]) &&
-                        (sip->is_small_ship() || !sip->is_flyable() || sip->is_harmless()))
+                        !(sip->is_huge_ship()))
                     {
                         continue;
                     }


### PR DESCRIPTION
Somewhere along the line, "sentry gun" was replaced with "escape pod" in the inverted is_flyable check.  This made the game think an escape pod wasn't flyable and therefore things like waypoint orders were not displayed.  This PR fixes that.

Additionally, I fixed a potential bug in weapons.cpp where the HUGE flag should really check against HUGE ships.  And there's a no-op formatting change in hudtargetbox.cpp.