### PR TITLE
Make Dinky Shockwaves not dinky by default.

### DIFF
--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -48,7 +48,7 @@ SCP_string Window_icon_path;
 bool Disable_built_in_translations;
 bool Weapon_shockwaves_respect_huge;
 bool Using_in_game_options;
-bool Dinky_shockwaves_by_default;
+float Dinky_shockwave_default_multiplier;
 std::tuple<ubyte, ubyte, ubyte> Arc_color_damage_p1;
 std::tuple<ubyte, ubyte, ubyte> Arc_color_damage_p2;
 std::tuple<ubyte, ubyte, ubyte> Arc_color_damage_s1;
@@ -498,13 +498,10 @@ void parse_mod_table(const char *filename)
 			}
 		}
 
-		if (optional_string("$Default Dinky Shockwaves:")) {
-			stuff_boolean(&Dinky_shockwaves_by_default);
-
-			if (Dinky_shockwaves_by_default) {
-				mprintf(("Game Settings Table: Using default dinky shockwaves.\n"));
-			} else {
-				mprintf(("Game Settings Table: Not using default dinky shockwaves.\n"));
+		if (optional_string("$Dinky Shockwave Default Multiplier:")) {
+			stuff_float(&Dinky_shockwave_default_multiplier);
+			if (Dinky_shockwave_default_multiplier != 1.0f) {
+				mprintf(("Game Settings Table: Setting default dinky shockwave multiplier to %.2f.\n", Dinky_shockwave_default_multiplier));
 			}
 		}
 
@@ -568,6 +565,7 @@ void mod_table_reset() {
 	Disable_built_in_translations = false;
 	Weapon_shockwaves_respect_huge = false;
 	Using_in_game_options = false;
+	Dinky_shockwave_default_multiplier = 1.0f;
 	Arc_color_damage_p1 = std::make_tuple(static_cast<ubyte>(64), static_cast<ubyte>(64), static_cast<ubyte>(225));
 	Arc_color_damage_p2 = std::make_tuple(static_cast<ubyte>(128), static_cast<ubyte>(128), static_cast<ubyte>(255));
 	Arc_color_damage_s1 = std::make_tuple(static_cast<ubyte>(200), static_cast<ubyte>(200), static_cast<ubyte>(255));

--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -48,6 +48,7 @@ SCP_string Window_icon_path;
 bool Disable_built_in_translations;
 bool Weapon_shockwaves_respect_huge;
 bool Using_in_game_options;
+bool Dinky_shockwaves_by_default;
 std::tuple<ubyte, ubyte, ubyte> Arc_color_damage_p1;
 std::tuple<ubyte, ubyte, ubyte> Arc_color_damage_p2;
 std::tuple<ubyte, ubyte, ubyte> Arc_color_damage_s1;
@@ -494,6 +495,16 @@ void parse_mod_table(const char *filename)
 				mprintf(("Game Settings Table: Using in-game options system.\n"));
 			} else {
 				mprintf(("Game Settings Table: Not using in-game options system.\n"));
+			}
+		}
+
+		if (optional_string("$Default Dinky Shockwaves:")) {
+			stuff_boolean(&Dinky_shockwaves_by_default);
+
+			if (Dinky_shockwaves_by_default) {
+				mprintf(("Game Settings Table: Using default dinky shockwaves.\n"));
+			} else {
+				mprintf(("Game Settings Table: Not using default dinky shockwaves.\n"));
 			}
 		}
 

--- a/code/mod_table/mod_table.h
+++ b/code/mod_table/mod_table.h
@@ -39,7 +39,7 @@ extern SCP_string Window_icon_path;
 extern bool Disable_built_in_translations;
 extern bool Weapon_shockwaves_respect_huge;
 extern bool Using_in_game_options;
-extern bool Dinky_shockwaves_by_default;
+extern float Dinky_shockwave_default_multiplier;
 extern std::tuple<ubyte, ubyte, ubyte> Arc_color_damage_p1;
 extern std::tuple<ubyte, ubyte, ubyte> Arc_color_damage_p2;
 extern std::tuple<ubyte, ubyte, ubyte> Arc_color_damage_s1;

--- a/code/mod_table/mod_table.h
+++ b/code/mod_table/mod_table.h
@@ -39,6 +39,7 @@ extern SCP_string Window_icon_path;
 extern bool Disable_built_in_translations;
 extern bool Weapon_shockwaves_respect_huge;
 extern bool Using_in_game_options;
+extern bool Dinky_shockwaves_by_default;
 extern std::tuple<ubyte, ubyte, ubyte> Arc_color_damage_p1;
 extern std::tuple<ubyte, ubyte, ubyte> Arc_color_damage_p2;
 extern std::tuple<ubyte, ubyte, ubyte> Arc_color_damage_s1;

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -1133,9 +1133,7 @@ int parse_weapon(int subtype, bool replace, const char *filename)
 	if(first_time)
 	{
 		wip->dinky_shockwave = wip->shockwave;
-		if (Dinky_shockwaves_by_default) {
-			wip->dinky_shockwave.damage /= 4.0f;
-		}
+		wip->dinky_shockwave.damage *= Dinky_shockwave_default_multiplier;
 	}
 
 	if(optional_string("$Dinky shockwave:"))

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -25,6 +25,7 @@
 #include "io/timer.h"
 #include "math/staticrand.h"
 #include "missionui/missionweaponchoice.h"
+#include "mod_table/mod_table.h"
 #include "network/multi.h"
 #include "network/multimsgs.h"
 #include "network/multiutil.h"
@@ -1132,7 +1133,9 @@ int parse_weapon(int subtype, bool replace, const char *filename)
 	if(first_time)
 	{
 		wip->dinky_shockwave = wip->shockwave;
-		wip->dinky_shockwave.damage /= 4.0f;
+		if (Dinky_shockwaves_by_default) {
+			wip->dinky_shockwave.damage /= 4.0f;
+		}
 	}
 
 	if(optional_string("$Dinky shockwave:"))


### PR DESCRIPTION
Adds a new mod table option "$Default Dinky Shockwaves:" that toggles the behavior. See issue #774 for more information.

Needless to say, fixes #774.