### PR TITLE
Fix #1433

### DIFF
--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -3805,12 +3805,10 @@ void game_simulation_frame()
 		game_maybe_update_sound_environment();
 		snd_update_listener(&Eye_position, &Player_obj->phys_info.vel, &Eye_matrix);
 
-// AL: debug code used for testing ambient subspace sound (ie when enabling subspace through debug console)
-#ifndef NDEBUG
+		//Cyborg 17 - Check for need to start/restart subspace ambient sound in edge cases
 		if ( Game_subspace_effect ) {
 			game_start_subspace_ambient_sound();
 		}
-#endif
 	}
 
 	Script_system.RunCondition(CHA_SIMULATION);


### PR DESCRIPTION
For Issue #1433 Susbace ambience does not restart from escape menu. According to Mageking, this is caused by the escape menu strangely circumventing state changes.

Instead of changing how the escape menu handles state changes and risking regression, we are going to enable some code in Release versions that :V: left in debug builds from testing in freespace.cpp. This will let FSO just do a quick "Is susbpace happening" check every frame.
