### PR TITLE
Fix assertion when playing downsampled sounds

### DIFF
--- a/code/sound/sound.cpp
+++ b/code/sound/sound.cpp
@@ -357,7 +357,7 @@ sound_load_id snd_load(game_snd_entry* entry, int flags, int /*allow_hardware_lo
 		return sound_load_id::invalid();
 	}
 
-	const auto fileProps = audio_file->getFileProperties();
+	auto fileProps = audio_file->getFileProperties();
 
 	type = 0;
 	if (flags & GAME_SND_USE_DS3D) {
@@ -369,6 +369,7 @@ sound_load_id snd_load(game_snd_entry* entry, int flags, int /*allow_hardware_lo
 			resample.num_channels = 1;
 
 			audio_file->setResamplingProperties(resample);
+			fileProps = audio_file->getFileProperties(); // Refresh properties so that we have accurate information
 
 #ifndef NDEBUG
 			// Retail has a few sounds that triggers this warning so we need to ignore those


### PR DESCRIPTION
The sound was passed the data from before the resampling took place so
it though it would be playing a stereo sound and rightly cause an
assertion. This fixes that by refreshing the properties after appliying
the resampling properties.