### PR TITLE
Fix #206: destroyed subsystems reverting to un-destroyed model

### DIFF
--- a/code/model/modelread.cpp
+++ b/code/model/modelread.cpp
@@ -4742,8 +4742,10 @@ void model_update_instance(int model_instance_num, int sub_model_num, submodel_i
 	// Set the "blown out" flags
 	if ( flags[Ship::Subsystem_Flags::No_disappear] ) {
 		smi->blown_off = false;
+		sm->blown_off = 0;
 	} else {
 		smi->blown_off = sii->blown_off ? true : false;
+		sm->blown_off = sii->blown_off;
 	}
 
 	if ( smi->blown_off && !(flags[Ship::Subsystem_Flags::No_replace]) )	{
@@ -4751,12 +4753,15 @@ void model_update_instance(int model_instance_num, int sub_model_num, submodel_i
 			pmi->submodel[sm->my_replacement].blown_off = false;
 			pmi->submodel[sm->my_replacement].angs = sii->angs;
 			pmi->submodel[sm->my_replacement].prev_angs = sii->prev_angs;
+			pm->submodel[sm->my_replacement].blown_off = 0;
+			pm->submodel[sm->my_replacement].angs = sii->angs;
 		}
 	} else {
 		// If submodel isn't yet blown off and has a -destroyed replacement model, we prevent
 		// the replacement model from being drawn by marking it as having been blown off
 		if ( sm->my_replacement > -1 && sm->my_replacement != sub_model_num)	{
 			pmi->submodel[sm->my_replacement].blown_off = true;
+			pm->submodel[sm->my_replacement].blown_off = 1;
 		}
 	}
 

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -18837,19 +18837,6 @@ void ship_render(object* obj, model_draw_list* scene)
 		}
 	}
 
-	model_clear_instance(sip->model_num);
-
-	// Only render electrical arcs if within 500m of the eye (for a 10m piece)
-	if ( vm_vec_dist_quick( &obj->pos, &Eye_position ) < obj->radius*50.0f && !Rendering_to_shadow_map ) {
-		for ( int i = 0; i < MAX_SHIP_ARCS; i++ )	{
-			if ( timestamp_valid(shipp->arc_timestamp[i]) ) {
-				model_add_arc(sip->model_num, -1, &shipp->arc_pts[i][0], &shipp->arc_pts[i][1], shipp->arc_type[i]);
-			}
-		}
-	}
-
-	uint render_flags = MR_NORMAL;
-
 	if ( shipp->large_ship_blowup_index >= 0 )	{
 		shipfx_large_blowup_queue_render(scene, shipp);
 
@@ -18863,9 +18850,23 @@ void ship_render(object* obj, model_draw_list* scene)
 			shipp->warpout_effect->warpShipRender();
 		}
 
+		model_clear_instance(sip->model_num);
 		return;
 	}
 		
+	model_clear_instance(sip->model_num);
+
+	// Only render electrical arcs if within 500m of the eye (for a 10m piece)
+	if (vm_vec_dist_quick(&obj->pos, &Eye_position) < obj->radius * 50.0f && !Rendering_to_shadow_map) {
+		for (int i = 0; i < MAX_SHIP_ARCS; i++) {
+			if (timestamp_valid(shipp->arc_timestamp[i])) {
+				model_add_arc(sip->model_num, -1, &shipp->arc_pts[i][0], &shipp->arc_pts[i][1], shipp->arc_type[i]);
+			}
+		}
+	}
+
+	uint render_flags = MR_NORMAL;
+
 	ship_render_batch_thrusters(obj);
 
 	model_render_params render_info;


### PR DESCRIPTION
This PR fixes issue #2046, which was a bug that destroyed subsystems reverted to their undestroyed models when a ship died. I tracked the bug to the commit 64ad950, which introduced the bug by removing the `ship_model_start(obj);` line in `ship_render()` (ship.cpp).

The reason removing this line caused the visual bug was because `model_set_instance()` was not called. Calling `model_set_instance()` properly set the `pm->blown_off values` (not just the `pmi->blown_off` values like `ship_model_update_instance()` does). The reason the `pm` values also need to be updated is because they are used by `shipfx_large_blowup_queue_render()` (in other words that function does not appear to use the `pmi` values that are updated in `ship_model_update_instance()`).

Thus, I simply added lines setting the `pm->blown_off` status to `ship_model_update_instance()`. Also in commit 3eb47c1 the line `model_clear_instance(sip->model_num);` was added to `ship_render()`. The function `model_clear_instance(sip->model_num);` sets the `pm->blown_off values` only based on `pm->submodel[i].is_damaged`. Thus, the `model_clear_instance(sip->model_num);` line should be moved to lower in the function, otherwise the `pm->blown_off values` get reset to default before `shipfx_large_blowup_queue_render()`.

Also moving the `model_clear_instance(sip->model_num);` to lower in the function meant that the lighting arc lines should also be moved, that way lighting arcs stay visible. 

Testing the new lines with multiple scenarios in game (quick restarts, sexp and manual destruction of subsystems, etc) confirmed the fix worked.