### PR TITLE
fix bug #1827: targeting brackets stuck in top left corner

### DIFF
--- a/code/hud/hudtarget.cpp
+++ b/code/hud/hudtarget.cpp
@@ -6338,6 +6338,8 @@ void HudGaugeOffscreen::calculatePosition(vertex* target_point, vec3d *tpos, vec
 	if (eye_vertex->flags&PF_OVERFLOW) {
 		Int3();			//	This is unlikely to happen, but can if a clip goes through the player's eye.
 		Player_ai->target_objnum = -1;
+		if (!in_frame)
+			g3_end_frame();
 		return;
 	}
 
@@ -6398,6 +6400,8 @@ void HudGaugeOffscreen::calculatePosition(vertex* target_point, vec3d *tpos, vec
 
 	} else {
 		Int3();
+		if (!in_frame)
+			g3_end_frame();
 		return;
 	}
 


### PR DESCRIPTION
Fixes #1827

Every g3_start_frame must have a matching g3_end_frame. Thus, a return in the middle of a function after an opening g3_start_frame must make sure to call g3_end_frame before it leaves to avoid a dangling frame
context.

As described in the bug report a floating point rounding issue could be the trigger for the problem.