### PR TITLE
add the ability to use multiple sexp parameter variants

### DIFF
--- a/code/parse/sexp/LuaSEXP.cpp
+++ b/code/parse/sexp/LuaSEXP.cpp
@@ -27,6 +27,7 @@ namespace {
 SCP_unordered_map<SCP_string, int> parameter_type_mapping{{ "boolean",      OPF_BOOL },
 														  { "number",       OPF_NUMBER },
 														  { "ship",         OPF_SHIP },
+														  { "shipname",     OPF_SHIP },
 														  { "string",       OPF_STRING },
 														  { "team",         OPF_IFF },
 														  { "waypointpath", OPF_WAYPOINT_PATH },
@@ -35,15 +36,15 @@ SCP_unordered_map<SCP_string, int> parameter_type_mapping{{ "boolean",      OPF_
 														  { "wing",         OPF_WING },
 														  { "shipclass",    OPF_SHIP_CLASS_NAME },
 														  { "weaponclass",  OPF_WEAPON_NAME }, };
-int get_parameter_type(const SCP_string& name) {
+std::pair<SCP_string, int> get_parameter_type(const SCP_string& name) {
 	SCP_string copy = name;
 	std::transform(copy.begin(), copy.end(), copy.begin(), [](char c) { return (char)::tolower(c); });
 
 	auto iter = parameter_type_mapping.find(copy);
 	if (iter == parameter_type_mapping.end()) {
-		return -1;
+		return std::pair<SCP_string, int>(copy, -1);
 	} else {
-		return iter->second;
+		return std::pair<SCP_string, int>(copy, iter->second);
 	}
 }
 
@@ -97,9 +98,9 @@ int LuaSEXP::getMinimumArguments() {
 int LuaSEXP::getMaximumArguments() {
 	return _max_args;
 }
-int LuaSEXP::getArgumentType(int argnum) const {
+std::pair<SCP_string, int> LuaSEXP::getArgumentInternalType(int argnum) const {
 	if (argnum < 0) {
-		return OPF_NONE;
+		return std::pair<SCP_string, int>(SEXP_NONE_STRING, OPF_NONE);
 	}
 
 	if (argnum < (int) _argument_types.size()) {
@@ -110,7 +111,7 @@ int LuaSEXP::getArgumentType(int argnum) const {
 	// sanity check in case of bad table data
 	if (_varargs_type_pattern.empty()) {
 		Warning(LOCATION, "Not enough parameters specified for Lua SEXP %s!", getName().c_str());
-		return OPF_NONE;
+		return std::pair<SCP_string, int>(SEXP_NONE_STRING, OPF_NONE);
 	}
 
 	// We are in the variable argument types region
@@ -123,11 +124,14 @@ int LuaSEXP::getArgumentType(int argnum) const {
 	// And then use that to get the parameter type
 	return _varargs_type_pattern[varargs_index];
 }
+int LuaSEXP::getArgumentType(int argnum) const {
+	return getArgumentInternalType(argnum).second;
+}
 luacpp::LuaValue LuaSEXP::sexpToLua(int node, int argnum) const {
 	using namespace scripting::api;
-	auto argtype = getArgumentType(argnum);
+	auto argtype = getArgumentInternalType(argnum);
 
-	switch (argtype) {
+	switch (argtype.second) {
 	case OPF_BOOL: {
 		auto value = is_sexp_true(node) != 0;
 		return LuaValue::createValue(_action.getLuaState(), value);
@@ -163,6 +167,11 @@ luacpp::LuaValue LuaSEXP::sexpToLua(int node, int argnum) const {
 		// The following argument types are all strings
 	case OPF_SHIP: {
 		auto ship_entry = eval_ship(node);
+
+		// if this is a shipname type, we want the name of a valid ship but not the ship itself
+		if (ship_entry && argtype.first == "shipname") {
+			return LuaValue::createValue(_action.getLuaState(), ship_entry->name);
+		}
 
 		if (!ship_entry || ship_entry->status != ShipStatus::PRESENT) {
 			// Name is invalid
@@ -438,9 +447,9 @@ void LuaSEXP::parseTable() {
 		stuff_string(type_str, F_NAME);
 
 		auto type = get_parameter_type(type_str);
-		if (type < 0) {
+		if (type.second < 0) {
 			error_display(0, "Unknown parameter type '%s'!", type_str.c_str());
-			type = OPF_STRING;
+			type = get_parameter_type("string");
 		}
 
 		if (variable_arg_part) {

--- a/code/parse/sexp/LuaSEXP.h
+++ b/code/parse/sexp/LuaSEXP.h
@@ -15,15 +15,17 @@ class LuaSEXP : public DynamicSEXP {
 	int _min_args;
 	int _max_args;
 
-	SCP_vector<int> _argument_types; //!< These are the types of the static, non-repeating arguments
-	SCP_vector<int> _varargs_type_pattern; //!< This is the pattern for the variable argument part of the SEXP
+	SCP_vector<std::pair<SCP_string, int>> _argument_types;			//!< These are the types of the static, non-repeating arguments
+	SCP_vector<std::pair<SCP_string, int>> _varargs_type_pattern;	//!< This is the pattern for the variable argument part of the SEXP
 
 	int _return_type = OPR_NULL;
 
 	int _category;
 	int _subcategory;
 
+	std::pair<SCP_string, int> getArgumentInternalType(int argnum) const;
 	luacpp::LuaValue sexpToLua(int node, int argnum) const;
+
  public:
 	explicit LuaSEXP(const SCP_string& name);
 


### PR DESCRIPTION
This is specifically for OPF_SHIP.  Currently if you specify a LuaSEXP with OPF_SHIP, it only works for ships that are present in the mission when the SEXP is called.  This is my attempt at a LuaSEXP parameter variant that will return a valid ship name regardless of the ship status.  It required a bit of finagling the existing API.