### PR TITLE
Cleaner fix for show-ship bug with detail_box calculations

### DIFF
--- a/code/model/modelrender.cpp
+++ b/code/model/modelrender.cpp
@@ -2539,13 +2539,13 @@ void model_render_debug(int model_num, matrix *orient, vec3d * pos, uint flags, 
 	gr_zbuffer_set(save_gr_zbuffering_mode);
 }
 
-void model_render_immediate(model_render_params* render_info, int model_num, matrix* orient, vec3d* pos, int render, bool sort, vec3d show_ship_pos, bool is_using_showship)
+void model_render_immediate(model_render_params *render_info, int model_num, matrix *orient, vec3d * pos, int render, bool sort)
 {
 	model_draw_list model_list;
 
 	model_list.init();
 
-	model_render_queue(render_info, &model_list, model_num, orient, pos, show_ship_pos, is_using_showship);
+	model_render_queue(render_info, &model_list, model_num, orient, pos);
 
 	model_list.init_render(sort);
 
@@ -2581,7 +2581,7 @@ void model_render_immediate(model_render_params* render_info, int model_num, mat
 	}
 }
 
-void model_render_queue(model_render_params* interp, model_draw_list* scene, int model_num, matrix* orient, vec3d* pos, vec3d show_ship_pos, bool is_using_showship)
+void model_render_queue(model_render_params *interp, model_draw_list *scene, int model_num, matrix *orient, vec3d *pos)
 {
 	int i;
 
@@ -2813,9 +2813,6 @@ void model_render_queue(model_render_params* interp, model_draw_list* scene, int
 	//*************************** draw the hull of the ship *********************************************
 	vec3d view_pos = scene->get_view_position();
 
-	if (is_using_showship) {
-		view_pos = show_ship_pos;
-	}
 	if ( model_render_check_detail_box(&view_pos, pm, pm->detail[detail_level], model_flags) ) {
 		int detail_model_num = pm->detail[detail_level];
 

--- a/code/model/modelrender.h
+++ b/code/model/modelrender.h
@@ -296,8 +296,8 @@ public:
 	void reset();
 };
 
-void model_render_immediate(model_render_params* render_info, int model_num, matrix* orient, vec3d* pos, int render = MODEL_RENDER_ALL, bool sort = true, vec3d show_ship_pos = vmd_zero_vector, bool is_using_showship = false);
-void model_render_queue(model_render_params* render_info, model_draw_list* scene, int model_num, matrix* orient, vec3d* pos, vec3d show_ship_pos = vmd_zero_vector, bool is_using_showship = false);
+void model_render_immediate(model_render_params *render_info, int model_num, matrix *orient, vec3d * pos, int render = MODEL_RENDER_ALL, bool sort = true);
+void model_render_queue(model_render_params *render_info, model_draw_list* scene, int model_num, matrix *orient, vec3d *pos);
 void submodel_render_immediate(model_render_params *render_info, int model_num, int submodel_num, matrix *orient, vec3d * pos);
 void submodel_render_queue(model_render_params *render_info, model_draw_list *scene, int model_num, int submodel_num, matrix *orient, vec3d * pos);
 void model_render_buffers(model_draw_list* scene, model_material *rendering_material, model_render_params* interp, vertex_buffer *buffer, polymodel *pm, int mn, int detail_level, uint tmap_flags);

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -6789,6 +6789,9 @@ void ship_render_cockpit(object *objp)
 
 void ship_render_show_ship_cockpit(object *objp)
 {
+	if (objp->type != OBJ_SHIP || objp->instance < 0)
+		return;
+
 	vec3d cockpit_eye_pos;
 	matrix dummy;
 	ship_get_eye(&cockpit_eye_pos, &dummy, objp, true, false); //Get cockpit eye position

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -6789,27 +6789,10 @@ void ship_render_cockpit(object *objp)
 
 void ship_render_show_ship_cockpit(object *objp)
 {
-	if (objp->type != OBJ_SHIP || objp->instance < 0)
-		return;
-
 	vec3d cockpit_eye_pos;
 	matrix dummy;
-	ship_get_eye(&cockpit_eye_pos, &dummy, objp, true, true); //Get cockpit eye position
+	ship_get_eye(&cockpit_eye_pos, &dummy, objp, true, false); //Get cockpit eye position
 	
-	// Get the eye position for the ship in local coordinates
-	// Will be used for detail_box calculations, which use local coordinates
-	ship* shipp    = &Ships[objp->instance];
-	ship_info* sip = &Ship_info[shipp->ship_info_index];
-	polymodel* pm  = model_get(sip->model_num);
-	vec3d pos_for_detail_box_check;
-	// Check if there is a valid eye position
-	if (!(shipp->current_viewpoint < 0) && !(pm->n_view_positions == 0) && !(shipp->current_viewpoint > pm->n_view_positions)) {
-		eye* ep = &(pm->view_positions[shipp->current_viewpoint]);
-		pos_for_detail_box_check = ep->pnt;
-	} else {
-		pos_for_detail_box_check = cockpit_eye_pos;
-	}
-
 	gr_end_view_matrix();
 	gr_end_proj_matrix();
 	gr_set_proj_matrix(Proj_fov, gr_screen.clip_aspect, 0.05f, Max_draw_distance);
@@ -6822,8 +6805,7 @@ void ship_render_show_ship_cockpit(object *objp)
 	render_info.set_object_number(OBJ_INDEX(objp));
 	render_info.set_detail_level_lock(0);
 
-	// Render ship model with fixed detail level 0 so its not switching LOD when moving away from origin
-	model_render_immediate(&render_info, sip->model_num, &objp->orient, &vmd_zero_vector, MODEL_RENDER_ALL, true, pos_for_detail_box_check, true);
+	model_render_immediate(&render_info, Ship_info[Ships[objp->instance].ship_info_index].model_num, &objp->orient, &objp->pos); // Render ship model with fixed detail level 0 so its not switching LOD when moving away from origin
 	Glowpoint_override = false;
 
 	gr_end_view_matrix();


### PR DESCRIPTION
This provides a cleaner fix for the bug where using show ship caused detail_box calculations to incorrectly work on the player's ship. 

This PR also reverts the changes made by PR #2018 (that's why there are so many deletions).

Sorry for the repeated PR's and big thank you to m!m for his assistance and patience. 