### PR TITLE
Two fixes to weapon states

### DIFF
--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -4876,25 +4876,7 @@ static void weapon_set_state(weapon_info* wip, weapon* wp, WeaponState state)
 		return;
 	}
 
-	auto current_state = wp->weapon_state;
-
 	wp->weapon_state = state;
-
-	if (current_state == WeaponState::INVALID)
-	{
-		// First weapon state, create the in-flight effect
-		auto map_entry = wip->state_effects.find(WeaponState::NORMAL);
-
-		if (map_entry != wip->state_effects.end())
-		{
-			auto source = particle::ParticleManager::get()->createSource(map_entry->second);
-
-			source.moveToObject(&Objects[wp->objnum], &vmd_zero_vector);
-			source.setWeaponState(WeaponState::NORMAL);
-
-			source.finish();
-		}
-	}
 
 	auto map_entry = wip->state_effects.find(wp->weapon_state);
 
@@ -4929,7 +4911,7 @@ static void weapon_update_state(weapon* wp)
 			infree_flight = true;
 		}
 		else if (lifetime >= fl2f(wip->free_flight_time) &&
-			(lifetime - Frametime) <= fl2f(wip->free_flight_time) && wp->homing_object != nullptr)
+			(lifetime - Frametime) <= fl2f(wip->free_flight_time) && wp->homing_object != &obj_used_list)
 		{
 			weapon_set_state(wip, wp, WeaponState::IGNITION);
 			infree_flight = true;
@@ -4938,7 +4920,7 @@ static void weapon_update_state(weapon* wp)
 
 	if (!infree_flight)
 	{
-		if (wp->homing_object == nullptr)
+		if (wp->homing_object == &obj_used_list)
 		{
 			weapon_set_state(wip, wp, WeaponState::UNHOMED_FLIGHT);
 		}

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -4910,7 +4910,7 @@ static void weapon_update_state(weapon* wp)
 			weapon_set_state(wip, wp, WeaponState::FREEFLIGHT);
 			infree_flight = true;
 		}
-		else if (lifetime >= fl2f(wip->free_flight_time) &&
+		else if (lifetime >= fl2f(wip->free_flight_time) &&        // V indicates a valid homing_objp V
 			(lifetime - Frametime) <= fl2f(wip->free_flight_time) && wp->homing_object != &obj_used_list)
 		{
 			weapon_set_state(wip, wp, WeaponState::IGNITION);
@@ -4919,7 +4919,7 @@ static void weapon_update_state(weapon* wp)
 	}
 
 	if (!infree_flight)
-	{
+	{    // V same here; means no homing_objp V
 		if (wp->homing_object == &obj_used_list)
 		{
 			weapon_set_state(wip, wp, WeaponState::UNHOMED_FLIGHT);


### PR DESCRIPTION
When the weapon state is changed for the purposes of creating particle sources, while switching to the new one it checks if the old one was `WeaponState::INVALID` and if so attempts to create a `WeaponState::NORMAL` particle source. Given that the normal, not-invalid case creates a new source for the new state directly afterwards anyway, this is redundant and causes NORMAL weapon states (that is, particles spawned by primaries) to have double the particle sources.

Additionally an invalid `wp->homing_object` is `&obj_used_list` and not `nullptr`, this was causing all dumbfired missiles to not create any particle sources at all.