### PR TITLE
Add feature to execute Lua coroutines at specific points

### DIFF
--- a/cmake/Cxx11.cmake
+++ b/cmake/Cxx11.cmake
@@ -4,8 +4,6 @@ include(WriteCompilerDetectionHeader)
 set(CMAKE_CXX_STANDARD_REQUIRED 11)
 set(CMAKE_CXX_STANDARD 11)
 
-set(REQUIRED_CXX_FEATURES cxx_rvalue_references cxx_nullptr)
-
 get_property(CMAKE_CXX_KNOWN_FEATURES GLOBAL PROPERTY CMAKE_CXX_KNOWN_FEATURES)
 
 write_compiler_detection_header(

--- a/cmake/toolchain-gcc.cmake
+++ b/cmake/toolchain-gcc.cmake
@@ -98,7 +98,7 @@ set(COMPILER_FLAGS_RELEASE "-O2 -Wno-unused-variable -Wno-unused-but-set-variabl
 
 set(COMPILER_FLAGS_DEBUG "-O0 -g -Wshadow")
 
-# Always use the base flags and add our compiler flags at the bacl
+# Always use the base flags and add our compiler flags at the back
 set(CMAKE_CXX_FLAGS "${CXX_BASE_FLAGS} ${COMPILER_FLAGS}")
 set(CMAKE_C_FLAGS "${C_BASE_FLAGS} ${COMPILER_FLAGS}")
 

--- a/cmake/util.cmake
+++ b/cmake/util.cmake
@@ -184,7 +184,7 @@ function(detect_simd_instructions _out_var)
 endfunction()
 
 function (check_linker_flag _flag _out_var)
-	SET(CMAKE_REQUIRED_FLAGS "${_flag}")
+	SET(CMAKE_REQUIRED_LINK_OPTIONS "${_flag}")
 	CHECK_C_COMPILER_FLAG("" ${_out_var})
 endfunction(check_linker_flag)
 

--- a/code/CMakeLists.txt
+++ b/code/CMakeLists.txt
@@ -5,7 +5,7 @@ INCLUDE(voice_rec.cmake)
 
 ADD_LIBRARY(code STATIC ${source_files} ${VOICE_REC_FILES})
 
-target_compile_features(code PUBLIC ${REQUIRED_CXX_FEATURES})
+target_compile_features(code PUBLIC cxx_std_11)
 
 INCLUDE(default_files.cmake)
 

--- a/code/cfile/cfile.h
+++ b/code/cfile/cfile.h
@@ -18,6 +18,7 @@
 #include <ctime>
 #include <stdexcept>
 #include <memory>
+#include <utility>
 
 
 #define CF_EOF (-1)
@@ -437,11 +438,11 @@ namespace cfile
 			{
 			}
 
-			explicit cfile_error(const std::string &excuse) : m_excuse(excuse)
+			explicit cfile_error(std::string excuse) : m_excuse(std::move(excuse))
 			{
 			}
 
-			~cfile_error() noexcept override {}
+			~cfile_error() noexcept override = default;
 
 			const char *what() const noexcept override {
 				return m_excuse.c_str();

--- a/code/cfile/cfile.h
+++ b/code/cfile/cfile.h
@@ -441,9 +441,9 @@ namespace cfile
 			{
 			}
 
-			~cfile_error() SCP_NOEXCEPT override {}
+			~cfile_error() noexcept override {}
 
-			const char *what() const SCP_NOEXCEPT override {
+			const char *what() const noexcept override {
 				return m_excuse.c_str();
 			}
 

--- a/code/decals/decals.cpp
+++ b/code/decals/decals.cpp
@@ -48,10 +48,10 @@ class DecalDefinition {
 	DecalDefinition& operator=(const DecalDefinition&) = delete;
 
 	// Move constructor and operator
-	DecalDefinition(DecalDefinition&& other) SCP_NOEXCEPT {
+	DecalDefinition(DecalDefinition&& other) noexcept {
 		*this = std::move(other); // Use operator implementation
 	}
-	DecalDefinition& operator=(DecalDefinition&& other) SCP_NOEXCEPT {
+	DecalDefinition& operator=(DecalDefinition&& other) noexcept {
 		std::swap(_name, other._name);
 
 		std::swap(_diffuseFilename, other._diffuseFilename);

--- a/code/executor/Executor.cpp
+++ b/code/executor/Executor.cpp
@@ -1,0 +1,63 @@
+
+#include "Executor.h"
+
+#include "utils/finally.h"
+
+namespace executor {
+
+namespace {
+thread_local Executor* currentExecutorRef = nullptr;
+}
+
+Executor* currentExecutor() { return currentExecutorRef; }
+
+void Executor::post(Executor::Callback cb)
+{
+	// To avoid deadlocks or recusive mutexes we have a temporary list which contains work items not added to the queue
+	// yet. Those items will be transferred to the main queue in the next process call.
+	std::unique_lock<std::mutex> lock(m_pendingWorkItemsMutex);
+	m_pendingWorkItems.push_back(std::move(cb));
+}
+
+void Executor::process()
+{
+	// Ensure that no deadlocks happen when this is called from multiple threads
+	std::lock(m_mainMutex, m_pendingWorkItemsMutex);
+
+	Assertion(currentExecutorRef == nullptr, "Executor is already processing! Only one is allowed at a time.");
+	currentExecutorRef = this;
+	// Clean up ref after this function
+	auto _ = util::finally([]() { currentExecutorRef = nullptr; });
+
+	std::lock_guard<std::mutex> lk1(m_mainMutex, std::adopt_lock);
+	{
+		// Only need this for a limited time so we do this in a separate scope
+		std::lock_guard<std::mutex> lk2(m_pendingWorkItemsMutex, std::adopt_lock);
+
+		// Now move the pending items over to the actual work list
+		std::move(m_pendingWorkItems.begin(), m_pendingWorkItems.end(), std::back_inserter(m_workItems));
+		m_pendingWorkItems.clear();
+	}
+
+	for (auto iter = m_workItems.begin(); iter != m_workItems.end();) {
+		auto& cb = *iter;
+		if (cb() == CallbackResult::Done) {
+			// This callback does not want to be called again
+			// if we're sitting on the very last work item, popping-back will invalidate the iterator!
+			if (iter + 1 == m_workItems.end()) {
+				m_workItems.pop_back();
+				break;
+			}
+
+			// Remove entry without copying it since the current iterator value is not needed anymore
+			std::iter_swap(iter, std::prev(m_workItems.end()));
+			m_workItems.pop_back();
+			continue;
+		}
+
+		// next particle
+		++iter;
+	}
+}
+
+} // namespace executor

--- a/code/executor/Executor.h
+++ b/code/executor/Executor.h
@@ -1,0 +1,54 @@
+#pragma once
+
+#include "globalincs/pstypes.h"
+
+#include <mutex>
+
+namespace executor {
+
+/**
+ * @brief A class that collects work that should be executed repeatedly.
+ *
+ * The intention behind this is that the engine code creates executor objects and then calls process() on them at
+ * specific points of the engine code. External code can then post() work items to be executed when that point of the
+ * code is reached without introducing a hard dependency between the two code modules.
+ *
+ * Work items have the option of specifying that they should be rescheduled for the next execution round.
+ *
+ * @note This class is thread safe and work items can be posted to the executor from different threads without risking
+ * data corruption.
+ */
+class Executor {
+  public:
+	enum class CallbackResult {
+		Done,       //! The work item is finished
+		Reschedule, //! The work item should be executed again in the next round
+	};
+
+	using Callback = std::function<CallbackResult()>;
+
+	/**
+	 * @brief Adds a work item to this executor
+	 *
+	 * This work item will be executed every time process() is called until it returns CallbackResult::Done.
+	 *
+	 * @param cb The work item
+	 */
+	void post(Callback cb);
+
+	/**
+	 * @brief Executes one round of work items
+	 */
+	void process();
+
+  private:
+	std::mutex m_mainMutex;
+	SCP_vector<Callback> m_workItems;
+
+	std::mutex m_pendingWorkItemsMutex;
+	SCP_vector<Callback> m_pendingWorkItems;
+};
+
+Executor* currentExecutor();
+
+} // namespace executor

--- a/code/executor/GameStateExecutionContext.cpp
+++ b/code/executor/GameStateExecutionContext.cpp
@@ -1,0 +1,42 @@
+#include "GameStateExecutionContext.h"
+
+#include "events/events.h"
+
+namespace executor {
+
+GameStateExecutionContext::GameStateExecutionContext(GS_STATE contextState, int stateInstance)
+	: m_contextState(contextState), m_stateInstanceId(stateInstance)
+{
+}
+GameStateExecutionContext::~GameStateExecutionContext() = default;
+
+IExecutionContext::State GameStateExecutionContext::determineContextState() const
+{
+	const auto depth = gameseq_get_state_idx(m_contextState);
+
+	if (depth < 0) {
+		// Our game state is not present anymore
+		return IExecutionContext::State::Invalid;
+	}
+
+	if (gameseq_get_state() == m_contextState) {
+		// Check if this is still the same instance
+		if (gameseq_get_state_instance_id() != m_stateInstanceId) {
+			return IExecutionContext::State::Invalid;
+		}
+
+		// This is still the same state and it is active
+		return State::Valid;
+	}
+
+	// We are not in the correct state but it is still in the stack so we might return to it at some point
+	return State::Suspended;
+}
+
+std::shared_ptr<IExecutionContext> GameStateExecutionContext::captureContext()
+{
+	return std::make_shared<GameStateExecutionContext>(static_cast<GS_STATE>(gameseq_get_state()),
+		gameseq_get_state_instance_id());
+}
+
+} // namespace executor

--- a/code/executor/GameStateExecutionContext.h
+++ b/code/executor/GameStateExecutionContext.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include "IExecutionContext.h"
+
+#include "gamesequence/gamesequence.h"
+#include "utils/event.h"
+
+namespace executor {
+
+/**
+ * @brief An execution context that captures the game state
+ *
+ * This will only execute if the game state is the same as at the time when captureContext() was called. If a game state
+ * is pushed onto the stack then this context will only suspend. Should the game state change completely then this
+ * context will be invalid. Will also become invalid if the same game state is active but with a different instance id.
+ */
+class GameStateExecutionContext : public IExecutionContext, public std::enable_shared_from_this<GameStateExecutionContext> {
+  public:
+	GameStateExecutionContext(GS_STATE contextState, int stateInstance);
+	~GameStateExecutionContext() override;
+
+	State determineContextState() const override;
+
+	static std::shared_ptr<IExecutionContext> captureContext();
+
+  private:
+	GS_STATE m_contextState = GS_STATE_INVALID;
+	int m_stateInstanceId = -1;
+};
+
+} // namespace executor

--- a/code/executor/IExecutionContext.cpp
+++ b/code/executor/IExecutionContext.cpp
@@ -2,7 +2,8 @@
 
 namespace executor {
 
-Executor::Callback runInContext(std::shared_ptr<IExecutionContext> context, IExecutionContext::Callback func)
+Executor::Callback runInContext(const std::shared_ptr<IExecutionContext>& context,
+	const IExecutionContext::Callback& func)
 {
 	return [context, func]() {
 		const auto ctxState = context->determineContextState();

--- a/code/executor/IExecutionContext.cpp
+++ b/code/executor/IExecutionContext.cpp
@@ -1,0 +1,29 @@
+#include "IExecutionContext.h"
+
+namespace executor {
+
+Executor::Callback runInContext(std::shared_ptr<IExecutionContext> context, IExecutionContext::Callback func)
+{
+	return [context, func]() {
+		const auto ctxState = context->determineContextState();
+
+		switch (ctxState) {
+		case IExecutionContext::State::Valid:
+			// We are in a valid state so execute our wrapped function
+			return func(IExecutionContext::State::Valid);
+		case IExecutionContext::State::Suspended:
+			// The state is not valid but my return so keep this function alive
+			return Executor::CallbackResult::Reschedule;
+		case IExecutionContext::State::Invalid:
+			// Call the function once more to let it know that the state became invalid
+			func(IExecutionContext::State::Invalid);
+			// This state will not become valid again so we do not need to be rescheduled
+			return Executor::CallbackResult::Done;
+		default:
+			UNREACHABLE("Unhandled context state %d", static_cast<int>(ctxState));
+			return Executor::CallbackResult::Done;
+		}
+	};
+}
+
+} // namespace executor

--- a/code/executor/IExecutionContext.h
+++ b/code/executor/IExecutionContext.h
@@ -41,6 +41,7 @@ class IExecutionContext {
  * @param func The function to wrap
  * @return An executor work item
  */
-Executor::Callback runInContext(std::shared_ptr<IExecutionContext> context, IExecutionContext::Callback func);
+Executor::Callback runInContext(const std::shared_ptr<IExecutionContext>& context,
+	const IExecutionContext::Callback& func);
 
 } // namespace executor

--- a/code/executor/IExecutionContext.h
+++ b/code/executor/IExecutionContext.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include "Executor.h"
+
+namespace executor {
+
+/**
+ * @brief Abstract class representing the context of an execution.
+ *
+ * This is intended to be used with executors to ensure that work items are only executed in the same context as they
+ * were started. See runInContext() for how to use this with executors.
+ */
+class IExecutionContext {
+  public:
+	enum class State {
+		Valid,     //! We are currently in the state captured in this context
+		Suspended, //! We are in a state that is not valid but may return to the captured state
+		Invalid,   //! We are in an unrelated state
+	};
+
+	using Callback = std::function<Executor::CallbackResult(State contextState)>;
+
+	virtual ~IExecutionContext() = default;
+
+	/**
+	 * @brief Determines the state of the context
+	 * @return The context state
+	 */
+	virtual State determineContextState() const = 0;
+};
+
+/**
+ * @brief Wraps the specified callback in an execution context
+ *
+ * The return value is a work item for an executor that will only call the passed function when the context is valid.
+ * The function will not be called when the context is suspended. Should the context become invalid, the function will
+ * be called one last time with State::Invalid to indicate to the function that the context became invalid. This is
+ * useful to do cleanup work (e.g. setting an error state in created Lua Promises).
+ *
+ * @param context The execution context
+ * @param func The function to wrap
+ * @return An executor work item
+ */
+Executor::Callback runInContext(std::shared_ptr<IExecutionContext> context, IExecutionContext::Callback func);
+
+} // namespace executor

--- a/code/executor/global_executors.cpp
+++ b/code/executor/global_executors.cpp
@@ -1,0 +1,10 @@
+
+#include "global_executors.h"
+
+namespace executor {
+
+const std::shared_ptr<Executor> OnSimulationExecutor = std::make_shared<Executor>();
+
+const std::shared_ptr<Executor> OnFrameExecutor = std::make_shared<Executor>();
+
+} // namespace executor

--- a/code/executor/global_executors.h
+++ b/code/executor/global_executors.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "Executor.h"
+
+namespace executor
+{
+
+/**
+ * @brief Executor that will be called at the end of every simulation frame.
+ */
+extern const std::shared_ptr<Executor> OnSimulationExecutor;
+
+/**
+ * @brief Executor that will be called just before the game triggers the presentation of the current frame.
+ */
+extern const std::shared_ptr<Executor> OnFrameExecutor;
+
+}

--- a/code/gamesequence/gamesequence.h
+++ b/code/gamesequence/gamesequence.h
@@ -193,11 +193,23 @@ void game_do_state(int current_state);
 // Kazan
 bool GameState_Stack_Valid();
 
-//WMC
+// WMC
 int gameseq_get_event_idx(const char* s);
 int gameseq_get_state_idx(const char* s);
 
-//zookeeper
+// zookeeper
 int gameseq_get_state_idx(int state);
+
+/**
+ * @brief Gets a state instance id of the specified depth.
+ *
+ * The instance ID is an integer associated with a specific instance of a state. Should the same state be entered later
+ * it will have a different instance id. This is meant to be used for keeping track of state changes without registering
+ * for the state change events.
+ *
+ * @param depth The depth in the stack to query the instance id
+ * @return The instance id
+ */
+int gameseq_get_state_instance_id(int depth = 0);
 
 #endif /* __GAMESEQUENCE_H__ */

--- a/code/globalincs/flagset.h
+++ b/code/globalincs/flagset.h
@@ -132,7 +132,7 @@ class flagset {
 namespace std {
 template <typename T, size_t N>
 struct hash<::flagset<T, N>> {
-	size_t operator()(const ::flagset<T, N>& val) { return val.hash(); }
+	size_t operator()(const ::flagset<T, N>& val) const { return val.hash(); }
 };
 } // namespace std
 

--- a/code/globalincs/scp_defines.h
+++ b/code/globalincs/scp_defines.h
@@ -8,14 +8,4 @@
 #define SCP_TOKEN_CONCAT1(x, y) x ## y
 #define SCP_TOKEN_CONCAT(x, y) SCP_TOKEN_CONCAT1(x, y)
 
-/**
- * Define for a function that should be constexpr but if the compiler doesn't support it then it uses inline
- */
-
-#if SCP_COMPILER_CXX_CONSTEXPR
-#define SCP_CONSTEXPR_FUNC constexpr
-#else
-#define SCP_CONSTEXPR_FUNC inline
-#endif
-
 #endif // SCP_DEFINES_H

--- a/code/graphics/2d.cpp
+++ b/code/graphics/2d.cpp
@@ -24,6 +24,7 @@
 
 #include "cmdline/cmdline.h"
 #include "debugconsole/console.h"
+#include "executor/global_executors.h"
 #include "graphics/opengl/gropengl.h"
 #include "graphics/paths/PathRenderer.h"
 #include "graphics/util/GPUMemoryHeap.h"
@@ -2617,6 +2618,9 @@ static void output_uniform_debug_data()
 
 void gr_flip(bool execute_scripting)
 {
+	// Execute external "On Frame" work items
+	executor::OnFrameExecutor->process();
+
 	// m!m avoid running CHA_ONFRAME when the "Quit mission" popup is shown. See mantis 2446 for reference
 	if (execute_scripting && !popup_active()) {
 		TRACE_SCOPE(tracing::LuaOnFrame);

--- a/code/graphics/opengl/ShaderProgram.cpp
+++ b/code/graphics/opengl/ShaderProgram.cpp
@@ -157,11 +157,11 @@ opengl::ShaderProgram::~ShaderProgram() {
 	}
 }
 
-opengl::ShaderProgram::ShaderProgram(ShaderProgram&& other) SCP_NOEXCEPT : _program_id(0), Uniforms(this) {
+opengl::ShaderProgram::ShaderProgram(ShaderProgram&& other) noexcept : _program_id(0), Uniforms(this) {
 	*this = std::move(other);
 }
 
-opengl::ShaderProgram& opengl::ShaderProgram::operator=(ShaderProgram&& other) SCP_NOEXCEPT {
+opengl::ShaderProgram& opengl::ShaderProgram::operator=(ShaderProgram&& other) noexcept {
 	std::swap(_program_id, other._program_id);
 	std::swap(Uniforms, other.Uniforms);
 

--- a/code/graphics/opengl/ShaderProgram.h
+++ b/code/graphics/opengl/ShaderProgram.h
@@ -58,8 +58,8 @@ class ShaderProgram {
 	ShaderProgram(const ShaderProgram&) SCP_DELETED_FUNCTION;
 	ShaderProgram& operator=(const ShaderProgram&) SCP_DELETED_FUNCTION;
 
-	ShaderProgram(ShaderProgram&& other) SCP_NOEXCEPT;
-	ShaderProgram& operator=(ShaderProgram&& other) SCP_NOEXCEPT;
+	ShaderProgram(ShaderProgram&& other) noexcept;
+	ShaderProgram& operator=(ShaderProgram&& other) noexcept;
 
 	void use();
 

--- a/code/graphics/opengl/gropenglshader.cpp
+++ b/code/graphics/opengl/gropenglshader.cpp
@@ -230,10 +230,10 @@ opengl_shader_t *Current_shader = NULL;
 opengl_shader_t::opengl_shader_t() : shader(SDR_TYPE_NONE), flags(0), flags2(0)
 {
 }
-opengl_shader_t::opengl_shader_t(opengl_shader_t&& other) SCP_NOEXCEPT {
+opengl_shader_t::opengl_shader_t(opengl_shader_t&& other) noexcept {
 	*this = std::move(other);
 }
-opengl_shader_t& opengl_shader_t::operator=(opengl_shader_t&& other) SCP_NOEXCEPT {
+opengl_shader_t& opengl_shader_t::operator=(opengl_shader_t&& other) noexcept {
 	// VS2013 doesn't support implicit move constructors so we need to explicitly declare it
 	shader = other.shader;
 	flags = other.flags;

--- a/code/graphics/opengl/gropenglshader.cpp
+++ b/code/graphics/opengl/gropenglshader.cpp
@@ -233,6 +233,7 @@ opengl_shader_t::opengl_shader_t() : shader(SDR_TYPE_NONE), flags(0), flags2(0)
 opengl_shader_t::opengl_shader_t(opengl_shader_t&& other) noexcept {
 	*this = std::move(other);
 }
+// NOLINTNEXTLINE(misc-unconventional-assign-operator)
 opengl_shader_t& opengl_shader_t::operator=(opengl_shader_t&& other) noexcept {
 	// VS2013 doesn't support implicit move constructors so we need to explicitly declare it
 	shader = other.shader;

--- a/code/graphics/opengl/gropenglshader.h
+++ b/code/graphics/opengl/gropenglshader.h
@@ -127,8 +127,8 @@ typedef struct opengl_shader_t {
 
 	opengl_shader_t();
 
-	opengl_shader_t(opengl_shader_t&& other) SCP_NOEXCEPT;
-	opengl_shader_t& operator=(opengl_shader_t&& other) SCP_NOEXCEPT;
+	opengl_shader_t(opengl_shader_t&& other) noexcept;
+	opengl_shader_t& operator=(opengl_shader_t&& other) noexcept;
 
 	opengl_shader_t(const opengl_shader_t&) = delete;
 	opengl_shader_t& operator=(const opengl_shader_t&) = delete;

--- a/code/graphics/paths/NanoVGRenderer.h
+++ b/code/graphics/paths/NanoVGRenderer.h
@@ -35,10 +35,10 @@ class NanoVGRenderer {
 		Image(const Image&) = delete;
 		Image& operator=(const Image&) = delete;
 
-		Image(Image&& other) SCP_NOEXCEPT {
+		Image(Image&& other) noexcept {
 			*this = std::move(other);
 		}
-		Image& operator=(Image&& other) SCP_NOEXCEPT {
+		Image& operator=(Image&& other) noexcept {
 			std::swap(bitmap, other.bitmap);
 			std::swap(data, other.data);
 			std::swap(type, other.type);

--- a/code/graphics/software/FontManager.h
+++ b/code/graphics/software/FontManager.h
@@ -21,12 +21,12 @@ namespace font {
 
 		TrueTypeFontData() : size(0) { }
 
-		TrueTypeFontData(TrueTypeFontData &&other) SCP_NOEXCEPT {
+		TrueTypeFontData(TrueTypeFontData &&other) noexcept {
 			std::swap(data, other.data);
 			size = other.size;
 		}
 
-		TrueTypeFontData &operator=(TrueTypeFontData &&other) SCP_NOEXCEPT {
+		TrueTypeFontData &operator=(TrueTypeFontData &&other) noexcept {
 			std::swap(data, other.data);
 			size = other.size;
 

--- a/code/io/cursor.cpp
+++ b/code/io/cursor.cpp
@@ -66,12 +66,12 @@ namespace io
 	namespace mouse
 	{
 
-		Cursor::Cursor(Cursor&& other) SCP_NOEXCEPT
+		Cursor::Cursor(Cursor&& other) noexcept
 		{
 			*this = std::move(other);
 		}
 		
-		Cursor& Cursor::operator=(Cursor&& other) SCP_NOEXCEPT
+		Cursor& Cursor::operator=(Cursor&& other) noexcept
 		{
 			std::swap(this->mAnimationFrames, other.mAnimationFrames);
 			

--- a/code/io/cursor.h
+++ b/code/io/cursor.h
@@ -43,14 +43,14 @@ namespace io
 			 *
 			 * Transfers SDL resources to this newly constructed object
 			 */
-			Cursor(Cursor&& other) SCP_NOEXCEPT;
+			Cursor(Cursor&& other) noexcept;
 			
 			/**
 			 * @brief Move operator
 			 *
 			 * Transfers SDL resources to this object
 			 */
-			Cursor& operator=(Cursor&& other) SCP_NOEXCEPT;
+			Cursor& operator=(Cursor&& other) noexcept;
 
 			/**
 			 * @brief Cursor destructor

--- a/code/io/joy-sdl.cpp
+++ b/code/io/joy-sdl.cpp
@@ -395,7 +395,7 @@ namespace joystick
 		fillValues();
 	}
 
-	Joystick::Joystick(Joystick &&other) SCP_NOEXCEPT :
+	Joystick::Joystick(Joystick &&other) noexcept :
 			_joystick(nullptr)
 	{
 		*this = std::move(other);
@@ -410,7 +410,7 @@ namespace joystick
 		}
 	}
 
-	Joystick &Joystick::operator=(Joystick &&other) SCP_NOEXCEPT
+	Joystick &Joystick::operator=(Joystick &&other) noexcept
 	{
 		std::swap(_device_id, other._device_id);
 		std::swap(_joystick, other._joystick);

--- a/code/io/joy.h
+++ b/code/io/joy.h
@@ -67,7 +67,7 @@ namespace io
 			 *
 			 * @param other A rvalue reference
 			 */
-			Joystick(Joystick &&other) SCP_NOEXCEPT;
+			Joystick(Joystick &&other) noexcept;
 
 			/**
 			 * @brief Frees the owned SDL handle
@@ -79,7 +79,7 @@ namespace io
 			 *
 			 * @param other A rvalue reference to the other object
 			 */
-			Joystick &operator=(Joystick &&other) SCP_NOEXCEPT;
+			Joystick &operator=(Joystick &&other) noexcept;
 
 			/**
 			 * @brief Determines if this joystick is still connected to the computer

--- a/code/jumpnode/jumpnode.cpp
+++ b/code/jumpnode/jumpnode.cpp
@@ -66,7 +66,7 @@ CJumpNode::CJumpNode(vec3d* position)
     m_objnum = obj_create(OBJ_JUMP_NODE, -1, -1, NULL, &m_pos, m_radius, default_flags);
 }
 
-CJumpNode::CJumpNode(CJumpNode&& other) SCP_NOEXCEPT
+CJumpNode::CJumpNode(CJumpNode&& other) noexcept
 	: m_radius(other.m_radius), m_modelnum(other.m_modelnum), m_objnum(other.m_objnum), m_polymodel_instance_num(other.m_polymodel_instance_num), m_flags(other.m_flags)
 {
 	other.m_radius = 0.0f;
@@ -81,7 +81,7 @@ CJumpNode::CJumpNode(CJumpNode&& other) SCP_NOEXCEPT
 	strcpy_s(m_name, other.m_name);
 }
 
-CJumpNode& CJumpNode::operator=(CJumpNode&& other) SCP_NOEXCEPT
+CJumpNode& CJumpNode::operator=(CJumpNode&& other) noexcept
 {
 	if (this != &other)
 	{

--- a/code/jumpnode/jumpnode.h
+++ b/code/jumpnode/jumpnode.h
@@ -48,9 +48,9 @@ public:
     //Constructors
     CJumpNode();
     CJumpNode(vec3d *position);
-	CJumpNode(CJumpNode&& other) SCP_NOEXCEPT;
+	CJumpNode(CJumpNode&& other) noexcept;
 
-	CJumpNode& operator=(CJumpNode&&) SCP_NOEXCEPT;
+	CJumpNode& operator=(CJumpNode&&) noexcept;
     
     //Destructor
     ~CJumpNode();

--- a/code/libs/ffmpeg/FFmpeg.h
+++ b/code/libs/ffmpeg/FFmpeg.h
@@ -14,7 +14,7 @@ void initialize();
 class FFmpegException: public std::runtime_error {
  public:
 	explicit FFmpegException(const std::string& msg) : std::runtime_error(msg) {}
-	~FFmpegException() SCP_NOEXCEPT override {}
+	~FFmpegException() noexcept override {}
 };
 
 }

--- a/code/libs/ffmpeg/FFmpeg.h
+++ b/code/libs/ffmpeg/FFmpeg.h
@@ -14,7 +14,7 @@ void initialize();
 class FFmpegException: public std::runtime_error {
  public:
 	explicit FFmpegException(const std::string& msg) : std::runtime_error(msg) {}
-	~FFmpegException() noexcept override {}
+	~FFmpegException() noexcept override = default;
 };
 
 }

--- a/code/parse/parselo.h
+++ b/code/parse/parselo.h
@@ -352,7 +352,7 @@ namespace parse
 	{
 	public:
 		explicit ParseException(const std::string& msg) : std::runtime_error(msg) {}
-		~ParseException() noexcept override {}
+		~ParseException() noexcept override = default;
 	};
 
 	/**

--- a/code/parse/parselo.h
+++ b/code/parse/parselo.h
@@ -352,7 +352,7 @@ namespace parse
 	{
 	public:
 		explicit ParseException(const std::string& msg) : std::runtime_error(msg) {}
-		~ParseException() SCP_NOEXCEPT override {}
+		~ParseException() noexcept override {}
 	};
 
 	/**

--- a/code/particle/ParticleSourceWrapper.cpp
+++ b/code/particle/ParticleSourceWrapper.cpp
@@ -12,7 +12,7 @@ namespace particle
 		m_sources.push_back(source);
 	}
 
-	ParticleSourceWrapper::ParticleSourceWrapper(ParticleSourceWrapper&& other) SCP_NOEXCEPT
+	ParticleSourceWrapper::ParticleSourceWrapper(ParticleSourceWrapper&& other) noexcept
 	{
 		*this = std::move(other);
 	}
@@ -28,7 +28,7 @@ namespace particle
 		}
 	}
 
-	ParticleSourceWrapper& ParticleSourceWrapper::operator=(ParticleSourceWrapper&& other) SCP_NOEXCEPT
+	ParticleSourceWrapper& ParticleSourceWrapper::operator=(ParticleSourceWrapper&& other) noexcept
 	{
 		std::swap(other.m_sources, m_sources);
 		return *this;

--- a/code/particle/ParticleSourceWrapper.h
+++ b/code/particle/ParticleSourceWrapper.h
@@ -40,9 +40,9 @@ namespace particle
 
 		~ParticleSourceWrapper();
 
-		ParticleSourceWrapper(ParticleSourceWrapper&& other) SCP_NOEXCEPT;
+		ParticleSourceWrapper(ParticleSourceWrapper&& other) noexcept;
 
-		ParticleSourceWrapper& operator=(ParticleSourceWrapper&& other) SCP_NOEXCEPT;
+		ParticleSourceWrapper& operator=(ParticleSourceWrapper&& other) noexcept;
 
 		void finish();
 

--- a/code/pngutils/pngutils.h
+++ b/code/pngutils/pngutils.h
@@ -94,7 +94,7 @@ class ApngException : public std::runtime_error
 {
  public:
 	explicit ApngException(const std::string& msg) : std::runtime_error(msg) {}
-	~ApngException() SCP_NOEXCEPT override {}
+	~ApngException() noexcept override {}
 };
 
 }

--- a/code/pngutils/pngutils.h
+++ b/code/pngutils/pngutils.h
@@ -94,7 +94,7 @@ class ApngException : public std::runtime_error
 {
  public:
 	explicit ApngException(const std::string& msg) : std::runtime_error(msg) {}
-	~ApngException() noexcept override {}
+	~ApngException() noexcept override = default;
 };
 
 }

--- a/code/scripting/api/LuaCoroutineRunner.cpp
+++ b/code/scripting/api/LuaCoroutineRunner.cpp
@@ -16,18 +16,73 @@ namespace {
  */
 class run_resolve_context : public resolve_context, public std::enable_shared_from_this<run_resolve_context> {
   public:
-	run_resolve_context(luacpp::LuaThread coroutine) : _coroutine(std::move(coroutine)) {}
+	run_resolve_context(luacpp::LuaThread coroutine,
+		std::shared_ptr<executor::Executor> executor,
+		std::shared_ptr<executor::IExecutionContext> executionContext)
+		: _coroutine(std::move(coroutine)), _executor(std::move(executor)),
+		  _executionContext(std::move(executionContext))
+	{
+	}
 
-	~run_resolve_context() override = default;
 	void setResolver(Resolver resolver) override
 	{
 		m_resolver = std::move(resolver);
 
 		// Kick off the coroutine once we know that someone cares about its result
-		resumeCoroutine(luacpp::LuaValueList());
+		scheduleResume(luacpp::LuaValueList());
 	}
 
   private:
+	void postToExecutor(executor::Executor::Callback cb)
+	{
+		if (_executor.get() == executor::currentExecutor()) {
+			// We are already in the right executor so we can invoke the callback directly
+			const auto ret = cb();
+			// It is possible that we get a reschedule here if the execution state is currently suspended
+			if (ret == executor::Executor::CallbackResult::Reschedule) {
+				_executor->post(std::move(cb));
+			}
+		} else {
+			_executor->post(std::move(cb));
+		}
+	}
+
+	void scheduleResume(const luacpp::LuaValueList& resumeParams)
+	{
+		if (!_executor) {
+			// If we have no executor we just execute the resume directly
+			resumeCoroutine(resumeParams);
+			return;
+		}
+
+		auto self = shared_from_this();
+		if (_executionContext) {
+			// If we have a context, wrap our resumer in that so that we only execute in our context
+			postToExecutor(executor::runInContext(_executionContext,
+				[this, self, resumeParams](executor::IExecutionContext::State state) {
+					if (state == executor::IExecutionContext::State::Invalid) {
+						// State became invalid while waiting
+						auto errorMessage = luacpp::LuaValue::createValue(_coroutine.getLuaState(),
+							"Coroutine context became invalid.");
+						m_resolver(true, {errorMessage});
+						m_resolver = nullptr;
+						return executor::Executor::CallbackResult::Done;
+					}
+
+					resumeCoroutine(resumeParams);
+					// We only need to run this once
+					return executor::Executor::CallbackResult::Done;
+				}));
+			return;
+		}
+
+		postToExecutor([this, self, resumeParams]() {
+			resumeCoroutine(resumeParams);
+			// We only need to run this once
+			return executor::Executor::CallbackResult::Done;
+		});
+	}
+
 	void resumeCoroutine(const luacpp::LuaValueList& resumeParams)
 	{
 		const auto result = _coroutine.resume(resumeParams);
@@ -35,6 +90,9 @@ class run_resolve_context : public resolve_context, public std::enable_shared_fr
 		if (result.completed) {
 			// Thread is finished! We can call our resolver
 			m_resolver(false, result.returnVals);
+
+			// Clean up reference since we do not need this anymore
+			m_resolver = nullptr;
 			return;
 		}
 
@@ -46,8 +104,9 @@ class run_resolve_context : public resolve_context, public std::enable_shared_fr
 		auto promiseStackStart = lua_gettop(_coroutine.getLuaState());
 		result.returnVals.front().pushValue(_coroutine.getLuaState());
 
-		internal::Ade_get_args_skip = promiseStackStart;
-		LuaPromise* promise         = nullptr;
+		internal::Ade_get_args_skip      = promiseStackStart;
+		internal::Ade_get_args_lfunction = true;
+		LuaPromise* promise              = nullptr;
 		if (!ade_get_args(_coroutine.getLuaState(), "o", l_Promise.GetPtr(&promise))) {
 			internal::Ade_get_args_skip = 0;
 			LuaError(_coroutine.getLuaState(),
@@ -55,35 +114,43 @@ class run_resolve_context : public resolve_context, public std::enable_shared_fr
 				"coroutines.");
 			return;
 		}
-		internal::Ade_get_args_skip = 0;
+		internal::Ade_get_args_lfunction = false;
+		internal::Ade_get_args_skip      = 0;
+
+		lua_settop(_coroutine.getLuaState(), promiseStackStart);
 
 		// Register ourself to be called when the promise resolves so that we can resume our coroutine
 		auto self = shared_from_this();
-		promise
-			->then([this, self](const luacpp::LuaValueList& resolveVals) {
-				// Since "self" keeps "this" alive it is safe to access that here
-				resumeCoroutine(resolveVals);
+		promise->then([this, self](const luacpp::LuaValueList& resolveVals) {
+			// Since "self" keeps "this" alive it is safe to access that here
+			scheduleResume(resolveVals);
 
-				return luacpp::LuaValueList();
-			})
-			.catchError([this, self](const luacpp::LuaValueList& resolveVals) {
-				// If the awaited coroutine causes an error we stop the coroutine and propagate that error to the
-				// promise
-				m_resolver(true, resolveVals);
+			return luacpp::LuaValueList();
+		});
+		promise->catchError([this, self](const luacpp::LuaValueList& resolveVals) {
+			// If the awaited coroutine causes an error we stop the coroutine and propagate that error to the
+			// promise
+			m_resolver(true, resolveVals);
+			m_resolver = nullptr;
 
-				return luacpp::LuaValueList();
-			});
+			return luacpp::LuaValueList();
+		});
 	}
 
 	Resolver m_resolver;
 	luacpp::LuaThread _coroutine;
+	std::shared_ptr<executor::Executor> _executor;
+	std::shared_ptr<executor::IExecutionContext> _executionContext;
 };
 
 } // namespace
 
-LuaPromise runAsyncCoroutine(luacpp::LuaThread luaThread)
+LuaPromise runAsyncCoroutine(luacpp::LuaThread luaThread,
+	std::shared_ptr<executor::Executor> executor,
+	std::shared_ptr<executor::IExecutionContext> executionContext)
 {
-	return LuaPromise(std::make_shared<run_resolve_context>(std::move(luaThread)));
+	return LuaPromise(
+		std::make_shared<run_resolve_context>(std::move(luaThread), std::move(executor), std::move(executionContext)));
 }
 
 } // namespace api

--- a/code/scripting/api/LuaCoroutineRunner.h
+++ b/code/scripting/api/LuaCoroutineRunner.h
@@ -2,6 +2,8 @@
 
 #include "LuaPromise.h"
 
+#include "executor/Executor.h"
+#include "executor/IExecutionContext.h"
 #include "scripting/lua/LuaThread.h"
 
 namespace scripting {
@@ -14,9 +16,14 @@ namespace api {
  * which suspends the coroutine until that promise resolves.
  *
  * @param luaThread The lua coroutine to run
+ * @param executor The executor on which the code of the coroutine should be executed. May be nullptr.
+ * @param executionContext The context to use for execution. Code on the coroutine will only be executed when the
+ * context is valid.
  * @return A LuaPromise that will resolve with the value returned when the coroutine completes
  */
-LuaPromise runAsyncCoroutine(luacpp::LuaThread luaThread);
+LuaPromise runAsyncCoroutine(luacpp::LuaThread luaThread,
+	std::shared_ptr<executor::Executor> executor,
+	std::shared_ptr<executor::IExecutionContext> executionContext);
 
 } // namespace api
 } // namespace scripting

--- a/code/scripting/api/LuaPromise.h
+++ b/code/scripting/api/LuaPromise.h
@@ -36,12 +36,13 @@ class LuaPromise {
 	 * @brief Initializes an invalid promise
 	 */
 	LuaPromise();
+	virtual ~LuaPromise();
 
 	/**
 	 * @brief Creates a pending promise
 	 * @param resolveContext The context to register on
 	 */
-	explicit LuaPromise(std::shared_ptr<resolve_context> resolveContext);
+	explicit LuaPromise(const std::shared_ptr<resolve_context>& resolveContext);
 
 	LuaPromise(const LuaPromise&);
 	LuaPromise& operator=(const LuaPromise&);

--- a/code/scripting/api/libs/mission.cpp
+++ b/code/scripting/api/libs/mission.cpp
@@ -829,7 +829,7 @@ ADE_FUNC(createShip,
 {
 	const char* name = nullptr;
 	int sclass       = -1;
-	matrix_h* orient = NULL;
+	matrix_h* orient = nullptr;
 	vec3d pos        = vmd_zero_vector;
 	ade_get_args(L, "|sooo", &name, l_Shipclass.Get(&sclass), l_Matrix.GetPtr(&orient), l_Vector.Get(&pos));
 

--- a/code/scripting/api/libs/mission.cpp
+++ b/code/scripting/api/libs/mission.cpp
@@ -3,13 +3,17 @@
 
 #include "mission.h"
 
+#include "globalincs/linklist.h"
+
 #include "freespace.h"
 
 #include "asteroid/asteroid.h"
 #include "debris/debris.h"
+#include "executor/GameStateExecutionContext.h"
+#include "executor/global_executors.h"
 #include "gamesequence/gamesequence.h"
-#include "globalincs/linklist.h"
 #include "hud/hudescort.h"
+#include "hud/hudmessage.h"
 #include "iff_defs/iff_defs.h"
 #include "mission/missioncampaign.h"
 #include "mission/missiongoals.h"
@@ -22,6 +26,7 @@
 #include "parse/sexp/DynamicSEXP.h"
 #include "parse/sexp/LuaSEXP.h"
 #include "parse/sexp/sexp_lookup.h"
+#include "scripting/api/LuaPromise.h"
 #include "scripting/api/objs/LuaSEXP.h"
 #include "scripting/api/objs/asteroid.h"
 #include "scripting/api/objs/background_element.h"
@@ -32,6 +37,7 @@
 #include "scripting/api/objs/message.h"
 #include "scripting/api/objs/object.h"
 #include "scripting/api/objs/parse_object.h"
+#include "scripting/api/objs/promise.h"
 #include "scripting/api/objs/sexpvar.h"
 #include "scripting/api/objs/ship.h"
 #include "scripting/api/objs/shipclass.h"
@@ -784,8 +790,7 @@ ADE_FUNC(sendTrainingMessage, l_Mission, "message message, number time[, number 
 		return ADE_RETURN_FALSE;
 	}
 
-	if (time < 0)
-	{
+	if (time < 0) {
 		LuaError(L, "Got invalid time of %d seconds!", time);
 		return ADE_RETURN_FALSE;
 	}
@@ -795,12 +800,37 @@ ADE_FUNC(sendTrainingMessage, l_Mission, "message message, number time[, number 
 	return ADE_RETURN_TRUE;
 }
 
-ADE_FUNC(createShip, l_Mission, "[string Name, shipclass Class=Shipclass[1], orientation Orientation=null, vector Position={0,0,0}]", "Creates a ship and returns a handle to it using the specified name, class, world orientation, and world position", "ship", "Ship handle, or invalid ship handle if ship couldn't be created")
+ADE_FUNC(sendPlainMessage,
+	l_Mission,
+	"string message",
+	"Sends a plain text message without it being present in the mission message list",
+	"boolean",
+	"true if successful false otherwise")
+{
+	const char* message = nullptr;
+
+	if (!ade_get_args(L, "s", &message))
+		return ADE_RETURN_FALSE;
+
+	if (message == nullptr)
+		return ADE_RETURN_FALSE;
+
+	HUD_sourced_printf(HUD_SOURCE_HIDDEN, "%s", message);
+
+	return ADE_RETURN_TRUE;
+}
+
+ADE_FUNC(createShip,
+	l_Mission,
+	"[string Name, shipclass Class=Shipclass[1], orientation Orientation=null, vector Position={0,0,0}]",
+	"Creates a ship and returns a handle to it using the specified name, class, world orientation, and world position",
+	"ship",
+	"Ship handle, or invalid ship handle if ship couldn't be created")
 {
 	const char* name = nullptr;
-	int sclass = -1;
-	matrix_h *orient = NULL;
-	vec3d pos = vmd_zero_vector;
+	int sclass       = -1;
+	matrix_h* orient = NULL;
+	vec3d pos        = vmd_zero_vector;
 	ade_get_args(L, "|sooo", &name, l_Shipclass.Get(&sclass), l_Matrix.GetPtr(&orient), l_Vector.Get(&pos));
 
 	matrix *real_orient = &vmd_identity_matrix;
@@ -1263,6 +1293,58 @@ ADE_FUNC(getArrivalList, l_Mission, nullptr, "Get the list of yet to arrive ship
 {
 	return ade_set_args(L, "u*o", luacpp::LuaFunction::createFromCFunction(L, arrivalListIter),
 	                    l_ParseObject.Set(parse_object_h(&Ship_arrival_list)));
+}
+
+ADE_FUNC(waitAsync,
+	l_Mission,
+	"number seconds",
+	"Performs an asynchronous wait until the specified amount of mission time has passed.",
+	"promise",
+	"A promise with no return value that resolves when the specified time has passed")
+{
+	float time = -1.0f;
+	if (!ade_get_args(L, "f", &time)) {
+		return ADE_RETURN_NIL;
+	}
+
+	if (time <= 0.0f) {
+		LuaError(L, "Invalid wait time %f specified. Must be greater than zero.", time);
+		return ADE_RETURN_NIL;
+	}
+
+	class time_resolve_context : public resolve_context, public std::enable_shared_from_this<time_resolve_context> {
+	  public:
+		time_resolve_context(int timestamp) : m_timestamp(timestamp) {}
+		void setResolver(Resolver resolver) override
+		{
+			// Keep checking the time until the timestamp is elapsed
+			auto self = shared_from_this();
+			auto cb = [this, self, resolver](
+						  executor::IExecutionContext::State contextState) {
+				if (contextState == executor::IExecutionContext::State::Invalid) {
+					resolver(true, luacpp::LuaValueList());
+					return executor::Executor::CallbackResult::Done;
+				}
+
+				if (timestamp_elapsed(m_timestamp)) {
+					resolver(false, luacpp::LuaValueList());
+					return executor::Executor::CallbackResult::Done;
+				}
+
+				return executor::Executor::CallbackResult::Reschedule;
+			};
+
+			// Use an game state execution context here to clean up references to this as soon as possible
+			executor::OnSimulationExecutor->post(
+				executor::runInContext(executor::GameStateExecutionContext::captureContext(), std::move(cb)));
+		}
+
+	  private:
+		int m_timestamp = -1;
+	};
+	return ade_set_args(L,
+		"o",
+		l_Promise.Set(LuaPromise(std::make_shared<time_resolve_context>(timestamp(fl2i(time * 1000.f))))));
 }
 
 //****LIBRARY: Campaign

--- a/code/scripting/api/objs/executor.cpp
+++ b/code/scripting/api/objs/executor.cpp
@@ -40,8 +40,8 @@ ADE_FUNC(schedule,
 	}
 
 	// Post the function onto the executor with a wrapper to convert the Lua value to the proper enum
-	executor->getExecutor()->post([func]() {
-		const auto ret = func();
+	executor->getExecutor()->post([L, func]() {
+		const auto ret = func(L);
 
 		if (ret.empty()) {
 			return executor::Executor::CallbackResult::Done;

--- a/code/scripting/api/objs/executor.cpp
+++ b/code/scripting/api/objs/executor.cpp
@@ -1,0 +1,82 @@
+
+#include "executor.h"
+
+#include <utility>
+
+namespace scripting {
+namespace api {
+
+executor_h::executor_h() = default;
+executor_h::executor_h(std::shared_ptr<executor::Executor> executor) : m_executor(std::move(executor)) {}
+bool executor_h::isValid() { return m_executor != nullptr; }
+const std::shared_ptr<executor::Executor>& executor_h::getExecutor() const { return m_executor; }
+
+//**********HANDLE: executor
+ADE_OBJ(l_Executor, executor_h, "executor", "An executor that can be used for scheduling the execution of a function.");
+
+ADE_FUNC(schedule,
+	l_Executor,
+	"function() -> boolean",
+	"Takes a function that returns a boolean and schedules that for execution on this executor. If the function "
+	"returns true it will be run again the. If it returns false it will be removed from the executor.<br>Note: Use "
+	"this with care since using this without proper care can lead to the function being run in states that are not "
+	"desired. Consider using async.run.",
+	"boolean",
+	"true if function was scheduled, false otherwise.")
+{
+	executor_h* executor = nullptr;
+	luacpp::LuaFunction func;
+	if (!ade_get_args(L, "ou", l_Executor.GetPtr(&executor), &func)) {
+		return ADE_RETURN_FALSE;
+	}
+
+	if (executor == nullptr || !executor->isValid()) {
+		return ADE_RETURN_FALSE;
+	}
+
+	if (!func.isValid()) {
+		LuaError(L, "Invalid function handle specified!");
+		return ADE_RETURN_FALSE;
+	}
+
+	// Post the function onto the executor with a wrapper to convert the Lua value to the proper enum
+	executor->getExecutor()->post([func]() {
+		const auto ret = func();
+
+		if (ret.empty()) {
+			return executor::Executor::CallbackResult::Done;
+		}
+
+		if (!ret[0].is(luacpp::ValueType::BOOLEAN)) {
+			return executor::Executor::CallbackResult::Done;
+		}
+
+		if (ret[0].getValue<bool>()) {
+			return executor::Executor::CallbackResult::Reschedule;
+		}
+		return executor::Executor::CallbackResult::Done;
+	});
+
+	return ADE_RETURN_TRUE;
+}
+
+ADE_FUNC(isValid,
+	l_Executor,
+	nullptr,
+	"Determined if this handle is valid",
+	"boolean",
+	"true if valid, false otherwise.")
+{
+	executor_h* executor = nullptr;
+	if (!ade_get_args(L, "o", l_Executor.GetPtr(&executor))) {
+		return ADE_RETURN_FALSE;
+	}
+
+	if (executor == nullptr || !executor->isValid()) {
+		return ADE_RETURN_FALSE;
+	}
+	return ADE_RETURN_TRUE;
+}
+
+} // namespace api
+} // namespace scripting

--- a/code/scripting/api/objs/executor.h
+++ b/code/scripting/api/objs/executor.h
@@ -1,0 +1,26 @@
+
+#pragma once
+
+#include "executor/Executor.h"
+#include "scripting/ade_api.h"
+
+namespace scripting {
+namespace api {
+
+class executor_h {
+  public:
+	executor_h();
+	executor_h(std::shared_ptr<executor::Executor> executor);
+
+	bool isValid();
+
+	const std::shared_ptr<executor::Executor>& getExecutor() const;
+
+  private:
+	std::shared_ptr<executor::Executor> m_executor;
+};
+
+DECLARE_ADE_OBJ(l_Executor, executor_h);
+
+} // namespace api
+} // namespace scripting

--- a/code/scripting/lua/LuaArgs.h
+++ b/code/scripting/lua/LuaArgs.h
@@ -14,10 +14,10 @@ namespace args {
 class ArgumentException: public LuaException {
  public:
 
-	ArgumentException(const std::string& message = "Argument Error!") SCP_NOEXCEPT : LuaException(message) {
+	ArgumentException(const std::string& message = "Argument Error!") noexcept : LuaException(message) {
 	}
 
-	~ArgumentException() SCP_NOEXCEPT override {
+	~ArgumentException() noexcept override {
 	}
 };
 

--- a/code/scripting/lua/LuaArgs.h
+++ b/code/scripting/lua/LuaArgs.h
@@ -17,8 +17,7 @@ class ArgumentException: public LuaException {
 	ArgumentException(const std::string& message = "Argument Error!") noexcept : LuaException(message) {
 	}
 
-	~ArgumentException() noexcept override {
-	}
+	~ArgumentException() noexcept override = default;
 };
 
 class opt {};

--- a/code/scripting/lua/LuaReference.cpp
+++ b/code/scripting/lua/LuaReference.cpp
@@ -41,10 +41,10 @@ UniqueLuaReference::UniqueLuaReference(lua_State* state, int reference) : _luaSt
 }
 UniqueLuaReference::UniqueLuaReference() : _luaState(nullptr), _reference(LUA_NOREF) {}
 
-UniqueLuaReference::UniqueLuaReference(UniqueLuaReference&& other) SCP_NOEXCEPT : _luaState(nullptr), _reference(LUA_NOREF) {
+UniqueLuaReference::UniqueLuaReference(UniqueLuaReference&& other) noexcept : _luaState(nullptr), _reference(LUA_NOREF) {
 	*this = std::move(other);
 }
-UniqueLuaReference& UniqueLuaReference::operator=(UniqueLuaReference&& other) SCP_NOEXCEPT {
+UniqueLuaReference& UniqueLuaReference::operator=(UniqueLuaReference&& other) noexcept {
 	std::swap(_luaState, other._luaState);
 	std::swap(_reference, other._reference);
 	return *this;

--- a/code/scripting/lua/LuaReference.h
+++ b/code/scripting/lua/LuaReference.h
@@ -4,8 +4,6 @@
 
 #include "LuaHeaders.h"
 
-#include <scp_compiler_detection.h>
-
 #include <memory>
 
 namespace luacpp {
@@ -76,8 +74,8 @@ class UniqueLuaReference {
 	UniqueLuaReference(const UniqueLuaReference&) = delete;
 	UniqueLuaReference& operator=(const UniqueLuaReference&) = delete;
 
-	UniqueLuaReference(UniqueLuaReference&& other) SCP_NOEXCEPT;
-	UniqueLuaReference& operator=(UniqueLuaReference&& other) SCP_NOEXCEPT;
+	UniqueLuaReference(UniqueLuaReference&& other) noexcept;
+	UniqueLuaReference& operator=(UniqueLuaReference&& other) noexcept;
 
 	lua_State* getState() { return _luaState; }
 

--- a/code/scripting/scripting.h
+++ b/code/scripting/scripting.h
@@ -166,6 +166,8 @@ struct HookVariableDocumentation {
 
 
 struct DocumentationElement {
+	virtual ~DocumentationElement() = default;
+
 	ElementType type = ElementType::Unknown;
 
 	SCP_string name;
@@ -177,10 +179,14 @@ struct DocumentationElement {
 };
 
 struct DocumentationElementClass : public DocumentationElement {
+	~DocumentationElementClass() override = default;
+
 	SCP_string superClass;
 };
 
 struct DocumentationElementProperty : public DocumentationElement {
+	~DocumentationElementProperty() override = default;
+
 	scripting::ade_type_info getterType;
 	SCP_string setterType;
 
@@ -188,6 +194,8 @@ struct DocumentationElementProperty : public DocumentationElement {
 };
 
 struct DocumentationElementFunction : public DocumentationElement {
+	~DocumentationElementFunction() override = default;
+
 	scripting::ade_type_info returnType;
 	SCP_string parameters;
 

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -1390,7 +1390,7 @@ void ship_info::free_strings()
 	CHECK_THEN_FREE(missile_banks);
 }
 
-ship_info &ship_info::operator= (ship_info&& other) SCP_NOEXCEPT
+ship_info &ship_info::operator= (ship_info&& other) noexcept
 {
 	if (this != &other) {
 		move(std::move(other));
@@ -1398,7 +1398,7 @@ ship_info &ship_info::operator= (ship_info&& other) SCP_NOEXCEPT
 	return *this;
 }
 
-ship_info::ship_info(ship_info&& other) SCP_NOEXCEPT
+ship_info::ship_info(ship_info&& other) noexcept
 {
 	// MageKing17 - Initialize these pointers to NULL because otherwise move() will leave them uninitialized.
 	type_str = NULL;

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -1254,9 +1254,9 @@ public:
 	~ship_info();
 	void clone(const ship_info& other);
 
-	ship_info(ship_info&& other) SCP_NOEXCEPT;
+	ship_info(ship_info&& other) noexcept;
 
-	ship_info &operator=(ship_info&& other) SCP_NOEXCEPT;
+	ship_info &operator=(ship_info&& other) noexcept;
 
 	void free_strings();
 

--- a/code/source_groups.cmake
+++ b/code/source_groups.cmake
@@ -260,6 +260,18 @@ add_file_folder("ExceptionHandler"
 	exceptionhandler/exceptionhandler.h
 )
 
+# Executor files
+add_file_folder("Executor"
+	executor/Executor.cpp
+	executor/Executor.h
+	executor/GameStateExecutionContext.cpp
+	executor/GameStateExecutionContext.h
+	executor/global_executors.cpp
+	executor/global_executors.h
+	executor/IExecutionContext.cpp
+	executor/IExecutionContext.h
+)
+
 # ExternalDLL files
 add_file_folder("ExternalDLL"
 	external_dll/externalcode.h
@@ -1126,6 +1138,8 @@ add_file_folder("Scripting\\\\Api\\\\Objs"
 	scripting/api/objs/enums.h
 	scripting/api/objs/event.cpp
 	scripting/api/objs/event.h
+	scripting/api/objs/executor.cpp
+	scripting/api/objs/executor.h
 	scripting/api/objs/eye.cpp
 	scripting/api/objs/eye.h
 	scripting/api/objs/file.cpp
@@ -1359,8 +1373,9 @@ add_file_folder("Ui"
 
 add_file_folder("Utils"
 	utils/encoding.cpp
-    utils/encoding.h
-    utils/event.h
+	utils/encoding.h
+	utils/event.h
+	utils/finally.h
 	utils/HeapAllocator.cpp
 	utils/HeapAllocator.h
 	utils/id.h

--- a/code/utils/boost/syncboundedqueue.h
+++ b/code/utils/boost/syncboundedqueue.h
@@ -33,7 +33,7 @@ class sync_queue_is_closed : public std::runtime_error
 {
 public:
 	sync_queue_is_closed() : std::runtime_error("Sync Bounded Queue is closed") {}
-	~sync_queue_is_closed() noexcept override {}
+	~sync_queue_is_closed() noexcept override = default;
 };
 
 template <typename ValueType>

--- a/code/utils/boost/syncboundedqueue.h
+++ b/code/utils/boost/syncboundedqueue.h
@@ -33,7 +33,7 @@ class sync_queue_is_closed : public std::runtime_error
 {
 public:
 	sync_queue_is_closed() : std::runtime_error("Sync Bounded Queue is closed") {}
-	~sync_queue_is_closed() SCP_NOEXCEPT override {}
+	~sync_queue_is_closed() noexcept override {}
 };
 
 template <typename ValueType>

--- a/code/utils/finally.h
+++ b/code/utils/finally.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <utility>
+
+namespace util {
+namespace detail {
+template <typename F>
+struct FinalAction {
+	FinalAction(F f) : m_finally{std::move(f)} {}
+	~FinalAction()
+	{
+		if (m_enabled) {
+			m_finally();
+		}
+	}
+
+	void disable() { m_enabled = false; };
+
+  private:
+	F m_finally;
+	bool m_enabled{true};
+};
+} // namespace detail
+
+template <typename F>
+detail::FinalAction<F> finally(F f)
+{
+	return detail::FinalAction<F>(f);
+}
+
+} // namespace util

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -46,6 +46,7 @@
 #include "cmeasure/cmeasure.h"
 #include "cutscene/cutscenes.h"
 #include "cutscene/movie.h"
+#include "executor/global_executors.h"
 #include "cutscene/player.h"
 #include "debris/debris.h"
 #include "debugconsole/console.h"
@@ -3596,6 +3597,8 @@ void game_simulation_frame()
 #endif
 	}
 
+	// Kick off externally injected operations after the simulation step has finished
+	executor::OnSimulationExecutor->process();
 	Script_system.RunCondition(CHA_SIMULATION);
 }
 


### PR DESCRIPTION
This adds a mechanism for running generic operations at specific points
of the frame execution. This can be used by any part of the code an not
just Lua since it simply executes std::functions. It also adds an
"execution context" concept that specifies in which situation an
operation should be executed.

This is then used by the Lua Coroutines code for resuming coroutines at
specific points instead of always when the awaited promise resolves.