### PR TITLE
temporary hack to increase flexibility of hook variables

### DIFF
--- a/code/scripting/ade.cpp
+++ b/code/scripting/ade.cpp
@@ -169,8 +169,13 @@ int ade_index_handler(lua_State* L) {
 	}
 	lua_pop(L, 1);    //WMC - metatable
 
-	if (type_name != NULL) {
-		LuaError(L, "Could not find index '%s' in type '%s'", lua_tostring(L, key_ldx), type_name);
+	if (type_name != nullptr) {
+		// TEMP HACK to allow scripts to test for the existence of hook variables without triggering an error
+		if (!strcmp(type_name, "HookVariables")) {
+			mprintf(("Could not find index '%s' in type '%s'\n", lua_tostring(L, key_ldx), type_name));
+		} else {
+			LuaError(L, "Could not find index '%s' in type '%s'", lua_tostring(L, key_ldx), type_name);
+		}
 	} else {
 		LuaError(L, "Could not find index '%s'", lua_tostring(L, key_ldx));
 	}


### PR DESCRIPTION
This allows the coder to test for the existence of a hook variable by comparing it to `nil`.  The engine will currently error out and crash if you try to access a nonexistent table field, which is useful for catching typos, but has the disadvantage of disallowing a perfectly reasonable Lua coding practice.  So this change checks whether the missing field is part of `HookVariables`, and if so, rather than throwing an error, it just prints a message to the log.

This is sort of a hackish approach, and will eventually be superseded by a rewrite of the Lua hook variable handling, which @asarium plans to do at some point in the future.