### PR TITLE
Compile curl ourselves on macOS and cache the result

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ cache:
   directories:
     - $HOME/cmake-3.8
     - $HOME/.ccache
+    - $HOME/curl_cache
 addons:
   apt:
     packages: &global_deps

--- a/ci/travis/check_release.sh
+++ b/ci/travis/check_release.sh
@@ -14,7 +14,7 @@ NIGHTLY_PATTERN="^nightly_(.*)$"
 TEST_BUILD_PATTERN="^test\/(.*)$"
 
 # These are for testing
-NIGHTLY_TEST=false
+NIGHTLY_TEST=true
 RELEASE_TEST=false
 TEST_BUILD_TEST=false
 


### PR DESCRIPTION
We need to build our own `curl` binary since Homebrew doesn't support `--with-libssh2` anymore.
I've also added caching to both the Linux and macOS code to avoid rebuilding curl for each nightly.
Not sure if the caching actually works but according to [the docs](https://docs.travis-ci.com/user/caching/) it should work.