### PR TITLE
SEXP data caching

### DIFF
--- a/code/ai/aigoals.cpp
+++ b/code/ai/aigoals.cpp
@@ -1648,25 +1648,35 @@ int ai_mission_goal_achievable( int objnum, ai_goal *aigp )
 	}
 	else
 	{
+		auto ship_entry = ship_registry_get(aigp->target_name);
+
+		if (!ship_entry)
+		{
+			status = SHIP_STATUS_UNKNOWN;
+		}
 		// goal ship is currently in mission
-		if ( ship_name_lookup( aigp->target_name ) != -1 )
+		else if (ship_entry->status == ShipStatus::PRESENT)
 		{
 			status = SHIP_STATUS_ARRIVED;
 		}
 		// goal ship is still on the arrival list
-		else if ( mission_check_ship_yet_to_arrive(aigp->target_name) )
+		else if (ship_entry->status == ShipStatus::NOT_YET_PRESENT)
 		{
 			status = SHIP_STATUS_NOT_ARRIVED;
 		}
 		// goal ship has left the area
-		else if ( ship_find_exited_ship_by_name(aigp->target_name) != -1 )
+		else if (ship_entry->status == ShipStatus::EXITED)
 		{
 			status = SHIP_STATUS_GONE;
 		}
 		else
 		{
-			mprintf(("Potentially incorrect behaviour in AI goal for ship %s: Ship %s could not be found among currently active, departed, or yet-to-arrive ships.\nPlease check the mission file.\n", Ships[objp->instance].ship_name, aigp->target_name));
 			status = SHIP_STATUS_UNKNOWN;
+		}
+
+		if (status == SHIP_STATUS_UNKNOWN)
+		{
+			mprintf(("Potentially incorrect behaviour in AI goal for ship %s: Ship %s could not be found among currently active, departed, or yet-to-arrive ships.\nPlease check the mission file.\n", Ships[objp->instance].ship_name, aigp->target_name));
 		}
 	}
 

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -4766,6 +4766,15 @@ void post_process_ships_wings()
 	// both ships and wings have been parsed.
 	mission_parse_set_up_initial_docks();
 
+	// Goober5000 - now add all the parse objects to the ship registry.  This must be done before
+	// any ships are created from the parse objects.
+	for (auto &pobjp : Parse_objects)
+	{
+		ship_registry_entry entry = { ShipStatus::NOT_YET_PRESENT, &pobjp, nullptr, nullptr, 0 };
+		Ship_registry.push_back(entry);
+		Ship_registry_map[pobjp.name] = static_cast<int>(Ship_registry.size() - 1);
+	}
+
 	// Goober5000 - now create all objects that we can.  This must be done before any ship stuff
 	// but can't be done until the dock references are resolved.  This was originally done
 	// in parse_object().

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -4251,7 +4251,10 @@ player * get_player_from_ship_node(int node, bool test_respawns)
 const ship_registry_entry *eval_ship(int node)
 {
 	if (Sexp_nodes[node].cache)
+	{
+		Assertion(Sexp_nodes[node].cache->sexp_node_data_type == OPF_SHIP, "Cache data mismatch!");
 		return &Ship_registry[Sexp_nodes[node].cache->ship_registry_index];
+	}
 
 	auto ship_it = Ship_registry_map.find(CTEXT(node));
 	if (ship_it != Ship_registry_map.end())
@@ -4277,7 +4280,10 @@ int sexp_atoi(int node)
 	Assertion(!Fred_running, "This function relies on SEXP caching which is not set up to work in FRED!");
 
 	if (Sexp_nodes[node].cache)
+	{
+		Assertion(Sexp_nodes[node].cache->sexp_node_data_type == OPF_NUMBER, "Cache data mismatch!");
 		return Sexp_nodes[node].cache->numeric_literal;
+	}
 
 	int num = atoi(CTEXT(node));
 

--- a/code/parse/sexp.h
+++ b/code/parse/sexp.h
@@ -1064,25 +1064,24 @@ typedef struct sexp_oper {
 // Goober5000
 struct sexp_cached_data
 {
-	int sexp_node_data_type;		// an OPF_ #define
-	int numeric_literal;			// i.e. a number
-	int ship_registry_index;		// because ship status is pretty common
-	void *pointer;					// could be an IFF, a wing, a goal, or other unchanging reference
+	int sexp_node_data_type = OPF_NONE;		// an OPF_ #define
+	int numeric_literal = 0;				// i.e. a number
+	int ship_registry_index = -1;			// because ship status is pretty common
+	void *pointer = nullptr;				// could be an IFF, a wing, a goal, or other unchanging reference
 
 	sexp_cached_data()
-		: sexp_node_data_type(OPF_NONE), numeric_literal(0), ship_registry_index(-1), pointer(nullptr)
 	{}
 
-	sexp_cached_data(int data_type)
-		: sexp_node_data_type(data_type), numeric_literal(0), ship_registry_index(-1), pointer(nullptr)
+	sexp_cached_data(int _sexp_node_data_type)
+		: sexp_node_data_type(_sexp_node_data_type)
 	{}
 
-	sexp_cached_data(int data_type, void *pointer)
-		: sexp_node_data_type(data_type), numeric_literal(0), ship_registry_index(-1), pointer(pointer)
+	sexp_cached_data(int _sexp_node_data_type, void *_pointer)
+		: sexp_node_data_type(_sexp_node_data_type), pointer(_pointer)
 	{}
 
-	sexp_cached_data(int data_type, int num, int registry_index)
-		: sexp_node_data_type(data_type), numeric_literal(num), ship_registry_index(registry_index), pointer(nullptr)
+	sexp_cached_data(int _sexp_node_data_type, int _numeric_literal, int _ship_registry_index)
+		: sexp_node_data_type(_sexp_node_data_type), numeric_literal(_numeric_literal), ship_registry_index(_ship_registry_index)
 	{}
 };
 

--- a/code/parse/sexp.h
+++ b/code/parse/sexp.h
@@ -1070,6 +1070,8 @@ typedef struct sexp_node {
 	int	rest;						// index into Sexp_nodes of rest of parameters
 	int	value;					// known to be true, known to be false, or not known
 	int flags;					// Goober5000
+
+	sexp_cached_data *cache;	// Goober5000
 } sexp_node;
 
 // Goober5000
@@ -1103,6 +1105,37 @@ class arg_item
 		int is_empty();
 		arg_item *get_next();
 		void clear_nesting_level(); 
+};
+
+// Goober5000
+struct sexp_cached_data
+{
+	int sexp_node_data_type;		// an OPF_ #define
+	int ship_registry_index;		// because ship status is pretty common
+
+	// these are open-ended
+	int numeric_literal;			// i.e. a number
+	void *pointer;					// could be an IFF, a wing, a goal, or other unchanging reference
+
+	sexp_cached_data()
+		: sexp_node_data_type(OPF_NONE), ship_registry_index(-1), numeric_literal(0), pointer(nullptr)
+	{}
+	
+	sexp_cached_data(int data_type)
+		: sexp_node_data_type(data_type), ship_registry_index(-1), numeric_literal(0), pointer(nullptr)
+	{}
+
+	sexp_cached_data(int data_type, void *pointer)
+		: sexp_node_data_type(data_type), ship_registry_index(-1), numeric_literal(0), pointer(pointer)
+	{}
+
+	sexp_cached_data(int data_type, int registry_index, int num)
+		: sexp_node_data_type(data_type), ship_registry_index(registry_index), numeric_literal(num), pointer(nullptr)
+	{}
+
+	sexp_cached_data(int data_type, int registry_index, int num, void *pointer)
+		: sexp_node_data_type(data_type), ship_registry_index(registry_index), numeric_literal(num), pointer(pointer)
+	{}
 };
 
 

--- a/code/parse/sexp.h
+++ b/code/parse/sexp.h
@@ -1061,6 +1061,31 @@ typedef struct sexp_oper {
 	int type;
 } sexp_oper;
 
+// Goober5000
+struct sexp_cached_data
+{
+	int sexp_node_data_type;		// an OPF_ #define
+	int numeric_literal;			// i.e. a number
+	int ship_registry_index;		// because ship status is pretty common
+	void *pointer;					// could be an IFF, a wing, a goal, or other unchanging reference
+
+	sexp_cached_data()
+		: sexp_node_data_type(OPF_NONE), numeric_literal(0), ship_registry_index(-1), pointer(nullptr)
+	{}
+
+	sexp_cached_data(int data_type)
+		: sexp_node_data_type(data_type), numeric_literal(0), ship_registry_index(-1), pointer(nullptr)
+	{}
+
+	sexp_cached_data(int data_type, void *pointer)
+		: sexp_node_data_type(data_type), numeric_literal(0), ship_registry_index(-1), pointer(pointer)
+	{}
+
+	sexp_cached_data(int data_type, int num, int registry_index)
+		: sexp_node_data_type(data_type), numeric_literal(num), ship_registry_index(registry_index), pointer(nullptr)
+	{}
+};
+
 typedef struct sexp_node {
 	char	text[TOKEN_LENGTH];
 	int op_index;				// the index in the Operators array for the operator at this node (or -1 if not an operator)
@@ -1072,6 +1097,7 @@ typedef struct sexp_node {
 	int flags;					// Goober5000
 
 	sexp_cached_data *cache;	// Goober5000
+	int cached_variable_index;	// Goober5000
 } sexp_node;
 
 // Goober5000
@@ -1105,37 +1131,6 @@ class arg_item
 		int is_empty();
 		arg_item *get_next();
 		void clear_nesting_level(); 
-};
-
-// Goober5000
-struct sexp_cached_data
-{
-	int sexp_node_data_type;		// an OPF_ #define
-	int ship_registry_index;		// because ship status is pretty common
-
-	// these are open-ended
-	int numeric_literal;			// i.e. a number
-	void *pointer;					// could be an IFF, a wing, a goal, or other unchanging reference
-
-	sexp_cached_data()
-		: sexp_node_data_type(OPF_NONE), ship_registry_index(-1), numeric_literal(0), pointer(nullptr)
-	{}
-	
-	sexp_cached_data(int data_type)
-		: sexp_node_data_type(data_type), ship_registry_index(-1), numeric_literal(0), pointer(nullptr)
-	{}
-
-	sexp_cached_data(int data_type, void *pointer)
-		: sexp_node_data_type(data_type), ship_registry_index(-1), numeric_literal(0), pointer(pointer)
-	{}
-
-	sexp_cached_data(int data_type, int registry_index, int num)
-		: sexp_node_data_type(data_type), ship_registry_index(registry_index), numeric_literal(num), pointer(nullptr)
-	{}
-
-	sexp_cached_data(int data_type, int registry_index, int num, void *pointer)
-		: sexp_node_data_type(data_type), ship_registry_index(registry_index), numeric_literal(num), pointer(pointer)
-	{}
 };
 
 
@@ -1233,7 +1228,6 @@ void flush_sexp_tree(int node);
 
 // sexp_variable
 void sexp_modify_variable(const char *text, int index, bool sexp_callback = true);
-int get_index_sexp_variable_from_node (int node);
 int get_index_sexp_variable_name(const char *text);
 int get_index_sexp_variable_name(SCP_string &text);	// Goober5000
 int get_index_sexp_variable_name_special(const char *text);	// Goober5000

--- a/code/parse/sexp.h
+++ b/code/parse/sexp.h
@@ -1069,8 +1069,7 @@ struct sexp_cached_data
 	int ship_registry_index = -1;			// because ship status is pretty common
 	void *pointer = nullptr;				// could be an IFF, a wing, a goal, or other unchanging reference
 
-	sexp_cached_data()
-	{}
+	sexp_cached_data() = default;
 
 	sexp_cached_data(int _sexp_node_data_type)
 		: sexp_node_data_type(_sexp_node_data_type)

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -7479,7 +7479,6 @@ void ship_cleanup(int shipnum, int cleanup_mode)
 	// Goober5000 - handle ship registry
 	auto entry = &Ship_registry[Ship_registry_map[shipp->ship_name]];
 	entry->status = ShipStatus::EXITED;
-	entry->pobjp = nullptr;
 	entry->objp = nullptr;
 	entry->shipp = nullptr;
 	entry->cleanup_mode = cleanup_mode;

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -7476,6 +7476,9 @@ void ship_cleanup(int shipnum, int cleanup_mode)
 	object *objp = &Objects[shipp->objnum];
 	char *jumpnode_name = nullptr;
 
+	// this should never happen
+	Assertion(Ship_registry_map.find(shipp->ship_name) != Ship_registry_map.end(), "Ship %s was destroyed, but was never stored in the ship registry!", shipp->ship_name);
+
 	// Goober5000 - handle ship registry
 	auto entry = &Ship_registry[Ship_registry_map[shipp->ship_name]];
 	entry->status = ShipStatus::EXITED;

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -165,6 +165,10 @@ static void parse_ship_values(ship_info* sip, const bool is_template, const bool
 // information for ships which have exited the game
 SCP_vector<exited_ship> Ships_exited;
 
+SCP_vector<ship_registry_entry> Ship_registry;
+SCP_unordered_map<SCP_string, int> Ship_registry_map;
+
+
 int	Num_engine_wash_types;
 int	Num_ship_subobj_types;
 int	Num_ship_subobjects;
@@ -5500,6 +5504,11 @@ void ship_level_init()
 	strcpy_s(TVT_wing_names[0], "Alpha");
 	strcpy_s(TVT_wing_names[1], "Zeta");
 
+	// clear out ship registry
+	Ship_registry.clear();
+	Ship_registry_map.clear();
+
+
 	// Empty the subsys list
 	ship_clear_subsystems();
 	list_init( &ship_subsys_free_list );
@@ -7457,6 +7466,14 @@ void ship_cleanup(int shipnum, int cleanup_mode)
 	ship *shipp = &Ships[shipnum];
 	object *objp = &Objects[shipp->objnum];
 	char *jumpnode_name = nullptr;
+
+	// Goober5000 - handle ship registry
+	auto entry = &Ship_registry[Ship_registry_map[shipp->ship_name]];
+	entry->status = ShipStatus::EXITED;
+	entry->pobjp = nullptr;
+	entry->objp = nullptr;
+	entry->shipp = nullptr;
+	entry->cleanup_mode = cleanup_mode;
 
 	// add the information to the exited ship list
 	switch (cleanup_mode) {
@@ -9564,6 +9581,23 @@ int ship_create(matrix* orient, vec3d* pos, int ship_type, const char* ship_name
 
 	// Add this ship to Ship_obj_list
 	shipp->ship_list_index = ship_obj_list_add(objnum);
+
+	// Goober5000 - update the ship registry
+	// (since scripts and sexps can create ships, the entry may not yet exist)
+	auto ship_it = Ship_registry_map.find(shipp->ship_name);
+	if (ship_it == Ship_registry_map.end())
+	{
+		ship_registry_entry entry = { ShipStatus::PRESENT, nullptr, &Objects[objnum], shipp, 0 };
+		Ship_registry.push_back(entry);
+		Ship_registry_map[shipp->ship_name] = static_cast<int>(Ship_registry.size() - 1);
+	}
+	else
+	{
+		auto entry = &Ship_registry[ship_it->second];
+		entry->status = ShipStatus::PRESENT;
+		entry->objp = &Objects[objnum];
+		entry->shipp = shipp;
+	}
 
 	// Set time when ship is created
 	shipp->create_time = timer_get_milliseconds();

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -168,6 +168,15 @@ SCP_vector<exited_ship> Ships_exited;
 SCP_vector<ship_registry_entry> Ship_registry;
 SCP_unordered_map<SCP_string, int> Ship_registry_map;
 
+const ship_registry_entry *ship_registry_get(const char *name)
+{
+	auto ship_it = Ship_registry_map.find(name);
+	if (ship_it != Ship_registry_map.end())
+		return &Ship_registry[ship_it->second];
+
+	return nullptr;
+}
+
 
 int	Num_engine_wash_types;
 int	Num_ship_subobj_types;

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -775,6 +775,23 @@ extern void ship_add_exited_ship( ship *shipp, Ship::Exit_Flags reason );
 extern int ship_find_exited_ship_by_name( const char *name );
 extern int ship_find_exited_ship_by_signature( int signature);
 
+// stuff for overall ship status, useful for reference by sexps and scripts
+
+enum ShipStatus { NOT_YET_PRESENT, PRESENT, EXITED };
+
+struct ship_registry_entry
+{
+	ShipStatus status;
+
+	p_object *pobjp;
+	object *objp;
+	ship *shipp;
+	int cleanup_mode;
+};
+
+extern SCP_vector<ship_registry_entry> Ship_registry;
+extern SCP_unordered_map<SCP_string, int> Ship_registry_map;
+
 #define REGULAR_WEAPON	(1<<0)
 #define DOGFIGHT_WEAPON (1<<1)
 

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -792,6 +792,8 @@ struct ship_registry_entry
 extern SCP_vector<ship_registry_entry> Ship_registry;
 extern SCP_unordered_map<SCP_string, int> Ship_registry_map;
 
+extern const ship_registry_entry *ship_registry_get(const char *name);
+
 #define REGULAR_WEAPON	(1<<0)
 #define DOGFIGHT_WEAPON (1<<1)
 


### PR DESCRIPTION
This is a first-level pass at optimizing SEXP execution.  In brief, rather than each SEXP node parsing and looking up each argument every frame, this PR saves the value in the SEXP node after it is determined.  Most SEXP data types (e.g. wings, IFFs, messages) will not change their reference for the duration of a mission.

At this point, ships, numeric literals, and variables are all cached.  Since ships can change status during the mission, this PR also introduces a ship registry that maintains the ship status and references to pointers.  This registry is applicable outside the SEXP system; see the example in the AI goal code.

To keep changes manageable, I limited the ship-related changes to mostly those SEXPs which used `sexp_get_ship_from_node`.  After this PR is merged I intend to make a followup PR dedicated specifically to refactoring the rest of the ship SEXPs, and additional followup PRs for other data types as needed.