### PR TITLE
Add "+WarpEffect:" field to ssm.tbl.

### DIFF
--- a/code/hud/hudartillery.cpp
+++ b/code/hud/hudartillery.cpp
@@ -95,6 +95,32 @@ void parse_ssm(const char *filename)
 				s.max_count = -1;
 			}
 
+			if (optional_string("+WarpEffect:")) {
+				int temp;
+				if (stuff_int_optional(&temp) != 2) {
+					// We have a string to parse instead.
+					char unique_id[NAME_LENGTH];
+					memset(unique_id, 0, NAME_LENGTH);
+					stuff_string(unique_id, F_NAME, NAME_LENGTH);
+					int fireball_type = fireball_info_lookup(unique_id);
+					if (fireball_type < 0) {
+						error_display(1, "Unknown fireball [%s] to use as warp effect for SSM strike [%s]", unique_id, s.name);
+						s.fireball_idx = FIREBALL_WARP;
+					} else {
+						s.fireball_idx = fireball_type;
+					}
+				} else {
+					if ((temp < 0) || (temp >= Num_fireball_types)) {
+						error_display(1, "Fireball index [%d] out of range (should be 0-%d) for SSM strike [%s]", temp, Num_fireball_types - 1, s.name);
+						s.fireball_idx = FIREBALL_WARP;
+					} else {
+						s.fireball_idx = temp;
+					}
+				}
+			} else {
+				s.fireball_idx = FIREBALL_WARP;
+			}
+
 			required_string("+WarpRadius:");
 			stuff_float(&s.warp_radius);
 
@@ -422,7 +448,7 @@ void ssm_process()
                     vm_vec_sub(&temp, &moveup->sinfo.target->pos, &moveup->sinfo.start_pos[idx]);
 					vm_vec_normalize(&temp);
 					vm_vector_2_matrix(&orient, &temp, NULL, NULL);
-					moveup->fireballs[idx] = fireball_create(&moveup->sinfo.start_pos[idx], FIREBALL_WARP, FIREBALL_WARP_EFFECT, -1, si->warp_radius, false, &vmd_zero_vector, si->warp_time, 0, &orient);
+					moveup->fireballs[idx] = fireball_create(&moveup->sinfo.start_pos[idx], si->fireball_idx, FIREBALL_WARP_EFFECT, -1, si->warp_radius, false, &vmd_zero_vector, si->warp_time, 0, &orient);
 				}
 			}
 		}

--- a/code/hud/hudartillery.h
+++ b/code/hud/hudartillery.h
@@ -30,6 +30,7 @@ typedef struct ssm_info {
 	int			count;					// # of missiles in this type of strike
 	int			max_count;				// Maximum # of missiles in this type of strike (-1 for no variance)
 	int			weapon_info_index;		// missile type
+	int			fireball_idx;			// Type of fireball to use for warp effect (defaults to FIREBALL_WARP)
 	float		warp_radius;			// radius of associated warp effect
 	float		warp_time;				// how long the warp effect lasts
 	float		radius;					// radius around the target ship
@@ -49,7 +50,7 @@ typedef struct ssm_firing_info {
 	SCP_vector<vec3d>	start_pos;		// start positions
 
 	int					count;			// The ssm_info count may be variable; this stores the actual number of projectiles for this strike.
-	size_t				ssm_index;		// index info ssm_info array
+	size_t				ssm_index;		// index into ssm_info array
 	class object*		target;			// target for the strike
 	int					ssm_team;		// team that fired the ssm.
 	float				duration;		// how far into the warp effect to fire


### PR DESCRIPTION
Allows subspace strikes to choose which fireball to use for the warp effect. If absent, `FIREBALL_WARP` is used as the default (which was the previous hardcoded behavior).

"+WarpEffect:" can be specified as either an index or using the fireball's unique ID.

Requested (and tested) by @AxemP.