### PR TITLE
fix HUD message offset for messages that come from [none]

### DIFF
--- a/code/hud/hudmessage.cpp
+++ b/code/hud/hudmessage.cpp
@@ -325,14 +325,14 @@ void HudGaugeMessages::processMessageBuffer()
 		ptr = strstr(msg, NOX(": "));
 		if ( ptr ) {
 			int sw;
-			gr_get_string_size(&sw, NULL, msg, (int)(ptr + 2 - msg));
+			gr_get_string_size(&sw, nullptr, msg, (int)(ptr + 2 - msg));
 			offset = sw;
 		}
 
 		x = 0;
 		split_str = msg;
 
-		while ((ptr = split_str_once(split_str, Max_width - x - 7)) != NULL) {		// the 7 is a fudge hack
+		while ((ptr = split_str_once(split_str, Max_width - x - 7)) != nullptr) {		// the 7 is a fudge hack
 			// make sure that split went ok, if not then bail
 			if (ptr == split_str) {
 				break;

--- a/code/hud/hudmessage.cpp
+++ b/code/hud/hudmessage.cpp
@@ -313,7 +313,7 @@ void HudGaugeMessages::pageIn()
 
 void HudGaugeMessages::processMessageBuffer()
 {
-	int sw, x, offset = 0;
+	int x, offset = 0;
 	size_t i;
 	char *msg;
 	char *split_str, *ptr;
@@ -322,10 +322,10 @@ void HudGaugeMessages::processMessageBuffer()
 		msg = new char [HUD_msg_buffer[i].text.size()+1];
 		strcpy(msg, HUD_msg_buffer[i].text.c_str());
 
-		ptr = strstr(msg, NOX(": ")) + 2;
-
+		ptr = strstr(msg, NOX(": "));
 		if ( ptr ) {
-			gr_get_string_size(&sw, NULL, msg, (int)(ptr - msg));
+			int sw;
+			gr_get_string_size(&sw, NULL, msg, (int)(ptr + 2 - msg));
 			offset = sw;
 		}
 


### PR DESCRIPTION
Tracked down another Volition bug, first reported by recead.  When messages do not have the ": " substring (which only happens when they are from MSG_SOURCE_NONE), they would calculate the wrong string size.  This is because the two-character offset was added to the pointer *before* the pointer was checked for null, and so non-matches were considered matches with strings beginning at memory offset 2.