### PR TITLE
prevent player leaving the loadout screen with incomplete weapons

### DIFF
--- a/code/localization/localize.cpp
+++ b/code/localization/localize.cpp
@@ -56,7 +56,7 @@ int Lcl_english = 1;
 // the english version (in the code) to a foreign version (in the table).  Thus, if you
 // add a new string to the code, you must assign it a new index.  Use the number below for
 // that index and increase the number below by one.
-#define XSTR_SIZE	1641
+#define XSTR_SIZE	1643
 
 
 // struct to allow for strings.tbl-determined x offset

--- a/code/missionui/missionshipchoice.cpp
+++ b/code/missionui/missionshipchoice.cpp
@@ -1860,7 +1860,7 @@ bool is_a_weapon_slot_empty()
 		// a ship must exist in this slot
 		if (Wss_slots[slot].ship_class >= 0)
 		{
-			for (int bank = 0; bank < MAX_SHIP_WEAPONS; bank++)
+			for (int bank = 0; bank < MAX_SHIP_WEAPONS; bank++)		// NOLINT(modernize-loop-convert)
 			{
 				// is there a weapon here?
 				if (Wss_slots[slot].wep_count[bank] <= 0)

--- a/code/missionui/missionshipchoice.cpp
+++ b/code/missionui/missionshipchoice.cpp
@@ -1853,6 +1853,25 @@ bool is_weapon_carried(int weapon_index)
 	return false;
 }
 
+bool is_a_weapon_slot_empty()
+{
+	for (int slot = 0; slot < MAX_WING_BLOCKS*MAX_WING_SLOTS; slot++)
+	{
+		// a ship must exist in this slot
+		if (Wss_slots[slot].ship_class >= 0)
+		{
+			for (int bank = 0; bank < MAX_SHIP_WEAPONS; bank++)
+			{
+				// is there a weapon here?
+				if (Wss_slots[slot].wep_count[bank] <= 0)
+					return true;
+			}
+		}
+	}
+
+	return false;
+}
+
 // ------------------------------------------------------------------------
 // commit_pressed() is called when the commit button from any of the briefing/ship select/ weapon
 // select screens is pressed.  The ship selected is created, and the interface music is stopped.
@@ -1918,6 +1937,14 @@ void commit_pressed()
 			popup(PF_USE_AFFIRMATIVE_ICON, 1, POPUP_OK, XSTR("The following weapons are required for this mission, but at least one of them has not been added to any ship loadout:\n\n%s", 1625), weapon_list.c_str());
 			return;
 		}
+	}
+
+	// Goober5000 - check that all weapon slots are filled (Mantis 2715)
+	// Note: don't check for training, scramble, or red-alert missions
+	if (is_a_weapon_slot_empty() && !(The_mission.game_type & MISSION_TYPE_TRAINING) && !The_mission.flags[Mission::Mission_Flags::Scramble] && !The_mission.flags[Mission::Mission_Flags::Red_alert])
+	{
+		popup(PF_USE_AFFIRMATIVE_ICON, 1, POPUP_OK, XSTR("At least one ship has an empty weapon bank.  All weapon banks must have weapons assigned.", 1642), weapon_list.c_str());
+		return;
 	}
 
 	// Check to ensure that the hotkeys are still pointing to valid objects.  It is possible

--- a/code/missionui/missionweaponchoice.cpp
+++ b/code/missionui/missionweaponchoice.cpp
@@ -4097,7 +4097,7 @@ void wl_apply_current_loadout_to_all_ships_in_current_wing()
 	// display error messages
 	if (error_flag)
 	{
-		SCP_string full_error_message = "The following errors were encountered:\n";
+		SCP_string full_error_message = XSTR("The following errors were encountered:\n", 1641);
 
 		size_t j;
 		bool is_duplicate;


### PR DESCRIPTION
This is the best way to address Mantis 2715.
http://scp.indiegames.us/mantis/view.php?id=2715

I took a look at allowing empty banks in the course of working on PR #2318, and it was completely intractable.  But in order to prevent certain "funnies" such as violation of bank restrictions, it's a good idea to ensure all banks are populated.

This PR adds a new XSTR for a popup message, and incidentally adds another XSTR to a message that should have had one already but didn't.