### PR TITLE
add +Hotkey Team: to override IFF designation in hotkey list

### DIFF
--- a/code/iff_defs/iff_defs.cpp
+++ b/code/iff_defs/iff_defs.cpp
@@ -360,6 +360,23 @@ void iff_init()
 				num_observed_colors[cur_iff]++;
 			}
 
+			// get F3 override
+			iff->hotkey_team = IFF_hotkey_team::Default;
+			if (optional_string("+Hotkey Team:"))
+			{
+				char temp[NAME_LENGTH];
+				stuff_string(temp, F_NAME, NAME_LENGTH);
+
+				if (!stricmp(temp, "Friendly"))
+					iff->hotkey_team = IFF_hotkey_team::Friendly;
+				else if (!stricmp(temp, "Hostile") || !stricmp(temp, "Enemy"))
+					iff->hotkey_team = IFF_hotkey_team::Hostile;
+				else if (!stricmp(temp, "None"))
+					iff->hotkey_team = IFF_hotkey_team::None;
+				else
+					Warning(LOCATION, "Unrecognized +Hotkey Tean: %s\n", temp);
+			}
+
 
 			// get flags ----------------------------------------------------------
 

--- a/code/iff_defs/iff_defs.cpp
+++ b/code/iff_defs/iff_defs.cpp
@@ -577,10 +577,8 @@ int iff_get_attacker_mask(int attackee_team)
  *
  * @param team_x Team of attacker
  * @param team_y Team of attackee
- *
- * @return >0 if true, 0 if false
  */
-int iff_x_attacks_y(int team_x, int team_y)
+bool iff_x_attacks_y(int team_x, int team_y)
 {
 	return iff_matches_mask(team_y, iff_get_attackee_mask(team_x));
 }
@@ -600,12 +598,10 @@ int iff_get_mask(int team)
  *
  * @param team Team to test
  * @param mask Mask
- *
- * @return 1 if matches, 0 if does not match
  */
-int iff_matches_mask(int team, int mask)
+bool iff_matches_mask(int team, int mask)
 {
-	return (iff_get_mask(team) & mask) ? 1 : 0;
+	return (iff_get_mask(team) & mask) != 0;
 }
 
 /**

--- a/code/iff_defs/iff_defs.h
+++ b/code/iff_defs/iff_defs.h
@@ -77,11 +77,11 @@ extern int iff_lookup(const char *iff_name);
 // If he fires at you, you don't react unless you are coded to attack him, because you are oblivious.
 extern int iff_get_attackee_mask(int attacker_team);
 extern int iff_get_attacker_mask(int attackee_team);
-extern int iff_x_attacks_y(int team_x, int team_y);
+extern bool iff_x_attacks_y(int team_x, int team_y);
 
 // mask stuff
 extern int iff_get_mask(int team);
-extern int iff_matches_mask(int team, int mask);
+extern bool iff_matches_mask(int team, int mask);
 
 // get color stuff
 extern color *iff_get_color(int color_index, int is_bright);

--- a/code/iff_defs/iff_defs.h
+++ b/code/iff_defs/iff_defs.h
@@ -22,6 +22,8 @@ class object;
 #define IFF_COLOR_TAGGED			2
 #define MAX_IFF_COLORS				(MAX_IFFS + 3)
 
+enum IFF_hotkey_team { Default = -1, None = 0, Friendly, Hostile };
+
 // iff flags
 #define IFFF_SUPPORT_ALLOWED				(1 << 0)	// this IFF can call for support
 #define IFFF_EXEMPT_FROM_ALL_TEAMS_AT_WAR	(1 << 1)	// self-explanatory
@@ -41,6 +43,7 @@ typedef struct iff_info {
 	int attackee_bitmask;						// treat this as private and use iff_get_attackee_mask or iff_x_attacks_y
 	int attackee_bitmask_all_teams_at_war;		// treat this as private and use iff_get_attackee_mask or iff_x_attacks_y
 	int observed_color_index[MAX_IFFS];			// treat this as private and use iff_get_color or iff_get_color_by_team
+	IFF_hotkey_team hotkey_team;
 
 	// flags
 	int flags;

--- a/code/scripting/api/objs/team.cpp
+++ b/code/scripting/api/objs/team.cpp
@@ -73,7 +73,7 @@ ADE_FUNC(attacks, l_Team, "team", "Checks the IFF status of another team", "bool
 {
 	int x, y;
 	ade_get_args(L, "oo", l_Team.Get(&x), l_Team.Get(&y));
-	if (iff_x_attacks_y(x, y) > 0)
+	if (iff_x_attacks_y(x, y))
 		return ADE_RETURN_TRUE;
 
 	return ADE_RETURN_FALSE;


### PR DESCRIPTION
This is in response to Mantis 1424:
http://scp.indiegames.us/mantis/view.php?id=1424

Since retail, the hotkey lists have been determined based on what attacks the player.  Mod makers may want to change this, so this PR adds the following options:

* Default - retail behavior
* Friendly/Enemy (or Hostile) - display in the specified list regardless of who attacks whom
* None - don't display in the hotkey list at all

This PR also slightly cleans up the hotkey list function with a small optimization and a few tweaky fixes for edge cases.