### PR TITLE
Use prebuilt FreeType library on Mac

### DIFF
--- a/lib/freetype.cmake
+++ b/lib/freetype.cmake
@@ -1,20 +1,24 @@
 
 add_library(freetype INTERFACE)
 
-if(PLATFORM_WINDOWS)
-	# We use prebuilt binaries for windows
+if(PLATFORM_WINDOWS OR PLATFORM_MAC)
+	# We use prebuilt binaries for windows and mac
 	get_prebuilt_path(PREBUILT_PATH)
-	set(FRRETYPE_ROOT_DIR "${PREBUILT_PATH}/freetype")
+	set(FREETYPE_ROOT_DIR "${PREBUILT_PATH}/freetype")
 
-	set(SEARCH_PATH "${FRRETYPE_ROOT_DIR}/lib")
+	set(SEARCH_PATH "${FREETYPE_ROOT_DIR}/lib")
 
-	set(dll_name "${SEARCH_PATH}/freetype281.dll")
+	target_include_directories(freetype INTERFACE "${FREETYPE_ROOT_DIR}/include")
 
-	target_include_directories(freetype INTERFACE "${FRRETYPE_ROOT_DIR}/include")
-
+if(PLATFORM_WINDOWS)
 	target_link_libraries(freetype INTERFACE "${SEARCH_PATH}/freetype281.lib")
-
+	set(dll_name "${SEARCH_PATH}/freetype281.dll")
 	add_target_copy_files("${dll_name}")
+else()
+	# mac freetype build uses only static linking
+	target_link_libraries(freetype INTERFACE "${SEARCH_PATH}/libfreetype.a")
+endif(PLATFORM_WINDOWS)
+
 else()
 	find_package(Freetype REQUIRED)
 

--- a/lib/prebuilt.cmake
+++ b/lib/prebuilt.cmake
@@ -1,5 +1,5 @@
 
-set(PREBUILT_VERSION_NAME "b5cddcd84af2d85c9e9394c28e1fc5be16aacff6")
+set(PREBUILT_VERSION_NAME "ba538510e6c957f5e773bb7009eac4ed285120e3")
 
 set(FSO_PREBUILT_OVERRIDE "" CACHE PATH "Path to the prebuilt binaries, if empty the binaries will be downloaded.")
 set(PREBUILT_LIB_DIR "${CMAKE_CURRENT_BINARY_DIR}/prebuilt")


### PR DESCRIPTION
Requires the FreeType static library for Mac found in [scp-prebuilt repo's PR 7](https://github.com/scp-fs2open/scp-prebuilt/pull/7).

Fixes Issue #2370 .