### PR TITLE
Fixes calculations for random fire rates when using min and max delays

### DIFF
--- a/code/ai/aiturret.cpp
+++ b/code/ai/aiturret.cpp
@@ -1680,7 +1680,7 @@ void turret_set_next_fire_timestamp(int weapon_num, weapon_info *wip, ship_subsy
 	} else {
 		// Random fire delay (DahBlount) used in ship_fire_primary(), added here by wookieejedi to correct oversight
 		if (wip->max_delay != 0.0f && wip->min_delay != 0.0f) {
-			wait *= (((float)rand()) / (((float)RAND_MAX + 1.0f) * (wip->max_delay - wip->min_delay + 1.0f) + wip->min_delay));
+			wait *= frand_range(wip->min_delay, wip->max_delay);
 		} else {
 			wait *= wip->fire_wait;
 		}

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -10831,7 +10831,7 @@ int ship_fire_primary(object * obj, int stream_weapons, int force)
 			if (winfo_p->burst_flags[Weapon::Burst_Flags::Fast_firing])
 				fast_firing = true;
 		} else if (winfo_p->max_delay != 0.0f && winfo_p->min_delay != 0.0f) {			// Random fire delay (DahBlount)
-			next_fire_delay = (((float)rand()) / (((float)RAND_MAX + 1.0f) * (winfo_p->max_delay - winfo_p->min_delay + 1.0f) + winfo_p->min_delay)) * 1000.0f;
+			next_fire_delay = frand_range(winfo_p->min_delay, winfo_p->max_delay) * 1000.0f;
 		} else {
 			next_fire_delay = winfo_p->fire_wait * 1000.0f;
 			swp->burst_counter[bank_to_fire] = 0;


### PR DESCRIPTION
Previously, using `Max` and `Min` for fire-rate delays resulted in guns firing that were not within the specified range. This PR fixes that while also simplifying the code. This solution uses `frand_range()`, which is already used in each of those functions so I figured it would be fine to use that function here. It also simplifies the code:
`wait *= frand_range(wip->min_delay, wip->max_delay)`
instead of previously
`next_fire_delay = (((float)rand()) / (((float)RAND_MAX + 1.0f) * (winfo_p->max_delay - winfo_p->min_delay + 1.0f) + winfo_p->min_delay))`.