### PR TITLE
Fix `detail_box` calculations when using `show ship`

### DIFF
--- a/code/model/modelrender.cpp
+++ b/code/model/modelrender.cpp
@@ -2539,13 +2539,13 @@ void model_render_debug(int model_num, matrix *orient, vec3d * pos, uint flags, 
 	gr_zbuffer_set(save_gr_zbuffering_mode);
 }
 
-void model_render_immediate(model_render_params *render_info, int model_num, matrix *orient, vec3d * pos, int render, bool sort)
+void model_render_immediate(model_render_params* render_info, int model_num, matrix* orient, vec3d* pos, int render, bool sort, vec3d show_ship_pos, bool is_using_showship)
 {
 	model_draw_list model_list;
 
 	model_list.init();
 
-	model_render_queue(render_info, &model_list, model_num, orient, pos);
+	model_render_queue(render_info, &model_list, model_num, orient, pos, show_ship_pos, is_using_showship);
 
 	model_list.init_render(sort);
 
@@ -2581,7 +2581,7 @@ void model_render_immediate(model_render_params *render_info, int model_num, mat
 	}
 }
 
-void model_render_queue(model_render_params *interp, model_draw_list *scene, int model_num, matrix *orient, vec3d *pos)
+void model_render_queue(model_render_params* interp, model_draw_list* scene, int model_num, matrix* orient, vec3d* pos, vec3d show_ship_pos, bool is_using_showship)
 {
 	int i;
 
@@ -2813,6 +2813,9 @@ void model_render_queue(model_render_params *interp, model_draw_list *scene, int
 	//*************************** draw the hull of the ship *********************************************
 	vec3d view_pos = scene->get_view_position();
 
+	if (is_using_showship) {
+		view_pos = show_ship_pos;
+	}
 	if ( model_render_check_detail_box(&view_pos, pm, pm->detail[detail_level], model_flags) ) {
 		int detail_model_num = pm->detail[detail_level];
 

--- a/code/model/modelrender.h
+++ b/code/model/modelrender.h
@@ -296,8 +296,8 @@ public:
 	void reset();
 };
 
-void model_render_immediate(model_render_params *render_info, int model_num, matrix *orient, vec3d * pos, int render = MODEL_RENDER_ALL, bool sort = true);
-void model_render_queue(model_render_params *render_info, model_draw_list* scene, int model_num, matrix *orient, vec3d *pos);
+void model_render_immediate(model_render_params* render_info, int model_num, matrix* orient, vec3d* pos, int render = MODEL_RENDER_ALL, bool sort = true, vec3d show_ship_pos = vmd_zero_vector, bool is_using_showship = false);
+void model_render_queue(model_render_params* render_info, model_draw_list* scene, int model_num, matrix* orient, vec3d* pos, vec3d show_ship_pos = vmd_zero_vector, bool is_using_showship = false);
 void submodel_render_immediate(model_render_params *render_info, int model_num, int submodel_num, matrix *orient, vec3d * pos);
 void submodel_render_queue(model_render_params *render_info, model_draw_list *scene, int model_num, int submodel_num, matrix *orient, vec3d * pos);
 void model_render_buffers(model_draw_list* scene, model_material *rendering_material, model_render_params* interp, vertex_buffer *buffer, polymodel *pm, int mn, int detail_level, uint tmap_flags);


### PR DESCRIPTION
This PR fixes issue #2015, which is a bug where using `show ship` caused detail_box calculations to incorrectly use world coordinates for submodels on the player's ship, rather then the correct local coordinates.

This PR replaces the one that got mangled by re-basing issues. I apologize for the inconvenience. 