### PR TITLE
upgrade clang-tidy to 8.0, the latest stable release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: bash
 sudo: required
-dist: trusty
+dist: xenial
 cache:
   directories:
     - $HOME/cmake-3.8
@@ -18,7 +18,6 @@ addons:
       - libjansson-dev
       - libsdl2-dev
       - libfreetype6-dev
-      - valgrind
       - qt57base
   coverity_scan:
     project:
@@ -73,7 +72,7 @@ matrix:
         apt:
           sources:
             - ubuntu-toolchain-r-test
-            - sourceline: 'ppa:beineri/opt-qt571-trusty'
+            - sourceline: 'ppa:beineri/opt-qt571-xenial'
           packages:
             - *global_deps
             - g++-5
@@ -83,7 +82,7 @@ matrix:
         apt:
           sources:
             - ubuntu-toolchain-r-test
-            - sourceline: 'ppa:beineri/opt-qt571-trusty'
+            - sourceline: 'ppa:beineri/opt-qt571-xenial'
           packages:
             - g++-9
             - *global_deps
@@ -93,15 +92,14 @@ matrix:
         apt:
           sources:
             - ubuntu-toolchain-r-test
-            - llvm-toolchain-trusty-4.0
-            - llvm-toolchain-trusty-8.0
-            - sourceline: 'ppa:beineri/opt-qt571-trusty'
+            - llvm-toolchain-xenial-8
+            - sourceline: 'ppa:beineri/opt-qt571-xenial'
           packages:
             - *global_deps
             - clang-4.0
-            - clang-tidy-4.0
-            - clang-tidy-8.0
+            - clang-tidy-8
             - libc++-dev
+            - libc++abi-dev
       script:
         - ./ci/travis/script.sh
         - ./ci/travis/clang_tidy.sh
@@ -119,7 +117,7 @@ matrix:
         apt:
           sources:
             - ubuntu-toolchain-r-test
-            - sourceline: 'ppa:beineri/opt-qt571-trusty'
+            - sourceline: 'ppa:beineri/opt-qt571-xenial'
           packages:
             - *global_deps
             - g++-5
@@ -129,7 +127,7 @@ matrix:
         apt:
           sources:
             - ubuntu-toolchain-r-test
-            - sourceline: 'ppa:beineri/opt-qt571-trusty'
+            - sourceline: 'ppa:beineri/opt-qt571-xenial'
           packages:
             - g++-9
             - *global_deps
@@ -139,12 +137,13 @@ matrix:
         apt:
           sources:
             - ubuntu-toolchain-r-test
-            - llvm-toolchain-trusty-4.0
-            - sourceline: 'ppa:beineri/opt-qt571-trusty'
+            - llvm-toolchain-xenial-4
+            - sourceline: 'ppa:beineri/opt-qt571-xenial'
           packages:
             - *global_deps
             - clang-4.0
             - libc++-dev
+            - libc++abi-dev
     - os: osx
       env: CONFIGURATION="Release"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -94,11 +94,13 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
             - llvm-toolchain-trusty-4.0
+            - llvm-toolchain-trusty-8.0
             - sourceline: 'ppa:beineri/opt-qt571-trusty'
           packages:
             - *global_deps
             - clang-4.0
             - clang-tidy-4.0
+            - clang-tidy-8.0
             - libc++-dev
       script:
         - ./ci/travis/script.sh

--- a/ci/travis/before_install.sh
+++ b/ci/travis/before_install.sh
@@ -3,8 +3,11 @@
 set -ex
 
 if [ "$TRAVIS_OS_NAME" = "linux" ]; then
-    # Nothing to do here
-    :
+    export DEBIAN_FRONTEND=noninteractive
+
+    sudo add-apt-repository -y "ppa:msulikowski/valgrind" # For fixing a bug with valgrind 3.11 which does not recognize the rdrand instruction
+    sudo apt-get -yq update
+    sudo apt-get -yq install valgrind
 elif [ "$TRAVIS_OS_NAME" = "osx" ]; then
     # Nothing to do here
     :

--- a/ci/travis/clang_tidy.sh
+++ b/ci/travis/clang_tidy.sh
@@ -13,7 +13,7 @@ echo "Running clang-tidy on changed files"
 git diff -U0 --no-color $TRAVIS_COMMIT_RANGE | \
     $TRAVIS_BUILD_DIR/ci/travis/clang-tidy-diff.py -path "$TRAVIS_BUILD_DIR/build" -p1 \
     -regex 'code/.*$|freespace2/.*$|qtfred/.*$|test/src/.*$|build/.*$|tools/.*' \
-    -clang-tidy-binary /usr/bin/clang-tidy-8.0 2>/dev/null | \
+    -clang-tidy-binary /usr/bin/clang-tidy-8 2>/dev/null | \
     tee clang-tidy-output.txt
 
 if [[ -n $(grep "warning: " clang-tidy-output.txt) ]] || [[ -n $(grep "error: " clang-tidy-output.txt) ]]; then

--- a/ci/travis/clang_tidy.sh
+++ b/ci/travis/clang_tidy.sh
@@ -13,7 +13,7 @@ echo "Running clang-tidy on changed files"
 git diff -U0 --no-color $TRAVIS_COMMIT_RANGE | \
     $TRAVIS_BUILD_DIR/ci/travis/clang-tidy-diff.py -path "$TRAVIS_BUILD_DIR/build" -p1 \
     -regex 'code/.*$|freespace2/.*$|qtfred/.*$|test/src/.*$|build/.*$|tools/.*' \
-    -clang-tidy-binary /usr/bin/clang-tidy-4.0 2>/dev/null | \
+    -clang-tidy-binary /usr/bin/clang-tidy-8.0 2>/dev/null | \
     tee clang-tidy-output.txt
 
 if [[ -n $(grep "warning: " clang-tidy-output.txt) ]] || [[ -n $(grep "error: " clang-tidy-output.txt) ]]; then

--- a/ci/travis/install.sh
+++ b/ci/travis/install.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 set -ex
 
@@ -11,7 +11,7 @@ if [ "$TRAVIS_OS_NAME" = "linux" ]; then
     	wget -O /tmp/cmake.tar.gz --no-check-certificate https://cmake.org/files/v3.8/cmake-3.8.2-Linux-x86_64.tar.gz
     	tar -xzf /tmp/cmake.tar.gz -C $HOME/cmake-3.8/ --strip-components=1
     fi
-	export PATH=$HOME/cmake-3.8/bin:$PATH
+    export PATH=$HOME/cmake-3.8/bin:$PATH
     
     cd $HOME
     
@@ -21,6 +21,11 @@ if [ "$TRAVIS_OS_NAME" = "linux" ]; then
 
         wget -O linuxdeployqt -c "https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage" # (64-bit)
         chmod a+x ./linuxdeployqt
+    fi
+
+    if [[ "$CC" =~ ^clang.*$ ]]; then
+      # Fix a header bug present in ubuntu...
+      sudo ln -s /usr/include/libcxxabi/__cxxabi_config.h /usr/include/c++/v1/__cxxabi_config.h
     fi
 elif [ "$TRAVIS_OS_NAME" = "osx" ]; then
     gem install xcpretty

--- a/ci/travis/valgrind.supp
+++ b/ci/travis/valgrind.supp
@@ -126,4 +126,39 @@
    fun:_ZN7testing8internal38HandleSehExceptionsInMethodIfSupportedINS_4TestEvEET0_PT_MS4_FS3_vEPKc
    fun:_ZN7testing8internal35HandleExceptionsInMethodIfSupportedINS_4TestEvEET0_PT_MS4_FS3_vEPKc
 }
-
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: definite
+   fun:malloc
+   fun:_dl_signal_error
+   fun:_dl_open
+   fun:dlopen_doit
+   fun:_dl_catch_error
+   fun:_dlerror_run
+   fun:dlopen@@GLIBC_2.2.5
+   obj:*
+   obj:*
+   fun:call_init.part.0
+   fun:call_init
+   fun:_dl_init
+   fun:dl_open_worker
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: definite
+   fun:malloc
+   fun:_dl_signal_error
+   fun:_dl_open
+   fun:dlopen_doit
+   fun:_dl_catch_error
+   fun:_dlerror_run
+   fun:dlopen@@GLIBC_2.2.5
+   obj:*
+   obj:*
+   fun:call_init.part.0
+   fun:call_init
+   fun:_dl_init
+   fun:dl_open_worker
+}


### PR DESCRIPTION
I propose upgrading the version of clang-tidy that we use.  This is motivated by a recent feature:

> New option _MinTypeNameLength_ for **`modernize-use-auto`** check to limit the minimal length of type names to be replaced with `auto`. Use to skip replacing short type names like `int`/`bool` with `auto`. Default value is 5 which means replace types with the name length >= 5 letters only (ex. `double`, `unsigned`).

It drives me nuts when `clang-tidy` wants to use `auto` instead of `int`.  I force-merged a previous PR because I refused to change it, and the same thing is happening again on #2026.