### PR TITLE
Make 2D sounds play from front speakers instead of rear.

### DIFF
--- a/code/sound/ds.cpp
+++ b/code/sound/ds.cpp
@@ -1061,7 +1061,7 @@ ds_sound_handle ds_play(int sid, int snd_id, int priority, const EnhancedSoundDa
 	}
 
 	if (pan) {
-		OpenAL_ErrorPrint( alSource3f(Channels[ch_idx].source_id, AL_POSITION, pan, 0.0f, 1.0f) );
+		OpenAL_ErrorPrint( alSource3f(Channels[ch_idx].source_id, AL_POSITION, pan, 0.0f, -1.0f) );
 	} else {
 		OpenAL_ErrorPrint( alSource3f(Channels[ch_idx].source_id, AL_POSITION, 0.0f, 0.0f, 0.0f) );
 	}
@@ -1206,7 +1206,7 @@ void ds_set_pan( int channel_id, float pan )
 
 	if (state == AL_PLAYING) {
 		//OpenAL_ErrorPrint( alSourcei(Channels[channel_id].source_id, AL_SOURCE_RELATIVE, AL_TRUE) );
-		OpenAL_ErrorPrint( alSource3f(Channels[channel_id].source_id, AL_POSITION, pan, 0.0f, 1.0f) );
+		OpenAL_ErrorPrint( alSource3f(Channels[channel_id].source_id, AL_POSITION, pan, 0.0f, -1.0f) );
 	}
 }
 


### PR DESCRIPTION
The Z coordinate, from negative to positive, means "front to back", so a Z value of 1.0 (with relative playback, which is what 2D sounds use) means "as far back as possible", i.e. the rear speakers. It's hard to know if this was intentional or not, but feedback from an actual user with a surround setup (@MjnMixael) is that the opposite is preferable.

Fixes #2173.