### PR TITLE
Fix fireball spawn for small time compression factors

### DIFF
--- a/code/debris/debris.cpp
+++ b/code/debris/debris.cpp
@@ -264,9 +264,10 @@ void debris_process_post(object * obj, float frame_time)
 		return;			// If arc_frequency <= 0, this piece has no arcs on it
 	}
 
-	if ( !timestamp_elapsed(db->fire_timeout) && timestamp_elapsed(db->next_fireball))	{		
+	if ( !timestamp_elapsed(db->fire_timeout) && (db->next_fireball < flFrametime))	{		
 
-		db->next_fireball = timestamp_rand(db->arc_frequency,db->arc_frequency*2 );
+		// use timestamp frequency to convert to float version of time
+		db->next_fireball = frand_range(db->arc_frequency,db->arc_frequency*2 )/TIMESTAMP_FREQUENCY;
 		db->arc_frequency += 100;	
 
 		if (db->is_hull)	{
@@ -339,6 +340,9 @@ void debris_process_post(object * obj, float frame_time)
 				snd_play_3d( gamesnd_get_game_sound(GameSounds::DEBRIS_ARC_01), &snd_pos, &View_position, obj->radius );
 			}
 		}
+	}
+	else {
+		db->next_fireball -= flFrametime;
 	}
 
 	for (int i=0; i<MAX_DEBRIS_ARCS; ++i)	{
@@ -541,7 +545,7 @@ object *debris_create(object *source_obj, int model_num, int submodel_num, vec3d
 	}
 	float radius = submodel_get_radius( db->model_num, db->submodel_num );
 
-	db->next_fireball = timestamp_rand(500,2000);	//start one 1/2 - 2 secs later
+	db->next_fireball = frand_range(0.500f,2.000f);	//start one 1/2 - 2 secs later
 
 	if ( pos == NULL )
 		pos = &source_obj->pos;

--- a/code/debris/debris.h
+++ b/code/debris/debris.h
@@ -43,7 +43,7 @@ typedef struct debris {
 	int		must_survive_until;		//WMC - timestamp of earliest point that it can be murthered.
 	int		model_num;				// What model this uses
 	int		submodel_num;			// What submodel this uses
-	int		next_fireball;			// When to start a fireball
+	float	next_fireball;			// In how many ms to start a fireball
 	int		is_hull;				// indicates a large hull chunk of debris
 	int		species;				// What species this is from.  -1 if don't care.
 	int		fire_timeout;			// timestamp that holds time for fireballs to stop appearing

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -501,7 +501,7 @@ public:
 	int warpin_params_index;
 	int warpout_params_index;
 
-	int	next_fireball;
+	float next_fireball;
 
 	int	next_hit_spark;
 	int	num_hits;			//	Note, this is the number of spark emitter positions!

--- a/code/ship/shiphit.cpp
+++ b/code/ship/shiphit.cpp
@@ -1503,7 +1503,7 @@ void ship_generic_kill_stuff( object *objp, float percent_killed )
 
 	sp->pre_death_explosion_happened = 0;				// The little fireballs haven't came in yet.
 
-	sp->next_fireball = timestamp(0);	//start one right away
+	sp->next_fireball = 0.0f;	//start one right away
 
 	ai_deathroll_start(objp);
 


### PR DESCRIPTION
*Needs more testing to ensure that debris, ship halves and Knossos all explode like in retail but do not spawn too many explosions in screencam script, but feel free to review, as afaict, this is the final version and _should_ work*

Switches time calculation to flFrametime to fix too many explosions showing up,