### PR TITLE
Fix mantis 2791

### DIFF
--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -12550,13 +12550,13 @@ int ai_acquire_emerge_path(object *pl_objp, int parent_objnum, int allowed_path_
 	polymodel *pm = model_get( Ship_info[parent_shipp->ship_info_index].model_num );
 	ship_bay *bay = pm->ship_bay;
 
-	if ( bay == NULL ) {
-		WarningEx(LOCATION, "Ship %s was set to arrive from fighter bay on object %s, but no fighter bay exists on that ships' model (%s).\n", shipp->ship_name, parent_shipp->ship_name, pm->filename);
+	if ( bay == nullptr ) {
+		Warning(LOCATION, "Ship %s was set to arrive from fighter bay on object %s, but no fighter bay exists on that ships' model (%s).\n", shipp->ship_name, parent_shipp->ship_name, pm->filename);
 		return -1;
 	}
 
 	if ( bay->num_paths <= 0 ) {
-		WarningEx(LOCATION, "Ship %s was set to arrive from fighter bay on object %s, but no fighter bay paths exist on that ships' model (%s).\n", shipp->ship_name, parent_shipp->ship_name, pm->filename);
+		Warning(LOCATION, "Ship %s was set to arrive from fighter bay on object %s, but no fighter bay paths exist on that ships' model (%s).\n", shipp->ship_name, parent_shipp->ship_name, pm->filename);
 		return -1;
 	}
 

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -6643,7 +6643,8 @@ int mission_set_arrival_location(int anchor, int location, int dist, int objnum,
 
 		// if we get an error, just let the ship arrive(?)
 		if ( ai_acquire_emerge_path(&Objects[objnum], anchor_objnum, path_mask, &pos, &fvec) == -1 ) {
-			Int3();			// get MWA or AL -- not sure what to do here when we cannot acquire a path
+			// get MWA or AL -- not sure what to do here when we cannot acquire a path
+			mprintf(("Unable to acquire arrival path on anchor ship %s\n", Ships[shipnum].ship_name));
 			return -1;
 		}
 		Objects[objnum].pos = pos;

--- a/code/model/model.h
+++ b/code/model/model.h
@@ -371,7 +371,7 @@ typedef struct mp_vert {
 } mp_vert;
 
 typedef struct model_path {
-	char			name[MAX_NAME_LEN];					// name of the subsystem.  Probably displayed on HUD
+	char			name[MAX_NAME_LEN];					// name of the path.  Should be unique
 	char			parent_name[MAX_NAME_LEN];			// parent name of submodel that path is linked to in POF
 	int			parent_submodel;
 	int			nverts;

--- a/code/model/modelread.cpp
+++ b/code/model/modelread.cpp
@@ -2273,7 +2273,15 @@ int read_model_file(polymodel * pm, const char *filename, int n_subsystems, mode
 				memset( pm->paths, 0, sizeof(model_path) * pm->n_paths );
 					
 				for (i=0; i<pm->n_paths; i++ )	{
-					cfread_string_len(pm->paths[i].name , MAX_NAME_LEN-1, fp);
+					cfread_string_len(pm->paths[i].name, MAX_NAME_LEN-1, fp);
+
+					// check for reused path names... not fatal, but maybe problematic
+					for (j = 0; j < i; j++) {
+						if (!stricmp(pm->paths[i].name, pm->paths[j].name)) {
+							Warning(LOCATION, "Path '%s' in model %s has a name that is not unique!", pm->paths[i].name, pm->filename);
+						}
+					}
+
 					if ( pm->version >= 2002 ) {
 						// store the sub_model name number of the parent
 						cfread_string_len(pm->paths[i].parent_name , MAX_NAME_LEN-1, fp);

--- a/code/model/modelread.cpp
+++ b/code/model/modelread.cpp
@@ -3081,6 +3081,8 @@ void model_set_bay_path_nums(polymodel *pm)
 	pm->ship_bay->arrive_flags = 0;	// bitfield, set to 1 when that path number is reserved for an arrival
 	pm->ship_bay->depart_flags = 0;	// bitfield, set to 1 when that path number is reserved for a departure
 
+	// sanity part 1
+	memset(pm->ship_bay->path_indexes, -1, MAX_SHIP_BAY_PATHS * sizeof(int));
 
 	// iterate through the paths that exist in the polymodel, searching for $bayN pathnames
 	bool too_many_paths = false;
@@ -3115,6 +3117,16 @@ void model_set_bay_path_nums(polymodel *pm)
 	if(too_many_paths)
 	{
 		Warning(LOCATION, "Model '%s' has too many bay paths - max is %d", pm->filename, MAX_SHIP_BAY_PATHS);
+	}
+
+	// sanity part 2
+	for (i = 0; i < pm->ship_bay->num_paths; i++)
+	{
+		if (pm->ship_bay->path_indexes[i] < 0)
+		{
+			Warning(LOCATION, "Model '%s' does not have a '$bay%.2d' path specified!  A total of %d bay paths were counted.  Either there is a gap in the path sequence, or a path has a duplicate name.", pm->filename, i + 1, pm->ship_bay->num_paths);
+			pm->ship_bay->path_indexes[i] = 0;	// avoid crashes
+		}
 	}
 }
 


### PR DESCRIPTION
See: http://scp.indiegames.us/mantis/view.php?id=2791

Instead of firing an Int3() when a ship has no arrival paths, just log it and continue.  And change the upstream warnings, which should have been more visible, from WarningEx to Warning.

Also, warn if model paths do not have unique names, and warn if there is a gap in the path sequence.