### PR TITLE
Debris enhancements

### DIFF
--- a/code/debris/debris.h
+++ b/code/debris/debris.h
@@ -31,39 +31,40 @@ FLAG_LIST(Debris_Flags) {
 
 
 typedef struct debris {
-	debris	*next, *prev;		 // used for a linked list of the hull debris chunks
-	flagset<Debris_Flags> flags; // See DEBRIS_??? defines
-	int		source_objnum;		// What object this came from
-	int		damage_type_idx;	// Damage type of this debris
-	int		ship_info_index;	// Ship info index of the ship type debris came from
+	// used for a linked list of the hull debris chunks
+	debris	*next = nullptr;
+	debris *prev = nullptr;
+
+	flagset<Debris_Flags> flags;	// See DEBRIS_??? defines
+	int		source_objnum;			// What object this came from
+	int		damage_type_idx;		// Damage type of this debris
+	int		ship_info_index;		// Ship info index of the ship type debris came from
 	int		team;					// Team of the ship where the debris came from
-	gamesnd_id ambient_sound;	// Ambient looping sound
-	int		objnum;				// What object this is linked to
+	gamesnd_id ambient_sound;		// Ambient looping sound
+	int		objnum = -1;			// What object this is linked to
 	float		lifeleft;			// When 0 or less object dies
-	int		must_survive_until;	//WMC - timestamp of earliest point that it can be murthered.
-	int		model_num;			// What model this uses
-	int		submodel_num;		// What submodel this uses
-	int		next_fireball;		// When to start a fireball
+	int		must_survive_until;		//WMC - timestamp of earliest point that it can be murthered.
+	int		model_num;				// What model this uses
+	int		submodel_num;			// What submodel this uses
+	int		next_fireball;			// When to start a fireball
 	int		is_hull;				// indicates a large hull chunk of debris
 	int		species;				// What species this is from.  -1 if don't care.
-	int		fire_timeout;		// timestamp that holds time for fireballs to stop appearing
-	int		sound_delay;		// timestamp to signal when sound should start
-	fix		time_started;		// time when debris was created
+	int		fire_timeout;			// timestamp that holds time for fireballs to stop appearing
+	int		sound_delay;			// timestamp to signal when sound should start
+	fix		time_started;			// time when debris was created
 	int		next_distance_check;	//	timestamp to determine whether to delete this piece of debris.
 
-	vec3d	arc_pts[MAX_DEBRIS_ARCS][2];		// The endpoints of each arc
+	vec3d	arc_pts[MAX_DEBRIS_ARCS][2];	// The endpoints of each arc
 	int		arc_timestamp[MAX_DEBRIS_ARCS];	// When this times out, the spark goes away.  -1 is not used
-	int		arc_frequency;							// Starts at 0, gets bigger
+	int		arc_frequency;					// Starts at 1000, gets bigger
 	int		parent_alt_name;
 	float	damage_mult;
-	
+
+	// flags and objnum are the only things that are cleared when debris is deleted, so they are the only values initialized here (plus next and prev)
 } debris;
 
-#define	MAX_DEBRIS_PIECES	64
-
-extern	debris Debris[MAX_DEBRIS_PIECES];
-
-extern int Num_debris_pieces;
+#define	SOFT_LIMIT_DEBRIS_PIECES	64
+extern	SCP_vector<debris> Debris;
 
 struct collision_info_struct;
 
@@ -75,6 +76,11 @@ object *debris_create( object * source_obj, int model_num, int submodel_num, vec
 int debris_check_collision( object * obj, object * other_obj, vec3d * hitpos, collision_info_struct *debris_hit_info=NULL, vec3d* hitnormal = NULL );
 void debris_hit( object * debris_obj, object * other_obj, vec3d * hitpos, float damage );
 int debris_get_team(object *objp);
+
+void debris_add_to_hull_list(debris *db);
 void debris_remove_from_hull_list(debris *db);
+
+bool debris_is_generic(debris *db);
+bool debris_is_vaporized(debris *db);
 
 #endif // _DEBRIS_H

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -3521,7 +3521,6 @@ void mission_parse_maybe_create_parse_object(p_object *pobjp)
 			// FreeSpace
 			if (!Fred_running)
 			{
-				int i;
 				shipfx_blow_up_model(objp, Ship_info[Ships[objp->instance].ship_info_index].model_num, 0, 0, &objp->pos);
 				objp->flags.set(Object::Object_Flags::Should_be_dead);
 
@@ -3531,22 +3530,19 @@ void mission_parse_maybe_create_parse_object(p_object *pobjp)
 
 				// once the ship is exploded, find the debris pieces belonging to this object, mark them
 				// as not to expire, and move them forward in time N seconds
-				for (i = 0; i < MAX_DEBRIS_PIECES; i++)
+				for (auto &db: Debris)
 				{
-					debris *db;
-
-					db = &Debris[i];
-					if (!(db->flags[Debris_Flags::Used]))		// not used, move onto the next one.
+					if (!(db.flags[Debris_Flags::Used]))		// not used, move onto the next one.
 						continue;
-					if (db->source_objnum != real_objnum)		// not from this ship, move to next one
+					if (db.source_objnum != real_objnum)		// not from this ship, move to next one
 						continue;
 					
-					debris_remove_from_hull_list(db);
-					db->flags.set(Debris_Flags::DoNotExpire);   // mark as don't expire
-					db->lifeleft = -1.0f;						// be sure that lifeleft == -1.0 so that it really doesn't expire!
+					debris_remove_from_hull_list(&db);
+					db.flags.set(Debris_Flags::DoNotExpire);   // mark as don't expire
+					db.lifeleft = -1.0f;						// be sure that lifeleft == -1.0 so that it really doesn't expire!
 
 					// now move the debris along its path for N seconds
-					objp = &Objects[db->objnum];
+					objp = &Objects[db.objnum];
 					physics_sim(&objp->pos, &objp->orient, &objp->phys_info, (float) pobjp->destroy_before_mission_time);
 				}
 			}

--- a/code/scripting/api/libs/mission.cpp
+++ b/code/scripting/api/libs/mission.cpp
@@ -172,8 +172,10 @@ ADE_INDEXER(l_Mission_Debris, "number Index", "Array of debris in the current mi
 	if( !ade_get_args( L, "*i", &idx ) ) {
 		return ade_set_error(L, "o", l_Debris.Set(object_h()));
 	}
-	if( idx > -1 && idx < Num_debris_pieces ) {
-		idx--; // Lua -> C
+
+	idx--; // Lua -> C
+
+	if( idx >= 0 && idx < (int)Debris.size() ) {
 		if (Debris[idx].objnum == -1) //Somehow accessed an invalid debris piece
 			return ade_set_error(L, "o", l_Debris.Set(object_h()));
 		return ade_set_args(L, "o", l_Debris.Set(object_h(&Objects[Debris[idx].objnum])));
@@ -188,7 +190,7 @@ ADE_FUNC(__len, l_Mission_Debris, NULL,
 		 "number",
 		 "Current number of debris particles")
 {
-	return ade_set_args(L, "i", Num_debris_pieces);
+	return ade_set_args(L, "i", (int)Debris.size());
 }
 
 //****SUBLIBRARY: Mission/EscortShips

--- a/code/scripting/api/objs/debris.cpp
+++ b/code/scripting/api/objs/debris.cpp
@@ -8,9 +8,6 @@
 #include "globalincs/linklist.h"
 #include "ship/ship.h"
 
-extern int Num_hull_pieces;
-extern debris Hull_debris_list;
-
 namespace scripting {
 namespace api {
 
@@ -79,16 +76,10 @@ ADE_VIRTVAR(DoNotExpire, l_Debris, "boolean", "Whether the debris should expire.
 		// per comments in debris.cpp: "pieces that ... have the DoNotExpire flag should not be on it"
 		if (db->is_hull)
 		{
-			if (set && db->next)
-			{
-				list_remove(&Hull_debris_list, db);
-				Num_hull_pieces--;
-			}
-			else if (!set && !db->next)
-			{
-				list_append(&Hull_debris_list, db);
-				Num_hull_pieces++;
-			}
+			if (set)
+				debris_remove_from_hull_list(db);
+			else
+				debris_add_to_hull_list(db);
 		}
 	}
 
@@ -146,6 +137,34 @@ ADE_FUNC(isValid, l_Debris, NULL, "Return if this debris handle is valid", "bool
 		return ADE_RETURN_FALSE;
 
 	return ade_set_args(L, "b", oh != NULL && oh->IsValid());
+}
+
+ADE_FUNC(isGeneric, l_Debris, nullptr, "Return if this debris is the generic debris model, not a model subobject", "boolean", "true if Debris_model")
+{
+	object_h *oh;
+	if (!ade_get_args(L, "o", l_Debris.GetPtr(&oh)))
+		return ADE_RETURN_FALSE;
+
+	if (!oh->IsValid())
+		return ADE_RETURN_FALSE;
+
+	debris *db = &Debris[oh->objp->instance];
+
+	return ade_set_args(L, "b", debris_is_generic(db));
+}
+
+ADE_FUNC(isVaporized, l_Debris, nullptr, "Return if this debris is the vaporized debris model, not a model subobject", "boolean", "true if Debris_vaporize_model")
+{
+	object_h *oh;
+	if (!ade_get_args(L, "o", l_Debris.GetPtr(&oh)))
+		return ADE_RETURN_FALSE;
+
+	if (!oh->IsValid())
+		return ADE_RETURN_FALSE;
+
+	debris *db = &Debris[oh->objp->instance];
+
+	return ade_set_args(L, "b", debris_is_vaporized(db));
 }
 
 

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -2017,8 +2017,9 @@ static void parse_ship_sounds(ship_info *sip)
 	parse_ship_sound("$MissileEvadedSnd:",                GameSounds::MISSILE_EVADED_POPUP, sip);
 	parse_ship_sound("$CargoScanningSnd:",                GameSounds::CARGO_SCAN, sip);
 
-	// Use SND_SHIP_EXPLODE_1 for custom explosion sounds
+	parse_ship_sound("$DeathRollSnd:",                    GameSounds::DEATH_ROLL, sip);
 	parse_ship_sound("$ExplosionSnd:",                    GameSounds::SHIP_EXPLODE_1, sip);
+	parse_ship_sound("$SubsysExplosionSnd:",              GameSounds::SUBSYS_EXPLODE, sip);
 } 
 
 static void parse_ship_particle_effect(ship_info* sip, particle_effect* pe, const char *id_string)

--- a/code/ship/shipfx.cpp
+++ b/code/ship/shipfx.cpp
@@ -786,21 +786,18 @@ bool shipfx_eye_in_shadow( vec3d *eye_pos, object * src_obj, int sun_n )
 	}
 
 	// Check all the big hull debris pieces.
-	debris	*db = Debris;
-
-	int i;
-	for ( i = 0; i < MAX_DEBRIS_PIECES; i++, db++ )	{
-		if ( !(db->flags[Debris_Flags::Used]) || !db->is_hull ){
+	for (auto &db: Debris)	{
+		if ( !(db.flags[Debris_Flags::Used]) || !db.is_hull ){
 			continue;
 		}
 
-		objp = &Objects[db->objnum];
+		objp = &Objects[db.objnum];
 
 		vm_vec_scale_add( &rp1, &rp0, &light_dir, objp->radius*10.0f );
 
 		mc.model_instance_num = -1;
-		mc.model_num = db->model_num;	// Fill in the model to check
-		mc.submodel_num = db->submodel_num;
+		mc.model_num = db.model_num;	// Fill in the model to check
+		mc.submodel_num = db.submodel_num;
 		model_clear_instance( mc.model_num );
 		mc.orient = &objp->orient;					// The object's orient
 		mc.pos = &objp->pos;							// The object's position
@@ -927,7 +924,7 @@ bool shipfx_eye_in_shadow( vec3d *eye_pos, object * src_obj, int sun_n )
         return false;
     }
 
-    for (i = 0 ; i < MAX_ASTEROIDS; i++, ast++)
+    for (int i = 0 ; i < MAX_ASTEROIDS; i++, ast++)
     {
         if (!(ast->flags & AF_USED))
         {

--- a/code/ship/shiphit.cpp
+++ b/code/ship/shiphit.cpp
@@ -155,10 +155,8 @@ void do_subobj_destroyed_stuff( ship *ship_p, ship_subsys *subsys, vec3d* hitpos
 	}
 
 	// create fireballs when subsys destroy for large ships.
-	object* objp = &Objects[ship_p->objnum];
-
 	if (!(subsys->flags[Ship::Subsystem_Flags::Vanished]) && !no_explosion) {
-		if (objp->radius > 100.0f) {
+		if (ship_objp->radius > 100.0f) {
 			// number of fireballs determined by radius of subsys
 			int num_fireballs;
 			if ( psub->radius < 3 ) {
@@ -168,7 +166,7 @@ void do_subobj_destroyed_stuff( ship *ship_p, ship_subsys *subsys, vec3d* hitpos
 			}
 
 			vec3d temp_vec, center_to_subsys, rand_vec;
-			vm_vec_sub(&center_to_subsys, &g_subobj_pos, &objp->pos);
+			vm_vec_sub(&center_to_subsys, &g_subobj_pos, &ship_objp->pos);
 			for (i=0; i<num_fireballs; i++) {
 				if (i==0) {
 					// make first fireball at hitpos
@@ -192,14 +190,14 @@ void do_subobj_destroyed_stuff( ship *ship_p, ship_subsys *subsys, vec3d* hitpos
 				}
 
 				vec3d fb_vel;
-				vm_vec_cross(&fb_vel, &objp->phys_info.rotvel, &center_to_subsys);
-				vm_vec_add2(&fb_vel, &objp->phys_info.vel);
+				vm_vec_cross(&fb_vel, &ship_objp->phys_info.rotvel, &center_to_subsys);
+				vm_vec_add2(&fb_vel, &ship_objp->phys_info.vel);
 
 				int fireball_type = fireball_ship_explosion_type(sip);
 				if(fireball_type < 0) {
 					fireball_type = FIREBALL_EXPLOSION_MEDIUM;
 				}
-				fireball_create( &temp_vec, fireball_type, FIREBALL_MEDIUM_EXPLOSION, OBJ_INDEX(objp), fireball_rad, false, &fb_vel );
+				fireball_create( &temp_vec, fireball_type, FIREBALL_MEDIUM_EXPLOSION, ship_p->objnum, fireball_rad, false, &fb_vel );
 			}
 		}
 	}
@@ -285,7 +283,7 @@ void do_subobj_destroyed_stuff( ship *ship_p, ship_subsys *subsys, vec3d* hitpos
 	if ( psub->type == SUBSYSTEM_TURRET ) {
 		if ( ship_p->subsys_info[type].aggregate_current_hits <= 0.0f ) {
 			//	Don't create "disarmed" event for small ships.
-			if (!(Ship_info[ship_p->ship_info_index].is_small_ship())) {
+			if (!(sip->is_small_ship())) {
 				mission_log_add_entry(LOG_SHIP_DISARMED, ship_p->ship_name, NULL );
 				// ship_p->flags |= SF_DISARMED;
 			}
@@ -318,10 +316,14 @@ void do_subobj_destroyed_stuff( ship *ship_p, ship_subsys *subsys, vec3d* hitpos
 	if (notify && !no_explosion) {
 		// play sound effect when subsys gets blown up
 		gamesnd_id sound_index;
-		if ( Ship_info[ship_p->ship_info_index].is_huge_ship() ) {
-			sound_index=GameSounds::CAPSHIP_SUBSYS_EXPLODE;
-		} else if ( Ship_info[ship_p->ship_info_index].is_big_ship() ) {
-			sound_index=GameSounds::SUBSYS_EXPLODE;
+		if (ship_has_sound(ship_objp, GameSounds::SUBSYS_EXPLODE)) {
+			sound_index = ship_get_sound(ship_objp, GameSounds::SUBSYS_EXPLODE);
+		} else {
+			if ( sip->is_huge_ship() ) {
+				sound_index = GameSounds::CAPSHIP_SUBSYS_EXPLODE;
+			} else if ( sip->is_big_ship() ) {
+				sound_index = GameSounds::SUBSYS_EXPLODE;
+			}
 		}
 		if ( sound_index.isValid() ) {
 			snd_play_3d( gamesnd_get_game_sound(sound_index), &g_subobj_pos, &View_position );
@@ -1507,7 +1509,9 @@ void ship_generic_kill_stuff( object *objp, float percent_killed )
 	ai_deathroll_start(objp);
 
 	// play death roll begin sound
-	sp->death_roll_snd = snd_play_3d( gamesnd_get_game_sound(GameSounds::DEATH_ROLL), &objp->pos, &View_position, objp->radius );
+	auto snd_id = ship_get_sound(objp, GameSounds::DEATH_ROLL);
+	if (snd_id.isValid())
+		sp->death_roll_snd = snd_play_3d( gamesnd_get_game_sound(snd_id), &objp->pos, &View_position, objp->radius );
 	if (objp == Player_obj)
 		joy_ff_deathroll();
 
@@ -2007,7 +2011,7 @@ static void ship_do_damage(object *ship_objp, object *other_obj, vec3d *hitpos, 
 		other_obj_is_beam = ((other_obj->type == OBJ_BEAM) && (other_obj->instance >= 0) && (other_obj->instance < MAX_BEAMS));
 		other_obj_is_shockwave = ((other_obj->type == OBJ_SHOCKWAVE) && (other_obj->instance >= 0) && (other_obj->instance < MAX_SHOCKWAVES));
 		other_obj_is_asteroid = ((other_obj->type == OBJ_ASTEROID) && (other_obj->instance >= 0) && (other_obj->instance < MAX_ASTEROIDS));
-		other_obj_is_debris = ((other_obj->type == OBJ_DEBRIS) && (other_obj->instance >= 0) && (other_obj->instance < MAX_DEBRIS_PIECES));
+		other_obj_is_debris = ((other_obj->type == OBJ_DEBRIS) && (other_obj->instance >= 0) && (other_obj->instance < (int)Debris.size()));
 		other_obj_is_ship = ((other_obj->type == OBJ_SHIP) && (other_obj->instance >= 0) && (other_obj->instance < MAX_SHIPS));
 	}
 	else

--- a/code/ship/shiphit.cpp
+++ b/code/ship/shiphit.cpp
@@ -155,7 +155,7 @@ void do_subobj_destroyed_stuff( ship *ship_p, ship_subsys *subsys, vec3d* hitpos
 	}
 
 	// create fireballs when subsys destroy for large ships.
-	if (!(subsys->flags[Ship::Subsystem_Flags::Vanished]) && !no_explosion) {
+	if (!(subsys->flags[Ship::Subsystem_Flags::Vanished, Ship::Subsystem_Flags::No_disappear]) && !no_explosion) {
 		if (ship_objp->radius > 100.0f) {
 			// number of fireballs determined by radius of subsys
 			int num_fireballs;
@@ -304,13 +304,15 @@ void do_subobj_destroyed_stuff( ship *ship_p, ship_subsys *subsys, vec3d* hitpos
 	Script_system.RunCondition(CHA_ONSUBSYSDEATH, ship_objp);
 	Script_system.RemHookVars(2, "Ship", "Subsystem");
 
-	if ( psub->subobj_num > -1 )	{
-		shipfx_blow_off_subsystem(ship_objp,ship_p,subsys,&g_subobj_pos,no_explosion);
-		subsys->submodel_info_1.blown_off = 1;
-	}
+	if (!(subsys->flags[Ship::Subsystem_Flags::No_disappear])) {
+		if (psub->subobj_num > -1) {
+			shipfx_blow_off_subsystem(ship_objp, ship_p, subsys, &g_subobj_pos, no_explosion);
+			subsys->submodel_info_1.blown_off = 1;
+		}
 
-	if ( (psub->subobj_num != psub->turret_gun_sobj) && (psub->turret_gun_sobj >= 0) )		{
-		subsys->submodel_info_2.blown_off = 1;
+		if ((psub->subobj_num != psub->turret_gun_sobj) && (psub->turret_gun_sobj >= 0)) {
+			subsys->submodel_info_2.blown_off = 1;
+		}
 	}
 
 	if (notify && !no_explosion) {


### PR DESCRIPTION
1) Make Debris dynamic, and use a soft limit at 64 pieces (the old MAX) where the game will try to remove old pieces
2) Add scripting functions to tell whether the debris is a tiny generic/vaporized piece, rather than a modeled piece of ship
3) Allow per-class specification of death roll sounds and subsystem explosion sounds
4) Fix an off-by-one bug in the Debris[] Lua indexer