### PR TITLE
Fix issues with docked ships warping

### DIFF
--- a/code/object/collideshipship.cpp
+++ b/code/object/collideshipship.cpp
@@ -129,7 +129,7 @@ int ship_ship_check_collision(collision_info_struct *ship_ship_hit_info, vec3d *
 	}
 
 	// Make ships that are warping in not get collision detection done
-	if ( heavy_shipp->flags[Ship::Ship_Flags::Arriving_stage_1, Ship::Ship_Flags::Arriving_stage_1_ndl] ) {
+	if ( heavy_shipp->is_arriving_stage_1_all_docked() ) {
 		return 0;
 	}
 
@@ -1268,8 +1268,8 @@ int collide_ship_ship( obj_pair * pair )
         // if ship is warping in, in stage 1, its velocity is 0, so make ship try to collide next frame
 
         // if ship is huge and warping in or out
-        if (((Ships[A->instance].flags[Ship::Ship_Flags::Arriving_stage_1, Ship::Ship_Flags::Arriving_stage_1_ndl]) && (Ship_info[Ships[A->instance].ship_info_index].is_huge_ship()))
-			|| ((Ships[B->instance].flags[Ship::Ship_Flags::Arriving_stage_1, Ship::Ship_Flags::Arriving_stage_1_ndl]) && (Ship_info[Ships[B->instance].ship_info_index].is_huge_ship())) ) {
+        if (((Ships[A->instance].is_arriving_stage_1_all_docked()) && (Ship_info[Ships[A->instance].ship_info_index].is_huge_ship()))
+			|| ((Ships[B->instance].is_arriving_stage_1_all_docked()) && (Ship_info[Ships[B->instance].ship_info_index].is_huge_ship())) ) {
 			pair->next_check_time = timestamp(0);	// check next time
 			return 0;
 		}

--- a/code/object/collideshipship.cpp
+++ b/code/object/collideshipship.cpp
@@ -129,7 +129,7 @@ int ship_ship_check_collision(collision_info_struct *ship_ship_hit_info, vec3d *
 	}
 
 	// Make ships that are warping in not get collision detection done
-	if ( heavy_shipp->flags[Ship::Ship_Flags::Arriving_stage_1] ) { 
+	if ( heavy_shipp->flags[Ship::Ship_Flags::Arriving_stage_1, Ship::Ship_Flags::Arriving_stage_1_ndl] ) {
 		return 0;
 	}
 
@@ -1268,8 +1268,8 @@ int collide_ship_ship( obj_pair * pair )
         // if ship is warping in, in stage 1, its velocity is 0, so make ship try to collide next frame
 
         // if ship is huge and warping in or out
-        if (((Ships[A->instance].flags[Ship::Ship_Flags::Arriving_stage_1]) && (Ship_info[Ships[A->instance].ship_info_index].is_huge_ship()))
-			|| ((Ships[B->instance].flags[Ship::Ship_Flags::Arriving_stage_1]) && (Ship_info[Ships[B->instance].ship_info_index].is_huge_ship())) ) {
+        if (((Ships[A->instance].flags[Ship::Ship_Flags::Arriving_stage_1, Ship::Ship_Flags::Arriving_stage_1_ndl]) && (Ship_info[Ships[A->instance].ship_info_index].is_huge_ship()))
+			|| ((Ships[B->instance].flags[Ship::Ship_Flags::Arriving_stage_1, Ship::Ship_Flags::Arriving_stage_1_ndl]) && (Ship_info[Ships[B->instance].ship_info_index].is_huge_ship())) ) {
 			pair->next_check_time = timestamp(0);	// check next time
 			return 0;
 		}

--- a/code/object/collideshipship.cpp
+++ b/code/object/collideshipship.cpp
@@ -129,7 +129,7 @@ int ship_ship_check_collision(collision_info_struct *ship_ship_hit_info, vec3d *
 	}
 
 	// Make ships that are warping in not get collision detection done
-	if ( heavy_shipp->is_arriving_stage_1_all_docked() ) {
+	if ( heavy_shipp->is_arriving(ship::warpstage::STAGE1, false) ) {
 		return 0;
 	}
 
@@ -1268,8 +1268,8 @@ int collide_ship_ship( obj_pair * pair )
         // if ship is warping in, in stage 1, its velocity is 0, so make ship try to collide next frame
 
         // if ship is huge and warping in or out
-        if (((Ships[A->instance].is_arriving_stage_1_all_docked()) && (Ship_info[Ships[A->instance].ship_info_index].is_huge_ship()))
-			|| ((Ships[B->instance].is_arriving_stage_1_all_docked()) && (Ship_info[Ships[B->instance].ship_info_index].is_huge_ship())) ) {
+        if (((Ships[A->instance].is_arriving(ship::warpstage::STAGE1, false)) && (Ship_info[Ships[A->instance].ship_info_index].is_huge_ship()))
+			|| ((Ships[B->instance].is_arriving(ship::warpstage::STAGE1, false)) && (Ship_info[Ships[B->instance].ship_info_index].is_huge_ship())) ) {
 			pair->next_check_time = timestamp(0);	// check next time
 			return 0;
 		}

--- a/code/object/objectdock.cpp
+++ b/code/object/objectdock.cpp
@@ -711,22 +711,26 @@ void dock_find_max_speed_helper(object *objp, dock_function_info *infop)
 
 void object_set_arriving_stage1_ndl_flag_helper(object *objp, dock_function_info * /*infop*/ )
 {
-	Ships[objp->instance].flags.set(Ship::Ship_Flags::Arriving_stage_1_ndl);
+	if (! Ships[objp->instance].flags[Ship::Ship_Flags::Dock_leader])
+		Ships[objp->instance].flags.set(Ship::Ship_Flags::Arriving_stage_1_dock_follower);
 }
 
 void object_remove_arriving_stage1_ndl_flag_helper(object *objp, dock_function_info * /*infop*/ )
 {
-	Ships[objp->instance].flags.remove(Ship::Ship_Flags::Arriving_stage_1_ndl);
+	if (! Ships[objp->instance].flags[Ship::Ship_Flags::Dock_leader])
+		Ships[objp->instance].flags.remove(Ship::Ship_Flags::Arriving_stage_1_dock_follower);
 }
 
 void object_set_arriving_stage2_ndl_flag_helper(object *objp, dock_function_info * /*infop*/ )
 {
-	Ships[objp->instance].flags.set(Ship::Ship_Flags::Arriving_stage_2_ndl);
+	if (! Ships[objp->instance].flags[Ship::Ship_Flags::Dock_leader])
+		Ships[objp->instance].flags.set(Ship::Ship_Flags::Arriving_stage_2_dock_follower);
 }
 
 void object_remove_arriving_stage2_ndl_flag_helper(object *objp, dock_function_info * /*infop*/ )
 {
-	Ships[objp->instance].flags.remove(Ship::Ship_Flags::Arriving_stage_2_ndl);
+	if (! Ships[objp->instance].flags[Ship::Ship_Flags::Dock_leader])
+		Ships[objp->instance].flags.remove(Ship::Ship_Flags::Arriving_stage_2_dock_follower);
 }
 
 // ---------------------------------------------------------------------------------------------------------------

--- a/code/object/objectdock.cpp
+++ b/code/object/objectdock.cpp
@@ -708,6 +708,27 @@ void dock_find_max_speed_helper(object *objp, dock_function_info *infop)
 		infop->maintained_variables.objp_value = objp;
 	}
 }
+
+void object_set_arriving_stage1_ndl_flag_helper(object *objp, dock_function_info * /*infop*/ )
+{
+	Ships[objp->instance].flags.set(Ship::Ship_Flags::Arriving_stage_1_ndl);
+}
+
+void object_remove_arriving_stage1_ndl_flag_helper(object *objp, dock_function_info * /*infop*/ )
+{
+	Ships[objp->instance].flags.remove(Ship::Ship_Flags::Arriving_stage_1_ndl);
+}
+
+void object_set_arriving_stage2_ndl_flag_helper(object *objp, dock_function_info * /*infop*/ )
+{
+	Ships[objp->instance].flags.set(Ship::Ship_Flags::Arriving_stage_2_ndl);
+}
+
+void object_remove_arriving_stage2_ndl_flag_helper(object *objp, dock_function_info * /*infop*/ )
+{
+	Ships[objp->instance].flags.remove(Ship::Ship_Flags::Arriving_stage_2_ndl);
+}
+
 // ---------------------------------------------------------------------------------------------------------------
 // end of über code block ----------------------------------------------------------------------------------------
 

--- a/code/object/objectdock.h
+++ b/code/object/objectdock.h
@@ -141,4 +141,10 @@ void dock_undock_all(object *objp);
 // free the entire dock list without undocking anything; should only be used on object cleanup
 void dock_free_dock_list(object *objp);
 
+// flag set/remove helpers required in multiple places
+void object_set_arriving_stage1_ndl_flag_helper(object *objp, dock_function_info * /*infop*/ );
+void object_remove_arriving_stage1_ndl_flag_helper(object *objp, dock_function_info * /*infop*/ );
+void object_set_arriving_stage2_ndl_flag_helper(object *objp, dock_function_info * /*infop*/ );
+void object_remove_arriving_stage2_ndl_flag_helper(object *objp, dock_function_info * /*infop*/ );
+
 #endif	// _OBJECT_DOCK_H

--- a/code/radar/radarsetup.cpp
+++ b/code/radar/radarsetup.cpp
@@ -95,7 +95,7 @@ void radar_stuff_blip_info(object *objp, int is_bright, color **blip_color, int 
 		case OBJ_SHIP:
 			shipp = &Ships[objp->instance];
 
-			if (shipp->flags[Ship::Ship_Flags::Arriving_stage_1, Ship::Ship_Flags::Arriving_stage_1_ndl])
+			if (shipp->is_arriving_stage_1_all_docked())
 			{
 				*blip_color = &Radar_colors[RCOL_WARPING_SHIP][is_bright];
 				*blip_type = BLIP_TYPE_WARPING_SHIP;
@@ -525,7 +525,7 @@ RadarVisibility radar_is_visible( object *objp )
 				return NOT_VISIBLE;
 
 			// Ships that are warp in in are not visible on the radar
-			if (Ships[objp->instance].flags[Ship::Ship_Flags::Arriving_stage_1, Ship::Ship_Flags::Arriving_stage_1_ndl])
+			if (Ships[objp->instance].is_arriving_stage_1_all_docked())
 				return NOT_VISIBLE;
 
 			break;

--- a/code/radar/radarsetup.cpp
+++ b/code/radar/radarsetup.cpp
@@ -95,7 +95,7 @@ void radar_stuff_blip_info(object *objp, int is_bright, color **blip_color, int 
 		case OBJ_SHIP:
 			shipp = &Ships[objp->instance];
 
-			if (shipp->is_arriving_stage_1_all_docked())
+			if (shipp->is_arriving(ship::warpstage::STAGE1, false))
 			{
 				*blip_color = &Radar_colors[RCOL_WARPING_SHIP][is_bright];
 				*blip_type = BLIP_TYPE_WARPING_SHIP;
@@ -525,7 +525,7 @@ RadarVisibility radar_is_visible( object *objp )
 				return NOT_VISIBLE;
 
 			// Ships that are warp in in are not visible on the radar
-			if (Ships[objp->instance].is_arriving_stage_1_all_docked())
+			if (Ships[objp->instance].is_arriving(ship::warpstage::STAGE1, false))
 				return NOT_VISIBLE;
 
 			break;

--- a/code/radar/radarsetup.cpp
+++ b/code/radar/radarsetup.cpp
@@ -95,7 +95,7 @@ void radar_stuff_blip_info(object *objp, int is_bright, color **blip_color, int 
 		case OBJ_SHIP:
 			shipp = &Ships[objp->instance];
 
-			if (shipp->flags[Ship::Ship_Flags::Arriving_stage_1])
+			if (shipp->flags[Ship::Ship_Flags::Arriving_stage_1, Ship::Ship_Flags::Arriving_stage_1_ndl])
 			{
 				*blip_color = &Radar_colors[RCOL_WARPING_SHIP][is_bright];
 				*blip_type = BLIP_TYPE_WARPING_SHIP;
@@ -525,7 +525,7 @@ RadarVisibility radar_is_visible( object *objp )
 				return NOT_VISIBLE;
 
 			// Ships that are warp in in are not visible on the radar
-			if (Ships[objp->instance].flags[Ship::Ship_Flags::Arriving_stage_1])
+			if (Ships[objp->instance].flags[Ship::Ship_Flags::Arriving_stage_1, Ship::Ship_Flags::Arriving_stage_1_ndl])
 				return NOT_VISIBLE;
 
 			break;

--- a/code/scripting/api/objs/ship.cpp
+++ b/code/scripting/api/objs/ship.cpp
@@ -1488,7 +1488,7 @@ ADE_FUNC(isWarpingIn, l_Ship, NULL, "Checks if ship is warping in", "boolean", "
 		return ADE_RETURN_NIL;
 
 	ship *shipp = &Ships[objh->objp->instance];
-	if(shipp->flags[Ship::Ship_Flags::Arriving_stage_1, Ship::Ship_Flags::Arriving_stage_1_ndl]){
+	if(shipp->is_arriving_stage_1_all_docked()){
 		return ADE_RETURN_TRUE;
 	}
 

--- a/code/scripting/api/objs/ship.cpp
+++ b/code/scripting/api/objs/ship.cpp
@@ -1488,7 +1488,7 @@ ADE_FUNC(isWarpingIn, l_Ship, NULL, "Checks if ship is warping in", "boolean", "
 		return ADE_RETURN_NIL;
 
 	ship *shipp = &Ships[objh->objp->instance];
-	if(shipp->is_arriving_stage_1_all_docked()){
+	if(shipp->is_arriving(ship::warpstage::STAGE1, false)){
 		return ADE_RETURN_TRUE;
 	}
 

--- a/code/scripting/api/objs/ship.cpp
+++ b/code/scripting/api/objs/ship.cpp
@@ -1488,7 +1488,7 @@ ADE_FUNC(isWarpingIn, l_Ship, NULL, "Checks if ship is warping in", "boolean", "
 		return ADE_RETURN_NIL;
 
 	ship *shipp = &Ships[objh->objp->instance];
-	if(shipp->flags[Ship::Ship_Flags::Arriving_stage_1]){
+	if(shipp->flags[Ship::Ship_Flags::Arriving_stage_1, Ship::Ship_Flags::Arriving_stage_1_ndl]){
 		return ADE_RETURN_TRUE;
 	}
 

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -18990,20 +18990,20 @@ ship_subsys* ship_get_subsys_for_submodel(ship* shipp, int submodel)
 /**
  * Is the requested type of ship arriving in the requested stage?
  *
- * Dock leaders & followers need to be handled separately such that
- * leaders handle the warp process, but followers need to behave as though
- * warping with respect to targeting, drawing thrusters, radar, AI
- * targeting, etc
+ * Dock leaders (plus single ships) & dock followers need to be handled
+ * separately such that leaders+singles handle the warp process, but
+ * followers need to behave as though they are warping with respect to
+ * HUD targeting, drawing thrusters, radar, AI targeting, etc
  *
  * @param stage Check one of stage1, stage2 or both
- * @param dock_leader_only only the dock leader, or leader/followers/non-docked?
+ * @param dock_leader_or_single_only check dock-leaders+singles, or dock-followers?
  *
  * @return is the ship arriving, bool
  */
-bool ship::is_arriving(ship::warpstage stage, bool dock_leader_only)
+bool ship::is_arriving(ship::warpstage stage, bool dock_leader_or_single_only)
 {
 	if (stage == ship::warpstage::BOTH) {
-		if (dock_leader_only == false) {
+		if (!dock_leader_or_single_only) {
 			return flags[Ship::Ship_Flags::Arriving_stage_1, Ship::Ship_Flags::Arriving_stage_1_dock_follower, Ship::Ship_Flags::Arriving_stage_2, Ship::Ship_Flags::Arriving_stage_2_dock_follower];
 		}
 		else {
@@ -19011,7 +19011,7 @@ bool ship::is_arriving(ship::warpstage stage, bool dock_leader_only)
 		}
 	}
 	else if (stage == ship::warpstage::STAGE1) {
-		if (dock_leader_only == false) {
+		if (!dock_leader_or_single_only) {
 			return flags[Ship::Ship_Flags::Arriving_stage_1, Ship::Ship_Flags::Arriving_stage_1_dock_follower];
 		}
 		else {
@@ -19019,7 +19019,7 @@ bool ship::is_arriving(ship::warpstage stage, bool dock_leader_only)
 		}
 	}
 	if (stage == ship::warpstage::STAGE2) {
-		if (dock_leader_only == false) {
+		if (!dock_leader_or_single_only) {
 			return flags[Ship::Ship_Flags::Arriving_stage_2, Ship::Ship_Flags::Arriving_stage_2_dock_follower];
 		}
 		else {

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -6718,7 +6718,8 @@ static void ship_find_warping_ship_helper(object *objp, dock_function_info *info
 		return;
 
 	// am I arriving or departing by warp?
-	if (Ships[objp->instance].is_arriving() || Ships[objp->instance].flags[Ship_Flags::Depart_warp])
+	// ignore _ndl flags as they are now on all docked-warping ships; we need the dock leader!
+	if (Ships[objp->instance].flags[Ship_Flags::Arriving_stage_1, Ship_Flags::Arriving_stage_2, Ship_Flags::Depart_warp])
 	{
 #ifndef NDEBUG
 		// in debug builds, make sure only one of the docked objects has these flags set
@@ -8820,7 +8821,7 @@ void ship_process_post(object * obj, float frametime)
 		}
 	}
 	
-	if ( shipp->is_arriving() && Ai_info[shipp->ai_index].mode != AIM_BAY_EMERGE )	{
+	if ( shipp->flags[Ship::Ship_Flags::Arriving_stage_1, Ship::Ship_Flags::Arriving_stage_2] && Ai_info[shipp->ai_index].mode != AIM_BAY_EMERGE )	{ // _ndl's don't manage warping
 		// JAS -- if the ship is warping in, just move it forward at a speed
 		// fast enough to move 2x its radius in SHIP_WARP_TIME seconds.
 		shipfx_warpin_frame( obj, frametime );
@@ -18785,7 +18786,7 @@ void ship_render(object* obj, model_draw_list* scene)
 		//WMC - based on Bobb's secondary thruster stuff
 		//which was in turn based on the beam code.
 		//I'm gonna need some serious acid to neutralize this base.
-		if(shipp->is_arriving()) {
+		if(shipp->flags[Ship::Ship_Flags::Arriving_stage_1, Ship::Ship_Flags::Arriving_stage_2]) {
 			shipp->warpin_effect->warpShipRender();
 		} else if(shipp->flags[Ship_Flags::Depart_warp]) {
 			shipp->warpout_effect->warpShipRender();
@@ -18821,7 +18822,7 @@ void ship_render(object* obj, model_draw_list* scene)
 		//WMC - based on Bobb's secondary thruster stuff
 		//which was in turn based on the beam code.
 		//I'm gonna need some serious acid to neutralize this base.
-		if(shipp->is_arriving()) {
+		if(shipp->flags[Ship::Ship_Flags::Arriving_stage_1, Ship::Ship_Flags::Arriving_stage_2]) {
 			shipp->warpin_effect->warpShipRender();
 		} else if(shipp->flags[Ship_Flags::Depart_warp]) {
 			shipp->warpout_effect->warpShipRender();
@@ -18847,7 +18848,7 @@ void ship_render(object* obj, model_draw_list* scene)
 	// Warp_shipp points to the ship that is going through a
 	// warp... either this ship or the ship it is docked with.
 	if ( warp_shipp != NULL ) {
-		if ( warp_shipp->is_arriving() ) {
+		if ( warp_shipp->flags[Ship::Ship_Flags::Arriving_stage_1, Ship::Ship_Flags::Arriving_stage_2] ) {
 			warp_shipp->warpin_effect->warpShipClip(&render_info);
 		} else if ( warp_shipp->flags[Ship_Flags::Depart_warp] ) {
 			warp_shipp->warpout_effect->warpShipClip(&render_info);
@@ -18944,7 +18945,7 @@ void ship_render(object* obj, model_draw_list* scene)
 	//WMC - based on Bobb's secondary thruster stuff
 	//which was in turn based on the beam code.
 	//I'm gonna need some serious acid to neutralize this base.
-	if(shipp->is_arriving()) {
+	if(shipp->flags[Ship::Ship_Flags::Arriving_stage_1, Ship::Ship_Flags::Arriving_stage_2]) {
 		shipp->warpin_effect->warpShipRender();
 	} else if(shipp->flags[Ship_Flags::Depart_warp]) {
 		shipp->warpout_effect->warpShipRender();
@@ -18958,6 +18959,7 @@ void set_default_ignore_list() {
 	Ignore_List.set(Ship::Ship_Flags::Depart_warp);
 	Ignore_List.set(Ship::Ship_Flags::Dying);
 	Ignore_List.set(Ship::Ship_Flags::Arriving_stage_1);
+	Ignore_List.set(Ship::Ship_Flags::Arriving_stage_1_ndl);
 	Ignore_List.set(Ship::Ship_Flags::Hidden_from_sensors);
 }
 

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -18996,14 +18996,14 @@ ship_subsys* ship_get_subsys_for_submodel(ship* shipp, int submodel)
  * HUD targeting, drawing thrusters, radar, AI targeting, etc
  *
  * @param stage Check one of stage1, stage2 or both
- * @param dock_leader_or_single_only check dock-leaders+singles, or dock-followers?
+ * @param dock_leader_or_single check dock-leaders+singles, or dock-followers?
  *
  * @return is the ship arriving, bool
  */
-bool ship::is_arriving(ship::warpstage stage, bool dock_leader_or_single_only)
+bool ship::is_arriving(ship::warpstage stage, bool dock_leader_or_single)
 {
 	if (stage == ship::warpstage::BOTH) {
-		if (!dock_leader_or_single_only) {
+		if (!dock_leader_or_single) {
 			return flags[Ship::Ship_Flags::Arriving_stage_1, Ship::Ship_Flags::Arriving_stage_1_dock_follower, Ship::Ship_Flags::Arriving_stage_2, Ship::Ship_Flags::Arriving_stage_2_dock_follower];
 		}
 		else {
@@ -19011,7 +19011,7 @@ bool ship::is_arriving(ship::warpstage stage, bool dock_leader_or_single_only)
 		}
 	}
 	else if (stage == ship::warpstage::STAGE1) {
-		if (!dock_leader_or_single_only) {
+		if (!dock_leader_or_single) {
 			return flags[Ship::Ship_Flags::Arriving_stage_1, Ship::Ship_Flags::Arriving_stage_1_dock_follower];
 		}
 		else {
@@ -19019,7 +19019,7 @@ bool ship::is_arriving(ship::warpstage stage, bool dock_leader_or_single_only)
 		}
 	}
 	if (stage == ship::warpstage::STAGE2) {
-		if (!dock_leader_or_single_only) {
+		if (!dock_leader_or_single) {
 			return flags[Ship::Ship_Flags::Arriving_stage_2, Ship::Ship_Flags::Arriving_stage_2_dock_follower];
 		}
 		else {

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -6718,8 +6718,7 @@ static void ship_find_warping_ship_helper(object *objp, dock_function_info *info
 		return;
 
 	// am I arriving or departing by warp?
-	// ignore _ndl flags as they are now on all docked-warping ships; we need the dock leader!
-	if (Ships[objp->instance].flags[Ship_Flags::Arriving_stage_1, Ship_Flags::Arriving_stage_2, Ship_Flags::Depart_warp])
+	if (Ships[objp->instance].is_arriving_dock_leader() || Ships[objp->instance].flags[Ship_Flags::Depart_warp])
 	{
 #ifndef NDEBUG
 		// in debug builds, make sure only one of the docked objects has these flags set
@@ -8821,7 +8820,7 @@ void ship_process_post(object * obj, float frametime)
 		}
 	}
 	
-	if ( shipp->flags[Ship::Ship_Flags::Arriving_stage_1, Ship::Ship_Flags::Arriving_stage_2] && Ai_info[shipp->ai_index].mode != AIM_BAY_EMERGE )	{ // _ndl's don't manage warping
+	if ( shipp->is_arriving_dock_leader() && Ai_info[shipp->ai_index].mode != AIM_BAY_EMERGE )	{ // _ndl's don't manage warping
 		// JAS -- if the ship is warping in, just move it forward at a speed
 		// fast enough to move 2x its radius in SHIP_WARP_TIME seconds.
 		shipfx_warpin_frame( obj, frametime );
@@ -18786,7 +18785,7 @@ void ship_render(object* obj, model_draw_list* scene)
 		//WMC - based on Bobb's secondary thruster stuff
 		//which was in turn based on the beam code.
 		//I'm gonna need some serious acid to neutralize this base.
-		if(shipp->flags[Ship::Ship_Flags::Arriving_stage_1, Ship::Ship_Flags::Arriving_stage_2]) {
+		if(shipp->is_arriving_dock_leader()) {
 			shipp->warpin_effect->warpShipRender();
 		} else if(shipp->flags[Ship_Flags::Depart_warp]) {
 			shipp->warpout_effect->warpShipRender();
@@ -18822,7 +18821,7 @@ void ship_render(object* obj, model_draw_list* scene)
 		//WMC - based on Bobb's secondary thruster stuff
 		//which was in turn based on the beam code.
 		//I'm gonna need some serious acid to neutralize this base.
-		if(shipp->flags[Ship::Ship_Flags::Arriving_stage_1, Ship::Ship_Flags::Arriving_stage_2]) {
+		if(shipp->is_arriving_dock_leader()) {
 			shipp->warpin_effect->warpShipRender();
 		} else if(shipp->flags[Ship_Flags::Depart_warp]) {
 			shipp->warpout_effect->warpShipRender();
@@ -18848,7 +18847,7 @@ void ship_render(object* obj, model_draw_list* scene)
 	// Warp_shipp points to the ship that is going through a
 	// warp... either this ship or the ship it is docked with.
 	if ( warp_shipp != NULL ) {
-		if ( warp_shipp->flags[Ship::Ship_Flags::Arriving_stage_1, Ship::Ship_Flags::Arriving_stage_2] ) {
+		if ( warp_shipp->is_arriving_dock_leader() ) {
 			warp_shipp->warpin_effect->warpShipClip(&render_info);
 		} else if ( warp_shipp->flags[Ship_Flags::Depart_warp] ) {
 			warp_shipp->warpout_effect->warpShipClip(&render_info);
@@ -18945,7 +18944,7 @@ void ship_render(object* obj, model_draw_list* scene)
 	//WMC - based on Bobb's secondary thruster stuff
 	//which was in turn based on the beam code.
 	//I'm gonna need some serious acid to neutralize this base.
-	if(shipp->flags[Ship::Ship_Flags::Arriving_stage_1, Ship::Ship_Flags::Arriving_stage_2]) {
+	if(shipp->is_arriving_dock_leader()) {
 		shipp->warpin_effect->warpShipRender();
 	} else if(shipp->flags[Ship_Flags::Depart_warp]) {
 		shipp->warpout_effect->warpShipRender();

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -720,7 +720,7 @@ public:
 	void clear();
 
     //Helper functions
-	bool is_arriving(ship::warpstage stage = ship::warpstage::BOTH, bool dock_leader_or_single_only = false);
+	bool is_arriving(ship::warpstage stage = ship::warpstage::BOTH, bool dock_leader_or_single = false);
 	inline bool is_departing() { return flags[Ship::Ship_Flags::Depart_warp, Ship::Ship_Flags::Depart_dockbay]; }
 	inline bool cannot_warp() { return flags[Ship::Ship_Flags::Warp_broken, Ship::Ship_Flags::Warp_never, Ship::Ship_Flags::Disabled]; }
 	inline bool is_dying_or_departing() { return is_departing() || flags[Ship::Ship_Flags::Dying]; }

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -710,16 +710,20 @@ public:
 
 	float autoaim_fov;
 
+	enum warpstage {
+		STAGE1 = 0,
+		STAGE2,
+		BOTH,
+	};
+
 	// reset to a completely blank ship
 	void clear();
 
     //Helper functions
-    inline bool is_arriving() { return flags[Ship::Ship_Flags::Arriving_stage_1, Ship::Ship_Flags::Arriving_stage_1_ndl, Ship::Ship_Flags::Arriving_stage_2, Ship::Ship_Flags::Arriving_stage_2_ndl]; }
-    inline bool is_arriving_dock_leader() { return flags[Ship::Ship_Flags::Arriving_stage_1, Ship::Ship_Flags::Arriving_stage_2]; }
-    inline bool is_arriving_stage_1_all_docked() { return flags[Ship::Ship_Flags::Arriving_stage_1, Ship::Ship_Flags::Arriving_stage_1_ndl]; }
-    inline bool is_departing() { return flags[Ship::Ship_Flags::Depart_warp, Ship::Ship_Flags::Depart_dockbay]; }
-    inline bool cannot_warp() { return flags[Ship::Ship_Flags::Warp_broken, Ship::Ship_Flags::Warp_never, Ship::Ship_Flags::Disabled]; }
-    inline bool is_dying_or_departing() { return is_departing() || flags[Ship::Ship_Flags::Dying]; }
+	bool is_arriving(ship::warpstage stage = ship::warpstage::BOTH, bool dock_leader_only = false);
+	inline bool is_departing() { return flags[Ship::Ship_Flags::Depart_warp, Ship::Ship_Flags::Depart_dockbay]; }
+	inline bool cannot_warp() { return flags[Ship::Ship_Flags::Warp_broken, Ship::Ship_Flags::Warp_never, Ship::Ship_Flags::Disabled]; }
+	inline bool is_dying_or_departing() { return is_departing() || flags[Ship::Ship_Flags::Dying]; }
 
 	bool has_display_name();
 	const char* get_display_string();

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -720,7 +720,7 @@ public:
 	void clear();
 
     //Helper functions
-	bool is_arriving(ship::warpstage stage = ship::warpstage::BOTH, bool dock_leader_only = false);
+	bool is_arriving(ship::warpstage stage = ship::warpstage::BOTH, bool dock_leader_or_single_only = false);
 	inline bool is_departing() { return flags[Ship::Ship_Flags::Depart_warp, Ship::Ship_Flags::Depart_dockbay]; }
 	inline bool cannot_warp() { return flags[Ship::Ship_Flags::Warp_broken, Ship::Ship_Flags::Warp_never, Ship::Ship_Flags::Disabled]; }
 	inline bool is_dying_or_departing() { return is_departing() || flags[Ship::Ship_Flags::Dying]; }

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -714,7 +714,7 @@ public:
 	void clear();
 
     //Helper functions
-    inline bool is_arriving() { return flags[Ship::Ship_Flags::Arriving_stage_1, Ship::Ship_Flags::Arriving_stage_2]; }
+    inline bool is_arriving() { return flags[Ship::Ship_Flags::Arriving_stage_1, Ship::Ship_Flags::Arriving_stage_1_ndl, Ship::Ship_Flags::Arriving_stage_2, Ship::Ship_Flags::Arriving_stage_2_ndl]; }
     inline bool is_departing() { return flags[Ship::Ship_Flags::Depart_warp, Ship::Ship_Flags::Depart_dockbay]; }
     inline bool cannot_warp() { return flags[Ship::Ship_Flags::Warp_broken, Ship::Ship_Flags::Warp_never, Ship::Ship_Flags::Disabled]; }
     inline bool is_dying_or_departing() { return is_departing() || flags[Ship::Ship_Flags::Dying]; }

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -715,6 +715,8 @@ public:
 
     //Helper functions
     inline bool is_arriving() { return flags[Ship::Ship_Flags::Arriving_stage_1, Ship::Ship_Flags::Arriving_stage_1_ndl, Ship::Ship_Flags::Arriving_stage_2, Ship::Ship_Flags::Arriving_stage_2_ndl]; }
+    inline bool is_arriving_dock_leader() { return flags[Ship::Ship_Flags::Arriving_stage_1, Ship::Ship_Flags::Arriving_stage_2]; }
+    inline bool is_arriving_stage_1_all_docked() { return flags[Ship::Ship_Flags::Arriving_stage_1, Ship::Ship_Flags::Arriving_stage_1_ndl]; }
     inline bool is_departing() { return flags[Ship::Ship_Flags::Depart_warp, Ship::Ship_Flags::Depart_dockbay]; }
     inline bool cannot_warp() { return flags[Ship::Ship_Flags::Warp_broken, Ship::Ship_Flags::Warp_never, Ship::Ship_Flags::Disabled]; }
     inline bool is_dying_or_departing() { return is_departing() || flags[Ship::Ship_Flags::Dying]; }

--- a/code/ship/ship_flags.h
+++ b/code/ship/ship_flags.h
@@ -57,9 +57,9 @@ namespace Ship {
 		Depart_warp,				// ship is departing via warp-out
 		Depart_dockbay,				// ship is departing via docking bay
 		Arriving_stage_1,			// ship is arriving. In other words, doing warp in effect, stage 1
-		Arriving_stage_1_ndl,		// "Arriving but Not the Dock Leader" (ndl) these guys need some warp stuff done but not all
+		Arriving_stage_1_dock_follower,		// "Arriving but Not the Dock Leader"; these guys need some warp stuff done but not all
 		Arriving_stage_2,			// ship is arriving. In other words, doing warp in effect, stage 2             
-		Arriving_stage_2_ndl,		// "Arriving but Not the Dock Leader" (ndl) these guys need some warp stuff done but not all
+		Arriving_stage_2_dock_follower,		// "Arriving but Not the Dock Leader"; these guys need some warp stuff done but not all
 		Engines_on,					// engines sound should play if set
 		Dock_leader,				// Goober5000 - this guy is in charge of everybody he's docked to
 		Cargo_revealed,				// ship's cargo is revealed to all friendly ships

--- a/code/ship/ship_flags.h
+++ b/code/ship/ship_flags.h
@@ -57,7 +57,9 @@ namespace Ship {
 		Depart_warp,				// ship is departing via warp-out
 		Depart_dockbay,				// ship is departing via docking bay
 		Arriving_stage_1,			// ship is arriving. In other words, doing warp in effect, stage 1
+		Arriving_stage_1_ndl,		// "Arriving but Not the Dock Leader" (ndl) these guys need some warp stuff done but not all
 		Arriving_stage_2,			// ship is arriving. In other words, doing warp in effect, stage 2             
+		Arriving_stage_2_ndl,		// "Arriving but Not the Dock Leader" (ndl) these guys need some warp stuff done but not all
 		Engines_on,					// engines sound should play if set
 		Dock_leader,				// Goober5000 - this guy is in charge of everybody he's docked to
 		Cargo_revealed,				// ship's cargo is revealed to all friendly ships


### PR DESCRIPTION
There's a number of issues fixed here:
* Radar blips of docked ships were the wrong colour in stage 1
* You could target docked ships in stage 1
* Docked ships thrusters were visible in stage 1
* Hyperspace warptype ship could initially appear at their
warp-destination, then spring back to the correct location to complete
the rest of their warpin (because a docked ship had higher speed than
the dock leader)

There may also be a number of other subtle bugs with docked warpin;
e.g. I suspect (but haven't tested) that AI turrets could fire on
docked ships during warpin
These should also be fixed

Lastly, fixes issue #1867