### PR TITLE
Fix to Non Shielded Ships Manage ETS

### DIFF
--- a/code/hud/hudets.cpp
+++ b/code/hud/hudets.cpp
@@ -202,7 +202,7 @@ void ai_manage_ets(object* obj)
 {
 	ship* ship_p = &Ships[obj->instance];
 	ship_info* ship_info_p = &Ship_info[ship_p->ship_info_index];
-	ai_info	*aip = &Ai_info[Ships[Pl_objp->instance].ai_index];
+	ai_info* aip = &Ai_info[Ships[obj->instance].ai_index];
 
 	if ( ship_info_p->power_output == 0 )
 		return;


### PR DESCRIPTION
This one line fix properly specifies which ship to use for ETS managment. The recent merge of `Non-shielded ships manage ETS` had a object reference error, so this rectifies that. Thanks to Axem for finding this!