### PR TITLE
various collision group fixes

### DIFF
--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -25590,7 +25590,7 @@ int get_sexp_main()
 	return start_node;
 }
 
-int run_sexp(const char* sexpression)
+int run_sexp(const char* sexpression, bool run_eval_num, bool *is_nan_or_nan_forever)
 {
 	char* oldMp = Mp;
 	int n, i, sexp_val = UNINITIALIZED;
@@ -25608,9 +25608,19 @@ int run_sexp(const char* sexpression)
 	n = get_sexp_main();
 	if (n != -1)
 	{
-		sexp_val = eval_sexp(n);
+		if (run_eval_num)
+		{
+			bool is_nan, is_nan_forever;
+			sexp_val = eval_num(n, is_nan, is_nan_forever);
+			if (is_nan_or_nan_forever != nullptr)
+				*is_nan_or_nan_forever = (is_nan || is_nan_forever);
+		}
+		else
+			sexp_val = eval_sexp(n);
+
 		free_sexp2(n);
 	}
+
 	Mp = oldMp;
 
 	return sexp_val;

--- a/code/parse/sexp.h
+++ b/code/parse/sexp.h
@@ -1192,7 +1192,7 @@ extern int get_operator_const(int node);
 
 extern int check_sexp_syntax(int node, int return_type = OPR_BOOL, int recursive = 0, int *bad_node = 0 /*NULL*/, int mode = 0);
 extern int get_sexp_main(void);	//	Returns start node
-extern int run_sexp(const char* sexpression); // debug and lua sexps
+extern int run_sexp(const char* sexpression, bool run_eval_num = false, bool *is_nan_or_nan_forever = nullptr); // debug and lua sexps
 extern int stuff_sexp_variable_list();
 extern int eval_sexp(int cur_node, int referenced_node = -1);
 extern int eval_num(int n, bool &is_nan, bool &is_nan_forever);

--- a/code/scripting/api/libs/mission.cpp
+++ b/code/scripting/api/libs/mission.cpp
@@ -83,7 +83,7 @@ ADE_FUNC(getObjectFromSignature, l_Mission, "number Signature", "Gets a handle o
 	return ade_set_object_with_breed(L, objnum);
 }
 
-ADE_FUNC(evaluateSEXP, l_Mission, "string", "Runs the defined SEXP script", "boolean", "if the operation was successful")
+ADE_FUNC(evaluateSEXP, l_Mission, "string", "Runs the defined SEXP script, and returns the result as a boolean", "boolean", "true if the SEXP returned SEXP_TRUE or SEXP_KNOWN_TRUE; false if the SEXP returned anything else (even a number)")
 {
 	const char* s;
 	int r_val;
@@ -99,7 +99,24 @@ ADE_FUNC(evaluateSEXP, l_Mission, "string", "Runs the defined SEXP script", "boo
 		return ADE_RETURN_FALSE;
 }
 
-ADE_FUNC(runSEXP, l_Mission, "string", "Runs the defined SEXP script", "boolean", "if the operation was successful")
+ADE_FUNC(evaluateNumericSEXP, l_Mission, "string", "Runs the defined SEXP script, and returns the result as a number", "number", "the value of the SEXP result (or NaN if the SEXP returned SEXP_NAN or SEXP_NAN_FOREVER)")
+{
+	const char* s;
+	int r_val;
+	bool got_nan;
+
+	if (!ade_get_args(L, "s", &s))
+		return ade_set_args(L, "i", 0);
+
+	r_val = run_sexp(s, true, &got_nan);
+
+	if (got_nan)
+		return ade_set_args(L, "f", std::numeric_limits<float>::quiet_NaN());
+	else
+		return ade_set_args(L, "i", r_val);
+}
+
+ADE_FUNC(runSEXP, l_Mission, "string", "Runs the defined SEXP script within a `when` operator", "boolean", "if the operation was successful")
 {
 	const char* s;
 	int r_val;

--- a/code/scripting/api/objs/object.cpp
+++ b/code/scripting/api/objs/object.cpp
@@ -273,6 +273,40 @@ ADE_VIRTVAR(CollisionGroups, l_Object, "number", "Collision group data", "number
 	return ade_set_args(L, "i", objh->objp->collision_group_id);
 }
 
+ADE_FUNC(addToCollisionGroup, l_Object, "number group", "Adds this object to the specified collision group.  The group must be between 0 and 31, inclusive.", nullptr, "Returns nothing")
+{
+	object_h *objh = nullptr;
+	int group;
+
+	if (!ade_get_args(L, "oi", l_Object.GetPtr(&objh), &group))
+		return ADE_RETURN_NIL;
+
+	if (!objh->IsValid())
+		return ADE_RETURN_NIL;
+
+	if (group >= 0 && group <= 31)
+		objh->objp->collision_group_id |= (1 << group);
+
+	return ADE_RETURN_NIL;
+}
+
+ADE_FUNC(removeFromCollisionGroup, l_Object, "number group", "Removes this object from the specified collision group.  The group must be between 0 and 31, inclusive.", nullptr, "Returns nothing")
+{
+	object_h *objh = nullptr;
+	int group;
+
+	if (!ade_get_args(L, "oi", l_Object.GetPtr(&objh), &group))
+		return ADE_RETURN_NIL;
+
+	if (!objh->IsValid())
+		return ADE_RETURN_NIL;
+
+	if (group >= 0 && group <= 31)
+		objh->objp->collision_group_id &= ~(1 << group);
+
+	return ADE_RETURN_NIL;
+}
+
 ADE_FUNC(getfvec, l_Object, "[boolean normalize]", "Returns the objects' current fvec.", "vector", "Objects' forward vector, or nil if invalid. If called with a true argument, vector will be normalized.")
 {
 	object_h *objh = NULL;


### PR DESCRIPTION
Collision groups as previously coded were unusable due to Lua 5.1's lack of support for bitwise operators.  This fixes that deficiency in two ways:
1) Objects now have the functions `addToCollisionGroup` and `removeFromCollisionGroup`
2) An `evaluateNumericSEXP` function has been added for returning SEXP results as numbers (so that scripts can use the bitwise SEXP operators)