### PR TITLE
Don't perform automatic hash truncation before template-copying.

### DIFF
--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -1947,6 +1947,7 @@ static void parse_ship(const char *filename, bool replace)
 	bool first_time = false;
 	bool create_if_not_found = true;
 	bool remove_ship = false;
+	bool new_name = false;
 
 	required_string("$Name:");
 	stuff_string(fname, F_NAME, NAME_LENGTH);
@@ -2035,13 +2036,7 @@ static void parse_ship(const char *filename, bool replace)
 		first_time = true;
 
 		strcpy_s(sip->name, fname);
-
-		// if this name has a hash, create a default display name
-		if (get_pointer_to_first_hash_symbol(sip->name)) {
-			strcpy_s(sip->display_name, sip->name);
-			end_string_at_first_hash_symbol(sip->display_name);
-			sip->flags.set(Ship::Info_Flags::Has_display_name);
-		}
+		new_name = true;
 	}
 
 	// Use a template for this ship.
@@ -2057,10 +2052,20 @@ static void parse_ship(const char *filename, bool replace)
 				first_time = false;
 				sip->clone(Ship_templates[template_id]);
 				strcpy_s(sip->name, fname);
+				new_name = true;
 			}
 			else {
 				Warning(LOCATION, "Unable to find ship template '%s' requested by ship class '%s', ignoring template request...", template_name, fname);
 			}
+		}
+	}
+
+	if (new_name && !sip->flags[Ship::Info_Flags::Has_display_name]) {
+		// if this name has a hash, create a default display name
+		if (get_pointer_to_first_hash_symbol(sip->name)) {
+			strcpy_s(sip->display_name, sip->name);
+			end_string_at_first_hash_symbol(sip->display_name);
+			sip->flags.set(Ship::Info_Flags::Has_display_name);
 		}
 	}
 


### PR DESCRIPTION
In commit 3b2af702f764b7f7a7bd5fc35eef6586a6e02cb5, the hash truncation was changed so that instead of being part of the HUD, it's stored as the class's display name. However, this action was performed before `+Use Template:` was parsed, which would then overwrite the display name and clear the `Has_display_name` flag. I've moved it so that it now happens after the copy operation (and added a check for an existing display name, in case the template defines one). I use a new boolean variable to indicate that default display name creation needs to happen rather than duplicate that code.