### PR TITLE
Expose Weapons SS Damage Threshold for Turret Inaccuracy

### DIFF
--- a/code/ai/aiturret.cpp
+++ b/code/ai/aiturret.cpp
@@ -1425,7 +1425,7 @@ int aifft_rotate_turret(ship *shipp, int parent_objnum, ship_subsys *ss, object 
 		set_predicted_enemy_pos_turret(predicted_enemy_pos, &gun_pos, objp, &enemy_point, &target_moving_direction, wip->max_speed, ss->turret_time_enemy_in_range * (weapon_system_strength + 1.0f)/2.0f);
 
 		//Mess with the turret's accuracy if the weapon system is damaged.
-		if (weapon_system_strength < 0.7f) {
+		if (weapon_system_strength < Weapon_SS_Threshold_Turret_Inaccuracy) {
 			vec3d	rand_vec;
 
 			static_randvec(Missiontime >> 18, &rand_vec);	//	Return same random number for two seconds.

--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -62,6 +62,7 @@ bool Use_engine_wash_intensity;
 bool Ai_before_physics;
 bool Swarmers_lead_targets;
 SCP_vector<gr_capability> Required_render_ext;
+float Weapon_SS_Threshold_Turret_Inaccuracy;
 
 SCP_vector<std::pair<SCP_string, gr_capability>> req_render_ext_pairs = {
 	std::make_pair("BPTC Texture Compression", CAPABILITY_BPTC)
@@ -556,6 +557,16 @@ void parse_mod_table(const char *filename)
 			stuff_boolean(&Swarmers_lead_targets);
 		}
 
+		if (optional_string("$Damage Threshold for Weapons Subsystems to Trigger Turret Inaccuracy:")) {
+			float weapon_ss_threshold;
+			stuff_float(&weapon_ss_threshold);
+			if (0.0f <= weapon_ss_threshold <= 1.0f) {
+				Weapon_SS_Threshold_Turret_Inaccuracy = weapon_ss_threshold;
+			} else {
+				mprintf(("Game Settings Table: '$Damage Threshold for Weapons Subsystems to Trigger Turret Inaccuracy:' value of %.6f is not between 0 and 1. Using default value of 0.70.\n", weapon_ss_threshold));
+			}
+		}
+
 		required_string("#END");
 	}
 	catch (const parse::ParseException& e)
@@ -633,4 +644,5 @@ void mod_table_reset()
   Ai_before_physics = false;
 	Swarmers_lead_targets = false;
 	Required_render_ext.clear();
+	Weapon_SS_Threshold_Turret_Inaccuracy = 0.7; // Defaults to retail value of 0.7 --wookieejedi
 }

--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -560,7 +560,7 @@ void parse_mod_table(const char *filename)
 		if (optional_string("$Damage Threshold for Weapons Subsystems to Trigger Turret Inaccuracy:")) {
 			float weapon_ss_threshold;
 			stuff_float(&weapon_ss_threshold);
-			if (0.0f <= weapon_ss_threshold <= 1.0f) {
+			if ( (weapon_ss_threshold >= 0.0f) && (weapon_ss_threshold <= 1.0f) ) {
 				Weapon_SS_Threshold_Turret_Inaccuracy = weapon_ss_threshold;
 			} else {
 				mprintf(("Game Settings Table: '$Damage Threshold for Weapons Subsystems to Trigger Turret Inaccuracy:' value of %.6f is not between 0 and 1. Using default value of 0.70.\n", weapon_ss_threshold));

--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -644,5 +644,5 @@ void mod_table_reset()
   Ai_before_physics = false;
 	Swarmers_lead_targets = false;
 	Required_render_ext.clear();
-	Weapon_SS_Threshold_Turret_Inaccuracy = 0.7; // Defaults to retail value of 0.7 --wookieejedi
+	Weapon_SS_Threshold_Turret_Inaccuracy = 0.7f; // Defaults to retail value of 0.7 --wookieejedi
 }

--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -563,7 +563,7 @@ void parse_mod_table(const char *filename)
 			if ( (weapon_ss_threshold >= 0.0f) && (weapon_ss_threshold <= 1.0f) ) {
 				Weapon_SS_Threshold_Turret_Inaccuracy = weapon_ss_threshold;
 			} else {
-				mprintf(("Game Settings Table: '$Damage Threshold for Weapons Subsystems to Trigger Turret Inaccuracy:' value of %.6f is not between 0 and 1. Using default value of 0.70.\n", weapon_ss_threshold));
+				mprintf(("Game Settings Table: '$Damage Threshold for Weapons Subsystems to Trigger Turret Inaccuracy:' value of %.2f is not between 0 and 1. Using default value of 0.70.\n", weapon_ss_threshold));
 			}
 		}
 

--- a/code/mod_table/mod_table.h
+++ b/code/mod_table/mod_table.h
@@ -54,6 +54,7 @@ extern bool Use_engine_wash_intensity;
 extern bool Ai_before_physics;
 extern bool Swarmers_lead_targets;
 extern SCP_vector<gr_capability> Required_render_ext;
+extern float Weapon_SS_Threshold_Turret_Inaccuracy;
 
 void mod_table_init();
 


### PR DESCRIPTION
This PR adds a table entry that allows modders to specify the damage threshold for when turrets become less accurate due to weapon subsystem damage. A Game table setting is easier to set once and tune, thus this PR allows that efficient exposure to the modder and does not require a large change or complex table entry.