### PR TITLE
very small fix to multi_sexp_close_sound_from_file

### DIFF
--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -11375,7 +11375,7 @@ void sexp_close_sound_from_file(int n)
 
 void multi_sexp_close_sound_from_file()
 {
-	bool fade = false;
+	bool fade = true;
 	int sexp_var = -1;
 
 	Current_sexp_network_packet.get_bool(fade);


### PR DESCRIPTION
The default fade argument is `true`, as specified by the sexp help, not false.  This probably doesn't matter here as the multi packet should receive all sexp arguments anyway, but better to be consistent.