### PR TITLE
Fixes accidental break with multi due to max key numbers

### DIFF
--- a/code/controlconfig/controlsconfig.h
+++ b/code/controlconfig/controlsconfig.h
@@ -286,8 +286,6 @@ enum IoActionId  {
 	CUSTOM_CONTROL_1								= 125,
 	CUSTOM_CONTROL_2								= 126,
 	CUSTOM_CONTROL_3								= 127,
-	CUSTOM_CONTROL_4								= 128,
-	CUSTOM_CONTROL_5								= 129,
 
 	/*!
 	 * This must always be below the last defined item

--- a/code/controlconfig/controlsconfig.h
+++ b/code/controlconfig/controlsconfig.h
@@ -271,21 +271,13 @@ enum IoActionId  {
 	CYCLE_PRIMARY_WEAPON_SEQUENCE					=118,	//!< cycle num primaries to fire at once
 
 	//!< @n
-	//!< Key 0 and 5-9 slots
-	//!< ----------------------------
-	CONTROL_KEY_0									= 119,
-	CONTROL_KEY_5									= 120,
-	CONTROL_KEY_6									= 121,
-	CONTROL_KEY_7									= 122,
-	CONTROL_KEY_8									= 123,
-	CONTROL_KEY_9									= 124,
-
-	//!< @n
 	//!< Custom control slots
 	//!< ----------------------------
-	CUSTOM_CONTROL_1								= 125,
-	CUSTOM_CONTROL_2								= 126,
-	CUSTOM_CONTROL_3								= 127,
+	CUSTOM_CONTROL_1								= 119,
+	CUSTOM_CONTROL_2								= 120,
+	CUSTOM_CONTROL_3								= 121,
+	CUSTOM_CONTROL_4								= 122,
+	CUSTOM_CONTROL_5								= 123,
 
 	/*!
 	 * This must always be below the last defined item

--- a/code/controlconfig/controlsconfigcommon.cpp
+++ b/code/controlconfig/controlsconfigcommon.cpp
@@ -198,8 +198,6 @@ config_item Control_config[CCFG_MAX + 1] = {
 	{ KEY_ALTED | KEY_SHIFTED | KEY_1,              -1, COMPUTER_TAB, 0, "Custom Control 1",                       CC_TYPE_TRIGGER,    -1, -1, 0, true,  false },
 	{ KEY_ALTED | KEY_SHIFTED | KEY_2,              -1, COMPUTER_TAB, 0, "Custom Control 2",                       CC_TYPE_TRIGGER,    -1, -1, 0, true,  false },
 	{ KEY_ALTED | KEY_SHIFTED | KEY_3,              -1, COMPUTER_TAB, 0, "Custom Control 3",                       CC_TYPE_TRIGGER,    -1, -1, 0, true,  false },
-	{ KEY_ALTED | KEY_SHIFTED | KEY_4,              -1, COMPUTER_TAB, 0, "Custom Control 4",                       CC_TYPE_TRIGGER,    -1, -1, 0, true,  false },
-	{ KEY_ALTED | KEY_SHIFTED | KEY_5,              -1, COMPUTER_TAB, 0, "Custom Control 5",                       CC_TYPE_TRIGGER,    -1, -1, 0, true,  false },
 	{                           -1,                 -1, -1,           0, "",                                       CC_TYPE_TRIGGER,    -1, -1, 0, false, false }
 };
 

--- a/code/controlconfig/controlsconfigcommon.cpp
+++ b/code/controlconfig/controlsconfigcommon.cpp
@@ -189,15 +189,11 @@ config_item Control_config[CCFG_MAX + 1] = {
 	{ KEY_ALTED |               KEY_N,              -1, COMPUTER_TAB, 0, "Cycle Nav Points",                       CC_TYPE_TRIGGER,    -1, -1, 0, false, false },
 	{ KEY_ALTED |               KEY_G,              -1, SHIP_TAB,     0, "Toggle Gliding",                         CC_TYPE_TRIGGER,    -1, -1, 0, false, false },
 	{                           KEY_O,              -1, WEAPON_TAB,   0, "Cycle Primary Weapon Firing Rate",       CC_TYPE_TRIGGER,    -1, -1, 0, false, false },
-	{                           KEY_0,              -1, COMPUTER_TAB, 0, "Key 0",                                  CC_TYPE_TRIGGER,    -1, -1, 0, false, false },
-	{                           KEY_5,              -1, COMPUTER_TAB, 0, "Key 5",                                  CC_TYPE_TRIGGER,    -1, -1, 0, false, false },
-	{                           KEY_6,              -1, COMPUTER_TAB, 0, "Key 6",                                  CC_TYPE_TRIGGER,    -1, -1, 0, false, false },
-	{                           KEY_7,              -1, COMPUTER_TAB, 0, "Key 7",                                  CC_TYPE_TRIGGER,    -1, -1, 0, false, false },
-	{                           KEY_8,              -1, COMPUTER_TAB, 0, "Key 8",                                  CC_TYPE_TRIGGER,    -1, -1, 0, false, false },
-	{                           KEY_9,              -1, COMPUTER_TAB, 0, "Key 9",                                  CC_TYPE_TRIGGER,    -1, -1, 0, false, false },
 	{ KEY_ALTED | KEY_SHIFTED | KEY_1,              -1, COMPUTER_TAB, 0, "Custom Control 1",                       CC_TYPE_TRIGGER,    -1, -1, 0, true,  false },
 	{ KEY_ALTED | KEY_SHIFTED | KEY_2,              -1, COMPUTER_TAB, 0, "Custom Control 2",                       CC_TYPE_TRIGGER,    -1, -1, 0, true,  false },
 	{ KEY_ALTED | KEY_SHIFTED | KEY_3,              -1, COMPUTER_TAB, 0, "Custom Control 3",                       CC_TYPE_TRIGGER,    -1, -1, 0, true,  false },
+	{ KEY_ALTED | KEY_SHIFTED | KEY_4,              -1, COMPUTER_TAB, 0, "Custom Control 4",                       CC_TYPE_TRIGGER,    -1, -1, 0, true,  false },
+	{ KEY_ALTED | KEY_SHIFTED | KEY_5,              -1, COMPUTER_TAB, 0, "Custom Control 5",                       CC_TYPE_TRIGGER,    -1, -1, 0, true,  false },
 	{                           -1,                 -1, -1,           0, "",                                       CC_TYPE_TRIGGER,    -1, -1, 0, false, false }
 };
 

--- a/code/io/keycontrol.cpp
+++ b/code/io/keycontrol.cpp
@@ -2068,6 +2068,15 @@ int button_function_critical(int n, net_player *p = NULL)
 		case ZERO_THROTTLE:
 		case MAX_THROTTLE:
 		case TOGGLE_GLIDING:
+	    case CONTROL_KEY_0:
+	    case CONTROL_KEY_5:
+	    case CONTROL_KEY_6:
+	    case CONTROL_KEY_7:
+	    case CONTROL_KEY_8:
+	    case CONTROL_KEY_9:
+	    case CUSTOM_CONTROL_1:
+	    case CUSTOM_CONTROL_2:
+	    case CUSTOM_CONTROL_3:
 			return 0;
 
 		default :

--- a/code/io/keycontrol.cpp
+++ b/code/io/keycontrol.cpp
@@ -330,15 +330,11 @@ int Normal_key_set[] = {
 
 	TOGGLE_GLIDING,
 	CYCLE_PRIMARY_WEAPON_SEQUENCE,
-	CONTROL_KEY_0,
-	CONTROL_KEY_5,
-	CONTROL_KEY_6,
-	CONTROL_KEY_7,
-	CONTROL_KEY_8,
-	CONTROL_KEY_9,
 	CUSTOM_CONTROL_1,
     CUSTOM_CONTROL_2,
-    CUSTOM_CONTROL_3
+    CUSTOM_CONTROL_3,
+	CUSTOM_CONTROL_4,
+	CUSTOM_CONTROL_5
 };
 
 int Dead_key_set[] = {
@@ -474,15 +470,11 @@ int Non_critical_key_set[] = {
 	NAV_CYCLE,
 	TOGGLE_GLIDING,
 	CYCLE_PRIMARY_WEAPON_SEQUENCE,
-	CONTROL_KEY_0,
-	CONTROL_KEY_5,
-	CONTROL_KEY_6,
-	CONTROL_KEY_7,
-	CONTROL_KEY_8,
-	CONTROL_KEY_9,
     CUSTOM_CONTROL_1,
     CUSTOM_CONTROL_2,
-    CUSTOM_CONTROL_3
+    CUSTOM_CONTROL_3,
+	CUSTOM_CONTROL_4,
+	CUSTOM_CONTROL_5
 };
 
 int Ignored_keys[CCFG_MAX];
@@ -2068,15 +2060,11 @@ int button_function_critical(int n, net_player *p = NULL)
 		case ZERO_THROTTLE:
 		case MAX_THROTTLE:
 		case TOGGLE_GLIDING:
-	    case CONTROL_KEY_0:
-	    case CONTROL_KEY_5:
-	    case CONTROL_KEY_6:
-	    case CONTROL_KEY_7:
-	    case CONTROL_KEY_8:
-	    case CONTROL_KEY_9:
 	    case CUSTOM_CONTROL_1:
 	    case CUSTOM_CONTROL_2:
 	    case CUSTOM_CONTROL_3:
+	    case CUSTOM_CONTROL_4:
+	    case CUSTOM_CONTROL_5:
 			return 0;
 
 		default :
@@ -2329,15 +2317,11 @@ int button_function(int n)
 		case MAX_THROTTLE:
 		case TOGGLE_GLIDING:
 		case GLIDE_WHEN_PRESSED:
-	    case CONTROL_KEY_0:
-	    case CONTROL_KEY_5:
-	    case CONTROL_KEY_6:
-	    case CONTROL_KEY_7:
-	    case CONTROL_KEY_8:
-	    case CONTROL_KEY_9:
 	    case CUSTOM_CONTROL_1:
 	    case CUSTOM_CONTROL_2:
 	    case CUSTOM_CONTROL_3:
+	    case CUSTOM_CONTROL_4:
+	    case CUSTOM_CONTROL_5:
 			return 0;
 	}
 

--- a/code/io/keycontrol.cpp
+++ b/code/io/keycontrol.cpp
@@ -338,9 +338,7 @@ int Normal_key_set[] = {
 	CONTROL_KEY_9,
 	CUSTOM_CONTROL_1,
     CUSTOM_CONTROL_2,
-    CUSTOM_CONTROL_3,
-    CUSTOM_CONTROL_4,
-    CUSTOM_CONTROL_5
+    CUSTOM_CONTROL_3
 };
 
 int Dead_key_set[] = {
@@ -484,9 +482,7 @@ int Non_critical_key_set[] = {
 	CONTROL_KEY_9,
     CUSTOM_CONTROL_1,
     CUSTOM_CONTROL_2,
-    CUSTOM_CONTROL_3,
-    CUSTOM_CONTROL_4,
-    CUSTOM_CONTROL_5
+    CUSTOM_CONTROL_3
 };
 
 int Ignored_keys[CCFG_MAX];
@@ -2333,8 +2329,6 @@ int button_function(int n)
 	    case CUSTOM_CONTROL_1:
 	    case CUSTOM_CONTROL_2:
 	    case CUSTOM_CONTROL_3:
-	    case CUSTOM_CONTROL_4:
-	    case CUSTOM_CONTROL_5:
 			return 0;
 	}
 


### PR DESCRIPTION
This PR reduces the number of controls back down to 127 so as to keep multi compatibility.  