### PR TITLE
Enhanced ship maneuvers

### DIFF
--- a/code/ai/ai_flags.h
+++ b/code/ai/ai_flags.h
@@ -51,14 +51,19 @@ namespace AI {
 	};
 
 	FLAG_LIST(Maneuver_Override_Flags) {
-		Full,		//	Full sexp control
+		Full_rot,	//	full sexp control over pitch/bank/heading rotation
 		Roll,		//	Sexp forced roll maneuver
 		Pitch,		//	Sexp forced pitch change
 		Heading,	//	Sexp forced heading change
 		Full_lat,	//  full control over up/side/forward movement
-		Up,			//	vertical movement
-		Sideways,	//	horizontal movement
-		Forward,	//	forward movement
+		Up,			//	Sexp forced vertical movement
+		Sideways,	//	Sexp forced horizontal movement
+		Forward,	//	Sexp forced forward movement
+
+		Dont_bank_when_turning,		// maps to CIF_DONT_BANK_WHEN_TURNING
+		Dont_clamp_max_velocity,	// maps to CIF_DONT_CLAMP_MAX_VELOCITY
+		Dont_accelerate,			// maps to CIF_DONT_ACCELERATE
+		Never_expire,				// don't clear the maneuver when the timestamp is up
 
 		NUM_VALUES
 	};

--- a/code/ai/ai_flags.h
+++ b/code/ai/ai_flags.h
@@ -62,7 +62,7 @@ namespace AI {
 
 		Dont_bank_when_turning,		// maps to CIF_DONT_BANK_WHEN_TURNING
 		Dont_clamp_max_velocity,	// maps to CIF_DONT_CLAMP_MAX_VELOCITY
-		Dont_accelerate,			// maps to CIF_DONT_ACCELERATE
+		Instantaneous_acceleration,	// maps to CIF_INSTANTANEOUS_ACCELERATION
 		Never_expire,				// don't clear the maneuver when the timestamp is up
 
 		NUM_VALUES

--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -14079,50 +14079,65 @@ void ai_frame(int objnum)
 
 static void ai_control_info_check(ai_info *aip)
 {
-	if(aip->ai_override_flags.none_set())
+	if (aip->ai_override_flags.none_set())
 		return;
 
-	if(timestamp_elapsed(aip->ai_override_timestamp)) {
+	if (!aip->ai_override_flags[AI::Maneuver_Override_Flags::Never_expire] && timestamp_elapsed(aip->ai_override_timestamp))
+	{
 		aip->ai_override_flags.reset();
-	} else {
-		if(aip->ai_override_flags[AI::Maneuver_Override_Flags::Full])
+	}
+	else
+	{
+		if (aip->ai_override_flags[AI::Maneuver_Override_Flags::Full_rot])
 		{
 			AI_ci.pitch = aip->ai_override_ci.pitch;
 			AI_ci.heading = aip->ai_override_ci.heading;
 			AI_ci.bank = aip->ai_override_ci.bank;
-		} else {
-			if(aip->ai_override_flags[AI::Maneuver_Override_Flags::Pitch])
+		}
+		else
+		{
+			if (aip->ai_override_flags[AI::Maneuver_Override_Flags::Pitch])
 			{
 				AI_ci.pitch = aip->ai_override_ci.pitch;
 			}
-			if(aip->ai_override_flags[AI::Maneuver_Override_Flags::Heading])
+			if (aip->ai_override_flags[AI::Maneuver_Override_Flags::Heading])
 			{
 				AI_ci.heading = aip->ai_override_ci.heading;
 			}
-			if(aip->ai_override_flags[AI::Maneuver_Override_Flags::Roll])
+			if (aip->ai_override_flags[AI::Maneuver_Override_Flags::Roll])
 			{
 				AI_ci.bank = aip->ai_override_ci.bank;
 			}
 		}
-		if(aip->ai_override_flags[AI::Maneuver_Override_Flags::Full_lat])
+
+		if (aip->ai_override_flags[AI::Maneuver_Override_Flags::Full_lat])
 		{
 			AI_ci.vertical = aip->ai_override_ci.vertical;
 			AI_ci.sideways = aip->ai_override_ci.sideways;
 			AI_ci.forward = aip->ai_override_ci.forward;
-		} else {
-			if(aip->ai_override_flags[AI::Maneuver_Override_Flags::Up])
+		}
+		else
+		{
+			if (aip->ai_override_flags[AI::Maneuver_Override_Flags::Up])
 			{
 				AI_ci.vertical = aip->ai_override_ci.vertical;
 			}
-			if(aip->ai_override_flags[AI::Maneuver_Override_Flags::Sideways])
+			if (aip->ai_override_flags[AI::Maneuver_Override_Flags::Sideways])
 			{
 				AI_ci.sideways = aip->ai_override_ci.sideways;
 			}
-			if(aip->ai_override_flags[AI::Maneuver_Override_Flags::Forward])
+			if (aip->ai_override_flags[AI::Maneuver_Override_Flags::Forward])
 			{
 				AI_ci.forward = aip->ai_override_ci.forward;
 			}
 		}
+
+		if (aip->ai_override_flags[AI::Maneuver_Override_Flags::Dont_bank_when_turning])
+			AI_ci.control_flags |= CIF_DONT_BANK_WHEN_TURNING;
+		if (aip->ai_override_flags[AI::Maneuver_Override_Flags::Dont_clamp_max_velocity])
+			AI_ci.control_flags |= CIF_DONT_CLAMP_MAX_VELOCITY;
+		if (aip->ai_override_flags[AI::Maneuver_Override_Flags::Dont_accelerate])
+			AI_ci.control_flags |= CIF_DONT_ACCELERATE;
 	}
 }
 

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -539,9 +539,9 @@ SCP_vector<sexp_oper> Operators = {
 	{ "set-object-speed-x",				OP_SET_OBJECT_SPEED_X,					2,	3,			SEXP_ACTION_OPERATOR,	},	// WMC
 	{ "set-object-speed-y",				OP_SET_OBJECT_SPEED_Y,					2,	3,			SEXP_ACTION_OPERATOR,	},	// WMC
 	{ "set-object-speed-z",				OP_SET_OBJECT_SPEED_Z,					2,	3,			SEXP_ACTION_OPERATOR,	},	// WMC
-	{ "ship-maneuver",					OP_SHIP_MANEUVER,						10, 10,			SEXP_ACTION_OPERATOR,	},	// Wanderer
-	{ "ship-rot-maneuver",				OP_SHIP_ROT_MANEUVER,					6,	6,			SEXP_ACTION_OPERATOR,	},	// Wanderer
-	{ "ship-lat-maneuver",				OP_SHIP_LAT_MANEUVER,					6,	6,			SEXP_ACTION_OPERATOR,	},	// Wanderer
+	{ "ship-maneuver",					OP_SHIP_MANEUVER,						10, 11,			SEXP_ACTION_OPERATOR,	},	// Wanderer
+	{ "ship-rot-maneuver",				OP_SHIP_ROT_MANEUVER,					6,	7,			SEXP_ACTION_OPERATOR,	},	// Wanderer
+	{ "ship-lat-maneuver",				OP_SHIP_LAT_MANEUVER,					6,	7,			SEXP_ACTION_OPERATOR,	},	// Wanderer
 	{ "set-immobile",					OP_SET_IMMOBILE,						1,	INT_MAX,	SEXP_ACTION_OPERATOR,	},	// Goober5000
 	{ "set-mobile",						OP_SET_MOBILE,							1,	INT_MAX,	SEXP_ACTION_OPERATOR,	},	// Goober5000
 
@@ -7909,7 +7909,7 @@ void sexp_set_object_facing(int n, bool facing_object)
 	sexp_set_oswpt_facing(&oswpt1, location, turn_time, bank);
 }
 
-void sexp_set_ship_man(object *objp, int duration, int heading, int pitch, int bank, bool apply_all_rotate, int up, int sideways, int forward, bool apply_all_lat)
+void sexp_set_ship_man(object *objp, int duration, int heading, int pitch, int bank, bool apply_all_rotate, int up, int sideways, int forward, bool apply_all_lat, int maneuver_flags)
 {
 	if (objp->type != OBJ_SHIP)
 		return;
@@ -7917,11 +7917,18 @@ void sexp_set_ship_man(object *objp, int duration, int heading, int pitch, int b
 	ship *shipp = &Ships[objp->instance];
 	ai_info	*aip = &Ai_info[shipp->ai_index];
 	
-	aip->ai_override_timestamp = timestamp(duration);
 	aip->ai_override_flags.reset();
-	
+
+	// handle infinite timestamps
+	if (duration >= 2) {
+		aip->ai_override_timestamp = timestamp(duration);
+	} else {
+		aip->ai_override_timestamp = timestamp(10);
+		aip->ai_override_flags.set(AI::Maneuver_Override_Flags::Never_expire);
+	}
+
 	if (apply_all_rotate) {
-		aip->ai_override_flags.set(AI::Maneuver_Override_Flags::Full);
+		aip->ai_override_flags.set(AI::Maneuver_Override_Flags::Full_rot);
 		aip->ai_override_ci.bank = bank / 100.0f;
 		aip->ai_override_ci.pitch = pitch / 100.0f;
 		aip->ai_override_ci.heading = heading / 100.0f;
@@ -7958,16 +7965,26 @@ void sexp_set_ship_man(object *objp, int duration, int heading, int pitch, int b
 			aip->ai_override_ci.forward = forward / 100.0f;
 		}
 	}
+
+	if (maneuver_flags & CIF_DONT_BANK_WHEN_TURNING) {
+		aip->ai_override_flags.set(AI::Maneuver_Override_Flags::Dont_bank_when_turning);
+	}
+	if (maneuver_flags & CIF_DONT_CLAMP_MAX_VELOCITY) {
+		aip->ai_override_flags.set(AI::Maneuver_Override_Flags::Dont_clamp_max_velocity);
+	}
+	if (maneuver_flags & CIF_DONT_ACCELERATE) {
+		aip->ai_override_flags.set(AI::Maneuver_Override_Flags::Dont_accelerate);
+	}
 }
 
-void sexp_set_oswpt_maneuver(object_ship_wing_point_team *oswpt, int duration, int heading, int pitch, int bank, bool apply_all_rotate, int up, int sideways, int forward, bool apply_all_lat)
+void sexp_set_oswpt_maneuver(object_ship_wing_point_team *oswpt, int duration, int heading, int pitch, int bank, bool apply_all_rotate, int up, int sideways, int forward, bool apply_all_lat, int maneuver_flags)
 {
 	Assert(oswpt);
 
 	switch (oswpt->type)
 	{
 		case OSWPT_TYPE_SHIP:
-			sexp_set_ship_man(oswpt->objp, duration, heading, pitch, bank, apply_all_rotate, up, sideways, forward, apply_all_lat);
+			sexp_set_ship_man(oswpt->objp, duration, heading, pitch, bank, apply_all_rotate, up, sideways, forward, apply_all_lat, maneuver_flags);
 			break;
 
 		case OSWPT_TYPE_WING:
@@ -7976,7 +7993,7 @@ void sexp_set_oswpt_maneuver(object_ship_wing_point_team *oswpt, int duration, i
 			{
 				object *objp = &Objects[Ships[oswpt->wingp->ship_index[i]].objnum];
 
-				sexp_set_ship_man(objp, duration, heading, pitch, bank, apply_all_rotate, up, sideways, forward, apply_all_lat);
+				sexp_set_ship_man(objp, duration, heading, pitch, bank, apply_all_rotate, up, sideways, forward, apply_all_lat, maneuver_flags);
 			}
 
 			break;
@@ -7988,7 +8005,7 @@ void sexp_set_ship_maneuver(int n, int op_num)
 {
 	int bank = 0, heading = 0, pitch = 0;
 	int up = 0, sideways = 0, forward = 0;
-	int duration, i, temp;
+	int duration, i, temp, maneuver_flags = 0;
 	bool apply_all_rotate = false, apply_all_lat = false, is_nan, is_nan_forever;
 	object_ship_wing_point_team oswpt;
 
@@ -7996,7 +8013,7 @@ void sexp_set_ship_maneuver(int n, int op_num)
 
 	n = CDR(n);
 	duration = eval_num(n, is_nan, is_nan_forever);
-	if (is_nan || is_nan_forever || duration < 2)
+	if (is_nan || is_nan_forever)
 		return;
 
 	if (op_num == OP_SHIP_ROT_MANEUVER || op_num == OP_SHIP_MANEUVER) {
@@ -8006,9 +8023,6 @@ void sexp_set_ship_maneuver(int n, int op_num)
 			temp = eval_num(n, is_nan, is_nan_forever);
 			if (is_nan || is_nan_forever)
 				return;
-
-			if (temp > 100) temp = 100;
-			if (temp < -100) temp = -100;
 
 			if (i == 0)
 				heading = temp;
@@ -8030,9 +8044,6 @@ void sexp_set_ship_maneuver(int n, int op_num)
 			if (is_nan || is_nan_forever)
 				return;
 
-			if (temp > 100) temp = 100;
-			if (temp < -100) temp = -100;
-
 			if (i == 0)
 				up = temp;
 			else if (i == 1)
@@ -8048,7 +8059,14 @@ void sexp_set_ship_maneuver(int n, int op_num)
 	if ((bank == 0) && (pitch == 0) && (heading == 0) && !apply_all_rotate && (up == 0) && (sideways == 0) && (forward == 0) && !apply_all_lat)
 		return;
 
-	sexp_set_oswpt_maneuver(&oswpt, duration, heading, pitch, bank, apply_all_rotate, up, sideways, forward, apply_all_lat);
+	n = CDR(n);
+	if (n >= 0) {
+		maneuver_flags = eval_num(n, is_nan, is_nan_forever);
+		if (is_nan || is_nan_forever)
+			return;
+	}
+
+	sexp_set_oswpt_maneuver(&oswpt, duration, heading, pitch, bank, apply_all_rotate, up, sideways, forward, apply_all_lat, maneuver_flags);
 }
 
 /**
@@ -27788,8 +27806,10 @@ int query_operator_argument_type(int op, int argnum)
 				return OPF_BOOL;
 			else if (argnum < 9)
 				return OPF_NUMBER;
-			else
+			else if (argnum == 9)
 				return OPF_BOOL;
+			else
+				return OPF_POSITIVE;
 
 		case OP_SHIP_ROT_MANEUVER:
 		case OP_SHIP_LAT_MANEUVER:
@@ -27799,8 +27819,10 @@ int query_operator_argument_type(int op, int argnum)
 				return OPF_POSITIVE;
 			else if (argnum < 5)
 				return OPF_NUMBER;
-			else
+			else if (argnum == 5)
 				return OPF_BOOL;
+			else
+				return OPF_POSITIVE;
 
 		case OP_MODIFY_VARIABLE:
 			if (argnum == 0) {
@@ -32697,9 +32719,9 @@ SCP_vector<sexp_help_struct> Sexp_help = {
 
 	// Wanderer
 	{ OP_SHIP_MANEUVER, "ship-maneuver\r\n"
-		"\tCombines the effects of the ship-rot-maneuver and ship-lat-maneuver sexps.  Takes 10 arguments:\r\n"
+		"\tCombines the effects of the ship-rot-maneuver and ship-lat-maneuver sexps.  Takes 10 or 11 arguments:\r\n"
 		"\t1: The name of a ship or wing\r\n"
-		"\t2: Duration of the maneuver, in milliseconds\r\n"
+		"\t2: Duration of the maneuver, in milliseconds.  Specifying 0 or 1 indicates infinite duration.\r\n"
 		"\t3: Heading movement velocity, as a percentage (-100 to 100) of the tabled maximum heading velocity, or 0 to not modify the ship's current value\r\n"
 		"\t4: Pitch movement velocity, as a percentage (-100 to 100) of the tabled maximum pitch velocity, or 0 to not modify the ship's current value\r\n"
 		"\t5: Bank movement velocity, as a percentage (-100 to 100) of the tabled maximum bank velocity, or 0 to not modify the ship's current value\r\n"
@@ -32707,31 +32729,46 @@ SCP_vector<sexp_help_struct> Sexp_help = {
 		"\t7: Vertical movement velocity, as a percentage (-100 to 100) of the tabled maximum vertical velocity, or 0 to not modify the ship's current value\r\n"
 		"\t8: Sideways movement velocity, as a percentage (-100 to 100) of the tabled maximum sideways velocity, or 0 to not modify the ship's current value\r\n"
 		"\t9: Forward movement velocity, as a percentage (-100 to 100) of the tabled maximum forward velocity, or 0 to not modify the ship's current value\r\n"
-		"\t10: Whether to apply all of the lateral velocity values even if any of them are 0\r\n" },
+		"\t10: Whether to apply all of the lateral velocity values even if any of them are 0\r\n"
+		"\t11: Maneuver flags (optional): a bitfield with any of the following options:\r\n"
+		"\t\t1 or 2^0: don't bank when changing heading\r\n"
+		"\t\t2 or 2^1: allow maneuvers exceeding tabled maximums (outside the -100 to 100 range)\r\n"
+		"\t\t4 or 2^2: instantaneously jump to the goal velocity\r\n"
+	},
 
 	// Wanderer
 	{ OP_SHIP_ROT_MANEUVER, "ship-rot-maneuver\r\n"
 		"\tCauses a ship to move in a rotational direction.  For the purposes of this sexp, this means the ship rotates along its own heading, pitch, or bank axis (or a combination of axes) without regard to normal ship rotation rules.  "
 		"You may find it necessary to disable the ship AI (e.g. by issuing a play-dead order) before running this sexp.\r\n\r\n"
-		"Takes 6 arguments:\r\n"
+		"Takes 6 or 7 arguments:\r\n"
 		"\t1: The name of a ship or wing\r\n"
-		"\t2: Duration of the maneuver, in milliseconds\r\n"
+		"\t2: Duration of the maneuver, in milliseconds.  Specifying 0 or 1 indicates infinite duration.\r\n"
 		"\t3: Heading movement velocity, as a percentage (-100 to 100) of the tabled maximum heading velocity, or 0 to not modify the ship's current value\r\n"
 		"\t4: Pitch movement velocity, as a percentage (-100 to 100) of the tabled maximum pitch velocity, or 0 to not modify the ship's current value\r\n"
 		"\t5: Bank movement velocity, as a percentage (-100 to 100) of the tabled maximum bank velocity, or 0 to not modify the ship's current value\r\n"
-		"\t6: Whether to apply all of the above velocity values even if any of them are 0\r\n" },
+		"\t6: Whether to apply all of the above velocity values even if any of them are 0\r\n"
+		"\t7: Maneuver flags (optional): a bitfield with any of the following options:\r\n"
+		"\t\t1 or 2^0: don't bank when changing heading\r\n"
+		"\t\t2 or 2^1: allow maneuvers exceeding tabled maximums (outside the -100 to 100 range)\r\n"
+		"\t\t4 or 2^2: instantaneously jump to the goal velocity\r\n"
+	},
 	
 	// Wanderer
 	{ OP_SHIP_LAT_MANEUVER, "ship-lat-maneuver\r\n"
 		"\tCauses a ship to move in a lateral direction.  For the purposes of this sexp, this means the ship translates along its own X, Y, or Z axis (or a combination of axes) without regard to normal ship movement rules.  "
 		"You may find it necessary to disable the ship AI (e.g. by issuing a play-dead order) before running this sexp.\r\n\r\n"
-		"Takes 6 arguments:\r\n"
+		"Takes 6 or 7 arguments:\r\n"
 		"\t1: The name of a ship or wing\r\n"
-		"\t2: Duration of the maneuver, in milliseconds\r\n"
+		"\t2: Duration of the maneuver, in milliseconds.  Specifying 0 or 1 indicates infinite duration.\r\n"
 		"\t3: Vertical movement velocity, as a percentage (-100 to 100) of the tabled maximum vertical velocity, or 0 to not modify the ship's current value\r\n"
 		"\t4: Sideways movement velocity, as a percentage (-100 to 100) of the tabled maximum sideways velocity, or 0 to not modify the ship's current value\r\n"
 		"\t5: Forward movement velocity, as a percentage (-100 to 100) of the tabled maximum forward velocity, or 0 to not modify the ship's current value\r\n"
-		"\t6: Whether to apply all of the above velocity values even if any of them are 0\r\n" },
+		"\t6: Whether to apply all of the above velocity values even if any of them are 0\r\n"
+		"\t7: Maneuver flags (optional): a bitfield with any of the following options:\r\n"
+		"\t\t1 or 2^0: don't bank when changing heading (which won't have any affect for lat-maneuver)\r\n"
+		"\t\t2 or 2^1: allow maneuvers exceeding tabled maximums (outside the -100 to 100 range)\r\n"
+		"\t\t4 or 2^2: instantaneously jump to the goal velocity\r\n"
+	},
 
 	// Goober5000
 	{ OP_SHIP_TAG, "ship-tag\r\n"

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -7972,8 +7972,8 @@ void sexp_set_ship_man(object *objp, int duration, int heading, int pitch, int b
 	if (maneuver_flags & CIF_DONT_CLAMP_MAX_VELOCITY) {
 		aip->ai_override_flags.set(AI::Maneuver_Override_Flags::Dont_clamp_max_velocity);
 	}
-	if (maneuver_flags & CIF_DONT_ACCELERATE) {
-		aip->ai_override_flags.set(AI::Maneuver_Override_Flags::Dont_accelerate);
+	if (maneuver_flags & CIF_INSTANTANEOUS_ACCELERATION) {
+		aip->ai_override_flags.set(AI::Maneuver_Override_Flags::Instantaneous_acceleration);
 	}
 }
 

--- a/code/physics/physics.cpp
+++ b/code/physics/physics.cpp
@@ -427,7 +427,7 @@ void physics_read_flying_controls( matrix * orient, physics_info * pi, control_i
 	}
 
 	// maybe we don't need to clamp our velocity...
-	if (!(ci->control_flags & CIF_DONT_CLAMP_TO_MAX))
+	if (!(ci->control_flags & CIF_DONT_CLAMP_MAX_VELOCITY))
 	{
 		if (ci->pitch > 1.0f ) ci->pitch = 1.0f;
 		else if (ci->pitch < -1.0f ) ci->pitch = -1.0f;

--- a/code/physics/physics.h
+++ b/code/physics/physics.h
@@ -94,6 +94,11 @@ typedef struct physics_info {
 	float afterburner_reverse_accel; //SparK: Afterburner's acceleration on reverse mode
 } physics_info;
 
+
+#define CIF_DONT_BANK_WHEN_TURNING		(1 << 1)	// Goober5000 - changing heading does not change bank
+#define CIF_DONT_CLAMP_TO_MAX			(1 << 2)	// Goober5000 - maneuvers can exceed tabled max velocity
+#define CIF_DONT_ACCELERATE				(1 << 3)	// Goober5000 - instantaneously jump to the goal velocity
+
 // All of these are numbers from -1.0 to 1.0 indicating
 // what percent of full velocity you want to go.
 typedef struct control_info {
@@ -115,6 +120,8 @@ typedef struct control_info {
 	// afterburner control information
 	int	afterburner_start;
 	int	afterburner_stop;
+
+	int control_flags;					// for sexp- and script-controlled maneuvers
 
 } control_info;
 

--- a/code/physics/physics.h
+++ b/code/physics/physics.h
@@ -95,9 +95,9 @@ typedef struct physics_info {
 } physics_info;
 
 
-#define CIF_DONT_BANK_WHEN_TURNING		(1 << 1)	// Goober5000 - changing heading does not change bank
-#define CIF_DONT_CLAMP_TO_MAX			(1 << 2)	// Goober5000 - maneuvers can exceed tabled max velocity
-#define CIF_DONT_ACCELERATE				(1 << 3)	// Goober5000 - instantaneously jump to the goal velocity
+#define CIF_DONT_BANK_WHEN_TURNING		(1 << 0)	// Goober5000 - changing heading does not change bank
+#define CIF_DONT_CLAMP_MAX_VELOCITY		(1 << 1)	// Goober5000 - maneuvers can exceed tabled max velocity
+#define CIF_DONT_ACCELERATE				(1 << 2)	// Goober5000 - instantaneously jump to the goal velocity
 
 // All of these are numbers from -1.0 to 1.0 indicating
 // what percent of full velocity you want to go.

--- a/code/physics/physics.h
+++ b/code/physics/physics.h
@@ -15,22 +15,24 @@
 #include "math/vecmat.h"
 
 
-#define	PF_ACCELERATES			(1 << 1)
-#define	PF_USE_VEL				(1 << 2)		//	Use velocity present in physics_info struct, don't call physics_sim_vel.
-#define	PF_AFTERBURNER_ON		(1 << 3)		//	Afterburner currently engaged.
-#define	PF_SLIDE_ENABLED		(1 << 4)		// Allow descent style sliding
-#define	PF_REDUCED_DAMP		(1 << 5)		// Allows reduced damping on z (for death, shockwave) (CAN be reset in physics)
-#define	PF_IN_SHOCKWAVE		(1 << 6)		// Indicates whether object has recently been hit by shockwave (used to enable shake)
-#define	PF_DEAD_DAMP			(1 << 7)		// Makes forward damping same as sideways (NOT reset in physics)
-#define	PF_AFTERBURNER_WAIT	(1 << 8)		// true when afterburner cannot be used.  replaces variable used in afterburner code
-#define	PF_CONST_VEL			(1 << 9)		// Use velocity in phys_info struct.  Optimize weapons in phys_sim 
-#define	PF_WARP_IN				(1 << 10)	//	Use when ship is warping in
-#define	PF_SPECIAL_WARP_IN	(1 << 11)	//	Use when ship is warping in and we want to slow the ship faster than normal game physics
-#define	PF_WARP_OUT				(1 << 12)	//	Use when ship is warping out
-#define	PF_SPECIAL_WARP_OUT	(1 << 13)	//	Use when ship is warping out and we want to slow the ship faster than normal game physics
-#define PF_BOOSTER_ON		(1 << 14)
-#define PF_GLIDING			(1 << 15)
-#define PF_FORCE_GLIDE		(1 << 16)
+#define	PF_ACCELERATES			(1 << 0)
+#define	PF_USE_VEL				(1 << 1)	//	Use velocity present in physics_info struct, don't call physics_sim_vel.
+#define	PF_AFTERBURNER_ON		(1 << 2)	//	Afterburner currently engaged.
+#define	PF_SLIDE_ENABLED		(1 << 3)	// Allow descent style sliding
+#define	PF_REDUCED_DAMP			(1 << 4)	// Allows reduced damping on z (for death, shockwave) (CAN be reset in physics)
+#define	PF_IN_SHOCKWAVE			(1 << 5)	// Indicates whether object has recently been hit by shockwave (used to enable shake)
+#define	PF_DEAD_DAMP			(1 << 6)	// Makes forward damping same as sideways (NOT reset in physics)
+#define	PF_AFTERBURNER_WAIT		(1 << 7)	// true when afterburner cannot be used.  replaces variable used in afterburner code
+#define	PF_CONST_VEL			(1 << 8)	// Use velocity in phys_info struct.  Optimize weapons in phys_sim 
+#define	PF_WARP_IN				(1 << 9)	//	Use when ship is warping in
+#define	PF_SPECIAL_WARP_IN		(1 << 10)	//	Use when ship is warping in and we want to slow the ship faster than normal game physics
+#define	PF_WARP_OUT				(1 << 11)	//	Use when ship is warping out
+#define	PF_SPECIAL_WARP_OUT		(1 << 12)	//	Use when ship is warping out and we want to slow the ship faster than normal game physics
+#define PF_BOOSTER_ON			(1 << 13)
+#define PF_GLIDING				(1 << 14)
+#define PF_FORCE_GLIDE			(1 << 15)
+#define PF_NEWTONIAN_DAMP		(1 << 16)	// SUSHI: Whether or not to use newtonian dampening
+#define PF_NO_DAMP				(1 << 17)	// Goober5000 - don't damp velocity changes in physics; used for instantaneous acceleration
 
 //information for physics sim for an object
 typedef struct physics_info {
@@ -89,7 +91,7 @@ typedef struct physics_info {
 	float	glide_cap;	//Backslash - for 'newtonian'-style gliding, the cap on velocity (so that something can't accelerate to ridiculous speeds... unless allowed to)
 	float	cur_glide_cap;	//SUSHI: Used for dynamic glide cap, so we can use the ramping function on the glide cap
 	float	glide_accel_mult;	//SUSHI: The acceleration multiplier for glide mode. A value < 0 means use glide ramping instead
-	bool use_newtonian_damp;	//SUSHI: Whether or not to use newtonian dampening
+
 	float afterburner_max_reverse_vel; //SparK: This is the reverse afterburners top speed vector
 	float afterburner_reverse_accel; //SparK: Afterburner's acceleration on reverse mode
 } physics_info;
@@ -97,7 +99,7 @@ typedef struct physics_info {
 
 #define CIF_DONT_BANK_WHEN_TURNING		(1 << 0)	// Goober5000 - changing heading does not change bank
 #define CIF_DONT_CLAMP_MAX_VELOCITY		(1 << 1)	// Goober5000 - maneuvers can exceed tabled max velocity
-#define CIF_DONT_ACCELERATE				(1 << 2)	// Goober5000 - instantaneously jump to the goal velocity
+#define CIF_INSTANTANEOUS_ACCELERATION	(1 << 2)	// Goober5000 - instantaneously jump to the goal velocity
 
 // All of these are numbers from -1.0 to 1.0 indicating
 // what percent of full velocity you want to go.

--- a/code/scripting/api/objs/ship.cpp
+++ b/code/scripting/api/objs/ship.cpp
@@ -1404,8 +1404,8 @@ ADE_FUNC(doManeuver, l_Ship, "number Duration, number Heading, number Pitch, num
 	if (maneuver_flags & CIF_DONT_CLAMP_MAX_VELOCITY) {
 		aip->ai_override_flags.set(AI::Maneuver_Override_Flags::Dont_clamp_max_velocity);
 	}
-	if (maneuver_flags & CIF_DONT_ACCELERATE) {
-		aip->ai_override_flags.set(AI::Maneuver_Override_Flags::Dont_accelerate);
+	if (maneuver_flags & CIF_INSTANTANEOUS_ACCELERATION) {
+		aip->ai_override_flags.set(AI::Maneuver_Override_Flags::Instantaneous_acceleration);
 	}
 
 	return ADE_RETURN_TRUE;

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -5620,9 +5620,15 @@ void physics_ship_init(object *objp)
 	pi->glide_accel_mult = sinfo->glide_accel_mult;
 
 	//SUSHI: This defaults to the AI_Profile value, and is only optionally overridden
-	pi->use_newtonian_damp = The_mission.ai_profile->flags[AI::Profile_Flags::Use_newtonian_dampening];
+	if (The_mission.ai_profile->flags[AI::Profile_Flags::Use_newtonian_dampening])
+		pi->flags |= PF_NEWTONIAN_DAMP;
 	if (sinfo->newtonian_damp_override)
-		pi->use_newtonian_damp = sinfo->use_newtonian_damp;
+	{
+		if (sinfo->use_newtonian_damp)
+			pi->flags |= PF_NEWTONIAN_DAMP;
+		else
+			pi->flags &= ~PF_NEWTONIAN_DAMP;
+	}
 
 	vm_vec_zero(&pi->vel);
 	vm_vec_zero(&pi->rotvel);


### PR DESCRIPTION
Add some useful flags for ship maneuvers:
* don't bank when turning (changing heading does not change bank)
* don't clamp max velocity (maneuvers can exceed tabled values)
* instantaneous acceleration

Also allow perpetual (non-expiring) ship maneuvers.  These flags are available in both sexps and scripts.