### PR TITLE
Make .csg loading code check rp_dist, just like .plr loading does.

### DIFF
--- a/code/pilotfile/csg.cpp
+++ b/code/pilotfile/csg.cpp
@@ -953,6 +953,10 @@ void pilotfile::csg_read_hud()
 
 	HUD_config.rp_flags = cfread_int(cfp);
 	HUD_config.rp_dist = cfread_int(cfp);
+	if (HUD_config.rp_dist < 0 || HUD_config.rp_dist >= RR_MAX_RANGES) {
+		Warning(LOCATION, "Campaign file has invalid radar range %d, setting to default.\n", HUD_config.rp_dist);
+		HUD_config.rp_dist = RR_INFINITY;
+	}
 
 	// basic colors
 	HUD_config.main_color = cfread_int(cfp);


### PR DESCRIPTION
When loading a .plr file, `HUD_config.rp_dist` is loaded and then sanity-checked; if the value is out of bounds, a `Warning` is generated and `RR_INFINITY` assigned. `HUD_config.rp_dist` is also loaded when loading a .csg file, however the sanity check isn't present; this copies the block over so the behavior is identical.