### PR TITLE
detail boxes can ignore default distance scaling

### DIFF
--- a/code/model/model.h
+++ b/code/model/model.h
@@ -346,6 +346,7 @@ public:
 	bool	use_render_box_offset;		// whether an offset has been defined; needed because one can't tell just by looking at render_box_offset
 	int		use_render_sphere;		// 0==do nothing, 1==only render this object if you are inside the sphere, -1==only if you're outside
 	bool 	use_render_sphere_offset;// whether an offset has been defined; needed because one can't tell just by looking at render_sphere_offset
+	bool    do_not_scale_detail_distances{false}; // if set should not scale boxes or spheres based on 'model detail' settings
 	bool	gun_rotation;			// for animated weapon models
 	bool	no_collisions;			// for $no_collisions property - kazan
 	bool	nocollide_this_only;	//SUSHI: Like no_collisions, but not recursive. For the "replacement" collision model scheme.

--- a/code/model/modelread.cpp
+++ b/code/model/modelread.cpp
@@ -1513,6 +1513,11 @@ int read_model_file(polymodel * pm, const char *filename, int n_subsystems, mode
 					} else {
 						pm->submodel[n].render_box_max = pm->submodel[n].max;
 					}
+
+					if ( (p = strstr(props, "$do_not_scale_distances")) != nullptr ) {
+						p += 23;
+						pm->submodel[n].do_not_scale_detail_distances = true;
+					}
 				}
 
 				if ( (p = strstr(props, "$detail_sphere:")) != NULL ) {
@@ -1540,6 +1545,11 @@ int read_model_file(polymodel * pm, const char *filename, int n_subsystems, mode
 						pm->submodel[n].use_render_sphere_offset = true;
 					} else {
 						pm->submodel[n].render_sphere_offset = vmd_zero_vector;
+					}
+
+					if ( (p = strstr(props, "$do_not_scale_distances")) != nullptr ) {
+						p += 23;
+						pm->submodel[n].do_not_scale_detail_distances = true;
 					}
 				}
 

--- a/code/model/modelrender.cpp
+++ b/code/model/modelrender.cpp
@@ -1461,6 +1461,9 @@ bool model_render_check_detail_box(vec3d *view_pos, polymodel *pm, int submodel_
 	bsp_info *model = &pm->submodel[submodel_num];
 
 	float box_scale = model_render_determine_box_scale();
+	if (model->do_not_scale_detail_distances) {
+		box_scale = 1.0f;
+	}
 
 	if ( !( flags & MR_FULL_DETAIL ) && model->use_render_box ) {
 		vec3d box_min, box_max, offset;


### PR DESCRIPTION
Add a submodel property that overrides the hard-coded distance
multipliers applied to the distances at which details boxes & spheres
are rendered. The distance multipliers are set by the "model detail"
setting in the options screen. Note that this is different to the LOD
distance multipliers which are not hard-coded.

This allows some more creative uses of detail boxes & spheres, e.g. to
stop models subobjects from being rendered when they're out of player
view. Past testing showed a reasonable performance improvement with
complicated models.

This is a submodel property rather than global, or a ship flag, to allow
flexibility, i.e. a single model could choose this option only for the
submodels that want to use detail boxes/spheres in this fashion, while
other detail boxes/spheres use the conventional approach.

Code & ideas originally from zookeeper, I've just packaged it up for
the PR.