### PR TITLE
make internal variables in static_rand unsigned.

### DIFF
--- a/code/math/staticrand.cpp
+++ b/code/math/staticrand.cpp
@@ -7,26 +7,21 @@
  *
 */ 
 
-
-
 #include "math/staticrand.h"
 #include "math/vecmat.h"
 
-
-int Semirand_inited = 0;
-int Semirand[SEMIRAND_MAX];
+bool Semirand_inited = false;
+unsigned int Semirand[SEMIRAND_MAX];
 
 /**
  * @brief Initialize Semirand array. Doesn't have to be called.
  */
 void init_semirand()
 {
-	int	i;
+	Semirand_inited = true;
 
-	Semirand_inited = 1;
-
-	for (i=0; i<SEMIRAND_MAX; i++)
-		Semirand[i] = (myrand() << 15) + myrand();
+	for (auto & number : Semirand)
+		number = (static_cast<unsigned>(myrand()) << 15u) + myrand();
 }
 
 /**
@@ -37,17 +32,16 @@ void init_semirand()
  */
 int static_rand(int num)
 {
-	int	a, b, c;
-
-	if (num < 0) 
+	if (num < 0)
 		num *= -1;
 
 	if (!Semirand_inited)
 		init_semirand();
 
-	a = num & (SEMIRAND_MAX - 1);
-	b = (num >> SEMIRAND_MAX_LOG) & (SEMIRAND_MAX - 1);
-	c = (num >> (2 * SEMIRAND_MAX_LOG)) & (SEMIRAND_MAX - 1);
+	const unsigned int num_unsigned = num;
+	auto a = num_unsigned & (SEMIRAND_MAX - 1);
+	auto b = (num_unsigned >> SEMIRAND_MAX_LOG) & (SEMIRAND_MAX - 1);
+	auto c = (num_unsigned >> (2 * SEMIRAND_MAX_LOG)) & (SEMIRAND_MAX - 1);
 
 	return Semirand[a] ^ Semirand[b] ^ Semirand[c];
 }
@@ -60,10 +54,7 @@ int static_rand(int num)
  */
 float static_randf(int num)
 {
-	int	a;
-
-	a = static_rand(num);
-
+	unsigned int	a = static_rand(num);
 	return (a & 0xffff) / 65536.0f;
 }
 
@@ -94,9 +85,7 @@ int static_rand_range(int num, int min, int max)
  */
 float static_randf_range(int num, float min, float max)
 {
-	float	rval;
-	
-	rval = static_randf(num);
+	float rval = static_randf(num);
 	rval = rval * (max - min) + min;
 
 	return rval;
@@ -133,10 +122,10 @@ void static_rand_cone(int num, vec3d *out, vec3d *in, float max_angle, matrix *o
 	matrix m;
 
 	// get an orientation matrix
-	if(orient != NULL){
+	if(orient != nullptr){
 		rot = orient;
 	} else {
-		vm_vector_2_matrix(&m, in, NULL, NULL);
+		vm_vector_2_matrix(&m, in, nullptr, nullptr);
 		rot = &m;
 	}
 	
@@ -153,12 +142,12 @@ void static_rand_cone(int num, vec3d *out, vec3d *in, float max_angle, matrix *o
 /////////////////////////////////////////////////////////////////////
 // Alternate random number generator, that doesn't affect rand() sequence
 /////////////////////////////////////////////////////////////////////
-#define RND_MASK	0x6000
-#define RND_MAX	0x7fff
-int Rnd_seed = 1;
+constexpr unsigned int RND_MASK = 0x6000;
+constexpr int RND_MAX = 0x7fff;
+unsigned int Rnd_seed = 1;
 
-/** 
- * @brief Seed the alternative random number generator. 
+/**
+ * @brief Seed the alternative random number generator.
  * Doesn't have to be called.
  *
  * @param seed Seed input number
@@ -175,11 +164,10 @@ void init_static_rand_alt(int seed)
  */
 int static_rand_alt()
 {
-	static int x=Rnd_seed;
-	int old_x;
-	old_x = x;
-	x >>= 1;
-	if ( old_x & 1 ) {
+	static unsigned int x=Rnd_seed;
+	unsigned int old_x = x;
+	x >>= 1u;
+	if ( old_x & 1u ) {
 		x ^= RND_MASK;
 	}
 	return x;

--- a/code/math/staticrand.h
+++ b/code/math/staticrand.h
@@ -14,10 +14,8 @@
 
 #include "globalincs/pstypes.h"
 
-#define	SEMIRAND_MAX_LOG	4
-#define	SEMIRAND_MAX		(2 << SEMIRAND_MAX_LOG)	//	Do not change this!  Change SEMIRAND_MAX_LOG!
-
-extern int Semirand[SEMIRAND_MAX];			// this array is saved by the ai code on save/restore
+constexpr unsigned int SEMIRAND_MAX_LOG = 4;
+constexpr unsigned int SEMIRAND_MAX = (2u << SEMIRAND_MAX_LOG); //Do not change this!  Change SEMIRAND_MAX_LOG!
 
 extern void init_semirand();
 extern int static_rand(int num);
@@ -25,12 +23,14 @@ extern float static_randf(int num);
 extern void static_randvec(int num, vec3d *vp);
 extern int static_rand_range(int num, int min, int max);
 extern float static_randf_range(int num, float min, float max);
-void static_rand_cone(int num, vec3d *out, vec3d *in, float max_angle, matrix *orient = NULL);
+void static_rand_cone(int num, vec3d *out, vec3d *in, float max_angle, matrix *orient = nullptr);
 
 // Alternate random number generator that doesn't affect rand() sequence
-
-void	init_static_rand_alt(int seed);	// Seed the random number generator
-int		static_rand_alt();				// Get a random integer between 1 and RND_MAX
-float	static_randf_alt();				// Get a random float between 0 and 1.0
+/// Get a random integer between 1 and RND_MAX
+int static_rand_alt();
+/// Seed the random number generator
+void init_static_rand_alt(int seed);
+/// Get a random float between 0 and 1.0
+float static_randf_alt();
 
 #endif


### PR DESCRIPTION
several of the bitwise manipulations on signed integers are technically undefined behaviour.
I made the internal variables unsigned and the results are then converted to signed ints as before.
This should not actually change any observable results.

Did some cleanup as well, while I was at it.

Fixes the first part of  #1210