### PR TITLE
Improve vm_orthogonalize_matrix safety

### DIFF
--- a/code/math/vecmat.cpp
+++ b/code/math/vecmat.cpp
@@ -1150,6 +1150,8 @@ void find_point_on_line_nearest_skew_line(vec3d *dest, const vec3d *p1, const ve
 	vm_vec_scale_add(dest, p1, d1, numerator / denominator);
 }
 
+
+// normalizes only if above a small threshold, returns if normalized or not
 bool vm_maybe_normalize(vec3d* dst, const vec3d* src) {
 	float mag = vm_vec_mag(src);
 	if (mag < SMALL_NUM) return false;
@@ -1196,11 +1198,11 @@ void vm_orthogonalize_two_vec(vec3d* dst1, vec3d* dst2, const vec3d* src1, const
 	}
 }
 
-//make sure matrix is orthogonal
-//computes a matrix from one or more vectors. The forward vector is required,
-//with the other two being optional.  If both up & right vectors are passed,
-//the up vector is used.  If only the forward vector is passed, a bank of
-//zero is assumed
+// make sure matrix is orthogonal
+// computes a matrix from one or more vectors. The forward vector is required,
+// with the other two being optional.  If both up & right vectors are passed,
+// the up vector is used.  If only the forward vector is passed, a bank of
+// zero is assumed
 void vm_orthogonalize_matrix(matrix *m_src)
 {
 	vec3d fvec, uvec;

--- a/code/math/vecmat.cpp
+++ b/code/math/vecmat.cpp
@@ -1151,10 +1151,10 @@ void find_point_on_line_nearest_skew_line(vec3d *dest, const vec3d *p1, const ve
 }
 
 
-// normalizes only if above a small threshold, returns if normalized or not
-bool vm_maybe_normalize(vec3d* dst, const vec3d* src) {
+// normalizes only if above a threshold, returns if normalized or not
+bool vm_maybe_normalize(vec3d* dst, const vec3d* src, float threshold) {
 	float mag = vm_vec_mag(src);
-	if (mag < SMALL_NUM) return false;
+	if (mag < threshold) return false;
 	vm_vec_copy_scale(dst, src, 1 / mag);
 	return true;
 }

--- a/code/math/vecmat.cpp
+++ b/code/math/vecmat.cpp
@@ -1163,7 +1163,7 @@ bool vm_maybe_normalize(vec3d* dst, const vec3d* src) {
 // in the direction preference (if not null). If that direction doesn't work it picks the z or y direction,
 // so that an output perpendicular vector is guaranteed.
 void vm_orthogonalize_one_vec(vec3d* dst, const vec3d* unit_normal, const vec3d* preference) {
-	if (preference) {
+	if (preference != nullptr) {
 		vm_vec_projection_onto_plane(dst, preference, unit_normal);
 		if (vm_maybe_normalize(dst, dst)) {
 			// The process of rescaling dst may have exaggerated floating point inaccuracy
@@ -1192,7 +1192,7 @@ void vm_orthogonalize_two_vec(vec3d* dst1, vec3d* dst2, const vec3d* src1, const
 	else if (vm_maybe_normalize(dst2, src2))
 		vm_orthogonalize_one_vec(dst1, dst2, src1);
 	else {
-		if (!preference || !vm_maybe_normalize(dst1, preference))
+		if (preference == nullptr || !vm_maybe_normalize(dst1, preference))
 			vm_vec_make(dst1, 1, 0, 0);
 		vm_orthogonalize_one_vec(dst2, dst1, src2);
 	}

--- a/code/math/vecmat.h
+++ b/code/math/vecmat.h
@@ -377,6 +377,10 @@ int find_intersection(float *s, const vec3d* p0, const vec3d* p1, const vec3d* v
  */
 void find_point_on_line_nearest_skew_line(vec3d *dest, const vec3d *p1, const vec3d *d1, const vec3d *p2, const vec3d *d2);
 
+// normalizes only if the vector's magnitude is above an optionally specified threshold, defaulting to 10 times machine epsilon
+// returns whether or not it normalized
+bool vm_maybe_normalize(vec3d* dst, const vec3d* src, float threshold = std::numeric_limits<int>::epsilon() * 10.f);
+
 float vm_vec_dot_to_point(const vec3d *dir, const vec3d *p1, const vec3d *p2);
 
 void compute_point_on_plane(vec3d *q, const plane *planep, const vec3d *p);

--- a/test/src/math/test_vecmat.cpp
+++ b/test/src/math/test_vecmat.cpp
@@ -688,11 +688,12 @@ TEST_F(VecmatTest, test_vm_vec_copy_normalize)
 }
 
 TEST_F(VecmatTest, orthogonalize_matrix) {
+	// V regression test - old version couldn't handle this V
 	matrix input_matrix = make_matrix(
 		0.636235237f, -0.0492025875f, -0.769924462f,
 		-0.513205945f, -0.419860631f, 0.748556376f,
 		-0.513205945f, -0.419860631f, 0.748556376f);
-	for (int i = 0; i < 10000; i++) {
+	for (int i = 0; i < 1000; i++) {
 		matrix hopefully_orthogonal_matrix = input_matrix;
 		vm_orthogonalize_matrix(&hopefully_orthogonal_matrix);
 


### PR DESCRIPTION
And also add a unit test for it. Currently, orthogonalize is not guaranteed to actually return an orthogonal matrix if two of the vectors are the same, so the logic is tightened up to ensure orthogonal vectors while retaining as much of the original matrix as possible. This _appears_ to obsolete fix_matrix as well, but it seems like it's used by FRED to have different vector preferences.