### PR TITLE
fix/sun_fionbio: Load filio.h on Sun for FIONBIO

### DIFF
--- a/code/inetfile/chttpget.cpp
+++ b/code/inetfile/chttpget.cpp
@@ -20,6 +20,9 @@
 #include <arpa/inet.h>
 #include <netdb.h>
 #include <sys/ioctl.h>
+#ifdef SCP_SOLARIS
+#include <sys/filio.h>
+#endif
 
 #define WSAGetLastError()  (errno)
 #endif


### PR DESCRIPTION
This include is needed on Sun platforms for it to have access to FIONBIO.