### PR TITLE
properly save single/multi mode setting

### DIFF
--- a/code/menuui/barracks.cpp
+++ b/code/menuui/barracks.cpp
@@ -1146,6 +1146,7 @@ void barracks_button_pressed(int n)
 				// make sure we don't carry over the multi flag
 				if (Cur_pilot->flags & PLAYER_FLAGS_IS_MULTI) {
 					Cur_pilot->flags &= ~PLAYER_FLAGS_IS_MULTI;
+					Cur_pilot->player_was_multi = 0;
 				}
 				Pilot.save_player(Cur_pilot);
 				barracks_init_player_stuff(PLAYER_SELECT_MODE_SINGLE);
@@ -1161,6 +1162,7 @@ void barracks_button_pressed(int n)
 			if (Player_sel_mode != PLAYER_SELECT_MODE_MULTI) {
 				gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 				Cur_pilot->flags |= PLAYER_FLAGS_IS_MULTI;
+				Cur_pilot->player_was_multi = 1;
 				Pilot.save_player(Cur_pilot);
 				barracks_init_player_stuff(PLAYER_SELECT_MODE_MULTI);
 			}
@@ -1303,9 +1305,11 @@ void barracks_accept_new_pilot_callsign()
 	// displayed correctly
 	if (Player_sel_mode == PLAYER_SELECT_MODE_SINGLE) {
 		Cur_pilot->flags &= ~(PLAYER_FLAGS_IS_MULTI);
+		Cur_pilot->player_was_multi = 0;
 	} else {
 		Cur_pilot->flags |= PLAYER_FLAGS_IS_MULTI;
 		Cur_pilot->stats.flags |= STATS_FLAG_MULTIPLAYER;
+		Cur_pilot->player_was_multi = 1;
 	}
 
 	if ( !(Game_mode & GM_STANDALONE_SERVER) ) {
@@ -1542,11 +1546,13 @@ void barracks_do_frame(float  /*frametime*/)
 
 				if (Player_sel_mode == PLAYER_SELECT_MODE_SINGLE) {
 					Cur_pilot->flags |= PLAYER_FLAGS_IS_MULTI;
+					Cur_pilot->player_was_multi = 1;
 					Pilot.save_player(Cur_pilot);
 					barracks_init_player_stuff(PLAYER_SELECT_MODE_MULTI);
 				} else {
 					// make sure we don't carry over the multi flag
 					Cur_pilot->flags &= ~PLAYER_FLAGS_IS_MULTI;
+					Cur_pilot->player_was_multi = 0;
 					Pilot.save_player(Cur_pilot);
 					barracks_init_player_stuff(PLAYER_SELECT_MODE_SINGLE);
 				}

--- a/code/menuui/playermenu.cpp
+++ b/code/menuui/playermenu.cpp
@@ -504,6 +504,12 @@ void player_select_close()
 		Pilot.load_savefile(Player, Player->current_campaign);
 	}
 
+	if (Player_select_mode == PLAYER_SELECT_MODE_MULTI) {
+		Player->player_was_multi = 1;
+	} else {
+		Player->player_was_multi = 0;
+	}
+
 	os_config_write_string(nullptr, "LastPlayer", Player->callsign);
 
 	if (Player_select_force_main_hall != "") {
@@ -1092,6 +1098,9 @@ void player_select_process_input(int k)
 		if (Player_select_mode == PLAYER_SELECT_MODE_MULTI) {
 			Player->flags |= PLAYER_FLAGS_IS_MULTI;
 			Player->stats.flags |= STATS_FLAG_MULTIPLAYER;
+			Player->player_was_multi = 1;
+		} else {
+			Player->player_was_multi = 0;
 		}
 
 		// create his pilot file


### PR DESCRIPTION
This will update the pilot file setting that remembers player mode (single or multi). The setting was read and written correctly but never actually updated when changing modes.