### PR TITLE
Flag to allow ships with no shields to manage ETS

### DIFF
--- a/code/ai/ai_flags.h
+++ b/code/ai/ai_flags.h
@@ -128,6 +128,7 @@ namespace AI {
         Use_only_single_fov_for_turrets,
         No_turning_directional_bias,
 		Use_axial_turnrate_differences,
+		nonshielded_ships_can_manage_ets,
 
 		NUM_VALUES
 	};

--- a/code/ai/ai_profiles.cpp
+++ b/code/ai/ai_profiles.cpp
@@ -523,7 +523,7 @@ void parse_ai_profiles_tbl(const char *filename)
 
 				set_flag(profile, "$respect ship axial turnrate differences:", AI::Profile_Flags::Use_axial_turnrate_differences);
 
-				set_flag(profile, "$Ships with no shields can manage ETS:", AI::Profile_Flags::nonshielded_ships_can_manage_ets);
+				set_flag(profile, "$ships with no shields can manage ETS:", AI::Profile_Flags::nonshielded_ships_can_manage_ets);
 
 				// if we've been through once already and are at the same place, force a move
 				if (saved_Mp && (saved_Mp == Mp))

--- a/code/ai/ai_profiles.cpp
+++ b/code/ai/ai_profiles.cpp
@@ -523,6 +523,8 @@ void parse_ai_profiles_tbl(const char *filename)
 
 				set_flag(profile, "$respect ship axial turnrate differences:", AI::Profile_Flags::Use_axial_turnrate_differences);
 
+				set_flag(profile, "$Ships with no shields can manage ETS:", AI::Profile_Flags::nonshielded_ships_can_manage_ets);
+
 				// if we've been through once already and are at the same place, force a move
 				if (saved_Mp && (saved_Mp == Mp))
 				{
@@ -670,6 +672,7 @@ void ai_profile_t::reset()
 		flags.set(AI::Profile_Flags::Fix_ai_path_order_bug);
 		flags.set(AI::Profile_Flags::Aspect_invulnerability_fix);
 		flags.set(AI::Profile_Flags::Use_actual_primary_range);
+		flags.set(AI::Profile_Flags::nonshielded_ships_can_manage_ets);
 	}
 	// this flag has been enabled ever since 3.7.2
 	if (mod_supports_version(3, 7, 2)) {

--- a/code/hud/hudets.cpp
+++ b/code/hud/hudets.cpp
@@ -225,7 +225,7 @@ void ai_manage_ets(object* obj)
 		decrease_recharge_rate(obj, WEAPONS);
 	}
 
-	if (obj->flags[Object::Object_Flags::No_shields]) {
+	if (!(obj->flags[Object::Object_Flags::No_shields])) {
 		float shield_left_percent = get_shield_pct(obj);
 		// maximum level check for shields
 		if (shield_left_percent == 1.0f) {
@@ -248,7 +248,7 @@ void ai_manage_ets(object* obj)
 	}
 
 	// emergency check for ships with shields
-	if (obj->flags[Object::Object_Flags::No_shields]) {
+	if (!(obj->flags[Object::Object_Flags::No_shields])) {
 		float shield_left_percent = get_shield_pct(obj);
 		if ( shield_left_percent < SHIELDS_EMERG_LEVEL_PERCENT ) {
 			if (ship_p->target_shields_delta == 0.0f)

--- a/code/hud/hudets.cpp
+++ b/code/hud/hudets.cpp
@@ -202,6 +202,7 @@ void ai_manage_ets(object* obj)
 {
 	ship* ship_p = &Ships[obj->instance];
 	ship_info* ship_info_p = &Ship_info[ship_p->ship_info_index];
+	ai_info	*aip = &Ai_info[Ships[Pl_objp->instance].ai_index];
 
 	if ( ship_info_p->power_output == 0 )
 		return;
@@ -209,30 +210,36 @@ void ai_manage_ets(object* obj)
 	if (ship_p->flags[Ship::Ship_Flags::Dying])
 		return;
 
-	// check if any of the three systems are not being used.  If so, don't allow energy management.
-	if ( !ship_p->ship_max_shield_strength || !ship_info_p->max_speed || !ship_info_p->max_weapon_reserve)
-		return;
+	// check if weapons or engines are not being used. If so, don't allow energy management.
+	// also check if the ship has no shields and if the AI is allowed to manage weapons and engines --wookieejedi
+	if ( !ship_info_p->max_speed || !ship_info_p->max_weapon_reserve || 
+		(!ship_p->ship_max_shield_strength && !aip->ai_profile_flags[AI::Profile_Flags::nonshielded_ships_can_manage_ets]) ) {
+			return;
+	}
 
-	float shield_left_percent = get_shield_pct(obj);
 	float weapon_left_percent = ship_p->weapon_energy/ship_info_p->max_weapon_reserve;
 
-	// maximum level check
+	// maximum level check for weapons
 	//	MK, changed these, might as well let them go up to 100% if nothing else needs the recharge ability.
 	if ( weapon_left_percent == 1.0f) {
 		decrease_recharge_rate(obj, WEAPONS);
 	}
 
-	if (!(obj->flags[Object::Object_Flags::No_shields]) && (shield_left_percent == 1.0f)) {
-		decrease_recharge_rate(obj, SHIELDS);
+	bool has_shields = !ship_p->ship_max_shield_strength && !(obj->flags[Object::Object_Flags::No_shields]);
+	if (has_shields) {
+		float shield_left_percent = get_shield_pct(obj);
+		// maximum level check for shields
+		if (shield_left_percent == 1.0f) {
+			decrease_recharge_rate(obj, SHIELDS);
+		}
+		// minimum check for shields
+		if (shield_left_percent < SHIELDS_MIN_LEVEL_PERCENT) {
+			if (weapon_left_percent > WEAPONS_MIN_LEVEL_PERCENT)
+				increase_recharge_rate(obj, SHIELDS);
+		}
 	}
 
-	// minimum check
-
-	if (!(obj->flags[Object::Object_Flags::No_shields]) && (shield_left_percent < SHIELDS_MIN_LEVEL_PERCENT)) {
-		if ( weapon_left_percent > WEAPONS_MIN_LEVEL_PERCENT )
-			increase_recharge_rate(obj, SHIELDS);
-	}
-
+	// minimum check for weapons and engines
 	if ( weapon_left_percent < WEAPONS_MIN_LEVEL_PERCENT ) {
 		increase_recharge_rate(obj, WEAPONS);
 	}
@@ -241,8 +248,9 @@ void ai_manage_ets(object* obj)
 		increase_recharge_rate(obj, ENGINES);
 	}
 
-	// emergency check
-	if (!(obj->flags[Object::Object_Flags::No_shields])) {
+	// emergency check for ships with shields
+	if (has_shields) {
+		float shield_left_percent = get_shield_pct(obj);
 		if ( shield_left_percent < SHIELDS_EMERG_LEVEL_PERCENT ) {
 			if (ship_p->target_shields_delta == 0.0f)
 				transfer_energy_to_shields(obj);
@@ -250,7 +258,6 @@ void ai_manage_ets(object* obj)
 			if ( shield_left_percent > SHIELDS_MIN_LEVEL_PERCENT || weapon_left_percent <= 0.01 )	// dampen ai enthusiasm for sucking energy to weapons
 				transfer_energy_to_weapons(obj);
 		}
-
 	
 		// check for return to normal values
 		if ( fl_abs( shield_left_percent - 0.5f ) < NORMAL_TOLERANCE_PERCENT ) {
@@ -260,7 +267,6 @@ void ai_manage_ets(object* obj)
 				increase_recharge_rate(obj, SHIELDS);
 		}
 	}
-
 
 	if ( fl_abs( weapon_left_percent - 0.5f ) < NORMAL_TOLERANCE_PERCENT ) {
 		if ( ship_p->weapon_recharge_index > DEFAULT_CHARGE_INDEX )
@@ -276,10 +282,10 @@ void ai_manage_ets(object* obj)
 void set_default_recharge_rates(object* obj)
 {
 	int ship_properties;
-
+	
 	ship* ship_p = &Ships[obj->instance];
 	ship_info* ship_info_p = &Ship_info[ship_p->ship_info_index];
-
+	mprintf(("settig up ETS for ship %s ...\n", ship_p->ship_name));
 	if ( ship_info_p->power_output == 0 )
 		return;
 
@@ -287,9 +293,10 @@ void set_default_recharge_rates(object* obj)
 	if (ship_has_energy_weapons(ship_p))
 		ship_properties |= HAS_WEAPONS;
 	
-	if (!(obj->flags[Object::Object_Flags::No_shields]))
+	if (!(obj->flags[Object::Object_Flags::No_shields])) {
 		ship_properties |= HAS_SHIELDS;
-
+		mprintf(("following ship has sheilds %s ...\n", ship_p->ship_name));
+	}
 	if (ship_has_engine_power(ship_p))
 		ship_properties |= HAS_ENGINES;
 
@@ -317,6 +324,7 @@ void set_default_recharge_rates(object* obj)
 			ship_p->shield_recharge_index = ZERO_INDEX;
 			ship_p->weapon_recharge_index = ONE_HALF_INDEX;
 			ship_p->engine_recharge_index = ONE_HALF_INDEX;
+			mprintf(("settig shield to 0 for ship %s ...\n", ship_p->ship_name));
 			break;
 
 		case HAS_SHIELDS:

--- a/code/hud/hudets.cpp
+++ b/code/hud/hudets.cpp
@@ -225,8 +225,7 @@ void ai_manage_ets(object* obj)
 		decrease_recharge_rate(obj, WEAPONS);
 	}
 
-	bool has_shields = !ship_p->ship_max_shield_strength && !(obj->flags[Object::Object_Flags::No_shields]);
-	if (has_shields) {
+	if (obj->flags[Object::Object_Flags::No_shields]) {
 		float shield_left_percent = get_shield_pct(obj);
 		// maximum level check for shields
 		if (shield_left_percent == 1.0f) {
@@ -249,7 +248,7 @@ void ai_manage_ets(object* obj)
 	}
 
 	// emergency check for ships with shields
-	if (has_shields) {
+	if (obj->flags[Object::Object_Flags::No_shields]) {
 		float shield_left_percent = get_shield_pct(obj);
 		if ( shield_left_percent < SHIELDS_EMERG_LEVEL_PERCENT ) {
 			if (ship_p->target_shields_delta == 0.0f)
@@ -282,10 +281,10 @@ void ai_manage_ets(object* obj)
 void set_default_recharge_rates(object* obj)
 {
 	int ship_properties;
-	
+
 	ship* ship_p = &Ships[obj->instance];
 	ship_info* ship_info_p = &Ship_info[ship_p->ship_info_index];
-	mprintf(("settig up ETS for ship %s ...\n", ship_p->ship_name));
+
 	if ( ship_info_p->power_output == 0 )
 		return;
 
@@ -293,10 +292,9 @@ void set_default_recharge_rates(object* obj)
 	if (ship_has_energy_weapons(ship_p))
 		ship_properties |= HAS_WEAPONS;
 	
-	if (!(obj->flags[Object::Object_Flags::No_shields])) {
+	if (!(obj->flags[Object::Object_Flags::No_shields]))
 		ship_properties |= HAS_SHIELDS;
-		mprintf(("following ship has sheilds %s ...\n", ship_p->ship_name));
-	}
+
 	if (ship_has_engine_power(ship_p))
 		ship_properties |= HAS_ENGINES;
 
@@ -324,7 +322,6 @@ void set_default_recharge_rates(object* obj)
 			ship_p->shield_recharge_index = ZERO_INDEX;
 			ship_p->weapon_recharge_index = ONE_HALF_INDEX;
 			ship_p->engine_recharge_index = ONE_HALF_INDEX;
-			mprintf(("settig shield to 0 for ship %s ...\n", ship_p->ship_name));
 			break;
 
 		case HAS_SHIELDS:


### PR DESCRIPTION
Using the `No_shields` flag for ships is common usage in multiple mods, and as it turns out ships with that flag set will not have the AI manage ETS values due to an early return in the `ai_manage_ets` function. This PR adds an AI flag to allow ships with no shields to manage ETS regarding weapons and engines. This flag was tested and works as expected.