### PR TITLE
Message size fix

### DIFF
--- a/code/graphics/software/VFNTFont.cpp
+++ b/code/graphics/software/VFNTFont.cpp
@@ -60,10 +60,9 @@ namespace font
 
 					if (checkLength)
 					{
-						if (textLen < 0)
-							break;
-
 						textLen--;
+						if (textLen <= 0)
+							break;
 					}
 
 					if (*text)
@@ -88,10 +87,9 @@ namespace font
 
 				if (checkLength)
 				{
-					if (textLen < 0)
-						break;
-
 					textLen--;
+					if (textLen <= 0)
+						break;
 				}
 			}
 		}

--- a/code/hud/hudtarget.cpp
+++ b/code/hud/hudtarget.cpp
@@ -5238,27 +5238,41 @@ void hudtarget_page_in()
 	}
 }
 
-void hud_stuff_ship_name(char *ship_name_text, ship *shipp)
+void hud_stuff_ship_name(char *ship_name_text, const ship *shipp)
+{
+	strcpy(ship_name_text, hud_get_ship_name(shipp).c_str());
+}
+
+SCP_string hud_get_ship_name(const ship *shipp)
 {
 	// print ship name
 	if ( ((Iff_info[shipp->team].flags & IFFF_WING_NAME_HIDDEN) && (shipp->wingnum != -1)) || (shipp->flags[Ship::Ship_Flags::Hide_ship_name]) ) {
-		*ship_name_text = 0;
+		return "";
+	} else if (Disable_built_in_translations) {
+		return shipp->get_display_name();
 	} else {
-		strcpy(ship_name_text, shipp->get_display_name());
-
-		if (!Disable_built_in_translations) {
-			// handle translation
-			if (Lcl_gr) {
-				lcl_translate_targetbox_name_gr(ship_name_text);
-			} else if (Lcl_pl) {
-				lcl_translate_targetbox_name_pl(ship_name_text);
-			}
+		// handle translation
+		if (Lcl_gr) {
+			char buf[128];
+			lcl_translate_targetbox_name_gr(buf);
+			return buf;
+		} else if (Lcl_pl) {
+			char buf[128];
+			lcl_translate_targetbox_name_pl(buf);
+			return buf;
+		} else {
+			return shipp->get_display_name();
 		}
 	}
 }
 
+void hud_stuff_ship_callsign(char *ship_callsign_text, const ship *shipp)
+{
+	strcpy(ship_callsign_text, hud_get_ship_callsign(shipp).c_str());
+}
+
 extern char Fred_callsigns[MAX_SHIPS][NAME_LENGTH+1];
-void hud_stuff_ship_callsign(char *ship_callsign_text, ship *shipp)
+SCP_string hud_get_ship_callsign(const ship *shipp)
 {
 	// handle multiplayer callsign
 	if (Game_mode & GM_MULTIPLAYER) {
@@ -5266,57 +5280,79 @@ void hud_stuff_ship_callsign(char *ship_callsign_text, ship *shipp)
 		int pn = multi_find_player_by_object( &Objects[shipp->objnum] );
 
 		if (pn >= 0) {
-			strcpy(ship_callsign_text, Net_players[pn].m_player->short_callsign);
-			return;
+			return Net_players[pn].m_player->short_callsign;
 		}
 	}
 
+	SCP_string ship_callsign_text;
+
 	// try to get callsign
 	if (Fred_running) {
-		strcpy(ship_callsign_text, Fred_callsigns[shipp-Ships]);
+		ship_callsign_text = Fred_callsigns[shipp-Ships];
 	} else {
-		*ship_callsign_text = 0;
 		if (shipp->callsign_index >= 0) {
-			strcpy(ship_callsign_text, mission_parse_lookup_callsign_index(shipp->callsign_index));
+			ship_callsign_text = mission_parse_lookup_callsign_index(shipp->callsign_index);
 		}
 	}
 
 	if (!Disable_built_in_translations) {
 		// handle translation
 		if (Lcl_gr) {
-			lcl_translate_targetbox_name_gr(ship_callsign_text);
+			char buf[128];
+			strcpy(buf, ship_callsign_text.c_str());
+			lcl_translate_targetbox_name_gr(buf);
+			return buf;
 		} else if (Lcl_pl) {
-			lcl_translate_targetbox_name_pl(ship_callsign_text);
+			char buf[128];
+			strcpy(buf, ship_callsign_text.c_str());
+			lcl_translate_targetbox_name_pl(buf);
+			return buf;
 		}
 	}
+
+	return ship_callsign_text;
 }
 
-extern char Fred_alt_names[MAX_SHIPS][NAME_LENGTH+1];
-void hud_stuff_ship_class(char *ship_class_text, ship *shipp)
+void hud_stuff_ship_class(char *ship_class_text, const ship *shipp)
 {
+	strcpy(ship_class_text, hud_get_ship_class(shipp).c_str());
+}
+
+extern char Fred_alt_names[MAX_SHIPS][NAME_LENGTH + 1];
+SCP_string hud_get_ship_class(const ship *shipp)
+{
+	SCP_string ship_class_text;
+
 	// try to get alt name
 	if (Fred_running) {
-		strcpy(ship_class_text, Fred_alt_names[shipp-Ships]);
+		ship_class_text = Fred_alt_names[shipp-Ships];
 	} else {
-		*ship_class_text = 0;
 		if (shipp->alt_type_index >= 0) {
-			strcpy(ship_class_text, mission_parse_lookup_alt_index(shipp->alt_type_index));
+			ship_class_text = mission_parse_lookup_alt_index(shipp->alt_type_index);
 		}
 	}
 
 	// maybe get ship class
-	if (!*ship_class_text) {
-		strcpy(ship_class_text, Ship_info[shipp->ship_info_index].get_display_name());
+	if (ship_class_text.empty()) {
+		ship_class_text = Ship_info[shipp->ship_info_index].get_display_name();
 	}
 
 	if (!Disable_built_in_translations) {
 		// handle translation
 		if (Lcl_gr) {
-			lcl_translate_targetbox_name_gr(ship_class_text);
+			char buf[128];
+			strcpy(buf, ship_class_text.c_str());
+			lcl_translate_targetbox_name_gr(buf);
+			return buf;
 		} else if (Lcl_pl) {
-			lcl_translate_targetbox_name_pl(ship_class_text);
+			char buf[128];
+			strcpy(buf, ship_class_text.c_str());
+			lcl_translate_targetbox_name_pl(buf);
+			return buf;
 		}
 	}
+
+	return ship_class_text;
 }
 
 HudGaugeCmeasures::HudGaugeCmeasures():

--- a/code/hud/hudtarget.cpp
+++ b/code/hud/hudtarget.cpp
@@ -5248,22 +5248,22 @@ SCP_string hud_get_ship_name(const ship *shipp)
 	// print ship name
 	if ( ((Iff_info[shipp->team].flags & IFFF_WING_NAME_HIDDEN) && (shipp->wingnum != -1)) || (shipp->flags[Ship::Ship_Flags::Hide_ship_name]) ) {
 		return "";
-	} else if (Disable_built_in_translations) {
-		return shipp->get_display_name();
-	} else {
+	} else if (!Disable_built_in_translations) {
 		// handle translation
 		if (Lcl_gr) {
 			char buf[128];
+			strcpy(buf, shipp->get_display_name());
 			lcl_translate_targetbox_name_gr(buf);
 			return buf;
 		} else if (Lcl_pl) {
 			char buf[128];
+			strcpy(buf, shipp->get_display_name());
 			lcl_translate_targetbox_name_pl(buf);
 			return buf;
-		} else {
-			return shipp->get_display_name();
 		}
 	}
+
+	return shipp->get_display_name();
 }
 
 void hud_stuff_ship_callsign(char *ship_callsign_text, const ship *shipp)

--- a/code/hud/hudtarget.h
+++ b/code/hud/hudtarget.h
@@ -153,9 +153,12 @@ float hud_find_target_distance( object *targetee, const vec3d *targeter_pos );
 extern void polish_predicted_target_pos(weapon_info *wip, object *targetp, vec3d *enemy_pos, vec3d *predicted_enemy_pos, float dist_to_enemy, vec3d *last_delta_vec, int num_polish_steps);
 void hud_calculate_lead_pos(vec3d *lead_target_pos, vec3d *target_pos, object *targetp, weapon_info	*wip, float dist_to_target, vec3d *rel_pos = NULL);
 
-void hud_stuff_ship_name(char *ship_name_text, ship *shipp);
-void hud_stuff_ship_callsign(char *ship_callsign_text, ship *shipp);
-void hud_stuff_ship_class(char *ship_class_text, ship *shipp);
+void hud_stuff_ship_name(char *ship_name_text, const ship *shipp);
+void hud_stuff_ship_callsign(char *ship_callsign_text, const ship *shipp);
+void hud_stuff_ship_class(char *ship_class_text, const ship *shipp);
+SCP_string hud_get_ship_name(const ship *shipp);
+SCP_string hud_get_ship_callsign(const ship *shipp);
+SCP_string hud_get_ship_class(const ship *shipp);
 
 #define TARGET_DISPLAY_DIST		(1<<0)
 #define TARGET_DISPLAY_DOTS		(1<<1)

--- a/code/mission/missionmessage.cpp
+++ b/code/mission/missionmessage.cpp
@@ -233,7 +233,7 @@ const auto OnMessageReceivedHook = scripting::Hook::Factory(
 	});
 
 // forward declarations
-void message_maybe_distort_text(char *text, int shipnum, bool for_death_scream);
+void message_maybe_distort_text(SCP_string &text, int shipnum, bool for_death_scream);
 int comm_between_player_and_ship(int other_shipnum, bool for_death_scream);
 
 // following functions to parse messages.tbl -- code pretty much ripped from weapon/ship table parsing code
@@ -1292,8 +1292,8 @@ void message_play_anim( message_q *q )
  */
 void message_queue_process()
 {	
-	char	buf[MESSAGE_LENGTH];
-	char who_from[NAME_LENGTH];	
+	SCP_string buf;
+	SCP_string who_from;
 	message_q *q;
 	int i;
 	MissionMessage *m;
@@ -1580,11 +1580,11 @@ void message_queue_process()
 	else
 		message_translate_tokens(buf, q->special_message);
 
-	Message_expire = timestamp(static_cast<int>(42 * strlen(buf)));
+	Message_expire = timestamp(static_cast<int>(42 * buf.size()));
 
 	// play wave first, since need to know duration for picking anim start frame
 	if(message_play_wave(q) == false) {
-		fsspeech_play(FSSPEECH_FROM_INGAME, buf);
+		fsspeech_play(FSSPEECH_FROM_INGAME, buf.c_str());
 	}
 
 	// play animation for head
@@ -1596,7 +1596,7 @@ void message_queue_process()
 #ifndef NDEBUG
 	// debug only -- if the message is a builtin message, put in parens whether or not the voice played
 	if (Sound_enabled && !Playing_messages[Num_messages_playing].wave.isValid()) {
-		strcat_s( buf, NOX("..(no wavefile for voice)"));
+		buf += NOX("..(no wavefile for voice)");
 		snd_play(gamesnd_get_game_sound(GameSounds::CUE_VOICE));
 	}
 #endif
@@ -1605,19 +1605,21 @@ void message_queue_process()
 	if ( Message_shipnum >= 0 ) {
 		ship *shipp = &Ships[Message_shipnum];
 		if ( shipp->callsign_index >= 0 ) {
-			hud_stuff_ship_callsign( who_from, shipp );
+			who_from = hud_get_ship_callsign( shipp );
 		} else if ( ((Iff_info[shipp->team].flags & IFFF_WING_NAME_HIDDEN) && (shipp->wingnum != -1)) || (shipp->flags[Ship::Ship_Flags::Hide_ship_name]) ) {
-			hud_stuff_ship_class( who_from, shipp );
+			who_from = hud_get_ship_class( shipp );
 		} else {
-			strcpy_s( who_from, shipp->get_display_name() );
+			who_from = shipp->get_display_name();
 		}
 	} else {
-		strcpy_s( who_from, q->who_from );
+		who_from = q->who_from;
 	}
 
-	if ( !stricmp(who_from, "<none>") ) {
-		HUD_sourced_printf( q->source, NOX("%s"), buf );
-	} else HUD_sourced_printf( q->source, NOX("%s: %s"), who_from, buf );
+	if ( !stricmp(who_from.c_str(), "<none>") ) {
+		HUD_sourced_printf( q->source, NOX("%s"), buf.c_str() );
+	} else {
+		HUD_sourced_printf( q->source, NOX("%s: %s"), who_from.c_str(), buf.c_str() );
+	}
 
 	if ( Message_shipnum >= 0 ) {
 		hud_target_last_transmit_add(Message_shipnum);
@@ -2240,7 +2242,7 @@ void message_maybe_distort()
 //					 Blank out portions of the sound based on Distort_num, this this is that same
 //					 data that will be used to blank out portions of the audio playback
 //
-void message_maybe_distort_text(char *text, int shipnum, bool for_death_scream)
+void message_maybe_distort_text(SCP_string &text, int shipnum, bool for_death_scream)
 {
 	int voice_duration;
 
@@ -2248,15 +2250,14 @@ void message_maybe_distort_text(char *text, int shipnum, bool for_death_scream)
 		return;
 	}
 
-	auto buffer_size = strlen(text);
-	auto len         = unicode::num_codepoints(text, text + buffer_size);
+	auto len         = unicode::num_codepoints(text.begin(), text.end());
 	if (Message_wave_duration == 0) {
 		SCP_string result_str;
 
 		size_t next_distort = 5 + myrand() % 5;
 		size_t i            = 0;
 		size_t run = 0;
-		for (auto cp : unicode::codepoint_range(text)) {
+		for (auto cp : unicode::codepoint_range(text.c_str())) {
 			if (i == next_distort) {
 				run = 3 + myrand() % 5;
 				if (i + run > len)
@@ -2276,8 +2277,7 @@ void message_maybe_distort_text(char *text, int shipnum, bool for_death_scream)
 
 			++i;
 		}
-		Assertion(result_str.size() <= buffer_size, "Buffer after scrambling message is bigger than before!");
-		strcpy(text, result_str.c_str());
+		text = result_str;
 		return;
 	}
 
@@ -2286,7 +2286,7 @@ void message_maybe_distort_text(char *text, int shipnum, bool for_death_scream)
 	// distort text
 	Distort_num = myrand()%MAX_DISTORT_PATTERNS;
 	Distort_next = 0;
-	unicode::codepoint_range range(text);
+	unicode::codepoint_range range(text.c_str());
 	auto curr_iter = range.begin();
 	size_t curr_offset = 0;
 	SCP_string result_str;
@@ -2319,8 +2319,7 @@ void message_maybe_distort_text(char *text, int shipnum, bool for_death_scream)
 		if ( Distort_next >= MAX_DISTORT_LEVELS )
 			Distort_next = 0;
 	}
-	Assertion(result_str.size() <= buffer_size, "Buffer after scrambling message is bigger than before!");
-	strcpy(text, result_str.c_str());
+	text = result_str;
 	
 	Distort_next = 0;
 }

--- a/code/mission/missionmessage.cpp
+++ b/code/mission/missionmessage.cpp
@@ -2274,7 +2274,7 @@ void message_maybe_distort_text(SCP_string &text, int shipnum, bool for_death_sc
 
 			++i;
 		}
-		text = result_str;
+		text = std::move(result_str);
 		return;
 	}
 
@@ -2316,7 +2316,7 @@ void message_maybe_distort_text(SCP_string &text, int shipnum, bool for_death_sc
 		if ( Distort_next >= MAX_DISTORT_LEVELS )
 			Distort_next = 0;
 	}
-	text = result_str;
+	text = std::move(result_str);
 	
 	Distort_next = 0;
 }

--- a/code/mission/missionmessage.cpp
+++ b/code/mission/missionmessage.cpp
@@ -1575,10 +1575,7 @@ void message_queue_process()
 	Message_wave_duration = 0;
 
 	// translate tokens in message to the real things
-	if (q->special_message == NULL)
-		message_translate_tokens(buf, m->message);
-	else
-		message_translate_tokens(buf, q->special_message);
+	buf = message_translate_tokens(q->special_message ? q->special_message : m->message);
 
 	Message_expire = timestamp(static_cast<int>(42 * buf.size()));
 

--- a/code/mission/missiontraining.cpp
+++ b/code/mission/missiontraining.cpp
@@ -247,8 +247,7 @@ void HudGaugeDirectives::render(float  /*frametime*/)
 
 		c = &Color_normal;
 		if (Training_obj_lines[i + offset] & TRAINING_OBJ_LINES_KEY) {
-			SCP_string temp_buf;
-			message_translate_tokens(temp_buf, Mission_events[z].objective_key_text);  // remap keys
+			SCP_string temp_buf = message_translate_tokens(Mission_events[z].objective_key_text);  // remap keys
 			strcpy_s(buf, temp_buf.c_str());
 			c = &Color_bright_green;
 		} else {
@@ -622,13 +621,13 @@ char *translate_message_token(char *str)
 /**
  * Translates all special tokens in a message, producing the new finalized message to be displayed
  */
-void message_translate_tokens(SCP_string &buf, const char *text)
+SCP_string message_translate_tokens(const char *text)
 {
 	char temp[40], *ptr;
 	const char *toke1, *toke2;
 	int r;
+	SCP_string buf;
 
-	buf.clear();
 	toke1 = strchr(text, '$');
 	toke2 = strchr(text, '#');
 	while (toke1 || toke2) {  // is either token types present?
@@ -696,7 +695,7 @@ void message_translate_tokens(SCP_string &buf, const char *text)
 	}
 
 	buf += text;
-	return;
+	return buf;
 }
 
 /**
@@ -804,10 +803,7 @@ void message_training_setup(int m, int length, char *special_message)
 	}
 
 	// translate tokens in message to the real things
-	if (special_message == NULL)
-		message_translate_tokens(Training_buf, Messages[m].message);
-	else
-		message_translate_tokens(Training_buf, special_message);
+	Training_buf = message_translate_tokens(special_message ? special_message : Messages[m].message);
 
 	HUD_add_to_scrollback(Training_buf.c_str(), HUD_SOURCE_TRAINING);
 
@@ -1100,7 +1096,7 @@ void training_process_message()
 	}
 
 	if (count < MAX_TRAINING_MESSAGE_MODS)
-		Training_message_mods[count].pos = NULL;
+		Training_message_mods[count].pos = 0;
 }
 
 void training_fail()

--- a/code/mission/missiontraining.cpp
+++ b/code/mission/missiontraining.cpp
@@ -53,7 +53,7 @@
 #define TMMOD_BOLD	1
 
 typedef struct {
-	char *pos;
+	size_t pos;
 	int mode;  // what function to perform at given position (TMMOD_*)
 } training_message_mods;  // training message modifiers
 
@@ -64,7 +64,7 @@ typedef struct {
 	char *special_message;
 } training_message_queue;
 
-char Training_buf[TRAINING_MESSAGE_LENGTH];
+SCP_string Training_buf;
 const char *Training_lines[MAX_TRAINING_MESSAGE_LINES];  // Training message split into lines
 int Training_line_lengths[MAX_TRAINING_MESSAGE_LINES];
 
@@ -103,8 +103,7 @@ int Training_obj_lines[TRAINING_OBJ_LINES];
 training_message_mods Training_message_mods[MAX_TRAINING_MESSAGE_MODS];
 
 // local module prototypes
-void training_process_message(char *message);
-void message_translate_tokens(char *buf, const char *text);
+void training_process_message();
 
 
 static int Directive_frames_loaded = 0;
@@ -248,7 +247,9 @@ void HudGaugeDirectives::render(float  /*frametime*/)
 
 		c = &Color_normal;
 		if (Training_obj_lines[i + offset] & TRAINING_OBJ_LINES_KEY) {
-			message_translate_tokens(buf, Mission_events[z].objective_key_text);  // remap keys
+			SCP_string temp_buf;
+			message_translate_tokens(temp_buf, Mission_events[z].objective_key_text);  // remap keys
+			strcpy_s(buf, temp_buf.c_str());
 			c = &Color_bright_green;
 		} else {
 			strcpy_s(buf, Mission_events[z].objective_text);
@@ -602,7 +603,7 @@ void training_mission_shutdown()
 	Training_voice = -1;
 	Training_num_lines = Training_obj_num_lines = 0;
 
-	*Training_buf = 0;
+	Training_buf.clear();
 }
 
 /**
@@ -621,19 +622,18 @@ char *translate_message_token(char *str)
 /**
  * Translates all special tokens in a message, producing the new finalized message to be displayed
  */
-void message_translate_tokens(char *buf, const char *text)
+void message_translate_tokens(SCP_string &buf, const char *text)
 {
 	char temp[40], *ptr;
 	const char *toke1, *toke2;
 	int r;
 
-	*buf = 0;
+	buf.clear();
 	toke1 = strchr(text, '$');
 	toke2 = strchr(text, '#');
 	while (toke1 || toke2) {  // is either token types present?
 		if (!toke2 || (toke1 && (toke1 < toke2))) {  // found $ before #
-			strncpy(buf, text, toke1 - text + 1);  // copy text up to token
-			buf += toke1 - text + 1;
+			buf.append(text, toke1 - text + 1);  // copy text up to token
 			text = toke1 + 1;  // advance pointers past processed data
 
 			toke2 = strchr(text, '$');
@@ -663,15 +663,13 @@ void message_translate_tokens(char *buf, const char *text)
 						}
 					}
 
-					buf--;  // erase the $
-					strcpy(buf, ptr);  // put translated key in place of token
-					buf += strlen(buf);
+					buf.pop_back();	// erase the $
+					buf += ptr;		// put translated key in place of token
 					text = toke2 + 1;
 				}
 			}
 		} else {
-			strncpy(buf, text, toke2 - text + 1);  // copy text up to token
-			buf += toke2 - text + 1;
+			buf.append(text, toke2 - text + 1);  // copy text up to token
 			text = toke2 + 1;  // advance pointers past processed data
 
 			toke1 = strchr(text, '#');
@@ -686,9 +684,8 @@ void message_translate_tokens(char *buf, const char *text)
 				temp[toke1 - text] = 0;  // null terminate string
 				ptr = translate_message_token(temp);  // try and translate key
 				if (ptr) {  // was key translated properly?
-					buf--;  // erase the #
-					strcpy(buf, ptr);  // put translated key in place of token
-					buf += strlen(buf);
+					buf.pop_back();	// erase the #
+					buf += ptr;		// put translated key in place of token
 					text = toke1 + 1;
 				}
 			}
@@ -698,7 +695,7 @@ void message_translate_tokens(char *buf, const char *text)
 		toke2 = strchr(text, '#');
 	}
 
-	strcpy(buf, text);
+	buf += text;
 	return;
 }
 
@@ -812,12 +809,12 @@ void message_training_setup(int m, int length, char *special_message)
 	else
 		message_translate_tokens(Training_buf, special_message);
 
-	HUD_add_to_scrollback(Training_buf, HUD_SOURCE_TRAINING);
+	HUD_add_to_scrollback(Training_buf.c_str(), HUD_SOURCE_TRAINING);
 
 	// moved from message_training_display() because we got rid of an extra buffer and we have to determine
 	// the number of lines earlier to avoid inadvertant modification of Training_buf.  - taylor
-	training_process_message(Training_buf);
-	Training_num_lines = split_str(Training_buf, TRAINING_LINE_WIDTH, Training_line_lengths, Training_lines, MAX_TRAINING_MESSAGE_LINES);
+	training_process_message();
+	Training_num_lines = split_str(Training_buf.c_str(), TRAINING_LINE_WIDTH, Training_line_lengths, Training_lines, MAX_TRAINING_MESSAGE_LINES);
 
 	Assert(Training_num_lines >= 0);
 
@@ -837,7 +834,7 @@ void message_training_setup(int m, int length, char *special_message)
 void message_training_queue(const char *text, int timestamp, int length)
 {
 	int m;
-	char temp_buf[TRAINING_MESSAGE_LENGTH];
+	SCP_string temp_buf;
 
 	Assert(Training_message_queue_count < TRAINING_MESSAGE_QUEUE_MAX);
 	if (Training_message_queue_count < TRAINING_MESSAGE_QUEUE_MAX) {
@@ -866,9 +863,9 @@ void message_training_queue(const char *text, int timestamp, int length)
 		}
 
 		// Goober5000 - replace variables if necessary
-		strcpy_s(temp_buf, Messages[m].message);
-		if (sexp_replace_variable_names_with_values(temp_buf, MESSAGE_LENGTH))
-			Training_message_queue[Training_message_queue_count].special_message = vm_strdup(temp_buf);
+		temp_buf = Messages[m].message;
+		if (sexp_replace_variable_names_with_values(temp_buf))
+			Training_message_queue[Training_message_queue_count].special_message = vm_strdup(temp_buf.c_str());
 
 		Training_message_queue_count++;
 	}
@@ -947,7 +944,7 @@ void message_training_update_frame()
 		return;
 	}
 
-	if (timestamp_elapsed(Training_message_timestamp) || !strlen(Training_buf)){
+	if (timestamp_elapsed(Training_message_timestamp) || Training_buf.empty()){
 		return;
 	}
 
@@ -1018,7 +1015,7 @@ void HudGaugeTrainingMessages::render(float  /*frametime*/)
 		return;
 	}
 
-	if (timestamp_elapsed(Training_message_timestamp) || !strlen(Training_buf)){
+	if (timestamp_elapsed(Training_message_timestamp) || Training_buf.empty()){
 		return;
 	}
 
@@ -1041,7 +1038,7 @@ void HudGaugeTrainingMessages::render(float  /*frametime*/)
 		y = position[1] + i * height + height / 2 + 1;
 
 		while ((str - Training_lines[i]) < Training_line_lengths[i]) {  // loop through each character of each line
-			if ((count < MAX_TRAINING_MESSAGE_MODS) && (str == Training_message_mods[count].pos)) {
+			if ((count < MAX_TRAINING_MESSAGE_MODS) && ((str - Training_lines[i]) == Training_message_mods[count].pos)) {
 				buf[z] = 0;
 				renderPrintf(x, y, "%s", buf);
 				gr_get_string_size(&z, NULL, buf);
@@ -1073,20 +1070,20 @@ void HudGaugeTrainingMessages::render(float  /*frametime*/)
 /**
  * Processes a new training message to get hilighting information and store it in internal structures.
  */
-void training_process_message(char *message)
+void training_process_message()
 {
-	int count;
-	char *src, *dest, buf[TRAINING_MESSAGE_LENGTH];
+	int count = 0;
+	SCP_string orig = Training_buf;
+	Training_buf.clear();
+	auto src = orig.c_str();
 
-	message_translate_tokens(buf, message);
-	count = 0;
-	src = buf;
-	dest = Training_buf;
+	// basically what this is doing is re-copying the training message, marking out the points where it is bolded or un-bolded
+	// (it does the re-copying in case it has to skip over the bold tags)
 	while (*src) {
 		if (!strnicmp(src, NOX("<b>"), 3)) {
 			Assert(count < MAX_TRAINING_MESSAGE_MODS);
 			src += 3;
-			Training_message_mods[count].pos = dest;
+			Training_message_mods[count].pos = Training_buf.size();
 			Training_message_mods[count].mode = TMMOD_BOLD;
 			count++;
 		}
@@ -1094,15 +1091,14 @@ void training_process_message(char *message)
 		if (!strnicmp(src, NOX("</b>"), 4)) {
 			Assert(count < MAX_TRAINING_MESSAGE_MODS);
 			src += 4;
-			Training_message_mods[count].pos = dest;
+			Training_message_mods[count].pos = Training_buf.size();
 			Training_message_mods[count].mode = TMMOD_NORMAL;
 			count++;
 		}
 
-		*dest++ = *src++;
+		Training_buf += *src++;
 	}
 
-	*dest = 0;
 	if (count < MAX_TRAINING_MESSAGE_MODS)
 		Training_message_mods[count].pos = NULL;
 }

--- a/code/mission/missiontraining.cpp
+++ b/code/mission/missiontraining.cpp
@@ -655,7 +655,7 @@ SCP_string message_translate_tokens(const char *text)
 
 							if (r) {  // do they want to abort the mission?
 								gameseq_post_event(GS_EVENT_END_GAME);
-								return;
+								return buf;
 							}
 
 							gameseq_post_event(GS_EVENT_CONTROL_CONFIG);  // goto control config screen to bind the control
@@ -1034,7 +1034,7 @@ void HudGaugeTrainingMessages::render(float  /*frametime*/)
 		y = position[1] + i * height + height / 2 + 1;
 
 		while ((str - Training_lines[i]) < Training_line_lengths[i]) {  // loop through each character of each line
-			if ((count < MAX_TRAINING_MESSAGE_MODS) && ((str - Training_lines[i]) == Training_message_mods[count].pos)) {
+			if ((count < MAX_TRAINING_MESSAGE_MODS) && (static_cast<size_t>(str - Training_lines[i]) == Training_message_mods[count].pos)) {
 				buf[z] = 0;
 				renderPrintf(x, y, "%s", buf);
 				gr_get_string_size(&z, NULL, buf);

--- a/code/mission/missiontraining.h
+++ b/code/mission/missiontraining.h
@@ -22,8 +22,7 @@ void training_mission_init();
 void training_mission_shutdown();
 void training_check_objectives();
 void message_training_queue(const char *text, int timestamp, int length = -1);
-void message_training_setup(int num, int length = -1);
-void message_translate_tokens(SCP_string &buf, const char *text);
+SCP_string message_translate_tokens(const char *text);
 void training_fail();
 void message_training_update_frame();
 

--- a/code/mission/missiontraining.h
+++ b/code/mission/missiontraining.h
@@ -23,7 +23,7 @@ void training_mission_shutdown();
 void training_check_objectives();
 void message_training_queue(const char *text, int timestamp, int length = -1);
 void message_training_setup(int num, int length = -1);
-void message_translate_tokens(char *buf, const char *text);
+void message_translate_tokens(SCP_string &buf, const char *text);
 void training_fail();
 void message_training_update_frame();
 

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -10996,9 +10996,7 @@ void sexp_hud_set_directive(int n)
 {
 	auto gaugename = CTEXT(n);
 	auto text = CTEXT(CDR(n));
-	SCP_string message;
-
-	message_translate_tokens(message, text);
+	SCP_string message = message_translate_tokens(text);
 
 	if (message.size() > MESSAGE_LENGTH) {
 		WarningEx(LOCATION, "Message %s is too long for use in a HUD gauge. Please shorten it to %d characters or less.", message.c_str(), MESSAGE_LENGTH);
@@ -21743,7 +21741,7 @@ void sexp_show_subtitle_text(int node)
 
 	// translate things like keypresses, e.g. $T$ for targeting key
 	// (we don't need to do variable replacements because the subtitle code already does that)
-	message_translate_tokens(text, ctext);
+	text = message_translate_tokens(ctext);
 
 	std::array<int, 2> xy_pct;
 	eval_array<int>(xy_pct, n, is_nan, is_nan_forever, [](int num)->int {
@@ -21845,7 +21843,7 @@ void multi_sexp_show_subtitle_text()
 	}
 	else {
 		auto ctext = Messages[message_index].message;
-		message_translate_tokens(text, ctext);
+		text = message_translate_tokens(ctext);
 	}
 	Current_sexp_network_packet.get_float(display_time);
 	Current_sexp_network_packet.get_float(fade_time);

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -10996,12 +10996,12 @@ void sexp_hud_set_directive(int n)
 {
 	auto gaugename = CTEXT(n);
 	auto text = CTEXT(CDR(n));
-	char message[MESSAGE_LENGTH];
+	SCP_string message;
 
 	message_translate_tokens(message, text);
 
-	if (strlen(message) > MESSAGE_LENGTH) {
-		WarningEx(LOCATION, "Message %s is too long for use in a HUD gauge. Please shorten it to %d characters or less.", message, MESSAGE_LENGTH);
+	if (message.size() > MESSAGE_LENGTH) {
+		WarningEx(LOCATION, "Message %s is too long for use in a HUD gauge. Please shorten it to %d characters or less.", message.c_str(), MESSAGE_LENGTH);
 		return;
 	}
 
@@ -21724,7 +21724,7 @@ void sexp_show_subtitle_text(int node)
 {
 	bool is_nan, is_nan_forever;
 	int i, n = node, message_index = -1;
-	char text[MESSAGE_LENGTH];
+	SCP_string text;
 
 	// we'll suppose it's the string for now
 	auto ctext = CTEXT(n);
@@ -21803,7 +21803,7 @@ void sexp_show_subtitle_text(int node)
 	int width = fl2i(gr_screen.center_w * (width_pct / 100.0f));
 
 	// add the subtitle
-	subtitle new_subtitle(x_pos, y_pos, text, nullptr, display_time, fade_time, &new_color, fontnum, center_x, center_y, width, 0, post_shaded);
+	subtitle new_subtitle(x_pos, y_pos, text.c_str(), nullptr, display_time, fade_time, &new_color, fontnum, center_x, center_y, width, 0, post_shaded);
 	Subtitles.push_back(new_subtitle);
 
 	Current_sexp_network_packet.start_callback();
@@ -21830,7 +21830,7 @@ void sexp_show_subtitle_text(int node)
 void multi_sexp_show_subtitle_text()
 {
 	int x_pct, y_pct, width_pct, fontnum, message_index = -1;
-	char text[MESSAGE_LENGTH];
+	SCP_string text;
 	float display_time, fade_time=0.0f;
 	int red=255, green=255, blue=255;
 	bool center_x=false, center_y=false;
@@ -21866,7 +21866,7 @@ void multi_sexp_show_subtitle_text()
 	int width = (int)(gr_screen.center_w * (width_pct / 100.0f));
 
 	// add the subtitle
-	subtitle new_subtitle(x_pos, y_pos, text, nullptr, display_time, fade_time, &new_color, fontnum, center_x, center_y, width, 0, post_shaded);
+	subtitle new_subtitle(x_pos, y_pos, text.c_str(), nullptr, display_time, fade_time, &new_color, fontnum, center_x, center_y, width, 0, post_shaded);
 	Subtitles.push_back(new_subtitle);	
 
 }

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -1857,7 +1857,7 @@ ship_info::~ship_info()
 	free_strings();
 }
 
-const char* ship_info::get_display_name()
+const char* ship_info::get_display_name() const
 {
 	if (has_display_name())
 		return display_name;
@@ -1865,7 +1865,7 @@ const char* ship_info::get_display_name()
 		return name;
 }
 
-bool ship_info::has_display_name()
+bool ship_info::has_display_name() const
 {
 	return flags[Ship::Info_Flags::Has_display_name];
 }
@@ -6241,10 +6241,10 @@ void ship::clear()
 
 	autoaim_fov = 0.0f;
 }
-bool ship::has_display_name() {
+bool ship::has_display_name() const {
 	return flags[Ship::Ship_Flags::Has_display_name];
 }
-const char* ship::get_display_name() {
+const char* ship::get_display_name() const {
 	if (has_display_name()) {
 		return display_name.c_str();
 	} else {

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -761,8 +761,8 @@ public:
 	inline bool cannot_warp_flags() { return flags[Ship::Ship_Flags::Warp_broken, Ship::Ship_Flags::Warp_never, Ship::Ship_Flags::Disabled, Ship::Ship_Flags::No_subspace_drive]; }
 	inline bool is_dying_or_departing() { return is_departing() || flags[Ship::Ship_Flags::Dying]; }
 
-	const char* get_display_name();
-	bool has_display_name();
+	const char* get_display_name() const;
+	bool has_display_name() const;
 
 	void apply_replacement_textures(SCP_vector<texture_replace> &replacements);
 };
@@ -1338,8 +1338,8 @@ public:
     inline bool is_big_or_huge() const { return is_big_ship() || is_huge_ship(); }
     inline bool avoids_shockwaves() const { return is_small_ship(); }
 
-	const char* get_display_name();
-	bool has_display_name();
+	const char* get_display_name() const;
+	bool has_display_name() const;
 
 private:
 	void move(ship_info&& other);

--- a/code/stats/medals.cpp
+++ b/code/stats/medals.cpp
@@ -191,7 +191,7 @@ medal_stuff::medal_stuff()
 	voice_base[0] = '\0';
 }
 
-const char* medal_stuff::get_display_name() {
+const char* medal_stuff::get_display_name() const {
 	if (!alt_name.empty()) {
 		return alt_name.c_str();
 	} else {

--- a/code/stats/medals.h
+++ b/code/stats/medals.h
@@ -43,7 +43,7 @@ public:
 
 	medal_stuff();
 
-	const char* get_display_name();
+	const char* get_display_name() const;
 };
 
 extern SCP_vector<medal_stuff> Medals;

--- a/code/weapon/weapon.h
+++ b/code/weapon/weapon.h
@@ -509,8 +509,8 @@ public:
     inline bool hurts_big_ships()  { return wi_flags[Weapon::Info_Flags::Bomb, Weapon::Info_Flags::Beam, Weapon::Info_Flags::Huge, Weapon::Info_Flags::Big_only]; }
     inline bool is_interceptable() { return wi_flags[Weapon::Info_Flags::Fighter_Interceptable, Weapon::Info_Flags::Turret_Interceptable]; }
 
-	const char* get_display_name();
-	bool has_display_name();
+	const char* get_display_name() const;
+	bool has_display_name() const;
 
 	void reset();
 };

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -8148,7 +8148,7 @@ void weapon_info::reset()
 	this->impact_decal = decals::creation_info();
 }
 
-const char* weapon_info::get_display_name()
+const char* weapon_info::get_display_name() const
 {
 	if (has_display_name())
 		return display_name;
@@ -8156,7 +8156,7 @@ const char* weapon_info::get_display_name()
 		return name;
 }
 
-bool weapon_info::has_display_name()
+bool weapon_info::has_display_name() const
 {
 	return wi_flags[Weapon::Info_Flags::Has_display_name];
 }


### PR DESCRIPTION
1) Fix underline length calculation in message scrollback
2) Use SCP_string for message source and message text (which allows ships with long display names to work without crashing)
3) Upgrade assorted functions to work with SCP_string