### PR TITLE
Fix a bug with model animation

### DIFF
--- a/code/model/modelanim.cpp
+++ b/code/model/modelanim.cpp
@@ -810,7 +810,7 @@ int model_anim_get_time_type(ship_subsys *pss, AnimationTriggerType animation_ty
 			} else {
 				// if it isn't moving then it's trivial.
 				// no currently playing animation
-				ani_time = 0;
+				ani_time = psub->triggers[i].end + psub->triggers[i].start;
 			}
 
 			if (ret < ani_time)


### PR DESCRIPTION
Even after some investigation, it was pretty difficult to for me to try and pry apart the model animation code and properly diagnose this. I stumbled on this merely by walking back changes in #2195 , which was confirmed to be the cause of #2882 . I've checked out other animations, mostly those from BP ships, and all of them continue to function normally after this change, and if anyone can think of any other cases, I'd be happy to test those as well.

The relevant code seems to be returning the total time of an animation, and in the problem case `psub->triggers[i].end + psub->triggers[i].start` was 9000, 9 seconds total, rather than 0. The other cases, such as the BP ships also go through this code without problem with or without this change so I'm not really sure what the root cause of the issue was, but given it critically broke a soon-to-be-released campaign, I figured making it go away promptly while not breaking anything else was the best way to go.