### PR TITLE
Fix Mantis 3171

### DIFF
--- a/code/object/waypoint.cpp
+++ b/code/object/waypoint.cpp
@@ -497,7 +497,6 @@ void waypoint_remove(waypoint *wpt)
 					break;
 				}
 			}
-			Assert(ii != Waypoint_lists.end());
 
 			// iterate through all waypoints that are in lists later than this one,
 			// and edit their instances so that they point to a list one place lower
@@ -522,7 +521,6 @@ void waypoint_remove(waypoint *wpt)
 				break;
 			}
 		}
-		Assert(ii != wp_list->get_waypoints().end());
 
 		// iterate through all waypoints that are later than this one,
 		// and edit their instances so that they point to a waypoint one place lower

--- a/fred2/fredview.cpp
+++ b/fred2/fredview.cpp
@@ -526,9 +526,11 @@ int drag_objects()
 		Dup_drag = 0;
 
 	if (Dup_drag == 1) {
-		dup_object(NULL);  // reset waypoint list
 		cobj = Duped_wing = -1;
 		flag = 0;
+
+		int duping_waypoint_list = -1;
+
 		objp = GET_FIRST(&obj_used_list);
 		while (objp != END_OF_LIST(&obj_used_list))	{
 			Assert(objp->type != OBJ_NONE);
@@ -542,6 +544,15 @@ int drag_objects()
 
 				} else
 					Duped_wing = -1;
+
+				// make sure we dup as many waypoint lists as we have
+				if (objp->type == OBJ_WAYPOINT) {
+					int this_list = calc_waypoint_list_index(objp->instance);
+					if (duping_waypoint_list != this_list) {
+						dup_object(nullptr);  // reset waypoint list
+						duping_waypoint_list = this_list;
+					}
+				}
 
 				flag = 1;
 				z = dup_object(objp);

--- a/qtfred/src/mission/EditorViewport.cpp
+++ b/qtfred/src/mission/EditorViewport.cpp
@@ -955,9 +955,11 @@ int EditorViewport::drag_objects(int x, int y)
 	}
 
 	if (Dup_drag == 1) {
-		editor->dup_object(NULL);  // reset waypoint list
 		cobj = Duped_wing = -1;
 		flag = 0;
+
+		int duping_waypoint_list = -1;
+
 		objp = GET_FIRST(&obj_used_list);
 		while (objp != END_OF_LIST(&obj_used_list))	{
 			Assert(objp->type != OBJ_NONE);
@@ -971,6 +973,15 @@ int EditorViewport::drag_objects(int x, int y)
 
 				} else
 					Duped_wing = -1;
+
+				// make sure we dup as many waypoint lists as we have
+				if (objp->type == OBJ_WAYPOINT) {
+					int this_list = calc_waypoint_list_index(objp->instance);
+					if (duping_waypoint_list != this_list) {
+						editor->dup_object(nullptr);  // reset waypoint list
+						duping_waypoint_list = this_list;
+					}
+				}
 
 				flag = 1;
 				z = editor->dup_object(objp);


### PR DESCRIPTION
See Mantis 3171:
http://scp.indiegames.us/mantis/view.php?id=3171

This PR properly resets waypoint lists as-needed so that multiple lists can be copied.

This also removes two Asserts that never worked and are not needed anyway.