### PR TITLE
Fix overriding the default values in control table for `disabled`

### DIFF
--- a/code/controlconfig/controlsconfigcommon.cpp
+++ b/code/controlconfig/controlsconfigcommon.cpp
@@ -591,7 +591,6 @@ void control_config_common_load_overrides();
 void control_config_common_init()
 {
 	for (int i=0; i<CCFG_MAX; i++) {
-		Control_config[i].disabled = false;
 		Control_config[i].continuous_ongoing = false;
 	}
 


### PR DESCRIPTION
For some reason my repo had some critical issues and I was unable to commit to the PR #2210. I have closed that PR and opened this one given the discussion in #2210. The result of that discussion was `but omit line 594`. That is what this PR does.