### PR TITLE
Controls0 - Vectorize Controls_config

### DIFF
--- a/code/controlconfig/controlsconfig.cpp
+++ b/code/controlconfig/controlsconfig.cpp
@@ -123,7 +123,7 @@ int Conflict_bright = 0;
 #define LIST_BUTTONS_MAX	42
 #define JOY_AXIS			0x80000
 
-static int Num_cc_lines;
+static int Num_cc_lines;	// Number of Cc_lines to display on the current page. Is, at worse, CCFG_MAX + NUM_JOY_AXIS_ACTIONS
 
 /**
  * @struct cc_line
@@ -506,30 +506,34 @@ void control_config_conflict_check()
 // do list setup required prior to rendering and checking for the controls listing.  Called when list changes
 void control_config_list_prepare()
 {
-	int j, y, z;
+	int y;	// Offset, in pixels, the Cc_line has from the top
+	int z;	// index into Control_config[]
 	int font_height = gr_get_font_height();
 
 	Num_cc_lines = y = z = 0;
-	while (z < CCFG_MAX) {
-		if (Control_config[z].tab == Tab && !Control_config[z].disabled) {
-			if (Control_config[z].indexXSTR > 1) {
-				Cc_lines[Num_cc_lines].label = XSTR(Control_config[z].text.c_str(), Control_config[z].indexXSTR, true);
-			} else if (Control_config[z].indexXSTR == 1) {
-				Cc_lines[Num_cc_lines].label = XSTR(Control_config[z].text.c_str(), CONTROL_CONFIG_XSTR + z, true);
+
+	// Populate the digital controls
+	for (const auto &item : Control_config) {
+		if (item.tab == Tab && !item.disabled) {
+			if (item.indexXSTR > 1) {
+				Cc_lines[Num_cc_lines].label = XSTR(item.text.c_str(), item.indexXSTR, true);
+			} else if (item.indexXSTR == 1) {
+				Cc_lines[Num_cc_lines].label = XSTR(item.text.c_str(), CONTROL_CONFIG_XSTR + z, true);
 			} else {
-				Cc_lines[Num_cc_lines].label = Control_config[z].text.c_str();
+				Cc_lines[Num_cc_lines].label = item.text.c_str();
 			}
 
 			Cc_lines[Num_cc_lines].cc_index = z;
 			Cc_lines[Num_cc_lines++].y = y;
 			y += font_height + 2;
-		}
+		} // Else, Ignore and hide items
 
-		z++;
+		z++;	// z is the index position in Control_config[]
 	}
 
+	// Populate the analog controls.
 	if (Tab == SHIP_TAB) {
-		for (j=0; j<NUM_JOY_AXIS_ACTIONS; j++) {
+		for (int j = 0; j < NUM_JOY_AXIS_ACTIONS; j++) {
 			Cc_lines[Num_cc_lines].label = Joy_axis_action_text[j];
 			Cc_lines[Num_cc_lines].cc_index = j | JOY_AXIS;
 			Cc_lines[Num_cc_lines++].y = y;
@@ -1194,7 +1198,7 @@ void control_config_init()
 
 	// Init Cc_lines
 	Cc_lines.clear();
-	Cc_lines.resize(Control_config.size());	// Can't use CCFG_MAX here, since scripts or might add controls
+	Cc_lines.resize(Control_config.size() + NUM_JOY_AXIS_ACTIONS);	// Can't use CCFG_MAX here, since scripts or might add controls
 
 	Defaults_cycle_pos = 0;
 

--- a/code/controlconfig/controlsconfig.cpp
+++ b/code/controlconfig/controlsconfig.cpp
@@ -517,11 +517,11 @@ void control_config_list_prepare()
 	while (z < CCFG_MAX) {
 		if (Control_config[z].tab == Tab && !Control_config[z].disabled) {
 			if (Control_config[z].indexXSTR > 1) {
-				Cc_lines[Num_cc_lines].label = XSTR(Control_config[z].text, Control_config[z].indexXSTR, true);
+				Cc_lines[Num_cc_lines].label = XSTR(Control_config[z].text.c_str, Control_config[z].indexXSTR, true);
 			} else if (Control_config[z].indexXSTR == 1) {
-				Cc_lines[Num_cc_lines].label = XSTR(Control_config[z].text, CONTROL_CONFIG_XSTR + z, true);
+				Cc_lines[Num_cc_lines].label = XSTR(Control_config[z].text.c_str, CONTROL_CONFIG_XSTR + z, true);
 			} else {
-				Cc_lines[Num_cc_lines].label = Control_config[z].text;
+				Cc_lines[Num_cc_lines].label = Control_config[z].text.c_str;
 			}
 
 			Cc_lines[Num_cc_lines].cc_index = z;
@@ -1985,11 +1985,11 @@ void control_config_do_frame(float frametime)
 		gr_printf_menu(x - w / 2, y - font_height, "%s", str);
 
 		if (Control_config[i].indexXSTR > 1) {
-			strcpy_s(buf, XSTR(Control_config[i].text, Control_config[i].indexXSTR, true));
+			strcpy_s(buf, XSTR(Control_config[i].text.c_str, Control_config[i].indexXSTR, true));
 		} else if (Control_config[i].indexXSTR == 1) {
-			strcpy_s(buf, XSTR(Control_config[i].text, CONTROL_CONFIG_XSTR + i, true));
+			strcpy_s(buf, XSTR(Control_config[i].text.c_str, CONTROL_CONFIG_XSTR + i, true));
 		} else {
-			strcpy_s(buf, Control_config[i].text);
+			strcpy_s(buf, Control_config[i].text.c_str);
 		}
 
 		font::force_fit_string(buf, 255, Conflict_wnd_coords[gr_screen.res][CONTROL_W_COORD]);

--- a/code/controlconfig/controlsconfig.cpp
+++ b/code/controlconfig/controlsconfig.cpp
@@ -1184,13 +1184,17 @@ void control_config_init()
 	int i;
 	ui_button_info *b;
 
-	// Free up data from any previous backups.  Not needed but is insurance
+	// Init the backup vectors
 	Control_config_backup.clear();
-
-	// make backup of all controls
+	Control_config_backup.reserve(Control_config.size());
 	std::copy(Control_config.begin(), Control_config.end(), std::back_inserter(Control_config_backup));
-	std::copy(Axis_map_to, Axis_map_to + JOY_NUM_AXES, Axis_map_to_backup);
+
+	std::copy(Axis_map_to, Axis_map_to + NUM_JOY_AXIS_ACTIONS, Axis_map_to_backup);
 	std::copy(Invert_axis, Invert_axis + JOY_NUM_AXES, Invert_axis_backup);
+
+	// Init Cc_lines
+	Cc_lines.clear();
+	Cc_lines.resize(Control_config.size());	// Can't use CCFG_MAX here, since scripts or might add controls
 
 	Defaults_cycle_pos = 0;
 
@@ -1333,6 +1337,10 @@ void control_config_close()
 			Invert_text[idx] = NULL;
 		}
 	}
+
+	// Free up memory from dynamic containers
+	Control_config_backup.resize(0);
+	Cc_lines.resize(0);
 }
 
 void control_config_do_frame(float frametime)

--- a/code/controlconfig/controlsconfig.h
+++ b/code/controlconfig/controlsconfig.h
@@ -80,8 +80,6 @@ enum CC_type {
 	CC_TYPE_CONTINUOUS				//!< A continous control that is activated as long as the key or button is held down
 };
 
-SCP_vector<SCP_string> Joy_table;	//!< Table of all bound joystick GUID's;  Index in this vector is ordered and uses the CID
-
 /*!
  *  A singular button binding
  */

--- a/code/controlconfig/controlsconfig.h
+++ b/code/controlconfig/controlsconfig.h
@@ -101,7 +101,7 @@ public:
 	short key_id;
 
 	char tab;               //!< what tab (category) it belongs in
-	int  indexXSTR;         //!< what string index we should use to translate this with an XSTR
+	int  indexXSTR;         //!< what string index we should use to translate this with an XSTR 0 = None, 1= Use item index + CONTROL_CONFIG_XSTR, 2 <= use CCI::indexXSTR directly
 	SCP_string text;        //!< describes the action in the config screen
 
 	CC_type type;           //!< manner control should be checked in

--- a/code/controlconfig/controlsconfig.h
+++ b/code/controlconfig/controlsconfig.h
@@ -51,9 +51,8 @@ enum Joy_axis_action_index {
 	JOY_HEADING_AXIS	=0,	//
 	JOY_PITCH_AXIS,
 	JOY_BANK_AXIS,
-	JOY_THROTTLE_AXIS,
-	JOY_LATERAL_AXIS,       //!< Left/Right thrust axis
-	JOY_VERTICAL_AXIS,      //!< Up/Down thrust axis
+	JOY_ABS_THROTTLE_AXIS,
+	JOY_REL_THROTTLE_AXIS,
 
 	/*!
 	 * This must always be below the last defined item
@@ -95,7 +94,8 @@ struct CC_bind {
  * Control configuration item type.
  * @detail Contains binding info, documentation, behavior, etc. for a single control
  */
-struct CCI {
+class CCI {
+public:
 // Items Set in menu
 	short joy_default;
 	short key_default;
@@ -113,8 +113,7 @@ struct CCI {
 	bool disabled;              //!< whether this action should be available at all
 	bool continuous_ongoing;    //!< whether this action is a continuous one and is currently ongoing
 
-	// default const.
-	CCI() : disabled(true){};
+	CCI() : disabled(true) {};
 };
 
 enum IoActionId;
@@ -137,7 +136,7 @@ public:
 	/*!
 	 * End a chain of factory methods.  If there any post-init work to be done, that's done here.
 	 */
-	CCI_builder& end();
+	void end();
 
 	/*!
 	 * Assigns the hardcoded binding to the given action
@@ -155,8 +154,7 @@ private:
  * This is the value of the id field in config_item
  * The first group of items are ship targeting.
  */
-//...no its not!
-// screw these hardcoded numbers, it makes re-organizing and adding new Id's next to impossible
+
 // Since we're upgrading the Control_config array into a proper vector, and since we're using contructor predicates we can organize these to however we like and pass the IoActionId to the constructor to ensure the correct placement
 enum IoActionId  {
 	TARGET_NEXT										=0,		//!< target next
@@ -369,6 +367,7 @@ enum IoActionId  {
 extern int Failed_key_index;
 
 extern int Axis_map_to[];
+extern int Axis_map_to_defaults[];
 extern int Invert_axis[];
 extern int Invert_axis_defaults[];
 
@@ -378,8 +377,8 @@ extern int Joy_sensitivity;
 extern int Control_config_overlay_id;
 
 extern SCP_vector<CCI> Control_config;		//!< Stores the keyboard configuration
-extern SCP_vector<CCI*> Control_config_presets; // tabled control presets; pointers to config_item arrays
-extern SCP_vector<SCP_string> Control_config_preset_names; // names for Control_config_presets (identical order of items)
+//extern SCP_vector<CCI*> Control_config_presets; // tabled control presets; pointers to config_item arrays
+//extern SCP_vector<SCP_string> Control_config_preset_names; // names for Control_config_presets (identical order of items)
 extern const char **Scan_code_text;
 extern const char **Joy_button_text;
 

--- a/code/controlconfig/controlsconfig.h
+++ b/code/controlconfig/controlsconfig.h
@@ -364,9 +364,9 @@ enum IoActionId  {
 
 extern int Failed_key_index;
 
-extern int Axis_map_to[];
+extern int Axis_map_to[];           // Array to map an axis action to a joy axis. size() = NUM_JOY_AXIS_ACTIONS
 extern int Axis_map_to_defaults[];
-extern int Invert_axis[];
+extern int Invert_axis[];           // Array to hold inversion bools for a joy axis. size() = JOY_NUM_AXES
 extern int Invert_axis_defaults[];
 
 extern int Joy_dead_zone_size;

--- a/code/controlconfig/controlsconfigcommon.cpp
+++ b/code/controlconfig/controlsconfigcommon.cpp
@@ -71,6 +71,8 @@ int Invert_axis_defaults[JOY_NUM_AXES] = { 0, 0, 0, 0, 0, 0 };
 SCP_vector<CCI> Control_config;
 
 void controls_config_init_bindings() {
+	Control_config.clear();	// Clear exisitng vectory, just in case init is run more than once for whatever reason
+
 	CCI_builder Builder(Control_config);
 	Builder.start()
 	// Note: when adding new controls, group them according to the tab they would show up on.
@@ -778,6 +780,8 @@ void control_config_common_load_overrides();
 // initialize common control config stuff - call at game startup after localization has been initialized
 void control_config_common_init()
 {
+	controls_config_init_bindings();
+
 	for (int i=0; i<CCFG_MAX; i++) {
 		Control_config[i].continuous_ongoing = false;
 	}

--- a/code/controlconfig/controlsconfigcommon.cpp
+++ b/code/controlconfig/controlsconfigcommon.cpp
@@ -137,15 +137,15 @@ void controls_config_init_bindings() {
 	// flight controls (flight modes)
 	(BANK_WHEN_PRESSED,                                      -1, -1, SHIP_TAB, 1, "Bank When Pressed",  CC_TYPE_CONTINUOUS)
 	(AFTERBURNER,                                       KEY_TAB,  5, SHIP_TAB, 1, "Afterburner",        CC_TYPE_CONTINUOUS)
-	(GLIDE_WHEN_PRESSED,                                     -1, -1, SHIP_TAB, 0, "Glide When Pressed", CC_TYPE_CONTINUOUS)
-	(TOGGLE_GLIDING,                          KEY_ALTED | KEY_G, -1, SHIP_TAB, 0, "Toggle Gliding",     CC_TYPE_TRIGGER)
+	(GLIDE_WHEN_PRESSED,                                     -1, -1, SHIP_TAB, 0, "Glide When Pressed", CC_TYPE_CONTINUOUS, true)
+	(TOGGLE_GLIDING,                          KEY_ALTED | KEY_G, -1, SHIP_TAB, 0, "Toggle Gliding",     CC_TYPE_TRIGGER, true)
 
 	// weapons
 	(FIRE_PRIMARY,                                    KEY_LCTRL,  0, WEAPON_TAB, 1, "Fire Primary Weapon",                    CC_TYPE_CONTINUOUS)
 	(FIRE_SECONDARY,                               KEY_SPACEBAR,  1, WEAPON_TAB, 1, "Fire Secondary Weapon",                  CC_TYPE_CONTINUOUS)
 	(CYCLE_NEXT_PRIMARY,                             KEY_PERIOD, -1, WEAPON_TAB, 1, "Cycle Primary Weapon Forward",           CC_TYPE_TRIGGER)
 	(CYCLE_PREV_PRIMARY,                              KEY_COMMA, -1, WEAPON_TAB, 1, "Cycle Primary Weapon Backward",          CC_TYPE_TRIGGER)
-	(CYCLE_PRIMARY_WEAPON_SEQUENCE,                       KEY_O, -1, WEAPON_TAB, 0, "Cycle Primary Weapon Firing Rate",       CC_TYPE_TRIGGER)
+	(CYCLE_PRIMARY_WEAPON_SEQUENCE,                       KEY_O, -1, WEAPON_TAB, 0, "Cycle Primary Weapon Firing Rate",       CC_TYPE_TRIGGER, true)
 	(CYCLE_SECONDARY,                                KEY_DIVIDE, -1, WEAPON_TAB, 1, "Cycle Secondary Weapon Forward",         CC_TYPE_TRIGGER)
 	(CYCLE_NUM_MISSLES,                KEY_SHIFTED | KEY_DIVIDE, -1, WEAPON_TAB, 1, "Cycle Secondary Weapon Firing Rate",     CC_TYPE_TRIGGER)
 	(LAUNCH_COUNTERMEASURE,                               KEY_X,  3, WEAPON_TAB, 1, "Launch Countermeasure",                  CC_TYPE_TRIGGER)
@@ -181,8 +181,8 @@ void controls_config_init_bindings() {
 	(PADLOCK_DOWN,                                           -1, 32, COMPUTER_TAB, 1, "View Rear",                          CC_TYPE_CONTINUOUS)
 	(PADLOCK_LEFT,                                           -1, 34, COMPUTER_TAB, 1, "View Left",                          CC_TYPE_CONTINUOUS)
 	(PADLOCK_RIGHT,                                          -1, 35, COMPUTER_TAB, 1, "View Right",                         CC_TYPE_CONTINUOUS)
-	(VIEW_TOPDOWN,                                           -1, -1, COMPUTER_TAB, 0, "Top-Down View",                      CC_TYPE_TRIGGER)
-	(VIEW_TRACK_TARGET,                                      -1, -1, COMPUTER_TAB, 0, "Target Padlock View",                CC_TYPE_TRIGGER)
+	(VIEW_TOPDOWN,                                           -1, -1, COMPUTER_TAB, 0, "Top-Down View",                      CC_TYPE_TRIGGER, true)
+	(VIEW_TRACK_TARGET,                                      -1, -1, COMPUTER_TAB, 0, "Target Padlock View",                CC_TYPE_TRIGGER, true)
 
 	(RADAR_RANGE_CYCLE,                            KEY_RAPOSTRO, -1, COMPUTER_TAB, 1, "Cycle Radar Range",                 CC_TYPE_TRIGGER)
 	(SQUADMSG_MENU,                                       KEY_C, -1, COMPUTER_TAB, 1, "Communications Menu",               CC_TYPE_TRIGGER)
@@ -207,8 +207,8 @@ void controls_config_init_bindings() {
 
 	// Navigation and Autopilot
 	(SHOW_NAVMAP,                                            -1, -1, NO_TAB,       1, "Show Nav Map",       CC_TYPE_TRIGGER)
-	(AUTO_PILOT_TOGGLE,                       KEY_ALTED | KEY_A, -1, COMPUTER_TAB, 0, "Toggle Auto Pilot",  CC_TYPE_TRIGGER)
-	(NAV_CYCLE,                               KEY_ALTED | KEY_N, -1, COMPUTER_TAB, 0, "Cycle Nav Points",   CC_TYPE_TRIGGER)
+	(AUTO_PILOT_TOGGLE,                       KEY_ALTED | KEY_A, -1, COMPUTER_TAB, 0, "Toggle Auto Pilot",  CC_TYPE_TRIGGER, true)
+	(NAV_CYCLE,                               KEY_ALTED | KEY_N, -1, COMPUTER_TAB, 0, "Cycle Nav Points",   CC_TYPE_TRIGGER, true)
 
 	// Escort
 	(ADD_REMOVE_ESCORT,                       KEY_ALTED | KEY_E, -1, COMPUTER_TAB, 1, "Add or Remove Escort",   CC_TYPE_TRIGGER)

--- a/code/gamehelp/gameplayhelp.cpp
+++ b/code/gamehelp/gameplayhelp.cpp
@@ -114,9 +114,8 @@ void gameplay_help_blit_control_line(int x, int y, int id)
 {
 	int			has_key=0, has_joy=0;
 	char			buf[256];
-	config_item	*ci;
 
-	ci = &Control_config[id];
+	auto ci = &Control_config[id];
 
 	buf[0] = 0;
 
@@ -140,7 +139,7 @@ void gameplay_help_blit_control_line(int x, int y, int id)
 	gr_string(x,y,buf,GR_RESIZE_MENU);
 
 //	gr_string(x+KEY_DESCRIPTION_OFFSET,y,ci->text,GR_RESIZE_MENU);
-	gr_string(x+KEY_DESCRIPTION_OFFSET, y, XSTR(ci->text, CONTROL_CONFIG_XSTR + id), GR_RESIZE_MENU);
+	gr_string(x+KEY_DESCRIPTION_OFFSET, y, XSTR(ci->text.c_str(), CONTROL_CONFIG_XSTR + id), GR_RESIZE_MENU);
 }
 
 void gameplay_help_blit_control_line_raw(int x, int y, const char *control_text, const char *control_description)

--- a/code/mission/missiontraining.cpp
+++ b/code/mission/missiontraining.cpp
@@ -655,7 +655,7 @@ SCP_string message_translate_tokens(const char *text)
 						if ( The_mission.game_type & MISSION_TYPE_TRAINING ) {
 							r = popup(PF_TITLE_BIG | PF_TITLE_RED, 2, XSTR( "&Bind Control", 424), XSTR( "&Abort mission", 425),
 								XSTR( "Warning\nYou have no control bound to the action \"%s\".  You must do so before you can continue with your training.", 426),
-								XSTR(Control_config[Failed_key_index].text, CONTROL_CONFIG_XSTR + Failed_key_index));
+								XSTR(Control_config[Failed_key_index].text.c_str(), CONTROL_CONFIG_XSTR + Failed_key_index));
 
 							if (r) {  // do they want to abort the mission?
 								gameseq_post_event(GS_EVENT_END_GAME);

--- a/code/pilotfile/pilotfile_convert.h
+++ b/code/pilotfile/pilotfile_convert.h
@@ -137,7 +137,7 @@ struct plr_data {
 	unsigned char hud_colors[39][4];
 
 	// control setup
-	SCP_vector<config_item> controls;
+	SCP_vector<CCI> controls;
 
 	int joy_axis_map_to[5];
 	int joy_invert_axis[5];
@@ -254,6 +254,10 @@ class pilotfile_convert {
 		plr_data *plr;
 
 		void plr_import();
+
+		/**
+		 * @brief Reads in the player controls from the playerfile.  Assumes controls are written in the order they are hardcoded.
+		 */
 		void plr_import_controls();
 		void plr_import_hud();
 		void plr_import_detail();

--- a/code/pilotfile/plr_convert.cpp
+++ b/code/pilotfile/plr_convert.cpp
@@ -126,7 +126,7 @@ plr_data::~plr_data()
 void pilotfile_convert::plr_import_controls()
 {
 	int idx;
-	config_item con;
+	CCI con;
 
 	unsigned char num_controls = cfread_ubyte(cfp);
 
@@ -134,8 +134,8 @@ void pilotfile_convert::plr_import_controls()
 		return;
 	}
 
-	// it may be less than 118, but it shouldn't be more than 118
-	if (num_controls > 118) {
+	// TODO: Currently only checks for hardcoded control bindings. Scripted controls will be sliced out in the pilot file
+	if (num_controls > CCFG_MAX) {
 		throw "Data check failure in controls!";
 	}
 

--- a/code/pilotfile/plr_convert.cpp
+++ b/code/pilotfile/plr_convert.cpp
@@ -134,8 +134,9 @@ void pilotfile_convert::plr_import_controls()
 		return;
 	}
 
-	// TODO: Currently only checks for hardcoded control bindings. Scripted controls will be sliced out in the pilot file
-	if (num_controls > CCFG_MAX) {
+	// it may be less than 118, but it shouldn't be more than 118
+	// Don't touch this magic number! This is for old playerfiles. See banner at top of this file.
+	if (num_controls > 118) {
 		throw "Data check failure in controls!";
 	}
 

--- a/code/scripting/scripting.cpp
+++ b/code/scripting/scripting.cpp
@@ -509,7 +509,7 @@ bool ConditionedHook::ConditionsValid(int action, object *objp, int more_data)
 
 					int action_index = more_data;
 
-					if (action_index <= 0 || stricmp(scp->condition_string.c_str(), Control_config[action_index].text) != 0)
+					if (action_index <= 0 || stricmp(scp->condition_string.c_str(), Control_config[action_index].text.c_str()) != 0)
 						return false;
 					break;
 				}


### PR DESCRIPTION
First PR of the overhaul.  This changes the Controls_config array into an SCP_vector to allow scripting to add more controls as they wish, enabling mod devs to create new controls with scripting and not needing hardcode support in the future.  (Custom controls are still a ways off, however)

Notice: Due to the nature of the controls code, Some features had to be disabled to get a compilation.  These will be address with the next PRs as soon as possible.

* Disabled the Undo system of the controls config menu.  You won't be able to undo bindings outside of doing a total reset via Escape.
* Disabled the Config presets.  You won't be able to cycle through or create new presets with this build.
* Restricted controlsconfigdefaults.tbl to use the first override set.  This is because the table used the config presets.  For now, the overrides are put directly into Control_config items as the defaults, thereby overriding the default hardcoded bindings for duration of the selected mod.

Vanilla behavior should not be affected in any way, this is primarily a refactor PR, but focus on the particular thigns:
[  ] Bind mode behaves as it should
[  ] Search mode behaves as it should
[  ] Loading controlconfigdefaults with retail data
[  ] Loading controlconfigdefaults with mod data
[  ] Undo shouldn't work (Intentionally disabled)
[  ] Presets shouldn't work (Intentionally disabled)