### PR TITLE
Aiturret Cleanup Take 2

### DIFF
--- a/code/ai/aiturret.cpp
+++ b/code/ai/aiturret.cpp
@@ -1179,7 +1179,7 @@ int find_turret_enemy(ship_subsys *turret_subsys, int objnum, vec3d *tpos, vec3d
 			if (Ship_types[sip->class_type].flags[Ship::Type_Info_Flags::Turret_tgt_ship_tgt]) {
 
 				// Turrets and ships should not be targeting the wrong team.
-				if ((Objects[aip->target_objnum].signature == aip->target_signature) ||
+				if ((Objects[aip->target_objnum].signature == aip->target_signature) &&
 				    (iff_matches_mask(Ships[Objects[aip->target_objnum].instance].team, enemy_team_mask))) {
 					if ((!tagged_only_flag) || (tagged_only_flag && ship_is_tagged(&Objects[aip->target_objnum]))) {
 						// nprintf(("AI", "Frame %i: Object %i resuming goal of object %i\n", AI_FrameCount, objnum,

--- a/code/ai/aiturret.cpp
+++ b/code/ai/aiturret.cpp
@@ -856,11 +856,11 @@ int get_nearest_turret_objnum(int turret_parent_objnum, ship_subsys *turret_subs
 	// flags for weapon types
 	if (beam_flag)
 		eeo.eeo_flags |= EEOF_BEAM;
-	else if (flak_flag)
+	if (flak_flag)
 		eeo.eeo_flags |= EEOF_FLAK;
-	else if (laser_flag)
+	if (laser_flag)
 		eeo.eeo_flags |= EEOF_LASER;
-	else if (missile_flag)
+	if (missile_flag)
 		eeo.eeo_flags |= EEOF_MISSILE;
 
 	eeo.enemy_team_mask = enemy_team_mask;


### PR DESCRIPTION
While probably not a full fix to #1791 , this should clean up the portion of the code that looks the most suspicious, by making the checks for weapon flags for the whole block instead of just part.  Also attempts to make it more readable and one or two more checks.  Two places I am not removing what appears to be nonsense because I am trying not to change AI behavior.

Hopefully, all these changes are just changing the checking order and adding checks, and should not affect the actual AI.  I apologize in advance for any mistakes, since this ended up being much more involved than I thought.