### PR TITLE
Engine Wash Optimizations  *testing of effects not complete, in draft status*

### DIFF
--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -652,6 +652,8 @@ static void engine_wash_info_init(engine_wash_info *ewi)
 {
 	ewi->name[0] = '\0';
 	ewi->angle = PI / 10.0f;
+	ewi->cos_result  = 1.0f;
+	ewi->tan_result  = 1.0f;
 	ewi->radius_mult = 1.0f;
 	ewi->length = 500.0f;
 	ewi->intensity = 1.0f;
@@ -714,6 +716,14 @@ static void parse_engine_wash(bool replace)
 	{
 		stuff_float(&ewp->angle);
 		ewp->angle *= (PI / 180.0f);
+		ewp->cos_result = cosf(ewp->angle);
+
+		// Cyborg17 - To avoid division by float 0.0 later on
+		if (fl_tan(ewp->angle)) {
+			ewp->tan_result = fl_tan(ewp->angle);
+		} else {
+			ewp->tan_result = 0.001f;
+		}
 	}
 
 	// radius multiplier for hemisphere around thruster pt

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -1261,6 +1261,8 @@ typedef struct engine_wash_info
 {
 	char		name[NAME_LENGTH];
 	float		angle;			// half angle of cone around engine thruster
+	float		cos_result;		// keeps the engine from re-calculating this 50 times
+	float		tan_result;		// keeps the engine from re-calculating this 50 times
 	float		radius_mult;	// multiplier for radius 
 	float		length;			// length of engine wash, measured from thruster
 	float		intensity;		// intensity of engine wash


### PR DESCRIPTION
A few optimizations to the Engine Wash function I found while bug hunting.

The engine was calculating the same value for tan and cos of ewp->angle.  These values never change, so setting them on table parse is trivial and far more optimal.  I think this function is supposed to be called 4 times a second for every ship, so I believe the optimization is worthwhile.

Secondly, on slower computers, engine wash was likely occasionally firing extra times because a check used less than instead of less than or equal to, forcing a weird situation in the timestamp function, making the function do the whole calculation again the next frame.

Third, pre-multiply a value that gets used more than once later on, so we don't square it every time we use it.

Last, we were calling the damage function for no reason when we weren't going to apply damage, anyway.

Very open to suggestions/corrections on this, since I am really just trying to learn with this PR, and I know that the performance gains are not going to be noticeable.