### PR TITLE
Suppress "Too many triangles in shield hit" log spam

### DIFF
--- a/code/ship/shield.cpp
+++ b/code/ship/shield.cpp
@@ -655,7 +655,9 @@ void copy_shield_to_globals( int objnum, shield_info *shieldp, matrix *hit_orien
 			Shield_hits[shnum].tri_list[count++] = gi;
 
 			if (count >= MAX_TRIS_PER_HIT) {
-				mprintf(("Warning: Too many triangles in shield hit.\n"));
+				if (Detail.shield_effects < 4) {
+					mprintf(("Warning: Too many triangles in shield hit.\n"));
+				}
 				break;
 			}
 		}


### PR DESCRIPTION
This refers to a global array containing all the shield tris involved in all current shield hits, it's of fixed size and each shield hit is only allowed to contribute 40 tris, any more and it prints that, and bails. Any other triangles involved in the shield hit won't be rendered.

That array is only used when "Shield Effects" detail level is less than 5, and since this will happen practically every time there's a shield hit on a modern ship,  I've had the mprintf only print if that's case. Below max detail the shield hits indeed look terrible, half or more of the triangles don't render and the effect is cut into pieces along the shield. I'm not sure if this is a real problem that should be addressed or what, since it seems that practically no one plays below max given no one has reported the issue.