### PR TITLE
Proposal to cleanup debug log statement regarding turret fire

### DIFF
--- a/code/ai/aiturret.cpp
+++ b/code/ai/aiturret.cpp
@@ -2731,7 +2731,7 @@ void ai_fire_from_turret(ship *shipp, ship_subsys *ss, int parent_objnum)
 
 		if(!something_was_ok_to_fire)
 		{
-			mprintf(("nothing ok to fire\n"));
+			// mprintf(("nothing ok to fire\n")); // wookieejedi - commenting this out since it pollutes the debug log with missions with turreted ships
             
 			if (ss->turret_best_weapon >= 0) {
 				//Impose a penalty on turret accuracy for losing site of its goal, or just not being able to fire.

--- a/code/ai/aiturret.cpp
+++ b/code/ai/aiturret.cpp
@@ -2731,8 +2731,6 @@ void ai_fire_from_turret(ship *shipp, ship_subsys *ss, int parent_objnum)
 
 		if(!something_was_ok_to_fire)
 		{
-			// mprintf(("nothing ok to fire\n")); // wookieejedi - commenting this out since it pollutes the debug log with missions with turreted ships
-            
 			if (ss->turret_best_weapon >= 0) {
 				//Impose a penalty on turret accuracy for losing site of its goal, or just not being able to fire.
 				turret_update_enemy_in_range(ss, -4*Weapon_info[ss->turret_best_weapon].fire_wait);


### PR DESCRIPTION
In `aiturret.cpp` there is a `mprintf`, `mprintf(("nothing ok to fire\n"));`. This print statement greatly pollutes the debug log in missions with turreted ships. I'm not sure what this message helps debug, thus I propose commenting it out.