### PR TITLE
Fix missing background color in paletted HUD gauges

### DIFF
--- a/code/anim/packunpack.cpp
+++ b/code/anim/packunpack.cpp
@@ -151,14 +151,21 @@ int unpack_pixel(anim_instance *ai, ubyte *data, ubyte pix, int aabitmap, int bp
 			bit_16 = (ushort)pix;
 			break;
 		case 8:
-			// 8 bit-per-pixel aa bitmaps are a bit special since they only use value in the range [0, 15] where 15 wraps
-			// around back to 0. Since the rest of the code expects the value to be in the range [0, 255] the pixel value
-			// needs to be adjusted here. By muliplying the value with 17 the original range [0, 15] is mapped to [0, 255]
-			if (pix >= 15) {
-				bit_8 = 0;
-			} else {
-				bit_8 = (ubyte)(pix * 17);
+			// 8 bit-per-pixel aa bitmaps are a bit special since they only use a palette index value in the range [0, 15]. These 
+			// palette indexes must be remapped to alpha values between [0, 255] which is what graphics code expects. Palette 
+			// range [0, 14] is a gradient from black to white, and palette index 15 is a special color which indicates the background
+			// area of a HUD gauge. Retail code uses the final alpha value for index 1 for this special index to give gauges a dark
+			// transparent background.
+			if (pix > 15) {
+				bit_8 = 255;
 			}
+			else if (pix == 15) {
+				bit_8 = 18;
+			}
+			else {
+				bit_8 = (ubyte)(pix * 18);
+			}
+
 			break;
 		default:
 			Int3();
@@ -242,14 +249,21 @@ int unpack_pixel_count(anim_instance *ai, ubyte *data, ubyte pix, int count = 0,
 			bit_16 = (ushort)pix;
 			break;
 		case 8 :
-			// 8 bit-per-pixel aa bitmaps are a bit special since they only use value in the range [0, 15] where 15 wraps
-			// around back to 0. Since the rest of the code expects the value to be in the range [0, 255] the pixel value
-			// needs to be adjusted here. By muliplying the value with 17 the original range [0, 15] is mapped to [0, 255]
-			if (pix >= 15) {
-				bit_8 = 0;
-			} else {
-				bit_8 = (ubyte)(pix * 17);
+			// 8 bit-per-pixel aa bitmaps are a bit special since they only use a palette index value in the range [0, 15]. These 
+			// palette indexes must be remapped to alpha values between [0, 255] which is what graphics code expects. Palette 
+			// range [0, 14] is a gradient from black to white, and palette index 15 is a special color which indicates the background
+			// area of a HUD gauge. Retail code uses the final alpha value for index 1 for this special index to give gauges a dark
+			// transparent background.
+			if (pix > 15) {
+				bit_8 = 255;
 			}
+			else if (pix == 15) {
+				bit_8 = 18;
+			}
+			else {
+				bit_8 = (ubyte)(pix * 18);
+			}
+
 			break;
 		default :
 			Int3();			


### PR DESCRIPTION
Fixes #2811

Code was moved around between 3.8.0 and 19.0.0 which broke the colored backgrounds of paletted HUD gauges.

Palette index 15 is used by the HUD gauge graphics to indicate background area of HUD gauges. When the code to remap palette indexes to alpha values was moved to packunpack.cpp in Commit 72a797f, palette index 15 was mistakenly mapped to alpha value 0 (nothing) rather than the alpha that palette index 1 would get (which is what retail/3.8.0 code does) causing all HUD gauges to be missing their dark transparent backgrounds.

Also: the code maps palette indexes [0, 15] to alpha values [0, 255]. But due to an oversight (palette index 15 not being part of this gradient and being mapped to a lower value) alpha value 255 is never used so the range of alpha values for HUD gauges ended up being [0, 238], never reaching full white/fully opaque. Conversion math is now tweaked to make the alpha range [0, 252] which is much closer to [0, 255] while still not needing to do multiplication with floats