### PR TITLE
Bug fix: adds missing conditional when using weapon icons and 3D weapon selection

### DIFF
--- a/code/missionui/missionweaponchoice.cpp
+++ b/code/missionui/missionweaponchoice.cpp
@@ -1276,7 +1276,7 @@ void wl_load_icons(int weapon_class)
 
 	multi_send_anti_timeout_ping();
 
-	if ( first_frame == -1 && icon->model_index == -1 || (Cmdline_weapon_choice_3d && !strlen(wip->anim_filename)) )
+	if ( (first_frame == -1 && icon->model_index == -1) || (Cmdline_weapon_choice_3d && !strlen(wip->anim_filename)) )
 	{
 		if(strlen(wip->tech_model))
 		{

--- a/code/missionui/missionweaponchoice.cpp
+++ b/code/missionui/missionweaponchoice.cpp
@@ -1265,7 +1265,7 @@ void wl_load_icons(int weapon_class)
 
 	icon = &Wl_icons[weapon_class];
 
-	if(!Cmdline_weapon_choice_3d || (wip->render_type == WRT_LASER && !strlen(wip->tech_model)))
+	if(!Cmdline_weapon_choice_3d || (wip->render_type == WRT_LASER && !strlen(wip->tech_model)) || strlen(Weapon_info[weapon_class].icon_filename) )
 	{
 		first_frame = bm_load_animation(Weapon_info[weapon_class].icon_filename, &num_frames, nullptr, nullptr, nullptr, false, CF_TYPE_INTERFACE);
 
@@ -1276,7 +1276,7 @@ void wl_load_icons(int weapon_class)
 
 	multi_send_anti_timeout_ping();
 
-	if ( first_frame == -1 && icon->model_index == -1)
+	if ( first_frame == -1 && icon->model_index == -1 || (Cmdline_weapon_choice_3d && !strlen(wip->anim_filename)) )
 	{
 		if(strlen(wip->tech_model))
 		{


### PR DESCRIPTION
Previously if the 3D weapon flag was used it would always create a weapon icon and override any pre-existing icons the modder would specify. This PR fixes that by adding an extra set of conditionals, which specifies two things.
1) If a weapon has an icon file name then that icon should be used and not overwritten by an image of the pof.
2) If the weapon does not have an `$Anim:` but does have a model then that model should be used if the 3D_weapon flag is enabled.