### PR TITLE
fix alignments in the hud gauge parsing

### DIFF
--- a/code/hud/hud.cpp
+++ b/code/hud/hud.cpp
@@ -3271,6 +3271,15 @@ int hud_gauge_maybe_flash(int gauge_index)
 	return flash_status;
 }
 
+HudAlignment hud_alignment_lookup(const char *name)
+{
+	if (!stricmp(name, "left"))
+		return HudAlignment::LEFT;
+	if (!stricmp(name, "right"))
+		return HudAlignment::RIGHT;
+	return HudAlignment::NONE;
+}
+
 /**
  * @brief Initialise the objective message display data
  */

--- a/code/hud/hud.h
+++ b/code/hud/hud.h
@@ -60,6 +60,14 @@ typedef struct hud_subsys_damage
 	char* name;
 } hud_subsys_damage;
 
+// used for hudtarget
+enum class HudAlignment
+{
+	NONE,
+	LEFT,
+	RIGHT
+};
+
 extern int HUD_draw;
 extern int HUD_contrast;
 
@@ -167,6 +175,8 @@ void	hud_set_gauge_color(int gauge_index, int bright_index = HUD_C_NONE);
 int	hud_gauge_active(int gauge_index);
 void	hud_gauge_start_flash(int gauge_index);
 int	hud_gauge_maybe_flash(int gauge_index);
+
+HudAlignment hud_alignment_lookup(const char *name);
 
 // popup gauges
 void	hud_gauge_popup_start(int gauge_index, int time=4000);

--- a/code/hud/hudparse.cpp
+++ b/code/hud/hudparse.cpp
@@ -1575,13 +1575,13 @@ void load_gauge_weapon_energy(gauge_settings* settings)
 {
 	int Wenergy_text_offsets[2];
 	int Wenergy_h;
-	int text_alignment = 0;
+	HudAlignment text_alignment = HudAlignment::NONE;
 	bool always_show_text = false;
 	bool show_ballistic = false;
 	bool moving_text = false;
 	int armed_weapon_offsets[2] = {0, 0};
 	int armed_weapon_h = 12;
-	int weapon_alignment = 0;
+	HudAlignment weapon_alignment = HudAlignment::NONE;
 	bool show_weapons = false;
 	char fname[MAX_FILENAME_LEN];
 	
@@ -1633,9 +1633,9 @@ void load_gauge_weapon_energy(gauge_settings* settings)
 		stuff_int_list(Wenergy_text_offsets, 2);
 
 		if(optional_string("Text Alignment:")) {
-			if(required_string("Right")) {
-				text_alignment = 1;
-			}
+			char temp[NAME_LENGTH];
+			stuff_string(temp, F_NAME, NAME_LENGTH);
+			text_alignment = hud_alignment_lookup(temp);
 		}
 	}
 	if(optional_string("Always Show Text:")) {
@@ -1652,9 +1652,9 @@ void load_gauge_weapon_energy(gauge_settings* settings)
 		show_weapons = true;
 
 		if(optional_string("Armed Guns List Alignment:")) {
-			if(required_string("Right")) {
-				weapon_alignment = 1;
-			}
+			char temp[NAME_LENGTH];
+			stuff_string(temp, F_NAME, NAME_LENGTH);
+			weapon_alignment = hud_alignment_lookup(temp);
 		}
 
 		if(optional_string("Armed Guns List Entry Height:")) {
@@ -4919,7 +4919,7 @@ void load_gauge_warhead_count(gauge_settings* settings)
 	int icon_height = 0;
 	int max_icons = 0;
 	int max_columns = 0;
-	int alignment = 0;
+	HudAlignment alignment = HudAlignment::NONE;
 	char fname[MAX_FILENAME_LEN] = "warhead_icon";
 	
 	settings->origin[0] = 1.0f;
@@ -4965,11 +4965,9 @@ void load_gauge_warhead_count(gauge_settings* settings)
 	}
 
 	if ( optional_string("Name Alignment:") ) {
-		if ( optional_string("Right") ) {
-			alignment = 1;
-		} else {
-			alignment = 0;
-		}
+		char temp[NAME_LENGTH];
+		stuff_string(temp, F_NAME, NAME_LENGTH);
+		alignment = hud_alignment_lookup(temp);
 	}
 
 	hud_gauge->initBitmap(fname);

--- a/code/hud/hudtarget.cpp
+++ b/code/hud/hudtarget.cpp
@@ -5456,7 +5456,7 @@ void HudGaugeWeaponEnergy::initEnergyHeight(int h)
 	Wenergy_h = h;
 }
 
-void HudGaugeWeaponEnergy::initAlignments(int text_align, int armed_align)
+void HudGaugeWeaponEnergy::initAlignments(HudAlignment text_align, HudAlignment armed_align)
 {
 	Text_alignment = text_align;
 	Armed_alignment = armed_align;
@@ -5684,7 +5684,7 @@ void HudGaugeWeaponEnergy::render(float  /*frametime*/)
 
 			hud_num_make_mono(buf, font_num);
 
-			if ( Text_alignment ) {
+			if ( Text_alignment == HudAlignment::RIGHT ) {
 				gr_get_string_size(&w, &h, buf);
 				delta_x = -w;
 			}
@@ -5702,7 +5702,7 @@ void HudGaugeWeaponEnergy::render(float  /*frametime*/)
 					wip = &Weapon_info[sw->primary_bank_weapons[i]];
 					strcpy_s(buf, wip->get_display_string());
 
-					if ( Armed_alignment ) {
+					if ( Armed_alignment == HudAlignment::RIGHT ) {
 						gr_get_string_size(&w, &h, buf);
 					} else {
 						w = 0;
@@ -5716,7 +5716,7 @@ void HudGaugeWeaponEnergy::render(float  /*frametime*/)
 				wip = &Weapon_info[sw->primary_bank_weapons[i]];
 				strcpy_s(buf, wip->get_display_string());
 
-				if ( Armed_alignment ) {
+				if ( Armed_alignment == HudAlignment::RIGHT ) {
 					gr_get_string_size(&w, &h, buf);
 				} else {
 					w = 0;
@@ -6611,7 +6611,7 @@ void HudGaugeWarheadCount::initMaxColumns(int count)
 	Max_columns = count;
 }
 
-void HudGaugeWarheadCount::initTextAlign(int align)
+void HudGaugeWarheadCount::initTextAlign(HudAlignment align)
 {
 	Text_align = align;
 }
@@ -6653,12 +6653,12 @@ void HudGaugeWarheadCount::render(float  /*frametime*/)
 	setGaugeColor();
 
 	// display the weapon name
-	if ( Text_align ) {
+	if ( Text_align == HudAlignment::RIGHT ) {
 		int w, h;
 
 		gr_get_string_size(&w, &h, weapon_name);
 		renderString(position[0] + Warhead_name_offsets[0] - w, position[1] + Warhead_name_offsets[1], weapon_name);
-	} else {
+	} else if ( Text_align == HudAlignment::LEFT ) {
 		renderString(position[0] + Warhead_name_offsets[0], position[1] + Warhead_name_offsets[1], weapon_name);
 	}
 
@@ -6671,12 +6671,12 @@ void HudGaugeWarheadCount::render(float  /*frametime*/)
 		sprintf(ammo_str, "%d", ammo);
 		hud_num_make_mono(ammo_str, font_num);
 
-		if ( Text_align ) {
+		if ( Text_align == HudAlignment::RIGHT ) {
 			int w, h;
 
 			gr_get_string_size(&w, &h, ammo_str);
 			renderString(position[0] + Warhead_count_offsets[0] - w, position[1] + Warhead_count_offsets[1], ammo_str);
-		} else {
+		} else if ( Text_align == HudAlignment::LEFT ) {
 			renderString(position[0] + Warhead_count_offsets[0], position[1] + Warhead_count_offsets[1], ammo_str);
 		}
 
@@ -6684,9 +6684,9 @@ void HudGaugeWarheadCount::render(float  /*frametime*/)
 	}
 
 	int delta_x = 0, delta_y = 0;
-	if ( Text_align ) {
+	if ( Text_align == HudAlignment::RIGHT ) {
 		delta_x = -Warhead_count_size[0];
-	} else {
+	} else if ( Text_align == HudAlignment::LEFT ) {
 		delta_x = Warhead_count_size[0];
 	}
 

--- a/code/hud/hudtarget.h
+++ b/code/hud/hudtarget.h
@@ -262,10 +262,10 @@ protected:
 
 	int Wenergy_text_offsets[2];
 	int Wenergy_h;
-	int Text_alignment;
+	HudAlignment Text_alignment;
 
 	int Armed_name_offsets[2];
-	int Armed_alignment;
+	HudAlignment Armed_alignment;
 	bool Show_armed;
 	int Armed_name_h;
 	
@@ -280,7 +280,7 @@ public:
 	void initAlwaysShowText(bool show_text);
 	void initMoveText(bool move_text);
 	void initShowBallistics(bool show_ballistics);
-	void initAlignments(int text_align, int armed_align);
+	void initAlignments(HudAlignment text_align, HudAlignment armed_align);
 	void initArmedOffsets(int x, int y, int h, bool show);
 	void render(float frametime) override;
 	void pageIn() override;
@@ -451,7 +451,7 @@ class HudGaugeWarheadCount: public HudGauge
 	int Warhead_count_size[2];
 
 	int Max_symbols;
-	int Text_align;
+	HudAlignment Text_align;
 	int Max_columns;
 public:
 	HudGaugeWarheadCount();
@@ -461,7 +461,7 @@ public:
 	void initCountSizes(int w, int h);
 	void initMaxSymbols(int count);
 	void initMaxColumns(int count);
-	void initTextAlign(int align);
+	void initTextAlign(HudAlignment align);
 	void render(float frametime) override;
 	void pageIn() override;
 };


### PR DESCRIPTION
Admiral Nelson led me to discover that the HUD gauges expected "right" or no string at all for the gauge alignment.  I added basic recognition of LEFT and RIGHT alignment.  Someone more familiar with the HUD than me can flesh it out more.