### PR TITLE
Multiplayer Resimulation for Client Fired Linear Weapons (Rollback)

### DIFF
--- a/code/network/multi.cpp
+++ b/code/network/multi.cpp
@@ -856,6 +856,10 @@ void process_packet_normal(ubyte* data, header *header_info)
 			process_NEW_primary_fired_packet(data, header_info);
 			break;
 
+		case LINEAR_WEAPON_FIRED:
+			process_non_homing_fired_packet(data, header_info);
+			break;
+
 		case COUNTERMEASURE_NEW:
 			process_NEW_countermeasure_fired_packet(data, header_info);
 			break;
@@ -1247,7 +1251,11 @@ void multi_do_frame()
 				// reset timestamp
 				Next_bytes_time = (int) time(NULL);				
 			}
-		} else {			
+		} else {
+
+			// right before sending new positions, we should do any rollback shots and resimulation
+			multi_ship_record_do_rollback();
+
 			// sending new objects from here is dependent on having objects only created after
 			// the game is done moving the objects.  I think that I can enforce this.				
 			multi_oo_process();			

--- a/code/network/multi.h
+++ b/code/network/multi.h
@@ -64,9 +64,10 @@ class player;
 // version 49 - 7/26/2020 Addition of multilock
 // version 50 - 7/27/2020 IPv6
 // version 51 - 9/20/2020 Object Update Packet Upgrade: Waypoints, subsystem rotation, bandwidth improvements, bugfixes
+// version 52 - 10/9/2020 Dumbfire Rollback, increases accuracy of high ping, or delayed packet primary fire for clients.
 // STANDALONE_ONLY
 
-#define MULTI_FS_SERVER_VERSION							51
+#define MULTI_FS_SERVER_VERSION							52
 
 #define MULTI_FS_SERVER_COMPATIBLE_VERSION			MULTI_FS_SERVER_VERSION
 

--- a/code/network/multi_obj.cpp
+++ b/code/network/multi_obj.cpp
@@ -22,6 +22,7 @@
 #include "network/multi_rate.h"
 #include "network/multi.h"
 #include "object/object.h"
+#include "object/objcollide.h"		// for multi rollback collisions
 #include "object/objectshield.h"
 #include "ship/ship.h"
 #include "playerman/player.h"
@@ -48,6 +49,7 @@ struct oo_ship_position_records {
 	vec3d positions[MAX_FRAMES_RECORDED];							// The recorded ship positions, cur_frame_index is the index.
 	matrix orientations[MAX_FRAMES_RECORDED];						// The recorded ship orientations, cur_frame_index is the index. 
 	vec3d velocities[MAX_FRAMES_RECORDED];							// The recorded ship velocities (required for additive velocity shots and auto aim), cur_frame_index is the index.
+	vec3d rotational_velocities[MAX_FRAMES_RECORDED];				// The recorded ship rotational velocities (required for auto aim if certain ), cur_frame_index is the index.
 };
 
 // keeps track of what has been sent to each player, helps cut down on bandwidth, allowing only new information to be sent instead of old.
@@ -132,6 +134,7 @@ struct oo_rollback_restore_record {
 	vec3d position;			// position to restore to
 	matrix orientation;		// orientation to restore to
 	vec3d velocity;			// velocity to restore to
+	vec3d rotational_velocity; // rotational velocity to restore to
 };
 
 // Keeps track of how many shots that need to be fired in rollback mode.
@@ -159,8 +162,6 @@ struct oo_general_info {
 	// how many times that is reset, up to MAX_SERVER_TRACKER_SMALL_WRAPS, we multiply these two to get the seq_num
 	// sent to oo_packet recipients. larger_wrap_count allows us to figure out if we are in an "odd" larger wrap
 	int number_of_frames;									// how many frames have we gone through, total.
-	short larger_wrap_count;								// how many of the larger wrap, used to set an OO_packet flag.
-	ushort wrap_count;										// how many times have we wrapped the cur_frame_index.
 	ubyte cur_frame_index;									// the current frame index (to access the recorded info)
 
 	int timestamps[MAX_FRAMES_RECORDED];					// The timestamp for the recorded frame
@@ -194,6 +195,17 @@ int multi_find_prev_frame_idx();
 // quickly lookup how much time has passed since the given frame.
 uint multi_ship_record_get_time_elapsed(int original_frame, int new_frame);
 
+// fire the rollback weapons that are in the rollback struct
+void multi_oo_fire_rollback_shots(int frame_idx);
+
+// moves all rollbacked ships back to the original frame
+void multi_oo_restore_frame(int frame_idx);
+
+// pushes the rollback weapons forward for a single rollback frame.
+void multi_oo_simulate_rollback_shots(int frame_idx);
+
+// restores ships to the positions they were in bedfore rollback.
+void multi_record_restore_positions();
 
 // See if a newly arrived packet is a good new option as a reference object
 void multi_ship_record_rank_seq_num(object* objp, int seq_num);
@@ -244,11 +256,6 @@ float multi_oo_calc_pos_time_difference(int player_id, int net_sig_idx);
 // how often we should send full hull/shield updates
 #define OO_HULL_SHIELD_TIME		600
 #define OO_SUBSYS_TIME				1000
-
-// for making the frame record wrapping predictable. 273 is the highest that we can put without a remainder. ~(65536/30) 
-#define MAX_SERVER_TRACKER_SMALL_WRAPS 2184
-#define SERVER_TRACKER_LARGE_WRAP_TOTAL (MAX_SERVER_TRACKER_SMALL_WRAPS * MAX_FRAMES_RECORDED)
-#define HAS_WRAPPED_MINIMUM			(SERVER_TRACKER_LARGE_WRAP_TOTAL - (MAX_FRAMES_RECORDED * 2)) 
 
 // timestamp values for object update times based on client's update level.
 // Cyborg17 - This is the one update number I have adjusted, because it's the player's target.
@@ -397,6 +404,8 @@ void multi_ship_record_add_ship(int obj_num)
 		// only add positional info if they are in the mission.
 		Oo_info.frame_info[net_sig_idx].positions[Oo_info.cur_frame_index] = objp->pos;
 		Oo_info.frame_info[net_sig_idx].orientations[Oo_info.cur_frame_index] = objp->orient;
+		Oo_info.frame_info[net_sig_idx].velocities[Oo_info.cur_frame_index] = objp->phys_info.vel;
+		Oo_info.frame_info[net_sig_idx].rotational_velocities[Oo_info.cur_frame_index] = objp->phys_info.rotvel;
 	}
 }
 
@@ -413,14 +422,14 @@ void multi_ship_record_update_all()
 	object* objp;
 
 	for (ship & cur_ship : Ships) {
-		
+		// apparently this occasionally happens.
 		if (cur_ship.objnum == -1) {
 			continue;
 		}		
 		
 		objp = &Objects[cur_ship.objnum];
 
-		if (objp == nullptr) {
+		if (objp == nullptr || objp->type != OBJ_SHIP) {
 			continue;
 		}
 		 
@@ -435,6 +444,7 @@ void multi_ship_record_update_all()
 		Oo_info.frame_info[net_sig_idx].positions[Oo_info.cur_frame_index] = objp->pos;
 		Oo_info.frame_info[net_sig_idx].orientations[Oo_info.cur_frame_index] = objp->orient;
 		Oo_info.frame_info[net_sig_idx].velocities[Oo_info.cur_frame_index] = objp->phys_info.vel;
+		Oo_info.frame_info[net_sig_idx].rotational_velocities[Oo_info.cur_frame_index] = objp->phys_info.rotvel;
 	}
 }
 
@@ -447,11 +457,6 @@ void multi_ship_record_increment_frame()
 	// Because we are only tracking 30 frames (up to a quarter second on a 120 frame machine), we will have to wrap the index often
 	if (Oo_info.cur_frame_index == MAX_FRAMES_RECORDED) {
 		Oo_info.cur_frame_index = 0;
-		Oo_info.wrap_count++;
-		if (Oo_info.wrap_count == MAX_SERVER_TRACKER_SMALL_WRAPS) {
-			Oo_info.wrap_count = 0;
-			Oo_info.larger_wrap_count++;
-		}
 	}
 
 	Oo_info.timestamps[Oo_info.cur_frame_index] = timestamp();
@@ -468,46 +473,26 @@ int multi_find_prev_frame_idx()
 }
 
 // Finds the first frame that is before the incoming timestamp.
-int multi_ship_record_find_frame(ushort client_frame, int time_elapsed)
+int multi_ship_record_find_frame(int client_frame, int time_elapsed)
 {	
-	// figure out the correct wrap
-	int wrap = client_frame  / MAX_FRAMES_RECORDED;
-
-	// figure out the frame index within the wrap
-	int frame = client_frame % MAX_FRAMES_RECORDED;
-
-	// if the wrap is not the same.
-	if (wrap != Oo_info.wrap_count) {
-		// somewhat out of date but still salvagable case.
-		if (wrap == (Oo_info.wrap_count - 1)) {
-
-			// but we can't use it if it would index to info in the current wrap instead of the previous wrap.
-			if (frame <= Oo_info.cur_frame_index) {
-				return -1;
-			}
-		// Just in case the larger wrap just happened....
-		} else if ((wrap == MAX_SERVER_TRACKER_SMALL_WRAPS - 1) && Oo_info.wrap_count == 0){
-			// again we can't use it if it would index to info in the current wrap instead of the previous wrap.
-			if (frame <= Oo_info.cur_frame_index) {
-				return -1;
-			}
-
-		} // otherwise the request is unsalvagable.
-		else {
-			return -1;
-		}
+	// frame coming in from the client is too old to be used.
+	if (Oo_info.cur_frame_index - client_frame >= MAX_FRAMES_RECORDED) {
+		return -1;
 	}
+
+	// figure out the frame index (the frame index wraps every MAX_FRAMES_RECORDED frames)
+	int frame = client_frame % MAX_FRAMES_RECORDED;
 
 	// Now that the wrap has been verified, if time_elapsed is zero return the frame it gave us.
 	if(time_elapsed == 0){
 		return frame;
 	}
 
-	// Otherwise, look for the frame that the client is saying to look for.  If we hit the frame the client sent, return.
-	// get how many frames we would go into the future.
+	// Now we look for the frame that the client is saying to look for. 
+	// get the timestamp we are looking for.
 	int target_timestamp = Oo_info.timestamps[frame] + time_elapsed;
 
-	for (int i = Oo_info.cur_frame_index - 1; i > -1; i--) {
+	for (int i = Oo_info.cur_frame_index - 2; i > -1; i--) {
 
 		// Check to see if the client's timestamp matches the recorded frames.
 		if ((Oo_info.timestamps[i] <= target_timestamp) && (Oo_info.timestamps[i + 1] > target_timestamp)) {
@@ -533,7 +518,7 @@ int multi_ship_record_find_frame(ushort client_frame, int time_elapsed)
 		}
 	}
 
-	// this is if again the request is way too delayed to be valid, but somehow wasn't caught earlier.
+	// shouldn't be reachable... somehow wasn't caught earlier.  Just let the old system handle this one.
 	return -1;
 }
 
@@ -598,6 +583,222 @@ int multi_ship_record_find_time_after_frame(int starting_frame, int ending_frame
 
 	int return_value = time_elapsed - (Oo_info.timestamps[ending_frame] - Oo_info.timestamps[starting_frame]);
 	return return_value;
+}
+
+// Returns whether weapons currently being created should be part of the rollback simulation.
+bool multi_ship_record_get_rollback_wep_mode() 
+{
+	return Oo_info.rollback_mode;
+}
+
+// Adds an object pointer to the list of weapons that needs to be simulated as part of rollback.
+void multi_ship_record_add_rollback_wep(int wep_objnum) 
+{
+	object* wobjp = &Objects[wep_objnum];
+
+	// check for valid pointer
+	if (wobjp == nullptr){
+		mprintf(("Nullptr when trying to add weapons to the weapon rollback tracker.\n"));
+		return;
+	}
+	
+	// add it to the list of weapons we'll need to add to the simulation.
+	Oo_info.rollback_wobjp_created_this_frame.push_back(wobjp);
+}
+
+// This stores the information we got from the client to create later.
+void multi_ship_record_add_rollback_shot(object* pobjp, vec3d* pos, matrix* orient, int frame, bool secondary) 
+{
+	Oo_info.rollback_mode = true;
+
+	oo_unsimulated_shots new_shot;
+	new_shot.shooterp = pobjp;
+	new_shot.pos = *pos;
+	new_shot.orient = *orient;
+	new_shot.secondary_shot = secondary;
+
+	Oo_info.rollback_shots_to_be_fired[frame].push_back(new_shot);	
+}
+
+// Manage rollback for a frame
+void multi_ship_record_do_rollback() 
+{	
+	// only rollback if there are shots to simulate.
+	if (!Oo_info.rollback_mode) {
+		return;
+	}
+	nprintf(("Network","At least one multiplayer rollback shot is being simulated this frame.\n"));
+	int net_sig_idx;
+	object* objp;
+
+	// set up all restore points and ship portion of the collision list
+	for (ship& cur_ship : Ships) {
+
+		// once this happens, we've run out of ships.
+		if (cur_ship.objnum < 0) {
+			break;
+		}
+
+		objp = &Objects[cur_ship.objnum];
+		if (objp == nullptr) {
+			continue;
+		}
+
+		net_sig_idx = objp->net_signature;
+
+		// this should not happen, but it would not access correct info. 
+		//It only means a less accurate simulation (and a mystery), not a crash. So, for now, write to the log. 
+		if (net_sig_idx < 1) {
+			mprintf(("Rollback ship does not have a net signature.  Someone should probably investigate this at some point.\n"));
+			continue;
+		}
+
+		// also, we must *not* attempt to rollback the standalone ship 
+		if (net_sig_idx == STANDALONE_SHIP_SIG) {
+			continue;
+		}
+
+		Oo_info.rollback_ships.push_back(objp);
+
+		oo_rollback_restore_record restore_point;
+
+		restore_point.roll_objp = objp;
+		restore_point.position = objp->pos;
+		restore_point.orientation = objp->orient;
+		restore_point.velocity = objp->phys_info.vel;
+		restore_point.rotational_velocity = objp->phys_info.rotvel;
+
+		Oo_info.restore_points.push_back(restore_point);
+		// Also take this opportunity to set up their collision 
+		Oo_info.rollback_collide_list.push_back(OBJ_INDEX(objp));
+	}
+
+	// now we need to figure out which frame will start the rollback simulation
+	int frame_idx = Oo_info.cur_frame_index + 1;
+	if (frame_idx >= MAX_FRAMES_RECORDED) {
+		frame_idx = 0;
+	}
+
+	// loop through them
+	while (frame_idx != Oo_info.cur_frame_index) {
+		if (!Oo_info.rollback_shots_to_be_fired[frame_idx].empty()) {
+			break;
+		}
+		frame_idx++;
+		if (frame_idx >= MAX_FRAMES_RECORDED) {
+			frame_idx = 0;
+		}
+	}
+
+	// make sure we found one.
+	Assertion(frame_idx != Oo_info.cur_frame_index, "Rollback was called without there being a rollback shot to simulate. This is a coder error. Please report!");
+
+	if (frame_idx == Oo_info.cur_frame_index) {
+		return;
+	}
+
+	do {
+		// move all ships to their recorded positions
+		multi_oo_restore_frame(frame_idx);
+
+		// push weapons forward for the frame (weapons do not get pushed forward for the first frame of their existence)
+		multi_oo_simulate_rollback_shots(frame_idx);
+
+		// then fire all shots for the frame, primary and secondary, if there are any
+		multi_oo_fire_rollback_shots(frame_idx);
+
+		// perform collision detection for that frame.
+		obj_sort_and_collide(Oo_info.rollback_collide_list);
+
+		//increment the frame
+		frame_idx++;
+		if (frame_idx >= MAX_FRAMES_RECORDED) {
+			frame_idx = 0;
+		}
+
+	} while (frame_idx != Oo_info.cur_frame_index);
+
+	// restore the old frame
+	multi_record_restore_positions();
+
+	// clean up the rollback info that has been taken care of.
+	Oo_info.rollback_collide_list.clear();
+	Oo_info.rollback_mode = false;
+	Oo_info.rollback_ships.clear();
+	for (auto & shots_to_be_fired : Oo_info.rollback_shots_to_be_fired) {
+		shots_to_be_fired.clear();
+	}
+	Oo_info.rollback_wobjp.clear();
+}
+
+// fires the rollback weapons that are in the rollback struct
+void multi_oo_fire_rollback_shots(int frame_idx)
+{
+	for (auto & rollback_shot : Oo_info.rollback_shots_to_be_fired[frame_idx]) {
+		rollback_shot.shooterp->pos = rollback_shot.pos;
+		rollback_shot.shooterp->orient = rollback_shot.orient;
+		if (rollback_shot.secondary_shot) {
+			ship_fire_secondary(rollback_shot.shooterp, 1, true);
+		}
+		else {
+			ship_fire_primary(rollback_shot.shooterp, 0, 1, true);
+		}
+	}
+
+	// add the newly created shots to the collision list.
+	for (auto& wobjp : Oo_info.rollback_wobjp_created_this_frame) {
+		Oo_info.rollback_wobjp.push_back(wobjp);
+		Assertion(wobjp != nullptr, "Somehow FSO added a nullptr to a list of weapons it is supposed to rollback.");
+		Oo_info.rollback_collide_list.push_back(OBJ_INDEX(wobjp));
+	}
+	Oo_info.rollback_wobjp_created_this_frame.clear();
+}
+
+// moves all rollbacked ships back to the original frame
+void multi_oo_restore_frame(int frame_idx)
+{
+	// set the position, orientation, and velocity for each object
+	for (auto& objp : Oo_info.rollback_ships) {
+		Assertion(objp != nullptr, "Nullptr somehow got into the rollback ship vector, please report!");
+		objp->pos = Oo_info.frame_info[objp->net_signature].positions[frame_idx];
+		objp->orient = Oo_info.frame_info[objp->net_signature].orientations[frame_idx];
+		objp->phys_info.vel = Oo_info.frame_info[objp->net_signature].velocities[frame_idx];
+		objp->phys_info.rotvel = Oo_info.frame_info[objp->net_signature].rotational_velocities[frame_idx];
+	}
+}
+
+// pushes the rollback weapons forward for a single rollback frame.
+void multi_oo_simulate_rollback_shots(int frame_idx) 
+{
+	int prev_frame = frame_idx - 1;
+	if (prev_frame < 0) {
+		prev_frame = MAX_FRAMES_RECORDED - 1;
+	}
+
+	// calculate the float version of the frametime.
+	float frametime = (float)multi_ship_record_get_time_elapsed(prev_frame, frame_idx) / (float)TIMESTAMP_FREQUENCY;
+
+	// push the weapons forward.
+	for (auto& objp : Oo_info.rollback_wobjp) {
+		Assertion(objp != nullptr, "Nullptr somehow got into the rollback weapon vector, please report!");
+		vm_vec_scale_add2(&objp->pos, &objp->phys_info.vel, frametime);
+		Weapons[objp->instance].lifeleft -= frametime;
+	}
+}
+
+// restores ships to the positions they were in bedfore rollback.
+void multi_record_restore_positions() 
+{
+	for (auto restore_point : Oo_info.restore_points) {
+
+		object* objp = restore_point.roll_objp;
+		// reset the position, orientation, and velocity for each object
+		objp->pos = restore_point.position;
+		objp->orient = restore_point.orientation;
+		objp->phys_info.vel = restore_point.velocity;
+	}
+
+	Oo_info.restore_points.clear();
 }
 
 // ---------------------------------------------------------------------------------------------------
@@ -2299,8 +2500,6 @@ void multi_init_oo_and_ship_tracker()
 	}
 
 	Oo_info.number_of_frames = 0;
-	Oo_info.wrap_count = 0;
-	Oo_info.larger_wrap_count = 0;
 	Oo_info.cur_frame_index = 0;
 	for (int i = 0; i < MAX_FRAMES_RECORDED; i++) { // NOLINT
 		Oo_info.timestamps[i] = MAX_TIME; // This needs to be Max time (or at least some absurdly high number) for rollback to work correctly
@@ -2331,6 +2530,7 @@ void multi_init_oo_and_ship_tracker()
 		temp_position_records.orientations[i] = vmd_identity_matrix;
 		temp_position_records.positions[i] = vmd_zero_vector;
 		temp_position_records.velocities[i] = vmd_zero_vector;
+		temp_position_records.rotational_velocities[i] = vmd_zero_vector;
 	}
 
 	int cur = 0;

--- a/code/network/multi_obj.cpp
+++ b/code/network/multi_obj.cpp
@@ -595,8 +595,8 @@ bool multi_ship_record_get_rollback_wep_mode()
 void multi_ship_record_add_rollback_wep(int wep_objnum) 
 {
 	// check for valid pointer
-	if (wep_objnum > -1 && wep_objnum < MAX_WEAPONS){
-		mprintf(("Invalid weapon number passed when trying to add weapons to the weapon rollback tracker.\n"));
+	if (wep_objnum > -1 && wep_objnum < MAX_OBJECTS){
+		mprintf(("Invalid object number passed when trying to add weapons to the weapon rollback tracker.\n"));
 		return;
 	}
 	

--- a/code/network/multi_obj.cpp
+++ b/code/network/multi_obj.cpp
@@ -1649,8 +1649,8 @@ int multi_oo_unpack_data(net_player* pl, ubyte* data, int seq_num)
 	GET_USHORT(data_size);
 	if (MULTIPLAYER_MASTER) {
 		// client cannot send these types because the server is in charge of all of these things.
-		Assertion(!(oo_flags & (OO_AI_NEW | OO_SHIELDS_NEW | OO_HULL_NEW | OO_SUBSYSTEMS_NEW | OO_SUPPORT_SHIP)), "Invalid flag from client, please report! oo_flags value: %d\n", oo_flags);
-		if (oo_flags & (OO_AI_NEW | OO_SHIELDS_NEW | OO_HULL_NEW | OO_SUBSYSTEMS_NEW | OO_SUPPORT_SHIP)) {
+		Assertion(!(oo_flags & (OO_AI_NEW | OO_SHIELDS_NEW | OO_HULL_NEW | OO_SUPPORT_SHIP)), "Invalid flag from client, please report! oo_flags value: %d\n", oo_flags);
+		if (oo_flags & (OO_AI_NEW | OO_SHIELDS_NEW | OO_HULL_NEW | OO_SUPPORT_SHIP)) {
 			offset += data_size;
 			return offset;
 		}

--- a/code/network/multi_obj.h
+++ b/code/network/multi_obj.h
@@ -68,7 +68,7 @@ void multi_ship_record_update_all();
 void multi_ship_record_increment_frame();
 
 // find the right frame to start our weapon simulation
-int multi_ship_record_find_frame(ushort client_frame, int time_elapsed);
+int multi_ship_record_find_frame(int client_frame, int time_elapsed);
 
 // a quick lookups for position and orientation
 vec3d multi_ship_record_lookup_position(object* objp, int frame);
@@ -76,9 +76,10 @@ vec3d multi_ship_record_lookup_position(object* objp, int frame);
 // a quick lookups for orientation
 matrix multi_ship_record_lookup_orientation(object* objp, int frame);
 
+// figures out how much time has passed bwetween the two frames.
 int multi_ship_record_find_time_after_frame(int client_frame, int frame, int time_elapsed);
 
-// This stores the information we got from the client to create later, and checks to see if this is the oldest shot we are going to fire during rollback.
+// This stores the information we got from the client to create later.
 void multi_ship_record_add_rollback_shot(object* pobjp, vec3d* pos, matrix* orient, int frame, bool secondary);
 
 // Lookup whether rollback mode is on

--- a/code/network/multimsgs.cpp
+++ b/code/network/multimsgs.cpp
@@ -3036,6 +3036,11 @@ void send_secondary_fired_packet( ship *shipp, ushort starting_sig, int  /*start
 		return;
 	}
 
+	// if this is a rollback shot, the firing player does not need this packet.
+	if (multi_ship_record_get_rollback_wep_mode()) {
+		return;
+	}
+
 	// now build up the packet to send to the player who actually fired.
 	BUILD_HEADER( SECONDARY_FIRED_PLR );
 	ADD_USHORT(starting_sig);
@@ -3069,7 +3074,7 @@ void process_secondary_fired_packet(ubyte* data, header* hinfo, int from_player)
 	if ( !from_player ) {
 		GET_USHORT( net_signature );
 		GET_USHORT( starting_sig );
-		GET_DATA( sinfo );			// are we firing swarm missiles
+		GET_DATA( sinfo );			// includes flags and the secondary bank.
 
 		GET_USHORT( target_net_signature );
 		GET_DATA( t_subsys );
@@ -3953,12 +3958,12 @@ void send_observer_update_packet()
 	}
 
 	packet_size = 0;
-	
+
 	BUILD_HEADER(OBSERVER_UPDATE);
 
 	ret = multi_pack_unpack_position( 1, data + packet_size, &Player_obj->pos );
 	packet_size += ret;
-	
+
 	angles temp_angles;
 
 	vm_extract_angles_matrix_alternate(&temp_angles, &Player_obj->orient);
@@ -4539,6 +4544,9 @@ void process_subsystem_destroyed_packet( ubyte *data, header *hinfo )
 			PACKET_SET_SIZE();
 			return;
 		}
+
+		// Cyborg17 - We need to do this here because otherwise FSO will not mark subsystem strength as zero (It used to rely on the object Update packet)
+		subsysp->current_hits = 0;
 
 		vm_vec_unrotate( &world_hit_pos, &local_hit_pos, &objp->orient );
 		vm_vec_add2( &world_hit_pos, &objp->pos );
@@ -7475,45 +7483,33 @@ void process_reinforcement_avail( ubyte *data, header *hinfo )
 	}
 }
 
+// Sends a primary fire shot from any ship on the server, or as a backup packet type for the client
+// if reference ship cannot be found.
 void send_NEW_primary_fired_packet(ship *shipp, int banks_fired)
 {
+	// in case nothing got fired, we don't have to do anything.
+	if(banks_fired <= 0){
+		return;
+	}
+
 	int packet_size, objnum;
-	ubyte data[MAX_PACKET_SIZE]; // ubanks_fired, current_bank;
+	ubyte data[MAX_PACKET_SIZE];
 	object *objp;	
 	int np_index;
-	net_player *ignore = NULL;
+	net_player *ignore = nullptr;
 
 	// get an object pointer for this ship.
 	objnum = shipp->objnum;
 	objp = &Objects[objnum];
 
 	// if i'm a multiplayer client, I should never send primary fired packets for anyone except me
-	if(MULTIPLAYER_CLIENT && (Player_obj != objp)){
+	if (MULTIPLAYER_CLIENT && (Player_obj != objp)){
 		return;
 	}
 
-	// just in case nothing got fired
-	if(banks_fired <= 0){
-		return;
-	}
-
-	// ubanks_fired = (ubyte)banks_fired;
-	// current_bank = (ubyte)shipp->weapons.current_primary_bank;
-	// Assert( current_bank <= 3 );
-
-	// insert the current primary bank into this byte
-	// ubanks_fired |= (current_bank << CURRENT_BANK_BIT);
-
-	// append the SF_PRIMARY_LINKED flag on the top nibble of the banks_fired
-	// if ( shipp->flags[Ship::Ship_Flags::Primary_linked] ){
-		// ubanks_fired |= (1<<7);
-	// }	
-
-	if(MULTIPLAYER_MASTER){
-		np_index = multi_find_player_by_net_signature(objp->net_signature);
-		if((np_index >= 0) && (np_index < MAX_PLAYERS)){
-			ignore = &Net_players[np_index];
-		}
+	np_index = multi_find_player_by_net_signature(objp->net_signature);
+	if((np_index >= 0) && (np_index < MAX_PLAYERS)){
+		ignore = &Net_players[np_index];
 	}
 
 	// build up the standard weapon fired packet.  This packet will get sent to all players if an AI
@@ -7522,7 +7518,6 @@ void send_NEW_primary_fired_packet(ship *shipp, int banks_fired)
 	// and server in sync w.r.t. weapon energy for player ship
 	BUILD_HEADER( PRIMARY_FIRED_NEW );
 	ADD_USHORT(objp->net_signature);
-	// ADD_DATA(ubanks_fired);
 
 	// if I'm a server, broadcast to all players
 	if(MULTIPLAYER_MASTER){		
@@ -7539,8 +7534,7 @@ void send_NEW_primary_fired_packet(ship *shipp, int banks_fired)
 
 void process_NEW_primary_fired_packet(ubyte *data, header *hinfo)
 {
-	int offset; // linked;	
-	// ubyte banks_fired, current_bank;
+	int offset; 
 	object* objp;	
 	ship *shipp;
 	ushort shooter_sig;	
@@ -7548,12 +7542,11 @@ void process_NEW_primary_fired_packet(ubyte *data, header *hinfo)
 	// read all packet info
 	offset = HEADER_LENGTH;
 	GET_USHORT(shooter_sig);
-	// GET_DATA(banks_fired);
 	PACKET_SET_SIZE();
 
 	// find the object this fired packet is operating on
 	objp = multi_get_network_object( shooter_sig );
-	if ( objp == NULL ) {
+	if ( objp == nullptr ) {
 		nprintf(("Network", "Could not find ship for fire primary packet NEW!\n"));
 		return;
 	}
@@ -7566,33 +7559,9 @@ void process_NEW_primary_fired_packet(ubyte *data, header *hinfo)
 		return;
 	}
 	shipp = &Ships[objp->instance];
-	
-	// get the link status of the primary banks
-	// linked = 0;
-	// if ( banks_fired & (1<<7) ) {
-		// linked = 1;
-		// banks_fired ^= (1<<7);
-	// }
-
-	// get the current primary bank
-	// current_bank = (ubyte)(banks_fired >> CURRENT_BANK_BIT);
-	// current_bank &= 0x3;
-	// Assert( (current_bank >= 0) && (current_bank < MAX_SHIP_PRIMARY_BANKS) );
-	// shipp->weapons.current_primary_bank = current_bank;
-
-	// strip off all remaining bits and just keep which banks were actually fired.
-	// banks_fired &= 0x3;
-	
-	// set the link status of the ship if not the player.  If it is the player, we will do sanity checking
-	// only (for now).	
-	// if ( !linked ){
-// 		shipp->flags &= ~SF_PRIMARY_LINKED;
-	// } else {
-		// shipp->flags.set(Ship::Ship_Flags::Primary_linked);
-	// }
 
 	// if we're in client firing mode, ignore ones for myself	
-	if((Player_obj != NULL) && (Player_obj == objp)){		
+	if((Player_obj != nullptr) && (Player_obj == objp)){		
 		return;
 	}
 		
@@ -7608,6 +7577,220 @@ void process_NEW_primary_fired_packet(ubyte *data, header *hinfo)
 		shipp->flags.set(Ship::Ship_Flags::Trigger_down);
 		ship_fire_primary( objp, 1, 1 );
 		shipp->flags.set(Ship::Ship_Flags::Trigger_down, flags);
+	}
+}
+
+const int NON_HOMING_PACKET_MISSILE	= (1 << 0);
+
+// Cyborg17 -- send the relative position of my fire to my current target as well as the frametime.
+// The whole goal of this is to create the weapon on the server that is heading at your target 
+// in the same exact way that it is on the client.
+void send_non_homing_fired_packet(ship* shipp, int banks_or_number_of_missiles_fired, bool secondary)
+{
+	Assertion(MULTIPLAYER_CLIENT, "Server is attempting to send the non_homing_fired_packet, which is client only. \n\nThis is a coder mistake.  Please report!");
+	if (MULTIPLAYER_MASTER) {
+		return;
+	}
+
+	int packet_size, objnum;
+	ubyte data[MAX_PACKET_SIZE], flags = 0; // ubanks_fired, current_bank;
+	object* objp;
+
+	// just in case nothing got fired
+	if (banks_or_number_of_missiles_fired <= 0) {
+		return;
+	}
+
+	// get an object pointer for this ship.
+	objnum = shipp->objnum;
+	objp = &Objects[objnum];
+
+	// I should never send non-homing packets for anyone except me
+	if (Player_obj != objp) {
+		return;
+	}
+
+	object* ref_objp = multi_get_network_object(multi_client_lookup_ref_obj_net_sig());
+	if (ref_objp == nullptr) {
+		mprintf(("Unable to get accurate reference object for non-homing packet.\n"));
+		if (!secondary) {
+			send_NEW_primary_fired_packet(shipp, banks_or_number_of_missiles_fired);
+		}
+		return;
+	}
+
+	BUILD_HEADER(LINEAR_WEAPON_FIRED);
+
+	if (secondary) {
+		flags |= NON_HOMING_PACKET_MISSILE;
+	}
+
+	// Add the shooting object.
+	ADD_USHORT(objp->net_signature);
+	ADD_DATA(flags);
+	ADD_USHORT(ref_objp->net_signature);
+
+	// We need the time elpased, so send the last frame we got from the server and how much time has happened since then.
+	int last_received_frame = multi_client_lookup_frame_idx();
+	auto time_elapsed = (ubyte)(timestamp() - multi_client_lookup_frame_timestamp());
+
+	ADD_INT(last_received_frame);
+	ADD_DATA(time_elapsed);
+
+	// Save the transposed matrix so that we can optimize and use it twice.
+	matrix ref_ori;
+	vm_copy_transpose(&ref_ori, &ref_objp->orient);
+
+	vec3d ref_to_ship_vec, temp;
+
+	// Find the vector between the two objects and normalize.
+	float distance = vm_vec_normalized_dir(&temp, &objp->pos, &ref_objp->pos);
+
+	ADD_FLOAT(distance);
+
+	// unrotate via transposed matrix. This is an "unrotate", because the matrix has already been transposed.  
+	// This finalized the relative position we will send to the server. 
+	vm_vec_rotate(&ref_to_ship_vec, &temp, &ref_ori );
+	ADD_VECTOR(ref_to_ship_vec);
+
+	angles adjustment_angles, player_ship_angles;
+
+	// Save on bandwidth by changing to angles.
+	vm_extract_angles_matrix_alternate(&adjustment_angles, &ref_ori);
+	vm_extract_angles_matrix_alternate(&player_ship_angles, &objp->orient);
+	
+	ADD_FLOAT(adjustment_angles.b);
+	ADD_FLOAT(adjustment_angles.h);
+	ADD_FLOAT(adjustment_angles.p);
+	ADD_FLOAT(player_ship_angles.b);
+	ADD_FLOAT(player_ship_angles.h);
+	ADD_FLOAT(player_ship_angles.p);
+
+	multi_io_send(Net_player, data, packet_size);
+}
+
+void process_non_homing_fired_packet(ubyte* data, header* hinfo)
+{
+	int offset; // linked;	
+	object* objp;
+	ushort shooter_sig;
+	ubyte flags;
+	bool secondary = false;
+
+	// read all packet info
+	offset = HEADER_LENGTH;
+	GET_USHORT(shooter_sig);
+	GET_DATA(flags);
+
+	// find the object this fired packet is operating on
+	objp = multi_get_network_object(shooter_sig);
+
+	if (flags & NON_HOMING_PACKET_MISSILE) {
+		secondary = true;
+	}
+
+	ubyte time_elapsed;
+	ushort target_ref;
+	int client_frame;
+	angles adjustment_angles, player_ship_angles;
+	float distance;
+	vec3d ref_to_ship_vec;
+
+	//finish processing the packet 
+	GET_USHORT(target_ref);
+	GET_INT(client_frame);
+	GET_DATA(time_elapsed);
+	GET_FLOAT(distance);
+	GET_VECTOR(ref_to_ship_vec);
+	GET_FLOAT(adjustment_angles.b);
+	GET_FLOAT(adjustment_angles.h);
+	GET_FLOAT(adjustment_angles.p);
+	GET_FLOAT(player_ship_angles.b);
+	GET_FLOAT(player_ship_angles.h);
+	GET_FLOAT(player_ship_angles.p);
+
+	PACKET_SET_SIZE();
+
+	if (objp == nullptr) {
+		nprintf(("Network", "Could not find ship for fire primary packet NEW!\n"));
+		return;
+	}
+	// if this object is not actually a valid ship, don't do anything
+	if (objp->type != OBJ_SHIP) {
+		return;
+	}
+	// Juke - also check (objp->instance >= MAX_SHIPS)
+	if (objp->instance < 0 || objp->instance >= MAX_SHIPS) {
+		return;
+	}
+
+	object* objp_ref = multi_get_network_object(target_ref);
+
+	if (objp_ref == nullptr) {
+		// new way failed, use the old new way.
+		if (secondary) {
+			// if this is a rollback shot from a dumbfire secondary, we have to mark this as a 
+			// rollback shot so the client doesn't get an extra shot.
+			ship_fire_secondary(objp, 0, true);
+		}
+		else {
+			ship_fire_primary(objp, 0, 1);
+		}
+		return;
+	}
+
+	// figure out correct start frame
+	int frame = multi_ship_record_find_frame(client_frame, time_elapsed);
+
+	if (frame > -1) {
+		// adjust time so that we can interpolate the position and orientation that was seen on the client.
+		int time_after_frame = multi_ship_record_find_time_after_frame(client_frame, frame, time_elapsed);
+		Assertion(time_after_frame >= 0, "Primary fire packet processor found an invalid time_after_frame of %d", time_after_frame);
+
+		vec3d new_tar_pos = multi_ship_record_lookup_position(objp_ref, frame);
+		matrix new_tar_ori = multi_ship_record_lookup_orientation(objp_ref, frame);
+		// find out where the angle to the new primary fire should be, by
+		// rotating the vector
+
+		vec3d temp_vec = ref_to_ship_vec;
+
+		// figure out the new position for the firing ship.
+		vm_vec_rotate(&ref_to_ship_vec, &temp_vec, &new_tar_ori);
+
+		// multiplay the distance back in
+		vm_vec_scale(&ref_to_ship_vec, distance);
+
+		// Finish finding the shot's starting position	
+		vec3d new_player_pos;
+		vm_vec_add(&new_player_pos, &ref_to_ship_vec, &new_tar_pos);
+
+		// "decompress" the orientation matrix from the packet's angles.
+		matrix adjust_ship_matrix, old_player_ori;
+		vm_angles_2_matrix(&adjust_ship_matrix, &adjustment_angles);
+		vm_angles_2_matrix(&old_player_ori, &player_ship_angles);
+
+		// "decompress" in the second way. The firing ship orientation was also stored in the packet because
+		// it was unrotated on the client side using the target's old orientation. 
+		matrix temp_ori;
+		vm_matrix_x_matrix(&temp_ori, &new_tar_ori, &adjust_ship_matrix);
+		vm_orthogonalize_matrix(&temp_ori);
+
+		// Now multiply the two matrices to find the orientation of the firing ship.
+		matrix new_player_ori;
+		vm_matrix_x_matrix(&new_player_ori, &old_player_ori, &temp_ori);
+		multi_ship_record_add_rollback_shot(objp, &new_player_pos, &new_player_ori, frame, secondary);
+
+	}	// if the new way fails for some reason, use the old way.
+	else {
+		nprintf(("Network", "Rollback was not performed because the frame sent by the client is either too old or invalid.. Using the old system.\n"));
+		if (secondary) {
+			// if this is a rollback shot from a dumbfire secondary, we have to mark this as a 
+			// rollback shot so the client doesn't get an extra missile for free.
+			ship_fire_secondary(objp, 0, true);
+		}
+		else {
+			ship_fire_primary(objp, 0, 1);
+		}
 	}
 }
 

--- a/code/network/multimsgs.cpp
+++ b/code/network/multimsgs.cpp
@@ -7632,10 +7632,10 @@ void send_non_homing_fired_packet(ship* shipp, int banks_or_number_of_missiles_f
 
 	// We need the time elpased, so send the last frame we got from the server and how much time has happened since then.
 	int last_received_frame = multi_client_lookup_frame_idx();
-	auto time_elapsed = (ubyte)(timestamp() - multi_client_lookup_frame_timestamp());
+	auto time_elapsed = (ushort)(timestamp() - multi_client_lookup_frame_timestamp());
 
 	ADD_INT(last_received_frame);
-	ADD_DATA(time_elapsed);
+	ADD_USHORT(time_elapsed);
 
 	// Save the transposed matrix so that we can optimize and use it twice.
 	matrix ref_ori;
@@ -7689,7 +7689,7 @@ void process_non_homing_fired_packet(ubyte* data, header* hinfo)
 		secondary = true;
 	}
 
-	ubyte time_elapsed;
+	ushort time_elapsed;
 	ushort target_ref;
 	int client_frame;
 	angles adjustment_angles, player_ship_angles;
@@ -7699,7 +7699,7 @@ void process_non_homing_fired_packet(ubyte* data, header* hinfo)
 	//finish processing the packet 
 	GET_USHORT(target_ref);
 	GET_INT(client_frame);
-	GET_DATA(time_elapsed);
+	GET_USHORT(time_elapsed);
 	GET_FLOAT(distance);
 	GET_VECTOR(ref_to_ship_vec);
 	GET_FLOAT(adjustment_angles.b);
@@ -7740,11 +7740,11 @@ void process_non_homing_fired_packet(ubyte* data, header* hinfo)
 	}
 
 	// figure out correct start frame
-	int frame = multi_ship_record_find_frame(client_frame, time_elapsed);
+	int frame = multi_ship_record_find_frame(client_frame, (int)time_elapsed);
 
 	if (frame > -1) {
 		// adjust time so that we can interpolate the position and orientation that was seen on the client.
-		int time_after_frame = multi_ship_record_find_time_after_frame(client_frame, frame, time_elapsed);
+		int time_after_frame = multi_ship_record_find_time_after_frame(client_frame, frame, (int)time_elapsed);
 		Assertion(time_after_frame >= 0, "Primary fire packet processor found an invalid time_after_frame of %d", time_after_frame);
 
 		vec3d new_tar_pos = multi_ship_record_lookup_position(objp_ref, frame);

--- a/code/network/multimsgs.h
+++ b/code/network/multimsgs.h
@@ -477,9 +477,13 @@ void process_emp_effect(ubyte *data, header *hinfo);
 void send_reinforcement_avail( int rnum );
 void process_reinforcement_avail( ubyte *data, header *hinfo );
 
+// for basic server shots to clients
+void send_NEW_primary_fired_packet(ship* shipp, int banks_fired);
+void process_NEW_primary_fired_packet(ubyte* data, header* hinfo);
+
 // new primary fired info
-void send_NEW_primary_fired_packet(ship *shipp, int banks_fired);
-void process_NEW_primary_fired_packet(ubyte *data, header *hinfo);
+void send_non_homing_fired_packet(ship *shipp, int banks_fired, bool secondary = false);
+void process_non_homing_fired_packet(ubyte *data, header *hinfo);
 
 // new countermeasure fired info
 void send_NEW_countermeasure_fired_packet(object *objp, int cmeasure_count, int rand_val);

--- a/code/object/collideshipship.cpp
+++ b/code/object/collideshipship.cpp
@@ -1124,6 +1124,11 @@ int collide_ship_ship( obj_pair * pair )
 	Assert( A->type == OBJ_SHIP );
 	Assert( B->type == OBJ_SHIP );
 
+	// Cyborg17 - no ship-ship collisions when doing multiplayer rollback
+	if ( (Game_mode & GM_MULTIPLAYER) && multi_ship_record_get_rollback_wep_mode() ) {
+		return 0;
+	}
+
 	if (reject_due_collision_groups(A,B))
 		return 0;
 

--- a/code/object/collideshipweapon.cpp
+++ b/code/object/collideshipweapon.cpp
@@ -497,6 +497,11 @@ int collide_ship_weapon( obj_pair * pair )
 
 	ship_info *sip = &Ship_info[Ships[ship->instance].ship_info_index];
 
+	// Cyborg17 - no ship-ship collisions when doing multiplayer rollback
+	if ( (Game_mode & GM_MULTIPLAYER) && multi_ship_record_get_rollback_wep_mode() && (weapon_obj->parent_sig == OBJ_INDEX(ship)) ) {
+		return 0;
+	}
+
 	// Don't check collisions for player if past first warpout stage.
 	if ( Player->control_mode > PCM_WARPOUT_STAGE1)	{
 		if ( ship == Player_obj )

--- a/code/object/objcollide.cpp
+++ b/code/object/objcollide.cpp
@@ -1023,7 +1023,7 @@ void obj_find_overlap_colliders(SCP_vector<int> &overlap_list_out, SCP_vector<in
 static SCP_vector<int> sort_list_y;
 static SCP_vector<int> sort_list_z;
 
-void obj_sort_and_collide()
+void obj_sort_and_collide(SCP_vector<int> Collision_list)
 {
 	if (Cmdline_dis_collisions)
 		return;
@@ -1034,9 +1034,9 @@ void obj_sort_and_collide()
 	sort_list_y.clear();
 	{
 		TRACE_SCOPE(tracing::SortColliders);
-		obj_quicksort_colliders(&Collision_sort_list, 0, (int)(Collision_sort_list.size() - 1), 0);
+		obj_quicksort_colliders(&Collision_list, 0, (int)(Collision_list.size() - 1), 0);
 	}
-	obj_find_overlap_colliders(sort_list_y, Collision_sort_list, 0, false);
+	obj_find_overlap_colliders(sort_list_y, Collision_list, 0, false);
 
 	sort_list_z.clear();
 	{

--- a/code/object/objcollide.cpp
+++ b/code/object/objcollide.cpp
@@ -1031,6 +1031,12 @@ void obj_sort_and_collide(SCP_vector<int>* Collision_list)
 	if ( !(Game_detail_flags & DETAIL_FLAG_COLLISION) )
 		return;
 
+	// the main use case is to go through the main Collision detection list, so use that if
+	// nothing is defined.
+	if (Collision_list == nullptr) {
+		Collision_list = &Collision_sort_list;
+	}
+
 	sort_list_y.clear();
 	{
 		TRACE_SCOPE(tracing::SortColliders);

--- a/code/object/objcollide.cpp
+++ b/code/object/objcollide.cpp
@@ -1023,7 +1023,7 @@ void obj_find_overlap_colliders(SCP_vector<int> &overlap_list_out, SCP_vector<in
 static SCP_vector<int> sort_list_y;
 static SCP_vector<int> sort_list_z;
 
-void obj_sort_and_collide(SCP_vector<int> Collision_list)
+void obj_sort_and_collide(SCP_vector<int>* Collision_list)
 {
 	if (Cmdline_dis_collisions)
 		return;
@@ -1034,9 +1034,9 @@ void obj_sort_and_collide(SCP_vector<int> Collision_list)
 	sort_list_y.clear();
 	{
 		TRACE_SCOPE(tracing::SortColliders);
-		obj_quicksort_colliders(&Collision_list, 0, (int)(Collision_list.size() - 1), 0);
+		obj_quicksort_colliders(Collision_list, 0, (int)(Collision_list->size() - 1), 0);
 	}
-	obj_find_overlap_colliders(sort_list_y, Collision_list, 0, false);
+	obj_find_overlap_colliders(sort_list_y, *Collision_list, 0, false);
 
 	sort_list_z.clear();
 	{

--- a/code/object/objcollide.h
+++ b/code/object/objcollide.h
@@ -57,6 +57,7 @@ struct obj_pair	{
 	struct obj_pair *next;
 };
 
+extern SCP_vector<int> Collision_sort_list;
 
 #define COLLISION_OF(a,b) (((a)<<8)|(b))
 
@@ -67,7 +68,7 @@ void set_hit_struct_info(collision_info_struct *hit, mc_info *mc, int submodel_r
 void obj_add_collider(int obj_index);
 void obj_remove_collider(int obj_index);
 void obj_reset_colliders();
-void obj_sort_and_collide();
+void obj_sort_and_collide(SCP_vector<int> Collision_list = Collision_sort_list);
 
 // retimes all collision pairs to be checked (in 25ms by default)
 void obj_collide_retime_cached_pairs(int checkdly=25);

--- a/code/object/objcollide.h
+++ b/code/object/objcollide.h
@@ -68,7 +68,7 @@ void set_hit_struct_info(collision_info_struct *hit, mc_info *mc, int submodel_r
 void obj_add_collider(int obj_index);
 void obj_remove_collider(int obj_index);
 void obj_reset_colliders();
-void obj_sort_and_collide(SCP_vector<int>* Collision_list = &Collision_sort_list);
+void obj_sort_and_collide(SCP_vector<int>* Collision_list = nullptr);
 
 // retimes all collision pairs to be checked (in 25ms by default)
 void obj_collide_retime_cached_pairs(int checkdly=25);

--- a/code/object/objcollide.h
+++ b/code/object/objcollide.h
@@ -68,7 +68,7 @@ void set_hit_struct_info(collision_info_struct *hit, mc_info *mc, int submodel_r
 void obj_add_collider(int obj_index);
 void obj_remove_collider(int obj_index);
 void obj_reset_colliders();
-void obj_sort_and_collide(SCP_vector<int> Collision_list = Collision_sort_list);
+void obj_sort_and_collide(SCP_vector<int>* Collision_list = &Collision_sort_list);
 
 // retimes all collision pairs to be checked (in 25ms by default)
 void obj_collide_retime_cached_pairs(int checkdly=25);

--- a/code/object/object.cpp
+++ b/code/object/object.cpp
@@ -24,6 +24,7 @@
 #include "mission/missionparse.h" //For 2D Mode
 #include "network/multi.h"
 #include "network/multiutil.h"
+#include "network//multi_obj.h"
 #include "object/deadobjectdock.h"
 #include "object/objcollide.h"
 #include "object/object.h"
@@ -765,7 +766,13 @@ void obj_player_fire_stuff( object *objp, control_info ci )
 			}
 
 			// fire non-streaming primaries here
-			ship_fire_primary( objp, 0 );
+			// Cyborg17, this is where the inaccurate multi shots are being shot... 
+			// so let's let the new system take over instead by excluding client player shots
+			// on the server.
+			if (!(MULTIPLAYER_MASTER) || (objp == Player_obj)) {
+				ship_fire_primary(objp, 0);
+			}
+			
 		} else {
 			// unflag the ship as having the trigger down
 			if(shipp != NULL){
@@ -780,8 +787,10 @@ void obj_player_fire_stuff( object *objp, control_info ci )
 	}
 
 	// single player and multiplayer masters do all of the following
-	if ( !MULTIPLAYER_CLIENT ) {		
-		if ( ci.fire_secondary_count ) {
+	if ( !MULTIPLAYER_CLIENT 
+		// Cyborg17 - except clients now fire dumbfires for rollback on the server
+		|| !(Weapon_info[shipp->weapons.secondary_bank_weapons[shipp->weapons.current_secondary_bank]].is_homing())) {		
+		if (ci.fire_secondary_count) {
    			if ( !ship_start_secondary_fire(objp) ) {
 				ship_fire_secondary( objp );
 			}
@@ -1593,6 +1602,11 @@ void obj_move_all(float frametime)
 
 	// do post-collision stuff for beam weapons
 	beam_move_all_post();
+
+	// Cyborg17 - Update the multi record on multi with these new positions. Clients need to get updated, too.
+	if (MULTIPLAYER_MASTER) {
+		multi_ship_record_update_all();
+	}
 
 	// update artillery locking info now
 	ship_update_artillery_lock();

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -9839,6 +9839,11 @@ int ship_create(matrix* orient, vec3d* pos, int ship_type, const char* ship_name
 		entry->objp = &Objects[objnum];
 		entry->shipp = shipp;
 	}
+	
+	// Start up stracking for this ship in multi.
+	if (Game_mode & (GM_MULTIPLAYER)) {
+		multi_ship_record_add_ship(objnum);
+	}
 
 	// Set time when ship is created
 	shipp->create_time = timer_get_milliseconds();
@@ -10998,7 +11003,7 @@ bool in_autoaim_fov(ship *shipp, int bank_to_fire, object *obj)
 // the function.  The check_energy parameter (defaults to 1) tells us whether or not
 // we should check the energy.  It will be 0 when a multiplayer client is firing an AI
 // primary.
-int ship_fire_primary(object * obj, int stream_weapons, int force)
+int ship_fire_primary(object * obj, int stream_weapons, int force, bool rollback_shot)
 {
 	vec3d		gun_point, pnt, firing_pos, target_position, target_velocity_vec;
 	int			n = obj->instance;
@@ -11161,18 +11166,20 @@ int ship_fire_primary(object * obj, int stream_weapons, int force)
 			continue;
 		}
 
-		// if we're firing stream weapons and this is a non stream weapon, skip it
-		if(stream_weapons && !(winfo_p->wi_flags[Weapon::Info_Flags::Stream])){
-			continue;
-		}
-		// if we're firing non stream weapons and this is a stream weapon, skip it
-		if(!stream_weapons && (winfo_p->wi_flags[Weapon::Info_Flags::Stream])){
-			continue;
-		}
-
-		// only non-multiplayer clients (single, multi-host) need to do timestamp checking
-		if ( !timestamp_elapsed(swp->next_primary_fire_stamp[bank_to_fire]) ) {
-			continue;
+		// Cyborg17 - In rollback mode we don't need to worry about stream weapons or timestamps, because we are recreating an exact shot, anywway.
+		if (!rollback_shot) {
+			// if we're firing stream weapons and this is a non stream weapon, skip it
+			if (stream_weapons && !(winfo_p->wi_flags[Weapon::Info_Flags::Stream])) {
+				continue;
+			}
+			// if we're firing non stream weapons and this is a stream weapon, skip it
+			if (!stream_weapons && (winfo_p->wi_flags[Weapon::Info_Flags::Stream])) {
+				continue;
+			}
+			// only non-multiplayer clients (single, multi-host) need to do timestamp checking
+			if ( !timestamp_elapsed(swp->next_primary_fire_stamp[bank_to_fire]) ) {
+				continue;
+			}
 		}
 
 		// if weapons are linked and this is a nolink weapon, skip it
@@ -11685,7 +11692,12 @@ int ship_fire_primary(object * obj, int stream_weapons, int force)
 							}
 
 							num_fired++;
-							shipp->last_fired_point[bank_to_fire] = (shipp->last_fired_point[bank_to_fire] + 1) % num_slots;
+							shipp->last_fired_point[bank_to_fire] = (shipp->last_fired_point[bank_to_fire] + 1) % num_slots;				
+
+							// maybe add this weapon to the list of those we need to roll forward
+							if ((Game_mode & (GM_MULTIPLAYER | GM_STANDALONE_SERVER )) && rollback_shot) {
+								multi_ship_record_add_rollback_wep(weapon_objnum);
+							}
 						}
 					}
 					swp->external_model_fp_counter[bank_to_fire]++;
@@ -11765,10 +11777,13 @@ int ship_fire_primary(object * obj, int stream_weapons, int force)
 	
 	// if multiplayer and we're client-side firing, send the packet
 	if(Game_mode & GM_MULTIPLAYER){
-		// if i'm a client, and this is not me, don't send
-		if(!(MULTIPLAYER_CLIENT && (shipp != Player_ship))){
-			send_NEW_primary_fired_packet( shipp, banks_fired );
-		}
+		// if I'm a Host send a primary fired packet packet if it's brand new
+		if(MULTIPLAYER_MASTER && !rollback_shot) {
+			send_NEW_primary_fired_packet(shipp, banks_fired);
+		// or if I'm a client, and it is my ship send it for rollback on the server.
+		} else if (MULTIPLAYER_CLIENT && (shipp == Player_ship)) {
+				send_non_homing_fired_packet(shipp, banks_fired);
+		}		 
 	}
 
    // STATS
@@ -11950,7 +11965,7 @@ extern void ai_maybe_announce_shockwave_weapon(object *firing_objp, int weapon_i
 //	code comes aruond and fires it.
 // allow_swarm -> default value is 0... since swarm missiles are fired over several frames,
 //                need to avoid firing when normally called
-int ship_fire_secondary( object *obj, int allow_swarm )
+int ship_fire_secondary( object *obj, int allow_swarm, bool rollback_shot )
 {
 	int			n, weapon_idx, j, bank, bank_adjusted, starting_bank_count = -1, num_fired;
 	ushort		starting_sig = 0;
@@ -12116,7 +12131,7 @@ int ship_fire_secondary( object *obj, int allow_swarm )
 	{
 		if (!ship_is_tagged(&Objects[aip->target_objnum]))
 		{
-			if (obj==Player_obj)
+			if (obj==Player_obj || (MULTIPLAYER_MASTER && obj->flags[Object::Object_Flags::Player_ship]))
 			{
 				if ( !Weapon_energy_cheat )
 				{
@@ -12378,6 +12393,11 @@ int ship_fire_secondary( object *obj, int allow_swarm )
 				if (Weapon_info[weapon_idx].wi_flags[Weapon::Info_Flags::Remote])
 					swp->remote_detonaters_active++;
 
+				// possibly add this to the rollback vector
+				if ((Game_mode & (GM_MULTIPLAYER | GM_STANDALONE_SERVER)) && rollback_shot){
+					multi_ship_record_add_rollback_wep(weapon_num);
+				}
+
 				// subtract the number of missiles fired
 				if ( !Weapon_energy_cheat ){
 					swp->secondary_bank_ammo[bank]--;
@@ -12410,14 +12430,14 @@ done_secondary:
 
 	if(num_fired > 0){
 		// if I am the master of a multiplayer game, send a secondary fired packet along with the
-		// first network signatures for the newly created weapons.  if nothing got fired, send a failed
-		// packet if 
+		// first network signatures for the newly created weapons.
+		// Cyborg17 - If this is a rollback shot, the server will let the player know within the packet.
 		if ( MULTIPLAYER_MASTER ) {			
 			Assert(starting_sig != 0);
 			send_secondary_fired_packet( shipp, starting_sig, starting_bank_count, num_fired, allow_swarm );			
 		}
 
-		// STATS
+		// Handle Player only stuff, including stats and client secondary packets
 		if (obj->flags[Object::Object_Flags::Player_ship]) {
 			// in multiplayer -- only the server needs to keep track of the stats.  Call the cool
 			// function to find the player given the object *.  It had better return a valid player
@@ -12430,7 +12450,10 @@ done_secondary:
 					Assert ( player_num != -1 );
 
 					Net_players[player_num].m_player->stats.ms_shots_fired += num_fired;
-				}				
+				} else if (MULTIPLAYER_CLIENT) {
+					if (!wip->is_homing())
+					send_non_homing_fired_packet(shipp, num_fired, true);
+				}
 			} else {
 				Player->stats.ms_shots_fired += num_fired;
 			}

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -1518,11 +1518,10 @@ extern void ship_actually_depart(int shipnum, int method = SHIP_DEPARTED_WARP);
 
 extern bool in_autoaim_fov(ship *shipp, int bank_to_fire, object *obj);
 extern int ship_stop_fire_primary(object * obj);
-extern int ship_fire_primary(object * objp, int stream_weapons, int force = 0);
-extern int ship_fire_secondary(object * objp, int allow_swarm = 0 );
+extern int ship_fire_primary(object * objp, int stream_weapons, int force = 0, bool rollback_shot = false);
+extern int ship_fire_secondary(object * objp, int allow_swarm = 0, bool rollback_shot = false );
 bool ship_start_secondary_fire(object* objp);
 bool ship_stop_secondary_fire(object* objp);
-
 extern int ship_launch_countermeasure(object *objp, int rand_val = -1);
 
 // for special targeting lasers


### PR DESCRIPTION
This creates a packet that sends the relative position and orientation info for a primary or dumbfire missile shot.  The client creates this packet when firing those two types of weapons and sends it to the server.  The server goes back to the frame that the client fired the weapon and quickly re-simulates all the frames in-between.

This includes collision detection, restoring positions, orientations and velocities, but not subsystem orientations.

Now that the object update packet is merged, note that this is mainly to ensure that high ping clients can fire primary shots with the same accuracy on server and client.