### PR TITLE
Fix pilot info bug and crash in PXO chat lobby

### DIFF
--- a/code/network/chat_api.cpp
+++ b/code/network/chat_api.cpp
@@ -1266,6 +1266,7 @@ char *GetTrackerIdByUser(char *nickname)
 		if(Getting_user_tracker_error)
 		{
 			Getting_user_tracker_error = 0;
+			Getting_user_channel_error = 0;
 			GettingUserTID = 0;
 			return (char *)-1;
 		}
@@ -1296,6 +1297,7 @@ char *GetChannelByUser(char *nickname)
 		if(Getting_user_channel_error)
 		{
 			Getting_user_channel_error = 0;
+			Getting_user_tracker_error = 0;
 			GettingUserChannel = 0;
 			return (char *)-1;
 		}

--- a/code/network/multi_pxo.cpp
+++ b/code/network/multi_pxo.cpp
@@ -4368,7 +4368,7 @@ int multi_pxo_pinfo_cond()
 
 			if (ret_string != NULL) {
 				// user not-online/not found
-				if ( (int)ret_string[0] == -1) {
+				if (reinterpret_cast<ptr_s>(ret_string) == -1) {
 					return 1;
 				} 
 


### PR DESCRIPTION
Fix bug where searching for a player that isn't online or doesn't exist will cause the next attempt to get pilot info to fail. This failure also triggered a memory access bug in the pilot info error handling.