### PR TITLE
add seconds-to-goal sexp

### DIFF
--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -758,6 +758,7 @@ SCP_vector<sexp_oper> Operators = {
 	{ "special-check",					OP_SPECIAL_CHECK,						1,	1,			SEXP_ACTION_OPERATOR,	},
 	{ "set-training-context-fly-path",	OP_SET_TRAINING_CONTEXT_FLY_PATH,		2,	2,			SEXP_ACTION_OPERATOR,	},
 	{ "set-training-context-speed",		OP_SET_TRAINING_CONTEXT_SPEED,			2,	2,			SEXP_ACTION_OPERATOR,	},
+	{ "seconds-to-goal",				OP_SECONDS_TO_GOAL,	   	         		1,	1,			SEXP_INTEGER_OPERATOR,	}, // tcrayford
 };
 
 sexp_ai_goal_link Sexp_ai_goal_links[] = {
@@ -16457,6 +16458,12 @@ int sexp_query_orders (int n)
 	return hud_query_order_issued(order_to, order, target, timestamp, order_from, special);
 }
 
+int sexp_seconds_to_waypoint (int n)
+{
+    ship* shipp = sexp_get_ship_from_node(n);
+	return ship_return_seconds_to_goal(shipp);
+}
+
 // Karajorma
 void sexp_reset_orders (int  /*n*/)
 {
@@ -25359,6 +25366,11 @@ int eval_sexp(int cur_node, int referenced_node)
 				sexp_val = sexp_query_orders(node);
 				break;
 
+			case OP_SECONDS_TO_GOAL:
+				sexp_val = sexp_seconds_to_waypoint(node);
+				break;
+
+
 			// Karajorma
 			case OP_RESET_ORDERS:
 				sexp_reset_orders(node);
@@ -26898,6 +26910,7 @@ int query_operator_return_type(int op)
 		case OP_GET_COLGROUP_ID:
 		case OP_FUNCTIONAL_IF_THEN_ELSE:
 	    case OP_GET_HOTKEY:
+        case OP_SECONDS_TO_GOAL:
 			return OPR_NUMBER;
 
 		case OP_ABS:
@@ -27701,6 +27714,10 @@ int query_operator_argument_type(int op, int argnum)
 				return OPF_SUBSYSTEM;
 			else
 				return OPF_SHIP_WING;
+
+		case OP_SECONDS_TO_GOAL:
+			if (argnum == 0)
+				return OPF_SHIP;
 
 		case OP_WAS_DESTROYED_BY_DELAY:
 			if (argnum == 0)
@@ -33016,7 +33033,10 @@ SCP_vector<sexp_help_struct> Sexp_help = {
 		"\tBecomes true when a waypoint is hit that is before the last one hit, which "
 		"indicates they have flown a waypoint twice.\r\n\r\n"
 		"Returns a boolean value.  Takes no arguments." },
-
+	{ OP_SECONDS_TO_GOAL, "Seconds-to-goal (Number training operator)\r\n"
+		"\tReturns the number of seconds until a ship reaches its waypoint\r\n\r\n"
+		"Returns a number value.  Takes 1 argument...\r\n"
+		"\t1:\tName of ship to check waypoint time." },
 	{ OP_TRAINING_MSG, "Training-msg (Action training operator)\r\n"
 		"\tSends the player a training message.  Uses the same messages as normal messages, "
 		"only they get displayed differently using this operator.  If a secondary message "

--- a/code/parse/sexp.h
+++ b/code/parse/sexp.h
@@ -820,6 +820,7 @@ class waypoint_list;
 #define OP_QUERY_ORDERS						(0x0014 | OP_CATEGORY_TRAINING) // Karajorma
 #define OP_NODE_TARGETED					(0x0015 | OP_CATEGORY_TRAINING) // FUBAR
 #define OP_IGNORE_KEY						(0x0016 | OP_CATEGORY_TRAINING) // Karajorma
+#define OP_SECONDS_TO_GOAL					(0x0017 | OP_CATEGORY_TRAINING) // tcrayford
 
 // defines for string constants
 #define SEXP_HULL_STRING			"Hull"

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -15080,8 +15080,31 @@ SCP_string ship_return_orders(ship* sp)
 // it suits your needs for something.
 char *ship_return_time_to_goal(char *outbuf, ship *sp)
 {
+	int	minutes, seconds;
+	int time = ship_return_seconds_to_goal(sp);
+	if ( time >= 0 ) {
+		minutes = time/60;
+		seconds = time%60;
+		if ( minutes > 99 ) {
+			minutes = 99;
+			seconds = 99;
+		}
+		sprintf(outbuf, NOX("%02d:%02d"), minutes, seconds);
+	} else if ( time == -2) {
+        // -2 is used as a signal of "there is no valid goal right now"
+	} else {
+		strcpy( outbuf, XSTR( "Unknown", 497) );
+	}
+
+	return outbuf;
+}
+
+// tcrayford: returns the number of seconds to a goal
+// split out of ship_return_time_to_goal
+int ship_return_seconds_to_goal(ship *sp)
+{
 	ai_info	*aip;
-	int		time, seconds, minutes;
+	int		time;
 	float		dist = 0.0f;
 	object	*objp;	
 	float		min_speed, max_speed;
@@ -15114,7 +15137,7 @@ char *ship_return_time_to_goal(char *outbuf, ship *sp)
 		}
 
 		if ( dist < 1.0f) {
-			return NULL;
+			return -2;
 		}	
 
 		if ( (Objects[sp->objnum].phys_info.speed <= 0) || (max_speed <= 0.0f) ) {
@@ -15133,22 +15156,9 @@ char *ship_return_time_to_goal(char *outbuf, ship *sp)
 		time = hud_get_dock_time( objp );
 	} else {
 		// don't return anytime for time to except for waypoints and actual docking.
-		return NULL;
+		return -2;
 	}
-
-	if ( time >= 0 ) {
-		minutes = time/60;
-		seconds = time%60;
-		if ( minutes > 99 ) {
-			minutes = 99;
-			seconds = 99;
-		}
-		sprintf(outbuf, NOX("%02d:%02d"), minutes, seconds);
-	} else {
-		strcpy( outbuf, XSTR( "Unknown", 497) );
-	}
-
-	return outbuf;
+	return time;
 }
 
 /* Karajorma - V decided not to use this function so I've commented it out so it isn't confused with code

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -1566,6 +1566,7 @@ int ship_lock_threat(ship *sp);
 int	bitmask_2_bitnum(int num);
 SCP_string ship_return_orders(ship *sp);
 char	*ship_return_time_to_goal(char *outbuf, ship *sp);
+int	ship_return_seconds_to_goal(ship *sp);
 
 void	ship_maybe_warn_player(ship *enemy_sp, float dist);
 void	ship_maybe_praise_player(ship *deader_sp);


### PR DESCRIPTION
This adds `seconds-to-goal`, as requested by `0rph3u5` on the HLP discord:

request:

> wait a minute, there is no function to get the estimate for a ship reaching its waypoints?
(I mean I get that for simple waypoints I can just do a distance/speed and update that every time I change the speed or each time a waypoint is passed; or just go in the mission and copy what's on the HUD - but really the engine already does that for the HUD and there is no sexp to get the value from that display?)

I've slightly refactored the `ship_return_time_to_goal` so that there's a function to grab the seconds now.

I've tested this:

1. I setup a simple mission with a ship and a waypoint and an initial order to go there, and the time in the hud shows up the same as a normal build
2. I setup the same mission with this sexp:

```
$Formula: ( when 
   ( true ) 
   ( training-msg "debug" ) 
   ( modify-variable @debug[0] (seconds-to-waypoint "Support 1") ) 
)
+Name: Event name
+Repeat Count: -1
+Trigger Count: 276447231
+Interval: 0
```

This message:

```
$Name: debug
$Team: -1
$MessageNew:  XSTR("$debug", -1)
$end_multi_text
```

and the variable `debug` - and the training message shows the timer decreasing in seconds as the ship gets closer.