### PR TITLE
Fix minor mis-setting of script function for displaying armor string

### DIFF
--- a/code/scripting/api/objs/ship.cpp
+++ b/code/scripting/api/objs/ship.cpp
@@ -183,7 +183,7 @@ ADE_VIRTVAR(ShieldArmorClass, l_Ship, "string", "Current Armor class of the ship
 {
 	object_h *objh;
 	const char* s    = nullptr;
-	const char *name = NULL;
+	const char *name = nullptr;
 
 	if(!ade_get_args(L, "o|s", l_Ship.GetPtr(&objh), &s))
 		return ade_set_error(L, "s", "");
@@ -192,10 +192,12 @@ ADE_VIRTVAR(ShieldArmorClass, l_Ship, "string", "Current Armor class of the ship
 		return ade_set_error(L, "s", "");
 
 	ship *shipp = &Ships[objh->objp->instance];
-	int atindex = -1;
-	if (ADE_SETTING_VAR && s != NULL) {
+	int atindex;
+	if (ADE_SETTING_VAR && s != nullptr) {
 		atindex = armor_type_get_idx(s);
 		shipp->shield_armor_type_idx = atindex;
+	} else {
+		atindex = shipp->shield_armor_type_idx;
 	}
 
 	if (atindex != -1)
@@ -210,7 +212,7 @@ ADE_VIRTVAR(ArmorClass, l_Ship, "string", "Current Armor class", "string", "Armo
 {
 	object_h *objh;
 	const char* s    = nullptr;
-	const char *name = NULL;
+	const char *name = nullptr;
 
 	if(!ade_get_args(L, "o|s", l_Ship.GetPtr(&objh), &s))
 		return ade_set_error(L, "s", "");
@@ -219,10 +221,12 @@ ADE_VIRTVAR(ArmorClass, l_Ship, "string", "Current Armor class", "string", "Armo
 		return ade_set_error(L, "s", "");
 
 	ship *shipp = &Ships[objh->objp->instance];
-	int atindex = -1;
-	if (ADE_SETTING_VAR && s != NULL) {
+	int atindex;
+	if (ADE_SETTING_VAR && s != nullptr) {
 		atindex = armor_type_get_idx(s);
 		shipp->armor_type_idx = atindex;
+	} else {
+		atindex = shipp->armor_type_idx;
 	}
 
 	if (atindex != -1)

--- a/code/scripting/api/objs/subsystem.cpp
+++ b/code/scripting/api/objs/subsystem.cpp
@@ -43,7 +43,7 @@ ADE_VIRTVAR(ArmorClass, l_Subsystem, "string", "Current Armor class", "string", 
 {
 	ship_subsys_h *sso;
 	const char* s    = nullptr;
-	const char *name = NULL;
+	const char *name = nullptr;
 
 	if(!ade_get_args(L, "o|s", l_Subsystem.GetPtr(&sso), &s))
 		return ade_set_error(L, "s", "");
@@ -53,10 +53,12 @@ ADE_VIRTVAR(ArmorClass, l_Subsystem, "string", "Current Armor class", "string", 
 
 	ship_subsys *ssys = sso->ss;
 
-	int atindex = -1;
-	if (ADE_SETTING_VAR && s != NULL) {
+	int atindex;
+	if (ADE_SETTING_VAR && s != nullptr) {
 		atindex = armor_type_get_idx(s);
 		ssys->armor_type_idx = atindex;
+	} else {
+		atindex = ssys->armor_type_idx;
 	}
 
 	if (atindex != -1)


### PR DESCRIPTION
Previously, using the script function ArmorClass did not properly display the actual armor class, instead it always displayed -1. This PR fixes that. I have tested these changes and they now properly display the armor class.