### PR TITLE
Supply world coordinates in whack function calls

### DIFF
--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -9020,26 +9020,6 @@ int find_parent_rotating_submodel(polymodel *pm, int dock_index)
 }
 
 // Goober5000
-// pruned version of below function
-void find_adjusted_dockpoint_normal(vec3d *global_p0_norm, object *objp, polymodel *pm, int submodel, int dock_index)
-{
-	Assertion(global_p0_norm != nullptr && objp != nullptr && pm != nullptr, "arguments cannot be null!");
-	Assertion(dock_index >= 0 && dock_index < pm->n_docks, "for model %s, dock_index %d must be >= 0 and < %d!", pm->filename, dock_index, pm->n_docks);
-
-	// are we basing this off a rotating submodel?
-	if (submodel >= 0)
-	{
-		// find the normal of the first dockpoint
-		model_instance_find_world_dir(global_p0_norm, &pm->docking_bays[dock_index].norm[0], Ships[objp->instance].model_instance_num, submodel, &objp->orient);
-	}
-	// use the static dockpoints
-	else
-	{
-		vm_vec_unrotate(global_p0_norm, &pm->docking_bays[dock_index].norm[0], &objp->orient);
-	}
-}
-
-// Goober5000
 void find_adjusted_dockpoint_info(vec3d *global_p0, vec3d *global_p1, vec3d *global_p0_norm, object *objp, polymodel *pm, int modelnum, int submodel, int dock_index)
 {
 	Assertion(global_p0 != nullptr && global_p1 != nullptr && global_p0_norm != nullptr && objp != nullptr && pm != nullptr, "arguments cannot be null!");

--- a/code/network/multimsgs.cpp
+++ b/code/network/multimsgs.cpp
@@ -8231,7 +8231,7 @@ void process_player_pain_packet(ubyte *data, header *hinfo)
 	short windex = 0;
 	ushort udamage;
 	vec3d force;
-	vec3d local_hit_pos;
+	vec3d hit_pos;
 	weapon_info *wip;
 	int quadrant_num;
 
@@ -8240,7 +8240,7 @@ void process_player_pain_packet(ubyte *data, header *hinfo)
 	GET_SHORT(windex);
 	GET_USHORT(udamage);
 	GET_VECTOR(force);
-	GET_VECTOR(local_hit_pos);
+	GET_VECTOR(hit_pos);
 	GET_INT(quadrant_num);
 	PACKET_SET_SIZE();
 
@@ -8266,7 +8266,7 @@ void process_player_pain_packet(ubyte *data, header *hinfo)
 	ship_hit_pain((float)udamage, quadrant_num);
 
 	// apply the whack	
-	ship_apply_whack(&force, &local_hit_pos, Player_obj);	
+	ship_apply_whack(&force, &hit_pos, Player_obj);	
 }
 
 // lightning packet

--- a/code/object/collideshipweapon.cpp
+++ b/code/object/collideshipweapon.cpp
@@ -96,7 +96,7 @@ static void ship_weapon_do_hit_stuff(object *pship_obj, object *weapon_obj, vec3
 
 		// if this is a player ship
 		if((np_index >= 0) && (np_index != MY_NET_PLAYER_NUM) && (wip->subtype == WP_LASER)){
-			send_player_pain_packet(&Net_players[np_index], wp->weapon_info_index, wip->damage * weapon_get_damage_scale(wip, weapon_obj, pship_obj), &force, hitpos, quadrant_num);
+			send_player_pain_packet(&Net_players[np_index], wp->weapon_info_index, wip->damage * weapon_get_damage_scale(wip, weapon_obj, pship_obj), &force, world_hitpos, quadrant_num);
 		}
 	}	
 
@@ -115,7 +115,7 @@ static void ship_weapon_do_hit_stuff(object *pship_obj, object *weapon_obj, vec3
 	// don't apply whack for multiplayer_client from laser - will occur with pain packet
 	if (!((wip->subtype == WP_LASER) && MULTIPLAYER_CLIENT) ) {		
 		// apply a whack		
-		ship_apply_whack( &force, hitpos, pship_obj );
+		ship_apply_whack( &force, world_hitpos, pship_obj );
 	}
 
 	// Add impact decal

--- a/code/object/objectdock.cpp
+++ b/code/object/objectdock.cpp
@@ -379,27 +379,22 @@ object* dock_find_dock_root(object *objp)
 	return fastest_objp;
 }
 
-void dock_calculate_and_apply_whack_docked_object(vec3d* impulse, const vec3d* rel_world_hit_pos, object* objp)
+void dock_calculate_and_apply_whack_docked_object(vec3d* impulse, const vec3d* world_hit_pos, object* objp)
 {
-	Assertion((objp != nullptr) && (impulse != nullptr) && (rel_world_hit_pos != nullptr),
+	Assertion((objp != nullptr) && (impulse != nullptr) && (world_hit_pos != nullptr),
 		"dock_whack_docked_object invalid argument(s)");
 
 	//	Detect null vector.
 	if (whack_below_limit(impulse))
 		return;
 
-	vec3d world_center_of_mass;
-	vec3d world_hit_pos;
-
-	// calc world hit pos of the hit ship
-	vm_vec_add(&world_hit_pos, rel_world_hit_pos, &objp->pos);
-
 	// calc overall world center-of-mass of all ships
+	vec3d world_center_of_mass;
 	float total_mass = dock_calc_docked_center_of_mass(&world_center_of_mass, objp);
 
 	vec3d hit_pos;
 	// the new hitpos is the vector from world center-of-mass to world hitpos
-	vm_vec_sub(&hit_pos, &world_hit_pos, &world_center_of_mass);
+	vm_vec_sub(&hit_pos, world_hit_pos, &world_center_of_mass);
 
 	matrix moi, inv_moi;
 	// calculate the effective inverse MOI for the docked composite object about its center of mass

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -12060,13 +12060,12 @@ void sexp_explosion_effect(int n)
 				{
 					case OBJ_SHIP:
 						ship_apply_global_damage( objp, nullptr, &origin, t_damage );
-						vec3d force, vec_ship_to_impact, world_hit_pos;
+						vec3d force, vec_ship_to_impact;
 						vm_vec_sub( &vec_ship_to_impact, &objp->pos, &origin );
 						if (!IS_VEC_NULL_SQ_SAFE( &vec_ship_to_impact )) {
 							vm_vec_copy_normalize( &force, &vec_ship_to_impact );
 							vm_vec_scale( &force, (float)max_blast );
-							vm_vec_add(&world_hit_pos, &vec_ship_to_impact, &objp->pos);
-							ship_apply_whack( &force, &world_hit_pos, objp );
+							ship_apply_whack( &force, &origin, objp );
 						}
 						break;
 

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -12060,12 +12060,13 @@ void sexp_explosion_effect(int n)
 				{
 					case OBJ_SHIP:
 						ship_apply_global_damage( objp, nullptr, &origin, t_damage );
-						vec3d force, vec_ship_to_impact;
+						vec3d force, vec_ship_to_impact, world_hit_pos;
 						vm_vec_sub( &vec_ship_to_impact, &objp->pos, &origin );
 						if (!IS_VEC_NULL_SQ_SAFE( &vec_ship_to_impact )) {
 							vm_vec_copy_normalize( &force, &vec_ship_to_impact );
 							vm_vec_scale( &force, (float)max_blast );
-							ship_apply_whack( &force, &vec_ship_to_impact, objp );
+							vm_vec_add(&world_hit_pos, &vec_ship_to_impact, &objp->pos);
+							ship_apply_whack( &force, &world_hit_pos, objp );
 						}
 						break;
 

--- a/code/physics/physics.cpp
+++ b/code/physics/physics.cpp
@@ -737,17 +737,15 @@ bool whack_below_limit(const vec3d* impulse)
 }
 
 // ----------------------------------------------------------------------------
-// physics_apply_whack applies an instaneous whack on an object changing
-// both the objects velocity and the rotational velocity based on the impulse
-// being applied.
+// physics_calculate_and_apply_whack changes the rotaional and linear velocites of a ship due to
+// an instantaneous whack.
 //
-//	input:	impulse		=>		impulse vector ( force*time = impulse = change in momentum (mv) )
+//	input:	impulse		=>		impulse vector (direction and magnitude of the impulse)
 //				pos			=>		vector from center of mass to location (in world coords) of where the force acts 
 //				pi				=>		pointer to phys_info struct of object getting whacked
 //				orient		=>		orientation matrix (needed to set rotational impulse in body coords)
-//				mass			=>		mass of the object (may be different from pi.mass if docked)
 //
-void physics_calculate_and_apply_whack(vec3d *impulse, vec3d *pos, physics_info *pi, matrix *orient, float mass, matrix *inv_moi)
+void physics_calculate_and_apply_whack(vec3d *impulse, vec3d *pos, physics_info *pi, matrix *orient, matrix *inv_moi)
 {
 	vec3d	local_angular_impulse, angular_impulse;
 
@@ -765,8 +763,7 @@ void physics_calculate_and_apply_whack(vec3d *impulse, vec3d *pos, physics_info 
 	vec3d delta_rotvel;
 	vm_vec_rotate(&delta_rotvel, &local_angular_impulse, inv_moi);
 
-	// Goober5000 - pi->mass should probably be just mass, as specified in the header
-	vec3d delta_vel = *impulse * (1.0f / mass);
+	vec3d delta_vel = *impulse * (1.0f / pi->mass);
 
 	physics_apply_whack(vm_vec_mag(impulse), pi, &delta_rotvel, &delta_vel, orient);
 }

--- a/code/physics/physics.h
+++ b/code/physics/physics.h
@@ -141,7 +141,7 @@ extern void physics_sim_editor(vec3d *position, matrix * orient, physics_info * 
 extern void physics_sim_vel(vec3d * position, physics_info * pi, float sim_time, matrix * orient);
 extern void physics_sim_rot(matrix * orient, physics_info * pi, float sim_time );
 extern bool whack_below_limit(const vec3d* impulse);
-extern void physics_calculate_and_apply_whack(vec3d *force, vec3d *pos, physics_info *pi, matrix *orient, float mass, matrix *inv_moi);
+extern void physics_calculate_and_apply_whack(vec3d *force, vec3d *pos, physics_info *pi, matrix *orient, matrix *inv_moi);
 extern void physics_apply_whack(float orig_impulse, physics_info* pi, vec3d *delta_rotvel, vec3d* delta_vel, matrix* orient);
 extern void physics_apply_shock(vec3d *direction_vec, float pressure, physics_info *pi, matrix *orient, vec3d *min, vec3d *max, float radius);
 extern void physics_collide_whack(vec3d *impulse, vec3d *delta_rotvel, physics_info *pi, matrix *orient, bool is_landing);

--- a/code/scripting/api/objs/physics_info.cpp
+++ b/code/scripting/api/objs/physics_info.cpp
@@ -1,6 +1,7 @@
 
 #include "physics_info.h"
 #include "vecmath.h"
+#include "math/vecmat.h"
 #include "ship/shiphit.h"
 
 namespace scripting {
@@ -458,7 +459,7 @@ ADE_FUNC(isGliding, l_Physics, NULL, "True if glide mode is on, false or nil if 
 		return ade_set_args(L, "b",  false);
 }
 
-ADE_FUNC(applyWhack, l_Physics, "vector Impulse, [ vector Position]", "Applies a whack to an object at a position (a local vector) based on impulse supplied (a world vector). If no position is supplied, an empty vector is used.", "boolean", "true if it succeeded, false otherwise")
+ADE_FUNC(applyWhack, l_Physics, "vector Impulse, [ vector Position]", "Applies a whack to an object at a position relative to the ship, in world orientation based on an impulse vector, indicating the direction and strength of the whack. If no position is supplied, an empty vector is used.", "boolean", "true if it succeeded, false otherwise")
 {
 	object_h objh;
 	physics_info_h *pih;
@@ -469,6 +470,28 @@ ADE_FUNC(applyWhack, l_Physics, "vector Impulse, [ vector Position]", "Applies a
 		return ADE_RETURN_NIL;
 
 	objh = pih->objh;
+	vm_vec_add2(offset, &objh.objp->pos);
+
+	ship_apply_whack(impulse, offset, objh.objp);
+
+	return ADE_RETURN_TRUE;
+
+}
+
+ADE_FUNC(applyWhackWorld, l_Physics, "vector Impulse, [ vector Position]", "Applies a whack to an object at a world position based on an impulse vector, indicating the direction and strength of whack. If no position is supplied, the ship's position will be used.", "boolean", "true if it succeeded, false otherwise")
+{
+	object_h objh;
+	physics_info_h* pih;
+	vec3d* impulse;
+	vec3d* offset = &vmd_zero_vector;
+
+	if (!ade_get_args(L, "oo|o", l_Physics.GetPtr(&pih), l_Vector.GetPtr(&impulse), l_Vector.GetPtr(&offset)))
+		return ADE_RETURN_NIL;
+
+	objh = pih->objh;
+	if (!IS_VEC_NULL(offset)) {
+		offset = &objh.objp->pos;
+	}
 
 	ship_apply_whack(impulse, offset, objh.objp);
 

--- a/code/scripting/api/objs/physics_info.cpp
+++ b/code/scripting/api/objs/physics_info.cpp
@@ -459,7 +459,7 @@ ADE_FUNC(isGliding, l_Physics, NULL, "True if glide mode is on, false or nil if 
 		return ade_set_args(L, "b",  false);
 }
 
-ADE_FUNC(applyWhack, l_Physics, "vector Impulse, [ vector Position]", "Applies a whack to an object at a position relative to the ship, in world orientation based on an impulse vector, indicating the direction and strength of the whack. If no position is supplied, an empty vector is used.", "boolean", "true if it succeeded, false otherwise")
+ADE_FUNC(applyWhack, l_Physics, "vector Impulse, [ vector Position]", "Applies a whack to an object based on an impulse vector, indicating the direction and strength of whack and optionally at a position relative to the ship in world orientation, the ship's center being default.", "boolean", "true if it succeeded, false otherwise")
 {
 	object_h objh;
 	physics_info_h *pih;
@@ -478,22 +478,22 @@ ADE_FUNC(applyWhack, l_Physics, "vector Impulse, [ vector Position]", "Applies a
 
 }
 
-ADE_FUNC(applyWhackWorld, l_Physics, "vector Impulse, [ vector Position]", "Applies a whack to an object at a world position based on an impulse vector, indicating the direction and strength of whack. If no position is supplied, the ship's position will be used.", "boolean", "true if it succeeded, false otherwise")
+ADE_FUNC(applyWhackWorld, l_Physics, "vector Impulse, [ vector Position]", "Applies a whack to an object based on an impulse vector, indicating the direction and strength of whack and optionally at a world position, the ship's center being default.", "boolean", "true if it succeeded, false otherwise")
 {
 	object_h objh;
 	physics_info_h* pih;
 	vec3d* impulse;
-	vec3d* offset = &vmd_zero_vector;
+	vec3d* world_pos = nullptr;
 
-	if (!ade_get_args(L, "oo|o", l_Physics.GetPtr(&pih), l_Vector.GetPtr(&impulse), l_Vector.GetPtr(&offset)))
+	if (!ade_get_args(L, "oo|o", l_Physics.GetPtr(&pih), l_Vector.GetPtr(&impulse), l_Vector.GetPtr(&world_pos)))
 		return ADE_RETURN_NIL;
 
 	objh = pih->objh;
-	if (!IS_VEC_NULL(offset)) {
-		offset = &objh.objp->pos;
+	if (!world_pos) {
+		world_pos = &objh.objp->pos;
 	}
 
-	ship_apply_whack(impulse, offset, objh.objp);
+	ship_apply_whack(impulse, world_pos, objh.objp);
 
 	return ADE_RETURN_TRUE;
 

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -16939,7 +16939,7 @@ int ship_get_random_targetable_ship()
 void object_jettison_cargo(object *objp, object *cargo_objp, float jettison_speed, bool jettison_new)
 {
 	// make sure we are docked
-	Assert((objp != NULL) && (cargo_objp != NULL));
+	Assert((objp != nullptr) && (cargo_objp != nullptr));
 	Assert(dock_check_find_direct_docked_object(objp, cargo_objp));
 
 	vec3d impulse, pos;

--- a/code/ship/shiphit.cpp
+++ b/code/ship/shiphit.cpp
@@ -1780,7 +1780,7 @@ extern int Homing_hits, Homing_misses;
 
 // Call this instead of physics_apply_whack directly to 
 // deal with two docked ships properly.
-// Goober5000 - note... hit_pos is in *local* coordinates
+// Goober5000 - note... hit_pos is in *world* coordinates
 void ship_apply_whack(vec3d *force, vec3d *hit_pos, object *objp)
 {
 	Assertion((objp != nullptr) && (force != nullptr) && (hit_pos != nullptr), "ship_apply_whack invalid argument(s)");
@@ -1792,19 +1792,18 @@ void ship_apply_whack(vec3d *force, vec3d *hit_pos, object *objp)
 
 		game_whack_apply( -test.xyz.x, -test.xyz.y );
 	}
-	
-	// get the world coords hit position relative to the ship
-	vec3d rel_world_hit_pos;
-	vm_vec_unrotate(&rel_world_hit_pos, hit_pos, &objp->orient);
 
 
 	if (object_is_docked(objp))
 	{
-		dock_calculate_and_apply_whack_docked_object(force, &rel_world_hit_pos, objp);
+		dock_calculate_and_apply_whack_docked_object(force, hit_pos, objp);
 	}
 	else
 	{
-		physics_calculate_and_apply_whack(force, &rel_world_hit_pos, &objp->phys_info, &objp->orient, objp->phys_info.mass, &objp->phys_info.I_body_inv);
+		// this one needs local position but since it doesn't have the objp its easier to just do this now
+		vec3d rel_hit_pos;
+		vm_vec_sub(&rel_hit_pos, hit_pos, &objp->pos);
+		physics_calculate_and_apply_whack(force, &rel_hit_pos, &objp->phys_info, &objp->orient, &objp->phys_info.I_body_inv);
 	}					
 }
 

--- a/code/weapon/beam.cpp
+++ b/code/weapon/beam.cpp
@@ -3300,9 +3300,7 @@ void beam_handle_collisions(beam *b)
 				// if this is the first hit on the player ship. whack him
 				if(apply_beam_physics)
 				{
-					// Goober5000 - AGH!  BAD BAD BAD BAD BAD BAD BAD BAD bug!  The whack's hit point is in *local*
-					// coordinates, NOT world coordinates!
-					beam_apply_whack(b, &Objects[target], &b->f_collisions[idx].cinfo.hit_point);
+					beam_apply_whack(b, &Objects[target], &b->f_collisions[idx].cinfo.hit_point_world);
 				}
 				break;
 			}		

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -6006,7 +6006,7 @@ int weapon_area_calc_damage(object *objp, vec3d *pos, float inner_rad, float out
  */
 void weapon_area_apply_blast(vec3d * /*force_apply_pos*/, object *ship_objp, vec3d *blast_pos, float blast, int make_shockwave)
 {
-	vec3d		force, vec_blast_to_ship, vec_ship_to_impact, world_hit_pos;
+	vec3d		force, vec_blast_to_ship, vec_ship_to_impact;
 	polymodel		*pm;
 
 	// don't waste time here if there is no blast force
@@ -6019,7 +6019,6 @@ void weapon_area_apply_blast(vec3d * /*force_apply_pos*/, object *ship_objp, vec
 	vm_vec_copy_scale(&force, &vec_blast_to_ship, blast );
 
 	vm_vec_sub(&vec_ship_to_impact, blast_pos, &ship_objp->pos);
-	vm_vec_add(&world_hit_pos, &vec_ship_to_impact, &ship_objp->pos);
 
 	pm = model_get(Ship_info[Ships[ship_objp->instance].ship_info_index].model_num);
 	Assert ( pm != NULL );
@@ -6030,7 +6029,7 @@ void weapon_area_apply_blast(vec3d * /*force_apply_pos*/, object *ship_objp, vec
 			joy_ff_play_vector_effect(&vec_blast_to_ship, blast * 2.0f);
 		}
 	} else {
-		ship_apply_whack( &force, &world_hit_pos, ship_objp);
+		ship_apply_whack( &force, blast_pos, ship_objp);
 	}
 }
 

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -6006,7 +6006,7 @@ int weapon_area_calc_damage(object *objp, vec3d *pos, float inner_rad, float out
  */
 void weapon_area_apply_blast(vec3d * /*force_apply_pos*/, object *ship_objp, vec3d *blast_pos, float blast, int make_shockwave)
 {
-	vec3d		force, vec_blast_to_ship, vec_ship_to_impact;
+	vec3d		force, vec_blast_to_ship, vec_ship_to_impact, world_hit_pos;
 	polymodel		*pm;
 
 	// don't waste time here if there is no blast force
@@ -6019,6 +6019,7 @@ void weapon_area_apply_blast(vec3d * /*force_apply_pos*/, object *ship_objp, vec
 	vm_vec_copy_scale(&force, &vec_blast_to_ship, blast );
 
 	vm_vec_sub(&vec_ship_to_impact, blast_pos, &ship_objp->pos);
+	vm_vec_add(&world_hit_pos, &vec_ship_to_impact, &ship_objp->pos);
 
 	pm = model_get(Ship_info[Ships[ship_objp->instance].ship_info_index].model_num);
 	Assert ( pm != NULL );
@@ -6029,7 +6030,7 @@ void weapon_area_apply_blast(vec3d * /*force_apply_pos*/, object *ship_objp, vec
 			joy_ff_play_vector_effect(&vec_blast_to_ship, blast * 2.0f);
 		}
 	} else {
-		ship_apply_whack( &force, &vec_ship_to_impact, ship_objp);
+		ship_apply_whack( &force, &world_hit_pos, ship_objp);
 	}
 }
 


### PR DESCRIPTION
This changes all calls to `ship_apply_whack` so that a world position is sent, making them all, most importantly, consistent (this was not true before). All of these paths have been tested to work properly except for the script functions, the scripting implementation is still dark voodoo magic to me, so extra care to ensure I have implemented it properly would be appreciated.

Edit: Also unintentionally fixes #1763 , recoil had always supplied a world position, causing the unusually strong recoil.