### PR TITLE
Add Expanded Option of Smart Primary Selection

### DIFF
--- a/code/ai/ai_flags.h
+++ b/code/ai/ai_flags.h
@@ -115,6 +115,7 @@ namespace AI {
         Shockwaves_damage_small_ship_subsystems,
         Smart_afterburner_management,
         Smart_primary_weapon_selection,
+		Use_full_check_primary_selection,
         Smart_secondary_weapon_selection,
         Smart_shield_management,
         Smart_subsystem_targeting_for_turrets,

--- a/code/ai/ai_profiles.cpp
+++ b/code/ai/ai_profiles.cpp
@@ -352,6 +352,8 @@ void parse_ai_profiles_tbl(const char *filename)
 
 				set_flag(profile, "$smart primary weapon selection:", AI::Profile_Flags::Smart_primary_weapon_selection);
 
+				set_flag(profile, "$use full checks for smart primary weapon selection:", AI::Profile_Flags::Use_full_check_primary_selection);
+
 				set_flag(profile, "$smart secondary weapon selection:", AI::Profile_Flags::Smart_secondary_weapon_selection);
 
 				set_flag(profile, "$smart shield management:", AI::Profile_Flags::Smart_shield_management);

--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -5404,9 +5404,7 @@ int ai_select_primary_weapon(object *objp, object *other_objp, Weapon::Info_Flag
 				
 				// also account for shockwave damage
 				float armor_damage_shockwave = 0;
-				bool use_shockwave = false;
 				if (wip->shockwave.inner_rad > 0.0f) {
-					use_shockwave = true;
 					armor_damage_shockwave = wip->shockwave.damage;
 				}
 

--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -5430,12 +5430,12 @@ int ai_select_primary_weapon(object *objp, object *other_objp, Weapon::Info_Flag
 				// check shields
 				if (is_target_shielded) 
 				{
-					// 1A. if shields, get shield damage and account for shield armor and puncture
+					// 1A. if shields, get shield damage and account for shield armor and piercing
 					float shield_damage = (wip->shield_factor) * (wip->damage);
 					int shield_armor_type = other_shipp->shield_armor_type_idx;
 					shield_damage = Armor_types[shield_armor_type].GetDamage(shield_damage, wip->damage_type_idx, 1.0f, 0);
 
-					// 1B. check puncture and get pierce damage
+					// 1B. get and check pierce damage
 					int pierce_damage = 0;
 					float piercing_pct = Armor_types[shield_armor_type].GetShieldPiercePCT(wip->damage_type_idx);
 					if (piercing_pct > 0.0f) {
@@ -5448,6 +5448,9 @@ int ai_select_primary_weapon(object *objp, object *other_objp, Weapon::Info_Flag
 						} else {
 							final_damage = shield_damage;
 						}
+					}
+					else {
+						final_damage = shield_damage;
 					}
 
 				} else {

--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -5378,14 +5378,9 @@ int ai_select_primary_weapon(object *objp, object *other_objp, Weapon::Info_Flag
 		// variables to track
 		float i_factor_prev = 0;		// Previous weapon bank factor (this is the safe way to do it)
 		int i_factor_prev_bank = -1;	// Bank which gave us this factor
-		bool is_target_shielded;
 
 		// determine if shielded as bool, that way the primary check loop only runs once
-		if (enemy_remaining_shield >= 0.05f) {
-			is_target_shielded = true;
-		} else {
-			is_target_shielded = false;
-		}
+		bool is_target_shielded = (enemy_remaining_shield >= 0.05f);
 
 		// Find the weapon with the best damage for the situation
 		for (int i = 0; i < swp->num_primary_banks; i++)


### PR DESCRIPTION
With gradual code changes with adding armor values, it seems that primary selection was never updated to take those into account (nor did it include checks to the subsystem or shockwaves). This makes AI not really choose the best weapon for a situation if armor tables are used heavily to determine balance. This PR adds an updated logic in `ai_select_primary_weapon` along with an `ai_profiles` flag to turn it on. I'd also be open to allowing the threshold values used in the function as settable for the modder in `ai_profiles`.