### PR TITLE
Replace multicast code with mDNS/DNS-SD

### DIFF
--- a/code/CMakeLists.txt
+++ b/code/CMakeLists.txt
@@ -52,6 +52,8 @@ endif()
 
 target_link_libraries(code PUBLIC parsers)
 
+target_link_libraries(code PUBLIC mdns)
+
 enable_clang_tidy(code)
 
 IF (FSO_USE_SPEECH)

--- a/code/globalincs/toolchain/msvc.h
+++ b/code/globalincs/toolchain/msvc.h
@@ -82,11 +82,16 @@
 /**
  * @brief Suppresses all warnings and allows to pop back to normal afterwards
  */
-#define PUSH_SUPPRESS_WARNINGS
+#define PUSH_SUPPRESS_WARNINGS \
+__pragma(warning( push )) \
+__pragma(warning( disable : 4244 )) \
+__pragma(warning( disable : 4505 )) \
+__pragma(warning( disable : 4189 ))
 
 /**
  * @brief Restored previous warning settings
  */
-#define POP_SUPPRESS_WARNINGS
+#define POP_SUPPRESS_WARNINGS \
+__pragma(warning( pop ))
 
 #endif

--- a/code/network/multi.cpp
+++ b/code/network/multi.cpp
@@ -52,6 +52,7 @@
 #include "pilotfile/pilotfile.h"
 #include "debugconsole/console.h"
 #include "network/psnet2.h"
+#include "network/multi_mdns.h"
 
 // Stupid windows workaround...
 #ifdef MessageBox
@@ -1325,6 +1326,9 @@ void multi_do_frame()
 	// if master then maybe do port forwarding setup/refresh/wait
 	if (Net_player->flags & NETINFO_FLAG_AM_MASTER) {
 		multi_port_forward_do();
+
+		// do mdns stuff here too
+		multi_mdns_service_do();
 	}
 }
 
@@ -1425,6 +1429,9 @@ void multi_pause_do_frame()
 	// if master then maybe do port forwarding setup/refresh/wait
 	if (Net_player->flags & NETINFO_FLAG_AM_MASTER) {
 		multi_port_forward_do();
+
+		// do mdns stuff here too
+		multi_mdns_service_do();
 	}
 }
 
@@ -1554,6 +1561,9 @@ void standalone_main_init()
 	// setup port forwarding
 	multi_port_forward_init();
 
+	// setup mdns
+	multi_mdns_service_init();
+
 	// login to game tracker
 	std_tracker_login();
 
@@ -1593,6 +1603,9 @@ void standalone_main_do()
 
    // process/renew port mapping
    multi_port_forward_do();
+
+   // handle mdns messages
+   multi_mdns_service_do();
 }
 
 // --------------------------------------------------------------------------------
@@ -1608,6 +1621,9 @@ void standalone_main_close()
 
 	// remove port forwarding
 	multi_port_forward_close();
+
+	// stop mdns
+	multi_mdns_service_close();
 }
 
 void multi_standalone_reset_all()

--- a/code/network/multi.cpp
+++ b/code/network/multi.cpp
@@ -1328,7 +1328,9 @@ void multi_do_frame()
 		multi_port_forward_do();
 
 		// do mdns stuff here too
-		multi_mdns_service_do();
+		if ( !MULTI_IS_TRACKER_GAME && (Net_player->p_info.options.flags & MLO_FLAG_LOCAL_BROADCAST) ) {
+			multi_mdns_service_do();
+		}
 	}
 }
 
@@ -1431,7 +1433,9 @@ void multi_pause_do_frame()
 		multi_port_forward_do();
 
 		// do mdns stuff here too
-		multi_mdns_service_do();
+		if ( !MULTI_IS_TRACKER_GAME && (Net_player->p_info.options.flags & MLO_FLAG_LOCAL_BROADCAST) ) {
+			multi_mdns_service_do();
+		}
 	}
 }
 
@@ -1562,7 +1566,9 @@ void standalone_main_init()
 	multi_port_forward_init();
 
 	// setup mdns
-	multi_mdns_service_init();
+	if ( !MULTI_IS_TRACKER_GAME ) {
+		multi_mdns_service_init();
+	}
 
 	// login to game tracker
 	std_tracker_login();
@@ -1604,8 +1610,10 @@ void standalone_main_do()
    // process/renew port mapping
    multi_port_forward_do();
 
-   // handle mdns messages
-   multi_mdns_service_do();
+	// handle mdns messages
+	if ( !MULTI_IS_TRACKER_GAME ) {
+		multi_mdns_service_do();
+	}
 }
 
 // --------------------------------------------------------------------------------

--- a/code/network/multi_endgame.cpp
+++ b/code/network/multi_endgame.cpp
@@ -25,6 +25,7 @@
 #include "network/multi_portfwd.h"
 #include "hud/hudconfig.h"
 #include "network/multi_fstracker.h"
+#include "network/multi_mdns.h"
 
 
 // ----------------------------------------------------------------------------------------------------------
@@ -377,6 +378,9 @@ void multi_endgame_cleanup()
 
 		// stop port forwarding
 		multi_port_forward_close();
+
+		// stop mdns
+		multi_mdns_service_close();
 
 		// if we're in Parallax Online mode, log back in there	
 		if (Multi_options_g.pxo == 1) {

--- a/code/network/multi_mdns.cpp
+++ b/code/network/multi_mdns.cpp
@@ -6,13 +6,15 @@
 #include <arpa/inet.h>
 #endif
 
-#include "mdns.h"
-
 #include "globalincs/pstypes.h"
 #include "network/psnet2.h"
 #include "network/multimsgs.h"
 #include "network/multi_log.h"
 #include "network/multi_mdns.h"
+
+PUSH_SUPPRESS_WARNINGS
+#include "mdns.h"
+POP_SUPPRESS_WARNINGS
 
 
 static const SCP_string SERVICE_NAME = "_fso._hard-light._udp.local.";
@@ -73,13 +75,13 @@ static int service_callback(int sock, const struct sockaddr* from, size_t addrle
 		// check for special discovery record and reply accordingly
 		const SCP_string dns_sd = "_services._dns-sd._udp.local.";
 
-		if ( (service.length == dns_sd.size()) && !dns_sd.compare(service.str) ) {
+		if ( (service.length == dns_sd.size()) && (dns_sd == service.str) ) {
 			mdns_discovery_answer(sock, from, addrlen, BUFFER.data(), BUFFER.size(), SERVICE_NAME.c_str(), SERVICE_NAME.size());
 			return 0;
 		}
 
 		// ignore anything not meant for us
-		if ( (service.length != SERVICE_NAME.size()) || SERVICE_NAME.compare(service.str) ) {
+		if ( (service.length != SERVICE_NAME.size()) || !(SERVICE_NAME == service.str) ) {
 			return 0;
 		}
 
@@ -198,7 +200,7 @@ void multi_mdns_query_do()
 			timeout.tv_usec = 0;
 
 			FD_ZERO(&read_fds);
-			FD_SET(sock, &read_fds);
+			FD_SET(static_cast<SOCKET>(sock), &read_fds);
 
 			if ( select(sock+1, &read_fds, nullptr, nullptr, &timeout) == SOCKET_ERROR ) {
 				break;
@@ -284,7 +286,7 @@ void multi_mdns_service_do()
 			timeout.tv_usec = 0;
 
 			FD_ZERO(&read_fds);
-			FD_SET(sock, &read_fds);
+			FD_SET(static_cast<SOCKET>(sock), &read_fds);
 
 			if ( select(sock+1, &read_fds, nullptr, nullptr, &timeout) == SOCKET_ERROR ) {
 				break;

--- a/code/network/multi_mdns.cpp
+++ b/code/network/multi_mdns.cpp
@@ -1,0 +1,305 @@
+
+#ifdef _WIN32
+#include <winsock2.h>
+#else
+#include <netdb.h>
+#include <arpa/inet.h>
+#endif
+
+#include "mdns.h"
+
+#include "globalincs/pstypes.h"
+#include "network/psnet2.h"
+#include "network/multimsgs.h"
+#include "network/multi_log.h"
+#include "network/multi_mdns.h"
+
+
+static const SCP_string SERVICE_NAME = "_fso._hard-light._udp.local.";
+static SCP_string HOST_NAME = "fs2open";
+
+static SCP_vector<int> mSockets;
+
+static in_addr IPv4_addr;
+static bool has_ipv4 = false;
+static uint8_t IPv6_addr[sizeof(in6_addr)];
+static bool has_ipv6 = false;
+
+
+static int query_callback(int sock __UNUSED, const struct sockaddr *from __UNUSED, size_t addrlen __UNUSED, mdns_entry_type_t entry __UNUSED,
+							   uint16_t query_id __UNUSED, uint16_t rtype, uint16_t rclass __UNUSED, uint32_t ttl __UNUSED, const void *data,
+							   size_t size, size_t name_offset __UNUSED, size_t name_length __UNUSED, size_t record_offset,
+							   size_t record_length, void *user_data)
+{
+	SOCKADDR_IN in4;
+	SOCKADDR_IN6 sockaddr;
+	auto *addr = reinterpret_cast<net_addr *>(user_data);
+
+	if (rtype == MDNS_RECORDTYPE_SRV) {
+		std::array<char, 256> NAME_BUFFER{};
+		mdns_record_srv_t svr = mdns_record_parse_srv(data, size, record_offset, record_length, NAME_BUFFER.data(), NAME_BUFFER.size());
+
+		addr->port = svr.port;
+	} else if (rtype == MDNS_RECORDTYPE_A) {
+		mdns_record_parse_a(data, size, record_offset, record_length, &in4);
+
+		psnet_map4to6(&in4.sin_addr, &sockaddr.sin6_addr);
+		memcpy(&addr->addr, &sockaddr.sin6_addr, sizeof(addr->addr));
+	}
+	// if we have both A and AAAA records, prefer A
+	else if ( (rtype == MDNS_RECORDTYPE_AAAA) && !IN6_IS_ADDR_UNSPECIFIED(reinterpret_cast<in6_addr *>(&addr->addr)) ) {
+		mdns_record_parse_aaaa(data, size, record_offset, record_length, &sockaddr);
+
+		memcpy(&addr->addr, &sockaddr.sin6_addr, sizeof(addr->addr));
+	}
+
+	return 0;
+}
+
+static int service_callback(int sock, const struct sockaddr* from, size_t addrlen, mdns_entry_type_t entry,
+							uint16_t query_id, uint16_t rtype, uint16_t rclass, uint32_t ttl __UNUSED, const void* data,
+							size_t size, size_t name_offset __UNUSED, size_t name_length __UNUSED, size_t record_offset,
+							size_t record_length, void* user_data __UNUSED)
+{
+	if (entry != MDNS_ENTRYTYPE_QUESTION) {
+		return 0;
+	}
+
+	std::array<char, 256> BUFFER{};
+
+	if (rtype == MDNS_RECORDTYPE_PTR) {
+		mdns_string_t service = mdns_record_parse_ptr(data, size, record_offset, record_length, BUFFER.data(), BUFFER.size());
+
+		// check for special discovery record and reply accordingly
+		const SCP_string dns_sd = "_services._dns-sd._udp.local.";
+
+		if ( (service.length == dns_sd.size()) && !dns_sd.compare(service.str) ) {
+			mdns_discovery_answer(sock, from, addrlen, BUFFER.data(), BUFFER.size(), SERVICE_NAME.c_str(), SERVICE_NAME.size());
+			return 0;
+		}
+
+		// ignore anything not meant for us
+		if ( (service.length != SERVICE_NAME.size()) || SERVICE_NAME.compare(service.str) ) {
+			return 0;
+		}
+
+		uint16_t unicast = (rclass & MDNS_UNICAST_RESPONSE);
+
+		// this one call will send all required records
+		mdns_query_answer(sock, from, (unicast) ? addrlen : 0, BUFFER.data(), BUFFER.size(), query_id,
+						  SERVICE_NAME.c_str(), SERVICE_NAME.size(), HOST_NAME.c_str(), HOST_NAME.size(),
+						  has_ipv4 ? IPv4_addr.s_addr : 0, has_ipv6 ? IPv6_addr : nullptr,
+						  Psnet_default_port, nullptr, 0);
+	}
+
+	return 0;
+}
+
+static void close_mdns_sockets()
+{
+	for (auto &sock : mSockets) {
+		mdns_socket_close(sock);
+	}
+
+	mSockets.clear();
+}
+
+static bool open_mdns_sockets(bool add_addr = false)
+{
+	const int ip_mode = psnet_get_ip_mode();
+	int sock;
+
+	if ( !mSockets.empty() ) {
+		close_mdns_sockets();
+	}
+
+	if (ip_mode & PSNET_IP_MODE_V4) {
+		SOCKADDR_IN saddr;
+
+		if (add_addr) {
+			memset(&saddr, 0, sizeof(saddr));
+
+			saddr.sin_family = AF_INET;
+			saddr.sin_addr.s_addr = INADDR_ANY;
+			saddr.sin_port = htons(MDNS_PORT);
+		}
+
+		sock = mdns_socket_open_ipv4(add_addr ? &saddr : nullptr);
+
+		if (sock >= 0) {
+			mSockets.push_back(sock);
+		}
+	}
+
+	if (ip_mode & PSNET_IP_MODE_V6) {
+		SOCKADDR_IN6 saddr;
+
+		if (add_addr) {
+			memset(&saddr, 0, sizeof(saddr));
+
+			saddr.sin6_family = AF_INET6;
+			saddr.sin6_addr = in6addr_any;
+			saddr.sin6_port = htons(MDNS_PORT);
+		}
+
+		sock = mdns_socket_open_ipv6(add_addr ? &saddr : nullptr);
+
+		if (sock >= 0) {
+			mSockets.push_back(sock);
+		}
+	}
+
+	return !mSockets.empty();
+}
+
+
+bool multi_mdns_query()
+{
+	size_t failed = 0;
+
+	if ( !open_mdns_sockets() ) {
+		return false;
+	}
+
+	std::array<uint8_t, 2048> buffer{};
+
+	for (auto &sock : mSockets) {
+		int rval = mdns_query_send(sock, MDNS_RECORDTYPE_PTR, SERVICE_NAME.c_str(),
+								   SERVICE_NAME.size(), buffer.data(), buffer.size(), 0);
+
+		if (rval < 0) {
+			ml_printf("Failed to send mDNS query: %s\n", strerror(errno));
+			++failed;
+		}
+	}
+
+	if (failed == mSockets.size()) {
+		multi_mdns_query_close();
+		return false;
+	}
+
+	return true;
+}
+
+void multi_mdns_query_do()
+{
+	if (mSockets.empty()) {
+		return;
+	}
+
+	struct timeval timeout;
+	fd_set read_fds;
+	std::array<uint8_t, 2048> buffer{};
+	net_addr addr;
+
+	for (auto &sock : mSockets) {
+		do {
+			timeout.tv_sec = 0;
+			timeout.tv_usec = 0;
+
+			FD_ZERO(&read_fds);
+			FD_SET(sock, &read_fds);
+
+			if ( select(sock+1, &read_fds, nullptr, nullptr, &timeout) == SOCKET_ERROR ) {
+				break;
+			}
+
+			if ( !FD_ISSET(sock, &read_fds) ) {
+				break;
+			}
+
+			memset(&addr, 0, sizeof(net_addr));
+
+			mdns_query_recv(sock, buffer.data(), buffer.size(), query_callback, &addr, 0);
+
+			if ( (addr.port == 0) || IN6_IS_ADDR_UNSPECIFIED(reinterpret_cast<in6_addr *>(&addr.addr)) ) {
+				continue;
+			}
+
+			send_server_query(&addr);
+		} while (true);
+	}
+}
+
+void multi_mdns_query_close()
+{
+	close_mdns_sockets();
+}
+
+bool multi_mdns_service_init()
+{
+	if ( !open_mdns_sockets(true) ) {
+		return false;
+	}
+
+	// setup local ip info
+	IPv4_addr.s_addr = INADDR_ANY;
+	memset(&IPv6_addr, 0, sizeof(IPv6_addr));
+
+	has_ipv4 = false;
+	has_ipv6 = false;
+
+	int ip_mode = psnet_get_ip_mode();
+
+	if (ip_mode & PSNET_IP_MODE_V4) {
+		auto *in6 = psnet_get_local_ip(AF_INET);
+
+		if (in6 && psnet_map6to4(in6, &IPv4_addr)) {
+			has_ipv4 = true;
+		}
+	}
+
+	if (ip_mode & PSNET_IP_MODE_V6) {
+		auto in6 = psnet_get_local_ip(AF_INET6);
+
+		if (in6) {
+			memcpy(&IPv6_addr, in6, sizeof(in6_addr));
+			has_ipv6 = true;
+		}
+	}
+
+	// setup hostname
+	std::array<char, 256> hostname{};
+
+	if ( !gethostname(hostname.data(), static_cast<int>(hostname.size())) ) {
+		HOST_NAME = hostname.data();
+	}
+
+	return true;
+}
+
+void multi_mdns_service_do()
+{
+	if (mSockets.empty()) {
+		return;
+	}
+
+	struct timeval timeout;
+	fd_set read_fds;
+	std::array<uint8_t, 2048> buffer{};
+
+	for (auto &sock : mSockets) {
+		do {
+			timeout.tv_sec = 0;
+			timeout.tv_usec = 0;
+
+			FD_ZERO(&read_fds);
+			FD_SET(sock, &read_fds);
+
+			if ( select(sock+1, &read_fds, nullptr, nullptr, &timeout) == SOCKET_ERROR ) {
+				break;
+			}
+
+			if ( !FD_ISSET(sock, &read_fds) ) {
+				break;
+			}
+
+			mdns_socket_listen(sock, buffer.data(), buffer.size(), service_callback, nullptr);
+		} while (true);
+	}
+}
+
+void multi_mdns_service_close()
+{
+	close_mdns_sockets();
+}

--- a/code/network/multi_mdns.h
+++ b/code/network/multi_mdns.h
@@ -1,0 +1,12 @@
+#ifndef MULTI_MDNS_H
+#define MULTI_MDNS_H
+
+bool multi_mdns_query();
+void multi_mdns_query_do();
+void multi_mdns_query_close();
+
+bool multi_mdns_service_init();
+void multi_mdns_service_do();
+void multi_mdns_service_close();
+
+#endif

--- a/code/network/multimsgs.cpp
+++ b/code/network/multimsgs.cpp
@@ -73,6 +73,7 @@
 #include "network/multi_fstracker.h"
 #include "network/multi_sw.h"
 #include "network/multi_sexp.h"
+#include "network/multi_mdns.h"
 
 // #define _MULTI_SUPER_WACKY_COMPRESSION
 
@@ -2248,9 +2249,7 @@ void process_netgame_descript_packet( ubyte *data, header *hinfo )
 // broadcast a query for active games. TCP will either request from the MT or from the specified list
 void broadcast_game_query()
 {
-	int packet_size;
 	server_item *s_moveup;
-	ubyte data[MAX_PACKET_SIZE];
 
 	if (MULTI_IS_TRACKER_GAME) {
 		// check with MT
@@ -2269,8 +2268,7 @@ void broadcast_game_query()
 
 	// send out a broadcast if our options allow us
 	if(Net_player->p_info.options.flags & MLO_FLAG_LOCAL_BROADCAST){
-		BUILD_HEADER(GAME_QUERY);
-		psnet_broadcast(data, packet_size);
+		multi_mdns_query();
 	}
 }
 

--- a/code/network/multiui.cpp
+++ b/code/network/multiui.cpp
@@ -68,6 +68,7 @@
 #include "network/multi_sw.h"
 #include "menuui/mainhallmenu.h"
 #include "debugconsole/console.h"
+#include "network/multi_mdns.h"
 
 #include <algorithm>
 
@@ -1114,7 +1115,10 @@ void multi_join_game_close()
 
 	// free up the active game list
 	multi_free_active_games();
-	
+
+	// cancel mdns queries
+	multi_mdns_query_close();
+
 	// destroy the UI_WINDOW
 	Multi_join_window.destroy();
 }
@@ -1500,6 +1504,11 @@ void multi_join_do_netstuff()
 		} else {
 			Multi_join_glr_stamp = timestamp(MULTI_JOIN_REFRESH_TIME);
 		}		
+	}
+
+	// if we're doing local broadcast then check broadcast queries
+	if (Net_player->p_info.options.flags & MLO_FLAG_LOCAL_BROADCAST) {
+		multi_mdns_query_do();
 	}
 
 	// check to see if we've been accepted.  If so, put up message saying so
@@ -4119,6 +4128,9 @@ void multi_create_init_as_server()
 
 	// setup port forwarding
 	multi_port_forward_init();
+
+	// setup mdns
+	multi_mdns_service_init();
 }
 
 // if on a standalone

--- a/code/network/multiui.cpp
+++ b/code/network/multiui.cpp
@@ -1507,7 +1507,7 @@ void multi_join_do_netstuff()
 	}
 
 	// if we're doing local broadcast then check broadcast queries
-	if (Net_player->p_info.options.flags & MLO_FLAG_LOCAL_BROADCAST) {
+	if ( !MULTI_IS_TRACKER_GAME && (Net_player->p_info.options.flags & MLO_FLAG_LOCAL_BROADCAST) ) {
 		multi_mdns_query_do();
 	}
 
@@ -4130,7 +4130,9 @@ void multi_create_init_as_server()
 	multi_port_forward_init();
 
 	// setup mdns
-	multi_mdns_service_init();
+	if ( !MULTI_IS_TRACKER_GAME && (Net_player->p_info.options.flags & MLO_FLAG_LOCAL_BROADCAST) ) {
+		multi_mdns_service_init();
+	}
 }
 
 // if on a standalone

--- a/code/network/psnet2.cpp
+++ b/code/network/psnet2.cpp
@@ -45,27 +45,15 @@
 net_addr Psnet_my_addr;
 static SCP_vector<in6_addr> Psnet_my_ip;
 
-#define PSNET_IP_MODE_UNKNOWN	0
-#define PSNET_IP_MODE_V4		1
-#define PSNET_IP_MODE_V6		2
-#define PSNET_IP_MODE_DUAL		3
-
 static int Psnet_ip_mode = PSNET_IP_MODE_UNKNOWN;
 
 static bool Psnet_active = false;
-static bool Can_broadcast = false;
 
 static int Network_status;
 int Psnet_failure_code = 0;
 int Psnet_connection;
 
 uint16_t Psnet_default_port;
-
-// stuff for multicast
-static SOCKET Psnet_mcast_socket = INVALID_SOCKET;
-static SOCKADDR_STORAGE Psnet_mcast_addr;
-#define PSNET_MCAST_DEST		"224.1.2.3"
-#define PSNET_MCAST_DEST_IP6	"ff12::6673:325f:6f70:656e"
 
 // defines and variables to indicate network connection status
 #define NETWORK_STATUS_NOT_INITIALIZED	1
@@ -208,10 +196,6 @@ bool psnet_init_socket();
 
 // initilize my addr
 bool psnet_init_my_addr();
-
-// multicast stuff
-bool psnet_init_multicast();
-void psnet_multicast_process();
 
 // get time in seconds
 float psnet_get_time();
@@ -356,9 +340,6 @@ void PSNET_TOP_LAYER_PROCESS()
 		return;
 	}
 
-	// grab any multicast data too
-	psnet_multicast_process();
-
 	// clear the addresses to remove compiler warnings
 	memset(&from_addr, 0, sizeof(from_addr));
 
@@ -457,13 +438,6 @@ void psnet_init(uint16_t port_num)
 		return;
 	}
 
-	Can_broadcast = false;
-
-	if ( psnet_init_multicast() ) {
-		ml_string("Multicast setup complete");
-		Can_broadcast = true;
-	}
-
 	psnet_init_rel_tcp();
 
 	Psnet_active = true;
@@ -491,11 +465,6 @@ void psnet_close()
 	// send a disconnect to any remote machines
 	psnet_rel_close();
 
-	if (Psnet_mcast_socket != INVALID_SOCKET) {
-		shutdown(Psnet_mcast_socket, 1);
-		closesocket(Psnet_mcast_socket);
-	}
-
 	if (Psnet_socket != INVALID_SOCKET) {
 		shutdown(Psnet_socket, 1);
 		closesocket(Psnet_socket);
@@ -503,7 +472,6 @@ void psnet_close()
 
 	Psnet_active = false;
 	Network_status = NETWORK_STATUS_NOT_INITIALIZED;
-	Can_broadcast = false;
 
 #ifdef _WIN32
 	WSACleanup();
@@ -785,6 +753,14 @@ bool psnet_is_local_addr(const net_addr *addr)
 }
 
 /**
+ * Get IP mode (IPv4, IPv6, dual stack...)
+ */
+int psnet_get_ip_mode()
+{
+	return Psnet_ip_mode;
+}
+
+/**
  * Send data unreliably
  */
 int psnet_send(net_addr *who_to_addr, void *data, int len, int np_index)	// NOLINT(misc-unused-parameters)
@@ -869,26 +845,6 @@ int psnet_get(void *data, net_addr *addr)
 }
 
 /**
- * Broadcast data on multicast socket
- */
-int psnet_broadcast(void *data, int len)
-{
-	if ( !Can_broadcast ) {
-		return 0;
-	}
-
-	int ret = SENDTO(Psnet_mcast_socket, reinterpret_cast<char *>(data), len, 0,
-				reinterpret_cast<LPSOCKADDR>(&Psnet_mcast_addr), sizeof(Psnet_mcast_addr),
-				PSNET_TYPE_UNRELIABLE);
-
-	if (ret == SOCKET_ERROR) {
-		return 0;
-	}
-
-	return 1;
-}
-
-/**
  * Flush all sockets
  */
 void psnet_flush()
@@ -957,6 +913,20 @@ void psnet_map4to6(const in_addr *in4, in6_addr *in6)
 		reinterpret_cast<uint32_t *>(in6)[2] = htonl(0xffff);
 		reinterpret_cast<uint32_t *>(in6)[3] = in4->s_addr;
 	}
+}
+
+/**
+ * Helper to map IPv6 to IPv4
+ */
+bool psnet_map6to4(const in6_addr *in6, in_addr *in4)
+{
+	if ( !IN6_IS_ADDR_V4MAPPED(in6) ) {
+		return false;
+	}
+
+	in4->s_addr = reinterpret_cast<const uint32_t *>(in6)[3];
+
+	return true;
 }
 
 /**
@@ -1157,11 +1127,11 @@ bool psnet_get_addr(const char *host, const char *port, SOCKADDR_STORAGE *addr, 
 			hints.ai_flags |= AI_NUMERICHOST;
 		}
 		// skip AAAA lookups if we can't use them
-		else if (Psnet_ip_mode == PSNET_IP_MODE_V4) {
+		else if ( !(Psnet_ip_mode & PSNET_IP_MODE_V6) ) {
 			hints.ai_family = AF_INET;
 		}
 		// skip A lookups if we can't use them
-		else if (Psnet_ip_mode == PSNET_IP_MODE_V6) {
+		else if ( !(Psnet_ip_mode & PSNET_IP_MODE_V4) ) {
 			hints.ai_family = AF_INET6;
 		}
 	}
@@ -1217,6 +1187,34 @@ bool psnet_get_addr(const char *host, const uint16_t port, SOCKADDR_STORAGE *add
 	SCP_string port_str = std::to_string(port);
 
 	return psnet_get_addr(host, port_str.c_str(), addr, flags | ADDR_FLAG_NUMERIC_SERVICE);
+}
+
+const in6_addr *psnet_get_local_ip(int af_type)
+{
+	switch (af_type) {
+		case AF_INET: {
+			if (Psnet_ip_mode == PSNET_IP_MODE_DUAL) {
+				return &Psnet_my_ip[1];
+			} else if (Psnet_ip_mode & PSNET_IP_MODE_V4) {
+				return &Psnet_my_ip[0];
+			}
+
+			break;
+		}
+
+		case AF_INET6: {
+			if (Psnet_ip_mode & PSNET_IP_MODE_V6) {
+				return &Psnet_my_ip[0];
+			}
+
+			break;
+		}
+
+		default:
+			break;
+	}
+
+	return nullptr;
 }
 
 // -------------------------------------------------------------------------------------------------------
@@ -2256,224 +2254,6 @@ bool psnet_init_socket()
 
 	// success
 	return true;
-}
-
-static bool psnet_multicast_get_addr(int af, const char *host, const char *port, SOCKADDR_STORAGE *addr)
-{
-	struct addrinfo hints, *srvinfo = nullptr;
-	bool success = false;
-	int rval;
-
-	memset(&hints, 0, sizeof(hints));
-
-	hints.ai_family = af;
-	hints.ai_socktype = SOCK_DGRAM;
-
-	if (host == nullptr) {
-		hints.ai_flags |= AI_PASSIVE;
-	} else {
-		hints.ai_flags |= AI_NUMERICHOST;
-	}
-
-	if (port != nullptr) {
-		hints.ai_flags |= AI_NUMERICSERV;
-	}
-
-	if ( (rval = getaddrinfo(host, port, &hints, &srvinfo)) != 0 ) {
-		ml_printf("Multicast getadinfo() => %s", gai_strerror(rval));
-
-		if (srvinfo) {
-			freeaddrinfo(srvinfo);
-		}
-
-		return false;
-	}
-
-	for (auto *srv = srvinfo; srv != nullptr; srv = srv->ai_next) {
-		if ( (srv->ai_family == AF_INET) || (srv->ai_family == AF_INET6) ) {
-			memcpy(addr, srv->ai_addr, srv->ai_addrlen);
-
-			success = true;
-
-			break;
-		}
-	}
-
-	if (srvinfo) {
-		freeaddrinfo(srvinfo);
-	}
-
-	return success;
-}
-
-bool psnet_init_multicast()
-{
-	int family = AF_INET6;
-	int option;
-	const SCP_string port_str = std::to_string(DEFAULT_GAME_PORT + 10000);
-	SOCKADDR_STORAGE listenAddr, groupAddr;
-
-	if (Psnet_ip_mode == PSNET_IP_MODE_UNKNOWN) {
-		return false;
-	}
-
-	// drop to IPv4 multicast if we are mapped
-	if (Psnet_ip_mode == PSNET_IP_MODE_V4) {
-		family = AF_INET;
-	}
-
-	Psnet_mcast_socket = socket(family, SOCK_DGRAM, IPPROTO_UDP);
-
-	if (Psnet_mcast_socket == INVALID_SOCKET) {
-		ml_printf("Error creating multicast socket %d", WSAGetLastError());
-		return false;
-	}
-
-	// reuse socket, in case we're running multiple instances
-	option = 1;
-	if ( setsockopt(Psnet_mcast_socket, SOL_SOCKET, SO_REUSEADDR, reinterpret_cast<const char *>(&option), sizeof(option)) ) {
-		ml_printf("Unable to set multicast reuse addr option (%d)", WSAGetLastError());
-		return false;
-	}
-
-	// fill listen addr
-	psnet_multicast_get_addr(family, nullptr, port_str.c_str(), &listenAddr);
-
-	if ( bind(Psnet_mcast_socket, reinterpret_cast<LPSOCKADDR>(&listenAddr), sizeof(listenAddr)) == SOCKET_ERROR ) {
-		ml_printf("Couldn't bind multicast socket (%d)!", WSAGetLastError());
-		return false;
-	}
-
-	if (family == AF_INET6) {
-		// disable data loopback
-		option = 0;
-		if ( setsockopt(Psnet_mcast_socket, IPPROTO_IPV6, IPV6_MULTICAST_LOOP, reinterpret_cast<const char *>(&option), sizeof(option)) ) {
-			ml_printf("Unable to set multicast loop option (%d)", WSAGetLastError());
-			return false;
-		}
-
-		// set interface
-		unsigned int iface = 0;	// any
-		if ( setsockopt(Psnet_mcast_socket, IPPROTO_IPV6, IPV6_MULTICAST_IF, reinterpret_cast<const char *>(&iface), sizeof(iface)) ) {
-			ml_printf("Unable to set multicast interface option (%d)", WSAGetLastError());
-			return false;
-		}
-
-		// fill destination addr (sending)
-		psnet_multicast_get_addr(family, PSNET_MCAST_DEST_IP6, port_str.c_str(), &Psnet_mcast_addr);
-
-		// join multicast group
-		psnet_multicast_get_addr(family, PSNET_MCAST_DEST_IP6, nullptr, &groupAddr);
-		auto *sa6 = reinterpret_cast<SOCKADDR_IN6 *>(&groupAddr);
-
-		struct ipv6_mreq mRequest;
-		memcpy(&mRequest.ipv6mr_multiaddr, &sa6->sin6_addr, sizeof(in6_addr));
-		mRequest.ipv6mr_interface = 0;	// any
-
-		if ( setsockopt(Psnet_mcast_socket, IPPROTO_IPV6, IPV6_JOIN_GROUP, reinterpret_cast<const char *>(&mRequest), sizeof(mRequest)) ) {
-			ml_printf("Unable to set multicast membership option (%d)", WSAGetLastError());
-			return false;
-		}
-	} else {
-		Assert(family == AF_INET);
-
-		// disable data loopback
-		option = 0;
-		if ( setsockopt(Psnet_mcast_socket, IPPROTO_IP, IP_MULTICAST_LOOP, reinterpret_cast<const char *>(&option), sizeof(option)) ) {
-			ml_printf("Unable to set multicast loop option (%d)", WSAGetLastError());
-			return false;
-		}
-
-		// set interface
-		uint32_t iface = INADDR_ANY;
-		if ( setsockopt(Psnet_mcast_socket, IPPROTO_IP, IP_MULTICAST_IF, reinterpret_cast<const char *>(&iface), sizeof(iface)) ) {
-			ml_printf("Unable to set multicast interface option (%d)", WSAGetLastError());
-			return false;
-		}
-
-		// fill destination addr (sending)
-		psnet_multicast_get_addr(family, PSNET_MCAST_DEST, port_str.c_str(), &Psnet_mcast_addr);
-
-		// join multicast group
-		psnet_multicast_get_addr(family, PSNET_MCAST_DEST, nullptr, &groupAddr);
-		auto *sa4 = reinterpret_cast<SOCKADDR_IN *>(&groupAddr);
-
-		struct ip_mreq mRequest;
-		memcpy(&mRequest.imr_multiaddr, &sa4->sin_addr, sizeof(in_addr));
-		mRequest.imr_interface.s_addr = htonl(INADDR_ANY);
-
-		if ( setsockopt(Psnet_mcast_socket, IPPROTO_IP, IP_ADD_MEMBERSHIP, reinterpret_cast<const char *>(&mRequest), sizeof(mRequest)) ) {
-			ml_printf("Unable to set multicast membership option (%d)", WSAGetLastError());
-			return false;
-		}
-	}
-
-	return true;
-}
-
-void psnet_multicast_process()
-{
-	fd_set readfds;
-	timeval timeout;
-	SOCKADDR_STORAGE from_addr;
-	SOCKADDR_IN6 from_addr6;
-	socklen_t from_len;
-	SSIZE_T read_len;
-	uint8_t packet_data[MAX_TOP_LAYER_PACKET_SIZE];
-
-	if ( !Can_broadcast ) {
-		return;
-	}
-
-	FD_ZERO(&readfds);
-	FD_SET(Psnet_mcast_socket, &readfds);
-
-	timeout.tv_sec = 0;
-	timeout.tv_usec = 0;
-
-	if ( select(static_cast<int>(Psnet_mcast_socket + 1), &readfds, nullptr, nullptr, &timeout) == SOCKET_ERROR ) {
-		ml_printf("Error %d doing a multicast socket select", WSAGetLastError());
-		return;
-	}
-
-	if ( !FD_ISSET(Psnet_mcast_socket, &readfds) ) {
-		return;
-	}
-
-	from_len = sizeof(from_addr);
-	read_len = recvfrom(Psnet_mcast_socket, reinterpret_cast<char *>(packet_data), sizeof(packet_data),
-						0, reinterpret_cast<LPSOCKADDR>(&from_addr), &from_len);
-
-	if (read_len <= 0) {
-		if (read_len == SOCKET_ERROR) {
-			ml_string("Error getting multicast socket data %d", WSAGetLastError());
-		}
-
-		return;
-	}
-
-	if (from_addr.ss_family == AF_INET6) {
-		memcpy(&from_addr6, &from_addr, sizeof(from_addr6));
-	} else if (from_addr.ss_family == AF_INET) {
-		auto *sa4 = reinterpret_cast<SOCKADDR_IN *>(&from_addr);
-
-		memset(&from_addr6, 0, sizeof(from_addr6));
-
-		psnet_map4to6(&sa4->sin_addr, &from_addr6.sin6_addr);
-		from_addr6.sin6_port = sa4->sin_port;
-	} else {
-		Int3();
-		return;
-	}
-
-	// determine the packet_type
-	int packet_type = packet_data[0];
-	Assertion(( (packet_type >= 0) && (packet_type < PSNET_NUM_TYPES) ), "Invalid packet_type found. Packet type %d does not exist", packet_type);
-
-	if ( (packet_type >= 0) && (packet_type < PSNET_NUM_TYPES) ) {
-		// buffer the packet
-		psnet_buffer_packet(&Psnet_top_buffers[packet_type], packet_data + 1, read_len - 1, &from_addr6);
-	}
 }
 
 /**

--- a/code/network/psnet2.h
+++ b/code/network/psnet2.h
@@ -104,6 +104,11 @@ extern SOCKET Psnet_socket;	// all PXO API modules should use this to send and r
 
 extern unsigned int Serverconn;
 
+#define PSNET_IP_MODE_UNKNOWN	0
+#define PSNET_IP_MODE_V4		(1<<0)
+#define PSNET_IP_MODE_V6		(1<<1)
+#define PSNET_IP_MODE_DUAL		(PSNET_IP_MODE_V4|PSNET_IP_MODE_V6)
+
 // -------------------------------------------------------------------------------------------------------
 // PSNET 2 TOP LAYER FUNCTIONS - these functions simply buffer and store packets based upon type (see PSNET_TYPE_* defines)
 //
@@ -157,9 +162,6 @@ int psnet_send(net_addr *who_to, void *data, int len, int np_index = -1);
 // get data from the unreliable socket
 int psnet_get(void *data, net_addr *from_addr);
 
-// broadcast data on unreliable socket
-int psnet_broadcast(void *data, int len);
-
 // flush all sockets
 void psnet_flush();
 
@@ -179,8 +181,15 @@ bool psnet_get_addr(const char *host, uint16_t port, SOCKADDR_STORAGE *addr, int
 // map an IPv4 address to IPv6
 void psnet_map4to6(const in_addr *in4, in6_addr *in6);
 
+// map an IPv4-mapped IPv6 address to IPv4
+bool psnet_map6to4(const in6_addr *in6, in_addr *in4);
+
 // anonymize address for logging
 in6_addr *psnet_mask_addr(const in6_addr *inaddr);
+
+const in6_addr *psnet_get_local_ip(int af_type);
+
+int psnet_get_ip_mode();
 
 // -------------------------------------------------------------------------------------------------------
 // PSNET 2 RELIABLE SOCKET FUNCTIONS

--- a/code/source_groups.cmake
+++ b/code/source_groups.cmake
@@ -821,6 +821,8 @@ add_file_folder("Network"
 	network/multi_kick.h
 	network/multi_log.cpp
 	network/multi_log.h
+	network/multi_mdns.cpp
+	network/multi_mdns.h
 	network/multi_obj.cpp
 	network/multi_obj.h
 	network/multi_observer.cpp

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -46,3 +46,5 @@ endif()
 include(antlr4.cmake)
 
 include(vulkan.cmake)
+
+add_subdirectory(mdns)

--- a/lib/mdns/CMakeLists.txt
+++ b/lib/mdns/CMakeLists.txt
@@ -1,0 +1,3 @@
+add_library(mdns INTERFACE)
+
+target_include_directories(mdns SYSTEM INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}")

--- a/lib/mdns/LICENSE
+++ b/lib/mdns/LICENSE
@@ -1,0 +1,24 @@
+This is free and unencumbered software released into the public domain.
+
+Anyone is free to copy, modify, publish, use, compile, sell, or
+distribute this software, either in source code form or as a compiled
+binary, for any purpose, commercial or non-commercial, and by any
+means.
+
+In jurisdictions that recognize copyright laws, the author or authors
+of this software dedicate any and all copyright interest in the
+software to the public domain. We make this dedication for the benefit
+of the public at large and to the detriment of our heirs and
+successors. We intend this dedication to be an overt act of
+relinquishment in perpetuity of all present and future rights to this
+software under copyright law.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+For more information, please refer to <http://unlicense.org>

--- a/lib/mdns/README.md
+++ b/lib/mdns/README.md
@@ -1,0 +1,80 @@
+# Public domain mDNS/DNS-SD library in C
+
+This library provides a header only cross-platform mDNS and DNS-DS library in C. The latest source code is always available at
+
+https://github.com/mjansson/mdns
+
+This library is put in the public domain; you can redistribute it and/or modify it without any restrictions.
+
+Created by Mattias Jansson ([@maniccoder](https://twitter.com/maniccoder))
+
+## Features
+
+The library does DNS-SD discovery and service as well as one-shot single record mDNS query and response. There are no memory allocations done by the library, all buffers used must be passed in by the caller. Custom data for use in processing can be passed along using a user data opaque pointer.
+
+## Usage
+
+The `mdns.c` test executable file demonstrates the use of all features, including discovery, query and service response.
+
+### Sockets
+
+Socket for mDNS communication can either be opened by the library by using `mdns_socket_open_ipv4` or `mdns_socket_open_ipv6`, or by initializing an existing socket with `mdns_socket_setup_ipv4` or `mdns_socket_setup_ipv6`. The socket open/setup functions will initialize the socket with multicast membership (including loopback) and set to non-blocking mode.
+
+Call `mdns_socket_close` to close a socket opened with `mdns_socket_open_ipv4` or `mdns_socket_open_ipv6`.
+
+#### Port
+
+To open/setup the socket for one-shot queries you can pass a null pointer socket address, or set the port in the passed socket address to 0. This will bind the socket to a random ephemeral local UDP port as required by the RFCs for one-shot queries.
+
+To open/setup the socket for service, responding to incoming queries, you need pass in a socket address structure with the port set to 5353 (defined by MDNS_PORT in the header).
+
+#### Network interface
+
+To do discovery or queries on the default network interface, you can pass a null pointer as socket address in the socket create/setup functions. This will bind the socket to the default network interface. Otherwise you should enumerate the available interfaces and pass the appropriate socket address to the create/setup function. See the example program in `mdns.c` for an example implementation of doing this for both IPv4 and IPv6.
+
+If you want to do mDNS service response to incoming queries, you do not need to enumerate interfaces to do service response on all interfaces as sockets receive data from all interfaces. See the example program in `mdns.c` for an example of setting up a service socket for both IPv4 and IPv6.
+
+### Discovery
+
+To send a DNS-SD service discovery request use `mdns_discovery_send`. This will send a single multicast packet (single PTR question record for `_services._dns-sd._udp.local.`) requesting a unicast response.
+
+To read discovery responses use `mdns_discovery_recv`. All records received since last call will be piped to the callback supplied in the function call. The entry type will be one of `MDNS_ENTRYTYPE_ANSWER`, `MDNS_ENTRYTYPE_AUTHORITY` and `MDNS_ENTRYTYPE_ADDITIONAL`.
+
+### Query
+
+To send a one-shot mDNS query for a single record use `mdns_query_send`. This will send a single multicast packet for the given record (single PTR question record, for example `_http._tcp.local.`). You can optionally pass in a query ID for the query for later filtering of responses (even though this is discouraged by the RFC), or pass 0 to be fully compliant. The function returns the query ID associated with this query, which if non-zero can be used to filter responses in `mdns_query_recv`. If the socket is bound to port 5353 a multicast response is requested, otherwise a unicast response.
+
+To read query responses use `mdns_query_recv`. All records received since last call will be piped to the callback supplied in the function call. If `query_id` parameter is non-zero the function will filter out any response with a query ID that does not match the given query ID. The entry type will be one of `MDNS_ENTRYTYPE_ANSWER`, `MDNS_ENTRYTYPE_AUTHORITY` and `MDNS_ENTRYTYPE_ADDITIONAL`.
+
+### Service
+
+To listen for incoming DNS-SD requests and mDNS queries the socket can be opened/setup on the default interface by passing 0 as socket address in the call to the socket open/setup functions (the socket will receive data from all network interfaces). Then call `mdns_socket_listen` either on notification of incoming data, or by setting blocking mode and calling `mdns_socket_listen` to block until data is available and parsed.
+
+The entry type passed to the callback will be `MDNS_ENTRYTYPE_QUESTION` and record type `MDNS_RECORDTYPE_PTR`. Use the `mdns_record_parse_ptr` function to get the name string of the service record that was asked for.
+
+If service record name is `_services._dns-sd._udp.local.` you should use `mdns_discovery_answer` to send the records of the services you provide (DNS-SD).
+
+If the service record name is a service you provide, use `mdns_query_answer` to send the service details back in response to the query.
+
+See the test executable implementation for more details on how to handle the parameters to the given functions.
+
+## Test executable
+The `mdns.c` file contains a test executable implementation using the library to do DNS-SD and mDNS queries. Compile into an executable and run to see command line options for discovery, query and service modes.
+
+### Windows
+
+#### Microsoft compiler
+`cl mdns.c /Zi /Fdmdns.pdb /link /out:mdns.exe ws2_32.lib iphlpapi.lib`
+
+### Linux
+
+#### GCC
+`gcc -o mdns mdns.c`
+
+#### clang
+`clang -o mdns mdns.c`
+
+## Using with cmake or conan
+
+* use cmake with `FetchContent` or install and `find_package`
+* use conan with dependency name `mdns/20200130`, and `find_package` -> https://conan.io/center/mdns/20200130

--- a/lib/mdns/mdns.c
+++ b/lib/mdns/mdns.c
@@ -1,0 +1,702 @@
+
+#ifdef _WIN32
+#define _CRT_SECURE_NO_WARNINGS 1
+#endif
+
+#include <stdio.h>
+
+#include "mdns.h"
+
+#include <errno.h>
+
+#ifdef _WIN32
+#include <iphlpapi.h>
+#define sleep(x) Sleep(x * 1000)
+#else
+#include <netdb.h>
+#include <ifaddrs.h>
+#endif
+
+static char addrbuffer[64];
+static char entrybuffer[256];
+static char namebuffer[256];
+static char sendbuffer[256];
+static mdns_record_txt_t txtbuffer[128];
+
+static uint32_t service_address_ipv4;
+static uint8_t service_address_ipv6[16];
+
+static int has_ipv4;
+static int has_ipv6;
+
+typedef struct {
+	const char* service;
+	const char* hostname;
+	uint32_t address_ipv4;
+	uint8_t* address_ipv6;
+	int port;
+} service_record_t;
+
+static mdns_string_t
+ipv4_address_to_string(char* buffer, size_t capacity, const struct sockaddr_in* addr,
+                       size_t addrlen) {
+	char host[NI_MAXHOST] = {0};
+	char service[NI_MAXSERV] = {0};
+	int ret = getnameinfo((const struct sockaddr*)addr, (socklen_t)addrlen, host, NI_MAXHOST,
+	                      service, NI_MAXSERV, NI_NUMERICSERV | NI_NUMERICHOST);
+	int len = 0;
+	if (ret == 0) {
+		if (addr->sin_port != 0)
+			len = snprintf(buffer, capacity, "%s:%s", host, service);
+		else
+			len = snprintf(buffer, capacity, "%s", host);
+	}
+	if (len >= (int)capacity)
+		len = (int)capacity - 1;
+	mdns_string_t str;
+	str.str = buffer;
+	str.length = len;
+	return str;
+}
+
+static mdns_string_t
+ipv6_address_to_string(char* buffer, size_t capacity, const struct sockaddr_in6* addr,
+                       size_t addrlen) {
+	char host[NI_MAXHOST] = {0};
+	char service[NI_MAXSERV] = {0};
+	int ret = getnameinfo((const struct sockaddr*)addr, (socklen_t)addrlen, host, NI_MAXHOST,
+	                      service, NI_MAXSERV, NI_NUMERICSERV | NI_NUMERICHOST);
+	int len = 0;
+	if (ret == 0) {
+		if (addr->sin6_port != 0)
+			len = snprintf(buffer, capacity, "[%s]:%s", host, service);
+		else
+			len = snprintf(buffer, capacity, "%s", host);
+	}
+	if (len >= (int)capacity)
+		len = (int)capacity - 1;
+	mdns_string_t str;
+	str.str = buffer;
+	str.length = len;
+	return str;
+}
+
+static mdns_string_t
+ip_address_to_string(char* buffer, size_t capacity, const struct sockaddr* addr, size_t addrlen) {
+	if (addr->sa_family == AF_INET6)
+		return ipv6_address_to_string(buffer, capacity, (const struct sockaddr_in6*)addr, addrlen);
+	return ipv4_address_to_string(buffer, capacity, (const struct sockaddr_in*)addr, addrlen);
+}
+
+static int
+query_callback(int sock, const struct sockaddr* from, size_t addrlen, mdns_entry_type_t entry,
+               uint16_t query_id, uint16_t rtype, uint16_t rclass, uint32_t ttl, const void* data,
+               size_t size, size_t name_offset, size_t name_length, size_t record_offset,
+               size_t record_length, void* user_data) {
+	(void)sizeof(sock);
+	(void)sizeof(query_id);
+	(void)sizeof(name_length);
+	(void)sizeof(user_data);
+	mdns_string_t fromaddrstr = ip_address_to_string(addrbuffer, sizeof(addrbuffer), from, addrlen);
+	const char* entrytype = (entry == MDNS_ENTRYTYPE_ANSWER) ?
+	                            "answer" :
+	                            ((entry == MDNS_ENTRYTYPE_AUTHORITY) ? "authority" : "additional");
+	mdns_string_t entrystr =
+	    mdns_string_extract(data, size, &name_offset, entrybuffer, sizeof(entrybuffer));
+	if (rtype == MDNS_RECORDTYPE_PTR) {
+		mdns_string_t namestr = mdns_record_parse_ptr(data, size, record_offset, record_length,
+		                                              namebuffer, sizeof(namebuffer));
+		printf("%.*s : %s %.*s PTR %.*s rclass 0x%x ttl %u length %d\n",
+		       MDNS_STRING_FORMAT(fromaddrstr), entrytype, MDNS_STRING_FORMAT(entrystr),
+		       MDNS_STRING_FORMAT(namestr), rclass, ttl, (int)record_length);
+	} else if (rtype == MDNS_RECORDTYPE_SRV) {
+		mdns_record_srv_t srv = mdns_record_parse_srv(data, size, record_offset, record_length,
+		                                              namebuffer, sizeof(namebuffer));
+		printf("%.*s : %s %.*s SRV %.*s priority %d weight %d port %d\n",
+		       MDNS_STRING_FORMAT(fromaddrstr), entrytype, MDNS_STRING_FORMAT(entrystr),
+		       MDNS_STRING_FORMAT(srv.name), srv.priority, srv.weight, srv.port);
+	} else if (rtype == MDNS_RECORDTYPE_A) {
+		struct sockaddr_in addr;
+		mdns_record_parse_a(data, size, record_offset, record_length, &addr);
+		mdns_string_t addrstr =
+		    ipv4_address_to_string(namebuffer, sizeof(namebuffer), &addr, sizeof(addr));
+		printf("%.*s : %s %.*s A %.*s\n", MDNS_STRING_FORMAT(fromaddrstr), entrytype,
+		       MDNS_STRING_FORMAT(entrystr), MDNS_STRING_FORMAT(addrstr));
+	} else if (rtype == MDNS_RECORDTYPE_AAAA) {
+		struct sockaddr_in6 addr;
+		mdns_record_parse_aaaa(data, size, record_offset, record_length, &addr);
+		mdns_string_t addrstr =
+		    ipv6_address_to_string(namebuffer, sizeof(namebuffer), &addr, sizeof(addr));
+		printf("%.*s : %s %.*s AAAA %.*s\n", MDNS_STRING_FORMAT(fromaddrstr), entrytype,
+		       MDNS_STRING_FORMAT(entrystr), MDNS_STRING_FORMAT(addrstr));
+	} else if (rtype == MDNS_RECORDTYPE_TXT) {
+		size_t parsed = mdns_record_parse_txt(data, size, record_offset, record_length, txtbuffer,
+		                                      sizeof(txtbuffer) / sizeof(mdns_record_txt_t));
+		for (size_t itxt = 0; itxt < parsed; ++itxt) {
+			if (txtbuffer[itxt].value.length) {
+				printf("%.*s : %s %.*s TXT %.*s = %.*s\n", MDNS_STRING_FORMAT(fromaddrstr),
+				       entrytype, MDNS_STRING_FORMAT(entrystr),
+				       MDNS_STRING_FORMAT(txtbuffer[itxt].key),
+				       MDNS_STRING_FORMAT(txtbuffer[itxt].value));
+			} else {
+				printf("%.*s : %s %.*s TXT %.*s\n", MDNS_STRING_FORMAT(fromaddrstr), entrytype,
+				       MDNS_STRING_FORMAT(entrystr), MDNS_STRING_FORMAT(txtbuffer[itxt].key));
+			}
+		}
+	} else {
+		printf("%.*s : %s %.*s type %u rclass 0x%x ttl %u length %d\n",
+		       MDNS_STRING_FORMAT(fromaddrstr), entrytype, MDNS_STRING_FORMAT(entrystr), rtype,
+		       rclass, ttl, (int)record_length);
+	}
+	return 0;
+}
+
+static int
+service_callback(int sock, const struct sockaddr* from, size_t addrlen, mdns_entry_type_t entry,
+                 uint16_t query_id, uint16_t rtype, uint16_t rclass, uint32_t ttl, const void* data,
+                 size_t size, size_t name_offset, size_t name_length, size_t record_offset,
+                 size_t record_length, void* user_data) {
+	(void)sizeof(name_offset);
+	(void)sizeof(name_length);
+	(void)sizeof(ttl);
+	if (entry != MDNS_ENTRYTYPE_QUESTION)
+		return 0;
+	mdns_string_t fromaddrstr = ip_address_to_string(addrbuffer, sizeof(addrbuffer), from, addrlen);
+	if (rtype == MDNS_RECORDTYPE_PTR) {
+		mdns_string_t service = mdns_record_parse_ptr(data, size, record_offset, record_length,
+		                                              namebuffer, sizeof(namebuffer));
+		printf("%.*s : question PTR %.*s\n", MDNS_STRING_FORMAT(fromaddrstr),
+		       MDNS_STRING_FORMAT(service));
+
+		const char dns_sd[] = "_services._dns-sd._udp.local.";
+		const service_record_t* service_record = (const service_record_t*)user_data;
+		size_t service_length = strlen(service_record->service);
+		if ((service.length == (sizeof(dns_sd) - 1)) &&
+		    (strncmp(service.str, dns_sd, sizeof(dns_sd) - 1) == 0)) {
+			printf("  --> answer %s\n", service_record->service);
+			mdns_discovery_answer(sock, from, addrlen, sendbuffer, sizeof(sendbuffer),
+			                      service_record->service, service_length);
+		} else if ((service.length == service_length) &&
+		           (strncmp(service.str, service_record->service, service_length) == 0)) {
+			uint16_t unicast = (rclass & MDNS_UNICAST_RESPONSE);
+			printf("  --> answer %s.%s port %d (%s)\n", service_record->hostname,
+			       service_record->service, service_record->port,
+			       (unicast ? "unicast" : "multicast"));
+			if (!unicast)
+				addrlen = 0;
+			char txt_record[] = "test=1";
+			mdns_query_answer(sock, from, addrlen, sendbuffer, sizeof(sendbuffer), query_id,
+			                  service_record->service, service_length, service_record->hostname,
+			                  strlen(service_record->hostname), service_record->address_ipv4,
+			                  service_record->address_ipv6, (uint16_t)service_record->port,
+			                  txt_record, sizeof(txt_record));
+		}
+	} else if (rtype == MDNS_RECORDTYPE_SRV) {
+		mdns_record_srv_t service = mdns_record_parse_srv(data, size, record_offset, record_length,
+		                                                  namebuffer, sizeof(namebuffer));
+		printf("%.*s : question SRV %.*s\n", MDNS_STRING_FORMAT(fromaddrstr),
+		       MDNS_STRING_FORMAT(service.name));
+#if 0
+		if ((service.length == service_length) &&
+		    (strncmp(service.str, service_record->service, service_length) == 0)) {
+			uint16_t unicast = (rclass & MDNS_UNICAST_RESPONSE);
+			printf("  --> answer %s.%s port %d (%s)\n", service_record->hostname,
+			       service_record->service, service_record->port,
+			       (unicast ? "unicast" : "multicast"));
+			if (!unicast)
+				addrlen = 0;
+			char txt_record[] = "test=1";
+			mdns_query_answer(sock, from, addrlen, sendbuffer, sizeof(sendbuffer), query_id,
+			                  service_record->service, service_length, service_record->hostname,
+			                  strlen(service_record->hostname), service_record->address_ipv4,
+			                  service_record->address_ipv6, (uint16_t)service_record->port,
+			                  txt_record, sizeof(txt_record));
+		}
+#endif
+	}
+	return 0;
+}
+
+static int
+open_client_sockets(int* sockets, int max_sockets, int port) {
+	// When sending, each socket can only send to one network interface
+	// Thus we need to open one socket for each interface and address family
+	int num_sockets = 0;
+
+#ifdef _WIN32
+
+	IP_ADAPTER_ADDRESSES* adapter_address = 0;
+	ULONG address_size = 8000;
+	unsigned int ret;
+	unsigned int num_retries = 4;
+	do {
+		adapter_address = malloc(address_size);
+		ret = GetAdaptersAddresses(AF_UNSPEC, GAA_FLAG_SKIP_MULTICAST | GAA_FLAG_SKIP_ANYCAST, 0,
+		                           adapter_address, &address_size);
+		if (ret == ERROR_BUFFER_OVERFLOW) {
+			free(adapter_address);
+			adapter_address = 0;
+		} else {
+			break;
+		}
+	} while (num_retries-- > 0);
+
+	if (!adapter_address || (ret != NO_ERROR)) {
+		free(adapter_address);
+		printf("Failed to get network adapter addresses\n");
+		return num_sockets;
+	}
+
+	int first_ipv4 = 1;
+	int first_ipv6 = 1;
+	for (PIP_ADAPTER_ADDRESSES adapter = adapter_address; adapter; adapter = adapter->Next) {
+		if (adapter->TunnelType == TUNNEL_TYPE_TEREDO)
+			continue;
+		if (adapter->OperStatus != IfOperStatusUp)
+			continue;
+
+		for (IP_ADAPTER_UNICAST_ADDRESS* unicast = adapter->FirstUnicastAddress; unicast;
+		     unicast = unicast->Next) {
+			if (unicast->Address.lpSockaddr->sa_family == AF_INET) {
+				struct sockaddr_in* saddr = (struct sockaddr_in*)unicast->Address.lpSockaddr;
+				if ((saddr->sin_addr.S_un.S_un_b.s_b1 != 127) ||
+				    (saddr->sin_addr.S_un.S_un_b.s_b2 != 0) ||
+				    (saddr->sin_addr.S_un.S_un_b.s_b3 != 0) ||
+				    (saddr->sin_addr.S_un.S_un_b.s_b4 != 1)) {
+					int log_addr = 0;
+					if (first_ipv4) {
+						service_address_ipv4 = saddr->sin_addr.S_un.S_addr;
+						first_ipv4 = 0;
+						log_addr = 1;
+					}
+					has_ipv4 = 1;
+					if (num_sockets < max_sockets) {
+						saddr->sin_port = htons((unsigned short)port);
+						int sock = mdns_socket_open_ipv4(saddr);
+						if (sock >= 0) {
+							sockets[num_sockets++] = sock;
+							log_addr = 1;
+						} else {
+							log_addr = 0;
+						}
+					}
+					if (log_addr) {
+						char buffer[128];
+						mdns_string_t addr = ipv4_address_to_string(buffer, sizeof(buffer), saddr,
+						                                            sizeof(struct sockaddr_in));
+						printf("Local IPv4 address: %.*s\n", MDNS_STRING_FORMAT(addr));
+					}
+				}
+			} else if (unicast->Address.lpSockaddr->sa_family == AF_INET6) {
+				struct sockaddr_in6* saddr = (struct sockaddr_in6*)unicast->Address.lpSockaddr;
+				static const unsigned char localhost[] = {0, 0, 0, 0, 0, 0, 0, 0,
+				                                          0, 0, 0, 0, 0, 0, 0, 1};
+				static const unsigned char localhost_mapped[] = {0, 0, 0,    0,    0,    0, 0, 0,
+				                                                 0, 0, 0xff, 0xff, 0x7f, 0, 0, 1};
+				if ((unicast->DadState == NldsPreferred) &&
+				    memcmp(saddr->sin6_addr.s6_addr, localhost, 16) &&
+				    memcmp(saddr->sin6_addr.s6_addr, localhost_mapped, 16)) {
+					int log_addr = 0;
+					if (first_ipv6) {
+						memcpy(service_address_ipv6, &saddr->sin6_addr, 16);
+						first_ipv6 = 0;
+						log_addr = 1;
+					}
+					has_ipv6 = 1;
+					if (num_sockets < max_sockets) {
+						saddr->sin6_port = htons((unsigned short)port);
+						int sock = mdns_socket_open_ipv6(saddr);
+						if (sock >= 0) {
+							sockets[num_sockets++] = sock;
+							log_addr = 1;
+						} else {
+							log_addr = 0;
+						}
+					}
+					if (log_addr) {
+						char buffer[128];
+						mdns_string_t addr = ipv6_address_to_string(buffer, sizeof(buffer), saddr,
+						                                            sizeof(struct sockaddr_in6));
+						printf("Local IPv6 address: %.*s\n", MDNS_STRING_FORMAT(addr));
+					}
+				}
+			}
+		}
+	}
+
+	free(adapter_address);
+
+#else
+
+	struct ifaddrs* ifaddr = 0;
+	struct ifaddrs* ifa = 0;
+
+	if (getifaddrs(&ifaddr) < 0)
+		printf("Unable to get interface addresses\n");
+
+	int first_ipv4 = 1;
+	int first_ipv6 = 1;
+	for (ifa = ifaddr; ifa; ifa = ifa->ifa_next) {
+		if (!ifa->ifa_addr)
+			continue;
+
+		if (ifa->ifa_addr->sa_family == AF_INET) {
+			struct sockaddr_in* saddr = (struct sockaddr_in*)ifa->ifa_addr;
+			if (saddr->sin_addr.s_addr != htonl(INADDR_LOOPBACK)) {
+				int log_addr = 0;
+				if (first_ipv4) {
+					service_address_ipv4 = saddr->sin_addr.s_addr;
+					first_ipv4 = 0;
+					log_addr = 1;
+				}
+				has_ipv4 = 1;
+				if (num_sockets < max_sockets) {
+					saddr->sin_port = htons(port);
+					int sock = mdns_socket_open_ipv4(saddr);
+					if (sock >= 0) {
+						sockets[num_sockets++] = sock;
+						log_addr = 1;
+					} else {
+						log_addr = 0;
+					}
+				}
+				if (log_addr) {
+					char buffer[128];
+					mdns_string_t addr = ipv4_address_to_string(buffer, sizeof(buffer), saddr,
+					                                            sizeof(struct sockaddr_in));
+					printf("Local IPv4 address: %.*s\n", MDNS_STRING_FORMAT(addr));
+				}
+			}
+		} else if (ifa->ifa_addr->sa_family == AF_INET6) {
+			struct sockaddr_in6* saddr = (struct sockaddr_in6*)ifa->ifa_addr;
+			static const unsigned char localhost[] = {0, 0, 0, 0, 0, 0, 0, 0,
+			                                          0, 0, 0, 0, 0, 0, 0, 1};
+			static const unsigned char localhost_mapped[] = {0, 0, 0,    0,    0,    0, 0, 0,
+			                                                 0, 0, 0xff, 0xff, 0x7f, 0, 0, 1};
+			if (memcmp(saddr->sin6_addr.s6_addr, localhost, 16) &&
+			    memcmp(saddr->sin6_addr.s6_addr, localhost_mapped, 16)) {
+				int log_addr = 0;
+				if (first_ipv6) {
+					memcpy(service_address_ipv6, &saddr->sin6_addr, 16);
+					first_ipv6 = 0;
+					log_addr = 1;
+				}
+				has_ipv6 = 1;
+				if (num_sockets < max_sockets) {
+					saddr->sin6_port = htons(port);
+					int sock = mdns_socket_open_ipv6(saddr);
+					if (sock >= 0) {
+						sockets[num_sockets++] = sock;
+						log_addr = 1;
+					} else {
+						log_addr = 0;
+					}
+				}
+				if (log_addr) {
+					char buffer[128];
+					mdns_string_t addr = ipv6_address_to_string(buffer, sizeof(buffer), saddr,
+					                                            sizeof(struct sockaddr_in6));
+					printf("Local IPv6 address: %.*s\n", MDNS_STRING_FORMAT(addr));
+				}
+			}
+		}
+	}
+
+	freeifaddrs(ifaddr);
+
+#endif
+
+	return num_sockets;
+}
+
+static int
+open_service_sockets(int* sockets, int max_sockets) {
+	// When recieving, each socket can recieve data from all network interfaces
+	// Thus we only need to open one socket for each address family
+	int num_sockets = 0;
+
+	// Call the client socket function to enumerate and get local addresses,
+	// but not open the actual sockets
+	open_client_sockets(0, 0, 0);
+
+	if (num_sockets < max_sockets) {
+		struct sockaddr_in sock_addr;
+		memset(&sock_addr, 0, sizeof(struct sockaddr_in));
+		sock_addr.sin_family = AF_INET;
+#ifdef _WIN32
+		sock_addr.sin_addr = in4addr_any;
+#else
+		sock_addr.sin_addr.s_addr = INADDR_ANY;
+#endif
+		sock_addr.sin_port = htons(MDNS_PORT);
+#ifdef __APPLE__
+		sock_addr.sin_len = sizeof(struct sockaddr_in);
+#endif
+		int sock = mdns_socket_open_ipv4(&sock_addr);
+		if (sock >= 0)
+			sockets[num_sockets++] = sock;
+	}
+
+	if (num_sockets < max_sockets) {
+		struct sockaddr_in6 sock_addr;
+		memset(&sock_addr, 0, sizeof(struct sockaddr_in6));
+		sock_addr.sin6_family = AF_INET6;
+		sock_addr.sin6_addr = in6addr_any;
+		sock_addr.sin6_port = htons(MDNS_PORT);
+#ifdef __APPLE__
+		sock_addr.sin6_len = sizeof(struct sockaddr_in6);
+#endif
+		int sock = mdns_socket_open_ipv6(&sock_addr);
+		if (sock >= 0)
+			sockets[num_sockets++] = sock;
+	}
+
+	return num_sockets;
+}
+
+static int
+send_dns_sd(void) {
+	int sockets[32];
+	int num_sockets = open_client_sockets(sockets, sizeof(sockets) / sizeof(sockets[0]), 0);
+	if (num_sockets <= 0) {
+		printf("Failed to open any client sockets\n");
+		return -1;
+	}
+	printf("Opened %d socket%s for DNS-SD\n", num_sockets, num_sockets ? "s" : "");
+
+	printf("Sending DNS-SD discovery\n");
+	for (int isock = 0; isock < num_sockets; ++isock) {
+		if (mdns_discovery_send(sockets[isock]))
+			printf("Failed to send DNS-DS discovery: %s\n", strerror(errno));
+	}
+
+	size_t capacity = 2048;
+	void* buffer = malloc(capacity);
+	void* user_data = 0;
+	size_t records;
+
+	// This is a simple implementation that loops for 5 seconds or as long as we get replies
+	int res;
+	printf("Reading DNS-SD replies\n");
+	do {
+		struct timeval timeout;
+		timeout.tv_sec = 5;
+		timeout.tv_usec = 0;
+
+		int nfds = 0;
+		fd_set readfs;
+		FD_ZERO(&readfs);
+		for (int isock = 0; isock < num_sockets; ++isock) {
+			if (sockets[isock] >= nfds)
+				nfds = sockets[isock] + 1;
+			FD_SET(sockets[isock], &readfs);
+		}
+
+		records = 0;
+		res = select(nfds, &readfs, 0, 0, &timeout);
+		if (res > 0) {
+			for (int isock = 0; isock < num_sockets; ++isock) {
+				if (FD_ISSET(sockets[isock], &readfs)) {
+					records += mdns_discovery_recv(sockets[isock], buffer, capacity, query_callback,
+					                               user_data);
+				}
+			}
+		}
+	} while (res > 0);
+
+	free(buffer);
+
+	for (int isock = 0; isock < num_sockets; ++isock)
+		mdns_socket_close(sockets[isock]);
+	printf("Closed socket%s\n", num_sockets ? "s" : "");
+
+	return 0;
+}
+
+static int
+send_mdns_query(const char* service) {
+	int sockets[32];
+	int query_id[32];
+	int num_sockets = open_client_sockets(sockets, sizeof(sockets) / sizeof(sockets[0]), 0);
+	if (num_sockets <= 0) {
+		printf("Failed to open any client sockets\n");
+		return -1;
+	}
+	printf("Opened %d socket%s for mDNS query\n", num_sockets, num_sockets ? "s" : "");
+
+	size_t capacity = 2048;
+	void* buffer = malloc(capacity);
+	void* user_data = 0;
+	size_t records;
+
+	printf("Sending mDNS query: %s\n", service);
+	for (int isock = 0; isock < num_sockets; ++isock) {
+		query_id[isock] = mdns_query_send(sockets[isock], MDNS_RECORDTYPE_PTR, service,
+		                                  strlen(service), buffer, capacity, 0);
+		if (query_id[isock] < 0)
+			printf("Failed to send mDNS query: %s\n", strerror(errno));
+	}
+
+	// This is a simple implementation that loops for 5 seconds or as long as we get replies
+	int res;
+	printf("Reading mDNS query replies\n");
+	do {
+		struct timeval timeout;
+		timeout.tv_sec = 5;
+		timeout.tv_usec = 0;
+
+		int nfds = 0;
+		fd_set readfs;
+		FD_ZERO(&readfs);
+		for (int isock = 0; isock < num_sockets; ++isock) {
+			if (sockets[isock] >= nfds)
+				nfds = sockets[isock] + 1;
+			FD_SET(sockets[isock], &readfs);
+		}
+
+		records = 0;
+		res = select(nfds, &readfs, 0, 0, &timeout);
+		if (res > 0) {
+			for (int isock = 0; isock < num_sockets; ++isock) {
+				if (FD_ISSET(sockets[isock], &readfs)) {
+					records += mdns_query_recv(sockets[isock], buffer, capacity, query_callback,
+					                           user_data, query_id[isock]);
+				}
+				FD_SET(sockets[isock], &readfs);
+			}
+		}
+	} while (res > 0);
+
+	free(buffer);
+
+	for (int isock = 0; isock < num_sockets; ++isock)
+		mdns_socket_close(sockets[isock]);
+	printf("Closed socket%s\n", num_sockets ? "s" : "");
+
+	return 0;
+}
+
+static int
+service_mdns(const char* hostname, const char* service, int service_port) {
+	int sockets[32];
+	int num_sockets = open_service_sockets(sockets, sizeof(sockets) / sizeof(sockets[0]));
+	if (num_sockets <= 0) {
+		printf("Failed to open any client sockets\n");
+		return -1;
+	}
+	printf("Opened %d socket%s for mDNS service\n", num_sockets, num_sockets ? "s" : "");
+
+	printf("Service mDNS: %s:%d\n", service, service_port);
+	printf("Hostname: %s\n", hostname);
+
+	size_t capacity = 2048;
+	void* buffer = malloc(capacity);
+
+	service_record_t service_record;
+	service_record.service = service;
+	service_record.hostname = hostname;
+	service_record.address_ipv4 = has_ipv4 ? service_address_ipv4 : 0;
+	service_record.address_ipv6 = has_ipv6 ? service_address_ipv6 : 0;
+	service_record.port = service_port;
+
+	// This is a crude implementation that checks for incoming queries
+	while (1) {
+		int nfds = 0;
+		fd_set readfs;
+		FD_ZERO(&readfs);
+		for (int isock = 0; isock < num_sockets; ++isock) {
+			if (sockets[isock] >= nfds)
+				nfds = sockets[isock] + 1;
+			FD_SET(sockets[isock], &readfs);
+		}
+
+		if (select(nfds, &readfs, 0, 0, 0) >= 0) {
+			for (int isock = 0; isock < num_sockets; ++isock) {
+				if (FD_ISSET(sockets[isock], &readfs)) {
+					mdns_socket_listen(sockets[isock], buffer, capacity, service_callback,
+					                   &service_record);
+				}
+				FD_SET(sockets[isock], &readfs);
+			}
+		} else {
+			break;
+		}
+	}
+
+	free(buffer);
+
+	for (int isock = 0; isock < num_sockets; ++isock)
+		mdns_socket_close(sockets[isock]);
+	printf("Closed socket%s\n", num_sockets ? "s" : "");
+
+	return 0;
+}
+
+int
+main(int argc, const char* const* argv) {
+	int mode = 0;
+	const char* service = "_test-mdns._tcp.local.";
+	const char* hostname = "dummy-host";
+	int service_port = 42424;
+
+#ifdef _WIN32
+
+	WORD versionWanted = MAKEWORD(1, 1);
+	WSADATA wsaData;
+	if (WSAStartup(versionWanted, &wsaData)) {
+		printf("Failed to initialize WinSock\n");
+		return -1;
+	}
+
+	char hostname_buffer[256];
+	DWORD hostname_size = (DWORD)sizeof(hostname_buffer);
+	if (GetComputerNameA(hostname_buffer, &hostname_size))
+		hostname = hostname_buffer;
+
+#else
+
+	char hostname_buffer[256];
+	size_t hostname_size = sizeof(hostname_buffer);
+	if (gethostname(hostname_buffer, hostname_size) == 0)
+		hostname = hostname_buffer;
+
+#endif
+
+	for (int iarg = 0; iarg < argc; ++iarg) {
+		if (strcmp(argv[iarg], "--discovery") == 0) {
+			mode = 0;
+		} else if (strcmp(argv[iarg], "--query") == 0) {
+			mode = 1;
+			++iarg;
+			if (iarg < argc)
+				service = argv[iarg];
+		} else if (strcmp(argv[iarg], "--service") == 0) {
+			mode = 2;
+			++iarg;
+			if (iarg < argc)
+				service = argv[iarg];
+		} else if (strcmp(argv[iarg], "--hostname") == 0) {
+			++iarg;
+			if (iarg < argc)
+				hostname = argv[iarg];
+		} else if (strcmp(argv[iarg], "--port") == 0) {
+			++iarg;
+			if (iarg < argc)
+				service_port = atoi(argv[iarg]);
+		}
+	}
+
+	int ret;
+	if (mode == 0)
+		ret = send_dns_sd();
+	else if (mode == 1)
+		ret = send_mdns_query(service);
+	else if (mode == 2)
+		ret = service_mdns(hostname, service, service_port);
+
+#ifdef _WIN32
+	WSACleanup();
+#endif
+
+	return 0;
+}

--- a/lib/mdns/mdns.h
+++ b/lib/mdns/mdns.h
@@ -1,0 +1,1268 @@
+/* mdns.h  -  mDNS/DNS-SD library  -  Public Domain  -  2017 Mattias Jansson
+ *
+ * This library provides a cross-platform mDNS and DNS-SD library in C.
+ * The implementation is based on RFC 6762 and RFC 6763.
+ *
+ * The latest source code is always available at
+ *
+ * https://github.com/mjansson/mdns
+ *
+ * This library is put in the public domain; you can redistribute it and/or modify it without any
+ * restrictions.
+ *
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include <stddef.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <fcntl.h>
+#ifdef _WIN32
+#include <Winsock2.h>
+#include <Ws2tcpip.h>
+#define strncasecmp _strnicmp
+#else
+#include <unistd.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define MDNS_INVALID_POS ((size_t)-1)
+
+#define MDNS_STRING_CONST(s) (s), (sizeof((s)) - 1)
+#define MDNS_STRING_FORMAT(s) (int)((s).length), s.str
+
+#define MDNS_POINTER_OFFSET(p, ofs) ((void*)((char*)(p) + (ptrdiff_t)(ofs)))
+#define MDNS_POINTER_OFFSET_CONST(p, ofs) ((const void*)((const char*)(p) + (ptrdiff_t)(ofs)))
+#define MDNS_POINTER_DIFF(a, b) ((size_t)((const char*)(a) - (const char*)(b)))
+
+#define MDNS_PORT 5353
+#define MDNS_UNICAST_RESPONSE 0x8000U
+#define MDNS_CACHE_FLUSH 0x8000U
+
+enum mdns_record_type {
+	MDNS_RECORDTYPE_IGNORE = 0,
+	// Address
+	MDNS_RECORDTYPE_A = 1,
+	// Domain Name pointer
+	MDNS_RECORDTYPE_PTR = 12,
+	// Arbitrary text string
+	MDNS_RECORDTYPE_TXT = 16,
+	// IP6 Address [Thomson]
+	MDNS_RECORDTYPE_AAAA = 28,
+	// Server Selection [RFC2782]
+	MDNS_RECORDTYPE_SRV = 33
+};
+
+enum mdns_entry_type {
+	MDNS_ENTRYTYPE_QUESTION = 0,
+	MDNS_ENTRYTYPE_ANSWER = 1,
+	MDNS_ENTRYTYPE_AUTHORITY = 2,
+	MDNS_ENTRYTYPE_ADDITIONAL = 3
+};
+
+enum mdns_class { MDNS_CLASS_IN = 1 };
+
+typedef enum mdns_record_type mdns_record_type_t;
+typedef enum mdns_entry_type mdns_entry_type_t;
+typedef enum mdns_class mdns_class_t;
+
+typedef int (*mdns_record_callback_fn)(int sock, const struct sockaddr* from, size_t addrlen,
+                                       mdns_entry_type_t entry, uint16_t query_id, uint16_t rtype,
+                                       uint16_t rclass, uint32_t ttl, const void* data, size_t size,
+                                       size_t name_offset, size_t name_length, size_t record_offset,
+                                       size_t record_length, void* user_data);
+
+typedef struct mdns_string_t mdns_string_t;
+typedef struct mdns_string_pair_t mdns_string_pair_t;
+typedef struct mdns_record_srv_t mdns_record_srv_t;
+typedef struct mdns_record_txt_t mdns_record_txt_t;
+
+#ifdef _WIN32
+typedef int mdns_size_t;
+#else
+typedef size_t mdns_size_t;
+#endif
+
+struct mdns_string_t {
+	const char* str;
+	size_t length;
+};
+
+struct mdns_string_pair_t {
+	size_t offset;
+	size_t length;
+	int ref;
+};
+
+struct mdns_record_srv_t {
+	uint16_t priority;
+	uint16_t weight;
+	uint16_t port;
+	mdns_string_t name;
+};
+
+struct mdns_record_txt_t {
+	mdns_string_t key;
+	mdns_string_t value;
+};
+
+struct mdns_header_t {
+	uint16_t query_id;
+	uint16_t flags;
+	uint16_t questions;
+	uint16_t answer_rrs;
+	uint16_t authority_rrs;
+	uint16_t additional_rrs;
+};
+
+// mDNS/DNS-SD public API
+
+//! Open and setup a IPv4 socket for mDNS/DNS-SD. To bind the socket to a specific interface,
+//  pass in the appropriate socket address in saddr, otherwise pass a null pointer for INADDR_ANY.
+//  To send one-shot discovery requests and queries pass a null pointer or set 0 as port to assign
+//  a random user level ephemeral port. To run discovery service listening for incoming
+//  discoveries and queries, you must set MDNS_PORT as port.
+static int
+mdns_socket_open_ipv4(struct sockaddr_in* saddr);
+
+//! Setup an already opened IPv4 socket for mDNS/DNS-SD. To bind the socket to a specific interface,
+//  pass in the appropriate socket address in saddr, otherwise pass a null pointer for INADDR_ANY.
+//  To send one-shot discovery requests and queries pass a null pointer or set 0 as port to assign
+//  a random user level ephemeral port. To run discovery service listening for incoming
+//  discoveries and queries, you must set MDNS_PORT as port.
+static int
+mdns_socket_setup_ipv4(int sock, struct sockaddr_in* saddr);
+
+//! Open and setup a IPv6 socket for mDNS/DNS-SD. To bind the socket to a specific interface,
+//  pass in the appropriate socket address in saddr, otherwise pass a null pointer for in6addr_any.
+//  To send one-shot discovery requests and queries pass a null pointer or set 0 as port to assign
+//  a random user level ephemeral port. To run discovery service listening for incoming
+//  discoveries and queries, you must set MDNS_PORT as port.
+static int
+mdns_socket_open_ipv6(struct sockaddr_in6* saddr);
+
+//! Setup an already opened IPv6 socket for mDNS/DNS-SD. To bind the socket to a specific interface,
+//  pass in the appropriate socket address in saddr, otherwise pass a null pointer for in6addr_any.
+//  To send one-shot discovery requests and queries pass a null pointer or set 0 as port to assign
+//  a random user level ephemeral port. To run discovery service listening for incoming
+//  discoveries and queries, you must set MDNS_PORT as port.
+static int
+mdns_socket_setup_ipv6(int sock, struct sockaddr_in6* saddr);
+
+//! Close a socket opened with mdns_socket_open_ipv4 and mdns_socket_open_ipv6.
+static void
+mdns_socket_close(int sock);
+
+//! Listen for incoming multicast DNS-SD and mDNS query requests. The socket should have been
+//  opened on port MDNS_PORT using one of the mdns open or setup socket functions. Returns the
+//  number of queries  parsed.
+static size_t
+mdns_socket_listen(int sock, void* buffer, size_t capacity, mdns_record_callback_fn callback,
+                   void* user_data);
+
+//! Send a multicast DNS-SD reqeuest on the given socket to discover available services. Returns
+//  0 on success, or <0 if error.
+static int
+mdns_discovery_send(int sock);
+
+//! Recieve unicast responses to a DNS-SD sent with mdns_discovery_send. Any data will be piped to
+//  the given callback for parsing. Returns the number of responses parsed.
+static size_t
+mdns_discovery_recv(int sock, void* buffer, size_t capacity, mdns_record_callback_fn callback,
+                    void* user_data);
+
+//! Send a unicast DNS-SD answer with a single record to the given address. Returns 0 if success,
+//  or <0 if error.
+static int
+mdns_discovery_answer(int sock, const void* address, size_t address_size, void* buffer,
+                      size_t capacity, const char* record, size_t length);
+
+//! Send a multicast mDNS query on the given socket for the given service name. The supplied buffer
+//  will be used to build the query packet. The query ID can be set to non-zero to filter responses,
+//  however the RFC states that the query ID SHOULD be set to 0 for multicast queries. The query
+//  will request a unicast response if the socket is bound to an ephemeral port, or a multicast
+//  response if the socket is bound to mDNS port 5353.
+//  Returns the used query ID, or <0 if error.
+static int
+mdns_query_send(int sock, mdns_record_type_t type, const char* name, size_t length, void* buffer,
+                size_t capacity, uint16_t query_id);
+
+//! Receive unicast responses to a mDNS query sent with mdns_discovery_recv, optionally filtering
+//  out any responses not matching the given query ID. Set the query ID to 0 to parse
+//  all responses, even if it is not matching the query ID set in a specific query. Any data will
+//  be piped to the given callback for parsing. Returns the number of responses parsed.
+static size_t
+mdns_query_recv(int sock, void* buffer, size_t capacity, mdns_record_callback_fn callback,
+                void* user_data, int query_id);
+
+//! Send a unicast or multicast mDNS query answer with a single record to the given address. The
+//  answer will be sent multicast if address size is 0, otherwise it will be sent unicast to the
+//  given address. Use the top bit of the query class field (MDNS_UNICAST_RESPONSE) to determine
+//  if the answer should be sent unicast (bit set) or multicast (bit not set).
+//  Returns 0 if success, or <0 if error.
+static int
+mdns_query_answer(int sock, const void* address, size_t address_size, void* buffer, size_t capacity,
+                  uint16_t query_id, const char* service, size_t service_length,
+                  const char* hostname, size_t hostname_length, uint32_t ipv4, const uint8_t* ipv6,
+                  uint16_t port, const char* txt, size_t txt_length);
+
+// Internal functions
+
+static mdns_string_t
+mdns_string_extract(const void* buffer, size_t size, size_t* offset, char* str, size_t capacity);
+
+static int
+mdns_string_skip(const void* buffer, size_t size, size_t* offset);
+
+static int
+mdns_string_equal(const void* buffer_lhs, size_t size_lhs, size_t* ofs_lhs, const void* buffer_rhs,
+                  size_t size_rhs, size_t* ofs_rhs);
+
+static void*
+mdns_string_make(void* data, size_t capacity, const char* name, size_t length);
+
+static void*
+mdns_string_make_ref(void* data, size_t capacity, size_t ref_offset);
+
+static void*
+mdns_string_make_with_ref(void* data, size_t capacity, const char* name, size_t length,
+                          size_t ref_offset);
+
+static mdns_string_t
+mdns_record_parse_ptr(const void* buffer, size_t size, size_t offset, size_t length,
+                      char* strbuffer, size_t capacity);
+
+static mdns_record_srv_t
+mdns_record_parse_srv(const void* buffer, size_t size, size_t offset, size_t length,
+                      char* strbuffer, size_t capacity);
+
+static struct sockaddr_in*
+mdns_record_parse_a(const void* buffer, size_t size, size_t offset, size_t length,
+                    struct sockaddr_in* addr);
+
+static struct sockaddr_in6*
+mdns_record_parse_aaaa(const void* buffer, size_t size, size_t offset, size_t length,
+                       struct sockaddr_in6* addr);
+
+static size_t
+mdns_record_parse_txt(const void* buffer, size_t size, size_t offset, size_t length,
+                      mdns_record_txt_t* records, size_t capacity);
+
+// Implementations
+
+static int
+mdns_socket_open_ipv4(struct sockaddr_in* saddr) {
+	int sock = (int)socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
+	if (sock < 0)
+		return -1;
+	if (mdns_socket_setup_ipv4(sock, saddr)) {
+		mdns_socket_close(sock);
+		return -1;
+	}
+	return sock;
+}
+
+static int
+mdns_socket_setup_ipv4(int sock, struct sockaddr_in* saddr) {
+	unsigned char ttl = 1;
+	unsigned char loopback = 1;
+	unsigned int reuseaddr = 1;
+	struct ip_mreq req;
+
+	setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, (const char*)&reuseaddr, sizeof(reuseaddr));
+#ifdef SO_REUSEPORT
+	setsockopt(sock, SOL_SOCKET, SO_REUSEPORT, (const char*)&reuseaddr, sizeof(reuseaddr));
+#endif
+	setsockopt(sock, IPPROTO_IP, IP_MULTICAST_TTL, (const char*)&ttl, sizeof(ttl));
+	setsockopt(sock, IPPROTO_IP, IP_MULTICAST_LOOP, (const char*)&loopback, sizeof(loopback));
+
+	memset(&req, 0, sizeof(req));
+	req.imr_multiaddr.s_addr = htonl((((uint32_t)224U) << 24U) | ((uint32_t)251U));
+	if (saddr)
+		req.imr_interface = saddr->sin_addr;
+	if (setsockopt(sock, IPPROTO_IP, IP_ADD_MEMBERSHIP, (char*)&req, sizeof(req)))
+		return -1;
+
+	struct sockaddr_in sock_addr;
+	if (!saddr) {
+		saddr = &sock_addr;
+		memset(saddr, 0, sizeof(struct sockaddr_in));
+		saddr->sin_family = AF_INET;
+		saddr->sin_addr.s_addr = INADDR_ANY;
+#ifdef __APPLE__
+		saddr->sin_len = sizeof(struct sockaddr_in);
+#endif
+	} else {
+		setsockopt(sock, IPPROTO_IP, IP_MULTICAST_IF, (const char*)&saddr->sin_addr,
+		           sizeof(saddr->sin_addr));
+#ifndef _WIN32
+		saddr->sin_addr.s_addr = INADDR_ANY;
+#endif
+	}
+
+	if (bind(sock, (struct sockaddr*)saddr, sizeof(struct sockaddr_in)))
+		return -1;
+
+#ifdef _WIN32
+	unsigned long param = 1;
+	ioctlsocket(sock, FIONBIO, &param);
+#else
+	const int flags = fcntl(sock, F_GETFL, 0);
+	fcntl(sock, F_SETFL, flags | O_NONBLOCK);
+#endif
+
+	return 0;
+}
+
+static int
+mdns_socket_open_ipv6(struct sockaddr_in6* saddr) {
+	int sock = (int)socket(AF_INET6, SOCK_DGRAM, IPPROTO_UDP);
+	if (sock < 0)
+		return -1;
+	if (mdns_socket_setup_ipv6(sock, saddr)) {
+		mdns_socket_close(sock);
+		return -1;
+	}
+	return sock;
+}
+
+static int
+mdns_socket_setup_ipv6(int sock, struct sockaddr_in6* saddr) {
+	int hops = 1;
+	unsigned int loopback = 1;
+	unsigned int reuseaddr = 1;
+	struct ipv6_mreq req;
+
+	setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, (const char*)&reuseaddr, sizeof(reuseaddr));
+#ifdef SO_REUSEPORT
+	setsockopt(sock, SOL_SOCKET, SO_REUSEPORT, (const char*)&reuseaddr, sizeof(reuseaddr));
+#endif
+	setsockopt(sock, IPPROTO_IPV6, IPV6_MULTICAST_HOPS, (const char*)&hops, sizeof(hops));
+	setsockopt(sock, IPPROTO_IPV6, IPV6_MULTICAST_LOOP, (const char*)&loopback, sizeof(loopback));
+
+	memset(&req, 0, sizeof(req));
+	req.ipv6mr_multiaddr.s6_addr[0] = 0xFF;
+	req.ipv6mr_multiaddr.s6_addr[1] = 0x02;
+	req.ipv6mr_multiaddr.s6_addr[15] = 0xFB;
+	if (setsockopt(sock, IPPROTO_IPV6, IPV6_JOIN_GROUP, (char*)&req, sizeof(req)))
+		return -1;
+
+	struct sockaddr_in6 sock_addr;
+	if (!saddr) {
+		saddr = &sock_addr;
+		memset(saddr, 0, sizeof(struct sockaddr_in6));
+		saddr->sin6_family = AF_INET6;
+		saddr->sin6_addr = in6addr_any;
+#ifdef __APPLE__
+		saddr->sin6_len = sizeof(struct sockaddr_in6);
+#endif
+	} else {
+		unsigned int ifindex = 0;
+		setsockopt(sock, IPPROTO_IPV6, IPV6_MULTICAST_IF, (const char*)&ifindex, sizeof(ifindex));
+#ifndef _WIN32
+		saddr->sin6_addr = in6addr_any;
+#endif
+	}
+
+	if (bind(sock, (struct sockaddr*)saddr, sizeof(struct sockaddr_in6)))
+		return -1;
+
+#ifdef _WIN32
+	unsigned long param = 1;
+	ioctlsocket(sock, FIONBIO, &param);
+#else
+	const int flags = fcntl(sock, F_GETFL, 0);
+	fcntl(sock, F_SETFL, flags | O_NONBLOCK);
+#endif
+
+	return 0;
+}
+
+static void
+mdns_socket_close(int sock) {
+#ifdef _WIN32
+	closesocket(sock);
+#else
+	close(sock);
+#endif
+}
+
+static int
+mdns_is_string_ref(uint8_t val) {
+	return (0xC0 == (val & 0xC0));
+}
+
+static mdns_string_pair_t
+mdns_get_next_substring(const void* rawdata, size_t size, size_t offset) {
+	const uint8_t* buffer = (const uint8_t*)rawdata;
+	mdns_string_pair_t pair = {MDNS_INVALID_POS, 0, 0};
+	if (!buffer[offset]) {
+		pair.offset = offset;
+		return pair;
+	}
+	if (mdns_is_string_ref(buffer[offset])) {
+		if (size < offset + 2)
+			return pair;
+
+		offset = 0x3fff & ntohs(*(uint16_t*)MDNS_POINTER_OFFSET(buffer, offset));
+		if (offset >= size)
+			return pair;
+
+		pair.ref = 1;
+	}
+
+	size_t length = (size_t)buffer[offset++];
+	if (size < offset + length)
+		return pair;
+
+	pair.offset = offset;
+	pair.length = length;
+
+	return pair;
+}
+
+static int
+mdns_string_skip(const void* buffer, size_t size, size_t* offset) {
+	size_t cur = *offset;
+	mdns_string_pair_t substr;
+	do {
+		substr = mdns_get_next_substring(buffer, size, cur);
+		if (substr.offset == MDNS_INVALID_POS)
+			return 0;
+		if (substr.ref) {
+			*offset = cur + 2;
+			return 1;
+		}
+		cur = substr.offset + substr.length;
+	} while (substr.length);
+
+	*offset = cur + 1;
+	return 1;
+}
+
+static int
+mdns_string_equal(const void* buffer_lhs, size_t size_lhs, size_t* ofs_lhs, const void* buffer_rhs,
+                  size_t size_rhs, size_t* ofs_rhs) {
+	size_t lhs_cur = *ofs_lhs;
+	size_t rhs_cur = *ofs_rhs;
+	size_t lhs_end = MDNS_INVALID_POS;
+	size_t rhs_end = MDNS_INVALID_POS;
+	mdns_string_pair_t lhs_substr;
+	mdns_string_pair_t rhs_substr;
+	do {
+		lhs_substr = mdns_get_next_substring(buffer_lhs, size_lhs, lhs_cur);
+		rhs_substr = mdns_get_next_substring(buffer_rhs, size_rhs, rhs_cur);
+		if ((lhs_substr.offset == MDNS_INVALID_POS) || (rhs_substr.offset == MDNS_INVALID_POS))
+			return 0;
+		if (lhs_substr.length != rhs_substr.length)
+			return 0;
+		if (strncasecmp((const char*)buffer_rhs + rhs_substr.offset,
+		                (const char*)buffer_lhs + lhs_substr.offset, rhs_substr.length))
+			return 0;
+		if (lhs_substr.ref && (lhs_end == MDNS_INVALID_POS))
+			lhs_end = lhs_cur + 2;
+		if (rhs_substr.ref && (rhs_end == MDNS_INVALID_POS))
+			rhs_end = rhs_cur + 2;
+		lhs_cur = lhs_substr.offset + lhs_substr.length;
+		rhs_cur = rhs_substr.offset + rhs_substr.length;
+	} while (lhs_substr.length);
+
+	if (lhs_end == MDNS_INVALID_POS)
+		lhs_end = lhs_cur + 1;
+	*ofs_lhs = lhs_end;
+
+	if (rhs_end == MDNS_INVALID_POS)
+		rhs_end = rhs_cur + 1;
+	*ofs_rhs = rhs_end;
+
+	return 1;
+}
+
+static mdns_string_t
+mdns_string_extract(const void* buffer, size_t size, size_t* offset, char* str, size_t capacity) {
+	size_t cur = *offset;
+	size_t end = MDNS_INVALID_POS;
+	mdns_string_pair_t substr;
+	mdns_string_t result;
+	result.str = str;
+	result.length = 0;
+	char* dst = str;
+	size_t remain = capacity;
+	do {
+		substr = mdns_get_next_substring(buffer, size, cur);
+		if (substr.offset == MDNS_INVALID_POS)
+			return result;
+		if (substr.ref && (end == MDNS_INVALID_POS))
+			end = cur + 2;
+		if (substr.length) {
+			size_t to_copy = (substr.length < remain) ? substr.length : remain;
+			memcpy(dst, (const char*)buffer + substr.offset, to_copy);
+			dst += to_copy;
+			remain -= to_copy;
+			if (remain) {
+				*dst++ = '.';
+				--remain;
+			}
+		}
+		cur = substr.offset + substr.length;
+	} while (substr.length);
+
+	if (end == MDNS_INVALID_POS)
+		end = cur + 1;
+	*offset = end;
+
+	result.length = capacity - remain;
+	return result;
+}
+
+static size_t
+mdns_string_find(const char* str, size_t length, char c, size_t offset) {
+	const void* found;
+	if (offset >= length)
+		return MDNS_INVALID_POS;
+	found = memchr(str + offset, c, length - offset);
+	if (found)
+		return (size_t)((const char*)found - str);
+	return MDNS_INVALID_POS;
+}
+
+static void*
+mdns_string_make(void* data, size_t capacity, const char* name, size_t length) {
+	size_t pos = 0;
+	size_t last_pos = 0;
+	size_t remain = capacity;
+	unsigned char* dest = (unsigned char*)data;
+	while ((last_pos < length) &&
+	       ((pos = mdns_string_find(name, length, '.', last_pos)) != MDNS_INVALID_POS)) {
+		size_t sublength = pos - last_pos;
+		if (sublength < remain) {
+			*dest = (unsigned char)sublength;
+			memcpy(dest + 1, name + last_pos, sublength);
+			dest += sublength + 1;
+			remain -= sublength + 1;
+		} else {
+			return 0;
+		}
+		last_pos = pos + 1;
+	}
+	if (last_pos < length) {
+		size_t sublength = length - last_pos;
+		if (sublength < remain) {
+			*dest = (unsigned char)sublength;
+			memcpy(dest + 1, name + last_pos, sublength);
+			dest += sublength + 1;
+			remain -= sublength + 1;
+		} else {
+			return 0;
+		}
+	}
+	if (!remain)
+		return 0;
+	*dest++ = 0;
+	return dest;
+}
+
+static void*
+mdns_string_make_ref(void* data, size_t capacity, size_t ref_offset) {
+	if (capacity < 2)
+		return 0;
+	uint16_t* udata = (uint16_t*)data;
+	*udata++ = htons(0xC000 | (uint16_t)ref_offset);
+	return udata;
+}
+
+static void*
+mdns_string_make_with_ref(void* data, size_t capacity, const char* name, size_t length,
+                          size_t ref_offset) {
+	void* remaindata = mdns_string_make(data, capacity, name, length);
+	capacity -= MDNS_POINTER_DIFF(remaindata, data);
+	if (!data || !capacity)
+		return 0;
+	return mdns_string_make_ref(MDNS_POINTER_OFFSET(remaindata, -1), capacity + 1, ref_offset);
+}
+
+static size_t
+mdns_records_parse(int sock, const struct sockaddr* from, size_t addrlen, const void* buffer,
+                   size_t size, size_t* offset, mdns_entry_type_t type, uint16_t query_id,
+                   size_t records, mdns_record_callback_fn callback, void* user_data) {
+	size_t parsed = 0;
+	int do_callback = (callback ? 1 : 0);
+	for (size_t i = 0; i < records; ++i) {
+		size_t name_offset = *offset;
+		mdns_string_skip(buffer, size, offset);
+		size_t name_length = (*offset) - name_offset;
+		const uint16_t* data = (const uint16_t*)((const char*)buffer + (*offset));
+
+		uint16_t rtype = ntohs(*data++);
+		uint16_t rclass = ntohs(*data++);
+		uint32_t ttl = ntohl(*(const uint32_t*)(const void*)data);
+		data += 2;
+		uint16_t length = ntohs(*data++);
+
+		*offset += 10;
+
+		if (do_callback) {
+			++parsed;
+			if (callback(sock, from, addrlen, type, query_id, rtype, rclass, ttl, buffer, size,
+			             name_offset, name_length, *offset, length, user_data))
+				do_callback = 0;
+		}
+
+		*offset += length;
+	}
+	return parsed;
+}
+
+static int
+mdns_unicast_send(int sock, const void* address, size_t address_size, const void* buffer,
+                  size_t size) {
+	if (sendto(sock, (const char*)buffer, (mdns_size_t)size, 0, (const struct sockaddr*)address,
+	           (socklen_t)address_size) < 0)
+		return -1;
+	return 0;
+}
+
+static int
+mdns_multicast_send(int sock, const void* buffer, size_t size) {
+	struct sockaddr_storage addr_storage;
+	struct sockaddr_in addr;
+	struct sockaddr_in6 addr6;
+	struct sockaddr* saddr = (struct sockaddr*)&addr_storage;
+	socklen_t saddrlen = sizeof(struct sockaddr_storage);
+	if (getsockname(sock, saddr, &saddrlen))
+		return -1;
+	if (saddr->sa_family == AF_INET6) {
+		memset(&addr6, 0, sizeof(addr6));
+		addr6.sin6_family = AF_INET6;
+#ifdef __APPLE__
+		addr6.sin6_len = sizeof(addr6);
+#endif
+		addr6.sin6_addr.s6_addr[0] = 0xFF;
+		addr6.sin6_addr.s6_addr[1] = 0x02;
+		addr6.sin6_addr.s6_addr[15] = 0xFB;
+		addr6.sin6_port = htons((unsigned short)MDNS_PORT);
+		saddr = (struct sockaddr*)&addr6;
+		saddrlen = sizeof(addr6);
+	} else {
+		memset(&addr, 0, sizeof(addr));
+		addr.sin_family = AF_INET;
+#ifdef __APPLE__
+		addr.sin_len = sizeof(addr);
+#endif
+		addr.sin_addr.s_addr = htonl((((uint32_t)224U) << 24U) | ((uint32_t)251U));
+		addr.sin_port = htons((unsigned short)MDNS_PORT);
+		saddr = (struct sockaddr*)&addr;
+		saddrlen = sizeof(addr);
+	}
+
+	if (sendto(sock, (const char*)buffer, (mdns_size_t)size, 0, saddr, saddrlen) < 0)
+		return -1;
+	return 0;
+}
+
+static const uint8_t mdns_services_query[] = {
+    // Query ID
+    0x00, 0x00,
+    // Flags
+    0x00, 0x00,
+    // 1 question
+    0x00, 0x01,
+    // No answer, authority or additional RRs
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    // _services._dns-sd._udp.local.
+    0x09, '_', 's', 'e', 'r', 'v', 'i', 'c', 'e', 's', 0x07, '_', 'd', 'n', 's', '-', 's', 'd',
+    0x04, '_', 'u', 'd', 'p', 0x05, 'l', 'o', 'c', 'a', 'l', 0x00,
+    // PTR record
+    0x00, MDNS_RECORDTYPE_PTR,
+    // QU (unicast response) and class IN
+    0x80, MDNS_CLASS_IN};
+
+static int
+mdns_discovery_send(int sock) {
+	return mdns_multicast_send(sock, mdns_services_query, sizeof(mdns_services_query));
+}
+
+static size_t
+mdns_discovery_recv(int sock, void* buffer, size_t capacity, mdns_record_callback_fn callback,
+                    void* user_data) {
+	struct sockaddr_in6 addr;
+	struct sockaddr* saddr = (struct sockaddr*)&addr;
+	socklen_t addrlen = sizeof(addr);
+	memset(&addr, 0, sizeof(addr));
+#ifdef __APPLE__
+	saddr->sa_len = sizeof(addr);
+#endif
+	int ret = recvfrom(sock, (char*)buffer, (mdns_size_t)capacity, 0, saddr, &addrlen);
+	if (ret <= 0)
+		return 0;
+
+	size_t data_size = (size_t)ret;
+	size_t records = 0;
+	uint16_t* data = (uint16_t*)buffer;
+
+	uint16_t query_id = ntohs(*data++);
+	uint16_t flags = ntohs(*data++);
+	uint16_t questions = ntohs(*data++);
+	uint16_t answer_rrs = ntohs(*data++);
+	uint16_t authority_rrs = ntohs(*data++);
+	uint16_t additional_rrs = ntohs(*data++);
+
+	// According to RFC 6762 the query ID MUST match the sent query ID (which is 0 in our case)
+	if (query_id || (flags != 0x8400))
+		return 0;  // Not a reply to our question
+
+	// It seems some implementations do not fill the correct questions field,
+	// so ignore this check for now and only validate answer string
+	/*
+	if (questions != 1)
+	    return 0;
+	*/
+
+	int i;
+	for (i = 0; i < questions; ++i) {
+		size_t ofs = (size_t)((char*)data - (char*)buffer);
+		size_t verify_ofs = 12;
+		// Verify it's our question, _services._dns-sd._udp.local.
+		if (!mdns_string_equal(buffer, data_size, &ofs, mdns_services_query,
+		                       sizeof(mdns_services_query), &verify_ofs))
+			return 0;
+		data = (uint16_t*)((char*)buffer + ofs);
+
+		uint16_t rtype = ntohs(*data++);
+		uint16_t rclass = ntohs(*data++);
+
+		// Make sure we get a reply based on our PTR question for class IN
+		if ((rtype != MDNS_RECORDTYPE_PTR) || ((rclass & 0x7FFF) != MDNS_CLASS_IN))
+			return 0;
+	}
+
+	int do_callback = 1;
+	for (i = 0; i < answer_rrs; ++i) {
+		size_t ofs = (size_t)((char*)data - (char*)buffer);
+		size_t verify_ofs = 12;
+		// Verify it's an answer to our question, _services._dns-sd._udp.local.
+		size_t name_offset = ofs;
+		int is_answer = mdns_string_equal(buffer, data_size, &ofs, mdns_services_query,
+		                                  sizeof(mdns_services_query), &verify_ofs);
+		size_t name_length = ofs - name_offset;
+		data = (uint16_t*)((char*)buffer + ofs);
+
+		uint16_t rtype = ntohs(*data++);
+		uint16_t rclass = ntohs(*data++);
+		uint32_t ttl = ntohl(*(uint32_t*)(void*)data);
+		data += 2;
+		uint16_t length = ntohs(*data++);
+		if (length >= (data_size - ofs))
+			return 0;
+
+		if (is_answer && do_callback) {
+			++records;
+			ofs = (size_t)((char*)data - (char*)buffer);
+			if (callback(sock, saddr, addrlen, MDNS_ENTRYTYPE_ANSWER, query_id, rtype, rclass, ttl,
+			             buffer, data_size, name_offset, name_length, ofs, length, user_data))
+				do_callback = 0;
+		}
+		data = (uint16_t*)((char*)data + length);
+	}
+
+	size_t offset = (size_t)((char*)data - (char*)buffer);
+	records +=
+	    mdns_records_parse(sock, saddr, addrlen, buffer, data_size, &offset,
+	                       MDNS_ENTRYTYPE_AUTHORITY, query_id, authority_rrs, callback, user_data);
+	records += mdns_records_parse(sock, saddr, addrlen, buffer, data_size, &offset,
+	                              MDNS_ENTRYTYPE_ADDITIONAL, query_id, additional_rrs, callback,
+	                              user_data);
+
+	return records;
+}
+
+static size_t
+mdns_socket_listen(int sock, void* buffer, size_t capacity, mdns_record_callback_fn callback,
+                   void* user_data) {
+	struct sockaddr_in6 addr;
+	struct sockaddr* saddr = (struct sockaddr*)&addr;
+	socklen_t addrlen = sizeof(addr);
+	memset(&addr, 0, sizeof(addr));
+#ifdef __APPLE__
+	saddr->sa_len = sizeof(addr);
+#endif
+	int ret = recvfrom(sock, (char*)buffer, (mdns_size_t)capacity, 0, saddr, &addrlen);
+	if (ret <= 0)
+		return 0;
+
+	size_t data_size = (size_t)ret;
+	uint16_t* data = (uint16_t*)buffer;
+
+	uint16_t query_id = ntohs(*data++);
+	uint16_t flags = ntohs(*data++);
+	uint16_t questions = ntohs(*data++);
+	/*
+	This data is unused at the moment, skip
+	uint16_t answer_rrs = ntohs(*data++);
+	uint16_t authority_rrs = ntohs(*data++);
+	uint16_t additional_rrs = ntohs(*data++);
+	*/
+	data += 3;
+
+	size_t parsed = 0;
+	for (int iquestion = 0; iquestion < questions; ++iquestion) {
+		size_t question_offset = (size_t)((char*)data - (char*)buffer);
+		size_t offset = question_offset;
+		size_t verify_ofs = 12;
+		if (mdns_string_equal(buffer, data_size, &offset, mdns_services_query,
+		                      sizeof(mdns_services_query), &verify_ofs)) {
+			if (flags || (questions != 1))
+				return 0;
+		} else {
+			offset = question_offset;
+			if (!mdns_string_skip(buffer, data_size, &offset))
+				break;
+		}
+		size_t length = offset - question_offset;
+		data = (uint16_t*)((char*)buffer + offset);
+
+		uint16_t rtype = ntohs(*data++);
+		uint16_t rclass = ntohs(*data++);
+
+		// Make sure we get a question of class IN
+		if ((rclass & 0x7FFF) != MDNS_CLASS_IN)
+			return 0;
+
+		if (callback)
+			callback(sock, saddr, addrlen, MDNS_ENTRYTYPE_QUESTION, query_id, rtype, rclass, 0,
+			         buffer, data_size, question_offset, length, question_offset, length,
+			         user_data);
+
+		++parsed;
+	}
+
+	return parsed;
+}
+
+static int
+mdns_discovery_answer(int sock, const void* address, size_t address_size, void* buffer,
+                      size_t capacity, const char* record, size_t length) {
+	if (capacity < (sizeof(mdns_services_query) + 32 + length))
+		return -1;
+
+	uint16_t* data = (uint16_t*)buffer;
+	// Basic reply structure
+	memcpy(data, mdns_services_query, sizeof(mdns_services_query));
+	// Flags
+	uint16_t* flags = data + 1;
+	*flags = htons(0x8400U);
+	// One answer
+	uint16_t* answers = data + 3;
+	*answers = htons(1);
+
+	// Fill in answer PTR record
+	data = (uint16_t*)((char*)buffer + sizeof(mdns_services_query));
+	// Reference _services._dns-sd._udp.local. string in question
+	*data++ = htons(0xC000U | 12U);
+	// Type
+	*data++ = htons(MDNS_RECORDTYPE_PTR);
+	// Rclass
+	*data++ = htons(MDNS_CLASS_IN);
+	// TTL
+	*(uint32_t*)data = htonl(10);
+	data += 2;
+	// Record string length
+	uint16_t* record_length = data++;
+	uint8_t* record_data = (uint8_t*)data;
+	size_t remain = capacity - (sizeof(mdns_services_query) + 10);
+	record_data = (uint8_t*)mdns_string_make(record_data, remain, record, length);
+	*record_length = htons((uint16_t)(record_data - (uint8_t*)data));
+	*record_data++ = 0;
+
+	ptrdiff_t tosend = (char*)record_data - (char*)buffer;
+	return mdns_unicast_send(sock, address, address_size, buffer, (size_t)tosend);
+}
+
+static int
+mdns_query_send(int sock, mdns_record_type_t type, const char* name, size_t length, void* buffer,
+                size_t capacity, uint16_t query_id) {
+	if (capacity < (17 + length))
+		return -1;
+
+	uint16_t rclass = MDNS_CLASS_IN | MDNS_UNICAST_RESPONSE;
+
+	struct sockaddr_storage addr_storage;
+	struct sockaddr* saddr = (struct sockaddr*)&addr_storage;
+	socklen_t saddrlen = sizeof(addr_storage);
+	if (getsockname(sock, saddr, &saddrlen) == 0) {
+		if ((saddr->sa_family == AF_INET) &&
+		    (ntohs(((struct sockaddr_in*)saddr)->sin_port) == MDNS_PORT))
+			rclass &= ~MDNS_UNICAST_RESPONSE;
+		else if ((saddr->sa_family == AF_INET6) &&
+		         (ntohs(((struct sockaddr_in6*)saddr)->sin6_port) == MDNS_PORT))
+			rclass &= ~MDNS_UNICAST_RESPONSE;
+	}
+
+	uint16_t* data = (uint16_t*)buffer;
+	// Query ID
+	*data++ = htons(query_id);
+	// Flags
+	*data++ = 0;
+	// Questions
+	*data++ = htons(1);
+	// No answer, authority or additional RRs
+	*data++ = 0;
+	*data++ = 0;
+	*data++ = 0;
+	// Fill in question
+	// Name string
+	data = (uint16_t*)mdns_string_make(data, capacity - 17, name, length);
+	if (!data)
+		return -1;
+	// Record type
+	*data++ = htons(type);
+	//! Optional unicast response based on local port, class IN
+	*data++ = htons(rclass);
+
+	ptrdiff_t tosend = (char*)data - (char*)buffer;
+	if (mdns_multicast_send(sock, buffer, (size_t)tosend))
+		return -1;
+	return query_id;
+}
+
+static size_t
+mdns_query_recv(int sock, void* buffer, size_t capacity, mdns_record_callback_fn callback,
+                void* user_data, int only_query_id) {
+	struct sockaddr_in6 addr;
+	struct sockaddr* saddr = (struct sockaddr*)&addr;
+	socklen_t addrlen = sizeof(addr);
+	memset(&addr, 0, sizeof(addr));
+#ifdef __APPLE__
+	saddr->sa_len = sizeof(addr);
+#endif
+	int ret = recvfrom(sock, (char*)buffer, (mdns_size_t)capacity, 0, saddr, &addrlen);
+	if (ret <= 0)
+		return 0;
+
+	size_t data_size = (size_t)ret;
+	uint16_t* data = (uint16_t*)buffer;
+
+	uint16_t query_id = ntohs(*data++);
+	uint16_t flags = ntohs(*data++);
+	uint16_t questions = ntohs(*data++);
+	uint16_t answer_rrs = ntohs(*data++);
+	uint16_t authority_rrs = ntohs(*data++);
+	uint16_t additional_rrs = ntohs(*data++);
+	(void)sizeof(flags);
+
+	if ((only_query_id > 0) && (query_id != only_query_id))
+		return 0;  // Not a reply to the wanted one-shot query
+
+	if (questions > 1)
+		return 0;
+
+	// Skip questions part
+	int i;
+	for (i = 0; i < questions; ++i) {
+		size_t ofs = (size_t)((char*)data - (char*)buffer);
+		if (!mdns_string_skip(buffer, data_size, &ofs))
+			return 0;
+		data = (uint16_t*)((char*)buffer + ofs);
+		uint16_t rtype = ntohs(*data++);
+		uint16_t rclass = ntohs(*data++);
+		(void)sizeof(rtype);
+		(void)sizeof(rclass);
+	}
+
+	size_t records = 0;
+	size_t offset = MDNS_POINTER_DIFF(data, buffer);
+	records += mdns_records_parse(sock, saddr, addrlen, buffer, data_size, &offset,
+	                              MDNS_ENTRYTYPE_ANSWER, query_id, answer_rrs, callback, user_data);
+	records +=
+	    mdns_records_parse(sock, saddr, addrlen, buffer, data_size, &offset,
+	                       MDNS_ENTRYTYPE_AUTHORITY, query_id, authority_rrs, callback, user_data);
+	records += mdns_records_parse(sock, saddr, addrlen, buffer, data_size, &offset,
+	                              MDNS_ENTRYTYPE_ADDITIONAL, query_id, additional_rrs, callback,
+	                              user_data);
+	return records;
+}
+
+static int
+mdns_query_answer(int sock, const void* address, size_t address_size, void* buffer, size_t capacity,
+                  uint16_t query_id, const char* service, size_t service_length,
+                  const char* hostname, size_t hostname_length, uint32_t ipv4, const uint8_t* ipv6,
+                  uint16_t port, const char* txt, size_t txt_length) {
+	if (capacity < (sizeof(struct mdns_header_t) + 32 + service_length + hostname_length))
+		return -1;
+
+	int unicast = (address_size ? 1 : 0);
+	int use_ipv4 = (ipv4 != 0);
+	int use_ipv6 = (ipv6 != 0);
+	int use_txt = (txt && txt_length && (txt_length <= 255));
+
+	uint16_t question_rclass = (unicast ? MDNS_UNICAST_RESPONSE : 0) | MDNS_CLASS_IN;
+	uint16_t rclass = (unicast ? MDNS_CACHE_FLUSH : 0) | MDNS_CLASS_IN;
+	uint32_t ttl = (unicast ? 10 : 60);
+	uint32_t a_ttl = ttl;
+
+	// Basic answer structure
+	struct mdns_header_t* header = (struct mdns_header_t*)buffer;
+	header->query_id = (address_size ? htons(query_id) : 0);
+	header->flags = htons(0x8400);
+	header->questions = htons(unicast ? 1 : 0);
+	header->answer_rrs = htons(1);
+	header->authority_rrs = 0;
+	header->additional_rrs = htons((unsigned short)(1 + use_ipv4 + use_ipv6 + use_txt));
+
+	void* data = MDNS_POINTER_OFFSET(buffer, sizeof(struct mdns_header_t));
+	uint16_t* udata;
+	size_t remain, service_offset = 0, local_offset = 0, full_offset, host_offset;
+
+	// Fill in question if unicast
+	if (unicast) {
+		service_offset = MDNS_POINTER_DIFF(data, buffer);
+		remain = capacity - service_offset;
+		data = mdns_string_make(data, remain, service, service_length);
+		local_offset = MDNS_POINTER_DIFF(data, buffer) - 7;
+		remain = capacity - MDNS_POINTER_DIFF(data, buffer);
+		if (!data || (remain <= 4))
+			return -1;
+
+		udata = (uint16_t*)data;
+		*udata++ = htons(MDNS_RECORDTYPE_PTR);
+		*udata++ = htons(question_rclass);
+		data = udata;
+	}
+	remain = capacity - MDNS_POINTER_DIFF(data, buffer);
+
+	// Fill in answers
+	// PTR record for service
+	if (unicast) {
+		data = mdns_string_make_ref(data, remain, service_offset);
+	} else {
+		service_offset = MDNS_POINTER_DIFF(data, buffer);
+		remain = capacity - service_offset;
+		data = mdns_string_make(data, remain, service, service_length);
+		local_offset = MDNS_POINTER_DIFF(data, buffer) - 7;
+	}
+	remain = capacity - MDNS_POINTER_DIFF(data, buffer);
+	if (!data || (remain <= 10))
+		return -1;
+	udata = (uint16_t*)data;
+	*udata++ = htons(MDNS_RECORDTYPE_PTR);
+	*udata++ = htons(rclass);
+	*(uint32_t*)udata = htonl(ttl);
+	udata += 2;
+	uint16_t* record_length = udata++;  // length
+	data = udata;
+	// Make a string <hostname>.<service>.local.
+	full_offset = MDNS_POINTER_DIFF(data, buffer);
+	remain = capacity - full_offset;
+	data = mdns_string_make_with_ref(data, remain, hostname, hostname_length, service_offset);
+	remain = capacity - MDNS_POINTER_DIFF(data, buffer);
+	if (!data || (remain <= 10))
+		return -1;
+	*record_length = htons((uint16_t)MDNS_POINTER_DIFF(data, record_length + 1));
+
+	// Fill in additional records
+	// SRV record for <hostname>.<service>.local.
+	data = mdns_string_make_ref(data, remain, full_offset);
+	remain = capacity - MDNS_POINTER_DIFF(data, buffer);
+	if (!data || (remain <= 10))
+		return -1;
+	udata = (uint16_t*)data;
+	*udata++ = htons(MDNS_RECORDTYPE_SRV);
+	*udata++ = htons(rclass);
+	*(uint32_t*)udata = htonl(ttl);
+	udata += 2;
+	record_length = udata++;  // length
+	*udata++ = htons(0);      // priority
+	*udata++ = htons(0);      // weight
+	*udata++ = htons(port);   // port
+	// Make a string <hostname>.local.
+	data = udata;
+	host_offset = MDNS_POINTER_DIFF(data, buffer);
+	remain = capacity - host_offset;
+	data = mdns_string_make_with_ref(data, remain, hostname, hostname_length, local_offset);
+	remain = capacity - MDNS_POINTER_DIFF(data, buffer);
+	if (!data || (remain <= 10))
+		return -1;
+	*record_length = htons((uint16_t)MDNS_POINTER_DIFF(data, record_length + 1));
+
+	// A record for <hostname>.local.
+	if (use_ipv4) {
+		data = mdns_string_make_ref(data, remain, host_offset);
+		remain = capacity - MDNS_POINTER_DIFF(data, buffer);
+		if (!data || (remain <= 14))
+			return -1;
+		udata = (uint16_t*)data;
+		*udata++ = htons(MDNS_RECORDTYPE_A);
+		*udata++ = htons(rclass);
+		*(uint32_t*)udata = htonl(a_ttl);
+		udata += 2;
+		*udata++ = htons(4);       // length
+		*(uint32_t*)udata = ipv4;  // ipv4 address
+		udata += 2;
+		data = udata;
+		remain = capacity - MDNS_POINTER_DIFF(data, buffer);
+	}
+
+	// AAAA record for <hostname>.local.
+	if (use_ipv6) {
+		data = mdns_string_make_ref(data, remain, host_offset);
+		remain = capacity - MDNS_POINTER_DIFF(data, buffer);
+		if (!data || (remain <= 26))
+			return -1;
+		udata = (uint16_t*)data;
+		*udata++ = htons(MDNS_RECORDTYPE_AAAA);
+		*udata++ = htons(rclass);
+		*(uint32_t*)udata = htonl(a_ttl);
+		udata += 2;
+		*udata++ = htons(16);     // length
+		memcpy(udata, ipv6, 16);  // ipv6 address
+		data = MDNS_POINTER_OFFSET(udata, 16);
+		remain = capacity - MDNS_POINTER_DIFF(data, buffer);
+	}
+
+	// TXT record for <hostname>.<service>.local.
+	if (use_txt) {
+		data = mdns_string_make_ref(data, remain, full_offset);
+		remain = capacity - MDNS_POINTER_DIFF(data, buffer);
+		if (!data || (remain <= (11 + txt_length)))
+			return -1;
+		udata = (uint16_t*)data;
+		*udata++ = htons(MDNS_RECORDTYPE_TXT);
+		*udata++ = htons(rclass);
+		*(uint32_t*)udata = htonl(ttl);
+		udata += 2;
+		*udata++ = htons((unsigned short)(txt_length + 1));  // length
+		char* txt_record = (char*)udata;
+		*txt_record++ = (char)txt_length;
+		memcpy(txt_record, txt, txt_length);  // txt record
+		data = MDNS_POINTER_OFFSET(txt_record, txt_length);
+		// Unused until multiple txt records are supported
+		// remain = capacity - MDNS_POINTER_DIFF(data, buffer);
+	}
+
+	size_t tosend = MDNS_POINTER_DIFF(data, buffer);
+	if (address_size)
+		return mdns_unicast_send(sock, address, address_size, buffer, tosend);
+	return mdns_multicast_send(sock, buffer, tosend);
+}
+
+static mdns_string_t
+mdns_record_parse_ptr(const void* buffer, size_t size, size_t offset, size_t length,
+                      char* strbuffer, size_t capacity) {
+	// PTR record is just a string
+	if ((size >= offset + length) && (length >= 2))
+		return mdns_string_extract(buffer, size, &offset, strbuffer, capacity);
+	mdns_string_t empty = {0, 0};
+	return empty;
+}
+
+static mdns_record_srv_t
+mdns_record_parse_srv(const void* buffer, size_t size, size_t offset, size_t length,
+                      char* strbuffer, size_t capacity) {
+	mdns_record_srv_t srv;
+	memset(&srv, 0, sizeof(mdns_record_srv_t));
+	// Read the priority, weight, port number and the discovery name
+	// SRV record format (http://www.ietf.org/rfc/rfc2782.txt):
+	// 2 bytes network-order unsigned priority
+	// 2 bytes network-order unsigned weight
+	// 2 bytes network-order unsigned port
+	// string: discovery (domain) name, minimum 2 bytes when compressed
+	if ((size >= offset + length) && (length >= 8)) {
+		const uint16_t* recorddata = (const uint16_t*)((const char*)buffer + offset);
+		srv.priority = ntohs(*recorddata++);
+		srv.weight = ntohs(*recorddata++);
+		srv.port = ntohs(*recorddata++);
+		offset += 6;
+		srv.name = mdns_string_extract(buffer, size, &offset, strbuffer, capacity);
+	}
+	return srv;
+}
+
+static struct sockaddr_in*
+mdns_record_parse_a(const void* buffer, size_t size, size_t offset, size_t length,
+                    struct sockaddr_in* addr) {
+	memset(addr, 0, sizeof(struct sockaddr_in));
+	addr->sin_family = AF_INET;
+#ifdef __APPLE__
+	addr->sin_len = sizeof(struct sockaddr_in);
+#endif
+	if ((size >= offset + length) && (length == 4))
+		addr->sin_addr.s_addr = *(const uint32_t*)((const char*)buffer + offset);
+	return addr;
+}
+
+static struct sockaddr_in6*
+mdns_record_parse_aaaa(const void* buffer, size_t size, size_t offset, size_t length,
+                       struct sockaddr_in6* addr) {
+	memset(addr, 0, sizeof(struct sockaddr_in6));
+	addr->sin6_family = AF_INET6;
+#ifdef __APPLE__
+	addr->sin6_len = sizeof(struct sockaddr_in6);
+#endif
+	if ((size >= offset + length) && (length == 16))
+		addr->sin6_addr = *(const struct in6_addr*)((const char*)buffer + offset);
+	return addr;
+}
+
+static size_t
+mdns_record_parse_txt(const void* buffer, size_t size, size_t offset, size_t length,
+                      mdns_record_txt_t* records, size_t capacity) {
+	size_t parsed = 0;
+	const char* strdata;
+	size_t separator, sublength;
+	size_t end = offset + length;
+
+	if (size < end)
+		end = size;
+
+	while ((offset < end) && (parsed < capacity)) {
+		strdata = (const char*)buffer + offset;
+		sublength = *(const unsigned char*)strdata;
+
+		++strdata;
+		offset += sublength + 1;
+
+		separator = 0;
+		for (size_t c = 0; c < sublength; ++c) {
+			// DNS-SD TXT record keys MUST be printable US-ASCII, [0x20, 0x7E]
+			if ((strdata[c] < 0x20) || (strdata[c] > 0x7E))
+				break;
+			if (strdata[c] == '=') {
+				separator = c;
+				break;
+			}
+		}
+
+		if (!separator)
+			continue;
+
+		if (separator < sublength) {
+			records[parsed].key.str = strdata;
+			records[parsed].key.length = separator;
+			records[parsed].value.str = strdata + separator + 1;
+			records[parsed].value.length = sublength - (separator + 1);
+		} else {
+			records[parsed].key.str = strdata;
+			records[parsed].key.length = sublength;
+		}
+
+		++parsed;
+	}
+
+	return parsed;
+}
+
+#ifdef _WIN32
+#undef strncasecmp
+#endif
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
This replaces the original multicast code with mDNS/DNS-SD and should allow for LAN discovery with minimal to zero effort on the part of users.