### PR TITLE
fix XSTR lookup for $Has XSTR:

### DIFF
--- a/code/controlconfig/controlsconfig.cpp
+++ b/code/controlconfig/controlsconfig.cpp
@@ -517,9 +517,9 @@ void control_config_list_prepare()
 	while (z < CCFG_MAX) {
 		if (Control_config[z].tab == Tab && !Control_config[z].disabled) {
 			if (Control_config[z].indexXSTR > 1) {
-				Cc_lines[Num_cc_lines].label = XSTR(Control_config[z].text, Control_config[z].indexXSTR);
+				Cc_lines[Num_cc_lines].label = XSTR(Control_config[z].text, Control_config[z].indexXSTR, true);
 			} else if (Control_config[z].indexXSTR == 1) {
-				Cc_lines[Num_cc_lines].label = XSTR(Control_config[z].text, CONTROL_CONFIG_XSTR + z);
+				Cc_lines[Num_cc_lines].label = XSTR(Control_config[z].text, CONTROL_CONFIG_XSTR + z, true);
 			} else {
 				Cc_lines[Num_cc_lines].label = Control_config[z].text;
 			}
@@ -1985,9 +1985,9 @@ void control_config_do_frame(float frametime)
 		gr_printf_menu(x - w / 2, y - font_height, "%s", str);
 
 		if (Control_config[i].indexXSTR > 1) {
-			strcpy_s(buf, XSTR(Control_config[i].text, Control_config[i].indexXSTR));
+			strcpy_s(buf, XSTR(Control_config[i].text, Control_config[i].indexXSTR, true));
 		} else if (Control_config[i].indexXSTR == 1) {
-			strcpy_s(buf, XSTR(Control_config[i].text, CONTROL_CONFIG_XSTR + i));
+			strcpy_s(buf, XSTR(Control_config[i].text, CONTROL_CONFIG_XSTR + i, true));
 		} else {
 			strcpy_s(buf, Control_config[i].text);
 		}

--- a/code/globalincs/pstypes.h
+++ b/code/globalincs/pstypes.h
@@ -388,7 +388,7 @@ extern void game_busy(const char *filename = NULL);
 
 #define NOX(s) s
 
-const char *XSTR(const char *str, int index);
+const char *XSTR(const char *str, int index, bool force_lookup = false);
 
 // Caps V between MN and MX.
 template <class T> void CAP( T& v, T mn, T mx )

--- a/code/localization/localize.cpp
+++ b/code/localization/localize.cpp
@@ -69,7 +69,6 @@ typedef struct {
 	int  offset_x_hi;			// string offset in 1024
 } lcl_xstr;
 
-//char *Xstr_table[XSTR_SIZE];
 lcl_xstr Xstr_table[XSTR_SIZE];
 int Xstr_inited = 0;
 
@@ -901,7 +900,7 @@ void lcl_ext_localize(const SCP_string &in, SCP_string &out, int *id)
 }
 
 // translate the specified string based upon the current language
-const char *XSTR(const char *str, int index)
+const char *XSTR(const char *str, int index, bool force_lookup)
 {
 	if(!Xstr_inited)
 	{
@@ -909,7 +908,9 @@ const char *XSTR(const char *str, int index)
 		return str;
 	}
 
-	if (Lcl_current_lang != LCL_UNTRANSLATED)
+	// for some internal strings, such as the ones we loaded using $Has XStr:,
+	// we want to force a lookup even if we're normally untranslated
+	if (Lcl_current_lang != LCL_UNTRANSLATED || force_lookup)
 	{
 		// perform a lookup
 		if (index >= 0 && index < XSTR_SIZE)

--- a/code/localization/localize.h
+++ b/code/localization/localize.h
@@ -118,7 +118,6 @@ void lcl_ext_localize(const char *in, char *out, size_t max_len, int *id = nullp
 void lcl_ext_localize(const SCP_string &in, SCP_string &out, int *id = nullptr);
 
 // translate the specified string based upon the current language
-const char *XSTR(const char *str, int index);
 int lcl_get_xstr_offset(int index, int res);
 
 void lcl_translate_wep_name_gr(char *name);


### PR DESCRIPTION
If we specify an XSTR index, we want the internal control lookup to happen regardless of whether the game is running in untranslated mode or not.