### PR TITLE
Fixes bug with lua font handle

### DIFF
--- a/code/scripting/api/libs/graphics.cpp
+++ b/code/scripting/api/libs/graphics.cpp
@@ -103,7 +103,7 @@ ADE_INDEXER(l_Graphics_Fonts, "number Index/string Filename", "Array of loaded f
 
 		if (realIdx < 0 || realIdx >= font::FontManager::numberOfFonts())
 		{
-			LuaError(L, "Invalid font index %d specified, must be between 1 and %d!", index, font::FontManager::numberOfFonts());
+			return ade_set_error(L, "o", l_Font.Set(font_h()));
 		}
 
 		return ade_set_args(L, "o", l_Font.Set(font_h(font::FontManager::getFont(index - 1))));


### PR DESCRIPTION
This PR fixes a bug where an invalid lua font handle would not be properly returned as invalid. An invalid handle is returned properly if the font name is invalid, but not if the index is invalid. This PR fixes that.