### PR TITLE
Make redalert missions work better in multi

### DIFF
--- a/code/missionui/redalert.cpp
+++ b/code/missionui/redalert.cpp
@@ -28,6 +28,7 @@
 #include "missionui/missionweaponchoice.h"
 #include "missionui/redalert.h"
 #include "network/multiteamselect.h"
+#include "network/multi_endgame.h"
 #include "mod_table/mod_table.h"
 #include "model/model.h"
 #include "object/deadobjectdock.h"
@@ -409,7 +410,12 @@ void red_alert_do_frame(float frametime)
 	switch (k) {
 		case KEY_ESC:
 //			gameseq_post_event(GS_EVENT_ENTER_GAME);
-			gameseq_post_event(GS_EVENT_MAIN_MENU);
+			if (Game_mode & GM_MULTIPLAYER) {
+				gamesnd_play_iface(InterfaceSounds::USER_SELECT);
+				multi_quit_game(PROMPT_ALL);
+			} else {
+				gameseq_post_event(GS_EVENT_MAIN_MENU);
+			}
 			break;
 	}	// end switch
 

--- a/code/missionui/redalert.cpp
+++ b/code/missionui/redalert.cpp
@@ -242,7 +242,7 @@ void red_alert_button_pressed(int n)
 		break;
 
 	case RA_REPLAY_MISSION:
-		if ( Game_mode & GM_CAMPAIGN_MODE ) {
+		if ( (Game_mode & GM_CAMPAIGN_MODE) && !(Game_mode & GM_MULTIPLAYER) ) {
 			// TODO: make call to campaign code to set correct mission for loading
 			// mission_campaign_play_previous_mission(Red_alert_precursor_mission);
 			if ( !mission_campaign_previous_mission() ) {

--- a/code/network/multimsgs.cpp
+++ b/code/network/multimsgs.cpp
@@ -2127,7 +2127,14 @@ void process_netgame_update_packet( ubyte *data, header *hinfo )
 			multi_handle_state_special();
 
 			strcpy_s( Game_current_mission_filename, Netgame.mission_name );
-			gameseq_post_event(GS_EVENT_START_BRIEFING);			
+
+			extern int red_alert_mission();
+
+			if ( red_alert_mission() ) {
+				gameseq_post_event(GS_EVENT_RED_ALERT);
+			} else {
+				gameseq_post_event(GS_EVENT_START_BRIEFING);
+			}
 		}
 	} 		
 	// move from the debriefing to the create game screen

--- a/code/network/multiteamselect.cpp
+++ b/code/network/multiteamselect.cpp
@@ -2624,7 +2624,9 @@ void multi_ts_commit_pressed()
 {					
 	// if my team's slots are still not "locked", we cannot commit unless we're the only player in the game
 	if(!Multi_ts_team[Net_player->p_info.team].multi_players_locked){
-		if(multi_num_players() != 1){
+		extern int red_alert_mission();
+		// skip this for red-alert missions too since nothing is selectable
+		if ( !red_alert_mission() && (multi_num_players() != 1) ) {
 			popup(PF_USE_AFFIRMATIVE_ICON | PF_BODY_BIG,1,POPUP_OK, XSTR("Players have not yet been assigned to their ships",751));
 			return;
 		} else {


### PR DESCRIPTION
Still needs a little more testing to verify it works properly on standalone, host, and clients.

Should address the following issues:
 - support sync state before entering mission
 - return to briefing for sync and stats saving
 - handle campaign progression properly
 - initialize net_player state properly (fixes #2560)