### PR TITLE
Add Shield and Weapon Regen Rates to Ship Object and Expose to Scripting

### DIFF
--- a/code/hud/hudets.cpp
+++ b/code/hud/hudets.cpp
@@ -83,7 +83,7 @@ void update_ets(object* objp, float fl_frametime)
 //	new_energy = fl_frametime * sinfo_p->power_output;
 
 	// update weapon energy
-	max_new_weapon_energy = fl_frametime * sinfo_p->max_weapon_regen_per_second * max_g;
+	max_new_weapon_energy = fl_frametime * ship_p->max_weapon_regen_per_second * max_g;
 	if ( objp->flags[Object::Object_Flags::Player_ship] ) {
 		ship_p->weapon_energy += Energy_levels[ship_p->weapon_recharge_index] * max_new_weapon_energy * The_mission.ai_profile->weapon_energy_scale[Game_skill_level];
 	} else {
@@ -95,7 +95,7 @@ void update_ets(object* objp, float fl_frametime)
 	}
 
 	float shield_delta;
-	max_new_shield_energy = fl_frametime * sinfo_p->max_shield_regen_per_second * shield_get_max_strength(objp, true); // recharge rate is unaffected by $Max Shield Recharge
+	max_new_shield_energy = fl_frametime * ship_p->max_shield_regen_per_second * shield_get_max_strength(objp, true); // recharge rate is unaffected by $Max Shield Recharge
 	if ( objp->flags[Object::Object_Flags::Player_ship] ) {
 		shield_delta = Energy_levels[ship_p->shield_recharge_index] * max_new_shield_energy * The_mission.ai_profile->shield_energy_scale[Game_skill_level];
 	} else {

--- a/code/scripting/api/objs/ship.cpp
+++ b/code/scripting/api/objs/ship.cpp
@@ -412,6 +412,42 @@ ADE_VIRTVAR(HitpointsMax, l_Ship, "number", "Total hitpoints", "number", "Ship m
 	return ade_set_args(L, "f", shipp->ship_max_hull_strength);
 }
 
+ADE_VIRTVAR(ShieldRegenRate, l_Ship, "number", "Maximum percentage/100 of shield energy regenerated per second. For example, 0.02 = 2% recharge per second.", "number", "Ship maximum shield regeneration rate, or 0 if handle is invalid")
+{
+	object_h *objh;
+	float new_shield_regen = -1;
+	if (!ade_get_args(L, "o|f", l_Ship.GetPtr(&objh), &new_shield_regen))
+		return ade_set_error(L, "f", 0.0f);
+
+	if(!objh->IsValid())
+		return ade_set_error(L, "f", 0.0f);
+
+	ship *shipp = &Ships[objh->objp->instance];
+
+	if (ADE_SETTING_VAR && new_shield_regen > -1)
+		shipp->max_shield_regen_per_second = new_shield_regen;
+
+	return ade_set_args(L, "f", shipp->max_shield_regen_per_second);
+}
+
+ADE_VIRTVAR(WeaponRegenRate, l_Ship, "number", "Maximum percentage/100 of weapon energy regenerated per second. For example, 0.02 = 2% recharge per second.", "number", "Ship maximum weapon regeneration rate, or 0 if handle is invalid")
+{
+	object_h *objh;
+	float new_weapon_regen = -1;
+	if (!ade_get_args(L, "o|f", l_Ship.GetPtr(&objh), &new_weapon_regen))
+		return ade_set_error(L, "f", 0.0f);
+
+	if(!objh->IsValid())
+		return ade_set_error(L, "f", 0.0f);
+
+	ship *shipp = &Ships[objh->objp->instance];
+
+	if (ADE_SETTING_VAR && new_weapon_regen > -1)
+		shipp->max_weapon_regen_per_second = new_weapon_regen;
+
+	return ade_set_args(L, "f", shipp->max_weapon_regen_per_second);
+}
+
 ADE_VIRTVAR(WeaponEnergyLeft, l_Ship, "number", "Current weapon energy reserves", "number", "Ship current weapon energy reserve level, or 0 if invalid")
 {
 	object_h *objh;

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -6315,6 +6315,8 @@ static void ship_set(int ship_index, int objnum, int ship_type)
 	shipp->secondary_team_name = "none";
 
 	shipp->autoaim_fov = sip->autoaim_fov;
+	shipp->max_shield_regen_per_second = sip->max_shield_regen_per_second;
+	shipp->max_weapon_regen_per_second = sip->max_weapon_regen_per_second;
 }
 
 /**

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -492,6 +492,8 @@ public:
 	float ship_max_hull_strength;
 
 	float max_shield_recharge;
+	float max_shield_regen_per_second;		// wookieejedi - make this a ship object variable
+	float max_weapon_regen_per_second;		// wookieejedi - make this a ship object variable
 
 	int ship_guardian_threshold;	// Goober5000 - now also determines whether ship is guardian'd
 


### PR DESCRIPTION
Previously a ship's shields and weapon regeneration per second rates were only stored in the `ship_info` strut, thus they should not be changed during a mission or via scripting (see #2236 and and #2239). There are many precedents for taking a `ship_info` value and copying it to a `ship_object` value so the value can be changed on a per ship basis in mission (auto aim FOV is one of many examples). This PR thus copies the shield and weapon recharge values to the `ship_object` and exposes those new values to scripting.