### PR TITLE
Check flags are valid in multi_sexp_deal_with_ship_flag().

### DIFF
--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -13109,7 +13109,7 @@ void multi_sexp_deal_with_ship_flag()
 		}
 		else {
 			Current_sexp_network_packet.get_parse_object(pobjp); 
-			if ((pobjp != NULL) && (p_object_flag != (int)Mission::Parse_Object_Flags::NUM_VALUES)) {
+			if ((pobjp != nullptr) && (p_object_flag != (int)Mission::Parse_Object_Flags::NUM_VALUES)) {
                 pobjp->flags.set((Mission::Parse_Object_Flags)p_object_flag, set_it);
 			}
 		}

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -13062,8 +13062,12 @@ void multi_sexp_deal_with_ship_flag()
 			// save flags for state change comparisons
 			auto object_flag_orig = Objects[shipp->objnum].flags;
 
-			Objects[shipp->objnum].flags.set((Object::Object_Flags)object_flag, set_it);
-            shipp->flags.set((Ship::Ship_Flags)ship_flag, set_it);
+			if (object_flag != (int)Object::Object_Flags::NUM_VALUES) {
+				Objects[shipp->objnum].flags.set((Object::Object_Flags)object_flag, set_it);
+			}
+			if (ship_flag != (int)Ship::Ship_Flags::NUM_VALUES) {
+	            shipp->flags.set((Ship::Ship_Flags)ship_flag, set_it);
+			}
 
 			// deal with side effects of these flags
 			if (object_flag == (int)Object::Object_Flags::No_shields) {
@@ -13105,7 +13109,7 @@ void multi_sexp_deal_with_ship_flag()
 		}
 		else {
 			Current_sexp_network_packet.get_parse_object(pobjp); 
-			if (pobjp != NULL) {
+			if ((pobjp != NULL) && (p_object_flag != (int)Mission::Parse_Object_Flags::NUM_VALUES)) {
                 pobjp->flags.set((Mission::Parse_Object_Flags)p_object_flag, set_it);
 			}
 		}


### PR DESCRIPTION
In single-player, or while running as a server, `sexp_deal_with_ship_flag()` makes sure that `object_flag`, `ship_flag`, and `p_object_flag` aren't `NUM_VALUES` (i.e. not set) before trying to call `flags.set()` with them. However, the client code in `multi_sexp_deal_with_ship_flag()` had no such security checks, and as such would try to set `NUM_VALUES`, which is outside the range of valid flags; this led to a crash in Release builds and an Assertion otherwise.