### PR TITLE
Make removing non-existent hook-vars a no-op

### DIFF
--- a/code/scripting/scripting.cpp
+++ b/code/scripting/scripting.cpp
@@ -627,9 +627,10 @@ void script_state::RemHookVars(std::initializer_list<SCP_string> names)
 {
 	if (LuaState != nullptr) {
 		for (const auto& hookVar : names) {
-			Assertion(!HookVariableValues[hookVar].empty(),
-				"Tried to remove uninitialized hook variable '%s'",
-				hookVar.c_str());
+			if (HookVariableValues[hookVar].empty()) {
+				// Nothing to do
+				continue;
+			}
 			HookVariableValues[hookVar].pop_back();
 		}
 	}

--- a/test/src/scripting/api/hookvars.cpp
+++ b/test/src/scripting/api/hookvars.cpp
@@ -38,3 +38,9 @@ TEST_F(HookVarsTest, withHookVars)
 
 	this->EvalTestScript();
 }
+
+TEST_F(HookVarsTest, removeNonExistent)
+{
+	// Should not cause any errors
+	_state->RemHookVar("Test");
+}


### PR DESCRIPTION
There are some usages where a hook variable is removed blindly which
caused issues in multi.

This fixes #2824.