### PR TITLE
Fix Free look turning in the wrong directions

### DIFF
--- a/code/controlconfig/controlsconfigcommon.cpp
+++ b/code/controlconfig/controlsconfigcommon.cpp
@@ -111,7 +111,7 @@ config_item Control_config[CCFG_MAX + 1] = {
 	{                           KEY_PADMULTIPLY,    -1, COMPUTER_TAB, true,  "Chase View",                             CC_TYPE_TRIGGER,    -1, -1, 0, false, false },
 	{                           KEY_PADPERIOD,      -1, COMPUTER_TAB, true,  "External View",                          CC_TYPE_TRIGGER,    -1, -1, 0, false, false },
 	{                           KEY_PADENTER,       -1, COMPUTER_TAB, true,  "Toggle External Camera Lock",            CC_TYPE_TRIGGER,    -1, -1, 0, false, false },
-	{                           KEY_PAD0,           -1, COMPUTER_TAB, true,  "Free Look View",                         CC_TYPE_CONTINUOUS, -1, -1, 0, false, false }, // Not in use anymore (Swifty)
+	{                           KEY_PAD0,           -1, COMPUTER_TAB, true,  "Free Look View",                         CC_TYPE_CONTINUOUS, -1, -1, 0, false, false },
 	{                           KEY_PADDIVIDE,      -1, COMPUTER_TAB, true,  "Current Target View",                    CC_TYPE_TRIGGER,    -1, -1, 0, false, false },
 	{                           KEY_PADPLUS,        -1, COMPUTER_TAB, true,  "Increase View Distance",                 CC_TYPE_CONTINUOUS, -1, -1, 0, false, false },
 	{                           KEY_PADMINUS,       -1, COMPUTER_TAB, true,  "Decrease View Distance",                 CC_TYPE_CONTINUOUS, -1, -1, 0, false, false },

--- a/code/playerman/playercontrol.cpp
+++ b/code/playerman/playercontrol.cpp
@@ -219,12 +219,13 @@ void view_modify(angles *ma, angles *da, float max_p, float max_h, float frame_t
 
 	} else {
 		// Camera is unlocked - Pitch and Yaw axes control X and Y slew axes
-		t = (check_control_timef(YAW_LEFT) - check_control_timef(YAW_RIGHT));
-		u = (check_control_timef(PITCH_BACK) - check_control_timef(PITCH_FORWARD));
+		t = (check_control_timef(YAW_RIGHT) - check_control_timef(YAW_LEFT));
+		u = (check_control_timef(PITCH_FORWARD) - check_control_timef(PITCH_BACK));
 
 		playercontrol_read_stick(axis, frame_time);
 
-		h = -f2fl(axis[JOY_HEADING_AXIS]);
+		// Does the same thing as t and u but for the joystick input 
+		h = f2fl(axis[JOY_HEADING_AXIS]);
 		p = -f2fl(axis[JOY_PITCH_AXIS]);
 	}
 


### PR DESCRIPTION
Free look will now move in the same directions as ship controls, whether pitch or yaw, and whether using keyboard or mouse/joystick.

Also, remove an inaccurate comment, since freelook has been enabled.