### PR TITLE
Change special_char_indexes to a vector

### DIFF
--- a/code/graphics/software/font.cpp
+++ b/code/graphics/software/font.cpp
@@ -249,8 +249,22 @@ namespace
 					  fontName.c_str(), MAX_SPECIAL_CHAR_IDX);
 			}
 
-			for (auto i = 0; i < (int)Lcl_languages.size(); ++i) {
-				Lcl_languages[i].special_char_indexes[font_id] = (ubyte)default_special_char_index;
+		}
+
+		// add the index specified to all the languages 
+		for (auto & Lcl_language : Lcl_languages) {
+
+			// if there wasn't already something specified for this font.
+			if (font_id >= (int)Lcl_language.special_char_indexes.size()) {
+				// if a lot of indexes were missing, add some defaults to fill in the gaps until ...
+				while (font_id > (int)Lcl_language.special_char_indexes.size()) {
+					Lcl_language.special_char_indexes.push_back(0);
+				}
+				// we're at just the right place in the vector to add the index we just read from the table.
+				Lcl_language.special_char_indexes.push_back((ubyte)default_special_char_index);
+			} // if there was something already specified that's being replaced.
+			else {
+				Lcl_language.special_char_indexes[font_id] = (ubyte)default_special_char_index;
 			}
 		}
 

--- a/code/localization/localize.cpp
+++ b/code/localization/localize.cpp
@@ -190,20 +190,22 @@ void parse_stringstbl_quick(const char *filename)
 
 				if (!Unicode_text_mode) {
 					required_string("+Special Character Index:");
-					stuff_ubyte(&language.special_char_indexes[0]);
-					for (i = 1; i < LCL_MAX_FONTS; ++i) {
+					ubyte temp;
+					stuff_ubyte(&temp);
+					language.special_char_indexes.push_back(temp);
+					for (i = 1; i < LCL_MINIMUM_FONTS; ++i) {
 						// default to "none"/0 except for font03 which defaults to 176
 						// NOTE: fonts.tbl may override these values
 						if (i == font::FONT3) {
-							language.special_char_indexes[i] = 176;
+							language.special_char_indexes.push_back(176);
 						} else {
-							language.special_char_indexes[i] = 0;
+							language.special_char_indexes.push_back(0);
 						}
 					}
 				} else {
 					// Set all indices to valid values
-					for (i = 0; i < LCL_MAX_FONTS; ++i) {
-						language.special_char_indexes[i] = 0;
+					for (i = 1; i < LCL_MINIMUM_FONTS; ++i) {
+						language.special_char_indexes.push_back(0);
 					}
 				}
 
@@ -521,8 +523,8 @@ ubyte lcl_get_font_index(int font_num)
 		// we just return 0 to signify that there are no special characters in this font
 		return 0;
 	} else {
-		Assertion((font_num >= 0) && (font_num < LCL_MAX_FONTS), "Passed an invalid font index");
-		Assertion((lang >= 0) && (lang < (int)Lcl_languages.size()), "Current language is not valid, can't get font indexes");
+		Assertion((lang >= 0) && (lang < (int)Lcl_languages.size()), "Passed an invalid language index %d when the size of the language array was %d ", lang, (int)Lcl_languages.size());
+		Assertion((font_num >= 0) && (font_num < (int)Lcl_languages[lang].special_char_indexes.size()), "Passed an invalid font index %d when the size of the vector was %d", font_num, (int)Lcl_languages[lang].special_char_indexes.size());
 
 		return Lcl_languages[lang].special_char_indexes[font_num];
 	}

--- a/code/localization/localize.h
+++ b/code/localization/localize.h
@@ -31,13 +31,14 @@
 // for language name strings
 #define LCL_LANG_NAME_LEN				32
 
-#define LCL_MAX_FONTS					5
+// Cyborg17 - We define at least this many special_char_indexes for each language to match retail behavior
+#define LCL_MINIMUM_FONTS				3   
 
 // language info table
 typedef struct lang_info {
 	char lang_name[LCL_LANG_NAME_LEN + 1];				// literal name of the language
 	char lang_ext[LCL_LANG_NAME_LEN + 1];				// the extension used for adding to names on disk access
-	ubyte special_char_indexes[LCL_MAX_FONTS];			// where in the font do we have the special characters for this language
+	SCP_vector<ubyte> special_char_indexes;				// where in the font do we have the special characters for this language
 														// note: treats 0 as "none" since a zero offset in a font makes no sense
 														// i.e. all the normal chars start at zero
 	int checksum;										// used for language auto-detection


### PR DESCRIPTION
Without this change certain font tables can hit the meaningless LCL_MAX_FONTS limit, as fotg did.

LCL_MAX_FONTS is kept around just to facilitate parsing of the hard-coded table.

I am not an expert by an means in this part of the code.  I ran both retail and fotg, which uses a font table with more than 5 entries and it seems to work.

Related to #2650