### PR TITLE
add for-ship-class and for-ship-type sexps

### DIFF
--- a/code/parse/sexp.h
+++ b/code/parse/sexp.h
@@ -418,6 +418,8 @@ class waypoint_list;
 #define OP_IF_THEN_ELSE						(0x0010 | OP_CATEGORY_CONDITIONAL)	// Goober5000
 #define OP_NUM_VALID_ARGUMENTS				(0x0011 | OP_CATEGORY_CONDITIONAL)	// Karajorma
 #define OP_FUNCTIONAL_IF_THEN_ELSE			(0x0012 | OP_CATEGORY_CONDITIONAL)	// Goober5000
+#define OP_FOR_SHIP_CLASS					(0x0013 | OP_CATEGORY_CONDITIONAL)	// Goober5000
+#define OP_FOR_SHIP_TYPE					(0x0014 | OP_CATEGORY_CONDITIONAL)	// Goober5000
 
 
 // sexpressions with side-effects


### PR DESCRIPTION
These sexps work just like for-counter, supplying arguments for when-argument.  They will list all ships that are present in the mission and are of a certain class or type.