### PR TITLE
Makes slight adjustments to the lighting defaults.

### DIFF
--- a/code/cmdline/cmdline.cpp
+++ b/code/cmdline/cmdline.cpp
@@ -163,7 +163,7 @@ Flag exe_params[] =
 	{ "-nomotiondebris",	"Disable motion debris",					true,	EASY_ALL_ON,		EASY_DEFAULT,		"Graphics",		"http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-nomotiondebris",},
 	{ "-noscalevid",		"Disable scale-to-window for movies",		true,	0,					EASY_DEFAULT,		"Graphics",		"http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-noscalevid", },
 	{ "-nonormal",			"Disable normal maps",						true,	EASY_DEFAULT_MEM,	EASY_MEM_ALL_ON,	"Graphics",		"http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-normal" },
-	{ "-no_emissive_light",	"Disable emissive light from ships",		true,	0,					EASY_DEFAULT,		"Graphics",		"http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-no_emissive_light" },
+	{ "-emissive_light",	"Enable emissive light from ships",			true,	0,					EASY_DEFAULT,		"Graphics",		"http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-no_emissive_light" },
 	{ "-noheight",			"Disable height/parallax maps",				true,	EASY_DEFAULT_MEM,	EASY_MEM_ALL_ON,	"Graphics",		"http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-height" },
 	{ "-3dshockwave",		"Enable 3D shockwaves",						true,	EASY_MEM_ALL_ON,	EASY_DEFAULT_MEM,	"Graphics",		"http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-3dshockwave" },
 	{ "-post_process",		"Enable post processing",					true,	EASY_ALL_ON,		EASY_DEFAULT,		"Graphics",		"http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-post_process" },
@@ -317,7 +317,7 @@ cmdline_parm glow_arg("-noglow", NULL, AT_NONE); 						// Cmdline_glow  -- use B
 cmdline_parm nomotiondebris_arg("-nomotiondebris", NULL, AT_NONE);		// Cmdline_nomotiondebris  -- Removes those ugly floating rocks -C
 cmdline_parm noscalevid_arg("-noscalevid", NULL, AT_NONE);				// Cmdline_noscalevid  -- disable video scaling that fits to window
 cmdline_parm spec_arg("-nospec", NULL, AT_NONE);			// Cmdline_spec  --
-cmdline_parm noemissive_arg("-no_emissive_light", "Disable emissive light from ships", AT_NONE);		// Cmdline_no_emissive  -- don't use emissive light in OGL
+cmdline_parm emissive_arg("-emissive_light", "Enable emissive light from ships", AT_NONE);		// Cmdline_no_emissive  -- don't use emissive light in OGL
 cmdline_parm normal_arg("-nonormal", NULL, AT_NONE);						// Cmdline_normal  -- disable normal mapping
 cmdline_parm height_arg("-noheight", NULL, AT_NONE);						// Cmdline_height  -- enable support for parallax mapping
 cmdline_parm enable_3d_shockwave_arg("-3dshockwave", NULL, AT_NONE);
@@ -344,7 +344,7 @@ int Cmdline_mipmap = 0;
 int Cmdline_glow = 1;
 int Cmdline_noscalevid = 0;
 int Cmdline_spec = 1;
-int Cmdline_no_emissive = 0;
+int Cmdline_emissive = 0;
 int Cmdline_normal = 1;
 int Cmdline_height = 1;
 int Cmdline_enable_3d_shockwave = 0;
@@ -527,6 +527,7 @@ cmdline_parm deprecated_brieflighting_arg("-brief_lighting", "Deprecated", AT_NO
 cmdline_parm deprecated_sndpreload_arg("-snd_preload", "Deprecated", AT_NONE);
 cmdline_parm deprecated_missile_lighting_arg("-missile_lighting", "Deprecated", AT_NONE);
 cmdline_parm deprecated_cache_bitmaps_arg("-cache_bitmaps", "Deprecated", AT_NONE);
+cmdline_parm deprecated_no_emissive_arg("-no_emissive_light", "Deprecated", AT_NONE);
 
 int Cmdline_deprecated_spec = 0;
 int Cmdline_deprecated_glow = 0;
@@ -1987,8 +1988,8 @@ bool SetCmdlineParams()
 		Cmdline_no_fbo = 1;
 	}
 
-	if ( noemissive_arg.found() ) {
-		Cmdline_no_emissive = 1;
+	if ( emissive_arg.found() ) {
+		Cmdline_emissive = 1;
 	}
 
 	if ( ogl_spec_arg.found() ) {
@@ -2183,6 +2184,10 @@ bool SetCmdlineParams()
 		Cmdline_deprecated_cache_bitmaps = true;
 	}
 
+	if (deprecated_no_emissive_arg.found()) {
+		Cmdline_emissive = 1;
+	}
+ 
 	return true; 
 }
 

--- a/code/cmdline/cmdline.cpp
+++ b/code/cmdline/cmdline.cpp
@@ -349,7 +349,7 @@ int Cmdline_normal = 1;
 int Cmdline_height = 1;
 int Cmdline_enable_3d_shockwave = 0;
 int Cmdline_softparticles = 0;
-int Cmdline_bloom_intensity = 75;
+int Cmdline_bloom_intensity = 25;
 extern bool ls_force_off;
 int Cmdline_no_deferred_lighting = 0;
 int Cmdline_aniso_level = 0;

--- a/code/cmdline/cmdline.cpp
+++ b/code/cmdline/cmdline.cpp
@@ -163,7 +163,7 @@ Flag exe_params[] =
 	{ "-nomotiondebris",	"Disable motion debris",					true,	EASY_ALL_ON,		EASY_DEFAULT,		"Graphics",		"http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-nomotiondebris",},
 	{ "-noscalevid",		"Disable scale-to-window for movies",		true,	0,					EASY_DEFAULT,		"Graphics",		"http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-noscalevid", },
 	{ "-nonormal",			"Disable normal maps",						true,	EASY_DEFAULT_MEM,	EASY_MEM_ALL_ON,	"Graphics",		"http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-normal" },
-	{ "-emissive_light",	"Enable emissive light from ships",			true,	0,					EASY_DEFAULT,		"Graphics",		"http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-no_emissive_light" },
+	{ "-emissive_light",	"Enable emissive light from ships",			true,	0,					EASY_DEFAULT,		"Graphics",		"http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-emissive_light" },
 	{ "-noheight",			"Disable height/parallax maps",				true,	EASY_DEFAULT_MEM,	EASY_MEM_ALL_ON,	"Graphics",		"http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-height" },
 	{ "-3dshockwave",		"Enable 3D shockwaves",						true,	EASY_MEM_ALL_ON,	EASY_DEFAULT_MEM,	"Graphics",		"http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-3dshockwave" },
 	{ "-post_process",		"Enable post processing",					true,	EASY_ALL_ON,		EASY_DEFAULT,		"Graphics",		"http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-post_process" },

--- a/code/cmdline/cmdline.h
+++ b/code/cmdline/cmdline.h
@@ -70,7 +70,7 @@ extern int Cmdline_enable_3d_shockwave;
 extern int Cmdline_softparticles;
 extern int Cmdline_bloom_intensity;
 extern int Cmdline_no_deferred_lighting;
-extern int Cmdline_no_emissive;
+extern int Cmdline_emissive;
 extern int Cmdline_aniso_level;
 
 // Game Speed related

--- a/code/graphics/uniforms.cpp
+++ b/code/graphics/uniforms.cpp
@@ -89,7 +89,7 @@ void convert_model_material(model_uniform_data* data_out,
 		CLAMP(data_out->ambientFactor.xyz.y, 0.02f, 1.0f);
 		CLAMP(data_out->ambientFactor.xyz.z, 0.02f, 1.0f);
 
-		if (material.get_light_factor() > 0.25f && !Cmdline_no_emissive) {
+		if (material.get_light_factor() > 0.25f && Cmdline_emissive) {
 			data_out->emissionFactor.xyz.x = gr_light_emission[0];
 			data_out->emissionFactor.xyz.y = gr_light_emission[1];
 			data_out->emissionFactor.xyz.z = gr_light_emission[2];

--- a/code/lab/lab.cpp
+++ b/code/lab/lab.cpp
@@ -147,7 +147,7 @@ bool Lab_Envmap_override         = false;
 bool Lab_Normalmap_override      = false;
 bool Lab_Heightmap_override      = false;
 bool Lab_Miscmap_override        = false;
-bool Lab_emissive_light_override = !Cmdline_no_emissive;
+bool Lab_emissive_light_override = Cmdline_emissive;
 
 fix Lab_Save_Missiontime;
 
@@ -407,14 +407,14 @@ void labviewer_render_model(float frametime)
 		auto lab_render_light_save    = Lab_render_without_light;
 		auto lab_debris_override_save = Motion_debris_enabled;
 		auto lab_envmap_override_save = Envmap_override;
-		auto lab_emissive_light_save  = Cmdline_no_emissive;
+		auto lab_emissive_light_save  = Cmdline_emissive;
 
 		if (Lab_selected_mission == "None") {
 			Lab_render_without_light = true;
 			Motion_debris_enabled    = true;
 		}
 
-		Cmdline_no_emissive = !Lab_emissive_light_override;
+		Cmdline_emissive = !Lab_emissive_light_override;
 
 		object* obj = &Objects[Lab_selected_object];
 
@@ -466,7 +466,7 @@ void labviewer_render_model(float frametime)
 		Lab_render_without_light = lab_render_light_save;
 		Motion_debris_enabled    = lab_debris_override_save;
 		Envmap_override          = lab_envmap_override_save;
-		Cmdline_no_emissive      = lab_emissive_light_save;
+		Cmdline_emissive      = lab_emissive_light_save;
 
 		gr_reset_clip();
 		gr_set_color_fast(&HUD_color_debug);

--- a/code/lab/lab.cpp
+++ b/code/lab/lab.cpp
@@ -414,7 +414,7 @@ void labviewer_render_model(float frametime)
 			Motion_debris_enabled    = true;
 		}
 
-		Cmdline_emissive = !Lab_emissive_light_override;
+		Cmdline_emissive = Lab_emissive_light_override;
 
 		object* obj = &Objects[Lab_selected_object];
 


### PR DESCRIPTION
This commit disables emissive lighting on objects by default (as the new HDR process makes it unnecessary) and switches the -no-emissive commandline parameter to -emissive; Setting that parameter will restore the old behaviour. The -no-emissive parameter is retained to avoid user-facing error messages.
In addition, this commit sets the default bloom value to 25.