### PR TITLE
Allow sexp-tree for `key-pressed` to actually show what the mod will use

### DIFF
--- a/fred2/fred.cpp
+++ b/fred2/fred.cpp
@@ -331,7 +331,6 @@ BOOL CFREDApp::InitInstance() {
 
 	h_cursor_move = LoadCursor(IDC_CURSOR1);
 	h_cursor_rotate = LoadCursor(IDC_CURSOR2);
-
 	return TRUE;
 }
 

--- a/fred2/fred.cpp
+++ b/fred2/fred.cpp
@@ -331,6 +331,13 @@ BOOL CFREDApp::InitInstance() {
 
 	h_cursor_move = LoadCursor(IDC_CURSOR1);
 	h_cursor_rotate = LoadCursor(IDC_CURSOR2);
+
+	// wookieejedi
+	// load in the controls and defaults including the controlconfigdefault.tbl
+	// this allows the sexp tree in key-pressed to actually match what the game will use
+	// especially useful when a custom Controlconfigdefaults.tbl is used
+	control_config_common_init();
+
 	return TRUE;
 }
 

--- a/fred2/fred.cpp
+++ b/fred2/fred.cpp
@@ -332,12 +332,6 @@ BOOL CFREDApp::InitInstance() {
 	h_cursor_move = LoadCursor(IDC_CURSOR1);
 	h_cursor_rotate = LoadCursor(IDC_CURSOR2);
 
-	// wookieejedi
-	// load in the controls and defaults including the controlconfigdefault.tbl
-	// this allows the sexp tree in key-pressed to actually match what the game will use
-	// especially useful when a custom Controlconfigdefaults.tbl is used
-	control_config_common_init();
-
 	return TRUE;
 }
 

--- a/fred2/management.cpp
+++ b/fred2/management.cpp
@@ -462,6 +462,12 @@ bool fred_init(std::unique_ptr<os::GraphicsOperations>&& graphicsOps)
 
 	Script_system.RunCondition(CHA_GAMEINIT);
 
+	// wookieejedi
+	// load in the controls and defaults including the controlconfigdefault.tbl
+	// this allows the sexp tree in key-pressed to actually match what the game will use
+	// especially useful when a custom Controlconfigdefaults.tbl is used
+	control_config_common_init();
+
 	return true;
 }
 

--- a/fred2/management.cpp
+++ b/fred2/management.cpp
@@ -448,6 +448,12 @@ bool fred_init(std::unique_ptr<os::GraphicsOperations>&& graphicsOps)
 
 	sexp::dynamic_sexp_init();
 
+	// wookieejedi
+	// load in the controls and defaults including the controlconfigdefault.tbl
+	// this allows the sexp tree in key-pressed to actually match what the game will use
+	// especially useful when a custom Controlconfigdefaults.tbl is used
+	control_config_common_init();
+
 	gr_reset_clip();
 	g3_start_frame(0);
 	g3_set_view_matrix(&eye_pos, &eye_orient, 0.5f);
@@ -461,12 +467,6 @@ bool fred_init(std::unique_ptr<os::GraphicsOperations>&& graphicsOps)
 	Fred_main_wnd -> init_tools();
 
 	Script_system.RunCondition(CHA_GAMEINIT);
-
-	// wookieejedi
-	// load in the controls and defaults including the controlconfigdefault.tbl
-	// this allows the sexp tree in key-pressed to actually match what the game will use
-	// especially useful when a custom Controlconfigdefaults.tbl is used
-	control_config_common_init();
 
 	return true;
 }

--- a/qtfred/src/mission/management.cpp
+++ b/qtfred/src/mission/management.cpp
@@ -247,15 +247,15 @@ initialize(const std::string& cfilepath, int argc, char* argv[], Editor* editor,
 	listener(SubSystem::DynamicSEXPs);
 	sexp::dynamic_sexp_init();
 
-	listener(SubSystem::ScriptingInitHook);
-	Script_system.RunCondition(CHA_GAMEINIT);
-	
 	// wookieejedi
 	// load in the controls and defaults including the controlconfigdefault.tbl
 	// this allows the sexp tree in key-pressed to actually match what the game will use
 	// especially useful when a custom Controlconfigdefaults.tbl is used
 	control_config_common_init();
 
+	listener(SubSystem::ScriptingInitHook);
+	Script_system.RunCondition(CHA_GAMEINIT);
+	
 	return true;
 }
 

--- a/qtfred/src/mission/management.cpp
+++ b/qtfred/src/mission/management.cpp
@@ -249,6 +249,12 @@ initialize(const std::string& cfilepath, int argc, char* argv[], Editor* editor,
 
 	listener(SubSystem::ScriptingInitHook);
 	Script_system.RunCondition(CHA_GAMEINIT);
+	
+	// wookieejedi
+	// load in the controls and defaults including the controlconfigdefault.tbl
+	// this allows the sexp tree in key-pressed to actually match what the game will use
+	// especially useful when a custom Controlconfigdefaults.tbl is used
+	control_config_common_init();
 
 	return true;
 }


### PR DESCRIPTION
This PR allows modders/FREDers to actually see what default controls available are in FRED and not the hard coded ones from `Control_config` that may not be relevant for their mod. For example, a mod may disable many controls and change the default key for many controls in the table, but that is currently not reflected in FRED since FRED simply checks the hard-coded ones from `Control_config`. I tested this and it works exactly as expected.

Example:
Previously, if the modder specifies a default key for, say, `Enter Subspace (End Mission)` as `Enter` instead of `Alt-J` in `Controlconfigdefaults.tbl` then the game will only look for if `Enter` was pressed, whereas the `key-pressed` tree in FRED will not show that and will still show `Alt-J`. Then if the FREDer uses `Alt-J` it won't ever actually trigger in-game since the control table has switched it to `Enter`. This PR would allow FRED to properly show `Enter` instead of `Alt-J` in the sexp tree for `key-pressed`.

Background:
1) Game reads the hard-coded values for each key and saves in `Control_config`
2) Game parses `Controlconfigdefaults.tbl` and updates the default keys in `Control_config` with any that are specified in that table.
3) Now the key defaults have been changed, and when `key-pressed` is called it searches for it's argument in the updated `Control_config` array, but only searches for the default. Thus even if the player changed the key, it will still find it and properly convert it.

All of that works well and as expected. But FRED never goes beyond step 1, so when FREDing I don't use the drop down tree for `key-pressed` since it doesn't actually match what the game will know when it parses `Controlconfigdefaults.tbl` in step 2. This PR fixes that. 