### PR TITLE
Use architecture specific cache for Qt

### DIFF
--- a/.github/workflows/pr-workflow.yaml
+++ b/.github/workflows/pr-workflow.yaml
@@ -109,7 +109,7 @@ jobs:
         uses: actions/cache@v1
         with:
           path: ${{ github.workspace }}/../Qt
-          key: ${{ runner.os }}-QtCache-${{ env.QT_VERSION }}
+          key: ${{ runner.os }}-${{ matrix.arch }}-QtCache-${{ env.QT_VERSION }}
       - name: Install Qt (32 bit)
         uses: jurplel/install-qt-action@v2
         if: ${{ matrix.compiler  == 'MSVC' && matrix.arch == 'Win32' }}


### PR DESCRIPTION
Otherwise 32-bit might bet binaries for 64-bit or the other way around.