### PR TITLE
Patch a Crash Point

### DIFF
--- a/code/network/multi_campaign.cpp
+++ b/code/network/multi_campaign.cpp
@@ -114,6 +114,13 @@ void multi_campaign_client_start()
 
 	// set campaign mode. why not.
 	Game_mode |= GM_CAMPAIGN_MODE;
+
+	// also, set the campaign type correctly so that we can also rely on that info
+	if (Netgame.type_flags & NG_TYPE_TVT) {
+		Campaign.type = CAMPAIGN_TYPE_MULTI_TEAMS;
+	} else {
+		Campaign.type = CAMPAIGN_TYPE_MULTI_COOP;
+	}
 }
 
 // move everything and eveyrone into the next mission state


### PR DESCRIPTION
Campaign.type is not properly set for MP clients and cannot be relied upon.  This may be a temporary fix until I can research better how to set Campaign.type on clients correctly, if it is possible at all.