### PR TITLE
Unify Cfile blocks and CFILE handles

### DIFF
--- a/code/cfile/cfile.h
+++ b/code/cfile/cfile.h
@@ -26,10 +26,8 @@
 #define CF_SEEK_CUR (1)
 #define CF_SEEK_END (2)
 
-typedef struct CFILE {
-	int		id;			// Index into cfile.cpp specific structure
-	int		version;		// version of this file
-} CFILE;
+// Opaque file handle
+struct CFILE;
 
 // extra info that can be returned when getting a file listing
 typedef struct {
@@ -304,14 +302,14 @@ int cfile_flush_dir(int type);
 // These are all high level, built up from
 // cfread.
 char *cfgets(char *buf, size_t n, CFILE *fp);
-char cfread_char(CFILE *file, int ver = 0, char deflt = 0);
-ubyte cfread_ubyte(CFILE *file, int ver = 0, ubyte deflt = 0);
-short cfread_short(CFILE *file, int ver = 0, short deflt = 0);
-ushort cfread_ushort(CFILE *file, int ver = 0, ushort deflt = 0);
-int cfread_int(CFILE *file, int ver = 0, int deflt = 0);
-uint cfread_uint(CFILE *file, int ver = 0, uint deflt = 0);
-float cfread_float(CFILE *file, int ver = 0, float deflt = 0.0f);
-void cfread_vector(vec3d *vec, CFILE *file, int ver = 0, vec3d *deflt = NULL);
+char cfread_char(CFILE* file, char deflt = 0);
+ubyte cfread_ubyte(CFILE* file, ubyte deflt = 0);
+short cfread_short(CFILE* file, short deflt = 0);
+ushort cfread_ushort(CFILE* file, ushort deflt = 0);
+int cfread_int(CFILE* file, int deflt = 0);
+uint cfread_uint(CFILE* file, uint deflt = 0);
+float cfread_float(CFILE* file, float deflt = 0.0f);
+void cfread_vector(vec3d* vec, CFILE* file, vec3d* deflt = nullptr);
 
 // Reads variable length, null-termined string.   Will only read up
 // to n characters.

--- a/code/cfile/cfilearchive.h
+++ b/code/cfile/cfilearchive.h
@@ -22,30 +22,30 @@
 #define CFILE_BLOCK_UNUSED		0
 #define CFILE_BLOCK_USED		1
 
-typedef struct Cfile_block {
-	int		type;				// CFILE_BLOCK_UNUSED, CFILE_BLOCK_USED
-	int		dir_type;		// directory location
-	FILE		*fp;				// File pointer if opening an individual file
-	const void	*data;			// Pointer for memory-mapped file access.  NULL if not mem-mapped.
-	bool 	mem_mapped;		// Flag for memory mapped files (if data is not null and this is false it means that it's an embedded file)
+struct CFILE {
+	int type = CFILE_BLOCK_UNUSED;                // CFILE_BLOCK_UNUSED, CFILE_BLOCK_USED
+	int dir_type;        // directory location
+	FILE* fp;                // File pointer if opening an individual file
+	const void* data;            // Pointer for memory-mapped file access.  NULL if not mem-mapped.
+	bool mem_mapped; // Flag for memory mapped files (if data is not null and this is false it means that it's an embedded file)
 #ifdef _WIN32
 	HANDLE	hInFile;			// Handle from CreateFile()
 	HANDLE	hMapFile;		// Handle from CreateFileMapping()
 #else
-	size_t	data_length;	// length of data for mmap
+	size_t data_length;    // length of data for mmap
 #endif
-	size_t	lib_offset;
-	size_t	raw_position;
-	size_t	size;				// for packed files
+	size_t lib_offset;
+	size_t raw_position;
+	size_t size;                // for packed files
 
-	size_t	max_read_len;	// max read offset, for special error handling
-	
+	size_t max_read_len;    // max read offset, for special error handling
+
 	const char* source_file;
 	int line_num;
-} Cfile_block;
+};
 
 #define MAX_CFILE_BLOCKS	64
-extern Cfile_block Cfile_block_list[MAX_CFILE_BLOCKS];
+extern std::array<CFILE, MAX_CFILE_BLOCKS> Cfile_block_list;
 
 // Called once to setup the low-level reading code.
 void cf_init_lowlevel_read_code( CFILE * cfile, size_t lib_offset, size_t size, size_t pos );

--- a/code/prefix_header.h
+++ b/code/prefix_header.h
@@ -36,4 +36,5 @@
 #include <fstream>
 #include <random>
 #include <future>
+#include <array>
 


### PR DESCRIPTION
The only thing a CFILE contained was a version field which isn't used
anymore so that could be removed which basically meant that CFILE was
just an indirection to a Cfile_block which I then just renamed to CFILE.
The CFILE type is an opaque handle now since the contents are not
relevant to a user of Cfile.