### PR TITLE
Fix RTT Subsystem Bracket Bug

### DIFF
--- a/code/hud/hudtargetbox.cpp
+++ b/code/hud/hudtargetbox.cpp
@@ -647,7 +647,12 @@ void HudGaugeTargetBox::renderTargetShip(object *target_objp)
 		if ( Player_ai->targeted_subsys == Player_ai->last_subsys_target ) {
 			vec3d save_pos;
 
-			gr_set_screen_scale(base_w, base_h);
+			if (gr_screen.rendering_to_texture != -1) {
+				gr_set_screen_scale(canvas_w, canvas_h, -1, -1, target_w, target_h, target_w, target_h, true);
+			} else {
+				gr_set_screen_scale(base_w, base_h);
+			}
+			
 			save_pos = target_objp->pos;
 			target_objp->pos = obj_pos;
 			subsys_in_view = hud_targetbox_subsystem_in_view(target_objp, &sx, &sy);


### PR DESCRIPTION
Previously, subsystem brackets in the target ship gauge were not always drawn in the correct location when using RTT with the gauge. This PR fixes that (#1303) by accounting for screen scaling of brackets when using RTT.