### PR TITLE
Give Lua libRockets documents their own environment

### DIFF
--- a/cmake/toolchain-gcc.cmake
+++ b/cmake/toolchain-gcc.cmake
@@ -9,6 +9,7 @@ option(GCC_ENABLE_LEAK_CHECK "Enable -fsanitize=leak" OFF)
 option(GCC_ENABLE_ADDRESS_SANITIZER "Enable -fsanitize=address" OFF)
 option(GCC_ENABLE_SANITIZE_UNDEFINED "Enable -fsanitize=undefined" OFF)
 option(GCC_USE_GOLD "Use the gold linker instead of the standard linker" OFF)
+option(GCC_GENERATE_GDB_INDEX "Adds linker option to generate the gdb index for debug builds" OFF)
 
 # These are the default values
 set(C_BASE_FLAGS "-march=native -pipe")
@@ -134,6 +135,12 @@ endif()
 
 set(CMAKE_EXE_LINKER_FLAGS_RELEASE "")
 set(CMAKE_EXE_LINKER_FLAGS_DEBUG "-g")
+
+if (GCC_GENERATE_GDB_INDEX)
+	# For pure debug binaries, generate a gdb index for better debugging
+	SET(CMAKE_EXE_LINKER_FLAGS_DEBUG "${CMAKE_EXE_LINKER_FLAGS_DEBUG} -Wl,--gdb-index")
+endif()
+
 IF(NOT MINGW)
 	SET(CMAKE_EXE_LINKER_FLAGS_DEBUG "${CMAKE_EXE_LINKER_FLAGS_DEBUG} -rdynamic")
 	# Allow the linker to perform dead code elimination; this is considered

--- a/code/scpui/RocketLuaSystemInterface.cpp
+++ b/code/scpui/RocketLuaSystemInterface.cpp
@@ -1,0 +1,93 @@
+
+#include "RocketLuaSystemInterface.h"
+
+#include "scripting/lua/LuaTable.h"
+
+#include <Rocket/Core/ElementDocument.h>
+#include <Rocket/Core/ValueReference.h>
+
+namespace scpui {
+
+namespace {
+
+const char* LuaEnvironmentIdentifier = "document_lua_environment";
+
+class LuaTableReference : public Rocket::Core::ValueReference {
+  public:
+	LuaTableReference(const luacpp::LuaTable& envtable) : _envtable(envtable) {}
+	~LuaTableReference() override = default;
+
+	const luacpp::LuaTable& getEnvTable() const
+	{
+		return _envtable;
+	}
+
+  private:
+	luacpp::LuaTable _envtable;
+};
+
+luacpp::LuaTable createEnvironment(lua_State* L)
+{
+	// local env = {}
+	auto env = luacpp::LuaTable::create(L);
+
+	// local metatable = {}
+	auto metatable = luacpp::LuaTable::create(L);
+
+	// metatable.__index = _G (non-local lookups go to the global table)
+	metatable.pushValue(L);
+	lua_getfield(L, LUA_GLOBALSINDEX, "_G");
+	lua_setfield(L, -2, "__index");
+
+	lua_pop(L, 1);
+
+	// Use that simply metatable for the environment
+	env.setMetatable(metatable);
+
+	return env;
+}
+
+} // namespace
+
+RocketLuaSystemInterface::RocketLuaSystemInterface() = default;
+RocketLuaSystemInterface::~RocketLuaSystemInterface() = default;
+void RocketLuaSystemInterface::PrepareFunction(lua_State* L, int funcIdx, Rocket::Core::Element* context)
+{
+	if (context == nullptr) {
+		// Nothing we can do in this case
+		return;
+	}
+
+	// To ensure consistent stack indices even for relative funcIdx values
+	auto top = lua_gettop(L);
+	lua_pushvalue(L, funcIdx);
+
+	auto envTable =
+		static_cast<LuaTableReference*>(context->GetOwnerDocument()->GetUserValue(LuaEnvironmentIdentifier));
+
+	if (envTable == nullptr) {
+		auto reference = std::unique_ptr<LuaTableReference>(new LuaTableReference(createEnvironment(L)));
+		envTable = reference.get();
+
+		context->GetOwnerDocument()->PutUserValue(LuaEnvironmentIdentifier, std::move(reference));
+	}
+
+	// Set the table as the environment of the function
+	envTable->getEnvTable().pushValue(L);
+	lua_setfenv(L, -2);
+
+	lua_settop(L, top);
+}
+void RocketLuaSystemInterface::ReportError(lua_State* L, const Rocket::Core::String& location)
+{
+	if (!location.Empty()) {
+		LuaError(L, "Location: %s", location.CString());
+	} else {
+		LuaError(L);
+	}
+}
+int RocketLuaSystemInterface::ErrorHandler(lua_State* L) {
+	return scripting::ade_friendly_error(L);
+}
+
+} // namespace scpui

--- a/code/scpui/RocketLuaSystemInterface.h
+++ b/code/scpui/RocketLuaSystemInterface.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "globalincs/pstypes.h"
+
+// Our Assert conflicts with the definitions inside libRocket
+#pragma push_macro("Assert")
+#undef Assert
+
+#include <Rocket/Core/Element.h>
+#include <Rocket/Core/Lua/LuaSystemInterface.h>
+
+#pragma pop_macro("Assert")
+
+namespace scpui {
+
+class RocketLuaSystemInterface : public Rocket::Core::Lua::LuaSystemInterface {
+  public:
+	RocketLuaSystemInterface();
+	~RocketLuaSystemInterface() override;
+
+	void PrepareFunction(lua_State* L, int funcIdx, Rocket::Core::Element* context) override;
+
+	void ReportError(lua_State* L, const Rocket::Core::String& location) override;
+
+	int ErrorHandler(lua_State* L) override;
+};
+
+} // namespace scpui

--- a/code/scpui/rocket_ui.cpp
+++ b/code/scpui/rocket_ui.cpp
@@ -17,6 +17,7 @@
 #include "osapi/osapi.h"
 #include "scpui/IncludeNodeHandler.h"
 #include "scpui/RocketFileInterface.h"
+#include "scpui/RocketLuaSystemInterface.h"
 #include "scpui/RocketRenderingInterface.h"
 #include "scpui/RocketSystemInterface.h"
 #include "scpui/SoundPlugin.h"
@@ -552,7 +553,8 @@ void initialize()
 	}
 
 	// Initialise the Lua interface
-	Rocket::Core::Lua::Interpreter::Initialise(Script_system.GetLuaSession());
+	Rocket::Core::Lua::Interpreter::Initialise(Script_system.GetLuaSession(),
+		std::unique_ptr<Rocket::Core::Lua::LuaSystemInterface>(new RocketLuaSystemInterface()));
 	Rocket::Controls::Lua::RegisterTypes(Rocket::Core::Lua::Interpreter::GetLuaState());
 
 	load_fonts();

--- a/code/source_groups.cmake
+++ b/code/source_groups.cmake
@@ -1060,6 +1060,8 @@ add_file_folder("ScpUi"
 	scpui/rocket_ui.h
 	scpui/RocketFileInterface.cpp
 	scpui/RocketFileInterface.h
+	scpui/RocketLuaSystemInterface.cpp
+	scpui/RocketLuaSystemInterface.h
 	scpui/RocketRenderingInterface.cpp
 	scpui/RocketRenderingInterface.h
 	scpui/RocketSystemInterface.cpp


### PR DESCRIPTION
This gives every document their own environment instead of using the
global environment. Previously it was necessary to store variables in
the global namespace since otherwise they could not be accessed by event
listeners.

This creates a separate environment table for every document so that all
<script> blocks and event handlers share the same "global" environment.