### PR TITLE
improve detection of vasudan main hall for cheats

### DIFF
--- a/code/menuui/mainhallmenu.cpp
+++ b/code/menuui/mainhallmenu.cpp
@@ -2492,13 +2492,11 @@ void main_hall_vasudan_funny()
 }
 
 /**
- * Lookup if Vasudan main hall, based upon music name
- * @return 1 if true, 0 if false
+ * Lookup if Vasudan main hall, based upon background graphics
  */
-int main_hall_is_vasudan()
+bool main_hall_is_vasudan()
 {
-	// kind of a hack for now
-	return (!stricmp(Main_hall->music_name.c_str(), "Psampik") || !stricmp(Main_hall->music_name.c_str(), "Psamtik"));
+	return !stricmp(Main_hall->bitmap.c_str(), "vhall") || !stricmp(Main_hall->bitmap.c_str(), "2_vhall");
 }
 
 /**

--- a/code/menuui/mainhallmenu.h
+++ b/code/menuui/mainhallmenu.h
@@ -198,7 +198,7 @@ int main_hall_get_overlay_resolution_index();
 int main_hall_id();
 
 // Vasudan?
-int main_hall_is_vasudan();
+bool main_hall_is_vasudan();
 
 // start the ambient sounds playing in the main hall
 void main_hall_start_ambient();


### PR DESCRIPTION
This PR makes the main hall cheat check for Vasudan graphics, instead of Vasudan music.  This is better because the Vasudan main hall cheats (fishes and headz) affect the graphics, and other mods may use the same graphics with different music, or the same music with different graphics.