### PR TITLE
Use full path  in SFTP, unlike the FTP one this was modified from.

### DIFF
--- a/ci/travis/ftp_deploy.sh
+++ b/ci/travis/ftp_deploy.sh
@@ -84,6 +84,6 @@ for file in *; do
         curl -k "sftp://scp.indiegames.us/~/public_html/builds/nightly/$VERSION_NAME/" --user "$INDIEGAMES_USER:$INDIEGAMES_PASSWORD" -T "$file" --ftp-create-dirs
 
         # Upload to datacorder
-        curl -k "sftp://porphyrion.feralhosting.com/www/datacorder.porphyrion.feralhosting.com/public_html/builds/nightly/$VERSION_NAME/" --user "$DATACORDER_USER:$DATACORDER_PASSWORD" -T "$file" --ftp-create-dirs
+        curl -k "sftp://porphyrion.feralhosting.com/~/www/datacorder.porphyrion.feralhosting.com/public_html/builds/nightly/$VERSION_NAME/" --user "$DATACORDER_USER:$DATACORDER_PASSWORD" -T "$file" --ftp-create-dirs
     fi
 done


### PR DESCRIPTION
I think this will do the trick.  I confirmed that the resulting curl call works with a test file, which should mean that anything I changed has now been tested to work, after this fix is deployed.  Just need to use the ~ path like in the Indiegames call since apparently the sftp method doesn't work with a relative path like the ftp one did before.