### PR TITLE
fix compact_multitext_string

### DIFF
--- a/code/parse/parselo.cpp
+++ b/code/parse/parselo.cpp
@@ -1398,7 +1398,6 @@ void compact_multitext_string(char *str)
 	while (*p_src)
 	{
 		char ch = *p_src;
-		p_src++;
 
 		// skip CR
 		// convert LF to space
@@ -1412,6 +1411,7 @@ void compact_multitext_string(char *str)
 
 			p_dest++;
 		}
+		p_src++;
 	}
 
 	if (p_dest != p_src)
@@ -1427,7 +1427,6 @@ void compact_multitext_string(SCP_string &str)
 	while (p_src != str.end())
 	{
 		char ch = *p_src;
-		p_src++;
 
 		// skip CR
 		// convert LF to space
@@ -1441,6 +1440,7 @@ void compact_multitext_string(SCP_string &str)
 
 			p_dest++;
 		}
+		p_src++;
 	}
 
 	if (p_dest != p_src)


### PR DESCRIPTION
This is a follow-up to PR #2373.  Tomimaki noticed that the first character was truncated in the cutscene description, and it turned out that the algorithm was slightly wrong.