### PR TITLE
revert the clang-tidy changes from #2298

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -14,8 +14,6 @@ misc-*,\
 -misc-static-assert,\
 -misc-unused-parameters,\
 -misc-non-private-member-variables-in-classes,\
-readability-*,\
--readability-implicit-bool-conversion,\
 "
 WarningsAsErrors: ''
 HeaderFilterRegex: 'code/.*$|freespace2/.*$|qtfred/.*$|test/src/.*$|build/.*$'
@@ -25,7 +23,5 @@ CheckOptions:
     value:        'assert,Assert,Assertion'
   - key:          'modernize-use-emplace.ContainersWithPushBack'
     value:        'std::vector;std::deque;std::list;SCP_vector;SCP_deque;SCP_list'
-  - key:          'readability-braces-around-statements.ShortStatementLines'
-    value:        '2' # Avoid flagging simple if (...) return false; statements
 ...
 


### PR DESCRIPTION
These are far too pedantic, and were not related to the feature in #2298 anyway.

This will fix the CI complaints in #2392 and #2394, as well as the CI complaint which delayed merging of #2298 itself.