### PR TITLE
Suppress muzzle flashes from the player (and add a flag to re-enable it)

### DIFF
--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -63,6 +63,7 @@ bool Framerate_independent_turning; // an in-depth explanation how this flag is 
 bool Swarmers_lead_targets;
 SCP_vector<gr_capability> Required_render_ext;
 float Weapon_SS_Threshold_Turret_Inaccuracy;
+bool Render_player_mflash;
 
 SCP_vector<std::pair<SCP_string, gr_capability>> req_render_ext_pairs = {
 	std::make_pair("BPTC Texture Compression", CAPABILITY_BPTC)
@@ -372,6 +373,10 @@ void parse_mod_table(const char *filename)
 			}
 		}
 
+		if (optional_string("$Render player muzzle flashes in cockpit:")) {
+			stuff_boolean(&Render_player_mflash);
+		}
+
 		optional_string("#NETWORK SETTINGS");
 
 		if (optional_string("$FS2NetD port:")) {
@@ -645,4 +650,5 @@ void mod_table_reset()
 	Swarmers_lead_targets = false;
 	Required_render_ext.clear();
 	Weapon_SS_Threshold_Turret_Inaccuracy = 0.7f; // Defaults to retail value of 0.7 --wookieejedi
+	Render_player_mflash = false;
 }

--- a/code/mod_table/mod_table.h
+++ b/code/mod_table/mod_table.h
@@ -55,6 +55,7 @@ extern bool Swarmers_lead_targets;
 extern SCP_vector<gr_capability> Required_render_ext;
 extern float Weapon_SS_Threshold_Turret_Inaccuracy;
 extern bool Framerate_independent_turning;
+extern bool Render_player_mflash;
 
 void mod_table_init();
 

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -11674,10 +11674,7 @@ int ship_fire_primary(object * obj, int stream_weapons, int force)
 								}
 							}
 							// create the muzzle flash effect
-							if ( (obj != Player_obj) || (sip->flags[Ship::Info_Flags::Show_ship_model]) || (Viewer_mode) ) {
-								// show the flash only if in not cockpit view, or if "show ship" flag is set
-								shipfx_flash_create( obj, sip->model_num, &pnt, &obj->orient.vec.fvec, 1, weapon_idx );
-							}
+							shipfx_flash_create( obj, sip->model_num, &pnt, &obj->orient.vec.fvec, 1, weapon_idx );
 
 							// maybe shudder the ship - if its me
 							if((winfo_p->wi_flags[Weapon::Info_Flags::Shudder]) && (obj == Player_obj) && !(Game_mode & GM_STANDALONE_SERVER)){
@@ -12416,10 +12413,7 @@ int ship_fire_secondary( object *obj, int allow_swarm )
 				has_fired = true;
 
 				// create the muzzle flash effect
-				if ( (obj != Player_obj) || (sip->flags[Ship::Info_Flags::Show_ship_model]) || (Viewer_mode) ) {
-					// show the flash only if in not cockpit view, or if "show ship" flag is set
-					shipfx_flash_create(obj, sip->model_num, &pnt, &obj->orient.vec.fvec, 0, weapon_idx);
-				}
+				shipfx_flash_create(obj, sip->model_num, &pnt, &obj->orient.vec.fvec, 0, weapon_idx);
 
 				if((wip->wi_flags[Weapon::Info_Flags::Shudder]) && (obj == Player_obj) && !(Game_mode & GM_STANDALONE_SERVER)){
 					// calculate some arbitrary value between 100

--- a/code/ship/shipfx.cpp
+++ b/code/ship/shipfx.cpp
@@ -1007,7 +1007,11 @@ void shipfx_flash_create(object *objp, int model_num, vec3d *gun_pos, vec3d *gun
 	// ALWAYS do this - since this is called once per firing
 	// if this is a cannon type weapon, create a muzzle flash
 	// HACK - let the flak guns do this on their own since they fire so quickly
-	if ((Weapon_info[weapon_info_index].muzzle_flash >= 0) && !(Weapon_info[weapon_info_index].wi_flags[Weapon::Info_Flags::Flak])) {
+	// Also don't create if its the player in the cockpit unless he's also got show_ship_model
+	bool in_cockpit_view = (Viewer_mode & (VM_EXTERNAL | VM_CHASE | VM_OTHER_SHIP | VM_WARP_CHASE)) == 0;
+	bool player_show_ship_model = objp == Player_obj && Ship_info[Ships[objp->instance].ship_info_index].flags[Ship::Info_Flags::Show_ship_model];
+	if ((Weapon_info[weapon_info_index].muzzle_flash >= 0) && !(Weapon_info[weapon_info_index].wi_flags[Weapon::Info_Flags::Flak]) &&
+		(!(objp == Player_obj && in_cockpit_view) || player_show_ship_model)) {
 		vec3d real_dir;
 		vm_vec_rotate(&real_dir, gun_dir,&objp->orient);	
 		mflash_create(gun_pos, &real_dir, &objp->phys_info, Weapon_info[weapon_info_index].muzzle_flash, objp);		

--- a/code/ship/shipfx.cpp
+++ b/code/ship/shipfx.cpp
@@ -1007,11 +1007,11 @@ void shipfx_flash_create(object *objp, int model_num, vec3d *gun_pos, vec3d *gun
 	// ALWAYS do this - since this is called once per firing
 	// if this is a cannon type weapon, create a muzzle flash
 	// HACK - let the flak guns do this on their own since they fire so quickly
-	// Also don't create if its the player in the cockpit unless he's also got show_ship_model
+	// Also don't create if its the player in the cockpit unless he's also got show_ship_model, provided render_player_mflash isnt on
 	bool in_cockpit_view = (Viewer_mode & (VM_EXTERNAL | VM_CHASE | VM_OTHER_SHIP | VM_WARP_CHASE)) == 0;
 	bool player_show_ship_model = objp == Player_obj && Ship_info[Ships[objp->instance].ship_info_index].flags[Ship::Info_Flags::Show_ship_model];
 	if ((Weapon_info[weapon_info_index].muzzle_flash >= 0) && !(Weapon_info[weapon_info_index].wi_flags[Weapon::Info_Flags::Flak]) &&
-		(!(objp == Player_obj && in_cockpit_view) || player_show_ship_model)) {
+		(objp != Player_obj || Render_player_mflash || (!in_cockpit_view || player_show_ship_model))) {
 		vec3d real_dir;
 		vm_vec_rotate(&real_dir, gun_dir,&objp->orient);	
 		mflash_create(gun_pos, &real_dir, &objp->phys_info, Weapon_info[weapon_info_index].muzzle_flash, objp);		

--- a/code/weapon/beam.cpp
+++ b/code/weapon/beam.cpp
@@ -1396,10 +1396,10 @@ void beam_render_muzzle_glow(beam *b)
 	if (bwi->beam_glow.first_frame < 0)
 		return;
 
-	// don't show the muzzle glow for players in the cockpit unless show_ship_model is on
+	// don't show the muzzle glow for players in the cockpit unless show_ship_model is on, provided Render_player_mflash isn't on
 	bool in_cockpit_view = (Viewer_mode & (VM_EXTERNAL | VM_CHASE | VM_OTHER_SHIP | VM_WARP_CHASE)) == 0;
 	bool player_show_ship_model = b->objp == Player_obj && Ship_info[Ships[b->objp->instance].ship_info_index].flags[Ship::Info_Flags::Show_ship_model];
-	if ((b->flags & BF_IS_FIGHTER_BEAM) && (b->objp == Player_obj && in_cockpit_view && !player_show_ship_model)) {
+	if ((b->flags & BF_IS_FIGHTER_BEAM) && (b->objp == Player_obj && !Render_player_mflash && in_cockpit_view && !player_show_ship_model)) {
 		return;
 	}
 

--- a/code/weapon/beam.cpp
+++ b/code/weapon/beam.cpp
@@ -1396,6 +1396,13 @@ void beam_render_muzzle_glow(beam *b)
 	if (bwi->beam_glow.first_frame < 0)
 		return;
 
+	// don't show the muzzle glow for players in the cockpit unless show_ship_model is on
+	bool in_cockpit_view = (Viewer_mode & (VM_EXTERNAL | VM_CHASE | VM_OTHER_SHIP | VM_WARP_CHASE)) == 0;
+	bool player_show_ship_model = b->objp == Player_obj && Ship_info[Ships[b->objp->instance].ship_info_index].flags[Ship::Info_Flags::Show_ship_model];
+	if ((b->flags & BF_IS_FIGHTER_BEAM) && (b->objp == Player_obj && in_cockpit_view && !player_show_ship_model)) {
+		return;
+	}
+
 	// if the beam is warming up, scale the glow
 	if (b->warmup_stamp != -1) {		
 		// get warmup pct


### PR DESCRIPTION
I went into this PR expecting to implement this, only to find this was always intended! Simply using `Viewer_mode` to determine if the player is in the cockpit is no longer enough as `VM_CAMERA_LOCKED` is true from the get-go. It was modified in PR #848 , but I'm not sure if that behavior (camera_locked being on from the start) is actually a bug or not.

Regardless I've handled the logic slightly differently to allow muzzle flashes to go deep enough to create light, but not the flash animation itself. The idea here is to quietly sweep under the rug the obnoxious bitmaps that would've been flashing in the players face, rather than implying the muzzle flash never existed in the first place.

Also extends the logic to beams, so you can now use BGreens for testing purposes without the entire screen turning white.

EDIT: Also adds a flag to force player muzzle flashes regardless, per wookieejedi's suggestion.