### PR TITLE
Fix a bug with collision_radius_override

### DIFF
--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -7920,6 +7920,7 @@ void weapon_info::reset()
 	this->laser_head_radius = 1.0f;
 	this->laser_tail_radius = 1.0f;
 
+	this->collision_radius_override = -1.0f;
 	this->max_speed = 10.0f;
 	this->acceleration_time = 0.0f;
 	this->vel_inherit_amount = 1.0f;


### PR DESCRIPTION
It was never initialized, and so could be corrupting all weapons' radius.