### PR TITLE
handle audio pause/unpause for all of the F2 screens

### DIFF
--- a/code/menuui/optionsmenu.cpp
+++ b/code/menuui/optionsmenu.cpp
@@ -901,13 +901,6 @@ void options_menu_init()
 
 	Assert(!Options_menu_inited);
 
-	// pause all sounds, since we could get here through the game
-	weapon_pause_sounds();
-	// only pause music if we're in-mission; we could also be in the main hall
-	if (Game_mode & GM_IN_MISSION) {
-		audiostream_pause_all();
-	}
-
 	Tab = 0;
 	Gamma_last_set = -1;
 
@@ -1035,18 +1028,9 @@ void options_menu_close()
 	Pilot.save_savefile();
 	game_flush();
 	
-	// unpause all sounds, since we could be headed back to the game
-	weapon_unpause_sounds();
-	// only unpause music if we're in-mission; we could also be in the main hall
-	if (Game_mode & GM_IN_MISSION) {
-		audiostream_unpause_all();
-	}
-	
 	Options_menu_inited = 0;
 	Options_multi_inited = 0;
 	Options_detail_inited = 0;
-
-
 }
 
 

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -5069,11 +5069,20 @@ void game_leave_state( int old_state, int new_state )
 			break;
 
 		case GS_STATE_OPTIONS_MENU:
-			//game_start_time();
 			if(new_state == GS_STATE_MULTI_JOIN_GAME){
 				multi_join_clear_game_list();
 			}
+
 			options_menu_close();
+
+			if (new_state != GS_STATE_CONTROL_CONFIG && new_state != GS_STATE_HUD_CONFIG) {
+				// unpause all sounds, since we could be headed back to the game
+				// only unpause if we're in-mission; we could also be in the main hall
+				if (Game_mode & GM_IN_MISSION) {
+					weapon_unpause_sounds();
+					audiostream_unpause_all();
+				}
+			}
 			break;
 
 		case GS_STATE_BARRACKS_MENU:
@@ -5529,6 +5538,15 @@ void game_enter_state( int old_state, int new_state )
 
 		case GS_STATE_OPTIONS_MENU:
 			options_menu_init();
+
+			if (old_state != GS_STATE_CONTROL_CONFIG && old_state != GS_STATE_HUD_CONFIG) {
+				// pause all sounds, since we could get here through the game
+				// only pause if we're in-mission; we could also be in the main hall
+				if (Game_mode & GM_IN_MISSION) {
+					weapon_pause_sounds();
+					audiostream_pause_all();
+				}
+			}
 			break;
  
 		case GS_STATE_GAME_PLAY:


### PR DESCRIPTION
This is a follow-up to #2100.  Don't pause/unpause the audio if we are moving from/to the Control Config or HUD Config screens.  We could hit F2 and move around a bit before resuming the game, so we don't want the audio to resume until we're ready.