### PR TITLE
Fix a bug with shockwave damage parsing

### DIFF
--- a/code/weapon/shockwave.cpp
+++ b/code/weapon/shockwave.cpp
@@ -709,6 +709,7 @@ void shockwave_create_info_init(shockwave_create_info *sci)
 	sci->rot_angles.p = sci->rot_angles.b = sci->rot_angles.h = 0.0f;
 	sci->rot_defined = false;
 	sci->damage_type_idx = sci->damage_type_idx_sav = -1;
+	sci->damage_overidden = false;
 }
 
 /**

--- a/code/weapon/shockwave.h
+++ b/code/weapon/shockwave.h
@@ -79,6 +79,7 @@ typedef struct shockwave_create_info {
 	float speed;
 	angles rot_angles;
 	bool rot_defined;		// if the modder specified rot_angles
+	bool damage_overidden;  // did this have shockwave damage specifically set or not
 
 	int damage_type_idx;
 	int damage_type_idx_sav;	// stored value from table used to reset damage_type_idx

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -701,6 +701,7 @@ void parse_shockwave_info(shockwave_create_info *sci, const char *pre_char)
 	sprintf(buf, "%sShockwave damage:", pre_char);
 	if(optional_string(buf)) {
 		stuff_float(&sci->damage);
+		sci->damage_overidden = true;
 	}
 
 	sprintf(buf, "%sShockwave damage type:", pre_char);
@@ -1150,7 +1151,7 @@ int parse_weapon(int subtype, bool replace, const char *filename)
 		stuff_float(&wip->damage);
 		//WMC - now that shockwave damage can be set for them individually,
 		//do this automagically
-		if(first_time) {
+		if(!wip->shockwave.damage_overidden) {
 			wip->shockwave.damage = wip->damage;
 		}
 	}


### PR DESCRIPTION
`$Damage` only updates the shockwave's damage the first time through, future .tbms won't affect it. With this, changes to `$Damage` also affect the shockwave damage unless it was specifically set.