### PR TITLE
Fix #2086: Detect unsupported characters in root paths

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -4,6 +4,7 @@ modernize-*,\
 -modernize-raw-string-literal,\
 -modernize-use-using,\
 -modernize-make-unique,\
+-modernize-use-trailing-return-type\
 performance-*,\
 -performance-type-promotion-in-math-fn,\
 misc-*,\


### PR DESCRIPTION
Since FSO does not support Unicode characters in filesystem paths on
Windows yet, it is necessary to catch these issues early on and display
an appropriate error message. These changes do that by going through the
path with our UTF-8 decoder and detecting any characters that are out of
the ASCII range.