### PR TITLE
Object update packet upgrade

### DIFF
--- a/code/hud/hudobserver.cpp
+++ b/code/hud/hudobserver.cpp
@@ -39,7 +39,6 @@ void hud_observer_init(ship *shipp, ai_info *aip)
 	Hud_obs_ship.wingnum = shipp->wingnum;
 	Hud_obs_ship.alt_type_index = shipp->alt_type_index;
 	Hud_obs_ship.callsign_index = shipp->callsign_index;
-	memcpy(&Hud_obs_ship.np_updates, shipp->np_updates, MAX_PLAYERS * sizeof(np_update));
 	Hud_obs_ship.ship_max_hull_strength = shipp->ship_max_hull_strength;
 	Hud_obs_ship.ship_max_shield_strength = shipp->ship_max_shield_strength;
 	Hud_obs_ship.weapons = shipp->weapons;

--- a/code/io/timer.cpp
+++ b/code/io/timer.cpp
@@ -126,7 +126,7 @@ void timestamp_reset()
 // so we don't have to use UINTs to calculate rollover.
 // For debugging & testing, you could set this to
 // something like 1 minute (6000).
-const std::uint32_t MAX_TIME = INT_MAX / 2;
+extern const std::uint32_t MAX_TIME = INT_MAX / 2;
 
 static int timestamp_ms() {
 	if (timestamp_ticker <= 2) {

--- a/code/math/vecmat.cpp
+++ b/code/math/vecmat.cpp
@@ -2763,7 +2763,7 @@ void vm_interpolate_angles_quick(angles *dest0, angles *src0, angles *src1, floa
 	  // pitch
 	  // if start and end are basically the same, assume we can basically jump to the end.
 	if ( (fabs(arc_measures.p) < 0.00001f) ) {
-			arc_measures.p = 0.0f;
+		arc_measures.p = 0.0f;
 	} // Test for positive difference
 	else if (arc_measures.p > 0.0f)  {
 

--- a/code/math/vecmat.cpp
+++ b/code/math/vecmat.cpp
@@ -2744,3 +2744,94 @@ void vm_match_bank(vec3d* out_rvec, const vec3d* goal_fvec, const matrix* match_
 	vm_vec_rotate(&temp, &match_orient->vec.rvec, &source_frame);
 	vm_vec_unrotate(out_rvec, &temp, &dest_frame);
 }
+
+// Cyborg17 - Rotational interpolation between two angle structs in radians.  Assumes that the rotation direction is the smaller arc difference.
+// src0 is the starting angle struct, src1 is the ending angle struct, interp_perc must be a float between 0.0f and 1.0f inclusive.
+// rot_vel is only used to determine the rotation direction. This functions assumes a <= 2PI rotation in any axis.  
+// You will get inaccurate results otherwise.
+void vm_interpolate_angles_quick(angles *dest0, angles *src0, angles *src1, float interp_perc) {
+	
+	Assertion((interp_perc >= 0.0f) && (interp_perc <= 1.0f), "Interpolation percentage, %f, sent to vm_interpolate_angles is invalid. The valid range is [0,1], go find a coder!", interp_perc);
+
+
+	angles arc_measures;
+
+	arc_measures.p = src1->p - src0->p;	
+	arc_measures.h = src1->h - src0->h;	
+	arc_measures.b = src1->b - src0->b;
+
+	  // pitch
+	  // if start and end are basically the same, assume we can basically jump to the end.
+	if ( (fabs(arc_measures.p) < 0.00001f) ) {
+			arc_measures.p = 0.0f;
+	} // Test for positive difference
+	else if (arc_measures.p > 0.0f)  {
+
+		// do we actually need to go in the other direction
+		if (arc_measures.p > (PI*1.5f)) {
+			arc_measures.p = PI2 - arc_measures.p;
+
+		}
+
+	} // Negative difference then.
+	else {
+
+		// do we actually need to go in the other direction
+		if (arc_measures.p < -PI_2) {
+			arc_measures.p = -PI2 - arc_measures.p;
+
+		}
+	}
+
+	// heading
+	// if start and end are basically the same, assume we can basically jump to the end.
+	if ( (fabs(arc_measures.h) < 0.00001f) ) {
+		arc_measures.h = 0.0f;
+	} // Test for positive difference
+	else if (arc_measures.h > 0.0f)  {
+
+		// do we actually need to go in the other direction
+		if (arc_measures.h > (PI*1.5f)) {
+			arc_measures.h = PI2 - arc_measures.h;
+
+		}
+
+	} // Negative difference then.
+	else {
+
+		// do we actually need to go in the other direction
+		if (arc_measures.h < -PI_2) {
+			arc_measures.h = -PI2 - arc_measures.h;
+
+		}
+	}
+
+	// bank
+	// if start and end are basically the same, assume we can basically jump to the end.
+	if ( (fabs(arc_measures.b) < 0.00001f) ) {
+		arc_measures.b = 0.0f;
+	} // Test for positive difference
+	else if (arc_measures.b > 0.0f)  {
+
+		// do we actually need to go in the other direction
+		if (arc_measures.b > (PI*1.5f)) {
+			arc_measures.b = PI2 - arc_measures.b;
+
+		}
+
+	} // Negative difference then.
+	else {
+
+		// do we actually need to go in the other direction
+		if (arc_measures.b < -PI_2) {
+			arc_measures.b = -PI2 - arc_measures.b;
+
+		}
+	}
+
+	// Now just multiply the difference in angles by the given percentage, and then subtract it from the destination angles.
+	// If arc_measures is 0.0f, then we are basically bashing to the ending orientation without worrying about the inbetween.
+	dest0->p = src0->p + (arc_measures.p * interp_perc);
+	dest0->h = src0->h + (arc_measures.h * interp_perc);
+	dest0->b = src0->b + (arc_measures.b * interp_perc);
+}

--- a/code/math/vecmat.cpp
+++ b/code/math/vecmat.cpp
@@ -2753,7 +2753,6 @@ void vm_interpolate_angles_quick(angles *dest0, angles *src0, angles *src1, floa
 	
 	Assertion((interp_perc >= 0.0f) && (interp_perc <= 1.0f), "Interpolation percentage, %f, sent to vm_interpolate_angles is invalid. The valid range is [0,1], go find a coder!", interp_perc);
 
-
 	angles arc_measures;
 
 	arc_measures.p = src1->p - src0->p;	
@@ -2764,69 +2763,42 @@ void vm_interpolate_angles_quick(angles *dest0, angles *src0, angles *src1, floa
 	  // if start and end are basically the same, assume we can basically jump to the end.
 	if ( (fabs(arc_measures.p) < 0.00001f) ) {
 		arc_measures.p = 0.0f;
-	} // Test for positive difference
-	else if (arc_measures.p > 0.0f)  {
 
-		// do we actually need to go in the other direction
-		if (arc_measures.p > (PI*1.5f)) {
-			arc_measures.p = PI2 - arc_measures.p;
+	} // Test if we actually need to go in the other direction
+	else if (arc_measures.p > (PI*1.5f)) {
+		arc_measures.p = PI2 - arc_measures.p;
 
-		}
-
-	} // Negative difference then.
-	else {
-
-		// do we actually need to go in the other direction
-		if (arc_measures.p < -PI_2) {
-			arc_measures.p = -PI2 - arc_measures.p;
-
-		}
+	} // Test if we actually need to go in the other direction for negative values
+	else if (arc_measures.p < -PI_2) {
+		arc_measures.p = -PI2 - arc_measures.p;
 	}
 
-	// heading
-	// if start and end are basically the same, assume we can basically jump to the end.
+	  // heading
+	  // if start and end are basically the same, assume we can basically jump to the end.
 	if ( (fabs(arc_measures.h) < 0.00001f) ) {
 		arc_measures.h = 0.0f;
-	} // Test for positive difference
-	else if (arc_measures.h > 0.0f)  {
 
-		// do we actually need to go in the other direction
-		if (arc_measures.h > (PI*1.5f)) {
-			arc_measures.h = PI2 - arc_measures.h;
+	} // Test if we actually need to go in the other direction
+	else if (arc_measures.h > (PI*1.5f)) {
+		arc_measures.h = PI2 - arc_measures.h;
 
-		}
-
-	} // Negative difference then.
-	else {
-
-		// do we actually need to go in the other direction
-		if (arc_measures.h < -PI_2) {
-			arc_measures.h = -PI2 - arc_measures.h;
-
-		}
+	} // Test if we actually need to go in the other direction for negative values
+	else if (arc_measures.h < -PI_2) {
+		arc_measures.h = -PI2 - arc_measures.h;
 	}
 
 	// bank
 	// if start and end are basically the same, assume we can basically jump to the end.
 	if ( (fabs(arc_measures.b) < 0.00001f) ) {
 		arc_measures.b = 0.0f;
-	} // Test for positive difference
-	else if (arc_measures.b > 0.0f)  {
 
-		// do we actually need to go in the other direction
-		if (arc_measures.b > (PI*1.5f)) {
-			arc_measures.b = PI2 - arc_measures.b;
+	} // Test if we actually need to go in the other direction
+	else if (arc_measures.b > (PI*1.5f)) {
+		arc_measures.b = PI2 - arc_measures.b;
 
-		}
-
-	} // Negative difference then.
-	else {
-
-		// do we actually need to go in the other direction
-		if (arc_measures.b < -PI_2) {
-			arc_measures.b = -PI2 - arc_measures.b;
-
-		}
+	} // Test if we actually need to go in the other direction for negative values
+	else if (arc_measures.b < -PI_2) {
+		arc_measures.b = -PI2 - arc_measures.b;
 	}
 
 	// Now just multiply the difference in angles by the given percentage, and then subtract it from the destination angles.

--- a/code/math/vecmat.h
+++ b/code/math/vecmat.h
@@ -546,6 +546,12 @@ vec4 vm_vec3_to_ve4(const vec3d& vec, float w = 1.0f);
 // calculates the best rvec to match another orient while maintaining a given fvec
 void vm_match_bank(vec3d* out_rvec, const vec3d* goal_fvec, const matrix* match_orient);
 
+// Cyborg17 - Rotational interpolation between two angle structs in radians, given a rotational velocity, in radians.
+// src0 is the starting angle struct, src1 is the ending angle struct, interp_perc must be a float between 0.0f and 1.0f.
+// rot_vel is only used to determine the rotation direction. Assumes that it is not a full 2PI rotation in any axis.  
+// You will get strange results otherwise.
+void vm_interpolate_angles_quick(angles* dest0, angles* src0, angles* src1, float interp_perc);
+
 /** Compares two vec3ds */
 inline bool operator==(const vec3d& left, const vec3d& right) { return vm_vec_same(&left, &right) != 0; }
 inline bool operator!=(const vec3d& left, const vec3d& right) { return !(left == right); }

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -2449,6 +2449,8 @@ int parse_create_object_sub(p_object *p_objp)
 			if ((Game_mode & GM_IN_MISSION) && MULTIPLAYER_MASTER && (p_objp->wingnum == -1))
 				send_ship_create_packet(&Objects[objnum], (p_objp == Arriving_support_ship) ? 1 : 0);
 		}
+		// also add this ship to the multi ship tracking and interpolation struct
+		multi_ship_record_add_ship(objnum);
 	}
 
 	// If the ship is in a wing, this will be done in mission_set_wing_arrival_location() instead

--- a/code/network/multi.cpp
+++ b/code/network/multi.cpp
@@ -211,6 +211,7 @@ void multi_vars_init()
 	Next_asteroid_signature = ASTEROID_SIG_MIN;
 	Next_non_perm_signature = NPERM_SIG_MIN;   
 	Next_debris_signature = DEBRIS_SIG_MIN;
+	Next_waypoint_signature = WAYPOINT_SIG_MIN;
 	
 	// server-client critical stuff
 	Multi_button_info_ok = 0;
@@ -1228,10 +1229,10 @@ void multi_do_frame()
 				}
 			} else if ( !(Player_ship->is_departing() ) ){
 				// if the rate limiting system says its ok
-				if(multi_oo_cirate_can_send()){
+//				if(multi_oo_cirate_can_send()){
 					// use the new method
-					multi_oo_send_control_info();
-				}				
+					multi_oo_send_control_info(); // Cyborg17 - Don't limit clients updating themselves.
+//				}				
 			}
 
 			// bytes received info
@@ -1297,6 +1298,11 @@ void multi_do_frame()
 	
 	// process any tracker messages
 	multi_fs_tracker_process();
+
+	// Cyborg17 update the new frame recording system for accurate client shots, needs to go after most everything else in multi.
+	if (Game_mode & GM_IN_MISSION) {
+		multi_ship_record_increment_frame();
+	}
 
 	// if on the standalone, do any gui stuff
 	if (Game_mode & GM_STANDALONE_SERVER) {
@@ -1769,9 +1775,6 @@ void multi_reset_timestamps()
 
 	// reset standalone gui timestamps (these are not game critical, so there is not much danger)
 	std_reset_timestamps();
-
-	// initialize all object update timestamps
-	multi_oo_gameplay_init();
 }
 
 // netgame debug flags for debug console stuff

--- a/code/network/multi.cpp
+++ b/code/network/multi.cpp
@@ -1229,10 +1229,10 @@ void multi_do_frame()
 				}
 			} else if ( !(Player_ship->is_departing() ) ){
 				// if the rate limiting system says its ok
-//				if(multi_oo_cirate_can_send()){
+				if(multi_oo_cirate_can_send()){
 					// use the new method
-					multi_oo_send_control_info(); // Cyborg17 - Don't limit clients updating themselves.
-//				}				
+					multi_oo_send_control_info();
+				}				
 			}
 
 			// bytes received info

--- a/code/network/multi.h
+++ b/code/network/multi.h
@@ -63,9 +63,10 @@ class player;
 // version 48 - 8/15/2016 Multiple changes to the packet format for multi sexps
 // version 49 - 7/26/2020 Addition of multilock
 // version 50 - 7/27/2020 IPv6
+// version 51 - 9/20/2020 Object Update Packet Upgrade: Waypoints, subsystem rotation, bandwidth improvements, bugfixes
 // STANDALONE_ONLY
 
-#define MULTI_FS_SERVER_VERSION							50
+#define MULTI_FS_SERVER_VERSION							51
 
 #define MULTI_FS_SERVER_COMPATIBLE_VERSION			MULTI_FS_SERVER_VERSION
 
@@ -190,9 +191,10 @@ class player;
 #define OPTIONS_UPDATE				0x28		// options (netgame or local) update packet
 #define CLIENT_UPDATE				0x29		// sent from server to client periodically to update important info (pause status, etc)
 #define CD_VERIFY						0x2A		// cd verification update
-#define PRIMARY_FIRED_NEW			0x2B		// for client-side firing - highly streamlined
+#define PRIMARY_FIRED_NEW			0x2B		// For ships on the server, and client-side firing on LINEAR_WEAPON_FIRED fail
 #define COUNTERMEASURE_NEW			0x2C		// for client-side firing
 #define EVENT_UPDATE					0x2D		// event change
+#define LINEAR_WEAPON_FIRED			0x2E		//  Cyborg17 - for firing of non-homing weapons from the player on a client to send to the server
 
 #define SECONDARY_FIRED_AI			0xA0		// fired a secondary weapon (ai ship)
 #define SECONDARY_FIRED_PLR		0xA1		// fired a secondary weapon (player ship)
@@ -723,24 +725,28 @@ extern net_player *Net_player;										// pointer to console's net_player entry
 
 // network object management
 #define SHIP_SIG_MIN				1
-#define SHIP_SIG_MAX				(0x2fff)
+#define SHIP_SIG_MAX				(0x1fef)		// Cyborg17 - 8000 ships ought to be enough.
 
 #define STANDALONE_SHIP_SIG	(SHIP_SIG_MAX+1)
-#define REAL_SHIP_SIG_MAX		(0x3fff)
+#define REAL_SHIP_SIG_MAX		(0x1fff)			 
 
 #define DEBRIS_SIG_MIN			(REAL_SHIP_SIG_MAX+1)
-#define DEBRIS_SIG_MAX			(0x5fff)
+#define DEBRIS_SIG_MAX			(0x3fff)			// allows for 1000 ships to be destroyed and for ~8 debris chunks to be generated for each.
 
 #define ASTEROID_SIG_MIN		(DEBRIS_SIG_MAX+1)
-#define ASTEROID_SIG_MAX		(0x7fff)
+#define ASTEROID_SIG_MAX		(0x6fff)			
 
-#define NPERM_SIG_MIN			(ASTEROID_SIG_MAX+1)
-#define NPERM_SIG_MAX			(0xffff)
+#define WAYPOINT_SIG_MIN		(ASTEROID_SIG_MAX+1)
+#define WAYPOINT_SIG_MAX		(0x7fff)			// required for dynamic waypoints.
+
+#define NPERM_SIG_MIN			(WAYPOINT_SIG_MAX+1)
+#define NPERM_SIG_MAX			(0xffff)			// Allows us to have ~ 30K weapons simultaneously in a mission.
 
 extern ushort Next_ship_signature;									// next network signature to assign to an object
 extern ushort Next_asteroid_signature;								// next asteroid signature
 extern ushort Next_non_perm_signature;								// next non-permanent signature
 extern ushort Next_debris_signature;								// next debris signature
+extern ushort Next_waypoint_signature;								// next waypoint signature for dynamic waypoints in multi missions
 
 // netgame vars
 extern netgame_info Netgame;											// netgame information

--- a/code/network/multi_ingame.cpp
+++ b/code/network/multi_ingame.cpp
@@ -1039,6 +1039,9 @@ void process_ingame_ships_packet( ubyte *data, header *hinfo )
         Objects[objnum].flags.from_u64(oflags);
 		Objects[objnum].net_signature = net_signature;
 
+		// Cyborg17 also add this ship to the multi ship tracking and interpolation struct
+		multi_ship_record_add_ship(objnum);
+
 		// assign any common data
 		strcpy_s(Ships[ship_num].ship_name, ship_name);
 		Ships[ship_num].flags.from_u64(sflags);

--- a/code/network/multi_obj.cpp
+++ b/code/network/multi_obj.cpp
@@ -1543,7 +1543,7 @@ int multi_oo_unpack_data(net_player* pl, ubyte* data, int seq_num)
 
 		vec3d local_desired_vel = vmd_zero_vector;
 		
-		bool full_physics = (oo_flags & OO_FULL_PHYSICS);
+		bool full_physics = (oo_flags & OO_FULL_PHYSICS) ? true : false;
 
 		int r5 = multi_pack_unpack_desired_vel_and_desired_rotvel(0, full_physics, data + offset, &pobjp->phys_info, &local_desired_vel);
 		offset += r5;
@@ -2289,7 +2289,7 @@ void multi_init_oo_and_ship_tracker()
 	Oo_info.ref_timestamp = -1;
 	Oo_info.most_recent_updated_net_signature = 0;
 	Oo_info.most_recent_frame = 0;
-	for (int i = 0; i < MAX_PLAYERS; i++) {
+	for (int i = 0; i < MAX_PLAYERS; i++) { // NOLINT
 		Oo_info.received_frametimes[i].clear();
 		Oo_info.received_frametimes[i].reserve(36000); // enough memory for 10 minutes worth of frame time.
 	}
@@ -2298,7 +2298,7 @@ void multi_init_oo_and_ship_tracker()
 	Oo_info.wrap_count = 0;
 	Oo_info.larger_wrap_count = 0;
 	Oo_info.cur_frame_index = 0;
-	for (int i = 0; i < MAX_FRAMES_RECORDED; i++) {
+	for (int i = 0; i < MAX_FRAMES_RECORDED; i++) { // NOLINT
 		Oo_info.timestamps[i] = MAX_TIME; // This needs to be Max time (or at least some absurdly high number) for rollback to work correctly
 	}
 
@@ -2306,7 +2306,7 @@ void multi_init_oo_and_ship_tracker()
 	Oo_info.rollback_wobjp.clear();
 	Oo_info.rollback_collide_list.clear();
 	Oo_info.rollback_ships.clear();
-	for (int i = 0; i < MAX_FRAMES_RECORDED; i++) {
+	for (int i = 0; i < MAX_FRAMES_RECORDED; i++) { // NOLINT
 		Oo_info.rollback_shots_to_be_fired[i].clear();
 		Oo_info.rollback_shots_to_be_fired[i].reserve(20);
 	}
@@ -2415,7 +2415,7 @@ void multi_init_oo_and_ship_tracker()
 
 	// reset datarate stamp now
 	extern int OO_gran;
-	for(int i=0; i<MAX_PLAYERS; i++){
+	for(int i=0; i<MAX_PLAYERS; i++){ // NOLINT
 		Net_players[i].s_info.rate_stamp = timestamp( (int)(1000.0f / (float)OO_gran) );
 	}
 }

--- a/code/network/multi_obj.cpp
+++ b/code/network/multi_obj.cpp
@@ -1543,7 +1543,11 @@ int multi_oo_unpack_data(net_player* pl, ubyte* data, int seq_num)
 
 		vec3d local_desired_vel = vmd_zero_vector;
 		
-		bool full_physics = (oo_flags & OO_FULL_PHYSICS) ? true : false;
+		bool full_physics = false;
+
+		if (oo_flags & OO_FULL_PHYSICS) {
+			full_physics = true;
+		}
 
 		int r5 = multi_pack_unpack_desired_vel_and_desired_rotvel(0, full_physics, data + offset, &pobjp->phys_info, &local_desired_vel);
 		offset += r5;

--- a/code/network/multi_obj.cpp
+++ b/code/network/multi_obj.cpp
@@ -874,8 +874,8 @@ int multi_oo_pack_client_data(ubyte *data, ship* shipp)
 	ADD_DATA( out_flags );
 
 	// client targeting information	
-	ushort t_subsys = -1;
-	ushort l_subsys = -1;
+	ushort t_subsys = OOC_INDEX_NULLPTR_SUBSYSEM;
+	ushort l_subsys = OOC_INDEX_NULLPTR_SUBSYSEM;
 
 	// if nothing targeted
 	if(Player_ai->target_objnum == -1){
@@ -1360,14 +1360,14 @@ int multi_oo_unpack_client_data(net_player* pl, ubyte* data)
 		// assign subsystems if possible					
 		if (Objects[pl->m_player->objnum].type == OBJ_SHIP) {
 			Ai_info[Ships[Objects[pl->m_player->objnum].instance].ai_index].targeted_subsys = nullptr;
-			if ((t_subsys != -1) && (tobj->type == OBJ_SHIP)) {
+			if ((t_subsys != OOC_INDEX_NULLPTR_SUBSYSEM) && (tobj->type == OBJ_SHIP)) {
 				Ai_info[Ships[Objects[pl->m_player->objnum].instance].ai_index].targeted_subsys = ship_get_indexed_subsys(&Ships[tobj->instance], t_subsys);
 			}
 		}
 
 		pl->m_player->locking_subsys = nullptr;
 		if (Objects[pl->m_player->objnum].type == OBJ_SHIP) {
-			if ((l_subsys != -1) && (tobj->type == OBJ_SHIP)) {
+			if ((l_subsys != OOC_INDEX_NULLPTR_SUBSYSEM) && (tobj->type == OBJ_SHIP)) {
 				pl->m_player->locking_subsys = ship_get_indexed_subsys(&Ships[tobj->instance], l_subsys);
 			}
 		}
@@ -1385,7 +1385,7 @@ int multi_oo_unpack_client_data(net_player* pl, ubyte* data)
 	temp_lock_info.locked = true;
 
 	ushort multilock_target_net_signature;
-	ubyte subsystem_index;
+	ushort subsystem_index;
 
 	// clear whatever we had before, because we're getting brand new info straight from the client.
 	if (shipp != nullptr) {
@@ -1395,7 +1395,7 @@ int multi_oo_unpack_client_data(net_player* pl, ubyte* data)
 	// add each lock, one at a time.
 	for (int i = 0; i < count; i++) {
 		GET_USHORT(multilock_target_net_signature);
-		GET_DATA(subsystem_index);
+		GET_USHORT(subsystem_index);
 		temp_lock_info.obj = multi_get_network_object(multilock_target_net_signature);
 
 		if (temp_lock_info.obj != nullptr && shipp != nullptr) {

--- a/code/network/multi_obj.cpp
+++ b/code/network/multi_obj.cpp
@@ -30,42 +30,208 @@
 #include "ship/afterburner.h"
 #include "cfile/cfile.h"
 #include "debugconsole/console.h"
+#include "object/waypoint.h"
 #include "weapon/weapon.h"
 
 
 // ---------------------------------------------------------------------------------------------------
-// OBJECT UPDATE DEFINES/VARS
-//
+// OBJECT UPDATE STRUCTS
+// 
 
-// test stuff
-float oo_arrive_time[MAX_SHIPS][5];				// the last 5 arrival times for each ship
-int oo_arrive_time_count[MAX_SHIPS];			// size of the arrival queue
-float oo_arrive_time_avg_diff[MAX_SHIPS];		// the average time between arrivals
+extern const std::uint32_t MAX_TIME;
+constexpr int TIMESTAMP_OUT_IF_ERROR = 17; // The default value to send for a timestamp if FSO makes a mistake and calculates a negative timestamp.(instead of a crash, just guess)
+constexpr int OO_MAIN_HEADER_SIZE = 6;  // two ubytes and an int
 
-// interp stuff
-int oo_interp_count[MAX_SHIPS];
-vec3d oo_interp_points[MAX_SHIPS][2];
-bez_spline oo_interp_splines[MAX_SHIPS];
-void multi_oo_calc_interp_splines(int ship_index, vec3d *cur_pos, physics_info *cur_phys_info, vec3d *new_pos, matrix *new_orient, physics_info *new_phys_info);
 
-// HACK!!!
-bool Multi_oo_afterburn_hack = false;
+// One frame record per ship with each contained array holding one element for each frame.
+struct oo_ship_position_records {
+	vec3d positions[MAX_FRAMES_RECORDED];							// The recorded ship positions, cur_frame_index is the index.
+	matrix orientations[MAX_FRAMES_RECORDED];						// The recorded ship orientations, cur_frame_index is the index. 
+	vec3d velocities[MAX_FRAMES_RECORDED];							// The recorded ship velocities (required for additive velocity shots and auto aim), cur_frame_index is the index.
+};
+
+// keeps track of what has been sent to each player, helps cut down on bandwidth, allowing only new information to be sent instead of old.
+struct oo_info_sent_to_players {	
+	int timestamp;					// The overall timestamp which is used to decide if a new packet should be sent to this player for this ship.
+
+	vec3d position;					// If they are stationary, there's no need to update their position.
+	float hull;						// no need to send hull if hull hasn't changed.
+
+	// shields are a little special because they are constantly regenerating, so if they are *not* at full strength we need to send them.
+	bool perfect_shields_sent;		
+
+	int ai_mode;					// what ai mode was last sent.
+	int ai_submode;					// what ai submode was last sent.
+	int target_signature;			// what target_signature was last sent (used for AI portion of OO packet)
+
+	SCP_vector<float> subsystem_health;	// We need vectors to keep track of all subsystem health and subsystem angles.
+	SCP_vector<float> subsystem_1b;
+	SCP_vector<float> subsystem_1h;
+	SCP_vector<float> subsystem_1p;
+	SCP_vector<float> subsystem_2b;
+	SCP_vector<float> subsystem_2h;
+	SCP_vector<float> subsystem_2p;
+};
+
+struct oo_netplayer_records{
+	SCP_vector<oo_info_sent_to_players> last_sent;			// Subcategory of which player did I send this info to?  Corresponds to net_player index.
+	// This is not yet implemented, but may be necessary for autoaim to work in more busy scenes.  Basically, if you're switching targets,
+	// autoaim may succeed on the client but head to the wrong target on the server.
+//	int player_target_record[MAX_FRAMES_RECORDED];			// For rollback, we need to keep track of the player's targets. Uses frame as its index.
+};
+
+// Tracking Received info and timing per ship
+struct oo_packet_and_interp_tracking {
+	int cur_pack_pos_frame;				// the last position packet arrival frame
+	int prev_pack_pos_frame;			// the prev position packet arrival frame
+
+	bool client_simulation_mode;		// if the packets come in too late, a toggle to sim things like normal
+
+	bool prev_packet_positionless;		// a flag that marks if the last packet as having no new position or orientation info.
+
+	float pos_time_delta;				// How much time passed between position packets, in the same format as flFrametime
+	int pos_timestamp;					// Time that FSO processes the most recent position packet
+	vec3d old_packet_position;			// The last packet's pos
+	vec3d new_packet_position;			// The current packet's pos
+	vec3d position_error;				// Position error that is removed over a few frames
+
+	angles old_angles;					// The last packet's orientation (in angles)
+	angles new_angles;					// The current packet's orientation (in angles)
+	angles anticipated_angles_a;		// The first angles we get from calculating the spline
+	angles anticipated_angles_b;		// The second angles we get from calculating the spline
+	angles anticipated_angles_c;		// The third angles we get from calculating the spline
+	matrix new_orientation;				// The "uncompressed" orientation calculated from the packet's new angles
+
+	vec3d new_velocity;					// The velocity we calculate from the packet
+	vec3d anticipated_velocity1;		// The first velocity we get from calculating the spline
+	vec3d anticipated_velocity2;		// The second velocity we get from calculating the spline
+	vec3d anticipated_velocity3;		// The third velocity we get from calculating the spline
+
+	bez_spline pos_spline;				// The points we calculated which the bezier interpolation is based on.
+
+	// bashing the last received desired velocity and desired rotational velocity allows us to keep 
+	// anything unexpected messing with where this ship should be.
+	vec3d cur_pack_des_vel;				// 
+	vec3d cur_pack_local_des_vel;		// desired velocity is in global coordinates normally, but this optimizes some.
+	vec3d cur_pack_des_rot_vel;
+
+	// Frame numbers that helps us figure out if we should ignore new information coming from the server because
+	// we already received a newer packet than this one for all the info, or the most specific information.
+	int most_recent_packet;				// what is the seq number of the most recent packet, not worried about type of packet.
+	int pos_comparison_frame;			// what frame was the last position information received? 
+	int prev_pos_comparison_frame;		// what frame was the second to last position information received?
+	int hull_comparison_frame;			// what frame was the last hull information received?
+	int shields_comparison_frame;		// what frame was the last shield information received?
+	SCP_vector<int> subsystems_comparison_frame; // what frame was the last subsystem information received? (for each subsystem)
+	int ai_comparison_frame;			// what frame was the last ai information received?
+};
+
+// Keep track of the ships we'll need to restore later after rollback is done.
+struct oo_rollback_restore_record {
+	object* roll_objp;		// object pointer to the ship we need to restore. 
+	vec3d position;			// position to restore to
+	matrix orientation;		// orientation to restore to
+	vec3d velocity;			// velocity to restore to
+};
+
+// Keeps track of how many shots that need to be fired in rollback mode.
+struct oo_unsimulated_shots {
+	object* shooterp;		// pointer to the shooting object (ship)
+	vec3d pos;				// the relative position calculated from the non-homing packet.
+	matrix orient;			// the relative orientation from the non-homing packet.
+	bool secondary_shot;	// is this a dumbfire missile shot?
+};
+
+// our main struct for keeping track of all interpolation and oo packet info.
+struct oo_general_info {
+	// info that helps us figure out what is the best reference object available when sending a rollback shot.
+	// We go by what is the most recent object update packet received, and then by distance.
+	int ref_timestamp;							// what time did we receive the reference object
+	ushort most_recent_updated_net_signature;	// what is the net signature of the reference object.
+	int most_recent_frame;					// what is the frame from the update of most recently updated object.
+
+	// The previously received frametimes.  One entry for *every* frame, received or not, up to the last received frame.
+	// For frames it does not receive, it assumes that the frame time is the same as the frames around it.
+	SCP_vector<ubyte> received_frametimes[MAX_PLAYERS];
+
+	// Frame tracking info, we can have up to INT_MAX frames, but to save on bandwidth and memory we have to "wrap"
+	// the index.  Cur_frame_index goes up to MAX_FRAMES_RECORDED and makes info easy to access, wrap_count counts 
+	// how many times that is reset, up to MAX_SERVER_TRACKER_SMALL_WRAPS, we multiply these two to get the seq_num
+	// sent to oo_packet recipients. larger_wrap_count allows us to figure out if we are in an "odd" larger wrap
+	int number_of_frames;									// how many frames have we gone through, total.
+	short larger_wrap_count;								// how many of the larger wrap, used to set an OO_packet flag.
+	ushort wrap_count;										// how many times have we wrapped the cur_frame_index.
+	ubyte cur_frame_index;									// the current frame index (to access the recorded info)
+
+	int timestamps[MAX_FRAMES_RECORDED];					// The timestamp for the recorded frame
+	SCP_vector<oo_ship_position_records> frame_info;		// Actually keeps track of ship physics info.  Uses net_signature as its index.
+	SCP_vector<oo_netplayer_records> player_frame_info;		// keeps track of player targets and what has been sent to each player. Uses player as the index
+
+
+	SCP_vector<oo_packet_and_interp_tracking> interp;		// Tracking received info and interpolation timing per ship, uses net_signature as its index.
+	// rollback info
+	bool rollback_mode;										// are we currently creating and moving weapons from the client primary fire packets
+	SCP_vector<object*> rollback_wobjp_created_this_frame;	// the weapons created this rollback frame.
+	SCP_vector<object*> rollback_wobjp;						// a list of the weapons that were created, so that we can roll them into the current simulation
+
+	SCP_vector<object*> rollback_ships;						// a list of ships that take part in roll back, no quick index, must be iterated through.
+	SCP_vector<oo_rollback_restore_record> restore_points;	// where to move ships back to when done with rollback. no quick index, must be iterated through.
+	SCP_vector<oo_unsimulated_shots> 
+		rollback_shots_to_be_fired[MAX_FRAMES_RECORDED];				// the shots we will need to fire and simulate during rollback, organized into the frames they will be fired
+	SCP_vector<int>rollback_collide_list;					// the list of ships and weapons that we need to pass to collision detection during rollback.
+														
+	SCP_vector<const ship_registry_entry*> rotation_list;	// subsystem rotation
+};
+
+oo_general_info Oo_info;
+
+// flags
+bool Afterburn_hack = false;			// HACK!!!
+
+// for multilock
+#define OOC_INDEX_NULLPTR_SUBSYSEM			255			// If a lock has a nullptr subsystem, send this as the invalid index.
+
+// returns the last frame's index.
+int multi_find_prev_frame_idx();
+
+// quickly lookup how much time has passed since the given frame.
+uint multi_ship_record_get_time_elapsed(int original_frame, int new_frame);
+
+
+// See if a newly arrived packet is a good new option as a reference object
+void multi_ship_record_rank_seq_num(object* objp, int seq_num);
+
+// Set the points for bezier interpolation
+void multi_oo_calc_interp_splines(int player_id, object* objp, matrix *new_orient, physics_info *new_phys_info);
+
+// helper function that updates all interpolation info for a specific ship from a packet
+void multi_oo_maybe_update_interp_info(int player_id, object* objp, vec3d* new_pos, angles* new_ori_angles, matrix* new_ori_mat, physics_info* new_phys_info, bool adjust_pos, bool newest_pos);
+
+// recalculate how much time is between position packets
+float multi_oo_calc_pos_time_difference(int player_id, int net_sig_idx);
+
 
 // how much data we're willing to put into a given oo packet
 #define OO_MAX_SIZE					480
 
 // tolerance for bashing position
-#define OO_POS_UPDATE_TOLERANCE	100.0f
+#define OO_POS_UPDATE_TOLERANCE	150.0f
 
 // new improved - more compacted info type
-#define OO_POS_NEW					(1<<0)		// 
-#define OO_ORIENT_NEW				(1<<1)		// 
-#define OO_HULL_NEW					(1<<2)		// Hull AND shields
-#define OO_AFTERBURNER_NEW			(1<<3)		// 
-#define OO_SUBSYSTEMS_AND_AI_NEW	(1<<4)		// 
-#define OO_PRIMARY_BANK				(1<<5)		// if this is set, fighter has selected bank one
-#define OO_PRIMARY_LINKED			(1<<6)		// if this is set, banks are linked
-#define OO_TRIGGER_DOWN				(1<<7)		// if this is set, trigger is DOWN
+#define OO_POS_AND_ORIENT_NEW		(1<<0)		// To update position and orientation. Because getting accurate velocity requires orientation, and accurate orienation requires velocity
+#define OO_FULL_PHYSICS				(1<<1)		// Since AI don't use all phys_info values, we need a flag to confirm when all have been transmitted.
+#define OO_HULL_NEW					(1<<2)		// To Update Hull
+#define OO_SHIELDS_NEW				(1<<3)		// To Update Shields.
+#define OO_SUBSYSTEMS_NEW			(1<<4)		// Send Subsystem Info
+#define OO_ANIMATION				(1<<5)		// Subsystem Animation info
+#define OO_AI_NEW					(1<<6)		// Send updated AI Info
+#define OO_AFTERBURNER_NEW			(1<<7)		// Flag for Afterburner hack
+#define OO_PRIMARY_BANK				(1<<8)		// if this is set, fighter has selected bank one
+#define OO_PRIMARY_LINKED			(1<<9)		// if this is set, banks are linked
+#define OO_TRIGGER_DOWN				(1<<10)		// if this is set, trigger is DOWN
+#define OO_SUPPORT_SHIP				(1<<11)		// Send extra info for the support ship.
+
+#define OO_SBUSYS_ROTATION_CUTOFF	0.1f		// if the squared difference between the old and new angles is less than this, don't send.
 
 #define OO_VIEW_CONE_DOT			(0.1f)
 #define OO_VIEW_DIFF_TOL			(0.15f)			// if the dotproducts differ this far between frames, he's coming into view
@@ -85,13 +251,19 @@ bool Multi_oo_afterburn_hack = false;
 #define OO_HULL_SHIELD_TIME		600
 #define OO_SUBSYS_TIME				1000
 
+// for making the frame record wrapping predictable. 273 is the highest that we can put without a remainder. ~(65536/30) 
+#define MAX_SERVER_TRACKER_SMALL_WRAPS 2184
+#define SERVER_TRACKER_LARGE_WRAP_TOTAL (MAX_SERVER_TRACKER_SMALL_WRAPS * MAX_FRAMES_RECORDED)
+#define HAS_WRAPPED_MINIMUM			(SERVER_TRACKER_LARGE_WRAP_TOTAL - (MAX_FRAMES_RECORDED * 2)) 
+
 // timestamp values for object update times based on client's update level.
+// Cyborg17 - This is the one update number I have adjusted, because it's the player's target.
 int Multi_oo_target_update_times[MAX_OBJ_UPDATE_LEVELS] = 
 {
-	100, 				// 15x a second 
-	100, 				// 15x a second
-	66,				// 30x a second
-	66,
+	50, 				// 20x a second 
+	50, 				// 20x a second
+	20,				// 50x a second
+	20,				// 50x a second
 };
 
 // for near ships
@@ -100,7 +272,7 @@ int Multi_oo_front_near_update_times[MAX_OBJ_UPDATE_LEVELS] =
 	150,				// low update
 	100,				// medium update
 	66,				// high update
-	66,
+	66,				// LAN update
 };
 
 // for medium ships
@@ -109,7 +281,7 @@ int Multi_oo_front_medium_update_times[MAX_OBJ_UPDATE_LEVELS] =
 	250,				// low update
 	180, 				// medium update
 	120,				// high update
-	66,
+	66,					// LAN update
 };
 
 // for far ships
@@ -118,7 +290,7 @@ int Multi_oo_front_far_update_times[MAX_OBJ_UPDATE_LEVELS] =
 	750,				// low update
 	350, 				// medium update
 	150, 				// high update
-	66,
+	66,					// LAN update
 };
 
 // for near ships
@@ -127,7 +299,7 @@ int Multi_oo_rear_near_update_times[MAX_OBJ_UPDATE_LEVELS] =
 	300,				// low update
 	200,				// medium update
 	100,				// high update
-	66,
+	66,					// LAN update
 };
 
 // for medium ships
@@ -136,22 +308,413 @@ int Multi_oo_rear_medium_update_times[MAX_OBJ_UPDATE_LEVELS] =
 	800,				// low update
 	600,				// medium update
 	300,				// high update
-	66,
+	66,					// LAN update
 };
 
 // for far ships
 int Multi_oo_rear_far_update_times[MAX_OBJ_UPDATE_LEVELS] = 
 {
-	2500, 			// low update
+	2500, 				// low update
 	1500,				// medium update
 	400,				// high update
-	66,
+	66,					// LAN update
 };
 
 // ship index list for possibly sorting ships based upon distance, etc
 short OO_ship_index[MAX_SHIPS];
 
-int OO_update_index = -1;							// index into OO_update_records for displaying update record info
+// Cyborg17 - I'm leaving this system in place, just in case, although I never used it. 
+// It needs cleanup in keycontrol.cpp before it can be used.
+int OO_update_index = -1;							// The player index that allows us to look up multi rate through the debug
+													//  console and display it on the hud.
+
+
+// ---------------------------------------------------------------------------------------------------
+// POSITION AND ORIENTATION RECORDING
+// if it breaks, find Cyborg17
+
+// We record positions and orientations in Oo_info.frame_info so that we can create a weapon in the same relative 
+// circumstances as on the client.  I was directly in front, 600 meters away when I fired?  Well, now the client 
+// will tell the server that and the server will rewind part of its simulation to recreate that shot and then 
+// redo its simulation. There will still be some very small differences between server and client caused by the 
+// fact that the flFrametimes will be different, but changing that would be impossible.
+// ---------------------------------------------------------------------------------------------------
+
+// Add a new ship to the tracking struct
+void multi_ship_record_add_ship(int obj_num)
+{
+	object* objp = &Objects[obj_num];
+	int net_sig_idx = objp->net_signature;
+
+	// check for a ship that will enter the mission later on and has not yet had its net_signature set.
+	// These ships will be added later when they are actually in the mission
+	if (net_sig_idx == 0) {
+		return;
+	}
+
+	// our target size is the number of ships in the vector plus one because net_signatures start at 1 and size gives the number of elements, and this should be a new element.
+	int current_size = (int)Oo_info.frame_info.size();
+	// if we're right where we should be.
+	if (net_sig_idx == current_size) {
+		Oo_info.frame_info.push_back(Oo_info.frame_info[0]);
+		Oo_info.interp.push_back(Oo_info.interp[0]);
+		for (int i = 0; i < MAX_PLAYERS; i++) {
+			Oo_info.player_frame_info[i].last_sent.push_back( Oo_info.player_frame_info[i].last_sent[0] );
+		}
+
+	} // if not, create the storage for it.
+	else if (net_sig_idx > current_size) {
+		while (net_sig_idx >= current_size) {
+			Oo_info.frame_info.push_back(Oo_info.frame_info[0]);
+			Oo_info.interp.push_back(Oo_info.interp[0]);
+			for (int i = 0; i < MAX_PLAYERS; i++) {
+				Oo_info.player_frame_info[i].last_sent.push_back( Oo_info.player_frame_info[i].last_sent[0] );
+			}
+			current_size++;
+		}
+	} 
+
+	Assertion(net_sig_idx <= (current_size + 1), "New entry into the multi ship traker struct does not equal the index that should belong to it.\nNet_signature: %d and current_size %d\n", net_sig_idx, current_size);
+
+	ship_info* sip = &Ship_info[Ships[objp->instance].ship_info_index];
+
+	// To use vectors for the subsystems, we have to init the subsystem them here.
+	uint subsystem_count = (uint)sip->n_subsystems;
+
+	Oo_info.interp[net_sig_idx].subsystems_comparison_frame.reserve(subsystem_count);
+
+	while (Oo_info.interp[net_sig_idx].subsystems_comparison_frame.size() < subsystem_count) {
+		Oo_info.interp[net_sig_idx].subsystems_comparison_frame.push_back(-1);
+
+		for (int i = 0; i < MAX_PLAYERS; i++) {
+			Oo_info.player_frame_info[i].last_sent[net_sig_idx].subsystem_health.push_back(-1.0f);
+			Oo_info.player_frame_info[i].last_sent[net_sig_idx].subsystem_1b.push_back(-1.0f);
+			Oo_info.player_frame_info[i].last_sent[net_sig_idx].subsystem_1h.push_back(-1.0f);
+			Oo_info.player_frame_info[i].last_sent[net_sig_idx].subsystem_1p.push_back(-1.0f);
+			Oo_info.player_frame_info[i].last_sent[net_sig_idx].subsystem_2b.push_back(-1.0f);
+			Oo_info.player_frame_info[i].last_sent[net_sig_idx].subsystem_2h.push_back(-1.0f);
+			Oo_info.player_frame_info[i].last_sent[net_sig_idx].subsystem_2p.push_back(-1.0f);
+		}
+	}
+
+	// store info from the obj struct if it's already in the mission, otherwise, let the physics update call take care of it when the first frame starts.
+	if (Game_mode & GM_IN_MISSION) {
+
+		// only add positional info if they are in the mission.
+		Oo_info.frame_info[net_sig_idx].positions[Oo_info.cur_frame_index] = objp->pos;
+		Oo_info.frame_info[net_sig_idx].orientations[Oo_info.cur_frame_index] = objp->orient;
+	}
+}
+
+// Update the tracking struct whenever the object is updated in-game
+void multi_ship_record_update_all() 
+{
+	Assertion(MULTIPLAYER_MASTER, "Non-server accessed a server only function multi_ship_record_update_all(). Please report!!");
+
+	if (!MULTIPLAYER_MASTER) {
+		return;
+	}
+
+	int net_sig_idx;
+	object* objp;
+
+	for (ship & cur_ship : Ships) {
+		
+		if (cur_ship.objnum == -1) {
+			continue;
+		}		
+		
+		objp = &Objects[cur_ship.objnum];
+
+		if (objp == nullptr) {
+			continue;
+		}
+		 
+		net_sig_idx = objp->net_signature;
+
+		Assertion(net_sig_idx <= STANDALONE_SHIP_SIG, "Multi tracker got an invalid index of %d while updating it records. This is likely a coder error, please report!", net_sig_idx);
+		// make sure it's a valid index.
+		if (net_sig_idx < SHIP_SIG_MIN || net_sig_idx == STANDALONE_SHIP_SIG || net_sig_idx > SHIP_SIG_MAX) {
+			 continue;
+		}
+
+		Oo_info.frame_info[net_sig_idx].positions[Oo_info.cur_frame_index] = objp->pos;
+		Oo_info.frame_info[net_sig_idx].orientations[Oo_info.cur_frame_index] = objp->orient;
+		Oo_info.frame_info[net_sig_idx].velocities[Oo_info.cur_frame_index] = objp->phys_info.vel;
+	}
+}
+
+// Increment the tracker per frame, before packets are processed
+void multi_ship_record_increment_frame() 
+{
+	Oo_info.number_of_frames++;
+	Oo_info.cur_frame_index++;
+
+	// Because we are only tracking 30 frames (up to a quarter second on a 120 frame machine), we will have to wrap the index often
+	if (Oo_info.cur_frame_index == MAX_FRAMES_RECORDED) {
+		Oo_info.cur_frame_index = 0;
+		Oo_info.wrap_count++;
+		if (Oo_info.wrap_count == MAX_SERVER_TRACKER_SMALL_WRAPS) {
+			Oo_info.wrap_count = 0;
+			Oo_info.larger_wrap_count++;
+		}
+	}
+
+	Oo_info.timestamps[Oo_info.cur_frame_index] = timestamp();
+}
+
+// returns the last frame's index.
+int multi_find_prev_frame_idx() 
+{
+	if (Oo_info.cur_frame_index == 0) {
+		return MAX_FRAMES_RECORDED - 1;
+	} else {
+		return Oo_info.cur_frame_index - 1;
+	}
+}
+
+// Finds the first frame that is before the incoming timestamp.
+int multi_ship_record_find_frame(ushort client_frame, int time_elapsed)
+{	
+	// figure out the correct wrap
+	int wrap = client_frame  / MAX_FRAMES_RECORDED;
+
+	// figure out the frame index within the wrap
+	int frame = client_frame % MAX_FRAMES_RECORDED;
+
+	// if the wrap is not the same.
+	if (wrap != Oo_info.wrap_count) {
+		// somewhat out of date but still salvagable case.
+		if (wrap == (Oo_info.wrap_count - 1)) {
+
+			// but we can't use it if it would index to info in the current wrap instead of the previous wrap.
+			if (frame <= Oo_info.cur_frame_index) {
+				return -1;
+			}
+		// Just in case the larger wrap just happened....
+		} else if ((wrap == MAX_SERVER_TRACKER_SMALL_WRAPS - 1) && Oo_info.wrap_count == 0){
+			// again we can't use it if it would index to info in the current wrap instead of the previous wrap.
+			if (frame <= Oo_info.cur_frame_index) {
+				return -1;
+			}
+
+		} // otherwise the request is unsalvagable.
+		else {
+			return -1;
+		}
+	}
+
+	// Now that the wrap has been verified, if time_elapsed is zero return the frame it gave us.
+	if(time_elapsed == 0){
+		return frame;
+	}
+
+	// Otherwise, look for the frame that the client is saying to look for.  If we hit the frame the client sent, return.
+	// get how many frames we would go into the future.
+	int target_timestamp = Oo_info.timestamps[frame] + time_elapsed;
+
+	for (int i = Oo_info.cur_frame_index - 1; i > -1; i--) {
+
+		// Check to see if the client's timestamp matches the recorded frames.
+		if ((Oo_info.timestamps[i] <= target_timestamp) && (Oo_info.timestamps[i + 1] > target_timestamp)) {
+			return i;
+		}
+		else if (i == frame) {
+			return -1;
+		}
+	}
+
+	// Check for an end of the wrap condition.
+	if ((Oo_info.timestamps[MAX_FRAMES_RECORDED - 1] <= target_timestamp) && (Oo_info.timestamps[0] > target_timestamp)) {
+		return MAX_FRAMES_RECORDED - 1;
+	}
+
+	// Check the oldest frames.
+	for (int i = MAX_FRAMES_RECORDED - 2; i > Oo_info.cur_frame_index; i--) {
+		if ((Oo_info.timestamps[i] <= target_timestamp) && (Oo_info.timestamps[i + 1] > target_timestamp)) {
+			return i;
+		}
+		else if (i == frame) {
+			return -1;
+		}
+	}
+
+	// this is if again the request is way too delayed to be valid, but somehow wasn't caught earlier.
+	return -1;
+}
+
+// Quick lookup for the record of position.
+vec3d multi_ship_record_lookup_position(object* objp, int frame) 
+{
+	Assertion(objp != nullptr, "nullptr given to multi_ship_record_lookup_position. \nThis should be handled earlier in the code, please report!");
+	return Oo_info.frame_info[objp->net_signature].positions[frame];
+}
+
+// Quick lookup for the record of orientation.
+matrix multi_ship_record_lookup_orientation(object* objp, int frame) 
+{
+	Assertion(objp != nullptr, "nullptr given to multi_ship_record_lookup_position. \nThis should be handled earlier in the code, please report!");
+	if (objp == nullptr) {
+		return vmd_identity_matrix;
+	}
+	return Oo_info.frame_info[objp->net_signature].orientations[frame];
+}
+
+// figure out how many items we may have to create
+void multi_ship_record_add_timestamp(int pl_id, ubyte timestamp, int seq_num) {
+
+	// sanity!
+	Assertion((pl_id < MAX_PLAYERS) && (pl_id >= 0) && (seq_num >= 0), "Somehow multi_ship_record_add_timestamp() was passed a nonsense value, please report these values: pl_id %d, seq_num %d", pl_id, seq_num);
+
+	int temp_diff = seq_num - (int)Oo_info.received_frametimes[pl_id].size() + 1;
+	// if it already has enough slots, just fill in the value, because it really should be the same as before.
+	if (temp_diff <= 0) {
+		Oo_info.received_frametimes[pl_id].at(seq_num) = timestamp;
+	}	// if there weren't enough slots, create the necessary slots.
+	else {
+		// loop is checked against 1, because once there is only a difference of 1, we should add the timestamp onto the end.
+		for (int i = temp_diff; i > 1; i--) {
+			// keep adding zero to the timestamps we have not yet received, because that is our impossible value.
+			Oo_info.received_frametimes[pl_id].push_back(0);
+		}
+		// lastly, add the timestamp we received to the end.
+		Oo_info.received_frametimes[pl_id].push_back(timestamp);
+	}
+
+}
+
+
+// quickly lookup how much time has passed between two frames.
+uint multi_ship_record_get_time_elapsed(int original_frame, int new_frame) 
+{
+	// Bogus values
+	Assertion(original_frame <= MAX_FRAMES_RECORDED, "Function multi_ship_record_get_time_elapsed() got passed an invalid original frame, this is a code error, please report. ");
+	Assertion(new_frame <= MAX_FRAMES_RECORDED, "Function multi_ship_record_get_time_elapsed() got passed an invalid new frame, this is a code error, please report. ");
+	if (original_frame >= MAX_FRAMES_RECORDED || new_frame >= MAX_FRAMES_RECORDED) {
+		return 0;
+	}
+
+	return Oo_info.timestamps[new_frame] - Oo_info.timestamps[original_frame];
+}
+
+// figures out how much time has passed bwetween the two frames.
+int multi_ship_record_find_time_after_frame(int starting_frame, int ending_frame, int time_elapsed) 
+{
+	starting_frame = starting_frame % MAX_FRAMES_RECORDED;
+
+	int return_value = time_elapsed - (Oo_info.timestamps[ending_frame] - Oo_info.timestamps[starting_frame]);
+	return return_value;
+}
+
+// ---------------------------------------------------------------------------------------------------
+// Client side frame tracking, for now used only for referenced in fire packets to improve client accuracy.
+// 
+
+// See if a newly arrived object update packet should be the new reference for the improved primary fire packet 
+void multi_ship_record_rank_seq_num(object* objp, int seq_num) 
+{
+	// see if it's more recent.  Most recent is best.
+	if (seq_num > Oo_info.most_recent_frame || Oo_info.most_recent_updated_net_signature == 0) {
+		Oo_info.most_recent_updated_net_signature = objp->net_signature;
+		Oo_info.most_recent_frame = seq_num;
+		Oo_info.ref_timestamp = timestamp();
+
+	} // if this packet is from the same frame, the closer ship makes for a slightly more accurate reference point
+	else if (seq_num == Oo_info.most_recent_frame) {
+		object* temp_reference_object = multi_get_network_object(Oo_info.most_recent_updated_net_signature);
+		// check the distance
+		if ( (temp_reference_object == nullptr) || vm_vec_dist_squared(&temp_reference_object->pos, &Objects[Player->objnum].pos) > vm_vec_dist_squared(&objp->pos, &Objects[Player->objnum].pos) ) {
+			Oo_info.most_recent_updated_net_signature = objp->net_signature;
+			Oo_info.most_recent_frame = seq_num;
+			Oo_info.ref_timestamp = timestamp();
+		}
+	}
+}
+
+// Quick lookup for the most recently received ship
+ushort multi_client_lookup_ref_obj_net_sig()
+{	
+	return Oo_info.most_recent_updated_net_signature;
+}
+
+// Quick lookup for the most recently received frame
+int multi_client_lookup_frame_idx()
+{
+	return Oo_info.most_recent_frame;
+}
+
+// Quick lookup for the most recently received timestamp.
+int multi_client_lookup_frame_timestamp()
+{
+	return Oo_info.ref_timestamp;
+}
+
+// Resets what info we have sent and interpolation info for a respawn
+// To be safe, I believe that most info should be reset.
+void multi_oo_respawn_reset_info(ushort net_sig) 
+{
+	Assertion(net_sig != 0, "Multi_reset_oo_info got passed an invalid value. This is a coder error, please report.");
+	if (net_sig == 0) {
+		return;
+	}
+
+	// When a player respawns, they keep their net signature, so clean up all the info that could mess things up in the future.
+	for (auto & player_record : Oo_info.player_frame_info) {
+		player_record.last_sent[net_sig].timestamp = -1;
+		player_record.last_sent[net_sig].position = vmd_zero_vector;
+		player_record.last_sent[net_sig].hull = -1.0f;
+		player_record.last_sent[net_sig].ai_mode = -1;
+		player_record.last_sent[net_sig].ai_submode = -1;
+		player_record.last_sent[net_sig].target_signature = -1;
+		player_record.last_sent[net_sig].perfect_shields_sent = false;
+		for (int i = 0; i < (int)player_record.last_sent[net_sig].subsystem_health.size(); i++) {
+			player_record.last_sent[net_sig].subsystem_health[i] = -1.0f;
+			player_record.last_sent[net_sig].subsystem_1b[i] = -1.0f;
+			player_record.last_sent[net_sig].subsystem_1h[i] = -1.0f;
+			player_record.last_sent[net_sig].subsystem_1p[i] = -1.0f;
+			player_record.last_sent[net_sig].subsystem_2b[i] = -1.0f;
+			player_record.last_sent[net_sig].subsystem_2h[i] = -1.0f;
+			player_record.last_sent[net_sig].subsystem_2p[i] = -1.0f;
+
+		}
+	}
+
+	oo_packet_and_interp_tracking* interp = &Oo_info.interp[net_sig];
+	// To ensure clean interpolation, we should probably just reset everything.
+	interp->ai_comparison_frame = -MAX_FRAMES_RECORDED;
+	interp->cur_pack_pos_frame = -1;
+	interp->prev_pack_pos_frame = -1;
+	interp->pos_comparison_frame = -MAX_FRAMES_RECORDED;
+	interp->prev_pos_comparison_frame = -MAX_FRAMES_RECORDED;
+	interp->hull_comparison_frame = -MAX_FRAMES_RECORDED;
+	interp->shields_comparison_frame = -MAX_FRAMES_RECORDED;
+		for (auto & subsys : interp->subsystems_comparison_frame ){
+			subsys = -MAX_FRAMES_RECORDED; // ship adder recreates the vector entries
+		}
+
+	interp->old_packet_position = vmd_zero_vector;
+	interp->new_packet_position = vmd_zero_vector;
+	interp->position_error = vmd_zero_vector;
+	interp->pos_time_delta = 0.0f;
+
+	interp->new_angles = vmd_zero_angles;
+	interp->old_angles = vmd_zero_angles;
+	interp->anticipated_angles_a = vmd_zero_angles;
+	interp->anticipated_angles_b = vmd_zero_angles;
+	interp->anticipated_angles_c = vmd_zero_angles;
+	interp->new_orientation = vmd_identity_matrix;
+
+	interp->client_simulation_mode = true;
+	interp->prev_packet_positionless = false;
+
+	interp->new_velocity = vmd_zero_vector;
+	interp->anticipated_velocity1 = vmd_zero_vector;
+	interp->anticipated_velocity2 = vmd_zero_vector;
+	interp->anticipated_velocity3 = vmd_zero_vector;
+
+	interp->cur_pack_des_rot_vel = vmd_zero_vector;
+	interp->cur_pack_local_des_vel = vmd_zero_vector;
+}
 
 // ---------------------------------------------------------------------------------------------------
 // OBJECT UPDATE FUNCTIONS
@@ -232,8 +795,8 @@ void multi_oo_build_ship_list(net_player *pl)
 			continue;
 		}
 
-		// don't send info for dying ships
-		if (Ships[Objects[moveup->objnum].instance].flags[Ship::Ship_Flags::Dying]){
+		// don't send info for dying ships -- Cyborg17 - Or dead ships that are going to respawn later.
+		if (Ships[Objects[moveup->objnum].instance].flags[Ship::Ship_Flags::Dying] || Ships[Objects[moveup->objnum].instance].flags[Ship::Ship_Flags::Exploded]) {
 			continue;
 		}		
 
@@ -264,6 +827,17 @@ void multi_oo_build_ship_list(net_player *pl)
 		std::sort(OO_ship_index, OO_ship_index + ship_index, multi_oo_sort_func);
 	}
 }
+
+
+constexpr int OO_CLIENT_HEADER_SIZE = 4;	// flags and data_size ushorts
+constexpr int OO_SERVER_HEADER_SIZE = 6; // flags, data_size, and net_signature ushorts
+constexpr int OO_POSITION_UPDATE_SIZE = 28; // see the position section of pack_data() to know where this number is coming from.
+constexpr int OO_MAX_CLIENT_DATA_SIZE = MAX_PACKET_SIZE - OO_MAIN_HEADER_SIZE - OO_CLIENT_HEADER_SIZE - OO_POSITION_UPDATE_SIZE;
+constexpr int OO_MAX_DATA_SIZE = MAX_PACKET_SIZE - OO_MAIN_HEADER_SIZE - OO_SERVER_HEADER_SIZE;
+
+// whatever crazy thing happens, keep the buffer from overflowing because we can just "erase" the part that overflowed it
+constexpr int OO_SAFE_BUFFER_SIZE = 10000; 
+constexpr int OO_LOCK_SIZE = 3;
 
 // pack information for a client (myself), return bytes added
 int multi_oo_pack_client_data(ubyte *data, ship* shipp)
@@ -354,8 +928,8 @@ int multi_oo_pack_client_data(ubyte *data, ship* shipp)
 				
 			count++;
 
-			// Quit looking if we're at the maximum.
-			if (count >= OOC_MAX_LOCKS) {
+			// Check to see if the next lock will force us over the max.
+			if ((count + 1) * OO_LOCK_SIZE >= OO_MAX_CLIENT_DATA_SIZE) {
 				break;
 			}
 		}
@@ -379,15 +953,13 @@ int multi_oo_pack_client_data(ubyte *data, ship* shipp)
 #define PACK_USHORT(v) { std::uint16_t swap = INTEL_SHORT(v); memcpy( data + packet_size + header_bytes, &swap, sizeof(std::uint16_t) ); packet_size += sizeof(std::uint16_t); }
 #define PACK_INT(v) { std::int32_t swap = INTEL_INT(v); memcpy( data + packet_size + header_bytes, &swap, sizeof(std::int32_t) ); packet_size += sizeof(std::int32_t); }
 #define PACK_ULONG(v) { std::uint64_t swap = INTEL_LONG(v); memcpy( data + packet_size + header_bytes, &swap, sizeof(std::uint64_t) ); packet_size += sizeof(std::uint64_t); }
-int multi_oo_pack_data(net_player *pl, object *objp, ubyte oo_flags, ubyte *data_out)
-{	
-	ubyte data[255];
-	ubyte data_size = 0;	
-	char percent;
+int multi_oo_pack_data(net_player *pl, object *objp, ushort oo_flags, ubyte *data_out)
+{
+	ubyte data[OO_SAFE_BUFFER_SIZE], ret = 0;
+	ushort data_size = 0;	// now a ushort because of IPv6 size extensions
 	ship *shipp;	
 	ship_info *sip;
-	ubyte ret;
-	float temp;	
+	float temp_float;	
 	int header_bytes;
 	int packet_size = 0;
 
@@ -401,130 +973,222 @@ int multi_oo_pack_data(net_player *pl, object *objp, ubyte oo_flags, ubyte *data
 	}			
 
 	// invalid player
-	if(pl == NULL){
+	if(pl == nullptr || shipp == nullptr){
 		return 0;
 	}
 
-	// no flags -> do nothing
-	if(oo_flags == 0){
-		return 0;
-	}
+	// if no flags we now send an "empty" packet that tells the client "Keep this ship where it belongs"
 
 	// if i'm the client, make sure I only send certain things	
-	if(!MULTIPLAYER_MASTER){
-		Assert(oo_flags & (OO_POS_NEW | OO_ORIENT_NEW));
-		Assert(!(oo_flags & (OO_HULL_NEW | OO_SUBSYSTEMS_AND_AI_NEW)));
+	if (MULTIPLAYER_CLIENT) {
+		Assert(!(oo_flags & (OO_HULL_NEW | OO_SHIELDS_NEW | OO_SUBSYSTEMS_NEW)));
+		oo_flags &= ~(OO_HULL_NEW | OO_SHIELDS_NEW | OO_SUBSYSTEMS_NEW);
 	} 
-	// server 
-	else {
-		// Assert(oo_flags & OO_POS_NEW);
-	}
 
-	// header sizes
+	// header sizes -- Cyborg17 - Note this is in place because the size of the packet is 
+	// determined at the end of this function, and so we have to keep track of how much
+	// we are adding to the packet throughout.
 	if(MULTIPLAYER_MASTER){
-		header_bytes = 5;
+		header_bytes = OO_SERVER_HEADER_SIZE;
 	} else {
-		header_bytes = 2;
+		header_bytes = OO_CLIENT_HEADER_SIZE;
 	}	
+
+	// putting this in the position bucket because it's mainly to help with position interpolation
+	multi_rate_add(NET_PLAYER_NUM(pl), "pos", 1);
+
 
 	// if we're a client (and therefore sending control info), pack client-specific info
 	if((Net_player != NULL) && !(Net_player->flags & NETINFO_FLAG_AM_MASTER)){
 		packet_size += multi_oo_pack_client_data(data + packet_size + header_bytes, shipp);		
 	}		
 		
-	// position, velocity
-	if ( oo_flags & OO_POS_NEW ) {		
-		ret = (ubyte)multi_pack_unpack_position( 1, data + packet_size + header_bytes, &objp->pos );
+	// position - Now includes, position, orientation, velocity, rotational velocity, desired velocity and desired rotational velocity.
+	// this should always be sent when it is determined to be needed.
+	if ( oo_flags & OO_POS_AND_ORIENT_NEW ) {	
+		ret = (ubyte)multi_pack_unpack_position( 1, data + packet_size + header_bytes, &objp->pos ); // 10 bytes
 		packet_size += ret;
-		
-		// global records
-		multi_rate_add(NET_PLAYER_NUM(pl), "pos", ret);		
-			
-		ret = (ubyte)multi_pack_unpack_vel( 1, data + packet_size + header_bytes, &objp->orient, &objp->pos, &objp->phys_info );
-		packet_size += ret;		
-			
-		// global records		
-		multi_rate_add(NET_PLAYER_NUM(pl), "pos", ret);				
-	}	
 
-	// orientation	
-	if(oo_flags & OO_ORIENT_NEW){
-		ret = (ubyte)multi_pack_unpack_orient( 1, data + packet_size + header_bytes, &objp->orient );
-		// Assert(ret == OO_ORIENT_RET_SIZE);
+		// datarate tracking.
+		multi_rate_add(NET_PLAYER_NUM(pl), "pos", ret);
+
+		// orientation (now done via angles)
+		angles temp_angles;
+		vm_extract_angles_matrix_alternate(&temp_angles, &objp->orient);	
+
+		// actual packing function, 6 bytes
+		ret = (ubyte)multi_pack_unpack_orient( 1, data + packet_size + header_bytes, &temp_angles); 
+
 		packet_size += ret;
-		multi_rate_add(NET_PLAYER_NUM(pl), "ori", ret);				
+		// datarate tracking.
+		multi_rate_add(NET_PLAYER_NUM(pl), "ori", ret);	
 
-		ret = (ubyte)multi_pack_unpack_rotvel( 1, data + packet_size + header_bytes, &objp->orient, &objp->pos, &objp->phys_info );
+		// velocity, 4 bytes-- Tried to do this by calculation instead but kept running into issues. 
+		ret = (ubyte)multi_pack_unpack_vel(1, data + packet_size + header_bytes, &objp->orient, &objp->phys_info);
+
+		packet_size += ret;
+		// datarate tracking.
+		multi_rate_add(NET_PLAYER_NUM(pl), "pos", ret);	
+
+		// Rotational Velocity, 4 bytes
+		ret = (ubyte)multi_pack_unpack_rotvel( 1, data + packet_size + header_bytes, &objp->phys_info );
+
 		packet_size += ret;	
 
-		// global records		
+		// datarate tracking.		
 		multi_rate_add(NET_PLAYER_NUM(pl), "ori", ret);		
-	}
-			
-	// forward thrust	
-	percent = (char)(objp->phys_info.forward_thrust * 100.0f);
-	Assert( percent <= 100 );
+		ret = 0;
 
-	PACK_BYTE( percent );
+		// in order to send data by axis we must rotate the global velocity into local coordinates
+		vec3d local_desired_vel;
 
-	// global records	
-	multi_rate_add(NET_PLAYER_NUM(pl), "fth", 1);	
+		vm_vec_rotate(&local_desired_vel, &objp->phys_info.desired_vel, &objp->orient);
 
-	// hull info
-	if ( oo_flags & OO_HULL_NEW ){
-		// add the hull value for this guy		
-		temp = get_hull_pct(objp);
-		if ( (temp < 0.004f) && (temp > 0.0f) ) {
-			temp = 0.004f;		// 0.004 is the lowest positive value we can have before we zero out when packing
+		// is this a ship with full phyiscs? (just player-controled for now)
+		bool full_physics = false;
+		if (objp->flags[Object::Object_Flags::Player_ship]) {
+			full_physics = true;
+			oo_flags |= OO_FULL_PHYSICS;
 		}
-		PACK_PERCENT(temp);				
-		multi_rate_add(NET_PLAYER_NUM(pl), "hul", 1);	
+
+		// actual packing function, 4 bytes
+		ret = multi_pack_unpack_desired_vel_and_desired_rotvel(1, full_physics, data + packet_size + header_bytes, &objp->phys_info, &local_desired_vel);
+
+		packet_size += ret;
+	}
+
+	// datarate records	
+	multi_rate_add(NET_PLAYER_NUM(pl), "fth", ret);	
+
+	// hull info -- also should be required, but can never be sent by client, so unless something's really messed up,
+	// at this point it is impossible to overflow the buffer.
+	if (oo_flags & OO_HULL_NEW) {
+		// add the hull value for this guy		
+		temp_float = get_hull_pct(objp);
+		if ((temp_float < 0.004f) && (temp_float > 0.0f)) {
+			temp_float = 0.004f;		// 0.004 is the lowest positive value we can have before we zero out when packing
+		}
+		PACK_PERCENT(temp_float);
+		multi_rate_add(NET_PLAYER_NUM(pl), "hul", 1);
+	}
+
+	// add shields, which can have now have a dynamic number of quadrants, we need to start checking for buffer overflow here
+	if (oo_flags & OO_SHIELDS_NEW) {
+		int pre_section_size = packet_size;
 
 		float quad = shield_get_max_quad(objp);
 
 		for (int i = 0; i < objp->n_quadrants; i++) {
-			temp = (objp->shield_quadrant[i] / quad);
-			PACK_PERCENT(temp);
+			temp_float = (objp->shield_quadrant[i] / quad);
+			PACK_PERCENT(temp_float);
 		}
 				
-		multi_rate_add(NET_PLAYER_NUM(pl), "shl", objp->n_quadrants);	
+		// Check that we are not sending too much data, if so, don't actually send.
+		if (packet_size > OO_MAX_DATA_SIZE) {
+			nprintf(("Network","Had to remove shields section from data packet for %s\n", shipp->ship_name));
+			packet_size = pre_section_size;
+			oo_flags &= ~OO_SHIELDS_NEW;
+		}
+		else {
+			multi_rate_add(NET_PLAYER_NUM(pl), "shl", objp->n_quadrants);	
+		}
 	}	
 
-	// subsystem info
-	if( oo_flags & OO_SUBSYSTEMS_AND_AI_NEW ){
-		ubyte ns;		
-		ship_subsys *subsysp;
-				
-		// just in case we have some kind of invalid data (should've been taken care of earlier in this function)
-		if(shipp->ship_info_index < 0){
-			ns = 0;
-			PACK_BYTE( ns );
+	// Cyborg17 - add the subsystem data, now with packer function.
+	if ((MULTIPLAYER_MASTER || objp->flags[Object::Object_Flags::Player_ship]) && shipp->ship_info_index >= 0) {
+		SCP_vector<ubyte> flags;
+		SCP_vector<float> subsys_data;
+		ubyte i = 0;
 
-			multi_rate_add(NET_PLAYER_NUM(pl), "sub", 1);	
+		flags.reserve(MAX_MODEL_SUBSYSTEMS);
+		subsys_data.reserve(MAX_MODEL_SUBSYSTEMS); // propbably won't exceed this, and even if it does, it will get cut off.
+
+		for (ship_subsys* subsystem = GET_FIRST(&shipp->subsys_list); subsystem != END_OF_LIST(&shipp->subsys_list);
+			subsystem = GET_NEXT(subsystem)) {
+			flags.push_back(0);
+			// Don't send destroyed subsystems, (another packet handles that), but check to see if the subsystem changed since the last update. 
+			if (MULTIPLAYER_MASTER && (subsystem->current_hits != 0.0f) && (subsystem->current_hits != Oo_info.player_frame_info[pl->player_id].last_sent[objp->net_signature].subsystem_health[i])) {
+				flags[i] |= OO_SUBSYS_HEALTH;
+				subsys_data.push_back(subsystem->current_hits / subsystem->max_hits);
+				// good thing this cheap because we have to calculate this twice to avoid iterating through the whole system list twice.
+				Oo_info.player_frame_info[pl->player_id].last_sent[objp->net_signature].subsystem_health[i] = subsystem->current_hits;
+
+				// this should be safe because we only work with subsystems that have health.
+				// and also track the list of subsystems that we packed by index
+			}
+			
+
+			// retrieve the submodel for rotation info.
+			if (subsystem->system_info->flags[Model::Subsystem_Flags::Rotates, Model::Subsystem_Flags::Dum_rotates]) {
+
+				// here we're checking to see if the subsystems rotated enough to send.
+				if (subsystem->submodel_info_1.angs.b != Oo_info.player_frame_info[pl->player_id].last_sent[objp->net_signature].subsystem_1b[i]) {
+					flags[i] |= OO_SUBSYS_ROTATION_1b;
+					subsys_data.push_back(subsystem->submodel_info_1.angs.b / PI2);
+				}
+
+				if (subsystem->submodel_info_1.angs.h != Oo_info.player_frame_info[pl->player_id].last_sent[objp->net_signature].subsystem_1h[i]) {
+					flags[i] |= OO_SUBSYS_ROTATION_1h;
+					subsys_data.push_back(subsystem->submodel_info_1.angs.h / PI2);
+				}
+
+				if (subsystem->submodel_info_1.angs.p != Oo_info.player_frame_info[pl->player_id].last_sent[objp->net_signature].subsystem_1p[i]) {
+					flags[i] |= OO_SUBSYS_ROTATION_1p;
+					subsys_data.push_back(subsystem->submodel_info_1.angs.p / PI2);
+				}
+
+				if (subsystem->submodel_info_2.angs.b != Oo_info.player_frame_info[pl->player_id].last_sent[objp->net_signature].subsystem_2b[i]) {
+					flags[i] |= OO_SUBSYS_ROTATION_2b;
+					subsys_data.push_back(subsystem->submodel_info_2.angs.b / PI2);
+				}
+
+				if (subsystem->submodel_info_2.angs.h != Oo_info.player_frame_info[pl->player_id].last_sent[objp->net_signature].subsystem_2h[i]) {
+					flags[i] |= OO_SUBSYS_ROTATION_2h;
+					subsys_data.push_back(subsystem->submodel_info_2.angs.h / PI2);
+				}
+
+				if (subsystem->submodel_info_2.angs.p != Oo_info.player_frame_info[pl->player_id].last_sent[objp->net_signature].subsystem_2p[i]) {
+					flags[i] |= OO_SUBSYS_ROTATION_2p;
+					subsys_data.push_back(subsystem->submodel_info_2.angs.p / PI2);
+				}
+
+			}
+			i++;
 		}
-		// add the # of subsystems, and their data
-		else {
-			ns = (ubyte)Ship_info[shipp->ship_info_index].n_subsystems;
-			PACK_BYTE( ns );
 
-			multi_rate_add(NET_PLAYER_NUM(pl), "sub", 1);	
+		// Only send info if the count is greater than zero and if we're *not* on the very first frame when everything is already synced, anyway.
+		if (!subsys_data.empty() && Oo_info.number_of_frames != 0){
 
-			// now the subsystems.
-			for ( subsysp = GET_FIRST(&shipp->subsys_list); subsysp != END_OF_LIST(&shipp->subsys_list); subsysp = GET_NEXT(subsysp) ) {
-				temp = (float)subsysp->current_hits / (float)subsysp->max_hits;
-				PACK_PERCENT(temp);
-				
-				multi_rate_add(NET_PLAYER_NUM(pl), "sub", 1);
+			Assertion(i <= MAX_MODEL_SUBSYSTEMS, "Object Update packet exceeded limit for number of subsystems. This is a coder error, please report!\n");
+			ret = multi_pack_unpack_subsystem_list(true, data + packet_size + header_bytes, &flags, &subsys_data);
+
+			// Check that we are not sending too much data, if so, don't actually send.
+			if (packet_size + ret <= OO_MAX_DATA_SIZE) {
+				nprintf(("Network","Had to remove subsystems section from data packet for %s\n", shipp->ship_name));
+				oo_flags |= OO_SUBSYSTEMS_NEW;		
+				packet_size += ret;
 			}
 		}
+	}
+
+	// Cyborg17 - only server should send this
+	if (oo_flags & OO_AI_NEW){
+		int pre_section_size = packet_size;
+		ai_info *aip = &Ai_info[shipp->ai_index];
 
 		// ai mode info
-		ubyte umode = (ubyte)(Ai_info[shipp->ai_index].mode);
-		short submode = (short)(Ai_info[shipp->ai_index].submode);
-		ushort target_signature;
+		auto umode = (ubyte)(aip->mode);
+		auto submode = (short)(aip->submode);
+		ushort target_signature = 0;
 
-		target_signature = 0;
-		if ( Ai_info[shipp->ai_index].target_objnum != -1 ){
+		// either send out the waypoint they are trying to get to *or* their current target
+		if (umode == AIM_WAYPOINTS) {
+			// if it's already started pointing to a waypoint, grab its net_signature and send that instead
+			if ((aip->wp_list != nullptr) && (aip->wp_list->get_waypoints().size() > aip->wp_index)) {
+				target_signature = Objects[aip->wp_list->get_waypoints().at(aip->wp_index).get_objnum()].net_signature;
+			}
+		} // send the target signature.
+		else if (aip->target_objnum != -1) {
 			target_signature = Objects[Ai_info[shipp->ai_index].target_objnum].net_signature;
 		}
 
@@ -532,27 +1196,26 @@ int multi_oo_pack_data(net_player *pl, object *objp, ubyte oo_flags, ubyte *data
 		PACK_SHORT( submode );
 		PACK_USHORT( target_signature );	
 
-		multi_rate_add(NET_PLAYER_NUM(pl), "aim", 5);
-
 		// primary weapon energy
-		temp = shipp->weapon_energy / sip->max_weapon_reserve;
-		PACK_PERCENT(temp);
+		temp_float = shipp->weapon_energy / sip->max_weapon_reserve;
+		PACK_PERCENT(temp_float);
+
+		// check for adding too much data, if so don't send what we just wrote.
+		if (packet_size > OO_MAX_DATA_SIZE) {
+			nprintf(("Network","Had to remove AI section from data packet for %s\n", shipp->ship_name));
+			packet_size = pre_section_size;
+			oo_flags &= ~OO_AI_NEW;
+		} // otherwise, make sure it gets counted int the rate limiting system.
+		else {
+			multi_rate_add(NET_PLAYER_NUM(pl), "aim", 5);
+		}
 	}		
 
-	// afterburner info
-	oo_flags &= ~OO_AFTERBURNER_NEW;
-	if(objp->phys_info.flags & PF_AFTERBURNER_ON){
-		oo_flags |= OO_AFTERBURNER_NEW;
-	}
-
 	// if this ship is a support ship, send some extra info
-	ubyte support_extra = 0;
 	if(MULTIPLAYER_MASTER && (sip->flags[Ship::Info_Flags::Support]) && (shipp->ai_index >= 0) && (shipp->ai_index < MAX_AI_INFO)){
+		int pre_section_size = packet_size;
 		ushort dock_sig;
 
-		// flag
-		support_extra = 1;		
-		PACK_BYTE( support_extra );
 		PACK_ULONG( Ai_info[shipp->ai_index].ai_flags.to_u64() );
 		PACK_INT( Ai_info[shipp->ai_index].mode );
 		PACK_INT( Ai_info[shipp->ai_index].submode );
@@ -564,37 +1227,44 @@ int multi_oo_pack_data(net_player *pl, object *objp, ubyte oo_flags, ubyte *data
 		}		
 
 		PACK_USHORT( dock_sig );
-	} else {
-		support_extra = 0;
-		PACK_BYTE( support_extra );
-	}			
 
-	// make sure we have a valid chunk of data
-	// Clients: must be able to accomodate the data_size and shipp->np_updates[NET_PLAYER_NUM(pl)].seq before the data itself
-	// Server: TODO
-	Assert(packet_size < 255-1);
-	if(packet_size >= 255-1){
+		// check for adding too much data, if so don't send what we just wrote.
+		if (packet_size > OO_MAX_DATA_SIZE) {
+			nprintf(("Network","Had to remove support ship section from data packet for %s\n", shipp->ship_name));
+			packet_size = pre_section_size;
+		}
+		else {
+			oo_flags |= OO_SUPPORT_SHIP;
+		}
+	}
+
+	// afterburner info
+	oo_flags &= ~OO_AFTERBURNER_NEW;
+	if(objp->phys_info.flags & PF_AFTERBURNER_ON){
+		oo_flags |= OO_AFTERBURNER_NEW;
+	}
+
+	// make sure we have a a packet that will fit.
+	Assertion(packet_size <= OO_MAX_DATA_SIZE, "Somehow, the buffer overflow safeguards that are supposed to keep the OO_packet from overflowing failed for %s and came up to a size of %d. Please report!!", shipp->ship_name, packet_size);
+	if(packet_size >= OO_MAX_DATA_SIZE){
 		return 0;
 	}
-	data_size = (ubyte)packet_size;
+	data_size = (ushort)packet_size;
 
-	// add the object's net signature, type and oo_flags
+	// reset packet_size so that we add the header at the beginning of the packet where it belongs.
 	packet_size = 0;
 	// don't add for clients
-	if(Net_player->flags & NETINFO_FLAG_AM_MASTER){		
+	if(MULTIPLAYER_MASTER){		
 		multi_rate_add(NET_PLAYER_NUM(pl), "sig", 2);
-		ADD_USHORT( objp->net_signature );		
-
-		multi_rate_add(NET_PLAYER_NUM(pl), "flg", 1);
-		ADD_DATA( oo_flags );
+		ADD_USHORT( objp->net_signature );
 	}	
 
-	multi_rate_add(NET_PLAYER_NUM(pl), "siz", 1);
-	ADD_DATA( data_size );	
-	
-	multi_rate_add(NET_PLAYER_NUM(pl), "seq", 1);
-	ADD_DATA( shipp->np_updates[NET_PLAYER_NUM(pl)].seq );
+	multi_rate_add(NET_PLAYER_NUM(pl), "flg", 1);
+	ADD_USHORT( oo_flags );
 
+	multi_rate_add(NET_PLAYER_NUM(pl), "siz", 1);
+	ADD_USHORT( data_size );	
+	
 	packet_size += data_size;
 
 	// copy to the outgoing data
@@ -603,7 +1273,6 @@ int multi_oo_pack_data(net_player *pl, object *objp, ubyte oo_flags, ubyte *data
 	return packet_size;	
 }
 
-// unpack information for a client , return bytes processed
 // unpack information for a client, return bytes processed
 int multi_oo_unpack_client_data(net_player* pl, ubyte* data)
 {
@@ -667,8 +1336,8 @@ int multi_oo_unpack_client_data(net_player* pl, ubyte* data)
 		}
 
 		// afterburner status
-		if ((objp != nullptr) && (in_flags & OOC_AFTERBURNER_ON)) {
-			Multi_oo_afterburn_hack = true;
+		if ( (objp != nullptr) && (in_flags & OOC_AFTERBURNER_ON) ) {
+			Afterburn_hack = true;
 		}
 	}
 
@@ -759,68 +1428,87 @@ int multi_oo_unpack_client_data(net_player* pl, ubyte* data)
 }
 
 // unpack the object data, return bytes processed
+// Cyborg17 - This function has been revamped to ignore out of date information by type.  For example, if we got pos info
+// more recently, but the packet has the newest AI info, we will still use the AI info, even though it's not the newest
+// packet.
 #define UNPACK_PERCENT(v)					{ ubyte temp_byte; memcpy(&temp_byte, data + offset, sizeof(ubyte)); v = (float)temp_byte / 255.0f; offset++;}
-int multi_oo_unpack_data(net_player *pl, ubyte *data)
-{	
-	int offset = 0;		
-	object *pobjp;
+int multi_oo_unpack_data(net_player* pl, ubyte* data, int seq_num)
+{
+	int offset = 0;
+	object* pobjp;
 	ushort net_sig = 0;
-	ubyte data_size, oo_flags;
-	ubyte seq_num;
-	char percent;	
+	ushort data_size; // now a ushort because of IPv6
+	ushort oo_flags;
 	float fpct;
-	ship *shipp;
-	ship_info *sip;
+	ship* shipp;
+	ship_info* sip;
+
+	// ---------------------------------------------------------------------------------------------------------------
+	// Header Processing
+	// ---------------------------------------------------------------------------------------------------------------
 
 	// add the object's net signature, type and oo_flags
-	if(!(Net_player->flags & NETINFO_FLAG_AM_MASTER)){
-		GET_USHORT( net_sig );		
-		GET_DATA( oo_flags );	
-	}	
-	// clients always pos and orient stuff only
-	else {			
-		oo_flags = (OO_POS_NEW | OO_ORIENT_NEW);
+	if (!(Net_player->flags & NETINFO_FLAG_AM_MASTER)) {
+		GET_USHORT(net_sig);
 	}
-	GET_DATA( data_size );	
-	GET_DATA( seq_num );
 
-	// try and find the object
-	if(!(Net_player->flags & NETINFO_FLAG_AM_MASTER)){
-		pobjp = multi_get_network_object(net_sig);	
-	} else {	
-		if((pl != NULL) && (pl->m_player->objnum != -1)){
-			pobjp = &Objects[pl->m_player->objnum];
-		} else {
-			pobjp = NULL;
+	// clients always pos and orient stuff only
+	GET_USHORT(oo_flags);
+	GET_USHORT(data_size);
+	if (MULTIPLAYER_MASTER) {
+		// client cannot send these types because the server is in charge of all of these things.
+		Assertion(!(oo_flags & (OO_AI_NEW | OO_SHIELDS_NEW | OO_HULL_NEW | OO_SUBSYSTEMS_NEW | OO_SUPPORT_SHIP)), "Invalid flag from client, please report! oo_flags value: %d\n", oo_flags);
+		if (oo_flags & (OO_AI_NEW | OO_SHIELDS_NEW | OO_HULL_NEW | OO_SUBSYSTEMS_NEW | OO_SUPPORT_SHIP)) {
+			offset += data_size;
+			return offset;
 		}
-	}	
-	
-	// if we can't find the object, set pointer to bogus object to continue reading the data
-	// ignore out of sequence packets here as well
+	}
+	// try and find the object
+	if (MULTIPLAYER_CLIENT) {
+		pobjp = multi_get_network_object(net_sig);
+	}
+	else {
+		if ((pl != nullptr) && (pl->m_player->objnum != -1)) {
+			pobjp = &Objects[pl->m_player->objnum];
+			// Cyborg17 - We still need the net_signature if we're the Server because that's how we track interpolation info now.
+			net_sig = pobjp->net_signature;
+		}
+		else {
+			pobjp = nullptr;
+		}
+	}
+
+	// if we can't find the object, skip the packet
 	if ( (pobjp == nullptr) || (pobjp->type != OBJ_SHIP) || (pobjp->instance < 0) || (pobjp->instance >= MAX_SHIPS) || (Ships[pobjp->instance].ship_info_index < 0) || (Ships[pobjp->instance].ship_info_index >= ship_info_size())) {
 		offset += data_size;
 		return offset;
 	}
-	
+
 	// ship pointer
 	shipp = &Ships[pobjp->instance];
 	sip = &Ship_info[shipp->ship_info_index];
 
-	// ---------------------------------------------------------------------------------------------------------------
-	// CRITICAL OBJECT UPDATE SHIZ
-	// ---------------------------------------------------------------------------------------------------------------
-	
-	// if the packet is out of order
-	if(seq_num < shipp->np_updates[NET_PLAYER_NUM(pl)].seq){
-		// non-wraparound case
-		if((shipp->np_updates[NET_PLAYER_NUM(pl)].seq - seq_num) <= 100){
-			offset += data_size;
-			return offset;
-		}
-	}	
+	Assertion(net_sig <= Oo_info.interp.size(), "Somehow there weren't enough copies of the interpolation tracking info created.");
 
-	// make sure the ab hack is reset before we read in new info
-	Multi_oo_afterburn_hack = false;
+	oo_packet_and_interp_tracking* interp_data = &Oo_info.interp[net_sig];
+
+	// two variables to make the following code more readable.
+	int most_recent = interp_data->most_recent_packet;
+
+	// maybe mark as the most recent packet for this ship
+	if (seq_num > most_recent) {
+		interp_data->most_recent_packet = seq_num;
+	}
+
+	// Cyborg17 - determine if this is the most recently updated ship.  If it is, it will become the ship that the
+	// client will use as its reference when sending a primary shot packet.
+	if (MULTIPLAYER_CLIENT) {
+		multi_ship_record_rank_seq_num(pobjp, seq_num);
+	}
+
+	// ---------------------------------------------------------------------------------------------------------------
+	// SPECIAL CLIENT INFO
+	// ---------------------------------------------------------------------------------------------------------------
 
 	// if this is from a player, read his button info
 	if(MULTIPLAYER_MASTER){
@@ -828,182 +1516,303 @@ int multi_oo_unpack_data(net_player *pl, ubyte *data)
 		offset += r0;
 	}
 
-	// new info
+	// ---------------------------------------------------------------------------------------------------------------
+	// CRITICAL OBJECT UPDATE SHIZ
+	// ---------------------------------------------------------------------------------------------------------------
+	// (Positon, Orientation, and the related velocities and desired velocities)
+
+	// Have "new info" default to the old info before reading
 	vec3d new_pos = pobjp->pos;
-	physics_info new_phys_info = pobjp->phys_info;
+	angles new_angles;
 	matrix new_orient = pobjp->orient;
-	
-	// position
-	if ( oo_flags & OO_POS_NEW ) {						
-		// AVERAGE TIME BETWEEN PACKETS FOR THIS SHIP
-		// store this latest time stamp
-		if(oo_arrive_time_count[shipp - Ships] == 5){
-			memmove(&oo_arrive_time[shipp - Ships][0], &oo_arrive_time[shipp - Ships][1], sizeof(float) * 4);
-			oo_arrive_time[shipp - Ships][4] = f2fl(Missiontime);
-		} else {
-			oo_arrive_time[shipp - Ships][oo_arrive_time_count[shipp - Ships]++] = f2fl(Missiontime);
-		}
-		// if we've got 5 elements calculate the average
-		if(oo_arrive_time_count[shipp - Ships] == 5){
-			int idx;
-			oo_arrive_time_avg_diff[shipp - Ships] = 0.0f;
-			for(idx=0; idx<4; idx++){
-				oo_arrive_time_avg_diff[shipp - Ships] += oo_arrive_time[shipp - Ships][idx + 1] - oo_arrive_time[shipp - Ships][idx];
-			}
-			oo_arrive_time_avg_diff[shipp - Ships] /= 5.0f;
-		}
+	physics_info new_phys_info = pobjp->phys_info;
 
-		// int r1 = multi_pack_unpack_position( 0, data + offset, &pobjp->pos );
-		int r1 = multi_pack_unpack_position( 0, data + offset, &new_pos );
-		offset += r1;				
+	bool pos_new = false, adjust_interp_pos = false;
 
-		// int r3 = multi_pack_unpack_vel( 0, data + offset, &pobjp->orient, &pobjp->pos, &pobjp->phys_info );
-		int r3 = multi_pack_unpack_vel( 0, data + offset, &pobjp->orient, &new_pos, &new_phys_info );
+	if ( oo_flags & OO_POS_AND_ORIENT_NEW) {
+
+		// unpack position
+		int r1 = multi_pack_unpack_position(0, data + offset, &new_pos);
+		offset += r1;
+
+		// unpack orientation
+		int r2 = multi_pack_unpack_orient( 0, data + offset, &new_angles );
+		offset += r2;
+
+		// new version of the orient packer sends angles instead to save on bandwidth, so we'll need the orienation from that.
+		vm_angles_2_matrix(&new_orient, &new_angles);
+
+		int r3 = multi_pack_unpack_vel(0, data + offset, &new_orient, &new_phys_info);
 		offset += r3;
+
+		int r4 = multi_pack_unpack_rotvel( 0, data + offset, &new_phys_info );
+		offset += r4;
+
+		vec3d local_desired_vel = vmd_zero_vector;
 		
-		// bash desired vel to be velocity
-		// pobjp->phys_info.desired_vel = pobjp->phys_info.vel;		
-	}	
+		bool full_physics = (oo_flags & OO_FULL_PHYSICS);
 
-	// orientation	
-	if ( oo_flags & OO_ORIENT_NEW ) {		
-		// int r2 = multi_pack_unpack_orient( 0, data + offset, &pobjp->orient );
-		int r2 = multi_pack_unpack_orient( 0, data + offset, &new_orient );
-		offset += r2;		
-
-		// int r5 = multi_pack_unpack_rotvel( 0, data + offset, &pobjp->orient, &pobjp->pos, &pobjp->phys_info );
-		int r5 = multi_pack_unpack_rotvel( 0, data + offset, &new_orient, &new_pos, &new_phys_info );
+		ubyte r5 = multi_pack_unpack_desired_vel_and_desired_rotvel(0, full_physics, data + offset, &pobjp->phys_info, &local_desired_vel);
 		offset += r5;
+		// change it back to global coordinates.
+		vm_vec_unrotate(&new_phys_info.desired_vel, &local_desired_vel, &new_orient);
 
-		// bash desired rotvel to be 0
-		// pobjp->phys_info.desired_rotvel = vmd_zero_vector;
-	}
-	
-	// forward thrust	
-	percent = (char)(pobjp->phys_info.forward_thrust * 100.0f);
-	Assert( percent <= 100 );
-	GET_DATA(percent);		
+		// make sure this is the newest frame sent and then start storing everything.
+		if (seq_num > interp_data->pos_comparison_frame) {
+			// mark this packet as a brand new update.
+			pos_new = true;
 
-	// now stuff all this new info
-	if(oo_flags & OO_POS_NEW){
-		// if we're past the position update tolerance, bash.
-		// this should cause our 2 interpolation splines to be exactly the same. so we'll see a jump,
-		// but it should be nice and smooth immediately afterwards
-		if(vm_vec_dist(&new_pos, &pobjp->pos) > OO_POS_UPDATE_TOLERANCE){
-			pobjp->pos = new_pos;
+			// make sure to turn off no position change mode.
+			interp_data->prev_packet_positionless = false;
+
+			// update timing info, position
+			interp_data->prev_pack_pos_frame = interp_data->cur_pack_pos_frame;
+			interp_data->prev_pos_comparison_frame = interp_data->pos_comparison_frame;
+			interp_data->cur_pack_pos_frame = interp_data->pos_comparison_frame = seq_num;
+			// double check that we have valid data
+			if (interp_data->prev_pack_pos_frame != interp_data->cur_pack_pos_frame) {
+				adjust_interp_pos = true;
+			}
+
+			interp_data->pos_timestamp = timestamp();
+
+		} // if we actually received a slightly old frame...
+		else if (seq_num > interp_data->prev_pos_comparison_frame){
+			//update timing info.
+			if (seq_num != interp_data->cur_pack_pos_frame) {
+				interp_data->prev_pack_pos_frame = interp_data->prev_pos_comparison_frame = seq_num;
+				adjust_interp_pos = true;
+			}
 		}
 
-		// recalc any interpolation info		
-		if(oo_interp_count[shipp - Ships] < 2){
-			oo_interp_points[shipp - Ships][oo_interp_count[shipp - Ships]++] = new_pos;			
-		} else {
-			oo_interp_points[shipp - Ships][0] = oo_interp_points[shipp - Ships][1];
-			oo_interp_points[shipp - Ships][1] = new_pos;			
+		// implement desired_vel and desired rotvel
+		if (pos_new) {
+			interp_data->cur_pack_des_vel = new_phys_info.desired_vel;
+			interp_data->cur_pack_local_des_vel = local_desired_vel;
+			interp_data->cur_pack_des_rot_vel = new_phys_info.desired_rotvel;
 
-			multi_oo_calc_interp_splines(SHIP_INDEX(shipp), &pobjp->pos, &pobjp->phys_info, &new_pos, &new_orient, &new_phys_info);
+			pobjp->phys_info = new_phys_info;			
 		}
+
+		float temp_distance = vm_vec_dist(&new_pos, &pobjp->pos);
 		
-		pobjp->phys_info.vel = new_phys_info.vel;		
-		pobjp->phys_info.desired_vel = new_phys_info.vel;
-	} 
+		// Cyborg17 - fully bash if we're past the position update tolerance or not moving
+		// Past the update tolerance will cause a jump, but it should be nice and smooth immediately afterwards
+		if(pos_new && (temp_distance > OO_POS_UPDATE_TOLERANCE || new_phys_info.vel == vmd_zero_vector)){
+			pobjp->pos = new_pos;
+			//Also, make sure that FSO knows that it does not need to smooth anything out
+			interp_data->position_error = vmd_zero_vector;
+		} 	// When not bashing, find how much error to smooth out during interpolation.
+		else {
+			vm_vec_sub(&interp_data->position_error, &pobjp->pos, &new_pos);
+		}
 
-	// we'll just sim rotation straight. it works fine.
-	if(oo_flags & OO_ORIENT_NEW){
-		pobjp->orient = new_orient;
-		pobjp->phys_info.rotvel = new_phys_info.rotvel;
-		// pobjp->phys_info.desired_rotvel = vmd_zero_vector;
-		pobjp->phys_info.desired_rotvel = new_phys_info.rotvel;
-	}	
+		// for orientation, we should bash for brand new orientations and then let interpolation do its work.  
+		// This is similar to the straight siming that was done before, but the new interpolation makes 
+		// the movement smoother by having the two simulated together when creating the spline 
+		// and using the same time deltas.
+		if (pos_new){
+			pobjp->orient = new_orient;
+			interp_data->new_orientation = new_orient;
+		}
 
+		multi_oo_maybe_update_interp_info(pl->player_id, pobjp, &new_pos, &new_angles, &new_orient, &new_phys_info, adjust_interp_pos, pos_new);
+
+	} // in order to allow the server to send only new pos and ori info, we have to do a couple checks here
+	else if (seq_num == interp_data->most_recent_packet){
+		if (!interp_data->prev_packet_positionless) {
+			interp_data->prev_packet_positionless = true;
+			interp_data->prev_pack_pos_frame = interp_data->cur_pack_pos_frame ;
+			interp_data->cur_pack_pos_frame = seq_num;
+			
+			// bash the ship's velocity and rotational velocity to zero
+			pobjp->phys_info.vel = vmd_zero_vector;
+			pobjp->phys_info.desired_vel = vmd_zero_vector;
+			pobjp->phys_info.rotvel = vmd_zero_vector;
+			pobjp->phys_info.desired_rotvel = vmd_zero_vector;
+
+			// if we haven't moved, there is *no* position error.
+			interp_data->position_error = vmd_zero_vector;
+		}
+	}
+
+	// Packet processing needs to stop here if the ship is still arriving, leaving, dead or dying to prevent bugs.
+	if (shipp->is_arriving() || shipp->is_dying_or_departing() || shipp->flags[Ship::Ship_Flags::Exploded]) {
+		int header_bytes = (MULTIPLAYER_MASTER) ? OO_CLIENT_HEADER_SIZE : OO_SERVER_HEADER_SIZE;		
+		offset = header_bytes + data_size;
+		return offset;
+	}
 
 	// ---------------------------------------------------------------------------------------------------------------
-	// ANYTHING BELOW HERE WORKS FINE - nothing here which causes jumpiness or bandwidth problems :) WHEEEEE!
+	// SHIP STATUS
 	// ---------------------------------------------------------------------------------------------------------------
 	
 	// hull info
 	if ( oo_flags & OO_HULL_NEW ){
 		UNPACK_PERCENT(fpct);
-		pobjp->hull_strength = fpct * Ships[pobjp->instance].ship_max_hull_strength;		
-
-		float quad = shield_get_max_quad(pobjp);
-
-		for (int i = 0; i < pobjp->n_quadrants; i++) {
-			UNPACK_PERCENT(fpct);
-			pobjp->shield_quadrant[i] = fpct * quad;
+		if (seq_num > interp_data->hull_comparison_frame) {
+			pobjp->hull_strength = fpct * Ships[pobjp->instance].ship_max_hull_strength;
+			interp_data->hull_comparison_frame = seq_num;
 		}
 	}	
 
-	if ( oo_flags & OO_SUBSYSTEMS_AND_AI_NEW ) {
-		ubyte n_subsystems, subsys_count;
-		float subsystem_percent[MAX_MODEL_SUBSYSTEMS];		
-		ship_subsys *subsysp;		
-		float val;		
-		int i;		
+	// update shields
+	if (oo_flags & OO_SHIELDS_NEW) {
+		float quad = shield_get_max_quad(pobjp);
 
-		// get the data for the subsystems
-		GET_DATA( n_subsystems );
-		for ( i = 0; i < n_subsystems; i++ ){
-			UNPACK_PERCENT( subsystem_percent[i] );
-		}		
-		
-		// fill in the subsystem data
-		subsys_count = 0;
-		for ( subsysp = GET_FIRST(&shipp->subsys_list); subsysp != END_OF_LIST(&shipp->subsys_list); subsysp = GET_NEXT(subsysp) ) {
-			int subsys_type;
-
-			val = subsystem_percent[subsys_count] * subsysp->max_hits;
-			subsysp->current_hits = val;
-
-			// add the value just generated (it was zero'ed above) into the array of generic system types
-			subsys_type = subsysp->system_info->type;					// this is the generic type of subsystem
-			Assert ( subsys_type < SUBSYSTEM_MAX );
-			if (!(subsysp->flags[Ship::Subsystem_Flags::No_aggregate])) {
-				shipp->subsys_info[subsys_type].aggregate_current_hits += val;
+		// check before unpacking here so we don't have to recheck for each quadrant.
+		if (seq_num > interp_data->shields_comparison_frame ) {
+			for (int i = 0; i < pobjp->n_quadrants; i++) {
+				UNPACK_PERCENT(fpct);
+				pobjp->shield_quadrant[i] = fpct * quad;
 			}
-			subsys_count++;
-
-			// if we've reached max subsystems for some reason, bail out
-			if(subsys_count >= n_subsystems){
-				break;
+			interp_data->shields_comparison_frame = seq_num;
+		}
+		else {
+			for (int i = 0; i < pobjp->n_quadrants; i++) {
+				UNPACK_PERCENT(fpct);
 			}
 		}
-		
-		// recalculate all ship subsystems
-		ship_recalc_subsys_strength( shipp );			
+	}
 
+	// get the subsystem info
+	if (oo_flags & OO_SUBSYSTEMS_NEW) {
+		SCP_vector<ubyte> flags;  flags.reserve(MAX_MODEL_SUBSYSTEMS);
+		SCP_vector<float> subsys_data;  subsys_data.reserve(MAX_MODEL_SUBSYSTEMS); // couldn't think of a better constant to put here
+		
+		ubyte ret7 = multi_pack_unpack_subsystem_list(false, data + offset, &flags, &subsys_data);
+		offset += ret7;
+
+		// Before we start the loop, we need to get the first subsystem, to make sure that it's set up to avoid issues.
+		ship_subsys* subsysp = GET_FIRST(&shipp->subsys_list);
+
+		// and the index to use in the subsys_data vector
+		int data_idx = 0;
+
+		if (subsysp != nullptr) {
+			// look for a match, in order to set values.
+			for (int i = 0; i < (int)flags.size(); i++) {
+				// the current subsystem had no info, or was somehow a nullptr, so try the next subsystem.
+				if (flags[i] == 0 || subsysp == nullptr) {
+					subsysp = GET_NEXT(subsysp);
+					continue;
+				}
+
+				// update health
+				if (flags[i] & OO_SUBSYS_HEALTH) {
+					if (seq_num > interp_data->subsystems_comparison_frame[i]) {
+						interp_data->subsystems_comparison_frame[i] = seq_num;
+						subsysp->current_hits = subsys_data[data_idx] * subsysp->max_hits;
+
+						// Aggregate if necessary.
+						if (!(subsysp->flags[Ship::Subsystem_Flags::No_aggregate])) {
+							shipp->subsys_info[subsysp->system_info->type].aggregate_current_hits += subsysp->current_hits;
+						}
+					}
+					data_idx++;
+				}
+
+				if (flags[i] & OO_SUBSYS_ROTATION_1b) {
+					subsysp->submodel_info_1.prev_angs.b = subsysp->submodel_info_1.angs.b;
+					subsysp->submodel_info_1.angs.b = (subsys_data[data_idx] * PI2);
+					data_idx++;
+				}
+
+				if (flags[i] & OO_SUBSYS_ROTATION_1h) {
+					subsysp->submodel_info_1.prev_angs.h = subsysp->submodel_info_1.angs.h;
+					subsysp->submodel_info_1.angs.h = (subsys_data[data_idx] * PI2);
+					data_idx++;
+				}
+
+				if (flags[i] & OO_SUBSYS_ROTATION_1p) {
+					subsysp->submodel_info_1.prev_angs.p = subsysp->submodel_info_1.angs.p;
+					subsysp->submodel_info_1.angs.p = (subsys_data[data_idx] * PI2);
+					data_idx++;
+				}
+
+				if (flags[i] & OO_SUBSYS_ROTATION_2b) {
+					subsysp->submodel_info_2.prev_angs.b = subsysp->submodel_info_2.angs.b;
+					subsysp->submodel_info_2.angs.b = (subsys_data[data_idx] * PI2);
+					data_idx++;
+				}
+
+				if (flags[i] & OO_SUBSYS_ROTATION_2h) {
+					subsysp->submodel_info_2.prev_angs.h = subsysp->submodel_info_2.angs.h;
+					subsysp->submodel_info_2.angs.h = (subsys_data[data_idx] * PI2);
+					data_idx++;
+				}
+
+				if (flags[i] & OO_SUBSYS_ROTATION_2p) {
+					subsysp->submodel_info_2.prev_angs.p = subsysp->submodel_info_2.angs.p;
+					subsysp->submodel_info_2.angs.p = (subsys_data[data_idx] * PI2);
+					data_idx++;
+				}
+				subsysp = GET_NEXT(subsysp);
+
+			}
+			// recalculate all ship subsystems
+			ship_recalc_subsys_strength(shipp);
+		}
+
+	}
+
+	// ---------------------------------------------------------------------------------------------------------------
+	// AI & SUPPORT SHIP INFO
+	// ---------------------------------------------------------------------------------------------------------------
+
+	if ( oo_flags & OO_AI_NEW ) {
 		// ai mode info
 		ubyte umode;
 		short submode;
 		ushort target_signature;
 		object *target_objp;
 
+		// AI info
 		GET_DATA( umode );
 		GET_SHORT( submode );
 		GET_USHORT( target_signature );		
 
-		if(shipp->ai_index >= 0){
-			Ai_info[shipp->ai_index].mode = umode;
-			Ai_info[shipp->ai_index].submode = submode;		
-
-			// set this guys target objnum
-			target_objp = multi_get_network_object( target_signature );
-			if ( target_objp == NULL ){
-				Ai_info[shipp->ai_index].target_objnum = -1;
-			} else {
-				Ai_info[shipp->ai_index].target_objnum = OBJ_INDEX(target_objp);
-			}
-		}		
-
 		// primary weapon energy		
 		float weapon_energy_pct;
 		UNPACK_PERCENT(weapon_energy_pct);
-		shipp->weapon_energy = sip->max_weapon_reserve * weapon_energy_pct;		
+
+		if( seq_num > interp_data->ai_comparison_frame ){
+			if ( shipp->ai_index >= 0 ){
+				// make sure to undo the wrap if it occurred during compression for unset ai mode.
+				if (umode == 255) {
+					Ai_info[shipp->ai_index].mode = -1; 
+				}
+				else {
+					Ai_info[shipp->ai_index].mode = umode;
+				}
+				Ai_info[shipp->ai_index].submode = submode;		
+
+				// set this guy's target objnum, and other info
+				target_objp = multi_get_network_object( target_signature );
+				// if the info was bogus, set the target to an invalid object
+				if ( target_objp == nullptr ){
+					Ai_info[shipp->ai_index].target_objnum = -1;
+					Ai_info[shipp->ai_index].goals[0].target_name = "";
+				// set their waypoints if in waypoint mode.
+				} else if (umode == AIM_WAYPOINTS) {
+					waypoint* destination = find_waypoint_with_instance(target_objp->instance);
+					if (destination != nullptr) {
+						Ai_info[shipp->ai_index].wp_list = destination->get_parent_list();
+						Ai_info[shipp->ai_index].wp_index = find_index_of_waypoint(Ai_info[shipp->ai_index].wp_list, destination);
+					} else {
+						Ai_info[shipp->ai_index].wp_list = nullptr;
+					}
+				} else {
+					Ai_info[shipp->ai_index].target_objnum = OBJ_INDEX(target_objp);
+					Ai_info[shipp->ai_index].goals[0].target_name = Ships[target_objp->instance].ship_name;
+				}
+			}
+
+			shipp->weapon_energy = sip->max_weapon_reserve * weapon_energy_pct;
+		}		
 	}	
 
-	// support ship extra info
-	ubyte support_extra;
-	GET_DATA(support_extra);
-	if(support_extra){
+	if(oo_flags & OO_SUPPORT_SHIP){
 		ushort dock_sig;
 		int ai_mode, ai_submode;
 		std::uint64_t ai_flags;
@@ -1014,28 +1823,32 @@ int multi_oo_unpack_data(net_player *pl, ubyte *data)
 		GET_INT(ai_submode);
 		GET_USHORT(dock_sig);		
 
-		// valid ship?							
-		if((shipp != NULL) && (shipp->ai_index >= 0) && (shipp->ai_index < MAX_AI_INFO)){
+		// verify that it's a valid ship							
+		if((shipp != nullptr) && (shipp->ai_index >= 0) && (shipp->ai_index < MAX_AI_INFO)){
+			// bash ai info, this info does not get rebashed, because it is not as vital.
 			Ai_info[shipp->ai_index].ai_flags.from_u64(ai_flags);
 			Ai_info[shipp->ai_index].mode = ai_mode;
 			Ai_info[shipp->ai_index].submode = ai_submode;
 
 			object *objp = multi_get_network_object( dock_sig );
-			if(objp != NULL){
+			if(objp != nullptr){
 				Ai_info[shipp->ai_index].support_ship_objnum = OBJ_INDEX(objp);
 			}
 		}			
 	} 
 
+	// make sure the ab hack is reset before we read in new info
+	Afterburn_hack = false;
+
 	// afterburner info
-	if ( (oo_flags & OO_AFTERBURNER_NEW) || Multi_oo_afterburn_hack ) {
+	if ( (oo_flags & OO_AFTERBURNER_NEW) || Afterburn_hack ) {
 		// maybe turn them on
 		if(!(pobjp->phys_info.flags & PF_AFTERBURNER_ON)){
 			afterburners_start(pobjp);
 		}
 
 		// make sure the ab hack is reset before we read in new info
-		Multi_oo_afterburn_hack = false;
+		Afterburn_hack = false;
 	} else {
 		// maybe turn them off
 		if(pobjp->phys_info.flags & PF_AFTERBURNER_ON){
@@ -1044,7 +1857,7 @@ int multi_oo_unpack_data(net_player *pl, ubyte *data)
 	}
 
 	// primary info (only clients care about this)
-	if( !MULTIPLAYER_MASTER && (shipp != NULL) ){
+	if( !MULTIPLAYER_MASTER && (shipp != nullptr) ){
 		// what bank
 		if(oo_flags & OO_PRIMARY_BANK){
 			shipp->weapons.current_primary_bank = 1;
@@ -1066,17 +1879,10 @@ int multi_oo_unpack_data(net_player *pl, ubyte *data)
 	}
 	
 	// if we're the multiplayer server, set eye position and orient
-	if(MULTIPLAYER_MASTER && (pl != NULL) && (pobjp != NULL)){
+	if(MULTIPLAYER_MASTER && (pl != nullptr) && (pobjp != nullptr)){
 		pl->s_info.eye_pos = pobjp->pos;
 		pl->s_info.eye_orient = pobjp->orient;
 	} 		
-
-	// update the sequence #
-	shipp->np_updates[NET_PLAYER_NUM(pl)].seq = seq_num;
-
-	// flag the object as just updated
-	// pobjp->flags |= OF_JUST_UPDATED;
-	
 	return offset;
 }
 
@@ -1125,26 +1931,14 @@ void multi_oo_reset_timestamp(net_player *pl, object *objp, int range, int in_co
 
 	// reset the timestamp for this object
 	if(objp->type == OBJ_SHIP){
-		Ships[objp->instance].np_updates[NET_PLAYER_NUM(pl)].update_stamp = timestamp(stamp);
+		Oo_info.player_frame_info[pl->player_id].last_sent[objp->net_signature].timestamp = timestamp(stamp);
 	} 
-}
-
-// reset the timestamp appropriately for the passed in object
-void multi_oo_reset_status_timestamp(object *objp, int player_index)
-{
-	Ships[objp->instance].np_updates[player_index].status_update_stamp = timestamp(OO_HULL_SHIELD_TIME);
-}
-
-// reset the timestamp appropriately for the passed in object
-void multi_oo_reset_subsys_timestamp(object *objp, int player_index)
-{
-	Ships[objp->instance].np_updates[player_index].subsys_update_stamp = timestamp(OO_SUBSYS_TIME);
 }
 
 // determine what needs to get sent for this player regarding the passed object, and when
 int multi_oo_maybe_update(net_player *pl, object *obj, ubyte *data)
 {
-	ubyte oo_flags;
+	ushort oo_flags = 0;
 	int stamp;
 	int player_index;
 	vec3d player_eye;
@@ -1154,8 +1948,6 @@ int multi_oo_maybe_update(net_player *pl, object *obj, ubyte *data)
 	int range;
 	ship *shipp;
 	ship_info *sip;
-	ushort cur_pos_chksum = 0;
-	ushort cur_orient_chksum = 0;
 
 	// if the timestamp has elapsed for this guy, send stuff
 	player_index = NET_PLAYER_INDEX(pl);
@@ -1163,9 +1955,11 @@ int multi_oo_maybe_update(net_player *pl, object *obj, ubyte *data)
 		return 0;
 	}
 
+	int net_sig_idx = obj->net_signature;
+
 	// determine what the timestamp is for this object
 	if(obj->type == OBJ_SHIP){
-		stamp = Ships[obj->instance].np_updates[NET_PLAYER_NUM(pl)].update_stamp;
+		stamp = Oo_info.player_frame_info[pl->player_id].last_sent[net_sig_idx].timestamp;
 	} else {
 		return 0;
 	}
@@ -1175,13 +1969,13 @@ int multi_oo_maybe_update(net_player *pl, object *obj, ubyte *data)
 		return 0;
 	}
 	
-	// if we're supposed to update this guy	
+	// if we're supposed to update this guy	start figuring out what we should send.
 
 	// get the ship pointer
 	shipp = &Ships[obj->instance];
 
 	// get ship info pointer
-	sip = NULL;
+	sip = nullptr;
 	if(shipp->ship_info_index >= 0){
 		sip = &Ship_info[shipp->ship_info_index];
 	}
@@ -1209,12 +2003,28 @@ int multi_oo_maybe_update(net_player *pl, object *obj, ubyte *data)
 
 	// reset the timestamp for the next update for this guy
 	multi_oo_reset_timestamp(pl, obj, range, in_cone);
+	
+	// position should be almost constant, except for ships that aren't moving.
+	if ( (Oo_info.player_frame_info[pl->player_id].last_sent[net_sig_idx].position != obj->pos) && (vm_vec_mag_quick(&obj->phys_info.vel) > 0.0f ) ) {
+		oo_flags |= OO_POS_AND_ORIENT_NEW;
+		// update the last position sent, will be done in each of the cases below.
+		Oo_info.player_frame_info[pl->player_id].last_sent[net_sig_idx].position = obj->pos;
+	}   // same with orientation
+	else if (obj->phys_info.rotvel != vmd_zero_vector) {
+		oo_flags |= OO_POS_AND_ORIENT_NEW;
+	} 	// add info for a targeted object
+	else if((pl->s_info.target_objnum != -1) && (OBJ_INDEX(obj) == pl->s_info.target_objnum)){
+		oo_flags |= OO_POS_AND_ORIENT_NEW;
+	}	// add info which is contingent upon being "in front"			
+	else if(in_cone){
+		oo_flags |= OO_POS_AND_ORIENT_NEW;
+	}						
+		
 
-	// base oo_flags
-	oo_flags = OO_POS_NEW | OO_ORIENT_NEW;
 
 	// if its a small ship, add weapon link info
-	if((sip != NULL) && (sip->is_fighter_bomber())){
+	// Cyborg17 - these don't take any extra space because they are part of the flags variable, so it's ok to send them with every packet.
+	if((sip != nullptr) && (sip->is_fighter_bomber())){
 		// primary bank 0 or 1
 		if(shipp->weapons.current_primary_bank > 0){
 			oo_flags |= OO_PRIMARY_BANK;
@@ -1231,87 +2041,110 @@ int multi_oo_maybe_update(net_player *pl, object *obj, ubyte *data)
 		}
 	}	
 		
-	// if the object's hull/shield timestamp has expired
-	if((Ships[obj->instance].np_updates[player_index].status_update_stamp == -1) || timestamp_elapsed_safe(Ships[obj->instance].np_updates[player_index].status_update_stamp, OO_MAX_TIMESTAMP)){
+	// maybe update hull
+	if(Oo_info.player_frame_info[pl->player_id].last_sent[net_sig_idx].hull != obj->hull_strength){
 		oo_flags |= (OO_HULL_NEW);
-
-		// reset the timestamp
-		multi_oo_reset_status_timestamp(obj, player_index);			
+		Oo_info.player_frame_info[pl->player_id].last_sent[net_sig_idx].hull = obj->hull_strength;		
 	}
 
-	// if the object's hull/shield timestamp has expired
-	if((Ships[obj->instance].np_updates[player_index].subsys_update_stamp == -1) || timestamp_elapsed_safe(Ships[obj->instance].np_updates[player_index].subsys_update_stamp, OO_MAX_TIMESTAMP)){
-		oo_flags |= OO_SUBSYSTEMS_AND_AI_NEW;
-
-		// reset the timestamp
-		multi_oo_reset_subsys_timestamp(obj, player_index);
+	float temp_max = shield_get_max_quad(obj);
+	bool all_max = true;
+	// Client and server deal with ship death differently, so sending this info for dead ships can cause bugs
+	if (!(shipp->is_dying_or_departing() || shipp->flags[Ship::Ship_Flags::Exploded])) {
+		// maybe update shields, which are constantly repairing, and should be regularly updated, unless they are already spotless.
+		for (auto quadrant : obj->shield_quadrant) {
+			if (quadrant != temp_max) {
+				all_max = false;
+				break;
+			}
+		}
 	}
 
-	// add info for a targeted object
-	if((pl->s_info.target_objnum != -1) && (OBJ_INDEX(obj) == pl->s_info.target_objnum)){
-		oo_flags |= (OO_POS_NEW | OO_ORIENT_NEW | OO_HULL_NEW);
+	if (all_max) {
+		// shields are currently perfect, were they perfect last time?
+		if ( !Oo_info.player_frame_info[pl->player_id].last_sent[net_sig_idx].perfect_shields_sent){
+			// send the newly perfected shields
+			oo_flags |= OO_SHIELDS_NEW;
+		}
+		// make sure to mark it as perfect for next time.
+		Oo_info.player_frame_info[pl->player_id].last_sent[net_sig_idx].perfect_shields_sent = true;
+	} // if they're not perfect, make sure they're marked as not perfect.
+	else {
+		Oo_info.player_frame_info[pl->player_id].last_sent[net_sig_idx].perfect_shields_sent = false;
+		oo_flags |= OO_SHIELDS_NEW;
 	}
-	// all other cases
-	else {					
-		// add info which is contingent upon being "in front"			
-		if(in_cone){
-			oo_flags |= OO_ORIENT_NEW;
-		}						
-	}		
 
-	// get current position and orient checksums		
-	cur_pos_chksum = cf_add_chksum_short(cur_pos_chksum, (ubyte*)(&obj->pos), sizeof(vec3d));
-	cur_orient_chksum = cf_add_chksum_short(cur_orient_chksum, (ubyte*)(&obj->orient), sizeof(matrix));
 
-	// if position or orientation haven't changed	
-	if((shipp->np_updates[player_index].pos_chksum != 0) && (shipp->np_updates[player_index].pos_chksum == cur_pos_chksum)){
-		oo_flags &= ~(OO_POS_NEW);
+	ai_info *aip = &Ai_info[shipp->ai_index];
+
+	// check to see if the AI mode updated
+	if ((Oo_info.player_frame_info[pl->player_id].last_sent[net_sig_idx].ai_mode != aip->mode) 
+		|| (Oo_info.player_frame_info[pl->player_id].last_sent[net_sig_idx].ai_submode != aip->submode) 
+		|| (Oo_info.player_frame_info[pl->player_id].last_sent[net_sig_idx].target_signature != aip->target_signature)) {
+
+		// send, if so.
+		oo_flags |= OO_AI_NEW;
+
+		// set new values to check against later.
+		Oo_info.player_frame_info[pl->player_id].last_sent[net_sig_idx].ai_mode = aip->mode;
+		Oo_info.player_frame_info[pl->player_id].last_sent[net_sig_idx].ai_submode = aip->submode;
+		Oo_info.player_frame_info[pl->player_id].last_sent[net_sig_idx].target_signature = aip->target_signature;
 	}
-	if((shipp->np_updates[player_index].orient_chksum != 0) && (shipp->np_updates[player_index].orient_chksum == cur_orient_chksum)){
-		oo_flags &= ~(OO_ORIENT_NEW);
-	}
-	shipp->np_updates[player_index].pos_chksum = cur_pos_chksum;
-	shipp->np_updates[player_index].orient_chksum = cur_orient_chksum;
 
-	// pack stuff only if we have to 	
-	int packed = multi_oo_pack_data(pl, obj, oo_flags ,data);	
-
-	// increment sequence #
-	Ships[obj->instance].np_updates[NET_PLAYER_NUM(pl)].seq++;
+	// finally, pack stuff only if we have to 	
+	int packed = multi_oo_pack_data(pl, obj, oo_flags, data);	
 
 	// bytes packed
 	return packed;
 }
 
+
 // process all other objects for this player
 void multi_oo_process_all(net_player *pl)
 {
-	ubyte data[MAX_PACKET_SIZE];
-	ubyte data_add[MAX_PACKET_SIZE];
-	ubyte stop;
-	int add_size;	
-	int packet_size = 0;
-	int idx;
-		
-	object *moveup;	
-
-	// if the player has an invalid objnum..
+	// if the player has an invalid objnum abort..
 	if(pl->m_player->objnum < 0){
 		return;
 	}
 
-	object *targ_obj;	
+	// these two variables are needed throughout the whole function because of the ADD and BUILD_HEADER macros
+	ubyte data[MAX_PACKET_SIZE];
+	int packet_size = 0;	
 
 	// build the list of ships to check against
 	multi_oo_build_ship_list(pl);
 
+	// build the header
+	BUILD_HEADER(OBJECT_UPDATE);		
+
+	// Cyborg17 - And now header shared between ships, to help simplify the sequence and timing logic. This will save Server bandwidth
+	ADD_INT(Oo_info.number_of_frames);
+
+	// also the timestamp.
+	int temp_timestamp = (Oo_info.timestamps[Oo_info.cur_frame_index] - Oo_info.timestamps[multi_find_prev_frame_idx()]);
+
+	// only the very longest frames are going to have greater than 255 ms, so cap it at that.
+	if (temp_timestamp > 255) {
+		temp_timestamp = 255;
+	} else if (temp_timestamp < 0) {
+		// Send to the log if we're getting negative times. 
+		mprintf(("Somehow the object update packet is calculating a negative time differential in multi_oo_send_control_info. Value: %d. It's going to guess on a correct value. Please investigate.", temp_timestamp));
+		temp_timestamp = TIMESTAMP_OUT_IF_ERROR;
+	}
+
+	// finish adding the timestamp
+	auto time_out = (ubyte)temp_timestamp;
+	ADD_DATA(time_out);
+
+	ubyte stop;
+	int add_size;	
+	ubyte data_add[MAX_PACKET_SIZE * 2]; // we could have up to two maximum sized packets in the array without it overflowing.
+
 	// do nothing if he has no object targeted, or if he has a weapon targeted
 	if((pl->s_info.target_objnum != -1) && (Objects[pl->s_info.target_objnum].type == OBJ_SHIP)){
-		// build the header
-		BUILD_HEADER(OBJECT_UPDATE);		
-	
+
 		// get a pointer to the object
-		targ_obj = &Objects[pl->s_info.target_objnum];
+		object *targ_obj = &Objects[pl->s_info.target_objnum];
 	
 		// run through the maybe_update function
 		add_size = multi_oo_maybe_update(pl, targ_obj, data_add);
@@ -1325,39 +2158,40 @@ void multi_oo_process_all(net_player *pl)
 			memcpy(data + packet_size, data_add, add_size);
 			packet_size += add_size;		
 		}
-	} else {
-		// just build the header for the rest of the function
-		BUILD_HEADER(OBJECT_UPDATE);		
 	}
-		
-	idx = 0;
+	
+	bool packet_sent = false;
+	int idx = 0;
+
 	// rely on logical-AND shortcut evaluation to prevent array out-of-bounds read of OO_ship_index[idx]
 	while((idx < MAX_SHIPS) && (OO_ship_index[idx] >= 0)){
 		// if this guy is over his datarate limit, do nothing
 		if(multi_oo_rate_exceeded(pl)){
 			nprintf(("Network","Capping client\n"));
-			idx++;
-
-			continue;
+			break;
 		}			
 
 		// get the object
-		moveup = &Objects[Ships[OO_ship_index[idx]].objnum];
+		object *moveup = &Objects[Ships[OO_ship_index[idx]].objnum];
 
 		// maybe send some info		
 		add_size = multi_oo_maybe_update(pl, moveup, data_add);
 
 		// if this data is too much for the packet, send off what we currently have and start over
-		if(packet_size + add_size > OO_MAX_SIZE){
+		if(packet_size + add_size > MAX_PACKET_SIZE - 1){
 			stop = 0x00;			
 			multi_rate_add(NET_PLAYER_NUM(pl), "stp", 1);
 			ADD_DATA(stop);
 									
 			multi_io_send(pl, data, packet_size);
+			packet_sent = true;
 			pl->s_info.rate_bytes += packet_size + UDP_HEADER_SIZE;
 
 			packet_size = 0;
-			BUILD_HEADER(OBJECT_UPDATE);			
+			BUILD_HEADER(OBJECT_UPDATE);
+			// Cyborg17 - regurgitate shared header
+			ADD_INT(Oo_info.number_of_frames);
+			ADD_DATA(time_out);
 		}
 
 		if(add_size){
@@ -1374,12 +2208,12 @@ void multi_oo_process_all(net_player *pl)
 		idx++;
 	}
 
-	// if we have anything more than 3 byte in the packet, send the last one off
-	if(packet_size > 3){
+	// Cyborg17 - Now that this is basically an object update and timing update packet, we always should send at least one.
+	if (packet_size > OO_MAIN_HEADER_SIZE || !packet_sent) {
 		stop = 0x00;		
 		multi_rate_add(NET_PLAYER_NUM(pl), "stp", 1);
 		ADD_DATA(stop);
-								
+
 		multi_io_send(pl, data, packet_size);
 		pl->s_info.rate_bytes += packet_size + UDP_HEADER_SIZE;
 	}
@@ -1397,7 +2231,7 @@ void multi_oo_process()
 			multi_oo_process_all(&Net_players[idx]);
 
 			// do firing stuff for this player
-			if((Net_players[idx].m_player != NULL) && (Net_players[idx].m_player->objnum >= 0) && !(Net_players[idx].flags & NETINFO_FLAG_LIMBO) && !(Net_players[idx].flags & NETINFO_FLAG_RESPAWNING)){
+			if((Net_players[idx].m_player != nullptr) && (Net_players[idx].m_player->objnum >= 0) && !(Net_players[idx].flags & NETINFO_FLAG_LIMBO) && !(Net_players[idx].flags & NETINFO_FLAG_RESPAWNING)){
 				if((Objects[Net_players[idx].m_player->objnum].flags[Object::Object_Flags::Player_ship]) && !(Objects[Net_players[idx].m_player->objnum].flags[Object::Object_Flags::Should_be_dead])){
 					obj_player_fire_stuff( &Objects[Net_players[idx].m_player->objnum], Net_players[idx].m_player->ci );
 				}
@@ -1409,101 +2243,217 @@ void multi_oo_process()
 // process incoming object update data
 void multi_oo_process_update(ubyte *data, header *hinfo)
 {	
-	ubyte stop;	
 	int player_index;	
 	int offset = HEADER_LENGTH;
-	net_player *pl = NULL;	
+	net_player *pl = nullptr;	
 
 	// determine what player this came from 
 	player_index = find_player_id(hinfo->id);
 	if(player_index != -1){						
 		pl = &Net_players[player_index];
 	}
-	// otherwise its a "regular" object update packet on a client from the server. use "myself" as the reference player
+	// otherwise its a "regular" object update packet on a client from the server. Use the server as the reference.
 	else {						
-		pl = Net_player;
+		pl = Netgame.server;
 	}
 
+	int seq_num;
+	ubyte timestamp;
+	ubyte stop;	
+
+	// TODO: ADD COMPLICATED TIMESTAMP LOGIC HERE
+	GET_INT(seq_num);
+	GET_DATA(timestamp);
 	GET_DATA(stop);
 	
+	multi_ship_record_add_timestamp(pl->player_id, timestamp, seq_num);
+
 	while(stop == 0xff){
 		// process the data
-		offset += multi_oo_unpack_data(pl, data + offset);
+		offset += multi_oo_unpack_data(pl, data + offset, seq_num);
 
 		GET_DATA(stop);
 	}
 	PACKET_SET_SIZE();
 }
 
-// initialize all object update timestamps (call whenever entering gameplay state)
-void multi_oo_gameplay_init()
+// initialize all object update info (call whenever entering gameplay state)
+void multi_init_oo_and_ship_tracker()
 {
-	int cur, s_idx, idx;
-	//ship_obj *so;				
-	ship *shipp;
-	/*
-	int num_ships = ship_get_num_ships();
+	// setup initial object update info	
+	// Part 1: Get the non-repeating parts of the struct set.
 
-	if(num_ships <= 0){
-		return;
+	Oo_info.ref_timestamp = -1;
+	Oo_info.most_recent_updated_net_signature = 0;
+	Oo_info.most_recent_frame = 0;
+	for (int i = 0; i < MAX_PLAYERS; i++) {
+		Oo_info.received_frametimes[i].clear();
+		Oo_info.received_frametimes[i].reserve(36000); // enough memory for 10 minutes worth of frame time.
 	}
-	split = 3000 / num_ships;
-	*/
-	//split = 1;
-	//split = 150;
 
-	// server should setup initial update timestamps	
-	// stagger initial updates over 3 seconds or so
-	cur = 0;
-	//for ( so = GET_FIRST(&Ship_obj_list); so != END_OF_LIST(&Ship_obj_list); so = GET_NEXT(so) ) {
-		//if(Objects[so->objnum].type == OBJ_SHIP){
-	for(s_idx=0; s_idx<MAX_SHIPS; s_idx++){
-			shipp = &Ships[s_idx];
-		
-			// update the timestamps
-			for(idx=0;idx<MAX_PLAYERS;idx++){
-				shipp->np_updates[idx].update_stamp = timestamp(cur);
-				shipp->np_updates[idx].status_update_stamp = timestamp(cur);
-				shipp->np_updates[idx].subsys_update_stamp = timestamp(cur);
-				shipp->np_updates[idx].seq = 0;		
-				shipp->np_updates[idx].pos_chksum = 0;
-				shipp->np_updates[idx].orient_chksum = 0;
-			} 
-			
-			oo_arrive_time_count[shipp - Ships] = 0;			
-			oo_interp_count[shipp - Ships] = 0;
+	Oo_info.number_of_frames = 0;
+	Oo_info.wrap_count = 0;
+	Oo_info.larger_wrap_count = 0;
+	Oo_info.cur_frame_index = 0;
+	for (int i = 0; i < MAX_FRAMES_RECORDED; i++) {
+		Oo_info.timestamps[i] = MAX_TIME; // This needs to be Max time (or at least some absurdly high number) for rollback to work correctly
+	}
 
-			// increment the time
-//			cur += split;			
-		}
-	//}			
+	Oo_info.rollback_mode = false;
+	Oo_info.rollback_wobjp.clear();
+	Oo_info.rollback_collide_list.clear();
+	Oo_info.rollback_ships.clear();
+	for (int i = 0; i < MAX_FRAMES_RECORDED; i++) {
+		Oo_info.rollback_shots_to_be_fired[i].clear();
+		Oo_info.rollback_shots_to_be_fired[i].reserve(20);
+	}
+
+	// Part 2: Init/Reset the repeating parts of the struct. 
+	Oo_info.frame_info.clear();		
+	Oo_info.player_frame_info.clear();
+	Oo_info.interp.clear();
+
+	Oo_info.frame_info.reserve(MAX_SHIPS); // Reserving up to a reasonable number of ships here should help optimize a little bit.
+	Oo_info.player_frame_info.reserve(MAX_PLAYERS); // Reserve up to the max players
+	Oo_info.interp.reserve(MAX_SHIPS);
+
+	oo_ship_position_records temp_position_records;
+	oo_netplayer_records temp_netplayer_records;
+
+	for (int i = 0; i < MAX_FRAMES_RECORDED; i++) {
+		temp_position_records.orientations[i] = vmd_identity_matrix;
+		temp_position_records.positions[i] = vmd_zero_vector;
+		temp_position_records.velocities[i] = vmd_zero_vector;
+	}
+
+	int cur = 0;
+	oo_info_sent_to_players temp_sent_to_player;
+
+	temp_sent_to_player.timestamp = timestamp(cur);
+	temp_sent_to_player.position = vmd_zero_vector;
+	temp_sent_to_player.hull = 0.0f;
+	temp_sent_to_player.ai_mode = 0;
+	temp_sent_to_player.ai_submode = -1;
+	temp_sent_to_player.target_signature = 0;
+	temp_sent_to_player.perfect_shields_sent = false;
+
+	// See if *any* of the subsystems changed, so we have to allow for a variable number of subsystems within a variable number of ships.
+	temp_sent_to_player.subsystem_health.reserve(MAX_MODEL_SUBSYSTEMS);
+	temp_sent_to_player.subsystem_health.push_back(0.0f);
+
+	temp_sent_to_player.subsystem_1b.reserve(MAX_MODEL_SUBSYSTEMS);
+	temp_sent_to_player.subsystem_1b.push_back(0.0f);
+	
+	temp_sent_to_player.subsystem_1h.reserve(MAX_MODEL_SUBSYSTEMS);
+	temp_sent_to_player.subsystem_1h.push_back(0.0f);
+	
+	temp_sent_to_player.subsystem_1p.reserve(MAX_MODEL_SUBSYSTEMS);
+	temp_sent_to_player.subsystem_1p.push_back(0.0f);
+	
+	temp_sent_to_player.subsystem_2b.reserve(MAX_MODEL_SUBSYSTEMS);
+	temp_sent_to_player.subsystem_2b.push_back(0.0f);
+	
+	temp_sent_to_player.subsystem_2h.reserve(MAX_MODEL_SUBSYSTEMS);
+	temp_sent_to_player.subsystem_2h.push_back(0.0f);
+	
+	temp_sent_to_player.subsystem_2p.reserve(MAX_MODEL_SUBSYSTEMS);
+	temp_sent_to_player.subsystem_2p.push_back(0.0f);
+
+	temp_netplayer_records.last_sent.push_back(temp_sent_to_player);
+	Oo_info.frame_info.push_back(temp_position_records);
+	
+	for (int i = 0; i < MAX_PLAYERS; i++) {
+		Oo_info.player_frame_info.push_back(temp_netplayer_records);
+	}
+
+	// create a temporary struct and then push it to the vector
+	oo_packet_and_interp_tracking temp_interp;
+
+	temp_interp.cur_pack_pos_frame = -1;
+	temp_interp.prev_pack_pos_frame = -1;
+
+	temp_interp.client_simulation_mode = true;
+	temp_interp.prev_packet_positionless = false;
+
+	temp_interp.pos_time_delta = -1.0f;
+	temp_interp.old_packet_position = vmd_zero_vector;
+	temp_interp.new_packet_position = vmd_zero_vector;
+	temp_interp.position_error = vmd_zero_vector;
+
+	temp_interp.old_angles = vmd_zero_angles;
+	temp_interp.new_angles = vmd_zero_angles;
+	temp_interp.anticipated_angles_a = vmd_zero_angles;
+	temp_interp.anticipated_angles_b = vmd_zero_angles;
+	temp_interp.anticipated_angles_c = vmd_zero_angles;
+	temp_interp.new_orientation = vmd_identity_matrix;
+
+	temp_interp.new_velocity = vmd_zero_vector;
+	temp_interp.anticipated_velocity1 = vmd_zero_vector;
+	temp_interp.anticipated_velocity2 = vmd_zero_vector;
+	temp_interp.anticipated_velocity3 = vmd_zero_vector;
+
+	temp_interp.pos_spline = bez_spline();
+
+	temp_interp.cur_pack_des_vel = vmd_zero_vector;
+	temp_interp.cur_pack_local_des_vel = vmd_zero_vector;
+	temp_interp.cur_pack_des_rot_vel = vmd_zero_vector;
+
+	temp_interp.most_recent_packet = -1;
+	temp_interp.pos_comparison_frame = -1;
+	temp_interp.prev_pos_comparison_frame = -1;
+	temp_interp.hull_comparison_frame = -1;
+	temp_interp.shields_comparison_frame = -1;
+
+	temp_interp.subsystems_comparison_frame.reserve(MAX_MODEL_SUBSYSTEMS);
+	temp_interp.subsystems_comparison_frame.push_back(-1);
+
+	temp_interp.ai_comparison_frame = -1;
+	Oo_info.interp.push_back(temp_interp);
 
 	// reset datarate stamp now
 	extern int OO_gran;
-	for(idx=0; idx<MAX_PLAYERS; idx++){
-		Net_players[idx].s_info.rate_stamp = timestamp( (int)(1000.0f / (float)OO_gran) );
+	for(int i=0; i<MAX_PLAYERS; i++){
+		Net_players[i].s_info.rate_stamp = timestamp( (int)(1000.0f / (float)OO_gran) );
 	}
 }
+
 
 // send control info for a client (which is basically a "reverse" object update)
 void multi_oo_send_control_info()
 {
 	ubyte data[MAX_PACKET_SIZE], stop;
 	ubyte data_add[MAX_PACKET_SIZE];
-	ubyte oo_flags;	
+	ushort oo_flags;	
 	int add_size;
 	int packet_size = 0;
 
 	// if I'm dying or my object type is not a ship, bail here
-	if((Player_obj != NULL) && (Player_ship->flags[Ship::Ship_Flags::Dying])){
+	if((Player_obj != nullptr) && (Player_ship->flags[Ship::Ship_Flags::Dying])){
 		return;
 	}	
 	
 	// build the header
 	BUILD_HEADER(OBJECT_UPDATE);		
 
+	// Cyborg17 - And now the shared header, to help simplify the logic. Will save Server bandwidth
+	ADD_INT(Oo_info.number_of_frames);
+
+	// also the timestamp.
+	int temp_timestamp = (Oo_info.timestamps[Oo_info.cur_frame_index] - Oo_info.timestamps[multi_find_prev_frame_idx()]);
+
+	// only the very longest frames are going to have greater than 255 ms, so cap it at that.
+	if (temp_timestamp > 255) {
+		temp_timestamp = 255;
+	} else if (temp_timestamp < 0) {
+		// Send to the log if we're getting negative times.  
+		mprintf(("Somehow the object update packet is calculating negative time differential in multi_oo_send_control_info. Value: %d. It's going to guess on a correct value. Please investigate.", temp_timestamp));
+		temp_timestamp = TIMESTAMP_OUT_IF_ERROR;
+	}
+	auto time_out = (ubyte)temp_timestamp;
+	ADD_DATA(time_out);
+
 	// pos and orient always
-	oo_flags = (OO_POS_NEW | OO_ORIENT_NEW);		
+	oo_flags = OO_POS_AND_ORIENT_NEW;		
 
 	// pack the appropriate info into the data
 	add_size = multi_oo_pack_data(Net_player, Player_obj, oo_flags, data_add);
@@ -1524,11 +2474,8 @@ void multi_oo_send_control_info()
 	multi_rate_add(NET_PLAYER_NUM(Net_player), "stp", 1);
 	ADD_DATA(stop);
 
-	// increment sequence #
-	Player_ship->np_updates[MY_NET_PLAYER_NUM].seq++;
-
 	// send to the server
-	if(Netgame.server != NULL){								
+	if(Netgame.server != nullptr){								
 		multi_io_send(Net_player, data, packet_size);
 	}
 }
@@ -1539,7 +2486,7 @@ void multi_oo_send_changed_object(object *changedobj)
 {
 	ubyte data[MAX_PACKET_SIZE], stop;
 	ubyte data_add[MAX_PACKET_SIZE];
-	ubyte oo_flags;	
+	ushort oo_flags;	
 	int add_size;
 	int packet_size = 0;
 	int idx = 0;
@@ -1559,10 +2506,27 @@ void multi_oo_send_changed_object(object *changedobj)
 		return;
 	}
 	// build the header
-	BUILD_HEADER(OBJECT_UPDATE);		
+	BUILD_HEADER(OBJECT_UPDATE);
+
+	// Cyborg17 - And now the shared header, to help simplify the logic. Will save Server bandwidth
+	ADD_INT(Oo_info.number_of_frames);
+
+	// also the timestamp.
+	int temp_timestamp = (Oo_info.timestamps[Oo_info.cur_frame_index] - Oo_info.timestamps[multi_find_prev_frame_idx()]);
+
+	// only the very longest frames are going to have greater than 255 ms, so cap it at that.
+	if (temp_timestamp > 255) {
+		temp_timestamp = 255;
+	} else if (temp_timestamp < 0) {
+		// Send to the log if we're getting negative times.  
+		mprintf(("Somehow the object update packet is calculating negative time differential in multi_oo_send_control_info. Value: %d. It's going to guess on a correct value. Please investigate.", temp_timestamp));
+		temp_timestamp = TIMESTAMP_OUT_IF_ERROR;
+	}
+	auto time_out = (ubyte)temp_timestamp;
+	ADD_DATA(time_out);
 
 	// pos and orient always
-	oo_flags = (OO_POS_NEW | OO_ORIENT_NEW);
+	oo_flags = (OO_POS_AND_ORIENT_NEW);
 
 	// pack the appropriate info into the data
 	add_size = multi_oo_pack_data(&Net_players[idx], changedobj, oo_flags, data_add);
@@ -1583,12 +2547,43 @@ void multi_oo_send_changed_object(object *changedobj)
 	multi_rate_add(idx, "stp", 1);
 	ADD_DATA(stop);
 
-	// increment sequence #
-//	Player_ship->np_updates[idx].seq++;
-
 	multi_io_send(&Net_players[idx], data, packet_size);
 }
 
+
+// updates all interpolation info for a specific ship
+void multi_oo_maybe_update_interp_info(int player_id, object* objp, vec3d* new_pos, angles* new_ori_angles, matrix* new_ori_mat, physics_info* new_phys_info, bool adjust_pos, bool newest_pos)
+{
+	Assert(objp != nullptr);
+
+	if (objp == nullptr) {
+		return;
+	}
+
+	int net_sig_idx = objp->net_signature;
+
+	Assert(net_sig_idx >= 0);
+	// store and replace interpolation info
+	if (adjust_pos) {
+		// if this is the newest position packet, update everything
+		if (newest_pos) {
+			Oo_info.interp[net_sig_idx].old_packet_position = Oo_info.interp[net_sig_idx].new_packet_position;
+			Oo_info.interp[net_sig_idx].new_packet_position = *new_pos;
+
+			Oo_info.interp[net_sig_idx].old_angles = Oo_info.interp[net_sig_idx].new_angles;
+			Oo_info.interp[net_sig_idx].new_angles = *new_ori_angles;
+		} // if this is the second newest, update that instead
+		else {
+			Oo_info.interp[net_sig_idx].old_packet_position = *new_pos;
+			Oo_info.interp[net_sig_idx].old_angles = *new_ori_angles;
+		}
+
+		// now we'll update the interpolation splines if both points have been set.
+		if ( Oo_info.interp[net_sig_idx].prev_pack_pos_frame > -1) {
+			multi_oo_calc_interp_splines(player_id, objp, new_ori_mat, new_phys_info);
+		}
+	}
+}
 
 // display any oo info on the hud
 void multi_oo_display()
@@ -1657,7 +2652,7 @@ void multi_oo_update_server_rate();
 void multi_oo_rate_process()
 {
 	// if I have no valid player, drop out here
-	if(Net_player == NULL){
+	if(Net_player == nullptr){
 		return;
 	}
 
@@ -1723,7 +2718,7 @@ void multi_oo_rate_init_all()
 	int idx;
 
 	// if I don't have a net_player, bail here
-	if(Net_player == NULL){
+	if(Net_player == nullptr){
 		return;
 	}
 
@@ -1820,7 +2815,7 @@ void multi_oo_update_server_rate()
 	int num_connections;	
 	
 	// bail conditions
-	if((Net_player == NULL) || !(Net_player->flags & NETINFO_FLAG_AM_MASTER)){
+	if((Net_player == nullptr) || !(Net_player->flags & NETINFO_FLAG_AM_MASTER)){
 		return;
 	}
 
@@ -1910,152 +2905,319 @@ int multi_oo_is_interp_object(object *objp)
 	return 1;
 }
 
-// interp
-void multi_oo_interp(object *objp)
-{		
+// Calculate the physics info in the current frame for a ship based on the data calculated in multi_oo_calc_interp_splines
+void multi_oo_interp(object* objp)
+{
 	// make sure its a valid ship
 	Assert(Game_mode & GM_MULTIPLAYER);
-	if(objp->type != OBJ_SHIP){
+	Assert(objp->net_signature <= STANDALONE_SHIP_SIG);
+
+	if (objp->type != OBJ_SHIP || objp->net_signature == STANDALONE_SHIP_SIG) {
 		return;
 	}
-	if((objp->instance < 0) || (objp->instance >= MAX_SHIPS)){
+	if ((objp->instance < 0) || (objp->instance >= MAX_SHIPS)) {
 		return;
-	}	
-
+	}
 	// Now that we know we have a valid ship, do stream weapon firing for this ship before we do anything else that makes us abort
 	Assert(objp != Player_obj);
 	if (objp != Player_obj) {
-		ship_fire_primary(objp, 1, 0);
-	}
-
-	// if this ship doesn't have enough data points yet, pretend it's a normal ship and skip it
-	if(oo_interp_count[objp->instance] < 2){
-		physics_sim(&objp->pos, &objp->orient, &objp->phys_info, flFrametime);
-		return;
-	}
-
-	extern fix game_get_overall_frametime();
-
-	// Cyborg17 - Here's the new timing calculation: we subtract the last packet's arrival time oo_arrive_time[objp->instance][oo_arrive_time_count[objp->instance] - 1]
-	// from the current frame time (f2fl(game_get_overall_frametime()) to see how long it's been, and then we divide by the average difference in time.  This gives us a
-	// percent that tells us, for example, "35% of the time has elapsed until the next packet."
-	float t = (f2fl(game_get_overall_frametime()) - oo_arrive_time[objp->instance][oo_arrive_time_count[objp->instance] - 1]) / oo_arrive_time_avg_diff[objp->instance];
-
-	// gr_set_color_fast(&Color_bright);
-	// gr_printf(100, 10, "%f\n", t);
-	
-	// we've overshot. hmm. just keep the sim running I guess	
-	// Cyborg17 - I've adjusted this percentage up to 125% because we should at least have a little wiggle room for slightly late packets.
-	// For example, if I have 4 previous packets all arrive with the same timing and this one is the tiniest bit slower than them, having the cutoff
-	// just at average would not let us consider those packets.
-	if(t > 1.25f){
-		physics_sim(&objp->pos, &objp->orient, &objp->phys_info, flFrametime);
-		return;
-	// in case they are slightly late, we'll just use the last good point.
-	} else if (t > 1.0f) {
-		t = 1.0f;
-	}	
-
-	// Cyborg17 - we are no longer blending the two curves.  I'm not sure *how*, but they were somehow making the interpolation look 
-	// less erratic when the timing was messed up in the first place.  Now we take the *good* curve at its word. 
-
-	float u = 0.5f + (t * 0.5f);
-	vec3d interp_point;
-	oo_interp_splines[objp->instance].bez_get_point(&interp_point, u);
-	vm_vec_scale(&interp_point, t);
-	//vm_vec_scale(&p_bad, 1.0f - t);
-	objp->pos = interp_point;	
-
-	// set new velocity
-	// vm_vec_sub(&objp->phys_info.vel, &objp->pos, &objp->last_pos);
-	
-	// run the sim for rotation	
-	// TODO: add a bezier for rot_vel.  It was working really well previously, but now it looks slightly choppy.
-	physics_sim_rot(&objp->orient, &objp->phys_info, flFrametime);
-
-	// blend velocity vectors together with an average weight
-	/*
-	vec3d v_bad, v_good;
-	oo_interp_splines[objp->instance][0].herm_get_deriv(&v_bad, u, 0);
-	oo_interp_splines[objp->instance][1].herm_get_deriv(&v_good, u, 0);	
-
-	// t -= 1.0f;
-	vm_vec_scale(&v_good, t);
-	vm_vec_scale(&v_bad, 1.0f - t);
-	vm_vec_avg(&objp->phys_info.vel, &v_bad, &v_good);
-	
-	// run the sim
-	physics_sim(&objp->pos, &objp->orient, &objp->phys_info, flFrametime);
-	*/
-
-	/*
-	vec3d v_bad, v_good;
-	oo_interp_splines[objp->instance][0].herm_get_point(&v_bad, u, 0);
-	oo_interp_splines[objp->instance][1].herm_get_point(&v_good, u, 0);	
-
-	// t -= 1.0f;
-	vm_vec_scale(&v_good, t);
-	vm_vec_scale(&v_bad, 1.0f - t);
-	vm_vec_avg(&objp->pos, &v_bad, &v_good);	
-	
-	// run the sim
-	// physics_sim(&objp->pos, &objp->orient, &objp->phys_info, flFrametime);
-	physics_sim_rot(&objp->orient, &objp->phys_info, flFrametime);
-	*/
-}
-
-float oo_error = 0.8f;
-DCF(oo_error, "Sets error factor for flight path prediction physics (Multiplayer)")
-{
-	if (dc_optional_string_either("help", "--help")) {
-		dc_printf("Usage: oo_error <value>\n");
-		return;
-	}
-
-	if (dc_optional_string_either("status", "--status") || dc_optional_string_either("?", "--?")) {
-		dc_printf("oo_error is currently %f", oo_error);
-		return;
-	}
-
-	dc_stuff_float(&oo_error);
-	
-	dc_printf("oo_error set to %f", oo_error);
-}
-
-void multi_oo_calc_interp_splines(int ship_index, vec3d *cur_pos, physics_info *cur_phys_info, vec3d *new_pos, matrix *new_orient, physics_info *new_phys_info)
-{
-	vec3d a, b, c;
-	matrix m_copy;
-	physics_info p_copy;
-	vec3d *pts[3] = {&a, &b, &c};	
-	
-	// average time between packets
-	float avg_diff = oo_arrive_time_avg_diff[ship_index];	
-
-	// would this cause us to rubber-band?
-	vec3d v_norm = cur_phys_info->vel;	
-	vec3d v_dir;
-	vm_vec_sub(&v_dir, new_pos, cur_pos);	
-	if(!IS_VEC_NULL_SQ_SAFE(&v_norm) && !IS_VEC_NULL_SQ_SAFE(&v_dir)){
-		vm_vec_normalize(&v_dir);
-		vm_vec_normalize(&v_norm);	
-		if(vm_vec_dot(&v_dir, &v_norm) < 0.0f){
-			*new_pos = *cur_pos;
+		if (MULTIPLAYER_CLIENT) {
+			ship_fire_primary(objp, 1, 0);
 		}
 	}
 
-	// get the spline representing where this new point tells us we'd be heading
-	a = oo_interp_points[ship_index][0]; //-V519
-	b = oo_interp_points[ship_index][1]; //-V519
-	c = oo_interp_points[ship_index][1];
-	m_copy = *new_orient;
-	p_copy = *new_phys_info;
-	physics_sim(&c, &m_copy, &p_copy, avg_diff);			// next point, given this new info
-	oo_interp_splines[ship_index].bez_set_points(3, pts);	
+	vec3d store_old_pos = objp->pos;
+	ushort net_sig_idx = objp->net_signature;
 
+	oo_packet_and_interp_tracking* interp_data = &Oo_info.interp[net_sig_idx];
+
+	if (interp_data == nullptr) {
+		return;
+	}
+
+	float packet_delta = interp_data->pos_time_delta;
+
+	// if this ship doesn't have enough data points yet or somehow else invalid, pretend it's a normal ship and skip it.
+	if (interp_data->prev_pack_pos_frame == -1) {
+		physics_sim_vel(&objp->pos, &objp->phys_info, flFrametime, &objp->orient);
+		physics_sim_rot(&objp->orient, &objp->phys_info, flFrametime);
+
+	} // once there are enough data points, we begin interpolating.
+	else {
+		// figure out how much time has passed
+		int temp_numerator = timestamp() - interp_data->pos_timestamp;
+
+		// add the ~1/2 of ping to keep the players in better sync
+		if (MULTIPLAYER_MASTER) {
+			int player_id = multi_find_player_by_net_signature(net_sig_idx);
+			temp_numerator += Net_players[player_id].s_info.ping.ping_avg / 2;
+		}
+		else {
+			temp_numerator += Netgame.server->s_info.ping.ping_avg / 2;
+		}
+
+		// divide in order to change to flFrametime format
+		float time_elapsed = i2fl(temp_numerator) / TIMESTAMP_FREQUENCY;
+
+		// Cyborg17 - Here's the new timing calculation: we subtract the last packet's arrival time 
+		// from the current timestamp to see how long it's been and add 1/2 of the current ping, and 
+		// then we divide by the difference in time between the last two packets.
+		// We add one because we do not want to go back into data from before the current packet was received.
+		float time_factor = (time_elapsed / packet_delta) + 1.0f;
+
+		// if there was no movement, bash position and velocity, rotation is handled after.
+		if (interp_data->prev_packet_positionless) {
+			interp_data->client_simulation_mode = false;
+			objp->pos = interp_data->new_packet_position;
+			objp->orient = interp_data->new_orientation;
+			objp->phys_info.vel = vmd_zero_vector;
+		} // Overshoting in this frame or some edge case bug. Just sim the ship from the known values.
+		else if (time_factor > 4.0f || time_factor < 1.0f) {
+			// if transitioning to uninterpolated movement, we need to jump to the end of the simulated points 
+			// and then simulate forward some if there's extra time. 
+			float regular_sim_delta;
+
+			if (!interp_data->client_simulation_mode) {
+				interp_data->client_simulation_mode = true;
+				objp->pos = interp_data->new_packet_position;
+				objp->orient = interp_data->new_orientation;
+				regular_sim_delta = time_elapsed - (2 * packet_delta);
+			}
+			else {
+				regular_sim_delta = flFrametime;
+			}
+			// Continue simulating if we have time that we need to simulate and exclude fake values.
+			if (regular_sim_delta > 0.001f && regular_sim_delta < 0.500f) {
+				// make sure to bash desired velocity and rotational velocity in this case.
+				objp->phys_info.desired_vel = interp_data->cur_pack_des_vel;
+				objp->phys_info.desired_rotvel = interp_data->cur_pack_des_rot_vel;
+				physics_sim_vel(&objp->pos, &objp->phys_info, regular_sim_delta, &objp->orient);
+				physics_sim_rot(&objp->orient, &objp->phys_info, regular_sim_delta);
+			}
+		} // valid time factors.
+		else {
+			interp_data->client_simulation_mode = false;
+
+			// Cyborg17 - we are no longer blending two interpolation curves.  I'm not sure *how*, but they were somehow making it look 
+			// less erratic when the timing was broken in the first place. 
+			float u = (time_factor) / 4.0f;
+			vec3d interp_point;
+			interp_data->pos_spline.bez_get_point(&interp_point, u);
+			// now to smooth out the error that the client caused during the last round of interpolation.
+			if ((time_factor < 2.0f) && (time_factor > 0.0f) && (vm_vec_mag_squared(&interp_data->position_error) > 0.0f)) {
+				vec3d remove_error_vector;
+				// .5 and 2 are multiplicative inverses. We want all the error gone at time_factor 2.
+				float temp_error_factor = 1 - (time_factor * 0.5f);
+				vm_vec_copy_scale(&remove_error_vector, &interp_data->position_error, temp_error_factor);
+				vm_vec_add2(&interp_point, &remove_error_vector);
+			}
+
+			// set the new position.
+			objp->pos = interp_point;
+
+			// Now rotational interpolation
+			// exactly on the middle point, save some time and just put the ship on that orientation.
+			if (time_factor == 2.0f) {
+				vm_angles_2_matrix(&objp->orient, &interp_data->anticipated_angles_a);
+				objp->phys_info.vel = interp_data->anticipated_velocity1;
+			} // Same for being exactly on the end point
+
+			else if (time_factor == 3.0f) {
+				vm_angles_2_matrix(&objp->orient, &interp_data->anticipated_angles_b);
+				objp->phys_info.vel = interp_data->anticipated_velocity2;
+			}
+			else if (time_factor == 4.0f) {
+				vm_angles_2_matrix(&objp->orient, &interp_data->anticipated_angles_c);
+				objp->phys_info.vel = interp_data->anticipated_velocity3;
+
+			} // in case we have to do our interpolation. We cannot do anything if it's less than 1 because those are actually old values that *should* never happen.
+			else if (time_factor > 1.0f) {
+				angles temp_angles, old_angles, new_angles;
+				vec3d old_velocity, new_velocity;
+				// Between packet and first interpolated angles
+				if (time_factor < 2.0f) {
+
+					old_angles = interp_data->new_angles;
+					new_angles = interp_data->anticipated_angles_a;
+					old_velocity = interp_data->new_velocity;
+					new_velocity = interp_data->anticipated_velocity1;
+
+					time_factor--;
+				} // between interpolated angles a and b
+				else if (time_factor < 3.0f) {
+
+					old_angles = interp_data->anticipated_angles_a;
+					new_angles = interp_data->anticipated_angles_b;
+					old_velocity = interp_data->anticipated_velocity1;
+					new_velocity = interp_data->anticipated_velocity2;
+
+					time_factor -= 2.0f;
+				} // between interpolated angles b and c
+				else if (time_factor < 4.0f) {
+
+					old_angles = interp_data->anticipated_angles_b;
+					new_angles = interp_data->anticipated_angles_c;
+					old_velocity = interp_data->anticipated_velocity2;
+					new_velocity = interp_data->anticipated_velocity3;
+
+					time_factor -= 3.0f;
+				}
+
+				vm_interpolate_angles_quick(&temp_angles, &old_angles, &new_angles, time_factor);
+				vm_angles_2_matrix(&objp->orient, &temp_angles);
+				vm_vec_scale(&new_velocity, time_factor);
+				vm_vec_scale(&old_velocity, 1 - time_factor);
+				vm_vec_add(&objp->phys_info.vel, &new_velocity, &old_velocity);
+			}
+		}
+	}
+
+	// this gets rid of ships shaking in place, but once the velocity has started, it's a free for all.
+	vec3d temp_rubberband_test, local_displacement, temp_local_vel, local_rubberband_correction, global_rubberband_correction;
+	vm_vec_sub(&temp_rubberband_test, &objp->pos, &store_old_pos);
+
+	vm_vec_rotate(&local_displacement, &temp_rubberband_test, &objp->orient);
+	vm_vec_rotate(&temp_local_vel, &objp->phys_info.vel, &objp->orient);
+
+	local_rubberband_correction = vmd_zero_vector;
+
+	// a difference in sign means something just rubberbanded.
+	if ( ((local_displacement.xyz.x < 0.0f) && (temp_local_vel.xyz.x > 0.0f)) || ((local_displacement.xyz.x > 0.0f) && (temp_local_vel.xyz.x < 0.0f)) ) {
+		local_rubberband_correction.xyz.x = -local_displacement.xyz.x;
+	}
+	if ( ((local_displacement.xyz.y < 0.0f) && (temp_local_vel.xyz.y > 0.0f)) || ((local_displacement.xyz.y > 0.0f) && (temp_local_vel.xyz.y < 0.0f)) ) {
+		local_rubberband_correction.xyz.y = -local_displacement.xyz.y;
+	}
+	if ( ((local_displacement.xyz.z < 0.0f) && (temp_local_vel.xyz.z > 0.0f)) || ((local_displacement.xyz.z > 0.0f) && (temp_local_vel.xyz.z < 0.0f)) ) {
+		local_rubberband_correction.xyz.z = -local_displacement.xyz.z;
+	}
+
+	vm_vec_unrotate(&global_rubberband_correction, &local_rubberband_correction, &objp->orient);
+
+	vm_vec_add2(&objp->pos, &global_rubberband_correction);
+
+	// duplicate the rest of the physics engine's calls here to make the simulation more exact.
+	objp->phys_info.speed = vm_vec_mag(&objp->phys_info.vel);
+	objp->phys_info.fspeed = vm_vec_dot(&objp->orient.vec.fvec, &objp->phys_info.vel);
 }
 
-int display_oo_bez = 0;
+// Establish the values that FSO will later interpolate with based on packet data.
+void multi_oo_calc_interp_splines(int player_id, object* objp, matrix *new_orient, physics_info *new_phys_info)
+{
+	Assert(objp != nullptr);
+
+	if (objp == nullptr) {
+		return;
+	}
+
+	ushort net_sig_idx = objp->net_signature;
+	
+	// find the float time version of how much time has passed
+	float delta = multi_oo_calc_pos_time_difference(player_id, net_sig_idx);
+	// if an error or invalid value, use the local timestamps instead of those received. Should be rare.
+	if (delta <= 0.0f) {
+		delta = (float)(timestamp() - Oo_info.received_frametimes[player_id].at(Oo_info.interp[net_sig_idx].pos_timestamp)) / TIMESTAMP_FREQUENCY;
+	}
+
+	Oo_info.interp[net_sig_idx].pos_time_delta = delta;
+
+	// create the vector which will hold the spline
+	vec3d point1, point2, point3;
+	vec3d *pts[3] = {&point1, &point2, &point3};
+	matrix matrix_copy;
+	physics_info physics_copy;
+
+	// 3 point curve, 5 time deltas. Point1 is 1 delta before (prev packet positon), point2 is 1 delta ahead, 
+	// point3 is 3 deltas ahead. This is to allow for the time period to be even between the three interpolation points,
+	// while also doing interpolation for a longer period of time.
+
+	point1 = Oo_info.interp[net_sig_idx].old_packet_position;
+	point2 = Oo_info.interp[net_sig_idx].new_packet_position; 
+	matrix_copy = *new_orient;
+	physics_copy = *new_phys_info;
+	Oo_info.interp[net_sig_idx].new_velocity = physics_copy.vel;
+
+	angles angle_equivalent;
+
+	// ------------ CALCUATION 1 ------------ //
+	// Calculate up to 1 delta past the packet, then store point2 as point two in the bezier, and the angles.
+	physics_sim(&point2, &matrix_copy, &physics_copy, delta);			
+	vm_extract_angles_matrix_alternate(&angle_equivalent, &matrix_copy);
+
+	// Adjust desired velocity, because it's in world coordinates, and it doesn't make sense to reuse the same one four more times.
+	vm_vec_unrotate(&physics_copy.desired_vel, &Oo_info.interp[net_sig_idx].cur_pack_local_des_vel, &matrix_copy);
+
+	Oo_info.interp[net_sig_idx].anticipated_angles_a = angle_equivalent;
+
+	// Since point2 is calculated, pass it off to point3 to finish off the calculations, which is 2 more deltas later
+	point3 = point2;
+
+	// ------------ CALCUATION 2 ------------ //
+
+	Oo_info.interp[net_sig_idx].anticipated_velocity1 = physics_copy.vel;
+	
+	// Only the angles get stored here.
+	physics_sim(&point3, &matrix_copy, &physics_copy, delta);			
+	vm_extract_angles_matrix_alternate(&angle_equivalent, &matrix_copy);
+
+	// Readjust desired velocity, assuming that you would have the same throttle.
+	vm_vec_unrotate(&physics_copy.desired_vel, &Oo_info.interp[net_sig_idx].cur_pack_local_des_vel, &matrix_copy);
+
+	Oo_info.interp[net_sig_idx].anticipated_angles_b = angle_equivalent;
+	Oo_info.interp[net_sig_idx].anticipated_velocity2 = physics_copy.vel;
+
+	// ------------ CALCUATION 3 ------------ //
+	physics_sim(&point3, &matrix_copy, &physics_copy, delta);			
+	vm_extract_angles_matrix_alternate(&angle_equivalent, &matrix_copy);
+
+	// Readjust desired velocity, assuming that you would have the same throttle.
+	vm_vec_unrotate(&physics_copy.desired_vel, &Oo_info.interp[net_sig_idx].cur_pack_local_des_vel, &matrix_copy);
+
+	Oo_info.interp[net_sig_idx].anticipated_angles_c = angle_equivalent;
+	Oo_info.interp[net_sig_idx].anticipated_velocity3 = physics_copy.vel;
+
+	// Set the points to the bezier
+	Oo_info.interp[net_sig_idx].pos_spline.bez_set_points(3, pts);
+}
+
+// Calculates how much time has gone by between the two most recent frames 
+float multi_oo_calc_pos_time_difference(int player_id, int net_sig_idx) 
+{
+	Assertion((player_id >= 0) && (player_id < MAX_PLAYERS) && (net_sig_idx > 0) && (net_sig_idx < STANDALONE_SHIP_SIG), "Somehow a nonsense value got passed to multi_oo_calc_pos_time_difference.  Please report these values:\nplayer_id %d and net_sig_idx %d", player_id, net_sig_idx );
+	int old_frame = Oo_info.interp[net_sig_idx].prev_pack_pos_frame;
+	int new_frame = Oo_info.interp[net_sig_idx].cur_pack_pos_frame;
+	
+	// make sure we have enough packets so far. (old_frame is updated after new_frame)
+	if (old_frame == -1 ) {
+		return -1.0f;
+	}
+	
+	if (old_frame == new_frame) {
+		nprintf(("network","multi_oo_calc_pos_time_difference somehow showed the same frame for old and new frame.\n"));
+	}
+	
+	if (old_frame == new_frame) {
+		return -1.0f;
+	}
+
+	float temp_sum = 0.0f;
+	int frame_time = Oo_info.received_frametimes[player_id].at(old_frame);
+
+	// add up the frametimes in between, not including the old_frame's frametime because that was the amount of time from
+	// the frame before that to the old_frame.
+	for (int i = old_frame + 1; i <= new_frame; i++) {
+		// a zero value means we haven't received that frame yet. So just use the last frame_time
+		if (Oo_info.received_frametimes[player_id].at(i) > 0) {
+			frame_time = Oo_info.received_frametimes[player_id].at(i);
+		}
+		temp_sum += frame_time;
+	}
+	temp_sum /= TIMESTAMP_FREQUENCY; // convert from timestamp to float frame time
+
+	return temp_sum;
+}
+
+bool display_oo_bez = false;
 DCF(bez, "Toggles rendering of player ship trajectory interpolation splines (Multiplayer) *disabled*")
 {
 	if (dc_optional_string_either("status", "--status") || dc_optional_string_either("?", "--?")) {
@@ -2065,7 +3227,7 @@ DCF(bez, "Toggles rendering of player ship trajectory interpolation splines (Mul
 
 	display_oo_bez = !display_oo_bez;
 
-	dc_printf("%showing interp splines", display_oo_bez ? "S" : "Not s");
+	dc_printf("%showing positional interp spline", display_oo_bez ? "S" : "Not s");
 }
 
 void oo_display()

--- a/code/network/multi_obj.cpp
+++ b/code/network/multi_obj.cpp
@@ -188,9 +188,6 @@ oo_general_info Oo_info;
 // flags
 bool Afterburn_hack = false;			// HACK!!!
 
-// for multilock
-#define OOC_INDEX_NULLPTR_SUBSYSEM			255			// If a lock has a nullptr subsystem, send this as the invalid index.
-
 // returns the last frame's index.
 int multi_find_prev_frame_idx();
 

--- a/code/network/multi_obj.h
+++ b/code/network/multi_obj.h
@@ -21,6 +21,9 @@ struct interp_info;
 class object;
 struct header;
 struct net_player;
+class ship;
+struct physics_info;
+struct weapon;
 
 
 // client button info flags
@@ -32,19 +35,80 @@ struct net_player;
 #define OOC_AFTERBURNER_ON			(1<<5)
 // two spots now left for more OOC flags
 
+// what we are setting the subsystem "index" to if there was no subsystem.
+#define OOC_INDEX_NULLPTR_SUBSYSEM 255
+
+// Cyborg17, Server will be tracking only the last second of frames
+#define MAX_FRAMES_RECORDED		30
+#define PRIMARY_PACKET_CUTOFF			2000
+
 // and two special values to help with multilock
 #define OOC_INDEX_NULLPTR_SUBSYSEM 255
 #define OOC_MAX_LOCKS			   128  // Probably *could* be up to 140, but this is safer
 
-// update info
-typedef struct np_update {	
-	ubyte		seq;							// sequence #
-	int		update_stamp;				// global update stamp
-	int		status_update_stamp;
-	int		subsys_update_stamp;
-	ushort	pos_chksum;					// positional checksum
-	ushort	orient_chksum;				// orient checksum
-} np_update;
+// some values for subsystem packing
+#define OO_SUBSYS_HEALTH			(1<<0)		// Did this subsystem's health change
+#define OO_SUBSYS_ROTATION_1b		(1<<1)		// Did this subsystem's base rotation angles change
+#define OO_SUBSYS_ROTATION_1h		(1<<2)		// Did this subsystem's base rotation angles change
+#define OO_SUBSYS_ROTATION_1p		(1<<3)		// Did this subsystem's base rotation angles change
+#define OO_SUBSYS_ROTATION_2b		(1<<4)		// Did this subsystem's barrel rotation angles change
+#define OO_SUBSYS_ROTATION_2h		(1<<5)		// Did this subsystem's barrel rotation angles change
+#define OO_SUBSYS_ROTATION_2p		(1<<6)		// Did this subsystem's barrel rotation angles change
+#define OO_SUBSYS_TRANSLATION		(1<<7)		// Only for backwards compatibility of future builds.
+
+
+// ---------------------------------------------------------------------------------------------------
+// POSITION AND ORIENTATION RECORDING
+// if it breaks, find Cyborg17 so you can yell at him
+// This section is almost all server side
+
+// Add a new ship *ON IN-GAME SHIP CREATION* to the tracking struct
+void multi_ship_record_add_ship(int obj_num);
+
+// Update the tracking struct whenver the object is updated in-game
+void multi_ship_record_update_all();
+
+// increment the tracker per frame, before incoming object packets are processed
+void multi_ship_record_increment_frame();
+
+// find the right frame to start our weapon simulation
+int multi_ship_record_find_frame(ushort client_frame, int time_elapsed);
+
+// a quick lookups for position and orientation
+vec3d multi_ship_record_lookup_position(object* objp, int frame);
+
+// a quick lookups for orientation
+matrix multi_ship_record_lookup_orientation(object* objp, int frame);
+
+int multi_ship_record_find_time_after_frame(int client_frame, int frame, int time_elapsed);
+
+// This stores the information we got from the client to create later, and checks to see if this is the oldest shot we are going to fire during rollback.
+void multi_ship_record_add_rollback_shot(object* pobjp, vec3d* pos, matrix* orient, int frame, bool secondary);
+
+// Lookup whether rollback mode is on
+bool multi_ship_record_get_rollback_wep_mode();
+
+// Adds a weapon to the rollback tracker.
+void multi_ship_record_add_rollback_wep(int wep_objnum);
+
+// Manage rollback for a frame
+void multi_ship_record_do_rollback();
+
+// ---------------------------------------------------------------------------------------------------
+// Client side frame tracking, for now used only to help lookup info from packets to improve client accuracy.
+// 
+
+// Quick lookup for the most recently received frame
+ushort multi_client_lookup_ref_obj_net_sig();
+
+// Quick lookup for the most recently received frame
+int multi_client_lookup_frame_idx();
+
+// Quick lookup for the most recently received timestamp.
+int multi_client_lookup_frame_timestamp();
+
+// reset all the necessary info for respawning player.
+void multi_oo_respawn_reset_info(ushort net_sig);
 
 // ---------------------------------------------------------------------------------------------------
 // OBJECT UPDATE FUNCTIONS
@@ -57,17 +121,24 @@ void multi_oo_process();
 void multi_oo_process_update(ubyte *data, header *hinfo);
 
 // initialize all object update timestamps (call whenever entering gameplay state)
-void multi_oo_gameplay_init();
+void multi_init_oo_and_ship_tracker();
 
 // send control info for a client (which is basically a "reverse" object update)
 void multi_oo_send_control_info();
 void multi_oo_send_changed_object(object *changedobj);
 
+
+// reset all sequencing info
+void multi_oo_reset_sequencing();
+
 // is this object one which needs to go through the interpolation
 int multi_oo_is_interp_object(object *objp);
 
-// interp
+// interp position and orientation
 void multi_oo_interp(object *objp);
+
+// Cyborg17 - sort through subsystems to make sure we only update the ones we need to update.
+//int multi_pack_required_subsytems(ship* shipp, ubyte* data, int packet_size, int header_bytes);
 
 
 // ---------------------------------------------------------------------------------------------------

--- a/code/network/multi_obj.h
+++ b/code/network/multi_obj.h
@@ -35,16 +35,12 @@ struct weapon;
 #define OOC_AFTERBURNER_ON			(1<<5)
 // two spots now left for more OOC flags
 
-// what we are setting the subsystem "index" to if there was no subsystem.
-#define OOC_INDEX_NULLPTR_SUBSYSEM 255
-
-// Cyborg17, Server will be tracking only the last second of frames
+// Cyborg17, Server will be tracking only the last 0.5-1.0 second of frames
 #define MAX_FRAMES_RECORDED		30
 #define PRIMARY_PACKET_CUTOFF			2000
 
-// and two special values to help with multilock
-#define OOC_INDEX_NULLPTR_SUBSYSEM 255
-#define OOC_MAX_LOCKS			   128  // Probably *could* be up to 140, but this is safer
+// one special value to help with multilock
+#define OOC_INDEX_NULLPTR_SUBSYSEM USHRT_MAX
 
 // some values for subsystem packing
 #define OO_SUBSYS_HEALTH			(1<<0)		// Did this subsystem's health change

--- a/code/network/multi_respawn.cpp
+++ b/code/network/multi_respawn.cpp
@@ -326,7 +326,6 @@ int multi_respawn_common_stuff(p_object *pobjp)
 	int objnum, team, slot_index;
 	object *objp;
 	ship *shipp;
-	int idx;
 
 	// create the object
 	objnum = parse_create_object(pobjp);
@@ -339,15 +338,6 @@ int multi_respawn_common_stuff(p_object *pobjp)
 	Assert( team != -1 );
 	Assert( slot_index != -1 );
 
-	// reset object update stuff
-	for(idx=0; idx<MAX_PLAYERS; idx++){
-		shipp->np_updates[idx].orient_chksum = 0;
-		shipp->np_updates[idx].pos_chksum = 0;
-		shipp->np_updates[idx].seq = 0;
-		shipp->np_updates[idx].status_update_stamp = -1;
-		shipp->np_updates[idx].subsys_update_stamp = -1;
-		shipp->np_updates[idx].update_stamp = -1;
-	}
 
 	// change the ship type and the weapons
 	if (team != -1 && slot_index != -1) {
@@ -359,6 +349,9 @@ int multi_respawn_common_stuff(p_object *pobjp)
 	if(Netgame.type_flags & NG_TYPE_TEAM){
 		multi_team_mark_ship(&Ships[Objects[objnum].instance]);
 	}
+
+	// need to make sure that we will update this object and that the frame tracker knows this is a valid ship again.
+	multi_oo_respawn_reset_info(objp->net_signature);
 
 	pobjp->respawn_count++;
 
@@ -405,6 +398,10 @@ void multi_respawn_player(net_player *pl, char cur_primary_bank, char cur_second
 	if ( pl == Net_player ) {
 		object *oldplr = Player_obj;
 
+		// Cyborg17 - Despite the fact that the object and ship are getting deleted below, unless the net_signature is cleared here
+		// respawning in a rollback enabled game will crash the server.
+		oldplr->net_signature = 0;
+
 		Player_obj = objp;
 		Player_ship = shipp;
 		Player_ai = &Ai_info[Player_ship->ai_index];
@@ -421,7 +418,7 @@ void multi_respawn_player(net_player *pl, char cur_primary_bank, char cur_second
 	if(!(Net_player->flags & NETINFO_FLAG_AM_MASTER)){
 		objp->net_signature = net_sig;
 	}
-	
+
 	// restore the correct weapon bank selections
 	shipp->weapons.current_primary_bank = (int)cur_primary_bank;
 	shipp->weapons.current_secondary_bank = (int)cur_secondary_bank;
@@ -491,7 +488,7 @@ void multi_respawn_ai( p_object *pobjp )
 	object *objp;
 
 	// create the object and change the ship type
-	objnum = multi_respawn_common_stuff( pobjp );
+	objnum = multi_respawn_common_stuff( pobjp);
 	objp = &Objects[objnum];
 
 	// be sure the the OF_PLAYER_SHIP flag is unset, and the could be player flag is set
@@ -724,7 +721,7 @@ void multi_respawn_server()
 	Assert(Net_player->flags & NETINFO_FLAG_AM_MASTER);
 
 	// respawn me
-	multi_respawn_player(Net_player, Net_player->s_info.cur_primary_bank, Net_player->s_info.cur_secondary_bank, Net_player->s_info.cur_link_status, Net_player->s_info.ship_ets, 0, Net_player->p_info.p_objp->name);
+	multi_respawn_player(Net_player, Net_player->s_info.cur_primary_bank, Net_player->s_info.cur_secondary_bank, Net_player->s_info.cur_link_status, Net_player->s_info.ship_ets, Net_player->p_info.p_objp->net_signature, Net_player->p_info.p_objp->name);
 
 	// jump back into the game
 	gameseq_post_event(GS_EVENT_ENTER_GAME);	

--- a/code/network/multimsgs.cpp
+++ b/code/network/multimsgs.cpp
@@ -39,10 +39,12 @@
 #include "network/multi_ingame.h"
 #include "network/multiteamselect.h"
 #include "ai/aigoals.h"
+#include "ai/ai.h"
 #include "network/multi_campaign.h"
 #include "network/multi_team.h"
 #include "network/multi_respawn.h"
 #include "network/multi_observer.h"
+#include "network/multi_obj.h"
 #include "asteroid/asteroid.h"
 #include "network/multi_pmsg.h"
 #include "object/object.h"
@@ -3956,7 +3958,12 @@ void send_observer_update_packet()
 
 	ret = multi_pack_unpack_position( 1, data + packet_size, &Player_obj->pos );
 	packet_size += ret;
-	ret = multi_pack_unpack_orient( 1, data + packet_size, &Player_obj->orient );
+	
+	angles temp_angles;
+
+	vm_extract_angles_matrix_alternate(&temp_angles, &Player_obj->orient);
+	ret = multi_pack_unpack_orient( 1, data + packet_size, &temp_angles);
+
 	packet_size += ret;
 
 	// add targeting infomation
@@ -3976,6 +3983,7 @@ void process_observer_update_packet(ubyte *data, header *hinfo)
 	int offset,ret;
 	int obs_num;
 	vec3d g_vec;
+	angles temp_angles;
 	matrix g_mat;
 	physics_info bogus_pi;	
 	ushort target_sig;
@@ -3987,7 +3995,9 @@ void process_observer_update_packet(ubyte *data, header *hinfo)
 	memset(&bogus_pi,0,sizeof(physics_info));
 	ret = multi_pack_unpack_position( 0, data + offset, &g_vec );
 	offset += ret;
-	ret = multi_pack_unpack_orient( 0, data + offset, &g_mat );
+
+	ret = multi_pack_unpack_orient( 0, data + offset, &temp_angles );
+	vm_angles_2_matrix(&g_mat, &temp_angles);
 	offset += ret;
 
 	// targeting information

--- a/code/network/multiutil.cpp
+++ b/code/network/multiutil.cpp
@@ -89,7 +89,7 @@ ushort Next_ship_signature;										// next permanent network signature to assi
 ushort Next_asteroid_signature;									// next signature for an asteroid
 ushort Next_non_perm_signature;									// next non-permanent network signature to assign to an object
 ushort Next_debris_signature;										// next debris signature
-
+ushort Next_waypoint_signature;									// next waypoint signature
 
 // if a client doesn't receive an update for an object after this many seconds, query server
 // as to the objects status.
@@ -97,7 +97,7 @@ ushort Next_debris_signature;										// next debris signature
 #define MAX_SHIPS_PER_QUERY			10
 
 
-// this function assignes the given object with the given signature.  If the signature is 0, then we choose
+// this function assigns the given object with the given signature.  If the signature is 0, then we choose
 // the next signature number from the correct pool.  I thought that it might be desireable
 // to not always have to take the next signature on the list.  what_kind is used to assign either a
 // permanent or non-permanent signature to an object.  permanent signatures are used for ships, non_permanent
@@ -105,6 +105,8 @@ ushort Next_debris_signature;										// next debris signature
 ushort multi_assign_network_signature( int what_kind )
 {
 	ushort sig;	
+
+	Assertion(what_kind >= MULTI_SIG_SHIP && what_kind <= MULTI_SIG_WAYPOINT, "multi_assign_network_signature was passed an invalid index.");
 
 	// do limit checking on the permanent and non_permanent signatures.  Ships are considered "permanent"
 	// as are debris and asteroids since they don't die very often.  It would be vary rare for this
@@ -129,7 +131,6 @@ ushort multi_assign_network_signature( int what_kind )
 
 		sig = Next_asteroid_signature++;
 		if ( Next_asteroid_signature == ASTEROID_SIG_MAX ) {
-			Int3();			// get Allender -- signature stuff wrapped.
 			Next_asteroid_signature = ASTEROID_SIG_MIN;
 		}
 
@@ -141,7 +142,6 @@ ushort multi_assign_network_signature( int what_kind )
 
 		sig = Next_debris_signature++;
 		if ( Next_debris_signature == DEBRIS_SIG_MAX ) {
-			Int3();			// get Allender -- signature stuff wrapped.
 			Next_debris_signature = DEBRIS_SIG_MIN;
 		}
 
@@ -155,8 +155,16 @@ ushort multi_assign_network_signature( int what_kind )
 		if ( (Next_non_perm_signature < NPERM_SIG_MIN) || (Next_non_perm_signature == NPERM_SIG_MAX) ) {
 			Next_non_perm_signature = NPERM_SIG_MIN;
 		}
+	} else if (what_kind == MULTI_SIG_WAYPOINT) {
+		if (Next_waypoint_signature < WAYPOINT_SIG_MIN) {
+			Next_waypoint_signature = WAYPOINT_SIG_MIN;
+		}
+
+		sig = Next_waypoint_signature++;
+		if (Next_waypoint_signature == WAYPOINT_SIG_MAX){
+			Next_waypoint_signature = WAYPOINT_SIG_MIN;
+		}
 	} else {
-		Int3();		// get allender - Illegal signature type requested
 		sig = 0;
 	}
 
@@ -182,6 +190,11 @@ ushort multi_get_next_network_signature( int what_kind )
 			Next_asteroid_signature = ASTEROID_SIG_MIN;
 		return Next_asteroid_signature;
 
+	} else if ( what_kind == MULTI_SIG_WAYPOINT ) {
+		if ( Next_waypoint_signature < WAYPOINT_SIG_MIN )
+			Next_waypoint_signature = WAYPOINT_SIG_MIN;
+		return Next_waypoint_signature;
+
 	} else if ( what_kind == MULTI_SIG_NON_PERMANENT ) {
 		if ( Next_non_perm_signature < NPERM_SIG_MIN )
 			Next_non_perm_signature = NPERM_SIG_MIN;
@@ -199,7 +212,7 @@ void multi_set_network_signature( ushort signature, int what_kind )
 {
 	Assertion(signature != 0, "Invalid net signature of 0 requested in multi_set_network_signature().");
 	Assertion(what_kind > 0, "Invalid net signature type of value %d requested in multi_set_network_signature().", what_kind);  // get Allender
-	Assertion(what_kind < 5, "Invalid net signature type of value %d requested in multi_set_network_signature().", what_kind);
+	Assertion(what_kind < 6, "Invalid net signature type of value %d requested in multi_set_network_signature().", what_kind);
 
 	if ( what_kind == MULTI_SIG_SHIP ) {
 		Assert( (signature >= SHIP_SIG_MIN) && (signature <= SHIP_SIG_MAX) );
@@ -210,6 +223,8 @@ void multi_set_network_signature( ushort signature, int what_kind )
 	} else if ( what_kind == MULTI_SIG_ASTEROID ) {
 		Assert( (signature >= ASTEROID_SIG_MIN) && (signature <= ASTEROID_SIG_MAX) );
 		Next_asteroid_signature = signature;
+	} else if ( what_kind == MULTI_SIG_WAYPOINT ) {
+		Assert( (signature >= WAYPOINT_SIG_MIN) && (signature <= WAYPOINT_SIG_MAX) );
 	} else if (what_kind == MULTI_SIG_NON_PERMANENT) {
 		// Cyborg17 - spawn weapons can set this past the max and overflow the short
 		if (signature >= NPERM_SIG_MIN) {
@@ -217,6 +232,7 @@ void multi_set_network_signature( ushort signature, int what_kind )
 		// so if they did, just add it to the minimum, because that's where we need to be, anyway.
 		} else {
 			Next_non_perm_signature = NPERM_SIG_MIN + signature;
+			// and if they somehow wrap twice throw an assert, because that will definitely cause undesired behavior.
 			Assertion(Next_non_perm_signature >= NPERM_SIG_MIN,"Somehow the non permanent signatures in multi_set_network_signature overflowed the short *twice*, and we cannot code around this.\n\n The likely cause is having spawn weapons with too many children.");
 		}
 	} 			
@@ -688,7 +704,6 @@ void stuff_netplayer_info( net_player *nplayer, net_addr *addr, int ship_class, 
 void multi_assign_player_ship( int net_player_num, object *objp,int ship_class )
 {
 	ship *shipp;
-	int idx;
 
 	Assert ( MULTI_CONNECTED(Net_players[net_player_num]) );
 
@@ -716,15 +731,6 @@ void multi_assign_player_ship( int net_player_num, object *objp,int ship_class )
 		Net_players[net_player_num].s_info.eye_orient = objp->orient;
 	}
 
-	// zero update info	
-	for(idx=0; idx<MAX_PLAYERS; idx++){
-		shipp->np_updates[idx].orient_chksum = 0;
-		shipp->np_updates[idx].pos_chksum = 0;
-		shipp->np_updates[idx].seq = 0;
-		shipp->np_updates[idx].status_update_stamp = -1;
-		shipp->np_updates[idx].subsys_update_stamp = -1;
-		shipp->np_updates[idx].update_stamp = -1;
-	}
 }
 
 // -------------------------------------------------------------------------------------------------
@@ -3410,6 +3416,8 @@ int bitbuffer_get_signed( bitbuffer *bitbuf, int bit_count )
 
 // Packs/unpacks an object position.
 // Returns number of bytes read or written.
+// Cyborg17 This packer saves 2 bytes over sending the whole vector.  
+// It now has a maximum effective range of ~130k in the x and z and ~65K in the y
 int multi_pack_unpack_position( int write, ubyte *data, vec3d *pos)
 {
 	bitbuffer buf;
@@ -3419,32 +3427,31 @@ int multi_pack_unpack_position( int write, ubyte *data, vec3d *pos)
 	int a, b, c;
 
 	if ( write )	{
+
 		// Output pos
-
-		a = (int)std::lround(pos->xyz.x*105.0f);
-		b = (int)std::lround(pos->xyz.y*105.0f);
-		c = (int)std::lround(pos->xyz.z*105.0f);
-		CAP(a,-8388608,8388607);
-		CAP(b,-8388608,8388607);
-		CAP(c,-8388608,8388607);
+		a = (int)round(pos->xyz.x*512.0f);
+		b = (int)round(pos->xyz.y*512.0f); 
+		c = (int)round(pos->xyz.z*512.0f);
+		CAP(a, -67108864, 67108863);		
+		CAP(b, -33554432, 33554431);		
+		CAP(c, -67108864, 67108863);		
 		
-		bitbuffer_put( &buf, (uint)a, 24 );
-		bitbuffer_put( &buf, (uint)b, 24 );
-		bitbuffer_put( &buf, (uint)c, 24 );
-
+		bitbuffer_put( &buf, (uint)a, 27 );
+		bitbuffer_put( &buf, (uint)b, 26 ); // Cyborg17 this is set to 26 bits on purpose.			
+		bitbuffer_put( &buf, (uint)c, 27 );
 
 		return bitbuffer_write_flush(&buf);
 
 	} else {
 
 		// unpack pos
-		a = bitbuffer_get_signed(&buf,24);
-		b = bitbuffer_get_signed(&buf,24);
-		c = bitbuffer_get_signed(&buf,24);
+		a = bitbuffer_get_signed(&buf,27);
+		b = bitbuffer_get_signed(&buf,26); // Cyborg17 this is set to 26 bits on purpose.
+		c = bitbuffer_get_signed(&buf,27);
 
-		pos->xyz.x = i2fl(a)/105.0f;
-		pos->xyz.y = i2fl(b)/105.0f;
-		pos->xyz.z = i2fl(c)/105.0f;
+		pos->xyz.x = i2fl(a)/512.0f;
+		pos->xyz.y = i2fl(b)/512.0f;
+		pos->xyz.z = i2fl(c)/512.0f;
 
 		return bitbuffer_read_flush(&buf);
 	}
@@ -3452,143 +3459,54 @@ int multi_pack_unpack_position( int write, ubyte *data, vec3d *pos)
 
 // Packs/unpacks an orientation matrix.
 // Returns number of bytes read or written.
-int multi_pack_unpack_orient( int write, ubyte *data, matrix *orient)
+// Cyborg17 - Because of testing and a bugfix from Wookiejedi, this is now used in tandem with
+// vm_extract_angles_matrix() to save bandwidth. We return the raw angles by reference
+// because they are also useful in rotational interpolation.
+int multi_pack_unpack_orient( int write, ubyte *data, angles *angles)
 {
 	bitbuffer buf;
 
-	bitbuffer_init(&buf, data + 1);
+	bitbuffer_init(&buf, data);
 
-	vec3d rot_axis;	
-	float theta;
-	int a, b, c, d;
-	angles ang;	
-	ubyte flag = 0x00;	
+	int a, b, c;
 
-	#define D_SCALE 32768.0f
-	#define D_MAX_RANGE 32767
-	#define D_MIN_RANGE -32768
-
-	#define N_SCALE 2048.0f
-	#define N_MAX_RANGE 2047
-	#define N_MIN_RANGE -2048
+	// set up some constants to facilitate compression 
+	const float n_scale = 32768.0f/ PI;
+	const int n_min_range = -32768;
+	const int n_max_range =  32767;
 
 	if ( write )	{			
-		// degenerate case - send the whole orient matrix
-		vm_extract_angles_matrix(&ang, orient);	
-		if((ang.h > 3.130) && (ang.h < 3.150)){
+		// Subtract PI/2 because the output of vm_extract_angles_matrix is from -PI/2 to 3PI/2
+		a = fl2i(round((angles->b/* - PI/2*/) * n_scale)); 
+		b = fl2i(round((angles->h/* - PI/2*/) * n_scale));
+		c = fl2i(round((angles->p/* - PI/2*/) * n_scale));
 
-			flag = 0xff;
-			
-			// stuff it	
-			a = fl2i(orient->vec.fvec.xyz.x * D_SCALE);
-			CAP(a, D_MIN_RANGE, D_MAX_RANGE);			
-			bitbuffer_put( &buf, a, 16  );
-			a = fl2i(orient->vec.fvec.xyz.y * D_SCALE);
-			CAP(a, D_MIN_RANGE, D_MAX_RANGE);			
-			bitbuffer_put( &buf, a, 16  );
-			a = fl2i(orient->vec.fvec.xyz.z * D_SCALE);
-			CAP(a, D_MIN_RANGE, D_MAX_RANGE);			
-			bitbuffer_put( &buf, a, 16  );
-
-			a = fl2i(orient->vec.uvec.xyz.x * D_SCALE);
-			CAP(a, D_MIN_RANGE, D_MAX_RANGE);			
-			bitbuffer_put( &buf, a, 16  );
-			a = fl2i(orient->vec.uvec.xyz.y * D_SCALE);
-			CAP(a, D_MIN_RANGE, D_MAX_RANGE);			
-			bitbuffer_put( &buf, a, 16  );
-			a = fl2i(orient->vec.uvec.xyz.z * D_SCALE);
-			CAP(a, D_MIN_RANGE, D_MAX_RANGE);			
-			bitbuffer_put( &buf, a, 16  );
-
-			a = fl2i(orient->vec.rvec.xyz.x * D_SCALE);
-			CAP(a, D_MIN_RANGE, D_MAX_RANGE);			
-			bitbuffer_put( &buf, a, 16  );
-			a = fl2i(orient->vec.rvec.xyz.y * D_SCALE);
-			CAP(a, D_MIN_RANGE, D_MAX_RANGE);			
-			bitbuffer_put( &buf, a, 16  );
-			a = fl2i(orient->vec.rvec.xyz.z * D_SCALE);
-			CAP(a, D_MIN_RANGE, D_MAX_RANGE);			
-			bitbuffer_put( &buf, a, 16  );
-		} else {
-				
-			vm_matrix_to_rot_axis_and_angle(orient, &theta, &rot_axis);		
-			// Have theta, which is an angle between 0 and PI.
-			// Convert it to be between -1.0f and 1.0f
-			theta = theta*2.0f/PI-1.0f;			
-
-			// -1 to 1
-			a = fl2i(rot_axis.xyz.x*N_SCALE); 
-			b = fl2i(rot_axis.xyz.y*N_SCALE);
-			c = fl2i(rot_axis.xyz.z*N_SCALE);
-			d = fl2i(theta*N_SCALE);
-
-			CAP(a, N_MIN_RANGE, N_MAX_RANGE);
-			CAP(b, N_MIN_RANGE, N_MAX_RANGE);
-			CAP(c, N_MIN_RANGE, N_MAX_RANGE);
-			CAP(d, N_MIN_RANGE, N_MAX_RANGE);
+		CAP(a, n_min_range, n_max_range);
+		CAP(b, n_min_range, n_max_range);
+		CAP(c, n_min_range, n_max_range);
 					
-			bitbuffer_put( &buf, (uint)a, 12 );
-			bitbuffer_put( &buf, (uint)b, 12 );
-			bitbuffer_put( &buf, (uint)c, 12 );
-			bitbuffer_put( &buf, (uint)d, 12 );
-		}
+		bitbuffer_put( &buf, (uint)a, 16 );
+		bitbuffer_put( &buf, (uint)b, 16 );
+		bitbuffer_put( &buf, (uint)c, 16 );
 
-		// flag for degenerate case
-		data[0] = flag;
-
-		return bitbuffer_write_flush(&buf) + 1;
+		return bitbuffer_write_flush(&buf);
 	} else {
-		flag = data[0];
 
-		// degenerate
-		if(flag){
-			a = bitbuffer_get_signed(&buf, 16);
-			orient->vec.fvec.xyz.x = i2fl(a) / D_SCALE;			
-			a = bitbuffer_get_signed(&buf, 16);
-			orient->vec.fvec.xyz.y = i2fl(a) / D_SCALE;			
-			a = bitbuffer_get_signed(&buf, 16);
-			orient->vec.fvec.xyz.z = i2fl(a) / D_SCALE;			
+		a = bitbuffer_get_signed(&buf,16);
+		b = bitbuffer_get_signed(&buf,16);
+		c = bitbuffer_get_signed(&buf,16);
 
-			a = bitbuffer_get_signed(&buf, 16);
-			orient->vec.uvec.xyz.x = i2fl(a) / D_SCALE;			
-			a = bitbuffer_get_signed(&buf, 16);
-			orient->vec.uvec.xyz.y = i2fl(a) / D_SCALE;			
-			a = bitbuffer_get_signed(&buf, 16);
-			orient->vec.uvec.xyz.z = i2fl(a) / D_SCALE;			
-
-			a = bitbuffer_get_signed(&buf, 16);
-			orient->vec.rvec.xyz.x = i2fl(a) / D_SCALE;			
-			a = bitbuffer_get_signed(&buf, 16);
-			orient->vec.rvec.xyz.y = i2fl(a) / D_SCALE;			
-			a = bitbuffer_get_signed(&buf, 16);
-			orient->vec.rvec.xyz.z = i2fl(a) / D_SCALE;			
-		} else {
-			a = bitbuffer_get_signed(&buf,12);
-			b = bitbuffer_get_signed(&buf,12);
-			c = bitbuffer_get_signed(&buf,12);
-			d = bitbuffer_get_signed(&buf,12);
-
-			// special case		
-			rot_axis.xyz.x = i2fl(a)/N_SCALE;
-			rot_axis.xyz.y = i2fl(b)/N_SCALE;
-			rot_axis.xyz.z = i2fl(c)/N_SCALE;
-			theta = i2fl(d)/N_SCALE;
-				
-			// Convert theta back to range 0-PI
-			theta = (theta+1.0f)*PI_2;
-				
-			vm_quaternion_rotate(orient, theta, &rot_axis);		
-
-			vm_orthogonalize_matrix(orient);		
-		}
-
-		return bitbuffer_read_flush(&buf) + 1;
+		angles->b =/* PI/2 +*/ (i2fl(a)/n_scale);
+		angles->h =/* PI/2 +*/ (i2fl(b)/n_scale);
+		angles->p =/* PI/2 +*/ (i2fl(c)/n_scale);
+		
+		return bitbuffer_read_flush(&buf);
 	}
 }
 
 // Packs/unpacks velocity
 // Returns number of bytes read or written.
-int multi_pack_unpack_vel( int write, ubyte *data, matrix *orient, vec3d * /*pos*/, physics_info *pi)
+int multi_pack_unpack_vel( int write, ubyte *data, matrix *orient, physics_info *pi)
 {
 	bitbuffer buf;
 
@@ -3603,25 +3521,26 @@ int multi_pack_unpack_vel( int write, ubyte *data, matrix *orient, vec3d * /*pos
 		u = vm_vec_dot( &orient->vec.uvec, &pi->vel );
 		f = vm_vec_dot( &orient->vec.fvec, &pi->vel );
 
-		a = fl2i(r * 0.5f); 
-		b = fl2i(u * 0.5f);
-		c = fl2i(f * 0.5f);
+		// Cyborg17 - using round here allows us keep part of the decimal accuracy that would have been dropped with just fl2i
+		a = fl2i(round(r * 2.0f)); 
+		b = fl2i(round(u * 2.0f));
+		c = fl2i(round(f * 4.0f));
 		CAP(a,-512,511);
 		CAP(b,-512,511);
-		CAP(c,-512,511);
+		CAP(c,-2048,2047);
 		bitbuffer_put( &buf, (uint)a, 10 );
 		bitbuffer_put( &buf, (uint)b, 10 );
-		bitbuffer_put( &buf, (uint)c, 10 );
+		bitbuffer_put( &buf, (uint)c, 12 );
 
 		return bitbuffer_write_flush(&buf);
 	} else {
 		// unpack velocity
 		a = bitbuffer_get_signed(&buf,10);
 		b = bitbuffer_get_signed(&buf,10);
-		c = bitbuffer_get_signed(&buf,10);
-		r = i2fl(a)/0.5f;
-		u = i2fl(b)/0.5f;
-		f = i2fl(c)/0.5f;
+		c = bitbuffer_get_signed(&buf,12);
+		r = i2fl(a)/2.0f;
+		u = i2fl(b)/2.0f;
+		f = i2fl(c)/4.0f;
 
 		// Convert into world coordinates
 		vm_vec_zero(&pi->vel);
@@ -3633,108 +3552,9 @@ int multi_pack_unpack_vel( int write, ubyte *data, matrix *orient, vec3d * /*pos
 	}
 }
 
-// Packs/unpacks desired_velocity
-// Returns number of bytes read or written.
-int multi_pack_unpack_desired_vel( int write, ubyte *data, matrix *orient, vec3d * /*pos*/, physics_info *pi, ship_info *sip)
-{
-	bitbuffer buf;
-
-	bitbuffer_init(&buf,data);
-
-	int a;
-	vec3d	max_vel;
-	float r,u,f;
-	int fields = 0;
-
-	max_vel.xyz.x = MAX( sip->max_vel.xyz.x, sip->afterburner_max_vel.xyz.x );
-	max_vel.xyz.y = MAX( sip->max_vel.xyz.y, sip->afterburner_max_vel.xyz.y );
-	max_vel.xyz.z = MAX( sip->max_vel.xyz.z, sip->afterburner_max_vel.xyz.z );	
-
-	if ( write )	{
-		// Find desired vel in local coordinates
-		// Velocity can be from -1024 to 1024
-
-		// bitfields for each value		
-		if(max_vel.xyz.x > 0.0f){
-			fields |= (1<<0);
-		}
-		if(max_vel.xyz.y > 0.0f){
-			fields |= (1<<1);
-		}
-		if(max_vel.xyz.z > 0.0f){
-			fields |= (1<<2);
-		}		
-		// fields = sip - Ship_info;
-		bitbuffer_put(&buf, (uint)fields, 8);
-
-		r = vm_vec_dot( &orient->vec.rvec, &pi->desired_vel );
-		u = vm_vec_dot( &orient->vec.uvec, &pi->desired_vel );
-		f = vm_vec_dot( &orient->vec.fvec, &pi->desired_vel );
-
-		if ( max_vel.xyz.x > 0.0f )	{
-			r = r / max_vel.xyz.x;
-			a = fl2i( r * 128.0f );
-			CAP(a,-128, 127 );			
-			bitbuffer_put( &buf, (uint)a, 8 );			
-		} 
-
-		if ( max_vel.xyz.y > 0.0f )	{
-			u = u / max_vel.xyz.y;
-			a = fl2i( u * 128.0f );
-			CAP(a,-128, 127 );
-			bitbuffer_put( &buf, (uint)a, 8 );
-		} 
-
-		if ( max_vel.xyz.z > 0.0f )	{
-			f = f / max_vel.xyz.z;
-			a = fl2i( f * 128.0f );
-			CAP(a,-128, 127 );
-			bitbuffer_put( &buf, (uint)a, 8 );
-		}
-
-		return bitbuffer_write_flush(&buf);
-	} else {
-
-		// Find desired vel in local coordinates
-		// Velocity can be from -1024 to 1024
-
-		// get the fields bitbuffer
-		fields = bitbuffer_get_signed(&buf, 8);
-		
-		if ( fields & (1<<0) )	{
-			a = bitbuffer_get_signed(&buf,8);
-			r = i2fl(a)/128.0f;
-		} else {
-			r = 0.0f;
-		}
-		
-		if ( fields & (1<<1) )	{
-			a = bitbuffer_get_signed(&buf,8);
-			u = i2fl(a)/128.0f;
-		} else {
-			u = 0.0f;
-		}
-		
-		if ( fields & (1<<2) )	{
-			a = bitbuffer_get_signed(&buf,8);
-			f = i2fl(a)/128.0f;
-		} else {
-			f = 0.0f;
-		}		
-		
-		// Convert into world coordinates
-		vm_vec_zero(&pi->vel);
-		vm_vec_scale_add2( &pi->desired_vel, &orient->vec.rvec, r*max_vel.xyz.x );
-		vm_vec_scale_add2( &pi->desired_vel, &orient->vec.uvec, u*max_vel.xyz.y );
-		vm_vec_scale_add2( &pi->desired_vel, &orient->vec.fvec, f*max_vel.xyz.z );
-
-		return bitbuffer_read_flush(&buf);
-	}
-}
-
 // Packs/unpacks rotational velocity
 // Returns number of bytes read or written.
-int multi_pack_unpack_rotvel( int write, ubyte *data, matrix * /*orient*/, vec3d * /*pos*/, physics_info *pi)
+int multi_pack_unpack_rotvel( int write, ubyte *data, physics_info *pi)
 {
 	bitbuffer buf;
 
@@ -3744,9 +3564,9 @@ int multi_pack_unpack_rotvel( int write, ubyte *data, matrix * /*orient*/, vec3d
 
 	if ( write )	{
 		// output rotational velocity
-		a = fl2i(pi->rotvel.xyz.x*32.0f); 
-		b = fl2i(pi->rotvel.xyz.y*32.0f);
-		c = fl2i(pi->rotvel.xyz.z*32.0f);
+		a = fl2i(round(pi->rotvel.xyz.x*32.0f)); 
+		b = fl2i(round(pi->rotvel.xyz.y*32.0f));
+		c = fl2i(round(pi->rotvel.xyz.z*32.0f));
 		CAP(a,-512,511);
 		CAP(b,-512,511);
 		CAP(c,-512,511);
@@ -3771,81 +3591,398 @@ int multi_pack_unpack_rotvel( int write, ubyte *data, matrix * /*orient*/, vec3d
 	}
 }
 
-// Packs/unpacks desired rotvel
-// Returns number of bytes read or written.
-int multi_pack_unpack_desired_rotvel( int write, ubyte *data, matrix * /*orient*/, vec3d * /*pos*/, physics_info *pi, ship_info *sip)
+ubyte multi_pack_unpack_desired_vel_and_desired_rotvel( int write, bool full_physics, ubyte *data, physics_info *pi, vec3d* local_desired_vel)
 {
 	bitbuffer buf;
-	int fields = 0;
 
 	bitbuffer_init(&buf,data);
 
-	int a;
-	float r,u,f;
+	int a = 0, b = 0, c = 0;
+	int d = 0, e = 0, f = 0;
 
 	if ( write )	{
-		// use ship_info values for max_rotvel instead of taking it from physics info
+		if (full_physics) {
+			// output desired rotational velocity
+			if (pi->max_rotvel.xyz.x > 0.0f) {
+				a = fl2i(round( (pi->desired_rotvel.xyz.x / pi->max_rotvel.xyz.x) * 15.0f)); 
+			}
 
-		// bitfields for each value
-		if(sip->max_rotvel.xyz.x > 0.0f){
-			fields |= (1<<0);
+			if (pi->max_rotvel.xyz.y > 0.0f) {
+				b = fl2i(round( (pi->desired_rotvel.xyz.y / pi->max_rotvel.xyz.y) * 15.0f));
+			}
+
+			if (pi->max_rotvel.xyz.z > 0.0f) {
+				c = fl2i(round( (pi->desired_rotvel.xyz.z / pi->max_rotvel.xyz.z) * 15.0f));
+			}
+
+			CAP(a,-15,15);
+			CAP(b,-15,15);
+			CAP(c,-15,15);
+			bitbuffer_put( &buf, (uint)a,5);
+			bitbuffer_put( &buf, (uint)b,5);
+			bitbuffer_put( &buf, (uint)c,5);
+
 		}
-		if(sip->max_rotvel.xyz.y > 0.0f){
-			fields |= (1<<1);
+
+		// pack desired velocity.
+		if (pi->max_vel.xyz.x > 0.0f) {
+			d = fl2i(round( (local_desired_vel->xyz.x / pi->max_vel.xyz.x) * 7.0f)); 
 		}
-		if(sip->max_rotvel.xyz.z > 0.0f){
-			fields |= (1<<2);
 
+		if (pi->max_vel.xyz.y > 0.0f) {
+			e = fl2i(round( (local_desired_vel->xyz.y / pi->max_vel.xyz.y) * 7.0f));
 		}
-		bitbuffer_put(&buf, (uint)fields, 8);
+		// for z velocity, take into account afterburner.
+		if (pi->max_vel.xyz.z > 0.0f) {
+			f = fl2i(round( (local_desired_vel->xyz.z / pi->afterburner_max_vel.xyz.z) * 255.0f));
+		}
 
-		// output desired rotational velocity as a percent of max		
-		if ( sip->max_rotvel.xyz.x > 0.0f )	{		
-			a = fl2i( pi->desired_rotvel.xyz.x*128.0f / sip->max_rotvel.xyz.x );
-			CAP(a,-128, 127 );
-			bitbuffer_put( &buf, (uint)a, 8 );
-		} 
+		CAP(d,-7,7);
+		CAP(e,-7,7);
+		CAP(f,-255,255);
+		bitbuffer_put( &buf, (uint)d,4);
+		bitbuffer_put( &buf, (uint)e,4);
+		bitbuffer_put( &buf, (uint)f,9);
 
-		if ( sip->max_rotvel.xyz.y > 0.0f )	{		
-			a = fl2i( pi->desired_rotvel.xyz.y*128.0f / sip->max_rotvel.xyz.y );
-			CAP(a,-128, 127 );
-			bitbuffer_put( &buf, (uint)a, 8 );
-		} 
+		return (ubyte)bitbuffer_write_flush(&buf);
 
-		if ( sip->max_rotvel.xyz.z > 0.0f )	{		
-			a = fl2i( pi->desired_rotvel.xyz.z*128.0f / sip->max_rotvel.xyz.z );
-			CAP(a,-128, 127 );
-			bitbuffer_put( &buf, (uint)a, 8 );
-		} 
-
-		return bitbuffer_write_flush(&buf);
 	} else {
-		fields = bitbuffer_get_signed(&buf, 8);
 
-		// unpack desired rotational velocity
-		if ( fields & (1<<0) )	{		
-			a = bitbuffer_get_signed(&buf,8);
-			r = i2fl(a)/128.0f;
-		} else {
-			r = 0.0f;
-		}
-		if ( fields & (1<<1) )	{		
-			a = bitbuffer_get_signed(&buf,8);
-			u = i2fl(a)/128.0f;
-		} else {
-			u = 0.0f;
-		}
-		if ( fields & (1<<2) )	{		
-			a = bitbuffer_get_signed(&buf,8);
-			f = i2fl(a)/128.0f;
-		} else {
-			f = 0.0f;
-		}
-		pi->desired_rotvel.xyz.x = r*sip->max_rotvel.xyz.x;
-		pi->desired_rotvel.xyz.y = u*sip->max_rotvel.xyz.y;
-		pi->desired_rotvel.xyz.z = f*sip->max_rotvel.xyz.z;
+		if (full_physics) {
+			// unpack desired rotational velocity
+			a = bitbuffer_get_signed(&buf,5);
+			b = bitbuffer_get_signed(&buf,5);
+			c = bitbuffer_get_signed(&buf,5);
+			pi->rotvel.xyz.x = pi->max_rotvel.xyz.x * i2fl(a)/15.0f;
+			pi->rotvel.xyz.y = pi->max_rotvel.xyz.y * i2fl(b)/15.0f;
+			pi->rotvel.xyz.z = pi->max_rotvel.xyz.z * i2fl(c)/15.0f;
 
-		return bitbuffer_read_flush(&buf);
+		}
+
+		// unpack desired velocity
+		d = bitbuffer_get_signed(&buf,4);
+		e = bitbuffer_get_signed(&buf,4);
+		f = bitbuffer_get_signed(&buf,9);
+		local_desired_vel->xyz.x = pi->max_vel.xyz.x * i2fl(d)/7.0f;
+		local_desired_vel->xyz.y = pi->max_vel.xyz.y * i2fl(e)/7.0f;
+		local_desired_vel->xyz.z = pi->afterburner_max_vel.xyz.z * i2fl(f)/255.0f;
+
+
+		return (ubyte)bitbuffer_read_flush(&buf);
+	}
+}
+
+#define SUBSYSTEM_LIST_MINI_PACKET_SIZE 7
+#define SUBSYSTEM_PACKER_CUTOFF 128
+#define SUBSYSTEM_PACKER_TRUE  1
+#define SUBSYSTEM_PACKER_FALSE 0
+
+// Cyborg17 - A packing function to manage subsystem info.
+ubyte multi_pack_unpack_subsystem_list(bool write, ubyte* data, SCP_vector<ubyte>* flags, SCP_vector<float>* subsys_data)
+{
+
+	bitbuffer buf;
+
+	bitbuffer_init(&buf,data);
+
+	Assertion(flags != nullptr, "Someone fed multi_pack_unpack_subsystem_list a nullptr. This is a coder mistake, please report.");
+	Assertion(subsys_data != nullptr, "Someone fed multi_pack_unpack_subsystem_list a nullptr. This is a coder mistake, please report.");
+
+	// packing/unpacking variable
+	int a = 0;
+	bool done = false;
+
+	if (write) {
+
+		int last_index = (int)flags->size();
+
+		// no need to pack anything if there's nothing to pack.
+		if (last_index == 0) {
+			return 0;
+		}
+
+		// because we need to make sure there are predictable chunks, expand the last chunck if it is the wrong size.
+		// we can't depend on the subsystem info being the same on both sides and knowing how the packet ends that way.
+		int remainder = last_index % SUBSYSTEM_LIST_MINI_PACKET_SIZE;
+
+		if (remainder > 0) {
+			last_index += SUBSYSTEM_LIST_MINI_PACKET_SIZE - remainder;
+			for (int i = remainder; i < SUBSYSTEM_LIST_MINI_PACKET_SIZE; i++) {
+				flags->push_back(0);
+			}
+		}
+
+
+		ubyte current_flags;
+		int subsys_data_index = 0;
+
+		// go through the list of subsystems sent to the packer
+		for (int i = 0; i < last_index; i++) {
+			current_flags = flags->at(i);
+
+			// mark this if there are things to store for this subsystem
+			if (current_flags > 0) {
+				a = SUBSYSTEM_PACKER_TRUE;
+				bitbuffer_put( &buf, (uint)a,1);
+
+				// is there health stored?
+				if (current_flags & OO_SUBSYS_HEALTH) {
+					a = SUBSYSTEM_PACKER_TRUE;
+					bitbuffer_put( &buf, (uint)a,1);
+
+					// stuff the health of the subsystem.  
+					a = (int)(subsys_data->at(subsys_data_index) * 127);
+					CAP(a, 0, 127);
+					bitbuffer_put( &buf, (uint)a,7);
+					subsys_data_index++;
+
+					// this succinctly marks if there are any other flags, instead of listing each.
+					// because a lot of times we do not have both health and animation marked.
+					current_flags &= ~OO_SUBSYS_HEALTH;
+					if (current_flags > 0) {
+						a = SUBSYSTEM_PACKER_TRUE;
+						bitbuffer_put( &buf, (uint)a,1);
+
+					} // if no other flags, mark as done and go to the next subsystem
+					else {
+						a = SUBSYSTEM_PACKER_FALSE;
+						bitbuffer_put( &buf, (uint)a,1);
+						done = true;
+					}					
+				} // no new health info for this subsystem.
+				else {
+					a = SUBSYSTEM_PACKER_FALSE;
+					bitbuffer_put(&buf, (uint)a, 1);
+				}
+
+				if (!done) {
+
+					// health is dealt with, now add turret orientation
+					// (other types need to be dealt with in other ways.i.e. Dumb rotate needs time syncing, not constant updates)
+					if (current_flags & (OO_SUBSYS_ROTATION_1b)) {
+						// mark as present
+						a = SUBSYSTEM_PACKER_TRUE;
+						bitbuffer_put(&buf, (uint)a, 1);
+						// stuff value
+						a = (int)(subsys_data->at(subsys_data_index) * 511);
+						CAP(a, 0, 511);
+						// 9 bits allows for an accuracy of less than a degree
+						bitbuffer_put(&buf, (uint)a, 9);
+
+						subsys_data_index++;
+
+					} // no rotation in this axis
+					else {
+						a = SUBSYSTEM_PACKER_FALSE;
+						bitbuffer_put(&buf, (uint)a, 1);
+					}
+
+					if (current_flags & (OO_SUBSYS_ROTATION_1h)) {
+						// mark as present
+						a = SUBSYSTEM_PACKER_TRUE;
+						bitbuffer_put(&buf, (uint)a, 1);
+						// stuff value
+						a = (int)(subsys_data->at(subsys_data_index) * 511);
+						CAP(a, 0, 511);
+						// 9 bits allows for an accuracy of less than a degree
+						bitbuffer_put(&buf, (uint)a, 9);
+						// move on to the next piece of info
+						subsys_data_index++;
+
+					} // no rotation in this axis
+					else {
+						a = SUBSYSTEM_PACKER_FALSE;
+						bitbuffer_put(&buf, (uint)a, 1);
+					}
+
+					if (current_flags & (OO_SUBSYS_ROTATION_1p)) {
+						// mark as present
+						a = SUBSYSTEM_PACKER_TRUE;
+						bitbuffer_put(&buf, (uint)a, 1);
+						// stuff value
+						a = (int)(subsys_data->at(subsys_data_index) * 511);
+						CAP(a, 0, 511);
+						// 9 bits allows for an accuracy of less than a degree
+						bitbuffer_put(&buf, (uint)a, 9);
+						// move on to the next piece of info
+						subsys_data_index++;
+
+					} // no rotation in this axis
+					else {
+						a = SUBSYSTEM_PACKER_FALSE;
+						bitbuffer_put(&buf, (uint)a, 1);
+					}
+
+					if (current_flags & (OO_SUBSYS_ROTATION_2b)) {
+						// mark as present
+						a = SUBSYSTEM_PACKER_TRUE;
+						bitbuffer_put(&buf, (uint)a, 1);
+						// stuff value
+						a = (int)(subsys_data->at(subsys_data_index) * 511);
+						CAP(a, 0, 511);
+						// 9 bits allows for an accuracy of less than a degree
+						bitbuffer_put(&buf, (uint)a, 9);
+						// move on to the next piece of info
+						subsys_data_index++;
+
+					} // no rotation in this axis
+					else {
+						a = SUBSYSTEM_PACKER_FALSE;
+						bitbuffer_put(&buf, (uint)a, 1);
+					}
+
+					if (current_flags & (OO_SUBSYS_ROTATION_2h)) {
+						// mark as present
+						a = SUBSYSTEM_PACKER_TRUE;
+						bitbuffer_put(&buf, (uint)a, 1);
+						// stuff value
+						a = (int)(subsys_data->at(subsys_data_index) * 511);
+						CAP(a, 0, 511);
+						// 9 bits allows for an accuracy of less than a degree
+						bitbuffer_put(&buf, (uint)a, 9);
+						// move on to the next piece of info
+						subsys_data_index++;
+
+					} // no rotation in this axis
+					else {
+						a = SUBSYSTEM_PACKER_FALSE;
+						bitbuffer_put(&buf, (uint)a, 1);
+					}
+
+					if (current_flags & (OO_SUBSYS_ROTATION_2p)) {
+						// mark as present
+						a = SUBSYSTEM_PACKER_TRUE;
+						bitbuffer_put(&buf, (uint)a, 1);
+						// stuff value
+						a = (int)(subsys_data->at(subsys_data_index) * 511);
+						CAP(a, 0, 511);
+						// 9 bits allows for an accuracy of less than a degree
+						bitbuffer_put(&buf, (uint)a, 9);
+						// move on to the next piece of info
+						subsys_data_index++;
+
+					} // no rotation in this axis
+					else {
+						a = SUBSYSTEM_PACKER_FALSE;
+						bitbuffer_put(&buf, (uint)a, 1);
+					}
+
+					// this is where translation info should go, once implemented and if needed! 
+					// It Will require a multi bump...
+				}
+
+
+			} // if there was no info to pack, mark it as so, and move on.
+			else {
+				a = SUBSYSTEM_PACKER_FALSE;
+				bitbuffer_put( &buf, (uint)a,1);
+			}
+
+
+			// whenever we've reached the end of a section, tell the client if we're continuing.
+			if (( (i + 1) % 7 == 0) && (i != 0)) {
+				// and if we're at the end or have gone too far, mark it as the end.
+				if ((i >= (last_index - 1)) || (bitbuffer_read_flush(&buf) >= SUBSYSTEM_PACKER_CUTOFF) ){
+					a = SUBSYSTEM_PACKER_FALSE;
+					bitbuffer_put( &buf, (uint)a,1);
+					break;
+				} // start a new section right after this bit.
+				else {
+					a = SUBSYSTEM_PACKER_TRUE;
+					bitbuffer_put( &buf, (uint)a,1);
+				}
+			}
+
+			// reset skipping rotation flag
+			done = false;
+		}
+		return (ubyte)bitbuffer_write_flush(&buf);
+	}
+	else {
+	Assertion(flags->empty(), "The flags vector was not empty before being sent to multi_pack_unpack_subsystem_list. This is a coder mistake, please report!");
+	Assertion(subsys_data->empty(), "The subsys_data vector was not empty before being sent to multi_pack_unpack_subsystem_list. This is a coder mistake, please report!");
+
+	int current_subsystem_index = 0;
+	flags->push_back(0);
+		// each iteration of this outer loop is a mini packet within the OO_packet.
+		do {
+			for (int i = 0; i < SUBSYSTEM_LIST_MINI_PACKET_SIZE; i++) {
+				done = false;
+				a = bitbuffer_get_unsigned(&buf, 1);
+			
+				// check to see if there is info to unpack
+				if (a == SUBSYSTEM_PACKER_TRUE) {
+
+					// is there health info?
+					a = bitbuffer_get_unsigned(&buf, 1);
+					if (a == SUBSYSTEM_PACKER_TRUE) {
+						flags->at(current_subsystem_index) |= OO_SUBSYS_HEALTH;
+
+						a = bitbuffer_get_unsigned(&buf, 7);
+						subsys_data->push_back((float)a / 127.0f);
+
+						// check for additional info for this subsystem.
+						a = bitbuffer_get_unsigned(&buf, 1);
+						if (a == SUBSYSTEM_PACKER_FALSE) {
+							// no further info, continue.
+							done = true;
+						}
+					}
+
+					if (!done) {
+						//  now check for each type of subsystem rotation before going on to the next subsystem
+						a = bitbuffer_get_unsigned(&buf, 1);
+						if (a == SUBSYSTEM_PACKER_TRUE) {
+							flags->at(current_subsystem_index) |= OO_SUBSYS_ROTATION_1b;
+							a = bitbuffer_get_unsigned(&buf, 9);
+							subsys_data->push_back( ((float) a) / 511.0f);	
+						}
+
+						a = bitbuffer_get_unsigned(&buf, 1);
+						if (a == SUBSYSTEM_PACKER_TRUE) {
+							flags->at(current_subsystem_index) |= OO_SUBSYS_ROTATION_1h;
+							a = bitbuffer_get_unsigned(&buf, 9);
+							subsys_data->push_back( ((float) a) / 511.0f);	
+						}
+
+						a = bitbuffer_get_unsigned(&buf, 1);
+						if (a == SUBSYSTEM_PACKER_TRUE) {
+							flags->at(current_subsystem_index) |= OO_SUBSYS_ROTATION_1p;
+							a = bitbuffer_get_unsigned(&buf, 9);
+							subsys_data->push_back( ((float) a) / 511.0f);	
+						}
+
+						a = bitbuffer_get_unsigned(&buf, 1);
+						if (a == SUBSYSTEM_PACKER_TRUE) {
+							flags->at(current_subsystem_index) |= OO_SUBSYS_ROTATION_2b;
+							a = bitbuffer_get_unsigned(&buf, 9);
+							subsys_data->push_back( ((float) a) / 511.0f);	
+						}
+
+						a = bitbuffer_get_unsigned(&buf, 1);
+						if (a == SUBSYSTEM_PACKER_TRUE) {
+							flags->at(current_subsystem_index) |= OO_SUBSYS_ROTATION_2h;
+							a = bitbuffer_get_unsigned(&buf, 9);
+							subsys_data->push_back( ((float) a) / 511.0f);	
+						}
+
+						a = bitbuffer_get_unsigned(&buf, 1);
+						if (a == SUBSYSTEM_PACKER_TRUE) {
+							flags->at(current_subsystem_index) |= OO_SUBSYS_ROTATION_2p;
+							a = bitbuffer_get_unsigned(&buf, 9);
+							subsys_data->push_back( ((float) a) / 511.0f);	
+						}
+					}
+				} 
+
+				flags->push_back(0);
+				current_subsystem_index++;
+			}
+
+			a = bitbuffer_get_unsigned(&buf, 1);
+		} while (a == SUBSYSTEM_PACKER_TRUE);
+		
+		return (ubyte)bitbuffer_read_flush(&buf);
 	}
 }
 

--- a/code/network/multiutil.cpp
+++ b/code/network/multiutil.cpp
@@ -225,6 +225,7 @@ void multi_set_network_signature( ushort signature, int what_kind )
 		Next_asteroid_signature = signature;
 	} else if ( what_kind == MULTI_SIG_WAYPOINT ) {
 		Assert( (signature >= WAYPOINT_SIG_MIN) && (signature <= WAYPOINT_SIG_MAX) );
+		Next_waypoint_signature = signature;
 	} else if (what_kind == MULTI_SIG_NON_PERMANENT) {
 		// Cyborg17 - spawn weapons can set this past the max and overflow the short
 		if (signature >= NPERM_SIG_MIN) {
@@ -3591,7 +3592,7 @@ int multi_pack_unpack_rotvel( int write, ubyte *data, physics_info *pi)
 	}
 }
 
-ubyte multi_pack_unpack_desired_vel_and_desired_rotvel( int write, bool full_physics, ubyte *data, physics_info *pi, vec3d* local_desired_vel)
+int multi_pack_unpack_desired_vel_and_desired_rotvel( int write, bool full_physics, ubyte *data, physics_info *pi, vec3d* local_desired_vel)
 {
 	bitbuffer buf;
 
@@ -3644,7 +3645,7 @@ ubyte multi_pack_unpack_desired_vel_and_desired_rotvel( int write, bool full_phy
 		bitbuffer_put( &buf, (uint)e,4);
 		bitbuffer_put( &buf, (uint)f,9);
 
-		return (ubyte)bitbuffer_write_flush(&buf);
+		return bitbuffer_write_flush(&buf);
 
 	} else {
 
@@ -3668,7 +3669,7 @@ ubyte multi_pack_unpack_desired_vel_and_desired_rotvel( int write, bool full_phy
 		local_desired_vel->xyz.z = pi->afterburner_max_vel.xyz.z * i2fl(f)/255.0f;
 
 
-		return (ubyte)bitbuffer_read_flush(&buf);
+		return bitbuffer_read_flush(&buf);
 	}
 }
 
@@ -3678,7 +3679,7 @@ ubyte multi_pack_unpack_desired_vel_and_desired_rotvel( int write, bool full_phy
 #define SUBSYSTEM_PACKER_FALSE 0
 
 // Cyborg17 - A packing function to manage subsystem info.
-ubyte multi_pack_unpack_subsystem_list(bool write, ubyte* data, SCP_vector<ubyte>* flags, SCP_vector<float>* subsys_data)
+int multi_pack_unpack_subsystem_list(bool write, ubyte* data, SCP_vector<ubyte>* flags, SCP_vector<float>* subsys_data)
 {
 
 	bitbuffer buf;
@@ -3896,7 +3897,7 @@ ubyte multi_pack_unpack_subsystem_list(bool write, ubyte* data, SCP_vector<ubyte
 			// reset skipping rotation flag
 			done = false;
 		}
-		return (ubyte)bitbuffer_write_flush(&buf);
+		return bitbuffer_write_flush(&buf);
 	}
 	else {
 	Assertion(flags->empty(), "The flags vector was not empty before being sent to multi_pack_unpack_subsystem_list. This is a coder mistake, please report!");
@@ -3982,7 +3983,7 @@ ubyte multi_pack_unpack_subsystem_list(bool write, ubyte* data, SCP_vector<ubyte
 			a = bitbuffer_get_unsigned(&buf, 1);
 		} while (a == SUBSYSTEM_PACKER_TRUE);
 		
-		return (ubyte)bitbuffer_read_flush(&buf);
+		return bitbuffer_read_flush(&buf);
 	}
 }
 

--- a/code/network/multiutil.h
+++ b/code/network/multiutil.h
@@ -28,11 +28,12 @@ struct server_item;
 class ship_info;
 class p_object;
 
-// two types of signatures that we can request,  permanent signatures are all below 1000.  non-permanent are above 1000
+// two types of signatures that we can request,  permanent signatures are all below 5000.  non-permanent are above 5000
 #define MULTI_SIG_SHIP					1
 #define MULTI_SIG_ASTEROID				2
 #define MULTI_SIG_NON_PERMANENT		3
 #define MULTI_SIG_DEBRIS				4
+#define MULTI_SIG_WAYPOINT				5				// Added for dynamic waypoints in multiplayer missions
 
 extern ushort multi_assign_network_signature( int what_kind );
 extern ushort multi_get_next_network_signature( int what_kind );
@@ -185,33 +186,25 @@ void multi_get_mission_checksum(const char *filename);
 
 // Packs/unpacks an object position.
 // Returns number of bytes read or written.
-#define OO_POS_RET_SIZE							9
 int multi_pack_unpack_position(int write, ubyte *data, vec3d *pos);
 
 // Packs/unpacks an orientation matrix.
 // Returns number of bytes read or written.
-#define OO_ORIENT_RET_SIZE						6
-int multi_pack_unpack_orient(int write, ubyte *data, matrix *orient);
+int multi_pack_unpack_orient(int write, ubyte *data, angles *angles_out);
 
 // Packs/unpacks velocity
 // Returns number of bytes read or written.
-#define OO_VEL_RET_SIZE							4
-int multi_pack_unpack_vel(int write, ubyte *data, matrix *orient, vec3d *pos, physics_info *pi);
-
-// Packs/unpacks desired_velocity
-// Returns number of bytes read or written.
-#define OO_DESIRED_VEL_RET_SIZE				3
-int multi_pack_unpack_desired_vel(int write, ubyte *data, matrix *orient, vec3d *pos, physics_info *pi, ship_info *sip);
+int multi_pack_unpack_vel(int write, ubyte *data, matrix *orient, physics_info *pi);
 
 // Packs/unpacks rotational velocity
 // Returns number of bytes read or written.
-#define OO_ROTVEL_RET_SIZE						4
-int multi_pack_unpack_rotvel(int write, ubyte *data, matrix *orient, vec3d *pos, physics_info *pi);
+int multi_pack_unpack_rotvel(int write, ubyte *data, physics_info *pi);
 
-// Packs/unpacks desired rotvel
-// Returns number of bytes read or written.
-#define OO_DESIRED_ROTVEL_RET_SIZE			3
-int multi_pack_unpack_desired_rotvel(int write, ubyte *data, matrix *orient, vec3d *pos, physics_info *pi, ship_info *sip);
+// Cyborg17 - Packs/unpacks desired velocity and rotational velocity.
+ubyte multi_pack_unpack_desired_vel_and_desired_rotvel(int write, bool full_physics, ubyte* data, physics_info* pi, vec3d* local_desired_vel);
+
+// Cyborg17 - Compresses the list of subsystems, so that we don't have to mark each one with a ubyte
+ubyte multi_pack_unpack_subsystem_list(bool write, ubyte* data, SCP_vector<ubyte>* flags, SCP_vector<float>* subsys_data);
 
 char multi_unit_to_char(float unit);
 float multi_char_to_unit(float val);

--- a/code/network/multiutil.h
+++ b/code/network/multiutil.h
@@ -201,10 +201,10 @@ int multi_pack_unpack_vel(int write, ubyte *data, matrix *orient, physics_info *
 int multi_pack_unpack_rotvel(int write, ubyte *data, physics_info *pi);
 
 // Cyborg17 - Packs/unpacks desired velocity and rotational velocity.
-ubyte multi_pack_unpack_desired_vel_and_desired_rotvel(int write, bool full_physics, ubyte* data, physics_info* pi, vec3d* local_desired_vel);
+int multi_pack_unpack_desired_vel_and_desired_rotvel(int write, bool full_physics, ubyte* data, physics_info* pi, vec3d* local_desired_vel);
 
 // Cyborg17 - Compresses the list of subsystems, so that we don't have to mark each one with a ubyte
-ubyte multi_pack_unpack_subsystem_list(bool write, ubyte* data, SCP_vector<ubyte>* flags, SCP_vector<float>* subsys_data);
+int multi_pack_unpack_subsystem_list(bool write, ubyte* data, SCP_vector<ubyte>* flags, SCP_vector<float>* subsys_data);
 
 char multi_unit_to_char(float unit);
 float multi_char_to_unit(float val);

--- a/code/object/waypoint.cpp
+++ b/code/object/waypoint.cpp
@@ -4,6 +4,7 @@
 #include "globalincs/linklist.h"
 #include "object/object.h"
 #include "object/waypoint.h"
+#include "network/multiutil.h"
 
 //********************GLOBALS********************
 SCP_list<waypoint_list> Waypoint_lists;
@@ -142,6 +143,7 @@ void waypoint_create_game_object(waypoint *wpt, int list_index, int wpt_index)
     flagset<Object::Object_Flags> default_flags;
     default_flags.set(Object::Object_Flags::Renders);
 	wpt->objnum = obj_create(OBJ_WAYPOINT, -1, calc_waypoint_instance(list_index, wpt_index), NULL, wpt->get_pos(), 0.0f, default_flags);
+	Objects[wpt->objnum].net_signature = multi_assign_network_signature(MULTI_SIG_WAYPOINT);
 }
 
 // done immediately after mission load; originally found in aicode.cpp

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -6153,16 +6153,6 @@ void ship::clear()
 	level2_tag_total = 0.0f;
 	level2_tag_left = -1.0f;
 
-	for (i = 0; i < MAX_PLAYERS; i++ )
-	{
-		np_updates[i].seq = 0;
-		np_updates[i].update_stamp = -1;
-		np_updates[i].status_update_stamp = -1;
-		np_updates[i].subsys_update_stamp = -1;
-		np_updates[i].pos_chksum = 0;
-		np_updates[i].orient_chksum = 0;
-	}
-
 	lightning_stamp = timestamp(-1);
 
 	// set awacs warning flags so awacs ship only asks for help once at each level
@@ -6367,11 +6357,6 @@ static void ship_set(int ship_index, int objnum, int ship_type)
 	ship_info	*sip = &(Ship_info[ship_type]);
 	ship_weapon	*swp = &shipp->weapons;
 	polymodel *pm = model_get(sip->model_num);
-
-	extern int oo_arrive_time_count[MAX_SHIPS];		
-	extern int oo_interp_count[MAX_SHIPS];	
-	oo_arrive_time_count[shipp - Ships] = 0;
-	oo_interp_count[shipp - Ships] = 0;
 
 	Assert(strlen(shipp->ship_name) <= NAME_LENGTH - 1);
 	shipp->ship_info_index = ship_type;

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -657,9 +657,6 @@ public:
 	float level2_tag_total;							// total tag time
 	float level2_tag_left;							// total tag remaining	
 
-	// old-style object update stuff
-	np_update		np_updates[MAX_PLAYERS];	// for both server and client
-
 	// lightning timestamp
 	int lightning_stamp;
 

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -947,6 +947,7 @@ void game_level_init()
 	NavSystem_Init();				// zero out the nav system
 
 	ai_level_init();				//	Call this before ship_init() because it reads ai.tbl.
+	multi_init_oo_and_ship_tracker();	// Inits/resets multiplayer ship tracking system.  Has to be done before creating any ships.
 	ship_level_init();
 	player_level_init();
 	shipfx_flash_init();			// Init the ship gun flash system.
@@ -5648,11 +5649,6 @@ void mouse_force_pos(int x, int y);
 			// when coming from the multi paused state, reset the timestamps
 			if ( (Game_mode & GM_MULTIPLAYER) && (old_state == GS_STATE_MULTI_PAUSED) ){
 				multi_reset_timestamps();
-			}
-
-			if ((Game_mode & GM_MULTIPLAYER) && (old_state != GS_STATE_DEATH_BLEW_UP) ) {
-				// initialize all object update details
-				multi_oo_gameplay_init();
 			}
 	
 			// under certain circumstances, the server should reset the object update rate limiting stuff


### PR DESCRIPTION
All right, the second big change.  This basically reworks nearly every part of the object update packet.  I may not have touched the support ship section, but that may be it.

**Things that need to be finished before merging:**
~~1. Need better handling for AI because their movement is literally in another physics system as discovered by @Baezon .~~ Decided that this isn't strictly needed.  The "issue" is that there is minor forward and back jittering of only AI controlled craft. But it's so small that accuracy is not affected.  I will just spend the time writing the lua packet, instead.
~~2. Bug on standalones.  Crash occurs if waypoints are in use.  Cause not yet discovered.~~
~~3. Need to abort adding information to the packet and fix flags once the packet is filled.~~ 

**This upgrade:**
1. Keeps the object update packet aligned, even if the ship is dying or has not yet arrived on the client.
2. Properly handles model point shields (yes, that's what was causing multi to crash the most!)
3. Reworks positional interpolation timing and adds rotational interpolation.
 -- note timing information is now sent with every object update packet.
4. Saves a lot of bandwidth by only sending data that is changing. (no more sending all subsystems once per second!)
5. Better handles out of order packets (but can still use their information if recent enough!)
6. Builds the basis for Rollback by beginning to record the positions and orientations and velocities of ships for the last 30 frames.
7. Adds subsystem rotation -- Yeah, you saw that right, subsystems will now spin in multi.
8. Waypoint movement is now enabled via sexp, and time to arrival of waypoints is updated on the target info gauge.

**Things to keep in mind:**
I was pretty inexperienced when I started this, even as I made progress and fixed bugs, I reworked the structs that keep track of this a lot, trying to make them as understandable as possible.  But I'm open to suggestions, even though a lot of work has already been done.

**Here's an edited version of what I sent to Taylor to help explain in more detail:**

So the object update upgrade separates the Hull and Shields section, and adds a timestamp section as a header to the whole packet, not each individual ship's update. It also upgrades the rest of the packet sections.  `Seq_num` now an int, is also moved to that header and has been changed from an arbitrary number to the actual frame on the other computer as tracked by the Oo_info struct.  This allows FSO to figure out more certainly (but still approximately) how much time has elapsed on another computer, improving interpolation and adding a basis for the rollback feature.

All of these sections now check to see if the information has been sent already before sending it, and the receiving side will filter out that section's information if a newer packet already provided information from that section by storing that same sequence number when it uses new information.

The Hull section is basically the same, the shields section is basically the same, except that this section is skipped if attempting to bash the info would cause a crash (the ship is already dying, departing or possibly just arriving).  These crashes were introduced with the model point shields feature that made the number of shield sections dynamic.

Didn't change the afterburner flag.

Subsystem section has a big change. It was taking up a tremendous amount of space sending all of the subsystems, especially for larger ships, as it sent them once a second.  It keeps track of them in the Oo_info struct. Again, this section has to be skipped if the ship is arriving departing or dying. It is put through a compression function which does list every subsystem with a "does/does not" have updated info flag, but each subsystem that does not have updated info only takes up one bit.  Also if no subsystems have updated info, it will not send any subsystem info.

The big, big changes are with the position and orientation.  It now just sends everything whenever the ship is moving. Pos, velocity, desired velocity, orientation, rotational velocity, desired rotational velocity.

_Desired rotational velocity is *not* sent for ai._

All of the information is compressed in some way. If they were compressed before, their compression was more than likely adjusted. The biggest bandwidth saver here is sending angles for the orientation instead of the whole matrix (or at least part of it).  The angles are just derived from the orientation matrix before and the converted back to a matrix after.

