### PR TITLE
use consistent jump node distances on HUD

### DIFF
--- a/code/hud/hudtargetbox.cpp
+++ b/code/hud/hudtargetbox.cpp
@@ -1247,7 +1247,7 @@ void HudGaugeTargetBox::renderTargetJumpNode(object *target_objp)
 		end_string_at_first_hash_symbol(outstr);
 		renderString(position[0] + Name_offsets[0], position[1] + Name_offsets[1], EG_TBOX_NAME, outstr);	
 
-		dist = vm_vec_dist_quick(&target_objp->pos, &Player_obj->pos);
+		dist = Player_ai->current_target_distance;
 		if ( Hud_unit_multiplier > 0.0f ) {	// use a different displayed distance scale
 			dist = dist * Hud_unit_multiplier;
 		}


### PR DESCRIPTION
There is a special function, `hud_find_target_distance`, which is used in most places for target distance.  However it wasn't used for jump nodes in this location.

Incidentally, the player's target's distance is cached, and this distance will always be current for the target box, so we can use the cached value and save a function call.