### PR TITLE
fix exited ship mismatch

### DIFF
--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -8521,8 +8521,8 @@ int sexp_get_damage_caused(int node)
 		}
 
 		// this ship may have exited already.
-		if (ship_entry->exited_index >= 0) {
-			attacker_sig = Ships_exited[ship_entry->exited_index].obj_signature;
+		if (attacker->exited_index >= 0) {
+			attacker_sig = Ships_exited[attacker->exited_index].obj_signature;
 		} else {
 			attacker_sig = attacker->objp->signature;
 		}


### PR DESCRIPTION
Due to a copy+paste error, the `get-damage-caused` sexp referred to the wrong exited ship.

This fixes #2501.