### PR TITLE
use get_operator_* optimizations

### DIFF
--- a/code/ai/aigoals.cpp
+++ b/code/ai/aigoals.cpp
@@ -1015,7 +1015,7 @@ void ai_add_goal_sub_sexp( int sexp, int type, ai_goal *aigp, char *actor_name )
 	}
 
 	if ( aigp->priority > MAX_GOAL_PRIORITY ) {
-		nprintf (("AI", "bashing sexpression priority of goal %s from %d to %d.\n", text, aigp->priority, MAX_GOAL_PRIORITY));
+		nprintf (("AI", "bashing sexpression priority of goal %s from %d to %d.\n", CTEXT(node), aigp->priority, MAX_GOAL_PRIORITY));
 		aigp->priority = MAX_GOAL_PRIORITY;
 	}
 

--- a/code/ai/aigoals.cpp
+++ b/code/ai/aigoals.cpp
@@ -835,11 +835,10 @@ void ai_add_wing_goal_player( int type, int mode, int submode, char *shipname, i
 void ai_add_goal_sub_sexp( int sexp, int type, ai_goal *aigp, char *actor_name )
 {
 	int node, dummy, op;
-	char *text;
 
 	Assert ( Sexp_nodes[sexp].first != -1 );
 	node = Sexp_nodes[sexp].first;
-	text = CTEXT(node);
+	op = get_operator_const( node );
 
 	aigp->signature = Ai_goal_signature++;
 
@@ -847,8 +846,6 @@ void ai_add_goal_sub_sexp( int sexp, int type, ai_goal *aigp, char *actor_name )
 	aigp->time = Missiontime;
 	aigp->type = type;
 	aigp->flags.reset();
-
-	op = get_operator_const( text );
 
 	switch (op) {
 
@@ -1083,14 +1080,9 @@ int ai_remove_goal_sexp_sub( int sexp, ai_goal* aigp )
 	int goalsubmode = -1;
 
 	/* Sexp node */
-	int node = -1;
+	int node = Sexp_nodes[sexp].first;
 	/* The operator to use */
-	char* op_text = NULL;
-	int op = -1;
-
-	node = Sexp_nodes[ sexp ].first;
-	op_text = CTEXT( node );
-	op = get_operator_const( op_text );
+	int op = get_operator_const( node );
 
 	/* We now need to determine what the mode and submode values are*/
 	switch( op )

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -5829,7 +5829,7 @@ bool post_process_mission()
 		if (is_sexp_top_level(i) && (!Fred_running || (i != Sexp_clipboard))) {
 			int result, bad_node, op;
 
-			op = get_operator_index(CTEXT(i));
+			op = get_operator_index(i);
 			Assert(op != -1);  // need to make sure it is an operator before we treat it like one..
 			result = check_sexp_syntax( i, query_operator_return_type(op), 1, &bad_node);
 

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -1738,7 +1738,7 @@ int check_sexp_syntax(int node, int return_type, int recursive, int *bad_node, i
 	if (Sexp_nodes[op_node].subtype != SEXP_ATOM_OPERATOR)
 		return SEXP_CHECK_OP_EXPECTED;  // not an operator, which it should always be
 
-	op = get_operator_index(CTEXT(op_node));
+	op = get_operator_index(op_node);
 	if (op == -1)
 		return SEXP_CHECK_UNKNOWN_OP;  // unrecognized operator
 
@@ -1791,7 +1791,7 @@ int check_sexp_syntax(int node, int return_type, int recursive, int *bad_node, i
 			if (Sexp_nodes[i].subtype == SEXP_ATOM_LIST)
 				return 0;
 
-			op2 = get_operator_index(CTEXT(i));
+			op2 = get_operator_index(i);
 			if (op2 == -1)
 				return SEXP_CHECK_UNKNOWN_OP;
 
@@ -1865,7 +1865,7 @@ int check_sexp_syntax(int node, int return_type, int recursive, int *bad_node, i
 			}
 
 			i = atoi(CTEXT(node));
-			z = get_operator_const(CTEXT(op_node));
+			z = get_operator_const(op_node);
 			if ( (z == OP_HAS_DOCKED_DELAY) || (z == OP_HAS_UNDOCKED_DELAY) )
 				if ( (argnum == 2) && (i < 1) )
 					return SEXP_CHECK_NUM_RANGE_INVALID;
@@ -1879,7 +1879,7 @@ int check_sexp_syntax(int node, int return_type, int recursive, int *bad_node, i
 				}
 			}
 
-			z = get_operator_index(CTEXT(op_node));
+			z = get_operator_index(op_node);
 			if ( (query_operator_return_type(z) == OPR_AI_GOAL) && (argnum == Operators[op].min - 1) )
 				if ( (i < 0) || (i > 200) )
 					return SEXP_CHECK_NUM_RANGE_INVALID;
@@ -2096,7 +2096,7 @@ int check_sexp_syntax(int node, int return_type, int recursive, int *bad_node, i
 				// with that name.  This code assumes by default that the ship is *always* the first name
 				// in the sexpression.  If this is ever not the case, the code here must be changed to
 				// get the correct ship name.
-				switch(get_operator_const(CTEXT(op_node)))
+				switch(get_operator_const(op_node))
 				{
 					case OP_CAP_SUBSYS_CARGO_KNOWN_DELAY:
 					case OP_DISTANCE_SUBSYSTEM:
@@ -2477,7 +2477,7 @@ int check_sexp_syntax(int node, int return_type, int recursive, int *bad_node, i
 					int ship_num, ship2, w = 0;
 
 					// if it's the "goals" operator, this is part of initial orders, so just assume it's okay
-					if (get_operator_const(Sexp_nodes[op_node].text) == OP_GOALS_ID) {
+					if (get_operator_const(op_node) == OP_GOALS_ID) {
 						break;
 					}
 
@@ -2496,7 +2496,7 @@ int check_sexp_syntax(int node, int return_type, int recursive, int *bad_node, i
 					Assert(Sexp_nodes[node].subtype == SEXP_ATOM_LIST);
 					z = Sexp_nodes[node].first;
 					Assert(Sexp_nodes[z].subtype != SEXP_ATOM_LIST);
-					z = get_operator_const(CTEXT(z));
+					z = get_operator_const(z);
 					if (ship_num >= 0) {
 						if (!query_sexp_ai_goal_valid(z, ship_num)){
 							return SEXP_CHECK_ORDER_NOT_ALLOWED;
@@ -2704,14 +2704,14 @@ int check_sexp_syntax(int node, int return_type, int recursive, int *bad_node, i
 
 					// Look for the node containing the docker ship as its first argument. For set-docked, we want 
 					// the current SEXP. Otherwise (for ai-dock), we want its parent.
-					if (get_operator_const(Sexp_nodes[op_node].text) == OP_SET_DOCKED) {
+					if (get_operator_const(op_node) == OP_SET_DOCKED) {
 						z = op_node;
 					}
 					else {
 						z = find_parent_operator(op_node);
 					
 						// if it's the "goals" operator, this is part of initial orders, so just assume it's okay
-						if (get_operator_const(Sexp_nodes[z].text) == OP_GOALS_ID) {
+						if (get_operator_const(z) == OP_GOALS_ID) {
 							break;
 						}
 					}
@@ -2747,7 +2747,7 @@ int check_sexp_syntax(int node, int return_type, int recursive, int *bad_node, i
 					int ship_num, model;
 
 					// If we're using set-docked, we want to look up the ship from the third SEXP argument.
-					if (get_operator_const(Sexp_nodes[op_node].text) == OP_SET_DOCKED) {
+					if (get_operator_const(op_node) == OP_SET_DOCKED) {
 						//Navigate to the third argument
 						z = op_node;
 						for (i = 0; i < 3; i++)
@@ -3545,7 +3545,7 @@ int get_sexp()
 
 	
 	// Goober5000 - backwards compatibility for removed ai-chase-any-except
-	if (get_operator_const(CTEXT(start)) == OP_AI_CHASE_ANY)
+	if (get_operator_const(start) == OP_AI_CHASE_ANY)
 	{
 		// if there is more than one argument, free the extras
 		int n = CDR(CDR(start));
@@ -3563,11 +3563,11 @@ int get_sexp()
 
 		// see if we're using special arguments
 		parent = find_parent_operator(start);
-		if (parent >= 0 && is_blank_argument_op(get_operator_const(CTEXT(parent))))
+		if (parent >= 0 && is_blank_argument_op(get_operator_const(parent)))
 		{
 			// get the first op of the parent, which should be a *_of operator
 			arg_handler = CADR(parent);
-			if (arg_handler >= 0 && !is_blank_of_op(get_operator_const(CTEXT(arg_handler))))
+			if (arg_handler >= 0 && !is_blank_of_op(get_operator_const(arg_handler)))
 				arg_handler = -1;
 		}
 
@@ -3580,7 +3580,7 @@ int get_sexp()
 		arg_handler = -1;
 
 		// preload according to sexp
-		op = get_operator_const(CTEXT(start));
+		op = get_operator_const(start);
 		switch (op)
 		{
 			case OP_CHANGE_SHIP_CLASS:
@@ -9087,7 +9087,7 @@ int special_argument_appears_in_sexp_tree(int node)
 
 	// we don't want to include special arguments if they are nested in a new argument SEXP
 	if (Sexp_nodes[node].type == SEXP_ATOM && Sexp_nodes[node].subtype == SEXP_ATOM_OPERATOR) {
-		if (is_blank_argument_op(get_operator_const(CTEXT(node)))) {
+		if (is_blank_argument_op(get_operator_const(node))) {
 			return 0; 
 		}
 	}
@@ -9120,7 +9120,7 @@ void eval_when_do_one_exp(int exp)
 	arg_item *ptr;
 	int do_node;
 
-	switch (get_operator_const(CTEXT(exp)))
+	switch (get_operator_const(exp))
 	{
 		// if the op is a conditional then we just evaluate it
 		case OP_WHEN:
@@ -9199,7 +9199,7 @@ void eval_when_do_all_exp(int all_actions, int when_op_num)
 		{	
 			exp = CAR(actions);	
 
-			op_num = get_operator_const(CTEXT(exp));
+			op_num = get_operator_const(exp);
 
 			if (op_num == OP_DO_FOR_VALID_ARGUMENTS) {
 				int do_node = CDR(exp); 
@@ -9902,7 +9902,7 @@ void sexp_change_all_argument_validity(int n, bool invalidate)
 		return;
 
 	// can't change validity of for-counter
-	if (get_operator_const(CTEXT(arg_handler)) == OP_FOR_COUNTER)
+	if (get_operator_const(arg_handler) == OP_FOR_COUNTER)
 		return;
 		
 	while (n != -1)
@@ -9959,7 +9959,7 @@ void sexp_change_argument_validity(int n, bool invalidate)
 		return;
 
 	// can't change validity of for-counter
-	if (get_operator_const(CTEXT(arg_handler)) == OP_FOR_COUNTER)
+	if (get_operator_const(arg_handler) == OP_FOR_COUNTER)
 		return;
 		
 	// loop through arguments
@@ -10038,11 +10038,11 @@ int get_handler_for_x_of_operator(int n)
 			return -1;
 		}
 	}
-	while (!is_blank_argument_op(get_operator_const(CTEXT(conditional))));
+	while (!is_blank_argument_op(get_operator_const(conditional)));
 
 	// get the first op of the parent, which should be a *_of operator
 	arg_handler = CADR(conditional);
-	if (arg_handler < 0 || !is_blank_of_op(get_operator_const(CTEXT(arg_handler)))) {
+	if (arg_handler < 0 || !is_blank_of_op(get_operator_const(arg_handler))) {
 		return -1;
 	}
 
@@ -26949,7 +26949,7 @@ int get_sexp_main()
 	// only need to check syntax if we have a operator
 	if (!Fred_running && (start_node >= 0))
 	{
-		op = get_operator_index(CTEXT(start_node));
+		op = get_operator_index(start_node);
 		if (op < 0)
 		{
 			Error(LOCATION, "Can't find operator %s in operator list!\n", CTEXT(start_node));
@@ -29924,7 +29924,7 @@ void update_sexp_references(const char *old_name, const char *new_name, int form
 	if (Sexp_nodes[node].subtype != SEXP_ATOM_OPERATOR)
 		return;
 
-	op = get_operator_index(CTEXT(node));
+	op = get_operator_index(node);
 	Assert(Sexp_nodes[node].first < 0);
 	n = Sexp_nodes[node].rest;
 	i = 0;

--- a/code/parse/sexp.h
+++ b/code/parse/sexp.h
@@ -1189,7 +1189,9 @@ extern int is_sexp_top_level( int node );
 
 // Goober5000 - renamed these to be more clear, to prevent bugs :p
 extern int get_operator_index(const char *token);
+extern int get_operator_index(int node);
 extern int get_operator_const(const char *token);
+extern int get_operator_const(int node);
 
 extern int check_sexp_syntax(int node, int return_type = OPR_BOOL, int recursive = 0, int *bad_node = 0 /*NULL*/, int mode = 0);
 extern int get_sexp_main(void);	//	Returns start node

--- a/fred2/fredview.cpp
+++ b/fred2/fredview.cpp
@@ -3658,7 +3658,7 @@ void fred_check_message_personas()
 			continue;
 
 		// now look for the send-message opeator
-		op = get_operator_const( Sexp_nodes[i].text );
+		op = get_operator_const( i );
 		if ( op != OP_SEND_MESSAGE )
 			continue;
 

--- a/fred2/messageeditordlg.cpp
+++ b/fred2/messageeditordlg.cpp
@@ -299,19 +299,20 @@ int CMessageEditorDlg::find_event()
 		node = Mission_events[i].formula;
 		Assertion(node >= 0, "Can't have a formula point to sexp node -1!");
 
-		if ( get_operator_const(CTEXT(node)) == OP_WHEN || get_operator_const(CTEXT(node)) == OP_EVERY_TIME
-			|| get_operator_const(CTEXT(node)) == OP_WHEN_ARGUMENT || get_operator_const(CTEXT(node)) == OP_EVERY_TIME_ARGUMENT
-			|| get_operator_const(CTEXT(node)) == OP_IF_THEN_ELSE || get_operator_const(CTEXT(node)) == OP_PERFORM_ACTIONS )
+		int op_const = get_operator_const(node);
+		if (op_const == OP_WHEN || op_const == OP_EVERY_TIME
+			|| op_const == OP_WHEN_ARGUMENT || op_const == OP_EVERY_TIME_ARGUMENT
+			|| op_const == OP_IF_THEN_ELSE || op_const == OP_PERFORM_ACTIONS )
 		{
 			// Goober5000 - the bool part of the *-argument conditional starts at the second, not first, argument
-			if (is_blank_argument_op(get_operator_const(CTEXT(node))))
+			if (is_blank_argument_op(op_const))
 				node = CDR(node);
 
 			node = CDR(node);
 			formula = CAR(node);  // bool conditional
 			if (CDR(CDR(node)) == -1) {  // only 1 action
 				node = CADR(node);
-				if ((get_operator_const(CTEXT(node)) == OP_SEND_MESSAGE) && !stricmp(CTEXT(CDR(CDR(CDR(node)))), m_message_name)) {
+				if ((get_operator_const(node) == OP_SEND_MESSAGE) && !stricmp(CTEXT(CDDDR(node)), m_message_name)) {
 					box = (CComboBox *) GetDlgItem(IDC_SENDER);
 					str = CTEXT(CDR(node));
 					m_sender = box->FindStringExact(-1, str);
@@ -319,7 +320,7 @@ int CMessageEditorDlg::find_event()
 						m_sender = 0;
 
 					box = (CComboBox *) GetDlgItem(IDC_PRIORITY);
-					str = CTEXT(CDR(CDR(node)));
+					str = CTEXT(CDDR(node));
 					m_priority = box->FindStringExact(-1, str);
 					if (m_priority == CB_ERR)
 						m_priority = 0;

--- a/fred2/voiceactingmanager.cpp
+++ b/fred2/voiceactingmanager.cpp
@@ -742,7 +742,7 @@ char *VoiceActingManager::get_message_sender(char *message)
 			continue;
 
 		// stuff
-		int op = get_operator_const(Sexp_nodes[i].text);
+		int op = get_operator_const(i);
 		int n = CDR(i);
 
 		// find the message sexps
@@ -834,7 +834,7 @@ void VoiceActingManager::group_message_indexes_in_tree(int node, SCP_vector<int>
 		return;
 
 	// stuff
-	op = get_operator_const(Sexp_nodes[node].text);
+	op = get_operator_const(node);
 	n = CDR(node);
 
 	if (op == OP_SEND_MESSAGE_LIST)


### PR DESCRIPTION
Awhile back, the get_operator_const and get_operator_index functions were enhanced to cache the result of the operator lookup.  But this only works when called on the node itself, not the text.  So let's call these functions on the node whenever possible.