### PR TITLE
Use datacorder in CI instead of fs2downloads

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,9 +36,9 @@ env:
     # These declarations set INDIEGAMES_USER and INDIEGAMES_PASSWORD for uploading nightly builds to the indiegames server
     - secure: "lUuRu8XIi8MKNf1ebOfyC4iVEpPyASojJIDWXRo2bNqEF4ILAljXdkVeXeN6H5yKCHD52cxCNTtyePIG/o3p3QEuGSVud9bDS3D7LaQicLETGGrsw3l07U49gF2OKHXGopg0MzBbZUU9QmhoFTAe8t6PV9NDuEayYCheqvTqjZg="
     - secure: "E/DHLYcPK/hBUqxBYYlUqp5sjgvIqY5A0qRHyQ4bmjsB+WB/Xx71bGCSiF7hk6lTxar1ZI1i5RAXXh9AIvNVaYAIdEOlCP+q3gvwCYuc5naZEKmkxlUCf0oEL4O9Fye93A/3VkFHuBdC1TGPYYf69m4W5r4367wWO9dPRIdWpJA="
-    # These declarations set FS2DOWNLOADS_USER and FS2DOWNLOADS_PASSWORD
-    - secure: "h6GbMX2jLsW1bS9fCM9fthOSJ1nfQQIRWi6EUH2p8u4NFLD5Bfi/C8JhQPKHUzyo3wvKkSHl+PsW7bgr1oXLusRwAur/dtv2N3imqvtbfIz305b00hZlsvbcYmQmUzQFSAdOGShK57JJ5aKQKccaUBP25KqB7Q+JaqBRdaMBS54="
-    - secure: "fUDAPAUUaaYZy8I4zU3SJ0JcK7aw4eb6eTdaEr7LyNyTMSfPgwY6P1MrbSQC0lJNQIUQ5ffjdxE5g7D7OYpoJF9L14ni4UY8t2QASt7kmpgcYihmjeuYy8FQXgmFG8CTxiWBPKTybZJ7voQcvIvRaNG7b2wM9PMfc5lRIondB6c="
+    # These declarations set DATACORDER_USER and DATACORDER_PASSWORD
+    - secure: "kd4266HPqFH/+ZzdgPrrkMak6Bh3VF+/KTBZD+h9PHS6ThcwPWVpcTv4WmL2J9n7+7dnaHgkIb/z/19TddIx9WOCgiVm88EoKXoJ6wBY2kgjXLrRPs5rJETP4kpa83HuM0XBPwrWlARtm+0lOeKp5RItdTeUYtJd96Xbx+YWG9E="
+    - secure: "dZ4wK+2bF8GevrMokQMZUP6i703nji51iK2vIGA17HD1nWauWNAOUgFBHx45ARZzW5tZ07gbQQyjMJ/lS1b4X4UvO4aIo2eGLRuGbyQf7Kd3EyRLG701nQb5NYkfXk0N7jjkg07tVrCltPQ3tA00aPX2Zowfk+j2BOqT2qwQbJw="
 deploy:
   - provider: releases
     api_key:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -58,6 +58,5 @@ deploy:
       password:
         secure: CrzmDVca8AGG08iWPA1gOD4Ge06+wJ3rcBagBGclwYQ=
       folder: www/datacorder.porphyrion.feralhosting.com/public_html/builds/test/$(VersionName)
-      beta: true
       on:
           TestBuild: true        # deploy on test build push only

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -40,25 +40,24 @@ deploy:
           NightlyBuild: true        # deploy on nightly push only
 
     - provider: FTP
-      protocol: ftp
-      host: swc.fs2downloads.com
-      username: 
-        secure: EXg2ADoKzMduZF90ip2Q0g==
+      protocol: sftp
+      host: porphyrion.feralhosting.com
+      username:
+        secure: 36+bVD8eJgI0BVbi7TZ4zQ==
       password:
-        secure: x0LL0uY9yBAQ7JTARhQ6AA==
-      folder: swc.fs2downloads.com/builds/nightly/$(VersionName)
-      beta: true
+        secure: CrzmDVca8AGG08iWPA1gOD4Ge06+wJ3rcBagBGclwYQ=
+      folder: www/datacorder.porphyrion.feralhosting.com/public_html/builds/nightly/$(VersionName)
       on:
           NightlyBuild: true        # deploy on nightly push only
 
     - provider: FTP
-      protocol: ftp
-      host: swc.fs2downloads.com
-      username: 
-        secure: EXg2ADoKzMduZF90ip2Q0g==
+      protocol: sftp
+      host: porphyrion.feralhosting.com
+      username:
+        secure: 36+bVD8eJgI0BVbi7TZ4zQ==
       password:
-        secure: x0LL0uY9yBAQ7JTARhQ6AA==
-      folder: swc.fs2downloads.com/builds/test/$(VersionName)
+        secure: CrzmDVca8AGG08iWPA1gOD4Ge06+wJ3rcBagBGclwYQ=
+      folder: www/datacorder.porphyrion.feralhosting.com/public_html/builds/test/$(VersionName)
       beta: true
       on:
           TestBuild: true        # deploy on test build push only

--- a/ci/travis/ftp_deploy.sh
+++ b/ci/travis/ftp_deploy.sh
@@ -77,13 +77,13 @@ cd /tmp/builds
 
 for file in *; do
     if [ "$TEST_BUILD" = true ]; then
-        # Upload to fs2downloads
-        curl -k "ftp://swc.fs2downloads.com/swc.fs2downloads.com/builds/test/$VERSION_NAME/" --user "$FS2DOWNLOADS_USER:$FS2DOWNLOADS_PASSWORD" -T "$file" --ftp-create-dirs
+        # Upload to datacorder
+        curl -k "sftp://porphyrion.feralhosting.com/www/datacorder.porphyrion.feralhosting.com/public_html/builds/test/$VERSION_NAME/" --user "$DATACORDER_USER:$DATACORDER_PASSWORD" -T "$file" --ftp-create-dirs
     else
         # Upload to indiegames
         curl -k "sftp://scp.indiegames.us/~/public_html/builds/nightly/$VERSION_NAME/" --user "$INDIEGAMES_USER:$INDIEGAMES_PASSWORD" -T "$file" --ftp-create-dirs
 
-        # Upload to fs2downloads
-        curl -k "ftp://swc.fs2downloads.com/swc.fs2downloads.com/builds/nightly/$VERSION_NAME/" --user "$FS2DOWNLOADS_USER:$FS2DOWNLOADS_PASSWORD" -T "$file" --ftp-create-dirs
+        # Upload to datacorder
+        curl -k "sftp://porphyrion.feralhosting.com/www/datacorder.porphyrion.feralhosting.com/public_html/builds/nightly/$VERSION_NAME/" --user "$DATACORDER_USER:$DATACORDER_PASSWORD" -T "$file" --ftp-create-dirs
     fi
 done


### PR DESCRIPTION
The swc.fs2downloads.com FTP mirror hasn't been liking the 7z binaries from AppVeyor since December 14.  Most fail entirely or end up corrupted.  Need to make sure we update the nightlybuild config.yml at the same time this is merged so the forum post and the actual uploads agree with each other.  File is already updated in place as config.yml.new on the server, just need to replace it.