### PR TITLE
Make Lua documentation generation more generic

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -4,7 +4,8 @@ modernize-*,\
 -modernize-raw-string-literal,\
 -modernize-use-using,\
 -modernize-make-unique,\
--modernize-use-trailing-return-type\
+-modernize-use-trailing-return-type,\
+-modernize-avoid-c-arrays,\
 performance-*,\
 -performance-type-promotion-in-math-fn,\
 misc-*,\
@@ -12,7 +13,7 @@ misc-*,\
 -misc-misplaced-widening-cast,\
 -misc-static-assert,\
 -misc-unused-parameters,\
--modernize-make-unique,\
+-misc-non-private-member-variables-in-classes,
 "
 WarningsAsErrors: ''
 HeaderFilterRegex: 'code/.*$|freespace2/.*$|qtfred/.*$|test/src/.*$|build/.*$'

--- a/.travis.yml
+++ b/.travis.yml
@@ -87,7 +87,7 @@ matrix:
             - g++-9
             - *global_deps
     - os: linux
-      env: CONFIGURATION="Debug" CC=clang-4.0 CXX=clang++-4.0 CMAKE_OPTIONS="-DCMAKE_EXPORT_COMPILE_COMMANDS=ON"
+      env: CONFIGURATION="Debug" CC=clang-4.0 CXX=clang++-4.0 CMAKE_OPTIONS="-DCLANG_USE_LIBCXX=ON"
       addons:
         apt:
           sources:
@@ -97,9 +97,18 @@ matrix:
           packages:
             - *global_deps
             - clang-4.0
-            - clang-tidy-8
             - libc++-dev
             - libc++abi-dev
+    - os: linux
+      env: CONFIGURATION="Debug" CC=clang-9 CXX=clang++-9 CMAKE_OPTIONS="-DCMAKE_EXPORT_COMPILE_COMMANDS=ON"
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+            - sourceline: 'ppa:beineri/opt-qt571-xenial'
+          packages:
+            - *global_deps
+            - g++-9
       script:
         - ./ci/travis/script.sh
         - ./ci/travis/clang_tidy.sh
@@ -132,18 +141,31 @@ matrix:
             - g++-9
             - *global_deps
     - os: linux
-      env: CONFIGURATION="Release" CC=clang-4.0 CXX=clang++-4.0
+      env: CONFIGURATION="Release" CC=clang-4.0 CXX=clang++-4.0 CMAKE_OPTIONS="-DCLANG_USE_LIBCXX=ON"
       addons:
         apt:
           sources:
             - ubuntu-toolchain-r-test
-            - llvm-toolchain-xenial-4
+            - llvm-toolchain-xenial-8
             - sourceline: 'ppa:beineri/opt-qt571-xenial'
           packages:
             - *global_deps
             - clang-4.0
             - libc++-dev
             - libc++abi-dev
+    - os: linux
+      env: CONFIGURATION="Release" CC=clang-9 CXX=clang++-9 CMAKE_OPTIONS="-DCMAKE_EXPORT_COMPILE_COMMANDS=ON"
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+            - sourceline: 'ppa:beineri/opt-qt571-xenial'
+          packages:
+            - *global_deps
+            - g++-9
+      script:
+        - ./ci/travis/script.sh
+        - ./ci/travis/clang_tidy.sh
     - os: osx
       env: CONFIGURATION="Release"
 

--- a/ci/travis/before_install.sh
+++ b/ci/travis/before_install.sh
@@ -6,8 +6,11 @@ if [ "$TRAVIS_OS_NAME" = "linux" ]; then
     export DEBIAN_FRONTEND=noninteractive
 
     sudo add-apt-repository -y "ppa:msulikowski/valgrind" # For fixing a bug with valgrind 3.11 which does not recognize the rdrand instruction
+
+    wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
+    sudo add-apt-repository -y 'deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-9 main'
+
     sudo apt-get -yq update
-    sudo apt-get -yq install valgrind
 elif [ "$TRAVIS_OS_NAME" = "osx" ]; then
     # Nothing to do here
     :

--- a/ci/travis/before_script.sh
+++ b/ci/travis/before_script.sh
@@ -15,8 +15,8 @@ mkdir -p build
 cd build
 
 if [ "$TRAVIS_OS_NAME" = "linux" ]; then
-    CXXFLAGS="-m64 -mtune=generic -mfpmath=sse -msse -msse2 -pipe -Wno-unknown-pragmas -fno-asynchronous-unwind-tables"
-    CFLAGS="-m64 -mtune=generic -mfpmath=sse -msse -msse2 -pipe -Wno-unknown-pragmas -fno-asynchronous-unwind-tables"
+    CXXFLAGS="-m64 -mtune=generic -mfpmath=sse -msse -msse2 -pipe -Wno-unknown-pragmas"
+    CFLAGS="-m64 -mtune=generic -mfpmath=sse -msse -msse2 -pipe -Wno-unknown-pragmas"
 
     export CXXFLAGS
     export CFLAGS

--- a/ci/travis/before_script.sh
+++ b/ci/travis/before_script.sh
@@ -18,10 +18,6 @@ if [ "$TRAVIS_OS_NAME" = "linux" ]; then
     CXXFLAGS="-m64 -mtune=generic -mfpmath=sse -msse -msse2 -pipe -Wno-unknown-pragmas"
     CFLAGS="-m64 -mtune=generic -mfpmath=sse -msse -msse2 -pipe -Wno-unknown-pragmas"
 
-    if [[ "$CC" =~ ^clang.*$ ]]; then
-        CXXFLAGS="$CXXFLAGS -stdlib=libc++"
-    fi
-
     export CXXFLAGS
     export CFLAGS
     CMAKE="cmake -G Ninja -DFSO_FATAL_WARNINGS=ON $CMAKE_OPTIONS"

--- a/ci/travis/before_script.sh
+++ b/ci/travis/before_script.sh
@@ -15,8 +15,8 @@ mkdir -p build
 cd build
 
 if [ "$TRAVIS_OS_NAME" = "linux" ]; then
-    CXXFLAGS="-m64 -mtune=generic -mfpmath=sse -msse -msse2 -pipe -Wno-unknown-pragmas"
-    CFLAGS="-m64 -mtune=generic -mfpmath=sse -msse -msse2 -pipe -Wno-unknown-pragmas"
+    CXXFLAGS="-m64 -mtune=generic -mfpmath=sse -msse -msse2 -pipe -Wno-unknown-pragmas -fno-asynchronous-unwind-tables"
+    CFLAGS="-m64 -mtune=generic -mfpmath=sse -msse -msse2 -pipe -Wno-unknown-pragmas -fno-asynchronous-unwind-tables"
 
     export CXXFLAGS
     export CFLAGS

--- a/ci/travis/clang-tidy-diff.py
+++ b/ci/travis/clang-tidy-diff.py
@@ -2,10 +2,9 @@
 #
 #===- clang-tidy-diff.py - ClangTidy Diff Checker ------------*- python -*--===#
 #
-#                     The LLVM Compiler Infrastructure
-#
-# This file is distributed under the University of Illinois Open Source
-# License. See LICENSE.TXT for details.
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
 #===------------------------------------------------------------------------===#
 
@@ -25,117 +24,245 @@ Example usage for git/svn users:
 """
 
 import argparse
+import glob
 import json
+import multiprocessing
+import os
 import re
+import shutil
 import subprocess
 import sys
+import tempfile
+import threading
+import traceback
+
+try:
+    import yaml
+except ImportError:
+    yaml = None
+
+is_py2 = sys.version[0] == '2'
+
+if is_py2:
+    import Queue as queue
+else:
+    import queue as queue
+
+
+def run_tidy(task_queue, lock, timeout):
+    watchdog = None
+    while True:
+        command = task_queue.get()
+        try:
+            proc = subprocess.Popen(command,
+                                    stdout=subprocess.PIPE,
+                                    stderr=subprocess.PIPE)
+
+            if timeout is not None:
+                watchdog = threading.Timer(timeout, proc.kill)
+                watchdog.start()
+
+            stdout, stderr = proc.communicate()
+
+            with lock:
+                sys.stdout.write(stdout.decode('utf-8'))
+                sys.stdout.flush()
+                if stderr:
+                    sys.stderr.write(stderr.decode('utf-8'))
+                    sys.stderr.flush()
+        except Exception as e:
+            with lock:
+                sys.stderr.write('Failed: ' + str(e) + ': '.join(command) + '\n')
+        finally:
+            with lock:
+                if (not timeout is None) and (not watchdog is None):
+                    if not watchdog.is_alive():
+                        sys.stderr.write('Terminated by timeout: ' +
+                                         ' '.join(command) + '\n')
+                    watchdog.cancel()
+            task_queue.task_done()
+
+
+def start_workers(max_tasks, tidy_caller, task_queue, lock, timeout):
+    for _ in range(max_tasks):
+        t = threading.Thread(target=tidy_caller, args=(task_queue, lock, timeout))
+        t.daemon = True
+        t.start()
+
+def merge_replacement_files(tmpdir, mergefile):
+    """Merge all replacement files in a directory into a single file"""
+    # The fixes suggested by clang-tidy >= 4.0.0 are given under
+    # the top level key 'Diagnostics' in the output yaml files
+    mergekey = "Diagnostics"
+    merged = []
+    for replacefile in glob.iglob(os.path.join(tmpdir, '*.yaml')):
+        content = yaml.safe_load(open(replacefile, 'r'))
+        if not content:
+            continue # Skip empty files.
+        merged.extend(content.get(mergekey, []))
+
+    if merged:
+        # MainSourceFile: The key is required by the definition inside
+        # include/clang/Tooling/ReplacementsYaml.h, but the value
+        # is actually never used inside clang-apply-replacements,
+        # so we set it to '' here.
+        output = { 'MainSourceFile': '', mergekey: merged }
+        with open(mergefile, 'w') as out:
+            yaml.safe_dump(output, out)
+    else:
+        # Empty the file:
+        open(mergefile, 'w').close()
 
 
 def main():
-  parser = argparse.ArgumentParser(description=
-                                   'Run clang-tidy against changed files, and '
-                                   'output diagnostics only for modified '
-                                   'lines.')
-  parser.add_argument('-clang-tidy-binary', metavar='PATH',
-                      default='clang-tidy',
-                      help='path to clang-tidy binary')
-  parser.add_argument('-p', metavar='NUM', default=0,
-                      help='strip the smallest prefix containing P slashes')
-  parser.add_argument('-regex', metavar='PATTERN', default=None,
-                      help='custom pattern selecting file paths to check '
-                      '(case sensitive, overrides -iregex)')
-  parser.add_argument('-iregex', metavar='PATTERN', default=
-                      r'.*\.(cpp|cc|c\+\+|cxx|c|cl|h|hpp|m|mm|inc)',
-                      help='custom pattern selecting file paths to check '
-                      '(case insensitive, overridden by -regex)')
+    parser = argparse.ArgumentParser(description=
+                                     'Run clang-tidy against changed files, and '
+                                     'output diagnostics only for modified '
+                                     'lines.')
+    parser.add_argument('-clang-tidy-binary', metavar='PATH',
+                        default='clang-tidy',
+                        help='path to clang-tidy binary')
+    parser.add_argument('-p', metavar='NUM', default=0,
+                        help='strip the smallest prefix containing P slashes')
+    parser.add_argument('-regex', metavar='PATTERN', default=None,
+                        help='custom pattern selecting file paths to check '
+                             '(case sensitive, overrides -iregex)')
+    parser.add_argument('-iregex', metavar='PATTERN', default=
+    r'.*\.(cpp|cc|c\+\+|cxx|c|cl|h|hpp|m|mm|inc)',
+                        help='custom pattern selecting file paths to check '
+                             '(case insensitive, overridden by -regex)')
+    parser.add_argument('-j', type=int, default=1,
+                        help='number of tidy instances to be run in parallel.')
+    parser.add_argument('-timeout', type=int, default=None,
+                        help='timeout per each file in seconds.')
+    parser.add_argument('-fix', action='store_true', default=False,
+                        help='apply suggested fixes')
+    parser.add_argument('-checks',
+                        help='checks filter, when not specified, use clang-tidy '
+                             'default',
+                        default='')
+    parser.add_argument('-path', dest='build_path',
+                        help='Path used to read a compile command database.')
+    if yaml:
+        parser.add_argument('-export-fixes', metavar='FILE', dest='export_fixes',
+                            help='Create a yaml file to store suggested fixes in, '
+                                 'which can be applied with clang-apply-replacements.')
+    parser.add_argument('-extra-arg', dest='extra_arg',
+                        action='append', default=[],
+                        help='Additional argument to append to the compiler '
+                             'command line.')
+    parser.add_argument('-extra-arg-before', dest='extra_arg_before',
+                        action='append', default=[],
+                        help='Additional argument to prepend to the compiler '
+                             'command line.')
+    parser.add_argument('-quiet', action='store_true', default=False,
+                        help='Run clang-tidy in quiet mode')
+    clang_tidy_args = []
+    argv = sys.argv[1:]
+    if '--' in argv:
+        clang_tidy_args.extend(argv[argv.index('--'):])
+        argv = argv[:argv.index('--')]
 
-  parser.add_argument('-fix', action='store_true', default=False,
-                      help='apply suggested fixes')
-  parser.add_argument('-checks',
-                      help='checks filter, when not specified, use clang-tidy '
-                      'default',
-                      default='')
-  parser.add_argument('-path', dest='build_path',
-                      help='Path used to read a compile command database.')
-  parser.add_argument('-extra-arg', dest='extra_arg',
-                      action='append', default=[],
-                      help='Additional argument to append to the compiler '
-                      'command line.')
-  parser.add_argument('-extra-arg-before', dest='extra_arg_before',
-                      action='append', default=[],
-                      help='Additional argument to prepend to the compiler '
-                      'command line.')
-  parser.add_argument('-quiet', action='store_true', default=False,
-                      help='Run clang-tidy in quiet mode')
-  clang_tidy_args = []
-  argv = sys.argv[1:]
-  if '--' in argv:
-    clang_tidy_args.extend(argv[argv.index('--'):])
-    argv = argv[:argv.index('--')]
+    args = parser.parse_args(argv)
 
-  args = parser.parse_args(argv)
+    # Extract changed lines for each file.
+    filename = None
+    lines_by_file = {}
+    for line in sys.stdin:
+        match = re.search('^\+\+\+\ \"?(.*?/){%s}([^ \t\n\"]*)' % args.p, line)
+        if match:
+            filename = match.group(2)
+        if filename is None:
+            continue
 
-  # Extract changed lines for each file.
-  filename = None
-  lines_by_file = {}
-  for line in sys.stdin:
-    match = re.search('^\+\+\+\ \"?(.*?/){%s}([^ \t\n\"]*)' % args.p, line)
-    if match:
-      filename = match.group(2)
-    if filename == None:
-      continue
+        if args.regex is not None:
+            if not re.match('^%s$' % args.regex, filename):
+                continue
+        else:
+            if not re.match('^%s$' % args.iregex, filename, re.IGNORECASE):
+                continue
 
-    if args.regex is not None:
-      if not re.match('^%s$' % args.regex, filename):
-        continue
-    else:
-      if not re.match('^%s$' % args.iregex, filename, re.IGNORECASE):
-        continue
+        match = re.search('^@@.*\+(\d+)(,(\d+))?', line)
+        if match:
+            start_line = int(match.group(1))
+            line_count = 1
+            if match.group(3):
+                line_count = int(match.group(3))
+            if line_count == 0:
+                continue
+            end_line = start_line + line_count - 1
+            lines_by_file.setdefault(filename, []).append([start_line, end_line])
 
-    match = re.search('^@@.*\+(\d+)(,(\d+))?', line)
-    if match:
-      start_line = int(match.group(1))
-      line_count = 1
-      if match.group(3):
-        line_count = int(match.group(3))
-      if line_count == 0:
-        continue
-      end_line = start_line + line_count - 1;
-      lines_by_file.setdefault(filename, []).append([start_line, end_line])
+    if not any(lines_by_file):
+        print("No relevant changes found.")
+        sys.exit(0)
 
-  if len(lines_by_file) == 0:
-    print("No relevant changes found.")
-    sys.exit(0)
+    max_task_count = args.j
+    if max_task_count == 0:
+        max_task_count = multiprocessing.cpu_count()
+    max_task_count = min(len(lines_by_file), max_task_count)
 
-  line_filter_json = json.dumps(
-    [{"name" : name, "lines" : lines_by_file[name]} for name in lines_by_file],
-    separators = (',', ':'))
+    tmpdir = None
+    if yaml and args.export_fixes:
+        tmpdir = tempfile.mkdtemp()
 
-  quote = "";
-  if sys.platform == 'win32':
-    line_filter_json=re.sub(r'"', r'"""', line_filter_json)
-  else:
-    quote = "'";
+    # Tasks for clang-tidy.
+    task_queue = queue.Queue(max_task_count)
+    # A lock for console output.
+    lock = threading.Lock()
 
-  # Run clang-tidy on files containing changes.
-  command = [args.clang_tidy_binary]
-  command.append('-line-filter=' + quote + line_filter_json + quote)
-  if args.fix:
-    command.append('-fix')
-  if args.checks != '':
-    command.append('-checks=' + quote + args.checks + quote)
-  if args.quiet:
-    command.append('-quiet')
-  if args.build_path is not None:
-    command.append('-p=%s' % args.build_path)
-  command.extend(lines_by_file.keys())
-  for arg in args.extra_arg:
-      command.append('-extra-arg=%s' % arg)
-  for arg in args.extra_arg_before:
-      command.append('-extra-arg-before=%s' % arg)
-  command.extend(clang_tidy_args)
+    # Run a pool of clang-tidy workers.
+    start_workers(max_task_count, run_tidy, task_queue, lock, args.timeout)
 
-  sys.exit(subprocess.call(' '.join(command), shell=True))
+    # Form the common args list.
+    common_clang_tidy_args = []
+    if args.fix:
+        common_clang_tidy_args.append('-fix')
+    if args.checks != '':
+        common_clang_tidy_args.append('-checks=' + args.checks)
+    if args.quiet:
+        common_clang_tidy_args.append('-quiet')
+    if args.build_path is not None:
+        common_clang_tidy_args.append('-p=%s' % args.build_path)
+    for arg in args.extra_arg:
+        common_clang_tidy_args.append('-extra-arg=%s' % arg)
+    for arg in args.extra_arg_before:
+        common_clang_tidy_args.append('-extra-arg-before=%s' % arg)
+
+    for name in lines_by_file:
+        line_filter_json = json.dumps(
+            [{"name": name, "lines": lines_by_file[name]}],
+            separators=(',', ':'))
+
+        # Run clang-tidy on files containing changes.
+        command = [args.clang_tidy_binary]
+        command.append('-line-filter=' + line_filter_json)
+        if yaml and args.export_fixes:
+            # Get a temporary file. We immediately close the handle so clang-tidy can
+            # overwrite it.
+            (handle, tmp_name) = tempfile.mkstemp(suffix='.yaml', dir=tmpdir)
+            os.close(handle)
+            command.append('-export-fixes=' + tmp_name)
+        command.extend(common_clang_tidy_args)
+        command.append(name)
+        command.extend(clang_tidy_args)
+
+        task_queue.put(command)
+
+    # Wait for all threads to be done.
+    task_queue.join()
+
+    if yaml and args.export_fixes:
+        print('Writing fixes to ' + args.export_fixes + ' ...')
+        try:
+            merge_replacement_files(tmpdir, args.export_fixes)
+        except:
+            sys.stderr.write('Error exporting fixes.\n')
+            traceback.print_exc()
+
+    if tmpdir:
+        shutil.rmtree(tmpdir)
+
 
 if __name__ == '__main__':
-  main()
+    main()

--- a/ci/travis/clang_tidy.sh
+++ b/ci/travis/clang_tidy.sh
@@ -13,7 +13,7 @@ echo "Running clang-tidy on changed files"
 git diff -U0 --no-color $TRAVIS_COMMIT_RANGE | \
     $TRAVIS_BUILD_DIR/ci/travis/clang-tidy-diff.py -path "$TRAVIS_BUILD_DIR/build" -p1 \
     -regex 'code/.*$|freespace2/.*$|qtfred/.*$|test/src/.*$|build/.*$|tools/.*' \
-    -clang-tidy-binary /usr/bin/clang-tidy-8 2>/dev/null | \
+    -clang-tidy-binary /usr/bin/clang-tidy-9 -j$(nproc) -quiet 2>/dev/null | \
     tee clang-tidy-output.txt
 
 if [[ -n $(grep "warning: " clang-tidy-output.txt) ]] || [[ -n $(grep "error: " clang-tidy-output.txt) ]]; then

--- a/ci/travis/install.sh
+++ b/ci/travis/install.sh
@@ -4,6 +4,8 @@ set -ex
 
 FILENAME=
 if [ "$TRAVIS_OS_NAME" = "linux" ]; then
+    export DEBIAN_FRONTEND=noninteractive
+
     if [ ! -d "$HOME/cmake-3.8/bin" ]; then
         # If the cache does not currently contain CMake then download and install it
     	mkdir -p $HOME/cmake-3.8/
@@ -23,7 +25,13 @@ if [ "$TRAVIS_OS_NAME" = "linux" ]; then
         chmod a+x ./linuxdeployqt
     fi
 
-    if [[ "$CC" =~ ^clang.*$ ]]; then
+    sudo apt-get -yq install valgrind
+
+    if [[ "$CC" = "clang-9" ]]; then
+      sudo apt-get -yq install clang-9 clang-tidy-9
+    fi
+
+    if [[ "$CC" = "clang-4.0" ]]; then
       # Fix a header bug present in ubuntu...
       sudo ln -s /usr/include/libcxxabi/__cxxabi_config.h /usr/include/c++/v1/__cxxabi_config.h
     fi

--- a/ci/travis/script.sh
+++ b/ci/travis/script.sh
@@ -7,7 +7,6 @@ cd build
 if [ "$TRAVIS_OS_NAME" = "linux" ]; then
     ninja -k 20 all
 
-
     if [ "$CONFIGURATION" = "Debug" ]; then
         valgrind --leak-check=full --error-exitcode=1 --gen-suppressions=all \
             --suppressions="$TRAVIS_BUILD_DIR/ci/travis/valgrind.supp" ./bin/unittests --gtest_shuffle

--- a/cmake/platform-unix.cmake
+++ b/cmake/platform-unix.cmake
@@ -3,7 +3,7 @@ INCLUDE(util)
 
 MESSAGE(STATUS "Configuring UNIX specific things and stuff...")
 
-target_compile_definitions(platform INTERFACE SCP_UNIX USE_OPENAL)
+target_compile_definitions(platform INTERFACE SCP_UNIX USE_OPENAL _REENTRANT)
 
 # Set RPATH
 set(CMAKE_SKIP_BUILD_RPATH TRUE)

--- a/cmake/toolchain-clang.cmake
+++ b/cmake/toolchain-clang.cmake
@@ -7,6 +7,8 @@ MESSAGE(STATUS "Doing configuration specific to clang...")
 option(CLANG_ENABLE_LEAK_CHECK "Enable -fsanitize=leak" OFF)
 option(CLANG_ENABLE_ADDRESS_SANITIZER "Enable -fsanitize=address" OFF)
 
+option(CLANG_USE_LIBCXX "Use libc++" OFF)
+
 # These are the default values
 set(C_BASE_FLAGS "-march=native -pipe")
 set(CXX_BASE_FLAGS "-march=native -pipe")
@@ -17,6 +19,10 @@ if(DEFINED ENV{CXXFLAGS})
 endif()
 if(DEFINED ENV{CFLAGS})
 	set(C_BASE_FLAGS $ENV{CFLAGS})
+endif()
+
+if (CLANG_USE_LIBCXX)
+	set(CXX_BASE_FLAGS "${CXX_BASE_FLAGS} -stdlib=libc++")
 endif()
 
 # Initialize with an empty string to make sure we always get a clean start
@@ -92,6 +98,10 @@ set(CMAKE_C_FLAGS_DEBUG ${COMPILER_FLAGS_DEBUG})
 
 
 set(CMAKE_EXE_LINKER_FLAGS "")
+
+if (CLANG_USE_LIBCXX)
+	set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -lc++abi")
+endif()
 
 if (SANITIZE_FLAGS)
 	set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${SANITIZE_FLAGS}")

--- a/code/cmdline/cmdline.cpp
+++ b/code/cmdline/cmdline.cpp
@@ -240,6 +240,7 @@ Flag exe_params[] =
 	{ "-dis_weapons",		"Disable weapon rendering",					true,	0,					EASY_DEFAULT,		"Dev Tool",		"http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-dis_weapons", },
 	{ "-output_sexps",		"Output SEXPs to sexps.html",				true,	0,					EASY_DEFAULT,		"Dev Tool",		"http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-output_sexps", },
 	{ "-output_scripting",	"Output scripting to scripting.html",		true,	0,					EASY_DEFAULT,		"Dev Tool",		"http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-output_scripting", },
+	{ "-output_script_json",	"Output scripting doc to scripting.json",		true,	0,					EASY_DEFAULT,		"Dev Tool",		"http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-output_script_json", },
 	{ "-save_render_target",	"Save render targets to file",			true,	0,					EASY_DEFAULT,		"Dev Tool",		"http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-save_render_target", },
 	{ "-verify_vps",		"Spew VP CRCs to vp_crcs.txt",				true,	0,					EASY_DEFAULT,		"Dev Tool",		"http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-verify_vps", },
 	{ "-reparse_mainhall",	"Reparse mainhall.tbl when loading halls",	false,	0,					EASY_DEFAULT,		"Dev Tool",		"http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-reparse_mainhall", },
@@ -514,6 +515,7 @@ bool Cmdline_debug_window = false;
 cmdline_parm get_flags_arg(GET_FLAGS_STRING, "Output the launcher flags file", AT_STRING);
 cmdline_parm output_sexp_arg("-output_sexps", NULL, AT_NONE); //WMC - outputs all SEXPs to sexps.html
 cmdline_parm output_scripting_arg("-output_scripting", NULL, AT_NONE);	//WMC
+cmdline_parm output_script_json_arg("-output_script_json", nullptr, AT_NONE);	// m!m
 
 // Deprecated flags - CommanderDJ
 cmdline_parm deprecated_spec_arg("-spec", "Deprecated", AT_NONE);
@@ -1914,6 +1916,9 @@ bool SetCmdlineParams()
 
 	if ( output_scripting_arg.found() )
 		Output_scripting_meta = true;
+
+	if (output_script_json_arg.found() )
+		Output_scripting_json = true;
 
 	if (output_sexp_arg.found() ) {
 		Cmdline_output_sexp_info = true;

--- a/code/lab/lab.cpp
+++ b/code/lab/lab.cpp
@@ -147,7 +147,7 @@ bool Lab_Envmap_override         = false;
 bool Lab_Normalmap_override      = false;
 bool Lab_Heightmap_override      = false;
 bool Lab_Miscmap_override        = false;
-bool Lab_emissive_light_override = Cmdline_emissive;
+bool Lab_emissive_light_override = Cmdline_emissive != 0;
 
 fix Lab_Save_Missiontime;
 

--- a/code/scripting/ade_api.h
+++ b/code/scripting/ade_api.h
@@ -229,7 +229,7 @@ class ade_lib : public ade_lib_handle {
 class ade_func : public ade_lib_handle {
   public:
 	ade_func(const char* name, lua_CFunction func, const ade_lib_handle& parent, const char* args, const char* desc,
-	         const char* ret_type, const char* ret_desc, const gameversion::version& deprecation_version,
+	         ade_type_info ret_type, const char* ret_desc, const gameversion::version& deprecation_version,
 	         const char* deprecation_message);
 };
 
@@ -282,7 +282,7 @@ class ade_func : public ade_lib_handle {
 class ade_virtvar : public ade_lib_handle {
   public:
 	ade_virtvar(const char* name, lua_CFunction func, const ade_lib_handle& parent, const char* args, const char* desc,
-	            const char* ret_type, const char* ret_desc, const gameversion::version& deprecation_version,
+	            ade_type_info ret_type, const char* ret_desc, const gameversion::version& deprecation_version,
 	            const char* deprecation_message);
 };
 
@@ -336,7 +336,7 @@ class ade_virtvar : public ade_lib_handle {
 class ade_indexer : public ade_lib_handle {
   public:
 	ade_indexer(lua_CFunction func, const ade_lib_handle& parent, const char* args = nullptr,
-	            const char* desc = nullptr, const char* ret_type = nullptr, const char* ret_desc = nullptr);
+	            const char* desc = nullptr, ade_type_info ret_type = ade_type_info(), const char* ret_desc = nullptr);
 };
 
 /**

--- a/code/scripting/api/libs/audio.cpp
+++ b/code/scripting/api/libs/audio.cpp
@@ -110,7 +110,10 @@ ADE_FUNC(playLoopingSound, l_Audio, "soundentry", "Plays the specified sound as 
 	}
 }
 
-ADE_FUNC(play3DSound, l_Audio, "soundentry[, vector source[, vector listener]]", "Plays the specified sound entry handle. Source if by default 0, 0, 0 and listener is by default the current viewposition", "3Dsound", "A handle to the playing sound")
+ADE_FUNC(play3DSound, l_Audio, "soundentry[, vector source[, vector listener]]",
+         "Plays the specified sound entry handle. Source if by default 0, 0, 0 and listener is by default the current "
+         "viewposition",
+         "sound3D", "A handle to the playing sound")
 {
 	sound_entry_h *seh = NULL;
 	vec3d *source = &vmd_zero_vector;

--- a/code/scripting/api/libs/base.cpp
+++ b/code/scripting/api/libs/base.cpp
@@ -223,7 +223,7 @@ ADE_FUNC(setButtonControlMode, l_Base, "NIL or enumeration LE_*_BUTTON_CONTROL",
 	}
 }
 
-ADE_FUNC(getControlInfo, l_Base, NULL, "Gets the control info handle.", "control info", "control info handle")
+ADE_FUNC(getControlInfo, l_Base, nullptr, "Gets the control info handle.", "control_info", "control info handle")
 {
 	return ade_set_args(L, "o", l_Control_Info.Set(1));
 }
@@ -245,7 +245,9 @@ ADE_FUNC(setTips, l_Base, "True or false", "Sets whether to display tips of the 
 	return ADE_RETURN_NIL;
 }
 
-ADE_FUNC(getGameDifficulty, l_Base, NULL, "Returns the difficulty level from 1-5, 1 being the lowest, (Very Easy) and 5 being the highest (Insane)", "integer", "Difficulty level as integer")
+ADE_FUNC(getGameDifficulty, l_Base, nullptr,
+         "Returns the difficulty level from 1-5, 1 being the lowest, (Very Easy) and 5 being the highest (Insane)",
+         "number", "Difficulty level as integer")
 {
 	return ade_set_args(L, "i", Game_skill_level+1);
 }

--- a/code/scripting/api/libs/cfile.cpp
+++ b/code/scripting/api/libs/cfile.cpp
@@ -57,7 +57,7 @@ ADE_FUNC(fileExists, l_CFile, "string Filename, [string Path = \"\", boolean Che
 ADE_FUNC(listFiles, l_CFile, "string directory, string filter",
          "Lists all the files in the specified directory and optionally applies a filter. The filter must have the "
          "format \"*<rest>\" (the wildcard has to appear at the start).",
-         "table", "A table with all files in the directory or nil on error")
+         ade_type_array("string"), "A table with all files in the directory or nil on error")
 {
 	using namespace luacpp;
 

--- a/code/scripting/api/libs/graphics.cpp
+++ b/code/scripting/api/libs/graphics.cpp
@@ -250,7 +250,8 @@ ADE_VIRTVAR(CurrentRenderTarget, l_Graphics, "texture", "Current rendering targe
 	}
 }
 
-ADE_FUNC(clearScreen, l_Graphics, "[integer red, number green, number blue, number alpha]", "Clears the screen to black, or the color specified.", NULL, NULL)
+ADE_FUNC(clearScreen, l_Graphics, "[number red, number green, number blue, number alpha]",
+         "Clears the screen to black, or the color specified.", nullptr, nullptr)
 {
 	int r,g,b,a;
 	r=g=b=0;
@@ -467,7 +468,8 @@ ADE_FUNC(setCamera, l_Graphics, "[camera handle Camera]", "Sets current camera, 
 	return ADE_RETURN_TRUE;
 }
 
-ADE_FUNC(setColor, l_Graphics, "integer Red, number Green, number Blue, [integer Alpha]", "Sets 2D drawing color; each color number should be from 0 (darkest) to 255 (brightest)", NULL, NULL)
+ADE_FUNC(setColor, l_Graphics, "number Red, number Green, number Blue, [integer Alpha]",
+         "Sets 2D drawing color; each color number should be from 0 (darkest) to 255 (brightest)", nullptr, nullptr)
 {
 	if(!Gr_inited)
 		return ADE_RETURN_NIL;
@@ -713,7 +715,10 @@ ADE_FUNC(drawSphere, l_Graphics, "[number Radius = 1.0, vector Position]", "Draw
 }
 
 // Aardwolf's test code to render a model, supposed to emulate WMC's gr.drawModel function
-ADE_FUNC(drawModel, l_Graphics, "model, position, orientation", "Draws the given model with the specified position and orientation - Use with extreme care, may not work properly in all scripting hooks.", "int", "Zero if successful, otherwise an integer error code")
+ADE_FUNC(drawModel, l_Graphics, "model, position, orientation",
+         "Draws the given model with the specified position and orientation - Use with extreme care, may not work "
+         "properly in all scripting hooks.",
+         "number", "Zero if successful, otherwise an integer error code")
 {
 	model_h *mdl = NULL;
 	vec3d *v = &vmd_zero_vector;
@@ -779,7 +784,10 @@ ADE_FUNC(drawModel, l_Graphics, "model, position, orientation", "Draws the given
 }
 
 // Wanderer
-ADE_FUNC(drawModelOOR, l_Graphics, "model Model, vector Position, matrix Orientation, [integer Flags]", "Draws the given model with the specified position and orientation - Use with extreme care, designed to operate properly only in On Object Render hooks.", "int", "Zero if successful, otherwise an integer error code")
+ADE_FUNC(drawModelOOR, l_Graphics, "model Model, vector Position, matrix Orientation, [number Flags]",
+         "Draws the given model with the specified position and orientation - Use with extreme care, designed to "
+         "operate properly only in On Object Render hooks.",
+         "number", "Zero if successful, otherwise an integer error code")
 {
 	model_h *mdl = NULL;
 	vec3d *v = &vmd_zero_vector;
@@ -817,9 +825,11 @@ ADE_FUNC(drawModelOOR, l_Graphics, "model Model, vector Position, matrix Orienta
 
 // Aardwolf's targeting brackets function
 ADE_FUNC(drawTargetingBrackets, l_Graphics, "object Object, [boolean draw=true, int padding=5]",
-		 "Gets the edge positions of targeting brackets for the specified object. The brackets will only be drawn if draw is true or the default value of draw is used. Brackets are drawn with the current color. The brackets will have a padding (distance from the actual bounding box); the default value (used elsewhere in FS2) is 5.",
-		 "number,number,number,number",
-		 "Left, top, right, and bottom positions of the brackets, or nil if invalid")
+         "Gets the edge positions of targeting brackets for the specified object. The brackets will only be drawn if "
+         "draw is true or the default value of draw is used. Brackets are drawn with the current color. The brackets "
+         "will have a padding (distance from the actual bounding box); the default value (used elsewhere in FS2) is 5.",
+         ade_type_info({"number", "number", "number", "number"}),
+         "Left, top, right, and bottom positions of the brackets, or nil if invalid")
 {
 	if(!Gr_inited) {
 		return ADE_RETURN_NIL;
@@ -916,10 +926,12 @@ ADE_FUNC(drawTargetingBrackets, l_Graphics, "object Object, [boolean draw=true, 
 	return ade_set_args(L, "iiii", x1, y1, x2, y2);
 }
 
-ADE_FUNC(drawSubsystemTargetingBrackets, l_Graphics, "subsystem subsys, [boolean draw=true, boolean setColor=false]",
-		 "Gets the edge position of the targeting brackets drawn for a subsystem as if they were drawn on the HUD. Only actually draws the brackets if <i>draw</i> is true, optionally sets the color the as if it was drawn on the HUD",
-		 "number,number,number,number",
-		 "Left, top, right, and bottom positions of the brackets, or nil if invalid or off-screen")
+ADE_FUNC(
+    drawSubsystemTargetingBrackets, l_Graphics, "subsystem subsys, [boolean draw=true, boolean setColor=false]",
+    "Gets the edge position of the targeting brackets drawn for a subsystem as if they were drawn on the HUD. Only "
+    "actually draws the brackets if <i>draw</i> is true, optionally sets the color the as if it was drawn on the HUD",
+    ade_type_info({"number", "number", "number", "number"}),
+    "Left, top, right, and bottom positions of the brackets, or nil if invalid or off-screen")
 {
 	if(!Gr_inited) {
 		return ADE_RETURN_NIL;
@@ -966,9 +978,11 @@ ADE_FUNC(drawSubsystemTargetingBrackets, l_Graphics, "subsystem subsys, [boolean
 }
 
 ADE_FUNC(drawOffscreenIndicator, l_Graphics, "object Object, [boolean draw=true, boolean setColor=false]",
-		 "Draws an off-screen indicator for the given object. The indicator will not be drawn if draw=false, but the coordinates will be returned in either case. The indicator will be drawn using the current color if setColor=true and using the IFF color of the object if setColor=false.",
-		 "number,number",
-		 "Coordinates of the indicator (at the very edge of the screen), or nil if object is on-screen")
+         "Draws an off-screen indicator for the given object. The indicator will not be drawn if draw=false, but the "
+         "coordinates will be returned in either case. The indicator will be drawn using the current color if "
+         "setColor=true and using the IFF color of the object if setColor=false.",
+         ade_type_info({"number", "number"}),
+         "Coordinates of the indicator (at the very edge of the screen), or nil if object is on-screen")
 {
 	object_h *objh = NULL;
 	bool draw = false;

--- a/code/scripting/api/libs/hud.cpp
+++ b/code/scripting/api/libs/hud.cpp
@@ -53,7 +53,9 @@ ADE_VIRTVAR(HUDDisabledExceptMessages, l_HUD, "boolean", "Specifies if only the 
 		return ADE_RETURN_FALSE;
 }
 
-ADE_FUNC(setHUDGaugeColor, l_HUD, "number (index number of the gauge), [integer red, number green, number blue, number alpha]", "Color used to draw the gauge", "boolean", "If the operation was successful")
+ADE_FUNC(setHUDGaugeColor, l_HUD,
+         "number (index number of the gauge), [number red, number green, number blue, number alpha]",
+         "Color used to draw the gauge", "boolean", "If the operation was successful")
 {
 	int idx = -1;
 	int r = 0;
@@ -72,7 +74,8 @@ ADE_FUNC(setHUDGaugeColor, l_HUD, "number (index number of the gauge), [integer 
 	return ADE_RETURN_TRUE;
 }
 
-ADE_FUNC(getHUDGaugeColor, l_HUD, "number (index number of the gauge)", "Color used to draw the gauge", "number, number, number, number", "Red, green, blue, and alpha of the gauge")
+ADE_FUNC(getHUDGaugeColor, l_HUD, "number (index number of the gauge)", "Color used to draw the gauge",
+         ade_type_info({"number", "number", "number", "number"}), "Red, green, blue, and alpha of the gauge")
 {
 	int idx = -1;
 

--- a/code/scripting/api/libs/options.cpp
+++ b/code/scripting/api/libs/options.cpp
@@ -12,7 +12,7 @@ namespace api {
 //**********LIBRARY: Mission
 ADE_LIB(l_Options, "Options", "opt", "Options library");
 
-ADE_VIRTVAR(Options, l_Options, nullptr, "The available options.", "{option...}", "A table of all the options.")
+ADE_VIRTVAR(Options, l_Options, nullptr, "The available options.", ade_type_array("option"), "A table of all the options.")
 {
 	using namespace luacpp;
 
@@ -32,7 +32,7 @@ ADE_VIRTVAR(Options, l_Options, nullptr, "The available options.", "{option...}"
 ADE_FUNC(persistChanges, l_Options, nullptr,
          "Persist any changes made to the options system. Options can be incapable of applying changes immediately in "
          "which case they are returned here.",
-         "{option...}", "The options that did not support changing their value")
+         ade_type_array("option"), "The options that did not support changing their value")
 {
 	using namespace luacpp;
 

--- a/code/scripting/api/libs/ui.cpp
+++ b/code/scripting/api/libs/ui.cpp
@@ -117,7 +117,7 @@ ADE_VIRTVAR(ErrorCount, l_UserInterface_PilotSelect, nullptr, "The amount of err
 }
 
 ADE_FUNC(enumeratePilots, l_UserInterface_PilotSelect, nullptr,
-         "Lists all pilots available for the pilot selection<br>", "table{ name... }",
+         "Lists all pilots available for the pilot selection<br>", ade_type_array("string"),
          "A table containing the pilots (without a file extension) or nil on error")
 {
 	using namespace luacpp;
@@ -135,7 +135,7 @@ ADE_FUNC(enumeratePilots, l_UserInterface_PilotSelect, nullptr,
 ADE_FUNC(getLastPilot, l_UserInterface_PilotSelect, nullptr,
          "Reads the last active pilot from the config file and returns some information about it. callsign is the name "
          "of the player and is_multi indicates whether the pilot was last active as a multiplayer pilot.",
-         "string callsign", "The pilot name or nil if there was no last pilot")
+         "string", "The pilot name or nil if there was no last pilot")
 {
 	using namespace luacpp;
 
@@ -160,7 +160,7 @@ ADE_FUNC(checkPilotLanguage, l_UserInterface_PilotSelect, "string callsign",
 }
 
 ADE_FUNC(selectPilot, l_UserInterface_PilotSelect, "string callsign, boolean is_multi",
-         "Selects the pilot with the specified callsign and advances the game to the main menu.", "nil", "nothing")
+         "Selects the pilot with the specified callsign and advances the game to the main menu.", nullptr, "nothing")
 {
 	const char* callsign;
 	bool is_multi;
@@ -213,7 +213,7 @@ ADE_LIB_DERIV(l_UserInterface_MainHall, "MainHall", nullptr,
               "API for the new UI system. This should not be used by other code and may be removed in the future!",
               l_UserInterface);
 
-ADE_FUNC(startAmbientSound, l_UserInterface_MainHall, nullptr, "Starts the ambient mainhall sound.", "nil", "nothing")
+ADE_FUNC(startAmbientSound, l_UserInterface_MainHall, nullptr, "Starts the ambient mainhall sound.", nullptr, "nothing")
 {
 	(void)L;
 	main_hall_start_ambient();
@@ -227,7 +227,7 @@ ADE_LIB_DERIV(l_UserInterface_Barracks, "Barracks", nullptr,
               l_UserInterface);
 
 ADE_FUNC(listPilotImages, l_UserInterface_Barracks, nullptr, "Lists the names of the available pilot images.",
-         "table {string...}", "The list of pilot filenames or nil on error")
+         ade_type_array("string"), "The list of pilot filenames or nil on error")
 {
 	pilot_load_pic_list();
 
@@ -241,7 +241,7 @@ ADE_FUNC(listPilotImages, l_UserInterface_Barracks, nullptr, "Lists the names of
 }
 
 ADE_FUNC(listSquadImages, l_UserInterface_Barracks, nullptr, "Lists the names of the available squad images.",
-         "table {string...}", "The list of squad filenames or nil on error")
+         ade_type_array("string"), "The list of squad filenames or nil on error")
 {
 	pilot_load_squad_pic_list();
 

--- a/code/scripting/api/objs/beam.cpp
+++ b/code/scripting/api/objs/beam.cpp
@@ -255,7 +255,8 @@ ADE_FUNC(getCollisionPosition, l_Beam, "number", "Get the position of the define
 	return ade_set_args(L, "o", l_Vector.Set(bp->f_collisions[idx].cinfo.hit_point_world));
 }
 
-ADE_FUNC(getCollisionInformation, l_Beam, "number", "Get the collision information of the specified collision", "collision info", "handle to information or invalid handle on error")
+ADE_FUNC(getCollisionInformation, l_Beam, "number", "Get the collision information of the specified collision",
+         "collision_info", "handle to information or invalid handle on error")
 {
 	object_h *objh;
 	int idx;

--- a/code/scripting/api/objs/cockpit_display.cpp
+++ b/code/scripting/api/objs/cockpit_display.cpp
@@ -43,7 +43,7 @@ bool cockpit_disp_info_h::isValid() {
 	return true;
 }
 
-ADE_OBJ(l_DisplayInfo, cockpit_disp_info_h, "display info", "Ship cockpit display information handle");
+ADE_OBJ(l_DisplayInfo, cockpit_disp_info_h, "display_info", "Ship cockpit display information handle");
 
 ADE_FUNC(getName, l_DisplayInfo, NULL, "Gets the name of this cockpit display as defined in ships.tbl", "string", "Name string or empty string on error")
 {
@@ -123,7 +123,8 @@ ADE_FUNC(getBackgroundFileName, l_DisplayInfo, NULL, "Gets the file name of the 
 	return ade_set_args(L, "s", cdi->bg_filename);
 }
 
-ADE_FUNC(getSize, l_DisplayInfo, NULL, "Gets the size of this cockpit display", "number, number", "Width and height of the display or -1, -1 on error")
+ADE_FUNC(getSize, l_DisplayInfo, nullptr, "Gets the size of this cockpit display", ade_type_info({"number", "number"}),
+         "Width and height of the display or -1, -1 on error")
 {
 	cockpit_disp_info_h *cdh = NULL;
 
@@ -141,7 +142,8 @@ ADE_FUNC(getSize, l_DisplayInfo, NULL, "Gets the size of this cockpit display", 
 	return ade_set_args(L, "ii", cdi->size[0], cdi->size[1]);
 }
 
-ADE_FUNC(getOffset, l_DisplayInfo, NULL, "Gets the offset of this cockpit display", "number, number", "x and y offset of the display or -1, -1 on error")
+ADE_FUNC(getOffset, l_DisplayInfo, nullptr, "Gets the offset of this cockpit display",
+         ade_type_info({"number", "number"}), "x and y offset of the display or -1, -1 on error")
 {
 	cockpit_disp_info_h *cdh = NULL;
 
@@ -302,7 +304,8 @@ ADE_FUNC(getForegroundTexture, l_CockpitDisplay, NULL, "Gets the foreground text
 	return ade_set_args(L, "o", l_Texture.Set(texture_h(cd->foreground)));
 }
 
-ADE_FUNC(getSize, l_CockpitDisplay, NULL, "Gets the size of this cockpit display", "number, number", "Width and height of the display or -1, -1 on error")
+ADE_FUNC(getSize, l_CockpitDisplay, nullptr, "Gets the size of this cockpit display",
+         ade_type_info({"number", "number"}), "Width and height of the display or -1, -1 on error")
 {
 	cockpit_display_h *cdh = NULL;
 
@@ -320,7 +323,8 @@ ADE_FUNC(getSize, l_CockpitDisplay, NULL, "Gets the size of this cockpit display
 	return ade_set_args(L, "ii", cd->size[0], cd->size[1]);
 }
 
-ADE_FUNC(getOffset, l_CockpitDisplay, NULL, "Gets the offset of this cockpit display", "number, number", "x and y offset of the display or -1, -1 on error")
+ADE_FUNC(getOffset, l_CockpitDisplay, nullptr, "Gets the offset of this cockpit display",
+         ade_type_info({"number", "number"}), "x and y offset of the display or -1, -1 on error")
 {
 	cockpit_display_h *cdh = NULL;
 
@@ -389,7 +393,9 @@ ADE_FUNC(__len, l_CockpitDisplayInfos, NULL, "Number of cockpit displays for thi
 	return ade_set_args(L, "i", (int) cdih->Get()->displays.size());
 }
 
-ADE_INDEXER(l_CockpitDisplayInfos, "number/string", "Returns the handle at the requested index or the handle with the specified name", "display info", "display handle or invalid handle on error")
+ADE_INDEXER(l_CockpitDisplayInfos, "number/string",
+            "Returns the handle at the requested index or the handle with the specified name", "display_info",
+            "display handle or invalid handle on error")
 {
 	if (lua_isnumber(L, 2))
 	{

--- a/code/scripting/api/objs/control_info.cpp
+++ b/code/scripting/api/objs/control_info.cpp
@@ -135,7 +135,7 @@ namespace scripting {
 namespace api {
 
 //**********HANDLE: Control Info
-ADE_OBJ(l_Control_Info, int, "control info", "control info handle");
+ADE_OBJ(l_Control_Info, int, "control_info", "control info handle");
 
 ADE_VIRTVAR(Pitch, l_Control_Info, "number", "Pitch of the player ship", "number", "Pitch")
 {
@@ -298,7 +298,8 @@ ADE_FUNC(clearLuaButtonInfo, l_Control_Info, NULL, "Clears the lua button contro
 	return ADE_RETURN_NIL;
 }
 
-ADE_FUNC(getButtonInfo, l_Control_Info, NULL, "Access the four bitfields containing the button info", "number, number, number,number", "Four bitfields")
+ADE_FUNC(getButtonInfo, l_Control_Info, nullptr, "Access the four bitfields containing the button info",
+         ade_type_info({"number", "number", "number", "number"}), "Four bitfields")
 {
 	int i;
 	int bi_status[4];
@@ -313,7 +314,9 @@ ADE_FUNC(getButtonInfo, l_Control_Info, NULL, "Access the four bitfields contain
 	return ade_set_args(L, "iiii", bi_status[0], bi_status[1], bi_status[2], bi_status[3]);
 }
 
-ADE_FUNC(accessButtonInfo, l_Control_Info, "number, number, number, number", "Access the four bitfields containing the button info", "number, number, number,number", "Four bitfields")
+ADE_FUNC(accessButtonInfo, l_Control_Info, "number, number, number, number",
+         "Access the four bitfields containing the button info",
+         ade_type_info({"number", "number", "number", "number"}), "Four bitfields")
 {
 	int i;
 	int bi_status[4];
@@ -420,7 +423,8 @@ ADE_VIRTVAR(AllButtonPolling, l_Control_Info, "boolean", "Toggles the all button
 		return ADE_RETURN_FALSE;
 }
 
-ADE_FUNC(pollAllButtons, l_Control_Info, NULL, "Access the four bitfields containing the button info", "number, number, number,number", "Four bitfields")
+ADE_FUNC(pollAllButtons, l_Control_Info, nullptr, "Access the four bitfields containing the button info",
+         ade_type_info({"number", "number", "number", "number"}), "Four bitfields")
 {
 	int i;
 	int bi_status[4];

--- a/code/scripting/api/objs/file.cpp
+++ b/code/scripting/api/objs/file.cpp
@@ -78,15 +78,14 @@ ADE_FUNC(getPath, l_File, NULL, "Determines path of the given file", "string", "
 		return ade_set_args(L, "s", "");
 }
 
-ADE_FUNC(read, l_File, "number or string, ...",
-	"Reads part of or all of a file, depending on arguments passed. Based on basic Lua file:read function."
-	"Returns nil when the end of the file is reached."
-	"<br><ul><li>\"*n\" - Reads a number.</li>"
-	"<li>\"*a\" - Reads the rest of the file and returns it as a string.</li>"
-	"<li>\"*l\" - Reads a line. Skips the end of line markers.</li>"
-	"<li>(number) - Reads given number of characters, then returns them as a string.</li></ul>",
-	"number or string, ...",
-	"Requested data, or nil if the function fails")
+ADE_FUNC(read, l_File, "number|string, ...",
+         "Reads part of or all of a file, depending on arguments passed. Based on basic Lua file:read function."
+         "Returns nil when the end of the file is reached."
+         "<br><ul><li>\"*n\" - Reads a number.</li>"
+         "<li>\"*a\" - Reads the rest of the file and returns it as a string.</li>"
+         "<li>\"*l\" - Reads a line. Skips the end of line markers.</li>"
+         "<li>(number) - Reads given number of characters, then returns them as a string.</li></ul>",
+         ade_type_info({"number|string", "..."}), "Requested data, or nil if the function fails")
 {
 	cfile_h* cfp = nullptr;
 	if (!ade_get_args(L, "o", l_File.GetPtr(&cfp)))

--- a/code/scripting/api/objs/mc_info.cpp
+++ b/code/scripting/api/objs/mc_info.cpp
@@ -16,7 +16,7 @@ mc_info* mc_info_h::Get() { return &info; }
 bool mc_info_h::IsValid() { return valid; }
 
 //**********HANDLE: Collision info
-ADE_OBJ(l_ColInfo, mc_info_h, "collision info", "Information about a collision");
+ADE_OBJ(l_ColInfo, mc_info_h, "collision_info", "Information about a collision");
 
 ADE_VIRTVAR(Model, l_ColInfo, "model", "The model this collision info is about", "model", "The model")
 {

--- a/code/scripting/api/objs/model.cpp
+++ b/code/scripting/api/objs/model.cpp
@@ -799,7 +799,11 @@ ADE_FUNC(getNormal, l_Dockingbay, "number index", "Gets the normal of a docking 
 	return ade_set_args(L, "o", l_Vector.Set(dbp->norm[index]));
 }
 
-ADE_FUNC(computeDocker, l_Dockingbay, "dockingbay", "Computes the final position and orientation of a docker bay that docks with this bay.", "vector, orientation", "The local location and orientation of the docker vessel in the reference to the vessel of the docking bay handle, or a nil value on error")
+ADE_FUNC(computeDocker, l_Dockingbay, "dockingbay",
+         "Computes the final position and orientation of a docker bay that docks with this bay.",
+         ade_type_info({"vector", "orientation"}),
+         "The local location and orientation of the docker vessel in the reference to the vessel of the docking bay "
+         "handle, or a nil value on error")
 {
 	dockingbay_h *dockee_bay_h = NULL, *docker_bay_h = NULL;
 	vec3d final_pos;

--- a/code/scripting/api/objs/movie_player.cpp
+++ b/code/scripting/api/objs/movie_player.cpp
@@ -104,7 +104,7 @@ ADE_FUNC(isPlaybackReady, l_MoviePlayer, nullptr,
 }
 
 ADE_FUNC(drawMovie, l_MoviePlayer, "number x1, number y1[, number x2, number y2]",
-         "Draws the current frame of the movie at the specified coordinates.", "nothing", "Returns nothing")
+         "Draws the current frame of the movie at the specified coordinates.", nullptr, "Returns nothing")
 {
 	movie_player_h* ph = nullptr;
 	float x1;
@@ -137,7 +137,7 @@ ADE_FUNC(drawMovie, l_MoviePlayer, "number x1, number y1[, number x2, number y2]
 ADE_FUNC(stop, l_MoviePlayer, nullptr,
          "Explicitly stops playback. This function should be called when the player isn't needed anymore to free up "
          "some resources.",
-         "nothing", "Returns nothing")
+         nullptr, "Returns nothing")
 {
 	movie_player_h* ph = nullptr;
 	if (!ade_get_args(L, "o", l_MoviePlayer.GetPtr(&ph)))

--- a/code/scripting/api/objs/object.cpp
+++ b/code/scripting/api/objs/object.cpp
@@ -336,7 +336,11 @@ ADE_FUNC(getrvec, l_Object, "[boolean normalize]", "Returns the objects' current
 	return ade_set_args(L, "o", l_Vector.Set(v1));
 }
 
-ADE_FUNC(checkRayCollision, l_Object, "vector Start Point, vector End Point, [boolean Local]", "Checks the collisions between the polygons of the current object and a ray", "vector, collision info", "World collision point (local if boolean is set to true) and the specific collsision info, nil if no collisions")
+ADE_FUNC(
+    checkRayCollision, l_Object, "vector Start Point, vector End Point, [boolean Local]",
+    "Checks the collisions between the polygons of the current object and a ray",
+    ade_type_info({"vector", "collision_info"}),
+    "World collision point (local if boolean is set to true) and the specific collsision info, nil if no collisions")
 {
 	object_h *objh = NULL;
 	object *obj = NULL;
@@ -413,7 +417,7 @@ ADE_FUNC(addPreMoveHook, l_Object, "function(object) callback",
          "Registers a callback on this object which is called every time <i>before</i> the physics rules are applied "
          "to the object. The callback is attached to this specific object and will not be called anymore once the "
          "object is deleted. The parameter of the function is the object that is being moved.",
-         "nothing", "Returns nothing.")
+         nullptr, "Returns nothing.")
 {
 	object_h* objh = nullptr;
 	luacpp::LuaFunction callback;
@@ -437,7 +441,7 @@ ADE_FUNC(addPostMoveHook, l_Object, "function(object) callback",
          "Registers a callback on this object which is called every time <i>after</i> the physics rules are applied "
          "to the object. The callback is attached to this specific object and will not be called anymore once the "
          "object is deleted. The parameter of the function is the object that is being moved.",
-         "nothing", "Returns nothing.")
+         nullptr, "Returns nothing.")
 {
 	object_h* objh = nullptr;
 	luacpp::LuaFunction callback;

--- a/code/scripting/api/objs/option.cpp
+++ b/code/scripting/api/objs/option.cpp
@@ -193,7 +193,7 @@ ADE_FUNC(getInterpolantFromValue, l_Option, "ValueDescription value",
 ADE_FUNC(getValidValues, l_Option, nullptr,
          "Gets the valid values of this option. The order or the returned values must be maintained in the UI. This is "
          "only valid for selection or boolean options.",
-         "{ValueDescription...}", "A table containing the possible values or nil on error.")
+         ade_type_array("ValueDescription"), "A table containing the possible values or nil on error.")
 {
 	option_h* opt;
 	if (!ade_get_args(L, "o", l_Option.GetPtr(&opt))) {

--- a/code/scripting/api/objs/sound.cpp
+++ b/code/scripting/api/objs/sound.cpp
@@ -81,9 +81,11 @@ ADE_FUNC(getDuration, l_SoundEntry, NULL, "Gives the length of the sound in seco
 	return ade_set_args(L, "f", (i2fl(gamesnd_get_max_duration(seh->Get())) / 1000.0f));
 }
 
-ADE_FUNC(get3DValues, l_SoundEntry, "vector Postion[, number radius=0.0]", "Computes the volume and the panning of the sound when it would be played from the specified position.<br>"
-	"If range is given then the volume will diminish when the listener is withing that distance to the source.<br>"
-	"The position of the listener is always the the current viewing position.", "number, number", "The volume and the panning, in that sequence, or both -1 on error")
+ADE_FUNC(get3DValues, l_SoundEntry, "vector Postion[, number radius=0.0]",
+         "Computes the volume and the panning of the sound when it would be played from the specified position.<br>"
+         "If range is given then the volume will diminish when the listener is withing that distance to the source.<br>"
+         "The position of the listener is always the the current viewing position.",
+         ade_type_info({"number", "number"}), "The volume and the panning, in that sequence, or both -1 on error")
 {
 	sound_entry_h *seh = NULL;
 	vec3d *sourcePos = NULL;
@@ -328,8 +330,7 @@ ADE_FUNC(isSoundValid, l_Sound, NULL, "Checks if only the sound is valid, should
 	return ade_set_args(L, "b", sh->IsSoundValid());
 }
 
-
-ADE_OBJ_DERIV(l_Sound3D, sound_h, "3Dsound", "3D sound instance handle", l_Sound);
+ADE_OBJ_DERIV(l_Sound3D, sound_h, "sound3D", "3D sound instance handle", l_Sound);
 
 ADE_FUNC(updatePosition, l_Sound3D, "vector Position[, number radius = 0.0]", "Updates the given 3D sound with the specified position and an optional range value", "boolean", "true if succeesed, false otherwise")
 {

--- a/code/scripting/api/objs/streaminganim.cpp
+++ b/code/scripting/api/objs/streaminganim.cpp
@@ -116,7 +116,8 @@ ADE_FUNC(getFilename, l_streaminganim, NULL, "Get the filename of the animation"
 	return ade_set_args(L, "s", sah->ga.filename);
 }
 
-ADE_FUNC(getFrameCount, l_streaminganim, NULL, "Get the number of frames in the animation.", "integer", "Total number of frames")
+ADE_FUNC(getFrameCount, l_streaminganim, nullptr, "Get the number of frames in the animation.", "number",
+         "Total number of frames")
 {
 	streaminganim_h* sah;
 
@@ -129,7 +130,8 @@ ADE_FUNC(getFrameCount, l_streaminganim, NULL, "Get the number of frames in the 
 	return ade_set_args(L, "i", sah->ga.num_frames);
 }
 
-ADE_FUNC(getFrameIndex, l_streaminganim, NULL, "Get the current frame index of the animation", "integer", "Current frame index")
+ADE_FUNC(getFrameIndex, l_streaminganim, nullptr, "Get the current frame index of the animation", "number",
+         "Current frame index")
 {
 	streaminganim_h* sah;
 
@@ -147,7 +149,8 @@ ADE_FUNC(getFrameIndex, l_streaminganim, NULL, "Get the current frame index of t
 	return ade_set_args(L, "i", ++cframe); // C++ to LUA array index
 }
 
-ADE_FUNC(getHeight, l_streaminganim, NULL, "Get the height of the animation in pixels", "integer", "Height or nil if invalid")
+ADE_FUNC(getHeight, l_streaminganim, nullptr, "Get the height of the animation in pixels", "number",
+         "Height or nil if invalid")
 {
 	streaminganim_h* sah;
 
@@ -160,7 +163,8 @@ ADE_FUNC(getHeight, l_streaminganim, NULL, "Get the height of the animation in p
 	return ade_set_args(L, "i", sah->ga.height);
 }
 
-ADE_FUNC(getWidth, l_streaminganim, NULL, "Get the width of the animation in pixels", "integer", "Width or nil if invalid")
+ADE_FUNC(getWidth, l_streaminganim, nullptr, "Get the width of the animation in pixels", "number",
+         "Width or nil if invalid")
 {
 	streaminganim_h* sah;
 
@@ -240,7 +244,7 @@ ADE_FUNC(reset, l_streaminganim, "[none]", "Reset a streaming animation back to 
 	return ADE_RETURN_TRUE;
 }
 
-ADE_FUNC(timeLeft, l_streaminganim, NULL, "Get the amount of time left in the animation, in seconds", "float", "Time left in secs or nil if invalid")
+ADE_FUNC(timeLeft, l_streaminganim, nullptr, "Get the amount of time left in the animation, in seconds", "number", "Time left in secs or nil if invalid")
 {
 	streaminganim_h* sah;
 

--- a/code/scripting/api/objs/subsystem.cpp
+++ b/code/scripting/api/objs/subsystem.cpp
@@ -615,7 +615,8 @@ ADE_FUNC(getTurretHeading, l_Subsystem, NULL, "Returns the turrets forward vecto
 	return ade_set_args(L, "o", l_Vector.Set(out));
 }
 
-ADE_FUNC(getFOVs, l_Subsystem, NULL, "Returns current turrets FOVs", "number, number, number", "Standard FOV, maximum barrel elevation, turret base fov.")
+ADE_FUNC(getFOVs, l_Subsystem, nullptr, "Returns current turrets FOVs", ade_type_info({"number", "number", "number"}),
+         "Standard FOV, maximum barrel elevation, turret base fov.")
 {
 	ship_subsys_h *sso;
 	float fov, fov_e, fov_y;
@@ -634,7 +635,10 @@ ADE_FUNC(getFOVs, l_Subsystem, NULL, "Returns current turrets FOVs", "number, nu
 	return ade_set_args(L, "fff", fov, fov_e, fov_y);
 }
 
-ADE_FUNC(getNextFiringPosition, l_Subsystem, NULL, "Retrieves the next position and firing normal this turret will fire from. This function returns a world position", "vector, vector", "vector or null vector on error")
+ADE_FUNC(
+    getNextFiringPosition, l_Subsystem, nullptr,
+    "Retrieves the next position and firing normal this turret will fire from. This function returns a world position",
+    ade_type_info({"vector", "vector"}), "vector or null vector on error")
 {
 	ship_subsys_h *sso;
 	if(!ade_get_args(L, "o", l_Subsystem.GetPtr(&sso)))
@@ -650,7 +654,7 @@ ADE_FUNC(getNextFiringPosition, l_Subsystem, NULL, "Retrieves the next position 
 	return ade_set_args(L, "oo", l_Vector.Set(gpos), l_Vector.Set(gvec));
 }
 
-ADE_FUNC(getTurretMatrix, l_Subsystem, NULL, "Returns current subsystems turret matrix", "matrix", "Turret matrix.")
+ADE_FUNC(getTurretMatrix, l_Subsystem, nullptr, "Returns current subsystems turret matrix", "orientation", "Turret matrix.")
 {
 	ship_subsys_h *sso;
 	matrix m;

--- a/code/scripting/api/objs/team.cpp
+++ b/code/scripting/api/objs/team.cpp
@@ -37,7 +37,9 @@ ADE_VIRTVAR(Name, l_Team, "string", "Team name", "string", "Team name, or empty 
 	return ade_set_args(L, "s", Iff_info[tdx].iff_name);
 }
 
-ADE_FUNC(getColor, l_Team, NULL, "Gets the IFF color of the specified Team", "number, number, number", "rgb color for the specified team or nil if invalid") {
+ADE_FUNC(getColor, l_Team, nullptr, "Gets the IFF color of the specified Team",
+         ade_type_info({"number", "number", "number"}), "rgb color for the specified team or nil if invalid")
+{
 	int idx;
 	int r,g,b;
 	if(!ade_get_args(L, "o", l_Team.Get(&idx)))

--- a/code/scripting/api/objs/texture.cpp
+++ b/code/scripting/api/objs/texture.cpp
@@ -198,11 +198,11 @@ ADE_FUNC(getFramesLeft, l_Texture, NULL, "Gets number of frames left, from handl
 }
 
 ADE_FUNC(getFrame, l_Texture, "number Elapsed time (secs), [boolean Loop]",
-		 "Get the frame number from the elapsed time of the animation<br>"
-			 "The 1st argument is the time that has elapsed since the animation started<br>"
-			 "If 2nd argument is set to true, the animation is expected to loop when the elapsed time exceeds the duration of a single playback",
-		 "integer",
-		 "Frame number")
+         "Get the frame number from the elapsed time of the animation<br>"
+         "The 1st argument is the time that has elapsed since the animation started<br>"
+         "If 2nd argument is set to true, the animation is expected to loop when the elapsed time exceeds the duration "
+         "of a single playback",
+         "number", "Frame number")
 {
 	texture_h* th;
 	int frame = 0;

--- a/code/scripting/api/objs/vecmath.cpp
+++ b/code/scripting/api/objs/vecmath.cpp
@@ -516,12 +516,9 @@ ADE_FUNC(getCrossProduct,
 	return ade_set_args(L, "o", l_Vector.Set(v3r));
 }
 
-ADE_FUNC(getScreenCoords,
-		 l_Vector,
-		 NULL,
-		 "Gets screen cordinates of a world vector",
-		 "number,number",
-		 "X (number), Y (number), or false if off-screen") {
+ADE_FUNC(getScreenCoords, l_Vector, nullptr, "Gets screen cordinates of a world vector",
+         ade_type_info({"number", "number"}), "X (number), Y (number), or false if off-screen")
+{
 	vec3d v3;
 	if (!ade_get_args(L, "o", l_Vector.Get(&v3))) {
 		return ADE_RETURN_NIL;

--- a/code/scripting/api/objs/weapon.cpp
+++ b/code/scripting/api/objs/weapon.cpp
@@ -311,7 +311,8 @@ ADE_FUNC(isArmed, l_Weapon, "[boolean Hit target]", "Checks if the weapon is arm
 	return ADE_RETURN_FALSE;
 }
 
-ADE_FUNC(getCollisionInformation, l_Weapon, NULL, "Returns the collision information for this weapon", "collision info", "The collision information or invalid handle if none")
+ADE_FUNC(getCollisionInformation, l_Weapon, nullptr, "Returns the collision information for this weapon",
+         "collision_info", "The collision information or invalid handle if none")
 {
 	object_h *oh=NULL;
 	if(!ade_get_args(L, "o", l_Weapon.GetPtr(&oh)))

--- a/code/scripting/lua.cpp
+++ b/code/scripting/lua.cpp
@@ -277,10 +277,34 @@ static bool sort_doc_entries(const ade_table_entry* left, const ade_table_entry*
 	return false;
 }
 
+void script_state::OutputLuaDocumentation(ScriptingDocumentation& doc)
+{
+	SCP_vector<ade_table_entry*> table_entries;
+
+	//***Everything
+	for (uint32_t i = 0; i < ade_manager::getInstance()->getNumEntries(); i++) {
+		auto ate = &ade_manager::getInstance()->getEntry(i);
+		if (ate->ParentIdx == UINT_MAX)
+			table_entries.push_back(ate);
+	}
+
+	std::sort(std::begin(table_entries), std::end(table_entries), sort_doc_entries);
+	for (auto entry : table_entries) {
+		doc.elements.emplace_back(entry->ToDocumentationElement());
+	}
+
+	//***Enumerations
+	for (uint32_t i = 0; i < Num_enumerations; i++) {
+		DocumentationEnum e;
+		e.name  = Enumerations[i].name;
+		e.value = Enumerations[i].def;
+
+		doc.enumerations.push_back(e);
+	}
+}
+
 void script_state::OutputLuaMeta(FILE *fp)
 {
-	uint i;
-	ade_table_entry *ate;
 	fputs("<dl>\n", fp);
 
 	//***Version info
@@ -290,10 +314,9 @@ void script_state::OutputLuaMeta(FILE *fp)
 
 	//***TOC: Libraries
 	fputs("<dt><b>Libraries</b></dt>\n", fp);
-	for(i = 0; i < ade_manager::getInstance()->getNumEntries(); i++)
-	{
-		ate = &ade_manager::getInstance()->getEntry(i);
-		if(ate->ParentIdx == UINT_MAX && ate->Type == 'o' && ate->Instanced) {
+	for (uint32_t i = 0; i < ade_manager::getInstance()->getNumEntries(); i++) {
+		auto ate = &ade_manager::getInstance()->getEntry(i);
+		if (ate->ParentIdx == UINT_MAX && ate->Type == 'o' && ate->Instanced) {
 			table_entries.push_back(ate);
 		}
 	}
@@ -305,10 +328,9 @@ void script_state::OutputLuaMeta(FILE *fp)
 
 	//***TOC: Objects
 	fputs("<dt><b>Types</b></dt>\n", fp);
-	for(i = 0; i < ade_manager::getInstance()->getNumEntries(); i++)
-	{
-		ate = &ade_manager::getInstance()->getEntry(i);
-		if(ate->ParentIdx == UINT_MAX && ate->Type == 'o' && !ate->Instanced) {
+	for (uint32_t i = 0; i < ade_manager::getInstance()->getNumEntries(); i++) {
+		auto ate = &ade_manager::getInstance()->getEntry(i);
+		if (ate->ParentIdx == UINT_MAX && ate->Type == 'o' && !ate->Instanced) {
 			table_entries.push_back(ate);
 		}
 	}
@@ -326,9 +348,8 @@ void script_state::OutputLuaMeta(FILE *fp)
 
 	//***Everything
 	fputs("<dl>\n", fp);
-	for(i = 0; i < ade_manager::getInstance()->getNumEntries(); i++)
-	{
-		ate = &ade_manager::getInstance()->getEntry(i);
+	for (uint32_t i = 0; i < ade_manager::getInstance()->getNumEntries(); i++) {
+		auto ate = &ade_manager::getInstance()->getEntry(i);
 		if(ate->ParentIdx == UINT_MAX)
 			table_entries.push_back(ate);
 	}
@@ -341,8 +362,7 @@ void script_state::OutputLuaMeta(FILE *fp)
 
 	//***Enumerations
 	fprintf(fp, "<dt id=\"Enumerations\"><h2>Enumerations</h2></dt>");
-	for(i = 0; i < Num_enumerations; i++)
-	{
+	for (uint32_t i = 0; i < Num_enumerations; i++) {
 		//WMC - This is in case we ever want to add descriptions to enums.
 		//fprintf(fp, "<dd><dl><dt><b>%s</b></dt><dd>%s</dd></dl></dd>", Enumerations[i].name, Enumerations[i].desc);
 

--- a/code/scripting/scripting.cpp
+++ b/code/scripting/scripting.cpp
@@ -785,7 +785,7 @@ void script_state::RemHookVar(const char *name)
 
 void script_state::RemHookVars(unsigned int num, ...)
 {
-	if(LuaState != NULL)
+	if (LuaState != nullptr)
 	{
 		//WMC - Quick and clean. :)
 		//WMC - *sigh* nostalgia
@@ -881,7 +881,7 @@ void script_state::Clear()
 	// Free all lua value references
 	ConditionalHooks.clear();
 
-	if(LuaState != NULL) {
+	if (LuaState != nullptr) {
 		OnStateDestroy(LuaState);
 
 		lua_close(LuaState);
@@ -912,12 +912,12 @@ script_state::~script_state()
 
 void script_state::SetLuaSession(lua_State *L)
 {
-	if(LuaState != NULL)
+	if (LuaState != nullptr)
 	{
 		lua_close(LuaState);
 	}
 	LuaState = L;
-	if(LuaState != NULL) {
+	if (LuaState != nullptr) {
 		Langs |= SC_LUA;
 	}
 	else if(Langs & SC_LUA) {

--- a/code/scripting/scripting.cpp
+++ b/code/scripting/scripting.cpp
@@ -1,28 +1,32 @@
-#include <cstdio>
-#include <cstdarg>
+#include "scripting/scripting.h"
+
+#include "ade.h"
+#include "freespace.h"
 
 #include "bmpman/bmpman.h"
 #include "controlconfig/controlsconfig.h"
-#include "freespace.h"
 #include "gamesequence/gamesequence.h"
 #include "globalincs/systemvars.h"
 #include "globalincs/version.h"
 #include "hud/hud.h"
 #include "io/key.h"
+#include "libs/jansson.h"
 #include "mission/missioncampaign.h"
 #include "parse/parselo.h"
-#include "scripting/scripting.h"
 #include "scripting/ade_args.h"
 #include "ship/ship.h"
 #include "weapon/beam.h"
 #include "weapon/weapon.h"
-#include "ade.h"
+
+#include <cstdarg>
+#include <cstdio>
 
 using namespace scripting;
 
 //tehe. Declare the main event
 script_state Script_system("FS2_Open Scripting");
 bool Output_scripting_meta = false;
+bool Output_scripting_json = false;
 
 flag_def_list Script_conditions[] = 
 {
@@ -174,6 +178,140 @@ void script_parse_table(const char *filename)
 	}
 }
 
+static void json_doc_generate_class(json_t* elObj, const DocumentationElementClass* lib)
+{
+	json_object_set_new(elObj, "superClass", json_string(lib->superClass.c_str()));
+}
+static json_t* json_doc_generate_return_type(const scripting::ade_type_info& type_info)
+{
+	switch (type_info.getType()) {
+	case ade_type_info_type::Empty:
+		return json_string("void");
+	case ade_type_info_type::Simple:
+		return json_string(type_info.getSimpleName());
+	case ade_type_info_type::Tuple: {
+		json_t* tupleTypes = json_array();
+
+		for (const auto& type : type_info.elements()) {
+			json_array_append_new(tupleTypes, json_doc_generate_return_type(type));
+		}
+
+		return json_pack("{ssso}", "type", "tuple", "elements", tupleTypes);
+	}
+	case ade_type_info_type::Array: {
+		return json_pack("{ssso}",
+		                 "type",
+		                 "list",
+		                 "element",
+		                 json_doc_generate_return_type(type_info.elements().front()));
+	}
+	default:
+		UNREACHABLE("Unknown type type!");
+		return nullptr;
+	}
+
+}
+static void json_doc_generate_function(json_t* elObj, const DocumentationElementFunction* lib)
+{
+	json_object_set_new(elObj, "returnType", json_doc_generate_return_type(lib->returnType));
+	json_object_set_new(elObj, "parameters", json_string(lib->parameters.c_str()));
+	json_object_set_new(elObj, "returnDocumentation", json_string(lib->returnDocumentation.c_str()));
+}
+static void json_doc_generate_property(json_t* elObj, const DocumentationElementProperty* lib)
+{
+	json_object_set_new(elObj, "getterType", json_doc_generate_return_type(lib->getterType));
+	json_object_set_new(elObj, "setterType", json_string(lib->setterType.c_str()));
+	json_object_set_new(elObj, "returnDocumentation", json_string(lib->returnDocumentation.c_str()));
+}
+static json_t* json_doc_generate_elements(const SCP_vector<std::unique_ptr<DocumentationElement>>& elements);
+static json_t* json_doc_generate_element(const std::unique_ptr<DocumentationElement>& element)
+{
+	json_t* elementsObj = json_object();
+
+	json_object_set_new(elementsObj, "name", json_string(element->name.c_str()));
+	json_object_set_new(elementsObj, "shortName", json_string(element->shortName.c_str()));
+	json_object_set_new(elementsObj, "description", json_string(element->description.c_str()));
+
+	switch (element->type) {
+	case ElementType::Library:
+		json_object_set_new(elementsObj, "type", json_string("library"));
+		break;
+	case ElementType::Class:
+		json_object_set_new(elementsObj, "type", json_string("class"));
+		json_doc_generate_class(elementsObj, static_cast<DocumentationElementClass*>(element.get()));
+		break;
+	case ElementType::Function:
+		json_object_set_new(elementsObj, "type", json_string("function"));
+		json_doc_generate_function(elementsObj, static_cast<DocumentationElementFunction*>(element.get()));
+		break;
+	case ElementType::Operator:
+		json_object_set_new(elementsObj, "type", json_string("operator"));
+		json_doc_generate_function(elementsObj, static_cast<DocumentationElementFunction*>(element.get()));
+		break;
+	case ElementType::Property:
+		json_object_set_new(elementsObj, "type", json_string("property"));
+		json_doc_generate_property(elementsObj, static_cast<DocumentationElementProperty*>(element.get()));
+		break;
+	default:
+		json_object_set_new(elementsObj, "type", json_string("unknown"));
+		break;
+	}
+
+	json_object_set_new(elementsObj, "children", json_doc_generate_elements(element->children));
+
+	return elementsObj;
+}
+
+static json_t* json_doc_generate_elements(const SCP_vector<std::unique_ptr<DocumentationElement>>& elements)
+{
+	json_t* elementsArray = json_array();
+
+	for (const auto& el : elements) {
+		json_array_append_new(elementsArray, json_doc_generate_element(el));
+	}
+
+	return elementsArray;
+}
+
+static void documentation_to_json(const ScriptingDocumentation& doc)
+{
+	std::unique_ptr<json_t> root(json_object());
+
+	{
+		json_t* actionArray = json_array();
+
+		for (const auto& action : doc.actions) {
+			json_array_append_new(actionArray, json_string(action.c_str()));
+		}
+
+		json_object_set_new(root.get(), "actions", actionArray);
+	}
+	{
+		json_t* conditionArray = json_array();
+
+		for (const auto& cond : doc.conditions) {
+			json_array_append_new(conditionArray, json_string(cond.c_str()));
+		}
+
+		json_object_set_new(root.get(), "conditions", conditionArray);
+	}
+	{
+		json_t* enumObject = json_object();
+
+		for (const auto& enumVal : doc.enumerations) {
+			json_object_set_new(enumObject, enumVal.name.c_str(), json_integer(enumVal.value));
+		}
+
+		json_object_set_new(root.get(), "enums", enumObject);
+	}
+	json_object_set_new(root.get(), "elements", json_doc_generate_elements(doc.elements));
+
+	const auto jsonStr = json_dump_string(root.get(), JSON_INDENT(2) | JSON_SORT_KEYS);
+
+	std::ofstream outStr("scripting.json");
+	outStr << jsonStr;
+}
+
 //Initializes the (global) scripting system, as well as any subsystems.
 //script_close is handled by destructors
 void script_init()
@@ -183,10 +321,17 @@ void script_init()
 	mprintf(("SCRIPTING: Beginning Lua initialization...\n"));
 	Script_system.CreateLuaState();
 
-	if(Output_scripting_meta)
-	{
-		mprintf(("SCRIPTING: Outputting scripting metadata...\n"));
-		Script_system.OutputMeta("scripting.html");
+	if (Output_scripting_meta || Output_scripting_json) {
+		const auto doc = Script_system.OutputDocumentation();
+
+		if (Output_scripting_meta) {
+			mprintf(("SCRIPTING: Outputting scripting metadata...\n"));
+			Script_system.OutputMeta("scripting.html");
+		}
+		if (Output_scripting_json) {
+			mprintf(("SCRIPTING: Outputting scripting metadata in JSON format...\n"));
+			documentation_to_json(doc);
+		}
 	}
 	mprintf(("SCRIPTING: Beginning main hook parse sequence....\n"));
 	script_parse_table("scripting.tbl");
@@ -778,6 +923,29 @@ void script_state::SetLuaSession(lua_State *L)
 	else if(Langs & SC_LUA) {
 		Langs &= ~SC_LUA;
 	}
+}
+
+ScriptingDocumentation script_state::OutputDocumentation()
+{
+	ScriptingDocumentation doc;
+
+	// Conditions
+	doc.conditions.reserve(static_cast<size_t>(Num_script_conditions));
+	for (int32_t i = 0; i < Num_script_conditions; i++) {
+		doc.conditions.emplace_back(Script_conditions[i].name);
+	}
+
+	// Actions
+	doc.actions.reserve(static_cast<size_t>(Num_script_actions));
+	for (int32_t i = 0; i < Num_script_actions; i++) {
+		doc.actions.emplace_back(Script_actions[i].name);
+	}
+
+	if (Langs & SC_LUA) {
+		OutputLuaDocumentation(doc);
+	}
+
+	return doc;
 }
 
 int script_state::OutputMeta(const char *filename)

--- a/code/scripting/scripting.h
+++ b/code/scripting/scripting.h
@@ -155,6 +155,58 @@ public:
 	bool Run(class script_state* sys, int action);
 };
 
+enum class ElementType {
+	Unknown,
+	Library,
+	Class,
+	Function,
+	Operator,
+	Property,
+};
+
+struct DocumentationElement {
+	ElementType type = ElementType::Unknown;
+
+	SCP_string name;
+	SCP_string shortName;
+
+	SCP_string description;
+
+	SCP_vector<std::unique_ptr<DocumentationElement>> children;
+};
+
+struct DocumentationElementClass : public DocumentationElement {
+	SCP_string superClass;
+};
+
+struct DocumentationElementProperty : public DocumentationElement {
+	scripting::ade_type_info getterType;
+	SCP_string setterType;
+
+	SCP_string returnDocumentation;
+};
+
+struct DocumentationElementFunction : public DocumentationElement {
+	scripting::ade_type_info returnType;
+	SCP_string parameters;
+
+	SCP_string returnDocumentation;
+};
+
+struct DocumentationEnum {
+	SCP_string name;
+	int value;
+};
+
+struct ScriptingDocumentation {
+	SCP_vector<SCP_string> conditions;
+	SCP_vector<SCP_string> actions;
+
+	SCP_vector<std::unique_ptr<DocumentationElement>> elements;
+
+	SCP_vector<DocumentationEnum> enumerations;
+};
+
 //**********Main script_state function
 class script_state
 {
@@ -176,7 +228,8 @@ private:
 	void SetLuaSession(struct lua_State *L);
 
 	void OutputLuaMeta(FILE *fp);
-	
+	void OutputLuaDocumentation(ScriptingDocumentation& doc);
+
 	//Lua private helper functions
 	bool OpenHookVarTable();
 	bool CloseHookVarTable();
@@ -208,6 +261,7 @@ public:
 	int CreateLuaState();
 
 	//***Get data
+	ScriptingDocumentation OutputDocumentation();
 	int OutputMeta(const char *filename);
 
 	//***Moves data
@@ -382,6 +436,7 @@ void script_init();
 //**********Script globals
 extern class script_state Script_system;
 extern bool Output_scripting_meta;
+extern bool Output_scripting_json;
 
 //*************************Conditional scripting*************************
 

--- a/qtfred/src/ui/widgets/sexp_tree.cpp
+++ b/qtfred/src/ui/widgets/sexp_tree.cpp
@@ -188,6 +188,7 @@ int SexpTreeEditorInterface::getRootReturnType() const {
 bool SexpTreeEditorInterface::requireCampaignOperators() const {
 	return false;
 }
+SexpTreeEditorInterface::~SexpTreeEditorInterface() = default;
 
 QIcon sexp_tree::convertNodeImageToIcon(NodeImage image) {
 	return QIcon(node_image_to_resource_name(image));
@@ -210,6 +211,8 @@ sexp_tree::sexp_tree(QWidget* parent) : QTreeWidget(parent) {
 	connect(this, &QTreeWidget::itemChanged, this, &sexp_tree::handleItemChange);
 	connect(this, &QTreeWidget::itemSelectionChanged, this, &sexp_tree::handleNewItemSelected);
 }
+
+sexp_tree::~sexp_tree() = default;
 
 // clears out the tree, so all the nodes are unused.
 void sexp_tree::clear_tree(const char* op) {
@@ -1679,7 +1682,7 @@ int sexp_tree::add_operator(const char* op, QTreeWidgetItem* h) {
 {
 	char str[80];
 	int node1, node2;
-	
+
 	expand_operator(item_index);
 	node1 = allocate_node(item_index);
 	node2 = allocate_node(node1);
@@ -1835,7 +1838,7 @@ int sexp_tree::verify_tree(int node, int *bypass)
 			case OPF_FLEXIBLE_ARGUMENT:
 				if (type2 != OPR_FLEXIBLE_ARGUMENT)
 					return node_error(node, "Flexible argument return type expected here", bypass);
-				
+
 				break;
 
 			case OPF_ANYTHING:
@@ -2009,7 +2012,7 @@ void sexp_tree::verify_and_fix_arguments(int node) {
 				char* text_ptr;
 				char default_variable_text[TOKEN_LENGTH];
 				if (tree_nodes[item_index].type & SEXPT_VARIABLE) {
-					// special case for SEXPs which can modify a variable 
+					// special case for SEXPs which can modify a variable
 					if (type == OPF_VARIABLE_NAME) {
 						// make text_ptr to start - before '('
 						get_variable_name_from_sexp_tree_node_text(tree_nodes[item_index].text, default_variable_text);
@@ -2062,7 +2065,7 @@ void sexp_tree::verify_and_fix_arguments(int node) {
 					ptr = ptr->next;
 				}
 
-				if (!ptr) {  // argument isn't in list of valid choices, 
+				if (!ptr) {  // argument isn't in list of valid choices,
 					if (list->op >= 0) {
 						replace_operator(list->text.c_str());
 					} else {
@@ -2094,7 +2097,7 @@ void sexp_tree::verify_and_fix_arguments(int node) {
 		}
 
 		//fix the node if it is the argument for modify-variable
-		if (is_variable_arg //&& 
+		if (is_variable_arg //&&
 			//	!(tree_nodes[item_index].type & SEXPT_OPERATOR || tree_nodes[item_index].type & SEXPT_VARIABLE )
 			) {
 			switch (type) {
@@ -2218,7 +2221,7 @@ void sexp_tree::replace_operator(const char* op) {
 	h = tree_nodes[item_index].handle;
 	while (ItemHasChildren(h))
 		DeleteItem(GetChildItem(h));
-	
+
 	node = allocate_node(item_index);
 	set_node(item_index, SEXPT_OPERATOR, op);
 	set_node(node, type, data);
@@ -2406,7 +2409,7 @@ const char* sexp_tree::help(int code) {
 int sexp_tree::get_type(QTreeWidgetItem* h) {
 	uint i;
 
-	// get index into sexp_tree 
+	// get index into sexp_tree
 	for (i = 0; i < tree_nodes.size(); i++) {
 		if (tree_nodes[i].handle == h) {
 			break;

--- a/qtfred/src/ui/widgets/sexp_tree.h
+++ b/qtfred/src/ui/widgets/sexp_tree.h
@@ -100,6 +100,7 @@ class SexpTreeEditorInterface {
  public:
 	SexpTreeEditorInterface();
 	explicit SexpTreeEditorInterface(const flagset<TreeFlags>& flags);
+	virtual ~SexpTreeEditorInterface();
 
 	virtual bool hasDefaultMessageParamter();
 	virtual SCP_vector<SCP_string> getMessages();
@@ -171,6 +172,7 @@ class sexp_tree: public QTreeWidget {
  	static QIcon convertNodeImageToIcon(NodeImage image);
 
 	explicit sexp_tree(QWidget* parent = nullptr);
+	~sexp_tree() override;
 
 	int find_text(const char* text, int* find, int max_depth);
 	int query_restricted_opf_range(int opf);


### PR DESCRIPTION
This adds JSON as an additional scripting documentation output format.
This can be used by external tools to examine the scripting
documentation and generate interface declarations or documentation for
any language. The existing documentation code is left largely in place.

The initial purpose of this is to allow using TypeScript with FSO by using
the [TypeScript to Lua](https://typescripttolua.github.io/) compiler.