### PR TITLE
Make sure various model rendering/collision code reference submodel instances instead of the prototype data

### DIFF
--- a/code/model/modelcollide.cpp
+++ b/code/model/modelcollide.cpp
@@ -1325,8 +1325,14 @@ int model_collide(mc_info *mc_info_obj)
 		// Check all the the highest detail model polygons and subobjects for intersections
 
 		// Don't check it or its children if it is destroyed
-		if (!Mc_pm->submodel[Mc_pm->detail[0]].blown_off)	{	
-			mc_check_subobj( Mc_pm->detail[0] );
+		if ( Mc_pmi ) {
+			if ( !Mc_pmi->submodel[Mc_pm->detail[0]].blown_off ) {
+				mc_check_subobj(Mc_pm->detail[0]);
+			}
+		} else {
+			if ( !Mc_pm->submodel[Mc_pm->detail[0]].blown_off ) {
+				mc_check_subobj(Mc_pm->detail[0]);
+			}
 		}
 	}
 

--- a/code/model/modelread.cpp
+++ b/code/model/modelread.cpp
@@ -4422,13 +4422,15 @@ void model_get_rotating_submodel_list(SCP_vector<int> *submodel_vector, object *
 	}
 
 	polymodel_instance *pmi = model_get_instance(model_instance_num);
+	submodel_instance *child_submodel_instance = &pmi->submodel[pm->detail[0]];
 
 	int i = child_submodel->first_child;
 	while ( i >= 0 )	{
 		child_submodel = &pm->submodel[i];
+		child_submodel_instance = &pmi->submodel[i];
 
 		// Don't check it or its children if it is destroyed or it is a replacement (non-moving)
-		if ( !child_submodel->blown_off && (child_submodel->i_replace == -1) && !child_submodel->no_collisions && !child_submodel->nocollide_this_only)	{
+		if ( !child_submodel_instance->blown_off && (child_submodel->i_replace == -1) && !child_submodel->no_collisions && !child_submodel->nocollide_this_only)	{
 
 			// Only look for submodels that rotate or intrinsic-rotate
 			if (child_submodel->movement_type == MOVEMENT_TYPE_ROT || child_submodel->movement_type == MOVEMENT_TYPE_INTRINSIC_ROTATE) {

--- a/code/ship/shipfx.cpp
+++ b/code/ship/shipfx.cpp
@@ -263,7 +263,7 @@ static void shipfx_maybe_create_live_debris_at_ship_death( object *ship_objp )
 						shipfx_subsystem_maybe_create_live_debris(ship_objp, shipp, pss, &exp_center, 3.0f);
 
 						// now set subsystem as blown off, so we only get one copy
-						pm->submodel[parent].blown_off = 1;
+						pmi->submodel[parent].blown_off = true;
 						pss->submodel_info_1.blown_off = 1;
 					}
 				}


### PR DESCRIPTION
We should not be referencing bsp_info for submodel data specific to live game objects. When I migrated the rendering and collision code to the polymodel instance system, these stragglers fell between the cracks.

This should fix https://github.com/scp-fs2open/fs2open.github.com/issues/2046

