### PR TITLE
Improve physics_ship_init safety

### DIFF
--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -5645,13 +5645,13 @@ void physics_ship_init(object *objp)
 	else 
 		pi->mass = pm->mass * sinfo->density;
 
-	// it was print-worthy back in modelread.cpp, but now that its being used for an actual ship the user should be warned.
+	// it was print-worthy back in read_model_file() in modelread.cpp, but now that its being used for an actual ship the user should be warned.
 	if (IS_VEC_NULL(&pm->moment_of_inertia.vec.fvec)
 		&& IS_VEC_NULL(&pm->moment_of_inertia.vec.uvec)
 		&& IS_VEC_NULL(&pm->moment_of_inertia.vec.rvec))
 		Warning(LOCATION, "%s (%s) has a null moment of inertia!", sinfo->name, sinfo->pof_file);
 
-	// if invalid they were already warned about this in modelread.cpp, so now we just need to try and sweep it under the rug
+	// if invalid they were already warned about this in read_model_file() in modelread.cpp, so now we just need to try and sweep it under the rug
 	if (!is_valid_matrix(&pm->moment_of_inertia))
 	{
 		// TODO: generate MOI properly


### PR DESCRIPTION
Improves physics initialization for ships; a few changes here.

Firstly, a check for density. Ships should never have density 0.

Now that density has been sanity checked it can't ruin attempts at compensating for 0 mass when it scales the new mass at the end by density (*facepalm*).

And then, as the comments state, invalid MOI got a warning earlier, but not zero MOI because it might not be a big deal. Now it is a bigger deal so warn for zero MOI.

Only if we have a truly invalid MOI do we "compensate" by setting it zero (instead of just using the bad MOI anyway (*facepalm*)). Zero MOI is not great either, but if the intention is to try and sweep this problem under the rug for release, zero MOI is the safest bet. It'll just be immovable (rotationally), and if you're not paying close attention it can totally fly under the radar.

Finally, scaling MOI by a density greater than 1 will make it _easier_ to whack, not harder, since the MOI is inverted. Scale by inverse density! (I suspect this is why the Isis, with density 2, has always been so easy to whack around).