### PR TITLE
Fix overriding the default values in control table for `disabled` and `continuous_ongoing`

### DIFF
--- a/code/controlconfig/controlsconfigcommon.cpp
+++ b/code/controlconfig/controlsconfigcommon.cpp
@@ -590,12 +590,8 @@ void control_config_common_load_overrides();
 // initialize common control config stuff - call at game startup after localization has been initialized
 void control_config_common_init()
 {
-	for (int i=0; i<CCFG_MAX; i++) {
-		Control_config[i].disabled = false;
-		Control_config[i].continuous_ongoing = false;
-	}
-
 	control_config_common_load_overrides();
+
 	if(Lcl_gr){
 		Scan_code_text = Scan_code_text_german;
 		Joy_button_text = Joy_button_text_german;


### PR DESCRIPTION
Previously, `control_config_common_init()` started with a loop that set the `disabled` and `continuous_ongoing` values to false for all controls in the config array. This overrides the default values set in the array. For example, if a control is set to be disabled by default then this loop overrides that incorrectly.

These lines were added in the following commits:

https://github.com/scp-fs2open/fs2open.github.com/commit/45da46eddd9d9249bf1178ac18164e4ab43570e1#diff-45a0618f2fa10c25b123d4a771f98228

and

https://github.com/scp-fs2open/fs2open.github.com/commit/61d9ce895be392c048437e985cf583ee2fc6161a#diff-45a0618f2fa10c25b123d4a771f98228


The goal of adding these lines was to initiate the values, but these values were already set in the struct table and those lines simply override the values. No other fields in the config array are set like this and simply use the values set in the array.

In tests I have removed these lines and printed what the default values are and the print statements print what is expected from the config array. (For example, `mprintf(("Check_control_disabled_for %s and value is %s...\n", Control_config[i].text, Control_config[i].disabled ? "true" : "false"));` printed what was in the array correctly). 

This PR removes those unneeded lines and thus allows the fields for `disabled` and `continuous_ongoing` to be respected as the default. Of course table changes can be used to alter these, but that's only if a controlconfigdefaults.tbl is present.