### PR TITLE
Update GitHub token used for AppVeyor release building

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,7 +24,7 @@ test_script:
 deploy:
     - provider: GitHub
       auth_token:
-          secure: 3kV4efHXwRnfXzmJPRAOs8D7+MhwXUXYeayI/P5y114L09kJa6b6L70beXdW7yYr
+          secure: h55Scpy+3vmo1Yb7WlSIGA4d9DRnsbzUYc2LYsQdByQHZHbqrqjBpicH0D2FFLEO
       on:
           ReleaseBuild: true        # deploy on release push only
 


### PR DESCRIPTION
For some reason the old token was removed from the AppVeyor GitHub
account which made the release build fail.