### PR TITLE
Add some quality of life improvements to external camera

### DIFF
--- a/code/camera/camera.cpp
+++ b/code/camera/camera.cpp
@@ -1097,7 +1097,7 @@ eye* get_submodel_eye(polymodel *pm, int submodel_num)
 }
 
 // maybe push the camera away from preferred dist if it would intersect the ship's bounding box
-float cam_get_bbox_dist(object* viewer_obj, float preferred_distance, const matrix* cam_orient) {
+float cam_get_bbox_dist(const object* viewer_obj, float preferred_distance, const matrix* cam_orient) {
 	if (viewer_obj == nullptr)
 		return preferred_distance;
 

--- a/code/camera/camera.h
+++ b/code/camera/camera.h
@@ -15,6 +15,9 @@
 #define CAM_STATIONARY_POS			(1<<2)
 #define CAM_DEFAULT_FLAGS			0
 
+#define	EXTERN_CAM_BBOX_CONSTANT_PADDING			5.0f
+#define	EXTERN_CAM_BBOX_MULTIPLIER_PADDING			1.5f
+
 class camera
 {
 protected:
@@ -164,6 +167,7 @@ camid cam_lookup(const char* name);
 camid cam_get_camera(uint index);
 camid cam_get_current();
 size_t cam_get_num();
+float cam_get_bbox_dist(object* viewer_obj, float preferred_distance, const matrix* cam_orient);
 
 void get_turret_cam_pos(camera *cam, vec3d *pos);
 void get_turret_cam_orient(camera *cam, matrix *ori);

--- a/code/camera/camera.h
+++ b/code/camera/camera.h
@@ -167,7 +167,7 @@ camid cam_lookup(const char* name);
 camid cam_get_camera(uint index);
 camid cam_get_current();
 size_t cam_get_num();
-float cam_get_bbox_dist(object* viewer_obj, float preferred_distance, const matrix* cam_orient);
+float cam_get_bbox_dist(const object* viewer_obj, float preferred_distance, const matrix* cam_orient);
 
 void get_turret_cam_pos(camera *cam, vec3d *pos);
 void get_turret_cam_orient(camera *cam, matrix *ori);

--- a/code/globalincs/systemvars.h
+++ b/code/globalincs/systemvars.h
@@ -75,12 +75,13 @@ extern int Fade_end_timestamp;
 
 typedef struct vei {
 	angles_t	angles;			//	Angles defining viewer location.
-	float		distance;		//	Distance from which to view, plus 2x radius.
+	float		preferred_distance; // the distance the player wants to be at, may be set to farther away by cam_get_bbox_dist
+	float		current_distance; // the actual cam distance after cam_get_bbox_dist
 } vei;
 
 typedef struct vci {
 	angles_t	angles;
-	float		distance;		// Distance from which to view, plus 3x radius
+	float		distance; // extra distance added by the controls, 0 when as close as possible
 } vci;
 
 extern fix Missiontime;

--- a/code/hud/hudtarget.cpp
+++ b/code/hud/hudtarget.cpp
@@ -4435,6 +4435,14 @@ void hud_target_change_check()
 				hud_restore_subsystem_target(&Ships[Objects[Player_ai->target_objnum].instance]);
 			}
 		}
+
+		// reset external cam distance
+		if (Viewer_mode & VM_EXTERNAL) {
+			if (Viewer_mode & VM_OTHER_SHIP)
+				Viewer_external_info.preferred_distance = 2 * Objects[Player_ai->target_objnum].radius;
+			else
+				Viewer_external_info.preferred_distance = 2 * Player_obj->radius;
+		}
 	}
 	else {
 		if (Player_ai->current_target_distance < Player_ai->last_dist-0.01){

--- a/code/io/keycontrol.cpp
+++ b/code/io/keycontrol.cpp
@@ -2188,6 +2188,13 @@ int button_function_demo_valid(int n)
 		{
 			Viewer_mode ^= VM_EXTERNAL;
 			Viewer_mode &= ~VM_CAMERA_LOCKED;	// reset camera lock when leaving/entering external view
+			// reset external camera distance if we're external
+			if (Viewer_mode & VM_EXTERNAL) {
+				if (Viewer_mode & VM_OTHER_SHIP)
+					Viewer_external_info.preferred_distance = 2 * Objects[Player_ai->target_objnum].radius;
+				else
+					Viewer_external_info.preferred_distance = 2 * Player_obj->radius;
+			}
 		}
 		else
 		{
@@ -2231,6 +2238,13 @@ int button_function_demo_valid(int n)
 				snd_play( gamesnd_get_game_sound(GameSounds::TARGET_FAIL) );
 			} else {
 				Viewer_mode ^= VM_OTHER_SHIP;
+				// reset external camera distance if we're external
+				if (Viewer_mode & VM_EXTERNAL) {
+					if (Viewer_mode & VM_OTHER_SHIP)
+						Viewer_external_info.preferred_distance = 2 * Objects[Player_ai->target_objnum].radius;
+					else
+						Viewer_external_info.preferred_distance = 2 * Player_obj->radius;
+				}
 			}
 		}
 		ret = 1;

--- a/code/object/object.cpp
+++ b/code/object/object.cpp
@@ -1993,7 +1993,7 @@ int obj_get_by_signature(int sig)
 /**
  * Gets object model
  */
-int object_get_model(object *objp)
+int object_get_model(const object *objp)
 {
 	switch(objp->type)
 	{

--- a/code/object/object.h
+++ b/code/object/object.h
@@ -343,7 +343,7 @@ void object_set_gliding(object *objp, bool enable=true, bool force = false);
 bool object_get_gliding(object *objp);
 bool object_glide_forced(object* objp);
 int obj_get_by_signature(int sig);
-int object_get_model(object *objp);
+int object_get_model(const object *objp);
 
 void obj_render_queue_all();
 

--- a/code/playerman/playercontrol.cpp
+++ b/code/playerman/playercontrol.cpp
@@ -261,9 +261,9 @@ void view_modify(angles *ma, angles *da, float max_p, float max_h, float frame_t
 	} else {
 		//If time compression is less than normal, still move camera at same speed
 		//This gives a cool matrix effect
-		ma->p += da->p * flRealframetime;
-		ma->b += da->b * flRealframetime;
-		ma->h += da->h * flRealframetime;
+		ma->p += da->p * flFrametime;
+		ma->b += da->b * flFrametime;
+		ma->h += da->h * flFrametime;
 	}
 
 	// Clamp resulting angles to their maximums
@@ -431,7 +431,7 @@ void do_view_chase(float  /*frame_time*/)
 	}
 	
 	// Process distance +/- keys
-	t = check_control_timef(VIEW_DIST_INCREASE) - check_control_timef(VIEW_DIST_DECREASE);
+	t = check_control_timef(VIEW_DIST_INCREASE) - check_control_timef(VIEW_DIST_DECREASE); 
 	Viewer_chase_info.distance += t*4;
 	if (Viewer_chase_info.distance < 0.0f)
 		Viewer_chase_info.distance = 0.0f;
@@ -472,9 +472,20 @@ void do_view_external(float frame_time)
 		Viewer_external_info.angles.h = 0.0f;
 		Viewer_external_info.distance = 0.0f;
 	}
+
+	object* viewer_obj;
+	if (!(Viewer_mode & VM_FREECAMERA))
+		viewer_obj = Player_obj;
+
+	if (Viewer_mode & VM_OTHER_SHIP) {
+		if (Player_ai->target_objnum != -1) {
+			viewer_obj = &Objects[Player_ai->target_objnum];
+		}
+	}
+	float currentdist = 2.0f * viewer_obj->radius + Viewer_external_info.distance;
 	
 	t = check_control_timef(VIEW_DIST_INCREASE) - check_control_timef(VIEW_DIST_DECREASE);
-	Viewer_external_info.distance += t*4*camera_zoom_scale;
+	Viewer_external_info.distance += t * (currentdist / 10) * camera_zoom_scale;
 	if (Viewer_external_info.distance < 0.0f){
 		Viewer_external_info.distance = 0.0f;
 	}

--- a/code/playerman/playercontrol.cpp
+++ b/code/playerman/playercontrol.cpp
@@ -272,7 +272,7 @@ void view_modify(angles *ma, angles *da, float max_p, float max_h)
 	CLAMP(ma->h, -max_h, max_h);
 }
 
-void do_view_track_target(float  /*frame_time*/)
+void do_view_track_target()
 {
 	vec3d view_vector;
 	vec3d targetpos_rotated;
@@ -345,14 +345,14 @@ void do_view_track_target(float  /*frame_time*/)
  *
  * @note Some mods may prefer to set their own limits, so, maybe make this as a table option in the future
  */
-void do_view_slew(float frame_time)
+void do_view_slew()
 {
 	view_modify(&chase_slew_angles, &Viewer_slew_angles_delta, PI_2, PI2/3);
 
 	// Check Track target
 	if (Viewer_mode & VM_TRACK) {
 		// Player's vision will track current target.
-		do_view_track_target(frame_time);
+		do_view_track_target();
 		Viewer_mode |= VM_CAMERA_LOCKED;
 		return;
 	}
@@ -429,7 +429,7 @@ DCF(camera_speed, "Sets the camera zoom scale")
 	dc_printf("Camera zoom scale set to %f\n", camera_zoom_scale);
 }
 
-void do_view_chase(float  /*frame_time*/)
+void do_view_chase()
 {
 	float t;
 
@@ -445,9 +445,7 @@ void do_view_chase(float  /*frame_time*/)
 		Viewer_chase_info.distance = 0.0f;
 	}
 
-	object* viewer_obj;
-	if (!(Viewer_mode & VM_FREECAMERA))
-		viewer_obj = Player_obj;
+	object* viewer_obj = Player_obj;
 
 	if (Viewer_mode & VM_OTHER_SHIP) {
 		if (Player_ai->target_objnum != -1) {
@@ -469,13 +467,11 @@ void do_view_chase(float  /*frame_time*/)
 	Viewer_mode |= VM_CAMERA_LOCKED;
 }
 
-void do_view_external(float frame_time)
+void do_view_external()
 {
 	float	t;
 
-	object* viewer_obj;
-	if (!(Viewer_mode & VM_FREECAMERA))
-		viewer_obj = Player_obj;
+	object* viewer_obj = Player_obj;
 
 	if (Viewer_mode & VM_OTHER_SHIP) {
 		if (Player_ai->target_objnum != -1) {
@@ -628,15 +624,15 @@ void read_keyboard_controls( control_info * ci, float frame_time, physics_info *
 	if ( Viewer_mode & VM_EXTERNAL ) {
 		control_used(VIEW_EXTERNAL);
 
-		do_view_external(frame_time);
+		do_view_external();
 		do_thrust_keys(ci);
 
 	} else if ( Viewer_mode & VM_CHASE ) {
-		do_view_chase(frame_time);
+		do_view_chase();
 
 	} else {
 		// We're in the cockpit. 
-		do_view_slew(frame_time);
+		do_view_slew();
 	}
 
 	chase_angles_to_value(&Viewer_slew_angles, &chase_slew_angles, centering_speed);

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -3105,7 +3105,9 @@ camid game_render_frame_setup()
 				vm_angles_2_matrix(&tm2, &Viewer_external_info.angles);
 				vm_matrix_x_matrix(&tm, &Viewer_obj->orient, &tm2);
 
-				vm_vec_scale_add(&eye_pos, &Viewer_obj->pos, &tm.vec.fvec, 2.0f * Viewer_obj->radius + Viewer_external_info.distance);
+				Viewer_external_info.current_distance = cam_get_bbox_dist(Viewer_obj, Viewer_external_info.preferred_distance, &tm2);
+
+				vm_vec_scale_add(&eye_pos, &Viewer_obj->pos, &tm.vec.fvec, Viewer_external_info.current_distance);
 
 				vm_vec_sub(&tmp_dir, &Viewer_obj->pos, &eye_pos);
 				vm_vec_normalize(&tmp_dir);


### PR DESCRIPTION
Three main changes. 
1. Send real frametime to `playercontrol_read_stick` while changing the external view, `frame_time` was modified by time compression causing the external view to be come very difficult to move with joystick (or mouse) while on high time compression.

2. Use an exponential factor when increasing/decreasing the external and chase camera distance, so now it doesn't become unreasonably slow when you're far from your view target or viewing a large target. (capped at 30km now)

3. The biggest change, allow the external camera to get much closer than 2* radius, and instead limiting by an ellipsoid determined by the bounding box. Due to the camera now being more "sensitive" to distance changes (it is more obvious now that you can get much closer), the external camera is more aggressive in resetting its distance.