### PR TITLE
Settable minimum spawn angles.

### DIFF
--- a/code/math/staticrand.cpp
+++ b/code/math/staticrand.cpp
@@ -141,15 +141,14 @@ void static_rand_cone(int num, vec3d *out, const vec3d* const in, float max_angl
 
 //generates a random vector in a cone, with a min amd max angle. 
 //Clone of vm_vec_random_cone overload of the same function, adapted to use static_randf_range
-void static_rand_cone(int num, vec3d* out, const vec3d* const in, float min_angle, float max_angle, const matrix* const orient) {
+void static_rand_cone(int num, vec3d* out, const vec3d* const in, float min_angle, float max_angle, const matrix* const orient)
+{
 	vec3d temp;
 	const matrix* rot;
 	matrix m;
 
 	if (max_angle < min_angle) {
-		auto tmp = min_angle;
-		min_angle = max_angle;
-		max_angle = tmp;
+		std::swap(min_angle, max_angle);
 	}
 
 	// get an orientation matrix
@@ -163,8 +162,8 @@ void static_rand_cone(int num, vec3d* out, const vec3d* const in, float min_angl
 
 	// Get properly distributed spherical coordinates (DahBlount)
 	// This might not seem intuitive, but the min_angle is the angle that will have a larger z coordinate
-	float z = static_randf_range(num,cosf(fl_radians(max_angle)), cosf(fl_radians(min_angle))); // Take a 2-sphere slice
-	float phi = static_randf_range(num+1,0.0f, PI2);
+	float z = static_randf_range(num, cosf(fl_radians(max_angle)), cosf(fl_radians(min_angle))); // Take a 2-sphere slice
+	float phi = static_randf_range(num+1, 0.0f, PI2);
 	vm_vec_make(&temp, sqrtf(1.0f - z * z) * cosf(phi), sqrtf(1.0f - z * z) * sinf(phi), z); // Using the z-vec as the starting point
 
 	vm_vec_unrotate(out, &temp, rot); // We find the final vector by rotating temp to the correct orientation

--- a/code/math/staticrand.cpp
+++ b/code/math/staticrand.cpp
@@ -153,11 +153,11 @@ void static_rand_cone(int num, vec3d* out, const vec3d* const in, float min_angl
 	}
 
 	// get an orientation matrix
-	if (orient != NULL) {
+	if (orient != nullptr) {
 		rot = orient;
 	}
 	else {
-		vm_vector_2_matrix(&m, in, NULL, NULL);
+		vm_vector_2_matrix(&m, in, nullptr, nullptr);
 		rot = &m;
 	}
 

--- a/code/math/staticrand.cpp
+++ b/code/math/staticrand.cpp
@@ -139,6 +139,38 @@ void static_rand_cone(int num, vec3d *out, vec3d *in, float max_angle, matrix *o
 	vm_rot_point_around_line(out, &t2, fl_radians(static_randf_range(num+2,-max_angle, max_angle)), &vmd_zero_vector, &rot->vec.uvec);
 }
 
+//generates a random vector in a cone, with a min amd max angle. 
+//Clone of vm_vec_random_cone overload of the same function, adapted to use static_randf_range
+void static_rand_cone(int num,vec3d* out, const vec3d* in, float min_angle, float max_angle, const matrix* orient) {
+	vec3d temp;
+	const matrix* rot;
+	matrix m;
+
+	if (max_angle < min_angle) {
+		auto tmp = min_angle;
+		min_angle = max_angle;
+		max_angle = tmp;
+	}
+
+	// get an orientation matrix
+	if (orient != NULL) {
+		rot = orient;
+	}
+	else {
+		vm_vector_2_matrix(&m, in, NULL, NULL);
+		rot = &m;
+	}
+
+	// Get properly distributed spherical coordinates (DahBlount)
+	// This might not seem intuitive, but the min_angle is the angle that will have a larger z coordinate
+	float z = static_randf_range(num,cosf(fl_radians(max_angle)), cosf(fl_radians(min_angle))); // Take a 2-sphere slice
+	float phi = static_randf_range(num+1,0.0f, PI2);
+	vm_vec_make(&temp, sqrtf(1.0f - z * z) * cosf(phi), sqrtf(1.0f - z * z) * sinf(phi), z); // Using the z-vec as the starting point
+
+	vm_vec_unrotate(out, &temp, rot); // We find the final vector by rotating temp to the correct orientation
+}
+
+
 /////////////////////////////////////////////////////////////////////
 // Alternate random number generator, that doesn't affect rand() sequence
 /////////////////////////////////////////////////////////////////////

--- a/code/math/staticrand.cpp
+++ b/code/math/staticrand.cpp
@@ -115,10 +115,10 @@ void static_randvec(int num, vec3d *vp)
  * @param max_angle
  * @param orient
  */
-void static_rand_cone(int num, vec3d *out, vec3d *in, float max_angle, matrix *orient)
+void static_rand_cone(int num, vec3d *out, const vec3d const *in, float max_angle, const matrix const *orient)
 {
 	vec3d t1, t2;
-	matrix *rot;
+	const matrix *rot;
 	matrix m;
 
 	// get an orientation matrix
@@ -141,7 +141,7 @@ void static_rand_cone(int num, vec3d *out, vec3d *in, float max_angle, matrix *o
 
 //generates a random vector in a cone, with a min amd max angle. 
 //Clone of vm_vec_random_cone overload of the same function, adapted to use static_randf_range
-void static_rand_cone(int num,vec3d* out, const vec3d* in, float min_angle, float max_angle, const matrix* orient) {
+void static_rand_cone(int num, vec3d* out, const vec3d* const in, float min_angle, float max_angle, const matrix* const orient) {
 	vec3d temp;
 	const matrix* rot;
 	matrix m;

--- a/code/math/staticrand.cpp
+++ b/code/math/staticrand.cpp
@@ -115,7 +115,7 @@ void static_randvec(int num, vec3d *vp)
  * @param max_angle
  * @param orient
  */
-void static_rand_cone(int num, vec3d *out, const vec3d const *in, float max_angle, const matrix const *orient)
+void static_rand_cone(int num, vec3d *out, const vec3d* const in, float max_angle, const matrix* const orient)
 {
 	vec3d t1, t2;
 	const matrix *rot;

--- a/code/math/staticrand.h
+++ b/code/math/staticrand.h
@@ -23,8 +23,8 @@ extern float static_randf(int num);
 extern void static_randvec(int num, vec3d *vp);
 extern int static_rand_range(int num, int min, int max);
 extern float static_randf_range(int num, float min, float max);
-void static_rand_cone(int num, vec3d *out, const vec3d const *in, float max_angle, const matrix const *orient = nullptr);
-void static_rand_cone(int num, vec3d *out, const vec3d const *in, float min_angle, float max_angle, const matrix const *orient = nullptr);
+void static_rand_cone(int num, vec3d *out, const vec3d* const in, float max_angle, const matrix* const orient = nullptr);
+void static_rand_cone(int num, vec3d *out, const vec3d* const in, float min_angle, float max_angle, const matrix* const orient = nullptr);
 
 // Alternate random number generator that doesn't affect rand() sequence
 /// Get a random integer between 1 and RND_MAX

--- a/code/math/staticrand.h
+++ b/code/math/staticrand.h
@@ -24,6 +24,7 @@ extern void static_randvec(int num, vec3d *vp);
 extern int static_rand_range(int num, int min, int max);
 extern float static_randf_range(int num, float min, float max);
 void static_rand_cone(int num, vec3d *out, vec3d *in, float max_angle, matrix *orient = nullptr);
+void static_rand_cone(int num, vec3d* out, vec3d* in, float min_angle, float max_angle, matrix* orient = nullptr);
 
 // Alternate random number generator that doesn't affect rand() sequence
 /// Get a random integer between 1 and RND_MAX

--- a/code/math/staticrand.h
+++ b/code/math/staticrand.h
@@ -23,8 +23,8 @@ extern float static_randf(int num);
 extern void static_randvec(int num, vec3d *vp);
 extern int static_rand_range(int num, int min, int max);
 extern float static_randf_range(int num, float min, float max);
-void static_rand_cone(int num, vec3d *out, vec3d *in, float max_angle, matrix *orient = nullptr);
-void static_rand_cone(int num, vec3d* out, vec3d* in, float min_angle, float max_angle, matrix* orient = nullptr);
+void static_rand_cone(int num, vec3d *out, const vec3d const *in, float max_angle, const matrix const *orient = nullptr);
+void static_rand_cone(int num, vec3d *out, const vec3d const *in, float min_angle, float max_angle, const matrix const *orient = nullptr);
 
 // Alternate random number generator that doesn't affect rand() sequence
 /// Get a random integer between 1 and RND_MAX

--- a/code/weapon/weapon.h
+++ b/code/weapon/weapon.h
@@ -205,6 +205,7 @@ typedef struct spawn_weapon_info
 	short	spawn_type;							//	Type of weapon to spawn when detonated.
 	short	spawn_count;						//	Number of weapons of spawn_type to spawn.
 	float	spawn_angle;						//  Angle to spawn the child weapons in.  default is 180
+	float	spawn_min_angle;					//  Angle of spawning 'deadzone' inside spawn angle. Default 0.
 } spawn_weapon_info;
 
 #define MAX_SPAWN_TYPES_PER_WEAPON 5

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -5657,7 +5657,10 @@ void spawn_child_weapons(object *objp)
 			// for multiplayer, use the static randvec functions based on the network signatures to provide
 			// the randomness so that it is the same on all machines.
 			if ( Game_mode & GM_MULTIPLAYER ) {
-				static_rand_cone(objp->net_signature + j, &tvec, fvec, wip->spawn_info[i].spawn_angle);
+				if (wip->spawn_info[i].spawn_min_angle <= 0)
+					static_rand_cone(objp->net_signature + j, &tvec, fvec, wip->spawn_info[i].spawn_angle);
+				else
+					static_rand_cone(objp->net_signature + j, &tvec, fvec, wip->spawn_info[i].spawn_min_angle, wip->spawn_info[i].spawn_angle);
 			} else {
 				if(wip->spawn_info[i].spawn_min_angle <= 0)
 					vm_vec_random_cone(&tvec, fvec, wip->spawn_info[i].spawn_angle);

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -2039,6 +2039,19 @@ int parse_weapon(int subtype, bool replace, const char *filename)
         }
 	}
 
+	int num_spawn_min_angs_defined = 0;
+
+	while (optional_string("$Spawn Minimum Angle:"))
+	{
+		stuff_float(&dum_float);
+		
+		if (num_spawn_min_angs_defined < MAX_SPAWN_TYPES_PER_WEAPON)
+		{
+			wip->spawn_info[num_spawn_min_angs_defined].spawn_min_angle = dum_float;
+			num_spawn_min_angs_defined++;
+		}
+	}
+
 	if (wip->wi_flags[Weapon::Info_Flags::Local_ssm] && optional_string("$Local SSM:"))
 	{
 		if(optional_string("+Warpout Delay:")) {
@@ -5646,7 +5659,10 @@ void spawn_child_weapons(object *objp)
 			if ( Game_mode & GM_MULTIPLAYER ) {
 				static_rand_cone(objp->net_signature + j, &tvec, fvec, wip->spawn_info[i].spawn_angle);
 			} else {
-				vm_vec_random_cone(&tvec, fvec, wip->spawn_info[i].spawn_angle);
+				if(wip->spawn_info[i].spawn_min_angle <= 0)
+					vm_vec_random_cone(&tvec, fvec, wip->spawn_info[i].spawn_angle);
+				else
+					vm_vec_random_cone(&tvec, fvec, wip->spawn_info[i].spawn_min_angle, wip->spawn_info[i].spawn_angle);
 			}
 			vm_vec_scale_add(&pos, opos, &tvec, objp->radius);
 
@@ -7693,6 +7709,7 @@ void weapon_info::reset()
 	{
 		this->spawn_info[i].spawn_type = -1;
 		this->spawn_info[i].spawn_angle = 180;
+		this->spawn_info[i].spawn_min_angle = 0;
 		this->spawn_info[i].spawn_count = DEFAULT_WEAPON_SPAWN_COUNT;
 	}
 


### PR DESCRIPTION
Implements half of #2423, specifically the child weapon spawn angle part. I know at least one person besides me wants this, so I figure it's better to get it in asap rather than wait for me to finish deciding how much I want to match the existing more complex $fof options.