### PR TITLE
Improved collision avoidance for fighters

### DIFF
--- a/code/ai/ai.h
+++ b/code/ai/ai.h
@@ -471,8 +471,8 @@ typedef struct ai_info {
 	fix		avoid_check_timestamp;			//	timestamp at which to next check for having to avoid ship
 
 	vec3d	big_collision_normal;			// Global normal of collision with big ship.  Helps find direction to fly away from big ship.  Set for each collision.
-	vec3d	big_recover_pos_1;				//	Global point to fly towards when recovering from collision with a big ship, stage 1.
-	vec3d	big_recover_pos_2;				//	Global point to fly towards when recovering from collision with a big ship, stage 2.
+	vec3d	big_recover_1_direction;		//	A relative direction to fly towards when recovering from collision with a big ship, stage 1.
+	vec3d	big_recover_2_pos;				//	Global point to fly towards when recovering from collision with a big ship, stage 2.
 	int		big_recover_timestamp;			//	timestamp at which it's OK to re-enter stage 1.
 
 	int		abort_rearm_timestamp;			//	time at which this rearm should be aborted in a multiplayer game.

--- a/code/ai/ai_flags.h
+++ b/code/ai/ai_flags.h
@@ -129,6 +129,7 @@ namespace AI {
         No_turning_directional_bias,
 		Use_axial_turnrate_differences,
 		nonshielded_ships_can_manage_ets,
+		Better_collision_avoidance,
 
 		NUM_VALUES
 	};

--- a/code/ai/ai_profiles.cpp
+++ b/code/ai/ai_profiles.cpp
@@ -525,6 +525,8 @@ void parse_ai_profiles_tbl(const char *filename)
 
 				set_flag(profile, "$ships with no shields can manage ETS:", AI::Profile_Flags::nonshielded_ships_can_manage_ets);
 
+				set_flag(profile, "$better combat collision avoidance for fightercraft:", AI::Profile_Flags::Better_collision_avoidance);
+
 				// if we've been through once already and are at the same place, force a move
 				if (saved_Mp && (saved_Mp == Mp))
 				{

--- a/code/ai/aibig.cpp
+++ b/code/ai/aibig.cpp
@@ -737,7 +737,7 @@ void ai_big_chase_ct()
 extern void ai_select_secondary_weapon(object *objp, ship_weapon *swp, int priority1 = -1, int priority2 = -1);
 extern float set_secondary_fire_delay(ai_info *aip, ship *shipp, weapon_info *swip, bool burst);
 extern void ai_choose_secondary_weapon(object *objp, ai_info *aip, object *en_objp);
-extern int maybe_avoid_big_ship(object *objp, object *ignore_objp, ai_info *aip, vec3d *goal_point, float delta_time);
+extern int maybe_avoid_big_ship(object *objp, object *ignore_objp, ai_info *aip, vec3d *goal_point, float delta_time, float time_scale = 1.f);
 
 extern void maybe_cheat_fire_synaptic(object *objp);
 

--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -14905,7 +14905,7 @@ void big_ship_collide_recover_start(object *objp, object *big_objp, vec3d *colli
 
 	vec3d global_recover_pos_1 = aip->big_recover_1_direction + objp->pos;
 	// go out 200 m from box closest box point
-	get_world_closest_box_point_with_delta(&aip->big_recover_2_pos, big_objp, &global_recover_pos_1, NULL, 300.0f);
+	get_world_closest_box_point_with_delta(&aip->big_recover_2_pos, big_objp, &global_recover_pos_1, nullptr, 300.0f);
 
 	accelerate_ship(aip, 0.0f);
 }


### PR DESCRIPTION
Tired of enemies afterburning directly into the broad side of an Orion? Not anymore! 

Adds the "$better combat collision avoidance for fightercraft:" flag. While fighting, and only while fighting, (that is, `AIM_CHASE`) small ships will project their velocity outward to predict collisions and avoid colliding with big or huge ships that it finds, before executing any of its submodes. This is sort of collision detection is usually only done while in an attack submode, and only along the me-to-my-target vector, making it only useful to circumvent intervening obstacles. For this reason (and probably also for now irrelevant performance reasons), the timings used by the function are relatively long, so a `time_scale` parameter was added so it could be used much more frequently by the general combat collision avoidance. 1.5 seconds, the default time to recheck if no collision was found, is more than enough time to go from 'a comfortable distance from the destroyer' to a collision, so the time scale has been set for it to check ten times more frequently.

Additionally, since this system is not perfect and collisions will still occasionally occur, ships in combat will now spend far less time recovering from it. Rather than up to 45 seconds (!!!) and usually making them utterly useless and a sitting duck, these ships will only spend two seconds recovering, instead of leisurely waltzing to the ship's bounding box.

One small change that is *not* covered by the flag, and will affect retail is that the recovery system was slightly altered. Normally after a collision the ship will project a vector 100m away from the collision to go to for phase 1, and then the closest bbox point for phase 2 (spending at most 15 and 30 seconds on each phase). I've modified it slightly so that phase 1 generates a relative direction to travel in, rather than a global position, and since it can't actually reach this point now the time was reduced to 5 seconds (an average case for phase 1). For high velocity collisions its entirely possible the ship can end up several hundred meters from its original position by the time it regains control, so it may end up spending phase 1 uselessly traveling basically back to the original collision point rather than actually moving away from the collision.

This was done because it works very well in tandem with the other changes, but is hard to reconcile with the retail handling while also being very minor and unlikely to break anything.
