### PR TITLE
add overlooked generic file

### DIFF
--- a/code/mission/missionmessage.cpp
+++ b/code/mission/missionmessage.cpp
@@ -625,6 +625,7 @@ void parse_msgtbl()
 		generic_message_filenames.clear();
 		generic_message_filenames.push_back("none");
 		generic_message_filenames.push_back("cuevoice");
+		generic_message_filenames.push_back("cue_voice");
 		generic_message_filenames.push_back("emptymsg");
 		generic_message_filenames.push_back("generic");
 		generic_message_filenames.push_back("msgstart");


### PR DESCRIPTION
It turns out that the extant placeholder wav has an underscore in the filename, so add that to the list.