### PR TITLE
Change MP Initial Player Wing Ship Behavior to Match SP

### DIFF
--- a/code/ai/aigoals.cpp
+++ b/code/ai/aigoals.cpp
@@ -25,6 +25,8 @@
 #include "ship/ship.h"
 #include "weapon/weapon.h"
 
+// Just a reference to this struct being for looking up a ship's team in TVT
+struct ship_registry_entry;
 
 // all ai goals dealt with in this code are goals that are specified through
 // sexpressions in the mission file.  They are either specified as part of a
@@ -134,28 +136,48 @@ const char *Ai_goal_text(int goal)
 	return NULL;
 }
 
-// function to maybe add the form on my wing goal for a player's starting wing.  Called when a player wing arrives.
-void ai_maybe_add_form_goal( wing *wingp )
+void ai_maybe_add_form_goal(wing* wingp)
 {
+	// Cyborg17 - Changes from the client would just get overridden by the server anyway
+	// might as well keep them more closely in sync.
+	if (MULTIPLAYER_CLIENT) {
+		return;
+	}
+
 	int j;
 
 	// iterate through the ship_index list of this wing and check for orders.  We will do
 	// this for all ships in the wing instead of on a wing only basis in case some ships
 	// in the wing actually have different orders than others
-	for ( j = 0; j < wingp->current_count; j++ ) {
-		ai_info *aip;
+	for (j = 0; j < wingp->current_count; j++) {
+		ai_info* aip;
 
-		Assert( wingp->ship_index[j] != -1 );						// get Allender
+		Assert(wingp->ship_index[j] != -1);						// get Allender
 
 		aip = &Ai_info[Ships[wingp->ship_index[j]].ai_index];
-		// don't process Player_ship
-		if ( aip == Player_ai )
+		// don't process a Player_ship
+		if (Objects[Ships[aip->shipnum].objnum].flags[Object::Object_Flags::Player_ship]) {
 			continue;
-		
+		}
+
+		// need to add a form on my wing goal here.  Ships are always forming on the player's wing.
 		// it is sufficient enough to check the first goal entry to see if it has a valid goal
-		if ( aip->goals[0].ai_mode == AI_GOAL_NONE ) {
-			// need to add a form on my wing goal here.  Ships are always forming on the player's wing.
-			ai_add_ship_goal_player( AIG_TYPE_PLAYER_SHIP, AI_GOAL_FORM_ON_WING, -1, Player_ship->ship_name, aip );
+		if (aip->goals[0].ai_mode == AI_GOAL_NONE) {
+			// Need to have a more specific target in multi, or they may end up trying to target standalone placeholder.
+			// So form on their team leader.  In dogfight, all player-slot ai die, so just exclude.
+			if (MULTIPLAYER_MASTER && !(Netgame.type_flags & NG_TYPE_DOGFIGHT)) {
+				int wingnum;
+				if (Netgame.type_flags & NG_TYPE_TEAM) {
+					const ship_registry_entry* ship_regp = ship_registry_get(Ships[wingp->ship_index[j]].ship_name);
+					wingnum = TVT_wings[ship_regp->p_objp->team];
+					ai_add_ship_goal_player(AIG_TYPE_PLAYER_SHIP, AI_GOAL_FORM_ON_WING, -1, Ships[Wings[wingnum].ship_index[Wings[wingnum].special_ship]].ship_name, aip);
+				} else {
+					wingnum = Starting_wings[0];
+					ai_add_ship_goal_player(AIG_TYPE_PLAYER_SHIP, AI_GOAL_FORM_ON_WING, -1, Ships[Wings[wingnum].ship_index[Wings[wingnum].special_ship]].ship_name, aip);
+				}
+			} else if (!(Game_mode & GM_MULTIPLAYER)) {
+				ai_add_ship_goal_player(AIG_TYPE_PLAYER_SHIP, AI_GOAL_FORM_ON_WING, -1, Player_ship->ship_name, aip);
+			}
 		}
 	}
 }


### PR DESCRIPTION
The way that this function was structured before would 1. Change the AI mode of player ships (very minor) 2. Keep AI in player wings from doing anything because they were trying to form on the wing of the standalone ship placeholder. 

To clarify, this doesn't mean that they will now start out fighting without order. Instead, they should start out only forming on the wing of their team leader. 

Need to do some more testing to make sure that this is 100% fixed, since Alpha 4 was acting strange during the last test, but otherwise, the initial test looked good.  

Mainly just need to test Team vs. Team on standalone.  This is apparently impossible on one computer, as I just tried and both clients hit an assert.