### PR TITLE
properly handle destruction/repair of subsystem tree

### DIFF
--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -447,9 +447,9 @@ SCP_vector<sexp_oper> Operators = {
 	{ "destroy-instantly",				OP_DESTROY_INSTANTLY,					1,	INT_MAX,	SEXP_ACTION_OPERATOR,	},	// Admiral MS
 	{ "destroy-subsys-instantly",		OP_DESTROY_SUBSYS_INSTANTLY,			2,	INT_MAX,	SEXP_ACTION_OPERATOR,	},	// Admiral MS
 	{ "sabotage-subsystem",				OP_SABOTAGE_SUBSYSTEM,					3,	3,			SEXP_ACTION_OPERATOR,	},
-	{ "repair-subsystem",				OP_REPAIR_SUBSYSTEM,					3,	4,			SEXP_ACTION_OPERATOR,	},
+	{ "repair-subsystem",				OP_REPAIR_SUBSYSTEM,					3,	5,			SEXP_ACTION_OPERATOR,	},
 	{ "ship-copy-damage",				OP_SHIP_COPY_DAMAGE,					2,	INT_MAX,	SEXP_ACTION_OPERATOR,	},	// Goober5000
-	{ "set-subsystem-strength",			OP_SET_SUBSYSTEM_STRNGTH,				3,	4,			SEXP_ACTION_OPERATOR,	},
+	{ "set-subsystem-strength",			OP_SET_SUBSYSTEM_STRNGTH,				3,	5,			SEXP_ACTION_OPERATOR,	},
 	{ "subsys-set-random",				OP_SUBSYS_SET_RANDOM,					3,	INT_MAX,	SEXP_ACTION_OPERATOR,	},
 	{ "lock-rotating-subsystem",		OP_LOCK_ROTATING_SUBSYSTEM,				2,	INT_MAX,	SEXP_ACTION_OPERATOR,	},	// Goober5000
 	{ "free-rotating-subsystem",		OP_FREE_ROTATING_SUBSYSTEM,				2,	INT_MAX,	SEXP_ACTION_OPERATOR,	},	// Goober5000
@@ -11504,6 +11504,65 @@ void sexp_end_campaign(int n)
 	}
 }
 
+void set_subsys_strength_and_maybe_ancestors(ship *shipp, ship_subsys *ss, polymodel *pm, const int *assign_percent, const int *repair_percent, const int *sabotage_percent, bool do_submodel_repair, bool repair_ancestors)
+{
+	Assertion(shipp != nullptr && ss != nullptr, "Ship and subsys must not be null!");
+	Assertion(assign_percent != nullptr || repair_percent != nullptr || sabotage_percent != nullptr, "Either assign_percent or repair_percent or sabotage_percent must not be null!");
+
+	bool originally_zero = (ss->current_hits == 0 || ss->submodel_info_1.blown_off != 0 || ss->submodel_info_2.blown_off != 0);
+
+	if (assign_percent != nullptr)
+	{
+		int percentage = *assign_percent;
+		Assertion(percentage >= 0 && percentage <= 100, "Percentage must be in range [0, 100]");
+
+		// maybe blow up subsys
+		if (ss->current_hits > 0 && percentage < 1)
+			do_subobj_destroyed_stuff(shipp, ss, nullptr);
+
+		// assign the hitpoints
+		ss->current_hits = ss->max_hits * ((float)percentage / 100.0f);
+	}
+	else if (repair_percent != nullptr)
+	{
+		int percentage = *repair_percent;
+		Assertion(percentage > 0, "Repair percentage must be more than zero!");
+
+		// repair the hitpoints
+		float repair_hits = ss->max_hits * ((float)percentage / 100.0f);
+		ss->current_hits += repair_hits;
+		if (ss->current_hits > ss->max_hits)
+			ss->current_hits = ss->max_hits;
+	}
+	else if (sabotage_percent != nullptr)
+	{
+		int percentage = *sabotage_percent;
+		Assertion(percentage > 0, "Sabotage percentage must be more than zero!");
+
+		// sabotage the hitpoints
+		float sabotage_hits = ss->max_hits * ((float)percentage / 100.0f);
+		ss->current_hits -= sabotage_hits;
+		if (ss->current_hits < 0.0f)
+			ss->current_hits = 0.0f;
+
+		// maybe blow up subsys
+		if (ss->current_hits <= 0 && !originally_zero)
+			do_subobj_destroyed_stuff(shipp, ss, nullptr);
+	}
+	else
+		return;
+
+	// and now see if we are repairing from zero
+	if (originally_zero && ss->current_hits > 0 && do_submodel_repair)
+	{
+		ss->submodel_info_1.blown_off = 0;
+		ss->submodel_info_2.blown_off = 0;
+
+		// determine the submodel for this subsystem
+		//todo();
+	}
+}
+
 /**
  * Reduces the strength of a subsystem by the given percentage.
  *
@@ -11522,11 +11581,17 @@ void sexp_sabotage_subsystem(int n)
 	subsystem = CTEXT(CDR(n));
 	percentage = eval_num(CDR(CDR(n)));
 
+	// abort if we're not even sabotaging anything
+	if (percentage <= 0) {
+		return;
+	}
+
 	shipnum = ship_name_lookup(shipname);
 	
 	// if no ship, then return immediately.
-	if ( shipnum == -1 )
+	if (shipnum < 0) {
 		return;
+	}
 	shipp = &Ships[shipnum];
 
 	// see if we are dealing with the HULL
@@ -11599,15 +11664,7 @@ void sexp_sabotage_subsystem(int n)
 			}
 		}
 
-		sabotage_hits = ss->max_hits * ((float)percentage / 100.0f);
-		ss->current_hits -= sabotage_hits;
-		if ( ss->current_hits < 0.0f )
-			ss->current_hits = 0.0f;
-
-		// maybe blow up subsys
-		if (ss->current_hits <= 0) {
-			do_subobj_destroyed_stuff(shipp, ss, NULL);
-		}
+		set_subsys_strength_and_maybe_ancestors(shipp, ss, nullptr, nullptr, nullptr, &percentage, false, false);
 
 		ship_recalc_subsys_strength( shipp );
 	}
@@ -11622,22 +11679,36 @@ void sexp_repair_subsystem(int n)
 {
 	char *shipname, *subsystem;
 	int	percentage, shipnum, index, generic_type;
-	bool do_submodel_repair;
+	bool do_submodel_repair = true, do_ancestor_repair = true;
 	float repair_hits;
 	ship *shipp;
 	ship_subsys *ss = NULL, *ss_start;
 	bool do_loop = true;
 
 	shipname = CTEXT(n);
-	subsystem = CTEXT(CDR(n));
-	percentage = eval_num(CDDR(n));
+	n = CDR(n);
+	subsystem = CTEXT(n);
+	n = CDR(n);
+	percentage = eval_num(n);
+	n = CDR(n);
+	if (n >= 0)
+	{
+		do_submodel_repair = is_sexp_true(n);
+		n = CDR(n);
 
-	do_submodel_repair = (CDDDR(n) == -1) || is_sexp_true(CDDDR(n));
+		if (n >= 0)
+			do_ancestor_repair = is_sexp_true(n);
+	}
+
+	// abort if we're not even repairing anything
+	if (percentage <= 0) {
+		return;
+	}
 
 	shipnum = ship_name_lookup(shipname);
 	
 	// if no ship, then return immediately.
-	if ( shipnum == -1 ) {
+	if (shipnum < 0) {
 		return;
 	}
 	shipp = &Ships[shipnum];
@@ -11710,17 +11781,8 @@ void sexp_repair_subsystem(int n)
 				return;
 			}
 		}
-	
-		repair_hits = ss->max_hits * ((float)percentage / 100.0f);
-		ss->current_hits += repair_hits;
-		if ( ss->current_hits > ss->max_hits )
-			ss->current_hits = ss->max_hits;
 
-		if ((ss->current_hits > 0) && (do_submodel_repair))
-		{
-			ss->submodel_info_1.blown_off = 0;
-			ss->submodel_info_2.blown_off = 0;
-		}
+		set_subsys_strength_and_maybe_ancestors(shipp, ss, nullptr, nullptr, &percentage, nullptr, do_submodel_repair, do_ancestor_repair);
 
 		ship_recalc_subsys_strength( shipp );
 	}
@@ -11733,16 +11795,25 @@ void sexp_set_subsystem_strength(int n)
 {
 	char *shipname, *subsystem;
 	int	percentage, shipnum, index, generic_type;
-	bool do_submodel_repair;
+	bool do_submodel_repair = true, do_ancestor_repair = true;
 	ship *shipp;
 	ship_subsys *ss = NULL, *ss_start;
 	bool do_loop = true;
 
 	shipname = CTEXT(n);
-	subsystem = CTEXT(CDR(n));
-	percentage = eval_num(CDR(CDR(n)));
+	n = CDR(n);
+	subsystem = CTEXT(n);
+	n = CDR(n);
+	percentage = eval_num(n);
+	n = CDR(n);
+	if (n >= 0)
+	{
+		do_submodel_repair = is_sexp_true(n);
+		n = CDR(n);
 
-	do_submodel_repair = (CDDDR(n) == -1) || is_sexp_true(CDDDR(n));
+		if (n >= 0)
+			do_ancestor_repair = is_sexp_true(n);
+	}
 
 	shipnum = ship_name_lookup(shipname);
 	
@@ -11830,22 +11901,8 @@ void sexp_set_subsystem_strength(int n)
 				return;
 			}
 		}
-		
-		// maybe blow up subsys
-		if (ss->current_hits > 0) {
-			if (percentage < 1) {
-				do_subobj_destroyed_stuff(shipp, ss, NULL);
-			}
-		}
 
-		// set hit points
-		ss->current_hits = ss->max_hits * ((float)percentage / 100.0f);
-
-		if ((ss->current_hits > 0) && (do_submodel_repair))
-		{
-			ss->submodel_info_1.blown_off = 0;
-			ss->submodel_info_2.blown_off = 0;
-		}
+		set_subsys_strength_and_maybe_ancestors(shipp, ss, nullptr, &percentage, nullptr, nullptr, do_submodel_repair, do_ancestor_repair);
 
 		ship_recalc_subsys_strength( shipp );
 	}
@@ -31641,23 +31698,25 @@ SCP_vector<sexp_help_struct> Sexp_help = {
 
 	{ OP_REPAIR_SUBSYSTEM, "Repair Subystem (Action operator)\r\n"
 		"\tIncreases the specified subsystem integrity by the specified percentage."
-		"If the percntage strength of the subsystem (after completion) is greater than 100%,"
+		"If the percentage strength of the subsystem (after completion) is greater than 100%,"
 		"subsystem strength is set to 100%.\r\n\r\n"
-		"Takes 4 arguments...\r\n"
+		"Takes 3 to 5 arguments...\r\n"
 		"\t1:\tName of ship subsystem is on.\r\n"
 		"\t2:\tName of subsystem to repair.\r\n"
 		"\t3:\tPercentage to increase subsystem integrity by.\r\n"
-		"\t4:\tRepair turret submodel.  Optional argument that defaults to true."},
+		"\t4:\tRepair submodel if it exists.  Optional argument that defaults to true.\r\n"
+		"\t5:\tRepair ancestor submodels if they were destroyed.  Optional argument that defaults to true.\r\n" },
 
 	{ OP_SET_SUBSYSTEM_STRNGTH, "Set Subsystem Strength (Action operator)\r\n"
 		"\tSets the specified subsystem to the the specified percentage."
 		"If the percentage specified is < 0, strength is set to 0.  If the percentage is "
 		"> 100 % the subsystem strength is set to 100%.\r\n\r\n"
-		"Takes 3 arguments...\r\n"
+		"Takes 3 to 5 arguments...\r\n"
 		"\t1:\tName of ship subsystem is on.\r\n"
 		"\t2:\tName of subsystem to set strength.\r\n"
 		"\t3:\tPercentage to set subsystem integrity to.\r\n" 
-		"\t4:\tRepair turret submodel.  Optional argument that defaults to true."},
+		"\t4:\tRepair submodel if it exists.  Optional argument that defaults to true.\r\n"
+		"\t5:\tRepair ancestor submodels if they were destroyed.  Optional argument that defaults to true.\r\n" },
 
 	{ OP_DESTROY_SUBSYS_INSTANTLY, "destroy-subsys-instantly\r\n"
 		"\tDestroys the specified subsystems without effects."

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -11891,7 +11891,6 @@ void sexp_destroy_subsys_instantly(int n)
 				{
 					// do destruction stuff
 					ss->current_hits = 0;
-					ship_recalc_subsys_strength(shipp);
 					do_subobj_destroyed_stuff(shipp, ss, nullptr, true);
 
 					if (MULTIPLAYER_MASTER)
@@ -11915,7 +11914,6 @@ void sexp_destroy_subsys_instantly(int n)
 
 			// do destruction stuff
 			ss->current_hits = 0;
-			ship_recalc_subsys_strength(shipp);
 			do_subobj_destroyed_stuff(shipp, ss, nullptr, true);
 
 			if (MULTIPLAYER_MASTER)
@@ -11926,6 +11924,9 @@ void sexp_destroy_subsys_instantly(int n)
 			}
 		}
 	}
+
+	// recalculate when done
+	ship_recalc_subsys_strength(shipp);
 
 	if (MULTIPLAYER_MASTER)
 		Current_sexp_network_packet.end_callback();
@@ -11948,9 +11949,11 @@ void multi_sexp_destroy_subsys_instantly()
 
 		// do destruction stuff
 		ss->current_hits = 0;
-		ship_recalc_subsys_strength(shipp);
 		do_subobj_destroyed_stuff(shipp, ss, nullptr, true);
 	}
+
+	// recalculate when done
+	ship_recalc_subsys_strength(shipp);
 }
 
 /**

--- a/code/ship/shipfx.cpp
+++ b/code/ship/shipfx.cpp
@@ -213,27 +213,6 @@ static void shipfx_subsystem_maybe_create_live_debris(object *ship_objp, ship *s
 	}
 }
 
-static void set_ship_submodel_as_blown_off(ship *shipp, const char *name)
-{
-	int found =	FALSE;
-
-	// go through list of ship subsystems and find name
-	ship_subsys	*pss = NULL;
-	for (pss=GET_FIRST(&shipp->subsys_list); pss!=END_OF_LIST(&shipp->subsys_list); pss=GET_NEXT(pss)) {
-		if ( subsystem_stricmp(pss->system_info->subobj_name, name) == 0) {
-			found = TRUE;
-			break;
-		}
-	}
-
-	// set its blown off flag to TRUE
-	Assert(found);
-	if (found) {
-		pss->submodel_info_1.blown_off = 1;
-	}
-}
-
-
 /**
  * Create debris for ship submodel which has live debris (at ship death)
  * when ship submodel has not already been blown off (and hence liberated live debris)
@@ -285,7 +264,7 @@ static void shipfx_maybe_create_live_debris_at_ship_death( object *ship_objp )
 
 						// now set subsystem as blown off, so we only get one copy
 						pm->submodel[parent].blown_off = 1;
-						set_ship_submodel_as_blown_off(&Ships[ship_objp->instance], pss->system_info->subobj_name);
+						pss->submodel_info_1.blown_off = 1;
 					}
 				}
 			}

--- a/code/ship/shiphit.cpp
+++ b/code/ship/shiphit.cpp
@@ -108,6 +108,8 @@ static bool is_subsys_destroyed(ship *shipp, int submodel)
 // do_subobj_destroyed_stuff is called when a subobject for a ship is killed.  Separated out
 // to separate function on 10/15/97 by MWA for easy multiplayer access.  It does all of the
 // cool things like blowing off the model (if applicable, writing the logs, etc)
+// NOTE: if this function is used with ship_recalc_subsys_strength, it MUST be called first. If
+// a child subsystem needs to be destroyed, the strength calculation needs to take it into account.
 void do_subobj_destroyed_stuff( ship *ship_p, ship_subsys *subsys, vec3d* hitpos, bool no_explosion )
 {
 	ship_info *sip;

--- a/code/ship/shiphit.cpp
+++ b/code/ship/shiphit.cpp
@@ -658,6 +658,7 @@ float do_subobj_hit_stuff(object *ship_objp, object *other_obj, vec3d *hitpos, i
 	{
 		float	dist, range;
 		ship_subsys	*subsystem;
+
 		int	min_index = -1;
 
 		if (Damage_impacted_subsystem_first && subsys_hit_first > -1) {
@@ -673,22 +674,21 @@ float do_subobj_hit_stuff(object *ship_objp, object *other_obj, vec3d *hitpos, i
 					min_index = i;
 				}
 			}
+			Assert(min_index != -1);
 		}
 
-		Assert(min_index != -1);
+		float	damage_to_apply = 0.0f;
 		subsystem = subsys_list[min_index].ptr;
+		range = subsys_list[min_index].range;
+		dist = subsys_list[min_index].dist;
 		subsys_list[min_index].dist = 9999999.9f;	//	Make sure we don't use this one again.
+
+		Assert(range > 0.0f);	// Goober5000 - avoid div-0 below
 
 		// Make sure this subsystem still has hitpoints.  If it's a child of a parent that was destroyed, it will have been destroyed already.
 		if (subsystem->current_hits <= 0.0f) {
 			continue;
 		}
-
-		float	damage_to_apply = 0.0f;
-		range = subsys_list[min_index].range;
-		dist = subsys_list[min_index].dist;
-
-		Assert(range > 0.0f);	// Goober5000 - avoid div-0 below
 
 		// only do this for the closest affected subsystem
 		if ( (j == 0) && (!(parent_armor_flags & SAF_IGNORE_SS_ARMOR))) {

--- a/code/ship/shiphit.cpp
+++ b/code/ship/shiphit.cpp
@@ -114,6 +114,7 @@ void do_subobj_destroyed_stuff( ship *ship_p, ship_subsys *subsys, vec3d* hitpos
 {
 	ship_info *sip;
 	object *ship_objp;
+	ship_subsys *ssp;
 	model_subsystem *psub;
 	vec3d	g_subobj_pos;
 	int type, i, log_index;
@@ -124,6 +125,27 @@ void do_subobj_destroyed_stuff( ship *ship_p, ship_subsys *subsys, vec3d* hitpos
 	psub = subsys->system_info;
 	type = psub->type;
 	get_subsystem_world_pos(ship_objp, subsys, &g_subobj_pos);
+
+	// see if this subsystem is on a submodel
+	if (psub->subobj_num >= 0) {
+		polymodel *pm = model_get(sip->model_num);
+
+		// see if there are any subsystems which have this submodel as a parent
+		for (ssp = GET_FIRST(&ship_p->subsys_list); ssp != END_OF_LIST(&ship_p->subsys_list); ssp = GET_NEXT(ssp)) {
+			// is it another subsys which has a submodel?
+			if (ssp != subsys && ssp->system_info->subobj_num >= 0) {
+				// is this other submodel a child of the one being destroyed?
+				if (pm->submodel[ssp->system_info->subobj_num].parent == psub->subobj_num) {
+					// is it not yet destroyed?  (this is a valid check because we already know there is a submodel)
+					if (!ssp->submodel_info_1.blown_off) {
+						// then destroy it first
+						ssp->current_hits = 0;
+						do_subobj_destroyed_stuff(ship_p, ssp, nullptr, no_explosion);
+					}
+				}
+			}
+		}
+	}
 
 	// create fireballs when subsys destroy for large ships.
 	object* objp = &Objects[ship_p->objnum];
@@ -194,10 +216,8 @@ void do_subobj_destroyed_stuff( ship *ship_p, ship_subsys *subsys, vec3d* hitpos
 	if ( ship_p->subsys_info[type].type_count == 1 ) {
 		ship_p->subsys_info[type].aggregate_current_hits = 0.0f;
 	} else {
-		float hits;
-		ship_subsys *ssp;
+		float hits = 0.0f;
 
-		hits = 0.0f;
 		for ( ssp=GET_FIRST(&ship_p->subsys_list); ssp != END_OF_LIST(&ship_p->subsys_list); ssp = GET_NEXT(ssp) ) {
 			// type matches?
 			if ( (ssp->system_info->type == type) && !(ssp->flags[Ship::Subsystem_Flags::No_aggregate]) ) {
@@ -638,7 +658,6 @@ float do_subobj_hit_stuff(object *ship_objp, object *other_obj, vec3d *hitpos, i
 	{
 		float	dist, range;
 		ship_subsys	*subsystem;
-
 		int	min_index = -1;
 
 		if (Damage_impacted_subsystem_first && subsys_hit_first > -1) {
@@ -657,9 +676,14 @@ float do_subobj_hit_stuff(object *ship_objp, object *other_obj, vec3d *hitpos, i
 		}
 
 		Assert(min_index != -1);
+		subsystem = subsys_list[min_index].ptr;
+
+		// Make sure this subsystem still has hitpoints.  If it's a child of a parent that was destroyed, it will have been destroyed already.
+		if (subsystem->current_hits <= 0.0f) {
+			continue;
+		}
 
 		float	damage_to_apply = 0.0f;
-		subsystem = subsys_list[min_index].ptr;
 		range = subsys_list[min_index].range;
 		dist = subsys_list[min_index].dist;
 		subsys_list[min_index].dist = 9999999.9f;	//	Make sure we don't use this one again.

--- a/code/ship/shiphit.cpp
+++ b/code/ship/shiphit.cpp
@@ -677,6 +677,7 @@ float do_subobj_hit_stuff(object *ship_objp, object *other_obj, vec3d *hitpos, i
 
 		Assert(min_index != -1);
 		subsystem = subsys_list[min_index].ptr;
+		subsys_list[min_index].dist = 9999999.9f;	//	Make sure we don't use this one again.
 
 		// Make sure this subsystem still has hitpoints.  If it's a child of a parent that was destroyed, it will have been destroyed already.
 		if (subsystem->current_hits <= 0.0f) {
@@ -686,7 +687,6 @@ float do_subobj_hit_stuff(object *ship_objp, object *other_obj, vec3d *hitpos, i
 		float	damage_to_apply = 0.0f;
 		range = subsys_list[min_index].range;
 		dist = subsys_list[min_index].dist;
-		subsys_list[min_index].dist = 9999999.9f;	//	Make sure we don't use this one again.
 
 		Assert(range > 0.0f);	// Goober5000 - avoid div-0 below
 


### PR DESCRIPTION
Fixes #605.  If a parent subobject is destroyed while a child subobject still has hitpoints, the child subobject is destroyed as well.  Conversely, if a child subobject is repaired while a parent subobject is destroyed, the parent subobject is also repaired.

~~This PR is based on the `on_subsystem_destroyed` branch of PR #2037.  I will rebase this onto master after that PR has been merged.~~  Okay, this PR is now based on master.