### PR TITLE
Two small fixes to the external camera

### DIFF
--- a/code/camera/camera.cpp
+++ b/code/camera/camera.cpp
@@ -1101,8 +1101,9 @@ float cam_get_bbox_dist(const object* viewer_obj, float preferred_distance, cons
 	if (viewer_obj == nullptr)
 		return preferred_distance;
 
-	// radius should be the maximal extent of the bbox from the center, so if its at least that plus the padding its guaranteed to be good
-	if (preferred_distance > viewer_obj->radius * EXTERN_CAM_BBOX_MULTIPLIER_PADDING + EXTERN_CAM_BBOX_CONSTANT_PADDING) 
+	// radius is the maximal extent of the ship's bbox from the center, so if its at least that plus the padding its guaranteed to be good
+	// plus a little fudge factor at the end because shields count against the bounding box, but not the radius
+	if (preferred_distance > (viewer_obj->radius * EXTERN_CAM_BBOX_MULTIPLIER_PADDING + EXTERN_CAM_BBOX_CONSTANT_PADDING) * 1.5f) 
 		return preferred_distance;
 	
 	int modelnum = object_get_model(viewer_obj);

--- a/code/hud/hudtarget.cpp
+++ b/code/hud/hudtarget.cpp
@@ -4440,8 +4440,6 @@ void hud_target_change_check()
 		if (Viewer_mode & VM_EXTERNAL) {
 			if (Viewer_mode & VM_OTHER_SHIP)
 				Viewer_external_info.preferred_distance = 2 * Objects[Player_ai->target_objnum].radius;
-			else
-				Viewer_external_info.preferred_distance = 2 * Player_obj->radius;
 		}
 	}
 	else {


### PR DESCRIPTION
Adds a bit more buffer to the early out for the camera bbox collision function since shields count towards the bounding box, but not the radius. 1.5x should work in practically all situations.

Also no need to reset the camera distance when you're external but not viewing from another ship, changing target in that case doesn't change your camera view.