### PR TITLE
Add scripting API for tracing custom code

### DIFF
--- a/code/graphics/2d.cpp
+++ b/code/graphics/2d.cpp
@@ -2617,8 +2617,6 @@ static void output_uniform_debug_data()
 
 void gr_flip(bool execute_scripting)
 {
-	TRACE_SCOPE(tracing::PageFlip);
-
 	// m!m avoid running CHA_ONFRAME when the "Quit mission" popup is shown. See mantis 2446 for reference
 	if (execute_scripting && !popup_active()) {
 		TRACE_SCOPE(tracing::LuaOnFrame);
@@ -2645,6 +2643,7 @@ void gr_flip(bool execute_scripting)
 	// Use this opportunity for retiring the uniform buffers
 	uniform_buffer_managers_retire_buffers();
 
+	TRACE_SCOPE(tracing::PageFlip);
 	gr_screen.gf_flip();
 }
 

--- a/code/scpui/RocketRenderingInterface.cpp
+++ b/code/scpui/RocketRenderingInterface.cpp
@@ -21,6 +21,8 @@
 
 #include "graphics/2d.h"
 #include "graphics/material.h"
+#include "tracing/categories.h"
+#include "tracing/tracing.h"
 
 using namespace Rocket::Core;
 
@@ -60,6 +62,7 @@ Rocket::Core::TextureHandle RocketRenderingInterface::get_texture_handle(RocketR
 CompiledGeometryHandle RocketRenderingInterface::CompileGeometry(Vertex* vertices, int num_vertices, int* indices,
                                                                  int num_indices, TextureHandle texture)
 {
+	TRACE_SCOPE(tracing::RocketCompileGeometry);
 	GR_DEBUG_SCOPE("libRocket::CompileGeometry");
 
 	auto* geom          = new CompiledGeometry();
@@ -76,6 +79,7 @@ CompiledGeometryHandle RocketRenderingInterface::CompileGeometry(Vertex* vertice
 }
 void RocketRenderingInterface::RenderCompiledGeometry(CompiledGeometryHandle geometry, const Vector2f& translation)
 {
+	TRACE_SCOPE(tracing::RocketRenderCompiledGeometry);
 	GR_DEBUG_SCOPE("libRocket::RenderCompiledGeometry");
 
 	auto geom = reinterpret_cast<CompiledGeometry*>(geometry);
@@ -119,6 +123,7 @@ void RocketRenderingInterface::SetScissorRegion(int x, int y, int width, int hei
 bool RocketRenderingInterface::LoadTexture(TextureHandle& texture_handle, Vector2i& texture_dimensions,
                                            const String& source)
 {
+	TRACE_SCOPE(tracing::RocketLoadTexture);
 	GR_DEBUG_SCOPE("libRocket::LoadTexture");
 	SCP_string filename;
 	int dir_type;
@@ -152,6 +157,7 @@ bool RocketRenderingInterface::LoadTexture(TextureHandle& texture_handle, Vector
 bool RocketRenderingInterface::GenerateTexture(TextureHandle& texture_handle, const Rocket::Core::byte* source,
                                                const Vector2i& source_dimensions)
 {
+	TRACE_SCOPE(tracing::RocketGenerateTexture);
 	GR_DEBUG_SCOPE("libRocket::GenerateTexture");
 	auto size = (size_t)(source_dimensions.x * source_dimensions.y * 4); // RGBA format
 
@@ -184,6 +190,8 @@ void RocketRenderingInterface::ReleaseTexture(TextureHandle texture)
 void RocketRenderingInterface::RenderGeometry(Vertex* vertices, int num_vertices, int* indices, int num_indices,
                                               TextureHandle texture, const Vector2f& translation)
 {
+	TRACE_SCOPE(tracing::RocketRenderGeometry);
+	GR_DEBUG_SCOPE("libRocket::RenderGeometry");
 	gr_update_buffer_data(vertex_stream_buffer, sizeof(*vertices) * num_vertices, vertices);
 	gr_update_buffer_data(index_stream_buffer, sizeof(*indices) * num_indices, indices);
 

--- a/code/scpui/RocketRenderingInterface.h
+++ b/code/scpui/RocketRenderingInterface.h
@@ -36,9 +36,9 @@ class RocketRenderingInterface : public Rocket::Core::RenderInterface {
 
 	vec2d renderOffset;
 
-	Texture* get_texture(Rocket::Core::TextureHandle handle);
+	static Texture* get_texture(Rocket::Core::TextureHandle handle);
 
-	Rocket::Core::TextureHandle get_texture_handle(Texture* bitmap);
+	static Rocket::Core::TextureHandle get_texture_handle(Texture* bitmap);
 
 	void renderGeometry(int vertex_buffer, int index_buffer, int num_elements, int bitmap,
 	                    const Rocket::Core::Vector2f& translation);
@@ -132,14 +132,14 @@ class RocketRenderingInterface : public Rocket::Core::RenderInterface {
 	 * @param handle The libRocket texture handle
 	 * @return The bitmap number
 	 */
-	int getBitmapNum(Rocket::Core::TextureHandle handle);
+	static int getBitmapNum(Rocket::Core::TextureHandle handle);
 
 	/**
 	 * @brief Sets the animation frame that the TextureHandle will use when it's rendered
 	 * @param handle The libRocket texture handle to modify
 	 * @param frame The animation frame (0-based for the first frame)
 	 */
-	void setAnimationFrame(Rocket::Core::TextureHandle handle, int frame);
+	static void setAnimationFrame(Rocket::Core::TextureHandle handle, int frame);
 };
 
 } // namespace scpui

--- a/code/scripting/api/libs/engine.cpp
+++ b/code/scripting/api/libs/engine.cpp
@@ -3,6 +3,7 @@
 
 #include "engine.h"
 
+#include "scripting/api/objs/tracing_category.h"
 #include "scripting/scripting.h"
 
 namespace scripting {
@@ -79,7 +80,12 @@ ADE_FUNC(addHook, l_Engine,
 	return ADE_RETURN_TRUE;
 }
 
-ADE_FUNC(sleep, l_Engine, "number seconds", "Executes a <b>blocking</b> sleep. Usually only necessary for development or testing purposes. Use with care!", nullptr, nullptr)
+ADE_FUNC(sleep,
+	l_Engine,
+	"number seconds",
+	"Executes a <b>blocking</b> sleep. Usually only necessary for development or testing purposes. Use with care!",
+	nullptr,
+	nullptr)
 {
 	float seconds = 0.0f;
 	if (!ade_get_args(L, "f", &seconds)) {
@@ -88,6 +94,23 @@ ADE_FUNC(sleep, l_Engine, "number seconds", "Executes a <b>blocking</b> sleep. U
 
 	os_sleep(fl2i(seconds * 1000.0f));
 	return ADE_RETURN_NIL;
+}
+
+ADE_FUNC(createTracingCategory,
+	l_Engine,
+	"string name, [boolean gpu_category = false]",
+	"Creates a new category for tracing the runtime of a code segment. Also allows to trace how long the corresponding "
+	"code took on the GPU.",
+	"tracing_category",
+	"The allocated category.")
+{
+	const char* name  = nullptr;
+	bool gpu_category = false;
+	if (!ade_get_args(L, "s|b", &name, &gpu_category)) {
+		return ADE_RETURN_NIL;
+	}
+
+	return ade_set_args(L, "o", l_TracingCategory.Set(tracing::Category(name, gpu_category)));
 }
 
 } // namespace api

--- a/code/scripting/api/objs/tracing_category.cpp
+++ b/code/scripting/api/objs/tracing_category.cpp
@@ -1,0 +1,34 @@
+#include "tracing_category.h"
+
+#include "tracing/tracing.h"
+
+namespace scripting {
+namespace api {
+
+ADE_OBJ(l_TracingCategory, tracing::Category, "tracing_category", "A category for tracing engine performance");
+
+ADE_FUNC(trace,
+	l_TracingCategory,
+	"function body()",
+	"Traces the run time of the specified function that will be invoked in this call.",
+	nullptr,
+	nullptr)
+{
+	tracing::Category* category = nullptr;
+	luacpp::LuaFunction func;
+	if (!ade_get_args(L, "ou", l_TracingCategory.GetPtr(&category), &func)) {
+		return ADE_RETURN_NIL;
+	}
+
+	if (!func.isValid()) {
+		LuaError(L, "Invalid function reference passed!");
+		return ADE_RETURN_NIL;
+	}
+
+	TRACE_SCOPE(*category);
+	func();
+	return ADE_RETURN_NIL;
+}
+
+} // namespace api
+} // namespace scripting

--- a/code/scripting/api/objs/tracing_category.h
+++ b/code/scripting/api/objs/tracing_category.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include "scripting/ade.h"
+#include "scripting/ade_api.h"
+#include "tracing/categories.h"
+
+namespace scripting {
+namespace api {
+
+DECLARE_ADE_OBJ(l_TracingCategory, tracing::Category);
+
+} // namespace api
+} // namespace scripting

--- a/code/source_groups.cmake
+++ b/code/source_groups.cmake
@@ -1194,6 +1194,8 @@ add_file_folder("Scripting\\\\Api\\\\Objs"
 	scripting/api/objs/texturemap.h
     scripting/api/objs/time_obj.cpp
     scripting/api/objs/time_obj.h
+	scripting/api/objs/tracing_category.cpp
+	scripting/api/objs/tracing_category.h
 	scripting/api/objs/vecmath.cpp
 	scripting/api/objs/vecmath.h
 	scripting/api/objs/waypoint.cpp

--- a/code/tracing/categories.cpp
+++ b/code/tracing/categories.cpp
@@ -6,7 +6,7 @@ namespace tracing {
 Category::Category(const char* name, bool is_graphics) : _name(name), _graphics_category(is_graphics) {
 }
 const char* Category::getName() const {
-	return _name;
+	return _name.c_str();
 }
 bool Category::usesGPUCounter() const {
 	return _graphics_category;
@@ -111,6 +111,12 @@ Category CutsceneProcessAudioData("Process audio data", false);
 
 Category CutsceneFFmpegVideoDecoder("FFmpeg decode video", false);
 Category CutsceneFFmpegAudioDecoder("FFmpeg decode audio", false);
+
+Category RocketCompileGeometry("Rocket compile geometry", true);
+Category RocketRenderCompiledGeometry("Rocket render compiled geometry", true);
+Category RocketLoadTexture("Rocket load texture", true);
+Category RocketGenerateTexture("Rocket generate texture", true);
+Category RocketRenderGeometry("Rocket render geometry", true);
 
 Category LoadMissionLoad("Load mission", false);
 Category LoadPostMissionLoad("Mission load post processing", false);

--- a/code/tracing/categories.h
+++ b/code/tracing/categories.h
@@ -3,6 +3,7 @@
 #define _TRACING_CATEGORIES_H
 #pragma once
 
+#include "globalincs/pstypes.h"
 
 /** @file
  *  @ingroup tracing
@@ -14,7 +15,7 @@
 namespace tracing {
 
 class Category {
-	const char* _name;
+	const SCP_string _name;
 	bool _graphics_category;
  public:
 	Category(const char* name, bool is_graphics);
@@ -123,6 +124,12 @@ extern Category CutsceneProcessAudioData;
 
 extern Category CutsceneFFmpegVideoDecoder;
 extern Category CutsceneFFmpegAudioDecoder;
+
+extern Category RocketCompileGeometry;
+extern Category RocketRenderCompiledGeometry;
+extern Category RocketLoadTexture;
+extern Category RocketGenerateTexture;
+extern Category RocketRenderGeometry;
 
 // Loading scopes
 extern Category LoadMissionLoad;

--- a/code/tracing/tracing.h
+++ b/code/tracing/tracing.h
@@ -19,7 +19,7 @@
 namespace tracing {
 
 /**
- * @brief Process if used for GPU events
+ * @brief Process id used for GPU events
  */
 const std::int64_t GPU_PID = std::numeric_limits<std::int64_t>::min();
 


### PR DESCRIPTION
This can be used by Lua code to trace the runtime of their code in the
same way the engine already is capable of doing for most in-mission and
mission loading code.

Also adds some tracing scopes to the libRocket code