### PR TITLE
Add 'Turning Acceleration Time' to missiles

### DIFF
--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -1278,6 +1278,11 @@ void ai_turn_towards_vector(vec3d* dest, object* objp, vec3d* slide_vec, vec3d* 
 		else { 
 			// else, calculate the retail-friendly vel and acc values
 			ai_compensate_for_retail_turning(&vel_limit, &acc_limit, rotdamp, objp->type == OBJ_WEAPON);
+
+			// handle missile turning accel (which is bundled into rotdamp)
+			if (objp->type == OBJ_WEAPON && rotdamp != 0.f) {
+				acc_limit = vel_limit * (0.5f / rotdamp);
+			}
 		}
 	}
 

--- a/code/physics/physics.h
+++ b/code/physics/physics.h
@@ -42,7 +42,9 @@ typedef struct physics_info {
 	vec3d		center_of_mass;		// Goober5000 - this is never ever used by physics; currently physics assumes the center of an object is the center of mass
 	matrix	I_body_inv;		// inverse moment of inertia tensor (used to calculate rotational effects)
 
-	float		rotdamp;			//rotational velocity damping
+	float		rotdamp;			// for players, the exponential time constant applied to rotational velocity changes
+									// for AI ships and missiles, the polynomial approximation of the same, 
+									// such that rotdamp * 2 is the total acceleration time
 	float		side_slip_time_const;	// time const for achieving desired velocity in the local sideways direction
 												//   value should be zero for no sideslip and increase depending on desired slip
 

--- a/code/weapon/weapon.h
+++ b/code/weapon/weapon.h
@@ -321,6 +321,7 @@ struct weapon_info
 	flagset<Weapon::Info_Flags>	wi_flags;							//	bit flags defining behavior, see WIF_xxxx
 
 	float turn_time;
+	float turn_accel_time;
 	float	cargo_size;							// cargo space taken up by individual weapon (missiles only)
 	float rearm_rate;							// rate per second at which secondary weapons are loaded during rearming
 	int		reloaded_per_batch;				    // number of munitions rearmed per batch

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -1333,6 +1333,14 @@ int parse_weapon(int subtype, bool replace, const char *filename)
 				stuff_float(&wip->turn_time);
 			}
 
+			if (optional_string("+Turning Acceleration Time:")) {
+				stuff_float(&wip->turn_accel_time);
+				if (!Framerate_independent_turning) {
+					Warning(LOCATION, "Turning Acceleration Time for weapon %s requires \"AI use framerate independent turning\" in game_settings.tbl ", wip->name);
+					wip->turn_accel_time = 0.f;
+				}
+			}
+
 			if(optional_string("+View Cone:")) {
 				stuff_float(&view_cone_angle);
 				wip->fov = cosf(fl_radians(view_cone_angle * 0.5f));
@@ -1374,6 +1382,14 @@ int parse_weapon(int subtype, bool replace, const char *filename)
 		{
 			if(optional_string("+Turn Time:")) {
 				stuff_float(&wip->turn_time);
+			}
+
+			if (optional_string("+Turning Acceleration Time:")) {
+				stuff_float(&wip->turn_accel_time);
+				if (!Framerate_independent_turning) {
+					Warning(LOCATION, "Turning Acceleration Time for weapon %s requires \"AI use framerate independent turning\" in game_settings.tbl ", wip->name);
+					wip->turn_accel_time = 0.f;
+				}
 			}
 
 			if(optional_string("+View Cone:")) {
@@ -5599,7 +5615,7 @@ int weapon_create( vec3d * pos, matrix * porient, int weapon_type, int parent_ob
 
 	objp->phys_info.mass = wip->mass;
 	objp->phys_info.side_slip_time_const = 0.0f;
-	objp->phys_info.rotdamp = 0.0f;
+	objp->phys_info.rotdamp = wip->turn_accel_time ? wip->turn_accel_time / 2.f : 0.0f;
 	vm_vec_zero(&objp->phys_info.max_vel);
 	objp->phys_info.max_vel.xyz.z = wip->max_speed;
 	vm_vec_zero(&objp->phys_info.max_rotvel);
@@ -7914,6 +7930,7 @@ void weapon_info::reset()
 	this->wi_flags.reset();
 
 	this->turn_time = 1.0f;
+	this->turn_accel_time = 0.f;
 	this->cargo_size = 1.0f;
 	this->rearm_rate = 1.0f;
 	this->reloaded_per_batch = -1;

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -1336,7 +1336,11 @@ int parse_weapon(int subtype, bool replace, const char *filename)
 			if (optional_string("+Turning Acceleration Time:")) {
 				stuff_float(&wip->turn_accel_time);
 				if (!Framerate_independent_turning) {
-					Warning(LOCATION, "Turning Acceleration Time for weapon %s requires \"AI use framerate independent turning\" in game_settings.tbl ", wip->name);
+					static bool No_flag_turn_accel_warned = false;
+					if (!No_flag_turn_accel_warned) {
+						No_flag_turn_accel_warned = true;
+						Warning(LOCATION, "One or more weapons are using Turning Acceleration Time; this requires \"AI use framerate independent turning\" in game_settings.tbl ");
+					}
 					wip->turn_accel_time = 0.f;
 				}
 			}
@@ -1387,7 +1391,11 @@ int parse_weapon(int subtype, bool replace, const char *filename)
 			if (optional_string("+Turning Acceleration Time:")) {
 				stuff_float(&wip->turn_accel_time);
 				if (!Framerate_independent_turning) {
-					Warning(LOCATION, "Turning Acceleration Time for weapon %s requires \"AI use framerate independent turning\" in game_settings.tbl ", wip->name);
+					static bool No_flag_turn_accel_warned = false;
+					if (!No_flag_turn_accel_warned) {
+						No_flag_turn_accel_warned = true;
+						Warning(LOCATION, "One or more weapons are using Turning Acceleration Time; this requires \"AI use framerate independent turning\" in game_settings.tbl ");
+					}
 					wip->turn_accel_time = 0.f;
 				}
 			}


### PR DESCRIPTION
Allows missiles to accelerate to their maximum turning speed, adds an interesting extra dynamic to their flight, and also makes their path look a bit more realistic, but does require `Framerate_independent_turning`