### PR TITLE
Fix 2526 and Add Two Game_setting.tbl flags

### DIFF
--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -50,6 +50,8 @@ bool Disable_built_in_translations;
 bool Weapon_shockwaves_respect_huge;
 bool Using_in_game_options;
 float Dinky_shockwave_default_multiplier;
+bool Shockwaves_always_damage_bombs;
+bool Shockwaves_damage_all_obj_types_once;
 std::tuple<ubyte, ubyte, ubyte> Arc_color_damage_p1;
 std::tuple<ubyte, ubyte, ubyte> Arc_color_damage_p2;
 std::tuple<ubyte, ubyte, ubyte> Arc_color_damage_s1;
@@ -538,6 +540,14 @@ void parse_mod_table(const char *filename)
 			}
 		}
 
+		if (optional_string("$Shockwaves Always Damage Bombs:")) {
+			stuff_boolean(&Shockwaves_always_damage_bombs);
+		}
+
+		if (optional_string("$Shockwaves Damage All Object Types Once:")) {
+			stuff_boolean(&Shockwaves_damage_all_obj_types_once);
+		}
+
 		if (optional_string("$Use Engine Wash Intensity:")) {
 			stuff_boolean(&Use_engine_wash_intensity);
 		}
@@ -611,6 +621,8 @@ void mod_table_reset()
 	Weapon_shockwaves_respect_huge = false;
 	Using_in_game_options = false;
 	Dinky_shockwave_default_multiplier = 1.0f;
+	Shockwaves_always_damage_bombs = false;
+	Shockwaves_damage_all_obj_types_once = false;
 	Arc_color_damage_p1 = std::make_tuple(static_cast<ubyte>(64), static_cast<ubyte>(64), static_cast<ubyte>(225));
 	Arc_color_damage_p2 = std::make_tuple(static_cast<ubyte>(128), static_cast<ubyte>(128), static_cast<ubyte>(255));
 	Arc_color_damage_s1 = std::make_tuple(static_cast<ubyte>(200), static_cast<ubyte>(200), static_cast<ubyte>(255));

--- a/code/mod_table/mod_table.h
+++ b/code/mod_table/mod_table.h
@@ -42,6 +42,8 @@ extern bool Disable_built_in_translations;
 extern bool Weapon_shockwaves_respect_huge;
 extern bool Using_in_game_options;
 extern float Dinky_shockwave_default_multiplier;
+extern bool Shockwaves_always_damage_bombs;
+extern bool Shockwaves_damage_all_obj_types_once;
 extern std::tuple<ubyte, ubyte, ubyte> Arc_color_damage_p1;
 extern std::tuple<ubyte, ubyte, ubyte> Arc_color_damage_p2;
 extern std::tuple<ubyte, ubyte, ubyte> Arc_color_damage_s1;

--- a/code/weapon/shockwave.cpp
+++ b/code/weapon/shockwave.cpp
@@ -128,7 +128,7 @@ int shockwave_create(int parent_objnum, vec3d* pos, shockwave_create_info* sci, 
 	sw->blast = sci->blast;
 	sw->radius = 1.0f;
 	sw->pos = *pos;
-	sw->num_objs_hit = 0;
+	sw->obj_sig_hitlist.clear();
 	sw->shockwave_info_index = info_index;		// only one type for now... type could be passed is as a parameter
 	sw->current_bitmap = -1;
 
@@ -246,7 +246,6 @@ void shockwave_move(object *shockwave_objp, float frametime)
 	shockwave	*sw;
 	object		*objp;
 	float			blast,damage;
-	int			i;
 
 	Assertion(shockwave_objp->type == OBJ_SHOCKWAVE, "shockwave_move() called on an object of type %d instead of OBJ_SHOCKWAVE (%d); get a coder!\n", shockwave_objp->type, OBJ_SHOCKWAVE);
 	Assertion(shockwave_objp->instance  >= 0 && shockwave_objp->instance < MAX_SHOCKWAVES, "shockwave_move() called on an object with an instance of %d (should be 0-%d); get a coder!\n", shockwave_objp->instance, MAX_SHOCKWAVES - 1);
@@ -285,7 +284,7 @@ void shockwave_move(object *shockwave_objp, float frametime)
 			if (wip->weapon_hitpoints <= 0)
 				continue;
 
-			if (!(wip->wi_flags[Weapon::Info_Flags::Takes_shockwave_damage] || (sw->weapon_info_index >= 0 && Weapon_info[sw->weapon_info_index].wi_flags[Weapon::Info_Flags::Ciws])))
+			if (!Shockwaves_always_damage_bombs && !(wip->wi_flags[Weapon::Info_Flags::Takes_shockwave_damage] || (sw->weapon_info_index >= 0 && Weapon_info[sw->weapon_info_index].wi_flags[Weapon::Info_Flags::Ciws])))
 				continue;
 		}
 
@@ -297,14 +296,17 @@ void shockwave_move(object *shockwave_objp, float frametime)
 			}
 		}
 
-		// only apply damage to a ship once from a shockwave
-		for ( i = 0; i < sw->num_objs_hit; i++ ) {
-			if ( objp->signature == sw->obj_sig_hitlist[i] ){
+		bool found_in_list = false;
+
+		// only apply damage to an object once from a shockwave
+		for (auto & comparison : sw->obj_sig_hitlist) {
+			if ( (objp->signature == comparison.first) && (objp->type == comparison.second) ){
+				found_in_list = true;
 				break;
 			}
 		}
 
-		if ( i < sw->num_objs_hit ){
+		if (found_in_list) {
 			continue;
 		}
 
@@ -312,17 +314,16 @@ void shockwave_move(object *shockwave_objp, float frametime)
 			continue;
 		}
 
-		// okay, we have damage applied, record the object signature so we don't repeatedly apply damage
-		Assert(sw->num_objs_hit < SW_MAX_OBJS_HIT);
-		if ( sw->num_objs_hit >= SW_MAX_OBJS_HIT) {
-			sw->num_objs_hit--;
-		}
-
 		weapon_info* wip = NULL;
+		
+		// okay, we have damage applied, record the object signature so we don't repeatedly apply damage 
+		// but only add non-ships to the list if the Game_settings flag is set
+		if (objp->type == OBJ_SHIP || Shockwaves_damage_all_obj_types_once) {
+			sw->obj_sig_hitlist.emplace_back(objp->signature, objp->type);
+		}
 
 		switch(objp->type) {
 		case OBJ_SHIP:
-			sw->obj_sig_hitlist[sw->num_objs_hit++] = objp->signature;
 			// If we're doing an AoE Electronics shockwave, do the electronics stuff. -MageKing17
 			if ( (sw->weapon_info_index >= 0) && (Weapon_info[sw->weapon_info_index].wi_flags[Weapon::Info_Flags::Aoe_Electronics]) && !(objp->flags[Object::Object_Flags::Invulnerable]) ) {
 				weapon_do_electronics_effect(objp, &sw->pos, sw->weapon_info_index);

--- a/code/weapon/shockwave.h
+++ b/code/weapon/shockwave.h
@@ -24,7 +24,6 @@ class model_draw_list;
 #define	SW_WEAPON_KILL		(1<<3)	// Shockwave created when weapon destroyed by another
 
 #define	MAX_SHOCKWAVES					16
-#define	SW_MAX_OBJS_HIT	64
 
 // -----------------------------------------------------------
 // Data structures
@@ -51,8 +50,7 @@ typedef struct shockwave {
 	shockwave	*next, *prev;
 	int			flags;
 	int			objnum;					// index into Objects[] for shockwave
-	int			num_objs_hit;
-	int			obj_sig_hitlist[SW_MAX_OBJS_HIT];
+	SCP_vector<std::pair<int, int>>			obj_sig_hitlist;
 	float		speed, radius;
 	float		inner_radius, outer_radius, damage;
 	int			weapon_info_index;	// -1 if shockwave not caused by weapon	


### PR DESCRIPTION
Fixes #2526  by making the array a vector and also adds a Shockwaves always damage bombs game_setting.tbl setting and a Shockwaves_consistently_apply_damage game_settings.tbl setting.  The second one keeps bombs and asteroids from being hit more than once by shockwaves, like ships do!