### PR TITLE
avoid ending mission on death unless we should

### DIFF
--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -5464,36 +5464,39 @@ void game_leave_state( int old_state, int new_state )
 			break;
 
 		case GS_STATE_DEATH_DIED:
-			Game_mode &= ~GM_DEAD_DIED;
+			if (end_mission) {
+				Game_mode &= ~GM_DEAD_DIED;
 
-			if ( !(Game_mode & GM_MULTIPLAYER) ) {
-				if ( end_mission && (new_state == GS_STATE_DEBRIEF) ) {
-					freespace_stop_mission();
-				}
-			} else {
-				// early end while respawning or blowing up in a multiplayer game
-				if ( (new_state == GS_STATE_DEBRIEF) || (new_state == GS_STATE_MULTI_DOGFIGHT_DEBRIEF) ) {
-					game_stop_time();
-					freespace_stop_mission();
+				if ( !(Game_mode & GM_MULTIPLAYER) ) {
+					if (new_state == GS_STATE_DEBRIEF) {
+						freespace_stop_mission();
+					}
+				} else {
+					// early end while respawning or blowing up in a multiplayer game
+					if ( (new_state == GS_STATE_DEBRIEF) || (new_state == GS_STATE_MULTI_DOGFIGHT_DEBRIEF) ) {
+						game_stop_time();
+						freespace_stop_mission();
+					}
 				}
 			}
+
 			break;
 
 		case GS_STATE_DEATH_BLEW_UP:
-			Game_mode &= ~GM_DEAD_BLEW_UP;
+			if (end_mission) {
+				Game_mode &= ~GM_DEAD_BLEW_UP;
 
-			// for single player, we might reload mission, etc.  For multiplayer, look at my new state
-			// to determine if I should do anything.
-			if ( !(Game_mode & GM_MULTIPLAYER) ) {
-				if ( end_mission ){
+				// for single player, we might reload mission, etc.  For multiplayer, look at my new state
+				// to determine if I should do anything.
+				if ( !(Game_mode & GM_MULTIPLAYER) ) {
 					freespace_stop_mission();
-				}
-			} else {
-				// if we are not respawing as an observer or as a player, our new state will not
-				// be gameplay state.
-				if ( (new_state != GS_STATE_GAME_PLAY) && (new_state != GS_STATE_MULTI_PAUSED) ) {
-					game_stop_time();									// hasn't been called yet!!
-					freespace_stop_mission();
+				} else {
+					// if we are not respawing as an observer or as a player, our new state will not
+					// be gameplay state.
+					if ( (new_state != GS_STATE_GAME_PLAY) && (new_state != GS_STATE_MULTI_PAUSED) ) {
+						game_stop_time();									// hasn't been called yet!!
+						freespace_stop_mission();
+					}
 				}
 			}
 			break;


### PR DESCRIPTION
When dead, particularly in multi, the mission is closed out even if we aren't done with it. Various menus are still accessible but once you exit the menu it returns to processing the game frame as normal, except everything got closed out which triggers a multitude of asserts and other problems. This should fix Mantis 2377 and anything related.