### PR TITLE
Do not allow failure for Windows Travis builds anymore

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -150,16 +150,6 @@ matrix:
       env: CONFIGURATION="Release" CMAKE_TOOLSET=v141_xp CMAKE_GENERATOR="Visual Studio 15 2017"
     - os: windows
       env: CONFIGURATION="Release" CMAKE_TOOLSET="" CMAKE_GENERATOR="Ninja"
-  # As long as Windows is still experimental on Travis CI, allow failures
-  allow_failures:
-    - os: windows
-      env: CONFIGURATION="Debug" CMAKE_TOOLSET=v141_xp CMAKE_GENERATOR="Visual Studio 15 2017"
-    - os: windows
-      env: CONFIGURATION="Debug" CMAKE_TOOLSET="" CMAKE_GENERATOR="Ninja"
-    - os: windows
-      env: CONFIGURATION="Release" CMAKE_TOOLSET=v141_xp CMAKE_GENERATOR="Visual Studio 15 2017"
-    - os: windows
-      env: CONFIGURATION="Release" CMAKE_TOOLSET="" CMAKE_GENERATOR="Ninja"
   fast_finish: true
 
 before_install:

--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -557,10 +557,10 @@ void mod_table_reset() {
 	Disable_built_in_translations = false;
 	Weapon_shockwaves_respect_huge = false;
 	Using_in_game_options = false;
-	Arc_color_damage_p1 = std::make_tuple(64, 64, 225);
-	Arc_color_damage_p2 = std::make_tuple(128, 128, 255);
-	Arc_color_damage_s1 = std::make_tuple(200, 200, 255);
-	Arc_color_emp_p1 = std::make_tuple(64, 64, 5);
-	Arc_color_emp_p2 = std::make_tuple(128, 128, 10);
-	Arc_color_emp_s1 = std::make_tuple(255, 255, 10);
+	Arc_color_damage_p1 = std::make_tuple(static_cast<ubyte>(64), static_cast<ubyte>(64), static_cast<ubyte>(225));
+	Arc_color_damage_p2 = std::make_tuple(static_cast<ubyte>(128), static_cast<ubyte>(128), static_cast<ubyte>(255));
+	Arc_color_damage_s1 = std::make_tuple(static_cast<ubyte>(200), static_cast<ubyte>(200), static_cast<ubyte>(255));
+	Arc_color_emp_p1 = std::make_tuple(static_cast<ubyte>(64), static_cast<ubyte>(64), static_cast<ubyte>(5));
+	Arc_color_emp_p2 = std::make_tuple(static_cast<ubyte>(128), static_cast<ubyte>(128), static_cast<ubyte>(10));
+	Arc_color_emp_s1 = std::make_tuple(static_cast<ubyte>(255), static_cast<ubyte>(255), static_cast<ubyte>(10));
 }

--- a/code/network/psnet2.cpp
+++ b/code/network/psnet2.cpp
@@ -1993,17 +1993,17 @@ unsigned int psnet_ras_status()
 		return INADDR_ANY;
 	}
 
-	pRasEnumConnections = (DWORD (__stdcall *)(LPRASCONN, LPDWORD, LPDWORD))GetProcAddress(ras_handle, "RasEnumConnectionsA");
+	pRasEnumConnections = (DWORD (__stdcall *)(LPRASCONN, LPDWORD, LPDWORD))(void*)GetProcAddress(ras_handle, "RasEnumConnectionsA");
 	if (!pRasEnumConnections)	{
 		FreeLibrary( ras_handle );
 		return INADDR_ANY;
 	}
-	pRasGetConnectStatus = (DWORD (__stdcall *)(HRASCONN, LPRASCONNSTATUS))GetProcAddress(ras_handle, "RasGetConnectStatusA");
+	pRasGetConnectStatus = (DWORD (__stdcall *)(HRASCONN, LPRASCONNSTATUS))(void*)GetProcAddress(ras_handle, "RasGetConnectStatusA");
 	if (!pRasGetConnectStatus)	{
 		FreeLibrary( ras_handle );
 		return INADDR_ANY;
 	}
-	pRasGetProjectionInfo = (DWORD (__stdcall *)(HRASCONN, RASPROJECTION, LPVOID, LPDWORD))GetProcAddress(ras_handle, "RasGetProjectionInfoA");
+	pRasGetProjectionInfo = (DWORD (__stdcall *)(HRASCONN, RASPROJECTION, LPVOID, LPDWORD))(void*)GetProcAddress(ras_handle, "RasGetProjectionInfoA");
 	if (!pRasGetProjectionInfo)	{
 		FreeLibrary( ras_handle );
 		return INADDR_ANY;

--- a/code/network/stand_gui.cpp
+++ b/code/network/stand_gui.cpp
@@ -111,7 +111,7 @@ char title_str[512];
 static HWND Multi_gen_dialog = NULL;		// the dialog itself
 
 // dialog proc for this dialog
-BOOL CALLBACK std_gen_dialog_proc(HWND /*hwndDlg*/, UINT uMsg, WPARAM /*wParam*/, LPARAM /*lParam*/)
+INT_PTR CALLBACK std_gen_dialog_proc(HWND /*hwndDlg*/, UINT uMsg, WPARAM /*wParam*/, LPARAM /*lParam*/)
 {
 	switch(uMsg){		
 	case WM_INITDIALOG:
@@ -483,7 +483,7 @@ int std_connect_lindex_to_npindex(int index)
 }
 
 // message handler for the connect tab
-BOOL CALLBACK connect_proc(HWND hwndDlg,UINT uMsg,WPARAM wParam,LPARAM lParam)
+INT_PTR CALLBACK connect_proc(HWND hwndDlg,UINT uMsg,WPARAM wParam,LPARAM lParam)
 {
    switch(uMsg){
 	// initialize the dialog
@@ -1016,7 +1016,7 @@ HTREEITEM std_multi_get_goal_item(char *goal_string,int type)
 }
 
 // message handler for the multiplayer tab
-BOOL CALLBACK multi_proc(HWND hwndDlg,UINT uMsg,WPARAM /*wParam*/,LPARAM lParam)
+INT_PTR CALLBACK multi_proc(HWND hwndDlg,UINT uMsg,WPARAM /*wParam*/,LPARAM lParam)
 {
 	switch(uMsg){
 	// initialize the page
@@ -1271,7 +1271,7 @@ int std_pinfo_player_is_active(net_player *p)
 }
 
 // message handler for the player info tab
-BOOL CALLBACK player_info_proc(HWND hwndDlg,UINT uMsg,WPARAM wParam,LPARAM lParam)
+INT_PTR CALLBACK player_info_proc(HWND hwndDlg,UINT uMsg,WPARAM wParam,LPARAM lParam)
 {
 	int player_num;	
 	char callsign[40];
@@ -1453,7 +1453,7 @@ void std_gs_init_godstuff_controls()
 }
 
 // message handler for the godstuff tab
-BOOL CALLBACK godstuff_proc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam)
+INT_PTR CALLBACK godstuff_proc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
 	switch (uMsg)
 	{
@@ -1607,7 +1607,7 @@ void std_debug_init_debug_controls(HWND hwndDlg)
 }
 
 // message handler for the godstuff tab
-BOOL CALLBACK debug_proc(HWND hwndDlg,UINT uMsg,WPARAM /*wParam*/,LPARAM lParam)
+INT_PTR CALLBACK debug_proc(HWND hwndDlg,UINT uMsg,WPARAM /*wParam*/,LPARAM lParam)
 {
 	switch(uMsg){
 	// initialize the dialog
@@ -2343,7 +2343,7 @@ static void standalone_do_systray(int mode)
 }
 
 // just like the osapi version for the nonstandalone mode of FreeSpace
-DWORD standalone_process(WORD /*lparam*/)
+DWORD standalone_process(LPVOID /*lparam*/)
 {
 	MSG msg;
 

--- a/code/osapi/osregistry.cpp
+++ b/code/osapi/osregistry.cpp
@@ -130,7 +130,7 @@ namespace
 			}
 			userSIDInitialized = true;
 		}
-#if _MSC_VER >= 1400
+#if !defined(_MSC_VER) || _MSC_VER >= 1400
 		if (userSIDValid)
 		{
 			if (needsWOW64())


### PR DESCRIPTION
This will make the PR builds fail if one of the Windows builds (MSVC or MinGW) fails so that no new compile breaks are introduced on those platforms.