### PR TITLE
Coverity 1093370

### DIFF
--- a/code/physics/physics.cpp
+++ b/code/physics/physics.cpp
@@ -850,7 +850,7 @@ void physics_apply_shock(vec3d *direction_vec, float pressure, physics_info *pi,
 
 	vm_vec_normalize_safe ( direction_vec );
 
-	area.xyz.x = (max->xyz.y - min->xyz.z) * (max->xyz.z - min->xyz.z);
+	area.xyz.x = (max->xyz.y - min->xyz.y) * (max->xyz.z - min->xyz.z);
 	area.xyz.y = (max->xyz.x - min->xyz.x) * (max->xyz.z - min->xyz.z);
 	area.xyz.z = (max->xyz.x - min->xyz.x) * (max->xyz.y - min->xyz.y);
 


### PR DESCRIPTION
Copy paste error, I can think of no reason to compare Max y and Min z, and the code afterward is using it as just a factor in multiplication.  My guess is that it would just cause unpredictable results, especially at coordinates with high y or z values.