### PR TITLE
Fix standalone signal handling

### DIFF
--- a/code/network/multi_fstracker.cpp
+++ b/code/network/multi_fstracker.cpp
@@ -1059,6 +1059,8 @@ int multi_fs_tracker_validate_mission(char *filename)
 	if(!Multi_fs_tracker_inited){
 		return MVALID_STATUS_UNKNOWN;
 	}
+
+	mprintf(("Standalone: Validating '%s'\n", filename));
 	
 	// get the checksum of the local file	
 	memset(&mission, 0, sizeof(mission));

--- a/code/network/multiutil.cpp
+++ b/code/network/multiutil.cpp
@@ -3030,6 +3030,7 @@ void multi_update_valid_missions()
 	if (Game_mode & GM_STANDALONE_SERVER) {
 		std_create_gen_dialog("Validating missions");
 		std_gen_set_text("Querying:", 1);
+		mprintf(("Standalone: Validating missions\n"));
 	}
 
 	// mark all missions on our list as being MVALID_STATUS_UNKNOWN

--- a/code/network/stand_gui-unix.cpp
+++ b/code/network/stand_gui-unix.cpp
@@ -820,7 +820,10 @@ void webapi_shutdown() {
 }
 
 void std_init_standalone() {
-    atexit(webapi_shutdown);
+}
+
+void std_deinit_standalone() {
+	webapi_shutdown();
 }
 
 void std_configLoaded(multi_global_options *options) {
@@ -950,11 +953,6 @@ void std_tracker_login()
 	}
 
 	multi_fs_tracker_login_freespace();
-}
-
-void std_init_os()
-{
-	os_init_registry_stuff(Osreg_company_name, Osreg_app_name);
 }
 
 /**

--- a/code/network/stand_gui.cpp
+++ b/code/network/stand_gui.cpp
@@ -2383,20 +2383,11 @@ DWORD standalone_process(LPVOID /*lparam*/)
 	return 0;
 }
 
-void std_init_os()
-{
-	os_init_registry_stuff(Osreg_company_name, Osreg_app_name);
-}
-
-
 // called when freespace initialized
 void std_init_standalone()
 {
 	// start the main thread
 	Standalone_thread = CreateThread( NULL, 0, (LPTHREAD_START_ROUTINE)standalone_process, NULL, 0, &Standalone_thread_id );
-	
-	// set the close functions
-	atexit(std_deinit_standalone);
 }
 
 // called when freespace closes

--- a/code/network/stand_gui.h
+++ b/code/network/stand_gui.h
@@ -187,14 +187,11 @@ void std_reset_standalone_gui();
 // reset all networking/gui stuff (calls reset_standalone_gui) for the standalone
 void std_multi_standalone_reset_all();
 
-// setup registry access, etc for the standalone
-void std_init_os();
-
-// close down the standalone
-void std_deinit_standalone();
-
 // initialize the standalone
 void std_init_standalone();
+
+// Shut down the standalone
+void std_deinit_standalone();
 
 // do any gui related issues on the standalone (like periodically updating player stats, etc...)
 void std_do_gui_frame();

--- a/code/osapi/osapi.cpp
+++ b/code/osapi/osapi.cpp
@@ -125,6 +125,7 @@ namespace
 	}
 	
 	bool quit_handler(const SDL_Event&  /*e*/) {
+		mprintf(("Recevied quit signal\n"));
 		gameseq_post_event(GS_EVENT_QUIT_GAME);
 		return true;
 	}

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -1607,12 +1607,7 @@ void game_init()
 #endif
 
 	// init os stuff next
-	if ( !Is_standalone ) {
-		os_init( Osreg_class_name, Window_title.c_str(), Osreg_app_name );
-	}
-	else {
-		std_init_os();
-	}
+	os_init( Osreg_class_name, Window_title.c_str(), Osreg_app_name );
 
 #ifndef NDEBUG
 	mprintf(("FreeSpace 2 Open version: %s\n", FS_VERSION_FULL));
@@ -6549,6 +6544,10 @@ void game_shutdown(void)
 #endif
 
 	gr_close();
+
+	if (Is_standalone) {
+		std_deinit_standalone();
+	}
 
 	os_cleanup();
 


### PR DESCRIPTION
The standalone did not initialize SDL and so did not receive the quit
signal when it was sent SIGTERM or SIGINT. This fixes that by making the
standalone server just use the normal os initialization code.

Also includes some other code cleanup and some more logging to make it
more apparent in the log what is currently happening at standalone
startup.