### PR TITLE
Make Vulkan an optional component

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,6 +121,8 @@ option(FSO_RELEASE_LOGGING "Enable logging output for release builds" OFF)
 
 OPTION(FSO_BUILD_WITH_FFMPEG "Enable the usage of FFmpeg for sound and custscenes" ON)
 
+OPTION(FSO_BUILD_WITH_VULKAN "Enable compilation of the Vulkan renderer" ON)
+
 MARK_AS_ADVANCED(FORCE FSO_CMAKE_DEBUG)
 MARK_AS_ADVANCED(FORCE FSO_BUILD_INCLUDED_LIBS)
 MARK_AS_ADVANCED(FORCE FSO_USE_OPENALSOFT)
@@ -131,6 +133,7 @@ mark_as_advanced(FORCE FSO_INSTALL_DEBUG_FILES)
 mark_as_advanced(FORCE ENABLE_COTIRE)
 mark_as_advanced(FORCE FSO_RELEASE_LOGGING)
 mark_as_advanced(FORCE FSO_BUILD_WITH_FFMPEG)
+mark_as_advanced(FORCE FSO_BUILD_WITH_VULKAN)
 
 # Include cotire file from https://github.com/sakra/cotire/
 include(cotire)
@@ -207,3 +210,4 @@ message(STATUS "Building qtFRED: ${FSO_BUILD_QTFRED}")
 message(STATUS "Fatal warnings: ${FSO_FATAL_WARNINGS}")
 message(STATUS "Release logging: ${FSO_RELEASE_LOGGING}")
 message(STATUS "With FFmpeg: ${FSO_BUILD_WITH_FFMPEG}")
+message(STATUS "With Vulkan: ${FSO_BUILD_WITH_VULKAN}")

--- a/code/CMakeLists.txt
+++ b/code/CMakeLists.txt
@@ -45,7 +45,9 @@ target_link_libraries(code PUBLIC libRocket)
 
 target_link_libraries(code PUBLIC pcp)
 
-target_link_libraries(code PUBLIC vulkan-hpp)
+if (FSO_BUILD_WITH_VULKAN)
+	target_link_libraries(code PUBLIC vulkan-hpp)
+endif()
 
 target_link_libraries(code PUBLIC parsers)
 
@@ -91,6 +93,9 @@ endif()
 
 if (FSO_BUILD_WITH_FFMPEG)
 	target_compile_definitions(code PUBLIC WITH_FFMPEG)
+endif()
+if (FSO_BUILD_WITH_VULKAN)
+	target_compile_definitions(code PUBLIC WITH_VULKAN)
 endif()
 
 include(util)

--- a/code/source_groups.cmake
+++ b/code/source_groups.cmake
@@ -475,12 +475,14 @@ add_file_folder("Graphics\\\\Util"
 	graphics/util/UniformBufferManager.cpp
 )
 
-add_file_folder("Graphics\\\\Vulkan"
-	graphics/vulkan/gr_vulkan.cpp
-	graphics/vulkan/gr_vulkan.h
-	graphics/vulkan/VulkanRenderer.cpp
-	graphics/vulkan/VulkanRenderer.h
-)
+if (FSO_BUILD_WITH_VULKAN)
+	add_file_folder("Graphics\\\\Vulkan"
+		graphics/vulkan/gr_vulkan.cpp
+		graphics/vulkan/gr_vulkan.h
+		graphics/vulkan/VulkanRenderer.cpp
+		graphics/vulkan/VulkanRenderer.h
+	)
+endif()
 
 # HeadTracking files
 add_file_folder("HeadTracking"

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -37,6 +37,8 @@ include(libRocket.cmake)
 
 add_subdirectory(libpcp)
 
-add_subdirectory(vulkan-hpp)
+if (FSO_BUILD_WITH_VULKAN)
+	add_subdirectory(vulkan-hpp)
+endif()
 
 include(antlr4.cmake)


### PR DESCRIPTION
This makes it possible to still compile FSO on platforms that are not
supported by the Vulkan headers.