### PR TITLE
Add beam parameter validation

### DIFF
--- a/code/ai/aiturret.cpp
+++ b/code/ai/aiturret.cpp
@@ -1878,6 +1878,7 @@ bool turret_fire_weapon(int weapon_num, ship_subsys *turret, int parent_objnum, 
 			else
 				fire_info.target_subsys = NULL;
 			fire_info.turret = turret;
+			fire_info.fire_method = BFM_TURRET_FIRED;
 
 			// fire a beam weapon
 			weapon_objnum = beam_fire(&fire_info);

--- a/code/hud/hudartillery.cpp
+++ b/code/hud/hudartillery.cpp
@@ -413,6 +413,7 @@ void ssm_process()
 							fire_info.starting_pos = moveup->sinfo.start_pos[idx];
 							fire_info.beam_info_index = si->weapon_info_index;
 							fire_info.team = static_cast<char>(moveup->sinfo.ssm_team);
+							fire_info.fire_method = BFM_SUBSPACE_STRIKE;
 
 							// fire the beam
 							beam_fire(&fire_info);

--- a/code/network/multimsgs.cpp
+++ b/code/network/multimsgs.cpp
@@ -7859,8 +7859,10 @@ void process_beam_fired_packet(ubyte *data, header *hinfo)
 
 		fire_info.turret = &shipp->fighter_beam_turret_data;
 		fire_info.bank = bank;
+		fire_info.fire_method = BFM_FIGHTER_FIRED;
 	} else {
 		fire_info.turret = ship_get_indexed_subsys(shipp, (int)subsys_index);
+		fire_info.fire_method = BFM_TURRET_FIRED;
 
 		if (fire_info.turret == NULL) {
 			nprintf(("Network", "Couldn't get turret for BEAM weapon!\n"));

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -17960,6 +17960,8 @@ void sexp_beam_fire(int node, bool at_coords)
 
 	// fire the beam
 	if (fire_info.beam_info_index != -1) {
+		fire_info.fire_method = BFM_TURRET_FORCE_FIRED;
+
 		beam_fire(&fire_info);
 	} else {
 		// it would appear the turret doesn't have any beam weapons
@@ -18045,6 +18047,8 @@ void sexp_beam_floating_fire(int n)
 		return;
 	if (count == 0)
 		fire_info.target_pos2 = fire_info.target_pos1;
+
+	fire_info.fire_method = BFM_SEXP_FLOATING_FIRED;
 
 	beam_fire(&fire_info);
 }

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -11400,8 +11400,8 @@ int ship_fire_primary(object * obj, int stream_weapons, int force)
 					fbfire_info.targeting_laser_offset = pm->gun_banks[bank_to_fire].pnt[j];
 					shipp->beam_sys_info.pnt = pm->gun_banks[bank_to_fire].pnt[j];
 					shipp->beam_sys_info.turret_firing_point[0] = pm->gun_banks[bank_to_fire].pnt[j];
-
 					fbfire_info.point = j;
+					fbfire_info.fire_method = BFM_FIGHTER_FIRED;
 
 					beam_fire(&fbfire_info);
 					has_fired = true;

--- a/code/weapon/beam.h
+++ b/code/weapon/beam.h
@@ -99,7 +99,6 @@ typedef struct fighter_beam_fire_info {
 	int warmdown_stamp;
 	float life_left;	
 	float life_total;
-	int  fire_method;
 } fighter_beam_fire_info;
 
 // max # of collisions we'll allow per frame

--- a/code/weapon/beam.h
+++ b/code/weapon/beam.h
@@ -55,6 +55,14 @@ typedef struct beam_info {
 #define BFIF_TARGETING_COORDS	(1<<2)
 #define BFIF_FLOATING_BEAM		(1<<3)
 
+// to ensure validity of fire_info, the related fields MUST be provided
+#define BFM_TURRET_FIRED         0   // objp, subsys, target
+#define BFM_TURRET_FORCE_FIRED   1   // objp, subsys, target OR target_pos
+#define BFM_FIGHTER_FIRED        2   // objp, subsys
+#define BFM_SPAWNED              3   // starting pos, target OR target_pos
+#define BFM_SEXP_FLOATING_FIRED  4   // starting pos, target OR target_pos
+#define BFM_SUBSPACE_STRIKE      5   // starting pos, target
+
 // pass to beam fire 
 typedef struct beam_fire_info {
 	int				beam_info_index;				// weapon info index 
@@ -73,6 +81,7 @@ typedef struct beam_fire_info {
 	int point;									// for fighters, which point on the bank it is from
 	int bfi_flags;
 	char team;									// for floating beams, determines which team the beam is on
+	int  fire_method;
 } beam_fire_info;
 
 typedef struct fighter_beam_fire_info {
@@ -90,6 +99,7 @@ typedef struct fighter_beam_fire_info {
 	int warmdown_stamp;
 	float life_left;	
 	float life_total;
+	int  fire_method;
 } fighter_beam_fire_info;
 
 // max # of collisions we'll allow per frame

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -5916,6 +5916,7 @@ void spawn_child_weapons(object *objp)
 				fire_info.starting_pos = *opos;
 				fire_info.beam_info_index = child_id;
 				fire_info.team = static_cast<char>(obj_team(&Objects[parent_num]));
+				fire_info.fire_method = BFM_SPAWNED;
 
 				// fire the beam
 				beam_fire(&fire_info);


### PR DESCRIPTION
Adds a `beam_has_valid_params` function that beams use to validate their vital inputs. This was being handled pretty much ok already, but having an actual exhaustive list of the ways beams can be fired and what sorts of data they're actually supposed to have is A. less confusing and B. useful for multiplayer, which was the main impetus for this change. The changes to beam packet sending/receiving are here mostly just not to break anything in general, as @notimaginative will have a much better version of these soon. 

~~Also finishes removing `delta_ang` . This was only ever used in some dubious collision checking for beams that was fixed in #2735 , and `BEAM_T` which returns the 0-1 value of the beam's lifetime where it uselessly multiplied and divided by `delta_ang`.~~ holding off on this for now, per comments below