### PR TITLE
add OTF fonts

### DIFF
--- a/code/cfile/cfile.cpp
+++ b/code/cfile/cfile.cpp
@@ -71,7 +71,7 @@ cf_pathtype Pathtypes[CF_MAX_PATH_TYPES]  = {
 	{ CF_TYPE_MUSIC,				"data" DIR_SEPARATOR_STR "music",											".wav .ogg",						CF_TYPE_DATA	},
 	{ CF_TYPE_MOVIES,				"data" DIR_SEPARATOR_STR "movies",											".mve .msb .ogg .mp4 .srt .webm .png",CF_TYPE_DATA	},
 	{ CF_TYPE_INTERFACE,			"data" DIR_SEPARATOR_STR "interface",										".pcx .ani .dds .tga .eff .png .jpg",	CF_TYPE_DATA	},
-	{ CF_TYPE_FONT,					"data" DIR_SEPARATOR_STR "fonts",											".vf .ttf",							CF_TYPE_DATA	},
+	{ CF_TYPE_FONT,					"data" DIR_SEPARATOR_STR "fonts",											".vf .ttf .otf",						CF_TYPE_DATA	},
 	{ CF_TYPE_EFFECTS,				"data" DIR_SEPARATOR_STR "effects",											".ani .eff .pcx .neb .tga .jpg .png .dds .sdr",	CF_TYPE_DATA	},
 	{ CF_TYPE_HUD,					"data" DIR_SEPARATOR_STR "hud",												".pcx .ani .eff .tga .jpg .png .dds",	CF_TYPE_DATA	},
 	{ CF_TYPE_PLAYERS,				"data" DIR_SEPARATOR_STR "players",											".hcf",								CF_TYPE_DATA	},

--- a/code/scpui/rocket_ui.cpp
+++ b/code/scpui/rocket_ui.cpp
@@ -117,6 +117,14 @@ void load_fonts()
 		// The file extension gets removed by CFile
 		FontDatabase::LoadFontFace((name + ".ttf").c_str());
 	}
+
+	files.clear();
+	cf_get_file_list(files, CF_TYPE_FONT, "*.otf");
+
+	for (auto& name : files) {
+		// The file extension gets removed by CFile
+		FontDatabase::LoadFontFace((name + ".otf").c_str());
+	}
 }
 
 bool mouse_motion_handler(const SDL_Event& evt)


### PR DESCRIPTION
There are fonts with an .otf extension that are similar to .ttf, and in fact can be opened with our TTF code.  So this adds support for that extension.