### PR TITLE
some UTF-8 improvements

### DIFF
--- a/code/parse/parselo.h
+++ b/code/parse/parselo.h
@@ -263,6 +263,7 @@ extern void read_file_text(const char *filename, int mode = CF_TYPE_ANY, char *p
 extern void read_file_text_from_default(const default_file& file, char *processed_text = NULL, char *raw_text = NULL);
 extern void read_raw_file_text(const char *filename, int mode = CF_TYPE_ANY, char *raw_text = NULL);
 extern void process_raw_file_text(char *processed_text = NULL, char *raw_text = NULL);
+extern void coerce_to_utf8(SCP_string &buffer, const char *src);
 extern void debug_show_mission_text();
 extern void convert_sexp_to_string(SCP_string &dest, int cur_node, int mode);
 extern size_t maybe_convert_foreign_characters(const char *in, char *out, bool add_null = true);

--- a/code/pilotfile/JSONFileHandler.cpp
+++ b/code/pilotfile/JSONFileHandler.cpp
@@ -4,6 +4,11 @@
 #include "libs/jansson.h"
 #include "parse/parselo.h"
 
+// it's kinda tricky to #include "utf.h" here, so we forward-declare this, but note that it's a C function
+extern "C" {
+	extern int utf8_check_string(const char *string, size_t length);
+}
+
 namespace {
 const SCP_vector<std::pair<Section, const char*>> SectionMapping {
 	std::pair<Section, const char*>(Section::Unnamed, nullptr),
@@ -104,7 +109,18 @@ void pilot::JSONFileHandler::writeFloat(const char* name, float value) {
 }
 void pilot::JSONFileHandler::writeString(const char* name, const char* str) {
 	ensureNotExists(name);
-	json_object_set_new(_currentEl, name, json_string(str));
+	json_t *jstr;
+
+	// if this string isn't proper UTF-8, try to convert it
+	if (str && !utf8_check_string(str, strlen(str))) {
+		SCP_string buffer;
+		coerce_to_utf8(buffer, str);
+		jstr = json_string(buffer.c_str());
+	} else {
+		jstr = json_string(str);
+	}
+
+	json_object_set_new(_currentEl, name, jstr);
 }
 void pilot::JSONFileHandler::beginWritingSections() {
 	ensureNotExists("sections");


### PR DESCRIPTION
1) Write all non-UTF-8 strings to JSON, either by converting or truncating
2) Add `coerce_to_utf8` function
3) Tweak `read_raw_file_text` because the function returns length on success, not 0

Fixes Mantis ticket:
http://scp.indiegames.us/mantis/view.php?id=3209