### PR TITLE
Improve Linux linking performance

### DIFF
--- a/cmake/toolchain-clang.cmake
+++ b/cmake/toolchain-clang.cmake
@@ -118,3 +118,12 @@ endif()
 
 # Always define this to make sure that the fixed width format macros are available
 target_compile_definitions(compiler INTERFACE __STDC_FORMAT_MACROS)
+
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux" OR MINGW)
+	# GNU ar: Create thin archive files.
+	# Requires binutils-2.19 or later.
+	set(CMAKE_C_ARCHIVE_CREATE   "<CMAKE_AR> qcTP <TARGET> <LINK_FLAGS> <OBJECTS>")
+	set(CMAKE_C_ARCHIVE_APPEND   "<CMAKE_AR> qTP  <TARGET> <LINK_FLAGS> <OBJECTS>")
+	set(CMAKE_CXX_ARCHIVE_CREATE "<CMAKE_AR> qcTP <TARGET> <LINK_FLAGS> <OBJECTS>")
+	set(CMAKE_CXX_ARCHIVE_APPEND "<CMAKE_AR> qTP  <TARGET> <LINK_FLAGS> <OBJECTS>")
+endif()

--- a/cmake/toolchain-gcc.cmake
+++ b/cmake/toolchain-gcc.cmake
@@ -8,6 +8,7 @@ MESSAGE(STATUS "Doing configuration specific to gcc...")
 option(GCC_ENABLE_LEAK_CHECK "Enable -fsanitize=leak" OFF)
 option(GCC_ENABLE_ADDRESS_SANITIZER "Enable -fsanitize=address" OFF)
 option(GCC_ENABLE_SANITIZE_UNDEFINED "Enable -fsanitize=undefined" OFF)
+option(GCC_USE_GOLD "Use the gold linker instead of the standard linker" OFF)
 
 # These are the default values
 set(C_BASE_FLAGS "-march=native -pipe")
@@ -23,6 +24,16 @@ endif()
 
 # Initialize with an empty string to make sure we always get a clean start
 set(COMPILER_FLAGS "")
+set(LINKER_FLAGS "")
+
+if (GCC_USE_GOLD)
+	OPTION(GCC_INCREMENTAL_LINKING "Use incremental linking" OFF)
+	set(LINKER_FLAGS "${LINKER_FLAGS} -fuse-ld=gold")
+
+	if (GCC_INCREMENTAL_LINKING)
+		set(LINKER_FLAGS "${LINKER_FLAGS} -fno-use-linker-plugin -Wl,-z,norelro -Wl,--incremental")
+	endif()
+endif()
 
 # This is a slight hack since our flag setup is a bit more complicated
 _enable_extra_compiler_warnings_flags()
@@ -30,9 +41,11 @@ set(COMPILER_FLAGS "${COMPILER_FLAGS} ${_flags}")
 
 set(COMPILER_FLAGS "${COMPILER_FLAGS} -funroll-loops -fsigned-char -Wno-unknown-pragmas")
 
-# Place each function and data in its own section so the linker can
-# perform dead code elimination
-set(COMPILER_FLAGS "${COMPILER_FLAGS} -fdata-sections -ffunction-sections")
+if (NOT GCC_INCREMENTAL_LINKING)
+	# Place each function and data in its own section so the linker can
+	# perform dead code elimination
+	set(COMPILER_FLAGS "${COMPILER_FLAGS} -fdata-sections -ffunction-sections")
+endif()
 
 if ("${CMAKE_GENERATOR}" STREQUAL "Ninja")
 	# Force color diagnostics for Ninja generator
@@ -108,7 +121,7 @@ set(CMAKE_C_FLAGS_RELEASE ${COMPILER_FLAGS_RELEASE})
 set(CMAKE_CXX_FLAGS_DEBUG ${COMPILER_FLAGS_DEBUG})
 set(CMAKE_C_FLAGS_DEBUG ${COMPILER_FLAGS_DEBUG})
 
-set(CMAKE_EXE_LINKER_FLAGS "")
+set(CMAKE_EXE_LINKER_FLAGS "${LINKER_FLAGS}")
 
 IF (MINGW)
 	SET(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -static -static-libgcc -static-libstdc++ -Wl,--enable-auto-import")
@@ -126,12 +139,14 @@ IF(NOT MINGW)
 	# Allow the linker to perform dead code elimination; this is considered
 	# experimental for COFF and PE formats and thus disabled for Windows builds
 	# (https://sourceware.org/binutils/docs/ld/Options.html)
-	SET(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--gc-sections")
+	if (NOT GCC_INCREMENTAL_LINKING)
+		SET(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--gc-sections")
+	endif()
 ENDIF(NOT MINGW)
 
 IF(${CMAKE_SYSTEM_NAME} MATCHES "SunOS")
-	SET(CMAKE_EXE_LINKER_FLAGS "-Wl,-zignore")
-ENDIF(${CMAKE_SYSTEM_NAME} MATCHES "SunOS")
+	SET(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,-zignore")
+ENDIF()
 
 if (FSO_FATAL_WARNINGS)
 	# Make warnings fatal if the right variable is set
@@ -140,3 +155,12 @@ endif()
 
 # Always define this to make sure that the fixed width format macros are available
 target_compile_definitions(compiler INTERFACE __STDC_FORMAT_MACROS=1)
+
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux" OR MINGW)
+	# GNU ar: Create thin archive files.
+	# Requires binutils-2.19 or later.
+	set(CMAKE_C_ARCHIVE_CREATE   "<CMAKE_AR> qcTP <TARGET> <LINK_FLAGS> <OBJECTS>")
+	set(CMAKE_C_ARCHIVE_APPEND   "<CMAKE_AR> qTP  <TARGET> <LINK_FLAGS> <OBJECTS>")
+	set(CMAKE_CXX_ARCHIVE_CREATE "<CMAKE_AR> qcTP <TARGET> <LINK_FLAGS> <OBJECTS>")
+	set(CMAKE_CXX_ARCHIVE_APPEND "<CMAKE_AR> qTP  <TARGET> <LINK_FLAGS> <OBJECTS>")
+endif()


### PR DESCRIPTION
This does two things:
 1. Use thin archives which speeds up static library creation by only
    storing references to the object files instead of copying them all
 2. Allow to use the gold linker with GCC along with an option for
    incremental linking. Since this is undesirable for non-development
    builds it is disabled by default.