### PR TITLE
Allow polish_position() to use any player's position in multi

### DIFF
--- a/code/hud/hudtarget.cpp
+++ b/code/hud/hudtarget.cpp
@@ -3725,10 +3725,12 @@ int hud_get_best_primary_bank(float *range)
 //
 // Called by the draw lead indicator code to predict where the enemy is going to be
 //
-void polish_predicted_target_pos(weapon_info *wip, object *targetp, vec3d *enemy_pos, vec3d *predicted_enemy_pos, float dist_to_enemy, vec3d *last_delta_vec, int num_polish_steps)
+void polish_predicted_target_pos(weapon_info *wip, object *targetp, vec3d *enemy_pos, vec3d *predicted_enemy_pos, float dist_to_enemy, vec3d *last_delta_vec, int num_polish_steps, object *reference_object)
 {
+	Assertion(reference_object != nullptr, "polish_predicted_target_pos received a nullptr for its reference ship, this is a coder mistake, please report!");
+
 	int	iteration;
-	vec3d	player_pos = Player_obj->pos;
+	vec3d	reference_pos = reference_object->pos;
 	float		time_to_enemy;
 	vec3d	last_predicted_enemy_pos = *predicted_enemy_pos;
 
@@ -3747,11 +3749,11 @@ void polish_predicted_target_pos(weapon_info *wip, object *targetp, vec3d *enemy
 	// additive velocity stuff
 	// not just the player's main target
 	if (The_mission.ai_profile->flags[AI::Profile_Flags::Use_additive_weapon_velocity]) {
-		vm_vec_scale_sub2( &enemy_vel, &Player_obj->phys_info.vel, wip->vel_inherit_amount);
+		vm_vec_scale_sub2( &enemy_vel, &reference_object->phys_info.vel, wip->vel_inherit_amount);
 	}
 
 	for (iteration=0; iteration < num_polish_steps; iteration++) {
-		dist_to_enemy = vm_vec_dist_quick(predicted_enemy_pos, &player_pos);
+		dist_to_enemy = vm_vec_dist_quick(predicted_enemy_pos, &reference_pos);
 		time_to_enemy = dist_to_enemy/weapon_speed;
 		vm_vec_scale_add(predicted_enemy_pos, enemy_pos, &enemy_vel, time_to_enemy);
 		if (The_mission.ai_profile->second_order_lead_predict_factor > 0) {

--- a/code/hud/hudtarget.h
+++ b/code/hud/hudtarget.h
@@ -150,7 +150,9 @@ void hud_tri_empty(float x1,float y1,float x2,float y2,float x3,float y3);
 float hud_find_target_distance( object *targetee, object *targeter );
 float hud_find_target_distance( object *targetee, const vec3d *targeter_pos );
 
-extern void polish_predicted_target_pos(weapon_info *wip, object *targetp, vec3d *enemy_pos, vec3d *predicted_enemy_pos, float dist_to_enemy, vec3d *last_delta_vec, int num_polish_steps);
+extern object* Player_obj;
+
+extern void polish_predicted_target_pos(weapon_info *wip, object *targetp, vec3d *enemy_pos, vec3d *predicted_enemy_pos, float dist_to_enemy, vec3d *last_delta_vec, int num_polish_steps, object *reference_obj = Player_obj);
 void hud_calculate_lead_pos(vec3d *lead_target_pos, vec3d *target_pos, object *targetp, weapon_info	*wip, float dist_to_target, vec3d *rel_pos = NULL);
 
 void hud_stuff_ship_name(char *ship_name_text, const ship *shipp);

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -11306,8 +11306,13 @@ int ship_fire_primary(object * obj, int stream_weapons, int force)
 					time_to_target = dist_to_target / winfo_p->max_speed;
 				}
 
+				// This is to circumvent a nine-year-old bug that prevents autoaim from working in multi. In most cases polish_predicted_target_pos needs
+				// the Player object, but in multi it needs the shooting object.  Also, additional conditions would need to be added in the future if you 
+				// want to apply autoaim to AI, for whatever reason.
+				object* object_to_send = (obj->flags[Object::Object_Flags::Player_ship]) ? obj : Player_obj;
+
 				vm_vec_scale_add(&predicted_target_pos, &target_position, &target_velocity_vec, time_to_target);
-				polish_predicted_target_pos(winfo_p, &Objects[aip->target_objnum], &target_position, &predicted_target_pos, dist_to_target, &last_delta_vec, 1);
+				polish_predicted_target_pos(winfo_p, &Objects[aip->target_objnum], &target_position, &predicted_target_pos, dist_to_target, &last_delta_vec, 1, object_to_send);
 				vm_vec_sub(&plr_to_target_vec, &predicted_target_pos, &obj->pos);
 
 				if (has_autoaim) {


### PR DESCRIPTION
9 year old bug. This will now switches from Player_obj to the shooting object if the shooting object is a player object.  The edited function now uses Player_obj as the default parameter to maintain the same balance for those mods that use this feature.