### PR TITLE
Make Respawning independent from Ship Names

### DIFF
--- a/code/network/multi_ingame.cpp
+++ b/code/network/multi_ingame.cpp
@@ -1067,7 +1067,7 @@ void process_ingame_ships_packet( ubyte *data, header *hinfo )
 			// get the team and slot.  Team will be -1 when it isn't a part of player wing.  So, if
 			// not -1, then be sure we have a valid slot, then change the ship type, etc.
 			objp = &Objects[Ships[idx].objnum];		
-			multi_ts_get_team_and_slot(Ships[idx].ship_name, &team_val, &slot_index);
+			multi_ts_get_team_and_slot(&Ships[idx], &team_val, &slot_index);
 			if ( team_val != -1 ) {
 				Assert( slot_index != -1 );
 
@@ -1661,7 +1661,7 @@ void process_ingame_ship_request_packet(ubyte *data, header *hinfo)
 
 		// must change the ship type and weapons.  An ingame joiner know about the default class
 		// and weapons for a ship, but these could have changed.
-		multi_ts_get_team_and_slot(Player_ship->ship_name, &team, &slot_index);
+		multi_ts_get_team_and_slot(Player_ship, &team, &slot_index);
 		Assert( team != -1 );
 		Assert( slot_index != -1 );
 		change_ship_type(objp->instance, Wss_slots_teams[team][slot_index].ship_class);

--- a/code/network/multi_respawn.cpp
+++ b/code/network/multi_respawn.cpp
@@ -332,10 +332,11 @@ int multi_respawn_common_stuff(p_object *pobjp)
 	objnum = parse_create_object(pobjp);
 	Assert(objnum != -1);
 	objp = &Objects[objnum];
+	Assert(objp->type == OBJ_SHIP);
 
 	// get the team and slot
 	shipp = &Ships[objp->instance];
-	multi_ts_get_team_and_slot(shipp->ship_name, &team, &slot_index);
+	multi_ts_get_team_and_slot(shipp, &team, &slot_index);
 	Assert( team != -1 );
 	Assert( slot_index != -1 );
 

--- a/code/network/multiteamselect.h
+++ b/code/network/multiteamselect.h
@@ -17,6 +17,7 @@
 //
 #include "globalincs/pstypes.h"
 #include "gamesnd/gamesnd.h"
+#include "ship/ship.h"
 
 struct header;
 
@@ -74,7 +75,7 @@ void multi_ts_commit_pressed();
 int multi_ts_get_team(char *ship_name);
 
 // function to get the team and slot of a particular ship
-void multi_ts_get_team_and_slot(char *ship_name,int *team_index,int *slot_index, bool mantis2757switch = false);
+void multi_ts_get_team_and_slot(ship *shipp, int *team_index, int *slot_index);
 
 // function to return the shipname of the ship belonging in slot N
 void multi_ts_get_shipname( char *ship_name, int team, int slot_index );

--- a/code/object/object.cpp
+++ b/code/object/object.cpp
@@ -1084,8 +1084,8 @@ void obj_set_flags( object *obj, const flagset<Object::Object_Flags>& new_flags 
 
 		// see if this ship is really a player ship (or should be)
 		shipp = &Ships[obj->instance];
-		extern void multi_ts_get_team_and_slot(char *, int *, int *, bool);
-		multi_ts_get_team_and_slot(shipp->ship_name,&team,&slot, false);
+		extern void multi_ts_get_team_and_slot(ship *, int *, int *);
+		multi_ts_get_team_and_slot(shipp,&team,&slot);
 		if ( (shipp->wingnum == -1) || (team == -1) || (slot==-1) ) {
 			Int3();
 			return;


### PR DESCRIPTION
Changes the way `multi_ts_get_team_and_slot()` searches for the correct slot in order to keep return values from being -1 whenever the current method would run into trouble, like when "#" is used in a wing name, or when `Ship[]` is cleared after a ship's death (thank you, Taylor!!!).  This iteration of the function pulls the wing name directly from a pointer to the `Ships[]` array and also gets more info from a pointer to the 'Wings[]' array.

Tested as a host in a coop match, but needs three more quick things for testing,
1. Need to check to make sure it works for clients as well as hosts (more than likely already does, but let's be sure)
2. Need to check that this works in TVT
3. Need to check that correct loadout is being given to the respawned ship