### PR TITLE
properly indicate that player ships have departed at the end of a mission

### DIFF
--- a/code/ai/aigoals.cpp
+++ b/code/ai/aigoals.cpp
@@ -1626,7 +1626,7 @@ int ai_mission_goal_achievable( int objnum, ai_goal *aigp )
 			status = SHIP_STATUS_ARRIVED;
 		}
 		// goal ship is still on the arrival list
-		else if ( mission_parse_get_arrival_ship(aigp->target_name) )
+		else if ( mission_check_ship_yet_to_arrive(aigp->target_name) )
 		{
 			status = SHIP_STATUS_NOT_ARRIVED;
 		}

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -4045,7 +4045,7 @@ int parse_wing_create_ships( wing *wingp, int num_to_create, int force, int spec
 				int num_remaining;
 
 				// see if ship is yet to arrive.  If so, then return 0 so we can evaluate again later.
-				if (mission_parse_get_arrival_ship(name))
+				if (mission_check_ship_yet_to_arrive(name))
 					return 0;
 
 				// since this wing cannot arrive from this place, we need to mark the wing as destroyed and
@@ -6808,7 +6808,7 @@ int mission_did_ship_arrive(p_object *objp)
 			shipnum = ship_name_lookup( name );
 			if ( shipnum == -1 ) {
 				// see if ship is yet to arrive.  If so, then return -1 so we can evaluate again later.
-				if (mission_parse_get_arrival_ship(name))
+				if (mission_check_ship_yet_to_arrive(name))
 					return -1;
 
 				mission_parse_mark_non_arrival(objp);	// Goober5000
@@ -7195,7 +7195,7 @@ int mission_do_departure(object *objp, bool goal_is_to_warp)
 		name = Parse_names[anchor];
 
 		// see if ship is yet to arrive.  If so, then warp.
-		if (mission_parse_get_arrival_ship(name))
+		if (mission_check_ship_yet_to_arrive(name))
 		{
 			mprintf(("Anchor ship %s hasn't arrived yet!  Trying to warp...\n", name));
 			goto try_to_warp;

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -6574,8 +6574,8 @@ p_object *mission_parse_get_arrival_ship(ushort net_signature)
 }
 
 /**
- * Because player ships remain on the arrival list (see parse_wing_create_ships), checking the list isn't sufficient
- * to determine whether a ship is yet to arrive.  So this function also checks whether the object was created.
+ * Because player ships remain on the arrival list (see parse_wing_create_ships), testing for yet-to-arrive by merely
+ * checking the list will produce false positives for player ships.  So this function also checks whether the object was created.
  */
 bool mission_check_ship_yet_to_arrive(const char *name)
 {

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -6536,8 +6536,8 @@ p_object *mission_parse_get_arrival_ship(const char *name)
 {
 	p_object *p_objp;
 
-	if (name == NULL)
-		return NULL;
+	if (name == nullptr)
+		return nullptr;
 
 	for (p_objp = GET_FIRST(&Ship_arrival_list); p_objp != END_OF_LIST(&Ship_arrival_list); p_objp = GET_NEXT(p_objp))
 	{
@@ -6547,7 +6547,7 @@ p_object *mission_parse_get_arrival_ship(const char *name)
 		}
 	}
 
-	return NULL;
+	return nullptr;
 }
 
 /**
@@ -6571,6 +6571,22 @@ p_object *mission_parse_get_arrival_ship(ushort net_signature)
 	}
 
 	return NULL;
+}
+
+/**
+ * Because player ships remain on the arrival list (see parse_wing_create_ships), checking the list isn't sufficient
+ * to determine whether a ship is yet to arrive.  So this function also checks whether the object was created.
+ */
+bool mission_check_ship_yet_to_arrive(const char *name)
+{
+	p_object *p_objp = mission_parse_get_arrival_ship(name);
+	if (p_objp == nullptr)
+		return false;
+
+	if (p_objp->created_object != nullptr)
+		return false;
+
+	return true;
 }
 
 /**

--- a/code/mission/missionparse.h
+++ b/code/mission/missionparse.h
@@ -482,6 +482,7 @@ extern char Neb2_texture_name[MAX_FILENAME_LEN];
 bool parse_main(const char *mission_name, int flags = 0);
 p_object *mission_parse_get_arrival_ship(ushort net_signature);
 p_object *mission_parse_get_arrival_ship(const char *name);
+bool mission_check_ship_yet_to_arrive(const char *name);
 p_object *mission_parse_get_parse_object(ushort net_signature);
 p_object *mission_parse_get_parse_object(const char *name);
 int parse_create_object(p_object *objp);

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -2327,7 +2327,6 @@ int check_sexp_syntax(int node, int return_type, int recursive, int *bad_node, i
 			case OPF_SHIP_WITH_BAY:
 			{
 				char *name = CTEXT(node);
-				p_object *p_objp;
 				int shipnum = -1;
 
 				if (type2 != SEXP_ATOM_STRING)

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -12748,36 +12748,6 @@ int ship_type_name_lookup(const char *name)
 	return -1;
 }
 
-// checks the (arrival & departure) state of a ship.  Return values:
-// -1: has yet to arrive in mission
-//  0: is currently in mission
-//  1: has been destroyed, departed, or never existed
-int ship_query_state(char *name)
-{
-	int i;
-
-	// bogus
-	Assert(name != NULL);
-	if(name == NULL){
-		return -1;
-	}
-
-	for (i=0; i<MAX_SHIPS; i++){
-		if (Ships[i].objnum >= 0){
-			if ((Objects[Ships[i].objnum].type == OBJ_SHIP) || (Objects[Ships[i].objnum].type == OBJ_START)){
-				if (!stricmp(name, Ships[i].ship_name)){
-					return 0;
-				}
-			}
-		}
-	}
-
-	if (mission_parse_get_arrival_ship(name))
-		return -1;
-
-	return 1;
-}
-
 // Finds the world position of a subsystem.
 // Return true/false for subsystem found/not found.
 // Stuff vector *pos with absolute position.

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -1525,8 +1525,6 @@ extern int ship_query_general_type(ship *shipp);
 extern int ship_docking_valid(int docker, int dockee);
 extern int get_quadrant(vec3d *hit_pnt, object *shipobjp = NULL);	//	Return quadrant num of given hit point.
 
-extern int ship_query_state(char *name);
-
 int ship_secondary_bank_has_ammo(int shipnum);	// check if current secondary bank has ammo
 
 int ship_engine_ok_to_warp(ship *sp);		// check if ship has engine power to warp


### PR DESCRIPTION
Evaluating `has-departed-delay "Alpha 1"` during a debriefing stage yields incorrect results in current FSO builds.  This is because the sexp short-circuits and evaluates to false if the ship hasn't arrived yet.  Unfortunately, the arrival check was flawed.

To handle respawns in multiplayer, player ships are not removed from the arrival queue.  A naive test for a yet-to-arrive ship by checking the arrival queue will therefore return false positives for player ships.  The solution is to not only check the list but also check whether the ship was in fact created.

I added a new function `mission_check_ship_yet_to_arrive` and substituted it for `mission_parse_get_arrival_ship` where appropriate.  I also checked all uses of `mission_parse_get_arrival_ship` that were *not* substituted to make sure that they were being used as they should.

Finally I removed the `ship_query_state` function because after implementing this fix, it was only used in one sexp and that instance was better handled by other functions.

This fixes the issue reported in Discord where Into the Lion's Den did not display any briefing stages.