### PR TITLE
Standardize nonstandard "+nocreate" behavior in objecttypes.tbl

### DIFF
--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -4742,7 +4742,7 @@ static void parse_ship_type(const char *filename, const bool replace)
 {
 	char name_buf[NAME_LENGTH];
 	bool create_if_not_found = true;
-	ship_type_info *stp = NULL;
+	ship_type_info *stp = nullptr;
 
 	required_string("$Name:");
 	stuff_string(name_buf, F_NAME, NAME_LENGTH);


### PR DESCRIPTION
If you modified an existing ship type without using `+nocreate`, it would both modify it and add it to the vector again, leading to (at the very least) wasted memory. I copied over some more standard behavior from other parsing functions to hopefully avoid problems with modular objecttypes.