### PR TITLE
Don't add --gc-sections linker arg on SunOS

### DIFF
--- a/cmake/toolchain-gcc.cmake
+++ b/cmake/toolchain-gcc.cmake
@@ -139,7 +139,7 @@ IF(NOT MINGW)
 	# Allow the linker to perform dead code elimination; this is considered
 	# experimental for COFF and PE formats and thus disabled for Windows builds
 	# (https://sourceware.org/binutils/docs/ld/Options.html)
-	if (NOT GCC_INCREMENTAL_LINKING)
+	if (NOT GCC_INCREMENTAL_LINKING AND NOT ${CMAKE_SYSTEM_NAME} MATCHES "SunOS")
 		SET(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--gc-sections")
 	endif()
 ENDIF(NOT MINGW)


### PR DESCRIPTION
gc-sections is misbehaving on SunOS since #2669, so skip the part that adds it to restore old behavior unless a proper fix can be found.

The linker flags for SunOS were previously just hardcoded, not using any previously defined variable.  Now it is appending instead, and the --gc-sections flag that it appends is causing it to break due to something with Threads.

```
CMake Error at freespace2/CMakeLists.txt:22 (ADD_EXECUTABLE):
  Target "Freespace2" links to target "Threads::Threads" but the target was
  not found.  Perhaps a find_package() call is missing for an IMPORTED
  target, or an ALIAS target is missing?


CMake Error at freespace2/CMakeLists.txt:22 (ADD_EXECUTABLE):
  Target "Freespace2" links to target "Threads::Threads" but the target was
  not found.  Perhaps a find_package() call is missing for an IMPORTED
  target, or an ALIAS target is missing?


CMake Error at lib/discord/src/CMakeLists.txt:42 (add_library):
  Target "discord-rpc" links to target "Threads::Threads" but the target was
  not found.  Perhaps a find_package() call is missing for an IMPORTED
  target, or an ALIAS target is missing?


CMake Error at code/CMakeLists.txt:6 (ADD_LIBRARY):
  Target "code" links to target "Threads::Threads" but the target was not
  found.  Perhaps a find_package() call is missing for an IMPORTED target, or
  an ALIAS target is missing?


-- Generating done
CMake Generate step failed.  Build files cannot be regenerated correctly.
```