### PR TITLE
add newlines to mprintf and nprintf

### DIFF
--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -4652,7 +4652,7 @@ void ai_fly_to_ship()
 		{
 			if (aip->mode == AIM_FLY_TO_SHIP || aip->goals[i].ai_mode == AI_GOAL_FLY_TO_SHIP)
 			{
-				mprintf(("Ship '%s' told to fly to target ship '%s'",
+				mprintf(("Ship '%s' told to fly to target ship '%s'\n",
 					Ships[Pl_objp->instance].ship_name,
 					aip->goals[i].target_name));
 			}
@@ -10683,7 +10683,7 @@ void ai_dock()
 			char *goal_dock_path_name = model_get(goal_sip->model_num)->paths[aip->mp_index].name;
 
 			mprintf(("Ship class %s has only %i points on dock path \"%s\".  Recommended minimum number of points is 4.  "\
-				"Docking along that path will look strange.  You may wish to edit the model.", goal_ship_class_name, aip->path_length, goal_dock_path_name));
+				"Docking along that path will look strange.  You may wish to edit the model.\n", goal_ship_class_name, aip->path_length, goal_dock_path_name));
 		}
 
 		aip->submode = AIS_DOCK_1;

--- a/code/ai/aigoals.cpp
+++ b/code/ai/aigoals.cpp
@@ -1376,7 +1376,7 @@ void ai_copy_mission_wing_goal( ai_goal *aigp, ai_info *aip )
 	}
 
 	if (j >= MAX_AI_GOALS) {
-		mprintf(("Unable to assign wing goal to ship %s; the ship goals are already filled to capacity", Ships[aip->shipnum].ship_name));
+		mprintf(("Unable to assign wing goal to ship %s; the ship goals are already filled to capacity\n", Ships[aip->shipnum].ship_name));
 	}
 }
 

--- a/code/asteroid/asteroid.cpp
+++ b/code/asteroid/asteroid.cpp
@@ -1937,11 +1937,11 @@ static void asteroid_parse_tbl()
 		if (tally != max_asteroids)
 		{
 #ifndef NDEBUG
+			mprintf(("Asteroid.tbl as parsed:\n"));
 			for (SCP_vector<SCP_string>::iterator iter = parsed_asteroids.begin();
 				iter != parsed_asteroids.end(); ++iter)
 			{
-				mprintf(("Asteroid.tbl as parsed:\n"));
-				mprintf(("%s", iter->c_str()));
+				mprintf(("%s\n", iter->c_str()));
 			}
 #endif
 			Error(LOCATION,

--- a/code/asteroid/asteroid.cpp
+++ b/code/asteroid/asteroid.cpp
@@ -478,7 +478,7 @@ static void asteroid_load(int asteroid_info_index, int asteroid_subtype)
 			}
 			else
 			{
-				nprintf(("Warning",  "For asteroid '%s', detail level mismatch (POF needs %d)", asip->name, pm->n_detail_levels));
+				nprintf(("Warning",  "For asteroid '%s', detail level mismatch (POF needs %d)\n", asip->name, pm->n_detail_levels));
 			}
 		}	
 		// Stuff detail level distances.

--- a/code/controlconfig/controlsconfig.cpp
+++ b/code/controlconfig/controlsconfig.cpp
@@ -2304,7 +2304,7 @@ int check_control_used(int id, int key)
 
 	if ((Control_config[id].key_id == key) || joy_down_count(Control_config[id].joy_id, 1) ||
 			((Control_config[id].joy_id >= 0) && (Control_config[id].joy_id < MOUSE_NUM_BUTTONS) && mouse_down_count(1 << Control_config[id].joy_id))) {
-		//mprintf(("Key used %d", key));
+		//mprintf(("Key used %d\n", key));
 		control_used(id);
 		return 1;
 	}

--- a/code/cutscene/ffmpeg/AudioDecoder.cpp
+++ b/code/cutscene/ffmpeg/AudioDecoder.cpp
@@ -126,7 +126,7 @@ void AudioDecoder::handleDecodedFrame(AVFrame* frame) {
 		auto ret = av_samples_alloc(m_outData, &m_outLinesize, OUT_NUM_CHANNELS, m_outNumSamples,
 									OUT_SAMPLE_FORMAT, 1);
 		if (ret < 0) {
-			mprintf(("FFMPEG: Failed to allocate samples!!!"));
+			mprintf(("FFMPEG: Failed to allocate samples!!!\n"));
 			return;
 		}
 

--- a/code/graphics/2d.cpp
+++ b/code/graphics/2d.cpp
@@ -2211,7 +2211,7 @@ int poly_list::find_first_vertex_fast(int idx)
 
 	if ( first_idx == sorted_indices + n_verts ) {
 		// if this happens then idx was never in the index list to begin with which is not good
-		mprintf(("Sorted index list missing index %d!", idx));
+		mprintf(("Sorted index list missing index %d!\n", idx));
 		Int3();
 		return idx;
 	}

--- a/code/graphics/generic.cpp
+++ b/code/graphics/generic.cpp
@@ -254,7 +254,7 @@ int generic_anim_stream(generic_anim *ga, const bool cache)
 		}
 		ga->bitmap_id = bm_load(frame_name);
 		if(ga->bitmap_id < 0) {
-			mprintf(("Cannot find first frame for eff streaming. eff Filename: %s", ga->filename));
+			mprintf(("Cannot find first frame for eff streaming. eff Filename: %s\n", ga->filename));
 			return -1;
 		}
 		if (snprintf(frame_name, MAX_FILENAME_LEN, "%s_0001", ga->filename) >= MAX_FILENAME_LEN) {

--- a/code/graphics/vulkan/VulkanRenderer.cpp
+++ b/code/graphics/vulkan/VulkanRenderer.cpp
@@ -114,7 +114,7 @@ bool VulkanRenderer::initializeInstance()
 
 	unsigned int count;
 	if (!SDL_Vulkan_GetInstanceExtensions(window, &count, nullptr)) {
-		mprintf(("Error in first SDL_Vulkan_GetInstanceExtensions: %s", SDL_GetError()));
+		mprintf(("Error in first SDL_Vulkan_GetInstanceExtensions: %s\n", SDL_GetError()));
 		return false;
 	}
 
@@ -122,7 +122,7 @@ bool VulkanRenderer::initializeInstance()
 	extensions.resize(count);
 
 	if (!SDL_Vulkan_GetInstanceExtensions(window, &count, extensions.data())) {
-		mprintf(("Error in second SDL_Vulkan_GetInstanceExtensions: %s", SDL_GetError()));
+		mprintf(("Error in second SDL_Vulkan_GetInstanceExtensions: %s\n", SDL_GetError()));
 		return false;
 	}
 
@@ -132,7 +132,7 @@ bool VulkanRenderer::initializeInstance()
 	mprintf(("Vulkan instance version %s\n", gameversion::format_version(vulkanVersion).c_str()));
 
 	if (vulkanVersion < MinVulkanVersion) {
-		mprintf(("Vulkan version is less than the minimum which is %s.",
+		mprintf(("Vulkan version is less than the minimum which is %s.\n",
 				 gameversion::format_version(MinVulkanVersion).c_str()));
 		return false;
 	}
@@ -213,7 +213,7 @@ bool VulkanRenderer::initializeSurface()
 
 	VkSurfaceKHR surface;
 	if (!SDL_Vulkan_CreateSurface(window, static_cast<VkInstance>(*m_vkInstance), &surface)) {
-		mprintf(("Failed to create vulkan surface: %s", SDL_GetError()));
+		mprintf(("Failed to create vulkan surface: %s\n", SDL_GetError()));
 		return false;
 	}
 

--- a/code/graphics/vulkan/VulkanRenderer.cpp
+++ b/code/graphics/vulkan/VulkanRenderer.cpp
@@ -48,12 +48,12 @@ bool VulkanRenderer::initialize()
 	}
 
 	if (!initializeInstance()) {
-		mprintf(("Failed to create Vulkan instance!"));
+		mprintf(("Failed to create Vulkan instance!\n"));
 		return false;
 	}
 
 	if (!initializeSurface()) {
-		mprintf(("Failed to create Vulkan surface!"));
+		mprintf(("Failed to create Vulkan surface!\n"));
 		return false;
 	}
 
@@ -202,7 +202,7 @@ bool VulkanRenderer::initializeInstance()
 	m_vkInstance = std::move(instance);
 	return true;
 #else
-	mprintf(("SDL does not support Vulkan in its current version."));
+	mprintf(("SDL does not support Vulkan in its current version.\n"));
 	return false;
 #endif
 }

--- a/code/io/cursor.cpp
+++ b/code/io/cursor.cpp
@@ -168,7 +168,7 @@ namespace io
 
 			if (handle < 0)
 			{
-				mprintf(("Failed to load cursor bitmap %s!", fileName));
+				mprintf(("Failed to load cursor bitmap %s!\n", fileName));
 				return nullptr;
 			}
 

--- a/code/io/joy-sdl.cpp
+++ b/code/io/joy-sdl.cpp
@@ -594,7 +594,7 @@ namespace joystick
 			coord2d coord;
 			if (SDL_JoystickGetBall(_joystick, i, &coord.x, &coord.y))
 			{
-				mprintf(("Failed to get ball %d value for joystick %s: %s", i, _name.c_str(), SDL_GetError()));
+				mprintf(("Failed to get ball %d value for joystick %s: %s\n", i, _name.c_str(), SDL_GetError()));
 			}
 		}
 

--- a/code/mission/missionbriefcommon.cpp
+++ b/code/mission/missionbriefcommon.cpp
@@ -567,14 +567,14 @@ briefing_icon_info *brief_get_icon_info(brief_icon *bi)
 				if (sip->bii_index_wing_with_cargo >= 0)
 					return &Briefing_icon_info[sip->bii_index_wing_with_cargo];
 				else
-					mprintf(("Ship '%s' is missing the wing-with-cargo briefing icon!", sip->name));
+					mprintf(("Ship '%s' is missing the wing-with-cargo briefing icon!\n", sip->name));
 			}
 			else
 			{
 				if (sip->bii_index_wing >= 0)
 					return &Briefing_icon_info[sip->bii_index_wing];
 				else
-					mprintf(("Ship '%s' is missing the wing briefing icon!", sip->name));
+					mprintf(("Ship '%s' is missing the wing briefing icon!\n", sip->name));
 			}
 		}
 		else
@@ -584,7 +584,7 @@ briefing_icon_info *brief_get_icon_info(brief_icon *bi)
 				if (sip->bii_index_ship_with_cargo >= 0)
 					return &Briefing_icon_info[sip->bii_index_ship_with_cargo];
 				else
-					mprintf(("Ship '%s' is missing the ship-with-cargo briefing icon!", sip->name));
+					mprintf(("Ship '%s' is missing the ship-with-cargo briefing icon!\n", sip->name));
 			}
 		}
 

--- a/code/mission/missionload.cpp
+++ b/code/mission/missionload.cpp
@@ -118,7 +118,7 @@ bool mission_load(const char* filename_ext)
 	}
 
 	if (mission_is_ignored(filename)) {
-		mprintf(("MISSION LOAD: Tried to load an ignored mission!  Aborting..."));
+		mprintf(("MISSION LOAD: Tried to load an ignored mission!  Aborting...\n"));
 		return false;
 	}
 

--- a/code/mission/missionmessage.cpp
+++ b/code/mission/missionmessage.cpp
@@ -2050,7 +2050,7 @@ void message_send_builtin_to_player( int type, ship *shipp, int priority, int ti
 		case BUILTIN_MATCHES_PERSONA_EXCLUDED:
 			nprintf(("MESSAGING", "Couldn't find builtin message %s for persona %d with a none excluded mood\n", Builtin_messages[type].name, persona_index));
 			if (!Personas[persona_index].substitute_missing_messages) {
-				nprintf(("MESSAGING", "Persona does not allow substitution, skipping message."));
+				nprintf(("MESSAGING", "Persona does not allow substitution, skipping message.\n"));
 				return;
 			}
 			else
@@ -2059,7 +2059,7 @@ void message_send_builtin_to_player( int type, ship *shipp, int priority, int ti
 		case BUILTIN_MATCHES_SPECIES:
 			nprintf(("MESSAGING", "Couldn't find builtin message %s for persona %d\n", Builtin_messages[type].name, persona_index));
 			if (!Personas[persona_index].substitute_missing_messages) {
-				nprintf(("MESSAGING", "Persona does not allow substitution, skipping message."));
+				nprintf(("MESSAGING", "Persona does not allow substitution, skipping message.\n"));
 				return;
 			}
 			else
@@ -2068,7 +2068,7 @@ void message_send_builtin_to_player( int type, ship *shipp, int priority, int ti
 		case BUILTIN_MATCHES_TYPE:
 			nprintf(("MESSAGING", "Couldn't find builtin message %s for persona %d\n", Builtin_messages[type].name, persona_index));
 			if (!Personas[persona_index].substitute_missing_messages) {
-				nprintf(("MESSAGING", "Persona does not allow substitution, skipping message."));
+				nprintf(("MESSAGING", "Persona does not allow substitution, skipping message.\n"));
 				return;
 			}
 			else

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -3203,7 +3203,7 @@ int parse_object(mission *pm, int  /*flag*/, p_object *p_objp)
 		}
 
 		if (period_detected) {
-			nprintf(("Warning", "Special explosion attributes have been returned to integer format"));
+			nprintf(("Warning", "Special explosion attributes have been returned to integer format\n"));
 		}
 	}
 

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -423,11 +423,11 @@ void parse_custom_bitmap(const char *expected_string_640, const char *expected_s
 	// error testing
 	if (Fred_running && (found640) && !(found1024))
 	{
-		mprintf(("Mission: found an entry for %s but not a corresponding entry for %s!", expected_string_640, expected_string_1024));
+		mprintf(("Mission: found an entry for %s but not a corresponding entry for %s!\n", expected_string_640, expected_string_1024));
 	}
 	if (Fred_running && !(found640) && (found1024))
 	{
-		mprintf(("Mission: found an entry for %s but not a corresponding entry for %s!", expected_string_1024, expected_string_640));
+		mprintf(("Mission: found an entry for %s but not a corresponding entry for %s!\n", expected_string_1024, expected_string_640));
 	}
 }
 
@@ -5673,7 +5673,7 @@ bool parse_mission(mission *pm, int flags)
 	if ((Num_unknown_ship_classes > 0) || ( Num_unknown_loadout_classes > 0 )) {
 		// if running on standalone server, just print to the log
 		if (Game_mode & GM_STANDALONE_SERVER) {
-			mprintf(("Warning!  Could not load %d ship classes!", Num_unknown_ship_classes));
+			mprintf(("Warning!  Could not load %d ship classes!\n", Num_unknown_ship_classes));
 			return false;
 		}
 		// don't do this in FRED; we will display a separate popup

--- a/code/model/modelanim.cpp
+++ b/code/model/modelanim.cpp
@@ -410,7 +410,7 @@ void model_anim_submodel_trigger_rotate(model_subsystem *psub, ship_subsys *ss)
 	Assert( psub->flags[Model::Subsystem_Flags::Triggered] );
 	
 	if (ss->triggered_rotation_index < 0) {
-		mprintf(("Invalid rotation index for triggered rotation in subsystem %s in model %s!", psub->name, model_get(Ship_info[Ships[Objects[ss->parent_objnum].instance].ship_info_index].model_num)->filename));
+		mprintf(("Invalid rotation index for triggered rotation in subsystem %s in model %s!\n", psub->name, model_get(Ship_info[Ships[Objects[ss->parent_objnum].instance].ship_info_index].model_num)->filename));
 		return;
 	}
 
@@ -583,7 +583,7 @@ bool model_anim_start_type(ship_subsys *pss, int animation_type, int subtype, in
 	if ( !(psub->flags[Model::Subsystem_Flags::Triggered]) )
 		return false;
 	if (pss->triggered_rotation_index < 0) {
-		mprintf(("Invalid rotation index for triggered rotation in subsystem %s in model %s!", psub->name, model_get(Ship_info[Ships[Objects[pss->parent_objnum].instance].ship_info_index].model_num)->filename));
+		mprintf(("Invalid rotation index for triggered rotation in subsystem %s in model %s!\n", psub->name, model_get(Ship_info[Ships[Objects[pss->parent_objnum].instance].ship_info_index].model_num)->filename));
 		return false;
 	}
 	triggered_rotation *trigger = &Triggered_rotations[pss->triggered_rotation_index];
@@ -764,7 +764,7 @@ int model_anim_get_time_type(ship_subsys *pss, int animation_type, int subtype)
 	if ( !(psub->flags[Model::Subsystem_Flags::Triggered]) )
 		return timestamp();
 	if (pss->triggered_rotation_index < 0) {
-		mprintf(("Invalid rotation index for triggered rotation in subsystem %s in model %s!", psub->name, model_get(Ship_info[Ships[Objects[pss->parent_objnum].instance].ship_info_index].model_num)->filename));
+		mprintf(("Invalid rotation index for triggered rotation in subsystem %s in model %s!\n", psub->name, model_get(Ship_info[Ships[Objects[pss->parent_objnum].instance].ship_info_index].model_num)->filename));
 		return timestamp();
 	}
 	triggered_rotation *tr = &Triggered_rotations[pss->triggered_rotation_index];
@@ -871,7 +871,7 @@ void model_anim_set_initial_states(ship *shipp)
 					pss->submodel_info_1.angs.h = psub->triggers[i].angle.xyz.y;
 				} else {
 					if (pss->triggered_rotation_index < 0) {
-						mprintf(("Invalid rotation index for triggered rotation in subsystem %s in model %s!", psub->name, model_get(Ship_info[shipp->ship_info_index].model_num)->filename));
+						mprintf(("Invalid rotation index for triggered rotation in subsystem %s in model %s!\n", psub->name, model_get(Ship_info[shipp->ship_info_index].model_num)->filename));
 						continue;
 					}
 					triggered_rotation *tr = &Triggered_rotations[pss->triggered_rotation_index];
@@ -914,7 +914,7 @@ void model_anim_handle_multiplayer(ship *shipp)
 			continue;
 
 		if (pss->triggered_rotation_index < 0) {
-			mprintf(("Invalid rotation index for triggered rotation in subsystem %s in model %s!", pss->system_info->name, model_get(Ship_info[shipp->ship_info_index].model_num)->filename));
+			mprintf(("Invalid rotation index for triggered rotation in subsystem %s in model %s!\n", pss->system_info->name, model_get(Ship_info[shipp->ship_info_index].model_num)->filename));
 			continue;
 		}
 		

--- a/code/model/modelread.cpp
+++ b/code/model/modelread.cpp
@@ -1292,7 +1292,7 @@ int read_model_file(polymodel * pm, const char *filename, int n_subsystems, mode
 				//mprintf(0,"Got chunk SOBJ, len=%d\n",len);
 
 				n = cfread_int(fp);
-				//mprintf(("SOBJ IDed itself as %d", n));
+				//mprintf(("SOBJ IDed itself as %d\n", n));
 
 				Assert(n < pm->n_models );
 

--- a/code/network/multi_voice.cpp
+++ b/code/network/multi_voice.cpp
@@ -671,7 +671,7 @@ void multi_voice_player_process()
 			// if we've recorded the max time allowed, send the data
 			if((Multi_voice_recording_stamp != -1) && timestamp_elapsed(Multi_voice_recording_stamp)){
 #ifdef MULTI_VOICE_VERBOSE
-				nprintf(("Network","MULTI VOICE : timestamp popped"));
+				nprintf(("Network","MULTI VOICE : timestamp popped\n"));
 #endif
 				// mark me as no longer recording
 				Multi_voice_recording = 0;			

--- a/code/network/multimsgs.cpp
+++ b/code/network/multimsgs.cpp
@@ -3075,7 +3075,7 @@ void process_secondary_fired_packet(ubyte* data, header* hinfo, int from_player)
 		// find the object (based on network signatures) for the object that fired
 		objp = multi_get_network_object( net_signature );
 		if ( objp == NULL ) {
-			nprintf(("Network", "Could not find ship for fire secondary packet!"));
+			nprintf(("Network", "Could not find ship for fire secondary packet!\n"));
 			return;
 		}
 
@@ -4708,7 +4708,7 @@ void process_netplayer_load_packet(ubyte *data, header *hinfo)
 
 		// MWA 2/3/98 -- ingame join changes!!!
 		// everyone can go through the same mission loading path here!!!!
-		nprintf(("Network","Loading mission..."));
+		nprintf(("Network","Loading mission...\n"));
 
 		// notify everyone that I'm loading the mission
 		Net_player->state = NETPLAYER_STATE_MISSION_LOADING;
@@ -7542,7 +7542,7 @@ void process_NEW_primary_fired_packet(ubyte *data, header *hinfo)
 	// find the object this fired packet is operating on
 	objp = multi_get_network_object( shooter_sig );
 	if ( objp == NULL ) {
-		nprintf(("Network", "Could not find ship for fire primary packet NEW!"));
+		nprintf(("Network", "Could not find ship for fire primary packet NEW!\n"));
 		return;
 	}
 	// if this object is not actually a valid ship, don't do anything

--- a/code/network/multiui.cpp
+++ b/code/network/multiui.cpp
@@ -7990,7 +7990,7 @@ void multi_sync_pre_do()
 
 			// load the mission myself, as soon as possible
 			if(!Multi_mission_loaded){
-				nprintf(("Network","Server loading mission..."));
+				nprintf(("Network","Server loading mission...\n"));
 	
 				// update everyone about my status
 				Net_player->state = NETPLAYER_STATE_MISSION_LOADING;

--- a/code/osapi/osapi.cpp
+++ b/code/osapi/osapi.cpp
@@ -286,7 +286,7 @@ void os_init(const char * wclass, const char * title, const char * app_name)
 	if (SDL_Init(SDL_INIT_EVENTS) < 0)
 	{
 		fprintf(stderr, "Couldn't init SDL: %s", SDL_GetError());
-		mprintf(("Couldn't init SDL: %s", SDL_GetError()));
+		mprintf(("Couldn't init SDL: %s\n", SDL_GetError()));
 
 		exit(1);
 		return;

--- a/code/osapi/osregistry.cpp
+++ b/code/osapi/osregistry.cpp
@@ -64,7 +64,7 @@ namespace
 
 		if (IsValidSid(ptkUser->User.Sid) == FALSE)
 		{
-			mprintf(("Invalid SID structure detected!"));
+			mprintf(("Invalid SID structure detected!\n"));
 
 			delete[] ptkUser;
 			return false;
@@ -96,7 +96,7 @@ namespace
 		BOOL bIsWow64 = FALSE;
 		if (!IsWow64Process(GetCurrentProcess(), &bIsWow64))
 		{
-			mprintf(("Failed to determine if we run under Wow64, registry configuration may fail!"));
+			mprintf(("Failed to determine if we run under Wow64, registry configuration may fail!\n"));
 			return false;
 		}
 

--- a/code/osapi/osregistry.cpp
+++ b/code/osapi/osregistry.cpp
@@ -47,7 +47,7 @@ namespace
 		HANDLE hToken = NULL;
 		if (OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &hToken) == FALSE)
 		{
-			mprintf(("Failed to get process token! Error Code: %d", (int)GetLastError()));
+			mprintf(("Failed to get process token! Error Code: %d\n", (int)GetLastError()));
 
 			return false;
 		}
@@ -73,7 +73,7 @@ namespace
 		LPTSTR sidName = NULL;
 		if (ConvertSidToStringSid(ptkUser->User.Sid, &sidName) == 0)
 		{
-			mprintf(("Failed to convert SID structure to string! Error Code: %d", (int)GetLastError()));
+			mprintf(("Failed to convert SID structure to string! Error Code: %d\n", (int)GetLastError()));
 
 			delete[] ptkUser;
 			return false;

--- a/code/parse/generic_log.cpp
+++ b/code/parse/generic_log.cpp
@@ -137,6 +137,6 @@ void log_string(int logfile_type, const char *string, int add_time)
 	cflush(logfiles[logfile_type].log_file);
 
 #if defined(LOGFILE_ECHO_TO_DEBUG)
-	mprintf(("Log file type %d %s",logfile_type, tmp));
+	mprintf(("Log file type %d %s\n",logfile_type, tmp));
 #endif
 }

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -14893,7 +14893,7 @@ int sexp_previous_goal_status( int n, int status )
 
 		if ( i == -1 ) {
 			// if mission not found, assume that goal was false (so previous-goal-false returns true)
-			nprintf(("General", "Couldn't find mission name \"%s\" in current campaign's list of missions.\nReturning %s for goal-status function.", mission_name, (status==GOAL_COMPLETE)?"false":"true"));
+			nprintf(("General", "Couldn't find mission name \"%s\" in current campaign's list of missions.\nReturning %s for goal-status function.\n", mission_name, (status==GOAL_COMPLETE)?"false":"true"));
 			if ( status == GOAL_COMPLETE )
 				rval = SEXP_KNOWN_FALSE;
 			else
@@ -14973,7 +14973,7 @@ int sexp_previous_event_status( int n, int status )
 
 		// if the mission name wasn't found -- make this return FALSE for the event status.
 		if ( i == -1 ) {
-			nprintf(("General", "Couldn't find mission name \"%s\" in current campaign's list of missions.\nReturning %s for event-status function.", mission_name, (status==EVENT_SATISFIED)?"false":"true"));
+			nprintf(("General", "Couldn't find mission name \"%s\" in current campaign's list of missions.\nReturning %s for event-status function.\n", mission_name, (status==EVENT_SATISFIED)?"false":"true"));
 			if ( status == EVENT_SATISFIED ) {
 				rval = SEXP_KNOWN_FALSE;
 			} else {

--- a/code/scpui/rocket_ui.cpp
+++ b/code/scpui/rocket_ui.cpp
@@ -179,7 +179,7 @@ bool mouse_button_handler(const SDL_Event& evt)
 		break;
 	default:
 		// Unknown SDL button value
-		mprintf(("Unknown SDL button value %d in libRocket mouse handler!", evt.button.button));
+		mprintf(("Unknown SDL button value %d in libRocket mouse handler!\n", evt.button.button));
 		return false;
 	}
 

--- a/code/sound/ds.cpp
+++ b/code/sound/ds.cpp
@@ -340,7 +340,7 @@ bool ds_check_for_openal_soft()
 	const ALchar * renderer = alGetString(AL_RENDERER);
 	if (renderer == NULL)
 	{
-		mprintf(("ds_check_for_openal_soft: renderer is null!"));
+		mprintf(("ds_check_for_openal_soft: renderer is null!\n"));
 		return false;
 	}
 	else if (!stricmp((const char *)renderer, "OpenAL Soft"))

--- a/code/sound/ds3d.cpp
+++ b/code/sound/ds3d.cpp
@@ -35,7 +35,7 @@
 int ds3d_update_buffer(int channel_id, float min, float max, vec3d *pos, vec3d *vel)
 {
 	if (Cmdline_no_3d_sound) {
-		nprintf(("Sound", "Aborting ds3d_update_buffer due to Cmdline_no_3d_sound..."));
+		nprintf(("Sound", "Aborting ds3d_update_buffer due to Cmdline_no_3d_sound...\n"));
 		return -1;
 	}
 
@@ -92,7 +92,7 @@ int ds3d_update_listener(vec3d *pos, vec3d *vel, matrix *orient)
 	}
 
 	if (Cmdline_no_3d_sound) {
-		nprintf(("Sound", "Aborting ds3d_update_listener due to Cmdline_no_3d_sound..."));
+		nprintf(("Sound", "Aborting ds3d_update_listener due to Cmdline_no_3d_sound...\n"));
 		return -1;
 	}
 

--- a/code/tracing/ThreadedEventProcessor.h
+++ b/code/tracing/ThreadedEventProcessor.h
@@ -69,7 +69,7 @@ class ThreadedEventProcessor {
 		try {
 			_event_queue.wait_push_back(*event);
 		} catch (const sync_queue_is_closed&) {
-			mprintf(("Stream queue was closed in processEvent! This should not be possible..."));
+			mprintf(("Stream queue was closed in processEvent! This should not be possible...\n"));
 		}
 	}
 };

--- a/fred2/MFCGraphicsOperations.cpp
+++ b/fred2/MFCGraphicsOperations.cpp
@@ -79,7 +79,7 @@ MFCOpenGLContext::~MFCOpenGLContext()
 {
 	if (!wglDeleteContext(_render_context))
 	{
-		mprintf(("Failed to delete render context!"));
+		mprintf(("Failed to delete render context!\n"));
 	}
 
 	--_oglDllReferenceCount;
@@ -214,7 +214,7 @@ std::unique_ptr<os::OpenGLContext> MFCGraphicsOperations::createOpenGLContext(os
 		mprintf(("Unable to make current thread for OpenGL W32!\n"));
 		if (!wglDeleteContext(temp_ctx))
 		{
-			mprintf(("Failed to delete render context!"));
+			mprintf(("Failed to delete render context!\n"));
 		}
 		return nullptr;
 	}
@@ -225,7 +225,7 @@ std::unique_ptr<os::OpenGLContext> MFCGraphicsOperations::createOpenGLContext(os
 		wglMakeCurrent(nullptr, nullptr);
 		if (!wglDeleteContext(temp_ctx))
 		{
-			mprintf(("Failed to delete render context!"));
+			mprintf(("Failed to delete render context!\n"));
 		}
 		return nullptr;
 	}
@@ -239,7 +239,7 @@ std::unique_ptr<os::OpenGLContext> MFCGraphicsOperations::createOpenGLContext(os
 			wglMakeCurrent(nullptr, nullptr);
 			if (!wglDeleteContext(temp_ctx))
 			{
-				mprintf(("Failed to delete fake context!"));
+				mprintf(("Failed to delete fake context!\n"));
 			}
 			return nullptr;
 		}
@@ -284,7 +284,7 @@ std::unique_ptr<os::OpenGLContext> MFCGraphicsOperations::createOpenGLContext(os
 	wglMakeCurrent(nullptr, nullptr);
 	if (!wglDeleteContext(temp_ctx))
 	{
-		mprintf(("Failed to delete fakse context!"));
+		mprintf(("Failed to delete fake context!\n"));
 	}
 	
 	if (attrib_ctx == nullptr)
@@ -297,7 +297,7 @@ std::unique_ptr<os::OpenGLContext> MFCGraphicsOperations::createOpenGLContext(os
 		mprintf(("Unable to make current thread for OpenGL W32!\n"));
 		if (!wglDeleteContext(attrib_ctx))
 		{
-			mprintf(("Failed to delete render context!"));
+			mprintf(("Failed to delete render context!\n"));
 		}
 		return nullptr;
 	}
@@ -308,7 +308,7 @@ std::unique_ptr<os::OpenGLContext> MFCGraphicsOperations::createOpenGLContext(os
 		wglMakeCurrent(nullptr, nullptr);
 		if (!wglDeleteContext(temp_ctx))
 		{
-			mprintf(("Failed to delete render context!"));
+			mprintf(("Failed to delete render context!\n"));
 		}
 		return nullptr;
 	}


### PR DESCRIPTION
There are several places in the code where mprintf and nprintf did not have newlines at the end of their strings.  I ran a regexp search and I think I got them all.  Here it is in case any regexp gurus catch something I missed:

`[m|n]printf\(\(\"[^\";]*[^n]\"[^\";]*\)\)`