### PR TITLE
Cleaned up code that renders subsystem target boxes. (Follow-up to #2315)

### DIFF
--- a/code/model/modelread.cpp
+++ b/code/model/modelread.cpp
@@ -3340,12 +3340,15 @@ int submodel_find_2d_bound_min(int model_num,int submodel, matrix *orient, vec3d
  *
  * Note that x1,y1,x2,y2 aren't clipped to 2D screen coordinates.
  *
+ * Calculates the focal length of the camera, and uses the law of similar
+ * triangles to project the subsystem's radius to the screen.
+ *
  * @return zero if x1,y1,x2,y2 are valid
  * @return 2 for point offscreen
  */
 int subobj_find_2d_bound(float radius ,matrix * /*orient*/, vec3d * pos,int *x1, int *y1, int *x2, int *y2 )
 {
-	float w,h;
+	float w,h,focal_length;
 	vertex pnt;
 
 	g3_rotate_vertex(&pnt,pos);
@@ -3359,7 +3362,10 @@ int subobj_find_2d_bound(float radius ,matrix * /*orient*/, vec3d * pos,int *x1,
 	if (pnt.flags & PF_OVERFLOW)
 		return 2;
 
-	w = h = radius * Canv_h2 * Matrix_scale.xyz.y / pnt.world.xyz.z;
+	focal_length = Canv_h2 * Matrix_scale.xyz.y;
+	h = radius * focal_length / pnt.world.xyz.z;
+
+	w = h;
 
 	if (x1) *x1 = fl2i(pnt.screen.xyw.x - w);
 	if (y1) *y1 = fl2i(pnt.screen.xyw.y - h);

--- a/code/model/modelread.cpp
+++ b/code/model/modelread.cpp
@@ -3345,11 +3345,8 @@ int submodel_find_2d_bound_min(int model_num,int submodel, matrix *orient, vec3d
  */
 int subobj_find_2d_bound(float radius ,matrix * /*orient*/, vec3d * pos,int *x1, int *y1, int *x2, int *y2 )
 {
-	float t,w,h;
+	float w,h;
 	vertex pnt;
-
-	float width = radius;
-	float height = radius;
 
 	g3_rotate_vertex(&pnt,pos);
 
@@ -3362,14 +3359,7 @@ int subobj_find_2d_bound(float radius ,matrix * /*orient*/, vec3d * pos,int *x1,
 	if (pnt.flags & PF_OVERFLOW)
 		return 2;
 
-	t = (width * Canv_w2)/pnt.world.xyz.z;
-	w = t*Matrix_scale.xyz.x;
-
-	t = (height*Canv_h2)/pnt.world.xyz.z;
-	h = t*Matrix_scale.xyz.y;
-
-	// Use the smaller of the width and height (forces the resulting targetting reticle to be square on non-square aspect ratios).
-	w = h = (w < h) ? w : h;
+	w = h = radius * Canv_h2 * Matrix_scale.xyz.y / pnt.world.xyz.z;
 
 	if (x1) *x1 = fl2i(pnt.screen.xyw.x - w);
 	if (y1) *y1 = fl2i(pnt.screen.xyw.y - h);


### PR DESCRIPTION
A follow-up to #2315. I Verifyed that the math of the old calculations is valid, except it shouldn't calculate both the width and height of the bounding box separately (it should only calculate height and use that for both). Then I cleaned up that function a little bit, reducing the number of local variables and the number of floating-point operations.

I have tested these changes on regular resolutions (1024 x 768):
![image](https://user-images.githubusercontent.com/3933825/79087585-5d30a900-7d05-11ea-8894-9656021e4f87.png)
![image](https://user-images.githubusercontent.com/3933825/79087591-63268a00-7d05-11ea-87bb-b67aa2f406fb.png)

As well as exotic resolutions (5760 x 1080):
![image](https://user-images.githubusercontent.com/3933825/79087618-79cce100-7d05-11ea-89fe-82d70ec0c6f3.png)
![image](https://user-images.githubusercontent.com/3933825/79087626-7fc2c200-7d05-11ea-872c-2610b4e2f7a3.png)