### PR TITLE
add $Never Viewable flag for cutscenes

### DIFF
--- a/code/cutscene/cutscenes.cpp
+++ b/code/cutscene/cutscenes.cpp
@@ -450,7 +450,7 @@ void cutscenes_screen_init()
 	Cutscene_list.clear();
 
 	int u = 0;
-	for (SCP_vector<cutscene_info>::iterator cut = Cutscenes.begin(); cut != Cutscenes.end(); ++cut, ++u)
+	for (auto cut = Cutscenes.begin(); cut != Cutscenes.end(); ++cut, ++u)
 	{
 		int flags = (*cut).flags;
 

--- a/code/cutscene/cutscenes.cpp
+++ b/code/cutscene/cutscenes.cpp
@@ -452,7 +452,7 @@ void cutscenes_screen_init()
 	int u = 0;
 	for (auto cut = Cutscenes.begin(); cut != Cutscenes.end(); ++cut, ++u)
 	{
-		if ((cut->flags[Cutscene::Cutscene_Flags::Viewable] || cut->flags[Cutscene::Cutscene_Flags::Always_viewable]) && !cut->flags[Cutscene::Cutscene_Flags::Never_viewable])
+		if (cut->flags[Cutscene::Cutscene_Flags::Viewable, Cutscene::Cutscene_Flags::Always_viewable] && !cut->flags[Cutscene::Cutscene_Flags::Never_viewable])
 		{
 			Cutscene_list.push_back(u);
 		}

--- a/code/cutscene/cutscenes.cpp
+++ b/code/cutscene/cutscenes.cpp
@@ -88,13 +88,13 @@ void cutscene_init()
 				stuff_int(&junk);
 			}
 
-			cutinfo.flags = 0;
+			cutinfo.flags.reset();
 
 			if (isFirstCutscene)
 			{
 				isFirstCutscene = false;
 				// The original code assumes the first movie is the intro, so make it viewable
-				cutinfo.flags |= CF_VIEWABLE;
+				cutinfo.flags.set(Cutscene::Cutscene_Flags::Viewable);
 			}
 
 			if (optional_string("$Always Viewable:"))
@@ -102,14 +102,14 @@ void cutscene_init()
 				bool flag;
 				stuff_boolean(&flag);
 				if (flag)
-					cutinfo.flags |= CF_ALWAYS_VIEWABLE;
+					cutinfo.flags.set(Cutscene::Cutscene_Flags::Always_viewable);
 			}
 			if (optional_string("$Never Viewable:"))
 			{
 				bool flag;
 				stuff_boolean(&flag);
 				if (flag)
-					cutinfo.flags |= CF_NEVER_VIEWABLE;
+					cutinfo.flags.set(Cutscene::Cutscene_Flags::Never_viewable);
 			}
 
 			Cutscenes.push_back(cutinfo);
@@ -152,7 +152,7 @@ void cutscene_mark_viewable(const char* filename)
 		// see if the stripped filename matches the cutscene filename
 		if (strstr(cut_file, file) != NULL)
 		{
-			cut->flags |= CF_VIEWABLE;
+			cut->flags.set(Cutscene::Cutscene_Flags::Viewable);
 			return;
 		}
 		i++;
@@ -452,9 +452,7 @@ void cutscenes_screen_init()
 	int u = 0;
 	for (auto cut = Cutscenes.begin(); cut != Cutscenes.end(); ++cut, ++u)
 	{
-		int flags = (*cut).flags;
-
-		if ( (flags & CF_VIEWABLE || flags & CF_ALWAYS_VIEWABLE) && !(flags & CF_NEVER_VIEWABLE) )
+		if ((cut->flags[Cutscene::Cutscene_Flags::Viewable] || cut->flags[Cutscene::Cutscene_Flags::Always_viewable]) && !cut->flags[Cutscene::Cutscene_Flags::Never_viewable])
 		{
 			Cutscene_list.push_back(u);
 		}

--- a/code/cutscene/cutscenes.cpp
+++ b/code/cutscene/cutscenes.cpp
@@ -83,24 +83,33 @@ void cutscene_init()
 
 			if (optional_string("$cd:"))
 			{
-				// Option isn't needed anymore. Consume the token and ignore it
-
+				// CD option isn't needed anymore. Consume the token and ignore it
 				int junk;
 				stuff_int(&junk);
 			}
 
-			cutinfo.viewable = false;
+			cutinfo.flags = 0;
 
 			if (isFirstCutscene)
 			{
 				isFirstCutscene = false;
-				// The original code assumes the first movie is the intro, so always viewable
-				cutinfo.viewable = true;
+				// The original code assumes the first movie is the intro, so make it viewable
+				cutinfo.flags |= CF_VIEWABLE;
 			}
 
 			if (optional_string("$Always Viewable:"))
 			{
-				stuff_boolean(&cutinfo.viewable);
+				bool flag;
+				stuff_boolean(&flag);
+				if (flag)
+					cutinfo.flags |= CF_ALWAYS_VIEWABLE;
+			}
+			if (optional_string("$Never Viewable:"))
+			{
+				bool flag;
+				stuff_boolean(&flag);
+				if (flag)
+					cutinfo.flags |= CF_NEVER_VIEWABLE;
 			}
 
 			Cutscenes.push_back(cutinfo);
@@ -143,7 +152,7 @@ void cutscene_mark_viewable(const char* filename)
 		// see if the stripped filename matches the cutscene filename
 		if (strstr(cut_file, file) != NULL)
 		{
-			cut->viewable = true;
+			cut->flags |= CF_VIEWABLE;
 			return;
 		}
 		i++;
@@ -441,9 +450,11 @@ void cutscenes_screen_init()
 	Cutscene_list.clear();
 
 	int u = 0;
-	for (SCP_vector<cutscene_info>::iterator cut = Cutscenes.begin(); cut != Cutscenes.end(); ++cut, u++)
+	for (SCP_vector<cutscene_info>::iterator cut = Cutscenes.begin(); cut != Cutscenes.end(); ++cut, ++u)
 	{
-		if ((*cut).viewable)
+		int flags = (*cut).flags;
+
+		if ( (flags & CF_VIEWABLE || flags & CF_ALWAYS_VIEWABLE) && !(flags & CF_NEVER_VIEWABLE) )
 		{
 			Cutscene_list.push_back(u);
 		}

--- a/code/cutscene/cutscenes.h
+++ b/code/cutscene/cutscenes.h
@@ -13,16 +13,16 @@
 #include "globalincs/globals.h"
 #include "globalincs/pstypes.h"
 
-#define CF_VIEWABLE			(1<<0)
-#define CF_ALWAYS_VIEWABLE	(1<<1)
-#define CF_NEVER_VIEWABLE	(1<<2)
+const int CF_VIEWABLE =         (1<<0);
+const int CF_ALWAYS_VIEWABLE =  (1<<1);
+const int CF_NEVER_VIEWABLE =   (1<<2);
 
 typedef struct cutscene_info
 {
 	char filename[MAX_FILENAME_LEN];
 	char name[NAME_LENGTH];
 	char* description;
-	int flags;
+	uint32_t flags;
 } cutscene_info;
 
 extern SCP_vector<cutscene_info> Cutscenes;

--- a/code/cutscene/cutscenes.h
+++ b/code/cutscene/cutscenes.h
@@ -10,19 +10,28 @@
 #ifndef _FREESPACE_CUTSCENES_SCREEN_HEADER_FILE
 #define _FREESPACE_CUTSCENES_SCREEN_HEADER_FILE
 
+#include "globalincs/flagset.h"
 #include "globalincs/globals.h"
 #include "globalincs/pstypes.h"
 
-const int CF_VIEWABLE =         (1<<0);
-const int CF_ALWAYS_VIEWABLE =  (1<<1);
-const int CF_NEVER_VIEWABLE =   (1<<2);
+namespace Cutscene
+{
+	FLAG_LIST(Cutscene_Flags)
+	{
+		Viewable = 0,
+		Always_viewable,
+		Never_viewable,
+
+		NUM_VALUES
+	};
+}
 
 typedef struct cutscene_info
 {
 	char filename[MAX_FILENAME_LEN];
 	char name[NAME_LENGTH];
 	char* description;
-	uint32_t flags;
+	flagset<Cutscene::Cutscene_Flags> flags;
 } cutscene_info;
 
 extern SCP_vector<cutscene_info> Cutscenes;

--- a/code/cutscene/cutscenes.h
+++ b/code/cutscene/cutscenes.h
@@ -13,12 +13,16 @@
 #include "globalincs/globals.h"
 #include "globalincs/pstypes.h"
 
+#define CF_VIEWABLE			(1<<0)
+#define CF_ALWAYS_VIEWABLE	(1<<1)
+#define CF_NEVER_VIEWABLE	(1<<2)
+
 typedef struct cutscene_info
 {
 	char filename[MAX_FILENAME_LEN];
 	char name[NAME_LENGTH];
 	char* description;
-	bool viewable;
+	int flags;
 } cutscene_info;
 
 extern SCP_vector<cutscene_info> Cutscenes;

--- a/code/pilotfile/csg.cpp
+++ b/code/pilotfile/csg.cpp
@@ -1212,7 +1212,7 @@ void pilotfile::csg_write_cutscenes() {
 
 	size_t viewableScenes = 0;
 	for (cut = Cutscenes.begin(); cut != Cutscenes.end(); ++cut) {
-		if (cut->flags & CF_VIEWABLE) {
+		if (cut->flags[Cutscene::Cutscene_Flags::Viewable]) {
 			viewableScenes++;
 		}
 	}
@@ -1223,7 +1223,7 @@ void pilotfile::csg_write_cutscenes() {
 	cfwrite_uint((uint)viewableScenes, cfp);
 
 	for (cut = Cutscenes.begin(); cut != Cutscenes.end(); ++cut) {
-		if (cut->flags & CF_VIEWABLE) {
+		if (cut->flags[Cutscene::Cutscene_Flags::Viewable]) {
 			cfwrite_string_len(cut->filename, cfp);
 		}
 	}

--- a/code/pilotfile/csg.cpp
+++ b/code/pilotfile/csg.cpp
@@ -1211,9 +1211,10 @@ void pilotfile::csg_write_cutscenes() {
 	startSection(Section::Cutscenes);
 
 	size_t viewableScenes = 0;
-	for(cut = Cutscenes.begin(); cut != Cutscenes.end(); ++cut) {
-		if(cut->viewable)
-			viewableScenes ++;
+	for (cut = Cutscenes.begin(); cut != Cutscenes.end(); ++cut) {
+		if (cut->flags & CF_VIEWABLE) {
+			viewableScenes++;
+		}
 	}
 
 	// Check for possible overflow because we can only write 32 bit integers
@@ -1221,9 +1222,10 @@ void pilotfile::csg_write_cutscenes() {
 
 	cfwrite_uint((uint)viewableScenes, cfp);
 
-	for(cut = Cutscenes.begin(); cut != Cutscenes.end(); ++cut) {
-		if(cut->viewable)
+	for (cut = Cutscenes.begin(); cut != Cutscenes.end(); ++cut) {
+		if (cut->flags & CF_VIEWABLE) {
 			cfwrite_string_len(cut->filename, cfp);
+		}
 	}
 
 	endSection();

--- a/code/pilotfile/csg_convert.cpp
+++ b/code/pilotfile/csg_convert.cpp
@@ -1104,7 +1104,7 @@ void pilotfile_convert::csg_export_cutscenes() {
 	size_t viewableScenes = 0;
 	for (size_t j=0; j<size && j<32; ++j) {
 		if ( (j < Cutscenes.size()) && (csg->cutscenes & (1<<j)) ) {
-			Cutscenes.at(j).flags |= CF_VIEWABLE;
+			Cutscenes.at(j).flags.set(Cutscene::Cutscene_Flags::Viewable);
 			viewableScenes++;
 		}
 	}
@@ -1116,7 +1116,7 @@ void pilotfile_convert::csg_export_cutscenes() {
 	cfwrite_uint((uint)viewableScenes, cfp);
 
 	for (cut = Cutscenes.begin(); cut != Cutscenes.end(); ++cut) {
-		if (cut->flags & CF_VIEWABLE) {
+		if (cut->flags[Cutscene::Cutscene_Flags::Viewable]) {
 			cfwrite_string_len(cut->filename, cfp);
 		}
 	}

--- a/code/pilotfile/csg_convert.cpp
+++ b/code/pilotfile/csg_convert.cpp
@@ -1103,8 +1103,8 @@ void pilotfile_convert::csg_export_cutscenes() {
 	size_t size = Cutscenes.size();
 	size_t viewableScenes = 0;
 	for (size_t j=0; j<size && j<32; ++j) {
-		if ( csg->cutscenes & (1<<j) ) {
-			Cutscenes.at(j).viewable = true;
+		if ( (j < Cutscenes.size()) && (csg->cutscenes & (1<<j)) ) {
+			Cutscenes.at(j).flags |= CF_VIEWABLE;
 			viewableScenes++;
 		}
 	}
@@ -1115,9 +1115,10 @@ void pilotfile_convert::csg_export_cutscenes() {
 	// output cutscene data in new format
 	cfwrite_uint((uint)viewableScenes, cfp);
 
-	for(cut = Cutscenes.begin(); cut != Cutscenes.end(); ++cut) {
-		if(cut->viewable)
+	for (cut = Cutscenes.begin(); cut != Cutscenes.end(); ++cut) {
+		if (cut->flags & CF_VIEWABLE) {
 			cfwrite_string_len(cut->filename, cfp);
+		}
 	}
 
 	endSection();


### PR DESCRIPTION
There are now three states for cutscenes: always viewable, where they will appear no matter what; never viewable, where they will never appear; and viewable, which can be modified during the campaign.  Currently cutscenes will go from not-viewable to viewable, but organizing the flags this way will allow a future feature to make cutscenes not-viewable, if that is desired.

There's also a small edit to csv_convert to guard against array overflows.  Not directly related to the feature but it's in the same place and affects the same code.