### PR TITLE
Clean up map::iterator usage

### DIFF
--- a/code/graphics/grbatch.cpp
+++ b/code/graphics/grbatch.cpp
@@ -667,7 +667,7 @@ float batch_add_laser(int texture, vec3d *p0, float width1, vec3d *p1, float wid
 	batch_item *item = NULL;
 	SCP_map<int, batch_item>::iterator it = geometry_map.find(texture);
 
-	if ( !geometry_map.empty() && it != geometry_map.end() ) {
+	if (it != geometry_map.end()) {
 		item = &it->second;
 	} else {
 		item = &geometry_map[texture];
@@ -706,7 +706,7 @@ int batch_add_bitmap(int texture, int tmap_flags, vertex *pnt, int orient, float
 
 	SCP_map<int, batch_item>::iterator it = geometry_map.find(texture);
 
-	if ( !geometry_map.empty() && it != geometry_map.end() ) {
+	if (it != geometry_map.end()) {
 		item = &it->second;
 	} else {
 		item = &geometry_map[texture];
@@ -735,7 +735,7 @@ int geometry_batch_add_bitmap(int texture, int tmap_flags, vertex *pnt, int orie
 	g_sdr_batch_item *item = NULL;
 	SCP_map<int, g_sdr_batch_item>::iterator it = geometry_shader_map.find(texture);
 
-	if ( !geometry_shader_map.empty() && it != geometry_shader_map.end() ) {
+	if (it != geometry_shader_map.end()) {
 		item = &it->second;
 	} else {
 		item = &geometry_shader_map[texture];
@@ -768,7 +768,7 @@ int batch_add_bitmap_rotated(int texture, int tmap_flags, vertex *pnt, float ang
 
 	SCP_map<int, batch_item>::iterator it = geometry_map.find(texture);
 
-	if ( !geometry_map.empty() && it != geometry_map.end() ) {
+	if (it != geometry_map.end()) {
 		item = &it->second;
 	} else {
 		item = &geometry_map[texture];
@@ -798,7 +798,7 @@ int batch_add_tri(int texture, int tmap_flags, vertex *verts, float alpha)
 
 	SCP_map<int, batch_item>::iterator it = geometry_map.find(texture);
 
-	if ( !geometry_map.empty() && it != geometry_map.end() ) {
+	if (it != geometry_map.end()) {
 		item = &it->second;
 	} else {
 		item = &geometry_map[texture];
@@ -828,7 +828,7 @@ int batch_add_quad(int texture, int tmap_flags, vertex *verts, float alpha)
 
 	SCP_map<int, batch_item>::iterator it = geometry_map.find(texture);
 
-	if ( !geometry_map.empty() && it != geometry_map.end() ) {
+	if (it != geometry_map.end()) {
 		item = &it->second;
 	} else {
 		item = &geometry_map[texture];
@@ -908,7 +908,7 @@ int batch_add_polygon(int texture, int tmap_flags, vec3d *pos, matrix *orient, f
 
 	SCP_map<int, batch_item>::iterator it = geometry_map.find(texture);
 
-	if ( !geometry_map.empty() && it != geometry_map.end() ) {
+	if (it != geometry_map.end()) {
 		item = &it->second;
 	} else {
 		item = &geometry_map[texture];
@@ -938,7 +938,7 @@ int batch_add_beam(int texture, int tmap_flags, vec3d *start, vec3d *end, float 
 
 	SCP_map<int, batch_item>::iterator it = geometry_map.find(texture);
 
-	if ( !geometry_map.empty() && it != geometry_map.end() ) {
+	if (it != geometry_map.end()) {
 		item = &it->second;
 	} else {
 		item = &geometry_map[texture];
@@ -959,102 +959,102 @@ int batch_add_beam(int texture, int tmap_flags, vec3d *start, vec3d *end, float 
 
 void batch_render_lasers(int buffer_handle)
 {
-	for (SCP_map<int, batch_item>::iterator bi = geometry_map.begin(); bi != geometry_map.end(); ++bi) {
+	for (auto &bi : geometry_map) {
 
-		if ( !bi->second.laser )
+		if ( !bi.second.laser )
 			continue;
 
-		if ( !bi->second.batch.need_to_render() )
+		if ( !bi.second.batch.need_to_render() )
 			continue;
 
-		Assert( bi->second.texture >= 0 );
-		gr_set_bitmap(bi->second.texture, GR_ALPHABLEND_FILTER, GR_BITBLT_MODE_NORMAL, 0.99999f);
+		Assert( bi.second.texture >= 0 );
+		gr_set_bitmap(bi.second.texture, GR_ALPHABLEND_FILTER, GR_BITBLT_MODE_NORMAL, 0.99999f);
 		if ( buffer_handle >= 0 ) {
-			bi->second.batch.render_buffer(buffer_handle, TMAP_FLAG_TEXTURED | TMAP_FLAG_XPARENT | TMAP_HTL_3D_UNLIT | TMAP_FLAG_RGB | TMAP_FLAG_GOURAUD | TMAP_FLAG_CORRECT | TMAP_FLAG_EMISSIVE);
+			bi.second.batch.render_buffer(buffer_handle, TMAP_FLAG_TEXTURED | TMAP_FLAG_XPARENT | TMAP_HTL_3D_UNLIT | TMAP_FLAG_RGB | TMAP_FLAG_GOURAUD | TMAP_FLAG_CORRECT | TMAP_FLAG_EMISSIVE);
 		} else {
-			bi->second.batch.render(TMAP_FLAG_TEXTURED | TMAP_FLAG_XPARENT | TMAP_HTL_3D_UNLIT | TMAP_FLAG_RGB | TMAP_FLAG_GOURAUD | TMAP_FLAG_CORRECT | TMAP_FLAG_EMISSIVE);
+			bi.second.batch.render(TMAP_FLAG_TEXTURED | TMAP_FLAG_XPARENT | TMAP_HTL_3D_UNLIT | TMAP_FLAG_RGB | TMAP_FLAG_GOURAUD | TMAP_FLAG_CORRECT | TMAP_FLAG_EMISSIVE);
 		}
 	}
 }
 
 void batch_load_buffer_lasers(effect_vertex* buffer, int *n_verts)
 {
-	for (SCP_map<int, batch_item>::iterator bi = geometry_map.begin(); bi != geometry_map.end(); ++bi) {
+	for (auto &bi : geometry_map) {
 
-		if ( !bi->second.laser )
+		if ( !bi.second.laser )
 			continue;
 
-		if ( !bi->second.batch.need_to_render() )
+		if ( !bi.second.batch.need_to_render() )
 			continue;
 
-		Assert( bi->second.texture >= 0 );
-		bi->second.batch.load_buffer(buffer, n_verts);
+		Assert( bi.second.texture >= 0 );
+		bi.second.batch.load_buffer(buffer, n_verts);
 	}
 }
 
 void batch_render_geometry_map_bitmaps(int buffer_handle)
 {
-	for (SCP_map<int, batch_item>::iterator bi = geometry_map.begin(); bi != geometry_map.end(); ++bi) {
+	for (auto &bi : geometry_map) {
 
-		if ( bi->second.laser )
+		if ( bi.second.laser )
 			continue;
 
-		if ( !bi->second.batch.need_to_render() )
+		if ( !bi.second.batch.need_to_render() )
 			continue;
 
-		Assert( bi->second.texture >= 0 );
-		gr_set_bitmap(bi->second.texture, GR_ALPHABLEND_FILTER, GR_BITBLT_MODE_NORMAL, bi->second.alpha);
+		Assert( bi.second.texture >= 0 );
+		gr_set_bitmap(bi.second.texture, GR_ALPHABLEND_FILTER, GR_BITBLT_MODE_NORMAL, bi.second.alpha);
 		if ( buffer_handle >= 0 ) {
-			bi->second.batch.render_buffer(buffer_handle, bi->second.tmap_flags);
+			bi.second.batch.render_buffer(buffer_handle, bi.second.tmap_flags);
 		} else {
-			bi->second.batch.render( bi->second.tmap_flags);
+			bi.second.batch.render( bi.second.tmap_flags);
 		}
 	}
 }
 
 void batch_render_geometry_shader_map_bitmaps(int buffer_handle)
 {
-	for (SCP_map<int, g_sdr_batch_item>::iterator bi = geometry_shader_map.begin(); bi != geometry_shader_map.end(); ++bi) {
+	for (auto &bi : geometry_shader_map) {
 
-		if ( bi->second.laser )
+		if ( bi.second.laser )
 			continue;
 
-		if ( !bi->second.batch.need_to_render() )
+		if ( !bi.second.batch.need_to_render() )
 			continue;
 
-		Assert( bi->second.texture >= 0 );
-		gr_set_bitmap(bi->second.texture, GR_ALPHABLEND_FILTER, GR_BITBLT_MODE_NORMAL, bi->second.alpha);
-		bi->second.batch.render_buffer(buffer_handle, bi->second.tmap_flags);
+		Assert( bi.second.texture >= 0 );
+		gr_set_bitmap(bi.second.texture, GR_ALPHABLEND_FILTER, GR_BITBLT_MODE_NORMAL, bi.second.alpha);
+		bi.second.batch.render_buffer(buffer_handle, bi.second.tmap_flags);
 	}
 }
 
 void batch_load_buffer_geometry_map_bitmaps(effect_vertex* buffer, int *n_verts)
 {
-	for (SCP_map<int, batch_item>::iterator bi = geometry_map.begin(); bi != geometry_map.end(); ++bi) {
+	for (auto &bi : geometry_map) {
 
-		if ( bi->second.laser )
+		if ( bi.second.laser )
 			continue;
 
-		if ( !bi->second.batch.need_to_render() )
+		if ( !bi.second.batch.need_to_render() )
 			continue;
 
-		Assert( bi->second.texture >= 0 );
-		bi->second.batch.load_buffer(buffer, n_verts);
+		Assert( bi.second.texture >= 0 );
+		bi.second.batch.load_buffer(buffer, n_verts);
 	}
 }
 
 void batch_load_buffer_geometry_shader_map_bitmaps(particle_pnt* buffer, size_t *n_verts)
 {
-	for (SCP_map<int, g_sdr_batch_item>::iterator bi = geometry_shader_map.begin(); bi != geometry_shader_map.end(); ++bi) {
+	for (auto &bi : geometry_shader_map) {
 
-		if ( bi->second.laser )
+		if ( bi.second.laser )
 			continue;
 
-		if ( !bi->second.batch.need_to_render() )
+		if ( !bi.second.batch.need_to_render() )
 			continue;
 
-		Assert( bi->second.texture >= 0 );
-		bi->second.batch.load_buffer(buffer, n_verts);
+		Assert( bi.second.texture >= 0 );
+		bi.second.batch.load_buffer(buffer, n_verts);
 	}
 }
 
@@ -1145,7 +1145,7 @@ int distortion_add_bitmap_rotated(int texture, int tmap_flags, vertex *pnt, floa
 
 	SCP_map<int, batch_item>::iterator it = distortion_map.find(texture);
 
-	if ( !distortion_map.empty() && it != distortion_map.end() ) {
+	if (it != distortion_map.end()) {
 		item = &it->second;
 	} else {
 		item = &distortion_map[texture];
@@ -1175,7 +1175,7 @@ int distortion_add_beam(int texture, int tmap_flags, vec3d *start, vec3d *end, f
 
 	SCP_map<int, batch_item>::iterator it = distortion_map.find(texture);
 
-	if ( !distortion_map.empty() && it != distortion_map.end() ) {
+	if (it != distortion_map.end()) {
 		item = &it->second;
 	} else {
 		item = &distortion_map[texture];
@@ -1196,54 +1196,53 @@ int distortion_add_beam(int texture, int tmap_flags, vec3d *start, vec3d *end, f
 
 void batch_render_distortion_map_bitmaps(int buffer_handle)
 {
-	for (SCP_map<int,batch_item>::iterator bi = distortion_map.begin(); bi != distortion_map.end(); ++bi) {
+	for (auto &bi : distortion_map) {
 
-		if ( bi->second.laser )
+		if ( bi.second.laser )
 			continue;
 
-		if ( !bi->second.batch.need_to_render() )
+		if ( !bi.second.batch.need_to_render() )
 			continue;
 
-		Assert( bi->second.texture >= 0 );
-		gr_set_bitmap(bi->second.texture, GR_ALPHABLEND_NONE, GR_BITBLT_MODE_NORMAL, bi->second.alpha);
+		Assert( bi.second.texture >= 0 );
+		gr_set_bitmap(bi.second.texture, GR_ALPHABLEND_NONE, GR_BITBLT_MODE_NORMAL, bi.second.alpha);
 
 		if ( buffer_handle >= 0 ) {
-			bi->second.batch.render_buffer(buffer_handle, bi->second.tmap_flags);
+			bi.second.batch.render_buffer(buffer_handle, bi.second.tmap_flags);
 		} else {
-			bi->second.batch.render( bi->second.tmap_flags);
+			bi.second.batch.render( bi.second.tmap_flags);
 		}
 	}
 }
 
 void batch_load_buffer_distortion_map_bitmaps(effect_vertex* buffer, int *n_verts)
 {
-	for (SCP_map<int, batch_item>::iterator bi = distortion_map.begin(); bi != distortion_map.end(); ++bi) {
+	for (auto &bi : distortion_map) {
 
-		if ( bi->second.laser )
+		if ( bi.second.laser )
 			continue;
 
-		if ( !bi->second.batch.need_to_render() )
+		if ( !bi.second.batch.need_to_render() )
 			continue;
 
-		Assert( bi->second.texture >= 0 );
-		bi->second.batch.load_buffer(buffer, n_verts);
+		Assert( bi.second.texture >= 0 );
+		bi.second.batch.load_buffer(buffer, n_verts);
 	}
 }
 
 int batch_get_size()
 {
 	int n_to_render = 0;
-	SCP_map<int, batch_item>::iterator bi;
 
-	for (bi = geometry_map.begin(); bi != geometry_map.end(); ++bi) {
-		n_to_render += bi->second.batch.need_to_render();
+	for (auto &bi : geometry_map) {
+		n_to_render += bi.second.batch.need_to_render();
 	}
 
-	for (bi = distortion_map.begin(); bi != distortion_map.end(); ++bi) {
-		if ( bi->second.laser )
+	for (auto &bi : distortion_map) {
+		if ( bi.second.laser )
 			continue;
 
-		n_to_render += bi->second.batch.need_to_render();
+		n_to_render += bi.second.batch.need_to_render();
 	}
 
 	return n_to_render * 3;
@@ -1252,10 +1251,9 @@ int batch_get_size()
 size_t geometry_batch_get_size()
 {
 	size_t n_to_render = 0;
-	SCP_map<int, g_sdr_batch_item>::iterator bi;
 
-	for (bi = geometry_shader_map.begin(); bi != geometry_shader_map.end(); ++bi) {
-		n_to_render += bi->second.batch.need_to_render();
+	for (auto &bi : geometry_shader_map) {
+		n_to_render += bi.second.batch.need_to_render();
 	}
 
 	return n_to_render;

--- a/code/graphics/opengl/gropenglstate.cpp
+++ b/code/graphics/opengl/gropenglstate.cpp
@@ -718,10 +718,8 @@ void opengl_array_state::VertexAttribPointer(GLuint index, GLint size, GLenum ty
 
 void opengl_array_state::ResetVertexAttribs()
 {
-	SCP_map<GLuint, opengl_vertex_attrib_unit>::iterator it;
-
-	for ( it = vertex_attrib_units.begin(); it != vertex_attrib_units.end(); ++it ) {
-		DisableVertexAttrib(it->first);
+	for (auto &it : vertex_attrib_units) {
+		DisableVertexAttrib(it.first);
 	}
 
 	vertex_attrib_units.clear();
@@ -733,19 +731,17 @@ void opengl_array_state::BindPointersBegin()
 		client_texture_units[i].used_for_draw = false;
 	}
 
-	SCP_map<GLuint, opengl_vertex_attrib_unit>::iterator it;
-
-	for (it = vertex_attrib_units.begin(); it != vertex_attrib_units.end(); ++it) {
-		it->second.used_for_draw = false;
+	for (auto &it : vertex_attrib_units) {
+		it.second.used_for_draw = false;
 	}
 }
 
 void opengl_array_state::BindPointersEnd()
 {
-	SCP_map<GLuint, opengl_vertex_attrib_unit>::iterator it;
-
-	for (it = vertex_attrib_units.begin(); it != vertex_attrib_units.end(); ++it) {
-		if ( !it->second.used_for_draw ) DisableVertexAttrib(it->first);
+	for (auto &it : vertex_attrib_units) {
+		if (!it.second.used_for_draw) {
+			DisableVertexAttrib(it.first);
+		}
 	}
 }
 
@@ -764,10 +760,8 @@ void opengl_array_state::BindArrayBuffer(GLuint id)
 		client_texture_units[i].reset_ptr = true;
 	}
 
-	SCP_map<GLuint,opengl_vertex_attrib_unit>::iterator it;
-
-	for ( it = vertex_attrib_units.begin(); it != vertex_attrib_units.end(); ++it ) {
-		it->second.reset_ptr = true;
+	for (auto &it : vertex_attrib_units) {
+		it.second.reset_ptr = true;
 	}
 }
 

--- a/code/render/batching.cpp
+++ b/code/render/batching.cpp
@@ -823,17 +823,14 @@ void batching_load_buffers(bool distortion)
 	GR_DEBUG_SCOPE("Batching load buffers");
 	TRACE_SCOPE(tracing::LoadBatchingBuffers);
 
-	SCP_map<batch_info, primitive_batch>::iterator bi;
-	SCP_map<batch_buffer_key, primitive_batch_buffer>::iterator buffer_iter;
-
-	for ( buffer_iter = Batching_buffers.begin(); buffer_iter != Batching_buffers.end(); ++buffer_iter ) {
+	for (auto &buffer_iter : Batching_buffers) {
 		// zero out the buffers
-		buffer_iter->second.desired_buffer_size = 0;
+		buffer_iter.second.desired_buffer_size = 0;
 	}
 
 	// assign primitive batch items
-	for ( bi = Batching_primitives.begin(); bi != Batching_primitives.end(); ++bi ) {
-		if ( bi->first.mat_type == batch_info::DISTORTION ) {
+	for (auto &bi : Batching_primitives) {
+		if ( bi.first.mat_type == batch_info::DISTORTION ) {
 			if ( !distortion ) {
 				continue;
 			}
@@ -843,10 +840,10 @@ void batching_load_buffers(bool distortion)
 			}
 		}
 
-		size_t num_verts = bi->second.num_verts();
+		size_t num_verts = bi.second.num_verts();
 
 		if ( num_verts > 0 ) {
-			batch_info render_info = bi->second.get_render_info();
+			batch_info render_info = bi.second.get_render_info();
 			uint vertex_mask = batching_determine_vertex_layout(&render_info);
 
 			primitive_batch_buffer *buffer = batching_find_buffer(vertex_mask, render_info.prim_type);
@@ -855,15 +852,15 @@ void batching_load_buffers(bool distortion)
 			draw_item.batch_item_info = render_info;
 			draw_item.offset = 0;
 			draw_item.n_verts = num_verts;
-			draw_item.batch = &bi->second;
+			draw_item.batch = &bi.second;
 
 			buffer->desired_buffer_size += num_verts * sizeof(batch_vertex);
 			buffer->items.push_back(draw_item);
 		}
 	}
 
-	for ( buffer_iter = Batching_buffers.begin(); buffer_iter != Batching_buffers.end(); ++buffer_iter ) {
-		batching_allocate_and_load_buffer(&buffer_iter->second);
+	for (auto &buffer_iter : Batching_buffers) {
+		batching_allocate_and_load_buffer(&buffer_iter.second);
 	}
 }
 

--- a/code/stats/scoring.cpp
+++ b/code/stats/scoring.cpp
@@ -1338,7 +1338,6 @@ DCF(rank, "changes player rank")
 
 void scoreing_close()
 {
-	SCP_map<int, char*>::iterator it;
 	for(int i = 0; i<NUM_RANKS; i++) {
 		Ranks[i].promotion_text.clear();
 	}


### PR DESCRIPTION
I was looking for places where `SCP_unordered_map` could be used instead of `SCP_map` and found a few spots where iterating through maps could be improved.
This PR removes some pointless checks for empty maps and converts a few `map::iterator`-based for loops to range-based fors.  This will make it easier for a possible switch to `SCP_unordered_map` in the future but even if this doesn't happen, it still makes the code more readable.
Note that there are a some explicit `SCP_map::iterator` type declarations which I did not switch to `auto` because I don't know what the policy is for iterators declared outside a loop.  I can change those if desired.