### PR TITLE
New translateable strings for the strings.tbl

### DIFF
--- a/code/controlconfig/controlsconfigcommon.cpp
+++ b/code/controlconfig/controlsconfigcommon.cpp
@@ -504,7 +504,9 @@ char *translate_key(char *key)
 	// both key and joystick button are mapped to this control
 	if ((key_code >= 0 ) && (joy_code >= 0) ) {
 		strcpy_s(text, key_text);
-		strcat_s(text, XSTR( " or ", 1638));
+		strcat_s(text, " ");
+		strcat_s(text, XSTR("or", 1638));
+		strcat_s(text, " ");
 		strcat_s(text, joy_text);
 	}
 	// if we only have one

--- a/code/controlconfig/controlsconfigcommon.cpp
+++ b/code/controlconfig/controlsconfigcommon.cpp
@@ -504,7 +504,7 @@ char *translate_key(char *key)
 	// both key and joystick button are mapped to this control
 	if ((key_code >= 0 ) && (joy_code >= 0) ) {
 		strcpy_s(text, key_text);
-		strcat_s(text, " or ");
+		strcat_s(text, XSTR( " or ", 1638));
 		strcat_s(text, joy_text);
 	}
 	// if we only have one

--- a/code/hud/hud.cpp
+++ b/code/hud/hud.cpp
@@ -3911,7 +3911,7 @@ void HudGaugeSupernova::render(float  /*frametime*/)
 	if (Lcl_pl) {
 		renderPrintf(position[0], position[1], "Wybuch supernowej: %.2f s", time_left);
 	} else {
-		renderPrintf(position[0], position[1], "Supernova Warning: %.2f s", time_left);
+		renderPrintf(position[0], position[1], XSTR( "Supernova Warning: %.2f s", 1639), time_left);
 	}
 }
 

--- a/code/localization/localize.cpp
+++ b/code/localization/localize.cpp
@@ -56,7 +56,7 @@ int Lcl_english = 1;
 // the english version (in the code) to a foreign version (in the table).  Thus, if you
 // add a new string to the code, you must assign it a new index.  Use the number below for
 // that index and increase the number below by one.
-#define XSTR_SIZE	1638
+#define XSTR_SIZE	1641
 
 
 // struct to allow for strings.tbl-determined x offset

--- a/code/menuui/playermenu.cpp
+++ b/code/menuui/playermenu.cpp
@@ -352,7 +352,7 @@ void player_select_do()
 	// Goober5000 - display a popup warning about problems in the mod
 	if ((Global_warning_count > 10 || Global_error_count > 0) && !Startup_warning_dialog_displayed) {
 		char text[512];
-		sprintf(text, "Warning!\n\nThe currently active mod has generated %d warnings and/or errors during program startup.  These could have been caused by anything from incorrectly formated table files to corrupt models.\n\nWhile FreeSpace Open will attempt to compensate for these issues, it cannot guarantee a trouble-free gameplay experience.\n\nPlease contact the authors of the mod for assistance.", Global_warning_count + Global_error_count);
+		sprintf(text, XSTR ("Warning!\n\nThe currently active mod has generated %d warnings and/or errors during program startup.  These could have been caused by anything from incorrectly formated table files to corrupt models.\n\nWhile FreeSpace Open will attempt to compensate for these issues, it cannot guarantee a trouble-free gameplay experience.\n\nPlease contact the authors of the mod for assistance.", 1640), Global_warning_count + Global_error_count);
 		popup(PF_TITLE_BIG | PF_TITLE_RED | PF_USE_AFFIRMATIVE_ICON, 1, POPUP_OK, text);
 		Startup_warning_dialog_displayed = true;
 	}


### PR DESCRIPTION
This commit add Ids for existing strings, that were not translateable before. Now they can be translated through the strings.tbl.
The string limit of FSO was bumped up to 1641 for this.

The following is translateable now:
- The 'or' seperator in the Keypress Directive gauge, if one function is bound to two keys.
- The Supernova warning.
- The error message that is displayed before the pilot selection screen, if something is wrong with the loaded modification.