### PR TITLE
Write Minidumps when a crash occurs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ endif()
 include(cmake/util.cmake)
 
 # Set a few policies
-set_policy(CMP0051 OLD)
+set_policy(CMP0051 NEW)
 set_policy(CMP0053 NEW)
 set_policy(CMP0054 NEW)
 

--- a/ci/appveyor/build.ps1
+++ b/ci/appveyor/build.ps1
@@ -134,6 +134,7 @@ if ($DeployBuild) {
 	cmake -DCMAKE_INSTALL_PREFIX="$env:APPVEYOR_BUILD_FOLDER/../install" -DFSO_USE_SPEECH="ON" `
 		-DFSO_USE_VOICEREC="ON" -DMSVC_SIMD_INSTRUCTIONS="$($buildConfig.SimdType)" `
 		-DQT5_INSTALL_ROOT="$($buildConfig.QtDir)" -DFSO_BUILD_QTFRED=ON `
+		-DFSO_INSTALL_DEBUG_FILES="ON" `
 		-G "$($buildConfig.Generator)" -T "$($buildConfig.Toolset)" ..
 
 	$Configs = @("Release", "FastDebug")
@@ -145,8 +146,11 @@ if ($DeployBuild) {
     	}
 	}
 
-    7z a "$($PackageName)-builds-$($buildConfig.PackageType).zip" "$env:APPVEYOR_BUILD_FOLDER/../install/*"
+    7z a -xr'!*.pdb' "$($PackageName)-builds-$($buildConfig.PackageType).zip" "$env:APPVEYOR_BUILD_FOLDER/../install/*"
     Push-AppveyorArtifact "$($PackageName)-builds-$($buildConfig.PackageType).zip"
+
+	7z a "$($PackageName)-debug-$($buildConfig.PackageType).7z" "$env:APPVEYOR_BUILD_FOLDER/../install/*.pdb"
+	Push-AppveyorArtifact "$($PackageName)-debug-$($buildConfig.PackageType).7z"
 } else {
 	cmake -DFSO_USE_SPEECH="ON" -DFSO_FATAL_WARNINGS="ON" -DFSO_USE_VOICEREC="ON" -DFSO_BUILD_TESTS="ON" -DMSVC_SIMD_INSTRUCTIONS=SSE2 `
 	-DFSO_BUILD_QTFRED=ON -DQT5_INSTALL_ROOT="$env:QT_DIR" -DFSO_BUILD_FRED2="ON" `

--- a/cmake/toolchain-msvc.cmake
+++ b/cmake/toolchain-msvc.cmake
@@ -51,7 +51,8 @@ set(CMAKE_STATIC_LINKER_FLAGS "")
 # Release
 set(CMAKE_C_FLAGS_RELEASE "/GL /W2 /Gy- /Ox /Ot /Ob2 /fp:precise /GF /Oy /Oi /Zi /W3")
 set(CMAKE_CXX_FLAGS_RELEASE "/GL /W2 /Gy- /Ox /Ot /Ob2 /fp:precise /GF /Oy /Oi /Zi /W3")
-set(CMAKE_EXE_LINKER_FLAGS_RELEASE "/OPT:REF /LTCG /INCREMENTAL:NO")
+# /DEBUG:FULL so that we get PDBs which is needed for debugging crashdumps
+set(CMAKE_EXE_LINKER_FLAGS_RELEASE "/OPT:REF /LTCG /INCREMENTAL:NO /DEBUG:FULL")
 set(CMAKE_STATIC_LINKER_FLAGS_RELEASE "/LTCG")
 
 globally_enable_extra_compiler_warnings()
@@ -63,8 +64,6 @@ if (MSVC_RELEASE_DEBUGGING)
 		set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} /Zo")
 		set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /Zo")
 	endif()
-	
-	set(CMAKE_EXE_LINKER_FLAGS_RELEASE "${CMAKE_EXE_LINKER_FLAGS_RELEASE} /DEBUG")
 endif()
 
 IF(MSVC_USE_RUNTIME_DLL)

--- a/code/globalincs/crashdump.cpp
+++ b/code/globalincs/crashdump.cpp
@@ -1,0 +1,75 @@
+#include "crashdump.h"
+
+#ifdef WIN32
+
+#ifdef _MSC_VER
+#pragma warning (push)
+#pragma warning (disable:4091) // a microsoft header has warnings. Very nice.
+#endif
+
+// clang-format off
+#include <windows.h>
+#include <dbghelp.h>
+// clang-format on
+
+#ifdef _MSC_VER
+#pragma warning (pop)
+#endif
+
+#include "globalincs/pstypes.h"
+
+void make_minidump(EXCEPTION_POINTERS* e)
+{
+	const auto hDbgHelp = LoadLibraryA("dbghelp");
+	if (hDbgHelp == nullptr)
+		return;
+	const auto pMiniDumpWriteDump = reinterpret_cast<decltype(&MiniDumpWriteDump)>(
+	    reinterpret_cast<void*>(GetProcAddress(hDbgHelp, "MiniDumpWriteDump")));
+	if (pMiniDumpWriteDump == nullptr)
+		return;
+
+	char name[MAX_PATH];
+	{
+		const auto nameEnd = name + GetModuleFileNameA(GetModuleHandleA(nullptr), name, MAX_PATH);
+		SYSTEMTIME t;
+		GetSystemTime(&t);
+		wsprintfA(nameEnd - strlen(".exe"), "_%4d%02d%02d_%02d%02d%02d.mdmp", t.wYear, t.wMonth, t.wDay, t.wHour,
+		          t.wMinute, t.wSecond);
+	}
+
+	const auto hFile = CreateFileA(name, GENERIC_WRITE, FILE_SHARE_READ, nullptr, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, 0);
+	if (hFile == INVALID_HANDLE_VALUE)
+		return;
+
+	MINIDUMP_EXCEPTION_INFORMATION exceptionInfo;
+	exceptionInfo.ThreadId          = GetCurrentThreadId();
+	exceptionInfo.ExceptionPointers = e;
+	exceptionInfo.ClientPointers    = FALSE;
+
+	pMiniDumpWriteDump(GetCurrentProcess(), GetCurrentProcessId(), hFile,
+	                   MINIDUMP_TYPE(MiniDumpWithIndirectlyReferencedMemory | MiniDumpScanMemory),
+	                   e ? &exceptionInfo : nullptr, nullptr, nullptr);
+
+	CloseHandle(hFile);
+
+	mprintf(("CRASH DETECTED!!! Wrote crash dump to %s\n", name));
+}
+
+LONG CALLBACK unhandled_handler(EXCEPTION_POINTERS* e)
+{
+	make_minidump(e);
+	return EXCEPTION_CONTINUE_SEARCH;
+}
+
+#endif
+
+namespace crashdump {
+
+void installCrashHandler()
+{
+#ifdef WIN32
+	SetUnhandledExceptionFilter(unhandled_handler);
+#endif
+}
+
+} // namespace crashdump

--- a/code/globalincs/crashdump.h
+++ b/code/globalincs/crashdump.h
@@ -1,0 +1,7 @@
+#pragma once
+
+namespace crashdump {
+
+void installCrashHandler();
+
+}

--- a/code/source_groups.cmake
+++ b/code/source_groups.cmake
@@ -314,6 +314,8 @@ add_file_folder("Generated Files"
 add_file_folder("GlobalIncs"
 	globalincs/alphacolors.cpp
 	globalincs/alphacolors.h
+	globalincs/crashdump.cpp
+	globalincs/crashdump.h
 	globalincs/fsmemory.h
 	globalincs/globals.h
 	globalincs/linklist.h

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -53,6 +53,7 @@
 #include "gamesnd/eventmusic.h"
 #include "gamesnd/gamesnd.h"
 #include "globalincs/alphacolors.h"
+#include "globalincs/crashdump.h"
 #include "globalincs/mspdb_callstack.h"
 #include "globalincs/version.h"
 #include "graphics/font.h"
@@ -7957,6 +7958,8 @@ int actual_main(int argc, char *argv[])
 {
 	int result = -1;
 	Assert(argc > 0);
+
+	crashdump::installCrashHandler();
 
 #ifdef WIN32
 	// Don't let more than one instance of FreeSpace run.

--- a/qtfred/CMakeLists.txt
+++ b/qtfred/CMakeLists.txt
@@ -136,3 +136,11 @@ elseif(FSO_BUILD_APPIMAGE)
     install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/resources/fred_icon.png" DESTINATION "."
             COMPONENT "qtFRED")
 endif()
+
+if (FSO_INSTALL_DEBUG_FILES)
+    if (MSVC)
+        install(FILES "$<TARGET_PDB_FILE:qtfred>"
+                DESTINATION ${BINARY_DESTINATION}
+                OPTIONAL)
+    endif()
+endif()


### PR DESCRIPTION
This will write Mini dumps in the event that the executable causes a
crash. This will allow us to take a closer look at any crashes without
having to reproduce them. This will also upload the PDBs of the builds
to our servers so we can use those for resolving symbols in the crash
dumps.