### PR TITLE
tweak some untranslated internal XSTR strings

### DIFF
--- a/code/hud/hud.cpp
+++ b/code/hud/hud.cpp
@@ -1707,7 +1707,7 @@ void HudGaugeMissionTime::render(float  /*frametime*/)
 	if ( time_comp < 1 ) {
 		renderPrintf(position[0] + time_val_offsets[0], position[1] + time_val_offsets[1], /*XSTR( "x%.1f", 215), time_comp)*/ NOX("%.2f"), time_comp);
 	} else {
-		renderPrintf(position[0] + time_val_offsets[0], position[1] + time_val_offsets[1], XSTR( "x%.2f", 216), time_comp);
+		renderPrintf(position[0] + time_val_offsets[0], position[1] + time_val_offsets[1], XSTR( "x%.0f", 216), time_comp);
 	}
 }
 

--- a/code/io/keycontrol.cpp
+++ b/code/io/keycontrol.cpp
@@ -897,7 +897,7 @@ void process_debug_keys(int k)
 				vm_vec_scale_add(&pos, &Player_obj->pos, &randvec, Player_obj->radius);
 			ship_apply_local_damage(Player_obj, Player_obj, &pos, 25.0f, MISS_SHIELDS, CREATE_SPARKS);
 			hud_get_target_strength(Player_obj, &shield, &integrity);
-			HUD_sourced_printf(HUD_SOURCE_HIDDEN, XSTR( "You knocked yourself down to %7.3f percent hull.\n", 9), 100.0f * integrity);
+			HUD_sourced_printf(HUD_SOURCE_HIDDEN, XSTR( "You whacked yourself down to %7.3f percent hull.\n", 9), 100.0f * integrity);
 			break;
 			}
 			

--- a/code/localization/localize.cpp
+++ b/code/localization/localize.cpp
@@ -58,7 +58,7 @@ bool *Lcl_unexpected_tstring_check = nullptr;
 // the english version (in the code) to a foreign version (in the table).  Thus, if you
 // add a new string to the code, you must assign it a new index.  Use the number below for
 // that index and increase the number below by one.
-#define XSTR_SIZE	1645
+#define XSTR_SIZE	1647
 
 
 // struct to allow for strings.tbl-determined x offset
@@ -640,7 +640,7 @@ void lcl_fred_replace_stuff(SCP_string &text)
 // valid input to this function includes :
 // "this is some text"
 // XSTR("wheeee", -1)
-// XSTR("whee", 20)
+// XSTR("whee", 2000)
 // and these should cover all the externalized string cases
 // fills in id if non-NULL. a value of -2 indicates it is not an external string
 // returns true if we were able to extract the XSTR elements (text_str and maybe id are populated)

--- a/code/localization/localize.h
+++ b/code/localization/localize.h
@@ -111,7 +111,7 @@ void lcl_fred_replace_stuff(SCP_string &text);
 // valid input to this function includes :
 // "this is some text"
 // XSTR("wheeee", -1)
-// XSTR("whee", 20)
+// XSTR("whee", 2000)
 // and these should cover all the externalized string cases
 // fills in id if non-NULL. a value of -2 indicates it is not an external string
 void lcl_ext_localize(const char *in, char *out, size_t max_len, int *id = nullptr);

--- a/code/menuui/playermenu.cpp
+++ b/code/menuui/playermenu.cpp
@@ -678,7 +678,7 @@ void player_select_button_pressed(int n)
 			//  Only do this when changing modes, keeps bottom text from being empty by accident
 			player_select_set_bottom_text("");
 
-			player_select_set_bottom_text(XSTR( "Single Player Mode", 376));
+			player_select_set_bottom_text(XSTR( "Single-Player Mode", 376));
 
 			// reinitialize as single player mode
 			player_select_init_player_stuff(PLAYER_SELECT_MODE_SINGLE);

--- a/code/mission/missionlog.cpp
+++ b/code/mission/missionlog.cpp
@@ -711,7 +711,7 @@ void message_log_init_scrollback(int pw)
 				break;
 
 			case LOG_SELF_DESTRUCTED:
-				message_log_add_segs(XSTR( "Self Destructed", 1476), LOG_COLOR_NORMAL);
+				message_log_add_segs(XSTR( "Self destructed", 1476), LOG_COLOR_NORMAL);
 				break;
 
 			case LOG_WING_DESTROYED:

--- a/code/network/multi_endgame.cpp
+++ b/code/network/multi_endgame.cpp
@@ -505,12 +505,11 @@ void multi_endgame_popup(int notify_code,int error_code,int wsa_error)
 			case MULTI_END_ERROR_WAVE_COUNT:
 				strcat_s(err_msg,XSTR("The player wings Alpha, Beta, Gamma, and Zeta must have only 1 wave.  One of these wings currently has more than 1 wave.", 987));
 				break;
-			// Karajorma - both of these should really be replaced with new strings in strings.tbl but for now this one has much the same meaning
 			case MULTI_END_ERROR_TEAM0_EMPTY:
-				strcat_s(err_msg,XSTR("All players from team 1 have left the game", 664));
+				strcat_s(err_msg,XSTR("All players from team 1 have left the game", 1645));
 				break;
 			case MULTI_END_ERROR_TEAM1_EMPTY:
-				strcat_s(err_msg,XSTR("All players from team 2 have left the game", 664));
+				strcat_s(err_msg,XSTR("All players from team 2 have left the game", 1646));
 				break;
 			case MULTI_END_ERROR_CAPTAIN_LEFT:
 				strcat_s(err_msg,XSTR("Team captain(s) have left the game, aborting...",664));

--- a/code/network/multi_pinfo.cpp
+++ b/code/network/multi_pinfo.cpp
@@ -352,7 +352,7 @@ void multi_pinfo_popup_init(net_player *np)
 	Multi_pinfo_stats_labels[5] = vm_strdup(XSTR("Primary Shots Fired", 1012));
 	Multi_pinfo_stats_labels[6] = vm_strdup(XSTR("Primary Hit %", 1013));
 	Multi_pinfo_stats_labels[7] = vm_strdup(XSTR("Secondary Shots Fired",	1014));
-	Multi_pinfo_stats_labels[8] = vm_strdup(XSTR("Secondary Hit %", 1015));				
+	Multi_pinfo_stats_labels[8] = vm_strdup(XSTR("Secondary Hit %", 1015));
 }
 
 // run the popup in a tight loop (no states)

--- a/code/network/multiui.cpp
+++ b/code/network/multiui.cpp
@@ -4970,7 +4970,7 @@ void multi_create_accept_hit()
 	if ( (Netgame.type_flags & NG_TYPE_COOP) && (Net_player->flags & NETINFO_FLAG_AM_MASTER) ) {
 		// check for time limit
 		if (Netgame.options.mission_time_limit != i2f(-1)) {
-			popup_choice = popup(0, 3, POPUP_CANCEL, POPUP_YES, XSTR( " &No", 506 ),
+			popup_choice = popup(0, 3, POPUP_CANCEL, POPUP_YES, POPUP_NO,
 								XSTR("A time limit is being used in a co-op game.\r\n"
 									"  Select \'Cancel\' to go back to the mission select screen.\r\n"
 									"  Select \'Yes\' to continue with this time limit.\r\n"
@@ -4985,7 +4985,7 @@ void multi_create_accept_hit()
 
 		// check kill limit (NOTE: <= 0 is considered no limit)
 		if ( (Netgame.options.kill_limit > 0) && (Netgame.options.kill_limit != 9999) ) {
-			popup_choice = popup(0, 3, POPUP_CANCEL, POPUP_YES, XSTR( " &No", 506 ),
+			popup_choice = popup(0, 3, POPUP_CANCEL, POPUP_YES, POPUP_NO,
 								XSTR("A kill limit is being used in a co-op game.\r\n"
 									"  Select \'Cancel\' to go back to the mission select screen.\r\n"
 									"  Select \'Yes\' to continue with this kill limit.\r\n"


### PR DESCRIPTION
This is a minor follow-up to PR #2390.  There are a few small differences between untranslated strings and the internal strings in strings.tbl; this PR fixes them.