### PR TITLE
fix flags in ships.tbl and weapons.tbl

### DIFF
--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -3595,9 +3595,11 @@ static void parse_ship_values(ship_info* sip, const bool is_template, const bool
 			// clear only those which are actually set in the flags
 			bool has_afterburner = sip->flags[Ship::Info_Flags::Afterburner];
 			bool draw_weapon_models = sip->flags[Ship::Info_Flags::Draw_weapon_models];
+			bool has_display_name = sip->flags[Ship::Info_Flags::Has_display_name];
 			sip->flags.reset();
 			sip->flags.set(Ship::Info_Flags::Afterburner, has_afterburner);
 			sip->flags.set(Ship::Info_Flags::Draw_weapon_models, draw_weapon_models);
+			sip->flags.set(Ship::Info_Flags::Has_display_name, has_display_name);
 		}
 
 		for (auto i = 0; i < num_strings; i++)


### PR DESCRIPTION
When flags are parsed, they can be reset.  This is a problem for flags that are set based on lines elsewhere in the entry, so each table uses its own method to get around it.  However, not all flags used this method - particularly the new `Has_display_name` flags.  This brings the flag management up to date.