### PR TITLE
Improve error reporting related to SSM strikes.

### DIFF
--- a/code/hud/hudartillery.cpp
+++ b/code/hud/hudartillery.cpp
@@ -82,6 +82,12 @@ void parse_ssm(const char *filename)
 			required_string("+Weapon:");
 			stuff_string(weapon_name, F_NAME, NAME_LENGTH);
 
+			// see if we have a valid weapon
+			s.weapon_info_index = weapon_info_lookup(weapon_name);
+			if (s.weapon_info_index < 0) {
+				error_display(0, "Unknown weapon [%s] for SSM strike [%s]; this SSM strike will be discarded.", weapon_name, s.name);
+			}
+
 			string_index = optional_string_either("+Count:", "+Min Count:");
 			if (string_index == 0) {
 				stuff_int(&s.count);
@@ -104,14 +110,14 @@ void parse_ssm(const char *filename)
 					stuff_string(unique_id, F_NAME, NAME_LENGTH);
 					int fireball_type = fireball_info_lookup(unique_id);
 					if (fireball_type < 0) {
-						error_display(1, "Unknown fireball [%s] to use as warp effect for SSM strike [%s]", unique_id, s.name);
+						error_display(0, "Unknown fireball [%s] to use as warp effect for SSM strike [%s]", unique_id, s.name);
 						s.fireball_idx = FIREBALL_WARP;
 					} else {
 						s.fireball_idx = fireball_type;
 					}
 				} else {
 					if ((temp < 0) || (temp >= Num_fireball_types)) {
-						error_display(1, "Fireball index [%d] out of range (should be 0-%d) for SSM strike [%s]", temp, Num_fireball_types - 1, s.name);
+						error_display(0, "Fireball index [%d] out of range (should be 0-%d) for SSM strike [%s]", temp, Num_fireball_types - 1, s.name);
 						s.fireball_idx = FIREBALL_WARP;
 					} else {
 						s.fireball_idx = temp;
@@ -129,7 +135,7 @@ void parse_ssm(const char *filename)
 				// According to fireballs.cpp, "Warp lifetime must be at least 4 seconds!"
 				if ( (s.warp_time) < 4.0f) {
 					// So let's warn them before they try to use it, shall we?
-					Warning(LOCATION, "Expected a '+WarpTime:' value equal or greater than 4.0, found '%f' in weapon '%s'.\n Setting to 4.0, please check and set to a number 4.0 or greater!\n", s.warp_time, weapon_name);
+					error_display(0, "Expected a '+WarpTime:' value equal or greater than 4.0, found '%f' in SSM strike [%s].\nSetting to 4.0, please check and set to a number 4.0 or greater!", s.warp_time, s.name);
 					// And then make the Assert obsolete -- Zacam
 					s.warp_time = 4.0f;
 				}
@@ -198,8 +204,6 @@ void parse_ssm(const char *filename)
 			s.sound_index = gamesnd_id();
 			parse_game_sound("+Alarm Sound:", &s.sound_index);
 
-			// see if we have a valid weapon
-			s.weapon_info_index = weapon_info_lookup(weapon_name);
 			if(s.weapon_info_index >= 0) {
 				// valid
 				int existing = ssm_info_lookup(s.name);
@@ -208,7 +212,7 @@ void parse_ssm(const char *filename)
 				} else {
 					Ssm_info.push_back(s);
 				}
-			}
+			} // We already warned the modder that the SSM strike was invalid without a valid weapon.
 		}
 	}
 	catch (const parse::ParseException& e)

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -7688,7 +7688,11 @@ void validate_SSM_entries()
 		nprintf(("parse", "Starting validation of '%s' [wip->name is '%s'], currently has an SSM_index of %d.\n", it->c_str(), wip->name, wip->SSM_index));
 		wip->SSM_index = ssm_info_lookup(dat->ssm_entry.c_str());
 		if (wip->SSM_index < 0) {
-			Warning(LOCATION, "Unknown SSM entry '%s' in specification for %s (%s:line %d).\n", dat->ssm_entry.c_str(), it->c_str(), dat->filename.c_str(), dat->linenum);
+			if (Ssm_info.empty()) {
+				Warning(LOCATION, "SSM entry '%s' in specification for %s (%s:line %d), despite no SSM strikes being defined.\n", dat->ssm_entry.c_str(), it->c_str(), dat->filename.c_str(), dat->linenum);
+			} else {
+				Warning(LOCATION, "Unknown SSM entry '%s' in specification for %s (%s:line %d).\n", dat->ssm_entry.c_str(), it->c_str(), dat->filename.c_str(), dat->linenum);
+			}
 		}
 		nprintf(("parse", "Validation complete, SSM_index is %d.\n", wip->SSM_index));
 	}
@@ -7704,7 +7708,11 @@ void validate_SSM_entries()
 		wip = &Weapon_info[wi];
 		nprintf(("parse", "Starting validation of '%s' [wip->name is '%s'], currently has an SSM_index of %d.\n", it->c_str(), wip->name, wip->SSM_index));
 		if (wip->SSM_index < -1 || wip->SSM_index >= static_cast<int>(Ssm_info.size())) {
-			Warning(LOCATION, "Invalid SSM index '%d' (should be 0-" SIZE_T_ARG ") in specification for %s (%s:line %d).\n", wip->SSM_index, Ssm_info.size() - 1, it->c_str(), dat->filename.c_str(), dat->linenum);
+			if (Ssm_info.empty()) {
+				Warning(LOCATION, "SSM index '%d' in specification for %s (%s:line %d), despite no SSM strikes being defined.\n", wip->SSM_index, it->c_str(), dat->filename.c_str(), dat->linenum);
+			} else {
+				Warning(LOCATION, "Invalid SSM index '%d' (should be 0-" SIZE_T_ARG ") in specification for %s (%s:line %d).\n", wip->SSM_index, Ssm_info.size() - 1, it->c_str(), dat->filename.c_str(), dat->linenum);
+			}
 			wip->SSM_index = -1;
 		}
 		nprintf(("parse", "Validation complete, SSM-index is %d.\n", wip->SSM_index));


### PR DESCRIPTION
First, in hudartillery.cpp, change some errors to warnings (actually `error_display(1, ...)` to `error_display(0, ...)`, but same difference).

Second, change a `Warning` to an `error_display(0, ...)`, and make it actually name the SSM strike instead of just reporting the name of the weapon it's using.

Third, do the `weapon_info_lookup()` earlier so we can use `error_display()` to point to the right line, and tell the modder that an invalid weapon invalidates the entire SSM strike (instead of just silently discarding the whole thing at the end).

Finally, in weapons.cpp, change `validate_SSM_entries()` to mention if `Ssm_info` is empty (instead of, say, telling the modder that the index needs to be between 0 and 4294967295—or, rather, -1 expressed as an unsigned 32-bit integer, since `Ssm_info.size() - 1` is, indeed, -1 when the vector is empty).