### PR TITLE
Better excluding of beam-weapon collisions with the same parent

### DIFF
--- a/code/object/objcollide.cpp
+++ b/code/object/objcollide.cpp
@@ -889,7 +889,7 @@ void obj_collide_pair(object *A, object *B)
         collision_info->next_check_time = timestamp(0);
     }
 
-    if ( valid &&  A->type != OBJ_BEAM ) {
+    if ( valid ) {
         // if this signature is valid, make the necessary checks to see if we need to collide check
         if ( collision_info->next_check_time == -1 ) {
             return;


### PR DESCRIPTION
`pair->b == b->objp` in `beam_collide_missile` (that is, `colliding_missile == beam->objp` ) used to cull collisions will never be true, `beam->objp` will always be a ship, but I've replaced it with a similar check that weapon-weapon collisions do to ensure they never collide if fired from the same parent. Beams don't have `parent_sig` so it has some looking up to do first, essentially preventing a ship's beams from shooting down its own missiles. This is an absurdly unlikely situation normally, but becomes significantly more likely with continuous spawn.

Also renames the abysmally named beam variables in the collision functions so you don't have horribly confusing looking lines like `pair->b == b->objp` (`pair->b` is the other collider, `b` is the beam).

And also removes the bizarre exclusion of beams from never being collision checked if the function returns 1. It's hard to say if this was retail since collision was completely overhauled at some point, but I couldn't find any indications that it was. I had assumed this was done because it didn't return 1 properly or had some way of invalidating a previous claim of 'never being able to collide'. But the only time these functions return 1 is when this parenting relation excludes them or it can't get a model to collide against. Both of which are perfectly valid and permanent situations.