### PR TITLE
add an ai-profiles flag to govern the Mantis 3147 fix

### DIFF
--- a/code/ai/ai_flags.h
+++ b/code/ai/ai_flags.h
@@ -91,6 +91,7 @@ namespace AI {
         Fix_ai_path_order_bug,
         Fix_heat_seeker_stealth_bug,
         Fix_linked_primary_bug,
+		Fix_ramming_stationary_targets_bug,
         Force_beam_turret_fov,
 		Free_afterburner_use,
         Glide_decay_requires_thrust,

--- a/code/ai/ai_profiles.cpp
+++ b/code/ai/ai_profiles.cpp
@@ -627,8 +627,8 @@ void ai_profile_t::reset()
         detail_distance_mult[i] = 0;
     }
 
-	// via Github #2332, enable bugfixes if we are targeting > 19.0
-	if (Targetted_version > gameversion::version(19)) {
+	// via Github #2332, enable bugfixes if we are targeting version 20 and up
+	if (mod_supports_version(20, 0, 0)) {
 		flags.set(AI::Profile_Flags::Huge_turret_weapons_ignore_bombs);
 		flags.set(AI::Profile_Flags::Fix_linked_primary_bug);
 		flags.set(AI::Profile_Flags::Prevent_targeting_bombs_beyond_range);
@@ -641,7 +641,7 @@ void ai_profile_t::reset()
 		flags.set(AI::Profile_Flags::Use_actual_primary_range);
 	}
 	// this flag has been enabled ever since 3.7.2
-	if (Targetted_version >= gameversion::version(3, 7, 2)) {
+	if (mod_supports_version(3, 7, 2)) {
 		flags.set(AI::Profile_Flags::Fix_ramming_stationary_targets_bug);
 	}
 }

--- a/code/ai/ai_profiles.cpp
+++ b/code/ai/ai_profiles.cpp
@@ -7,11 +7,11 @@
 
 
 
-#include "globalincs/pstypes.h"
-#include "def_files/def_files.h"
 #include "ai/ai_profiles.h"
+#include "def_files/def_files.h"
 #include "globalincs/pstypes.h"
 #include "localization/localize.h"
+#include "mod_table/mod_table.h"
 #include "parse/parselo.h"
 #include "ship/ship.h"
 #include "weapon/weapon.h"
@@ -626,4 +626,22 @@ void ai_profile_t::reset()
     for (int i = 0; i <= MAX_DETAIL_LEVEL; ++i) {
         detail_distance_mult[i] = 0;
     }
+
+	// via Github #2332, enable bugfixes if we are targeting > 19.0
+	if (Targetted_version > gameversion::version(19)) {
+		flags.set(AI::Profile_Flags::Huge_turret_weapons_ignore_bombs);
+		flags.set(AI::Profile_Flags::Fix_linked_primary_bug);
+		flags.set(AI::Profile_Flags::Prevent_targeting_bombs_beyond_range);
+		flags.set(AI::Profile_Flags::Fix_heat_seeker_stealth_bug);
+		flags.set(AI::Profile_Flags::Allow_vertical_dodge);
+		flags.set(AI::Profile_Flags::Fix_ai_class_bug);
+		flags.set(AI::Profile_Flags::Ai_guards_specific_ship_in_wing);
+		flags.set(AI::Profile_Flags::Fix_ai_path_order_bug);
+		flags.set(AI::Profile_Flags::Aspect_invulnerability_fix);
+		flags.set(AI::Profile_Flags::Use_actual_primary_range);
+	}
+	// this flag has been enabled ever since 3.7.2
+	if (Targetted_version >= gameversion::version(3, 7, 2)) {
+		flags.set(AI::Profile_Flags::Fix_ramming_stationary_targets_bug);
+	}
 }

--- a/code/ai/ai_profiles.cpp
+++ b/code/ai/ai_profiles.cpp
@@ -391,6 +391,8 @@ void parse_ai_profiles_tbl(const char *filename)
 
 				set_flag(profile, "$fix linked primary weapon decision bug:", AI::Profile_Flags::Fix_linked_primary_bug);
 
+				set_flag(profile, "$fix ramming stationary targets bug:", AI::Profile_Flags::Fix_ramming_stationary_targets_bug);
+
 				set_flag(profile, "$prevent turrets targeting too distant bombs:", AI::Profile_Flags::Prevent_targeting_bombs_beyond_range);
 
 				set_flag(profile, "$smart subsystem targeting for turrets:", AI::Profile_Flags::Smart_subsystem_targeting_for_turrets);

--- a/code/globalincs/version.h
+++ b/code/globalincs/version.h
@@ -55,7 +55,7 @@ struct version {
 
 	version() = default;
 
-	version(int major, int minor, int build, int revision);
+	version(int major, int minor = 0, int build = 0, int revision = 0);
 
 	bool isValid() const;
 

--- a/code/mod_table/mod_table.h
+++ b/code/mod_table/mod_table.h
@@ -8,6 +8,7 @@
 #include "globalincs/globals.h"
 #include "globalincs/pstypes.h"
 #include "globalincs/systemvars.h"
+#include "globalincs/version.h"
 
 extern int Directive_wait_time;
 extern bool True_loop_argument_sexps;
@@ -31,6 +32,7 @@ extern bool Red_alert_applies_to_delayed_ships;
 extern bool Beams_use_damage_factors;
 extern float Generic_pain_flash_factor;
 extern float Shield_pain_flash_factor;
+extern gameversion::version Targetted_version;
 extern SCP_string Window_title;
 extern bool Unicode_text_mode;
 extern SCP_string Movie_subtitle_font;

--- a/code/mod_table/mod_table.h
+++ b/code/mod_table/mod_table.h
@@ -8,7 +8,6 @@
 #include "globalincs/globals.h"
 #include "globalincs/pstypes.h"
 #include "globalincs/systemvars.h"
-#include "globalincs/version.h"
 
 extern int Directive_wait_time;
 extern bool True_loop_argument_sexps;
@@ -32,7 +31,6 @@ extern bool Red_alert_applies_to_delayed_ships;
 extern bool Beams_use_damage_factors;
 extern float Generic_pain_flash_factor;
 extern float Shield_pain_flash_factor;
-extern gameversion::version Targetted_version;
 extern SCP_string Window_title;
 extern bool Unicode_text_mode;
 extern SCP_string Movie_subtitle_font;


### PR DESCRIPTION
See Mantis 3147:
http://scp.indiegames.us/mantis/view.php?id=3147

I was awaiting a response, and then a response never happened. :)  So I implemented the flag myself.  The new flag should enable the fixed behavior when active, and default to retail behavior when inactive.

The original changes were committed in SVN revision 11284.  Here is the diff from that revision:

```
Index: aicode.cpp
===================================================================
--- aicode.cpp	(revision 11283)
+++ aicode.cpp	(revision 11284)
@@ -5644,7 +5644,7 @@
 	float	dot;
 	vec3d	v2t;
 
-	if (!( vm_vec_mag_quick(&G_predicted_pos) < AICODE_SMALL_MAGNITUDE )) {
+	if ( !(vm_vec_mag_quick(&G_predicted_pos) < AICODE_SMALL_MAGNITUDE ) && !(aip->submode == SM_AVOID) ) {
 		if ( vm_vec_cmp(&G_predicted_pos, &G_fire_pos) ) {
 			vm_vec_normalized_dir(&v2t, &G_predicted_pos, &G_fire_pos);
 			dot = vm_vec_dot(&v2t, &objp->orient.vec.fvec);
@@ -8238,8 +8238,12 @@
 
 	//	If seeking lock, try to point directly at ship, else predict position so lasers can hit it.
 	//	If just acquired target, or target is not in reasonable cone, don't refine believed enemy position.
-	if ((real_dot_to_enemy < 0.25f) || (aip->target_time < 1.0f) || (aip->ai_flags & AIF_SEEK_LOCK)) {
+	if ((real_dot_to_enemy < 0.25f) || (aip->target_time < 1.0f)) {
 		predicted_enemy_pos = enemy_pos;
+	} else if (aip->ai_flags & AIF_SEEK_LOCK) {
+		set_predicted_enemy_pos(&predicted_enemy_pos, Pl_objp, &aip->last_aim_enemy_pos, &aip->last_aim_enemy_vel, aip);	// Set G_fire_pos
+		predicted_enemy_pos = enemy_pos;
+		G_predicted_pos = predicted_enemy_pos;
 	} else {
 		//	Set predicted_enemy_pos.
 		//	See if attacking a subsystem.
```