### PR TITLE
fix Trails.next pointing to invalid address

### DIFF
--- a/code/weapon/trails.cpp
+++ b/code/weapon/trails.cpp
@@ -40,6 +40,7 @@ void trail_level_close()
 	}
 
 	Num_trails=0;
+	Trails.next = &Trails;
 }
 
 //returns the number of a free trail


### PR DESCRIPTION
Trails.next is initialized on `level_init()` but not `level_close()`. This can cause issues if `game_frame()` is called after the mission is closed out.