### PR TITLE
Fix Two Multi Crash Points

### DIFF
--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -11991,12 +11991,13 @@ void ai_do_repair_frame(object *objp, ai_info *aip, float frametime)
 {
 	static bool rearm_eta_found=false;
 
-	if (Ships[objp->instance].team == Iff_traitor) {
-		ai_abort_rearm_request(objp);
-		return;
-	}
 
 	if (aip->ai_flags[AI::AI_Flags::Being_repaired, AI::AI_Flags::Awaiting_repair]) {
+		if (Ships[objp->instance].team == Iff_traitor) {
+			ai_abort_rearm_request(objp);
+			return;
+		}
+
 		int	support_objnum;
 		
 		ai_info	*repair_aip;

--- a/code/network/multiutil.cpp
+++ b/code/network/multiutil.cpp
@@ -3385,20 +3385,20 @@ void bitbuffer_put( bitbuffer *bitbuf, uint data, int bit_count )
 
 uint bitbuffer_get_unsigned( bitbuffer *bitbuf, int bit_count ) 
 {
-	uint mask;
+	uint local_mask;
 	uint return_value;
 
-	mask = 1L << ( bit_count - 1 );
+	local_mask = 1L << ( bit_count - 1 );
 	return_value = 0;
 
-	while ( mask != 0)	{
+	while ( local_mask != 0)	{
 		if ( bitbuf->mask == 0x80 ) {
 			bitbuf->rack = *bitbuf->data++;
 		}
 		if ( bitbuf->rack & bitbuf->mask )	{
-			return_value |= mask;
+			return_value |= local_mask;
 		}
-		mask >>= 1;
+		local_mask >>= 1;
 		bitbuf->mask >>= 1;
 		if ( bitbuf->mask == 0 )	{
 			bitbuf->mask = 0x80;
@@ -3410,20 +3410,19 @@ uint bitbuffer_get_unsigned( bitbuffer *bitbuf, int bit_count )
 
 int bitbuffer_get_signed( bitbuffer *bitbuf, int bit_count ) 
 {
-	uint mask;
+	uint local_mask;
 	uint return_value;
 
-	mask = 1L << ( bit_count - 1 );
+	local_mask = 1L << ( bit_count - 1 );
 	return_value = 0;
-
-	while ( mask != 0)	{
+	while ( local_mask != 0)	{
 		if ( bitbuf->mask == 0x80 ) {
 			bitbuf->rack = *bitbuf->data++;
 		}
 		if ( bitbuf->rack & bitbuf->mask )	{
-			return_value |= mask;
+			return_value |= local_mask;
 		}
-		mask >>= 1;
+		local_mask >>= 1;
 		bitbuf->mask >>= 1;
 		if ( bitbuf->mask == 0 )	{
 			bitbuf->mask = 0x80;

--- a/code/object/object.cpp
+++ b/code/object/object.cpp
@@ -619,6 +619,7 @@ void obj_delete(int objnum)
 		} else {
 			// we need to be able to delete GHOST objects in multiplayer to allow for player respawns.
 			nprintf(("Network","Deleting GHOST object\n"));
+			objp->net_signature = 0;
 		}		
 		break;
 	case OBJ_OBSERVER:


### PR DESCRIPTION
This fixes two points at which multi can crash. One is during respawn. The net_signature needs to be set to zero on Ghost Object deletion to facilitate respawn properly. (FSO can get confused between two objects with the same net_signature if it tries to look them up via net_signature, so set the dead one to 0 and the new one from the parse object will be set correctly)

The other fix is during dogfight missions and has to do with errant rearm requests (which are invalid because the player is a traitor in dogfight mode).
It is actually a fix for [Mantis 2175](http://scp.indiegames.us/mantis/view.php?id=2175
) 

From my comments on that ticket. "Checking explicitly for a rearm or repair request before canceling it for traitors is the fix. "

*These changes have been part of all builds that I have sent out during the entire multi testing period.*  I just got good enough at git to separate them from unrelated waypoint changes that require a multi bump.

This also has some variable renames in multi_util.cpp which make a few functions much more readable.  Those can be dropped easily on request.