### PR TITLE
Fix Setting of Initial Velocity

### DIFF
--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -2372,9 +2372,14 @@ int parse_create_object_sub(p_object *p_objp)
 		if (!(Game_mode & GM_IN_MISSION) || (Warp_params[shipp->warpin_params_index].warp_type == WT_IN_PLACE_ANIM || Warp_params[shipp->warpin_params_index].warp_type == WT_HYPERSPACE))
 		{
 			Objects[objnum].phys_info.speed = (float) p_objp->initial_velocity * sip->max_speed / 100.0f;
-			Objects[objnum].phys_info.vel.xyz.z = Objects[objnum].phys_info.speed;
-			Objects[objnum].phys_info.prev_ramp_vel = Objects[objnum].phys_info.vel;
+			// set initial velocity to z of temp velocity vector
+			vec3d temp_vel = ZERO_VECTOR;
+			temp_vel.xyz.z = Objects[objnum].phys_info.speed;
+			// convert to global coordinates and set to ship velocity
+			vm_vec_unrotate(&Objects[objnum].phys_info.vel, &temp_vel, &Objects[objnum].orient);
 			Objects[objnum].phys_info.desired_vel = Objects[objnum].phys_info.vel;
+			// prev_ramp_vel needs to be in local coordinates
+			Objects[objnum].phys_info.prev_ramp_vel = temp_vel;
 		}
 
 		// recalculate damage of subsystems

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -2372,14 +2372,14 @@ int parse_create_object_sub(p_object *p_objp)
 		if (!(Game_mode & GM_IN_MISSION) || (Warp_params[shipp->warpin_params_index].warp_type == WT_IN_PLACE_ANIM || Warp_params[shipp->warpin_params_index].warp_type == WT_HYPERSPACE))
 		{
 			Objects[objnum].phys_info.speed = (float) p_objp->initial_velocity * sip->max_speed / 100.0f;
-			// set initial velocity to z of temp velocity vector
-			vec3d temp_vel = ZERO_VECTOR;
-			temp_vel.xyz.z = Objects[objnum].phys_info.speed;
-			// convert to global coordinates and set to ship velocity
-			vm_vec_unrotate(&Objects[objnum].phys_info.vel, &temp_vel, &Objects[objnum].orient);
-			Objects[objnum].phys_info.desired_vel = Objects[objnum].phys_info.vel;
 			// prev_ramp_vel needs to be in local coordinates
-			Objects[objnum].phys_info.prev_ramp_vel = temp_vel;
+			vm_vec_zero(&Objects[objnum].phys_info.prev_ramp_vel);
+			// set z of prev_ramp_vel to initial velocity
+			Objects[objnum].phys_info.prev_ramp_vel.xyz.z = Objects[objnum].phys_info.speed;
+			// convert to global coordinates and set to ship velocity and desired velocity
+			vm_vec_unrotate(&Objects[objnum].phys_info.vel, &Objects[objnum].phys_info.prev_ramp_vel, &Objects[objnum].orient);
+			Objects[objnum].phys_info.desired_vel = Objects[objnum].phys_info.vel;
+
 		}
 
 		// recalculate damage of subsystems

--- a/code/physics/physics.h
+++ b/code/physics/physics.h
@@ -68,7 +68,7 @@ typedef struct physics_info {
 
 	// These get changed by the control code.  The physics uses these
 	// as input values when doing physics.
-	vec3d	prev_ramp_vel;				// follows the user's desired velocity
+	vec3d	prev_ramp_vel;				// follows the user's desired velocity, in local coord
 	vec3d	desired_vel;				// in world coord
 	vec3d	desired_rotvel;			// in local coord
 	float		forward_thrust;			// How much the forward thruster is applied.  0-1.

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -10200,9 +10200,14 @@ void change_ship_type(int n, int ship_type, int by_sexp)
 	// zookeeper - If we're switching in the loadout screen, make sure we retain initial velocity set in FRED
 	if (!(Game_mode & GM_IN_MISSION) && !(Fred_running)) {
 		Objects[sp->objnum].phys_info.speed = (float) p_objp->initial_velocity * sip->max_speed / 100.0f;
-		Objects[sp->objnum].phys_info.vel.xyz.z = Objects[sp->objnum].phys_info.speed;
-		Objects[sp->objnum].phys_info.prev_ramp_vel = Objects[sp->objnum].phys_info.vel;
+		// set initial velocity to z of temp velocity vector
+		vec3d temp_vel = ZERO_VECTOR;
+		temp_vel.xyz.z = Objects[sp->objnum].phys_info.speed;
+		// convert to global coordinates and set to ship velocity
+		vm_vec_unrotate(&Objects[sp->objnum].phys_info.vel, &temp_vel, &Objects[sp->objnum].orient);
 		Objects[sp->objnum].phys_info.desired_vel = Objects[sp->objnum].phys_info.vel;
+		// prev_ramp_vel needs to be in local coordinates
+		Objects[sp->objnum].phys_info.prev_ramp_vel = temp_vel;
 	}
 
 	// Goober5000 - if we're changing to a ship class that has a different default set of orders, update the orders

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -10200,14 +10200,13 @@ void change_ship_type(int n, int ship_type, int by_sexp)
 	// zookeeper - If we're switching in the loadout screen, make sure we retain initial velocity set in FRED
 	if (!(Game_mode & GM_IN_MISSION) && !(Fred_running)) {
 		Objects[sp->objnum].phys_info.speed = (float) p_objp->initial_velocity * sip->max_speed / 100.0f;
-		// set initial velocity to z of temp velocity vector
-		vec3d temp_vel = ZERO_VECTOR;
-		temp_vel.xyz.z = Objects[sp->objnum].phys_info.speed;
-		// convert to global coordinates and set to ship velocity
-		vm_vec_unrotate(&Objects[sp->objnum].phys_info.vel, &temp_vel, &Objects[sp->objnum].orient);
-		Objects[sp->objnum].phys_info.desired_vel = Objects[sp->objnum].phys_info.vel;
 		// prev_ramp_vel needs to be in local coordinates
-		Objects[sp->objnum].phys_info.prev_ramp_vel = temp_vel;
+		vm_vec_zero(&Objects[sp->objnum].phys_info.prev_ramp_vel);
+		// set z of prev_ramp_vel to initial velocity
+		Objects[sp->objnum].phys_info.prev_ramp_vel.xyz.z = Objects[sp->objnum].phys_info.speed;
+		// convert to global coordinates and set to ship velocity and desired velocity
+		vm_vec_unrotate(&Objects[sp->objnum].phys_info.vel, &Objects[sp->objnum].phys_info.prev_ramp_vel, &Objects[sp->objnum].orient);
+		Objects[sp->objnum].phys_info.desired_vel = Objects[sp->objnum].phys_info.vel;
 	}
 
 	// Goober5000 - if we're changing to a ship class that has a different default set of orders, update the orders


### PR DESCRIPTION
It turns out that the code that set initial ship velocities did not account for local ship rotation changes. This bug is only noticeable when ships are very high speeds, high initial velocities, and have high drift values thus it was never recognized before. This PR fixes that by ensuring that the velocity vectors are set appropriately. As discussed with Goober on Discord, this fixed behavior is indistinguishable when using FS ships and most mods, thus the behavior will be on by default.