### PR TITLE
Make the lab's "show damage lightning" flag work again.

### DIFF
--- a/code/lab/lab.cpp
+++ b/code/lab/lab.cpp
@@ -445,7 +445,7 @@ void labviewer_render_model(float frametime)
 				obj->hull_strength = 1.0f;
 			}
 			else {
-				obj->hull_strength = 1000000.0f;
+				obj->hull_strength = Ship_info[Ships[obj->instance].ship_info_index].max_hull_strength;
 			}
 		}
 

--- a/code/lab/lab.cpp
+++ b/code/lab/lab.cpp
@@ -440,6 +440,13 @@ void labviewer_render_model(float frametime)
 			ship_model_update_instance(obj);
 
 			Ships[obj->instance].team_name = Lab_team_color;
+
+			if (Lab_viewer_flags & LAB_FLAG_LIGHTNING_ARCS) {
+				obj->hull_strength = 1.0f;
+			}
+			else {
+				obj->hull_strength = 1000000.0f;
+			}
 		}
 
 		if (Lab_render_wireframe)


### PR DESCRIPTION
Note that it may take a few frames for lightning to disappear when unchecking that checkbox.