### PR TITLE
Fix FRED not working

### DIFF
--- a/code/ai/aigoals.cpp
+++ b/code/ai/aigoals.cpp
@@ -271,12 +271,9 @@ void ai_clear_ship_goals( ai_info *aip )
 	}
 
 	// add scripting hook for 'On Goals Cleared' --wookieejedi
-	// only run if there is a valid lua state
-	if (Script_system.GetLuaSession != nullptr) {
-		Script_system.SetHookObject("Ship", &Objects[Ships[aip->shipnum].objnum]);
-		Script_system.RunCondition(CHA_ONGOALSCLEARED);
-		Script_system.RemHookVars(1, "Ship");
-	}
+	Script_system.SetHookObject("Ship", &Objects[Ships[aip->shipnum].objnum]);
+	Script_system.RunCondition(CHA_ONGOALSCLEARED);
+	Script_system.RemHookVars(1, "Ship");
 
 }
 

--- a/code/ai/aigoals.cpp
+++ b/code/ai/aigoals.cpp
@@ -271,9 +271,12 @@ void ai_clear_ship_goals( ai_info *aip )
 	}
 
 	// add scripting hook for 'On Goals Cleared' --wookieejedi
-	Script_system.SetHookObject("Ship", &Objects[Ships[aip->shipnum].objnum]);
-	Script_system.RunCondition(CHA_ONGOALSCLEARED);
-	Script_system.RemHookVars(1, "Ship");
+	// only run if there is a valid lua state
+	if (Script_system.GetLuaSession != nullptr) {
+		Script_system.SetHookObject("Ship", &Objects[Ships[aip->shipnum].objnum]);
+		Script_system.RunCondition(CHA_ONGOALSCLEARED);
+		Script_system.RemHookVars(1, "Ship");
+	}
 
 }
 

--- a/code/scripting/scripting.cpp
+++ b/code/scripting/scripting.cpp
@@ -541,6 +541,10 @@ void script_state::SetHookObject(const char *name, object *objp)
 
 void script_state::SetHookObjects(int num, ...)
 {
+	if (LuaState == nullptr) {
+		return;
+	}
+
 	va_list vl;
 	va_start(vl, num);
 	if(this->OpenHookVarTable())
@@ -700,6 +704,10 @@ void script_state::UnloadImages()
 
 int script_state::RunCondition(int action, object* objp, int more_data)
 {
+	if (LuaState == nullptr) {
+		return;
+	}
+
 	int num = 0;
 	for(SCP_vector<ConditionedHook>::iterator chp = ConditionalHooks.begin(); chp != ConditionalHooks.end(); ++chp) 
 	{

--- a/code/scripting/scripting.cpp
+++ b/code/scripting/scripting.cpp
@@ -704,11 +704,12 @@ void script_state::UnloadImages()
 
 int script_state::RunCondition(int action, object* objp, int more_data)
 {
+	int num = 0;
+
 	if (LuaState == nullptr) {
-		return;
+		return num;
 	}
 
-	int num = 0;
 	for(SCP_vector<ConditionedHook>::iterator chp = ConditionalHooks.begin(); chp != ConditionalHooks.end(); ++chp) 
 	{
 		if(chp->ConditionsValid(action, objp, more_data))


### PR DESCRIPTION
The `On Goals Cleared` scripting hook resulted in FRED not working, thus this PR adds a check for a valid scripting state to `SetHookObjects` and `RunCondition`. Now FRED will run properly. Fixes PR #2159.