### PR TITLE
Add Lua API for serializing values

### DIFF
--- a/code/libs/jansson.cpp
+++ b/code/libs/jansson.cpp
@@ -46,10 +46,83 @@ SCP_string json_dump_string(const json_t* json, size_t flags)
 
 	return out;
 }
-SCP_string json_dump_string_new(json_t* json, size_t flags) {
+SCP_string json_dump_string_new(json_t* json, size_t flags)
+{
 	auto str = json_dump_string(json, flags);
 	json_decref(json);
 	return str;
 }
 
 json_exception::json_exception(const json_error_t& error) : std::runtime_error(format_error(error)) {}
+
+namespace json {
+namespace detail {
+object_iterator::object_iterator(json_t* obj, void* iter) : m_obj(obj), m_iter(iter) {}
+object_iterator& object_iterator::operator++()
+{
+	Assertion(m_iter != nullptr, "Tried to increment iterator after it was at the end!");
+
+	m_iter = json_object_iter_next(m_obj, m_iter);
+	return *this;
+}
+object_iterator::value_type object_iterator::operator*() const
+{
+	return object_iterator::value_type{json_object_iter_key(m_iter), json_object_iter_value(m_iter)};
+}
+
+bool operator==(const object_iterator& lhs, const object_iterator& rhs)
+{
+	return lhs.m_obj == rhs.m_obj && lhs.m_iter == rhs.m_iter;
+}
+bool operator!=(const object_iterator& lhs, const object_iterator& rhs)
+{
+	return !(rhs == lhs);
+}
+array_iterator::array_iterator(json_t* array, size_t index) : m_array(array), m_index(index) {}
+bool operator==(const array_iterator& lhs, const array_iterator& rhs)
+{
+	return lhs.m_array == rhs.m_array && lhs.m_index == rhs.m_index;
+}
+bool operator!=(const array_iterator& lhs, const array_iterator& rhs)
+{
+	return !(rhs == lhs);
+}
+array_iterator& array_iterator::operator++()
+{
+	++m_index;
+	return *this;
+}
+array_iterator::value_type array_iterator::operator*() const
+{
+	Assertion(m_index < json_array_size(m_array), "Invalid index encountered!");
+	return json_array_get(m_array, m_index);
+}
+} // namespace detail
+
+object_range::object_range(json_t* obj) : m_obj(obj)
+{
+	Assertion(json_typeof(m_obj) == JSON_OBJECT, "Invalid object type %d for json value.", json_typeof(m_obj));
+}
+detail::object_iterator object_range::begin()
+{
+	// Need to suppress the warning here since applying the requested change breaks on other compilers
+	return detail::object_iterator(m_obj, json_object_iter(m_obj)); // NOLINT(modernize-return-braced-init-list)
+}
+detail::object_iterator object_range::end()
+{
+	return {m_obj, nullptr};
+}
+
+array_range::array_range(json_t* array) : m_array(array)
+{
+	Assertion(json_typeof(m_array) == JSON_ARRAY, "Invalid object type %d for json value.", json_typeof(m_array));
+}
+detail::array_iterator array_range::begin()
+{
+	return {m_array, 0};
+}
+detail::array_iterator array_range::end()
+{
+	return {m_array, json_array_size(m_array)};
+}
+} // namespace json

--- a/code/libs/jansson.h
+++ b/code/libs/jansson.h
@@ -30,3 +30,71 @@ class json_exception : public std::runtime_error {
   public:
 	explicit json_exception(const json_error_t& error);
 };
+
+namespace json {
+namespace detail {
+
+class object_iterator {
+  public:
+	using value_type = std::tuple<const char*, json_t*>;
+	using reference = value_type&;
+	using pointer = value_type*;
+
+	object_iterator(json_t* obj, void* iter);
+
+	object_iterator& operator++();
+	value_type operator*() const;
+
+	friend bool operator==(const object_iterator& lhs, const object_iterator& rhs);
+	friend bool operator!=(const object_iterator& lhs, const object_iterator& rhs);
+
+  private:
+	json_t* m_obj = nullptr;
+	void* m_iter = nullptr;
+};
+
+class array_iterator {
+  public:
+	using value_type = json_t*;
+	using reference = value_type&;
+	using pointer = value_type*;
+
+	array_iterator(json_t* obj, size_t index);
+
+	array_iterator& operator++();
+	value_type operator*() const;
+
+	friend bool operator==(const array_iterator& lhs, const array_iterator& rhs);
+	friend bool operator!=(const array_iterator& lhs, const array_iterator& rhs);
+  private:
+	json_t* m_array = nullptr;
+	size_t m_index = 0;
+};
+
+} // namespace detail
+
+class object_range {
+  public:
+	object_range(json_t* obj);
+
+	detail::object_iterator begin();
+
+	detail::object_iterator end();
+
+  private:
+	json_t* m_obj = nullptr;
+};
+
+class array_range {
+  public:
+	array_range(json_t* array);
+
+	detail::array_iterator begin();
+
+	detail::array_iterator end();
+
+  private:
+	json_t* m_array = nullptr;
+};
+
+} // namespace json

--- a/code/scripting/ade_args.cpp
+++ b/code/scripting/ade_args.cpp
@@ -102,6 +102,17 @@ bool get_single_arg(lua_State* L, const get_args_state& state, char fmt, luacpp:
 	f->setErrorFunction(luacpp::LuaFunction::createFromCFunction(L, ade_friendly_error));
 	return true;
 }
+bool get_single_arg(lua_State* L, const get_args_state& state, char fmt, luacpp::LuaValue* f)
+{
+	Assertion(fmt == 'a', "Invalid character '%c' for any type!", fmt);
+
+	// Get a function
+	if (!luacpp::convert::popValue(L, *f, state.nargs, false)) {
+		LuaError(L, "%s: Failed to get argument %d. Internal error.", state.funcname, state.nargs);
+		return false;
+	}
+	return true;
+}
 
 void set_single_arg(lua_State* L, char fmt, const char* s)
 {
@@ -131,6 +142,11 @@ void set_single_arg(lua_State* L, char fmt, luacpp::LuaFunction* func)
 void set_single_arg(lua_State* L, char fmt, const luacpp::LuaFunction& func)
 {
 	Assertion(fmt == 'u', "Invalid format character '%c' for function type!", fmt);
+	func.pushValue(L);
+}
+void set_single_arg(lua_State* L, char fmt, const luacpp::LuaValue& func)
+{
+	Assertion(fmt == 'a', "Invalid format character '%c' for any type!", fmt);
 	func.pushValue(L);
 }
 

--- a/code/scripting/ade_args.h
+++ b/code/scripting/ade_args.h
@@ -110,6 +110,7 @@ bool get_single_arg(lua_State* L, const get_args_state& state, char fmt, ade_oda
 
 bool get_single_arg(lua_State* L, const get_args_state& state, char fmt, luacpp::LuaTable* t);
 bool get_single_arg(lua_State* L, const get_args_state& state, char fmt, luacpp::LuaFunction* f);
+bool get_single_arg(lua_State* L, const get_args_state& state, char fmt, luacpp::LuaValue* f);
 
 // This is not a template function so we can put the implementation in a source file
 inline bool get_args_actual(lua_State* /*L*/, get_args_state& state, const char* fmt)
@@ -312,6 +313,8 @@ void set_single_arg(lua_State* /*L*/, char fmt, const luacpp::LuaTable& table);
 
 void set_single_arg(lua_State* /*L*/, char fmt, luacpp::LuaFunction* func);
 void set_single_arg(lua_State* /*L*/, char fmt, const luacpp::LuaFunction& func);
+
+void set_single_arg(lua_State* /*L*/, char fmt, const luacpp::LuaValue& func);
 
 // This is not a template function so we can put the implementation in a source file
 inline void set_args_actual(lua_State* /*L*/, set_args_state& /*state*/, const char* fmt)

--- a/code/scripting/api/objs/bytearray.cpp
+++ b/code/scripting/api/objs/bytearray.cpp
@@ -1,0 +1,27 @@
+#include "bytearray.h"
+
+namespace scripting {
+namespace api {
+
+bytearray_h::bytearray_h() = default;
+bytearray_h::bytearray_h(SCP_vector<uint8_t> data) : m_data(std::move(data)) {}
+const SCP_vector<uint8_t>& bytearray_h::data() const
+{
+	return m_data;
+}
+
+//**********HANDLE: bytearray
+ADE_OBJ(l_Bytearray, bytearray_h, "bytearray", "An array of binary data");
+
+ADE_FUNC(__len, l_Bytearray, nullptr, "The number of bytes in this array", "number", "The length in bytes")
+{
+	bytearray_h* array = nullptr;
+	if (!ade_get_args(L, "o", l_Bytearray.GetPtr(&array))) {
+		return ade_set_args(L, "i", 0);
+	}
+
+	return ade_set_args(L, "i", array->data().size());
+}
+
+} // namespace api
+} // namespace scripting

--- a/code/scripting/api/objs/bytearray.h
+++ b/code/scripting/api/objs/bytearray.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "scripting/ade_api.h"
+
+namespace scripting {
+namespace api {
+
+struct bytearray_h {
+	SCP_vector<uint8_t> m_data;
+
+  public:
+	bytearray_h();
+	explicit bytearray_h(SCP_vector<uint8_t> data);
+
+	const SCP_vector<uint8_t>& data() const;
+};
+
+DECLARE_ADE_OBJ(l_Bytearray, bytearray_h);
+
+} // namespace api
+} // namespace scripting

--- a/code/scripting/lua/LuaTable.cpp
+++ b/code/scripting/lua/LuaTable.cpp
@@ -52,7 +52,7 @@ void LuaTable::setReference(const LuaReference& ref) {
 	}
 }
 
-size_t LuaTable::getLength() {
+size_t LuaTable::getLength() const {
 	this->pushValue(_luaState);
 
 	size_t length = lua_objlen(_luaState, -1);
@@ -90,13 +90,13 @@ std::pair<LuaValue, LuaValue> LuaTable::iterator::operator*() {
 	return _iter->getElement();
 }
 
-LuaTable::iterator LuaTable::begin() {
+LuaTable::iterator LuaTable::begin() const {
 	iterator iter(*this);
 
 	// This will call lua_next and automatically handle the end of the table
 	return iter;
 }
-LuaTable::iterator LuaTable::end() {
+LuaTable::iterator LuaTable::end() const { // NOLINT(readability-convert-member-functions-to-static)
 	return iterator(); // Empty iterator
 }
 

--- a/code/scripting/lua/LuaTable.h
+++ b/code/scripting/lua/LuaTable.h
@@ -159,7 +159,7 @@ class LuaTable: public LuaValue {
      * @return @c true when the value could be successfully converted, @c false otherwise
      */
 	template<class IndexType, class ValueType>
-	bool getValue(const IndexType& index, ValueType& target) {
+	bool getValue(const IndexType& index, ValueType& target) const {
 		this->pushValue(_luaState);
 
 		convert::pushValue(_luaState, index);
@@ -189,7 +189,7 @@ class LuaTable: public LuaValue {
      */
 	template<class ValueType, class IndexType>
 	// IndexType is last so the compiler can deduce it from the argument
-	ValueType getValue(const IndexType& index) {
+	ValueType getValue(const IndexType& index) const {
 		ValueType target;
 
 		if (!getValue(index, target)) {
@@ -206,7 +206,7 @@ class LuaTable: public LuaValue {
      *
      * @return The size value.
      */
-	size_t getLength();
+	size_t getLength() const;
 
 	/**
 	 * @brief Returns an iterator to the begin of this table
@@ -217,7 +217,7 @@ class LuaTable: public LuaValue {
 	 *
 	 * @return The iterator to the begin of the table
 	 */
-	iterator begin();
+	iterator begin() const;
 
 	/**
 	 * @brief Returns an iterator to the end of this table
@@ -226,7 +226,7 @@ class LuaTable: public LuaValue {
 	 *
 	 * @return The iterator to the end of the table
 	 */
-	iterator end();
+	iterator end() const;
 
 };
 

--- a/code/scripting/util/LuaValueDeserializer.cpp
+++ b/code/scripting/util/LuaValueDeserializer.cpp
@@ -1,0 +1,80 @@
+
+#include "LuaValueDeserializer.h"
+
+#include "LuaValueSerializer.h"
+
+namespace scripting {
+namespace util {
+
+LuaValueDeserializer::LuaValueDeserializer(lua_State* L) : m_L(L) {}
+
+luacpp::LuaValue LuaValueDeserializer::deserialize(const SCP_vector<uint8_t>& serialized) const
+{
+	if (serialized.empty()) {
+		throw std::runtime_error("Not enough data");
+	}
+
+	const auto type = static_cast<SerializationType>(serialized.front());
+
+	switch (type) {
+	case SerializationType::PlainJson:
+		return deserializePlainJson(serialized.data() + 1, serialized.size() - 1);
+	default:
+		throw std::runtime_error("Unknown serialization type.");
+	}
+}
+luacpp::LuaValue LuaValueDeserializer::deserializePlainJson(const uint8_t* data, size_t size) const
+{
+	json_error_t error;
+	std::unique_ptr<json_t> json(json_loadb(reinterpret_cast<const char*>(data),
+		size,
+		JSON_DECODE_ANY | JSON_DECODE_INT_AS_REAL | JSON_ALLOW_NUL,
+		&error));
+
+	if (!json) {
+		throw json_exception(error);
+	}
+
+	return jsonToValue(json.get());
+}
+luacpp::LuaValue LuaValueDeserializer::jsonToValue(json_t* json) const
+{
+	switch (json_typeof(json)) {
+	case JSON_OBJECT: {
+		auto objectTbl = luacpp::LuaTable::create(m_L);
+		for(const auto& pair : json::object_range(json))
+		{
+			objectTbl.addValue(std::get<0>(pair), jsonToValue(std::get<1>(pair)));
+		}
+		return std::move(objectTbl);
+	}
+	case JSON_ARRAY: {
+		auto arrayTbl = luacpp::LuaTable::create(m_L);
+		size_t i = 1;
+		for (const auto& value : json::array_range(json))
+		{
+			arrayTbl.addValue(i, jsonToValue(value));
+			++i;
+		}
+		return std::move(arrayTbl);
+	}
+	case JSON_STRING: {
+		const auto val = json_string_value(json);
+		const auto len = json_string_length(json);
+		return luacpp::LuaValue::createValue(m_L, SCP_string(val, val + len));
+	}
+	case JSON_REAL:
+		return luacpp::LuaValue::createValue(m_L, json_real_value(json));
+	case JSON_TRUE:
+		return luacpp::LuaValue::createValue(m_L, true);
+	case JSON_FALSE:
+		return luacpp::LuaValue::createValue(m_L, false);
+	case JSON_NULL:
+		return luacpp::LuaValue::createNil(m_L);
+	default:
+		return luacpp::LuaValue();
+	}
+}
+
+} // namespace util
+} // namespace scripting

--- a/code/scripting/util/LuaValueDeserializer.h
+++ b/code/scripting/util/LuaValueDeserializer.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "libs/jansson.h"
+#include "scripting/lua/LuaTable.h"
+#include "scripting/lua/LuaValue.h"
+
+namespace scripting {
+namespace util {
+
+class LuaValueDeserializer {
+  public:
+	LuaValueDeserializer(lua_State* L);
+
+	luacpp::LuaValue deserialize(const SCP_vector<uint8_t>& serialized) const;
+  private:
+	luacpp::LuaValue deserializePlainJson(const uint8_t* data, size_t size) const;
+	luacpp::LuaValue jsonToValue(json_t* json) const;
+
+	lua_State* m_L = nullptr;
+};
+
+} // namespace util
+} // namespace scripting

--- a/code/scripting/util/LuaValueSerializer.cpp
+++ b/code/scripting/util/LuaValueSerializer.cpp
@@ -1,0 +1,101 @@
+
+#include "LuaValueSerializer.h"
+
+#include "scripting/lua/LuaTable.h"
+
+namespace scripting {
+namespace util {
+
+LuaValueSerializer::LuaValueSerializer(luacpp::LuaValue value) : m_value(std::move(value)) {}
+
+SCP_vector<uint8_t> LuaValueSerializer::serialize() const
+{
+	std::unique_ptr<json_t> serializedJson(toJson());
+
+	const auto json = json_dump_string(serializedJson.get(), JSON_ENCODE_ANY | JSON_COMPACT);
+
+	SCP_vector<uint8_t> data;
+	data.reserve(json.size() + 1);
+
+	// Add a tiny header describing the following data for future proofing.
+	data.push_back(static_cast<uint8_t>(SerializationType::PlainJson));
+
+	std::transform(json.cbegin(), json.cend(), std::back_inserter(data), [](char c) {
+		return static_cast<uint8_t>(c);
+	});
+
+	return data;
+}
+
+json_t* LuaValueSerializer::toJson() const
+{
+	switch (m_value.getValueType()) {
+	case luacpp::ValueType::NIL:
+		return json_null();
+	case luacpp::ValueType::BOOLEAN:
+		return json_boolean(m_value.getValue<bool>());
+	case luacpp::ValueType::STRING: {
+		const auto string = m_value.getValue<SCP_string>();
+		return json_stringn(string.c_str(), string.size());
+	}
+	case luacpp::ValueType::NUMBER:
+		return json_real(m_value.getValue<double>());
+	case luacpp::ValueType::TABLE:
+		return tableToJson();
+	case luacpp::ValueType::NONE:
+	case luacpp::ValueType::USERDATA:
+	case luacpp::ValueType::FUNCTION:
+	case luacpp::ValueType::LIGHTUSERDATA:
+	case luacpp::ValueType::THREAD:
+	default:
+		throw std::runtime_error("Unsupported value type!");
+	}
+}
+json_t* LuaValueSerializer::tableToJson() const
+{
+	luacpp::LuaTable tableVal;
+	tableVal.setReference(m_value.getReference());
+
+	auto testVal = tableVal.getValue<luacpp::LuaValue>(1);
+	if (testVal.getValueType() == luacpp::ValueType::NIL) {
+		// If there is no first array element then we assume it is an object
+		return tableToJsonObject(tableVal);
+	} else {
+		// Assume this is an object
+		return tableToJsonArray(tableVal);
+	}
+}
+json_t* LuaValueSerializer::tableToJsonArray(const luacpp::LuaTable& table)
+{
+	auto size = table.getLength();
+	auto jsonArray = json_array();
+	for (size_t i = 1; i <= size; ++i) {
+		luacpp::LuaValue arrayVal;
+		if (!table.getValue(i, arrayVal)) {
+			json_array_append_new(jsonArray, json_null());
+		} else {
+			LuaValueSerializer valueSerializer(arrayVal);
+			json_array_append_new(jsonArray, valueSerializer.toJson());
+		}
+	}
+	return jsonArray;
+}
+json_t* LuaValueSerializer::tableToJsonObject(const luacpp::LuaTable& table)
+{
+	auto jsonObj = json_object();
+	for (const auto& entry : table) {
+		if (entry.first.getValueType() != luacpp::ValueType::STRING) {
+			// Ignore non-string indices
+			continue;
+		}
+
+		const auto index = entry.first.getValue<SCP_string>();
+
+		LuaValueSerializer valueSerializer(entry.second);
+		json_object_set_new(jsonObj, index.c_str(), valueSerializer.toJson());
+	}
+	return jsonObj;
+}
+
+} // namespace util
+} // namespace scripting

--- a/code/scripting/util/LuaValueSerializer.h
+++ b/code/scripting/util/LuaValueSerializer.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include "scripting/lua/LuaValue.h"
+#include "scripting/lua/LuaTable.h"
+
+#include "libs/jansson.h"
+
+namespace scripting {
+namespace util {
+
+enum class SerializationType : uint8_t {
+	PlainJson = 0,
+};
+
+class LuaValueSerializer {
+  public:
+	LuaValueSerializer(luacpp::LuaValue value);
+
+	SCP_vector<uint8_t> serialize() const;
+  private:
+	json_t* toJson() const;
+
+	json_t* tableToJson() const;
+	static json_t* tableToJsonArray(const luacpp::LuaTable& table);
+	static json_t* tableToJsonObject(const luacpp::LuaTable& table);
+
+	luacpp::LuaValue m_value;
+};
+
+} // namespace util
+} // namespace scripting

--- a/code/source_groups.cmake
+++ b/code/source_groups.cmake
@@ -1097,6 +1097,13 @@ add_file_folder("Scripting"
 	scripting/scripting_doc.h
 )
 
+add_file_folder("Scripting\\\\Util"
+	scripting/util/LuaValueDeserializer.cpp
+	scripting/util/LuaValueDeserializer.h
+	scripting/util/LuaValueSerializer.cpp
+	scripting/util/LuaValueSerializer.h
+)
+
 add_file_folder("Scripting\\\\Api"
 	scripting/api/LuaCoroutineRunner.cpp
 	scripting/api/LuaCoroutineRunner.h
@@ -1154,6 +1161,8 @@ add_file_folder("Scripting\\\\Api\\\\Objs"
 	scripting/api/objs/background_element.h
 	scripting/api/objs/beam.cpp
 	scripting/api/objs/beam.h
+	scripting/api/objs/bytearray.cpp
+	scripting/api/objs/bytearray.h
 	scripting/api/objs/camera.cpp
 	scripting/api/objs/camera.h
 	scripting/api/objs/cmd_brief.cpp

--- a/test/src/scripting/api/base.cpp
+++ b/test/src/scripting/api/base.cpp
@@ -11,3 +11,33 @@ class ScriptingBaseTest : public test::scripting::ScriptingTestFixture {
 TEST_F(ScriptingBaseTest, print) {
 	this->EvalTestScript();
 }
+
+class ScriptingSerializationTest : public ScriptingBaseTest {
+  public:
+	ScriptingSerializationTest() = default;
+};
+
+TEST_F(ScriptingSerializationTest, serializeNil)
+{
+	this->EvalTestScript();
+}
+
+TEST_F(ScriptingSerializationTest, serializeBoolean)
+{
+	this->EvalTestScript();
+}
+
+TEST_F(ScriptingSerializationTest, serializeString)
+{
+	this->EvalTestScript();
+}
+
+TEST_F(ScriptingSerializationTest, serializeNumber)
+{
+	this->EvalTestScript();
+}
+
+TEST_F(ScriptingSerializationTest, serializeTable)
+{
+	this->EvalTestScript();
+}

--- a/test/test_data/scripting/base/data/scripts/serializeTest.lua
+++ b/test/test_data/scripting/base/data/scripts/serializeTest.lua
@@ -1,0 +1,13 @@
+
+local assert = require("assert")
+
+return function(value)
+    local serialized = ba.serializeValue(value)
+    local deserialized = ba.deserializeValue(serialized)
+
+    if type(value) == "table" then
+        assert.tablesEqual(value, deserialized)
+    else
+        assert.equals(value, deserialized)
+    end
+end

--- a/test/test_data/scripting/base/serializeBoolean/data/scripts/test.lua
+++ b/test/test_data/scripting/base/serializeBoolean/data/scripts/test.lua
@@ -1,0 +1,4 @@
+
+local serializeTest = require("serializeTest")
+
+serializeTest(nil)

--- a/test/test_data/scripting/base/serializeNil/data/scripts/test.lua
+++ b/test/test_data/scripting/base/serializeNil/data/scripts/test.lua
@@ -1,0 +1,5 @@
+
+local serializeTest = require("serializeTest")
+
+serializeTest(false)
+serializeTest(true)

--- a/test/test_data/scripting/base/serializeNumber/data/scripts/test.lua
+++ b/test/test_data/scripting/base/serializeNumber/data/scripts/test.lua
@@ -1,0 +1,8 @@
+
+local serializeTest = require("serializeTest")
+
+serializeTest(1)
+serializeTest(2)
+serializeTest(9.4)
+serializeTest(-42)
+serializeTest(3.94583E10)

--- a/test/test_data/scripting/base/serializeString/data/scripts/test.lua
+++ b/test/test_data/scripting/base/serializeString/data/scripts/test.lua
@@ -1,0 +1,5 @@
+
+local serializeTest = require("serializeTest")
+
+serializeTest("Hello World")
+serializeTest("This is a \0 string with a null byte")

--- a/test/test_data/scripting/base/serializeTable/data/scripts/test.lua
+++ b/test/test_data/scripting/base/serializeTable/data/scripts/test.lua
@@ -1,0 +1,24 @@
+
+local serializeTest = require("serializeTest")
+
+serializeTest({})
+
+local array = {}
+table.insert(array, 1)
+table.insert(array, "asdf")
+table.insert(array, false)
+serializeTest(array)
+
+serializeTest({
+    test = 42,
+    __hello = "Hello World"
+})
+
+serializeTest({
+    test = { "asdf", false, 42, true },
+    __hello = "Hello World",
+    _nestedTable = {
+        test = 42,
+        __hello = "Hello World"
+    }
+})

--- a/test/test_data/scripting/data/scripts/assert.lua
+++ b/test/test_data/scripting/data/scripts/assert.lua
@@ -1,5 +1,9 @@
 local module = {}
 
+function module.__call(condition)
+    assert(condition)
+end
+
 function module.equals(expected, actual)
     if (expected == actual) then
         return
@@ -17,15 +21,15 @@ function module.tablesEqual(expected, actual)
         error("Actual value is not a table")
     end
 
-    if #expected ~= #actual then
-        error(string.format("Expected table length %d did not match actual %d.", #expected, #actual))
-    end
-
-    for i, expectedVal in ipairs(expected) do
+    for i, expectedVal in pairs(expected) do
         local actualVal = actual[i]
 
-        if expectedVal ~= actualVal then
-            error(string.format("Mismatch at index %d. Expected value of %q but was %q", i, tostring(expected), tostring(actual)))
+        if type(expectedVal) == "table" then
+            module.tablesEqual(expectedVal, actualVal)
+        else
+            if expectedVal ~= actualVal then
+                error(string.format("Mismatch at index %d. Expected value of %q but was %q", i, tostring(expected), tostring(actual)))
+            end
         end
     end
 end


### PR DESCRIPTION
This can be used by script code for reliably storing Lua values without
having to build a custom serialization format.

The C++ code can also be used by other code modules that want to
serialize data. The new classes simply return a byte array with an
unspecified format.

At the moment this uses a plain JSON encoding but could be extended in
the future to include either compression or BSON encoding if necessary.
The format is future compatible by using a simple header to identify
different kinds of formats.