### PR TITLE
Cleanup Reaming Issues with Initial Velocity

### DIFF
--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -2373,13 +2373,12 @@ int parse_create_object_sub(p_object *p_objp)
 		{
 			Objects[objnum].phys_info.speed = (float) p_objp->initial_velocity * sip->max_speed / 100.0f;
 			// prev_ramp_vel needs to be in local coordinates
-			vm_vec_zero(&Objects[objnum].phys_info.prev_ramp_vel);
 			// set z of prev_ramp_vel to initial velocity
+			vm_vec_zero(&Objects[objnum].phys_info.prev_ramp_vel);
 			Objects[objnum].phys_info.prev_ramp_vel.xyz.z = Objects[objnum].phys_info.speed;
 			// convert to global coordinates and set to ship velocity and desired velocity
 			vm_vec_unrotate(&Objects[objnum].phys_info.vel, &Objects[objnum].phys_info.prev_ramp_vel, &Objects[objnum].orient);
 			Objects[objnum].phys_info.desired_vel = Objects[objnum].phys_info.vel;
-
 		}
 
 		// recalculate damage of subsystems
@@ -5769,8 +5768,9 @@ bool post_process_mission()
 	Player_ai->targeted_subsys_parent = -1;
 
 	// determine if player start has initial velocity and set forward cruise percent to relect this
-	if ( Player_obj->phys_info.vel.xyz.z > 0.0f )
-		Player->ci.forward_cruise_percent = Player_obj->phys_info.vel.xyz.z / Player_ship->current_max_speed * 100.0f;
+	// this should check prev_ramp_vel because that is in local coordinates --wookieejedi
+	if ( Player_obj->phys_info.prev_ramp_vel.xyz.z > 0.0f )
+		Player->ci.forward_cruise_percent = Player_obj->phys_info.prev_ramp_vel.xyz.z / Player_ship->current_max_speed * 100.0f;
 
 	// set up wing indexes
 	for (i = 0; i < MAX_STARTING_WINGS; i++ ) {

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -10201,8 +10201,8 @@ void change_ship_type(int n, int ship_type, int by_sexp)
 	if (!(Game_mode & GM_IN_MISSION) && !(Fred_running)) {
 		Objects[sp->objnum].phys_info.speed = (float) p_objp->initial_velocity * sip->max_speed / 100.0f;
 		// prev_ramp_vel needs to be in local coordinates
-		vm_vec_zero(&Objects[sp->objnum].phys_info.prev_ramp_vel);
 		// set z of prev_ramp_vel to initial velocity
+		vm_vec_zero(&Objects[sp->objnum].phys_info.prev_ramp_vel);
 		Objects[sp->objnum].phys_info.prev_ramp_vel.xyz.z = Objects[sp->objnum].phys_info.speed;
 		// convert to global coordinates and set to ship velocity and desired velocity
 		vm_vec_unrotate(&Objects[sp->objnum].phys_info.vel, &Objects[sp->objnum].phys_info.prev_ramp_vel, &Objects[sp->objnum].orient);

--- a/code/ship/shipfx.cpp
+++ b/code/ship/shipfx.cpp
@@ -4218,10 +4218,10 @@ int WE_Hyperspace::warpStart()
 			Assertion(shipp->flags[Ship::Ship_Flags::Dock_leader], "The ship warping in (%s) must be the dock leader at this point!\n", shipp->ship_name);
 			dock_function_info dfi;
 			dock_evaluate_all_docked_objects(objp, &dfi, object_set_arriving_stage1_ndl_flag_helper);
+			// docked objects use speed to find the object that controls movement; therefore the warping in dock leader must have the highest speed!
+			objp->phys_info.speed = (scale_factor / params->time)*1000.0f;
 		}
 		objp->phys_info.flags |= PF_WARP_IN;
-		objp->phys_info.vel.xyz.z = (scale_factor / params->time)*1000.0f;
-		objp->phys_info.speed = objp->phys_info.vel.xyz.z;  // docked objects use speed to find the object that controls movement; therefore the warping in dock leader must have the highest speed!
 		objp->flags.remove(Object::Object_Flags::Physics);
 	}
 	else if(direction == WarpDirection::WARP_OUT)
@@ -4260,17 +4260,9 @@ int WE_Hyperspace::warpFrame(float  /*frametime*/)
 	if(timestamp_elapsed(total_time_end))
 	{
 		objp->pos = pos_final;
-		if(direction == WarpDirection::WARP_OUT)
-			objp->phys_info.vel.xyz.z = 0.0f;
-		else
-		{
-			vec3d vel;
-			vel = objp->orient.vec.fvec;
-			vm_vec_scale( &vel, initial_velocity );
-			objp->phys_info.vel = vel;
-			objp->phys_info.desired_vel = vel;
-			objp->phys_info.speed = vel.xyz.z;
-			// warpEnd() removes Arriving_* Ship_Flags; no need to set any here
+		if (direction == WarpDirection::WARP_OUT) {
+			// this needs to be prev_ramp_vel because that is in local coord
+			objp->phys_info.prev_ramp_vel.xyz.z = 0.0f;
 		}
         objp->flags.set(Object::Object_Flags::Physics);
 		this->warpEnd();

--- a/code/ship/shipfx.cpp
+++ b/code/ship/shipfx.cpp
@@ -4210,7 +4210,7 @@ int WE_Hyperspace::warpStart()
 	if(direction == WarpDirection::WARP_IN)
 	{
 		p_object* p_objp = mission_parse_get_parse_object(shipp->ship_name);
-		if (p_objp != NULL) {
+		if (p_objp != nullptr) {
 			initial_velocity = (float)p_objp->initial_velocity * sip->max_speed / 100.0f;
 		}
 


### PR DESCRIPTION
This PR tidies up the comments in the initial velocity setting, properly sets the player's throttle, and cleans up issues with initial velocity setting and hyperspace warpin types.

Note the removed code block for hyperspace warpin ending was removed because it is not needed, as physics calculations already handles that. Also the calculations that were there did not properly account for initial ship velocity setting.