### PR TITLE
add for-players sexp

### DIFF
--- a/code/parse/sexp.h
+++ b/code/parse/sexp.h
@@ -423,6 +423,7 @@ class waypoint_list;
 #define OP_FOR_SHIP_TYPE					(0x0014 | OP_CATEGORY_CONDITIONAL)	// Goober5000
 #define OP_FOR_SHIP_TEAM					(0x0015 | OP_CATEGORY_CONDITIONAL)	// Goober5000
 #define OP_FOR_SHIP_SPECIES					(0x0016 | OP_CATEGORY_CONDITIONAL)	// Goober5000
+#define OP_FOR_PLAYERS						(0x0017 | OP_CATEGORY_CONDITIONAL)	// Goober5000
 
 
 // sexpressions with side-effects


### PR DESCRIPTION
Useful for multiplayer missions.  Lists all currently valid player ships in the mission.  Works in both singleplayer and multiplayer.