### PR TITLE
Improve beam collision optimization

### DIFF
--- a/code/math/fvi.cpp
+++ b/code/math/fvi.cpp
@@ -243,6 +243,33 @@ int fvi_segment_sphere(vec3d *intp, const vec3d *p0, const vec3d *p1, const vec3
 		return 0;
 }
 
+/**
+ * Determine if a cylinder *may* intersect with a sphere
+ *
+ * cylinder from p0 to p1 with radius cyl_rad
+ * sphere at sphere_pos with radius sphere_rad
+ * @return false if definitely not intersecting, returns true if intersection is possible
+ */
+bool fvi_cylinder_sphere_may_collide(const vec3d* p0, const vec3d* p1, float cyl_rad, const vec3d* sphere_pos, float sphere_rad)
+{
+	vec3d cyl_rel = *p1 - *p0;
+	vec3d sphere_rel = *sphere_pos - *p0;
+
+	float cyl_len = vm_vec_mag(&cyl_rel);
+	if (cyl_len < SMALL_NUM)
+		// zero length cylinder, weird but ok, just do two sphere intersection
+		return vm_vec_mag_squared(&sphere_rel) <= (cyl_rad + sphere_rad) * (cyl_rad + sphere_rad);
+	 
+	vec3d cyl_dir = cyl_rel / cyl_len;
+	float intp_dist = vm_vec_dot(&cyl_dir, &sphere_rel);
+	if (intp_dist < -sphere_rad || intp_dist > cyl_len + sphere_rad)
+		// sphere is too far beyond either end of the cylinder
+		return false;
+
+	vec3d sphere_rel_intp = sphere_rel - cyl_dir * intp_dist;
+	return vm_vec_mag_squared(&sphere_rel_intp) <= (cyl_rad + sphere_rad) * (cyl_rad + sphere_rad);
+}
+
 
 /**
  * Determine if and where a ray intersects with a sphere

--- a/code/math/fvi.h
+++ b/code/math/fvi.h
@@ -90,6 +90,15 @@ int fvi_point_face(const vec3d *checkp, int nv, vec3d const *const *verts, const
 //else returns 0
 int fvi_segment_sphere(vec3d *intp, const vec3d *p0, const vec3d *p1, const vec3d *sphere_pos, float sphere_rad);
 
+/**
+ * Determine if a cylinder *may* intersect with a sphere
+ *
+ * cylinder from p0 to p1 with radius cyl_rad
+ * sphere at sphere_pos with radius sphere_rad
+ * @return false if definitely not intersecting, returns true if intersection is possible
+ */
+bool fvi_cylinder_sphere_may_collide(const vec3d* p0, const vec3d* p1, float cyl_rad, const vec3d* sphere_pos, float sphere_rad);
+
 //determine if and where a ray intersects with a sphere
 //vector defined by p0,p1 
 //returns 1 if intersects, and fills in intp

--- a/code/weapon/beam.cpp
+++ b/code/weapon/beam.cpp
@@ -268,6 +268,29 @@ void beam_level_close()
 	list_init( &Beam_used_list );
 }
 
+// get the width of the widest section of the beam
+float beam_get_widest(beam* b)
+{
+	int idx;
+	float widest = -1.0f;
+
+	// sanity
+	Assert(b->weapon_info_index >= 0);
+	if (b->weapon_info_index < 0) {
+		return -1.0f;
+	}
+
+	// lookup
+	for (idx = 0; idx < Weapon_info[b->weapon_info_index].b_info.beam_num_sections; idx++) {
+		if (Weapon_info[b->weapon_info_index].b_info.sections[idx].width > widest) {
+			widest = Weapon_info[b->weapon_info_index].b_info.sections[idx].width;
+		}
+	}
+
+	// return	
+	return widest;
+}
+
 // fire a beam, returns nonzero on success. the innards of the code handle all the rest, foo
 int beam_fire(beam_fire_info *fire_info)
 {
@@ -386,20 +409,9 @@ int beam_fire(beam_fire_info *fire_info)
 	for (int i = 0; i < MAX_BEAM_SECTIONS; i++)
 		new_item->beam_section_frame[i] = 0.0f;
 
-	// beam width
-	if (wip->b_info.beam_width > 0.0f) {
-		new_item->beam_width = wip->b_info.beam_width;
-	}
-	else {
-		// lookup
-		float widest = -1.0f;
-		for (int idx = 0; idx < Weapon_info[new_item->weapon_info_index].b_info.beam_num_sections; idx++) {
-			if (Weapon_info[new_item->weapon_info_index].b_info.sections[idx].width > widest) {
-				widest = Weapon_info[new_item->weapon_info_index].b_info.sections[idx].width;
-			}
-		}
-		new_item->beam_width = widest;
-	}
+	// beam width, if it wasn't already set above
+	if (new_item->beam_width <= 0.f)
+		new_item->beam_width = beam_get_widest(new_item);
 	
 	if (fire_info->bfi_flags & BFIF_IS_FIGHTER_BEAM) {
 		new_item->type = BEAM_TYPE_C;

--- a/code/weapon/beam.cpp
+++ b/code/weapon/beam.cpp
@@ -3003,7 +3003,7 @@ int beam_collide_early_out(object *a, object *b)
 // resulting in "tooled" ships taking twice as much damage (in a later function) as they should.
 void beam_add_collision(beam *b, object *hit_object, mc_info *cinfo, int quadrant_num, bool exit_flag)
 {
-	beam_collision *bc = NULL;
+	beam_collision *bc = nullptr;
 	int idx;
 
 	// if we haven't reached the limit for beam collisions, just add it
@@ -3014,12 +3014,12 @@ void beam_add_collision(beam *b, object *hit_object, mc_info *cinfo, int quadran
 	// I guess we can always just remove the farthest item
 	else {
 		for (idx = 0; idx < MAX_FRAME_COLLISIONS; idx++) {
-			if ((bc == NULL) || (b->f_collisions[idx].cinfo.hit_dist > bc->cinfo.hit_dist))
+			if ((bc == nullptr) || (b->f_collisions[idx].cinfo.hit_dist > bc->cinfo.hit_dist))
 				bc = &b->f_collisions[idx];
 		}
 	}
 
-	if (bc == NULL) {
+	if (bc == nullptr) {
 		Int3();
 		return;
 	}

--- a/code/weapon/beam.cpp
+++ b/code/weapon/beam.cpp
@@ -24,6 +24,7 @@
 #include "iff_defs/iff_defs.h"
 #include "io/timer.h"
 #include "lighting/lighting.h"
+#include "math/fvi.h"
 #include "mod_table/mod_table.h"
 #include "network/multi.h"
 #include "network/multimsgs.h"
@@ -2924,7 +2925,6 @@ int beam_collide_early_out(object *a, object *b)
 {
 	beam *bm;
 	weapon_info *bwi;
-	vec3d dot_test, dot_test2, dist_test;	
 		
 	// get the beam
 	Assert(a->instance >= 0);
@@ -2993,17 +2993,9 @@ int beam_collide_early_out(object *a, object *b)
 		break;
 	}
 
-	// get full cull value
-	beam_get_cull_vals(b, bm, &cull_dot, &cull_dist);
-
-	// if the object fails these conditions, bail
-	vm_vec_sub(&dist_test, &b->pos, &bm->last_start);
-	dot_test = dist_test;
-	vm_vec_sub(&dot_test2, &bm->last_shot, &bm->last_start);
-	vm_vec_normalize_quick(&dot_test);
-	vm_vec_normalize_quick(&dot_test2);
-	// cull_dist == DIST SQUARED FOO!
-	if((vm_vec_dot(&dot_test, &dot_test2) < cull_dot) && (vm_vec_mag_squared(&dist_test) > cull_dist)){
+	// do a cylinder-sphere collision test
+	if (!fvi_cylinder_sphere_may_collide(&bm->last_start, &bm->last_shot,
+		bm->beam_width * bm->shrink * 0.5f, &b->pos, b->radius * 1.2f)) {
 		return 1;
 	}
 	

--- a/code/weapon/beam.cpp
+++ b/code/weapon/beam.cpp
@@ -1669,7 +1669,7 @@ void beam_add_light_small(beam *bm, object *objp, vec3d *pt_override = NULL)
 		noise = 1.0f;
 
 	// get the width of the beam
-	float light_rad = bm->beam_width * bm->shrink * blight * noise;	
+	float light_rad = bm->beam_width * bm->current_width_factor * blight * noise;	
 
 	// nearest point on the beam, and its distance to the ship
 	vec3d near_pt;
@@ -1736,7 +1736,7 @@ void beam_add_light_large(beam *bm, object *objp, vec3d *pt0, vec3d *pt1)
 	noise = frand_range(1.0f - bwi->sections[0].flicker, 1.0f + bwi->sections[0].flicker);
 
 	// width of the beam
-	float light_rad = bm->beam_width * bm->shrink * blight * noise;		
+	float light_rad = bm->beam_width * bm->current_width_factor * blight * noise;
 
 	// average rgb of the beam	
 	float fr = (float)wip->laser_color_1.red / 255.0f;
@@ -2456,7 +2456,7 @@ int beam_collide_ship(obj_pair *pair)
 	polymodel *pm = model_get(model_num);
 
 	// get the width of the beam
-	width = b->beam_width * b->shrink;
+	width = b->beam_width * b->current_width_factor;
 
 
 	// Goober5000 - I tried to make collision code much saner... here begin the (major) changes
@@ -2999,7 +2999,7 @@ int beam_collide_early_out(object *a, object *b)
 		break;
 	}
 
-	float beam_radius = bm->beam_width * bm->shrink * 0.5f;
+	float beam_radius = bm->beam_width * bm->current_width_factor * 0.5f;
 	// do a cylinder-sphere collision test
 	if (!fvi_cylinder_sphere_may_collide(&bm->last_start, &bm->last_shot,
 		beam_radius, &b->pos, b->radius * 1.2f)) {
@@ -3075,7 +3075,7 @@ void beam_handle_collisions(beam *b)
 	wi = &Weapon_info[b->weapon_info_index];
 
 	// get the width of the beam
-	width = b->beam_width * b->shrink;
+	width = b->beam_width * b->current_width_factor;
 
 	// the first thing we need to do is sort the collisions, from closest to farthest
 	std::sort(b->f_collisions, b->f_collisions + b->f_collision_count, beam_sort_collisions_func);


### PR DESCRIPTION
The `beam_get_cone_dot` function used for early collision culling will claim that non-slashers could possibly collide in a "very small" cone of 50 degrees. This is obviously absurdly conservative and, more problematically, I could also adversarially beat it and get erroneous early outs. This led me down a rabbit hole of profiling every step of the beam collision process and attempting multiple approaches to improve performance and most importantly, be actually correct in all cases. 

From this profiling I've learned that memory access is almost certainly a greater barrier to speed now as opposed to math, and the various functions calls and basic math trying their damndest to skirt around ever using a square root are no longer really relevant on modern architecture. Replacing the 'dot test' (checking the angle of the beam to the possible collider's position) and 'dist test' (check if the beam origin is within possible collider's radius) with a basic cylinder-sphere collision function takes about as much time (~700 nanoseconds), and improves the early culling percentage from ~65% to ~95%, with an overall 'per collision check' average from ~3500 ns to ~2000 ns. (tested with 6 beam-armed warships and a dozen fighters in the attached test mission)
[beamtest.txt](https://github.com/scp-fs2open/fs2open.github.com/files/5207541/beamtest.txt)

The actual `model_collide` function will use `fvi_segment_sphere` regardless, which is largely similar to the added `fvi_cylinder_sphere_may_collide` but excludes some unnecessary sphere intersection points and doesn't need to do all the set up of the collision info struct ahead of time (excluding the early out, reaching and concluding `fvi_segment_sphere` has already cost ~1400 ns).

Similar optimizations could probably be made all over the collision code, but... one step at a time.

Almost unrelatedly, but this was the original change that sent me down the rabbit hole, beam width never changes during its lifetime and the beam stores `beam_width` anyway (but only in the case its manually defined), so there's no reason for a function to recalculate it everytime its needed; calculate once at creation and then use that.