### PR TITLE
Urgent Multi Fix

### DIFF
--- a/code/network/multi_obj.cpp
+++ b/code/network/multi_obj.cpp
@@ -513,7 +513,7 @@ int multi_oo_pack_data(net_player *pl, object *objp, ubyte oo_flags, ubyte *data
 	}		
 
 	// afterburner info
-	oo_flags &= ~PF_AFTERBURNER_ON;
+	oo_flags &= ~OO_AFTERBURNER_NEW;
 	if(objp->phys_info.flags & PF_AFTERBURNER_ON){
 		oo_flags |= OO_AFTERBURNER_NEW;
 	}


### PR DESCRIPTION
Already tested. 

Any server build created this year will crash any client connected to it because it will send a packet containing hull updating information, but accidentally unset the flag for new hull info. The client was therefore unaligned with the packet, causing the local subsystem_update array to think there were 255 subsystems.