### PR TITLE
synchronize localization

### DIFF
--- a/code/localization/localize.cpp
+++ b/code/localization/localize.cpp
@@ -712,8 +712,8 @@ bool lcl_ext_localize_sub(const char *in, char *text_str, char *out, size_t max_
 		return false;
 	}
 	
-	// if the localization file is not open, or there's no entry, return the original string
-	if ( !Xstr_inited || (str_id < 0) ) {
+	// if the localization file is not open, or there's no entry, or we're not translating, return the original string
+	if ( !Xstr_inited || (str_id < 0) || (Lcl_current_lang == LCL_UNTRANSLATED) ) {
 		if ( strlen(text_str) > max_len && !Lcl_unexpected_tstring_check )
 			error_display(0, "Token too long: [%s].  Length = " SIZE_T_ARG ".  Max is " SIZE_T_ARG ".\n", text_str, strlen(text_str), max_len);
 
@@ -770,7 +770,7 @@ bool lcl_ext_localize_sub(const SCP_string &in, SCP_string &text_str, SCP_string
 	}
 
 	// otherwise, check to see if it's an XSTR() tag
-	if (in.compare(0, 4, "XSTR")) {
+	if (in.compare(0, 4, "XSTR") != 0) {
 		// NOT an XSTR() tag
 		out = in;
 

--- a/code/localization/localize.cpp
+++ b/code/localization/localize.cpp
@@ -770,7 +770,7 @@ bool lcl_ext_localize_sub(const SCP_string &in, SCP_string &text_str, SCP_string
 	}
 
 	// otherwise, check to see if it's an XSTR() tag
-	if (in.compare(0, 4, "XSTR") != 0) {
+	if (strnicmp(in.c_str(), "XSTR", 4) != 0) {
 		// NOT an XSTR() tag
 		out = in;
 

--- a/test/src/menuui/test_intel_parse.cpp
+++ b/test/src/menuui/test_intel_parse.cpp
@@ -29,20 +29,20 @@ class IntelParseTest : public test::FSTestFixture {
 
 // Commonly used expected intel data entries.
 static intel_data expected_foo = {
-	"Foo name default", // XSTR id 3000
-	"Foo desc default", // XSTR id 3001
+	"Foo name", // XSTR id 3000
+	"Foo desc", // XSTR id 3001
 	"Foo anim",
 	IIF_IN_TECH_DATABASE | IIF_DEFAULT_IN_TECH_DATABASE
 };
 static intel_data expected_bar = {
-	"Bar name default", // XSTR id 3002
-	"Bar desc default", // XSTR id 3003
+	"Bar name", // XSTR id 3002
+	"Bar desc", // XSTR id 3003
 	"Bar anim",
 	0
 };
 static intel_data expected_baz = {
-	"Baz name default", // XSTR id 3004
-	"Baz desc default", // XSTR id 3005
+	"Baz name", // XSTR id 3004
+	"Baz desc", // XSTR id 3005
 	"Baz anim",
 	IIF_IN_TECH_DATABASE | IIF_DEFAULT_IN_TECH_DATABASE
 };


### PR DESCRIPTION
Back in PR #2390, I fixed translation behavior in `lcl_ext_localize_sub` for SCP_string, but neglected to also fix it for `char*`.  This PR remedies that.

I also fixed the string comparison since `SCP_string.compare()` is not case-insensitive.

This bug was discovered while tracking down test inconsistencies in PR #2663, so the test framework is doing its job. :+1: 