### PR TITLE
add ship-maneuver flags to ship_info

### DIFF
--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -1213,8 +1213,10 @@ void ai_turn_towards_vector(vec3d *dest, object *objp, float turn_time, vec3d *s
 	}
 
 	//	Should be more general case here.  Currently, anything that is not a weapon will bank when it turns.
-	// Goober5000 - don't bank if sexp says not to
+	// Goober5000 - don't bank if sexp or ship says not to
 	if ( (objp->type == OBJ_WEAPON) || (sexp_flags & AITTV_IGNORE_BANK ) )
+		delta_bank = 0.0f;
+	else if (objp->type == OBJ_SHIP && Ship_info[Ships[objp->instance].ship_info_index].flags[Ship::Info_Flags::Dont_bank_when_turning])
 		delta_bank = 0.0f;
 	else if ((bank_override) && (iff_x_attacks_y(Ships[objp->instance].team, Player_ship->team))) {	//	Theoretically, this will only happen for Shivans.
 		delta_bank = bank_override;
@@ -14108,7 +14110,7 @@ void ai_frame(int objnum)
 	}
 }
 
-static void ai_control_info_check(ai_info *aip, physics_info *pi)
+static void ai_control_info_check(ai_info *aip, ship_info *sip, physics_info *pi)
 {
 	if (aip->ai_override_flags.none_set())
 		return;
@@ -14163,11 +14165,11 @@ static void ai_control_info_check(ai_info *aip, physics_info *pi)
 			}
 		}
 
-		if (aip->ai_override_flags[AI::Maneuver_Override_Flags::Dont_bank_when_turning])
+		if (aip->ai_override_flags[AI::Maneuver_Override_Flags::Dont_bank_when_turning] || sip->flags[Ship::Info_Flags::Dont_bank_when_turning])
 			AI_ci.control_flags |= CIF_DONT_BANK_WHEN_TURNING;
-		if (aip->ai_override_flags[AI::Maneuver_Override_Flags::Dont_clamp_max_velocity])
+		if (aip->ai_override_flags[AI::Maneuver_Override_Flags::Dont_clamp_max_velocity] || sip->flags[Ship::Info_Flags::Dont_clamp_max_velocity])
 			AI_ci.control_flags |= CIF_DONT_CLAMP_MAX_VELOCITY;
-		if (aip->ai_override_flags[AI::Maneuver_Override_Flags::Instantaneous_acceleration])
+		if (aip->ai_override_flags[AI::Maneuver_Override_Flags::Instantaneous_acceleration] || sip->flags[Ship::Info_Flags::Instantaneous_acceleration])
 			AI_ci.control_flags |= CIF_INSTANTANEOUS_ACCELERATION;
 	}
 
@@ -14185,15 +14187,19 @@ void ai_process( object * obj, int ai_index, float frametime )
 	if (obj->flags[Object::Object_Flags::Should_be_dead])
 		return;
 
+	Assert(obj->type == OBJ_SHIP);
+	auto shipp = &Ships[obj->instance];
+	auto sip = &Ship_info[shipp->ship_info_index];
+
 	// return if ship is dead, unless it's a big ship...then its turrets still fire, like I was quoted in a magazine.  -- MK, 5/15/98.
-	if ((Ships[obj->instance].flags[Ship::Ship_Flags::Dying] ) && !(Ship_info[Ships[obj->instance].ship_info_index].is_big_or_huge())) {
+	if ((shipp->flags[Ship::Ship_Flags::Dying] ) && !(Ship_info[shipp->ship_info_index].is_big_or_huge())) {
 		return;
 	}
 
 	bool rfc = true;		//	Assume will be Reading Flying Controls.
 
-	Assert( obj->type == OBJ_SHIP );
 	Assert( ai_index >= 0 );
+	auto aip = &Ai_info[shipp->ai_index];
 
 	AI_frametime = frametime;
 	if (OBJ_INDEX(obj) <= Last_ai_obj) {
@@ -14209,8 +14215,7 @@ void ai_process( object * obj, int ai_index, float frametime )
 	AI_ci.heading = 0.0f;
 
 	// the ships maximum velocity now depends on the energy flowing to engines
-	obj->phys_info.max_vel.xyz.z = Ships[obj->instance].current_max_speed;
-	ai_info	*aip = &Ai_info[Ships[obj->instance].ai_index];
+	obj->phys_info.max_vel.xyz.z = shipp->current_max_speed;
 
 	//	In certain circumstances, the AI says don't fly in the normal way.
 	//	One circumstance is in docking and undocking, when the ship is moving
@@ -14230,7 +14235,7 @@ void ai_process( object * obj, int ai_index, float frametime )
 
 	if (rfc) {
 		// Wanderer - sexp based override goes here - only if rfc is valid though
-		ai_control_info_check(aip, &obj->phys_info);
+		ai_control_info_check(aip, sip, &obj->phys_info);
 		vec3d copy_desired_rotvel = obj->phys_info.rotvel;
 		physics_read_flying_controls( &obj->orient, &obj->phys_info, &AI_ci, frametime);
 		// if obj is in formation and not flight leader, don't update rotvel

--- a/code/playerman/playercontrol.cpp
+++ b/code/playerman/playercontrol.cpp
@@ -1009,6 +1009,18 @@ void read_player_controls(object *objp, float frametime)
 		case PCM_NORMAL:
 			read_keyboard_controls(&(Player->ci), frametime, &objp->phys_info );
 
+			// this is similar to ai_control_info_check
+			if (Player_obj->type == OBJ_SHIP) {
+				auto sip = &Ship_info[Ships[Player_obj->instance].ship_info_index];
+
+				if (sip->flags[Ship::Info_Flags::Dont_bank_when_turning])
+					Player->ci.control_flags |= CIF_DONT_BANK_WHEN_TURNING;
+				if (sip->flags[Ship::Info_Flags::Dont_clamp_max_velocity])
+					Player->ci.control_flags |= CIF_DONT_CLAMP_MAX_VELOCITY;
+				if (sip->flags[Ship::Info_Flags::Instantaneous_acceleration])
+					Player->ci.control_flags |= CIF_INSTANTANEOUS_ACCELERATION;
+			}
+
 			if ( lua_game_control & LGC_STEERING ) {
 				// make sure to copy the control before reseting it
 				Player->lua_ci = Player->ci;

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -317,7 +317,7 @@ flag_def_list_new<Info_Flags> Ship_flags[] = {
     { "ship copy",					Info_Flags::Ship_copy,				true, false },
     { "in tech database",			Info_Flags::In_tech_database,		true, false },
     { "in tech database multi",		Info_Flags::In_tech_database_m,		true, false },
-    { "dont collide invisible",		Info_Flags::Ship_class_dont_collide_invis, true, false },
+    { "don't collide invisible",	Info_Flags::Ship_class_dont_collide_invis, true, false },
     { "big damage",					Info_Flags::Big_damage,				true, false },
     { "corvette",					Info_Flags::Corvette,				true, false },
     { "gas miner",					Info_Flags::Gas_miner,				true, false },
@@ -340,6 +340,9 @@ flag_def_list_new<Info_Flags> Ship_flags[] = {
     { "auto spread shields",		Info_Flags::Auto_spread_shields,	true, false },
     { "model point shields",		Info_Flags::Model_point_shields,	true, false },
     { "repair disabled subsystems", Info_Flags::Subsys_repair_when_disabled, true, false},
+	{ "don't bank when turning",	Info_Flags::Dont_bank_when_turning,		true, false },
+	{ "don't clamp max velocity",	Info_Flags::Dont_clamp_max_velocity,	true, false },
+	{ "instantaneous acceleration",	Info_Flags::Instantaneous_acceleration,	true, false },
     // to keep things clean, obsolete options go last
     { "ballistic primaries",		Info_Flags::Ballistic_primaries,	false, false }
 };
@@ -3477,6 +3480,18 @@ static void parse_ship_values(ship_info* sip, const bool is_template, const bool
 			if (!stricmp(ship_strings[i], "no-collide") || !stricmp(ship_strings[i], "no_collide")) {
 				flag_found = true;
 				sip->flags.set(Ship::Info_Flags::No_collide);
+			}
+			if (!stricmp(ship_strings[i], "dont collide invisible")) {
+				flag_found = true;
+				sip->flags.set(Ship::Info_Flags::Ship_class_dont_collide_invis);
+			}
+			if (!stricmp(ship_strings[i], "dont bank when turning")) {
+				flag_found = true;
+				sip->flags.set(Ship::Info_Flags::Dont_bank_when_turning);
+			}
+			if (!stricmp(ship_strings[i], "dont clamp max velocity")) {
+				flag_found = true;
+				sip->flags.set(Ship::Info_Flags::Dont_clamp_max_velocity);
 			}
 
 			if ( !flag_found && (ship_type_index < 0) )

--- a/code/ship/ship_flags.h
+++ b/code/ship/ship_flags.h
@@ -188,6 +188,9 @@ namespace Ship {
 		Draw_weapon_models,				// the ship draws weapon models of any sort (used to be a boolean)
 		Model_point_shields,			// zookeeper - uses model-defined shield points instead of quadrants
         Subsys_repair_when_disabled,    // MageKing17 - Subsystems auto-repair themselves even when disabled.
+		Dont_bank_when_turning,			// Goober5000
+		Dont_clamp_max_velocity,		// Goober5000
+		Instantaneous_acceleration,		// Goober5000
 
 		NUM_VALUES
 	};


### PR DESCRIPTION
This allows the ship-maneuver flags to be used by default in a ship class.