### PR TITLE
Minor Refactor of Special Character Index Handling

### DIFF
--- a/code/graphics/software/FSFont.cpp
+++ b/code/graphics/software/FSFont.cpp
@@ -25,6 +25,11 @@ namespace font
 		this->name = newName;
 	}
 
+	void FSFont::setFilename(const SCP_string& newName) 
+	{
+		this->filename = newName;
+	}
+
 	float FSFont::getBottomOffset() const
 	{
 		return this->offsetBottom;
@@ -43,6 +48,11 @@ namespace font
 	const SCP_string &FSFont::getName() const
 	{
 		return this->name;
+	}
+
+	const SCP_string &FSFont::getFilename() const
+	{
+		return this->filename;
 	}
 
 	void FSFont::computeFontMetrics() {

--- a/code/graphics/software/FSFont.h
+++ b/code/graphics/software/FSFont.h
@@ -32,6 +32,7 @@ namespace font
 	{
 	private:
 		SCP_string name;	//!< The name of this font
+		SCP_string filename; //!< The file name used to retrieve this font
 
 	protected:
 		float offsetTop;		//!< The offset at the top of a line of text
@@ -64,9 +65,18 @@ namespace font
 		*
 		* @date	23.11.2011
 		*
-		* @param	name	The new name.
+		* @param	newName		The new name.
 		*/
 		void setName(const SCP_string& newName);
+
+		/**
+		* @brief	Sets the filename of this font.
+		*
+		* @date	9.9.2020
+		*
+		* @param	newName		The new filename.
+		*/
+		void setFilename(const SCP_string& newName);
 
 		/**
 		* @brief	Gets the name of this font.
@@ -76,6 +86,15 @@ namespace font
 		* @return	The name.
 		*/
 		const SCP_string& getName() const;
+
+		/**
+		* @brief	Gets the filename of this font.
+		*
+		* @date	9.9.2020
+		*
+		* @return	The name.
+		*/
+		const SCP_string& getFilename() const;
 
 		/**
 		* @brief	Gets the type of this font.

--- a/code/graphics/software/FontManager.cpp
+++ b/code/graphics/software/FontManager.cpp
@@ -31,6 +31,16 @@ namespace font
 		return NULL;
 	}
 
+	FSFont* FontManager::getFontByFilename(const SCP_string& filename) 
+	{
+		for (auto & iter : fonts) 
+		{
+			if (iter->getFilename() == filename)
+				return iter.get();
+		}
+		return nullptr;
+	}
+
 	FSFont *FontManager::getCurrentFont()
 	{
 		return currentFont;

--- a/code/graphics/software/FontManager.h
+++ b/code/graphics/software/FontManager.h
@@ -72,6 +72,17 @@ namespace font {
 		static FSFont *getFont(const SCP_string &name);
 
 		/**
+		* @brief Returns a pointer to the font with the specified filename
+		*
+		* Searches the internal list of fonts for the _first_ font with the filename and returns it to the caller.
+		* If the specified name could not be found then nullptr is returned instead.
+		*
+		* @param filename The filename that should be searched for
+		* @return The font pointer or nullptr when font could not be found.
+		*/
+		static FSFont* getFontByFilename(const SCP_string &filename);
+
+		/**
 		* @brief Returns a pointer to the font at the specified index
 		*
 		* Returns the font pointer which is located as the specified index or @c NULL when the specified index is invald

--- a/code/graphics/software/font.h
+++ b/code/graphics/software/font.h
@@ -104,4 +104,12 @@ namespace font
 	* @return The font pointer or NULL if no font with that name could be found
 	*/
 	FSFont *get_font(const SCP_string& name);
+
+	/**
+	* @brief Retrieves a font by filename 
+	*
+	* @param filename The filename which should be searched
+	* @return The font pointer or nullptr if no font with that filename could be found
+	*/
+	FSFont *get_font_by_filename(const SCP_string& filename);
 }

--- a/code/localization/localize.cpp
+++ b/code/localization/localize.cpp
@@ -191,7 +191,7 @@ void parse_stringstbl_quick(const char *filename)
 				if (!Unicode_text_mode) {
 					required_string("+Special Character Index:");
 					stuff_ubyte(&language.special_char_indexes[0]);
-					for (i = 1; i < LCL_MAX_FONTS; ++i) {
+					for (i = 1; i < LCL_MIN_FONTS; ++i) {
 						// default to "none"/0 except for font03 which defaults to 176
 						// NOTE: fonts.tbl may override these values
 						if (i == font::FONT3) {
@@ -202,7 +202,7 @@ void parse_stringstbl_quick(const char *filename)
 					}
 				} else {
 					// Set all indices to valid values
-					for (i = 0; i < LCL_MAX_FONTS; ++i) {
+					for (i = 0; i < LCL_MIN_FONTS; ++i) {
 						language.special_char_indexes[i] = 0;
 					}
 				}
@@ -521,8 +521,8 @@ ubyte lcl_get_font_index(int font_num)
 		// we just return 0 to signify that there are no special characters in this font
 		return 0;
 	} else {
-		Assertion((font_num >= 0) && (font_num < LCL_MAX_FONTS), "Passed an invalid font index");
-		Assertion((lang >= 0) && (lang < (int)Lcl_languages.size()), "Current language is not valid, can't get font indexes");
+		Assertion((lang >= 0) && (lang < (int)Lcl_languages.size()), "Current language %d is not valid, can't get font indexes. This is a coder error, please report.", lang);
+		Assertion((font_num >= 0) && (font_num < (int)Lcl_languages[lang].special_char_indexes.size()), "Passed an invalid font index, %d. This is a coder error, please report.", font_num);
 
 		return Lcl_languages[lang].special_char_indexes[font_num];
 	}

--- a/code/localization/localize.h
+++ b/code/localization/localize.h
@@ -31,13 +31,13 @@
 // for language name strings
 #define LCL_LANG_NAME_LEN				32
 
-#define LCL_MAX_FONTS					5
+#define LCL_MIN_FONTS					3
 
 // language info table
 typedef struct lang_info {
 	char lang_name[LCL_LANG_NAME_LEN + 1];				// literal name of the language
 	char lang_ext[LCL_LANG_NAME_LEN + 1];				// the extension used for adding to names on disk access
-	ubyte special_char_indexes[LCL_MAX_FONTS];			// where in the font do we have the special characters for this language
+	SCP_vector<ubyte> special_char_indexes;				// where in the font do we have the special characters for this language
 														// note: treats 0 as "none" since a zero offset in a font makes no sense
 														// i.e. all the normal chars start at zero
 	int checksum;										// used for language auto-detection


### PR DESCRIPTION
Now tested on Retail, Admiral Nelson's 4K mod and FotG . Special characters all appear normally.

1. Stores the filename from the table Parser into the font struct so we can lookup fonts via their filename.
2. Allow "+Special Character Font:" to specify the first entry with the same filename's special character index for their own special character index, provide a default if not, or allow the modder to specify them manually, but do not override already recorded values if the default is picked in order to protect retail behavior.
3. Vectorize Special Character Indexes, so that we don't have a table limit that will randomly crash FSO based on what table you happened to write! Woohoo! But provide a minimum to again protect retail behavior.