### PR TITLE
Fix Missing Check for Primary Linking

### DIFF
--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -5581,11 +5581,14 @@ void set_primary_weapon_linkage(object *objp)
 	}
 
 	// make linking decision based on weapon energy
-	if (energy > aip->ai_link_energy_levels_always) {
-        shipp->flags.set(Ship::Ship_Flags::Primary_linked);
-	} else if (energy > aip->ai_link_ammo_levels_maybe) {
-		if (objp->hull_strength < shipp->ship_max_hull_strength/3.0f) {
+	// but only if primary linking is allowed --wookieejedi
+	if (!sip->flags[Ship::Info_Flags::No_primary_linking]) {
+		if (energy > aip->ai_link_energy_levels_always) {
 			shipp->flags.set(Ship::Ship_Flags::Primary_linked);
+		} else if (energy > aip->ai_link_ammo_levels_maybe) {
+			if (objp->hull_strength < shipp->ship_max_hull_strength / 3.0f) {
+				shipp->flags.set(Ship::Ship_Flags::Primary_linked);
+			}
 		}
 	}
 


### PR DESCRIPTION
Previously, `ai_link_energy_levels_always` or `ai_link_ammo_levels_maybe` could allow a ship to link weapons even if the `No_primary_linking` flag was setfor that ship. This PR fixes that by added a check for `No_primary_linking` before `ai_link_energy_levels_always` or `ai_link_ammo_levels_maybe` is evaluated.