### PR TITLE
Fix a bug in the debris deletion code

### DIFF
--- a/code/debris/debris.cpp
+++ b/code/debris/debris.cpp
@@ -37,6 +37,8 @@
 
 int		Num_hull_pieces;		// number of hull pieces in existance
 debris	Hull_debris_list;		// head of linked list for hull debris chunks, for quick search
+								// This list holds debris pieces that are set to expire when their lifetime runs out;
+								// pieces that were placed by FREDers (i.e. that have the DoNotExpire flag) should not be on it.
 
 debris Debris[MAX_DEBRIS_PIECES];
 
@@ -169,7 +171,7 @@ void debris_delete( object * obj )
 	db = &Debris[num];
 
 	Assert( Num_debris_pieces >= 0 );
-	if ( db->is_hull && (!db->flags[Debris_Flags::DoNotExpire]) ) {
+	if ( db->is_hull ) {
 		debris_remove_from_hull_list(db);
 	}
 

--- a/code/debris/debris.h
+++ b/code/debris/debris.h
@@ -13,6 +13,8 @@
 #define _DEBRIS_H
 
 #include "globalincs/pstypes.h"
+#include "globalincs/flagset.h"
+
 
 class object;
 struct CFILE;
@@ -20,9 +22,17 @@ class model_draw_list;
 
 #define MAX_DEBRIS_ARCS 8		// Must be less than MAX_ARC_EFFECTS in model.h
 
+FLAG_LIST(Debris_Flags) {
+	Used,
+	DoNotExpire,		// This debris piece has been placed in FRED and should not expire automatically
+
+	NUM_VALUES
+};
+
+
 typedef struct debris {
-	debris	*next, *prev;		// used for a linked list of the hull debris chunks
-	int		flags;					// See DEBRIS_??? defines
+	debris	*next, *prev;		 // used for a linked list of the hull debris chunks
+	flagset<Debris_Flags> flags; // See DEBRIS_??? defines
 	int		source_objnum;		// What object this came from
 	int		damage_type_idx;	// Damage type of this debris
 	int		ship_info_index;	// Ship info index of the ship type debris came from
@@ -48,11 +58,6 @@ typedef struct debris {
 	
 } debris;
 
-
-// flags for debris pieces
-#define	DEBRIS_USED				(1<<0)
-#define	DEBRIS_EXPIRE			(1<<1)	// debris can expire (ie hull chunks from small ships)
-
 #define	MAX_DEBRIS_PIECES	64
 
 extern	debris Debris[MAX_DEBRIS_PIECES];
@@ -69,6 +74,6 @@ object *debris_create( object * source_obj, int model_num, int submodel_num, vec
 int debris_check_collision( object * obj, object * other_obj, vec3d * hitpos, collision_info_struct *debris_hit_info=NULL, vec3d* hitnormal = NULL );
 void debris_hit( object * debris_obj, object * other_obj, vec3d * hitpos, float damage );
 int debris_get_team(object *objp);
-void debris_clear_expired_flag(debris *db);
+void debris_remove_from_hull_list(debris *db);
 
 #endif // _DEBRIS_H

--- a/code/graphics/shadows.cpp
+++ b/code/graphics/shadows.cpp
@@ -478,7 +478,7 @@ void shadows_render_all(float fov, matrix *eye_orient, vec3d *eye_pos)
 				debris *db;
 				db = &Debris[objp->instance];
 
-				if ( !(db->flags & DEBRIS_USED)){
+				if ( !(db->flags[Debris_Flags::Used])){
 					continue;
 				}
 								

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -3534,7 +3534,8 @@ void mission_parse_maybe_create_parse_object(p_object *pobjp)
 						continue;
 					if (db->source_objnum != real_objnum)		// not from this ship, move to next one
 						continue;
-
+					
+					debris_remove_from_hull_list(db);
 					db->flags.set(Debris_Flags::DoNotExpire);   // mark as don't expire
 					db->lifeleft = -1.0f;						// be sure that lifeleft == -1.0 so that it really doesn't expire!
 

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -3530,12 +3530,12 @@ void mission_parse_maybe_create_parse_object(p_object *pobjp)
 					debris *db;
 
 					db = &Debris[i];
-					if (!(db->flags & DEBRIS_USED))				// not used, move onto the next one.
+					if (!(db->flags[Debris_Flags::Used]))		// not used, move onto the next one.
 						continue;
 					if (db->source_objnum != real_objnum)		// not from this ship, move to next one
 						continue;
 
-					debris_clear_expired_flag(db);				// mark as don't expire
+					db->flags.set(Debris_Flags::DoNotExpire);   // mark as don't expire
 					db->lifeleft = -1.0f;						// be sure that lifeleft == -1.0 so that it really doesn't expire!
 
 					// now move the debris along its path for N seconds

--- a/code/object/object.cpp
+++ b/code/object/object.cpp
@@ -225,7 +225,7 @@ int free_object_slots(int num_used)
 	}
 
 	for (i=0; i<num_to_free; i++)
-		if ( (Objects[obj_list[i]].type == OBJ_DEBRIS) && (Debris[Objects[obj_list[i]].instance].flags & DEBRIS_EXPIRE) ) {
+		if ( (Objects[obj_list[i]].type == OBJ_DEBRIS) && (!Debris[Objects[obj_list[i]].instance].flags[Debris_Flags::DoNotExpire]) ) {
 			num_to_free--;
 			nprintf(("allender", "Freeing   DEBRIS object %3i\n", obj_list[i]));
 			Objects[obj_list[i]].flags.set(Object::Object_Flags::Should_be_dead);

--- a/code/ship/shipfx.cpp
+++ b/code/ship/shipfx.cpp
@@ -790,7 +790,7 @@ bool shipfx_eye_in_shadow( vec3d *eye_pos, object * src_obj, int sun_n )
 
 	int i;
 	for ( i = 0; i < MAX_DEBRIS_PIECES; i++, db++ )	{
-		if ( !(db->flags & DEBRIS_USED) || !db->is_hull ){
+		if ( !(db->flags[Debris_Flags::Used]) || !db->is_hull ){
 			continue;
 		}
 


### PR DESCRIPTION
Fix a bug in the debris deletion code introduced by the lab explosion feature commit. This also makes the debris code use the new flag system to mark debris pieces as nondeleteable instead of relying on a magic lifeleft value.