### PR TITLE
Enable sensible clang readability checks

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -14,6 +14,17 @@ misc-*,\
 -misc-static-assert,\
 -misc-unused-parameters,\
 -misc-non-private-member-variables-in-classes,\
+readability-*,\
+-readability-function-size,\
+-readability-identifier-naming,\
+-readability-implicit-bool-conversion,\
+-readability-inconsistent-declaration-parameter-name,\
+-readability-isolate-declaration,\
+-readability-magic-numbers,\
+-readability-named-parameter,\
+-readability-qualified-auto,\
+-readability-uppercase-literal-suffix,\
+-readability-else-after-return,\
 "
 WarningsAsErrors: ''
 HeaderFilterRegex: 'code/.*$|freespace2/.*$|qtfred/.*$|test/src/.*$|build/.*$'
@@ -23,5 +34,7 @@ CheckOptions:
     value:        'assert,Assert,Assertion'
   - key:          'modernize-use-emplace.ContainersWithPushBack'
     value:        'std::vector;std::deque;std::list;SCP_vector;SCP_deque;SCP_list'
+  - key:          'readability-braces-around-statements.ShortStatementLines'
+    value:        '4' # Avoid flagging simple if (...) return false; statements
 ...
 


### PR DESCRIPTION
This enables the clang readability checks that I found to be sensible. I
disabled a few that would have caused a lot of unnecessary warnings in
our code.