### PR TITLE
Add more draw functions to scripted gauge

### DIFF
--- a/code/hud/hud.cpp
+++ b/code/hud/hud.cpp
@@ -924,7 +924,7 @@ void HudGauge::renderRect(int x, int y, int w, int h)
 	gr_reset_screen_scale();
 }
 
-void HudGauge::renderCircle(int x, int y, int diameter) 
+void HudGauge::renderCircle(int x, int y, int diameter, bool filled) 
 {
 	int nx = 0, ny = 0;
 
@@ -942,30 +942,12 @@ void HudGauge::renderCircle(int x, int y, int diameter)
 			gr_set_screen_scale(base_w, base_h);
 		}
 	}
-	
-	gr_circle(x+nx, y+ny, diameter);
-	gr_reset_screen_scale();
-}
-
-void HudGauge::renderCircle_unfilled(int x, int y, int diameter)
-{
-	int nx = 0, ny = 0;
-
-	if (gr_screen.rendering_to_texture != -1) {
-		gr_set_screen_scale(canvas_w, canvas_h, -1, -1, target_w, target_h, target_w, target_h, true);
+	if (filled) {
+		gr_circle(x + nx, y + ny, diameter);
 	} else {
-		if (reticle_follow) {
-			nx = HUD_nose_x;
-			ny = HUD_nose_y;
-
-			gr_resize_screen_pos(&nx, &ny);
-			gr_set_screen_scale(base_w, base_h);
-			gr_unsize_screen_pos(&nx, &ny);
-		} else {
-			gr_set_screen_scale(base_w, base_h);
-		}
+		gr_unfilled_circle(x + nx, y + ny, diameter);
 	}
-	gr_unfilled_circle(x + nx, y + ny, diameter);
+	
 	gr_reset_screen_scale();
 }
 

--- a/code/hud/hud.cpp
+++ b/code/hud/hud.cpp
@@ -947,6 +947,28 @@ void HudGauge::renderCircle(int x, int y, int diameter)
 	gr_reset_screen_scale();
 }
 
+void HudGauge::renderCircle_unfilled(int x, int y, int diameter)
+{
+	int nx = 0, ny = 0;
+
+	if (gr_screen.rendering_to_texture != -1) {
+		gr_set_screen_scale(canvas_w, canvas_h, -1, -1, target_w, target_h, target_w, target_h, true);
+	} else {
+		if (reticle_follow) {
+			nx = HUD_nose_x;
+			ny = HUD_nose_y;
+
+			gr_resize_screen_pos(&nx, &ny);
+			gr_set_screen_scale(base_w, base_h);
+			gr_unsize_screen_pos(&nx, &ny);
+		} else {
+			gr_set_screen_scale(base_w, base_h);
+		}
+	}
+	gr_unfilled_circle(x + nx, y + ny, diameter);
+	gr_reset_screen_scale();
+}
+
 void HudGauge::setClip(int x, int y, int w, int h)
 {
 	int hx = fl2i(HUD_offset_x);

--- a/code/hud/hud.h
+++ b/code/hud/hud.h
@@ -318,8 +318,7 @@ public:
 	void renderLine(int x1, int y1, int x2, int y2);
 	void renderGradientLine(int x1, int y1, int x2, int y2);
 	void renderRect(int x, int y, int w, int h);
-	void renderCircle(int x, int y, int diameter);
-	void renderCircle_unfilled(int x, int y, int diameter);
+	void renderCircle(int x, int y, int diameter, bool filled = true);
 
 	void unsize(int *x, int *y);
 	void unsize(float *x, float *y);

--- a/code/hud/hud.h
+++ b/code/hud/hud.h
@@ -319,6 +319,7 @@ public:
 	void renderGradientLine(int x1, int y1, int x2, int y2);
 	void renderRect(int x, int y, int w, int h);
 	void renderCircle(int x, int y, int diameter);
+	void renderCircle_unfilled(int x, int y, int diameter);
 
 	void unsize(int *x, int *y);
 	void unsize(float *x, float *y);

--- a/code/scripting/api/objs/hudgauge.cpp
+++ b/code/scripting/api/objs/hudgauge.cpp
@@ -117,7 +117,7 @@ ADE_FUNC(drawLine, l_HudGaugeDrawFuncs, "number X1, number Y1, number X2, number
 	return ADE_RETURN_TRUE;
 }
 
-ADE_FUNC(drawCirle, l_HudGaugeDrawFuncs, "number X, number Y, number radius, [boolean filled=true]",
+ADE_FUNC(drawCirle, l_HudGaugeDrawFuncs, "number radius, number X, number Y, [boolean filled=true]",
          "Draws a circle in the context of the HUD gauge.", "boolean", "true on success, false otherwise")
 {
 	HudGauge* gauge;
@@ -126,7 +126,7 @@ ADE_FUNC(drawCirle, l_HudGaugeDrawFuncs, "number X, number Y, number radius, [bo
 	float radius;
 	bool filled=true;
 
-	if (!ade_get_args(L, "offf|b", l_HudGaugeDrawFuncs.Get(&gauge), &x, &y, &radius, &filled)) {
+	if (!ade_get_args(L, "offf|b", l_HudGaugeDrawFuncs.Get(&gauge), &radius, &x, &y, &filled)) {
 		return ADE_RETURN_FALSE;
 	}
 

--- a/code/scripting/api/objs/hudgauge.cpp
+++ b/code/scripting/api/objs/hudgauge.cpp
@@ -117,7 +117,7 @@ ADE_FUNC(drawLine, l_HudGaugeDrawFuncs, "number X1, number Y1, number X2, number
 	return ADE_RETURN_TRUE;
 }
 
-ADE_FUNC(drawCirle, l_HudGaugeDrawFuncs, "number radius, number X, number Y, [boolean filled=true]",
+ADE_FUNC(drawCircle, l_HudGaugeDrawFuncs, "number radius, number X, number Y, [boolean filled=true]",
          "Draws a circle in the context of the HUD gauge.", "boolean", "true on success, false otherwise")
 {
 	HudGauge* gauge;

--- a/code/scripting/api/objs/hudgauge.cpp
+++ b/code/scripting/api/objs/hudgauge.cpp
@@ -75,7 +75,7 @@ ADE_OBJ(l_HudGaugeDrawFuncs,
 
 ADE_FUNC(drawString,
          l_HudGaugeDrawFuncs,
-         "number x, number y, string text",
+         "string text, number x, number y",
          "Draws a string in the context of the HUD gauge.",
          "boolean",
          "true on success, false otherwise") {
@@ -84,7 +84,7 @@ ADE_FUNC(drawString,
 	float y;
 	const char* text;
 
-	if (!ade_get_args(L, "offs", l_HudGaugeDrawFuncs.Get(&gauge), &x, &y, &text)) {
+	if (!ade_get_args(L, "osff", l_HudGaugeDrawFuncs.Get(&gauge), &text, &x, &y)) {
 		return ADE_RETURN_FALSE;
 	}
 
@@ -144,7 +144,7 @@ ADE_FUNC(drawCirle, l_HudGaugeDrawFuncs, "number X, number Y, number radius, [bo
 	return ADE_RETURN_TRUE;
 }
 
-ADE_FUNC(drawRect, l_HudGaugeDrawFuncs, "number X1, number Y1, number X2, number Y2, [boolean Filled=true]",
+ADE_FUNC(drawRectangle, l_HudGaugeDrawFuncs, "number X1, number Y1, number X2, number Y2, [boolean Filled=true]",
          "Draws a rectangle in the context of the HUD gauge.", "boolean", "true on success, false otherwise")
 {
 	HudGauge* gauge;

--- a/code/scripting/api/objs/hudgauge.cpp
+++ b/code/scripting/api/objs/hudgauge.cpp
@@ -96,6 +96,83 @@ ADE_FUNC(drawString,
 	return ADE_RETURN_TRUE;
 }
 
+ADE_FUNC(drawLine, l_HudGaugeDrawFuncs, "number X1, number Y1, number X2, number Y2",
+         "Draws a line in the context of the HUD gauge.", "boolean", "true on success, false otherwise")
+{
+	HudGauge* gauge;
+	float x1;
+	float y1;
+	float x2;
+	float y2;
+
+	if (!ade_get_args(L, "offff", l_HudGaugeDrawFuncs.Get(&gauge), &x1, &y1, &x2, &y2)) {
+		return ADE_RETURN_FALSE;
+	}
+
+	int gauge_x, gauge_y;
+	gauge->getPosition(&gauge_x, &gauge_y);
+
+	gauge->renderLine(fl2i(gauge_x + x1), fl2i(gauge_y + y1), fl2i(gauge_x + x2), fl2i(gauge_y + y2));
+
+	return ADE_RETURN_TRUE;
+}
+
+ADE_FUNC(drawCirle, l_HudGaugeDrawFuncs, "number X, number Y, number radius, [boolean filled=true]",
+         "Draws a circle in the context of the HUD gauge.", "boolean", "true on success, false otherwise")
+{
+	HudGauge* gauge;
+	float x;
+	float y;
+	float radius;
+	bool filled=true;
+
+	if (!ade_get_args(L, "offf|b", l_HudGaugeDrawFuncs.Get(&gauge), &x, &y, &radius, &filled)) {
+		return ADE_RETURN_FALSE;
+	}
+
+	int gauge_x, gauge_y;
+	gauge->getPosition(&gauge_x, &gauge_y);
+
+	if (filled ) {
+		gauge->renderCircle(fl2i(gauge_x + x), fl2i(gauge_y + y), fl2i(radius*2));
+	}
+	else
+	{
+		gauge->renderCircle_unfilled(fl2i(gauge_x + x), fl2i(gauge_y + y), fl2i(radius * 2));
+	}
+
+	return ADE_RETURN_TRUE;
+}
+
+ADE_FUNC(drawRect, l_HudGaugeDrawFuncs, "number X1, number Y1, number X2, number Y2, [boolean Filled=true]",
+         "Draws a rectangle in the context of the HUD gauge.", "boolean", "true on success, false otherwise")
+{
+	HudGauge* gauge;
+	float x1;
+	float y1;
+	float x2;
+	float y2;
+	bool filled = true;
+
+	if (!ade_get_args(L, "offff|b", l_HudGaugeDrawFuncs.Get(&gauge), &x1, &y1, &x2, &y2, &filled)) {
+		return ADE_RETURN_FALSE;
+	}
+
+	int gauge_x, gauge_y;
+	gauge->getPosition(&gauge_x, &gauge_y);
+
+	if (filled) {
+		gauge->renderRect(fl2i(gauge_x + x1), fl2i(gauge_y + y1), fl2i(gauge_x + x2), fl2i(gauge_y + y2));
+	} else {
+		gauge->renderLine(fl2i(gauge_x + x1), fl2i(gauge_y + y1), fl2i(gauge_x + x2), fl2i(gauge_y + y1));
+		gauge->renderLine(fl2i(gauge_x + x1), fl2i(gauge_y + y2), fl2i(gauge_x + x2), fl2i(gauge_y + y2));
+		gauge->renderLine(fl2i(gauge_x + x1), fl2i(gauge_y + y1), fl2i(gauge_x + x1), fl2i(gauge_y + y2));
+		gauge->renderLine(fl2i(gauge_x + x2), fl2i(gauge_y + y1), fl2i(gauge_x + x2), fl2i(gauge_y + y2));
+	}
+
+	return ADE_RETURN_TRUE;
+}
+
 ADE_FUNC(drawImage, l_HudGaugeDrawFuncs, "texture handle Texture, [number X=0, Y=0]",
          "Draws an image in the context of the HUD gauge.", "boolean",
          "true on success, false otherwise")

--- a/code/scripting/api/objs/hudgauge.cpp
+++ b/code/scripting/api/objs/hudgauge.cpp
@@ -91,7 +91,7 @@ ADE_FUNC(drawString,
 	int gauge_x, gauge_y;
 	gauge->getPosition(&gauge_x, &gauge_y);
 
-	gauge->renderString(fl2i(gauge_x + x), fl2i(gauge_y), text);
+	gauge->renderString(fl2i(gauge_x + x), fl2i(gauge_y + y), text);
 
 	return ADE_RETURN_TRUE;
 }

--- a/code/scripting/api/objs/hudgauge.cpp
+++ b/code/scripting/api/objs/hudgauge.cpp
@@ -3,6 +3,8 @@
 
 #include "hudgauge.h"
 #include "hud/hudscripting.h"
+#include "texture.h"
+#include "texturemap.h"
 
 namespace scripting {
 namespace api {
@@ -91,6 +93,30 @@ ADE_FUNC(drawString,
 	gauge->getPosition(&gauge_x, &gauge_y);
 
 	gauge->renderString(fl2i(gauge_x + x), fl2i(gauge_y), text);
+
+	return ADE_RETURN_TRUE;
+}
+
+ADE_FUNC(drawImage, l_HudGaugeDrawFuncs, "texture handle Texture, [number X=0, Y=0]",
+         "Draws an image in the context of the HUD gauge.", "boolean",
+         "true on success, false otherwise")
+{
+	HudGauge* gauge;
+	texture_h* texture = nullptr;
+	float x1           = 0;
+	float y1           = 0;
+
+	if (!ade_get_args(L, "oo|ff", l_HudGaugeDrawFuncs.Get(&gauge), l_Texture.GetPtr(&texture), &x1, &y1)) {
+		return ADE_RETURN_FALSE;
+	}
+	if (!texture->isValid()) {
+		return ADE_RETURN_FALSE;
+	}
+
+	int gauge_x, gauge_y;
+	gauge->getPosition(&gauge_x, &gauge_y);
+
+	gauge->renderBitmapColor(texture->handle, fl2i(gauge_x + x1), fl2i(gauge_y + y1));
 
 	return ADE_RETURN_TRUE;
 }

--- a/code/scripting/api/objs/hudgauge.cpp
+++ b/code/scripting/api/objs/hudgauge.cpp
@@ -4,7 +4,6 @@
 #include "hudgauge.h"
 #include "hud/hudscripting.h"
 #include "texture.h"
-#include "texturemap.h"
 
 namespace scripting {
 namespace api {

--- a/code/scripting/api/objs/hudgauge.cpp
+++ b/code/scripting/api/objs/hudgauge.cpp
@@ -133,13 +133,7 @@ ADE_FUNC(drawCirle, l_HudGaugeDrawFuncs, "number radius, number X, number Y, [bo
 	int gauge_x, gauge_y;
 	gauge->getPosition(&gauge_x, &gauge_y);
 
-	if (filled ) {
-		gauge->renderCircle(fl2i(gauge_x + x), fl2i(gauge_y + y), fl2i(radius*2));
-	}
-	else
-	{
-		gauge->renderCircle_unfilled(fl2i(gauge_x + x), fl2i(gauge_y + y), fl2i(radius * 2));
-	}
+	gauge->renderCircle(fl2i(gauge_x + x), fl2i(gauge_y + y), fl2i(radius*2), filled);
 
 	return ADE_RETURN_TRUE;
 }


### PR DESCRIPTION
This adds the following functions to the scripted gauge API: `drawCircle`, `drawRect`, and `drawLine`. Also note that I created an additional function, for `HUDGauge:renderCircle_unfilled`, because the precedent shown by having two functions for `gr_unfilled_circle` and `gr_circle` and adding a fourth argument to `renderCircle` seemed to affect a lot of other functions.