### PR TITLE
fix FRED's verify_and_fix_arguments

### DIFF
--- a/fred2/sexp_tree.cpp
+++ b/fred2/sexp_tree.cpp
@@ -3290,14 +3290,14 @@ int sexp_tree::get_modify_variable_type(int parent)
 void sexp_tree::verify_and_fix_arguments(int node)
 {
 	int op_index, arg_num, type, tmp;
+	static int here_count = 0;
 	sexp_list_item *list, *ptr;
 	bool is_variable_arg = false; 
 
-	static bool was_here = false;
-	if (was_here)
+	if (here_count)
 		return;
 
-	was_here = true;
+	here_count++;
 	op_index = get_operator_index(tree_nodes[node].text);
 	if (op_index < 0)
 		return;
@@ -3319,7 +3319,7 @@ void sexp_tree::verify_and_fix_arguments(int node)
 			if (!list && (arg_num >= Operators[op_index].min)) {
 				free_node(item_index, 1);
 				item_index = tmp;
-				flag--;
+				here_count--;
 				return;
 			}
 
@@ -3436,7 +3436,7 @@ void sexp_tree::verify_and_fix_arguments(int node)
 	}
 
 	item_index = tmp;
-	flag--;
+	here_count--;
 }
 
 void sexp_tree::replace_data(const char *data, int type)

--- a/qtfred/src/ui/widgets/sexp_tree.cpp
+++ b/qtfred/src/ui/widgets/sexp_tree.cpp
@@ -1973,15 +1973,15 @@ int sexp_tree::get_modify_variable_type(int parent) {
 
 void sexp_tree::verify_and_fix_arguments(int node) {
 	int op_index, arg_num, type, tmp;
+	static int here_count = 0;
 	sexp_list_item* list, * ptr;
 	bool is_variable_arg = false;
 
-	static bool was_here = false;
-	if (was_here) {
+	if (here_count) {
 		return;
 	}
 
-	was_here = true;
+	here_count++;
 	op_index = get_operator_index(tree_nodes[node].text);
 	if (op_index < 0) {
 		return;
@@ -2004,7 +2004,7 @@ void sexp_tree::verify_and_fix_arguments(int node) {
 			if (!list && (arg_num >= Operators[op_index].min)) {
 				free_node(item_index, 1);
 				setCurrentItemIndex(tmp);
-				flag--;
+				here_count--;
 				return;
 			}
 
@@ -2123,7 +2123,7 @@ void sexp_tree::verify_and_fix_arguments(int node) {
 	}
 
 	setCurrentItemIndex(tmp);
-	flag--;
+	here_count--;
 }
 
 void sexp_tree::replace_data(const char* new_data, int type) {


### PR DESCRIPTION
This was a fun one.  Volition used a bizarre and very poorly named "flag" static variable to track iterations through the `verify_and_fix_arguments` function.  I'm not sure how this actually works, but on comparing with the original public source code I see that @asarium didn't quite fix the "declaration masks class variable" compiler warning the right way.  This rolls back that 2016 change and fixes it properly.

The effect of this fix is so that FRED will correctly handle arguments when node data types change, such as when the modify-variable argument is changed from a numeric variable to a string variable.