### PR TITLE
Fix a bug with form-on-wing on a object outside the wing

### DIFF
--- a/code/ai/ai.h
+++ b/code/ai/ai.h
@@ -580,7 +580,7 @@ extern void ai_update_danger_weapon(int objnum, int weapon_objnum);
 
 // called externally from MissionParse.cpp to position ships in wings upon arrival into the
 // mission.
-extern void get_absolute_wing_pos(vec3d *result_pos, object *leader_objp, int wing_index, int wingnum, bool formation_object_flag, bool autopilot = false);
+extern void get_absolute_wing_pos(vec3d *result_pos, object *leader_objp, int wingnum, int wing_index, bool formation_object_flag, bool autopilot = false);
 
 //	Interface from goals code to AI.  Set ship to guard.  *objp guards *other_objp
 extern void ai_set_guard_object(object *objp, object *other_objp);

--- a/code/ai/ai.h
+++ b/code/ai/ai.h
@@ -580,8 +580,8 @@ extern void ai_update_danger_weapon(int objnum, int weapon_objnum);
 
 // called externally from MissionParse.cpp to position ships in wings upon arrival into the
 // mission.
-extern void get_absolute_wing_pos( vec3d *result_pos, object *leader_objp, int wing_index, int formation_object_flag);
-extern void get_absolute_wing_pos_autopilot( vec3d *result_pos, object *leader_objp, int wing_index, int formation_object_flag);
+extern void get_absolute_wing_pos( vec3d *result_pos, object *leader_objp, int wing_index, int formation_object_flag, int wingnum);
+extern void get_absolute_wing_pos_autopilot( vec3d *result_pos, object *leader_objp, int wing_index, int formation_object_flag, int wingnum);
 
 //	Interface from goals code to AI.  Set ship to guard.  *objp guards *other_objp
 extern void ai_set_guard_object(object *objp, object *other_objp);

--- a/code/ai/ai.h
+++ b/code/ai/ai.h
@@ -580,8 +580,7 @@ extern void ai_update_danger_weapon(int objnum, int weapon_objnum);
 
 // called externally from MissionParse.cpp to position ships in wings upon arrival into the
 // mission.
-extern void get_absolute_wing_pos( vec3d *result_pos, object *leader_objp, int wing_index, int formation_object_flag, int wingnum);
-extern void get_absolute_wing_pos_autopilot( vec3d *result_pos, object *leader_objp, int wing_index, int formation_object_flag, int wingnum);
+extern void get_absolute_wing_pos(vec3d *result_pos, object *leader_objp, int wing_index, int wingnum, bool formation_object_flag, bool autopilot = false);
 
 //	Interface from goals code to AI.  Set ship to guard.  *objp guards *other_objp
 extern void ai_set_guard_object(object *objp, object *other_objp);

--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -4376,7 +4376,7 @@ void ai_fly_to_target_position(vec3d* target_pos, bool* pl_done_p=NULL, bool* pl
 
 				if (wing_leader != Pl_objp) {
 					// not wing leader.. get my position relative to wing leader
-					get_absolute_wing_pos(&goal_point, wing_leader, wing_index, shipp->wingnum, aip->ai_flags[AI::AI_Flags::Formation_object], true);
+					get_absolute_wing_pos(&goal_point, wing_leader, shipp->wingnum, wing_index, aip->ai_flags[AI::AI_Flags::Formation_object], true);
 				} else {
 					// Am wing leader.. get the wings position relative to the flight leader
 					j = 1+int( (float)floor(double(autopilot_wings[aip->wing]-1)/2.0) );
@@ -11446,7 +11446,7 @@ DCF(wing_scale, "Adjusts the wing formation scale. (Default is 1.0f)")
  * Given an object to fly off of, a wing and a position in the wing formation, return the desired absolute location to fly to.
  * @return result in *result_pos.
  */
-void get_absolute_wing_pos(vec3d *result_pos, object *leader_objp, int wing_index, int wingnum, bool formation_object_flag, bool autopilot)
+void get_absolute_wing_pos(vec3d *result_pos, object *leader_objp, int wingnum, int wing_index, bool formation_object_flag, bool autopilot)
 {
 	vec3d	wing_delta, rotated_wing_delta;
 	float		wing_spread_size;
@@ -11454,7 +11454,7 @@ void get_absolute_wing_pos(vec3d *result_pos, object *leader_objp, int wing_inde
 
 	if (wing_index == 0)
 		wing_delta = vmd_zero_vector;
-	else if ( formation_index != -1 && wing_index < 6) 
+	else if ( formation_index != -1 && wing_index < MAX_SHIPS_PER_WING) 
 		wing_delta = Wing_formations[formation_index].positions[wing_index - 1]; //  custom desired location in leader's reference frame
 	else 
 		get_wing_delta(&wing_delta, wing_index);		//	default desired location in leader's reference frame
@@ -11508,7 +11508,7 @@ void render_wing_phantoms(object *objp)
 
 	for (i=0; i<32; i++)
 		if (Debug_render_wing_phantoms & (1 << i)) {
-			get_absolute_wing_pos(&goal_point, objp, i, shipp->wingnum, false);
+			get_absolute_wing_pos(&goal_point, objp, shipp->wingnum, i, false);
 	
 			vertex	vert;
 			gr_set_color(255, 0, 128);
@@ -11736,7 +11736,7 @@ int ai_formation()
 	leader_speed = leader_objp->phys_info.speed;
 	vec3d leader_vec = leader_objp->phys_info.vel;
 
-	get_absolute_wing_pos(&goal_point, leader_objp, wing_index, Ships[Pl_objp->instance].wingnum, aip->ai_flags[AI::AI_Flags::Formation_object]);
+	get_absolute_wing_pos(&goal_point, leader_objp, Ships[Pl_objp->instance].wingnum, wing_index, aip->ai_flags[AI::AI_Flags::Formation_object]);
 	vm_vec_scale_add(&future_goal_point_5, &goal_point, &leader_vec, 10.0f);
 	vm_vec_scale_add(&future_goal_point_2, &goal_point, &leader_vec, 5.0f);
 	vm_vec_scale_add(&future_goal_point_x, &goal_point, &leader_objp->orient.vec.fvec, 10.0f);	//	used when very close to destination

--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -4376,7 +4376,7 @@ void ai_fly_to_target_position(vec3d* target_pos, bool* pl_done_p=NULL, bool* pl
 
 				if (wing_leader != Pl_objp) {
 					// not wing leader.. get my position relative to wing leader
-					get_absolute_wing_pos_autopilot(&goal_point, wing_leader, wing_index, aip->ai_flags[AI::AI_Flags::Formation_object], shipp->wingnum);
+					get_absolute_wing_pos(&goal_point, wing_leader, wing_index, shipp->wingnum, aip->ai_flags[AI::AI_Flags::Formation_object], true);
 				} else {
 					// Am wing leader.. get the wings position relative to the flight leader
 					j = 1+int( (float)floor(double(autopilot_wings[aip->wing]-1)/2.0) );
@@ -11446,7 +11446,7 @@ DCF(wing_scale, "Adjusts the wing formation scale. (Default is 1.0f)")
  * Given an object to fly off of, a wing and a position in the wing formation, return the desired absolute location to fly to.
  * @return result in *result_pos.
  */
-void get_absolute_wing_pos(vec3d *result_pos, object *leader_objp, int wing_index, int formation_object_flag, int wingnum)
+void get_absolute_wing_pos(vec3d *result_pos, object *leader_objp, int wing_index, int wingnum, bool formation_object_flag, bool autopilot)
 {
 	vec3d	wing_delta, rotated_wing_delta;
 	float		wing_spread_size;
@@ -11454,45 +11454,23 @@ void get_absolute_wing_pos(vec3d *result_pos, object *leader_objp, int wing_inde
 
 	if (wing_index == 0)
 		wing_delta = vmd_zero_vector;
-	else if ( formation_index != -1) 
+	else if ( formation_index != -1 && wing_index < 6) 
 		wing_delta = Wing_formations[formation_index].positions[wing_index - 1]; //  custom desired location in leader's reference frame
 	else 
 		get_wing_delta(&wing_delta, wing_index);		//	default desired location in leader's reference frame
 	
 	wing_spread_size = MAX(50.0f, 3.0f * get_wing_largest_radius(leader_objp, formation_object_flag) + 15.0f);
 
-	// apply debug modifications to spread size and also y scale (2x default) unless it's a custom position
-	if (leader_objp->flags[Object::Object_Flags::Player_ship]) {
+	// if not autopilot apply debug modifications to spread size and also y scale (2x default) unless it's a custom position
+	if (leader_objp->flags[Object::Object_Flags::Player_ship] && !autopilot) {
 		if(formation_index == -1)
 			wing_delta.xyz.y *= Wing_y_scale;
 		wing_spread_size *= Wing_scale;
 	}
 
-	vm_vec_scale(&wing_delta, wing_spread_size * (1.0f + leader_objp->phys_info.speed/70.0f));
+	float scale_factor = autopilot ? 1.5f : (1.0f + leader_objp->phys_info.speed / 70.0f);
+	vm_vec_scale(&wing_delta, wing_spread_size * scale_factor);
 
-
-	vm_vec_unrotate(&rotated_wing_delta, &wing_delta, &leader_objp->orient);	//	Rotate into leader's reference.
-
-	vm_vec_add(result_pos, &leader_objp->pos, &rotated_wing_delta);	//	goal_point is absolute 3-space point.
-}
-
-// autopilot variant.. removes some scaling crap
-void get_absolute_wing_pos_autopilot(vec3d *result_pos, object *leader_objp, int wing_index, int formation_object_flag, int wingnum)
-{
-	vec3d	wing_delta, rotated_wing_delta;
-	float		wing_spread_size;
-	int formation_index = Wings[wingnum].formation;
-
-	if (wing_index == 0)
-		wing_delta = vmd_zero_vector;
-	else if (formation_index != -1)
-		wing_delta = Wing_formations[formation_index].positions[wing_index - 1]; //  custom desired location in leader's reference frame
-	else
-		get_wing_delta(&wing_delta, wing_index);		//	default desired location in leader's reference frame
-
-	wing_spread_size = MAX(50.0f, 3.0f * get_wing_largest_radius(leader_objp, formation_object_flag) + 15.0f);
-
-	vm_vec_scale(&wing_delta, wing_spread_size * 1.5f);
 	vm_vec_unrotate(&rotated_wing_delta, &wing_delta, &leader_objp->orient);	//	Rotate into leader's reference.
 	vm_vec_add(result_pos, &leader_objp->pos, &rotated_wing_delta);	//	goal_point is absolute 3-space point.
 }
@@ -11530,7 +11508,7 @@ void render_wing_phantoms(object *objp)
 
 	for (i=0; i<32; i++)
 		if (Debug_render_wing_phantoms & (1 << i)) {
-			get_absolute_wing_pos(&goal_point, objp, i, 0, shipp->wingnum);
+			get_absolute_wing_pos(&goal_point, objp, i, shipp->wingnum, false);
 	
 			vertex	vert;
 			gr_set_color(255, 0, 128);
@@ -11758,7 +11736,7 @@ int ai_formation()
 	leader_speed = leader_objp->phys_info.speed;
 	vec3d leader_vec = leader_objp->phys_info.vel;
 
-	get_absolute_wing_pos(&goal_point, leader_objp, wing_index, aip->ai_flags[AI::AI_Flags::Formation_object], Ships[Pl_objp->instance].wingnum);
+	get_absolute_wing_pos(&goal_point, leader_objp, wing_index, Ships[Pl_objp->instance].wingnum, aip->ai_flags[AI::AI_Flags::Formation_object]);
 	vm_vec_scale_add(&future_goal_point_5, &goal_point, &leader_vec, 10.0f);
 	vm_vec_scale_add(&future_goal_point_2, &goal_point, &leader_vec, 5.0f);
 	vm_vec_scale_add(&future_goal_point_x, &goal_point, &leader_objp->orient.vec.fvec, 10.0f);	//	used when very close to destination

--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -4376,7 +4376,7 @@ void ai_fly_to_target_position(vec3d* target_pos, bool* pl_done_p=NULL, bool* pl
 
 				if (wing_leader != Pl_objp) {
 					// not wing leader.. get my position relative to wing leader
-					get_absolute_wing_pos(&goal_point, wing_leader, shipp->wingnum, wing_index, aip->ai_flags[AI::AI_Flags::Formation_object], true);
+					get_absolute_wing_pos(&goal_point, wing_leader, aip->wing, wing_index, aip->ai_flags[AI::AI_Flags::Formation_object], true);
 				} else {
 					// Am wing leader.. get the wings position relative to the flight leader
 					j = 1+int( (float)floor(double(autopilot_wings[aip->wing]-1)/2.0) );
@@ -11508,7 +11508,7 @@ void render_wing_phantoms(object *objp)
 
 	for (i=0; i<32; i++)
 		if (Debug_render_wing_phantoms & (1 << i)) {
-			get_absolute_wing_pos(&goal_point, objp, shipp->wingnum, i, false);
+			get_absolute_wing_pos(&goal_point, objp, wingnum, i, false);
 	
 			vertex	vert;
 			gr_set_color(255, 0, 128);
@@ -11736,7 +11736,7 @@ int ai_formation()
 	leader_speed = leader_objp->phys_info.speed;
 	vec3d leader_vec = leader_objp->phys_info.vel;
 
-	get_absolute_wing_pos(&goal_point, leader_objp, Ships[Pl_objp->instance].wingnum, wing_index, aip->ai_flags[AI::AI_Flags::Formation_object]);
+	get_absolute_wing_pos(&goal_point, leader_objp, aip->wing, wing_index, aip->ai_flags[AI::AI_Flags::Formation_object]);
 	vm_vec_scale_add(&future_goal_point_5, &goal_point, &leader_vec, 10.0f);
 	vm_vec_scale_add(&future_goal_point_2, &goal_point, &leader_vec, 5.0f);
 	vm_vec_scale_add(&future_goal_point_x, &goal_point, &leader_objp->orient.vec.fvec, 10.0f);	//	used when very close to destination

--- a/code/autopilot/autopilot.cpp
+++ b/code/autopilot/autopilot.cpp
@@ -409,7 +409,7 @@ bool StartAutopilot()
 				if (leader_objp != &Objects[Ships[i].objnum])
 				{
 					// not leader.. get our position relative to leader
-					get_absolute_wing_pos_autopilot(&goal_point, leader_objp, wing_index, aip->ai_flags[AI::AI_Flags::Formation_object]);
+					get_absolute_wing_pos_autopilot(&goal_point, leader_objp, wing_index, aip->ai_flags[AI::AI_Flags::Formation_object], wingnum);
 				}
 				else
 				{

--- a/code/autopilot/autopilot.cpp
+++ b/code/autopilot/autopilot.cpp
@@ -409,7 +409,7 @@ bool StartAutopilot()
 				if (leader_objp != &Objects[Ships[i].objnum])
 				{
 					// not leader.. get our position relative to leader
-					get_absolute_wing_pos(&goal_point, leader_objp, wing_index, wingnum, aip->ai_flags[AI::AI_Flags::Formation_object], true);
+					get_absolute_wing_pos(&goal_point, leader_objp, wingnum, wing_index, aip->ai_flags[AI::AI_Flags::Formation_object], true);
 				}
 				else
 				{

--- a/code/autopilot/autopilot.cpp
+++ b/code/autopilot/autopilot.cpp
@@ -409,7 +409,7 @@ bool StartAutopilot()
 				if (leader_objp != &Objects[Ships[i].objnum])
 				{
 					// not leader.. get our position relative to leader
-					get_absolute_wing_pos_autopilot(&goal_point, leader_objp, wing_index, aip->ai_flags[AI::AI_Flags::Formation_object], wingnum);
+					get_absolute_wing_pos(&goal_point, leader_objp, wing_index, wingnum, aip->ai_flags[AI::AI_Flags::Formation_object], true);
 				}
 				else
 				{

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -6202,7 +6202,7 @@ void mission_set_wing_arrival_location( wing *wingp, int num_to_set )
 
 				// change the position of the next ships in the wing.  Use the cool function in AiCode.cpp which
 				// Mike K wrote to give new positions to the wing members.
-				get_absolute_wing_pos( &objp->pos, leader_objp, wing_index++, Ships[objp->instance].wingnum, false);
+				get_absolute_wing_pos( &objp->pos, leader_objp, Ships[objp->instance].wingnum, wing_index++, false);
 				memcpy( &objp->orient, &orient, sizeof(matrix) );
 
 				index++;

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -6202,7 +6202,7 @@ void mission_set_wing_arrival_location( wing *wingp, int num_to_set )
 
 				// change the position of the next ships in the wing.  Use the cool function in AiCode.cpp which
 				// Mike K wrote to give new positions to the wing members.
-				get_absolute_wing_pos( &objp->pos, leader_objp, wing_index++, 0);
+				get_absolute_wing_pos( &objp->pos, leader_objp, wing_index++, 0, Ships[objp->instance].wingnum);
 				memcpy( &objp->orient, &orient, sizeof(matrix) );
 
 				index++;

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -6202,7 +6202,7 @@ void mission_set_wing_arrival_location( wing *wingp, int num_to_set )
 
 				// change the position of the next ships in the wing.  Use the cool function in AiCode.cpp which
 				// Mike K wrote to give new positions to the wing members.
-				get_absolute_wing_pos( &objp->pos, leader_objp, wing_index++, 0, Ships[objp->instance].wingnum);
+				get_absolute_wing_pos( &objp->pos, leader_objp, wing_index++, Ships[objp->instance].wingnum, false);
 				memcpy( &objp->orient, &orient, sizeof(matrix) );
 
 				index++;

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -6202,7 +6202,7 @@ void mission_set_wing_arrival_location( wing *wingp, int num_to_set )
 
 				// change the position of the next ships in the wing.  Use the cool function in AiCode.cpp which
 				// Mike K wrote to give new positions to the wing members.
-				get_absolute_wing_pos( &objp->pos, leader_objp, Ships[objp->instance].wingnum, wing_index++, false);
+				get_absolute_wing_pos( &objp->pos, leader_objp, WING_INDEX(wingp), wing_index++, false);
 				memcpy( &objp->orient, &orient, sizeof(matrix) );
 
 				index++;


### PR DESCRIPTION
`leader_objp` can't be relied on to provide the formation since it could be some random object the wing was ordered to form up on. Now the wingnum is passed in so the formation is based on whoever is doing the forming up. Also update the new logic for the autopilot version of `get_absolute_wing_pos`. 