### PR TITLE
Allow overwriting hook variables

### DIFF
--- a/code/scripting/scripting.h
+++ b/code/scripting/scripting.h
@@ -266,7 +266,7 @@ void script_state::SetHookVar(const char *name, char format, T&& value)
 		auto reference = luacpp::UniqueLuaReference::create(LuaState);
 		lua_pop(LuaState, 1); // Remove object value from the stack
 
-		HookVariableValues.emplace(name, std::move(reference));
+		HookVariableValues[name] = std::move(reference);
 	}
 }
 

--- a/test/src/scripting/api/hookvars.cpp
+++ b/test/src/scripting/api/hookvars.cpp
@@ -20,6 +20,9 @@ TEST_F(HookVarsTest, empty)
 
 TEST_F(HookVarsTest, withHookVars)
 {
+	_state->SetHookVar("Test", 's', "Something else");
+
+	// Check that overwriting hook vars works
 	_state->SetHookVar("Test", 's', "Hello World");
 	_state->SetHookVar("Value", 'i', 1234);
 


### PR DESCRIPTION
The previous version used the wrong function for the map and so values
added later were not written to the map and so not available to Lua.

This fixes that by using the simple array operator.