### PR TITLE
Fix Non-Standalone Servers Failing to Switch Between PXO and Non-PXO

### DIFF
--- a/code/network/multi_fstracker.cpp
+++ b/code/network/multi_fstracker.cpp
@@ -519,7 +519,7 @@ void multi_fs_tracker_send_game_request()
 // if the API has successfully been initialized and is running
 int multi_fs_tracker_inited()
 {
-	return Multi_fs_tracker_inited;
+	return (Multi_fs_tracker_inited && Multi_options_g.pxo);
 }
 
 // update our settings on the tracker regarding the current netgame stuff


### PR DESCRIPTION
Simple fix, already tested.

Adds a function to check if PXO is in use rather than just initialized, so that a very important flag can be properly set.