### PR TITLE
Add generic audio stream API

### DIFF
--- a/code/scripting/api/objs/audio_stream.cpp
+++ b/code/scripting/api/objs/audio_stream.cpp
@@ -1,0 +1,95 @@
+
+#include "audio_stream.h"
+
+#include "sound/audiostr.h"
+
+namespace scripting {
+namespace api {
+
+//**********HANDLE: Asteroid
+ADE_OBJ(l_AudioStream, int, "audio_stream", "An audio stream handle");
+
+ADE_FUNC(play,
+	l_AudioStream,
+	"[number volume = -1.0 /* By default uses preset volume of the stream type */, boolean loop = false]",
+	"Starts playing the audio stream",
+	"boolean",
+	"true on success, false otherwise")
+{
+	int streamHandle = -1;
+	float volume = -1.0f;
+	bool loop = false;
+	if (!ade_get_args(L, "o|fb", l_AudioStream.Get(&streamHandle), &volume, &loop)) {
+		return ADE_RETURN_FALSE;
+	}
+
+	if (streamHandle < 0) {
+		return ade_set_args(L, "b", false);
+	}
+
+	audiostream_play(streamHandle, volume, loop ? 1 : 0);
+	return ade_set_args(L, "b", true);
+}
+
+ADE_FUNC(pause, l_AudioStream, nullptr, "Pauses the audio stream", "boolean", "true on success, false otherwise")
+{
+	int streamHandle = -1;
+	if (!ade_get_args(L, "o", l_AudioStream.Get(&streamHandle))) {
+		return ADE_RETURN_FALSE;
+	}
+
+	if (streamHandle < 0) {
+		return ADE_RETURN_FALSE;
+	}
+
+	audiostream_pause(streamHandle, true);
+	return ade_set_args(L, "b", true);
+}
+
+ADE_FUNC(unpause, l_AudioStream, nullptr, "Unpauses the audio stream", "boolean", "true on success, false otherwise")
+{
+	int streamHandle = -1;
+	if (!ade_get_args(L, "o", l_AudioStream.Get(&streamHandle))) {
+		return ADE_RETURN_FALSE;
+	}
+
+	if (streamHandle < 0) {
+		return ADE_RETURN_FALSE;
+	}
+
+	audiostream_unpause(streamHandle, true);
+	return ade_set_args(L, "b", true);
+}
+
+ADE_FUNC(stop, l_AudioStream, nullptr, "Stops the audio stream", "boolean", "true on success, false otherwise")
+{
+	int streamHandle = -1;
+	if (!ade_get_args(L, "o", l_AudioStream.Get(&streamHandle))) {
+		return ADE_RETURN_FALSE;
+	}
+
+	if (streamHandle < 0) {
+		return ADE_RETURN_FALSE;
+	}
+
+	audiostream_stop(streamHandle);
+	return ade_set_args(L, "b", true);
+}
+
+ADE_FUNC(isValid,
+	l_AudioStream,
+	nullptr,
+	"Determines if the handle is valid",
+	"boolean",
+	"true if valid, false otherwise")
+{
+	int streamHandle = -1;
+	if (!ade_get_args(L, "o", l_AudioStream.Get(&streamHandle))) {
+		return ADE_RETURN_FALSE;
+	}
+
+	return ade_set_args(L, "b", streamHandle >= 0);
+}
+
+} // namespace api
+} // namespace scripting

--- a/code/scripting/api/objs/audio_stream.h
+++ b/code/scripting/api/objs/audio_stream.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include "object/object.h"
+#include "scripting/ade_api.h"
+
+namespace scripting {
+namespace api {
+DECLARE_ADE_OBJ(l_AudioStream, int);
+}
+} // namespace scripting

--- a/code/scripting/api/objs/enums.cpp
+++ b/code/scripting/api/objs/enums.cpp
@@ -485,6 +485,21 @@ flag_def_list Enumerations[] = {
 		LE_OPTION_TYPE_RANGE,
 		0
 	},
+	{
+		"AUDIOSTREAM_EVENTMUSIC",
+		LE_ASF_EVENTMUSIC,
+		0
+	},
+	{
+		"AUDIOSTREAM_MENUMUSIC",
+		LE_ASF_MENUMUSIC,
+		0
+	},
+	{
+		"AUDIOSTREAM_VOICE",
+		LE_ASF_VOICE,
+		0
+	},
 };
 
 //DO NOT FORGET to increment NEXT INDEX: !!!!!!!!!!!!!

--- a/code/scripting/api/objs/enums.h
+++ b/code/scripting/api/objs/enums.h
@@ -89,8 +89,11 @@ const int32_t LE_MESSAGE_PRIORITY_NORMAL     = 72;
 const int32_t LE_MESSAGE_PRIORITY_HIGH       = 73;
 const int32_t LE_OPTION_TYPE_SELECTION       = 78;
 const int32_t LE_OPTION_TYPE_RANGE           = 79;
+const int32_t LE_ASF_EVENTMUSIC              = 80;
+const int32_t LE_ASF_MENUMUSIC               = 81;
+const int32_t LE_ASF_VOICE                   = 82;
 
-const int ENUM_NEXT_INDEX = 80; // <<<<<<<<<<<<<<<<<<<<<<
+const int ENUM_NEXT_INDEX = 83; // <<<<<<<<<<<<<<<<<<<<<<
 extern flag_def_list Enumerations[];
 extern size_t Num_enumerations;
 

--- a/code/source_groups.cmake
+++ b/code/source_groups.cmake
@@ -1135,6 +1135,8 @@ add_file_folder("Scripting\\\\Api\\\\Libs"
 add_file_folder("Scripting\\\\Api\\\\Objs"
 	scripting/api/objs/asteroid.cpp
 	scripting/api/objs/asteroid.h
+	scripting/api/objs/audio_stream.cpp
+	scripting/api/objs/audio_stream.h
 	scripting/api/objs/background_element.cpp
 	scripting/api/objs/background_element.h
 	scripting/api/objs/beam.cpp


### PR DESCRIPTION
The previous API only allowed very limited access to the audio stream
system. These changes add full support for playing all types of audio
streams via a dedicated API.