### PR TITLE
Prevent loadout issues in multi due to iff changes

### DIFF
--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -2916,6 +2916,10 @@ int parse_object(mission *pm, int  /*flag*/, p_object *p_objp)
 
 	find_and_stuff("$Team:", &p_objp->team, F_NAME, temp_team_names, Num_iffs, "team name");
 
+	// save current team for loadout purposes, so that in multi we always respawn
+	// from the original loadout slot even if the team changes
+	p_objp->loadout_team = p_objp->team;
+
 	if (optional_string("$Team Color Setting:")) {
 		char temp[NAME_LENGTH];
 		stuff_string(temp, F_NAME, NAME_LENGTH);

--- a/code/mission/missionparse.h
+++ b/code/mission/missionparse.h
@@ -336,6 +336,7 @@ public:
 	matrix	orient;
 	int	ship_class;
 	int	team;
+	int loadout_team;						// original team, should never be changed after being set!!
 	int	behavior;							// ai_class;
 	int	ai_goals;							// sexp of lists of goals that this ship should try and do
 	char	cargo1;

--- a/code/network/multiteamselect.cpp
+++ b/code/network/multiteamselect.cpp
@@ -1684,7 +1684,8 @@ void multi_ts_get_team_and_slot(char* ship_name, int* team_index, int* slot_inde
 		return;
 	}
 
-	*team_index = ship_regp->p_objp->team;
+	// this should send the original team, in case the team changes via sexp or scripting
+	*team_index = ship_regp->p_objp->loadout_team;
 
 	// if we're in team vs. team mode
 	if(Netgame.type_flags & NG_TYPE_TEAM){


### PR DESCRIPTION
Fixes a bug where the loadout will be different when respawning or with in-game joining if the iff of the ship/wing has changed since the mission started.