### PR TITLE
Add parser for scripting argument documentation

### DIFF
--- a/code/scripting/ade.cpp
+++ b/code/scripting/ade.cpp
@@ -3,13 +3,14 @@
 
 #include "scripting/ade.h"
 
+#include "globalincs/version.h"
+
 #include "ade.h"
 #include "ade_api.h"
 #include "ade_args.h"
 #include "scripting.h"
 
 #include "def_files/def_files.h"
-#include "globalincs/version.h"
 #include "mod_table/mod_table.h"
 #include "scripting/api/objs/asteroid.h"
 #include "scripting/api/objs/beam.h"
@@ -20,6 +21,8 @@
 #include "scripting/api/objs/weapon.h"
 #include "scripting/lua/LuaFunction.h"
 #include "ship/ship.h"
+
+#include <utility>
 
 namespace {
 using namespace scripting;
@@ -281,6 +284,29 @@ void ade_output_type_link(FILE* fp, const ade_type_info& type_info) {
 		ade_output_type_link(fp, type_info.arrayType());
 		fputs(" ... }", fp);
 		break;
+	case ade_type_info_type::Map:
+		fputs("{ ", fp);
+		ade_output_type_link(fp, type_info.elements()[0]);
+		fputs(" -> ", fp);
+		ade_output_type_link(fp, type_info.elements()[1]);
+		fputs(" ... }", fp);
+		break;
+	case ade_type_info_type::Iterator:
+		fputs("iterator< ", fp);
+		ade_output_type_link(fp, type_info.arrayType());
+		fputs(" >", fp);
+		break;
+	case ade_type_info_type::Alternative: {
+		bool first = true;
+		for (const auto& type : type_info.elements()) {
+			if (!first) {
+				fputs(" | ", fp);
+			}
+			first = false;
+
+			ade_output_type_link(fp, type);
+		}
+	}
 	}
 }
 
@@ -649,15 +675,45 @@ void ade_table_entry::OutputMeta(FILE *fp)
 							fprintf(fp, "<b>%s", ade_Operators[ao].dest);
 					}
 				}
-				if(ao < 0)
-				{
-					if(Arguments != NULL) {
-						fprintf(fp, "(</b><i>%s</i><b>)</b>\n", Arguments);
-					} else {
-						fprintf(fp, "()</b>\n");
+
+				if(ao < 0) {
+					fputs("(</b>", fp);
+					if (Arguments != nullptr) {
+						argument_list_parser arg_parser;
+						if (arg_parser.parse(Arguments)) {
+							bool first    = true;
+							bool optional = false;
+							for (const auto& arg : arg_parser.getArgList()) {
+								if (!first) {
+									fputs(", ", fp);
+								}
+								first = false;
+
+								if (arg.optional && !optional) {
+									fputs("[", fp);
+									optional = true;
+								}
+
+								ade_output_type_link(fp, arg.type);
+
+								if (!arg.name.empty()) {
+									fprintf(fp, " <i>%s</i>", arg.name.c_str());
+
+									if (!arg.def_val.empty()) {
+										fprintf(fp, " = <i>%s</i>", arg.def_val.c_str());
+									}
+								}
+							}
+
+							if (optional) {
+								fputs("]", fp);
+							}
+						} else {
+							fprintf(fp, "<i>%s</i>", Arguments);
+						}
 					}
-				}
-				else
+					fputs("<b>)</b>\n", fp);
+				} else
 				{
 					fputs("</b>", fp);
 					if(Arguments != NULL) {
@@ -889,12 +945,12 @@ ade_func::ade_func(const char* name, lua_CFunction func, const ade_lib_handle& p
 
 	ate.Name = name;
 	ate.Instanced = true;
-	ate.Type = 'u';
-	ate.Function = func;
-	ate.Arguments = args;
-	ate.Description = desc;
-	ate.ReturnType = ret_type;
-	ate.ReturnDescription = ret_desc;
+	ate.Type               = 'u';
+	ate.Function           = func;
+	ate.Arguments          = args;
+	ate.Description        = desc;
+	ate.ReturnType         = ret_type;
+	ate.ReturnDescription  = ret_desc;
 	ate.DeprecationVersion = deprecation_version;
 	ate.DeprecationMessage = deprecation_message;
 
@@ -1157,57 +1213,5 @@ void load_default_script(lua_State* L, const char* name)
 }
 
 ade_table_entry& internal::getTableEntry(size_t idx) { return ade_manager::getInstance()->getEntry(idx); }
-
-ade_type_info::ade_type_info(std::initializer_list<ade_type_info> tuple_types) :
-	_type(ade_type_info_type::Tuple), _elements(tuple_types) {
-	Assertion(tuple_types.size() >= 1, "Tuples must have more than one element!");
-}
-ade_type_info::ade_type_info(const char* single_type) : _type(ade_type_info_type::Simple), _simple_name{ single_type }
-{
-	if (single_type == nullptr) {
-		// It would be better to handle this via an overload with std::nullptr_t but there are a lot of NULL usages left
-		// so this is the soltuion that requires fewer changes
-		_type = ade_type_info_type::Empty;
-		return;
-	}
-
-	// Otherwise, make sure no one tries to specify a tuple with a single string.
-	Assertion(strchr(single_type, ',') == nullptr,
-	          "Type string '%s' may not contain commas! Use the intializer list instead.", single_type);
-}
-ade_type_info::ade_type_info(const ade_type_array& listType) :
-	_type(ade_type_info_type::Array), _elements{ listType.getElementType() } {
-
-}
-bool ade_type_info::isEmpty() const {
-	return _type == ade_type_info_type::Empty;
-}
-bool ade_type_info::isTuple() const {
-	return _type == ade_type_info_type::Tuple;
-}
-bool ade_type_info::isSimple() const {
-	return _type == ade_type_info_type::Simple;
-}
-bool ade_type_info::isArray() const {
-	return _type == ade_type_info_type::Array;
-}
-const SCP_vector<ade_type_info>& ade_type_info::elements() const {
-	return _elements;
-}
-const char* ade_type_info::getSimpleName() const {
-	return _simple_name;
-}
-ade_type_info_type ade_type_info::getType() const {
-	return _type;
-}
-const ade_type_info& ade_type_info::arrayType() const {
-	return _elements.front();
-}
-
-ade_type_array::ade_type_array(ade_type_info  elementType) : _element_type(std::move(elementType)) {
-}
-const ade_type_info& ade_type_array::getElementType() const {
-	return _element_type;
-}
 
 }

--- a/code/scripting/ade.h
+++ b/code/scripting/ade.h
@@ -8,6 +8,7 @@
 #include "globalincs/version.h"
 
 #include "object/object.h"
+#include "scripting/ade_doc.h"
 
 extern "C" {
 #include <lauxlib.h>
@@ -95,56 +96,6 @@ struct ade_odata_setter {
 //v - virtual variable
 //
 //u - oh wait...
-
-enum class ade_type_info_type {
-	Empty,
-	Simple,
-	Tuple,
-	Array
-};
-
-class ade_type_array;
-
-/**
- * @brief A definition of a type used in the ADE system
- */
-class ade_type_info {
-	ade_type_info_type _type = ade_type_info_type::Empty;
-
-	const char* _simple_name = nullptr;
-
-	SCP_vector<ade_type_info> _elements;
-
-  public:
-	ade_type_info() = default;
-	/*implicit*/ ade_type_info(const char* single_type); // NOLINT(hicpp-explicit-conversions)
-	/*implicit*/ ade_type_info(std::initializer_list<ade_type_info> tuple_types);
-	/*implicit*/ ade_type_info(const ade_type_array& listType);
-
-	ade_type_info_type getType() const;
-
-	bool isEmpty() const;
-
-	bool isSimple() const;
-
-	bool isTuple() const;
-
-	bool isArray() const;
-
-	const char* getSimpleName() const;
-
-	const ade_type_info& arrayType() const;
-
-	const SCP_vector<ade_type_info>& elements() const;
-};
-
-class ade_type_array {
-	ade_type_info _element_type;
-  public:
-	explicit ade_type_array(ade_type_info elementType);
-
-	const ade_type_info& getElementType() const;
-};
 
 /**
  * @ingroup ade_api

--- a/code/scripting/ade_api.h
+++ b/code/scripting/ade_api.h
@@ -7,6 +7,7 @@
 #include "globalincs/version.h"
 #include "scripting/ade.h"
 #include "scripting/ade_args.h"
+#include "scripting/ade_doc.h"
 
 namespace scripting {
 

--- a/code/scripting/ade_doc.cpp
+++ b/code/scripting/ade_doc.cpp
@@ -1,0 +1,539 @@
+#include "ade_doc.h"
+
+#include "globalincs/pstypes.h"
+
+#include <regex>
+#include <utility>
+
+namespace scripting {
+
+ade_type_info::ade_type_info(std::initializer_list<ade_type_info> tuple_types)
+	: _type(ade_type_info_type::Tuple), _elements(tuple_types)
+{
+	Assertion(tuple_types.size() >= 1, "Tuples must have more than one element!");
+}
+ade_type_info::ade_type_info(const char* single_type) : _type(ade_type_info_type::Simple)
+{
+	if (single_type != nullptr) {
+		_simple_name.assign(single_type);
+	}
+
+	if (single_type == nullptr) {
+		// It would be better to handle this via an overload with std::nullptr_t but there are a lot of NULL usages left
+		// so this is the soltuion that requires fewer changes
+		_type = ade_type_info_type::Empty;
+		return;
+	}
+
+	// Otherwise, make sure no one tries to specify a tuple with a single string.
+	Assertion(strchr(single_type, ',') == nullptr,
+		"Type string '%s' may not contain commas! Use the intializer list instead.",
+		single_type);
+}
+ade_type_info::ade_type_info(const ade_type_array& listType)
+	: _type(ade_type_info_type::Array), _elements{listType.getElementType()}
+{
+}
+ade_type_info::ade_type_info(const ade_type_map& listType)
+	: _type(ade_type_info_type::Map), _elements{listType.getKeyType(), listType.getValueType()}
+{
+}
+ade_type_info::ade_type_info(const ade_type_iterator& iteratorType)
+	: _type(ade_type_info_type::Iterator), _elements{iteratorType.getElementType()}
+{
+}
+ade_type_info::ade_type_info(const ade_type_alternative& iteratorType)
+	: _type(ade_type_info_type::Alternative), _elements(iteratorType.getElementTypes())
+{
+}
+bool ade_type_info::isEmpty() const { return _type == ade_type_info_type::Empty; }
+bool ade_type_info::isTuple() const { return _type == ade_type_info_type::Tuple; }
+bool ade_type_info::isSimple() const { return _type == ade_type_info_type::Simple; }
+bool ade_type_info::isArray() const { return _type == ade_type_info_type::Array; }
+const SCP_vector<ade_type_info>& ade_type_info::elements() const { return _elements; }
+const char* ade_type_info::getSimpleName() const { return _simple_name.c_str(); }
+ade_type_info_type ade_type_info::getType() const { return _type; }
+const ade_type_info& ade_type_info::arrayType() const { return _elements.front(); }
+
+ade_type_array::ade_type_array(ade_type_info elementType) : _element_type(std::move(elementType)) {}
+const ade_type_info& ade_type_array::getElementType() const { return _element_type; }
+
+ade_type_map::ade_type_map(ade_type_info keyType, ade_type_info valueType)
+	: _key_type(std::move(keyType)), _value_type(std::move(valueType))
+{
+}
+const ade_type_info& ade_type_map::getKeyType() const { return _key_type; }
+const ade_type_info& ade_type_map::getValueType() const { return _value_type; }
+
+ade_type_iterator::ade_type_iterator(ade_type_info elementType) : _element_type(std::move(elementType)) {}
+const ade_type_info& ade_type_iterator::getElementType() const { return _element_type; }
+
+ade_type_alternative::ade_type_alternative(SCP_vector<ade_type_info> elements) : _elements(std::move(elements)) {}
+const SCP_vector<ade_type_info>& ade_type_alternative::getElementTypes() const { return _elements; }
+
+namespace {
+
+struct arglist_parser_regexes {
+	std::regex identifier{R"(^[\w:_-%]+)"};
+	std::regex number{R"(^-?\d+(\.\d*)?)"};
+	std::regex string{R"(^"[^"]*")"};
+	std::regex tableInit{R"(^\{[^\}]*\})"};
+};
+
+arglist_parser_regexes& regexes()
+{
+	// Keep a single instance of this to keep the construction cost down. Also use the static initializer since this
+	// code will be needed at program startup
+	static arglist_parser_regexes instance;
+	return instance;
+}
+
+enum class TokenType {
+	Equals,
+	LeftBracket,
+	RightBracket,
+	Comma,
+	TypeAlternative,
+
+	Identifier,
+	Number,
+	String,
+	TableInitializer,
+
+	EndOfFile,
+};
+
+struct regex_token {
+	TokenType type;
+	const std::regex& regex;
+};
+
+using regex_tokens = std::array<regex_token, 4>;
+regex_tokens getRegexTokens()
+{
+	const auto& regex = regexes();
+
+	return {
+		regex_token{TokenType::Number, regex.number},
+		regex_token{TokenType::String, regex.string},
+		regex_token{TokenType::Identifier, regex.identifier},
+		regex_token{TokenType::TableInitializer, regex.tableInit},
+	};
+}
+
+const char* to_string(TokenType t)
+{
+	switch (t) {
+	case TokenType::Equals:
+		return "'='";
+	case TokenType::LeftBracket:
+		return "'['";
+	case TokenType::RightBracket:
+		return "']'";
+	case TokenType::Comma:
+		return "','";
+	case TokenType::TypeAlternative:
+		return "'|' or '/'";
+	case TokenType::EndOfFile:
+		return ">End Of Input<";
+	case TokenType::Identifier:
+		return "<identifier>";
+	case TokenType::String:
+		return "<string>";
+	case TokenType::Number:
+		return "<number>";
+	case TokenType::TableInitializer:
+		return "<table initializer>";
+	}
+
+	UNREACHABLE("Unknown token type %d", static_cast<int>(t));
+	return "UNKNOWN";
+}
+
+struct Token {
+	TokenType type;
+	SCP_string content;
+	size_t offset;
+};
+
+class token_error : public std::exception {
+	static SCP_string formatTokenMessage(const Token& t)
+	{
+		SCP_string str = to_string(t.type);
+		if (!t.content.empty()) {
+			str += " (\"";
+			str += t.content;
+			str += "\")";
+		}
+		return str;
+	}
+
+  public:
+	token_error(SCP_string errMsg, Token token) : _errMsg(std::move(errMsg)), _token(std::move(token))
+	{
+		_errMsg += ": Found ";
+		_errMsg += formatTokenMessage(_token);
+	}
+	~token_error() override = default;
+
+	const char* what() const noexcept override { return _errMsg.c_str(); }
+
+	const Token& getToken() const { return _token; }
+
+  private:
+	SCP_string _errMsg;
+	Token _token;
+};
+
+// What follows is a recursive decent parser for a LL(1) language that should parse most argument lists we have that
+// don't involve too complicated constructs. This should be handled by an actual parser generator but I don't want to
+// pull is bison/flex for such a simple language...
+using lookahead_array = std::array<Token, 1>;
+
+namespace detail {
+bool checkType(TokenType) { return false; }
+template <typename T, typename... Rest>
+bool checkType(TokenType t, T testVal, Rest... rest)
+{
+	return t == testVal || checkType(t, rest...);
+}
+
+template <typename T>
+void appendExpectString(SCP_stringstream& stream, bool toplevel, T enumVal)
+{
+	if (!toplevel) {
+		stream << "or ";
+	}
+	stream << to_string(enumVal);
+}
+template <typename T, typename... Rest>
+void appendExpectString(SCP_stringstream& stream, bool, T enumVal, Rest... rest)
+{
+	stream << to_string(enumVal) << ", ";
+	appendExpectString(stream, false, rest...);
+}
+} // namespace detail
+
+template <TokenType... ValidTypes>
+bool isTypeValid(TokenType t)
+{
+	return detail::checkType(t, ValidTypes...);
+}
+
+template <TokenType... ValidTypes>
+SCP_string constructExpectString()
+{
+	SCP_stringstream stream;
+	detail::appendExpectString(stream, true, ValidTypes...);
+	return stream.str();
+}
+
+struct lexer_state {
+	SCP_string parse_text;
+
+	Token parseToken()
+	{
+		fillLookahead();
+		Assertion(lookeahead_size > 0, "Lookahead was not filled after fillLookahead!");
+		Token parsed = std::move(lookahead[0]);
+		--lookeahead_size;
+		return parsed;
+	}
+
+	template <TokenType... ValidTypes>
+	Token parseAndValidateToken()
+	{
+		auto parsed = parseToken();
+
+		if (!isTypeValid<ValidTypes...>(parsed.type)) {
+			throw token_error("Unexpected token. Expected " + constructExpectString<ValidTypes...>(), parsed);
+		}
+
+		return parsed;
+	}
+
+	const Token& peekToken()
+	{
+		fillLookahead();
+
+		Assertion(lookeahead_size > 0, "Lookahead was not filled after fillLookahead!");
+		return lookahead[0];
+	}
+
+  private:
+	size_t offset = 0;
+
+	lookahead_array lookahead;
+	size_t lookeahead_size = 0;
+
+	void fillLookahead()
+	{
+		while (lookeahead_size < lookahead.size()) {
+			lookahead[lookeahead_size] = parseAndAdvance();
+			++lookeahead_size;
+		}
+	}
+
+	Token parseAndAdvance()
+	{
+		// Skip whitespace
+		while (offset < parse_text.size() && parse_text[offset] == ' ') {
+			++offset;
+		}
+		if (offset >= parse_text.size()) {
+			return {TokenType::EndOfFile, SCP_string(), offset};
+		}
+
+		const auto tokenOff = offset;
+
+		switch (parse_text[offset]) {
+		case '[':
+			++offset;
+			return {TokenType::LeftBracket, SCP_string(), tokenOff};
+		case ']':
+			++offset;
+			return {TokenType::RightBracket, SCP_string(), tokenOff};
+		case ',':
+			++offset;
+			return {TokenType::Comma, SCP_string(), tokenOff};
+		case '=':
+			++offset;
+			return {TokenType::Equals, SCP_string(), tokenOff};
+		case '|':
+		case '/':
+			++offset;
+			return {TokenType::TypeAlternative, SCP_string(), tokenOff};
+		}
+
+		// Check if this a regex based token
+		for (const auto& regexTok : getRegexTokens()) {
+			std::smatch match;
+			if (!std::regex_search(parse_text.cbegin() + offset, parse_text.cend(), match, regexTok.regex)) {
+				continue;
+			}
+
+			offset += match.length(0);
+			return {regexTok.type, match.str(0), tokenOff};
+		}
+
+		throw std::runtime_error("Unrecognized input: " + parse_text.substr(offset));
+	}
+};
+
+struct parser_state {
+	lexer_state lexer;
+
+	SCP_vector<argument_def> arguments;
+
+	void main_arg_list()
+	{
+		const auto& next = lexer.peekToken();
+		if (next.type == TokenType::EndOfFile) {
+			// Empty parameter list is valid
+			return;
+		}
+
+		arg_list();
+	}
+
+	SCP_string value()
+	{
+		auto t = lexer.parseAndValidateToken<TokenType::Identifier,
+			TokenType::Number,
+			TokenType::String,
+			TokenType::TableInitializer>();
+		return t.content;
+	}
+
+	ade_type_info simple_type()
+	{
+		Token t = lexer.parseAndValidateToken<TokenType::Identifier>();
+		return ade_type_info(t.content.c_str());
+	}
+
+	ade_type_info type()
+	{
+		auto firstType = simple_type();
+
+		auto& next = lexer.peekToken();
+		if (next.type != TokenType::TypeAlternative) {
+			// Not something for us
+			return firstType;
+		}
+		lexer.parseToken(); // Remove peeked token from stream
+
+		auto rest = type();
+
+		SCP_vector<ade_type_info> typeList;
+		typeList.reserve(rest.elements().size() + 1);
+
+		typeList.push_back(firstType);
+		if (rest.getType() == ade_type_info_type::Alternative) {
+			typeList.insert(typeList.end(), rest.elements().begin(), rest.elements().end());
+		} else {
+			typeList.push_back(rest);
+		}
+
+		return ade_type_alternative(typeList);
+	}
+
+	void arg_list()
+	{
+		argument_def def;
+
+		// An argument has the form ("[")? identifier (identifier ("=" value)? )? ("," arg_list)? ("]")?
+		{
+			const Token& next = lexer.peekToken();
+			if (next.type == TokenType::LeftBracket) {
+				lexer.parseToken();
+
+				def.optional = true;
+			}
+		}
+
+		// The first identifier is always the type name
+		def.type = type();
+
+		// We can either have an identifier (arg name) or a comma (another argument)
+		auto t = lexer.parseToken();
+		if (t.type == TokenType::EndOfFile) {
+			// This is fine, rest is optional
+			arguments.insert(arguments.cbegin(), std::move(def));
+			return;
+		}
+
+		if (t.type == TokenType::Comma) {
+			// Since there was a comma another argument must follow
+			arg_list();
+
+			// Since we parse the rest of the argument already we need to insert this at the front
+			arguments.insert(arguments.cbegin(), std::move(def));
+			return;
+		}
+
+		if (t.type != TokenType::Identifier) {
+			// This is a valid point to terminate the parameter
+			arguments.insert(arguments.cbegin(), std::move(def));
+			return;
+		}
+
+		// token is an identifier which must be our argument name
+		def.name = t.content;
+
+		if (!def.optional) {
+			// Make sure we do not consume the right bracket of our parent
+			const auto& next = lexer.peekToken();
+
+			if (next.type == TokenType::RightBracket) {
+				// Ok, let our parent handle the right bracket
+				arguments.insert(arguments.cbegin(), std::move(def));
+				return;
+			}
+		}
+
+		// We either expect a comma (next argument) or an equals (default value specifier)
+		if (def.optional) {
+			// If we saw the opening optional group then the right bracket is also valid here
+			t = lexer.parseAndValidateToken<TokenType::EndOfFile,
+				TokenType::Comma,
+				TokenType::Equals,
+				TokenType::RightBracket>();
+		} else {
+			t = lexer.parseAndValidateToken<TokenType::EndOfFile, TokenType::Comma, TokenType::Equals>();
+		}
+		if (t.type == TokenType::EndOfFile) {
+			// This is fine, rest is optional
+			arguments.insert(arguments.cbegin(), std::move(def));
+			return;
+		}
+
+		if (t.type == TokenType::Comma) {
+			// Since there was a comma another argument must follow
+			arg_list();
+
+			// Since we parse the rest of the argument already we need to insert this at the front
+			arguments.insert(arguments.cbegin(), std::move(def));
+			return;
+		}
+
+		if (def.optional && t.type == TokenType::RightBracket) {
+			// We are done and nothing else is expected now
+			arguments.insert(arguments.cbegin(), std::move(def));
+			return;
+		}
+
+		// This must now be the default value
+		def.def_val = value();
+
+		bool sawClosingBracket = false;
+		const auto& next       = lexer.peekToken();
+		if (def.optional && next.type == TokenType::RightBracket) {
+			// Properly terminated an optional parameter
+			lexer.parseToken(); // Remove from stream
+			sawClosingBracket = true;
+		} else if (next.type == TokenType::Comma) {
+			// There is another parameter
+			lexer.parseToken(); // Remove from stream
+
+			arg_list();
+		}
+
+		// Final check, if we didn't see the closing bracket yet it must be here
+		if (!sawClosingBracket && def.optional) {
+			lexer.parseAndValidateToken<TokenType::RightBracket>();
+		}
+
+		// Since we parse the rest of the argument already we need to insert this at the front
+		arguments.insert(arguments.cbegin(), std::move(def));
+	}
+
+	void toplevel_arg_list()
+	{
+		const Token& next = lexer.peekToken();
+		if (next.type == TokenType::EndOfFile) {
+			// Valid to have an empty list
+			return;
+		}
+
+		arg_list();
+	}
+};
+
+} // namespace
+
+bool argument_list_parser::parse(const SCP_string& argumentList)
+{
+	lexer_state lexer;
+	lexer.parse_text = argumentList;
+
+	parser_state parser;
+	parser.lexer = std::move(lexer);
+
+	try {
+		// Kick off the parsing by expecting an argument list
+		parser.toplevel_arg_list();
+
+		const auto& next = lexer.peekToken();
+		if (next.type != TokenType::EndOfFile) {
+			throw token_error("Input remained after parsing.", next);
+		}
+
+		_argList = parser.arguments;
+		return true;
+	} catch (const token_error& token_error) {
+		fprintf(stderr,
+			"Error while parsing\n%s\n%s^\n%s\n\n",
+			parser.lexer.parse_text.c_str(),
+			std::string(token_error.getToken().offset, ' ').c_str(),
+			token_error.what());
+
+		return false;
+	} catch (const std::exception& e) {
+		fprintf(stderr, "Error while parsing\n%s\n%s\n\n", parser.lexer.parse_text.c_str(), e.what());
+
+		return false;
+	}
+}
+const SCP_vector<scripting::argument_def>& argument_list_parser::getArgList() const { return _argList; }
+
+} // namespace scripting

--- a/code/scripting/ade_doc.h
+++ b/code/scripting/ade_doc.h
@@ -1,0 +1,114 @@
+#pragma once
+
+#include "globalincs/pstypes.h"
+
+namespace scripting {
+
+enum class ade_type_info_type {
+	Empty,
+	Simple,
+	Tuple,
+	Array,
+	Map,
+	Iterator,
+	Alternative,
+};
+
+class ade_type_array;
+class ade_type_map;
+class ade_type_iterator;
+class ade_type_alternative;
+
+/**
+ * @brief A definition of a type used in the ADE system
+ */
+class ade_type_info {
+	ade_type_info_type _type = ade_type_info_type::Empty;
+
+	SCP_string _simple_name;
+
+	SCP_vector<ade_type_info> _elements;
+
+  public:
+	ade_type_info() = default;
+	/*implicit*/ ade_type_info(const char* single_type); // NOLINT(hicpp-explicit-conversions)
+	/*implicit*/ ade_type_info(std::initializer_list<ade_type_info> tuple_types);
+	/*implicit*/ ade_type_info(const ade_type_array& listType);
+	/*implicit*/ ade_type_info(const ade_type_map& listType);
+	/*implicit*/ ade_type_info(const ade_type_iterator& iteratorType);
+	/*implicit*/ ade_type_info(const ade_type_alternative& iteratorType);
+
+	ade_type_info_type getType() const;
+
+	bool isEmpty() const;
+
+	bool isSimple() const;
+
+	bool isTuple() const;
+
+	bool isArray() const;
+
+	const char* getSimpleName() const;
+
+	const ade_type_info& arrayType() const;
+
+	const SCP_vector<ade_type_info>& elements() const;
+};
+
+class ade_type_array {
+	ade_type_info _element_type;
+
+  public:
+	explicit ade_type_array(ade_type_info elementType);
+
+	const ade_type_info& getElementType() const;
+};
+
+class ade_type_map {
+	ade_type_info _key_type;
+	ade_type_info _value_type;
+
+  public:
+	explicit ade_type_map(ade_type_info keyType, ade_type_info valueType);
+
+	const ade_type_info& getKeyType() const;
+
+	const ade_type_info& getValueType() const;
+};
+
+class ade_type_iterator {
+	ade_type_info _element_type;
+
+  public:
+	explicit ade_type_iterator(ade_type_info elementType);
+
+	const ade_type_info& getElementType() const;
+};
+
+class ade_type_alternative {
+	SCP_vector<ade_type_info> _elements;
+
+  public:
+	explicit ade_type_alternative(SCP_vector<ade_type_info> elements);
+
+	const SCP_vector<ade_type_info>& getElementTypes() const;
+};
+
+struct argument_def {
+	ade_type_info type;
+	SCP_string name;
+	SCP_string def_val;
+	bool optional = false;
+};
+
+class argument_list_parser {
+  public:
+	bool parse(const SCP_string& argumentList);
+
+	const SCP_vector<scripting::argument_def>& getArgList() const;
+
+  private:
+	SCP_vector<argument_def> _argList;
+};
+
+} // namespace scripting

--- a/code/scripting/api/libs/base.cpp
+++ b/code/scripting/api/libs/base.cpp
@@ -80,7 +80,7 @@ ADE_FUNC(getFrametimeOverall, l_Base, NULL, "The overall frame time in seconds s
 	return ade_set_args(L, "x", game_get_overall_frametime());
 }
 
-ADE_FUNC(getFrametime, l_Base, "[Do not adjust for time compression (Boolean)]", "Gets how long this frame is calculated to take. Use it to for animations, physics, etc to make incremental changes.", "number", "Frame time (seconds)")
+ADE_FUNC(getFrametime, l_Base, "[boolean adjustForTimeCompression]", "Gets how long this frame is calculated to take. Use it to for animations, physics, etc to make incremental changes.", "number", "Frame time (seconds)")
 {
 	bool b=false;
 	ade_get_args(L, "|b", &b);
@@ -88,7 +88,7 @@ ADE_FUNC(getFrametime, l_Base, "[Do not adjust for time compression (Boolean)]",
 	return ade_set_args(L, "f", b ? flRealframetime : flFrametime);
 }
 
-ADE_FUNC(getCurrentGameState, l_Base, "[Depth (number)]", "Gets current FreeSpace state; if a depth is specified, the state at that depth is returned. (IE at the in-game options game, a depth of 1 would give you the game state, while the function defaults to 0, which would be the options screen.", "gamestate", "Current game state at specified depth, or invalid handle if no game state is active yet")
+ADE_FUNC(getCurrentGameState, l_Base, "[number depth]", "Gets current FreeSpace state; if a depth is specified, the state at that depth is returned. (IE at the in-game options game, a depth of 1 would give you the game state, while the function defaults to 0, which would be the options screen.", "gamestate", "Current game state at specified depth, or invalid handle if no game state is active yet")
 {
 	int depth = 0;
 	ade_get_args(L, "|i", &depth);
@@ -228,7 +228,7 @@ ADE_FUNC(getControlInfo, l_Base, nullptr, "Gets the control info handle.", "cont
 	return ade_set_args(L, "o", l_Control_Info.Set(1));
 }
 
-ADE_FUNC(setTips, l_Base, "True or false", "Sets whether to display tips of the day the next time the current pilot enters the mainhall.", NULL, NULL)
+ADE_FUNC(setTips, l_Base, "boolean", "Sets whether to display tips of the day the next time the current pilot enters the mainhall.", nullptr, nullptr)
 {
 	if (Player == NULL)
 		return ADE_RETURN_NIL;
@@ -299,7 +299,7 @@ ADE_FUNC(inMissionEditor, l_Base, nullptr, "Determine if the current script is r
 
 ADE_FUNC(isEngineVersionAtLeast,
 		 l_Base,
-		 "number major, number minor, number build[, number revision = 0]",
+		 "number major, number minor, number build, [number revision = 0]",
 		 "Checks if the current version of the engine is at least the specified version. This can be used to check if a feature introduced in a later version of the engine is available.",
 		 "boolean",
 		 "true if the version is at least the specified version. false otherwise.") {
@@ -380,7 +380,7 @@ ADE_VIRTVAR(MultiplayerMode, l_Base, "boolean", "Determines if the game is curre
 //**********SUBLIBRARY: Base/Events
 ADE_LIB_DERIV(l_Base_Events, "GameEvents", NULL, "Freespace 2 game events", l_Base);
 
-ADE_INDEXER(l_Base_Events, "number Index/string Name", "Array of game events", "gameevent", "Game event, or invalid gameevent handle if index is invalid")
+ADE_INDEXER(l_Base_Events, "number/string IndexOrName", "Array of game events", "gameevent", "Game event, or invalid gameevent handle if index is invalid")
 {
 	const char* name;
 	if(!ade_get_args(L, "*s", &name))
@@ -410,7 +410,7 @@ ADE_FUNC(__len, l_Base_Events, NULL, "Number of events", "number", "Number of ev
 //**********SUBLIBRARY: Base/States
 ADE_LIB_DERIV(l_Base_States, "GameStates", NULL, "Freespace 2 states", l_Base);
 
-ADE_INDEXER(l_Base_States, "number Index/string Name", "Array of game states", "gamestate", "Game state, or invalid gamestate handle if index is invalid")
+ADE_INDEXER(l_Base_States, "number/string IndexOrName", "Array of game states", "gamestate", "Game state, or invalid gamestate handle if index is invalid")
 {
 	const char* name;
 	if(!ade_get_args(L, "*s", &name))

--- a/code/scripting/api/libs/bitops.cpp
+++ b/code/scripting/api/libs/bitops.cpp
@@ -42,7 +42,7 @@ ADE_FUNC(XOR, l_BitOps, "number, number", "Values for which bitwise boolean XOR 
 	return ade_set_args(L, "i", c);
 }
 
-ADE_FUNC(toggleBit, l_BitOps, "number, number (bit)", "Toggles the value of the set bit in the given number for 32 bit integer", "number", "Result of the operation")
+ADE_FUNC(toggleBit, l_BitOps, "number baseNumber, number bit", "Toggles the value of the set bit in the given number for 32 bit integer", "number", "Result of the operation")
 {
 	int a, b, c;
 	if(!ade_get_args(L, "ii", &a,&b))
@@ -56,7 +56,7 @@ ADE_FUNC(toggleBit, l_BitOps, "number, number (bit)", "Toggles the value of the 
 	return ade_set_args(L, "i", c);
 }
 
-ADE_FUNC(checkBit, l_BitOps, "number, number (bit)", "Checks the value of the set bit in the given number for 32 bit integer", "boolean", "Was the bit true of false")
+ADE_FUNC(checkBit, l_BitOps, "number baseNumber, number bit", "Checks the value of the set bit in the given number for 32 bit integer", "boolean", "Was the bit true of false")
 {
 	int a, b;
 	if(!ade_get_args(L, "ii", &a,&b))
@@ -71,7 +71,7 @@ ADE_FUNC(checkBit, l_BitOps, "number, number (bit)", "Checks the value of the se
 		return ADE_RETURN_FALSE;
 }
 
-ADE_FUNC(addBit, l_BitOps, "number, number (bit)", "Performs inclusive or (OR) operation on the set bit of the value", "number", "Result of the operation")
+ADE_FUNC(addBit, l_BitOps, "number baseNumber, number bit", "Performs inclusive or (OR) operation on the set bit of the value", "number", "Result of the operation")
 {
 	int a, b, c;
 	if(!ade_get_args(L, "ii", &a,&b))

--- a/code/scripting/api/libs/graphics.cpp
+++ b/code/scripting/api/libs/graphics.cpp
@@ -59,7 +59,7 @@ static int lua_Opacity_type = GR_ALPHABLEND_FILTER;
 //****SUBLIBRARY: Graphics/Cameras
 ADE_LIB_DERIV(l_Graphics_Cameras, "Cameras", NULL, "Cameras", l_Graphics);
 
-ADE_INDEXER(l_Graphics_Cameras, "number Index/string Name", "Gets camera", "camera", "Ship handle, or invalid ship handle if index was invalid")
+ADE_INDEXER(l_Graphics_Cameras, "number/string IndexOrName", "Gets camera", "camera", "Ship handle, or invalid ship handle if index was invalid")
 {
 	const char* s = nullptr;
 	if(!ade_get_args(L, "*s", &s))
@@ -93,7 +93,7 @@ ADE_FUNC(__len, l_Graphics_Fonts, NULL, "Number of loaded fonts", "number", "Num
 	return ade_set_args(L, "i", font::FontManager::numberOfFonts());
 }
 
-ADE_INDEXER(l_Graphics_Fonts, "number Index/string Filename", "Array of loaded fonts", "font", "Font handle, or invalid font handle if index is invalid")
+ADE_INDEXER(l_Graphics_Fonts, "number/string IndexOrFilename", "Array of loaded fonts", "font", "Font handle, or invalid font handle if index is invalid")
 {
 	if (lua_isnumber(L, 2))
 	{
@@ -451,7 +451,7 @@ ADE_FUNC(setTarget, l_Graphics, "[texture Texture]",
 	}
 }
 
-ADE_FUNC(setCamera, l_Graphics, "[camera handle Camera]", "Sets current camera, or resets camera if none specified", "boolean", "true if successful, false or nil otherwise")
+ADE_FUNC(setCamera, l_Graphics, "[camera Camera]", "Sets current camera, or resets camera if none specified", "boolean", "true if successful, false or nil otherwise")
 {
 	camid cid;
 	if(!ade_get_args(L, "|o", l_Camera.Get(&cid)))
@@ -1285,12 +1285,15 @@ ADE_FUNC(loadTexture, l_Graphics, "string Filename, [boolean LoadIfAnimation, bo
 	return ade_set_args(L, "o", l_Texture.Set(texture_h(idx)));
 }
 
-ADE_FUNC(drawImage, l_Graphics, "string Filename/texture Texture, [number X1=0, Y1=0, number X2, number Y2, number UVX1 = 0.0, number UVY1 = 0.0, number UVX2=1.0, number UVY2=1.0, number alpha=1.0]",
-		 "Draws an image or texture. Any image extension passed will be ignored."
-			 "The UV variables specify the UV value for each corner of the image. "
-			 "In UV coordinates, (0,0) is the top left of the image; (1,1) is the lower right.",
-		 "boolean",
-		 "Whether image was drawn")
+ADE_FUNC(drawImage,
+	l_Graphics,
+	"string|texture fileNameOrTexture, [number X1=0, number Y1=0, number X2, number Y2, number UVX1 = 0.0, number UVY1 "
+	"= 0.0, number UVX2=1.0, number UVY2=1.0, number alpha=1.0]",
+	"Draws an image file or texture. Any image extension passed will be ignored."
+	"The UV variables specify the UV value for each corner of the image. "
+	"In UV coordinates, (0,0) is the top left of the image; (1,1) is the lower right.",
+	"boolean",
+	"Whether image was drawn")
 {
 	if(!Gr_inited)
 		return ade_set_error(L, "b", false);
@@ -1351,7 +1354,12 @@ ADE_FUNC(drawImage, l_Graphics, "string Filename/texture Texture, [number X1=0, 
 	return ADE_RETURN_TRUE;
 }
 
-ADE_FUNC(drawMonochromeImage, l_Graphics, "string Filename/texture Texture, number X1, number Y1, [number X2, number Y2, number alpha=1.0]", "Draws a monochrome image using the current color", "boolean", "Whether image was drawn")
+ADE_FUNC(drawMonochromeImage,
+	l_Graphics,
+	"string|texture fileNameOrTexture, number X1, number Y1, [number X2, number Y2, number alpha=1.0]",
+	"Draws a monochrome image from a texture or file using the current color",
+	"boolean",
+	"Whether image was drawn")
 {
 	if(!Gr_inited)
 		return ade_set_error(L, "b", false);
@@ -1622,15 +1630,17 @@ ADE_FUNC(openMovie, l_Graphics, "string name, boolean looping = false",
 	return ade_set_args(L, "o", l_MoviePlayer.Set(movie_player_h(std::move(player))));
 }
 
-ADE_FUNC(createPersistentParticle, l_Graphics,
-         "vector Position, vector Velocity, number Lifetime, number Radius, enumeration Type, [number Tracer "
-         "length=-1, boolean Reverse=false, texture Texture=Nil, object Attached Object=Nil]",
-         "Creates a persistent particle. Persistent variables are handled specially by the engine so that this "
-         "function can return a handle to the caller. Only use this if you absolutely need it. Use createParticle if "
-         "the returned handle is not required. Use PARTICLE_* enumerations for type."
-         "Reverse reverse animation, if one is specified"
-         "Attached object specifies object that Position will be (and always be) relative to.",
-         "particle", "Handle to the created particle")
+ADE_FUNC(createPersistentParticle,
+	l_Graphics,
+	"vector Position, vector Velocity, number Lifetime, number Radius, enumeration Type, [number TracerLength=-1, "
+	"boolean Reverse=false, texture Texture=Nil, object AttachedObject=Nil]",
+	"Creates a persistent particle. Persistent variables are handled specially by the engine so that this "
+	"function can return a handle to the caller. Only use this if you absolutely need it. Use createParticle if "
+	"the returned handle is not required. Use PARTICLE_* enumerations for type."
+	"Reverse reverse animation, if one is specified"
+	"Attached object specifies object that Position will be (and always be) relative to.",
+	"particle",
+	"Handle to the created particle")
 {
 	particle::particle_info pi;
 	pi.type            = particle::PARTICLE_DEBUG;
@@ -1692,13 +1702,15 @@ ADE_FUNC(createPersistentParticle, l_Graphics,
 		return ADE_RETURN_NIL;
 }
 
-ADE_FUNC(createParticle, l_Graphics,
-         "vector Position, vector Velocity, number Lifetime, number Radius, enumeration Type, [number Tracer "
-         "length=-1, boolean Reverse=false, texture Texture=Nil, object Attached Object=Nil]",
-         "Creates a non-persistent particle. Use PARTICLE_* enumerations for type."
-         "Reverse reverse animation, if one is specified"
-         "Attached object specifies object that Position will be (and always be) relative to.",
-         "boolean", "true if particle was created, false otherwise")
+ADE_FUNC(createParticle,
+	l_Graphics,
+	"vector Position, vector Velocity, number Lifetime, number Radius, enumeration Type, [number TracerLength=-1, "
+	"boolean Reverse=false, texture Texture=Nil, object AttachedObject=Nil]",
+	"Creates a non-persistent particle. Use PARTICLE_* enumerations for type."
+	"Reverse reverse animation, if one is specified"
+	"Attached object specifies object that Position will be (and always be) relative to.",
+	"boolean",
+	"true if particle was created, false otherwise")
 {
 	particle::particle_info pi;
 	pi.type            = particle::PARTICLE_DEBUG;

--- a/code/scripting/api/libs/hud.cpp
+++ b/code/scripting/api/libs/hud.cpp
@@ -54,7 +54,7 @@ ADE_VIRTVAR(HUDDisabledExceptMessages, l_HUD, "boolean", "Specifies if only the 
 }
 
 ADE_FUNC(setHUDGaugeColor, l_HUD,
-         "number (index number of the gauge), [number red, number green, number blue, number alpha]",
+         "number gaugeIndex, [number red, number green, number blue, number alpha]",
          "Color used to draw the gauge", "boolean", "If the operation was successful")
 {
 	int idx = -1;
@@ -74,7 +74,7 @@ ADE_FUNC(setHUDGaugeColor, l_HUD,
 	return ADE_RETURN_TRUE;
 }
 
-ADE_FUNC(getHUDGaugeColor, l_HUD, "number (index number of the gauge)", "Color used to draw the gauge",
+ADE_FUNC(getHUDGaugeColor, l_HUD, "number gaugeIndex", "Color used to draw the gauge",
          ade_type_info({"number", "number", "number", "number"}), "Red, green, blue, and alpha of the gauge")
 {
 	int idx = -1;

--- a/code/scripting/api/libs/mission.cpp
+++ b/code/scripting/api/libs/mission.cpp
@@ -215,7 +215,7 @@ ADE_FUNC(__len, l_Mission_EscortShips, NULL, "Current number of escort ships", "
 //****SUBLIBRARY: Mission/Events
 ADE_LIB_DERIV(l_Mission_Events, "Events", NULL, "Events", l_Mission);
 
-ADE_INDEXER(l_Mission_Events, "number Index/string Name", "Indexes events list", "event", "Event handle, or invalid event handle if index was invalid")
+ADE_INDEXER(l_Mission_Events, "number/string IndexOrName", "Indexes events list", "event", "Event handle, or invalid event handle if index was invalid")
 {
 	const char* s;
 	if(!ade_get_args(L, "*s", &s))
@@ -247,7 +247,7 @@ ADE_FUNC(__len, l_Mission_Events, NULL, "Number of events in mission", "number",
 //****SUBLIBRARY: Mission/SEXPVariables
 ADE_LIB_DERIV(l_Mission_SEXPVariables, "SEXPVariables", NULL, "SEXP Variables", l_Mission);
 
-ADE_INDEXER(l_Mission_SEXPVariables, "number Index/string Name", "Array of SEXP variables. Note that you can set a sexp variable using the array, eg \'SEXPVariables[\"newvariable\"] = \"newvalue\"\'", "sexpvariable", "Handle to SEXP variable, or invalid sexpvariable handle if index was invalid")
+ADE_INDEXER(l_Mission_SEXPVariables, "number/string IndexOrName", "Array of SEXP variables. Note that you can set a sexp variable using the array, eg \'SEXPVariables[\"newvariable\"] = \"newvalue\"\'", "sexpvariable", "Handle to SEXP variable, or invalid sexpvariable handle if index was invalid")
 {
 	const char* name   = nullptr;
 	const char* newval = nullptr;
@@ -295,7 +295,7 @@ ADE_FUNC(__len, l_Mission_SEXPVariables, NULL, "Current number of SEXP variables
 //****SUBLIBRARY: Mission/Ships
 ADE_LIB_DERIV(l_Mission_Ships, "Ships", NULL, "Ships in the mission", l_Mission);
 
-ADE_INDEXER(l_Mission_Ships, "number Index/string Name", "Gets ship", "ship", "Ship handle, or invalid ship handle if index was invalid")
+ADE_INDEXER(l_Mission_Ships, "number/string IndexOrName", "Gets ship", "ship", "Ship handle, or invalid ship handle if index was invalid")
 {
 	const char* name;
 	if(!ade_get_args(L, "*s", &name))
@@ -387,7 +387,7 @@ ADE_FUNC(__len, l_Mission_Waypoints, NULL, "Gets number of waypoints in mission.
 //****SUBLIBRARY: Mission/WaypointLists
 ADE_LIB_DERIV(l_Mission_WaypointLists, "WaypointLists", NULL, NULL, l_Mission);
 
-ADE_INDEXER(l_Mission_WaypointLists, "number Index/string WaypointListName", "Array of waypoint lists", "waypointlist", "Gets waypointlist handle")
+ADE_INDEXER(l_Mission_WaypointLists, "number/string IndexOrWaypointListName", "Array of waypoint lists", "waypointlist", "Gets waypointlist handle")
 {
 	waypointlist_h wpl;
 	const char* name;
@@ -482,7 +482,7 @@ ADE_FUNC(__len, l_Mission_Beams, NULL, "Number of beam objects in mission. Note 
 //****SUBLIBRARY: Mission/Wings
 ADE_LIB_DERIV(l_Mission_Wings, "Wings", NULL, NULL, l_Mission);
 
-ADE_INDEXER(l_Mission_Wings, "number Index/string WingName", "Wings in the mission", "wing", "Wing handle, or invalid wing handle if index or name was invalid")
+ADE_INDEXER(l_Mission_Wings, "number/string IndexOrWingName", "Wings in the mission", "wing", "Wing handle, or invalid wing handle if index or name was invalid")
 {
 	const char* name;
 	if(!ade_get_args(L, "*s", &name))
@@ -511,7 +511,7 @@ ADE_FUNC(__len, l_Mission_Wings, NULL, "Number of wings in mission", "number", "
 //****SUBLIBRARY: Mission/Teams
 ADE_LIB_DERIV(l_Mission_Teams, "Teams", NULL, NULL, l_Mission);
 
-ADE_INDEXER(l_Mission_Teams, "number Index/string TeamName", "Teams in the mission", "team", "Team handle or invalid team handle if the requested team could not be found")
+ADE_INDEXER(l_Mission_Teams, "number/string IndexOrTeamName", "Teams in the mission", "team", "Team handle or invalid team handle if the requested team could not be found")
 {
 	const char* name;
 	if(!ade_get_args(L, "*s", &name))
@@ -540,7 +540,7 @@ ADE_FUNC(__len, l_Mission_Teams, NULL, "Number of teams in mission", "number", "
 //****SUBLIBRARY: Mission/Messages
 ADE_LIB_DERIV(l_Mission_Messages, "Messages", NULL, NULL, l_Mission);
 
-ADE_INDEXER(l_Mission_Messages, "number Index/string messageName", "Messages of the mission", "message", "Message handle or invalid handle on error")
+ADE_INDEXER(l_Mission_Messages, "number/string IndexOrMessageName", "Messages of the mission", "message", "Message handle or invalid handle on error")
 {
 	int idx = -1;
 
@@ -587,7 +587,7 @@ ADE_FUNC(__len, l_Mission_Messages, NULL, "Number of messages in the mission", "
 //****SUBLIBRARY: Mission/BuiltinMessages
 ADE_LIB_DERIV(l_Mission_BuiltinMessages, "BuiltinMessages", NULL, NULL, l_Mission);
 
-ADE_INDEXER(l_Mission_BuiltinMessages, "number Index/string messageName", "Built-in messages of the mission", "message", "Message handle or invalid handle on error")
+ADE_INDEXER(l_Mission_BuiltinMessages, "number/string IndexOrMessageName", "Built-in messages of the mission", "message", "Message handle or invalid handle on error")
 {
 	int idx = -1;
 
@@ -632,7 +632,7 @@ ADE_FUNC(__len, l_Mission_BuiltinMessages, NULL, "Number of built-in messages in
 //****SUBLIBRARY: Mission/Personas
 ADE_LIB_DERIV(l_Mission_Personas, "Personas", NULL, NULL, l_Mission);
 
-ADE_INDEXER(l_Mission_Personas, "number Index/string name", "Personas of the mission", "persona", "Persona handle or invalid handle on error")
+ADE_INDEXER(l_Mission_Personas, "number/string IndexOrName", "Personas of the mission", "persona", "Persona handle or invalid handle on error")
 {
 	int idx = -1;
 
@@ -667,7 +667,7 @@ ADE_FUNC(__len, l_Mission_Personas, NULL, "Number of personas in the mission", "
 	return ade_set_args(L, "i", Num_personas);
 }
 
-ADE_FUNC(addMessage, l_Mission, "string name, string text[, persona persona]", "Adds a message", "message", "The new message or invalid handle on error")
+ADE_FUNC(addMessage, l_Mission, "string name, string text, [persona persona]", "Adds a message", "message", "The new message or invalid handle on error")
 {
 	const char* name = nullptr;
 	const char* text = nullptr;
@@ -687,11 +687,16 @@ ADE_FUNC(addMessage, l_Mission, "string name, string text[, persona persona]", "
 	return ade_set_error(L, "o", l_Message.Set((int) Messages.size() - 1));
 }
 
-ADE_FUNC(sendMessage, l_Mission, "string sender, message message[, number delay=0.0[, enumeration priority = MESSAGE_PRIORITY_NORMAL[, boolean fromCommand = false]]]",
-		 "Sends a message from the given source (not from a ship!) with the given priority or optionally sends it from the missions command source.<br>"
-			 "If delay is specified the message will be delayed by the specified time in seconds<br>"
-			 "If you pass <i>nil</i> as the sender then the message will not have a sender.",
-		 "boolean", "true if successfull, false otherwise")
+ADE_FUNC(sendMessage,
+	l_Mission,
+	"string sender, message message, [number delay=0.0, enumeration priority = MESSAGE_PRIORITY_NORMAL, boolean "
+	"fromCommand = false]",
+	"Sends a message from the given source (not from a ship!) with the given priority or optionally sends it from the "
+	"missions command source.<br>"
+	"If delay is specified the message will be delayed by the specified time in seconds<br>"
+	"If you pass <i>nil</i> as the sender then the message will not have a sender.",
+	"boolean",
+	"true if successfull, false otherwise")
 {
 	const char* sender = nullptr;
 	int messageIdx = -1;
@@ -764,7 +769,7 @@ ADE_FUNC(sendMessage, l_Mission, "string sender, message message[, number delay=
 	return ADE_RETURN_TRUE;
 }
 
-ADE_FUNC(sendTrainingMessage, l_Mission, "message message, number time[, number delay=0.0]",
+ADE_FUNC(sendTrainingMessage, l_Mission, "message message, number time, [number delay=0.0]",
 		 "Sends a training message to the player. <i>time</i> is the amount in seconds to display the message, only whole seconds are used!",
 		 "boolean", "true if successfull, false otherwise")
 {
@@ -861,11 +866,14 @@ ADE_FUNC(createWaypoint, l_Mission, "[vector Position, waypointlist List]",
 		return ade_set_args(L, "o", l_Waypoint.Set(object_h()));
 }
 
-ADE_FUNC(createWeapon, l_Mission, "[weaponclass Class=WeaponClass[1], orientation Orientation=null, world vector Position={0,0,0}, object Parent = nil, number Group = -1",
-		 "Creates a weapon and returns a handle to it. 'Group' is used for lighting grouping purposes;"
-			 " for example, quad lasers would only need to act as one light source.",
-		 "weapon",
-		 "Weapon handle, or invalid weapon handle if weapon couldn't be created.")
+ADE_FUNC(createWeapon,
+	l_Mission,
+	"[weaponclass Class=FirstTableWeapon, orientation Orientation=identity, vector WorldPosition={0,0,0}, object Parent = "
+	"nil, number Group = -1]",
+	"Creates a weapon and returns a handle to it. 'Group' is used for lighting grouping purposes;"
+	" for example, quad lasers would only need to act as one light source.",
+	"weapon",
+	"Weapon handle, or invalid weapon handle if weapon couldn't be created.")
 {
 	int wclass = -1;
 	object_h *parent = NULL;

--- a/code/scripting/api/libs/mission.cpp
+++ b/code/scripting/api/libs/mission.cpp
@@ -1258,8 +1258,12 @@ static int arrivalListIter(lua_State* L)
 	return ade_set_args(L, "o", l_ParseObject.Set(parse_object_h(next)));
 }
 
-ADE_FUNC(getArrivalList, l_Mission, nullptr, "Get the list of yet to arrive ships for this mission", "iterator[parse_object]",
-            "An iterator across all the yet to arrive ships. Can be used in a for .. in loop")
+ADE_FUNC(getArrivalList,
+	l_Mission,
+	nullptr,
+	"Get the list of yet to arrive ships for this mission",
+	ade_type_iterator("parse_object"),
+	"An iterator across all the yet to arrive ships. Can be used in a for .. in loop")
 {
 	return ade_set_args(L, "u*o", luacpp::LuaFunction::createFromCFunction(L, arrivalListIter),
 	                    l_ParseObject.Set(parse_object_h(&Ship_arrival_list)));

--- a/code/scripting/api/libs/tables.cpp
+++ b/code/scripting/api/libs/tables.cpp
@@ -23,7 +23,7 @@ ADE_LIB(l_Tables, "Tables", "tb", "Tables library");
 
 //*****SUBLIBRARY: Tables/ShipClasses
 ADE_LIB_DERIV(l_Tables_ShipClasses, "ShipClasses", NULL, NULL, l_Tables);
-ADE_INDEXER(l_Tables_ShipClasses, "number Index/string Name", "Array of ship classes", "shipclass", "Ship handle, or invalid ship handle if index is invalid")
+ADE_INDEXER(l_Tables_ShipClasses, "number/string IndexOrName", "Array of ship classes", "shipclass", "Ship handle, or invalid ship handle if index is invalid")
 {
 	if(!ships_inited)
 		return ade_set_error(L, "o", l_Shipclass.Set(-1));
@@ -62,7 +62,7 @@ ADE_FUNC(__len, l_Tables_ShipClasses, NULL, "Number of ship classes", "number", 
 //*****SUBLIBRARY: Tables/WeaponClasses
 ADE_LIB_DERIV(l_Tables_WeaponClasses, "WeaponClasses", NULL, NULL, l_Tables);
 
-ADE_INDEXER(l_Tables_WeaponClasses, "number Index/string WeaponName", "Array of weapon classes", "weapon", "Weapon class handle, or invalid weaponclass handle if index is invalid")
+ADE_INDEXER(l_Tables_WeaponClasses, "number/string IndexOrWeaponName", "Array of weapon classes", "weapon", "Weapon class handle, or invalid weaponclass handle if index is invalid")
 {
 	if(!Weapons_inited)
 		return ade_set_error(L, "o", l_Weaponclass.Set(-1));

--- a/code/scripting/api/libs/testing.cpp
+++ b/code/scripting/api/libs/testing.cpp
@@ -55,14 +55,17 @@ ADE_FUNC(avdTest, l_Testing, NULL, "Test the AVD Physics code", NULL, NULL)
 	return ADE_RETURN_NIL;
 }
 
-ADE_FUNC_DEPRECATED(createParticle, l_Testing,
-                    "vector Position, vector Velocity, number Lifetime, number Radius, enumeration Type, [number "
-                    "Tracer length=-1, boolean Reverse=false, texture Texture=Nil, object Attached Object=Nil]",
-                    "Creates a particle. Use PARTICLE_* enumerations for type."
-                    "Reverse reverse animation, if one is specified"
-                    "Attached object specifies object that Position will be (and always be) relative to.",
-                    "particle", "Handle to the created particle", gameversion::version(19, 0, 0, 0),
-                    "Not available in the testing library anymore. Use gr.createPersistentParticle instead.")
+ADE_FUNC_DEPRECATED(createParticle,
+	l_Testing,
+	"vector Position, vector Velocity, number Lifetime, number Radius, enumeration Type, [number "
+	"TracerLength=-1, boolean Reverse=false, texture Texture=Nil, object AttachedObject=Nil]",
+	"Creates a particle. Use PARTICLE_* enumerations for type."
+	"Reverse reverse animation, if one is specified"
+	"Attached object specifies object that Position will be (and always be) relative to.",
+	"particle",
+	"Handle to the created particle",
+	gameversion::version(19, 0, 0, 0),
+	"Not available in the testing library anymore. Use gr.createPersistentParticle instead.")
 {
 	particle::particle_info pi;
 	pi.type = particle::PARTICLE_DEBUG;

--- a/code/scripting/api/libs/ui.cpp
+++ b/code/scripting/api/libs/ui.cpp
@@ -77,7 +77,7 @@ ADE_FUNC(disableInput, l_UserInterface, "", "Disables UI input", "boolean", "tru
 }
 
 ADE_FUNC(playElementSound, l_UserInterface,
-         "Rocket::Element element, string event, string state = "
+         "Rocket::Element element, string event, string state = \"\""
          "",
          "Plays an element specific sound with an optional state for differentiating different UI states.", "boolean",
          "true if a sound was played, false otherwise")

--- a/code/scripting/api/libs/ui.cpp
+++ b/code/scripting/api/libs/ui.cpp
@@ -190,7 +190,7 @@ ADE_FUNC(deletePilot, l_UserInterface_PilotSelect, "string callsign",
 }
 
 ADE_FUNC(
-    createPilot, l_UserInterface_PilotSelect, "string callsign, boolean is_multi[, string copy_from]",
+    createPilot, l_UserInterface_PilotSelect, "string callsign, boolean is_multi, [string copy_from]",
     "Creates a new pilot in either single or multiplayer mode and optionally copies settings from an existing pilot.",
     "boolean", "true on success, false otherwise")
 {

--- a/code/scripting/api/libs/utf8.cpp
+++ b/code/scripting/api/libs/utf8.cpp
@@ -20,7 +20,7 @@ ADE_LIB(l_Utf8, "Unicode", "utf8", "Functions for handling UTF-8 encoded unicode
 
 ADE_FUNC(sub,
 		 l_Utf8,
-		 "string arg, number start[, number end = -1]",
+		 "string arg, number start, [number end = -1]",
 		 "This function is similar to the standard library string.sub but this can operate on UTF-8 encoded unicode strings. "
 			 "This function will respect the unicode mode setting of the current mod so you can use it even if you don't use Unicode strings.",
 		 "string",

--- a/code/scripting/api/objs/camera.cpp
+++ b/code/scripting/api/objs/camera.cpp
@@ -219,7 +219,7 @@ ADE_VIRTVAR(TargetSubsystem, l_Camera, "subsystem", "New target subsystem", "sub
 	return ade_set_args(L, "o", l_Subsystem.Set(ship_subsys_h(objp, ss)));
 }
 
-ADE_FUNC(setFOV, l_Camera, "[number FOV, number Zoom Time, number Zoom Acceleration Time, number Zoom deceleration Time]",
+ADE_FUNC(setFOV, l_Camera, "[number FOV, number ZoomTime, number ZoomAccelerationTime, number ZoomDecelerationTime]",
 		 "Sets camera FOV"
 			 "<br>FOV is the final field of view, in radians, of the camera."
 			 "<br>Zoom Time is the total time to take zooming in or out."
@@ -243,7 +243,7 @@ ADE_FUNC(setFOV, l_Camera, "[number FOV, number Zoom Time, number Zoom Accelerat
 	return ADE_RETURN_TRUE;
 }
 
-ADE_FUNC(setOrientation, l_Camera, "[world orientation Orientation, number Rotation Time, number Acceleration Time, number Deceleration time]",
+ADE_FUNC(setOrientation, l_Camera, "[orientation WorldOrientation, number RotationTime, number AccelerationTime, number DecelerationTime]",
 		 "Sets camera orientation and velocity data."
 			 "<br>Orientation is the final orientation for the camera, after it has finished moving. If not specified, the camera will simply stop at its current orientation."
 			 "<br>Rotation time (seconds) is how long total, including acceleration, the camera should take to rotate. If it is not specified, the camera will jump to the specified orientation."
@@ -276,7 +276,7 @@ ADE_FUNC(setOrientation, l_Camera, "[world orientation Orientation, number Rotat
 	return ADE_RETURN_TRUE;
 }
 
-ADE_FUNC(setPosition, l_Camera, "[wvector Position, number Translation Time, number Acceleration Time, number Deceleration Time]",
+ADE_FUNC(setPosition, l_Camera, "[vector Position, number TranslationTime, number AccelerationTime, number DecelerationTime]",
 		 "Sets camera position and velocity data."
 			 "<br>Position is the final position for the camera. If not specified, the camera will simply stop at its current position."
 			 "<br>Translation time (seconds) is how long total, including acceleration, the camera should take to move. If it is not specified, the camera will jump to the specified position."

--- a/code/scripting/api/objs/controls.cpp
+++ b/code/scripting/api/objs/controls.cpp
@@ -101,7 +101,7 @@ ADE_FUNC(setCursorImage, l_Mouse, "Image filename", "Sets mouse cursor image, an
 	return ade_set_args(L, "b", true);
 }
 
-ADE_FUNC(setCursorHidden, l_Mouse, "boolean hide[, boolean grab]", "Hides the cursor when <i>hide</i> is true, otherwise shows it. <i>grab</i> determines if "
+ADE_FUNC(setCursorHidden, l_Mouse, "boolean hide, [boolean grab]", "Hides the cursor when <i>hide</i> is true, otherwise shows it. <i>grab</i> determines if "
 	"the mouse will be restricted to the window. Set this to true when hiding the cursor while in game. By default grab will be true when we are in the game play state, false otherwise.", NULL, NULL)
 {
 	if(!mouse_inited)
@@ -116,7 +116,7 @@ ADE_FUNC(setCursorHidden, l_Mouse, "boolean hide[, boolean grab]", "Hides the cu
 	return ADE_RETURN_NIL;
 }
 
-ADE_FUNC(forceMousePosition, l_Mouse, "number, number (coordinates)", "function to force mouse position", "boolean", "if the operation succeeded or not")
+ADE_FUNC(forceMousePosition, l_Mouse, "number x, number y", "function to force mouse position", "boolean", "if the operation succeeded or not")
 {
 	if(!mouse_inited)
 		return ADE_RETURN_FALSE;

--- a/code/scripting/api/objs/file.cpp
+++ b/code/scripting/api/objs/file.cpp
@@ -78,14 +78,17 @@ ADE_FUNC(getPath, l_File, NULL, "Determines path of the given file", "string", "
 		return ade_set_args(L, "s", "");
 }
 
-ADE_FUNC(read, l_File, "number|string, ...",
-         "Reads part of or all of a file, depending on arguments passed. Based on basic Lua file:read function."
-         "Returns nil when the end of the file is reached."
-         "<br><ul><li>\"*n\" - Reads a number.</li>"
-         "<li>\"*a\" - Reads the rest of the file and returns it as a string.</li>"
-         "<li>\"*l\" - Reads a line. Skips the end of line markers.</li>"
-         "<li>(number) - Reads given number of characters, then returns them as a string.</li></ul>",
-         ade_type_info({"number|string", "..."}), "Requested data, or nil if the function fails")
+ADE_FUNC(read,
+	l_File,
+	"number|string, ...",
+	"Reads part of or all of a file, depending on arguments passed. Based on basic Lua file:read function."
+	"Returns nil when the end of the file is reached."
+	"<br><ul><li>\"*n\" - Reads a number.</li>"
+	"<li>\"*a\" - Reads the rest of the file and returns it as a string.</li>"
+	"<li>\"*l\" - Reads a line. Skips the end of line markers.</li>"
+	"<li>(number) - Reads given number of characters, then returns them as a string.</li></ul>",
+	ade_type_info({ade_type_alternative({"number", "string"}), "..."}),
+	"Requested data, or nil if the function fails")
 {
 	cfile_h* cfp = nullptr;
 	if (!ade_get_args(L, "o", l_File.GetPtr(&cfp)))

--- a/code/scripting/api/objs/hudgauge.cpp
+++ b/code/scripting/api/objs/hudgauge.cpp
@@ -167,7 +167,7 @@ ADE_FUNC(drawRectangle, l_HudGaugeDrawFuncs, "number X1, number Y1, number X2, n
 	return ADE_RETURN_TRUE;
 }
 
-ADE_FUNC(drawImage, l_HudGaugeDrawFuncs, "texture handle Texture, [number X=0, Y=0]",
+ADE_FUNC(drawImage, l_HudGaugeDrawFuncs, "texture Texture, [number X=0, number Y=0]",
          "Draws an image in the context of the HUD gauge.", "boolean",
          "true on success, false otherwise")
 {

--- a/code/scripting/api/objs/movie_player.cpp
+++ b/code/scripting/api/objs/movie_player.cpp
@@ -103,7 +103,7 @@ ADE_FUNC(isPlaybackReady, l_MoviePlayer, nullptr,
 	return ade_set_args(L, "b", ret);
 }
 
-ADE_FUNC(drawMovie, l_MoviePlayer, "number x1, number y1[, number x2, number y2]",
+ADE_FUNC(drawMovie, l_MoviePlayer, "number x1, number y1, [number x2, number y2]",
          "Draws the current frame of the movie at the specified coordinates.", nullptr, "Returns nothing")
 {
 	movie_player_h* ph = nullptr;

--- a/code/scripting/api/objs/object.cpp
+++ b/code/scripting/api/objs/object.cpp
@@ -337,7 +337,7 @@ ADE_FUNC(getrvec, l_Object, "[boolean normalize]", "Returns the objects' current
 }
 
 ADE_FUNC(
-    checkRayCollision, l_Object, "vector Start Point, vector End Point[, boolean Local=false]",
+    checkRayCollision, l_Object, "vector StartPoint, vector EndPoint, [boolean Local=false]",
     "Checks the collisions between the polygons of the current object and a ray. Start and end vectors are in world "
     "coordinates",
     ade_type_info({"vector", "collision_info"}),

--- a/code/scripting/api/objs/option.cpp
+++ b/code/scripting/api/objs/option.cpp
@@ -150,13 +150,16 @@ ADE_VIRTVAR(Value, l_Option, "ValueDescription", "The current value of this opti
 	}
 	return ade_set_args(L, "o", l_ValueDescription.Set(opt->get()->getCurrentValueDescription()));
 }
-ADE_VIRTVAR(Flags, l_Option, nullptr,
-            "Contains a list mapping a flag name to its value. Possible names are:"
-            "<ul>"
-            "<li><b>ForceMultiValueSelection:</b> If true, a selection option with two values should be displayed the "
-            "same as an option with more possible values</li>"
-            "</ul>",
-            "{string->boolean...}", "The table of flags values.")
+ADE_VIRTVAR(Flags,
+	l_Option,
+	nullptr,
+	"Contains a list mapping a flag name to its value. Possible names are:"
+	"<ul>"
+	"<li><b>ForceMultiValueSelection:</b> If true, a selection option with two values should be displayed the "
+	"same as an option with more possible values</li>"
+	"</ul>",
+	ade_type_map("string", "boolean"),
+	"The table of flags values.")
 {
 	option_h* opt;
 	options::ValueDescription* new_val = nullptr;

--- a/code/scripting/api/objs/player.cpp
+++ b/code/scripting/api/objs/player.cpp
@@ -238,7 +238,7 @@ ADE_FUNC(getMultiSquadronName, l_Player, NULL, "Gets current player multi squad 
 	return ade_set_args(L, "s", plr->get()->m_squad_name);
 }
 
-ADE_FUNC(loadCampaignSavefile, l_Player, "string campaign = <current>", "Loads the specified campaign save file.",
+ADE_FUNC(loadCampaignSavefile, l_Player, "string campaign = \"<current>\"", "Loads the specified campaign save file.",
          "boolean", "true on success, false otherwise")
 {
 	player_h* plh;

--- a/code/scripting/api/objs/ship.cpp
+++ b/code/scripting/api/objs/ship.cpp
@@ -52,7 +52,7 @@ ADE_FUNC(__len, l_ShipTextures, NULL, "Number of textures on ship", "number", "N
 	return ade_set_args(L, "i", pm->n_textures*TM_NUM_TYPES);
 }
 
-ADE_INDEXER(l_ShipTextures, "number Index/string TextureFilename", "Array of ship textures", "texture", "Texture, or invalid texture handle on failure")
+ADE_INDEXER(l_ShipTextures, "number/string IndexOrTextureFilename", "Array of ship textures", "texture", "Texture, or invalid texture handle on failure")
 {
 	object_h *oh;
 	const char* s;
@@ -137,7 +137,7 @@ ADE_FUNC(isValid, l_ShipTextures, NULL, "Detects whether handle is valid", "bool
 //**********HANDLE: Ship
 ADE_OBJ_DERIV(l_Ship, object_h, "ship", "Ship handle", l_Object);
 
-ADE_INDEXER(l_Ship, "string Name/number Index", "Array of ship subsystems", "subsystem", "Subsystem handle, or invalid subsystem handle if index or ship handle is invalid")
+ADE_INDEXER(l_Ship, "string/number NameOrIndex", "Array of ship subsystems", "subsystem", "Subsystem handle, or invalid subsystem handle if index or ship handle is invalid")
 {
 	object_h *objh;
 	const char* s      = nullptr;
@@ -946,7 +946,7 @@ ADE_FUNC(kill, l_Ship, "[object Killer]", "Kills the ship. Set \"Killer\" to the
 	return ADE_RETURN_TRUE;
 }
 
-ADE_FUNC(addShipEffect, l_Ship, "string name, int duration (in milliseconds)", "Activates an effect for this ship. Effect names are defined in Post_processing.tbl, and need to be implemented in the main shader. This functions analogous to the ship-effect sexp. NOTE: only one effect can be active at any time, adding new effects will override effects already in progress.\n", "boolean", "Returns true if the effect was successfully added, false otherwise") {
+ADE_FUNC(addShipEffect, l_Ship, "string name, number durationMillis", "Activates an effect for this ship. Effect names are defined in Post_processing.tbl, and need to be implemented in the main shader. This functions analogous to the ship-effect sexp. NOTE: only one effect can be active at any time, adding new effects will override effects already in progress.\n", "boolean", "Returns true if the effect was successfully added, false otherwise") {
 	object_h *shiph;
 	const char* effect = nullptr;
 	int duration;
@@ -1340,7 +1340,13 @@ ADE_FUNC(giveOrder, l_Ship, "enumeration Order, [object Target=nil, subsystem Ta
 	return ADE_RETURN_TRUE;
 }
 
-ADE_FUNC(doManeuver, l_Ship, "number Duration, number Heading, number Pitch, number Bank, boolean Apply-all Rotation, number Vertical, number Sideways, number Forward, boolean Apply-all Movement, number Maneuver Bitfield", "Sets ship maneuver over the defined time period", "boolean", "True if maneuver order was given, otherwise false or nil")
+ADE_FUNC(doManeuver,
+	l_Ship,
+	"number Duration, number Heading, number Pitch, number Bank, boolean ApplyAllRotation, number Vertical, number "
+	"Sideways, number Forward, boolean ApplyAllMovement, number ManeuverBitfield",
+	"Sets ship maneuver over the defined time period",
+	"boolean",
+	"True if maneuver order was given, otherwise false or nil")
 {
 	object_h *objh;
 	float heading, pitch, bank, up, sideways, forward;
@@ -1646,7 +1652,7 @@ ADE_FUNC(getMaximumSpeed, l_Ship, "[number energy = 0.333]", "Gets the maximum s
 	}
 }
 
-ADE_FUNC(EtsSetIndexes, l_Ship, "number Engine Index, number Shield Index, number Weapon Index",
+ADE_FUNC(EtsSetIndexes, l_Ship, "number EngineIndex, number ShieldIndex, number WeaponIndex",
 		 "Sets ships ETS systems to specified values",
 		 "boolean",
 		 "True if successful, false if target ships ETS was missing, or only has one system")

--- a/code/scripting/api/objs/shipclass.cpp
+++ b/code/scripting/api/objs/shipclass.cpp
@@ -463,7 +463,13 @@ ADE_FUNC(isInTechroom, l_Shipclass, NULL, "Gets whether or not the ship class is
 	return ade_set_args(L, "b", b);
 }
 
-ADE_FUNC(renderTechModel, l_Shipclass, "X1, Y1, X2, Y2, [Rotation %=0, Pitch %=0, Bank %=40, number Zoom=1.3]", "Draws ship model as if in techroom", "boolean", "Whether ship was rendered")
+ADE_FUNC(renderTechModel,
+	l_Shipclass,
+	"number X1, number Y1, number X2, number Y2, [number RotationPercent =0, number PitchPercent =0, number "
+	"BankPercent=40, number Zoom=1.3]",
+	"Draws ship model as if in techroom",
+	"boolean",
+	"Whether ship was rendered")
 {
 	int x1,y1,x2,y2;
 	angles rot_angles = {0.0f, 0.0f, 40.0f};

--- a/code/scripting/api/objs/sound.cpp
+++ b/code/scripting/api/objs/sound.cpp
@@ -81,7 +81,7 @@ ADE_FUNC(getDuration, l_SoundEntry, NULL, "Gives the length of the sound in seco
 	return ade_set_args(L, "f", (i2fl(gamesnd_get_max_duration(seh->Get())) / 1000.0f));
 }
 
-ADE_FUNC(get3DValues, l_SoundEntry, "vector Postion[, number radius=0.0]",
+ADE_FUNC(get3DValues, l_SoundEntry, "vector Postion, [number radius=0.0]",
          "Computes the volume and the panning of the sound when it would be played from the specified position.<br>"
          "If range is given then the volume will diminish when the listener is withing that distance to the source.<br>"
          "The position of the listener is always the the current viewing position.",
@@ -332,7 +332,7 @@ ADE_FUNC(isSoundValid, l_Sound, NULL, "Checks if only the sound is valid, should
 
 ADE_OBJ_DERIV(l_Sound3D, sound_h, "sound3D", "3D sound instance handle", l_Sound);
 
-ADE_FUNC(updatePosition, l_Sound3D, "vector Position[, number radius = 0.0]", "Updates the given 3D sound with the specified position and an optional range value", "boolean", "true if succeesed, false otherwise")
+ADE_FUNC(updatePosition, l_Sound3D, "vector Position, [number radius = 0.0]", "Updates the given 3D sound with the specified position and an optional range value", "boolean", "true if succeesed, false otherwise")
 {
 	sound_h *sh;
 	vec3d *newPos = NULL;
@@ -386,7 +386,7 @@ ADE_VIRTVAR(Filename, l_Soundfile, "string", "The filename of the file", "string
 }
 
 
-ADE_FUNC(play, l_Soundfile, "[number volume = 1.0[, number panning = 0.0]]", "Plays the sound", "sound", "A sound handle or invalid handle on error")
+ADE_FUNC(play, l_Soundfile, "[number volume = 1.0, number panning = 0.0]", "Plays the sound", "sound", "A sound handle or invalid handle on error")
 {
 	soundfile_h* handle = nullptr;
 	float volume = 1.0f;

--- a/code/scripting/api/objs/subsystem.cpp
+++ b/code/scripting/api/objs/subsystem.cpp
@@ -582,7 +582,7 @@ ADE_FUNC(isTargetInFOV, l_Subsystem, "object Target", "Determines if the object 
 		return ADE_RETURN_FALSE;
 }
 
-ADE_FUNC(fireWeapon, l_Subsystem, "[Turret weapon index = 1, Flak range = 100]", "Fires weapon on turret", NULL, NULL)
+ADE_FUNC(fireWeapon, l_Subsystem, "[number TurretWeaponIndex = 1, number FlakRange = 100]", "Fires weapon on turret", nullptr, nullptr)
 {
 	ship_subsys_h *sso;
 	int wnum = 1;
@@ -612,7 +612,7 @@ ADE_FUNC(fireWeapon, l_Subsystem, "[Turret weapon index = 1, Flak range = 100]",
 	return ade_set_args(L, "b", rtn);
 }
 
-ADE_FUNC(rotateTurret, l_Subsystem, "vector Pos[, boolean reset=false", "Rotates the turret to face Pos or resets the turret to its original state", "boolean", "true on success false otherwise")
+ADE_FUNC(rotateTurret, l_Subsystem, "vector Pos, boolean reset=false", "Rotates the turret to face Pos or resets the turret to its original state", "boolean", "true on success false otherwise")
 {
 	ship_subsys_h *sso;
 	vec3d pos = vmd_zero_vector;

--- a/code/scripting/api/objs/texture.cpp
+++ b/code/scripting/api/objs/texture.cpp
@@ -197,7 +197,7 @@ ADE_FUNC(getFramesLeft, l_Texture, NULL, "Gets number of frames left, from handl
 	return ade_set_args(L, "i", num);
 }
 
-ADE_FUNC(getFrame, l_Texture, "number Elapsed time (secs), [boolean Loop]",
+ADE_FUNC(getFrame, l_Texture, "number ElapsedTimeSeconds, [boolean Loop]",
          "Get the frame number from the elapsed time of the animation<br>"
          "The 1st argument is the time that has elapsed since the animation started<br>"
          "If 2nd argument is set to true, the animation is expected to loop when the elapsed time exceeds the duration "

--- a/code/scripting/api/objs/weapon.cpp
+++ b/code/scripting/api/objs/weapon.cpp
@@ -315,7 +315,7 @@ ADE_VIRTVAR(OverrideHoming, l_Weapon, "boolean",
 	return ade_set_args(L, "b", wp->weapon_flags[Weapon::Weapon_Flags::Overridden_homing]);
 }
 
-ADE_FUNC(isArmed, l_Weapon, "[boolean Hit target]", "Checks if the weapon is armed.", "boolean", "boolean value of the weapon arming status")
+ADE_FUNC(isArmed, l_Weapon, "[boolean HitTarget]", "Checks if the weapon is armed.", "boolean", "boolean value of the weapon arming status")
 {
 	object_h *oh = NULL;
 	bool hit_target = false;

--- a/code/scripting/scripting.cpp
+++ b/code/scripting/scripting.cpp
@@ -232,11 +232,35 @@ static json_t* json_doc_generate_return_type(const scripting::ade_type_info& typ
 		                 "element",
 		                 json_doc_generate_return_type(type_info.elements().front()));
 	}
-	default:
-		UNREACHABLE("Unknown type type!");
-		return nullptr;
+	case ade_type_info_type::Map: {
+		return json_pack("{sssoso}",
+			"type",
+			"map",
+			"key",
+			json_doc_generate_return_type(type_info.elements()[0]),
+			"value",
+			json_doc_generate_return_type(type_info.elements()[1]));
+	}
+	case ade_type_info_type::Iterator: {
+		return json_pack("{ssso}",
+			"type",
+			"iterator",
+			"element",
+			json_doc_generate_return_type(type_info.elements().front()));
+	}
+	case ade_type_info_type::Alternative: {
+		json_t* alternativeTypes = json_array();
+
+		for (const auto& type : type_info.elements()) {
+			json_array_append_new(alternativeTypes, json_doc_generate_return_type(type));
+		}
+
+		return json_pack("{ssso}", "type", "alternative", "elements", alternativeTypes);
+	}
 	}
 
+	UNREACHABLE("Unknown type type!");
+	return nullptr;
 }
 static void json_doc_generate_function(json_t* elObj, const DocumentationElementFunction* lib)
 {
@@ -399,6 +423,7 @@ void script_init()
 		if (Output_scripting_json) {
 			mprintf(("SCRIPTING: Outputting scripting metadata in JSON format...\n"));
 			documentation_to_json(doc);
+			exit(1);
 		}
 	}
 

--- a/code/scripting/scripting.h
+++ b/code/scripting/scripting.h
@@ -189,7 +189,14 @@ struct DocumentationElementProperty : public DocumentationElement {
 
 struct DocumentationElementFunction : public DocumentationElement {
 	scripting::ade_type_info returnType;
-	SCP_string parameters;
+
+	struct argument_list {
+		SCP_string simple;
+
+		SCP_vector<scripting::argument_def> arguments;
+	};
+
+	argument_list parameters;
 
 	SCP_string returnDocumentation;
 };

--- a/code/source_groups.cmake
+++ b/code/source_groups.cmake
@@ -1052,6 +1052,8 @@ add_file_folder("Scripting"
 	scripting/ade_api.h
 	scripting/ade_args.cpp
 	scripting/ade_args.h
+	scripting/ade_doc.cpp
+	scripting/ade_doc.h
 	scripting/hook_api.cpp
 	scripting/hook_api.h
 	scripting/lua.cpp

--- a/test/src/scripting/ade_doc.cpp
+++ b/test/src/scripting/ade_doc.cpp
@@ -1,0 +1,180 @@
+
+#include "scripting/ade_doc.h"
+
+#include <gtest/gtest.h>
+
+using namespace scripting;
+
+struct ArgumentListParserTest : public testing::Test {
+	argument_list_parser parser;
+};
+
+TEST_F(ArgumentListParserTest, parseEmpty) {
+	ASSERT_TRUE(parser.parse(""));
+}
+
+TEST_F(ArgumentListParserTest, singleTypeParam) {
+	ASSERT_TRUE(parser.parse("number"));
+
+	const auto arglist = parser.getArgList();
+	ASSERT_EQ(1, arglist.size());
+	ASSERT_STREQ("number", arglist[0].type.getSimpleName());
+	ASSERT_EQ("", arglist[0].name);
+	ASSERT_EQ("", arglist[0].def_val);
+	ASSERT_FALSE(arglist[0].optional);
+}
+
+TEST_F(ArgumentListParserTest, alternativeTypeParam) {
+	ASSERT_TRUE(parser.parse("number|string"));
+
+	const auto arglist = parser.getArgList();
+	ASSERT_EQ(1, arglist.size());
+	ASSERT_EQ("", arglist[0].name);
+	ASSERT_EQ("", arglist[0].def_val);
+	ASSERT_FALSE(arglist[0].optional);
+
+	ASSERT_EQ(ade_type_info_type::Alternative, arglist[0].type.getType());
+	const auto& elemTypes = arglist[0].type.elements();
+	ASSERT_EQ(2, elemTypes.size());
+	ASSERT_STREQ("number", elemTypes[0].getSimpleName());
+	ASSERT_STREQ("string", elemTypes[1].getSimpleName());
+}
+
+TEST_F(ArgumentListParserTest, alternativeTypeParamWith3) {
+	ASSERT_TRUE(parser.parse("number|string|object"));
+
+	const auto arglist = parser.getArgList();
+	ASSERT_EQ(1, arglist.size());
+	ASSERT_EQ("", arglist[0].name);
+	ASSERT_EQ("", arglist[0].def_val);
+	ASSERT_FALSE(arglist[0].optional);
+
+	ASSERT_EQ(ade_type_info_type::Alternative, arglist[0].type.getType());
+	const auto& elemTypes = arglist[0].type.elements();
+	ASSERT_EQ(3, elemTypes.size());
+	ASSERT_STREQ("number", elemTypes[0].getSimpleName());
+	ASSERT_STREQ("string", elemTypes[1].getSimpleName());
+	ASSERT_STREQ("object", elemTypes[2].getSimpleName());
+}
+
+TEST_F(ArgumentListParserTest, paramWithTypeAndName) {
+	ASSERT_TRUE(parser.parse("number test"));
+
+	const auto arglist = parser.getArgList();
+	ASSERT_EQ(1, arglist.size());
+	ASSERT_STREQ("number", arglist[0].type.getSimpleName());
+	ASSERT_EQ("test", arglist[0].name);
+	ASSERT_EQ("", arglist[0].def_val);
+	ASSERT_FALSE(arglist[0].optional);
+}
+
+TEST_F(ArgumentListParserTest, paramWithTypeAndNameAndDefaultVal) {
+	ASSERT_TRUE(parser.parse("number test = tset"));
+
+	const auto arglist = parser.getArgList();
+	ASSERT_EQ(1, arglist.size());
+	ASSERT_STREQ("number", arglist[0].type.getSimpleName());
+	ASSERT_EQ("test", arglist[0].name);
+	ASSERT_EQ("tset", arglist[0].def_val);
+	ASSERT_FALSE(arglist[0].optional);
+}
+
+TEST_F(ArgumentListParserTest, twoParametersOneDefault) {
+	ASSERT_TRUE(parser.parse("number test1 = first, string test2"));
+
+	const auto arglist = parser.getArgList();
+	ASSERT_EQ(2, arglist.size());
+
+	ASSERT_STREQ("number", arglist[0].type.getSimpleName());
+	ASSERT_EQ("test1", arglist[0].name);
+	ASSERT_EQ("first", arglist[0].def_val);
+	ASSERT_FALSE(arglist[0].optional);
+
+	ASSERT_STREQ("string", arglist[1].type.getSimpleName());
+	ASSERT_EQ("test2", arglist[1].name);
+	ASSERT_EQ("", arglist[1].def_val);
+	ASSERT_FALSE(arglist[1].optional);
+}
+
+TEST_F(ArgumentListParserTest, optionalParameterPackOnSingleParam) {
+	ASSERT_TRUE(parser.parse("number test1 = first, [string test2]"));
+
+	const auto arglist = parser.getArgList();
+	ASSERT_EQ(2, arglist.size());
+
+	ASSERT_STREQ("number", arglist[0].type.getSimpleName());
+	ASSERT_EQ("test1", arglist[0].name);
+	ASSERT_EQ("first", arglist[0].def_val);
+	ASSERT_FALSE(arglist[0].optional);
+
+	ASSERT_STREQ("string", arglist[1].type.getSimpleName());
+	ASSERT_EQ("test2", arglist[1].name);
+	ASSERT_EQ("", arglist[1].def_val);
+	ASSERT_TRUE(arglist[1].optional);
+}
+
+TEST_F(ArgumentListParserTest, optionalParameterPackOnMultipleParam) {
+	ASSERT_TRUE(parser.parse("number test1 = first, [string test2, object objTest]"));
+
+	const auto arglist = parser.getArgList();
+	ASSERT_EQ(3, arglist.size());
+
+	ASSERT_STREQ("number", arglist[0].type.getSimpleName());
+	ASSERT_EQ("test1", arglist[0].name);
+	ASSERT_EQ("first", arglist[0].def_val);
+	ASSERT_FALSE(arglist[0].optional);
+
+	ASSERT_STREQ("string", arglist[1].type.getSimpleName());
+	ASSERT_EQ("test2", arglist[1].name);
+	ASSERT_EQ("", arglist[1].def_val);
+	ASSERT_TRUE(arglist[1].optional);
+
+	ASSERT_STREQ("object", arglist[2].type.getSimpleName());
+	ASSERT_EQ("objTest", arglist[2].name);
+	ASSERT_EQ("", arglist[2].def_val);
+	ASSERT_FALSE(arglist[2].optional);
+}
+
+TEST_F(ArgumentListParserTest, optionalParameterPackOnMultipleParamWithDefault) {
+	ASSERT_TRUE(parser.parse("number test1 = first, [string test2 = \"test\", object objTest]"));
+
+	const auto arglist = parser.getArgList();
+	ASSERT_EQ(3, arglist.size());
+
+	ASSERT_STREQ("number", arglist[0].type.getSimpleName());
+	ASSERT_EQ("test1", arglist[0].name);
+	ASSERT_EQ("first", arglist[0].def_val);
+	ASSERT_FALSE(arglist[0].optional);
+
+	ASSERT_STREQ("string", arglist[1].type.getSimpleName());
+	ASSERT_EQ("test2", arglist[1].name);
+	ASSERT_EQ("\"test\"", arglist[1].def_val);
+	ASSERT_TRUE(arglist[1].optional);
+
+	ASSERT_STREQ("object", arglist[2].type.getSimpleName());
+	ASSERT_EQ("objTest", arglist[2].name);
+	ASSERT_EQ("", arglist[2].def_val);
+	ASSERT_FALSE(arglist[2].optional);
+}
+
+TEST_F(ArgumentListParserTest, entireListOptional) {
+	ASSERT_TRUE(parser.parse("[number test1 = first, string test2 = \"test\", object objTest]"));
+
+	const auto arglist = parser.getArgList();
+	ASSERT_EQ(3, arglist.size());
+
+	ASSERT_STREQ("number", arglist[0].type.getSimpleName());
+	ASSERT_EQ("test1", arglist[0].name);
+	ASSERT_EQ("first", arglist[0].def_val);
+	ASSERT_TRUE(arglist[0].optional);
+
+	ASSERT_STREQ("string", arglist[1].type.getSimpleName());
+	ASSERT_EQ("test2", arglist[1].name);
+	ASSERT_EQ("\"test\"", arglist[1].def_val);
+	ASSERT_FALSE(arglist[1].optional);
+
+	ASSERT_STREQ("object", arglist[2].type.getSimpleName());
+	ASSERT_EQ("objTest", arglist[2].name);
+	ASSERT_EQ("", arglist[2].def_val);
+	ASSERT_FALSE(arglist[2].optional);
+}

--- a/test/src/scripting/ade_doc.cpp
+++ b/test/src/scripting/ade_doc.cpp
@@ -17,7 +17,7 @@ TEST_F(ArgumentListParserTest, singleTypeParam) {
 	ASSERT_TRUE(parser.parse("number"));
 
 	const auto arglist = parser.getArgList();
-	ASSERT_EQ(1, arglist.size());
+	ASSERT_EQ(1, static_cast<int>(arglist.size()));
 	ASSERT_STREQ("number", arglist[0].type.getSimpleName());
 	ASSERT_EQ("", arglist[0].name);
 	ASSERT_EQ("", arglist[0].def_val);
@@ -28,14 +28,14 @@ TEST_F(ArgumentListParserTest, alternativeTypeParam) {
 	ASSERT_TRUE(parser.parse("number|string"));
 
 	const auto arglist = parser.getArgList();
-	ASSERT_EQ(1, arglist.size());
+	ASSERT_EQ(1, static_cast<int>(arglist.size()));
 	ASSERT_EQ("", arglist[0].name);
 	ASSERT_EQ("", arglist[0].def_val);
 	ASSERT_FALSE(arglist[0].optional);
 
 	ASSERT_EQ(ade_type_info_type::Alternative, arglist[0].type.getType());
 	const auto& elemTypes = arglist[0].type.elements();
-	ASSERT_EQ(2, elemTypes.size());
+	ASSERT_EQ(2, static_cast<int>(elemTypes.size()));
 	ASSERT_STREQ("number", elemTypes[0].getSimpleName());
 	ASSERT_STREQ("string", elemTypes[1].getSimpleName());
 }
@@ -44,14 +44,14 @@ TEST_F(ArgumentListParserTest, alternativeTypeParamWith3) {
 	ASSERT_TRUE(parser.parse("number|string|object"));
 
 	const auto arglist = parser.getArgList();
-	ASSERT_EQ(1, arglist.size());
+	ASSERT_EQ(1, static_cast<int>(arglist.size()));
 	ASSERT_EQ("", arglist[0].name);
 	ASSERT_EQ("", arglist[0].def_val);
 	ASSERT_FALSE(arglist[0].optional);
 
 	ASSERT_EQ(ade_type_info_type::Alternative, arglist[0].type.getType());
 	const auto& elemTypes = arglist[0].type.elements();
-	ASSERT_EQ(3, elemTypes.size());
+	ASSERT_EQ(3, static_cast<int>(elemTypes.size()));
 	ASSERT_STREQ("number", elemTypes[0].getSimpleName());
 	ASSERT_STREQ("string", elemTypes[1].getSimpleName());
 	ASSERT_STREQ("object", elemTypes[2].getSimpleName());
@@ -61,7 +61,7 @@ TEST_F(ArgumentListParserTest, paramWithTypeAndName) {
 	ASSERT_TRUE(parser.parse("number test"));
 
 	const auto arglist = parser.getArgList();
-	ASSERT_EQ(1, arglist.size());
+	ASSERT_EQ(1, static_cast<int>(arglist.size()));
 	ASSERT_STREQ("number", arglist[0].type.getSimpleName());
 	ASSERT_EQ("test", arglist[0].name);
 	ASSERT_EQ("", arglist[0].def_val);
@@ -72,7 +72,7 @@ TEST_F(ArgumentListParserTest, paramWithTypeAndNameAndDefaultVal) {
 	ASSERT_TRUE(parser.parse("number test = tset"));
 
 	const auto arglist = parser.getArgList();
-	ASSERT_EQ(1, arglist.size());
+	ASSERT_EQ(1, static_cast<int>(arglist.size()));
 	ASSERT_STREQ("number", arglist[0].type.getSimpleName());
 	ASSERT_EQ("test", arglist[0].name);
 	ASSERT_EQ("tset", arglist[0].def_val);
@@ -83,7 +83,7 @@ TEST_F(ArgumentListParserTest, twoParametersOneDefault) {
 	ASSERT_TRUE(parser.parse("number test1 = first, string test2"));
 
 	const auto arglist = parser.getArgList();
-	ASSERT_EQ(2, arglist.size());
+	ASSERT_EQ(2, static_cast<int>(arglist.size()));
 
 	ASSERT_STREQ("number", arglist[0].type.getSimpleName());
 	ASSERT_EQ("test1", arglist[0].name);
@@ -100,7 +100,7 @@ TEST_F(ArgumentListParserTest, optionalParameterPackOnSingleParam) {
 	ASSERT_TRUE(parser.parse("number test1 = first, [string test2]"));
 
 	const auto arglist = parser.getArgList();
-	ASSERT_EQ(2, arglist.size());
+	ASSERT_EQ(2, static_cast<int>(arglist.size()));
 
 	ASSERT_STREQ("number", arglist[0].type.getSimpleName());
 	ASSERT_EQ("test1", arglist[0].name);
@@ -117,7 +117,7 @@ TEST_F(ArgumentListParserTest, optionalParameterPackOnMultipleParam) {
 	ASSERT_TRUE(parser.parse("number test1 = first, [string test2, object objTest]"));
 
 	const auto arglist = parser.getArgList();
-	ASSERT_EQ(3, arglist.size());
+	ASSERT_EQ(3, static_cast<int>(arglist.size()));
 
 	ASSERT_STREQ("number", arglist[0].type.getSimpleName());
 	ASSERT_EQ("test1", arglist[0].name);
@@ -139,7 +139,7 @@ TEST_F(ArgumentListParserTest, optionalParameterPackOnMultipleParamWithDefault) 
 	ASSERT_TRUE(parser.parse("number test1 = first, [string test2 = \"test\", object objTest]"));
 
 	const auto arglist = parser.getArgList();
-	ASSERT_EQ(3, arglist.size());
+	ASSERT_EQ(3, static_cast<int>(arglist.size()));
 
 	ASSERT_STREQ("number", arglist[0].type.getSimpleName());
 	ASSERT_EQ("test1", arglist[0].name);
@@ -161,7 +161,7 @@ TEST_F(ArgumentListParserTest, entireListOptional) {
 	ASSERT_TRUE(parser.parse("[number test1 = first, string test2 = \"test\", object objTest]"));
 
 	const auto arglist = parser.getArgList();
-	ASSERT_EQ(3, arglist.size());
+	ASSERT_EQ(3, static_cast<int>(arglist.size()));
 
 	ASSERT_STREQ("number", arglist[0].type.getSimpleName());
 	ASSERT_EQ("test1", arglist[0].name);

--- a/test/src/source_groups.cmake
+++ b/test/src/source_groups.cmake
@@ -38,6 +38,7 @@ add_file_folder("Pilotfile"
 
 add_file_folder("Scripting"
     scripting/ade_args.cpp
+    scripting/ade_doc.cpp
     scripting/require.cpp
     scripting/ScriptingTestFixture.h
     scripting/ScriptingTestFixture.cpp


### PR DESCRIPTION
This adds a simple parser that takes the existing argument
documentations and parses them so that better documentation can be
generated from that information. This should be sufficient for providing
proper documentation generation for the most common and simple cases of
argument lists (type, name, possible default value, and optional
groups).