### PR TITLE
Handle pausing and unpausing music in certain screens

### DIFF
--- a/code/io/keycontrol.cpp
+++ b/code/io/keycontrol.cpp
@@ -1453,16 +1453,17 @@ void game_do_end_mission_popup()
 			break;
 
 		case 2:
+			gameseq_post_event(GS_EVENT_ENTER_GAME);
+			break;
+
+		// do nothing; resume game
+		default:
 			// Cyborg17 - best place to check for this *one* looping sound.
 			if (Game_subspace_effect) {
 				game_start_subspace_ambient_sound();
 			}
 			audiostream_unpause_all();
-			gameseq_post_event(GS_EVENT_ENTER_GAME);
 			break;
-
-		default:
-			break;  // do nothing
 		}
 
 		game_start_time();

--- a/code/io/keycontrol.cpp
+++ b/code/io/keycontrol.cpp
@@ -1441,6 +1441,7 @@ void game_do_end_mission_popup()
 		// do housekeeping things.
 		game_stop_time();
 		game_stop_looped_sounds();
+		audiostream_pause_all();
 		snd_stop_all();
 
 		pf_flags = PF_BODY_BIG | PF_USE_AFFIRMATIVE_ICON | PF_USE_NEGATIVE_ICON;
@@ -1456,6 +1457,7 @@ void game_do_end_mission_popup()
 			if (Game_subspace_effect) {
 				game_start_subspace_ambient_sound();
 			}
+			audiostream_unpause_all();
 			gameseq_post_event(GS_EVENT_ENTER_GAME);
 			break;
 

--- a/code/menuui/optionsmenu.cpp
+++ b/code/menuui/optionsmenu.cpp
@@ -929,7 +929,10 @@ void options_menu_init()
 
 	// pause all sounds, since we could get here through the game
 	weapon_pause_sounds();
-	//audiostream_pause_all();
+	// only pause music if we're in-mission; we could also be in the main hall
+	if (Game_mode & GM_IN_MISSION) {
+		audiostream_pause_all();
+	}
 
 	Tab = 0;
 	Gamma_last_set = -1;
@@ -1060,7 +1063,10 @@ void options_menu_close()
 	
 	// unpause all sounds, since we could be headed back to the game
 	weapon_unpause_sounds();
-	//audiostream_unpause_all();
+	// only unpause music if we're in-mission; we could also be in the main hall
+	if (Game_mode & GM_IN_MISSION) {
+		audiostream_unpause_all();
+	}
 	
 	Options_menu_inited = 0;
 	Options_multi_inited = 0;


### PR DESCRIPTION
This PR does several things:

1) Properly pause and unpause music when Escape is pressed
2) Properly pause and unpause music when F2 is pressed (which is how F1, F3, and F4 handle it)
3) Continue to play music when F2 is pressed while the player is in the main hall
4) Properly fix the subspace sound issue; PR #2078 put the fix in the wrong place.

This fixes #2099 and #1433.