### PR TITLE
implement Mantis 1947, treat ship comm systems the same as player comm systems

### DIFF
--- a/code/ai/ai_flags.h
+++ b/code/ai/ai_flags.h
@@ -84,6 +84,7 @@ namespace AI {
         Assist_scoring_scales_with_damage,
         Beams_damage_weapons,
         Big_ships_can_attack_beam_turrets_on_untargeted_ships,
+		Check_comms_for_non_player_ships,
         Disable_linked_fire_penalty,
         Disable_weapon_damage_scaling,
         Dont_insert_random_turret_fire_delay,

--- a/code/ai/ai_profiles.cpp
+++ b/code/ai/ai_profiles.cpp
@@ -371,6 +371,8 @@ void parse_ai_profiles_tbl(const char *filename)
 
 				set_flag(profile, "$navigation subsystem governs warpout capability:", AI::Profile_Flags::Navigation_subsys_governs_warp);
 
+				set_flag(profile, "$check communications for non-player ships:", AI::Profile_Flags::Check_comms_for_non_player_ships);
+
 				set_flag(profile, "$ignore lower bound for minimum speed of docked ship:", AI::Profile_Flags::No_min_dock_speed_cap);
 
 				set_flag(profile, "$disable linked fire penalty:", AI::Profile_Flags::Disable_linked_fire_penalty);

--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -66,6 +66,7 @@
 #include "ship/ship.h"
 #include "ship/shipfx.h"
 #include "ship/shiphit.h"
+#include "ship/subsysdamage.h"
 #include "weapon/beam.h"
 #include "weapon/flak.h"
 #include "weapon/swarm.h"
@@ -14526,6 +14527,9 @@ void process_friendly_hit_message( int message, object *objp )
 
 	// If the ship can't send messages pick someone else
 	if (Ships[objp->instance].flags[Ship::Ship_Flags::No_builtin_messages]) {
+		index = -1;
+	}
+	if (The_mission.ai_profile->flags[AI::Profile_Flags::Check_comms_for_non_player_ships] && hud_communications_state(&Ships[objp->instance]) <= COMM_DAMAGED) {
 		index = -1;
 	}
 

--- a/code/hud/hudsquadmsg.cpp
+++ b/code/hud/hudsquadmsg.cpp
@@ -238,8 +238,8 @@ SCP_vector<squadmsg_history> Squadmsg_history;
 // forward declarations
 void hud_add_issued_order(const char *name, int order);
 void hud_update_last_order(char *target, int order_source, int special_index);
-bool hud_squadmsg_is_target_order_valid(int order, int find_order, ai_info *aip = nullptr );
-bool hud_squadmsg_ship_valid(ship *shipp, object *objp);
+bool hud_squadmsg_is_target_order_valid(int order, int find_order, ai_info *aip = nullptr);
+bool hud_squadmsg_ship_valid(ship *shipp, object *objp = nullptr);
 bool hud_squadmsg_ship_order_valid( int shipnum, int order );
 
 // function to set up variables needed when messaging mode is started
@@ -426,7 +426,7 @@ bool hud_squadmsg_wing_valid(wing *wingp)
 		Assert(ship_num >= 0);
 
 		// if at least one ship in this wing is valid, that's all we need
-		if (hud_squadmsg_ship_valid(&Ships[ship_num], &Objects[Ships[ship_num].objnum]))
+		if (hud_squadmsg_ship_valid(&Ships[ship_num]))
 			return true;
 	}
 

--- a/code/hud/hudtarget.cpp
+++ b/code/hud/hudtarget.cpp
@@ -4556,7 +4556,7 @@ int hud_sensors_ok(ship *sp, int show_msg)
 	}
 }
 
-int hud_communications_state(ship *sp)
+int hud_communications_state(ship *sp, bool for_death_scream)
 {
 	float str;
 
@@ -4570,7 +4570,7 @@ int hud_communications_state(ship *sp)
 	if ((sp == Player_ship) && (sp->flags[Ship::Ship_Flags::Dying]))
 		return COMM_OK;
 
-	str = ship_get_subsystem_strength( sp, SUBSYSTEM_COMMUNICATION );
+	str = ship_get_subsystem_strength( sp, SUBSYSTEM_COMMUNICATION, for_death_scream );
 
 	if ( (str <= 0.01) || ship_subsys_disrupted(sp, SUBSYSTEM_COMMUNICATION) ) {
 		return COMM_DESTROYED;

--- a/code/hud/hudtarget.cpp
+++ b/code/hud/hudtarget.cpp
@@ -4570,10 +4570,6 @@ int hud_communications_state(ship *sp)
 	if ((sp == Player_ship) && (sp->flags[Ship::Ship_Flags::Dying]))
 		return COMM_OK;
 
-	// Goober5000 - check for scrambled communications
-	if ( emp_active_local() || sp->flags[Ship::Ship_Flags::Scramble_messages] )
-		return COMM_SCRAMBLED;
-
 	str = ship_get_subsystem_strength( sp, SUBSYSTEM_COMMUNICATION );
 
 	if ( (str <= 0.01) || ship_subsys_disrupted(sp, SUBSYSTEM_COMMUNICATION) ) {
@@ -4581,6 +4577,10 @@ int hud_communications_state(ship *sp)
 	} else if ( str < MIN_COMM_STR_TO_MESSAGE ) {
 		return COMM_DAMAGED;
 	}
+
+	// Goober5000 - check for scrambled communications
+	if (emp_active_local() || sp->flags[Ship::Ship_Flags::Scramble_messages])
+		return COMM_SCRAMBLED;
 
 	return COMM_OK;
 }

--- a/code/hud/hudtarget.h
+++ b/code/hud/hudtarget.h
@@ -125,7 +125,7 @@ void hud_update_weapon_flash();
 void hud_process_homing_missiles(void);
 
 int hud_sensors_ok(ship *sp, int show_msg = 1);
-int hud_communications_state(ship *sp);
+int hud_communications_state(ship *sp, bool for_death_scream = false);
 
 int hud_get_best_primary_bank(float *range);
 void hud_target_toggle_hidden_from_sensors();

--- a/code/mission/missionmessage.cpp
+++ b/code/mission/missionmessage.cpp
@@ -864,9 +864,8 @@ void message_kill_all( int kill_all )
 
 	if ( kill_all ) {
 		Num_messages_playing = 0;
+		fsspeech_stop();
 	}
-
-	fsspeech_stop();
 }
 
 // function to kill nth playing message

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -10579,8 +10579,6 @@ int ship_stop_fire_primary(object * obj)
 
 int tracers[MAX_SHIPS][4][4];
 
-float ship_get_subsystem_strength( ship *shipp, int type );
-
 /**
  * Checks whether a ship would use autoaim if it were to fire its primaries at
  * the given object, taking lead into account.
@@ -13272,7 +13270,7 @@ int ship_get_subsys_index(ship *shipp, ship_subsys *subsys)
 // 0.0 and 1.0 which is the relative combined strength of the given subsystem type.  The number
 // calculated for the engines is slightly different.  Once an engine reaches < 15% of its hits, its
 // output drops to that %.  A dead engine has no output.
-float ship_get_subsystem_strength( ship *shipp, int type )
+float ship_get_subsystem_strength( ship *shipp, int type, bool skip_dying_check )
 {
 	float strength;
 	ship_subsys *ssp;
@@ -13280,7 +13278,7 @@ float ship_get_subsystem_strength( ship *shipp, int type )
 	Assert ( (type >= 0) && (type < SUBSYSTEM_MAX) );
 
 	//	For a dying ship, all subsystem strengths are zero.
-	if (Objects[shipp->objnum].hull_strength <= 0.0f)
+	if (Objects[shipp->objnum].hull_strength <= 0.0f && !skip_dying_check)
 		return 0.0f;
 
 	// short circuit 1

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -1492,7 +1492,7 @@ extern ship_subsys *ship_get_indexed_subsys( ship *sp, int index, vec3d *attacke
 extern int ship_get_index_from_subsys(ship_subsys *ssp, int objnum);
 extern int ship_get_subsys_index(ship *sp, const char* ss_name);		// returns numerical index in linked list of subsystems
 extern int ship_get_subsys_index(ship *shipp, ship_subsys *subsys);
-extern float ship_get_subsystem_strength( ship *shipp, int type );
+extern float ship_get_subsystem_strength( ship *shipp, int type, bool skip_dying_check = false );
 extern ship_subsys *ship_get_subsys(ship *shipp, const char *subsys_name);
 extern int ship_get_num_subsys(ship *shipp);
 extern ship_subsys *ship_get_closest_subsys_in_sight(ship *sp, int subsys_type, vec3d *attacker_pos);

--- a/code/sound/voicerec.cpp
+++ b/code/sound/voicerec.cpp
@@ -56,7 +56,7 @@ extern int button_function(int n);
 extern void hud_squadmsg_msg_all_fighters();
 extern void hud_squadmsg_shortcut( int command );
 extern bool hud_squadmsg_ship_valid(ship *shipp, object *objp = nullptr);
-extern int hud_squadmsg_wing_valid(wing *wingp);
+extern bool hud_squadmsg_wing_valid(wing *wingp);
 
 extern int Msg_instance;;
 extern int Msg_shortcut_command;


### PR DESCRIPTION
This adds an ai_profiles flag that checks comm systems for non-player ships.  If their comm system is damaged, they will not send messages and you will not be able to issue squadmsg orders.

See also:
http://scp.indiegames.us/mantis/view.php?id=1947

Also, this PR fixes a few bugs:
1) message scramble status incorrectly took priority over subsystem health status
2) synthesized speech could be stopped when only the head animation needed to be stopped
3) don't allow messages that are never played to delay messages that *are* played