### PR TITLE
Fix some CI issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -173,6 +173,12 @@ matrix:
       env: CONFIGURATION="Release" CMAKE_TOOLSET=v141_xp CMAKE_GENERATOR="Visual Studio 15 2017"
     - os: windows
       env: CONFIGURATION="Release" CMAKE_TOOLSET="" CMAKE_GENERATOR="Ninja"
+  # There is a GCC compiler bug with MinGW that causes compilation failures on Windows at the moment
+  allow_failures:
+    - os: windows
+      env: CONFIGURATION="Debug" CMAKE_TOOLSET="" CMAKE_GENERATOR="Ninja"
+    - os: windows
+      env: CONFIGURATION="Release" CMAKE_TOOLSET="" CMAKE_GENERATOR="Ninja"
   fast_finish: true
 
 before_install:

--- a/ci/travis/clang_tidy.sh
+++ b/ci/travis/clang_tidy.sh
@@ -12,7 +12,7 @@ cd "$TRAVIS_BUILD_DIR"
 echo "Running clang-tidy on changed files"
 git diff -U0 --no-color $TRAVIS_COMMIT_RANGE | \
     $TRAVIS_BUILD_DIR/ci/travis/clang-tidy-diff.py -path "$TRAVIS_BUILD_DIR/build" -p1 \
-    -regex 'code/.*$|freespace2/.*$|qtfred/.*$|test/src/.*$|build/.*$|tools/.*' \
+    -regex '(code|freespace2|qtfred|testsrc|build|tools)\/.*\.(cpp|h)' \
     -clang-tidy-binary /usr/bin/clang-tidy-9 -j$(nproc) -quiet 2>/dev/null | \
     tee clang-tidy-output.txt
 


### PR DESCRIPTION
First one is to allow MinGW failures since that is unreliable at the
moment. Second one is a fix for the regex used by clang-tidy so that it
doesn't try to analyze CMake files.