### PR TITLE
add const-correctness to the autopilot API

### DIFF
--- a/code/autopilot/autopilot.cpp
+++ b/code/autopilot/autopilot.cpp
@@ -108,7 +108,7 @@ bool Sel_NextNav()
 
 
 // ********************************************************************************************
-vec3d *NavPoint::GetPosition()
+const vec3d *NavPoint::GetPosition()
 {
 	if (flags & NP_WAYPOINT)
 	{
@@ -123,7 +123,7 @@ vec3d *NavPoint::GetPosition()
 }
 
 // ********************************************************************************************
-bool CanAutopilot(vec3d targetPos, bool send_msg)
+bool CanAutopilot(const vec3d *targetPos, bool send_msg)
 {
 	if (CurrentNav == -1)
 	{
@@ -140,7 +140,7 @@ bool CanAutopilot(vec3d targetPos, bool send_msg)
 	}
 
 	// You cannot autopilot if you're within 1000 meters of your destination nav point
-	if (vm_vec_dist_quick(&targetPos, Navs[CurrentNav].GetPosition()) < 1000) {
+	if (vm_vec_dist_quick(targetPos, Navs[CurrentNav].GetPosition()) < 1000) {
 		if (send_msg)
 					send_autopilot_msgID(NP_MSG_FAIL_TOCLOSE);
 		return false;
@@ -156,7 +156,7 @@ bool CanAutopilot(vec3d targetPos, bool send_msg)
 				&& !(Ship_info[Ships[other_objp->instance].ship_info_index].flags[Ship::Info_Flags::Cargo])) // ignore cargo
 			{
 				// Cannot autopilot if enemy within AutopilotMinEnemyDistance meters
-				if (vm_vec_dist_quick(&targetPos, &other_objp->pos) < AutopilotMinEnemyDistance) {
+				if (vm_vec_dist_quick(targetPos, &other_objp->pos) < AutopilotMinEnemyDistance) {
 					if (send_msg)
 						send_autopilot_msgID(NP_MSG_FAIL_HOSTILES);
 					return false;
@@ -173,7 +173,7 @@ bool CanAutopilot(vec3d targetPos, bool send_msg)
 			if (Asteroids[n].flags & AF_USED)
 			{
 				// Cannot autopilot if asteroid within AutopilotMinAsteroidDistance meters
-				if (vm_vec_dist_quick(&targetPos, &Objects[Asteroids[n].objnum].pos) < AutopilotMinAsteroidDistance) {
+				if (vm_vec_dist_quick(targetPos, &Objects[Asteroids[n].objnum].pos) < AutopilotMinAsteroidDistance) {
 					if (send_msg)
 						send_autopilot_msgID(NP_MSG_FAIL_HAZARD);
 					return false;
@@ -989,7 +989,7 @@ void nav_warp(bool prewarp=false)
 	/* using the vector of the flight leaders's path, simulate moving the 
 	flight along this path by checking the autopilot conditions as specific
 	intervals along the path*/
-	while (CanAutopilot(tpos))
+	while (CanAutopilot(&tpos))
 	{
 		vm_vec_add(&tpos, &tpos, &pos);
 	}
@@ -1192,7 +1192,7 @@ void send_autopilot_msgID(int msgid)
 }
 // ********************************************************************************************
 
-void send_autopilot_msg(char *msg, char *snd)
+void send_autopilot_msg(const char *msg, const char *snd)
 {
 	// setup
 	if (audio_handle != -1)
@@ -1312,7 +1312,7 @@ void parse_autopilot_table(const char *filename)
 
 // ********************************************************************************************
 // Finds a Nav point by name
-int FindNav(char *Nav)
+int FindNav(const char *Nav)
 {
 	for (int i = 0; i < MAX_NAVPOINTS; i++)
 	{
@@ -1325,7 +1325,7 @@ int FindNav(char *Nav)
 
 // ********************************************************************************************
 // Removes a Nav
-bool DelNavPoint(char *Nav)
+bool DelNavPoint(const char *Nav)
 {
 	int n = FindNav(Nav);
 
@@ -1354,7 +1354,7 @@ bool DelNavPoint(int nav)
 
 // ********************************************************************************************
 // adds a Nav
-bool AddNav_Ship(char *Nav, char *TargetName, int flags)
+bool AddNav_Ship(const char *Nav, const char *TargetName, int flags)
 {
 	// find an empty nav - should be the end
 
@@ -1397,7 +1397,7 @@ bool AddNav_Ship(char *Nav, char *TargetName, int flags)
 }
 
 
-bool AddNav_Waypoint(char *Nav, char *WP_Path, int node, int flags)
+bool AddNav_Waypoint(const char *Nav, const char *WP_Path, int node, int flags)
 {
 	// find an empty nav - should be the end
 
@@ -1435,7 +1435,7 @@ bool AddNav_Waypoint(char *Nav, char *WP_Path, int node, int flags)
 
 // ********************************************************************************************
 //Get Flags
-int Nav_Get_Flags(char *Nav)
+int Nav_Get_Flags(const char *Nav)
 {
 	int flags = 0;
 
@@ -1451,7 +1451,7 @@ int Nav_Get_Flags(char *Nav)
 // Sexp Accessors
 
 //Generic
-bool Nav_Set_Flag(char *Nav, int flag)
+bool Nav_Set_Flag(const char *Nav, int flag)
 {
 	Assert(!(flag & NP_VALIDTYPE));
 	int nav = FindNav(Nav);
@@ -1467,7 +1467,7 @@ bool Nav_Set_Flag(char *Nav, int flag)
 
 //+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 
-bool Nav_UnSet_Flag(char *Nav, int flag)
+bool Nav_UnSet_Flag(const char *Nav, int flag)
 {
 	Assert(!(flag & NP_VALIDTYPE));
 
@@ -1484,7 +1484,7 @@ bool Nav_UnSet_Flag(char *Nav, int flag)
 
 //+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 //Named
-bool Nav_Set_Hidden(char *Nav)
+bool Nav_Set_Hidden(const char *Nav)
 {
 	return Nav_Set_Flag(Nav, NP_HIDDEN);
 
@@ -1492,14 +1492,14 @@ bool Nav_Set_Hidden(char *Nav)
 
 //+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 
-bool Nav_Set_NoAccess(char *Nav)
+bool Nav_Set_NoAccess(const char *Nav)
 {
 	return Nav_Set_Flag(Nav, NP_NOACCESS);
 }
 
 //+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 
-bool Nav_Set_Visited(char *Nav)
+bool Nav_Set_Visited(const char *Nav)
 {
 	
 	return Nav_Set_Flag(Nav, NP_VISITED);
@@ -1507,28 +1507,28 @@ bool Nav_Set_Visited(char *Nav)
 
 //+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 
-bool Nav_UnSet_Hidden(char *Nav)
+bool Nav_UnSet_Hidden(const char *Nav)
 {
 	return Nav_UnSet_Flag(Nav, NP_HIDDEN);
 }
 
 //+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 
-bool Nav_UnSet_NoAccess(char *Nav)
+bool Nav_UnSet_NoAccess(const char *Nav)
 {
 	return Nav_UnSet_Flag(Nav, NP_NOACCESS);
 }
 
 //+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 
-bool Nav_UnSet_Visited(char *Nav)
+bool Nav_UnSet_Visited(const char *Nav)
 {
 	return Nav_UnSet_Flag(Nav, NP_VISITED);
 }
 
 // ********************************************************************************************
 // Selects a navpoint by name.
-void SelectNav(char *Nav)
+void SelectNav(const char *Nav)
 {
 	for (int i = 0; i < MAX_NAVPOINTS; i++)
 	{
@@ -1547,7 +1547,7 @@ void DeselectNav()
 //+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 
 
-unsigned int DistanceTo(char *nav)
+unsigned int DistanceTo(const char *nav)
 {
 	int n = FindNav(nav);
 
@@ -1564,7 +1564,7 @@ unsigned int DistanceTo(int nav)
 
 //+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 
-bool IsVisited(char *nav)
+bool IsVisited(const char *nav)
 {
 	int n = FindNav(nav);
 

--- a/code/autopilot/autopilot.h
+++ b/code/autopilot/autopilot.h
@@ -32,17 +32,17 @@ public:
 	char m_NavName[32];
 	int flags;
 
-	void *target_obj;
+	const void *target_obj;
 	int waypoint_num; //only used when flags & NP_WAYPOINT
 
-	vec3d *GetPosition();
+	const vec3d *GetPosition();
 
 	void clear()
 	{
 		m_NavName[0] = 0;
 		flags = 0;
 
-		target_obj = NULL;
+		target_obj = nullptr;
 		waypoint_num = -1;
 	}
 };
@@ -82,11 +82,11 @@ bool Sel_NextNav();
 //        * No asteroids within AutopilotMinAsteroidDistance meters
 //        * Destination > 1,000 meters away
 //        * Support ship not present or is actively leaving
-bool CanAutopilot(vec3d targetPos, bool send_msg=false);
+bool CanAutopilot(const vec3d *targetPos, bool send_msg=false);
 
 // Check if autopilot is allowed at player's current position
 // See CanAutopilot(vec3d, bool) for more information
-inline bool CanAutopilot(bool send_msg=false) { return CanAutopilot(Player_obj->pos, send_msg); }
+inline bool CanAutopilot(bool send_msg=false) { return CanAutopilot(&Player_obj->pos, send_msg); }
 
 // Engages autopilot
 // This does:
@@ -120,42 +120,42 @@ void NavSystem_Init();
 void parse_autopilot_table(const char *filename);
 
 // Finds a Nav point by name
-int FindNav(char *Nav);
+int FindNav(const char *Nav);
 
 // Selects a Nav point by name
-void SelectNav(char *Nav);
+void SelectNav(const char *Nav);
 
 // Deselects any navpoint selected.
 void DeselectNav();
 
 // Removes a Nav
-bool DelNavPoint(char *Nav);
+bool DelNavPoint(const char *Nav);
 bool DelNavPoint(int nav);
 
 // adds a Nav
-bool AddNav_Ship(char *Nav, char *TargetName, int flags); 
-bool AddNav_Waypoint(char *Nav, char *WP_Path, int node, int flags);
+bool AddNav_Ship(const char *Nav, const char *TargetName, int flags);
+bool AddNav_Waypoint(const char *Nav, const char *WP_Path, int node, int flags);
 
 // Sexp Accessors
-bool Nav_Set_Flag(char *Nav, int flag);
-bool Nav_UnSet_Flag(char *Nav, int flag);
+bool Nav_Set_Flag(const char *Nav, int flag);
+bool Nav_UnSet_Flag(const char *Nav, int flag);
 
-bool Nav_Set_Hidden(char *Nav);
-bool Nav_Set_NoAccess(char *Nav);
-bool Nav_Set_Visited(char *Nav);
+bool Nav_Set_Hidden(const char *Nav);
+bool Nav_Set_NoAccess(const char *Nav);
+bool Nav_Set_Visited(const char *Nav);
 
-bool Nav_UnSet_Hidden(char *Nav);
-bool Nav_UnSet_NoAccess(char *Nav);
-bool Nav_UnSet_Visited(char *Nav);
+bool Nav_UnSet_Hidden(const char *Nav);
+bool Nav_UnSet_NoAccess(const char *Nav);
+bool Nav_UnSet_Visited(const char *Nav);
 
 // Useful functions
-unsigned int DistanceTo(char *nav);
+unsigned int DistanceTo(const char *nav);
 unsigned int DistanceTo(int nav);
 
-bool IsVisited(char *nav);
+bool IsVisited(const char *nav);
 bool IsVisited(int nav);
 
-void send_autopilot_msg(char *msg, char *snd=NULL);
+void send_autopilot_msg(const char *msg, const char *snd=nullptr);
 void send_autopilot_msgID(int msgid);
 #endif
 

--- a/code/hud/hudnavigation.cpp
+++ b/code/hud/hudnavigation.cpp
@@ -32,7 +32,7 @@ void hud_draw_navigation()
 			in_cockpit = 0;
 
 		vertex target_point;	// temp vertex used to find screen position for 3-D object;
-		vec3d *target_pos = Navs[CurrentNav].GetPosition();
+		auto target_pos = Navs[CurrentNav].GetPosition();
 
 		color NavColor;
         

--- a/code/hud/hudtarget.cpp
+++ b/code/hud/hudtarget.cpp
@@ -6171,7 +6171,7 @@ void HudGaugeWeapons::maybeFlashWeapon(int index)
 	}
 }
 
-void hud_target_add_display_list(object *objp, vertex *target_point, vec3d *target_pos, int correction, color *bracket_clr, char* name, int flags)
+void hud_target_add_display_list(object *objp, const vertex *target_point, const vec3d *target_pos, int correction, const color *bracket_clr, const char* name, int flags)
 {
 	target_display_info element;
 

--- a/code/hud/hudtarget.h
+++ b/code/hud/hudtarget.h
@@ -175,7 +175,7 @@ typedef struct target_display_info {
 
 extern SCP_vector<target_display_info> target_display_list;
 
-void hud_target_add_display_list(object *objp, vertex *target_point, vec3d *target_pos, int correction, color *bracket_clr, char *name, int flags);
+void hud_target_add_display_list(object *objp, const vertex *target_point, const vec3d *target_pos, int correction, const color *bracket_clr, const char *name, int flags);
 void hud_target_clear_display_list();
 
 class HudGaugeAutoTarget: public HudGauge


### PR DESCRIPTION
This was suggested by the sexp overhaul but is useful on its own too.  Some of the `const` changes cascade a bit.