### PR TITLE
clean up fireball filename init

### DIFF
--- a/code/fireball/fireballs.cpp
+++ b/code/fireball/fireballs.cpp
@@ -385,10 +385,15 @@ void fireball_parse_tbl()
 	parse_modular_table(NOX("*-fbl.tbm"), parse_fireball_tbl);
 
 	// fill in extra LOD filenames
-	for (int i = 0; i < Num_fireball_types; i++)
+	for (auto &fi: Fireball_info)
 	{
-		for (int j = 1; j < Fireball_info[i].lod_count; j++)
-			sprintf( Fireball_info[i].lod[j].filename, "%s_%d", Fireball_info[i].lod[0].filename, j);
+		if (fi.lod_count > 1)
+		{
+			auto lod0 = fi.lod[0].filename;
+
+			for (int j = 1; j < fi.lod_count; ++j)
+				sprintf(fi.lod[j].filename, "%s_%d", lod0, j);
+		}
 	}
 
 	fireballs_parsed = true;


### PR DESCRIPTION
GCC 10.1.0 complained about the filename overwriting itself in the old version of the code.  This was a false positive, but the code wasn't terribly clear, so I cleaned it up a bit.