### PR TITLE
Allow weapons in the lab

### DIFF
--- a/code/lab/lab.cpp
+++ b/code/lab/lab.cpp
@@ -2192,7 +2192,7 @@ void labviewer_fill_loadout_window() {
 					auto others_head = weapons_tree->AddItem(bank_head, "Others", 0, false);
 
 					auto n_weapons = MIN(Weapon_info.size(), MAX_WEAPON_TYPES);
-					for (auto j = 0; j < n_weapons; ++j) {
+					for (size_t j = 0; j < n_weapons; ++j) {
 						auto wip = &Weapon_info[j];
 						if (wip->subtype == WP_LASER || wip->subtype == WP_BEAM) {
 							if (sip->allowed_weapons[j] != 0) {
@@ -2213,7 +2213,7 @@ void labviewer_fill_loadout_window() {
 					auto others_head = weapons_tree->AddItem(bank_head, "Others", 0, false);
 
 					auto n_weapons = MIN(Weapon_info.size(), MAX_WEAPON_TYPES);
-					for (auto j = 0; j < n_weapons; ++j) {
+					for (size_t j = 0; j < n_weapons; ++j) {
 						auto wip = &Weapon_info[j];
 						if (wip->subtype == WP_MISSILE) {
 							if (sip->allowed_weapons[j] != 0) {
@@ -2449,7 +2449,7 @@ void lab_pseudomission_setup() {
 	team_data* teamp = &Team_data[0];
 
 	// In the lab, all ships are valid
-	for (auto i = 0; i < Ship_info.size(); ++i) {
+	for (size_t i = 0; i < Ship_info.size(); ++i) {
 		teamp->ship_list[i] = i;
 		strcpy_s(teamp->ship_list_variables[i], "");
 		teamp->ship_count[i] = 1;
@@ -2460,7 +2460,7 @@ void lab_pseudomission_setup() {
 	teamp->num_ship_choices = static_cast<int>(Ship_info.size());
 
 	// you want guns? you get guns.
-	for (auto i = 0; i < Weapon_info.size(); ++i) {
+	for (size_t i = 0; i < Weapon_info.size(); ++i) {
 		teamp->weaponry_pool[i] = i;
 		teamp->weaponry_count[i] = 640; // should be enough for everyone
 		strcpy_s(teamp->weaponry_amount_variable[i], "");

--- a/code/lab/lab.cpp
+++ b/code/lab/lab.cpp
@@ -2452,7 +2452,6 @@ void lab_scroll_down()
 void lab_pseudomission_setup() {
 
 	// External weapon displays require a call to weapons_page_in, which in turn requires team data to be set
-	extern int Num_teams;
 	Num_teams = 1;
 
 	team_data* teamp = &Team_data[0];

--- a/code/lab/lab.cpp
+++ b/code/lab/lab.cpp
@@ -205,8 +205,6 @@ void reset_view()
 void labviewer_change_model(char* model_fname, int lod = 0, int sel_index = -1)
 {
 	bool change_model = true;
-	int l;
-	ship_info* sip = nullptr;
 
 	anim_timer_start = timer_get_milliseconds();
 
@@ -242,12 +240,6 @@ void labviewer_change_model(char* model_fname, int lod = 0, int sel_index = -1)
 				if (Lab_model_num >= 0) {
 					model_page_in_textures(Lab_model_num, sel_index);
 				}
-			}
-
-			// do the same for weapon models if necessary
-			if (Lab_mode == LAB_MODE_SHIP) {
-				sip = &Ship_info[Lab_selected_index];
-				l   = 0;
 			}
 		} else {
 			// clear out the model filename

--- a/code/lab/lab.cpp
+++ b/code/lab/lab.cpp
@@ -39,7 +39,7 @@
 #include "weapon/beam.h"
 #include "weapon/weapon.h"
 #include <utility>
-#include <weapon\muzzleflash.h>
+#include <weapon/muzzleflash.h>
 
 // flags
 #define LAB_FLAG_NORMAL (0)                    // default

--- a/code/lab/lab.cpp
+++ b/code/lab/lab.cpp
@@ -417,26 +417,22 @@ void labviewer_render_model(float frametime)
 			}
 
 			bool weapons_firing = false;
-			for (auto i = 0; i < MAX_SHIP_PRIMARY_BANKS; ++i) {
+			for (auto i = 0; i < Ships[obj->instance].weapons.num_primary_banks; ++i) {
 				if (Lab_fire_primaries & (1 << i)) {
 					weapons_firing = true;
-					if (i < Ships[obj->instance].weapons.num_primary_banks) {
-						Ships[obj->instance].weapons.current_primary_bank = i;
+					Ships[obj->instance].weapons.current_primary_bank = i;
 
-						ship_fire_primary(obj, 0);
-					}
+					ship_fire_primary(obj, 0);
 				}
 			}
 
 			Ships[obj->instance].flags.set(Ship::Ship_Flags::Trigger_down, weapons_firing);
 
-			for (auto i = 0; i < MAX_SHIP_SECONDARY_BANKS; ++i) {
+			for (auto i = 0; i < Ships[obj->instance].weapons.num_secondary_banks; ++i) {
 				if (Lab_fire_secondaries & (1 << i)) {
-					if (i < Ships[obj->instance].weapons.num_secondary_banks) {
-						Ships[obj->instance].weapons.current_secondary_bank = i;
+					Ships[obj->instance].weapons.current_secondary_bank = i;
 
-						ship_fire_secondary(obj);
-					}
+					ship_fire_secondary(obj);
 				}
 			}
 		}

--- a/code/lab/lab.cpp
+++ b/code/lab/lab.cpp
@@ -2586,6 +2586,7 @@ void lab_init()
 	shockwave_level_init();
 	shipfx_flash_init();
 	mflash_page_in(true);
+	beam_level_init();
 	particle::init();
 
 	lab_pseudomission_setup();
@@ -2841,6 +2842,7 @@ void lab_close()
 	obj_init();
 
 	shockwave_level_close();
+	beam_level_close();
 
 	ai_paused = 0;
 	physics_paused = 0;

--- a/code/lab/lab.cpp
+++ b/code/lab/lab.cpp
@@ -103,7 +103,6 @@ static int Lab_last_selected_weapon = -1;
 static int Lab_model_num = -1;
 static int Lab_model_LOD = 0;
 static char Lab_model_filename[MAX_FILENAME_LEN];
-static char Lab_weaponmodel_filename[MAX_SHIP_WEAPONS][MAX_FILENAME_LEN];
 
 static vec3d Lab_model_pos = ZERO_VECTOR;
 

--- a/code/lab/lab.cpp
+++ b/code/lab/lab.cpp
@@ -2104,18 +2104,20 @@ void labviewer_actions_destroy_ship(Button* /*caller*/) {
 }
 
 void labviewer_actions_destroy_subsystem(Tree* caller) {
-	auto selected_subsys_subobj_num = caller->GetSelectedItem()->GetData();
+	auto selected_subsys_index = caller->GetSelectedItem()->GetData();
 
 	if (Lab_mode == LAB_MODE_SHIP) {
 		if (Lab_selected_object != -1) {
 			auto sp = &Ships[Objects[Lab_selected_object].instance];
 			auto ssp = GET_FIRST(&sp->subsys_list);
+			auto subsys_index = 0;
 			while (ssp != END_OF_LIST(&sp->subsys_list)) {
-				if (ssp->system_info->subobj_num == selected_subsys_subobj_num) {
+				if (subsys_index == selected_subsys_index) {
 					do_subobj_destroyed_stuff(sp, ssp, nullptr);
 				}
 
 				ssp = GET_NEXT(ssp);
+				++subsys_index;
 			}
 		}
 	}
@@ -2154,9 +2156,11 @@ void labviewer_fill_subsystem_menu() {
 		if (Lab_selected_object != -1) {
 			auto sp = &Ships[Objects[Lab_selected_object].instance];
 			auto ssp = GET_FIRST(&sp->subsys_list);
+			auto subsys_index = 0;
 			while (ssp != END_OF_LIST(&sp->subsys_list)) {
-				subsys_tree->AddItem(nullptr, ssp->system_info->name, ssp->system_info->subobj_num, true, labviewer_actions_destroy_subsystem);
+				subsys_tree->AddItem(nullptr, ssp->system_info->name, subsys_index, true, labviewer_actions_destroy_subsystem);
 				ssp = GET_NEXT(ssp);
+				++subsys_index;
 			}
 		}
 	}

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -18860,7 +18860,7 @@ void ship_render_weapon_models(model_render_params *ship_render_info, model_draw
 	ship *shipp = &Ships[num];
 	ship_info *sip = &Ship_info[Ships[num].ship_info_index];
 
-	if ( !(sip->flags[Ship::Info_Flags::Draw_weapon_models]) || (shipp->flags[Ship_Flags::Cloaked]) ) {
+	if ( !(sip->flags[Ship::Info_Flags::Draw_weapon_models]) || (shipp->flags[Ship_Flags::Cloaked]) || (shipp->flags[Ship_Flags::Render_without_weapons]) ) {
 		return;
 	}
 

--- a/code/ship/ship_flags.h
+++ b/code/ship/ship_flags.h
@@ -118,6 +118,7 @@ namespace Ship {
 		Render_without_miscmap,
 		Render_full_detail, 
 		Render_without_light,
+		Render_without_weapons,		// The_E -- Skip weapon model rendering
 
 		NUM_VALUES
 

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -5173,8 +5173,8 @@ int weapon_create( vec3d * pos, matrix * porient, int weapon_type, int parent_ob
 		Assertion( position != NULL, "'%s' is trying to fire a weapon that is not selected", Ships[parent_objp->instance].ship_name );
 
 		size_t curr_pos = *position;
-		if (((Weapon_info[weapon_type].subtype == WP_LASER && Player_ship->flags[Ship::Ship_Flags::Primary_linked]) || 
-			 (Weapon_info[weapon_type].subtype == WP_MISSILE && Player_ship->flags[Ship::Ship_Flags::Secondary_dual_fire])) && 
+		if (((Weapon_info[weapon_type].subtype == WP_LASER && parent_shipp->flags[Ship::Ship_Flags::Primary_linked]) ||
+			 (Weapon_info[weapon_type].subtype == WP_MISSILE && parent_shipp->flags[Ship::Ship_Flags::Secondary_dual_fire])) &&
 			 (curr_pos > 0)) {
 			curr_pos--;
 		}


### PR DESCRIPTION
This reenables rendering of external weapon models in the lab.

This also adds actions to change a ship's loadout and fire guns. Note that weapons that have a firewait or require lock-on will not work here.
Also note that the lab will no longer open instantly, since we need to load all the weapon data now.