### PR TITLE
Adds Target Closest Hostile Fighter

### DIFF
--- a/code/controlconfig/controlsconfig.h
+++ b/code/controlconfig/controlsconfig.h
@@ -279,6 +279,10 @@ enum IoActionId  {
 	CUSTOM_CONTROL_4								= 122,
 	CUSTOM_CONTROL_5								= 123,
 
+	//!< @n
+	//!< Additional targetting controls
+	//!< ----------------------------
+	TARGET_CLOSEST_HOSTILE_FIGHTER					= 124,	  //!< target the next closest hostile fighter
 	/*!
 	 * This must always be below the last defined item
 	 */

--- a/code/controlconfig/controlsconfigcommon.cpp
+++ b/code/controlconfig/controlsconfigcommon.cpp
@@ -194,6 +194,7 @@ config_item Control_config[CCFG_MAX + 1] = {
 	{ KEY_ALTED | KEY_SHIFTED | KEY_3,              -1, COMPUTER_TAB, 0, "Custom Control 3",                       CC_TYPE_TRIGGER,    -1, -1, 0, true,  false },
 	{ KEY_ALTED | KEY_SHIFTED | KEY_4,              -1, COMPUTER_TAB, 0, "Custom Control 4",                       CC_TYPE_TRIGGER,    -1, -1, 0, true,  false },
 	{ KEY_ALTED | KEY_SHIFTED | KEY_5,              -1, COMPUTER_TAB, 0, "Custom Control 5",                       CC_TYPE_TRIGGER,    -1, -1, 0, true,  false },
+	{ KEY_ALTED | KEY_SHIFTED | KEY_R,              -1, TARGET_TAB,   0, "Target Closest Hostile Fighter",         CC_TYPE_TRIGGER,    -1, -1, 0, false, false },
 	{                           -1,                 -1, -1,           0, "",                                       CC_TYPE_TRIGGER,    -1, -1, 0, false, false }
 };
 

--- a/code/hud/hudtarget.h
+++ b/code/hud/hudtarget.h
@@ -96,6 +96,7 @@ void	hud_show_targeting_gauges(float frametime);
 void	hud_target_targets_target();
 void	hud_check_reticle_list();
 void	hud_target_missile(object *source_obj, int next_flag);
+void	hud_target_hostile_fighter(object *source_obj, int next_flag);
 void	hud_target_next_list(int hostile=1, int next_flag=1, int team_mask = -1, int attacked_objnum = -1, int play_fail_sound = TRUE, int filter = 0, int turret_attacking_target = 0);
 int	hud_target_closest_repair_ship(int goal_objnum=-1);
 void	hud_target_auto_target_next();

--- a/code/io/keycontrol.cpp
+++ b/code/io/keycontrol.cpp
@@ -334,7 +334,9 @@ int Normal_key_set[] = {
     CUSTOM_CONTROL_2,
     CUSTOM_CONTROL_3,
 	CUSTOM_CONTROL_4,
-	CUSTOM_CONTROL_5
+	CUSTOM_CONTROL_5,
+
+	TARGET_CLOSEST_HOSTILE_FIGHTER
 };
 
 int Dead_key_set[] = {
@@ -376,7 +378,9 @@ int Dead_key_set[] = {
 	MULTI_OBSERVER_ZOOM_TO,
 
 	TIME_SPEED_UP,
-	TIME_SLOW_DOWN
+	TIME_SLOW_DOWN,
+
+	TARGET_CLOSEST_HOSTILE_FIGHTER
 };
 
 int Critical_key_set[] = {	
@@ -474,7 +478,9 @@ int Non_critical_key_set[] = {
     CUSTOM_CONTROL_2,
     CUSTOM_CONTROL_3,
 	CUSTOM_CONTROL_4,
-	CUSTOM_CONTROL_5
+	CUSTOM_CONTROL_5,
+
+	TARGET_CLOSEST_HOSTILE_FIGHTER
 };
 
 int Ignored_keys[CCFG_MAX];
@@ -2065,6 +2071,7 @@ int button_function_critical(int n, net_player *p = NULL)
 	    case CUSTOM_CONTROL_3:
 	    case CUSTOM_CONTROL_4:
 	    case CUSTOM_CONTROL_5:
+	    case TARGET_CLOSEST_HOSTILE_FIGHTER:
 			return 0;
 
 		default :
@@ -2224,6 +2231,7 @@ bool key_is_targeting(int n)
 		case TARGET_SUBOBJECT_IN_RETICLE:
 		case TARGET_PREV_SUBOBJECT:
 		case TARGET_NEXT_SUBOBJECT:
+	    case TARGET_CLOSEST_HOSTILE_FIGHTER:
 			return true;
 
 		default:
@@ -2299,6 +2307,7 @@ int button_function(int n)
 			case TARGET_NEXT_LIVE_TURRET:
 			case TARGET_PREV_LIVE_TURRET:
 			case TARGET_NEXT_ESCORT_SHIP:
+		    case TARGET_CLOSEST_HOSTILE_FIGHTER:
 				control_used(n);	// set the timestamp for when we used the control, in case we need it
 				return 1;			// pretend we took the action: if we return 0, strange stuff may happen
 		}
@@ -2705,6 +2714,11 @@ int button_function(int n)
 		case STOP_TARGETING_SUBSYSTEM:
 			hud_cease_subsystem_targeting();
 			break;
+
+		// target the cloest hostile fighter
+	    case TARGET_CLOSEST_HOSTILE_FIGHTER:
+		    hud_target_hostile_fighter(Player_obj, 1);
+		    break;
 			
 		case TARGET_NEXT_BOMB:
 			hud_target_missile(Player_obj, 1);


### PR DESCRIPTION
In reference to issue #2215, this PR adds a new control that allows the player to target the closest hostile fighter.

I am also open to discussion on whether it would better to incorporate this target control as a script using the new custom controls rather than a PR.