### PR TITLE
Add comment about new hooks system to legacy hook list

### DIFF
--- a/code/scripting/scripting.cpp
+++ b/code/scripting/scripting.cpp
@@ -104,6 +104,7 @@ static USED_VARIABLE SCP_vector<std::shared_ptr<BuiltinHook>> Script_actions
 	std::make_shared<BuiltinHook>("On Subsystem Destroyed",	CHA_ONSUBSYSDEATH ),
 	std::make_shared<BuiltinHook>("On Goals Cleared",		CHA_ONGOALSCLEARED ),
 	std::make_shared<BuiltinHook>("On Briefing Stage",		CHA_ONBRIEFSTAGE ),
+	// DO NOT ADD NEW HOOKS HERE, see scripting.h for a more in-depth explanation
 };
 
 static HookVariableDocumentation GlobalVariables[] =

--- a/code/scripting/scripting.h
+++ b/code/scripting/scripting.h
@@ -113,6 +113,11 @@ enum ConditionalActions : int32_t {
 	CHA_ONGOALSCLEARED,
 	CHA_ONBRIEFSTAGE,
 
+	// DO NOT ADD NEW HOOKS HERE
+	// There is a new Lua Hook API, see hook_api.h
+	// There you use either scripting::Hook for non-overridable or scripting::OverridableHook for overridable hooks
+	// while also having the option to document when the hook is called and what hook variables are set for it.
+
 	CHA_LAST = CHA_ONBRIEFSTAGE,
 };
 


### PR DESCRIPTION
Since the old system is deprecated it needs to be made obvious that new
hooks should not be added using that system.