### PR TITLE
Add deprecation warning for VM_EXTERNAL_CAMERA_LOCKED

### DIFF
--- a/code/scripting/api/libs/graphics.cpp
+++ b/code/scripting/api/libs/graphics.cpp
@@ -1481,6 +1481,7 @@ ADE_FUNC(hasViewmode, l_Graphics, "enumeration", "Specifies if the current viemo
 		return ade_set_error(L, "b", false);
 
 	int bit = 0;
+	static bool VM_EXTERNAL_CAMERA_LOCKED_WARNED = false;
 
 	switch(type->index)
 	{
@@ -1505,6 +1506,13 @@ ADE_FUNC(hasViewmode, l_Graphics, "enumeration", "Specifies if the current viemo
 			break;
 
 		case LE_VM_EXTERNAL_CAMERA_LOCKED:
+		    if (!VM_EXTERNAL_CAMERA_LOCKED_WARNED) {
+			    Warning(LOCATION, "The enumeration VM_EXTERNAL_CAMERA_LOCKED has been deprecated for lua function "
+			                      "hasViewmode()! To ensure future compatibility, please check for either "
+			                      "VM_CAMERA_LOCKED, VM_EXTERNAL, or both, instead.");		    
+				VM_EXTERNAL_CAMERA_LOCKED_WARNED = true;
+			}
+
 			return ade_set_args(L, "b", ((Viewer_mode & VM_CAMERA_LOCKED) && (Viewer_mode & VM_EXTERNAL)) != 0);
 			break;
 

--- a/code/scripting/lua.cpp
+++ b/code/scripting/lua.cpp
@@ -363,11 +363,17 @@ void script_state::OutputLuaMeta(FILE *fp)
 	//***Enumerations
 	fprintf(fp, "<dt id=\"Enumerations\"><h2>Enumerations</h2></dt>");
 	for (uint32_t i = 0; i < Num_enumerations; i++) {
-		//WMC - This is in case we ever want to add descriptions to enums.
-		//fprintf(fp, "<dd><dl><dt><b>%s</b></dt><dd>%s</dd></dl></dd>", Enumerations[i].name, Enumerations[i].desc);
 
-		//WMC - Otherwise, just use this.
-		fprintf(fp, "<dd><b>%s</b></dd>", Enumerations[i].name);
+		// Cyborg17 -- Omit the deprecated flag
+		if (!stricmp(Enumerations[i].name,
+		             "VM_EXTERNAL_CAMERA_LOCKED") /* || !stricmp(Enumerations[i], "ADD DEPRECATED ENUM HERE"*/) {
+			continue;
+		}		
+		// WMC - This is in case we ever want to add descriptions to enums.
+		// fprintf(fp, "<dd><dl><dt><b>%s</b></dt><dd>%s</dd></dl></dd>", Enumerations[i].name, Enumerations[i].desc);
+  
+		// WMC - For now, print to the file without the description.
+		fprintf(fp, "<dd><b>%s</b></dd>", Enumerations[i].name);		
 	}
 	fputs("</dl>\n", fp);
 


### PR DESCRIPTION
Previously deprecated enum for lua function hasViewmode() didn't have a warning.  This fixes that. (And only does it once per instance, test confirmed)

Also, I am adding a check to omit it while writing scripting.html so that modders don't accidentally pick start using it.

It still has the correct behavior from the last time it was edited, tested via a script written by @wookieejedi which checks each flag per frame.  The camera modes are enabled via keyboard controls.  Pressing number pad . turns on the external camera, and pressing number pad enter locks that camera.  The script showed that the check for VM_EXTERNAL_CAMERA_LOCKED returned true only when both VM_EXTERNAL and VM_CAMERA_LOCKED are true.

Only step left for us to is change wiki documentation and do a quick check for documentation elsewhere.

For  #1066 .