### PR TITLE
sanitize parsed multi.cfg settings for PXO

### DIFF
--- a/code/network/multi_fstracker.cpp
+++ b/code/network/multi_fstracker.cpp
@@ -117,6 +117,9 @@ static pxo_net_game_data Multi_tracker_game_data;
 static vmt_stats_struct Multi_tracker_fs_pilot;
 static squad_war_response Multi_tracker_sw_response;
 
+#define PXO_DEFAULT_TRACKER "tracker.pxo.nottheeye.com"
+#define PXO_WEBSITE_URL "http://pxo.nottheeye.com"	// NOTE: *must* be http: for compatiblity
+
 // -----------------------------------------------------------------------------------
 // FREESPACE MASTER TRACKER DEFINITIONS
 //
@@ -1526,3 +1529,53 @@ int multi_fs_tracker_store_sw(squad_war_result *sw_res, char * /*bad_reply*/, co
 	return 0;
 }
 
+// verify and possibly update Multi_options_g with sane PXO values
+void multi_fs_tracker_verify_options()
+{
+	bool override = false;
+
+	// if any tracker ip is missing, force update
+	if ( !strlen(Multi_options_g.user_tracker_ip) || !strlen(Multi_options_g.game_tracker_ip)
+		 || !strlen(Multi_options_g.pxo_ip)	)
+	{
+		override = true;
+	}
+
+	// if user tracker ip is set to retail setting, force update
+	if ( !override && !strcmp(Multi_options_g.user_tracker_ip, "ut.pxo.net") ) {
+		override = true;
+	}
+
+	// if user tracker ip is set to FS2NetD, force update
+	if ( !override && !strcmp(Multi_options_g.user_tracker_ip, "fs2netd.game-warden.com") ) {
+		override = true;
+	}
+
+	if ( !override ) {
+		return;
+	}
+
+	//
+	// update required options
+	//
+
+	strcpy_s(Multi_options_g.user_tracker_ip, PXO_DEFAULT_TRACKER);
+	strcpy_s(Multi_options_g.game_tracker_ip, PXO_DEFAULT_TRACKER);
+	strcpy_s(Multi_options_g.pxo_ip, PXO_DEFAULT_TRACKER);
+
+	//
+	// update optional urls
+	//
+
+	strcpy_s(Multi_options_g.pxo_rank_url, PXO_WEBSITE_URL);
+	strcat_s(Multi_options_g.pxo_rank_url, "/rankings");
+
+	strcpy_s(Multi_options_g.pxo_create_url, PXO_WEBSITE_URL);
+	strcat_s(Multi_options_g.pxo_create_url, "/register");
+
+	strcpy_s(Multi_options_g.pxo_verify_url, PXO_WEBSITE_URL);
+	strcat_s(Multi_options_g.pxo_verify_url, "/account");
+
+	strcpy_s(Multi_options_g.pxo_banner_url, PXO_WEBSITE_URL);
+	strcat_s(Multi_options_g.pxo_banner_url, "/files/banners");
+}

--- a/code/network/multi_fstracker.h
+++ b/code/network/multi_fstracker.h
@@ -102,4 +102,7 @@ int multi_fs_tracker_store_sw(squad_war_result *sw_res, char *bad_reply, const s
 // this is hacked data check as well as mod ident
 int multi_fs_tracker_validate_game_data();
 
+// verify and possibly update Multi_options_g with sane PXO values
+void multi_fs_tracker_verify_options();
+
 #endif

--- a/code/network/multi_options.cpp
+++ b/code/network/multi_options.cpp
@@ -286,6 +286,9 @@ void multi_options_read_config()
 		in = NULL;
 	}
 
+	// sanitize config options for PXO
+	multi_fs_tracker_verify_options();
+
 #ifndef _WIN32
 	if (Is_standalone) {
 		std_configLoaded(&Multi_options_g);


### PR DESCRIPTION
This will use default settings related to PXO if one of the following conditions is met:
- `multi.cfg` is missing or a required field is missing
- the settings in `multi.cfg` are from retail FS2
- the settings in `multi.cfg` are from FS2NetD

Fresh installs and mods configured for FS2NetD should now work without any extra steps.