### PR TITLE
Reinstates necessary soundtrack function call on level load

### DIFF
--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -1224,6 +1224,9 @@ void freespace_mission_load_stuff()
 	
 		mprintf(( "=================== STARTING LEVEL DATA LOAD ==================\n" ));
 
+		game_busy( NOX("** setting up event music **") );
+		event_music_level_start(-1);	// preloads the first 2 seconds for each event music track
+
 		game_busy( NOX("** unloading interface sounds **") );
 		gamesnd_unload_interface_sounds();		// unload interface sounds from memory
 


### PR DESCRIPTION
This updates #2299 and restores the use of `event_music_level_start(-1)` in `freespace.cpp`. This call was removed in #2299 because it was thought to be redundant but removal of that call resulted in music not playing upon mission restarts. This PR restores that call and fixes that issue (tested and confirmed with multiple restarts).