### PR TITLE
Allow for second-order lead indicator prediction

### DIFF
--- a/code/ai/ai_profiles.cpp
+++ b/code/ai/ai_profiles.cpp
@@ -595,7 +595,7 @@ void ai_profile_t::reset()
 	subsystem_path_radii = 0;
     bay_arrive_speed_mult = 0;
     bay_depart_speed_mult = 0;
-	second_order_lead_prediction = 0;
+	second_order_lead_predict_factor = 0;
 
     for (int i = 0; i < NUM_SKILL_LEVELS; ++i) {
         max_incoming_asteroids[i] = 0;

--- a/code/ai/ai_profiles.cpp
+++ b/code/ai/ai_profiles.cpp
@@ -511,6 +511,13 @@ void parse_ai_profiles_tbl(const char *filename)
 					stuff_boolean(&temp);
                     profile->flags.set(AI::Profile_Flags::Allow_primary_link_at_start, !temp);
 				}
+				if (optional_string("$lead indicator second-order prediction factor:")) {
+					stuff_float(&profile->second_order_lead_predict_factor);
+					if (profile->second_order_lead_predict_factor > 1 || profile->second_order_lead_predict_factor < 0) {
+						mprintf(("Warning: \"$lead indicator second-order prediction factor\" must be 0 - 1, resetting to 0.\"\n"));
+						profile->second_order_lead_predict_factor = 0;
+					}
+				}
 
 
 				// if we've been through once already and are at the same place, force a move
@@ -588,6 +595,7 @@ void ai_profile_t::reset()
 	subsystem_path_radii = 0;
     bay_arrive_speed_mult = 0;
     bay_depart_speed_mult = 0;
+	second_order_lead_prediction = 0;
 
     for (int i = 0; i < NUM_SKILL_LEVELS; ++i) {
         max_incoming_asteroids[i] = 0;

--- a/code/ai/ai_profiles.h
+++ b/code/ai/ai_profiles.h
@@ -105,6 +105,9 @@ public:
 	float bay_arrive_speed_mult;
 	float bay_depart_speed_mult;
 
+	// How much 0-1 of a second-order lead prediction factor to add to lead indicators. Affects AI, HUD, and autoaim.
+	float second_order_lead_predict_factor;
+
     void reset();
 };
 

--- a/code/ai/ai_profiles.h
+++ b/code/ai/ai_profiles.h
@@ -105,7 +105,7 @@ public:
 	float bay_arrive_speed_mult;
 	float bay_depart_speed_mult;
 
-	// How much 0-1 of a second-order lead prediction factor to add to lead indicators. Affects AI, HUD, and autoaim.
+	// How much 0-1 of a second-order lead prediction factor to add to lead indicators. Affects only the HUD indicator, and autoaim.
 	float second_order_lead_predict_factor;
 
     void reset();


### PR DESCRIPTION
Adds a flag that will allow the lead indicator to predict changes in predicted position parabolically based on current rotvel. Allows for better prediction for turning targets but still limited by high time-to-target or fast turn speeds (a parabola can only approximate a circle so far). Might add circular prediction for high rotvel targets at some point but would be more complicated.