### PR TITLE
Allow pasting clipboard contents into input boxes

### DIFF
--- a/code/ui/ui.h
+++ b/code/ui/ui.h
@@ -316,6 +316,7 @@ class UI_INPUTBOX : public UI_GADGET
 		int pressed();
 		void get_text(char *out);
 		void set_text(const char *in);
+		void append_text(const char *in);
 };
 
 // Icon flags


### PR DESCRIPTION
By special request of Cyborg. Pressing CTRL+v in an active input box will append any text from the system clipboard into the control.