### PR TITLE
Allow for arbitrary wingmate relative positions

### DIFF
--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -11429,10 +11429,11 @@ void get_absolute_wing_pos(vec3d *result_pos, object *leader_objp, int wing_inde
 	vec3d	wing_delta, rotated_wing_delta;
 	float		wing_spread_size;
 	species_info* species = &Species_info[Ship_info[Ships[leader_objp->instance].ship_info_index].species];
-	bool is_custom_pos = species->custom_wing_positions > wing_index;
+	int formation_index = Wings[Ships[leader_objp->instance].wingnum].formation;
 
-	if (wing_index != 0 && is_custom_pos) {
-		wing_delta = species->wing_positions[wing_index - 1]; //  custom desired location in leader's reference frame
+
+	if (wing_index != 0 && formation_index != -1) {
+		wing_delta = species->formations[formation_index][wing_index - 1]; //  custom desired location in leader's reference frame
 	}
 	else {
 		get_wing_delta(&wing_delta, wing_index);		//	default desired location in leader's reference frame
@@ -11442,12 +11443,13 @@ void get_absolute_wing_pos(vec3d *result_pos, object *leader_objp, int wing_inde
 
 	// apply debug modifications to spread size and also y scale (2x default) unless it's a custom position
 	if (leader_objp->flags[Object::Object_Flags::Player_ship]) {
-		if(!is_custom_pos)
+		if(formation_index == -1)
 			wing_delta.xyz.y *= Wing_y_scale;
 		wing_spread_size *= Wing_scale;
 	}
 
 	vm_vec_scale(&wing_delta, wing_spread_size * (1.0f + leader_objp->phys_info.speed/70.0f));
+
 
 	vm_vec_unrotate(&rotated_wing_delta, &wing_delta, &leader_objp->orient);	//	Rotate into leader's reference.
 

--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -11428,14 +11428,22 @@ void get_absolute_wing_pos(vec3d *result_pos, object *leader_objp, int wing_inde
 {
 	vec3d	wing_delta, rotated_wing_delta;
 	float		wing_spread_size;
+	species_info* species = &Species_info[Ship_info[Ships[leader_objp->instance].ship_info_index].species];
+	bool is_custom_pos = species->custom_wing_positions > wing_index;
 
-	get_wing_delta(&wing_delta, wing_index);		//	Desired location in leader's reference frame
+	if (wing_index != 0 && is_custom_pos) {
+		wing_delta = species->wing_positions[wing_index - 1]; //  custom desired location in leader's reference frame
+	}
+	else {
+		get_wing_delta(&wing_delta, wing_index);		//	default desired location in leader's reference frame
+	}
 
 	wing_spread_size = MAX(50.0f, 3.0f * get_wing_largest_radius(leader_objp, formation_object_flag) + 15.0f);
 
-	// for player obj (1) move ships up 20% (2) scale formation up 20%
+	// apply debug modifications to spread size and also y scale (2x default) unless it's a custom position
 	if (leader_objp->flags[Object::Object_Flags::Player_ship]) {
-		wing_delta.xyz.y *= Wing_y_scale;
+		if(!is_custom_pos)
+			wing_delta.xyz.y *= Wing_y_scale;
 		wing_spread_size *= Wing_scale;
 	}
 

--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -11431,14 +11431,13 @@ void get_absolute_wing_pos(vec3d *result_pos, object *leader_objp, int wing_inde
 	species_info* species = &Species_info[Ship_info[Ships[leader_objp->instance].ship_info_index].species];
 	int formation_index = Wings[Ships[leader_objp->instance].wingnum].formation;
 
-
-	if (wing_index != 0 && formation_index != -1) {
+	if (wing_index == 0)
+		wing_delta = vmd_zero_vector;
+	else if ( formation_index != -1) 
 		wing_delta = species->formations[formation_index][wing_index - 1]; //  custom desired location in leader's reference frame
-	}
-	else {
+	else 
 		get_wing_delta(&wing_delta, wing_index);		//	default desired location in leader's reference frame
-	}
-
+	
 	wing_spread_size = MAX(50.0f, 3.0f * get_wing_largest_radius(leader_objp, formation_object_flag) + 15.0f);
 
 	// apply debug modifications to spread size and also y scale (2x default) unless it's a custom position

--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -11428,13 +11428,12 @@ void get_absolute_wing_pos(vec3d *result_pos, object *leader_objp, int wing_inde
 {
 	vec3d	wing_delta, rotated_wing_delta;
 	float		wing_spread_size;
-	species_info* species = &Species_info[Ship_info[Ships[leader_objp->instance].ship_info_index].species];
 	int formation_index = Wings[Ships[leader_objp->instance].wingnum].formation;
 
 	if (wing_index == 0)
 		wing_delta = vmd_zero_vector;
 	else if ( formation_index != -1) 
-		wing_delta = species->formations[formation_index][wing_index - 1]; //  custom desired location in leader's reference frame
+		wing_delta = Wing_formations[formation_index].positions[wing_index - 1]; //  custom desired location in leader's reference frame
 	else 
 		get_wing_delta(&wing_delta, wing_index);		//	default desired location in leader's reference frame
 	

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -4575,11 +4575,16 @@ void parse_wing(mission *pm)
 	wingp->wave_delay_timestamp = timestamp(0);
 
 	// Use a custom formation if specified
+	species_info species = Species_info[Ship_info[Ships[wingp->ship_index[0]].ship_info_index].species];
 	if (optional_string("+Formation Index:")) {
 		stuff_int(&(wingp->formation));
+		if (wingp->formation <= -2 || wingp->formation >= (int)species.formations.size()) {
+			Warning(LOCATION, "Invalid Formation Index %d.", wingp->formation);
+			wingp->formation = species.default_formation;
+		}
 	}
-	else { // else use the retail formation
-		wingp->formation = -1;
+	else { // else use the species' default formation
+		wingp->formation = species.default_formation;
 	}
 
 	// initialize wing goals

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -4438,6 +4438,20 @@ void parse_wing(mission *pm)
 	required_string("$Special Ship:");
 	stuff_int(&wingp->special_ship);
 
+	// Use a custom formation if specified
+	if (optional_string("+Formation:")) {
+		char f[NAME_LENGTH];
+		stuff_string(f, F_NAME, NAME_LENGTH);
+
+		wingp->formation = wing_formation_lookup(f);
+		if (wingp->formation < 0) {
+			Warning(LOCATION, "Invalid Formation %s.", f);
+		}
+	}
+	else {
+		wingp->formation = -1;
+	}
+
 	wingp->arrival_anchor = -1;
 	wingp->arrival_distance = 0;
 	wingp->arrival_path_mask = -1;	// -1 only until resolved
@@ -4573,20 +4587,6 @@ void parse_wing(mission *pm)
 	// be sure to set the wave arrival timestamp of this wing to pop right away so that the
 	// wing could be created if it needs to be
 	wingp->wave_delay_timestamp = timestamp(0);
-
-	// Use a custom formation if specified
-	if (optional_string("+Formation:")) {
-		char f[NAME_LENGTH];
-		stuff_string(f, F_NAME, NAME_LENGTH);
-
-		wingp->formation = wing_formation_lookup(f);
-		if (wingp->formation < 0) {
-			Warning(LOCATION, "Invalid Formation %s.", f);
-		}
-	}
-	else {
-		wingp->formation = -1;
-	}
 
 	// initialize wing goals
 	for (i=0; i<MAX_AI_GOALS; i++) {

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -4574,6 +4574,14 @@ void parse_wing(mission *pm)
 	// wing could be created if it needs to be
 	wingp->wave_delay_timestamp = timestamp(0);
 
+	// Use a custom formation if specified
+	if (optional_string("+Formation Index:")) {
+		stuff_int(&(wingp->formation));
+	}
+	else { // else use the retail formation
+		wingp->formation = -1;
+	}
+
 	// initialize wing goals
 	for (i=0; i<MAX_AI_GOALS; i++) {
 		wingp->ai_goals[i].ai_mode = AI_GOAL_NONE;

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -4575,16 +4575,17 @@ void parse_wing(mission *pm)
 	wingp->wave_delay_timestamp = timestamp(0);
 
 	// Use a custom formation if specified
-	species_info species = Species_info[Ship_info[Ships[wingp->ship_index[0]].ship_info_index].species];
-	if (optional_string("+Formation Index:")) {
-		stuff_int(&(wingp->formation));
-		if (wingp->formation <= -2 || wingp->formation >= (int)species.formations.size()) {
-			Warning(LOCATION, "Invalid Formation Index %d.", wingp->formation);
-			wingp->formation = species.default_formation;
+	if (optional_string("+Formation:")) {
+		char f[NAME_LENGTH];
+		stuff_string(f, F_NAME, NAME_LENGTH);
+
+		wingp->formation = wing_formation_lookup(f);
+		if (wingp->formation < 0) {
+			Warning(LOCATION, "Invalid Formation %s.", f);
 		}
 	}
-	else { // else use the species' default formation
-		wingp->formation = species.default_formation;
+	else {
+		wingp->formation = -1;
 	}
 
 	// initialize wing goals

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -551,6 +551,8 @@ static int Missile_out_snd_timer;	// timer so we play out of laser sound effect 
 
 SCP_vector<ship_counts>	Ship_type_counts;
 
+SCP_vector<wing_formation> Wing_formations;
+
 // I don't want to do an AI cargo check every frame, so I made a global timer to limit check to
 // every SHIP_CARGO_CHECK_INTERVAL ms.  Didn't want to make a timer in each ship struct.  Ensure
 // inited to 1 at mission start.

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -1441,6 +1441,15 @@ typedef struct ship_counts {
 extern SCP_vector<ship_counts> Ship_type_counts;
 
 
+// Formations
+typedef struct wing_formation {
+	char name[NAME_LENGTH];
+	std::array<vec3d, MAX_SHIPS_PER_WING - 1> positions;	// does NOT include wing leader, so index 0 for each formation is the second in the wing, 1 is third, etc
+} wing_formation;
+
+SCP_vector<wing_formation> Wing_formations;
+
+
 // Use the below macros when you want to find the index of an array element in the
 // Wings[] or Ships[] arrays.
 #define WING_INDEX(wingp) ((int)(wingp-Wings))
@@ -1527,6 +1536,7 @@ inline int ship_info_size()
 }
 
 extern int wing_lookup(const char *name);
+extern int wing_formation_lookup(const char *formation_name);
 
 // returns 0 if no conflict, 1 if conflict, -1 on some kind of error with wing struct
 extern int wing_has_conflicting_teams(int wing_index);

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -1408,7 +1408,7 @@ typedef struct wing {
 	// and it also makes practical sense: no wing has two different squadrons in it :)
 	int wing_insignia_texture;
 
-	// if -1, retail formation, else a custom one defined by the species
+	// if -1, retail formation, else a custom one defined in ships.tbl
 	int formation;
 } wing;
 

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -1407,6 +1407,9 @@ typedef struct wing {
 	// of stuff that needs to be sitting in memory at once - each ship uses the wing texture;
 	// and it also makes practical sense: no wing has two different squadrons in it :)
 	int wing_insignia_texture;
+
+	// if -1, retail formation, else a custom one defined by the species
+	int formation;
 } wing;
 
 extern wing Wings[MAX_WINGS];

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -1447,7 +1447,7 @@ typedef struct wing_formation {
 	std::array<vec3d, MAX_SHIPS_PER_WING - 1> positions;	// does NOT include wing leader, so index 0 for each formation is the second in the wing, 1 is third, etc
 } wing_formation;
 
-SCP_vector<wing_formation> Wing_formations;
+extern SCP_vector<wing_formation> Wing_formations;
 
 
 // Use the below macros when you want to find the index of an array element in the

--- a/code/species_defs/species_defs.cpp
+++ b/code/species_defs/species_defs.cpp
@@ -334,7 +334,7 @@ void parse_species_tbl(const char *filename)
 					SCP_vector<vec3d> current_formation;
 
 					if (stuff_vec3d_list(current_formation) != MAX_SHIPS_PER_WING - 1) {
-						Warning(LOCATION, "A custom formation for species %s did not have %d positions. Ignoring.", species->species_name, MAX_SHIPS_PER_WING-1);
+						Warning(LOCATION, "A custom formation for species %s did not have " SIZE_T_ARG " positions. Ignoring.", species->species_name, (size_t)(MAX_SHIPS_PER_WING-1));
 					} else {
 						species->formations.emplace_back();
 						std::copy_n(current_formation.begin(), MAX_SHIPS_PER_WING-1, species->formations.back().begin());

--- a/code/species_defs/species_defs.cpp
+++ b/code/species_defs/species_defs.cpp
@@ -334,7 +334,7 @@ void parse_species_tbl(const char *filename)
 					SCP_vector<vec3d> current_formation;
 
 					if (stuff_vec3d_list(current_formation) != MAX_SHIPS_PER_WING - 1) {
-						Warning(LOCATION, "A custom formation for species %s did not have 5 positions. Ignoring.", species->species_name);
+						Warning(LOCATION, "A custom formation for species %s did not have %d positions. Ignoring.", species->species_name, MAX_SHIPS_PER_WING-1);
 					} else {
 						species->formations.emplace_back();
 						std::copy_n(current_formation.begin(), MAX_SHIPS_PER_WING-1, species->formations.back().begin());

--- a/code/species_defs/species_defs.cpp
+++ b/code/species_defs/species_defs.cpp
@@ -346,7 +346,7 @@ void parse_species_tbl(const char *filename)
 				else {
 					stuff_int(&species->default_formation);
 
-					if (species->default_formation >= species->formations.size() || species->default_formation <= -2) {
+					if (species->default_formation >= (int)species->formations.size() || species->default_formation <= -2) {
 						Warning(LOCATION, "Invalid default formation index for species %s. Ignoring.", species->species_name);
 						species->default_formation = -1;
 					}

--- a/code/species_defs/species_defs.cpp
+++ b/code/species_defs/species_defs.cpp
@@ -328,6 +328,30 @@ void parse_species_tbl(const char *filename)
 			if (optional_string("$Countermeasure type:"))
 				stuff_string(species->cmeasure_name, F_NAME, NAME_LENGTH);
 
+			if (optional_string("$Custom wingmate relative positions:")) {
+
+				int wing_index = 1;
+
+				while (check_for_string("(")) {
+
+					if (wing_index >= MAX_SHIPS_PER_WING)
+					{
+						Warning(LOCATION, "Species %s : Custom wing positions cannot exceed %d.  Ignoring the rest...", species_name, MAX_SHIPS_PER_WING);
+						break;
+					}
+
+					if (stuff_float_list(species->wing_positions[wing_index-1].a1d, 3) != 3) {
+						Warning(LOCATION, "Species %s : Incorrect position definition, each wing position must have an x, y and z coordinate.", species_name);
+						break;
+					}
+
+
+					wing_index++;
+				}
+
+				species->custom_wing_positions = wing_index;
+			}
+
 			// don't add new entry if this is just a modified one
 			if (!no_create)
 				Species_info.push_back(new_species);

--- a/code/species_defs/species_defs.cpp
+++ b/code/species_defs/species_defs.cpp
@@ -331,10 +331,13 @@ void parse_species_tbl(const char *filename)
 			if (optional_string("$Custom wingmate formations:")) {
 
 				while (check_for_string("(")) {
-					species->formations.emplace_back();
-					if (stuff_vec3d_list(species->formations.back().data(), MAX_SHIPS_PER_WING - 1) != MAX_SHIPS_PER_WING - 1) {
+					SCP_vector<vec3d> current_formation;
+
+					if (stuff_vec3d_list(current_formation) != MAX_SHIPS_PER_WING - 1) {
 						Warning(LOCATION, "A custom formation for species %s did not have 5 positions. Ignoring.", species->species_name);
-						species->formations.pop_back();
+					} else {
+						species->formations.emplace_back();
+						std::copy_n(current_formation.begin(), MAX_SHIPS_PER_WING-1, species->formations.back().begin());
 					}
 				}
 			}

--- a/code/species_defs/species_defs.cpp
+++ b/code/species_defs/species_defs.cpp
@@ -328,33 +328,6 @@ void parse_species_tbl(const char *filename)
 			if (optional_string("$Countermeasure type:"))
 				stuff_string(species->cmeasure_name, F_NAME, NAME_LENGTH);
 
-			if (optional_string("$Custom wingmate formations:")) {
-
-				while (check_for_string("(")) {
-					SCP_vector<vec3d> current_formation;
-
-					if (stuff_vec3d_list(current_formation) != MAX_SHIPS_PER_WING - 1) {
-						Warning(LOCATION, "A custom formation for species %s did not have " SIZE_T_ARG " positions. Ignoring.", species->species_name, (size_t)(MAX_SHIPS_PER_WING-1));
-					} else {
-						species->formations.emplace_back();
-						std::copy_n(current_formation.begin(), MAX_SHIPS_PER_WING-1, species->formations.back().begin());
-					}
-				}
-			}
-
-			if (optional_string("$Default formation index:")) {
-				if (species->formations.empty()) {
-					Warning(LOCATION, "A default formation index was provided for species %s but no formations are defined.", species->species_name);
-				}
-				else {
-					stuff_int(&species->default_formation);
-
-					if (species->default_formation >= (int)species->formations.size() || species->default_formation <= -2) {
-						Warning(LOCATION, "Invalid default formation index for species %s. Ignoring.", species->species_name);
-						species->default_formation = -1;
-					}
-				}
-			}
 
 			// don't add new entry if this is just a modified one
 			if (!no_create)

--- a/code/species_defs/species_defs.h
+++ b/code/species_defs/species_defs.h
@@ -75,6 +75,11 @@ public:
 	char cmeasure_name[NAME_LENGTH];
 	int cmeasure_index;
 
+	// if 0, default positions
+	int custom_wing_positions;
+	// does NOT include wing leader, so index 0 is the second in the wing, 1 is third, etc
+	vec3d wing_positions[MAX_SHIPS_PER_WING-1];
+
 	species_info()
 	{
 		for (int i = 0; i < MIN_BRIEF_ICONS; i++)

--- a/code/species_defs/species_defs.h
+++ b/code/species_defs/species_defs.h
@@ -87,6 +87,7 @@ public:
 
 		cmeasure_name[0] = '\0';
 		cmeasure_index = -1;
+		default_formation = -1;
 	}
 };
 

--- a/code/species_defs/species_defs.h
+++ b/code/species_defs/species_defs.h
@@ -75,10 +75,10 @@ public:
 	char cmeasure_name[NAME_LENGTH];
 	int cmeasure_index;
 
-	// if 0, default positions
-	int custom_wing_positions;
-	// does NOT include wing leader, so index 0 is the second in the wing, 1 is third, etc
-	vec3d wing_positions[MAX_SHIPS_PER_WING-1];
+
+	// does NOT include wing leader, so index 0 for each formation is the second in the wing, 1 is third, etc
+	SCP_vector<std::array<vec3d, MAX_SHIPS_PER_WING - 1>> formations;
+	int default_formation;
 
 	species_info()
 	{

--- a/code/species_defs/species_defs.h
+++ b/code/species_defs/species_defs.h
@@ -75,11 +75,6 @@ public:
 	char cmeasure_name[NAME_LENGTH];
 	int cmeasure_index;
 
-
-	// does NOT include wing leader, so index 0 for each formation is the second in the wing, 1 is third, etc
-	SCP_vector<std::array<vec3d, MAX_SHIPS_PER_WING - 1>> formations;
-	int default_formation;
-
 	species_info()
 	{
 		for (int i = 0; i < MIN_BRIEF_ICONS; i++)
@@ -87,7 +82,6 @@ public:
 
 		cmeasure_name[0] = '\0';
 		cmeasure_index = -1;
-		default_formation = -1;
 	}
 };
 

--- a/fred2/fred.rc
+++ b/fred2/fred.rc
@@ -1143,7 +1143,7 @@ BEGIN
     CONTROL         "Spin2",IDC_SPIN_WAVE_THRESHOLD,"msctls_updown32",UDS_SETBUDDYINT | UDS_ALIGNRIGHT | UDS_AUTOBUDDY | UDS_ARROWKEYS,127,53,11,15
     COMBOBOX        IDC_HOTKEY,65,70,73,115,CBS_DROPDOWNLIST | WS_VSCROLL | WS_TABSTOP
     PUSHBUTTON      "Squad Logo",IDC_WING_SQUAD_LOGO_BUTTON,7,89,55,14
-    EDITTEXT        IDC_WING_SQUAD_LOGO,65,90,98,14,ES_AUTOHSCROLL | ES_READONLY
+    EDITTEXT        IDC_WING_SQUAD_LOGO,65,90,80,14,ES_AUTOHSCROLL | ES_READONLY
     CONTROL         "Reinforcement Unit",IDC_REINFORCEMENT,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,143,16,77,10
     CONTROL         "Ignore for Counting Goals",IDC_IGNORE_COUNT,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,143,27,96,10
     CONTROL         "No Arrival Music",IDC_NO_ARRIVAL_MUSIC,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,143,38,67,10
@@ -1194,6 +1194,8 @@ BEGIN
     PUSHBUTTON      "Restrict Departure Paths",IDC_RESTRICT_DEPARTURE,160,223,123,14,0,WS_EX_STATICEDGE
     PUSHBUTTON      "Custom Warp-in Parameters",IDC_CUSTOM_WARPIN_PARAMS,15,240,122,14,0,WS_EX_STATICEDGE
     PUSHBUTTON      "Custom Warp-out Parameters",IDC_CUSTOM_WARPOUT_PARAMS,160,240,123,14,0,WS_EX_STATICEDGE
+    COMBOBOX        IDC_WING_FORMATION,192,89,99,127,CBS_DROPDOWNLIST | WS_VSCROLL | WS_TABSTOP
+    LTEXT           "Formation",IDC_STATIC,154,92,34,8
 END
 
 IDD_OPERATOR_ARGUMENT_TYPES DIALOG 0, 0, 235, 50
@@ -2898,7 +2900,14 @@ BEGIN
     ID_EDIT_SELECT_ALL      "Select the entire document\nSelect All"
     ID_EDIT_UNDO            "Undo the last action\nUndo"
     ID_EDIT_REDO            "Redo the previously undone action\nRedo"
-    ID_EDIT_CLONEMARKEDOBJECTS  "Clone every marked object in-place, like Ctrl-drag without the dragging"
+END
+
+STRINGTABLE
+BEGIN
+    ID_MISC_MOVESHIPSWHENUNDOCKING 
+                            "When setting initially docked ships to initially undocked, move the smaller ship away from the dockpoint by one ship length"
+    ID_EDIT_CLONEMARKEDOBJECTS 
+                            "Clone every marked object in-place, like Ctrl-drag without the dragging"
 END
 
 STRINGTABLE
@@ -3021,6 +3030,7 @@ BEGIN
     ID_SHOW_GRID_POSITIONS  "Draw an elevation line above or below the grid plane for all visible objects"
     ID_SHOW_COORDINATES     "Display the coordinates of objects/waypoints."
     ID_SELECT_LIST          "Select from List\nSelect List (H)"
+    ID_CONSTRAIN_Y          "Constrain movement to global Y axis\nY Constraint"
     ID_ZOOM                 "Zoom view in/out\nZoom Mode"
     ID_SELECTION_LOCK       "Selection Lock\nSelection Lock (Spacebar)"
     ID_DISSOLVE_WING        "Remove selected ships from Wing(s)\nRemove from Wing"
@@ -3031,11 +3041,8 @@ BEGIN
     ID_SELECT_AND_MOVE      "Select and Move objects\nSelect and Move (M)"
     ID_SELECT_AND_ROTATE    "Select and Rotate objects\nSelect and Rotate (R)"
     ID_CONSTRAIN_X          "Constrain movement to global X axis\nX Constraint"
-    ID_CONSTRAIN_Y          "Constrain movement to global Y axis\nY Constraint"
     ID_CONSTRAIN_Z          "Constrain movement to global Z axis\nZ Constraint"
     ID_CONSTRAIN_XZ         "Constrain movement to global XZ plane\nXZ Constraint"
-    ID_CONSTRAIN_YZ         "Constrain movement to global YZ plane\nYZ Constraint"
-    ID_CONSTRAIN_XY         "Constrain movement to global XY plane\nXY Constraint"
     ID_FORM_WING            "Form marked ships into Wing\nForm Wing (Ctrl+W)"
     ID_DISBAND_WING         "Take marked ships out of wing\nDisband Wing (Ctrl+D)"
     ID_SHOW_DISTANCED       "Show distances between marked objects"
@@ -3046,6 +3053,8 @@ END
 
 STRINGTABLE
 BEGIN
+    ID_CONSTRAIN_YZ         "Constrain movement to global YZ plane\nYZ Constraint"
+    ID_CONSTRAIN_XY         "Constrain movement to global XY plane\nXY Constraint"
     ID_FLYING_CONTROLS      "Use real time flying controls instead of stepped controls"
     ID_SELECT_AND_ROTATE_LOCALLY "Rotate objects locally\nRotate Locally"
     ID_ROTATE_LOCALLY       "Rotate around local object's axis system\nRotate locally (X)"
@@ -3077,12 +3086,11 @@ END
 
 STRINGTABLE
 BEGIN
-    ID_LEVEL_OBJ            "Rotate object (or camera if no objects are marked) so that its Y-axis matches the grid's normal vector"
-    ID_ALIGN_OBJ            "Align object (or camera if no objects are marked) X/Y/Z axes with the global axes that are closest"
-    ID_MARK_WING            "Mark the entire wing that contains the currently marked object"
     ID_EDITORS_ADJUST_GRID  "Adjust the orientation and level of the grid"
-    ID_MISC_MOVESHIPSWHENUNDOCKING  "When setting initially docked ships to initially undocked, move the smaller ship away from the dockpoint by one ship length"
     ID_EDITORS_SHIELD_SYS   "Editor for availability of shield system for ships"
+    ID_ALIGN_OBJ            "Align object (or camera if no objects are marked) X/Y/Z axes with the global axes that are closest"
+    ID_LEVEL_OBJ            "Rotate object (or camera if no objects are marked) so that its Y-axis matches the grid's normal vector"
+    ID_MARK_WING            "Mark the entire wing that contains the currently marked object"
 END
 
 STRINGTABLE

--- a/fred2/missionsave.cpp
+++ b/fred2/missionsave.cpp
@@ -4320,6 +4320,20 @@ int CFred_mission_save::save_wings()
 			fout(" %d", Wings[i].wave_delay_max);
 		}
 
+		if (Mission_save_format != FSO_FORMAT_RETAIL) {
+			if (Wings[i].formation > -1)
+			{
+				if (optional_string_fred("+Formation Index:", "$Name:")) {
+					parse_comments();
+				}
+				else {
+					fout("\n+Formation Index:");
+				}
+
+				fout(" %d", Wings[i].formation);
+			}
+		}
+
 		fso_comment_pop();
 	}
 

--- a/fred2/missionsave.cpp
+++ b/fred2/missionsave.cpp
@@ -4134,8 +4134,22 @@ int CFred_mission_save::save_wings()
 
 		required_string_fred("$Special Ship:");
 		parse_comments();
-		fout(" %d\t\t;! %s\n", Wings[i].special_ship,
+		fout(" %d\t\t;! %s", Wings[i].special_ship,
 			 Ships[Wings[i].ship_index[Wings[i].special_ship]].ship_name);
+
+		if (Mission_save_format != FSO_FORMAT_RETAIL) {
+			if (Wings[i].formation >= 0 && Wings[i].formation < (int)Wing_formations.size())
+			{
+				if (optional_string_fred("+Formation:", "$Name:")) {
+					parse_comments();
+				}
+				else {
+					fout("\n+Formation:");
+				}
+
+				fout(" %s", Wing_formations[Wings[i].formation].name);
+			}
+		}
 
 		required_string_fred("$Arrival Location:");
 		parse_comments();
@@ -4318,20 +4332,6 @@ int CFred_mission_save::save_wings()
 				fout("\n+Wave Delay Max:");
 
 			fout(" %d", Wings[i].wave_delay_max);
-		}
-
-		if (Mission_save_format != FSO_FORMAT_RETAIL) {
-			if (Wings[i].formation > -1)
-			{
-				if (optional_string_fred("+Formation Index:", "$Name:")) {
-					parse_comments();
-				}
-				else {
-					fout("\n+Formation Index:");
-				}
-
-				fout(" %d", Wings[i].formation);
-			}
 		}
 
 		fso_comment_pop();

--- a/fred2/resource.h
+++ b/fred2/resource.h
@@ -543,6 +543,7 @@
 #define IDC_FILTER_SHIPS_IFF_8          1225
 #define IDC_DEPARTURE_CUE2              1226
 #define IDC_FILTER_SHIPS_IFF_9          1226
+#define IDC_WING_FORMATION              1226
 #define IDC_ARRIVAL_TREE                1227
 #define IDC_DEPARTURE_TREE              1228
 #define ID_NUMBERS                      1229

--- a/fred2/wing.cpp
+++ b/fred2/wing.cpp
@@ -176,6 +176,7 @@ int create_wing() {
 
 		Wings[wing].num_waves = 1;
 		Wings[wing].threshold = 0;
+		Wings[wing].formation = -1;
 		Wings[wing].arrival_location = Wings[wing].departure_location = 0;
 		Wings[wing].arrival_distance = 0;
 		Wings[wing].arrival_anchor = -1;

--- a/fred2/wing.cpp
+++ b/fred2/wing.cpp
@@ -33,27 +33,6 @@ static char THIS_FILE[] = __FILE__;
 #endif
 #define MULTI_WING	999999
 
-/**
- * @brief 8 Vectors per formation. Possible to have more than 8 ships.
- *
- * @details  A vector is where a ship is located relative to the leader.  Other ships can be located at the same
- * vector relative to another member.  So wing formation size is not limited by this constant.
- */
-#define MAX_WING_VECTORS    8
-
-/**
- * @brief 8 different kinds of wing formations
- */
-#define MAX_WING_FORMATIONS 8
-
-typedef struct formation
-{
-	int		num_vectors;
-	vec3d	offsets[MAX_WING_VECTORS];
-} formation;
-
-formation Wing_formations[MAX_WING_FORMATIONS];
-
 int already_deleting_wing = 0;
 int Wings_initialized = 0;
 
@@ -422,16 +401,6 @@ void initialize_wings(void) {
 		return;
 
 	Wings_initialized = 1;
-
-	Wing_formations[0].num_vectors = 2;
-
-	Wing_formations[0].offsets[0].xyz.x = -5.0f;
-	Wing_formations[0].offsets[0].xyz.y = +1.0f;
-	Wing_formations[0].offsets[0].xyz.z = -5.0f;
-
-	Wing_formations[0].offsets[1].xyz.x = +5.0f;
-	Wing_formations[0].offsets[1].xyz.y = +1.0f;
-	Wing_formations[0].offsets[1].xyz.z = -5.0f;
 }
 
 void mark_wing(int wing)

--- a/fred2/wing_editor.cpp
+++ b/fred2/wing_editor.cpp
@@ -44,6 +44,7 @@ wing_editor::wing_editor(CWnd* pParent /*=NULL*/)
 	m_special_ship = -1;
 	m_waves = 0;
 	m_threshold = 0;
+	m_formation = 0;	// retail formation (no formation) is -1, but it's the 0-offset in the combo box
 	m_arrival_location = -1;
 	m_departure_location = -1;
 	m_arrival_delay = 0;
@@ -82,6 +83,7 @@ void wing_editor::DoDataExchange(CDataExchange* pDX)
 	DDX_Text(pDX, IDC_WING_NAME, m_wing_name);
 	DDX_Text(pDX, IDC_WING_SQUAD_LOGO, m_wing_squad_filename);
 	DDX_CBIndex(pDX, IDC_WING_SPECIAL_SHIP, m_special_ship);
+	DDX_CBIndex(pDX, IDC_WING_FORMATION, m_formation);
 	DDX_CBIndex(pDX, IDC_ARRIVAL_LOCATION, m_arrival_location);
 	DDX_CBIndex(pDX, IDC_DEPARTURE_LOCATION, m_departure_location);
 	DDX_Check(pDX, IDC_REINFORCEMENT, m_reinforcement);
@@ -179,6 +181,13 @@ BOOL wing_editor::Create()
 	CComboBox *box;
 
 	r = CDialog::Create(IDD, Fred_main_wnd);
+
+	box = (CComboBox *)GetDlgItem(IDC_WING_FORMATION);
+	box->ResetContent();
+	box->AddString("Retail");
+	for (auto &f : Wing_formations)
+		box->AddString(f.name);
+
 	box = (CComboBox *) GetDlgItem(IDC_ARRIVAL_LOCATION);
 	box->ResetContent();
 	for (i=0; i<MAX_ARRIVAL_NAMES; i++)
@@ -263,6 +272,7 @@ void wing_editor::initialize_data_safe(int full_update)
 	if (cur_wing < 0) {
 		m_wing_squad_filename = _T("");
 		m_special_ship = -1;
+		m_formation = 0;
 		m_arrival_location = -1;
 		m_departure_location = -1;
 		m_arrival_delay = 0;
@@ -322,6 +332,7 @@ void wing_editor::initialize_data_safe(int full_update)
 		m_special_ship = Wings[cur_wing].special_ship;
 		m_waves = Wings[cur_wing].num_waves;
 		m_threshold = Wings[cur_wing].threshold;
+		m_formation = Wings[cur_wing].formation + 1;
 		m_arrival_location = Wings[cur_wing].arrival_location;
 		m_departure_location = Wings[cur_wing].departure_location;
 		m_arrival_delay = Wings[cur_wing].arrival_delay;
@@ -430,8 +441,10 @@ void wing_editor::initialize_data_safe(int full_update)
 	GetDlgItem(IDC_DISBAND_WING)->EnableWindow(enable);
 	GetDlgItem(IDC_SPIN_WAVES)->EnableWindow(player_enabled);
 	GetDlgItem(IDC_SPIN_WAVE_THRESHOLD)->EnableWindow(player_enabled);
-	GetDlgItem(IDC_ARRIVAL_LOCATION)->EnableWindow(enable);
 
+	GetDlgItem(IDC_WING_FORMATION)->EnableWindow(enable);
+
+	GetDlgItem(IDC_ARRIVAL_LOCATION)->EnableWindow(enable);
 	GetDlgItem(IDC_ARRIVAL_DELAY)->EnableWindow(player_enabled);
 	GetDlgItem(IDC_ARRIVAL_DELAY_MIN)->EnableWindow(player_enabled);
 	GetDlgItem(IDC_ARRIVAL_DELAY_MAX)->EnableWindow(player_enabled);
@@ -777,6 +790,7 @@ void wing_editor::update_data_safe()
 	MODIFY(Wings[cur_wing].special_ship, m_special_ship);
 	MODIFY(Wings[cur_wing].num_waves, m_waves);
 	MODIFY(Wings[cur_wing].threshold, m_threshold);
+	MODIFY(Wings[cur_wing].formation, m_formation - 1);
 	MODIFY(Wings[cur_wing].arrival_location, m_arrival_location);
 	MODIFY(Wings[cur_wing].departure_location, m_departure_location);
 	MODIFY(Wings[cur_wing].arrival_delay, m_arrival_delay);

--- a/fred2/wing_editor.h
+++ b/fred2/wing_editor.h
@@ -47,6 +47,7 @@ public:
 	int		m_special_ship;
 	int		m_waves;
 	int		m_threshold;
+	int		m_formation;
 	int		m_arrival_location;
 	int		m_departure_location;
 	int		m_arrival_delay;

--- a/qtfred/src/mission/missionsave.cpp
+++ b/qtfred/src/mission/missionsave.cpp
@@ -4297,6 +4297,20 @@ int CFred_mission_save::save_wings()
 			fout(" %d", Wings[i].wave_delay_max);
 		}
 
+		if (save_format != MissionFormat::RETAIL) {
+			if (Wings[i].formation > -1)
+			{
+				if (optional_string_fred("+Formation Index:", "$Name:")) {
+					parse_comments();
+				}
+				else {
+					fout("\n+Formation Index:");
+				}
+
+				fout(" %d", Wings[i].formation);
+			}
+		}
+
 		fso_comment_pop();
 	}
 

--- a/qtfred/src/mission/missionsave.cpp
+++ b/qtfred/src/mission/missionsave.cpp
@@ -4097,7 +4097,21 @@ int CFred_mission_save::save_wings()
 
 		required_string_fred("$Special Ship:");
 		parse_comments();
-		fout(" %d\t\t;! %s\n", Wings[i].special_ship, Ships[Wings[i].ship_index[Wings[i].special_ship]].ship_name);
+		fout(" %d\t\t;! %s", Wings[i].special_ship, Ships[Wings[i].ship_index[Wings[i].special_ship]].ship_name);
+
+		if (save_format != MissionFormat::RETAIL) {
+			if (Wings[i].formation >= 0 && Wings[i].formation < (int)Wing_formations.size())
+			{
+				if (optional_string_fred("+Formation:", "$Name:")) {
+					parse_comments();
+				}
+				else {
+					fout("\n+Formation:");
+				}
+
+				fout(" %s", Wing_formations[Wings[i].formation].name);
+			}
+		}
 
 		required_string_fred("$Arrival Location:");
 		parse_comments();
@@ -4295,20 +4309,6 @@ int CFred_mission_save::save_wings()
 			}
 
 			fout(" %d", Wings[i].wave_delay_max);
-		}
-
-		if (save_format != MissionFormat::RETAIL) {
-			if (Wings[i].formation > -1)
-			{
-				if (optional_string_fred("+Formation Index:", "$Name:")) {
-					parse_comments();
-				}
-				else {
-					fout("\n+Formation Index:");
-				}
-
-				fout(" %d", Wings[i].formation);
-			}
 		}
 
 		fso_comment_pop();


### PR DESCRIPTION
Adds the "$Custom wingmate relative positions:" field to species_defs.tbl. Pretty self-explanatory, modders can now specify whatever positions they want for wingmates to occupy while formation flying. I'll be sure to note in the documentation that these are unscaled by size, and provide the retail positions for reference.