### PR TITLE
Add '$Swarmers Lead Targets:' to game_settings.tbl

### DIFF
--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -57,6 +57,7 @@ std::tuple<ubyte, ubyte, ubyte> Arc_color_emp_p1;
 std::tuple<ubyte, ubyte, ubyte> Arc_color_emp_p2;
 std::tuple<ubyte, ubyte, ubyte> Arc_color_emp_s1;
 bool Use_engine_wash_intensity;
+bool Swarmers_lead_targets;
 
 void parse_mod_table(const char *filename)
 {
@@ -518,6 +519,10 @@ void parse_mod_table(const char *filename)
 			stuff_boolean(&Use_engine_wash_intensity);
 		}
 
+		if (optional_string("$Swarmers Lead Targets:")) {
+			stuff_boolean(&Swarmers_lead_targets);
+		}
+
 		required_string("#END");
 	}
 	catch (const parse::ParseException& e)
@@ -590,4 +595,5 @@ void mod_table_reset()
 	Arc_color_emp_p2 = std::make_tuple(static_cast<ubyte>(128), static_cast<ubyte>(128), static_cast<ubyte>(10));
 	Arc_color_emp_s1 = std::make_tuple(static_cast<ubyte>(255), static_cast<ubyte>(255), static_cast<ubyte>(10));
 	Use_engine_wash_intensity = false;
+	Swarmers_lead_targets = false;
 }

--- a/code/mod_table/mod_table.h
+++ b/code/mod_table/mod_table.h
@@ -48,6 +48,7 @@ extern std::tuple<ubyte, ubyte, ubyte> Arc_color_emp_p1;
 extern std::tuple<ubyte, ubyte, ubyte> Arc_color_emp_p2;
 extern std::tuple<ubyte, ubyte, ubyte> Arc_color_emp_s1;
 extern bool Use_engine_wash_intensity;
+extern bool Swarmers_lead_targets;
 
 void mod_table_init();
 

--- a/code/weapon/swarm.cpp
+++ b/code/weapon/swarm.cpp
@@ -249,9 +249,33 @@ void swarm_update_direction(object *objp)
 
 		} else if (hobjp != &obj_used_list &&
 				   f2fl(Missiontime - wp->creation_time) > 0.5f &&
-				   f2fl(Missiontime - wp->creation_time) > wip->free_flight_time) {
-			// swarm missile is homing in on homing_pos
-			swarmp->original_target = wp->homing_pos;
+				   f2fl(Missiontime - wp->creation_time) > wip->free_flight_time) 
+		{
+			if (Swarmers_lead_targets) { // This is a copy of the relevant bits near the end of weapon_home() to make missiles lead their targets
+				vec3d target_pos = wp->homing_pos;
+				vec3d vec_to_goal;
+				float dist_to_target = vm_vec_normalized_dir(&vec_to_goal, &target_pos, &objp->pos);
+				float time_to_target = dist_to_target / wip->max_speed;
+
+				vec3d tvec;
+				tvec = objp->phys_info.vel;
+				vm_vec_normalize(&tvec);
+
+				float old_dot = vm_vec_dot(&tvec, &vec_to_goal);
+
+				if ((old_dot > 0.1f) && (time_to_target > 0.1f)) {
+					if (wip->wi_flags[Weapon::Info_Flags::Variable_lead_homing]) {
+						vm_vec_scale_add2(&target_pos, &hobjp->phys_info.vel, (0.33f * wip->target_lead_scaler * MIN(time_to_target, 6.0f)));
+					}
+					else if (wip->is_locked_homing()) {
+						vm_vec_scale_add2(&target_pos, &hobjp->phys_info.vel, MIN(time_to_target, 2.0f));
+					}
+				}
+				swarmp->original_target = target_pos;
+			}
+			else { // Else, retail behavior (usually simply the target's position)
+				swarmp->original_target = wp->homing_pos;
+			}
 		}
 
 		// Calculate a rvec and uvec that will determine the displacement from the


### PR DESCRIPTION
Before, swarmers would ignore all of the code that handles leading of targets when it leaves weapon_home() and enters swarm_update_direction(). This will restore that hunk of code when the swarm handles the actual position they're homing towards. 

Note that, until they're in the home stretch and allowed to book it straight for the target, they only change their direction at all every time they 'zig', so they'll still be less accurate than non-swarmers.