### PR TITLE
Allows Modders to Actually Use Engine Wash Intensity

### DIFF
--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -577,4 +577,5 @@ void mod_table_reset() {
 	Arc_color_emp_p1 = std::make_tuple(static_cast<ubyte>(64), static_cast<ubyte>(64), static_cast<ubyte>(5));
 	Arc_color_emp_p2 = std::make_tuple(static_cast<ubyte>(128), static_cast<ubyte>(128), static_cast<ubyte>(10));
 	Arc_color_emp_s1 = std::make_tuple(static_cast<ubyte>(255), static_cast<ubyte>(255), static_cast<ubyte>(10));
+	Use_engine_wash_intensity = false;
 }

--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -55,6 +55,7 @@ std::tuple<ubyte, ubyte, ubyte> Arc_color_damage_s1;
 std::tuple<ubyte, ubyte, ubyte> Arc_color_emp_p1;
 std::tuple<ubyte, ubyte, ubyte> Arc_color_emp_p2;
 std::tuple<ubyte, ubyte, ubyte> Arc_color_emp_s1;
+bool Use_engine_wash_intensity;
 
 void parse_mod_table(const char *filename)
 {
@@ -503,6 +504,10 @@ void parse_mod_table(const char *filename)
 			if (Dinky_shockwave_default_multiplier != 1.0f) {
 				mprintf(("Game Settings Table: Setting default dinky shockwave multiplier to %.2f.\n", Dinky_shockwave_default_multiplier));
 			}
+		}
+
+		if (optional_string("$Use Engine Wash Intensity:")) {
+			stuff_boolean(&Use_engine_wash_intensity);
 		}
 
 		required_string("#END");

--- a/code/mod_table/mod_table.h
+++ b/code/mod_table/mod_table.h
@@ -46,6 +46,7 @@ extern std::tuple<ubyte, ubyte, ubyte> Arc_color_damage_s1;
 extern std::tuple<ubyte, ubyte, ubyte> Arc_color_emp_p1;
 extern std::tuple<ubyte, ubyte, ubyte> Arc_color_emp_p2;
 extern std::tuple<ubyte, ubyte, ubyte> Arc_color_emp_s1;
+extern bool Use_engine_wash_intensity;
 
 void mod_table_init();
 

--- a/code/ship/shipfx.cpp
+++ b/code/ship/shipfx.cpp
@@ -2527,7 +2527,7 @@ void engine_wash_ship_process(ship *shipp)
 	float dist_sqr, inset_depth, dot_to_ship, max_ship_intensity;
 	polymodel *pm;
 
-	float max_wash_dist, half_angle, radius_mult, wash_intensity;
+	float max_wash_dist, half_angle, radius_mult;
 
 	// if this is not a fighter or bomber, we don't care
 	if ((objp->type != OBJ_SHIP) || !(Ship_info[shipp->ship_info_index].is_fighter_bomber()) ) {
@@ -2614,6 +2614,7 @@ void engine_wash_ship_process(ship *shipp)
 			engine_wash_info *ewp = bank->wash_info_pointer;
 			half_angle = ewp->angle;
 			radius_mult = ewp->radius_mult;
+			float wash_intensity;
 			if (Use_engine_wash_intensity) {
 				wash_intensity = ewp->intensity;
 			} else {

--- a/code/ship/shipfx.cpp
+++ b/code/ship/shipfx.cpp
@@ -23,6 +23,7 @@
 #include "io/timer.h"
 #include "lighting/lighting.h"
 #include "math/fvi.h"
+#include "mod_table/mod_table.h"
 #include "model/model.h"
 #include "network/multi.h"
 #include "network/multimsgs.h"
@@ -2526,7 +2527,7 @@ void engine_wash_ship_process(ship *shipp)
 	float dist_sqr, inset_depth, dot_to_ship, max_ship_intensity;
 	polymodel *pm;
 
-	float max_wash_dist, half_angle, radius_mult;
+	float max_wash_dist, half_angle, radius_mult, wash_intensity;
 
 	// if this is not a fighter or bomber, we don't care
 	if ((objp->type != OBJ_SHIP) || !(Ship_info[shipp->ship_info_index].is_fighter_bomber()) ) {
@@ -2613,6 +2614,12 @@ void engine_wash_ship_process(ship *shipp)
 			engine_wash_info *ewp = bank->wash_info_pointer;
 			half_angle = ewp->angle;
 			radius_mult = ewp->radius_mult;
+			if (Use_engine_wash_intensity) {
+				wash_intensity = ewp->intensity;
+			} else {
+				wash_intensity = 1.0f;
+			}
+			
 
 
 			// If bank is attached to a submodel, prepare to account for rotations
@@ -2665,7 +2672,7 @@ void engine_wash_ship_process(ship *shipp)
 						if ( dist_sqr < ((radius_mult * radius_mult) * (bank->points[j].radius * bank->points[j].radius)) ) {
 							vm_vec_cross(&temp, &world_thruster_norm, &thruster_to_ship);
 							vm_vec_scale_add2(&shipp->wash_rot_axis, &temp, dot_to_ship / dist_sqr);
-							ship_intensity += (1.0f - dist_sqr / (max_wash_dist*max_wash_dist));
+							ship_intensity += (1.0f - dist_sqr / (max_wash_dist*max_wash_dist)) * wash_intensity;
 							if (!do_damage) {
 								if (dist_sqr < 0.25 * max_wash_dist * max_wash_dist) {
 									do_damage = 1;
@@ -2682,7 +2689,7 @@ void engine_wash_ship_process(ship *shipp)
 							if (vm_vec_dot(&apex_to_ship, &world_thruster_norm) > cosf(half_angle)) {
 								vm_vec_cross(&temp, &world_thruster_norm, &thruster_to_ship);
 								vm_vec_scale_add2(&shipp->wash_rot_axis, &temp, dot_to_ship / dist_sqr);
-								ship_intensity += (1.0f - dist_sqr / (max_wash_dist*max_wash_dist));
+								ship_intensity += (1.0f - dist_sqr / (max_wash_dist*max_wash_dist)) * wash_intensity;
 								if (!do_damage) {
 									if (dist_sqr < 0.25 * max_wash_dist * max_wash_dist) {
 										do_damage = 1;


### PR DESCRIPTION
Previously, Engine Wash Intensity didn't actually do anything in the code. This adds a game table setting, `$Use Engine Wash Intensity:`, that let's modders specify to the game to actually take the intensity value into account when calculating engine wash effects.

I was going to use a boolean check at each time `wash_intensity` was used, but since the `ship_intensity` value is cumulative that means that each `wash_intensity` needs to be applied to it's respective thruster before being added to the cumulative total. 