### PR TITLE
Add '$Collision Radius Override' to weapons

### DIFF
--- a/code/weapon/weapon.h
+++ b/code/weapon/weapon.h
@@ -285,6 +285,7 @@ struct weapon_info
 	color	laser_color_1;						// for cycling between glow colors
 	color	laser_color_2;						// for cycling between glow colors
 	float	laser_head_radius, laser_tail_radius;
+	float	collision_radius_override;          // overrides the radius for the purposes of collision
 
 	float	max_speed;							// max speed of the weapon
 	float	acceleration_time;					// how many seconds to reach max speed (secondaries only)

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -1110,6 +1110,10 @@ int parse_weapon(int subtype, bool replace, const char *filename)
 		stuff_float(&wip->laser_tail_radius );
 	}
 
+	if (optional_string("$Collision Radius Override:")) {
+		stuff_float(&wip->collision_radius_override);
+	}
+
 	if(optional_string("$Mass:")) {
 		stuff_float( &(wip->mass) );
 
@@ -5635,7 +5639,9 @@ int weapon_create( vec3d * pos, matrix * porient, int weapon_type, int parent_ob
 		objp->hull_strength = 0.0f;
 	}
 
-	if ( wip->render_type == WRT_POF ) {
+	if (wip->collision_radius_override > 0.f)
+		objp->radius = wip->collision_radius_override;
+	else if ( wip->render_type == WRT_POF ) {
 		// this should have been checked above, but let's be extra sure
 		Assert(wip->model_num >= 0);
 

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -5639,7 +5639,7 @@ int weapon_create( vec3d * pos, matrix * porient, int weapon_type, int parent_ob
 		objp->hull_strength = 0.0f;
 	}
 
-	if (wip->collision_radius_override > 0.f)
+	if (wip->collision_radius_override > 0.0f)
 		objp->radius = wip->collision_radius_override;
 	else if ( wip->render_type == WRT_POF ) {
 		// this should have been checked above, but let's be extra sure


### PR DESCRIPTION
Useful if a laser's bitmap doesn't visually map well to the radius the modder thinks it should have, or otherwise wants a weapon to have a particular radius. Ship-weapon collisions still only check against a ray so this won't affect them, which I may attempt to address at some point, but the specific requester only need it for weapon-weapon collisions so this should be fine for now.