### PR TITLE
Weapon bugfixes

### DIFF
--- a/code/io/keycontrol.cpp
+++ b/code/io/keycontrol.cpp
@@ -589,6 +589,7 @@ void debug_max_secondary_weapons(object *objp)
 			weapon_info *wip = &Weapon_info[swp->secondary_bank_weapons[index]];
 			float capacity = (float)sip->secondary_bank_ammo_capacity[index];
 			float size = (float)wip->cargo_size;
+			Assertion(size > 0.0f, "Weapon cargo size for %s must be greater than 0!", wip->name);
 			swp->secondary_bank_ammo[index] = (int)std::lround(capacity / size);
 		}
 	}
@@ -610,6 +611,7 @@ void debug_max_primary_weapons(object *objp)	// Goober5000
 			{
 				float capacity = (float)sip->primary_bank_ammo_capacity[index];
 				float size = (float)wip->cargo_size;
+				Assertion(size > 0.0f, "Weapon cargo size for %s must be greater than 0!", wip->name);
 				swp->primary_bank_ammo[index] = (int)std::lround(capacity / size);
 			}
 		}

--- a/code/io/keycontrol.cpp
+++ b/code/io/keycontrol.cpp
@@ -577,36 +577,41 @@ void debug_cycle_targeted_ship(int delta)
 
 void debug_max_secondary_weapons(object *objp)
 {
-	int index;
+	Assert(objp);
 	ship *shipp = &Ships[objp->instance];
 	ship_info *sip = &Ship_info[shipp->ship_info_index];
 	ship_weapon *swp = &shipp->weapons;
 
-	for ( index = 0; index < MAX_SHIP_SECONDARY_BANKS; index++ )
+	for (int index = 0; index < MAX_SHIP_SECONDARY_BANKS; ++index)
 	{
-		swp->secondary_bank_ammo[index] = sip->secondary_bank_ammo_capacity[index];
+		if (swp->secondary_bank_weapons[index] >= 0)
+		{
+			weapon_info *wip = &Weapon_info[swp->secondary_bank_weapons[index]];
+			float capacity = (float)sip->secondary_bank_ammo_capacity[index];
+			float size = (float)wip->cargo_size;
+			swp->secondary_bank_ammo[index] = (int)std::lround(capacity / size);
+		}
 	}
 }
 
 void debug_max_primary_weapons(object *objp)	// Goober5000
 {
-	Assert(objp);	// Goober5000
-
-	int index;
+	Assert(objp);
 	ship *shipp = &Ships[objp->instance];
 	ship_info *sip = &Ship_info[shipp->ship_info_index];
 	ship_weapon *swp = &shipp->weapons;
-	weapon_info *wip;
 
-	for ( index = 0; index < MAX_SHIP_PRIMARY_BANKS; index++ )
+	for (int index = 0; index < MAX_SHIP_PRIMARY_BANKS; ++index)
 	{
-		wip = &Weapon_info[swp->primary_bank_weapons[index]];
-		if (wip->wi_flags[Weapon::Info_Flags::Ballistic])
+		if (swp->primary_bank_weapons[index] >= 0)
 		{
-			float capacity, size;
-			capacity = (float) sip->primary_bank_ammo_capacity[index];
-			size = (float) wip->cargo_size;
-			swp->primary_bank_ammo[index] = (int)std::lround(capacity / size);
+			weapon_info *wip = &Weapon_info[swp->primary_bank_weapons[index]];
+			if (wip->wi_flags[Weapon::Info_Flags::Ballistic])
+			{
+				float capacity = (float)sip->primary_bank_ammo_capacity[index];
+				float size = (float)wip->cargo_size;
+				swp->primary_bank_ammo[index] = (int)std::lround(capacity / size);
+			}
 		}
 	}
 }

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -16063,15 +16063,18 @@ float ship_get_secondary_weapon_range(ship *shipp)
  */
 int get_max_ammo_count_for_primary_bank(int ship_class, int bank, int ammo_type)
 {
-	float capacity, size;
-	
-	if (!(Weapon_info[ammo_type].wi_flags[Weapon::Info_Flags::Ballistic]))
+	Assertion(ship_class < ship_info_size(), "Invalid ship_class of %d is >= Ship_info.size() (%d); get a coder!\n", ship_class, ship_info_size());
+	Assertion(bank < MAX_SHIP_PRIMARY_BANKS, "Invalid primary bank of %d (max is %d); get a coder!\n", bank, MAX_SHIP_PRIMARY_BANKS - 1);
+	Assertion(ammo_type < weapon_info_size(), "Invalid ammo_type of %d is >= Weapon_info.size() (%d); get a coder!\n", ammo_type, weapon_info_size());
+
+	// Invalid and non-existent weapons, and non-ballistic weapons, have capacities of 0, per ship_weapon::clear()
+	if (ship_class < 0 || bank < 0 || ammo_type < 0 || !(Weapon_info[ammo_type].wi_flags[Weapon::Info_Flags::Ballistic]))
 		return 0;
 
-	capacity = (float) Ship_info[ship_class].primary_bank_ammo_capacity[bank];
-	size = (float) Weapon_info[ammo_type].cargo_size;
+	float capacity = (float)Ship_info[ship_class].primary_bank_ammo_capacity[bank];
+	float size = (float)Weapon_info[ammo_type].cargo_size;
 	Assertion(size > 0.0f, "Weapon cargo size for %s must be greater than 0!", Weapon_info[ammo_type].name);
-	return  (int)std::lround(capacity / size);
+	return (int)std::lround(capacity / size);
 }
 
 /**
@@ -16079,20 +16082,18 @@ int get_max_ammo_count_for_primary_bank(int ship_class, int bank, int ammo_type)
  */
 int get_max_ammo_count_for_bank(int ship_class, int bank, int ammo_type)
 {
-	float capacity, size;
-
 	Assertion(ship_class < ship_info_size(), "Invalid ship_class of %d is >= Ship_info.size() (%d); get a coder!\n", ship_class, ship_info_size());
 	Assertion(bank < MAX_SHIP_SECONDARY_BANKS, "Invalid secondary bank of %d (max is %d); get a coder!\n", bank, MAX_SHIP_SECONDARY_BANKS - 1);
 	Assertion(ammo_type < weapon_info_size(), "Invalid ammo_type of %d is >= Weapon_info.size() (%d); get a coder!\n", ammo_type, weapon_info_size());
 
-	if (ship_class < 0 || bank < 0 || ammo_type < 0) {
+	// Invalid and non-existent weapons have capacities of 0, per ship_weapon::clear()
+	if (ship_class < 0 || bank < 0 || ammo_type < 0)
 		return 0;
-	} else {
-		capacity = (float) Ship_info[ship_class].secondary_bank_ammo_capacity[bank];
-		size = (float) Weapon_info[ammo_type].cargo_size;
-		Assertion(size > 0.0f, "Weapon cargo size for %s must be greater than 0!", Weapon_info[ammo_type].name);
-		return fl2ir(capacity / size);
-	}
+
+	float capacity = (float)Ship_info[ship_class].secondary_bank_ammo_capacity[bank];
+	float size = (float)Weapon_info[ammo_type].cargo_size;
+	Assertion(size > 0.0f, "Weapon cargo size for %s must be greater than 0!", Weapon_info[ammo_type].name);
+	return (int)std::lround(capacity / size);
 }
 
 /**


### PR DESCRIPTION
The crashes in #2316 were both caused by references to weapon indexes of -1, which should never have worked. Previously the game silently got away with this, but with the Weapon_info conversion to vector, index bounds are now enforced.

This PR prevents invalid index referencing in both the weapons cheat and the red-alert ammo count check.  It also does a bit of cleanup to make the functions match their counterparts.

This fixes #2316.