### PR TITLE
fix/sun_sun: Use 'bgsun' instead of 'sun'

### DIFF
--- a/code/starfield/starfield.cpp
+++ b/code/starfield/starfield.cpp
@@ -1865,8 +1865,8 @@ void stars_preload_background(int background_idx)
 		return;
 
 	// preload all the stuff for this background
-	for (auto &sun : Backgrounds[background_idx].suns)
-		stars_preload_sun_bitmap(sun.filename);
+	for (auto &bgsun : Backgrounds[background_idx].suns)
+		stars_preload_sun_bitmap(bgsun.filename);
 	for (auto &bitmap : Backgrounds[background_idx].bitmaps)
 		stars_preload_background_bitmap(bitmap.filename);
 }


### PR DESCRIPTION
'sun' is a reserved keyword on Sun, so use 'bgsun' here instead.  Fixed compilation on OpenIndiana.