### PR TITLE
Improve shockwave handling for docked ships

### DIFF
--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -32,6 +32,7 @@
 #include "network/multimsgs.h"
 #include "network/multiutil.h"
 #include "object/objcollide.h"
+#include "object/objectdock.h"
 #include "scripting/scripting.h"
 #include "particle/particle.h"
 #include "playerman/player.h"
@@ -6201,6 +6202,11 @@ void weapon_area_apply_blast(vec3d * /*force_apply_pos*/, object *ship_objp, vec
 	Assert ( pm != NULL );
 
 	if (make_shockwave) {
+		if (object_is_docked(ship_objp)) {
+			// TODO: this sales down the effect properly but physics_apply_shock will apply
+			// forces based on this ship's bbox, rather than the whole assembly's bbox like it should
+			blast *= ship_objp->phys_info.mass / dock_calc_total_docked_mass(ship_objp);
+		}
 		physics_apply_shock (&force, blast, &ship_objp->phys_info, &ship_objp->orient, &pm->mins, &pm->maxs, pm->rad);
 		if (ship_objp == Player_obj) {
 			joy_ff_play_vector_effect(&vec_blast_to_ship, blast * 2.0f);


### PR DESCRIPTION
This scales down the blast force based on the ship's contribution to its total docked mass, if docked. This will prevent crazy scenarios like small ships being docked to big ships swinging around the big ship like crazy if the small one gets hit by a shockwave, and generally makes ships more resistant to shockwaves if they are docked/the more/bigger ships are docked like one would expect. 

As the comment says this is still not technically generating the correct rotations, since the shockwave will apply a rotational force based on the dimensions of ship's bbox and its orientation to the shockwave; an aggregate bbox would have to be specially calculated and handled for this purpose. While I plan on doing that eventually, this should prevent any egregious or damaging behavior that you could get otherwise in the meantime.