### PR TITLE
Add 'Choose Random Bitmap' for particle effects

### DIFF
--- a/code/particle/ParticleManager.cpp
+++ b/code/particle/ParticleManager.cpp
@@ -362,7 +362,7 @@ SCP_vector<int> parseAnimationList(bool critical) {
 	
 	SCP_vector<int> handles;
 
-	for (SCP_string name: bitmap_strings) {
+	for (auto name: bitmap_strings) {
 		auto handle = bm_load_animation(name.c_str());
 		if (handle >= 0) {
 			handles.push_back(handle);

--- a/code/particle/ParticleManager.cpp
+++ b/code/particle/ParticleManager.cpp
@@ -343,28 +343,26 @@ bool required_string_if_new(const char* token, bool no_create) {
 	return true;
 }
 
-int parseAnimation(bool critical) {
-	SCP_string name;
-	stuff_string(name, F_FILESPEC);
-
-	auto handle = bm_load_animation(name.c_str());
-
-	if (handle < 0) {
-		int level = critical ? 1 : 0;
-		error_display(level, "Failed to load effect %s!", name.c_str());
-	}
-
-	return handle;
-}
-
 SCP_vector<int> parseAnimationList(bool critical) {
 
 	SCP_vector<SCP_string> bitmap_strings;
-	int num_bitmaps = stuff_string_list(bitmap_strings);
+	
+	// check to see if we are parsing a single value or list
+	ignore_white_space();
+	if (*Mp == '(') {
+		// list of names case
+		stuff_string_list(bitmap_strings);
+	}
+	else {
+		// single name case
+		SCP_string name;
+		stuff_string(name, F_FILESPEC);
+		bitmap_strings.push_back(name);
+	}
+	
 	SCP_vector<int> handles;
-	size_t tbl_idx;
 
-	for (auto i = 0; i < num_bitmaps; i++) {
+	for (auto i = 0; i < bitmap_strings.size(); i++) {
 		SCP_string name = bitmap_strings[i];
 		auto handle = bm_load_animation(name.c_str());
 		if (handle < 0) {

--- a/code/particle/ParticleManager.cpp
+++ b/code/particle/ParticleManager.cpp
@@ -356,5 +356,26 @@ int parseAnimation(bool critical) {
 
 	return handle;
 }
+
+SCP_vector<int> parseAnimationList(bool critical) {
+
+	SCP_vector<SCP_string> bitmap_strings;
+	int num_bitmaps = stuff_string_list(bitmap_strings);
+	SCP_vector<int> handles;
+	size_t tbl_idx;
+
+	for (auto i = 0; i < num_bitmaps; i++) {
+		SCP_string name = bitmap_strings[i];
+		auto handle = bm_load_animation(name.c_str());
+		if (handle < 0) {
+			int level = critical ? 1 : 0;
+			error_display(level, "Failed to load effect %s!", name.c_str());
+		}
+		handles[i] = handle;
+	}
+
+	return handles;
+}
+
 }
 }

--- a/code/particle/ParticleManager.cpp
+++ b/code/particle/ParticleManager.cpp
@@ -362,7 +362,7 @@ SCP_vector<int> parseAnimationList(bool critical) {
 	
 	SCP_vector<int> handles;
 
-	for (auto i = 0; i < bitmap_strings.size(); i++) {
+	for (size_t i = 0; i < bitmap_strings.size(); i++) {
 		SCP_string name = bitmap_strings[i];
 		auto handle = bm_load_animation(name.c_str());
 		if (handle < 0) {

--- a/code/particle/ParticleManager.cpp
+++ b/code/particle/ParticleManager.cpp
@@ -362,14 +362,15 @@ SCP_vector<int> parseAnimationList(bool critical) {
 	
 	SCP_vector<int> handles;
 
-	for (size_t i = 0; i < bitmap_strings.size(); i++) {
-		SCP_string name = bitmap_strings[i];
+	for (SCP_string name: bitmap_strings) {
 		auto handle = bm_load_animation(name.c_str());
-		if (handle < 0) {
+		if (handle >= 0) {
+			handles.push_back(handle);
+		}
+		else {
 			int level = critical ? 1 : 0;
 			error_display(level, "Failed to load effect %s!", name.c_str());
 		}
-		handles.push_back(handle);
 	}
 
 	return handles;

--- a/code/particle/ParticleManager.cpp
+++ b/code/particle/ParticleManager.cpp
@@ -362,7 +362,7 @@ SCP_vector<int> parseAnimationList(bool critical) {
 	
 	SCP_vector<int> handles;
 
-	for (auto name: bitmap_strings) {
+	for (auto const &name: bitmap_strings) {
 		auto handle = bm_load_animation(name.c_str());
 		if (handle >= 0) {
 			handles.push_back(handle);

--- a/code/particle/ParticleManager.cpp
+++ b/code/particle/ParticleManager.cpp
@@ -371,7 +371,7 @@ SCP_vector<int> parseAnimationList(bool critical) {
 			int level = critical ? 1 : 0;
 			error_display(level, "Failed to load effect %s!", name.c_str());
 		}
-		handles[i] = handle;
+		handles.push_back(handle);
 	}
 
 	return handles;

--- a/code/particle/ParticleManager.h
+++ b/code/particle/ParticleManager.h
@@ -166,7 +166,7 @@ bool required_string_if_new(const char* token, bool no_create);
  * an error. Otherwise it will be cause a warning.
  *
  * @param critical @c true if a failure is critical
- * @return The vecotr of animation handles
+ * @return The vector of animation handles
  */
 
 SCP_vector<int> parseAnimationList(bool critical = true);

--- a/code/particle/ParticleManager.h
+++ b/code/particle/ParticleManager.h
@@ -160,15 +160,14 @@ ParticleEffectHandle parseEffectElement(EffectType forcedType = EffectType::Inva
 bool required_string_if_new(const char* token, bool no_create);
 
 /**
- * @brief Parses an animation
+ * @brief Parses an animation or list of animations.
  *
- * Parses and animation and returns the handle. If critical is @c true then a failure to load the animation will cause
+ * Parses an animation or list of animations and returns the handle(s). If critical is @c true then a failure to load the animation will cause
  * an error. Otherwise it will be cause a warning.
  *
  * @param critical @c true if a failure is critical
- * @return The animation handle
+ * @return The vecotr of animation handles
  */
-int parseAnimation(bool critical = true);
 
 SCP_vector<int> parseAnimationList(bool critical = true);
 }

--- a/code/particle/ParticleManager.h
+++ b/code/particle/ParticleManager.h
@@ -172,7 +172,6 @@ bool required_string_if_new(const char* token, bool no_create);
 SCP_vector<int> parseAnimationList(bool critical = true);
 }
 
-
 namespace util {
 /**
  * @brief Parses an effect name

--- a/code/particle/ParticleManager.h
+++ b/code/particle/ParticleManager.h
@@ -169,7 +169,10 @@ bool required_string_if_new(const char* token, bool no_create);
  * @return The animation handle
  */
 int parseAnimation(bool critical = true);
+
+SCP_vector<int> parseAnimationList(bool critical = true);
 }
+
 
 namespace util {
 /**

--- a/code/particle/effects/SingleParticleEffect.cpp
+++ b/code/particle/effects/SingleParticleEffect.cpp
@@ -58,7 +58,9 @@ SingleParticleEffect* SingleParticleEffect::createInstance(int effectID, float m
 	Assertion(minSize >= 0.0f, "Minimum size may not be less than zero, got %f!", minSize);
 
 	auto effectPtr = new SingleParticleEffect("");
-	effectPtr->m_particleProperties.m_bitmap = effectID;
+	SCP_vector<int> bitmap_list;
+	bitmap_list.push_back(effectID);
+	effectPtr->m_particleProperties.m_bitmap_list = bitmap_list;
 	effectPtr->m_particleProperties.m_radius = ::util::UniformFloatRange(minSize, maxSize);
 
 	if (lifetime > 0.0f) {

--- a/code/particle/effects/SingleParticleEffect.cpp
+++ b/code/particle/effects/SingleParticleEffect.cpp
@@ -59,6 +59,7 @@ SingleParticleEffect* SingleParticleEffect::createInstance(int effectID, float m
 
 	auto effectPtr = new SingleParticleEffect("");
 	effectPtr->m_particleProperties.m_bitmap_list.push_back(effectID);
+	effectPtr->m_particleProperties.m_bitmap_range = ::util::UniformRange<size_t>(0, effectPtr->m_particleProperties.m_bitmap_list.size() - 1);
 	effectPtr->m_particleProperties.m_radius = ::util::UniformFloatRange(minSize, maxSize);
 
 	if (lifetime > 0.0f) {

--- a/code/particle/effects/SingleParticleEffect.cpp
+++ b/code/particle/effects/SingleParticleEffect.cpp
@@ -58,9 +58,7 @@ SingleParticleEffect* SingleParticleEffect::createInstance(int effectID, float m
 	Assertion(minSize >= 0.0f, "Minimum size may not be less than zero, got %f!", minSize);
 
 	auto effectPtr = new SingleParticleEffect("");
-	SCP_vector<int> bitmap_list;
-	bitmap_list.push_back(effectID);
-	effectPtr->m_particleProperties.m_bitmap_list = bitmap_list;
+	effectPtr->m_particleProperties.m_bitmap_list.push_back(effectID);
 	effectPtr->m_particleProperties.m_radius = ::util::UniformFloatRange(minSize, maxSize);
 
 	if (lifetime > 0.0f) {

--- a/code/particle/util/ParticleProperties.cpp
+++ b/code/particle/util/ParticleProperties.cpp
@@ -44,7 +44,7 @@ int ParticleProperties::chooseBitmap()
 	int num_bitmaps = (int)m_bitmap_list.size();
 
 	if (num_bitmaps == 1) {
-		bitmap_index = 0;
+		bitmap_index = m_bitmap_list[0];
 	} else if (num_bitmaps > 1) {
 		bitmap_index = m_bitmap_list[rand() % num_bitmaps];		
 	} else {

--- a/code/particle/util/ParticleProperties.cpp
+++ b/code/particle/util/ParticleProperties.cpp
@@ -37,21 +37,11 @@ void ParticleProperties::parse(bool nocreate) {
 int ParticleProperties::chooseBitmap()
 {
 	// failsafe check, though we should not have been able to get to this point
-	if (m_bitmap_list.empty())
-		return -1;
+	Assertion(!m_bitmap_list.empty(), "No bitmaps found!");
 
-	int bitmap_index;
-	int num_bitmaps = (int)m_bitmap_list.size();
+	size_t index = ::util::UniformRange<size_t>(0, m_bitmap_list.size() - 1).next();
 
-	if (num_bitmaps == 1) {
-		bitmap_index = m_bitmap_list[0];
-	} else if (num_bitmaps > 1) {
-		bitmap_index = m_bitmap_list[rand() % num_bitmaps];		
-	} else {
-		bitmap_index = -1;
-	}
-
-	return bitmap_index;
+	return m_bitmap_list[(int)index];
 }
 
 void ParticleProperties::createParticle(particle_info& info) {
@@ -83,12 +73,9 @@ WeakParticlePtr ParticleProperties::createPersistentParticle(particle_info& info
 }
 
 void ParticleProperties::pageIn() {
-	
-	size_t num_bitmaps = m_bitmap_list.size();
-	if (num_bitmaps > 0 ) {
-		for (size_t i = 0; i < num_bitmaps; i++) {
-			bm_page_in_aabitmap(m_bitmap_list[i], -1);
-		}
+
+	for (size_t bitmap: m_bitmap_list) {
+		bm_page_in_aabitmap(bitmap, -1);
 	}
 
 }

--- a/code/particle/util/ParticleProperties.cpp
+++ b/code/particle/util/ParticleProperties.cpp
@@ -41,7 +41,7 @@ int ParticleProperties::chooseBitmap()
 
 	size_t index = ::util::UniformRange<size_t>(0, m_bitmap_list.size() - 1).next();
 
-	return m_bitmap_list[(int)index];
+	return m_bitmap_list[index];
 }
 
 void ParticleProperties::createParticle(particle_info& info) {

--- a/code/particle/util/ParticleProperties.cpp
+++ b/code/particle/util/ParticleProperties.cpp
@@ -12,6 +12,7 @@ ParticleProperties::ParticleProperties() : m_radius(0.0f, 1.0f), m_lifetime(0.0f
 void ParticleProperties::parse(bool nocreate) {
 	if (internal::required_string_if_new("+Filename:", nocreate)) {
 		m_bitmap_list = internal::parseAnimationList(true);
+		m_bitmap_range = ::util::UniformRange<size_t>(0, m_bitmap_list.size() - 1);
 	}
 
 	if (internal::required_string_if_new("+Size:", nocreate)) {
@@ -39,9 +40,7 @@ int ParticleProperties::chooseBitmap()
 	// failsafe check, though we should not have been able to get to this point
 	Assertion(!m_bitmap_list.empty(), "No bitmaps found!");
 
-	size_t index = ::util::UniformRange<size_t>(0, m_bitmap_list.size() - 1).next();
-
-	return m_bitmap_list[index];
+	return m_bitmap_list[m_bitmap_range.next()];
 }
 
 void ParticleProperties::createParticle(particle_info& info) {

--- a/code/particle/util/ParticleProperties.cpp
+++ b/code/particle/util/ParticleProperties.cpp
@@ -84,9 +84,9 @@ WeakParticlePtr ParticleProperties::createPersistentParticle(particle_info& info
 
 void ParticleProperties::pageIn() {
 	
-	int num_bitmaps = m_bitmap_list.size();
+	size_t num_bitmaps = m_bitmap_list.size();
 	if (num_bitmaps > 0 ) {
-		for (auto i = 0; i < num_bitmaps; i++) {
+		for (size_t i = 0; i < num_bitmaps; i++) {
 			bm_page_in_aabitmap(m_bitmap_list[i], -1);
 		}
 	}

--- a/code/particle/util/ParticleProperties.cpp
+++ b/code/particle/util/ParticleProperties.cpp
@@ -14,6 +14,10 @@ void ParticleProperties::parse(bool nocreate) {
 		m_bitmap = internal::parseAnimation(true);
 	}
 
+	if (optional_string("+Filenames:")) {
+		m_bitmap_list = internal::parseAnimationList(true);
+	}
+
 	if (internal::required_string_if_new("+Size:", nocreate)) {
 		m_radius = ::util::parseUniformRange<float>();
 	}
@@ -34,7 +38,27 @@ void ParticleProperties::parse(bool nocreate) {
 	}
 }
 
+int ParticleProperties::chooseBitmap()
+{
+	// if list is empty that means the optional string to add multiple bitmaps was not used
+	// thus choose the necessary bitmap specified "+Filename:"
+	if (m_bitmap_list.empty())
+		return m_bitmap;
+
+	int bitmap_index = -1;
+	int num_bitmaps = (int)m_bitmap_list.size();
+
+	if (num_bitmaps > 0) {
+		bitmap_index = m_bitmap_list[rand() % num_bitmaps];
+		return bitmap_index;
+	} else {
+		return m_bitmap;
+	}
+	
+}
+
 void ParticleProperties::createParticle(particle_info& info) {
+	m_bitmap = ParticleProperties::chooseBitmap();
 	info.optional_data = m_bitmap;
 	info.type = PARTICLE_BITMAP;
 	info.rad = m_radius.next();
@@ -48,6 +72,7 @@ void ParticleProperties::createParticle(particle_info& info) {
 }
 
 WeakParticlePtr ParticleProperties::createPersistentParticle(particle_info& info) {
+	m_bitmap = ParticleProperties::chooseBitmap();
 	info.optional_data = m_bitmap;
 	info.type = PARTICLE_BITMAP;
 	info.rad = m_radius.next();

--- a/code/particle/util/ParticleProperties.cpp
+++ b/code/particle/util/ParticleProperties.cpp
@@ -74,7 +74,7 @@ WeakParticlePtr ParticleProperties::createPersistentParticle(particle_info& info
 
 void ParticleProperties::pageIn() {
 
-	for (size_t bitmap: m_bitmap_list) {
+	for (int bitmap: m_bitmap_list) {
 		bm_page_in_aabitmap(bitmap, -1);
 	}
 

--- a/code/particle/util/ParticleProperties.h
+++ b/code/particle/util/ParticleProperties.h
@@ -14,7 +14,7 @@ namespace util {
  */
 class ParticleProperties {
  public:
-	int m_bitmap = -1;
+
 	SCP_vector<int> m_bitmap_list;
 	::util::UniformFloatRange m_radius;
 

--- a/code/particle/util/ParticleProperties.h
+++ b/code/particle/util/ParticleProperties.h
@@ -15,6 +15,7 @@ namespace util {
 class ParticleProperties {
  public:
 	int m_bitmap = -1;
+	SCP_vector<int> m_bitmap_list;
 	::util::UniformFloatRange m_radius;
 
 	bool m_hasLifetime = false;
@@ -28,6 +29,11 @@ class ParticleProperties {
 	 * @param nocreate @c true if +nocreate was found
 	 */
 	void parse(bool nocreate);
+
+	/**
+	 * @brief Choose particle from bitmap list
+	 */
+	int chooseBitmap();
 
 	/**
 	 * @brief Creates a particle with the stored values

--- a/code/particle/util/ParticleProperties.h
+++ b/code/particle/util/ParticleProperties.h
@@ -22,6 +22,7 @@ private:
  public:
 
 	SCP_vector<int> m_bitmap_list;
+	::util::UniformRange<size_t> m_bitmap_range;
 	::util::UniformFloatRange m_radius;
 
 	bool m_hasLifetime = false;

--- a/code/particle/util/ParticleProperties.h
+++ b/code/particle/util/ParticleProperties.h
@@ -13,6 +13,12 @@ namespace util {
  * @ingroup particleUtils
  */
 class ParticleProperties {
+private:
+	/**
+	 * @brief Choose particle from bitmap list
+	 */
+	int chooseBitmap();
+
  public:
 
 	SCP_vector<int> m_bitmap_list;
@@ -29,11 +35,6 @@ class ParticleProperties {
 	 * @param nocreate @c true if +nocreate was found
 	 */
 	void parse(bool nocreate);
-
-	/**
-	 * @brief Choose particle from bitmap list
-	 */
-	int chooseBitmap();
 
 	/**
 	 * @brief Creates a particle with the stored values


### PR DESCRIPTION
This PR adds the ability to specify a list of bitmaps for a particle effect to choose from. The selected bitmap will be randomly chosen from the list when the individual particle is created. This feature allows modders to make much more varied particle effects much more efficiently. I've tested this with a variety of single and composite effects with both lists and single filenames and everything works as expected.  

Thanks to m!m for all his help with the implementation and preliminary early review! 