### PR TITLE
Restoring the free flight speed missile table value to functioning

### DIFF
--- a/code/weapon/weapon.h
+++ b/code/weapon/weapon.h
@@ -277,6 +277,7 @@ struct weapon_info
 	float	acceleration_time;					// how many seconds to reach max speed (secondaries only)
 	float	vel_inherit_amount;					// how much of the parent ship's velocity is inherited (0.0..1.0)
 	float	free_flight_time;
+	float	free_flight_speed;
 	float mass;									// mass of the weapon
 	float fire_wait;							// fire rate -- amount of time before you can refire the weapon
 	float max_delay;							// max time to delay a shot (DahBlount)

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -210,7 +210,7 @@ int		Weapon_impact_timer;			// timer, initialized at start of each mission
 #define HOMING_DEFAULT_FREE_FLIGHT_TIME	0.5f
 
 // default percentage of max speed to coast at during freeflight
-#define HOMING_DEFAULT_FREE_FLIGHT_FACTOR	0.25f
+const float HOMING_DEFAULT_FREE_FLIGHT_FACTOR = 0.25f;
 
 // time delay between each swarm missile that is fired
 #define SWARM_MISSILE_DELAY				150
@@ -1508,13 +1508,12 @@ int parse_weapon(int subtype, bool replace, const char *filename)
 	if(optional_string("$Free Flight Speed:")) {
 		stuff_float(&(wip->free_flight_speed));
 		if (wip->free_flight_speed < 0.01f) {
-			nprintf(("Warning", "Free Flight Speed value is too low for weapon '%s'. Resetting to default (0.25 times maximum)\n", wip->name));
-			wip->free_flight_speed = 0.25f;
+			error_display(0, "Free Flight Speed value is too low for weapon '%s'. Resetting to default (0.25 times maximum)", wip->name);
+			wip->free_flight_speed = HOMING_DEFAULT_FREE_FLIGHT_FACTOR;
 		}
 	}
 	else if (first_time && is_homing) {
 		wip->free_flight_speed = HOMING_DEFAULT_FREE_FLIGHT_FACTOR;
-
 	}
 	//Optional one-shot sound to play at the beginning of firing
 	parse_game_sound("$PreLaunchSnd:", &wip->pre_launch_snd);

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -209,6 +209,9 @@ int		Weapon_impact_timer;			// timer, initialized at start of each mission
 //default time of a homing weapon to not home
 #define HOMING_DEFAULT_FREE_FLIGHT_TIME	0.5f
 
+// default percentage of max speed to coast at during freeflight
+#define HOMING_DEFAULT_FREE_FLIGHT_FACTOR	0.25f
+
 // time delay between each swarm missile that is fired
 #define SWARM_MISSILE_DELAY				150
 
@@ -1503,9 +1506,15 @@ int parse_weapon(int subtype, bool replace, const char *filename)
 	}
 
 	if(optional_string("$Free Flight Speed:")) {
-		float temp;
-		stuff_float(&temp);
-		nprintf(("Warning", "Ignoring free flight speed for weapon '%s'\n", wip->name));
+		stuff_float(&(wip->free_flight_speed));
+		if (wip->free_flight_speed < 0.01f) {
+			nprintf(("Warning", "Free Flight Speed value is too low for weapon '%s'. Resetting to default (0.25 times maximum)\n", wip->name));
+			wip->free_flight_speed = 0.25f;
+		}
+	}
+	else if (first_time && is_homing) {
+		wip->free_flight_speed = HOMING_DEFAULT_FREE_FLIGHT_FACTOR;
+
 	}
 	//Optional one-shot sound to play at the beginning of firing
 	parse_game_sound("$PreLaunchSnd:", &wip->pre_launch_snd);
@@ -4179,8 +4188,8 @@ void weapon_home(object *obj, int num, float frame_time)
 		else if (wip->free_flight_time > 0.0f) {
 			if (obj->phys_info.speed > max_speed) {
 				obj->phys_info.speed -= frame_time * 4;
-			} else if ((obj->phys_info.speed < max_speed / 4) && (wip->wi_flags[Weapon::Info_Flags::Homing_heat])) {
-				obj->phys_info.speed = max_speed / 4;
+			} else if ((obj->phys_info.speed < max_speed * wip->free_flight_speed) && (wip->wi_flags[Weapon::Info_Flags::Homing_heat])) {
+				obj->phys_info.speed = max_speed * wip->free_flight_speed;
 			}
 		}
 		// no free_flight_time, so immediately set desired speed
@@ -5538,18 +5547,18 @@ int weapon_create( vec3d * pos, matrix * porient, int weapon_type, int parent_ob
 		objp->phys_info.vel = objp->phys_info.desired_vel;
 		objp->phys_info.speed = vm_vec_mag(&objp->phys_info.desired_vel);
 	} else {		
-		//	For weapons that home, set velocity to sum of forward component of parent's velocity and 1/4 weapon's max speed.
+		//	For weapons that home, set velocity to sum of forward component of parent's velocity and freeflight speed factor(default 1/4)
 		//	Note that it is important to extract the forward component of the parent's velocity to factor out sliding, else
 		//	the missile will not be moving forward.
 		if(parent_objp != NULL){
 			if (wip->free_flight_time > 0.0)
-				vm_vec_copy_scale(&objp->phys_info.desired_vel, &objp->orient.vec.fvec, vm_vec_dot(&parent_objp->phys_info.vel, &parent_objp->orient.vec.fvec) + objp->phys_info.max_vel.xyz.z/4 );
+				vm_vec_copy_scale(&objp->phys_info.desired_vel, &objp->orient.vec.fvec, vm_vec_dot(&parent_objp->phys_info.vel, &parent_objp->orient.vec.fvec) + objp->phys_info.max_vel.xyz.z * wip->free_flight_speed);
 			else
-				vm_vec_copy_scale(&objp->phys_info.desired_vel, &objp->orient.vec.fvec, objp->phys_info.max_vel.xyz.z );
+				vm_vec_copy_scale(&objp->phys_info.desired_vel, &objp->orient.vec.fvec, objp->phys_info.max_vel.xyz.z*wip->free_flight_speed );
 		} else {
 			if (!is_locked && wip->free_flight_time > 0.0)
             {
-			    vm_vec_copy_scale(&objp->phys_info.desired_vel, &objp->orient.vec.fvec, objp->phys_info.max_vel.xyz.z/4 );
+			    vm_vec_copy_scale(&objp->phys_info.desired_vel, &objp->orient.vec.fvec, objp->phys_info.max_vel.xyz.z* wip->free_flight_speed);
             }
             else
             {
@@ -7762,6 +7771,7 @@ void weapon_info::reset()
 	this->acceleration_time = 0.0f;
 	this->vel_inherit_amount = 1.0f;
 	this->free_flight_time = 0.0f;
+	this->free_flight_speed = 0.25f;
 	this->mass = 1.0f;
 	this->fire_wait = 1.0f;
 	this->max_delay = 0.0f;


### PR DESCRIPTION
The free flight speed value was added to the weapons table for 3.6.14 but never fully implemented, and subsequently the partial implementation was removed. This restores and completes the feature.

A sort of followup to PR #2632

Resolves #2408, at least the heart of it.