### PR TITLE
Allow Fred to Manually Adjust Squadron Wings When Some Are Not Present

### DIFF
--- a/fred2/missionsave.cpp
+++ b/fred2/missionsave.cpp
@@ -2438,24 +2438,35 @@ int CFred_mission_save::save_mission_info()
 			fout(")");
 		}
 
-		// We are now always writing squadron wings to avoid a multi bug where, if the mission designer skips one of the squadron wings
+		// We are now always writing multi squadron wings to avoid a multi bug where, if the mission designer skips one of the squadron wings
 		// it would disappear from the mission
-		fout("\n$Squadron wing names: ( ");
+		if (The_mission.game_type & MISSION_TYPE_MULTI) {
+			fout("\n$Squadron wing names: ( ");
 
-		SCP_vector<int> undefined_wings;
-		for (i = 0; i < MAX_SQUADRON_WINGS; i++) {
-			if (is_wing_defined(Squadron_wing_names[i])) {
-				fout("\"%s\" ", Squadron_wing_names[i]);
-			} else {
-				undefined_wings.push_back(i);
+			SCP_vector<int> undefined_wings;
+			for (i = 0; i < MAX_SQUADRON_WINGS; i++) {
+				if (is_wing_defined(Squadron_wing_names[i])) {
+					fout("\"%s\" ", Squadron_wing_names[i]);
+				} else {
+					undefined_wings.push_back(i);
+				}
+			}
+
+			for (auto & undefined_wing : undefined_wings){
+				fout("\"%s\" ", Squadron_wing_names[undefined_wing]);
+			}
+
+			fout(")");
+		} // otherwise, do what we always used to do, output only if they are not the default.
+		else if (strcmp(Squadron_wing_names[0], "Alpha") || strcmp(Squadron_wing_names[1], "Beta") || strcmp(Squadron_wing_names[2], "Gamma") || strcmp(Squadron_wing_names[3], "Delta") || strcmp(Squadron_wing_names[4], "Epsilon")) {
+			{
+				fout("\n$Squadron wing names: ( ");
+				for (i = 0; i < MAX_SQUADRON_WINGS; i++) {
+					fout("\"%s\" ", Squadron_wing_names[i]);
+				}
+				fout(")");
 			}
 		}
-
-		for (auto & undefined_wing : undefined_wings){
-			fout("\"%s\" ", Squadron_wing_names[undefined_wing]);
-		}
-
-		fout(")");
 
 		// tvt wings
 		if (strcmp(TVT_wing_names[0], "Alpha") || strcmp(TVT_wing_names[1], "Zeta")) {

--- a/fred2/missionsave.cpp
+++ b/fred2/missionsave.cpp
@@ -2439,7 +2439,7 @@ int CFred_mission_save::save_mission_info()
 		}
 
 		// We are now always writing multi squadron wings to avoid a multi bug where, if the mission designer skips one of the squadron wings
-		// it would disappear from the mission
+		// the wing after would disappear from the mission
 		if (The_mission.game_type & MISSION_TYPE_MULTI) {
 			fout("\n$Squadron wing names: ( ");
 

--- a/fred2/missionsave.cpp
+++ b/fred2/missionsave.cpp
@@ -51,6 +51,9 @@
 
 #include <freespace.h>
 
+// quick helper function
+bool is_wing_defined(char* wing_name);
+
 int CFred_mission_save::autosave_mission_file(char *pathname)
 {
 	char backup_name[256], name2[256];
@@ -2435,16 +2438,24 @@ int CFred_mission_save::save_mission_info()
 			fout(")");
 		}
 
-		// squadron wings
-		if (strcmp(Squadron_wing_names[0], "Alpha") || strcmp(Squadron_wing_names[1], "Beta") || strcmp(Squadron_wing_names[2], "Gamma") || strcmp(Squadron_wing_names[3], "Delta") || strcmp(Squadron_wing_names[4], "Epsilon")) {
-			fout("\n$Squadron wing names: ( ");
+		// We are now always writing squadron wings to avoid a multi bug where, if the mission designer skips one of the squadron wings
+		// it would disappear from the mission
+		fout("\n$Squadron wing names: ( ");
 
-			for (i = 0; i < MAX_SQUADRON_WINGS; i++) {
+		SCP_vector<int> undefined_wings;
+		for (i = 0; i < MAX_SQUADRON_WINGS; i++) {
+			if (is_wing_defined(Squadron_wing_names[i])) {
 				fout("\"%s\" ", Squadron_wing_names[i]);
+			} else {
+				undefined_wings.push_back(i);
 			}
-
-			fout(")");
 		}
+
+		for (auto & undefined_wing : undefined_wings){
+			fout("\"%s\" ", Squadron_wing_names[undefined_wing]);
+		}
+
+		fout(")");
 
 		// tvt wings
 		if (strcmp(TVT_wing_names[0], "Alpha") || strcmp(TVT_wing_names[1], "Zeta")) {
@@ -4348,3 +4359,15 @@ int CFred_mission_save::save_wings()
 	Assert(count == Num_wings);
 	return err;
 }
+
+// quick helper function to check if a wing is currently defined.
+bool is_wing_defined(char* wing_name)
+{
+	for (auto& wing : Wings) {
+		if (!strcmp(wing_name, wing.name)) {
+			return true;
+		}
+	}
+	return false;
+}
+


### PR DESCRIPTION
In order to avoid a multi bug that would be a lot of work to fix properly (reworking the entire way that multi handles loadouts), this adjusts the Fred saving function to, at first, ignore unused wings in the Squadron Wings array.  It then sets those missing names at the end of the list so that the slots can be set correctly during mission initialization.