### PR TITLE
Allow multilock missiles to restrict lock based on class or species

### DIFF
--- a/code/hud/hudlock.cpp
+++ b/code/hud/hudlock.cpp
@@ -919,7 +919,7 @@ void hud_lock_acquire_uncaged_target(lock_info *current_lock, weapon_info *wip)
 			continue;
 		}*/
 
-		if (!weapon_multilock_can_lock_on_ship(wip, A->instance)) {
+		if (!wip->multilock.can_lock_on_ship(A->instance)) {
 			continue;
 		}
 
@@ -1037,7 +1037,7 @@ void hud_lock_determine_lock_target(lock_info *lock_slot, weapon_info *wip)
 			return;
 		}
 
-		if ( !weapon_multilock_can_lock_on_ship(wip, lock_slot->obj->instance) ) {
+		if ( !wip->multilock.can_lock_on_ship(lock_slot->obj->instance) ) {
 			ship_clear_lock(lock_slot);
 			return;
 		}
@@ -1105,7 +1105,7 @@ void hud_lock_determine_lock_target(lock_info *lock_slot, weapon_info *wip)
 			return;
 		}
 
-		if ( !weapon_multilock_can_lock_on_ship(wip, lock_slot->obj->instance) ) {
+		if ( !wip->multilock.can_lock_on_ship(lock_slot->obj->instance) ) {
 			ship_clear_lock(lock_slot);
 			return;
 		}

--- a/code/hud/hudlock.cpp
+++ b/code/hud/hudlock.cpp
@@ -919,7 +919,7 @@ void hud_lock_acquire_uncaged_target(lock_info *current_lock, weapon_info *wip)
 			continue;
 		}*/
 
-		if (!wip->multilock.can_lock_on_ship(A->instance)) {
+		if (!weapon_multilock_can_lock_on_ship(wip, A->instance)) {
 			continue;
 		}
 
@@ -1037,7 +1037,7 @@ void hud_lock_determine_lock_target(lock_info *lock_slot, weapon_info *wip)
 			return;
 		}
 
-		if ( !wip->multilock.can_lock_on_ship(lock_slot->obj->instance) ) {
+		if ( !weapon_multilock_can_lock_on_ship(wip, lock_slot->obj->instance) ) {
 			ship_clear_lock(lock_slot);
 			return;
 		}
@@ -1105,7 +1105,7 @@ void hud_lock_determine_lock_target(lock_info *lock_slot, weapon_info *wip)
 			return;
 		}
 
-		if ( !wip->multilock.can_lock_on_ship(lock_slot->obj->instance) ) {
+		if ( !weapon_multilock_can_lock_on_ship(wip, lock_slot->obj->instance) ) {
 			ship_clear_lock(lock_slot);
 			return;
 		}

--- a/code/hud/hudlock.cpp
+++ b/code/hud/hudlock.cpp
@@ -1037,6 +1037,11 @@ void hud_lock_determine_lock_target(lock_info *lock_slot, weapon_info *wip)
 			return;
 		}
 
+		if (!weapon_multilock_can_lock_on_ship(wip, &Ships[lock_slot->obj->instance])) {
+			ship_clear_lock(lock_slot);
+			return;
+		}
+
 		if ( !weapon_can_lock_on_ship_type(wip, Ship_info[Ships[lock_slot->obj->instance].ship_info_index].class_type) ) {
 			ship_clear_lock(lock_slot);
 			return;

--- a/code/hud/hudlock.cpp
+++ b/code/hud/hudlock.cpp
@@ -919,7 +919,7 @@ void hud_lock_acquire_uncaged_target(lock_info *current_lock, weapon_info *wip)
 			continue;
 		}*/
 
-		if ( !weapon_can_lock_on_ship_type(wip, Ship_info[sp->ship_info_index].class_type) ) {
+		if (!weapon_multilock_can_lock_on_ship(wip, A->instance)) {
 			continue;
 		}
 
@@ -1037,12 +1037,7 @@ void hud_lock_determine_lock_target(lock_info *lock_slot, weapon_info *wip)
 			return;
 		}
 
-		if (!weapon_multilock_can_lock_on_ship(wip, &Ships[lock_slot->obj->instance])) {
-			ship_clear_lock(lock_slot);
-			return;
-		}
-
-		if ( !weapon_can_lock_on_ship_type(wip, Ship_info[Ships[lock_slot->obj->instance].ship_info_index].class_type) ) {
+		if ( !weapon_multilock_can_lock_on_ship(wip, lock_slot->obj->instance) ) {
 			ship_clear_lock(lock_slot);
 			return;
 		}
@@ -1110,7 +1105,7 @@ void hud_lock_determine_lock_target(lock_info *lock_slot, weapon_info *wip)
 			return;
 		}
 
-		if ( !weapon_can_lock_on_ship_type(wip, Ship_info[Ships[lock_slot->obj->instance].ship_info_index].class_type) ) {
+		if ( !weapon_multilock_can_lock_on_ship(wip, lock_slot->obj->instance) ) {
 			ship_clear_lock(lock_slot);
 			return;
 		}

--- a/code/weapon/weapon.h
+++ b/code/weapon/weapon.h
@@ -338,9 +338,7 @@ struct weapon_info
 	int max_seekers_per_target;			// how many seekers can be attached to a target.
 
 	SCP_vector<multilock_restriction> ship_restrict;
-	SCP_vector<SCP_string> ship_type_restrict_temp;
-	SCP_vector<SCP_string> ship_class_restrict_temp;
-	SCP_vector<SCP_string> ship_species_restrict_temp;
+	SCP_vector<std::pair<MultilockRestrictionType, SCP_string>> ship_restrict_strings;
 
 	bool trigger_lock;						// Trigger must be held down and released to lock and fire.
 	bool launch_reset_locks;				// Lock indicators reset after firing

--- a/code/weapon/weapon.h
+++ b/code/weapon/weapon.h
@@ -332,6 +332,10 @@ struct weapon_info
 
 	SCP_vector<int> ship_type_restrict;
 	SCP_vector<SCP_string> ship_type_restrict_temp;
+	SCP_vector<int> ship_class_restrict;
+	SCP_vector<SCP_string> ship_class_restrict_temp;
+	SCP_vector<int> ship_species_restrict;
+	SCP_vector<SCP_string> ship_species_restrict_temp;
 
 	bool trigger_lock;						// Trigger must be held down and released to lock and fire.
 	bool launch_reset_locks;				// Lock indicators reset after firing
@@ -656,7 +660,7 @@ void shield_impact_explosion(vec3d *hitpos, object *objp, float radius, int idx)
 int weapon_get_max_missile_seekers(weapon_info *wip);
 
 // return if this weapon can lock on this ship type
-bool weapon_can_lock_on_ship_type(weapon_info *wip, int ship_type);
+bool weapon_multilock_can_lock_on_ship(weapon_info *wip, ship* ship);
 
 
 #endif

--- a/code/weapon/weapon.h
+++ b/code/weapon/weapon.h
@@ -236,6 +236,29 @@ enum InFlightSoundType
 
 #define MAX_SUBSTITUTION_PATTERNS	10
 
+class filter {
+public:
+	virtual bool apply(int ship) = 0;
+	virtual bool active() = 0;
+	virtual void clear() = 0;
+	virtual ~filter() {}
+};
+
+struct weapon_info;
+
+class multilock_filter {
+public:
+	multilock_filter();
+	void clear();
+	void init(weapon_info& wip);
+
+	// return if this weapon can lock on this ship, based on its type, class or species
+	bool can_lock_on_ship(int ship_num);
+private:
+	std::array<std::unique_ptr<filter>, 3> filters;
+	static void init_vec_filter(const weapon_info& wip, std::unique_ptr<filter>& dest, SCP_vector<SCP_string>& strs, int (*fun)(const char*));
+};
+
 struct weapon_info
 {
 	char	name[NAME_LENGTH];				// name of this weapon
@@ -330,11 +353,9 @@ struct weapon_info
 	int max_seeking;						// how many seekers can be active at a time if multilock is enabled. A value of one will lock stuff up one by one.
 	int max_seekers_per_target;			// how many seekers can be attached to a target.
 
-	SCP_vector<int> ship_type_restrict;
+	multilock_filter multilock;
 	SCP_vector<SCP_string> ship_type_restrict_temp;
-	SCP_vector<int> ship_class_restrict;
 	SCP_vector<SCP_string> ship_class_restrict_temp;
-	SCP_vector<int> ship_species_restrict;
 	SCP_vector<SCP_string> ship_species_restrict_temp;
 
 	bool trigger_lock;						// Trigger must be held down and released to lock and fire.
@@ -658,9 +679,5 @@ void shield_impact_explosion(vec3d *hitpos, object *objp, float radius, int idx)
 
 // Swifty - return number of max simultaneous locks 
 int weapon_get_max_missile_seekers(weapon_info *wip);
-
-// return if this weapon can lock on this ship, based on its type, class or species
-bool weapon_multilock_can_lock_on_ship(weapon_info *wip, int ship_num);
-
 
 #endif

--- a/code/weapon/weapon.h
+++ b/code/weapon/weapon.h
@@ -659,8 +659,8 @@ void shield_impact_explosion(vec3d *hitpos, object *objp, float radius, int idx)
 // Swifty - return number of max simultaneous locks 
 int weapon_get_max_missile_seekers(weapon_info *wip);
 
-// return if this weapon can lock on this ship type
-bool weapon_multilock_can_lock_on_ship(weapon_info *wip, ship* ship);
+// return if this weapon can lock on this ship, based on its type, class or species
+bool weapon_multilock_can_lock_on_ship(weapon_info *wip, int ship_num);
 
 
 #endif

--- a/code/weapon/weapon.h
+++ b/code/weapon/weapon.h
@@ -236,28 +236,12 @@ enum InFlightSoundType
 
 #define MAX_SUBSTITUTION_PATTERNS	10
 
-class filter {
-public:
-	virtual bool apply(int ship) = 0;
-	virtual bool active() = 0;
-	virtual void clear() = 0;
-	virtual ~filter() {}
+enum class MultilockRestrictionType
+{
+	TYPE, CLASS, SPECIES
 };
 
-struct weapon_info;
-
-class multilock_filter {
-public:
-	multilock_filter();
-	void clear();
-	void init(weapon_info& wip);
-
-	// return if this weapon can lock on this ship, based on its type, class or species
-	bool can_lock_on_ship(int ship_num);
-private:
-	std::array<std::unique_ptr<filter>, 3> filters;
-	static void init_vec_filter(const weapon_info& wip, std::unique_ptr<filter>& dest, SCP_vector<SCP_string>& strs, int (*fun)(const char*));
-};
+typedef std::pair<MultilockRestrictionType, int> multilock_restriction;
 
 struct weapon_info
 {
@@ -353,7 +337,7 @@ struct weapon_info
 	int max_seeking;						// how many seekers can be active at a time if multilock is enabled. A value of one will lock stuff up one by one.
 	int max_seekers_per_target;			// how many seekers can be attached to a target.
 
-	multilock_filter multilock;
+	SCP_vector<multilock_restriction> ship_restrict;
 	SCP_vector<SCP_string> ship_type_restrict_temp;
 	SCP_vector<SCP_string> ship_class_restrict_temp;
 	SCP_vector<SCP_string> ship_species_restrict_temp;
@@ -679,5 +663,9 @@ void shield_impact_explosion(vec3d *hitpos, object *objp, float radius, int idx)
 
 // Swifty - return number of max simultaneous locks 
 int weapon_get_max_missile_seekers(weapon_info *wip);
+
+// return if this weapon can lock on this ship, based on its type, class or species
+bool weapon_multilock_can_lock_on_ship(weapon_info *wip, int ship_num);
+
 
 #endif

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -8278,10 +8278,10 @@ bool multilock_filter::can_lock_on_ship(int ship_num)
 {
 	// if you didn't specify any restrictions, you can always lock
 	if (!std::any_of(filters.begin(), filters.end(),
-		[](std::unique_ptr<vec_filter>& f) { return f.get()->active(); })) return true;
+		[](std::unique_ptr<filter>& f) { return f.get()->active(); })) return true;
 	// otherwise, you're good as long as one of the lists is specified and the target's in it
 	return std::any_of(filters.begin(), filters.end(),
-		[=](std::unique_ptr<vec_filter>& f) { return f.get()->apply(ship_num); });
+		[=](std::unique_ptr<filter>& f) { return f.get()->apply(ship_num); });
 }
 
 void multilock_filter::init_vec_filter(const weapon_info& wip, std::unique_ptr<filter>& dest, SCP_vector<SCP_string>& strs, int (*fun)(const char*)) {

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -8277,9 +8277,11 @@ void multilock_filter::clear() {
 bool multilock_filter::can_lock_on_ship(int ship_num)
 {
 	// if you didn't specify any restrictions, you can always lock
-	if (!std::any_of(filters.begin(), filters.end(), [](auto& f) { return f.get()->active(); })) return true;
+	if (!std::any_of(filters.begin(), filters.end(),
+		[](std::unique_ptr<vec_filter>& f) { return f.get()->active(); })) return true;
 	// otherwise, you're good as long as one of the lists is specified and the target's in it
-	return std::any_of(filters.begin(), filters.end(), [=](auto& f) { return f.get()->apply(ship_num); });
+	return std::any_of(filters.begin(), filters.end(),
+		[=](std::unique_ptr<vec_filter>& f) { return f.get()->apply(ship_num); });
 }
 
 void multilock_filter::init_vec_filter(const weapon_info& wip, std::unique_ptr<filter>& dest, SCP_vector<SCP_string>& strs, int (*fun)(const char*)) {

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -8282,31 +8282,18 @@ int weapon_get_max_missile_seekers(weapon_info *wip)
 	return max_target_locks;
 }
 
-bool weapon_can_lock_on_ship_type(weapon_info *wip, int ship_type)
+bool weapon_multilock_can_lock_on_ship(weapon_info* wip, int ship_num)
 {
-	// Determine if there are any type restrictions, treating an empty list as true
-	return (wip->ship_type_restrict.empty()) || 
-			std::any_of(wip->ship_type_restrict.begin(), wip->ship_type_restrict.end(), [ship_type](int type) { return type == ship_type; });
-}
-
-bool weapon_can_lock_on_ship_class(weapon_info* wip, int ship_class)
-{
-	// Determine if there are any class restrictions, treating an empty list as true
-	return (wip->ship_class_restrict.empty()) ||
-		std::any_of(wip->ship_class_restrict.begin(), wip->ship_class_restrict.end(), [ship_class](int restricted_class) { return restricted_class == ship_class; });
-}
-
-bool weapon_can_lock_on_ship_species(weapon_info* wip, int species)
-{
-	// Determine if there are any species restrictions, treating an empty list as true
-	return (wip->ship_species_restrict.empty()) ||
-		std::any_of(wip->ship_species_restrict.begin(), wip->ship_species_restrict.end(), [species](int restricted_species) { return restricted_species == species; });
-}
-
-bool weapon_multilock_can_lock_on_ship(weapon_info* wip, object* ship)
-{
-	int type = ship->ty
-	// Determine if there are any restrictions, treating an empty list as true
-	return (wip->ship_species_restrict.empty()) ||
-		std::any_of(wip->ship_species_restrict.begin(), wip->ship_species_restrict.end(), [species](int restricted_species) { return restricted_species == species; });
+	int type_num = Ship_info[Ships[ship_num].ship_info_index].class_type;
+	int class_num = Ships[ship_num].ship_info_index;
+	int species_num = Ship_info[Ships[ship_num].ship_info_index].species;
+	auto& types = wip->ship_type_restrict;
+	auto& classes = wip->ship_class_restrict;
+	auto& species = wip->ship_species_restrict;
+	// if you didn't specify any restrictions, you can always lock
+	if (types.empty() && classes.empty() && species.empty()) return true;
+	// otherwise, you're good as long as one of the lists is specified and the target's in it
+	return 	(!types.empty() && std::find(types.begin(), types.end(), type_num) != types.end()) ||
+		(!classes.empty() && std::find(classes.begin(), classes.end(), class_num) != classes.end()) ||
+		(!species.empty() && std::find(species.begin(), species.end(), species_num) != species.end());
 }

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -3135,24 +3135,24 @@ void weapon_sort_by_type()
 
 			case WP_LASER:
 				if (Weapon_info[i].wi_flags[Weapon::Info_Flags::Child])
-					child_primaries[num_child_primaries++] = std::move(Weapon_info[i]);
+					child_primaries[num_child_primaries++] = Weapon_info[i];
 				else if (Weapon_info[i].wi_flags[Weapon::Info_Flags::Big_only])
-					big_lasers[num_big_lasers++] = std::move(Weapon_info[i]);
+					big_lasers[num_big_lasers++] = Weapon_info[i];
 				else
-					lasers[num_lasers++] = std::move(Weapon_info[i]);
+					lasers[num_lasers++] = Weapon_info[i];
 				break;
 		
 			case WP_BEAM:
-				beams[num_beams++] = std::move(Weapon_info[i]);
+				beams[num_beams++] = Weapon_info[i];
 				break;
 
 			case WP_MISSILE:
 				if (Weapon_info[i].wi_flags[Weapon::Info_Flags::Child])
-					child_secondaries[num_child_secondaries++] = std::move(Weapon_info[i]);
+					child_secondaries[num_child_secondaries++] = Weapon_info[i];
 				else if (Weapon_info[i].wi_flags[Weapon::Info_Flags::Big_only])
-					big_missiles[num_big_missiles++] = std::move(Weapon_info[i]);
+					big_missiles[num_big_missiles++] = Weapon_info[i];
 				else
-					missiles[num_missiles++] = std::move(Weapon_info[i]);
+					missiles[num_missiles++]=Weapon_info[i];
 				break;
 
 			default:
@@ -3164,28 +3164,28 @@ void weapon_sort_by_type()
 
 	// reorder the weapon_info structure according to our rules defined above
 	for (i = 0; i < num_lasers; i++, weapon_index++)
-		Weapon_info[weapon_index] = std::move(lasers[i]);
+		Weapon_info[weapon_index] = lasers[i];
 
 	for (i = 0; i < num_big_lasers; i++, weapon_index++)
-		Weapon_info[weapon_index] = std::move(big_lasers[i]);
+		Weapon_info[weapon_index] = big_lasers[i];
 
 	for (i = 0; i < num_beams; i++, weapon_index++)
-		Weapon_info[weapon_index] = std::move(beams[i]);
+		Weapon_info[weapon_index] = beams[i];
 
 	for (i = 0; i < num_child_primaries; i++, weapon_index++)
-		Weapon_info[weapon_index] = std::move(child_primaries[i]);
+		Weapon_info[weapon_index] = child_primaries[i];
 
 	// designate start of secondary weapons so that we'll have the correct offset later on
 	First_secondary_index = weapon_index;
 
 	for (i = 0; i < num_missiles; i++, weapon_index++)
-		Weapon_info[weapon_index] = std::move(missiles[i]);
+		Weapon_info[weapon_index] = missiles[i];
 
 	for (i = 0; i < num_big_missiles; i++, weapon_index++)
-		Weapon_info[weapon_index] = std::move(big_missiles[i]);
+		Weapon_info[weapon_index] = big_missiles[i];
 
 	for (i = 0; i < num_child_secondaries; i++, weapon_index++)
-		Weapon_info[weapon_index] = std::move(child_secondaries[i]);
+		Weapon_info[weapon_index] = child_secondaries[i];
 
 
 	if (lasers)			delete [] lasers;
@@ -3689,7 +3689,46 @@ void weapon_level_init()
 
 		if ( Ships_inited ) {
 			// populate ship type lock restrictions
-			Weapon_info[i].multilock.init(Weapon_info[i]);
+			for ( int j = 0; j < (int)Weapon_info[i].ship_type_restrict_temp.size(); ++j ) {
+				const char* name = Weapon_info[i].ship_type_restrict_temp[j].c_str();
+				int idx = ship_type_name_lookup(name);
+
+				if ( idx >= 0 ) {
+					Weapon_info[i].ship_restrict.emplace_back(MultilockRestrictionType::TYPE, idx);
+				}
+				else {
+					Warning(LOCATION, "Couldn't find multi lock restriction type '%s' for weapon '%s'", name, Weapon_info[i].name);
+				}
+			}
+			Weapon_info[i].ship_type_restrict_temp.clear();
+
+			// populate ship class lock restrictions
+			for (int j = 0; j < (int)Weapon_info[i].ship_class_restrict_temp.size(); ++j) {
+				const char* name = Weapon_info[i].ship_class_restrict_temp[j].c_str();
+				int idx = ship_info_lookup(name);
+
+				if (idx >= 0) {
+					Weapon_info[i].ship_restrict.emplace_back(MultilockRestrictionType::CLASS, idx);
+				}
+				else {
+					Warning(LOCATION, "Couldn't find multi lock restriction class '%s' for weapon '%s'", name, Weapon_info[i].name);
+				}
+			}
+			Weapon_info[i].ship_class_restrict_temp.clear();
+
+			// populate ship species lock restrictions
+			for (int j = 0; j < (int)Weapon_info[i].ship_species_restrict_temp.size(); ++j) {
+				const char* name = Weapon_info[i].ship_species_restrict_temp[j].c_str();
+				int idx = species_info_lookup(name);
+
+				if (idx >= 0) {
+					Weapon_info[i].ship_restrict.emplace_back(MultilockRestrictionType::SPECIES, idx);
+				}
+				else {
+					Warning(LOCATION, "Couldn't find multi lock restriction species '%s' for weapon '%s'", name, Weapon_info[i].name);
+				}
+			}
+			Weapon_info[i].ship_species_restrict_temp.clear();
 		}
 	}
 
@@ -7806,7 +7845,7 @@ void weapon_info::reset()
 	
 	this->max_seeking = 1;
 	this->max_seekers_per_target = 1;
-	this->multilock.clear();
+	this->ship_restrict.clear();
 	this->ship_type_restrict_temp.clear();
 	this->ship_class_restrict_temp.clear();
 	this->ship_species_restrict_temp.clear();
@@ -8241,61 +8280,24 @@ int weapon_get_max_missile_seekers(weapon_info *wip)
 	return max_target_locks;
 }
 
-struct vec_filter : public filter {
-	SCP_vector<int> allowed;
-	int (*to_index)(int);
-	vec_filter(int (*_to_index)(int)) : to_index(_to_index) {}
-	bool apply(int ship) {
-		return active() && std::binary_search(allowed.begin(), allowed.end(), to_index(ship));
-	}
-	bool active() {
-		return !allowed.empty();
-	}
-	void clear() {
-		allowed.clear();
-	}
-};
-
-// target filtering functions
-multilock_filter::multilock_filter() : filters{
-	std::unique_ptr<vec_filter>(new vec_filter([](int ship_num) { return Ship_info[Ships[ship_num].ship_info_index].class_type; })),
-	std::unique_ptr<vec_filter>(new vec_filter([](int ship_num) { return Ships[ship_num].ship_info_index; })),
-	std::unique_ptr<vec_filter>(new vec_filter([](int ship_num) { return Ship_info[Ships[ship_num].ship_info_index].species; }))
-} {}
-
-// initializing functions
-void multilock_filter::init(weapon_info& wip) {
-	init_vec_filter(wip, filters[0], wip.ship_type_restrict_temp, &ship_type_name_lookup);
-	init_vec_filter(wip, filters[1], wip.ship_class_restrict_temp, &ship_info_lookup);
-	init_vec_filter(wip, filters[2], wip.ship_species_restrict_temp, &species_info_lookup);
-}
-
-void multilock_filter::clear() {
-	for (auto& f : filters) f.get()->clear();
-}
-
-bool multilock_filter::can_lock_on_ship(int ship_num)
+bool weapon_multilock_can_lock_on_ship(weapon_info* wip, int ship_num)
 {
+	auto& restrictions = wip->ship_restrict;
 	// if you didn't specify any restrictions, you can always lock
-	if (!std::any_of(filters.begin(), filters.end(),
-		[](std::unique_ptr<filter>& f) { return f.get()->active(); })) return true;
-	// otherwise, you're good as long as one of the lists is specified and the target's in it
-	return std::any_of(filters.begin(), filters.end(),
-		[=](std::unique_ptr<filter>& f) { return f.get()->apply(ship_num); });
-}
+	if (restrictions.empty()) return true;
 
-void multilock_filter::init_vec_filter(const weapon_info& wip, std::unique_ptr<filter>& dest, SCP_vector<SCP_string>& strs, int (*fun)(const char*)) {
-	SCP_vector<int>& result = static_cast<vec_filter*>(dest.get())->allowed;
-	for (auto s : strs) {
-		const char* name = s.c_str();
-		int idx = fun(name);
-		if (idx >= 0) {
-			result.push_back(idx);
-		}
-		else {
-			Warning(LOCATION, "Couldn't find multi lock restriction type '%s' for weapon '%s'", name, wip.name);
-		}
-	}
-	strs.clear();
-	std::sort(result.begin(), result.end());
+	int type_num = Ship_info[Ships[ship_num].ship_info_index].class_type;
+	int class_num = Ships[ship_num].ship_info_index;
+	int species_num = Ship_info[Ships[ship_num].ship_info_index].species;
+
+	// otherwise, you're good as long as it matches one of the allowances in the restriction list
+	return std::any_of(restrictions.begin(), restrictions.end(),
+		[=](std::pair<MultilockRestrictionType, int>& restriction) {
+			switch (restriction.first) {
+				case MultilockRestrictionType::TYPE: return restriction.second == type_num;
+				case MultilockRestrictionType::CLASS: return restriction.second == class_num;
+				case MultilockRestrictionType::SPECIES: return restriction.second == species_num;
+				default: return true;
+			}
+		});
 }

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -1450,6 +1450,16 @@ int parse_weapon(int subtype, bool replace, const char *filename)
 				
 			}
 
+				if (optional_string("+Ship Classes:")) {
+				stuff_string_list(wip->ship_class_restrict_temp);
+
+			}
+
+				if (optional_string("+Species:")) {
+				stuff_string_list(wip->ship_species_restrict_temp);
+
+			}
+
 			if (wip->is_locked_homing()) {
 				// locked homing missiles have a much longer lifespan than the AI think they do
 				wip->max_lifetime = wip->lifetime * LOCKED_HOMING_EXTENDED_LIFE_FACTOR; 
@@ -3680,14 +3690,45 @@ void weapon_level_init()
 		if ( Ships_inited ) {
 			// populate ship type lock restrictions
 			for ( int j = 0; j < (int)Weapon_info[i].ship_type_restrict_temp.size(); ++j ) {
-				int idx = ship_type_name_lookup((char*)Weapon_info[i].ship_type_restrict_temp[j].c_str());
+				const char* name = Weapon_info[i].ship_type_restrict_temp[j].c_str();
+				int idx = ship_type_name_lookup(name);
 
 				if ( idx >= 0 ) {
 					Weapon_info[i].ship_type_restrict.push_back(idx);
 				}
+				else {
+					Warning(LOCATION, "Couldn't find multi lock restriction type '%s' for weapon '%s'", name, Weapon_info[i].name);
+				}
 			}
-
 			Weapon_info[i].ship_type_restrict_temp.clear();
+
+			// populate ship class lock restrictions
+			for (int j = 0; j < (int)Weapon_info[i].ship_class_restrict_temp.size(); ++j) {
+				const char* name = Weapon_info[i].ship_class_restrict_temp[j].c_str();
+				int idx = ship_info_lookup(name);
+
+				if (idx >= 0) {
+					Weapon_info[i].ship_class_restrict.push_back(idx);
+				}
+				else {
+					Warning(LOCATION, "Couldn't find multi lock restriction class '%s' for weapon '%s'", name, Weapon_info[i].name);
+				}
+			}
+			Weapon_info[i].ship_class_restrict_temp.clear();
+
+			// populate ship species lock restrictions
+			for (int j = 0; j < (int)Weapon_info[i].ship_species_restrict_temp.size(); ++j) {
+				const char* name = Weapon_info[i].ship_species_restrict_temp[j].c_str();
+				int idx = species_info_lookup(name);
+
+				if (idx >= 0) {
+					Weapon_info[i].ship_species_restrict.push_back(idx);
+				}
+				else {
+					Warning(LOCATION, "Couldn't find multi lock restriction species '%s' for weapon '%s'", name, Weapon_info[i].name);
+				}
+			}
+			Weapon_info[i].ship_species_restrict_temp.clear();
 		}
 	}
 
@@ -7806,6 +7847,10 @@ void weapon_info::reset()
 	this->max_seekers_per_target = 1;
 	this->ship_type_restrict.clear();
 	this->ship_type_restrict_temp.clear();
+	this->ship_class_restrict.clear();
+	this->ship_class_restrict_temp.clear();
+	this->ship_species_restrict.clear();
+	this->ship_species_restrict_temp.clear();
 	
 	this->acquire_method = WLOCK_PIXEL;
 
@@ -8239,7 +8284,29 @@ int weapon_get_max_missile_seekers(weapon_info *wip)
 
 bool weapon_can_lock_on_ship_type(weapon_info *wip, int ship_type)
 {
-	// Determine if there are any restrictions, treating an empty list as true
+	// Determine if there are any type restrictions, treating an empty list as true
 	return (wip->ship_type_restrict.empty()) || 
 			std::any_of(wip->ship_type_restrict.begin(), wip->ship_type_restrict.end(), [ship_type](int type) { return type == ship_type; });
+}
+
+bool weapon_can_lock_on_ship_class(weapon_info* wip, int ship_class)
+{
+	// Determine if there are any class restrictions, treating an empty list as true
+	return (wip->ship_class_restrict.empty()) ||
+		std::any_of(wip->ship_class_restrict.begin(), wip->ship_class_restrict.end(), [ship_class](int restricted_class) { return restricted_class == ship_class; });
+}
+
+bool weapon_can_lock_on_ship_species(weapon_info* wip, int species)
+{
+	// Determine if there are any species restrictions, treating an empty list as true
+	return (wip->ship_species_restrict.empty()) ||
+		std::any_of(wip->ship_species_restrict.begin(), wip->ship_species_restrict.end(), [species](int restricted_species) { return restricted_species == species; });
+}
+
+bool weapon_multilock_can_lock_on_ship(weapon_info* wip, object* ship)
+{
+	int type = ship->ty
+	// Determine if there are any restrictions, treating an empty list as true
+	return (wip->ship_species_restrict.empty()) ||
+		std::any_of(wip->ship_species_restrict.begin(), wip->ship_species_restrict.end(), [species](int restricted_species) { return restricted_species == species; });
 }

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -8258,9 +8258,9 @@ struct vec_filter : public filter {
 
 // target filtering functions
 multilock_filter::multilock_filter() : filters{
-	std::make_unique<vec_filter>([](int ship_num) { return Ship_info[Ships[ship_num].ship_info_index].class_type; }),
-	std::make_unique<vec_filter>([](int ship_num) { return Ships[ship_num].ship_info_index; }),
-	std::make_unique<vec_filter>([](int ship_num) { return Ship_info[Ships[ship_num].ship_info_index].species; })
+	std::unique_ptr<vec_filter>(new vec_filter([](int ship_num) { return Ship_info[Ships[ship_num].ship_info_index].class_type; })),
+	std::unique_ptr<vec_filter>(new vec_filter([](int ship_num) { return Ships[ship_num].ship_info_index; })),
+	std::unique_ptr<vec_filter>(new vec_filter([](int ship_num) { return Ship_info[Ships[ship_num].ship_info_index].species; }))
 } {}
 
 // initializing functions


### PR DESCRIPTION
Pretty much what it says on the tin. A lock is considered valid if it can match into any of the non-empty restriction lists, or if all are empty. Also warnings for invalid names in any of the lists.