### PR TITLE
add multi support for red-alert sexp

### DIFF
--- a/code/missionui/redalert.cpp
+++ b/code/missionui/redalert.cpp
@@ -1051,20 +1051,23 @@ void red_alert_start_mission()
 //		return;
 //	}
 
-	// check player health here.  
+	// check player health here, but only in single-player
 	// if we're dead (or about to die), don't start red alert mission.
-	if (Player_obj->type == OBJ_SHIP) {
-		if (Player_obj->hull_strength > 0) {
+	if ( (Game_mode & GM_MULTIPLAYER) ||
+		 ((Player_obj->type == OBJ_SHIP) && !Player_ship->flags[Ship::Ship_Flags::Dying] && (Player_obj->hull_strength > 0)) )
+	{
+		if (Player_obj->type == OBJ_SHIP)
+		{
 			// make sure we don't die
 			Player_ship->ship_guardian_threshold = SHIP_GUARDIAN_THRESHOLD_DEFAULT;
-
-			// do normal red alert stuff
-			Red_alert_new_mission_timestamp = timestamp(RED_ALERT_WARN_TIME);
-
-			// throw down a sound here to make the warning seem ultra-important
-			// gamesnd_play_iface(SND_USER_SELECT);
-			snd_play(gamesnd_get_game_sound(GameSounds::DIRECTIVE_COMPLETE));
 		}
+
+		// do normal red alert stuff
+		Red_alert_new_mission_timestamp = timestamp(RED_ALERT_WARN_TIME);
+
+		// throw down a sound here to make the warning seem ultra-important
+		// gamesnd_play_iface(SND_USER_SELECT);
+		snd_play(gamesnd_get_game_sound(GameSounds::DIRECTIVE_COMPLETE));
 	}
 }
 

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -13922,6 +13922,20 @@ void sexp_change_team_score(int node)
 	}
 }
 
+void sexp_red_alert()
+{
+	// in the case of a red_alert mission, simply call the red alert function to close
+	// the current campaign's mission and move forward to the next mission
+	red_alert_start_mission();
+
+	Current_sexp_network_packet.do_callback();
+}
+
+void multi_sexp_red_alert()
+{
+	red_alert_start_mission();
+}
+
 void sexp_tech_add_ship(int node)
 {
 	// this function doesn't mean anything when not in campaign mode
@@ -24203,10 +24217,8 @@ int eval_sexp(int cur_node, int referenced_node)
 				sexp_val = SEXP_TRUE;
 				break;
 
-				// in the case of a red_alert mission, simply call the red alert function to close
-				// the current campaign's mission and move forward to the next mission
 			case OP_RED_ALERT:
-				red_alert_start_mission();
+				sexp_red_alert();
 				sexp_val = SEXP_TRUE;
 				break;
 
@@ -25471,6 +25483,7 @@ void multi_sexp_eval()
 			case OP_SET_OBJECT_SPEED_Z:
 				multi_sexp_set_object_speed();
 				break;
+
 			case OP_SET_OBJECT_POSITION:
 				multi_sexp_set_object_position();
 				break;
@@ -25536,6 +25549,10 @@ void multi_sexp_eval()
 
 			case OP_DESTROY_SUBSYS_INSTANTLY:
 				multi_sexp_destroy_subsys_instantly();
+				break;
+
+			case OP_RED_ALERT:
+				multi_sexp_red_alert();
 				break;
 
 			// bad sexp in the packet

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -4009,10 +4009,6 @@ void game_frame(bool paused)
 				}
 			}
 
-			// Goober5000 - check if we should red-alert
-			// (this is approximately where the red_alert_check_status() function tree began in the pre-HUD-overhaul code)
-			red_alert_maybe_move_to_next_mission();
-
 			DEBUG_GET_TIME( render3_time2 )
 			DEBUG_GET_TIME( render2_time1 )
 
@@ -4044,6 +4040,8 @@ void game_frame(bool paused)
 			game_show_standalone_framerate();
 		}
 	}
+
+	red_alert_maybe_move_to_next_mission();
 
 	asteroid_frame();
 


### PR DESCRIPTION
This makes the red-alert SEXP execute properly in multiplayer.

Note, this is just the SEXP and a bit of cleanup.  Multi-knowledgeable people will need to evaluate `red_alert_maybe_move_to_next_mission` to make sure that function will work properly in multiplayer.