### PR TITLE
Fix#1916

### DIFF
--- a/code/pilotfile/pilotfile.h
+++ b/code/pilotfile/pilotfile.h
@@ -128,7 +128,7 @@ class pilotfile {
 		// --------------------------------------------------------------------
 		// PLR specific
 		// --------------------------------------------------------------------
-		void plr_reset_data();
+	    void plr_reset_data(bool reset_all);
 		void plr_close();
 
 		void plr_read_flags();

--- a/code/pilotfile/plr.cpp
+++ b/code/pilotfile/plr.cpp
@@ -682,7 +682,7 @@ void pilotfile::plr_write_settings()
 	handler->endSectionWrite();
 }
 
-void pilotfile::plr_reset_data()
+void pilotfile::plr_reset_data(bool reset_all)
 {
 	// internals
 	m_have_flags = false;
@@ -691,7 +691,9 @@ void pilotfile::plr_reset_data()
 	m_data_invalid = false;
 
 	// set all the entries in the control config arrays to -1 (undefined)
-	control_config_clear();
+	// Cyborg17 - clear_all is false when we are just trying to verify the file, but true when we load the whole thing.
+	// Otherwise, we can end up getting rid of a pilot's controls by accident.
+	if ( reset_all ) control_config_clear();
 
 	// init stats
 	p->stats.init();
@@ -797,7 +799,8 @@ bool pilotfile::load_player(const char* callsign, player* _p, bool force_binary)
 
 	mprintf(("PLR => Loading '%s' with version %d...\n", filename.c_str(), version));
 
-	plr_reset_data();
+	//1 resets everything, 0 sets up file verify.
+	plr_reset_data(1);
 
 	// the point of all this: read in the PLR contents
 	handler->beginSectionRead();
@@ -1016,7 +1019,8 @@ bool pilotfile::verify(const char *fname, int *rank, char *valid_language)
 
 	mprintf(("PLR => Verifying '%s' with version %d...\n", filename.c_str(), version));
 
-	plr_reset_data();
+	// 1 resets everything, 0 sets up file verify.
+	plr_reset_data(0);
 
 	bool have_flags = false;
 	bool have_info = false;


### PR DESCRIPTION
"Cloning" failure was actually being caused by the pilot verification function resetting all pilot info and then not loading controls from the file to replace them.

The Control_Config array would all be set to -1 and then would get written into the file the next time the player was saved, making it seem that the controls were not being copied.

The original and current code would reset controls to defaults when a pilot was created.  And it would just let the old controls remain in case of a clone.  The above problem would occur just as you hit accept on the bottom of the baracks screen.