### PR TITLE
switch to using winsock2

### DIFF
--- a/cmake/platform-win32.cmake
+++ b/cmake/platform-win32.cmake
@@ -8,7 +8,7 @@ SET(WIN32_LIBS
 	odbccp32
 	vfw32
 	winmm
-	wsock32
+	ws2_32
 	psapi
 )
 

--- a/code/bmpman/bmpman.cpp
+++ b/code/bmpman/bmpman.cpp
@@ -10,6 +10,7 @@
 #define BMPMAN_NDEBUG
 #endif
 
+#define WIN32_LEAN_AND_MEAN
 #define BMPMAN_INTERNAL
 
 #include "anim/animplay.h"

--- a/code/bmpman/bmpman.cpp
+++ b/code/bmpman/bmpman.cpp
@@ -12,10 +12,6 @@
 
 #define BMPMAN_INTERNAL
 
-#ifdef _WIN32
-#include <windows.h>
-#endif
-
 #include "anim/animplay.h"
 #include "anim/packunpack.h"
 #include "bmpman/bm_internal.h"

--- a/code/inetfile/cftp.cpp
+++ b/code/inetfile/cftp.cpp
@@ -13,10 +13,7 @@
 
 #include "globalincs/pstypes.h"
 
-#ifdef WIN32
-#include <windows.h>
-#include <process.h>
-#else
+#ifndef WIN32
 #include <sys/time.h>
 #include <sys/types.h>
 #include <sys/socket.h>
@@ -361,15 +358,6 @@ uint CFtpGet::IssuePort()
 	}
 				
 	// Format the PORT command with the correct numbers.
-#ifdef WIN32
-	sprintf(szCommandString, "PORT %d,%d,%d,%d,%d,%d\r\n", 
-				listenaddr.sin_addr.S_un.S_un_b.s_b1, 
-				listenaddr.sin_addr.S_un.S_un_b.s_b2,
-				listenaddr.sin_addr.S_un.S_un_b.s_b3,
-				listenaddr.sin_addr.S_un.S_un_b.s_b4,
-				nLocalPort & 0xFF,	
-				nLocalPort >> 8);
-#else
 	sprintf(szCommandString, "PORT %d,%d,%d,%d,%d,%d\r\n", 
 			  (listenaddr.sin_addr.s_addr & 0xff000000) >> 24,
 			  (listenaddr.sin_addr.s_addr & 0x00ff0000) >> 16,
@@ -377,7 +365,6 @@ uint CFtpGet::IssuePort()
 			  (listenaddr.sin_addr.s_addr & 0x000000ff),
 				nLocalPort & 0xFF,	
 				nLocalPort >> 8);
-#endif
 
 	// Tell the server which port to use for data.
 	nReplyCode = SendFTPCommand(szCommandString);
@@ -575,11 +562,7 @@ void CFtpGet::FlushControlChannel()
 	FD_ZERO(&read_fds);
 	FD_SET(m_ControlSock, &read_fds);    
 
-#ifdef WIN32
-	while ( select(0, &read_fds, NULL, NULL, &timeout) )
-#else
-	while ( select(m_ControlSock+1, &read_fds, NULL, NULL, &timeout) )
-#endif
+	while ( select(m_ControlSock+1, &read_fds, nullptr, nullptr, &timeout) )
 	{
 		recv(m_ControlSock,flushbuff,1,0);
 

--- a/code/inetfile/cftp.cpp
+++ b/code/inetfile/cftp.cpp
@@ -562,7 +562,7 @@ void CFtpGet::FlushControlChannel()
 	FD_ZERO(&read_fds);
 	FD_SET(m_ControlSock, &read_fds);    
 
-	while ( select(m_ControlSock+1, &read_fds, nullptr, nullptr, &timeout) )
+	while ( select(static_cast<int>(m_ControlSock+1), &read_fds, nullptr, nullptr, &timeout) )
 	{
 		recv(m_ControlSock,flushbuff,1,0);
 

--- a/code/inetfile/cftp.cpp
+++ b/code/inetfile/cftp.cpp
@@ -358,13 +358,13 @@ uint CFtpGet::IssuePort()
 	}
 				
 	// Format the PORT command with the correct numbers.
-	sprintf(szCommandString, "PORT %d,%d,%d,%d,%d,%d\r\n", 
-			  (listenaddr.sin_addr.s_addr & 0xff000000) >> 24,
-			  (listenaddr.sin_addr.s_addr & 0x00ff0000) >> 16,
-			  (listenaddr.sin_addr.s_addr & 0x0000ff00) >>  8,
-			  (listenaddr.sin_addr.s_addr & 0x000000ff),
-				nLocalPort & 0xFF,	
-				nLocalPort >> 8);
+	sprintf(szCommandString, "PORT %d,%d,%d,%d,%d,%d\r\n",
+				static_cast<int>((listenaddr.sin_addr.s_addr >> 0)  & 0xFF),
+				static_cast<int>((listenaddr.sin_addr.s_addr >> 8)  & 0xFF),
+				static_cast<int>((listenaddr.sin_addr.s_addr >> 16) & 0xFF),
+				static_cast<int>((listenaddr.sin_addr.s_addr >> 24) & 0xFF),
+				nLocalPort >> 8,
+				nLocalPort & 0xFF);
 
 	// Tell the server which port to use for data.
 	nReplyCode = SendFTPCommand(szCommandString);

--- a/code/inetfile/cftp.h
+++ b/code/inetfile/cftp.h
@@ -17,7 +17,7 @@
 #include <cstdio>
 
 #ifdef WIN32
-#include <winsock.h>
+#include <winsock2.h>
 #endif
  
 #define FTP_STATE_INTERNAL_ERROR		0

--- a/code/inetfile/chttpget.cpp
+++ b/code/inetfile/chttpget.cpp
@@ -393,7 +393,7 @@ int ChttpGet::ConnectSocket()
 			FD_ZERO(&wfds);
 			FD_SET( m_DataSock, &wfds );
 
-			if ( select(m_DataSock+1, nullptr, &wfds, nullptr, &timeout) )
+			if ( select(static_cast<int>(m_DataSock+1), nullptr, &wfds, nullptr, &timeout) )
 			{
 				serr = 0;
 				break;
@@ -518,7 +518,7 @@ uint ChttpGet::ReadDataChannel()
 		if ( (m_iBytesTotal) && (m_iBytesIn == m_iBytesTotal) )
 			break;
 
-		select(m_DataSock+1, &wfds, nullptr, nullptr, &timeout);
+		select(static_cast<int>(m_DataSock+1), &wfds, nullptr, nullptr, &timeout);
 	
     	if (m_Aborting) {
 			fclose(LOCALFILE);

--- a/code/inetfile/chttpget.cpp
+++ b/code/inetfile/chttpget.cpp
@@ -12,10 +12,7 @@
 
 #include "globalincs/pstypes.h"
 
-#ifdef _WIN32
-#include <windows.h>
-#include <process.h>
-#else
+#ifndef _WIN32
 #include <sys/time.h>
 #include <sys/types.h>
 #include <sys/socket.h>
@@ -396,11 +393,7 @@ int ChttpGet::ConnectSocket()
 			FD_ZERO(&wfds);
 			FD_SET( m_DataSock, &wfds );
 
-#ifdef WIN32
-			if ( select(0, NULL, &wfds, NULL, &timeout) )
-#else
-			if ( select(m_DataSock+1, NULL, &wfds, NULL, &timeout) )
-#endif
+			if ( select(m_DataSock+1, nullptr, &wfds, nullptr, &timeout) )
 			{
 				serr = 0;
 				break;
@@ -525,11 +518,7 @@ uint ChttpGet::ReadDataChannel()
 		if ( (m_iBytesTotal) && (m_iBytesIn == m_iBytesTotal) )
 			break;
 
-#ifdef WIN32
-		select(0, &wfds, NULL, NULL, &timeout);
-#else
-		select(m_DataSock+1, &wfds, NULL, NULL, &timeout);
-#endif
+		select(m_DataSock+1, &wfds, nullptr, nullptr, &timeout);
 	
     	if (m_Aborting) {
 			fclose(LOCALFILE);

--- a/code/inetfile/inetgetfile.cpp
+++ b/code/inetfile/inetgetfile.cpp
@@ -11,10 +11,6 @@
 
 #include "globalincs/pstypes.h"
 
-#ifdef _WIN32
-#include <windows.h>
-#include <direct.h>
-#endif
 #include <cstdio>
 #include <cstring>
 

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -9,10 +9,6 @@
 
 
 
-#ifdef _WIN32
-#include <windows.h>
-#endif
-
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>

--- a/code/network/chat_api.cpp
+++ b/code/network/chat_api.cpp
@@ -26,7 +26,7 @@
 
 #define WSAGetLastError()  (errno)
 #else
-#include <winsock.h>
+#include <winsock2.h>
 typedef int socklen_t;
 #endif
 
@@ -475,11 +475,7 @@ char *ChatGetString(void)
 	FD_ZERO(&read_fds);
 	FD_SET(Chatsock,&read_fds);    
 	//Writable -- that means it's connected
-#ifdef WIN32
-	while ( select(0, &read_fds, NULL, NULL, &timeout) )
-#else
-	while ( select(Chatsock+1, &read_fds, NULL, NULL, &timeout) )
-#endif
+	while ( select(Chatsock+1, &read_fds, nullptr, nullptr, &timeout) )
 	{
 		bytesread = recv(Chatsock,ch,1,0);
 		if(bytesread)

--- a/code/network/chat_api.cpp
+++ b/code/network/chat_api.cpp
@@ -475,7 +475,7 @@ char *ChatGetString(void)
 	FD_ZERO(&read_fds);
 	FD_SET(Chatsock,&read_fds);    
 	//Writable -- that means it's connected
-	while ( select(Chatsock+1, &read_fds, nullptr, nullptr, &timeout) )
+	while ( select(static_cast<int>(Chatsock+1), &read_fds, nullptr, nullptr, &timeout) )
 	{
 		bytesread = recv(Chatsock,ch,1,0);
 		if(bytesread)

--- a/code/network/multi_pxo.cpp
+++ b/code/network/multi_pxo.cpp
@@ -10,7 +10,7 @@
 
 
 #ifdef _WIN32
-#include <winsock.h>
+#include <winsock2.h>
 #endif
 
 #include "network/multi_pxo.h"

--- a/code/network/multilag.cpp
+++ b/code/network/multilag.cpp
@@ -11,7 +11,7 @@
 
 #ifndef SCP_UNIX
 
-#include <winsock.h>
+#include <winsock2.h>
 
 #include "network/multilag.h"
 #include "io/timer.h"

--- a/code/network/multiui.cpp
+++ b/code/network/multiui.cpp
@@ -11,7 +11,7 @@
 
 
 #ifdef _WIN32
-#include <winsock.h>	// for inet_addr()
+#include <winsock2.h>	// for inet_addr()
 #else
 #include <arpa/inet.h>
 #include <netinet/in.h>

--- a/code/network/multiutil.cpp
+++ b/code/network/multiutil.cpp
@@ -11,7 +11,7 @@
 
 
 #if defined _WIN32
-#include <winsock.h>
+#include <winsock2.h>
 #elif defined SCP_UNIX
 #include <sys/types.h>
 #include <sys/socket.h>

--- a/code/network/psnet2.cpp
+++ b/code/network/psnet2.cpp
@@ -378,7 +378,7 @@ void PSNET_TOP_LAYER_PROCESS()
 		timeout.tv_sec = 0;
 		timeout.tv_usec = 0;
 
-		if ( select( Unreliable_socket + 1, &rfds, nullptr, nullptr, &timeout) == SOCKET_ERROR ) {
+		if ( select( static_cast<int>(Unreliable_socket + 1), &rfds, nullptr, nullptr, &timeout) == SOCKET_ERROR ) {
 			ml_printf("Error %d doing a socket select on read", WSAGetLastError());
 			break;
 		}
@@ -818,7 +818,7 @@ int psnet_send( net_addr * who_to, void * data, int len, int np_index )
 	timeout.tv_sec = 0;
 	timeout.tv_usec = 0;
 
-	if ( SELECT( send_sock+1, nullptr, &wfds, nullptr, &timeout, PSNET_TYPE_UNRELIABLE) == SOCKET_ERROR ) {
+	if ( SELECT( static_cast<int>(send_sock+1), nullptr, &wfds, nullptr, &timeout, PSNET_TYPE_UNRELIABLE) == SOCKET_ERROR ) {
 		ml_printf("Error on blocking select for write %d", WSAGetLastError() );
 		return 0;
 	}
@@ -1222,7 +1222,7 @@ void psnet_rel_work()
 		if(Tcp_active && (Socket_type == NET_TCP)){
 			FD_ZERO(&read_fds);
 			FD_SET(Unreliable_socket, &read_fds);    
-			udp_has_data = SELECT(Unreliable_socket+1, &read_fds, nullptr, nullptr, &timeout, PSNET_TYPE_RELIABLE);
+			udp_has_data = SELECT(static_cast<int>(Unreliable_socket+1), &read_fds, nullptr, nullptr, &timeout, PSNET_TYPE_RELIABLE);
 		}
 		bytesin = 0;
 		addrlen = sizeof(SOCKADDR);
@@ -1595,7 +1595,7 @@ void psnet_rel_connect_to_server(PSNET_SOCKET *socket, net_addr *server_addr)
 	if(Tcp_active && (Socket_type == NET_TCP)){
 		FD_ZERO(&read_fds);
 		FD_SET(Unreliable_socket, &read_fds);    
-		while(SELECT(Unreliable_socket+1, &read_fds, nullptr, nullptr, &timeout, PSNET_TYPE_RELIABLE)){
+		while(SELECT(static_cast<int>(Unreliable_socket+1), &read_fds, nullptr, nullptr, &timeout, PSNET_TYPE_RELIABLE)){
 			addrlen = sizeof(SOCKADDR);
 			bytesin = RECVFROM(Unreliable_socket, (char *)&ack_header,sizeof(reliable_header),0,(SOCKADDR *)&rcv_addr,&addrlen, PSNET_TYPE_RELIABLE);
 			if(bytesin==-1){
@@ -1644,7 +1644,7 @@ void psnet_rel_connect_to_server(PSNET_SOCKET *socket, net_addr *server_addr)
 
 		FD_ZERO(&read_fds);
 		FD_SET(typeless_sock, &read_fds);    		
-		if(SELECT(typeless_sock+1, &read_fds, nullptr, nullptr, &timeout, PSNET_TYPE_RELIABLE)){
+		if(SELECT(static_cast<int>(typeless_sock+1), &read_fds, nullptr, nullptr, &timeout, PSNET_TYPE_RELIABLE)){
 			ml_string("selected() in psnet_rel_connect_to_server()");
 
 			addrlen = sizeof(SOCKADDR);

--- a/code/network/psnet2.cpp
+++ b/code/network/psnet2.cpp
@@ -11,10 +11,7 @@
 
 
 #ifdef _WIN32
-#include <windows.h>
-#include <windowsx.h>
-#include <winsock.h>
-#include <process.h>
+#include <winsock2.h>
 #include <ras.h>
 #include <raserror.h>
 #else
@@ -293,11 +290,7 @@ int RECVFROM(SOCKET  /*s*/, char *buf, int  /*len*/, int  /*flags*/, sockaddr *f
 	switch ( Socket_type ) {
 	case NET_TCP:			
 		((SOCKADDR_IN*)from)->sin_port = htons(addr.port);
-#ifdef _WIN32
-		memcpy(&((SOCKADDR_IN*)from)->sin_addr.S_un.S_addr, addr.addr, 4);		
-#else
-		memcpy(&((SOCKADDR_IN*)from)->sin_addr.s_addr, addr.addr, 4);		
-#endif
+		memcpy(&(reinterpret_cast<SOCKADDR_IN *>(from))->sin_addr.s_addr, addr.addr, 4);
 		((SOCKADDR_IN*)from)->sin_family = AF_INET;
 		*fromlen = sizeof(SOCKADDR_IN);
 		break;
@@ -385,11 +378,7 @@ void PSNET_TOP_LAYER_PROCESS()
 		timeout.tv_sec = 0;
 		timeout.tv_usec = 0;
 
-#ifdef _WIN32
-		if ( select( -1, &rfds, NULL, NULL, &timeout) == SOCKET_ERROR ) {
-#else
-		if ( select( Unreliable_socket + 1, &rfds, NULL, NULL, &timeout) == SOCKET_ERROR ) {
-#endif
+		if ( select( Unreliable_socket + 1, &rfds, nullptr, nullptr, &timeout) == SOCKET_ERROR ) {
 			ml_printf("Error %d doing a socket select on read", WSAGetLastError());
 			break;
 		}
@@ -419,11 +408,7 @@ void PSNET_TOP_LAYER_PROCESS()
 		case NET_TCP:			
 			from_addr.port = ntohs( ip_addr.sin_port );			
 			memset(from_addr.addr, 0x00, 6);
-#ifdef _WIN32
-			memcpy(from_addr.addr, &ip_addr.sin_addr.S_un.S_addr, 4); //-V512
-#else
 			memcpy(from_addr.addr, &ip_addr.sin_addr.s_addr, 4); //-V512
-#endif
 			break;
 
 		default:
@@ -636,11 +621,7 @@ int psnet_use_protocol( int protocol )
 		if (custom_ip != NULL) {
 			SOCKADDR_IN custom_address;
 
-#ifndef WIN32
-			if ( inet_aton(custom_ip, &custom_address.sin_addr) ) {
-#else
 			if ( (custom_address.sin_addr.s_addr = inet_addr(custom_ip)) != INADDR_NONE ) {
-#endif
 				memcpy(&ip_addr.sin_addr, &custom_address.sin_addr, sizeof(custom_address.sin_addr));
 			} else {
 				ml_printf("WARNING  =>  psnet_get_ip() custom IP is invalid: %s", custom_ip);
@@ -837,11 +818,7 @@ int psnet_send( net_addr * who_to, void * data, int len, int np_index )
 	timeout.tv_sec = 0;
 	timeout.tv_usec = 0;
 
-#ifdef _WIN32
-	if ( SELECT( -1, NULL, &wfds, NULL, &timeout, PSNET_TYPE_UNRELIABLE) == SOCKET_ERROR ) {
-#else
-	if ( SELECT( send_sock+1, NULL, &wfds, NULL, &timeout, PSNET_TYPE_UNRELIABLE) == SOCKET_ERROR ) {
-#endif
+	if ( SELECT( send_sock+1, nullptr, &wfds, nullptr, &timeout, PSNET_TYPE_UNRELIABLE) == SOCKET_ERROR ) {
 		ml_printf("Error on blocking select for write %d", WSAGetLastError() );
 		return 0;
 	}
@@ -1245,11 +1222,7 @@ void psnet_rel_work()
 		if(Tcp_active && (Socket_type == NET_TCP)){
 			FD_ZERO(&read_fds);
 			FD_SET(Unreliable_socket, &read_fds);    
-#ifdef _WIN32
-			udp_has_data = SELECT(0,&read_fds,NULL,NULL,&timeout, PSNET_TYPE_RELIABLE);
-#else
-			udp_has_data = SELECT(Unreliable_socket+1, &read_fds,NULL,NULL,&timeout, PSNET_TYPE_RELIABLE);
-#endif
+			udp_has_data = SELECT(Unreliable_socket+1, &read_fds, nullptr, nullptr, &timeout, PSNET_TYPE_RELIABLE);
 		}
 		bytesin = 0;
 		addrlen = sizeof(SOCKADDR);
@@ -1569,11 +1542,7 @@ int psnet_rel_check_for_listen(net_addr *from_addr)
 				memset(from_addr, 0x00, sizeof(net_addr));
 				from_addr->port = ntohs( ip_addr->sin_port );
 				from_addr->type = NET_TCP;
-#ifdef _WIN32
-				memcpy(from_addr->addr, &ip_addr->sin_addr.S_un.S_addr, 4); //-V512
-#else
 				memcpy(from_addr->addr, &ip_addr->sin_addr.s_addr, 4); //-V512
-#endif
 				break;
 			
 			default:
@@ -1626,11 +1595,7 @@ void psnet_rel_connect_to_server(PSNET_SOCKET *socket, net_addr *server_addr)
 	if(Tcp_active && (Socket_type == NET_TCP)){
 		FD_ZERO(&read_fds);
 		FD_SET(Unreliable_socket, &read_fds);    
-#ifdef _WIN32
-		while(SELECT(0, &read_fds, NULL, NULL, &timeout, PSNET_TYPE_RELIABLE)){
-#else
-		while(SELECT(Unreliable_socket+1, &read_fds, NULL, NULL, &timeout, PSNET_TYPE_RELIABLE)){
-#endif
+		while(SELECT(Unreliable_socket+1, &read_fds, nullptr, nullptr, &timeout, PSNET_TYPE_RELIABLE)){
 			addrlen = sizeof(SOCKADDR);
 			bytesin = RECVFROM(Unreliable_socket, (char *)&ack_header,sizeof(reliable_header),0,(SOCKADDR *)&rcv_addr,&addrlen, PSNET_TYPE_RELIABLE);
 			if(bytesin==-1){
@@ -1679,11 +1644,7 @@ void psnet_rel_connect_to_server(PSNET_SOCKET *socket, net_addr *server_addr)
 
 		FD_ZERO(&read_fds);
 		FD_SET(typeless_sock, &read_fds);    		
-#ifdef _WIN32
-		if(SELECT(0, &read_fds, NULL,NULL,&timeout, PSNET_TYPE_RELIABLE)){
-#else
-		if(SELECT(typeless_sock+1, &read_fds, NULL,NULL,&timeout, PSNET_TYPE_RELIABLE)){
-#endif
+		if(SELECT(typeless_sock+1, &read_fds, nullptr, nullptr, &timeout, PSNET_TYPE_RELIABLE)){
 			ml_string("selected() in psnet_rel_connect_to_server()");
 
 			addrlen = sizeof(SOCKADDR);

--- a/code/network/psnet2.h
+++ b/code/network/psnet2.h
@@ -14,7 +14,7 @@
 
 
 #ifdef _WIN32
-#include <winsock.h>
+#include <winsock2.h>
 #else
 #include <cerrno>
 #endif

--- a/code/network/stand_gui.cpp
+++ b/code/network/stand_gui.cpp
@@ -12,6 +12,7 @@
 #ifndef SCP_UNIX
 
 #ifdef _WIN32
+#include <winsock2.h>
 #include <windows.h>
 #include <commctrl.h>
 #endif

--- a/code/sound/voicerec.cpp
+++ b/code/sound/voicerec.cpp
@@ -27,6 +27,7 @@
 #include <cstdio>
 #pragma warning(pop)
 
+#define WIN32_LEAN_AND_MEAN
 
 #include <sphelper.h>                           // Contains definitions of SAPI functions
 #include <stdio.h>

--- a/code/stats/stats.cpp
+++ b/code/stats/stats.cpp
@@ -10,11 +10,6 @@
 
 
 
-#ifdef _WIN32
-#include <io.h>
-#include <winsock.h>
-#endif
-
 #include "globalincs/systemvars.h"
 #include "hud/hud.h"
 #include "network/multi.h"

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -11,9 +11,9 @@
 
 
 #ifdef _WIN32
+ #include <winsock2.h>	// required to prevent winsock 1.1 being used
  #include <direct.h>
  #include <io.h>
- #include <windows.h>
  #include <psapi.h>
 #ifndef _MINGW
  #include <crtdbg.h>

--- a/qtfred/src/ui/QtGraphicsOperations.h
+++ b/qtfred/src/ui/QtGraphicsOperations.h
@@ -4,6 +4,7 @@
 #include "mission/Editor.h"
 #include "FredView.h"
 
+#define WIN32_LEAN_AND_MEAN
 #include <QtGui/QOpenGLContext>
 
 namespace fso {

--- a/wxfred2/CMakeLists.txt
+++ b/wxfred2/CMakeLists.txt
@@ -98,7 +98,7 @@ elseif(MSVC)
 		odbccp32.lib
 		comctl32.lib
 		rpcrt4.lib
-		wsock32.lib
+		ws2_32.lib
 		winmm.lib
 	)
 	


### PR DESCRIPTION
This moves from winsock 1.1, which was deprecated 20 years ago, to winsock2. Some obsolete platform specific #ifdef's and unneeded windows headers were also removed.