### PR TITLE
Add system for adding SEXPs externally

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -4,7 +4,7 @@ Standard: Cpp11
 # BasedOnStyle:  LLVM
 AccessModifierOffset: -2
 AlignAfterOpenBracket: DontAlign
-AlignConsecutiveAssignments: true
+AlignConsecutiveAssignments: false
 AlignConsecutiveDeclarations: false
 AlignEscapedNewlines: Left
 AlignOperands:   true

--- a/code/parse/sexp/DynamicSEXP.h
+++ b/code/parse/sexp/DynamicSEXP.h
@@ -23,6 +23,13 @@ class DynamicSEXP {
 	const SCP_string& getHelpText() const;
 
 	/**
+	 * @brief Called when the sexp is added to the SEXP system
+	 *
+	 * This can be used for executing operations that can only be run once the SEXP is added to the system
+	 */
+	virtual void initialize() = 0;
+
+	/**
 	 * @brief Retrieves the minimum number of parameters this SEXP needs
 	 *
 	 * All remaining parameters are optional and the implementation must handle non-existing parameters gracefully

--- a/code/parse/sexp/EngineSEXP.cpp
+++ b/code/parse/sexp/EngineSEXP.cpp
@@ -1,0 +1,239 @@
+#include "EngineSEXP.h"
+
+#include "sexp_lookup.h"
+
+#include "parse/sexp.h"
+
+namespace sexp {
+namespace {
+
+int get_subcategory(const SCP_string& name)
+{
+	for (auto& subcat : op_submenu) {
+		if (subcat.name == name) {
+			return subcat.id;
+		}
+	}
+
+	return -1;
+}
+
+} // namespace
+
+EngineSEXPFactory::ArgumentListBuilder::ArgumentListBuilder(EngineSEXPFactory* parent) : _parent(parent) {}
+EngineSEXPFactory::ArgumentListBuilder& EngineSEXPFactory::ArgumentListBuilder::arg(int type, SCP_string help_text)
+{
+	argument arg;
+	arg.type = type;
+	arg.help_text = std::move(help_text);
+
+	_parent->_arguments.emplace_back(std::move(arg));
+	return *this;
+}
+EngineSEXPFactory::ArgumentListBuilder& EngineSEXPFactory::ArgumentListBuilder::beginOptional()
+{
+	Assertion(std::find_if(_parent->_arguments.begin(),
+				  _parent->_arguments.end(),
+				  [](const argument& arg) { return arg.optional_marker; }) == _parent->_arguments.end(),
+		"Optional marker was already added!");
+	Assertion(std::find_if(_parent->_arguments.begin(),
+				  _parent->_arguments.end(),
+				  [](const argument& arg) { return arg.varargs_marker; }) == _parent->_arguments.end(),
+		"Adding optional arguments after varags specifier is not allowed!");
+
+	argument arg;
+	arg.optional_marker = true;
+
+	_parent->_arguments.emplace_back(std::move(arg));
+	return *this;
+}
+EngineSEXPFactory::ArgumentListBuilder& EngineSEXPFactory::ArgumentListBuilder::beginVarargs()
+{
+	Assertion(std::find_if(_parent->_arguments.begin(),
+				  _parent->_arguments.end(),
+				  [](const argument& arg) { return arg.varargs_marker; }) == _parent->_arguments.end(),
+		"Varargs marker was already added!");
+
+	argument arg;
+	arg.varargs_marker = true;
+
+	_parent->_arguments.emplace_back(std::move(arg));
+	return *this;
+}
+EngineSEXPFactory& EngineSEXPFactory::ArgumentListBuilder::finishArguments() { return *_parent; }
+
+EngineSEXPFactory::EngineSEXPFactory(std::unique_ptr<EngineSEXP> sexp) : m_sexp(std::move(sexp)) {}
+
+EngineSEXPFactory& EngineSEXPFactory::category(int cat)
+{
+	_category = cat;
+	return *this;
+}
+EngineSEXPFactory& EngineSEXPFactory::subcategory(int cat)
+{
+	_category = cat;
+	return *this;
+}
+EngineSEXPFactory& EngineSEXPFactory::subcategory(const SCP_string& subcat)
+{
+	_subcategoryName = subcat;
+	return *this;
+}
+EngineSEXPFactory::ArgumentListBuilder EngineSEXPFactory::beginArgList() { return {this}; }
+
+dummy_return EngineSEXPFactory::finish()
+{
+	Assertion(_category >= 0, "Engine SEXP %s: A category has to be specified!", m_sexp->getName().c_str());
+	Assertion(_returnType >= 0, "Engine SEXP %s: A return type has to be specified!", m_sexp->getName().c_str());
+
+	m_sexp->setCategory(_category);
+	if (_subcategory >= 0) {
+		m_sexp->setSubcategory(_subcategory);
+	} else {
+		Assertion(!_subcategoryName.empty(), "A subcategory has to be specified!");
+		m_sexp->setSubcategoryName(_subcategoryName);
+	}
+
+	m_sexp->setReturnType(_returnType);
+
+	SCP_stringstream helpStream;
+	helpStream << m_sexp->getName() << "\r\n";
+	helpStream << "\t" << _helpText << "\r\n";
+
+	// Now build the argument help text and min and max argument count
+	int min_args_counter = 0;
+	int max_args_counter = 0;
+	SCP_vector<int> argument_types;
+	SCP_vector<int> variable_argument_types;
+
+	int arg_counter = 1;
+	bool varargs = false;
+	bool optional = false;
+	for (const auto& arg : _arguments) {
+		if (arg.varargs_marker) {
+			helpStream << "Rest: (The following pattern repeats)\r\n";
+			// Number non-vararg and vararg parameters separately
+			arg_counter = 1;
+			varargs = true;
+			continue;
+		} else if (arg.optional_marker) {
+			optional = true;
+			continue;
+		}
+
+		helpStream << arg_counter << ": " << arg.help_text << "\r\n";
+		++arg_counter;
+
+		if (!varargs && !optional) {
+			// Keep track of minimum number of arguments. If we are either in the varargs part or the optional part then
+			// we have found the minimum number and should not increment it any further.
+			min_args_counter++;
+		}
+		// Always increment max. varargs are handled after the loop
+		max_args_counter++;
+
+		// Collect argument types
+		if (varargs) {
+			variable_argument_types.push_back(arg.type);
+		} else {
+			argument_types.push_back(arg.type);
+		}
+	}
+
+	if (varargs) {
+		max_args_counter = std::numeric_limits<int>::max();
+	}
+
+	m_sexp->initArguments(min_args_counter,
+		max_args_counter,
+		std::move(argument_types),
+		std::move(variable_argument_types));
+	m_sexp->setHelpText(helpStream.str());
+	m_sexp->setAction(std::move(_action));
+
+	add_dynamic_sexp(std::move(m_sexp));
+
+	return {};
+}
+EngineSEXPFactory::~EngineSEXPFactory()
+{
+	Assertion(m_sexp == nullptr, "Did not call finish on a EngineSEXP factory!");
+}
+EngineSEXPFactory& EngineSEXPFactory::helpText(SCP_string text)
+{
+	_helpText = std::move(text);
+	return *this;
+}
+EngineSEXPFactory& EngineSEXPFactory::returnType(int type)
+{
+	_returnType = type;
+	return *this;
+}
+EngineSEXPFactory& EngineSEXPFactory::action(EngineSexpAction act)
+{
+	_action = std::move(act);
+	return *this;
+}
+EngineSEXP::EngineSEXP(const SCP_string& name) : DynamicSEXP(name) {}
+
+EngineSEXPFactory EngineSEXP::create(const SCP_string& name)
+{
+	return { std::unique_ptr<EngineSEXP>(new EngineSEXP(name)) };
+}
+void EngineSEXP::initialize()
+{
+	// Initialize subcategory now that we know that it is safe to do so
+	if (_subcategory < 0) {
+		_subcategory = get_subcategory(_subcategoryName);
+
+		if (_subcategory < 0) {
+			_subcategory = add_subcategory(_category, _subcategoryName);
+		}
+	}
+}
+int EngineSEXP::getMinimumArguments() { return _minArgs; }
+int EngineSEXP::getMaximumArguments() { return _maxArgs; }
+int EngineSEXP::getArgumentType(int argnum) const
+{
+	if (argnum >= static_cast<int>(_argumentTypes.size())) {
+		// We are in the varargs part. Adjust the number and then fit it into the varargs types array
+		argnum -= static_cast<int>(_argumentTypes.size());
+
+		// Error checking to avoid division by zero
+		if (_variableArgumentsTypes.empty()) {
+			return OPF_NONE;
+		}
+
+		argnum = argnum % _variableArgumentsTypes.size();
+
+		return _variableArgumentsTypes[argnum];
+	} else {
+		// Normal arguments so just look up the type
+		return _argumentTypes[argnum];
+	}
+}
+int EngineSEXP::execute(int node)
+{
+	SEXPParameterExtractor extractor(node);
+	return _action(&extractor);
+}
+int EngineSEXP::getReturnType() { return _returnType; }
+int EngineSEXP::getSubcategory() { return _subcategory; }
+int EngineSEXP::getCategory() { return _category; }
+
+void EngineSEXP::setCategory(int category) { _category = category; }
+void EngineSEXP::setSubcategory(int subcategory) { _subcategory = subcategory; }
+void EngineSEXP::setSubcategoryName(SCP_string subcategory) { _subcategoryName = std::move(subcategory); }
+void EngineSEXP::setHelpText(SCP_string helpText) { _help_text = std::move(helpText); }
+void EngineSEXP::setReturnType(int returnType) { _returnType = returnType; }
+void EngineSEXP::initArguments(int minArgs, int maxArgs, SCP_vector<int> argTypes, SCP_vector<int> varargsTypes)
+{
+	_minArgs = minArgs;
+	_maxArgs = maxArgs;
+
+	_argumentTypes = std::move(argTypes);
+	_variableArgumentsTypes = std::move(varargsTypes);
+}
+void EngineSEXP::setAction(EngineSexpAction action) { _action = std::move(action); }
+
+} // namespace sexp

--- a/code/parse/sexp/EngineSEXP.h
+++ b/code/parse/sexp/EngineSEXP.h
@@ -1,0 +1,198 @@
+#pragma once
+
+#include "globalincs/pstypes.h"
+
+#include "DynamicSEXP.h"
+#include "SEXPParameterExtractor.h"
+
+namespace sexp {
+
+class EngineSEXP;
+
+struct dummy_return {
+};
+
+using EngineSexpAction = std::function<int(SEXPParameterExtractor* extractor)>;
+
+class EngineSEXPFactory {
+	std::unique_ptr<EngineSEXP> m_sexp;
+
+	SCP_string _helpText;
+
+	int _category = -1;
+
+	int _subcategory = -1;
+	SCP_string _subcategoryName;
+
+	int _returnType = -1;
+
+	EngineSexpAction _action;
+
+	struct argument {
+		int type = -1;
+		SCP_string help_text;
+
+		bool optional_marker = false;
+		bool varargs_marker = false;
+	};
+
+	SCP_vector<argument> _arguments;
+
+	class ArgumentListBuilder {
+		EngineSEXPFactory* _parent;
+
+	  public:
+		ArgumentListBuilder(EngineSEXPFactory* parent);
+
+		/**
+		 * @brief Adds a parameter of the specified type with help text.
+		 * @param type The type of this parameter
+		 * @param help_text A helpful text for this parameter
+		 * @return The arglist builder
+		 */
+		ArgumentListBuilder& arg(int type, SCP_string help_text);
+		/**
+		 * @brief Specifies that all following arguments are optional
+		 * @return The arglist builder
+		 */
+		ArgumentListBuilder& beginOptional();
+		/**
+		 * @brief Begins the part of the parameter list which can be repeated
+		 * @return The arglist builder
+		 */
+		ArgumentListBuilder& beginVarargs();
+
+		/**
+		 * @brief Finishes the argument list
+		 * @return The parent engine SEXP factory
+		 */
+		EngineSEXPFactory& finishArguments();
+	};
+
+	friend ArgumentListBuilder;
+
+  public:
+	EngineSEXPFactory(std::unique_ptr<EngineSEXP> sexp);
+	virtual ~EngineSEXPFactory();
+
+	EngineSEXPFactory(EngineSEXPFactory&&) noexcept = default;
+	EngineSEXPFactory& operator=(EngineSEXPFactory&&) noexcept = default;
+
+	/**
+	 * @brief Specifies the help text of the SEXP
+	 * @param text The help text
+	 * @return The factory
+	 */
+	EngineSEXPFactory& helpText(SCP_string text);
+
+	/**
+	 * @brief The return type of the SEXP
+	 *
+	 * This is a required value!
+	 *
+	 * @param type The OPR_ value
+	 * @return The factory
+	 */
+	EngineSEXPFactory& returnType(int type);
+
+	/**
+	 * @brief The category where this SEXP will be located
+	 *
+	 * This is a required value!
+	 *
+	 * @param cat The OP_CATEGORY_ value
+	 * @return The factory
+	 */
+	EngineSEXPFactory& category(int cat);
+
+	/**
+	 * @brief The subcategory of this SEXP
+	 *
+	 * This or the string variant is a required value!
+	 *
+	 * @param subcat The *_SUBCATEGORY_* value
+	 * @return The factory
+	 */
+	EngineSEXPFactory& subcategory(int subcat);
+	/**
+	 * @brief Sets the subcategory of the SEXP.
+	 *
+	 * This can be a new subcategory which will be created automatically.
+	 *
+	 * This or the number variant is a required value!
+	 *
+	 * @param subcat The name of the subcategory
+	 * @return The factory
+	 */
+	EngineSEXPFactory& subcategory(const SCP_string& subcat);
+
+	/**
+	 * @brief Begins specifying arguments for the SEXP
+	 * @return
+	 */
+	ArgumentListBuilder beginArgList();
+
+	/**
+	 * @brief The function that will be called for executing the SEXP
+	 * @param act The function to execute
+	 * @return The factory
+	 */
+	EngineSEXPFactory& action(EngineSexpAction act);
+
+	/**
+	 * @brief Finishes the construction of the SEXP
+	 * @return A dummy value to allow SEXPs to be added statically at application start
+	 */
+	dummy_return finish();
+};
+
+class EngineSEXP : public DynamicSEXP {
+	EngineSEXP(const SCP_string& name);
+
+  public:
+	void initialize() override;
+	int getMinimumArguments() override;
+	int getMaximumArguments() override;
+	int getArgumentType(int argnum) const override;
+	int execute(int node) override;
+	int getReturnType() override;
+	int getSubcategory() override;
+	int getCategory() override;
+
+	/**
+	 * @brief Start creating an engine SEXP.
+	 *
+	 * This returns a factory with which the various parameters of the SEXP can be configured
+	 *
+	 * @param name The name of the SEXP
+	 * @return The engine SEXP factory
+	 */
+	static EngineSEXPFactory create(const SCP_string& name);
+
+  private:
+	void setCategory(int category);
+	void setSubcategory(int subcategory);
+	void setSubcategoryName(SCP_string subcategory);
+	void setHelpText(SCP_string helpText);
+	void setReturnType(int returnType);
+	void initArguments(int minArgs, int maxArgs, SCP_vector<int> argTypes, SCP_vector<int> varargsTypes);
+	void setAction(EngineSexpAction action);
+
+	int _category = -1;
+
+	int _subcategory = -1;
+	SCP_string _subcategoryName;
+
+	int _returnType = -1;
+
+	int _minArgs = -1;
+	int _maxArgs = -1;
+	SCP_vector<int> _argumentTypes;
+	SCP_vector<int> _variableArgumentsTypes;
+
+	EngineSexpAction _action;
+
+	friend EngineSEXPFactory;
+};
+
+} // namespace sexp

--- a/code/parse/sexp/LuaSEXP.cpp
+++ b/code/parse/sexp/LuaSEXP.cpp
@@ -88,6 +88,9 @@ namespace sexp {
 
 LuaSEXP::LuaSEXP(const SCP_string& name) : DynamicSEXP(name) {
 }
+void LuaSEXP::initialize() {
+	// Nothing to do for this type
+}
 int LuaSEXP::getMinimumArguments() {
 	return _min_args;
 }
@@ -326,7 +329,7 @@ void LuaSEXP::parseTable() {
 	_category = get_category(category);
 	if (_category < 0) {
 		error_display(0, "Invalid category '%s' found. New main categories can't be added!", category.c_str());
-		_category = OP_CATEGORY_CHANGE; // Default to change2 so we have a valid value later on
+		_category = OP_CATEGORY_CHANGE2; // Default to change2 so we have a valid value later on
 	}
 
 	required_string("$Subcategory:");

--- a/code/parse/sexp/LuaSEXP.h
+++ b/code/parse/sexp/LuaSEXP.h
@@ -27,6 +27,8 @@ class LuaSEXP : public DynamicSEXP {
  public:
 	explicit LuaSEXP(const SCP_string& name);
 
+	void initialize() override;
+
 	int getMinimumArguments() override;
 
 	int getMaximumArguments() override;

--- a/code/parse/sexp/SEXPParameterExtractor.cpp
+++ b/code/parse/sexp/SEXPParameterExtractor.cpp
@@ -1,0 +1,23 @@
+
+#include "SEXPParameterExtractor.h"
+
+#include "parse/sexp.h"
+
+namespace sexp {
+integer_return::integer_return() = default;
+integer_return::integer_return(int _value) : value(_value) {}
+
+namespace detail {
+void nodeToValue(int node, bool& valOut) { valOut = is_sexp_true(node); }
+
+void nodeToValue(int node, integer_return& valOut)
+{
+	valOut.value = eval_num(node, valOut.is_nan, valOut.is_nan_forever);
+}
+
+} // namespace detail
+
+SEXPParameterExtractor::SEXPParameterExtractor(int node) : _node(node) {}
+bool SEXPParameterExtractor::hasMore() const { return _node != -1; }
+
+} // namespace sexp

--- a/code/parse/sexp/SEXPParameterExtractor.h
+++ b/code/parse/sexp/SEXPParameterExtractor.h
@@ -1,0 +1,63 @@
+#pragma once
+
+#include "globalincs/pstypes.h"
+
+#include "parse/sexp.h"
+
+namespace sexp {
+
+struct integer_return {
+	int value = -1;
+	bool is_nan = false;
+	bool is_nan_forever = false;
+
+	integer_return();
+	integer_return(int _value);
+};
+
+namespace detail {
+void nodeToValue(int node, bool& valOut);
+
+template <typename T>
+struct conversion_traits {
+	using output_type = T;
+};
+
+template <>
+struct conversion_traits<int> {
+	using output_type = integer_return;
+};
+void nodeToValue(int node, integer_return& valOut);
+
+} // namespace detail
+
+class SEXPParameterExtractor {
+	int _node = -1;
+
+  public:
+	SEXPParameterExtractor(int node);
+
+	bool hasMore() const;
+
+	template <typename T>
+	typename detail::conversion_traits<T>::output_type getArg()
+	{
+		Assertion(hasMore(), "Required value was missing!");
+		typename detail::conversion_traits<T>::output_type value;
+		detail::nodeToValue(_node, value);
+		_node = CDR(_node);
+		return value;
+	}
+
+	template <typename T>
+	typename detail::conversion_traits<T>::output_type getOptionalArg(const T& defaultVal = T())
+	{
+		if (!hasMore()) {
+			return typename detail::conversion_traits<T>::output_type(defaultVal);
+		}
+
+		return getArg<T>();
+	}
+};
+
+} // namespace sexp

--- a/code/source_groups.cmake
+++ b/code/source_groups.cmake
@@ -920,10 +920,14 @@ add_file_folder("Parse"
 add_file_folder("Parse\\\\SEXP"
 	parse/sexp/DynamicSEXP.cpp
 	parse/sexp/DynamicSEXP.h
+	parse/sexp/EngineSEXP.cpp
+	parse/sexp/EngineSEXP.h
 	parse/sexp/LuaSEXP.cpp
 	parse/sexp/LuaSEXP.h
 	parse/sexp/sexp_lookup.cpp
 	parse/sexp/sexp_lookup.h
+	parse/sexp/SEXPParameterExtractor.cpp
+	parse/sexp/SEXPParameterExtractor.h
 )
 
 # Particle files


### PR DESCRIPTION
This adds a "clear-debris" SEXP with a new system for declaring SEXPs
outside of sexp.cpp. This makes it easier to keep code modules self
contained since they do not need to export previously private
functionality just for having missiong being able to interface with it.

This is mostly a proof-of-concept which only supports basic parameter
types (booleans and integers).

As for the reasoning why this could just be added to sexp.cpp: It's already 1MB big. Let's not add more...