### PR TITLE
Fix Standalone Crashes

### DIFF
--- a/code/graphics/2d.cpp
+++ b/code/graphics/2d.cpp
@@ -1659,7 +1659,7 @@ void gr_activate(int active)
 	}
 	gr_activated = active;
 
-	if ( !Gr_inited ) { 
+	if ( !Gr_inited || os::getMainViewport() == nullptr) { 
 		return;
 	}
 


### PR DESCRIPTION
Standalones would crash if they had an error dialog pop up because of a nullptr.  This just checks for the nullptr and returns early to prevent the crash.