### PR TITLE
Three sexps and some sexp improvements

### DIFF
--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -6334,7 +6334,7 @@ int sexp_directive_value(int n)
 		replace_current_value = eval_sexp(n);
 	}
 
-	if (replace_current_value == SEXP_FALSE) { // note: any SEXP_KNOWN_FALSE result will return SEXP_FALSE
+	if (replace_current_value == SEXP_FALSE || replace_current_value == SEXP_KNOWN_FALSE) {
 		Directive_count += directive_value;
 	}
 	else {
@@ -8505,7 +8505,7 @@ int eval_when(int n, int when_op_num)
 
 
 	// if value is true, perform the actions in the 'then' part
-	if (val == SEXP_TRUE) // note: SEXP_KNOWN_TRUE is never returned from eval_sexp
+	if (val == SEXP_TRUE || val == SEXP_KNOWN_TRUE)
 	{
 		// get the operator
 		int exp = CAR(actions);
@@ -8537,7 +8537,7 @@ int eval_when(int n, int when_op_num)
 		}
 	}
 	// if-then-else has actions to perform under "else"
-	else if (val == SEXP_FALSE && when_op_num == OP_IF_THEN_ELSE) // note: SEXP_KNOWN_FALSE is never returned from eval_sexp
+	else if ((val == SEXP_FALSE || val == SEXP_KNOWN_FALSE) && (when_op_num == OP_IF_THEN_ELSE))
 	{
 		// skip past the "if" action
 		actions = CDR(actions);
@@ -8602,7 +8602,7 @@ int eval_cond(int n)
 
 		// if the conditional evaluated to true, then we must evaluate the rest of the expression returning
 		// the value of this evaluation
-		if (val == SEXP_TRUE) // note: any SEXP_KNOWN_TRUE result is returned as SEXP_TRUE
+		if (val == SEXP_TRUE || val == SEXP_KNOWN_TRUE)
 		{
 			int actions, exp;
 
@@ -8947,7 +8947,7 @@ int eval_random_of(int arg_handler_node, int condition_node, bool multiple)
 		val = eval_sexp(condition_node);
 
 		// true?
-		if (val == SEXP_TRUE)
+		if (val == SEXP_TRUE || val == SEXP_KNOWN_TRUE)
 		{
 			Sexp_applicable_argument_list.add_data(Sexp_nodes[n].text);
 		} else if ((!multiple || num_valid_args == 1) && (Sexp_nodes[condition_node].value == SEXP_KNOWN_FALSE || Sexp_nodes[condition_node].value == SEXP_NAN_FOREVER)) {
@@ -8998,7 +8998,7 @@ int eval_in_sequence(int arg_handler_node, int condition_node)
 		val = eval_sexp(condition_node);
 
 		// true?
-		if (val == SEXP_TRUE)
+		if (val == SEXP_TRUE || val == SEXP_KNOWN_TRUE)
 		{
 			Sexp_applicable_argument_list.add_data(Sexp_nodes[n].text);
 		} else if ((Sexp_nodes[condition_node].value == SEXP_KNOWN_FALSE) || (Sexp_nodes[condition_node].value == SEXP_NAN_FOREVER)) {
@@ -22970,10 +22970,10 @@ bool is_sexp_true(int cur_node, int referenced_node)
 {
 	int result = eval_sexp(cur_node, referenced_node);
 
-	// any SEXP_KNOWN_TRUE result will return SEXP_TRUE from eval_sexp, but let's be defensive
+	// any* SEXP_KNOWN_TRUE result will return SEXP_TRUE from eval_sexp, but let's be defensive
+	// *for almost all return paths... there is one path where it has not yet been proven that it won't
 	return (result == SEXP_TRUE) || (result == SEXP_KNOWN_TRUE);
 }
-
 
 /**
 * 

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -136,7 +136,7 @@ SCP_vector<sexp_oper> Operators = {
 	{ "pow",							OP_POW,									2,	2,			SEXP_ARITHMETIC_OPERATOR,	},	// Goober5000
 	{ "signum",							OP_SIGNUM,								1,	1,			SEXP_ARITHMETIC_OPERATOR,	},	// Goober5000
 	{ "is-nan",							OP_IS_NAN,								1,	1,			SEXP_ARITHMETIC_OPERATOR,	},	// Goober5000
-	{ "nan-to-num",						OP_NAN_TO_NUM,							1,	1,			SEXP_ARITHMETIC_OPERATOR,	},	// Goober5000
+	{ "nan-to-number",					OP_NAN_TO_NUMBER,						1,	1,			SEXP_ARITHMETIC_OPERATOR,	},	// Goober5000
 	{ "set-bit",						OP_SET_BIT,								2,	2,			SEXP_ARITHMETIC_OPERATOR,	},	// Goober5000
 	{ "unset-bit",						OP_UNSET_BIT,							2,	2,			SEXP_ARITHMETIC_OPERATOR,	},	// Goober5000
 	{ "is-bit-set",						OP_IS_BIT_SET,							2,	2,			SEXP_BOOLEAN_OPERATOR,		},	// Goober5000
@@ -4324,7 +4324,7 @@ int sexp_is_nan(int n)
 }
 
 // Goober5000
-int sexp_nan_to_num(int n)
+int sexp_nan_to_number(int n)
 {
 	// if this sexp has an operator, evaluate it
 	if (CAR(n) != -1) {
@@ -23370,8 +23370,8 @@ int eval_sexp(int cur_node, int referenced_node)
 				sexp_val = sexp_is_nan(node);
 				break;
 
-			case OP_NAN_TO_NUM:
-				sexp_val = sexp_nan_to_num(node);
+			case OP_NAN_TO_NUMBER:
+				sexp_val = sexp_nan_to_number(node);
 				break;
 
 			case OP_SET_BIT:
@@ -26168,7 +26168,7 @@ int query_operator_return_type(int op)
 		case OP_AVG:
 		case OP_POW:
 		case OP_SIGNUM:
-		case OP_NAN_TO_NUM:
+		case OP_NAN_TO_NUMBER:
 		case OP_GET_OBJECT_X:
 		case OP_GET_OBJECT_Y:
 		case OP_GET_OBJECT_Z:
@@ -26700,7 +26700,7 @@ int query_operator_argument_type(int op, int argnum)
 		case OP_AVG:
 		case OP_SIGNUM:
 		case OP_IS_NAN:
-		case OP_NAN_TO_NUM:
+		case OP_NAN_TO_NUMBER:
 			return OPF_NUMBER;
 
 		case OP_POW:
@@ -30808,7 +30808,7 @@ SCP_vector<sexp_help_struct> Sexp_help = {
 		"\tReturns true if the argument is NaN (not-a-number).  This can happen e.g. when checking statistics for ships that have departed.  Takes one argument.\r\n" },
 
 	// Goober5000
-	{ OP_NAN_TO_NUM, "NaN-to-Number (Arithmetic operator)\r\n"
+	{ OP_NAN_TO_NUMBER, "NaN-to-Number (Arithmetic operator)\r\n"
 		"\tUsed to safely filter NaN values from arithmetic operations, which would otherwise pass NaN up the sexp tree.  If the argument is a number, it is returned.  If the argument is NaN, a zero is returned.  Takes one argument.\r\n" },
 
 	// Goober5000

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -6381,7 +6381,7 @@ int sexp_directive_value(int n)
 		replace_current_value = eval_sexp(n);
 	}
 
-	if (replace_current_value == SEXP_FALSE || replace_current_value == SEXP_KNOWN_FALSE) {
+	if (replace_current_value == SEXP_FALSE) { // note: any SEXP_KNOWN_FALSE result will return SEXP_FALSE
 		Directive_count += directive_value;
 	}
 	else {
@@ -8552,7 +8552,7 @@ int eval_when(int n, int when_op_num)
 
 
 	// if value is true, perform the actions in the 'then' part
-	if (val == SEXP_TRUE || val == SEXP_KNOWN_TRUE)
+	if (val == SEXP_TRUE) // note: SEXP_KNOWN_TRUE is never returned from eval_sexp
 	{
 		// get the operator
 		int exp = CAR(actions);
@@ -8584,7 +8584,7 @@ int eval_when(int n, int when_op_num)
 		}
 	}
 	// if-then-else has actions to perform under "else"
-	else if ((val == SEXP_FALSE || val == SEXP_KNOWN_FALSE) && (when_op_num == OP_IF_THEN_ELSE))
+	else if (val == SEXP_FALSE && when_op_num == OP_IF_THEN_ELSE) // note: SEXP_KNOWN_FALSE is never returned from eval_sexp
 	{
 		// skip past the "if" action
 		actions = CDR(actions);
@@ -8649,7 +8649,7 @@ int eval_cond(int n)
 
 		// if the conditional evaluated to true, then we must evaluate the rest of the expression returning
 		// the value of this evaluation
-		if (val == SEXP_TRUE || val == SEXP_KNOWN_TRUE)
+		if (val == SEXP_TRUE) // note: any SEXP_KNOWN_TRUE result is returned as SEXP_TRUE
 		{
 			int actions, exp;
 
@@ -8994,7 +8994,7 @@ int eval_random_of(int arg_handler_node, int condition_node, bool multiple)
 		val = eval_sexp(condition_node);
 
 		// true?
-		if (val == SEXP_TRUE || val == SEXP_KNOWN_TRUE)
+		if (val == SEXP_TRUE)
 		{
 			Sexp_applicable_argument_list.add_data(Sexp_nodes[n].text);
 		} else if ((!multiple || num_valid_args == 1) && (Sexp_nodes[condition_node].value == SEXP_KNOWN_FALSE || Sexp_nodes[condition_node].value == SEXP_NAN_FOREVER)) {
@@ -9045,7 +9045,7 @@ int eval_in_sequence(int arg_handler_node, int condition_node)
 		val = eval_sexp(condition_node);
 
 		// true?
-		if (val == SEXP_TRUE || val == SEXP_KNOWN_TRUE)
+		if (val == SEXP_TRUE)
 		{
 			Sexp_applicable_argument_list.add_data(Sexp_nodes[n].text);
 		} else if ((Sexp_nodes[condition_node].value == SEXP_KNOWN_FALSE) || (Sexp_nodes[condition_node].value == SEXP_NAN_FOREVER)) {
@@ -23036,8 +23036,7 @@ bool is_sexp_true(int cur_node, int referenced_node)
 {
 	int result = eval_sexp(cur_node, referenced_node);
 
-	// any* SEXP_KNOWN_TRUE result will return SEXP_TRUE from eval_sexp, but let's be defensive
-	// *for almost all return paths... there is one path where it has not yet been proven that it won't
+	// any SEXP_KNOWN_TRUE result will return SEXP_TRUE from eval_sexp, but let's be defensive
 	return (result == SEXP_TRUE) || (result == SEXP_KNOWN_TRUE);
 }
 

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -25576,7 +25576,7 @@ int eval_sexp(int cur_node, int referenced_node)
 		}
 
 		// now, reconcile positive and negative - Goober5000
-		if (sexp_val < 0 || sexp_val > SEXP_UNLIKELY_RETURN_VALUE_BOUND)
+		if (sexp_val < 0 && sexp_val > SEXP_UNLIKELY_RETURN_VALUE_BOUND)
 		{
 			int parent_node = find_parent_operator(cur_node);
 

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -25497,7 +25497,7 @@ int eval_sexp(int cur_node, int referenced_node)
 		}
 
 		// now, reconcile positive and negative - Goober5000
-		if (sexp_val < 0)
+		if (sexp_val < 0 || sexp_val > SEXP_UNLIKELY_RETURN_VALUE_BOUND)
 		{
 			int parent_node = find_parent_operator(cur_node);
 

--- a/code/parse/sexp.h
+++ b/code/parse/sexp.h
@@ -236,7 +236,7 @@ class waypoint_list;
 #define OP_IS_BIT_SET						(0x0012 | OP_CATEGORY_ARITHMETIC)	// Goober5000
 #define OP_SIGNUM							(0x0013 | OP_CATEGORY_ARITHMETIC)	// Goober5000
 #define OP_IS_NAN							(0x0014 | OP_CATEGORY_ARITHMETIC)	// Goober5000
-#define OP_NAN_TO_NUM						(0x0015 | OP_CATEGORY_ARITHMETIC)	// Goober5000
+#define OP_NAN_TO_NUMBER					(0x0015 | OP_CATEGORY_ARITHMETIC)	// Goober5000
 
 
 #define	OP_TRUE								(0x0000 | OP_CATEGORY_LOGICAL)

--- a/code/parse/sexp.h
+++ b/code/parse/sexp.h
@@ -235,6 +235,8 @@ class waypoint_list;
 #define OP_UNSET_BIT						(0x0011 | OP_CATEGORY_ARITHMETIC)	// Goober5000
 #define OP_IS_BIT_SET						(0x0012 | OP_CATEGORY_ARITHMETIC)	// Goober5000
 #define OP_SIGNUM							(0x0013 | OP_CATEGORY_ARITHMETIC)	// Goober5000
+#define OP_IS_NAN							(0x0014 | OP_CATEGORY_ARITHMETIC)	// Goober5000
+#define OP_NAN_TO_NUM						(0x0015 | OP_CATEGORY_ARITHMETIC)	// Goober5000
 
 
 #define	OP_TRUE								(0x0000 | OP_CATEGORY_LOGICAL)
@@ -408,8 +410,10 @@ class waypoint_list;
 #define OP_INVALIDATE_ALL_ARGUMENTS			(0x000d | OP_CATEGORY_CONDITIONAL)	// Karajorma
 #define OP_VALIDATE_ALL_ARGUMENTS			(0x000e | OP_CATEGORY_CONDITIONAL)	// Karajorma
 #define OP_FOR_COUNTER						(0x000f | OP_CATEGORY_CONDITIONAL)	// Goober5000
+
 #define OP_IF_THEN_ELSE						(0x0010 | OP_CATEGORY_CONDITIONAL)	// Goober5000
 #define OP_NUM_VALID_ARGUMENTS				(0x0011 | OP_CATEGORY_CONDITIONAL)	// Karajorma
+#define OP_FUNCTIONAL_IF_THEN_ELSE			(0x0012 | OP_CATEGORY_CONDITIONAL)	// Goober5000
 
 
 // sexpressions with side-effects

--- a/code/parse/sexp.h
+++ b/code/parse/sexp.h
@@ -946,13 +946,13 @@ char *CTEXT(int n);
 #define SEXP_TRUE			1
 #define SEXP_FALSE			0
 // Goober5000: changed these to unlikely values, because now we have sexps using negative numbers
-#define SEXP_KNOWN_FALSE	-32767	//-1
-#define SEXP_KNOWN_TRUE		-32766	//-2
-#define SEXP_UNKNOWN		-32765	//-3
-#define SEXP_NAN			-32764	//-4	// not a number -- used when ships/wing part of boolean and haven't arrived yet
-#define SEXP_NAN_FOREVER	-32763	//-5	// not a number and will never change -- used to falsify boolean sexpressions
-#define SEXP_CANT_EVAL		-32762	//-6	// can't evaluate yet for whatever reason (acts like false)
-#define SEXP_NUM_EVAL		-32761	//-7	// already completed an arithmetic operation and result is stored
+#define SEXP_KNOWN_FALSE	(INT_MIN+10)
+#define SEXP_KNOWN_TRUE		(INT_MIN+11)
+#define SEXP_UNKNOWN		(INT_MIN+12)
+#define SEXP_NAN			(INT_MIN+13)	// not a number -- used when ships/wing part of boolean and haven't arrived yet
+#define SEXP_NAN_FOREVER	(INT_MIN+14)	// not a number and will never change -- used to falsify boolean sexpressions
+#define SEXP_CANT_EVAL		(INT_MIN+15)	// can't evaluate yet for whatever reason (acts like false)
+#define SEXP_NUM_EVAL		(INT_MIN+16)	// already completed an arithmetic operation and result is stored
 
 // defines for check_sexp_syntax
 #define SEXP_CHECK_NONOP_ARGS			-1			// non-operator has arguments

--- a/code/parse/sexp.h
+++ b/code/parse/sexp.h
@@ -945,6 +945,7 @@ char *CTEXT(int n);
 
 #define SEXP_TRUE			1
 #define SEXP_FALSE			0
+
 // Goober5000: changed these to unlikely values, because now we have sexps using negative numbers
 #define SEXP_KNOWN_FALSE	(INT_MIN+10)
 #define SEXP_KNOWN_TRUE		(INT_MIN+11)
@@ -953,6 +954,8 @@ char *CTEXT(int n);
 #define SEXP_NAN_FOREVER	(INT_MIN+14)	// not a number and will never change -- used to falsify boolean sexpressions
 #define SEXP_CANT_EVAL		(INT_MIN+15)	// can't evaluate yet for whatever reason (acts like false)
 #define SEXP_NUM_EVAL		(INT_MIN+16)	// already completed an arithmetic operation and result is stored
+// in case we want to test for any of the above
+#define SEXP_UNLIKELY_RETURN_VALUE_BOUND		(INT_MIN+17)
 
 // defines for check_sexp_syntax
 #define SEXP_CHECK_NONOP_ARGS			-1			// non-operator has arguments


### PR DESCRIPTION
Several changes here:

* Made the "magic number" sexp return values even more unlikely, in case FREDders want to use numbers around -37000
* Optimize `eval_sexp` by not running the positive/negative number reconciliation code if the negative number is a magic number
* ~~Always check `SEXP_KNOWN_TRUE` when checking `SEXP_TRUE`, and likewise for false. This may not be needed, but better safe than sorry.~~
* Add `is-nan` which checks for not-a-number values
* Add `nan-to-number` which casts NaNs to 0
* Add `functional-if-then-else` which is like the ?: ternary operator