### PR TITLE
fix crash from multilock merge

### DIFF
--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -6120,9 +6120,9 @@ void ship_weapon::clear()
     num_secondary_banks = 0;
     num_tertiary_banks = 0;
 
-    current_primary_bank = 0;
-    current_secondary_bank = 0;
-    current_tertiary_bank = 0;
+    current_primary_bank = -1;
+    current_secondary_bank = -1;
+    current_tertiary_bank = -1;
 
     previous_primary_bank = 0;
     previous_secondary_bank = 0;


### PR DESCRIPTION
After the multilock PR #2207, ships without secondary weapons will crash the game.  This can easily be seen in the very first training mission of the FS2 main campaign, and it is due to an invalid bank access in `ship_stop_secondary_fire`.  The `current_secondary_bank` is 0, but there are 0 secondary banks.  The Assert catches this, but that's not enough.

This change fixes the crash, as it initializes the current banks to -1 instead of 0.  However I'm not familiar with the new multilock way of doing things so I can't say if that is correct in all cases.