### PR TITLE
Force subsystem targetting reticle to be square, even on non-square aspect ratios.

### DIFF
--- a/code/model/modelread.cpp
+++ b/code/model/modelread.cpp
@@ -3368,6 +3368,9 @@ int subobj_find_2d_bound(float radius ,matrix * /*orient*/, vec3d * pos,int *x1,
 	t = (height*Canv_h2)/pnt.world.xyz.z;
 	h = t*Matrix_scale.xyz.y;
 
+	// Use the smaller of the width and height (forces the resulting targetting reticle to be square on non-square aspect ratios).
+	w = h = (w < h) ? w : h;
+
 	if (x1) *x1 = fl2i(pnt.screen.xyw.x - w);
 	if (y1) *y1 = fl2i(pnt.screen.xyw.y - h);
 


### PR DESCRIPTION
This is a simple hack to fix an annoying problem on multi-monitor setups. As it turns out the subsystem targeting reticle is coded so it has the same width-to-height ratio as the screen the game is being played on. While on screens with a 16:9 or 4:3 aspect ratio this is fine because the reticle looks more or less square, on ultra-wide monitors or multi-monitor setups this is incredibly annoying, as shown in the following image where I'm targetting the engines on the GTCv Escher in one of the missions of the Derelict campaign while playing on my triple-monitor setup:
![image](https://user-images.githubusercontent.com/3933825/78517997-a53f5100-7784-11ea-85cf-c4fa6c498f0c.png)

The fix resolves this problem, forcing the reticle to always be square by choosing the smallest of the reticle's width/height and assigning it to height/width. This gives far more desirable results:
![image](https://user-images.githubusercontent.com/3933825/78518650-b12c1280-7786-11ea-9e85-7d0fd698ed8c.png)

Also, my changes work as intended when you get a lot closer to the target as well:
![image](https://user-images.githubusercontent.com/3933825/78519910-57c5e280-778a-11ea-8c56-dfd121466113.png)

I don't think there's any need to disable this functionality for retail FS2, since I believe that having square subsystem reticles was always the intention, and it's very unlikely this would affect gameplay otherwise.