### PR TITLE
fix modular table loading errors on non windows

### DIFF
--- a/code/cfile/cfilesystem.cpp
+++ b/code/cfile/cfilesystem.cpp
@@ -1556,6 +1556,9 @@ static int cf_file_already_in_list( SCP_vector<SCP_string> &list, const char *fi
 // This one has a 'type', which is a CF_TYPE_* value.  Because this specifies the directory
 // location, 'filter' only needs to be the filter itself, with no path information.
 // See above descriptions of cf_get_file_list() for more information about how it all works.
+// Note that filesystem listing is always sorted by name *before* sorting by the
+// provided sort order. This isn't strictly needed on NTFS, which always provides the list
+// sorted by name. But on mac/linux it's always needed.
 int cf_get_file_list(SCP_vector<SCP_string>& list, int pathtype, const char* filter, int sort,
                      SCP_vector<file_list_info>* info, uint32_t location_flags)
 {
@@ -1744,6 +1747,9 @@ int cf_get_file_list(SCP_vector<SCP_string>& list, int pathtype, const char* fil
 	}
 
 
+	// tcrayford: sort the filesystem listing by name by default to ensure
+	// a stable order across filesystems
+	cf_sort_filenames( list, CF_SORT_NAME, info );
 	if (sort != CF_SORT_NONE)	{
 		cf_sort_filenames( list, sort, info );
 	}


### PR DESCRIPTION
When running a mod on non-windows, that isn't packed into VP files, the
mod can break when loading. On non-windows filesystems, the file
order isn't guaranteed to be alphabetical (but it is on Windows).
As a result, we load tables in an effectively random order.

Lots of mods rely on the filesystem ordering to e.g. implement a very
loose dependency system for their lua scripts.

Referenced on the forum here:
https://www.hard-light.net/forums/index.php?topic=95750.msg1885275#msg1885275

Here's a log from Solaris failing to run:

https://fsnebula.org/log/5d7b4414cb0d332b466b5ee2#True-138

Instead, always sort filesystem listing by name *before* applying the
provided sort order.

I've built a few different versions of this patch, and like this one the
best. The other ones I tried:
1. Adding a `CF_SORT_REVERSE_NAME` and using it everywhere that
`CF_SORT_REVERSE` is used, and replacing all uses of `CF_SORT_NONE` with
`CF_SORT_NAME`. I didn't like this as it was a much larger diff.
2. Adding a `CF_SORT_REVERSE_NAME` to the `scripting.cpp` call for
loading tables. I didn't like this one because this bug can in theory
impact non scripting tables.

I don't think doing one extra sort on all filesystem listing calls is much of a performance impact, usually the numbers of files we're talking about is in the low hundreds to thousands, and computers are really very fast.

Here's a log from Solaris working with the new build:
https://fsnebula.org/log/5d7b4f37cb0d332b3d6b5ed3#True-138

While it might be a reasonable enhancement in the future to build a proper dependency system for lua scripts and tables,
this is a much smaller and easier change, and doesn't require any work from modders.