### PR TITLE
Add Large Radius Option as AI Flag for Following Subsystem Path Points

### DIFF
--- a/code/ai/ai_flags.h
+++ b/code/ai/ai_flags.h
@@ -122,7 +122,7 @@ namespace AI {
 		Support_dont_add_primaries, //Prevents support ship from equipping new primary as requested in http://scp.indiegames.us/mantis/view.php?id=3198
         Turrets_ignore_target_radius,
         Use_actual_primary_range,
-        Use_large_radii_for_subsystem_path_points,
+        Use_subsystem_path_point_radii,
         Use_additive_weapon_velocity,
         Use_newtonian_dampening,
         Use_only_single_fov_for_turrets,

--- a/code/ai/ai_flags.h
+++ b/code/ai/ai_flags.h
@@ -122,6 +122,7 @@ namespace AI {
 		Support_dont_add_primaries, //Prevents support ship from equipping new primary as requested in http://scp.indiegames.us/mantis/view.php?id=3198
         Turrets_ignore_target_radius,
         Use_actual_primary_range,
+        Use_large_path_radius,
         Use_additive_weapon_velocity,
         Use_newtonian_dampening,
         Use_only_single_fov_for_turrets,

--- a/code/ai/ai_flags.h
+++ b/code/ai/ai_flags.h
@@ -122,7 +122,7 @@ namespace AI {
 		Support_dont_add_primaries, //Prevents support ship from equipping new primary as requested in http://scp.indiegames.us/mantis/view.php?id=3198
         Turrets_ignore_target_radius,
         Use_actual_primary_range,
-        Use_large_path_radius,
+        Use_large_radii_for_subsystem_path_points,
         Use_additive_weapon_velocity,
         Use_newtonian_dampening,
         Use_only_single_fov_for_turrets,

--- a/code/ai/ai_profiles.cpp
+++ b/code/ai/ai_profiles.cpp
@@ -472,17 +472,17 @@ void parse_ai_profiles_tbl(const char *filename)
 
 				set_flag(profile, "$use actual primary range:", AI::Profile_Flags::Use_actual_primary_range);
 
-				if (optional_string("$constant radii for subsystem path points:")) {
+				if (optional_string("$override radius for subsystem path points:")) {
 					int path_radii;
 					stuff_int(&path_radii);
-					if (path_radii > 0) {
+					if (path_radii >= 1) {
 						profile->subsystem_path_radii = path_radii;
 					} else {
-						mprintf(("Warning: \"$constant radii for subsystem path points:\" should be greater than 0 (read %i). Value will not be used. ", path_radii));
+						mprintf(("Warning: \"$override radius for subsystem path points:\" should be greater than 1 (read %i). Value will not be used. ", path_radii));
 					}
 				}
 
-				set_flag(profile, "$use model path point radii for subsystem path navigation:", AI::Profile_Flags::Use_subsystem_path_point_radii);
+				set_flag(profile, "$use POF radius for subsystem path points:", AI::Profile_Flags::Use_subsystem_path_point_radii);
 
 				profile->bay_arrive_speed_mult = 1.0f;
 				profile->bay_depart_speed_mult = 1.0f;
@@ -584,6 +584,7 @@ void ai_profile_t::reset()
     flags.reset();
 
     ai_path_mode = 0;
+	subsystem_path_radii = 0;
     bay_arrive_speed_mult = 0;
     bay_depart_speed_mult = 0;
 

--- a/code/ai/ai_profiles.cpp
+++ b/code/ai/ai_profiles.cpp
@@ -475,7 +475,7 @@ void parse_ai_profiles_tbl(const char *filename)
 				if (optional_string("$constant radii for subsystem path points:")) {
 					int path_radii;
 					stuff_int(&path_radii);
-					if (path_radii) {
+					if (path_radii > 0) {
 						profile->subsystem_path_radii = path_radii;
 					} else {
 						mprintf(("Warning: \"$constant radii for subsystem path points:\" should be greater than 0 (read %i). Value will not be used. ", path_radii));

--- a/code/ai/ai_profiles.cpp
+++ b/code/ai/ai_profiles.cpp
@@ -8,6 +8,7 @@
 
 
 #include "ai/ai_profiles.h"
+#include "ai/aibig.h"
 #include "def_files/def_files.h"
 #include "globalincs/pstypes.h"
 #include "localization/localize.h"
@@ -475,10 +476,10 @@ void parse_ai_profiles_tbl(const char *filename)
 				if (optional_string("$override radius for subsystem path points:")) {
 					int path_radii;
 					stuff_int(&path_radii);
-					if (path_radii >= 1) {
+					if (path_radii >= Minimum_subsystem_path_pt_dist) {
 						profile->subsystem_path_radii = path_radii;
 					} else {
-						mprintf(("Warning: \"$override radius for subsystem path points:\" should be >= 1 (read %i). Value will not be used. ", path_radii));
+						mprintf(("Warning: \"$override radius for subsystem path points:\" should be >= %i (read %i). Value will not be used. ", Minimum_subsystem_path_pt_dist, path_radii));
 					}
 				}
 

--- a/code/ai/ai_profiles.cpp
+++ b/code/ai/ai_profiles.cpp
@@ -472,6 +472,8 @@ void parse_ai_profiles_tbl(const char *filename)
 
 				set_flag(profile, "$use actual primary range:", AI::Profile_Flags::Use_actual_primary_range);
 
+				set_flag(profile, "$use model path radius:", AI::Profile_Flags::Use_large_path_radius);
+
 				profile->bay_arrive_speed_mult = 1.0f;
 				profile->bay_depart_speed_mult = 1.0f;
 				if (optional_string("$bay arrive speed multiplier:")) {

--- a/code/ai/ai_profiles.cpp
+++ b/code/ai/ai_profiles.cpp
@@ -472,7 +472,7 @@ void parse_ai_profiles_tbl(const char *filename)
 
 				set_flag(profile, "$use actual primary range:", AI::Profile_Flags::Use_actual_primary_range);
 
-				set_flag(profile, "$use model path radius:", AI::Profile_Flags::Use_large_path_radius);
+				set_flag(profile, "$use large path radius:", AI::Profile_Flags::Use_large_path_radius);
 
 				profile->bay_arrive_speed_mult = 1.0f;
 				profile->bay_depart_speed_mult = 1.0f;

--- a/code/ai/ai_profiles.cpp
+++ b/code/ai/ai_profiles.cpp
@@ -472,7 +472,7 @@ void parse_ai_profiles_tbl(const char *filename)
 
 				set_flag(profile, "$use actual primary range:", AI::Profile_Flags::Use_actual_primary_range);
 
-				set_flag(profile, "$use large path radius:", AI::Profile_Flags::Use_large_path_radius);
+				set_flag(profile, "$use large radii for subsytem path points:", AI::Profile_Flags::Use_large_radii_for_subsystem_path_points);
 
 				profile->bay_arrive_speed_mult = 1.0f;
 				profile->bay_depart_speed_mult = 1.0f;

--- a/code/ai/ai_profiles.cpp
+++ b/code/ai/ai_profiles.cpp
@@ -478,7 +478,7 @@ void parse_ai_profiles_tbl(const char *filename)
 					if (path_radii >= 1) {
 						profile->subsystem_path_radii = path_radii;
 					} else {
-						mprintf(("Warning: \"$override radius for subsystem path points:\" should be greater than 1 (read %i). Value will not be used. ", path_radii));
+						mprintf(("Warning: \"$override radius for subsystem path points:\" should be >= 1 (read %i). Value will not be used. ", path_radii));
 					}
 				}
 

--- a/code/ai/ai_profiles.cpp
+++ b/code/ai/ai_profiles.cpp
@@ -478,7 +478,7 @@ void parse_ai_profiles_tbl(const char *filename)
 					if (path_radii) {
 						profile->subsystem_path_radii = path_radii;
 					} else {
-						mprintf(("Warning: \"$constant radii for subsystem path points:\" should be greater than 0 (read %i). Value will not be used. "));
+						mprintf(("Warning: \"$constant radii for subsystem path points:\" should be greater than 0 (read %i). Value will not be used. ", path_radii));
 					}
 				}
 

--- a/code/ai/ai_profiles.cpp
+++ b/code/ai/ai_profiles.cpp
@@ -472,7 +472,17 @@ void parse_ai_profiles_tbl(const char *filename)
 
 				set_flag(profile, "$use actual primary range:", AI::Profile_Flags::Use_actual_primary_range);
 
-				set_flag(profile, "$use large radii for subsytem path points:", AI::Profile_Flags::Use_large_radii_for_subsystem_path_points);
+				if (optional_string("$constant radii for subsystem path points:")) {
+					int path_radii;
+					stuff_int(&path_radii);
+					if (path_radii) {
+						profile->subsystem_path_radii = path_radii;
+					} else {
+						mprintf(("Warning: \"$constant radii for subsystem path points:\" should be greater than 0 (read %i). Value will not be used. "));
+					}
+				}
+
+				set_flag(profile, "$use model path point radii for subsystem path navigation:", AI::Profile_Flags::Use_subsystem_path_point_radii);
 
 				profile->bay_arrive_speed_mult = 1.0f;
 				profile->bay_depart_speed_mult = 1.0f;

--- a/code/ai/ai_profiles.h
+++ b/code/ai/ai_profiles.h
@@ -97,6 +97,9 @@ public:
 
 	int ai_path_mode;
 
+	// radii to use for the radius for subsystem path points and default value --wookieejedi
+	int subsystem_path_radii;
+
 	// Ships flying bay paths will gradually accelerate/decelerate instead of
 	// flying the whole path at max speed
 	float bay_arrive_speed_mult;

--- a/code/ai/aibig.cpp
+++ b/code/ai/aibig.cpp
@@ -464,7 +464,7 @@ int ai_big_maybe_follow_subsys_path(int do_dot_check)
 				path_done=1;
 			} else {
 				// if not done check what magnitude of distance to use --wookieejedi
-				if (aip->ai_profile_flags[AI::Profile_Flags::Use_large_path_radius]) {
+				if (aip->ai_profile_flags[AI::Profile_Flags::Use_large_radii_for_subsystem_path_points]) {
 					// use large distance
 					aip->path_goal_dist = 775;
 				} else {
@@ -472,7 +472,7 @@ int ai_big_maybe_follow_subsys_path(int do_dot_check)
 					aip->path_goal_dist = 5;
 				}
 			}
-
+			mprintf(("dragon: aip->path_goal_dist: %i ...\n", aip->path_goal_dist));
 			min_dot = (target_objp->phys_info.fspeed > 5.0f?MIN_DOT_TO_ATTACK_MOVING_SUBSYS:MIN_DOT_TO_ATTACK_SUBSYS);
 			if ( (checked_sight && subsys_in_sight) && (dot > min_dot) ) {
 				in_view=1;

--- a/code/ai/aibig.cpp
+++ b/code/ai/aibig.cpp
@@ -431,7 +431,6 @@ int ai_big_maybe_follow_subsys_path(int do_dot_check)
 		min_dot = (target_objp->phys_info.fspeed > 5.0f?MIN_DOT_TO_ATTACK_MOVING_SUBSYS:MIN_DOT_TO_ATTACK_SUBSYS);
 		if ( (checked_sight && ((!subsys_in_sight) || (dot < min_dot)) ) )  {
 
-			aip->path_goal_dist = 5;
 			subsys_path_num = aip->targeted_subsys->system_info->path_num;
 			if ( ((aip->path_start) == -1 || (aip->mp_index != subsys_path_num)) && subsys_path_num < pm_t->n_paths ) {
 				// maybe create a new path
@@ -463,6 +462,15 @@ int ai_big_maybe_follow_subsys_path(int do_dot_check)
 
 			if ( aip->path_cur >= (aip->path_start+aip->path_length-1) ) {
 				path_done=1;
+			} else {
+				// if not done check what magnitude of distance to use --wookieejedi
+				if (aip->ai_profile_flags[AI::Profile_Flags::Use_large_path_radius]) {
+					// use large distance
+					aip->path_goal_dist = 775;
+				} else {
+					// use default distance
+					aip->path_goal_dist = 5;
+				}
 			}
 
 			min_dot = (target_objp->phys_info.fspeed > 5.0f?MIN_DOT_TO_ATTACK_MOVING_SUBSYS:MIN_DOT_TO_ATTACK_SUBSYS);

--- a/code/ai/aibig.cpp
+++ b/code/ai/aibig.cpp
@@ -456,20 +456,44 @@ int ai_big_maybe_follow_subsys_path(int do_dot_check)
 		if ( aip->path_length > 0 ) {
 			int path_done=0;
 			int in_view=0;
+			int default_dist = 5;
 
 			Assert(aip->path_length >= 2);
 			dist = vm_vec_dist_quick(&Path_points[aip->path_start+aip->path_length-2].pos, &Pl_objp->pos);
 
+			// distance setting --wookieejedi
 			if ( aip->path_cur >= (aip->path_start+aip->path_length-1) ) {
+				// register that path is done and reset goal distance to default
+				aip->path_goal_dist = default_dist;
 				path_done=1;
-			} else {
-				// if not done check what magnitude of distance to use --wookieejedi
-				if (aip->ai_profile_flags[AI::Profile_Flags::Use_large_radii_for_subsystem_path_points]) {
-					// use large distance
-					aip->path_goal_dist = 775;
-				} else {
-					// use default distance
-					aip->path_goal_dist = 5;
+			}
+			// if not done then set path distances based on specified options
+			else {
+				bool found_point = false;
+				// 1. use radii of path points if specified
+				if (aip->ai_profile_flags[AI::Profile_Flags::Use_subsystem_path_point_radii]) {
+					// need a valid path and point in model to use pof specified radius
+					int path_num = aip->targeted_subsys->system_info->path_num;
+					if ((0 <= path_num) && (path_num <= pm_t->n_paths)) {
+						// need a valid place in the path
+						if ((0 <= aip->path_cur) && (aip->path_cur <= aip->path_length)) {
+							float path_point_radius = pm_t->paths[path_num].verts[aip->path_cur].radius;
+							int goal_dist = fl2i(path_point_radius);
+							// only set if > 0
+							if (goal_dist) {
+								aip->path_goal_dist = goal_dist;
+								found_point = true;
+							}
+						}
+					}
+				}
+				// 2. use radii value in ai_profiles table if specified and no valid point found
+				if (!found_point && The_mission.ai_profile->subsystem_path_radii) {
+					aip->path_goal_dist = The_mission.ai_profile->subsystem_path_radii;
+				}
+				// 3. use default radii value if no valid point or specified radii
+				else {
+					aip->path_goal_dist = default_dist;
 				}
 			}
 

--- a/code/ai/aibig.cpp
+++ b/code/ai/aibig.cpp
@@ -456,7 +456,6 @@ int ai_big_maybe_follow_subsys_path(int do_dot_check)
 		if ( aip->path_length > 0 ) {
 			int path_done=0;
 			int in_view=0;
-			int default_dist = 5;
 
 			Assert(aip->path_length >= 2);
 			dist = vm_vec_dist_quick(&Path_points[aip->path_start+aip->path_length-2].pos, &Pl_objp->pos);
@@ -464,7 +463,7 @@ int ai_big_maybe_follow_subsys_path(int do_dot_check)
 			// distance setting --wookieejedi
 			if ( aip->path_cur >= (aip->path_start+aip->path_length-1) ) {
 				// register that path is done and reset goal distance to default
-				aip->path_goal_dist = default_dist;
+				aip->path_goal_dist = Default_subsystem_path_pt_dist;
 				path_done=1;
 			}
 			// if not done then set path distances based on specified options
@@ -479,8 +478,8 @@ int ai_big_maybe_follow_subsys_path(int do_dot_check)
 						if ((0 <= aip->path_cur) && (aip->path_cur < aip->path_length)) {
 							float path_point_radius = pm_t->paths[path_num].verts[aip->path_cur].radius;
 							int goal_dist = fl2i(path_point_radius);
-							// only set if > 0
-							if (goal_dist > 0) {
+							// only set if > 1
+							if (goal_dist >= 1) {
 								aip->path_goal_dist = goal_dist;
 								found_point = true;
 							}
@@ -493,7 +492,7 @@ int ai_big_maybe_follow_subsys_path(int do_dot_check)
 				}
 				// 3. use default radii value if no valid point or specified radii
 				else {
-					aip->path_goal_dist = default_dist;
+					aip->path_goal_dist = Default_subsystem_path_pt_dist;
 				}
 			}
 

--- a/code/ai/aibig.cpp
+++ b/code/ai/aibig.cpp
@@ -472,7 +472,7 @@ int ai_big_maybe_follow_subsys_path(int do_dot_check)
 					aip->path_goal_dist = 5;
 				}
 			}
-			mprintf(("dragon: aip->path_goal_dist: %i ...\n", aip->path_goal_dist));
+
 			min_dot = (target_objp->phys_info.fspeed > 5.0f?MIN_DOT_TO_ATTACK_MOVING_SUBSYS:MIN_DOT_TO_ATTACK_SUBSYS);
 			if ( (checked_sight && subsys_in_sight) && (dot > min_dot) ) {
 				in_view=1;

--- a/code/ai/aibig.cpp
+++ b/code/ai/aibig.cpp
@@ -478,7 +478,7 @@ int ai_big_maybe_follow_subsys_path(int do_dot_check)
 						if ((0 <= aip->path_cur) && (aip->path_cur < aip->path_length)) {
 							float path_point_radius = pm_t->paths[path_num].verts[aip->path_cur].radius;
 							int goal_dist = fl2i(path_point_radius);
-							// only set if > 1
+							// only set if >= 1
 							if (goal_dist >= 1) {
 								aip->path_goal_dist = goal_dist;
 								found_point = true;

--- a/code/ai/aibig.cpp
+++ b/code/ai/aibig.cpp
@@ -474,13 +474,13 @@ int ai_big_maybe_follow_subsys_path(int do_dot_check)
 				if (aip->ai_profile_flags[AI::Profile_Flags::Use_subsystem_path_point_radii]) {
 					// need a valid path and point in model to use pof specified radius
 					int path_num = aip->targeted_subsys->system_info->path_num;
-					if ((0 <= path_num) && (path_num <= pm_t->n_paths)) {
+					if ((0 <= path_num) && (path_num < pm_t->n_paths)) {
 						// need a valid place in the path
-						if ((0 <= aip->path_cur) && (aip->path_cur <= aip->path_length)) {
+						if ((0 <= aip->path_cur) && (aip->path_cur < aip->path_length)) {
 							float path_point_radius = pm_t->paths[path_num].verts[aip->path_cur].radius;
 							int goal_dist = fl2i(path_point_radius);
 							// only set if > 0
-							if (goal_dist) {
+							if (goal_dist > 0) {
 								aip->path_goal_dist = goal_dist;
 								found_point = true;
 							}

--- a/code/ai/aibig.cpp
+++ b/code/ai/aibig.cpp
@@ -478,8 +478,8 @@ int ai_big_maybe_follow_subsys_path(int do_dot_check)
 						if ((0 <= aip->path_cur) && (aip->path_cur < aip->path_length)) {
 							float path_point_radius = pm_t->paths[path_num].verts[aip->path_cur].radius;
 							int goal_dist = fl2i(path_point_radius);
-							// only set if >= 1
-							if (goal_dist >= 1) {
+							// only set if >= Minimum path distance specified in aibig.h
+							if (goal_dist >= Minimum_subsystem_path_pt_dist) {
 								aip->path_goal_dist = goal_dist;
 								found_point = true;
 							}

--- a/code/ai/aibig.h
+++ b/code/ai/aibig.h
@@ -27,6 +27,9 @@ void	ai_big_strafe_maybe_attack_turret(const object *ship_objp, const object *we
 void ai_big_pick_attack_point(object *objp, object *attacker_objp, vec3d *attack_point, float fov=1.0f);
 void ai_big_pick_attack_point_turret(object *objp, ship_subsys *ssp, vec3d *gpos, vec3d *gvec, vec3d *attack_point, float weapon_travel_dist, float fov=1.0f);
 
+// default distance for following subsystem path points --wookieejedi
+// the value is 5 because that was the original value specified in ai_big_maybe_follow_subsys_path()
+const int Default_subsystem_path_pt_dist = 5;
 
 #endif
 

--- a/code/ai/aibig.h
+++ b/code/ai/aibig.h
@@ -30,6 +30,7 @@ void ai_big_pick_attack_point_turret(object *objp, ship_subsys *ssp, vec3d *gpos
 // default distance for following subsystem path points --wookieejedi
 // the value is 5 because that was the original value specified in ai_big_maybe_follow_subsys_path()
 const int Default_subsystem_path_pt_dist = 5;
+const int Minimum_subsystem_path_pt_dist = 1;
 
 #endif
 


### PR DESCRIPTION
Previously, the default distance for determining if a ship had finished a point in a model subsystem path was only 5. This worked fine for ships with low damp or no Newtonian physics. However, it did not work well with ships that use higher damps or Newtonian physics, because those ships continually overshoot that 5 meter distance and get stuck flying in a large circle trying to reach that point. This fix allows modders to set an AI flag to specify that the path distance check uses a larger value of 775 for points that are not the last point in the path. The value of 775 was chosen because it seemed like the average value that PCS2 made for path points when they were autogenerated. If desired I can add a game settings option that allows modders to set this value.

I did not use the radius in the POF model for the paths because the game will create a new path if none exist, thus a more global method is needed to ensure the distance is large. Also, this method was much more efficient for modders, because they do not have to set every single radius in their model. 

Also note that `aip->path_goal_dist` is only used for following points in a path for a subsystem. It is not used for bay arrivals or departures, waypoints, or docking. 