### PR TITLE
Use a stack for scripting hook variables

### DIFF
--- a/code/scripting/scripting.cpp
+++ b/code/scripting/scripting.cpp
@@ -609,7 +609,7 @@ void script_state::SetHookObjects(int num, ...)
 		auto reference = luacpp::UniqueLuaReference::create(LuaState);
 		lua_pop(LuaState, 1); // Remove object value from the stack
 
-		HookVariableValues.emplace(name, std::move(reference));
+		HookVariableValues[name].push_back(std::move(reference));
 	}
 
 	va_end(vl);
@@ -624,11 +624,14 @@ void script_state::RemHookVars(std::initializer_list<SCP_string> names)
 {
 	if (LuaState != nullptr) {
 		for (const auto& hookVar : names) {
-			HookVariableValues.erase(hookVar);
+			Assertion(!HookVariableValues[hookVar].empty(),
+				"Tried to remove uninitialized hook variable '%s'",
+				hookVar.c_str());
+			HookVariableValues[hookVar].pop_back();
 		}
 	}
 }
-const SCP_unordered_map<SCP_string, luacpp::LuaReference>& script_state::GetHookVariableReferences()
+const SCP_unordered_map<SCP_string, SCP_vector<luacpp::LuaReference>>& script_state::GetHookVariableReferences()
 {
 	return HookVariableValues;
 }

--- a/code/scripting/scripting.h
+++ b/code/scripting/scripting.h
@@ -173,8 +173,9 @@ private:
 
 	// Stores references to the Lua values for the hook variables. Uses a raw reference since we do not need the more
 	// advanced features of LuaValue
-	SCP_unordered_map<SCP_string, luacpp::LuaReference> HookVariableValues;
-private:
+	// values are a vector to provide a stack of values. This is necessary to ensure consistent behavior if a scripting
+	// hook is called from within another script (e.g. calls to createShip)
+	SCP_unordered_map<SCP_string, SCP_vector<luacpp::LuaReference>> HookVariableValues;
 
 	void ParseChunkSub(script_function& out_func, const char* debug_str=NULL);
 
@@ -221,7 +222,7 @@ public:
 	void RemHookVar(const char *name);
 	void RemHookVars(std::initializer_list<SCP_string> names);
 
-	const SCP_unordered_map<SCP_string, luacpp::LuaReference>& GetHookVariableReferences();
+	const SCP_unordered_map<SCP_string, SCP_vector<luacpp::LuaReference>>& GetHookVariableReferences();
 
 	//***Hook creation functions
 	template <typename T>
@@ -266,7 +267,7 @@ void script_state::SetHookVar(const char *name, char format, T&& value)
 		auto reference = luacpp::UniqueLuaReference::create(LuaState);
 		lua_pop(LuaState, 1); // Remove object value from the stack
 
-		HookVariableValues[name] = std::move(reference);
+		HookVariableValues[name].push_back(std::move(reference));
 	}
 }
 

--- a/test/src/scripting/api/hookvars.cpp
+++ b/test/src/scripting/api/hookvars.cpp
@@ -28,7 +28,13 @@ TEST_F(HookVarsTest, withHookVars)
 
 	this->EvalTestScript();
 
-	_state->RemHookVar("Value");
+	// Now check that the stack mechanism works. This should result in the old "Test" value
+	_state->RemHookVar("Test");
+
+	this->EvalTestScript();
+
+	// And then check if clearing the stacked value works
+	_state->RemHookVar("Test");
 
 	this->EvalTestScript();
 }

--- a/test/test_data/scripting/hookvars/withHookVars/data/scripts/test.lua
+++ b/test/test_data/scripting/hookvars/withHookVars/data/scripts/test.lua
@@ -19,6 +19,18 @@ if invocation == 1 then
     assert.equals("Hello World", hv.Test)
     assert.equals(1234, hv.Value)
 elseif invocation == 2 then
+    assert.equals(2, #hv.Globals)
+    local varNames = {}
+    for i=1, #hv.Globals do
+        table.insert(varNames, hv.Globals[i])
+    end
+    table.sort(varNames)
+
+    assert.tablesEqual({ "Test", "Value" }, varNames)
+
+    assert.equals("Something else", hv.Test)
+    assert.equals(1234, hv.Value)
+elseif invocation == 3 then
     assert.equals(1, #hv.Globals)
     local varNames = {}
     for i=1, #hv.Globals do
@@ -26,7 +38,8 @@ elseif invocation == 2 then
     end
     table.sort(varNames)
 
-    assert.tablesEqual({ "Test" }, varNames)
+    assert.tablesEqual({ "Value" }, varNames)
 
-    assert.equals("Hello World", hv.Test)
+    assert.equals(nil, hv.Test)
+    assert.equals(1234, hv.Value)
 end


### PR DESCRIPTION
Previously, if a script called a function that called another scripting
hook, some hook variables might be removed. This was the case since
after executing the hook the code would remove the set hook variables
again. If these variables had the same name as previously set variables,
they would overwrite and corrupt the state the original script expected.

This was unexpected behavior for script writers so this puts values on a
stack and only adds or removes from the stack instead of overwriting
values. This should make the hook variable state consistent for scripts
even if scripting hooks are called indirectly.