### PR TITLE
fix a couple things with mainhall intercom sounds

### DIFF
--- a/code/globalincs/pstypes.h
+++ b/code/globalincs/pstypes.h
@@ -350,7 +350,12 @@ const size_t INVALID_SIZE = static_cast<size_t>(-1);
 #define FALSE	0
 
 int myrand();
-int rand32(); // returns a random number between 0 and 0x7fffffff
+
+// Returns a random number between 0 and 0x7fffffff
+int rand32();
+
+// Returns a random integer from low to high, inclusive
+int rand32(int low, int high);
 
 
 // lod checker for (modular) table parsing

--- a/code/globalincs/systemvars.cpp
+++ b/code/globalincs/systemvars.cpp
@@ -136,6 +136,20 @@ int rand32()
 	}
 }
 
+int rand32(int low, int high)
+{
+	int diff;
+
+	// get diff - don't allow negative or zero
+	diff = high - low;
+	if (diff < 0)
+		diff = 0;
+
+	// To get a range of values between min and max, inclusive:
+	// random value = min + random number % (max - min + 1)
+	return (low + rand32() % (diff + 1));
+}
+
 // Variables for the loading callback hooks
 static int cf_timestamp = -1;
 static void (*cf_callback)(int count) = NULL;

--- a/code/hud/hudartillery.cpp
+++ b/code/hud/hudartillery.cpp
@@ -298,9 +298,7 @@ void ssm_create(object *target, vec3d *start, size_t ssm_index, ssm_firing_info 
 
 	count = Ssm_info[ssm_index].count;
 	if (Ssm_info[ssm_index].max_count != -1) {
-		// To get a range of values between min and max, inclusive:
-		// random value = min + randon number % (max - min + 1)
-		count += rand32() % (Ssm_info[ssm_index].max_count - count + 1);
+		count += rand32(count, Ssm_info[ssm_index].max_count);
 	}
 
 	// override in multiplayer

--- a/code/menuui/mainhallmenu.cpp
+++ b/code/menuui/mainhallmenu.cpp
@@ -434,6 +434,11 @@ void main_hall_init(const SCP_string &main_hall_name)
 		main_hall_to_load = main_hall_name;
 	}
 
+	// if we're switching to a different mainhall, stop the ambient (it will be started again promptly)
+	if (Main_hall && Main_hall->name != main_hall_to_load) {
+		main_hall_stop_ambient();
+	}
+
 	// if we're switching to a different mainhall we may need to change music
 	if (main_hall_get_music_index(main_hall_get_index(main_hall_to_load)) != Main_hall_music_index) {
 		main_hall_stop_music(true);

--- a/code/menuui/mainhallmenu.cpp
+++ b/code/menuui/mainhallmenu.cpp
@@ -1529,11 +1529,10 @@ void main_hall_handle_random_intercom_sounds()
 		return;
 	}
 
-	// if we have no timestamp for the next random sound, then set on
+	// if we have no timestamp for the next random sound, then set one
 	if ((Main_hall_next_intercom_sound_stamp == -1) && (!Main_hall_intercom_sound_handle.isValid())) {
-		Main_hall_next_intercom_sound_stamp = timestamp((int)((rand() * RAND_MAX_1f) * 
-			(float)(Main_hall->intercom_delay.at(Main_hall_next_intercom_sound).at(1) 
-				- Main_hall->intercom_delay.at(Main_hall_next_intercom_sound).at(0))) );
+		int delta_ms = rand32(Main_hall->intercom_delay.at(Main_hall_next_intercom_sound).at(0), Main_hall->intercom_delay.at(Main_hall_next_intercom_sound).at(1));
+		Main_hall_next_intercom_sound_stamp = timestamp(delta_ms);
 	}
 
 	// if the there is no sound playing
@@ -1570,9 +1569,8 @@ void main_hall_handle_random_intercom_sounds()
 			}
 
 			// set the timestamp
-			Main_hall_next_intercom_sound_stamp = timestamp((int)((rand() * RAND_MAX_1f) * 
-				(float)(Main_hall->intercom_delay.at(Main_hall_next_intercom_sound).at(1) 
-					- Main_hall->intercom_delay.at(Main_hall_next_intercom_sound).at(0))) );
+			int delta_ms = rand32(Main_hall->intercom_delay.at(Main_hall_next_intercom_sound).at(0), Main_hall->intercom_delay.at(Main_hall_next_intercom_sound).at(1));
+			Main_hall_next_intercom_sound_stamp = timestamp(delta_ms);
 
 			// release the sound handle
 			Main_hall_intercom_sound_handle = sound_handle::invalid();
@@ -1639,6 +1637,8 @@ void main_hall_start_ambient()
 	if (play_ambient_loop) {
 		Main_hall_ambient_loop = snd_play_looping(gamesnd_get_interface_sound(InterfaceSounds::MAIN_HALL_AMBIENT));
 	}
+
+	// no need to restart the intercom, since the game will set the timestamp for a new one
 }
 
 /**
@@ -1649,6 +1649,15 @@ void main_hall_stop_ambient()
 	if (Main_hall_ambient_loop.isValid()) {
 		snd_stop(Main_hall_ambient_loop);
 		Main_hall_ambient_loop = sound_handle::invalid();
+	}
+
+	// also stop any PA announcements
+	if (Main_hall_intercom_sound_handle.isValid()) {
+		snd_stop(Main_hall_intercom_sound_handle);
+		Main_hall_intercom_sound_handle = sound_handle::invalid();
+
+		// reset the timestamp so that the game will eventually pick a new intercom sound
+		Main_hall_next_intercom_sound_stamp = -1;
 	}
 }
 

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -4694,18 +4694,11 @@ int mod_sexps(int n)
 
 int rand_internal(int low, int high, int seed = 0)
 {
-	int diff;
-
 	// maybe seed it
 	if (seed > 0)
 		srand(seed);
 
-	// get diff - don't allow negative or zero
-	diff = high - low;
-	if (diff < 0)
-		diff = 0;
-
-	return (low + rand32() % (diff + 1));
+	return rand32(low, high);
 }
 
 // Goober5000


### PR DESCRIPTION
As noticed in issue #2458, intercom sounds did not stop when pausing the game or loading a mission.  I fixed this by augmenting `main_hall_stop_ambient()` to also stop the intercom.

Additionally, it turns out that the intercom delays were not being calculated correctly due to a very bizarre random number formula.  I overloaded `rand32()` to add a min/max variant and used this instead.