### PR TITLE
Weapon statistics for comparison and extended descriptions

### DIFF
--- a/code/cmdline/cmdline.cpp
+++ b/code/cmdline/cmdline.cpp
@@ -230,7 +230,8 @@ Flag exe_params[] =
 	{ "-pos",				"Show position of camera",					false,	0,									EASY_DEFAULT,					"Dev Tool",		"http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-pos", },
 	{ "-stats",				"Show statistics",							true,	0,									EASY_DEFAULT,					"Dev Tool",		"http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-stats", },
 	{ "-coords",			"Show coordinates",							false,	0,									EASY_DEFAULT,					"Dev Tool",		"http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-coords", },
-	{ "-pofspew",			"Generate all ibx files immediately",		false,	0,									EASY_DEFAULT,					"Dev Tool",		"http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-pofspew", },
+	{ "-pofspew",			"Dump model information to pofspew.txt",	false,	0,									EASY_DEFAULT,					"Dev Tool",		"http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-pofspew", },
+	{ "-weaponspew",		"Dump weapon stats and spreadsheets",		true,	0,									EASY_DEFAULT,					"Dev Tool",		"http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-weaponspew", },
 	{ "-tablecrcs",			"Dump table CRCs for multi validation",		true,	0,									EASY_DEFAULT,					"Dev Tool",		"http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-tablecrcs", },
 	{ "-missioncrcs",		"Dump mission CRCs for multi validation",	true,	0,									EASY_DEFAULT,					"Dev Tool",		"http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-missioncrcs", },
 	{ "-dis_collisions",	"Disable collisions",						true,	0,									EASY_DEFAULT,					"Dev Tool",		"http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-dis_collisions", },
@@ -274,6 +275,7 @@ cmdline_parm port_arg("-port", "Multiplayer network port", AT_INT);
 cmdline_parm multilog_arg("-multilog", NULL, AT_NONE);		// Cmdline_multi_log
 cmdline_parm client_dodamage("-clientdamage", NULL, AT_NONE);	// Cmdline_client_dodamage
 cmdline_parm pof_spew("-pofspew", NULL, AT_NONE);			// Cmdline_spew_pof_info
+cmdline_parm weapon_spew("-weaponspew", nullptr, AT_NONE);			// Cmdline_spew_weapon_stats
 cmdline_parm mouse_coords("-coords", NULL, AT_NONE);			// Cmdline_mouse_coords
 cmdline_parm timeout("-timeout", "Multiplayer network timeout (secs)", AT_INT);				// Cmdline_timeout
 cmdline_parm bit32_arg("-32bit", "Deprecated", AT_NONE);				// (only here for retail compatibility reasons, doesn't actually do anything)
@@ -295,6 +297,7 @@ int Cmdline_multi_stream_chat_to_file = 0;
 int Cmdline_network_port = -1;
 int Cmdline_restricted_game = 0;
 int Cmdline_spew_pof_info = 0;
+bool Cmdline_spew_weapon_stats = false;
 int Cmdline_start_netgame = 0;
 int Cmdline_timeout = -1;
 int Cmdline_use_last_pilot = 0;
@@ -1666,6 +1669,11 @@ bool SetCmdlineParams()
 	// spew pof info
 	if(pof_spew.found()){
 		Cmdline_spew_pof_info = 1;
+	}
+
+	// spew weapon stats
+	if (weapon_spew.found()) {
+		Cmdline_spew_weapon_stats = true;
 	}
 
 	// mouse coords

--- a/code/cmdline/cmdline.h
+++ b/code/cmdline/cmdline.h
@@ -149,5 +149,7 @@ extern bool Cmdline_show_video_info;
 extern bool Cmdline_debug_window;
 extern bool Cmdline_graphics_debug_output;
 extern bool Cmdline_log_to_stdout;
+extern bool Cmdline_spew_weapon_stats;
+
 
 #endif

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -7944,7 +7944,7 @@ void weapon_spew_stats()
 
 			mprintf(("%.2f,", wi.energy_consumed / wi.fire_wait));
 			mprintf(("%.2f,%.2f,", wi.fire_wait, 1.0f / wi.fire_wait));
-			mprintf((",,", wi.rearm_rate, 1.0f / wi.rearm_rate));	// no reload for primaries
+			mprintf((",,"));	// no reload for primaries
 
 			if (wi.shockwave.inner_rad > 0.0f || wi.shockwave.outer_rad > 0.0f)
 				mprintf(("Yes,"));

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -3631,7 +3631,7 @@ void weapon_init()
 	}
 	for (auto &wi : Weapon_info)
 	{
-		if (wi.wi_flags[Weapon::Info_Flags::Player_allowed] && wi.subtype == WP_MISSILE)
+		if (!stricmp(wi.name, "Hornet#Weak") || !stricmp(wi.name, "Harpoon#Weak") || !stricmp(wi.name, "TAG-C") || (wi.wi_flags[Weapon::Info_Flags::Player_allowed] && wi.subtype == WP_MISSILE) || wi.wi_flags[Weapon::Info_Flags::Child])
 		{
 			mprintf(("%s\n", wi.name));
 			mprintf(("\tVelocity: %-11.0fRange: %.0f\n", wi.max_speed, wi.max_speed * wi.lifetime));

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -3549,6 +3549,43 @@ void weapon_init()
 	}
 
 	weapon_level_init();
+
+	// log all weapon stats
+	mprintf(("Name,Type,Velocity,Range,Damage Hull,DPS Hull,Damage Shield,DPS Shield,Damage Subsystem,DPS Subsystem,Power Use,Fire Wait,ROF,Reload,1/Reload\n"));
+	for (auto &wi : Weapon_info)
+	{
+		if (wi.wi_flags[Weapon::Info_Flags::Player_allowed] && wi.subtype == WP_LASER)
+		{
+			mprintf(("%s,%s,", wi.name, "Primary"));
+			mprintf(("%.2f,%.2f,", wi.max_speed, wi.max_speed * wi.lifetime));
+
+			float multiplier = (wi.shockwave.inner_rad > 0.0f) ? 2.0f : 1.0f;
+			mprintf(("%.2f,%.2f,", multiplier * wi.damage * wi.armor_factor, multiplier * wi.damage * wi.armor_factor / wi.fire_wait));
+			mprintf(("%.2f,%.2f,", multiplier * wi.damage * wi.shield_factor, multiplier * wi.damage * wi.shield_factor / wi.fire_wait));
+			mprintf(("%.2f,%.2f,", multiplier * wi.damage * wi.subsystem_factor, multiplier * wi.damage * wi.subsystem_factor / wi.fire_wait));
+
+			mprintf(("%.2f,", wi.energy_consumed / wi.fire_wait));
+			mprintf(("%.2f,%.2f,", wi.fire_wait, 1.0f / wi.fire_wait));
+			mprintf((",\n", wi.rearm_rate, 1.0f / wi.rearm_rate));	// no reload for primaries
+		}
+	}
+	for (auto &wi : Weapon_info)
+	{
+		if (wi.wi_flags[Weapon::Info_Flags::Player_allowed] && wi.subtype == WP_MISSILE)
+		{
+			mprintf(("%s,%s,", wi.name, "Secondary"));
+			mprintf(("%.2f,%.2f,", wi.max_speed, wi.max_speed * wi.lifetime));
+
+			float multiplier = (wi.shockwave.inner_rad > 0.0f) ? 2.0f : 1.0f;
+			mprintf(("%.2f,%.2f,", multiplier * wi.damage * wi.armor_factor, multiplier * wi.damage * wi.armor_factor / wi.fire_wait));
+			mprintf(("%.2f,%.2f,", multiplier * wi.damage * wi.shield_factor, multiplier * wi.damage * wi.shield_factor / wi.fire_wait));
+			mprintf(("%.2f,%.2f,", multiplier * wi.damage * wi.subsystem_factor, multiplier * wi.damage * wi.subsystem_factor / wi.fire_wait));
+
+			mprintf((","));	// no power use for secondaries
+			mprintf(("%.2f,%.2f,", wi.fire_wait, 1.0f / wi.fire_wait));
+			mprintf(("%.2f,%.2f\n", wi.rearm_rate, 1.0f / wi.rearm_rate));
+		}
+	}
 }
 
 

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -3588,7 +3588,7 @@ void weapon_init()
 
 			mprintf((","));	// no power use for secondaries
 			mprintf(("%.2f,%.2f,", wi.fire_wait, 1.0f / wi.fire_wait));
-			mprintf(("%.2f,%.2f,", wi.rearm_rate, 1.0f / wi.rearm_rate));
+			mprintf(("%.2f,%.2f,", wi.reloaded_per_batch / wi.rearm_rate, wi.rearm_rate / wi.reloaded_per_batch));	// rearm_rate is actually the reciprocal of what is in weapons.tbl
 
 			if (wi.shockwave.speed > 0.0f)
 				mprintf(("Yes\n"));

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -3564,7 +3564,8 @@ void weapon_init()
 			strcpy_s(temp, wi.name);
 			end_string_at_first_hash_symbol(temp);
 			int idx = weapon_info_lookup(temp);
-			wip_base = &Weapon_info[idx];
+			if (idx >= 0)
+				wip_base = &Weapon_info[idx];
 		}
 
 		if (wi.wi_flags[Weapon::Info_Flags::Player_allowed] || (wip_base != nullptr && wip_base->wi_flags[Weapon::Info_Flags::Player_allowed]))
@@ -3604,7 +3605,8 @@ void weapon_init()
 			strcpy_s(temp, wi.name);
 			end_string_at_first_hash_symbol(temp);
 			int idx = weapon_info_lookup(temp);
-			wip_base = &Weapon_info[idx];
+			if (idx >= 0)
+				wip_base = &Weapon_info[idx];
 		}
 
 		if (wi.wi_flags[Weapon::Info_Flags::Player_allowed] || (wip_base != nullptr && wip_base->wi_flags[Weapon::Info_Flags::Player_allowed]) || wi.wi_flags[Weapon::Info_Flags::Child])
@@ -3637,7 +3639,21 @@ void weapon_init()
 	mprintf(("\n"));
 	for (auto &wi : Weapon_info)
 	{
-		if (wi.subtype == WP_LASER && wi.wi_flags[Weapon::Info_Flags::Player_allowed])
+		if (wi.subtype != WP_LASER)
+			continue;
+
+		weapon_info *wip_base = nullptr;
+		if (strchr(wi.name, '#'))
+		{
+			char temp[NAME_LENGTH];
+			strcpy_s(temp, wi.name);
+			end_string_at_first_hash_symbol(temp);
+			int idx = weapon_info_lookup(temp);
+			if (idx >= 0)
+				wip_base = &Weapon_info[idx];
+		}
+
+		if (wi.wi_flags[Weapon::Info_Flags::Player_allowed] || (wip_base != nullptr && wip_base->wi_flags[Weapon::Info_Flags::Player_allowed]))
 		{
 			mprintf(("%s\n", wi.name));
 			mprintf(("\tVelocity: %-11.0fRange: %.0f\n", wi.max_speed, wi.max_speed * wi.lifetime));
@@ -3667,7 +3683,21 @@ void weapon_init()
 	}
 	for (auto &wi : Weapon_info)
 	{
-		if (wi.subtype == WP_MISSILE && (wi.wi_flags[Weapon::Info_Flags::Player_allowed] || wi.wi_flags[Weapon::Info_Flags::Child]))
+		if (wi.subtype != WP_MISSILE)
+			continue;
+
+		weapon_info *wip_base = nullptr;
+		if (strchr(wi.name, '#'))
+		{
+			char temp[NAME_LENGTH];
+			strcpy_s(temp, wi.name);
+			end_string_at_first_hash_symbol(temp);
+			int idx = weapon_info_lookup(temp);
+			if (idx >= 0)
+				wip_base = &Weapon_info[idx];
+		}
+
+		if (wi.wi_flags[Weapon::Info_Flags::Player_allowed] || (wip_base != nullptr && wip_base->wi_flags[Weapon::Info_Flags::Player_allowed]) || wi.wi_flags[Weapon::Info_Flags::Child])
 		{
 			mprintf(("%s\n", wi.name));
 			mprintf(("\tVelocity: %-11.0fRange: %.0f\n", wi.max_speed, wi.max_speed * wi.lifetime));

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -3551,7 +3551,7 @@ void weapon_init()
 	weapon_level_init();
 
 	// log all weapon stats
-	mprintf(("Name,Type,Velocity,Range,Damage Hull,DPS Hull,Damage Shield,DPS Shield,Damage Subsystem,DPS Subsystem,Power Use,Fire Wait,ROF,Reload,1/Reload,Shockwave\n"));
+	mprintf(("Name,Type,Velocity,Range,Damage Hull,DPS Hull,Damage Shield,DPS Shield,Damage Subsystem,DPS Subsystem,Power Use,Fire Wait,ROF,Reload,1/Reload,Area Effect,Shockwave\n"));
 	for (auto &wi : Weapon_info)
 	{
 		if (wi.subtype == WP_LASER && wi.wi_flags[Weapon::Info_Flags::Player_allowed])
@@ -3567,6 +3567,11 @@ void weapon_init()
 			mprintf(("%.2f,", wi.energy_consumed / wi.fire_wait));
 			mprintf(("%.2f,%.2f,", wi.fire_wait, 1.0f / wi.fire_wait));
 			mprintf((",,", wi.rearm_rate, 1.0f / wi.rearm_rate));	// no reload for primaries
+
+			if (wi.shockwave.inner_rad > 0.0f || wi.shockwave.outer_rad > 0.0f)
+				mprintf(("Yes,"));
+			else
+				mprintf((","));
 
 			if (wi.shockwave.speed > 0.0f)
 				mprintf(("Yes\n"));
@@ -3590,6 +3595,11 @@ void weapon_init()
 			mprintf(("%.2f,%.2f,", wi.fire_wait, 1.0f / wi.fire_wait));
 			mprintf(("%.2f,%.2f,", wi.reloaded_per_batch / wi.rearm_rate, wi.rearm_rate / wi.reloaded_per_batch));	// rearm_rate is actually the reciprocal of what is in weapons.tbl
 
+			if (wi.shockwave.inner_rad > 0.0f || wi.shockwave.outer_rad > 0.0f)
+				mprintf(("Yes,"));
+			else
+				mprintf((","));
+
 			if (wi.shockwave.speed > 0.0f)
 				mprintf(("Yes\n"));
 			else
@@ -3606,7 +3616,7 @@ void weapon_init()
 			mprintf(("%s\n", wi.name));
 			mprintf(("\tVelocity: %-11.0fRange: %.0f\n", wi.max_speed, wi.max_speed * wi.lifetime));
 
-			float multiplier = (wi.shockwave.speed > 0.0f) ? 2.0f : 1.0f;
+			float multiplier = (wi.shockwave.inner_rad > 0.0f || wi.shockwave.outer_rad > 0.0f) ? 2.0f : 1.0f;
 			mprintf(("\tDPS: "));
 			mprintf(("%.0f Hull, ", multiplier * wi.damage * wi.armor_factor / wi.fire_wait));
 			mprintf(("%.0f Shield, ", multiplier * wi.damage * wi.shield_factor / wi.fire_wait));
@@ -3636,7 +3646,7 @@ void weapon_init()
 			mprintf(("%s\n", wi.name));
 			mprintf(("\tVelocity: %-11.0fRange: %.0f\n", wi.max_speed, wi.max_speed * wi.lifetime));
 
-			float multiplier = (wi.shockwave.speed > 0.0f) ? 2.0f : 1.0f;
+			float multiplier = (wi.shockwave.inner_rad > 0.0f || wi.shockwave.outer_rad > 0.0f) ? 2.0f : 1.0f;
 			mprintf(("\tDamage: "));
 			mprintf(("%.0f Hull, ", multiplier * wi.damage * wi.armor_factor));
 			mprintf(("%.0f Shield, ", multiplier * wi.damage * wi.shield_factor));

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -3554,7 +3554,7 @@ void weapon_init()
 	mprintf(("Name,Type,Velocity,Range,Damage Hull,DPS Hull,Damage Shield,DPS Shield,Damage Subsystem,DPS Subsystem,Power Use,Fire Wait,ROF,Reload,1/Reload,Shockwave\n"));
 	for (auto &wi : Weapon_info)
 	{
-		if (wi.wi_flags[Weapon::Info_Flags::Player_allowed] && wi.subtype == WP_LASER)
+		if (wi.subtype == WP_LASER && wi.wi_flags[Weapon::Info_Flags::Player_allowed])
 		{
 			mprintf(("%s,%s,", wi.name, "Primary"));
 			mprintf(("%.2f,%.2f,", wi.max_speed, wi.max_speed * wi.lifetime));
@@ -3576,7 +3576,7 @@ void weapon_init()
 	}
 	for (auto &wi : Weapon_info)
 	{
-		if (wi.wi_flags[Weapon::Info_Flags::Player_allowed] && wi.subtype == WP_MISSILE)
+		if (wi.subtype == WP_MISSILE && (wi.wi_flags[Weapon::Info_Flags::Player_allowed] || wi.wi_flags[Weapon::Info_Flags::Child]))
 		{
 			mprintf(("%s,%s,", wi.name, "Secondary"));
 			mprintf(("%.2f,%.2f,", wi.max_speed, wi.max_speed * wi.lifetime));
@@ -3601,7 +3601,7 @@ void weapon_init()
 	mprintf(("\n"));
 	for (auto &wi : Weapon_info)
 	{
-		if (wi.wi_flags[Weapon::Info_Flags::Player_allowed] && wi.subtype == WP_LASER)
+		if (wi.subtype == WP_LASER && wi.wi_flags[Weapon::Info_Flags::Player_allowed])
 		{
 			mprintf(("%s\n", wi.name));
 			mprintf(("\tVelocity: %-11.0fRange: %.0f\n", wi.max_speed, wi.max_speed * wi.lifetime));
@@ -3631,7 +3631,7 @@ void weapon_init()
 	}
 	for (auto &wi : Weapon_info)
 	{
-		if (!stricmp(wi.name, "Hornet#Weak") || !stricmp(wi.name, "Harpoon#Weak") || !stricmp(wi.name, "TAG-C") || (wi.wi_flags[Weapon::Info_Flags::Player_allowed] && wi.subtype == WP_MISSILE) || wi.wi_flags[Weapon::Info_Flags::Child])
+		if (wi.subtype == WP_MISSILE && (wi.wi_flags[Weapon::Info_Flags::Player_allowed] || wi.wi_flags[Weapon::Info_Flags::Child]))
 		{
 			mprintf(("%s\n", wi.name));
 			mprintf(("\tVelocity: %-11.0fRange: %.0f\n", wi.max_speed, wi.max_speed * wi.lifetime));

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -3554,7 +3554,20 @@ void weapon_init()
 	mprintf(("Name,Type,Velocity,Range,Damage Hull,DPS Hull,Damage Shield,DPS Shield,Damage Subsystem,DPS Subsystem,Power Use,Fire Wait,ROF,Reload,1/Reload,Area Effect,Shockwave\n"));
 	for (auto &wi : Weapon_info)
 	{
-		if (wi.subtype == WP_LASER && wi.wi_flags[Weapon::Info_Flags::Player_allowed])
+		if (wi.subtype != WP_LASER)
+			continue;
+
+		weapon_info *wip_base = nullptr;
+		if (strchr(wi.name, '#'))
+		{
+			char temp[NAME_LENGTH];
+			strcpy_s(temp, wi.name);
+			end_string_at_first_hash_symbol(temp);
+			int idx = weapon_info_lookup(temp);
+			wip_base = &Weapon_info[idx];
+		}
+
+		if (wi.wi_flags[Weapon::Info_Flags::Player_allowed] || (wip_base != nullptr && wip_base->wi_flags[Weapon::Info_Flags::Player_allowed]))
 		{
 			mprintf(("%s,%s,", wi.name, "Primary"));
 			mprintf(("%.2f,%.2f,", wi.max_speed, wi.max_speed * wi.lifetime));
@@ -3581,7 +3594,20 @@ void weapon_init()
 	}
 	for (auto &wi : Weapon_info)
 	{
-		if (wi.subtype == WP_MISSILE && (wi.wi_flags[Weapon::Info_Flags::Player_allowed] || wi.wi_flags[Weapon::Info_Flags::Child]))
+		if (wi.subtype != WP_MISSILE)
+			continue;
+
+		weapon_info *wip_base = nullptr;
+		if (strchr(wi.name, '#'))
+		{
+			char temp[NAME_LENGTH];
+			strcpy_s(temp, wi.name);
+			end_string_at_first_hash_symbol(temp);
+			int idx = weapon_info_lookup(temp);
+			wip_base = &Weapon_info[idx];
+		}
+
+		if (wi.wi_flags[Weapon::Info_Flags::Player_allowed] || (wip_base != nullptr && wip_base->wi_flags[Weapon::Info_Flags::Player_allowed]) || wi.wi_flags[Weapon::Info_Flags::Child])
 		{
 			mprintf(("%s,%s,", wi.name, "Secondary"));
 			mprintf(("%.2f,%.2f,", wi.max_speed, wi.max_speed * wi.lifetime));


### PR DESCRIPTION
I coded up this feature to do two things:
* print a spreadsheet allowing comparison of damage per second, rate of fire, and other useful info
* print statistics to allow easy copy+paste of MediaVP-style weapon descriptions

I found this useful for the MediaVPs, Scroll, and FSPort, so I thought other people might find it useful too.  Use the `-weaponspew` command-line option in a debug build, and you'll find all the information printed to the log file.