### PR TITLE
fix PXO banners (and inetgetfile stuff)

### DIFF
--- a/code/cfile/cfile.h
+++ b/code/cfile/cfile.h
@@ -291,6 +291,10 @@ uint cf_add_chksum_long(uint seed, ubyte *buffer, size_t size);
 #define CF_RENAME_FAIL_EXIST			2					// old name does not exist
 int cf_rename(const char *old_name, const char *name, int type = CF_TYPE_ANY );
 
+// Creates the directory path if it doesn't exist. Even creates all its
+// parent paths.
+void cf_create_directory(int dir_type, uint32_t location_flags = CF_LOCATION_ALL);
+
 // changes the attributes of a file
 void cf_attrib(const char *name, int set, int clear, int type);
 

--- a/code/inetfile/cftp.cpp
+++ b/code/inetfile/cftp.cpp
@@ -51,7 +51,7 @@ void CFtpGet::AbortGet()
 	}
 }
 
-CFtpGet::CFtpGet(char *URL, char *localfile, char *Username, char *Password)
+CFtpGet::CFtpGet(const char *URL, const char *localfile, const char *Username, const char *Password)
 {
 	SOCKADDR_IN listensockaddr;
 	m_State = FTP_STATE_STARTUP;
@@ -129,7 +129,7 @@ CFtpGet::CFtpGet(char *URL, char *localfile, char *Username, char *Password)
 	}
 	//Parse the URL
 	//Get rid of any extra ftp:// stuff
-	char *pURL = URL;
+	const char *pURL = URL;
 	if(strnicmp(URL,"ftp:",4)==0)
 	{
 		pURL +=4;
@@ -148,8 +148,8 @@ CFtpGet::CFtpGet(char *URL, char *localfile, char *Username, char *Password)
 	//read the filename by searching backwards for a /
 	//then keep reading until you find the first /
 	//when you found it, you have the host and dir
-	char *filestart = NULL;
-	char *dirstart = NULL;
+	const char *filestart = nullptr;
+	const char *dirstart = nullptr;
 	for(size_t i = strlen(pURL);;i--)
 	{
 		if(pURL[i]== '/')
@@ -456,7 +456,7 @@ int CFtpGet::LoginHost()
 }
 
 
-uint CFtpGet::SendFTPCommand(char *command)
+uint CFtpGet::SendFTPCommand(const char *command)
 {
 
 	FlushControlChannel();

--- a/code/inetfile/cftp.h
+++ b/code/inetfile/cftp.h
@@ -45,7 +45,7 @@ class CFtpGet
 {
 
 public:
-	CFtpGet(char *URL, char *localfile, char *Username = NULL, char *Password = NULL);
+	CFtpGet(const char *URL, const char *localfile, const char *Username = nullptr, const char *Password = nullptr);
 	~CFtpGet();
 	int GetStatus();
 	uint GetBytesIn();
@@ -58,7 +58,7 @@ protected:
 	
 	int ConnectControlSocket();
 	int LoginHost();	
-	uint SendFTPCommand(char *command);
+	uint SendFTPCommand(const char *command);
 	uint ReadFTPServerReply();
 	uint GetFile();
 	uint IssuePort();

--- a/code/inetfile/chttpget.cpp
+++ b/code/inetfile/chttpget.cpp
@@ -8,11 +8,9 @@
 */
 
 
-
-
-#include "globalincs/pstypes.h"
-
-#ifndef _WIN32
+#ifdef _WIN32
+#include <winsock2.h>
+#else
 #include <sys/time.h>
 #include <sys/types.h>
 #include <sys/socket.h>
@@ -32,9 +30,11 @@
 #include <cctype>
 #include <cerrno>
 
+#include "globalincs/pstypes.h"
 #include "osapi/osapi.h"
 #include "inetfile/inetgetfile.h"
 #include "inetfile/chttpget.h"
+#include "io/timer.h"
 
 
 
@@ -42,11 +42,7 @@
 #define NW_AGHBN_LOOKUP		2
 #define NW_AGHBN_READ		3
 
-#ifdef WIN32
-void __cdecl http_gethostbynameworker(void *parm);
-#else
 int http_gethostbynameworker(void *parm);
-#endif
 
 int http_Asyncgethostbyname(unsigned int *ip,int command, char *hostname);
 
@@ -55,7 +51,7 @@ int HTTPObjThread( void *obj )
 	((ChttpGet *)obj)->WorkerThread();
 	((ChttpGet *)obj)->m_Aborted = true;
 
-	return 0;
+	return (reinterpret_cast<ChttpGet *>(obj))->GetStatus();
 }
 
 void ChttpGet::AbortGet()
@@ -87,7 +83,6 @@ void ChttpGet::GetFile(char *URL,char *localfile)
 	m_State = HTTP_STATE_STARTUP;
 	m_Aborting = false;
 	m_Aborted = false;
-	thread_id = NULL;
 
 	strncpy(m_URL,URL,MAX_URL_LEN-1);
 	m_URL[MAX_URL_LEN-1] = 0;
@@ -96,17 +91,19 @@ void ChttpGet::GetFile(char *URL,char *localfile)
 	if(NULL == LOCALFILE)
 	{
 		m_State = HTTP_STATE_CANT_WRITE_FILE;
+		m_Aborted = true;
 		return;
 	}
 	m_DataSock = socket(AF_INET, SOCK_STREAM, 0);
 	if(INVALID_SOCKET == m_DataSock)
 	{
 		m_State = HTTP_STATE_SOCKET_ERROR;
+		m_Aborted = true;
 		return;
 	}
 
-//	uint arg = 1;
-//	ioctlsocket( m_DataSock, FIONBIO, &arg );
+	unsigned long arg = 1;
+	ioctlsocket( m_DataSock, FIONBIO, &arg );
 
 	char *pURL = URL;
 	if(strnicmp(URL,"http:",5)==0)
@@ -121,6 +118,7 @@ void ChttpGet::GetFile(char *URL,char *localfile)
 	if(strchr(pURL,':'))
 	{
 		m_State = HTTP_STATE_URL_PARSING_ERROR;
+		m_Aborted = true;
 		return;
 	}
 	//read the filename by searching backwards for a /
@@ -150,6 +148,7 @@ void ChttpGet::GetFile(char *URL,char *localfile)
 	if((dirstart==NULL) || (filestart==NULL))
 	{
 		m_State = HTTP_STATE_URL_PARSING_ERROR;
+		m_Aborted = true;
 		return;
 	}
 	else
@@ -160,24 +159,31 @@ void ChttpGet::GetFile(char *URL,char *localfile)
 		m_szHost[(dirstart-pURL)-1] = '\0';
 	}
 
-	if ( (thread_id = SDL_CreateThread(HTTPObjThread, "HTTP", this)) == NULL )
+	SDL_Thread *thread = SDL_CreateThread(HTTPObjThread, "HTTPObjThread", this);
+
+	if(thread == nullptr)
 	{
 		m_State = HTTP_STATE_INTERNAL_ERROR;
-		return;
+		m_Aborted = true;
+	}
+	else
+	{
+		SDL_DetachThread(thread);
 	}
 }
 
 
 ChttpGet::~ChttpGet()
 {
-	if (thread_id)
-		SDL_WaitThread(thread_id, NULL);
-
-	fclose(LOCALFILE);
-    
-	if (m_DataSock != INVALID_SOCKET) {
-		shutdown(m_DataSock, 2);
+	if(m_DataSock != INVALID_SOCKET)
+	{
+		shutdown(m_DataSock,2);
 		closesocket(m_DataSock);
+	}
+
+	if(LOCALFILE != nullptr)
+	{
+		fclose(LOCALFILE);
 	}
 }
 
@@ -206,11 +212,13 @@ void ChttpGet::WorkerThread()
 	if(m_Aborting)
 	{
 		fclose(LOCALFILE);
+		LOCALFILE = nullptr;
 		return;
 	}
 	if(m_State != HTTP_STATE_CONNECTED)
 	{
 		fclose(LOCALFILE);
+		LOCALFILE = nullptr;
 		return;
 	}
 	sprintf(szCommand,"GET %s%s HTTP/1.1\nAccept: */*\nAccept-Encoding: deflate\nHost: %s\n\n\n",m_ProxyEnabled?"":"/",m_ProxyEnabled?m_URL:m_szDir,m_szHost);
@@ -225,6 +233,7 @@ void ChttpGet::WorkerThread()
 		{
 			m_State = HTTP_STATE_UNKNOWN_ERROR;	
 			fclose(LOCALFILE);
+			LOCALFILE = nullptr;
 			return;
 
 		}
@@ -236,11 +245,11 @@ void ChttpGet::WorkerThread()
 		{
 			m_State = HTTP_STATE_UNKNOWN_ERROR;	
 			fclose(LOCALFILE);
+			LOCALFILE = nullptr;
 			return;
 		}
 		if(irsp==200)
 		{
-			int idataready=0;
 			do
 			{
 				p = GetHTTPLine();
@@ -248,11 +257,11 @@ void ChttpGet::WorkerThread()
 				{
 					m_State = HTTP_STATE_UNKNOWN_ERROR;	
 					fclose(LOCALFILE);
+					LOCALFILE = nullptr;
 					return;
 				}
 				if(*p=='\0')
 				{
-					idataready = 1;
 					break;
 				}
 				if(strnicmp(p,"Content-Length:",strlen("Content-Length:"))==0)
@@ -275,18 +284,20 @@ void ChttpGet::WorkerThread()
 				}
 
 				os_sleep(1);
-			}while(!idataready);
+			}while(true);
 		ReadDataChannel();
 		return;
 		}
 		m_State = HTTP_STATE_FILE_NOT_FOUND;
 		fclose(LOCALFILE);
+		LOCALFILE = nullptr;
 		return;
 	}
 	else
 	{
 		m_State = HTTP_STATE_UNKNOWN_ERROR;
 		fclose(LOCALFILE);
+		LOCALFILE = nullptr;
 		return;
 	}
 }
@@ -376,9 +387,6 @@ int ChttpGet::ConnectSocket()
 		memcpy(&hostaddr.sin_addr,&ip,4);
 
 	}
-    
-	memset(&hostaddr.sin_zero, 0, sizeof(hostaddr.sin_zero));
-
 	//Now we will connect to the host					
 	fd_set	wfds;
 
@@ -389,13 +397,26 @@ int ChttpGet::ConnectSocket()
 	int serr = connect(m_DataSock, (SOCKADDR *)&hostaddr, sizeof(SOCKADDR));
 	int cerr = WSAGetLastError();
 	if (serr) {
-		while ( (cerr == WSAEALREADY) || (cerr == WSAEINVAL) || (cerr == WSAEWOULDBLOCK) ) {
+		// fail after 20 seconds
+		int failtime = timer_get_seconds() + 20;
+
+		while ( (cerr == WSAEALREADY) || (cerr == WSAEINVAL) || NETCALL_WOULDBLOCK(cerr) ) {
 			FD_ZERO(&wfds);
 			FD_SET( m_DataSock, &wfds );
 
 			if ( select(static_cast<int>(m_DataSock+1), nullptr, &wfds, nullptr, &timeout) )
 			{
-				serr = 0;
+				int error_code = 0;
+				SOCKLEN_T error_code_size = sizeof(error_code);
+
+				// check to make sure socket is *really* connected
+				int rc = getsockopt(m_DataSock, SOL_SOCKET, SO_ERROR, (char *)&error_code, &error_code_size);
+
+				if(!rc && !error_code)
+				{
+					serr = 0;
+				}
+
 				break;
 			}
 
@@ -411,6 +432,10 @@ int ChttpGet::ConnectSocket()
 	
 			if (cerr == WSAEISCONN) {
 				serr = 0;
+				break;
+			}
+
+			if (timer_get_seconds() > failtime) {
 				break;
 			}
 
@@ -445,7 +470,7 @@ char *ChttpGet::GetHTTPLine()
 			if(SOCKET_ERROR == iBytesRead)
 			{
 				int error = WSAGetLastError();
-				if(WSAEWOULDBLOCK==error)
+				if( NETCALL_WOULDBLOCK(error) )
 				{
 					gotdata = false;
 					continue;
@@ -471,7 +496,7 @@ char *ChttpGet::GetHTTPLine()
 				if(SOCKET_ERROR == iBytesRead)
 				{	
 					int error = WSAGetLastError();
-					if(WSAEWOULDBLOCK==error)
+					if( NETCALL_WOULDBLOCK(error) )
 					{
 						gotdata = false;
 						continue;
@@ -522,6 +547,7 @@ uint ChttpGet::ReadDataChannel()
 	
     	if (m_Aborting) {
 			fclose(LOCALFILE);
+			LOCALFILE = nullptr;
 			return 0;		
 		}
 
@@ -529,13 +555,14 @@ uint ChttpGet::ReadDataChannel()
 	
     	if (m_Aborting) {
 			fclose(LOCALFILE);
+			LOCALFILE = nullptr;
 			return 0;
 		}
 	
 		if (SOCKET_ERROR == nBytesRecv) {	
 			int error = WSAGetLastError();
 
-			if (error == WSAEWOULDBLOCK) {
+			if ( NETCALL_WOULDBLOCK(error) ) {
 				nBytesRecv = 1;
 				continue;
 			}
@@ -551,6 +578,7 @@ uint ChttpGet::ReadDataChannel()
 	} while (nBytesRecv > 0);
 
 	fclose(LOCALFILE);	
+	LOCALFILE = nullptr;
 	
 	// Close the file and check for error returns.
 	if (nBytesRecv == SOCKET_ERROR) { 
@@ -577,11 +605,7 @@ typedef struct _async_dns_lookup
 async_dns_lookup httpaslu;
 async_dns_lookup *http_lastaslu = NULL;
 
-#ifdef WIN32
-void __cdecl http_gethostbynameworker(void *parm);
-#else
 int http_gethostbynameworker(void *parm);
-#endif
 
 int http_Asyncgethostbyname(unsigned int *ip,int command, char *hostname)
 {
@@ -593,7 +617,7 @@ int http_Asyncgethostbyname(unsigned int *ip,int command, char *hostname)
 
 		async_dns_lookup *newaslu;
 		newaslu = (async_dns_lookup *)vm_malloc(sizeof(async_dns_lookup));
-		memset(&newaslu->ip,0,sizeof(unsigned int));
+		newaslu->ip = 0;
 		newaslu->host = hostname;
 		newaslu->done = false;
 		newaslu->error = false;
@@ -601,19 +625,7 @@ int http_Asyncgethostbyname(unsigned int *ip,int command, char *hostname)
 		http_lastaslu = newaslu;
 		httpaslu.done = false;
 
-#ifdef WIN32
-		_beginthread(http_gethostbynameworker, 0, newaslu);
-#else
-		HOSTENT *he = gethostbyname(hostname);
-
-		if (he == NULL) {
-			newaslu->error = true;
-		} else if ( !newaslu->abort ) {
-			memcpy( &newaslu->ip, he->h_addr_list[0], sizeof(uint) );
-			newaslu->done = true;
-			memcpy( &httpaslu,newaslu, sizeof(async_dns_lookup) );
-		}
-#endif
+		SDL_CreateThread(http_gethostbynameworker, "GetHostByNameWorker", newaslu);
 
 		return 1;
 	}
@@ -630,7 +642,7 @@ int http_Asyncgethostbyname(unsigned int *ip,int command, char *hostname)
 		if(httpaslu.done)
 		{
 			http_lastaslu = NULL;
-			memcpy(ip,&httpaslu.ip,sizeof(unsigned int));
+			*ip = httpaslu.ip;
 			return 1;
 		}
 		else if(httpaslu.error)
@@ -646,25 +658,14 @@ int http_Asyncgethostbyname(unsigned int *ip,int command, char *hostname)
 }
 
 // This is the worker thread which does the lookup.
-#ifdef WIN32
-void __cdecl http_gethostbynameworker(void *parm)
-#else
 int http_gethostbynameworker(void *parm)
-#endif
 {
-#ifdef SCP_UNIX
-//	df_pthread_detach(df_pthread_self());
-#endif
-	async_dns_lookup *lookup = (async_dns_lookup *)parm;
-	HOSTENT *he = gethostbyname(lookup->host);
-	if(he==NULL)
+	async_dns_lookup *lookup = reinterpret_cast<async_dns_lookup *>(parm);
+	struct hostent *he = gethostbyname(lookup->host);
+	if(he==nullptr)
 	{
 		lookup->error = true;
-#ifdef WIN32
-		return;
-#else
-		return 0;
-#endif
+		return 1;
 	}
 	else if(!lookup->abort)
 	{
@@ -674,7 +675,5 @@ int http_gethostbynameworker(void *parm)
 	}
 	vm_free(lookup);
 
-#ifdef SCP_UNIX
 	return 0;
-#endif
 }

--- a/code/inetfile/chttpget.cpp
+++ b/code/inetfile/chttpget.cpp
@@ -660,7 +660,7 @@ int http_Asyncgethostbyname(unsigned int *ip, int command, const char *hostname)
 // This is the worker thread which does the lookup.
 int http_gethostbynameworker(void *parm)
 {
-	async_dns_lookup *lookup = reinterpret_cast<async_dns_lookup *>(parm);
+	auto *lookup = reinterpret_cast<async_dns_lookup *>(parm);
 	struct hostent *he = gethostbyname(lookup->host);
 	if(he==nullptr)
 	{

--- a/code/inetfile/chttpget.cpp
+++ b/code/inetfile/chttpget.cpp
@@ -44,7 +44,7 @@
 
 int http_gethostbynameworker(void *parm);
 
-int http_Asyncgethostbyname(unsigned int *ip,int command, char *hostname);
+int http_Asyncgethostbyname(unsigned int *ip, int command, const char *hostname);
 
 int HTTPObjThread( void *obj )
 {
@@ -60,7 +60,7 @@ void ChttpGet::AbortGet()
 	while(!m_Aborted) os_sleep(50); //Wait for the thread to end
 }
 
-ChttpGet::ChttpGet(char *URL,char *localfile,char *proxyip,unsigned short proxyport)
+ChttpGet::ChttpGet(const char *URL, const char *localfile, const char *proxyip, unsigned short proxyport)
 {
 	m_ProxyEnabled = true;
 	m_ProxyIP = proxyip;
@@ -68,14 +68,14 @@ ChttpGet::ChttpGet(char *URL,char *localfile,char *proxyip,unsigned short proxyp
 	GetFile(URL,localfile);
 }
 
-ChttpGet::ChttpGet(char *URL,char *localfile)
+ChttpGet::ChttpGet(const char *URL, const char *localfile)
 {
 	m_ProxyEnabled = false;
 	GetFile(URL,localfile);
 }
 
 
-void ChttpGet::GetFile(char *URL,char *localfile)
+void ChttpGet::GetFile(const char *URL, const char *localfile)
 {
 	m_DataSock = INVALID_SOCKET;
 	m_iBytesIn = 0;
@@ -105,7 +105,7 @@ void ChttpGet::GetFile(char *URL,char *localfile)
 	unsigned long arg = 1;
 	ioctlsocket( m_DataSock, FIONBIO, &arg );
 
-	char *pURL = URL;
+	const char *pURL = URL;
 	if(strnicmp(URL,"http:",5)==0)
 	{
 		pURL +=5;
@@ -124,8 +124,8 @@ void ChttpGet::GetFile(char *URL,char *localfile)
 	//read the filename by searching backwards for a /
 	//then keep reading until you find the first /
 	//when you found it, you have the host and dir
-	char *filestart = NULL;
-	char *dirstart = NULL;
+	const char *filestart = nullptr;
+	const char *dirstart = nullptr;
 	for(size_t i = strlen(pURL);;i--)
 	{
 		if(pURL[i]== '/')
@@ -596,7 +596,7 @@ uint ChttpGet::ReadDataChannel()
 typedef struct _async_dns_lookup
 {
 	unsigned int ip;	//resolved host. Write only to worker thread.
-	char * host;//host name to resolve. read only to worker thread
+	const char * host;//host name to resolve. read only to worker thread
 	bool done;	//write only to the worker thread. Signals that the operation is complete
 	bool error; //write only to worker thread. Thread sets this if the name doesn't resolve
 	bool abort;	//read only to worker thread. If this is set, don't fill in the struct.
@@ -607,7 +607,7 @@ async_dns_lookup *http_lastaslu = NULL;
 
 int http_gethostbynameworker(void *parm);
 
-int http_Asyncgethostbyname(unsigned int *ip,int command, char *hostname)
+int http_Asyncgethostbyname(unsigned int *ip, int command, const char *hostname)
 {
 	
 	if(command==NW_AGHBN_LOOKUP)

--- a/code/inetfile/chttpget.h
+++ b/code/inetfile/chttpget.h
@@ -32,10 +32,10 @@
 class ChttpGet
 {
 public:
-	ChttpGet(char *URL,char *localfile);
-	ChttpGet(char *URL,char *localfile,char *proxyip,unsigned short proxyport);
+	ChttpGet(const char *URL, const char *localfile);
+	ChttpGet(const char *URL, const char *localfile, const char *proxyip, unsigned short proxyport);
 	~ChttpGet();
-	void GetFile(char *URL,char *localfile);
+	void GetFile(const char *URL, const char *localfile);
 	int GetStatus();
 	uint GetBytesIn();
 	uint GetTotalBytes();
@@ -51,7 +51,7 @@ protected:
 	uint m_iBytesTotal;
 	uint m_State;
 	bool m_ProxyEnabled;
-	char *m_ProxyIP;
+	const char *m_ProxyIP;
 	char m_URL[MAX_URL_LEN];
 	ushort m_ProxyPort;
 

--- a/code/inetfile/chttpget.h
+++ b/code/inetfile/chttpget.h
@@ -12,6 +12,8 @@
 #ifndef _CHTTPGET_HEADER_
 #define _CHTTPGET_HEADER_
 
+#include "globalincs/pstypes.h"
+
 #define HTTP_STATE_INTERNAL_ERROR		0
 #define HTTP_STATE_SOCKET_ERROR			1
 #define HTTP_STATE_URL_PARSING_ERROR	2

--- a/code/inetfile/inetgetfile.cpp
+++ b/code/inetfile/inetgetfile.cpp
@@ -40,7 +40,7 @@ void InetGetFile::AbortGet()
 	}
 }
 
-InetGetFile::InetGetFile(char *URL, char *filename, int cf_type)
+InetGetFile::InetGetFile(const char *URL, const char *filename, int cf_type)
 {
 	m_HardError = 0;
 	http = NULL;

--- a/code/inetfile/inetgetfile.cpp
+++ b/code/inetfile/inetgetfile.cpp
@@ -8,17 +8,21 @@
 */
 
 
+#ifdef _WIN32
+#include <winsock2.h>
+#endif
 
 #include "globalincs/pstypes.h"
 
 #include <cstdio>
 #include <cstring>
 
+#include "cfile/cfile.h"
+#include "cfile/cfilesystem.h"
 #include "inetfile/cftp.h"
 #include "inetfile/chttpget.h"
-
 #include "inetfile/inetgetfile.h"
-
+#include "osapi/osapi.h"
 
 
 #define INET_STATE_CONNECTING		1
@@ -29,49 +33,34 @@
 
 void InetGetFile::AbortGet()
 {
-#ifdef USE_INETFILE
 	if (m_bUseHTTP) {
 		http->AbortGet();
 	} else {
 		ftp->AbortGet();
 	}
-#endif
 }
 
-InetGetFile::InetGetFile(char * /*URL*/, char * /*localfile*/)
+InetGetFile::InetGetFile(char *URL, char *filename, int cf_type)
 {
-#ifdef USE_INETFILE
 	m_HardError = 0;
 	http = NULL;
 	ftp = NULL;
 
-	if ( (URL == NULL) || (localfile == NULL) )
+	if ( (URL == nullptr) || (filename == nullptr) || !CF_TYPE_SPECIFIED(cf_type) ) {
 		m_HardError = INET_ERROR_BADPARMS;
+		return;
+	}
 
 	// create directory if not already there.
-	char dir_name[256], *end;
+	cf_create_directory(cf_type);
 
-	// make sure localfile has \ in it or we'll be here a long time.
-	if ( strstr(localfile, DIR_SEPARATOR_STR) ) {
-		strcpy_s(dir_name, localfile);
-		int len = strlen(localfile);
-		end = dir_name + len;
+	// create full path for file
+	char localfile[MAX_PATH_LEN] = "";
+	cf_create_default_path_string(localfile, MAX_PATH_LEN, cf_type, filename);
 
-		// start from end of localfile and go to first \ to get dirname
-		while ( *end != DIR_SEPARATOR_CHAR ) {
-			end--;
-		}
-
-		*end = '\0';
-
-		if ( _mkdir(dir_name) == 0 )	{
-			mprintf(( "CFILE: Created new directory '%s'\n", dir_name ));
-		}
-	}
-printf("URL: %s\n", URL);
 	if ( strstr(URL, "http:") ) {
 		m_bUseHTTP = true;
-printf("using http!\n");
+
 		// using http proxy?
 		extern char Multi_options_proxy[512];
 		extern ushort Multi_options_proxy_port;
@@ -87,7 +76,7 @@ printf("using http!\n");
 		}
 	} else if ( strstr(URL, "ftp:") ) {
 		m_bUseHTTP = FALSE;
-printf("using ftp! (%s)\n", URL);
+
 		ftp = new CFtpGet(URL,localfile);
 
 		if (ftp == NULL) {
@@ -97,8 +86,7 @@ printf("using ftp! (%s)\n", URL);
 		m_HardError = INET_ERROR_CANT_PARSE_URL;
 	}
 
-	Sleep(1000);
-#endif
+	os_sleep(1000);
 }
 
 InetGetFile::~InetGetFile()
@@ -112,7 +100,6 @@ InetGetFile::~InetGetFile()
 
 bool InetGetFile::IsConnecting()
 {
-#ifdef USE_INETFILE
 	int state;
 
 	if (m_bUseHTTP) {
@@ -126,14 +113,10 @@ bool InetGetFile::IsConnecting()
 	} else {
 		return false;
 	}
-#else
-	return false;
-#endif
 }
 
 bool InetGetFile::IsReceiving()
 {
-#ifdef USE_INETFILE
 	int state;
 
 	if (m_bUseHTTP) {
@@ -147,14 +130,10 @@ bool InetGetFile::IsReceiving()
 	} else {
 		return false;
 	}
-#else
-	return false;
-#endif
 }
 
 bool InetGetFile::IsFileReceived()
 {
-#ifdef USE_INETFILE
 	int state;
 
 	if (m_bUseHTTP) {
@@ -168,14 +147,10 @@ bool InetGetFile::IsFileReceived()
 	} else {
 		return false;
 	}
-#else
-	return false;
-#endif
 }
 
 bool InetGetFile::IsFileError()
 {
-#ifdef USE_INETFILE
 	int state;
 
 	if (m_HardError)
@@ -186,7 +161,7 @@ bool InetGetFile::IsFileError()
 	} else {
 		state = ftp->GetStatus();
 	}
-printf("state: %i\n", state);
+
 	switch (state)
 	{
 		case FTP_STATE_URL_PARSING_ERROR:
@@ -208,13 +183,10 @@ printf("state: %i\n", state);
 		default:
 			return false;
 	}
-#endif
-	return false;
 }
 
 int InetGetFile::GetErrorCode()
 {
-#ifdef USE_INETFILE
 	int state;
 
 	if (m_HardError)
@@ -252,32 +224,22 @@ int InetGetFile::GetErrorCode()
 		default:
 			return INET_ERROR_NO_ERROR;
 	}
-#endif
-	return INET_ERROR_NO_ERROR;
 }
 
 int InetGetFile::GetTotalBytes()
 {
-#ifdef USE_INETFILE
 	if (m_bUseHTTP) {
 		return http->GetTotalBytes();
 	} else {
 		return ftp->GetTotalBytes();
 	}
-#else
-	return 0;
-#endif
 }
 
 int InetGetFile::GetBytesIn()
 {
-#ifdef USE_INETFILE
 	if (m_bUseHTTP) {
 		return http->GetBytesIn();
 	} else {
 		return ftp->GetBytesIn();
 	}
-#else
-	return 0;
-#endif
 }

--- a/code/inetfile/inetgetfile.h
+++ b/code/inetfile/inetgetfile.h
@@ -29,7 +29,7 @@
 class InetGetFile
 {
 public:
-	InetGetFile(char *URL, char *filename, int cf_type = 1 /* CF_TYPE_ROOT */);
+	InetGetFile(const char *URL, const char *filename, int cf_type = 1 /* CF_TYPE_ROOT */);
 	~InetGetFile();
 	bool IsFileReceived();
 	bool IsFileError();

--- a/code/inetfile/inetgetfile.h
+++ b/code/inetfile/inetgetfile.h
@@ -29,7 +29,7 @@
 class InetGetFile
 {
 public:
-	InetGetFile(char *URL,char *localfile);
+	InetGetFile(char *URL, char *filename, int cf_type = 1 /* CF_TYPE_ROOT */);
 	~InetGetFile();
 	bool IsFileReceived();
 	bool IsFileError();

--- a/code/windows_stub/config.h
+++ b/code/windows_stub/config.h
@@ -35,6 +35,10 @@
 
 #define STUB_FUNCTION nprintf(( "Warning", "STUB: %s in " __FILE__ " at line %d\n", __FUNCTION__, __LINE__))
 
+#define SOCKLEN_T int
+
+#define NETCALL_WOULDBLOCK(err) (err == WSAEWOULDBLOCK)
+
 #else  // ! Win32
 
 
@@ -67,9 +71,13 @@
 #define SOCKET_ERROR	(-1)
 #define ioctlsocket(x, y, z)	ioctl(x, y, z)
 
+#define NETCALL_WOULDBLOCK(err) (err == EAGAIN || err == EINPROGRESS)
+
 #ifndef INVALID_SOCKET
 #define INVALID_SOCKET ((SOCKET) -1)
 #endif
+
+#define SOCKLEN_T socklen_t
 
 // file related items
 #define _MAX_FNAME					255


### PR DESCRIPTION
This will get the inetgetfile, cftp, and chttpget code working again so that it can be used for PXO banners ("ads" on the chat screen). It does not make the banners clickable as that might lead to issues and requires further discussion.