### PR TITLE
optimze memory usage by weapon loadout

### DIFF
--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -1869,11 +1869,13 @@ bool ship_info::has_display_name()
 	return flags[Ship::Info_Flags::Has_display_name];
 }
 
-const ubyte allowed_weapon_bank::find_flags(int weapon_info_index) const
+ubyte allowed_weapon_bank::find_flags(int weapon_info_index) const
 {
 	for (auto &wf : weapon_and_flags)
 		if (wf.first == weapon_info_index)
 			return wf.second;
+
+	// since we can return 0 here, we can't make the return type 'const ubyte &'
 	return 0;
 }
 
@@ -1887,6 +1889,7 @@ void allowed_weapon_bank::set_flag(int weapon_info_index, ubyte flag)
 			return;
 		}
 	}
+
 	// if we couldn't find it, add a new entry with that flag
 	weapon_and_flags.emplace_back(weapon_info_index, flag);
 }
@@ -1921,11 +1924,11 @@ void allowed_weapon_bank::clear()
 
 // read-only!
 // (because we don't want to fill up our member vector with a bunch of zeros)
-const ubyte allowed_weapon_bank::operator[](int index) const
+ubyte allowed_weapon_bank::operator[](int index) const
 {
 	return find_flags(index);
 }
-const ubyte allowed_weapon_bank::operator[](size_t index) const
+ubyte allowed_weapon_bank::operator[](size_t index) const
 {
 	return find_flags(static_cast<int>(index));
 }

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -1002,6 +1002,22 @@ typedef struct path_metadata {
 	float depart_speed_mult;
 } path_metadata;
 
+class allowed_weapon_bank
+{
+public:
+	SCP_vector<std::pair<int, ubyte>> weapon_and_flags;
+
+	const ubyte find_flags(int weapon_info_index) const;
+	void set_flag(int weapon_info_index, ubyte flag);
+	void clear_flag(int weapon_info_index, ubyte flag);
+	void clear_flag(ubyte flag);
+
+	void clear();
+
+	const ubyte operator[](int index) const;
+	const ubyte operator[](size_t index) const;
+};
+
 // The real FreeSpace ship_info struct.
 // NOTE: Can't be treated as a struct anymore, since it has STL data structures in its object tree!
 class ship_info
@@ -1169,12 +1185,12 @@ public:
 	vec3d	closeup_pos_targetbox;			// position for camera when using ship in closeup view for hud target monitor
 	float	closeup_zoom_targetbox;			// zoom when using ship in closeup view for hud target monitor
 
-	int		allowed_weapons[MAX_WEAPON_TYPES];	// array which specifies which weapons can be loaded out by the
-												// player during weapons loadout.
+	allowed_weapon_bank allowed_weapons;	// specifies which weapons can be loaded out by the
+											// player during weapons loadout.
 
 	// Goober5000 - fix for restricted banks mod
-	int restricted_loadout_flag[MAX_SHIP_WEAPONS];
-	int allowed_bank_restricted_weapons[MAX_SHIP_WEAPONS][MAX_WEAPON_TYPES];
+	SCP_vector<ubyte> restricted_loadout_flag;
+	SCP_vector<allowed_weapon_bank> allowed_bank_restricted_weapons;
 
 	ubyte	shield_icon_index;				// index to locate ship-specific animation frames for the shield on HUD
 	char	icon_filename[MAX_FILENAME_LEN];	// filename for icon that is displayed in ship selection

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -1007,15 +1007,15 @@ class allowed_weapon_bank
 public:
 	SCP_vector<std::pair<int, ubyte>> weapon_and_flags;
 
-	const ubyte find_flags(int weapon_info_index) const;
+	ubyte find_flags(int weapon_info_index) const;
 	void set_flag(int weapon_info_index, ubyte flag);
 	void clear_flag(int weapon_info_index, ubyte flag);
 	void clear_flag(ubyte flag);
 
 	void clear();
 
-	const ubyte operator[](int index) const;
-	const ubyte operator[](size_t index) const;
+	ubyte operator[](int index) const;
+	ubyte operator[](size_t index) const;
 };
 
 // The real FreeSpace ship_info struct.


### PR DESCRIPTION
The weapon loadout arrays wasted a ton of memory in several ways.  First, only friendly fighters and bombers have weapon loadouts; most ship classes do not need this storage.  Second, as DahBlount noticed, only 8 bits are needed for the flags, while the fields were using standard 32-bit ints.  Third, there are currently 500 weapon types but most loadouts only provide a dozen or so options.

This refactors the loadout storage to keep a short vector of weapon-flag pairs for each bank, and the bank storage is allocated only when needed.  The new `allowed_weapon_bank` class provides `operator[]` implementations so that the new API is almost completely compatible with the old one.  The only things that require the new API are assignments, since `operator[]` is read-only.  (A writable `operator[]` would not be able to tell when a flag value of 0 should be stored or not.)