### PR TITLE
Add Dockerfile for compiling minimal standalone image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+/build
+/.git

--- a/.gitignore
+++ b/.gitignore
@@ -257,3 +257,4 @@ CMakeSettings.json
 # This gets ignored by one of the rules above for some reason...
 !/code/scripting/lua/LuaConvert.h
 !/code/debugconsole/
+!/docker/build

--- a/code/graphics/paths/nanovg/stb_truetype.h
+++ b/code/graphics/paths/nanovg/stb_truetype.h
@@ -2130,6 +2130,13 @@ static int stbtt__run_charstring(const stbtt_fontinfo *info, int glyph_index, st
 			#ifdef __GNUC__
 				#if __has_include(<features.h>)
 					#include <features.h>
+					#ifndef __GNUC_PREREQ
+						#if defined __GNUC__ && defined __GNUC_MINOR__
+							#define __GNUC_PREREQ(maj, min) ((__GNUC__ << 16) + __GNUC_MINOR__ >= ((maj) << 16) + (min))
+						#else
+							#define __GNUC_PREREQ(maj, min) 0
+						#endif
+					#endif
 					#if __GNUC_PREREQ(8, 0)
 						__attribute__((fallthrough));
 					#endif		

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+echo "Building configuration $1"
+
+mkdir -p build/alpine
+cd build/alpine
+
+export CXXFLAGS="-m64 -mtune=generic -mfpmath=sse -msse -msse2 -pipe -Wno-unknown-pragmas"
+export CFLAGS="-m64 -mtune=generic -mfpmath=sse -msse -msse2 -pipe -Wno-unknown-pragmas"
+
+cmake -G Ninja -DCMAKE_INSTALL_PREFIX=/install -DFSO_BUILD_APPIMAGE=ON -DCMAKE_BUILD_TYPE=$1 ../..
+
+ninja
+ninja install

--- a/docker/standalone/Dockerfile
+++ b/docker/standalone/Dockerfile
@@ -1,0 +1,33 @@
+FROM alpine:latest AS builder
+
+ARG build_type
+
+RUN apk add --no-cache cmake gcc g++ ninja openal-soft-dev \
+	freetype-dev ffmpeg-dev sdl2-dev linux-headers unzip
+
+COPY docker/build.sh /build.sh
+
+ADD . /code
+
+WORKDIR /code
+RUN /build.sh "${build_type}"
+
+ADD https://github.com/scp-fs2open/fs2open_webui/archive/master.zip /build/webui.zip
+RUN unzip /build/webui.zip -d /build/fso-webui && cp -r /build/fso-webui/fs2open_webui-master/. /webui
+
+FROM alpine:latest
+
+RUN apk add --no-cache openal-soft freetype ffmpeg-libs sdl2 libstdc++
+
+ENV XDG_DATA_HOME=/fso-config
+COPY docker/standalone/fs2_open.ini /fso-config/HardLightProductions/FreeSpaceOpen/
+COPY docker/standalone/multi.cfg /fso-config/HardLightProductions/FreeSpaceOpen/data/
+
+COPY --from=builder /install /fso-bin
+COPY --from=builder /webui /fso-webui
+
+EXPOSE 8080 7808/udp
+
+VOLUME ["/fso"]
+WORKDIR /fso
+ENTRYPOINT ["/fso-bin/AppRun", "-nosound", "-standalone", "-noninteractive", "-port", "7808", "-stdout_log"]

--- a/docker/standalone/fs2_open.ini
+++ b/docker/standalone/fs2_open.ini
@@ -1,0 +1,2 @@
+[Default]
+VideocardFs2open=OGL -(1920x1200)x32 bit

--- a/docker/standalone/multi.cfg
+++ b/docker/standalone/multi.cfg
@@ -1,0 +1,9 @@
++name Docker Standalone
++no_voice
++high_update
++max_players 12
++pxo #Eleh
++webui_root /fso-webui
++webapi_username admin
++webapi_password admin
++webapi_server_port 8080


### PR DESCRIPTION
This adds a Dockerfile which compiles FSO for the alpine Linux
distribution and then creates a standalone image based on those
binaries. That sidesteps the problem that existed with trying to use the
AppImage binaries on that distribution.

This produces a much smaller image (78MB instead of 230MB) so it should
be a bit more managable. Building can be done like this:
```
docker build --build-arg build_type=FastDebug -t scpfs2open/fso-standalone -f docker/standalone/Dockerfile .
```