### PR TITLE
cancel mission load when a syntax error is found

### DIFF
--- a/code/mission/missionload.cpp
+++ b/code/mission/missionload.cpp
@@ -97,9 +97,8 @@ bool mission_is_ignored(const char *filename)
 // Mission_load takes no parameters.
 // It sets the following global variables
 //   Game_current_mission_filename
-
-// returns -1 if failed, 0 if successful
-int mission_load(const char* filename_ext)
+// returns true successful, false if failed
+bool mission_load(const char* filename_ext)
 {
 	TRACE_SCOPE(tracing::LoadMissionLoad);
 
@@ -120,7 +119,7 @@ int mission_load(const char* filename_ext)
 
 	if (mission_is_ignored(filename)) {
 		mprintf(("MISSION LOAD: Tried to load an ignored mission!  Aborting..."));
-		return -1;
+		return false;
 	}
 
 	strcat_s(filename, FS_MISSION_FILE_EXT);
@@ -131,8 +130,8 @@ int mission_load(const char* filename_ext)
 	// to choose the type of ship that he is to fly
 	// return value of 0 indicates success, other is failure.
 
-	if ( parse_main(filename) )
-		return -1;
+	if ( !parse_main(filename) )
+		return false;
 
 	if (Select_default_ship) {
 		int ret;
@@ -143,7 +142,8 @@ int mission_load(const char* filename_ext)
 	ml_update_recent_missions(filename_ext);  // update recently played missions list (save the csg later)
 
 	init_hud();
-	return 0;
+
+	return true;
 }
 
 //====================================

--- a/code/mission/missionload.h
+++ b/code/mission/missionload.h
@@ -27,7 +27,7 @@ extern SCP_vector<SCP_string> Ignored_missions;
 // It sets the following global variables:
 // Game_current_mission_filename
 
-int mission_load(const char* filename_ext);
+bool mission_load(const char* filename_ext);
 
 bool mission_is_ignored(const char *filename);
 

--- a/code/mission/missionparse.h
+++ b/code/mission/missionparse.h
@@ -479,7 +479,7 @@ extern p_object *Arriving_support_ship;
 extern char Neb2_texture_name[MAX_FILENAME_LEN];
 
 
-int parse_main(const char *mission_name, int flags = 0);
+bool parse_main(const char *mission_name, int flags = 0);
 p_object *mission_parse_get_arrival_ship(ushort net_signature);
 p_object *mission_parse_get_arrival_ship(const char *name);
 p_object *mission_parse_get_parse_object(ushort net_signature);

--- a/code/scripting/api/libs/mission.cpp
+++ b/code/scripting/api/libs/mission.cpp
@@ -995,7 +995,7 @@ ADE_FUNC(loadMission, l_Mission, "Mission name", "Loads a mission", "boolean", "
 	get_mission_info(s, &The_mission, false);
 	game_level_init();
 
-	if(mission_load(s) == -1)
+	if(!mission_load(s))
 		return ADE_RETURN_FALSE;
 
 	game_post_level_init();

--- a/fred2/freddoc.cpp
+++ b/fred2/freddoc.cpp
@@ -100,9 +100,10 @@ void CFREDDoc::AssertValid() const {
 }
 #endif //_DEBUG
 
-int CFREDDoc::autoload() {
+bool CFREDDoc::autoload() {
 	char name[256], backup_name[256];
-	int i, r;
+	int i;
+	bool r;
 	FILE *fp;
 
 	cf_create_default_path_string(name, sizeof(name) - 1, CF_TYPE_MISSIONS);
@@ -217,7 +218,7 @@ void CFREDDoc::editor_init_mission() {
 	recreate_dialogs();
 }
 
-int CFREDDoc::load_mission(char *pathname, int flags) {
+bool CFREDDoc::load_mission(char *pathname, int flags) {
 	// make sure we're in the correct working directory!!!!!!
 	chdir(Fred_base_dir);
 
@@ -234,7 +235,7 @@ int CFREDDoc::load_mission(char *pathname, int flags) {
 
 	clear_mission();
 
-	if (parse_main(pathname, flags)) {
+	if (!parse_main(pathname, flags)) {
 		if (flags & MPF_IMPORT_FSM) {
 			sprintf(name, "Unable to import the file \"%s\".", pathname);
 			Fred_view_wnd->MessageBox(name);
@@ -243,7 +244,7 @@ int CFREDDoc::load_mission(char *pathname, int flags) {
 			Fred_view_wnd->MessageBox(name);
 		}
 		create_new_mission();
-		return -1;
+		return false;
 	}
 
 	if ((Num_unknown_ship_classes > 0) || (Num_unknown_weapon_classes > 0) || (Num_unknown_loadout_classes > 0)) {
@@ -360,7 +361,7 @@ int CFREDDoc::load_mission(char *pathname, int flags) {
 
 	recreate_dialogs();
 
-	return 0;
+	return true;
 }
 
 void CFREDDoc::OnDuplicate() {
@@ -514,7 +515,7 @@ void CFREDDoc::OnFileImportFSM() {
 		strcpy_s(fs1_path, fs1_path_mfc);
 
 		// load mission into memory
-		if (load_mission(fs1_path, MPF_IMPORT_FSM))
+		if (!load_mission(fs1_path, MPF_IMPORT_FSM))
 			continue;
 
 		// get filename
@@ -597,7 +598,7 @@ BOOL CFREDDoc::OnOpenDocument(LPCTSTR pathname) {
 	//		unlink(name);
 	//	}
 
-	if (load_mission(mission_pathname)) {
+	if (!load_mission(mission_pathname)) {
 		*Mission_filename = 0;
 		return FALSE;
 	}
@@ -653,7 +654,7 @@ BOOL CFREDDoc::OnSaveDocument(LPCTSTR pathname) {
 	}
 
 	SetModifiedFlag(FALSE);
-	if (load_mission((char *) pathname))
+	if (!load_mission((char *) pathname))
 		Error(LOCATION, "Failed attempting to reload mission after saving.  Report this bug now!");
 
 	if (Briefing_dialog) {

--- a/fred2/freddoc.h
+++ b/fred2/freddoc.h
@@ -38,7 +38,7 @@ public:
 	 *
 	 * @returns The file index of the loaded Undo item
 	 */
-	int autoload();
+	bool autoload();
 
 	/**
 	 * @brief Read in a new mission file from disk
@@ -46,10 +46,9 @@ public:
 	 * @param[in] pathname The full filepath name of the file to open
 	 * @param[in] flags
 	 *
-	 * @returns File index of the loaded file, or
-	 * @returns 0 if unable to load
+	 * @returns true on success, false on failure
 	 */
-	int load_mission(char *pathname, int flags = 0);
+	bool load_mission(char *pathname, int flags = 0);
 
 	/**
 	 * @brief Pushes an Undo item onto the stack

--- a/fred2/fredstubs.cpp
+++ b/fred2/fredstubs.cpp
@@ -178,7 +178,7 @@ void game_set_view_clip(){}
 int Warpout_forced = 0;
 float Warpout_time;
 vec3d Dead_player_last_vel;
-int game_start_mission(){return 0;}
+bool game_start_mission() {return false;}
 int Game_weapons_tbl_valid;
 int Game_ships_tbl_valid;
 void game_level_close(){}

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -1399,7 +1399,7 @@ void game_post_level_init()
 /**
  * Tells the server to load the mission and initialize structures
  */
-int game_start_mission()
+bool game_start_mission()
 {
 	mprintf(( "=================== STARTING LEVEL LOAD ==================\n" ));
 
@@ -1424,7 +1424,7 @@ int game_start_mission()
 
 	game_busy( NOX("** starting mission_load() **") );
 	load_mission_load = (uint) time(NULL);
-	if (mission_load(Game_current_mission_filename)) {
+	if ( !mission_load(Game_current_mission_filename) ) {
 		if ( !(Game_mode & GM_MULTIPLAYER) ) {
 			popup(PF_BODY_BIG | PF_USE_AFFIRMATIVE_ICON, 1, POPUP_OK, XSTR( "Attempt to load the mission failed", 169));
 			gameseq_post_event(GS_EVENT_MAIN_MENU);
@@ -1438,7 +1438,7 @@ int game_start_mission()
 
 		game_level_close();
 
-		return 0;
+		return false;
 	}
 	load_mission_load = (uint) (time(NULL) - load_mission_load);
 
@@ -1463,7 +1463,7 @@ int game_start_mission()
 	int e1 __UNUSED = timer_get_milliseconds();
 
 	mprintf(("Level load took %f seconds.\n", (e1 - s1) / 1000.0f ));
-	return 1;
+	return true;
 }
 
 int Interface_framerate = 0;

--- a/freespace2/freespace.h
+++ b/freespace2/freespace.h
@@ -93,7 +93,7 @@ typedef struct fs_builtin_mission {
 // mission management -------------------------------------------------
 
 // loads in the currently selected mission
-int game_start_mission();		
+bool game_start_mission();		
 
 // shutdown a mission
 void game_level_close();

--- a/qtfred/src/fredstubs.cpp
+++ b/qtfred/src/fredstubs.cpp
@@ -182,7 +182,7 @@ void game_set_view_clip(){}
 int Warpout_forced = 0;
 float Warpout_time;
 vec3d Dead_player_last_vel;
-int game_start_mission(){return 0;}
+bool game_start_mission() {return false;}
 int Game_weapons_tbl_valid;
 int Game_ships_tbl_valid;
 void game_level_close(){}

--- a/test/src/test_stubs.cpp
+++ b/test/src/test_stubs.cpp
@@ -186,7 +186,7 @@ void game_set_view_clip(){}
 int Warpout_forced = 0;
 float Warpout_time;
 vec3d Dead_player_last_vel;
-int game_start_mission(){return 0;}
+bool game_start_mission() {return false;}
 int Game_weapons_tbl_valid;
 int Game_ships_tbl_valid;
 void game_level_close(){}


### PR DESCRIPTION
Previously, when a sexp syntax error was encountered, the engine would display an Error dialog which would usually result in aborting the entire game session.  This PR changes things so that a Warning dialog is displayed and the engine stops loading the mission.

This addresses one of the complaints in #1995.