### PR TITLE
Fix multi crash when ship has less than two primary weapons

### DIFF
--- a/code/network/multimsgs.cpp
+++ b/code/network/multimsgs.cpp
@@ -6061,10 +6061,10 @@ void process_post_sync_data_packet(ubyte *data, header *hinfo)
 
 			// primary weapon info
 		GET_DATA(val);
-		shipp->weapons.primary_bank_weapons[0] = (int)val;
+		shipp->weapons.primary_bank_weapons[0] = ((val == 255) ? -1 : static_cast<int>(val));
 
 		GET_DATA(val);
-		shipp->weapons.primary_bank_weapons[1] = (int)val;
+		shipp->weapons.primary_bank_weapons[1] = ((val == 255) ? -1 : static_cast<int>(val));
 
 		// secondary weapon info
 		GET_SHORT(val_short);


### PR DESCRIPTION
If a ship has less than two primary weapons the client will set the primary weapon type to 255 instead of -1 due to the data type.

A proper fix for this bug is already included in the multi_packet_fixes PR which allows for more than 255 weapon types for primaries.