### PR TITLE
Relative error for mag and dist_quick, and seeded vecmat tests

### DIFF
--- a/test/src/math/test_vecmat.cpp
+++ b/test/src/math/test_vecmat.cpp
@@ -35,7 +35,7 @@ public:
 	VecmatTest() : test::FSTestFixture() { pushModDir("vecmat"); }
 
 protected:
-	void SetUp() override { test::FSTestFixture::SetUp(); }
+	void SetUp() override { test::FSTestFixture::SetUp(); srand(1); }
 	void TearDown() override { test::FSTestFixture::TearDown(); }
 };
 
@@ -642,7 +642,10 @@ TEST_F(VecmatTest, test_vm_vec_mag_quick) {
 
 		auto magnitude = vm_vec_mag(&v);
 
-		ASSERT_NEAR(magnitude, vm_vec_mag_quick(&v), 0.1f);
+		// maximum relative error here calculated to be 0.90211 <= (approx/real) <= 1.08433
+		const double tolerated_error = fmax(fabs(magnitude), 1e-6) * 0.1f;
+
+		ASSERT_NEAR(magnitude, vm_vec_mag_quick(&v), tolerated_error);
 	}
 }
 
@@ -657,7 +660,10 @@ TEST_F(VecmatTest, test_vm_vec_dist_quick)
 		auto distance = vm_vec_dist_quick(&v1, &v2);
 		auto real_distance = vm_vec_dist(&v1, &v2);
 
-		ASSERT_NEAR(distance, real_distance, 0.13f);
+		// maximum relative error here calculated to be 0.90211 <= (approx/real) <= 1.08433
+		const double tolerated_error = fmax(fabs(real_distance), 1e-6) * 0.1f;
+		
+		ASSERT_NEAR(distance, real_distance, tolerated_error);
 	}
 }
 

--- a/test/src/math/test_vecmat.cpp
+++ b/test/src/math/test_vecmat.cpp
@@ -35,7 +35,11 @@ public:
 	VecmatTest() : test::FSTestFixture() { pushModDir("vecmat"); }
 
 protected:
-	void SetUp() override { test::FSTestFixture::SetUp(); srand(1); }
+	void SetUp() override 
+	{ 
+		test::FSTestFixture::SetUp(); 
+		srand(1); 
+	}
 	void TearDown() override { test::FSTestFixture::TearDown(); }
 };
 


### PR DESCRIPTION
I calculated mag_quick's exact relative error (used also by dist_quick) and am using that instead of an absolute value. Also uses a seed for the random tests to avoid one in a thousand compiles failing for someone.