### PR TITLE
Remove turning framerate dependence for AI

### DIFF
--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -1140,6 +1140,7 @@ void ai_update_danger_weapon(int attacked_objnum, int weapon_objnum)
 
 // Asteroth - Manipulates retail inputs to produce the outputs that would match retail behavior
 // vel and acc_limit should already be sent in with retail values
+// A more in-depth explanation can be found in the #2740 PR description
 void ai_compensate_for_retail_turning(vec3d* vel_limit, vec3d* acc_limit, float rotdamp, bool is_weapon) {
 	
 	if (is_weapon) {
@@ -1150,7 +1151,9 @@ void ai_compensate_for_retail_turning(vec3d* vel_limit, vec3d* acc_limit, float 
 		return;
 	}
 
-	 // If we're a ship instead things get a bit hairier
+	// If we're a ship instead things get a bit hairier
+	// This is the polynomial approximation of the 'combination' effects of
+	// angular_move and physics_sim_rot
 	for (int i = 0; i < 3; i++) {
 		float& vel = vel_limit->a1d[i];
 		float& acc = acc_limit->a1d[i];

--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -1140,9 +1140,9 @@ void ai_update_danger_weapon(int attacked_objnum, int weapon_objnum)
 
 // Asteroth - Manipulates retail inputs to produce the outputs that would match retail behavior
 // vel and acc_limit should already be sent in with retail values
-void ai_compensate_for_retail_turning(vec3d* vel_limit, vec3d* acc_limit, float rotdamp, bool weapon) {
+void ai_compensate_for_retail_turning(vec3d* vel_limit, vec3d* acc_limit, float rotdamp, bool is_weapon) {
 	
-	if (weapon) {
+	if (is_weapon) {
 		// Missiles accelerated instantly technically, but this should do.
 		*acc_limit = *vel_limit * 1000.f;
 		// Approximately what you'd get at 60fps
@@ -1252,7 +1252,7 @@ void ai_turn_towards_vector(vec3d* dest, object* objp, vec3d* slide_vec, vec3d* 
 		acc_limit *= 8.0f;
 
 	if (Framerate_independent_turning) {
-		// handle modifications to rotdamp (and therefore acc_limit)
+		// handle modifications to rotdamp (that could affect acc_limit and vel_limit)
 		// handled in its entirety in physics_sim_rot 
 		float rotdamp = pip->rotdamp;
 		float shock_fraction_time_left = 0.f;
@@ -12025,6 +12025,7 @@ int ai_formation()
 		}
 
 	}
+
 	return 0;
 }
 

--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -59,7 +59,7 @@ std::tuple<ubyte, ubyte, ubyte> Arc_color_emp_p1;
 std::tuple<ubyte, ubyte, ubyte> Arc_color_emp_p2;
 std::tuple<ubyte, ubyte, ubyte> Arc_color_emp_s1;
 bool Use_engine_wash_intensity;
-bool Ai_before_physics;
+bool Framerate_independent_turning;
 bool Swarmers_lead_targets;
 SCP_vector<gr_capability> Required_render_ext;
 float Weapon_SS_Threshold_Turret_Inaccuracy;
@@ -114,10 +114,6 @@ void parse_mod_table(const char *filename)
 			stuff_boolean(&Use_tabled_strings_for_default_language);
 
 			mprintf(("Game settings table: Use tabled strings (translations) for the default language: %s\n", Use_tabled_strings_for_default_language ? "yes" : "no"));
-		}
-
-		if (optional_string("$Process AI before physics:")) {
-			stuff_boolean(&Ai_before_physics);
 		}
 
 		optional_string("#CAMPAIGN SETTINGS");
@@ -567,6 +563,10 @@ void parse_mod_table(const char *filename)
 			}
 		}
 
+		if (optional_string("$AI use framerate independent turning:")) {
+			stuff_boolean(&Framerate_independent_turning);
+		}
+
 		required_string("#END");
 	}
 	catch (const parse::ParseException& e)
@@ -641,7 +641,7 @@ void mod_table_reset()
 	Arc_color_emp_p2 = std::make_tuple(static_cast<ubyte>(128), static_cast<ubyte>(128), static_cast<ubyte>(10));
 	Arc_color_emp_s1 = std::make_tuple(static_cast<ubyte>(255), static_cast<ubyte>(255), static_cast<ubyte>(10));
 	Use_engine_wash_intensity = false;
-  Ai_before_physics = false;
+	Framerate_independent_turning = false;
 	Swarmers_lead_targets = false;
 	Required_render_ext.clear();
 	Weapon_SS_Threshold_Turret_Inaccuracy = 0.7f; // Defaults to retail value of 0.7 --wookieejedi

--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -59,7 +59,7 @@ std::tuple<ubyte, ubyte, ubyte> Arc_color_emp_p1;
 std::tuple<ubyte, ubyte, ubyte> Arc_color_emp_p2;
 std::tuple<ubyte, ubyte, ubyte> Arc_color_emp_s1;
 bool Use_engine_wash_intensity;
-bool Framerate_independent_turning;
+bool Framerate_independent_turning; // an in-depth explanation how this flag is supposed to work can be found in #2740 PR description
 bool Swarmers_lead_targets;
 SCP_vector<gr_capability> Required_render_ext;
 float Weapon_SS_Threshold_Turret_Inaccuracy;

--- a/code/mod_table/mod_table.h
+++ b/code/mod_table/mod_table.h
@@ -51,7 +51,6 @@ extern std::tuple<ubyte, ubyte, ubyte> Arc_color_emp_p1;
 extern std::tuple<ubyte, ubyte, ubyte> Arc_color_emp_p2;
 extern std::tuple<ubyte, ubyte, ubyte> Arc_color_emp_s1;
 extern bool Use_engine_wash_intensity;
-extern bool Ai_before_physics;
 extern bool Swarmers_lead_targets;
 extern SCP_vector<gr_capability> Required_render_ext;
 extern float Weapon_SS_Threshold_Turret_Inaccuracy;

--- a/code/mod_table/mod_table.h
+++ b/code/mod_table/mod_table.h
@@ -55,6 +55,7 @@ extern bool Ai_before_physics;
 extern bool Swarmers_lead_targets;
 extern SCP_vector<gr_capability> Required_render_ext;
 extern float Weapon_SS_Threshold_Turret_Inaccuracy;
+extern bool Framerate_independent_turning;
 
 void mod_table_init();
 

--- a/code/object/object.cpp
+++ b/code/object/object.cpp
@@ -928,8 +928,7 @@ void obj_move_call_physics(object *objp, float frametime)
 			// then reset the flag and don't move the object.
             if (MULTIPLAYER_MASTER && (objp->flags[Object::Object_Flags::Just_updated])) {
 				objp->flags.remove(Object::Object_Flags::Just_updated);
-			}
-			else {
+			} else {
 				physics_sim(&objp->pos, &objp->orient, &objp->phys_info, frametime);		// simulate the physics
 			}
 

--- a/code/object/object.cpp
+++ b/code/object/object.cpp
@@ -839,6 +839,7 @@ void obj_move_call_physics(object *objp, float frametime)
 			if (engine_strength == 0.0f) {	//	All this is necessary to make ship gradually come to a stop after engines are blown.
 				vm_vec_zero(&objp->phys_info.desired_vel);
 				vm_vec_zero(&objp->phys_info.desired_rotvel);
+				vm_mat_zero(&objp->phys_info.ai_desired_orient);
 				objp->phys_info.flags |= (PF_REDUCED_DAMP | PF_DEAD_DAMP);
 				objp->phys_info.side_slip_time_const = Ship_info[shipp->ship_info_index].damp * 4.0f;
 			}

--- a/code/object/object.cpp
+++ b/code/object/object.cpp
@@ -928,15 +928,14 @@ void obj_move_call_physics(object *objp, float frametime)
 			// then reset the flag and don't move the object.
             if (MULTIPLAYER_MASTER && (objp->flags[Object::Object_Flags::Just_updated])) {
 				objp->flags.remove(Object::Object_Flags::Just_updated);
-				goto obj_maybe_fire;
 			}
-
-				physics_sim(&objp->pos, &objp->orient, &objp->phys_info, frametime );		// simulate the physics
+			else {
+				physics_sim(&objp->pos, &objp->orient, &objp->phys_info, frametime);		// simulate the physics
+			}
 
 			// if the object is the player object, do things that need to be done after the ship
 			// is moved (like firing weapons, etc).  This routine will get called either single
 			// or multiplayer.  We must find the player object to get to the control info field
-obj_maybe_fire:
 			if ( (objp->flags[Object::Object_Flags::Player_ship]) && (objp->type != OBJ_OBSERVER) && (objp == Player_obj)) {
 				player *pp;
 				if(Player != NULL){

--- a/code/physics/physics.cpp
+++ b/code/physics/physics.cpp
@@ -150,10 +150,8 @@ void physics_set_viewer( physics_info * p, int dir )
 
 void physics_sim_rot(matrix * orient, physics_info * pi, float sim_time )
 {
-	angles	tangles = { 0,0,0 };
 	vec3d	new_vel;
 	matrix	tmp;
-	float		shock_amplitude = 0.0f;
 	float		rotdamp;
 	float		shock_fraction_time_left;
 
@@ -162,6 +160,7 @@ void physics_sim_rot(matrix * orient, physics_info * pi, float sim_time )
 	Assert(is_valid_vec(&pi->desired_rotvel));
 
 	// Handle special case of shockwave
+	float		shock_amplitude = 0.0f;
 	if (pi->flags & PF_IN_SHOCKWAVE) {
 		if (timestamp_elapsed(pi->shockwave_decay)) {
 			pi->flags &= ~PF_IN_SHOCKWAVE;
@@ -180,6 +179,9 @@ void physics_sim_rot(matrix * orient, physics_info * pi, float sim_time )
 		rotdamp = pi->rotdamp;
 	}
 
+	angles	tangles = vmd_zero_angles;
+
+	// "frit" here meaning Framerate_independent_turning
 	bool frit_ai_wants_to_move = Framerate_independent_turning && !IS_MAT_NULL(&pi->ai_desired_orient);
 	bool spinning_too_fast = vm_vec_mag(&pi->max_rotvel) > 0.001f &&
 		(pi->rotvel.xyz.x > pi->max_rotvel.xyz.x * 1.5f ||

--- a/code/physics/physics.cpp
+++ b/code/physics/physics.cpp
@@ -208,9 +208,9 @@ void physics_sim_rot(matrix * orient, physics_info * pi, float sim_time )
 		}
 
 		// Do rotational physics with given damping
-		apply_physics(rotdamp, pi->desired_rotvel.xyz.x, pi->rotvel.xyz.x, sim_time, &new_vel.xyz.x, NULL);
-		apply_physics(rotdamp, pi->desired_rotvel.xyz.y, pi->rotvel.xyz.y, sim_time, &new_vel.xyz.y, NULL);
-		apply_physics(rotdamp, pi->desired_rotvel.xyz.z, pi->rotvel.xyz.z, sim_time, &new_vel.xyz.z, NULL);
+		apply_physics(rotdamp, pi->desired_rotvel.xyz.x, pi->rotvel.xyz.x, sim_time, &new_vel.xyz.x, nullptr);
+		apply_physics(rotdamp, pi->desired_rotvel.xyz.y, pi->rotvel.xyz.y, sim_time, &new_vel.xyz.y, nullptr);
+		apply_physics(rotdamp, pi->desired_rotvel.xyz.z, pi->rotvel.xyz.z, sim_time, &new_vel.xyz.z, nullptr);
 
 		Assert(is_valid_vec(&new_vel));
 
@@ -476,7 +476,7 @@ void physics_read_flying_controls( matrix * orient, physics_info * pi, control_i
 
 	// If Framerate_independent_turning is on, AI don't use CI to turn
 	if (!Framerate_independent_turning || IS_MAT_NULL(&pi->ai_desired_orient)){
-		if (!Flight_controls_follow_eyepoint_orientation || (Player_obj == NULL) || (Player_obj->type != OBJ_SHIP)) {
+		if (!Flight_controls_follow_eyepoint_orientation || (Player_obj == nullptr) || (Player_obj->type != OBJ_SHIP)) {
 			// Default behavior; eyepoint orientation has no effect on controls
 			pi->desired_rotvel.xyz.x = ci->pitch * pi->max_rotvel.xyz.x;
 			pi->desired_rotvel.xyz.y = ci->heading * pi->max_rotvel.xyz.y;

--- a/code/physics/physics.cpp
+++ b/code/physics/physics.cpp
@@ -34,8 +34,6 @@
 #define MAX_SHIP_SPEED		500		// Maximum speed allowed after whack or shockwave
 #define RESET_SHIP_SPEED	440		// Speed that a ship is reset to after exceeding MAX_SHIP_SPEED
 
-#define	SW_ROT_FACTOR			5		// increase in rotational time constant in shockwave
-#define	SW_BLAST_DURATION		2000	// maximum duration of shockwave
 #define	REDUCED_DAMP_FACTOR	10		// increase in side_slip and acceleration time constants (scaled according to reduced damp time)
 #define	REDUCED_DAMP_VEL		30		// change in velocity at which reduced_damp_time is 2000 ms
 #define	REDUCED_DAMP_TIME		2000	// ms (2.0 sec)
@@ -85,6 +83,8 @@ void physics_init( physics_info * pi )
 	vm_vec_make( &pi->I_body_inv.vec.rvec, 1e-5f, 0.0f, 0.0f );
 	vm_vec_make( &pi->I_body_inv.vec.uvec, 0.0f, 1e-5f, 0.0f );
 	vm_vec_make( &pi->I_body_inv.vec.fvec, 0.0f, 0.0f, 1e-5f );
+
+	pi->ai_desired_orient = vmd_zero_matrix; // Asteroth - initialize to the "invalid" orientation, which will be ignored by physics unless set otherwise
 
 }
 

--- a/code/physics/physics.h
+++ b/code/physics/physics.h
@@ -96,14 +96,17 @@ typedef struct physics_info {
 	float afterburner_max_reverse_vel; //SparK: This is the reverse afterburners top speed vector
 	float afterburner_reverse_accel; //SparK: Afterburner's acceleration on reverse mode
 
-	matrix ai_desired_orient;   // Asteroth - This is only set if Frametime_independent_turning is enabled, and only by the AI after calls to angular_move
-							// It is read and then discarded by physics_sim_rot
+	matrix ai_desired_orient;   // Asteroth - This is only set to something other than the zero matrix if Framerate_independent_turning is enabled, and 
+								// only by the AI after calls to angular_move. It is read and then zeroed out for the rest of the frame by physics_sim_rot
 } physics_info;
 
 
 #define CIF_DONT_BANK_WHEN_TURNING		(1 << 0)	// Goober5000 - changing heading does not change bank
 #define CIF_DONT_CLAMP_MAX_VELOCITY		(1 << 1)	// Goober5000 - maneuvers can exceed tabled max velocity
 #define CIF_INSTANTANEOUS_ACCELERATION	(1 << 2)	// Goober5000 - instantaneously jump to the goal velocity
+
+#define	SW_ROT_FACTOR			5		// increase in rotational time constant in shockwave
+#define	SW_BLAST_DURATION		2000	// maximum duration of shockwave
 
 // All of these are numbers from -1.0 to 1.0 indicating
 // what percent of full velocity you want to go.

--- a/code/physics/physics.h
+++ b/code/physics/physics.h
@@ -69,8 +69,9 @@ typedef struct physics_info {
 	// These get changed by the control code.  The physics uses these
 	// as input values when doing physics.
 	vec3d	prev_ramp_vel;				// follows the user's desired velocity, in local coord
-	vec3d	desired_vel;				// in world coord
-	vec3d	desired_rotvel;			// in local coord
+	vec3d	desired_vel;				// in world coord, (possibly) damped by side_slip_time_const to get final vel
+	vec3d	desired_rotvel;				// in local coords, damped by rotdamp to get final rotvel
+										// With framerate_independent_turning, the AI are not damped, see physics_sim_rot
 	float		forward_thrust;			// How much the forward thruster is applied.  0-1.
 	float		side_thrust;			// How much the forward thruster is +x.  0-1.
 	float		vert_thrust;			// How much the forward thruster is +y.  0-1.
@@ -94,6 +95,9 @@ typedef struct physics_info {
 
 	float afterburner_max_reverse_vel; //SparK: This is the reverse afterburners top speed vector
 	float afterburner_reverse_accel; //SparK: Afterburner's acceleration on reverse mode
+
+	matrix ai_desired_orient;   // Asteroth - This is only set if Frametime_independent_turning is enabled, and only by the AI after calls to matrix/forward_interpolate
+							// It is read and then discarded by physics_sim_rot
 } physics_info;
 
 

--- a/code/physics/physics.h
+++ b/code/physics/physics.h
@@ -96,7 +96,7 @@ typedef struct physics_info {
 	float afterburner_max_reverse_vel; //SparK: This is the reverse afterburners top speed vector
 	float afterburner_reverse_accel; //SparK: Afterburner's acceleration on reverse mode
 
-	matrix ai_desired_orient;   // Asteroth - This is only set if Frametime_independent_turning is enabled, and only by the AI after calls to matrix/forward_interpolate
+	matrix ai_desired_orient;   // Asteroth - This is only set if Frametime_independent_turning is enabled, and only by the AI after calls to angular_move
 							// It is read and then discarded by physics_sim_rot
 } physics_info;
 

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -10448,6 +10448,7 @@ void change_ship_type(int n, int ship_type, int by_sexp)
 		Objects[sp->objnum].phys_info.speed = ph_inf.speed;
 		Objects[sp->objnum].phys_info.vel = ph_inf.vel;
 		Objects[sp->objnum].phys_info.vert_thrust = ph_inf.vert_thrust;
+		Objects[sp->objnum].phys_info.ai_desired_orient = ph_inf.ai_desired_orient;
 	}
 
 	ship_set_new_ai_class(sp, sip->ai_class);

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -9047,7 +9047,7 @@ static void lethality_decay(ai_info *aip)
 #endif
 }
 
-// moved out of ship_process_post() so it can be called from either -post() or -pre() depending on Ai_before_physics
+// moved out of ship_process_post() so it can be called from either -post() or -pre() depending on Framerate_independent_turning
 void ship_evaluate_ai(object* obj, float frametime) {
 
 	int num = obj->instance;
@@ -9097,9 +9097,9 @@ void ship_evaluate_ai(object* obj, float frametime) {
 
 void ship_process_pre(object *obj, float frametime)
 {
-	// If Ai_before_physics is false everything following is evaluated in ship_process_post()
+	// If Framerate_independent_turning is false everything following is evaluated in ship_process_post()
 	// Also only multi masters do ai
-	if ( (obj == nullptr) || !frametime || MULTIPLAYER_CLIENT || !Ai_before_physics)
+	if ( (obj == nullptr) || !frametime || MULTIPLAYER_CLIENT || !Framerate_independent_turning)
 		return;
 
 	if (obj->type != OBJ_SHIP) {
@@ -9330,7 +9330,8 @@ void ship_process_post(object * obj, float frametime)
 			ship_check_player_distance();
 		}
 
-		if (!Ai_before_physics)
+		// If Framerate_independent_turning is true this is evaluated in ship_process_pre()
+		if (!Framerate_independent_turning)
 			ship_evaluate_ai(obj, frametime);
 	}
 }

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -4623,7 +4623,7 @@ void weapon_home(object *obj, int num, float frame_time)
 }
 
 
-// moved out of weapon_process_post() so it can be called from either -post() or -pre() depending on Ai_before_physics
+// moved out of weapon_process_post() so it can be called from either -post() or -pre() depending on Framerate_independent_turning
 void weapon_update_missiles(object* obj, float  frame_time) {
 
 	Assertion(obj->type == OBJ_WEAPON, "weapon_update_missiles called on a non-weapon object");
@@ -4638,10 +4638,6 @@ void weapon_update_missiles(object* obj, float  frame_time) {
 		// If this is a swarm type missile,  
 		if (wp->swarm_index >= 0) {
 			swarm_update_direction(obj);
-		}
-
-		if (wp->cscrew_index >= 0) {
-			cscrew_process_post(obj);
 		}
 	}
 	else if (wip->acceleration_time > 0.0f) {
@@ -4705,7 +4701,7 @@ void weapon_process_pre( object *obj, float  frame_time)
 	}
 
 	// If this flag is false missile turning is evaluated in weapon_process_post()
-	if (Ai_before_physics) {
+	if (Framerate_independent_turning) {
 		weapon_update_missiles(obj, frame_time);
 	}
 }
@@ -5008,8 +5004,13 @@ void weapon_process_post(object * obj, float frame_time)
 	}
 
 	// If this flag is true this is evaluated in weapon_process_pre()
-	if (!Ai_before_physics) {
+	if (!Framerate_independent_turning) {
 		weapon_update_missiles(obj, frame_time);
+	}
+
+	//handle corkscrew missiles
+	if (wip->is_homing() && !(wp->weapon_flags[Weapon::Weapon_Flags::No_homing]) && wp->cscrew_index >= 0) {
+		cscrew_process_post(obj);
 	}
 
 	//local ssm stuff


### PR DESCRIPTION
Puts issue #487 into a well-deserved grave. I have a lot to say about this PR, even just for posterity reasons so I'm chunking it up into sections.

THE PROBLEM

First, an overview of the problem. In retail for a given AI controlled entity on a given frame, physics happens first, but nothing interesting happens here because the AI's influence hasn't been introduced yet, so we'll just sort of gloss over this first physics step. Later in the frame the AI is run (or `weapon_home` for missiles), it does its decision procedure and decides it wants to turn toward something. In order to do this, it runs `angular_move` which the AI feeds with its angular velocity and acceleration limits, and current angular velocity, and then proceeds to do the basic math -- for each axis it slows down or speeds up as necessary to arrive at its goal orientation with 0 rotvel as quickly as possible. Importantly, this function is capable of sub-frame maneuvers, if it _can_ accelerate, decelerate and arrive all within the frame it will do so, unlike velocity and position, where velocity is simply set, and then it waits until next frame to see how close it is and maybe speeds up or slows down.

An obvious but important note is that if the ship can't accelerate much, but is moving fast (perhaps it was collided with) the ship will attempt to slow down but otherwise report that it will mostly have turned due to the already existing rotvel.

Once finished the function returns with a new orientation and rotvel, _both of which it sets directly to the ship_, physically turning the ship. On the first frame, all of it's turning came from this AI function.

Next frame: physics comes first. Importantly none of those calculations changed `desired_rotvel`, which is always left at 0, and this is what `physics_sim_rot` works on. It will move the objects current rotvel towards its `desired_rotvel` exponentially, based on its the objects $rotdamp, more rotdamp = less movement towards desired_rotvel. When concluded this function _also_ updates the ship's rotvel and orientation, and since the `desired_rotvel` is always 0, this is always attempting to slow down the AI. If the AI is run again this frame `angular_move` will work on this new orientation, providing a _second_ updated orientation and overwriting the previous rotvel, resulting in (up to) double the apparent angular motion, but half the rotvel it should be given that motion.

THE SYMPTOMS

For a ships and missiles, the apparent results will diverge quite a bit based on that rotdamp. For a very slow capital ship with a rotdamp of 2, the physics doesn't end up slowing it down much at all, but _will_ make the orientation change, in effect doubling the movement that the AI is doing, since it's making basically the same orientation update when it goes as well. The result is that most capitals have a doubled turnrate or an actual rotation time of half of what is claimed in the table.

For a zippy fighter with a low rotdamp of 0.35, the physics reducing it's speed is quite effective. It's exponential so the 'physics speed damping' gets more effective the farther it is from 0, so the ship will sluggishly accelerate (`angular_move` is polynomial so the acceleration is constant so early on it will win) until it eventually reaches a point where the two balance out, and its reached its maximum effective rotvel. For a rotdamp less than about 0.5, this will always be slower than it's actual tabled rotation time, the lower the rotdamp the worse its maximum effective rotvel will be.

Missiles always have a rotdamp of 0, so the physics will always take it to 0 rotvel every frame. The only turning it gets is what it is able to accelerate later in the frame; none of that accumulated velocity will carry over into the next frame. 

For ships although they aren't turning at their tabled rates and low rotdamp makes them rotationally accelerate _slower_ rather than faster, ships aren't really affected by framerate. Both the physics and AI's effects are scaled in proportion to the framerate, so effect is largely a constant one.

However the physics effect on missiles _isn't_ scaled by frametime, it always goes to 0 whether it was turning at 0.01 or 100, but its acceleration from AI has no such help. Luckily for the missile, AI happens later so it an still get some turning done, but the turning is directly dependent on how long the frame is, the more time it has the more it can accelerate, before physics puts it back to 0, which is why missiles have such framerate dependent turnrate. Ships also suffer but in a constant way so it's not so bad.

THE SOLUTION

`angular_move` put forth a lot of work to calculate what the ship's orientation and rotvel should be and `physics_sim_rot` is relatively clueless and simply messing things up. So if a flag can be tripped then `physics_sim_rot` can basically skip what it's doing and take `angular_move` at its word. This can only be done if the AI happens first in the frame however, which is part of the changes (more specifically this change was made alone in PR #2613 ). I was initially very hesitant to make this change, but after extensive testing I've yet to find any AI breakages due to this. 

So now with the 'Framerate_independent_turning' flag, the AI will set the `ai_desired_orient` and `desired_rotvel` (for this purpose `desired_rotvel` is treated differently by physics; I decided to reuse an otherwise unused variable in the interest of space, but I'd be open to the argument that a new value would be preferable in the interest of clarity) values to the output from `angular_move` which `physics_sim_rot` then applies, so at least actual orientation and rotvel changes are still happening in `physics_sim`, even if they aren't being calculated there.

The old, table-accurate values being produced by `angular_move` aren't actually what was observed however, (as explained in 'THE SYMPTOMS') so a new function is used to take in the values, including rotdamp, and produce what was actually being observed, so retail behavior is preserved when it comes to ships. For missiles, "objectively true" turntimes aren't so clear, since it has always been framerate dependent. For now, it produces observed behavior at 60fps. There were discussions to expose this value in some way, including as game_settings option, but it's an imperfect solution since that is for the most part, determined by the mod, not the player. Framerate is player-specific, not mod-specific, so ideally it should be exposed to them, but I'm not sure what the best approach is here. Input would be appreciated.

THE IMPLICATIONS

This has the unsavory result of various physical aspects being duplicated, in physics and also fed to `angular_move`, (such as the immobile flag, and shockwaves) since they're both attempting to "simulate physics". This duplication is a fundamental aspect of this 'sub-frame' 'hands-on' approach to turning the AI, I don't know why Volition did AI turning this way, I haven't seen what turning looks like if its done the 'normal' way, but I suspect they did it for a reason, and I'm merely trying to properly implement what appeared to be their intentions (based on what little I've been able to piece together it appears they were aware of some of these issues, but unaware of why they were happening).

In this new scenario rotational maneuver overrides **will not function** while the AI is attempting to rotationally maneuver itself. Before it appears it would do a weird sort of 'halfsies' mix of both. I think this is okay because I'm pretty sure ship-maneuver recommends disabling the AI anyway during maneuvers.

CHANGES FROM #2613 'Ai before physics'

I've renamed the flag to "$AI use framerate independent turning" from "$Process AI before physics:" because I think it's a lot clearer to users as to what the flag actually does, although it is granted that it may no longer be quite as clear to coders why this framerate turning thing needs to evaluate AI at a different time, but I'm open to suggestions on this. I realize that naming flags is a bit of a faux pas, but it was introduced very recently and I'm pretty sure no one was using it.

Also this removes `cscrew_process_post` from the purview of the flag, since it really is a form of post-processing and needs to be in `obj_move_post`


Phew. Now tell me this isn't the biggest PR description for FSO.