### PR TITLE
Fix a crash in the Lab when viewing bombs

### DIFF
--- a/code/globalincs/systemvars.h
+++ b/code/globalincs/systemvars.h
@@ -29,6 +29,7 @@
 #define  GM_STANDALONE_SERVER			(1 << 8)
 #define	GM_STATS_TRANSFER				(1 << 9)				// in the process of stats transfer
 #define	GM_CAMPAIGN_MODE				(1 << 10)			// are we currently in a campaign.
+#define GM_LAB							(1 << 11)			// We are currently in the F3 lab
 
 #define	VM_EXTERNAL						(1 << 0)				//	Set if not viewing from player position.
 #define	VM_TRACK						(1 << 1)				//	Set if viewer is tracking target.

--- a/code/lab/lab.cpp
+++ b/code/lab/lab.cpp
@@ -1586,8 +1586,11 @@ void labviewer_change_ship_lod(Tree* caller)
 		// reset any existing model/bitmap that is showing
 		labviewer_change_model(nullptr);
 	} else {
-		obj_delete(Lab_selected_object);
+		obj_delete_all();
 	}
+
+	// clean up any running particle effects
+	particle::kill_all();
 
 	Lab_selected_object = ship_create(&vmd_identity_matrix, &Lab_model_pos, ship_index);
 	auto ship_objp = &Ships[Objects[Lab_selected_object].instance];
@@ -1640,6 +1643,7 @@ void labviewer_change_ship_lod(Tree* caller)
 	labviewer_recalc_camera();
 
 	Lab_viewer_flags &= ~LAB_FLAG_SHIP_EXPLODING;
+	physics_paused = 1;
 }
 
 void labviewer_change_ship(Tree* caller)
@@ -2099,6 +2103,7 @@ void labviewer_actions_destroy_ship(Button* /*caller*/) {
 		obj->flags.remove(Object::Object_Flags::Player_ship);
 		ship_self_destruct(obj);
 		Lab_viewer_flags |= LAB_FLAG_SHIP_EXPLODING;
+		physics_paused = 0;
 	}
 }
 
@@ -2328,7 +2333,6 @@ void lab_init()
 	particle::init();
 
 	ai_paused = 1;
-	physics_paused = 1;
 	Game_mode |= GM_LAB;
 }
 

--- a/code/lab/lab.cpp
+++ b/code/lab/lab.cpp
@@ -2328,6 +2328,8 @@ void lab_init()
 	particle::init();
 
 	ai_paused = 1;
+	physics_paused = 1;
+	Game_mode |= GM_LAB;
 }
 
 #include "lab.h"
@@ -2585,4 +2587,6 @@ void lab_close()
 	shockwave_level_close();
 
 	ai_paused = 0;
+	physics_paused = 0;
+	Game_mode &= ~GM_LAB;
 }

--- a/code/radar/radarsetup.cpp
+++ b/code/radar/radarsetup.cpp
@@ -157,6 +157,11 @@ void radar_plot_object( object *objp )
 		return;
 	}
 
+	// if we are in the lab, do nothing here
+	if (Game_mode & GM_LAB) {
+		return;
+	}
+
 	// multiplayer clients ingame joining should skip this function
 	if ( MULTIPLAYER_CLIENT && (Net_player->flags & NETINFO_FLAG_INGAME_JOIN) ){
 		return;
@@ -217,7 +222,7 @@ void radar_plot_object( object *objp )
 				return;
 
 			// if we don't attack the bomb, return
-			if ( (!(Weapon_info[Weapons[objp->instance].weapon_info_index].wi_flags[Weapon::Info_Flags::Show_friendly])) && (!iff_x_attacks_y(Player_ship->team, obj_team(objp))))
+			if ( (!(Weapon_info[Weapons[objp->instance].weapon_info_index].wi_flags[Weapon::Info_Flags::Show_friendly])) && (Player_ship != nullptr && !iff_x_attacks_y(Player_ship->team, obj_team(objp))))
 				return;
 
 			// if a local ssm is in subspace, return
@@ -281,7 +286,8 @@ void radar_plot_object( object *objp )
 	blip_bright = (dist <= Radar_bright_range);
 
 	// flag the blip as a current target if it is
-	if (OBJ_INDEX(objp) == Player_ai->target_objnum)
+	// if we are in the lab, Player_ai is null; we need to catch this h
+	if (Player_ai != nullptr && OBJ_INDEX(objp) == Player_ai->target_objnum)
 	{
 		b->flags |= BLIP_CURRENT_TARGET;
 		blip_bright = 1;

--- a/code/radar/radarsetup.cpp
+++ b/code/radar/radarsetup.cpp
@@ -286,7 +286,6 @@ void radar_plot_object( object *objp )
 	blip_bright = (dist <= Radar_bright_range);
 
 	// flag the blip as a current target if it is
-	// if we are in the lab, Player_ai is null; we need to catch this h
 	if (OBJ_INDEX(objp) == Player_ai->target_objnum)
 	{
 		b->flags |= BLIP_CURRENT_TARGET;

--- a/code/radar/radarsetup.cpp
+++ b/code/radar/radarsetup.cpp
@@ -222,7 +222,7 @@ void radar_plot_object( object *objp )
 				return;
 
 			// if we don't attack the bomb, return
-			if ( (!(Weapon_info[Weapons[objp->instance].weapon_info_index].wi_flags[Weapon::Info_Flags::Show_friendly])) && (Player_ship != nullptr && !iff_x_attacks_y(Player_ship->team, obj_team(objp))))
+			if ( (!(Weapon_info[Weapons[objp->instance].weapon_info_index].wi_flags[Weapon::Info_Flags::Show_friendly])) && (!iff_x_attacks_y(Player_ship->team, obj_team(objp))))
 				return;
 
 			// if a local ssm is in subspace, return
@@ -287,7 +287,7 @@ void radar_plot_object( object *objp )
 
 	// flag the blip as a current target if it is
 	// if we are in the lab, Player_ai is null; we need to catch this h
-	if (Player_ai != nullptr && OBJ_INDEX(objp) == Player_ai->target_objnum)
+	if (OBJ_INDEX(objp) == Player_ai->target_objnum)
 	{
 		b->flags |= BLIP_CURRENT_TARGET;
 		blip_bright = 1;


### PR DESCRIPTION
This fixes #2422 

This also adds a few cleanup functions to the lab to make sure that debris, explosions and particles are deleted when switching ship models.