### PR TITLE
Disable doublefire

### DIFF
--- a/code/ai/ai_flags.h
+++ b/code/ai/ai_flags.h
@@ -85,6 +85,7 @@ namespace AI {
         Beams_damage_weapons,
         Big_ships_can_attack_beam_turrets_on_untargeted_ships,
         Disable_linked_fire_penalty,
+		Disable_player_secondary_doublefire,
 		Disable_ai_secondary_doublefire,
         Disable_weapon_damage_scaling,
         Dont_insert_random_turret_fire_delay,

--- a/code/ai/ai_flags.h
+++ b/code/ai/ai_flags.h
@@ -85,6 +85,7 @@ namespace AI {
         Beams_damage_weapons,
         Big_ships_can_attack_beam_turrets_on_untargeted_ships,
         Disable_linked_fire_penalty,
+		Disable_ai_secondary_doublefire,
         Disable_weapon_damage_scaling,
         Dont_insert_random_turret_fire_delay,
         Fix_ai_class_bug,

--- a/code/ai/ai_profiles.cpp
+++ b/code/ai/ai_profiles.cpp
@@ -375,6 +375,8 @@ void parse_ai_profiles_tbl(const char *filename)
 
 				set_flag(profile, "$disable linked fire penalty:", AI::Profile_Flags::Disable_linked_fire_penalty);
 
+				set_flag(profile, "$disable player secondary doublefire:", AI::Profile_Flags::Disable_player_secondary_doublefire);
+
 				set_flag(profile, "$disable ai secondary doublefire:", AI::Profile_Flags::Disable_ai_secondary_doublefire);
 
 				set_flag(profile, "$disable weapon damage scaling:", AI::Profile_Flags::Disable_weapon_damage_scaling);

--- a/code/ai/ai_profiles.cpp
+++ b/code/ai/ai_profiles.cpp
@@ -375,6 +375,8 @@ void parse_ai_profiles_tbl(const char *filename)
 
 				set_flag(profile, "$disable linked fire penalty:", AI::Profile_Flags::Disable_linked_fire_penalty);
 
+				set_flag(profile, "$disable ai secondary doublefire:", AI::Profile_Flags::Disable_ai_secondary_doublefire);
+
 				set_flag(profile, "$disable weapon damage scaling:", AI::Profile_Flags::Disable_weapon_damage_scaling);
 
 				set_flag(profile, "$use additive weapon velocity:", AI::Profile_Flags::Use_additive_weapon_velocity);

--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -5520,7 +5520,8 @@ void set_primary_weapon_linkage(object *objp)
 				if (!sip->flags[Ship::Info_Flags::No_primary_linking] ) {
 					shipp->flags.set(Ship::Ship_Flags::Primary_linked);
 				}
-				if (The_mission.ai_profile->flags[AI::Profile_Flags::Disable_ai_secondary_doublefire]) {
+				if (The_mission.ai_profile->flags[AI::Profile_Flags::Disable_ai_secondary_doublefire] || 
+					Weapon_info[swp->secondary_bank_weapons[swp->current_secondary_bank]].wi_flags[Weapon::Info_Flags::No_doublefire]) {
 					shipp->flags.remove(Ship::Ship_Flags::Secondary_dual_fire);
 				} else {
 					shipp->flags.set(Ship::Ship_Flags::Secondary_dual_fire);

--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -5520,7 +5520,11 @@ void set_primary_weapon_linkage(object *objp)
 				if (!sip->flags[Ship::Info_Flags::No_primary_linking] ) {
 					shipp->flags.set(Ship::Ship_Flags::Primary_linked);
 				}
-                shipp->flags.set(Ship::Ship_Flags::Secondary_dual_fire);
+				if (The_mission.ai_profile->flags[AI::Profile_Flags::Disable_ai_secondary_doublefire]) {
+					shipp->flags.remove(Ship::Ship_Flags::Secondary_dual_fire);
+				} else {
+					shipp->flags.set(Ship::Ship_Flags::Secondary_dual_fire);
+				}
 				return;
 			}
 		}

--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -5894,6 +5894,8 @@ void ai_select_secondary_weapon(object *objp, ship_weapon *swp, flagset<Weapon::
 
 
 	//	If switched banks, force reacquisition of aspect lock.
+	//	Also check if doublefire is valid for the new missile. Only checking the weapon flag
+	//  if the AI profile flag is set then it won't be set in the first place.
 	if (swp->current_secondary_bank != initial_bank) {
 		auto wi_flags = Weapon_info[swp->secondary_bank_weapons[swp->current_secondary_bank]].wi_flags;
 		aip->aspect_locked_time = 0.0f;
@@ -5901,6 +5903,7 @@ void ai_select_secondary_weapon(object *objp, ship_weapon *swp, flagset<Weapon::
 		if (Ships[objp->instance].flags[Ship::Ship_Flags::Secondary_dual_fire] &&
 			wi_flags[Weapon::Info_Flags::No_doublefire]) {
 			Ships[objp->instance].flags.remove(Ship::Ship_Flags::Secondary_dual_fire);
+		}
 	}
 
 	if (swp->current_secondary_bank >= 0 && swp->current_secondary_bank < MAX_SHIP_SECONDARY_BANKS) 

--- a/code/ai/aicode.cpp.orig
+++ b/code/ai/aicode.cpp.orig
@@ -5898,9 +5898,13 @@ void ai_select_secondary_weapon(object *objp, ship_weapon *swp, flagset<Weapon::
 		auto wi_flags = Weapon_info[swp->secondary_bank_weapons[swp->current_secondary_bank]].wi_flags;
 		aip->aspect_locked_time = 0.0f;
 		aip->current_target_is_locked = 0;
+<<<<<<< HEAD
+=======
 		if (Ships[objp->instance].flags[Ship::Ship_Flags::Secondary_dual_fire] &&
 			wi_flags[Weapon::Info_Flags::No_doublefire]) {
 			Ships[objp->instance].flags.remove(Ship::Ship_Flags::Secondary_dual_fire);
+		}
+>>>>>>> 6c8aac5fc... fixed AI doublefire enabling being erroneously linked to primary linking
 	}
 
 	if (swp->current_secondary_bank >= 0 && swp->current_secondary_bank < MAX_SHIP_SECONDARY_BANKS) 

--- a/code/ai/aicode.cpp.orig
+++ b/code/ai/aicode.cpp.orig
@@ -5894,17 +5894,21 @@ void ai_select_secondary_weapon(object *objp, ship_weapon *swp, flagset<Weapon::
 
 
 	//	If switched banks, force reacquisition of aspect lock.
+	//	Also check if doublefire is valid for the new missile. Only checking the weapon flag
+	//  if the AI profile flag is set then it won't be set in the first place.
 	if (swp->current_secondary_bank != initial_bank) {
 		auto wi_flags = Weapon_info[swp->secondary_bank_weapons[swp->current_secondary_bank]].wi_flags;
 		aip->aspect_locked_time = 0.0f;
 		aip->current_target_is_locked = 0;
-<<<<<<< HEAD
-=======
 		if (Ships[objp->instance].flags[Ship::Ship_Flags::Secondary_dual_fire] &&
+<<<<<<< HEAD
 			wi_flags[Weapon::Info_Flags::No_doublefire]) {
 			Ships[objp->instance].flags.remove(Ship::Ship_Flags::Secondary_dual_fire);
+=======
+			Weapon_info[swp->secondary_bank_weapons[swp->current_secondary_bank]].wi_flags[Weapon::Info_Flags::No_doublefire]) {
+			Ships[objp->instance].flags.remove(Ship::Ship_Flags::Secondary_dual_fire);
 		}
->>>>>>> 6c8aac5fc... fixed AI doublefire enabling being erroneously linked to primary linking
+>>>>>>> 56048d6f0... now check for doublefire validity when the AI switches secondary banks
 	}
 
 	if (swp->current_secondary_bank >= 0 && swp->current_secondary_bank < MAX_SHIP_SECONDARY_BANKS) 

--- a/code/io/keycontrol.cpp
+++ b/code/io/keycontrol.cpp
@@ -1888,8 +1888,9 @@ int button_function_critical(int n, net_player *p = NULL)
 
 			int firepoints = pm->missile_banks[Ships[objp->instance].weapons.current_secondary_bank].num_slots;
 
-            if (Ships[objp->instance].flags[Ship::Ship_Flags::Secondary_dual_fire] || firepoints < 2) {
-                Ships[objp->instance].flags.remove(Ship::Ship_Flags::Secondary_dual_fire);
+			if (Ships[objp->instance].flags[Ship::Ship_Flags::Secondary_dual_fire] || firepoints < 2 ||
+				The_mission.ai_profile->flags[AI::Profile_Flags::Disable_player_secondary_doublefire]) {
+				Ships[objp->instance].flags.remove(Ship::Ship_Flags::Secondary_dual_fire);
 				if(at_self) {
 					HUD_sourced_printf(HUD_SOURCE_HIDDEN, "%s", XSTR( "Secondary weapon set to normal fire mode", 34));
 					snd_play( gamesnd_get_game_sound(ship_get_sound(Player_obj, GameSounds::SECONDARY_CYCLE)) );

--- a/code/io/keycontrol.cpp
+++ b/code/io/keycontrol.cpp
@@ -1860,7 +1860,6 @@ int button_function_critical(int n, net_player *p = NULL)
 			if (ship_select_next_secondary(objp)) {
 				ship* shipp = &Ships[objp->instance];
 				ship_weapon* swp = &shipp->weapons;
-				ship_info* sip = &Ship_info[shipp->ship_info_index];
 				if ( timestamp_elapsed(shipp->weapons.next_secondary_fire_stamp[shipp->weapons.current_secondary_bank]) ) {
 					shipp->weapons.next_secondary_fire_stamp[shipp->weapons.current_secondary_bank] = timestamp(250);	//	1/4 second delay until can fire
 				}

--- a/code/io/keycontrol.cpp
+++ b/code/io/keycontrol.cpp
@@ -1869,7 +1869,7 @@ int button_function_critical(int n, net_player *p = NULL)
 
 				//Check if doublefire is valid for the new weapon, and disable it if not.
 				if (The_mission.ai_profile->flags[AI::Profile_Flags::Disable_player_secondary_doublefire] ||
-					(Weapon_info[current_secondary_weapon].wi_flags[Weapon::Info_Flags::No_doublefire])) {
+					Weapon_info[current_secondary_weapon].wi_flags[Weapon::Info_Flags::No_doublefire]) {
 					Ships[objp->instance].flags.remove(Ship::Ship_Flags::Secondary_dual_fire);
 				}
 
@@ -1911,8 +1911,8 @@ int button_function_critical(int n, net_player *p = NULL)
 					snd_play( gamesnd_get_game_sound(ship_get_sound(Player_obj, GameSounds::SECONDARY_CYCLE)) );
 					hud_gauge_popup_start(HUD_WEAPONS_GAUGE);
 				}
-			} else if(The_mission.ai_profile->flags[AI::Profile_Flags::Disable_player_secondary_doublefire] == false && 
-				(Weapon_info[current_secondary_weapon].wi_flags[Weapon::Info_Flags::No_doublefire] == false)) {
+			} else if(!The_mission.ai_profile->flags[AI::Profile_Flags::Disable_player_secondary_doublefire] && 
+				!Weapon_info[current_secondary_weapon].wi_flags[Weapon::Info_Flags::No_doublefire]) {
                 Ships[objp->instance].flags.set(Ship::Ship_Flags::Secondary_dual_fire);
 				if(at_self) {
 					HUD_sourced_printf(HUD_SOURCE_HIDDEN, "%s", XSTR( "Secondary weapon set to dual fire mode", 35));

--- a/code/playerman/playercontrol.cpp
+++ b/code/playerman/playercontrol.cpp
@@ -1307,6 +1307,8 @@ void player_restore_target_and_weapon_link_prefs()
 {
 	ship_info *player_sip;
 	player_sip = &Ship_info[Player_ship->ship_info_index];
+	ship_weapon* swp = &Player_ship->weapons;
+	ship_info* sip = &Ship_info[Player_ship->ship_info_index];
 	polymodel *pm = model_get(player_sip->model_num);
 
 	//	Don't restores the save flags in training, as we must ensure certain things are off, such as speed matching.
@@ -1320,7 +1322,12 @@ void player_restore_target_and_weapon_link_prefs()
 		}
 	}
 
-	if ( Player->flags & PLAYER_FLAGS_LINK_SECONDARY && (pm->n_missiles > 0 && pm->missile_banks[0].num_slots > 1) ) {
+	int current_secondary_weapon = swp->secondary_bank_weapons[swp->current_secondary_bank];
+
+	//Don't set the secondary dualfire flag if dualfire is not valid for the current secondary.
+	if ( Player->flags & PLAYER_FLAGS_LINK_SECONDARY && (pm->n_missiles > 0 && pm->missile_banks[0].num_slots > 1) && 
+			!(The_mission.ai_profile->flags[AI::Profile_Flags::Disable_player_secondary_doublefire] ||
+				Weapon_info[current_secondary_weapon].wi_flags[Weapon::Info_Flags::No_doublefire])) {
 		Player_ship->flags.set(Ship::Ship_Flags::Secondary_dual_fire);
 	}
 }

--- a/code/playerman/playercontrol.cpp
+++ b/code/playerman/playercontrol.cpp
@@ -1308,7 +1308,6 @@ void player_restore_target_and_weapon_link_prefs()
 	ship_info *player_sip;
 	player_sip = &Ship_info[Player_ship->ship_info_index];
 	ship_weapon* swp = &Player_ship->weapons;
-	ship_info* sip = &Ship_info[Player_ship->ship_info_index];
 	polymodel *pm = model_get(player_sip->model_num);
 
 	//	Don't restores the save flags in training, as we must ensure certain things are off, such as speed matching.

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -11921,7 +11921,13 @@ int ship_fire_secondary( object *obj, int allow_swarm )
 
 		int start_slot, end_slot;
 
-		if ( shipp->flags[Ship_Flags::Secondary_dual_fire] && num_slots > 1) {
+		// Checking for the secondary doublefire disabling here in case it slipped, such as being set to double fire in a previous session
+		if (The_mission.ai_profile->flags[AI::Profile_Flags::Disable_player_secondary_doublefire] &&
+			shipp->flags[Ship_Flags::Secondary_dual_fire]) {
+			shipp->flags.remove(Ship_Flags::Secondary_dual_fire);
+		}
+
+		if (shipp->flags[Ship_Flags::Secondary_dual_fire] && num_slots > 1) {
 			start_slot = swp->secondary_next_slot[bank];
 			// AL 11-19-97: Ensure enough ammo remains when firing linked secondary weapons
 			if ( check_ammo && (swp->secondary_bank_ammo[bank] < 2) ) {

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -11922,15 +11922,6 @@ int ship_fire_secondary( object *obj, int allow_swarm )
 
 		int start_slot, end_slot;
 
-		// Checking for the secondary doublefire disabling here in case it slipped, such as being set to double fire in
-		// a previous session If doublefire is set and((player double fire is disabled and this is the player) or 
-		/// (this weapon's doublefire is disabled))
-		if (shipp->flags[Ship_Flags::Secondary_dual_fire] &&
-			((The_mission.ai_profile->flags[AI::Profile_Flags::Disable_player_secondary_doublefire] &&  obj == Player_obj) ||
-			 Weapon_info[swp->secondary_bank_weapons[swp->current_secondary_bank]].wi_flags[Weapon::Info_Flags::No_doublefire])) {
-			shipp->flags.remove(Ship_Flags::Secondary_dual_fire);
-		}
-
 		if (shipp->flags[Ship_Flags::Secondary_dual_fire] && num_slots > 1) {
 			start_slot = swp->secondary_next_slot[bank];
 			// AL 11-19-97: Ensure enough ammo remains when firing linked secondary weapons

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -11922,10 +11922,12 @@ int ship_fire_secondary( object *obj, int allow_swarm )
 
 		int start_slot, end_slot;
 
-		// Checking for the secondary doublefire disabling here in case it slipped, such as being set to double fire in a previous session
-		if ((The_mission.ai_profile->flags[AI::Profile_Flags::Disable_player_secondary_doublefire] || 
-			Weapon_info[swp->secondary_bank_weapons[swp->current_secondary_bank]].wi_flags[Weapon::Info_Flags::No_doublefire]) &&
-			shipp->flags[Ship_Flags::Secondary_dual_fire]) {
+		// Checking for the secondary doublefire disabling here in case it slipped, such as being set to double fire in
+		// a previous session If doublefire is set and((player double fire is disabled and this is the player) or 
+		/// (this weapon's doublefire is disabled))
+		if (shipp->flags[Ship_Flags::Secondary_dual_fire] &&
+			((The_mission.ai_profile->flags[AI::Profile_Flags::Disable_player_secondary_doublefire] &&  obj == Player_obj) ||
+			 Weapon_info[swp->secondary_bank_weapons[swp->current_secondary_bank]].wi_flags[Weapon::Info_Flags::No_doublefire])) {
 			shipp->flags.remove(Ship_Flags::Secondary_dual_fire);
 		}
 

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -446,6 +446,7 @@ flag_def_list_new<Weapon::Info_Flags> ai_tgt_weapon_flags[] = {
     { "big ship",					Weapon::Info_Flags::Big_only,							true, false },
     { "child",						Weapon::Info_Flags::Child,								true, false },
     { "no dumbfire",				Weapon::Info_Flags::No_dumbfire,						true, false },
+	{ "no doublefire",				Weapon::Info_Flags::No_doublefire,						true, false },
     { "thruster",					Weapon::Info_Flags::Thruster,							true, false },
     { "in tech database",			Weapon::Info_Flags::In_tech_database,					true, false },
     { "player allowed",				Weapon::Info_Flags::Player_allowed,						true, false },
@@ -11922,7 +11923,8 @@ int ship_fire_secondary( object *obj, int allow_swarm )
 		int start_slot, end_slot;
 
 		// Checking for the secondary doublefire disabling here in case it slipped, such as being set to double fire in a previous session
-		if (The_mission.ai_profile->flags[AI::Profile_Flags::Disable_player_secondary_doublefire] &&
+		if ((The_mission.ai_profile->flags[AI::Profile_Flags::Disable_player_secondary_doublefire] || 
+			Weapon_info[swp->secondary_bank_weapons[swp->current_secondary_bank]].wi_flags[Weapon::Info_Flags::No_doublefire]) &&
 			shipp->flags[Ship_Flags::Secondary_dual_fire]) {
 			shipp->flags.remove(Ship_Flags::Secondary_dual_fire);
 		}

--- a/code/weapon/weapon_flags.h
+++ b/code/weapon/weapon_flags.h
@@ -23,6 +23,7 @@ namespace Weapon {
 		Bomb,								// Bomb-type missile, can be targeted
 		Huge,								// Huge damage (generally 500+), probably only fired at huge ships.
 		No_dumbfire,						// Missile cannot be fired dumbfire (ie requires aspect lock)
+		No_doublefire,						// Disables linked firing for secondaries - EatThePath
 		Thruster,							// Has thruster cone and/or glow
 		In_tech_database,
 		Player_allowed,						// allowed to be on starting wing ships/in weaponry pool

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -115,6 +115,7 @@ flag_def_list_new<Weapon::Info_Flags> Weapon_Info_Flags[] = {
     { "child",							Weapon::Info_Flags::Child,								true, false },
     { "bomb",							Weapon::Info_Flags::Bomb,								true, false },
     { "no dumbfire",					Weapon::Info_Flags::No_dumbfire,						true, false },
+	{ "no doublefire",					Weapon::Info_Flags::No_doublefire,						true, false },
     { "in tech database",				Weapon::Info_Flags::In_tech_database,					true, false },
     { "player allowed",					Weapon::Info_Flags::Player_allowed,                     true, false },
     { "particle spew",					Weapon::Info_Flags::Particle_spew,						true, false },


### PR DESCRIPTION
Implements the requested features in #1851 

Doublefiring can be turned off for AIs and/or players separately through AI profiles flags. Went with that instead of gamesettings largely because that seems consistent with other similar behavior options, and I can conceivably see someone wanting to vary it between missions. 

It can also be turned off on a per-weapon basis through a new weapon flag.