### PR TITLE
Improve Homeworld warp effect

### DIFF
--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -17559,7 +17559,8 @@ float ship_get_warpout_speed(object *objp, ship_info *sip, float half_length, fl
 	WarpParams *params = &Warp_params[Ships[objp->instance].warpout_params_index];
 
 	//WMC - Any speed is good for in place anims (aka BSG FTL effect)
-	if (params->warp_type == WT_IN_PLACE_ANIM && params->speed <= 0.0f)
+	//Asteroth - or for the sweeper (aka Homeworld FTL effect)
+	if ((params->warp_type == WT_IN_PLACE_ANIM || params->warp_type == WT_SWEEPER) && params->speed <= 0.0f)
 	{
 		return objp->phys_info.speed;
 	}

--- a/code/ship/shipfx.cpp
+++ b/code/ship/shipfx.cpp
@@ -3950,7 +3950,7 @@ WE_Homeworld::WE_Homeworld(object *n_objp, WarpDirection n_direction)
 	//Configure stage duration 3
 	stage_duration[3] = params->time - (stage_duration[1] + stage_duration[2] + stage_duration[4] + stage_duration[5]);
 	if (stage_duration[3] <= 0)
-		stage_duration[3] = 2400; // set for a 8 second total time
+		stage_duration[3] = 3400; // set for a 9 second total time
 
 	//Anim
 	anim = bm_load_either(params->anim, &anim_nframes, &anim_fps, nullptr, true);

--- a/code/ship/shipfx.cpp
+++ b/code/ship/shipfx.cpp
@@ -4196,7 +4196,7 @@ int WE_Homeworld::getWarpOrientation(matrix* output)
         return 0;
     }
 
-    vm_vector_2_matrix(output, &fvec, NULL, NULL);
+	*output = objp->orient;
     return 1;
 }
 

--- a/code/ship/shipfx.cpp
+++ b/code/ship/shipfx.cpp
@@ -3928,7 +3928,7 @@ int WE_BSG::getWarpOrientation(matrix* output)
 }
 
 //********************-----CLASS: WE_Homeworld-----********************//
-#define HOMEWORLD_SWEEPER_LINE_THICKNESS 0.002f // How tall the initial and final hyperspace "lines" are, factor of height
+const float HOMEWORLD_SWEEPER_LINE_THICKNESS = 0.002f; // How tall the initial and final hyperspace "lines" are, as a factor of height
 WE_Homeworld::WE_Homeworld(object *n_objp, WarpDirection n_direction)
 	:WarpEffect(n_objp, n_direction)
 {
@@ -4124,7 +4124,7 @@ int WE_Homeworld::warpFrame(float  /*frametime*/)
 			height = (height_full * visual_progress) + height_full * HOMEWORLD_SWEEPER_LINE_THICKNESS;
 			break;
 		case 3:
-			sweeper_z_position = z_offset_max - progress * (z_offset_max - z_offset_min);
+			sweeper_z_position = z_offset_max - adjusted_progress * (z_offset_max - z_offset_min);
 			break;
 		case 4:
 			sweeper_z_position = z_offset_min;


### PR DESCRIPTION
This PR might be a bit confusing if you aren't familiar with the games, but several changes were made:

Stages were added (or more accurately, unused stages were actually used) at the very beginning and end of the effect, for when the "sweeper" is a line and gaining/shrinking in width before/after gaining/shrinking in height.

The first and final two stages when the sweeper is changing size were adjusted to move more smoothly to follow the canonical motion of the effect, as well as timings adjusted.

Allow the sweeper to follow the position of the ship at all stages.

And add the sweeper-type warp to the exclusions from requiring a specific speed before the warp may commence (if a speed was not manually specified). Canonically, Homeworld ships were shown warping regardless of their speed.

EDIT:
Attached is a before and after video of the effect.
[HWwarp.zip](https://github.com/scp-fs2open/fs2open.github.com/files/5265657/HWwarp.zip)

~~Thrusters render on the wrong side of the sweeper when warping out, but this is the second time I've encountered a sign error regarding the warp clip plane, so I'm going to go through and check every place where it is used and have it be a separate PR.~~
EDITEDIT: The solution was simple (in general the warp's orient always follow the ship's orient), turned out to be not related to other similar issues, and doesn't break anything else.