### PR TITLE
update .clang-tidy based on Discord comments

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,20 +1,22 @@
 ---
 Checks: "-*,\
 modernize-*,\
--modernize-raw-string-literal,\
--modernize-use-using,\
--modernize-make-unique,\
--modernize-use-trailing-return-type,\
 -modernize-avoid-c-arrays,\
+-modernize-make-unique,\
+-modernize-raw-string-literal,\
+-modernize-use-trailing-return-type,\
+-modernize-use-using,\
 performance-*,\
 -performance-type-promotion-in-math-fn,\
 misc-*,\
 -misc-macro-parentheses,\
 -misc-misplaced-widening-cast,\
+-misc-non-private-member-variables-in-classes,\
 -misc-static-assert,\
 -misc-unused-parameters,\
--misc-non-private-member-variables-in-classes,\
 readability-*,\
+-readability-avoid-const-params-in-decls,\
+-readability-else-after-return,\
 -readability-function-size,\
 -readability-identifier-naming,\
 -readability-implicit-bool-conversion,\
@@ -24,7 +26,6 @@ readability-*,\
 -readability-named-parameter,\
 -readability-qualified-auto,\
 -readability-uppercase-literal-suffix,\
--readability-else-after-return,\
 "
 WarningsAsErrors: ''
 HeaderFilterRegex: 'code/.*$|freespace2/.*$|qtfred/.*$|test/src/.*$|build/.*$'


### PR DESCRIPTION
This removes `readability-avoid-const-params-in-decls` from the list of things clang checks.  Function declarations and headers should be the same, so it makes no sense to warn about `const` in one but not the other.

This also alphabetizes the exceptions for easier reading.