### PR TITLE
Fix detailbox showship bug

### DIFF
--- a/ci/travis/check_release.sh
+++ b/ci/travis/check_release.sh
@@ -14,7 +14,7 @@ NIGHTLY_PATTERN="^nightly_(.*)$"
 TEST_BUILD_PATTERN="^test\/(.*)$"
 
 # These are for testing
-NIGHTLY_TEST=true
+NIGHTLY_TEST=false
 RELEASE_TEST=false
 TEST_BUILD_TEST=false
 

--- a/ci/travis/ftp_deploy.sh
+++ b/ci/travis/ftp_deploy.sh
@@ -65,6 +65,7 @@ if [[ ! "$(curl -V)" == *"sftp"* ]]; then
             cp -a . ~/curl_cache/curl
             sudo make install
         fi
+        export PATH=/usr/local/bin:$PATH
     fi
 
     # After

--- a/code/hud/hud.cpp
+++ b/code/hud/hud.cpp
@@ -924,7 +924,7 @@ void HudGauge::renderRect(int x, int y, int w, int h)
 	gr_reset_screen_scale();
 }
 
-void HudGauge::renderCircle(int x, int y, int diameter) 
+void HudGauge::renderCircle(int x, int y, int diameter, bool filled) 
 {
 	int nx = 0, ny = 0;
 
@@ -942,8 +942,12 @@ void HudGauge::renderCircle(int x, int y, int diameter)
 			gr_set_screen_scale(base_w, base_h);
 		}
 	}
+	if (filled) {
+		gr_circle(x + nx, y + ny, diameter);
+	} else {
+		gr_unfilled_circle(x + nx, y + ny, diameter);
+	}
 	
-	gr_circle(x+nx, y+ny, diameter);
 	gr_reset_screen_scale();
 }
 

--- a/code/hud/hud.h
+++ b/code/hud/hud.h
@@ -318,7 +318,7 @@ public:
 	void renderLine(int x1, int y1, int x2, int y2);
 	void renderGradientLine(int x1, int y1, int x2, int y2);
 	void renderRect(int x, int y, int w, int h);
-	void renderCircle(int x, int y, int diameter);
+	void renderCircle(int x, int y, int diameter, bool filled = true);
 
 	void unsize(int *x, int *y);
 	void unsize(float *x, float *y);

--- a/code/hud/hudartillery.cpp
+++ b/code/hud/hudartillery.cpp
@@ -95,6 +95,32 @@ void parse_ssm(const char *filename)
 				s.max_count = -1;
 			}
 
+			if (optional_string("+WarpEffect:")) {
+				int temp;
+				if (stuff_int_optional(&temp) != 2) {
+					// We have a string to parse instead.
+					char unique_id[NAME_LENGTH];
+					memset(unique_id, 0, NAME_LENGTH);
+					stuff_string(unique_id, F_NAME, NAME_LENGTH);
+					int fireball_type = fireball_info_lookup(unique_id);
+					if (fireball_type < 0) {
+						error_display(1, "Unknown fireball [%s] to use as warp effect for SSM strike [%s]", unique_id, s.name);
+						s.fireball_idx = FIREBALL_WARP;
+					} else {
+						s.fireball_idx = fireball_type;
+					}
+				} else {
+					if ((temp < 0) || (temp >= Num_fireball_types)) {
+						error_display(1, "Fireball index [%d] out of range (should be 0-%d) for SSM strike [%s]", temp, Num_fireball_types - 1, s.name);
+						s.fireball_idx = FIREBALL_WARP;
+					} else {
+						s.fireball_idx = temp;
+					}
+				}
+			} else {
+				s.fireball_idx = FIREBALL_WARP;
+			}
+
 			required_string("+WarpRadius:");
 			stuff_float(&s.warp_radius);
 
@@ -422,7 +448,7 @@ void ssm_process()
                     vm_vec_sub(&temp, &moveup->sinfo.target->pos, &moveup->sinfo.start_pos[idx]);
 					vm_vec_normalize(&temp);
 					vm_vector_2_matrix(&orient, &temp, NULL, NULL);
-					moveup->fireballs[idx] = fireball_create(&moveup->sinfo.start_pos[idx], FIREBALL_WARP, FIREBALL_WARP_EFFECT, -1, si->warp_radius, false, &vmd_zero_vector, si->warp_time, 0, &orient);
+					moveup->fireballs[idx] = fireball_create(&moveup->sinfo.start_pos[idx], si->fireball_idx, FIREBALL_WARP_EFFECT, -1, si->warp_radius, false, &vmd_zero_vector, si->warp_time, 0, &orient);
 				}
 			}
 		}

--- a/code/hud/hudartillery.h
+++ b/code/hud/hudartillery.h
@@ -30,6 +30,7 @@ typedef struct ssm_info {
 	int			count;					// # of missiles in this type of strike
 	int			max_count;				// Maximum # of missiles in this type of strike (-1 for no variance)
 	int			weapon_info_index;		// missile type
+	int			fireball_idx;			// Type of fireball to use for warp effect (defaults to FIREBALL_WARP)
 	float		warp_radius;			// radius of associated warp effect
 	float		warp_time;				// how long the warp effect lasts
 	float		radius;					// radius around the target ship
@@ -49,7 +50,7 @@ typedef struct ssm_firing_info {
 	SCP_vector<vec3d>	start_pos;		// start positions
 
 	int					count;			// The ssm_info count may be variable; this stores the actual number of projectiles for this strike.
-	size_t				ssm_index;		// index info ssm_info array
+	size_t				ssm_index;		// index into ssm_info array
 	class object*		target;			// target for the strike
 	int					ssm_team;		// team that fired the ssm.
 	float				duration;		// how far into the warp effect to fire

--- a/code/model/model.h
+++ b/code/model/model.h
@@ -346,6 +346,7 @@ public:
 	bool	use_render_box_offset;		// whether an offset has been defined; needed because one can't tell just by looking at render_box_offset
 	int		use_render_sphere;		// 0==do nothing, 1==only render this object if you are inside the sphere, -1==only if you're outside
 	bool 	use_render_sphere_offset;// whether an offset has been defined; needed because one can't tell just by looking at render_sphere_offset
+	bool    do_not_scale_detail_distances{false}; // if set should not scale boxes or spheres based on 'model detail' settings
 	bool	gun_rotation;			// for animated weapon models
 	bool	no_collisions;			// for $no_collisions property - kazan
 	bool	nocollide_this_only;	//SUSHI: Like no_collisions, but not recursive. For the "replacement" collision model scheme.

--- a/code/model/modelread.cpp
+++ b/code/model/modelread.cpp
@@ -1513,6 +1513,11 @@ int read_model_file(polymodel * pm, const char *filename, int n_subsystems, mode
 					} else {
 						pm->submodel[n].render_box_max = pm->submodel[n].max;
 					}
+
+					if ( (p = strstr(props, "$do_not_scale_distances")) != nullptr ) {
+						p += 23;
+						pm->submodel[n].do_not_scale_detail_distances = true;
+					}
 				}
 
 				if ( (p = strstr(props, "$detail_sphere:")) != NULL ) {
@@ -1540,6 +1545,11 @@ int read_model_file(polymodel * pm, const char *filename, int n_subsystems, mode
 						pm->submodel[n].use_render_sphere_offset = true;
 					} else {
 						pm->submodel[n].render_sphere_offset = vmd_zero_vector;
+					}
+
+					if ( (p = strstr(props, "$do_not_scale_distances")) != nullptr ) {
+						p += 23;
+						pm->submodel[n].do_not_scale_detail_distances = true;
 					}
 				}
 

--- a/code/model/modelrender.cpp
+++ b/code/model/modelrender.cpp
@@ -1461,6 +1461,9 @@ bool model_render_check_detail_box(vec3d *view_pos, polymodel *pm, int submodel_
 	bsp_info *model = &pm->submodel[submodel_num];
 
 	float box_scale = model_render_determine_box_scale();
+	if (model->do_not_scale_detail_distances) {
+		box_scale = 1.0f;
+	}
 
 	if ( !( flags & MR_FULL_DETAIL ) && model->use_render_box ) {
 		vec3d box_min, box_max, offset;
@@ -2536,13 +2539,13 @@ void model_render_debug(int model_num, matrix *orient, vec3d * pos, uint flags, 
 	gr_zbuffer_set(save_gr_zbuffering_mode);
 }
 
-void model_render_immediate(model_render_params *render_info, int model_num, matrix *orient, vec3d * pos, int render, bool sort)
+void model_render_immediate(model_render_params* render_info, int model_num, matrix* orient, vec3d* pos, int render, bool sort, vec3d show_ship_pos, bool is_using_showship)
 {
 	model_draw_list model_list;
 
 	model_list.init();
 
-	model_render_queue(render_info, &model_list, model_num, orient, pos);
+	model_render_queue(render_info, &model_list, model_num, orient, pos, show_ship_pos, is_using_showship);
 
 	model_list.init_render(sort);
 
@@ -2578,7 +2581,7 @@ void model_render_immediate(model_render_params *render_info, int model_num, mat
 	}
 }
 
-void model_render_queue(model_render_params *interp, model_draw_list *scene, int model_num, matrix *orient, vec3d *pos)
+void model_render_queue(model_render_params* interp, model_draw_list* scene, int model_num, matrix* orient, vec3d* pos, vec3d show_ship_pos, bool is_using_showship)
 {
 	int i;
 
@@ -2809,7 +2812,9 @@ void model_render_queue(model_render_params *interp, model_draw_list *scene, int
 
 	//*************************** draw the hull of the ship *********************************************
 	vec3d view_pos = scene->get_view_position();
-
+	if (is_using_showship) {
+		view_pos = show_ship_pos;
+	}
 	if ( model_render_check_detail_box(&view_pos, pm, pm->detail[detail_level], model_flags) ) {
 		int detail_model_num = pm->detail[detail_level];
 

--- a/code/model/modelrender.h
+++ b/code/model/modelrender.h
@@ -296,8 +296,8 @@ public:
 	void reset();
 };
 
-void model_render_immediate(model_render_params *render_info, int model_num, matrix *orient, vec3d * pos, int render = MODEL_RENDER_ALL, bool sort = true);
-void model_render_queue(model_render_params *render_info, model_draw_list* scene, int model_num, matrix *orient, vec3d *pos);
+void model_render_immediate(model_render_params* render_info, int model_num, matrix* orient, vec3d* pos, int render = MODEL_RENDER_ALL, bool sort = true, vec3d show_ship_pos = vmd_zero_vector, bool is_using_showship = false);
+void model_render_queue(model_render_params* render_info, model_draw_list* scene, int model_num, matrix* orient, vec3d* pos, vec3d show_ship_pos = vmd_zero_vector, bool is_using_showship = false);
 void submodel_render_immediate(model_render_params *render_info, int model_num, int submodel_num, matrix *orient, vec3d * pos);
 void submodel_render_queue(model_render_params *render_info, model_draw_list *scene, int model_num, int submodel_num, matrix *orient, vec3d * pos);
 void model_render_buffers(model_draw_list* scene, model_material *rendering_material, model_render_params* interp, vertex_buffer *buffer, polymodel *pm, int mn, int detail_level, uint tmap_flags);

--- a/code/scripting/api/objs/hudgauge.cpp
+++ b/code/scripting/api/objs/hudgauge.cpp
@@ -75,7 +75,7 @@ ADE_OBJ(l_HudGaugeDrawFuncs,
 
 ADE_FUNC(drawString,
          l_HudGaugeDrawFuncs,
-         "number x, number y, string text",
+         "string text, number x, number y",
          "Draws a string in the context of the HUD gauge.",
          "boolean",
          "true on success, false otherwise") {
@@ -84,14 +84,85 @@ ADE_FUNC(drawString,
 	float y;
 	const char* text;
 
-	if (!ade_get_args(L, "offs", l_HudGaugeDrawFuncs.Get(&gauge), &x, &y, &text)) {
+	if (!ade_get_args(L, "osff", l_HudGaugeDrawFuncs.Get(&gauge), &text, &x, &y)) {
 		return ADE_RETURN_FALSE;
 	}
 
 	int gauge_x, gauge_y;
 	gauge->getPosition(&gauge_x, &gauge_y);
 
-	gauge->renderString(fl2i(gauge_x + x), fl2i(gauge_y), text);
+	gauge->renderString(fl2i(gauge_x + x), fl2i(gauge_y + y), text);
+
+	return ADE_RETURN_TRUE;
+}
+
+ADE_FUNC(drawLine, l_HudGaugeDrawFuncs, "number X1, number Y1, number X2, number Y2",
+         "Draws a line in the context of the HUD gauge.", "boolean", "true on success, false otherwise")
+{
+	HudGauge* gauge;
+	float x1;
+	float y1;
+	float x2;
+	float y2;
+
+	if (!ade_get_args(L, "offff", l_HudGaugeDrawFuncs.Get(&gauge), &x1, &y1, &x2, &y2)) {
+		return ADE_RETURN_FALSE;
+	}
+
+	int gauge_x, gauge_y;
+	gauge->getPosition(&gauge_x, &gauge_y);
+
+	gauge->renderLine(fl2i(gauge_x + x1), fl2i(gauge_y + y1), fl2i(gauge_x + x2), fl2i(gauge_y + y2));
+
+	return ADE_RETURN_TRUE;
+}
+
+ADE_FUNC(drawCircle, l_HudGaugeDrawFuncs, "number radius, number X, number Y, [boolean filled=true]",
+         "Draws a circle in the context of the HUD gauge.", "boolean", "true on success, false otherwise")
+{
+	HudGauge* gauge;
+	float x;
+	float y;
+	float radius;
+	bool filled=true;
+
+	if (!ade_get_args(L, "offf|b", l_HudGaugeDrawFuncs.Get(&gauge), &radius, &x, &y, &filled)) {
+		return ADE_RETURN_FALSE;
+	}
+
+	int gauge_x, gauge_y;
+	gauge->getPosition(&gauge_x, &gauge_y);
+
+	gauge->renderCircle(fl2i(gauge_x + x), fl2i(gauge_y + y), fl2i(radius*2), filled);
+
+	return ADE_RETURN_TRUE;
+}
+
+ADE_FUNC(drawRectangle, l_HudGaugeDrawFuncs, "number X1, number Y1, number X2, number Y2, [boolean Filled=true]",
+         "Draws a rectangle in the context of the HUD gauge.", "boolean", "true on success, false otherwise")
+{
+	HudGauge* gauge;
+	float x1;
+	float y1;
+	float x2;
+	float y2;
+	bool filled = true;
+
+	if (!ade_get_args(L, "offff|b", l_HudGaugeDrawFuncs.Get(&gauge), &x1, &y1, &x2, &y2, &filled)) {
+		return ADE_RETURN_FALSE;
+	}
+
+	int gauge_x, gauge_y;
+	gauge->getPosition(&gauge_x, &gauge_y);
+
+	if (filled) {
+		gauge->renderRect(fl2i(gauge_x + x1), fl2i(gauge_y + y1), fl2i(x2-x1), fl2i(y2-y1));
+	} else {
+		gauge->renderLine(fl2i(gauge_x + x1), fl2i(gauge_y + y1), fl2i(gauge_x + x2), fl2i(gauge_y + y1));
+		gauge->renderLine(fl2i(gauge_x + x1), fl2i(gauge_y + y2), fl2i(gauge_x + x2), fl2i(gauge_y + y2));
+		gauge->renderLine(fl2i(gauge_x + x1), fl2i(gauge_y + y1), fl2i(gauge_x + x1), fl2i(gauge_y + y2));
+		gauge->renderLine(fl2i(gauge_x + x2), fl2i(gauge_y + y1), fl2i(gauge_x + x2), fl2i(gauge_y + y2));
+	}
 
 	return ADE_RETURN_TRUE;
 }

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -6789,10 +6789,27 @@ void ship_render_cockpit(object *objp)
 
 void ship_render_show_ship_cockpit(object *objp)
 {
+	if (objp->type != OBJ_SHIP || objp->instance < 0)
+		return;
+
 	vec3d cockpit_eye_pos;
 	matrix dummy;
 	ship_get_eye(&cockpit_eye_pos, &dummy, objp, true, true); //Get cockpit eye position
-	
+
+	// Get the eye position for the ship in local coordinates
+	// Will be used for detail_box calculations, which use local coordinates
+	ship* shipp    = &Ships[objp->instance];
+	ship_info* sip = &Ship_info[shipp->ship_info_index];
+	polymodel* pm  = model_get(sip->model_num);
+	vec3d pos_for_detail_box_check;
+	// Check if there is a valid eye position
+	if (!(shipp->current_viewpoint < 0) && !(pm->n_view_positions == 0) && !(shipp->current_viewpoint > pm->n_view_positions)) {
+		eye* ep = &(pm->view_positions[shipp->current_viewpoint]);
+		pos_for_detail_box_check = ep->pnt;
+	} else {
+		pos_for_detail_box_check = cockpit_eye_pos;
+	}
+
 	gr_end_view_matrix();
 	gr_end_proj_matrix();
 	gr_set_proj_matrix(Proj_fov, gr_screen.clip_aspect, 0.05f, Max_draw_distance);
@@ -6804,8 +6821,8 @@ void ship_render_show_ship_cockpit(object *objp)
 
 	render_info.set_object_number(OBJ_INDEX(objp));
 	render_info.set_detail_level_lock(0);
-
-	model_render_immediate(&render_info, Ship_info[Ships[objp->instance].ship_info_index].model_num, &objp->orient, &vmd_zero_vector); // Render ship model with fixed detail level 0 so its not switching LOD when moving away from origin
+	// Render ship model with fixed detail level 0 so its not switching LOD when moving away from origin
+	model_render_immediate(&render_info, sip->model_num, &objp->orient, &vmd_zero_vector, MODEL_RENDER_ALL, true, pos_for_detail_box_check, true);
 	Glowpoint_override = false;
 
 	gr_end_view_matrix();


### PR DESCRIPTION
This PR fixes issue #2015, which is a bug where using `show ship` caused `detail_box` calculations to incorrectly use world coordinates for sub-models on the player's ship, rather then the correct local coordinates.

I figured out that the `show_ship rendering` couldn't be changed without causing issues...so I just added an extra optional argument from `show_ship` that gets passed to the `detail_box` check, and that argument tells `detail_box` to do it's distance checks from local coordinates instead of the world coordinates the `show_ship` was using.