### PR TITLE
Some visual fixes to local ssms

### DIFF
--- a/code/weapon/corkscrew.cpp
+++ b/code/weapon/corkscrew.cpp
@@ -246,7 +246,7 @@ void cscrew_process_post(object *objp)
 	vm_vec_sub(&ci->cen_p, &cen, &objp->pos);
 
 	// do trail stuff here
-	if ( wp->trail_ptr != NULL && wp->lssm_stage != 3)	{
+	if ( wp->trail_ptr != nullptr && wp->lssm_stage != 3)	{
 		if (trail_stamp_elapsed(wp->trail_ptr)) {
 			trail_add_segment( wp->trail_ptr, &objp->pos );
 			trail_set_stamp(wp->trail_ptr);

--- a/code/weapon/corkscrew.cpp
+++ b/code/weapon/corkscrew.cpp
@@ -246,7 +246,7 @@ void cscrew_process_post(object *objp)
 	vm_vec_sub(&ci->cen_p, &cen, &objp->pos);
 
 	// do trail stuff here
-	if ( wp->trail_ptr != NULL )	{
+	if ( wp->trail_ptr != NULL && wp->lssm_stage != 3)	{
 		if (trail_stamp_elapsed(wp->trail_ptr)) {
 			trail_add_segment( wp->trail_ptr, &objp->pos );
 			trail_set_stamp(wp->trail_ptr);

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -5073,8 +5073,13 @@ void weapon_process_post(object * obj, float frame_time)
 			//create a warp effect
 			vm_vec_copy_scale(&warpout,&obj->phys_info.vel,3.0f);
 
+			//get the size of the warp, directly using the model if possible
+			float warp_size = obj->radius;
+			if (wip->model_num >= 0)
+				warp_size = model_get_radius(wip->model_num);
+
 			//set the time the warphole stays open, minimum of 7 seconds
-			wp->lssm_warp_time = ((obj->radius * 2) / (obj->phys_info.speed)) +1.5f;
+			wp->lssm_warp_time = ((warp_size * 2) / (obj->phys_info.speed)) +1.5f;
 			wp->lssm_warp_time = MAX(wp->lssm_warp_time,7.0f);
 
 			//calculate the percerentage of the warpholes life at which the missile is fully in subspace.
@@ -5082,7 +5087,7 @@ void weapon_process_post(object * obj, float frame_time)
 
 			//create the warphole
 			vm_vec_add2(&warpout,&obj->pos);
-			wp->lssm_warp_idx = fireball_create(&warpout, FIREBALL_WARP, FIREBALL_WARP_EFFECT, -1, obj->radius*1.5f, true, &vmd_zero_vector, wp->lssm_warp_time, 0, &obj->orient);
+			wp->lssm_warp_idx = fireball_create(&warpout, FIREBALL_WARP, FIREBALL_WARP_EFFECT, -1, warp_size * 1.5f, true, &vmd_zero_vector, wp->lssm_warp_time, 0, &obj->orient);
 
 			if (wp->lssm_warp_idx < 0) {
 				mprintf(("LSSM: Failed to create warp effect! Please report if this happens frequently.\n"));
@@ -5102,6 +5107,12 @@ void weapon_process_post(object * obj, float frame_time)
 
 			obj_set_flags(obj, flags);
 		
+			// stop its trail here
+			if (wp->trail_ptr != nullptr) {
+				trail_object_died(wp->trail_ptr);
+				wp->trail_ptr = nullptr;
+			}
+
 			//get the position of the target, and estimate its position when it warps out
 			//so we have an idea of where it will be.
 			auto target_objp = wp->homing_object;
@@ -5139,8 +5150,13 @@ void weapon_process_post(object * obj, float frame_time)
 			vm_vec_sub(&fvec,&wp->lssm_target_pos, &warpin);
 			vm_vector_2_matrix(&orient,&fvec,NULL,NULL);
 
+			//get the size of the warp, directly using the model if possible
+			float warp_size = obj->radius;
+			if (wip->model_num >= 0)
+				warp_size = model_get_radius(wip->model_num);
+
 			//create a warpin effect
-			wp->lssm_warp_idx = fireball_create(&warpin, FIREBALL_WARP, FIREBALL_WARP_EFFECT, -1, obj->radius*1.5f, false, &vmd_zero_vector, wp->lssm_warp_time, 0, &orient);
+			wp->lssm_warp_idx = fireball_create(&warpin, FIREBALL_WARP, FIREBALL_WARP_EFFECT, -1, warp_size * 1.5f, false, &vmd_zero_vector, wp->lssm_warp_time, 0, &orient);
 			
 			if (wp->lssm_warp_idx < 0) {
 				mprintf(("LSSM: Failed to create warp effect! Please report if this happens frequently.\n"));
@@ -5170,6 +5186,17 @@ void weapon_process_post(object * obj, float frame_time)
             flags.set(Object::Object_Flags::Collides);
 
 			obj_set_flags(obj,flags);
+
+			// start the trail back up if applicable
+			if (wip->wi_flags[Weapon::Info_Flags::Trail]) {
+				wp->trail_ptr = trail_create(&wip->tr_info);
+
+				if (wp->trail_ptr != nullptr) {
+					// Add two segments.  One to stay at launch pos, one to move.
+					trail_add_segment(wp->trail_ptr, &obj->pos);
+					trail_add_segment(wp->trail_ptr, &obj->pos);
+				}
+			}
 		}
 	}
 

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -5040,7 +5040,7 @@ void weapon_process_post(object * obj, float frame_time)
 		}
 	}
 
-	if(wip->wi_flags[Weapon::Info_Flags::Particle_spew]){
+	if(wip->wi_flags[Weapon::Info_Flags::Particle_spew] && wp->lssm_stage != 3 ){
 		weapon_maybe_spew_particle(obj);
 	}
 


### PR DESCRIPTION
No particle spew during stage 3, don't update the trail for corkscrew missiles in stage 3, kill the old trail, and create a new one when entering/exiting warp, and make sure to use the model's radius for the warp effect, in case the object''s radius was overwritten. 

Closes #2792 