### PR TITLE
Fix Dumb_Rotate Regression

### DIFF
--- a/code/jumpnode/jumpnode.cpp
+++ b/code/jumpnode/jumpnode.cpp
@@ -18,7 +18,7 @@ SCP_list<CJumpNode> Jump_nodes;
 /**
  * Constructor for CJumpNode class, default
  */
-CJumpNode::CJumpNode() : m_radius(0.0f), m_modelnum(-1), m_objnum(-1), m_flags(0)
+CJumpNode::CJumpNode()
 {	
     gr_init_alphacolor(&m_display_color, 0, 255, 0, 255);
 
@@ -33,7 +33,6 @@ CJumpNode::CJumpNode() : m_radius(0.0f), m_modelnum(-1), m_objnum(-1), m_flags(0
  * Constructor for CJumpNode class, with world position argument
  */
 CJumpNode::CJumpNode(vec3d* position)
-    : m_radius(0.0f), m_modelnum(-1), m_objnum(-1), m_flags(0)
 {	
 	Assert(position != NULL);
 	

--- a/code/jumpnode/jumpnode.h
+++ b/code/jumpnode/jumpnode.h
@@ -36,6 +36,7 @@ private:
 
     int	m_modelnum;
     int	m_objnum;						// objnum of this jump node
+	int m_polymodel_instance_num {-1}; // polymodel instance number, used for rotations 
 
     int m_flags;
     color m_display_color;			// Color node will be shown in (Default:0/255/0/255)
@@ -58,6 +59,7 @@ public:
     char *GetName();
     int GetModelNumber();
     int GetSCPObjectNumber();
+	int GetPolymodelInstanceNum(); 
     object *GetSCPObject();
     color GetColor();
     vec3d *GetPosition();
@@ -83,6 +85,7 @@ extern SCP_list<CJumpNode> Jump_nodes;
 
 //-----Functions-----
 CJumpNode *jumpnode_get_by_name(const char *name);
+CJumpNode *jumpnode_get_by_objnum(int objnum);
 CJumpNode *jumpnode_get_which_in(object *objp);
 
 void jumpnode_render_all();

--- a/code/jumpnode/jumpnode.h
+++ b/code/jumpnode/jumpnode.h
@@ -32,13 +32,13 @@ class CJumpNode
 {
 private:
     char m_name[NAME_LENGTH];
-    float m_radius;
+    float m_radius {0.0f};
 
-    int	m_modelnum;
-    int	m_objnum;						// objnum of this jump node
+    int	m_modelnum {-1};
+	int m_objnum {-1};                 // objnum of this jump node
 	int m_polymodel_instance_num {-1}; // polymodel instance number, used for rotations 
 
-    int m_flags;
+    int m_flags {0};
     color m_display_color;			// Color node will be shown in (Default:0/255/0/255)
 	vec3d m_pos;
 

--- a/code/model/modelrender.cpp
+++ b/code/model/modelrender.cpp
@@ -19,6 +19,7 @@
 #include "graphics/light.h"
 #include "graphics/uniforms.h"
 #include "io/timer.h"
+#include "jumpnode/jumpnode.h"
 #include "math/staticrand.h"
 #include "mod_table/mod_table.h"
 #include "model/modelrender.h"
@@ -2628,12 +2629,17 @@ void model_render_queue(model_render_params* interp, model_draw_list* scene, int
 			pmi = model_get_instance(shipp->model_instance_num);
 		}
 		else if (pm->flags & PM_FLAG_HAS_INTRINSIC_ROTATE) {
-			if (objp->type == OBJ_ASTEROID)
+			if (objp->type == OBJ_ASTEROID) {
 				pmi = model_get_instance(Asteroids[objp->instance].model_instance_num);
-			else if (objp->type == OBJ_WEAPON)
+			} else if (objp->type == OBJ_WEAPON) {
 				pmi = model_get_instance(Weapons[objp->instance].model_instance_num);
-			else
+			} else if (objp->type == OBJ_JUMP_NODE) {
+				CJumpNode* jnp = jumpnode_get_by_objnum(objnum);
+				Assertion(jnp != nullptr, "Could not find jump node with object number %d!", objnum);
+				pmi = model_get_instance(jnp->GetPolymodelInstanceNum());
+			} else {			
 				Warning(LOCATION, "Unsupported object type %d for rendering intrinsic-rotate submodels!", objp->type);
+			}
 		}
 	}
 


### PR DESCRIPTION
Allows jump nodes to use instrinsic/dumb rotation again by exposing the jump node class to the model instancing code and adding a check for it in modelread.  For #1682