### PR TITLE
Add unload function for freeing audio memory of a soundfile handle

### DIFF
--- a/code/scripting/api/libs/audio.cpp
+++ b/code/scripting/api/libs/audio.cpp
@@ -59,13 +59,13 @@ ADE_FUNC(loadSoundfile, l_Audio, "string filename", "Loads the specified sound f
 	const char* fileName = nullptr;
 
 	if (!ade_get_args(L, "s", &fileName))
-		return ade_set_error(L, "o", l_Soundfile.Set(sound_load_id::invalid()));
+		return ade_set_error(L, "o", l_Soundfile.Set(soundfile_h(sound_load_id::invalid())));
 
 	game_snd_entry tmp_gs;
 	strcpy_s( tmp_gs.filename, fileName );
 	auto n = snd_load(&tmp_gs, 0, 0);
 
-	return ade_set_error(L, "o", l_Soundfile.Set(n));
+	return ade_set_error(L, "o", l_Soundfile.Set(soundfile_h(n)));
 }
 
 ADE_FUNC(playSound, l_Audio, "soundentry", "Plays the specified sound entry handle", "sound", "A handle to the playing sound")

--- a/code/scripting/api/objs/message.cpp
+++ b/code/scripting/api/objs/message.cpp
@@ -83,20 +83,20 @@ ADE_VIRTVAR(Message, l_Message, "string", "The unaltered text of the message, se
 ADE_VIRTVAR(VoiceFile, l_Message, "soundfile", "The voice file of the message", "soundfile", "The voice file handle or invalid handle when not present")
 {
 	int idx = -1;
-	auto sndIdx = sound_load_id::invalid();
+	soundfile_h* sndIdx = nullptr;
 
-	if (!ade_get_args(L, "o|o", l_Message.Get(&idx), l_Soundfile.Get(&sndIdx)))
-		return ade_set_error(L, "o", l_Soundfile.Set(sound_load_id::invalid()));
+	if (!ade_get_args(L, "o|o", l_Message.Get(&idx), l_Soundfile.GetPtr(&sndIdx)))
+		return ade_set_error(L, "o", l_Soundfile.Set(soundfile_h()));
 
 	if (idx < 0 && idx >= (int) Messages.size())
-		return ade_set_error(L, "o", l_Soundfile.Set(sound_load_id::invalid()));
+		return ade_set_error(L, "o", l_Soundfile.Set(soundfile_h()));
 
 	MissionMessage* msg = &Messages[idx];
 
 	if (ADE_SETTING_VAR)
 	{
-		if (sndIdx.isValid()) {
-			const char* newFilename = snd_get_filename(sndIdx);
+		if (sndIdx->idx.isValid()) {
+			const char* newFilename = snd_get_filename(sndIdx->idx);
 
 			msg->wave_info.index = add_wave(newFilename);
 		}
@@ -108,7 +108,7 @@ ADE_VIRTVAR(VoiceFile, l_Message, "soundfile", "The voice file of the message", 
 
 	if (msg->wave_info.index < 0)
 	{
-		return ade_set_args(L, "o", l_Soundfile.Set(sound_load_id::invalid()));
+		return ade_set_args(L, "o", l_Soundfile.Set(soundfile_h()));
 	}
 	else
 	{
@@ -116,7 +116,7 @@ ADE_VIRTVAR(VoiceFile, l_Message, "soundfile", "The voice file of the message", 
 		// Load the sound before using it
 		message_load_wave(index, Message_waves[index].name);
 
-		return ade_set_args(L, "o", l_Soundfile.Set(Message_waves[index].num));
+		return ade_set_args(L, "o", l_Soundfile.Set(soundfile_h(Message_waves[index].num)));
 	}
 }
 
@@ -126,10 +126,10 @@ ADE_VIRTVAR(Persona, l_Message, "persona", "The persona of the message", "person
 	int newPersona = -1;
 
 	if (!ade_get_args(L, "o|o", l_Message.Get(&idx), l_Persona.Get(&newPersona)))
-		return ade_set_error(L, "o", l_Soundfile.Set(sound_load_id::invalid()));
+		return ade_set_error(L, "o", l_Soundfile.Set(soundfile_h()));
 
 	if (idx < 0 && idx >= (int) Messages.size())
-		return ade_set_error(L, "o", l_Soundfile.Set(sound_load_id::invalid()));
+		return ade_set_error(L, "o", l_Soundfile.Set(soundfile_h()));
 
 	if (ADE_SETTING_VAR && newPersona >= 0 && newPersona < Num_personas)
 	{

--- a/code/scripting/api/objs/sound.cpp
+++ b/code/scripting/api/objs/sound.cpp
@@ -305,7 +305,11 @@ ADE_FUNC(stop, l_Sound, NULL, "Stops the sound of this handle", "boolean", "true
 	return ADE_RETURN_TRUE;
 }
 
-ADE_FUNC(isValid, l_Sound, NULL, "Detects whether the whole handle is valid", "boolean", "true if valid, false if handle is invalid, nil if a syntax/type error occurs")
+ADE_FUNC(isValid, l_Sound, nullptr,
+         "Detects whether the whole handle is valid.<br>"
+         "<b>Warning:</b> This does not work for sounds started by a "
+         "directly loaded sound file! Use isSoundValid() in that case instead.",
+         "boolean", "true if valid, false if handle is invalid, nil if a syntax/type error occurs")
 {
 	sound_h *sh;
 	if(!ade_get_args(L, "o", l_Sound.GetPtr(&sh)))
@@ -346,34 +350,36 @@ ADE_FUNC(updatePosition, l_Sound3D, "vector Position[, number radius = 0.0]", "U
 
 
 //**********HANDLE: Soundfile
-ADE_OBJ(l_Soundfile, sound_load_id, "soundfile", "Handle to a sound file");
+soundfile_h::soundfile_h(sound_load_id id) : idx(id) {}
+
+ADE_OBJ(l_Soundfile, soundfile_h, "soundfile", "Handle to a sound file");
 
 ADE_VIRTVAR(Duration, l_Soundfile, "number", "The duration of the sound file, in seconds", "number", "The duration or -1 on error")
 {
-	auto snd_idx = sound_load_id::invalid();
+	soundfile_h* handle = nullptr;
 
-	if (!ade_get_args(L, "o", l_Soundfile.Get(&snd_idx)))
+	if (!ade_get_args(L, "o", l_Soundfile.GetPtr(&handle)))
 		return ade_set_error(L, "f", -1.0f);
 
-	if (!snd_idx.isValid())
+	if (!handle->idx.isValid())
 		return ade_set_error(L, "f", -1.0f);
 
-	int duration = snd_get_duration(snd_idx);
+	int duration = snd_get_duration(handle->idx);
 
 	return ade_set_args(L, "f", i2fl(duration) / 1000.0f);
 }
 
 ADE_VIRTVAR(Filename, l_Soundfile, "string", "The filename of the file", "string", "The file name or empty string on error")
 {
-	auto snd_idx = sound_load_id::invalid();
+	soundfile_h* handle = nullptr;
 
-	if (!ade_get_args(L, "o", l_Soundfile.Get(&snd_idx)))
+	if (!ade_get_args(L, "o", l_Soundfile.GetPtr(&handle)))
 		return ade_set_error(L, "s", "");
 
-	if (!snd_idx.isValid())
+	if (!handle->idx.isValid())
 		return ade_set_error(L, "s", "");
 
-	const char* filename = snd_get_filename(snd_idx);
+	const char* filename = snd_get_filename(handle->idx);
 
 	return ade_set_args(L, "s", filename);
 }
@@ -381,14 +387,14 @@ ADE_VIRTVAR(Filename, l_Soundfile, "string", "The filename of the file", "string
 
 ADE_FUNC(play, l_Soundfile, "[number volume = 1.0[, number panning = 0.0]]", "Plays the sound", "sound", "A sound handle or invalid handle on error")
 {
-	auto snd_idx  = sound_load_id::invalid();
+	soundfile_h* handle = nullptr;
 	float volume = 1.0f;
 	float panning = 0.0f;
 
-	if (!ade_get_args(L, "o|ff", l_Soundfile.Get(&snd_idx), &volume, &panning))
+	if (!ade_get_args(L, "o|ff", l_Soundfile.GetPtr(&handle), &volume, &panning))
 		return ade_set_error(L, "o", l_Sound.Set(sound_h()));
 
-	if (!snd_idx.isValid())
+	if (!handle->idx.isValid())
 		return ade_set_error(L, "o", l_Sound.Set(sound_h()));
 
 	if (volume < 0.0f)
@@ -397,19 +403,45 @@ ADE_FUNC(play, l_Soundfile, "[number volume = 1.0[, number panning = 0.0]]", "Pl
 		return ade_set_error(L, "o", l_Sound.Set(sound_h()));
 	}
 
-	auto handle = snd_play_raw(snd_idx, panning, volume);
+	auto snd_handle = snd_play_raw(handle->idx, panning, volume);
 
-	return ade_set_args(L, "o", l_Sound.Set(sound_h(gamesnd_id(), handle)));
+	return ade_set_args(L, "o", l_Sound.Set(sound_h(gamesnd_id(), snd_handle)));
+}
+
+ADE_FUNC(unload, l_Soundfile, nullptr,
+         "Unloads the audio data loaded for this sound file. This invalidates the handle on which this is called!",
+         "boolean", "true if successful, false otherwise")
+{
+	soundfile_h* handle = nullptr;
+
+	if (!ade_get_args(L, "o", l_Soundfile.GetPtr(&handle)))
+		return ade_set_error(L, "b", false);
+
+	if (!handle->idx.isValid())
+		return ade_set_error(L, "b", false);
+
+	auto result = snd_unload(handle->idx);
+
+	if (result != 0) {
+		// Invalidate this handle so that the script cannot do something bad with it
+		handle->idx = sound_load_id::invalid();
+	}
+
+	return ade_set_args(L, "b", result != 0);
 }
 
 ADE_FUNC(isValid, l_Soundfile, NULL, "Checks if the soundfile handle is valid", "boolean", "true if valid, false otherwise")
 {
-	auto idx = sound_load_id::invalid();
+	soundfile_h* handle = nullptr;
 
-	if (!ade_get_args(L, "o", l_Soundfile.Get(&idx)))
+	if (!ade_get_args(L, "o", l_Soundfile.GetPtr(&handle)))
 		return ADE_RETURN_FALSE;
 
-	return ade_set_args(L, "b", idx.isValid());
+	if (handle == nullptr) {
+		return ADE_RETURN_FALSE;
+	}
+
+	return ade_set_args(L, "b", handle->idx.isValid());
 }
 
 

--- a/code/scripting/api/objs/sound.h
+++ b/code/scripting/api/objs/sound.h
@@ -48,7 +48,14 @@ DECLARE_ADE_OBJ(l_Sound3D, sound_h);
 
 
 //**********HANDLE: Soundfile
-DECLARE_ADE_OBJ(l_Soundfile, sound_load_id);
+
+struct soundfile_h {
+	sound_load_id idx;
+
+	explicit soundfile_h(sound_load_id id = sound_load_id::invalid());
+};
+
+DECLARE_ADE_OBJ(l_Soundfile, soundfile_h);
 }
 }
 


### PR DESCRIPTION
This can be used by scripts for explicitly freeing up some memory when
necessary.