### PR TITLE
redo the locking animations for multilock

### DIFF
--- a/code/hud/hudlock.cpp
+++ b/code/hud/hudlock.cpp
@@ -143,6 +143,11 @@ void HudGaugeLock::initLoopLockedAnim(bool loop)
 	loop_locked_anim = loop;
 }
 
+void HudGaugeLock::initBlinkLockedAnim(bool blink)
+{
+	blink_locked_anim = blink;
+}
+
 void HudGaugeLock::initBitmaps(char *lock_gauge_fname, char *lock_anim_fname)
 {
 	hud_anim_init(&Lock_gauge, 0, 0, lock_gauge_fname);
@@ -291,11 +296,6 @@ void HudGaugeLock::render(float frametime)
 		g3_start_frame(0);
 	gr_set_screen_scale(base_w, base_h);
 
-	Lock_gauge.time_elapsed += frametime;
-	if ( Lock_gauge.time_elapsed > Lock_gauge.total_time ) {
-		Lock_gauge.time_elapsed = 0.0f;
-	}
-
 	// go through all present lock indicators
 	for ( i = 0; i < Player_ship->missile_locks.size(); ++i ) {
 		current_lock = &Player_ship->missile_locks[i];
@@ -324,7 +324,7 @@ void HudGaugeLock::render(float frametime)
 			gr_unsize_screen_pos(&sx, &sy);
 
 			// show the rotating triangles if target is locked
-			renderLockTrianglesNew(sx, sy, current_lock->locked_timestamp);
+			renderLockTrianglesNew(sx, sy, frametime, current_lock);
 		} else {
 			const float scaling_factor = (gr_screen.clip_center_x < gr_screen.clip_center_y)
 											 ? (gr_screen.clip_center_x / VIRTUAL_FRAME_HALF_WIDTH)
@@ -337,13 +337,15 @@ void HudGaugeLock::render(float frametime)
 		Lock_gauge.sx = sx - Lock_gauge_half_w;
 		Lock_gauge.sy = sy - Lock_gauge_half_h;
 		if( current_lock->locked ){
-			float saved_time_elapsed = Lock_gauge.time_elapsed;
-			
-			Lock_gauge.time_elapsed = 0.0f;	
 			hud_anim_render(&Lock_gauge, 0.0f, 1);
-
-			Lock_gauge.time_elapsed = saved_time_elapsed;
 		} else {
+			// manually track the animation time, since we may have more than one lock
+			current_lock->lock_gauge_time_elapsed += frametime;
+			if (current_lock->lock_gauge_time_elapsed > Lock_gauge.total_time) {
+				current_lock->lock_gauge_time_elapsed = 0.0f;
+			}
+			Lock_gauge.time_elapsed = current_lock->lock_gauge_time_elapsed;
+
 			hud_anim_render(&Lock_gauge, 0.0f, 1);
 		}
 	}
@@ -1612,7 +1614,7 @@ void hud_do_lock_indicators(float frametime)
 				}
 			}
 
-			lock_slot->locked_timestamp = timestamp();
+			lock_slot->lock_anim_time_elapsed = 0.0f;
 		} else if ( !lock_slot->locked ) {
 			if (Missile_lock_loop.isValid() && snd_is_playing(Missile_lock_loop)) {
 				snd_stop(Missile_lock_loop);
@@ -1699,25 +1701,31 @@ void HudGaugeLock::renderLockTriangles(int center_x, int center_y, float frameti
 				hud_anim_render(&Lock_anim, frametime, 1, 0, 1);
 			}
 		} else {
-			// if the timestamp is unset or expired
-			if((Lock_gauge_draw_stamp < 0) || timestamp_elapsed(Lock_gauge_draw_stamp)){
-				// reset timestamp
-				Lock_gauge_draw_stamp = timestamp(1000 / (2 * LOCK_GAUGE_BLINK_RATE));
+			if(blink_locked_anim) {
+				// if the timestamp is unset or expired
+				if((Lock_gauge_draw_stamp < 0) || timestamp_elapsed(Lock_gauge_draw_stamp)){
+					// reset timestamp
+					Lock_gauge_draw_stamp = timestamp(1000 / (2 * LOCK_GAUGE_BLINK_RATE));
 
-				// switch between draw and don't-draw
-				Lock_gauge_draw = !Lock_gauge_draw;
+					// switch between draw and don't-draw
+					Lock_gauge_draw = !Lock_gauge_draw;
+				}
 			}
 
 			// maybe draw the anim
 			Lock_gauge.time_elapsed = 0.0f;			
-			if(Lock_gauge_draw){
-				hud_anim_render(&Lock_anim, frametime, 1, 0, 1);
+			if(Lock_gauge_draw || !blink_locked_anim){
+				if(loop_locked_anim) {
+					hud_anim_render(&Lock_anim, frametime, 1, 1, 0);
+				} else {
+					hud_anim_render(&Lock_anim, frametime, 1, 0, 1);
+				}
 			}
 		}
 	}
 }
 
-void HudGaugeLock::renderLockTrianglesNew(int center_x, int center_y, int start_timestamp)
+void HudGaugeLock::renderLockTrianglesNew(int center_x, int center_y, float frametime, lock_info *slot)
 {
 	if ( Lock_anim.first_frame == -1 ) {
 		renderLockTrianglesOld(center_x, center_y, Lock_target_box_width/2);
@@ -1726,30 +1734,41 @@ void HudGaugeLock::renderLockTrianglesNew(int center_x, int center_y, int start_
 		Lock_anim.sx = center_x - Lockspin_half_w;
 		Lock_anim.sy = center_y - Lockspin_half_h;
 
-		float time_elapsed = i2fl(timestamp() - start_timestamp)/1000.0f;
-		Lock_anim.time_elapsed = time_elapsed;
-
 		// if it's still animating
-		if(Lock_anim.time_elapsed < Lock_anim.total_time){
+		if(slot->lock_anim_time_elapsed < Lock_anim.total_time){
+			// manually track the animation time, since we may have more than one lock
+			slot->lock_anim_time_elapsed += frametime;
+			Lock_anim.time_elapsed = slot->lock_anim_time_elapsed;
+
 			if(loop_locked_anim) {
 				hud_anim_render(&Lock_anim, 0.0f, 1, 1, 0);
 			} else {
 				hud_anim_render(&Lock_anim, 0.0f, 1, 0, 1);
 			}
 		} else {
-			// if the timestamp is unset or expired
-			if((Lock_gauge_draw_stamp < 0) || timestamp_elapsed(Lock_gauge_draw_stamp)){
-				// reset timestamp
-				Lock_gauge_draw_stamp = timestamp(1000 / (2 * LOCK_GAUGE_BLINK_RATE));
+			if(blink_locked_anim) {
+				// if the timestamp is unset or expired
+				if((Lock_gauge_draw_stamp < 0) || timestamp_elapsed(Lock_gauge_draw_stamp)){
+					// reset timestamp
+					Lock_gauge_draw_stamp = timestamp(1000 / (2 * LOCK_GAUGE_BLINK_RATE));
 
-				// switch between draw and don't-draw
-				Lock_gauge_draw = !Lock_gauge_draw;
+					// switch between draw and don't-draw
+					Lock_gauge_draw = !Lock_gauge_draw;
+				}
 			}
 
 			// maybe draw the anim
-			Lock_gauge.time_elapsed = 0.0f;			
-			if(Lock_gauge_draw){
-				hud_anim_render(&Lock_anim, 0.0f, 1, 0, 1);
+			slot->lock_gauge_time_elapsed = 0.0f;			
+			if(Lock_gauge_draw || !blink_locked_anim){
+				// manually track the animation time, since we may have more than one lock
+				slot->lock_anim_time_elapsed += frametime;
+				Lock_anim.time_elapsed = slot->lock_anim_time_elapsed;
+
+				if(loop_locked_anim) {
+					hud_anim_render(&Lock_anim, 0.0f, 1, 1, 0);
+				} else {
+					hud_anim_render(&Lock_anim, 0.0f, 1, 0, 1);
+				}
 			}
 		}
 	}

--- a/code/hud/hudlock.h
+++ b/code/hud/hudlock.h
@@ -14,6 +14,8 @@
 
 #include "hud/hud.h"
 
+struct lock_info;
+
 void hud_init_missile_lock();
 void hud_calculate_lock_position(float frametime);
 void hud_calculate_lock_start_pos();
@@ -29,6 +31,7 @@ protected:
 	hud_anim Lock_anim;
 
 	bool loop_locked_anim;
+	bool blink_locked_anim;
 
 	int Lock_gauge_half_w;
 	int Lock_gauge_half_h;
@@ -53,11 +56,12 @@ public:
 	void initTriBase(float length);
 	void initTargetBoxSize(int w, int h);
 	void initLoopLockedAnim(bool loop);
+	void initBlinkLockedAnim(bool blink);
 
 	void render(float frametime) override;
 	void renderOld(float frametime);
 	void renderLockTriangles(int center_x, int center_y, float frametime);
-	void renderLockTrianglesNew(int center_x, int center_y, int start_timestamp);
+	void renderLockTrianglesNew(int center_x, int center_y, float frametime, lock_info *slot);
 	void renderLockTrianglesOld(int center_x, int center_y, int radius);
 	void pageIn() override;
 	void initialize() override;

--- a/code/hud/hudparse.cpp
+++ b/code/hud/hudparse.cpp
@@ -4427,6 +4427,7 @@ void load_gauge_lock(gauge_settings* settings)
 	int Lock_target_box_width;
 	int Lock_target_box_height;
 	bool loop_locked_anim;
+	bool blink_locked_anim;
 	char fname_lock[MAX_FILENAME_LEN];
 	char fname_spin[MAX_FILENAME_LEN];
 
@@ -4444,6 +4445,7 @@ void load_gauge_lock(gauge_settings* settings)
 			Lock_target_box_width = 19;
 			Lock_target_box_height = 30;
 			loop_locked_anim = true;
+			blink_locked_anim = false;
 
 			strcpy_s(fname_lock, "lock1_fs1");
 			strcpy_s(fname_spin, "lockspin_fs1");
@@ -4457,6 +4459,7 @@ void load_gauge_lock(gauge_settings* settings)
 			Lock_target_box_width = 19;
 			Lock_target_box_height = 30;
 			loop_locked_anim = true;
+			blink_locked_anim = false;
 
 			strcpy_s(fname_lock, "2_lock1_fs1");
 			strcpy_s(fname_spin, "2_lockspin_fs1");
@@ -4472,6 +4475,7 @@ void load_gauge_lock(gauge_settings* settings)
 			Lock_target_box_width = 19;
 			Lock_target_box_height = 30;
 			loop_locked_anim = false;
+			blink_locked_anim = true;
 
 			strcpy_s(fname_lock, "lock1");
 			strcpy_s(fname_spin, "lockspin");
@@ -4485,6 +4489,7 @@ void load_gauge_lock(gauge_settings* settings)
 			Lock_target_box_width = 19;
 			Lock_target_box_height = 30;
 			loop_locked_anim = false;
+			blink_locked_anim = true;
 
 			strcpy_s(fname_lock, "2_lock1");
 			strcpy_s(fname_spin, "2_lockspin");
@@ -4518,6 +4523,7 @@ void load_gauge_lock(gauge_settings* settings)
 
 	hud_gauge->initBitmaps(fname_lock, fname_spin);
 	hud_gauge->initLoopLockedAnim(loop_locked_anim);
+	hud_gauge->initBlinkLockedAnim(blink_locked_anim);
 	hud_gauge->initGaugeHalfSize(Lock_gauge_half_w, Lock_gauge_half_h);
 	hud_gauge->initSpinHalfSize(Lockspin_half_w, Lockspin_half_h);
 	hud_gauge->initTriHeight(Lock_triangle_height);

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -19581,7 +19581,8 @@ void ship_clear_lock(lock_info *slot) {
 
 	slot->last_dist_to_target = 0.0f;
 
-	slot->locked_timestamp = 0;
+	slot->lock_anim_time_elapsed = 0.0f;
+	slot->lock_gauge_time_elapsed = 0.0f;
 
 	slot->maintain_lock_count = 0;
 

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -310,7 +310,8 @@ typedef struct lock_info {
 	bool need_new_start_pos;
 	bool target_in_lock_cone;
 
-	int locked_timestamp;
+	float lock_gauge_time_elapsed;
+	float lock_anim_time_elapsed;
 } lock_info;
 
 // structure definition for a linked list of subsystems for a ship.  Each subsystem has a pointer


### PR DESCRIPTION
The multilock patch did not handle `Lock_anim` in the best way, and handled `Lock_gauge` in a very bizarre way, despite the fact that they are two simple hud animations.  This changes the `lock_info` struct to track the correct `time_elapsed` value for both, and changes the locking code to use the values in the correct way.

Additionally, this properly loops the lock triangles on the FS1 lock indicator.  Strangely, even prior to the multilock merge it appears that the triangles wouldn't have animated more than a quarter turn.

Finally, this prevents the FS1 lock indicator from blinking, since in retail FS1 it didn't blink.

Tested with FSPort and no-mods.  Fixes #2826.