### PR TITLE
Fix Change IFF Multi Sexp (AKA Mystery of the Nullptr)

### DIFF
--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -10417,7 +10417,7 @@ void sexp_change_iff(int n)
 void multi_sexp_change_iff()
 {
 	int new_team;
-	char *name = nullptr;
+	char name[TOKEN_LENGTH];
 
 	Current_sexp_network_packet.get_int(new_team);
 	while (Current_sexp_network_packet.get_string(name)) {
@@ -10547,7 +10547,7 @@ void sexp_change_iff_color(int n)
 void multi_sexp_change_iff_color()
 {
 	int observer_team, observed_team, alternate_iff_color;
-	char *name = nullptr;
+	char name[TOKEN_LENGTH];
 
 	Current_sexp_network_packet.get_int(observer_team);
 	Current_sexp_network_packet.get_int(observed_team);
@@ -10734,7 +10734,7 @@ void multi_sexp_change_ai_class()
 {
 	int new_ai_class;
 	ship *shipp;
-	char *subsystem = nullptr;
+	char subsystem[TOKEN_LENGTH];
 
 	Current_sexp_network_packet.get_ship(shipp); 
 	Current_sexp_network_packet.get_int(new_ai_class);


### PR DESCRIPTION
Crashes in the multi version of Mystery of the Trinity turned up this bug.  Three multi sexps were setting char arrays to `nullptr`. Not sure *why* instead of making a `TOKEN_LENGTH` array like the rest of the file.  The `memcpy` in the `GET_STRING` macro would cause the crash when it determined it could not write to address `0000000000000000`.

~~What a mystery!~~

Just tested.  Now works as expected.