### PR TITLE
Hide FPS counter with the rest of HUD

### DIFF
--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -2121,7 +2121,7 @@ void game_show_framerate()
 #endif
 
 
-	if (Show_framerate || Cmdline_frame_profile || Cmdline_bmpman_usage) {
+	if ((Show_framerate && HUD_draw) || Cmdline_frame_profile || Cmdline_bmpman_usage) {
 		gr_set_color_fast(&HUD_color_debug);
 
 		if (Cmdline_frame_profile) {


### PR DESCRIPTION
A quick update that should allow for the FPS gauge to be hidden together with the rest of the HUD. Sounds useful for anyone wanting to take clean screenshots.
Also, thanks @wookiejedi for showing me how to do this.
(Will that even work? that's my first real meeting with GitHub so I'm a bit anxious.)