### PR TITLE
Fix#1791 ChangeIFF & Laser_Flag

### DIFF
--- a/code/ai/aiturret.cpp
+++ b/code/ai/aiturret.cpp
@@ -856,11 +856,11 @@ int get_nearest_turret_objnum(int turret_parent_objnum, ship_subsys *turret_subs
 	// flags for weapon types
 	if (beam_flag)
 		eeo.eeo_flags |= EEOF_BEAM;
-	else if (flak_flag)
+	if (flak_flag)
 		eeo.eeo_flags |= EEOF_FLAK;
-	else if (laser_flag)
+	if (laser_flag)
 		eeo.eeo_flags |= EEOF_LASER;
-	else if (missile_flag)
+	if (missile_flag)
 		eeo.eeo_flags |= EEOF_MISSILE;
 
 	eeo.enemy_team_mask = enemy_team_mask;


### PR DESCRIPTION
Extremely rare bug caused by use of multiple protect from weapon flags. One of the Ai-Turret functions was setting only one of the flags because "else if" was typed instead of "if".

Possible improvements to related files to come in *other* PR's.