### PR TITLE
Disable doublefire take 2

### DIFF
--- a/code/ai/ai_flags.h
+++ b/code/ai/ai_flags.h
@@ -85,6 +85,8 @@ namespace AI {
         Beams_damage_weapons,
         Big_ships_can_attack_beam_turrets_on_untargeted_ships,
         Disable_linked_fire_penalty,
+        Disable_player_secondary_doublefire,
+        Disable_ai_secondary_doublefire,
         Disable_weapon_damage_scaling,
         Dont_insert_random_turret_fire_delay,
         Fix_ai_class_bug,

--- a/code/ai/ai_profiles.cpp
+++ b/code/ai/ai_profiles.cpp
@@ -375,6 +375,10 @@ void parse_ai_profiles_tbl(const char *filename)
 
 				set_flag(profile, "$disable linked fire penalty:", AI::Profile_Flags::Disable_linked_fire_penalty);
 
+				set_flag(profile, "$disable player secondary doublefire:", AI::Profile_Flags::Disable_player_secondary_doublefire);
+
+				set_flag(profile, "$disable ai secondary doublefire:", AI::Profile_Flags::Disable_ai_secondary_doublefire);
+
 				set_flag(profile, "$disable weapon damage scaling:", AI::Profile_Flags::Disable_weapon_damage_scaling);
 
 				set_flag(profile, "$use additive weapon velocity:", AI::Profile_Flags::Use_additive_weapon_velocity);

--- a/code/hud/hudtarget.cpp
+++ b/code/hud/hudtarget.cpp
@@ -6074,7 +6074,10 @@ void HudGaugeWeapons::render(float  /*frametime*/)
 			renderPrintf(position[0] + Weapon_sunlinked_offset_x, name_y, EG_NULL, "%c", Weapon_link_icon);
 
 			// indicate if this is linked
-			if ( Player_ship->flags[Ship::Ship_Flags::Secondary_dual_fire] ) {
+			// don't draw the link indicator if the fire can't be fired link.
+			// the link flag is ignored rather than cleared so the player can cycle past a no-doublefire weapon without the setting being cleared
+			if ( Player_ship->flags[Ship::Ship_Flags::Secondary_dual_fire] && !wip->wi_flags[Weapon::Info_Flags::No_doublefire] &&
+					!The_mission.ai_profile->flags[AI::Profile_Flags::Disable_player_secondary_doublefire] ) {
 				renderPrintf(position[0] + Weapon_slinked_offset_x, name_y, EG_NULL, "%c", Weapon_link_icon);
 			}
 
@@ -6992,7 +6995,10 @@ void HudGaugeSecondaryWeapons::render(float  /*frametime*/)
 			renderPrintf(position[0] + _sunlinked_offset_x, position[1] + text_y_offset, EG_NULL, "%c", Weapon_link_icon);
 
 			// indicate if this is linked
-			if ( Player_ship->flags[Ship::Ship_Flags::Secondary_dual_fire] ) {
+			// don't draw the link indicator if the fire can't be fired link.
+			// the link flag is ignored rather than cleared so the player can cycle past a no-doublefire weapon without the setting being cleared
+			if ( Player_ship->flags[Ship::Ship_Flags::Secondary_dual_fire] && !wip->wi_flags[Weapon::Info_Flags::No_doublefire] &&
+					!The_mission.ai_profile->flags[AI::Profile_Flags::Disable_player_secondary_doublefire] ) {
 				renderPrintf(position[0] + _slinked_offset_x, position[1] + text_y_offset, EG_NULL, "%c", Weapon_link_icon);
 			}
 

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -11951,8 +11951,11 @@ int ship_fire_secondary( object *obj, int allow_swarm )
 			goto done_secondary;
 		}
 
-		int start_slot, end_slot;
-
+		// Handle the optional disabling of dual fire
+		// dual fire/doublefire can be disabled for individual weapons, for players, or for AIs
+		// if any of these apply to the current weapon, unset the dual fire flag on the ship 
+		// then proceed as normal.
+		// This is only handled at firing time so dualfire isn't lost when cycling through weapons
 		if (shipp->flags[Ship_Flags::Secondary_dual_fire] &&
 			( wip->wi_flags[Weapon::Info_Flags::No_doublefire] || 
 			( The_mission.ai_profile->flags[AI::Profile_Flags::Disable_ai_secondary_doublefire] && 
@@ -11962,6 +11965,8 @@ int ship_fire_secondary( object *obj, int allow_swarm )
 			) {
 			shipp->flags.remove(Ship_Flags::Secondary_dual_fire);
 		}
+
+		int start_slot, end_slot;
 
 		if ( shipp->flags[Ship_Flags::Secondary_dual_fire] && num_slots > 1) {
 			start_slot = swp->secondary_next_slot[bank];

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -446,6 +446,7 @@ flag_def_list_new<Weapon::Info_Flags> ai_tgt_weapon_flags[] = {
     { "big ship",					Weapon::Info_Flags::Big_only,							true, false },
     { "child",						Weapon::Info_Flags::Child,								true, false },
     { "no dumbfire",				Weapon::Info_Flags::No_dumbfire,						true, false },
+	{ "no doublefire",				Weapon::Info_Flags::No_doublefire,						true, false },
     { "thruster",					Weapon::Info_Flags::Thruster,							true, false },
     { "in tech database",			Weapon::Info_Flags::In_tech_database,					true, false },
     { "player allowed",				Weapon::Info_Flags::Player_allowed,						true, false },

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -11953,6 +11953,16 @@ int ship_fire_secondary( object *obj, int allow_swarm )
 
 		int start_slot, end_slot;
 
+		if (shipp->flags[Ship_Flags::Secondary_dual_fire] &&
+			( wip->wi_flags[Weapon::Info_Flags::No_doublefire] || 
+			( The_mission.ai_profile->flags[AI::Profile_Flags::Disable_ai_secondary_doublefire] && 
+				shipp->objnum != OBJ_INDEX(Player_obj) ) ||
+			( The_mission.ai_profile->flags[AI::Profile_Flags::Disable_player_secondary_doublefire] &&
+				shipp->objnum == OBJ_INDEX(Player_obj) ))
+			) {
+			shipp->flags.remove(Ship_Flags::Secondary_dual_fire);
+		}
+
 		if ( shipp->flags[Ship_Flags::Secondary_dual_fire] && num_slots > 1) {
 			start_slot = swp->secondary_next_slot[bank];
 			// AL 11-19-97: Ensure enough ammo remains when firing linked secondary weapons

--- a/code/weapon/weapon_flags.h
+++ b/code/weapon/weapon_flags.h
@@ -23,6 +23,7 @@ namespace Weapon {
 		Bomb,								// Bomb-type missile, can be targeted
 		Huge,								// Huge damage (generally 500+), probably only fired at huge ships.
 		No_dumbfire,						// Missile cannot be fired dumbfire (ie requires aspect lock)
+		No_doublefire,						// Disables linked firing for secondaries - EatThePath
 		Thruster,							// Has thruster cone and/or glow
 		In_tech_database,
 		Player_allowed,						// allowed to be on starting wing ships/in weaponry pool

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -115,6 +115,7 @@ flag_def_list_new<Weapon::Info_Flags> Weapon_Info_Flags[] = {
     { "child",							Weapon::Info_Flags::Child,								true, false },
     { "bomb",							Weapon::Info_Flags::Bomb,								true, false },
     { "no dumbfire",					Weapon::Info_Flags::No_dumbfire,						true, false },
+	{ "no doublefire",					Weapon::Info_Flags::No_doublefire,						true, false },
     { "in tech database",				Weapon::Info_Flags::In_tech_database,					true, false },
     { "player allowed",					Weapon::Info_Flags::Player_allowed,                     true, false },
     { "particle spew",					Weapon::Info_Flags::Particle_spew,						true, false },


### PR DESCRIPTION
Implements the requested features in #1851

Doublefiring can be turned off for AIs and/or players separately through AI profiles flags. Went with that instead of gamesettings largely because that seems consistent with other similar behavior options, and I can conceivably see someone wanting to vary it between missions.

It can also be turned off on a per-weapon basis through a new weapon flag.

Originally attempted in PR #2328, but the feedback there led to enough course corrections that I felt a clean slate was for the better.