### PR TITLE
Adds Table Option to Modify Arc Colors

### DIFF
--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -48,6 +48,24 @@ SCP_string Window_icon_path;
 bool Disable_built_in_translations;
 bool Weapon_shockwaves_respect_huge;
 bool Using_in_game_options;
+ubyte Arc_color_damage_p1_r = 64;
+ubyte Arc_color_damage_p1_g = 64;
+ubyte Arc_color_damage_p1_b = 225;
+ubyte Arc_color_damage_p2_r = 128;
+ubyte Arc_color_damage_p2_g = 128;
+ubyte Arc_color_damage_p2_b = 255;
+ubyte Arc_color_damage_s1_r = 200;
+ubyte Arc_color_damage_s1_g = 200;
+ubyte Arc_color_damage_s1_b = 255;
+ubyte Arc_color_emp_p1_r    = 64;
+ubyte Arc_color_emp_p1_g    = 64;
+ubyte Arc_color_emp_p1_b    = 5;
+ubyte Arc_color_emp_p2_r    = 128;
+ubyte Arc_color_emp_p2_g    = 128;
+ubyte Arc_color_emp_p2_b    = 10;
+ubyte Arc_color_emp_s1_r    = 255;
+ubyte Arc_color_emp_s1_g    = 255;
+ubyte Arc_color_emp_s1_b    = 10;
 
 void parse_mod_table(const char *filename)
 {
@@ -265,6 +283,42 @@ void parse_mod_table(const char *filename)
 			stuff_int(&tmp);
 
 			mprintf(("Game Settings Table: $BMPMAN Slot Limit is deprecated and should be removed. It is not needed anymore.\n"));
+		}
+
+		if (optional_string("$EMP Arc Color:")) {
+			if (optional_string("+Primary Color Option 1:")) {
+				stuff_ubyte(&Arc_color_damage_p1_r);
+				stuff_ubyte(&Arc_color_damage_p1_g);
+				stuff_ubyte(&Arc_color_damage_p1_b);
+			}
+			if (optional_string("+Primary Color Option 2:")) {
+				stuff_ubyte(&Arc_color_damage_p2_r);
+				stuff_ubyte(&Arc_color_damage_p2_g);
+				stuff_ubyte(&Arc_color_damage_p2_b);
+			}
+			if (optional_string("+Secondary Color Option 1:")) {
+				stuff_ubyte(&Arc_color_damage_s1_r);
+				stuff_ubyte(&Arc_color_damage_s1_g);
+				stuff_ubyte(&Arc_color_damage_s1_b);
+			}
+		}
+
+		if (optional_string("$Damage Arc Color:")) {
+			if (optional_string("+Primary Color Option 1:")) {
+				stuff_ubyte(&Arc_color_emp_p1_r);
+				stuff_ubyte(&Arc_color_emp_p1_g);
+				stuff_ubyte(&Arc_color_emp_p1_b);
+			}
+			if (optional_string("+Primary Color Option 2:")) {
+				stuff_ubyte(&Arc_color_emp_p2_r);
+				stuff_ubyte(&Arc_color_emp_p2_g);
+				stuff_ubyte(&Arc_color_emp_p2_b);
+			}
+			if (optional_string("+Secondary Color Option 1:")) {
+				stuff_ubyte(&Arc_color_emp_s1_r);
+				stuff_ubyte(&Arc_color_emp_s1_g);
+				stuff_ubyte(&Arc_color_emp_s1_b);
+			}
 		}
 
 		optional_string("#NETWORK SETTINGS");

--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -275,36 +275,30 @@ void parse_mod_table(const char *filename)
 
 		if (optional_string("$EMP Arc Color:")) {
 			if (optional_string("+Primary Color Option 1:")) {
-				ubyte r, g, b;
-				stuff_ubyte(&r);
-				stuff_ubyte(&g);
-				stuff_ubyte(&b);
-				if ( (r >= 0 && r <= 255) && (g >= 0 && g <= 255) && (b >= 0 && b <= 255) ) { 
-					Arc_color_emp_p1 = std::make_tuple(r, g, b);
+				int rgb[3];
+				stuff_int_list(rgb, 3);
+				if ((rgb[0] >= 0 && rgb[0] <= 255) && (rgb[1] >= 0 && rgb[1] <= 255) && (rgb[2] >= 0 && rgb[2] <= 255)) {
+					Arc_color_emp_p1 = std::make_tuple(static_cast<ubyte>(rgb[0]), static_cast<ubyte>(rgb[1]), static_cast<ubyte>(rgb[2]));
 				} else {
 					error_display(0, "$EMP Arc Color: +Primary Color Option 1 is %f, %f, %f. "
 						"One or more of these values is not within the range of 0-255. Assuming default color.", r, g, b);
 				}
 			}
 			if (optional_string("+Primary Color Option 2:")) {
-				ubyte r, g, b;
-				stuff_ubyte(&r);
-				stuff_ubyte(&g);
-				stuff_ubyte(&b);
-				if ((r >= 0 && r <= 255) && (g >= 0 && g <= 255) && (b >= 0 && b <= 255)) {
-					Arc_color_emp_p2 = std::make_tuple(r, g, b);
+				int rgb[3];
+				stuff_int_list(rgb, 3);
+				if ((rgb[0] >= 0 && rgb[0] <= 255) && (rgb[1] >= 0 && rgb[1] <= 255) && (rgb[2] >= 0 && rgb[2] <= 255)) {
+					Arc_color_emp_p2 = std::make_tuple(static_cast<ubyte>(rgb[0]), static_cast<ubyte>(rgb[1]), static_cast<ubyte>(rgb[2]));
 				} else {
 					error_display(0, "$EMP Arc Color: +Primary Color Option 2 is %f, %f, %f. "
 					    "One or more of these values is not within the range of 0-255. Assuming default color.", r, g, b);
 				}
 			}
 			if (optional_string("+Secondary Color Option 1:")) {
-				ubyte r, g, b;
-				stuff_ubyte(&r);
-				stuff_ubyte(&g);
-				stuff_ubyte(&b);
-			    if ((r >= 0 && r <= 255) && (g >= 0 && g <= 255) && (b >= 0 && b <= 255)) {
-				    Arc_color_emp_s1 = std::make_tuple(r, g, b);
+				int rgb[3];
+				stuff_int_list(rgb, 3);
+				if ((rgb[0] >= 0 && rgb[0] <= 255) && (rgb[1] >= 0 && rgb[1] <= 255) && (rgb[2] >= 0 && rgb[2] <= 255)) {
+					Arc_color_emp_s1 = std::make_tuple(static_cast<ubyte>(rgb[0]), static_cast<ubyte>(rgb[1]), static_cast<ubyte>(rgb[2]));
 			    } else {
 				    error_display(0,"$EMP Arc Color: +Secondary Color Option 1 is %f, %f, %f. "
 				        "One or more of these values is not within the range of 0-255. Assuming default color.", r, g, b);
@@ -314,36 +308,30 @@ void parse_mod_table(const char *filename)
 
 		if (optional_string("$Damage Arc Color:")) {
 			if (optional_string("+Primary Color Option 1:")) {
-				ubyte r, g, b;
-				stuff_ubyte(&r);
-				stuff_ubyte(&g);
-				stuff_ubyte(&b);
-		        if ((r >= 0 && r <= 255) && (g >= 0 && g <= 255) && (b >= 0 && b <= 255)) {
-			        Arc_color_damage_p1 = std::make_tuple(r, g, b);
+				int rgb[3];
+				stuff_int_list(rgb, 3);
+				if ((rgb[0] >= 0 && rgb[0] <= 255) && (rgb[1] >= 0 && rgb[1] <= 255) && (rgb[2] >= 0 && rgb[2] <= 255)) {
+					Arc_color_damage_p1 = std::make_tuple(static_cast<ubyte>(rgb[0]), static_cast<ubyte>(rgb[1]), static_cast<ubyte>(rgb[2]));
 		        } else {
 			        error_display(0, "Damage Arc Color: +Primary Color Option 1 is %f, %f, %f. "
 			            "One or more of these values is not within the range of 0-255. Assuming default color.", r, g, b);
 		        }
 	        }
 			if (optional_string("+Primary Color Option 2:")) {
-				ubyte r, g, b;
-				stuff_ubyte(&r);
-				stuff_ubyte(&g);
-				stuff_ubyte(&b);
-	            if ((r >= 0 && r <= 255) && (g >= 0 && g <= 255) && (b >= 0 && b <= 255)) {
-		            Arc_color_damage_p1 = std::make_tuple(r, g, b);
+				int rgb[3];
+				stuff_int_list(rgb, 3);
+				if ((rgb[0] >= 0 && rgb[0] <= 255) && (rgb[1] >= 0 && rgb[1] <= 255) && (rgb[2] >= 0 && rgb[2] <= 255)) {
+					Arc_color_damage_p2 = std::make_tuple(static_cast<ubyte>(rgb[0]), static_cast<ubyte>(rgb[1]), static_cast<ubyte>(rgb[2]));
 	            } else {
 		            error_display(0, "$Damage Arc Color: +Primary Color Option 2 is %f, %f, %f. "
 		                "One or more of these values is not within the range of 0-255. Assuming default color.", r, g, b);
 	            }
 			}
 			if (optional_string("+Secondary Color Option 1:")) {
-				ubyte r, g, b;
-				stuff_ubyte(&r);
-				stuff_ubyte(&g);
-				stuff_ubyte(&b);
-	            if ((r >= 0 && r <= 255) && (g >= 0 && g <= 255) && (b >= 0 && b <= 255)) {
-		            Arc_color_damage_s1 = std::make_tuple(r, g, b);
+				int rgb[3];
+				stuff_int_list(rgb, 3);
+				if ((rgb[0] >= 0 && rgb[0] <= 255) && (rgb[1] >= 0 && rgb[1] <= 255) && (rgb[2] >= 0 && rgb[2] <= 255)) {
+					Arc_color_damage_s1 = std::make_tuple(static_cast<ubyte>(rgb[0]), static_cast<ubyte>(rgb[1]), static_cast<ubyte>(rgb[2]));
 	            } else {
 		            error_display(0, "$Damage Arc Color: +Secondary Color Option 1 is %f, %f, %f. "
 		                "One or more of these values is not within the range of 0-255. Assuming default color.", r, g, b);

--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -48,24 +48,12 @@ SCP_string Window_icon_path;
 bool Disable_built_in_translations;
 bool Weapon_shockwaves_respect_huge;
 bool Using_in_game_options;
-ubyte Arc_color_damage_p1_r = 64;
-ubyte Arc_color_damage_p1_g = 64;
-ubyte Arc_color_damage_p1_b = 225;
-ubyte Arc_color_damage_p2_r = 128;
-ubyte Arc_color_damage_p2_g = 128;
-ubyte Arc_color_damage_p2_b = 255;
-ubyte Arc_color_damage_s1_r = 200;
-ubyte Arc_color_damage_s1_g = 200;
-ubyte Arc_color_damage_s1_b = 255;
-ubyte Arc_color_emp_p1_r    = 64;
-ubyte Arc_color_emp_p1_g    = 64;
-ubyte Arc_color_emp_p1_b    = 5;
-ubyte Arc_color_emp_p2_r    = 128;
-ubyte Arc_color_emp_p2_g    = 128;
-ubyte Arc_color_emp_p2_b    = 10;
-ubyte Arc_color_emp_s1_r    = 255;
-ubyte Arc_color_emp_s1_g    = 255;
-ubyte Arc_color_emp_s1_b    = 10;
+std::tuple<ubyte, ubyte, ubyte> Arc_color_damage_p1;
+std::tuple<ubyte, ubyte, ubyte> Arc_color_damage_p2;
+std::tuple<ubyte, ubyte, ubyte> Arc_color_damage_s1;
+std::tuple<ubyte, ubyte, ubyte> Arc_color_emp_p1;
+std::tuple<ubyte, ubyte, ubyte> Arc_color_emp_p2;
+std::tuple<ubyte, ubyte, ubyte> Arc_color_emp_s1;
 
 void parse_mod_table(const char *filename)
 {
@@ -287,37 +275,79 @@ void parse_mod_table(const char *filename)
 
 		if (optional_string("$EMP Arc Color:")) {
 			if (optional_string("+Primary Color Option 1:")) {
-				stuff_ubyte(&Arc_color_damage_p1_r);
-				stuff_ubyte(&Arc_color_damage_p1_g);
-				stuff_ubyte(&Arc_color_damage_p1_b);
+				ubyte r, g, b;
+				stuff_ubyte(&r);
+				stuff_ubyte(&g);
+				stuff_ubyte(&b);
+				if ( (r >= 0 && r <= 255) && (g >= 0 && g <= 255) && (b >= 0 && b <= 255) ) { 
+					Arc_color_emp_p1 = std::make_tuple(r, g, b);
+				} else {
+					error_display(0, "$EMP Arc Color: +Primary Color Option 1 is %f, %f, %f. "
+						"One or more of these values is not within the range of 0-255. Assuming default color.", r, g, b);
+				}
 			}
 			if (optional_string("+Primary Color Option 2:")) {
-				stuff_ubyte(&Arc_color_damage_p2_r);
-				stuff_ubyte(&Arc_color_damage_p2_g);
-				stuff_ubyte(&Arc_color_damage_p2_b);
+				ubyte r, g, b;
+				stuff_ubyte(&r);
+				stuff_ubyte(&g);
+				stuff_ubyte(&b);
+				if ((r >= 0 && r <= 255) && (g >= 0 && g <= 255) && (b >= 0 && b <= 255)) {
+					Arc_color_emp_p2 = std::make_tuple(r, g, b);
+				} else {
+					error_display(0, "$EMP Arc Color: +Primary Color Option 2 is %f, %f, %f. "
+					    "One or more of these values is not within the range of 0-255. Assuming default color.", r, g, b);
+				}
 			}
 			if (optional_string("+Secondary Color Option 1:")) {
-				stuff_ubyte(&Arc_color_damage_s1_r);
-				stuff_ubyte(&Arc_color_damage_s1_g);
-				stuff_ubyte(&Arc_color_damage_s1_b);
-			}
+				ubyte r, g, b;
+				stuff_ubyte(&r);
+				stuff_ubyte(&g);
+				stuff_ubyte(&b);
+			    if ((r >= 0 && r <= 255) && (g >= 0 && g <= 255) && (b >= 0 && b <= 255)) {
+				    Arc_color_emp_s1 = std::make_tuple(r, g, b);
+			    } else {
+				    error_display(0,"$EMP Arc Color: +Secondary Color Option 1 is %f, %f, %f. "
+				        "One or more of these values is not within the range of 0-255. Assuming default color.", r, g, b);
+			    }
+		    }
 		}
 
 		if (optional_string("$Damage Arc Color:")) {
 			if (optional_string("+Primary Color Option 1:")) {
-				stuff_ubyte(&Arc_color_emp_p1_r);
-				stuff_ubyte(&Arc_color_emp_p1_g);
-				stuff_ubyte(&Arc_color_emp_p1_b);
-			}
+				ubyte r, g, b;
+				stuff_ubyte(&r);
+				stuff_ubyte(&g);
+				stuff_ubyte(&b);
+		        if ((r >= 0 && r <= 255) && (g >= 0 && g <= 255) && (b >= 0 && b <= 255)) {
+			        Arc_color_damage_p1 = std::make_tuple(r, g, b);
+		        } else {
+			        error_display(0, "Damage Arc Color: +Primary Color Option 1 is %f, %f, %f. "
+			            "One or more of these values is not within the range of 0-255. Assuming default color.", r, g, b);
+		        }
+	        }
 			if (optional_string("+Primary Color Option 2:")) {
-				stuff_ubyte(&Arc_color_emp_p2_r);
-				stuff_ubyte(&Arc_color_emp_p2_g);
-				stuff_ubyte(&Arc_color_emp_p2_b);
+				ubyte r, g, b;
+				stuff_ubyte(&r);
+				stuff_ubyte(&g);
+				stuff_ubyte(&b);
+	            if ((r >= 0 && r <= 255) && (g >= 0 && g <= 255) && (b >= 0 && b <= 255)) {
+		            Arc_color_damage_p1 = std::make_tuple(r, g, b);
+	            } else {
+		            error_display(0, "$Damage Arc Color: +Primary Color Option 2 is %f, %f, %f. "
+		                "One or more of these values is not within the range of 0-255. Assuming default color.", r, g, b);
+	            }
 			}
 			if (optional_string("+Secondary Color Option 1:")) {
-				stuff_ubyte(&Arc_color_emp_s1_r);
-				stuff_ubyte(&Arc_color_emp_s1_g);
-				stuff_ubyte(&Arc_color_emp_s1_b);
+				ubyte r, g, b;
+				stuff_ubyte(&r);
+				stuff_ubyte(&g);
+				stuff_ubyte(&b);
+	            if ((r >= 0 && r <= 255) && (g >= 0 && g <= 255) && (b >= 0 && b <= 255)) {
+		            Arc_color_damage_s1 = std::make_tuple(r, g, b);
+	            } else {
+		            error_display(0, "$Damage Arc Color: +Secondary Color Option 1 is %f, %f, %f. "
+		                "One or more of these values is not within the range of 0-255. Assuming default color.", r, g, b);
+	            }
 			}
 		}
 
@@ -539,4 +569,10 @@ void mod_table_reset() {
 	Disable_built_in_translations = false;
 	Weapon_shockwaves_respect_huge = false;
 	Using_in_game_options = false;
+	Arc_color_damage_p1 = std::make_tuple(64, 64, 225);
+	Arc_color_damage_p2 = std::make_tuple(128, 128, 255);
+	Arc_color_damage_s1 = std::make_tuple(200, 200, 255);
+	Arc_color_emp_p1 = std::make_tuple(64, 64, 5);
+	Arc_color_emp_p2 = std::make_tuple(128, 128, 10);
+	Arc_color_emp_s1 = std::make_tuple(255, 255, 10);
 }

--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -280,8 +280,8 @@ void parse_mod_table(const char *filename)
 				if ((rgb[0] >= 0 && rgb[0] <= 255) && (rgb[1] >= 0 && rgb[1] <= 255) && (rgb[2] >= 0 && rgb[2] <= 255)) {
 					Arc_color_emp_p1 = std::make_tuple(static_cast<ubyte>(rgb[0]), static_cast<ubyte>(rgb[1]), static_cast<ubyte>(rgb[2]));
 				} else {
-					error_display(0, "$EMP Arc Color: +Primary Color Option 1 is %f, %f, %f. "
-						"One or more of these values is not within the range of 0-255. Assuming default color.", r, g, b);
+					error_display(0, "$EMP Arc Color: +Primary Color Option 1 is %i, %i, %i. "
+						"One or more of these values is not within the range of 0-255. Assuming default color.", rgb[0], rgb[1], rgb[2]);
 				}
 			}
 			if (optional_string("+Primary Color Option 2:")) {
@@ -290,8 +290,8 @@ void parse_mod_table(const char *filename)
 				if ((rgb[0] >= 0 && rgb[0] <= 255) && (rgb[1] >= 0 && rgb[1] <= 255) && (rgb[2] >= 0 && rgb[2] <= 255)) {
 					Arc_color_emp_p2 = std::make_tuple(static_cast<ubyte>(rgb[0]), static_cast<ubyte>(rgb[1]), static_cast<ubyte>(rgb[2]));
 				} else {
-					error_display(0, "$EMP Arc Color: +Primary Color Option 2 is %f, %f, %f. "
-					    "One or more of these values is not within the range of 0-255. Assuming default color.", r, g, b);
+					error_display(0, "$EMP Arc Color: +Primary Color Option 2 is %i, %i, %i. "
+					    "One or more of these values is not within the range of 0-255. Assuming default color.", rgb[0], rgb[1], rgb[2]);
 				}
 			}
 			if (optional_string("+Secondary Color Option 1:")) {
@@ -300,8 +300,8 @@ void parse_mod_table(const char *filename)
 				if ((rgb[0] >= 0 && rgb[0] <= 255) && (rgb[1] >= 0 && rgb[1] <= 255) && (rgb[2] >= 0 && rgb[2] <= 255)) {
 					Arc_color_emp_s1 = std::make_tuple(static_cast<ubyte>(rgb[0]), static_cast<ubyte>(rgb[1]), static_cast<ubyte>(rgb[2]));
 			    } else {
-				    error_display(0,"$EMP Arc Color: +Secondary Color Option 1 is %f, %f, %f. "
-				        "One or more of these values is not within the range of 0-255. Assuming default color.", r, g, b);
+				    error_display(0,"$EMP Arc Color: +Secondary Color Option 1 is %i, %i, %i. "
+					    "One or more of these values is not within the range of 0-255. Assuming default color.", rgb[0], rgb[1], rgb[2]);
 			    }
 		    }
 		}
@@ -313,8 +313,8 @@ void parse_mod_table(const char *filename)
 				if ((rgb[0] >= 0 && rgb[0] <= 255) && (rgb[1] >= 0 && rgb[1] <= 255) && (rgb[2] >= 0 && rgb[2] <= 255)) {
 					Arc_color_damage_p1 = std::make_tuple(static_cast<ubyte>(rgb[0]), static_cast<ubyte>(rgb[1]), static_cast<ubyte>(rgb[2]));
 		        } else {
-			        error_display(0, "Damage Arc Color: +Primary Color Option 1 is %f, %f, %f. "
-			            "One or more of these values is not within the range of 0-255. Assuming default color.", r, g, b);
+			        error_display(0, "Damage Arc Color: +Primary Color Option 1 is %i, %i, %i. "
+					    "One or more of these values is not within the range of 0-255. Assuming default color.", rgb[0], rgb[1], rgb[2]);
 		        }
 	        }
 			if (optional_string("+Primary Color Option 2:")) {
@@ -323,8 +323,8 @@ void parse_mod_table(const char *filename)
 				if ((rgb[0] >= 0 && rgb[0] <= 255) && (rgb[1] >= 0 && rgb[1] <= 255) && (rgb[2] >= 0 && rgb[2] <= 255)) {
 					Arc_color_damage_p2 = std::make_tuple(static_cast<ubyte>(rgb[0]), static_cast<ubyte>(rgb[1]), static_cast<ubyte>(rgb[2]));
 	            } else {
-		            error_display(0, "$Damage Arc Color: +Primary Color Option 2 is %f, %f, %f. "
-		                "One or more of these values is not within the range of 0-255. Assuming default color.", r, g, b);
+		            error_display(0, "$Damage Arc Color: +Primary Color Option 2 is %i, %i, %i. "
+					    "One or more of these values is not within the range of 0-255. Assuming default color.", rgb[0], rgb[1], rgb[2]);
 	            }
 			}
 			if (optional_string("+Secondary Color Option 1:")) {
@@ -333,8 +333,8 @@ void parse_mod_table(const char *filename)
 				if ((rgb[0] >= 0 && rgb[0] <= 255) && (rgb[1] >= 0 && rgb[1] <= 255) && (rgb[2] >= 0 && rgb[2] <= 255)) {
 					Arc_color_damage_s1 = std::make_tuple(static_cast<ubyte>(rgb[0]), static_cast<ubyte>(rgb[1]), static_cast<ubyte>(rgb[2]));
 	            } else {
-		            error_display(0, "$Damage Arc Color: +Secondary Color Option 1 is %f, %f, %f. "
-		                "One or more of these values is not within the range of 0-255. Assuming default color.", r, g, b);
+		            error_display(0, "$Damage Arc Color: +Secondary Color Option 1 is %i, %i, %i. "
+					    "One or more of these values is not within the range of 0-255. Assuming default color.", rgb[0], rgb[1], rgb[2]);
 	            }
 			}
 		}

--- a/code/mod_table/mod_table.h
+++ b/code/mod_table/mod_table.h
@@ -39,12 +39,12 @@ extern SCP_string Window_icon_path;
 extern bool Disable_built_in_translations;
 extern bool Weapon_shockwaves_respect_huge;
 extern bool Using_in_game_options;
-extern ubyte Arc_color_damage_p1_r, Arc_color_damage_p1_g, Arc_color_damage_p1_b;
-extern ubyte Arc_color_damage_p2_r, Arc_color_damage_p2_g, Arc_color_damage_p2_b;
-extern ubyte Arc_color_damage_s1_r, Arc_color_damage_s1_g, Arc_color_damage_s1_b;
-extern ubyte Arc_color_emp_p1_r, Arc_color_emp_p1_g, Arc_color_emp_p1_b;
-extern ubyte Arc_color_emp_p2_r, Arc_color_emp_p2_g, Arc_color_emp_p2_b;
-extern ubyte Arc_color_emp_s1_r, Arc_color_emp_s1_g, Arc_color_emp_s1_b;
+extern std::tuple<ubyte, ubyte, ubyte> Arc_color_damage_p1;
+extern std::tuple<ubyte, ubyte, ubyte> Arc_color_damage_p2;
+extern std::tuple<ubyte, ubyte, ubyte> Arc_color_damage_s1;
+extern std::tuple<ubyte, ubyte, ubyte> Arc_color_emp_p1;
+extern std::tuple<ubyte, ubyte, ubyte> Arc_color_emp_p2;
+extern std::tuple<ubyte, ubyte, ubyte> Arc_color_emp_s1;
 
 void mod_table_init();
 

--- a/code/mod_table/mod_table.h
+++ b/code/mod_table/mod_table.h
@@ -39,6 +39,12 @@ extern SCP_string Window_icon_path;
 extern bool Disable_built_in_translations;
 extern bool Weapon_shockwaves_respect_huge;
 extern bool Using_in_game_options;
+extern ubyte Arc_color_damage_p1_r, Arc_color_damage_p1_g, Arc_color_damage_p1_b;
+extern ubyte Arc_color_damage_p2_r, Arc_color_damage_p2_g, Arc_color_damage_p2_b;
+extern ubyte Arc_color_damage_s1_r, Arc_color_damage_s1_g, Arc_color_damage_s1_b;
+extern ubyte Arc_color_emp_p1_r, Arc_color_emp_p1_g, Arc_color_emp_p1_b;
+extern ubyte Arc_color_emp_p2_r, Arc_color_emp_p2_g, Arc_color_emp_p2_b;
+extern ubyte Arc_color_emp_s1_r, Arc_color_emp_s1_g, Arc_color_emp_s1_b;
 
 void mod_table_init();
 

--- a/code/model/modelrender.cpp
+++ b/code/model/modelrender.cpp
@@ -20,6 +20,7 @@
 #include "graphics/uniforms.h"
 #include "io/timer.h"
 #include "math/staticrand.h"
+#include "mod_table/mod_table.h"
 #include "model/modelrender.h"
 #include "nebula/neb.h"
 #include "particle/particle.h"
@@ -831,13 +832,6 @@ void model_render_add_lightning( model_draw_list *scene, model_render_params* in
 	float width = 0.9f;
 	color primary, secondary;
 
-	const int AR = 64;
-	const int AG = 64;
-	const int AB = 5;
-	const int AR2 = 128;
-	const int AG2 = 128;
-	const int AB2 = 10;
-
 	Assert( sm->num_arcs > 0 );
 
 	if ( interp->get_model_flags() & MR_SHOW_OUTLINE_PRESET ) {
@@ -864,23 +858,23 @@ void model_render_add_lightning( model_draw_list *scene, model_render_params* in
 			// "normal", FreeSpace 1 style arcs
 		case MARC_TYPE_NORMAL:
 			if ( (rand()>>4) & 1 )	{
-				gr_init_color(&primary, 64, 64, 255);
+				gr_init_color(&primary, Arc_color_damage_p1_r, Arc_color_damage_p1_g, Arc_color_damage_p1_b);
 			} else {
-				gr_init_color(&primary, 128, 128, 255);
+				gr_init_color(&primary, Arc_color_damage_p2_r, Arc_color_damage_p2_g, Arc_color_damage_p2_b);
 			}
 
-			gr_init_color(&secondary, 200, 200, 255);
+			gr_init_color(&secondary, Arc_color_damage_s1_r, Arc_color_damage_s1_g, Arc_color_damage_s1_b);
 			break;
 
 			// "EMP" style arcs
 		case MARC_TYPE_EMP:
 			if ( (rand()>>4) & 1 )	{
-				gr_init_color(&primary, AR, AG, AB);
+				gr_init_color(&primary, Arc_color_emp_p1_r, Arc_color_emp_p1_g, Arc_color_emp_p1_b);
 			} else {
-				gr_init_color(&primary, AR2, AG2, AB2);
+				gr_init_color(&primary, Arc_color_emp_p2_r, Arc_color_emp_p2_g, Arc_color_emp_p2_b);
 			}
 
-			gr_init_color(&secondary, 255, 255, 10);
+			gr_init_color(&secondary, Arc_color_emp_s1_r, Arc_color_emp_s1_g, Arc_color_emp_s1_b);
 			break;
 
 		default:

--- a/code/model/modelrender.cpp
+++ b/code/model/modelrender.cpp
@@ -858,23 +858,23 @@ void model_render_add_lightning( model_draw_list *scene, model_render_params* in
 			// "normal", FreeSpace 1 style arcs
 		case MARC_TYPE_NORMAL:
 			if ( (rand()>>4) & 1 )	{
-				gr_init_color(&primary, Arc_color_damage_p1_r, Arc_color_damage_p1_g, Arc_color_damage_p1_b);
+				gr_init_color(&primary, std::get<0>(Arc_color_damage_p1), std::get<1>(Arc_color_damage_p1), std::get<2>(Arc_color_damage_p1));
 			} else {
-				gr_init_color(&primary, Arc_color_damage_p2_r, Arc_color_damage_p2_g, Arc_color_damage_p2_b);
+				gr_init_color(&primary, std::get<0>(Arc_color_damage_p2), std::get<1>(Arc_color_damage_p2), std::get<2>(Arc_color_damage_p2));
 			}
 
-			gr_init_color(&secondary, Arc_color_damage_s1_r, Arc_color_damage_s1_g, Arc_color_damage_s1_b);
+			gr_init_color(&primary, std::get<0>(Arc_color_damage_s1), std::get<1>(Arc_color_damage_s1), std::get<2>(Arc_color_damage_s1));
 			break;
 
 			// "EMP" style arcs
 		case MARC_TYPE_EMP:
 			if ( (rand()>>4) & 1 )	{
-				gr_init_color(&primary, Arc_color_emp_p1_r, Arc_color_emp_p1_g, Arc_color_emp_p1_b);
+				gr_init_color(&primary, std::get<0>(Arc_color_emp_p1), std::get<1>(Arc_color_emp_p1), std::get<2>(Arc_color_emp_p1));
 			} else {
-				gr_init_color(&primary, Arc_color_emp_p2_r, Arc_color_emp_p2_g, Arc_color_emp_p2_b);
+				gr_init_color(&primary, std::get<0>(Arc_color_emp_p2), std::get<1>(Arc_color_emp_p2), std::get<2>(Arc_color_emp_p2));
 			}
 
-			gr_init_color(&secondary, Arc_color_emp_s1_r, Arc_color_emp_s1_g, Arc_color_emp_s1_b);
+			gr_init_color(&primary, std::get<0>(Arc_color_emp_s1), std::get<1>(Arc_color_emp_s1), std::get<2>(Arc_color_emp_s1));
 			break;
 
 		default:


### PR DESCRIPTION
This PR adds a table entry that allows modders to specify the RGBI values for the damage and emp arc colors (which were previosuly hardcoded).

This option adds the table entry to `Game_settings.tbl` under `#Graphic Settings` with the lines:
```
$EMP Arc Color:
	+Primary Color Option 1: rgb
	+Primary Color Option 2: rgb
	+Secondary Color Option 1: rgb

$Damage Arc Color:
	+Primary Color Option 1: rgb
	+Primary Color Option 2: rgb
	+Secondary Color Option 1: rgb
```