### PR TITLE
init tracker when attempting to validate game data

### DIFF
--- a/code/network/multi_fstracker.cpp
+++ b/code/network/multi_fstracker.cpp
@@ -1238,6 +1238,8 @@ int multi_fs_tracker_validate_game_data()
 	// should only do this only once per game session
 	static int game_data_status = TVALID_STATUS_UNKNOWN;
 
+	multi_fs_tracker_init();
+
 	if ( !Multi_fs_tracker_inited ) {
 		return 1; // assume hacked
 	}


### PR DESCRIPTION
Due to the order in which the standalone code initializes, PXO table validation and mod detection ends up being broken. This makes sure that PXO is initted when table validation occurs. Is only called when PXO is supposed to be used.