### PR TITLE
miscellaneous scripting and ship-destruction enhancements

### DIFF
--- a/code/debris/debris.cpp
+++ b/code/debris/debris.cpp
@@ -220,9 +220,6 @@ void maybe_delete_debris(debris *db)
 	}
 }
 
-MONITOR(NumSmallDebris)
-MONITOR(NumHullDebris)
-
 /**
  * Do various updates to debris:  check if time to die, start fireballs
  * Maybe delete debris if it's very far away from player.
@@ -241,15 +238,12 @@ void debris_process_post(object * obj, float frame_time)
 	debris *db = &Debris[num];
 
 	if ( db->is_hull ) {
-		MONITOR_INC(NumHullDebris,1);
 		radar_plot_object( obj );
 
 		if ( timestamp_elapsed(db->sound_delay) ) {
 			obj_snd_assign(objnum, db->ambient_sound, &vmd_zero_vector, 0);
 			db->sound_delay = 0;
 		}
-	} else {
-		MONITOR_INC(NumSmallDebris,1);
 	}
 
 	if (!db->flags[Debris_Flags::DoNotExpire]) {
@@ -389,6 +383,9 @@ int debris_find_oldest()
 
 #define	DEBRIS_ROTVEL_SCALE	5.0f
 void calc_debris_physics_properties( physics_info *pi, vec3d *min, vec3d *max );
+
+MONITOR(NumSmallDebris)
+MONITOR(NumHullDebris)
 
 /**
  * Create debris from an object
@@ -690,6 +687,12 @@ object *debris_create(object *source_obj, int model_num, int submodel_num, vec3d
 	OnDebrisCreatedHook->run(scripting::hook_param_list(
 		scripting::hook_param("Debris", 'o', obj),
 		scripting::hook_param("Source", 'o', source_obj)));
+
+	if (db->is_hull) {
+		MONITOR_INC(NumHullDebris,1);
+	} else {
+		MONITOR_INC(NumSmallDebris,1);
+	}
 
 	return obj;
 }

--- a/code/network/multimsgs.cpp
+++ b/code/network/multimsgs.cpp
@@ -2644,7 +2644,7 @@ void process_ship_kill_packet( ubyte *data, header *hinfo )
 
 	// do the normal thing when not ingame joining.  When ingame joining, simply kill off the ship.
 	if ( !(Net_player->flags & NETINFO_FLAG_INGAME_JOIN) ) {
-		ship_hit_kill( sobjp, oobjp, percent_killed, sd );
+		ship_hit_kill( sobjp, oobjp, nullptr, percent_killed, sd );
 	} else {
         sobjp->flags.set(Object::Object_Flags::Should_be_dead);
 		ship_cleanup(sobjp->instance, SHIP_DESTROYED);

--- a/code/scripting/api/libs/mission.cpp
+++ b/code/scripting/api/libs/mission.cpp
@@ -831,7 +831,7 @@ ADE_FUNC(sendPlainMessage,
 ADE_FUNC(createShip,
 	l_Mission,
 	"[string Name, shipclass Class /* First ship class by default */, orientation Orientation=null, vector Position /* "
-	"null vector by default */]",
+	"null vector by default */, team Team]",
 	"Creates a ship and returns a handle to it using the specified name, class, world orientation, and world position",
 	"ship",
 	"Ship handle, or invalid ship handle if ship couldn't be created")
@@ -840,7 +840,8 @@ ADE_FUNC(createShip,
 	int sclass       = -1;
 	matrix_h* orient = nullptr;
 	vec3d pos        = vmd_zero_vector;
-	ade_get_args(L, "|sooo", &name, l_Shipclass.Get(&sclass), l_Matrix.GetPtr(&orient), l_Vector.Get(&pos));
+	int team         = -1;
+	ade_get_args(L, "|soooo", &name, l_Shipclass.Get(&sclass), l_Matrix.GetPtr(&orient), l_Vector.Get(&pos), l_Team.Get(&team));
 
 	matrix *real_orient = &vmd_identity_matrix;
 	if(orient != NULL)
@@ -855,6 +856,10 @@ ADE_FUNC(createShip,
 	int obj_idx = ship_create(real_orient, &pos, sclass, name);
 
 	if(obj_idx >= 0) {
+		if (team >= 0) {
+			Ships[Objects[obj_idx].instance].team = team;
+		}
+
 		model_page_in_textures(Ship_info[sclass].model_num, sclass);
 
 		ship_set_warp_effects(&Objects[obj_idx]);

--- a/code/scripting/api/objs/vecmath.cpp
+++ b/code/scripting/api/objs/vecmath.cpp
@@ -509,6 +509,15 @@ ADE_FUNC(getDistance, l_Vector, "vector otherPos", "Distance", "number", "Return
 	return ade_set_args(L, "f", vm_vec_dist(v3a, v3b));
 }
 
+ADE_FUNC(getDistanceSquared, l_Vector, "vector otherPos", "Distance squared", "number", "Returns distance squared from another vector") {
+	vec3d* v3a, * v3b;
+	if (!ade_get_args(L, "oo", l_Vector.GetPtr(&v3a), l_Vector.GetPtr(&v3b))) {
+		return ade_set_error(L, "f", 0.0f);
+	}
+
+	return ade_set_args(L, "f", vm_vec_dist_squared(v3a, v3b));
+}
+
 ADE_FUNC(getDotProduct,
 		 l_Vector,
 		 "vector OtherVector",

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -71,6 +71,7 @@
 #include "radar/radarsetup.h"
 #include "render/3d.h"
 #include "render/batching.h"
+#include "scripting/api/objs/vecmath.h"
 #include "ship/afterburner.h"
 #include "ship/ship.h"
 #include "ship/shipcontrails.h"
@@ -7472,9 +7473,9 @@ void ship_destroy_instantly(object *ship_objp)
 	mission_log_add_entry(LOG_SELF_DESTRUCTED, Ships[ship_objp->instance].ship_name, NULL );
 	
 	// scripting stuff
-	Script_system.SetHookObject("Self", ship_objp);
+	Script_system.SetHookObjects(2, "Self", ship_objp, "Ship", ship_objp);
 	Script_system.RunCondition(CHA_DEATH, ship_objp);
-	Script_system.RemHookVar("Self");
+	Script_system.RemHookVars(2, "Self", "Ship");
 
 	ship_objp->flags.set(Object::Object_Flags::Should_be_dead);
 	ship_cleanup(ship_objp->instance, SHIP_DESTROYED);
@@ -8113,7 +8114,8 @@ static void ship_dying_frame(object *objp, int ship_num)
 				}
 			}
 
-			snd_play_3d( gamesnd_get_game_sound(sound_index), &objp->pos, &View_position, objp->radius, NULL, 0, 1.0f, SND_PRIORITY_MUST_PLAY  );
+			if (sound_index.isValid())
+				snd_play_3d(gamesnd_get_game_sound(sound_index), &objp->pos, &View_position, objp->radius, nullptr, 0, 1.0f, SND_PRIORITY_MUST_PLAY);
 			if (objp == Player_obj)
 				joy_ff_explode();
 
@@ -13951,7 +13953,10 @@ int ship_do_rearm_frame( object *objp, float frametime )
 					else
 						sound_index = GameSounds::MISSILE_START_LOAD;
 
-					swp->primary_bank_rearm_time[i] = timestamp((int)gamesnd_get_max_duration(gamesnd_get_game_sound(sound_index)));
+					if (sound_index.isValid())
+						swp->primary_bank_rearm_time[i] = timestamp((int)gamesnd_get_max_duration(gamesnd_get_game_sound(sound_index)));
+					else
+						swp->primary_bank_rearm_time[i] = timestamp(0);
 				}
 
 				if ( swp->primary_bank_ammo[i] < swp->primary_bank_start_ammo[i] )
@@ -13975,7 +13980,8 @@ int ship_do_rearm_frame( object *objp, float frametime )
 						else
 							sound_index = GameSounds::MISSILE_LOAD;
 
-						snd_play_3d( gamesnd_get_game_sound(sound_index), &objp->pos, &View_position );
+						if (sound_index.isValid())
+							snd_play_3d( gamesnd_get_game_sound(sound_index), &objp->pos, &View_position );
 	
 						swp->primary_bank_ammo[i] += Weapon_info[swp->primary_bank_weapons[i]].reloaded_per_batch;
 						if ( swp->primary_bank_ammo[i] > swp->primary_bank_start_ammo[i] )
@@ -14006,7 +14012,8 @@ int ship_do_rearm_frame( object *objp, float frametime )
 					else
 						sound_index = GameSounds::MISSILE_START_LOAD;
 
-					snd_play_3d( gamesnd_get_game_sound(sound_index), &objp->pos, &View_position );
+					if (sound_index.isValid())
+						snd_play_3d( gamesnd_get_game_sound(sound_index), &objp->pos, &View_position );
 				}
 
 				aip->rearm_first_ballistic_primary = FALSE;

--- a/code/ship/shiphit.h
+++ b/code/ship/shiphit.h
@@ -55,7 +55,7 @@ void ship_apply_global_damage(object *ship_obj, object *other_obj, vec3d *force_
 void ship_apply_wash_damage(object *ship_obj, object *other_obj, float damage);
 
 // next routine needed for multiplayer
-void ship_hit_kill( object *ship_obj, object *other_obj, float percent_killed, int self_destruct);
+void ship_hit_kill( object *ship_obj, object *other_obj, vec3d *hitpos, float percent_killed, int self_destruct);
 
 void ship_self_destruct( object *objp );
 


### PR DESCRIPTION
1) Add `Hitpos` to the variables passed to the `On Death` scripting hook.
2) When creating a ship using ship-create, allow specification of the team (in both sexp and script).  This allows the right team color to appear in the mission log for the ship arrival entry.
3) Add `getCenterPosition` because the ship local origin is not always at the exact center of the model.
4) Add `getDistanceSquared`.
5) Add a "Ship" hook variable (which duplicates "Self") to the On Death scripting hook.
6) If there is no explosion sound, don't try to play it.  (Same for rearm start sound.)
7) Move the monitor tracing statements for debris creation to where the debris is actually created