### PR TITLE
Ensure Lua functions are executed in correct state

### DIFF
--- a/code/hud/hudscripting.cpp
+++ b/code/hud/hudscripting.cpp
@@ -4,8 +4,8 @@
 #include "hud/hudscripting.h"
 
 #include "parse/parselo.h"
-
 #include "scripting/api/objs/hudgauge.h"
+#include "scripting/scripting.h"
 
 HudGaugeScripting::HudGaugeScripting() :
 	HudGauge(HUD_OBJECT_SCRIPTING,
@@ -25,8 +25,8 @@ void HudGaugeScripting::render(float /*frametime*/) {
 		return;
 	}
 
-	_renderFunction.call({ luacpp::LuaValue::createValue(_renderFunction.getLuaState(),
-	                                                     l_HudGaugeDrawFuncs.Set(this)) });
+	_renderFunction.call(Script_system.GetLuaSession(),
+		{luacpp::LuaValue::createValue(_renderFunction.getLuaState(), l_HudGaugeDrawFuncs.Set(this))});
 }
 
 void HudGaugeScripting::initName(SCP_string name) {

--- a/code/parse/sexp/LuaSEXP.cpp
+++ b/code/parse/sexp/LuaSEXP.cpp
@@ -2,24 +2,23 @@
 //
 #include "LuaSEXP.h"
 
-#include "parse/parselo.h"
-#include "parse/sexp/sexp_lookup.h"
-#include "parse/sexp.h"
-
-#include "object/waypoint.h"
 #include "iff_defs/iff_defs.h"
-#include "ship/ship.h"
-#include "weapon/weapon.h"
 #include "mission/missionmessage.h"
-
+#include "object/waypoint.h"
+#include "parse/parselo.h"
+#include "parse/sexp.h"
+#include "parse/sexp/sexp_lookup.h"
+#include "scripting/api/objs/message.h"
 #include "scripting/api/objs/sexpvar.h"
-#include "scripting/api/objs/team.h"
-#include "scripting/api/objs/waypoint.h"
 #include "scripting/api/objs/ship.h"
 #include "scripting/api/objs/shipclass.h"
+#include "scripting/api/objs/team.h"
+#include "scripting/api/objs/waypoint.h"
 #include "scripting/api/objs/weaponclass.h"
 #include "scripting/api/objs/wing.h"
-#include "scripting/api/objs/message.h"
+#include "scripting/scripting.h"
+#include "ship/ship.h"
+#include "weapon/weapon.h"
 
 using namespace luacpp;
 
@@ -288,7 +287,7 @@ int LuaSEXP::execute(int node) {
 
 	// All parameters are now in LuaValues, time to call our function
 	try {
-		auto retVals = _action.call(luaParameters);
+		auto retVals = _action.call(Script_system.GetLuaSession(), luaParameters);
 
 		return getSexpReturnValue(retVals);
 	} catch(const LuaException&) {

--- a/code/scripting/ade.cpp
+++ b/code/scripting/ade.cpp
@@ -1146,7 +1146,7 @@ void load_default_script(lua_State* L, const char* name)
 		auto func = LuaFunction::createFromCode(L, source, source_name);
 		func.setErrorFunction(LuaFunction::createFromCFunction(L, ade_friendly_error));
 		try {
-			func();
+			func(L);
 		} catch (const LuaException&) {
 			// The execution of the function may also throw an exception but that should have been handled by a LuaError
 			// before

--- a/code/scripting/ade_api.h
+++ b/code/scripting/ade_api.h
@@ -5,6 +5,7 @@
 #define FS2_OPEN_ADE_API_H_H
 
 #include "globalincs/version.h"
+
 #include "scripting/ade.h"
 #include "scripting/ade_args.h"
 

--- a/code/scripting/api/LuaEventCallback.h
+++ b/code/scripting/api/LuaEventCallback.h
@@ -34,7 +34,7 @@ class LuaEventCallback {
 		LuaValueList lua_args;
 		convert_args(_func.getLuaState(), lua_args, args...);
 
-		_func(lua_args);
+		_func(_func.getLuaState(), lua_args);
 	}
 };
 

--- a/code/scripting/api/libs/async.cpp
+++ b/code/scripting/api/libs/async.cpp
@@ -19,7 +19,9 @@ ADE_LIB(l_Async, "Async", "async", "Support library for asynchronous operations"
  */
 class lua_func_resolve_context : public resolve_context {
   public:
-	lua_func_resolve_context(luacpp::LuaFunction callback) : _callback(std::move(callback)) {}
+	lua_func_resolve_context(lua_State* L, luacpp::LuaFunction callback) : _luaState(L), _callback(std::move(callback))
+	{
+	}
 
 	void setResolver(Resolver resolver) override
 	{
@@ -59,10 +61,11 @@ class lua_func_resolve_context : public resolve_context {
 				return luacpp::LuaValueList();
 			});
 
-		_callback({resolveFunc, rejectFunc});
+		_callback(_luaState, {resolveFunc, rejectFunc});
 	}
 
   private:
+	lua_State* _luaState = nullptr;
 	luacpp::LuaFunction _callback;
 };
 
@@ -85,7 +88,7 @@ ADE_FUNC(promise,
 		return ADE_RETURN_NIL;
 	}
 
-	std::unique_ptr<resolve_context> resolveCtx(new lua_func_resolve_context(std::move(callback)));
+	std::unique_ptr<resolve_context> resolveCtx(new lua_func_resolve_context(L, std::move(callback)));
 
 	return ade_set_args(L, "o", l_Promise.Set(LuaPromise(std::move(resolveCtx))));
 }

--- a/code/scripting/api/objs/promise.cpp
+++ b/code/scripting/api/objs/promise.cpp
@@ -36,7 +36,9 @@ ADE_FUNC(continueWith,
 		return ADE_RETURN_NIL;
 	}
 
-	return ade_set_args(L, "o", l_Promise.Set(promise->then(thenFunc)));
+	return ade_set_args(L,
+		"o",
+		l_Promise.Set(promise->then([L, thenFunc](const luacpp::LuaValueList& val) { return thenFunc(L, val); })));
 }
 
 ADE_FUNC(catch,
@@ -62,7 +64,9 @@ ADE_FUNC(catch,
 		return ADE_RETURN_NIL;
 	}
 
-	return ade_set_args(L, "o", l_Promise.Set(promise->catchError(thenFunc)));
+	return ade_set_args(L, "o", l_Promise.Set(promise->catchError([L, thenFunc](const luacpp::LuaValueList& val) {
+		return thenFunc(L, val);
+	})));
 }
 
 ADE_FUNC(isResolved,

--- a/code/scripting/api/objs/tracing_category.cpp
+++ b/code/scripting/api/objs/tracing_category.cpp
@@ -26,7 +26,7 @@ ADE_FUNC(trace,
 	}
 
 	TRACE_SCOPE(*category);
-	func();
+	func(L);
 	return ADE_RETURN_NIL;
 }
 

--- a/code/scripting/lua/LuaFunction.cpp
+++ b/code/scripting/lua/LuaFunction.cpp
@@ -134,8 +134,8 @@ bool LuaFunction::setEnvironment(const LuaTable& table) {
 	return ret;
 }
 
-LuaValueList LuaFunction::operator()(const LuaValueList& args) const {
-	return this->call(args);
+LuaValueList LuaFunction::operator()(lua_State* L, const LuaValueList& args) const {
+	return this->call(L, args);
 }
 
 void LuaFunction::setReference(const LuaReference& ref) {
@@ -159,38 +159,38 @@ void LuaFunction::setReference(const LuaReference& ref) {
 	}
 }
 
-LuaValueList LuaFunction::call(const LuaValueList& args) const {
+LuaValueList LuaFunction::call(lua_State* L, const LuaValueList& args) const {
 	int err_idx = 0;
 	int stackTop;
 
 	if (_errorFunction) {
 		// push the error function
-		_errorFunction->pushValue(_luaState);
-		err_idx = lua_gettop(_luaState);
+		_errorFunction->pushValue(L);
+		err_idx = lua_gettop(L);
 		stackTop = err_idx;
 	} else {
-		stackTop = lua_gettop(_luaState);
+		stackTop = lua_gettop(L);
 	}
 
 	// Push the function onto the stack
-	this->pushValue(_luaState);
+	this->pushValue(L);
 
 	// Push the arguments onto the stack
 	for (const auto& arg : args) {
-		arg.pushValue(_luaState);
+		arg.pushValue(L);
 	}
 
 	// actually call the function now!
-	int err = lua_pcall(_luaState, (int) args.size(), LUA_MULTRET, err_idx);
+	int err = lua_pcall(L, (int) args.size(), LUA_MULTRET, err_idx);
 
 	if (!err) {
-		int numReturn = lua_gettop(_luaState) - stackTop;
+		int numReturn = lua_gettop(L) - stackTop;
 		LuaValueList values;
 		values.reserve(numReturn);
 
 		LuaValue val;
 		for (int i = 0; i < numReturn; ++i) {
-			if (convert::popValue(_luaState, val)) {
+			if (convert::popValue(L, val)) {
 				// Add values at the begin as the last return value is on top
 				// of the stack.
 				values.insert(values.begin(), val);
@@ -199,7 +199,7 @@ LuaValueList LuaFunction::call(const LuaValueList& args) const {
 
 		if (err_idx != 0) {
 			// Remove the error function
-			lua_pop(_luaState, 1);
+			lua_pop(L, 1);
 		}
 
 		return values;
@@ -207,21 +207,21 @@ LuaValueList LuaFunction::call(const LuaValueList& args) const {
 		// Make sure that there is exactly one parameter left on the stack
 		// If the error function didn't return anything then this will push nil
 		// If it pushed more than one value then this will discard all of them except the last one
-		lua_settop(_luaState, stackTop + 1);
+		lua_settop(L, stackTop + 1);
 
 		std::string err_msg;
-		if (!lua_isstring(_luaState, -1)) {
+		if (!lua_isstring(L, -1)) {
 			err_msg = "Invalid lua value on stack!";
-			lua_pop(_luaState, 1); // Remove the value on the stack
+			lua_pop(L, 1); // Remove the value on the stack
 		} else {
-			if (!convert::popValue(_luaState, err_msg)) {
+			if (!convert::popValue(L, err_msg)) {
 				err_msg = "Failed to get error message from Lua stack!";
 			}
 		}
 
 		if (err_idx != 0) {
 			// Pop the error function
-			lua_pop(_luaState, 1);
+			lua_pop(L, 1);
 		}
 
 		// Throw exception with generated message

--- a/code/scripting/lua/LuaFunction.h
+++ b/code/scripting/lua/LuaFunction.h
@@ -117,19 +117,20 @@ class LuaFunction: public LuaValue {
      * the arguments and then the function. After that the function is called with lua_pcall
      * and the return values are converted into a LuaValueList.
      *
+     * @param L The state in which the function should be executed
      * @param arguments The arguments passed to the functions. Defaults to none
      * @return luacpp::LuaValueList The values returned by the function call
      *
      * @exception LuaException If an error occurs while executing the function an exception is thrown
      * 	with the message of the error.
      */
-	LuaValueList call(const LuaValueList& arguments = LuaValueList()) const;
+	LuaValueList call(lua_State* L, const LuaValueList& arguments = LuaValueList()) const;
 
 	/**
      * @brief Calls the function. See call().
      * @return Same as call().
      */
-	LuaValueList operator()(const LuaValueList& arguments = LuaValueList()) const;
+	LuaValueList operator()(lua_State* L, const LuaValueList& arguments = LuaValueList()) const;
  private:
 	LuaReference _errorFunction;
 };

--- a/code/scripting/scripting.cpp
+++ b/code/scripting/scripting.cpp
@@ -1293,7 +1293,7 @@ bool script_state::EvalString(const char* string, const char* debug_str)
 		function.setErrorFunction(LuaFunction::createFromCFunction(LuaState, scripting::ade_friendly_error));
 
 		try {
-			function.call();
+			function.call(LuaState);
 		} catch (const LuaException&) {
 			return false;
 		}
@@ -1316,7 +1316,7 @@ int script_state::RunBytecode(script_function& hd)
 	GR_DEBUG_SCOPE("Lua code");
 
 	try {
-		hd.function.call();
+		hd.function.call(LuaState);
 	} catch (const LuaException&) {
 		return 0;
 	}
@@ -1469,7 +1469,7 @@ bool script_state::IsOverride(script_hook &hd)
 
 void script_state::RunInitFunctions() {
 	for (const auto& initFunc : GameInitFunctions) {
-		initFunc.function();
+		initFunc.function(LuaState);
 	}
 	// We don't need this anymore so no need to keep references to those functions around anymore
 	GameInitFunctions.clear();

--- a/code/scripting/scripting.h
+++ b/code/scripting/scripting.h
@@ -386,7 +386,7 @@ bool script_state::EvalStringWithReturn(const char* string, const char* format, 
 		function.setErrorFunction(LuaFunction::createFromCFunction(LuaState, scripting::ade_friendly_error));
 
 		try {
-			auto ret = function.call();
+			auto ret = function.call(LuaState);
 
 			if (rtn != nullptr && ret.size() >= 1) {
 				auto stack_start = lua_gettop(LuaState);
@@ -424,7 +424,7 @@ int script_state::RunBytecode(script_function& hd, char format, T* data)
 	GR_DEBUG_SCOPE("Lua code");
 
 	try {
-		auto ret = hd.function.call();
+		auto ret = hd.function.call(LuaState);
 
 		if (data != nullptr && ret.size() >= 1) {
 			auto stack_start = lua_gettop(LuaState);

--- a/test/src/scripting/lua/Function.cpp
+++ b/test/src/scripting/lua/Function.cpp
@@ -71,8 +71,8 @@ TEST_F(LuaFunctionTest, Call) {
 		// Test execution with failure
 		LuaFunction function = LuaFunction::createFromCode(L, "invalid()");
 
-		ASSERT_THROW(function.call(), luacpp::LuaException);
-		ASSERT_THROW(function(), luacpp::LuaException);
+		ASSERT_THROW(function.call(L), luacpp::LuaException);
+		ASSERT_THROW(function(L), luacpp::LuaException);
 	}
 	{
 		ScopedLuaStackTest stackTest(L);
@@ -80,8 +80,8 @@ TEST_F(LuaFunctionTest, Call) {
 		// Test execution without failure
 		LuaFunction function = LuaFunction::createFromCode(L, "local a = 1");
 
-		ASSERT_NO_THROW(function.call());
-		ASSERT_NO_THROW(function());
+		ASSERT_NO_THROW(function.call(L));
+		ASSERT_NO_THROW(function(L));
 	}
 	{
 		ScopedLuaStackTest stackTest(L);
@@ -90,7 +90,7 @@ TEST_F(LuaFunctionTest, Call) {
 		LuaFunction function = LuaFunction::createFromCode(L, "return 'abc', 5");
 
 
-		LuaValueList returnValues = function();
+		LuaValueList returnValues = function(L);
 
 		ASSERT_EQ(luacpp::ValueType::STRING, returnValues[0].getValueType());
 		ASSERT_EQ(luacpp::ValueType::NUMBER, returnValues[1].getValueType());
@@ -107,7 +107,7 @@ TEST_F(LuaFunctionTest, Call) {
 		ASSERT_TRUE(convert::popValue(L, func));
 
 		LuaValue arg = LuaValue::createValue(L, "testString");
-		LuaValueList returnVals = func({ arg });
+		LuaValueList returnVals = func(L, { arg });
 
 		ASSERT_EQ(1, (int)returnVals.size());
 		ASSERT_EQ(ValueType::STRING, returnVals[0].getValueType());
@@ -127,7 +127,7 @@ TEST_F(LuaFunctionTest, SetEnvironment) {
 
 		func.setEnvironment(envionment);
 
-		LuaValueList returnVals = func();
+		LuaValueList returnVals = func(L);
 
 		ASSERT_EQ(1, (int)returnVals.size());
 		ASSERT_EQ(ValueType::STRING, returnVals[0].getValueType());
@@ -142,7 +142,7 @@ TEST_F(LuaFunctionTest, SetCFunction) {
 
 		LuaFunction func = LuaFunction::createFromCFunction(L, testCFunction);
 
-		LuaValueList retVals = func();
+		LuaValueList retVals = func(L);
 
 		ASSERT_EQ(1, (int)retVals.size());
 		ASSERT_EQ(ValueType::NUMBER, retVals[0].getValueType());
@@ -158,7 +158,7 @@ TEST_F(LuaFunctionTest, SetErrorFunction) {
 		func.setErrorFunction(LuaFunction::createFromCFunction(L, &testErrorFunction));
 
 		try {
-			func();
+			func(L);
 			FAIL();
 		}
 		catch (const LuaException& err) {
@@ -192,7 +192,7 @@ TEST_F(LuaFunctionTest, ErrorFunctionMultipleReturnValues) {
 	func.setErrorFunction(LuaFunction::createFromCFunction(L, &testErrorFunctionTwoRetVals));
 
 	try {
-		func();
+		func(L);
 		FAIL();
 	}
 	catch (const LuaException& err) {
@@ -207,7 +207,7 @@ TEST_F(LuaFunctionTest, ErrorFunctionNoReturnValues) {
 	func.setErrorFunction(LuaFunction::createFromCFunction(L, &testErrorFunctionNoRetVals));
 
 	try {
-		func();
+		func(L);
 		FAIL();
 	} catch (const LuaException& err) {
 		ASSERT_STREQ("Invalid lua value on stack!", err.what());
@@ -222,7 +222,7 @@ TEST_F(LuaFunctionTest, Upvalues)
 
 	LuaFunction func = LuaFunction::createFromCFunction(L, upvalueTest, {upval});
 
-	auto ret = func();
+	auto ret = func(L);
 
 	ASSERT_EQ(1, (int)ret.size());
 	ASSERT_TRUE(ret.front().is(ValueType::BOOLEAN));
@@ -244,7 +244,7 @@ TEST_F(LuaFunctionTest, CreateFromStdFunction)
 
 	const auto stdFuncObj = LuaFunction::createFromStdFunction(L, stdFunc);
 
-	const auto testRet = stdFuncObj({LuaValue::createValue(L, 42), LuaValue::createValue(L, "TestString")});
+	const auto testRet = stdFuncObj(L, {LuaValue::createValue(L, 42), LuaValue::createValue(L, "TestString")});
 
 	EXPECT_EQ(2, static_cast<int>(testRet.size()));
 


### PR DESCRIPTION
This will ensure that Lua functions will always be executed in the
correct Lua state. Since we now have multiple threads (which are
different lua_State objects) it is possible that the current code could
execute a Lua function in the main state instead of the thread that is
currently executing. This can lead to weird behavior and probably also
to issues inside Lua.