### PR TITLE
Randomized weapon shockwave orientations

### DIFF
--- a/code/weapon/shockwave.cpp
+++ b/code/weapon/shockwave.cpp
@@ -706,6 +706,7 @@ void shockwave_create_info_init(shockwave_create_info *sci)
 	sci->inner_rad = sci->outer_rad = sci->damage = sci->blast = sci->speed = 0.0f;
 
 	sci->rot_angles.p = sci->rot_angles.b = sci->rot_angles.h = 0.0f;
+	sci->rot_defined = false;
 	sci->damage_type_idx = sci->damage_type_idx_sav = -1;
 }
 

--- a/code/weapon/shockwave.h
+++ b/code/weapon/shockwave.h
@@ -80,6 +80,7 @@ typedef struct shockwave_create_info {
 	float blast;
 	float speed;
 	angles rot_angles;
+	bool rot_defined;		// if the modder specified rot_angles
 
 	int damage_type_idx;
 	int damage_type_idx_sav;	// stored value from table used to reset damage_type_idx

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -6349,9 +6349,9 @@ void weapon_hit( object * weapon_obj, object * other_obj, vec3d * hitpos, int qu
 	{
 		if(sci->speed > 0.0f) {
 			if (!sci->rot_defined) {
-				sci->rot_angles.p = frand_range(0.0f, 1.99f * PI);
-				sci->rot_angles.b = frand_range(0.0f, 1.99f * PI);
-				sci->rot_angles.h = frand_range(0.0f, 1.99f * PI);
+				sci->rot_angles.p = frand_range(0.0f, PI2);
+				sci->rot_angles.b = frand_range(0.0f, PI2);
+				sci->rot_angles.h = frand_range(0.0f, PI2);
 			}
 			shockwave_create(OBJ_INDEX(weapon_obj), hitpos, sci, sw_flag, -1);
 		}

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -751,6 +751,8 @@ void parse_shockwave_info(shockwave_create_info *sci, const char *pre_char)
 		sci->rot_angles.p = angs[0];
 		sci->rot_angles.b = angs[1];
 		sci->rot_angles.h = angs[2];
+
+		sci->rot_defined = true;
 	}
 
 	sprintf(buf, "%sShockwave Model:", pre_char);
@@ -6346,6 +6348,11 @@ void weapon_hit( object * weapon_obj, object * other_obj, vec3d * hitpos, int qu
 	if (sci->inner_rad != 0.0f || sci->outer_rad != 0.0f)
 	{
 		if(sci->speed > 0.0f) {
+			if (!sci->rot_defined) {
+				sci->rot_angles.p = frand_range(0.0f, 1.99f * PI);
+				sci->rot_angles.b = frand_range(0.0f, 1.99f * PI);
+				sci->rot_angles.h = frand_range(0.0f, 1.99f * PI);
+			}
 			shockwave_create(OBJ_INDEX(weapon_obj), hitpos, sci, sw_flag, -1);
 		}
 		else {


### PR DESCRIPTION
Currently 3D shockwaves from weapons will always have their orientations fixed at 0,0,0 unless explicitly tabled otherwise. There's really no reason for them not to be simply randomized if the modder didn't set a specific orientation, and it looks quite jarring once you notice it.