### PR TITLE
Add some new afterburner options

### DIFF
--- a/code/ship/afterburner.cpp
+++ b/code/ship/afterburner.cpp
@@ -89,7 +89,7 @@ void afterburners_start(object *objp)
 
 	int now = timer_get_milliseconds();
 
-	if (now - shipp->afterburner_last_end_time < (int)(sip->afterburner_min_time_to_restart * 1000.0f)) {
+	if (now - shipp->afterburner_last_end_time < (int)(sip->afterburner_cooldown_time * 1000.0f)) {
 
 		if ((objp->flags[Object::Object_Flags::Player_ship]) && (objp == Player_obj))
 			snd_play(gamesnd_get_game_sound(ship_get_sound(objp, GameSounds::ABURN_FAIL)));
@@ -123,7 +123,7 @@ void afterburners_start(object *objp)
 	}
 
 	// Check if there is enough afterburner fuel
-	if ( (shipp->afterburner_fuel < sip->afterburner_min_fuel_to_start) && !MULTIPLAYER_CLIENT ) {
+	if ( (shipp->afterburner_fuel < sip->afterburner_min_start_fuel) && !MULTIPLAYER_CLIENT ) {
 		if ( objp == Player_obj ) {
 			snd_play( gamesnd_get_game_sound(ship_get_sound(objp, GameSounds::ABURN_FAIL)) );
 		}
@@ -246,8 +246,8 @@ void afterburners_update(object *objp, float fl_frametime)
 				afterburners_stop(objp);
 				return;
 			} // if the ship had to burn a certain amount of fuel, and it did so and isn't still trying to afterburn, stop it
-			else if (!(shipp->flags[Ship::Ship_Flags::Attempting_to_afterburn]) && sip->afterburner_min_fuel_to_consume > 0.0f &&
-				shipp->afterburner_last_engage_fuel - shipp->afterburner_fuel > sip->afterburner_min_fuel_to_consume) {
+			else if (!(shipp->flags[Ship::Ship_Flags::Attempting_to_afterburn]) && sip->afterburner_min_fuel_to_burn > 0.0f &&
+				shipp->afterburner_last_engage_fuel - shipp->afterburner_fuel > sip->afterburner_min_fuel_to_burn) {
 				afterburners_stop(objp);
 				return;
 			}
@@ -318,8 +318,8 @@ void afterburners_stop(object *objp, int key_released)
 
 	// if they need to burn a certain a amount of fuel but haven't done so, dont let them stop unless they have no fuel
 	// the removal of the above flag will turn it off later
-	if (shipp->afterburner_fuel > 0.0f && sip->afterburner_min_fuel_to_consume > 0.0f && 
-		shipp->afterburner_last_engage_fuel - shipp->afterburner_fuel < sip->afterburner_min_fuel_to_consume)
+	if (shipp->afterburner_fuel > 0.0f && sip->afterburner_min_fuel_to_burn > 0.0f && 
+		shipp->afterburner_last_engage_fuel - shipp->afterburner_fuel < sip->afterburner_min_fuel_to_burn)
 		return;
 
 	if ( !(objp->phys_info.flags & PF_AFTERBURNER_ON) ) {

--- a/code/ship/afterburner.cpp
+++ b/code/ship/afterburner.cpp
@@ -85,7 +85,9 @@ void afterburners_start(object *objp)
 		return;
 	}
 
-	unsigned int now = timer_get_milliseconds();
+	shipp->flags.set(Ship::Ship_Flags::Attempting_to_afterburn);
+
+	int now = timer_get_milliseconds();
 
 	if (now - shipp->afterburner_last_end_time < (int)(sip->afterburner_min_time_to_restart * 1000.0f)) {
 
@@ -128,7 +130,6 @@ void afterburners_start(object *objp)
 		return;
 	}
 
-	shipp->flags.set(Ship::Ship_Flags::Attempting_to_afterburn);
 	shipp->afterburner_last_engage_fuel = shipp->afterburner_fuel;
 
 	objp->phys_info.flags |= PF_AFTERBURNER_ON;

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -116,6 +116,10 @@ extern int splodeingtexture;
 
 #define SHIP_REPAIR_SUBSYSTEM_RATE	0.01f
 
+// The minimum required fuel to engage afterburners
+static const float DEFAULT_MIN_AFTERBURNER_FUEL_TO_ENGAGE = 10.0f;
+
+
 int	Ai_render_debug_flag=0;
 #ifndef NDEBUG
 int	Ship_auto_repair = 1;		// flag to indicate auto-repair of subsystem should occur
@@ -975,6 +979,9 @@ void ship_info::clone(const ship_info& other)
 	afterburner_recover_rate = other.afterburner_recover_rate;
 	afterburner_max_reverse_vel = other.afterburner_max_reverse_vel;
 	afterburner_reverse_accel = other.afterburner_reverse_accel;
+	afterburner_min_fuel_to_start = other.afterburner_min_fuel_to_start;
+	afterburner_min_fuel_to_consume = other.afterburner_min_fuel_to_consume;
+	afterburner_min_time_to_restart = other.afterburner_min_time_to_restart;
 
 	cmeasure_type = other.cmeasure_type;
 	cmeasure_max = other.cmeasure_max;
@@ -1266,6 +1273,9 @@ void ship_info::move(ship_info&& other)
 	afterburner_recover_rate = other.afterburner_recover_rate;
 	afterburner_max_reverse_vel = other.afterburner_max_reverse_vel;
 	afterburner_reverse_accel = other.afterburner_reverse_accel;
+	afterburner_min_fuel_to_start = other.afterburner_min_fuel_to_start;
+	afterburner_min_fuel_to_consume = other.afterburner_min_fuel_to_consume;
+	afterburner_min_time_to_restart = other.afterburner_min_time_to_restart;
 
 	cmeasure_type = other.cmeasure_type;
 	cmeasure_max = other.cmeasure_max;
@@ -1646,6 +1656,9 @@ ship_info::ship_info()
 	afterburner_recover_rate = 0.0f;
 	afterburner_max_reverse_vel = 0.0f;
 	afterburner_reverse_accel = 0.0f;
+	afterburner_min_fuel_to_start = DEFAULT_MIN_AFTERBURNER_FUEL_TO_ENGAGE;
+	afterburner_min_fuel_to_consume = 0.0f;
+	afterburner_min_time_to_restart = 0.0f;
 
 	cmeasure_type = Default_cmeasure_index;
 	cmeasure_max = 0;
@@ -3727,6 +3740,18 @@ static void parse_ship_values(ship_info* sip, const bool is_template, const bool
 
 		if(optional_string("+Aburn Rec Rate:")) {
 			stuff_float(&sip->afterburner_recover_rate);
+		}
+
+		if (optional_string("+Aburn Min Fuel to Start:")) {
+			stuff_float(&sip->afterburner_min_fuel_to_start);
+		}
+
+		if (optional_string("+Aburn Min Fuel to Consume:")) {
+			stuff_float(&sip->afterburner_min_fuel_to_consume);
+		}
+
+		if (optional_string("+Aburn Min Time to Restart:")) {
+			stuff_float(&sip->afterburner_min_time_to_restart);
 		}
 
 		if (!(sip->afterburner_fuel_capacity) ) {
@@ -6066,6 +6091,8 @@ void ship::clear()
 	reinforcement_index = -1;
 	
 	afterburner_fuel = 0.0f;
+	afterburner_last_engage_fuel = 0.0f;
+	afterburner_last_end_time = 0;
 
 	cmeasure_count = 0;
 	current_cmeasure = -1;

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -979,9 +979,9 @@ void ship_info::clone(const ship_info& other)
 	afterburner_recover_rate = other.afterburner_recover_rate;
 	afterburner_max_reverse_vel = other.afterburner_max_reverse_vel;
 	afterburner_reverse_accel = other.afterburner_reverse_accel;
-	afterburner_min_fuel_to_start = other.afterburner_min_fuel_to_start;
-	afterburner_min_fuel_to_consume = other.afterburner_min_fuel_to_consume;
-	afterburner_min_time_to_restart = other.afterburner_min_time_to_restart;
+	afterburner_min_start_fuel = other.afterburner_min_start_fuel;
+	afterburner_min_fuel_to_burn = other.afterburner_min_fuel_to_burn;
+	afterburner_cooldown_time = other.afterburner_cooldown_time;
 
 	cmeasure_type = other.cmeasure_type;
 	cmeasure_max = other.cmeasure_max;
@@ -1273,9 +1273,9 @@ void ship_info::move(ship_info&& other)
 	afterburner_recover_rate = other.afterburner_recover_rate;
 	afterburner_max_reverse_vel = other.afterburner_max_reverse_vel;
 	afterburner_reverse_accel = other.afterburner_reverse_accel;
-	afterburner_min_fuel_to_start = other.afterburner_min_fuel_to_start;
-	afterburner_min_fuel_to_consume = other.afterburner_min_fuel_to_consume;
-	afterburner_min_time_to_restart = other.afterburner_min_time_to_restart;
+	afterburner_min_start_fuel = other.afterburner_min_start_fuel;
+	afterburner_min_fuel_to_burn = other.afterburner_min_fuel_to_burn;
+	afterburner_cooldown_time = other.afterburner_cooldown_time;
 
 	cmeasure_type = other.cmeasure_type;
 	cmeasure_max = other.cmeasure_max;
@@ -1656,9 +1656,9 @@ ship_info::ship_info()
 	afterburner_recover_rate = 0.0f;
 	afterburner_max_reverse_vel = 0.0f;
 	afterburner_reverse_accel = 0.0f;
-	afterburner_min_fuel_to_start = DEFAULT_MIN_AFTERBURNER_FUEL_TO_ENGAGE;
-	afterburner_min_fuel_to_consume = 0.0f;
-	afterburner_min_time_to_restart = 0.0f;
+	afterburner_min_start_fuel = DEFAULT_MIN_AFTERBURNER_FUEL_TO_ENGAGE;
+	afterburner_min_fuel_to_burn = 0.0f;
+	afterburner_cooldown_time = 0.0f;
 
 	cmeasure_type = Default_cmeasure_index;
 	cmeasure_max = 0;
@@ -3742,16 +3742,16 @@ static void parse_ship_values(ship_info* sip, const bool is_template, const bool
 			stuff_float(&sip->afterburner_recover_rate);
 		}
 
-		if (optional_string("+Aburn Min Fuel to Start:")) {
-			stuff_float(&sip->afterburner_min_fuel_to_start);
+		if (optional_string("+Aburn Minimum Start Fuel:")) {
+			stuff_float(&sip->afterburner_min_start_fuel);
 		}
 
-		if (optional_string("+Aburn Min Fuel to Consume:")) {
-			stuff_float(&sip->afterburner_min_fuel_to_consume);
+		if (optional_string("+Aburn Minimum Fuel to Burn:")) {
+			stuff_float(&sip->afterburner_min_fuel_to_burn);
 		}
 
-		if (optional_string("+Aburn Min Time to Restart:")) {
-			stuff_float(&sip->afterburner_min_time_to_restart);
+		if (optional_string("+Aburn Cooldown Time:")) {
+			stuff_float(&sip->afterburner_cooldown_time);
 		}
 
 		if (!(sip->afterburner_fuel_capacity) ) {

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -574,7 +574,9 @@ public:
 	int	reinforcement_index;				// index into reinforcement struct or -1
 	
 	float	afterburner_fuel;					// amount of afterburner fuel remaining (capacity is stored
-													// as afterburner_fuel_capacity in ship_info).
+												// as afterburner_fuel_capacity in ship_info).
+	float   afterburner_last_engage_fuel;      // the fuel level when the afterburners were last engaged
+	int   afterburner_last_end_time;         // timestamp when the ship last stopped its afterburner
 
 	int cmeasure_count;						//	Number of charges of countermeasures this ship can hold.
 	int current_cmeasure;					//	Currently selected countermeasure.
@@ -1135,6 +1137,9 @@ public:
 	float		afterburner_fuel_capacity;		// maximum afterburner fuel that can be stored
 	float		afterburner_burn_rate;			// rate in fuel/second that afterburner consumes fuel
 	float		afterburner_recover_rate;		//	rate in fuel/second that afterburner recovers fuel
+	float       afterburner_min_fuel_to_start;  // must have at least this much fuel to start
+	float       afterburner_min_fuel_to_consume;// consumes at least this much fuel before allowing to stop
+	float       afterburner_min_time_to_restart;// minimum time between last afterburner finish and next start
 	//SparK: reverse afterburner
 	float		afterburner_max_reverse_vel;
 	float		afterburner_reverse_accel;

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -1137,9 +1137,9 @@ public:
 	float		afterburner_fuel_capacity;		// maximum afterburner fuel that can be stored
 	float		afterburner_burn_rate;			// rate in fuel/second that afterburner consumes fuel
 	float		afterburner_recover_rate;		//	rate in fuel/second that afterburner recovers fuel
-	float       afterburner_min_fuel_to_start;  // must have at least this much fuel to start
-	float       afterburner_min_fuel_to_consume;// consumes at least this much fuel before allowing to stop
-	float       afterburner_min_time_to_restart;// minimum time between last afterburner finish and next start
+	float       afterburner_min_start_fuel;     // must have at least this much fuel to start
+	float       afterburner_min_fuel_to_burn;   // consumes at least this much fuel before allowing to stop
+	float       afterburner_cooldown_time;      // minimum time between last afterburner finish and next start
 	//SparK: reverse afterburner
 	float		afterburner_max_reverse_vel;
 	float		afterburner_reverse_accel;

--- a/code/ship/ship_flags.h
+++ b/code/ship/ship_flags.h
@@ -121,6 +121,7 @@ namespace Ship {
 		Render_without_light,
 		Render_without_weapons,		// The_E -- Skip weapon model rendering
 		Has_display_name,			// Goober5000
+		Attempting_to_afterburn,    // set and unset by afterburner_start and stop, used by afterburner_min_fuel_to_consume
 
 		NUM_VALUES
 


### PR DESCRIPTION
Exposes minimum fuel to afterburn, and allows specifying a minimum time between aferburnings and a requisite amount of fuel to burn, which will continue on its own until it is consumed.

Closes #2867 