### PR TITLE
Allow death max rotation to be set per ship

### DIFF
--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -833,6 +833,9 @@ void ship_info::clone(const ship_info& other)
 	death_roll_r_mult = other.death_roll_r_mult;
 	death_fx_r_mult = other.death_fx_r_mult;
 	death_roll_time_mult = other.death_roll_time_mult;
+	death_roll_xrotation_cap = other.death_roll_xrotation_cap;
+	death_roll_yrotation_cap = other.death_roll_yrotation_cap;
+	death_roll_zrotation_cap = other.death_roll_zrotation_cap;
 	death_roll_base_time = other.death_roll_base_time;
 	death_fx_count = other.death_fx_count;
 	shockwave_count = other.shockwave_count;
@@ -1136,6 +1139,9 @@ void ship_info::move(ship_info&& other)
 	death_roll_r_mult = other.death_roll_r_mult;
 	death_fx_r_mult = other.death_fx_r_mult;
 	death_roll_time_mult = other.death_roll_time_mult;
+	death_roll_xrotation_cap = other.death_roll_xrotation_cap;
+	death_roll_yrotation_cap = other.death_roll_yrotation_cap;
+	death_roll_zrotation_cap = other.death_roll_zrotation_cap;
 	death_roll_base_time = other.death_roll_base_time;
 	death_fx_count = other.death_fx_count;
 	shockwave_count = other.shockwave_count;
@@ -1452,6 +1458,9 @@ ship_info::ship_info()
 	death_roll_r_mult = 1.0f;
 	death_fx_r_mult = 1.0f;
 	death_roll_time_mult = 1.0f;
+	death_roll_xrotation_cap = 0.75f*DEATHROLL_ROTVEL_CAP;
+	death_roll_yrotation_cap = 0.75f*DEATHROLL_ROTVEL_CAP;
+	death_roll_zrotation_cap = 0.75f*DEATHROLL_ROTVEL_CAP;
 	death_roll_base_time = 3000;
 	death_fx_count = 6;
 	shockwave_count = 1;
@@ -3060,6 +3069,24 @@ static int parse_ship_values(ship_info* sip, const bool is_template, const bool 
 		stuff_int(&sip->death_fx_count);
 		if (sip->death_fx_count < 0)
 			sip->death_fx_count = 0;
+	}
+
+	if(optional_string("$Death Roll X rotation Cap:")){
+		stuff_float(&sip->death_roll_xrotation_cap);
+		if (sip->death_roll_xrotation_cap < 0.0)
+			sip->death_roll_xrotation_cap = 0.0;
+	}
+
+	if(optional_string("$Death Roll Y rotation Cap:")){
+		stuff_float(&sip->death_roll_yrotation_cap);
+		if (sip->death_roll_yrotation_cap < 0.0)
+			sip->death_roll_yrotation_cap = 0.0;
+	}
+
+	if(optional_string("$Death Roll Z rotation Cap:")){
+		stuff_float(&sip->death_roll_zrotation_cap);
+		if (sip->death_roll_zrotation_cap < 0.0)
+			sip->death_roll_zrotation_cap = 0.0;
 	}
 
 	if(optional_string("$Ship Splitting Particles:"))

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -990,6 +990,9 @@ public:
 	float death_roll_r_mult;
 	float death_fx_r_mult;
 	float death_roll_time_mult;
+	float death_roll_xrotation_cap;         // max rotation around x-axis in radians-per-sec (aka pitch)
+	float death_roll_yrotation_cap;         // max rotation around y-axis in radians-per-sec (aka yaw)
+	float death_roll_zrotation_cap;         // max rotation around z-axis in radians-per-sec (aka roll)
 	int death_roll_base_time;
 	int death_fx_count;
 	int	shockwave_count;					// the # of total shockwaves

--- a/code/ship/shiphit.cpp
+++ b/code/ship/shiphit.cpp
@@ -1356,7 +1356,6 @@ static void player_died_start(object *killer_objp)
 
 //#define	DEATHROLL_TIME						3000			//	generic deathroll is 3 seconds (3 * 1000 milliseconds) - Moved to ships.tbl
 #define	MIN_PLAYER_DEATHROLL_TIME		1000			// at least one second deathroll for a player
-//#define	DEATHROLL_ROTVEL_CAP				6.3f			// maximum added deathroll rotvel in rad/sec (about 1 rev / sec) - moved to shiphit.h & converted to const float
 #define	DEATHROLL_ROTVEL_MIN				0.8f			// minimum added deathroll rotvel in rad/sec (about 1 rev / 12 sec)
 #define	DEATHROLL_MASS_STANDARD			50				// approximate mass of lightest ship
 #define	DEATHROLL_VELOCITY_STANDARD	70				// deathroll rotvel is scaled according to ship velocity

--- a/code/ship/shiphit.cpp
+++ b/code/ship/shiphit.cpp
@@ -1356,7 +1356,7 @@ static void player_died_start(object *killer_objp)
 
 //#define	DEATHROLL_TIME						3000			//	generic deathroll is 3 seconds (3 * 1000 milliseconds) - Moved to ships.tbl
 #define	MIN_PLAYER_DEATHROLL_TIME		1000			// at least one second deathroll for a player
-#define	DEATHROLL_ROTVEL_CAP				6.3f			// maximum added deathroll rotvel in rad/sec (about 1 rev / sec)
+//#define	DEATHROLL_ROTVEL_CAP				6.3f			// maximum added deathroll rotvel in rad/sec (about 1 rev / sec) - moved to shiphit.h & converted to const float
 #define	DEATHROLL_ROTVEL_MIN				0.8f			// minimum added deathroll rotvel in rad/sec (about 1 rev / 12 sec)
 #define	DEATHROLL_MASS_STANDARD			50				// approximate mass of lightest ship
 #define	DEATHROLL_VELOCITY_STANDARD	70				// deathroll rotvel is scaled according to ship velocity
@@ -1499,16 +1499,16 @@ void ship_generic_kill_stuff( object *objp, float percent_killed )
 		// if added rotvel is too random, we should decrease the random component, putting a const in front of the rotvel.
 		sp->deathroll_rotvel = objp->phys_info.rotvel;
 		sp->deathroll_rotvel.xyz.x += (frand() - 0.5f) * 2.0f * rotvel_mag;
-		saturate_fabs(&sp->deathroll_rotvel.xyz.x, 0.75f*DEATHROLL_ROTVEL_CAP);
+		saturate_fabs(&sp->deathroll_rotvel.xyz.x, sip->death_roll_xrotation_cap);
 		sp->deathroll_rotvel.xyz.y += (frand() - 0.5f) * 3.0f * rotvel_mag;
-		saturate_fabs(&sp->deathroll_rotvel.xyz.y, 0.75f*DEATHROLL_ROTVEL_CAP);
+		saturate_fabs(&sp->deathroll_rotvel.xyz.y, sip->death_roll_yrotation_cap);
 		sp->deathroll_rotvel.xyz.z += (frand() - 0.5f) * 6.0f * rotvel_mag;
 		// make z component  2x larger than larger of x,y
 		float largest_mag = MAX(fl_abs(sp->deathroll_rotvel.xyz.x), fl_abs(sp->deathroll_rotvel.xyz.y));
 		if (fl_abs(sp->deathroll_rotvel.xyz.z) < 2.0f*largest_mag) {
 			sp->deathroll_rotvel.xyz.z *= (2.0f * largest_mag / fl_abs(sp->deathroll_rotvel.xyz.z));
 		}
-		saturate_fabs(&sp->deathroll_rotvel.xyz.z, 0.75f*DEATHROLL_ROTVEL_CAP);
+		saturate_fabs(&sp->deathroll_rotvel.xyz.z, sip->death_roll_zrotation_cap);
 		// nprintf(("Physics", "Frame: %i rotvel_mag: %5.2f, rotvel: (%4.2f, %4.2f, %4.2f)\n", Framecount, rotvel_mag, sp->deathroll_rotvel.x, sp->deathroll_rotvel.y, sp->deathroll_rotvel.z));
 	}
 

--- a/code/ship/shiphit.h
+++ b/code/ship/shiphit.h
@@ -22,6 +22,8 @@ class object;
 
 #define MISS_SHIELDS		-1
 
+const float DEATHROLL_ROTVEL_CAP = 6.3f;
+
 // =====================   NOTE!! =========================
 // To apply damage to a ship, call either ship_apply_local_damage or ship_apply_global_damage.
 // These replace the old calls to ship_hit and ship_do_damage...

--- a/code/ship/shiphit.h
+++ b/code/ship/shiphit.h
@@ -22,7 +22,7 @@ class object;
 
 #define MISS_SHIELDS		-1
 
-const float DEATHROLL_ROTVEL_CAP = 6.3f;
+constexpr float DEATHROLL_ROTVEL_CAP = 6.3f;    // maximum added deathroll rotvel in rad/sec (6.3 rad/sec is about 1 rev/sec)
 
 // =====================   NOTE!! =========================
 // To apply damage to a ship, call either ship_apply_local_damage or ship_apply_global_damage.


### PR DESCRIPTION
This allows modders to restrict the amount of rotation in a death roll.
It's fairly simple to fit in with the existing code which has a lot of
hard coded constants. The intended use case is to restrict pitch &
heading changes so there's less chance of rapid forward rolls or flat
spins, especially with faster-than-FS2 ships.

I'd almost rather rewrite the entire code to dynamically use ships mass
& velocity except for retail compatibility issues.