### PR TITLE
refine ShipStatus::EXITED state

### DIFF
--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -775,9 +775,21 @@ extern void ship_add_exited_ship( ship *shipp, Ship::Exit_Flags reason );
 extern int ship_find_exited_ship_by_name( const char *name );
 extern int ship_find_exited_ship_by_signature( int signature);
 
-// stuff for overall ship status, useful for reference by sexps and scripts
+// Stuff for overall ship status, useful for reference by sexps and scripts.  Status changes occur in the same frame as mission log entries.
+enum ShipStatus
+{
+	// A ship is on the arrival list as a parse object
+	NOT_YET_PRESENT,
 
-enum ShipStatus { NOT_YET_PRESENT, PRESENT, EXITED };
+	// A ship is currently in-mission, and its objp and shipp pointers are valid
+	PRESENT,
+
+	// A ship is destroyed, departed, or vanished.  Note however that for destroyed ships,
+	// ship_cleanup is not called until the death roll is complete, which means there is a
+	// period of time where the ship is "exited", but objp and shipp are still valid and
+	// exited_index is not yet assigned.
+	EXITED
+};
 
 struct ship_registry_entry
 {

--- a/code/ship/shiphit.cpp
+++ b/code/ship/shiphit.cpp
@@ -1705,6 +1705,10 @@ void ship_hit_kill(object *ship_objp, object *other_obj, float percent_killed, i
 		}
 	}
 
+	// Goober5000 - since we added a mission log entry above, immediately set the status.  For destruction, ship_cleanup isn't called until a little bit later
+	auto entry = &Ship_registry[Ship_registry_map[sp->ship_name]];
+	entry->status = ShipStatus::EXITED;
+
 	ship_generic_kill_stuff( ship_objp, percent_killed );
 
 	// mwa -- removed 2/25/98 -- why is this here?  ship_objp->flags &= ~(OF_PLAYER_SHIP);


### PR DESCRIPTION
There is a slight discontinuity where ships that are destroyed have their mission log entries added a bit before `ship_cleanup` is called.  This addresses that.