### PR TITLE
Restore 3D Weapon Icons when Flag Used

### DIFF
--- a/code/missionui/missionweaponchoice.cpp
+++ b/code/missionui/missionweaponchoice.cpp
@@ -1265,7 +1265,7 @@ void wl_load_icons(int weapon_class)
 
 	icon = &Wl_icons[weapon_class];
 
-	if(!Cmdline_weapon_choice_3d || (wip->render_type == WRT_LASER && !strlen(wip->tech_model)) || strlen(Weapon_info[weapon_class].icon_filename) )
+	if(!Cmdline_weapon_choice_3d || (wip->render_type == WRT_LASER && !strlen(wip->tech_model)))
 	{
 		first_frame = bm_load_animation(Weapon_info[weapon_class].icon_filename, &num_frames, nullptr, nullptr, nullptr, false, CF_TYPE_INTERFACE);
 
@@ -1276,7 +1276,7 @@ void wl_load_icons(int weapon_class)
 
 	multi_send_anti_timeout_ping();
 
-	if ( (first_frame == -1 && icon->model_index == -1) || Cmdline_weapon_choice_3d )
+	if ( icon->model_index == -1 && ( ( strlen(wip->tech_model) && !strlen(wip->anim_filename) ) || (first_frame == -1) ) )
 	{
 		if(strlen(wip->tech_model))
 		{


### PR DESCRIPTION
Overview: This PR restores all expected functionality of the `3D weapon selection` flag while also providing modders with a way to use both 3D models and custom weapon icons simultaneously.

PR #2055 provided a way for modders to use 3D weapons while still using specified weapon icons. Unfortunately, that resulted in weapon icons not changing to an image of the 3D model when the `3D weapon selection flag` was used. It was requested on the forum that this behavior be restored. This PR restores that behavior while still allowing modders to use 3D weapon models and their own weapon icons. 

Instead of the approach taken in PR #2055, this PR will automatically show a 3D weapon model if there is no weapon animation specified and if a weapon tech model is specified. Thus, if a modder wants to use their custom weapon icon but also have a 3D weapon model shown, they do the following:
1) Do not specify a model animation 
2) Do specify a tech model for the weapon 
3) Leave the `3D weapon selection` flag unchecked. 
If the 3D weapon selection flag is checked then the 3D weapon model will of course still be used, but the weapon icons will now show the image of the 3D model instead of any custom weapon icons the modder specified (as expected for the player).

I also tested this for each case in both retail and mod cases and it works as described above.