### PR TITLE
make _quick quicker

### DIFF
--- a/code/math/vecmat.h
+++ b/code/math/vecmat.h
@@ -175,14 +175,14 @@ float vm_vec_dist_squared(const vec3d *v0, const vec3d *v1);
 //computes the distance between two points. (does sub and mag)
 float vm_vec_dist(const vec3d *v0, const vec3d *v1);
 
-//computes an approximation of the magnitude of the vector
-//uses dist = largest + next_largest*3/8 + smallest*3/16
-float vm_vec_mag_quick(const vec3d *v);
-
-//computes an approximation of the distance between two points.
-//uses dist = largest + next_largest*3/8 + smallest*3/16
-float vm_vec_dist_quick(const vec3d *v0, const vec3d *v1);
-
+// these are now deprecated because experimental testing on Discord has found
+// that they are actually *slower* than their counterparts
+#define vm_vec_mag_quick				vm_vec_mag
+#define vm_vec_dist_quick				vm_vec_dist
+#define vm_vec_copy_normalize_quick		vm_vec_copy_normalize
+#define vm_vec_normalize_quick			vm_vec_normalize
+#define vm_vec_normalized_dir_quick		vm_vec_normalized_dir
+#define vm_vec_rand_vec_quick			vm_vec_rand_vec
 
 //normalize a vector. returns mag of source vec
 float vm_vec_copy_normalize(vec3d *dest, const vec3d *src);
@@ -192,19 +192,11 @@ float vm_vec_normalize(vec3d *v);
 //	If it is detected, it generates a Warning() and returns the vector 1, 0, 0.
 float vm_vec_normalize_safe(vec3d *v);
 
-//normalize a vector. returns mag of source vec. uses approx mag
-float vm_vec_copy_normalize_quick(vec3d *dest, const vec3d *src);
-float vm_vec_normalize_quick(vec3d *v);
-
-//normalize a vector. returns mag of source vec. uses approx mag
-float vm_vec_copy_normalize_quick_mag(vec3d *dest, const vec3d *src);
-
 //return the normalized direction vector between two points
 //dest = normalized(end - start).  Returns mag of direction vector
+// Returns mag of direction vector
 //NOTE: the order of the parameters matches the vector subtraction
 float vm_vec_normalized_dir(vec3d *dest,const vec3d *end, const vec3d *start);
-// Returns mag of direction vector
-float vm_vec_normalized_dir_quick(vec3d *dest, const vec3d *end, const vec3d *start);
 
 ////returns dot product of two vectors
 float vm_vec_dot(const vec3d *v0, const vec3d *v1);
@@ -385,9 +377,8 @@ void compute_point_on_plane(vec3d *q, const plane *planep, const vec3d *p);
 //						plane_point		=>		plane point
 void vm_project_point_onto_plane(vec3d *new_point, const vec3d *point, const vec3d *plane_normal, const vec3d *plane_point);
 
-
-//	Returns fairly random vector, "quick" normalized
-void vm_vec_rand_vec_quick(vec3d *rvec);
+//	Returns fairly random vector, normalized
+void vm_vec_rand_vec(vec3d *rvec);
 
 // Given an point "in" rotate it by "angle" around an
 // arbritary line defined by a point on the line "line_point" 

--- a/test/src/math/test_vecmat.cpp
+++ b/test/src/math/test_vecmat.cpp
@@ -638,39 +638,6 @@ TEST_F(VecmatTest, test_vm_vec_dist_squared)
 	}
 }
 
-TEST_F(VecmatTest, test_vm_vec_mag_quick) {
-	for (size_t loop = 0; loop < 1000; ++loop) {
-		vec3d v;
-
-		static_randvec_unnormalized(rand32(), &v);
-
-		auto magnitude = vm_vec_mag(&v);
-
-		// maximum relative error here calculated to be 0.90211 <= (approx/real) <= 1.08433
-		const double tolerated_error = fmax(fabs(magnitude), 1e-6) * 0.1f;
-
-		ASSERT_NEAR(magnitude, vm_vec_mag_quick(&v), tolerated_error);
-	}
-}
-
-TEST_F(VecmatTest, test_vm_vec_dist_quick)
-{
-	for (size_t loop = 0; loop < 1000; ++loop) {
-		vec3d v1, v2;
-
-		static_randvec_unnormalized(rand32(), &v1);
-		static_randvec_unnormalized(rand32(), &v2);
-
-		auto distance = vm_vec_dist_quick(&v1, &v2);
-		auto real_distance = vm_vec_dist(&v1, &v2);
-
-		// maximum relative error here calculated to be 0.90211 <= (approx/real) <= 1.08433
-		const double tolerated_error = fmax(fabs(real_distance), 1e-6) * 0.1f;
-		
-		ASSERT_NEAR(distance, real_distance, tolerated_error);
-	}
-}
-
 TEST_F(VecmatTest, test_vm_vec_normalize)
 {
 	for (size_t loop = 0; loop < 1000; ++loop) {


### PR DESCRIPTION
The functions derived from `vm_vec_mag_quick` run *slower* than `vm_vec_mag`, according to @Baezon who did some testing.  So this PR makes all calls to the _quick functions use their more accurate counterparts.