### PR TITLE
Fix query bomb in PXO game tracker

### DIFF
--- a/code/network/gtrack.cpp
+++ b/code/network/gtrack.cpp
@@ -453,7 +453,7 @@ game_list * GetGameList()
 {
 	static game_list gl;
 
-	for (auto game : GameBuffer) {
+	for (auto &game : GameBuffer) {
 		if (game.game_type != GT_UNUSED) {
 			memcpy(&gl, &game, sizeof(game_list));
 			game.game_type = GT_UNUSED;


### PR DESCRIPTION
A loop mistakenly using value instead of reference caused servers to be bombarded with game queries.