### PR TITLE
Mantis 1826 - Sending Packet Updates for Campaigns

### DIFF
--- a/code/mission/missioncampaign.cpp
+++ b/code/mission/missioncampaign.cpp
@@ -97,7 +97,7 @@ campaign Campaign;
  * In the type field, we return if the campaign is a single player or multiplayer campaign.  
  * The type field will only be valid if the name returned is non-NULL
  */
-int mission_campaign_get_info(const char *filename, char *name, int *type, int *max_players, char **desc)
+int mission_campaign_get_info(const char *filename, char *name, int *type, int *max_players, char **desc, char **first_mission)
 {
 	int i, success = 0;
 	char campaign_type[NAME_LENGTH], fname[MAX_FILENAME_LEN];
@@ -154,6 +154,11 @@ int mission_campaign_get_info(const char *filename, char *name, int *type, int *
 			if ((*type) != CAMPAIGN_TYPE_SINGLE) {
 				skip_to_string("+Num Players:");
 				stuff_int(max_players);
+				// Cyborg17 - and the first mission name if we want it, too
+				if (first_mission) {
+					skip_to_string("$Mission:");
+					*first_mission = stuff_and_malloc_string(F_NAME, nullptr);
+				}
 			}
 
 			// if we found a valid campaign type

--- a/code/mission/missioncampaign.h
+++ b/code/mission/missioncampaign.h
@@ -206,7 +206,7 @@ void mission_campaign_savefile_generate_root(char *filename, player *pl = NULL);
 // execute the corresponding mission_campaign_savefile functions.
 
 // get name and type of specified campaign file
-int mission_campaign_get_info(const char *filename, char *name, int *type, int *max_players, char **desc = NULL);
+int mission_campaign_get_info(const char *filename, char *name, int *type, int *max_players, char **desc = nullptr, char **first_mission = nullptr);
 
 // get a listing of missions in a campaign
 int mission_campaign_get_mission_list(const char *filename, char **list, int max);

--- a/code/network/multi.h
+++ b/code/network/multi.h
@@ -89,6 +89,8 @@ class player;
 #define MAX_GAMENAME_LEN					32				// maximum length in characters of a game name
 #define DESCRIPT_LENGTH						512			// maximum length of a mission description (as specified by Fred)
 #define MAX_PASSWD_LEN						16				// maximum length of the password for a netgame
+#define MAX_PACKET_DESC_LEN		MAX_PACKET_SIZE - 12	// the maximum description length that can be sent in a packet
+#define MAX_TOTAL_DESC_LEN		2*(MAX_PACKET_DESC_LEN) // the maximum that the desciption packet will be able to send period. 
 
 // low level networking defines
 #define IP_ADDRESS_LENGTH					4				// length of the address field for an IP address
@@ -366,21 +368,6 @@ class player;
 
 #define MAX_SHIPS_PER_PACKET		64			// Number of ships in a STATS_MISSION_KILLS or STATS_ALLTIME_KILLS packet
 
-// campaign and mission description packet post-header type info
-#define DESCRIPT_MESSAGE_REQUEST	(1 << 0)
-#define DESCRIPT_PACKET_CAMPAIGN_MESSAGE_1	(1 << 1)
-#define DESCRIPT_PACKET_CAMPAIGN_MESSAGE_2	(1 << 2)
-#define DESCRIPT_PACKET_MISSION_MESSAGE_1	(1 << 3)
-#define DESCRIPT_PACKET_MISSION_MESSAGE_2	(1 << 4)
-#define DESCRIPT_PACKET_NO_ADDENDUM			(1 << 5)
-#define DESCRIPT_PACKET_FINAL_MESSAGE		(1 << 6)
-
-#define MULTI_MAX_DESC_LEN			2*(MAX_PACKET_SIZE - 10)
-
-const char PRE_CAMPAIGN_DESC[23] =	"Campaign Description:\n";
-const char PRE_MISSION_DESC[28]  =	"First Mission:\n";
-const char DOUBLE_NEW_LINE[3]    =  "\n\n";
-
 // ----------------------------------------------------------------------------------------
 
 
@@ -497,8 +484,8 @@ typedef struct netgame_info {
 	char		title[NAME_LENGTH+1];			// title of the mission (as appears in the mission file)
 	char		campaign_name[NAME_LENGTH+1];	// current campaign name	
 	char		passwd[MAX_PASSWD_LEN+1];		// password for the game
-	char		mission_desc[MULTI_MAX_DESC_LEN];      // Cyborg17 - Description of the current mission.
-	char		campaign_desc[MULTI_MAX_DESC_LEN];     // Cyborg17 - Description of the current campaign.
+	char		mission_desc[MAX_TOTAL_DESC_LEN];      // Cyborg17 - Description of the current mission.
+	char		campaign_desc[MAX_TOTAL_DESC_LEN];     // Cyborg17 - Description of the current campaign.
 	int		version_info;						// version info for this game.
 	int		type_flags;							// see NG_TYPE_* defines
 	int		mode;									// see NG_MODE_* defines

--- a/code/network/multi.h
+++ b/code/network/multi.h
@@ -257,7 +257,7 @@ class player;
 #define NETPLAYER_UPDATE			0xE4		// a player update packet
 #define OBJECT_UPDATE				0xE6		// an object update packet from server to all clients
 #define MISSION_LOG_ENTRY			0xE7		// ad an item into the mission log
-#define UPDATE_DESCRIPT				0xE8		// update the netgame description
+#define UPDATE_DESCRIPT				0xE8		// update the netgame description -- Cyborg17, Now updated for multiple description packets
 #define COUNTDOWN						0xE9		// countdown timer for starting a game (pretty benign)
 #define DEBRIEF_INFO					0xEA		// end of mission debriefing information
 #define EMP_EFFECT					0xEB		// EMP effect (mission disk only)
@@ -365,6 +365,21 @@ class player;
 #define STATS_ALLTIME_KILLS			5			// alltime kills, for one player
 
 #define MAX_SHIPS_PER_PACKET		64			// Number of ships in a STATS_MISSION_KILLS or STATS_ALLTIME_KILLS packet
+
+// campaign and mission description packet post-header type info
+#define DESCRIPT_MESSAGE_REQUEST	(1 << 0)
+#define DESCRIPT_PACKET_CAMPAIGN_MESSAGE_1	(1 << 1)
+#define DESCRIPT_PACKET_CAMPAIGN_MESSAGE_2	(1 << 2)
+#define DESCRIPT_PACKET_MISSION_MESSAGE_1	(1 << 3)
+#define DESCRIPT_PACKET_MISSION_MESSAGE_2	(1 << 4)
+#define DESCRIPT_PACKET_NO_ADDENDUM			(1 << 5)
+#define DESCRIPT_PACKET_FINAL_MESSAGE		(1 << 6)
+
+#define MULTI_MAX_DESC_LEN			2*(MAX_PACKET_SIZE - 10)
+
+const char PRE_CAMPAIGN_DESC[23] =	"Campaign Description:\n";
+const char PRE_MISSION_DESC[28]  =	"First Mission:\n";
+const char DOUBLE_NEW_LINE[3]    =  "\n\n";
 
 // ----------------------------------------------------------------------------------------
 
@@ -482,6 +497,8 @@ typedef struct netgame_info {
 	char		title[NAME_LENGTH+1];			// title of the mission (as appears in the mission file)
 	char		campaign_name[NAME_LENGTH+1];	// current campaign name	
 	char		passwd[MAX_PASSWD_LEN+1];		// password for the game
+	char		mission_desc[MULTI_MAX_DESC_LEN];      // Cyborg17 - Description of the current mission.
+	char		campaign_desc[MULTI_MAX_DESC_LEN];     // Cyborg17 - Description of the current campaign.
 	int		version_info;						// version info for this game.
 	int		type_flags;							// see NG_TYPE_* defines
 	int		mode;									// see NG_MODE_* defines

--- a/code/network/multimsgs.cpp
+++ b/code/network/multimsgs.cpp
@@ -2207,7 +2207,7 @@ void send_netgame_descript_packet(net_addr *addr, int code, bool campaign, bool 
 				strcat_s(message, "No campaign description.");
 				packet_type |= DESCRIPT_PACKET_CAMPAIGN_MESSAGE_1;
 			}			// subtract because of the text that marks this as a campaign description.
-			else if (!addendum && desc_len > (MAX_PACKET_DESC_LEN - strlen(PRE_CAMPAIGN_DESC))) {
+			else if (!addendum && desc_len > (int)(MAX_PACKET_DESC_LEN - strlen(PRE_CAMPAIGN_DESC))) {
 				// if we are going to need to recurse....
 				second_packet_needed = true;
 				desc_len = MAX_PACKET_DESC_LEN;
@@ -2254,7 +2254,7 @@ void send_netgame_descript_packet(net_addr *addr, int code, bool campaign, bool 
 				strcat_s(message, "No mission description.");
 				packet_type |= DESCRIPT_PACKET_MISSION_MESSAGE_1;
 			} // Not already an additonal portion, but too long for one packet.
-			else if (!addendum && desc_len > MAX_PACKET_DESC_LEN - strlen(PRE_MISSION_DESC)) {
+			else if (!addendum && desc_len > (int)(MAX_PACKET_DESC_LEN - strlen(PRE_MISSION_DESC))) {
 
 				// if we are going to need to recurse....
 				second_packet_needed = true;

--- a/code/network/multimsgs.cpp
+++ b/code/network/multimsgs.cpp
@@ -2171,7 +2171,7 @@ void process_netgame_update_packet( ubyte *data, header *hinfo )
 // Cyborg17 - Now recursive for longer descriptions! Original call needs to check if this is a campaign first. 
 // Message order is Campaign desc 1, Opt. Campaign addendum, Mission desc 1, then Opt. mission desc addendum
 // Single missions will skip straight to Mission desc 1.
-void send_netgame_descript_packet(net_addr *addr, int code, bool campaign, bool addendum, ubyte message_count)
+void send_netgame_descript_packet(net_addr *addr, int code, int campaign, bool addendum, ubyte message_count)
 {
 	// Get this out of the way, because we don't want to waste our time if the addr is bad.
 	Assert(addr != nullptr);
@@ -2194,7 +2194,7 @@ void send_netgame_descript_packet(net_addr *addr, int code, bool campaign, bool 
 		memset(message, 0, MAX_PACKET_DESC_LEN);
 		memset(temp, 0, 2 * MAX_PACKET_DESC_LEN);
 		
-		if (campaign) {
+		if (campaign == 1) {
 			// bitwise assignment to save bandwidth
 			strcpy_s(temp, Netgame.campaign_desc);
 
@@ -2310,14 +2310,15 @@ void send_netgame_descript_packet(net_addr *addr, int code, bool campaign, bool 
 		psnet_send(addr, data, packet_size);
 
 		// now that we've sent one of them, recurse if needed
-		if (campaign) {
+		if (campaign == 1) {
 			if (second_packet_needed) {
 				// we would either need to send the second campaign packet
 				addendum = true;
 				send_netgame_descript_packet(addr, code, campaign, addendum, ++message_count);
 			} else {
 				// or the first *mission* packet
-				campaign = addendum = false;
+				addendum = false;
+				campaign = 0;
 				send_netgame_descript_packet(addr, code, campaign, addendum, ++message_count);
 			}
 		} else if (second_packet_needed) {

--- a/code/network/multimsgs.h
+++ b/code/network/multimsgs.h
@@ -290,7 +290,7 @@ void send_player_order_packet(int type, int index, int command);
 
 // send a request or a reply for mission description, if code == 0, request, if code == 1, reply
 // campaign is true when there is a campaign, and addendum is true when we send a second desc packet
-void send_netgame_descript_packet(net_addr *addr, int code, bool campaign, bool addendum = false, ubyte message_count = 0);
+void send_netgame_descript_packet(net_addr *addr, int code, int campaign, bool addendum = false, ubyte message_count = 0);
 
 // send object update packet sends object updates for all objects in the game.  This function will be smart
 // about sending only certain objects to certain players based on the players distance from an object, whether

--- a/code/network/multimsgs.h
+++ b/code/network/multimsgs.h
@@ -278,7 +278,8 @@ void send_ship_status_packet(net_player *pl, button_info *bi, int id);
 void send_player_order_packet(int type, int index, int command);
 
 // send a request or a reply for mission description, if code == 0, request, if code == 1, reply
-void send_netgame_descript_packet(net_addr *addr, int code);
+// campaign is true when there is a campaign, and addendum is true when we send a second desc packet
+void send_netgame_descript_packet(net_addr *addr, int code, bool campaign, bool addendum = false, ubyte message_count = 0);
 
 // send object update packet sends object updates for all objects in the game.  This function will be smart
 // about sending only certain objects to certain players based on the players distance from an object, whether

--- a/code/network/multimsgs.h
+++ b/code/network/multimsgs.h
@@ -63,6 +63,17 @@ struct log_entry;
 #define MULTI_PRIMARY_CHANGED		1
 #define MULTI_SECONDARY_CHANGED	2
 
+// campaign and mission description packet post-header type info
+#define DESCRIPT_MESSAGE_REQUEST			(1 << 0)
+#define DESCRIPT_PACKET_CAMPAIGN_MESSAGE_1	(1 << 1)
+#define DESCRIPT_PACKET_CAMPAIGN_MESSAGE_2	(1 << 2)
+#define DESCRIPT_PACKET_MISSION_MESSAGE_1	(1 << 3)
+#define DESCRIPT_PACKET_MISSION_MESSAGE_2	(1 << 4)
+
+extern const char* PRE_CAMPAIGN_DESC;
+extern const char* PRE_MISSION_DESC;
+extern const char* DOUBLE_NEW_LINE;
+
 // data sending wrappers
 
 // send the specified data packet to all players

--- a/code/network/multiui.cpp
+++ b/code/network/multiui.cpp
@@ -105,6 +105,11 @@ const int MULTI_PING_MIN_ONE_SECOND = 1000;
 #define MULTI_COMMON_TEXT_MAX_LINES				20
 #define MULTI_COMMON_MAX_TEXT						(MULTI_COMMON_TEXT_MAX_LINES * MULTI_COMMON_TEXT_MAX_LINE_LENGTH)
 
+// Pre written mission/campaign description labels when both are on the screen.
+extern const char* PRE_CAMPAIGN_DESC;
+extern const char* PRE_MISSION_DESC;
+extern const char* DOUBLE_NEW_LINE;
+
 char Multi_common_all_text[MULTI_COMMON_MAX_TEXT];
 char Multi_common_text[MULTI_COMMON_TEXT_MAX_LINES][MULTI_COMMON_TEXT_MAX_LINE_LENGTH];
 char Multi_received_mission_description1[MAX_PACKET_SIZE];
@@ -220,19 +225,15 @@ void multi_mission_desciption_set(const char* str_in, int code, int index)
 
 	// now set whatever we've received.
 	if (code & DESCRIPT_PACKET_CAMPAIGN_MESSAGE_1) {
-		memset(Multi_received_mission_description1, 0, MAX_PACKET_SIZE);
 		strcpy_s(Multi_received_mission_description1, str_in);
 	}
 	else if (code & DESCRIPT_PACKET_CAMPAIGN_MESSAGE_2) {
-		memset(Multi_received_mission_description2, 0, MAX_PACKET_SIZE);
 		strcpy_s(Multi_received_mission_description2, str_in);
 	}
 	else if (code & DESCRIPT_PACKET_MISSION_MESSAGE_1) {
-		memset(Multi_received_mission_description3, 0, MAX_PACKET_SIZE);
 		strcpy_s(Multi_received_mission_description3, str_in);
 	}
 	else if (code & DESCRIPT_PACKET_MISSION_MESSAGE_2) {
-		memset(Multi_received_mission_description4, 0, MAX_PACKET_SIZE);
 		strcpy_s(Multi_received_mission_description4, str_in);
 	}
 
@@ -4844,8 +4845,8 @@ void multi_create_list_select_item(int n)
 		}
 
 		// out with the old, before we start with the new
-		memset(ng->campaign_desc, 0, MULTI_MAX_DESC_LEN);
-		memset(ng->mission_desc, 0, MULTI_MAX_DESC_LEN);
+		memset(ng->campaign_desc, 0, MAX_TOTAL_DESC_LEN);
+		memset(ng->mission_desc, 0, MAX_TOTAL_DESC_LEN);
 
 		switch(Multi_create_list_mode){
 		case MULTI_CREATE_SHOW_MISSIONS:		
@@ -4903,20 +4904,19 @@ void multi_create_list_select_item(int n)
 				//	Cyborg17 - Now that we can have both descriptions, markers in the text are helpful.
 				//  But that means we have a lot of concatenation...
 				char full_text[MULTI_COMMON_MAX_TEXT];				
-				memset(full_text, 0, MULTI_COMMON_MAX_TEXT);
 
 				// We can let the player know that the descption is empty by keeping it empty.
-				strcpy(full_text, PRE_CAMPAIGN_DESC);
+				strcpy_s(full_text, PRE_CAMPAIGN_DESC);
 				if (campaign_desc != nullptr) {
-					strcpy(ng->campaign_desc, campaign_desc);
+					SDL_strlcpy(ng->campaign_desc, campaign_desc, MAX_TOTAL_DESC_LEN);
 					strcat_s(full_text, campaign_desc);
 				}	
 
 				// if we successfully got the mission description.
 				if (!get_mission_info(first_mission, mp, true)) {
 					 if (strlen(mp->mission_desc) > 0) {
-						strcat(full_text, DOUBLE_NEW_LINE);
-						strcat(full_text, PRE_MISSION_DESC);
+						strcat_s(full_text, DOUBLE_NEW_LINE);
+						strcat_s(full_text, PRE_MISSION_DESC);
 						strcat_s(full_text, mp->mission_desc);	
 						strcpy_s(ng->mission_desc, mp->mission_desc);
 						}

--- a/code/network/multiui.cpp
+++ b/code/network/multiui.cpp
@@ -1694,7 +1694,7 @@ void multi_join_process_select()
 			Assert(Multi_join_selected_item != NULL);
 
 			// send a mission description request to this guy
-			send_netgame_descript_packet(&Multi_join_selected_item->server_addr, 0, false);
+			send_netgame_descript_packet(&Multi_join_selected_item->server_addr, 0, 0);
 			multi_common_set_text("");			
 		}		
 	}

--- a/code/network/multiui.h
+++ b/code/network/multiui.h
@@ -22,6 +22,7 @@ struct net_addr;
 
 void multi_common_add_text(const char *txt,int auto_scroll = 0);
 void multi_common_set_text(const char *str,int auto_scroll = 0);
+void multi_mission_desciption_set(const char* str_in, int code, int index);
 
 // time between sending refresh packets to known servers
 #define MULTI_JOIN_REFRESH_TIME			45000			
@@ -63,6 +64,9 @@ typedef struct multi_create_info {
 #define MICON_VOLITION					9
 #define MICON_VALID						10
 #define MICON_CD							11
+
+// a lone global which keeps track of how many mission we've sent description packets for.....
+extern ubyte Multi_sent_descript_packet_current_index;
 
 // common icon stuff
 extern int Multi_common_icons[MULTI_NUM_COMMON_ICONS];

--- a/code/network/psnet2.h
+++ b/code/network/psnet2.h
@@ -32,6 +32,7 @@
 // kazan - I think this should raise the ships limit across the network
 //#define MAX_PACKET_SIZE 4096
 #define MAX_PACKET_SIZE		512
+#define MAX_PACKET_DESC_LEN MAX_PACKET_SIZE - 12
 
 #define DEFAULT_GAME_PORT 7808
 

--- a/code/network/psnet2.h
+++ b/code/network/psnet2.h
@@ -32,7 +32,6 @@
 // kazan - I think this should raise the ships limit across the network
 //#define MAX_PACKET_SIZE 4096
 #define MAX_PACKET_SIZE		512
-#define MAX_PACKET_DESC_LEN MAX_PACKET_SIZE - 12
 
 #define DEFAULT_GAME_PORT 7808
 

--- a/code/parse/parselo.cpp
+++ b/code/parse/parselo.cpp
@@ -4224,13 +4224,31 @@ bool drop_extension(SCP_string &str)
 //WMC
 void backspace(char* src)
 {
-	Assert(src!= NULL);		//this would be bad
+	Assert(src!= nullptr);		//this would be bad
 
 	char *dest = src;
 	src++;
 
 	while(*src != '\0') {
 		*dest++ = *src++;
+	}
+
+	*dest = '\0';
+}
+
+// Cyborg17 - Backspace the passed number of characters
+void backspace(char* src, unsigned int spaces)
+{
+	Assertion(src != nullptr, "Nullptr was sent to backspace(). This is a code error, please report!"); // this would be bad
+	Assertion(spaces < strlen(src), "Spaces in a call to backspace() was longer than the string it was trying to shorten.  This is a code error, please report!");
+
+	char* dest = src;
+	src += spaces;
+
+	while (*src != '\0') {
+		*dest = *src;
+		dest++;
+		src++;
 	}
 
 	*dest = '\0';

--- a/code/parse/parselo.h
+++ b/code/parse/parselo.h
@@ -324,6 +324,9 @@ extern bool drop_extension(SCP_string &str);
 //WMC - backspaces the first character of given char pointer
 extern void backspace(char *src);
 
+// Cyborg17 - Multi Character version of backspace to make our lives easier.
+extern void backspace(char* src, unsigned int spaces);
+
 // Goober5000 - prints a properly comma-separated integer to a string
 extern void format_integer_with_commas(char *buf, int integer, bool use_comma_with_four_digits);
 


### PR DESCRIPTION
This allows FSO to send campaign descriptions during Multi, and the description of the first mission, like it does when it is in mission mode.  Also allows us to send the whole description via some quick recursion.

Lots of feedback welcome.  This is probably my most extensive contribution so far.  Also needs testing, but I thought I would also open it up for you guys to add initial reactions/corrections if you have them.