### PR TITLE
Add `Chase View Only` Option for HUD Gauges

### DIFF
--- a/code/hud/hud.cpp
+++ b/code/hud/hud.cpp
@@ -247,7 +247,7 @@ static int Damage_flash_timer;
 HudGauge::HudGauge():
 base_w(0), base_h(0), gauge_config(-1), font_num(font::FONT1), lock_color(false), sexp_lock_color(false), reticle_follow(false),
 active(false), off_by_default(false), sexp_override(false), pop_up(false), disabled_views(0), custom_gauge(false),
-texture_target(-1), canvas_w(-1), canvas_h(-1), target_w(-1), target_h(-1)
+texture_target(-1), canvas_w(-1), canvas_h(-1), target_w(-1), target_h(-1), only_render_in_chase_view(false)
 {
 	position[0] = 0;
 	position[1] = 0;
@@ -272,7 +272,7 @@ HudGauge::HudGauge(int _gauge_object, int _gauge_config, bool _slew, bool _messa
 base_w(0), base_h(0), gauge_config(_gauge_config), gauge_object(_gauge_object), font_num(font::FONT1), lock_color(false), sexp_lock_color(false),
 reticle_follow(_slew), active(false), off_by_default(false), sexp_override(false), pop_up(false), message_gauge(_message),
 disabled_views(_disabled_views), custom_gauge(false), textoffset_x(0), textoffset_y(0), texture_target(-1),
-canvas_w(-1), canvas_h(-1), target_w(-1), target_h(-1)
+canvas_w(-1), canvas_h(-1), target_w(-1), target_h(-1), only_render_in_chase_view(false)
 {
 	Assert(gauge_config <= NUM_HUD_GAUGES && gauge_config >= 0);
 
@@ -308,7 +308,7 @@ HudGauge::HudGauge(int _gauge_config, bool _slew, int r, int g, int b, char* _cu
 base_w(0), base_h(0), gauge_config(_gauge_config), gauge_object(HUD_OBJECT_CUSTOM), font_num(font::FONT1), lock_color(false), sexp_lock_color(false),
 reticle_follow(_slew), active(false), off_by_default(false), sexp_override(false), pop_up(false), message_gauge(false),
 disabled_views(VM_EXTERNAL | VM_DEAD_VIEW | VM_WARP_CHASE | VM_PADLOCK_ANY), custom_gauge(true), textoffset_x(txtoffset_x),
- textoffset_y(txtoffset_y), texture_target(-1), canvas_w(-1), canvas_h(-1), target_w(-1), target_h(-1)
+textoffset_y(txtoffset_y), texture_target(-1), canvas_w(-1), canvas_h(-1), target_w(-1), target_h(-1), only_render_in_chase_view(false)
 {
 	position[0] = 0;
 	position[1] = 0;
@@ -544,6 +544,11 @@ void HudGauge::updateActive(bool show)
 void HudGauge::initRenderStatus(bool do_render)
 {
 	off_by_default = !do_render;
+}
+
+void HudGauge::initChase_view_only(bool chase_view_only) 
+{ 
+	only_render_in_chase_view = chase_view_only; 
 }
 
 bool HudGauge::isOffbyDefault()
@@ -1079,6 +1084,10 @@ bool HudGauge::canRender()
 	}
 
 	if ((Viewer_mode & disabled_views)) {
+		return false;
+	}
+
+	if ((Viewer_mode & (VM_CHASE)) == 0 && only_render_in_chase_view) {
 		return false;
 	}
 

--- a/code/hud/hud.cpp
+++ b/code/hud/hud.cpp
@@ -246,8 +246,8 @@ static int Damage_flash_timer;
 
 HudGauge::HudGauge():
 base_w(0), base_h(0), gauge_config(-1), font_num(font::FONT1), lock_color(false), sexp_lock_color(false), reticle_follow(false),
-active(false), off_by_default(false), sexp_override(false), pop_up(false), disabled_views(0), custom_gauge(false),
-texture_target(-1), canvas_w(-1), canvas_h(-1), target_w(-1), target_h(-1), only_render_in_chase_view(false)
+active(false), off_by_default(false), sexp_override(false), pop_up(false), disabled_views(0), only_render_in_chase_view(false), custom_gauge(false),
+texture_target(-1), canvas_w(-1), canvas_h(-1), target_w(-1), target_h(-1)
 {
 	position[0] = 0;
 	position[1] = 0;
@@ -271,8 +271,8 @@ texture_target(-1), canvas_w(-1), canvas_h(-1), target_w(-1), target_h(-1), only
 HudGauge::HudGauge(int _gauge_object, int _gauge_config, bool _slew, bool _message, int _disabled_views, int r, int g, int b):
 base_w(0), base_h(0), gauge_config(_gauge_config), gauge_object(_gauge_object), font_num(font::FONT1), lock_color(false), sexp_lock_color(false),
 reticle_follow(_slew), active(false), off_by_default(false), sexp_override(false), pop_up(false), message_gauge(_message),
-disabled_views(_disabled_views), custom_gauge(false), textoffset_x(0), textoffset_y(0), texture_target(-1),
-canvas_w(-1), canvas_h(-1), target_w(-1), target_h(-1), only_render_in_chase_view(false)
+disabled_views(_disabled_views), only_render_in_chase_view(false), custom_gauge(false), textoffset_x(0), textoffset_y(0), texture_target(-1),
+canvas_w(-1), canvas_h(-1), target_w(-1), target_h(-1)
 {
 	Assert(gauge_config <= NUM_HUD_GAUGES && gauge_config >= 0);
 
@@ -307,8 +307,8 @@ canvas_w(-1), canvas_h(-1), target_w(-1), target_h(-1), only_render_in_chase_vie
 HudGauge::HudGauge(int _gauge_config, bool _slew, int r, int g, int b, char* _custom_name, char* _custom_text, char* frame_fname, int txtoffset_x, int txtoffset_y):
 base_w(0), base_h(0), gauge_config(_gauge_config), gauge_object(HUD_OBJECT_CUSTOM), font_num(font::FONT1), lock_color(false), sexp_lock_color(false),
 reticle_follow(_slew), active(false), off_by_default(false), sexp_override(false), pop_up(false), message_gauge(false),
-disabled_views(VM_EXTERNAL | VM_DEAD_VIEW | VM_WARP_CHASE | VM_PADLOCK_ANY), custom_gauge(true), textoffset_x(txtoffset_x),
-textoffset_y(txtoffset_y), texture_target(-1), canvas_w(-1), canvas_h(-1), target_w(-1), target_h(-1), only_render_in_chase_view(false)
+disabled_views(VM_EXTERNAL | VM_DEAD_VIEW | VM_WARP_CHASE | VM_PADLOCK_ANY), only_render_in_chase_view(false), custom_gauge(true), textoffset_x(txtoffset_x),
+textoffset_y(txtoffset_y), texture_target(-1), canvas_w(-1), canvas_h(-1), target_w(-1), target_h(-1)
 {
 	position[0] = 0;
 	position[1] = 0;

--- a/code/hud/hud.h
+++ b/code/hud/hud.h
@@ -223,6 +223,7 @@ protected:
 	int flash_duration;
 	int flash_next;
 	bool flash_status;
+	bool only_render_in_chase_view;
 
 	// custom gauge specific stuff
 	bool custom_gauge;
@@ -268,7 +269,7 @@ public:
 	void updateActive(bool show);
 	void updatePopUp(bool pop_up_flag);
 	void updateSexpOverride(bool sexp);
-
+	void initChase_view_only(bool chase_view_only);
 
 	// SEXP interfacing functions
 	// For flashing gauges in training missions

--- a/code/hud/hudparse.h
+++ b/code/hud/hudparse.h
@@ -41,7 +41,7 @@ typedef struct gauge_settings {
 	bool slew;
 	bool chase_view_only;
 
-	gauge_settings(): font_num(Hud_font), scale_gauge(Scale_retail_gauges), ship_idx(nullptr), use_clr(nullptr), use_coords(false), set_position(true), set_colour(true), slew(false), chase_view_only(Chase_view_only_ex) {
+	gauge_settings() : font_num(Hud_font), scale_gauge(Scale_retail_gauges), ship_idx(nullptr), use_clr(nullptr), use_coords(false), set_position(true), set_colour(true), slew(false), chase_view_only(Chase_view_only_ex) {
 		base_res[0] = -1;
 		base_res[1] = -1;
 		memcpy(force_scaling_above_res, Force_scaling_above_res_global, sizeof(force_scaling_above_res));

--- a/code/hud/hudparse.h
+++ b/code/hud/hudparse.h
@@ -23,6 +23,7 @@ extern int Hud_reticle_style;
 extern bool Scale_retail_gauges;
 extern int Force_scaling_above_res_global[2];
 extern int Hud_font;
+extern bool Chase_view_only_ex;
 
 typedef struct gauge_settings {
 	int base_res[2];
@@ -38,8 +39,9 @@ typedef struct gauge_settings {
 	bool set_position;
 	bool set_colour;
 	bool slew;
+	bool chase_view_only;
 
-	gauge_settings() : font_num(Hud_font), scale_gauge(Scale_retail_gauges), ship_idx(nullptr), use_clr(nullptr), use_coords(false), set_position(true), set_colour(true), slew(false) {
+	gauge_settings(): font_num(Hud_font), scale_gauge(Scale_retail_gauges), ship_idx(nullptr), use_clr(nullptr), use_coords(false), set_position(true), set_colour(true), slew(false), chase_view_only(Chase_view_only_ex) {
 		base_res[0] = -1;
 		base_res[1] = -1;
 		memcpy(force_scaling_above_res, Force_scaling_above_res_global, sizeof(force_scaling_above_res));


### PR DESCRIPTION
Currently, the player is unable to see a RTT hud gauge if in chase view. This adds an option in the `hud_gauges.tbl` that tells the game whether to draw a gauge based on if chase view is the active view. So for example, a modder using RTT mapped gauges can now make a HUD that displays on the interior of the ship (ie RTT with the cockpit model) and a HUD that displays when the player switches to chase view. If merged I will update the wiki for usage in `hud_gauges.tbl`.