### PR TITLE
Fixes RTT Target Box Scaling

### DIFF
--- a/code/hud/hudtargetbox.cpp
+++ b/code/hud/hudtargetbox.cpp
@@ -519,7 +519,7 @@ void HudGaugeTargetBox::renderTargetSetup(vec3d *camera_eye, matrix *camera_orie
 	// account for gauge RTT with cockpit here --wookieejedi
 	float clip_aspect;
 	if (gr_screen.rendering_to_texture != -1) {
-		clip_aspect = (clip_width / clip_height);
+		clip_aspect = ( i2fl(clip_width) / i2fl(clip_height) );
 	} else {
 		clip_aspect = gr_screen.clip_aspect;
 	}

--- a/code/hud/hudtargetbox.cpp
+++ b/code/hud/hudtargetbox.cpp
@@ -516,7 +516,15 @@ void HudGaugeTargetBox::renderTargetSetup(vec3d *camera_eye, matrix *camera_orie
 
 	setClip(position[0] + Viewport_offsets[0], position[1] + Viewport_offsets[1], Viewport_w, Viewport_h);
 
-	gr_set_proj_matrix(Proj_fov, gr_screen.clip_aspect, Min_draw_distance, Max_draw_distance);
+	// account for gauge RTT with cockpit here --wookieejedi
+	float clip_aspect;
+	if (gr_screen.rendering_to_texture != -1) {
+		clip_aspect = (clip_width / clip_height);
+	} else {
+		clip_aspect = gr_screen.clip_aspect;
+	}
+
+	gr_set_proj_matrix(Proj_fov, clip_aspect, Min_draw_distance, Max_draw_distance);
 	gr_set_view_matrix(&Eye_position, &Eye_matrix);
 }
 

--- a/code/hud/hudtargetbox.cpp
+++ b/code/hud/hudtargetbox.cpp
@@ -519,7 +519,7 @@ void HudGaugeTargetBox::renderTargetSetup(vec3d *camera_eye, matrix *camera_orie
 	// account for gauge RTT with cockpit here --wookieejedi
 	float clip_aspect;
 	if (gr_screen.rendering_to_texture != -1) {
-		clip_aspect = ( i2fl(clip_width) / i2fl(clip_height) );
+		clip_aspect = (i2fl(clip_width) / i2fl(clip_height));
 	} else {
 		clip_aspect = gr_screen.clip_aspect;
 	}


### PR DESCRIPTION
It seems that when RTT for cockpits was added that the scaling of ships in the target box fell through the cracks. Properly specifying the `clip_aspect` fixes the issue. This PR fixes issue #2250.

In detail, the `HudGaugeTargetBox::renderTargetSetup` function scales the drawn ship model by `gr_screen.clip_aspect`. When using RTT gauges the clip_aspect changes from the default, so that changed aspect ration needs to be used instead of the default `gr_screen.clip_aspect`.