### PR TITLE
Handle invalid standard deviation properly

### DIFF
--- a/code/particle/effects/ConeShape.h
+++ b/code/particle/effects/ConeShape.h
@@ -36,6 +36,12 @@ class ConeShape {
 			float deviation;
 			stuff_float(&deviation);
 
+			if (deviation < 0.001f) {
+				error_display(0, "A standard deviation of %f is not valid. Must be greater than 0. Defaulting to 1.",
+							  deviation);
+				deviation = 1.0f;
+			}
+
 			m_normalDeviation = ::util::NormalFloatRange(0.0, fl_radians(deviation));
 		}
 	}


### PR DESCRIPTION
If anything less than or equal to 0 was specified it would trigger some
kind of an assert in the standard library since that is not a valid
value for a normal distribution. Now a parse warning is generated and a
safe default value is used.

This fixes #2269.