### PR TITLE
Make sure aip->net_signature always defaults to -1 for no target.

### DIFF
--- a/code/scripting/api/objs/ship.cpp
+++ b/code/scripting/api/objs/ship.cpp
@@ -617,7 +617,7 @@ ADE_VIRTVAR(Target, l_Ship, "object", "Target of ship. Value may also be a deriv
 			else
 			{
 				aip->target_objnum = -1;
-				aip->target_signature = 0;
+				aip->target_signature = -1;
 				aip->target_time = 0.0f;
 			}
 
@@ -664,7 +664,7 @@ ADE_VIRTVAR(TargetSubsystem, l_Ship, "subsystem", "Target subsystem of ship.", "
 		else
 		{
 			aip->target_objnum = -1;
-			aip->target_signature = 0;
+			aip->target_signature = -1;
 			aip->target_time = 0.0f;
 
 			set_targeted_subsys(aip, NULL, -1);


### PR DESCRIPTION
Although not used very often, ai_info.target_signature should be set to -1 whenever no target is specified, just like everywhere else in the code to make sure that the code is as predictable as possible.  It references the shipnum (afaict). Having it set to zero instead could potentially cause unwanted and unpredictable behavior, albeit in a small percentage of cases.

This seems to be a small oversight present since almost the beginning of the scripting system.

(Found while trying to figure out why the heck would the Object update packet send this ai info at all??)