### PR TITLE
Coverity 1093387

### DIFF
--- a/code/jpgutils/jpgutils.cpp
+++ b/code/jpgutils/jpgutils.cpp
@@ -128,11 +128,6 @@ int jpeg_read_header(const char *real_filename, CFILE *img_cfp, int *w, int *h, 
 		jpeg_file = img_cfp;
 	}
 
-	Assert( jpeg_file != NULL );
-
-	if (jpeg_file == NULL)
-		return JPEG_ERROR_READING;
-
 	// set the basic/default error code
 	Jpeg_Set_Error(JPEG_ERROR_NONE);
 


### PR DESCRIPTION
The assert already checks for the file being Null, so why check again?

In case anyone decides to remove the assert, let's just comment the check out.  (But in my humble opinion, it's a big deal if we're trying to open a jpeg that doesn't exist.)

Both checks were introduced during a bugfix early in the SCP.