### PR TITLE
Add type safe handle for graphics buffers

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -13,6 +13,7 @@ AllowAllParametersOfDeclarationOnNextLine: false
 AllowAllArgumentsOnNextLine: false
 AllowShortBlocksOnASingleLine: Never
 AllowShortCaseLabelsOnASingleLine: false
+AllowShortEnumsOnASingleLine: false
 AllowShortFunctionsOnASingleLine: Empty
 AllowShortIfStatementsOnASingleLine: Never
 AllowShortLoopsOnASingleLine: false

--- a/code/graphics/2d.cpp
+++ b/code/graphics/2d.cpp
@@ -2858,7 +2858,7 @@ static graphics::util::GPUMemoryHeap* get_gpu_heap(GpuHeap heap_type) {
 	return gpu_heaps[static_cast<size_t>(heap_type)].get();
 }
 
-void gr_heap_allocate(GpuHeap heap_type, size_t size, void* data, size_t& offset_out, int& handle_out) {
+void gr_heap_allocate(GpuHeap heap_type, size_t size, void* data, size_t& offset_out, gr_buffer_handle& handle_out) {
 	TRACE_SCOPE(tracing::GpuHeapAllocate);
 
 	auto gpuHeap = get_gpu_heap(heap_type);

--- a/code/graphics/decal_draw_list.cpp
+++ b/code/graphics/decal_draw_list.cpp
@@ -27,8 +27,8 @@ uint32_t BOX_FACES[] =
 
 const size_t BOX_NUM_FACES = sizeof(BOX_FACES) / sizeof(BOX_FACES[0]);
 
-int box_vertex_buffer = -1;
-int box_index_buffer = -1;
+gr_buffer_handle box_vertex_buffer;
+gr_buffer_handle box_index_buffer;
 
 void init_buffers() {
 	box_vertex_buffer = gr_create_buffer(BufferType::Vertex, BufferUsageHint::Static);

--- a/code/graphics/grbatch.cpp
+++ b/code/graphics/grbatch.cpp
@@ -553,12 +553,12 @@ void geometry_batcher::load_buffer(effect_vertex* buffer, int *n_verts)
 	*n_verts = *n_verts + verts_to_render;
 }
 
-void geometry_batcher::render_buffer(int  /*buffer_handle*/, int  /*flags*/)
+void geometry_batcher::render_buffer(gr_buffer_handle  /*buffer_handle*/, int  /*flags*/)
 {
 
 }
 
-void geometry_shader_batcher::render_buffer(int  /*buffer_handle*/, int  /*flags*/)
+void geometry_shader_batcher::render_buffer(gr_buffer_handle /*buffer_handle*/, int  /*flags*/)
 {
 
 }
@@ -957,7 +957,7 @@ int batch_add_beam(int texture, int tmap_flags, vec3d *start, vec3d *end, float 
 	return 0;
 }
 
-void batch_render_lasers(int buffer_handle)
+void batch_render_lasers(gr_buffer_handle buffer_handle)
 {
 	for (auto &bi : geometry_map) {
 
@@ -969,7 +969,7 @@ void batch_render_lasers(int buffer_handle)
 
 		Assert( bi.second.texture >= 0 );
 		gr_set_bitmap(bi.second.texture, GR_ALPHABLEND_FILTER, GR_BITBLT_MODE_NORMAL, 0.99999f);
-		if ( buffer_handle >= 0 ) {
+		if (buffer_handle.isValid()) {
 			bi.second.batch.render_buffer(buffer_handle, TMAP_FLAG_TEXTURED | TMAP_FLAG_XPARENT | TMAP_HTL_3D_UNLIT | TMAP_FLAG_RGB | TMAP_FLAG_GOURAUD | TMAP_FLAG_CORRECT | TMAP_FLAG_EMISSIVE);
 		} else {
 			bi.second.batch.render(TMAP_FLAG_TEXTURED | TMAP_FLAG_XPARENT | TMAP_HTL_3D_UNLIT | TMAP_FLAG_RGB | TMAP_FLAG_GOURAUD | TMAP_FLAG_CORRECT | TMAP_FLAG_EMISSIVE);
@@ -992,7 +992,7 @@ void batch_load_buffer_lasers(effect_vertex* buffer, int *n_verts)
 	}
 }
 
-void batch_render_geometry_map_bitmaps(int buffer_handle)
+void batch_render_geometry_map_bitmaps(gr_buffer_handle buffer_handle)
 {
 	for (auto &bi : geometry_map) {
 
@@ -1004,7 +1004,7 @@ void batch_render_geometry_map_bitmaps(int buffer_handle)
 
 		Assert( bi.second.texture >= 0 );
 		gr_set_bitmap(bi.second.texture, GR_ALPHABLEND_FILTER, GR_BITBLT_MODE_NORMAL, bi.second.alpha);
-		if ( buffer_handle >= 0 ) {
+		if (buffer_handle.isValid()) {
 			bi.second.batch.render_buffer(buffer_handle, bi.second.tmap_flags);
 		} else {
 			bi.second.batch.render( bi.second.tmap_flags);
@@ -1012,7 +1012,7 @@ void batch_render_geometry_map_bitmaps(int buffer_handle)
 	}
 }
 
-void batch_render_geometry_shader_map_bitmaps(int buffer_handle)
+void batch_render_geometry_shader_map_bitmaps(gr_buffer_handle buffer_handle)
 {
 	for (auto &bi : geometry_shader_map) {
 
@@ -1058,9 +1058,9 @@ void batch_load_buffer_geometry_shader_map_bitmaps(particle_pnt* buffer, size_t 
 	}
 }
 
-void geometry_batch_render(int stream_buffer)
+void geometry_batch_render(gr_buffer_handle stream_buffer)
 {
-	if ( stream_buffer < 0 ) {
+	if (!stream_buffer.isValid()) {
 		return;
 	}
 
@@ -1083,9 +1083,9 @@ void geometry_batch_render(int stream_buffer)
 	batch_render_geometry_shader_map_bitmaps(stream_buffer);
 }
 
-void batch_render_all(int stream_buffer)
+void batch_render_all(gr_buffer_handle stream_buffer)
 {
-	if ( stream_buffer >= 0 ) {
+	if (stream_buffer.isValid()) {
 		// need to get vertex size
 		int n_to_render = batch_get_size();
 		int n_verts = 0;
@@ -1194,7 +1194,7 @@ int distortion_add_beam(int texture, int tmap_flags, vec3d *start, vec3d *end, f
 	return 0;
 }
 
-void batch_render_distortion_map_bitmaps(int buffer_handle)
+void batch_render_distortion_map_bitmaps(gr_buffer_handle buffer_handle)
 {
 	for (auto &bi : distortion_map) {
 
@@ -1207,7 +1207,7 @@ void batch_render_distortion_map_bitmaps(int buffer_handle)
 		Assert( bi.second.texture >= 0 );
 		gr_set_bitmap(bi.second.texture, GR_ALPHABLEND_NONE, GR_BITBLT_MODE_NORMAL, bi.second.alpha);
 
-		if ( buffer_handle >= 0 ) {
+		if (buffer_handle.isValid()) {
 			bi.second.batch.render_buffer(buffer_handle, bi.second.tmap_flags);
 		} else {
 			bi.second.batch.render( bi.second.tmap_flags);

--- a/code/graphics/grbatch.h
+++ b/code/graphics/grbatch.h
@@ -9,6 +9,8 @@
 #ifndef	__GRBATCH_H__
 #define	__GRBATCH_H__
 
+#include "2d.h"
+
 class geometry_batcher
 {
 private:
@@ -64,7 +66,7 @@ public:
 
 	void load_buffer(effect_vertex* buffer, int *n_verts);
 
-	void render_buffer(int buffer_handle, int flags);
+	void render_buffer(gr_buffer_handle buffer_handle, int flags);
 
 	// determine if we even need to try and render this (helpful for particle system)
 	int need_to_render() { return n_to_render; }
@@ -84,18 +86,18 @@ public:
 
 	void load_buffer(particle_pnt* buffer, size_t *n_verts);
 
-	void render_buffer(int buffer_handle, int flags);
+	void render_buffer(gr_buffer_handle buffer_handle, int flags);
 
 	size_t need_to_render() { return vertices.size(); }
 };
 
-void batch_render_all(int stream_buffer = -1);
-void batch_render_geometry_map_bitmaps(int buffer_handle = -1);
+void batch_render_all(gr_buffer_handle stream_buffer = gr_buffer_handle::invalid());
+void batch_render_geometry_map_bitmaps(gr_buffer_handle buffer_handle = gr_buffer_handle::invalid());
 void batch_load_buffer_geometry_map_bitmaps(effect_vertex* buffer, int *n_verts);
-void batch_render_lasers(int buffer_handle = -1);
+void batch_render_lasers(gr_buffer_handle buffer_handle = gr_buffer_handle::invalid());
 void batch_load_buffer_lasers(effect_vertex* buffer, int *n_verts);
 void batch_reset();
-void batch_render_distortion_map_bitmaps(int buffer_handle = -1);
+void batch_render_distortion_map_bitmaps(gr_buffer_handle buffer_handle = gr_buffer_handle::invalid());
 void batch_load_buffer_distortion_map_bitmaps(effect_vertex* buffer, int *n_verts);
 
 int batch_get_size();
@@ -104,7 +106,7 @@ void batch_render_close();
 int geometry_batch_add_bitmap(int texture, int tmap_flags, vertex *pnt, int orient, float rad, float alpha, float depth);
 void batch_load_buffer_geometry_shader_map_bitmaps(particle_pnt* buffer, int *n_verts);
 void batch_render_geometry_shader_map_bitmaps();
-void geometry_batch_render(int stream_buffer);
+void geometry_batch_render(gr_buffer_handle stream_buffer);
 size_t geometry_batch_get_size();
 
 #endif

--- a/code/graphics/grstub.cpp
+++ b/code/graphics/grstub.cpp
@@ -23,15 +23,12 @@ uint gr_stub_lock()
 	return 1;
 }
 
-int gr_stub_create_buffer(BufferType, BufferUsageHint)
+gr_buffer_handle gr_stub_create_buffer(BufferType, BufferUsageHint)
 {
-	return -1;
+	return {};
 }
 
-void gr_stub_delete_buffer(int  /*handle*/)
-{
-
-}
+void gr_stub_delete_buffer(gr_buffer_handle /*handle*/) {}
 
 int gr_stub_preload(int  /*bitmap_num*/, int  /*is_aabitmap*/)
 {
@@ -110,9 +107,14 @@ void gr_stub_save_mouse_area(int  /*x*/, int  /*y*/, int  /*w*/, int  /*h*/)
 {
 }
 
-void gr_stub_update_buffer_data(int /*handle*/, size_t /*size*/, const void* /*data*/) {}
+void gr_stub_update_buffer_data(gr_buffer_handle /*handle*/, size_t /*size*/, const void* /*data*/) {}
 
-void gr_stub_update_buffer_data_offset(int /*handle*/, size_t /*offset*/, size_t /*size*/, const void* /*data*/) {}
+void gr_stub_update_buffer_data_offset(gr_buffer_handle /*handle*/,
+	size_t /*offset*/,
+	size_t /*size*/,
+	const void* /*data*/)
+{
+}
 
 void gr_stub_update_transform_buffer(void*  /*data*/, size_t  /*size*/)
 {
@@ -291,9 +293,12 @@ void gr_stub_shadow_map_end()
 {
 }
 
-void gr_stub_render_shield_impact(shield_material * /*material_info*/, primitive_type  /*prim_type*/, vertex_layout * /*layout*/, int  /*buffer_handle*/, int  /*n_verts*/)
+void gr_stub_render_shield_impact(shield_material* /*material_info*/,
+	primitive_type /*prim_type*/,
+	vertex_layout* /*layout*/,
+	gr_buffer_handle /*buffer_handle*/,
+	int /*n_verts*/)
 {
-
 }
 
 void gr_stub_render_model(model_material*  /*material_info*/, indexed_vertex_source * /*vert_source*/, vertex_buffer*  /*bufferp*/, size_t  /*texi*/)
@@ -301,39 +306,66 @@ void gr_stub_render_model(model_material*  /*material_info*/, indexed_vertex_sou
 
 }
 
-void gr_stub_render_primitives(material*  /*material_info*/, primitive_type  /*prim_type*/, vertex_layout*  /*layout*/, int  /*offset*/, int  /*n_verts*/, int  /*buffer_handle*/, size_t  /*buffer_offset*/)
-{
-
-}
-
-void gr_stub_render_primitives_particle(particle_material*  /*material_info*/, primitive_type  /*prim_type*/, vertex_layout*  /*layout*/, int  /*offset*/, int  /*n_verts*/, int  /*buffer_handle*/)
-{
-
-}
-
-void gr_stub_render_primitives_distortion(distortion_material*  /*material_info*/, primitive_type  /*prim_type*/, vertex_layout*  /*layout*/, int  /*offset*/, int  /*n_verts*/, int  /*buffer_handle*/)
-{
-
-}
-void gr_stub_render_movie(movie_material*  /*material_info*/, primitive_type  /*prim_type*/, vertex_layout*  /*layout*/, int  /*n_verts*/, int  /*buffer*/, size_t /*buffer_offset*/)
+void gr_stub_render_primitives(material* /*material_info*/,
+	primitive_type /*prim_type*/,
+	vertex_layout* /*layout*/,
+	int /*offset*/,
+	int /*n_verts*/,
+	gr_buffer_handle /*buffer_handle*/,
+	size_t /*buffer_offset*/)
 {
 }
 
-void gr_stub_render_nanovg(nanovg_material*  /*material_info*/,
-							  primitive_type  /*prim_type*/,
-							  vertex_layout*  /*layout*/,
-							  int  /*offset*/,
-							  int  /*n_verts*/,
-							  int  /*buffer_handle*/) {
-}
-
-void gr_stub_render_primitives_batched(batched_bitmap_material*  /*material_info*/, primitive_type  /*prim_type*/, vertex_layout*  /*layout*/, int  /*offset*/, int  /*n_verts*/, int  /*buffer_handle*/)
+void gr_stub_render_primitives_particle(particle_material* /*material_info*/,
+	primitive_type /*prim_type*/,
+	vertex_layout* /*layout*/,
+	int /*offset*/,
+	int /*n_verts*/,
+	gr_buffer_handle /*buffer_handle*/)
 {
 }
 
-void gr_stub_render_rocket_primitives(interface_material* /*material_info*/, primitive_type /*prim_type*/,
-                                      vertex_layout* /*layout*/, int /*n_indices*/, int /*vertex_buffer*/,
-                                      int /*index_buffer*/)
+void gr_stub_render_primitives_distortion(distortion_material* /*material_info*/,
+	primitive_type /*prim_type*/,
+	vertex_layout* /*layout*/,
+	int /*offset*/,
+	int /*n_verts*/,
+	gr_buffer_handle /*buffer_handle*/)
+{
+}
+void gr_stub_render_movie(movie_material* /*material_info*/,
+	primitive_type /*prim_type*/,
+	vertex_layout* /*layout*/,
+	int /*n_verts*/,
+	gr_buffer_handle /*buffer*/,
+	size_t /*buffer_offset*/)
+{
+}
+
+void gr_stub_render_nanovg(nanovg_material* /*material_info*/,
+	primitive_type /*prim_type*/,
+	vertex_layout* /*layout*/,
+	int /*offset*/,
+	int /*n_verts*/,
+	gr_buffer_handle /*buffer_handle*/)
+{
+}
+
+void gr_stub_render_primitives_batched(batched_bitmap_material* /*material_info*/,
+	primitive_type /*prim_type*/,
+	vertex_layout* /*layout*/,
+	int /*offset*/,
+	int /*n_verts*/,
+	gr_buffer_handle /*buffer_handle*/)
+{
+}
+
+void gr_stub_render_rocket_primitives(interface_material* /*material_info*/,
+	primitive_type /*prim_type*/,
+	vertex_layout* /*layout*/,
+	int /*n_indices*/,
+	gr_buffer_handle /*vertex_buffer*/,
+	gr_buffer_handle /*index_buffer*/)
 {
 }
 
@@ -450,26 +482,26 @@ bool gr_stub_init()
 
 	gr_screen.gf_preload			= gr_stub_preload;
 
-	gr_screen.gf_set_texture_addressing	= gr_stub_set_texture_addressing;
-	gr_screen.gf_zbias					= gr_stub_zbias_stub;
-	gr_screen.gf_set_fill_mode			= gr_set_fill_mode_stub;
+	gr_screen.gf_set_texture_addressing = gr_stub_set_texture_addressing;
+	gr_screen.gf_zbias = gr_stub_zbias_stub;
+	gr_screen.gf_set_fill_mode = gr_set_fill_mode_stub;
 
-	gr_screen.gf_create_buffer	= gr_stub_create_buffer;
-	gr_screen.gf_delete_buffer		= gr_stub_delete_buffer;
+	gr_screen.gf_create_buffer = gr_stub_create_buffer;
+	gr_screen.gf_delete_buffer = gr_stub_delete_buffer;
 
-	gr_screen.gf_update_transform_buffer	= gr_stub_update_transform_buffer;
-	gr_screen.gf_update_buffer_data		= gr_stub_update_buffer_data;
+	gr_screen.gf_update_transform_buffer = gr_stub_update_transform_buffer;
+	gr_screen.gf_update_buffer_data = gr_stub_update_buffer_data;
 	gr_screen.gf_update_buffer_data_offset = gr_stub_update_buffer_data_offset;
-	gr_screen.gf_map_buffer                 = [](int) -> void* { return nullptr; };
-	gr_screen.gf_flush_mapped_buffer        = [](int, size_t, size_t) {};
+	gr_screen.gf_map_buffer = [](gr_buffer_handle) -> void* { return nullptr; };
+	gr_screen.gf_flush_mapped_buffer = [](gr_buffer_handle, size_t, size_t) {};
 
-	gr_screen.gf_post_process_set_effect	= gr_stub_post_process_set_effect;
-	gr_screen.gf_post_process_set_defaults	= gr_stub_post_process_set_defaults;
+	gr_screen.gf_post_process_set_effect = gr_stub_post_process_set_effect;
+	gr_screen.gf_post_process_set_defaults = gr_stub_post_process_set_defaults;
 
-	gr_screen.gf_post_process_begin		= gr_stub_post_process_begin;
-	gr_screen.gf_post_process_end		= gr_stub_post_process_end;
-	gr_screen.gf_post_process_save_zbuffer	= gr_stub_post_process_save_zbuffer;
-	gr_screen.gf_post_process_restore_zbuffer = [](){};
+	gr_screen.gf_post_process_begin = gr_stub_post_process_begin;
+	gr_screen.gf_post_process_end = gr_stub_post_process_end;
+	gr_screen.gf_post_process_save_zbuffer = gr_stub_post_process_save_zbuffer;
+	gr_screen.gf_post_process_restore_zbuffer = []() {};
 
 	gr_screen.gf_scene_texture_begin = gr_stub_scene_texture_begin;
 	gr_screen.gf_scene_texture_end = gr_stub_scene_texture_end;
@@ -519,7 +551,7 @@ bool gr_stub_init()
 	gr_screen.gf_create_viewport = [](const os::ViewPortProperties&) { return std::unique_ptr<os::Viewport>(); };
 	gr_screen.gf_use_viewport = [](os::Viewport*) {};
 
-	gr_screen.gf_bind_uniform_buffer = [](uniform_block_type, size_t, size_t, int) {};
+	gr_screen.gf_bind_uniform_buffer = [](uniform_block_type, size_t, size_t, gr_buffer_handle) {};
 
 	gr_screen.gf_sync_fence = []() -> gr_sync { return nullptr; };
 	gr_screen.gf_sync_wait = [](gr_sync /*sync*/, uint64_t /*timeoutns*/) { return true; };

--- a/code/graphics/opengl/gropengldraw.cpp
+++ b/code/graphics/opengl/gropengldraw.cpp
@@ -591,13 +591,17 @@ void gr_opengl_copy_effect_texture()
 	glDrawBuffer(GL_COLOR_ATTACHMENT0);
 }
 
-void gr_opengl_render_shield_impact(shield_material *material_info, primitive_type prim_type, vertex_layout *layout, int buffer_handle, int n_verts)
+void gr_opengl_render_shield_impact(shield_material* material_info,
+	primitive_type prim_type,
+	vertex_layout* layout,
+	gr_buffer_handle buffer_handle,
+	int n_verts)
 {
 	matrix4 impact_transform;
 	matrix4 impact_projection;
 	vec3d min;
 	vec3d max;
-	
+
 	opengl_tnl_set_material(material_info, false);
 
 	float radius = material_info->get_impact_radius();
@@ -731,11 +735,17 @@ void gr_opengl_update_distortion()
 	GL_state.CullFace(cull);
 }
 
-void opengl_render_primitives(primitive_type prim_type, vertex_layout* layout, int n_verts, int buffer_handle, size_t vert_offset, size_t byte_offset)
+void opengl_render_primitives(primitive_type prim_type,
+	vertex_layout* layout,
+	int n_verts,
+	gr_buffer_handle buffer_handle,
+	size_t vert_offset,
+	size_t byte_offset)
 {
 	GR_DEBUG_SCOPE("Render primitives");
 
-	Assertion(buffer_handle >= 0, "A valid buffer handle is required! Use the immediate buffer if data is not in GPU buffer yet.");
+	Assertion(buffer_handle.isValid(),
+		"A valid buffer handle is required! Use the immediate buffer if data is not in GPU buffer yet.");
 
 	opengl_bind_vertex_layout(*layout, opengl_buffer_get_id(GL_ARRAY_BUFFER, buffer_handle), 0, byte_offset);
 
@@ -749,7 +759,13 @@ void opengl_render_primitives_immediate(primitive_type prim_type, vertex_layout*
 	opengl_render_primitives(prim_type, layout, n_verts, gr_immediate_buffer_handle, 0, offset);
 }
 
-void gr_opengl_render_primitives(material* material_info, primitive_type prim_type, vertex_layout* layout, int offset, int n_verts, int buffer_handle, size_t buffer_offset)
+void gr_opengl_render_primitives(material* material_info,
+	primitive_type prim_type,
+	vertex_layout* layout,
+	int offset,
+	int n_verts,
+	gr_buffer_handle buffer_handle,
+	size_t buffer_offset)
 {
 	GL_CHECK_FOR_ERRORS("start of gr_opengl_render_primitives()");
 
@@ -760,35 +776,49 @@ void gr_opengl_render_primitives(material* material_info, primitive_type prim_ty
 	GL_CHECK_FOR_ERRORS("end of gr_opengl_render_primitives()");
 }
 
-void gr_opengl_render_primitives_particle(particle_material* material_info, primitive_type prim_type, vertex_layout* layout, int offset, int n_verts, int buffer_handle)
+void gr_opengl_render_primitives_particle(particle_material* material_info,
+	primitive_type prim_type,
+	vertex_layout* layout,
+	int offset,
+	int n_verts,
+	gr_buffer_handle buffer_handle)
 {
 	GL_CHECK_FOR_ERRORS("start of gr_opengl_render_primitives_particle()");
 
 	opengl_tnl_set_material_particle(material_info);
-	
+
 	opengl_render_primitives(prim_type, layout, n_verts, buffer_handle, offset, 0);
 
 	GL_CHECK_FOR_ERRORS("end of gr_opengl_render_primitives_particle()");
 }
 
-void gr_opengl_render_primitives_distortion(distortion_material* material_info, primitive_type prim_type, vertex_layout* layout, int offset, int n_verts, int buffer_handle)
+void gr_opengl_render_primitives_distortion(distortion_material* material_info,
+	primitive_type prim_type,
+	vertex_layout* layout,
+	int offset,
+	int n_verts,
+	gr_buffer_handle buffer_handle)
 {
 	GL_CHECK_FOR_ERRORS("start of gr_opengl_render_primitives_distortion()");
 
 	opengl_tnl_set_material_distortion(material_info);
-	
+
 	glDrawBuffer(GL_COLOR_ATTACHMENT0);
-	
+
 	opengl_render_primitives(prim_type, layout, n_verts, buffer_handle, offset, 0);
 
-	GLenum buffers[] = { GL_COLOR_ATTACHMENT0, GL_COLOR_ATTACHMENT1 };
+	GLenum buffers[] = {GL_COLOR_ATTACHMENT0, GL_COLOR_ATTACHMENT1};
 	glDrawBuffers(2, buffers);
 
 	GL_CHECK_FOR_ERRORS("start of gr_opengl_render_primitives_distortion()");
 }
 
-void gr_opengl_render_movie(movie_material* material_info, primitive_type prim_type, vertex_layout* layout, int n_verts,
-                            int buffer, size_t buffer_offset)
+void gr_opengl_render_movie(movie_material* material_info,
+	primitive_type prim_type,
+	vertex_layout* layout,
+	int n_verts,
+	gr_buffer_handle buffer,
+	size_t buffer_offset)
 {
 	GR_DEBUG_SCOPE("Render movie frame");
 
@@ -802,11 +832,12 @@ void gr_opengl_render_movie(movie_material* material_info, primitive_type prim_t
 }
 
 void gr_opengl_render_nanovg(nanovg_material* material_info,
-							 primitive_type prim_type,
-							 vertex_layout* layout,
-							 int offset,
-							 int n_verts,
-							 int buffer_handle) {
+	primitive_type prim_type,
+	vertex_layout* layout,
+	int offset,
+	int n_verts,
+	gr_buffer_handle buffer_handle)
+{
 	GR_DEBUG_SCOPE("Render NanoVG primitives");
 
 	opengl_tnl_set_material_nanovg(material_info);
@@ -815,19 +846,24 @@ void gr_opengl_render_nanovg(nanovg_material* material_info,
 }
 
 void gr_opengl_render_primitives_batched(batched_bitmap_material* material_info,
-										 primitive_type prim_type,
-										 vertex_layout* layout,
-										 int offset,
-										 int n_verts,
-										 int buffer_handle) {
+	primitive_type prim_type,
+	vertex_layout* layout,
+	int offset,
+	int n_verts,
+	gr_buffer_handle buffer_handle)
+{
 	GR_DEBUG_SCOPE("Render batched primitives");
 
 	opengl_tnl_set_material_batched(material_info);
 
 	opengl_render_primitives(prim_type, layout, n_verts, buffer_handle, offset, 0);
 }
-void gr_opengl_render_rocket_primitives(interface_material* material_info, primitive_type prim_type,
-                                        vertex_layout* layout, int n_indices, int vertex_buffer, int index_buffer)
+void gr_opengl_render_rocket_primitives(interface_material* material_info,
+	primitive_type prim_type,
+	vertex_layout* layout,
+	int n_indices,
+	gr_buffer_handle vertex_buffer,
+	gr_buffer_handle index_buffer)
 {
 	GR_DEBUG_SCOPE("Render rocket ui primitives");
 
@@ -835,8 +871,9 @@ void gr_opengl_render_rocket_primitives(interface_material* material_info, primi
 
 	opengl_tnl_set_rocketui_material(material_info);
 
-	opengl_bind_vertex_layout(*layout, opengl_buffer_get_id(GL_ARRAY_BUFFER, vertex_buffer),
-	                          opengl_buffer_get_id(GL_ELEMENT_ARRAY_BUFFER, index_buffer));
+	opengl_bind_vertex_layout(*layout,
+		opengl_buffer_get_id(GL_ARRAY_BUFFER, vertex_buffer),
+		opengl_buffer_get_id(GL_ELEMENT_ARRAY_BUFFER, index_buffer));
 
 	glDrawElements(opengl_primitive_type(prim_type), n_indices, GL_UNSIGNED_INT, nullptr);
 

--- a/code/graphics/opengl/gropengldraw.h
+++ b/code/graphics/opengl/gropengldraw.h
@@ -37,7 +37,11 @@ void gr_opengl_sphere(material *material_def, float rad);
 void gr_opengl_shadow_map_start(matrix4 *shadow_view_matrix, const matrix *light_orient);
 void gr_opengl_shadow_map_end();
 
-void gr_opengl_render_shield_impact(shield_material *material_info, primitive_type prim_type, vertex_layout *layout, int buffer_handle, int n_verts);
+void gr_opengl_render_shield_impact(shield_material* material_info,
+	primitive_type prim_type,
+	vertex_layout* layout,
+	gr_buffer_handle buffer_handle,
+	int n_verts);
 
 void opengl_setup_scene_textures();
 void opengl_scene_texture_shutdown();
@@ -45,21 +49,75 @@ void gr_opengl_scene_texture_begin();
 void gr_opengl_scene_texture_end();
 void gr_opengl_copy_effect_texture();
 
-void opengl_render_primitives(primitive_type prim_type, vertex_layout* layout, int n_verts, int buffer_handle, size_t vert_offset, size_t byte_offset);
-void opengl_render_primitives_immediate(primitive_type prim_type, vertex_layout* layout, int n_verts, void* data, int size);
+void opengl_render_primitives(primitive_type prim_type,
+	vertex_layout* layout,
+	int n_verts,
+	gr_buffer_handle buffer_handle,
+	size_t vert_offset,
+	size_t byte_offset);
+void opengl_render_primitives_immediate(primitive_type prim_type,
+	vertex_layout* layout,
+	int n_verts,
+	void* data,
+	int size);
 
-void gr_opengl_render_primitives(material* material_info, primitive_type prim_type, vertex_layout* layout, int offset, int n_verts, int buffer_handle, size_t buffer_offset);
-void gr_opengl_render_primitives_particle(particle_material* material_info, primitive_type prim_type, vertex_layout* layout, int offset, int n_verts, int buffer_handle);
-void gr_opengl_render_primitives_batched(batched_bitmap_material* material_info, primitive_type prim_type, vertex_layout* layout, int offset, int n_verts, int buffer_handle);
-void gr_opengl_render_primitives_distortion(distortion_material* material_info, primitive_type prim_type, vertex_layout* layout, int offset, int n_verts, int buffer_handle);
-void gr_opengl_render_movie(movie_material* material_info, primitive_type prim_type, vertex_layout* layout, int n_verts, int buffer, size_t buffer_offset);
-void gr_opengl_render_nanovg(nanovg_material* material_info, primitive_type prim_type, vertex_layout* layout, int offset, int n_verts, int buffer_handle);
-void gr_opengl_render_decals(decal_material* material_info, primitive_type prim_type, vertex_layout* layout, int num_elements, const indexed_vertex_source& binding);
-void gr_opengl_render_rocket_primitives(interface_material* material_info, primitive_type prim_type,
-                                        vertex_layout* layout, int n_indices, int vertex_buffer, int index_buffer);
+void gr_opengl_render_primitives(material* material_info,
+	primitive_type prim_type,
+	vertex_layout* layout,
+	int offset,
+	int n_verts,
+	gr_buffer_handle buffer_handle,
+	size_t buffer_offset);
+void gr_opengl_render_primitives_particle(particle_material* material_info,
+	primitive_type prim_type,
+	vertex_layout* layout,
+	int offset,
+	int n_verts,
+	gr_buffer_handle buffer_handle);
+void gr_opengl_render_primitives_batched(batched_bitmap_material* material_info,
+	primitive_type prim_type,
+	vertex_layout* layout,
+	int offset,
+	int n_verts,
+	gr_buffer_handle buffer_handle);
+void gr_opengl_render_primitives_distortion(distortion_material* material_info,
+	primitive_type prim_type,
+	vertex_layout* layout,
+	int offset,
+	int n_verts,
+	gr_buffer_handle buffer_handle);
+void gr_opengl_render_movie(movie_material* material_info,
+	primitive_type prim_type,
+	vertex_layout* layout,
+	int n_verts,
+	gr_buffer_handle buffer,
+	size_t buffer_offset);
+void gr_opengl_render_nanovg(nanovg_material* material_info,
+	primitive_type prim_type,
+	vertex_layout* layout,
+	int offset,
+	int n_verts,
+	gr_buffer_handle buffer_handle);
+void gr_opengl_render_decals(decal_material* material_info,
+	primitive_type prim_type,
+	vertex_layout* layout,
+	int num_elements,
+	const indexed_vertex_source& binding);
+void gr_opengl_render_rocket_primitives(interface_material* material_info,
+	primitive_type prim_type,
+	vertex_layout* layout,
+	int n_indices,
+	gr_buffer_handle vertex_buffer,
+	gr_buffer_handle index_buffer);
 
-void opengl_draw_textured_quad(GLfloat x1, GLfloat y1, GLfloat u1, GLfloat v1,
-							   GLfloat x2, GLfloat y2, GLfloat u2, GLfloat v2 );
+void opengl_draw_textured_quad(GLfloat x1,
+	GLfloat y1,
+	GLfloat u1,
+	GLfloat v1,
+	GLfloat x2,
+	GLfloat y2,
+	GLfloat u2,
+	GLfloat v2);
 
 /**
  * @brief Draw "something" so that the entire screen is covered and the corners use the UV values that are provided.

--- a/code/graphics/opengl/gropengltnl.cpp
+++ b/code/graphics/opengl/gropengltnl.cpp
@@ -66,7 +66,7 @@ GLuint Shadow_map_depth_texture = 0;
 GLuint shadow_fbo = 0;
 int Shadow_texture_size = 0;
 
-int Transform_buffer_handle = -1;
+gr_buffer_handle Transform_buffer_handle;
 
 SCP_unordered_map<vertex_layout, GLuint> Stored_vertex_arrays;
 
@@ -190,12 +190,12 @@ static GLenum convertComparisionFunction(ComparisionFunction func) {
 	return mode;
 }
 
-int opengl_create_buffer_object(GLenum type, GLenum gl_usage, BufferUsageHint usage)
+gr_buffer_handle opengl_create_buffer_object(GLenum type, GLenum gl_usage, BufferUsageHint usage)
 {
 	GR_DEBUG_SCOPE("Create buffer object");
 
 	Assertion(usage != BufferUsageHint::PersistentMapping || GLAD_GL_ARB_buffer_storage != 0,
-	          "Persistent mapping is not supported by this OpenGL implementation!");
+		"Persistent mapping is not supported by this OpenGL implementation!");
 
 	opengl_buffer_object buffer_obj;
 
@@ -208,17 +208,17 @@ int opengl_create_buffer_object(GLenum type, GLenum gl_usage, BufferUsageHint us
 
 	GL_buffer_objects.push_back(buffer_obj);
 
-	return (int)(GL_buffer_objects.size() - 1);
+	return gr_buffer_handle((int)(GL_buffer_objects.size() - 1));
 }
 
-void opengl_bind_buffer_object(int handle)
+void opengl_bind_buffer_object(gr_buffer_handle handle)
 {
 	GR_DEBUG_SCOPE("Bind buffer handle");
 
-	Assert(handle >= 0);
-	Assert((size_t)handle < GL_buffer_objects.size());
+	Assert(handle.isValid());
+	Assert((size_t)handle.value() < GL_buffer_objects.size());
 
-	opengl_buffer_object &buffer_obj = GL_buffer_objects[handle];
+	opengl_buffer_object &buffer_obj = GL_buffer_objects[handle.value()];
 
 	switch ( buffer_obj.type ) {
 	case GL_ARRAY_BUFFER:
@@ -239,28 +239,29 @@ void opengl_bind_buffer_object(int handle)
 		break;
 	}
 }
-GLuint opengl_buffer_get_id(GLenum expected_type, int handle) {
-	Assert(handle >= 0);
-	Assert((size_t)handle < GL_buffer_objects.size());
+GLuint opengl_buffer_get_id(GLenum expected_type, gr_buffer_handle handle)
+{
+	Assert(handle.isValid());
+	Assert((size_t)handle.value() < GL_buffer_objects.size());
 
-	opengl_buffer_object &buffer_obj = GL_buffer_objects[handle];
+	opengl_buffer_object& buffer_obj = GL_buffer_objects[handle.value()];
 
 	Assertion(expected_type == buffer_obj.type, "Expected buffer type did not match the actual buffer type!");
 
 	return buffer_obj.buffer_id;
 }
 
-void gr_opengl_update_buffer_data(int handle, size_t size, const void* data)
+void gr_opengl_update_buffer_data(gr_buffer_handle handle, size_t size, const void* data)
 {
 	// This has to be verified by the caller or else we will run into OPenGL errors
 	Assertion(size > 0, "Buffer updates must include some data!");
 
 	GR_DEBUG_SCOPE("Update buffer data");
 
-	Assert(handle >= 0);
-	Assert((size_t)handle < GL_buffer_objects.size());
+	Assert(handle.isValid());
+	Assert((size_t)handle.value() < GL_buffer_objects.size());
 
-	opengl_buffer_object &buffer_obj = GL_buffer_objects[handle];
+	opengl_buffer_object &buffer_obj = GL_buffer_objects[handle.value()];
 
 	opengl_bind_buffer_object(handle);
 
@@ -277,14 +278,14 @@ void gr_opengl_update_buffer_data(int handle, size_t size, const void* data)
 	GL_vertex_data_in += buffer_obj.size;
 }
 
-void gr_opengl_update_buffer_data_offset(int handle, size_t offset, size_t size, const void* data)
+void gr_opengl_update_buffer_data_offset(gr_buffer_handle handle, size_t offset, size_t size, const void* data)
 {
 	GR_DEBUG_SCOPE("Update buffer data with offset");
 
-	Assert(handle >= 0);
-	Assert((size_t)handle < GL_buffer_objects.size());
+	Assert(handle.isValid());
+	Assert((size_t)handle.value() < GL_buffer_objects.size());
 
-	opengl_buffer_object &buffer_obj = GL_buffer_objects[handle];
+	opengl_buffer_object &buffer_obj = GL_buffer_objects[handle.value()];
 
 	Assertion(buffer_obj.usage != BufferUsageHint::PersistentMapping,
 	          "Persistently mapped buffers may not be updated!");
@@ -293,14 +294,14 @@ void gr_opengl_update_buffer_data_offset(int handle, size_t offset, size_t size,
 
 	glBufferSubData(buffer_obj.type, offset, size, data);
 }
-void* gr_opengl_map_buffer(int handle)
+void* gr_opengl_map_buffer(gr_buffer_handle handle)
 {
 	GR_DEBUG_SCOPE("Map buffer");
 
-	Assert(handle >= 0);
-	Assert((size_t)handle < GL_buffer_objects.size());
+	Assert(handle.isValid());
+	Assert((size_t)handle.value() < GL_buffer_objects.size());
 
-	auto& buffer_obj = GL_buffer_objects[handle];
+	opengl_buffer_object &buffer_obj = GL_buffer_objects[handle.value()];
 
 	Assertion(buffer_obj.usage == BufferUsageHint::PersistentMapping,
 	          "Buffer mapping is only supported for persistently mapped buffers!");
@@ -310,14 +311,14 @@ void* gr_opengl_map_buffer(int handle)
 	return glMapBufferRange(buffer_obj.type, 0, buffer_obj.size,
 	                        GL_MAP_WRITE_BIT | GL_MAP_PERSISTENT_BIT | GL_MAP_FLUSH_EXPLICIT_BIT);
 }
-void gr_opengl_flush_mapped_buffer(int handle, size_t offset, size_t size)
+void gr_opengl_flush_mapped_buffer(gr_buffer_handle handle, size_t offset, size_t size)
 {
 	GR_DEBUG_SCOPE("Flush mapped buffer");
 
-	Assert(handle >= 0);
-	Assert((size_t)handle < GL_buffer_objects.size());
+	Assert(handle.isValid());
+	Assert((size_t)handle.value() < GL_buffer_objects.size());
 
-	auto& buffer_obj = GL_buffer_objects[handle];
+	opengl_buffer_object &buffer_obj = GL_buffer_objects[handle.value()];
 
 	Assertion(buffer_obj.usage == BufferUsageHint::PersistentMapping,
 	          "Buffer mapping is only supported for persistently mapped buffers!");
@@ -327,16 +328,16 @@ void gr_opengl_flush_mapped_buffer(int handle, size_t offset, size_t size)
 	glFlushMappedBufferRange(buffer_obj.type, offset, size);
 }
 
-void gr_opengl_delete_buffer(int handle)
+void gr_opengl_delete_buffer(gr_buffer_handle handle)
 {
 	if (GL_buffer_objects.size() == 0) return;
 
 	GR_DEBUG_SCOPE("Deleting buffer");
 
-	Assert(handle >= 0);
-	Assert((size_t)handle < GL_buffer_objects.size());
+	Assert(handle.isValid());
+	Assert((size_t)handle.value() < GL_buffer_objects.size());
 
-	opengl_buffer_object &buffer_obj = GL_buffer_objects[handle];
+	opengl_buffer_object &buffer_obj = GL_buffer_objects[handle.value()];
 
 	// de-bind the buffer point so we can clear the recorded state.
 	switch ( buffer_obj.type ) {
@@ -367,21 +368,20 @@ void gr_opengl_delete_buffer(int handle)
 	glDeleteBuffers(1, &buffer_obj.buffer_id);
 }
 
-int gr_opengl_create_buffer(BufferType type, BufferUsageHint usage)
+gr_buffer_handle gr_opengl_create_buffer(BufferType type, BufferUsageHint usage)
 {
 	return opengl_create_buffer_object(convertBufferType(type), convertUsageHint(usage), usage);
 }
 
-void gr_opengl_bind_uniform_buffer(uniform_block_type bind_point, size_t offset, size_t size, int buffer) {
+void gr_opengl_bind_uniform_buffer(uniform_block_type bind_point, size_t offset, size_t size, gr_buffer_handle buffer) {
 	GR_DEBUG_SCOPE("Bind uniform buffer range");
 
 	GLuint buffer_handle = 0;
 
-	if (buffer != -1) {
-		Assert(buffer >= 0);
-		Assert((size_t)buffer < GL_buffer_objects.size());
+	if (buffer.isValid()) {
+		Assert((size_t)buffer.value() < GL_buffer_objects.size());
 
-		opengl_buffer_object &buffer_obj = GL_buffer_objects[buffer];
+		opengl_buffer_object &buffer_obj = GL_buffer_objects[buffer.value()];
 
 		Assertion(buffer_obj.type == GL_UNIFORM_BUFFER, "Only uniform buffers are valid for this function!");
 		buffer_handle = buffer_obj.buffer_id;
@@ -391,15 +391,15 @@ void gr_opengl_bind_uniform_buffer(uniform_block_type bind_point, size_t offset,
 					  static_cast<GLsizeiptr>(size));
 }
 
-int opengl_create_texture_buffer_object()
+gr_buffer_handle opengl_create_texture_buffer_object()
 {
 	// create the buffer
-	int buffer_object_handle =
-	    opengl_create_buffer_object(GL_TEXTURE_BUFFER, GL_DYNAMIC_DRAW, BufferUsageHint::Dynamic);
+	auto buffer_object_handle =
+		opengl_create_buffer_object(GL_TEXTURE_BUFFER, GL_DYNAMIC_DRAW, BufferUsageHint::Dynamic);
 
 	opengl_check_for_errors();
 
-	opengl_buffer_object &buffer_obj = GL_buffer_objects[buffer_object_handle];
+	opengl_buffer_object& buffer_obj = GL_buffer_objects[buffer_object_handle.value()];
 
 	// create the texture
 	glGenTextures(1, &buffer_obj.texture);
@@ -416,13 +416,13 @@ int opengl_create_texture_buffer_object()
 
 void gr_opengl_update_transform_buffer(void* data, size_t size)
 {
-	if ( Transform_buffer_handle < 0 || size <= 0 ) {
+	if (!Transform_buffer_handle.isValid() || size <= 0) {
 		return;
 	}
 
 	gr_opengl_update_buffer_data(Transform_buffer_handle, size, data);
 
-	opengl_buffer_object &buffer_obj = GL_buffer_objects[Transform_buffer_handle];
+	opengl_buffer_object &buffer_obj = GL_buffer_objects[Transform_buffer_handle.value()];
 
 	// need to rebind the buffer object to the texture buffer after it's been updated.
 	// didn't have to do this on AMD and Nvidia drivers but Intel drivers seem to want it.
@@ -432,17 +432,17 @@ void gr_opengl_update_transform_buffer(void* data, size_t size)
 
 GLuint opengl_get_transform_buffer_texture()
 {
-	if ( Transform_buffer_handle < 0 ) {
+	if (!Transform_buffer_handle.isValid()) {
 		return 0;
 	}
 
-	return GL_buffer_objects[Transform_buffer_handle].texture;
+	return GL_buffer_objects[Transform_buffer_handle.value()].texture;
 }
 
 void opengl_destroy_all_buffers()
 {
 	for ( uint i = 0; i < GL_buffer_objects.size(); i++ ) {
-		gr_opengl_delete_buffer(i);
+		gr_opengl_delete_buffer(gr_buffer_handle(i));
 	}
 
 	GL_vertex_buffers_in_use = 0;
@@ -587,24 +587,24 @@ void opengl_render_model_program(model_material* material_info, indexed_vertex_s
 
 	opengl_tnl_set_model_material(material_info);
 
-	GLubyte *ibuffer = reinterpret_cast<GLubyte*>(vert_source->Index_offset);
+	auto ibuffer = reinterpret_cast<GLubyte*>(vert_source->Index_offset);
 
 	GLenum element_type = (datap->flags & VB_FLAG_LARGE_INDEX) ? GL_UNSIGNED_INT : GL_UNSIGNED_SHORT;
 
 	Assert(vert_source);
-	Assertion(vert_source->Vbuffer_handle >= 0, "The vertex data must be located in a GPU buffer!");
-	Assertion(vert_source->Ibuffer_handle >= 0, "The index values must be located in a GPU buffer!");
+	Assertion(vert_source->Vbuffer_handle.isValid(), "The vertex data must be located in a GPU buffer!");
+	Assertion(vert_source->Ibuffer_handle.isValid(), "The index values must be located in a GPU buffer!");
 
 	// basic setup of all data
 	opengl_bind_vertex_layout(bufferp->layout,
-							  opengl_buffer_get_id(GL_ARRAY_BUFFER, vert_source->Vbuffer_handle),
-							  opengl_buffer_get_id(GL_ELEMENT_ARRAY_BUFFER, vert_source->Ibuffer_handle));
+		opengl_buffer_get_id(GL_ARRAY_BUFFER, vert_source->Vbuffer_handle),
+		opengl_buffer_get_id(GL_ELEMENT_ARRAY_BUFFER, vert_source->Ibuffer_handle));
 
 	// If GL_ARB_gpu_shader5 is supprted then the instancing is handled by the geometry shader
-	if ( !GLAD_GL_ARB_gpu_shader5 && Rendering_to_shadow_map ) {
+	if (!GLAD_GL_ARB_gpu_shader5 && Rendering_to_shadow_map) {
 		glDrawElementsInstancedBaseVertex(GL_TRIANGLES,
-										  (GLsizei) datap->n_verts,
-										  element_type,
+			(GLsizei)datap->n_verts,
+			element_type,
 										  ibuffer + datap->index_offset,
 										  4,
 										  (GLint) (vert_source->Base_vertex_offset + bufferp->vertex_num_offset));

--- a/code/graphics/opengl/gropengltnl.h
+++ b/code/graphics/opengl/gropengltnl.h
@@ -43,15 +43,15 @@ struct opengl_vertex_bind {
 	opengl_vert_attrib::attrib_id attribute_id;
 };
 
-int gr_opengl_create_buffer(BufferType type, BufferUsageHint usage);
+gr_buffer_handle gr_opengl_create_buffer(BufferType type, BufferUsageHint usage);
 
-void opengl_bind_buffer_object(int handle);
-void gr_opengl_update_buffer_data(int handle, size_t size, const void* data);
-void gr_opengl_update_buffer_data_offset(int handle, size_t offset, size_t size, const void* data);
-void gr_opengl_delete_buffer(int handle);
-void gr_opengl_bind_uniform_buffer(uniform_block_type bind_point, size_t offset, size_t size, int buffer);
-void* gr_opengl_map_buffer(int handle);
-void gr_opengl_flush_mapped_buffer(int handle, size_t offset, size_t size);
+void opengl_bind_buffer_object(gr_buffer_handle handle);
+void gr_opengl_update_buffer_data(gr_buffer_handle handle, size_t size, const void* data);
+void gr_opengl_update_buffer_data_offset(gr_buffer_handle handle, size_t offset, size_t size, const void* data);
+void gr_opengl_delete_buffer(gr_buffer_handle handle);
+void gr_opengl_bind_uniform_buffer(uniform_block_type bind_point, size_t offset, size_t size, gr_buffer_handle buffer);
+void* gr_opengl_map_buffer(gr_buffer_handle handle);
+void gr_opengl_flush_mapped_buffer(gr_buffer_handle handle, size_t offset, size_t size);
 
 /**
  * @brief Retrieves the OpenGL handle of a generic buffer handle
@@ -59,7 +59,7 @@ void gr_opengl_flush_mapped_buffer(int handle, size_t offset, size_t size);
  * @param buffer_handle The handle of the generic buffer
  * @return The OpenGL handle ID
  */
-GLuint opengl_buffer_get_id(GLenum expected_type, int buffer_handle);
+GLuint opengl_buffer_get_id(GLenum expected_type, gr_buffer_handle buffer_handle);
 
 void gr_opengl_update_transform_buffer(void* data, size_t size);
 

--- a/code/graphics/paths/NanoVGRenderer.h
+++ b/code/graphics/paths/NanoVGRenderer.h
@@ -68,7 +68,7 @@ class NanoVGRenderer {
 		uint32_t strokeOffset;
 		uint32_t strokeCount;
 	};
-	int _vertexBuffer = -1;
+	gr_buffer_handle _vertexBuffer;
 	vertex_layout _vertexLayout;
 
 	util::UniformBuffer _uniformBuffer;

--- a/code/graphics/render.cpp
+++ b/code/graphics/render.cpp
@@ -1092,7 +1092,7 @@ void gr_2d_stop_buffer() {
 	path->endFrame();
 }
 
-int gr_immediate_buffer_handle = -1;
+gr_buffer_handle gr_immediate_buffer_handle;
 static size_t immediate_buffer_offset = 0;
 static size_t immediate_buffer_size = 0;
 static const int IMMEDIATE_BUFFER_RESIZE_BLOCK_SIZE = 2048;
@@ -1100,7 +1100,7 @@ static const int IMMEDIATE_BUFFER_RESIZE_BLOCK_SIZE = 2048;
 size_t gr_add_to_immediate_buffer(size_t size, void* data) {
 	GR_DEBUG_SCOPE("Add data to immediate buffer");
 
-	if ( gr_immediate_buffer_handle < 0 ) {
+	if (!gr_immediate_buffer_handle.isValid()) {
 		gr_immediate_buffer_handle = gr_create_buffer(BufferType::Vertex, BufferUsageHint::Dynamic);
 	}
 
@@ -1124,7 +1124,7 @@ size_t gr_add_to_immediate_buffer(size_t size, void* data) {
 	return old_offset;
 }
 void gr_reset_immediate_buffer() {
-	if ( gr_immediate_buffer_handle < 0 ) {
+	if (!gr_immediate_buffer_handle.isValid()) {
 		// we haven't used the immediate buffer yet
 		return;
 	}

--- a/code/graphics/render.h
+++ b/code/graphics/render.h
@@ -187,7 +187,7 @@ void gr_2d_stop_buffer();
 /**
  * @brief The buffer object holding the data for immediate draws
  */
-extern int gr_immediate_buffer_handle;
+extern gr_buffer_handle gr_immediate_buffer_handle;
 
 /**
  * @brief Adds data to the immediate buffer for use by draw operations

--- a/code/graphics/util/GPUMemoryHeap.cpp
+++ b/code/graphics/util/GPUMemoryHeap.cpp
@@ -27,9 +27,9 @@ GPUMemoryHeap::GPUMemoryHeap(GpuHeap heap_type) {
 	_allocator.reset(new ::util::HeapAllocator([this](size_t n) { resizeBuffer(n); }));
 }
 GPUMemoryHeap::~GPUMemoryHeap() {
-	if (_bufferHandle != -1) {
+	if (_bufferHandle.isValid()) {
 		gr_delete_buffer(_bufferHandle);
-		_bufferHandle = -1;
+		_bufferHandle = gr_buffer_handle();
 	}
 
 	if (_dataBuffer != nullptr) {
@@ -63,7 +63,7 @@ void GPUMemoryHeap::freeGpuData(size_t offset) {
 	_allocator->free(offset);
 	// Just leave the data in the buffers since it doesn't hurt anyone if it's kept in there
 }
-int GPUMemoryHeap::bufferHandle() {
+gr_buffer_handle GPUMemoryHeap::bufferHandle() {
 	return _bufferHandle;
 }
 

--- a/code/graphics/util/GPUMemoryHeap.h
+++ b/code/graphics/util/GPUMemoryHeap.h
@@ -16,7 +16,7 @@ namespace util {
  */
 class GPUMemoryHeap {
 	std::unique_ptr<::util::HeapAllocator> _allocator;
-	int _bufferHandle = -1;
+	gr_buffer_handle _bufferHandle;
 
 	void* _dataBuffer = nullptr;
 	size_t _bufferSize = 0;
@@ -53,7 +53,7 @@ class GPUMemoryHeap {
 	 *
 	 * @return The graphics code buffer handle.
 	 */
-	int bufferHandle();
+	gr_buffer_handle bufferHandle();
 };
 
 }

--- a/code/graphics/util/UniformBuffer.cpp
+++ b/code/graphics/util/UniformBuffer.cpp
@@ -16,7 +16,7 @@ UniformBuffer::UniformBuffer(UniformBufferManager* parent, size_t parent_offset,
 }
 UniformBuffer::~UniformBuffer() = default;
 void UniformBuffer::submitData() { _parent->submitData(_aligner.getData(), _aligner.getSize(), _parent_offset); }
-int UniformBuffer::bufferHandle() { return _buffer_handle; }
+gr_buffer_handle UniformBuffer::bufferHandle() { return _buffer_handle; }
 size_t UniformBuffer::getBufferOffset(size_t localOffset) { return _parent_offset + localOffset; }
 size_t UniformBuffer::getAlignerElementOffset(size_t index) { return getBufferOffset(_aligner.getOffset(index)); }
 size_t UniformBuffer::getCurrentAlignerOffset() { return getBufferOffset(_aligner.getCurrentOffset()); }

--- a/code/graphics/util/UniformBuffer.h
+++ b/code/graphics/util/UniformBuffer.h
@@ -20,7 +20,7 @@ class UniformBuffer {
 	UniformBufferManager* _parent = nullptr;
 	size_t _parent_offset         = 0;
 
-	int _buffer_handle = -1;
+	gr_buffer_handle _buffer_handle;
 
 	UniformAligner _aligner;
 
@@ -44,7 +44,7 @@ class UniformBuffer {
 	 * @brief Gets the buffer handle for use with gr_bind_uniform_buffer.
 	 * @return The buffer handle
 	 */
-	int bufferHandle();
+	gr_buffer_handle bufferHandle();
 
 	/**
 	 * @brief Submits the data from the uniform aligner to the underlying buffer object.

--- a/code/graphics/util/UniformBufferManager.cpp
+++ b/code/graphics/util/UniformBufferManager.cpp
@@ -63,9 +63,9 @@ UniformBufferManager::UniformBufferManager()
 }
 UniformBufferManager::~UniformBufferManager()
 {
-	if (_active_uniform_buffer >= 0) {
+	if (_active_uniform_buffer.isValid()) {
 		gr_delete_buffer(_active_uniform_buffer);
-		_active_uniform_buffer = -1;
+		_active_uniform_buffer = gr_buffer_handle();
 	}
 	for (auto& fence : _segment_fences) {
 		if (fence != nullptr) {
@@ -165,7 +165,7 @@ UniformBuffer UniformBufferManager::getUniformBuffer(uniform_block_type type, si
 }
 void UniformBufferManager::changeSegmentSize(size_t new_size)
 {
-	if (_active_uniform_buffer >= 0) {
+	if (_active_uniform_buffer.isValid()) {
 		// Retire the old buffer first
 		_retired_buffers.emplace_back(gr_sync_fence(), _active_uniform_buffer, std::move(_shadow_uniform_buffer));
 	}
@@ -203,7 +203,7 @@ void UniformBufferManager::submitData(void* buffer, size_t data_size, size_t off
 		gr_update_buffer_data_offset(_active_uniform_buffer, offset, data_size, buffer);
 	}
 }
-int UniformBufferManager::getActiveBufferHandle() { return _active_uniform_buffer; }
+gr_buffer_handle UniformBufferManager::getActiveBufferHandle() { return _active_uniform_buffer; }
 size_t UniformBufferManager::getBufferSize() { return _active_buffer_size; }
 size_t UniformBufferManager::getCurrentlyUsedSize() { return _segment_offset; }
 } // namespace util

--- a/code/graphics/util/UniformBufferManager.h
+++ b/code/graphics/util/UniformBufferManager.h
@@ -26,7 +26,7 @@ class UniformBufferManager {
 
 	std::array<gr_sync, NUM_SEGMENTS> _segment_fences;
 
-	int _active_uniform_buffer = -1;
+	gr_buffer_handle _active_uniform_buffer;
 	size_t _active_buffer_size = 0;
 	void* _buffer_ptr          = nullptr; // Pointer to mapped data for persistently mapped buffers
 
@@ -43,7 +43,7 @@ class UniformBufferManager {
 	 * The byte array is the associated shadow buffer which will ensure that the pointer stays valid until the buffer is
 	 * deleted at which point any reference to it will surely be removed.
 	 */
-	SCP_vector<std::tuple<gr_sync, int, std::unique_ptr<uint8_t[]>>> _retired_buffers;
+	SCP_vector<std::tuple<gr_sync, gr_buffer_handle, std::unique_ptr<uint8_t[]>>> _retired_buffers;
 
 	/**
 	 * @brief This is a pointer to an array which is a shadow of the uniform buffer
@@ -93,7 +93,7 @@ class UniformBufferManager {
 	 *
 	 * @return The uniform buffer handle
 	 */
-	int getActiveBufferHandle();
+	gr_buffer_handle getActiveBufferHandle();
 
 	/**
 	 * @brief Checks the used buffer and retires any buffers that are no longer in use for later reuse

--- a/code/graphics/vulkan/vulkan_stubs.cpp
+++ b/code/graphics/vulkan/vulkan_stubs.cpp
@@ -10,9 +10,12 @@ namespace vulkan {
 
 namespace {
 
-int stub_create_buffer(BufferType, BufferUsageHint) { return -1; }
+gr_buffer_handle stub_create_buffer(BufferType, BufferUsageHint)
+{
+	return gr_buffer_handle::invalid();
+}
 
-void stub_delete_buffer(int /*handle*/) {}
+void stub_delete_buffer(gr_buffer_handle /*handle*/) {}
 
 int stub_preload(int /*bitmap_num*/, int /*is_aabitmap*/) { return 0; }
 
@@ -36,9 +39,14 @@ void stub_reset_clip() {}
 
 void stub_restore_screen(int /*id*/) {}
 
-void stub_update_buffer_data(int /*handle*/, size_t /*size*/, const void* /*data*/) {}
+void stub_update_buffer_data(gr_buffer_handle /*handle*/, size_t /*size*/, const void* /*data*/) {}
 
-void stub_update_buffer_data_offset(int /*handle*/, size_t /*offset*/, size_t /*size*/, const void* /*data*/) {}
+void stub_update_buffer_data_offset(gr_buffer_handle /*handle*/,
+	size_t /*offset*/,
+	size_t /*size*/,
+	const void* /*data*/)
+{
+}
 
 void stub_update_transform_buffer(void* /*data*/, size_t /*size*/) {}
 
@@ -120,7 +128,7 @@ void stub_shadow_map_end() {}
 void stub_render_shield_impact(shield_material* /*material_info*/,
 	primitive_type /*prim_type*/,
 	vertex_layout* /*layout*/,
-	int /*buffer_handle*/,
+	gr_buffer_handle /*buffer_handle*/,
 	int /*n_verts*/)
 {
 }
@@ -137,7 +145,7 @@ void stub_render_primitives(material* /*material_info*/,
 	vertex_layout* /*layout*/,
 	int /*offset*/,
 	int /*n_verts*/,
-	int /*buffer_handle*/,
+	gr_buffer_handle /*buffer_handle*/,
 	size_t /*buffer_offset*/)
 {
 }
@@ -147,7 +155,7 @@ void stub_render_primitives_particle(particle_material* /*material_info*/,
 	vertex_layout* /*layout*/,
 	int /*offset*/,
 	int /*n_verts*/,
-	int /*buffer_handle*/)
+	gr_buffer_handle /*buffer_handle*/)
 {
 }
 
@@ -156,14 +164,14 @@ void stub_render_primitives_distortion(distortion_material* /*material_info*/,
 	vertex_layout* /*layout*/,
 	int /*offset*/,
 	int /*n_verts*/,
-	int /*buffer_handle*/)
+	gr_buffer_handle /*buffer_handle*/)
 {
 }
 void stub_render_movie(movie_material* /*material_info*/,
 	primitive_type /*prim_type*/,
 	vertex_layout* /*layout*/,
 	int /*n_verts*/,
-	int /*buffer*/,
+	gr_buffer_handle /*buffer*/,
 	size_t /*buffer_offset*/)
 {
 }
@@ -173,7 +181,7 @@ void stub_render_nanovg(nanovg_material* /*material_info*/,
 	vertex_layout* /*layout*/,
 	int /*offset*/,
 	int /*n_verts*/,
-	int /*buffer_handle*/)
+	gr_buffer_handle /*buffer_handle*/)
 {
 }
 
@@ -182,7 +190,7 @@ void stub_render_primitives_batched(batched_bitmap_material* /*material_info*/,
 	vertex_layout* /*layout*/,
 	int /*offset*/,
 	int /*n_verts*/,
-	int /*buffer_handle*/)
+	gr_buffer_handle /*buffer_handle*/)
 {
 }
 
@@ -190,8 +198,8 @@ void stub_render_rocket_primitives(interface_material* /*material_info*/,
 	primitive_type /*prim_type*/,
 	vertex_layout* /*layout*/,
 	int /*n_indices*/,
-	int /*vertex_buffer*/,
-	int /*index_buffer*/)
+	gr_buffer_handle /*vertex_buffer*/,
+	gr_buffer_handle /*index_buffer*/)
 {
 }
 
@@ -273,8 +281,8 @@ void init_stub_pointers()
 	gr_screen.gf_update_transform_buffer = stub_update_transform_buffer;
 	gr_screen.gf_update_buffer_data = stub_update_buffer_data;
 	gr_screen.gf_update_buffer_data_offset = stub_update_buffer_data_offset;
-	gr_screen.gf_map_buffer = [](int) -> void* { return nullptr; };
-	gr_screen.gf_flush_mapped_buffer = [](int, size_t, size_t) {};
+	gr_screen.gf_map_buffer = [](gr_buffer_handle) -> void* { return nullptr; };
+	gr_screen.gf_flush_mapped_buffer = [](gr_buffer_handle, size_t, size_t) {};
 
 	gr_screen.gf_post_process_set_effect = stub_post_process_set_effect;
 	gr_screen.gf_post_process_set_defaults = stub_post_process_set_defaults;
@@ -332,7 +340,7 @@ void init_stub_pointers()
 	gr_screen.gf_create_viewport = [](const os::ViewPortProperties&) { return std::unique_ptr<os::Viewport>(); };
 	gr_screen.gf_use_viewport = [](os::Viewport*) {};
 
-	gr_screen.gf_bind_uniform_buffer = [](uniform_block_type, size_t, size_t, int) {};
+	gr_screen.gf_bind_uniform_buffer = [](uniform_block_type, size_t, size_t, gr_buffer_handle) {};
 
 	gr_screen.gf_sync_fence = []() -> gr_sync { return nullptr; };
 	gr_screen.gf_sync_wait = [](gr_sync /*sync*/, uint64_t /*timeoutns*/) { return true; };

--- a/code/model/model.h
+++ b/code/model/model.h
@@ -528,7 +528,7 @@ struct shield_info {
 	shield_vertex	*verts;
 	shield_tri		*tris;
 
-	int buffer_id;
+	gr_buffer_handle buffer_id;
 	int buffer_n_verts;
 	vertex_layout layout;
 

--- a/code/model/modelinterp.cpp
+++ b/code/model/modelinterp.cpp
@@ -2485,7 +2485,7 @@ void model_interp_process_shield_mesh(polymodel * pm)
 		pm->shield.layout.add_vertex_component(vertex_format_data::POSITION3, sizeof(vec3d) * 2, 0);
 		pm->shield.layout.add_vertex_component(vertex_format_data::NORMAL, sizeof(vec3d) * 2, sizeof(vec3d));
 	} else {
-		pm->shield.buffer_id = -1;
+		pm->shield.buffer_id = gr_buffer_handle::invalid();
 	}
 }
 

--- a/code/model/modelread.cpp
+++ b/code/model/modelread.cpp
@@ -296,15 +296,15 @@ void model_unload(int modelnum, int force)
 		vm_free(pm->shield_collision_tree);
 	}
 
-	if ( pm->shield.buffer_id > -1 ) {
+	if (pm->shield.buffer_id.isValid()) {
 		gr_delete_buffer(pm->shield.buffer_id);
-		pm->shield.buffer_id = -1;
+		pm->shield.buffer_id = gr_buffer_handle::invalid();
 		pm->shield.buffer_n_verts = 0;
 	}
 
-	if ( pm->vert_source.Vbuffer_handle > -1 ) {
+	if (pm->vert_source.Vbuffer_handle.isValid()) {
 		gr_heap_deallocate(GpuHeap::ModelVertex, pm->vert_source.Vertex_offset);
-		pm->vert_source.Vbuffer_handle = -1;
+		pm->vert_source.Vbuffer_handle = gr_buffer_handle::invalid();
 
 		pm->vert_source.Vertex_offset = 0;
 		pm->vert_source.Base_vertex_offset = 0;
@@ -315,10 +315,10 @@ void model_unload(int modelnum, int force)
 		pm->vert_source.Vertex_list = NULL;
 	}
 
-	if ( pm->vert_source.Ibuffer_handle > -1 ) {
+	if (pm->vert_source.Ibuffer_handle.isValid()) {
 		gr_heap_deallocate(GpuHeap::ModelIndex, pm->vert_source.Index_offset);
 
-		pm->vert_source.Ibuffer_handle = -1;
+		pm->vert_source.Ibuffer_handle = gr_buffer_handle::invalid();
 		pm->vert_source.Index_offset = 0;
 	}
 

--- a/code/model/modelrender.cpp
+++ b/code/model/modelrender.cpp
@@ -742,11 +742,11 @@ bool model_draw_list::sort_draw_pair(model_draw_list* target, const int a, const
 	}
 
 	if ( draw_call_a->vert_src->Vbuffer_handle != draw_call_b->vert_src->Vbuffer_handle ) {
-		return draw_call_a->vert_src->Vbuffer_handle < draw_call_b->vert_src->Vbuffer_handle;
+		return draw_call_a->vert_src->Vbuffer_handle.value() < draw_call_b->vert_src->Vbuffer_handle.value();
 	}
 
 	if ( draw_call_a->vert_src->Ibuffer_handle != draw_call_b->vert_src->Ibuffer_handle ) {
-		return draw_call_a->vert_src->Ibuffer_handle < draw_call_b->vert_src->Ibuffer_handle;
+		return draw_call_a->vert_src->Ibuffer_handle.value() < draw_call_b->vert_src->Ibuffer_handle.value();
 	}
 
 	if ( draw_call_a->render_material.get_texture_map(TM_BASE_TYPE) != draw_call_b->render_material.get_texture_map(TM_BASE_TYPE) ) {

--- a/code/render/batching.cpp
+++ b/code/render/batching.cpp
@@ -762,7 +762,10 @@ void batching_add_tri(int texture, vertex *verts)
 	batching_add_tri_internal(batch, texture, verts);
 }
 
-void batching_render_batch_item(primitive_batch_item *item, vertex_layout *layout, primitive_type prim_type, int buffer_num)
+void batching_render_batch_item(primitive_batch_item* item,
+	vertex_layout* layout,
+	primitive_type prim_type,
+	gr_buffer_handle buffer_num)
 {
 	GR_DEBUG_SCOPE("Batching render item");
 	TRACE_SCOPE(tracing::RenderBatchItem);
@@ -813,7 +816,7 @@ void batching_allocate_and_load_buffer(primitive_batch_buffer *draw_queue)
 		offset += item->n_verts;
 	}
 
-	if ( draw_queue->buffer_num >= 0 ) {
+	if (draw_queue->buffer_num.isValid()) {
 		gr_update_buffer_data(draw_queue->buffer_num, draw_queue->buffer_size, draw_queue->buffer_ptr);
 	}
 }

--- a/code/render/batching.h
+++ b/code/render/batching.h
@@ -99,7 +99,7 @@ struct primitive_batch_item {
 
 struct primitive_batch_buffer {
 	vertex_layout layout;
-	int buffer_num;
+	gr_buffer_handle buffer_num;
 
 	void* buffer_ptr;
 	size_t buffer_size;

--- a/code/scpui/RocketRenderingInterface.cpp
+++ b/code/scpui/RocketRenderingInterface.cpp
@@ -44,10 +44,10 @@ RocketRenderingInterface::RocketRenderingInterface()
 
 RocketRenderingInterface::~RocketRenderingInterface()
 {
-	if (vertex_stream_buffer >= 0) {
+	if (vertex_stream_buffer.isValid()) {
 		gr_delete_buffer(vertex_stream_buffer);
 	}
-	if (index_stream_buffer >= 0) {
+	if (index_stream_buffer.isValid()) {
 		gr_delete_buffer(index_stream_buffer);
 	}
 }
@@ -252,8 +252,11 @@ float RocketRenderingInterface::GetPixelsPerInch()
 #endif
 }
 
-void RocketRenderingInterface::renderGeometry(int vertex_buffer, int index_buffer, int num_elements, int bitmap,
-                                              const Rocket::Core::Vector2f& translation)
+void RocketRenderingInterface::renderGeometry(gr_buffer_handle vertex_buffer,
+	gr_buffer_handle index_buffer,
+	int num_elements,
+	int bitmap,
+	const Rocket::Core::Vector2f& translation)
 {
 	interface_material material;
 

--- a/code/scpui/RocketRenderingInterface.h
+++ b/code/scpui/RocketRenderingInterface.h
@@ -29,9 +29,9 @@ class RocketRenderingInterface : public Rocket::Core::RenderInterface {
 	};
 
 	struct CompiledGeometry {
-		int vertex_buffer = -1;
-		int index_buffer  = -1;
-		int num_elements  = -1;
+		gr_buffer_handle vertex_buffer;
+		gr_buffer_handle index_buffer;
+		int num_elements = -1;
 
 		Texture* texture = nullptr;
 	};
@@ -44,11 +44,14 @@ class RocketRenderingInterface : public Rocket::Core::RenderInterface {
 
 	static Rocket::Core::TextureHandle get_texture_handle(Texture* bitmap);
 
-	void renderGeometry(int vertex_buffer, int index_buffer, int num_elements, int bitmap,
-	                    const Rocket::Core::Vector2f& translation);
+	void renderGeometry(gr_buffer_handle vertex_buffer,
+		gr_buffer_handle index_buffer,
+		int num_elements,
+		int bitmap,
+		const Rocket::Core::Vector2f& translation);
 
-	int vertex_stream_buffer = -1;
-	int index_stream_buffer  = -1;
+	gr_buffer_handle vertex_stream_buffer;
+	gr_buffer_handle index_stream_buffer;
 
 	vertex_layout layout;
 

--- a/code/ship/shield.cpp
+++ b/code/ship/shield.cpp
@@ -390,7 +390,7 @@ void shield_render_triangle(int texture, float alpha, gshield_tri *trip, matrix 
 
 void shield_render_decal(polymodel *pm, matrix *orient, vec3d *pos, matrix* hit_orient, vec3d *hit_pos, float hit_radius, int bitmap_id, color *clr)
 {
-	if ( pm->shield.buffer_id < 0 || pm->shield.buffer_n_verts < 3 ) {
+	if (!pm->shield.buffer_id.isValid() || pm->shield.buffer_n_verts < 3) {
 		return;
 	}
 


### PR DESCRIPTION
This converts the previous plain int type for a buffer handle to an
instance of our ID class which provides type safety.