### PR TITLE
fix display name

### DIFF
--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -2786,6 +2786,7 @@ int parse_object(mission *pm, int  /*flag*/, p_object *p_objp)
 	p_objp->created_object = NULL;
 	p_objp->next = NULL;
 	p_objp->prev = NULL;
+	p_objp->flags.reset();
 
 	required_string("$Name:");
 	stuff_string(p_objp->name, F_NAME, NAME_LENGTH);
@@ -3077,7 +3078,6 @@ int parse_object(mission *pm, int  /*flag*/, p_object *p_objp)
 	stuff_int(&dummy);
 
     // set flags
-    p_objp->flags.reset();
     if (optional_string("+Flags:"))
     {
         SCP_vector<SCP_string> unparsed;


### PR DESCRIPTION
PR #2718 introduced the Has_display_name flag, but for mission parsing, the parse object flags were cleared subsequent to their assignment.  This moves the flag reset earlier in the function.