### PR TITLE
Store and reuse formation object slotnum

### DIFF
--- a/code/ai/ai.h
+++ b/code/ai/ai.h
@@ -487,6 +487,8 @@ typedef struct ai_info {
 	flagset<AI::Maneuver_Override_Flags>	ai_override_flags;			// flags for marking ai overrides from sexp or lua systems
 	control_info	ai_override_ci;		// ai override control info
 	int		ai_override_timestamp;		// mark for when to end the current override
+
+	int form_obj_slotnum;               // for flying in formation object mode, the position in the formation
 } ai_info;
 
 // Goober5000
@@ -662,5 +664,7 @@ void ai_update_aim(ai_info *aip);
 
 //SUSHI: Random evasive sidethrust
 void do_random_sidethrust(ai_info *aip, ship_info *sip);
+
+void ai_formation_object_recalculate_slotnums(int form_objnum, int dying_objnum = -1);
 
 #endif

--- a/code/ai/ai.h
+++ b/code/ai/ai.h
@@ -665,6 +665,6 @@ void ai_update_aim(ai_info *aip);
 //SUSHI: Random evasive sidethrust
 void do_random_sidethrust(ai_info *aip, ship_info *sip);
 
-void ai_formation_object_recalculate_slotnums(int form_objnum, int dying_objnum = -1);
+void ai_formation_object_recalculate_slotnums(int form_objnum, int exiting_objnum = -1);
 
 #endif

--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -3389,9 +3389,9 @@ void ai_form_on_wing(object *objp, object *goal_objp)
 
 /**
  * Redistributes slotnums to all ships flying off a given formation object
- * In the case this is needed because a ship is dying, its objnum is needed to explicitly exclude it
+ * In the case this is needed because it has left the field or died, its objnum is needed to explicitly exclude it
  */
-void ai_formation_object_recalculate_slotnums(int form_objnum, int dying_objnum)
+void ai_formation_object_recalculate_slotnums(int form_objnum, int exiting_objnum)
 {
 	Assertion(form_objnum >= 0, "Invalid object number in ai_formation_object_recalculate_slotnums!");
 	int	slotnum = 1;			//	Note: Slot #0 means leader, which isn't someone who was told to form-on-wing.
@@ -3399,7 +3399,7 @@ void ai_formation_object_recalculate_slotnums(int form_objnum, int dying_objnum)
 	for (ship_obj* ship = GET_FIRST(&Ship_obj_list); ship != END_OF_LIST(&Ship_obj_list); ship = GET_NEXT(ship) ) {
 		ai_info* aip = &Ai_info[Ships[Objects[ship->objnum].instance].ai_index];
 
-		if (ship->objnum == dying_objnum)
+		if (ship->objnum == exiting_objnum)
 			continue;
 
 		if (aip->ai_flags[AI::AI_Flags::Formation_object]) {
@@ -15215,7 +15215,7 @@ void ai_ship_destroy(int shipnum)
 	}
 
 	if (dead_aip->ai_flags[AI::AI_Flags::Formation_object])
-		ai_formation_object_recalculate_slotnums(dead_aip->goal_objnum, shipnum);
+		ai_formation_object_recalculate_slotnums(dead_aip->goal_objnum, objnum);
 
 }
 

--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -14396,6 +14396,8 @@ void init_ai_object(int objnum)
 	aip->lethality = 0.0f;
 	aip->ai_override_flags.reset();
 	memset(&aip->ai_override_ci,0,sizeof(control_info));
+
+	aip->form_obj_slotnum = -1;
 }
 
 void init_ai_system()

--- a/code/ai/aigoals.cpp
+++ b/code/ai/aigoals.cpp
@@ -2118,7 +2118,13 @@ void ai_process_mission_orders( int objnum, ai_info *aip )
 	// if this object was flying in formation off of another object, remove the flag that tells him
 	// to do this.  The form-on-my-wing command is removed from the goal list as soon as it is called, so
 	// we are safe removing this bit here.
-	aip->ai_flags.remove(AI::AI_Flags::Formation_object);
+	int old_form_objnum = -1;
+	if (aip->ai_flags[AI::AI_Flags::Formation_object]) {
+		// save who he was following so we can tell any others 
+		// who are following to re-organize
+		old_form_objnum = aip->goal_objnum;
+		aip->ai_flags.remove(AI::AI_Flags::Formation_object);
+	}
 
 	// Goober5000 - we may want to use AI for the player
 	// AL 3-7-98: If this is a player ship, and the goal is not a formation goal, then do a quick out
@@ -2384,6 +2390,8 @@ void ai_process_mission_orders( int objnum, ai_info *aip )
 		break;
 	}
 
+	if (old_form_objnum != -1)
+		ai_formation_object_recalculate_slotnums(old_form_objnum);
 }
 
 void ai_update_goal_references(ai_goal *goals, int type, const char *old_name, const char *new_name)


### PR DESCRIPTION
Every frame every ship flying in formation object mode loops through all objects in order to find its slotnum to determine its rank and file position in the formation. This instead stores the number in `ai_info` and only recalculates when an order to enter or leave formation object mode is processed or a ship that was flying in the mode dies (and also does so for all ships flying off a given ship in one pass).