### PR TITLE
Adds Scaling for Target Box Models Separate from Techroom

### DIFF
--- a/code/hud/hudtargetbox.cpp
+++ b/code/hud/hudtargetbox.cpp
@@ -549,7 +549,7 @@ void HudGaugeTargetBox::renderTargetShip(object *target_objp)
 		vm_vec_sub(&orient_vec, &target_objp->pos, &Player_obj->pos);
 		vm_vec_normalize(&orient_vec);
 
-		factor = -target_sip->closeup_pos.xyz.z;
+		factor = -target_sip->closeup_pos_targetbox.xyz.z;
 
 		// use the player's up vector, and construct the viewers orientation matrix
 		if (Player_obj->type == OBJ_SHIP) {
@@ -567,7 +567,7 @@ void HudGaugeTargetBox::renderTargetShip(object *target_objp)
 		vm_vec_copy_scale(&obj_pos,&orient_vec,factor);
 
 		// RT, changed scaling here
-		renderTargetSetup(&camera_eye, &camera_orient, target_sip->closeup_zoom);
+		renderTargetSetup(&camera_eye, &camera_orient, target_sip->closeup_zoom_targetbox);
 
 		// IMPORTANT NOTE! Code handling the case 'missile_view == TRUE' in rendering section of renderTargetWeapon()
 		//                 is largely copied over from renderTargetShip(). To keep the codes similar please update

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -3679,9 +3679,9 @@ static void parse_ship_values(ship_info* sip, const bool is_template, const bool
 	{
 		stuff_vec3d(&sip->closeup_pos_targetbox);
 	} 
-	else 
+	else if (first_time)
 	{ 
-		vm_vec_copy_scale(&sip->closeup_pos_targetbox, &sip->closeup_pos, 1.0f);
+		sip->closeup_pos_targetbox = sip->closeup_pos;
 	}
 
 	if (optional_string("$Closeup_zoom_targetbox:")) {
@@ -3692,7 +3692,7 @@ static void parse_ship_values(ship_info* sip, const bool is_template, const bool
 			sip->closeup_zoom_targetbox = 0.5f;
 		}
 	}
-	else
+	else if (first_time)
 	{
 		sip->closeup_zoom_targetbox = sip->closeup_zoom;
 	}

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -945,6 +945,9 @@ void ship_info::clone(const ship_info& other)
 	closeup_pos = other.closeup_pos;
 	closeup_zoom = other.closeup_zoom;
 
+	closeup_pos_targetbox = other.closeup_pos_targetbox;
+	closeup_zoom_targetbox = other.closeup_zoom_targetbox;
+
 	memcpy(allowed_weapons, other.allowed_weapons, sizeof(int) * MAX_WEAPON_TYPES);
 
 	memcpy(restricted_loadout_flag, other.restricted_loadout_flag, sizeof(int) * MAX_SHIP_WEAPONS);
@@ -1226,6 +1229,9 @@ void ship_info::move(ship_info&& other)
 
 	std::swap(closeup_pos, other.closeup_pos);
 	closeup_zoom = other.closeup_zoom;
+
+	std::swap(closeup_pos_targetbox, other.closeup_pos_targetbox);
+	closeup_zoom_targetbox = other.closeup_zoom_targetbox;
 
 	std::swap(allowed_weapons, other.allowed_weapons);
 
@@ -1609,6 +1615,9 @@ ship_info::ship_info()
 
 	vm_vec_zero(&closeup_pos);
 	closeup_zoom = 0.5f;
+
+	vm_vec_zero(&closeup_pos_targetbox);
+	closeup_zoom_targetbox = 0.5f;
 
 	memset(allowed_weapons, 0, sizeof(int) * MAX_WEAPON_TYPES);
 
@@ -3664,6 +3673,28 @@ static void parse_ship_values(ship_info* sip, const bool is_template, const bool
 			mprintf(("Warning!  Ship '%s' has a $Closeup_zoom value that is less than or equal to 0 (%f). Setting to default value.\n", sip->name, sip->closeup_zoom));
 			sip->closeup_zoom = 0.5f;
 		}
+	}
+
+	if(optional_string("$Closeup_pos_targetbox:"))
+	{
+		stuff_vec3d(&sip->closeup_pos_targetbox);
+	} 
+	else 
+	{ 
+		vm_vec_copy_scale(&sip->closeup_pos_targetbox, &sip->closeup_pos, 1.0f);
+	}
+
+	if (optional_string("$Closeup_zoom_targetbox:")) {
+		stuff_float(&sip->closeup_zoom_targetbox);
+
+		if (sip->closeup_zoom_targetbox <= 0.0f) {
+			mprintf(("Warning!  Ship '%s' has a $Closeup_zoom_targetbox value that is less than or equal to 0 (%f). Setting to default value.\n", sip->name, sip->closeup_zoom_targetbox));
+			sip->closeup_zoom_targetbox = 0.5f;
+		}
+	}
+	else
+	{
+		sip->closeup_zoom_targetbox = sip->closeup_zoom;
 	}
 		
 	if(optional_string("$Topdown offset:")) {

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -1078,8 +1078,11 @@ public:
 	float	sup_shield_repair_rate;
 	float	sup_subsys_repair_rate;
 
-	vec3d	closeup_pos;					// position for camera when using ship in closeup view (eg briefing and hud target monitor)
-	float		closeup_zoom;					// zoom when using ship in closeup view (eg briefing and hud target monitor)
+	vec3d	closeup_pos;					// position for camera when using ship in closeup view (eg briefing and techroom)
+	float	closeup_zoom;					// zoom when using ship in closeup view (eg briefing and techroom)
+
+	vec3d	closeup_pos_targetbox;			// position for camera when using ship in closeup view for hud target monitor
+	float	closeup_zoom_targetbox;			// zoom when using ship in closeup view for hud target monitor
 
 	int		allowed_weapons[MAX_WEAPON_TYPES];	// array which specifies which weapons can be loaded out by the
 												// player during weapons loadout.


### PR DESCRIPTION
Currently `$Closeup_Pos:` and `$Closeup_Zoom:` control the camera zoom and position values for the Techroom, briefing, and HUD Target Box. Unfortunately, with very large long ships this results in an issue, to fit the view of an entire big ship in the HUD Target Box the zoom and position must be set a certain way which results in the ship looking very far away when viewed in the Techroom. This PR adds two new fields, `$Closeup_pos_targetbox:` and `$Closeup_Zoom_targetbox:`, that control camera position and zoom but only for the HUD Target Box. Now modders can set values for both and have the ships look properly zoomed in both the Techroom and HUD Target Box. The new HUD Target Box values are optional, and if not specified they default to the values for `$Closeup_Pos:` and `$Closeup_Zoom:` . I have tested and everything works as expected. 