### PR TITLE
Fix weapon names not filtering # in HUD gauge

### DIFF
--- a/code/hud/hudtarget.cpp
+++ b/code/hud/hudtarget.cpp
@@ -6013,6 +6013,7 @@ void HudGaugeWeapons::render(float  /*frametime*/)
 		if(Weapon_info[sw->primary_bank_weapons[0]].hud_image_index != -1) {
 			renderBitmap(Weapon_info[sw->primary_bank_weapons[i]].hud_image_index, position[0] + Weapon_pname_offset_x, name_y);
 		} else {
+			end_string_at_first_hash_symbol(name);
 			renderPrintf(position[0] + Weapon_pname_offset_x, name_y, EG_WEAPON_P2, "%s", name);
 		}
 
@@ -6105,6 +6106,7 @@ void HudGaugeWeapons::render(float  /*frametime*/)
 
 		// print out the ammo right justified
 		sprintf(ammo_str, "%d", ammo);
+		end_string_at_first_hash_symbol(ammo_str);
 		hud_num_make_mono(ammo_str, font_num);
 		gr_get_string_size(&w, &h, ammo_str);
 

--- a/code/hud/hudtarget.cpp
+++ b/code/hud/hudtarget.cpp
@@ -6106,7 +6106,6 @@ void HudGaugeWeapons::render(float  /*frametime*/)
 
 		// print out the ammo right justified
 		sprintf(ammo_str, "%d", ammo);
-		end_string_at_first_hash_symbol(ammo_str);
 		hud_num_make_mono(ammo_str, font_num);
 		gr_get_string_size(&w, &h, ammo_str);
 

--- a/code/hud/hudtarget.cpp
+++ b/code/hud/hudtarget.cpp
@@ -6022,9 +6022,6 @@ void HudGaugeWeapons::render(float  /*frametime*/)
 			// print out the ammo right justified
 			sprintf(ammo_str, "%d", sw->primary_bank_ammo[i]);
 
-			// get rid of #
-			end_string_at_first_hash_symbol(ammo_str);
-
 			hud_num_make_mono(ammo_str, font_num);
 			gr_get_string_size(&w, &h, ammo_str);
 


### PR DESCRIPTION
Weapon names with a `#` should not display text after that `#` in the HUD. For the most part this works, but there were a few cases this didn't (such as primaries using the weapon name). This PR fixes two spots that fell between the cracks. Note that line 6109 was added in that section/order because that is where it appeared in that order on line 6026.