### PR TITLE
Call common_select_init() before cutscenes where needed

### DIFF
--- a/code/missionui/fictionviewer.cpp
+++ b/code/missionui/fictionviewer.cpp
@@ -384,14 +384,6 @@ void fiction_viewer_init()
 		audiostream_play(Fiction_viewer_voice, Master_voice_volume, 0);
 	}
 
-	// we have to reset/setup the shipselect and weaponselect pointers before moving on
-	ship_select_common_init();
-	weapon_select_common_init();
-
-	if (Game_mode & GM_MULTIPLAYER) {
-		multi_ts_common_init();
-	}
-
 	Fiction_viewer_inited = 1;
 }
 

--- a/code/missionui/missioncmdbrief.cpp
+++ b/code/missionui/missioncmdbrief.cpp
@@ -628,14 +628,6 @@ void cmd_brief_init(int team)
 	for (i=0; i<Cur_cmd_brief->num_stages; i++)
 		cmd_brief_ani_wave_init(i);
 
-	// we have to reset/setup the shipselect and weaponselect pointers before moving on
-	ship_select_common_init();
-	weapon_select_common_init();
-
-	if (Game_mode & GM_MULTIPLAYER) {
-		multi_ts_common_init();
-	}
-
 	cmd_brief_init_voice();
 	cmd_brief_new_stage(0);
 	Cmd_brief_paused = 0;

--- a/code/missionui/redalert.cpp
+++ b/code/missionui/redalert.cpp
@@ -353,14 +353,6 @@ void red_alert_init()
 
 	red_alert_voice_load();
 
-	// we have to reset/setup the shipselect and weaponselect pointers before moving on
-	ship_select_common_init();
-	weapon_select_common_init();
-
-	if (Game_mode & GM_MULTIPLAYER) {
-		multi_ts_common_init();
-	}
-
 	Text_delay = timestamp(200);
 
 	Red_alert_voice_started = 0;

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -5483,6 +5483,8 @@ void game_enter_state( int old_state, int new_state )
 			break;
 
 		case GS_STATE_FICTION_VIEWER:
+			// init some elements common to ship/weapon select (to be done before cutscene)
+			common_select_init();
 			common_maybe_play_cutscene(MOVIE_PRE_FICTION); 	
 			fiction_viewer_init();
 			break;
@@ -5491,6 +5493,8 @@ void game_enter_state( int old_state, int new_state )
 			if (old_state == GS_STATE_OPTIONS_MENU) {
 				cmd_brief_unhold();
 			} else {
+				// init some elements common to ship/weapon select (to be done before cutscene)
+				common_select_init();
 				common_maybe_play_cutscene(MOVIE_PRE_CMD_BRIEF); 	
 				int team_num = 0;  // team number used as index for which cmd brief to use.
 				cmd_brief_init(team_num);
@@ -5499,11 +5503,16 @@ void game_enter_state( int old_state, int new_state )
 		}
 
 		case GS_STATE_RED_ALERT:
+			// init some elements common to ship/weapon select (to be done before cutscene)
+			common_select_init();
 			common_maybe_play_cutscene(MOVIE_PRE_BRIEF); 	
 			red_alert_init();
 			break;
 
 		case GS_STATE_BRIEFING:
+			// init some elements common to ship/weapon select (to be done before cutscene)
+			common_select_init();
+
 			if ( (old_state != GS_STATE_TEAM_SELECT) && (old_state != GS_STATE_SHIP_SELECT) &&
 				 (old_state != GS_STATE_WEAPON_SELECT) && (old_state != GS_STATE_OPTIONS_MENU) &&
 				 (old_state != GS_STATE_GAMEPLAY_HELP) )


### PR DESCRIPTION
Fixes crashing in multi where ships are locked by host while a
client is on fiction viewer, command brief, red alert, or cutscene.