### PR TITLE
Banish the Black Void

### DIFF
--- a/code/math/vecmat.cpp
+++ b/code/math/vecmat.cpp
@@ -2274,14 +2274,14 @@ void vm_estimate_next_orientation(const matrix *last_orient, const matrix *curre
 }
 
 //	Return true if all elements of *vec are legal, that is, not NaN or infinity.
-int is_valid_vec(const vec3d *vec)
+bool is_valid_vec(const vec3d *vec)
 {
 	return !std::isnan(vec->xyz.x) && !std::isnan(vec->xyz.y) && !std::isnan(vec->xyz.z)
 		&& !std::isinf(vec->xyz.x) && !std::isinf(vec->xyz.y) && !std::isinf(vec->xyz.z);
 }
 
 //	Return true if all elements of *m are legal, that is, not a NAN.
-int is_valid_matrix(const matrix *m)
+bool is_valid_matrix(const matrix *m)
 {
 	return is_valid_vec(&m->vec.fvec) && is_valid_vec(&m->vec.uvec) && is_valid_vec(&m->vec.rvec);
 }

--- a/code/math/vecmat.cpp
+++ b/code/math/vecmat.cpp
@@ -2509,20 +2509,21 @@ void vm_matrix_sub2(matrix* dest, const matrix* src)
 */
 bool vm_inverse_matrix(matrix* dest, const matrix* m)
 {
-	matrix inv;	// create a temp matrix so we can avoid getting a determinant that is 0
+	// Use doubles here because this is used for ship inv_mois and we could be dealing with extremely small numbers
+	double inv[3][3];	// create a temp matrix so we can avoid getting a determinant that is 0
 
 	// Use a2d so it's easier for people to read
-	inv.a2d[0][0] = -m->a2d[1][2] * m->a2d[2][1] + m->a2d[1][1] * m->a2d[2][2];
-	inv.a2d[0][1] = m->a2d[0][2] * m->a2d[2][1] - m->a2d[0][1] * m->a2d[2][2];
-	inv.a2d[0][2] = -m->a2d[0][2] * m->a2d[1][1] + m->a2d[0][1] * m->a2d[1][2];
-	inv.a2d[1][0] = m->a2d[1][2] * m->a2d[2][0] - m->a2d[1][0] * m->a2d[2][2];
-	inv.a2d[1][1] = -m->a2d[0][2] * m->a2d[2][0] + m->a2d[0][0] * m->a2d[2][2];
-	inv.a2d[1][2] = m->a2d[0][2] * m->a2d[1][0] - m->a2d[0][0] * m->a2d[1][2];
-	inv.a2d[2][0] = -m->a2d[1][1] * m->a2d[2][0] + m->a2d[1][0] * m->a2d[2][1];
-	inv.a2d[2][1] = m->a2d[0][1] * m->a2d[2][0] - m->a2d[0][0] * m->a2d[2][1];
-	inv.a2d[2][2] = -m->a2d[0][1] * m->a2d[1][0] + m->a2d[0][0] * m->a2d[1][1];
+	inv[0][0] = -(double)m->a2d[1][2] * m->a2d[2][1] + (double)m->a2d[1][1] * m->a2d[2][2];
+	inv[0][1] = (double)m->a2d[0][2] * m->a2d[2][1] - (double)m->a2d[0][1] * m->a2d[2][2];
+	inv[0][2] = -(double)m->a2d[0][2] * m->a2d[1][1] + (double)m->a2d[0][1] * m->a2d[1][2];
+	inv[1][0] = (double)m->a2d[1][2] * m->a2d[2][0] - (double)m->a2d[1][0] * m->a2d[2][2];
+	inv[1][1] = -(double)m->a2d[0][2] * m->a2d[2][0] + (double)m->a2d[0][0] * m->a2d[2][2];
+	inv[1][2] = (double)m->a2d[0][2] * m->a2d[1][0] - (double)m->a2d[0][0] * m->a2d[1][2];
+	inv[2][0] = -(double)m->a2d[1][1] * m->a2d[2][0] + (double)m->a2d[1][0] * m->a2d[2][1];
+	inv[2][1] = (double)m->a2d[0][1] * m->a2d[2][0] - (double)m->a2d[0][0] * m->a2d[2][1];
+	inv[2][2] = -(double)m->a2d[0][1] * m->a2d[1][0] + (double)m->a2d[0][0] * m->a2d[1][1];
 
-	float det = m->a2d[0][0] * inv.a2d[0][0] + m->a2d[0][1] * inv.a2d[1][0] + m->a2d[0][2] * inv.a2d[2][0];
+	double det = m->a2d[0][0] * inv[0][0] + m->a2d[0][1] * inv[1][0] + m->a2d[0][2] * inv[2][0];
 	if (det == 0) {
 		*dest = vmd_zero_matrix;
 		return false;
@@ -2530,8 +2531,10 @@ bool vm_inverse_matrix(matrix* dest, const matrix* m)
 
 	det = 1.0f / det;
 
-	for (int i = 0; i < 9; i++) {
-		dest->a1d[i] = inv.a1d[i] * det;
+	for (int i = 0; i < 3; i++) {
+		for (int j = 0; j < 3; j++) {
+			dest->a2d[i][j] = (float)(inv[i][j] * det);
+		}
 	}
 
 	return true;

--- a/code/math/vecmat.cpp
+++ b/code/math/vecmat.cpp
@@ -2513,17 +2513,17 @@ bool vm_inverse_matrix(matrix* dest, const matrix* m)
 	double inv[3][3];	// create a temp matrix so we can avoid getting a determinant that is 0
 
 	// Use a2d so it's easier for people to read
-	inv[0][0] = -(double)m->a2d[1][2] * m->a2d[2][1] + (double)m->a2d[1][1] * m->a2d[2][2];
-	inv[0][1] = (double)m->a2d[0][2] * m->a2d[2][1] - (double)m->a2d[0][1] * m->a2d[2][2];
-	inv[0][2] = -(double)m->a2d[0][2] * m->a2d[1][1] + (double)m->a2d[0][1] * m->a2d[1][2];
-	inv[1][0] = (double)m->a2d[1][2] * m->a2d[2][0] - (double)m->a2d[1][0] * m->a2d[2][2];
-	inv[1][1] = -(double)m->a2d[0][2] * m->a2d[2][0] + (double)m->a2d[0][0] * m->a2d[2][2];
-	inv[1][2] = (double)m->a2d[0][2] * m->a2d[1][0] - (double)m->a2d[0][0] * m->a2d[1][2];
-	inv[2][0] = -(double)m->a2d[1][1] * m->a2d[2][0] + (double)m->a2d[1][0] * m->a2d[2][1];
-	inv[2][1] = (double)m->a2d[0][1] * m->a2d[2][0] - (double)m->a2d[0][0] * m->a2d[2][1];
-	inv[2][2] = -(double)m->a2d[0][1] * m->a2d[1][0] + (double)m->a2d[0][0] * m->a2d[1][1];
+	inv[0][0] = -(double)m->a2d[1][2] * (double)m->a2d[2][1] + (double)m->a2d[1][1] * (double)m->a2d[2][2];
+	inv[0][1] = (double)m->a2d[0][2] * (double)m->a2d[2][1] - (double)m->a2d[0][1] * (double)m->a2d[2][2];
+	inv[0][2] = -(double)m->a2d[0][2] * (double)m->a2d[1][1] + (double)m->a2d[0][1] * (double)m->a2d[1][2];
+	inv[1][0] = (double)m->a2d[1][2] * (double)m->a2d[2][0] - (double)m->a2d[1][0] * (double)m->a2d[2][2];
+	inv[1][1] = -(double)m->a2d[0][2] * (double)m->a2d[2][0] + (double)m->a2d[0][0] * (double)m->a2d[2][2];
+	inv[1][2] = (double)m->a2d[0][2] * (double)m->a2d[1][0] - (double)m->a2d[0][0] * (double)m->a2d[1][2];
+	inv[2][0] = -(double)m->a2d[1][1] * (double)m->a2d[2][0] + (double)m->a2d[1][0] * (double)m->a2d[2][1];
+	inv[2][1] = (double)m->a2d[0][1] * (double)m->a2d[2][0] - (double)m->a2d[0][0] * (double)m->a2d[2][1];
+	inv[2][2] = -(double)m->a2d[0][1] * (double)m->a2d[1][0] + (double)m->a2d[0][0] * (double)m->a2d[1][1];
 
-	double det = m->a2d[0][0] * inv[0][0] + m->a2d[0][1] * inv[1][0] + m->a2d[0][2] * inv[2][0];
+	double det = (double)m->a2d[0][0] * inv[0][0] + (double)m->a2d[0][1] * inv[1][0] + (double)m->a2d[0][2] * inv[2][0];
 	if (det == 0) {
 		*dest = vmd_zero_matrix;
 		return false;

--- a/code/math/vecmat.h
+++ b/code/math/vecmat.h
@@ -453,10 +453,10 @@ vec3d* vm_rotate_vec_to_world(vec3d *world_vec, const vec3d *body_vec, const mat
 void vm_estimate_next_orientation(const matrix *last_orient, const matrix *current_orient, matrix *next_orient);
 
 //	Return true if all elements of *vec are legal, that is, not a NAN.
-int is_valid_vec(const vec3d *vec);
+bool is_valid_vec(const vec3d *vec);
 
 //	Return true if all elements of *m are legal, that is, not a NAN.
-int is_valid_matrix(const matrix *m);
+bool is_valid_matrix(const matrix *m);
 
 // Finds the rotation matrix corresponding to a rotation of theta about axis u
 void vm_quaternion_rotate(matrix *m, float theta, const vec3d *u);

--- a/code/object/objectdock.cpp
+++ b/code/object/objectdock.cpp
@@ -357,7 +357,7 @@ bool dock_calc_total_moi(matrix* dest, object* objp, vec3d *center)
 
 	dock_evaluate_all_docked_objects(objp, &dfi, dock_calc_total_moi_helper);
 
-	return is_valid_matrix(dest) != 0;
+	return is_valid_matrix(dest);
 }
 
 // This ship is the only ship NOT moved by docking AI to keep everyone together

--- a/code/object/objectdock.cpp
+++ b/code/object/objectdock.cpp
@@ -343,6 +343,7 @@ float dock_calc_docked_speed(object *objp)
 //		dest		=>		output matrix
 //		objp		=>		one of the objects in the assembly
 //		center 		=>		center of mass of the assembly in world coords ( use dock_calc_docked_center_of_mass to find it )
+// NOTE: THIS FUNCTION MAY RETURN NAN, to indicate that it's inverse MOI would be zero
 void dock_calc_total_moi(matrix* dest, object* objp, vec3d *center)
 {
 	Assertion((dest != nullptr) && (objp != nullptr) && (center != nullptr), "dock_calc_total_moi invalid argument(s)");
@@ -399,7 +400,14 @@ void dock_calculate_and_apply_whack_docked_object(vec3d* impulse, const vec3d* w
 	matrix moi, inv_moi;
 	// calculate the effective inverse MOI for the docked composite object about its center of mass
 	dock_calc_total_moi(&moi, objp, &world_center_of_mass);
-	vm_inverse_matrix(&inv_moi, &moi);
+
+	// Just in case anything funky happened (usually due to some of the input matrices being non-invertable or too close to it)
+	if (is_valid_matrix(&moi)) {
+		vm_inverse_matrix(&inv_moi, &moi);
+	}
+	else { 
+		inv_moi = vmd_zero_matrix;
+	}
 
 	// calculate the angular_impulse about the center of mass in world coords
 	vec3d angular_impulse;
@@ -836,7 +844,11 @@ void dock_calc_total_moi_helper(object* objp, dock_function_info* infop)
 	// So for each part:
 
 	// We invert the inverse MOI to get an MOI in the local frame
-	vm_inverse_matrix(&local_moi, &objp->phys_info.I_body_inv);
+	if (!vm_inverse_matrix(&local_moi, &objp->phys_info.I_body_inv)) {
+		// This is done on purpose to indicate a zero inv_moi
+		infop->maintained_variables.matrix_value->a1d[0] = NAN;
+		return;
+	}
 
 	// We calculate the inverse of the orientation matrix (which is also the transpose)
 	vm_copy_transpose(&unorient, &objp->orient);

--- a/code/object/objectdock.cpp
+++ b/code/object/objectdock.cpp
@@ -344,6 +344,7 @@ float dock_calc_docked_speed(object *objp)
 //		objp		=>		one of the objects in the assembly
 //		center 		=>		center of mass of the assembly in world coords ( use dock_calc_docked_center_of_mass to find it )
 // Returns whether or not was successful (in case some or all of the matrices were uninvertable or too close to it)
+// If not successful, dest will have NaN or infinity, use at your own risk!
 bool dock_calc_total_moi(matrix* dest, object* objp, vec3d *center)
 {
 	Assertion((dest != nullptr) && (objp != nullptr) && (center != nullptr), "dock_calc_total_moi invalid argument(s)");

--- a/code/object/objectdock.cpp
+++ b/code/object/objectdock.cpp
@@ -357,7 +357,7 @@ bool dock_calc_total_moi(matrix* dest, object* objp, vec3d *center)
 
 	dock_evaluate_all_docked_objects(objp, &dfi, dock_calc_total_moi_helper);
 
-	return is_valid_matrix(dest);
+	return is_valid_matrix(dest) != 0;
 }
 
 // This ship is the only ship NOT moved by docking AI to keep everyone together

--- a/code/weapon/beam.cpp
+++ b/code/weapon/beam.cpp
@@ -789,7 +789,7 @@ void beam_type_b_move(beam *b)
 
 	// now recalculate shot_point to be shooting through our new point
 	vm_vec_scale_add(&b->last_shot, &b->last_start, &actual_dir, b->range);
-	int is_valid = is_valid_vec(&b->last_shot);
+	bool is_valid = is_valid_vec(&b->last_shot);
 	Assert(is_valid);
 	if(!is_valid){
 		actual_dir = b->binfo.dir_a;


### PR DESCRIPTION
Since the whacking for docked ships code now needs to invert ships inv_moi's where never before this was needed, the numbers produced could end up much too small for floating points and get inverted into infinity and it all goes bad from there. This turns inverse_matrix's calculations into doubles to handle the entire range of floats (the determinant ends up with cubes of the original inv_moi, limiting its accuracy and range significantly when constrained to a float). Any ship with moi values smaller than 1.4323644 × 10^-13 were affected.

This also provides special cases to handle zero (or any other non-invertable) MOIs properly as well, if it is attempted to invert.