### PR TITLE
Add 'Process AI before Physics' flag

### DIFF
--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -57,6 +57,7 @@ std::tuple<ubyte, ubyte, ubyte> Arc_color_emp_p1;
 std::tuple<ubyte, ubyte, ubyte> Arc_color_emp_p2;
 std::tuple<ubyte, ubyte, ubyte> Arc_color_emp_s1;
 bool Use_engine_wash_intensity;
+bool Ai_before_physics;
 
 void parse_mod_table(const char *filename)
 {
@@ -104,6 +105,10 @@ void parse_mod_table(const char *filename)
 			stuff_boolean(&Use_tabled_strings_for_default_language);
 
 			mprintf(("Game settings table: Use tabled strings (translations) for the default language: %s\n", Use_tabled_strings_for_default_language ? "yes" : "no"));
+		}
+
+		if (optional_string("$Process AI before physics:")) {
+			stuff_boolean(&Ai_before_physics);
 		}
 
 		optional_string("#CAMPAIGN SETTINGS");

--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -595,4 +595,5 @@ void mod_table_reset()
 	Arc_color_emp_p2 = std::make_tuple(static_cast<ubyte>(128), static_cast<ubyte>(128), static_cast<ubyte>(10));
 	Arc_color_emp_s1 = std::make_tuple(static_cast<ubyte>(255), static_cast<ubyte>(255), static_cast<ubyte>(10));
 	Use_engine_wash_intensity = false;
+	Ai_before_physics = false;
 }

--- a/code/mod_table/mod_table.h
+++ b/code/mod_table/mod_table.h
@@ -48,6 +48,7 @@ extern std::tuple<ubyte, ubyte, ubyte> Arc_color_emp_p1;
 extern std::tuple<ubyte, ubyte, ubyte> Arc_color_emp_p2;
 extern std::tuple<ubyte, ubyte, ubyte> Arc_color_emp_s1;
 extern bool Use_engine_wash_intensity;
+extern bool Ai_before_physics;
 
 void mod_table_init();
 

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -8856,10 +8856,67 @@ static void lethality_decay(ai_info *aip)
 #endif
 }
 
-void ship_process_pre(object *objp, float frametime)
+void ship_process_pre(object *obj, float frametime)
 {
-	if ( (objp == NULL) || !frametime )
+	if ( (obj == NULL) || !frametime )
 		return;
+
+	int	num;
+	ship* shipp;
+	ship_info* sip;
+
+	if (obj->type != OBJ_SHIP) {
+		nprintf(("Network", "Ignoring non-ship object in ship_process_pre()\n"));
+		return;
+	}
+
+	num = obj->instance;
+	Assert(num >= 0 && num < MAX_SHIPS);
+	Assert(obj->type == OBJ_SHIP);
+	Assert(Ships[num].objnum == OBJ_INDEX(obj));
+
+	shipp = &Ships[num];
+
+	//rotate player subobjects since its processed by the ai functions
+	// AL 2-19-98: Fire turret for player if it exists
+	//WMC - changed this to call process_subobjects
+	if ((obj->flags[Object::Object_Flags::Player_ship]) && !Player_use_ai)
+	{
+		ai_info* aip = &Ai_info[Ships[obj->instance].ai_index];
+		if (aip->ai_flags[AI::AI_Flags::Being_repaired, AI::AI_Flags::Awaiting_repair])
+		{
+			if (aip->support_ship_objnum >= 0)
+			{
+				if (vm_vec_dist_quick(&obj->pos, &Objects[aip->support_ship_objnum].pos) < (obj->radius + Objects[aip->support_ship_objnum].radius) * 1.25f)
+					return;
+			}
+		}
+		if (!shipp->flags[Ship::Ship_Flags::Rotators_locked])
+			process_subobjects(OBJ_INDEX(obj));
+	}
+
+	if (obj == Player_obj) {
+		ship_check_player_distance();
+	}
+
+	// update ship lethality
+	if (Ships[num].ai_index >= 0) {
+		if (!physics_paused && !ai_paused) {
+			lethality_decay(&Ai_info[Ships[num].ai_index]);
+		}
+	}
+
+	// if the ship is an observer ship don't need to do AI
+	if (obj->type == OBJ_OBSERVER) {
+		return;
+	}
+
+	// Goober5000 - player may want to use AI
+	if ((Ships[num].ai_index >= 0) && (!(obj->flags[Object::Object_Flags::Player_ship]) || Player_use_ai)) {
+		if (!physics_paused && !ai_paused) {
+			ai_process(obj, Ships[num].ai_index, frametime);
+		}
+	}
 }
 
 MONITOR( NumShips )
@@ -9068,46 +9125,6 @@ void ship_process_post(object * obj, float frametime)
 		// maybe fire a corkscrew missile (just like swarmers)
 		cscrew_maybe_fire_missile(num);
 
-		//rotate player subobjects since its processed by the ai functions
-		// AL 2-19-98: Fire turret for player if it exists
-		//WMC - changed this to call process_subobjects
-		if ((obj->flags[Object::Object_Flags::Player_ship]) && !Player_use_ai)
-		{
-			ai_info *aip = &Ai_info[Ships[obj->instance].ai_index];
-			if (aip->ai_flags[AI::AI_Flags::Being_repaired, AI::AI_Flags::Awaiting_repair])
-			{
-				if (aip->support_ship_objnum >= 0)
-				{
-					if (vm_vec_dist_quick(&obj->pos, &Objects[aip->support_ship_objnum].pos) < (obj->radius + Objects[aip->support_ship_objnum].radius) * 1.25f)
-						return;
-				}
-			}
-			if (!shipp->flags[Ship::Ship_Flags::Rotators_locked])
-				process_subobjects(OBJ_INDEX(obj));
-		}
-
-		if (obj == Player_obj) {
-			ship_check_player_distance();
-		}
-
-		// update ship lethality
-		if ( Ships[num].ai_index >= 0 ){
-			if (!physics_paused && !ai_paused){
-				lethality_decay(&Ai_info[Ships[num].ai_index]);
-			}
-		}
-
-		// if the ship is an observer ship don't need to do AI
-		if ( obj->type == OBJ_OBSERVER)  {
-			return;
-		}
-
-		// Goober5000 - player may want to use AI
-		if ( (Ships[num].ai_index >= 0) && (!(obj->flags[Object::Object_Flags::Player_ship]) || Player_use_ai) ){
-			if (!physics_paused && !ai_paused){
-				ai_process( obj, Ships[num].ai_index, frametime );
-			}
-		}
 	}			
 }
 

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -8860,8 +8860,9 @@ static void lethality_decay(ai_info *aip)
 void ship_evaluate_ai(object* obj, float frametime) {
 
 	int num = obj->instance;
-	Assert(num >= 0 && num < MAX_SHIPS);
-	Assert(Ships[num].objnum == OBJ_INDEX(obj));
+	Assertion(obj->type == OBJ_SHIP, "Non-ship object passed to ship_evaluate_ai");
+	Assertion(num >= 0 && num < MAX_SHIPS, "Invalid ship instance num in ship_evaluate_ai");
+	Assertion(Ships[num].objnum == OBJ_INDEX(obj), "Ship objnum does not match its num in OBJ_INDEX in ship_evaluate_ai");
 
 	ship* shipp = &Ships[num];
 
@@ -8910,15 +8911,15 @@ void ship_process_pre(object *obj, float frametime)
 	if ( (obj == nullptr) || !frametime || MULTIPLAYER_CLIENT || !Ai_before_physics)
 		return;
 
-	int num = obj->instance;
-	Assert(num >= 0 && num < MAX_SHIPS);
-	Assert(Ships[num].objnum == OBJ_INDEX(obj));
-	ship* shipp = &Ships[num];
-
 	if (obj->type != OBJ_SHIP) {
 		nprintf(("AI", "Ignoring non-ship object in ship_process_pre()\n"));
 		return;
 	}
+
+	int num = obj->instance;
+	Assert(num >= 0 && num < MAX_SHIPS);
+	Assert(Ships[num].objnum == OBJ_INDEX(obj));
+	ship* shipp = &Ships[num];
 
 	if ((!(shipp->is_arriving()) || (Ai_info[shipp->ai_index].mode == AIM_BAY_EMERGE)
 		|| ((Warp_params[shipp->warpin_params_index].warp_type == WT_IN_PLACE_ANIM) && (shipp->flags[Ship_Flags::Arriving_stage_2])))
@@ -8989,6 +8990,7 @@ void ship_process_post(object * obj, float frametime)
 
 	num = obj->instance;
 	Assert( num >= 0 && num < MAX_SHIPS);
+	Assert( obj->type == OBJ_SHIP );
 	Assert( Ships[num].objnum == OBJ_INDEX(obj));	
 
 	shipp = &Ships[num];

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -8856,26 +8856,14 @@ static void lethality_decay(ai_info *aip)
 #endif
 }
 
-void ship_process_pre(object *obj, float frametime)
-{
-	// If Ai_before_physics is false everything following is evaluated in ship_process_post()
-	if ( (obj == nullptr) || !frametime || !Ai_before_physics)
-		return;
+// moved out of ship_process_post() so it can be called from either -post() or -pre() depending on Ai_before_physics
+void ship_evaluate_ai(object* obj, float frametime) {
 
-	int	num;
-	ship* shipp;
-
-	if (obj->type != OBJ_SHIP) {
-		nprintf(("Network", "Ignoring non-ship object in ship_process_pre()\n"));
-		return;
-	}
-
-	num = obj->instance;
+	int num = obj->instance;
 	Assert(num >= 0 && num < MAX_SHIPS);
-	Assert(obj->type == OBJ_SHIP);
 	Assert(Ships[num].objnum == OBJ_INDEX(obj));
 
-	shipp = &Ships[num];
+	ship* shipp = &Ships[num];
 
 	//rotate player subobjects since its processed by the ai functions
 	// AL 2-19-98: Fire turret for player if it exists
@@ -8895,27 +8883,48 @@ void ship_process_pre(object *obj, float frametime)
 			process_subobjects(OBJ_INDEX(obj));
 	}
 
-	if (obj == Player_obj) {
-		ship_check_player_distance();
-	}
-
 	// update ship lethality
-	if (Ships[num].ai_index >= 0) {
+	if (Ships[num].ai_index >= 0 ){
 		if (!physics_paused && !ai_paused) {
 			lethality_decay(&Ai_info[Ships[num].ai_index]);
 		}
 	}
 
 	// if the ship is an observer ship don't need to do AI
-	if (obj->type == OBJ_OBSERVER) {
+	if ( obj->type == OBJ_OBSERVER)  {
 		return;
 	}
 
 	// Goober5000 - player may want to use AI
-	if ((Ships[num].ai_index >= 0) && (!(obj->flags[Object::Object_Flags::Player_ship]) || Player_use_ai)) {
-		if (!physics_paused && !ai_paused) {
-			ai_process(obj, Ships[num].ai_index, frametime);
+	if ( (Ships[num].ai_index >= 0) && (!(obj->flags[Object::Object_Flags::Player_ship]) || Player_use_ai) ){
+		if (!physics_paused && !ai_paused){
+			ai_process( obj, Ships[num].ai_index, frametime );
 		}
+	}
+}
+
+void ship_process_pre(object *obj, float frametime)
+{
+	// If Ai_before_physics is false everything following is evaluated in ship_process_post()
+	// Also only multi masters do ai
+	if ( (obj == nullptr) || !frametime || MULTIPLAYER_CLIENT || !Ai_before_physics)
+		return;
+
+	int num = obj->instance;
+	Assert(num >= 0 && num < MAX_SHIPS);
+	Assert(Ships[num].objnum == OBJ_INDEX(obj));
+	ship* shipp = &Ships[num];
+
+	if (obj->type != OBJ_SHIP) {
+		nprintf(("AI", "Ignoring non-ship object in ship_process_pre()\n"));
+		return;
+	}
+
+	if ((!(shipp->is_arriving()) || (Ai_info[shipp->ai_index].mode == AIM_BAY_EMERGE)
+		|| ((Warp_params[shipp->warpin_params_index].warp_type == WT_IN_PLACE_ANIM) && (shipp->flags[Ship_Flags::Arriving_stage_2])))
+		&& !(shipp->flags[Ship_Flags::Depart_warp]))
+	{
+		ship_evaluate_ai(obj, frametime);
 	}
 }
 
@@ -8980,7 +8989,6 @@ void ship_process_post(object * obj, float frametime)
 
 	num = obj->instance;
 	Assert( num >= 0 && num < MAX_SHIPS);
-	Assert( obj->type == OBJ_SHIP );
 	Assert( Ships[num].objnum == OBJ_INDEX(obj));	
 
 	shipp = &Ships[num];
@@ -9125,50 +9133,12 @@ void ship_process_post(object * obj, float frametime)
 		// maybe fire a corkscrew missile (just like swarmers)
 		cscrew_maybe_fire_missile(num);
 
-	}
-
-	// If Ai_before_physics is true everything following is evaluated in ship_process_pre()
-	if (!Ai_before_physics) {
-		//rotate player subobjects since its processed by the ai functions
-		// AL 2-19-98: Fire turret for player if it exists
-		//WMC - changed this to call process_subobjects
-		if ((obj->flags[Object::Object_Flags::Player_ship]) && !Player_use_ai)
-		{
-			ai_info* aip = &Ai_info[Ships[obj->instance].ai_index];
-			if (aip->ai_flags[AI::AI_Flags::Being_repaired, AI::AI_Flags::Awaiting_repair])
-			{
-				if (aip->support_ship_objnum >= 0)
-				{
-					if (vm_vec_dist_quick(&obj->pos, &Objects[aip->support_ship_objnum].pos) < (obj->radius + Objects[aip->support_ship_objnum].radius) * 1.25f)
-						return;
-				}
-			}
-			if (!shipp->flags[Ship::Ship_Flags::Rotators_locked])
-				process_subobjects(OBJ_INDEX(obj));
-		}
-
 		if (obj == Player_obj) {
 			ship_check_player_distance();
 		}
 
-		// update ship lethality
-		if (Ships[num].ai_index >= 0) {
-			if (!physics_paused && !ai_paused) {
-				lethality_decay(&Ai_info[Ships[num].ai_index]);
-			}
-		}
-
-		// if the ship is an observer ship don't need to do AI
-		if (obj->type == OBJ_OBSERVER) {
-			return;
-		}
-
-		// Goober5000 - player may want to use AI
-		if ((Ships[num].ai_index >= 0) && (!(obj->flags[Object::Object_Flags::Player_ship]) || Player_use_ai)) {
-			if (!physics_paused && !ai_paused) {
-				ai_process(obj, Ships[num].ai_index, frametime);
-			}
-		}
+		if (!Ai_before_physics)
+			ship_evaluate_ai(obj, frametime);
 	}
 }
 

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -8859,7 +8859,7 @@ static void lethality_decay(ai_info *aip)
 void ship_process_pre(object *obj, float frametime)
 {
 	// If Ai_before_physics is false everything following is evaluated in ship_process_post()
-	if ( (obj == NULL) || !frametime || !Ai_before_physics)
+	if ( (obj == nullptr) || !frametime || !Ai_before_physics)
 		return;
 
 	int	num;

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -8981,7 +8981,7 @@ void ship_process_post(object * obj, float frametime)
 	ship_info *sip;
 
 	if(obj->type != OBJ_SHIP){
-		nprintf(("Network","Ignoring non-ship object in ship_process_post()\n"));
+		nprintf(("General","Ignoring non-ship object in ship_process_post()\n"));
 		return;
 	}
 

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -4474,6 +4474,8 @@ void weapon_home(object *obj, int num, float frame_time)
 // moved out of weapon_process_post() so it can be called from either -post() or -pre() depending on Ai_before_physics
 void weapon_update_missiles(object* obj, float  frame_time) {
 
+	Assertion(obj->type == OBJ_WEAPON, "weapon_update_missiles called on a non-weapon object");
+
 	weapon* wp = &Weapons[obj->instance];
 	weapon_info* wip = &Weapon_info[wp->weapon_info_index];
 

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -4470,6 +4470,42 @@ void weapon_home(object *obj, int num, float frame_time)
 	}
 }
 
+
+// moved out of weapon_process_post() so it can be called from either -post() or -pre() depending on Ai_before_physics
+void weapon_update_missiles(object* obj, float  frame_time) {
+
+	weapon* wp = &Weapons[obj->instance];
+	weapon_info* wip = &Weapon_info[wp->weapon_info_index];
+
+	// a single player or multiplayer server function -- it affects actual weapon movement.
+	if (wip->is_homing() && !(wp->weapon_flags[Weapon::Weapon_Flags::No_homing])) {
+		weapon_home(obj, obj->instance, frame_time);
+
+		// If this is a swarm type missile,  
+		if (wp->swarm_index >= 0) {
+			swarm_update_direction(obj);
+		}
+
+		if (wp->cscrew_index >= 0) {
+			cscrew_process_post(obj);
+		}
+	}
+	else if (wip->acceleration_time > 0.0f) {
+		if (Missiontime - wp->creation_time < fl2f(wip->acceleration_time)) {
+			float t;
+
+			t = f2fl(Missiontime - wp->creation_time) / wip->acceleration_time;
+			obj->phys_info.speed = wp->launch_speed + MAX(0.0f, wp->weapon_max_vel - wp->launch_speed) * t;
+		}
+		else {
+			obj->phys_info.speed = wip->max_speed;
+			obj->phys_info.flags |= PF_CONST_VEL; // Max speed reached, can use simpler physics calculations now
+		}
+
+		vm_vec_copy_scale(&obj->phys_info.desired_vel, &obj->orient.vec.fvec, obj->phys_info.speed);
+	}
+}
+
 // as Mike K did with ships -- break weapon into process_pre and process_post for code to execute
 // before and after physics movement
 
@@ -4514,35 +4550,9 @@ void weapon_process_pre( object *obj, float  frame_time)
 		}
 	}
 
-	// If this flag is false this is evaluated in weapon_process_post()
+	// If this flag is false missile turning is evaluated in weapon_process_post()
 	if (Ai_before_physics) {
-		// a single player or multiplayer server function -- it affects actual weapon movement.
-		if (wip->is_homing() && !(wp->weapon_flags[Weapon::Weapon_Flags::No_homing])) {
-			weapon_home(obj, obj->instance, frame_time);
-
-			// If this is a swarm type missile,  
-			if (wp->swarm_index >= 0) {
-				swarm_update_direction(obj);
-			}
-
-			if (wp->cscrew_index >= 0) {
-				cscrew_process_post(obj);
-			}
-		}
-		else if (wip->acceleration_time > 0.0f) {
-			if (Missiontime - wp->creation_time < fl2f(wip->acceleration_time)) {
-				float t;
-
-				t = f2fl(Missiontime - wp->creation_time) / wip->acceleration_time;
-				obj->phys_info.speed = wp->launch_speed + MAX(0.0f, wp->weapon_max_vel - wp->launch_speed) * t;
-			}
-			else {
-				obj->phys_info.speed = wip->max_speed;
-				obj->phys_info.flags |= PF_CONST_VEL; // Max speed reached, can use simpler physics calculations now
-			}
-
-			vm_vec_copy_scale(&obj->phys_info.desired_vel, &obj->orient.vec.fvec, obj->phys_info.speed);
-		}
+		weapon_update_missiles(obj, frame_time);
 	}
 }
 
@@ -4845,33 +4855,7 @@ void weapon_process_post(object * obj, float frame_time)
 
 	// If this flag is true this is evaluated in weapon_process_pre()
 	if (!Ai_before_physics) {
-		// a single player or multiplayer server function -- it affects actual weapon movement.
-		if (wip->is_homing() && !(wp->weapon_flags[Weapon::Weapon_Flags::No_homing])) {
-			weapon_home(obj, num, frame_time);
-
-			// If this is a swarm type missile,  
-			if (wp->swarm_index >= 0) {
-				swarm_update_direction(obj);
-			}
-
-			if (wp->cscrew_index >= 0) {
-				cscrew_process_post(obj);
-			}
-		}
-		else if (wip->acceleration_time > 0.0f) {
-			if (Missiontime - wp->creation_time < fl2f(wip->acceleration_time)) {
-				float t;
-
-				t = f2fl(Missiontime - wp->creation_time) / wip->acceleration_time;
-				obj->phys_info.speed = wp->launch_speed + MAX(0.0f, wp->weapon_max_vel - wp->launch_speed) * t;
-			}
-			else {
-				obj->phys_info.speed = wip->max_speed;
-				obj->phys_info.flags |= PF_CONST_VEL; // Max speed reached, can use simpler physics calculations now
-			}
-
-			vm_vec_copy_scale(&obj->phys_info.desired_vel, &obj->orient.vec.fvec, obj->phys_info.speed);
-		}
+		weapon_update_missiles(obj, frame_time);
 	}
 
 	//local ssm stuff


### PR DESCRIPTION
As is, and far as I've been able to test with a significant chunk of retail, and a few WiH and JAD missions, enabling this flag shouldn't result in any changed behavior. This will lay the groundwork for a better implementation of `ai_turn_towards_vector()` which doesn't result in strong frametime-dependance.