### PR TITLE
Address Coverity 1297186,187,188, 190

### DIFF
--- a/code/fs2netd/tcp_client.h
+++ b/code/fs2netd/tcp_client.h
@@ -56,19 +56,19 @@ void FS2NetD_Pong(int tstamp);
 // Some easy to use macros for handling the packet data
 #define BASE_PACKET_SIZE	(int)(sizeof(ubyte) + sizeof(int))
 
-#define PXO_ADD_DATA(d) do { Assert(buffer_size+sizeof(d) <= sizeof(buffer)); memcpy(buffer+buffer_size, &d, sizeof(d)); buffer_size += sizeof(d); } while (0)
-#define PXO_ADD_SHORT(d) do { Assert(buffer_size+sizeof(short) <= sizeof(buffer)); short swap = INTEL_SHORT(d); memcpy(buffer+buffer_size, &swap, sizeof(short)); buffer_size += sizeof(short); } while (0)
-#define PXO_ADD_USHORT(d) do { Assert(buffer_size+sizeof(ushort) <= sizeof(buffer)); ushort swap = INTEL_SHORT(d); memcpy(buffer+buffer_size, &swap, sizeof(ushort)); buffer_size += sizeof(ushort); } while (0)
-#define PXO_ADD_INT(d) do { Assert(buffer_size+sizeof(int) <= sizeof(buffer)); int swap = INTEL_INT(d); memcpy(buffer+buffer_size, &swap, sizeof(int)); buffer_size += sizeof(int); } while (0)
-#define PXO_ADD_UINT(d) do { Assert(buffer_size+sizeof(uint) <= sizeof(buffer)); uint swap = INTEL_INT(d); memcpy(buffer+buffer_size, &swap, sizeof(uint)); buffer_size += sizeof(uint); } while (0)
-#define PXO_ADD_STRING(s) do { Assert(buffer_size+strlen(s)+sizeof(int) <= sizeof(buffer)); int len = (int)strlen(s); PXO_ADD_INT(len); if (len > 0) { memcpy(buffer+buffer_size, s, len ); buffer_size += len; } } while(0)
+#define PXO_ADD_DATA(d) do { Assert(buffer_size+sizeof(d) <= sizeof(buffer)); memcpy(buffer+buffer_size, &d, sizeof(d)); buffer_size += sizeof(d); } while (false)
+#define PXO_ADD_SHORT(d) do { Assert(buffer_size+sizeof(short) <= sizeof(buffer)); short swap = INTEL_SHORT(d); memcpy(buffer+buffer_size, &swap, sizeof(short)); buffer_size += sizeof(short); } while (false)
+#define PXO_ADD_USHORT(d) do { Assert(buffer_size+sizeof(ushort) <= sizeof(buffer)); ushort swap = INTEL_SHORT(d); memcpy(buffer+buffer_size, &swap, sizeof(ushort)); buffer_size += sizeof(ushort); } while (false)
+#define PXO_ADD_INT(d) do { Assert(buffer_size+sizeof(int) <= sizeof(buffer)); int swap = INTEL_INT(d); memcpy(buffer+buffer_size, &swap, sizeof(int)); buffer_size += sizeof(int); } while (false)
+#define PXO_ADD_UINT(d) do { Assert(buffer_size+sizeof(uint) <= sizeof(buffer)); uint swap = INTEL_INT(d); memcpy(buffer+buffer_size, &swap, sizeof(uint)); buffer_size += sizeof(uint); } while (false)
+#define PXO_ADD_STRING(s) do { Assert(buffer_size+strlen(s)+sizeof(int) <= sizeof(buffer)); int len = (int)strlen(s); PXO_ADD_INT(len); if (len > 0) { memcpy(buffer+buffer_size, s, len ); buffer_size += len; } } while(false)
 
-#define PXO_GET_DATA(d) do { Assert(buffer_offset+sizeof(d) <= sizeof(buffer)); memcpy(&d, buffer+buffer_offset, sizeof(d) ); buffer_offset += sizeof(d); } while(0)
-#define PXO_GET_SHORT(d) do { Assert(buffer_offset+sizeof(short) <= sizeof(buffer)); short swap; memcpy(&swap, buffer+buffer_offset, sizeof(short) ); d = INTEL_SHORT(swap); buffer_offset += sizeof(short); } while(0)
-#define PXO_GET_USHORT(d) do { Assert(buffer_offset+sizeof(ushort) <= sizeof(buffer)); ushort swap; memcpy(&swap, buffer+buffer_offset, sizeof(ushort) ); d = INTEL_SHORT(swap); buffer_offset += sizeof(ushort); } while(0)
-#define PXO_GET_INT(d) do { Assert(buffer_offset+sizeof(int) <= sizeof(buffer)); int swap; memcpy(&swap, buffer+buffer_offset, sizeof(int) ); d = INTEL_INT(swap); buffer_offset += sizeof(int); } while(0)
-#define PXO_GET_UINT(d) do { Assert(buffer_offset+sizeof(uint) <= sizeof(buffer)); uint swap; memcpy(&swap, buffer+buffer_offset, sizeof(uint) ); d = INTEL_INT(swap); buffer_offset += sizeof(uint); } while(0)
-#define PXO_GET_STRING(s) do { Assert(buffer_offset+sizeof(int) <= sizeof(buffer)); s[0] = '\0'; int len; memcpy(&len, buffer+buffer_offset, sizeof(int)); len = INTEL_INT(len); buffer_offset += sizeof(int); if (len > 0) { memcpy(s, buffer+buffer_offset, len); buffer_offset += len; s[len] = '\0'; } } while(0)
+#define PXO_GET_DATA(d) do { Assert(buffer_offset+sizeof(d) <= sizeof(buffer)); memcpy(&d, buffer+buffer_offset, sizeof(d) ); buffer_offset += sizeof(d); } while(false)
+#define PXO_GET_SHORT(d) do { Assert(buffer_offset+sizeof(short) <= sizeof(buffer)); short swap; memcpy(&swap, buffer+buffer_offset, sizeof(short) ); d = INTEL_SHORT(swap); buffer_offset += sizeof(short); } while(false)
+#define PXO_GET_USHORT(d) do { Assert(buffer_offset+sizeof(ushort) <= sizeof(buffer)); ushort swap; memcpy(&swap, buffer+buffer_offset, sizeof(ushort) ); d = INTEL_SHORT(swap); buffer_offset += sizeof(ushort); } while(false)
+#define PXO_GET_INT(d) do { Assert(buffer_offset+sizeof(int) <= sizeof(buffer)); int swap; memcpy(&swap, buffer+buffer_offset, sizeof(int) ); d = INTEL_INT(swap); buffer_offset += sizeof(int); } while(false)
+#define PXO_GET_UINT(d) do { Assert(buffer_offset+sizeof(uint) <= sizeof(buffer)); uint swap; memcpy(&swap, buffer+buffer_offset, sizeof(uint) ); d = INTEL_INT(swap); buffer_offset += sizeof(uint); } while(false)
+#define PXO_GET_STRING(s) do { Assert(buffer_offset+sizeof(int) <= sizeof(buffer)); s[0] = '\0'; int len; memcpy(&len, buffer+buffer_offset, sizeof(int)); len = INTEL_INT(len); buffer_offset += sizeof(int); if (len > 0) { memcpy(s, buffer+buffer_offset, len); buffer_offset += len; s[len] = '\0'; } } while(false)
 
 // initialize a packet
 #define INIT_PACKET(x) { memset(buffer, 0, sizeof(buffer)); buffer_size = 0; ubyte pckt = (x); PXO_ADD_DATA(pckt); PXO_ADD_INT(buffer_size); }

--- a/code/globalincs/linklist.h
+++ b/code/globalincs/linklist.h
@@ -62,7 +62,7 @@ do {												\
 	(elem)->next->prev = (elem)->prev;	\
 	(elem)->next = NULL;						\
 	(elem)->prev = NULL;						\
-} while(0)
+} while(false)
 
 // Moves elem to be after head
 #define list_move_append(head, elem)		\

--- a/code/globalincs/pstypes.h
+++ b/code/globalincs/pstypes.h
@@ -259,14 +259,14 @@ extern int Global_error_count;
 /*******************NEVER COMMENT Assert ************************************************/
 
 // Goober5000 - define Verify for use in both release and debug mode
-#define Verify(x) do { if (!(x)){ Error(LOCATION, "Verify failure: %s\n", #x); } ASSUME(x); } while(0)
+#define Verify(x) do { if (!(x)){ Error(LOCATION, "Verify failure: %s\n", #x); } ASSUME(x); } while(false)
 
 // VerifyEx
 #ifndef _MSC_VER   // non MS compilers
-#	define VerifyEx(x, y, ...) do { if (!(x)) { Error(LOCATION, "Verify failure: %s with help text " #y "\n", #x, ##__VA_ARGS__); } ASSUME(x); } while(0)
+#	define VerifyEx(x, y, ...) do { if (!(x)) { Error(LOCATION, "Verify failure: %s with help text " #y "\n", #x, ##__VA_ARGS__); } ASSUME(x); } while(false)
 #else
 #	if _MSC_VER >= 1400	// VC 2005 or greater
-#		define VerifyEx(x, y, ...) do { if (!(x)) { Error(LOCATION, "Verify failure: %s with help text " #y "\n", #x, __VA_ARGS__); } ASSUME(x); } while(0)
+#		define VerifyEx(x, y, ...) do { if (!(x)) { Error(LOCATION, "Verify failure: %s with help text " #y "\n", #x, __VA_ARGS__); } ASSUME(x); } while(false)
 #	else // everything else
 #		define VerifyEx(x, y) Verify(x)
 #	endif
@@ -274,7 +274,7 @@ extern int Global_error_count;
 
 #if defined(NDEBUG)
 	// No debug version of Int3
-	#define Int3() do { } while (0)
+	#define Int3() do { } while (false)
 #else
 	void debug_int3(const char *file, int line);
 

--- a/code/graphics/2d.h
+++ b/code/graphics/2d.h
@@ -844,7 +844,7 @@ typedef struct screen {
 } screen;
 
 // handy macro
-#define GR_MAYBE_CLEAR_RES(bmap)		do  { int bmw = -1; int bmh = -1; if(bmap != -1){ bm_get_info( bmap, &bmw, &bmh, NULL, NULL, NULL); if((bmw != gr_screen.max_w) || (bmh != gr_screen.max_h)){gr_clear();} } else {gr_clear();} } while(0);
+#define GR_MAYBE_CLEAR_RES(bmap)		do  { int bmw = -1; int bmh = -1; if(bmap != -1){ bm_get_info( bmap, &bmw, &bmh, NULL, NULL, NULL); if((bmw != gr_screen.max_w) || (bmh != gr_screen.max_h)){gr_clear();} } else {gr_clear();} } while(false);
 
 //Window's interface to set up graphics:
 //--------------------------------------
@@ -1237,7 +1237,7 @@ class DebugScope {
 #ifndef NDEBUG
 #define GR_DEBUG_SCOPE(name) ::graphics::DebugScope SCP_TOKEN_CONCAT(gr_scope, __LINE__)(name)
 #else
-#define GR_DEBUG_SCOPE(name) do {} while(0)
+#define GR_DEBUG_SCOPE(name) do {} while(false)
 #endif
 
 enum AnimatedShader {

--- a/code/graphics/line.h
+++ b/code/graphics/line.h
@@ -20,7 +20,7 @@
     int __temp__ = (a);                                                 \
     (a) = (b);                                                          \
     (b) = __temp__;                                                     \
-} while(0)
+} while(false)
 
 //#define INT_SCALE(var,arg,num,den) ((var) = ((arg) * (num)) / (den))
 #define INT_SCALE(var,arg,num,den) ((var) = MulDiv(arg, num, den))
@@ -90,13 +90,13 @@
             WHEN_CLIPPED;                                               \
         }                                                               \
     }                                                                   \
-} while(0)
+} while(false)
 
 #define FL_EXCHG(a,b) do {                                                 \
     float __temp__ = (a);                                                 \
     (a) = (b);                                                          \
     (b) = __temp__;                                                     \
-} while(0)
+} while(false)
 
 #define FL_SCALE(var,arg,num,den) ((var) = ((arg) * (num)) / (den))
 
@@ -165,6 +165,6 @@
             WHEN_CLIPPED;                                               \
         }                                                               \
     }                                                                   \
-} while(0)
+} while(false)
 
 #endif

--- a/code/network/multi_options.cpp
+++ b/code/network/multi_options.cpp
@@ -54,7 +54,7 @@ ushort Multi_options_proxy_port = 0;
 //
 
 // load in the config file
-#define NEXT_TOKEN()						do { tok = strtok(NULL, "\n"); if(tok != NULL){ drop_leading_white_space(tok); drop_trailing_white_space(tok); } } while(0);
+#define NEXT_TOKEN()						do { tok = strtok(NULL, "\n"); if(tok != NULL){ drop_leading_white_space(tok); drop_trailing_white_space(tok); } } while(false);
 #define SETTING(s)						( !stricmp(tok, s) )
 void multi_options_read_config()
 {

--- a/code/network/multi_pxo.cpp
+++ b/code/network/multi_pxo.cpp
@@ -1448,7 +1448,7 @@ void multi_pxo_blit_all()
 		} else {
 			gr_clear();
 		} 
-	} while(0);
+	} while(false);
 	if(Multi_pxo_bitmap != -1){
 		gr_set_bitmap(Multi_pxo_bitmap);
 		gr_bitmap(0,0,GR_RESIZE_MENU);

--- a/code/network/multi_rate.cpp
+++ b/code/network/multi_rate.cpp
@@ -124,7 +124,7 @@ int multi_rate_add(int np_index, const char *type, int size)
 }
 
 // process
-#define R_AVG(ct, ar, avg)		do {int av_idx; float av_sum = 0.0f; if(ct == 0){ avg = 0;} else { for(av_idx=0; av_idx<ct; av_idx++){ av_sum += (float)ar[av_idx]; } avg = av_sum / (float)ct; } }while(0)
+#define R_AVG(ct, ar, avg)		do {int av_idx; float av_sum = 0.0f; if(ct == 0){ avg = 0;} else { for(av_idx=0; av_idx<ct; av_idx++){ av_sum += (float)ar[av_idx]; } avg = av_sum / (float)ct; } }while(false)
 void multi_rate_process()
 {
 	int idx, s_idx;

--- a/code/network/multi_respawn.cpp
+++ b/code/network/multi_respawn.cpp
@@ -890,7 +890,7 @@ void multi_respawn_place(object *new_obj, int team)
 			collided = 1; \
 		} \
 	} \
-} while(0)
+} while(false)
 
 #define MOVE_AWAY_BBOX() do { \
 	if (pm != NULL) { \
@@ -912,7 +912,7 @@ void multi_respawn_place(object *new_obj, int team)
 			break; \
 		} \
 	} \
-} while(0)
+} while(false)
 
 
 void prevent_spawning_collision(object *new_obj)

--- a/code/network/multi_team.cpp
+++ b/code/network/multi_team.cpp
@@ -568,7 +568,7 @@ void multi_team_get_player_counts(int *team0, int *team1)
 }
 
 // report on the winner/loser of the game via chat text
-#define SEND_AND_DISPLAY(mesg)		do { send_game_chat_packet(Net_player, mesg, MULTI_MSG_ALL, NULL, NULL, 1); multi_display_chat_msg(mesg, 0, 0); } while(0);
+#define SEND_AND_DISPLAY(mesg)		do { send_game_chat_packet(Net_player, mesg, MULTI_MSG_ALL, NULL, NULL, 1); multi_display_chat_msg(mesg, 0, 0); } while(false);
 void multi_team_report()
 {
 	int i;

--- a/code/network/multimsgs.cpp
+++ b/code/network/multimsgs.cpp
@@ -8150,8 +8150,8 @@ void process_flak_fired_packet(ubyte *data, header *hinfo)
 	}
 }
 
-#define ADD_NORM_VEC(d) do { Assert((packet_size + 3) < MAX_PACKET_SIZE); char vnorm[3] = { (char)(d.x * 127.0f), (char)(d.y * 127.0f), (char)(d.z * 127.0f) }; memcpy(data + packet_size, vnorm, 3); packet_size += 3; } while(0);
-#define GET_NORM_VEC(d) do { char vnorm[3]; memcpy(vnorm, data+offset, 3); d.x = (float)vnorm[0] / 127.0f; d.y = (float)vnorm[1] / 127.0f; d.z = (float)vnorm[2] / 127.0f; } while(0);
+#define ADD_NORM_VEC(d) do { Assert((packet_size + 3) < MAX_PACKET_SIZE); char vnorm[3] = { (char)(d.x * 127.0f), (char)(d.y * 127.0f), (char)(d.z * 127.0f) }; memcpy(data + packet_size, vnorm, 3); packet_size += 3; } while(false);
+#define GET_NORM_VEC(d) do { char vnorm[3]; memcpy(vnorm, data+offset, 3); d.x = (float)vnorm[0] / 127.0f; d.y = (float)vnorm[1] / 127.0f; d.z = (float)vnorm[2] / 127.0f; } while(false);
 
 // player pain packet
 void send_player_pain_packet(net_player *pl, int weapon_info_index, float damage, vec3d *force, vec3d *hitpos, int quadrant_num)

--- a/code/network/multimsgs.h
+++ b/code/network/multimsgs.h
@@ -34,30 +34,30 @@ struct log_entry;
 // there are two flavors of sending orientation matrices, 16 bit and 32 bit. Just #define ORIENT_16 to use
 // 16 bits, otherwise 32 bits is the default
 
-#define BUILD_HEADER(t) do { data[0]=t; packet_size = HEADER_LENGTH; } while(0)
-#define ADD_DATA(d) do { Assert((packet_size + sizeof(d)) < MAX_PACKET_SIZE); memcpy(data+packet_size, &d, sizeof(d) ); packet_size += sizeof(d); } while (0)
-#define ADD_SHORT(d) do { static_assert(sizeof(d) == sizeof(std::int16_t), "Size of short is not right!"); Assert((packet_size + sizeof(d)) < MAX_PACKET_SIZE); short swap = INTEL_SHORT(d); memcpy(data+packet_size, &swap, sizeof(d) ); packet_size += sizeof(d); } while (0)
-#define ADD_USHORT(d) do { static_assert(sizeof(d) == sizeof(std::uint16_t), "Size of unsigned short is not right!"); Assert((packet_size + sizeof(d)) < MAX_PACKET_SIZE); ushort swap = INTEL_SHORT(d); memcpy(data+packet_size, &swap, sizeof(d) ); packet_size += sizeof(d); } while (0)
-#define ADD_INT(d) do { static_assert(sizeof(d) == sizeof(std::int32_t), "Size of int is not right!"); Assert((packet_size + sizeof(d)) < MAX_PACKET_SIZE); int swap = INTEL_INT(d); memcpy(data+packet_size, &swap, sizeof(d) ); packet_size += sizeof(d); } while (0)
-#define ADD_UINT(d) do { static_assert(sizeof(d) == sizeof(std::uint32_t), "Size of unsigned int is not right!"); Assert((packet_size + sizeof(d)) < MAX_PACKET_SIZE); uint swap = INTEL_INT(d); memcpy(data+packet_size, &swap, sizeof(d) ); packet_size += sizeof(d); } while (0)
-#define ADD_ULONG(d) do { static_assert(sizeof(d) == sizeof(std::uint64_t), "Size of unsigned long is not right!"); Assert((packet_size + sizeof(d)) < MAX_PACKET_SIZE); std::uint64_t swap = INTEL_LONG(d); memcpy(data+packet_size, &swap, sizeof(d) ); packet_size += sizeof(d); } while (0)
-#define ADD_FLOAT(d) do { Assert((packet_size + sizeof(d)) < MAX_PACKET_SIZE); float swap = INTEL_FLOAT(&d); memcpy(data+packet_size, &swap, sizeof(d) ); packet_size += sizeof(d); } while (0)
-#define ADD_STRING(s) do { Assert((packet_size + strlen(s) + 4) < MAX_PACKET_SIZE);int len = (int)strlen(s); int len_tmp = INTEL_INT(len); ADD_DATA(len_tmp); memcpy(data+packet_size, s, len ); packet_size += len; } while(0)
+#define BUILD_HEADER(t) do { data[0]=t; packet_size = HEADER_LENGTH; } while(false)
+#define ADD_DATA(d) do { Assert((packet_size + sizeof(d)) < MAX_PACKET_SIZE); memcpy(data+packet_size, &d, sizeof(d) ); packet_size += sizeof(d); } while (false)
+#define ADD_SHORT(d) do { static_assert(sizeof(d) == sizeof(std::int16_t), "Size of short is not right!"); Assert((packet_size + sizeof(d)) < MAX_PACKET_SIZE); short swap = INTEL_SHORT(d); memcpy(data+packet_size, &swap, sizeof(d) ); packet_size += sizeof(d); } while (false)
+#define ADD_USHORT(d) do { static_assert(sizeof(d) == sizeof(std::uint16_t), "Size of unsigned short is not right!"); Assert((packet_size + sizeof(d)) < MAX_PACKET_SIZE); ushort swap = INTEL_SHORT(d); memcpy(data+packet_size, &swap, sizeof(d) ); packet_size += sizeof(d); } while (false)
+#define ADD_INT(d) do { static_assert(sizeof(d) == sizeof(std::int32_t), "Size of int is not right!"); Assert((packet_size + sizeof(d)) < MAX_PACKET_SIZE); int swap = INTEL_INT(d); memcpy(data+packet_size, &swap, sizeof(d) ); packet_size += sizeof(d); } while (false)
+#define ADD_UINT(d) do { static_assert(sizeof(d) == sizeof(std::uint32_t), "Size of unsigned int is not right!"); Assert((packet_size + sizeof(d)) < MAX_PACKET_SIZE); uint swap = INTEL_INT(d); memcpy(data+packet_size, &swap, sizeof(d) ); packet_size += sizeof(d); } while (false)
+#define ADD_ULONG(d) do { static_assert(sizeof(d) == sizeof(std::uint64_t), "Size of unsigned long is not right!"); Assert((packet_size + sizeof(d)) < MAX_PACKET_SIZE); std::uint64_t swap = INTEL_LONG(d); memcpy(data+packet_size, &swap, sizeof(d) ); packet_size += sizeof(d); } while (false)
+#define ADD_FLOAT(d) do { Assert((packet_size + sizeof(d)) < MAX_PACKET_SIZE); float swap = INTEL_FLOAT(&d); memcpy(data+packet_size, &swap, sizeof(d) ); packet_size += sizeof(d); } while (false)
+#define ADD_STRING(s) do { Assert((packet_size + strlen(s) + 4) < MAX_PACKET_SIZE);int len = (int)strlen(s); int len_tmp = INTEL_INT(len); ADD_DATA(len_tmp); memcpy(data+packet_size, s, len ); packet_size += len; } while(false)
 #define ADD_ORIENT(d) { Assert((packet_size + 17) < MAX_PACKET_SIZE); ubyte dt[17]; multi_pack_orient_matrix(dt,&d); memcpy(data+packet_size,dt,17); packet_size += 17; }
-#define ADD_VECTOR(d) do { vec3d tmpvec = ZERO_VECTOR; tmpvec.xyz.x = INTEL_FLOAT(&d.xyz.x); tmpvec.xyz.y = INTEL_FLOAT(&d.xyz.y); tmpvec.xyz.z = INTEL_FLOAT(&d.xyz.z); ADD_DATA(tmpvec); } while(0)
+#define ADD_VECTOR(d) do { vec3d tmpvec = ZERO_VECTOR; tmpvec.xyz.x = INTEL_FLOAT(&d.xyz.x); tmpvec.xyz.y = INTEL_FLOAT(&d.xyz.y); tmpvec.xyz.z = INTEL_FLOAT(&d.xyz.z); ADD_DATA(tmpvec); } while(false)
 
-#define GET_DATA(d) do { memcpy(&d, data+offset, sizeof(d) ); offset += sizeof(d); } while(0)
-#define GET_SHORT(d) do { std::int16_t swap; memcpy(&swap, data+offset, sizeof(d) ); d = INTEL_SHORT(swap); offset += sizeof(d); } while(0)
-#define GET_USHORT(d) do { std::uint16_t swap; memcpy(&swap, data+offset, sizeof(d) ); d = INTEL_SHORT(swap); offset += sizeof(d); } while(0)
-#define GET_INT(d) do { std::int32_t swap; memcpy(&swap, data+offset, sizeof(d) ); d = INTEL_INT(swap); offset += sizeof(d); } while(0)
-#define GET_UINT(d) do { std::uint32_t swap; memcpy(&swap, data+offset, sizeof(d) ); d = INTEL_INT(swap); offset += sizeof(d); } while(0)
-#define GET_ULONG(d) do { std::uint64_t swap; memcpy(&swap, data+offset, sizeof(d) ); d = INTEL_LONG(swap); offset += sizeof(d); } while(0)
-#define GET_FLOAT(d) do { float swap; memcpy(&swap, data+offset, sizeof(d) ); d = INTEL_FLOAT(&swap); offset += sizeof(d); } while(0)
-#define GET_STRING(s) do { int len;  memcpy(&len, data+offset, sizeof(len)); len = INTEL_INT(len); offset += sizeof(len); memcpy(s, data+offset, len); offset += len; s[len] = '\0'; } while(0)
+#define GET_DATA(d) do { memcpy(&d, data+offset, sizeof(d) ); offset += sizeof(d); } while(false)
+#define GET_SHORT(d) do { std::int16_t swap; memcpy(&swap, data+offset, sizeof(d) ); d = INTEL_SHORT(swap); offset += sizeof(d); } while(false)
+#define GET_USHORT(d) do { std::uint16_t swap; memcpy(&swap, data+offset, sizeof(d) ); d = INTEL_SHORT(swap); offset += sizeof(d); } while(false)
+#define GET_INT(d) do { std::int32_t swap; memcpy(&swap, data+offset, sizeof(d) ); d = INTEL_INT(swap); offset += sizeof(d); } while(false)
+#define GET_UINT(d) do { std::uint32_t swap; memcpy(&swap, data+offset, sizeof(d) ); d = INTEL_INT(swap); offset += sizeof(d); } while(false)
+#define GET_ULONG(d) do { std::uint64_t swap; memcpy(&swap, data+offset, sizeof(d) ); d = INTEL_LONG(swap); offset += sizeof(d); } while(false)
+#define GET_FLOAT(d) do { float swap; memcpy(&swap, data+offset, sizeof(d) ); d = INTEL_FLOAT(&swap); offset += sizeof(d); } while(false)
+#define GET_STRING(s) do { int len;  memcpy(&len, data+offset, sizeof(len)); len = INTEL_INT(len); offset += sizeof(len); memcpy(s, data+offset, len); offset += len; s[len] = '\0'; } while(false)
 #define GET_ORIENT(d) { ubyte dt[17]; memcpy(dt,data+offset,17); offset+=17; multi_unpack_orient_matrix(dt,&d); }
-#define GET_VECTOR(d) do { vec3d tmpvec = ZERO_VECTOR; GET_DATA(tmpvec); d.xyz.x = INTEL_FLOAT(&tmpvec.xyz.x); d.xyz.y = INTEL_FLOAT(&tmpvec.xyz.y); d.xyz.z = INTEL_FLOAT(&tmpvec.xyz.z); } while(0)
+#define GET_VECTOR(d) do { vec3d tmpvec = ZERO_VECTOR; GET_DATA(tmpvec); d.xyz.x = INTEL_FLOAT(&tmpvec.xyz.x); d.xyz.y = INTEL_FLOAT(&tmpvec.xyz.y); d.xyz.z = INTEL_FLOAT(&tmpvec.xyz.z); } while(false)
 
-#define PACKET_SET_SIZE() do { hinfo->bytes_processed = offset; } while(0)
+#define PACKET_SET_SIZE() do { hinfo->bytes_processed = offset; } while(false)
 
 // defines for weapon status changes.
 #define MULTI_PRIMARY_CHANGED		1

--- a/code/network/multiui.cpp
+++ b/code/network/multiui.cpp
@@ -706,9 +706,9 @@ int Multi_join_list_selected;						// which item we have selected
 active_game *Multi_join_selected_item;			// a pointer to the corresponding active_game
 
 // use this macro to modify the list start
-#define MJ_LIST_START_INC()			do { Multi_join_list_start++; } while(0);
-#define MJ_LIST_START_DEC()			do { Multi_join_list_start--; } while(0);
-#define MJ_LIST_START_SET(vl)			do { Multi_join_list_start = vl; } while(0);
+#define MJ_LIST_START_INC()			do { Multi_join_list_start++; } while(false);
+#define MJ_LIST_START_DEC()			do { Multi_join_list_start--; } while(false);
+#define MJ_LIST_START_SET(vl)			do { Multi_join_list_start = vl; } while(false);
 
 // if we should be sending a join request at the end of the frame
 int Multi_join_should_send = -1;

--- a/code/object/object.h
+++ b/code/object/object.h
@@ -252,7 +252,7 @@ void obj_delete_all();
 void obj_merge_created_list(void);
 
 // recalculate object pairs for an object
-#define OBJ_RECALC_PAIRS(obj_to_reset)		do {	obj_set_flags(obj_to_reset, obj_to_reset->flags - Object::Object_Flags::Collides); obj_set_flags(obj_to_reset, obj_to_reset->flags + Object::Object_Flags::Collides); } while(0);
+#define OBJ_RECALC_PAIRS(obj_to_reset)		do {	obj_set_flags(obj_to_reset, obj_to_reset->flags - Object::Object_Flags::Collides); obj_set_flags(obj_to_reset, obj_to_reset->flags + Object::Object_Flags::Collides); } while(false);
 
 //	Returns true if objects A and B are expected to collide in next duration seconds.
 //	For purposes of this check, the first object moves from current location to predicted

--- a/code/pcxutils/pcxutils.cpp
+++ b/code/pcxutils/pcxutils.cpp
@@ -108,7 +108,7 @@ int pcx_read_header(const char *real_filename, CFILE *img_cfp, int *w, int *h, i
 // int Pcx_load_offset = 0;
 // int Pcx_load_size = 0;
 /*
-// #define GET_BUF()			do { buffer = &Pcx_load[Pcx_load_offset]; if(Pcx_load_offset + buffer_size > Pcx_load_size) { buffer_size = Pcx_load_size - Pcx_load_offset; } } while(0);
+// #define GET_BUF()			do { buffer = &Pcx_load[Pcx_load_offset]; if(Pcx_load_offset + buffer_size > Pcx_load_size) { buffer_size = Pcx_load_size - Pcx_load_offset; } } while(false);
 int pcx_read_bitmap_8bpp( char * real_filename, ubyte *org_data, ubyte *palette )
 {
 	PCXHeader header;

--- a/code/tracing/Monitor.h
+++ b/code/tracing/Monitor.h
@@ -64,6 +64,6 @@ class Monitor: public MonitorBase {
 #define MONITOR(function_name)				static ::tracing::Monitor<int> mon_##function_name(#function_name, 0);
 
 // Increments a monitor variable
-#define MONITOR_INC(function_name, inc)		do { mon_##function_name += (inc); } while(0)
+#define MONITOR_INC(function_name, inc)		do { mon_##function_name += (inc); } while(false)
 
 

--- a/code/weapon/beam.cpp
+++ b/code/weapon/beam.cpp
@@ -1148,13 +1148,13 @@ void beam_move_all_post()
 	verts[2]->texture_position.v = 1.0f;\
 	verts[3]->texture_position.u = 0.0f;\
 	verts[3]->texture_position.v = 1.0f;\
-} while(0);
+} while(false);
 
 #define P_VERTICES()		do {\
 	for(idx=0; idx<4; idx++){\
 		g3_project_vertex(verts[idx]);\
 	}\
-} while(0);
+} while(false);
 
 void beam_render(beam *b, float u_offset)
 {	

--- a/fred2/fred.h
+++ b/fred2/fred.h
@@ -31,7 +31,7 @@
 		a = (b);            \
 		set_modified();     \
 	}                       \
-} while(0)
+} while(false)
 
 #define F_RENDER_SHIP_MODELS 0x01
 #define F_RENDER_SHIP_ICONS  0x02

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -6606,7 +6606,7 @@ void game_spew_pof_info_sub(int model_num, polymodel *pm, int sm, CFILE *out, in
 	*out_destroyed_total += sub_total_destroyed;
 }
 
-#define BAIL()			do { int _idx; for(_idx=0; _idx<num_files; _idx++){ if(pof_list[_idx] != NULL){vm_free(pof_list[_idx]); pof_list[_idx] = NULL;}} return;} while(0);
+#define BAIL()			do { int _idx; for(_idx=0; _idx<num_files; _idx++){ if(pof_list[_idx] != NULL){vm_free(pof_list[_idx]); pof_list[_idx] = NULL;}} return;} while(false);
 void game_spew_pof_info()
 {
 	char *pof_list[1000];


### PR DESCRIPTION
These Coverity issues are all caused by the same code being copy and pasted in three different places.

There does not seem to be actual danger of the negative array access, but the changes that "fix" it are also slight optimizations (placing a few variable assignments outside loops so that it only has to call the function once).

In short, I am basically just moving code around to avoid duplicate checks that coverity is suspicious of, and in other places checking for the negative array index explicitly.