### PR TITLE
fix/sun_renderdoc: Make Solaris a recognized platform for renderdoc.

### DIFF
--- a/code/libs/renderdoc/renderdoc_app.h
+++ b/code/libs/renderdoc/renderdoc_app.h
@@ -41,6 +41,8 @@
 #define RENDERDOC_CC
 #elif defined(__APPLE__)
 #define RENDERDOC_CC
+#elif defined(SCP_SOLARIS)
+#define RENDERDOC_CC
 #else
 #error "Unknown platform"
 #endif


### PR DESCRIPTION
This seemed to be all that was necessary for this to compile on OpenIndiana.