### PR TITLE
implement XSTR check as described in Mantis 2942

### DIFF
--- a/code/localization/localize.cpp
+++ b/code/localization/localize.cpp
@@ -815,7 +815,7 @@ bool lcl_ext_localize_sub(const SCP_string &in, SCP_string &text_str, SCP_string
 // Goober5000 - wrapper for lcl_ext_localize_sub; used because lcl_replace_stuff has to
 // be called *after* the translation is done, and the original function returned in so
 // many places that it would be messy to call lcl_replace_stuff everywhere
-// Addendum: Now, of course, it provides a handy way to encapsulate another check
+// Addendum: Now, of course, it provides a handy way to encapsulate the unexpected tstring check.
 void lcl_ext_localize(const char *in, char *out, size_t max_len, int *id)
 {
 	// buffer for the untranslated string inside the XSTR tag

--- a/code/localization/localize.h
+++ b/code/localization/localize.h
@@ -61,6 +61,9 @@ extern int Lcl_english;
 // The currently active language. Index into Lcl_languages.
 extern int Lcl_current_lang;
 
+// special check for misplaced mod data (see Mantis #2942)
+extern bool *Lcl_unexpected_tstring_check;
+
 
 // ------------------------------------------------------------------------------------------------------------
 // LOCALIZE FUNCTIONS
@@ -110,8 +113,8 @@ void lcl_fred_replace_stuff(SCP_string &text);
 // XSTR("whee", 20)
 // and these should cover all the externalized string cases
 // fills in id if non-NULL. a value of -2 indicates it is not an external string
-void lcl_ext_localize(const char *in, char *out, size_t max_len, int *id = NULL);
-void lcl_ext_localize(const SCP_string &in, SCP_string &out, int *id = NULL);
+void lcl_ext_localize(const char *in, char *out, size_t max_len, int *id = nullptr);
+void lcl_ext_localize(const SCP_string &in, SCP_string &out, int *id = nullptr);
 
 // translate the specified string based upon the current language
 const char *XSTR(const char *str, int index);

--- a/code/menuui/readyroom.cpp
+++ b/code/menuui/readyroom.cpp
@@ -1008,7 +1008,6 @@ void sim_room_init()
 	int i;
 	sim_room_buttons *b;
 	char wild_card[256];
-	bool dummy_buffer;
 
 	list_x1 = Mission_list_coords[gr_screen.res][0];
 	list_x2 = Campaign_list_coords[gr_screen.res][0];
@@ -1113,6 +1112,7 @@ void sim_room_init()
 #ifndef NDEBUG
 	// Activate the check while we fill the mission list so that we don't potentially end up with dozens of string length warnings.
 	// We don't actually remove mismatched missions from the list here; that will happen in build_standalone_mission_list_do_frame().
+	bool dummy_buffer;
 	Lcl_unexpected_tstring_check = &dummy_buffer;
 #endif
 	Num_standalone_missions = cf_get_file_list(MAX_MISSIONS, Mission_filenames, CF_TYPE_MISSIONS, wild_card, CF_SORT_NAME);

--- a/code/menuui/readyroom.cpp
+++ b/code/menuui/readyroom.cpp
@@ -1110,11 +1110,15 @@ void sim_room_init()
 	strcpy_s(wild_card, NOX("*"));
 	strcat_s(wild_card, FS_MISSION_FILE_EXT);
 
+#ifndef NDEBUG
 	// Activate the check while we fill the mission list so that we don't potentially end up with dozens of string length warnings.
 	// We don't actually remove mismatched missions from the list here; that will happen in build_standalone_mission_list_do_frame().
 	Lcl_unexpected_tstring_check = &dummy_buffer;
+#endif
 	Num_standalone_missions = cf_get_file_list(MAX_MISSIONS, Mission_filenames, CF_TYPE_MISSIONS, wild_card, CF_SORT_NAME);
+#ifndef NDEBUG
 	Lcl_unexpected_tstring_check = nullptr;
+#endif
 
 	// set up slider with 0 items to start
 	Sim_room_slider.create(&Ui_window, Sim_room_slider_coords[gr_screen.res][X_COORD], Sim_room_slider_coords[gr_screen.res][Y_COORD], Sim_room_slider_coords[gr_screen.res][W_COORD], Sim_room_slider_coords[gr_screen.res][H_COORD], 0, Sim_room_slider_filename[gr_screen.res], &sim_room_scroll_screen_up, &sim_room_scroll_screen_down, &sim_room_scroll_capture);

--- a/code/menuui/readyroom.cpp
+++ b/code/menuui/readyroom.cpp
@@ -450,6 +450,7 @@ int build_standalone_mission_list_do_frame()
 	int font_height = gr_get_font_height();
 	char filename[MAX_FILENAME_LEN];
 	char str[256];
+	bool lcl_weirdness = false;
 	
 	// When no standalone missions in data directory
 	if (Num_standalone_missions == 0) {
@@ -473,8 +474,16 @@ int build_standalone_mission_list_do_frame()
 			// tack on an extension
 			strcat_s(filename, FS_MISSION_FILE_EXT);
 
-			// check if we can list the mission and if loading basic info didn't return an error code
-			if (!mission_is_ignored(filename) && !get_mission_info(filename)) {
+			// activate tstrings check
+			Lcl_unexpected_tstring_check = &lcl_weirdness;
+
+			// check if we can list the mission, if loading basic info didn't return an error code, and if we didn't find an unexpected XSTR mismatch
+			bool condition = !mission_is_ignored(filename) && !get_mission_info(filename) && !lcl_weirdness;
+
+			// deactivate tstrings check
+			Lcl_unexpected_tstring_check = nullptr;
+
+			if (condition) {
 				Standalone_mission_names[Num_standalone_missions_with_info] = vm_strdup(The_mission.name);
 				Standalone_mission_flags[Num_standalone_missions_with_info] = The_mission.game_type;
 				int y = Num_lines * (font_height + 2);
@@ -999,6 +1008,7 @@ void sim_room_init()
 	int i;
 	sim_room_buttons *b;
 	char wild_card[256];
+	bool dummy_buffer;
 
 	list_x1 = Mission_list_coords[gr_screen.res][0];
 	list_x2 = Campaign_list_coords[gr_screen.res][0];
@@ -1099,7 +1109,12 @@ void sim_room_init()
 	memset(wild_card, 0, 256);
 	strcpy_s(wild_card, NOX("*"));
 	strcat_s(wild_card, FS_MISSION_FILE_EXT);
+
+	// Activate the check while we fill the mission list so that we don't potentially end up with dozens of string length warnings.
+	// We don't actually remove mismatched missions from the list here; that will happen in build_standalone_mission_list_do_frame().
+	Lcl_unexpected_tstring_check = &dummy_buffer;
 	Num_standalone_missions = cf_get_file_list(MAX_MISSIONS, Mission_filenames, CF_TYPE_MISSIONS, wild_card, CF_SORT_NAME);
+	Lcl_unexpected_tstring_check = nullptr;
 
 	// set up slider with 0 items to start
 	Sim_room_slider.create(&Ui_window, Sim_room_slider_coords[gr_screen.res][X_COORD], Sim_room_slider_coords[gr_screen.res][Y_COORD], Sim_room_slider_coords[gr_screen.res][W_COORD], Sim_room_slider_coords[gr_screen.res][H_COORD], 0, Sim_room_slider_filename[gr_screen.res], &sim_room_scroll_screen_up, &sim_room_scroll_screen_down, &sim_room_scroll_capture);

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -6011,15 +6011,18 @@ void parse_init(bool basic)
 {
 	reset_parse();
 
-	for (int i = 0; i < MAX_CARGO; i++)
-		Cargo_names[i] = Cargo_names_buf[i]; // make a pointer array for compatibility
+	// if we just want basic info then we don't need some of this initialization
+	if (!basic)
+	{
+		for (int i = 0; i < MAX_CARGO; i++)
+			Cargo_names[i] = Cargo_names_buf[i]; // make a pointer array for compatibility
 
-	Total_goal_target_names = 0;
+		Total_goal_target_names = 0;
 
-	// if we are just wanting basic info then we shouldn't need sexps
-	// (prevents memory fragmentation with the now dynamic Sexp_nodes[])
-	if ( !basic )
+		// if we are just wanting basic info then we shouldn't need sexps
+		// (prevents memory fragmentation with the now dynamic Sexp_nodes[])
 		init_sexp();
+	}
 }
 
 // main parse routine for parsing a mission.  The default parameter flags tells us which information

--- a/code/network/multiui.cpp
+++ b/code/network/multiui.cpp
@@ -4449,9 +4449,10 @@ void multi_create_list_load_missions()
 	}
 
 	for (idx = 0; idx < file_count; idx++) {
-		int flags,max_players;
+		int flags, max_players;
 		char *filename;
 		uint m_respawn;
+		bool lcl_weirdness = false;
 
 		fname = file_list[idx];
 		
@@ -4462,10 +4463,16 @@ void multi_create_list_load_missions()
 			std_gen_set_text(filename, 2);
 		}
 
+		// activate tstrings check
+		Lcl_unexpected_tstring_check = &lcl_weirdness;
+
 		flags = mission_parse_is_multi(filename, mission_name);
 
+		// deactivate tstrings check
+		Lcl_unexpected_tstring_check = nullptr;
+
 		// if the mission is a multiplayer mission, and we can list it, then add it to the mission list
-		if (flags && !mission_is_ignored(filename)) {
+		if (flags && !mission_is_ignored(filename) && !lcl_weirdness) {
 			max_players = mission_parse_get_multi_mission_info( filename );
 			m_respawn = The_mission.num_respawns;
 

--- a/test/src/menuui/test_intel_parse.cpp
+++ b/test/src/menuui/test_intel_parse.cpp
@@ -29,20 +29,20 @@ class IntelParseTest : public test::FSTestFixture {
 
 // Commonly used expected intel data entries.
 static intel_data expected_foo = {
-	"Foo name", // XSTR id 3000
-	"Foo desc", // XSTR id 3001
+	"Foo name default", // XSTR id 3000
+	"Foo desc default", // XSTR id 3001
 	"Foo anim",
 	IIF_IN_TECH_DATABASE | IIF_DEFAULT_IN_TECH_DATABASE
 };
 static intel_data expected_bar = {
-	"Bar name", // XSTR id 3002
-	"Bar desc", // XSTR id 3003
+	"Bar name default", // XSTR id 3002
+	"Bar desc default", // XSTR id 3003
 	"Bar anim",
 	0
 };
 static intel_data expected_baz = {
-	"Baz name", // XSTR id 3004
-	"Baz desc", // XSTR id 3005
+	"Baz name default", // XSTR id 3004
+	"Baz desc default", // XSTR id 3005
 	"Baz anim",
 	IIF_IN_TECH_DATABASE | IIF_DEFAULT_IN_TECH_DATABASE
 };


### PR DESCRIPTION
Certain mods provide their own tstrings.tbl, but this runs into trouble when you localize data meant for one mod using a tstrings.tbl meant for another mod.  See the Mantis ticket:
http://scp.indiegames.us/mantis/view.php?id=2942
and also the HLP post:
http://www.hard-light.net/forums/index.php?topic=85041.msg1716600#msg1716600

This PR adds an optional flag that will check the untranslated string against the "default language" translated string.  The two strings should be identical.  If they aren't, the code assumes there is a tstrings.tbl mismatch.

I modified the mission listing code to enable this check when localizing mission info (titles and descriptions), and to avoid adding the mission to the list if there is a mismatch.  Fortunately, I think mission listing is the only place where this bug is likely to happen.

Note also that the localization code never actually used to translate strings if the current language was the default language.  This PR changes this to always use the tabled version of the string, which is probably the behavior people expect.