### PR TITLE
Two subsystem-related fixes

### DIFF
--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -21274,15 +21274,18 @@ void sexp_subsys_set_random(int node)
 			// get non excluded subsystem
 			subsys = ship_get_indexed_subsys(shipp, idx, NULL);
 			if (subsys == NULL) {
-				nprintf(("Warning", "Nonexistent subsystem for index %d on ship %s for sabotage subsystem\n", idx, shipp->ship_name));
+				nprintf(("Warning", "Nonexistent subsystem for index %d on ship %s for subsys set random\n", idx, shipp->ship_name));
 				continue;
 			}
 
 			// randomize its hit points
 			rand = rand_internal(low, high);
-			subsys->current_hits = 0.01f * rand * subsys->max_hits;
+			set_subsys_strength_and_maybe_ancestors(shipp, subsys, nullptr, &rand, nullptr, nullptr, true, true);
 		}
 	}
+
+	// needed to keep aggregate info correct
+	ship_recalc_subsys_strength(shipp);
 }
 
 void sexp_supernova_start(int node)


### PR DESCRIPTION
1) When considering whether a disable/disarm/destroy-subsys goal is achievable, check the actual status of the subsystem, not the mission log.  This fixes #2124.

2) When setting the subsystem strengths to random values, submodels should be destroyed or repaired as appropriate (which should have been included in #2042 but was missed) and the aggregate subsystem information should be recalculated (which has been missing since retail).