### PR TITLE
CleanUp Unused Function

### DIFF
--- a/code/network/multi.cpp
+++ b/code/network/multi.cpp
@@ -1219,10 +1219,6 @@ void multi_do_frame()
 	// while in the mission, send my PlayerControls to the host so that he can process
 	// my movement
 	if ( Game_mode & GM_IN_MISSION ) {
-		// tickers
-		extern void oo_update_time();
-		oo_update_time();
-
 
 		if ( !(Net_player->flags & NETINFO_FLAG_AM_MASTER)){					
 			if(Net_player->flags & NETINFO_FLAG_OBSERVER){

--- a/code/network/multi_ingame.cpp
+++ b/code/network/multi_ingame.cpp
@@ -279,9 +279,6 @@ void multi_ingame_sync_init()
 	// everyone should re-initialize these 
 	init_multiplayer_stats();
 
-	// reset all sequencing info
-	multi_oo_reset_sequencing();
-
 	// send the file signature to the host for possible mission file transfer
 	strcpy_s(Netgame.mission_name,Game_current_mission_filename);
 	send_file_sig_packet(Multi_current_file_checksum,Multi_current_file_length);

--- a/code/network/multi_obj.cpp
+++ b/code/network/multi_obj.cpp
@@ -1991,10 +1991,6 @@ void multi_oo_calc_interp_splines(int ship_index, vec3d *cur_pos, physics_info *
 
 }
 
-void oo_update_time()
-{	
-}
-
 int display_oo_bez = 0;
 DCF(bez, "Toggles rendering of player ship trajectory interpolation splines (Multiplayer) *disabled*")
 {

--- a/code/network/multi_obj.cpp
+++ b/code/network/multi_obj.cpp
@@ -1800,11 +1800,6 @@ void multi_oo_update_server_rate()
 	OO_client_rate = (int)(((float)OO_server_rate / (float)OO_gran) / (float)num_connections);
 }
 
-// reset all sequencing info (obsolete for new object update stuff)
-void multi_oo_reset_sequencing()
-{		
-}
-
 // is this object one which needs to go through the interpolation
 int multi_oo_is_interp_object(object *objp)
 {	

--- a/code/network/multi_obj.h
+++ b/code/network/multi_obj.h
@@ -61,9 +61,6 @@ void multi_oo_gameplay_init();
 void multi_oo_send_control_info();
 void multi_oo_send_changed_object(object *changedobj);
 
-// reset all sequencing info
-void multi_oo_reset_sequencing();
-
 // is this object one which needs to go through the interpolation
 int multi_oo_is_interp_object(object *objp);
 

--- a/code/network/multiui.cpp
+++ b/code/network/multiui.cpp
@@ -8110,9 +8110,6 @@ void multi_sync_post_init()
 	// everyone should re-initialize these 
 	init_multiplayer_stats();
 
-	// reset all sequencing info
-	multi_oo_reset_sequencing();
-
 	// if I am not the master of the game, then send the firing information for my ship
 	// to the host
 	if ( !(Net_player->flags & NETINFO_FLAG_AM_MASTER) ){


### PR DESCRIPTION
This function does not have any contents and should be removed to make the code more readable.

(I'm trying to keep misc changes made in another branch)

It looks like it was here to update a timestamp that might have been planned to be attached to some packets, but no packets use such a timestamp, and such a timestamp could actually be counterproductive, since pings vary.  We rely on sequence numbers within packets instead.