### PR TITLE
Remove Debilitating Debug Function Calls

### DIFF
--- a/code/network/multi_obj.cpp
+++ b/code/network/multi_obj.cpp
@@ -1199,21 +1199,9 @@ int multi_oo_maybe_update(net_player *pl, object *obj, ubyte *data)
 
 	// if position or orientation haven't changed	
 	if((shipp->np_updates[player_index].pos_chksum != 0) && (shipp->np_updates[player_index].pos_chksum == cur_pos_chksum)){
-		// if we otherwise would have been sending it, keep track of it (debug only)
-#ifndef NDEBUG
-		if(oo_flags & OO_POS_NEW){
-			multi_rate_add(player_index, "skp_p", OO_POS_RET_SIZE + OO_VEL_RET_SIZE);
-		}		
-#endif
 		oo_flags &= ~(OO_POS_NEW);
 	}
 	if((shipp->np_updates[player_index].orient_chksum != 0) && (shipp->np_updates[player_index].orient_chksum == cur_orient_chksum)){
-		// if we otherwise would have been sending it, keep track of it (debug only)
-#ifndef NDEBUG
-		if(oo_flags & OO_ORIENT_NEW){
-			multi_rate_add(player_index, "skp_o", OO_ORIENT_RET_SIZE + OO_ROTVEL_RET_SIZE);
-		}		
-#endif
 		oo_flags &= ~(OO_ORIENT_NEW);
 	}
 	shipp->np_updates[player_index].pos_chksum = cur_pos_chksum;


### PR DESCRIPTION
These function calls have been around since retail.  What they were supposed to do was allow the :V: team to get a baseline of how much data the object updating system would use without the limiting system.

However, the way that multi_rate_add works, is that it say to the limiting system, "The client is getting a lot of data, so limit it some more." And that eventually causes debug build object updates to slow to a crawl, making bug hunting in debug builds difficult.

Removing these functions calls will allow us to track multi bugs a little bit easier (and less frustrating).