### PR TITLE
Slightly alter when a timestamp warning is written to the log.

### DIFF
--- a/code/network/multi_obj.cpp
+++ b/code/network/multi_obj.cpp
@@ -2334,10 +2334,14 @@ void multi_oo_process_all(net_player *pl)
 	// only the very longest frames are going to have greater than 255 ms, so cap it at that.
 	if (temp_timestamp > 255) {
 		temp_timestamp = 255;
-	} else if (temp_timestamp < 0) {
-		// Send to the log if we're getting negative times. 
-		mprintf(("Somehow the object update packet is calculating a negative time differential in multi_oo_send_control_info. Value: %d. It's going to guess on a correct value. Please investigate.", temp_timestamp));
-		temp_timestamp = TIMESTAMP_OUT_IF_ERROR;
+
+	} else if (temp_timestamp < 0 ){
+		// this should only happen when the game is just starting, because the previous timestamp is nonsense.
+		if (Oo_info.number_of_frames > 1) {
+			// Send to the log if we're getting negative times. 
+			mprintf(("Somehow the object update packet is calculating a negative time differential in multi_oo_send_control_info. Value: %d. It's going to guess on a correct value. Please investigate.", temp_timestamp));
+		}
+		temp_timestamp = TIMESTAMP_OUT_IF_ERROR; // average amount of time per frame on a 60fps machine
 	}
 
 	// finish adding the timestamp


### PR DESCRIPTION
This was always writing a warning about negative timestamps to the log.  But negative timestamp differentials are supposed to happen on the first two frames because there is no actual information to compare to.