### PR TITLE
Fix some inconsistencies with remote detonation

### DIFF
--- a/code/hud/hudtarget.cpp
+++ b/code/hud/hudtarget.cpp
@@ -3203,9 +3203,6 @@ void hud_process_remote_detonate_missile()
 						Int3();	// should never happen
 						return;
 					}
-
-					// do only for the first remote detonate missile
-					break;
 				}
 			}
 		}

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -141,8 +141,7 @@ public:
 	int tertiary_bank_capacity;		// Max number of shots in bank
 	int tertiary_bank_rearm_time;	// timestamp which indicates when bank can get new something (used for ammopod or boostpod)
 
-	int last_fired_weapon_index;		//	Index of last fired secondary weapon.  Used for remote detonates.
-	int last_fired_weapon_signature;	//	Signature of last fired weapon.
+	int remote_detonaters_active;
 	int detonate_weapon_time;			//	time at which last fired weapon can be detonated
 	int ai_class;
 

--- a/code/weapon/weapon.h
+++ b/code/weapon/weapon.h
@@ -60,6 +60,9 @@ extern int Num_weapon_subtypes;
 // scale factor for supercaps taking damage from weapons which are not "supercap" weapons
 #define SUPERCAP_DAMAGE_SCALE			0.25f
 
+// default amount of time to wait after firing before a remote detonated missile can be detonated
+#define DEFAULT_REMOTE_DETONATE_TRIGGER_WAIT  0.5f
+
 enum class WeaponState : uint32_t
 {
 	INVALID,

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -5850,6 +5850,8 @@ void spawn_child_weapons(object *objp)
 		}
 	}
 
+	ship* parent_shipp;
+	parent_shipp = &Ships[Objects[objp->parent].instance];
 	starting_sig = 0;
 
 	if ( Game_mode & GM_MULTIPLAYER ) {		
@@ -5936,6 +5938,10 @@ void spawn_child_weapons(object *objp)
 					}
 
 					Weapons[Objects[weapon_objnum].instance].lifeleft *= rand_val*0.4f + 0.8f;
+					if (child_wip->wi_flags[Weapon::Info_Flags::Remote]) {
+						parent_shipp->weapons.detonate_weapon_time = timestamp((int)(DEFAULT_REMOTE_DETONATE_TRIGGER_WAIT * 1000));
+						parent_shipp->weapons.remote_detonaters_active++;
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Fixes #2812 , and makes remote detonation more robust and flexible in general. The retail handling is pretty crude and does a bunch of futzing about with the missile's objnum and signature, presumably to avoid having to loop through all the missiles in the mission... except that it needs to do this anyway because of dual fire. Now it handles it entirely like dual fire, just loop through all the missiles, if they're mine, a remote detonator, and weren't spawned this frame (preventing premature detonation of child remote detonators being produced by this very loop), then detonate it.

Also puts brackets around all of your remote detonators, retail *did* explicitly comment that only one bracket was on purpose which make sense for dual fire, but when considering things like child spawned remote detonators, it becomes clear that bracketing all of them is important to maintain vital player feedback.