### PR TITLE
Add IFF to missile lock restrictions, and now all missiles can use them

### DIFF
--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -8897,7 +8897,7 @@ void ai_chase()
 								}
 							}
 
-							if (timestamp_elapsed(swp->next_secondary_fire_stamp[current_bank])) {
+							if (timestamp_elapsed(swp->next_secondary_fire_stamp[current_bank]) && weapon_can_lock_on_ship(swip, En_objp->instance)) {
 								if (current_bank >= 0) {
 									float firing_range;
 									

--- a/code/hud/hudlock.cpp
+++ b/code/hud/hudlock.cpp
@@ -498,7 +498,8 @@ int hud_abort_lock()
 	if ( (Player_ai->target_objnum >= 0) ) {
 		target_team = obj_team(&Objects[Player_ai->target_objnum]);
 
-		if ( ( Player_ship->team == target_team) && ( !iff_x_attacks_y(Player_ship->team, target_team) ) ) {
+		if ( ( Player_ship->team == target_team) && ( !iff_x_attacks_y(Player_ship->team, target_team) ) 
+			&& !weapon_has_iff_restrictions(wip)) {
 			// if we're in multiplayer dogfight, ignore this
 			// remember to check if we're firing a missile that doesn't require a current target
 			if(!MULTI_DOGFIGHT || wip->target_restrict == LR_ANY_TARGETS) {
@@ -907,8 +908,8 @@ void hud_lock_acquire_uncaged_target(lock_info *current_lock, weapon_info *wip)
 			continue;
 		}
 
-		// if this is part of the same team, reject lock
-		if ( Player_ship->team == obj_team(A) ) {
+		// if this is part of the same team and doesn't have any iff restrictions, reject lock
+		if ( !weapon_has_iff_restrictions(wip) && Player_ship->team == obj_team(A) ) {
 			continue;
 		}
 
@@ -921,7 +922,7 @@ void hud_lock_acquire_uncaged_target(lock_info *current_lock, weapon_info *wip)
 			continue;
 		}*/
 
-		if (!weapon_multilock_can_lock_on_ship(wip, A->instance)) {
+		if (!weapon_can_lock_on_ship(wip, A->instance)) {
 			continue;
 		}
 
@@ -1039,7 +1040,7 @@ void hud_lock_determine_lock_target(lock_info *lock_slot, weapon_info *wip)
 			return;
 		}
 
-		if ( !weapon_multilock_can_lock_on_ship(wip, lock_slot->obj->instance) ) {
+		if ( !weapon_can_lock_on_ship(wip, lock_slot->obj->instance) ) {
 			ship_clear_lock(lock_slot);
 			return;
 		}
@@ -1107,7 +1108,7 @@ void hud_lock_determine_lock_target(lock_info *lock_slot, weapon_info *wip)
 			return;
 		}
 
-		if ( !weapon_multilock_can_lock_on_ship(wip, lock_slot->obj->instance) ) {
+		if ( !weapon_can_lock_on_ship(wip, lock_slot->obj->instance) ) {
 			ship_clear_lock(lock_slot);
 			return;
 		}

--- a/code/weapon/weapon.h
+++ b/code/weapon/weapon.h
@@ -248,12 +248,12 @@ enum InFlightSoundType
 
 #define MAX_SUBSTITUTION_PATTERNS	10
 
-enum class MultilockRestrictionType
+enum class LockRestrictionType
 {
-	TYPE, CLASS, SPECIES
+	TYPE, CLASS, SPECIES, IFF
 };
 
-typedef std::pair<MultilockRestrictionType, int> multilock_restriction;
+typedef std::pair<LockRestrictionType, int> lock_restriction;
 
 struct weapon_info
 {
@@ -352,8 +352,8 @@ struct weapon_info
 	int max_seeking;						// how many seekers can be active at a time if multilock is enabled. A value of one will lock stuff up one by one.
 	int max_seekers_per_target;			// how many seekers can be attached to a target.
 
-	SCP_vector<multilock_restriction> ship_restrict;
-	SCP_vector<std::pair<MultilockRestrictionType, SCP_string>> ship_restrict_strings;
+	SCP_vector<lock_restriction> ship_restrict;                     // list of pairs of types of restrictions, and the specific restriction of that type
+	SCP_vector<std::pair<LockRestrictionType, SCP_string>> ship_restrict_strings;    // the above but the specific restrictions are the parsed strings (instead of looked up indicies)
 
 	bool trigger_lock;						// Trigger must be held down and released to lock and fire.
 	bool launch_reset_locks;				// Lock indicators reset after firing
@@ -676,8 +676,11 @@ void shield_impact_explosion(vec3d *hitpos, object *objp, float radius, int idx)
 // Swifty - return number of max simultaneous locks 
 int weapon_get_max_missile_seekers(weapon_info *wip);
 
-// return if this weapon can lock on this ship, based on its type, class or species
-bool weapon_multilock_can_lock_on_ship(weapon_info *wip, int ship_num);
+// return if this weapon can lock on this ship, based on its type, class, species or iff
+bool weapon_can_lock_on_ship(weapon_info *wip, int ship_num);
+
+// return if this weapon has iff restrictions, and should ignore normal iff targeting restrictions
+bool weapon_has_iff_restrictions(weapon_info* wip);
 
 
 #endif


### PR DESCRIPTION
Moved the restrictions parsing so it applies to non-aspect seeking and non-multilock missiles as well, including single target missiles and heat seeking missiles. Renamed some stuff to make this clear.

Since IFF restrictions can now be specified, including friendlies, using IFF restrictions at all will preclude the normal IFF targeting restrictions (hostiles only, no friendlies, etc) so the `weapon_has_iff_restrictions()` function is used to determine if this is case.