### PR TITLE
Add support for libRocket command briefing

### DIFF
--- a/code/graphics/generic.cpp
+++ b/code/graphics/generic.cpp
@@ -158,14 +158,11 @@ int generic_anim_stream(generic_anim *ga, const bool cache)
 {
 	CFILE *img_cfp = NULL;
 	int anim_fps = 0;
-	const int NUM_TYPES = 3;
-	const ubyte type_list[NUM_TYPES] = {BM_TYPE_EFF, BM_TYPE_ANI, BM_TYPE_PNG};
-	const char *ext_list[NUM_TYPES] = {".eff", ".ani", ".png"};
 	int bpp;
 
 	ga->type = BM_TYPE_NONE;
 
-	auto res = cf_find_file_location_ext(ga->filename, NUM_TYPES, ext_list, CF_TYPE_ANY, false);
+	auto res = cf_find_file_location_ext(ga->filename, BM_ANI_NUM_TYPES, bm_ani_ext_list, CF_TYPE_ANY, false);
 
 	// could not be found, or is invalid for some reason
 	if ( !res.found )
@@ -178,8 +175,8 @@ int generic_anim_stream(generic_anim *ga, const bool cache)
 		return -1;
 	}
 
-	strcat_s(ga->filename, ext_list[res.extension_index]);
-	ga->type = type_list[res.extension_index];
+	strcat_s(ga->filename, bm_ani_ext_list[res.extension_index]);
+	ga->type = bm_ani_type_list[res.extension_index];
 	//seek to the end
 	cfseek(img_cfp, 0, CF_SEEK_END);
 

--- a/code/graphics/generic.h
+++ b/code/graphics/generic.h
@@ -43,7 +43,7 @@ typedef struct generic_anim {
 			float previous_frame_time;
 		} png;
 	};
-	ubyte type;
+	BM_TYPE type;
 	unsigned char streaming;
 	ubyte *buffer;
 	int height;

--- a/code/missionui/missioncmdbrief.h
+++ b/code/missionui/missioncmdbrief.h
@@ -16,6 +16,8 @@
 
 #include "globalincs/globals.h"
 #include "globalincs/pstypes.h"
+
+#include "graphics/2d.h"
 #include "graphics/generic.h"
 
 struct anim;

--- a/code/scpui/RocketRenderingInterface.h
+++ b/code/scpui/RocketRenderingInterface.h
@@ -3,7 +3,9 @@
 //
 
 #include "globalincs/pstypes.h"
+
 #include "graphics/2d.h"
+#include "graphics/generic.h"
 
 // Our Assert conflicts with the definitions inside libRocket
 #pragma push_macro("Assert")
@@ -13,14 +15,16 @@
 
 #pragma pop_macro("Assert")
 
-#include <memory>
-
 namespace scpui {
 
 class RocketRenderingInterface : public Rocket::Core::RenderInterface {
 	struct Texture {
-		int handle    = -1;
-		int frame_num = 0;
+		bool is_animation = false;
+
+		generic_anim animation;
+
+		int bm_handle = -1;
+
 		std::unique_ptr<uint8_t[]> data;
 	};
 
@@ -135,11 +139,11 @@ class RocketRenderingInterface : public Rocket::Core::RenderInterface {
 	static int getBitmapNum(Rocket::Core::TextureHandle handle);
 
 	/**
-	 * @brief Sets the animation frame that the TextureHandle will use when it's rendered
+	 * @brief Advances an animation by the specified amount of seconds
 	 * @param handle The libRocket texture handle to modify
-	 * @param frame The animation frame (0-based for the first frame)
+	 * @param advanceTime The time to advance the animation by
 	 */
-	static void setAnimationFrame(Rocket::Core::TextureHandle handle, int frame);
+	static void advanceAnimation(Rocket::Core::TextureHandle handle, float advanceTime);
 };
 
 } // namespace scpui

--- a/code/scpui/elements/AnimationElement.h
+++ b/code/scpui/elements/AnimationElement.h
@@ -66,8 +66,7 @@ class AnimationElement : public Rocket::Core::Element {
 	Geometry geometry;
 	bool geometry_dirty;
 
-	float animation_start_time  = -1.f;
-	int current_animation_frame = -1;
+	float animation_last_update_time = -1.0f;
 };
 
 } // namespace elements

--- a/code/scripting/ade_args.cpp
+++ b/code/scripting/ade_args.cpp
@@ -110,10 +110,14 @@ void set_single_arg(lua_State* L, char fmt, const char* s)
 	lua_pushstring(L, s);
 }
 
-void set_single_arg(lua_State* L, char fmt, luacpp::LuaTable* table)
+void set_single_arg(lua_State* L, char fmt, const SCP_string& s)
 {
-	set_single_arg(L, fmt, *table);
+	Assertion(fmt == 's', "Invalid format character '%c' for string type!", fmt);
+	// WMC - Isn't working with HookVar for some strange reason
+	lua_pushlstring(L, s.c_str(), s.size());
 }
+
+void set_single_arg(lua_State* L, char fmt, luacpp::LuaTable* table) { set_single_arg(L, fmt, *table); }
 void set_single_arg(lua_State* L, char fmt, const luacpp::LuaTable& table)
 {
 	Assertion(fmt == 't', "Invalid format character '%c' for table type!", fmt);

--- a/code/scripting/ade_args.h
+++ b/code/scripting/ade_args.h
@@ -291,6 +291,7 @@ set_single_arg(lua_State* L, char fmt, T i)
 	}
 }
 void set_single_arg(lua_State* L, char fmt, const char* s);
+void set_single_arg(lua_State* L, char fmt, const SCP_string& s);
 template<typename T>
 void set_single_arg(lua_State* L, char fmt, ade_odata_setter<T>&& od)
 {

--- a/code/scripting/api/libs/ui.cpp
+++ b/code/scripting/api/libs/ui.cpp
@@ -12,6 +12,7 @@
 #include "playerman/managepilot.h"
 #include "scpui/SoundPlugin.h"
 #include "scpui/rocket_ui.h"
+#include "scripting/api/objs/cmd_brief.h"
 #include "scripting/api/objs/player.h"
 #include "scripting/lua/LuaTable.h"
 
@@ -367,6 +368,26 @@ ADE_FUNC(resetCampaign,
 	campaign_reset(filename);
 
 	return ADE_RETURN_TRUE;
+}
+
+//**********SUBLIBRARY: UserInterface/CommandBriefing
+// This needs a slightly different name since there is already a type called "Options"
+ADE_LIB_DERIV(l_UserInterface_CmdBrief,
+	"CommandBriefing",
+	nullptr,
+	"API for accessing data related to the command briefing UI.<br><b>Warning:</b> This is an internal "
+	"API for the new UI system. This should not be used by other code and may be removed in the future!",
+	l_UserInterface);
+
+ADE_FUNC(getBriefing,
+	l_UserInterface_CmdBrief,
+	nullptr,
+	"Get the command briefing.",
+	"cmd_briefing",
+	"The briefing data")
+{
+	// The cmd briefing code has support for specifying the team but only sets the index to 0
+	return ade_set_args(L, "o", l_CmdBrief.Set(Cmd_briefs[0]));
 }
 
 } // namespace api

--- a/code/scripting/api/objs/cmd_brief.cpp
+++ b/code/scripting/api/objs/cmd_brief.cpp
@@ -1,0 +1,98 @@
+
+#include "cmd_brief.h"
+
+namespace scripting {
+namespace api {
+
+//**********HANDLE: cmd_briefing
+ADE_OBJ(l_CmdBriefStage, cmd_brief_stage, "cmd_briefing_stage", "Command briefing stage handle");
+
+ADE_VIRTVAR(Text, l_CmdBriefStage, nullptr, "The text of the stage", "cmd_briefing_stage", "The text")
+{
+	cmd_brief_stage* stage = nullptr;
+	if (!ade_get_args(L, "o", l_CmdBriefStage.GetPtr(&stage))) {
+		return ADE_RETURN_NIL;
+	}
+
+	if (ADE_SETTING_VAR) {
+		LuaError(L, "This property is read only.");
+	}
+
+	return ade_set_args(L, "s", stage->text);
+}
+
+ADE_VIRTVAR(AniFilename,
+	l_CmdBriefStage,
+	nullptr,
+	"The filename of the animation to play",
+	"cmd_briefing_stage",
+	"The file name")
+{
+	cmd_brief_stage* stage = nullptr;
+	if (!ade_get_args(L, "o", l_CmdBriefStage.GetPtr(&stage))) {
+		return ADE_RETURN_NIL;
+	}
+
+	if (ADE_SETTING_VAR) {
+		LuaError(L, "This property is read only.");
+	}
+
+	return ade_set_args(L, "s", stage->ani_filename);
+}
+
+ADE_VIRTVAR(AudioFilename,
+	l_CmdBriefStage,
+	nullptr,
+	"The filename of the audio file to play",
+	"cmd_briefing_stage",
+	"The file name")
+{
+	cmd_brief_stage* stage = nullptr;
+	if (!ade_get_args(L, "o", l_CmdBriefStage.GetPtr(&stage))) {
+		return ADE_RETURN_NIL;
+	}
+
+	if (ADE_SETTING_VAR) {
+		LuaError(L, "This property is read only.");
+	}
+
+	return ade_set_args(L, "s", stage->wave_filename);
+}
+
+//**********HANDLE: cmd_briefing
+ADE_OBJ(l_CmdBrief, cmd_brief, "cmd_briefing", "Command briefing handle");
+
+ADE_INDEXER(l_CmdBrief,
+	"number index",
+	"The list of stages in the command briefing.",
+	"cmd_briefing_stage",
+	"The stage at the specified location.")
+{
+	cmd_brief* brief = nullptr;
+	int index        = -1;
+	if (!ade_get_args(L, "oi", l_CmdBrief.GetPtr(&brief), &index)) {
+		return ADE_RETURN_NIL;
+	}
+
+	--index;
+
+	if (index < 0 || index >= brief->num_stages) {
+		LuaError(L, "Invalid index %d, only have %d entries.", index + 1, brief->num_stages);
+		return ADE_RETURN_NIL;
+	}
+
+	return ade_set_args(L, "o", l_CmdBriefStage.Set(brief->stage[index]));
+}
+
+ADE_FUNC(__len, l_CmdBrief, nullptr, "The number of stages in the command briefing", "number", "The number of stages.")
+{
+	cmd_brief* brief = nullptr;
+	if (!ade_get_args(L, "o", l_CmdBrief.GetPtr(&brief))) {
+		return ADE_RETURN_NIL;
+	}
+
+	return ade_set_args(L, "i", brief->num_stages);
+}
+
+} // namespace api
+} // namespace scripting

--- a/code/scripting/api/objs/cmd_brief.h
+++ b/code/scripting/api/objs/cmd_brief.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "missionui/missioncmdbrief.h"
+#include "scripting/ade_api.h"
+
+namespace scripting {
+namespace api {
+
+DECLARE_ADE_OBJ(l_CmdBriefStage, cmd_brief_stage);
+
+DECLARE_ADE_OBJ(l_CmdBrief, cmd_brief);
+
+} // namespace api
+} // namespace scripting

--- a/code/source_groups.cmake
+++ b/code/source_groups.cmake
@@ -1135,6 +1135,8 @@ add_file_folder("Scripting\\\\Api\\\\Objs"
 	scripting/api/objs/beam.h
 	scripting/api/objs/camera.cpp
 	scripting/api/objs/camera.h
+	scripting/api/objs/cmd_brief.cpp
+	scripting/api/objs/cmd_brief.h
 	scripting/api/objs/cockpit_display.cpp
 	scripting/api/objs/cockpit_display.h
 	scripting/api/objs/control_info.cpp


### PR DESCRIPTION
This adds access to the command briefing data parsed from the mission
file to the scripting API so it can be used by the UI scripts for the
high res UI.

Also switches the animation support to using the generic anim to use
streaming to improve performance.