### PR TITLE
Build docker standalone image on tag push

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,3 +5,7 @@ indent_style = tab
 
 [*.sdr]
 indent_style = tab
+
+[*.{yml,yaml}]
+indent_style = space
+indent_size = 2

--- a/.github/workflows/standalone-image-workflow.yaml
+++ b/.github/workflows/standalone-image-workflow.yaml
@@ -1,0 +1,48 @@
+name: Publish Standalone docker image
+
+on:
+  push:
+    tags:
+    - '*'
+
+jobs:
+  build_images:
+    strategy:
+      matrix:
+        configuration: [FastDebug, Release]
+        include:
+        - configuration: FastDebug
+          latest_tag: latest_debug
+          nightly_tag: nightly_debug
+          release_tag: release_debug
+        - configuration: Release
+          latest_tag: latest
+          nightly_tag: nightly
+          release_tag: release
+      fail-fast: false
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+      name: Checkout
+      with:
+        submodules: true
+    - name: Docker login
+      run: echo ${{ secrets.DOCKER_ACCESSTOKEN }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
+    - name: Docker build
+      run: docker build --build-arg build_type=${{ matrix.configuration }} -f docker/standalone/Dockerfile -t ${{ secrets.DOCKER_REPOSITORY }}:${{ matrix.latest_tag }} .
+
+    - name: Push latest tag
+      run: |
+        docker push ${{ secrets.DOCKER_REPOSITORY }}:${{ matrix.latest_tag }}
+
+    - name: Push nightly tag
+      if: contains(github.ref, 'refs/tags/nightly_')
+      run: |
+        docker tag ${{ secrets.DOCKER_REPOSITORY }}:${{ matrix.latest_tag }} ${{ secrets.DOCKER_REPOSITORY }}:${{ matrix.nightly_tag }}
+        docker push ${{ secrets.DOCKER_REPOSITORY }}:${{ matrix.nightly_tag }}
+
+    - name: Push release tag
+      if: contains(github.ref, 'refs/tags/release_')
+      run: |
+        docker tag ${{ secrets.DOCKER_REPOSITORY }}:${{ matrix.latest_tag }} ${{ secrets.DOCKER_REPOSITORY }}:${{ matrix.release_tag }}
+        docker push ${{ secrets.DOCKER_REPOSITORY }}:${{ matrix.release_tag }}

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -8,7 +8,7 @@ cd build/alpine
 export CXXFLAGS="-m64 -mtune=generic -mfpmath=sse -msse -msse2 -pipe -Wno-unknown-pragmas"
 export CFLAGS="-m64 -mtune=generic -mfpmath=sse -msse -msse2 -pipe -Wno-unknown-pragmas"
 
-cmake -G Ninja -DCMAKE_INSTALL_PREFIX=/install -DFSO_BUILD_APPIMAGE=ON -DFSO_BUILD_WITH_FFMPEG=OFF -DCMAKE_BUILD_TYPE=$1 ../..
+cmake -G Ninja -DCMAKE_INSTALL_PREFIX=/install -DFSO_BUILD_APPIMAGE=ON -DFSO_BUILD_WITH_FFMPEG=OFF -DCMAKE_BUILD_TYPE=$1 -DFSO_RELEASE_LOGGING=ON ../..
 
 ninja
 ninja install


### PR DESCRIPTION
This way we will always have standalone images in an official repository.