### PR TITLE
Add `drawImage` to Scripted Gauge

### DIFF
--- a/code/scripting/api/objs/hudgauge.cpp
+++ b/code/scripting/api/objs/hudgauge.cpp
@@ -3,6 +3,8 @@
 
 #include "hudgauge.h"
 #include "hud/hudscripting.h"
+#include "texture.h"
+#include "texturemap.h"
 
 namespace scripting {
 namespace api {
@@ -91,6 +93,30 @@ ADE_FUNC(drawString,
 	gauge->getPosition(&gauge_x, &gauge_y);
 
 	gauge->renderString(fl2i(gauge_x + x), fl2i(gauge_y), text);
+
+	return ADE_RETURN_TRUE;
+}
+
+ADE_FUNC(drawImage, l_HudGaugeDrawFuncs, "texture handle Texture, [number X=0, Y=0]",
+         "Draws an image in the context of the HUD gauge.", "boolean",
+         "true on success, false otherwise")
+{
+	HudGauge* gauge;
+	texture_h* texture = nullptr;
+	float x1           = 0;
+	float y1           = 0;
+
+	if (!ade_get_args(L, "oo|ff", l_HudGaugeDrawFuncs.Get(&gauge), l_Texture.GetPtr(&texture), &x1, &y1)) {
+		return ADE_RETURN_FALSE;
+	}
+	if (!texture->isValid()) {
+		return ADE_RETURN_FALSE;
+	}
+
+	int gauge_x, gauge_y;
+	gauge->getPosition(&gauge_x, &gauge_y);
+
+	gauge->renderBitmapColor(texture->handle, fl2i(gauge_x + x1), fl2i(gauge_y + y1));
 
 	return ADE_RETURN_TRUE;
 }

--- a/code/scripting/api/objs/hudgauge.cpp
+++ b/code/scripting/api/objs/hudgauge.cpp
@@ -4,7 +4,6 @@
 #include "hudgauge.h"
 #include "hud/hudscripting.h"
 #include "texture.h"
-#include "texturemap.h"
 
 namespace scripting {
 namespace api {


### PR DESCRIPTION
Adds an additional draw function, `drawImage` to the new Scripted Gauge API. It testing it is most useful when using with a dynamic texture, ie per-frame changes can be drawn to the dynamic texture, then the texture is drawn to the scripted HUD gauge. In other words, a scripter can draw whatever they want to a dynamic texture then simply just use one line (`:drawImage`) to have it all be updated on on the scripted HUD gauge. 

Putting this here just for my reference as well. 

```
$On Gameplay Start: [
		if dy_texture == nil then 
			dy_texture = gr.createTexture(250, 250, TEXTURE_DYNAMIC) --canvas_size, set by gauge type
		end
		
		local scriptied_gname = "Custom Gauge" --or whatever the name of the scripted gauge is in hud_gauges.tbl. 
		if hu.getHUDGaugeHandle(scriptied_gname) and CustomWingGauge.RTT.canvas ~= nil then 
			hu.getHUDGaugeHandle(scriptied_gname).RenderFunction = function(dy_texture)
				gauge:drawImage(dy_texture)
			end
		end
]

$On HUD Draw: [
	if hu.HUDDrawn and mn.getMissionTime() > 0.1 then 				
		--draw gauge 
		if dy_texture ~= nil then 
			if dy_texture:isValid() then
				gr.setTarget(dy_texture)
				gr.clearScreen()
				--do whatever draw functions, ie drawString, drawCircle, etc 
				gr.setTarget()
			end
		end
	end
]
```