### PR TITLE
Allow Team Leaders to Send Messages

### DIFF
--- a/code/network/multiteamselect.h
+++ b/code/network/multiteamselect.h
@@ -74,7 +74,7 @@ void multi_ts_commit_pressed();
 int multi_ts_get_team(char *ship_name);
 
 // function to get the team and slot of a particular ship
-void multi_ts_get_team_and_slot(char *ship_name,int *team_index,int *slot_index, bool mantis2757switch = false);
+void multi_ts_get_team_and_slot(char *ship_name,int *team_index,int *slot_index);
 
 // function to return the shipname of the ship belonging in slot N
 void multi_ts_get_shipname( char *ship_name, int team, int slot_index );

--- a/code/network/multiutil.cpp
+++ b/code/network/multiutil.cpp
@@ -1843,7 +1843,6 @@ int multi_num_connections()
 int multi_can_message(net_player *p)
 {
 	int max_rank;
-	ship *sp;
 
 	// if the player is an observer of any kind, he cannot message
 	if(p->flags & NETINFO_FLAG_OBSERVER){
@@ -1861,19 +1860,23 @@ int multi_can_message(net_player *p)
 
 	// only wing/team leaders can message
 	case MSO_SQUAD_LEADER:
+	{
 		// if the player has an invalid object #
 		if(p->m_player->objnum < 0){
 			return 0;
 		}
 
 		// check to see if he's a wingleader
-		sp = &Ships[Objects[p->m_player->objnum].instance];
-		if (sp->ship_name[strlen(sp->ship_name)-1] == '1') 
+		const ship_registry_entry* ship_regp = ship_registry_get(Ships[Objects[p->m_player->objnum].instance].ship_name);
+
+		// verify that it's valid.
+		Assertion(ship_regp != nullptr, "Ship register entry is a nullptr for the player's ship.");
+		if (ship_regp->p_objp->pos_in_wing != 0) 
 		{
 			return 0;
 		}	
 		break;
-
+	}
 	// anyone can end message
 	case MSO_SQUAD_ANY:
 		break;
@@ -1892,7 +1895,6 @@ int multi_can_message(net_player *p)
 int multi_can_end_mission(net_player *p)
 {
 	int max_rank;
-	ship *sp;	
 
 	// the host can _always_ unpause a game
 	if(p->flags & NETINFO_FLAG_GAME_HOST){
@@ -1910,19 +1912,23 @@ int multi_can_end_mission(net_player *p)
 
 	// only wing/team leaders can end the mission
 	case MSO_END_LEADER:
+	{
 		// if the player has an invalid object #
 		if(p->m_player->objnum < 0){
 			return 0;
 		}
 
 		// check to see if he's a wingleader
-		sp = &Ships[Objects[p->m_player->objnum].instance];
-		if (sp->ship_name[strlen(sp->ship_name)-1] == '1') 
+		const ship_registry_entry* ship_regp = ship_registry_get(Ships[Objects[p->m_player->objnum].instance].ship_name);
+
+		// double check that the entry is valid.
+		Assertion(ship_regp != nullptr, "Ship register entry is a nullptr for the player's ship.");
+		if (ship_regp->p_objp->pos_in_wing != 0) 
 		{
 			return 0;
 		}	
 		break;
-
+	}
 	// anyone can end the mission
 	case MSO_END_ANY:
 		break;

--- a/code/object/object.cpp
+++ b/code/object/object.cpp
@@ -1084,8 +1084,8 @@ void obj_set_flags( object *obj, const flagset<Object::Object_Flags>& new_flags 
 
 		// see if this ship is really a player ship (or should be)
 		shipp = &Ships[obj->instance];
-		extern void multi_ts_get_team_and_slot(char *, int *, int *, bool);
-		multi_ts_get_team_and_slot(shipp->ship_name,&team,&slot, false);
+		extern void multi_ts_get_team_and_slot(char *, int *, int *);
+		multi_ts_get_team_and_slot(shipp->ship_name,&team,&slot);
 		if ( (shipp->wingnum == -1) || (team == -1) || (slot==-1) ) {
 			Int3();
 			return;


### PR DESCRIPTION
Gotta love your retail bugs!

Function was returning 0 instead of 1 when the team captains were messaging AI.  

Yes we could replace this with a fancier check than, "does the ship name end in 1???"  But we should come up with that system and fix all the places it relies on that behavior at once.

Edit: forgot to mention, this does not affect multi compatibility at all.

Edit2: Realized != matches the function better and keeps everyone else from messaging, so that's what we should go with instead.