### PR TITLE
Two small fixes

### DIFF
--- a/code/graphics/shadows.cpp
+++ b/code/graphics/shadows.cpp
@@ -28,7 +28,7 @@ float Shadow_cascade_distances[MAX_SHADOW_CASCADES];
 
 light_frustum_info Shadow_frustums[MAX_SHADOW_CASCADES];
 
-ShadowQuality Shadow_quality;
+ShadowQuality Shadow_quality = ShadowQuality::Disabled;
 
 auto ShadowQualityOption =
     options::OptionBuilder<ShadowQuality>("Graphics.Shadows", "Shadow Quality", "The quality of the shadows")

--- a/code/lab/lab.cpp
+++ b/code/lab/lab.cpp
@@ -147,7 +147,7 @@ bool Lab_Envmap_override         = false;
 bool Lab_Normalmap_override      = false;
 bool Lab_Heightmap_override      = false;
 bool Lab_Miscmap_override        = false;
-bool Lab_emissive_light_override = (bool)(Cmdline_emissive);
+bool Lab_emissive_light_override = (Cmdline_emissive != 0);
 
 fix Lab_Save_Missiontime;
 

--- a/code/lab/lab.cpp
+++ b/code/lab/lab.cpp
@@ -147,7 +147,7 @@ bool Lab_Envmap_override         = false;
 bool Lab_Normalmap_override      = false;
 bool Lab_Heightmap_override      = false;
 bool Lab_Miscmap_override        = false;
-bool Lab_emissive_light_override = Cmdline_emissive;
+bool Lab_emissive_light_override = (bool)(Cmdline_emissive);
 
 fix Lab_Save_Missiontime;
 


### PR DESCRIPTION
1) Initialize `Shadow_quality` to its default value.  According to the Internet, enums (even enum classes) do not have default constructors and are not guaranteed to be 0-initialized.

2) Add an explicit check for `Cmdline_emissive` in the lab instead of a cast.  The cast warning was tripping the warning-as-error checks in continuous integration.