### PR TITLE
Make FFmpeg an optional requirement

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,6 +117,8 @@ option(FSO_INSTALL_DEBUG_FILES "Install some debug files (currently only PDB fil
 
 option(ENABLE_COTIRE "Enable cotire for faster compilation. Enabled by default." ON)
 
+OPTION(FSO_BUILD_WITH_FFMPEG "Enable the usage of FFmpeg for sound and custscenes" ON)
+
 MARK_AS_ADVANCED(FORCE FSO_CMAKE_DEBUG)
 MARK_AS_ADVANCED(FORCE FSO_BUILD_INCLUDED_LIBS)
 MARK_AS_ADVANCED(FORCE FSO_USE_OPENALSOFT)
@@ -125,6 +127,7 @@ MARK_AS_ADVANCED(FORCE FSO_DEVELOPMENT_MODE)
 MARK_AS_ADVANCED(FORCE FSO_FATAL_WARNINGS)
 mark_as_advanced(FORCE FSO_INSTALL_DEBUG_FILES)
 mark_as_advanced(FORCE ENABLE_COTIRE)
+mark_as_advanced(FORCE FSO_BUILD_WITH_FFMPEG)
 
 # Include cotire file from https://github.com/sakra/cotire/
 include(cotire)
@@ -197,3 +200,4 @@ ENDIF()
 message(STATUS "Building FSO tools: ${FSO_BUILD_TOOLS}")
 message(STATUS "Building qtFRED: ${FSO_BUILD_QTFRED}")
 message(STATUS "Fatal warnings: ${FSO_FATAL_WARNINGS}")
+message(STATUS "With FFmpeg: ${FSO_BUILD_WITH_FFMPEG}")

--- a/code/CMakeLists.txt
+++ b/code/CMakeLists.txt
@@ -28,7 +28,9 @@ TARGET_LINK_LIBRARIES(code PUBLIC ${JPEG_LIBS})
 
 TARGET_LINK_LIBRARIES(code PUBLIC sdl2)
 
-TARGET_LINK_LIBRARIES(code PUBLIC ffmpeg)
+if (FSO_BUILD_WITH_FFMPEG)
+	TARGET_LINK_LIBRARIES(code PUBLIC ffmpeg)
+endif()
 
 TARGET_LINK_LIBRARIES(code PUBLIC utfcpp)
 
@@ -79,6 +81,10 @@ else()
 	ELSE()
 		MESSAGE("Unknown compiler for global includes. This will probably break the build.")
 	ENDIF()
+endif()
+
+if (FSO_BUILD_WITH_FFMPEG)
+	target_compile_definitions(code PUBLIC WITH_FFMPEG)
 endif()
 
 include(util)

--- a/code/cutscene/player.cpp
+++ b/code/cutscene/player.cpp
@@ -27,13 +27,15 @@ using namespace cutscene;
 
 const int MAX_AUDIO_BUFFERS = 15;
 
-std::unique_ptr<Decoder> findDecoder(const SCP_string& name, const PlaybackProperties& properties) {
+std::unique_ptr<Decoder> findDecoder(__UNUSED const SCP_string& name, __UNUSED const PlaybackProperties& properties) {
+#ifdef WITH_FFMPEG
 	{
 		std::unique_ptr<Decoder> ffmpeg(new ::cutscene::ffmpeg::FFMPEGDecoder());
 		if (ffmpeg->initialize(name, properties)) {
 			return ffmpeg;
 		}
 	}
+#endif
 
 	return nullptr;
 }

--- a/code/io/keycontrol.cpp
+++ b/code/io/keycontrol.cpp
@@ -5,7 +5,7 @@
  * or otherwise commercially exploit the source or things you created based on the 
  * source.
  *
-*/ 
+*/
 
 
 
@@ -59,6 +59,7 @@
 #include "autopilot/autopilot.h"
 #include "cmdline/cmdline.h"
 #include "object/objectshield.h"
+#include "sound/audiostr.h"
 
 /**
 * Natural number factor lookup class.

--- a/code/network/multi_pause.cpp
+++ b/code/network/multi_pause.cpp
@@ -27,6 +27,7 @@
 #include "globalincs/alphacolors.h"
 #include "io/timer.h"
 #include "osapi/osapi.h"
+#include "sound/audiostr.h"
 
 
 

--- a/code/scripting/api/libs/audio.cpp
+++ b/code/scripting/api/libs/audio.cpp
@@ -11,6 +11,7 @@
 #include "menuui/mainhallmenu.h"
 #include "menuui/credits.h"
 #include "render/3d.h"
+#include "sound/audiostr.h"
 
 extern float Master_event_music_volume;
 

--- a/code/sound/IAudioFile.h
+++ b/code/sound/IAudioFile.h
@@ -1,0 +1,77 @@
+#pragma once
+
+namespace sound {
+
+/**
+ * @brief Properties of an audio file
+ */
+struct AudioFileProperties {
+	int bytes_per_sample = -1;
+
+	double duration = -1.0;
+
+	int total_samples = -1;
+
+	int num_channels = -1;
+
+	int sample_rate = -1;
+};
+
+struct ResampleProperties {
+	int num_channels = -1;
+};
+
+/**
+ * @brief An audio file from which decoded audio data can be read
+ */
+class IAudioFile {
+  public:
+	virtual ~IAudioFile() = default;
+
+	/**
+	 * @brief Opens the specified file for playback
+	 *
+	 * After this call you can start reading from this file
+	 *
+	 * @param pszFilename The filename
+	 * @param keep_ext @c true if the extension of the specified file name should be kept
+	 * @return @c true if the file was succesfully loaded, @c false otherwise
+	 */
+	virtual bool Open(const char* pszFilename, bool keep_ext = true) = 0;
+
+	/**
+	 * @brief Prepare file for audio reading
+	 *
+	 * This reset the file poiner to the start of the stream and reset internal data. Future calls to Read start reading
+	 * from the beginning of the file again
+	 *
+	 * @return @c true if succesfull, @c false otherwise
+	 */
+	virtual bool Cue() = 0;
+
+	/**
+	 * @brief Read audio data into a buffer
+	 *
+	 * Reads up to cbSize bytes of audio data into the buffer. cbSize must be a multiple of the size of one sample
+	 *
+	 * @param pbDest The buffer to write data to
+	 * @param cbSize The size of the buffer
+	 * @return The number of bytes written into the buffer. Can be 0 if no data is available, try a bigger buffer.
+	 * Returns -1 when the end of the stream or an error has been encountered
+	 */
+	virtual int Read(uint8_t* pbDest, size_t cbSize) = 0;
+
+	/**
+	 * @brief Gets properties related to the audio file
+	 * @return A struct containing various file related members
+	 */
+	virtual AudioFileProperties getFileProperties() = 0;
+
+	/**
+	 * @brief Sets properties for resampling audio data before returning audio data
+	 * @param resampleProps The properties for resampling
+	 */
+	virtual void setResamplingProperties(const ResampleProperties& resampleProps) = 0;
+};
+
+} // namespace sound

--- a/code/sound/ds.cpp
+++ b/code/sound/ds.cpp
@@ -246,7 +246,7 @@ int ds_get_sid()
 	return (int)(sound_buffers.size() - 1);
 }
 
-int ds_load_buffer(int *sid, int  /*flags*/, ffmpeg::WaveFile* file)
+int ds_load_buffer(int *sid, int  /*flags*/, sound::IAudioFile* file)
 {
 	Assert(sid != NULL);
 	Assert(file != NULL);
@@ -261,14 +261,16 @@ int ds_load_buffer(int *sid, int  /*flags*/, ffmpeg::WaveFile* file)
 	ALuint pi;
 	OpenAL_ErrorCheck(alGenBuffers(1, &pi), return -1);
 
+	const auto fileProps = file->getFileProperties();
+
 	ALenum format;
-	ALsizei size = file->getTotalSamples() * file->getSampleByteSize();
-	ALint n_channels = file->getNumChannels();
+	ALsizei size = fileProps.total_samples * fileProps.bytes_per_sample * fileProps.num_channels;
+	ALint n_channels = fileProps.num_channels;
 	ALsizei frequency;
 		
 	// format is now in pcm
-	frequency = file->getSampleRate();
-	format = file->getALFormat();
+	frequency = fileProps.sample_rate;
+	format = openal_get_format(fileProps.bytes_per_sample * 8, fileProps.num_channels);
 
 	if (format == AL_INVALID_VALUE) {
 		return -1;
@@ -277,7 +279,7 @@ int ds_load_buffer(int *sid, int  /*flags*/, ffmpeg::WaveFile* file)
 	SCP_vector<uint8_t> audio_buffer;
 	audio_buffer.reserve(size);
 
-	SCP_vector<uint8_t> buffer(file->getSampleRate() * file->getSampleByteSize());
+	SCP_vector<uint8_t> buffer(fileProps.sample_rate * fileProps.bytes_per_sample * fileProps.num_channels);
 	int read;
 	while((read = file->Read(&buffer[0], buffer.size())) >= 0) {
 		if (read == 0) {
@@ -295,9 +297,9 @@ int ds_load_buffer(int *sid, int  /*flags*/, ffmpeg::WaveFile* file)
 	sound_buffers[*sid].buf_id = pi;
 	sound_buffers[*sid].channel_id = -1;
 	sound_buffers[*sid].frequency = frequency;
-	sound_buffers[*sid].bits_per_sample = (file->getSampleByteSize() / file->getNumChannels()) * 8;
+	sound_buffers[*sid].bits_per_sample = fileProps.bytes_per_sample * 8;
 	sound_buffers[*sid].nchannels = n_channels;
-	sound_buffers[*sid].nseconds = fl2i(file->getDuration());
+	sound_buffers[*sid].nseconds = fl2i(fileProps.duration);
 	sound_buffers[*sid].nbytes = (int)audio_buffer.size();
 
 	return 0;

--- a/code/sound/ds.h
+++ b/code/sound/ds.h
@@ -13,7 +13,7 @@
 #define __DS_H__
 
 #include "globalincs/pstypes.h"
-#include "sound/ffmpeg/WaveFile.h"
+#include "sound/IAudioFile.h"
 #include "utils/id.h"
 
 // Constants that DirectSound should assign, but doesn't
@@ -56,7 +56,7 @@ using ds_sound_handle = ::util::ID<ds_sound_handle_tag, int, -1>;
 
 int ds_init();
 void ds_close();
-int ds_load_buffer(int *sid, int flags, ffmpeg::WaveFile* file);
+int ds_load_buffer(int *sid, int flags, sound::IAudioFile* file);
 void ds_unload_buffer(int sid);
 ds_sound_handle ds_play(int sid, int snd_id, int priority, const EnhancedSoundData* enhanced_sound_data, float volume,
                         float pan, int looping, bool is_voice_msg = false);

--- a/code/sound/ffmpeg/FFmpegAudioReader.cpp
+++ b/code/sound/ffmpeg/FFmpegAudioReader.cpp
@@ -37,10 +37,10 @@ void av_packet_free(AVPacket **pkt)
 	av_freep(pkt);
 }
 #endif
-}
+} // namespace
 
-namespace ffmpeg
-{
+namespace sound {
+namespace ffmpeg {
 FFmpegAudioReader::FFmpegAudioReader(AVFormatContext* av_format_context, AVCodecContext* codec_ctx,
                                      int stream_idx) : _stream_idx(stream_idx),
                                                        _format_ctx(av_format_context),
@@ -182,4 +182,6 @@ FFmpegAudioReader::~FFmpegAudioReader() {
 	}
 #endif
 }
-}
+
+} // namespace ffmpeg
+} // namespace sound

--- a/code/sound/ffmpeg/FFmpegAudioReader.h
+++ b/code/sound/ffmpeg/FFmpegAudioReader.h
@@ -1,32 +1,27 @@
-
-#ifndef _FFMPEGAUDIOREADER_H
-#define _FFMPEGAUDIOREADER_H
 #pragma once
 
 #include "globalincs/pstypes.h"
 
 #include "libs/ffmpeg/FFmpegHeaders.h"
 
-namespace ffmpeg
-{
+namespace sound {
+namespace ffmpeg {
 
-class FFmpegAudioReader
-{
-	int _stream_idx = -1;
+class FFmpegAudioReader {
+	int _stream_idx              = -1;
 	AVFormatContext* _format_ctx = nullptr;
-	AVCodecContext* _codec_ctx = nullptr;
+	AVCodecContext* _codec_ctx   = nullptr;
 
 #if LIBAVCODEC_VERSION_INT <= AV_VERSION_INT(57, 24, 255)
-    AVPacket* _currentPacket = nullptr;
+	AVPacket* _currentPacket = nullptr;
 #endif
 
-public:
+  public:
 	FFmpegAudioReader(AVFormatContext* av_format_context, AVCodecContext* codec_ctx, int stream_idx);
 	~FFmpegAudioReader();
 
 	bool readFrame(AVFrame* decode_frame);
 };
 
-}
-
-#endif // _FFMPEGAUDIOREADER_H
+} // namespace ffmpeg
+} // namespace sound

--- a/code/sound/ffmpeg/FFmpegWaveFile.cpp
+++ b/code/sound/ffmpeg/FFmpegWaveFile.cpp
@@ -1,30 +1,34 @@
 //
 //
 
-#include "WaveFile.h"
+#include "FFmpegWaveFile.h"
+
 #include "FFmpegAudioReader.h"
+
 #include "sound/ds.h"
 
 // -- from parselo.cpp --
 extern const char* stristr(const char* str, const char* substr);
 
 namespace {
-using namespace ffmpeg;
+using namespace sound;
+using namespace sound::ffmpeg;
 
-AudioProperties getAudioProps(AVStream* stream) {
+AudioProperties getAudioProps(AVStream* stream)
+{
 	AudioProperties props;
 
 	int channels;
 #if LIBAVCODEC_VERSION_INT > AV_VERSION_INT(57, 24, 255)
-    channels = stream->codecpar->channels;
-    props.channel_layout = stream->codecpar->channel_layout;
-    props.sample_rate = stream->codecpar->sample_rate;
-    props.format = (AVSampleFormat)stream->codecpar->format;
+	channels             = stream->codecpar->channels;
+	props.channel_layout = stream->codecpar->channel_layout;
+	props.sample_rate    = stream->codecpar->sample_rate;
+	props.format         = (AVSampleFormat)stream->codecpar->format;
 #else
-	channels = stream->codec->channels;
+	channels             = stream->codec->channels;
 	props.channel_layout = stream->codec->channel_layout;
-	props.sample_rate = stream->codec->sample_rate;
-	props.format = stream->codec->sample_fmt;
+	props.sample_rate    = stream->codec->sample_rate;
+	props.format         = stream->codec->sample_fmt;
 #endif
 
 	if (props.channel_layout == 0) {
@@ -35,7 +39,8 @@ AudioProperties getAudioProps(AVStream* stream) {
 	return props;
 }
 
-AudioProperties getAdjustedAudioProps(const AudioProperties& baseProps) {
+AudioProperties getAdjustedAudioProps(const AudioProperties& baseProps)
+{
 	AudioProperties adjusted;
 	adjusted.sample_rate = baseProps.sample_rate; // Don't adjust sample rate
 
@@ -46,45 +51,47 @@ AudioProperties getAdjustedAudioProps(const AudioProperties& baseProps) {
 
 	int max_bytes_per_sample;
 	switch (Ds_sound_quality) {
-		case DS_SQ_HIGH:
-			max_bytes_per_sample = Ds_float_supported ? 4 : 2;
-			break;
+	case DS_SQ_HIGH:
+		max_bytes_per_sample = Ds_float_supported ? 4 : 2;
+		break;
 
-		case DS_SQ_MEDIUM:
-			max_bytes_per_sample = 2;
-			break;
+	case DS_SQ_MEDIUM:
+		max_bytes_per_sample = 2;
+		break;
 
-		default:
-			max_bytes_per_sample = 1;
-			break;
+	default:
+		max_bytes_per_sample = 1;
+		break;
 	}
 
-	// Determine the right format. Downsample if sound quality is low but don't increase size of samples if the source doesn't support it
+	// Determine the right format. Downsample if sound quality is low but don't increase size of samples if the source
+	// doesn't support it
 	auto bytes_per_sample = std::min(av_get_bytes_per_sample(baseProps.format), max_bytes_per_sample);
 
 	switch (bytes_per_sample) {
-		case 1:
-			adjusted.format = AV_SAMPLE_FMT_U8;
-			break;
-		case 2:
-			adjusted.format = AV_SAMPLE_FMT_S16;
-			break;
-		case 4:
-			adjusted.format = AV_SAMPLE_FMT_FLT;
-			break;
-		default:
-			UNREACHABLE("Unhandled switch value!");
-			adjusted.format = AV_SAMPLE_FMT_NONE;
-			break;
+	case 1:
+		adjusted.format = AV_SAMPLE_FMT_U8;
+		break;
+	case 2:
+		adjusted.format = AV_SAMPLE_FMT_S16;
+		break;
+	case 4:
+		adjusted.format = AV_SAMPLE_FMT_FLT;
+		break;
+	default:
+		UNREACHABLE("Unhandled switch value!");
+		adjusted.format = AV_SAMPLE_FMT_NONE;
+		break;
 	}
 
 	return adjusted;
 }
 
-SwrContext* getSWRContext(const AudioProperties& base, const AudioProperties& adjusted) {
+SwrContext* getSWRContext(const AudioProperties& base, const AudioProperties& adjusted)
+{
 	SwrContext* swr = nullptr;
-	swr = swr_alloc_set_opts(swr, adjusted.channel_layout, adjusted.format, adjusted.sample_rate,
-							 base.channel_layout, base.format, base.sample_rate, 0, nullptr);
+	swr = swr_alloc_set_opts(swr, adjusted.channel_layout, adjusted.format, adjusted.sample_rate, base.channel_layout,
+							 base.format, base.sample_rate, 0, nullptr);
 
 	if (swr_init(swr) < 0) {
 		return nullptr;
@@ -92,10 +99,12 @@ SwrContext* getSWRContext(const AudioProperties& base, const AudioProperties& ad
 
 	return swr;
 }
-}
+} // namespace
 
+namespace sound {
 namespace ffmpeg {
-WaveFile::WaveFile() {
+FFmpegWaveFile::FFmpegWaveFile()
+{
 	// Init data members
 	m_audioProps = AudioProperties();
 	m_ctx.reset();
@@ -103,7 +112,8 @@ WaveFile::WaveFile() {
 	m_decodeFrame = av_frame_alloc();
 }
 
-WaveFile::~WaveFile() {
+FFmpegWaveFile::~FFmpegWaveFile()
+{
 	av_frame_free(&m_decodeFrame);
 
 	if (m_audioCodecCtx) {
@@ -120,16 +130,17 @@ WaveFile::~WaveFile() {
 
 	// Free memory
 	m_ctx.reset();
-
 }
 
 // Open
-bool WaveFile::Open(const char* pszFilename, bool keep_ext) {
+bool FFmpegWaveFile::Open(const char* pszFilename, bool keep_ext)
+{
 	using namespace libs::ffmpeg;
 
 	char filename[MAX_FILENAME_LEN];
 
-	// NOTE: the extension will be removed and set to the actual extension of keep_ext is false, otherwise it's not changed
+	// NOTE: the extension will be removed and set to the actual extension of keep_ext is false, otherwise it's not
+	// changed
 	strcpy_s(filename, pszFilename);
 
 	try {
@@ -156,8 +167,7 @@ bool WaveFile::Open(const char* pszFilename, bool keep_ext) {
 			}
 
 			cfp = cfopen_special(res.full_name.c_str(), "rb", res.size, res.offset, res.data_ptr, CF_TYPE_ANY);
-		}
-		else {
+		} else {
 			// ... otherwise we just find the best match
 			auto res = cf_find_file_location_ext(filename, NUM_AUDIO_EXT, audio_ext_list, CF_TYPE_ANY, false);
 
@@ -181,11 +191,11 @@ bool WaveFile::Open(const char* pszFilename, bool keep_ext) {
 			throw FFmpegException("Failed to open file.");
 		}
 
-		m_ctx = FFmpegContext::createContext(cfp);
+		m_ctx    = FFmpegContext::createContext(cfp);
 		auto ctx = m_ctx->ctx();
 
 		AVCodec* audio_codec = nullptr;
-		m_audioStreamIndex = av_find_best_stream(ctx, AVMEDIA_TYPE_AUDIO, -1, -1, &audio_codec, 0);
+		m_audioStreamIndex   = av_find_best_stream(ctx, AVMEDIA_TYPE_AUDIO, -1, -1, &audio_codec, 0);
 		if (m_audioStreamIndex < 0) {
 			throw FFmpegException("Failed to find audio stream in file.");
 		}
@@ -193,15 +203,15 @@ bool WaveFile::Open(const char* pszFilename, bool keep_ext) {
 
 		int err;
 #if LIBAVCODEC_VERSION_INT > AV_VERSION_INT(57, 24, 255)
-        m_audioCodecCtx = avcodec_alloc_context3(audio_codec);
+		m_audioCodecCtx = avcodec_alloc_context3(audio_codec);
 
-        // Copy codec parameters from input stream to output codec context
-        err = avcodec_parameters_to_context(m_audioCodecCtx, m_audioStream->codecpar);
-        if (err < 0) {
-            char errorStr[512];
-            av_strerror(err, errorStr, sizeof(errorStr));
-            throw FFmpegException(errorStr);
-        }
+		// Copy codec parameters from input stream to output codec context
+		err = avcodec_parameters_to_context(m_audioCodecCtx, m_audioStream->codecpar);
+		if (err < 0) {
+			char errorStr[512];
+			av_strerror(err, errorStr, sizeof(errorStr));
+			throw FFmpegException(errorStr);
+		}
 #else
 		m_audioCodecCtx = m_audioStream->codec;
 #endif
@@ -216,11 +226,6 @@ bool WaveFile::Open(const char* pszFilename, bool keep_ext) {
 		m_baseAudioProps = getAudioProps(m_audioStream);
 
 		setAdjustedAudioProperties(getAdjustedAudioProps(m_baseAudioProps));
-
-		if (getALFormat() == AL_INVALID_VALUE) {
-			throw FFmpegException("Invalid audio format.");
-		}
-
 		nprintf(("SOUND", "SOUND => %s => Using codec %s (%s)\n", filename, audio_codec->long_name, audio_codec->name));
 	} catch (const FFmpegException& e) {
 		mprintf(("SOUND ==> Could not open wave file %s for streaming. Reason: %s\n", filename, e.what()));
@@ -237,8 +242,8 @@ bool WaveFile::Open(const char* pszFilename, bool keep_ext) {
 	return true;
 }
 
-
-bool WaveFile::Cue() {
+bool FFmpegWaveFile::Cue()
+{
 	auto err = av_seek_frame(m_ctx->ctx(), m_audioStreamIndex, 0, AVSEEK_FLAG_BYTE);
 
 	if (err >= 0) {
@@ -249,40 +254,39 @@ bool WaveFile::Cue() {
 	return err >= 0;
 }
 
-void WaveFile::setAdjustedAudioProperties(const AudioProperties& props) {
+void FFmpegWaveFile::setAdjustedAudioProperties(const AudioProperties& props)
+{
 	if (m_resampleCtx) {
 		swr_free(&m_resampleCtx);
 	}
-	m_audioProps = props;
+	m_audioProps  = props;
 	m_resampleCtx = getSWRContext(m_baseAudioProps, m_audioProps);
 
 	Assertion(m_resampleCtx != nullptr, "Resample context creation failed! This should not happen!");
 }
 
-size_t WaveFile::handleDecodedFrame(AVFrame* av_frame, uint8_t* out_buffer, size_t buffer_size) {
+size_t FFmpegWaveFile::handleDecodedFrame(AVFrame* av_frame, uint8_t* out_buffer, size_t buffer_size)
+{
 	const auto sample_size = (av_get_bytes_per_sample(m_audioProps.format) * getNumChannels());
 
 	int dest_num_samples = static_cast<int>(buffer_size / sample_size);
-	auto written = swr_convert(m_resampleCtx,
-							   &out_buffer,
-							   dest_num_samples,
-							   (const uint8_t**) av_frame->extended_data,
+	auto written = swr_convert(m_resampleCtx, &out_buffer, dest_num_samples, (const uint8_t**)av_frame->extended_data,
 							   av_frame->nb_samples);
 
-
-	return (size_t) (written * sample_size);
+	return (size_t)(written * sample_size);
 }
 
-size_t WaveFile::getBufferedData(uint8_t* buffer, size_t buffer_size) {
+size_t FFmpegWaveFile::getBufferedData(uint8_t* buffer, size_t buffer_size)
+{
 	// First determine if there is buffered data
 	auto buffered = swr_get_out_samples(m_resampleCtx, 0);
 
 	if (buffered > 0) {
 		const auto sample_size = (av_get_bytes_per_sample(m_audioProps.format) * getNumChannels());
-		int dest_num_samples = static_cast<int>(buffer_size / sample_size);
-		auto written = swr_convert(m_resampleCtx, &buffer, dest_num_samples, nullptr, 0);
+		int dest_num_samples   = static_cast<int>(buffer_size / sample_size);
+		auto written           = swr_convert(m_resampleCtx, &buffer, dest_num_samples, nullptr, 0);
 
-		auto advance = (size_t) (written * sample_size);
+		auto advance = (size_t)(written * sample_size);
 		Assertion(advance <= buffer_size,
 				  "Buffer overrun!!! Decoding has written more data into the buffer than available!");
 
@@ -291,7 +295,8 @@ size_t WaveFile::getBufferedData(uint8_t* buffer, size_t buffer_size) {
 	return 0;
 }
 
-int WaveFile::Read(uint8_t* pbDest, size_t cbSize) {
+int FFmpegWaveFile::Read(uint8_t* pbDest, size_t cbSize)
+{
 	size_t buffer_pos = 0;
 	buffer_pos += getBufferedData(pbDest, cbSize);
 	if (buffer_pos == cbSize) {
@@ -322,20 +327,9 @@ int WaveFile::Read(uint8_t* pbDest, size_t cbSize) {
 	return static_cast<int>(buffer_pos);
 }
 
-int WaveFile::getSampleByteSize() const {
-	return av_get_bytes_per_sample(m_audioProps.format) * getNumChannels();
-}
-
-int WaveFile::getSampleRate() const {
-	return m_audioProps.sample_rate;
-}
-
-double WaveFile::getDuration() const {
-	return av_q2d(av_mul_q(av_make_q(static_cast<int>(m_audioStream->duration), 1), m_audioStream->time_base));
-}
-
-int WaveFile::getTotalSamples() const {
-	auto duration = av_mul_q(av_make_q(static_cast<int>(m_audioStream->duration), 1), m_audioStream->time_base);
+int FFmpegWaveFile::getTotalSamples() const
+{
+	auto duration  = av_mul_q(av_make_q(static_cast<int>(m_audioStream->duration), 1), m_audioStream->time_base);
 	auto samples_r = av_mul_q(av_make_q(m_audioProps.sample_rate, 1), duration);
 
 	// Compute the actual sample number and round the result up
@@ -344,10 +338,38 @@ int WaveFile::getTotalSamples() const {
 	return samples;
 }
 
-int WaveFile::getNumChannels() const {
-	return av_get_channel_layout_nb_channels(m_audioProps.channel_layout);
+int FFmpegWaveFile::getNumChannels() const { return av_get_channel_layout_nb_channels(m_audioProps.channel_layout); }
+
+AudioFileProperties FFmpegWaveFile::getFileProperties()
+{
+	AudioFileProperties props{};
+	props.num_channels = getNumChannels();
+	props.duration =
+		av_q2d(av_mul_q(av_make_q(static_cast<int>(m_audioStream->duration), 1), m_audioStream->time_base));
+	props.total_samples    = getTotalSamples();
+	props.sample_rate      = m_audioProps.sample_rate;
+	props.bytes_per_sample = av_get_bytes_per_sample(m_audioProps.format);
+	return props;
 }
-ALenum WaveFile::getALFormat() const {
-	return openal_get_format(av_get_bytes_per_sample(m_audioProps.format) * 8, getNumChannels());;
+void FFmpegWaveFile::setResamplingProperties(const ResampleProperties& resampleProps)
+{
+	using namespace libs::ffmpeg;
+
+	auto current = m_audioProps;
+
+	if (getNumChannels() == resampleProps.num_channels) {
+		// No need to resample
+		return;
+	}
+
+	if (resampleProps.num_channels == 1) {
+		current.channel_layout = AV_CH_LAYOUT_MONO;
+
+		setAdjustedAudioProperties(current);
+	} else {
+		throw FFmpegException("Number of channels to resample to is not supported!");
+	}
 }
-}
+
+} // namespace ffmpeg
+} // namespace sound

--- a/code/sound/ffmpeg/FFmpegWaveFile.h
+++ b/code/sound/ffmpeg/FFmpegWaveFile.h
@@ -1,21 +1,15 @@
-
-#ifndef _WAVEFILE_H
-#define _WAVEFILE_H
 #pragma once
 
 #include "globalincs/pstypes.h"
+#include "libs/ffmpeg/FFmpegContext.h"
+#include "osapi/osapi.h"
+#include "sound/IAudioFile.h"
 #include "sound/audiostr.h"
 #include "sound/openal.h"
 
-#include "libs/ffmpeg/FFmpegContext.h"
-
-#include "osapi/osapi.h"
-
+namespace sound {
 namespace ffmpeg {
 
-/**
- * @brief Properties of an audio stream
- */
 struct AudioProperties
 {
 	int sample_rate = -1;
@@ -33,16 +27,15 @@ class FFmpegAudioReader;
  *
  * @details This uses FFmpeg to decode the audio files.
  */
-class WaveFile
-{
+class FFmpegWaveFile : public IAudioFile {
 	std::unique_ptr<libs::ffmpeg::FFmpegContext> m_ctx;
-	
+
 	AudioProperties m_baseAudioProps;
 	AudioProperties m_audioProps;
 
 	SwrContext* m_resampleCtx = nullptr;
 
-	int m_audioStreamIndex = -1;
+	int m_audioStreamIndex  = -1;
 	AVStream* m_audioStream = nullptr;
 
 	AVFrame* m_decodeFrame = nullptr;
@@ -52,13 +45,14 @@ class WaveFile
 	std::unique_ptr<FFmpegAudioReader> m_frameReader;
 
 	size_t getBufferedData(uint8_t* buffer, size_t buffer_size);
- public:
-	 WaveFile();
-	 ~WaveFile();
+
+  public:
+	FFmpegWaveFile();
+	~FFmpegWaveFile() override;
 
 	// Disallow copying
-	WaveFile(const WaveFile&) = delete;
-	WaveFile& operator=(const WaveFile&) = delete;
+	FFmpegWaveFile(const FFmpegWaveFile&) = delete;
+	FFmpegWaveFile& operator=(const FFmpegWaveFile&) = delete;
 
 	/**
 	 * @brief Opens the specified file for playback
@@ -69,7 +63,7 @@ class WaveFile
 	 * @param keep_ext @c true if the extension of the specified file name should be kept
 	 * @return @c true if the file was succesfully loaded, @c false otherwise
 	 */
-	bool Open (const char *pszFilename, bool keep_ext = true);
+	bool Open(const char* pszFilename, bool keep_ext = true) override;
 
 	/**
 	 * @brief Prepare file for audio reading
@@ -79,7 +73,7 @@ class WaveFile
 	 *
 	 * @return @c true if succesfull, @c false otherwise
 	 */
-	bool Cue ();
+	bool Cue() override;
 
 	/**
 	 * @brief Read audio data into a buffer
@@ -91,49 +85,18 @@ class WaveFile
 	 * @return The number of bytes written into the buffer. Can be 0 if no data is available, try a bigger buffer.
 	 * Returns -1 when the end of the stream or an error has been encountered
 	 */
-	int	Read (uint8_t *pbDest, size_t cbSize);
+	int Read(uint8_t* pbDest, size_t cbSize) override;
 
-	/**
-	 * @brief Gets the OpenAL format of the audio.
-	 * @return The OpenAL format.
-	 */
-	ALenum getALFormat() const;
+	AudioFileProperties getFileProperties() override;
 
-	/**
-	 * @brief Gets the size in bytes of one audio sample
-	 * @return The sample byte size
-	 */
-	int getSampleByteSize() const;
+	void setResamplingProperties(const ResampleProperties& resampleProps) override;
 
-	/**
-	 * @brief Gets the amount of samples per second
-	 * @return The sample rate
-	 */
-	int getSampleRate() const;
+  private:
+	size_t handleDecodedFrame(AVFrame* av_frame, uint8_t* out_buffer, size_t buffer_size);
 
-	/**
-	 * @brief Determines length of the file in seconds
-	 * @return The length of the audio in the file in seconds
-	 */
-	double getDuration() const;
-
-	/**
-	 * @brief Get total number of samples in the file
-	 * @return The total number of samples in the file
-	 */
 	int getTotalSamples() const;
 
-	/**
-	 * @brief Gets number of channels of the audio in the file
-	 * @return The number of channels
-	 */
 	int getNumChannels() const;
-
-	/**
-	 * @brief Gets the properties of the audio in the file
-	 * @return The audio properties
-	 */
-	const AudioProperties& getAudioProperties() const { return m_audioProps; }
 
 	/**
 	 * @brief Changes the audio format the read functions return
@@ -143,11 +106,7 @@ class WaveFile
 	 * @param props The desired properties of the output
 	 */
 	void setAdjustedAudioProperties(const AudioProperties& props);
-protected:
-	size_t handleDecodedFrame(AVFrame* av_frame, uint8_t* out_buffer, size_t buffer_size);
 };
 
-}
-
-
-#endif // _WAVEFILE_H
+} // namespace ffmpeg
+} // namespace sound

--- a/code/source_groups.cmake
+++ b/code/source_groups.cmake
@@ -99,19 +99,21 @@ add_file_folder("Cutscene"
 	cutscene/VideoPresenter.h
 )
 
-# Cutscene\ffmpeg files
-add_file_folder("Cutscene\\\\ffmpeg"
-	cutscene/ffmpeg/AudioDecoder.cpp
-	cutscene/ffmpeg/AudioDecoder.h
-	cutscene/ffmpeg/FFMPEGDecoder.cpp
-	cutscene/ffmpeg/FFMPEGDecoder.h
-	cutscene/ffmpeg/internal.cpp
-	cutscene/ffmpeg/internal.h
-	cutscene/ffmpeg/SubtitleDecoder.cpp
-	cutscene/ffmpeg/SubtitleDecoder.h
-	cutscene/ffmpeg/VideoDecoder.cpp
-	cutscene/ffmpeg/VideoDecoder.h
-)
+if (FSO_BUILD_WITH_FFMPEG)
+	# Cutscene\ffmpeg files
+	add_file_folder("Cutscene\\\\ffmpeg"
+		cutscene/ffmpeg/AudioDecoder.cpp
+		cutscene/ffmpeg/AudioDecoder.h
+		cutscene/ffmpeg/FFMPEGDecoder.cpp
+		cutscene/ffmpeg/FFMPEGDecoder.h
+		cutscene/ffmpeg/internal.cpp
+		cutscene/ffmpeg/internal.h
+		cutscene/ffmpeg/SubtitleDecoder.cpp
+		cutscene/ffmpeg/SubtitleDecoder.h
+		cutscene/ffmpeg/VideoDecoder.cpp
+		cutscene/ffmpeg/VideoDecoder.h
+	)
+endif()
 
 # ddsutils files
 add_file_folder("ddsutils"
@@ -593,13 +595,15 @@ add_file_folder("Libs\\\\Discord"
 	libs/discord/discord.h
 )
 
-add_file_folder("Libs\\\\FFmpeg"
-	libs/ffmpeg/FFmpeg.cpp
-	libs/ffmpeg/FFmpeg.h
-	libs/ffmpeg/FFmpegContext.cpp
-	libs/ffmpeg/FFmpegContext.h
-	libs/ffmpeg/FFmpegHeaders.h
-)
+if (FSO_BUILD_WITH_FFMPEG)
+	add_file_folder("Libs\\\\FFmpeg"
+		libs/ffmpeg/FFmpeg.cpp
+		libs/ffmpeg/FFmpeg.h
+		libs/ffmpeg/FFmpegContext.cpp
+		libs/ffmpeg/FFmpegContext.h
+		libs/ffmpeg/FFmpegHeaders.h
+	)
+endif()
 
 add_file_folder("Libs\\\\RenderDoc"
 	libs/renderdoc/renderdoc.cpp
@@ -1241,6 +1245,7 @@ add_file_folder("Sound"
 	sound/dscap.h
 	sound/fsspeech.cpp
 	sound/fsspeech.h
+	sound/IAudioFile.h
 	sound/openal.cpp
 	sound/openal.h
 	sound/phrases.xml
@@ -1254,13 +1259,15 @@ add_file_folder("Sound"
 	sound/voicerec.h
 )
 
-# Sound -> ffmpeg files
-add_file_folder("Sound\\\\FFmpeg"
-	sound/ffmpeg/FFmpegAudioReader.cpp
-	sound/ffmpeg/FFmpegAudioReader.h
-	sound/ffmpeg/WaveFile.cpp
-	sound/ffmpeg/WaveFile.h
-)
+if (FSO_BUILD_WITH_FFMPEG)
+	# Sound -> ffmpeg files
+	add_file_folder("Sound\\\\FFmpeg"
+		sound/ffmpeg/FFmpegAudioReader.cpp
+		sound/ffmpeg/FFmpegAudioReader.h
+		sound/ffmpeg/FFmpegWaveFile.cpp
+		sound/ffmpeg/FFmpegWaveFile.h
+	)
+endif()
 
 # Species_Defs files
 add_file_folder("Species_Defs"

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -8,7 +8,7 @@ cd build/alpine
 export CXXFLAGS="-m64 -mtune=generic -mfpmath=sse -msse -msse2 -pipe -Wno-unknown-pragmas"
 export CFLAGS="-m64 -mtune=generic -mfpmath=sse -msse -msse2 -pipe -Wno-unknown-pragmas"
 
-cmake -G Ninja -DCMAKE_INSTALL_PREFIX=/install -DFSO_BUILD_APPIMAGE=ON -DCMAKE_BUILD_TYPE=$1 ../..
+cmake -G Ninja -DCMAKE_INSTALL_PREFIX=/install -DFSO_BUILD_APPIMAGE=ON -DFSO_BUILD_WITH_FFMPEG=OFF -DCMAKE_BUILD_TYPE=$1 ../..
 
 ninja
 ninja install

--- a/docker/standalone/Dockerfile
+++ b/docker/standalone/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine:latest AS builder
 ARG build_type
 
 RUN apk add --no-cache cmake gcc g++ ninja openal-soft-dev \
-	freetype-dev ffmpeg-dev sdl2-dev linux-headers unzip
+	freetype-dev sdl2-dev linux-headers unzip
 
 COPY docker/build.sh /build.sh
 
@@ -17,7 +17,7 @@ RUN unzip /build/webui.zip -d /build/fso-webui && cp -r /build/fso-webui/fs2open
 
 FROM alpine:latest
 
-RUN apk add --no-cache openal-soft freetype ffmpeg-libs sdl2 libstdc++
+RUN apk add --no-cache openal-soft freetype sdl2 libstdc++
 
 ENV XDG_DATA_HOME=/fso-config
 COPY docker/standalone/fs2_open.ini /fso-config/HardLightProductions/FreeSpaceOpen/

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -1914,8 +1914,10 @@ void game_init()
 
 	// convert old pilot files (if they need it)
 	convert_pilot_files();
-	
+
+#ifdef WITH_FFMPEG
 	libs::ffmpeg::initialize();
+#endif
 
 	libs::discord::init();
 

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -27,7 +27,9 @@ add_subdirectory(utfcpp)
 
 include(freetype.cmake)
 
-include(FFmpeg.cmake)
+if (FSO_BUILD_WITH_FFMPEG)
+	include(FFmpeg.cmake)
+endif()
 
 add_subdirectory(discord)
 


### PR DESCRIPTION
This does some refactoring to make it possible to cimpile and run FSO
without needing to link to FFmpeg. Since that eliminates support for
cutscenes or sound this is mostly useful for running a standalone server
which has no need for this anyway.

This reduces the image size of the standalone Docker image to only 20MB
and also resolves any licensing issues that might have existed.