### PR TITLE
Capture Ade skip arguments locally

### DIFF
--- a/code/scripting/api/LuaCoroutineRunner.cpp
+++ b/code/scripting/api/LuaCoroutineRunner.cpp
@@ -108,14 +108,11 @@ class run_resolve_context : public resolve_context, public std::enable_shared_fr
 		internal::Ade_get_args_lfunction = true;
 		LuaPromise* promise              = nullptr;
 		if (!ade_get_args(_coroutine.getLuaState(), "o", l_Promise.GetPtr(&promise))) {
-			internal::Ade_get_args_skip = 0;
 			LuaError(_coroutine.getLuaState(),
 				"Failed to get promise after coroutine yielded. Make sure you only use async.await in async "
 				"coroutines.");
 			return;
 		}
-		internal::Ade_get_args_lfunction = false;
-		internal::Ade_get_args_skip      = 0;
 
 		lua_settop(_coroutine.getLuaState(), promiseStackStart);
 

--- a/code/scripting/scripting.h
+++ b/code/scripting/scripting.h
@@ -334,8 +334,6 @@ bool script_state::EvalStringWithReturn(const char* string, const char* format, 
 				scripting::internal::Ade_get_args_skip      = stack_start;
 				scripting::internal::Ade_get_args_lfunction = true;
 				scripting::ade_get_args(LuaState, format, rtn);
-				scripting::internal::Ade_get_args_skip      = 0;
-				scripting::internal::Ade_get_args_lfunction = false;
 			}
 		} catch (const LuaException&) {
 			return false;
@@ -373,8 +371,6 @@ int script_state::RunBytecode(script_function& hd, char format, T* data)
 			scripting::internal::Ade_get_args_skip      = stack_start;
 			scripting::internal::Ade_get_args_lfunction = true;
 			scripting::ade_get_args(LuaState, fmt, data);
-			scripting::internal::Ade_get_args_skip      = 0;
-			scripting::internal::Ade_get_args_lfunction = false;
 		}
 	} catch (const LuaException&) {
 		return 0;


### PR DESCRIPTION
These variables can be used for changing the behavior of the ade_ API
functions. However, they apply to all the ade_get calls so if there is a
call to ade_get_args from an ade_get_args call then it will reuse the
previously set values and produce incorrect results.

This captures those variables as soon as possible and then resets them
so that subsequent calls start with the default values for those
variables.