### PR TITLE
Fixes the extraction of pitch

### DIFF
--- a/code/math/vecmat.cpp
+++ b/code/math/vecmat.cpp
@@ -1015,7 +1015,13 @@ angles *vm_extract_angles_matrix(angles *a, const matrix *m)
 	else											//cosine is larger, so use it
 		cosp = m->vec.fvec.xyz.z*cosh;
 
-	a->p = atan2_safe(-m->vec.fvec.xyz.y, cosp);
+	//using the fvec_xz_distance extracts the correct pitch from the matrix --wookieejedi
+	//previously cosp was used as the denominator, but this resulted in some incorrect pitch extractions
+	float fvec_xz_distance;
+
+	fvec_xz_distance = pow((pow((m->vec.fvec.xyz.x), 2.0f) + pow((m->vec.fvec.xyz.z), 2.0f)), 0.5f);
+
+	a->p = atan2_safe(-m->vec.fvec.xyz.y, fvec_xz_distance);
 
 	if (cosp == 0.0f)	//the cosine of pitch is zero.  we're pitched straight up. say no bank
 

--- a/code/math/vecmat.cpp
+++ b/code/math/vecmat.cpp
@@ -1019,7 +1019,7 @@ angles *vm_extract_angles_matrix(angles *a, const matrix *m)
 	//previously cosp was used as the denominator, but this resulted in some incorrect pitch extractions
 	float fvec_xz_distance;
 
-	fvec_xz_distance = pow((pow((m->vec.fvec.xyz.x), 2.0f) + pow((m->vec.fvec.xyz.z), 2.0f)), 0.5f);
+	fvec_xz_distance = fl_sqrt( ( (m->vec.fvec.xyz.x)*(m->vec.fvec.xyz.x) ) + ( (m->vec.fvec.xyz.z)*(m->vec.fvec.xyz.z) ) );
 
 	a->p = atan2_safe(-m->vec.fvec.xyz.y, fvec_xz_distance);
 


### PR DESCRIPTION
It turns out that `vm_extract_angles_matrix` would return a pitch value that was occasionally not the actual pitch from the 3x3 matrix. The pitch line in the code uses a modified `cosp` as the denominator to calculate the pitch angle. I researched what the calculation should be and found a more accurate way than using the modified `cosp` is to use `( fvec.xyz.x^2 + fvec.xyz.z^2 )^0.5` I tested using the new calculation thoroughly and in each test it returned the proper pitch value from the 3x3 orientation matrix.