### PR TITLE
Don't warn for "no radius doubling" if the weapon isn't a bomb

### DIFF
--- a/code/object/collideweaponweapon.cpp
+++ b/code/object/collideweaponweapon.cpp
@@ -56,7 +56,7 @@ int collide_weapon_weapon( obj_pair * pair )
 	B_radius = B->radius;
 
 	if (wipA->weapon_hitpoints > 0) {
-		if (!(wipA->wi_flags[Weapon::Info_Flags::Hard_target_bomb])) {
+		if (!(wipA->wi_flags[Weapon::Info_Flags::No_radius_doubling])) {
 			A_radius *= 2;		// Makes bombs easier to hit
 		}
 		
@@ -69,7 +69,7 @@ int collide_weapon_weapon( obj_pair * pair )
 	}
 
 	if (wipB->weapon_hitpoints > 0) {
-		if (!(wipB->wi_flags[Weapon::Info_Flags::Hard_target_bomb])) {
+		if (!(wipB->wi_flags[Weapon::Info_Flags::No_radius_doubling])) {
 			B_radius *= 2;		// Makes bombs easier to hit
 		}
 		if ((The_mission.ai_profile->flags[AI::Profile_Flags::Aspect_invulnerability_fix]) && (wipB->is_locked_homing()) && (wpB->homing_object != &obj_used_list)) {

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -491,7 +491,7 @@ flag_def_list_new<Weapon::Info_Flags> ai_tgt_weapon_flags[] = {
     { "no emp kill",				Weapon::Info_Flags::No_emp_kill,						true, false },
     { "variable lead homing",		Weapon::Info_Flags::Variable_lead_homing,				true, false },
     { "untargeted heat seeker",		Weapon::Info_Flags::Untargeted_heat_seeker,			    true, false },
-    { "no radius doubling",			Weapon::Info_Flags::Hard_target_bomb,					true, false },
+    { "no radius doubling",			Weapon::Info_Flags::No_radius_doubling,					true, false },
     { "no subsystem homing",		Weapon::Info_Flags::Non_subsys_homing,					true, false },
     { "no lifeleft penalty",		Weapon::Info_Flags::No_life_lost_if_missed,			    true, false },
     { "custom seeker str",			Weapon::Info_Flags::Custom_seeker_str,					true, false },

--- a/code/weapon/weapon_flags.h
+++ b/code/weapon/weapon_flags.h
@@ -55,7 +55,7 @@ namespace Weapon {
 		No_emp_kill,						// though weapon has hitpoints it can not be disabled by EMP
 		Variable_lead_homing,				// allows user defined scaler to be added to lead (to enable, lead, pure or lag pursuit for missiles)
 		Untargeted_heat_seeker,				// forces heat seeker to lose target immeadiately (and acquire a random new one)
-		Hard_target_bomb,					// removes the radius doubling effect bombs have for collisions
+		No_radius_doubling,					// removes the radius doubling effect bombs have for collisions
 		Non_subsys_homing,					// spreads fired missiles around the target ships hull
 		No_life_lost_if_missed,				// prevents game from shortening the lifeleft of the missed but still homing missiles
 		Custom_seeker_str,					// sets the game to use custom seeker strengths instead of default values

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -146,7 +146,7 @@ flag_def_list_new<Weapon::Info_Flags> Weapon_Info_Flags[] = {
     { "inherit parent target",			Weapon::Info_Flags::Inherit_parent_target,				true, false },
     { "no emp kill",					Weapon::Info_Flags::No_emp_kill,						true, false },
     { "untargeted heat seeker",			Weapon::Info_Flags::Untargeted_heat_seeker,				true, false },
-    { "no radius doubling",				Weapon::Info_Flags::Hard_target_bomb,					true, false },
+    { "no radius doubling",				Weapon::Info_Flags::No_radius_doubling,					true, false },
     { "no subsystem homing",			Weapon::Info_Flags::Non_subsys_homing,					true, false },
     { "no lifeleft penalty",			Weapon::Info_Flags::No_life_lost_if_missed,				true, false },
     { "can be targeted",				Weapon::Info_Flags::Can_be_targeted,					true, false },
@@ -641,11 +641,6 @@ void parse_wi_flags(weapon_info *weaponp, flagset<Weapon::Info_Flags> preset_wi_
         
 	if (set_nopierce)
         weaponp->wi_flags.remove(Weapon::Info_Flags::Pierce_shields);
-
-    if (weaponp->wi_flags[Weapon::Info_Flags::Hard_target_bomb] && !weaponp->wi_flags[Weapon::Info_Flags::Bomb]) {
-        weaponp->wi_flags.remove(Weapon::Info_Flags::Hard_target_bomb);
-        Warning(LOCATION, "Weapon %s is not a bomb but has \"no radius doubling\" set. Ignoring this flag", weaponp->name);
-    }
 
     if (weaponp->wi_flags[Weapon::Info_Flags::In_tech_database])
         weaponp->wi_flags.set(Weapon::Info_Flags::Default_in_tech_database);
@@ -2873,6 +2868,11 @@ int parse_weapon(int subtype, bool replace, const char *filename)
 	// making sure bombs get their hitpoints assigned
 	if ((wip->wi_flags[Weapon::Info_Flags::Bomb]) && (wip->weapon_hitpoints == 0)) {
 		wip->weapon_hitpoints = 50;
+	}
+
+	if (wip->weapon_hitpoints <= 0.0f && (wip->wi_flags[Weapon::Info_Flags::No_radius_doubling])) {
+		Warning(LOCATION, "Weapon \'%s\' is not interceptable but has \"no radius doubling\" set. Ignoring the flag", wip->name);
+		wip->wi_flags.set(Weapon::Info_Flags::No_radius_doubling, false);
 	}
 
 	if(optional_string("$Armor Type:")) {


### PR DESCRIPTION
Because the weapon could still be interceptable and simply not a bomb, and fixed and moved the check into the proper place. And also renamed `Hard_target_bomb` to `No_radius_doubling` because it was a confusing name and... well why wasn't it called that from the get go they shouldn't have different names anyway

Closes #2850 