### PR TITLE
Fix physics whack for docked ships

### DIFF
--- a/code/object/objectdock.cpp
+++ b/code/object/objectdock.cpp
@@ -342,8 +342,8 @@ float dock_calc_docked_speed(object *objp)
 
 void dock_calc_total_moi(matrix* dest, object* objp, vec3d *center)
 {
-	Assert(dest != NULL);
-	Assert(objp != NULL);
+	Assert(dest != nullptr);
+	Assert(objp != nullptr);
 
 	matrix accum;
 	vm_mat_zero(&accum);

--- a/code/object/objectdock.cpp
+++ b/code/object/objectdock.cpp
@@ -376,7 +376,7 @@ object* dock_find_dock_root(object *objp)
 	return fastest_objp;
 }
 
-void dock_whack_docked_object(vec3d* force, vec3d* const rel_world_hit_pos, object* objp)
+void dock_calculate_whack_docked_object(vec3d* force, const vec3d* rel_world_hit_pos, object* objp)
 {
 	Assertion((objp != nullptr) && (force != nullptr) && (rel_world_hit_pos != nullptr),
 		"dock_whack_docked_object invalid argument(s)");
@@ -432,7 +432,7 @@ void dock_whack_docked_object(vec3d* force, vec3d* const rel_world_hit_pos, obje
 	vm_vec_add2(&root_delta_vel, &center_mass_delta_vel);
 
 	// whack it
-	physics_apply_whack_direct(vm_vec_mag(force),
+	physics_apply_whack(vm_vec_mag(force),
 		&root_objp->phys_info,
 		&local_delta_rotvel,
 		&root_delta_vel,

--- a/code/object/objectdock.cpp
+++ b/code/object/objectdock.cpp
@@ -376,7 +376,7 @@ object* dock_find_dock_root(object *objp)
 	return fastest_objp;
 }
 
-void dock_whack_docked_object(vec3d* force, const vec3d* rel_world_hit_pos, object* objp)
+void dock_whack_docked_object(vec3d* force, vec3d* const rel_world_hit_pos, object* objp)
 {
 	Assertion((objp != nullptr) && (force != nullptr) && (rel_world_hit_pos != nullptr),
 		"dock_whack_docked_object invalid argument(s)");

--- a/code/object/objectdock.cpp
+++ b/code/object/objectdock.cpp
@@ -29,7 +29,7 @@ void dock_calc_max_cross_sectional_radius_squared_perpendicular_to_line_helper(o
 void dock_calc_max_semilatus_rectum_squared_parallel_to_directrix_helper(object *objp, dock_function_info *infop);
 void dock_find_max_speed_helper(object *objp, dock_function_info *infop);
 void dock_find_max_fspeed_helper(object *objp, dock_function_info *infop);
-void dock_calc_inv_total_moi_helper(object* objp, dock_function_info* infop);
+void dock_calc_total_moi_helper(object* objp, dock_function_info* infop);
 void dock_whack_all_docked_objects_helper(object* objp, dock_function_info* infop);
 
 // management prototypes
@@ -343,14 +343,13 @@ void dock_calc_total_moi(matrix* dest, object* objp, vec3d *center)
 	Assertion(dest != nullptr, "dock_calc_total_moi invalid dest");
 	Assertion(objp != nullptr, "dock_calc_total_moi invalid objp");
 
-	matrix accum;
-	vm_mat_zero(&accum);
+	matrix accum = ZERO_MATRIX;
 
 	dock_function_info dfi;
 	dfi.parameter_variables.vecp_value = center;
 	dfi.maintained_variables.matrix_value = dest;
 
-	dock_evaluate_all_docked_objects(objp, &dfi, dock_calc_inv_total_moi_helper);
+	dock_evaluate_all_docked_objects(objp, &dfi, dock_calc_total_moi_helper);
 }
 
 void dock_whack_all_docked_objects(vec3d* force, vec3d* world_hit_pos, object* objp)
@@ -797,7 +796,7 @@ void object_remove_arriving_stage2_ndl_flag_helper(object *objp, dock_function_i
 		Ships[objp->instance].flags.remove(Ship::Ship_Flags::Arriving_stage_2_dock_follower);
 }
 
-void dock_calc_inv_total_moi_helper(object* objp, dock_function_info* infop)
+void dock_calc_total_moi_helper(object* objp, dock_function_info* infop)
 {
 	matrix local_moi, unorient, world_moi;
 	vm_inverse_matrix(&local_moi, &objp->phys_info.I_body_inv);

--- a/code/object/objectdock.cpp
+++ b/code/object/objectdock.cpp
@@ -345,7 +345,7 @@ void dock_calc_total_moi(matrix* dest, object* objp, vec3d *center)
 	Assert(dest != NULL);
 	Assert(objp != NULL);
 
-	matrix accum, local_moi;
+	matrix accum;
 	vm_mat_zero(&accum);
 
 	dock_function_info dfi;
@@ -372,7 +372,7 @@ void dock_whack_all_docked_objects(vec3d* force, vec3d* world_hit_pos, object* o
 	// the new hitpos is the vector from world center-of-mass to world hitpos
 	vm_vec_sub2(world_hit_pos, &world_center_of_mass);
 
-	matrix moi, local_moi, inv_moi;
+	matrix moi, inv_moi;
 
 	// calculate the effective inverse MOI for the docked composite object about its center of mass
 	dock_calc_total_moi(&moi, objp, &world_center_of_mass);

--- a/code/object/objectdock.cpp
+++ b/code/object/objectdock.cpp
@@ -189,8 +189,8 @@ void dock_calc_docked_extents(vec3d *mins, vec3d *maxs, object *objp)
 
 float dock_calc_docked_center_of_mass(vec3d *dest, object *objp)
 {
-	Assert(dest != NULL);
-	Assert(objp != NULL);
+	Assertion(dest != nullptr, "dock_calc_docked_center_of_mass, invalid dest");
+	Assertion(objp != nullptr, "dock_calc_docked_center_of_mass, invalid objp");
 
 	vm_vec_zero(dest);
 
@@ -207,8 +207,6 @@ float dock_calc_docked_center_of_mass(vec3d *dest, object *objp)
 
 float dock_calc_total_docked_mass(object *objp)
 {
-	Assert(objp != NULL);
-
 	dock_function_info dfi;
 	
 	dock_evaluate_all_docked_objects(objp, &dfi, dock_calc_total_docked_mass_helper);
@@ -342,8 +340,8 @@ float dock_calc_docked_speed(object *objp)
 
 void dock_calc_total_moi(matrix* dest, object* objp, vec3d *center)
 {
-	Assert(dest != nullptr);
-	Assert(objp != nullptr);
+	Assertion(dest != nullptr, "dock_calc_total_moi invalid dest");
+	Assertion(objp != nullptr, "dock_calc_total_moi invalid objp");
 
 	matrix accum;
 	vm_mat_zero(&accum);
@@ -357,6 +355,9 @@ void dock_calc_total_moi(matrix* dest, object* objp, vec3d *center)
 
 void dock_whack_all_docked_objects(vec3d* force, vec3d* world_hit_pos, object* objp)
 {
+	Assertion((objp != nullptr) && (force != nullptr) && (world_hit_pos != nullptr),
+		"dock_whack_all_docked_objects invalid argument(s)");
+
 	//	Detect null vector.
 	if (whack_below_limit(force))
 		return;
@@ -409,7 +410,8 @@ void dock_whack_all_docked_objects(vec3d* force, vec3d* world_hit_pos, object* o
 // evaluate a certain function for all docked objects
 void dock_evaluate_all_docked_objects(object *objp, dock_function_info *infop, void (*function)(object *, dock_function_info *))
 {
-	Assert((objp != NULL) && (infop != NULL) && (function != NULL));
+	Assertion((objp != nullptr) && (infop != nullptr) && (function != nullptr),
+		"dock_evaluate_all_docked_objects, invalid argument(s)");
 
 	// not docked?
 	if (!object_is_docked(objp))
@@ -820,6 +822,9 @@ void dock_calc_inv_total_moi_helper(object* objp, dock_function_info* infop)
 
 void dock_whack_all_docked_objects_helper(object* objp, dock_function_info* infop)
 {
+	Assertion((objp != nullptr) && (infop != nullptr),
+		"dock_whack_all_docked_objects_helper invalid argument(s)");
+
 	float orig_impulse = infop->parameter_variables.float_value;
 	vec3d* world_delta_rotvel = infop->parameter_variables.vecp_value;
 	vec3d* main_delta_vel = infop->parameter_variables.vecp_value2;

--- a/code/object/objectdock.cpp
+++ b/code/object/objectdock.cpp
@@ -379,9 +379,9 @@ object* dock_find_dock_root(object *objp)
 	return fastest_objp;
 }
 
-void dock_calculate_and_apply_whack_docked_object(vec3d* impulse, const vec3d* hit_pos, object* objp)
+void dock_calculate_and_apply_whack_docked_object(vec3d* impulse, const vec3d* rel_world_hit_pos, object* objp)
 {
-	Assertion((objp != nullptr) && (impulse != nullptr) && (hit_pos != nullptr),
+	Assertion((objp != nullptr) && (impulse != nullptr) && (rel_world_hit_pos != nullptr),
 		"dock_whack_docked_object invalid argument(s)");
 
 	//	Detect null vector.
@@ -392,22 +392,23 @@ void dock_calculate_and_apply_whack_docked_object(vec3d* impulse, const vec3d* h
 	vec3d world_hit_pos;
 
 	// calc world hit pos of the hit ship
-	vm_vec_add(&world_hit_pos, hit_pos, &objp->pos);
+	vm_vec_add(&world_hit_pos, rel_world_hit_pos, &objp->pos);
 
 	// calc overall world center-of-mass of all ships
 	float total_mass = dock_calc_docked_center_of_mass(&world_center_of_mass, objp);
 
+	vec3d hit_pos;
 	// the new hitpos is the vector from world center-of-mass to world hitpos
-	vm_vec_sub2(&world_hit_pos, &world_center_of_mass);
+	vm_vec_sub(&hit_pos, &world_hit_pos, &world_center_of_mass);
 
 	matrix moi, inv_moi;
 	// calculate the effective inverse MOI for the docked composite object about its center of mass
 	dock_calc_total_moi(&moi, objp, &world_center_of_mass);
 	vm_inverse_matrix(&inv_moi, &moi);
 
-	// calculate the torque about the center of mass in world coords
+	// calculate the angular_impulse about the center of mass in world coords
 	vec3d angular_impulse;
-	vm_vec_cross(&angular_impulse, &world_hit_pos, impulse);
+	vm_vec_cross(&angular_impulse, &hit_pos, impulse);
 
 	// calculate the change in rotvel caused by the whack in world coords
 	vec3d delta_rotvel;

--- a/code/object/objectdock.h
+++ b/code/object/objectdock.h
@@ -134,7 +134,7 @@ void dock_dock_objects(object *objp1, int dockpoint1, object *objp2, int dockpoi
 void dock_undock_objects(object *objp1, object *objp2);
 
 // apply force to a docked assembly of ships
-void dock_whack_all_docked_objects(vec3d* force, vec3d* hit_pos, object* objp);
+void dock_whack_docked_object(vec3d* force, vec3d* hit_pos, object* objp);
 
 	/**
  * @brief Undocks everything from the given object

--- a/code/object/objectdock.h
+++ b/code/object/objectdock.h
@@ -134,7 +134,7 @@ void dock_dock_objects(object *objp1, int dockpoint1, object *objp2, int dockpoi
 void dock_undock_objects(object *objp1, object *objp2);
 
 // apply force to a docked assembly of ships
-void dock_whack_docked_object(vec3d* force, const vec3d* hit_pos, object* objp);
+void dock_calculate_whack_docked_object(vec3d* force, const vec3d* hit_pos, object* objp);
 
 	/**
  * @brief Undocks everything from the given object

--- a/code/object/objectdock.h
+++ b/code/object/objectdock.h
@@ -134,7 +134,7 @@ void dock_dock_objects(object *objp1, int dockpoint1, object *objp2, int dockpoi
 void dock_undock_objects(object *objp1, object *objp2);
 
 // apply force to a docked assembly of ships
-void dock_calculate_whack_docked_object(vec3d* force, const vec3d* hit_pos, object* objp);
+void dock_calculate_and_apply_whack_docked_object(vec3d* force, const vec3d* hit_pos, object* objp);
 
 	/**
  * @brief Undocks everything from the given object

--- a/code/object/objectdock.h
+++ b/code/object/objectdock.h
@@ -134,7 +134,7 @@ void dock_dock_objects(object *objp1, int dockpoint1, object *objp2, int dockpoi
 void dock_undock_objects(object *objp1, object *objp2);
 
 // apply force to a docked assembly of ships
-void dock_whack_docked_object(vec3d* force, vec3d* hit_pos, object* objp);
+void dock_whack_docked_object(vec3d* force, const vec3d* hit_pos, object* objp);
 
 	/**
  * @brief Undocks everything from the given object

--- a/code/object/objectdock.h
+++ b/code/object/objectdock.h
@@ -38,6 +38,7 @@ public:
 		object*		objp_value;
 		vec3d*		vecp_value;
 		vec3d*		vecp_value2;
+		matrix*     matrix_value;
 		float		float_value;
 		int			int_value;
 		bool		bool_value;
@@ -97,7 +98,8 @@ void dock_calc_docked_extents(vec3d *mins, vec3d *maxs, object *objp);
 // calculate the center of mass of all docked objects (returned in dest)
 // currently the game assumes the center of mass is the center of an object; this will need to
 // be fixed eventually (though this function does weight the object masses properly)
-void dock_calc_docked_center_of_mass(vec3d *dest, object *objp);
+// returns the total mass of docked ships, calculated as a side effect
+float dock_calc_docked_center_of_mass(vec3d *dest, object *objp);
 
 // sum the masses of all directly or indirectly docked ships
 float dock_calc_total_docked_mass(object *objp);
@@ -131,7 +133,10 @@ void dock_dock_objects(object *objp1, int dockpoint1, object *objp2, int dockpoi
 // remove objp1 and objp2 from each others' dock lists; currently only called by ai_do_objects_undocked_stuff
 void dock_undock_objects(object *objp1, object *objp2);
 
-/**
+// apply force to a docked assembly of ships
+void dock_whack_all_docked_objects(vec3d* force, vec3d* hit_pos, object* objp);
+
+	/**
  * @brief Undocks everything from the given object
  * @note This is a slow method. use dock_free_dock_list() when doing object cleanup.
  * @note Currently, this function cannot be called from within ship_cleanup() [Github Issue #1177:https://github.com/scp-fs2open/fs2open.github.com/issues/1177]

--- a/code/physics/physics.cpp
+++ b/code/physics/physics.cpp
@@ -773,7 +773,7 @@ void physics_apply_whack(vec3d *impulse, vec3d *pos, physics_info *pi, matrix *o
 
 
 // This function applies the calculated delta rotational and linear velocities usually called by ^^^^ apply_whack, 
-// but also called directly by dock_whack_all_docked_objects in objectdock.cpp which has to do some extra legwork
+// but also called directly by dock_whack_docked_object in objectdock.cpp which has to do some extra legwork
 // and doesn't set this function up using physics_apply_whack
 void physics_apply_whack_direct(float orig_impulse, physics_info* pi, vec3d *delta_rotvel, vec3d* delta_vel, matrix* orient)
 {

--- a/code/physics/physics.cpp
+++ b/code/physics/physics.cpp
@@ -726,7 +726,7 @@ void physics_read_flying_controls( matrix * orient, physics_info * pi, control_i
 
 
 #define WHACK_LIMIT 0.001f
-#define ROTVEL_WHACK_CONST 0.12
+#define ROTVEL_WHACK_CONST 0.12f
 
 //	-----------------------------------------------------------------------------------------------------------
 // Returns true if this impulse is below the limit and should be ignored.
@@ -772,8 +772,8 @@ void physics_apply_whack(vec3d *impulse, vec3d *pos, physics_info *pi, matrix *o
 }
 
 
-// This function applies the calculated delta rotational and linear velocities, 
-// importantly called directly by dock_whack_all_docked_objects in objectdock.cpp which has to do some extra legwork
+// This function applies the calculated delta rotational and linear velocities usually called by ^^^^ apply_whack, 
+// but also called directly by dock_whack_all_docked_objects in objectdock.cpp which has to do some extra legwork
 // and doesn't set this function up using physics_apply_whack
 void physics_apply_whack_direct(float orig_impulse, physics_info* pi, vec3d *delta_rotvel, vec3d* delta_vel, matrix* orient)
 {

--- a/code/physics/physics.cpp
+++ b/code/physics/physics.cpp
@@ -730,7 +730,7 @@ void physics_read_flying_controls( matrix * orient, physics_info * pi, control_i
 
 //	-----------------------------------------------------------------------------------------------------------
 // Returns true if this impulse is below the limit and should be ignored.
-bool whack_below_limit(vec3d* impulse)
+bool whack_below_limit(const vec3d* impulse)
 {
 	return (fl_abs(impulse->xyz.x) < WHACK_LIMIT) && (fl_abs(impulse->xyz.y) < WHACK_LIMIT) &&
 		   (fl_abs(impulse->xyz.z) < WHACK_LIMIT);
@@ -1123,6 +1123,23 @@ void update_reduced_damp_timestamp( physics_info *pi, float impulse )
 		pi->reduced_damp_decay = timestamp( reduced_damp_decay_time );
 	}
 
+}
+
+void physics_add_point_mass_moi(matrix *moi, float mass, vec3d pos)
+{
+	// moment of inertia for a point mass: 
+	// I_xx = m(y^2+z^2) | I_yx = -mxy       | I_zx = -mxz
+	// I_xy = -mxy       | I_yy = m(x^2+z^2) | I_zy = -myz 
+	// I_xz = -mxz		 | I_yz = -myz	     | I_zz = m(x^2+y^2)
+	moi->a2d[0][0] += mass * (pos.xyz.y * pos.xyz.y + pos.xyz.z * pos.xyz.z);
+	moi->a2d[0][1] -= mass * pos.xyz.x * pos.xyz.y;
+	moi->a2d[0][2] -= mass * pos.xyz.x * pos.xyz.z;
+	moi->a2d[1][0] -= mass * pos.xyz.x * pos.xyz.y;
+	moi->a2d[1][1] += mass * (pos.xyz.x * pos.xyz.x + pos.xyz.z * pos.xyz.z);
+	moi->a2d[1][2] -= mass * pos.xyz.y * pos.xyz.z;
+	moi->a2d[2][0] -= mass * pos.xyz.x * pos.xyz.z;
+	moi->a2d[2][1] -= mass * pos.xyz.y * pos.xyz.z;
+	moi->a2d[2][2] += mass * (pos.xyz.x * pos.xyz.x + pos.xyz.y * pos.xyz.y);
 }
 
 //*************************CLASS: avd_movement*************************

--- a/code/physics/physics.cpp
+++ b/code/physics/physics.cpp
@@ -1131,15 +1131,15 @@ void physics_add_point_mass_moi(matrix *moi, float mass, vec3d *pos)
 	// I_xx = m(y^2+z^2) | I_yx = -mxy       | I_zx = -mxz
 	// I_xy = -mxy       | I_yy = m(x^2+z^2) | I_zy = -myz 
 	// I_xz = -mxz		 | I_yz = -myz	     | I_zz = m(x^2+y^2)
-	moi->a2d[0][0] += mass * (pos.xyz.y * pos.xyz.y + pos.xyz.z * pos.xyz.z);
-	moi->a2d[0][1] -= mass * pos.xyz.x * pos.xyz.y;
-	moi->a2d[0][2] -= mass * pos.xyz.x * pos.xyz.z;
-	moi->a2d[1][0] -= mass * pos.xyz.x * pos.xyz.y;
-	moi->a2d[1][1] += mass * (pos.xyz.x * pos.xyz.x + pos.xyz.z * pos.xyz.z);
-	moi->a2d[1][2] -= mass * pos.xyz.y * pos.xyz.z;
-	moi->a2d[2][0] -= mass * pos.xyz.x * pos.xyz.z;
-	moi->a2d[2][1] -= mass * pos.xyz.y * pos.xyz.z;
-	moi->a2d[2][2] += mass * (pos.xyz.x * pos.xyz.x + pos.xyz.y * pos.xyz.y);
+	moi->a2d[0][0] += mass * (pos->xyz.y * pos->xyz.y + pos->xyz.z * pos->xyz.z);
+	moi->a2d[0][1] -= mass * pos->xyz.x * pos->xyz.y;
+	moi->a2d[0][2] -= mass * pos->xyz.x * pos->xyz.z;
+	moi->a2d[1][0] -= mass * pos->xyz.x * pos->xyz.y;
+	moi->a2d[1][1] += mass * (pos->xyz.x * pos->xyz.x + pos->xyz.z * pos->xyz.z);
+	moi->a2d[1][2] -= mass * pos->xyz.y * pos->xyz.z;
+	moi->a2d[2][0] -= mass * pos->xyz.x * pos->xyz.z;
+	moi->a2d[2][1] -= mass * pos->xyz.y * pos->xyz.z;
+	moi->a2d[2][2] += mass * (pos->xyz.x * pos->xyz.x + pos->xyz.y * pos->xyz.y);
 }
 
 //*************************CLASS: avd_movement*************************

--- a/code/physics/physics.cpp
+++ b/code/physics/physics.cpp
@@ -732,8 +732,8 @@ void physics_read_flying_controls( matrix * orient, physics_info * pi, control_i
 // Returns true if this impulse is below the limit and should be ignored.
 bool whack_below_limit(vec3d* impulse)
 {
-	return (fl_abs(impulse->xyz.x) <= WHACK_LIMIT) && (fl_abs(impulse->xyz.y) <= WHACK_LIMIT) &&
-		   (fl_abs(impulse->xyz.z) <= WHACK_LIMIT);
+	return (fl_abs(impulse->xyz.x) < WHACK_LIMIT) && (fl_abs(impulse->xyz.y) < WHACK_LIMIT) &&
+		   (fl_abs(impulse->xyz.z) < WHACK_LIMIT);
 }
 
 // ----------------------------------------------------------------------------

--- a/code/physics/physics.cpp
+++ b/code/physics/physics.cpp
@@ -730,7 +730,7 @@ void physics_read_flying_controls( matrix * orient, physics_info * pi, control_i
 
 //	-----------------------------------------------------------------------------------------------------------
 // Returns true if this impulse is below the limit and should be ignored.
-bool whack_below_limit(vec3d* const impulse)
+bool whack_below_limit(const vec3d* impulse)
 {
 	return (fl_abs(impulse->xyz.x) < WHACK_LIMIT) && (fl_abs(impulse->xyz.y) < WHACK_LIMIT) &&
 		   (fl_abs(impulse->xyz.z) < WHACK_LIMIT);
@@ -747,7 +747,7 @@ bool whack_below_limit(vec3d* const impulse)
 //				orient		=>		orientation matrix (needed to set rotational impulse in body coords)
 //				mass			=>		mass of the object (may be different from pi.mass if docked)
 //
-void physics_apply_whack(vec3d *impulse, vec3d *pos, physics_info *pi, matrix *orient, float mass, matrix *inv_moi)
+void physics_calculate_whack(vec3d *impulse, vec3d *pos, physics_info *pi, matrix *orient, float mass, matrix *inv_moi)
 {
 	vec3d	local_torque, torque;
 
@@ -768,14 +768,14 @@ void physics_apply_whack(vec3d *impulse, vec3d *pos, physics_info *pi, matrix *o
 	// Goober5000 - pi->mass should probably be just mass, as specified in the header
 	vec3d delta_vel = *impulse * (1.0f / mass);
 
-	physics_apply_whack_direct(vm_vec_mag(impulse), pi, &delta_rotvel, &delta_vel, orient);
+	physics_apply_whack(vm_vec_mag(impulse), pi, &delta_rotvel, &delta_vel, orient);
 }
 
 
 // This function applies the calculated delta rotational and linear velocities usually called by ^^^^ apply_whack, 
-// but also called directly by dock_whack_docked_object in objectdock.cpp which has to do some extra legwork
-// and doesn't set this function up using physics_apply_whack
-void physics_apply_whack_direct(float orig_impulse, physics_info* pi, vec3d *delta_rotvel, vec3d* delta_vel, matrix* orient)
+// but also called directly by dock_calculate_whack_docked_object in objectdock.cpp which has to do some extra legwork
+// and doesn't set this function up using physics_calculate_whack
+void physics_apply_whack(float orig_impulse, physics_info* pi, vec3d *delta_rotvel, vec3d* delta_vel, matrix* orient)
 {
 	Assertion((pi != nullptr) && (delta_rotvel != nullptr) && (delta_vel != nullptr) && (orient != nullptr),
 		"physics_apply_whack_direct invalid argument(s)");

--- a/code/physics/physics.cpp
+++ b/code/physics/physics.cpp
@@ -730,7 +730,7 @@ void physics_read_flying_controls( matrix * orient, physics_info * pi, control_i
 
 //	-----------------------------------------------------------------------------------------------------------
 // Returns true if this impulse is below the limit and should be ignored.
-bool whack_below_limit(const vec3d* impulse)
+bool whack_below_limit(vec3d* const impulse)
 {
 	return (fl_abs(impulse->xyz.x) < WHACK_LIMIT) && (fl_abs(impulse->xyz.y) < WHACK_LIMIT) &&
 		   (fl_abs(impulse->xyz.z) < WHACK_LIMIT);
@@ -1125,7 +1125,7 @@ void update_reduced_damp_timestamp( physics_info *pi, float impulse )
 
 }
 
-void physics_add_point_mass_moi(matrix *moi, float mass, vec3d pos)
+void physics_add_point_mass_moi(matrix *moi, float mass, vec3d *pos)
 {
 	// moment of inertia for a point mass: 
 	// I_xx = m(y^2+z^2) | I_yx = -mxy       | I_zx = -mxz

--- a/code/physics/physics.cpp
+++ b/code/physics/physics.cpp
@@ -777,6 +777,9 @@ void physics_apply_whack(vec3d *impulse, vec3d *pos, physics_info *pi, matrix *o
 // and doesn't set this function up using physics_apply_whack
 void physics_apply_whack_direct(float orig_impulse, physics_info* pi, vec3d *delta_rotvel, vec3d* delta_vel, matrix* orient)
 {
+	Assertion((pi != nullptr) && (delta_rotvel != nullptr) && (delta_vel != nullptr) && (orient != nullptr),
+		"physics_apply_whack_direct invalid argument(s)");
+
 	vm_vec_scale(delta_rotvel, (float)ROTVEL_WHACK_CONST);
 	vm_vec_add2(&pi->rotvel, delta_rotvel);
 

--- a/code/physics/physics.h
+++ b/code/physics/physics.h
@@ -141,7 +141,7 @@ extern void physics_sim_editor(vec3d *position, matrix * orient, physics_info * 
 extern void physics_sim_vel(vec3d * position, physics_info * pi, float sim_time, matrix * orient);
 extern void physics_sim_rot(matrix * orient, physics_info * pi, float sim_time );
 extern bool whack_below_limit(const vec3d* impulse);
-extern void physics_calculate_whack(vec3d *force, vec3d *pos, physics_info *pi, matrix *orient, float mass, matrix *inv_moi);
+extern void physics_calculate_and_apply_whack(vec3d *force, vec3d *pos, physics_info *pi, matrix *orient, float mass, matrix *inv_moi);
 extern void physics_apply_whack(float orig_impulse, physics_info* pi, vec3d *delta_rotvel, vec3d* delta_vel, matrix* orient);
 extern void physics_apply_shock(vec3d *direction_vec, float pressure, physics_info *pi, matrix *orient, vec3d *min, vec3d *max, float radius);
 extern void physics_collide_whack(vec3d *impulse, vec3d *delta_rotvel, physics_info *pi, matrix *orient, bool is_landing);

--- a/code/physics/physics.h
+++ b/code/physics/physics.h
@@ -141,8 +141,8 @@ extern void physics_sim_editor(vec3d *position, matrix * orient, physics_info * 
 extern void physics_sim_vel(vec3d * position, physics_info * pi, float sim_time, matrix * orient);
 extern void physics_sim_rot(matrix * orient, physics_info * pi, float sim_time );
 extern bool whack_below_limit(vec3d* impulse);
-extern void physics_apply_whack(vec3d *force, vec3d *pos, physics_info *pi, matrix *orient, float mass, matrix *inv_moi);
-extern void physics_apply_whack_direct(float orig_impulse, physics_info* pi, vec3d *delta_rotvel, vec3d* delta_vel, matrix* orient);
+extern void physics_calculate_whack(vec3d *force, vec3d *pos, physics_info *pi, matrix *orient, float mass, matrix *inv_moi);
+extern void physics_apply_whack(float orig_impulse, physics_info* pi, vec3d *delta_rotvel, vec3d* delta_vel, matrix* orient);
 extern void physics_apply_shock(vec3d *direction_vec, float pressure, physics_info *pi, matrix *orient, vec3d *min, vec3d *max, float radius);
 extern void physics_collide_whack(vec3d *impulse, vec3d *delta_rotvel, physics_info *pi, matrix *orient, bool is_landing);
 int check_rotvel_limit( physics_info *pi );

--- a/code/physics/physics.h
+++ b/code/physics/physics.h
@@ -140,7 +140,9 @@ extern void physics_sim_editor(vec3d *position, matrix * orient, physics_info * 
 
 extern void physics_sim_vel(vec3d * position, physics_info * pi, float sim_time, matrix * orient);
 extern void physics_sim_rot(matrix * orient, physics_info * pi, float sim_time );
-extern void physics_apply_whack(vec3d *force, vec3d *pos, physics_info *pi, matrix *orient, float mass);
+extern bool whack_below_limit(vec3d* impulse);
+extern void physics_apply_whack(vec3d *force, vec3d *pos, physics_info *pi, matrix *orient, float mass, matrix *inv_moi);
+extern void physics_apply_whack_direct(float orig_impulse, physics_info* pi, vec3d *delta_rotvel, vec3d* delta_vel, matrix* orient);
 extern void physics_apply_shock(vec3d *direction_vec, float pressure, physics_info *pi, matrix *orient, vec3d *min, vec3d *max, float radius);
 extern void physics_collide_whack(vec3d *impulse, vec3d *delta_rotvel, physics_info *pi, matrix *orient, bool is_landing);
 int check_rotvel_limit( physics_info *pi );

--- a/code/physics/physics.h
+++ b/code/physics/physics.h
@@ -146,6 +146,7 @@ extern void physics_apply_whack_direct(float orig_impulse, physics_info* pi, vec
 extern void physics_apply_shock(vec3d *direction_vec, float pressure, physics_info *pi, matrix *orient, vec3d *min, vec3d *max, float radius);
 extern void physics_collide_whack(vec3d *impulse, vec3d *delta_rotvel, physics_info *pi, matrix *orient, bool is_landing);
 int check_rotvel_limit( physics_info *pi );
+extern void physics_add_point_mass_moi(matrix *moi, float mass, vec3d *pos);
 
 
 // If physics_set_viewer is called with the viewer's physics_info, then

--- a/code/physics/physics.h
+++ b/code/physics/physics.h
@@ -140,7 +140,7 @@ extern void physics_sim_editor(vec3d *position, matrix * orient, physics_info * 
 
 extern void physics_sim_vel(vec3d * position, physics_info * pi, float sim_time, matrix * orient);
 extern void physics_sim_rot(matrix * orient, physics_info * pi, float sim_time );
-extern bool whack_below_limit(vec3d* impulse);
+extern bool whack_below_limit(const vec3d* impulse);
 extern void physics_calculate_whack(vec3d *force, vec3d *pos, physics_info *pi, matrix *orient, float mass, matrix *inv_moi);
 extern void physics_apply_whack(float orig_impulse, physics_info* pi, vec3d *delta_rotvel, vec3d* delta_vel, matrix* orient);
 extern void physics_apply_shock(vec3d *direction_vec, float pressure, physics_info *pi, matrix *orient, vec3d *min, vec3d *max, float radius);

--- a/code/scripting/api/objs/physics_info.cpp
+++ b/code/scripting/api/objs/physics_info.cpp
@@ -1,6 +1,7 @@
 
 #include "physics_info.h"
 #include "vecmath.h"
+#include "ship/shiphit.h"
 
 namespace scripting {
 namespace api {
@@ -469,7 +470,7 @@ ADE_FUNC(applyWhack, l_Physics, "vector Impulse, [ vector Position]", "Applies a
 
 	objh = pih->objh;
 
-	physics_apply_whack(impulse, offset, pih->pi, &objh.objp->orient, pih->pi->mass);
+	ship_apply_whack(impulse, offset, objh.objp);
 
 	return ADE_RETURN_TRUE;
 

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -7840,7 +7840,7 @@ static void do_dying_undock_physics(object *dying_objp, ship *dying_shipp)
 		vm_vec_rand_vec_quick(&pos);
 		vm_vec_scale(&pos, docked_objp->radius);
 		// apply whack to docked object
-		physics_apply_whack(&impulse_vec, &pos, &docked_objp->phys_info, &docked_objp->orient, docked_objp->phys_info.mass);
+		ship_apply_whack(&impulse_vec, &pos, docked_objp);
 		// enhance rotation of the docked object
 		vm_vec_scale(&docked_objp->phys_info.rotvel, 2.0f);
 
@@ -7848,7 +7848,7 @@ static void do_dying_undock_physics(object *dying_objp, ship *dying_shipp)
 		vm_vec_negate(&impulse_vec);
 		vm_vec_rand_vec_quick(&pos);
 		vm_vec_scale(&pos, dying_objp->radius);
-		physics_apply_whack(&impulse_vec, &pos, &dying_objp->phys_info, &dying_objp->orient, dying_objp->phys_info.mass);
+		ship_apply_whack(&impulse_vec, &pos, dying_objp);
 
 		// unlink the two objects, since dying_objp has blown up
 		dock_dead_undock_objects(dying_objp, docked_objp);
@@ -16960,7 +16960,7 @@ void object_jettison_cargo(object *objp, object *cargo_objp, float jettison_spee
 	}
 
 	// whack the ship
-	physics_apply_whack(&impulse, &pos, &cargo_objp->phys_info, &cargo_objp->orient, cargo_objp->phys_info.mass);
+	ship_apply_whack(&impulse, &pos, cargo_objp);
 }
 
 float ship_get_exp_damage(object* objp)

--- a/code/ship/shiphit.cpp
+++ b/code/ship/shiphit.cpp
@@ -1800,7 +1800,7 @@ void ship_apply_whack(vec3d *force, vec3d *hit_pos, object *objp)
 
 	if (object_is_docked(objp))
 	{
-		dock_whack_docked_object(force, &rel_world_hit_pos, objp);
+		dock_calculate_whack_docked_object(force, &rel_world_hit_pos, objp);
 	}
 	else
 	{

--- a/code/ship/shiphit.cpp
+++ b/code/ship/shiphit.cpp
@@ -1796,10 +1796,10 @@ void ship_apply_whack(vec3d *force, vec3d *hit_pos, object *objp)
 	vec3d world_hit_pos;
 	vm_vec_unrotate(&world_hit_pos, hit_pos, &objp->orient);
 
-	// If docked, every ship has to be whacked in the correct directions and magnitudes so they all agree
+
 	if (object_is_docked(objp))
 	{
-		dock_whack_all_docked_objects(force, &world_hit_pos, objp);
+		dock_whack_docked_object(force, &world_hit_pos, objp);
 	}
 	else
 	{

--- a/code/ship/shiphit.cpp
+++ b/code/ship/shiphit.cpp
@@ -1790,39 +1790,18 @@ void ship_apply_whack(vec3d *force, vec3d *hit_pos, object *objp)
 
 		game_whack_apply( -test.xyz.x, -test.xyz.y );
 	}
+	
+	vec3d world_hit_pos;
+	vm_vec_unrotate(&world_hit_pos, hit_pos, &objp->orient);
 
+	// If docked, every ship has to be whacked in the correct directions and magnitudes so they all agree
 	if (object_is_docked(objp))
 	{
-		float overall_mass = dock_calc_total_docked_mass(objp);
-
-		// Goober5000 - this code attempts to account properly for whacking a docked object as one mass.
-		// It isn't perfect, because physics doesn't completely account for it (particularly because it
-		// still uses the moment of inertia for the whacked object, not for all objects).  Commenting
-		// out the contents of the block restores the Volition behavior, but it doesn't calculate the
-		// correct torque.
-		// Addendum: this block is now not executed for docked fighters or bombers because the whack
-		// looks like the fighter is doing evasive maneuvers
-		if ((objp->type != OBJ_SHIP) || !(Ship_info[Ships[objp->instance].ship_info_index].is_fighter_bomber()))
-		{
-			vec3d world_hit_pos, world_center_of_mass;
-
-			// calc world hit pos of the hit ship
-			vm_vec_unrotate(&world_hit_pos, hit_pos, &objp->orient);
-			vm_vec_add2(&world_hit_pos, &objp->pos);
-
-			// calc overall world center-of-mass of all ships
-			dock_calc_docked_center_of_mass(&world_center_of_mass, objp);
-
-			// the new hitpos is the vector from world center-of-mass to world hitpos
-			vm_vec_sub(hit_pos, &world_hit_pos, &world_center_of_mass);
-		}
-
-		// whack it
-		physics_apply_whack(force, hit_pos, &objp->phys_info, &objp->orient, overall_mass);
+		dock_whack_all_docked_objects(force, &world_hit_pos, objp);
 	}
 	else
 	{
-		physics_apply_whack(force, hit_pos, &objp->phys_info, &objp->orient, objp->phys_info.mass);
+		physics_apply_whack(force, &world_hit_pos, &objp->phys_info, &objp->orient, objp->phys_info.mass, &objp->phys_info.I_body_inv);
 	}					
 }
 

--- a/code/ship/shiphit.cpp
+++ b/code/ship/shiphit.cpp
@@ -1783,6 +1783,8 @@ extern int Homing_hits, Homing_misses;
 // Goober5000 - note... hit_pos is in *local* coordinates
 void ship_apply_whack(vec3d *force, vec3d *hit_pos, object *objp)
 {
+	Assertion((objp != nullptr) && (force != nullptr) && (hit_pos != nullptr), "ship_apply_whack invalid argument(s)");
+
 	if (objp == Player_obj) {
 		nprintf(("Sandeep", "Playing stupid joystick effect\n"));
 		vec3d test;

--- a/code/ship/shiphit.cpp
+++ b/code/ship/shiphit.cpp
@@ -1804,7 +1804,7 @@ void ship_apply_whack(vec3d *force, vec3d *hit_pos, object *objp)
 	}
 	else
 	{
-		physics_apply_whack(force, &rel_world_hit_pos, &objp->phys_info, &objp->orient, objp->phys_info.mass, &objp->phys_info.I_body_inv);
+		physics_calculate_whack(force, &rel_world_hit_pos, &objp->phys_info, &objp->orient, objp->phys_info.mass, &objp->phys_info.I_body_inv);
 	}					
 }
 

--- a/code/ship/shiphit.cpp
+++ b/code/ship/shiphit.cpp
@@ -1793,17 +1793,18 @@ void ship_apply_whack(vec3d *force, vec3d *hit_pos, object *objp)
 		game_whack_apply( -test.xyz.x, -test.xyz.y );
 	}
 	
-	vec3d world_hit_pos;
-	vm_vec_unrotate(&world_hit_pos, hit_pos, &objp->orient);
+	// get the world coords hit position relative to the ship
+	vec3d rel_world_hit_pos;
+	vm_vec_unrotate(&rel_world_hit_pos, hit_pos, &objp->orient);
 
 
 	if (object_is_docked(objp))
 	{
-		dock_whack_docked_object(force, &world_hit_pos, objp);
+		dock_whack_docked_object(force, &rel_world_hit_pos, objp);
 	}
 	else
 	{
-		physics_apply_whack(force, &world_hit_pos, &objp->phys_info, &objp->orient, objp->phys_info.mass, &objp->phys_info.I_body_inv);
+		physics_apply_whack(force, &rel_world_hit_pos, &objp->phys_info, &objp->orient, objp->phys_info.mass, &objp->phys_info.I_body_inv);
 	}					
 }
 

--- a/code/ship/shiphit.cpp
+++ b/code/ship/shiphit.cpp
@@ -1800,11 +1800,11 @@ void ship_apply_whack(vec3d *force, vec3d *hit_pos, object *objp)
 
 	if (object_is_docked(objp))
 	{
-		dock_calculate_whack_docked_object(force, &rel_world_hit_pos, objp);
+		dock_calculate_and_apply_whack_docked_object(force, &rel_world_hit_pos, objp);
 	}
 	else
 	{
-		physics_calculate_whack(force, &rel_world_hit_pos, &objp->phys_info, &objp->orient, objp->phys_info.mass, &objp->phys_info.I_body_inv);
+		physics_calculate_and_apply_whack(force, &rel_world_hit_pos, &objp->phys_info, &objp->orient, objp->phys_info.mass, &objp->phys_info.I_body_inv);
 	}					
 }
 


### PR DESCRIPTION
Fixes #2525 . Basically this will, after calculating the center of mass of the docked ships and their aggregate MOI, 'whack' each individual ship with corrected rotational and linear velocities so that all ships in the aggregate move along with what the aggregate would rotate and move with. Also replaces all outside callings of physics_apply_whack with ship_apply_whack, so this checking can be done. 

In general, physics_apply_whack shouldn't be called in lieu of ship_apply_whack or you'll get the previous issues. Also physics_apply_whack is now properly passed a world position, instead of a local position as it was doing before, fixing some weird whack behavior you could get and appeared to be retail!

Of note: this does NOT alter shockwaves or collisions, only weapons fire! They will continue to exhibit the bad behavior, and fixing them is on our to-do list.