### PR TITLE
Update terms of Licensing

### DIFF
--- a/Copying.md
+++ b/Copying.md
@@ -12,4 +12,11 @@ Modifications by members of the FreeSpace Source Code Project are
 released under whatever terms the individual authors choose, but the
 above notice continues to apply to all fs2_open code.
 
+All modifications made on or after November 1, 2020, shall be released under 
+the terms within [Unlicense](Unlicense.md). Modifications made before said date are released 
+under the previous terms with the exception of modifications made by members 
+of the FreeSpace Source Code Project that opt-in to the terms of Unlicense. Additionally, 
+a list of contributors who have opted in to the Unlicense terms can be found 
+in [**Licensing**](https://github.com/scp-fs2open/fs2open.github.com/wiki/Licensing).
+
 See [**Licensing**](https://github.com/scp-fs2open/fs2open.github.com/wiki/Licensing) for more information.

--- a/Unlicense.md
+++ b/Unlicense.md
@@ -1,0 +1,24 @@
+This is free and unencumbered software released into the public domain.
+
+Anyone is free to copy, modify, publish, use, compile, sell, or
+distribute this software, either in source code form or as a compiled
+binary, for any purpose, commercial or non-commercial, and by any
+means.
+
+In jurisdictions that recognize copyright laws, the author or authors
+of this software dedicate any and all copyright interest in the
+software to the public domain. We make this dedication for the benefit
+of the public at large and to the detriment of our heirs and
+successors. We intend this dedication to be an overt act of
+relinquishment in perpetuity of all present and future rights to this
+software under copyright law.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+For more information, please refer to [**Unlicense**](https://unlicense.org).


### PR DESCRIPTION
Here is the currently proposed updated terms of licensing for FSO. 

Alongside this change, a list of members that have opted into the new terms under Unlicense will be maintained at [**Licensing**](https://github.com/scp-fs2open/fs2open.github.com/wiki/Licensing).