### PR TITLE
additional infrastructure for sexp caching and ship registry

### DIFF
--- a/code/ai/ai.h
+++ b/code/ai/ai.h
@@ -630,7 +630,7 @@ void set_predicted_enemy_pos_turret(vec3d *predicted_enemy_pos, vec3d *gun_pos, 
 
 // function to change rearm status for ai ships (called from sexpression code)
 extern void ai_set_rearm_status( int team, int new_status );
-extern void ai_good_secondary_time( int team, int weapon_index, int num_weapons, char *shipname );
+extern void ai_good_secondary_time( int team, int weapon_index, int num_weapons, const char *shipname );
 
 extern void ai_do_objects_docked_stuff(object *docker, int docker_point, object *dockee, int dockee_point, bool update_clients = true);
 extern void ai_do_objects_undocked_stuff( object *docker, object *dockee );

--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -327,7 +327,7 @@ int ai_good_time_to_rearm(object *objp)
 /**
  * Entry point from sexpression code to set internal data for use by AI code.
  */
-void ai_good_secondary_time( int team, int weapon_index, int max_fire_count, char *shipname )
+void ai_good_secondary_time( int team, int weapon_index, int max_fire_count, const char *shipname )
 {
 	Assert(shipname != NULL);
 	int index;

--- a/code/ai/aigoals.cpp
+++ b/code/ai/aigoals.cpp
@@ -277,11 +277,9 @@ void ai_clear_ship_goals( ai_info *aip )
 
 }
 
-void ai_clear_wing_goals( int wingnum )
+void ai_clear_wing_goals( wing *wingp )
 {
 	int i;
-	wing *wingp = &Wings[wingnum];
-	//p_object *objp;
 
 	// clear the goals for all ships in the wing
 	for (i = 0; i < wingp->current_count; i++) {
@@ -292,15 +290,13 @@ void ai_clear_wing_goals( int wingnum )
 
 	}
 
-		// clear out the goals for the wing now
+	// clear out the goals for the wing now
 	for (i = 0; i < MAX_AI_GOALS; i++) {
 		wingp->ai_goals[i].ai_mode = AI_GOAL_NONE;
 		wingp->ai_goals[i].signature = -1;
 		wingp->ai_goals[i].priority = -1;
 		wingp->ai_goals[i].flags.reset();
 	}
-
-
 }
 
 // routine which marks a wing goal as being complete.  We get the wingnum and a pointer to the goal
@@ -1209,11 +1205,10 @@ int ai_remove_goal_sexp_sub( int sexp, ai_goal* aigp )
 }
 
 // code to add ai goals to wings.
-void ai_remove_wing_goal_sexp(int sexp, int wingnum)
+void ai_remove_wing_goal_sexp(int sexp, wing *wingp)
 {
 	int i;
 	int goalindex = -1;
-	wing *wingp = &Wings[wingnum];
 
 	// add the ai goal for any ship that is currently arrived in the game (only if fred isn't running)
 	if ( !Fred_running ) {
@@ -1244,10 +1239,9 @@ void ai_add_ship_goal_sexp( int sexp, int type, ai_info *aip )
 }
 
 // code to add ai goals to wings.
-void ai_add_wing_goal_sexp(int sexp, int type, int wingnum)
+void ai_add_wing_goal_sexp(int sexp, int type, wing *wingp)
 {
 	int i;
-	wing *wingp = &Wings[wingnum];
 
 	// add the ai goal for any ship that is currently arrived in the game (only if fred isn't running)
 	if ( !Fred_running ) {

--- a/code/ai/aigoals.h
+++ b/code/ai/aigoals.h
@@ -102,11 +102,11 @@ extern int ai_goal_num(ai_goal *goals);
 // adds goals to ships/wing through sexpressions
 extern void ai_add_ship_goal_scripting(int mode, int submode, int priority, char *shipname, ai_info *aip);
 extern void ai_add_ship_goal_sexp( int sexp, int type, ai_info *aip );
-extern void ai_add_wing_goal_sexp( int sexp, int type, int wingnum );
+extern void ai_add_wing_goal_sexp( int sexp, int type, wing *wingp );
 extern void ai_add_goal_sub_sexp( int sexp, int type, ai_goal *aigp, char *actor_name );
 
 extern int ai_remove_goal_sexp_sub( int sexp, ai_goal* aigp );
-extern void ai_remove_wing_goal_sexp(int sexp, int wingnum);
+extern void ai_remove_wing_goal_sexp( int sexp, wing *wingp );
 
 // adds goals to ships/sings through player orders
 extern void ai_add_ship_goal_player( int type, int mode, int submode, char *shipname, ai_info *aip );
@@ -114,7 +114,7 @@ extern void ai_add_wing_goal_player( int type, int mode, int submode, char *ship
 
 extern void ai_remove_ship_goal( ai_info *aip, int index );
 extern void ai_clear_ship_goals( ai_info *aip );
-extern void ai_clear_wing_goals( int wingnum );
+extern void ai_clear_wing_goals( wing *wingp );
 
 extern void ai_copy_mission_wing_goal( ai_goal *aigp, ai_info *aip );
 

--- a/code/autopilot/autopilot.cpp
+++ b/code/autopilot/autopilot.cpp
@@ -413,7 +413,7 @@ bool StartAutopilot()
 				}
 				else
 				{
-					ai_clear_wing_goals(wingnum);
+					ai_clear_wing_goals(&Wings[wingnum]);
 					j = 1+int( (float)floor(double(wcount-1)/2.0) );
 					switch (wcount % 2)
 					{
@@ -484,7 +484,7 @@ bool StartAutopilot()
 				//ai_add_wing_goal_player( AIG_TYPE_PLAYER_WING, AI_GOAL_WAYPOINTS_ONCE, 0, target_shipname, wingnum );
 				//ai_clear_ship_goals( &(Ai_info[Ships[num].ai_index]) );
 				
-				ai_clear_wing_goals( i );
+				ai_clear_wing_goals( &Wings[i] );
 				if (Navs[CurrentNav].flags & NP_WAYPOINT)
 				{
 					

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -1985,7 +1985,7 @@ int parse_create_object_sub(p_object *p_objp)
 	shipp->weapons.ai_class = p_objp->ai_class;  // Fred uses this instead of above.
 	//Fixes a bug where the AI class attributes were not copied if the AI class was set in the mission.
 	if (The_mission.ai_profile->flags[AI::Profile_Flags::Fix_ai_class_bug])
-		ship_set_new_ai_class(shipnum, p_objp->ai_class);
+		ship_set_new_ai_class(shipp, p_objp->ai_class);
 
 	aip->behavior = p_objp->behavior;
 	aip->mode = aip->behavior;
@@ -4618,7 +4618,7 @@ void parse_wing(mission *pm)
 		// this will assign the goals to the wings as well as to any ships in the wing that have been
 		// already created.
 		for ( sexp = CDR(wing_goals); sexp != -1; sexp = CDR(sexp) )
-			ai_add_wing_goal_sexp(sexp, AIG_TYPE_EVENT_WING, wingnum);  // used by Fred
+			ai_add_wing_goal_sexp(sexp, AIG_TYPE_EVENT_WING, wingp);  // used by Fred
 
 		free_sexp2(wing_goals);  // free up sexp nodes for reuse, since they aren't needed anymore.
 	}
@@ -4775,7 +4775,7 @@ void post_process_ships_wings()
 	// any ships are created from the parse objects.
 	for (auto &pobjp : Parse_objects)
 	{
-		ship_registry_entry entry = { ShipStatus::NOT_YET_PRESENT, &pobjp, nullptr, nullptr, 0 };
+		ship_registry_entry entry = { ShipStatus::NOT_YET_PRESENT, pobjp.name, &pobjp, nullptr, nullptr, 0, -1 };
 		Ship_registry.push_back(entry);
 		Ship_registry_map[pobjp.name] = static_cast<int>(Ship_registry.size() - 1);
 	}

--- a/code/network/multi_sexp.cpp
+++ b/code/network/multi_sexp.cpp
@@ -407,13 +407,13 @@ void sexp_network_packet::send_float(float value)
 
 void sexp_network_packet::send_vec3d(vec3d *value)
 {
-	for (int i = 0; i < 3; ++i)
+	for (int i = 0; i < 3; ++i)     // NOLINT
 		send_float(value->a1d[i]);
 }
 
 void sexp_network_packet::send_matrix(matrix *value)
 {
-	for (int i = 0; i < 9; ++i)
+	for (int i = 0; i < 9; ++i)     // NOLINT
 		send_float(value->a1d[i]);
 }
 
@@ -621,7 +621,7 @@ bool sexp_network_packet::get_float(float & value)
 
 bool sexp_network_packet::get_vec3d(vec3d *value)
 {
-	for (int i = 0; i < 3; ++i)
+	for (int i = 0; i < 3; ++i)     // NOLINT
 	{
 		if (!get_float(value->a1d[i]))
 			return false;
@@ -631,7 +631,7 @@ bool sexp_network_packet::get_vec3d(vec3d *value)
 
 bool sexp_network_packet::get_matrix(matrix *value)
 {
-	for (int i = 0; i < 9; ++i)
+	for (int i = 0; i < 9; ++i)     // NOLINT
 	{
 		if (!get_float(value->a1d[i]))
 			return false;

--- a/code/network/multi_sexp.cpp
+++ b/code/network/multi_sexp.cpp
@@ -306,6 +306,11 @@ void sexp_network_packet::send_ship(ship * shipp)
     current_argument_count += sizeof(ushort);
 }
 
+void sexp_network_packet::send_ship(int shipnum)
+{
+	send_ship(&Ships[shipnum]);
+}
+
 void sexp_network_packet::send_object(object * objp)
 {
     if (cannot_send_data()) {

--- a/code/network/multi_sexp.cpp
+++ b/code/network/multi_sexp.cpp
@@ -276,6 +276,21 @@ void sexp_network_packet::send_int(int value)
     current_argument_count += sizeof(int);
 }
 
+void sexp_network_packet::send_wing(wing * wingp)
+{
+	if (cannot_send_data()) {
+		return;
+	}
+
+	ensure_space_remains(sizeof(ushort));
+
+	//write into the Type buffer.
+	type[packet_size] = packet_data_type::WING;
+	//write the into the data buffer
+	ADD_USHORT(wingp->net_signature);
+	current_argument_count += sizeof(ushort);
+}
+
 void sexp_network_packet::send_ship(ship * shipp)
 {
     if (cannot_send_data()) {
@@ -289,17 +304,6 @@ void sexp_network_packet::send_ship(ship * shipp)
     //write the into the data buffer
     ADD_USHORT(Objects[shipp->objnum].net_signature);
     current_argument_count += sizeof(ushort);
-}
-
-void sexp_network_packet::send_ship(int shipnum)
-{
-    if (cannot_send_data()) {
-        return;
-    }
-
-    ensure_space_remains(sizeof(shipnum));
-
-    send_ship(&Ships[shipnum]);
 }
 
 void sexp_network_packet::send_object(object * objp)
@@ -396,6 +400,18 @@ void sexp_network_packet::send_float(float value)
     current_argument_count += sizeof(float);
 }
 
+void sexp_network_packet::send_vec3d(vec3d *value)
+{
+	for (int i = 0; i < 3; ++i)
+		send_float(value->a1d[i]);
+}
+
+void sexp_network_packet::send_matrix(matrix *value)
+{
+	for (int i = 0; i < 9; ++i)
+		send_float(value->a1d[i]);
+}
+
 void sexp_network_packet::send_short(short value)
 {
     if (cannot_send_data()) {
@@ -460,7 +476,7 @@ bool sexp_network_packet::get_ship(int & value)
         return true;
     }
 
-    Warning(LOCATION, "Current_sexp_network_packet.get_ship called for object %d even though it is not a ship", objp->instance);
+    Warning(LOCATION, "Current_sexp_network_packet.get_ship called for net signature %d even though it is not a ship", netsig);
     return false;
 }
 
@@ -473,6 +489,31 @@ bool sexp_network_packet::get_ship(ship *& shipp)
         return true;
     }
 
+    return false;
+}
+
+bool sexp_network_packet::get_wing(wing *& wingp)
+{
+	int i;
+    ushort netsig;
+
+    if (!sexp_bytes_left || !current_argument_count) {
+        return false;
+    }
+
+    // get the net signature of the wing
+    GET_USHORT(netsig);
+    reduce_counts(sizeof(ushort));
+
+    // lookup the wing
+	for (i = 0; i < Num_wings; i++) {
+		if (Wings[i].net_signature == netsig) {
+			wingp = &Wings[i];
+			return true;
+		}
+	}
+
+    Warning(LOCATION, "Current_sexp_network_packet.get_wing called for net signature %d even though it is not a ship", netsig);
     return false;
 }
 
@@ -571,6 +612,26 @@ bool sexp_network_packet::get_float(float & value)
     reduce_counts(sizeof(float));
 
     return true;
+}
+
+bool sexp_network_packet::get_vec3d(vec3d *value)
+{
+	for (int i = 0; i < 3; ++i)
+	{
+		if (!get_float(value->a1d[i]))
+			return false;
+	}
+	return true;
+}
+
+bool sexp_network_packet::get_matrix(matrix *value)
+{
+	for (int i = 0; i < 9; ++i)
+	{
+		if (!get_float(value->a1d[i]))
+			return false;
+	}
+	return true;
 }
 
 bool sexp_network_packet::get_short(short & value)

--- a/code/network/multi_sexp.h
+++ b/code/network/multi_sexp.h
@@ -33,6 +33,7 @@ enum class packet_data_type {
     SHORT				= 9,
     USHORT				= 10,
     OBJECT				= 11,
+	WING				= 12,
 };
 
 #if SCP_COMPILER_IS_GNU
@@ -121,9 +122,13 @@ public:
     * Adds a ship's net sig to the SEXP packet.
     */
     void send_ship(ship *shipp);
-    void send_ship(int shipnum);
     
-    /**
+	/**
+	* Adds a wing's net sig to the SEXP packet.
+	*/
+	void send_wing(wing *wingp);
+
+	/**
     * Add the net sig of an object to the SEXP packet.
     */
     void send_object(object *objp);
@@ -149,7 +154,17 @@ public:
     */
     void send_float(float value);
 
-    /**
+	/**
+	 * Add three floats in a row.
+	 */
+	void send_vec3d(vec3d *value);
+
+	/**
+	 * Add nine floats in a row.
+	 */
+	void send_matrix(matrix *value);
+
+	/**
     * Add a short to the SEXP packet.
     */
     void send_short(short value);
@@ -188,19 +203,25 @@ public:
     */   
     bool get_int(int &value);
 
-    /**
-    * Attempts to get an index for the Ships array based on the net sig it removes from the SEXP packet. Returns it as the value
-    * parameter. Returns false if unable to do so.
-    */
-    bool get_ship(int &value);
+	/**
+	* Attempts to get an index for the Ships array based on the net sig it removes from the SEXP packet. Returns it as the value
+	* parameter. Returns false if unable to do so.
+	*/
+	bool get_ship(int &value);
 
-    /**
+	/**
     * Attempts to get a ship pointer based on the net sig it removes from the SEXP packet. Returns it as the value parameter.
     * Returns false if unable to do so.
     */
     bool get_ship(ship*& shipp);
     
-    /**
+	/**
+	* Attempts to get a wing pointer based on the net sig it removes from the SEXP packet. Returns it as the value parameter.
+	* Returns false if unable to do so.
+	*/
+	bool get_wing(wing*& wingp);
+
+	/**
     * Attempts to get an object pointer based on the net sig it removes from the SEXP packet. Returns it as the value parameter.
     * Returns false if unable to do so.
     */
@@ -228,7 +249,17 @@ public:
     */
     bool get_float(float &value);
 
-    /**
+	/**
+	* Attempts to remove a vec3d from the SEXP packet and assign it to the value parameter. Returns false if it is unable to do so.
+	*/
+	bool get_vec3d(vec3d *value);
+
+	/**
+	* Attempts to remove a matrix from the SEXP packet and assign it to the value parameter. Returns false if it is unable to do so.
+	*/
+	bool get_matrix(matrix *value);
+
+	/**
     * Attempts to remove a short from the SEXP packet and assign it to the value parameter. Returns false if it is unable to do so.
     */
     bool get_short(short &value);

--- a/code/network/multi_sexp.h
+++ b/code/network/multi_sexp.h
@@ -122,6 +122,7 @@ public:
     * Adds a ship's net sig to the SEXP packet.
     */
     void send_ship(ship *shipp);
+	void send_ship(int shipnum);
     
 	/**
 	* Adds a wing's net sig to the SEXP packet.

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -10635,7 +10635,7 @@ void sexp_change_ai_class(int n)
 		return;
 
 	Current_sexp_network_packet.start_callback();
-	Current_sexp_network_packet.send_ship(&Ships[ship_num]);
+	Current_sexp_network_packet.send_ship(ship_num);
 	Current_sexp_network_packet.send_int(new_ai_class);
 
 	// subsys?
@@ -12824,7 +12824,7 @@ void sexp_repair_subsystem(int n)
 		ihs = shipp->ship_max_hull_strength;
 		repair_hits = ihs * ((float)percentage / 100.0f);
 		objp = &Objects[shipp->objnum];
-		objp->hull_strength += repair_hits;
+		objp->sim_hull_strength += repair_hits;
 		if ( objp->sim_hull_strength > ihs )
 			objp->sim_hull_strength = ihs;
 		return;
@@ -14174,7 +14174,7 @@ void sexp_deal_with_ship_flag(int node, bool process_subsequent_nodes, Object::O
 
 			if (send_multiplayer && MULTIPLAYER_MASTER) {
 				Current_sexp_network_packet.send_bool(true); 
-				Current_sexp_network_packet.send_ship(&Ships[ship_index]);
+				Current_sexp_network_packet.send_ship(ship_index);
 			}
 		}
 		// if it's not in-mission
@@ -14861,7 +14861,7 @@ void sexp_set_persona (int node)
 		Ships[sindex].persona_index = persona_index; 
 
 		if (MULTIPLAYER_MASTER) {
-			Current_sexp_network_packet.send_ship(&Ships[sindex]);
+			Current_sexp_network_packet.send_ship(sindex);
 		}
 	}
 
@@ -16008,7 +16008,7 @@ void sexp_destroy_instantly(int n)
 
 				// multiplayer callback
 				if (MULTIPLAYER_MASTER)
-					Current_sexp_network_packet.send_ship(&Ships[ship_num]);
+					Current_sexp_network_packet.send_ship(ship_num);
 			}
 		}
 	}
@@ -17019,7 +17019,7 @@ void sexp_set_ets_values(int node)
 			Ships[sindex].shield_recharge_index = ets_idx[SHIELDS];
 			Ships[sindex].weapon_recharge_index = ets_idx[WEAPONS];
 
-			Current_sexp_network_packet.send_ship(&Ships[sindex]);
+			Current_sexp_network_packet.send_ship(sindex);
 			Current_sexp_network_packet.send_int(ets_idx[ENGINES]);
             Current_sexp_network_packet.send_int(ets_idx[SHIELDS]);
 			Current_sexp_network_packet.send_int(ets_idx[WEAPONS]);
@@ -17308,7 +17308,7 @@ void sexp_set_primary_ammo (int node)
 
 	// do the multiplayer callback here
 	Current_sexp_network_packet.start_callback();
-	Current_sexp_network_packet.send_ship(&Ships[sindex]);
+	Current_sexp_network_packet.send_ship(sindex);
 	Current_sexp_network_packet.send_int(requested_bank);
 	Current_sexp_network_packet.send_int(requested_weapons);
 	Current_sexp_network_packet.send_int(rearm_limit);
@@ -17472,7 +17472,7 @@ void sexp_set_secondary_ammo (int node)
 
 	// do the multiplayer callback here
 	Current_sexp_network_packet.start_callback();
-	Current_sexp_network_packet.send_ship(&Ships[sindex]);
+	Current_sexp_network_packet.send_ship(sindex);
 	Current_sexp_network_packet.send_int(requested_bank);
 	Current_sexp_network_packet.send_int(requested_weapons);
 	Current_sexp_network_packet.send_int(rearm_limit);
@@ -17586,7 +17586,7 @@ void sexp_set_weapon(int node, bool primary)
 	}
 
 	Current_sexp_network_packet.start_callback();
-	Current_sexp_network_packet.send_ship(&Ships[sindex]);
+	Current_sexp_network_packet.send_ship(sindex);
 	Current_sexp_network_packet.send_bool(primary);
 	Current_sexp_network_packet.send_int(requested_bank);
 	Current_sexp_network_packet.send_int(windex);
@@ -17878,7 +17878,7 @@ void sexp_change_ship_class(int n)
 
 				if (MULTIPLAYER_MASTER) {
 					Current_sexp_network_packet.send_bool(true); 
-					Current_sexp_network_packet.send_ship(&Ships[ship_num]);
+					Current_sexp_network_packet.send_ship(ship_num);
 				}
 			}
 		}
@@ -23630,7 +23630,7 @@ void sexp_script_eval_multi(int node)
 				// otherwise notify the clients
 				else {
 					sindex = ship_name_lookup(CTEXT(node));
-					Current_sexp_network_packet.send_ship(&Ships[sindex]);
+					Current_sexp_network_packet.send_ship(sindex);
 				}
 			}
 

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -908,7 +908,7 @@ int Num_explosion_options = 6;
 int get_sexp();
 void build_extended_sexp_string(SCP_string &accumulator, int cur_node, int level, int mode);
 void update_sexp_references(const char *old_name, const char *new_name, int format, int node);
-int sexp_determine_team(char *subj);
+int sexp_determine_team(const char *subj);
 void init_sexp_vars();
 
 // for handling variables
@@ -930,13 +930,9 @@ bool is_blank_of_op(int op_const);
 
 int get_handler_for_x_of_operator(int node);
 
-int sexp_atoi(int node);
-bool sexp_can_construe_as_integer(int node);
-int sexp_get_variable_index(int node);
-
 //Karajorma
-int get_generic_subsys(char *subsy_name);
-bool ship_class_unchanged(int ship_index); 
+int get_generic_subsys(const char *subsy_name);
+bool ship_class_unchanged(int ship_index);
 void multi_sexp_modify_variable();
 
 int get_effect_from_name(const char* name);
@@ -7043,7 +7039,7 @@ int sexp_directive_value(int n)
 	return SEXP_TRUE;
 }
 
-int sexp_determine_team(char *subj)
+int sexp_determine_team(const char *subj)
 {
 	char team_name[NAME_LENGTH];
 
@@ -10225,7 +10221,8 @@ int sexp_is_iff(int n)
 					// it's probably an exited wing, which we don't store information about
 					return SEXP_NAN_FOREVER;
 				}
-				FALLTHROUGH;
+
+				break;
 			}
 
 			// we don't handle the other cases
@@ -24076,7 +24073,7 @@ void sexp_set_motion_debris(int node)
 /**
  * Returns the subsystem type if the name of a subsystem is actually a generic type (e.g \<all engines\> or \<all turrets\>
  */
-int get_generic_subsys(char *subsys_name) 
+int get_generic_subsys(const char *subsys_name)
 {
 	if (!strcmp(subsys_name, SEXP_ALL_ENGINES_STRING)) {
 		return SUBSYSTEM_ENGINE;

--- a/code/parse/sexp.h
+++ b/code/parse/sexp.h
@@ -1217,6 +1217,17 @@ extern int sexp_query_type_match(int opf, int opr);
 extern const char *sexp_error_message(int num);
 extern int count_free_sexp_nodes();
 
+struct ship_registry_entry;
+struct wing;
+
+// Goober5000 - stuff with caching
+// (included in the header file because Lua uses the first three)
+extern const ship_registry_entry *eval_ship(int node);
+extern wing *eval_wing(int node);
+extern int sexp_get_variable_index(int node);
+extern int sexp_atoi(int node);
+extern bool sexp_can_construe_as_integer(int node);
+
 // Goober5000
 void do_action_for_each_special_argument(int cur_node);
 bool special_argument_appears_in_sexp_tree(int node);

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -782,11 +782,13 @@ enum ShipStatus { NOT_YET_PRESENT, PRESENT, EXITED };
 struct ship_registry_entry
 {
 	ShipStatus status;
+	const char *name;
 
 	p_object *pobjp;
 	object *objp;
 	ship *shipp;
 	int cleanup_mode;
+	int exited_index;
 };
 
 extern SCP_vector<ship_registry_entry> Ship_registry;
@@ -1421,7 +1423,7 @@ extern int ship_get_num_ships();
 extern void ship_cleanup(int shipnum, int cleanup_mode);
 
 // Goober5000
-extern void ship_destroy_instantly(object *ship_obj, int shipnum);
+extern void ship_destroy_instantly(object *ship_obj);
 extern void ship_actually_depart(int shipnum, int method = SHIP_DEPARTED_WARP);
 
 extern bool in_autoaim_fov(ship *shipp, int bank_to_fire, object *obj);
@@ -1468,6 +1470,8 @@ extern int wing_has_conflicting_teams(int wing_index);
 // in the wing -- used to tell is the wing exists or not, not whether it exists and has ships currently
 // present.
 extern int wing_name_lookup(const char *name, int ignore_count = 0);
+
+extern bool wing_has_yet_to_arrive(const wing *wingp);
 
 // for generating a ship name for arbitrary waves/indexes of that wing... correctly handles the # character
 extern void wing_bash_ship_name(char *ship_name, const char *wing_name, int index);
@@ -1517,7 +1521,7 @@ extern int ship_get_index_from_subsys(ship_subsys *ssp, int objnum);
 extern int ship_get_subsys_index(ship *sp, const char* ss_name);		// returns numerical index in linked list of subsystems
 extern int ship_get_subsys_index(ship *shipp, ship_subsys *subsys);
 extern float ship_get_subsystem_strength( ship *shipp, int type, bool skip_dying_check = false );
-extern ship_subsys *ship_get_subsys(ship *shipp, const char *subsys_name);
+extern ship_subsys *ship_get_subsys(const ship *shipp, const char *subsys_name);
 extern int ship_get_num_subsys(ship *shipp);
 extern ship_subsys *ship_get_closest_subsys_in_sight(ship *sp, int subsys_type, vec3d *attacker_pos);
 
@@ -1714,8 +1718,8 @@ float ship_class_get_length(const ship_info *sip);
 void ship_class_get_actual_center(const ship_info *sip, vec3d *center_pos);
 
 // Goober5000 - used by change-ai-class
-extern void ship_set_new_ai_class(int ship_num, int new_ai_class);
-extern void ship_subsystem_set_new_ai_class(int ship_num, char *subsystem, int new_ai_class);
+extern void ship_set_new_ai_class(ship *shipp, int new_ai_class);
+extern void ship_subsystem_set_new_ai_class(ship *shipp, char *subsystem, int new_ai_class);
 
 // wing squad logos - Goober5000
 extern void wing_load_squad_bitmap(wing *w);

--- a/code/ship/shiphit.cpp
+++ b/code/ship/shiphit.cpp
@@ -2398,24 +2398,24 @@ static void ship_do_damage(object *ship_objp, object *other_obj, vec3d *hitpos, 
 }
 
 // Goober5000
-void ship_apply_tag(int ship_num, int tag_level, float tag_time, object *target, vec3d *start, int ssm_index, int ssm_team)
+void ship_apply_tag(ship *shipp, int tag_level, float tag_time, object *target, vec3d *start, int ssm_index, int ssm_team)
 {
 	// set time first tagged
-	if (Ships[ship_num].time_first_tagged == 0)
-		Ships[ship_num].time_first_tagged = Missiontime;
+	if (shipp->time_first_tagged == 0)
+		shipp->time_first_tagged = Missiontime;
 
 	// do tag effect
 	if (tag_level == 1)
 	{
-//		mprintf(("TAGGED %s for %f seconds\n", Ships[ship_num].ship_name, tag_time));
-		Ships[ship_num].tag_left = tag_time;
-		Ships[ship_num].tag_total = tag_time;
+//		mprintf(("TAGGED %s for %f seconds\n", shipp->ship_name, tag_time));
+		shipp->tag_left = tag_time;
+		shipp->tag_total = tag_time;
 	}
 	else if (tag_level == 2)
 	{
-//		mprintf(("Level 2 TAGGED %s for %f seconds\n", Ships[ship_num].ship_name, tag_time));
-		Ships[ship_num].level2_tag_left = tag_time;
-		Ships[ship_num].level2_tag_total = tag_time;
+//		mprintf(("Level 2 TAGGED %s for %f seconds\n", shipp->ship_name, tag_time));
+		shipp->level2_tag_left = tag_time;
+		shipp->level2_tag_total = tag_time;
 	}
 	else if (tag_level == 3)
 	{
@@ -2484,7 +2484,7 @@ void ship_apply_local_damage(object *ship_objp, object *other_obj, vec3d *hitpos
 			vec3d *start = hitpos;
 			int ssm_index = wip->SSM_index;
 
-			ship_apply_tag(ship_objp->instance, wip->tag_level, wip->tag_time, ship_objp, start, ssm_index, wp->team);
+			ship_apply_tag(ship_p, wip->tag_level, wip->tag_time, ship_objp, start, ssm_index, wp->team);
 		}
 	}
 

--- a/code/ship/shiphit.h
+++ b/code/ship/shiphit.h
@@ -35,7 +35,7 @@ constexpr float DEATHROLL_ROTVEL_CAP = 6.3f;    // maximum added deathroll rotve
 extern void do_subobj_destroyed_stuff( ship *ship_p, ship_subsys *subsys, vec3d *hitpos, bool no_explosion = false );
 
 // Goober5000
-extern void ship_apply_tag(int ship_num, int tag_level, float tag_time, object *target, vec3d *start, int ssm_index, int ssm_team);
+extern void ship_apply_tag(ship *ship_p, int tag_level, float tag_time, object *target, vec3d *start, int ssm_index, int ssm_team);
 
 // This gets called to apply damage when something hits a particular point on a ship.
 // This assumes that whoever called this knows if the shield got hit or not.


### PR DESCRIPTION
This is part of the ongoing sexp refactor.  Assorted functions outside sexp.cpp have been affected, so I separated them out into this PR to help keep reviews manageable.  Additionally:

1) `eval_wing` has been added to complement `eval_ship`.  Both of these functions are also now more forgiving, cache-wise, for nodes that might allow multiple data types.
2) A `name` field has been added to the ship registry for convenience.
3) An `exited_index` field has been added to the ship registry to track exited ships.
4) Lua sexps now take advantage of caching.
5) A bug with simulated hull has been fixed in `repair-subsystem`.
6) A subtle bug for exited ships has been fixed in `is-iff`.