### PR TITLE
Add compile time option to enable logging in release builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,6 +117,8 @@ option(FSO_INSTALL_DEBUG_FILES "Install some debug files (currently only PDB fil
 
 option(ENABLE_COTIRE "Enable cotire for faster compilation. Enabled by default." ON)
 
+option(FSO_RELEASE_LOGGING "Enable logging output for release builds" OFF)
+
 MARK_AS_ADVANCED(FORCE FSO_CMAKE_DEBUG)
 MARK_AS_ADVANCED(FORCE FSO_BUILD_INCLUDED_LIBS)
 MARK_AS_ADVANCED(FORCE FSO_USE_OPENALSOFT)
@@ -125,6 +127,7 @@ MARK_AS_ADVANCED(FORCE FSO_DEVELOPMENT_MODE)
 MARK_AS_ADVANCED(FORCE FSO_FATAL_WARNINGS)
 mark_as_advanced(FORCE FSO_INSTALL_DEBUG_FILES)
 mark_as_advanced(FORCE ENABLE_COTIRE)
+mark_as_advanced(FORCE FSO_RELEASE_LOGGING)
 
 # Include cotire file from https://github.com/sakra/cotire/
 include(cotire)
@@ -197,3 +200,4 @@ ENDIF()
 message(STATUS "Building FSO tools: ${FSO_BUILD_TOOLS}")
 message(STATUS "Building qtFRED: ${FSO_BUILD_QTFRED}")
 message(STATUS "Fatal warnings: ${FSO_FATAL_WARNINGS}")
+message(STATUS "Release logging: ${FSO_RELEASE_LOGGING}")

--- a/code/CMakeLists.txt
+++ b/code/CMakeLists.txt
@@ -81,6 +81,10 @@ else()
 	ENDIF()
 endif()
 
+if (FSO_RELEASE_LOGGING)
+	target_compile_definitions(code PUBLIC SCP_RELEASE_LOGGING)
+endif()
+
 include(util)
 configure_cotire(code)
 

--- a/code/globalincs/pstypes.h
+++ b/code/globalincs/pstypes.h
@@ -232,12 +232,17 @@ extern int Global_error_count;
 // To debug printf do this:
 // mprintf(( "Error opening %s\n", filename ));
 #ifndef NDEBUG
-#define mprintf(args) outwnd_printf2 args
-#define nprintf(args) outwnd_printf args
+constexpr bool LoggingEnabled = true;
 #else
-#define mprintf(args)
-#define nprintf(args)
+#ifdef SCP_RELEASE_LOGGING
+constexpr bool LoggingEnabled = true;
+#else
+constexpr bool LoggingEnabled = false;
 #endif
+#endif
+
+#define mprintf(args) do { if (LoggingEnabled) { outwnd_printf2 args; } } while (false)
+#define nprintf(args) do { if (LoggingEnabled) { outwnd_printf args; } } while (false)
 
 #define LOCATION __FILE__,__LINE__
 

--- a/code/graphics/paths/NanoVGRenderer.cpp
+++ b/code/graphics/paths/NanoVGRenderer.cpp
@@ -22,20 +22,20 @@
 #include "tracing/tracing.h"
 
 
-#ifndef NDEBUG
 // That is a wrapper function for log prints to be availiable for nanovg components. For now it is stb_truetype.h
 // Planted by ksotar with blessing from asarium
 extern "C" {
 	void nvgOldCPrintf(SCP_FORMAT_STRING const char *message, ...) {
-		SCP_string buf;
-		va_list args;
-		va_start(args, message);
-		vsprintf(buf, message, args);
-		va_end(args);
-		outwnd_printf2("%s", message);
+		if (LoggingEnabled) {
+			SCP_string buf;
+			va_list args;
+			va_start(args, message);
+			vsprintf(buf, message, args);
+			va_end(args);
+			outwnd_printf2("%s", message);
+		}
 	}
 }
-#endif
 
 
 namespace {

--- a/code/graphics/paths/nanovg/stb_truetype.h
+++ b/code/graphics/paths/nanovg/stb_truetype.h
@@ -431,10 +431,8 @@ typedef signed   int    stbtt_int32;
 typedef char stbtt__check_size32[sizeof(stbtt_int32) == 4 ? 1 : -1];
 typedef char stbtt__check_size16[sizeof(stbtt_int16) == 2 ? 1 : -1];
 
-#ifndef NDEBUG
-	// Function from NanoVGRenderer.cpp to provide log printing capabilities here.
-	extern void nvgOldCPrintf(const char *string, ...);
-#endif
+// Function from NanoVGRenderer.cpp to provide log printing capabilities here.
+extern void nvgOldCPrintf(const char *string, ...);
 // e.g. #define your own STBTT_ifloor/STBTT_iceil() to avoid math.h
 #ifndef STBTT_ifloor
 #include <math.h>
@@ -1505,11 +1503,9 @@ STBTT_DEF int stbtt_FindGlyphIndex(const stbtt_fontinfo *info, int unicode_codep
 			stbtt_uint16 offset, start;
 			stbtt_uint16 item = (stbtt_uint16)((search - endCount) >> 1);
 
-			#ifndef NDEBUG
-				if (unicode_codepoint > ttUSHORT(data + endCount + 2 * item)) {
-					nvgOldCPrintf("WARNING: A font character is probably missing. Unicode decimal index is %d.\n", unicode_codepoint);
-				}
-			#endif
+			if (unicode_codepoint > ttUSHORT(data + endCount + 2 * item)) {
+				nvgOldCPrintf("WARNING: A font character is probably missing. Unicode decimal index is %d.\n", unicode_codepoint);
+			}
 			STBTT_assert((unicode_codepoint <= ttUSHORT(data + endCount + 2 * item)) &&
 				"                                        \
 				Looks like the font file you're using misses a character. Search the log for 'WARNING: A font character is probably missing.' \

--- a/code/missionui/fictionviewer.cpp
+++ b/code/missionui/fictionviewer.cpp
@@ -289,10 +289,12 @@ void fiction_viewer_init()
 	if (*Fiction_viewer_stages[Fiction_viewer_active_stage].background[gr_screen.res] != '\0')
 	{
 		Fiction_viewer_bitmap = bm_load(Fiction_viewer_stages[Fiction_viewer_active_stage].background[gr_screen.res]);
-		if (Fiction_viewer_bitmap < 0)
-			mprintf(("Failed to load custom background bitmap %s!\n", Fiction_viewer_stages[Fiction_viewer_active_stage].background[gr_screen.res]));
-		else if (Fiction_viewer_ui < 0)
+		if (Fiction_viewer_bitmap < 0) {
+			mprintf(("Failed to load custom background bitmap %s!\n",
+					 Fiction_viewer_stages[Fiction_viewer_active_stage].background[gr_screen.res]));
+		} else if (Fiction_viewer_ui < 0) {
 			Fiction_viewer_ui = 0;
+		}
 	}
 
 	// if special background failed to load, or if no special background was supplied, load the standard bitmap

--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -225,10 +225,11 @@ void parse_mod_table(const char *filename)
 
 		if (optional_string("$Enable External Shaders:")) {
 			stuff_boolean(&Enable_external_shaders);
-			if (Enable_external_shaders)
+			if (Enable_external_shaders) {
 				mprintf(("Game Settings Table: External shaders are enabled\n"));
-			else
+			} else {
 				mprintf(("Game Settings Table: External shaders are DISABLED\n"));
+			}
 		}
 
 		if (optional_string("$Default Detail Level:")) {

--- a/code/network/multi_team.cpp
+++ b/code/network/multi_team.cpp
@@ -7,25 +7,19 @@
  *
 */
 
-
-
-
 #include "network/multi_team.h"
+
 #include "globalincs/linklist.h"
-#include "network/multimsgs.h"
-#include "network/multiutil.h"
+#include "iff_defs/iff_defs.h"
+#include "network/multi.h"
 #include "network/multi_endgame.h"
 #include "network/multi_pmsg.h"
-#include "network/multi.h"
+#include "network/multimsgs.h"
+#include "network/multiutil.h"
 #include "object/object.h"
-#include "ship/ship.h"
-#include "iff_defs/iff_defs.h"
-#include "stats/scoring.h"
-
-#ifndef NDEBUG
 #include "playerman/player.h"
-#endif
-
+#include "ship/ship.h"
+#include "stats/scoring.h"
 
 // ------------------------------------------------------------------------------------
 // MULTIPLAYER TEAMPLAY DEFINES/VARS

--- a/code/network/stand_gui.cpp
+++ b/code/network/stand_gui.cpp
@@ -2261,9 +2261,9 @@ BOOL std_create_standalone_window()
 	std_reset_standalone_gui();
 
 	// initialize the debug outwindow
-#ifndef NDEBUG
-	outwnd_init();
-#endif
+	if (LoggingEnabled) {
+		outwnd_init();
+	}
 
 	Standalone_minimized = FALSE;
 

--- a/code/osapi/osapi.cpp
+++ b/code/osapi/osapi.cpp
@@ -327,9 +327,9 @@ void os_cleanup()
 {
 	os_deinit_registry_stuff();
 
-#ifndef NDEBUG
-	outwnd_close();
-#endif
+	if (LoggingEnabled) {
+		outwnd_close();
+	}
 
 	os_deinit();
 }

--- a/code/osapi/outwnd.cpp
+++ b/code/osapi/outwnd.cpp
@@ -7,10 +7,6 @@
  *
 */
 
-
-
-#ifndef NDEBUG
-
 #include <cstdio>
 #include <cstdarg>
 #include <cstring>
@@ -320,5 +316,3 @@ void outwnd_debug_window_do_frame(float frametime) {
 void outwnd_debug_window_deinit() {
 	debugWindow.reset();
 }
-
-#endif //NDEBUG

--- a/code/osapi/outwnd.h
+++ b/code/osapi/outwnd.h
@@ -12,9 +12,7 @@
 
 #include "globalincs/pstypes.h"
 
-#ifndef NDEBUG
-
-void load_filter_info(void);
+void load_filter_info();
 void outwnd_init();
 void outwnd_close();
 void outwnd_printf(const char *id, SCP_FORMAT_STRING const char *format, ...) SCP_FORMAT_STRING_ARGS(2, 3);
@@ -25,7 +23,5 @@ void outwnd_debug_window_do_frame(float frametime);
 void outwnd_debug_window_deinit();
 
 extern bool Log_debug_output_to_file;
-
-#endif	// NDEBUG
 
 #endif	// _OUTWND_H

--- a/fred2/fred.cpp
+++ b/fred2/fred.cpp
@@ -175,9 +175,9 @@ CFREDApp::CFREDApp() {
 
 	SCP_mspdbcs_Initialise();
 
-#ifndef NDEBUG
-	outwnd_init();
-#endif
+	if (LoggingEnabled) {
+		outwnd_init();
+	}
 }
 
 CFREDApp::~CFREDApp() {

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -1601,10 +1601,10 @@ void game_init()
 
 	// Initialize the timer before the os
 	timer_init();
-	
-#ifndef NDEBUG
-	outwnd_init();
-#endif
+
+	if (LoggingEnabled) {
+		outwnd_init();
+	}
 
 	// init os stuff next
 	if ( !Is_standalone ) {
@@ -1712,11 +1712,9 @@ void game_init()
 		return;
 	}
 
-#ifndef NDEBUG
-	if (Cmdline_debug_window) {
+	if (LoggingEnabled && Cmdline_debug_window) {
 		outwnd_debug_window_init();
 	}
-#endif
 
 	// This needs to happen after graphics initialization
 	tracing::init();
@@ -6186,12 +6184,10 @@ void game_do_state(int state)
 
    } // end switch(gs_current_state)
 
-#ifndef NDEBUG
-	if (Cmdline_debug_window) {
+	if (LoggingEnabled && Cmdline_debug_window) {
 		// Do a frame for the debug window here since this code is always executed
 		outwnd_debug_window_do_frame(flFrametime);
 	}
-#endif
 }
 
 
@@ -6544,9 +6540,9 @@ void game_shutdown(void)
 
 	tracing::shutdown();
 
-#ifndef NDEBUG
-	outwnd_debug_window_deinit();
-#endif
+	if (LoggingEnabled) {
+		outwnd_debug_window_deinit();
+	}
 
 	gr_close();
 

--- a/qtfred/src/main.cpp
+++ b/qtfred/src/main.cpp
@@ -83,9 +83,9 @@ int main(int argc, char* argv[]) {
 	SCP_mspdbcs_Initialise();
 #endif
 
-#ifndef NDEBUG
-	outwnd_init();
-#endif
+	if (LoggingEnabled) {
+		outwnd_init();
+	}
 
 	qInstallMessageHandler(fsoMessageOutput);
 

--- a/qtfred/src/mission/management.cpp
+++ b/qtfred/src/mission/management.cpp
@@ -266,9 +266,9 @@ void shutdown() {
 
 	os_cleanup();
 
-#ifndef NDEBUG
-	outwnd_close();
-#endif
+	if (LoggingEnabled) {
+		outwnd_close();
+	}
 }
 
 

--- a/test/src/util/FSTestFixture.cpp
+++ b/test/src/util/FSTestFixture.cpp
@@ -24,10 +24,10 @@ void test::FSTestFixture::SetUp() {
 
 	timer_init();
 
-#ifndef NDEBUG
-	outwnd_init();
-	mprintf(("TEST: Setting up test '%s.%s'\n", currentTest->test_case_name(), currentTest->name()));
-#endif
+	if (LoggingEnabled) {
+		outwnd_init();
+		mprintf(("TEST: Setting up test '%s.%s'\n", currentTest->test_case_name(), currentTest->name()));
+	}
 
 	os_init("Test", "Test");
 
@@ -98,9 +98,9 @@ void test::FSTestFixture::TearDown() {
 
 	os_cleanup();
 
-#ifndef NDEBUG
-	outwnd_close();
-#endif
+	if (LoggingEnabled) {
+		outwnd_close();
+	}
 
 	// although the comment in cmdline.cpp said this isn't needed,
 	// Valgrind disagrees (quite possibly incorrectly), but this is just cleaner


### PR DESCRIPTION
This mostly meant for special docker standalone server builds where it
might be useful to have full release performance but also have the logs
available if necessary. This now always compiles the log statements but
enables or disables them with a constexpr so they should not appear in
actual release binaries.