### PR TITLE
Auto port forwarding

### DIFF
--- a/code/CMakeLists.txt
+++ b/code/CMakeLists.txt
@@ -41,6 +41,8 @@ target_link_libraries(code PUBLIC discord-rpc)
 
 target_link_libraries(code PUBLIC libRocket)
 
+target_link_libraries(code PUBLIC pcp)
+
 enable_clang_tidy(code)
 
 IF (FSO_USE_SPEECH)

--- a/code/cmdline/cmdline.cpp
+++ b/code/cmdline/cmdline.cpp
@@ -203,6 +203,7 @@ Flag exe_params[] =
 	{ "-multilog",			"",											false,	0,					EASY_DEFAULT,		"Multiplayer",	"http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-multilog", },
 	{ "-clientdamage",		"",											false,	0,					EASY_DEFAULT,		"Multiplayer",	"http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-clientdamage", },
 	{ "-mpnoreturn",		"Disable flight deck option",				true,	0,					EASY_DEFAULT,		"Multiplayer",	"http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-mpnoreturn", },
+	{ "-gateway_ip",		"Set gateway IP address",					false,	0,					EASY_DEFAULT,		"Multiplayer",	"http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-gateway_ip", },
 
 	{ "-no_set_gamma",		"Disable setting of gamma",					true,	0,					EASY_DEFAULT,		"Troubleshoot",	"http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-no_set_gamma", },
 	{ "-nomovies",			"Disable video playback",					true,	0,					EASY_DEFAULT,		"Troubleshoot",	"http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-nomovies", },
@@ -406,11 +407,13 @@ cmdline_parm almission_arg("-almission", "Autoload multiplayer mission", AT_STRI
 cmdline_parm ingamejoin_arg("-ingame_join", NULL, AT_NONE);	// Cmdline_ingamejoin
 cmdline_parm mpnoreturn_arg("-mpnoreturn", NULL, AT_NONE);	// Cmdline_mpnoreturn  -- Removes 'Return to Flight Deck' in respawn dialog -C
 cmdline_parm objupd_arg("-cap_object_update", "Multiplayer object update cap (0-3)", AT_INT);
+cmdline_parm gateway_ip_arg("-gateway_ip", "Set gateway IP address", AT_STRING);
 
 char *Cmdline_almission = NULL;	//DTP for autoload multi mission.
 int Cmdline_ingamejoin = 0;
 int Cmdline_mpnoreturn = 0;
 int Cmdline_objupd = 3;		// client object updates on LAN by default
+char *Cmdline_gateway_ip = nullptr;
 
 // Launcher related options
 cmdline_parm portable_mode("-portable_mode", NULL, AT_NONE);
@@ -1630,6 +1633,11 @@ bool SetCmdlineParams()
 	// get the port number for games
 	if ( port_arg.found() ) {
 		Cmdline_network_port = port_arg.get_int();
+	}
+
+	// get IP address of gateway, for auto port forwarding
+	if ( gateway_ip_arg.found() ) {
+		Cmdline_gateway_ip = gateway_ip_arg.str();
 	}
 
 	// the connect argument specifies to join a game at this particular address

--- a/code/cmdline/cmdline.h
+++ b/code/cmdline/cmdline.h
@@ -103,6 +103,7 @@ extern char *Cmdline_almission;	// DTP for autoload mission (for multi only)
 extern int Cmdline_ingamejoin;
 extern int Cmdline_mpnoreturn;
 extern int Cmdline_objupd;
+extern char *Cmdline_gateway_ip;
 
 // Launcher related options
 extern bool Cmdline_portable_mode;

--- a/code/menuui/credits.cpp
+++ b/code/menuui/credits.cpp
@@ -101,6 +101,7 @@ const char *fs2_open_credit_text =
 	"liblua (" LUA_RELEASE ") - " LUA_COPYRIGHT "\n"
 	"zlib - Copyright (C) 1995-2005 Jean-loup Gailly and Mark Adler\n"
 	"FXAA - Copyright (c) 2010 NVIDIA Corporation. All rights reserved.\n"
+	"libpcp - Copyright (c) 2013 by Cisco Systems, Inc.\n"
 	"This software uses libraries from the FFmpeg project under the LGPLv2.1\n"
 	"\n"
 	"\n"

--- a/code/network/multi.cpp
+++ b/code/network/multi.cpp
@@ -1314,7 +1314,7 @@ void multi_do_frame()
 	}
 
 	// if master then maybe do port forwarding setup/refresh/wait
-	if ( (Net_player->flags & NETINFO_FLAG_AM_MASTER) && (Net_player->flags & NETINFO_FLAG_CONNECTED) ) {
+	if (Net_player->flags & NETINFO_FLAG_AM_MASTER) {
 		multi_port_forward_do();
 	}
 }

--- a/code/network/multi_endgame.cpp
+++ b/code/network/multi_endgame.cpp
@@ -22,6 +22,7 @@
 #include "network/multiui.h"
 #include "network/multiutil.h"
 #include "network/multi_pmsg.h"
+#include "network/multi_portfwd.h"
 #include "hud/hudconfig.h"
 #include "network/multi_fstracker.h"
 
@@ -386,6 +387,9 @@ void multi_endgame_cleanup()
 		if (Net_player->flags & NETINFO_FLAG_MT_CONNECTED) {
 			multi_fs_tracker_logout();
 		}
+
+		// stop port forwarding
+		multi_port_forward_close();
 
 		// if we're in Parallax Online mode, log back in there	
 		if (Multi_options_g.pxo == 1) {

--- a/code/network/multi_portfwd.cpp
+++ b/code/network/multi_portfwd.cpp
@@ -1,0 +1,243 @@
+/*
+ * Copyright (C) Volition, Inc. 1999.  All rights reserved.
+ *
+ * All source code herein is the property of Volition, Inc. You may not sell
+ * or otherwise commercially exploit the source or things you created based on the
+ * source.
+ *
+*/
+
+#ifdef _WIN32
+#include <winsock2.h>
+#include <ws2tcpip.h>
+#else
+#include <arpa/inet.h>
+#include <netdb.h>
+#endif
+
+#include "pcp.h"
+
+#include "cmdline/cmdline.h"
+#include "io/timer.h"
+#include "network/multi_log.h"
+#include "network/multi_portfwd.h"
+#include "network/psnet2.h"
+
+// from "default_config.h" in libpcp
+#ifndef PCP_SERVER_PORT
+#define PCP_SERVER_PORT 5351
+#endif
+
+#ifndef PCP_MAX_SUPPORTED_VERSION
+#define PCP_MAX_SUPPORTED_VERSION 2
+#endif
+
+
+static bool PF_initted = false;
+
+static pcp_flow_t *PF_pcp_flow = nullptr;
+static pcp_ctx_t *PF_pcp_ctx = nullptr;
+
+static int PF_wait_timestamp = 0;
+
+static const uint32_t PF_lifetime = 7200;	// 2 hrs
+
+static bool PF_get_addr(const char *host, const uint16_t port, struct sockaddr *addr);
+static void PF_log_init();
+
+
+void multi_port_forward_init()
+{
+	struct sockaddr_storage gateway_addr;
+	struct sockaddr_storage local_addr;
+	int wait_ms;
+	bool auto_discover = true;
+
+	if (PF_initted) {
+		return;
+	}
+
+	if (Cmdline_gateway_ip) {
+		if ( PF_get_addr(Cmdline_gateway_ip, PCP_SERVER_PORT,
+						 reinterpret_cast<struct sockaddr *>(&gateway_addr)) )
+		{
+			auto_discover = false;
+		}
+	}
+
+	PF_log_init();	// must call before pcp_init() to fix logging
+
+	PF_pcp_ctx = pcp_init(auto_discover ? ENABLE_AUTODISCOVERY : DISABLE_AUTODISCOVERY, nullptr);
+
+	if (PF_pcp_ctx == nullptr) {
+		ml_string("Port forward => Initialization failed!");
+		return;
+	}
+
+	// this needs to be after successful pcp_init() so we'll know to shutdown
+	PF_initted = true;
+
+	if ( !auto_discover ) {
+		pcp_add_server(PF_pcp_ctx, reinterpret_cast<struct sockaddr *>(&gateway_addr), PCP_MAX_SUPPORTED_VERSION);
+	}
+
+	PF_get_addr(nullptr, Psnet_default_port, reinterpret_cast<struct sockaddr *>(&local_addr));
+
+	PF_pcp_flow = pcp_new_flow(PF_pcp_ctx, reinterpret_cast<struct sockaddr *>(&local_addr),
+							   nullptr, nullptr, IPPROTO_UDP, PF_lifetime, nullptr);
+
+	if (PF_pcp_flow == nullptr) {
+		ml_string("Port forward => Failed to init mapping!");
+		multi_port_forward_close();
+		return;
+	}
+
+	ml_string("Port forward => Initialized successfully");
+
+	// let's start this ball rolling...
+	wait_ms = pcp_pulse(PF_pcp_ctx, nullptr);
+	PF_wait_timestamp = timer_get_milliseconds() + wait_ms;
+}
+
+void multi_port_forward_do()
+{
+	pcp_fstate_e state;
+	size_t info_count = 0;
+	int wait_ms;
+
+	if ( !PF_initted ) {
+		return;
+	}
+
+	if ( PF_wait_timestamp > timer_get_milliseconds() ) {
+		return;
+	}
+
+	// this ultimately does everything to maintain the connection
+	wait_ms = pcp_pulse(PF_pcp_ctx, nullptr);
+	PF_wait_timestamp = timer_get_milliseconds() + wait_ms;
+
+	// check progress and log if needed
+	if ( pcp_eval_flow_state(PF_pcp_flow, &state) ) {
+		if (state == pcp_state_failed) {
+			ml_string("Port forward => Mapping failed!");
+		} else if (state == pcp_state_succeeded) {
+			pcp_flow_info_t *flow_info = pcp_flow_get_info(PF_pcp_flow, &info_count);
+
+			for (size_t idx = 0; idx < info_count; ++idx) {
+				pcp_flow_info_t *info = &flow_info[idx];
+
+				char time_str[16];
+				char int_ip[INET6_ADDRSTRLEN];
+				char ext_ip[INET6_ADDRSTRLEN];
+
+				memset(&int_ip, 0, sizeof(int_ip));
+				memset(&ext_ip, 0, sizeof(ext_ip));
+
+				inet_ntop(AF_INET6, &info->int_ip, int_ip, sizeof(int_ip));
+				inet_ntop(AF_INET6, &info->ext_ip, ext_ip, sizeof(ext_ip));
+
+				ml_printf("Port forward => Mapping successful (%s:%u <-> %s:%u)",
+						  int_ip, ntohs(info->int_port),
+						  ext_ip, ntohs(info->ext_port));
+
+				// formatted to match what multi_log uses
+				strftime(time_str, sizeof(time_str), "%m/%d %H:%M:%S", localtime(&info->recv_lifetime_end));
+				ml_printf("Port forward => Mapping valid until %s", time_str);
+			}
+
+			if (flow_info) {
+				free(flow_info);	// system call, allocated in lib  ** don't change! **
+			}
+		}
+	}
+}
+
+void multi_port_forward_close()
+{
+	if ( !PF_initted ) {
+		return;
+	}
+
+	pcp_terminate(PF_pcp_ctx, 1);
+
+	if (PF_pcp_flow) {
+		ml_string("Port forward => Mapping removed");
+	} else {
+		ml_string("Port forward => Shutdown");
+	}
+
+	PF_pcp_ctx = nullptr;
+	PF_pcp_flow = nullptr;
+
+	PF_initted = false;
+
+	PF_wait_timestamp = 0;
+}
+
+
+static bool PF_get_addr(const char *host, const uint16_t port, struct sockaddr *addr)
+{
+	struct addrinfo hints, *srvinfo;
+	bool success = false;
+
+	Assert(addr != nullptr);
+
+	memset(&hints, 0, sizeof(hints));
+
+	hints.ai_family = AF_UNSPEC;
+	hints.ai_socktype = SOCK_DGRAM;
+	hints.ai_flags = AI_V4MAPPED;
+
+	if (host == nullptr) {
+		hints.ai_flags |= AI_PASSIVE;
+	}
+
+	SCP_string port_str = std::to_string(port);
+
+	int rval = getaddrinfo(host, port_str.c_str(), &hints, &srvinfo);
+
+	if (rval) {
+		ml_printf("PF_get_addr : getaddrinfo() => %s", gai_strerror(rval));
+		return false;
+	}
+
+	for (auto *srv = srvinfo; srv != nullptr; srv = srv->ai_next) {
+		if ( (srv->ai_family == AF_INET) || (srv->ai_family == AF_INET6) ) {
+			size_t ssize = sizeof(struct sockaddr_in);
+
+			if (srv->ai_family == AF_INET6) {
+				ssize = sizeof(struct sockaddr_in6);
+			}
+
+			memcpy(addr, srv->ai_addr, ssize);
+
+			success = true;
+
+			break;
+		}
+	}
+
+	freeaddrinfo(srvinfo);
+
+	return success;
+}
+
+#ifndef NDEBUG
+static void PF_logger_fn(pcp_loglvl_e /* lvl */, const char *msg)
+{
+	ml_printf("Port forward => %s", msg);
+}
+#endif
+
+static void PF_log_init()
+{
+	// log spew for libpcp is set with this
+	pcp_log_level = PCP_LOGLVL_NONE;
+
+#ifndef NDEBUG
+	pcp_log_level = PCP_LOGLVL_INFO;
+
+	pcp_set_loggerfn(PF_logger_fn);
+#endif
+}

--- a/code/network/multi_portfwd.cpp
+++ b/code/network/multi_portfwd.cpp
@@ -137,7 +137,7 @@ void multi_port_forward_do()
 				inet_ntop(AF_INET6, &info->int_ip, int_ip, sizeof(int_ip));
 				inet_ntop(AF_INET6, &info->ext_ip, ext_ip, sizeof(ext_ip));
 
-				ml_printf("Port forward => Mapping successful (%s:%u <-> %s:%u)",
+				ml_printf("Port forward => Mapping successful  [%s]:%u <-> [%s]:%u",
 						  int_ip, ntohs(info->int_port),
 						  ext_ip, ntohs(info->ext_port));
 
@@ -232,10 +232,10 @@ static void PF_logger_fn(pcp_loglvl_e /* lvl */, const char *msg)
 
 static void PF_log_init()
 {
+#ifdef NDEBUG
 	// log spew for libpcp is set with this
 	pcp_log_level = PCP_LOGLVL_NONE;
-
-#ifndef NDEBUG
+#else
 	pcp_log_level = PCP_LOGLVL_INFO;
 
 	pcp_set_loggerfn(PF_logger_fn);

--- a/code/network/multi_portfwd.h
+++ b/code/network/multi_portfwd.h
@@ -1,0 +1,17 @@
+/*
+ * Copyright (C) Volition, Inc. 1999.  All rights reserved.
+ *
+ * All source code herein is the property of Volition, Inc. You may not sell
+ * or otherwise commercially exploit the source or things you created based on the
+ * source.
+ *
+*/
+
+#ifndef MULTI_PORTFWD_H
+#define MULTI_PORTFWD_H
+
+void multi_port_forward_init();
+void multi_port_forward_do();
+void multi_port_forward_close();
+
+#endif

--- a/code/network/multiui.cpp
+++ b/code/network/multiui.cpp
@@ -45,6 +45,7 @@
 #include "network/multi_campaign.h"
 #include "network/multi_team.h"
 #include "network/multi_pinfo.h"
+#include "network/multi_portfwd.h"
 #include "network/multi_observer.h"
 #include "network/multi_voice.h"
 #include "network/multi_endgame.h"
@@ -4141,7 +4142,10 @@ void multi_create_do_netstuff()
 void multi_create_init_as_server()
 {
 	// set me up as the host and master
-	Net_player->flags |= (NETINFO_FLAG_AM_MASTER | NETINFO_FLAG_GAME_HOST);		
+	Net_player->flags |= (NETINFO_FLAG_AM_MASTER | NETINFO_FLAG_GAME_HOST);
+
+	// setup port forwarding
+	multi_port_forward_init();
 }
 
 // if on a standalone

--- a/code/network/psnet2.h
+++ b/code/network/psnet2.h
@@ -168,9 +168,6 @@ int psnet_is_valid_ip_string( char *ip_string, int allow_port=1 );
 // mark a socket as having received data
 void psnet_mark_received(PSNET_SOCKET_RELIABLE socket);
 
-// port forwarding setup/wait processing
-void psnet_port_forward_do();
-
 // -------------------------------------------------------------------------------------------------------
 // PSNET 2 RELIABLE SOCKET FUNCTIONS
 //

--- a/code/network/psnet2.h
+++ b/code/network/psnet2.h
@@ -168,6 +168,8 @@ int psnet_is_valid_ip_string( char *ip_string, int allow_port=1 );
 // mark a socket as having received data
 void psnet_mark_received(PSNET_SOCKET_RELIABLE socket);
 
+// port forwarding setup/wait processing
+void psnet_port_forward_do();
 
 // -------------------------------------------------------------------------------------------------------
 // PSNET 2 RELIABLE SOCKET FUNCTIONS

--- a/code/source_groups.cmake
+++ b/code/source_groups.cmake
@@ -778,6 +778,8 @@ add_file_folder("Network"
 	network/multi_ping.h
 	network/multi_pmsg.cpp
 	network/multi_pmsg.h
+	network/multi_portfwd.cpp
+	network/multi_portfwd.h
 	network/multi_pxo.cpp
 	network/multi_pxo.h
 	network/multi_rate.cpp
@@ -1366,11 +1368,5 @@ add_file_folder("Weapon"
 # Windows stubs files
 add_file_folder("Windows Stubs"
 	windows_stub/config.h
+	windows_stub/stubs.cpp
 )
-
-IF(UNIX)
-	add_file_folder("Windows Stubs"
-		${file_root_windows_stubs}
-		windows_stub/stubs.cpp
-	)
-ENDIF(UNIX)

--- a/code/windows_stub/config.h
+++ b/code/windows_stub/config.h
@@ -39,6 +39,18 @@
 
 #define NETCALL_WOULDBLOCK(err) (err == WSAEWOULDBLOCK)
 
+#if (_WIN32_WINNT < 0x0600)
+#define AI_NUMERICSERV              0x00000008
+#define AI_ALL                      0x00000100
+#define AI_ADDRCONFIG               0x00000400
+#define AI_V4MAPPED                 0x00000800
+#define AI_NON_AUTHORITATIVE        0x00004000
+#define AI_SECURE                   0x00008000
+#define AI_RETURN_PREFERRED_NAMES   0x00010000
+
+extern const char *inet_ntop(int af, const void *src, char *dst, int size);
+#endif
+
 #else  // ! Win32
 
 

--- a/code/windows_stub/stubs.cpp
+++ b/code/windows_stub/stubs.cpp
@@ -30,7 +30,7 @@ const char *inet_ntop(int af, const void *src, char *dst, int size)
 		return nullptr;
 	}
 
-	srcaddr.ss_family = af;
+	srcaddr.ss_family = static_cast<short>(af);
 
 	if (WSAAddressToString(reinterpret_cast<struct sockaddr *>(&srcaddr), static_cast<DWORD>(slen),
 						   0, dst, reinterpret_cast<LPDWORD>(&size)) != 0)

--- a/code/windows_stub/stubs.cpp
+++ b/code/windows_stub/stubs.cpp
@@ -1,7 +1,48 @@
 
 
 
-#ifdef SCP_UNIX
+#ifdef _WIN32
+
+#if (_WIN32_WINNT < 0x0600)
+#include <winsock2.h>
+#include <ws2tcpip.h>
+
+const char *inet_ntop(int af, const void *src, char *dst, int size)
+{
+	struct sockaddr_storage srcaddr;
+	size_t slen;
+
+	if (af == AF_INET) {
+		struct sockaddr_in *sa4 = reinterpret_cast<struct sockaddr_in *>(&srcaddr);
+
+		memset(sa4, 0, sizeof(struct sockaddr_in));
+		memcpy(&(sa4->sin_addr), src, sizeof(sa4->sin_addr));
+
+		slen = sizeof(struct sockaddr_in);
+	} else if (af == AF_INET6) {
+		struct sockaddr_in6 *sa6 = reinterpret_cast<struct sockaddr_in6 *>(&srcaddr);
+
+		memset(sa6, 0, sizeof(struct sockaddr_in6));
+		memcpy(&(sa6->sin6_addr), src, sizeof(sa6->sin6_addr));
+
+		slen = sizeof(struct sockaddr_in6);
+	} else {
+		return nullptr;
+	}
+
+	srcaddr.ss_family = af;
+
+	if (WSAAddressToString(reinterpret_cast<struct sockaddr *>(&srcaddr), static_cast<DWORD>(slen),
+						   0, dst, reinterpret_cast<LPDWORD>(&size)) != 0)
+	{
+		return nullptr;
+	}
+
+	return dst;
+}
+#endif	// (_WIN32_WINNT < 0x0600)
+
+#else	// ! _WIN32
 
 #include <cctype>
 #include <cerrno>
@@ -238,4 +279,4 @@ int MulDiv(int number, int numerator, int denominator)
 	return result;
 }
 
-#endif // SCP_UNIX
+#endif // _WIN32

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -32,3 +32,5 @@ include(FFmpeg.cmake)
 add_subdirectory(discord)
 
 include(libRocket.cmake)
+
+add_subdirectory(libpcp)

--- a/lib/libpcp/CMakeLists.txt
+++ b/lib/libpcp/CMakeLists.txt
@@ -1,0 +1,72 @@
+set(LIBPCP_INCLUDE_DIRECTORIES
+    include
+    src
+    src/net
+)
+
+if(WIN32)
+    set(LIBPCP_INCLUDE_DIRECTORIES
+        ${LIBPCP_INCLUDE_DIRECTORIES}
+        include/windows
+        src/windows
+        win_utils
+    )
+endif(WIN32)
+
+# include directories with source and header files
+include_directories(${LIBPCP_INCLUDE_DIRECTORIES} )
+
+
+set(LIBPCP_SOURCES
+    include/pcp.h
+    src/net/gateway.c
+    src/net/gateway.h
+    src/net/findsaddr-udp.c
+    src/pcp_api.c
+    src/pcp_client_db.c
+    src/pcp_client_db.h
+    src/pcp_event_handler.c
+    src/pcp_event_handler.h
+    src/pcp_logger.c
+    src/pcp_logger.h
+    src/pcp_msg.c
+    src/pcp_msg.h
+    src/pcp_server_discovery.c
+    src/pcp_server_discovery.h
+    src/net/sock_ntop.c
+    src/net/pcp_socket.c
+    src/net/pcp_socket.h
+    src/net/findsaddr.h
+    src/net/unp.h
+)
+
+if(WIN32)
+    set(LIBPCP_SOURCES
+        ${LIBPCP_SOURCES}
+        src/windows/pcp_gettimeofday.c
+        src/windows/pcp_gettimeofday.h
+        src/windows/pcp_win_defines.h
+        src/windows/stdint.h
+    )
+endif(WIN32)
+
+
+add_library(pcp STATIC ${LIBPCP_SOURCES})
+
+if(WIN32)
+    if(MINGW)
+        target_compile_definitions(pcp PRIVATE HAVE_GETTIMEOFDAY)
+    endif(MINGW)
+
+    # target XP
+    target_compile_definitions(pcp PRIVATE WIN32 NTDDI_VERSION=0x05010000 _WIN32_WINNT=0x0501)
+    target_link_libraries(pcp INTERFACE iphlpapi ws2_32)
+endif(WIN32)
+
+suppress_warnings(pcp)
+
+set_target_properties(pcp PROPERTIES FOLDER "3rdparty")
+target_link_libraries(pcp PUBLIC compiler)
+
+target_include_directories(pcp SYSTEM PUBLIC
+    "${CMAKE_CURRENT_SOURCE_DIR}/include")

--- a/lib/libpcp/Makefile.am
+++ b/lib/libpcp/Makefile.am
@@ -1,0 +1,36 @@
+AM_CPPFLAGS = -I$(srcdir)/include -I$(srcdir)/src/net -I$(srcdir)/src
+AM_CPPFLAGS += $(PCP_CPPFLAGS)
+AM_CFLAGS = $(PCP_CFLAGS)
+
+pkginclude_HEADERS = include/pcp.h
+pkgconfigdir = $(libdir)/pkgconfig
+pkgconfig_DATA = libpcp-client.pc
+
+lib_LTLIBRARIES = libpcp-client.la
+libpcp_client_la_SOURCES = src/pcp_logger.c\
+                    src/pcp_server_discovery.c\
+                    src/pcp_client_db.c\
+                    src/pcp_msg.c\
+                    src/pcp_event_handler.c\
+                    src/net/gateway.c\
+                    src/pcp_msg_structs.h\
+                    src/pcp_api.c\
+                    src/net/findsaddr-udp.c \
+                    src/net/sock_ntop.c \
+                    src/net/pcp_socket.c
+
+noinst_HEADERS =    src/net/pcp_socket.h\
+                    src/net/gateway.h\
+                    src/pcp_event_handler.h\
+                    src/pcp_msg.h\
+                    src/pcp_client_db.h\
+                    src/pcp_logger.h\
+                    src/pcp_server_discovery.h\
+                    src/pcp_utils.h \
+                    src/net/findsaddr.h \
+                    src/net/unp.h
+
+libpcp_client_la_LDFLAGS = -version-info 0:0:0 -release 2 ${PCP_LDFLAGS}
+
+libpcp_client_la_LIBADD = $(GCOVLIB)
+

--- a/lib/libpcp/include/pcp.h
+++ b/lib/libpcp/include/pcp.h
@@ -1,0 +1,336 @@
+/*
+ Copyright (c) 2014 by Cisco Systems, Inc.
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following disclaimer in the documentation
+ and/or other materials provided with the distribution.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef PCP_H
+#define PCP_H
+
+#ifdef WIN32
+#include <winsock2.h>
+#include <in6addr.h>
+#include <ws2tcpip.h>
+#include <time.h>
+#ifndef __MINGW32__
+#include "stdint.h"
+#ifndef ssize_t
+typedef int ssize_t;
+#endif
+#endif
+#else //WIN32
+#include <sys/time.h>
+#include <stdint.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef PCP_SOCKET_IS_VOIDPTR
+#define PCP_SOCKET void *
+#else //PCP_SOCKET_IS_VOIDPTR
+#ifdef WIN32
+#define PCP_SOCKET SOCKET
+#else //WIN32
+#define PCP_SOCKET int
+#endif //WIN32
+#endif //PCP_SOCKET_IS_VOIDPTR
+
+#ifdef PCP_EXPERIMENTAL
+typedef struct pcp_userid_option *pcp_userid_option_p;
+typedef struct pcp_deviceid_option *pcp_deviceid_option_p;
+typedef struct pcp_location_option *pcp_location_option_p;
+#endif //PCP_EXPERIMENTAL
+
+typedef enum {
+    PCP_ERR_SUCCESS=0,
+    PCP_ERR_MAX_SIZE=-1,
+    PCP_ERR_OPT_ALREADY_PRESENT=-2,
+    PCP_ERR_BAD_AFINET=-3,
+    PCP_ERR_SEND_FAILED=-4,
+    PCP_ERR_RECV_FAILED=-5,
+    PCP_ERR_UNSUP_VERSION=-6,
+    PCP_ERR_NO_MEM=-7,
+    PCP_ERR_BAD_ARGS=-8,
+    PCP_ERR_UNKNOWN=-9,
+    PCP_ERR_SHORT_LIFETIME_ERR=-10,
+    PCP_ERR_TIMEOUT=-11,
+    PCP_ERR_NOT_FOUND=-12,
+    PCP_ERR_WOULDBLOCK=-13,
+    PCP_ERR_ADDRINUSE=-14
+} pcp_errno;
+
+/* DEBUG levels */
+typedef enum {
+    PCP_LOGLVL_NONE=0,
+    PCP_LOGLVL_ERR=1,
+    PCP_LOGLVL_WARN=2,
+    PCP_LOGLVL_INFO=3,
+    PCP_LOGLVL_PERR=4,
+    PCP_LOGLVL_DEBUG=5
+} pcp_loglvl_e;
+
+typedef void (*external_logger)(pcp_loglvl_e, const char *);
+
+void pcp_set_loggerfn(external_logger ext_log);
+
+// runtime level of logging
+extern pcp_loglvl_e pcp_log_level;
+
+typedef struct pcp_flow_s pcp_flow_t;
+typedef struct pcp_ctx_s pcp_ctx_t;
+
+typedef struct pcp_socket_vt_s {
+    PCP_SOCKET (*sock_create)(int domain, int type, int protocol);
+    ssize_t (*sock_recvfrom)(PCP_SOCKET sockfd, void *buf, size_t len,
+            int flags, struct sockaddr *src_addr, socklen_t *addrlen);
+    ssize_t (*sock_sendto)(PCP_SOCKET sockfd, const void *buf, size_t len,
+            int flags, struct sockaddr *dest_addr, socklen_t addrlen);
+    int (*sock_close)(PCP_SOCKET sockfd);
+} pcp_socket_vt_t;
+
+/*
+ * Initialize library, optionally initiate auto-discovery of PCP servers
+ *    autodiscovery  - enable/disable auto-discovery of PCP servers
+ *    socket_vt      - optional - virt. table to override default socket functions.
+ *                     Pointer has to be valid until pcp_terminate is called.
+ *                     Pass NULL to use default socket functions
+ *    return value   - pcp context used in other functions.
+ */
+#define ENABLE_AUTODISCOVERY  1
+#define DISABLE_AUTODISCOVERY 0
+pcp_ctx_t *pcp_init(uint8_t autodiscovery, pcp_socket_vt_t *socket_vt);
+
+//returns internal pcp server ID, -1 => error occurred
+int pcp_add_server(pcp_ctx_t *ctx, struct sockaddr *pcp_server,
+        uint8_t pcp_version);
+
+/*
+ * Close socket fds and clean up all settings, frees all library buffers
+ *      close_flows - signal end of flows to PCP servers
+ */
+void pcp_terminate(pcp_ctx_t *ctx, int close_flows);
+
+////////////////////////////////////////////////////////////////////////////////
+//                          Flow API
+
+/*
+ * Creates new PCP message from parameters parsed to this function:
+ *  src_addr    source IP/port
+ *  dst_addr    destination IP/port - optional
+ *  ext_addr    sugg. ext. IP/port  - optional
+ *  protocol    protocol associated with flow
+ *  lifetime    time in seconds how long should mapping last
+ *  userdata    pointer to user data associated with a new flow
+ *
+ *  return value
+ *  pcp_flow_t *used in other functions to reference this flow.
+ */
+pcp_flow_t *pcp_new_flow(pcp_ctx_t *ctx, struct sockaddr *src_addr,
+        struct sockaddr *dst_addr, struct sockaddr *ext_addr, uint8_t protocol,
+        uint32_t lifetime, void *userdata);
+
+void pcp_flow_set_lifetime(pcp_flow_t *f, uint32_t lifetime);
+
+/*
+ * Store pointer to application's user data associated with a flow. Pointer can
+ * be read by function pcp_flow_get_user_data. Arguments:
+ *  f           flow - to which store application's user data.
+ *  userdata    pointer to user data to be stored along a flow
+ */
+void pcp_flow_set_user_data(pcp_flow_t *f, void *userdata);
+
+/*
+ * Get a pointer to application's user data associated with the flow, previously
+ * stored by pcp_flow_set_user_data, or pcp_new_flow. Arguments:
+ *  f           flow - to which store application's user data.
+ *
+ *  return
+ *  void *      pointer to user data to be stored along a flow
+ */
+void *pcp_flow_get_user_data(pcp_flow_t *f);
+
+/*
+ * Set 3rd party option to the existing message flow info.
+ */
+void pcp_flow_set_3rd_party_opt(pcp_flow_t *f, struct sockaddr *thirdp_addr);
+
+#ifdef PCP_FLOW_PRIORITY
+/*
+ * Set PCP's flow priority option to the flow, causing a router to start
+ * altering IP packets' DSCP field to dscp_up in up direction and to dscp_down
+ * for down direction.
+ */
+void pcp_flow_set_flowp(pcp_flow_t *f, uint8_t dscp_up, uint8_t dscp_down);
+#endif
+
+#ifdef PCP_EXPERIMENTAL
+/*
+ * Append metadata option to the existing flow f
+ * if exists md with given id then replace with new value
+ * if value is NULL then remove metadata with this id
+ */
+void pcp_flow_add_md(pcp_flow_t *f, uint32_t md_id, void *value, size_t val_len);
+
+int pcp_flow_set_userid(pcp_flow_t *f, pcp_userid_option_p userid);
+int pcp_flow_set_deviceid(pcp_flow_t *f, pcp_deviceid_option_p dev);
+int pcp_flow_set_location(pcp_flow_t *f, pcp_location_option_p loc);
+#endif
+
+/*
+ * Append filter option.
+ */
+void pcp_flow_set_filter_opt(pcp_flow_t *f, struct sockaddr *filter_ip,
+        uint8_t filter_prefix);
+
+/*
+ * Append prefer failure option.
+ */
+void pcp_flow_set_prefer_failure_opt(pcp_flow_t *f);
+
+#ifdef PCP_SADSCP
+/*
+ * create new PCP message with SADSCP opcode. It's used to learn
+ * correct DSCP values to get desired flow treatment by router.
+ */
+pcp_flow_t *pcp_learn_dscp(pcp_ctx_t *ctx, uint8_t delay_tol, uint8_t loss_tol,
+        uint8_t jitter_tol, char *app_name);
+#endif
+
+/*
+ * Remove flow from PCP server. Sends a PCP message with lifetime set to 0
+ * to PCP server.
+ */
+void pcp_close_flow(pcp_flow_t *f);
+
+/*
+ * Frees memory pointed to by f; Invalidates f.
+ */
+void pcp_delete_flow(pcp_flow_t *f);
+
+typedef enum {
+    pcp_state_processing,
+    pcp_state_succeeded,
+    pcp_state_partial_result,
+    pcp_state_short_lifetime_error,
+    pcp_state_failed
+} pcp_fstate_e;
+
+typedef struct pcp_flow_info {
+    pcp_fstate_e     result;
+    struct in6_addr  pcp_server_ip;
+    struct in6_addr  ext_ip;
+    uint16_t         ext_port;     //network byte order
+    time_t           recv_lifetime_end;
+    time_t           lifetime_renew_s;
+    uint8_t          pcp_result_code;
+    struct in6_addr  int_ip;
+    uint16_t         int_port;     //network byte order
+    struct in6_addr  dst_ip;
+    uint16_t         dst_port;     //network byte order
+    uint8_t          protocol;
+    uint8_t          learned_dscp; //relevant only for flow created by pcp_learn_dscp
+} pcp_flow_info_t;
+
+// Allocates info_buf by malloc, has to be freed by client when no longer needed.
+pcp_flow_info_t *pcp_flow_get_info(pcp_flow_t *f, size_t *info_count);
+
+//callback function type - called when flow state has changed
+typedef void (*pcp_flow_change_notify)(pcp_flow_t *f, struct sockaddr *src_addr,
+        struct sockaddr *ext_addr, pcp_fstate_e, void *cb_arg);
+
+//set flow state change notify callback function
+void pcp_set_flow_change_cb(pcp_ctx_t *ctx, pcp_flow_change_notify cb_fun,
+        void *cb_arg);
+
+/* evaluate flow state
+ * params:
+ *   flow (in)    - handle of the flow
+ *   fstate (out) - state of the flow
+ *   return value - count of interfaces in exit_state (nonzero value means
+ *                  there is some result from PCP server)
+ */
+int pcp_eval_flow_state(pcp_flow_t *flow, pcp_fstate_e *fstate);
+
+////////////////////////////////////////////////////////////////////////////////
+//                      Event handling functions
+
+/*
+ * pcp_pulse - handle socket and timeout events. It's intended to be
+ * used in select loop.
+ * params:
+ *   pcp_ctx_t *ctx       - pcp context obtained by pcp_init
+ *   next_timeout(in/out) - nearest time-out. if it is filled by nonzero
+ *                          value it will return smaller one of provided and
+ *                          inner calculated. to be used in select function
+ */
+int pcp_pulse(pcp_ctx_t *ctx, struct timeval *next_timeout);
+
+/*
+ * Get socket used to communicate with PCP server.
+ */
+PCP_SOCKET pcp_get_socket(pcp_ctx_t *ctx);
+
+//example of pcp_pulse and pcp_get_socket use in select loop:
+/*
+ pcp_ctx_t *ctx=pcp_init(1, NULL);
+ int sock=pcp_get_socket(ctx);
+ pcp_flow_t f=pcp_new_flow(ctx,...);
+ fd_set rfds;
+ do {
+   struct timeval tv={0, 0};
+   FD_ZERO(&rfds);
+   FD_SET(sock, &rfds);
+   pcp_pulse(ctx, &tv);
+   select(sock+1, &rfds, NULL, NULL, &tv);
+ } while (1);
+ */
+
+////////////////////////////////////////////////////////////////////////////////
+// Blocking wait for flow reaching one of exit states or time-out(ms)
+// expiration.
+/*   pcp_wait
+ * params:
+ *   flow    (in)             - pcp flow handle
+ *   timeout (in)             - maximal time in ms to wait for result
+ *   exit_on_partial_res (in) - do not wait for result of all interfaces or
+ *                              possible PCP servers. Instead return immediately
+ *                              after first received result.
+ */
+pcp_fstate_e pcp_wait(pcp_flow_t *flow, int timeout, int exit_on_partial_res);
+
+// example of pcp_wait use:
+/*
+    pcp_flow_t f=pcp_new_flow(ctx, (struct sockaddr *)&src,
+                    (struct sockaddr *)&dst, NULL, IPPROTO_TCP, 60, NULL);
+    pcp_flow_set_flowp(f, 12, 16);
+    pcp_wait(f, 500, 0);  // send PCP msg and wait for response for 500 ms
+ */
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
+
+#endif /* PCP_H */

--- a/lib/libpcp/libpcp-client.pc.in
+++ b/lib/libpcp/libpcp-client.pc.in
@@ -1,0 +1,16 @@
+#libpcp-client pkg-config source file
+
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: libpcp-client
+Description: library implementing a PCP (Port Control Protocol) client
+Version: @VERSION@
+Requires:
+Conflicts:
+Libs: -L${libdir} -lpcp-client
+Libs.private: @LIBS@
+Cflags: -I${includedir}
+

--- a/lib/libpcp/src/default_config.h
+++ b/lib/libpcp/src/default_config.h
@@ -1,0 +1,88 @@
+/*
+ Copyright (c) 2014 by Cisco Systems, Inc.
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following disclaimer in the documentation
+ and/or other materials provided with the distribution.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef DEFAULT_CONFIG_H_
+#define DEFAULT_CONFIG_H_
+
+/* disable NATPMP support */
+/* #undef PCP_DISABLE_NATPMP_SUPPORT */
+
+/* enable experimental PCP options support */
+/* #undef PCP_EXPERIMENTAL */
+
+/* enable FLOW-PRIORITY option support */
+/* #undef PCP_FLOW_PRIORITY */
+
+/* Maximum number of ping attempts */
+#ifndef PCP_MAX_PING_COUNT
+#define PCP_MAX_PING_COUNT 5
+#endif
+
+/* Initial retransmission time */
+#ifndef PCP_RETX_IRT
+#define PCP_RETX_IRT 3000
+#endif
+
+/* Maximum retransmission count (0 indicates no maximum) */
+#ifndef PCP_RETX_MRC
+#define PCP_RETX_MRC 3
+#endif
+
+/* Maximum retransmission duration (0 indicates no maximum) */
+#ifndef PCP_RETX_MRD
+#define PCP_RETX_MRD 0
+#endif
+
+/* Maximum retransmission time */
+#ifndef PCP_RETX_MRT
+#define PCP_RETX_MRT 1024000
+#endif
+
+/* enable SADSCP option support */
+/* #undef PCP_SADSCP */
+
+/* Server discovery retry delay */
+#ifndef PCP_SERVER_DISCOVERY_RETRY_DELAY
+#define PCP_SERVER_DISCOVERY_RETRY_DELAY 3600
+#endif
+
+/* Default PCP server port */
+#ifndef PCP_SERVER_PORT
+#define PCP_SERVER_PORT 5351
+#endif
+
+#ifndef PCP_MAX_SUPPORTED_VERSION
+#define PCP_MAX_SUPPORTED_VERSION 2
+#endif
+
+#ifndef PCP_MIN_SUPPORTED_VERSION
+#ifdef PCP_DISABLE_NATPMP_SUPPORT
+#define PCP_MIN_SUPPORTED_VERSION 1
+#else
+#define PCP_MIN_SUPPORTED_VERSION 0
+#endif
+#endif
+
+#endif /* DEFAULT_CONFIG_H_ */

--- a/lib/libpcp/src/net/findsaddr-udp.c
+++ b/lib/libpcp/src/net/findsaddr-udp.c
@@ -1,0 +1,167 @@
+/*-
+ * Copyright (c) 2010 Bjoern A. Zeeb <bz@FreeBSD.org>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * $FreeBSD$
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#else
+#include "default_config.h"
+#endif
+
+#include <string.h>
+#ifndef WIN32
+# include <sys/types.h>
+# include <sys/socket.h>
+#include <netinet/in.h>
+#else
+# include <winsock2.h>
+# include <ws2tcpip.h> /*sockaddr, addrinfo etc.*/
+# include <stdint.h>
+#endif /*WIN32*/
+
+#include "pcp.h"
+#include "findsaddr.h"
+#include "unp.h"
+
+/*
+ * Return the source address for the given destination address.
+ *
+ * This makes use of proper source address selection in the FreeBSD kernel
+ * even taking jails into account (sys/netinet/in_pcb.c:in_pcbladdr()).
+ * We open a UDP socket, and connect to the destination, letting the kernel
+ * do the bind and then read the source IPv4 address using getsockname(2).
+ * This has multiple advantages: no need to do PF_ROUTE operations possibly
+ * needing special privileges, jails properly taken into account and most
+ * important - getting the result the kernel would give us rather than
+ * best-guessing ourselves.
+ */
+
+#ifndef SOCKET
+#define SOCKET int
+#endif
+
+#ifndef INVALID_SOCKET
+#define INVALID_SOCKET -1
+#endif
+
+const char *findsaddr(register const struct sockaddr_in *to,
+        struct in6_addr *from)
+{
+    const char *errstr;
+    struct sockaddr_in cto, cfrom;
+    SOCKET s;
+    socklen_t len;
+
+    s=socket(AF_INET, SOCK_DGRAM, 0);
+    if (s == INVALID_SOCKET)
+        return ("failed to open DGRAM socket for src addr selection.");
+    errstr=NULL;
+    len=sizeof(struct sockaddr_in);
+    memcpy(&cto, to, len);
+    cto.sin_port=htons(65535); /* Dummy port for connect(2). */
+    if (connect(s, (struct sockaddr *)&cto, len) == -1) {
+        errstr="failed to connect to peer for src addr selection.";
+        goto err;
+    }
+
+    if (getsockname(s, (struct sockaddr *)&cfrom, &len) == -1) {
+        errstr="failed to get socket name for src addr selection.";
+        goto err;
+    }
+
+    if (len != sizeof(struct sockaddr_in) || cfrom.sin_family != AF_INET) {
+        errstr="unexpected address family in src addr selection.";
+        goto err;
+    }
+
+    ((uint32_t *)from)[0]=0;
+    ((uint32_t *)from)[1]=0;
+    ((uint32_t *)from)[2]=htonl(0xffff);
+    ((uint32_t *)from)[3]=cfrom.sin_addr.s_addr;
+
+err:
+    (void)CLOSE(s);
+
+    /* No error (string) to return. */
+    return (errstr);
+}
+
+const char *findsaddr6(register const struct sockaddr_in6 *to,
+        register struct in6_addr *from)
+{
+    const char *errstr;
+    struct sockaddr_in6 cto, cfrom;
+    SOCKET s;
+    socklen_t len;
+    uint32_t sock_flg=0;
+
+    if (IN6_IS_ADDR_LOOPBACK(&to->sin6_addr)) {
+        memcpy(from, &to->sin6_addr, sizeof(struct in6_addr));
+        return NULL;
+    }
+
+    s=socket(AF_INET6, SOCK_DGRAM, 0);
+    if (s == INVALID_SOCKET)
+        return ("failed to open DGRAM socket for src addr selection.");
+
+    errstr=NULL;
+
+    //Enable Dual-stack socket for Vista and higher
+    if (setsockopt(s, IPPROTO_IPV6, IPV6_V6ONLY, (char *)&sock_flg,
+            sizeof(sock_flg)) == -1) {
+        errstr="setsockopt failed to set dual stack mode.";
+        goto err;
+    }
+
+    len=sizeof(struct sockaddr_in6);
+    memcpy(&cto, to, len);
+    cto.sin6_port=htons(65535); /* Dummy port for connect(2). */
+    if (connect(s, (struct sockaddr *)&cto, len) == -1) {
+        errstr="failed to connect to peer for src addr selection.";
+        goto err;
+    }
+
+    if (getsockname(s, (struct sockaddr *)&cfrom, &len) == -1) {
+        errstr="failed to get socket name for src addr selection.";
+        goto err;
+    }
+
+    if (len != sizeof(struct sockaddr_in6) || cfrom.sin6_family != AF_INET6) {
+        errstr="unexpected address family in src addr selection.";
+        goto err;
+    }
+
+    memcpy(from->s6_addr, cfrom.sin6_addr.s6_addr, sizeof(struct in6_addr));
+
+err:
+    (void) CLOSE(s);
+
+    /* No error (string) to return. */
+    return (errstr);
+}
+
+/* end */

--- a/lib/libpcp/src/net/findsaddr.h
+++ b/lib/libpcp/src/net/findsaddr.h
@@ -1,0 +1,35 @@
+/*
+ Copyright (c) 2014 by Cisco Systems, Inc.
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following disclaimer in the documentation
+ and/or other materials provided with the distribution.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef FINDSADDR_UDP_H_
+#define FINDSADDR_UDP_H_
+
+const char *findsaddr(register const struct sockaddr_in *to,
+        struct in6_addr *from);
+
+const char *findsaddr6(register const struct sockaddr_in6 *to,
+        register struct in6_addr *from);
+
+#endif //FINDSADDR_UDP_H_

--- a/lib/libpcp/src/net/gateway.c
+++ b/lib/libpcp/src/net/gateway.c
@@ -1,0 +1,958 @@
+/*
+ Copyright (c) 2014 by Cisco Systems, Inc.
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following disclaimer in the documentation
+ and/or other materials provided with the distribution.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#else
+#include "default_config.h"
+#endif
+
+#include <ctype.h>
+#include <errno.h>
+#include <sys/types.h>
+#ifndef WIN32
+#include <sys/socket.h>         // place it before <net/if.h> struct sockaddr
+#endif //WIN32
+#ifdef __linux__
+#define USE_NETLINK
+#include <linux/types.h>
+#include <linux/netlink.h>
+#include <linux/rtnetlink.h>
+#endif
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+
+#ifndef WIN32
+#include <sys/ioctl.h>          // ioctl()
+#include <net/if.h>             //struct ifreq
+#endif //WIN32
+#ifdef WIN32
+#undef USE_NETLINK
+#undef USE_SOCKET_ROUTE
+#define USE_WIN32_CODE
+
+#include <winsock2.h>
+#include <ws2ipdef.h>
+#include <iphlpapi.h>
+#include <ws2tcpip.h>
+#include "pcp_win_defines.h"
+#endif
+
+#if defined(__APPLE__) || defined(__FreeBSD__)
+#include <sys/sysctl.h>
+#include <net/if_dl.h>          //struct sockaddr_dl
+#define USE_SOCKET_ROUTE
+#endif
+
+#ifndef WIN32
+#include <arpa/inet.h>          // inet_addr()
+#include <net/route.h>          // struct rt_msghdr
+#ifdef USE_SOCKET_ROUTE
+#include <ifaddrs.h>            //getifaddrs() freeifaddrs()
+#endif
+#include <net/if.h>
+#include <net/route.h>
+#include <netinet/in.h>         //IPPROTO_GRE sturct sockaddr_in INADDR_ANY
+#endif
+
+#if defined(BSD) || defined(__FreeBSD_kernel__)
+#define USE_SOCKET_ROUTE
+#undef USE_WIN32_CODE
+#endif
+
+#if (defined(sun) && defined(__SVR4))
+#define USE_SOCKET_ROUTE
+#undef USE_WIN32_CODE
+#endif
+
+#include "gateway.h"
+#include "pcp_logger.h"
+#include "unp.h"
+#include "pcp_utils.h"
+
+#ifndef WIN32
+#define SUCCESS (0)
+#define FAILED  (-1)
+#define USE_WIN32_CODE
+#endif
+
+#define TO_IPV6MAPPED(x)        S6_ADDR32(x)[3] = S6_ADDR32(x)[0];\
+                                S6_ADDR32(x)[0] = 0;\
+                                S6_ADDR32(x)[1] = 0;\
+                                S6_ADDR32(x)[2] = htonl(0xFFFF);
+
+#ifdef USE_NETLINK
+
+#define BUFSIZE 8192
+
+static ssize_t readNlSock(int sockFd, char *bufPtr, unsigned seqNum,
+        unsigned pId)
+{
+    struct nlmsghdr *nlHdr;
+    ssize_t readLen=0, msgLen=0;
+
+    do {
+        /* Receive response from the kernel */
+        readLen=recv(sockFd, bufPtr, BUFSIZE - msgLen, 0);
+        if (readLen == -1) {
+            char errmsg[128];
+            pcp_strerror(errno, errmsg, sizeof(errmsg));
+            PCP_LOG(PCP_LOGLVL_DEBUG, "SOCK READ: %s", errmsg);
+            return -1;
+        }
+
+        nlHdr=(struct nlmsghdr *)bufPtr;
+
+        /* Check if the header is valid */
+        if ((NLMSG_OK(nlHdr, (unsigned)readLen) == 0)
+                || (nlHdr->nlmsg_type == NLMSG_ERROR)) {
+            PCP_LOG(PCP_LOGLVL_DEBUG, "%s", "Error in received packet");
+            return -1;
+        }
+
+        /* Check if the its the last message */
+        if (nlHdr->nlmsg_type == NLMSG_DONE) {
+            break;
+        } else {
+            /* Else move the pointer to buffer appropriately */
+            bufPtr+=readLen;
+            msgLen+=readLen;
+        }
+
+        /* Check if its a multi part message */
+        if ((nlHdr->nlmsg_flags & NLM_F_MULTI) == 0) {
+            /* return if its not */
+            break;
+        }
+    } while ((nlHdr->nlmsg_seq != seqNum) || (nlHdr->nlmsg_pid != pId));
+    return msgLen;
+}
+
+int getgateways(struct sockaddr_in6 **gws)
+{
+    struct nlmsghdr *nlMsg;
+    char msgBuf[BUFSIZE];
+
+    int sock, msgSeq=0;
+    ssize_t len;
+    int ret;
+
+    if (!gws) {
+        return PCP_ERR_BAD_ARGS;
+    }
+
+    /* Create Socket */
+    sock=socket(PF_NETLINK, SOCK_DGRAM, NETLINK_ROUTE);
+    if (sock < 0) {
+        PCP_LOG(PCP_LOGLVL_DEBUG, "%s", "Netlink Socket Creation Failed...");
+        return PCP_ERR_UNKNOWN;
+    }
+
+    /* Initialize the buffer */
+    memset(msgBuf, 0, BUFSIZE);
+
+    /* point the header and the msg structure pointers into the buffer */
+    nlMsg=(struct nlmsghdr *)msgBuf;
+
+    /* Fill in the nlmsg header*/
+    nlMsg->nlmsg_len=NLMSG_LENGTH(sizeof(struct rtmsg)); // Length of message.
+    nlMsg->nlmsg_type=RTM_GETROUTE; // Get the routes from kernel routing table.
+
+    nlMsg->nlmsg_flags=NLM_F_DUMP | NLM_F_REQUEST; // The message is a request for dump.
+    nlMsg->nlmsg_seq=msgSeq++; // Sequence of the message packet.
+    nlMsg->nlmsg_pid=getpid(); // PID of process sending the request.
+
+    /* Send the request */
+    len=send(sock, nlMsg, nlMsg->nlmsg_len, 0);
+    if (len == -1) {
+        PCP_LOG(PCP_LOGLVL_DEBUG, "%s", "Write To Netlink Socket Failed...");
+        ret=PCP_ERR_SEND_FAILED;
+        goto end;
+    }
+
+    /* Read the response */
+    len=readNlSock(sock, msgBuf, msgSeq, getpid());
+    if (len < 0) {
+        PCP_LOG(PCP_LOGLVL_DEBUG, "%s", "Read From Netlink Socket Failed...");
+        ret=PCP_ERR_RECV_FAILED;
+        goto end;
+    }
+    /* Parse and print the response */
+    ret=0;
+
+    for (; NLMSG_OK(nlMsg,(unsigned)len); nlMsg=NLMSG_NEXT(nlMsg,len)) {
+        struct rtmsg *rtMsg;
+        struct rtattr *rtAttr;
+        int rtLen;
+        unsigned int scope_id = 0;
+        struct in6_addr addr;
+        int found = 0;
+        rtMsg=(struct rtmsg *)NLMSG_DATA(nlMsg);
+
+        /* If the route is not for AF_INET(6) or does not belong to main
+           routing table then return. */
+        if (((rtMsg->rtm_family != AF_INET) && (rtMsg->rtm_family != AF_INET6))
+                || (rtMsg->rtm_table != RT_TABLE_MAIN)) {
+            continue;
+        }
+
+        /* get the rtattr field */
+        rtAttr=(struct rtattr *)RTM_RTA(rtMsg);
+        rtLen=RTM_PAYLOAD(nlMsg);
+        for (; RTA_OK(rtAttr,rtLen); rtAttr=RTA_NEXT(rtAttr,rtLen)) {
+            size_t rtaLen=RTA_PAYLOAD(rtAttr);
+            if (rtaLen > sizeof(struct in6_addr)) {
+                continue;
+            }
+            if (rtAttr->rta_type == RTA_OIF) {
+                memcpy(&scope_id, RTA_DATA(rtAttr), sizeof(unsigned int));
+            } else if (rtAttr->rta_type == RTA_GATEWAY) {
+                memset(&addr, 0, sizeof(struct in6_addr));
+                memcpy(&addr, RTA_DATA(rtAttr), rtaLen);
+                if (rtMsg->rtm_family == AF_INET) {
+                    TO_IPV6MAPPED(&addr);
+                }
+                found=1;
+            }
+        }
+        if (found) {
+            struct sockaddr_in6 *tmp_gws;
+            tmp_gws=(struct sockaddr_in6 *)realloc(*gws,
+                    sizeof(struct sockaddr_in6) * (ret + 1));
+            if (!tmp_gws) {
+                PCP_LOG(PCP_LOGLVL_ERR, "%s",
+                        "Error allocating memory");
+                if (*gws) {
+                    free(*gws);
+                    *gws=NULL;
+                }
+                ret=PCP_ERR_NO_MEM;
+                goto end;
+            }
+            *gws=tmp_gws;
+            (*gws + ret)->sin6_family=AF_INET6;
+            memcpy(&((*gws + ret)->sin6_addr), &addr, sizeof(addr));
+            (*gws + ret)->sin6_scope_id=scope_id;
+            SET_SA_LEN(*gws + ret, sizeof(struct sockaddr_in6))
+            ret++;
+        }
+    }
+end:
+    if (close(sock)) {
+        PCP_LOG(PCP_LOGLVL_DEBUG, "%s", "Close socket error");
+    }
+    return ret;
+}
+
+#endif /* #ifdef USE_NETLINK */
+
+#if defined (USE_WIN32_CODE) && defined(WIN32)
+
+#if 0 // WINVER>=NTDDI_VISTA
+int getgateways(struct in6_addr **gws)
+{
+    PMIB_IPFORWARD_TABLE2 ipf_table;
+    unsigned int i;
+
+    if (!gws) {
+        return PCP_ERR_UNKNOWN;
+    }
+
+    if (GetIpForwardTable2(AF_UNSPEC, &ipf_table) != NO_ERROR) {
+        return PCP_ERR_UNKNOWN;
+    }
+
+    if (!ipf_table) {
+        return PCP_ERR_UNKNOWN;
+    }
+
+    *gws=(struct in6_addr *)calloc(ipf_table->NumEntries,
+            sizeof(struct in6_addr));
+    if (*gws) {
+        PCP_LOG(PCP_LOGLVL_DEBUG, "%s", "Error allocating memory");
+        return PCP_ERR_NO_MEM;
+    }
+
+    for (i=0; i < ipf_table->NumEntries; ++i) {
+        if (ipf_table->Table[i].NextHop.si_family == AF_INET) {
+            S6_ADDR32((*gws)+i)[0]=
+                    ipf_table->Table[i].NextHop.Ipv4.sin_addr.s_addr;
+            TO_IPV6MAPPED(((*gws)+i));
+        }
+        if (ipf_table->Table[i].NextHop.si_family == AF_INET6) {
+            memcpy((*gws) + i, &ipf_table->Table[i].NextHop.Ipv6.sin6_addr,
+                    sizeof(struct in6_addr));
+        }
+    }
+    return i;
+}
+#else
+int getgateways(struct sockaddr_in6 **gws)
+{
+    PMIB_IPFORWARDTABLE ipf_table;
+    DWORD ipft_size=0;
+    int i, ret;
+
+    if (!gws) {
+        return PCP_ERR_UNKNOWN;
+    }
+
+    ipf_table=(MIB_IPFORWARDTABLE *)malloc(sizeof(MIB_IPFORWARDTABLE));
+    if (!ipf_table) {
+        PCP_LOG(PCP_LOGLVL_DEBUG, "%s", "Error allocating memory");
+        ret=PCP_ERR_NO_MEM;
+        goto end;
+    }
+
+    if (GetIpForwardTable(ipf_table, &ipft_size, 0)
+            == ERROR_INSUFFICIENT_BUFFER) {
+        MIB_IPFORWARDTABLE *new_ipf_table;
+        new_ipf_table=(MIB_IPFORWARDTABLE *)realloc(ipf_table, ipft_size);
+        if (!new_ipf_table) {
+            PCP_LOG(PCP_LOGLVL_DEBUG, "%s", "Error allocating memory");
+            ret=PCP_ERR_NO_MEM;
+            goto end;
+        }
+        ipf_table=new_ipf_table;
+    }
+
+    if (GetIpForwardTable(ipf_table, &ipft_size, 0) != NO_ERROR) {
+        PCP_LOG(PCP_LOGLVL_DEBUG, "%s", "GetIpForwardTable failed.");
+        ret=PCP_ERR_UNKNOWN;
+        goto end;
+    }
+
+    *gws=(struct sockaddr_in6 *)calloc(ipf_table->dwNumEntries,
+            sizeof(struct sockaddr_in6));
+    if (!*gws) {
+        PCP_LOG(PCP_LOGLVL_DEBUG, "%s", "Error allocating memory");
+        ret=PCP_ERR_NO_MEM;
+        goto end;
+    }
+
+    for (ret=0, i=0; i < (int)ipf_table->dwNumEntries; i++) {
+		if (ipf_table->table[i].dwForwardType == MIB_IPROUTE_TYPE_INDIRECT) {
+            (*gws)[ret].sin6_family = AF_INET6;
+            S6_ADDR32(&(*gws)[ret].sin6_addr)[0]=
+                (uint32_t)ipf_table->table[i].dwForwardNextHop;
+            TO_IPV6MAPPED(&(*gws)[ret].sin6_addr);
+            ret++;
+        }
+    }
+end:
+    if (ipf_table)
+        free(ipf_table);
+
+    return ret;
+}
+#endif
+
+#endif /* #ifdef USE_WIN32_CODE */
+
+#ifdef USE_SOCKET_ROUTE
+
+struct sockaddr;
+struct in6_addr;
+
+/* Adapted from Richard Stevens, UNIX Network Programming  */
+
+/*
+ * Round up 'a' to next multiple of 'size', which must be a power of 2
+ */
+#define ROUNDUP(a, size) (((a) & ((size)-1)) ? (1 + ((a) | ((size)-1))) : (a))
+
+/*
+ * Step to next socket address structure;
+ * if sa_len is 0, assume it is sizeof(u_long). Using u_long only works on 32-bit
+ machines. In 64-bit machines it needs to be u_int32_t !!
+ */
+#define NEXT_SA(ap)    ap = (struct sockaddr *) \
+    ((caddr_t) ap + (ap->sa_len ? ROUNDUP(ap->sa_len, sizeof(uint32_t)) : \
+                                    sizeof(uint32_t)))
+
+/* thanks Stevens for this very handy function */
+static void get_rtaddrs(int addrs, struct sockaddr *sa,
+        struct sockaddr **rti_info)
+{
+    int i;
+
+    for (i=0; i < RTAX_MAX; i++) {
+        if (addrs & (1 << i)) {
+            rti_info[i]=sa;
+            NEXT_SA(sa);
+        } else
+            rti_info[i]=NULL;
+    }
+}
+
+/* Portable (hopefully) function to lookup routing tables. sysctl()'s
+ advantage is that it does not need root permissions. Routing sockets
+ need root permission since it is of type SOCK_RAW. */
+static char *
+net_rt_dump(int type, int family, int flags, size_t *lenp)
+{
+    int mib[6];
+    char *buf;
+
+    mib[0]=CTL_NET;
+    mib[1]=AF_ROUTE;
+    mib[2]=0;
+    mib[3]=family; /* only addresses of this family */
+    mib[4]=type;
+    mib[5]=flags; /* not looked at with NET_RT_DUMP */
+    if (sysctl(mib, 6, NULL, lenp, NULL, 0) < 0)
+        return (NULL);
+
+    if ((buf=malloc(*lenp)) == NULL)
+        return (NULL);
+    if (sysctl(mib, 6, buf, lenp, NULL, 0) < 0)
+        return (NULL);
+
+    return (buf);
+}
+
+/* Performs a route table dump selecting only entries that have Gateways.
+ This means that the return buffer will have many duplicate entries since
+ certain gateways appear multiple times in the routing table.
+
+ It is up to the caller to weed out duplicates
+ */
+int getgateways(struct sockaddr_in6 **gws)
+{
+    char *buf, *next, *lim;
+    size_t len;
+    struct rt_msghdr *rtm;
+    struct sockaddr *sa, *rti_info[RTAX_MAX];
+    int rtcount=0;
+
+    if (!gws) {
+        return PCP_ERR_UNKNOWN;
+    }
+
+    /* net_rt_dump() will return all route entries with gateways */
+    buf=net_rt_dump(NET_RT_FLAGS, 0, RTF_GATEWAY, &len);
+    if (!buf)
+        return PCP_ERR_UNKNOWN;
+    lim=buf + len;
+    for (next=buf; next < lim; next+=rtm->rtm_msglen) {
+        rtm=(struct rt_msghdr *)next;
+        sa=(struct sockaddr *)(rtm + 1);
+        get_rtaddrs(rtm->rtm_addrs, sa, rti_info);
+
+        if ((sa=rti_info[RTAX_GATEWAY]) != NULL)
+
+            if ((rtm->rtm_addrs & (RTA_DST | RTA_GATEWAY))
+                    == (RTA_DST | RTA_GATEWAY)) {
+                struct sockaddr_in6 *in6=*gws;
+
+                *gws=(struct sockaddr_in6 *)realloc(*gws,
+                        sizeof(struct sockaddr_in6) * (rtcount + 1));
+
+                if (!*gws) {
+                    if (in6)
+                        free(in6);
+                    free(buf);
+                    return PCP_ERR_NO_MEM;
+                }
+
+                in6=(*gws) + rtcount;
+                memset(in6, 0, sizeof(struct sockaddr_in6));
+
+                if (sa->sa_family == AF_INET) {
+                    /* IPv4 gateways as returned as IPv4 mapped IPv6 addresses */
+                    in6->sin6_family = AF_INET6;
+                    S6_ADDR32(&in6->sin6_addr)[0]=
+                            ((struct sockaddr_in *)(rti_info[RTAX_GATEWAY]))->sin_addr.s_addr;
+                    TO_IPV6MAPPED(&in6->sin6_addr);
+                } else if (sa->sa_family == AF_INET6) {
+                    memcpy(in6,
+                            (struct sockaddr_in6 *)rti_info[RTAX_GATEWAY],
+                            sizeof(struct sockaddr_in6));
+                } else {
+                    continue;
+                }
+                rtcount++;
+            }
+    }
+    free(buf);
+    return rtcount;
+}
+
+#if 0
+
+/* This structure is used for route operations using routing sockets */
+
+/* I know I could have used sockaddr. But type casting eveywhere is nasty and error prone.
+   I do not believe a few bytes will make much impact and code will become much cleaner */
+
+typedef struct route_op {
+    struct sockaddr_in dst4;
+    struct sockaddr_in mask4;
+    struct sockaddr_in gw4;
+    struct sockaddr_in6 dst6;
+    struct sockaddr_in6 mask6;
+    struct sockaddr_in6 gw6;
+    char ifname[128];
+    uint16_t family;
+} route_op_t;
+
+static int
+get_if_addr_from_name(char *ifname, struct sockaddr *ifsock, int family);
+
+typedef route_op_t route_in_t;
+typedef route_op_t route_out_t;
+
+static int route_get(in_addr_t *dst, in_addr_t *mask, in_addr_t *gateway,
+        char *ifname, route_in_t *routein, route_out_t *routeout);
+static int route_add(in_addr_t dst, in_addr_t mask, in_addr_t gateway,
+        const char *ifname, route_in_t *routein, route_out_t *routeout);
+static int route_change(in_addr_t dst, in_addr_t mask, in_addr_t gateway,
+        const char *ifname, route_in_t *routein, route_out_t *routeout);
+static int route_delete(in_addr_t dst, in_addr_t mask, route_in_t *routein,
+        route_out_t *routeout);
+static int route_get_sa(struct sockaddr *dst, in_addr_t *mask,
+        struct sockaddr *gateway, char *ifname, route_in_t *routein,
+        route_out_t *routeout);
+
+static int find_if_with_name(const char *iface, struct sockaddr_dl *out)
+{
+    struct ifaddrs *ifap, *ifa;
+    struct sockaddr_dl *sdl=NULL;
+
+    if (getifaddrs(&ifap)) {
+        char err_msg[128];
+        pcp_strerror(errno, err_msg, sizeof(err_msg));
+        PCP_LOG(PCP_LOGLVL_DEBUG, "getifaddrs: %s", err_msg);
+        return -1;
+    }
+
+    for (ifa=ifap; ifa; ifa=ifa->ifa_next) {
+        if (ifa->ifa_addr->sa_family == AF_LINK &&
+        /*(ifa->ifa_flags & IFF_POINTOPOINT) && \ */
+        strcmp(iface, ifa->ifa_name) == 0) {
+            sdl=(struct sockaddr_dl *)ifa->ifa_addr;
+            break;
+        }
+    }
+
+    /* If we found it, then use it */
+    if (sdl)
+        bcopy((char *)sdl, (char *)out, (size_t)(sdl->sdl_len));
+
+    freeifaddrs(ifap);
+
+    if (sdl == NULL) {
+        PCP_LOG(PCP_LOGLVL_DEBUG,
+                "interface %s not found or invalid(must be p-p)", iface);
+        return -1;
+    }
+    return 0;
+}
+
+static int route_op(u_char op, in_addr_t *dst, in_addr_t *mask,
+        in_addr_t *gateway, char *iface, route_in_t *routein,
+        route_out_t *routeout)
+{
+
+#define ROUNDUP_CT(n)  ((n) > 0 ? (1 + (((n) - 1) | (sizeof(uint32_t) - 1))) : sizeof(uint32_t))
+#define ADVANCE_CT(x, n) (x += ROUNDUP_CT((n)->sa_len))
+
+#define NEXTADDR_CT(w, u) \
+    if (msg.msghdr.rtm_addrs & (w)) {\
+        len = ROUNDUP_CT(u.sa.sa_len); bcopy((char *)&(u), cp, len); cp += len;\
+    }
+
+    static int seq=0;
+    int err=0;
+    ssize_t len=0;
+    char *cp;
+    pid_t pid;
+
+    union {
+        struct sockaddr sa;
+        struct sockaddr_in sin;
+        struct sockaddr_dl sdl;
+        struct sockaddr_storage ss; /* added to avoid memory overrun */
+    } so_addr[RTAX_MAX];
+
+    struct {
+        struct rt_msghdr msghdr;
+        char buf[512];
+    } msg;
+
+    bzero(so_addr, sizeof(so_addr));
+    bzero(&msg, sizeof(msg));
+
+    PCP_LOG_BEGIN(PCP_LOGLVL_DEBUG);
+    cp=msg.buf;
+    pid=getpid();
+    //msg.msghdr.rtm_msglen  = 0;
+    msg.msghdr.rtm_version=RTM_VERSION;
+    //msg.msghdr.rtm_type    = RTM_ADD;
+    msg.msghdr.rtm_index=0;
+    msg.msghdr.rtm_pid=pid;
+    msg.msghdr.rtm_addrs=0;
+    msg.msghdr.rtm_seq=++seq;
+    msg.msghdr.rtm_errno=0;
+    msg.msghdr.rtm_flags=0;
+
+    // Destination
+    /* if (dst && *dst != 0xffffffff) { */
+    if (routein && routein->dst4.sin_addr.s_addr != 0xffffffff) {
+        msg.msghdr.rtm_addrs|=RTA_DST;
+
+        so_addr[RTAX_DST].sin.sin_len=sizeof(struct sockaddr_in);
+        so_addr[RTAX_DST].sin.sin_family=AF_INET;
+        so_addr[RTAX_DST].sin.sin_addr.s_addr=mask ? *dst & *mask : *dst;
+    } else {
+        PCP_LOG(PCP_LOGLVL_DEBUG, "%s", "invalid(require) dst address");
+        return -1;
+    }
+
+    // Netmask
+    if (mask && *mask != 0xffffffff) {
+        msg.msghdr.rtm_addrs|=RTA_NETMASK;
+
+        so_addr[RTAX_NETMASK].sin.sin_len=sizeof(struct sockaddr_in);
+        so_addr[RTAX_NETMASK].sin.sin_family=AF_INET;
+        so_addr[RTAX_NETMASK].sin.sin_addr.s_addr=*mask;
+
+    } else
+        msg.msghdr.rtm_flags|=RTF_HOST;
+
+    switch (op) {
+        case RTM_ADD:
+        case RTM_CHANGE:
+            msg.msghdr.rtm_type=op;
+            msg.msghdr.rtm_addrs|=RTA_GATEWAY;
+            msg.msghdr.rtm_flags|=RTF_UP;
+
+            // Gateway
+            if ((gateway && *gateway != 0x0 && *gateway != 0xffffffff)) {
+                msg.msghdr.rtm_flags|=RTF_GATEWAY;
+
+                so_addr[RTAX_GATEWAY].sin.sin_len=sizeof(struct sockaddr_in);
+                so_addr[RTAX_GATEWAY].sin.sin_family=AF_INET;
+                so_addr[RTAX_GATEWAY].sin.sin_addr.s_addr=*gateway;
+
+                if (iface != NULL) {
+                    msg.msghdr.rtm_addrs|=RTA_IFP;
+                    so_addr[RTAX_IFP].sdl.sdl_family=AF_LINK;
+
+                    //link_addr(iface, &so_addr[RTAX_IFP].sdl);
+                    if (find_if_with_name(iface, &so_addr[RTAX_IFP].sdl) < 0)
+                        return -2;
+                }
+
+            } else {
+                if (iface == NULL) {
+                    PCP_LOG(PCP_LOGLVL_DEBUG, "%s",
+                            "Requir gateway or iface.");
+                    return -1;
+                }
+
+                if (find_if_with_name(iface, &so_addr[RTAX_GATEWAY].sdl) < 0)
+                    return -1;
+            }
+            break;
+        case RTM_DELETE:
+            msg.msghdr.rtm_type=op;
+            msg.msghdr.rtm_addrs|=RTA_GATEWAY;
+            msg.msghdr.rtm_flags|=RTF_GATEWAY;
+            break;
+        case RTM_GET:
+            msg.msghdr.rtm_type=op;
+            msg.msghdr.rtm_addrs|=RTA_IFP;
+            so_addr[RTAX_IFP].sa.sa_family=AF_LINK;
+            so_addr[RTAX_IFP].sa.sa_len=sizeof(struct sockaddr_dl);
+            break;
+        default:
+            return EINVAL;
+    }
+
+    NEXTADDR_CT(RTA_DST, so_addr[RTAX_DST]);
+    NEXTADDR_CT(RTA_GATEWAY, so_addr[RTAX_GATEWAY]);
+    NEXTADDR_CT(RTA_NETMASK, so_addr[RTAX_NETMASK]);
+    NEXTADDR_CT(RTA_GENMASK, so_addr[RTAX_GENMASK]);
+    NEXTADDR_CT(RTA_IFP, so_addr[RTAX_IFP]);
+    NEXTADDR_CT(RTA_IFA, so_addr[RTAX_IFA]);
+
+    msg.msghdr.rtm_msglen=len=cp - (char *)&msg;
+
+    int sock=socket(PF_ROUTE, SOCK_RAW, AF_INET);
+    if (sock == -1) {
+        PCP_LOG(PCP_LOGLVL_DEBUG, "%s",
+                "socket(PF_ROUTE, SOCK_RAW, AF_INET) failed");
+        return -1;
+    }
+
+    if (write(sock, (char *)&msg, len) < 0) {
+        err=-1;
+        goto end;
+    }
+
+    if (op == RTM_GET) {
+        do {
+            len=read(sock, (char *)&msg, sizeof(msg));
+        } while (len > 0
+                && (msg.msghdr.rtm_seq != seq || msg.msghdr.rtm_pid != pid));
+
+        if (len < 0) {
+            PCP_LOG(PCP_LOGLVL_DEBUG, "%s",
+                    "read from routing socket failed");
+            err=-1;
+        } else {
+            struct sockaddr *s_netmask=NULL;
+            struct sockaddr *s_gate=NULL;
+            struct sockaddr_dl *s_ifp=NULL;
+            struct sockaddr *sa;
+            struct sockaddr *rti_info[RTAX_MAX];
+
+            if (msg.msghdr.rtm_version != RTM_VERSION) {
+                PCP_LOG(PCP_LOGLVL_DEBUG,
+                        "routing message version %d not understood",
+                        msg.msghdr.rtm_version);
+                err=-1;
+                goto end;
+            }
+            if (msg.msghdr.rtm_msglen > len) {
+                PCP_LOG(PCP_LOGLVL_DEBUG,
+                        "message length mismatch, in packet %d, returned %lu",
+                        msg.msghdr.rtm_msglen, (unsigned long)len);
+            }
+            if (msg.msghdr.rtm_errno) {
+                PCP_LOG(PCP_LOGLVL_DEBUG, "message indicates error %d, %s",
+                        msg.msghdr.rtm_errno, strerror(msg.msghdr.rtm_errno));
+                err=-1;
+                goto end;
+            }
+            cp=msg.buf;
+            if (msg.msghdr.rtm_addrs) {
+
+                sa=(struct sockaddr *)cp;
+                get_rtaddrs(msg.msghdr.rtm_addrs, sa, rti_info);
+
+                if ((sa=rti_info[RTAX_DST]) != NULL) {
+                    if (sa->sa_family == AF_INET) {
+                        char routeto4_str[INET_ADDRSTRLEN];
+
+                        memcpy((void *)&(routeout->dst4), (void *)sa,
+                                sizeof(struct sockaddr_in));
+                        inet_ntop(AF_INET, &(routein->dst4.sin_addr),
+                                routeto4_str, INET_ADDRSTRLEN);
+                        //memcpy(routeto4_str, sock_ntop((struct sockaddr *)&(routein->dst4), sizeof(struct sockaddr_in)),
+                        //        INET_ADDRSTRLEN);
+                        /* BSD uses a peculiar nomenclature. 'Route to' is the host for which we are looking up
+                         the route and 'destinaton' is the intermediate gateway or the final destination
+                         when hosts are in the same LAN */
+                        PCP_LOG(PCP_LOGLVL_DEBUG, "Dest: %s",
+                                sock_ntop(sa, sa->sa_len));
+                        if (msg.msghdr.rtm_flags & RTF_WASCLONED) {
+                            PCP_LOG(PCP_LOGLVL_DEBUG,
+                                    "Route to %s in the same subnet",
+                                    routeto4_str);
+                        } else if (msg.msghdr.rtm_flags & RTF_CLONING) {
+                            PCP_LOG(PCP_LOGLVL_DEBUG,
+                                    "Route to %s in the same subnet but not up",
+                                    routeto4_str);
+                        } else if (msg.msghdr.rtm_flags & RTF_GATEWAY) {
+                            PCP_LOG(PCP_LOGLVL_DEBUG,
+                                    "Route to %s not in the same subnet",
+                                    routeto4_str);
+                        }
+                        if (routeout->dst4.sin_addr.s_addr
+                                == routein->dst4.sin_addr.s_addr) {
+                            PCP_LOG(PCP_LOGLVL_DEBUG,
+                                    "Destination %s same as route to %s",
+                                    sock_ntop(sa, sa->sa_len), routeto4_str);
+                        }
+                    }
+                }
+
+                if ((sa=rti_info[RTAX_GATEWAY]) != NULL) {
+                    s_gate=sa;
+                    PCP_LOG(PCP_LOGLVL_DEBUG, "Gateway: %s \n",
+                            sock_ntop(sa, sa->sa_len));
+                    if (msg.msghdr.rtm_flags & RTF_GATEWAY) {
+                        *gateway=
+                                ((struct sockaddr_in *)s_gate)->sin_addr.s_addr;
+                        routeout->gw4.sin_addr.s_addr=
+                                ((struct sockaddr_in *)s_gate)->sin_addr.s_addr;
+                    } else {
+                        *gateway=0;
+                    }
+
+                }
+
+                if ((sa=rti_info[RTAX_IFP]) != NULL) {
+                    PCP_LOG(PCP_LOGLVL_DEBUG,
+                            "family: %d AF_LINK family : %d \n",
+                            sa->sa_family, AF_LINK);
+                    if ((sa->sa_family == AF_LINK)
+                            && ((struct sockaddr_dl *)sa)->sdl_nlen) {
+                        uint32_t slen;
+                        s_ifp=(struct sockaddr_dl *)sa;
+                        slen=s_ifp->sdl_nlen < IFNAMSIZ ?
+                                s_ifp->sdl_nlen : IFNAMSIZ;
+                        strncpy(iface, s_ifp->sdl_data, slen);
+                        strncpy(&(routeout->ifname[0]), s_ifp->sdl_data, slen);
+                        routeout->ifname[slen]='\0';
+                        iface[slen]='\0';
+                        PCP_LOG(PCP_LOGLVL_DEBUG,
+                                "Interface name %s and type %d \n",
+                                &(routeout->ifname[0]), s_ifp->sdl_type);
+                    }
+                }
+            }
+
+            if (mask) {
+                if (*dst == 0)
+                    *mask=0;
+                else if (s_netmask)
+                    *mask=((struct sockaddr_in *)s_netmask)->sin_addr.s_addr; // there must be something wrong here....Ah..
+                else
+                    *mask=0xffffffff; // it is a host
+            }
+
+#if 0
+            if (iface && s_ifp) {
+                strncpy(iface, s_ifp->sdl_data,
+                        s_ifp->sdl_nlen < IFNAMSIZ ?
+                                s_ifp->sdl_nlen : IFNAMSIZ);
+                iface[IFNAMSIZ - 1]='\0';
+            }
+#endif
+        }
+    }
+
+end:
+    if (close(sock) < 0) {
+        PCP_LOG(PCP_LOGLVL_DEBUG, "%s", "socket close failed");
+    }
+
+    PCP_LOG_END(PCP_LOGLVL_DEBUG);
+    return err;
+#undef MAX_INDEX
+}
+
+static int route_get_sa(struct sockaddr *dst, in_addr_t *mask,
+        struct sockaddr *gateway, char *ifname, route_in_t *routein,
+        route_out_t *routeout)
+{
+#if defined(__APPLE__) || defined(__FreeBSD__)
+    return route_op(RTM_GET, &(((struct sockaddr_in *) dst)->sin_addr.s_addr), mask,
+            &(((struct sockaddr_in *) gateway)->sin_addr.s_addr), ifname, routein, routeout);
+#else
+    PCP_LOG(PCP_LOGLVL_DEBUG, "%s: todo...\n", __FUNCTION__);
+    return 0;
+#endif
+}
+
+static int route_get(in_addr_t *dst, in_addr_t *mask, in_addr_t *gateway,
+        char iface[], route_in_t *routein, route_out_t *routeout)
+{
+#if defined(__APPLE__) || defined(__FreeBSD__)
+    return route_op(RTM_GET, dst, mask, gateway, iface, routein, routeout);
+#else
+    PCP_LOG(PCP_LOGLVL_DEBUG, "%s: todo...\n", __FUNCTION__);
+    return 0;
+#endif
+}
+
+static int route_add(in_addr_t dst, in_addr_t mask, in_addr_t gateway,
+        const char *iface, route_in_t *routein, route_out_t *routeout)
+{
+#if defined(__APPLE__) || defined(__FreeBSD__)
+    return route_op(RTM_ADD, &dst, &mask, &gateway, (char *)iface, routein, routeout);
+#else
+    PCP_LOG(PCP_LOGLVL_DEBUG, "%s: todo...\n", __FUNCTION__);
+    return -1;
+#endif
+}
+
+static int route_change(in_addr_t dst, in_addr_t mask, in_addr_t gateway,
+        const char *iface, route_in_t *routein, route_out_t *routeout)
+{
+#if defined(__APPLE__) || defined(__FreeBSD__)
+    return route_op(RTM_CHANGE, &dst, &mask, &gateway, (char *)iface, routein, routeout);
+#else
+    PCP_LOG(PCP_LOGLVL_DEBUG, "%s: todo...\n", __FUNCTION__);
+    return -1;
+#endif
+}
+
+static int route_delete(in_addr_t dst, in_addr_t mask, route_in_t *routein,
+        route_out_t *routeout)
+{
+#if defined(__APPLE__) || defined(__FreeBSD__)
+    return route_op(RTM_DELETE, &dst, &mask, 0, NULL, routein, routeout);
+#else
+    PCP_LOG(PCP_LOGLVL_DEBUG, "%s: todo...\n", __FUNCTION__);
+    return -1;
+#endif
+}
+
+/* Adapted from Linux manual example */
+
+/* We need to pass the family because an interface might have multiple addresses
+ each assocaited with different family
+ */
+static int get_if_addr_from_name(char *ifname, struct sockaddr *ifsock,
+        int family)
+{
+    struct ifaddrs *ifaddr, *ifa;
+
+    if (getifaddrs(&ifaddr) == -1) {
+        char err_msg[128];
+        pcp_strerror(errno, err_msg, sizeof(err_msg));
+        PCP_LOG(PCP_LOGLVL_DEBUG, "getifaddrs: %s", err_msg);
+        return -1;
+    }
+
+    /* Walk through linked list, maintaining head pointer so we
+     can free list later */
+
+    for (ifa=ifaddr; ifa != NULL; ifa=ifa->ifa_next) {
+        if (ifa->ifa_addr == NULL)
+            continue;
+
+        /* For an AF_INET* interface address, display the address */
+        if (!strcmp(ifname, ifa->ifa_name)
+                && (ifa->ifa_addr->sa_family == family)) {
+            memcpy(ifsock, ifa->ifa_addr, sizeof(struct sockaddr));
+            freeifaddrs(ifaddr);
+            return 0;
+        }
+
+    }
+
+    freeifaddrs(ifaddr);
+    return -1;
+}
+#endif //0
+
+#endif

--- a/lib/libpcp/src/net/gateway.c
+++ b/lib/libpcp/src/net/gateway.c
@@ -216,7 +216,7 @@ int getgateways(struct sockaddr_in6 **gws)
         /* If the route is not for AF_INET(6) or does not belong to main
            routing table then return. */
         if (((rtMsg->rtm_family != AF_INET) && (rtMsg->rtm_family != AF_INET6))
-                || (rtMsg->rtm_table != RT_TABLE_MAIN)) {
+                || ((rtMsg->rtm_type != RTN_UNICAST) && (rtMsg->rtm_table != RT_TABLE_MAIN))) {
             continue;
         }
 

--- a/lib/libpcp/src/net/gateway.h
+++ b/lib/libpcp/src/net/gateway.h
@@ -1,0 +1,33 @@
+/*
+ Copyright (c) 2014 by Cisco Systems, Inc.
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following disclaimer in the documentation
+ and/or other materials provided with the distribution.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef __GETGATEWAY_H__
+#define __GETGATEWAY_H__
+
+struct sockaddr_in6;
+
+int getgateways(struct sockaddr_in6 **gws);
+
+#endif

--- a/lib/libpcp/src/net/pcp_socket.c
+++ b/lib/libpcp/src/net/pcp_socket.c
@@ -1,0 +1,345 @@
+/*
+ Copyright (c) 2014 by Cisco Systems, Inc.
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following disclaimer in the documentation
+ and/or other materials provided with the distribution.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#else
+#include "default_config.h"
+#endif
+
+#include <stdio.h>
+#include <string.h>
+#include <assert.h>
+#ifdef WIN32
+#include "pcp_win_defines.h"
+#else  //WIN32
+#include <sys/socket.h>
+#include <netinet/in.h>
+#ifndef PCP_SOCKET_IS_VOIDPTR
+#include <unistd.h>
+#include <fcntl.h>
+#include <errno.h>
+#endif //PCP_SOCKET_IS_VOIDPTR
+#endif //!WIN32
+#include "pcp.h"
+#include "unp.h"
+#include "pcp_utils.h"
+#include "pcp_socket.h"
+
+static PCP_SOCKET pcp_socket_create_impl(int domain, int type, int protocol);
+static ssize_t pcp_socket_recvfrom_impl(PCP_SOCKET sock, void *buf, size_t len,
+        int flags, struct sockaddr *src_addr, socklen_t *addrlen);
+static ssize_t pcp_socket_sendto_impl(PCP_SOCKET sock, const void *buf,
+        size_t len, int flags, struct sockaddr *dest_addr, socklen_t addrlen);
+static int pcp_socket_close_impl(PCP_SOCKET sock);
+
+pcp_socket_vt_t default_socket_vt={
+        pcp_socket_create_impl,
+        pcp_socket_recvfrom_impl,
+        pcp_socket_sendto_impl,
+        pcp_socket_close_impl
+};
+
+#ifdef WIN32
+// function calling WSAStartup (used in pcp-server and pcp_app)
+int pcp_win_sock_startup()
+{
+    int err;
+    WORD wVersionRequested;
+    WSADATA wsaData;
+    OSVERSIONINFOEX osvi;
+
+    /* Use the MAKEWORD(lowbyte, highbyte) macro declared in Windef.h */
+    wVersionRequested=MAKEWORD(2, 2);
+    err=WSAStartup(wVersionRequested, &wsaData);
+    if (err != 0) {
+        /* Tell the user that we could not find a usable */
+        /* Winsock DLL.                                  */
+        perror("WSAStartup failed with error");
+        return 1;
+    }
+    //find windows version
+    ZeroMemory(&osvi, sizeof(osvi));
+    osvi.dwOSVersionInfoSize=sizeof(osvi);
+
+    if (!GetVersionEx((LPOSVERSIONINFO)(&osvi))) {
+        printf("pcp_app: GetVersionEx failed");
+        return 1;
+    }
+
+    return 0;
+}
+
+/* function calling WSACleanup
+ *  returns 0 on success and 1 on failure
+ */
+int pcp_win_sock_cleanup()
+{
+    if (WSACleanup() == PCP_SOCKET_ERROR) {
+        printf("WSACleanup failed.\n");
+        return 1;
+    }
+    return 0;
+}
+#endif
+
+void pcp_fill_in6_addr(struct in6_addr *dst_ip6, uint16_t *dst_port,
+        struct sockaddr *src)
+{
+    if (src->sa_family == AF_INET) {
+        struct sockaddr_in *src_ip4=(struct sockaddr_in *)src;
+
+        if (dst_ip6) {
+            if (src_ip4->sin_addr.s_addr != INADDR_ANY) {
+                S6_ADDR32(dst_ip6)[0]=0;
+                S6_ADDR32(dst_ip6)[1]=0;
+                S6_ADDR32(dst_ip6)[2]=htonl(0xFFFF);
+                S6_ADDR32(dst_ip6)[3]=src_ip4->sin_addr.s_addr;
+            } else {
+                unsigned i;
+                for (i=0; i < 4; ++i)
+                    S6_ADDR32(dst_ip6)[i]=0;
+            }
+        }
+        if (dst_port) {
+            *dst_port=src_ip4->sin_port;
+        }
+    } else if (src->sa_family == AF_INET6) {
+        struct sockaddr_in6 *src_ip6=(struct sockaddr_in6 *)src;
+
+        if (dst_ip6) {
+            memcpy(dst_ip6, src_ip6->sin6_addr.s6_addr, sizeof(*dst_ip6));
+        }
+        if (dst_port) {
+            *dst_port=src_ip6->sin6_port;
+        }
+    }
+}
+
+void pcp_fill_sockaddr(struct sockaddr *dst, struct in6_addr *sip,
+        uint16_t sport, int ret_ipv6_mapped_ipv4, uint32_t scope_id)
+{
+    if ((!ret_ipv6_mapped_ipv4) && (IN6_IS_ADDR_V4MAPPED(sip))) {
+        struct sockaddr_in *s=(struct sockaddr_in *)dst;
+
+        s->sin_family=AF_INET;
+        s->sin_addr.s_addr=S6_ADDR32(sip)[3];
+        s->sin_port=sport;
+        SET_SA_LEN(s, sizeof(struct sockaddr_in));
+    } else {
+        struct sockaddr_in6 *s=(struct sockaddr_in6 *)dst;
+
+        s->sin6_family=AF_INET6;
+        s->sin6_addr=*sip;
+        s->sin6_port=sport;
+        s->sin6_scope_id=scope_id;
+        SET_SA_LEN(s, sizeof(struct sockaddr_in6));
+    }
+}
+
+#ifndef PCP_SOCKET_IS_VOIDPTR
+static pcp_errno pcp_get_error()
+{
+#ifdef WIN32
+    int errnum=WSAGetLastError();
+
+    switch (errnum) {
+        case WSAEADDRINUSE:
+            return PCP_ERR_ADDRINUSE;
+        case WSAEWOULDBLOCK:
+            return PCP_ERR_WOULDBLOCK;
+        default:
+            return PCP_ERR_UNKNOWN;
+    }
+#else
+    switch (errno) {
+        case EADDRINUSE:
+            return PCP_ERR_ADDRINUSE;
+//        case EAGAIN:
+        case EWOULDBLOCK:
+            return PCP_ERR_WOULDBLOCK;
+        default:
+            return PCP_ERR_UNKNOWN;
+    }
+#endif
+}
+#endif
+
+PCP_SOCKET pcp_socket_create(struct pcp_ctx_s *ctx, int domain, int type,
+        int protocol)
+{
+    assert(ctx && ctx->virt_socket_tb && ctx->virt_socket_tb->sock_create);
+
+    return ctx->virt_socket_tb->sock_create(domain, type, protocol);
+}
+
+ssize_t pcp_socket_recvfrom(struct pcp_ctx_s *ctx, void *buf, size_t len,
+        int flags, struct sockaddr *src_addr, socklen_t *addrlen)
+{
+    assert(ctx && ctx->virt_socket_tb && ctx->virt_socket_tb->sock_recvfrom);
+
+    return ctx->virt_socket_tb->sock_recvfrom(ctx->socket, buf, len, flags,
+            src_addr, addrlen);
+}
+
+ssize_t pcp_socket_sendto(struct pcp_ctx_s *ctx, const void *buf, size_t len,
+        int flags, struct sockaddr *dest_addr, socklen_t addrlen)
+{
+    assert(ctx && ctx->virt_socket_tb && ctx->virt_socket_tb->sock_sendto);
+
+    return ctx->virt_socket_tb->sock_sendto(ctx->socket, buf, len, flags,
+            dest_addr, addrlen);
+}
+
+int pcp_socket_close(struct pcp_ctx_s *ctx)
+{
+    assert(ctx && ctx->virt_socket_tb && ctx->virt_socket_tb->sock_close);
+
+    return ctx->virt_socket_tb->sock_close(ctx->socket);
+}
+
+static PCP_SOCKET pcp_socket_create_impl(int domain, int type, int protocol)
+{
+#ifdef PCP_SOCKET_IS_VOIDPTR
+    return PCP_INVALID_SOCKET;
+#else
+    PCP_SOCKET s;
+    uint32_t flg;
+    unsigned long iMode=1;
+    struct sockaddr_storage sas;
+    struct sockaddr_in *sin=(struct sockaddr_in *)&sas;
+    struct sockaddr_in6 *sin6=(struct sockaddr_in6 *)&sas;
+
+    OSDEP(iMode);
+    OSDEP(flg);
+
+    memset(&sas, 0, sizeof(sas));
+    sas.ss_family=domain;
+    if (domain == AF_INET) {
+        sin->sin_port=htons(5350);
+        SET_SA_LEN(sin, sizeof(struct sockaddr_in));
+    } else if (domain == AF_INET6) {
+        sin6->sin6_port=htons(5350);
+        SET_SA_LEN(sin6, sizeof(struct sockaddr_in6));
+    } else {
+        PCP_LOG(PCP_LOGLVL_ERR, "Unsupported socket domain:%d", domain);
+    }
+
+    s=(PCP_SOCKET)socket(domain, type, protocol);
+    if (s == PCP_INVALID_SOCKET)
+        return PCP_INVALID_SOCKET;
+
+#ifdef WIN32
+    if (ioctlsocket(s, FIONBIO, &iMode)) {
+        PCP_LOG(PCP_LOGLVL_ERR, "%s",
+                "Unable to set nonblocking mode for socket.");
+        CLOSE(s);
+        return PCP_INVALID_SOCKET;
+    }
+#else
+    flg=fcntl(s, F_GETFL, 0);
+    if (fcntl(s, F_SETFL, flg | O_NONBLOCK)) {
+        PCP_LOG(PCP_LOGLVL_ERR, "%s",
+                "Unable to set nonblocking mode for socket.");
+        CLOSE(s);
+        return PCP_INVALID_SOCKET;
+    }
+#endif
+#ifdef PCP_USE_IPV6_SOCKET
+    flg=0;
+    if (PCP_SOCKET_ERROR
+            == setsockopt(s, IPPROTO_IPV6, IPV6_V6ONLY, (char *)&flg,
+                    sizeof(flg))) {
+        PCP_LOG(PCP_LOGLVL_ERR, "%s",
+                "Dual-stack sockets are not supported on this platform. "
+                "Recompile library with disabled IPv6 support.");
+        CLOSE(s);
+        return PCP_INVALID_SOCKET;
+    }
+#endif //PCP_USE_IPV6_SOCKET
+    while (bind(s, (struct sockaddr *)&sas,
+            SA_LEN((struct sockaddr *)&sas)) == PCP_SOCKET_ERROR) {
+        if (pcp_get_error() == PCP_ERR_ADDRINUSE) {
+            if (sas.ss_family == AF_INET) {
+                sin->sin_port=htons(ntohs(sin->sin_port) + 1);
+            } else {
+                sin6->sin6_port=htons(ntohs(sin6->sin6_port) + 1);
+            }
+        } else {
+            PCP_LOG(PCP_LOGLVL_ERR, "%s", "bind error");
+            CLOSE(s);
+            return PCP_INVALID_SOCKET;
+        }
+    }
+    PCP_LOG(PCP_LOGLVL_DEBUG, "%s: return %d", __FUNCTION__, s);
+    return s;
+#endif
+}
+
+static ssize_t pcp_socket_recvfrom_impl(PCP_SOCKET sock, void *buf,
+        size_t len, int flags, struct sockaddr *src_addr, socklen_t *addrlen)
+{
+    ssize_t ret=-1;
+
+#ifndef PCP_SOCKET_IS_VOIDPTR
+    ret=recvfrom(sock, buf, len, flags, src_addr, addrlen);
+    if (ret == PCP_SOCKET_ERROR) {
+        if (pcp_get_error() == PCP_ERR_WOULDBLOCK) {
+            ret=PCP_ERR_WOULDBLOCK;
+        } else {
+            ret=PCP_ERR_RECV_FAILED;
+        }
+    }
+#endif  //PCP_SOCKET_IS_VOIDPTR
+
+    return ret;
+}
+
+static ssize_t pcp_socket_sendto_impl(PCP_SOCKET sock, const void *buf,
+    size_t len, int flags UNUSED, struct sockaddr *dest_addr, socklen_t addrlen)
+{
+    ssize_t ret=-1;
+
+#ifndef PCP_SOCKET_IS_VOIDPTR
+    ret=sendto(sock, buf, len, 0, dest_addr, addrlen);
+    if ((ret == PCP_SOCKET_ERROR) || (ret != (ssize_t)len)) {
+        if (pcp_get_error() == PCP_ERR_WOULDBLOCK) {
+            ret=PCP_ERR_WOULDBLOCK;
+        } else {
+            ret=PCP_ERR_SEND_FAILED;
+        }
+    }
+#endif
+    return ret;
+}
+
+static int pcp_socket_close_impl(PCP_SOCKET sock)
+{
+#ifndef PCP_SOCKET_IS_VOIDPTR
+    return CLOSE(sock);
+#else
+    return PCP_SOCKET_ERROR;
+#endif
+}

--- a/lib/libpcp/src/net/pcp_socket.h
+++ b/lib/libpcp/src/net/pcp_socket.h
@@ -1,0 +1,122 @@
+/*
+ Copyright (c) 2014 by Cisco Systems, Inc.
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following disclaimer in the documentation
+ and/or other materials provided with the distribution.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef PCP_SOCKET_H
+#define PCP_SOCKET_H
+
+#include "pcp.h"
+
+#ifdef PCP_SOCKET_IS_VOIDPTR
+#define PD_SOCKET_STARTUP()
+#define PD_SOCKET_CLEANUP()
+#define PCP_INVALID_SOCKET NULL
+#define PCP_SOCKET_ERROR (-1)
+
+#ifdef WIN32
+#define CLOSE(sockfd) closesocket(sockfd)
+#else
+#define CLOSE(sockfd) close(sockfd)
+#endif
+
+#else
+
+#ifdef WIN32
+
+int pcp_win_sock_startup();
+int pcp_win_sock_cleanup();
+
+#define PD_SOCKET_STARTUP pcp_win_sock_startup
+#define PD_SOCKET_CLEANUP pcp_win_sock_cleanup
+#define PCP_SOCKET_ERROR SOCKET_ERROR
+#define PCP_INVALID_SOCKET INVALID_SOCKET
+#define CLOSE(sockfd) closesocket(sockfd)
+
+#else
+
+#define PD_SOCKET_STARTUP()
+#define PD_SOCKET_CLEANUP()
+#define PCP_SOCKET_ERROR (-1)
+#define PCP_INVALID_SOCKET (-1)
+#define CLOSE(sockfd) close(sockfd)
+
+#endif
+#endif
+
+struct pcp_ctx_s;
+
+extern pcp_socket_vt_t default_socket_vt;
+
+void pcp_fill_in6_addr(struct in6_addr *dst_ip6, uint16_t *dst_port,
+        struct sockaddr *src);
+
+void pcp_fill_sockaddr(struct sockaddr *dst, struct in6_addr *sip,
+        uint16_t sport, int ret_ipv6_mapped_ipv4, uint32_t scope_id);
+
+PCP_SOCKET pcp_socket_create(struct pcp_ctx_s *ctx, int domain, int type,
+        int protocol);
+
+ssize_t pcp_socket_recvfrom(struct pcp_ctx_s *ctx, void *buf, size_t len,
+        int flags, struct sockaddr *src_addr, socklen_t *addrlen);
+
+ssize_t pcp_socket_sendto(struct pcp_ctx_s *ctx, const void *buf, size_t len,
+        int flags, struct sockaddr *dest_addr, socklen_t addrlen);
+
+int pcp_socket_close(struct pcp_ctx_s *ctx);
+
+/*In Visual Studio inline keyword only available in C++ */
+#if (defined(_MSC_VER) && !defined(inline))
+#define inline __inline
+#endif
+
+#ifndef SA_LEN
+#ifdef HAVE_SOCKADDR_SA_LEN
+#define SA_LEN(addr)    ((addr)->sa_len)
+#else /* HAVE_SOCKADDR_SA_LEN */
+
+static inline size_t get_sa_len(struct sockaddr *addr)
+{
+    switch (addr->sa_family) {
+
+        case AF_INET:
+            return (sizeof(struct sockaddr_in));
+
+        case AF_INET6:
+            return (sizeof(struct sockaddr_in6));
+
+        default:
+            return (sizeof(struct sockaddr));
+    }
+}
+#define SA_LEN(addr)    (get_sa_len(addr))
+#endif /* HAVE_SOCKADDR_SA_LEN */
+#endif /* SA_LEN */
+
+#ifdef HAVE_SOCKADDR_SA_LEN
+#define SET_SA_LEN(s, l) ((struct sockaddr*)s)->sa_len=l
+#else
+#define SET_SA_LEN(s, l)
+#endif
+
+#endif /* PCP_SOCKET_H*/

--- a/lib/libpcp/src/net/sock_ntop.c
+++ b/lib/libpcp/src/net/sock_ntop.c
@@ -1,0 +1,353 @@
+/*
+ Copyright (c) 2014 by Cisco Systems, Inc.
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following disclaimer in the documentation
+ and/or other materials provided with the distribution.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#else
+#include "default_config.h"
+#endif
+
+#ifdef _MSC_VER
+#define _CRT_SECURE_NO_WARNINGS 1
+#endif
+
+#include    <stdio.h>
+#include    <stdlib.h>
+#include    <string.h>
+#include    <sys/types.h>    /* basic system data types */
+#ifdef WIN32
+#include    "pcp_win_defines.h"
+#else
+#include    <sys/socket.h>   /* basic socket definitions */
+#include    <netinet/in.h>   /* sockaddr_in{} and other Internet defns */
+#include    <arpa/inet.h>    /* inet(3) functions */
+#include    <netdb.h>
+#endif
+#include    <errno.h>
+#include    <ctype.h>
+#include    "pcp_utils.h"
+#include    "unp.h"
+
+#ifdef    HAVE_SOCKADDR_DL_STRUCT
+#include    <net/if_dl.h>
+#endif
+
+/* include sock_ntop */
+char *sock_ntop(const struct sockaddr *sa, socklen_t salen)
+{
+    char portstr[8];
+    static char str[128]; /* Unix domain is largest */
+
+    switch (sa->sa_family) {
+        case AF_INET: {
+          const struct sockaddr_in *sin=(const struct sockaddr_in *)sa;
+
+            if (inet_ntop(AF_INET, &sin->sin_addr, str, sizeof(str)) == NULL)
+                return (NULL);
+            if (ntohs(sin->sin_port) != 0) {
+                snprintf(portstr, sizeof(portstr) - 1, ":%d",
+                        ntohs(sin->sin_port));
+                portstr[sizeof(portstr) - 1]='\0';
+                strcat(str, portstr);
+            }
+            return (str);
+        }
+            /* end sock_ntop */
+
+#ifdef  AF_INET6
+        case AF_INET6: {
+            const struct sockaddr_in6 *sin6=(const struct sockaddr_in6 *)sa;
+
+            str[0]='[';
+            if (inet_ntop(AF_INET6, &sin6->sin6_addr, str + 1,
+                    sizeof(str) - 1) == NULL)
+                return (NULL);
+            if (ntohs(sin6->sin6_port) != 0) {
+                snprintf(portstr, sizeof(portstr) - 1, "]:%d",
+                        ntohs(sin6->sin6_port));
+                portstr[sizeof(portstr) - 1]='\0';
+                strcat(str, portstr);
+                return (str);
+            }
+            return (str + 1);
+        }
+#endif
+
+        default:
+            snprintf(str, sizeof(str) - 1,
+                    "sock_ntop: unknown AF_xxx: %d, len %d", sa->sa_family,
+                    salen);
+            str[sizeof(str) - 1]='\0';
+            return (str);
+    }
+    return (NULL);
+}
+
+char *
+Sock_ntop(const struct sockaddr *sa, socklen_t salen)
+{
+    char    *ptr;
+
+    if ( (ptr = sock_ntop(sa, salen)) == NULL)
+        perror("sock_ntop");    /* inet_ntop() sets errno */ //LCOV_EXCL_LINE
+    return(ptr);
+}
+
+int
+sock_pton(const char* cp, struct sockaddr *sa)
+{
+    const char * ip_end;
+    char * host_name = NULL;
+    const char* port=NULL;
+    if ((!cp)||(!sa)) {
+        return -1;
+    }
+
+    //skip ws
+    while ((cp)&&(isspace(*cp))) {
+        ++cp;
+    }
+
+    ip_end = cp;
+    if (*cp=='[') { //find matching bracket ']'
+        ++cp;
+        while ((*ip_end)&&(*ip_end!=']')) {
+            ++ip_end;
+        }
+
+        if (!*ip_end) {
+            return -2;
+        }
+        host_name=strndup(cp, ip_end-cp);
+        ++ip_end;
+    }
+    { //find start of port part
+        while (*ip_end) {
+            if (*ip_end==':') {
+                if (!port) {
+                    port = ip_end+1;
+                } else if (host_name==NULL) { // means addr has [] block
+                    port=NULL; // more than 1 ":" => assume the whole addr is IPv6 address w/o port
+                    host_name=strdup(cp);
+                    break;
+                }
+            }
+            ++ip_end;
+        }
+        if (!host_name) {
+            if ((*ip_end==0)&&(port!=NULL)) {
+                if (port-cp>1) { //only port entered
+                    host_name=strndup(cp, port-cp-1);
+                }
+            } else {
+                host_name=strndup(cp, ip_end-cp);
+            }
+        }
+    }
+
+    // getaddrinfo for host
+    {
+        struct addrinfo hints, *servinfo, *p;
+        int rv;
+
+        memset(&hints, 0, sizeof hints);
+        hints.ai_family = AF_UNSPEC;
+        hints.ai_socktype = SOCK_DGRAM;
+        hints.ai_flags = AI_V4MAPPED;
+
+        if ((rv = getaddrinfo(host_name, port, &hints, &servinfo)) != 0) {
+            fprintf(stderr, "getaddrinfo: %s\n",
+                    gai_strerror(rv));
+            if (host_name)
+                free (host_name);
+            return -2;
+        }
+
+        for(p = servinfo; p != NULL; p = p->ai_next) {
+            if ((p->ai_family == AF_INET)||(p->ai_family == AF_INET6)) {
+                memcpy(sa, p->ai_addr, SA_LEN(p->ai_addr));
+                if(host_name==NULL) { // getaddrinfo returns localhost ip if hostname is null
+                    switch (p->ai_family) {
+                    case AF_INET:
+                        ((struct sockaddr_in*)sa)->sin_addr.s_addr = INADDR_ANY;
+                        break;
+                    case AF_INET6:
+                        memset(&((struct sockaddr_in6*)sa)->sin6_addr, 0,
+                                sizeof(struct sockaddr_in6));
+                        break;
+                    default:   // Should never happen LCOV_EXCL_START
+                        if (host_name)
+                            free (host_name);
+                        return -2;
+                    }          //LCOV_EXCL_STOP
+                }
+                break;
+            }
+        }
+        freeaddrinfo(servinfo);
+    }
+
+    if (host_name)
+        free (host_name);
+    return 0;
+}
+
+struct sockaddr *Sock_pton(const char* cp)
+{
+    static struct sockaddr_storage sa_s;
+    if (sock_pton(cp, (struct sockaddr *)&sa_s)==0) {
+        return (struct sockaddr *)&sa_s;
+    } else {
+        return NULL;
+    }
+}
+
+int
+sock_pton_with_prefix(const char* cp, struct sockaddr *sa, int *int_prefix)
+{
+    const char * prefix_begin = NULL;
+    char * prefix = NULL;
+
+    const char * ip_end;
+    char * host_name = NULL;
+    const char* port=NULL;
+
+    if ((!cp)||(!sa)||(!int_prefix)) {
+        return -1;
+    }
+
+    //skip ws
+    while ((cp)&&(isspace(*cp))) {
+        ++cp;
+    }
+
+    ip_end = cp;
+    if (*cp=='[') { //find matching bracket ']'
+        ++cp;
+        while ((*ip_end)&&(*ip_end!=']')) {
+            if (*ip_end == '/' ){
+                prefix_begin = ip_end+1;
+            }
+            ++ip_end;
+        }
+
+        if (!*ip_end) {
+            return -2;
+        }
+
+        if (prefix_begin){
+            host_name=strndup(cp, prefix_begin-cp-1);
+            prefix = strndup(prefix_begin, ip_end-prefix_begin);
+            if (prefix) {
+                *int_prefix = atoi(prefix);
+                free(prefix);
+            }
+        } else {
+            host_name=strndup(cp, ip_end-cp);
+            *int_prefix=128;
+        }
+        ++ip_end;
+    } else {
+        return -2;
+    }
+
+    { //find start of port part
+        while (*ip_end) {
+            if (*ip_end==':') {
+                if (!port) {
+                    port = ip_end+1;
+                } else if (host_name==NULL) { // means addr has [] block
+                    port=NULL; // more than 1 ":" => assume the whole addr is IPv6 address w/o port
+                    host_name=strdup(cp);
+                    break;
+                }
+            }
+            ++ip_end;
+        }
+        if (!host_name) {
+            if ((*ip_end==0)&&(port!=NULL)) {
+                if (port-cp>1) { //only port entered
+                    host_name=strndup(cp, port-cp-1);
+                }
+            } else {
+                host_name=strndup(cp, ip_end-cp);
+            }
+        }
+    }
+
+    // getaddrinfo for host
+    {
+        struct addrinfo hints, *servinfo, *p;
+        int rv;
+
+        memset(&hints, 0, sizeof hints);
+        hints.ai_family = AF_UNSPEC;
+        hints.ai_socktype = SOCK_DGRAM;
+        hints.ai_flags = AI_V4MAPPED;
+
+        if ((rv = getaddrinfo(host_name, port, &hints, &servinfo)) != 0) {
+            fprintf(stderr, "getaddrinfo: %s\n",
+                    gai_strerror(rv));
+            if (host_name)
+                free (host_name);
+            return -2;
+        }
+
+        for(p = servinfo; p != NULL; p = p->ai_next) {
+            if ((p->ai_family == AF_INET)||(p->ai_family == AF_INET6)) {
+                memcpy(sa, p->ai_addr, SA_LEN(p->ai_addr));
+                if(host_name==NULL) { // getaddrinfo returns localhost ip if hostname is null
+                    switch (p->ai_family) {
+                    case AF_INET6:
+                        memset(&((struct sockaddr_in6*)sa)->sin6_addr, 0,
+                                sizeof(struct sockaddr_in6));
+                        break;
+                    default:   // Should never happen LCOV_EXCL_START
+                        if (host_name)
+                            free (host_name);
+                        return -2;
+                    }          //LCOV_EXCL_STOP
+                }
+                break;
+            }
+        }
+        freeaddrinfo(servinfo);
+    }
+
+    if (host_name)
+        free (host_name);
+
+    if ((sa->sa_family==AF_INET)&&(*int_prefix > 32)) {
+
+        return -2;
+    }
+
+    if ((sa->sa_family==AF_INET6)&&(*int_prefix > 128)) {
+
+        return -2;
+    }
+
+    return 0;
+}

--- a/lib/libpcp/src/net/unp.h
+++ b/lib/libpcp/src/net/unp.h
@@ -1,0 +1,61 @@
+/*
+ Copyright (c) 2013 by Cisco Systems, Inc.
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following disclaimer in the documentation
+ and/or other materials provided with the distribution.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef __unp_h
+#define __unp_h
+
+#ifdef WIN32
+#include <winsock2.h>
+#include <ws2tcpip.h>
+#else
+#include <unistd.h>
+#include <sys/time.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#endif
+
+#include "pcp_socket.h"
+
+#define SA struct sockaddr
+
+char *sock_ntop(const SA *, socklen_t);
+char *sock_ntop_host(const SA *, socklen_t);
+char *Sock_ntop(const SA *, socklen_t);
+char *Sock_ntop_host(const SA *, socklen_t);
+int	 Sockfd_to_family(int);
+
+int sock_pton(const char* cp, struct sockaddr *sa);
+int 
+sock_pton_with_prefix(const char* cp, struct sockaddr *sa, int *int_prefix);
+struct sockaddr *Sock_pton(const char* cp);
+
+void	 err_dump(const char *, ...);
+void	 err_msg(const char *, ...);
+void	 err_quit(const char *, ...);
+void	 err_ret(const char *, ...);
+void	 err_sys(const char *, ...);
+
+#endif	/* __unp_h */

--- a/lib/libpcp/src/pcp_api.c
+++ b/lib/libpcp/src/pcp_api.c
@@ -1,0 +1,777 @@
+/*
+ Copyright (c) 2014 by Cisco Systems, Inc.
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following disclaimer in the documentation
+ and/or other materials provided with the distribution.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#else
+#include "default_config.h"
+#endif
+
+#ifdef _MSC_VER
+#define _CRT_SECURE_NO_WARNINGS 1
+#endif
+
+#include <assert.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+#include <errno.h>
+
+#ifdef WIN32
+#include <winsock2.h>
+#include "pcp_win_defines.h"
+#include "pcp_gettimeofday.h"
+#else
+#include <sys/select.h>
+#include <time.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <netinet/in.h>
+#include <netdb.h>
+#include <arpa/inet.h>
+#endif
+#include "pcp.h"
+#include "pcp_socket.h"
+#include "pcp_client_db.h"
+#include "pcp_logger.h"
+#include "pcp_event_handler.h"
+#include "pcp_utils.h"
+#include "pcp_server_discovery.h"
+#include "net/findsaddr.h"
+
+PCP_SOCKET pcp_get_socket(pcp_ctx_t *ctx)
+{
+
+    return ctx ? ctx->socket : PCP_INVALID_SOCKET;
+}
+
+int pcp_add_server(pcp_ctx_t *ctx, struct sockaddr *pcp_server,
+        uint8_t pcp_version)
+{
+    int res;
+
+    PCP_LOG_BEGIN(PCP_LOGLVL_DEBUG);
+
+    if (!ctx) {
+        return PCP_ERR_BAD_ARGS;
+    }
+    if (pcp_version > PCP_MAX_SUPPORTED_VERSION) {
+        PCP_LOG_END(PCP_LOGLVL_INFO);
+        return PCP_ERR_UNSUP_VERSION;
+    }
+
+    res=psd_add_pcp_server(ctx, pcp_server, pcp_version);
+
+    PCP_LOG_END(PCP_LOGLVL_DEBUG);
+    return res;
+}
+
+pcp_ctx_t *pcp_init(uint8_t autodiscovery, pcp_socket_vt_t *socket_vt)
+{
+    pcp_ctx_t *ctx=(pcp_ctx_t *)calloc(1, sizeof(pcp_ctx_t));
+
+    pcp_logger_init();
+
+    PCP_LOG_BEGIN(PCP_LOGLVL_DEBUG);
+
+    if (!ctx) {
+        PCP_LOG_END(PCP_LOGLVL_DEBUG);
+        return NULL;
+    }
+
+    if (socket_vt) {
+        ctx->virt_socket_tb=socket_vt;
+    } else {
+        ctx->virt_socket_tb=&default_socket_vt;
+    }
+
+    ctx->socket=pcp_socket_create(ctx,
+#ifdef PCP_USE_IPV6_SOCKET
+            AF_INET6,
+#else
+            AF_INET,
+#endif
+            SOCK_DGRAM, 0);
+
+    if (ctx->socket == PCP_INVALID_SOCKET) {
+        PCP_LOG(PCP_LOGLVL_WARN, "%s",
+                "Error occurred while creating a PCP socket.");
+
+        PCP_LOG_END(PCP_LOGLVL_DEBUG);
+        return NULL;
+    }
+    PCP_LOG(PCP_LOGLVL_DEBUG, "%s", "Created a new PCP socket.");
+
+    if (autodiscovery)
+        psd_add_gws(ctx);
+
+    PCP_LOG_END(PCP_LOGLVL_DEBUG);
+    return ctx;
+}
+
+int pcp_eval_flow_state(pcp_flow_t *flow, pcp_fstate_e *fstate)
+{
+    pcp_flow_t *fiter;
+    int nexit_states=0;
+    int fpresent_no_exit_state=0;
+    int fsuccess=0;
+    int ffailed=0;
+
+    PCP_LOG_BEGIN(PCP_LOGLVL_DEBUG);
+
+    for (fiter=flow; fiter != NULL; fiter=fiter->next_child) {
+        switch (fiter->state) {
+            case pfs_wait_for_lifetime_renew:
+                fsuccess=1;
+                ++nexit_states;
+                break;
+            case pfs_failed:
+                ffailed=1;
+                ++nexit_states;
+                break;
+            case pfs_wait_after_short_life_error:
+                ++nexit_states;
+                break;
+            default:
+                fpresent_no_exit_state=1;
+                break;
+        }
+    }
+
+    if (fstate) {
+        if (fpresent_no_exit_state) {
+            if (fsuccess) {
+                *fstate=pcp_state_partial_result;
+            } else {
+                *fstate=pcp_state_processing;
+            }
+        } else {
+            if (fsuccess) {
+                *fstate=pcp_state_succeeded;
+            } else if (ffailed) {
+                *fstate=pcp_state_failed;
+            } else {
+                *fstate=pcp_state_short_lifetime_error;
+            }
+        }
+    }
+
+    PCP_LOG_END(PCP_LOGLVL_DEBUG);
+    return nexit_states;
+}
+
+pcp_fstate_e pcp_wait(pcp_flow_t *flow, int timeout, int exit_on_partial_res)
+{
+#ifdef PCP_SOCKET_IS_VOIDPTR
+    return pcp_state_failed;
+#else
+    fd_set read_fds;
+    int fdmax;
+    PCP_SOCKET fd;
+    struct timeval tout_end;
+    struct timeval tout_select;
+    pcp_fstate_e fstate;
+    int nflow_exit_states=pcp_eval_flow_state(flow, &fstate);
+
+    PCP_LOG_BEGIN(PCP_LOGLVL_DEBUG);
+
+    if (!flow) {
+        PCP_LOG(PCP_LOGLVL_PERR, "Flow argument of %s function set to NULL!",
+                __FUNCTION__);
+        return pcp_state_failed;
+    }
+
+    switch (fstate) {
+        case pcp_state_partial_result:
+        case pcp_state_processing:
+            break;
+        default:
+            nflow_exit_states=0;
+            break;
+    }
+
+    gettimeofday(&tout_end, NULL);
+    tout_end.tv_usec+=(timeout * 1000) % 1000000;
+    tout_end.tv_sec+=tout_end.tv_usec / 1000000;
+    tout_end.tv_usec=tout_end.tv_usec % 1000000;
+    tout_end.tv_sec+=timeout / 1000;
+
+    PCP_LOG(PCP_LOGLVL_INFO,
+            "Initialized wait for result of flow: %d, wait timeout %d ms",
+            flow->key_bucket, timeout);
+
+    FD_ZERO(&read_fds);
+
+    fd=pcp_get_socket(flow->ctx);
+    fdmax=fd + 1;
+
+    // main loop
+    for (;;) {
+        int ret_count;
+        pcp_fstate_e ret_state;
+        struct timeval ctv;
+
+        OSDEP(ret_count);
+        // check expiration of wait timeout
+        gettimeofday(&ctv, NULL);
+        if ((timeval_subtract(&tout_select, &tout_end, &ctv))
+                || ((tout_select.tv_sec == 0) && (tout_select.tv_usec == 0))
+                || (tout_select.tv_sec < 0)) {
+            return pcp_state_processing;
+        }
+
+        //process all events and get timeout value for next select
+        pcp_pulse(flow->ctx, &tout_select);
+
+        // check flow for reaching one of exit from wait states
+        // (also handles case when flow is MAP for 0.0.0.0)
+        if (pcp_eval_flow_state(flow, &ret_state) > nflow_exit_states) {
+            if ((exit_on_partial_res)
+                    || (ret_state != pcp_state_partial_result)) {
+                PCP_LOG_END(PCP_LOGLVL_DEBUG);
+                return ret_state;
+            }
+        }
+
+        FD_ZERO(&read_fds);
+        FD_SET(fd, &read_fds);
+
+        PCP_LOG(PCP_LOGLVL_DEBUG,
+                "Executing select with fdmax=%d, timeout = %ld s; %ld us",
+                fdmax, tout_select.tv_sec, (long int)tout_select.tv_usec);
+
+        ret_count=select(fdmax, &read_fds, NULL, NULL, &tout_select);
+
+        // check of select result // only for debug purposes
+#ifdef DEBUG
+        if (ret_count == -1) {
+            char error[ERR_BUF_LEN];
+            pcp_strerror(errno, error, sizeof(error));
+            PCP_LOG(PCP_LOGLVL_PERR,
+                    "select failed: %s", error);
+        } else if (ret_count == 0) {
+            PCP_LOG(PCP_LOGLVL_DEBUG, "%s",
+                    "select timed out");
+        } else {
+            PCP_LOG(PCP_LOGLVL_DEBUG,
+                    "select returned %d i/o events.", ret_count);
+        }
+#endif
+    }PCP_LOG_END(PCP_LOGLVL_DEBUG);
+    return pcp_state_succeeded;
+#endif //PCP_SOCKET_IS_VOIDPTR
+}
+
+static inline void init_flow(pcp_flow_t *f, pcp_server_t *s, int lifetime,
+        struct sockaddr *ext_addr)
+{
+    PCP_LOG_BEGIN(PCP_LOGLVL_DEBUG);
+    if (f && s) {
+        struct timeval curtime;
+        f->ctx=s->ctx;
+
+        switch (f->kd.operation) {
+          case PCP_OPCODE_MAP:
+          case PCP_OPCODE_PEER:
+              pcp_fill_in6_addr(&f->map_peer.ext_ip, &f->map_peer.ext_port,
+                  ext_addr);
+              break;
+          default:
+            assert(!ext_addr);
+            break;
+        }
+
+        gettimeofday(&curtime, NULL);
+        f->lifetime=lifetime;
+        f->timeout=curtime;
+
+        if (s->server_state == pss_wait_io) {
+            f->state=pfs_send;
+        } else {
+            f->state=pfs_wait_for_server_init;
+        }
+
+        s->next_timeout=curtime;
+        f->user_data=NULL;
+
+        pcp_db_add_flow(f);
+        PCP_LOG_FLOW(f, "Added new flow");
+    }
+    PCP_LOG_END(PCP_LOGLVL_DEBUG);
+}
+
+struct caasi_data {
+    struct flow_key_data *kd;
+    pcp_flow_t *fprev;
+    pcp_flow_t *ffirst;
+    uint32_t lifetime;
+    struct sockaddr *ext_addr;
+    struct in6_addr *src_ip;
+    uint8_t toler_fields;
+    char *app_name;
+    void *userdata;
+};
+
+static int chain_and_assign_src_ip(pcp_server_t *s, void *data)
+{
+    struct caasi_data *d=(struct caasi_data *)data;
+
+    PCP_LOG_BEGIN(PCP_LOGLVL_DEBUG);
+
+    if (s->server_state == pss_not_working) {
+        PCP_LOG_END(PCP_LOGLVL_DEBUG);
+        return 0;
+    }
+
+    if ((IN6_IS_ADDR_UNSPECIFIED(d->src_ip))
+            || (IN6_ARE_ADDR_EQUAL(d->src_ip, (struct in6_addr *) s->src_ip))) {
+        pcp_flow_t *f=NULL;
+
+        memcpy(&d->kd->src_ip, s->src_ip, sizeof(d->kd->src_ip));
+        memcpy(&d->kd->pcp_server_ip, s->pcp_ip, sizeof(d->kd->pcp_server_ip));
+        memcpy(&d->kd->nonce, &s->nonce, sizeof(d->kd->nonce));
+
+        f=pcp_create_flow(s, d->kd);
+        if (!f) {
+            PCP_LOG_END(PCP_LOGLVL_DEBUG);
+            return 1;
+        }
+#ifdef PCP_SADSCP
+        if (d->kd->operation == PCP_OPCODE_SADSCP) {
+            f->sadscp.toler_fields = d->toler_fields;
+            if (d->app_name) {
+                f->sadscp.app_name_length = strlen(d->app_name);
+                f->sadscp_app_name = strdup(d->app_name);
+            } else {
+                f->sadscp.app_name_length = 0;
+                f->sadscp_app_name = NULL;
+            }
+        }
+#endif
+        init_flow(f, s, d->lifetime, d->ext_addr);
+        f->user_data=d->userdata;
+        if (d->fprev) {
+            d->fprev->next_child=f;
+        } else {
+            d->ffirst=f;
+        }
+        d->fprev=f;
+    }
+
+    PCP_LOG_END(PCP_LOGLVL_DEBUG);
+    return 0;
+}
+
+pcp_flow_t *pcp_new_flow(pcp_ctx_t *ctx, struct sockaddr *src_addr,
+        struct sockaddr *dst_addr, struct sockaddr *ext_addr, uint8_t protocol,
+        uint32_t lifetime, void *userdata)
+{
+    struct flow_key_data kd;
+    struct caasi_data data;
+    struct in6_addr src_ip;
+    struct sockaddr_storage tmp_ext_addr;
+
+    PCP_LOG_BEGIN(PCP_LOGLVL_DEBUG);
+
+    memset(&kd, 0, sizeof(kd));
+
+    if ((!src_addr) || (!ctx)) {
+        return NULL;
+    }
+    pcp_fill_in6_addr(&src_ip, &kd.map_peer.src_port, src_addr);
+
+    kd.map_peer.protocol=protocol;
+
+    if (dst_addr) {
+        switch (dst_addr->sa_family) {
+            case AF_INET:
+                if (((struct sockaddr_in*)(dst_addr))->sin_addr.s_addr
+                        == INADDR_ANY) {
+                    dst_addr=NULL;
+                }
+                break;
+            case AF_INET6:
+                if (IN6_IS_ADDR_UNSPECIFIED(
+                        &((struct sockaddr_in6 *)(dst_addr))->sin6_addr)) {
+                    dst_addr=NULL;
+                }
+                break;
+            default:
+                dst_addr=NULL;
+                break;
+        }
+    }
+
+    if (dst_addr) {
+        pcp_fill_in6_addr(&kd.map_peer.dst_ip, &kd.map_peer.dst_port, dst_addr);
+        kd.operation=PCP_OPCODE_PEER;
+        if (src_addr->sa_family == AF_INET) {
+            if (S6_ADDR32(&src_ip)[3] == INADDR_ANY) {
+                findsaddr((struct sockaddr_in*)dst_addr, &src_ip);
+            }
+        } else if (IN6_IS_ADDR_UNSPECIFIED(&src_ip)) {
+            findsaddr6((struct sockaddr_in6*)dst_addr, &src_ip);
+        } else if (dst_addr->sa_family != src_addr->sa_family) {
+            PCP_LOG(PCP_LOGLVL_PERR, "%s",
+                    "Socket family mismatch.");
+
+            PCP_LOG_END(PCP_LOGLVL_DEBUG);
+            return NULL;
+        }
+    } else {
+        kd.operation=PCP_OPCODE_MAP;
+    }
+
+    if (!ext_addr) {
+      struct sockaddr_in *te4=(struct sockaddr_in *)&tmp_ext_addr;
+      struct sockaddr_in6 *te6=(struct sockaddr_in6 *)&tmp_ext_addr;
+      tmp_ext_addr.ss_family=src_addr->sa_family;
+      switch (tmp_ext_addr.ss_family) {
+        case AF_INET:
+          memset(&te4->sin_addr, 0, sizeof(te4->sin_addr));
+          te4->sin_port=0;
+          break;
+        case AF_INET6:
+          memset(&te6->sin6_addr, 0, sizeof(te6->sin6_addr));
+          te6->sin6_port=0;
+          break;
+        default:
+          PCP_LOG(PCP_LOGLVL_PERR, "%s",
+                  "Unsupported address family.");
+          return NULL;
+      }
+      ext_addr=(struct sockaddr *)&tmp_ext_addr;
+    }
+
+    data.fprev=NULL;
+    data.lifetime=lifetime;
+    data.ext_addr=ext_addr;
+    data.src_ip=&src_ip;
+    data.kd=&kd;
+    data.ffirst=NULL;
+    data.userdata=userdata;
+
+    if (pcp_db_foreach_server(ctx, chain_and_assign_src_ip, &data)
+            != PCP_ERR_MAX_SIZE) {    // didn't iterate through each server => error happened
+        pcp_delete_flow(data.ffirst);
+        PCP_LOG_END(PCP_LOGLVL_DEBUG);
+        return NULL;
+    }
+
+    PCP_LOG_END(PCP_LOGLVL_DEBUG);
+    return data.ffirst;
+}
+
+void pcp_flow_set_lifetime(pcp_flow_t *f, uint32_t lifetime)
+{
+    pcp_flow_t *fiter;
+
+    for (fiter=f; fiter != NULL; fiter=fiter->next_child) {
+        fiter->lifetime=lifetime;
+
+        pcp_flow_updated(fiter);
+    }
+}
+
+void pcp_flow_set_3rd_party_opt(pcp_flow_t *f, struct sockaddr *thirdp_addr)
+{
+    pcp_flow_t *fiter;
+
+    for (fiter=f; fiter != NULL; fiter=fiter->next_child) {
+        fiter->third_party_option_present=1;
+        pcp_fill_in6_addr(&fiter->third_party_ip, NULL, thirdp_addr);
+        pcp_flow_updated(fiter);
+    }
+}
+
+void pcp_flow_set_filter_opt(pcp_flow_t *f, struct sockaddr *filter_ip,
+        uint8_t filter_prefix)
+{
+    pcp_flow_t *fiter;
+
+    for (fiter=f; fiter != NULL; fiter=fiter->next_child) {
+        if (!fiter->filter_option_present) {
+            fiter->filter_option_present=1;
+        }
+        pcp_fill_in6_addr(&fiter->filter_ip, &fiter->filter_port, filter_ip);
+        fiter->filter_prefix=filter_prefix;
+        pcp_flow_updated(fiter);
+    }
+}
+
+void pcp_flow_set_prefer_failure_opt(pcp_flow_t *f)
+{
+    pcp_flow_t *fiter;
+
+    for (fiter=f; fiter != NULL; fiter=fiter->next_child) {
+        if (!fiter->pfailure_option_present) {
+            fiter->pfailure_option_present=1;
+            pcp_flow_updated(fiter);
+        }
+    }
+}
+#ifdef PCP_EXPERIMENTAL
+int pcp_flow_set_userid(pcp_flow_t *f, pcp_userid_option_p user)
+{
+    pcp_flow_t *fiter;
+
+    for (fiter=f; fiter; fiter=fiter->next_child) {
+        memcpy(&(fiter->f_userid.userid[0]), &(user->userid[0]), MAX_USER_ID);
+        pcp_flow_updated(fiter);
+    }
+    return 0;
+}
+
+int pcp_flow_set_location(pcp_flow_t *f, pcp_location_option_p loc)
+{
+    pcp_flow_t *fiter;
+
+    for (fiter=f; fiter; fiter=fiter->next_child) {
+        memcpy(&(fiter->f_location.location[0]), &(loc->location[0]), MAX_GEO_STR);
+        pcp_flow_updated(fiter);
+    }
+
+    return 0;
+}
+
+int pcp_flow_set_deviceid(pcp_flow_t *f, pcp_deviceid_option_p dev)
+{
+    pcp_flow_t *fiter;
+
+    for (fiter=f; fiter; fiter=fiter->next_child) {
+        memcpy(&(fiter->f_deviceid.deviceid[0]), &(dev->deviceid[0]), MAX_DEVICE_ID);
+        pcp_flow_updated(fiter);
+    }
+    return 0;
+}
+
+void
+pcp_flow_add_md (pcp_flow_t *f, uint32_t md_id, void *value, size_t val_len)
+{
+    pcp_flow_t *fiter;
+
+    for (fiter=f; fiter!=NULL; fiter=fiter->next_child) {
+        pcp_db_add_md(fiter, md_id, value, val_len);
+        pcp_flow_updated(fiter);
+    }
+}
+#endif
+
+#ifdef PCP_FLOW_PRIORITY
+void pcp_flow_set_flowp(pcp_flow_t *f, uint8_t dscp_up, uint8_t dscp_down)
+{
+    pcp_flow_t *fiter;
+
+    for (fiter=f; fiter; fiter=fiter->next_child) {
+        uint8_t fpresent = (dscp_up!=0)||(dscp_down!=0);
+        if (fiter->flowp_option_present != fpresent) {
+            fiter->flowp_option_present=fpresent;
+        }
+        if (fpresent) {
+            fiter->flowp_dscp_up=dscp_up;
+            fiter->flowp_dscp_down=dscp_down;
+        }
+        pcp_flow_updated(fiter);
+    }
+}
+#endif
+
+static inline void pcp_close_flow_intern(pcp_flow_t *f)
+{
+    switch (f->state) {
+        case pfs_wait_for_server_init:
+        case pfs_idle:
+        case pfs_failed:
+            f->state=pfs_failed;
+            break;
+        default:
+            f->lifetime=0;
+            pcp_flow_updated(f);
+            break;
+    }
+    if ((f->state != pfs_wait_for_server_init) && (f->state != pfs_idle)
+            && (f->state != pfs_failed)) {
+        PCP_LOG_FLOW(f, "Flow closed");
+        f->lifetime=0;
+        pcp_flow_updated(f);
+    } else {
+        f->state=pfs_failed;
+    }
+}
+
+void pcp_close_flow(pcp_flow_t *f)
+{
+    pcp_flow_t *fiter;
+
+    for (fiter=f; fiter; fiter=fiter->next_child) {
+        pcp_close_flow_intern(fiter);
+    }
+
+    if (f) {
+        pcp_pulse(f->ctx, NULL);
+    }
+}
+
+void pcp_delete_flow(pcp_flow_t *f)
+{
+    pcp_flow_t *fiter=f;
+    pcp_flow_t *fnext=NULL;
+
+    while (fiter) {
+        fnext=fiter->next_child;
+        pcp_delete_flow_intern(fiter);
+        fiter=fnext;
+    }
+}
+
+static int delete_flow_iter(pcp_flow_t *f, void *data)
+{
+    if (data) {
+        pcp_close_flow_intern(f);
+        pcp_pulse(f->ctx, NULL);
+    }
+    pcp_delete_flow_intern(f);
+
+    return 0;
+}
+
+void pcp_terminate(pcp_ctx_t *ctx, int close_flows)
+{
+    pcp_db_foreach_flow(ctx, delete_flow_iter, close_flows ? (void *)1 : NULL);
+    pcp_db_free_pcp_servers(ctx);
+    pcp_socket_close(ctx);
+}
+
+pcp_flow_info_t *pcp_flow_get_info(pcp_flow_t *f, size_t *info_count)
+{
+    pcp_flow_t *fiter;
+    pcp_flow_info_t *info_buf;
+    pcp_flow_info_t *info_iter;
+    uint32_t cnt=0;
+
+    if (!info_count) {
+        return NULL;
+    }
+
+    for (fiter=f; fiter; fiter=fiter->next_child) {
+      ++cnt;
+    }
+
+    info_buf=(pcp_flow_info_t *)calloc(cnt, sizeof(pcp_flow_info_t));
+    if (!info_buf) {
+        PCP_LOG(PCP_LOGLVL_DEBUG, "%s", "Error allocating memory");
+        return NULL;
+    }
+
+    for (fiter=f, info_iter=info_buf; fiter != NULL;
+            fiter=fiter->next_child, ++info_iter) {
+
+        switch (fiter->state) {
+            case pfs_wait_after_short_life_error:
+                info_iter->result=pcp_state_short_lifetime_error;
+                break;
+            case pfs_wait_for_lifetime_renew:
+                info_iter->result=pcp_state_succeeded;
+                break;
+            case pfs_failed:
+                info_iter->result=pcp_state_failed;
+                break;
+            default:
+                info_iter->result=pcp_state_processing;
+                break;
+        }
+
+        info_iter->recv_lifetime_end=fiter->recv_lifetime;
+        info_iter->lifetime_renew_s=fiter->lifetime;
+        info_iter->pcp_result_code=fiter->recv_result;
+        memcpy(&info_iter->int_ip, &fiter->kd.src_ip, sizeof(struct in6_addr));
+        memcpy(&info_iter->pcp_server_ip, &fiter->kd.pcp_server_ip,
+                sizeof(info_iter->pcp_server_ip));
+        if ((fiter->kd.operation == PCP_OPCODE_MAP)
+                || (fiter->kd.operation == PCP_OPCODE_PEER)) {
+            memcpy(&info_iter->dst_ip, &fiter->kd.map_peer.dst_ip,
+                    sizeof(info_iter->dst_ip));
+            memcpy(&info_iter->ext_ip, &fiter->map_peer.ext_ip,
+                    sizeof(info_iter->ext_ip));
+            info_iter->int_port=fiter->kd.map_peer.src_port;
+            info_iter->dst_port=fiter->kd.map_peer.dst_port;
+            info_iter->ext_port=fiter->map_peer.ext_port;
+            info_iter->protocol=fiter->kd.map_peer.protocol;
+#ifdef PCP_SADSCP
+        } else if (fiter->kd.operation == PCP_OPCODE_SADSCP) {
+            info_iter->learned_dscp=fiter->sadscp.learned_dscp;
+#endif
+        }
+    }
+    *info_count=cnt;
+
+    return info_buf;
+}
+
+void pcp_flow_set_user_data(pcp_flow_t *f, void *userdata)
+{
+    pcp_flow_t *fiter=f;
+
+    while (fiter) {
+        fiter->user_data=userdata;
+        fiter=fiter->next_child;
+    }
+}
+
+void *pcp_flow_get_user_data(pcp_flow_t *f)
+{
+    return (f ? f->user_data : NULL);
+}
+
+#ifdef PCP_SADSCP
+pcp_flow_t *pcp_learn_dscp(pcp_ctx_t *ctx, uint8_t delay_tol, uint8_t loss_tol,
+        uint8_t jitter_tol, char *app_name)
+{
+    struct flow_key_data kd;
+    struct caasi_data data;
+    struct in6_addr src_ip=IN6ADDR_ANY_INIT;
+
+    memset(&data, 0 ,sizeof(data));
+    memset(&kd, 0 ,sizeof(kd));
+
+    kd.operation=PCP_OPCODE_SADSCP;
+
+    data.fprev=NULL;
+    data.src_ip=&src_ip;
+    data.kd=&kd;
+    data.ffirst=NULL;
+    data.lifetime=0;
+    data.ext_addr=NULL;
+    data.toler_fields=(delay_tol&3)<<6 | ((loss_tol&3)<<4)
+        | ((jitter_tol&3)<<2);
+    data.app_name=app_name;
+
+    pcp_db_foreach_server(ctx, chain_and_assign_src_ip, &data);
+
+    return data.ffirst;
+}
+#endif

--- a/lib/libpcp/src/pcp_client_db.c
+++ b/lib/libpcp/src/pcp_client_db.c
@@ -1,0 +1,444 @@
+/*
+ Copyright (c) 2014 by Cisco Systems, Inc.
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following disclaimer in the documentation
+ and/or other materials provided with the distribution.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#else
+#include "default_config.h"
+#endif
+
+#include <assert.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+#include <errno.h>
+#include "pcp.h"
+#include "pcp_utils.h"
+#include "pcp_client_db.h"
+#include "pcp_logger.h"
+
+#define EMPTY 0xFFFFFFFF
+#define PCP_INIT_SERVER_COUNT 5
+
+static uint32_t compute_flow_key(struct flow_key_data *kd)
+{
+    uint32_t h=0;
+    uint8_t *k=(uint8_t*)(kd + 1);
+
+    while ((void*)(k--) != (void*)kd) {
+        uint32_t ho=h & 0xff000000;
+        h=h << 8;
+        h=h ^ (ho >> 24);
+        h=h ^ *k;
+    }
+
+    h=(h * 0x9E3779B9) >> (32 - FLOW_HASH_BITS);
+
+    return h;
+}
+
+pcp_flow_t *pcp_create_flow(pcp_server_t *s, struct flow_key_data *fkd)
+{
+    pcp_flow_t *flow;
+
+    PCP_LOG_BEGIN(PCP_LOGLVL_DEBUG);
+
+    assert(fkd && s);
+
+    flow=(pcp_flow_t*)calloc(1, sizeof(struct pcp_flow_s));
+    if (flow == NULL) {
+        PCP_LOG(PCP_LOGLVL_ERR, "%s",
+                "Malloc can't allocate enough memory for the pcp_flow.");
+        PCP_LOG(PCP_LOGLVL_ERR, "%s", "Returning NULL.");
+        PCP_LOG_END(PCP_LOGLVL_DEBUG);
+        return NULL;
+    }
+
+    flow->pcp_msg_len=0;
+    flow->pcp_server_indx=(s ? s->index : PCP_INV_SERVER);
+    flow->kd=*fkd;
+    flow->key_bucket=EMPTY;
+    flow->ctx=s->ctx;
+
+    PCP_LOG_END(PCP_LOGLVL_DEBUG);
+    return flow;
+}
+
+void pcp_flow_clear_msg_buf(pcp_flow_t *f)
+{
+    if (f) {
+        if (f->pcp_msg_buffer) {
+            free(f->pcp_msg_buffer);
+            f->pcp_msg_buffer=NULL;
+        }
+        f->pcp_msg_len=0;
+    }
+}
+
+pcp_errno pcp_delete_flow_intern(pcp_flow_t *f)
+{
+    pcp_server_t *s;
+
+    assert(f);
+
+    pcp_db_rem_flow(f);
+
+    if (f->pcp_msg_buffer) {
+        free(f->pcp_msg_buffer);
+    }
+
+#ifdef PCP_EXPERIMENTAL
+    if (f->md_vals) {
+        free(f->md_vals);
+    }
+#endif
+
+#ifdef PCP_SADSCP
+    if (f->sadscp_app_name) {
+        free(f->sadscp_app_name);
+    }
+#endif
+
+    if ((f->pcp_server_indx != PCP_INV_SERVER)
+            && ((s=get_pcp_server(f->ctx, f->pcp_server_indx)) != NULL)
+            && (s->ping_flow_msg == f)) {
+        s->ping_flow_msg=NULL;
+    }
+
+    free(f);
+    return PCP_ERR_SUCCESS;
+}
+
+pcp_errno pcp_db_add_flow(pcp_flow_t *f)
+{
+    uint32_t indx;
+    pcp_flow_t **fdb;
+    pcp_ctx_t *ctx;
+
+    if (!f) {
+        return PCP_ERR_BAD_ARGS;
+    }
+
+    ctx=f->ctx;
+
+    f->key_bucket=indx=compute_flow_key(&f->kd);
+    PCP_LOG(PCP_LOGLVL_DEBUG, "Adding flow %p, key_bucket %d",
+            f, f->key_bucket);
+
+    for (fdb=ctx->pcp_db.flows + indx; (*fdb) != NULL; fdb=&(*fdb)->next);
+
+    *fdb=f;
+    f->next=NULL;
+    ctx->pcp_db.flow_cnt++;
+
+    PCP_LOG(PCP_LOGLVL_DEBUG, "total Number of flows added %zu",
+            ctx->pcp_db.flow_cnt);
+
+    return PCP_ERR_SUCCESS;
+}
+
+pcp_flow_t *pcp_get_flow(struct flow_key_data *fkd, pcp_server_t *s)
+{
+    pcp_flow_t **fdb;
+    uint32_t bucket;
+    uint32_t pcp_server_index;
+
+    if ((!fkd) || (!s) || (!s->ctx)) {
+        return NULL;
+    }
+    pcp_server_index=s->index;
+
+    bucket=compute_flow_key(fkd);
+    PCP_LOG(PCP_LOGLVL_DEBUG, "Computed key_bucket %d", bucket);
+    for (fdb=&s->ctx->pcp_db.flows[bucket]; (*fdb) != NULL; fdb=&(*fdb)->next) {
+        if (((*fdb)->pcp_server_indx == pcp_server_index)
+                && (0 == memcmp(fkd, &(*fdb)->kd, sizeof(*fkd)))) {
+            return *fdb;
+        }
+    }
+
+    return NULL;
+}
+
+pcp_errno pcp_db_rem_flow(pcp_flow_t *f)
+{
+    pcp_flow_t **fdb=NULL;
+    pcp_ctx_t *ctx;
+
+    assert(f && f->ctx);
+
+    if (f->key_bucket == EMPTY) {
+        return PCP_ERR_NOT_FOUND;
+    }
+
+    ctx=f->ctx;
+    PCP_LOG(PCP_LOGLVL_DEBUG, "Removing flow %p, key_bucket %d",
+            f, f->key_bucket);
+
+    for (fdb=ctx->pcp_db.flows + f->key_bucket; (*fdb) != NULL;
+            fdb=&((*fdb)->next)) {
+        if (*fdb == f) {
+            (*fdb)->key_bucket=EMPTY;
+            (*fdb)=(*fdb)->next;
+            ctx->pcp_db.flow_cnt--;
+            return PCP_ERR_SUCCESS;
+        }
+    }
+
+    return PCP_ERR_NOT_FOUND;
+}
+
+pcp_errno pcp_db_foreach_flow(pcp_ctx_t *ctx, pcp_db_flow_iterate f, void *data)
+{
+    pcp_flow_t *fdb, *fdb_next=NULL;
+    uint32_t indx;
+
+    assert(f && ctx);
+
+    for (indx=0; indx < FLOW_HASH_SIZE; ++indx) {
+        fdb=ctx->pcp_db.flows[indx];
+        while (fdb != NULL) {
+            fdb_next=(fdb->next);
+            if ((*f)(fdb, data)) {
+                return PCP_ERR_SUCCESS;
+            }
+            fdb=fdb_next;
+        }
+
+    }
+
+    return PCP_ERR_NOT_FOUND;
+}
+
+#ifdef PCP_EXPERIMENTAL
+void pcp_db_add_md(pcp_flow_t *f, uint16_t md_id, void *val, size_t val_len)
+{
+    md_val_t *md;
+    uint32_t i;
+
+    assert(f);
+
+    for (i=f->md_val_count, md=f->md_vals; i>0 && md!=NULL; --i, ++md)
+    {
+        if (md->md_id == md_id) {
+            break;
+        }
+    }
+    if (i==0) {
+        md = NULL;
+    }
+
+    if (!md) {
+        md = (md_val_t*) realloc(f->md_vals,
+                sizeof(f->md_vals[0])*(f->md_val_count+1));
+        if (!md) { //LCOV_EXCL_START
+            return;
+        } //LCOV_EXCL_STOP
+        f->md_vals = md;
+        md = f->md_vals + f->md_val_count++;
+    }
+    md->md_id = md_id;
+    if ((val_len>0)&&(val!=NULL)) {
+        md->val_len = val_len > sizeof(md->val_buf) ?
+            sizeof(md->val_buf) : val_len;
+        memcpy(md->val_buf, val, md->val_len);
+    } else {
+        md->val_len=0;
+    }
+}
+#endif
+
+int pcp_new_server(pcp_ctx_t *ctx, struct in6_addr *ip, uint16_t port, uint32_t scope_id)
+{
+    uint32_t i;
+    pcp_server_t *ret=NULL;
+
+    PCP_LOG_BEGIN(PCP_LOGLVL_DEBUG);
+
+    assert(ctx && ip);
+
+    //initialize array of pcp servers, if not already initialized
+    if (!ctx->pcp_db.pcp_servers) {
+        ctx->pcp_db.pcp_servers=(pcp_server_t *)calloc(PCP_INIT_SERVER_COUNT,
+                sizeof(*ctx->pcp_db.pcp_servers));
+        if (!ctx->pcp_db.pcp_servers) {
+            char buff[ERR_BUF_LEN];
+            pcp_strerror(errno, buff, sizeof(buff));
+            PCP_LOG(PCP_LOGLVL_ERR, "Error (%s) occurred during realloc ",
+                    buff);
+            PCP_LOG_END(PCP_LOGLVL_DEBUG);
+            return PCP_ERR_NO_MEM;
+        }
+        ctx->pcp_db.pcp_servers_length=PCP_INIT_SERVER_COUNT;
+    }
+
+    //find first unused record
+    for (i=0; i < ctx->pcp_db.pcp_servers_length; ++i) {
+        pcp_server_t *s=ctx->pcp_db.pcp_servers + i;
+        if (s->server_state == pss_unitialized) {
+            ret=s;
+            break;
+        }
+    }
+
+    // if nothing available double the size of array
+    if (ret == NULL) {
+        ret=(pcp_server_t *)realloc(ctx->pcp_db.pcp_servers,
+                sizeof(ctx->pcp_db.pcp_servers[0])
+                        * (ctx->pcp_db.pcp_servers_length << 1));
+        if (!ret) {
+            char buff[ERR_BUF_LEN];
+
+            pcp_strerror(errno, buff, sizeof(buff));
+            PCP_LOG(PCP_LOGLVL_ERR, "Error (%s) occurred during realloc ",
+                    buff);
+            PCP_LOG_END(PCP_LOGLVL_DEBUG);
+            return PCP_ERR_NO_MEM;
+        }
+        ctx->pcp_db.pcp_servers=ret;
+        ret=ctx->pcp_db.pcp_servers + ctx->pcp_db.pcp_servers_length;
+        memset(ret, 0, sizeof(*ret)*ctx->pcp_db.pcp_servers_length);
+        ctx->pcp_db.pcp_servers_length<<=1;
+    }
+
+    ret->epoch=~0;
+#ifdef PCP_USE_IPV6_SOCKET
+    ret->af = AF_INET6;
+#else
+    ret->af=IN6_IS_ADDR_V4MAPPED(ip) ? AF_INET : AF_INET6;
+#endif
+    IPV6_ADDR_COPY((struct in6_addr*)ret->pcp_ip, ip);
+    ret->pcp_port=port;
+    ret->pcp_scope_id=scope_id;
+    ret->ctx=ctx;
+    ret->server_state=pss_allocated;
+    ret->pcp_version=PCP_MAX_SUPPORTED_VERSION;
+    createNonce(&ret->nonce);
+    ret->index=ret - ctx->pcp_db.pcp_servers;
+
+    PCP_LOG_END(PCP_LOGLVL_DEBUG);
+    return ret->index;
+}
+
+pcp_server_t *get_pcp_server(pcp_ctx_t *ctx, int pcp_server_index)
+{
+    PCP_LOG_BEGIN(PCP_LOGLVL_DEBUG);
+
+    assert(ctx);
+
+    if ((pcp_server_index < 0)
+            || ((unsigned)pcp_server_index >= ctx->pcp_db.pcp_servers_length)) {
+
+        PCP_LOG(PCP_LOGLVL_WARN, "server index(%d) out of bounds(%zu)",
+                pcp_server_index, ctx->pcp_db.pcp_servers_length);
+        PCP_LOG_END(PCP_LOGLVL_DEBUG);
+        return NULL;
+    }
+
+    if (ctx->pcp_db.pcp_servers[pcp_server_index].server_state
+            == pss_unitialized) {
+
+        PCP_LOG_END(PCP_LOGLVL_DEBUG);
+        return NULL;
+    }
+
+    PCP_LOG_END(PCP_LOGLVL_DEBUG);
+    return ctx->pcp_db.pcp_servers + pcp_server_index;
+}
+
+pcp_errno pcp_db_foreach_server(pcp_ctx_t *ctx, pcp_db_server_iterate f,
+        void *data)
+{
+    uint32_t indx;
+    int ret=PCP_ERR_MAX_SIZE;
+
+    PCP_LOG_BEGIN(PCP_LOGLVL_DEBUG);
+
+    assert(ctx && f);
+
+    for (indx=0; indx < ctx->pcp_db.pcp_servers_length; ++indx) {
+        if (ctx->pcp_db.pcp_servers[indx].server_state == pss_unitialized) {
+            continue;
+        }
+        if ((*f)(ctx->pcp_db.pcp_servers + indx, data)) {
+            ret=PCP_ERR_SUCCESS;
+            break;
+        }
+    } PCP_LOG_END(PCP_LOGLVL_DEBUG);
+    return ret;
+}
+
+typedef struct find_data {
+    struct in6_addr *ip;
+    pcp_server_t *found_server;
+} find_data_t;
+
+static int find_ip(pcp_server_t *s, void *data)
+{
+    find_data_t *fd=(find_data_t *)data;
+
+    if (IN6_ARE_ADDR_EQUAL(fd->ip, (struct in6_addr *) s->pcp_ip)) {
+
+        fd->found_server=s;
+        return 1;
+    }
+    return 0;
+}
+
+pcp_server_t *get_pcp_server_by_ip(pcp_ctx_t *ctx, struct in6_addr *ip)
+{
+    find_data_t fdata;
+
+    PCP_LOG_BEGIN(PCP_LOGLVL_DEBUG);
+
+    assert(ctx && ip);
+
+    fdata.found_server=NULL;
+    fdata.ip=ip;
+    pcp_db_foreach_server(ctx, find_ip, &fdata);
+
+    PCP_LOG_END(PCP_LOGLVL_DEBUG);
+    return fdata.found_server;
+}
+
+void pcp_db_free_pcp_servers(pcp_ctx_t *ctx)
+{
+    uint32_t i;
+
+    assert(ctx);
+
+    for (i=0; i < ctx->pcp_db.pcp_servers_length; ++i) {
+        pcp_server_t *s=ctx->pcp_db.pcp_servers + i;
+        pcp_server_state_e state=s->server_state;
+        if ((state != pss_unitialized) && (state != pss_allocated)) {
+            run_server_state_machine(s, pcpe_terminate);
+        }
+    }
+    free(ctx->pcp_db.pcp_servers);
+    ctx->pcp_db.pcp_servers=NULL;
+    ctx->pcp_db.pcp_servers_length=0;
+}

--- a/lib/libpcp/src/pcp_client_db.h
+++ b/lib/libpcp/src/pcp_client_db.h
@@ -1,0 +1,262 @@
+/*
+ Copyright (c) 2014 by Cisco Systems, Inc.
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following disclaimer in the documentation
+ and/or other materials provided with the distribution.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef PCP_CLIENT_DB_H_
+#define PCP_CLIENT_DB_H_
+
+#include <stdint.h>
+#include "pcp.h"
+#include "pcp_event_handler.h"
+#include "pcp_msg_structs.h"
+#ifdef WIN32
+#include "unp.h"
+#include "pcp_win_defines.h"
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum {
+    optf_3rd_party=1 << 0, optf_flowp=1 << 1,
+} opt_flags_e;
+
+#define PCP_INV_SERVER (~0u)
+
+#ifdef PCP_EXPERIMENTAL
+
+#ifndef MD_VAL_MAX_LEN
+#define MD_VAL_MAX_LEN 24
+#endif
+
+typedef struct {
+    uint16_t md_id;
+    uint16_t val_len;
+    uint8_t val_buf[MD_VAL_MAX_LEN];
+}md_val_t;
+#endif
+
+#define FLOW_HASH_BITS 5
+#define FLOW_HASH_SIZE (2<<FLOW_HASH_BITS)
+
+struct flow_key_data {
+    uint8_t operation;
+    struct in6_addr src_ip;
+    struct in6_addr pcp_server_ip;
+    struct pcp_nonce nonce;
+    union {
+        struct mp_keydata {
+            uint8_t protocol;
+            uint16_t src_port;
+            struct in6_addr dst_ip;
+            uint16_t dst_port;
+        } map_peer;
+    };
+};
+
+typedef struct pcp_recv_msg {
+    opt_flags_e opt_flags;
+    struct flow_key_data kd;
+    uint32_t key_bucket;
+
+    //response data
+    struct in6_addr assigned_ext_ip;
+    uint16_t assigned_ext_port;
+    uint8_t recv_dscp;
+    uint32_t recv_version;
+    uint32_t recv_epoch;
+    uint32_t recv_lifetime;
+    uint32_t recv_result;
+    time_t received_time;
+
+    //control data
+    uint32_t pcp_server_indx;
+    struct sockaddr_storage rcvd_from_addr;
+    //msg buffer
+    uint32_t pcp_msg_len;
+    char pcp_msg_buffer[PCP_MAX_LEN];
+} pcp_recv_msg_t;
+
+struct pcp_ctx_s {
+    PCP_SOCKET socket;
+    struct pcp_client_db {
+        size_t pcp_servers_length;
+        pcp_server_t *pcp_servers;
+        size_t flow_cnt;
+        pcp_flow_t *flows[FLOW_HASH_SIZE];
+    } pcp_db;
+    pcp_flow_change_notify flow_change_cb_fun;
+    void *flow_change_cb_arg;
+    pcp_recv_msg_t msg;
+    pcp_socket_vt_t *virt_socket_tb;
+};
+
+struct pcp_flow_s {
+    // flow's data
+    struct pcp_ctx_s *ctx;
+    opt_flags_e opt_flags;
+    struct flow_key_data kd;
+    uint32_t key_bucket;
+
+    uint32_t lifetime;
+    union {
+        struct {
+            struct in6_addr ext_ip;
+            uint16_t ext_port;
+        } map_peer;
+#ifdef PCP_SADSCP
+        struct {
+            uint8_t toler_fields;
+            uint8_t app_name_length;
+            uint8_t learned_dscp;
+        }sadscp;
+#endif
+    };
+#ifdef PCP_SADSCP
+    char *sadscp_app_name;
+#endif
+    //response data
+    time_t recv_lifetime;
+    uint32_t recv_result;
+
+    //control data
+    struct pcp_flow_s *next; //next flow with same key bucket
+    struct pcp_flow_s *next_child; //next flow for MAP with 0.0.0.0 src ip
+    uint32_t pcp_server_indx;
+    pcp_flow_state_e state;
+    uint32_t resend_timeout;
+    uint32_t retry_count;
+    uint32_t to_send_count;
+    struct timeval timeout;
+
+#ifdef PCP_EXPERIMENTAL
+    //Userid
+    pcp_userid_option_t f_userid;
+
+    //Location
+    pcp_location_option_t f_location;
+
+    //DeviceID
+    pcp_deviceid_option_t f_deviceid;
+#endif
+
+#ifdef PCP_FLOW_PRIORITY
+    //FLOW Priority Option
+    uint8_t flowp_option_present;
+    uint8_t flowp_dscp_up;
+    uint8_t flowp_dscp_down;
+#endif
+
+    //PREFER FAILURE Option
+    uint8_t pfailure_option_present;
+
+    //FILTER Option
+    uint8_t filter_option_present;
+    uint8_t filter_prefix;
+    uint16_t filter_port;
+    struct in6_addr filter_ip;
+
+    // THIRD_PARTY Option
+    uint8_t third_party_option_present;
+    struct in6_addr third_party_ip;
+
+#ifdef PCP_EXPERIMENTAL
+    //MD Option
+    uint32_t md_val_count;
+    md_val_t *md_vals;
+#endif
+
+    //msg buffer
+    uint32_t pcp_msg_len;
+    char *pcp_msg_buffer;
+    void *user_data;
+};
+
+/* structure holding PCP server specific data */
+struct pcp_server {
+    pcp_ctx_t *ctx;
+    uint32_t af;
+    uint32_t pcp_ip[4];
+    uint16_t pcp_port;
+    uint32_t pcp_scope_id;
+    uint32_t src_ip[4];
+    char pcp_server_paddr[INET6_ADDRSTRLEN];
+    struct sockaddr_storage pcp_server_saddr;
+    uint8_t pcp_version;
+    uint8_t next_version;
+    pcp_server_state_e server_state;
+    uint32_t epoch;
+    time_t cepoch;
+    struct pcp_nonce nonce;
+    uint32_t index;
+    pcp_flow_t *ping_flow_msg;
+    pcp_flow_t *restart_flow_msg;
+    uint32_t ping_count;
+    struct timeval next_timeout;
+    uint32_t natpmp_ext_addr;
+    void *app_data;
+};
+
+typedef int (*pcp_db_flow_iterate)(pcp_flow_t *f, void *data);
+
+typedef int (*pcp_db_server_iterate)(pcp_server_t *f, void *data);
+
+pcp_flow_t *pcp_create_flow(pcp_server_t *s, struct flow_key_data *fkd);
+
+pcp_errno pcp_free_flow(pcp_flow_t *f);
+
+pcp_flow_t *pcp_get_flow(struct flow_key_data *fkd, pcp_server_t *s);
+
+pcp_errno pcp_db_add_flow(pcp_flow_t *f);
+
+pcp_errno pcp_db_rem_flow(pcp_flow_t *f);
+
+pcp_errno pcp_db_foreach_flow(pcp_ctx_t *ctx, pcp_db_flow_iterate f,
+        void *data);
+
+void pcp_flow_clear_msg_buf(pcp_flow_t *f);
+
+#ifdef PCP_EXPERIMENTAL
+void pcp_db_add_md(pcp_flow_t *f, uint16_t md_id, void *val, size_t val_len);
+#endif
+
+int pcp_new_server(pcp_ctx_t *ctx, struct in6_addr *ip, uint16_t port, uint32_t scope_id);
+
+pcp_errno pcp_db_foreach_server(pcp_ctx_t *ctx, pcp_db_server_iterate f,
+        void *data);
+
+pcp_server_t *get_pcp_server(pcp_ctx_t *ctx, int pcp_server_index);
+
+pcp_server_t *get_pcp_server_by_ip(pcp_ctx_t *ctx, struct in6_addr *ip);
+
+void pcp_db_free_pcp_servers(pcp_ctx_t *ctx);
+
+pcp_errno pcp_delete_flow_intern(pcp_flow_t *f);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PCP_CLIENT_DB_H_ */

--- a/lib/libpcp/src/pcp_event_handler.c
+++ b/lib/libpcp/src/pcp_event_handler.c
@@ -1,0 +1,1363 @@
+/*
+ Copyright (c) 2014 by Cisco Systems, Inc.
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following disclaimer in the documentation
+ and/or other materials provided with the distribution.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#else
+#include "default_config.h"
+#endif
+
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+#include <errno.h>
+#include <time.h>
+#include <assert.h>
+
+#ifdef WIN32
+#include "pcp_win_defines.h"
+#include "pcp_gettimeofday.h"
+#else
+//#include <unistd.h>
+#include <sys/socket.h>
+#include <sys/select.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <sys/time.h>
+#endif
+
+#include "pcp.h"
+#include "pcp_utils.h"
+#include "pcp_msg.h"
+#include "pcp_msg_structs.h"
+#include "pcp_logger.h"
+#include "pcp_event_handler.h"
+#include "pcp_server_discovery.h"
+#include "pcp_socket.h"
+
+#define MIN(a, b) (a<b?a:b)
+#define MAX(a, b) (a>b?a:b)
+#define PCP_RT(rtprev) ((rtprev=rtprev<<1),(((8192+(1024-(rand()&2047))) \
+        * MIN (MAX(rtprev,PCP_RETX_IRT), PCP_RETX_MRT))>>13))
+
+static pcp_flow_event_e fhndl_send(pcp_flow_t *f, pcp_recv_msg_t *msg);
+static pcp_flow_event_e fhndl_resend(pcp_flow_t *f, pcp_recv_msg_t *msg);
+static pcp_flow_event_e fhndl_send_renew(pcp_flow_t *f, pcp_recv_msg_t *msg);
+static pcp_flow_event_e fhndl_shortlifeerror(pcp_flow_t *f, pcp_recv_msg_t *msg);
+static pcp_flow_event_e fhndl_received_success(pcp_flow_t *f, pcp_recv_msg_t *msg);
+static pcp_flow_event_e fhndl_clear_timeouts(pcp_flow_t *f, pcp_recv_msg_t *msg);
+static pcp_flow_event_e fhndl_waitresp(pcp_flow_t *f, pcp_recv_msg_t *msg);
+
+static pcp_server_state_e handle_wait_io_receive_msg(pcp_server_t *s);
+static pcp_server_state_e handle_server_ping(pcp_server_t *s);
+static pcp_server_state_e handle_wait_ping_resp_timeout(pcp_server_t *s);
+static pcp_server_state_e handle_wait_ping_resp_recv(pcp_server_t *s);
+static pcp_server_state_e handle_version_negotiation(pcp_server_t *s);
+static pcp_server_state_e handle_send_all_msgs(pcp_server_t *s);
+static pcp_server_state_e handle_server_restart(pcp_server_t *s);
+static pcp_server_state_e handle_wait_io_timeout(pcp_server_t *s);
+static pcp_server_state_e handle_server_set_not_working(pcp_server_t *s);
+static pcp_server_state_e handle_server_not_working(pcp_server_t *s);
+static pcp_server_state_e handle_server_reping(pcp_server_t *s);
+static pcp_server_state_e pcp_terminate_server(pcp_server_t *s);
+static pcp_server_state_e log_unexepected_state_event(pcp_server_t *s);
+static pcp_server_state_e ignore_events(pcp_server_t *s);
+
+#if PCP_MAX_LOG_LEVEL>=PCP_LOGLVL_DEBUG
+
+//LCOV_EXCL_START
+static const char *dbg_get_func_name(void *f)
+{
+    if (f == fhndl_send) {
+        return "fhndl_send";
+    } else if (f == fhndl_send_renew) {
+        return "fhndl_send_renew";
+    } else if (f == fhndl_resend) {
+        return "fhndl_resend";
+    } else if (f == fhndl_shortlifeerror) {
+        return "fhndl_shortlifeerror";
+    } else if (f == fhndl_received_success) {
+        return "fhndl_received_success";
+    } else if (f == fhndl_clear_timeouts) {
+        return "fhndl_clear_timeouts";
+    } else if (f == fhndl_waitresp) {
+        return "fhndl_waitresp";
+    } else if (f == handle_wait_io_receive_msg) {
+        return "handle_wait_io_receive_msg";
+    } else if (f == handle_server_ping) {
+        return "handle_server_ping";
+    } else if (f == handle_wait_ping_resp_timeout) {
+        return "handle_wait_ping_resp_timeout";
+    } else if (f == handle_wait_ping_resp_recv) {
+        return "handle_wait_ping_resp_recv";
+    } else if (f == handle_version_negotiation) {
+        return "handle_version_negotiation";
+    } else if (f == handle_send_all_msgs) {
+        return "handle_send_all_msgs";
+    } else if (f == handle_server_restart) {
+        return "handle_server_restart";
+    } else if (f == handle_wait_io_timeout) {
+        return "handle_wait_io_timeout";
+    } else if (f == handle_server_set_not_working) {
+        return "handle_server_set_not_working";
+    } else if (f == handle_server_not_working) {
+        return "handle_server_not_working";
+    } else if (f == handle_server_reping) {
+        return "handle_server_reping";
+    } else if (f == pcp_terminate_server) {
+        return "pcp_terminate_server";
+    } else if (f == log_unexepected_state_event) {
+        return "log_unexepected_state_event";
+    } else if (f == ignore_events) {
+        return "ignore_events";
+    } else {
+        return "unknown";
+    }
+}
+
+static const char *dbg_get_event_name(pcp_flow_event_e ev)
+{
+    static const char *event_names[]={
+            "fev_flow_timedout",
+            "fev_server_initialized",
+            "fev_send",
+            "fev_msg_sent",
+            "fev_failed",
+            "fev_none",
+            "fev_server_restarted",
+            "fev_ignored",
+            "fev_res_success",
+            "fev_res_unsupp_version",
+            "fev_res_not_authorized",
+            "fev_res_malformed_request",
+            "fev_res_unsupp_opcode",
+            "fev_res_unsupp_option",
+            "fev_res_malformed_option",
+            "fev_res_network_failure",
+            "fev_res_no_resources",
+            "fev_res_unsupp_protocol",
+            "fev_res_user_ex_quota",
+            "fev_res_cant_provide_ext",
+            "fev_res_address_mismatch",
+            "fev_res_exc_remote_peers",
+    };
+
+    assert(((int)ev < sizeof(event_names) / sizeof(event_names[0])));
+
+    return (int)ev >= 0 ? event_names[ev] : "";
+}
+
+static const char *dbg_get_state_name(pcp_flow_state_e s)
+{
+    static const char *state_names[]={
+            "pfs_idle",
+            "pfs_wait_for_server_init",
+            "pfs_send",
+            "pfs_wait_resp",
+            "pfs_wait_after_short_life_error",
+            "pfs_wait_for_lifetime_renew",
+            "pfs_send_renew",
+            "pfs_failed"
+    };
+
+    assert((int)s < (int)(sizeof(state_names) / sizeof(state_names[0])));
+
+    return s >= 0 ? state_names[s] : "";
+}
+
+static const char *dbg_get_sevent_name(pcp_event_e ev)
+{
+    static const char *sevent_names[]={
+            "pcpe_any",
+            "pcpe_timeout",
+            "pcpe_io_event",
+            "pcpe_terminate"
+    };
+
+    assert((int) ev < sizeof(sevent_names) / sizeof(sevent_names[0]));
+
+    return sevent_names[ev];
+}
+
+static const char *dbg_get_sstate_name(pcp_server_state_e s)
+{
+    static const char *server_state_names[]={
+            "pss_unitialized",
+            "pss_allocated",
+            "pss_ping",
+            "pss_wait_ping_resp",
+            "pss_version_negotiation",
+            "pss_send_all_msgs",
+            "pss_wait_io",
+            "pss_wait_io_calc_nearest_timeout",
+            "pss_server_restart",
+            "pss_server_reping",
+            "pss_set_not_working",
+            "pss_not_working"
+    };
+
+    assert((int)s < (int)(sizeof(server_state_names) /
+        sizeof(server_state_names[0])));
+
+    return (s >=0 ) ? server_state_names[s] : "";
+}
+
+static const char *dbg_get_fstate_name(pcp_fstate_e s)
+{
+    static const char *flow_state_names[]={"pcp_state_processing",
+            "pcp_state_succeeded", "pcp_state_partial_result",
+            "pcp_state_short_lifetime_error", "pcp_state_failed"};
+
+    assert((int)s < (int)sizeof(flow_state_names) /
+        sizeof(flow_state_names[0]));
+
+    return flow_state_names[s];
+}
+//LCOV_EXCL_STOP
+#endif
+
+////////////////////////////////////////////////////////////////////////////////
+//                  Flow State Machine definition
+
+typedef pcp_flow_event_e (*handle_flow_state_event)(pcp_flow_t *f, pcp_recv_msg_t *msg);
+
+typedef struct pcp_flow_state_trans {
+    pcp_flow_state_e state_from;
+    pcp_flow_state_e state_to;
+    handle_flow_state_event handler;
+} pcp_flow_state_trans_t;
+
+pcp_flow_state_trans_t flow_transitions[]={
+        {pfs_any, pfs_wait_resp, fhndl_waitresp},
+        {pfs_wait_resp, pfs_send, fhndl_resend},
+        {pfs_any, pfs_send, fhndl_send},
+        {pfs_any, pfs_wait_after_short_life_error, fhndl_shortlifeerror},
+        {pfs_wait_resp, pfs_wait_for_lifetime_renew, fhndl_received_success},
+        {pfs_any, pfs_send_renew, fhndl_send_renew},
+        {pfs_wait_for_lifetime_renew, pfs_wait_for_lifetime_renew, fhndl_received_success},
+        {pfs_any, pfs_wait_for_server_init, fhndl_clear_timeouts},
+        {pfs_any, pfs_failed, fhndl_clear_timeouts},
+};
+
+#define FLOW_TRANS_COUNT (sizeof(flow_transitions)/sizeof(*flow_transitions))
+
+typedef struct pcp_flow_state_event {
+    pcp_flow_state_e state;
+    pcp_flow_event_e event;
+    pcp_flow_state_e new_state;
+} pcp_flow_state_events_t;
+
+pcp_flow_state_events_t flow_events_sm[]={
+        {pfs_any, fev_send, pfs_send},
+        {pfs_wait_for_server_init, fev_server_initialized, pfs_send},
+        {pfs_wait_resp, fev_res_success, pfs_wait_for_lifetime_renew},
+        {pfs_wait_resp, fev_res_unsupp_version, pfs_wait_for_server_init},
+        {pfs_wait_resp, fev_res_network_failure, pfs_wait_after_short_life_error},
+        {pfs_wait_resp, fev_res_no_resources, pfs_wait_after_short_life_error},
+        {pfs_wait_resp, fev_res_exc_remote_peers, pfs_wait_after_short_life_error},
+        {pfs_wait_resp, fev_res_user_ex_quota, pfs_wait_after_short_life_error},
+        {pfs_wait_resp, fev_flow_timedout, pfs_send},
+        {pfs_wait_resp, fev_server_initialized, pfs_send},
+        {pfs_send, fev_server_initialized, pfs_send},
+        {pfs_send, fev_msg_sent, pfs_wait_resp},
+        {pfs_send, fev_flow_timedout, pfs_send},
+        {pfs_wait_after_short_life_error, fev_flow_timedout, pfs_send},
+        {pfs_wait_for_lifetime_renew, fev_flow_timedout, pfs_send_renew},
+        {pfs_wait_for_lifetime_renew, fev_res_success, pfs_wait_for_lifetime_renew},
+        {pfs_wait_for_lifetime_renew, fev_res_unsupp_version,pfs_wait_for_server_init},
+        {pfs_wait_for_lifetime_renew, fev_res_network_failure, pfs_send_renew},
+        {pfs_wait_for_lifetime_renew, fev_res_no_resources, pfs_send_renew},
+        {pfs_wait_for_lifetime_renew, fev_res_exc_remote_peers, pfs_send_renew},
+        {pfs_wait_for_lifetime_renew, fev_failed, pfs_send},
+        {pfs_wait_for_lifetime_renew, fev_res_user_ex_quota, pfs_send_renew},
+        {pfs_send_renew, fev_msg_sent, pfs_wait_for_lifetime_renew},
+        {pfs_send_renew, fev_flow_timedout, pfs_send_renew},
+        {pfs_send_renew, fev_failed, pfs_send},
+        {pfs_send, fev_ignored, pfs_wait_for_lifetime_renew},
+//        { pfs_failed, fev_server_restarted, pfs_send},
+        {pfs_any, fev_server_restarted, pfs_send},
+        {pfs_any, fev_failed, pfs_failed},
+///////////////////////////////////////////////////////////////////////////////
+//                  Long lifetime Error Responses from PCP server
+        {pfs_wait_resp, fev_res_not_authorized, pfs_failed},
+        {pfs_wait_resp, fev_res_malformed_request, pfs_failed},
+        {pfs_wait_resp, fev_res_unsupp_opcode, pfs_failed},
+        {pfs_wait_resp, fev_res_unsupp_option, pfs_failed},
+        {pfs_wait_resp, fev_res_unsupp_protocol, pfs_failed},
+        {pfs_wait_resp, fev_res_cant_provide_ext, pfs_failed},
+        {pfs_wait_resp, fev_res_address_mismatch, pfs_failed},
+        {pfs_wait_for_lifetime_renew, fev_res_not_authorized, pfs_failed},
+        {pfs_wait_for_lifetime_renew, fev_res_malformed_request, pfs_failed},
+        {pfs_wait_for_lifetime_renew, fev_res_unsupp_opcode, pfs_failed},
+        {pfs_wait_for_lifetime_renew, fev_res_unsupp_option, pfs_failed},
+        {pfs_wait_for_lifetime_renew, fev_res_unsupp_protocol, pfs_failed},
+        {pfs_wait_for_lifetime_renew, fev_res_cant_provide_ext, pfs_failed},
+        {pfs_wait_for_lifetime_renew, fev_res_address_mismatch, pfs_failed},
+};
+
+#define FLOW_EVENTS_SM_COUNT (sizeof(flow_events_sm)/sizeof(*flow_events_sm))
+
+static pcp_errno pcp_flow_send_msg(pcp_flow_t *flow, pcp_server_t *s)
+{
+    ssize_t ret;
+    size_t to_send_count;
+    pcp_ctx_t *ctx=s->ctx;
+
+    PCP_LOG_BEGIN(PCP_LOGLVL_DEBUG);
+
+    if ((!flow->pcp_msg_buffer) || (flow->pcp_msg_len == 0)) {
+        build_pcp_msg(flow);
+        if (flow->pcp_msg_buffer == NULL) {
+            PCP_LOG(PCP_LOGLVL_DEBUG, "Cannot build PCP MSG (flow bucket:%d)",
+                    flow->key_bucket);
+            PCP_LOG_END(PCP_LOGLVL_DEBUG);
+            return PCP_ERR_SEND_FAILED;
+        }
+    }
+
+    to_send_count=flow->pcp_msg_len;
+
+    while (to_send_count != 0) {
+        ret=flow->pcp_msg_len - to_send_count;
+
+        ret=pcp_socket_sendto(ctx, flow->pcp_msg_buffer + ret,
+                flow->pcp_msg_len - ret, MSG_DONTWAIT,
+                (struct sockaddr*)&s->pcp_server_saddr,
+                SA_LEN((struct sockaddr*)&s->pcp_server_saddr));
+        if (ret <= 0) {
+            PCP_LOG(PCP_LOGLVL_WARN, "Error occurred while sending "
+            "PCP packet to server %s", s->pcp_server_paddr);
+            PCP_LOG_END(PCP_LOGLVL_DEBUG);
+            return PCP_ERR_SEND_FAILED;
+        }
+        to_send_count-=ret;
+    }
+
+    PCP_LOG(PCP_LOGLVL_INFO, "Sent PCP MSG (flow bucket:%d)",
+            flow->key_bucket);
+
+    pcp_flow_clear_msg_buf(flow);
+
+    PCP_LOG_END(PCP_LOGLVL_DEBUG);
+    return PCP_ERR_SUCCESS;
+}
+
+static pcp_errno read_msg(pcp_ctx_t *ctx, pcp_recv_msg_t *msg)
+{
+    ssize_t ret;
+    socklen_t src_len=sizeof(msg->rcvd_from_addr);
+
+    memset(msg, 0, sizeof(*msg));
+
+    if ((ret=pcp_socket_recvfrom(ctx, msg->pcp_msg_buffer,
+            sizeof(msg->pcp_msg_buffer), MSG_DONTWAIT,
+            (struct sockaddr*)&msg->rcvd_from_addr, &src_len)) < 0) {
+        return ret;
+    }
+
+    msg->pcp_msg_len=ret;
+
+    return PCP_ERR_SUCCESS;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+//              Flow State Transitions Handlers
+
+static pcp_flow_event_e fhndl_send(pcp_flow_t *f, UNUSED pcp_recv_msg_t *msg)
+{
+    pcp_server_t*s=get_pcp_server(f->ctx, f->pcp_server_indx);
+    PCP_LOG_BEGIN(PCP_LOGLVL_DEBUG);
+
+    if (!s) {
+        PCP_LOG_END(PCP_LOGLVL_DEBUG);
+        return fev_failed;
+    }
+
+    if (s->restart_flow_msg == f) {
+        return fev_ignored;
+    }
+
+    if (pcp_flow_send_msg(f, s) != PCP_ERR_SUCCESS) {
+        PCP_LOG_END(PCP_LOGLVL_DEBUG);
+        return fev_failed;
+    }
+
+    f->resend_timeout=PCP_RETX_IRT;
+    //set timeout field
+    gettimeofday(&f->timeout, NULL);
+    f->timeout.tv_sec+=f->resend_timeout / 1000;
+    f->timeout.tv_usec+=(f->resend_timeout % 1000) * 1000;
+
+    PCP_LOG_END(PCP_LOGLVL_DEBUG);
+    return fev_msg_sent;
+}
+
+static pcp_flow_event_e fhndl_resend(pcp_flow_t *f, UNUSED pcp_recv_msg_t *msg)
+{
+    pcp_server_t *s=get_pcp_server(f->ctx, f->pcp_server_indx);
+    PCP_LOG_BEGIN(PCP_LOGLVL_DEBUG);
+
+    if (!s) {
+        PCP_LOG_END(PCP_LOGLVL_DEBUG);
+        return fev_failed;
+    }
+
+#if PCP_RETX_MRC>0
+    if (++f->retry_count >= PCP_RETX_MRC) {
+        return fev_failed;
+    }
+#endif
+
+    if (pcp_flow_send_msg(f, s) != PCP_ERR_SUCCESS) {
+        PCP_LOG_END(PCP_LOGLVL_DEBUG);
+        return fev_failed;
+    }
+
+    f->resend_timeout=PCP_RT(f->resend_timeout);
+
+#if (PCP_RETX_MRD>0)
+    {
+        int tdiff = (curtime - f->created_time)*1000;
+        if (tdiff > PCP_RETX_MRD) {
+            return fev_failed;
+        }
+        if (tdiff > f->resend_timeout) {
+            f->resend_timeout = tdiff;
+        }
+    }
+#endif
+
+    //set timeout field
+    gettimeofday(&f->timeout, NULL);
+    f->timeout.tv_sec+=f->resend_timeout / 1000;
+    f->timeout.tv_usec+=(f->resend_timeout % 1000) * 1000;
+
+    PCP_LOG_END(PCP_LOGLVL_DEBUG);
+    return fev_msg_sent;
+}
+
+static pcp_flow_event_e fhndl_shortlifeerror(pcp_flow_t *f, pcp_recv_msg_t *msg)
+{
+    PCP_LOG(PCP_LOGLVL_DEBUG,
+            "f->pcp_server_index=%d, f->state = %d, f->key_bucket=%d",
+            f->pcp_server_indx, f->state, f->key_bucket);
+
+    f->recv_result=msg->recv_result;
+
+    gettimeofday(&f->timeout, NULL);
+    f->timeout.tv_sec+=msg->recv_lifetime;
+
+    return fev_none;
+}
+
+static pcp_flow_event_e fhndl_received_success(pcp_flow_t *f,
+        pcp_recv_msg_t *msg)
+{
+    struct timeval ctv;
+
+    PCP_LOG_BEGIN(PCP_LOGLVL_DEBUG);
+    f->recv_lifetime=msg->received_time + msg->recv_lifetime;
+    if ((f->kd.operation == PCP_OPCODE_MAP)
+            || (f->kd.operation == PCP_OPCODE_PEER)) {
+        f->map_peer.ext_ip=msg->assigned_ext_ip;
+        f->map_peer.ext_port=msg->assigned_ext_port;
+#ifdef PCP_SADSCP
+    } else if (f->kd.operation == PCP_OPCODE_SADSCP) {
+        f->sadscp.learned_dscp = msg->recv_dscp;
+#endif
+    }
+    f->recv_result=msg->recv_result;
+
+    gettimeofday(&ctv, NULL);
+
+    if (msg->recv_lifetime == 0) {
+        f->timeout.tv_sec=0;
+        f->timeout.tv_usec=0;
+    } else {
+        f->timeout=ctv;
+        f->timeout.tv_sec+=(long int)((f->recv_lifetime - ctv.tv_sec) >> 1);
+    }
+
+    PCP_LOG_END(PCP_LOGLVL_DEBUG);
+    return fev_none;
+}
+
+static pcp_flow_event_e fhndl_send_renew(pcp_flow_t *f,
+        UNUSED pcp_recv_msg_t *msg)
+{
+    pcp_server_t *s=get_pcp_server(f->ctx, f->pcp_server_indx);
+    long timeout_add;
+
+    if (!s) {
+        return fev_failed;
+    }
+
+    if (pcp_flow_send_msg(f, s) != PCP_ERR_SUCCESS) {
+        return fev_failed;
+    }
+
+    gettimeofday(&f->timeout, NULL);
+    timeout_add=(long)((f->recv_lifetime - f->timeout.tv_sec) >> 1);
+
+    if (timeout_add == 0) {
+        return fev_failed;
+    } else {
+        f->timeout.tv_sec+=timeout_add;
+    }
+
+    return fev_msg_sent;
+}
+
+static pcp_flow_event_e fhndl_clear_timeouts(pcp_flow_t *f, pcp_recv_msg_t *msg)
+{
+    if (msg) {
+        f->recv_result=msg->recv_result;
+    }
+    pcp_flow_clear_msg_buf(f);
+    f->timeout.tv_sec=0;
+    f->timeout.tv_usec=0;
+
+    return fev_none;
+}
+
+static pcp_flow_event_e fhndl_waitresp(pcp_flow_t *f,
+        UNUSED pcp_recv_msg_t *msg)
+{
+    struct timeval ctv;
+
+    gettimeofday(&ctv, NULL);
+    if (timeval_comp(&f->timeout, &ctv) < 0) {
+        return fev_failed;
+    }
+
+    return fev_none;
+}
+
+static void flow_change_notify(pcp_flow_t *flow, pcp_fstate_e state);
+
+static pcp_flow_state_e handle_flow_event(pcp_flow_t *f, pcp_flow_event_e ev,
+        pcp_recv_msg_t *r)
+{
+    pcp_flow_state_e cur_state=f->state, next_state;
+    pcp_flow_state_events_t *esm;
+    pcp_flow_state_events_t *esm_end=flow_events_sm + FLOW_EVENTS_SM_COUNT;
+    pcp_flow_state_trans_t *trans;
+    pcp_flow_state_trans_t *trans_end=flow_transitions + FLOW_TRANS_COUNT;
+    pcp_fstate_e before, after;
+    struct in6_addr prev_ext_addr=f->map_peer.ext_ip;
+    uint16_t prev_ext_port=f->map_peer.ext_port;
+
+    PCP_LOG_BEGIN(PCP_LOGLVL_DEBUG);
+    pcp_eval_flow_state(f, &before);
+    for (;;) {
+        for (esm=flow_events_sm; esm < esm_end; ++esm) {
+            if (((esm->state == cur_state) || (esm->state == pfs_any))
+                    && (esm->event == ev)) {
+                break;
+            }
+        }
+
+        if (esm == esm_end) {
+            //TODO:log
+            goto end;
+        }
+
+        next_state=esm->new_state;
+
+        for (trans=flow_transitions; trans < trans_end; ++trans) {
+            if (((trans->state_from == cur_state)
+                    || (trans->state_from == pfs_any))
+                    && (trans->state_to == next_state)) {
+
+#if PCP_MAX_LOG_LEVEL>=PCP_LOGLVL_DEBUG
+                pcp_flow_event_e prev_ev=ev;
+#endif
+                f->state=next_state;
+
+                PCP_LOG_DEBUG(
+                        "Executing event handler %s\n    flow \t: %d (server %d)\n"
+                        "    states\t: %s => %s\n    event\t: %s",
+                        dbg_get_func_name(trans->handler), f->key_bucket, f->pcp_server_indx, dbg_get_state_name(cur_state), dbg_get_state_name(next_state), dbg_get_event_name(prev_ev));
+
+                ev=trans->handler(f, r);
+
+                PCP_LOG_DEBUG(
+                        "Return from event handler's %s \n    result event: %s",
+                        dbg_get_func_name(trans->handler), dbg_get_event_name(ev));
+
+                cur_state=next_state;
+
+                if (ev == fev_none) {
+                    goto end;
+                }
+                break;
+            }
+        }
+
+        //no transition handler
+        if (trans == trans_end) {
+            f->state=next_state;
+            goto end;
+        }
+    }
+end:
+    pcp_eval_flow_state(f, &after);
+    if ((before != after)
+            || (!IN6_ARE_ADDR_EQUAL(&prev_ext_addr, &f->map_peer.ext_ip))
+            || (prev_ext_port != f->map_peer.ext_port)) {
+        flow_change_notify(f, after);
+    }
+
+    PCP_LOG_END(PCP_LOGLVL_DEBUG);
+    return f->state;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+//            Helper functions for server state handlers
+
+static pcp_flow_t *server_process_rcvd_pcp_msg(pcp_server_t *s,
+        pcp_recv_msg_t *msg)
+{
+    pcp_flow_t *f;
+#ifndef PCP_DISABLE_NATPMP
+    if (msg->recv_version == 0) {
+        if (msg->kd.operation == NATPMP_OPCODE_ANNOUNCE) {
+            s->natpmp_ext_addr=S6_ADDR32(&msg->assigned_ext_ip)[3];
+            if ((s->pcp_version == 0) && (s->ping_flow_msg)
+                    && (s->ping_flow_msg->kd.operation == PCP_OPCODE_ANNOUNCE)) {
+                f=s->ping_flow_msg;
+            } else {
+                f=NULL;
+            }
+        } else {
+            S6_ADDR32(&msg->assigned_ext_ip)[3]=s->natpmp_ext_addr;
+            S6_ADDR32(&msg->assigned_ext_ip)[2]=htonl(0xFFFF);
+            S6_ADDR32(&msg->assigned_ext_ip)[1]=0;
+            S6_ADDR32(&msg->assigned_ext_ip)[0]=0;
+
+            f=pcp_get_flow(&msg->kd, s);
+        }
+    } else {
+        f=pcp_get_flow(&msg->kd, s);
+    }
+#else
+    f = pcp_get_flow(&msg->kd, s->index);
+#endif
+
+    if (!f) {
+        char in6[INET6_ADDRSTRLEN];
+
+        PCP_LOG(PCP_LOGLVL_INFO, "%s",
+                "Couldn't find matching flow to received PCP message.");
+        PCP_LOG(PCP_LOGLVL_PERR, "  Operation   : %u", msg->kd.operation);
+        if ((msg->kd.operation == PCP_OPCODE_MAP)
+                || (msg->kd.operation == PCP_OPCODE_PEER)) {
+            PCP_LOG(PCP_LOGLVL_PERR, "  Protocol    : %u",
+                    msg->kd.map_peer.protocol);
+            PCP_LOG(PCP_LOGLVL_PERR, "  Source      : %s:%hu",
+                    inet_ntop(s->af, &msg->kd.src_ip, in6, sizeof(in6)), ntohs(msg->kd.map_peer.src_port));
+            PCP_LOG(PCP_LOGLVL_PERR, "  Destination : %s:%hu",
+                    inet_ntop(s->af, &msg->kd.map_peer.dst_ip, in6, sizeof(in6)), ntohs(msg->kd.map_peer.dst_port));
+        } else {
+            //TODO: add print of SADSCP params
+        }
+        return NULL;
+    }
+
+    PCP_LOG(PCP_LOGLVL_INFO,
+            "Found matching flow %d to received PCP message.", f->key_bucket);
+
+    handle_flow_event(f, FEV_RES_BEGIN + msg->recv_result, msg);
+
+    return f;
+}
+
+static int check_flow_timeout(pcp_flow_t *f, void *timeout)
+{
+    struct timeval *tout=timeout;
+    struct timeval ctv;
+
+    if ((f->timeout.tv_sec == 0) && (f->timeout.tv_usec == 0)) {
+        return 0;
+    }
+
+    gettimeofday(&ctv, NULL);
+    if (timeval_comp(&f->timeout, &ctv) <= 0) {
+        // timed out
+        if (f->state == pfs_wait_resp) {
+            PCP_LOG(PCP_LOGLVL_WARN,
+                    "Recv of PCP response for flow %d timed out.",
+                    f->key_bucket);
+        }
+        handle_flow_event(f, fev_flow_timedout, NULL);
+    }
+
+    if ((f->timeout.tv_sec == 0) && (f->timeout.tv_usec == 0)) {
+        return 0;
+    }
+
+    timeval_subtract(&ctv, &f->timeout, &ctv);
+
+    if ((tout->tv_sec == 0) && (tout->tv_usec == 0)) {
+        *tout=ctv;
+        return 0;
+    }
+
+    if (timeval_comp(&ctv, tout) < 0) {
+        *tout=ctv;
+    }
+
+    return 0;
+}
+
+struct get_first_flow_iter_data {
+    pcp_server_t *s;
+    pcp_flow_t *msg;
+};
+
+static int get_first_flow_iter(pcp_flow_t *f, void *data)
+{
+    struct get_first_flow_iter_data *d=(struct get_first_flow_iter_data *)data;
+
+    if (f->pcp_server_indx == d->s->index) {
+        d->msg=f;
+        return 1;
+    } else {
+        return 0;
+    }
+}
+
+#ifndef PCP_DISABLE_NATPMP
+static inline pcp_flow_t *create_natpmp_ann_msg(pcp_server_t *s)
+{
+    struct flow_key_data kd;
+
+    memset(&kd, 0, sizeof(kd));
+    memcpy(&kd.src_ip, s->src_ip, sizeof(kd.src_ip));
+    memcpy(&kd.pcp_server_ip, s->pcp_ip, sizeof(kd.pcp_server_ip));
+    memcpy(&kd.nonce, &s->nonce, sizeof(kd.nonce));
+    kd.operation=NATPMP_OPCODE_ANNOUNCE;
+
+    s->ping_flow_msg=pcp_create_flow(s, &kd);
+    pcp_db_add_flow(s->ping_flow_msg);
+
+    return s->ping_flow_msg;
+}
+#endif
+
+static inline pcp_flow_t *get_ping_msg(pcp_server_t *s)
+{
+    struct get_first_flow_iter_data find_data;
+
+    PCP_LOG_BEGIN(PCP_LOGLVL_DEBUG);
+    if (!s)
+        return NULL;
+
+    find_data.s=s;
+    find_data.msg=NULL;
+
+    pcp_db_foreach_flow(s->ctx, get_first_flow_iter, &find_data);
+
+    s->ping_flow_msg=find_data.msg;
+
+    PCP_LOG_END(PCP_LOGLVL_DEBUG);
+    return find_data.msg;
+}
+
+struct flow_iterator_data {
+    pcp_server_t *s;
+    pcp_flow_event_e event;
+};
+
+static int flow_send_event_iter(pcp_flow_t *f, void *data)
+{
+    struct flow_iterator_data *d=(struct flow_iterator_data *)data;
+
+    if (f->pcp_server_indx == d->s->index) {
+        handle_flow_event(f, d->event, NULL);
+        check_flow_timeout(f, &d->s->next_timeout);
+    }
+
+    return 0;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+//                 Server state machine event handlers
+
+static pcp_server_state_e handle_server_ping(pcp_server_t *s)
+{
+    pcp_flow_t *msg;
+    PCP_LOG_BEGIN(PCP_LOGLVL_DEBUG);
+    s->ping_count=0;
+
+    msg=get_ping_msg(s);
+
+    if (!msg) {
+        s->next_timeout.tv_sec=0;
+        s->next_timeout.tv_usec=0;
+        return pss_ping;
+    }
+
+    msg->retry_count=0;
+
+    PCP_LOG(PCP_LOGLVL_INFO, "Pinging PCP server at address %s",
+            s->pcp_server_paddr);
+
+    if (handle_flow_event(msg, fev_send, NULL) != pfs_failed) {
+        s->next_timeout=msg->timeout;
+
+        PCP_LOG_END(PCP_LOGLVL_DEBUG);
+        return pss_wait_ping_resp;
+    }
+
+    gettimeofday(&s->next_timeout, NULL);
+    PCP_LOG_END(PCP_LOGLVL_DEBUG);
+    return pss_set_not_working;
+}
+
+static pcp_server_state_e handle_wait_ping_resp_timeout(pcp_server_t *s)
+{
+    if (++s->ping_count >= PCP_MAX_PING_COUNT) {
+        gettimeofday(&s->next_timeout, NULL);
+        return pss_set_not_working;
+    }
+
+    if (!s->ping_flow_msg) {
+        gettimeofday(&s->next_timeout, NULL);
+        return pss_ping;
+    }
+
+    if (handle_flow_event(s->ping_flow_msg, fev_flow_timedout, NULL)
+            == pfs_failed) {
+        gettimeofday(&s->next_timeout, NULL);
+        return pss_set_not_working;
+    }
+
+    if (s->ping_flow_msg) {
+        s->next_timeout=s->ping_flow_msg->timeout;
+    } else {
+        s->next_timeout.tv_sec=0;
+        s->next_timeout.tv_usec=0;
+        return pss_ping;
+    }
+    return pss_wait_ping_resp;
+}
+
+static pcp_server_state_e handle_wait_ping_resp_recv(pcp_server_t *s)
+{
+    pcp_server_state_e res=handle_wait_io_receive_msg(s);
+
+    switch (res) {
+        case pss_wait_io_calc_nearest_timeout:
+            res=pss_send_all_msgs;
+            break;
+        case pss_wait_io:
+            res=pss_wait_ping_resp;
+            break;
+        default:
+            break;
+    }
+    return res;
+}
+
+static pcp_server_state_e handle_version_negotiation(pcp_server_t *s)
+{
+    pcp_flow_t *ping_msg;
+
+    if (s->next_version == s->pcp_version) {
+        s->next_version--;
+    }
+
+    if (s->pcp_version == 0
+#if PCP_MIN_SUPPORTED_VERSION>0
+            || (s->next_version < PCP_MIN_SUPPORTED_VERSION)
+#endif
+            ) {
+        PCP_LOG(PCP_LOGLVL_WARN,
+                "Version negotiation failed for PCP server %s. "
+                "Disabling sending PCP messages to this server.",
+                s->pcp_server_paddr);
+
+        return pss_set_not_working;
+    }
+
+    PCP_LOG(PCP_LOGLVL_INFO,
+            "Version %d not supported by server %s. Trying version %d.",
+            s->pcp_version, s->pcp_server_paddr, s->next_version);
+    s->pcp_version=s->next_version;
+
+    ping_msg=s->ping_flow_msg;
+
+#ifndef PCP_DISABLE_NATPMP
+    if (s->pcp_version == 0) {
+        if (ping_msg) {
+            ping_msg->state=pfs_wait_for_server_init;
+            ping_msg->timeout.tv_sec=0;
+            ping_msg->timeout.tv_usec=0;
+        }
+        ping_msg=create_natpmp_ann_msg(s);
+    }
+#endif
+
+    if (!ping_msg) {
+        ping_msg=get_ping_msg(s);
+        if (!ping_msg) {
+            s->next_timeout.tv_sec=0;
+            s->next_timeout.tv_usec=0;
+            return pss_ping;
+        }
+    }
+
+    ping_msg->retry_count=0;
+    ping_msg->resend_timeout=0;
+
+    handle_flow_event(ping_msg, fev_send, NULL);
+    if (ping_msg->state == pfs_failed) {
+        return pss_set_not_working;
+    }
+
+    s->next_timeout=ping_msg->timeout;
+
+    return pss_wait_ping_resp;
+}
+
+static pcp_server_state_e handle_send_all_msgs(pcp_server_t *s)
+{
+    struct flow_iterator_data d={s, fev_server_initialized};
+
+    pcp_db_foreach_flow(s->ctx, flow_send_event_iter, &d);
+    gettimeofday(&s->next_timeout, NULL);
+
+    return pss_wait_io_calc_nearest_timeout;
+}
+
+static pcp_server_state_e handle_server_restart(pcp_server_t *s)
+{
+    struct flow_iterator_data d={s, fev_server_restarted};
+
+    pcp_db_foreach_flow(s->ctx, flow_send_event_iter, &d);
+    s->restart_flow_msg=NULL;
+    gettimeofday(&s->next_timeout, NULL);
+
+    return pss_wait_io_calc_nearest_timeout;
+}
+
+static pcp_server_state_e handle_wait_io_receive_msg(pcp_server_t *s)
+{
+    pcp_recv_msg_t *msg=&s->ctx->msg;
+    pcp_flow_t *f;
+
+    PCP_LOG(PCP_LOGLVL_INFO,
+            "Received PCP packet from server at %s, size %d, result_code %d, epoch %d",
+            s->pcp_server_paddr, msg->pcp_msg_len, msg->recv_result, msg->recv_epoch);
+
+    switch (msg->recv_result) {
+        case PCP_RES_UNSUPP_VERSION:
+            PCP_LOG(PCP_LOGLVL_DEBUG, "PCP server %s returned "
+            "result_code=Unsupported version", s->pcp_server_paddr);
+            gettimeofday(&s->next_timeout, NULL);
+            s->next_version=msg->recv_version;
+            return pss_version_negotiation;
+        case PCP_RES_ADDRESS_MISMATCH:
+            PCP_LOG(PCP_LOGLVL_WARN, "There is PCP-unaware NAT present "
+            "between client and PCP server %s. "
+            "Sending of PCP messages was disabled.", s->pcp_server_paddr);
+            gettimeofday(&s->next_timeout, NULL);
+            return pss_set_not_working;
+    }
+
+    f=server_process_rcvd_pcp_msg(s, msg);
+
+    if (compare_epochs(msg, s)) {
+        s->epoch=msg->recv_epoch;
+        s->cepoch=msg->received_time;
+        gettimeofday(&s->next_timeout, NULL);
+        s->restart_flow_msg=f;
+
+        return pss_server_restart;
+    }
+
+    gettimeofday(&s->next_timeout, NULL);
+
+    return pss_wait_io_calc_nearest_timeout;
+}
+
+static pcp_server_state_e handle_wait_io_timeout(pcp_server_t *s)
+{
+    struct timeval ctv;
+
+    s->next_timeout.tv_sec=0;
+    s->next_timeout.tv_usec=0;
+
+    pcp_db_foreach_flow(s->ctx, check_flow_timeout, &s->next_timeout);
+
+    if ((s->next_timeout.tv_sec != 0) || (s->next_timeout.tv_usec != 0)) {
+        gettimeofday(&ctv, NULL);
+        s->next_timeout.tv_sec+=ctv.tv_sec;
+        s->next_timeout.tv_usec+=ctv.tv_usec;
+        timeval_align(&s->next_timeout);
+    }
+
+    return pss_wait_io;
+}
+
+static pcp_server_state_e handle_server_set_not_working(pcp_server_t *s)
+{
+    struct flow_iterator_data d={s, fev_failed};
+
+    PCP_LOG(PCP_LOGLVL_DEBUG, "Entered function %s", __FUNCTION__);
+    PCP_LOG(PCP_LOGLVL_WARN, "PCP server %s failed to respond. "
+    "Disabling sending of PCP messages to this server for %d minutes.",
+            s->pcp_server_paddr, PCP_SERVER_DISCOVERY_RETRY_DELAY / 60);
+
+    pcp_db_foreach_flow(s->ctx, flow_send_event_iter, &d);
+
+    gettimeofday(&s->next_timeout, NULL);
+    s->next_timeout.tv_sec+=PCP_SERVER_DISCOVERY_RETRY_DELAY;
+
+    return pss_not_working;
+}
+
+static pcp_server_state_e handle_server_not_working(pcp_server_t *s)
+{
+    struct timeval ctv;
+
+    gettimeofday(&ctv, NULL);
+    if (timeval_comp(&ctv, &s->next_timeout) < 0) {
+        pcp_recv_msg_t *msg=&s->ctx->msg;
+        pcp_flow_t *f;
+
+        PCP_LOG(PCP_LOGLVL_INFO,
+                "Received PCP packet from server at %s, size %d, result_code %d, epoch %d",
+                s->pcp_server_paddr, msg->pcp_msg_len, msg->recv_result, msg->recv_epoch);
+
+        switch (msg->recv_result) {
+            case PCP_RES_UNSUPP_VERSION:
+                return pss_not_working;
+            case PCP_RES_ADDRESS_MISMATCH:
+                return pss_not_working;
+        }
+
+        f=server_process_rcvd_pcp_msg(s, msg);
+
+        s->epoch=msg->recv_epoch;
+        s->cepoch=msg->received_time;
+        gettimeofday(&s->next_timeout, NULL);
+        s->restart_flow_msg=f;
+
+        return pss_server_restart;
+    }
+
+    s->next_timeout=ctv;
+
+    return pss_server_reping;
+
+}
+
+static pcp_server_state_e handle_server_reping(pcp_server_t *s)
+{
+    PCP_LOG(PCP_LOGLVL_INFO, "Trying to ping PCP server %s again. ",
+            s->pcp_server_paddr);
+
+    s->pcp_version=PCP_MAX_SUPPORTED_VERSION;
+    gettimeofday(&s->next_timeout, NULL);
+
+    return pss_ping;
+}
+
+static pcp_server_state_e pcp_terminate_server(pcp_server_t *s)
+{
+    s->next_timeout.tv_sec=0;
+    s->next_timeout.tv_usec=0;
+
+    PCP_LOG(PCP_LOGLVL_INFO, "PCP server %s terminated. ",
+            s->pcp_server_paddr);
+
+    return pss_allocated;
+}
+
+static pcp_server_state_e ignore_events(pcp_server_t *s)
+{
+  s->next_timeout.tv_sec=0;
+  s->next_timeout.tv_usec=0;
+
+  return s->server_state;
+}
+
+//LCOV_EXCL_START
+static pcp_server_state_e log_unexepected_state_event(pcp_server_t *s)
+{
+    PCP_LOG(PCP_LOGLVL_PERR, "Event happened in the state %d on PCP server %s"
+            " and there is no event handler defined.",
+            s->server_state, s->pcp_server_paddr);
+
+    gettimeofday(&s->next_timeout, NULL);
+    return pss_set_not_working;
+}
+//LCOV_EXCL_STOP
+////////////////////////////////////////////////////////////////////////////////
+//                  Server State Machine definition
+
+typedef pcp_server_state_e (*handle_server_state_event)(pcp_server_t *s);
+
+typedef struct pcp_server_state_machine {
+    pcp_server_state_e state;
+    pcp_event_e event;
+    handle_server_state_event handler;
+} pcp_server_state_machine_t;
+
+pcp_server_state_machine_t server_sm[]={{pss_any, pcpe_terminate,
+        pcp_terminate_server},
+// -> allocated
+        {pss_ping, pcpe_any, handle_server_ping},
+        // -> wait_ping_resp | set_not_working
+        {pss_wait_ping_resp, pcpe_timeout, handle_wait_ping_resp_timeout},
+        // -> wait_ping_resp | set_not_working
+        {pss_wait_ping_resp, pcpe_io_event, handle_wait_ping_resp_recv},
+        // -> wait ping_resp | pss_send_waiting_msgs | set_not_working | version_neg
+        {pss_version_negotiation, pcpe_any, handle_version_negotiation},
+        // -> wait ping_resp | set_not_working
+        {pss_send_all_msgs, pcpe_any, handle_send_all_msgs},
+        // -> wait_io
+        {pss_wait_io, pcpe_io_event, handle_wait_io_receive_msg},
+        // -> wait_io_calc_nearest_timeout | server_restart |version_negotiation | set_not_working
+        {pss_wait_io, pcpe_timeout, handle_wait_io_timeout},
+        // -> wait_io | server_restart
+        {pss_wait_io_calc_nearest_timeout, pcpe_any, handle_wait_io_timeout},
+        // -> wait_io
+        {pss_server_restart, pcpe_any, handle_server_restart},
+        // -> wait_io
+        {pss_server_reping, pcpe_any, handle_server_reping},
+        // -> ping
+        {pss_set_not_working, pcpe_any, handle_server_set_not_working},
+        // -> not_working
+        {pss_not_working, pcpe_any, handle_server_not_working},
+        // -> reping
+        {pss_allocated, pcpe_any, ignore_events},
+        {pss_any, pcpe_any, log_unexepected_state_event}
+// -> last_state
+        };
+
+#define SERVER_STATE_MACHINE_COUNT (sizeof(server_sm)/sizeof(*server_sm))
+
+pcp_errno run_server_state_machine(pcp_server_t *s, pcp_event_e event)
+{
+    unsigned i;
+
+    PCP_LOG_BEGIN(PCP_LOGLVL_DEBUG);
+    if (!s) {
+        return PCP_ERR_BAD_ARGS;
+    }
+
+    for (i=0; i < SERVER_STATE_MACHINE_COUNT; ++i) {
+        pcp_server_state_machine_t *state_def=server_sm + i;
+        if ((state_def->state == s->server_state)
+                || (state_def->state == pss_any)) {
+            if ((state_def->event == pcpe_any) || (state_def->event == event)) {
+                PCP_LOG_DEBUG(
+                        "Executing server state handler %s\n    server \t: %s (index %d)\n"
+                        "    state\t: %s\n"
+                        "    event\t: %s",
+                        dbg_get_func_name(state_def->handler), s->pcp_server_paddr, s->index, dbg_get_sstate_name(s->server_state), dbg_get_sevent_name(event));
+
+                s->server_state=state_def->handler(s);
+
+                PCP_LOG_DEBUG(
+                        "Return from server state handler's %s \n    result state: %s",
+                        dbg_get_func_name(state_def->handler), dbg_get_sstate_name(s->server_state));
+
+                break;
+            }
+        }
+    }PCP_LOG_END(PCP_LOGLVL_DEBUG);
+    return PCP_ERR_SUCCESS;
+}
+
+struct hserver_iter_data {
+    struct timeval *res_timeout;
+    pcp_event_e ev;
+};
+
+static int hserver_iter(pcp_server_t *s, void *data)
+{
+    pcp_event_e ev=((struct hserver_iter_data*)data)->ev;
+    struct timeval *res_timeout=((struct hserver_iter_data*)data)->res_timeout;
+    struct timeval ctv;
+
+    PCP_LOG_BEGIN(PCP_LOGLVL_DEBUG);
+    if ((s == NULL) || (s->server_state == pss_unitialized) || (data == NULL)) {
+        PCP_LOG_END(PCP_LOGLVL_DEBUG);
+        return 0;
+    }
+
+    if (ev != pcpe_timeout)
+        run_server_state_machine(s, ev);
+
+    while (1) {
+        gettimeofday(&ctv, NULL);
+        if (((s->next_timeout.tv_sec == 0) && (s->next_timeout.tv_usec == 0))
+                || (!timeval_subtract(&ctv, &s->next_timeout, &ctv))) {
+            break;
+        }
+        run_server_state_machine(s, pcpe_timeout);
+    }
+
+    if ((!res_timeout)
+            || ((s->next_timeout.tv_sec == 0) && (s->next_timeout.tv_usec == 0))) {
+        PCP_LOG_END(PCP_LOGLVL_DEBUG);
+        return 0;
+    }
+
+    if ((res_timeout->tv_sec == 0) && (res_timeout->tv_usec == 0)) {
+
+        *res_timeout=ctv;
+
+    } else if (timeval_comp(&ctv, res_timeout) < 0) {
+
+        *res_timeout=ctv;
+    }
+
+    PCP_LOG_END(PCP_LOGLVL_DEBUG);
+    return 0;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+//                       Exported functions
+
+int pcp_pulse(pcp_ctx_t *ctx, struct timeval *next_timeout)
+{
+    pcp_recv_msg_t *msg;
+    struct timeval tmp_timeout={0, 0};
+
+    if (!ctx) {
+        return PCP_ERR_BAD_ARGS;
+    }
+
+    msg=&ctx->msg;
+
+    if (!next_timeout) {
+        next_timeout=&tmp_timeout;
+    }
+
+    memset(msg, 1, sizeof(*msg));
+
+    if (read_msg(ctx, msg) == PCP_ERR_SUCCESS) {
+        struct in6_addr ip6;
+        pcp_server_t *s;
+        struct hserver_iter_data param={NULL, pcpe_io_event};
+
+        msg->received_time=time(NULL);
+
+        if (!validate_pcp_msg(msg)) {
+            PCP_LOG(PCP_LOGLVL_PERR, "%s", "Invalid PCP msg");
+            goto process_timeouts;
+        }
+
+        if ((parse_response(msg)) != PCP_ERR_SUCCESS) {
+            PCP_LOG(PCP_LOGLVL_PERR, "%s", "Cannot parse PCP msg");
+            goto process_timeouts;
+        }
+
+        pcp_fill_in6_addr(&ip6, NULL, (struct sockaddr*)&msg->rcvd_from_addr);
+        s=get_pcp_server_by_ip(ctx, &ip6);
+
+        if (s) {
+          msg->pcp_server_indx=s->index;
+          memcpy(&msg->kd.src_ip, s->src_ip, sizeof(struct in6_addr));
+          memcpy(&msg->kd.pcp_server_ip, s->pcp_ip, sizeof(struct in6_addr));
+          if (msg->recv_version < 2) {
+            memcpy(&msg->kd.nonce, &s->nonce, sizeof(struct pcp_nonce));
+          }
+
+          // process pcpe_io_event for server
+          hserver_iter(s, &param);
+        }
+    }
+
+process_timeouts:
+    {
+        struct hserver_iter_data param={next_timeout, pcpe_timeout};
+        pcp_db_foreach_server(ctx, hserver_iter, &param);
+    }
+
+    PCP_LOG_END(PCP_LOGLVL_DEBUG);
+    return (next_timeout->tv_sec * 1000) + (next_timeout->tv_usec / 1000);
+}
+
+void pcp_flow_updated(pcp_flow_t *f)
+{
+    struct timeval curtime;
+    pcp_server_t*s;
+
+    if (!f)
+        return;
+
+    gettimeofday(&curtime, NULL);
+    s=get_pcp_server(f->ctx, f->pcp_server_indx);
+    if (s) {
+        s->next_timeout=curtime;
+    }
+    pcp_flow_clear_msg_buf(f);
+    f->timeout=curtime;
+    if ((f->state != pfs_wait_for_server_init) && (f->state != pfs_idle)
+            && (f->state != pfs_failed)) {
+        f->state=pfs_send;
+    }
+}
+
+void pcp_set_flow_change_cb(pcp_ctx_t *ctx, pcp_flow_change_notify cb_fun,
+        void *cb_arg)
+{
+    if (ctx) {
+        ctx->flow_change_cb_fun=cb_fun;
+        ctx->flow_change_cb_arg=cb_arg;
+    }
+}
+
+static void flow_change_notify(pcp_flow_t *flow, pcp_fstate_e state)
+{
+    struct sockaddr_storage src_addr, ext_addr;
+    pcp_ctx_t *ctx=flow->ctx;
+
+    PCP_LOG_DEBUG( "Flow's %d state changed to: %s",
+            flow->key_bucket, dbg_get_fstate_name(state));
+
+    if (ctx->flow_change_cb_fun) {
+        pcp_fill_sockaddr((struct sockaddr*)&src_addr, &flow->kd.src_ip,
+                flow->kd.map_peer.src_port, 0, 0/* scope_id */);
+        if (state == pcp_state_succeeded) {
+            pcp_fill_sockaddr((struct sockaddr*)&ext_addr,
+                    &flow->map_peer.ext_ip, flow->map_peer.ext_port, 0,
+                    0/* scope_id */);
+        } else {
+            memset(&ext_addr, 0, sizeof(ext_addr));
+            ext_addr.ss_family=AF_INET;
+        }
+        ctx->flow_change_cb_fun(flow, (struct sockaddr*)&src_addr,
+                (struct sockaddr*)&ext_addr, state, ctx->flow_change_cb_arg);
+    }
+}

--- a/lib/libpcp/src/pcp_event_handler.h
+++ b/lib/libpcp/src/pcp_event_handler.h
@@ -1,0 +1,98 @@
+/*
+ Copyright (c) 2014 by Cisco Systems, Inc.
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following disclaimer in the documentation
+ and/or other materials provided with the distribution.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef PCP_EVENT_HANDLER_H_
+#define PCP_EVENT_HANDLER_H_
+
+#include "pcp_msg_structs.h"
+
+typedef enum {
+    pfs_any                         = -1,
+    pfs_idle                        = 0,
+    pfs_wait_for_server_init        = 1,
+    pfs_send                        = 2,
+    pfs_wait_resp                   = 3,
+    pfs_wait_after_short_life_error = 4,
+    pfs_wait_for_lifetime_renew     = 5,
+    pfs_send_renew                  = 6,
+    pfs_failed                      = 7
+} pcp_flow_state_e;
+
+typedef enum {
+    pcpe_any, pcpe_timeout, pcpe_io_event, pcpe_terminate
+} pcp_event_e;
+
+typedef enum {
+    fev_flow_timedout,
+    fev_server_initialized,
+    fev_send,
+    fev_msg_sent,
+    fev_failed,
+    fev_none,
+    fev_server_restarted,
+    fev_ignored,
+    FEV_RES_BEGIN,
+    fev_res_success           = FEV_RES_BEGIN + PCP_RES_SUCCESS,
+    fev_res_unsupp_version    = FEV_RES_BEGIN + PCP_RES_UNSUPP_VERSION,
+    fev_res_not_authorized    = FEV_RES_BEGIN + PCP_RES_NOT_AUTHORIZED,
+    fev_res_malformed_request = FEV_RES_BEGIN + PCP_RES_MALFORMED_REQUEST,
+    fev_res_unsupp_opcode     = FEV_RES_BEGIN + PCP_RES_UNSUPP_OPCODE,
+    fev_res_unsupp_option     = FEV_RES_BEGIN + PCP_RES_UNSUPP_OPTION,
+    fev_res_malformed_option  = FEV_RES_BEGIN + PCP_RES_MALFORMED_OPTION,
+    fev_res_network_failure   = FEV_RES_BEGIN + PCP_RES_NETWORK_FAILURE,
+    fev_res_no_resources      = FEV_RES_BEGIN + PCP_RES_NO_RESOURCES,
+    fev_res_unsupp_protocol   = FEV_RES_BEGIN + PCP_RES_UNSUPP_PROTOCOL,
+    fev_res_user_ex_quota     = FEV_RES_BEGIN + PCP_RES_USER_EX_QUOTA,
+    fev_res_cant_provide_ext  = FEV_RES_BEGIN + PCP_RES_CANNOT_PROVIDE_EXTERNAL,
+    fev_res_address_mismatch  = FEV_RES_BEGIN + PCP_RES_ADDRESS_MISMATCH,
+    fev_res_exc_remote_peers  = FEV_RES_BEGIN + PCP_RES_EXCESSIVE_REMOTE_PEERS,
+} pcp_flow_event_e;
+
+typedef enum {
+    pss_any=-1,
+    pss_unitialized,
+    pss_allocated,
+    pss_ping,
+    pss_wait_ping_resp,
+    pss_version_negotiation,
+    pss_send_all_msgs,
+    pss_wait_io,
+    pss_wait_io_calc_nearest_timeout,
+    pss_server_restart,
+    pss_server_reping,
+    pss_set_not_working,
+    pss_not_working,
+    PSS_COUNT
+} pcp_server_state_e;
+
+void pcp_flow_updated(pcp_flow_t *f);
+
+typedef struct pcp_server pcp_server_t;
+
+pcp_errno run_server_state_machine(pcp_server_t *s, pcp_event_e event);
+
+void pcp_fd_change_notify(pcp_server_t *s, int added);
+
+#endif /* PCP_EVENT_HANDLER_H_ */

--- a/lib/libpcp/src/pcp_logger.c
+++ b/lib/libpcp/src/pcp_logger.c
@@ -1,0 +1,176 @@
+/*
+ Copyright (c) 2014 by Cisco Systems, Inc.
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following disclaimer in the documentation
+ and/or other materials provided with the distribution.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#else
+#include "default_config.h"
+#endif
+
+#ifdef _MSC_VER
+#define _CRT_SECURE_NO_WARNINGS 1
+#endif
+
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include "pcp.h"
+#include "pcp_logger.h"
+#ifdef _MSC_VER
+#include "pcp_gettimeofday.h" //gettimeofday()
+#else
+#include "sys/time.h"
+#endif //_MSC_VER
+pcp_loglvl_e pcp_log_level=PCP_MAX_LOG_LEVEL;
+
+void pcp_logger_init(void)
+{
+    char *env, *ret;
+
+    if ((env=getenv("PCP_LOG_LEVEL"))) {
+        long lvl=strtol(env, &ret, 0);
+        if ((ret) && (!*ret) && (lvl>=0) && (lvl<=PCP_MAX_LOG_LEVEL)) {
+            pcp_log_level=lvl;
+        }
+    }
+}
+
+static void default_logfn(pcp_loglvl_e mode, const char *msg)
+{
+
+    const char *prefix;
+    static struct timeval prev_timestamp={0, 0};
+    struct timeval cur_timestamp;
+    uint64_t diff;
+
+    gettimeofday(&cur_timestamp, NULL);
+
+    if ((prev_timestamp.tv_sec == 0) && (prev_timestamp.tv_usec == 0)) {
+        prev_timestamp=cur_timestamp;
+        diff=0;
+    } else {
+        diff=(cur_timestamp.tv_sec - prev_timestamp.tv_sec) * 1000000
+                + (cur_timestamp.tv_usec - prev_timestamp.tv_usec);
+    }
+
+    switch (mode) {
+        case PCP_LOGLVL_ERR:
+        case PCP_LOGLVL_PERR:
+            prefix="ERROR";
+            break;
+        case PCP_LOGLVL_WARN:
+            prefix="WARNING";
+            break;
+        case PCP_LOGLVL_INFO:
+            prefix="INFO";
+            break;
+        case PCP_LOGLVL_DEBUG:
+            prefix="DEBUG";
+            break;
+        default:
+            prefix="UNKNOWN";
+            break;
+    }
+
+    fprintf(stderr, "%3llus %03llums %03lluus %-7s: %s\n",
+            (long long int)diff / 1000000,
+            (long long int)(diff % 1000000) / 1000, (long long int)diff % 1000,
+            prefix, msg);
+}
+
+external_logger logger=default_logfn;
+
+void pcp_set_loggerfn(external_logger ext_log)
+{
+    logger=ext_log;
+}
+
+void pcp_logger(pcp_loglvl_e log_level, const char *fmt, ...)
+{
+    int n;
+    int size=256; /* Guess we need no more than 256 bytes. */
+    char *p, *np;
+    va_list ap;
+
+    if (log_level > pcp_log_level) {
+        return;
+    }
+
+    if (!(p=(char*)malloc(size))) {
+        return; //LCOV_EXCL_LINE
+    }
+
+    while (1) {
+
+        /* Try to print in the allocated space. */
+
+        va_start(ap, fmt);
+        n=vsnprintf(p, size, fmt, ap);
+        va_end(ap);
+
+        /* If that worked, return the string. */
+
+        if (n > -1 && n < size) {
+            break;
+        }
+
+        /* Else try again with more space. */
+
+        if (n > -1) /* glibc 2.1 */
+            size=n + 1; /* precisely what is needed */
+        else
+            /* glibc 2.0 */
+            size*=2; /* twice the old size */ //LCOV_EXCL_LINE
+
+        if (!(np=(char*)realloc(p, size))) {
+            free(p); //LCOV_EXCL_LINE
+            return; //LCOV_EXCL_LINE
+        }
+        p=np;
+    }
+
+    if (logger)
+        (*logger)(log_level, p);
+
+    free(p);
+    return;
+}
+
+void pcp_strerror(int errnum, char *buf, size_t buflen)
+{
+
+    memset(buf, 0, buflen);
+
+#ifdef WIN32
+
+    strerror_s(buf, buflen, errnum);
+
+#else //WIN32
+    strerror_r(errnum, buf, buflen);
+#endif //WIN32
+}
+

--- a/lib/libpcp/src/pcp_logger.h
+++ b/lib/libpcp/src/pcp_logger.h
@@ -1,0 +1,108 @@
+/*
+ Copyright (c) 2014 by Cisco Systems, Inc.
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following disclaimer in the documentation
+ and/or other materials provided with the distribution.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef PCP_LOGGER_H_
+#define PCP_LOGGER_H_
+
+#define ERR_BUF_LEN 256
+
+#include "pcp.h"
+
+#ifdef NDEBUG
+#undef DEBUG
+#endif
+
+void pcp_logger_init(void);
+
+#ifdef WIN32
+void pcp_logger(pcp_loglvl_e log_level, const char* fmt, ...);
+#else
+void pcp_logger(pcp_loglvl_e log_level, const char* fmt, ...)
+        __attribute__((format(printf, 2, 3)));
+#endif
+
+#ifdef DEBUG
+
+#ifndef PCP_MAX_LOG_LEVEL
+// Maximal log level for compile-time check
+#define PCP_MAX_LOG_LEVEL PCP_LOGLVL_DEBUG
+#endif
+
+#define PCP_LOG(level, fmt, ...) { if (level<=PCP_MAX_LOG_LEVEL) \
+pcp_logger(level, "FILE: %s:%d; Func: %s:\n     " fmt,\
+__FILE__, __LINE__, __FUNCTION__, __VA_ARGS__); }
+
+#define PCP_LOG_END(level) { if (level<=PCP_MAX_LOG_LEVEL) \
+pcp_logger(level, "FILE: %s:%d; Func: %s: END \n     " ,\
+__FILE__, __LINE__, __FUNCTION__); }
+
+#define PCP_LOG_BEGIN(level) { if (level<=PCP_MAX_LOG_LEVEL) \
+pcp_logger(level, "FILE: %s:%d; Func: %s: BEGIN \n     ",\
+__FILE__, __LINE__, __FUNCTION__); }
+
+#else //DEBUG
+#ifndef PCP_MAX_LOG_LEVEL
+// Maximal log level for compile-time check
+#define PCP_MAX_LOG_LEVEL PCP_LOGLVL_INFO
+#endif
+
+#define PCP_LOG(level, fmt, ...) { \
+if (level<=PCP_MAX_LOG_LEVEL) pcp_logger(level, fmt, __VA_ARGS__); }
+
+#define PCP_LOG_END(level)
+
+#define PCP_LOG_BEGIN(level)
+
+#endif // DEBUG
+#if PCP_MAX_LOG_LEVEL>=PCP_LOGLVL_DEBUG
+#define PCP_LOG_DEBUG(fmt, ...) PCP_LOG(PCP_LOGLVL_DEBUG, fmt, __VA_ARGS__)
+#else
+#define PCP_LOG_DEBUG(fmt, ...)
+#endif
+
+#if PCP_MAX_LOG_LEVEL>=PCP_LOGLVL_INFO
+#define PCP_LOG_FLOW(f, msg) \
+do { \
+    if (pcp_log_level >= PCP_LOGLVL_INFO) { \
+        char src_buf[INET6_ADDRSTRLEN]="Unknown"; \
+        char dst_buf[INET6_ADDRSTRLEN]="Unknown"; \
+        char pcp_buf[INET6_ADDRSTRLEN]="Unknown"; \
+\
+        inet_ntop(AF_INET6, &f->kd.src_ip, src_buf, sizeof(src_buf)); \
+        inet_ntop(AF_INET6, &f->kd.map_peer.dst_ip, dst_buf, \
+                sizeof(dst_buf)); \
+        inet_ntop(AF_INET6, &f->kd.pcp_server_ip, pcp_buf, sizeof(pcp_buf)); \
+        PCP_LOG(PCP_LOGLVL_INFO, \
+                "%s(PCP server: %s; Int. addr: [%s]:%d; Dest. addr: [%s]:%d; Key bucket: %d)", \
+                msg, pcp_buf, src_buf, ntohs(f->kd.map_peer.src_port), dst_buf, ntohs(f->kd.map_peer.dst_port), f->key_bucket); \
+    } \
+} while(0)
+#else
+#define PCP_LOG_FLOW(f, msg) do{} while(0)
+#endif
+
+void pcp_strerror(int errnum, char *buf, size_t buflen);
+
+#endif /* PCP_LOGGER_H_ */

--- a/lib/libpcp/src/pcp_msg.c
+++ b/lib/libpcp/src/pcp_msg.c
@@ -1,0 +1,714 @@
+/*
+ Copyright (c) 2014 by Cisco Systems, Inc.
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following disclaimer in the documentation
+ and/or other materials provided with the distribution.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#else
+#include "default_config.h"
+#endif
+
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+#include <errno.h>
+#include <time.h>
+#ifdef WIN32
+#include "pcp_win_defines.h"
+#else
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#endif //WIN32
+#include "pcp.h"
+#include "pcp_utils.h"
+#include "pcp_msg.h"
+#include "pcp_msg_structs.h"
+#include "pcp_logger.h"
+
+static void *add_filter_option(pcp_flow_t *f, void *cur)
+{
+    pcp_filter_option_t *filter_op=(pcp_filter_option_t *)cur;
+
+    filter_op->option=PCP_OPTION_FILTER;
+    filter_op->reserved=0;
+    filter_op->len=htons(sizeof(pcp_filter_option_t) - sizeof(pcp_options_hdr_t));
+    filter_op->reserved2=0;
+    filter_op->filter_prefix=f->filter_prefix;
+    filter_op->filter_peer_port=f->filter_port;
+    memcpy(&filter_op->filter_peer_ip, &f->filter_ip,
+            sizeof(filter_op->filter_peer_ip));
+    cur=filter_op->next_data;
+
+    return cur;
+}
+
+static void *add_prefer_failure_option(void *cur)
+{
+    pcp_prefer_fail_option_t *pfailure_op=(pcp_prefer_fail_option_t *)cur;
+
+    pfailure_op->option=PCP_OPTION_PREF_FAIL;
+    pfailure_op->reserved=0;
+    pfailure_op->len=htons(sizeof(pcp_prefer_fail_option_t) - sizeof(pcp_options_hdr_t));
+    cur=pfailure_op->next_data;
+
+    return cur;
+}
+
+static void *add_third_party_option(pcp_flow_t *f, void *cur)
+{
+    pcp_3rd_party_option_t *tp_op=(pcp_3rd_party_option_t *)cur;
+
+    tp_op->option=PCP_OPTION_3RD_PARTY;
+    tp_op->reserved=0;
+    memcpy(tp_op->ip, &f->third_party_ip, sizeof(f->third_party_ip));
+    tp_op->len=htons(sizeof(*tp_op) - sizeof(pcp_options_hdr_t));
+    cur=tp_op->next_data;
+
+    return cur;
+}
+
+#ifdef PCP_EXPERIMENTAL
+static void *add_userid_option(pcp_flow_t *f, void *cur)
+{
+    pcp_userid_option_t *userid_op = (pcp_userid_option_t *) cur;
+
+    userid_op->option=PCP_OPTION_USERID;
+    userid_op->len=htons(sizeof(pcp_userid_option_t) - sizeof(pcp_options_hdr_t));
+    memcpy(&(userid_op->userid[0]), &(f->f_userid.userid[0]), MAX_USER_ID);
+    cur=userid_op + 1;
+
+    return cur;
+}
+
+static void *add_location_option(pcp_flow_t *f, void *cur)
+{
+    pcp_location_option_t *location_op = (pcp_location_option_t *) cur;
+
+    location_op->option=PCP_OPTION_LOCATION;
+    location_op->len=htons(sizeof(pcp_location_option_t) - sizeof(pcp_options_hdr_t));
+    memcpy(&(location_op->location[0]), &(f->f_location.location[0]), MAX_GEO_STR);
+    cur=location_op + 1;
+
+    return cur;
+}
+
+static void *add_deviceid_option(pcp_flow_t *f, void *cur)
+{
+    pcp_deviceid_option_t *deviceid_op = (pcp_deviceid_option_t *) cur;
+
+    deviceid_op->option=PCP_OPTION_DEVICEID;
+    PCP_LOG_BEGIN(PCP_LOGLVL_DEBUG);
+    deviceid_op->len=htons(sizeof(pcp_deviceid_option_t) - sizeof(pcp_options_hdr_t));
+    memcpy(&(deviceid_op->deviceid[0]), &(f->f_deviceid.deviceid[0]), MAX_DEVICE_ID);
+    cur=deviceid_op + 1;
+
+    PCP_LOG_END(PCP_LOGLVL_DEBUG);
+    return cur;
+}
+#endif
+
+#ifdef PCP_FLOW_PRIORITY
+static void *add_flowp_option(pcp_flow_t *f, void *cur)
+{
+    pcp_flow_priority_option_t *flowp_op = (pcp_flow_priority_option_t *)cur;
+
+    flowp_op->option=PCP_OPTION_FLOW_PRIORITY;
+    flowp_op->len=htons(sizeof(pcp_flow_priority_option_t) - sizeof(pcp_options_hdr_t));
+    flowp_op->dscp_up=f->flowp_dscp_up;
+    flowp_op->dscp_down=f->flowp_dscp_down;
+    cur=flowp_op->next_data;
+
+    return cur;
+}
+#endif
+
+#ifdef PCP_EXPERIMENTAL
+static inline pcp_metadata_option_t *add_md_option(pcp_flow_t *f,
+        pcp_metadata_option_t *md_opt, md_val_t *md)
+{
+    size_t len_md=md->val_len;
+    uint32_t padding=(4 - (len_md % 4)) % 4;
+    size_t pcp_msg_len=((const char*)md_opt) - f->pcp_msg_buffer;
+
+    if ( (pcp_msg_len + (sizeof(pcp_metadata_option_t) + len_md + padding)) >
+            PCP_MAX_LEN) {
+        return md_opt;
+    }
+
+    md_opt->option=PCP_OPTION_METADATA;
+    md_opt->metadata_id=htonl(md->md_id);
+    memcpy(md_opt->metadata, md->val_buf, len_md);
+    md_opt->len=htons(sizeof(*md_opt) - sizeof(pcp_options_hdr_t) + len_md + padding);
+
+    return (pcp_metadata_option_t *)(((uint8_t *)(md_opt+1)) + len_md + padding);
+}
+
+static void *add_md_options(pcp_flow_t *f, void *cur)
+{
+    uint32_t i;
+    md_val_t *md;
+    pcp_metadata_option_t *md_opt=(pcp_metadata_option_t *)cur;
+
+    for (i=f->md_val_count, md=f->md_vals; i>0 && md!=NULL; --i, ++md)
+    {
+        if (md->val_len) {
+            md_opt = add_md_option(f, md_opt, md);
+        }
+    }
+    return md_opt;
+}
+#endif
+
+static pcp_errno build_pcp_options(pcp_flow_t *flow, void *cur)
+{
+#ifdef PCP_FLOW_PRIORITY
+    if (flow->flowp_option_present) {
+        cur=add_flowp_option(flow, cur);
+    }
+#endif
+    if (flow->filter_option_present) {
+        cur=add_filter_option(flow, cur);
+    }
+
+    if (flow->pfailure_option_present) {
+        cur=add_prefer_failure_option(cur);
+    }
+    if (flow->third_party_option_present) {
+        cur=add_third_party_option(flow, cur);
+    }
+#ifdef PCP_EXPERIMENTAL
+    if (flow->f_deviceid.deviceid[0] != '\0') {
+        cur=add_deviceid_option(flow, cur);
+    }
+
+    if (flow->f_userid.userid[0] != '\0') {
+        cur=add_userid_option(flow, cur);
+    }
+
+    if (flow->f_location.location[0] != '\0') {
+        cur=add_location_option(flow, cur);
+    }
+
+    if (flow->md_val_count>0) {
+        cur=add_md_options(flow, cur);
+    }
+#endif
+
+    flow->pcp_msg_len=((char*)cur) - flow->pcp_msg_buffer;
+
+    //TODO: implement building all pcp options into msg
+    return PCP_ERR_SUCCESS;
+}
+
+static pcp_errno build_pcp_peer(pcp_server_t *server, pcp_flow_t *flow,
+        void *peer_loc)
+{
+    void *next=NULL;
+
+    if (server->pcp_version == 1) {
+        pcp_peer_v1_t *peer_info=(pcp_peer_v1_t *)peer_loc;
+
+        peer_info->protocol=flow->kd.map_peer.protocol;
+        peer_info->int_port=flow->kd.map_peer.src_port;
+        peer_info->ext_port=flow->map_peer.ext_port;
+        peer_info->peer_port=flow->kd.map_peer.dst_port;
+        memcpy(peer_info->ext_ip, &flow->map_peer.ext_ip,
+                sizeof(peer_info->ext_ip));
+        memcpy(peer_info->peer_ip, &flow->kd.map_peer.dst_ip,
+                sizeof(peer_info->peer_ip));
+        next=peer_info + 1;
+    } else if (server->pcp_version == 2) {
+        pcp_peer_v2_t *peer_info=(pcp_peer_v2_t *)peer_loc;
+
+        peer_info->protocol=flow->kd.map_peer.protocol;
+        peer_info->int_port=flow->kd.map_peer.src_port;
+        peer_info->ext_port=flow->map_peer.ext_port;
+        peer_info->peer_port=flow->kd.map_peer.dst_port;
+        memcpy(peer_info->ext_ip, &flow->map_peer.ext_ip,
+                sizeof(peer_info->ext_ip));
+        memcpy(peer_info->peer_ip, &flow->kd.map_peer.dst_ip,
+                sizeof(peer_info->peer_ip));
+        peer_info->nonce=flow->kd.nonce;
+        next=peer_info + 1;
+    } else {
+        return PCP_ERR_UNSUP_VERSION;
+    }
+    return build_pcp_options(flow, next);
+}
+
+static pcp_errno build_pcp_map(pcp_server_t *server, pcp_flow_t *flow,
+        void *map_loc)
+{
+    void *next=NULL;
+
+    if (server->pcp_version == 1) {
+        pcp_map_v1_t *map_info=(pcp_map_v1_t *)map_loc;
+
+        map_info->protocol=flow->kd.map_peer.protocol;
+        map_info->int_port=flow->kd.map_peer.src_port;
+        map_info->ext_port=flow->map_peer.ext_port;
+        memcpy(map_info->ext_ip, &flow->map_peer.ext_ip,
+                sizeof(map_info->ext_ip));
+        next=map_info + 1;
+    } else if (server->pcp_version == 2) {
+        pcp_map_v2_t *map_info=(pcp_map_v2_t *)map_loc;
+
+        map_info->protocol=flow->kd.map_peer.protocol;
+        map_info->int_port=flow->kd.map_peer.src_port;
+        map_info->ext_port=flow->map_peer.ext_port;
+        memcpy(map_info->ext_ip, &flow->map_peer.ext_ip,
+                sizeof(map_info->ext_ip));
+        map_info->nonce=flow->kd.nonce;
+        next=map_info + 1;
+    } else {
+        return PCP_ERR_UNSUP_VERSION;
+    }
+
+    return build_pcp_options(flow, next);
+}
+
+#ifdef PCP_SADSCP
+static pcp_errno build_pcp_sadscp(pcp_server_t *server, pcp_flow_t *flow,
+        void *sadscp_loc)
+{
+    void *next=NULL;
+
+    if (server->pcp_version == 1) {
+        return PCP_ERR_UNSUP_VERSION;
+    } else if (server->pcp_version == 2) {
+        size_t fill_len;
+        pcp_sadscp_req_t *sadscp=(pcp_sadscp_req_t *)sadscp_loc;
+
+        sadscp->nonce=flow->kd.nonce;
+        sadscp->tolerance_fields=flow->sadscp.toler_fields;
+
+        //app name fill size to multiple of 4
+        fill_len=(4-((flow->sadscp.app_name_length+2)%4))%4;
+
+        sadscp->app_name_length=flow->sadscp.app_name_length + fill_len;
+        if (flow->sadscp_app_name) {
+            memcpy(sadscp->app_name, flow->sadscp_app_name,
+                    flow->sadscp.app_name_length);
+        } else {
+            memset(sadscp->app_name, 0,
+                    flow->sadscp.app_name_length);
+        }
+
+        next=((uint8_t *)sadscp_loc) + sizeof(pcp_sadscp_req_t) +
+                sadscp->app_name_length;
+    } else {
+        return PCP_ERR_UNSUP_VERSION;
+    }
+
+    return build_pcp_options(flow, next);
+}
+#endif
+
+#ifndef PCP_DISABLE_NATPMP
+static pcp_errno build_natpmp_msg(pcp_flow_t *flow)
+{
+    nat_pmp_announce_req_t *ann_msg;
+    nat_pmp_map_req_t *map_info;
+
+    switch (flow->kd.operation) {
+        case PCP_OPCODE_ANNOUNCE:
+            ann_msg=(nat_pmp_announce_req_t *)flow->pcp_msg_buffer;
+            ann_msg->ver=0;
+            ann_msg->opcode=NATPMP_OPCODE_ANNOUNCE;
+            flow->pcp_msg_len=sizeof(*ann_msg);
+            return PCP_RES_SUCCESS;
+
+        case PCP_OPCODE_MAP:
+            map_info=(nat_pmp_map_req_t *)flow->pcp_msg_buffer;
+            switch (flow->kd.map_peer.protocol) {
+                case IPPROTO_TCP:
+                    map_info->opcode=NATPMP_OPCODE_MAP_TCP;
+                    break;
+                case IPPROTO_UDP:
+                    map_info->opcode=NATPMP_OPCODE_MAP_UDP;
+                    break;
+                default:
+                    return PCP_RES_UNSUPP_PROTOCOL;
+            }
+            map_info->ver=0;
+            map_info->lifetime=htonl(flow->lifetime);
+            map_info->int_port=flow->kd.map_peer.src_port;
+            map_info->ext_port=flow->map_peer.ext_port;
+            flow->pcp_msg_len=sizeof(*map_info);
+            return PCP_RES_SUCCESS;
+
+        default:
+            return PCP_RES_UNSUPP_OPCODE;
+    }
+}
+#endif
+
+void *build_pcp_msg(pcp_flow_t *flow)
+{
+    ssize_t ret=-1;
+    pcp_server_t *pcp_server=NULL;
+    pcp_request_t *req;
+    // pointer used for referencing next data structure in linked list
+    void *next_data=NULL;
+
+    PCP_LOG_BEGIN(PCP_LOGLVL_DEBUG);
+
+    if (!flow) {
+        return NULL;
+    }
+
+    pcp_server=get_pcp_server(flow->ctx, flow->pcp_server_indx);
+
+    if (!pcp_server) {
+        return NULL;
+    }
+
+    if (!flow->pcp_msg_buffer) {
+        flow->pcp_msg_buffer=(char*)calloc(1, PCP_MAX_LEN);
+        if (flow->pcp_msg_buffer == NULL) {
+            PCP_LOG(PCP_LOGLVL_ERR, "%s",
+                    "Malloc can't allocate enough memory for the pcp_flow.");
+            PCP_LOG_END(PCP_LOGLVL_DEBUG);
+            return NULL;
+        }
+    }
+
+    req=(pcp_request_t *)flow->pcp_msg_buffer;
+
+    if (pcp_server->pcp_version == 0) {
+        // NATPMP
+#ifndef PCP_DISABLE_NATPMP
+        ret=build_natpmp_msg(flow);
+#endif
+    } else {
+
+        req->ver=pcp_server->pcp_version;
+
+        req->r_opcode|=(uint8_t)(flow->kd.operation & 0x7f); //set  opcode
+        req->req_lifetime=htonl((uint32_t)flow->lifetime);
+
+        memcpy(&req->ip, &flow->kd.src_ip, 16);
+        // next data in the packet
+        next_data=req->next_data;
+        flow->pcp_msg_len=(uint8_t *)next_data - (uint8_t *)req;
+
+        switch (flow->kd.operation) {
+            case PCP_OPCODE_PEER:
+                ret=build_pcp_peer(pcp_server, flow, next_data);
+                break;
+            case PCP_OPCODE_MAP:
+                ret=build_pcp_map(pcp_server, flow, next_data);
+                break;
+#ifdef PCP_SADSCP
+            case PCP_OPCODE_SADSCP:
+                ret=build_pcp_sadscp(pcp_server, flow, next_data);
+                break;
+#endif
+            case PCP_OPCODE_ANNOUNCE:
+                ret=0;
+                break;
+        }
+    }
+
+    if (ret < 0) {
+        PCP_LOG(PCP_LOGLVL_ERR, "%s", "Unsupported operation.");
+        free(flow->pcp_msg_buffer);
+        flow->pcp_msg_buffer=NULL;
+        flow->pcp_msg_len=0;
+        req=NULL;
+    }
+
+    PCP_LOG_END(PCP_LOGLVL_DEBUG);
+    return req;
+}
+
+int validate_pcp_msg(pcp_recv_msg_t *f)
+{
+    pcp_response_t *resp;
+
+    //check size
+    if (((f->pcp_msg_len & 3) != 0) || (f->pcp_msg_len < 4)
+            || (f->pcp_msg_len > PCP_MAX_LEN)) {
+        PCP_LOG(PCP_LOGLVL_WARN, "Received packet with invalid size %d)",
+                f->pcp_msg_len);
+        return 0;
+    }
+
+    resp=(pcp_response_t *)f->pcp_msg_buffer;
+    if ((resp->ver)&&!(resp->r_opcode & 0x80)) {
+        PCP_LOG(PCP_LOGLVL_WARN, "%s",
+                "Received packet without response bit set");
+        return 0;
+    }
+
+    if (resp->ver > PCP_MAX_SUPPORTED_VERSION) {
+        PCP_LOG(PCP_LOGLVL_WARN,
+                "Received PCP msg using unsupported PCP version %d", resp->ver);
+        return 0;
+    }
+
+    return 1;
+}
+
+static pcp_errno parse_options(UNUSED pcp_recv_msg_t *f, UNUSED void *r)
+{
+    //TODO: implement parsing of pcp options
+    return PCP_ERR_SUCCESS;
+}
+
+static pcp_errno parse_v1_map(pcp_recv_msg_t *f, void *r)
+{
+    pcp_map_v1_t *m;
+    size_t rest_size=f->pcp_msg_len - (((char*)r) - f->pcp_msg_buffer);
+
+    if (rest_size < sizeof(pcp_map_v1_t)) {
+        return PCP_ERR_RECV_FAILED;
+    }
+
+    m=(pcp_map_v1_t *)r;
+    f->kd.map_peer.src_port=m->int_port;
+    f->kd.map_peer.protocol=m->protocol;
+    f->assigned_ext_port=m->ext_port;
+    memcpy(&f->assigned_ext_ip, m->ext_ip, sizeof(f->assigned_ext_ip));
+
+    if (rest_size > sizeof(pcp_map_v1_t)) {
+        return parse_options(f, m + 1);
+    }
+    return PCP_ERR_SUCCESS;
+}
+
+static pcp_errno parse_v2_map(pcp_recv_msg_t *f, void *r)
+{
+    pcp_map_v2_t *m;
+    size_t rest_size=f->pcp_msg_len - (((char*)r) - f->pcp_msg_buffer);
+
+    if (rest_size < sizeof(pcp_map_v2_t)) {
+        return PCP_ERR_RECV_FAILED;
+    }
+
+    m=(pcp_map_v2_t *)r;
+    f->kd.nonce=m->nonce;
+    f->kd.map_peer.src_port=m->int_port;
+    f->kd.map_peer.protocol=m->protocol;
+    f->assigned_ext_port=m->ext_port;
+    memcpy(&f->assigned_ext_ip, m->ext_ip, sizeof(f->assigned_ext_ip));
+
+    if (rest_size > sizeof(pcp_map_v2_t)) {
+        return parse_options(f, m + 1);
+    }
+    return PCP_ERR_SUCCESS;
+}
+
+static pcp_errno parse_v1_peer(pcp_recv_msg_t *f, void *r)
+{
+    pcp_peer_v1_t *m;
+    size_t rest_size=f->pcp_msg_len - (((char*)r) - f->pcp_msg_buffer);
+
+    if (rest_size < sizeof(pcp_peer_v1_t)) {
+        return PCP_ERR_RECV_FAILED;
+    }
+
+    m=(pcp_peer_v1_t *)r;
+    f->kd.map_peer.src_port=m->int_port;
+    f->kd.map_peer.protocol=m->protocol;
+    f->kd.map_peer.dst_port=m->peer_port;
+    f->assigned_ext_port=m->ext_port;
+    memcpy(&f->kd.map_peer.dst_ip, m->peer_ip, sizeof(f->kd.map_peer.dst_ip));
+    memcpy(&f->assigned_ext_ip, m->ext_ip, sizeof(f->assigned_ext_ip));
+
+    if (rest_size > sizeof(pcp_peer_v1_t)) {
+        return parse_options(f, m + 1);
+    }
+    return PCP_ERR_SUCCESS;
+}
+
+static pcp_errno parse_v2_peer(pcp_recv_msg_t *f, void *r)
+{
+    pcp_peer_v2_t *m;
+    size_t rest_size=f->pcp_msg_len - (((char*)r) - f->pcp_msg_buffer);
+
+    if (rest_size < sizeof(pcp_peer_v2_t)) {
+        return PCP_ERR_RECV_FAILED;
+    }
+
+    m=(pcp_peer_v2_t *)r;
+    f->kd.nonce=m->nonce;
+    f->kd.map_peer.src_port=m->int_port;
+    f->kd.map_peer.protocol=m->protocol;
+    f->kd.map_peer.dst_port=m->peer_port;
+    f->assigned_ext_port=m->ext_port;
+    memcpy(&f->kd.map_peer.dst_ip, m->peer_ip, sizeof(f->kd.map_peer.dst_ip));
+    memcpy(&f->assigned_ext_ip, m->ext_ip, sizeof(f->assigned_ext_ip));
+
+    if (rest_size > sizeof(pcp_peer_v2_t)) {
+        return parse_options(f, m + 1);
+    }
+    return PCP_ERR_SUCCESS;
+}
+
+#ifdef PCP_SADSCP
+static pcp_errno parse_sadscp(pcp_recv_msg_t *f, void *r)
+{
+    pcp_sadscp_resp_t *d;
+    size_t rest_size = f->pcp_msg_len - (((char*) r) - f->pcp_msg_buffer);
+
+    if (rest_size < sizeof(pcp_sadscp_resp_t)) {
+        return PCP_ERR_RECV_FAILED;
+    }
+    d = (pcp_sadscp_resp_t *) r;
+    f->kd.nonce = d->nonce;
+    f->recv_dscp = d->a_r_dscp & (0x3f); //mask 6 lower bits
+
+    return PCP_ERR_SUCCESS;
+}
+#endif
+
+#ifndef PCP_DISABLE_NATPMP
+static pcp_errno parse_v0_resp(pcp_recv_msg_t *f, pcp_response_t *resp)
+{
+    switch(f->kd.operation) {
+        case PCP_OPCODE_ANNOUNCE:
+            if (f->pcp_msg_len == sizeof(nat_pmp_announce_resp_t)) {
+                nat_pmp_announce_resp_t *r=(nat_pmp_announce_resp_t *)resp;
+
+                f->recv_epoch=ntohl(r->epoch);
+                S6_ADDR32(&f->assigned_ext_ip)[0]=0;
+                S6_ADDR32(&f->assigned_ext_ip)[1]=0;
+                S6_ADDR32(&f->assigned_ext_ip)[2]=htonl(0xFFFF);
+                S6_ADDR32(&f->assigned_ext_ip)[3]=r->ext_ip;
+
+                return PCP_ERR_SUCCESS;
+            }
+            break;
+        case NATPMP_OPCODE_MAP_TCP:
+        case NATPMP_OPCODE_MAP_UDP:
+            if (f->pcp_msg_len == sizeof(nat_pmp_map_resp_t)) {
+                nat_pmp_map_resp_t *r=(nat_pmp_map_resp_t *)resp;
+
+                f->assigned_ext_port=r->ext_port;
+                f->kd.map_peer.src_port=r->int_port;
+                f->recv_epoch=ntohl(r->epoch);
+                f->recv_lifetime=ntohl(r->lifetime);
+                f->recv_result=ntohs(r->result);
+                f->kd.map_peer.protocol=
+                        f->kd.operation == NATPMP_OPCODE_MAP_TCP ?
+                                IPPROTO_TCP : IPPROTO_UDP;
+                f->kd.operation=PCP_OPCODE_MAP;
+                return PCP_ERR_SUCCESS;
+            }
+            break;
+        default:
+            break;
+    }
+
+    if (f->pcp_msg_len == sizeof(nat_pmp_inv_version_resp_t)) {
+        nat_pmp_inv_version_resp_t *r=(nat_pmp_inv_version_resp_t *)resp;
+
+        f->recv_result=ntohs(r->result);
+        f->recv_epoch=ntohl(r->epoch);
+        return PCP_ERR_SUCCESS;
+    }
+
+    return PCP_ERR_RECV_FAILED;
+}
+#endif
+
+static pcp_errno parse_v1_resp(pcp_recv_msg_t *f, pcp_response_t *resp)
+{
+    if (f->pcp_msg_len < sizeof(pcp_response_t)) {
+        return PCP_ERR_RECV_FAILED;
+    }
+
+    f->recv_lifetime=ntohl(resp->lifetime);
+    f->recv_epoch=ntohl(resp->epochtime);
+
+    switch (f->kd.operation) {
+        case PCP_OPCODE_ANNOUNCE:
+            return PCP_ERR_SUCCESS;
+        case PCP_OPCODE_MAP:
+            return parse_v1_map(f, resp->next_data);
+        case PCP_OPCODE_PEER:
+            return parse_v1_peer(f, resp->next_data);
+        default:
+            return PCP_ERR_RECV_FAILED;
+    }
+}
+
+static pcp_errno parse_v2_resp(pcp_recv_msg_t *f, pcp_response_t *resp)
+{
+    if (f->pcp_msg_len < sizeof(pcp_response_t)) {
+        return PCP_ERR_RECV_FAILED;
+    }
+
+    f->recv_lifetime=ntohl(resp->lifetime);
+    f->recv_epoch=ntohl(resp->epochtime);
+
+    switch (f->kd.operation) {
+        case PCP_OPCODE_ANNOUNCE:
+            return PCP_ERR_SUCCESS;
+        case PCP_OPCODE_MAP:
+            return parse_v2_map(f, resp->next_data);
+        case PCP_OPCODE_PEER:
+            return parse_v2_peer(f, resp->next_data);
+#ifdef PCP_SADSCP
+        case PCP_OPCODE_SADSCP:
+            return parse_sadscp(f, resp->next_data);
+#endif
+        default:
+            return PCP_ERR_RECV_FAILED;
+    }
+}
+
+pcp_errno parse_response(pcp_recv_msg_t *f)
+{
+    pcp_response_t *resp=(pcp_response_t *)f->pcp_msg_buffer;
+
+    f->recv_version=resp->ver;
+    f->recv_result=resp->result_code;
+    memset(&f->kd, 0, sizeof(f->kd));
+
+    f->kd.operation=resp->r_opcode & 0x7f;
+
+    PCP_LOG(PCP_LOGLVL_DEBUG, "parse_response: version: %d", f->recv_version);
+    PCP_LOG(PCP_LOGLVL_DEBUG, "parse_response: result: %d", f->recv_result);
+
+    switch (f->recv_version) {
+#ifndef PCP_DISABLE_NATPMP
+        case 0:
+            return parse_v0_resp(f, resp);
+            break;
+#endif
+        case 1:
+            return parse_v1_resp(f, resp);
+            break;
+        case 2:
+            return parse_v2_resp(f, resp);
+            break;
+    }
+    return PCP_ERR_UNSUP_VERSION;
+}
+

--- a/lib/libpcp/src/pcp_msg.h
+++ b/lib/libpcp/src/pcp_msg.h
@@ -1,0 +1,50 @@
+/*
+ Copyright (c) 2014 by Cisco Systems, Inc.
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following disclaimer in the documentation
+ and/or other materials provided with the distribution.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef PCP_MSG_H_
+#define PCP_MSG_H_
+
+#ifdef WIN32
+//#include <winsock2.h>
+#include "stdint.h"
+#else //WIN32
+#include <sys/socket.h>
+#include <stdint.h>
+#endif
+
+#include "pcp.h"
+#include "pcp_utils.h"
+#include "pcp_client_db.h"
+#include "pcp_msg_structs.h"
+
+void *build_pcp_msg(struct pcp_flow_s *flow);
+
+int validate_pcp_msg(pcp_recv_msg_t *f);
+
+void parse_response_hdr(pcp_recv_msg_t f);
+
+pcp_errno parse_response(pcp_recv_msg_t *f);
+
+#endif /* PCP_MSG_H_ */

--- a/lib/libpcp/src/pcp_msg_structs.h
+++ b/lib/libpcp/src/pcp_msg_structs.h
@@ -1,0 +1,316 @@
+/*
+ Copyright (c) 2014 by Cisco Systems, Inc.
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following disclaimer in the documentation
+ and/or other materials provided with the distribution.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef PCP_MSG_STRUCTS_H_
+#define PCP_MSG_STRUCTS_H_
+
+#ifdef WIN32
+#pragma warning (push)
+#pragma warning (disable:4200)
+#endif // WIN32
+#define PCP_MAX_LEN          1100
+#define PCP_OPCODE_ANNOUNCE     0
+#define PCP_OPCODE_MAP          1
+#define PCP_OPCODE_PEER         2
+#define PCP_OPCODE_SADSCP       3
+#define NATPMP_OPCODE_ANNOUNCE  0
+#define NATPMP_OPCODE_MAP_UDP   1
+#define NATPMP_OPCODE_MAP_TCP   2
+
+/* Possible response codes sent by server, as a result of client request*/
+#define PCP_RES_SUCCESS                   0
+#define PCP_RES_UNSUPP_VERSION            1
+#define PCP_RES_NOT_AUTHORIZED            2
+#define PCP_RES_MALFORMED_REQUEST         3
+#define PCP_RES_UNSUPP_OPCODE             4
+#define PCP_RES_UNSUPP_OPTION             5
+#define PCP_RES_MALFORMED_OPTION          6
+#define PCP_RES_NETWORK_FAILURE           7
+#define PCP_RES_NO_RESOURCES              8
+#define PCP_RES_UNSUPP_PROTOCOL           9
+#define PCP_RES_USER_EX_QUOTA             10
+#define PCP_RES_CANNOT_PROVIDE_EXTERNAL   11
+#define PCP_RES_ADDRESS_MISMATCH          12
+#define PCP_RES_EXCESSIVE_REMOTE_PEERS    13
+
+typedef enum pcp_options {
+    PCP_OPTION_3RD_PARTY=1,
+    PCP_OPTION_PREF_FAIL=2,
+    PCP_OPTION_FILTER=3,
+    PCP_OPTION_DEVICEID=96, /*private range */
+    PCP_OPTION_LOCATION=97,
+    PCP_OPTION_USERID=98,
+    PCP_OPTION_FLOW_PRIORITY=99,
+    PCP_OPTION_METADATA=100
+} pcp_options_t;
+
+#pragma pack(push,1)
+
+#ifndef MAX_USER_ID
+#define MAX_USER_ID 512
+#endif
+#ifndef MAX_DEViCE_ID_STR
+#define MAX_DEVICE_ID 32
+#endif
+#ifndef MAX_GEO_STR
+#define MAX_GEO_STR 32
+#endif
+
+/* PCP common request header*/
+typedef struct pcp_request {
+    uint8_t ver;
+    uint8_t r_opcode;
+    uint16_t reserved;
+    uint32_t req_lifetime;
+    uint32_t ip[4]; /* ipv4 will be represented
+     by the ipv4 mapped ipv6 */
+    uint8_t next_data[0];
+} pcp_request_t;
+
+/* PCP common response header*/
+typedef struct pcp_response {
+    uint8_t ver;
+    /* R indicates Request (0) or Response (1)
+       Opcode is 7 bit value specifying operation MAP or PEER */
+    uint8_t r_opcode;
+    /* reserved bits, must be 0 on transmission and must be ignored on
+       reception */
+    uint8_t reserved;
+    uint8_t result_code;
+    /* an unsigned 32-bit integer, in seconds {0, 2^32-1}*/
+    uint32_t lifetime;
+    /* epoch indicates how long has PCP server had its current mappings
+       it increases by 1 every second */
+    uint32_t epochtime;
+    /* For requests that were successfully parsed this must be sent as 0 */
+    uint32_t reserved1[3];
+    uint8_t next_data[0];
+} pcp_response_t;
+
+typedef struct pcp_options_hdr {
+    /* Most significant bit indicates if this option is mandatory (0)
+       or optional (1) */
+    uint8_t code;
+    /* MUST be set to 0 on transmission and MUST be ignored on reception */
+    uint8_t reserved;
+    /* indicates the length of the enclosed data in octets (see RFC) */
+    uint16_t len;
+    uint8_t next_data[0];
+} pcp_options_hdr_t;
+
+typedef struct nat_pmp_announce_req {
+    uint8_t ver;
+    uint8_t opcode;
+} nat_pmp_announce_req_t;
+
+typedef struct nat_pmp_announce_resp {
+    uint8_t ver;
+    uint8_t opcode;
+    uint16_t result;
+    uint32_t epoch;
+    uint32_t ext_ip;
+} nat_pmp_announce_resp_t;
+
+typedef struct nat_pmp_map_req {
+    uint8_t ver;
+    uint8_t opcode;
+    uint16_t reserved;
+    uint16_t int_port;
+    uint16_t ext_port;
+    uint32_t lifetime;
+} nat_pmp_map_req_t;
+
+typedef struct nat_pmp_map_resp {
+    uint8_t ver;
+    uint8_t opcode;
+    uint16_t result;
+    uint32_t epoch;
+    uint16_t int_port;
+    uint16_t ext_port;
+    uint32_t lifetime;
+} nat_pmp_map_resp_t;
+
+typedef struct nat_pmp_inv_version_resp {
+    uint8_t ver;
+    uint8_t opcode;
+    uint16_t result;
+    uint32_t epoch;
+} nat_pmp_inv_version_resp_t;
+
+struct pcp_nonce {
+    uint32_t n[3];
+};
+
+/* same for both request and response */
+typedef struct pcp_map_v2 {
+    struct pcp_nonce nonce;
+    uint8_t protocol;
+    uint8_t reserved[3];
+    uint16_t int_port;
+    uint16_t ext_port;
+    uint32_t ext_ip[4]; /* ipv4 will be represented by the ipv4 mapped ipv6 */
+    uint8_t next_data[0];
+} pcp_map_v2_t;
+
+/* same for both request and response */
+typedef struct pcp_map_v1 {
+    uint8_t protocol;
+    uint8_t reserved[3];
+    uint16_t int_port;
+    uint16_t ext_port;
+    uint32_t ext_ip[4]; /* ipv4 will be represented by the ipv4 mapped ipv6 */
+    uint8_t next_data[0];
+} pcp_map_v1_t;
+
+/* same for both request and response */
+typedef struct pcp_peer_v1 {
+    uint8_t protocol;
+    uint8_t reserved[3];
+    uint16_t int_port;
+    uint16_t ext_port;
+    uint32_t ext_ip[4]; /* ipv4 will be represented by the ipv4 mapped ipv6 */
+    uint16_t peer_port;
+    uint16_t reserved1;
+    uint32_t peer_ip[4];
+    uint8_t next_data[0];
+} pcp_peer_v1_t;
+
+/* same for both request and response */
+typedef struct pcp_peer_v2 {
+    struct pcp_nonce nonce;
+    uint8_t protocol;
+    uint8_t reserved[3];
+    uint16_t int_port;
+    uint16_t ext_port;
+    uint32_t ext_ip[4]; /* ipv4 will be represented by the ipv4 mapped ipv6 */
+    uint16_t peer_port;
+    uint16_t reserved1;
+    uint32_t peer_ip[4];
+    uint8_t next_data[0];
+} pcp_peer_v2_t;
+
+typedef struct pcp_sadscp_req {
+    struct pcp_nonce nonce;
+    uint8_t tolerance_fields;
+    uint8_t app_name_length;
+    char app_name[0];
+} pcp_sadscp_req_t;
+
+typedef struct pcp_sadscp_resp {
+    struct pcp_nonce nonce;
+    uint8_t a_r_dscp;
+    uint8_t reserved[3];
+} pcp_sadscp_resp_t;
+
+typedef struct pcp_location_option {
+    uint8_t option;
+    uint8_t reserved;
+    uint16_t len;
+    //float   latitude;
+    //float   longitude;
+    char location[MAX_GEO_STR];
+} pcp_location_option_t;
+
+typedef struct pcp_userid_option {
+    uint8_t option;
+    uint8_t reserved;
+    uint16_t len;
+    char userid[MAX_USER_ID];
+} pcp_userid_option_t;
+
+typedef struct pcp_deviceid_option {
+    uint8_t option;
+    uint8_t reserved;
+    uint16_t len;
+    // uint32_t device_class;
+    char deviceid[MAX_DEVICE_ID];
+} pcp_deviceid_option_t;
+
+#define FOREACH_DEVICE(DEVICE) \
+        DEVICE(smartphone)  \
+        DEVICE(iphone)   \
+        DEVICE(unknown)
+
+#define GENERATE_ENUM(ENUM) ENUM,
+#define GENERATE_STRING(STRING) #STRING ,
+
+typedef enum DEVICE_ENUM {
+    FOREACH_DEVICE(GENERATE_ENUM)
+} device_enum_e;
+
+typedef struct pcp_prefer_fail_option {
+    uint8_t option;
+    uint8_t reserved;
+    uint16_t len;
+    uint8_t next_data[0];
+} pcp_prefer_fail_option_t;
+
+typedef struct pcp_3rd_party_option {
+    uint8_t option;
+    uint8_t reserved;
+    uint16_t len;
+    uint32_t ip[4];
+    uint8_t next_data[0];
+} pcp_3rd_party_option_t;
+
+typedef struct pcp_filter_option {
+    uint8_t option;
+    uint8_t reserved;
+    uint16_t len;
+    uint8_t reserved2;
+    uint8_t filter_prefix;
+    uint16_t filter_peer_port;
+    uint32_t filter_peer_ip[4];
+    uint8_t next_data[0];
+} pcp_filter_option_t;
+
+typedef struct pcp_flow_priority_option {
+    uint8_t option;
+    uint8_t reserved;
+    uint16_t len;
+    uint8_t dscp_up;
+    uint8_t dscp_down;
+#define PCP_DSCP_MASK ((1<<6)-1)
+    uint8_t reserved2;
+    /* most significant bit is used for response */
+    uint8_t response_bit;
+//#define PCP_FLOW_OPTION_RESP_P (1<<7)
+    uint8_t next_data[0];
+} pcp_flow_priority_option_t;
+
+typedef struct pcp_metadata_option {
+    uint8_t option;
+    uint8_t reserved;
+    uint16_t len;
+    uint32_t metadata_id;
+    uint8_t metadata[];
+} pcp_metadata_option_t;
+
+#pragma pack(pop)
+
+#ifdef WIN32
+#pragma warning (pop)
+#endif // WIN32
+#endif /* PCP_MSG_STRUCTS_H_ */

--- a/lib/libpcp/src/pcp_server_discovery.c
+++ b/lib/libpcp/src/pcp_server_discovery.c
@@ -1,0 +1,235 @@
+/*
+ Copyright (c) 2014 by Cisco Systems, Inc.
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following disclaimer in the documentation
+ and/or other materials provided with the distribution.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#else
+#include "default_config.h"
+#endif
+
+#include <stddef.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+
+#ifdef WIN32
+#include "pcp_win_defines.h"
+#else
+#include <stdint.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#endif //WIN32
+#include "pcp.h"
+#include "pcp_utils.h"
+#include "pcp_server_discovery.h"
+#include "pcp_event_handler.h"
+#include "gateway.h"
+#include "pcp_msg.h"
+#include "pcp_logger.h"
+#include "findsaddr.h"
+#include "pcp_socket.h"
+
+static pcp_errno psd_fill_pcp_server_src(pcp_server_t *s)
+{
+    struct in6_addr src_ip;
+    const char *err=NULL;
+
+    PCP_LOG_BEGIN(PCP_LOGLVL_DEBUG);
+
+    if (!s) {
+        PCP_LOG_END(PCP_LOGLVL_DEBUG);
+        return PCP_ERR_BAD_ARGS;
+    }
+
+    memset(&s->pcp_server_saddr, 0, sizeof(s->pcp_server_saddr));
+    memset(&src_ip, 0, sizeof(src_ip));
+
+#ifndef PCP_USE_IPV6_SOCKET
+    s->pcp_server_saddr.ss_family=AF_INET;
+    if (s->af == AF_INET) {
+        ((struct sockaddr_in *)&s->pcp_server_saddr)->sin_addr.s_addr=
+                s->pcp_ip[3];
+        ((struct sockaddr_in *)&s->pcp_server_saddr)->sin_port=s->pcp_port;
+        SET_SA_LEN(&s->pcp_server_saddr, sizeof(struct sockaddr_in));
+        inet_ntop(AF_INET,
+                (void *)&((struct sockaddr_in *)&s->pcp_server_saddr)->sin_addr,
+                s->pcp_server_paddr, sizeof(s->pcp_server_paddr));
+
+        err=findsaddr((struct sockaddr_in *)&s->pcp_server_saddr, &src_ip);
+        if (err) {
+            PCP_LOG(PCP_LOGLVL_WARN,
+                    "Error (%s) occurred while registering a new "
+                    "PCP server %s", err, s->pcp_server_paddr);
+
+            PCP_LOG_END(PCP_LOGLVL_DEBUG);
+            return PCP_ERR_UNKNOWN;
+        }
+        s->src_ip[0]=0;
+
+        s->src_ip[1]=0;
+        s->src_ip[2]=htonl(0xFFFF);
+        s->src_ip[3]=S6_ADDR32(&src_ip)[3];
+    } else {
+        PCP_LOG(PCP_LOGLVL_WARN, "%s",
+                "IPv6 is disabled and IPv6 address of PCP server occurred");
+
+        PCP_LOG_END(PCP_LOGLVL_DEBUG);
+        return PCP_ERR_BAD_AFINET;
+    }
+#else //PCP_USE_IPV6_SOCKET
+    s->pcp_server_saddr.ss_family=AF_INET6;
+    if (s->af == AF_INET) {
+        return PCP_ERR_BAD_AFINET; //should never happen
+    }
+    pcp_fill_sockaddr((struct sockaddr *)&s->pcp_server_saddr,
+            (struct in6_addr *)&s->pcp_ip, s->pcp_port, 1, s->pcp_scope_id);
+
+    inet_ntop(AF_INET6,
+            (void *)&((struct sockaddr_in6*) &s->pcp_server_saddr)->sin6_addr,
+            s->pcp_server_paddr, sizeof(s->pcp_server_paddr));
+
+    err=findsaddr6((struct sockaddr_in6*)&s->pcp_server_saddr, &src_ip);
+    if (err) {
+        PCP_LOG(PCP_LOGLVL_WARN,
+                "Error (%s) occurred while registering a new "
+                "PCP server %s", err, s->pcp_server_paddr);
+
+        PCP_LOG_END(PCP_LOGLVL_DEBUG);
+        return PCP_ERR_UNKNOWN;
+    }
+    s->src_ip[0]=S6_ADDR32(&src_ip)[0];
+    s->src_ip[1]=S6_ADDR32(&src_ip)[1];
+    s->src_ip[2]=S6_ADDR32(&src_ip)[2];
+    s->src_ip[3]=S6_ADDR32(&src_ip)[3];
+#endif //PCP_USE_IPV6_SOCKET
+    s->server_state=pss_ping;
+    s->next_timeout.tv_sec=0;
+    s->next_timeout.tv_usec=0;
+
+    PCP_LOG_END(PCP_LOGLVL_DEBUG);
+    return PCP_ERR_SUCCESS;
+}
+
+void psd_add_gws(pcp_ctx_t *ctx)
+{
+    struct sockaddr_in6 *gws=NULL, *gw;
+    int rcount=getgateways(&gws);
+
+    gw=gws;
+
+    for (; rcount > 0; rcount--, gw++) {
+        int pcps_indx;
+
+        if ((IN6_IS_ADDR_V4MAPPED(&gw->sin6_addr)) && (S6_ADDR32(&gw->sin6_addr)[3] == INADDR_ANY))
+            continue;
+
+        if (IN6_IS_ADDR_UNSPECIFIED(&gw->sin6_addr))
+            continue;
+
+        if (get_pcp_server_by_ip(ctx, &gw->sin6_addr))
+            continue;
+
+        pcps_indx=pcp_new_server(ctx, &gw->sin6_addr, ntohs(PCP_SERVER_PORT), gw->sin6_scope_id);
+        if (pcps_indx >= 0) {
+            pcp_server_t *s=get_pcp_server(ctx, pcps_indx);
+            if (!s)
+                continue;
+
+            if (psd_fill_pcp_server_src(s)) {
+                PCP_LOG(PCP_LOGLVL_ERR,
+                        "Failed to initialize gateway %s as a PCP server.",
+                        s?s->pcp_server_paddr:"NULL pointer!!!");
+            } else {
+                PCP_LOG(PCP_LOGLVL_INFO, "Found gateway %s. "
+                "Added as possible PCP server.",
+                        s?s->pcp_server_paddr:"NULL pointer!!!");
+            }
+        }
+    }
+    free(gws);
+}
+
+pcp_errno psd_add_pcp_server(pcp_ctx_t *ctx, struct sockaddr *sa,
+        uint8_t version)
+{
+    struct in6_addr pcp_ip=IN6ADDR_ANY_INIT;
+    uint16_t pcp_port;
+    uint32_t scope_id=0;
+    pcp_server_t *pcps=NULL;
+
+    PCP_LOG_BEGIN(PCP_LOGLVL_DEBUG);
+
+    if (sa->sa_family == AF_INET) {
+        S6_ADDR32(&pcp_ip)[0]=0;
+        S6_ADDR32(&pcp_ip)[1]=0;
+        S6_ADDR32(&pcp_ip)[2]=htonl(0xFFFF);
+        S6_ADDR32(&pcp_ip)[3]=((struct sockaddr_in *)sa)->sin_addr.s_addr;
+        pcp_port=((struct sockaddr_in *)sa)->sin_port;
+    } else {
+        IPV6_ADDR_COPY(&pcp_ip, &((struct sockaddr_in6*)sa)->sin6_addr);
+        pcp_port=((struct sockaddr_in6 *)sa)->sin6_port;
+        scope_id=((struct sockaddr_in6 *)sa)->sin6_scope_id;
+    }
+
+    if (!pcp_port) {
+        pcp_port=ntohs(PCP_SERVER_PORT);
+    }
+
+    pcps=get_pcp_server_by_ip(ctx, (struct in6_addr *)&pcp_ip);
+    if (!pcps) {
+        int pcps_indx=pcp_new_server(ctx, &pcp_ip, pcp_port, scope_id);
+
+        if (pcps_indx >= 0) {
+            pcps=get_pcp_server(ctx, pcps_indx);
+        }
+
+        if (pcps == NULL) {
+            PCP_LOG(PCP_LOGLVL_ERR, "%s", "Can't add PCP server.\n");
+            PCP_LOG_END(PCP_LOGLVL_DEBUG);
+            return PCP_ERR_UNKNOWN;
+        }
+    } else {
+        pcps->pcp_port=pcp_port;
+    }
+
+    pcps->pcp_version=version;
+    pcps->server_state=pss_allocated;
+
+    if (psd_fill_pcp_server_src(pcps)) {
+        pcps->server_state=pss_unitialized;
+        PCP_LOG(PCP_LOGLVL_INFO, "Failed to add PCP server %s",
+                pcps->pcp_server_paddr);
+
+        PCP_LOG_END(PCP_LOGLVL_DEBUG);
+        return PCP_ERR_UNKNOWN;
+    }
+
+    PCP_LOG(PCP_LOGLVL_INFO, "Added PCP server %s", pcps->pcp_server_paddr);
+
+    PCP_LOG_END(PCP_LOGLVL_DEBUG);
+    return (pcp_errno)pcps->index;
+}

--- a/lib/libpcp/src/pcp_server_discovery.h
+++ b/lib/libpcp/src/pcp_server_discovery.h
@@ -1,0 +1,35 @@
+/*
+ Copyright (c) 2014 by Cisco Systems, Inc.
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following disclaimer in the documentation
+ and/or other materials provided with the distribution.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef PCP_SERVER_DISCOVERY_H_
+#define PCP_SERVER_DISCOVERY_H_
+
+#include "pcp_client_db.h"
+
+void psd_add_gws(pcp_ctx_t *ctx);
+pcp_errno psd_add_pcp_server(pcp_ctx_t *ctx, struct sockaddr *sa,
+        uint8_t version);
+
+#endif /* PCP_SERVER_DISCOVERY_H_ */

--- a/lib/libpcp/src/pcp_utils.h
+++ b/lib/libpcp/src/pcp_utils.h
@@ -1,0 +1,250 @@
+/*
+ Copyright (c) 2014 by Cisco Systems, Inc.
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following disclaimer in the documentation
+ and/or other materials provided with the distribution.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef PCP_UTILS_H_
+#define PCP_UTILS_H_
+
+#include <stdlib.h>
+#include <stdint.h>
+#include <string.h>
+#include "pcp_logger.h"
+#include "pcp_client_db.h"
+
+#ifndef max
+#define max(a,b) \
+   ({ typeof (a) _a=(a); \
+       typeof (b) _b=(b); \
+     _a > _b ? _a : _b; })
+#endif
+
+#ifndef min
+#define min(a,b) \
+   ({ typeof (a) _a=(a); \
+       typeof (b) _b=(b); \
+     _a > _b ? _b : _a; })
+#endif
+
+ #ifdef __GNUC__
+  #define UNUSED __attribute__ ((unused))
+ #else
+  #define UNUSED
+ #endif
+
+#ifdef WIN32
+/* variable num of arguments*/
+#define DUPPRINT(fp, fmt, ...)    \
+    do {                        \
+        printf(fmt, __VA_ARGS__);            \
+        if (fp != NULL) {       \
+            fprintf(fp, fmt, __VA_ARGS__);    \
+        }                       \
+    } while(0)
+#else /*WIN32*/
+#define DUPPRINT(fp, fmt...)    \
+    do {                        \
+        printf(fmt);            \
+        if (fp != NULL) {       \
+            fprintf(fp,fmt);    \
+        }                       \
+    } while(0)
+#endif /*WIN32*/
+
+#define log_err(STR) \
+    do {        \
+        printf("%s:%d "#STR": %s \n", __FUNCTION__, __LINE__, strerror(errno)); \
+    } while (0)
+
+#define log_debug_scr(STR) \
+    do {        \
+        printf("%s:%d %s \n", __FUNCTION__, __LINE__, STR); \
+    } while (0)
+
+#define log_debug(STR) \
+    do {        \
+        printf("%s:%d "#STR" \n", __FUNCTION__, __LINE__); \
+    } while (0)
+
+#define CHECK_RET_EXIT(func)        \
+    do {                            \
+        if (func < 0) {             \
+            log_err("");            \
+            exit (EXIT_FAILURE);    \
+        }                           \
+    } while(0)
+
+#define CHECK_NULL_EXIT(func)       \
+    do {                            \
+        if (func == NULL) {         \
+            log_err("");            \
+            exit (EXIT_FAILURE);    \
+        }                           \
+    } while(0)
+
+
+#define CHECK_RET(func)             \
+    do {                            \
+        if (func < 0) {             \
+            log_err("");            \
+        }                           \
+    } while(0)
+
+#define CHECK_RET_GOTO_ERROR(func)  \
+    do {                            \
+        if (func < 0) {             \
+            log_err("");            \
+            goto ERROR;             \
+        }                           \
+    } while(0)
+
+
+
+#define OSDEP(x) (void)(x)
+
+#ifdef s6_addr32
+#define S6_ADDR32(sa6) (sa6)->s6_addr32
+#else
+#define S6_ADDR32(sa6) ((uint32_t *)((sa6)->s6_addr))
+#endif
+
+#define IPV6_ADDR_COPY(dest, src)   \
+    do {                            \
+        (S6_ADDR32(dest))[0]=(S6_ADDR32(src))[0];       \
+        (S6_ADDR32(dest))[1]=(S6_ADDR32(src))[1];       \
+        (S6_ADDR32(dest))[2]=(S6_ADDR32(src))[2];       \
+        (S6_ADDR32(dest))[3]=(S6_ADDR32(src))[3];       \
+    } while (0)
+
+#include "pcp_msg.h"
+static inline int compare_epochs(pcp_recv_msg_t *f, pcp_server_t *s)
+{
+    uint32_t c_delta;
+    uint32_t s_delta;
+
+    if (s->epoch == ~0u) {
+        s->epoch=f->recv_epoch;
+        s->cepoch=f->received_time;
+    }
+    c_delta=(uint32_t)(f->received_time - s->cepoch);
+    s_delta=f->recv_epoch - s->epoch;
+
+    PCP_LOG(PCP_LOGLVL_DEBUG,
+            "Epoch - client delta = %u, server delta = %u",
+            c_delta, s_delta);
+
+    return (c_delta + 2 < s_delta - (s_delta >> 4))
+            || (s_delta + 2 < c_delta - (c_delta >> 4));
+}
+
+inline static void timeval_align(struct timeval *x)
+{
+    x->tv_sec+=x->tv_usec / 1000000;
+    x->tv_usec=x->tv_usec % 1000000;
+    if (x->tv_usec<0) {
+        x->tv_usec=1000000 + x->tv_usec;
+        x->tv_sec-=1;
+    }
+}
+
+inline static int timeval_comp(struct timeval *x, struct timeval *y)
+{
+    timeval_align(x);
+    timeval_align(y);
+    if (x->tv_sec < y->tv_sec) {
+        return -1;
+    } else if (x->tv_sec > y->tv_sec) {
+        return 1;
+    } else if (x->tv_usec < y->tv_usec) {
+        return -1;
+    } else if (x->tv_usec > y->tv_usec) {
+        return 1;
+    } else {
+        return 0;
+    }
+}
+
+inline static int timeval_subtract(struct timeval *result, struct timeval *x,
+        struct timeval *y)
+{
+    int ret=timeval_comp(x, y);
+
+    if (ret<=0) {
+        result->tv_sec=0;
+        result->tv_usec=0;
+        return 1;
+    }
+
+    // in case that tv_usec is unsigned -> perform the carry
+    if (x->tv_usec < y->tv_usec) {
+        int nsec=(y->tv_usec - x->tv_usec) / 1000000 + 1;
+        y->tv_usec-=1000000 * nsec;
+        y->tv_sec+=nsec;
+    }
+
+    /* Compute the time remaining to wait.
+       tv_usec is certainly positive. */
+    result->tv_sec=x->tv_sec - y->tv_sec;
+    result->tv_usec=x->tv_usec - y->tv_usec;
+    timeval_align(result);
+
+    /* Return 1 if result is negative. */
+    return ret <= 0;
+}
+
+/* Nonce is part of the MAP and PEER requests/responses
+   as of version 2 of the PCP protocol */
+static inline void createNonce(struct pcp_nonce *nonce_field)
+{
+    int i;
+    for (i = 2; i >= 0; --i)
+#ifdef WIN32
+        nonce_field->n[i]=htonl (rand());
+#else  //WIN32
+        nonce_field->n[i]=htonl(random());
+#endif //WIN32
+}
+
+#ifndef HAVE_STRNDUP
+static inline char *pcp_strndup(const char *s, size_t size) {
+  char *ret;
+  char *end=memchr(s, 0, size);
+
+  if (end) {
+    /* Length + 1 */
+    size=end - s + 1;
+  } else {
+    size++;
+  }
+  ret=malloc(size);
+
+  if (ret) {
+      memcpy(ret, s, size);
+      ret[size-1]='\0';
+  }
+  return ret;
+}
+#define strndup pcp_strndup
+#endif
+
+#endif /* PCP_UTILS_H_ */

--- a/lib/libpcp/src/windows/pcp_gettimeofday.c
+++ b/lib/libpcp/src/windows/pcp_gettimeofday.c
@@ -1,0 +1,89 @@
+/*
+ Copyright (c) 2014 by Cisco Systems, Inc.
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following disclaimer in the documentation
+ and/or other materials provided with the distribution.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#else
+#include "default_config.h"
+#endif
+
+#ifndef HAVE_GETTIMEOFDAY
+#include <windows.h>
+#include <time.h>
+#if defined(_MSC_VER) || defined(_MSC_EXTENSIONS)
+#define DELTA_EPOCH_IN_MICROSECS  11644473600000000Ui64
+#else /* defined(_MSC_VER) || defined(_MSC_EXTENSIONS)*/
+#define DELTA_EPOCH_IN_MICROSECS  11644473600000000ULL
+#endif /* defined(_MSC_VER) || defined(_MSC_EXTENSIONS)*/
+
+/* custom implementation of the gettimeofday function
+ for Windows platform. */
+
+struct timezone {
+    int tz_minuteswest; /* minutes W of Greenwich */
+    int tz_dsttime; /* type of dst correction */
+};
+
+int gettimeofday(struct timeval *tv, struct timezone *tz)
+{
+    FILETIME ft;
+    unsigned __int64 tmpres=0;
+    static int tzflag=0;
+    int tz_seconds=0;
+    int tz_daylight=0;
+
+    if (NULL != tv) {
+        GetSystemTimeAsFileTime(&ft);
+
+        tmpres|=ft.dwHighDateTime;
+        tmpres<<=32;
+        tmpres|=ft.dwLowDateTime;
+
+        tmpres/=10; /*convert into microseconds*/
+        /*converting file time to unix epoch*/
+        tmpres-=DELTA_EPOCH_IN_MICROSECS;
+        tv->tv_sec=(long)(tmpres / 1000000UL);
+        tv->tv_usec=(long)(tmpres % 1000000UL);
+    }
+
+    if (tz) {
+        if (!tzflag) {
+            _tzset();
+            tzflag++;
+        }
+        if (_get_timezone(&tz_seconds)) {
+            return -1;
+        }
+        if (_get_daylight(&tz_daylight)) {
+            return -1;
+        }
+        tz->tz_minuteswest=tz_seconds / 60;
+        tz->tz_dsttime=tz_daylight;
+    }
+
+    return 0;
+}
+
+#endif //HAVE_GETTIMEOFDAY

--- a/lib/libpcp/src/windows/pcp_gettimeofday.h
+++ b/lib/libpcp/src/windows/pcp_gettimeofday.h
@@ -1,0 +1,31 @@
+/*
+ Copyright (c) 2014 by Cisco Systems, Inc.
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following disclaimer in the documentation
+ and/or other materials provided with the distribution.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef PCP_GETTIMEOFDAY
+#define PCP_GETTIMEOFDAY
+
+int gettimeofday(struct timeval *tv, struct timezone *tz);
+
+#endif /*PCP_GETTIMEOFDAY*/

--- a/lib/libpcp/src/windows/pcp_win_defines.h
+++ b/lib/libpcp/src/windows/pcp_win_defines.h
@@ -1,0 +1,94 @@
+/*
+ Copyright (c) 2014 by Cisco Systems, Inc.
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following disclaimer in the documentation
+ and/or other materials provided with the distribution.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef PCP_WIN_DEFINES
+#define PCP_WIN_DEFINES
+
+#include <time.h>
+#include <winsock2.h>
+#include <ws2tcpip.h>
+#include <ws2ipdef.h>
+#include <winbase.h> /*GetCurrentProcessId*/ /*link with kernel32.dll*/
+#include "stdint.h"
+/* windows uses Sleep(miliseconds) method, instead of UNIX sleep(seconds) */
+#define sleep(x) Sleep((x) * 1000)
+#ifdef _MSC_VER
+#define inline __inline /*In Visual Studio inline keyword only available in C++ */
+#endif
+
+typedef uint16_t in_port_t;
+
+#if 1 //WINVER<NTDDI_VISTA
+static inline const char *pcp_inet_ntop(int af, const void *src, char *dst,
+        int cnt)
+{
+    struct sockaddr_storage srcaddr;
+    size_t slen;
+
+    if (af == AF_INET) {
+        struct sockaddr_in *sa4=(struct sockaddr_in *)&srcaddr;
+        memset(sa4, 0, sizeof(struct sockaddr_in));
+        memcpy(&(sa4->sin_addr), src, sizeof(sa4->sin_addr));
+        slen=sizeof(struct sockaddr_in);
+    } else if (af == AF_INET6) {
+        struct sockaddr_in6 *sa6=(struct sockaddr_in6 *)&srcaddr;
+        memset(sa6, 0, sizeof(struct sockaddr_in6));
+        memcpy(&(sa6->sin6_addr), src, sizeof(sa6->sin6_addr));
+        slen=sizeof(struct sockaddr_in6);
+    } else {
+        return NULL;
+    }
+    srcaddr.ss_family=af;
+    if (WSAAddressToString((struct sockaddr *)&srcaddr, (DWORD)slen, 0, dst,
+            (LPDWORD) & cnt) != 0) {
+        return NULL;
+    }
+    return dst;
+}
+#define inet_ntop pcp_inet_ntop
+#endif
+
+#define ssize_t SSIZE_T
+#define strdup _strdup
+
+#define getpid GetCurrentProcessId
+
+#define snprintf _snprintf
+
+int gettimeofday(struct timeval *tv, struct timezone *tz);
+
+#define MSG_DONTWAIT    0x0
+
+#if (_WIN32_WINNT < _WIN32_WINNT_VISTA)
+#define AI_NUMERICSERV              0x00000008
+#define AI_ALL                      0x00000100
+#define AI_ADDRCONFIG               0x00000400
+#define AI_V4MAPPED                 0x00000800
+#define AI_NON_AUTHORITATIVE        0x00004000
+#define AI_SECURE                   0x00008000
+#define AI_RETURN_PREFERRED_NAMES   0x00010000
+#endif
+
+#endif /*PCP_WIN_DEFINES*/

--- a/lib/libpcp/src/windows/stdint.h
+++ b/lib/libpcp/src/windows/stdint.h
@@ -1,0 +1,249 @@
+// ISO C9x  compliant stdint.h for Microsoft Visual Studio
+// Based on ISO/IEC 9899:TC2 Committee draft (May 6, 2005) WG14/N1124 
+// 
+//  Copyright (c) 2006-2008 Alexander Chemeris
+// 
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+// 
+//   1. Redistributions of source code must retain the above copyright notice,
+//      this list of conditions and the following disclaimer.
+// 
+//   2. Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+// 
+//   3. The name of the author may be used to endorse or promote products
+//      derived from this software without specific prior written permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR IMPLIED
+// WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+// EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+// OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+// OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+// ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// 
+///////////////////////////////////////////////////////////////////////////////
+
+#ifndef __MINGW32__ // [
+#ifndef _MSC_VER // [
+#error "Use this header only with Microsoft Visual C++ compilers!"
+#endif // _MSC_VER ]
+#endif // __MINGW32__ ]
+
+#ifndef _MSC_STDINT_H_ // [
+#define _MSC_STDINT_H_
+
+#if _MSC_VER > 1000
+#pragma once
+#endif
+
+#include <limits.h>
+
+// For Visual Studio 6 in C++ mode and for many Visual Studio versions when
+// compiling for ARM we should wrap <wchar.h> include with 'extern "C++" {}'
+// or compiler give many errors like this:
+//   error C2733: second C linkage of overloaded function 'wmemchr' not allowed
+#ifdef __cplusplus
+extern "C" {
+#endif
+#  include <wchar.h>
+#ifdef __cplusplus
+}
+#endif
+
+// Define _W64 macros to mark types changing their size, like intptr_t.
+#ifndef _W64
+#  if !defined(__midl) && (defined(_X86_) || defined(_M_IX86)) && _MSC_VER >= 1300
+#     define _W64 __w64
+#  else
+#     define _W64
+#  endif
+#endif
+
+
+// 7.18.1 Integer types
+
+// 7.18.1.1 Exact-width integer types
+
+// Visual Studio 6 and Embedded Visual C++ 4 doesn't
+// realize that, e.g. char has the same size as __int8
+// so we give up on __intX for them.
+#if (_MSC_VER < 1300)
+   typedef char              int8_t;
+   typedef short             int16_t;
+   typedef int               int32_t;
+   typedef unsigned char     uint8_t;
+   typedef unsigned short    uint16_t;
+   typedef unsigned int      uint32_t;
+#else
+   typedef __int8            int8_t;
+   typedef __int16           int16_t;
+   typedef __int32           int32_t;
+   typedef unsigned __int8   uint8_t;
+   typedef unsigned __int16  uint16_t;
+   typedef unsigned __int32  uint32_t;
+#endif
+typedef __int64              int64_t;
+typedef unsigned __int64     uint64_t;
+
+
+// 7.18.1.2 Minimum-width integer types
+typedef int8_t    int_least8_t;
+typedef int16_t   int_least16_t;
+typedef int32_t   int_least32_t;
+typedef int64_t   int_least64_t;
+typedef uint8_t   uint_least8_t;
+typedef uint16_t  uint_least16_t;
+typedef uint32_t  uint_least32_t;
+typedef uint64_t  uint_least64_t;
+
+// 7.18.1.3 Fastest minimum-width integer types
+typedef int8_t    int_fast8_t;
+typedef int16_t   int_fast16_t;
+typedef int32_t   int_fast32_t;
+typedef int64_t   int_fast64_t;
+typedef uint8_t   uint_fast8_t;
+typedef uint16_t  uint_fast16_t;
+typedef uint32_t  uint_fast32_t;
+typedef uint64_t  uint_fast64_t;
+
+// 7.18.1.4 Integer types capable of holding object pointers
+#ifdef _WIN64 // [
+   typedef __int64           intptr_t;
+   typedef unsigned __int64  uintptr_t;
+#else // _WIN64 ][
+   typedef _W64 int               intptr_t;
+   typedef _W64 unsigned int      uintptr_t;
+#endif // _WIN64 ]
+
+// 7.18.1.5 Greatest-width integer types
+typedef int64_t   intmax_t;
+typedef uint64_t  uintmax_t;
+
+
+// 7.18.2 Limits of specified-width integer types
+
+#if !defined(__cplusplus) || defined(__STDC_LIMIT_MACROS) // [   See footnote 220 at page 257 and footnote 221 at page 259
+
+// 7.18.2.1 Limits of exact-width integer types
+#define INT8_MIN     ((int8_t)_I8_MIN)
+#define INT8_MAX     _I8_MAX
+#define INT16_MIN    ((int16_t)_I16_MIN)
+#define INT16_MAX    _I16_MAX
+#define INT32_MIN    ((int32_t)_I32_MIN)
+#define INT32_MAX    _I32_MAX
+#define INT64_MIN    ((int64_t)_I64_MIN)
+#define INT64_MAX    _I64_MAX
+#define UINT8_MAX    _UI8_MAX
+#define UINT16_MAX   _UI16_MAX
+#define UINT32_MAX   _UI32_MAX
+#define UINT64_MAX   _UI64_MAX
+
+// 7.18.2.2 Limits of minimum-width integer types
+#define INT_LEAST8_MIN    INT8_MIN
+#define INT_LEAST8_MAX    INT8_MAX
+#define INT_LEAST16_MIN   INT16_MIN
+#define INT_LEAST16_MAX   INT16_MAX
+#define INT_LEAST32_MIN   INT32_MIN
+#define INT_LEAST32_MAX   INT32_MAX
+#define INT_LEAST64_MIN   INT64_MIN
+#define INT_LEAST64_MAX   INT64_MAX
+#define UINT_LEAST8_MAX   UINT8_MAX
+#define UINT_LEAST16_MAX  UINT16_MAX
+#define UINT_LEAST32_MAX  UINT32_MAX
+#define UINT_LEAST64_MAX  UINT64_MAX
+
+// 7.18.2.3 Limits of fastest minimum-width integer types
+#define INT_FAST8_MIN    INT8_MIN
+#define INT_FAST8_MAX    INT8_MAX
+#define INT_FAST16_MIN   INT16_MIN
+#define INT_FAST16_MAX   INT16_MAX
+#define INT_FAST32_MIN   INT32_MIN
+#define INT_FAST32_MAX   INT32_MAX
+#define INT_FAST64_MIN   INT64_MIN
+#define INT_FAST64_MAX   INT64_MAX
+#define UINT_FAST8_MAX   UINT8_MAX
+#define UINT_FAST16_MAX  UINT16_MAX
+#define UINT_FAST32_MAX  UINT32_MAX
+#define UINT_FAST64_MAX  UINT64_MAX
+
+// 7.18.2.4 Limits of integer types capable of holding object pointers
+#ifdef _WIN64 // [
+#  define INTPTR_MIN   INT64_MIN
+#  define INTPTR_MAX   INT64_MAX
+#  define UINTPTR_MAX  UINT64_MAX
+#else // _WIN64 ][
+#  define INTPTR_MIN   INT32_MIN
+#  define INTPTR_MAX   INT32_MAX
+#  define UINTPTR_MAX  UINT32_MAX
+#endif // _WIN64 ]
+
+// 7.18.2.5 Limits of greatest-width integer types
+#define INTMAX_MIN   INT64_MIN
+#define INTMAX_MAX   INT64_MAX
+#define UINTMAX_MAX  UINT64_MAX
+
+// 7.18.3 Limits of other integer types
+
+#ifdef _WIN64 // [
+#  define PTRDIFF_MIN  _I64_MIN
+#  define PTRDIFF_MAX  _I64_MAX
+#else  // _WIN64 ][
+#  define PTRDIFF_MIN  _I32_MIN
+#  define PTRDIFF_MAX  _I32_MAX
+#endif  // _WIN64 ]
+
+#define SIG_ATOMIC_MIN  INT_MIN
+#define SIG_ATOMIC_MAX  INT_MAX
+
+#ifndef SIZE_MAX // [
+#  ifdef _WIN64 // [
+#     define SIZE_MAX  _UI64_MAX
+#  else // _WIN64 ][
+#     define SIZE_MAX  _UI32_MAX
+#  endif // _WIN64 ]
+#endif // SIZE_MAX ]
+
+// WCHAR_MIN and WCHAR_MAX are also defined in <wchar.h>
+#ifndef WCHAR_MIN // [
+#  define WCHAR_MIN  0
+#endif  // WCHAR_MIN ]
+#ifndef WCHAR_MAX // [
+#  define WCHAR_MAX  _UI16_MAX
+#endif  // WCHAR_MAX ]
+
+#define WINT_MIN  0
+#define WINT_MAX  _UI16_MAX
+
+#endif // __STDC_LIMIT_MACROS ]
+
+
+// 7.18.4 Limits of other integer types
+
+#if !defined(__cplusplus) || defined(__STDC_CONSTANT_MACROS) // [   See footnote 224 at page 260
+
+// 7.18.4.1 Macros for minimum-width integer constants
+
+#define INT8_C(val)  val##i8
+#define INT16_C(val) val##i16
+#define INT32_C(val) val##i32
+#define INT64_C(val) val##i64
+
+#define UINT8_C(val)  val##ui8
+#define UINT16_C(val) val##ui16
+#define UINT32_C(val) val##ui32
+#define UINT64_C(val) val##ui64
+
+// 7.18.4.2 Macros for greatest-width integer constants
+#define INTMAX_C   INT64_C
+#define UINTMAX_C  UINT64_C
+
+#endif // __STDC_CONSTANT_MACROS ]
+
+
+#endif // _MSC_STDINT_H_ ]


### PR DESCRIPTION
This has been discussed before but I thought I might actually code something up and test it out. If someone else has done more research or working on this type of stuff previously then please provide your input.

After looking at the various options I decided to implement just NAT-PMP. In part because it's much cleaner and easier to do compared to UPnP. And if I was going to implement just one then NAT-PMP seems like the better option. PCP, the large-scale successor to small-scale NAT-PMP, should also let us get through carrier-grade NAT, which is another reason I went with NAT-PMP (although it's all gateway dependent). The only reason I can see to implement UPnP as well just for compatibility with routers that don't support NAT-PMP or just don't have it enabled.

Regardless of whether it's NAT-PMP or UPnP it still requires router/gateway support, plus actually being enabled. So there still might be something required on the user's side. Everything after that is automatic however, with firewall and DNAT rules being added and removed as needed.

Further reading for the curious:
[NAT-PMP](https://en.wikipedia.org/wiki/NAT_Port_Mapping_Protocol)
[PCP](https://en.wikipedia.org/wiki/Port_Control_Protocol)
[UPnP-IGD](https://en.wikipedia.org/wiki/Internet_Gateway_Device_Protocol)