### PR TITLE
Add CircleCI config file

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,182 @@
+version: 2
+
+references:
+  container_config: &container_config
+    docker:
+      - image: "debian:stretch"
+        working_directory: /root/build
+
+  restore_repo: &restore_repo
+    restore_cache:
+      keys:
+        - source-repo-{{ .Branch }}-{{ .Revision }}
+        - source-repo-{{ .Branch }}
+        - source-repo
+
+  cmake_configure: &cmake_configure
+    run:
+      name: Creating Build Files
+      command: |
+        mkdir build
+        cd build
+
+        CXXFLAGS="-m64 -mtune=generic -mfpmath=sse -msse -msse2 -pipe -Wno-unknown-pragmas"
+        CFLAGS="-m64 -mtune=generic -mfpmath=sse -msse -msse2 -pipe -Wno-unknown-pragmas"
+
+        if [[ "$CC" =~ ^clang.*$ ]]; then
+            CXXFLAGS="$CXXFLAGS -stdlib=libc++"
+        fi
+
+        eval $CC --version
+
+        export CXXFLAGS
+        export CFLAGS
+        CMAKE="cmake -G Ninja -DFSO_FATAL_WARNINGS=ON $CMAKE_OPTIONS"
+        eval $CMAKE -DCMAKE_BUILD_TYPE=$CONFIGURATION -DFSO_BUILD_TESTS=ON -DFSO_BUILD_INCLUDED_LIBS=ON ..
+
+  compile: &compile
+    run:
+      name: Compiling Source code
+      command: |
+        cd build
+        ninja -k 20 all
+
+  run_tests: &run_tests
+    run:
+      name: Run unit tests
+      command: |
+        ./build/bin/unittests --gtest_shuffle
+
+  compile_steps: &compile_steps
+    steps:
+      - *restore_repo
+      - *cmake_configure
+      - *compile
+      - *run_tests
+jobs:
+  checkout_code:
+    <<: *container_config
+    steps:
+      - run:
+          name: Installing Git
+          command: 'apt-get update && apt-get -yq install git'
+      - *restore_repo
+      - checkout
+      - run:
+          name: Updating submodules
+          command: 'git submodule update --init --recursive'
+      - save_cache:
+          key: source-repo-{{ .Branch }}-{{ .Revision }}
+          paths:
+            - .
+
+  build_gcc_lowest_debug:
+    docker:
+      - image: asarium/fso_compile:gcc-lowest
+        working_directory: /root/build
+    environment:
+      CC: gcc
+      CXX: g++
+      CONFIGURATION: Debug
+    <<: *compile_steps
+
+  build_gcc_lowest_release:
+    docker:
+      - image: asarium/fso_compile:gcc-lowest
+        working_directory: /root/build
+    environment:
+      CC: gcc
+      CXX: g++
+      CONFIGURATION: Release
+    <<: *compile_steps
+
+  build_gcc_latest_debug:
+    docker:
+      - image: asarium/fso_compile:gcc-latest
+        working_directory: /root/build
+    environment:
+      CC: gcc
+      CXX: g++
+      CONFIGURATION: Debug
+    <<: *compile_steps
+
+  build_gcc_latest_release:
+    docker:
+      - image: asarium/fso_compile:gcc-latest
+        working_directory: /root/build
+    environment:
+      CC: gcc
+      CXX: g++
+      CONFIGURATION: Release
+    <<: *compile_steps
+
+  build_clang_latest_debug:
+    docker:
+      - image: asarium/fso_compile:clang-latest
+        working_directory: /root/build
+    environment:
+      CC: clang-8
+      CXX: clang++-8
+      CONFIGURATION: Debug
+    <<: *compile_steps
+
+  build_clang_latest_release:
+    docker:
+      - image: asarium/fso_compile:clang-latest
+        working_directory: /root/build
+    environment:
+      CC: clang-8
+      CXX: clang++-8
+      CONFIGURATION: Release
+    <<: *compile_steps
+
+  build_clang_lowest_debug:
+    docker:
+      - image: asarium/fso_compile:clang-lowest
+        working_directory: /root/build
+    environment:
+      CC: clang
+      CXX: clang++
+      CONFIGURATION: Debug
+    <<: *compile_steps
+
+  build_clang_lowest_release:
+    docker:
+      - image: asarium/fso_compile:clang-lowest
+        working_directory: /root/build
+    environment:
+      CC: clang
+      CXX: clang++
+      CONFIGURATION: Release
+    <<: *compile_steps
+
+workflows:
+  version: 2
+
+  build_test:
+    jobs:
+      - checkout_code
+      - build_gcc_lowest_debug:
+          requires:
+            - checkout_code
+      - build_gcc_lowest_release:
+          requires:
+            - checkout_code
+      - build_gcc_latest_debug:
+          requires:
+            - checkout_code
+      - build_gcc_latest_release:
+          requires:
+            - checkout_code
+      - build_clang_latest_debug:
+          requires:
+            - checkout_code
+      - build_clang_latest_release:
+          requires:
+            - checkout_code
+      - build_clang_lowest_debug:
+          requires:
+            - checkout_code
+      - build_clang_lowest_release:
+          requires:
+            - checkout_code

--- a/code/cutscene/cutscenes.h
+++ b/code/cutscene/cutscenes.h
@@ -21,15 +21,7 @@ typedef struct cutscene_info
 	bool viewable;
 } cutscene_info;
 
-#if SCP_COMPILER_IS_GNU
-#pragma GCC diagnostic push
-// This suppresses a GCC bug where it thinks that the Cutscenes from the enum class below shadows a global variable
-#pragma GCC diagnostic ignored "-Wshadow"
-#endif
 extern SCP_vector<cutscene_info> Cutscenes;
-#if SCP_COMPILER_IS_GNU
-#pragma GCC diagnostic pop
-#endif
 
 // initializa table data
 void cutscene_init();

--- a/code/gamesnd/gamesnd.h
+++ b/code/gamesnd/gamesnd.h
@@ -246,7 +246,7 @@ enum class GameSounds {
 /**
  * Interface sounds
  */
-enum InterfaceSounds {
+enum class InterfaceSounds {
 	IFACE_MOUSE_CLICK       =0, //!< mouse click
 	ICON_PICKUP             =1, //!< pick up a ship icon (Empty in Retail)
 	ICON_DROP_ON_WING       =2, //!< drop a ship icon on a wing slot

--- a/code/pilotfile/csg_convert.cpp
+++ b/code/pilotfile/csg_convert.cpp
@@ -7,9 +7,9 @@
  */
 
 #include "cfile/cfilesystem.h"
+#include "pilotfile/pilotfile_convert.h"
 #include "cutscene/cutscenes.h"
 #include "menuui/techmenu.h"
-#include "pilotfile/pilotfile_convert.h"
 #include "ship/ship.h"
 #include "stats/medals.h"
 #include "weapon/weapon.h"

--- a/code/pilotfile/pilotfile_convert.cpp
+++ b/code/pilotfile/pilotfile_convert.cpp
@@ -30,7 +30,7 @@ pilotfile_convert::~pilotfile_convert()
 	}
 }
 
-void pilotfile_convert::startSection(Section::id section_id)
+void pilotfile_convert::startSection(Section section_id)
 {
 	Assert( cfp );
 

--- a/code/pilotfile/pilotfile_convert.h
+++ b/code/pilotfile/pilotfile_convert.h
@@ -224,27 +224,25 @@ class pilotfile_convert {
 		scoring_special_t multi_stats;
 
 		// sections of a pilot file. includes both plr and csg sections
-		struct Section {
-			enum id {
-				Flags			= 0x0001,
-				Info			= 0x0002,
-				Loadout			= 0x0003,
-				Controls		= 0x0004,
-				Multiplayer		= 0x0005,
-				Scoring			= 0x0006,
-				ScoringMulti	= 0x0007,
-				Techroom		= 0x0008,
-				HUD				= 0x0009,
-				Settings		= 0x0010,
-				RedAlert		= 0x0011,
-				Variables		= 0x0012,
-				Missions		= 0x0013,
-				Cutscenes		= 0x0014,
-			};
+		enum class Section {
+			Flags			= 0x0001,
+			Info			= 0x0002,
+			Loadout			= 0x0003,
+			Controls		= 0x0004,
+			Multiplayer		= 0x0005,
+			Scoring			= 0x0006,
+			ScoringMulti	= 0x0007,
+			Techroom		= 0x0008,
+			HUD				= 0x0009,
+			Settings		= 0x0010,
+			RedAlert		= 0x0011,
+			Variables		= 0x0012,
+			Missions		= 0x0013,
+			Cutscenes		= 0x0014,
 		};
 
 		// for writing files, sets/updates section info
-		void startSection(Section::id section_id);
+		void startSection(Section section_id);
 		void endSection();
 		// file offset of the size value for the current section (set with startSection())
 		size_t m_size_offset;


### PR DESCRIPTION
Given the recent changes at TravisCI it seemed like a good idea to investigate other possibilities for handling our CI. This adds the configuration necessary for compiling our code with CircleCI for Linux.

Their resources also appear to be better than TravisCI so builds complete much faster and their workflow system for building a pipeline of builds is also very interesting.

There were a few code changes required for making the newer clang version happy but nothing major.