### PR TITLE
Fix some issues with warp collision

### DIFF
--- a/code/asteroid/asteroid.cpp
+++ b/code/asteroid/asteroid.cpp
@@ -1149,7 +1149,7 @@ int asteroid_check_collision(object *pasteroid, object *other_obj, vec3d *hitpos
 		vec3d actual_world_hit_pos = mc.hit_point_world + heavy_obj->pos;
 		if ((shipp->is_arriving()) && (shipp->warpin_effect))
 			warp_effect = shipp->warpin_effect;
-		else if ((shipp->flags[Ship::Ship_Flags::Depart_warp]))
+		else if ((shipp->flags[Ship::Ship_Flags::Depart_warp]) && (shipp->warpout_effect))
 			warp_effect = shipp->warpout_effect;
 
 		if (warp_effect != nullptr && point_is_clipped_by_warp(&actual_world_hit_pos, warp_effect))

--- a/code/asteroid/asteroid.cpp
+++ b/code/asteroid/asteroid.cpp
@@ -1147,9 +1147,9 @@ int asteroid_check_collision(object *pasteroid, object *other_obj, vec3d *hitpos
 		// this is extremely confusing but mc.hit_point_world isn't actually in world coords
 		// everything above was calculated relative to the heavy's position
 		vec3d actual_world_hit_pos = mc.hit_point_world + heavy_obj->pos;
-		if ((shipp->is_arriving()) && (shipp->warpin_effect))
+		if ((shipp->is_arriving()) && (shipp->warpin_effect != nullptr))
 			warp_effect = shipp->warpin_effect;
-		else if ((shipp->flags[Ship::Ship_Flags::Depart_warp]) && (shipp->warpout_effect))
+		else if ((shipp->flags[Ship::Ship_Flags::Depart_warp]) && (shipp->warpout_effect != nullptr))
 			warp_effect = shipp->warpout_effect;
 
 		if (warp_effect != nullptr && point_is_clipped_by_warp(&actual_world_hit_pos, warp_effect))

--- a/code/debris/debris.cpp
+++ b/code/debris/debris.cpp
@@ -990,6 +990,22 @@ int debris_check_collision(object *pdebris, object *other_obj, vec3d *hitpos, co
 		}
 	}
 
+	if (mc_ret_val) {
+		WarpEffect* warp_effect = nullptr;
+		ship* shipp = &Ships[pship_obj->instance];
+
+		// this is extremely confusing but mc.hit_point_world isn't actually in world coords
+		// everything above was calculated relative to the heavy's position
+		vec3d actual_world_hit_pos = mc.hit_point_world + heavy_obj->pos;
+		if ((shipp->is_arriving()) && (shipp->warpin_effect))
+			warp_effect = shipp->warpin_effect;
+		else if ((shipp->flags[Ship::Ship_Flags::Depart_warp]))
+			warp_effect = shipp->warpout_effect;
+
+		if (warp_effect != nullptr && point_is_clipped_by_warp(&actual_world_hit_pos, warp_effect))
+			mc_ret_val = 0;
+	}
+
 
 	if ( mc_ret_val )	{
 

--- a/code/debris/debris.cpp
+++ b/code/debris/debris.cpp
@@ -999,7 +999,7 @@ int debris_check_collision(object *pdebris, object *other_obj, vec3d *hitpos, co
 		vec3d actual_world_hit_pos = mc.hit_point_world + heavy_obj->pos;
 		if ((shipp->is_arriving()) && (shipp->warpin_effect))
 			warp_effect = shipp->warpin_effect;
-		else if ((shipp->flags[Ship::Ship_Flags::Depart_warp]))
+		else if ((shipp->flags[Ship::Ship_Flags::Depart_warp]) && (shipp->warpout_effect))
 			warp_effect = shipp->warpout_effect;
 
 		if (warp_effect != nullptr && point_is_clipped_by_warp(&actual_world_hit_pos, warp_effect))

--- a/code/debris/debris.cpp
+++ b/code/debris/debris.cpp
@@ -997,9 +997,9 @@ int debris_check_collision(object *pdebris, object *other_obj, vec3d *hitpos, co
 		// this is extremely confusing but mc.hit_point_world isn't actually in world coords
 		// everything above was calculated relative to the heavy's position
 		vec3d actual_world_hit_pos = mc.hit_point_world + heavy_obj->pos;
-		if ((shipp->is_arriving()) && (shipp->warpin_effect))
+		if ((shipp->is_arriving()) && (shipp->warpin_effect != nullptr))
 			warp_effect = shipp->warpin_effect;
-		else if ((shipp->flags[Ship::Ship_Flags::Depart_warp]) && (shipp->warpout_effect))
+		else if ((shipp->flags[Ship::Ship_Flags::Depart_warp]) && (shipp->warpout_effect != nullptr))
 			warp_effect = shipp->warpout_effect;
 
 		if (warp_effect != nullptr && point_is_clipped_by_warp(&actual_world_hit_pos, warp_effect))

--- a/code/model/modelrender.cpp
+++ b/code/model/modelrender.cpp
@@ -1667,31 +1667,16 @@ void model_render_glowpoint(int point_num, vec3d *pos, matrix *orient, glow_poin
 	vm_vec_unrotate(&world_norm, &loc_norm, orient);
 
 	if ( shipp != NULL ) {
-		if ( (shipp->is_arriving() ) && (shipp->warpin_effect) && Warp_params[shipp->warpin_params_index].warp_type != WT_HYPERSPACE) {
-			vec3d warp_pnt, tmp;
-			matrix warp_orient;
+		// don't render if its on the wrong side of the portal
+		WarpEffect* warp_effect = nullptr;
 
-			shipp->warpin_effect->getWarpPosition(&warp_pnt);
-			shipp->warpin_effect->getWarpOrientation(&warp_orient);
-			vm_vec_sub( &tmp, &world_pnt, &warp_pnt );
+		if ((shipp->is_arriving()) && (shipp->warpin_effect) && Warp_params[shipp->warpin_params_index].warp_type != WT_HYPERSPACE)
+			warp_effect = shipp->warpin_effect;
+		else if ((shipp->flags[Ship::Ship_Flags::Depart_warp]) && (shipp->warpout_effect) && Warp_params[shipp->warpout_params_index].warp_type != WT_HYPERSPACE)
+			warp_effect = shipp->warpout_effect;
 
-			if ( vm_vec_dot( &tmp, &warp_orient.vec.fvec ) < 0.0f ) {
-				return;
-			}
-		}
-
-		if ( (shipp->flags[Ship::Ship_Flags::Depart_warp] ) && (shipp->warpout_effect) && Warp_params[shipp->warpout_params_index].warp_type != WT_HYPERSPACE) {
-			vec3d warp_pnt, tmp;
-			matrix warp_orient;
-
-			shipp->warpout_effect->getWarpPosition(&warp_pnt);
-			shipp->warpout_effect->getWarpOrientation(&warp_orient);
-			vm_vec_sub( &tmp, &world_pnt, &warp_pnt );
-
-			if ( vm_vec_dot( &tmp, &warp_orient.vec.fvec ) > 0.0f ) {
-				return;
-			}
-		}
+		if (warp_effect != nullptr && point_is_clipped_by_warp(&world_pnt, warp_effect))
+			return;
 	}
 
 	switch ((gpo && gpo->type_override)?gpo->type:bank->type)
@@ -2114,31 +2099,15 @@ void model_queue_render_thrusters(model_render_params *interp, polymodel *pm, in
 
 			if (shipp) {
 				// if ship is warping out, check position of the engine glow to the warp plane
-				if ( (shipp->is_arriving() ) && (shipp->warpin_effect) && Warp_params[shipp->warpin_params_index].warp_type != WT_HYPERSPACE) {
-					vec3d warp_pnt, tmp;
-					matrix warp_orient;
+				WarpEffect* warp_effect = nullptr;
 
-					shipp->warpin_effect->getWarpPosition(&warp_pnt);
-					shipp->warpin_effect->getWarpOrientation(&warp_orient);
-					vm_vec_sub( &tmp, &world_pnt, &warp_pnt );
+				if ((shipp->is_arriving()) && (shipp->warpin_effect) && Warp_params[shipp->warpin_params_index].warp_type != WT_HYPERSPACE)
+					warp_effect = shipp->warpin_effect;
+				else if ((shipp->flags[Ship::Ship_Flags::Depart_warp]) && (shipp->warpout_effect) && Warp_params[shipp->warpout_params_index].warp_type != WT_HYPERSPACE)
+					warp_effect = shipp->warpout_effect;
 
-					if ( vm_vec_dot( &tmp, &warp_orient.vec.fvec ) < 0.0f ) {
-						break;
-					}
-				}
-
-				if ( (shipp->flags[Ship::Ship_Flags::Depart_warp] ) && (shipp->warpout_effect) && Warp_params[shipp->warpout_params_index].warp_type != WT_HYPERSPACE) {
-					vec3d warp_pnt, tmp;
-					matrix warp_orient;
-
-					shipp->warpout_effect->getWarpPosition(&warp_pnt);
-					shipp->warpout_effect->getWarpOrientation(&warp_orient);
-					vm_vec_sub( &tmp, &world_pnt, &warp_pnt );
-
-					if ( vm_vec_dot( &tmp, &warp_orient.vec.fvec ) > 0.0f ) {
-						break;
-					}
-				}
+				if (warp_effect != nullptr && point_is_clipped_by_warp(&world_pnt, warp_effect))
+					continue;
 			}
 
 			vm_vec_sub(&tempv, &View_position, &world_pnt);

--- a/code/model/modelrender.cpp
+++ b/code/model/modelrender.cpp
@@ -1666,14 +1666,18 @@ void model_render_glowpoint(int point_num, vec3d *pos, matrix *orient, glow_poin
 
 	vm_vec_unrotate(&world_norm, &loc_norm, orient);
 
-	if ( shipp != NULL ) {
+	if (shipp != NULL) {
 		// don't render if its on the wrong side of the portal
 		WarpEffect* warp_effect = nullptr;
 
-		if ((shipp->is_arriving()) && (shipp->warpin_effect) && Warp_params[shipp->warpin_params_index].warp_type != WT_HYPERSPACE)
+		if ((shipp->is_arriving()) && (shipp->warpin_effect != nullptr)
+			&& Warp_params[shipp->warpin_params_index].warp_type != WT_HYPERSPACE) {
 			warp_effect = shipp->warpin_effect;
-		else if ((shipp->flags[Ship::Ship_Flags::Depart_warp]) && (shipp->warpout_effect) && Warp_params[shipp->warpout_params_index].warp_type != WT_HYPERSPACE)
+		}
+		else if ((shipp->flags[Ship::Ship_Flags::Depart_warp]) && (shipp->warpout_effect != nullptr) 
+			&& Warp_params[shipp->warpout_params_index].warp_type != WT_HYPERSPACE) {
 			warp_effect = shipp->warpout_effect;
+		}
 
 		if (warp_effect != nullptr && point_is_clipped_by_warp(&world_pnt, warp_effect))
 			return;
@@ -2101,10 +2105,14 @@ void model_queue_render_thrusters(model_render_params *interp, polymodel *pm, in
 				// if ship is warping out, check position of the engine glow to the warp plane
 				WarpEffect* warp_effect = nullptr;
 
-				if ((shipp->is_arriving()) && (shipp->warpin_effect) && Warp_params[shipp->warpin_params_index].warp_type != WT_HYPERSPACE)
+				if ((shipp->is_arriving()) && (shipp->warpin_effect != nullptr)
+					&& Warp_params[shipp->warpin_params_index].warp_type != WT_HYPERSPACE) {
 					warp_effect = shipp->warpin_effect;
-				else if ((shipp->flags[Ship::Ship_Flags::Depart_warp]) && (shipp->warpout_effect) && Warp_params[shipp->warpout_params_index].warp_type != WT_HYPERSPACE)
+				}
+				else if ((shipp->flags[Ship::Ship_Flags::Depart_warp]) && (shipp->warpout_effect != nullptr)
+					&& Warp_params[shipp->warpout_params_index].warp_type != WT_HYPERSPACE) {
 					warp_effect = shipp->warpout_effect;
+				}
 
 				if (warp_effect != nullptr && point_is_clipped_by_warp(&world_pnt, warp_effect))
 					continue;

--- a/code/model/modelrender.cpp
+++ b/code/model/modelrender.cpp
@@ -1666,7 +1666,7 @@ void model_render_glowpoint(int point_num, vec3d *pos, matrix *orient, glow_poin
 
 	vm_vec_unrotate(&world_norm, &loc_norm, orient);
 
-	if (shipp != NULL) {
+	if (shipp != nullptr) {
 		// don't render if its on the wrong side of the portal
 		WarpEffect* warp_effect = nullptr;
 

--- a/code/object/collideshipship.cpp
+++ b/code/object/collideshipship.cpp
@@ -354,32 +354,32 @@ int ship_ship_check_collision(collision_info_struct *ship_ship_hit_info, vec3d *
 	// check if the hit point is beyond the clip plane if one of the ships is warping in or out.
 	if (valid_hit_occured) {
 		WarpEffect* warp_effect = nullptr;
-		bool hv_warp, li_warp;
-		hv_warp = li_warp = false;
 
 		// this is extremely confusing but mc.hit_point_world isn't actually in world coords
 		// everything above was calculated relative to the heavy's position
 		vec3d actual_world_hit_pos = mc.hit_point_world + heavy_obj->pos;
 
-		if (heavy_shipp->flags[Ship::Ship_Flags::Depart_warp] && heavy_shipp->warpout_effect)
+		if (heavy_shipp->flags[Ship::Ship_Flags::Depart_warp] && heavy_shipp->warpout_effect != nullptr)
 			warp_effect = heavy_shipp->warpout_effect;
-		else if (heavy_shipp->flags[Ship::Ship_Flags::Arriving_stage_2] && heavy_shipp->warpin_effect)
-			warp_effect = heavy_shipp->warpout_effect;
+		else if (heavy_shipp->flags[Ship::Ship_Flags::Arriving_stage_2] && heavy_shipp->warpin_effect != nullptr)
+			warp_effect = heavy_shipp->warpin_effect;
 
+		bool heavy_warp_no_collide = false;
 		if (warp_effect != nullptr)
-			hv_warp = point_is_clipped_by_warp(&actual_world_hit_pos, warp_effect);
+			heavy_warp_no_collide = point_is_clipped_by_warp(&actual_world_hit_pos, warp_effect);
 
 		warp_effect = nullptr;
-		if (light_shipp->flags[Ship::Ship_Flags::Depart_warp] && light_shipp->warpout_effect)
+		if (light_shipp->flags[Ship::Ship_Flags::Depart_warp] && light_shipp->warpout_effect != nullptr)
 			warp_effect = light_shipp->warpout_effect;
-		else if (light_shipp->flags[Ship::Ship_Flags::Arriving_stage_2] && light_shipp->warpin_effect)
-			warp_effect = light_shipp->warpout_effect;
+		else if (light_shipp->flags[Ship::Ship_Flags::Arriving_stage_2] && light_shipp->warpin_effect != nullptr)
+			warp_effect = light_shipp->warpin_effect;
 
+		bool light_warp_no_collide = false;
 		if (warp_effect != nullptr)
-			li_warp = point_is_clipped_by_warp(&actual_world_hit_pos, warp_effect);
+			light_warp_no_collide = point_is_clipped_by_warp(&actual_world_hit_pos, warp_effect);
 
 		
-		if (hv_warp || li_warp)
+		if (heavy_warp_no_collide || light_warp_no_collide)
 			valid_hit_occured = 0;
 	}
 

--- a/code/object/collideshipship.cpp
+++ b/code/object/collideshipship.cpp
@@ -1363,8 +1363,8 @@ int collide_ship_ship( obj_pair * pair )
         // if ship is warping in, in stage 1, its velocity is 0, so make ship try to collide next frame
 
         // if ship is huge and warping in or out
-        if (((Ships[A->instance].is_arriving(ship::warpstage::STAGE1, false)) && (Ship_info[Ships[A->instance].ship_info_index].is_huge_ship()))
-			|| ((Ships[B->instance].is_arriving(ship::warpstage::STAGE1, false)) && (Ship_info[Ships[B->instance].ship_info_index].is_huge_ship())) ) {
+        if (((Ships[A->instance].is_arriving(ship::warpstage::STAGE1, false)) && (Ship_info[Ships[A->instance].ship_info_index].is_big_or_huge()))
+			|| ((Ships[B->instance].is_arriving(ship::warpstage::STAGE1, false)) && (Ship_info[Ships[B->instance].ship_info_index].is_big_or_huge())) ) {
 			pair->next_check_time = timestamp(0);	// check next time
 			return 0;
 		}

--- a/code/object/collideshipweapon.cpp
+++ b/code/object/collideshipweapon.cpp
@@ -358,7 +358,7 @@ static int ship_weapon_check_collision(object *ship_objp, object *weapon_objp, f
 	if (hull_collision || shield_collision) {
 		WarpEffect* warp_effect = nullptr;
 
-		if (shipp->flags[Ship::Ship_Flags::Depart_warp] && shipp->warpout_effect != nullptr)
+		if (shipp->flags[Ship::Ship_Flags::Depart_warp] && shipp->warpout_effect != nullptr) 
 			warp_effect = shipp->warpout_effect;
 		else if (shipp->flags[Ship::Ship_Flags::Arriving_stage_2] && shipp->warpin_effect != nullptr)
 			warp_effect = shipp->warpin_effect;

--- a/code/object/collideshipweapon.cpp
+++ b/code/object/collideshipweapon.cpp
@@ -357,14 +357,14 @@ static int ship_weapon_check_collision(object *ship_objp, object *weapon_objp, f
 	// check if the hit point is beyond the clip plane when warping out.
 	if (hull_collision || shield_collision) {
 		WarpEffect* warp_effect = nullptr;
+
+		if (shipp->flags[Ship::Ship_Flags::Depart_warp] && shipp->warpout_effect != nullptr)
+			warp_effect = shipp->warpout_effect;
+		else if (shipp->flags[Ship::Ship_Flags::Arriving_stage_2] && shipp->warpin_effect != nullptr)
+			warp_effect = shipp->warpin_effect;
+
 		bool hull_no_collide, shield_no_collide;
 		hull_no_collide = shield_no_collide = false;
-
-		if (shipp->flags[Ship::Ship_Flags::Depart_warp] && shipp->warpout_effect)
-			warp_effect = shipp->warpout_effect;
-		else if (shipp->flags[Ship::Ship_Flags::Arriving_stage_2] && shipp->warpin_effect)
-			warp_effect = shipp->warpout_effect;
-
 		if (warp_effect != nullptr) {
 			hull_no_collide = point_is_clipped_by_warp(&mc_hull.hit_point_world, warp_effect);
 			shield_no_collide = point_is_clipped_by_warp(&mc_shield.hit_point_world, warp_effect);

--- a/code/object/collideshipweapon.cpp
+++ b/code/object/collideshipweapon.cpp
@@ -354,13 +354,37 @@ static int ship_weapon_check_collision(object *ship_objp, object *weapon_objp, f
 		hull_collision = model_collide(&mc_hull);
 	}
 
+	// check if the hit point is beyond the clip plane when warping out.
+	if (hull_collision || shield_collision) {
+		WarpEffect* warp_effect = nullptr;
+		bool hull_no_collide, shield_no_collide;
+		hull_no_collide = shield_no_collide = false;
+
+		if (shipp->flags[Ship::Ship_Flags::Depart_warp] && shipp->warpout_effect)
+			warp_effect = shipp->warpout_effect;
+		else if (shipp->flags[Ship::Ship_Flags::Arriving_stage_2] && shipp->warpin_effect)
+			warp_effect = shipp->warpout_effect;
+
+		if (warp_effect != nullptr) {
+			hull_no_collide = point_is_clipped_by_warp(&mc_hull.hit_point_world, warp_effect);
+			shield_no_collide = point_is_clipped_by_warp(&mc_shield.hit_point_world, warp_effect);
+		}
+
+		if (hull_no_collide)
+			hull_collision = 0;
+		if (shield_no_collide)
+			shield_collision = 0;
+	}
+
 	if (shield_collision) {
 		// pick out the shield quadrant
 		quadrant_num = get_quadrant(&mc_shield.hit_point, ship_objp);
 
 		// make sure that the shield is active in that quadrant
-		if (shipp->flags[Ship::Ship_Flags::Dying] || !ship_is_shield_up(ship_objp, quadrant_num))
+		if (shipp->flags[Ship::Ship_Flags::Dying] || !ship_is_shield_up(ship_objp, quadrant_num)) {
 			quadrant_num = -1;
+			shield_collision = 0;
+		}
 
 		// see if we hit the shield
 		if (quadrant_num >= 0) {
@@ -371,43 +395,25 @@ static int ship_weapon_check_collision(object *ship_objp, object *weapon_objp, f
 
 			// if this weapon pierces the shield, then do the hit effect, but act like a shield collision never occurred;
 			// otherwise, we have a valid hit on this shield
-			if (wip->wi_flags[Weapon::Info_Flags::Pierce_shields])
+			if (wip->wi_flags[Weapon::Info_Flags::Pierce_shields]) {
 				quadrant_num = -1;
-			else
-				valid_hit_occurred = 1;
+				shield_collision = 0;
+			}
 		}
 	}
 
 	// see which impact we use
-	if (shield_collision && valid_hit_occurred)
+	if (shield_collision)
 	{
 		memcpy(&mc, &mc_shield, sizeof(mc_info));
 		Assert(quadrant_num >= 0);
+		valid_hit_occurred = 1;
 	}
 	else if (hull_collision)
 	{
 		memcpy(&mc, &mc_hull, sizeof(mc_info));
 		valid_hit_occurred = 1;
 	}
-
-    // check if the hit point is beyond the clip plane when warping out.
-    if ((shipp->flags[Ship::Ship_Flags::Depart_warp]) &&
-        (shipp->warpout_effect) &&
-        (valid_hit_occurred))
-    {
-        vec3d warp_pnt, hit_direction;
-        matrix warp_orient;
-
-        shipp->warpout_effect->getWarpPosition(&warp_pnt);
-        shipp->warpout_effect->getWarpOrientation(&warp_orient);
-
-        vm_vec_sub(&hit_direction, &mc.hit_point_world, &warp_pnt);
-
-        if (vm_vec_dot(&hit_direction, &warp_orient.vec.fvec) < 0.0f)
-        {
-             valid_hit_occurred = 0;
-        }
-    }
 
 	// deal with predictive collisions.  Find their actual hit time and see if they occured in current frame
 	if (next_hit && valid_hit_occurred) {

--- a/code/ship/shipfx.cpp
+++ b/code/ship/shipfx.cpp
@@ -3178,10 +3178,7 @@ bool point_is_clipped_by_warp(const vec3d* point, WarpEffect* warp_effect) {
 	warp_effect->getWarpOrientation(&warp_orient);
 
 	vm_vec_sub(&relative_direction, point, &warp_pnt);
-	if (vm_vec_dot(&relative_direction, &warp_orient.vec.fvec) < 0.0f)
-		return true;
-	else
-		return false;
+	return vm_vec_dot(&relative_direction, &warp_orient.vec.fvec) < 0.0f;
 }
 
 

--- a/code/ship/shipfx.cpp
+++ b/code/ship/shipfx.cpp
@@ -3598,11 +3598,11 @@ int WE_Default::getWarpOrientation(matrix* output)
 		return 0;
 
 	if (this->direction == WarpDirection::WARP_IN)
-		vm_vector_2_matrix(output, &objp->orient.vec.fvec, NULL, NULL);
+		vm_vector_2_matrix(output, &objp->orient.vec.fvec, nullptr, nullptr);
 	else {
 		vec3d backwards = objp->orient.vec.fvec;
 		vm_vec_negate(&backwards);
-		vm_vector_2_matrix(output, &backwards, NULL, NULL);
+		vm_vector_2_matrix(output, &backwards, nullptr, nullptr);
 	}
     return 1;
 }
@@ -4210,7 +4210,7 @@ int WE_Homeworld::getWarpOrientation(matrix* output)
 	else {
 		vec3d backwards = objp->orient.vec.fvec;
 		vm_vec_negate(&backwards);
-		vm_vector_2_matrix(output, &backwards, &objp->orient.vec.uvec, NULL);
+		vm_vector_2_matrix(output, &backwards, &objp->orient.vec.uvec, nullptr);
 	}
 
     return 1;

--- a/code/ship/shipfx.h
+++ b/code/ship/shipfx.h
@@ -218,6 +218,8 @@ public:
     virtual int getWarpOrientation(matrix *output);
 };
 
+bool point_is_clipped_by_warp(const vec3d* point, WarpEffect* warp_effect);
+
 //********************-----CLASS: WE_Default-----********************//
 #define WE_DEFAULT_NUM_STAGES			2
 class WE_Default : public WarpEffect

--- a/code/weapon/beam.cpp
+++ b/code/weapon/beam.cpp
@@ -2556,14 +2556,15 @@ int beam_collide_ship(obj_pair *pair)
 	
 	if (hull_enter_collision || hull_exit_collision || shield_collision) {
 		WarpEffect* warp_effect = nullptr;
+
+		if (shipp->flags[Ship::Ship_Flags::Depart_warp] && shipp->warpout_effect != nullptr)
+			warp_effect = shipp->warpout_effect;
+		else if (shipp->flags[Ship::Ship_Flags::Arriving_stage_2] && shipp->warpin_effect != nullptr)
+			warp_effect = shipp->warpin_effect;
+
+
 		bool hull_no_collide, shield_no_collide;
 		hull_no_collide = shield_no_collide = false;
-
-		if (shipp->flags[Ship::Ship_Flags::Depart_warp] && shipp->warpout_effect)
-			warp_effect = shipp->warpout_effect;
-		else if (shipp->flags[Ship::Ship_Flags::Arriving_stage_2] && shipp->warpin_effect)
-			warp_effect = shipp->warpout_effect;
-
 		if (warp_effect != nullptr) {
 			hull_no_collide = point_is_clipped_by_warp(&mc_hull_enter.hit_point_world, warp_effect);
 			shield_no_collide = point_is_clipped_by_warp(&mc_shield.hit_point_world, warp_effect);

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -4364,11 +4364,11 @@ int game_poll()
 			game_start_time();
 
 			// If we're in a single player game, pause it.
-			if (!(Game_mode & GM_MULTIPLAYER)){
-				if ((gameseq_get_state() == GS_STATE_GAME_PLAY) && (!popup_active()) && (!popupdead_is_active()))	{
-					game_process_pause_key();
-				}
-			}
+			//if (!(Game_mode & GM_MULTIPLAYER)){
+			//	if ((gameseq_get_state() == GS_STATE_GAME_PLAY) && (!popup_active()) && (!popupdead_is_active()))	{
+			//		game_process_pause_key();
+			//	}
+			//}
 		}
 	}
 

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -4364,11 +4364,11 @@ int game_poll()
 			game_start_time();
 
 			// If we're in a single player game, pause it.
-			//if (!(Game_mode & GM_MULTIPLAYER)){
-			//	if ((gameseq_get_state() == GS_STATE_GAME_PLAY) && (!popup_active()) && (!popupdead_is_active()))	{
-			//		game_process_pause_key();
-			//	}
-			//}
+			if (!(Game_mode & GM_MULTIPLAYER)){
+				if ((gameseq_get_state() == GS_STATE_GAME_PLAY) && (!popup_active()) && (!popupdead_is_active()))	{
+					game_process_pause_key();
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
There was a lot of duplication with checks against the warp clip plane depending on if the ship was arriving or departing so I've modified the default and homeworld `getWarpOrientation` to invert when warping out as one might expect (those two are the only ones that need their orientation like this) (`getWarpOrientation` is only used for this purpose; culling stuff on the other side) and made a function to deal with handling what side a point is on, so all the cases can be handled consistently.

There were some sign errors and ordering issues with ship-weapon collisions that were fixed, and checks against the warp plane were added for several types of collisions.

This *only prevents* where otherwise it *would* have collided, if it *would not* have collided before, it will *still not* now. I figured this was the safer option, even as unlikely as this is to actually break anything. 

Closes #2359

EDIT: Also, collision detection tries not to bother too often so it calculates when the next time two ships could collide based on their speed and distance. Huge ships get a special exemption during warping since they can go way faster than normal during this time, but big ships should be added to the check as well, sine they can too.