### PR TITLE
Fix AI banking when in formation

### DIFF
--- a/code/ai/ai.h
+++ b/code/ai/ai.h
@@ -618,7 +618,7 @@ extern int might_collide_with_ship(object *obj1, object *obj2, float dot_to_enem
 extern int ai_fire_primary_weapon(object *objp);	//changed to return weather it fired-Bobboau
 extern int ai_fire_secondary_weapon(object *objp);
 extern float ai_get_weapon_dist(ship_weapon *swp);
-extern void turn_towards_point(object *objp, vec3d *point, vec3d *slide_vec, float bank_override);
+extern void turn_towards_point(object *objp, vec3d *point, vec3d *slide_vec, float bank_override, matrix* target_orient = nullptr);
 extern int ai_maybe_fire_afterburner(object *objp, ai_info *aip);
 extern void set_predicted_enemy_pos(vec3d *predicted_enemy_pos, object *pobjp, vec3d *enemy_pos, vec3d *enemy_vel, ai_info *aip);
 

--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -11768,7 +11768,7 @@ int ai_formation()
 	}
 
 	if (dist_to_goal > 500.0f) {
-		turn_towards_point(Pl_objp, &goal_point, NULL, 0.0f, leader_orient);
+		turn_towards_point(Pl_objp, &goal_point, nullptr, 0.0f, leader_orient);
 		if (ab_allowed && !(Pl_objp->phys_info.flags & PF_AFTERBURNER_ON) && (dot_to_goal > 0.2f)) {
 			float percent_left = 100.0f * shipp->afterburner_fuel / sip->afterburner_fuel_capacity;
 			if (percent_left > 30.0f) {
@@ -11779,7 +11779,7 @@ int ai_formation()
 		accelerate_ship(aip, 1.0f);
 	} else if (dist_to_goal > 200.0f) {
 		if (dot_to_goal > -0.5f) {
-			turn_towards_point(Pl_objp, &goal_point, NULL, 0.0f, leader_orient);
+			turn_towards_point(Pl_objp, &goal_point, nullptr, 0.0f, leader_orient);
 			float range_speed = shipp->current_max_speed - leader_speed;
 			if (range_speed > 0.0f) {
 				set_accel_for_target_speed(Pl_objp, leader_speed + range_speed * (dist_to_goal+100.0f)/500.0f);
@@ -11801,7 +11801,7 @@ int ai_formation()
 				}
 			}
 		} else {
-			turn_towards_point(Pl_objp, &future_goal_point_5, NULL, 0.0f, leader_orient);
+			turn_towards_point(Pl_objp, &future_goal_point_5, nullptr, 0.0f, leader_orient);
 			if (leader_speed > 10.0f)
 				set_accel_for_target_speed(Pl_objp, leader_speed *(1.0f + dot_to_goal));
 			else
@@ -11819,12 +11819,12 @@ int ai_formation()
 
 		//	Leader flying like a maniac.  Don't try hard to form on wing.
 		if (chaotic_leader) {
-			turn_towards_point(Pl_objp, &future_goal_point_2, NULL, 0.0f, leader_orient);
+			turn_towards_point(Pl_objp, &future_goal_point_2, nullptr, 0.0f, leader_orient);
 			set_accel_for_target_speed(Pl_objp, MIN(leader_speed*0.8f, 20.0f));
 			if (Pl_objp->phys_info.flags & PF_AFTERBURNER_ON)
 				afterburners_stop(Pl_objp);
 		} else if (dist_to_goal > 75.0f) {
-			turn_towards_point(Pl_objp, &future_goal_point_2, NULL, 0.0f, leader_orient);
+			turn_towards_point(Pl_objp, &future_goal_point_2, nullptr, 0.0f, leader_orient);
 			float	delta_speed;
 			float range_speed = shipp->current_max_speed - leader_speed;
 			if (range_speed > 0.0f) {
@@ -11870,11 +11870,11 @@ int ai_formation()
 				//	moving very slowly, else momentum can carry far away from goal.
 
 				if ((dist_to_goal > 10.0f) || ((Pl_objp->phys_info.speed > leader_speed + 2.5f) && (dot_to_goal > 0.5f))) {
-					turn_towards_point(Pl_objp, &goal_point, NULL, 0.0f, leader_orient);
+					turn_towards_point(Pl_objp, &goal_point, nullptr, 0.0f, leader_orient);
 					set_accel_for_target_speed(Pl_objp, leader_speed + dist_to_goal/10.0f);
 				} else {
 					if (Pl_objp->phys_info.speed < 0.5f) {
-						turn_towards_point(Pl_objp, &future_goal_point_1000x, NULL, 0.0f, leader_orient);
+						turn_towards_point(Pl_objp, &future_goal_point_1000x, nullptr, 0.0f, leader_orient);
 					}
 					set_accel_for_target_speed(Pl_objp, leader_speed);
 				}
@@ -11884,7 +11884,7 @@ int ai_formation()
 			} else if (dist_to_goal > 10.0f) {
 				float	dv;
 
-				turn_towards_point(Pl_objp, &future_goal_point_2, NULL, 0.0f, leader_orient);
+				turn_towards_point(Pl_objp, &future_goal_point_2, nullptr, 0.0f, leader_orient);
 
 				if (dist_to_goal > 25.0f) {
 					if (dot_to_goal < 0.3f)
@@ -11918,9 +11918,9 @@ int ai_formation()
 
 			} else {
 				if (Pl_objp->phys_info.speed < 0.1f)
-					turn_towards_point(Pl_objp, &future_goal_point_1000x, NULL, 0.0f, leader_orient);
+					turn_towards_point(Pl_objp, &future_goal_point_1000x, nullptr, 0.0f, leader_orient);
 				else
-					turn_towards_point(Pl_objp, &future_goal_point_x, NULL, 0.0f, leader_orient);
+					turn_towards_point(Pl_objp, &future_goal_point_x, nullptr, 0.0f, leader_orient);
 
 				// Goober5000 7/5/2006 changed to leader_speed from 0.0f
 				set_accel_for_target_speed(Pl_objp, leader_speed);

--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -1511,8 +1511,6 @@ void get_tangent_point(vec3d *tan1, vec3d *p0, vec3d *centerp, vec3d *p1, float 
  */
 void turn_towards_point(object *objp, vec3d *point, vec3d *slide_vec, float bank_override, matrix* target_orient)
 {
-	ai_info	*aip;
-	aip = &Ai_info[Ships[Pl_objp->instance].ai_index];
 	vec3d* rvec = nullptr;
 	vec3d goal_rvec;
 

--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -1507,24 +1507,24 @@ void get_tangent_point(vec3d *tan1, vec3d *p0, vec3d *centerp, vec3d *p1, float 
 
 /**
  * Given an object and a point, turn towards the point, resulting in
- * approach behavior.
+ * approach behavior. Optional argument target_orient to attempt to match bank with
  */
-void turn_towards_point(object *objp, vec3d *point, vec3d *slide_vec, float bank_override)
+void turn_towards_point(object *objp, vec3d *point, vec3d *slide_vec, float bank_override, matrix* target_orient)
 {
 	ai_info	*aip;
 	aip = &Ai_info[Ships[Pl_objp->instance].ai_index];
-	
-	// check if in formation and if not leader, don't change rotvel.z (bank to match leader elsewhere)
-	if (aip->ai_flags[AI::AI_Flags::Formation_object, AI::AI_Flags::Formation_wing]) {
-		if (&Objects[aip->goal_objnum] != objp) {
-			float rotvel_z = objp->phys_info.rotvel.xyz.z;
-			ai_turn_towards_vector(point, objp, Ship_info[Ships[objp->instance].ship_info_index].srotation_time, slide_vec, nullptr, bank_override, 0);
-			objp->phys_info.rotvel.xyz.z = rotvel_z;
-		}
-	} else {
-		// normal turn
-		ai_turn_towards_vector(point, objp, Ship_info[Ships[objp->instance].ship_info_index].srotation_time, slide_vec, nullptr, bank_override, 0);
+	vec3d* rvec = nullptr;
+	vec3d goal_rvec;
+
+	if (target_orient != nullptr) {
+		rvec = &goal_rvec;
+		vec3d goal_fvec;
+
+		vm_vec_normalized_dir(&goal_fvec,point, &objp->pos);
+		vm_match_bank(rvec, &goal_fvec, target_orient);
 	}
+	
+	ai_turn_towards_vector(point, objp, Ship_info[Ships[objp->instance].ship_info_index].srotation_time, slide_vec, nullptr, bank_override, 0, rvec);
 }
 
 /**
@@ -11738,6 +11738,15 @@ int ai_formation()
 	dist_to_goal = vm_vec_dist_quick(&Pl_objp->pos, &goal_point);
 	float	dist_to_goal_2 = vm_vec_dist_quick(&Pl_objp->pos, &future_goal_point_2);
 
+	// See how different this ship's bank is relative to wing leader
+	// If it's too different, set leader_orient in subsequent calls to turn_towards_point
+	// (nullptr will be ignored otherwise)
+	float	leader_up_dot = vm_vec_dot(&leader_objp->orient.vec.uvec, &Pl_objp->orient.vec.uvec);
+	matrix* leader_orient = nullptr;
+	if (leader_up_dot < 0.996f) {
+		leader_orient = &leader_objp->orient;
+	}
+
 	int	chaotic_leader = 0;
 
 	chaotic_leader = formation_is_leader_chaotic(leader_objp);	//	Set to 1 if leader is player and flying erratically.  Causes ships to not aggressively pursue formation location.
@@ -11761,7 +11770,7 @@ int ai_formation()
 	}
 
 	if (dist_to_goal > 500.0f) {
-		turn_towards_point(Pl_objp, &goal_point, NULL, 0.0f);
+		turn_towards_point(Pl_objp, &goal_point, NULL, 0.0f, leader_orient);
 		if (ab_allowed && !(Pl_objp->phys_info.flags & PF_AFTERBURNER_ON) && (dot_to_goal > 0.2f)) {
 			float percent_left = 100.0f * shipp->afterburner_fuel / sip->afterburner_fuel_capacity;
 			if (percent_left > 30.0f) {
@@ -11772,7 +11781,7 @@ int ai_formation()
 		accelerate_ship(aip, 1.0f);
 	} else if (dist_to_goal > 200.0f) {
 		if (dot_to_goal > -0.5f) {
-			turn_towards_point(Pl_objp, &goal_point, NULL, 0.0f);
+			turn_towards_point(Pl_objp, &goal_point, NULL, 0.0f, leader_orient);
 			float range_speed = shipp->current_max_speed - leader_speed;
 			if (range_speed > 0.0f) {
 				set_accel_for_target_speed(Pl_objp, leader_speed + range_speed * (dist_to_goal+100.0f)/500.0f);
@@ -11794,7 +11803,7 @@ int ai_formation()
 				}
 			}
 		} else {
-			turn_towards_point(Pl_objp, &future_goal_point_5, NULL, 0.0f);
+			turn_towards_point(Pl_objp, &future_goal_point_5, NULL, 0.0f, leader_orient);
 			if (leader_speed > 10.0f)
 				set_accel_for_target_speed(Pl_objp, leader_speed *(1.0f + dot_to_goal));
 			else
@@ -11812,12 +11821,12 @@ int ai_formation()
 
 		//	Leader flying like a maniac.  Don't try hard to form on wing.
 		if (chaotic_leader) {
-			turn_towards_point(Pl_objp, &future_goal_point_2, NULL, 0.0f);
+			turn_towards_point(Pl_objp, &future_goal_point_2, NULL, 0.0f, leader_orient);
 			set_accel_for_target_speed(Pl_objp, MIN(leader_speed*0.8f, 20.0f));
 			if (Pl_objp->phys_info.flags & PF_AFTERBURNER_ON)
 				afterburners_stop(Pl_objp);
 		} else if (dist_to_goal > 75.0f) {
-			turn_towards_point(Pl_objp, &future_goal_point_2, NULL, 0.0f);
+			turn_towards_point(Pl_objp, &future_goal_point_2, NULL, 0.0f, leader_orient);
 			float	delta_speed;
 			float range_speed = shipp->current_max_speed - leader_speed;
 			if (range_speed > 0.0f) {
@@ -11863,11 +11872,11 @@ int ai_formation()
 				//	moving very slowly, else momentum can carry far away from goal.
 
 				if ((dist_to_goal > 10.0f) || ((Pl_objp->phys_info.speed > leader_speed + 2.5f) && (dot_to_goal > 0.5f))) {
-					turn_towards_point(Pl_objp, &goal_point, NULL, 0.0f);
+					turn_towards_point(Pl_objp, &goal_point, NULL, 0.0f, leader_orient);
 					set_accel_for_target_speed(Pl_objp, leader_speed + dist_to_goal/10.0f);
 				} else {
 					if (Pl_objp->phys_info.speed < 0.5f) {
-						turn_towards_point(Pl_objp, &future_goal_point_1000x, NULL, 0.0f);
+						turn_towards_point(Pl_objp, &future_goal_point_1000x, NULL, 0.0f, leader_orient);
 					}
 					set_accel_for_target_speed(Pl_objp, leader_speed);
 				}
@@ -11877,7 +11886,7 @@ int ai_formation()
 			} else if (dist_to_goal > 10.0f) {
 				float	dv;
 
-				turn_towards_point(Pl_objp, &future_goal_point_2, NULL, 0.0f);
+				turn_towards_point(Pl_objp, &future_goal_point_2, NULL, 0.0f, leader_orient);
 
 				if (dist_to_goal > 25.0f) {
 					if (dot_to_goal < 0.3f)
@@ -11911,9 +11920,9 @@ int ai_formation()
 
 			} else {
 				if (Pl_objp->phys_info.speed < 0.1f)
-					turn_towards_point(Pl_objp, &future_goal_point_1000x, NULL, 0.0f);
+					turn_towards_point(Pl_objp, &future_goal_point_1000x, NULL, 0.0f, leader_orient);
 				else
-					turn_towards_point(Pl_objp, &future_goal_point_x, NULL, 0.0f);
+					turn_towards_point(Pl_objp, &future_goal_point_x, NULL, 0.0f, leader_orient);
 
 				// Goober5000 7/5/2006 changed to leader_speed from 0.0f
 				set_accel_for_target_speed(Pl_objp, leader_speed);
@@ -11940,22 +11949,6 @@ int ai_formation()
 			}
 		}
 
-	}
-
-	//	See how different this ship's bank is relative to wing leader
-	float	up_dot = vm_vec_dot(&leader_objp->orient.vec.uvec, &Pl_objp->orient.vec.uvec);
-	if (up_dot < 0.996f) {
-		vec3d	w_out;
-		matrix	new_orient;
-		vec3d	angular_accel;
-
-		vm_vec_copy_scale(&angular_accel, &Pl_objp->phys_info.max_rotvel, 0.2f);
-		vm_matrix_interpolate(&leader_objp->orient, &Pl_objp->orient, &Pl_objp->phys_info.rotvel, flFrametime, &new_orient, &w_out, &Pl_objp->phys_info.max_rotvel, &angular_accel, 1);
-
-		Pl_objp->orient = new_orient;
-		Pl_objp->phys_info.rotvel = w_out;
-	} else {
-		Pl_objp->phys_info.rotvel.xyz.z = 0.0f;
 	}
 
 	return 0;
@@ -14219,15 +14212,7 @@ void ai_process( object * obj, int ai_index, float frametime )
 	if (rfc) {
 		// Wanderer - sexp based override goes here - only if rfc is valid though
 		ai_control_info_check(aip, sip, &obj->phys_info);
-		vec3d copy_desired_rotvel = obj->phys_info.rotvel;
 		physics_read_flying_controls( &obj->orient, &obj->phys_info, &AI_ci, frametime);
-		// if obj is in formation and not flight leader, don't update rotvel
-		if (aip->ai_flags[AI::AI_Flags::Formation_object, AI::AI_Flags::Formation_wing]) {
-			if (&Objects[aip->goal_objnum] != obj) {
-				obj->phys_info.desired_rotvel = copy_desired_rotvel;
-				obj->phys_info.rotvel = copy_desired_rotvel;
-			}
-		}
 	}
 
 	Last_ai_obj = OBJ_INDEX(obj);

--- a/code/math/vecmat.h
+++ b/code/math/vecmat.h
@@ -537,6 +537,9 @@ vec3d vm_vec4_to_vec3(const vec4& vec);
  */
 vec4 vm_vec3_to_ve4(const vec3d& vec, float w = 1.0f);
 
+// calculates the best rvec to match another orient while maintaining a given fvec
+void vm_match_bank(vec3d* out_rvec, const vec3d* goal_fvec, const matrix* match_orient);
+
 /** Compares two vec3ds */
 inline bool operator==(const vec3d& left, const vec3d& right) { return vm_vec_same(&left, &right) != 0; }
 inline bool operator!=(const vec3d& left, const vec3d& right) { return !(left == right); }


### PR DESCRIPTION
The AI code makes not one, not two, but three unnecessary and damaging checks for formation and attempting to handle bank. I've commented each location for the problems for each one causes, and how often it wouldn't even do what they were attempting. 

The desired behavior is obvious (as it is mentioned in the code multiple times), while a non-wing leader is flying in formation, it should attempt to match bank with the leader and also move to their assigned relative position. The retail code has the ship turn towards its assigned position, and then later in the function turn to match the leader's orientation. This is wrong in several ways that I've commented, but `ai_turn_towards_vector` comes with an optional `rvec` argument for exactly this reason!! I've added a function that will calculate the matching rvec to their wing leader and will pass that along to `turn_towards_vector` so it can accomplish all its goals in one call.