### PR TITLE
Allow for 'laser-style' particles

### DIFF
--- a/code/particle/particle.cpp
+++ b/code/particle/particle.cpp
@@ -440,7 +440,7 @@ namespace particle
 
 			Assert( cur_frame < part->nframes );
 
-			if (part->length) {
+			if (part->length != 0.0f) {
 				vec3d p0 = part->pos;
 
 				vec3d p1;

--- a/code/particle/particle.cpp
+++ b/code/particle/particle.cpp
@@ -140,6 +140,7 @@ namespace particle
 		part->reverse = info->reverse;
 		part->particle_index = (int) Persistent_particles.size();
 		part->looping = false;
+		part->length = info->length;
 
 		switch (info->type)
 		{
@@ -439,7 +440,20 @@ namespace particle
 
 			Assert( cur_frame < part->nframes );
 
-			batching_add_volume_bitmap(framenum + cur_frame, &pos, part->particle_index % 8, part->radius, alpha);
+			if (part->length) {
+				vec3d p0 = part->pos;
+
+				vec3d p1;
+				vm_vec_copy_normalize(&p1, &part->velocity);
+				p1 *= part->length;
+				p1 += part->pos;
+
+				batching_add_laser(framenum + cur_frame, &p0, part->radius, &p1, part->radius);
+			}
+			else {
+				batching_add_volume_bitmap(framenum + cur_frame, &pos, part->particle_index % 8, part->radius, alpha);
+			}
+
 
 			return true;
 		}

--- a/code/particle/particle.h
+++ b/code/particle/particle.h
@@ -74,6 +74,7 @@ namespace particle
 		int attached_sig = -1;					// to make sure the object hasn't changed or died. velocity is ignored in this case
 		bool reverse = false;					// play any animations in reverse
 		bool lifetime_from_animation = true;	// if the particle plays an animation then use the anim length for the particle life
+		float length = 0.f;						// if set, makes the particle render like a laser, oriented along its path
 	} particle_info;
 
 	typedef struct particle {
@@ -93,6 +94,7 @@ namespace particle
 		int		attached_sig;		// to check for dead/nonexistent objects
 		bool	reverse;			// play any animations in reverse
 		int		particle_index;		// used to keep particle offset in dynamic array for orient usage
+		float   length;				// the length of the particle for laser-style rendering
 	} particle;
 
 	typedef std::weak_ptr<particle> WeakParticlePtr;

--- a/code/particle/util/ParticleProperties.cpp
+++ b/code/particle/util/ParticleProperties.cpp
@@ -6,7 +6,7 @@
 
 namespace particle {
 namespace util {
-ParticleProperties::ParticleProperties() : m_radius(0.0f, 1.0f), m_lifetime(0.0f, 1.0f) {
+ParticleProperties::ParticleProperties() : m_radius(0.0f, 1.0f), m_lifetime(0.0f, 1.0f), m_length (0.0f, 1.0f){
 }
 
 void ParticleProperties::parse(bool nocreate) {
@@ -16,6 +16,10 @@ void ParticleProperties::parse(bool nocreate) {
 
 	if (internal::required_string_if_new("+Size:", nocreate)) {
 		m_radius = ::util::parseUniformRange<float>();
+	}
+
+	if (optional_string("+Length:")) {
+		m_length = ::util::parseUniformRange<float>();
 	}
 
 	if (optional_string("+Lifetime:")) {
@@ -34,6 +38,7 @@ void ParticleProperties::createParticle(particle_info& info) {
 	info.optional_data = m_bitmap;
 	info.type = PARTICLE_BITMAP;
 	info.rad = m_radius.next();
+	info.length = m_length.next();
 	if (m_hasLifetime) {
 		info.lifetime = m_lifetime.next();
 		info.lifetime_from_animation = false;
@@ -46,6 +51,7 @@ WeakParticlePtr ParticleProperties::createPersistentParticle(particle_info& info
 	info.optional_data = m_bitmap;
 	info.type = PARTICLE_BITMAP;
 	info.rad = m_radius.next();
+	info.length = m_length.next();
 
 	auto p = createPersistent(&info);
 

--- a/code/particle/util/ParticleProperties.cpp
+++ b/code/particle/util/ParticleProperties.cpp
@@ -6,7 +6,7 @@
 
 namespace particle {
 namespace util {
-ParticleProperties::ParticleProperties() : m_radius(0.0f, 1.0f), m_lifetime(0.0f, 1.0f), m_length (0.0f, 1.0f){
+ParticleProperties::ParticleProperties() : m_radius(0.0f, 1.0f), m_lifetime(0.0f, 1.0f), m_length (0.0f){
 }
 
 void ParticleProperties::parse(bool nocreate) {

--- a/code/particle/util/ParticleProperties.h
+++ b/code/particle/util/ParticleProperties.h
@@ -19,6 +19,7 @@ class ParticleProperties {
 
 	bool m_hasLifetime = false;
 	::util::UniformFloatRange m_lifetime;
+	::util::UniformFloatRange m_length;
 
 	ParticleProperties();
 


### PR DESCRIPTION
Adds the 'Length' field to particles in particles.tbl, which, when specified, will render the particle like a laser, with the head and tail radius as the 'Size', and the length... as the 'Length'. Importantly also orienting the bitmap along its velocity vector. I'm still acclimating to the fancier C++ structures, so some oversight would be appreciated.