### PR TITLE
Fix crash in joystick code

### DIFF
--- a/code/io/joy-sdl.cpp
+++ b/code/io/joy-sdl.cpp
@@ -121,8 +121,8 @@ bool joystickMatchesGuid(Joystick* testStick, const SCP_string& guid, int id)
 
 bool isCurrentJoystick(Joystick* testStick)
 {
-	auto currentGUID = os_config_read_string(nullptr, "CurrentJoystickGUID", nullptr);
-	auto currentId   = (int)os_config_read_uint(nullptr, "CurrentJoystick", 0);
+	const auto currentGUID = os_config_read_string(nullptr, "CurrentJoystickGUID", "");
+	const auto currentId   = static_cast<int>(os_config_read_uint(nullptr, "CurrentJoystick", 0));
 
 	return joystickMatchesGuid(testStick, currentGUID, currentId);
 }


### PR DESCRIPTION
Not sure why we didn't catch this earlier but this should hopefully fix
the crash. The cause was that we constructed an SCP_string from a null
pointer instead of using the empty string as the default.