### PR TITLE
Enable dllexport for Lua API

### DIFF
--- a/lib/lua/luaconf.h
+++ b/lib/lua/luaconf.h
@@ -161,7 +161,19 @@
 
 #else
 
+#ifdef WIN32
+// Export even when building statically to allow external libraries to load the Lua API symbols
+#if defined(LUA_CORE) || defined(LUA_LIB)
+#define LUA_API __declspec(dllexport)
+#else
+#define LUA_API extern
+#endif
+
+#else
+
 #define LUA_API		extern
+
+#endif
 
 #endif
 


### PR DESCRIPTION
This allows external libraries to load the Lua API from our executable
even if it is linked statically. This is useful for a Lua debugger which
needs to interact with the Lua API.