### PR TITLE
don't restart if we are switching to a previously finished campaign

### DIFF
--- a/code/menuui/readyroom.cpp
+++ b/code/menuui/readyroom.cpp
@@ -1551,33 +1551,14 @@ void campaign_room_commit()
 	}
 
 	// new campaign selected?
-	if (stricmp(Campaign_file_names[Selected_campaign_index], Campaign.filename) != 0) {
-		// Goober5000 - reinitialize tech database if needed
-		if ( (Campaign.flags & CF_CUSTOM_TECH_DATABASE) || !stricmp(Campaign.filename, "freespace2") )
-		{
-			// reset tech database to what's in the tables
-			tech_reset_to_default();
-		}
+	if (stricmp(Campaign_file_names[Selected_campaign_index], Campaign.filename) != 0)
+	{
+		strcpy_s(Player->current_campaign, Campaign_file_names[Selected_campaign_index]);  // track new campaign for player
 
-		int load_status = mission_campaign_load(Campaign_file_names[Selected_campaign_index]);
+		// the campaign loading status will be checked again when we try to load the campaign in the ready room
+		mission_campaign_load(Campaign_file_names[Selected_campaign_index]);
 
-		if (load_status == 0) {
-			strcpy_s(Player->current_campaign, Campaign.filename);  // track new campaign for player
-
-			// sanity check: if we just loaded a savefile, but we have no next mission,
-			// then we are switching back to an old campaign that we previously completed,
-			// and we want to clear it to start afresh
-			if (Campaign.next_mission == -1) {
-				mission_campaign_savefile_delete(Campaign_file_names[Selected_campaign_index]);
-				Campaign.next_mission = 0;
-			}
-		}
-		// TODO: other return values were never checked previously; do we need to check them???
-	}
-
-	if (mission_campaign_next_mission()) {  // is campaign and next mission valid?
-		gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
-		return;
+		// we no longer reset the tech db here since we're not resetting progress when we switch to a new campaign
 	}
 
 	gameseq_post_event(GS_EVENT_MAIN_MENU);

--- a/code/menuui/readyroom.cpp
+++ b/code/menuui/readyroom.cpp
@@ -1555,10 +1555,21 @@ void campaign_room_commit()
 	{
 		strcpy_s(Player->current_campaign, Campaign_file_names[Selected_campaign_index]);  // track new campaign for player
 
-		// the campaign loading status will be checked again when we try to load the campaign in the ready room
-		mission_campaign_load(Campaign_file_names[Selected_campaign_index]);
+		// attempt to load the campaign
+		int load_status = mission_campaign_load(Campaign_file_names[Selected_campaign_index]);
 
-		// we no longer reset the tech db here since we're not resetting progress when we switch to a new campaign
+		// see if we successfully loaded this campaign and it's at the beginning
+		if (load_status == 0 && Campaign.prev_mission < 0)
+		{
+			// Goober5000 - reinitialize tech database if needed
+			if ((Campaign.flags & CF_CUSTOM_TECH_DATABASE) || !stricmp(Campaign.filename, "freespace2"))
+			{
+				// reset tech database to what's in the tables
+				tech_reset_to_default();
+			}
+		}
+
+		// that's all we need to do for now; the campaign loading status will be checked again when we try to load the campaign in the ready room
 	}
 
 	gameseq_post_event(GS_EVENT_MAIN_MENU);

--- a/code/mission/missioncampaign.cpp
+++ b/code/mission/missioncampaign.cpp
@@ -420,6 +420,7 @@ int mission_campaign_load( char *filename, player *pl, int load_savefile, bool r
 
 	if (campaign_is_ignored(filename)) {
 		Campaign_file_missing = 1;
+		Campaign_load_failure = CAMPAIGN_ERROR_IGNORED;
 		return CAMPAIGN_ERROR_IGNORED;
 	}
 
@@ -659,6 +660,7 @@ int mission_campaign_load( char *filename, player *pl, int load_savefile, bool r
 			return CAMPAIGN_ERROR_MISSING;
 		}
 
+		Campaign_load_failure = CAMPAIGN_ERROR_CORRUPT;
 		return CAMPAIGN_ERROR_CORRUPT;
 	}
 


### PR DESCRIPTION
This is a follow-up to #1450, based on feedback and preference.  Instead of always resetting campaign progress, just switch to the campaign.  The player can then explore the tech room database or the finished missions if he chooses.

This also fixes a few bugs:

1) Ever since the tech-database-reset feature was introduced in 2003 or so, the game incorrectly checked the campaign being unselected, not the campaign being selected.
2) Not all campaign loading failure types were recorded in `mission_load_campaign`.