### PR TITLE
Add new HUD gauge type for scripted gauges

### DIFF
--- a/code/hud/hud.h
+++ b/code/hud/hud.h
@@ -110,6 +110,7 @@ extern int Hud_max_targeting_range;
 
 void HUD_init_colors();
 void HUD_init();
+void hud_scripting_close(lua_State*);
 void hud_close();
 void hud_level_close();
 void hud_update_frame(float frametime);		// updates hud systems not dependant on rendering

--- a/code/hud/hudparse.cpp
+++ b/code/hud/hudparse.cpp
@@ -19,6 +19,7 @@
 #include "hud/hudmessage.h"
 #include "hud/hudparse.h" //Duh.
 #include "hud/hudreticle.h"
+#include "hud/hudscripting.h"
 #include "hud/hudshield.h"
 #include "hud/hudsquadmsg.h"
 #include "hud/hudtarget.h"
@@ -898,6 +899,9 @@ int parse_gauge_type()
 
 	if ( optional_string("+Secondary Weapons:") )
 		return HUD_OBJECT_SECONDARY_WEAPONS;
+
+	if ( optional_string("+Scripted Gauge:") )
+		return HUD_OBJECT_SCRIPTING;
 	
 	return -1;
 }
@@ -1077,6 +1081,9 @@ void load_gauge(int gauge, gauge_settings* settings)
 		break;
 	case HUD_OBJECT_SECONDARY_WEAPONS:
 		load_gauge_secondary_weapons(settings);
+		break;
+	case HUD_OBJECT_SCRIPTING:
+		load_gauge_scripting(settings);
 		break;
 	default:
 		// It's either -1, indicating we're ignoring a parse error, or it's a coding error.
@@ -5189,6 +5196,18 @@ void load_gauge_secondary_weapons(gauge_settings* settings)
 	hud_gauge->initSecondaryReloadOffsetX(reload_x);
 	hud_gauge->initSecondaryUnlinkedOffsetX(unlink_x);
 	hud_gauge->initLinkIcon();
+
+	gauge_assign_common(settings, std::move(hud_gauge));
+}
+
+void load_gauge_scripting(gauge_settings* settings) {
+	auto hud_gauge = gauge_load_common<HudGaugeScripting>(settings);
+
+	required_string("Name:");
+	SCP_string name;
+	stuff_string(name, F_NAME);
+
+	hud_gauge->initName(name);
 
 	gauge_assign_common(settings, std::move(hud_gauge));
 }

--- a/code/hud/hudparse.h
+++ b/code/hud/hudparse.h
@@ -230,4 +230,7 @@ void load_gauge_primary_weapons(gauge_settings* settings);
 #define HUD_OBJECT_SECONDARY_WEAPONS	55
 void load_gauge_secondary_weapons(gauge_settings* settings);
 
+#define HUD_OBJECT_SCRIPTING 56
+void load_gauge_scripting(gauge_settings* settings);
+
 #endif // _HUDPARSE_H

--- a/code/hud/hudscripting.cpp
+++ b/code/hud/hudscripting.cpp
@@ -1,0 +1,47 @@
+//
+//
+
+#include "hud/hudscripting.h"
+
+#include "parse/parselo.h"
+
+#include "scripting/api/objs/hudgauge.h"
+
+HudGaugeScripting::HudGaugeScripting() :
+	HudGauge(HUD_OBJECT_SCRIPTING,
+	         HUD_CENTER_RETICLE,
+	         true,
+	         false,
+	         (VM_EXTERNAL | VM_DEAD_VIEW | VM_WARP_CHASE | VM_PADLOCK_ANY | VM_TOPDOWN | VM_OTHER_SHIP),
+	         255,
+	         255,
+	         255) {
+}
+
+void HudGaugeScripting::render(float /*frametime*/) {
+	using namespace scripting::api;
+
+	if (!_renderFunction.isValid()) {
+		return;
+	}
+
+	_renderFunction.call({ luacpp::LuaValue::createValue(_renderFunction.getLuaState(),
+	                                                     l_HudGaugeDrawFuncs.Set(this)) });
+}
+
+void HudGaugeScripting::initName(SCP_string name) {
+	if (name.size() > NAME_LENGTH - 1) {
+		error_display(0,
+		              "Name \"%s\" is too long. May not be longer than %d! Name will be truncated",
+		              name.c_str(),
+		              NAME_LENGTH - 1);
+		name.resize(NAME_LENGTH - 1);
+	}
+	strcpy(custom_name, name.c_str());
+}
+const luacpp::LuaFunction& HudGaugeScripting::getRenderFunction() const {
+	return _renderFunction;
+}
+void HudGaugeScripting::setRenderFunction(const luacpp::LuaFunction& renderFunction) {
+	_renderFunction = renderFunction;
+}

--- a/code/hud/hudscripting.h
+++ b/code/hud/hudscripting.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "globalincs/pstypes.h"
+#include "hud/hud.h"
+#include "scripting/lua/LuaFunction.h"
+
+class HudGaugeScripting: public HudGauge {
+	luacpp::LuaFunction _renderFunction;
+  public:
+	HudGaugeScripting();
+
+	void render(float frametime) override;
+
+	void initName(SCP_string name);
+
+	const luacpp::LuaFunction& getRenderFunction() const;
+	void setRenderFunction(const luacpp::LuaFunction& renderFunction);
+};

--- a/code/scripting/ade_args.cpp
+++ b/code/scripting/ade_args.cpp
@@ -108,15 +108,25 @@ void set_single_arg(lua_State* L, char fmt, const char* s)
 	// WMC - Isn't working with HookVar for some strange reason
 	lua_pushstring(L, s);
 }
-void set_single_arg(lua_State*, char fmt, luacpp::LuaTable* table)
+
+void set_single_arg(lua_State* L, char fmt, luacpp::LuaTable* table)
+{
+	set_single_arg(L, fmt, *table);
+}
+void set_single_arg(lua_State*, char fmt, const luacpp::LuaTable& table)
 {
 	Assertion(fmt == 't', "Invalid format character '%c' for table type!", fmt);
-	table->pushValue();
+	table.pushValue();
 }
-void set_single_arg(lua_State*, char fmt, luacpp::LuaFunction* func)
+
+void set_single_arg(lua_State* L, char fmt, luacpp::LuaFunction* func)
+{
+	set_single_arg(L, fmt, *func);
+}
+void set_single_arg(lua_State*, char fmt, const luacpp::LuaFunction& func)
 {
 	Assertion(fmt == 'u', "Invalid format character '%c' for function type!", fmt);
-	func->pushValue();
+	func.pushValue();
 }
 
 } // namespace internal

--- a/code/scripting/ade_args.h
+++ b/code/scripting/ade_args.h
@@ -299,7 +299,10 @@ void set_single_arg(lua_State* L, char fmt, ade_odata_setter<T>&& od)
 	luacpp::convert::pushValue(L, std::forward<ade_odata_setter<T>>(od));
 }
 void set_single_arg(lua_State* /*L*/, char fmt, luacpp::LuaTable* table);
+void set_single_arg(lua_State* /*L*/, char fmt, const luacpp::LuaTable& table);
+
 void set_single_arg(lua_State* /*L*/, char fmt, luacpp::LuaFunction* func);
+void set_single_arg(lua_State* /*L*/, char fmt, const luacpp::LuaFunction& func);
 
 // This is not a template function so we can put the implementation in a source file
 inline void set_args_actual(lua_State* /*L*/, set_args_state& /*state*/, const char* fmt)

--- a/code/scripting/api/objs/hudgauge.cpp
+++ b/code/scripting/api/objs/hudgauge.cpp
@@ -2,6 +2,7 @@
 //
 
 #include "hudgauge.h"
+#include "hud/hudscripting.h"
 
 namespace scripting {
 namespace api {
@@ -40,6 +41,59 @@ ADE_VIRTVAR(Text, l_HudGauge, "string", "Custom HUD Gauge text", "string", "Cust
 	return ade_set_args(L, "s", gauge->getCustomGaugeText());
 }
 
+ADE_VIRTVAR(RenderFunction,
+            l_HudGauge,
+            "function (HudGaugeDrawFunctions gauge_handle)",
+            "For scripted HUD gauges, the function that will be called for rendering the HUD gauge",
+            "function (HudGaugeDrawFunctions gauge_handle)",
+            "Render function or nil if no action is set or handle is invalid") {
+	HudGauge* gauge;
+	luacpp::LuaFunction func;
+
+	if (!ade_get_args(L, "o|u", l_HudGauge.Get(&gauge), &func)) {
+		return ADE_RETURN_NIL;
+	}
+
+	if (gauge->getObjectType() != HUD_OBJECT_SCRIPTING) {
+		return ADE_RETURN_NIL;
+	}
+
+	auto scriptedGauge = static_cast<HudGaugeScripting*>(gauge);
+
+	if (ADE_SETTING_VAR && func.isValid()) {
+		scriptedGauge->setRenderFunction(func);
+	}
+
+	return ade_set_args(L, "u", scriptedGauge->getRenderFunction());
+}
+
+ADE_OBJ(l_HudGaugeDrawFuncs,
+        HudGauge*,
+        "HudGaugeDrawFunctions",
+        "Handle to the rendering functions used for HUD gauges. Do not keep a reference to this since these are only useful inside the rendering callback of a HUD gauge.");
+
+ADE_FUNC(drawString,
+         l_HudGaugeDrawFuncs,
+         "number x, number y, string text",
+         "Draws a string in the context of the HUD gauge.",
+         "boolean",
+         "true on success, false otherwise") {
+	HudGauge* gauge;
+	float x;
+	float y;
+	const char* text;
+
+	if (!ade_get_args(L, "offs", l_HudGaugeDrawFuncs.Get(&gauge), &x, &y, &text)) {
+		return ADE_RETURN_FALSE;
+	}
+
+	int gauge_x, gauge_y;
+	gauge->getPosition(&gauge_x, &gauge_y);
+
+	gauge->renderString(fl2i(gauge_x + x), fl2i(gauge_y), text);
+
+	return ADE_RETURN_TRUE;
+}
 
 }
 }

--- a/code/scripting/api/objs/hudgauge.h
+++ b/code/scripting/api/objs/hudgauge.h
@@ -10,6 +10,8 @@ namespace api {
 
 DECLARE_ADE_OBJ(l_HudGauge, HudGauge*);
 
+DECLARE_ADE_OBJ(l_HudGaugeDrawFuncs, HudGauge*);
+
 }
 }
 

--- a/code/source_groups.cmake
+++ b/code/source_groups.cmake
@@ -509,6 +509,8 @@ add_file_folder("Hud"
 	hud/hudparse.h
 	hud/hudreticle.cpp
 	hud/hudreticle.h
+	hud/hudscripting.cpp
+	hud/hudscripting.h
 	hud/hudshield.cpp
 	hud/hudshield.h
 	hud/hudsquadmsg.cpp


### PR DESCRIPTION
The new gauge can be accessed by the scripting API with which a function
can be set which will be called when this gauge is rendered. This can be
used for exposing the HUD gauge positioning and RTT options to the
scripting API without a lot of work needed for the script writer.

There is currently only one rendering function implemented since this is
only a proof of concept.