### PR TITLE
miscellaneous XSTR cleanup

### DIFF
--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -15328,7 +15328,7 @@ void sexp_ship_guardian_threshold(int node)
 		// check to see if ship destroyed or departed.  In either case, do nothing.
 		ship_name = CTEXT(n);
 
-		if ( mission_log_get_time(LOG_SHIP_DEPARTED, ship_name, NULL, NULL) || mission_log_get_time(LOG_SHIP_DESTROYED, ship_name, NULL, NULL) || mission_log_get_time(LOG_SELF_DESTRUCTED, ship_name, NULL, NULL) ) {
+		if ( mission_log_get_time(LOG_SHIP_DEPARTED, ship_name, nullptr, nullptr) || mission_log_get_time(LOG_SHIP_DESTROYED, ship_name, nullptr, nullptr) || mission_log_get_time(LOG_SELF_DESTRUCTED, ship_name, nullptr, nullptr) ) {
 			continue;
 		}
 
@@ -15358,7 +15358,7 @@ void sexp_ship_subsys_guardian_threshold(int node)
 	n = CDR(n);
 
 	// check to see if ship destroyed or departed.  In either case, do nothing.
-	if ( mission_log_get_time(LOG_SHIP_DEPARTED, ship_name, NULL, NULL) || mission_log_get_time(LOG_SHIP_DESTROYED, ship_name, NULL, NULL) || mission_log_get_time(LOG_SELF_DESTRUCTED, ship_name, NULL, NULL) ) {
+	if ( mission_log_get_time(LOG_SHIP_DEPARTED, ship_name, nullptr, nullptr) || mission_log_get_time(LOG_SHIP_DESTROYED, ship_name, nullptr, nullptr) || mission_log_get_time(LOG_SELF_DESTRUCTED, ship_name, nullptr, nullptr) ) {
 		return;
 	}
 
@@ -15387,7 +15387,7 @@ void sexp_ship_subsys_guardian_threshold(int node)
 		}				
 		else {
 			ss = ship_get_subsys(&Ships[ship_num], hull_name);
-			if ( ss == NULL ) {
+			if ( ss == nullptr) {
 				if (ship_class_unchanged(ship_num)) {
 					Warning(LOCATION, "Invalid subsystem passed to ship-subsys-guardian-threshold: %s does not have a %s subsystem", ship_name, hull_name);
 				}
@@ -15410,7 +15410,7 @@ void sexp_ships_guardian( int n, int guardian )
 		ship_name = CTEXT(n);
 
 		// check to see if ship destroyed or departed.  In either case, do nothing.
-		if ( mission_log_get_time(LOG_SHIP_DEPARTED, ship_name, NULL, NULL) || mission_log_get_time(LOG_SHIP_DESTROYED, ship_name, NULL, NULL) || mission_log_get_time(LOG_SELF_DESTRUCTED, ship_name, NULL, NULL) )
+		if ( mission_log_get_time(LOG_SHIP_DEPARTED, ship_name, nullptr, nullptr) || mission_log_get_time(LOG_SHIP_DESTROYED, ship_name, nullptr, nullptr) || mission_log_get_time(LOG_SELF_DESTRUCTED, ship_name, nullptr, nullptr) )
 			continue;
 
 		// get the ship num.  If we get a -1 for the number here, ship has yet to arrive.  Store this ship

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -30083,7 +30083,8 @@ char *CTEXT(int n)
 
 	Assertion(n >= 0 && n < Num_sexp_nodes, "Passed an out-of-range node index (%d) to CTEXT!", n);
 	if ( n < 0 || n >= Num_sexp_nodes ) {
-		return "!INVALID!";
+		// we should make CTEXT return const char*, but that's for another PR
+		return const_cast<char*>("!INVALID!");
 	}
 
 	// Goober5000 - MWAHAHAHAHAHAHAHA!  Thank you, Volition programmers!  Without

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -13364,8 +13364,6 @@ void sexp_nebula_toggle_poof(int n)
 	bool result = is_sexp_true(CDR(n));
 	int i;
 
-	if (name == NULL) return;
-
 	for (i = 0; i < MAX_NEB2_POOFS; i++)
 	{
 		if (!stricmp(name,Neb2_poof_filenames[i]))
@@ -14826,7 +14824,6 @@ int sexp_event_status( int n, int want_true )
 	int i, result;
 
 	name = CTEXT(n);
-	Assertion(name != nullptr, "CTEXT returned NULL for node %d!", n);
 
 	for (i = 0; i < Num_mission_events; i++ ) {
 		// look for the event name, check it's status.  If formula is gone, we know the state won't ever change.
@@ -14865,7 +14862,6 @@ int sexp_event_delay_status( int n, int want_true, bool use_msecs = false)
 	bool use_as_directive = false;
 
 	name = CTEXT(n);
-	Assertion(name != nullptr, "CTEXT returned NULL for node %d!", n);
 
 	if (use_msecs) {
 		uint64_t tempDelay = eval_num(CDR(n), is_nan, is_nan_forever);
@@ -14940,7 +14936,6 @@ int sexp_event_incomplete(int n)
 	int i;
 
 	name = CTEXT(n);
-	Assertion(name != nullptr, "CTEXT returned NULL for node %d!", n);
 	
 	for (i = 0; i < Num_mission_events; i++ ) {
 		if ( !stricmp(Mission_events[i].name, name ) ) {
@@ -15378,29 +15373,27 @@ void sexp_ship_subsys_guardian_threshold(int node)
 		// check for HULL
 		hull_name = CTEXT(n);
 
-		if (hull_name != NULL) {
-			int generic_type = get_generic_subsys(hull_name);
-			if ( !strcmp(hull_name, SEXP_HULL_STRING) ) {
-				Ships[ship_num].ship_guardian_threshold = threshold;
-			}
-			else if (generic_type) {
-				// search through all subsystems
-				for (ss = GET_FIRST(&Ships[ship_num].subsys_list); ss != END_OF_LIST(&Ships[ship_num].subsys_list); ss = GET_NEXT(ss)) {
-					if (generic_type == ss->system_info->type) {
-						ss->subsys_guardian_threshold = threshold;
-					}
-				}
-			}				
-			else {
-				ss = ship_get_subsys(&Ships[ship_num], hull_name);
-				if ( ss == NULL ) {
-					if (ship_class_unchanged(ship_num)) {
-						Warning(LOCATION, "Invalid subsystem passed to ship-subsys-guardian-threshold: %s does not have a %s subsystem", ship_name, hull_name);
-					}
-				} 
-				else {
+		int generic_type = get_generic_subsys(hull_name);
+		if ( !strcmp(hull_name, SEXP_HULL_STRING) ) {
+			Ships[ship_num].ship_guardian_threshold = threshold;
+		}
+		else if (generic_type) {
+			// search through all subsystems
+			for (ss = GET_FIRST(&Ships[ship_num].subsys_list); ss != END_OF_LIST(&Ships[ship_num].subsys_list); ss = GET_NEXT(ss)) {
+				if (generic_type == ss->system_info->type) {
 					ss->subsys_guardian_threshold = threshold;
 				}
+			}
+		}				
+		else {
+			ss = ship_get_subsys(&Ships[ship_num], hull_name);
+			if ( ss == NULL ) {
+				if (ship_class_unchanged(ship_num)) {
+					Warning(LOCATION, "Invalid subsystem passed to ship-subsys-guardian-threshold: %s does not have a %s subsystem", ship_name, hull_name);
+				}
+			} 
+			else {
+				ss->subsys_guardian_threshold = threshold;
 			}
 		}
 	}
@@ -30089,8 +30082,8 @@ char *CTEXT(int n)
 	char *current_argument; 
 
 	Assertion(n >= 0 && n < Num_sexp_nodes, "Passed an out-of-range node index (%d) to CTEXT!", n);
-	if ( n < 0 ) {
-		return NULL;
+	if ( n < 0 || n >= Num_sexp_nodes ) {
+		return "!INVALID!";
 	}
 
 	// Goober5000 - MWAHAHAHAHAHAHAHA!  Thank you, Volition programmers!  Without

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -30084,7 +30084,7 @@ char *CTEXT(int n)
 	Assertion(n >= 0 && n < Num_sexp_nodes, "Passed an out-of-range node index (%d) to CTEXT!", n);
 	if ( n < 0 || n >= Num_sexp_nodes ) {
 		// we should make CTEXT return const char*, but that's for another PR
-		return const_cast<char*>("!INVALID!");
+		return const_cast<char*>("!INVALID CTEXT NODE INDEX!");
 	}
 
 	// Goober5000 - MWAHAHAHAHAHAHAHA!  Thank you, Volition programmers!  Without

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -13662,6 +13662,8 @@ void sexp_tech_add_intel(int node, boolean xstr)
 			id = atoi(Sexp_nodes[n].text);
 			n = CDR(n);
 		}
+		else
+			id = -1;
 
 		// if we have an xstr, we already translated this node in the preloader, so just look it up
 		i = intel_info_lookup(name);

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -222,7 +222,7 @@ SCP_vector<sexp_oper> Operators = {
 
 	//Player Sub-Category
 	{ "was-promotion-granted",			OP_WAS_PROMOTION_GRANTED,				0,	1,			SEXP_BOOLEAN_OPERATOR,	},
-	{ "was-medal-granted",				OP_WAS_MEDAL_GRANTED,					0,	2,			SEXP_BOOLEAN_OPERATOR,	},
+	{ "was-medal-granted",				OP_WAS_MEDAL_GRANTED,					0,	1,			SEXP_BOOLEAN_OPERATOR,	},
 	{ "skill-level-at-least",			OP_SKILL_LEVEL_AT_LEAST,				1,	1,			SEXP_BOOLEAN_OPERATOR,	},
 	{ "num_kills",						OP_NUM_KILLS,							1,	1,			SEXP_INTEGER_OPERATOR,	},
 	{ "num_assists",					OP_NUM_ASSISTS,							1,	1,			SEXP_INTEGER_OPERATOR,	},
@@ -557,7 +557,7 @@ SCP_vector<sexp_oper> Operators = {
 	{ "set-debriefing-toggled",			OP_SET_DEBRIEFING_TOGGLED,				1,	1,			SEXP_ACTION_OPERATOR,	},	// Goober5000
 	{ "allow-treason",					OP_ALLOW_TREASON,						1,	1,			SEXP_ACTION_OPERATOR,	},	// Karajorma
 	{ "grant-promotion",				OP_GRANT_PROMOTION,						0,	0,			SEXP_ACTION_OPERATOR,	},
-	{ "grant-medal",					OP_GRANT_MEDAL,							1,	2,			SEXP_ACTION_OPERATOR,	},
+	{ "grant-medal",					OP_GRANT_MEDAL,							1,	1,			SEXP_ACTION_OPERATOR,	},
 	{ "allow-ship",						OP_ALLOW_SHIP,							1,	1,			SEXP_ACTION_OPERATOR,	},
 	{ "allow-weapon",					OP_ALLOW_WEAPON,						1,	1,			SEXP_ACTION_OPERATOR,	},
 	{ "tech-add-ships",					OP_TECH_ADD_SHIP,						1,	INT_MAX,	SEXP_ACTION_OPERATOR,	},
@@ -3617,13 +3617,6 @@ int get_sexp()
 					localize_sexp(n, CDR(n));
 					n = CDDR(n);
 				}
-				break;
-
-			case OP_GRANT_MEDAL:
-			case OP_WAS_MEDAL_GRANTED:
-				// do XSTR translation if we have an XSTR id
-				n = CDR(start);
-				localize_sexp(n, CDR(n));
 				break;
 
 			case OP_MODIFY_VARIABLE_XSTR:
@@ -8175,7 +8168,7 @@ int sexp_was_medal_granted(int n)
 		return SEXP_FALSE;
 	}
 
-	medal_name = Sexp_nodes[n].text;
+	medal_name = CTEXT(n);
 
 	for (i=0; i<Num_medals; i++) {
 		if (!stricmp(medal_name, Medals[i].name))
@@ -13498,7 +13491,7 @@ void sexp_grant_medal(int n)
 	if ( (Game_mode & GM_NORMAL) && !(Game_mode & GM_CAMPAIGN_MODE) )
 		return;
 
-	medal_name = Sexp_nodes[n].text;
+	medal_name = CTEXT(n);
 
 	if (Player->stats.m_medal_earned >= 0) {
 		Warning(LOCATION, "Cannot grant more than one medal per mission!  New medal '%s' will replace old medal '%s'!", medal_name, Medals[Player->stats.m_medal_earned].name);
@@ -13638,7 +13631,7 @@ void sexp_tech_add_weapon(int node)
 }
 
 // Goober5000
-void sexp_tech_add_intel(int node, boolean xstr)
+void sexp_tech_add_intel(int node, bool xstr)
 {
 	int i, id, n = node;
 	char *name;
@@ -28478,7 +28471,7 @@ int query_operator_argument_type(int op, int argnum)
 
 		case OP_GRANT_MEDAL:
 		case OP_WAS_MEDAL_GRANTED:
-			return (argnum == 0) ? OPF_MEDAL_NAME : OPF_NUMBER;
+			return OPF_MEDAL_NAME;
 
 		case OP_IS_CARGO_KNOWN:
 			return OPF_SHIP;
@@ -33098,9 +33091,8 @@ SCP_vector<sexp_help_struct> Sexp_help = {
 	{ OP_GRANT_MEDAL, "Grant medal (Action operator)\r\n"
 		"\tIn single player missions, this function grants the given medal to the player.  "
 		"Currently, only 1 medal will be allowed to be given per mission.\r\n\r\n"
-		"Takes 1 or 2 arguments...\r\n"
-		"\t1:\tName of medal to grant to player.\r\n"
-		"\t2:\tXSTR ID of medal name, or -1 if there is no XSTR entry (optional).\r\n" },
+		"Takes 1 argument...\r\n"
+		"\t1:\tName of medal to grant to player." },
 
 	{ OP_GOOD_SECONDARY_TIME, "Set preferred secondary weapons\r\n"
 		"\tThis sexpression is used to inform the AI about preferred secondary weapons to "
@@ -33168,9 +33160,8 @@ SCP_vector<sexp_help_struct> Sexp_help = {
 		"\tReturns true if a medal was granted via via the 'Grant medal' operator in the mission.  "
 		"If you provide the optional argument to this operator, then true is only returned if the "
 		"specified medal was granted.\r\n\r\n"
-		"Returns a boolean value.  Takes 0-2 arguments...\r\n"
-		"\t1:\tName of medal to specifically check for (optional).\r\n"
-		"\t2:\tXSTR ID of medal name, or -1 if there is no XSTR entry (optional).\r\n" },
+		"Returns a boolean value.  Takes 0 or 1 arguments...\r\n"
+		"\t1:\tName of medal to specifically check for (optional)." },
 
 	{ OP_GOOD_REARM_TIME, "Good rearm time (Action operator)\r\n"
 		"\tInforms the game logic that right now is a good time for a given team to attempt to "

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -13491,8 +13491,7 @@ void sexp_grant_promotion()
  */
 void sexp_grant_medal(int n)
 {
-	int i, id = -1;
-	bool xstr = false;
+	int i;
 	char *medal_name;
 
 	// don't give medals in normal gameplay when not in campaign mode

--- a/fred2/sexp_tree.cpp
+++ b/fred2/sexp_tree.cpp
@@ -2408,6 +2408,13 @@ int sexp_tree::get_default_value(sexp_list_item *item, char *text_buf, int op, i
 				else
 					item->set_data("<any data>", (SEXPT_STRING | SEXPT_VALID));
 			}
+			else if ((Operators[op].value == OP_MODIFY_VARIABLE_XSTR))
+			{
+				if (i == 1)
+					item->set_data("<any data>", (SEXPT_STRING | SEXPT_VALID));
+				else
+					item->set_data("-1", (SEXPT_NUMBER | SEXPT_VALID));
+			}
 			else if ((Operators[op].value == OP_SET_VARIABLE_BY_INDEX))
 			{
 				if (i == 0)
@@ -2419,7 +2426,7 @@ int sexp_tree::get_default_value(sexp_list_item *item, char *text_buf, int op, i
 			{
 				item->set_data("25", (SEXPT_NUMBER | SEXPT_VALID));
 			}
-			else if (Operators[op].value == OP_MODIFY_VARIABLE_XSTR)
+			else if ( (Operators[op].value == OP_TECH_ADD_INTEL_XSTR) || (Operators[op].value == OP_GRANT_MEDAL) || (Operators[op].value == OP_WAS_MEDAL_GRANTED) )
 			{
 				item->set_data("-1", (SEXPT_NUMBER | SEXPT_VALID));
 			}

--- a/fred2/sexp_tree.cpp
+++ b/fred2/sexp_tree.cpp
@@ -2298,11 +2298,11 @@ int sexp_tree::get_default_value(sexp_list_item *item, char *text_buf, int op, i
 			{
 				item->set_data("1", (SEXPT_NUMBER | SEXPT_VALID));
 			}
-			else if ( (Operators[op].value == OP_SHIP_TYPE_DESTROYED) || (Operators[op].value == OP_GOOD_SECONDARY_TIME) )
+			else if ((Operators[op].value == OP_SHIP_TYPE_DESTROYED) || (Operators[op].value == OP_GOOD_SECONDARY_TIME))
 			{
 				item->set_data("100", (SEXPT_NUMBER | SEXPT_VALID));
 			}
-			else if ( (Operators[op].value == OP_SET_SUPPORT_SHIP) )
+			else if (Operators[op].value == OP_SET_SUPPORT_SHIP)
 			{
 				item->set_data("-1", (SEXPT_NUMBER | SEXPT_VALID));
 			}
@@ -2310,7 +2310,7 @@ int sexp_tree::get_default_value(sexp_list_item *item, char *text_buf, int op, i
 			{
 				item->set_data("1", (SEXPT_NUMBER | SEXPT_VALID));
 			}
-			else if ( (Operators[op].value == OP_EXPLOSION_EFFECT) )
+			else if (Operators[op].value == OP_EXPLOSION_EFFECT)
 			{
 				int temp;
 				char sexp_str_token[TOKEN_LENGTH];
@@ -2347,7 +2347,7 @@ int sexp_tree::get_default_value(sexp_list_item *item, char *text_buf, int op, i
 				sprintf(sexp_str_token, "%d", temp);
 				item->set_data_dup(sexp_str_token, (SEXPT_NUMBER | SEXPT_VALID));
 			}
-			else if ( (Operators[op].value == OP_WARP_EFFECT) )
+			else if (Operators[op].value == OP_WARP_EFFECT)
 			{
 				int temp;
 				char sexp_str_token[TOKEN_LENGTH];
@@ -2369,7 +2369,7 @@ int sexp_tree::get_default_value(sexp_list_item *item, char *text_buf, int op, i
 				sprintf(sexp_str_token, "%d", temp);
 				item->set_data_dup(sexp_str_token, (SEXPT_NUMBER | SEXPT_VALID));
 			}
-			else if ((Operators[op].value == OP_ADD_BACKGROUND_BITMAP))
+			else if (Operators[op].value == OP_ADD_BACKGROUND_BITMAP)
 			{
 				int temp = 0;
 				char sexp_str_token[TOKEN_LENGTH];
@@ -2390,7 +2390,7 @@ int sexp_tree::get_default_value(sexp_list_item *item, char *text_buf, int op, i
 				sprintf(sexp_str_token, "%d", temp);
 				item->set_data_dup(sexp_str_token, (SEXPT_NUMBER | SEXPT_VALID));
 			}
-			else if ((Operators[op].value == OP_ADD_SUN_BITMAP))
+			else if (Operators[op].value == OP_ADD_SUN_BITMAP)
 			{
 				int temp = 0;
 				char sexp_str_token[TOKEN_LENGTH];
@@ -2401,21 +2401,21 @@ int sexp_tree::get_default_value(sexp_list_item *item, char *text_buf, int op, i
 				sprintf(sexp_str_token, "%d", temp);
 				item->set_data_dup(sexp_str_token, (SEXPT_NUMBER | SEXPT_VALID));
 			}
-			else if ((Operators[op].value == OP_MODIFY_VARIABLE))
+			else if (Operators[op].value == OP_MODIFY_VARIABLE)
 			{
 				if (get_modify_variable_type(index) == OPF_NUMBER)
 					item->set_data("0", (SEXPT_NUMBER | SEXPT_VALID));
 				else
 					item->set_data("<any data>", (SEXPT_STRING | SEXPT_VALID));
 			}
-			else if ((Operators[op].value == OP_MODIFY_VARIABLE_XSTR))
+			else if (Operators[op].value == OP_MODIFY_VARIABLE_XSTR)
 			{
 				if (i == 1)
 					item->set_data("<any data>", (SEXPT_STRING | SEXPT_VALID));
 				else
 					item->set_data("-1", (SEXPT_NUMBER | SEXPT_VALID));
 			}
-			else if ((Operators[op].value == OP_SET_VARIABLE_BY_INDEX))
+			else if (Operators[op].value == OP_SET_VARIABLE_BY_INDEX)
 			{
 				if (i == 0)
 					item->set_data("0", (SEXPT_NUMBER | SEXPT_VALID));

--- a/fred2/sexp_tree.cpp
+++ b/fred2/sexp_tree.cpp
@@ -2426,7 +2426,7 @@ int sexp_tree::get_default_value(sexp_list_item *item, char *text_buf, int op, i
 			{
 				item->set_data("25", (SEXPT_NUMBER | SEXPT_VALID));
 			}
-			else if ( (Operators[op].value == OP_TECH_ADD_INTEL_XSTR) || (Operators[op].value == OP_GRANT_MEDAL) || (Operators[op].value == OP_WAS_MEDAL_GRANTED) )
+			else if (Operators[op].value == OP_TECH_ADD_INTEL_XSTR)
 			{
 				item->set_data("-1", (SEXPT_NUMBER | SEXPT_VALID));
 			}

--- a/qtfred/src/ui/widgets/sexp_tree.cpp
+++ b/qtfred/src/ui/widgets/sexp_tree.cpp
@@ -1115,6 +1115,12 @@ int sexp_tree::get_default_value(sexp_list_item* item, char* text_buf, int op, i
 			} else {
 				item->set_data("<any data>", (SEXPT_STRING | SEXPT_VALID));
 			}
+		} else if (Operators[op].value == OP_MODIFY_VARIABLE_XSTR) {
+			if (i == 1) {
+				item->set_data("<any data>", (SEXPT_STRING | SEXPT_VALID));
+			} else {
+				item->set_data("-1", (SEXPT_NUMBER | SEXPT_VALID));
+			}
 		} else if (Operators[op].value == OP_SET_VARIABLE_BY_INDEX) {
 			if (i == 0) {
 				item->set_data("0", (SEXPT_NUMBER | SEXPT_VALID));
@@ -1123,7 +1129,7 @@ int sexp_tree::get_default_value(sexp_list_item* item, char* text_buf, int op, i
 			}
 		} else if (Operators[op].value == OP_JETTISON_CARGO_NEW) {
 			item->set_data("25", (SEXPT_NUMBER | SEXPT_VALID));
-		} else if (Operators[op].value == OP_MODIFY_VARIABLE_XSTR) {
+		} else if ((Operators[op].value == OP_TECH_ADD_INTEL_XSTR) || (Operators[op].value == OP_GRANT_MEDAL) || (Operators[op].value == OP_WAS_MEDAL_GRANTED)) {
 			item->set_data("-1", (SEXPT_NUMBER | SEXPT_VALID));
 		} else {
 			item->set_data("0", (SEXPT_NUMBER | SEXPT_VALID));

--- a/qtfred/src/ui/widgets/sexp_tree.cpp
+++ b/qtfred/src/ui/widgets/sexp_tree.cpp
@@ -1129,7 +1129,7 @@ int sexp_tree::get_default_value(sexp_list_item* item, char* text_buf, int op, i
 			}
 		} else if (Operators[op].value == OP_JETTISON_CARGO_NEW) {
 			item->set_data("25", (SEXPT_NUMBER | SEXPT_VALID));
-		} else if ((Operators[op].value == OP_TECH_ADD_INTEL_XSTR) || (Operators[op].value == OP_GRANT_MEDAL) || (Operators[op].value == OP_WAS_MEDAL_GRANTED)) {
+		} else if (Operators[op].value == OP_TECH_ADD_INTEL_XSTR) {
 			item->set_data("-1", (SEXPT_NUMBER | SEXPT_VALID));
 		} else {
 			item->set_data("0", (SEXPT_NUMBER | SEXPT_VALID));


### PR DESCRIPTION
~~The grant-medal and was-medal-granted sexps will now translate medal names, in the same way that tech-add-intel-xstr translates intel entries.  There is also some minor cleanup and the specifying of correct default -1 numbers for the xstr-capable sexps.~~

~~This fixes #1285.~~

With Novachen's comment, this PR drops the modifications to `grant-medal` and `was-medal-granted`, and just does some cleanup with XSTR and CTEXT.