### PR TITLE
Coverity 1093382

### DIFF
--- a/code/inetfile/chttpget.cpp
+++ b/code/inetfile/chttpget.cpp
@@ -231,7 +231,7 @@ void ChttpGet::WorkerThread()
 			return;
 
 		}
-		pcode++
+		pcode++;
 		pcode[3] = '\0';
 		irsp = atoi(pcode);
 

--- a/code/inetfile/chttpget.cpp
+++ b/code/inetfile/chttpget.cpp
@@ -223,7 +223,15 @@ void ChttpGet::WorkerThread()
 	if(strnicmp("HTTP/",p,5)==0)
 	{
 		char *pcode;
-		pcode = strchr(p,' ')+1;
+		pcode = strchr(p,' ');
+		if(pcode == null)
+		{
+			m_State = HTTP_STATE_UNKNOWN_ERROR;	
+			fclose(LOCALFILE);
+			return;
+
+		}
+		pcode++
 		pcode[3] = '\0';
 		irsp = atoi(pcode);
 

--- a/code/inetfile/chttpget.cpp
+++ b/code/inetfile/chttpget.cpp
@@ -224,13 +224,6 @@ void ChttpGet::WorkerThread()
 	{
 		char *pcode;
 		pcode = strchr(p,' ')+1;
-		if(!pcode)
-		{
-			m_State = HTTP_STATE_UNKNOWN_ERROR;	
-			fclose(LOCALFILE);
-			return;
-
-		}
 		pcode[3] = '\0';
 		irsp = atoi(pcode);
 

--- a/code/inetfile/chttpget.cpp
+++ b/code/inetfile/chttpget.cpp
@@ -224,7 +224,7 @@ void ChttpGet::WorkerThread()
 	{
 		char *pcode;
 		pcode = strchr(p,' ');
-		if(pcode == null)
+		if(pcode == nullptr)
 		{
 			m_State = HTTP_STATE_UNKNOWN_ERROR;	
 			fclose(LOCALFILE);


### PR DESCRIPTION
Coverity spotted this dead code.  Looks like the original coder forgot that they had checked for !p already or was a case of mindless copy-pasting code..

Because
pcode = strchr(p,' ')+1;
keeps pcode from being null, it looks like it is safe to remove.