### PR TITLE
clean up handling of translated vs. untranslated English

### DIFF
--- a/code/cutscene/ffmpeg/FFMPEGDecoder.cpp
+++ b/code/cutscene/ffmpeg/FFMPEGDecoder.cpp
@@ -286,7 +286,7 @@ std::unique_ptr<DecoderStatus> initializeStatus(std::unique_ptr<InputStream>& st
 
 	if (status->subtitleStream == nullptr) {
 		// We don't have an external subtitle stream or loading from that file has failed
-		auto& current_language = Lcl_languages[Lcl_current_lang];
+		auto& current_language = Lcl_languages[Lcl_current_lang == LCL_UNTRANSLATED ? LCL_DEFAULT : Lcl_current_lang];
 		for (uint32_t i = 0; i < ctx->nb_streams; ++i) {
 			auto test_stream = ctx->streams[i];
 
@@ -428,7 +428,7 @@ std::unique_ptr<InputStream> openInputStream(const SCP_string& name) {
 
 std::unique_ptr<InputStream> openSubtitleStream(const SCP_string& name)
 {
-	auto& current_language = Lcl_languages[Lcl_current_lang];
+	auto& current_language = Lcl_languages[Lcl_current_lang == LCL_UNTRANSLATED ? LCL_DEFAULT : Lcl_current_lang];
 
 	for (auto ext : CHECKED_SUBT_EXTENSIONS) {
 		SCP_string fileName;

--- a/code/localization/localize.cpp
+++ b/code/localization/localize.cpp
@@ -139,7 +139,7 @@ void lcl_init(int lang_init)
 		memset(lang_string, 0, 128);
 		// default to DEFAULT_LANGUAGE (which should be English so we don't have to put German text
 		// in tstrings in the #default section)
-		ret = os_config_read_string(NULL, "Language", Lcl_languages[LCL_DEFAULT].lang_name);
+		ret = os_config_read_string(nullptr, "Language", Lcl_languages[LCL_DEFAULT].lang_name);
 		strcpy_s(lang_string, ret);		
 
 		// look it up

--- a/code/localization/localize.h
+++ b/code/localization/localize.h
@@ -19,13 +19,14 @@
 // LOCALIZE DEFINES/VARS
 //
 
-// language defines
+// language defines (English should always be index 0)
 #define LCL_ENGLISH						0
 #define LCL_GERMAN						1
 #define LCL_FRENCH						2
 #define LCL_POLISH						3
 
-#define FS2_OPEN_DEFAULT_LANGUAGE		0
+#define LCL_UNTRANSLATED				10	// this should be higher than the highest builtin language
+#define	LCL_DEFAULT						0
 
 // for language name strings
 #define LCL_LANG_NAME_LEN				32
@@ -56,7 +57,7 @@ extern int Lcl_special_chars;
 extern int Lcl_fr;
 extern int Lcl_gr;
 extern int Lcl_pl;
-extern int Lcl_english;
+extern int Lcl_en;
 
 // The currently active language. Index into Lcl_languages.
 extern int Lcl_current_lang;

--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -42,6 +42,7 @@ float Shield_pain_flash_factor;
 gameversion::version Targetted_version; // Defaults to retail
 SCP_string Window_title;
 bool Unicode_text_mode;
+bool Use_tabled_strings_for_default_language;
 SCP_string Movie_subtitle_font;
 bool Enable_scripts_in_fred; // By default FRED does not initialize the scripting system
 SCP_string Window_icon_path;
@@ -97,6 +98,12 @@ void parse_mod_table(const char *filename)
 			stuff_boolean(&Unicode_text_mode);
 
 			mprintf(("Game settings table: Unicode mode: %s\n", Unicode_text_mode ? "yes" : "no"));
+		}
+
+		if (optional_string("$Use tabled strings for the default language:")) {
+			stuff_boolean(&Use_tabled_strings_for_default_language);
+
+			mprintf(("Game settings table: Use tabled strings (translations) for the default language: %s\n", Use_tabled_strings_for_default_language ? "yes" : "no"));
 		}
 
 		optional_string("#CAMPAIGN SETTINGS");
@@ -535,11 +542,14 @@ void mod_table_init()
 	// parse any modular tables
 	parse_modular_table("*-mod.tbm", parse_mod_table);
 }
-bool mod_supports_version(int major, int minor, int build) {
+
+bool mod_supports_version(int major, int minor, int build)
+{
 	return Targetted_version >= gameversion::version(major, minor, build, 0);
 }
-void mod_table_reset() {
 
+void mod_table_reset()
+{
 	Directive_wait_time = 3000;
 	True_loop_argument_sexps = false;
 	Fixed_turret_collisions = false;
@@ -565,6 +575,7 @@ void mod_table_reset() {
 	Targetted_version = gameversion::version(2, 0, 0, 0); // Defaults to retail
 	Window_title = "";
 	Unicode_text_mode = false;
+	Use_tabled_strings_for_default_language = false;
 	Movie_subtitle_font = "font01.vf";
 	Enable_scripts_in_fred = false;
 	Window_icon_path = "app_icon_sse";

--- a/code/mod_table/mod_table.h
+++ b/code/mod_table/mod_table.h
@@ -33,6 +33,7 @@ extern float Generic_pain_flash_factor;
 extern float Shield_pain_flash_factor;
 extern SCP_string Window_title;
 extern bool Unicode_text_mode;
+extern bool Use_tabled_strings_for_default_language;
 extern SCP_string Movie_subtitle_font;
 extern bool Enable_scripts_in_fred;
 extern SCP_string Window_icon_path;

--- a/code/scripting/api/libs/base.cpp
+++ b/code/scripting/api/libs/base.cpp
@@ -323,7 +323,8 @@ ADE_FUNC(getCurrentLanguage,
 		 "Determines the language that is being used by the engine. This returns the full name of the language (e.g. \"English\").",
 		 "string",
 		 "The current game language") {
-	return ade_set_args(L, "s", Lcl_languages[Lcl_current_lang].lang_name);
+	auto lang_name = (Lcl_current_lang == LCL_UNTRANSLATED) ? "UNTRANSLATED" : Lcl_languages[Lcl_current_lang].lang_name;
+	return ade_set_args(L, "s", lang_name);
 }
 
 ADE_FUNC(getCurrentLanguageExtension,
@@ -334,7 +335,8 @@ ADE_FUNC(getCurrentLanguageExtension,
 			 "This will return an empty string for the default language.",
 		 "string",
 		 "The current game language") {
-	return ade_set_args(L, "s", Lcl_languages[Lcl_current_lang].lang_ext);
+	int lang = (Lcl_current_lang == LCL_UNTRANSLATED) ? LCL_DEFAULT : Lcl_current_lang;
+	return ade_set_args(L, "s", Lcl_languages[lang].lang_ext);
 }
 
 ADE_FUNC(getVersionString, l_Base, nullptr,

--- a/fred2/management.cpp
+++ b/fred2/management.cpp
@@ -333,13 +333,13 @@ bool fred_init(std::unique_ptr<os::GraphicsOperations>&& graphicsOps)
 	// Load game_settings.tbl
 	mod_table_init();
 
-	// initialize localization module. Make sure this is done AFTER initialzing OS.
-	// NOTE : Fred should ALWAYS run in English. Otherwise it might swap in another language
+	// initialize localization module. Make sure this is done AFTER initializing OS.
+	// NOTE: Fred should ALWAYS run without localization. Otherwise it might swap in another language
 	// when saving - which would cause inconsistencies when externalizing to tstrings.tbl via Exstr
 	// trust me on this :)
-	lcl_init(FS2_OPEN_DEFAULT_LANGUAGE);
+	lcl_init(LCL_UNTRANSLATED);
 
-	// Goober5000 - force init XSTRs (so they work, but only work in English, based on above comment)
+	// Goober5000 - force init XSTRs (so they work, but only work untranslated, based on above comment)
 	extern int Xstr_inited;
 	Xstr_inited = 1;
 

--- a/qtfred/src/mission/management.cpp
+++ b/qtfred/src/mission/management.cpp
@@ -95,13 +95,13 @@ initialize(const std::string& cfilepath, int argc, char* argv[], Editor* editor,
 	mod_table_init();
 
 	listener(SubSystem::Locale);
-	// initialize localization module. Make sure this is done AFTER initialzing OS.
-	// NOTE : Fred should ALWAYS run in English. Otherwise it might swap in another language
+	// initialize localization module. Make sure this is done AFTER initializing OS.
+	// NOTE: Fred should ALWAYS run without localization. Otherwise it might swap in another language
 	// when saving - which would cause inconsistencies when externalizing to tstrings.tbl via Exstr
 	// trust me on this :)
-	lcl_init(FS2_OPEN_DEFAULT_LANGUAGE);
+	lcl_init(LCL_UNTRANSLATED);
 
-	// Goober5000 - force init XSTRs (so they work, but only work in English, based on above comment)
+	// Goober5000 - force init XSTRs (so they work, but only work untranslated, based on above comment)
 	Xstr_inited = 1;
 
 #ifndef NDEBUG


### PR DESCRIPTION
Since the original release of FS2, internal strings have been translated to their English entries in strings.tbl but external strings have not been translated to their English entries in tstrings.tbl.  It appears that string translation was universal until it was disabled via a hack, probably due to FRED idiosyncrasies (see comment in `fred_init()`), and then not re-enabled for release.  PR #2343 re-enabled it, but this turned out to have undesirable side-effects since many mods used incorrect XSTR indexes for external strings.

This PR restores the previous behavior and also cleanly separates localization into translated and untranslated modes.  FRED will always run in untranslated mode.  FSO will run in translated mode for all languages except English, where it will run in untranslated mode UNLESS the new option `$Use tabled strings for the default language` is enabled in game_settings.tbl.