### PR TITLE
make sure to set all hook variables when the script hook is called

### DIFF
--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -2462,11 +2462,9 @@ int parse_create_object_sub(p_object *p_objp)
 	// If the ship is in a wing, this will be done in mission_set_wing_arrival_location() instead
 	// If the ship is in a wing, but the wing is docked then addition of bool brought_in_docked_wing accounts for that status --wookieejedi
 	if (Game_mode & GM_IN_MISSION && ((shipp->wingnum == -1) || (brought_in_docked_wing))) {
-		if (anchor_objnum >= 0)
-			Script_system.SetHookObjects(2, "Ship", &Objects[objnum], "Parent", &Objects[anchor_objnum]);
-		else
-			Script_system.SetHookObjects(2, "Ship", &Objects[objnum], "Parent", NULL);
+		object *anchor_objp = (anchor_objnum >= 0) ? &Objects[anchor_objnum] : nullptr;
 
+		Script_system.SetHookObjects(2, "Ship", &Objects[objnum], "Parent", anchor_objp);
 		Script_system.RunCondition(CHA_ONSHIPARRIVE, &Objects[objnum]);
 		Script_system.RemHookVars(2, "Ship", "Parent");
 	}
@@ -6166,12 +6164,9 @@ void mission_set_wing_arrival_location( wing *wingp, int num_to_set )
 	if (Game_mode & GM_IN_MISSION) {
 		for ( index = wingp->current_count - num_to_set; index < wingp->current_count; index ++ ) {
 			object *objp = &Objects[Ships[wingp->ship_index[index]].objnum];
+			object *anchor_objp = (anchor_objnum >= 0) ? &Objects[anchor_objnum] : nullptr;
 
-			if (anchor_objnum >= 0)
-				Script_system.SetHookObjects(2, "Ship", objp, "Parent", &Objects[anchor_objnum]);
-			else
-				Script_system.SetHookObjects(2, "Ship", objp, "Parent", NULL);
-
+			Script_system.SetHookObjects(2, "Ship", objp, "Parent", anchor_objp);
 			Script_system.RunCondition(CHA_ONSHIPARRIVE, objp);
 			Script_system.RemHookVars(2, "Ship", "Parent");
 

--- a/code/object/collidedebrisship.cpp
+++ b/code/object/collidedebrisship.cpp
@@ -66,11 +66,14 @@ int collide_debris_ship( obj_pair * pair )
 		hit = debris_check_collision(pdebris, pship, &hitpos, &debris_hit_info );
 		if ( hit )
 		{
-			Script_system.SetHookObjects(4, "Ship", pship, "Debris", pdebris, "Self", pship, "Object", pdebris);
+			Script_system.SetHookObjects(4, "Self", pship, "Object", pdebris, "Ship", pship, "Debris", pdebris);
 			bool ship_override = Script_system.IsConditionOverride(CHA_COLLIDEDEBRIS, pship);
+			Script_system.RemHookVars(4, "Self", "Object", "Ship", "Debris");
 
-			Script_system.SetHookObjects(2, "Self",pdebris, "Object", pship);
+			Script_system.SetHookObjects(4, "Self", pdebris, "Object", pship, "Ship", pship, "Debris", pdebris);
 			bool debris_override = Script_system.IsConditionOverride(CHA_COLLIDESHIP, pdebris);
+			Script_system.RemHookVars(4, "Self", "Object", "Ship", "Debris");
+
 			if(!ship_override && !debris_override)
 			{
 				float		ship_damage;	
@@ -133,15 +136,15 @@ int collide_debris_ship( obj_pair * pair )
 				collide_ship_ship_do_sound(&hitpos, pship, pdebris, pship==Player_obj);
 			}
 
-			Script_system.SetHookObjects(2, "Self",pship, "Object", pdebris);
+			Script_system.SetHookObjects(4, "Self", pship, "Object", pdebris, "Ship", pship, "Debris", pdebris);
 			if(!(debris_override && !ship_override))
 				Script_system.RunCondition(CHA_COLLIDEDEBRIS, pship);
+			Script_system.RemHookVars(4, "Self", "Object", "Ship", "Debris");
 
-			Script_system.SetHookObjects(2, "Self",pdebris, "Object", pship);
+			Script_system.SetHookObjects(4, "Self", pdebris, "Object", pship, "Ship", pship, "Debris", pdebris);
 			if((debris_override && !ship_override) || (!debris_override && !ship_override))
 				Script_system.RunCondition(CHA_COLLIDESHIP, pdebris);
-
-			Script_system.RemHookVars(4, "Ship", "Debris", "Self", "Object");
+			Script_system.RemHookVars(4, "Self", "Object", "Ship", "Debris");
 
 			return 0;
 		}
@@ -221,11 +224,13 @@ int collide_asteroid_ship( obj_pair * pair )
 		if ( hit )
 		{
 			//Scripting support (WMC)
-			Script_system.SetHookObjects(4, "Ship", pship, "Asteroid", pasteroid, "Self",pship, "Object", pasteroid);
+			Script_system.SetHookObjects(4, "Self", pship, "Object", pasteroid, "Ship", pship, "Asteroid", pasteroid);
 			bool ship_override = Script_system.IsConditionOverride(CHA_COLLIDEASTEROID, pship);
+			Script_system.RemHookVars(4, "Self", "Object", "Ship", "Asteroid");
 
-			Script_system.SetHookObjects(2, "Self",pasteroid, "Object", pship);
+			Script_system.SetHookObjects(4, "Self", pasteroid, "Object", pship, "Ship", pship, "Asteroid", pasteroid);
 			bool asteroid_override = Script_system.IsConditionOverride(CHA_COLLIDESHIP, pasteroid);
+			Script_system.RemHookVars(4, "Self", "Object", "Ship", "Asteroid");
 
 			if(!ship_override && !asteroid_override)
 			{
@@ -294,15 +299,15 @@ int collide_asteroid_ship( obj_pair * pair )
 				collide_ship_ship_do_sound(&hitpos, pship, pasteroid, pship==Player_obj);
 			}
 
-			Script_system.SetHookObjects(2, "Self",pship, "Object", pasteroid);
+			Script_system.SetHookObjects(4, "Self", pship, "Object", pasteroid, "Ship", pship, "Asteroid", pasteroid);
 			if(!(asteroid_override && !ship_override))
 				Script_system.RunCondition(CHA_COLLIDEASTEROID, pship);
+			Script_system.RemHookVars(4, "Self", "Object", "Ship", "Asteroid");
 
-			Script_system.SetHookObjects(2, "Self",pasteroid, "Object", pship);
+			Script_system.SetHookObjects(4, "Self", pasteroid, "Object", pship, "Ship", pship, "Asteroid", pasteroid);
 			if((asteroid_override && !ship_override) || (!asteroid_override && !ship_override))
 				Script_system.RunCondition(CHA_COLLIDESHIP, pasteroid);
-
-			Script_system.RemHookVars(4, "Ship", "Asteroid", "Self", "Object");
+			Script_system.RemHookVars(4, "Self", "Object", "Ship", "Asteroid");
 
 			return 0;
 		}

--- a/code/object/collidedebrisweapon.cpp
+++ b/code/object/collidedebrisweapon.cpp
@@ -42,11 +42,13 @@ int collide_debris_weapon( obj_pair * pair )
 		if ( !hit )
 			return 0;
 
-		Script_system.SetHookObjects(4, "Weapon", weapon_obj, "Debris", pdebris, "Self", weapon_obj, "Object", pdebris);
+		Script_system.SetHookObjects(4, "Self", weapon_obj, "Object", pdebris, "Weapon", weapon_obj, "Debris", pdebris);
 		bool weapon_override = Script_system.IsConditionOverride(CHA_COLLIDEDEBRIS, weapon_obj);
+		Script_system.RemHookVars(4, "Self", "Object", "Weapon", "Debris");
 
-		Script_system.SetHookObjects(2, "Self", pdebris, "Object", weapon_obj);
+		Script_system.SetHookObjects(4, "Self", pdebris, "Object", weapon_obj, "Weapon", weapon_obj, "Debris", pdebris);
 		bool debris_override = Script_system.IsConditionOverride(CHA_COLLIDEWEAPON, pdebris);
+		Script_system.RemHookVars(4, "Self", "Object", "Weapon", "Debris");
 
 		if(!weapon_override && !debris_override)
 		{
@@ -54,15 +56,16 @@ int collide_debris_weapon( obj_pair * pair )
 			debris_hit( pdebris, weapon_obj, &hitpos, Weapon_info[Weapons[weapon_obj->instance].weapon_info_index].damage );
 		}
 
-		Script_system.SetHookObjects(2, "Self", weapon_obj, "Object", pdebris);
+		Script_system.SetHookObjects(4, "Self", weapon_obj, "Object", pdebris, "Weapon", weapon_obj, "Debris", pdebris);
 		if(!(debris_override && !weapon_override))
 			Script_system.RunCondition(CHA_COLLIDEDEBRIS, weapon_obj);
+		Script_system.RemHookVars(4, "Self", "Object", "Weapon", "Debris");
 
-		Script_system.SetHookObjects(2, "Self", pdebris, "Object", weapon_obj);
+		Script_system.SetHookObjects(4, "Self", pdebris, "Object", weapon_obj, "Weapon", weapon_obj, "Debris", pdebris);
 		if((debris_override && !weapon_override) || (!debris_override && !weapon_override))
 			Script_system.RunCondition(CHA_COLLIDEWEAPON, pdebris, Weapons[weapon_obj->instance].weapon_info_index);
+		Script_system.RemHookVars(4, "Self", "Object", "Weapon", "Debris");
 
-		Script_system.RemHookVars(4, "Weapon", "Debris", "Self", "Object");
 		return 0;
 
 	} else {
@@ -97,11 +100,13 @@ int collide_asteroid_weapon( obj_pair * pair )
 		if ( !hit )
 			return 0;
 
-		Script_system.SetHookObjects(4, "Weapon", weapon_obj, "Asteroid", pasteroid, "Self", weapon_obj, "Object", pasteroid);
-
+		Script_system.SetHookObjects(4, "Self", weapon_obj, "Object", pasteroid, "Weapon", weapon_obj, "Asteroid", pasteroid);
 		bool weapon_override = Script_system.IsConditionOverride(CHA_COLLIDEASTEROID, weapon_obj);
-		Script_system.SetHookObjects(2, "Self",pasteroid, "Object", weapon_obj);
+		Script_system.RemHookVars(4, "Self", "Object", "Weapon", "Asteroid");
+
+		Script_system.SetHookObjects(4, "Self", pasteroid, "Object", weapon_obj, "Weapon", weapon_obj, "Asteroid", pasteroid);
 		bool asteroid_override = Script_system.IsConditionOverride(CHA_COLLIDEWEAPON, pasteroid);
+		Script_system.RemHookVars(4, "Self", "Object", "Weapon", "Asteroid");
 
 		if(!weapon_override && !asteroid_override)
 		{
@@ -109,15 +114,16 @@ int collide_asteroid_weapon( obj_pair * pair )
 			asteroid_hit( pasteroid, weapon_obj, &hitpos, Weapon_info[Weapons[weapon_obj->instance].weapon_info_index].damage );
 		}
 
-		Script_system.SetHookObjects(2, "Self", weapon_obj, "Object", pasteroid);
+		Script_system.SetHookObjects(4, "Self", weapon_obj, "Object", pasteroid, "Weapon", weapon_obj, "Asteroid", pasteroid);
 		if(!(asteroid_override && !weapon_override))
 			Script_system.RunCondition(CHA_COLLIDEASTEROID, weapon_obj);
+		Script_system.RemHookVars(4, "Self", "Object", "Weapon", "Asteroid");
 
-		Script_system.SetHookObjects(2, "Self", pasteroid, "Object", weapon_obj);
+		Script_system.SetHookObjects(4, "Self", pasteroid, "Object", weapon_obj, "Weapon", weapon_obj, "Asteroid", pasteroid);
 		if((asteroid_override && !weapon_override) || (!asteroid_override && !weapon_override))
 			Script_system.RunCondition(CHA_COLLIDEWEAPON, pasteroid, Weapons[weapon_obj->instance].weapon_info_index);
+		Script_system.RemHookVars(4, "Self", "Object", "Weapon", "Asteroid");
 
-		Script_system.RemHookVars(4, "Weapon", "Asteroid", "Self", "Object");
 		return 0;
 
 	} else {

--- a/code/object/collideshipship.cpp
+++ b/code/object/collideshipship.cpp
@@ -1137,12 +1137,15 @@ int collide_ship_ship( obj_pair * pair )
 
 		if ( hit )
 		{
-			Script_system.SetHookObjects(4, "Ship", A, "ShipB", B, "Self", A, "Object", B);
+			Script_system.SetHookObjects(4, "Self", A, "Object", B, "Ship", A, "ShipB", B);
 			bool a_override = Script_system.IsConditionOverride(CHA_COLLIDESHIP, A);
-			
+			Script_system.RemHookVars(4, "Self", "Object", "Ship", "ShipB");
+
 			//Yes this should be reversed.
-			Script_system.SetHookObjects(4, "Ship", B, "ShipB", A, "Self", B, "Object", A);
+			Script_system.SetHookObjects(4, "Self", B, "Object", A, "Ship", B, "ShipB", A);
 			bool b_override = Script_system.IsConditionOverride(CHA_COLLIDESHIP, B);
+			Script_system.RemHookVars(4, "Self", "Object", "Ship", "ShipB");
+
 			if(!a_override && !b_override)
 			{
 				float		damage;
@@ -1247,17 +1250,18 @@ int collide_ship_ship( obj_pair * pair )
 
 			if(!(b_override && !a_override))
 			{
-				Script_system.SetHookObjects(4, "Ship", A, "ShipB", B, "Self", A, "Object", B);
+				Script_system.SetHookObjects(4, "Self", A, "Object", B, "Ship", A, "ShipB", B);
 				Script_system.RunCondition(CHA_COLLIDESHIP, A);
+				Script_system.RemHookVars(4, "Self", "Object", "Ship", "ShipB");
 			}
 			if((b_override && !a_override) || (!b_override && !a_override))
 			{
 				//Yes this should be reversed.
-				Script_system.SetHookObjects(4, "Ship", B, "ShipB", A, "Self", B, "Object", A);
+				Script_system.SetHookObjects(4, "Self", B, "Object", A, "Ship", B, "ShipB", A);
 				Script_system.RunCondition(CHA_COLLIDESHIP, B);
+				Script_system.RemHookVars(4, "Self", "Object", "Ship", "ShipB");
 			}
 
-			Script_system.RemHookVars(4, "Ship", "ShipB", "Self", "Object");
 			return 0;
 		}					
     }

--- a/code/object/collideshipship.cpp
+++ b/code/object/collideshipship.cpp
@@ -1141,7 +1141,7 @@ int collide_ship_ship( obj_pair * pair )
 			bool a_override = Script_system.IsConditionOverride(CHA_COLLIDESHIP, A);
 			Script_system.RemHookVars(4, "Self", "Object", "Ship", "ShipB");
 
-			//Yes this should be reversed.
+			// Yes, this should be reversed.
 			Script_system.SetHookObjects(4, "Self", B, "Object", A, "Ship", B, "ShipB", A);
 			bool b_override = Script_system.IsConditionOverride(CHA_COLLIDESHIP, B);
 			Script_system.RemHookVars(4, "Self", "Object", "Ship", "ShipB");
@@ -1256,7 +1256,7 @@ int collide_ship_ship( obj_pair * pair )
 			}
 			if((b_override && !a_override) || (!b_override && !a_override))
 			{
-				//Yes this should be reversed.
+				// Yes, this should be reversed.
 				Script_system.SetHookObjects(4, "Self", B, "Object", A, "Ship", B, "ShipB", A);
 				Script_system.RunCondition(CHA_COLLIDESHIP, B);
 				Script_system.RemHookVars(4, "Self", "Object", "Ship", "ShipB");

--- a/code/object/collideshipweapon.cpp
+++ b/code/object/collideshipweapon.cpp
@@ -424,9 +424,11 @@ static int ship_weapon_check_collision(object *ship_objp, object *weapon_objp, f
 
 		Script_system.SetHookObjects(4, "Self", ship_objp, "Object", weapon_objp, "Ship", ship_objp, "Weapon", weapon_objp);
 		bool ship_override = Script_system.IsConditionOverride(CHA_COLLIDEWEAPON, ship_objp);
+		Script_system.RemHookVars(4, "Self", "Object", "Ship", "Weapon");
 
 		Script_system.SetHookObjects(4, "Self", weapon_objp, "Object", ship_objp, "Ship", ship_objp, "Weapon", weapon_objp);
 		bool weapon_override = Script_system.IsConditionOverride(CHA_COLLIDESHIP, weapon_objp);
+		Script_system.RemHookVars(4, "Self", "Object", "Ship", "Weapon");
 
 		if(!ship_override && !weapon_override) {
 			if (shield_collision && quadrant_num >= 0) {
@@ -440,11 +442,11 @@ static int ship_weapon_check_collision(object *ship_objp, object *weapon_objp, f
 		Script_system.SetHookObjects(4, "Self", ship_objp, "Object", weapon_objp, "Ship", ship_objp, "Weapon", weapon_objp);
 		if(!(weapon_override && !ship_override))
 			Script_system.RunCondition(CHA_COLLIDEWEAPON, ship_objp, wp->weapon_info_index);
+		Script_system.RemHookVars(4, "Self", "Object", "Ship", "Weapon");
 
 		Script_system.SetHookObjects(4, "Self", weapon_objp, "Object", ship_objp, "Ship", ship_objp, "Weapon", weapon_objp);
 		if((weapon_override && !ship_override) || (!weapon_override && !ship_override))
 			Script_system.RunCondition(CHA_COLLIDESHIP, weapon_objp);
-
 		Script_system.RemHookVars(4, "Self", "Object", "Ship", "Weapon");
 	}
 	else if ((Missiontime - wp->creation_time > F1_0/2) && (wip->is_homing()) && (wp->homing_object == ship_objp)) {

--- a/code/object/collideshipweapon.cpp
+++ b/code/object/collideshipweapon.cpp
@@ -422,10 +422,10 @@ static int ship_weapon_check_collision(object *ship_objp, object *weapon_objp, f
 		wp->collisionInfo = new mc_info;	// The weapon will free this memory later
 		memcpy(wp->collisionInfo, &mc, sizeof(mc_info));
 
-		Script_system.SetHookObjects(4, "Ship", ship_objp, "Weapon", weapon_objp, "Self",ship_objp, "Object", weapon_objp);
+		Script_system.SetHookObjects(4, "Self", ship_objp, "Object", weapon_objp, "Ship", ship_objp, "Weapon", weapon_objp);
 		bool ship_override = Script_system.IsConditionOverride(CHA_COLLIDEWEAPON, ship_objp);
 
-		Script_system.SetHookObjects(2, "Self",weapon_objp, "Object", ship_objp);
+		Script_system.SetHookObjects(4, "Self", weapon_objp, "Object", ship_objp, "Ship", ship_objp, "Weapon", weapon_objp);
 		bool weapon_override = Script_system.IsConditionOverride(CHA_COLLIDESHIP, weapon_objp);
 
 		if(!ship_override && !weapon_override) {
@@ -437,15 +437,15 @@ static int ship_weapon_check_collision(object *ship_objp, object *weapon_objp, f
 			ship_weapon_do_hit_stuff(ship_objp, weapon_objp, &mc.hit_point_world, &mc.hit_point, quadrant_num, mc.hit_submodel, mc.hit_normal);
 		}
 
-		Script_system.SetHookObjects(2, "Self",ship_objp, "Object", weapon_objp);
+		Script_system.SetHookObjects(4, "Self", ship_objp, "Object", weapon_objp, "Ship", ship_objp, "Weapon", weapon_objp);
 		if(!(weapon_override && !ship_override))
 			Script_system.RunCondition(CHA_COLLIDEWEAPON, ship_objp, wp->weapon_info_index);
 
-		Script_system.SetHookObjects(2, "Self",weapon_objp, "Object", ship_objp);
+		Script_system.SetHookObjects(4, "Self", weapon_objp, "Object", ship_objp, "Ship", ship_objp, "Weapon", weapon_objp);
 		if((weapon_override && !ship_override) || (!weapon_override && !ship_override))
 			Script_system.RunCondition(CHA_COLLIDESHIP, weapon_objp);
 
-		Script_system.RemHookVars(4, "Ship", "Weapon", "Self","Object");
+		Script_system.RemHookVars(4, "Self", "Object", "Ship", "Weapon");
 	}
 	else if ((Missiontime - wp->creation_time > F1_0/2) && (wip->is_homing()) && (wp->homing_object == ship_objp)) {
 		if (dist < wip->shockwave.inner_rad) {

--- a/code/object/collideweaponweapon.cpp
+++ b/code/object/collideweaponweapon.cpp
@@ -82,12 +82,14 @@ int collide_weapon_weapon( obj_pair * pair )
 	//	Rats, do collision detection.
 	if (collide_subdivide(&A->last_pos, &A->pos, A_radius, &B->last_pos, &B->pos, B_radius))
 	{
-		Script_system.SetHookObjects(4, "Weapon", A, "WeaponB", B, "Self",A, "Object", B);
+		Script_system.SetHookObjects(4, "Self", A, "Object", B, "Weapon", A, "WeaponB", B);
 		bool a_override = Script_system.IsConditionOverride(CHA_COLLIDEWEAPON, A);
-		
-		//Should be reversed
-		Script_system.SetHookObjects(4, "Weapon", B, "WeaponB", A, "Self",B, "Object", A);
+		Script_system.RemHookVars(4, "Self", "Object", "Weapon", "WeaponB");
+
+		// Yes, this should be reversed.
+		Script_system.SetHookObjects(4, "Self", B, "Object", A, "Weapon", B, "WeaponB", A);
 		bool b_override = Script_system.IsConditionOverride(CHA_COLLIDEWEAPON, B);
+		Script_system.RemHookVars(4, "Self", "Object", "Weapon", "WeaponB");
 
 		if(!a_override && !b_override)
 		{
@@ -170,17 +172,18 @@ int collide_weapon_weapon( obj_pair * pair )
 
 		if(!(b_override && !a_override))
 		{
-			Script_system.SetHookObjects(4, "Weapon", A, "WeaponB", B, "Self",A, "Object", B);
+			Script_system.SetHookObjects(4, "Self", A, "Object", B, "Weapon", A, "WeaponB", B);
 			Script_system.RunCondition(CHA_COLLIDEWEAPON, A, wpA->weapon_info_index);
+			Script_system.RemHookVars(4, "Self", "Object", "Weapon", "WeaponB");
 		}
 		else
 		{
-			//Should be reversed
-			Script_system.SetHookObjects(4, "Weapon", B, "WeaponB", A, "Self",B, "Object", A);
+			// Yes, this should be reversed.
+			Script_system.SetHookObjects(4, "Self", B, "Object", A, "Weapon", B, "WeaponB", A);
 			Script_system.RunCondition(CHA_COLLIDEWEAPON, B, wpB->weapon_info_index);
+			Script_system.RemHookVars(4, "Self", "Object", "Weapon", "WeaponB");
 		}
 
-		Script_system.RemHookVars(4, "Weapon", "WeaponB", "Self", "Object");
 		return 1;
 	}
 

--- a/code/object/object.cpp
+++ b/code/object/object.cpp
@@ -1498,8 +1498,8 @@ void obj_move_all(float frametime)
 
 			Script_system.SetHookObjects(2, "User", objp, "Target", target);
 			Script_system.RunCondition(CHA_ONWPEQUIPPED, objp);
+			Script_system.RemHookVars(2, "User", "Target");
 		}
-		Script_system.RemHookVars(2, "User", "Target");
 	}
 
 	// Now that we've moved all the objects, move all the models that use intrinsic rotations.  We do that here because we already handled the

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -11333,7 +11333,6 @@ int ship_fire_primary(object * obj, int stream_weapons, int force)
 
 		Script_system.SetHookObjects(2, "User", objp, "Target", target);
 		Script_system.RunCondition(CHA_ONWPFIRED, objp, 1);
-
 		Script_system.RunCondition(CHA_PRIMARYFIRE, objp);
 		Script_system.RemHookVars(2, "User", "Target");
 	}
@@ -11998,7 +11997,8 @@ done_secondary:
 		else
 			target = NULL;
 		if (objp == Player_obj && Player_ai->target_objnum != -1)
-			target = &Objects[Player_ai->target_objnum]; 
+			target = &Objects[Player_ai->target_objnum];
+
 		Script_system.SetHookObjects(2, "User", objp, "Target", target);
 		Script_system.RunCondition(CHA_ONWPFIRED, objp);
 		Script_system.RunCondition(CHA_SECONDARYFIRE, objp);
@@ -12257,12 +12257,13 @@ int ship_select_next_primary(object *objp, int direction)
 		else
 			target = NULL;
 		if (objp == Player_obj && Player_ai->target_objnum != -1)
-			target = &Objects[Player_ai->target_objnum]; 
+			target = &Objects[Player_ai->target_objnum];
+
 		Script_system.SetHookObjects(2, "User", objp, "Target", target);
 		Script_system.RunCondition(CHA_ONWPSELECTED, objp);
-		Script_system.SetHookObjects(2, "User", objp, "Target", target);
 		Script_system.RunCondition(CHA_ONWPDESELECTED, objp);
 		Script_system.RemHookVars(2, "User", "Target");
+
 		return 1;
 	}
 
@@ -12351,12 +12352,13 @@ int ship_select_next_secondary(object *objp)
 			else
 				target = NULL;
 			if (objp == Player_obj && Player_ai->target_objnum != -1)
-				target = &Objects[Player_ai->target_objnum]; 
+				target = &Objects[Player_ai->target_objnum];
+
 			Script_system.SetHookObjects(2, "User", objp, "Target", target);
 			Script_system.RunCondition(CHA_ONWPSELECTED, objp);
-			Script_system.SetHookObjects(2, "User", objp, "Target", target);
 			Script_system.RunCondition(CHA_ONWPDESELECTED, objp);
 			Script_system.RemHookVars(2, "User", "Target");
+
 			return 1;
 		}
 	} // end if

--- a/code/ship/shiphit.cpp
+++ b/code/ship/shiphit.cpp
@@ -1547,15 +1547,10 @@ void ship_hit_kill(object *ship_objp, object *other_obj, float percent_killed, i
 {
 	Assert(ship_objp);	// Goober5000 - but not other_obj, not only for sexp but also for self-destruct
 
-	Script_system.SetHookObject("Self", ship_objp);
-	if(other_obj != NULL)
-		Script_system.SetHookObject("Killer", other_obj);
-	else
-		Script_system.SetHookObject("Killer", 0);
-
 	if(Script_system.IsConditionOverride(CHA_DEATH, ship_objp))
 	{
 		//WMC - Do scripting stuff
+		Script_system.SetHookObjects(2, "Self", ship_objp, "Killer", other_obj);
 		Script_system.RunCondition(CHA_DEATH, ship_objp);
 		Script_system.RemHookVars(2, "Self", "Killer");
 		return;
@@ -1693,6 +1688,7 @@ void ship_hit_kill(object *ship_objp, object *other_obj, float percent_killed, i
 		ship_maybe_lament();
 	}
 
+	Script_system.SetHookObjects(2, "Self", ship_objp, "Killer", other_obj);
 	Script_system.RunCondition(CHA_DEATH, ship_objp);
 	Script_system.RemHookVars(2, "Self", "Killer");
 }

--- a/code/weapon/beam.cpp
+++ b/code/weapon/beam.cpp
@@ -2532,25 +2532,27 @@ int beam_collide_ship(obj_pair *pair)
 	if (valid_hit_occurred) {
 		// add to the collision_list
 
-		Script_system.SetHookObjects(4, "Ship", ship_objp, "Beam", weapon_objp, "Self",ship_objp, "Object", weapon_objp);
+		Script_system.SetHookObjects(4, "Self", ship_objp, "Object", weapon_objp, "Ship", ship_objp, "Beam", weapon_objp);
 		bool ship_override = Script_system.IsConditionOverride(CHA_COLLIDEBEAM, ship_objp);
+		Script_system.RemHookVars(4, "Self", "Object", "Ship", "Beam");
 
-		Script_system.SetHookObjects(2, "Self",weapon_objp, "Object", ship_objp);
+		Script_system.SetHookObjects(4, "Self", weapon_objp, "Object", ship_objp, "Ship", ship_objp, "Beam", weapon_objp);
 		bool weapon_override = Script_system.IsConditionOverride(CHA_COLLIDESHIP, weapon_objp);
+		Script_system.RemHookVars(4, "Self", "Object", "Ship", "Beam");
 
 		if(!ship_override && !weapon_override) {
 			beam_add_collision(b, ship_objp, &mc, quadrant_num);
 		}
 
-		Script_system.SetHookObjects(2, "Self",ship_objp, "Object", weapon_objp);
+		Script_system.SetHookObjects(4, "Self", ship_objp, "Object", weapon_objp, "Ship", ship_objp, "Beam", weapon_objp);
 		if(!(weapon_override && !ship_override))
 			Script_system.RunCondition(CHA_COLLIDEBEAM, ship_objp);
+		Script_system.RemHookVars(4, "Self", "Object", "Ship", "Beam");
 
-		Script_system.SetHookObjects(2, "Self",weapon_objp, "Object", ship_objp);
+		Script_system.SetHookObjects(4, "Self", weapon_objp, "Object", ship_objp, "Ship", ship_objp, "Beam", weapon_objp);
 		if((weapon_override && !ship_override) || (!weapon_override && !ship_override))
 			Script_system.RunCondition(CHA_COLLIDESHIP, weapon_objp);
-
-		Script_system.RemHookVars(4, "Ship", "Beam", "Self","Object");
+		Script_system.RemHookVars(4, "Self", "Object", "Ship", "Beam");
 
 		// if we got "tooled", add an exit hole too
 		if (hull_exit_collision)
@@ -2625,29 +2627,30 @@ int beam_collide_asteroid(obj_pair *pair)
 	if(test_collide.num_hits){
 		// add to the collision list
 
-		Script_system.SetHookObjects(4, "Beam", pair->a, "Asteroid", pair->b, "Self",pair->a, "Object", pair->b);
+		Script_system.SetHookObjects(4, "Self", pair->a, "Object", pair->b, "Beam", pair->a, "Asteroid", pair->b);
 		bool weapon_override = Script_system.IsConditionOverride(CHA_COLLIDEASTEROID, pair->a);
+		Script_system.RemHookVars(4, "Self", "Object", "Beam", "Asteroid");
 
-		Script_system.SetHookObjects(2, "Self",pair->b, "Object", pair->a);
+		Script_system.SetHookObjects(4, "Self", pair->b, "Object", pair->a, "Beam", pair->a, "Asteroid", pair->b);
 		bool asteroid_override = Script_system.IsConditionOverride(CHA_COLLIDEBEAM, pair->b);
+		Script_system.RemHookVars(4, "Self", "Object", "Beam", "Asteroid");
 
 		if(!weapon_override && !asteroid_override)
 		{
 			beam_add_collision(b, pair->b, &test_collide);
 		}
 
-		Script_system.SetHookObjects(2, "Self",pair->a, "Object", pair->b);
+		Script_system.SetHookObjects(4, "Self", pair->a, "Object", pair->b, "Beam", pair->a, "Asteroid", pair->b);
 		if(!(asteroid_override && !weapon_override))
 			Script_system.RunCondition(CHA_COLLIDEASTEROID, pair->a);
+		Script_system.RemHookVars(4, "Self", "Object", "Beam", "Asteroid");
 
-		Script_system.SetHookObjects(2, "Self",pair->b, "Object", pair->a);
+		Script_system.SetHookObjects(4, "Self", pair->b, "Object", pair->a, "Beam", pair->a, "Asteroid", pair->b);
 		if((asteroid_override && !weapon_override) || (!asteroid_override && !weapon_override))
 			Script_system.RunCondition(CHA_COLLIDEBEAM, pair->b);
+		Script_system.RemHookVars(4, "Self", "Object", "Beam", "Asteroid");
 
-		Script_system.RemHookVars(4, "Beam", "Asteroid", "Self","Object");
 		return 0;
-
-
 	}
 
 	// reset timestamp to timeout immediately
@@ -2715,32 +2718,32 @@ int beam_collide_missile(obj_pair *pair)
 	if(test_collide.num_hits){
 		// add to the collision list
 
-		Script_system.SetHookObjects(4, "Beam", pair->a, "Weapon", pair->b, "Self",pair->a, "Object", pair->b);
+		Script_system.SetHookObjects(4, "Self", pair->a, "Object", pair->b, "Beam", pair->a, "Weapon", pair->b);
 		bool a_override = Script_system.IsConditionOverride(CHA_COLLIDEWEAPON, pair->a);
+		Script_system.RemHookVars(4, "Self", "Object", "Beam", "Weapon");
 
 		//Should be reversed
-		Script_system.SetHookObjects(2, "Self",pair->b, "Object", pair->a);
+		Script_system.SetHookObjects(4, "Self", pair->b, "Object", pair->a, "Beam", pair->a, "Weapon", pair->b);
 		bool b_override = Script_system.IsConditionOverride(CHA_COLLIDEBEAM, pair->b);
+		Script_system.RemHookVars(4, "Self", "Object", "Beam", "Weapon");
 
 		if(!a_override && !b_override){
 			beam_add_collision(b, pair->b, &test_collide);
 		}
 
-
 		if(!(b_override && !a_override))
 		{
-			Script_system.SetHookObjects(4, "Beam", pair->a, "Weapon", pair->b, "Self",pair->a, "Object", pair->b);
+			Script_system.SetHookObjects(4, "Self", pair->a, "Object", pair->b, "Beam", pair->a, "Weapon", pair->b);
 			Script_system.RunCondition(CHA_COLLIDEWEAPON, pair->a);
+			Script_system.RemHookVars(4, "Self", "Object", "Beam", "Weapon");
 		}
 		if((b_override && !a_override) || (!b_override && !a_override))
 		{
 			//Should be reversed
-			Script_system.SetHookObjects(4, "Weapon", pair->b, "Beam", pair->a, "Self",pair->b, "Object", pair->a);
+			Script_system.SetHookObjects(4, "Self", pair->b, "Object", pair->a, "Beam", pair->a, "Weapon", pair->b);
 			Script_system.RunCondition(CHA_COLLIDEBEAM, pair->b);
+			Script_system.RemHookVars(4, "Self", "Object", "Beam", "Weapon");
 		}
-
-		Script_system.RemHookVars(4, "Weapon", "Beam", "Self","Object");
-
 	}
 
 	// reset timestamp to timeout immediately
@@ -2807,11 +2810,13 @@ int beam_collide_debris(obj_pair *pair)
 	// if we got a hit
 	if(test_collide.num_hits){
 
-		Script_system.SetHookObjects(4, "Beam", pair->a, "Debris", pair->b, "Self", pair->a, "Object", pair->b);
+		Script_system.SetHookObjects(4, "Self", pair->a, "Object", pair->b, "Beam", pair->a, "Debris", pair->b);
 		bool weapon_override = Script_system.IsConditionOverride(CHA_COLLIDEDEBRIS, pair->a);
+		Script_system.RemHookVars(4, "Self", "Object", "Beam", "Debris");
 
-		Script_system.SetHookObjects(2, "Self",pair->b, "Object",  pair->a);
+		Script_system.SetHookObjects(4, "Self", pair->b, "Object",  pair->a, "Beam", pair->a, "Debris", pair->b);
 		bool debris_override = Script_system.IsConditionOverride(CHA_COLLIDEBEAM, pair->b);
+		Script_system.RemHookVars(4, "Self", "Object", "Beam", "Debris");
 
 		if(!weapon_override && !debris_override)
 		{
@@ -2819,16 +2824,15 @@ int beam_collide_debris(obj_pair *pair)
 			beam_add_collision(b, pair->b, &test_collide);
 		}
 
-		Script_system.SetHookObjects(2, "Self", pair->a, "Object", pair->b);
+		Script_system.SetHookObjects(4, "Self", pair->a, "Object", pair->b, "Beam", pair->a, "Debris", pair->b);
 		if(!(debris_override && !weapon_override))
 			Script_system.RunCondition(CHA_COLLIDEDEBRIS, pair->a);
+		Script_system.RemHookVars(4, "Self", "Object", "Beam", "Debris");
 
-		Script_system.SetHookObjects(2, "Self", pair->b, "Object", pair->a);
+		Script_system.SetHookObjects(4, "Self", pair->b, "Object", pair->a, "Beam", pair->a, "Debris", pair->b);
 		if((debris_override && !weapon_override) || (!debris_override && !weapon_override))
 			Script_system.RunCondition(CHA_COLLIDEBEAM, pair->b);
-
-		Script_system.RemHookVars(4, "Beam", "Debris", "Self","Object");
-
+		Script_system.RemHookVars(4, "Self", "Object", "Beam", "Debris");
 	}
 
 	// reset timestamp to timeout immediately


### PR DESCRIPTION
In this block of code, the conditions were checked with a set of four hook variables but then subsequently run with only two.  This adds all four previously used variables.  More importantly, it adds the hook variables with expected and user-friendly names, since 'self' and 'object' are not necessarily intuitive.

This should fix #1996.