### PR TITLE
Add "resets" burst flag

### DIFF
--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -11183,6 +11183,15 @@ int ship_fire_primary(object * obj, int stream_weapons, int force)
 		// do timestamp stuff for next firing time
 		float next_fire_delay;
 		bool fast_firing = false;
+		// reset the burst if applicable
+		if (winfo_p->burst_flags[Weapon::Burst_Flags::Resets]) {
+			// a bit of an oversimplification but the reset time doesnt have to be super accurate
+			int reset_time = (int)(swp->last_primary_fire_stamp[bank_to_fire] + (winfo_p->fire_wait * 1000.f));
+			if (timestamp_elapsed(reset_time)) {
+				swp->burst_counter[bank_to_fire] = 0;
+			}
+		}
+
 		if (winfo_p->burst_shots > swp->burst_counter[bank_to_fire]) {
 			next_fire_delay = winfo_p->burst_delay * 1000.0f;
 			swp->burst_counter[bank_to_fire]++;

--- a/code/weapon/weapon_flags.h
+++ b/code/weapon/weapon_flags.h
@@ -107,6 +107,7 @@ namespace Weapon {
 	FLAG_LIST(Burst_Flags) {
 		Fast_firing,
 		Random_length,
+		Resets,
 
 		NUM_VALUES
 	};

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -97,7 +97,8 @@ int Num_weapon_subtypes = sizeof(Weapon_subtype_names)/sizeof(Weapon_subtype_nam
 
 flag_def_list_new<Weapon::Burst_Flags> Burst_fire_flags[] = {
 	{ "fast firing",		Weapon::Burst_Flags::Fast_firing,		true, false },
-	{ "random length",		Weapon::Burst_Flags::Random_length,		true, false }
+	{ "random length",		Weapon::Burst_Flags::Random_length,		true, false },
+	{ "resets",		Weapon::Burst_Flags::Resets,		true, false }
 };
 
 const size_t Num_burst_fire_flags = sizeof(Burst_fire_flags)/sizeof(flag_def_list_new<Weapon::Burst_Flags>);


### PR DESCRIPTION
When enabled, let's a burst reset back to 0 if the full fire wait has elapsed, even if it was 'in the middle' of a burst.