### PR TITLE
Handle invalid Lua reference correctly

### DIFF
--- a/code/scripting/lua/LuaFunction.cpp
+++ b/code/scripting/lua/LuaFunction.cpp
@@ -71,6 +71,13 @@ LuaValueList LuaFunction::operator()(const LuaValueList& args) {
 }
 
 void LuaFunction::setReference(const LuaReference& ref) {
+	if (ref == nullptr)
+	{
+		// If not a valid reference then let the base class handle everything
+		LuaValue::setReference(ref);
+		return;
+	}
+
 	ref->pushValue();
 
 	lua_State* L = ref->getState();

--- a/code/scripting/lua/LuaValue.cpp
+++ b/code/scripting/lua/LuaValue.cpp
@@ -59,8 +59,7 @@ LuaValue& LuaValue::operator=(const LuaValue& other) {
 	return *this;
 }
 
-LuaValue::~LuaValue() {
-}
+LuaValue::~LuaValue() = default;
 
 void LuaValue::setReference(const LuaReference& ref) {
 	this->_reference = ref;

--- a/code/scripting/lua/LuaValue.h
+++ b/code/scripting/lua/LuaValue.h
@@ -170,7 +170,7 @@ class LuaValue {
 
 	LuaReference _reference;
 
-	ValueType _luaType;
+	ValueType _luaType = ValueType::NONE;
 };
 
 /**


### PR DESCRIPTION
This should never have worked but was only discovered by the recent
switch to the default copy constructors for some reason.