### PR TITLE
fix ship registry in regards to wings with multiple waves

### DIFF
--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -4170,7 +4170,19 @@ int parse_wing_create_ships( wing *wingp, int num_to_create, int force, int spec
 		// bash the ship name to be the name of the wing + some number if there is > 1 wave in this wing
 		wingp->total_arrived_count++;
 		if (wingp->num_waves > 1)
+		{
 			wing_bash_ship_name(p_objp->name, wingp->name, wingp->total_arrived_count + wingp->red_alert_skipped_ships);
+
+			// subsequent waves of ships will not be in the ship registry, so add them
+			if (!ship_registry_get(p_objp->name))
+			{
+				ship_registry_entry entry(p_objp->name);
+				entry.p_objp = p_objp;
+
+				Ship_registry.push_back(entry);
+				Ship_registry_map[p_objp->name] = static_cast<int>(Ship_registry.size() - 1);
+			}
+		}
 
 		// also, if multiplayer, set the parse object's net signature to be wing's net signature
 		// base + total_arrived_count (before adding 1)
@@ -4773,7 +4785,9 @@ void post_process_ships_wings()
 	// any ships are created from the parse objects.
 	for (auto &p_obj : Parse_objects)
 	{
-		ship_registry_entry entry = { ShipStatus::NOT_YET_PRESENT, p_obj.name, &p_obj, nullptr, nullptr, 0, -1 };
+		ship_registry_entry entry(p_obj.name);
+		entry.p_objp = &p_obj;
+
 		Ship_registry.push_back(entry);
 		Ship_registry_map[p_obj.name] = static_cast<int>(Ship_registry.size() - 1);
 	}

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -9605,7 +9605,11 @@ int ship_create(matrix* orient, vec3d* pos, int ship_type, const char* ship_name
 	auto ship_it = Ship_registry_map.find(shipp->ship_name);
 	if (ship_it == Ship_registry_map.end())
 	{
-		ship_registry_entry entry = { ShipStatus::PRESENT, shipp->ship_name, nullptr, &Objects[objnum], shipp, 0, -1 };
+		ship_registry_entry entry(shipp->ship_name);
+		entry.status = ShipStatus::PRESENT;
+		entry.objp = &Objects[objnum];
+		entry.shipp = shipp;
+
 		Ship_registry.push_back(entry);
 		Ship_registry_map[shipp->ship_name] = static_cast<int>(Ship_registry.size() - 1);
 	}

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -795,14 +795,19 @@ enum ShipStatus
 
 struct ship_registry_entry
 {
-	ShipStatus status;
-	const char *name;
+	ShipStatus status = ShipStatus::NOT_YET_PRESENT;
+	char name[NAME_LENGTH];
 
-	p_object *p_objp;
-	object *objp;
-	ship *shipp;
-	int cleanup_mode;
-	int exited_index;
+	p_object *p_objp = nullptr;
+	object *objp = nullptr;
+	ship *shipp = nullptr;
+	int cleanup_mode = 0;
+	int exited_index = -1;
+
+	ship_registry_entry(const char *_name)
+	{
+		strcpy_s(name, _name);
+	}
 };
 
 extern SCP_vector<ship_registry_entry> Ship_registry;


### PR DESCRIPTION
The ship registry previously stored the ship name as a pointer, but that pointer was reused when subsequent waves of a wing overwrote a p_object from the first wave.  So, the name is now copied into an array.

Additionally, subsequent waves of a wing are now "eagerly" stored in the ship registry so that the p_object reference can be stored as well.