### PR TITLE
handle Hull_debris_list for dynamic debris

### DIFF
--- a/code/debris/debris.cpp
+++ b/code/debris/debris.cpp
@@ -404,7 +404,7 @@ MONITOR(NumHullDebris)
  */
 object *debris_create(object *source_obj, int model_num, int submodel_num, vec3d *pos, vec3d *exp_center, int hull_flag, float exp_force)
 {
-	int		n, objnum, parent_objnum;
+	int		objnum, parent_objnum;
 	object	*obj;
 	ship		*shipp;
 	debris	*db;	
@@ -432,27 +432,19 @@ object *debris_create(object *source_obj, int model_num, int submodel_num, vec3d
 		}
 	}
 
-	if ( hull_flag && (Num_hull_pieces >= SOFT_LIMIT_DEBRIS_PIECES ) ) {
+	// try to maintain our soft limit
+	if (hull_flag && (Num_hull_pieces >= SOFT_LIMIT_DEBRIS_PIECES)) {
 		// cause oldest hull debris chunk to blow up
-		n = debris_find_oldest();
-		if ( n >= 0 ) {
-			debris_start_death_roll(&Objects[Debris[n].objnum], &Debris[n] );
-		}
+		int oldest_n = debris_find_oldest();
+		if (oldest_n >= 0)
+			debris_start_death_roll(&Objects[Debris[oldest_n].objnum], &Debris[oldest_n]);
 	}
 
-	n = 0;
+	int n = 0;
 	for (auto &db_temp: Debris) {
 		if ( !(db_temp.flags[Debris_Flags::Used]) )
 			break;
 		++n;
-	}
-
-	// if we have too much debris, try to get rid of a piece
-	if (n >= SOFT_LIMIT_DEBRIS_PIECES) {
-		int oldest_n = debris_find_oldest();
-
-		if (oldest_n >= 0)
-			debris_start_death_roll(&Objects[Debris[oldest_n].objnum], &Debris[oldest_n]);
 	}
 
 	// we might have to create a new slot

--- a/code/debris/debris.h
+++ b/code/debris/debris.h
@@ -24,6 +24,7 @@ class model_draw_list;
 
 FLAG_LIST(Debris_Flags) {
 	Used,
+	OnHullDebrisList,
 	DoNotExpire,		// This debris piece has been placed in FRED and should not expire automatically
 
 	NUM_VALUES
@@ -31,10 +32,6 @@ FLAG_LIST(Debris_Flags) {
 
 
 typedef struct debris {
-	// used for a linked list of the hull debris chunks
-	debris	*next = nullptr;
-	debris *prev = nullptr;
-
 	flagset<Debris_Flags> flags;	// See DEBRIS_??? defines
 	int		source_objnum;			// What object this came from
 	int		damage_type_idx;		// Damage type of this debris


### PR DESCRIPTION
With dynamic debris, as soon as the Debris vector was reallocated it invalidated the `prev` and `next` pointers.  I figured out how to dispense with the actual list entirely, since we mainly need to know how many hull debris pieces there are and whether an individual piece is on the "list".

This is a follow-up to #2649.