### PR TITLE
Only Try To Load a Campaign Once

### DIFF
--- a/code/mission/missioncampaign.cpp
+++ b/code/mission/missioncampaign.cpp
@@ -1614,12 +1614,8 @@ int mission_load_up_campaign( player *pl )
 		}
 	}
 
-	rc = mission_campaign_load(Default_campaign_file_name, pl);
-
 	// builtin...
-	if (rc < 0) {
-		rc = mission_campaign_load(Default_campaign_file_name, pl);
-	}
+	rc = mission_campaign_load(Default_campaign_file_name, pl);
 
 	// everything else...
 	if (rc < 0) {


### PR DESCRIPTION
Very small change: Correct me if I'm wrong, but there's no need to try to load the default campaign twice with the same exact function arguments.