### PR TITLE
another stage of the sexp refactor

### DIFF
--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -5340,7 +5340,7 @@ struct object_ship_wing_point_team
 	{
 		ship_entry = ship_registry_get(sp->ship_name);
 		shipp = ship_entry->shipp;
-		p_objp = ship_entry->pobjp;
+		p_objp = ship_entry->p_objp;
 	}
 
 	object_ship_wing_point_team(p_object *pobjp)
@@ -5348,7 +5348,7 @@ struct object_ship_wing_point_team
 	{
 		ship_entry = ship_registry_get(pobjp->name);
 		shipp = ship_entry->shipp;
-		p_objp = ship_entry->pobjp;
+		p_objp = ship_entry->p_objp;
 	}
 
 	object_ship_wing_point_team(ship_obj *so)
@@ -5458,7 +5458,7 @@ void eval_object_ship_wing_point_team(object_ship_wing_point_team *oswpt, int no
 		oswpt->object_name = ship_entry->name;
 		oswpt->objp = ship_entry->objp;
 		oswpt->shipp = ship_entry->shipp;
-		oswpt->p_objp = ship_entry->pobjp;
+		oswpt->p_objp = ship_entry->p_objp;
 
 		switch (ship_entry->status)
 		{
@@ -14242,12 +14242,12 @@ void sexp_deal_with_ship_flag(int node, bool process_subsequent_nodes, Object::O
 			if (p_object_flag != Mission::Parse_Object_Flags::NUM_VALUES)
 			{
 				// set or clear?
-    			ship_entry->pobjp->flags.set((Mission::Parse_Object_Flags)p_object_flag, set_it);
+    			ship_entry->p_objp->flags.set((Mission::Parse_Object_Flags)p_object_flag, set_it);
 			}
 
 			if (send_multiplayer && MULTIPLAYER_MASTER) {
 				Current_sexp_network_packet.send_bool(false); 
-				Current_sexp_network_packet.send_parse_object(ship_entry->pobjp); 
+				Current_sexp_network_packet.send_parse_object(ship_entry->p_objp);
 			}
 		}
 	}
@@ -14458,9 +14458,9 @@ void sexp_alter_ship_flag_helper(object_ship_wing_point_team &oswpt, bool future
 			}
 
 			// see if we have a p_object flag to set
-			if (parse_obj_flag != Mission::Parse_Object_Flags::NUM_VALUES && oswpt.ship_entry->pobjp != nullptr)
+			if (parse_obj_flag != Mission::Parse_Object_Flags::NUM_VALUES && oswpt.ship_entry->p_objp != nullptr)
 			{
-                oswpt.ship_entry->pobjp->flags.set(parse_obj_flag, set_flag);
+                oswpt.ship_entry->p_objp->flags.set(parse_obj_flag, set_flag);
 			}
 			break;
 	}
@@ -14642,7 +14642,7 @@ void sexp_alter_ship_flag(int node)
 					break;
 
 				case OSWPT_TYPE_PARSE_OBJECT:
-					Current_sexp_network_packet.send_parse_object(oswpt.ship_entry->pobjp);
+					Current_sexp_network_packet.send_parse_object(oswpt.ship_entry->p_objp);
 					break;
 
 				case OSWPT_TYPE_WING_NOT_PRESENT:

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -14692,7 +14692,7 @@ void multi_sexp_alter_ship_flag()
 		int type;
 		while (Current_sexp_network_packet.get_int(type))
 		{
-			object_ship_wing_point_team *oswptp = nullptr;
+			std::unique_ptr<object_ship_wing_point_team> oswptp;
 
 			switch (type)
 			{
@@ -14700,7 +14700,7 @@ void multi_sexp_alter_ship_flag()
 				{
 					ship *shipp;
 					if (Current_sexp_network_packet.get_ship(shipp))
-						oswptp = new object_ship_wing_point_team(shipp);
+						oswptp.reset(new object_ship_wing_point_team(shipp));
 					else
 						Warning(LOCATION, "OSWPT had an invalid ship in multi_sexp_alter_ship_flag(), skipping");
 					break;
@@ -14710,7 +14710,7 @@ void multi_sexp_alter_ship_flag()
 				{
 					p_object *p_objp;
 					if (Current_sexp_network_packet.get_parse_object(p_objp))
-						oswptp = new object_ship_wing_point_team(p_objp);
+						oswptp.reset(new object_ship_wing_point_team(p_objp));
 					else
 						Warning(LOCATION, "OSWPT had an invalid parse object in multi_sexp_alter_ship_flag(), skipping");
 					break;
@@ -14721,7 +14721,7 @@ void multi_sexp_alter_ship_flag()
 				{
 					wing *wingp;
 					if (Current_sexp_network_packet.get_wing(wingp))
-						oswptp = new object_ship_wing_point_team(wingp);
+						oswptp.reset(new object_ship_wing_point_team(wingp));
 					else
 						Warning(LOCATION, "OSWPT had an invalid wing in multi_sexp_alter_ship_flag(), skipping");
 					break;
@@ -14732,7 +14732,7 @@ void multi_sexp_alter_ship_flag()
 					int team;
 					if (Current_sexp_network_packet.get_int(team))
 					{
-						oswptp = new object_ship_wing_point_team();
+						oswptp.reset(new object_ship_wing_point_team());
 						oswptp->type = OSWPT_TYPE_WHOLE_TEAM;
 						oswptp->team = team;
 					}
@@ -14743,10 +14743,7 @@ void multi_sexp_alter_ship_flag()
 			}
 
 			if (oswptp)
-			{
 				sexp_alter_ship_flag_helper(*oswptp, future_ships, object_flag, ship_flag, parse_obj_flag, ai_flag, set_flag);
-				delete oswptp;
-			}
 		}
 	}
 }

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -5355,8 +5355,8 @@ struct object_ship_wing_point_team
 		: object_ship_wing_point_team(&Ships[Objects[so->objnum].instance])
 	{}
 
-	object_ship_wing_point_team(wing *wingp)
-		: object_name(wingp->name), wingp(wingp)
+	object_ship_wing_point_team(wing *wp)
+		: object_name(wp->name), wingp(wp)
 	{
 		if (wingp->current_count > 0)
 			type = OSWPT_TYPE_WING;

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -5335,10 +5335,10 @@ struct object_ship_wing_point_team
 
 	object_ship_wing_point_team() = default;
 
-	object_ship_wing_point_team(ship *shipp)
-		: object_name(shipp->ship_name), type(OSWPT_TYPE_SHIP), objp(&Objects[shipp->objnum])
+	object_ship_wing_point_team(ship *sp)
+		: object_name(sp->ship_name), type(OSWPT_TYPE_SHIP), objp(&Objects[sp->objnum])
 	{
-		ship_entry = ship_registry_get(shipp->ship_name);
+		ship_entry = ship_registry_get(sp->ship_name);
 		shipp = ship_entry->shipp;
 		p_objp = ship_entry->pobjp;
 	}

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -784,7 +784,7 @@ struct ship_registry_entry
 	ShipStatus status;
 	const char *name;
 
-	p_object *pobjp;
+	p_object *p_objp;
 	object *objp;
 	ship *shipp;
 	int cleanup_mode;


### PR DESCRIPTION
This PR uses `eval_ship` and `eval_wing` to optimize `object_ship_wing_point_team` and `sexp_deal_with_ship_flags`.  The API changed a bit, but to ensure compatibility, there are fields and functions to support the old behavior.  These are temporary and will be removed when all changes have been merged via PRs.