### PR TITLE
Apply tabled texture replacements when loading ships in the F3 lab

### DIFF
--- a/code/lab/lab.cpp
+++ b/code/lab/lab.cpp
@@ -1575,6 +1575,27 @@ void labviewer_change_ship_lod(Tree* caller)
 
 	Lab_selected_object = ship_create(&vmd_identity_matrix, &Lab_model_pos, ship_index);
 	Objects[Lab_selected_object].flags.set(Object::Object_Flags::Player_ship);
+	auto ship_objp = &Ships[Objects[Lab_selected_object].instance];
+	auto ship_infop = &Ship_info[ship_objp->ship_info_index];
+
+	// If the ship class defines replacement textures, load them and apply them to the ship
+	// load the texture
+	auto replacements = SCP_vector<texture_replace>();
+	for (auto tr : ship_infop->replacement_textures) {
+		if (!stricmp(tr.new_texture, "invisible"))
+		{
+			// invisible is a special case
+			tr.new_texture_id = REPLACE_WITH_INVISIBLE;
+		}
+		else
+		{
+			// try to load texture or anim as normal
+			tr.new_texture_id = bm_load_either(tr.new_texture);
+		}
+		replacements.push_back(tr);
+	}
+
+	ship_objp->apply_replacement_textures(replacements);
 
 	lab_cam_distance = Objects[Lab_selected_object].radius * 1.6f;
 

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -2030,29 +2030,7 @@ int parse_create_object_sub(p_object *p_objp)
 	shipp->base_texture_anim_frametime = game_get_overall_frametime();
 
 	// handle the replacement textures
-	if (!p_objp->replacement_textures.empty())
-	{
-		shipp->ship_replacement_textures = (int *) vm_malloc( MAX_REPLACEMENT_TEXTURES * sizeof(int));
-
-		for (i = 0; i < MAX_REPLACEMENT_TEXTURES; i++)
-			shipp->ship_replacement_textures[i] = -1;
-	}
-
-	// now fill them in
-	for (SCP_vector<texture_replace>::iterator tr = p_objp->replacement_textures.begin(); tr != p_objp->replacement_textures.end(); ++tr)
-	{
-		pm = model_get(sip->model_num);
-
-		// look for textures
-		for (j = 0; j < pm->n_textures; j++)
-		{
-			texture_map *tmap = &pm->maps[j];
-
-			int tnum = tmap->FindTexture(tr->old_texture);
-			if(tnum > -1)
-				shipp->ship_replacement_textures[j * TM_NUM_TYPES + tnum] = tr->new_texture_id;
-		}
-	}
+	shipp->apply_replacement_textures(p_objp->replacement_textures);
 
 	// Copy across the alt classes (if any) for FRED
 	if (Fred_running) {

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -6047,7 +6047,7 @@ void ship::apply_replacement_textures(SCP_vector<texture_replace> &replacements)
 	}
 
 	// now fill them in
-	for (SCP_vector<texture_replace>::iterator tr = replacements.begin(); tr != replacements.end(); ++tr)
+	for (auto tr : replacements)
 	{
 		auto pm = model_get(Ship_info[ship_info_index].model_num);
 
@@ -6056,9 +6056,9 @@ void ship::apply_replacement_textures(SCP_vector<texture_replace> &replacements)
 		{
 			texture_map *tmap = &pm->maps[j];
 
-			int tnum = tmap->FindTexture(tr->old_texture);
+			int tnum = tmap->FindTexture(tr.old_texture);
 			if(tnum > -1)
-				ship_replacement_textures[j * TM_NUM_TYPES + tnum] = tr->new_texture_id;
+				ship_replacement_textures[j * TM_NUM_TYPES + tnum] = tr.new_texture_id;
 		}
 	}
 }

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -6036,6 +6036,33 @@ const char* ship::get_display_string() {
 	}
 }
 
+void ship::apply_replacement_textures(SCP_vector<texture_replace> &replacements)
+{
+	if (!replacements.empty())
+	{
+		ship_replacement_textures = (int *) vm_malloc( MAX_REPLACEMENT_TEXTURES * sizeof(int));
+
+		for (auto i = 0; i < MAX_REPLACEMENT_TEXTURES; i++)
+			ship_replacement_textures[i] = -1;
+	}
+
+	// now fill them in
+	for (SCP_vector<texture_replace>::iterator tr = replacements.begin(); tr != replacements.end(); ++tr)
+	{
+		auto pm = model_get(Ship_info[ship_info_index].model_num);
+
+		// look for textures
+		for (auto j = 0; j < pm->n_textures; j++)
+		{
+			texture_map *tmap = &pm->maps[j];
+
+			int tnum = tmap->FindTexture(tr->old_texture);
+			if(tnum > -1)
+				ship_replacement_textures[j * TM_NUM_TYPES + tnum] = tr->new_texture_id;
+		}
+	}
+}
+
 void ship_weapon::clear() 
 {
     flags.reset();

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -727,6 +727,8 @@ public:
 
 	bool has_display_name();
 	const char* get_display_string();
+
+	void apply_replacement_textures(SCP_vector<texture_replace> &replacements);
 };
 
 struct ai_target_priority {


### PR DESCRIPTION
This also moves the texture replacement apply code from missionparse to the ship class.