### PR TITLE
Update cases of pow(x,2) to just multiply values

### DIFF
--- a/code/def_files/data/effects/effect-f.sdr
+++ b/code/def_files/data/effects/effect-f.sdr
@@ -45,7 +45,7 @@ void main()
 		fragDepthLinear = ( 2.0 * farZ * nearZ ) / ( farZ + nearZ - gl_FragCoord.z * (farZ-nearZ) );
 	}
 	// assume UV of 0.5, 0.5 is the centroid of this sphere volume
-	float depthOffset = sqrt(pow(fragRadius, 2.0) - pow(offset_len, 2.0));
+	float depthOffset = sqrt((fragRadius*fragRadius) - (offset_len*offset_len));
 	float frontDepth = fragDepthLinear - depthOffset;
 	float backDepth = fragDepthLinear + depthOffset;
 	float intensity = smoothstep(max(nearZ, frontDepth), backDepth, sceneDepthLinear);

--- a/code/model/modelread.cpp
+++ b/code/model/modelread.cpp
@@ -4011,7 +4011,7 @@ int model_rotate_gun(int model_num, model_subsystem *turret, matrix *orient, ang
 	{
 		base_delta = vm_delta_from_interp_angle( base_angles->h, desired_angles.h );
 		gun_delta = vm_delta_from_interp_angle( gun_angles->p, desired_angles.p );
-		ss->points_to_target = sqrt( pow(base_delta,2) + pow(gun_delta,2));
+		ss->points_to_target = sqrt((base_delta*base_delta) + (gun_delta*gun_delta));
 	}
 
 	return 1;


### PR DESCRIPTION
Having recalled that other SCP folks stated `pow` should not be used to for simple squaring, I figured it might be a good idea to update the two instances I found where that was the case. Note these were the only instances applicable I could find in the whole code base.