### PR TITLE
Adds per-class flyby sounds

### DIFF
--- a/code/object/objectsnd.cpp
+++ b/code/object/objectsnd.cpp
@@ -394,12 +394,11 @@ void maybe_play_flyby_snd(float closest_dist, object *closest_objp, object *list
 				// check to see if a flyby sound is specified in ship class
 				// if not, then pick a random species-based sound
 
-				int shipinfo_int = Ships[closest_objp->instance].ship_info_index;
-				ship_info* sip = &Ship_info[shipinfo_int];
+				ship_info* sip = &Ship_info[Ships[closest_objp->instance].ship_info_index];
 				game_snd *snd;
 
-				if (Ship_info[shipinfo_int].glide_end_snd.isValid()) {
-					snd = gamesnd_get_game_sound(Ship_info[shipinfo_int].glide_end_snd);
+				if (sip->flyby_snd.isValid()) {
+					snd = gamesnd_get_game_sound(sip->flyby_snd);
 				} else {
 					if (sip->flags[Ship::Info_Flags::Bomber])
 						snd = &Species_info[sip->species].snd_flyby_bomber;

--- a/code/object/objectsnd.cpp
+++ b/code/object/objectsnd.cpp
@@ -391,18 +391,24 @@ void maybe_play_flyby_snd(float closest_dist, object *closest_objp, object *list
 					return;
 				}
 
-				// pick a random species-based sound
+				// check to see if a flyby sound is specified in ship class
+				// if not, then pick a random species-based sound
 
-				ship_info *sip = &Ship_info[Ships[closest_objp->instance].ship_info_index];
+				int shipinfo_int = Ships[closest_objp->instance].ship_info_index;
+				ship_info* sip = &Ship_info[shipinfo_int];
 				game_snd *snd;
 
-				if (sip->flags[Ship::Info_Flags::Bomber])
-					snd = &Species_info[sip->species].snd_flyby_bomber;
-				else
-					snd = &Species_info[sip->species].snd_flyby_fighter;
+				if (Ship_info[shipinfo_int].glide_end_snd.isValid()) {
+					snd = gamesnd_get_game_sound(Ship_info[shipinfo_int].glide_end_snd);
+				} else {
+					if (sip->flags[Ship::Info_Flags::Bomber])
+						snd = &Species_info[sip->species].snd_flyby_bomber;
+					else
+						snd = &Species_info[sip->species].snd_flyby_fighter;
+				}
 
 				if (snd->sound_entries.empty())
-					return; //This species does not define any relevant flyby sounds
+					return; // This class or species does not define any relevant flyby sounds
 
 				// play da sound
 				snd_play_3d(snd, &closest_objp->pos, &View_position);

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -1024,6 +1024,7 @@ void ship_info::clone(const ship_info& other)
 	min_engine_vol = other.min_engine_vol;
 	glide_start_snd = other.glide_start_snd;
 	glide_end_snd = other.glide_end_snd;
+	flyby_snd = other.flyby_snd;
 
 	ship_sounds = other.ship_sounds;
 
@@ -1302,6 +1303,7 @@ void ship_info::move(ship_info&& other)
 	min_engine_vol = other.min_engine_vol;
 	glide_start_snd = other.glide_start_snd;
 	glide_end_snd = other.glide_end_snd;
+	flyby_snd  = other.flyby_snd;
 
 	std::swap(ship_sounds, other.ship_sounds);
 
@@ -1692,6 +1694,7 @@ ship_info::ship_info()
 	min_engine_vol = -1.0f;
 	glide_start_snd = gamesnd_id();
 	glide_end_snd = gamesnd_id();
+	flyby_snd = gamesnd_id();
 
 	ship_sounds.clear();
 
@@ -3569,6 +3572,9 @@ static int parse_ship_values(ship_info* sip, const bool is_template, const bool 
 
 	//Parse optional sound to be used for end of a glide
 	parse_game_sound("$GlideEndSnd:", &sip->glide_end_snd);
+
+	// Parse optional sound to be used for bfly-by sound
+	parse_game_sound("$Flyby Sound:", &sip->flyby_snd);
 
 	parse_ship_sounds(sip);
 	

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -1171,7 +1171,7 @@ public:
 	float min_engine_vol;					// minimum volume modifier for engine sound when ship is stationary
 	gamesnd_id glide_start_snd;					// handle to sound to play at the beginning of a glide maneuver (default is 0 for regular throttle down sound)
 	gamesnd_id glide_end_snd;						// handle to sound to play at the end of a glide maneuver (default is 0 for regular throttle up sound)
-	gamesnd_id flyby_snd;					// handle to sound to play wtih ship flyby
+	gamesnd_id flyby_snd;					// handle to sound to play with ship flyby
 
 	SCP_map<GameSounds, gamesnd_id> ship_sounds;			// specifies ship-specific sound indexes
 

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -1171,6 +1171,7 @@ public:
 	float min_engine_vol;					// minimum volume modifier for engine sound when ship is stationary
 	gamesnd_id glide_start_snd;					// handle to sound to play at the beginning of a glide maneuver (default is 0 for regular throttle down sound)
 	gamesnd_id glide_end_snd;						// handle to sound to play at the end of a glide maneuver (default is 0 for regular throttle up sound)
+	gamesnd_id flyby_snd;					// handle to sound to play wtih ship flyby
 
 	SCP_map<GameSounds, gamesnd_id> ship_sounds;			// specifies ship-specific sound indexes
 


### PR DESCRIPTION
Previously, flyby sounds were only specified on a per-species basis. This PR allows each ship class to use a specific flyby sound. This will allow modders to set the custom sound in `ships.tbl` using the new `$Flyby Sound:` field.