### PR TITLE
Several small sound-related enhancements

### DIFF
--- a/code/debris/debris.cpp
+++ b/code/debris/debris.cpp
@@ -243,7 +243,7 @@ void debris_process_post(object * obj, float frame_time)
 		radar_plot_object( obj );
 
 		if ( timestamp_elapsed(db->sound_delay) ) {
-			obj_snd_assign(objnum, GameSounds::DEBRIS, &vmd_zero_vector, 0);
+			obj_snd_assign(objnum, db->ambient_sound, &vmd_zero_vector, 0);
 			db->sound_delay = 0;
 		}
 	} else {
@@ -505,6 +505,7 @@ object *debris_create(object *source_obj, int model_num, int submodel_num, vec3d
 	db->damage_type_idx = shipp->debris_damage_type_idx;
 	db->ship_info_index = shipp->ship_info_index;
 	db->team = shipp->team;
+	db->ambient_sound = sip->debris_ambient_sound;
 	db->fire_timeout = 0;	// if not changed, timestamp_elapsed() will return false
 	db->time_started = Missiontime;
 	db->species = Ship_info[shipp->ship_info_index].species;

--- a/code/debris/debris.h
+++ b/code/debris/debris.h
@@ -14,7 +14,7 @@
 
 #include "globalincs/pstypes.h"
 #include "globalincs/flagset.h"
-
+#include "gamesnd/gamesnd.h"
 
 class object;
 struct CFILE;
@@ -37,6 +37,7 @@ typedef struct debris {
 	int		damage_type_idx;	// Damage type of this debris
 	int		ship_info_index;	// Ship info index of the ship type debris came from
 	int		team;					// Team of the ship where the debris came from
+	gamesnd_id ambient_sound;	// Ambient looping sound
 	int		objnum;				// What object this is linked to
 	float		lifeleft;			// When 0 or less object dies
 	int		must_survive_until;	//WMC - timestamp of earliest point that it can be murthered.

--- a/code/gamesnd/gamesnd.cpp
+++ b/code/gamesnd/gamesnd.cpp
@@ -417,8 +417,9 @@ interface_snd_id gamesnd_get_by_iface_tbl_index(int index)
  * @param flags See the parse_sound_flags enum
  *
  */
-void parse_game_sound(const char* tag, gamesnd_id* idx_dest) {
-	if(optional_string(tag))
+bool parse_game_sound(const char* tag, gamesnd_id* idx_dest)
+{
+	if (optional_string(tag))
 	{
 		SCP_string buf;
 		stuff_string(buf, F_NAME);
@@ -426,10 +427,13 @@ void parse_game_sound(const char* tag, gamesnd_id* idx_dest) {
 		*idx_dest = gamesnd_get_by_name(buf.c_str());
 
 		// The special case "-1" is needed to silence warnings where sounds are intentionally removed
-		if (!idx_dest->isValid() && buf != "-1") {
-			error_display(0, "Could not find game sound with name '%s'!", buf.c_str());
-		}
+		if (idx_dest->isValid() || buf == "-1")
+			return true;
+		
+		error_display(0, "Could not find game sound with name '%s'!", buf.c_str());
 	}
+
+	return false;
 }
 
 /**

--- a/code/gamesnd/gamesnd.h
+++ b/code/gamesnd/gamesnd.h
@@ -368,9 +368,9 @@ interface_snd_id gamesnd_get_by_iface_name(const char* name);
 gamesnd_id gamesnd_get_by_tbl_index(int index);
 interface_snd_id gamesnd_get_by_iface_tbl_index(int index);
 
-//This should handle NO_SOUND just fine since it doesn't directly access lowlevel code
-//Does all parsing for a sound
-void parse_game_sound(const char* tag, gamesnd_id* idx_dest);
+// This should handle NO_SOUND just fine since it doesn't directly access lowlevel code
+// Does all parsing for a sound.  Returns true if a sound was successfully parsed.
+bool parse_game_sound(const char* tag, gamesnd_id* idx_dest);
 
 void parse_iface_sound(const char* tag, interface_snd_id* idx_dest);
 void parse_iface_sound_list(const char* tag, SCP_vector<interface_snd_id>& destination, const char* object_name, bool scp_list = false);

--- a/code/hud/hud.cpp
+++ b/code/hud/hud.cpp
@@ -1875,6 +1875,13 @@ void update_throttle_sound()
 
 	if ( timestamp_elapsed(throttle_sound_check_id) ) {
 
+		auto enginesnd_id = ship_get_sound(Player_obj, GameSounds::ENGINE);
+		if (!enginesnd_id.isValid())
+		{
+			throttle_sound_check_id = timestamp(-1);	// never time out
+			return;
+		}
+
 		throttle_sound_check_id = timestamp(THROTTLE_SOUND_CHECK_INTERVAL);
 	
 		if ( object_get_gliding(Player_obj) ) {	// Backslash
@@ -1895,7 +1902,7 @@ void update_throttle_sound()
 			}
 			else {
 				if (!Player_engine_snd_loop.isValid()) {
-					Player_engine_snd_loop = snd_play_looping( gamesnd_get_game_sound(ship_get_sound(Player_obj, GameSounds::ENGINE)), 0.0f , -1, -1, percent_throttle * ENGINE_MAX_VOL, FALSE);
+					Player_engine_snd_loop = snd_play_looping( gamesnd_get_game_sound(enginesnd_id), 0.0f , -1, -1, percent_throttle * ENGINE_MAX_VOL, FALSE);
 				} else {
 					// The sound may have been trashed at the low-level if sound channel overflow.
 					// TODO: implement system where certain sounds cannot be interrupted (priority?)

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -881,6 +881,7 @@ void ship_info::clone(const ship_info& other)
 	debris_max_hitpoints = other.debris_max_hitpoints;
 	debris_damage_mult = other.debris_damage_mult;
 	debris_arc_percent = other.debris_arc_percent;
+	debris_ambient_sound = other.debris_ambient_sound;
 
 	if ( other.n_subsystems > 0 ) {
 		if( n_subsystems < 1 ) {
@@ -1195,6 +1196,7 @@ void ship_info::move(ship_info&& other)
 	debris_max_hitpoints = other.debris_max_hitpoints;
 	debris_damage_mult = other.debris_damage_mult;
 	debris_arc_percent = other.debris_arc_percent;
+	debris_ambient_sound = other.debris_ambient_sound;
 
 	std::swap(subsystems, other.subsystems);
 	std::swap(n_subsystems, other.n_subsystems);
@@ -1568,6 +1570,7 @@ ship_info::ship_info()
 	debris_max_hitpoints = -1.0f;
 	debris_damage_mult = 1.0f;
 	debris_arc_percent = 0.5f;
+	debris_ambient_sound = GameSounds::DEBRIS;
 
 	n_subsystems = 0;
 	subsystems = NULL;
@@ -1982,9 +1985,7 @@ static void parse_ship_sound(const char *name, GameSounds id, ship_info *sip)
 
 	gamesnd_id temp_index;
 
-	parse_game_sound(name, &temp_index);
-
-	if (temp_index.isValid())
+	if (parse_game_sound(name, &temp_index))
 		sip->ship_sounds.insert(std::make_pair(id, temp_index));
 }
 
@@ -2852,6 +2853,10 @@ static void parse_ship_values(ship_info* sip, const bool is_template, const bool
 			sip->collision_physics.landing_rest_angle = cosf(fl_radians(90.0f - degrees));
 		}
 		parse_game_sound("+Landing Sound:", &sip->collision_physics.landing_sound_idx);
+
+		parse_game_sound("+Collision Sound Light:", &sip->collision_physics.collision_sound_light_idx);
+		parse_game_sound("+Collision Sound Heavy:", &sip->collision_physics.collision_sound_heavy_idx);
+		parse_game_sound("+Collision Sound Shielded:", &sip->collision_physics.collision_sound_shielded_idx);
 	}
 
 
@@ -2915,7 +2920,9 @@ static void parse_ship_values(ship_info* sip, const bool is_template, const bool
 			//Percent is nice for modders, but here in the code we want it betwwen 0 and 1.0
 			sip->debris_arc_percent /= 100.0;
 		}
-		
+		gamesnd_id ambient_snd;
+		if (parse_game_sound("+Ambient Sound:", &ambient_snd))
+			sip->debris_ambient_sound = ambient_snd;
 	}
 	//WMC - sanity checking
 	if(sip->debris_min_speed > sip->debris_max_speed && sip->debris_max_speed >= 0.0f) {

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -1488,6 +1488,9 @@ ship_info::ship_info()
 	collision_physics.rotation_factor = COLLISION_ROTATION_FACTOR;
 	collision_physics.reorient_mult = 1.0f;
 	collision_physics.landing_sound_idx = gamesnd_id();
+	collision_physics.collision_sound_light_idx = gamesnd_id();
+	collision_physics.collision_sound_heavy_idx = gamesnd_id();
+	collision_physics.collision_sound_shielded_idx = gamesnd_id();
 
 	shockwave_create_info_init(&shockwave);
 	explosion_propagates = 0;

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -1095,6 +1095,7 @@ public:
 	float			debris_max_hitpoints;
 	float			debris_damage_mult;
 	float			debris_arc_percent;
+	gamesnd_id		debris_ambient_sound;
 
 	// subsystem information
 	int		n_subsystems;						// this number comes from ships.tbl

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -988,6 +988,11 @@ typedef struct ship_collision_physics {
 	float reorient_mult{};		// How quickly the ship will reorient towards it's resting position
 	float landing_rest_angle{};	// The vertical angle where the ship's orientation comes to rest
 	gamesnd_id landing_sound_idx;		//Sound to play on successful landing collisions
+	
+	// Collision sounds
+	gamesnd_id collision_sound_light_idx;
+	gamesnd_id collision_sound_heavy_idx;
+	gamesnd_id collision_sound_shielded_idx;
 
 } ship_collision_physics;
 


### PR DESCRIPTION
1) Add debris ambient sounds, specified on a per-class basis
2) Allow -1 to be recognized by `parse_game_sound` (when specifying no-sound for something)
3) Make `CockpitEngineSnd` work for no sounds
4) Add the ability to specify collision sounds