### PR TITLE
fix background bug when loading subsequent missions

### DIFF
--- a/fred2/campaigneditordlg.cpp
+++ b/fred2/campaigneditordlg.cpp
@@ -145,14 +145,6 @@ void campaign_editor::OnLoad()
 		FREDDoc_ptr->SetPathName(res.full_name.c_str());
 	}
 	Campaign_wnd->DestroyWindow();
-
-//		if (FREDDoc_ptr->OnOpenDocument(Campaign.missions[Cur_campaign_mission].name)) {
-//			Bypass_clear_mission = 1;
-//			Campaign_wnd->DestroyWindow();
-//
-//		} else {
-//			MessageBox("Failed to load mission!", "Error");
-//		}
 }
 
 BOOL campaign_editor::Create(LPCTSTR lpszClassName, LPCTSTR lpszWindowName, DWORD dwStyle, const RECT& rect, CWnd* pParentWnd, UINT nID, CCreateContext* pContext) 

--- a/fred2/campaigntreewnd.cpp
+++ b/fred2/campaigntreewnd.cpp
@@ -29,7 +29,6 @@ static char THIS_FILE[] = __FILE__;
 
 int Mission_filename_cb_format;
 int Campaign_modified = 0;
-int Bypass_clear_mission;
 campaign_tree_wnd *Campaign_wnd = NULL;
 
 IMPLEMENT_DYNCREATE(campaign_tree_wnd, CFrameWnd)
@@ -39,7 +38,6 @@ IMPLEMENT_DYNCREATE(campaign_tree_wnd, CFrameWnd)
 
 campaign_tree_wnd::campaign_tree_wnd()
 {
-	Bypass_clear_mission = 0;
 }
 
 campaign_tree_wnd::~campaign_tree_wnd()
@@ -146,8 +144,7 @@ void campaign_tree_wnd::OnDestroy()
 
 	OnCpgnFileNew();
 	Fred_main_wnd->EnableWindow(TRUE);
-//	if (!Bypass_clear_mission)
-//		create_new_mission();
+
 	str = FREDDoc_ptr->GetPathName();
 	if (str.IsEmpty())
 		create_new_mission();

--- a/fred2/campaigntreewnd.h
+++ b/fred2/campaigntreewnd.h
@@ -67,5 +67,4 @@ public:
 
 extern int Mission_filename_cb_format;
 extern int Campaign_modified;
-extern int Bypass_clear_mission;
 extern campaign_tree_wnd *Campaign_wnd;

--- a/fred2/management.cpp
+++ b/fred2/management.cpp
@@ -427,7 +427,6 @@ bool fred_init(std::unique_ptr<os::GraphicsOperations>&& graphicsOps)
 	fhash_init();
 	fhash_activate();
 
-	create_new_mission();
 	neb2_init();						// fullneb stuff
 	stars_init();
 	ssm_init();		// The game calls this after stars_init(), and we need Ssm_info initialized for OPF_SSM_CLASS. -MageKing17
@@ -437,9 +436,9 @@ bool fred_init(std::unique_ptr<os::GraphicsOperations>&& graphicsOps)
 	fiction_viewer_reset();
 	cmd_brief_reset();
 	Show_waypoints = TRUE;
-	mission_campaign_clear();
 
-	stars_post_level_init();
+	mission_campaign_clear();
+	create_new_mission();
 
 	// neb lightning
 	nebl_init();
@@ -805,7 +804,9 @@ void create_new_mission()
 void reset_mission()
 {
 	clear_mission();
+
 	player_start1 = create_player(0, &vmd_zero_vector, &vmd_identity_matrix);
+	stars_post_level_init();
 }
 
 void clear_mission()


### PR DESCRIPTION
FRED's handling of mission loading and creation is a bit wonky.  The `stars_post_level_init()` function should run for each new mission, not just once when FRED is started.  That fixes a background editor crash and I also did a bit of other cleanup.