### PR TITLE
Fix 'getFrametime' scripting function

### DIFF
--- a/code/scripting/api/libs/base.cpp
+++ b/code/scripting/api/libs/base.cpp
@@ -229,17 +229,22 @@ ADE_FUNC(getFrametimeOverall, l_Base, NULL, "The overall frame time in seconds s
 	return ade_set_args(L, "x", game_get_overall_frametime());
 }
 
-ADE_FUNC(getTimeCompressedFrametime, l_Base, NULL, "Gets how long this frame is calculated to take. Use it to for animations, physics, etc to make incremental changes. Increased or decreased based on current time compression", "number", "Frame time (seconds)")
+ADE_FUNC(getTimeCompressedFrametime, l_Base, nullptr, "Gets how long this frame is calculated to take. Use it to for animations, physics, etc to make incremental changes. Increased or decreased based on current time compression", "number", "Frame time (seconds)")
 {
 	return ade_set_args(L, "f", flFrametime);
 }
 
-ADE_FUNC(getRealFrametime, l_Base, NULL, "Gets how long this frame is calculated to take in real time. Not affected by time compression.", "number", "Frame time (seconds)")
+ADE_FUNC(getRealFrametime, l_Base, nullptr, "Gets how long this frame is calculated to take in real time. Not affected by time compression.", "number", "Frame time (seconds)")
 {
 	return ade_set_args(L, "f", flRealframetime);
 }
 
-ADE_FUNC(getFrametime, l_Base, "[boolean adjustForTimeCompression]", "Gets how long this frame is calculated to take. Use it to for animations, physics, etc to make incremental changes. DEPRECATED, due a mistake in the documentaion.", "number", "Frame time (seconds)")
+ADE_FUNC_DEPRECATED(getFrametime, l_Base, 
+	"[boolean adjustForTimeCompression]", 
+	"Gets how long this frame is calculated to take. Use it to for animations, physics, etc to make incremental changes.", 
+	"number", "Frame time (seconds)", 
+	gameversion::version(20, 2, 0, 0),
+	"Please use getRealFrametime() or getTimeCompressedFrametime() instead.")
 {
 	bool b=false;
 	ade_get_args(L, "|b", &b);

--- a/code/scripting/api/libs/base.cpp
+++ b/code/scripting/api/libs/base.cpp
@@ -229,7 +229,17 @@ ADE_FUNC(getFrametimeOverall, l_Base, NULL, "The overall frame time in seconds s
 	return ade_set_args(L, "x", game_get_overall_frametime());
 }
 
-ADE_FUNC(getFrametime, l_Base, "[boolean adjustForTimeCompression]", "Gets how long this frame is calculated to take. Use it to for animations, physics, etc to make incremental changes.", "number", "Frame time (seconds)")
+ADE_FUNC(getTimeCompressedFrametime, l_Base, NULL, "Gets how long this frame is calculated to take. Use it to for animations, physics, etc to make incremental changes. Increased or decreased based on current time compression", "number", "Frame time (seconds)")
+{
+	return ade_set_args(L, "f", flFrametime);
+}
+
+ADE_FUNC(getRealFrametime, l_Base, NULL, "Gets how long this frame is calculated to take in real time. Not affected by time compression.", "number", "Frame time (seconds)")
+{
+	return ade_set_args(L, "f", flRealframetime);
+}
+
+ADE_FUNC(getFrametime, l_Base, "[boolean adjustForTimeCompression]", "Gets how long this frame is calculated to take. Use it to for animations, physics, etc to make incremental changes. DEPRECATED, due a mistake in the documentaion.", "number", "Frame time (seconds)")
 {
 	bool b=false;
 	ade_get_args(L, "|b", &b);

--- a/code/scripting/api/libs/base.cpp
+++ b/code/scripting/api/libs/base.cpp
@@ -229,7 +229,7 @@ ADE_FUNC(getFrametimeOverall, l_Base, NULL, "The overall frame time in seconds s
 	return ade_set_args(L, "x", game_get_overall_frametime());
 }
 
-ADE_FUNC(getTimeCompressedFrametime, l_Base, nullptr, "Gets how long this frame is calculated to take. Use it to for animations, physics, etc to make incremental changes. Increased or decreased based on current time compression", "number", "Frame time (seconds)")
+ADE_FUNC(getMissionFrametime, l_Base, nullptr, "Gets how long this frame is calculated to take. Use it to for animations, physics, etc to make incremental changes. Increased or decreased based on current time compression", "number", "Frame time (seconds)")
 {
 	return ade_set_args(L, "f", flFrametime);
 }
@@ -244,7 +244,7 @@ ADE_FUNC_DEPRECATED(getFrametime, l_Base,
 	"Gets how long this frame is calculated to take. Use it to for animations, physics, etc to make incremental changes.", 
 	"number", "Frame time (seconds)", 
 	gameversion::version(20, 2, 0, 0),
-	"Please use getRealFrametime() or getTimeCompressedFrametime() instead.")
+	"The parameter of this function is inverted from the naming (passing true returns non-adjusted time). Please use either getMissionFrametime() or getRealFrametime().")
 {
 	bool b=false;
 	ade_get_args(L, "|b", &b);


### PR DESCRIPTION
The documention stating of its optional parameter `[boolean adjustForTimeCompression]` is inverse of what the function actually does, setting this to true will give you the real frametime, instead. So per @asarium's suggestion, I've deprecated the old function in favor of two separate functions for each kind of frametime. I'm still not super happy with this approach, but I'm not sure how else to handle it.

IF YOU HAVE ANY SCRIPTS USING THIS YOU MAY WANT TO DOUBLE CHECK ITS IMPLEMENTATION.
getFrametime(true) -> Real frametime.
getFrametime(false or omitted) -> time compressed frametime.

EDIT: This is the crux of #2364 