### PR TITLE
cache on the argument node

### DIFF
--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -919,9 +919,8 @@ void sexp_set_variable_by_index(int node);
 void sexp_copy_variable_from_index(int node);
 void sexp_copy_variable_between_indexes(int node);
 
-SCP_vector<char*> Sexp_replacement_arguments;
+SCP_vector<std::pair<char*, int>> Sexp_replacement_arguments;
 int Sexp_current_argument_nesting_level;
-SCP_vector<char*> Applicable_arguments_temp;
 
 // Goober5000
 arg_item Sexp_applicable_argument_list;
@@ -949,13 +948,14 @@ SCP_vector<SCP_string> *Current_event_log_variable_buffer;
 SCP_vector<SCP_string> *Current_event_log_argument_buffer;
 
 // Goober5000 - arg_item class stuff, borrowed from sexp_list_item class stuff -------------
-void arg_item::add_data(char *str)
+void arg_item::add_data(const std::pair<char*, int> &data)
 {
 	arg_item *item, *ptr;
 
 	// create item
-	item = new arg_item;
-	item->text = str;
+	item = new arg_item();
+	item->text = data.first;
+	item->node = data.second;
 	item->nesting_level = Sexp_current_argument_nesting_level;
 
 	// prepend item to existing list
@@ -964,14 +964,15 @@ void arg_item::add_data(char *str)
 	item->next = ptr;
 }
 
-void arg_item::add_data_dup(char *str)
+void arg_item::add_data_dup(const std::pair<char*, int> &data)
 {
 	arg_item *item, *ptr;
 
 	// create item
-	item = new arg_item;
-	item->text = vm_strdup(str);
+	item = new arg_item();
+	item->text = vm_strdup(data.first);
 	item->flags |= ARG_ITEM_F_DUP;
+	item->node = data.second;
 	item->nesting_level = Sexp_current_argument_nesting_level;
 
 	// prepend item to existing list
@@ -980,14 +981,15 @@ void arg_item::add_data_dup(char *str)
 	item->next = ptr;
 }
 
-void arg_item::add_data_set_dup(char *str)
+void arg_item::add_data_set_dup(const std::pair<char*, int> &data)
 {
 	arg_item *item, *ptr;
 
 	// create item
 	item = new arg_item;
-	item->text = str;
+	item->text = data.first;
 	item->flags |= ARG_ITEM_F_DUP;
+	item->node = data.second;
 	item->nesting_level = Sexp_current_argument_nesting_level;
 
 	// prepend item to existing list
@@ -3263,9 +3265,9 @@ int check_sexp_syntax(int node, int return_type, int recursive, int *bad_node, i
 }
 
 // Goober5000
-void get_unformatted_sexp_variable_name(char *unformatted, char *formatted_pre)
+void get_unformatted_sexp_variable_name(char *unformatted, const char *formatted_pre)
 {
-	char *formatted;
+	const char *formatted;
 
 	// Goober5000 - trim @ if needed
 	if (formatted_pre[0] == SEXP_VARIABLE_CHAR)
@@ -3304,7 +3306,7 @@ void get_sexp_text_for_variable(char *text, char *token)
 void do_preload_for_arguments(void (*preloader)(char *), int arg_node, int arg_handler_node)
 {
 	// we have a special argument
-	if (!strcmp(Sexp_nodes[arg_node].text, SEXP_ARGUMENT_STRING))
+	if (Sexp_nodes[arg_node].flags & SNF_SPECIAL_ARG_IN_NODE)
 	{
 		int n;
 
@@ -3449,6 +3451,10 @@ int get_sexp()
 				strncpy(token, Mp + 1, len);
 				token[len] = 0;
 				node = alloc_sexp(token, SEXP_ATOM, SEXP_ATOM_STRING, -1, -1);
+
+				// special-arg?
+				if (!strcmp(token, SEXP_ARGUMENT_STRING))
+					Sexp_nodes[node].flags |= SNF_SPECIAL_ARG_IN_NODE;
 			}
 
 			// bump past closing \" by 1 char
@@ -3609,7 +3615,7 @@ int get_sexp()
 				n = CDR(n);
 
 				// set flag for taylor
-				if (CAR(n) != -1 || !strcmp(Sexp_nodes[n].text, SEXP_ARGUMENT_STRING))	// if it's evaluating a sexp or a special argument
+				if (CAR(n) != -1 || Sexp_nodes[n].flags & SNF_SPECIAL_ARG_IN_NODE)		// if it's evaluating a sexp or a special argument
 					Knossos_warp_ani_used = 1;												// set flag just in case
 				else if (atoi(CTEXT(n)) != 0)											// if it's not the default 0
 					Knossos_warp_ani_used = 1;												// set flag just in case
@@ -4257,6 +4263,7 @@ player *get_player_from_ship_node(int node, bool test_respawns = false, int *net
  */
 const ship_registry_entry *eval_ship(int node)
 {
+	// check cache
 	if (Sexp_nodes[node].cache)
 	{
 		// have we cached something else?
@@ -4264,6 +4271,16 @@ const ship_registry_entry *eval_ship(int node)
 			return nullptr;
 
 		return &Ship_registry[Sexp_nodes[node].cache->ship_registry_index];
+	}
+
+	// maybe forward to a special-arg node
+	if (Sexp_nodes[node].flags & SNF_SPECIAL_ARG_IN_NODE)
+	{
+		auto current_argument = Sexp_replacement_arguments.back();
+		int arg_node = current_argument.second;
+
+		if (arg_node >= 0)
+			return eval_ship(arg_node);
 	}
 
 	auto ship_it = Ship_registry_map.find(CTEXT(node));
@@ -4286,6 +4303,7 @@ const ship_registry_entry *eval_ship(int node)
  */
 wing *eval_wing(int node)
 {
+	// check cache
 	if (Sexp_nodes[node].cache)
 	{
 		// have we cached something else?
@@ -4293,6 +4311,16 @@ wing *eval_wing(int node)
 			return nullptr;
 
 		return static_cast<wing*>(Sexp_nodes[node].cache->pointer);
+	}
+
+	// maybe forward to a special-arg node
+	if (Sexp_nodes[node].flags & SNF_SPECIAL_ARG_IN_NODE)
+	{
+		auto current_argument = Sexp_replacement_arguments.back();
+		int arg_node = current_argument.second;
+
+		if (arg_node >= 0)
+			return eval_wing(arg_node);
 	}
 
 	int wing_num = wing_lookup(CTEXT(node));
@@ -4320,6 +4348,7 @@ int sexp_atoi(int node)
 {
 	Assertion(!Fred_running, "This function relies on SEXP caching which is not set up to work in FRED!");
 
+	// check cache
 	if (Sexp_nodes[node].cache)
 	{
 		// have we cached something else?
@@ -4327,6 +4356,16 @@ int sexp_atoi(int node)
 			return 0;
 
 		return Sexp_nodes[node].cache->numeric_literal;
+	}
+
+	// maybe forward to a special-arg node
+	if (Sexp_nodes[node].flags & SNF_SPECIAL_ARG_IN_NODE)
+	{
+		auto current_argument = Sexp_replacement_arguments.back();
+		int arg_node = current_argument.second;
+
+		if (arg_node >= 0)
+			return sexp_atoi(arg_node);
 	}
 
 	int num = atoi(CTEXT(node));
@@ -4349,11 +4388,23 @@ bool sexp_can_construe_as_integer(int node)
 	if (Sexp_nodes[node].cache && Sexp_nodes[node].cache->sexp_node_data_type == OPF_NUMBER)
 		return true;
 
+	// maybe forward to a special-arg node
+	if (Sexp_nodes[node].flags & SNF_SPECIAL_ARG_IN_NODE)
+	{
+		auto current_argument = Sexp_replacement_arguments.back();
+		int arg_node = current_argument.second;
+
+		if (arg_node >= 0)
+			return sexp_can_construe_as_integer(arg_node);
+	}
+
 	return can_construe_as_integer(CTEXT(node));
 }
 
 /*
  * This can be used by both FRED and FSO.  When in FSO, it incorporates caching that runs parallel to the main data caching.
+ * Note that this function does not do special-arg forwarding because it operates on the node text, not the CTEXT, and thus
+ * there is no possibility of processing a special argument.
  */
 int sexp_get_variable_index(int node)
 {
@@ -9138,10 +9189,10 @@ void eval_when_for_each_special_argument( int cur_node )
 	while (ptr != NULL)
 	{
 		// acquire argument to be used
-		Sexp_replacement_arguments.push_back(ptr->text);	
+		Sexp_replacement_arguments.emplace_back(ptr->text, ptr->node);
 
 		Sexp_current_argument_nesting_level++;
-		Sexp_applicable_argument_list.add_data(ptr->text);
+		Sexp_applicable_argument_list.add_data(std::pair<char*, int>(ptr->text, ptr->node));
 
 		// execute sexp... CTEXT will insert the argument as necessary
 		eval_sexp(cur_node);
@@ -9169,7 +9220,7 @@ void do_action_for_each_special_argument( int cur_node )
 	while (ptr != NULL)
 	{
 		// acquire argument to be used
-		Sexp_replacement_arguments.push_back(ptr->text);
+		Sexp_replacement_arguments.emplace_back(ptr->text, ptr->node);
 
 		// execute sexp... CTEXT will insert the argument as necessary
 		// (since these are all actions, they don't return any meaningful values)
@@ -9196,7 +9247,7 @@ bool special_argument_appears_in_sexp_tree(int node)
 		return false;
 
 	// special argument?
-	if (!strcmp(Sexp_nodes[node].text, SEXP_ARGUMENT_STRING))
+	if (Sexp_nodes[node].flags & SNF_SPECIAL_ARG_IN_NODE)
 		return true;
 
 	// we don't want to include special arguments if they are nested in a new argument SEXP
@@ -9225,7 +9276,7 @@ bool special_argument_appears_in_sexp_list(int node)
 	while (node != -1)
 	{
 		// special argument?
-		if (!strcmp(Sexp_nodes[node].text, SEXP_ARGUMENT_STRING))
+		if (Sexp_nodes[node].flags & SNF_SPECIAL_ARG_IN_NODE)
 			return true;
 
 		node = CDR(node);
@@ -9314,7 +9365,7 @@ void eval_when_do_all_exp(int all_actions, int when_op_num)
 	while (ptr != NULL)
 	{	
 		// acquire argument to be used
-		Sexp_replacement_arguments.push_back(ptr->text);
+		Sexp_replacement_arguments.emplace_back(ptr->text, ptr->node);
 		actions = all_actions; 
 
 		while (actions != -1)
@@ -9338,7 +9389,7 @@ void eval_when_do_all_exp(int all_actions, int when_op_num)
 					case OP_EVERY_TIME:
 					case OP_IF_THEN_ELSE:				
 						Sexp_current_argument_nesting_level++;
-						Sexp_applicable_argument_list.add_data(ptr->text);
+						Sexp_applicable_argument_list.add_data(std::pair<char*, int>(ptr->text, ptr->node));
 						eval_sexp(exp);
 						Sexp_applicable_argument_list.clear_nesting_level();
 						Sexp_current_argument_nesting_level--;
@@ -9562,6 +9613,7 @@ int eval_cond(int n)
 int test_argument_nodes_for_condition(int n, int condition_node, int *num_true, int *num_false, int *num_known_true, int *num_known_false)
 {
 	int val, num_valid_arguments;
+	SCP_vector<std::pair<char*, int>> Applicable_arguments_temp;
 	Assert(n != -1 && condition_node != -1);
 	Assert((num_true != NULL) && (num_false != NULL) && (num_known_true != NULL) && (num_known_false != NULL));
 
@@ -9586,7 +9638,7 @@ int test_argument_nodes_for_condition(int n, int condition_node, int *num_true, 
 			flush_sexp_tree(condition_node);
 
 			// evaluate conditional for current argument
-			Sexp_replacement_arguments.push_back(Sexp_nodes[n].text);
+			Sexp_replacement_arguments.emplace_back(Sexp_nodes[n].text, n);
 			val = eval_sexp(condition_node);
 			if ( Sexp_nodes[condition_node].value == SEXP_KNOWN_TRUE ||
 					Sexp_nodes[condition_node].value == SEXP_KNOWN_FALSE) {
@@ -9600,7 +9652,7 @@ int test_argument_nodes_for_condition(int n, int condition_node, int *num_true, 
 			{
 				case SEXP_TRUE:
 					(*num_true)++;
-					Applicable_arguments_temp.push_back(Sexp_nodes[n].text);
+					Applicable_arguments_temp.emplace_back(Sexp_nodes[n].text, n);
 					break;
 
 				case SEXP_FALSE:
@@ -9609,7 +9661,7 @@ int test_argument_nodes_for_condition(int n, int condition_node, int *num_true, 
 
 				case SEXP_KNOWN_TRUE:
 					(*num_known_true)++;
-					Applicable_arguments_temp.push_back(Sexp_nodes[n].text);
+					Applicable_arguments_temp.emplace_back(Sexp_nodes[n].text, n);
 					break;
 
 				case SEXP_KNOWN_FALSE:
@@ -9641,9 +9693,10 @@ int test_argument_nodes_for_condition(int n, int condition_node, int *num_true, 
 
 // Goober5000
 // NOTE: if you change this function, check to see if the previous function should also be changed!
-int test_argument_vector_for_condition(SCP_vector<char*> argument_vector, bool already_dupped, int condition_node, int *num_true, int *num_false, int *num_known_true, int *num_known_false)
+int test_argument_vector_for_condition(const SCP_vector<std::pair<char*, int>> &argument_vector, bool already_dupped, int condition_node, int *num_true, int *num_false, int *num_known_true, int *num_known_false)
 {
 	int val, num_valid_arguments;
+	SCP_vector<std::pair<char*, int>> Applicable_arguments_temp;
 	Assert(condition_node != -1);
 	Assert((num_true != NULL) && (num_false != NULL) && (num_known_true != NULL) && (num_known_false != NULL));
 
@@ -9659,7 +9712,7 @@ int test_argument_vector_for_condition(SCP_vector<char*> argument_vector, bool a
 	*num_known_false = 0;
 
 	// loop through all arguments
-	for (size_t i = 0; i < argument_vector.size(); i++)
+	for (const auto &argument : argument_vector)
 	{
 		// since we can't see or modify the validity, assume all are valid
 		{
@@ -9667,7 +9720,7 @@ int test_argument_vector_for_condition(SCP_vector<char*> argument_vector, bool a
 			flush_sexp_tree(condition_node);
 
 			// evaluate conditional for current argument
-			Sexp_replacement_arguments.push_back(argument_vector[i]);
+			Sexp_replacement_arguments.push_back(argument);
 			val = eval_sexp(condition_node);
 			if ( Sexp_nodes[condition_node].value == SEXP_KNOWN_TRUE ||
 					Sexp_nodes[condition_node].value == SEXP_KNOWN_FALSE) {
@@ -9681,7 +9734,7 @@ int test_argument_vector_for_condition(SCP_vector<char*> argument_vector, bool a
 			{
 				case SEXP_TRUE:
 					(*num_true)++;
-					Applicable_arguments_temp.push_back(argument_vector[i]);
+					Applicable_arguments_temp.push_back(argument);
 					break;
 
 				case SEXP_FALSE:
@@ -9690,7 +9743,7 @@ int test_argument_vector_for_condition(SCP_vector<char*> argument_vector, bool a
 
 				case SEXP_KNOWN_TRUE:
 					(*num_known_true)++;
-					Applicable_arguments_temp.push_back(argument_vector[i]);
+					Applicable_arguments_temp.push_back(argument);
 					break;
 
 				case SEXP_KNOWN_FALSE:
@@ -9701,7 +9754,7 @@ int test_argument_vector_for_condition(SCP_vector<char*> argument_vector, bool a
 			// if the argument was already dup'd, but not added as an applicable argument,
 			// we need to free it here before we cause a memory leak
 			if ((val == SEXP_FALSE || val == SEXP_KNOWN_FALSE) && already_dupped)
-				vm_free(argument_vector[i]);
+				vm_free(argument.first);
 
 			// clear argument, but not list, as we'll need it later
 			Sexp_replacement_arguments.pop_back();
@@ -9880,14 +9933,16 @@ int eval_random_of(int arg_handler_node, int condition_node, bool multiple)
 		flush_sexp_tree(condition_node);
 
 		// evaluate conditional for current argument
-		Sexp_replacement_arguments.push_back(Sexp_nodes[n].text);
+		Sexp_replacement_arguments.emplace_back(Sexp_nodes[n].text, n);
 		val = eval_sexp(condition_node);
 
 		// true?
 		if (val == SEXP_TRUE)
 		{
-			Sexp_applicable_argument_list.add_data(Sexp_nodes[n].text);
-		} else if ((!multiple || num_valid_args == 1) && (Sexp_nodes[condition_node].value == SEXP_KNOWN_FALSE || Sexp_nodes[condition_node].value == SEXP_NAN_FOREVER)) {
+			Sexp_applicable_argument_list.add_data(std::pair<char*, int>(Sexp_nodes[n].text, n));
+		}
+		else if ((!multiple || num_valid_args == 1) && (Sexp_nodes[condition_node].value == SEXP_KNOWN_FALSE || Sexp_nodes[condition_node].value == SEXP_NAN_FOREVER))
+		{
 			val = SEXP_KNOWN_FALSE;	// If we can't randomly pick another one and this one is guaranteed never to be true, then give up now.
 		}
 		
@@ -9931,14 +9986,16 @@ int eval_in_sequence(int arg_handler_node, int condition_node)
 		flush_sexp_tree(condition_node);
 
 		// evaluate conditional for current argument
-		Sexp_replacement_arguments.push_back(Sexp_nodes[n].text);
+		Sexp_replacement_arguments.emplace_back(Sexp_nodes[n].text, n);
 		val = eval_sexp(condition_node);
 
 		// true?
 		if (val == SEXP_TRUE)
 		{
-			Sexp_applicable_argument_list.add_data(Sexp_nodes[n].text);
-		} else if ((Sexp_nodes[condition_node].value == SEXP_KNOWN_FALSE) || (Sexp_nodes[condition_node].value == SEXP_NAN_FOREVER)) {
+			Sexp_applicable_argument_list.add_data(std::pair<char*, int>(Sexp_nodes[n].text, n));
+		}
+		else if ((Sexp_nodes[condition_node].value == SEXP_KNOWN_FALSE) || (Sexp_nodes[condition_node].value == SEXP_NAN_FOREVER))
+		{
 			val = SEXP_KNOWN_FALSE;	// If we're wasting our time evaluating this ever again, just go ahead and short-circuit.
 		}
 
@@ -9988,11 +10045,11 @@ int eval_for_counter(int arg_handler_node, int condition_node)
 	}
 
 	// build a vector of counter values
-	SCP_vector<char*> argument_vector;
+	SCP_vector<std::pair<char*, int>> argument_vector;
 	for (i = counter_start; ((counter_step > 0) ? i <= counter_stop : i >= counter_stop); i += counter_step)
 	{
 		sprintf(buf, "%d", i);
-		argument_vector.push_back(vm_strdup(buf));
+		argument_vector.emplace_back(vm_strdup(buf), -1);
 		// Note: we do not call vm_free() on the contents of argument_vector, and we don't for the very good
 		// reason that those pointers are then passed along by test_argument_vector_for_condition(), below.
 		// The strings will then be freed by arg_item::expunge() or arg_item::clear_nesting_level(), or even
@@ -23923,7 +23980,7 @@ void add_to_event_log_buffer(int op_num, int result)
 
 	if (True_loop_argument_sexps && !Sexp_replacement_arguments.empty()) {
 		tmp.append(" for argument ");
-		tmp.append(Sexp_replacement_arguments.back());
+		tmp.append(Sexp_replacement_arguments.back().first);
 	}
 	
 	if (!Current_event_log_argument_buffer->empty()) {
@@ -30015,14 +30072,29 @@ int query_sexp_ai_goal_valid(int sexp_ai_goal, int ship_num)
 	return ai_query_goal_valid(ship_num, Sexp_ai_goal_links[i].ai_goal);
 }
 
+int check_text_for_variable_name(const char *text)
+{
+	char variable_name[TOKEN_LENGTH];
+
+	// if the text is a variable name, get the variable index
+	int sexp_variable_index = get_index_sexp_variable_name(text);
+
+	// if the text is a formatted variable name, get the variable index
+	if (sexp_variable_index < 0 && text[0] == SEXP_VARIABLE_CHAR)
+	{
+		get_unformatted_sexp_variable_name(variable_name, text);
+		sexp_variable_index = get_index_sexp_variable_name(variable_name);
+	}
+
+	return sexp_variable_index;
+}
+
 /**
  * Wrapper around Sexp_node[xx].text for normal and variable
  */
 char *CTEXT(int n)
 {
 	int sexp_variable_index = -1;
-	char variable_name[TOKEN_LENGTH];
-	char *current_argument; 
 
 	Assertion(n >= 0 && n < Num_sexp_nodes, "Passed an out-of-range node index (%d) to CTEXT!", n);
 	if ( n < 0 || n >= Num_sexp_nodes ) {
@@ -30032,7 +30104,7 @@ char *CTEXT(int n)
 
 	// Goober5000 - MWAHAHAHAHAHAHAHA!  Thank you, Volition programmers!  Without
 	// the CTEXT wrapper, when-argument would probably be infeasibly difficult to code.
-	if (!strcmp(Sexp_nodes[n].text, SEXP_ARGUMENT_STRING))
+	if (Sexp_nodes[n].flags & SNF_SPECIAL_ARG_IN_NODE)
 	{
 		if (Fred_running)
 		{
@@ -30046,23 +30118,33 @@ char *CTEXT(int n)
 				return Sexp_nodes[n].text;
 		}
 
-		// if the replacement argument is a variable name, get the variable index
-		sexp_variable_index = get_index_sexp_variable_name(Sexp_replacement_arguments.back());
+		auto current_argument = Sexp_replacement_arguments.back();
+		auto text = current_argument.first;
 
-		current_argument = Sexp_replacement_arguments.back();
-
-		// if the replacement argument is a formatted variable name, get the variable index
-		if (current_argument[0] == SEXP_VARIABLE_CHAR)
+		// check referenced node for a variable
+		if (current_argument.second >= 0)
 		{
-			get_unformatted_sexp_variable_name(variable_name, current_argument);
-			sexp_variable_index = get_index_sexp_variable_name(variable_name);
+			int arg_n = current_argument.second;
+
+			if (!(Sexp_nodes[arg_n].flags & SNF_CHECKED_ARG_FOR_VAR))
+			{
+				Sexp_nodes[arg_n].cached_variable_index = check_text_for_variable_name(text);
+				Sexp_nodes[arg_n].flags |= SNF_CHECKED_ARG_FOR_VAR;
+			}
+
+			sexp_variable_index = Sexp_nodes[arg_n].cached_variable_index;
+		}
+		// just check the text of the argument for a variable
+		else
+		{
+			sexp_variable_index = check_text_for_variable_name(text);
 		}
 
 		// if we have a variable, return the variable value, else return the regular argument
-		if (sexp_variable_index != -1)
+		if (sexp_variable_index >= 0)
 			return Sexp_variables[sexp_variable_index].text;
 		else
-			return Sexp_replacement_arguments.back();
+			return text;
 	}
 
 	// Goober5000 - if not special argument, proceed as normal
@@ -32864,7 +32946,7 @@ SCP_vector<sexp_help_struct> Sexp_help = {
 		"vector of the point and the player, and the forward facing vector is within the "
 		"given angle.\r\n\r\n"
 		"Returns a boolean value.  Takes 2 argument...\r\n"
-		"\t1:\tShip to check is withing forward cone.\r\n"
+		"\t1:\tShip to check is within forward cone.\r\n"
 		"\t2:\tAngle in degrees of the forward cone." },
 
 	{ OP_IS_FACING, "Is Facing (Boolean training operator)\r\n"

--- a/code/parse/sexp.h
+++ b/code/parse/sexp.h
@@ -1103,8 +1103,10 @@ typedef struct sexp_node {
 // Goober5000
 #define SNF_ARGUMENT_VALID			(1<<0)
 #define SNF_ARGUMENT_SELECT			(1<<1)
-#define SNF_SPECIAL_ARG_IN_TREE		(1<<2)
-#define SNF_SPECIAL_ARG_NOT_IN_TREE	(1<<3)
+#define SNF_SPECIAL_ARG_IN_NODE		(1<<2)
+#define SNF_SPECIAL_ARG_IN_TREE		(1<<3)
+#define SNF_SPECIAL_ARG_NOT_IN_TREE	(1<<4)
+#define SNF_CHECKED_ARG_FOR_VAR		(1<<5)
 #define SNF_DEFAULT_VALUE			SNF_ARGUMENT_VALID
 
 typedef struct sexp_variable {
@@ -1120,15 +1122,18 @@ typedef struct sexp_variable {
 class arg_item
 {
 	public:
-		char *text;
-		arg_item *next;
-		int flags;
-		int nesting_level;
+		char *text = nullptr;
+		int node = -1;
 
-		arg_item() : text(NULL), next(NULL), flags(0), nesting_level(0) {}
-		void add_data(char *str);
-		void add_data_dup(char *str);
-		void add_data_set_dup(char *str);
+		arg_item *next = nullptr;
+		int flags = 0;
+		int nesting_level = 0;
+
+		arg_item() = default;
+
+		void add_data(const std::pair<char*, int> &data);
+		void add_data_dup(const std::pair<char*, int> &data);
+		void add_data_set_dup(const std::pair<char*, int> &data);
 		void expunge();
 		int is_empty();
 		arg_item *get_next();

--- a/code/parse/sexp.h
+++ b/code/parse/sexp.h
@@ -1115,32 +1115,6 @@ typedef struct sexp_variable {
 	char	variable_name[TOKEN_LENGTH];
 } sexp_variable;
 
-
-#define ARG_ITEM_F_DUP	(1<<0)
-
-// Goober5000 - adapted from sexp_list_item in Sexp_tree.h
-class arg_item
-{
-	public:
-		char *text = nullptr;
-		int node = -1;
-
-		arg_item *next = nullptr;
-		int flags = 0;
-		int nesting_level = 0;
-
-		arg_item() = default;
-
-		void add_data(const std::pair<char*, int> &data);
-		void add_data_dup(const std::pair<char*, int> &data);
-		void add_data_set_dup(const std::pair<char*, int> &data);
-		void expunge();
-		int is_empty();
-		arg_item *get_next();
-		void clear_nesting_level(); 
-};
-
-
 // next define used to eventually mark a directive as satisfied even though there may be more
 // waves for a wing.  bascially a hack for the directives display.
 #define DIRECTIVE_WING_ZERO		-999


### PR DESCRIPTION
When special arguments are used, the current node cannot be cached because it always contains `"<argument>"`.  So this feature adds the ability to forward the caching to the SEXP node that contains the value being referenced.  To enable this, the internal argument list now contains both the argument text and the node it comes from.  (If there is no node, such as with `for-counter` which generates its data dynamically, the reference will be -1.)

This also fixes a bug where values in certain `"<argument>"` nodes were incorrectly cached.