### PR TITLE
make the scripted turret firing code a bit more robust

### DIFF
--- a/code/scripting/api/objs/subsystem.cpp
+++ b/code/scripting/api/objs/subsystem.cpp
@@ -593,6 +593,12 @@ ADE_FUNC(fireWeapon, l_Subsystem, "[number TurretWeaponIndex = 1, number FlakRan
 	if (!sso->isSubsystemValid())
 		return ADE_RETURN_NIL;
 
+	// no place to fire a weapon; this may not actually be a turret
+	if (sso->ss->system_info->turret_num_firing_points <= 0)
+	{
+		return ADE_RETURN_NIL;
+	}
+
 	if (sso->ss->current_hits <= 0)
 	{
 		return ADE_RETURN_FALSE;


### PR DESCRIPTION
The scripted code previously didn't check to see if a weapon bank was valid before firing it, which could have led to memory problems and starting March 15 would actually crash the game.  This adds a few safety checks.