### PR TITLE
fix sexp auto-complete for manually-entered text

### DIFF
--- a/fred2/eventeditor.cpp
+++ b/fred2/eventeditor.cpp
@@ -626,7 +626,7 @@ void event_editor::update_cur_message()
 	UpdateData(FALSE);
 }
 
-int event_editor::handler(int code, int node, char *str)
+int event_editor::handler(int code, int node, const char *str)
 {
 	int i, index;
 

--- a/fred2/eventeditor.h
+++ b/fred2/eventeditor.h
@@ -43,7 +43,7 @@ public:
 	int query_modified();
 	void OnOK();
 	void OnCancel();
-	int handler(int code, int node, char *str = NULL);
+	int handler(int code, int node, const char *str = nullptr);
 	void create_tree();
 	void load_tree();
 	int modified;

--- a/fred2/sexp_tree.cpp
+++ b/fred2/sexp_tree.cpp
@@ -1424,18 +1424,14 @@ int sexp_tree::query_node_argument_type(int node)
 
 int sexp_tree::end_label_edit(TVITEMA &item)
 {
+	if (!item.pszText)
+		return 0;
+
 	HTREEITEM h = item.hItem; 
-	char *str = item.pszText;
+	SCP_string str(item.pszText);
 	int r = 1;	
 	bool update_node = true; 
 	uint node;
-
-	*modified = 1;
-	if (!str)
-		return 0;
-
-	// let's make sure we aren't introducing any invalid characters, per Mantis #2893
-	lcl_fred_replace_stuff(str, TOKEN_LENGTH - 1);
 
 	for (node=0; node<tree_nodes.size(); node++)
 		if (tree_nodes[node].handle == h)
@@ -1445,7 +1441,7 @@ int sexp_tree::end_label_edit(TVITEMA &item)
 		if (m_mode == MODE_EVENTS) {
 			item_index = (int)GetItemData(h);
 			Assert(Event_editor_dlg);
-			node = Event_editor_dlg->handler(ROOT_RENAMED, item_index, str);
+			node = Event_editor_dlg->handler(ROOT_RENAMED, item_index, str.c_str());
 			return 1;
 
 		} else
@@ -1457,7 +1453,10 @@ int sexp_tree::end_label_edit(TVITEMA &item)
 		auto op = match_closest_operator(str, node);
 		if (op.empty()) return 0;	// Goober5000 - avoids crashing
 
+		// use the text of the operator we found
 		SetItemText(h, op.c_str());
+		str = op;
+
 		item_index = node;
 		int op_num = get_operator_index(op.c_str()); 
 		if (op_num >= 0 ) {
@@ -1468,54 +1467,87 @@ int sexp_tree::end_label_edit(TVITEMA &item)
 		}
 		r = 0;
 	}
-
 	// gotta sidestep Goober5000's number hack and check entries are actually positive. 
 	else if (tree_nodes[node].type & SEXPT_NUMBER) {
-		if (query_node_argument_type(node) == OPF_POSITIVE) {			
-			int val = atoi(str); 
+		if (query_node_argument_type(node) == OPF_POSITIVE) {
+			int val = atoi(str.c_str()); 
 			if (val < 0) {
 				MessageBox("Can not enter a negative value", "Invalid Number", MB_ICONEXCLAMATION); 
-				update_node = false; 
+				update_node = false;
 			}
-		}		
+		}
 	}
 
 	// Error checking would not hurt here
-	auto len = strlen(str);
+	auto len = str.size();
 	if (len >= TOKEN_LENGTH)
 		len = TOKEN_LENGTH - 1;
 
 	if (update_node) {
-		strncpy(tree_nodes[node].text, str, len);
+		*modified = 1;
+		strncpy(tree_nodes[node].text, str.c_str(), len);
 		tree_nodes[node].text[len] = 0;
+
+		// let's make sure we aren't introducing any invalid characters, per Mantis #2893
+		lcl_fred_replace_stuff(tree_nodes[node].text, TOKEN_LENGTH - 1);
 	}
 	else {
-		strncpy(str, tree_nodes[node].text, len);
+		item.pszText = tree_nodes[node].text;
 		return 1;
 	}
 
-
-/*	node = tree_nodes[node].parent;
-	if (node != -1) {
-		child = tree_nodes[node].child;
-		if (child != -1 && tree_nodes[child].next == -1 && tree_nodes[child].child == -1) {
-			merge_operator(child);
-			return 0;
-		}
-	}*/
-
 	return r;
+}
+
+//
+// See https://en.wikibooks.org/wiki/Algorithm_Implementation/Strings/Levenshtein_distance#C++
+//
+template<typename T>
+typename T::size_type GeneralizedLevensteinDistance(const T &source,
+	const T &target,
+	typename T::size_type insert_cost = 1,
+	typename T::size_type delete_cost = 1,
+	typename T::size_type replace_cost = 1) {
+	if (source.size() > target.size()) {
+		return GeneralizedLevensteinDistance(target, source, delete_cost, insert_cost, replace_cost);
+	}
+
+	using TSizeType = typename T::size_type;
+	const TSizeType min_size = source.size(), max_size = target.size();
+	std::vector<TSizeType> lev_dist(min_size + 1);
+
+	lev_dist[0] = 0;
+	for (TSizeType i = 1; i <= min_size; ++i) {
+		lev_dist[i] = lev_dist[i - 1] + delete_cost;
+	}
+
+	for (TSizeType j = 1; j <= max_size; ++j) {
+		TSizeType previous_diagonal = lev_dist[0], previous_diagonal_save;
+		lev_dist[0] += insert_cost;
+
+		for (TSizeType i = 1; i <= min_size; ++i) {
+			previous_diagonal_save = lev_dist[i];
+			if (source[i - 1] == target[j - 1]) {
+				lev_dist[i] = previous_diagonal;
+			}
+			else {
+				lev_dist[i] = std::min(std::min(lev_dist[i - 1] + delete_cost, lev_dist[i] + insert_cost), previous_diagonal + replace_cost);
+			}
+			previous_diagonal = previous_diagonal_save;
+		}
+	}
+
+	return lev_dist[min_size];
 }
 
 // Look for the valid operator that is the closest match for 'str' and return the operator
 // number of it.  What operators are valid is determined by 'node', and an operator is valid
 // if it is allowed to fit at position 'node'
 //
-SCP_string sexp_tree::match_closest_operator(const char *str, int node)
+SCP_string sexp_tree::match_closest_operator(const SCP_string &str, int node)
 {
 	int z, i, op, arg_num, opf, opr;
-	SCP_string sub_best;
-	SCP_string best;
+	int min = -1, best = -1;
 
 	z = tree_nodes[node].parent;
 	if (z < 0) {
@@ -1527,44 +1559,23 @@ SCP_string sexp_tree::match_closest_operator(const char *str, int node)
 		return str;
 
 	// determine which argument we are of the parent
-	arg_num = find_argument_number(z, node); 
+	arg_num = find_argument_number(z, node);
+	opf = query_operator_argument_type(op, arg_num);	// check argument type at this position
 
-	opf = query_operator_argument_type(op, arg_num); // check argument type at this position
-	opr = query_operator_return_type(op);
 	for (i=0; i<(int)Operators.size(); i++) {
+		opr = query_operator_return_type(i);			// figure out which type this operator returns
+
 		if (sexp_query_type_match(opf, opr)) {
-			if ( (stricmp(str, Operators[i].text.c_str()) <= 0) && (stricmp(str, best.c_str()) < 0) )
-				best = Operators[i].text;
-			
-			if ( stricmp(Operators[i].text.c_str(), sub_best.c_str()) > 0 )
-				sub_best = Operators[i].text;
+			int dist = (int)GeneralizedLevensteinDistance(str, Operators[i].text, 2, 2, 3);
+			if (min < 0 || dist < min) {
+				min = dist;
+				best = i;
+			}
 		}
 	}
 
-	if (best.empty())
-		best = sub_best;  // no best found, use our plan #2 best found.
-
-	Assert(!best.empty());  // we better have some valid operator at this point.
-	return best;
-
-/*	char buf[256];
-	int child;
-
-	if (tree_nodes[node].flags == EDITABLE)  // data
-		node = tree_nodes[node].parent;
-
-	if (node != -1) {
-		child = tree_nodes[node].child;
-		if (child != -1 && tree_nodes[child].next == -1 && tree_nodes[child].child == -1) {
-			sprintf(buf, "%s %s", tree_nodes[node].text, tree_nodes[child].text);
-			SetItemText(tree_nodes[node].handle, buf);
-			tree_nodes[node].flags = OPERAND | EDITABLE;
-			tree_nodes[child].flags = COMBINED;
-			DeleteItem(tree_nodes[child].handle);
-			tree_nodes[child].handle = NULL;
-			return;
-		}
-	}*/
+	Assert(best >= 0);  // we better have some valid operator at this point.
+	return Operators[best].text;
 }
 
 // this really only handles messages generated by the right click popup menu

--- a/fred2/sexp_tree.h
+++ b/fred2/sexp_tree.h
@@ -175,7 +175,7 @@ public:
 	void add_sub_tree(int node, HTREEITEM root);
 	int load_sub_tree(int index, bool valid, const char *text);
 	void hilite_item(int node);
-	SCP_string match_closest_operator(const char *str, int node);
+	SCP_string match_closest_operator(const SCP_string &str, int node);
 	void delete_sexp_tree_variable(const char *var_name);
 	void modify_sexp_tree_variable(const char *old_name, int sexp_var_index);
 	int get_item_index_to_var_index();

--- a/qtfred/src/ui/widgets/sexp_tree.cpp
+++ b/qtfred/src/ui/widgets/sexp_tree.cpp
@@ -717,14 +717,54 @@ int sexp_tree::query_node_argument_type(int node) {
 	return query_operator_argument_type(op_num, argnum);
 }
 
+//
+// See https://en.wikibooks.org/wiki/Algorithm_Implementation/Strings/Levenshtein_distance#C++
+//
+template<typename T>
+typename T::size_type GeneralizedLevensteinDistance(const T &source,
+	const T &target,
+	typename T::size_type insert_cost = 1,
+	typename T::size_type delete_cost = 1,
+	typename T::size_type replace_cost = 1) {
+	if (source.size() > target.size()) {
+		return GeneralizedLevensteinDistance(target, source, delete_cost, insert_cost, replace_cost);
+	}
+
+	using TSizeType = typename T::size_type;
+	const TSizeType min_size = source.size(), max_size = target.size();
+	std::vector<TSizeType> lev_dist(min_size + 1);
+
+	lev_dist[0] = 0;
+	for (TSizeType i = 1; i <= min_size; ++i) {
+		lev_dist[i] = lev_dist[i - 1] + delete_cost;
+	}
+
+	for (TSizeType j = 1; j <= max_size; ++j) {
+		TSizeType previous_diagonal = lev_dist[0], previous_diagonal_save;
+		lev_dist[0] += insert_cost;
+
+		for (TSizeType i = 1; i <= min_size; ++i) {
+			previous_diagonal_save = lev_dist[i];
+			if (source[i - 1] == target[j - 1]) {
+				lev_dist[i] = previous_diagonal;
+			}
+			else {
+				lev_dist[i] = std::min(std::min(lev_dist[i - 1] + delete_cost, lev_dist[i] + insert_cost), previous_diagonal + replace_cost);
+			}
+			previous_diagonal = previous_diagonal_save;
+		}
+	}
+
+	return lev_dist[min_size];
+}
+
 // Look for the valid operator that is the closest match for 'str' and return the operator
 // number of it.  What operators are valid is determined by 'node', and an operator is valid
 // if it is allowed to fit at position 'node'
 //
-SCP_string sexp_tree::match_closest_operator(const char* str, int node) {
+SCP_string sexp_tree::match_closest_operator(const SCP_string &str, int node) {
 	int z, i, op, arg_num, opf, opr;
-	SCP_string sub_best;
-	SCP_string best;
+	int min = -1, best = -1;
 
 	z = tree_nodes[node].parent;
 	if (z < 0) {
@@ -738,46 +778,22 @@ SCP_string sexp_tree::match_closest_operator(const char* str, int node) {
 
 	// determine which argument we are of the parent
 	arg_num = find_argument_number(z, node);
+	opf = query_operator_argument_type(op, arg_num);	// check argument type at this position
 
-	opf = query_operator_argument_type(op, arg_num); // check argument type at this position
-	opr = query_operator_return_type(op);
 	for (i = 0; i < (int) Operators.size(); i++) {
-		if (sexp_query_type_match(opf, opr)) {
-			if ((stricmp(str, Operators[i].text.c_str()) <= 0) && (stricmp(str, best.c_str()) < 0)) {
-				best = Operators[i].text;
-			}
+		opr = query_operator_return_type(i);			// figure out which type this operator returns
 
-			if (stricmp(Operators[i].text.c_str(), sub_best.c_str()) > 0) {
-				sub_best = Operators[i].text;
+		if (sexp_query_type_match(opf, opr)) {
+			int dist = (int)GeneralizedLevensteinDistance(str, Operators[i].text, 2, 2, 3);
+			if (min < 0 || dist < min) {
+				min = dist;
+				best = i;
 			}
 		}
 	}
 
-	if (best.empty()) {
-		best = sub_best;
-	}  // no best found, use our plan #2 best found.
-
-	Assert(!best.empty());  // we better have some valid operator at this point.
-	return best;
-
-/*	char buf[256];
-	int child;
-
-	if (tree_nodes[node].flags == EDITABLE)  // data
-		node = tree_nodes[node].parent;
-
-	if (node != -1) {
-		child = tree_nodes[node].child;
-		if (child != -1 && tree_nodes[child].next == -1 && tree_nodes[child].child == -1) {
-			sprintf(buf, "%s %s", tree_nodes[node].text, tree_nodes[child].text);
-			SetItemText(tree_nodes[node].handle, buf);
-			tree_nodes[node].flags = OPERAND | EDITABLE;
-			tree_nodes[child].flags = COMBINED;
-			DeleteItem(tree_nodes[child].handle);
-			tree_nodes[child].handle = NULL;
-			return;
-		}
-	}*/
+	Assert(best >= 0);  // we better have some valid operator at this point.
+	return Operators[best].text;
 }
 
 // adds to or replaces (based on passed in flag) the current operator
@@ -5552,14 +5568,9 @@ void sexp_tree::handleItemChange(QTreeWidgetItem* item, int  /*column*/) {
 	bool update_node = true;
 	uint node;
 
-	modified();
 	if (str.isEmpty()) {
 		return;
 	}
-
-	// let's make sure we aren't introducing any invalid characters, per Mantis #2893
-	SCP_string replaced_str = str.toStdString();
-	lcl_fred_replace_stuff(replaced_str);
 
 	for (node = 0; node < tree_nodes.size(); node++) {
 		if (tree_nodes[node].handle == item) {
@@ -5577,12 +5588,15 @@ void sexp_tree::handleItemChange(QTreeWidgetItem* item, int  /*column*/) {
 
 	Assert(node < tree_nodes.size());
 	if (tree_nodes[node].type & SEXPT_OPERATOR) {
-		auto op = match_closest_operator(replaced_str.c_str(), node);
+		auto op = match_closest_operator(str, node);
 		if (op.empty()) {
 			return;
 		}    // Goober5000 - avoids crashing
 
+		// use the text of the operator we found
 		item->setText(0, QString::fromStdString(op));
+		str = op;
+
 		setCurrentItemIndex(node);
 		int op_num = get_operator_index(op.c_str());
 		if (op_num >= 0) {
@@ -5591,8 +5605,7 @@ void sexp_tree::handleItemChange(QTreeWidgetItem* item, int  /*column*/) {
 			update_node = false;
 		}
 	}
-
-		// gotta sidestep Goober5000's number hack and check entries are actually positive.
+	// gotta sidestep Goober5000's number hack and check entries are actually positive.
 	else if (tree_nodes[node].type & SEXPT_NUMBER) {
 		if (query_node_argument_type(node) == OPF_POSITIVE) {
 			int val = str.toInt();
@@ -5610,8 +5623,12 @@ void sexp_tree::handleItemChange(QTreeWidgetItem* item, int  /*column*/) {
 	}
 
 	if (update_node) {
+		modified();
 		strncpy(tree_nodes[node].text, str.toStdString().c_str(), len);
 		tree_nodes[node].text[len] = 0;
+
+		// let's make sure we aren't introducing any invalid characters, per Mantis #2893
+		lcl_fred_replace_stuff(tree_nodes[node].text, TOKEN_LENGTH - 1);
 	} else {
 		item->setText(0, QString::fromUtf8(tree_nodes[node].text, len));
 	}

--- a/qtfred/src/ui/widgets/sexp_tree.cpp
+++ b/qtfred/src/ui/widgets/sexp_tree.cpp
@@ -5594,8 +5594,8 @@ void sexp_tree::handleItemChange(QTreeWidgetItem* item, int  /*column*/) {
 		}    // Goober5000 - avoids crashing
 
 		// use the text of the operator we found
-		item->setText(0, QString::fromStdString(op));
-		str = op;
+		str = QString::fromStdString(op);
+		item->setText(0, str);
 
 		setCurrentItemIndex(node);
 		int op_num = get_operator_index(op.c_str());

--- a/qtfred/src/ui/widgets/sexp_tree.cpp
+++ b/qtfred/src/ui/widgets/sexp_tree.cpp
@@ -5588,7 +5588,7 @@ void sexp_tree::handleItemChange(QTreeWidgetItem* item, int  /*column*/) {
 
 	Assert(node < tree_nodes.size());
 	if (tree_nodes[node].type & SEXPT_OPERATOR) {
-		auto op = match_closest_operator(str, node);
+		auto op = match_closest_operator(str.toStdString(), node);
 		if (op.empty()) {
 			return;
 		}    // Goober5000 - avoids crashing

--- a/qtfred/src/ui/widgets/sexp_tree.h
+++ b/qtfred/src/ui/widgets/sexp_tree.h
@@ -226,7 +226,7 @@ class sexp_tree: public QTreeWidget {
 	void add_sub_tree(int node, QTreeWidgetItem* root);
 	int load_sub_tree(int index, bool valid, const char* text);
 	void hilite_item(int node);
-	SCP_string match_closest_operator(const char* str, int node);
+	SCP_string match_closest_operator(const SCP_string &str, int node);
 	void delete_sexp_tree_variable(const char* var_name);
 	void modify_sexp_tree_variable(const char* old_name, int sexp_var_index);
 	int get_item_index_to_var_index();


### PR DESCRIPTION
The old way of finding the closest match of sexp text to entered text didn't work very well.  This method uses Levenstein distance.

This also fixes the bug where when text was matched to an existing operator, and the operator used in the event editor, the underlying incorrect text was still in the mission file.