### PR TITLE
Update Travis to GCC 9 and fix warnings

### DIFF
--- a/.github/workflows/pr-workflow.yaml
+++ b/.github/workflows/pr-workflow.yaml
@@ -135,39 +135,3 @@ jobs:
           else
               "./bin/$CONFIGURATION/unittests" --gtest_shuffle
           fi
-  build_mac:
-    strategy:
-      matrix:
-        configuration: [Debug, Release]
-    name: Mac OS
-    runs-on: macOS-10.14
-    steps:
-      - name: Prepare Environment
-        run: |
-          gem install xcpretty
-
-          brew update
-          brew outdated cmake || brew upgrade cmake
-          brew install FreeType
-      - uses: actions/checkout@v1
-        name: Checkout
-        with:
-          submodules: true
-      - name: Configure CMake
-        run: |
-          mkdir build
-          cd build
-
-          cmake -G "Xcode" $CMAKE_OPTIONS ..
-      - name: Compile
-        working-directory: ./build
-        env:
-          CONFIGURATION: ${{ matrix.configuration }}
-        run: |
-          cmake --build . --config "$CONFIGURATION" | tee build.log | xcpretty
-          XCODE_RET=${PIPESTATUS[0]}
-          if [ "$XCODE_RET" -ne "0" ]; then
-              tar -cvzf build.log.tar.gz build.log
-              curl --upload-file build.log.tar.gz "https://transfer.sh/build.log.tar.gz"
-              exit $XCODE_RET
-          fi

--- a/.github/workflows/pr-workflow.yaml
+++ b/.github/workflows/pr-workflow.yaml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         configuration: [Debug, Release]
-        compiler: [gcc-5, gcc-8, clang-4.0]
+        compiler: [gcc-5, gcc-9, clang-4.0]
     name: Linux
     runs-on: ubuntu-16.04
     steps:
@@ -19,7 +19,7 @@ jobs:
           sudo add-apt-repository ppa:beineri/opt-qt571-xenial
           sudo add-apt-repository ppa:msulikowski/valgrind # For fixing a bug with valgrind 3.11 which does not recognize the rdrand instruction
           sudo apt-get -yq update
-          sudo apt-get -yq install cmake ninja-build libopenal-dev libreadline6-dev libpng12-dev libjpeg62-dev liblua5.1-0-dev libjansson-dev libsdl2-dev libfreetype6-dev valgrind qt57base g++-5 g++-8 clang-4.0 clang-tidy-4.0 libc++-dev libc++abi-dev
+          sudo apt-get -yq install cmake ninja-build libopenal-dev libreadline6-dev libpng12-dev libjpeg62-dev liblua5.1-0-dev libjansson-dev libsdl2-dev libfreetype6-dev valgrind qt57base g++-5 g++-9 clang-4.0 clang-tidy-4.0 libc++-dev libc++abi-dev
           # Fix a header bug present in ubuntu...
           sudo ln -s /usr/include/libcxxabi/__cxxabi_config.h /usr/include/c++/v1/__cxxabi_config.h
       - uses: actions/checkout@v1
@@ -35,9 +35,9 @@ jobs:
             export CC=gcc-5
             export CXX=g++-5
           fi
-          if [ "$COMPILER" = "gcc-8" ]; then
-            export CC=gcc-8
-            export CXX=g++-8
+          if [ "$COMPILER" = "gcc-9" ]; then
+            export CC=gcc-9
+            export CXX=g++-9
           fi
           if [ "$COMPILER" = "clang-4.0" ]; then
             export CC=clang-4.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -78,14 +78,14 @@ matrix:
             - *global_deps
             - g++-5
     - os: linux
-      env: CONFIGURATION="Debug" CC=gcc-8 CXX=g++-8
+      env: CONFIGURATION="Debug" CC=gcc-9 CXX=g++-9
       addons:
         apt:
           sources:
             - ubuntu-toolchain-r-test
             - sourceline: 'ppa:beineri/opt-qt571-trusty'
           packages:
-            - g++-8
+            - g++-9
             - *global_deps
     - os: linux
       env: CONFIGURATION="Debug" CC=clang-4.0 CXX=clang++-4.0 CMAKE_OPTIONS="-DCMAKE_EXPORT_COMPILE_COMMANDS=ON"
@@ -122,14 +122,14 @@ matrix:
             - *global_deps
             - g++-5
     - os: linux
-      env: CONFIGURATION="Release" CC=gcc-8 CXX=g++-8
+      env: CONFIGURATION="Release" CC=gcc-9 CXX=g++-9
       addons:
         apt:
           sources:
             - ubuntu-toolchain-r-test
             - sourceline: 'ppa:beineri/opt-qt571-trusty'
           packages:
-            - g++-8
+            - g++-9
             - *global_deps
     - os: linux
       env: CONFIGURATION="Release" CC=clang-4.0 CXX=clang++-4.0

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -7100,13 +7100,13 @@ void mission_eval_arrivals()
 				if (rship >= 0)
 				{
 					int j;
-					char message_name[NAME_LENGTH + 10];
+					SCP_string message_name;
 					sprintf(message_name, "%s Arrived", wingp->name);
 
 					// see if this wing has an arrival message associated with it
 					for (j = 0; j < MAX_BUILTIN_MESSAGE_TYPES; j++)
 					{
-						if (!stricmp(message_name, Builtin_messages[j].name))
+						if (!stricmp(message_name.c_str(), Builtin_messages[j].name))
 						{
 							message_send_builtin_to_player(j, &Ships[rship], MESSAGE_PRIORITY_LOW, MESSAGE_TIME_SOON, 0, 0, -1, -1);
 							break;

--- a/code/scripting/lua/LuaFunction.cpp
+++ b/code/scripting/lua/LuaFunction.cpp
@@ -45,11 +45,10 @@ LuaFunction LuaFunction::createFromCode(lua_State* L, std::string const& code, s
 LuaFunction::LuaFunction() : LuaValue(), _errorFunction(nullptr) {
 }
 
-LuaFunction::LuaFunction(const LuaFunction& other) : LuaValue(other), _errorFunction(other._errorFunction) {
-}
+LuaFunction::LuaFunction(const LuaFunction&) = default;
+LuaFunction& LuaFunction::operator=(const LuaFunction&) = default;
 
-LuaFunction::~LuaFunction() {
-}
+LuaFunction::~LuaFunction() = default;
 
 bool LuaFunction::setEnvironment(const LuaTable& table) {
 	if (!table.getReference()->isValid()) {

--- a/code/scripting/lua/LuaFunction.h
+++ b/code/scripting/lua/LuaFunction.h
@@ -60,11 +60,13 @@ class LuaFunction: public LuaValue {
      * @param other The other function.
      */
 	LuaFunction(const LuaFunction& other);
+	LuaFunction& operator=(const LuaFunction& other);
 
 	/**
      * @brief Frees the reference to the function if it exists.
      */
 	~LuaFunction() override;
+
 
 	/**
      * @brief Sets the function environment.

--- a/code/scripting/lua/LuaValue.cpp
+++ b/code/scripting/lua/LuaValue.cpp
@@ -53,6 +53,12 @@ LuaValue::LuaValue(const LuaValue& other) : _luaState(other._luaState) {
 	this->setReference(other._reference);
 }
 
+LuaValue& LuaValue::operator=(const LuaValue& other) {
+	_luaState = other._luaState;
+	this->setReference(other._reference);
+	return *this;
+}
+
 LuaValue::~LuaValue() {
 }
 

--- a/code/scripting/lua/LuaValue.h
+++ b/code/scripting/lua/LuaValue.h
@@ -82,6 +82,7 @@ class LuaValue {
      * @param other The other LuaValue.
      */
 	LuaValue(const LuaValue& other);
+	LuaValue& operator=(const LuaValue& other);
 
 	/**
      * @brief Releases the reference

--- a/code/stats/scoring.h
+++ b/code/stats/scoring.h
@@ -127,6 +127,7 @@ public:
 
 	scoring_struct() { init(); }
 	scoring_struct(const scoring_struct &s) { assign(s); }
+	scoring_struct& operator=(const scoring_struct &s) { assign(s); return *this; }
 
 	void init();
 	void assign(const scoring_struct &s);

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -2104,9 +2104,9 @@ int parse_weapon(int subtype, bool replace, const char *filename)
 		}
 		// now check miss factors for each IFF
 		for(iff=0; iff<Num_iffs; iff++) {
-			char miss_factor_string[NAME_LENGTH + 15];
+			SCP_string miss_factor_string;
 			sprintf(miss_factor_string, "+%s Miss Factor:", Iff_info[iff].iff_name);
-			if(optional_string(miss_factor_string)) {
+			if(optional_string(miss_factor_string.c_str())) {
 				// this Miss Factor applies only to the specified IFF
 				for(idx=0; idx<NUM_SKILL_LEVELS; idx++) {
 					if(!stuff_float_optional(&wip->b_info.beam_iff_miss_factor[iff][idx])) {

--- a/qtfred/src/mission/dialogs/MissionGoalsDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/MissionGoalsDialogModel.cpp
@@ -13,31 +13,31 @@ MissionGoalsDialogModel::MissionGoalsDialogModel(QObject* parent, fso::fred::Edi
 }
 bool MissionGoalsDialogModel::apply()
 {
-	for (int32_t i = 0; i < Num_goals; i++)
+	for (int i = 0; i < Num_goals; i++)
 		free_sexp2(Mission_goals[i].formula);
 
 	auto changes_detected = query_modified();
 
 	SCP_vector<std::pair<SCP_string, SCP_string>> names;
 
-	for (int32_t i = 0; i < Num_goals; i++)
+	for (int i = 0; i < Num_goals; i++)
 		Mission_goals[i].satisfied = 0; // use this as a processed flag
 
 	// rename all sexp references to old events
-	for (int32_t i = 0; i < m_num_goals; i++)
+	for (int i = 0; i < m_num_goals; i++)
 		if (m_sig[i] >= 0) {
 			names.emplace_back(Mission_goals[m_sig[i]].name, m_goals[i].name);
 			Mission_goals[m_sig[i]].satisfied = 1;
 		}
 
 	// invalidate all sexp references to deleted events.
-	for (int32_t i = 0; i < Num_goals; i++)
+	for (int i = 0; i < Num_goals; i++)
 		if (!Mission_goals[i].satisfied) {
 			names.emplace_back(Mission_goals[i].name, SCP_string("<") + Mission_goals[i].name + ">");
 		}
 
 	Num_goals = m_num_goals;
-	for (int32_t i = 0; i < Num_goals; i++) {
+	for (int i = 0; i < Num_goals; i++) {
 		Mission_goals[i]         = m_goals[i];
 		Mission_goals[i].formula = _sexp_tree->save_tree(Mission_goals[i].formula);
 		if (The_mission.game_type & MISSION_TYPE_MULTI_TEAMS) {
@@ -46,8 +46,9 @@ bool MissionGoalsDialogModel::apply()
 	}
 
 	// now update all sexp references
-	for (const auto& entry : names)
+	for (const auto& entry : names) {
 		update_sexp_references(entry.first.c_str(), entry.second.c_str(), OPF_GOAL_NAME);
+	}
 
 	// Only fire the signal after the changes have been applied to make sure the other parts of the code see the updated
 	// state

--- a/qtfred/src/ui/dialogs/EventEditorDialog.cpp
+++ b/qtfred/src/ui/dialogs/EventEditorDialog.cpp
@@ -620,7 +620,7 @@ void EventEditorDialog::applyChanges()
 
 	auto changes_detected = query_modified();
 
-	for (int32_t i = 0; i < Num_mission_events; i++) {
+	for (int i = 0; i < Num_mission_events; i++) {
 		free_sexp2(Mission_events[i].formula);
 		if (Mission_events[i].objective_text)
 			free(Mission_events[i].objective_text);
@@ -630,24 +630,24 @@ void EventEditorDialog::applyChanges()
 
 	SCP_vector<std::pair<SCP_string, SCP_string>> names;
 
-	for (int32_t i = 0; i < Num_mission_events; i++)
+	for (int i = 0; i < Num_mission_events; i++)
 		Mission_events[i].result = 0; // use this as a processed flag
 
 	// rename all sexp references to old events
-	for (int32_t i = 0; i < m_num_events; i++)
+	for (int i = 0; i < m_num_events; i++)
 		if (m_sig[i] >= 0) {
 			names.emplace_back(Mission_events[m_sig[i]].name, m_events[i].name);
 			Mission_events[m_sig[i]].result = 1;
 		}
 
 	// invalidate all sexp references to deleted events.
-	for (int32_t i = 0; i < Num_mission_events; i++)
+	for (int i = 0; i < Num_mission_events; i++)
 		if (!Mission_events[i].result) {
 			names.emplace_back(Mission_events[i].name, SCP_string("<") + Mission_events[i].name + ">");
 		}
 
 	Num_mission_events = m_num_events;
-	for (int32_t i = 0; i < m_num_events; i++) {
+	for (int i = 0; i < m_num_events; i++) {
 		Mission_events[i]                    = m_events[i];
 		Mission_events[i].formula            = ui->eventTree->save_tree(m_events[i].formula);
 		Mission_events[i].objective_text     = m_events[i].objective_text;
@@ -656,10 +656,11 @@ void EventEditorDialog::applyChanges()
 	}
 
 	// now update all sexp references
-	for (const auto& entry : names)
+	for (const auto& entry : names) {
 		update_sexp_references(entry.first.c_str(), entry.second.c_str(), OPF_EVENT_NAME);
+	}
 
-	for (int32_t i = Num_builtin_messages; i < Num_messages; i++) {
+	for (int i = Num_builtin_messages; i < Num_messages; i++) {
 		if (Messages[i].avi_info.name)
 			free(Messages[i].avi_info.name);
 
@@ -669,7 +670,7 @@ void EventEditorDialog::applyChanges()
 
 	Num_messages = m_num_messages + Num_builtin_messages;
 	Messages.resize(Num_messages);
-	for (int32_t i = 0; i < m_num_messages; i++)
+	for (int i = 0; i < m_num_messages; i++)
 		Messages[i + Num_builtin_messages] = m_messages[i];
 
 	// Only fire the signal after the changes have been applied to make sure the other parts of the code see the updated

--- a/qtfred/src/ui/widgets/sexp_tree.cpp
+++ b/qtfred/src/ui/widgets/sexp_tree.cpp
@@ -3945,10 +3945,10 @@ sexp_list_item* sexp_tree::get_listing_opf_ship_wing_shiponteam_point() {
 	sexp_list_item head;
 
 	for (i = 0; i < Num_iffs; i++) {
-		char tmp[NAME_LENGTH + 7];
+		SCP_string tmp;
 		sprintf(tmp, "<any %s>", Iff_info[i].iff_name);
-		strlwr(tmp);
-		head.add_data_dup(tmp);
+		std::transform(begin(tmp), end(tmp), begin(tmp), [](char c) { return (char)::tolower(c); });
+		head.add_data_dup(tmp.c_str());
 	}
 
 	head.add_list(get_listing_opf_ship_wing_point());


### PR DESCRIPTION
Only one warning type this time, the implicit copy operator for types
with a copy constructor has been deprecated so we need to delcare them
ourself.