### PR TITLE
Use uniform blocks for matrices

### DIFF
--- a/.github/workflows/pr-workflow.yaml
+++ b/.github/workflows/pr-workflow.yaml
@@ -76,15 +76,8 @@ jobs:
     strategy:
       matrix:
         configuration: [Debug, Release]
-        compiler: [MSVC, MinGW]
+        compiler: [MSVC]
         arch: [Win32, x64]
-        exclude:
-          - configuration: Debug
-            compiler: MinGW
-            arch: x64
-          - configuration: Release
-            compiler: MinGW
-            arch: x64
     name: Windows
     runs-on: windows-2019
     steps:

--- a/code/cmdline/cmdline.cpp
+++ b/code/cmdline/cmdline.cpp
@@ -249,6 +249,7 @@ Flag exe_params[] =
 	{ "-json_profiling",	"Generate JSON profiling output",			true,	0,									EASY_DEFAULT,					"Dev Tool",		"http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-json_profiling", },
 	{ "-profile_frame_time","Profile engine subsystems",				true,	0,									EASY_DEFAULT,					"Dev Tool",		"http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-profile_frame_timings", },
 	{ "-debug_window",		"Enable the debug window",					true,	0,									EASY_DEFAULT,					"Dev Tool",		"http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-debug_window", },
+	{ "-gr_debug",		"Output graphics debug information",			true,	0,									EASY_DEFAULT,					"Dev Tool",		"http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-gr_debug", },
 };
 // clang-format on
 
@@ -478,6 +479,7 @@ cmdline_parm json_profiling("-json_profiling", NULL, AT_NONE); //Cmdline_json_pr
 cmdline_parm show_video_info("-show_video_info", NULL, AT_NONE); //Cmdline_show_video_info
 cmdline_parm frame_profile_arg("-profile_frame_time", NULL, AT_NONE); //Cmdline_frame_profile
 cmdline_parm debug_window_arg("-debug_window", NULL, AT_NONE);	// Cmdline_debug_window
+cmdline_parm graphics_debug_output_arg("-gr_debug", nullptr, AT_NONE); // Cmdline_graphics_debug_output
 
 
 char *Cmdline_start_mission = NULL;
@@ -507,6 +509,7 @@ bool Cmdline_json_profiling = false;
 bool Cmdline_frame_profile = false;
 bool Cmdline_show_video_info = false;
 bool Cmdline_debug_window = false;
+bool Cmdline_graphics_debug_output = false;
 
 // Other
 cmdline_parm get_flags_arg(GET_FLAGS_STRING, "Output the launcher flags file", AT_STRING);
@@ -2131,6 +2134,10 @@ bool SetCmdlineParams()
 
 	if (debug_window_arg.found()) {
 		Cmdline_debug_window = true;
+	}
+
+	if (graphics_debug_output_arg.found()) {
+		Cmdline_graphics_debug_output = true;
 	}
 
 	if (show_video_info.found())

--- a/code/cmdline/cmdline.h
+++ b/code/cmdline/cmdline.h
@@ -147,5 +147,6 @@ extern bool Cmdline_json_profiling;
 extern bool Cmdline_frame_profile;
 extern bool Cmdline_show_video_info;
 extern bool Cmdline_debug_window;
+extern bool Cmdline_graphics_debug_output;
 
 #endif

--- a/code/def_files/data/effects/batched-v.sdr
+++ b/code/def_files/data/effects/batched-v.sdr
@@ -3,8 +3,12 @@ in vec4 vertTexCoord;
 in vec4 vertColor;
 out vec4 fragTexCoord;
 out vec4 fragColor;
-uniform mat4 modelViewMatrix;
-uniform mat4 projMatrix;
+
+layout (std140) uniform matrixData {
+	mat4 modelViewMatrix;
+	mat4 projMatrix;
+};
+
 uniform vec4 color;
 void main()
 {

--- a/code/def_files/data/effects/default-material-v.sdr
+++ b/code/def_files/data/effects/default-material-v.sdr
@@ -1,21 +1,27 @@
 in vec4 vertPosition;
 in vec4 vertTexCoord;
 in vec4 vertColor;
-in float vertRadius;
 out vec4 fragTexCoord;
 out vec4 fragColor;
-out float fragOffset;
 
 layout (std140) uniform matrixData {
 	mat4 modelViewMatrix;
 	mat4 projMatrix;
 };
 
-uniform float use_offset;
+uniform vec4 color;
+
+uniform mat4 modelMatrix;
+uniform bool clipEnabled;
+uniform vec4 clipEquation;
+
 void main()
 {
+	fragTexCoord = vertTexCoord;
+	fragColor = vertColor * color;
 	gl_Position = projMatrix * modelViewMatrix * vertPosition;
-	fragOffset = vertRadius * use_offset;
-	fragTexCoord = vec4(vertTexCoord.xyz, 0.0);
-	fragColor = vertColor;
+
+	if (clipEnabled) {
+		gl_ClipDistance[0] = dot(clipEquation, modelMatrix * vertPosition);
+	}
 }

--- a/code/def_files/data/effects/deferred-v.sdr
+++ b/code/def_files/data/effects/deferred-v.sdr
@@ -2,8 +2,11 @@
 #include "lighting.sdr"
 
 in vec4 vertPosition;
-uniform mat4 modelViewMatrix;
-uniform mat4 projMatrix;
+
+layout (std140) uniform matrixData {
+	mat4 modelViewMatrix;
+	mat4 projMatrix;
+};
 
 layout (std140) uniform lightData {
 	vec3 diffuseLightColor;

--- a/code/def_files/data/effects/effect-screen-g.sdr
+++ b/code/def_files/data/effects/effect-screen-g.sdr
@@ -8,7 +8,12 @@ out float fragRadius;
 out vec4 fragPosition;
 out vec4 fragTexCoord;
 out vec4 fragColor;
-uniform mat4 projMatrix;
+
+layout (std140) uniform matrixData {
+	mat4 modelViewMatrix;
+	mat4 projMatrix;
+};
+
 void main(void)
 {
 	vec3 forward_vec = vec3(0.0, 0.0, 1.0);

--- a/code/def_files/data/effects/effect-v.sdr
+++ b/code/def_files/data/effects/effect-v.sdr
@@ -18,8 +18,12 @@ in float vertRadius;
 out float fragOffset;
 uniform float use_offset;
 #endif
-uniform mat4 modelViewMatrix;
-uniform mat4 projMatrix;
+
+layout (std140) uniform matrixData {
+	mat4 modelViewMatrix;
+	mat4 projMatrix;
+};
+
 void main()
 {
 	#ifdef FLAG_EFFECT_GEOMETRY

--- a/code/def_files/data/effects/passthrough-v.sdr
+++ b/code/def_files/data/effects/passthrough-v.sdr
@@ -3,21 +3,17 @@ in vec4 vertTexCoord;
 in vec4 vertColor;
 out vec4 fragTexCoord;
 out vec4 fragColor;
-uniform mat4 modelViewMatrix;
-uniform mat4 projMatrix;
-uniform vec4 color;
 
-uniform mat4 modelMatrix;
-uniform bool clipEnabled;
-uniform vec4 clipEquation;
+layout (std140) uniform matrixData {
+	mat4 modelViewMatrix;
+	mat4 projMatrix;
+};
+
+uniform vec4 color;
 
 void main()
 {
 	fragTexCoord = vertTexCoord;
 	fragColor = vertColor * color;
 	gl_Position = projMatrix * modelViewMatrix * vertPosition;
-
-	if (clipEnabled) {
-		gl_ClipDistance[0] = dot(clipEquation, modelMatrix * vertPosition);
-	}
 }

--- a/code/def_files/data/effects/shield-impact-v.sdr
+++ b/code/def_files/data/effects/shield-impact-v.sdr
@@ -2,11 +2,16 @@ in vec4 vertPosition;
 in vec3 vertNormal;
 out vec4 fragImpactUV;
 out float fragNormOffset;
-uniform mat4 modelViewMatrix;
-uniform mat4 projMatrix;
+
 uniform vec3 hitNormal;
 uniform mat4 shieldModelViewMatrix;
 uniform mat4 shieldProjMatrix;
+
+layout (std140) uniform matrixData {
+	mat4 modelViewMatrix;
+	mat4 projMatrix;
+};
+
 void main()
 {
 	gl_Position = projMatrix * modelViewMatrix * vertPosition;

--- a/code/def_files/data/effects/video-v.sdr
+++ b/code/def_files/data/effects/video-v.sdr
@@ -1,8 +1,12 @@
 in vec4 vertPosition;
 in vec4 vertTexCoord;
 out vec4 fragTexCoord;
-uniform mat4 modelViewMatrix;
-uniform mat4 projMatrix;
+
+layout (std140) uniform matrixData {
+	mat4 modelViewMatrix;
+	mat4 projMatrix;
+};
+
 void main()
 {
 	fragTexCoord = vertTexCoord;

--- a/code/graphics/2d.h
+++ b/code/graphics/2d.h
@@ -240,6 +240,7 @@ enum class uniform_block_type {
 	DecalInfo = 3,
 	DecalGlobals = 4,
 	DeferredGlobals = 5,
+	Matrices = 6,
 
 	NUM_BLOCK_TYPES
 };

--- a/code/graphics/matrix.cpp
+++ b/code/graphics/matrix.cpp
@@ -1,6 +1,10 @@
 
 #include "matrix.h"
 
+#include "graphics/util/UniformBuffer.h"
+
+#include <graphics/util/uniform_structs.h>
+
 transform_stack gr_model_matrix_stack;
 matrix4 gr_view_matrix;
 matrix4 gr_model_view_matrix;
@@ -15,11 +19,13 @@ matrix4 gr_env_texture_matrix;
 bool gr_htl_projection_matrix_set = false;
 
 static int modelview_matrix_depth = 1;
-static bool htl_view_matrix_set = false;
-static int htl_2d_matrix_depth = 0;
-static bool htl_2d_matrix_set = false;
+static bool htl_view_matrix_set   = false;
+static int htl_2d_matrix_depth    = 0;
+static bool htl_2d_matrix_set     = false;
 
-static matrix4 create_view_matrix(const vec3d *pos, const matrix *orient)
+static bool matrix_uniform_up_to_date = false;
+
+static matrix4 create_view_matrix(const vec3d* pos, const matrix* orient)
 {
 	vec3d scaled_pos;
 	vec3d inv_pos;
@@ -81,6 +87,8 @@ void gr_start_instance_matrix(const vec3d *offset, const matrix *rotation)
 	vm_matrix4_x_matrix4(&gr_model_view_matrix, &gr_view_matrix, &model_matrix);
 
 	modelview_matrix_depth++;
+
+	matrix_uniform_up_to_date = false;
 }
 
 void gr_start_angles_instance_matrix(const vec3d *pos, const angles *rotation)
@@ -103,6 +111,8 @@ void gr_end_instance_matrix()
 	vm_matrix4_x_matrix4(&gr_model_view_matrix, &gr_view_matrix, &model_matrix);
 
 	modelview_matrix_depth--;
+
+	matrix_uniform_up_to_date = false;
 }
 
 // the projection matrix; fov, aspect ratio, near, far
@@ -126,6 +136,8 @@ void gr_set_proj_matrix(float fov, float aspect, float z_near, float z_far) {
 	}
 
 	gr_htl_projection_matrix_set = true;
+
+	matrix_uniform_up_to_date = false;
 }
 
 void gr_end_proj_matrix() {
@@ -141,6 +153,8 @@ void gr_end_proj_matrix() {
 	}
 
 	gr_htl_projection_matrix_set = false;
+
+	matrix_uniform_up_to_date = false;
 }
 
 void gr_set_view_matrix(const vec3d *pos, const matrix *orient)
@@ -174,6 +188,8 @@ void gr_set_view_matrix(const vec3d *pos, const matrix *orient)
 
 	modelview_matrix_depth = 2;
 	htl_view_matrix_set = true;
+
+	matrix_uniform_up_to_date = false;
 }
 
 void gr_end_view_matrix()
@@ -186,6 +202,8 @@ void gr_end_view_matrix()
 
 	modelview_matrix_depth = 1;
 	htl_view_matrix_set = false;
+
+	matrix_uniform_up_to_date = false;
 }
 
 // set a view and projection matrix for a 2D element
@@ -224,6 +242,8 @@ void gr_set_2d_matrix(/*int x, int y, int w, int h*/)
 
 	htl_2d_matrix_set = true;
 	htl_2d_matrix_depth++;
+
+	matrix_uniform_up_to_date = false;
 }
 
 // ends a previously set 2d view and projection matrix
@@ -248,6 +268,8 @@ void gr_end_2d_matrix()
 
 	htl_2d_matrix_set = false;
 	htl_2d_matrix_depth = 0;
+
+	matrix_uniform_up_to_date = false;
 }
 
 static bool scale_matrix_set = false;
@@ -265,6 +287,8 @@ void gr_push_scale_matrix(const vec3d *scale_factor)
 
 	auto model_matrix = gr_model_matrix_stack.get_transform();
 	vm_matrix4_x_matrix4(&gr_model_view_matrix, &gr_view_matrix, &model_matrix);
+
+	matrix_uniform_up_to_date = false;
 }
 
 void gr_pop_scale_matrix()
@@ -279,6 +303,8 @@ void gr_pop_scale_matrix()
 
 	modelview_matrix_depth--;
 	scale_matrix_set = false;
+
+	matrix_uniform_up_to_date = false;
 }
 void gr_setup_viewport() {
 	if (Gr_inited) {
@@ -296,6 +322,8 @@ void gr_setup_viewport() {
 	} else {
 		create_orthographic_projection_matrix(&gr_projection_matrix, 0, i2fl(gr_screen.max_w), i2fl(gr_screen.max_h), 0, -1, 1);
 	}
+
+	matrix_uniform_up_to_date = false;
 }
 void gr_reset_matrices() {
 	vm_matrix4_set_identity(&gr_projection_matrix);
@@ -308,12 +336,43 @@ void gr_reset_matrices() {
 	gr_model_matrix_stack.clear();
 
 	vm_matrix4_set_identity(&gr_texture_matrix);
+
+	matrix_uniform_up_to_date = false;
 }
 
-void gr_set_texture_panning(float u, float v, bool enable) {
+void gr_set_texture_panning(float u, float v, bool enable)
+{
 	vm_matrix4_set_identity(&gr_texture_matrix);
 	if (enable) {
 		gr_texture_matrix.a2d[3][0] = u;
 		gr_texture_matrix.a2d[3][1] = v;
 	}
+}
+
+void gr_matrix_on_frame()
+{
+	// The old uniform state is now out of date and should not be used anymore
+	matrix_uniform_up_to_date = false;
+}
+void gr_matrix_set_uniforms()
+{
+	if (matrix_uniform_up_to_date) {
+		// No changes since last time, no need to update
+		return;
+	}
+
+	GR_DEBUG_SCOPE("Updating matrix uniforms");
+
+	auto uniform_buffer = gr_get_uniform_buffer(uniform_block_type::Matrices, 1);
+	auto& aligner       = uniform_buffer.aligner();
+
+	auto matrix_data             = aligner.addTypedElement<graphics::matrix_uniforms>();
+	matrix_data->modelViewMatrix = gr_model_view_matrix;
+	matrix_data->projMatrix      = gr_projection_matrix;
+
+	uniform_buffer.submitData();
+	gr_bind_uniform_buffer(uniform_block_type::Matrices, uniform_buffer.getBufferOffset(0),
+	                       sizeof(graphics::matrix_uniforms), uniform_buffer.bufferHandle());
+
+	matrix_uniform_up_to_date = true;
 }

--- a/code/graphics/matrix.h
+++ b/code/graphics/matrix.h
@@ -9,14 +9,16 @@ extern matrix4 gr_projection_matrix;
 extern matrix4 gr_last_projection_matrix;
 extern matrix4 gr_env_texture_matrix;
 
-void gr_start_instance_matrix(const vec3d *offset, const matrix *rotation);
-void gr_start_angles_instance_matrix(const vec3d *pos, const angles *rotation);
+void gr_matrix_on_frame();
+
+void gr_start_instance_matrix(const vec3d* offset, const matrix* rotation);
+void gr_start_angles_instance_matrix(const vec3d* pos, const angles* rotation);
 void gr_end_instance_matrix();
 
 void gr_set_proj_matrix(float fov, float aspect, float z_near, float z_far);
 void gr_end_proj_matrix();
 
-void gr_set_view_matrix(const vec3d *pos, const matrix *orient);
+void gr_set_view_matrix(const vec3d* pos, const matrix* orient);
 void gr_end_view_matrix();
 
 void gr_set_2d_matrix(/*int x, int y, int w, int h*/);
@@ -32,3 +34,11 @@ void gr_reset_matrices();
 extern matrix4 gr_texture_matrix;
 
 void gr_set_texture_panning(float u, float v, bool enable);
+
+/**
+ * @brief Set current matrix uniforms
+ *
+ * Use this before rendering with a shader requiring the matrix uniforms so that the matrix uniform block point has the
+ * up-to-date data.
+ */
+void gr_matrix_set_uniforms();

--- a/code/graphics/opengl/gropengl.cpp
+++ b/code/graphics/opengl/gropengl.cpp
@@ -1,6 +1,7 @@
 
 
 #include "gropengl.h"
+
 #include "gropenglbmpman.h"
 #include "gropengldeferred.h"
 #include "gropengldraw.h"
@@ -11,29 +12,21 @@
 #include "gropenglsync.h"
 #include "gropengltexture.h"
 #include "gropengltnl.h"
+
 #include "bmpman/bmpman.h"
 #include "cfile/cfile.h"
 #include "cmdline/cmdline.h"
 #include "ddsutils/ddsutils.h"
 #include "debugconsole/console.h"
-#include "globalincs/systemvars.h"
 #include "graphics/2d.h"
-#include "graphics/line.h"
 #include "graphics/matrix.h"
-#include "graphics/paths/PathRenderer.h"
-#include "io/mouse.h"
-#include "io/timer.h"
 #include "libs/renderdoc/renderdoc.h"
 #include "math/floating.h"
 #include "model/model.h"
-#include "nebula/neb.h"
 #include "options/Option.h"
 #include "osapi/osapi.h"
 #include "osapi/osregistry.h"
 #include "pngutils/pngutils.h"
-#include "popup/popup.h"
-#include "render/3d.h"
-#include "tracing/tracing.h"
 
 #if defined(_WIN32)
 #include <windows.h>
@@ -190,14 +183,8 @@ void gr_opengl_clear()
 
 void gr_opengl_flip()
 {
-	if ( !GL_initted )
+	if (!GL_initted)
 		return;
-
-	TRACE_SCOPE(tracing::PageFlip);
-
-	gr_reset_clip();
-
-	mouse_reset_deltas();
 
 	if (Cmdline_gl_finish)
 		glFinish();

--- a/code/graphics/opengl/gropengldeferred.cpp
+++ b/code/graphics/opengl/gropengldeferred.cpp
@@ -359,8 +359,7 @@ void gr_opengl_draw_deferred_light_sphere(const vec3d *position)
 {
 	g3_start_instance_matrix(position, &vmd_identity_matrix, true);
 
-	Current_shader->program->Uniforms.setUniformMatrix4f("modelViewMatrix", gr_model_view_matrix);
-	Current_shader->program->Uniforms.setUniformMatrix4f("projMatrix", gr_projection_matrix);
+	gr_matrix_set_uniforms();
 
 	opengl_draw_sphere();
 
@@ -587,8 +586,7 @@ void gr_opengl_draw_deferred_light_cylinder(const vec3d *position, const matrix 
 {
 	g3_start_instance_matrix(position, orient, true);
 
-	Current_shader->program->Uniforms.setUniformMatrix4f("modelViewMatrix", gr_model_view_matrix);
-	Current_shader->program->Uniforms.setUniformMatrix4f("projMatrix", gr_projection_matrix);
+	gr_matrix_set_uniforms();
 
 	vertex_layout vertex_declare;
 

--- a/code/graphics/opengl/gropengldraw.cpp
+++ b/code/graphics/opengl/gropengldraw.cpp
@@ -626,8 +626,8 @@ void gr_opengl_render_shield_impact(shield_material *material_info, primitive_ty
 	Current_shader->program->Uniforms.setUniformi("shieldMapIndex", array_index);
 	Current_shader->program->Uniforms.setUniformi("srgb", High_dynamic_range ? 1 : 0);
 	Current_shader->program->Uniforms.setUniform4f("color", material_info->get_color());
-	Current_shader->program->Uniforms.setUniformMatrix4f("modelViewMatrix", gr_model_view_matrix);
-	Current_shader->program->Uniforms.setUniformMatrix4f("projMatrix", gr_projection_matrix);
+
+	gr_matrix_set_uniforms();
 	
 	opengl_render_primitives(prim_type, layout, n_verts, buffer_handle, 0, 0);
 }

--- a/code/graphics/opengl/gropenglshader.cpp
+++ b/code/graphics/opengl/gropenglshader.cpp
@@ -70,6 +70,7 @@ opengl_uniform_block_binding GL_uniform_blocks[] = {
 	{ uniform_block_type::DecalInfo, "decalInfoData" },
 	{ uniform_block_type::DecalGlobals, "decalGlobalData" },
 	{ uniform_block_type::DeferredGlobals, "globalDeferredData" },
+	{ uniform_block_type::Matrices, "matrixData" },
 };
 
 /**
@@ -129,7 +130,7 @@ static opengl_shader_type_t GL_shader_types[] = {
 	{ SDR_TYPE_BATCHED_BITMAP, "batched-v.sdr", "batched-f.sdr", nullptr,
 		{ opengl_vert_attrib::POSITION, opengl_vert_attrib::TEXCOORD, opengl_vert_attrib::COLOR }, "Batched bitmaps" },
 
-	{ SDR_TYPE_DEFAULT_MATERIAL, "passthrough-v.sdr", "default-material-f.sdr", nullptr,
+	{ SDR_TYPE_DEFAULT_MATERIAL, "default-material-v.sdr", "default-material-f.sdr", nullptr,
 		{ opengl_vert_attrib::POSITION, opengl_vert_attrib::TEXCOORD, opengl_vert_attrib::COLOR }, "Default material" },
 
 	{ SDR_TYPE_NANOVG, "nanovg-v.sdr", "nanovg-f.sdr", nullptr,
@@ -1022,8 +1023,7 @@ void opengl_shader_set_passthrough(bool textured, bool hdr)
 
 	Current_shader->program->Uniforms.setUniform4f("color", 1.0f, 1.0f, 1.0f, 1.0f);
 
-	Current_shader->program->Uniforms.setUniformMatrix4f("modelViewMatrix", gr_model_view_matrix);
-	Current_shader->program->Uniforms.setUniformMatrix4f("projMatrix", gr_projection_matrix);
+	gr_matrix_set_uniforms();
 }
 
 void opengl_shader_set_default_material(bool textured, bool alpha, vec4 *clr, float color_scale, uint32_t array_index, const material::clip_plane& clip_plane)
@@ -1055,7 +1055,7 @@ void opengl_shader_set_default_material(bool textured, bool alpha, vec4 *clr, fl
 
 	Current_shader->program->Uniforms.setUniformf("alphaThreshold", GL_alpha_threshold);
 
-	if ( clr != NULL ) {
+	if ( clr != nullptr ) {
 		Current_shader->program->Uniforms.setUniform4f("color", *clr);
 	} else {
 		Current_shader->program->Uniforms.setUniform4f("color", 1.0f, 1.0f, 1.0f, 1.0f);
@@ -1076,7 +1076,6 @@ void opengl_shader_set_default_material(bool textured, bool alpha, vec4 *clr, fl
 		Current_shader->program->Uniforms.setUniformi("clipEnabled", 0);
 	}
 
-	Current_shader->program->Uniforms.setUniformMatrix4f("modelViewMatrix", gr_model_view_matrix);
-	Current_shader->program->Uniforms.setUniformMatrix4f("projMatrix", gr_projection_matrix);
+	gr_matrix_set_uniforms();
 }
 

--- a/code/graphics/opengl/gropengltnl.cpp
+++ b/code/graphics/opengl/gropengltnl.cpp
@@ -767,8 +767,7 @@ void opengl_tnl_set_material(material* material_info, bool set_base_map, bool se
 		if (!clip_params.enabled) {
 			GL_state.ClipDistance(0, false);
 		} else {
-			Assertion(Current_shader != NULL && (Current_shader->shader == SDR_TYPE_MODEL
-				|| Current_shader->shader == SDR_TYPE_PASSTHROUGH_RENDER
+			Assertion(Current_shader != nullptr && (Current_shader->shader == SDR_TYPE_MODEL
 				|| Current_shader->shader == SDR_TYPE_DEFAULT_MATERIAL),
 					  "Clip planes are not supported by this shader!");
 
@@ -946,8 +945,7 @@ void opengl_tnl_set_material_particle(particle_material * material_info)
 {
 	opengl_tnl_set_material(material_info, true);
 
-	Current_shader->program->Uniforms.setUniformMatrix4f("modelViewMatrix", gr_model_view_matrix);
-	Current_shader->program->Uniforms.setUniformMatrix4f("projMatrix", gr_projection_matrix);
+	gr_matrix_set_uniforms();
 
 	Current_shader->program->Uniforms.setUniformi("baseMap", 0);
 	Current_shader->program->Uniforms.setUniformi("depthMap", 1);
@@ -979,11 +977,9 @@ void opengl_tnl_set_material_batched(batched_bitmap_material* material_info) {
 	opengl_tnl_set_material(material_info, true);
 
 	Current_shader->program->Uniforms.setUniformf("intensity", material_info->get_color_scale());
-
 	Current_shader->program->Uniforms.setUniform4f("color", material_info->get_color());
 
-	Current_shader->program->Uniforms.setUniformMatrix4f("modelViewMatrix", gr_model_view_matrix);
-	Current_shader->program->Uniforms.setUniformMatrix4f("projMatrix", gr_projection_matrix);
+	gr_matrix_set_uniforms();
 
 	Current_shader->program->Uniforms.setUniformi("baseMap", 0);
 }
@@ -992,8 +988,7 @@ void opengl_tnl_set_material_distortion(distortion_material* material_info)
 {
 	opengl_tnl_set_material(material_info, true);
 
-	Current_shader->program->Uniforms.setUniformMatrix4f("modelViewMatrix", gr_model_view_matrix);
-	Current_shader->program->Uniforms.setUniformMatrix4f("projMatrix", gr_projection_matrix);
+	gr_matrix_on_frame();
 
 	Current_shader->program->Uniforms.setUniformi("baseMap", 0);
 	Current_shader->program->Uniforms.setUniformi("depthMap", 1);
@@ -1026,8 +1021,7 @@ void opengl_tnl_set_material_distortion(distortion_material* material_info)
 void opengl_tnl_set_material_movie(movie_material* material_info) {
 	opengl_tnl_set_material(material_info, false);
 
-	Current_shader->program->Uniforms.setUniformMatrix4f("modelViewMatrix", gr_model_view_matrix);
-	Current_shader->program->Uniforms.setUniformMatrix4f("projMatrix", gr_projection_matrix);
+	gr_matrix_on_frame();
 
 	Current_shader->program->Uniforms.setUniformi("ytex", 0);
 	Current_shader->program->Uniforms.setUniformi("utex", 1);

--- a/code/graphics/util/UniformBufferManager.cpp
+++ b/code/graphics/util/UniformBufferManager.cpp
@@ -18,6 +18,8 @@ size_t getElementSize(uniform_block_type type)
 		return sizeof(graphics::nanovg_draw_data);
 	case uniform_block_type::DecalInfo:
 		return sizeof(graphics::decal_info);
+	case uniform_block_type::Matrices:
+		return sizeof(graphics::matrix_uniforms);
 	case uniform_block_type::NUM_BLOCK_TYPES:
 	default:
 		UNREACHABLE("Invalid block type encountered!");
@@ -34,6 +36,7 @@ size_t getHeaderSize(uniform_block_type type)
 		return sizeof(graphics::decal_globals);
 	case uniform_block_type::ModelData:
 	case uniform_block_type::NanoVGData:
+	case uniform_block_type::Matrices:
 		return 0;
 	case uniform_block_type::NUM_BLOCK_TYPES:
 	default:
@@ -196,5 +199,7 @@ void UniformBufferManager::submitData(void* buffer, size_t data_size, size_t off
 	}
 }
 int UniformBufferManager::getActiveBufferHandle() { return _active_uniform_buffer; }
+size_t UniformBufferManager::getBufferSize() { return _active_buffer_size; }
+size_t UniformBufferManager::getCurrentlyUsedSize() { return _segment_offset; }
 } // namespace util
 } // namespace graphics

--- a/code/graphics/util/UniformBufferManager.h
+++ b/code/graphics/util/UniformBufferManager.h
@@ -98,6 +98,20 @@ class UniformBufferManager {
 	 * @brief Checks the used buffer and retires any buffers that are no longer in use for later reuse
 	 */
 	void onFrameEnd();
+
+	/**
+	 * @brief Gets the current size of the uniform buffer
+	 * This is mostly for debugging purposes.
+	 * @return The size in bytes of the uniform buffer.
+	 */
+	size_t getBufferSize();
+
+	/**
+	 * @brief Gets the number of bytes used in the current segment of the buffer
+	 * This is mostly for debugging purposes.
+	 * @return The bytes used in the segment
+	 */
+	size_t getCurrentlyUsedSize();
 };
 
 }

--- a/code/graphics/util/uniform_structs.h
+++ b/code/graphics/util/uniform_structs.h
@@ -204,4 +204,9 @@ struct decal_info {
 	float pad;
 };
 
+struct matrix_uniforms {
+	matrix4 modelViewMatrix;
+	matrix4 projMatrix;
+};
+
 }

--- a/code/source_groups.cmake
+++ b/code/source_groups.cmake
@@ -166,6 +166,7 @@ add_file_folder("Default files\\\\data\\\\effects"
 	def_files/data/effects/decal-f.sdr
 	def_files/data/effects/decal-v.sdr
 	def_files/data/effects/default-material-f.sdr
+	def_files/data/effects/default-material-v.sdr
 	def_files/data/effects/deferred-clear-f.sdr
 	def_files/data/effects/deferred-clear-v.sdr
 	def_files/data/effects/deferred-f.sdr


### PR DESCRIPTION
This is a generic way to get matrix data to shaders without using
(old-school) uniforms. This is another step towards more compatibility
with how new APIs (Vulkan) do things to increase the odds for a Vulkan
port at some point.