### PR TITLE
Only update arrival/departure location if ship is not part of a wing

### DIFF
--- a/fred2/missionsave.cpp
+++ b/fred2/missionsave.cpp
@@ -2932,6 +2932,10 @@ int CFred_mission_save::save_objects() {
 		convert_sexp_to_string(sexp_out, shipp->arrival_cue, SEXP_SAVE_MODE);
 		fout(" %s", sexp_out.c_str());
 
+		if (shipp->wingnum >= 0) {
+			shipp->departure_location = DEPART_AT_LOCATION;
+		}
+
 		required_string_fred("$Departure Location:");
 		parse_comments();
 		fout(" %s", Departure_location_names[shipp->departure_location]);

--- a/fred2/shipeditordlg.cpp
+++ b/fred2/shipeditordlg.cpp
@@ -1300,11 +1300,6 @@ int CShipEditorDlg::update_ship(int ship)
 		}
 	}
 
-	if (m_arrival_location != -1)
-		MODIFY(Ships[ship].arrival_location, m_arrival_location);
-	if (m_departure_location != -1)
-		MODIFY(Ships[ship].departure_location, m_departure_location);
-
 	if (m_persona != -1)
 	{
 		// do the persona update
@@ -1319,6 +1314,12 @@ int CShipEditorDlg::update_ship(int ship)
 	}
 
 	if (Ships[ship].wingnum < 0) {
+
+		if (m_arrival_location != -1)
+			MODIFY(Ships[ship].arrival_location, m_arrival_location);
+		if (m_departure_location != -1)
+			MODIFY(Ships[ship].departure_location, m_departure_location);
+
 		if (!multi_edit || m_update_arrival) {  // should we update the arrival cue?
 			if (Ships[ship].arrival_cue >= 0)
 				free_sexp2(Ships[ship].arrival_cue);

--- a/qtfred/src/mission/missionsave.cpp
+++ b/qtfred/src/mission/missionsave.cpp
@@ -2786,6 +2786,10 @@ int CFred_mission_save::save_objects() {
 		convert_sexp_to_string(sexp_out, shipp->arrival_cue, SEXP_SAVE_MODE);
 		fout(" %s", sexp_out.c_str());
 
+		if (shipp->wingnum >= 0) {
+			shipp->departure_location = DEPART_AT_LOCATION;
+		}
+
 		required_string_fred("$Departure Location:");
 		parse_comments();
 		fout(" %s", Departure_location_names[shipp->departure_location]);


### PR DESCRIPTION
Replacement PR for #595.  This consists of @downwash's changes plus @MageKing17's suggestion to add the departure cue check on mission save. 

This should also fix Mantis 2869.