### PR TITLE
fix bug in copy_text_until error message

### DIFF
--- a/code/parse/parselo.cpp
+++ b/code/parse/parselo.cpp
@@ -910,7 +910,7 @@ void copy_text_until(char *outstr, char *instr, const char *endstr, int max_char
 
 	} else {
 		nprintf(("Error", "Error.  Too much text (" SIZE_T_ARG " chars, %i allowed) before %s\n",
-			foundstr - instr - strlen(endstr), max_chars, endstr));
+			foundstr - instr + strlen(endstr), max_chars, endstr));
 
         throw parse::ParseException("Too much text found");
 	}


### PR DESCRIPTION
This bug has been around since the original public source code release!

The error message character calculation did not agree with the actual error check.  This PR fixes that.  Thanks to Novachen on Discord for discovering this.