### PR TITLE
Remove naked int3() call in missionmessage

### DIFF
--- a/code/mission/missionmessage.cpp
+++ b/code/mission/missionmessage.cpp
@@ -1146,7 +1146,7 @@ void message_calc_anim_start_frame(int time, generic_anim *ani, int reverse)
 	}
 
 	if ( start_frame < 0 ) {
-		Int3();
+		mprintf(("Calculated start frame for animation %s was less than 0, setting to 0.", ani->filename));
 		start_frame=0;
 	}
 


### PR DESCRIPTION
The original Volition code called Int3() here; since there is a way out that does not require us to crash, we should just not crash.