### PR TITLE
Make sure gr_aa_preset_last_frame is initialized correctly

### DIFF
--- a/code/cmdline/cmdline.cpp
+++ b/code/cmdline/cmdline.cpp
@@ -1910,10 +1910,6 @@ bool SetCmdlineParams()
 		}
 	}
 
-	// If any of the AA presets were chosen, update the _last_frame AA mode to avoid an unnecessary
-	// shader recompile.
-	Gr_aa_mode_last_frame = Gr_aa_mode;
-
 	if ( glow_arg.found() )
 		Cmdline_glow = 0;
 

--- a/code/graphics/opengl/gropenglpostprocessing.cpp
+++ b/code/graphics/opengl/gropenglpostprocessing.cpp
@@ -1026,6 +1026,9 @@ bool opengl_post_init_shaders()
 	int idx;
 	int flags = 0;
 
+	// Make sure this is set properly before we actually try to render anything with the post pipeline
+	Gr_aa_mode_last_frame = Gr_aa_mode;
+
 	// figure out which flags we need for the main post process shader
 	for (idx = 0; idx < (int)Post_effects.size(); idx++) {
 		if (Post_effects[idx].always_on) {


### PR DESCRIPTION
Fixes a bug when both -aa and -fxaa or -smaa commandline parameters were specified.