### PR TITLE
Fix various issues of an unbalanced Lua stack

### DIFF
--- a/code/scripting/ade.cpp
+++ b/code/scripting/ade.cpp
@@ -332,10 +332,8 @@ int ade_table_entry::SetTable(lua_State* L, int p_amt_ldx, int p_mtb_ldx)
 		}
 
 		if (data_ldx != INT_MAX) {
-			//WMC - Cannot delete libs and stuff off here.
-			if (p_amt_ldx != LUA_GLOBALSINDEX) {
-				cleanup_items++;
-			}
+			// Remove data once we are done
+			cleanup_items++;
 
 			//WMC - Handle virtual variables by getting their table
 			if (Type == 'v') {

--- a/code/scripting/scripting.h
+++ b/code/scripting/scripting.h
@@ -371,6 +371,9 @@ int script_state::RunBytecode(script_function& hd, char format, T* data)
 			scripting::internal::Ade_get_args_skip      = stack_start;
 			scripting::internal::Ade_get_args_lfunction = true;
 			scripting::ade_get_args(LuaState, fmt, data);
+
+			// Reset stack again
+			lua_settop(LuaState, stack_start);
 		}
 	} catch (const LuaException&) {
 		return 0;


### PR DESCRIPTION
This fixes three issues where the Lua stack was not cleaned up properly:
- On hook execution, the return value was left on the stack
- For ADE initialization, the global tables were left on the stack
- In libRocket, a metatable was left on the stack