### PR TITLE
Fix sidebars retaining old rendering from mission quick exit

### DIFF
--- a/code/network/multi_endgame.cpp
+++ b/code/network/multi_endgame.cpp
@@ -292,7 +292,7 @@ int multi_quit_game(int prompt, int notify_code, int err_code, int wsa_error)
 				psnet_rel_close_socket(&Net_player->reliable_socket);
 				Net_player->reliable_socket = INVALID_SOCKET;
 
-				// remove our do-notworking flag
+				// remove our do-networking flag
 				Net_player->flags &= ~(NETINFO_FLAG_DO_NETWORKING);
 				
 				Multi_quit_game = 0;

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -5114,7 +5114,15 @@ void game_leave_state( int old_state, int new_state )
 				snd_aav_init();
 
 				freespace_stop_mission();
-				
+
+				// when going straight from the mission into the pxo state, make sure to clear the mission.
+				if (new_state == GS_STATE_PXO) {
+					gr_clear();
+					gr_flip();
+					gr_clear();
+					gr_flip();
+				}
+
 				if (Cmdline_benchmark_mode) {
 					gameseq_post_event( GS_EVENT_QUIT_GAME );
 				}


### PR DESCRIPTION
And also a minor typo

The issue in other words is that stuff rendered on the last frame of the mission will be stuck on the sidebars for a long time.

Just tested and this works on release and debug. Open to moving the fix somewhere, just let me know if there's a more proper place.