### PR TITLE
Controls 0, 1, and 2 - Vectorize Controls_config, Refactor Control Presets, and Use Undosys

### DIFF
--- a/code/controlconfig/controlsconfig.cpp
+++ b/code/controlconfig/controlsconfig.cpp
@@ -821,7 +821,7 @@ int control_config_do_reset()
 	// first, determine how many bindings need to be changed
 	for (size_t e = 0; e < Control_config.size(); ++e) {
 		auto item = Control_config[e];
-		auto default_item = Control_config_presets[Defaults_cycle_pos].bindings[i];
+		auto default_item = Control_config_presets[Defaults_cycle_pos].bindings[e];
 
 		if (item.disabled) {
 			// skip

--- a/code/controlconfig/controlsconfig.cpp
+++ b/code/controlconfig/controlsconfig.cpp
@@ -824,22 +824,17 @@ int control_config_do_reset()
 	return 0;
 }
 
-/**
- * @brief Resets all controls to values within the currently selected preset
- */
 void control_config_reset_defaults()
 {
-	int i;
-
 	// Reset keyboard defaults
 	const CC_preset &preset = Control_config_presets[Defaults_cycle_pos];
-	for (auto i = 0; i < Control_config.size(); ++i) {
+	for (size_t i = 0; i < Control_config.size(); ++i) {
 		Control_config[i].key_id = preset.bindings[i].first.btn;
 		Control_config[i].joy_id = preset.bindings[i].second.btn;
 	}
 
 	// Reset joy defaults.  No presets for joysticks currently
-	for (i=0; i<NUM_JOY_AXIS_ACTIONS; i++) {
+	for (size_t i = 0; i < NUM_JOY_AXIS_ACTIONS; i++) {
 		Axis_map_to[i] = control_config_axis_default(i);
 		Invert_axis[i] = Invert_axis_defaults[i];
 	}
@@ -2160,9 +2155,6 @@ int check_control_used(int id, int key)
 	return 0;
 }
 
-/**
-* Wrapper for check_control_used. Allows the game to ignore the key if told to do so by the ignore-key SEXP.
-*/
 int check_control(int id, int key) 
 {
 	if (check_control_used(id, key)) {
@@ -2189,7 +2181,6 @@ int check_control(int id, int key)
 	return 0;
 }
 
-// get heading, pitch, bank, throttle abs. and throttle rel. values.
 void control_get_axes_readings(int *h, int *p, int *b, int *ta, int *tr)
 {
 	int axes_values[JOY_NUM_AXES];
@@ -2267,19 +2258,14 @@ void control_used(int id)
 
 void control_config_clear_used_status()
 {
-	int i;
-
-	for (i=0; i<CCFG_MAX; i++) {
-		Control_config[i].used = 0;
+	for (auto &item : Control_config) {
+		item.used = 0;
 	}
 }
 
 void control_config_clear()
 {
-	int i;
-
-	// Reset keyboard defaults
-	for (i=0; i<CCFG_MAX; i++) {
-		Control_config[i].key_id = Control_config[i].joy_id = -1;
+	for (auto &item : Control_config) {
+		item.key_id = item.joy_id = -1;
 	}
 }

--- a/code/controlconfig/controlsconfig.cpp
+++ b/code/controlconfig/controlsconfig.cpp
@@ -1419,7 +1419,7 @@ void control_config_draw_selected_preset() {
 	// Draw the string
 	int font_height = gr_get_font_height();
 	int w;
-	gr_get_string_size(&w, NULL, preset_str.c_str());
+	gr_get_string_size(&w, nullptr, preset_str.c_str());
 	gr_set_color_fast(&Color_text_normal);
 
 	if (gr_screen.res == GR_640) {

--- a/code/controlconfig/controlsconfig.cpp
+++ b/code/controlconfig/controlsconfig.cpp
@@ -123,7 +123,7 @@ int Conflict_bright = 0;
 #define LIST_BUTTONS_MAX	42
 #define JOY_AXIS			0x80000
 
-static int Num_cc_lines;
+static int Num_cc_lines;	// Number of Cc_lines to display on the current page. Is, at worse, CCFG_MAX + NUM_JOY_AXIS_ACTIONS
 
 /**
  * @struct cc_line
@@ -506,30 +506,34 @@ void control_config_conflict_check()
 // do list setup required prior to rendering and checking for the controls listing.  Called when list changes
 void control_config_list_prepare()
 {
-	int j, y, z;
+	int y;	// Offset, in pixels, the Cc_line has from the top
+	int z;	// index into Control_config[]
 	int font_height = gr_get_font_height();
 
 	Num_cc_lines = y = z = 0;
-	while (z < CCFG_MAX) {
-		if (Control_config[z].tab == Tab && !Control_config[z].disabled) {
-			if (Control_config[z].indexXSTR > 1) {
-				Cc_lines[Num_cc_lines].label = XSTR(Control_config[z].text.c_str(), Control_config[z].indexXSTR, true);
-			} else if (Control_config[z].indexXSTR == 1) {
-				Cc_lines[Num_cc_lines].label = XSTR(Control_config[z].text.c_str(), CONTROL_CONFIG_XSTR + z, true);
+
+	// Populate the digital controls
+	for (const auto &item : Control_config) {
+		if (item.tab == Tab && !item.disabled) {
+			if (item.indexXSTR > 1) {
+				Cc_lines[Num_cc_lines].label = XSTR(item.text.c_str(), item.indexXSTR, true);
+			} else if (item.indexXSTR == 1) {
+				Cc_lines[Num_cc_lines].label = XSTR(item.text.c_str(), CONTROL_CONFIG_XSTR + z, true);
 			} else {
-				Cc_lines[Num_cc_lines].label = Control_config[z].text.c_str();
+				Cc_lines[Num_cc_lines].label = item.text.c_str();
 			}
 
 			Cc_lines[Num_cc_lines].cc_index = z;
 			Cc_lines[Num_cc_lines++].y = y;
 			y += font_height + 2;
-		}
+		} // Else, Ignore and hide items
 
-		z++;
+		z++;	// z is the index position in Control_config[]
 	}
 
+	// Populate the analog controls.
 	if (Tab == SHIP_TAB) {
-		for (j=0; j<NUM_JOY_AXIS_ACTIONS; j++) {
+		for (int j = 0; j < NUM_JOY_AXIS_ACTIONS; j++) {
 			Cc_lines[Num_cc_lines].label = Joy_axis_action_text[j];
 			Cc_lines[Num_cc_lines].cc_index = j | JOY_AXIS;
 			Cc_lines[Num_cc_lines++].y = y;
@@ -1194,7 +1198,7 @@ void control_config_init()
 
 	// Init Cc_lines
 	Cc_lines.clear();
-	Cc_lines.resize(Control_config.size());	// Can't use CCFG_MAX here, since scripts or might add controls
+	Cc_lines.resize(Control_config.size() + NUM_JOY_AXIS_ACTIONS);	// Can't use CCFG_MAX here, since scripts or might add controls
 
 	Defaults_cycle_pos = 0;
 

--- a/code/controlconfig/controlsconfig.cpp
+++ b/code/controlconfig/controlsconfig.cpp
@@ -1100,12 +1100,6 @@ void control_config_cancel_exit()
 	std::move(Axis_map_to_backup, Axis_map_to_backup + JOY_NUM_AXES, Axis_map_to);
 	std::move(Invert_axis_backup, Invert_axis_backup + JOY_NUM_AXES, Invert_axis);
 
-	// Free up memory from dynamic containers
-	Control_config_backup.clear();
-	Cc_lines.clear();
-	Conflicts.clear();
-	Undo_controls.clear();
-
 	gameseq_post_event(GS_EVENT_PREVIOUS_STATE);
 }
 

--- a/code/controlconfig/controlsconfig.cpp
+++ b/code/controlconfig/controlsconfig.cpp
@@ -777,7 +777,6 @@ int control_config_clear_all()
 
 		j++;
 	}
-	Assert(j == total);	// Er, how did we miss saving an item?
 	Undo_controls.save_stack(stack);
 
 	for (auto &item : Control_config) {
@@ -820,8 +819,16 @@ int control_config_do_reset()
 	Undo_stack stack;
 
 	// first, determine how many bindings need to be changed
-	for (auto &item : Control_config) {
-		if ((item.key_id != item.key_default) || (item.joy_id != item.joy_default)) {
+	for (i = 0; i < Control_config.size(); ++i) {
+		auto item = Control_config[i];
+		auto default_item = Control_config_presets[Defaults_cycle_pos].bindings[i];
+
+		if (item.disabled) {
+			// skip
+			continue;
+		}
+
+		if ((item.key_id != default_item.first.btn) || (item.joy_id != default_item.second.btn)) {
 			total++;
 		}
 	}

--- a/code/controlconfig/controlsconfig.cpp
+++ b/code/controlconfig/controlsconfig.cpp
@@ -517,11 +517,11 @@ void control_config_list_prepare()
 	while (z < CCFG_MAX) {
 		if (Control_config[z].tab == Tab && !Control_config[z].disabled) {
 			if (Control_config[z].indexXSTR > 1) {
-				Cc_lines[Num_cc_lines].label = XSTR(Control_config[z].text, Control_config[z].indexXSTR, true);
+				Cc_lines[Num_cc_lines].label = XSTR(Control_config[z].text.c_str, Control_config[z].indexXSTR, true);
 			} else if (Control_config[z].indexXSTR == 1) {
-				Cc_lines[Num_cc_lines].label = XSTR(Control_config[z].text, CONTROL_CONFIG_XSTR + z, true);
+				Cc_lines[Num_cc_lines].label = XSTR(Control_config[z].text.c_str, CONTROL_CONFIG_XSTR + z, true);
 			} else {
-				Cc_lines[Num_cc_lines].label = Control_config[z].text;
+				Cc_lines[Num_cc_lines].label = Control_config[z].text.c_str;
 			}
 
 			Cc_lines[Num_cc_lines].cc_index = z;
@@ -1985,11 +1985,11 @@ void control_config_do_frame(float frametime)
 		gr_printf_menu(x - w / 2, y - font_height, "%s", str);
 
 		if (Control_config[i].indexXSTR > 1) {
-			strcpy_s(buf, XSTR(Control_config[i].text, Control_config[i].indexXSTR, true));
+			strcpy_s(buf, XSTR(Control_config[i].text.c_str, Control_config[i].indexXSTR, true));
 		} else if (Control_config[i].indexXSTR == 1) {
-			strcpy_s(buf, XSTR(Control_config[i].text, CONTROL_CONFIG_XSTR + i, true));
+			strcpy_s(buf, XSTR(Control_config[i].text.c_str, CONTROL_CONFIG_XSTR + i, true));
 		} else {
-			strcpy_s(buf, Control_config[i].text);
+			strcpy_s(buf, Control_config[i].text.c_str);
 		}
 
 		font::force_fit_string(buf, 255, Conflict_wnd_coords[gr_screen.res][CONTROL_W_COORD]);

--- a/code/controlconfig/controlsconfig.cpp
+++ b/code/controlconfig/controlsconfig.cpp
@@ -819,8 +819,8 @@ int control_config_do_reset()
 	Undo_stack stack;
 
 	// first, determine how many bindings need to be changed
-	for (i = 0; i < Control_config.size(); ++i) {
-		auto item = Control_config[i];
+	for (size_t e = 0; e < Control_config.size(); ++e) {
+		auto item = Control_config[e];
 		auto default_item = Control_config_presets[Defaults_cycle_pos].bindings[i];
 
 		if (item.disabled) {

--- a/code/controlconfig/controlsconfig.cpp
+++ b/code/controlconfig/controlsconfig.cpp
@@ -1316,6 +1316,63 @@ void control_config_close()
 	Cc_lines.resize(0);
 }
 
+/**
+ * @brief Display the currently selected preset
+ */
+void control_config_draw_selected_preset() {
+	SCP_string preset_str;
+	auto preset_it = Control_config_presets.begin();
+
+	// Find the matching preset.
+	// We do this instead of relying on Defaults_cycle_pos because the player may end up duplicating a preset
+	for (; preset_it != Control_config_presets.end(); ++preset_it) {
+		bool found_match = true;
+
+		// Check digital controls
+		for (size_t i = 0; i < Control_config.size(); ++i) {
+			if (Control_config[i].disabled) {
+				// Skip
+				continue;
+			}
+
+			// Check key
+			if (Control_config[i].key_id != preset_it->bindings[i].first.btn) {
+				found_match = false;
+				break;
+			}
+
+			// Check Joy
+			if (Control_config[i].joy_id != preset_it->bindings[i].second.btn) {
+				found_match = false;
+				break;
+			}
+		}
+
+
+		if (found_match) {
+			break;
+		}
+	}
+
+	if (preset_it != Control_config_presets.end()) {
+		sprintf(preset_str, "Controls: %s", preset_it->name.c_str());
+	} else {
+		sprintf(preset_str, "Controls: custom");
+	}
+
+	// Draw the string
+	int font_height = gr_get_font_height();
+	int w;
+	gr_get_string_size(&w, NULL, preset_str.c_str());
+	gr_set_color_fast(&Color_text_normal);
+
+	if (gr_screen.res == GR_640) {
+		gr_string(16, (24 - font_height) / 2, preset_str.c_str(), GR_RESIZE_MENU);
+	} else {
+		gr_string(24, (40 - font_height) / 2, preset_str.c_str(), GR_RESIZE_MENU);
+	}
+}
+
 void control_config_do_frame(float frametime)
 {
 	const char *str;
@@ -1987,46 +2044,8 @@ void control_config_do_frame(float frametime)
 		List_buttons[i++].disable();
 	}
 
-	// If multiple controls presets are provided, display which one is in use
-	/* TODO
-	if (Control_config_presets.size() > 1) {
-		SCP_string preset_str;
-		int matching_preset = -1;
-
-		for (i=0; i<(int)Control_config_presets.size(); i++) {
-			bool this_preset_matches = true;
-			config_item *this_preset = Control_config_presets[i];
-
-			for (j=0; j<CCFG_MAX; j++) {
-				if (!Control_config[j].disabled && Control_config[j].key_id != this_preset[j].key_default) {
-					this_preset_matches = false;
-					break;
-				}
-			}
-
-			if (this_preset_matches) {
-				matching_preset = i;
-				break;
-			}
-		}
-
-		if (matching_preset >= 0) {
-			sprintf(preset_str, "Controls: %s", Control_config_preset_names[matching_preset].c_str());
-		} else {
-			sprintf(preset_str, "Controls: custom");
-			
-		}
-
-		gr_get_string_size(&w, NULL, preset_str.c_str());
-		gr_set_color_fast(&Color_text_normal);
-
-		if (gr_screen.res == GR_640) {
-			gr_string(16, (24 - font_height) / 2, preset_str.c_str(), GR_RESIZE_MENU);
-		} else {
-			gr_string(24, (40 - font_height) / 2, preset_str.c_str(), GR_RESIZE_MENU);
-		}
-	}
-	*/
+	// Display preset in use
+	control_config_draw_selected_preset();
 
 	// blit help overlay if active
 	help_overlay_maybe_blit(Control_config_overlay_id, gr_screen.res);

--- a/code/controlconfig/controlsconfig.cpp
+++ b/code/controlconfig/controlsconfig.cpp
@@ -873,7 +873,7 @@ void control_config_reset_defaults()
 	}
 
 	// Reset joy defaults.  No presets for joysticks currently
-	for (size_t i = 0; i < NUM_JOY_AXIS_ACTIONS; i++) {
+	for (int i = 0; i < NUM_JOY_AXIS_ACTIONS; i++) {
 		Axis_map_to[i] = control_config_axis_default(i);
 		Invert_axis[i] = Invert_axis_defaults[i];
 	}

--- a/code/controlconfig/controlsconfig.cpp
+++ b/code/controlconfig/controlsconfig.cpp
@@ -173,10 +173,14 @@ static unsigned int Defaults_cycle_pos = 0; // the controls preset that was last
 
 int Control_config_overlay_id;
 
-static struct {
+struct conflict {
 	int key;  // index of other control in conflict with this one
 	int joy;  // index of other control in conflict with this one
-} Conflicts[CCFG_MAX];
+
+	conflict() : key(-1), joy(-1) {};
+};
+
+SCP_vector<conflict> Conflicts;
 
 int Conflicts_axes[NUM_JOY_AXIS_ACTIONS];
 
@@ -1167,6 +1171,10 @@ void control_config_init()
 	std::copy(Axis_map_to, Axis_map_to + NUM_JOY_AXIS_ACTIONS, Axis_map_to_backup);
 	std::copy(Invert_axis, Invert_axis + JOY_NUM_AXES, Invert_axis_backup);
 
+	// Init conflict vector
+	Conflicts.clear();
+	Conflicts.resize(Control_config.size());
+
 	// Init Cc_lines
 	Cc_lines.clear();
 	Cc_lines.resize(Control_config.size() + NUM_JOY_AXIS_ACTIONS);	// Can't use CCFG_MAX here, since scripts or might add controls
@@ -1314,6 +1322,7 @@ void control_config_close()
 	// Free up memory from dynamic containers
 	Control_config_backup.resize(0);
 	Cc_lines.resize(0);
+	Conflicts.resize(0);
 }
 
 /**

--- a/code/controlconfig/controlsconfig.cpp
+++ b/code/controlconfig/controlsconfig.cpp
@@ -1184,13 +1184,17 @@ void control_config_init()
 	int i;
 	ui_button_info *b;
 
-	// Free up data from any previous backups.  Not needed but is insurance
+	// Init the backup vectors
 	Control_config_backup.clear();
-
-	// make backup of all controls
+	Control_config_backup.reserve(Control_config.size());
 	std::copy(Control_config.begin(), Control_config.end(), std::back_inserter(Control_config_backup));
-	std::copy(Axis_map_to, Axis_map_to + JOY_NUM_AXES, Axis_map_to_backup);
+
+	std::copy(Axis_map_to, Axis_map_to + NUM_JOY_AXIS_ACTIONS, Axis_map_to_backup);
 	std::copy(Invert_axis, Invert_axis + JOY_NUM_AXES, Invert_axis_backup);
+
+	// Init Cc_lines
+	Cc_lines.clear();
+	Cc_lines.resize(Control_config.size());	// Can't use CCFG_MAX here, since scripts or might add controls
 
 	Defaults_cycle_pos = 0;
 
@@ -1333,6 +1337,10 @@ void control_config_close()
 			Invert_text[idx] = NULL;
 		}
 	}
+
+	// Free up memory from dynamic containers
+	Control_config_backup.resize(0);
+	Cc_lines.resize(0);
 }
 
 void control_config_do_frame(float frametime)

--- a/code/controlconfig/controlsconfig.h
+++ b/code/controlconfig/controlsconfig.h
@@ -71,7 +71,6 @@ enum Joy_axis_action_mode {
 	JAAM_BTN_POS,   //!< Button mode, positive side.  Axis position in the positive side will trigger a button action
 };
 
-
 /*!
  * Control Configuration Types. Namely differ in how the control is activated
  */
@@ -81,93 +80,12 @@ enum CC_type {
 };
 
 /*!
- *  A singular button binding
- */
-struct CC_bind {
-	CID cid = CID_NONE; //!< Which controller this belongs to
-	short btn =     -1; //!< Which button to index; If cid == CID_KEYBOARD, this is a key hash.
-};
-
-/*!
- * A pair of bindings. Primary = first, Secondary = second
- */
-typedef std::pair<CC_bind, CC_bind> CCB;
-
-/*!
- * A preset, a collection of bindings for use in Control_config with an associated name
- */
-class CC_preset {
-public:
-	SCP_vector<CCB> bindings;
-	SCP_string name;
-};
-
-/*!
- * Control configuration item type.
- * @detail Contains binding info, documentation, behavior, etc. for a single control
- */
-class CCI {
-public:
-// Items Set in menu
-	short joy_default;
-	short key_default;
-	short joy_id;
-	short key_id;
-
-	char tab;               //!< what tab (category) it belongs in
-	int  indexXSTR;         //!< what string index we should use to translate this with an XSTR 0 = None, 1= Use item index + CONTROL_CONFIG_XSTR, 2 <= use CCI::indexXSTR directly
-	SCP_string text;        //!< describes the action in the config screen
-
-	CC_type type;           //!< manner control should be checked in
-
-// Items used during gameplay
-	int  used;                  //!< has control been used yet in mission?  If so, this is the timestamp
-	bool disabled;              //!< whether this action should be available at all
-	bool continuous_ongoing;    //!< whether this action is a continuous one and is currently ongoing
-
-	CCI() : disabled(true) {};
-};
-
-enum IoActionId;
-
-/*!
- * Builder predicate to populate a ControlConfig vector with hardcoded default bindings.
- */
-class CCI_builder {
-public:
-	/*!
-	 * Initilizes the given ControlConfig vector
-	 */
-	CCI_builder(SCP_vector<CCI>& _ControlConfig);
-
-	/*!
-	 * Start a chain of factory methods. If there are any pre-init work to be done, that's done here.
-	 */
-	CCI_builder& start();
-
-	/*!
-	 * End a chain of factory methods.  If there any post-init work to be done, that's done here.
-	 */
-	void end();
-
-	/*!
-	 * Assigns the hardcoded binding to the given action
-	 * @note This differs from the original hardcode from :V: in the hopes of it being more intuitive to future IoAction additions
-	 */
-	CCI_builder& operator()(IoActionId action_id, short key_default, short joy_default, char tab, int indexXSTR, const char *text, CC_type type, bool disabled = false);
-
-private:
-	CCI_builder();	// Only one builder per Control Config, so a default constructor is useless
-	SCP_vector<CCI>& ControlConfig;
-};
-
-/*!
  * All available actions
  * This is the value of the id field in config_item
  * The first group of items are ship targeting.
+ *
+ * Note: Do not adjust the order or numeric value
  */
-
-// Since we're upgrading the Control_config array into a proper vector, and since we're using contructor predicates we can organize these to however we like and pass the IoActionId to the constructor to ensure the correct placement
 enum IoActionId  {
 	TARGET_NEXT										=0,		//!< target next
 	TARGET_PREV										=1,		//!< target previous
@@ -376,6 +294,89 @@ enum IoActionId  {
 	CCFG_MAX                                  //!<  The total number of defined control actions (or last define + 1)
 };
 
+
+/*!
+ * A pair of bindings. Primary = first, Secondary = second
+ */
+typedef std::pair<CC_bind, CC_bind> CCB;
+
+
+/*!
+ *  A singular button binding
+ */
+struct CC_bind {
+	CID cid = CID_NONE; //!< Which controller this belongs to
+	short btn = -1; //!< Which button to index; If cid == CID_KEYBOARD, this is a key hash.
+};
+
+
+/*!
+ * A preset, a collection of bindings for use in Control_config with an associated name
+ */
+class CC_preset {
+public:
+	SCP_vector<CCB> bindings;
+	SCP_string name;
+};
+
+/*!
+ * Control configuration item type.
+ * @detail Contains binding info, documentation, behavior, etc. for a single control
+ */
+class CCI {
+public:
+// Items Set in menu
+	short joy_default;
+	short key_default;
+	short joy_id;
+	short key_id;
+
+	char tab;               //!< what tab (category) it belongs in
+	int  indexXSTR;         //!< what string index we should use to translate this with an XSTR 0 = None, 1= Use item index + CONTROL_CONFIG_XSTR, 2 <= use CCI::indexXSTR directly
+	SCP_string text;        //!< describes the action in the config screen
+
+	CC_type type;           //!< manner control should be checked in
+
+// Items used during gameplay
+	int  used;                  //!< has control been used yet in mission?  If so, this is the timestamp
+	bool disabled;              //!< whether this action should be available at all
+	bool continuous_ongoing;    //!< whether this action is a continuous one and is currently ongoing
+
+	CCI() : disabled(true) {};
+};
+
+/*!
+ * Builder predicate to populate a ControlConfig vector with hardcoded default bindings.
+ */
+class CCI_builder {
+public:
+	/*!
+	 * Initilizes the given ControlConfig vector
+	 */
+	CCI_builder(SCP_vector<CCI>& _ControlConfig);
+
+	/*!
+	 * Start a chain of factory methods. If there are any pre-init work to be done, that's done here.
+	 */
+	CCI_builder& start();
+
+	/*!
+	 * End a chain of factory methods.  If there any post-init work to be done, that's done here.
+	 */
+	void end();
+
+	/*!
+	 * Assigns the hardcoded binding to the given action
+	 * @note This differs from the original hardcode from :V: in the hopes of it being more intuitive to future IoAction additions
+	 */
+	CCI_builder& operator()(IoActionId action_id, short key_default, short joy_default, char tab, int indexXSTR, const char *text, CC_type type, bool disabled = false);
+
+private:
+	CCI_builder();	// Only one builder per Control Config, so a default constructor is useless
+	SCP_vector<CCI>& ControlConfig;
+};
+
+
 extern int Failed_key_index;
 
 extern int Axis_map_to[];           // Array to map an axis action to a joy axis. size() = NUM_JOY_AXIS_ACTIONS
@@ -393,17 +394,63 @@ extern SCP_vector<CC_preset> Control_config_presets; // tabled control presets; 
 extern const char **Scan_code_text;
 extern const char **Joy_button_text;
 
-void control_config_common_init();			//!< initialize common control config stuff - call at game startup after localization has been initialized
-void control_config_common_close();			//!< close common control config stuff - call at game shutdown
 
+/*!
+* @brief initialize common control config stuff - call at game startup after localization has been initialized
+*/
+void control_config_common_init();
+
+/*!
+ * @brief close common control config stuff - call at game shutdown
+ */
+void control_config_common_close();
+
+/*!
+ * @brief init config menu
+ */
 void control_config_init();
+
+/*!
+ * @brief do a frame of the config menu
+ */
 void control_config_do_frame(float frametime);
+
+/*!
+ * @brief close config menu
+ */
 void control_config_close();
 
+/*!
+ * @brief Cancel configuration of controls, revert any changes, return to previous menu/game state
+ */
 void control_config_cancel_exit();
 
+/*!
+ * @brief Resets all controls to values within the currently selected preset
+ */
 void control_config_reset_defaults();
+
+/*!
+ * Returns the IoActionId of a control bound to the given key
+ *
+ * @param[in] key           The key combo to look for
+ * @param[in] find_override If true, return the IoActionId of a control that has this key as its default
+ * @details If find_override is set to true, then this returns the index of the action
+ */
 int translate_key_to_index(const char *key, bool find_override=true);
+
+
+/*!
+ * @brief Given the system default key 'key', return the current key that is bound to that function.
+ *
+ * @param[in] key  The default key combo (as string) to a certain control
+ *
+ * @returns The key combo (as string) currently bound to the control
+ *
+ * @details Both the 'key' and the return value are descriptive strings that can be displayed
+ * directly to the user.  If 'key' isn't a real key, is not normally bound to anything,
+ * or there is no key currently bound to the function, NULL is returned.
+ */
 char *translate_key(char *key);
 
 /**
@@ -425,14 +472,70 @@ const char *textify_scancode(int code);
  */
 const char *textify_scancode_universal(int code);
 
+/*!
+ * @brief Checks how long a control has been active
+ *
+ * @param[in] id The IoActionId of the control to check
+ *
+ * @returns Time, in milliseconds, that the control has been active.
+ *
+ * @note This function is only to be used on CC_CONTINOUS type controls, or it will trigger an assertion
+ */
 float check_control_timef(int id);
+
+/**
+ * @brief Wrapper for check_control_used. Allows the game to ignore the key if told to do so by the ignore-key SEXP.
+ *
+ * @brief id    The IoActionId of the control to check
+ * @brief key   The key combo to check against the control.
+ *
+ * @returns 0 If the control wasn't used, or
+ * @returns 1 If the control was used
+ */
 int check_control(int id, int key = -1);
+
+/**
+ * @brief Gets the scaled reading for all control axes.
+ *
+ * @param[out] h  heading
+ * @param[out] p pitch
+ * @param[out] b bank
+ * @param[out] ta Throttle - Absolute
+ * @param[out] tr Throttle - Relative
+ *
+ * @note None of the input pointers may be nullptr
+ */
 void control_get_axes_readings(int *h, int *p, int *b, int *ta, int *tr);
+
+/**
+ * @brief Markes the given control (by IoActionId) as used
+ *
+ * @details Updates the ::used timestamp, triggers a script hook, and marks ::continous_ongoing as true
+ */
 void control_used(int id);
+
+/**
+ * @brief Clears the bindings of all controls
+ */
 void control_config_clear();
+
+/**
+ * @brief debug function used to indicate number of controls checked
+ */
 void control_check_indicate();
+
+/**
+ * @brief Clears the used timestamp of all controls
+ */
 void control_config_clear_used_status();
 
+/**
+ * @brief Applies sensitivity multiplier and deadzone histerisis to the raw axis value
+ *
+ * @param[in] raw  The raw axis value to transform
+ *
+ * @return The transformed value
+ */
 int joy_get_scaled_reading(int raw);
 
 #endif

--- a/code/controlconfig/controlsconfig.h
+++ b/code/controlconfig/controlsconfig.h
@@ -80,8 +80,6 @@ enum CC_type {
 	CC_TYPE_CONTINUOUS				//!< A continous control that is activated as long as the key or button is held down
 };
 
-SCP_vector<SCP_string> Joy_table;	//!< Table of all bound joystick GUID's;  Index in this vector is ordered and uses the CID
-
 /*!
  *  A singular button binding
  */

--- a/code/controlconfig/controlsconfig.h
+++ b/code/controlconfig/controlsconfig.h
@@ -337,10 +337,8 @@ public:
 
 // Items used during gameplay
 	int  used;                  //!< has control been used yet in mission?  If so, this is the timestamp
-	bool disabled;              //!< whether this action should be available at all
+	bool disabled = true;       //!< whether this action should be available at all
 	bool continuous_ongoing;    //!< whether this action is a continuous one and is currently ongoing
-
-	CCI() : disabled(true) {};
 };
 
 /*!

--- a/code/controlconfig/controlsconfig.h
+++ b/code/controlconfig/controlsconfig.h
@@ -296,12 +296,6 @@ enum IoActionId  {
 
 
 /*!
- * A pair of bindings. Primary = first, Secondary = second
- */
-typedef std::pair<CC_bind, CC_bind> CCB;
-
-
-/*!
  *  A singular button binding
  */
 struct CC_bind {
@@ -309,6 +303,10 @@ struct CC_bind {
 	short btn = -1; //!< Which button to index; If cid == CID_KEYBOARD, this is a key hash.
 };
 
+/*!
+ * A pair of bindings. Primary = first, Secondary = second
+ */
+typedef std::pair<CC_bind, CC_bind> CCB;
 
 /*!
  * A preset, a collection of bindings for use in Control_config with an associated name

--- a/code/controlconfig/controlsconfig.h
+++ b/code/controlconfig/controlsconfig.h
@@ -101,7 +101,7 @@ public:
 	short key_id;
 
 	char tab;               //!< what tab (category) it belongs in
-	int  indexXSTR;         //!< what string index we should use to translate this with an XSTR
+	int  indexXSTR;         //!< what string index we should use to translate this with an XSTR 0 = None, 1= Use item index + CONTROL_CONFIG_XSTR, 2 <= use CCI::indexXSTR directly
 	SCP_string text;        //!< describes the action in the config screen
 
 	CC_type type;           //!< manner control should be checked in

--- a/code/controlconfig/controlsconfig.h
+++ b/code/controlconfig/controlsconfig.h
@@ -85,7 +85,21 @@ enum CC_type {
  */
 struct CC_bind {
 	CID cid = CID_NONE; //!< Which controller this belongs to
-	short btn =     -1; //!< Which button to index
+	short btn =     -1; //!< Which button to index; If cid == CID_KEYBOARD, this is a key hash.
+};
+
+/*!
+ * A pair of bindings. Primary = first, Secondary = second
+ */
+typedef std::pair<CC_bind, CC_bind> CCB;
+
+/*!
+ * A preset, a collection of bindings for use in Control_config with an associated name
+ */
+class CC_preset {
+public:
+	SCP_vector<CCB> bindings;
+	SCP_string name;
 };
 
 /*!
@@ -375,8 +389,7 @@ extern int Joy_sensitivity;
 extern int Control_config_overlay_id;
 
 extern SCP_vector<CCI> Control_config;		//!< Stores the keyboard configuration
-//extern SCP_vector<CCI*> Control_config_presets; // tabled control presets; pointers to config_item arrays
-//extern SCP_vector<SCP_string> Control_config_preset_names; // names for Control_config_presets (identical order of items)
+extern SCP_vector<CC_preset> Control_config_presets; // tabled control presets; pointers to config_item arrays
 extern const char **Scan_code_text;
 extern const char **Joy_button_text;
 
@@ -389,7 +402,7 @@ void control_config_close();
 
 void control_config_cancel_exit();
 
-void control_config_reset_defaults(int presetnum=-1);
+void control_config_reset_defaults();
 int translate_key_to_index(const char *key, bool find_override=true);
 char *translate_key(char *key);
 

--- a/code/controlconfig/controlsconfig.h
+++ b/code/controlconfig/controlsconfig.h
@@ -51,9 +51,8 @@ enum Joy_axis_action_index {
 	JOY_HEADING_AXIS	=0,	//
 	JOY_PITCH_AXIS,
 	JOY_BANK_AXIS,
-	JOY_THROTTLE_AXIS,
-	JOY_LATERAL_AXIS,       //!< Left/Right thrust axis
-	JOY_VERTICAL_AXIS,      //!< Up/Down thrust axis
+	JOY_ABS_THROTTLE_AXIS,
+	JOY_REL_THROTTLE_AXIS,
 
 	/*!
 	 * This must always be below the last defined item
@@ -95,7 +94,8 @@ struct CC_bind {
  * Control configuration item type.
  * @detail Contains binding info, documentation, behavior, etc. for a single control
  */
-struct CCI {
+class CCI {
+public:
 // Items Set in menu
 	short joy_default;
 	short key_default;
@@ -113,8 +113,7 @@ struct CCI {
 	bool disabled;              //!< whether this action should be available at all
 	bool continuous_ongoing;    //!< whether this action is a continuous one and is currently ongoing
 
-	// default const.
-	CCI() : disabled(true){};
+	CCI() : disabled(true) {};
 };
 
 enum IoActionId;
@@ -137,7 +136,7 @@ public:
 	/*!
 	 * End a chain of factory methods.  If there any post-init work to be done, that's done here.
 	 */
-	CCI_builder& end();
+	void end();
 
 	/*!
 	 * Assigns the hardcoded binding to the given action
@@ -155,8 +154,7 @@ private:
  * This is the value of the id field in config_item
  * The first group of items are ship targeting.
  */
-//...no its not!
-// screw these hardcoded numbers, it makes re-organizing and adding new Id's next to impossible
+
 // Since we're upgrading the Control_config array into a proper vector, and since we're using contructor predicates we can organize these to however we like and pass the IoActionId to the constructor to ensure the correct placement
 enum IoActionId  {
 	TARGET_NEXT										=0,		//!< target next
@@ -369,6 +367,7 @@ enum IoActionId  {
 extern int Failed_key_index;
 
 extern int Axis_map_to[];
+extern int Axis_map_to_defaults[];
 extern int Invert_axis[];
 extern int Invert_axis_defaults[];
 
@@ -378,8 +377,8 @@ extern int Joy_sensitivity;
 extern int Control_config_overlay_id;
 
 extern SCP_vector<CCI> Control_config;		//!< Stores the keyboard configuration
-extern SCP_vector<CCI*> Control_config_presets; // tabled control presets; pointers to config_item arrays
-extern SCP_vector<SCP_string> Control_config_preset_names; // names for Control_config_presets (identical order of items)
+//extern SCP_vector<CCI*> Control_config_presets; // tabled control presets; pointers to config_item arrays
+//extern SCP_vector<SCP_string> Control_config_preset_names; // names for Control_config_presets (identical order of items)
 extern const char **Scan_code_text;
 extern const char **Joy_button_text;
 

--- a/code/controlconfig/controlsconfig.h
+++ b/code/controlconfig/controlsconfig.h
@@ -364,9 +364,9 @@ enum IoActionId  {
 
 extern int Failed_key_index;
 
-extern int Axis_map_to[];
+extern int Axis_map_to[];           // Array to map an axis action to a joy axis. size() = NUM_JOY_AXIS_ACTIONS
 extern int Axis_map_to_defaults[];
-extern int Invert_axis[];
+extern int Invert_axis[];           // Array to hold inversion bools for a joy axis. size() = JOY_NUM_AXES
 extern int Invert_axis_defaults[];
 
 extern int Joy_dead_zone_size;

--- a/code/controlconfig/controlsconfigcommon.cpp
+++ b/code/controlconfig/controlsconfigcommon.cpp
@@ -71,6 +71,8 @@ int Invert_axis_defaults[JOY_NUM_AXES] = { 0, 0, 0, 0, 0, 0 };
 SCP_vector<CCI> Control_config;
 
 void controls_config_init_bindings() {
+	Control_config.clear();	// Clear exisitng vectory, just in case init is run more than once for whatever reason
+
 	CCI_builder Builder(Control_config);
 	Builder.start()
 	// Note: when adding new controls, group them according to the tab they would show up on.
@@ -778,6 +780,8 @@ void control_config_common_load_overrides();
 // initialize common control config stuff - call at game startup after localization has been initialized
 void control_config_common_init()
 {
+	controls_config_init_bindings();
+
 	for (int i=0; i<CCFG_MAX; i++) {
 		Control_config[i].continuous_ongoing = false;
 	}

--- a/code/controlconfig/controlsconfigcommon.cpp
+++ b/code/controlconfig/controlsconfigcommon.cpp
@@ -1229,7 +1229,7 @@ void control_config_common_read_section(int s) {
 		try {
 			item_id = old_text.at(szTempBuffer);
 
-		} catch(const std::out_of_range& oor) {
+		} catch(const std::out_of_range) {
 			// Warning: Not Found
 			error_display(0, "Unknown Bind Name: %s\n", szTempBuffer.c_str());
 

--- a/code/controlconfig/controlsconfigcommon.cpp
+++ b/code/controlconfig/controlsconfigcommon.cpp
@@ -1242,6 +1242,7 @@ void control_config_common_read_section(int s) {
 	if (optional_string("$Name:")) {
 		SCP_string name;
 		stuff_string_line(name);
+		drop_leading_white_space(name);
 		new_preset.name = name;
 
 		auto it = std::find_if(Control_config_presets.begin(), Control_config_presets.end(), [&name](CC_preset& S) {return S.name == name;});
@@ -1325,6 +1326,7 @@ void control_config_common_read_section(int s) {
 
 			if (optional_string("$Text:")) {
 				stuff_string(item->text, F_NAME);
+				item->indexXSTR = 0;
 			}
 
 			if (optional_string("$Has XStr:")) {

--- a/code/controlconfig/controlsconfigcommon.cpp
+++ b/code/controlconfig/controlsconfigcommon.cpp
@@ -625,9 +625,6 @@ const char *Joy_button_text_english[] = {
 const char **Scan_code_text = Scan_code_text_english;
 const char **Joy_button_text = Joy_button_text_english;
 
-// If find_override is set to true, then this returns the index of the action
-// which has been bound to the given key. Otherwise, the index of the action
-// which has the given key as its default key will be returned.
 int translate_key_to_index(const char *key, bool find_override)
 {
 	int i, index = -1, alt = 0, shift = 0, max_scan_codes;
@@ -692,11 +689,6 @@ int translate_key_to_index(const char *key, bool find_override)
 	return -1;
 }
 
-/*! Given the system default key 'key', return the current key that is bound to that function.
-* Both are 'key' and the return value are descriptive strings that can be displayed
-* directly to the user.  If 'key' isn't a real key, is not normally bound to anything,
-* or there is no key currently bound to the function, NULL is returned.
-*/
 char *translate_key(char *key)
 {
 	int index = -1, key_code = -1, joy_code = -1;

--- a/code/controlconfig/controlsconfigcommon.cpp
+++ b/code/controlconfig/controlsconfigcommon.cpp
@@ -846,7 +846,7 @@ SCP_map<SCP_string, IoActionId> mActionToVal;
 
 /*! Helper function to LoadEnumsIntoMaps(), Loads the Keyboard definitions/enumerations into mKeyNameToVal
 */
-void LoadEnumsIntoKeyMap(void) {
+void LoadEnumsIntoKeyMap() {
 	// Dirty macro hack :D
 #define ADD_ENUM_TO_KEY_MAP(Enum) mKeyNameToVal[#Enum] = (Enum);
 
@@ -982,7 +982,7 @@ void LoadEnumsIntoKeyMap(void) {
 
 /*! Helper function to LoadEnumsIntoMaps(), Loads the Control Types enumerations into mCCTypeNameToVal
  */
-void LoadEnumsIntoCCTypeMap(void) {
+void LoadEnumsIntoCCTypeMap() {
 	// Dirty macro hack :D
 #define ADD_ENUM_TO_CCTYPE_MAP(Enum) mCCTypeNameToVal[#Enum] = (Enum);
 
@@ -994,7 +994,7 @@ void LoadEnumsIntoCCTypeMap(void) {
 
 /*! Helper function to LoadEnumsIntoMaps(), Loads the Control Tabs enumerations into mCCTabNameToVal
  */
-void LoadEnumsIntoCCTabMap(void) {
+void LoadEnumsIntoCCTabMap() {
 	// Dirty macro hack :D
 #define ADD_ENUM_TO_CCTAB_MAP(Enum) mCCTabNameToVal[#Enum] = (Enum);
 
@@ -1009,7 +1009,7 @@ void LoadEnumsIntoCCTabMap(void) {
 
 /*! Helper function to LoadEnumsIntoMaps(), Loads the IoActionId enums into mActionToVal
  */
-void LoadEnumsIntoActionMap(void) {
+void LoadEnumsIntoActionMap() {
 #define ADD_ENUM_TO_ACTION_MAP(Enum) mActionToVal[#Enum] = (Enum);
 	ADD_ENUM_TO_ACTION_MAP(TARGET_NEXT)
 	ADD_ENUM_TO_ACTION_MAP(TARGET_PREV)

--- a/code/controlconfig/controlsconfigcommon.cpp
+++ b/code/controlconfig/controlsconfigcommon.cpp
@@ -1369,13 +1369,6 @@ void control_config_common_load_overrides()
 		mprintf(("TABLES: Unable to parse 'controlconfigdefaults.tbl'!  Error message = %s.\n", e.what()));
 		return;
 	}
-
-	// Overwrite the control config with the first preset that was found
-	/*
-	if (!Control_config_presets.empty()) {
-		std::copy(Control_config_presets[0], Control_config_presets[0] + CCFG_MAX + 1, Control_config.begin());
-	}
-	*/
 }
 
 CCI_builder::CCI_builder(SCP_vector<CCI>& _ControlConfig) : ControlConfig(_ControlConfig) {

--- a/code/controlconfig/controlsconfigcommon.cpp
+++ b/code/controlconfig/controlsconfigcommon.cpp
@@ -1201,7 +1201,7 @@ size_t find_control_by_text(SCP_string& text) {
 	try {
 		item_id = old_text.at(text);
 
-	} catch (const std::out_of_range) {
+	} catch (const std::out_of_range &) {
 		// Couldn't find in old ::text
 		return Control_config.size();
 

--- a/code/controlconfig/controlsconfigcommon.cpp
+++ b/code/controlconfig/controlsconfigcommon.cpp
@@ -1431,7 +1431,7 @@ int control_config_common_write_tbl(bool overwrite = false) {
 			Assert(buf_str != "");
 		} else {
 			// Not bound
-			buf_str = "-1";
+			buf_str = "NONE";
 		}
 
 		cfputs(("$Bind Name: " + item.text + "\n").c_str(), cfile);

--- a/code/controlconfig/controlsconfigcommon.cpp
+++ b/code/controlconfig/controlsconfigcommon.cpp
@@ -137,15 +137,15 @@ void controls_config_init_bindings() {
 	// flight controls (flight modes)
 	(BANK_WHEN_PRESSED,                                      -1, -1, SHIP_TAB, 1, "Bank When Pressed",  CC_TYPE_CONTINUOUS)
 	(AFTERBURNER,                                       KEY_TAB,  5, SHIP_TAB, 1, "Afterburner",        CC_TYPE_CONTINUOUS)
-	(GLIDE_WHEN_PRESSED,                                     -1, -1, SHIP_TAB, 0, "Glide When Pressed", CC_TYPE_CONTINUOUS)
-	(TOGGLE_GLIDING,                          KEY_ALTED | KEY_G, -1, SHIP_TAB, 0, "Toggle Gliding",     CC_TYPE_TRIGGER)
+	(GLIDE_WHEN_PRESSED,                                     -1, -1, SHIP_TAB, 0, "Glide When Pressed", CC_TYPE_CONTINUOUS, true)
+	(TOGGLE_GLIDING,                          KEY_ALTED | KEY_G, -1, SHIP_TAB, 0, "Toggle Gliding",     CC_TYPE_TRIGGER, true)
 
 	// weapons
 	(FIRE_PRIMARY,                                    KEY_LCTRL,  0, WEAPON_TAB, 1, "Fire Primary Weapon",                    CC_TYPE_CONTINUOUS)
 	(FIRE_SECONDARY,                               KEY_SPACEBAR,  1, WEAPON_TAB, 1, "Fire Secondary Weapon",                  CC_TYPE_CONTINUOUS)
 	(CYCLE_NEXT_PRIMARY,                             KEY_PERIOD, -1, WEAPON_TAB, 1, "Cycle Primary Weapon Forward",           CC_TYPE_TRIGGER)
 	(CYCLE_PREV_PRIMARY,                              KEY_COMMA, -1, WEAPON_TAB, 1, "Cycle Primary Weapon Backward",          CC_TYPE_TRIGGER)
-	(CYCLE_PRIMARY_WEAPON_SEQUENCE,                       KEY_O, -1, WEAPON_TAB, 0, "Cycle Primary Weapon Firing Rate",       CC_TYPE_TRIGGER)
+	(CYCLE_PRIMARY_WEAPON_SEQUENCE,                       KEY_O, -1, WEAPON_TAB, 0, "Cycle Primary Weapon Firing Rate",       CC_TYPE_TRIGGER, true)
 	(CYCLE_SECONDARY,                                KEY_DIVIDE, -1, WEAPON_TAB, 1, "Cycle Secondary Weapon Forward",         CC_TYPE_TRIGGER)
 	(CYCLE_NUM_MISSLES,                KEY_SHIFTED | KEY_DIVIDE, -1, WEAPON_TAB, 1, "Cycle Secondary Weapon Firing Rate",     CC_TYPE_TRIGGER)
 	(LAUNCH_COUNTERMEASURE,                               KEY_X,  3, WEAPON_TAB, 1, "Launch Countermeasure",                  CC_TYPE_TRIGGER)
@@ -181,8 +181,8 @@ void controls_config_init_bindings() {
 	(PADLOCK_DOWN,                                           -1, 32, COMPUTER_TAB, 1, "View Rear",                          CC_TYPE_CONTINUOUS)
 	(PADLOCK_LEFT,                                           -1, 34, COMPUTER_TAB, 1, "View Left",                          CC_TYPE_CONTINUOUS)
 	(PADLOCK_RIGHT,                                          -1, 35, COMPUTER_TAB, 1, "View Right",                         CC_TYPE_CONTINUOUS)
-	(VIEW_TOPDOWN,                                           -1, -1, COMPUTER_TAB, 0, "Top-Down View",                      CC_TYPE_TRIGGER)
-	(VIEW_TRACK_TARGET,                                      -1, -1, COMPUTER_TAB, 0, "Target Padlock View",                CC_TYPE_TRIGGER)
+	(VIEW_TOPDOWN,                                           -1, -1, COMPUTER_TAB, 0, "Top-Down View",                      CC_TYPE_TRIGGER, true)
+	(VIEW_TRACK_TARGET,                                      -1, -1, COMPUTER_TAB, 0, "Target Padlock View",                CC_TYPE_TRIGGER, true)
 
 	(RADAR_RANGE_CYCLE,                            KEY_RAPOSTRO, -1, COMPUTER_TAB, 1, "Cycle Radar Range",                 CC_TYPE_TRIGGER)
 	(SQUADMSG_MENU,                                       KEY_C, -1, COMPUTER_TAB, 1, "Communications Menu",               CC_TYPE_TRIGGER)
@@ -207,8 +207,8 @@ void controls_config_init_bindings() {
 
 	// Navigation and Autopilot
 	(SHOW_NAVMAP,                                            -1, -1, NO_TAB,       1, "Show Nav Map",       CC_TYPE_TRIGGER)
-	(AUTO_PILOT_TOGGLE,                       KEY_ALTED | KEY_A, -1, COMPUTER_TAB, 0, "Toggle Auto Pilot",  CC_TYPE_TRIGGER)
-	(NAV_CYCLE,                               KEY_ALTED | KEY_N, -1, COMPUTER_TAB, 0, "Cycle Nav Points",   CC_TYPE_TRIGGER)
+	(AUTO_PILOT_TOGGLE,                       KEY_ALTED | KEY_A, -1, COMPUTER_TAB, 0, "Toggle Auto Pilot",  CC_TYPE_TRIGGER, true)
+	(NAV_CYCLE,                               KEY_ALTED | KEY_N, -1, COMPUTER_TAB, 0, "Cycle Nav Points",   CC_TYPE_TRIGGER, true)
 
 	// Escort
 	(ADD_REMOVE_ESCORT,                       KEY_ALTED | KEY_E, -1, COMPUTER_TAB, 1, "Add or Remove Escort",   CC_TYPE_TRIGGER)

--- a/code/gamehelp/gameplayhelp.cpp
+++ b/code/gamehelp/gameplayhelp.cpp
@@ -114,9 +114,8 @@ void gameplay_help_blit_control_line(int x, int y, int id)
 {
 	int			has_key=0, has_joy=0;
 	char			buf[256];
-	config_item	*ci;
 
-	ci = &Control_config[id];
+	auto ci = &Control_config[id];
 
 	buf[0] = 0;
 
@@ -140,7 +139,7 @@ void gameplay_help_blit_control_line(int x, int y, int id)
 	gr_string(x,y,buf,GR_RESIZE_MENU);
 
 //	gr_string(x+KEY_DESCRIPTION_OFFSET,y,ci->text,GR_RESIZE_MENU);
-	gr_string(x+KEY_DESCRIPTION_OFFSET, y, XSTR(ci->text, CONTROL_CONFIG_XSTR + id), GR_RESIZE_MENU);
+	gr_string(x+KEY_DESCRIPTION_OFFSET, y, XSTR(ci->text.c_str(), CONTROL_CONFIG_XSTR + id), GR_RESIZE_MENU);
 }
 
 void gameplay_help_blit_control_line_raw(int x, int y, const char *control_text, const char *control_description)

--- a/code/globalincs/undosys.cpp
+++ b/code/globalincs/undosys.cpp
@@ -9,7 +9,7 @@
 Undo_system::Undo_system()
 	: max_undos(10) {};
 
-Undo_system::Undo_system(uint _undos)
+Undo_system::Undo_system(size_t _undos)
 	: max_undos(_undos) {};
 
 void Undo_system::clear() {

--- a/code/globalincs/undosys.cpp
+++ b/code/globalincs/undosys.cpp
@@ -6,6 +6,9 @@
 #include "globalincs/undosys.h"
 #include "globalincs/vmallocator.h"
 
+// Pure virtual deconstructors must be defined.
+Undo_item_base::~Undo_item_base() {};
+
 Undo_system::Undo_system()
 	: max_undos(10) {};
 
@@ -43,24 +46,6 @@ void Undo_system::clear_redo() {
 	}
 	redo_stack.clear();
 }
-
-template<typename T>
-size_t Undo_system::save(T& item, T* container) {
-	// De-construct all intances of Undo_item on the redo stack, then clear the stack
-	clear_redo();
-
-	// Create a new instance of Undo_tem, with the correct type reference
-	Undo_item_base *new_item = new Undo_item<T>(item, container);
-
-	// If operator new fails, then we've got bigger problems!
-	// If needed, You can modify this to be tolerate of the issue by throwing an error before proceding
-	Assert(new_item != nullptr);
-	undo_stack.push_back(new_item);
-
-	clamp_stacks();
-
-	return undo_stack.size();
-};
 
 size_t Undo_system::save_stack(Undo_stack& stack) {
 	if (stack.size() == 0) {
@@ -115,6 +100,13 @@ std::pair<const void*, const void*> Undo_system::undo() {
 	return retval;
 };
 
+bool Undo_system::empty() {
+	return undo_stack.empty();
+}
+
+bool Undo_system::empty_redo() {
+	return redo_stack.empty();
+}
 size_t Undo_system::size() {
 	return undo_stack.size();
 }
@@ -157,19 +149,6 @@ std::pair<const void*, const void*> Undo_stack::restore() {
 	reverse = !reverse;
 	return retval;
 }
-
-template<typename T>
-size_t Undo_stack::save(T& item, T* container) {
-	// Create a new instance of Undo_tem, with the correct type reference
-	Undo_item_base *new_item = new Undo_item<T>(item, container);
-
-	// If operator new fails, then we've got bigger problems!
-	// If needed, You can modify this to be tolerate of the issue by throwing an error before proceding
-	Assert(new_item != nullptr);
-	stack.push_back(new_item);
-
-	return stack.size();
-};
 
 size_t Undo_stack::size() {
 	return stack.size();

--- a/code/globalincs/undosys.cpp
+++ b/code/globalincs/undosys.cpp
@@ -15,6 +15,18 @@ Undo_system::Undo_system()
 Undo_system::Undo_system(uint _undos)
 	: max_undos(_undos) {};
 
+void Undo_system::clear() {
+	for (auto it = redo_stack.begin(); it != redo_stack.end(); ++it) {
+		delete *it;
+	}
+	redo_stack.clear();
+
+	for (auto it = undo_stack.begin(); it != undo_stack.end(); ++it) {
+		delete *it;
+	}
+	undo_stack.clear();
+}
+
 template<typename T>
 size_t Undo_system::save(T& item, T* container) {
 	// De-construct all intances of Undo_item on the redo stack, then clear the stack
@@ -113,7 +125,7 @@ size_t Undo_system::size_redo() {
 
 
 Undo_stack::Undo_stack()
-	: reverse(fase) {
+	: reverse(false) {
 }
 
 Undo_stack::Undo_stack(size_t size)
@@ -122,7 +134,7 @@ Undo_stack::Undo_stack(size_t size)
 }
 
 Undo_stack::~Undo_stack() {
-	for (auto it = stack.begin; it != stack.end(); ++it) {
+	for (auto it = stack.begin(); it != stack.end(); ++it) {
 		delete *it;
 	}
 	stack.clear();

--- a/code/globalincs/undosys.cpp
+++ b/code/globalincs/undosys.cpp
@@ -52,6 +52,10 @@ size_t Undo_system::save(T& item, T* container) {
 };
 
 size_t Undo_system::save_stack(Undo_stack& stack) {
+	if (stack.size() == 0) {
+		return 0;
+	}
+	
 	for (auto it = redo_stack.begin(); it != redo_stack.end(); ++it) {
 		delete *it;
 	}
@@ -170,4 +174,8 @@ size_t Undo_stack::save(T& item, T* container) {
 
 	return stack.size();
 };
+
+size_t Undo_stack::size() {
+	return stack.size();
+}
 

--- a/code/globalincs/undosys.cpp
+++ b/code/globalincs/undosys.cpp
@@ -1,8 +1,5 @@
 /*
 * z64555's Undo system, created for the FreeSpace Source Code project
-*
-* Released under Creative Commons Attribution-ShareAlike 4.0 International
-* https://creativecommons.org/licenses/by-sa/4.0/
 */
 
 #include "globalincs/pstypes.h"

--- a/code/globalincs/undosys.cpp
+++ b/code/globalincs/undosys.cpp
@@ -7,7 +7,7 @@
 #include "globalincs/vmallocator.h"
 
 // Pure virtual deconstructors must be defined.
-Undo_item_base::~Undo_item_base() {};
+Undo_item_base::~Undo_item_base() = default;
 
 Undo_system::Undo_system()
 	: max_undos(10) {};
@@ -34,15 +34,15 @@ void Undo_system::clamp_stacks() {
 void Undo_system::clear() {
 	clear_redo();
 
-	for (auto it = undo_stack.begin(); it != undo_stack.end(); ++it) {
-		delete *it;
+	for (auto &element : undo_stack) {
+		delete element;
 	}
 	undo_stack.clear();
 }
 
 void Undo_system::clear_redo() {
-	for (auto it = redo_stack.begin(); it != redo_stack.end(); ++it) {
-		delete *it;
+	for (auto &element : redo_stack) {
+		delete element;
 	}
 	redo_stack.clear();
 }
@@ -73,7 +73,7 @@ std::pair<const void*, const void*> Undo_system::redo() {
 
 	if (redo_stack.empty()) {
 		// Nothing to redo
-		return std::pair<const void*, const void*>(nullptr, nullptr);
+		return {nullptr, nullptr};
 	}
 
 	auto &item = redo_stack.back();
@@ -89,7 +89,7 @@ std::pair<const void*, const void*> Undo_system::undo() {
 	
 	if (undo_stack.empty()) {
 		// Nothing to undo
-		return std::pair<const void*, const void*>(nullptr, nullptr);
+		return {nullptr, nullptr};
 	}
 
 	auto &item = undo_stack.back();
@@ -141,8 +141,8 @@ std::pair<const void*, const void*> Undo_stack::restore() {
 			retval = (*it)->restore();
 		}
 	} else {
-		for (auto it = stack.begin(); it != stack.end(); ++it) {
-			retval = (*it)->restore();
+		for (auto &element : stack) {
+			retval = element->restore();
 		}
 	}
 
@@ -159,8 +159,8 @@ void Undo_stack::untrack() {
 }
 
 void Undo_stack::clear() {
-	for (auto it = stack.begin(); it != stack.end(); ++it) {
-		delete *it;
+	for (auto &element : stack) {
+		delete element;
 	}
 	stack.clear();
 }

--- a/code/globalincs/undosys.h
+++ b/code/globalincs/undosys.h
@@ -8,6 +8,8 @@
 #include "globalincs/pstypes.h"
 #include "globalincs/vmallocator.h"
 
+#include <utility>
+
 /*!
  * @brief Base class of Undo_item. Use this when making an undo stack!
  * @sa Undo_item
@@ -16,7 +18,7 @@ class Undo_item_base
 {
 public:
 	virtual ~Undo_item_base() = 0;
-	virtual void restore() = 0;
+	virtual std::pair<const void*, const void*> restore() = 0;
 };
 
 
@@ -29,7 +31,7 @@ public:
  *   For example, if you're about to restore from the undo stack, you'd first save a copy of the current data to the
  *   redo stack, then do the undo. The Undo_item in the undo stack can then be popped off the stack.
  *
- * @note This CANNOT operate on C arrays! (can operate on std::array, however)
+ * @note If you want to save changes to an entire C-style array (such as 'int array[]'), try wrapping it in a std::array first.
  *
  * @sa Undo_item_base
  */
@@ -43,6 +45,10 @@ public:
 		save(_data);
 	};
 
+	Undo_item(T& _data, T* _cont) {
+		save(_data, _cont);
+	};
+
 	~Undo_item() {
 		if (data != nullptr) {
 			delete data;
@@ -52,30 +58,38 @@ public:
 	/**
 	 * @brief Restores the saved data
 	 *
+	 * @returns A pair of const void* referencing the affected item and its container (if it was provided)
 	 * @details If successful, the data at dest has been swapped. So if this was an undo item, it's now a redo item
 	 */
-	void restore() {
+	std::pair<const void*, const void*> restore() {
 		Assert((dest != nullptr) && (data != nullptr));
 
 		T copy = *static_cast<T*>(dest);
 		*static_cast<T*>(dest) = *static_cast<T*>(data);
 		*static_cast<T*>(data) = copy;
+
+		return std::pair<const void*, const void*>(dest, container);
 	};
 
 	/*!
 	 * @brief Saves data and its destination as an undo item
+	 *
+	 * @param[in] _data The data to save
+	 * @param[in] _cont The container this data is originally found in
 	 * @details The explicit definition is here to ensure type safety
 	 */
-	void save(T& _data) {
+	void save(T& _data, T* _cont = nullptr) {
 		Assert(_data != nullptr);
 
 		dest = *_data;
 		data = new T(_data);
+		container = _cont;
 	};
 
 private:
-	T* dest;     //!< Destination of the data
-	T* data;     //!< Reference to a copy of data on the heap
+	T* dest;        //!< Destination of the data
+	T* data;        //!< Reference to a copy of data on the heap
+	T* container;   //!< Optional reference to this item's container
 };
 
 
@@ -94,20 +108,36 @@ public:
 	/*!
 	 * @brief Saves the item onto the undo stack
 	 *
+	 * @param[in] item      The item to save
+	 * @param[in] container (Optional) The container wherein this item is located
 	 * @note Call this _before_ you do your operation on the item
 	 */
 	template<typename T>
-	size_t save(T& item);
+	size_t save(T& item, T* container = nullptr);
 
 	/*!
 	 * @brief Undo's the last changed item and save the changes into the Redo stack
+	 *
+	 * @returns A pair of const void* which reference the affected item, and its container (if it was provided)
 	 */
-	size_t undo();
+	std::pair<const void*, const void*> undo();
 
 	/*!
 	 * @brief Redo's the last changed item and save the changes into the undo
+	 *
+	 * @returns A pair of const void* which reference the affected item, and its container (if it was provided)
 	 */
-	size_t redo();
+	std::pair<const void*, const void*> redo();
+
+	/*!
+	 * @brief Returns the size of the undo stack
+	 */
+	size_t size();
+
+	/*!
+	 * @brief Returns the size of the redo stack
+	 */
+	size_t size_redo();
 
 private:
 	uint max_undos;	//!< Max number of Undo's available

--- a/code/globalincs/undosys.h
+++ b/code/globalincs/undosys.h
@@ -27,14 +27,14 @@ The undo system can save any type of data, you don't have to have an instance of
 	Undo_controls.save(std::array<int, JOY_AXIS_ACTIONS>(Axis_map_to));
 }
 
-In several cases, the client code would like to know exactly what was changed. The undo system provides a mechnism for doing this:
+In several cases, the client code would like to know exactly what was changed. The undo system provides a mechanism for doing this:
 	{
 		Undo_controls.save(Control_config[z], &Control_config[0]);   // Save the item, and a reference to its container. Here, we use the location of the first item in Control_config as our reference
 		Undo_controls.save(Axis_map_to[z], Axis_map_to);             // Saves an axis mapping, here, we use the array's head pointer as our reference (since a int[] is the same as a int*)
 
-		std::pair<const void*, const void*> ref = Undo_controls.undo();    // ::undo() returns a std::pair<const void*, const void*>, the first member referening the item that changed, and the second referencing the item's container (if we provided it)
+		std::pair<const void*, const void*> ref = Undo_controls.undo();    // ::undo() returns a std::pair<const void*, const void*>, the first member referencing the item that changed, and the second referencing the item's container (if we provided it)
 
-		// Once we've stored the return value fron ::undo, we can found out what the item is by comparing the second member with containers that we've been saving
+		// Once we've stored the return value from ::undo, we can found out what the item is by comparing the second member with containers that we've been saving
 		if (ref.second == &Control_config[0]) {
 			cout << "I'm a button!";
 			Tab = static_cast<Config_item>(ref.first).tab;  // Sets the selected tab within the Controls Config menu. We do a static cast here so we can access the Config_item::tab member
@@ -82,7 +82,7 @@ public:
 /*!
  * @brief Class which handles undo operations.
  * @details This class works with a single data item, to make a undo or redo stack you'd use something like a
- *   std::vector or a std::deque of this class. Undo and Redo stacks would be seperate. Before restoring data from
+ *   std::vector or a std::deque of this class. Undo and Redo stacks would be separate. Before restoring data from
  *   either, you'd save a copy of the item in the opposite stack.
  *
  *   For example, if you're about to restore from the undo stack, you'd first save a copy of the current data to the
@@ -162,7 +162,7 @@ public:
 	/*!
 	 * @brief Restores all items within the undo stack
 	 *
-	 * @details Maintains an internal flag which will reverse direction on the next call, thereby redo-ing
+	 * @details Maintains an internal flag which will reverse direction on the next call, thereby re-doing
 	 * 
 	 * @returns A pair of references to the last item restored
 	 */
@@ -182,6 +182,12 @@ public:
 	 * @brief Calls ::reserve() on the internal vector
 	 */
 	void reserve(size_t size);
+
+	/*!
+	 * @brief Returns the size of the stack
+	 */
+	 size_t size();
+
 private:
 	bool reverse;   // Direction to walk the stack. forward = false, reverse = True
 
@@ -217,6 +223,7 @@ public:
 
 	/*!
 	 * @brief Saves a stack of undo-items as a single undo-item within the system
+	 * @note Should the stack be empty, nothing will be saved to the undo system
 	 */
 	size_t save_stack(Undo_stack& stack);
 

--- a/code/globalincs/undosys.h
+++ b/code/globalincs/undosys.h
@@ -1,0 +1,123 @@
+/*
+ * z64555's Undo system, created for the FreeSpace Source Code project
+ *
+ * Released under Creative Commons Attribution-ShareAlike 4.0 International 
+ * https://creativecommons.org/licenses/by-sa/4.0/
+ */
+
+#include "globalincs/pstypes.h"
+#include "globalincs/vmallocator.h"
+
+/*!
+ * @brief Base class of Undo_item. Use this when making an undo stack!
+ * @sa Undo_item
+ */
+class Undo_item_base
+{
+public:
+	virtual ~Undo_item_base() = 0;
+	virtual void restore() = 0;
+};
+
+
+/*!
+ * @brief Class which handles undo operations.
+ * @details This class works with a single data item, to make a undo or redo stack you'd use something like a
+ *   std::vector or a std::deque of this class. Undo and Redo stacks would be seperate. Before restoring data from
+ *   either, you'd save a copy of the item in the opposite stack.
+ *
+ *   For example, if you're about to restore from the undo stack, you'd first save a copy of the current data to the
+ *   redo stack, then do the undo. The Undo_item in the undo stack can then be popped off the stack.
+ *
+ * @note This CANNOT operate on C arrays! (can operate on std::array, however)
+ *
+ * @sa Undo_item_base
+ */
+template<typename T> class Undo_item : Undo_item_base
+{
+public:
+	Undo_item()
+		: dest(nullptr), data(nullptr) {};
+
+	Undo_item(T& _data) {
+		save(_data);
+	};
+
+	~Undo_item() {
+		if (data != nullptr) {
+			delete data;
+		}
+	};
+
+	/**
+	 * @brief Restores the saved data
+	 *
+	 * @details If successful, the data at dest has been swapped. So if this was an undo item, it's now a redo item
+	 */
+	void restore() {
+		Assert((dest != nullptr) && (data != nullptr));
+
+		T copy = *static_cast<T*>(dest);
+		*static_cast<T*>(dest) = *static_cast<T*>(data);
+		*static_cast<T*>(data) = copy;
+	};
+
+	/*!
+	 * @brief Saves data and its destination as an undo item
+	 * @details The explicit definition is here to ensure type safety
+	 */
+	void save(T& _data) {
+		Assert(_data != nullptr);
+
+		dest = *_data;
+		data = new T(_data);
+	};
+
+private:
+	T* dest;     //!< Destination of the data
+	T* data;     //!< Reference to a copy of data on the heap
+};
+
+
+/*!
+ * @brief Generic Undo/Redo system. Save whatever, restore whatever!
+ *
+ * @details Currently uses a pair of deques. Would ideally use a ring container so that the actual Undo_item instances don't go anywhere.
+ */
+class Undo_system
+{
+public:
+	Undo_system();
+
+	Undo_system(uint _undos);
+
+	/*!
+	 * @brief Saves the item onto the undo stack
+	 *
+	 * @note Call this _before_ you do your operation on the item
+	 */
+	template<typename T>
+	size_t save(T& item);
+
+	/*!
+	 * @brief Undo's the last changed item and save the changes into the Redo stack
+	 */
+	size_t undo();
+
+	/*!
+	 * @brief Redo's the last changed item and save the changes into the undo
+	 */
+	size_t redo();
+
+private:
+	uint max_undos;	//!< Max number of Undo's available
+
+	/*! 
+	 * @brief The undo and redo stacks. These are containers of pointers, because we can't simply store the base class.
+	 *   If we did, then the data of the Undo_item instances would be sliced out.
+	 * @{
+	 */
+	SCP_deque<Undo_item_base*> undo_stack;
+	SCP_deque<Undo_item_base*> redo_stack;
+	//! @}
+};

--- a/code/globalincs/undosys.h
+++ b/code/globalincs/undosys.h
@@ -116,14 +116,12 @@ public:
 	 * @brief Restores the saved data
 	 *
 	 * @returns A pair of const void* referencing the affected item and its container (if it was provided)
-	 * @details If successful, the data at dest has been swapped. So if this was an undo item, it's now a redo item
+	 * @details swaps the data with the destination's, effectively making an undo item into a redo item, and vice versa
 	 */
 	std::pair<const void*, const void*> restore() {
 		Assert((dest != nullptr) && (data != nullptr));
 
-		T copy = *static_cast<T*>(dest);
-		*static_cast<T*>(dest) = *static_cast<T*>(data);
-		*static_cast<T*>(data) = copy;
+		std::swap(*static_cast<T*>(dest),*static_cast<T*>(data));
 
 		return std::pair<const void*, const void*>(dest, container);
 	};
@@ -136,7 +134,6 @@ public:
 	 * @details The explicit definition is here to ensure type safety
 	 */
 	void save(T& _data, T* _cont = nullptr) {
-		Assert(_data != nullptr);
 
 		dest = *_data;
 		data = new T(_data);
@@ -201,7 +198,7 @@ class Undo_system
 public:
 	Undo_system();
 
-	Undo_system(uint _undos);
+	Undo_system(size_t _undos);
 
 	/*!
 	 * @brief Deletes all undo and redo data
@@ -248,7 +245,7 @@ public:
 	size_t size_redo();
 
 private:
-	uint max_undos;	//!< Max number of Undo's available
+	size_t max_undos;	//!< Max number of Undo's available
 
 	/*! 
 	 * @brief The undo and redo stacks. These are containers of pointers, because we can't simply store the base class.

--- a/code/globalincs/undosys.h
+++ b/code/globalincs/undosys.h
@@ -1,8 +1,5 @@
 /*
  * z64555's Undo system, created for the FreeSpace Source Code project
- *
- * Released under Creative Commons Attribution-ShareAlike 4.0 International 
- * https://creativecommons.org/licenses/by-sa/4.0/
  */
 
 #include "globalincs/pstypes.h"

--- a/code/globalincs/undosys.h
+++ b/code/globalincs/undosys.h
@@ -136,7 +136,7 @@ public:
 	 */
 	void save(T& _data, T* _cont = nullptr) {
 
-		dest = *_data;
+		dest = &_data;
 		data = new T(_data);
 		container = _cont;
 	};
@@ -178,7 +178,14 @@ public:
 	 * @note Call this _before_ you do your operation on the item
 	 */
 	template<typename T>
-	size_t save(T& item, T* container = nullptr);
+	size_t save(T& item, T* container = nullptr) {
+		// Create a new instance of Undo_tem, with the correct type reference
+		Undo_item_base *new_item = new Undo_item<T>(item, container);
+
+		stack.push_back(new_item);
+
+		return stack.size();
+	};
 
 	/*!
 	 * @brief Calls ::reserve() on the internal vector
@@ -235,7 +242,19 @@ public:
 	 * @note Call this _before_ you do your operation on the item
 	 */
 	template<typename T>
-	size_t save(T& item, T* container = nullptr);
+	size_t save(T& item, T* container = nullptr) {
+		// De-construct all intances of Undo_item on the redo stack, then clear the stack
+		clear_redo();
+
+		// Create a new instance of Undo_tem, with the correct type reference
+		Undo_item_base *new_item = new Undo_item<T>(item, container);
+
+		undo_stack.push_back(new_item);
+
+		clamp_stacks();
+
+		return undo_stack.size();
+	};
 
 	/*!
 	 * @brief Saves a stack of undo-items as a single undo-item within the system
@@ -271,6 +290,16 @@ public:
 	 * @brief Returns the size of the redo stack
 	 */
 	size_t size_redo();
+
+	/*!
+	 * @brief True if undo stack size = 0
+	 */
+	bool empty();
+
+	/*!
+	 * @brief True if redo stack size = 0
+	 */
+	 bool empty_redo();
 
 protected:
 	/*!

--- a/code/globalincs/undosys.h
+++ b/code/globalincs/undosys.h
@@ -10,6 +10,66 @@
 
 #include <utility>
 
+/**********************************************************
+Usage:
+First, you need an instance of the Undo_system within your module:
+	{
+		Undo_styem Undo_controls;
+	}
+
+From now on, you can save and restore items. (Just be sure to save them before you change them!)
+	{
+		Undo_controls.save(Control_config[z]);             // 1. Save the item!!
+		Control_config[z].bind(cid(CID_KEYBOARD, KEY_UP)); // 2. Make changes to the item!!
+		Undo_controls.undo();                              // 3. Undo's the changes you did in step 2!
+		Undo_controls.redo();                              // 4. Redo's the changes you did in step 2!
+	}
+The undo system can save any type of data, you don't have to have an instance of a system per data type.
+!!NOTE!! C style arrays and strings should be wrapped in a std::array when saving. Simply passing the array/string's head won't save the entire array.
+{
+	Undo_controls.save(std::array<int, JOY_AXIS_ACTIONS>(Axis_map_to));
+}
+
+In several cases, the client code would like to know exactly what was changed. The undo system provides a mechnism for doing this:
+	{
+		Undo_controls.save(Control_config[z], &Control_config[0]);   // Save the item, and a reference to its container. Here, we use the location of the first item in Control_config as our reference
+		Undo_controls.save(Axis_map_to[z], Axis_map_to);             // Saves an axis mapping, here, we use the array's head pointer as our reference (since a int[] is the same as a int*)
+
+		std::pair<const void*, const void*> ref = Undo_controls.undo();    // ::undo() returns a std::pair<const void*, const void*>, the first member referening the item that changed, and the second referencing the item's container (if we provided it)
+
+		// Once we've stored the return value fron ::undo, we can found out what the item is by comparing the second member with containers that we've been saving
+		if (ref.second == &Control_config[0]) {
+			cout << "I'm a button!";
+			Tab = static_cast<Config_item>(ref.first).tab;  // Sets the selected tab within the Controls Config menu. We do a static cast here so we can access the Config_item::tab member
+		} else if (ref.second == Axis_map_to) {
+			cout << "I'm an axis!";
+			Tab = SHIP_TAB;                                 // Sets the selected tab within the Controls config menu. Can't do a cast on this one, since it's a simple C array. But we already know where the axes are kept (on the ship tab)
+		} else {
+			cout << "I don't know what I am!!! D:";         // Usually an error condition. Depending on the client code this can be fatal or just a minor setback
+		}
+	}
+
+Lastly, you can make stacks of undo operations, so that a single op in the system can undo/redo multiple item changes.
+	{
+		Undo_stack stack;  // We'll want to save multiple changes as a single operation. So we have to make a stack.
+
+		for (int i = 0; i < JOY_AXIS_ACTIONS; ++i) {
+			stack.save(Axis_map_to[i], Axis_map_to);		// This example saves a C style array. Does the same thing without a wrapper, but wasteful
+	}
+
+	Undo_controls.save(stack);	// Save the stack as a single item!
+	std::pair<const void*, const void*> ref = Undo_controls.undo();
+	// Undo rolls through the items as they were saved, should your data operate on the same location, this will apply the changes in the correct sequence
+	ref.second == Axis_map_to;
+	ref.first == &Axis_map_to[0];     // ::first references the _last_ item that the undo stack changed
+
+	//Also, performing an undo reverses the stack. So when you do a system undo, the changes are applied in reverse
+	ref = Undo_controls.redo();
+	ref.second == Axis_map_to;
+	ref.first == &Axis_map_to[JOY_AXIS_ACTIONS - 1];      // ::first references the _last_ item that the undo stack changed
+
+***********************************************************/
+
 /*!
  * @brief Base class of Undo_item. Use this when making an undo stack!
  * @sa Undo_item
@@ -146,6 +206,11 @@ public:
 
 	Undo_system(uint _undos);
 
+	/*!
+	 * @brief Deletes all undo and redo data
+	 */
+	void clear();
+	
 	/*!
 	 * @brief Saves the item onto the undo stack
 	 *

--- a/code/globalincs/undosys.h
+++ b/code/globalincs/undosys.h
@@ -107,7 +107,7 @@ public:
 		save(_data, _cont);
 	};
 
-	~Undo_item() {
+	~Undo_item() override {
 		if (data != nullptr) {
 			delete data;
 		}
@@ -119,7 +119,7 @@ public:
 	 * @returns A pair of const void* referencing the affected item and its container (if it was provided)
 	 * @details swaps the data with the destination's, effectively making an undo item into a redo item, and vice versa
 	 */
-	std::pair<const void*, const void*> restore() {
+	std::pair<const void*, const void*> restore() override {
 		Assert((dest != nullptr) && (data != nullptr));
 
 		std::swap(*static_cast<T*>(dest),*static_cast<T*>(data));
@@ -159,7 +159,7 @@ public:
 
 	Undo_stack(size_t size);
 
-	~Undo_stack();
+	~Undo_stack() override;
 
 	/*!
 	 * @brief Restores all items within the undo stack
@@ -168,7 +168,7 @@ public:
 	 * 
 	 * @returns A pair of references to the last item restored
 	 */
-	std::pair<const void*, const void*> restore();
+	std::pair<const void*, const void*> restore() override;
 
 	/*!
 	 * @brief Saves the item onto the undo stack

--- a/code/mission/missiontraining.cpp
+++ b/code/mission/missiontraining.cpp
@@ -655,7 +655,7 @@ SCP_string message_translate_tokens(const char *text)
 						if ( The_mission.game_type & MISSION_TYPE_TRAINING ) {
 							r = popup(PF_TITLE_BIG | PF_TITLE_RED, 2, XSTR( "&Bind Control", 424), XSTR( "&Abort mission", 425),
 								XSTR( "Warning\nYou have no control bound to the action \"%s\".  You must do so before you can continue with your training.", 426),
-								XSTR(Control_config[Failed_key_index].text, CONTROL_CONFIG_XSTR + Failed_key_index));
+								XSTR(Control_config[Failed_key_index].text.c_str(), CONTROL_CONFIG_XSTR + Failed_key_index));
 
 							if (r) {  // do they want to abort the mission?
 								gameseq_post_event(GS_EVENT_END_GAME);

--- a/code/pilotfile/pilotfile_convert.h
+++ b/code/pilotfile/pilotfile_convert.h
@@ -137,7 +137,7 @@ struct plr_data {
 	unsigned char hud_colors[39][4];
 
 	// control setup
-	SCP_vector<config_item> controls;
+	SCP_vector<CCI> controls;
 
 	int joy_axis_map_to[5];
 	int joy_invert_axis[5];
@@ -254,6 +254,10 @@ class pilotfile_convert {
 		plr_data *plr;
 
 		void plr_import();
+
+		/**
+		 * @brief Reads in the player controls from the playerfile.  Assumes controls are written in the order they are hardcoded.
+		 */
 		void plr_import_controls();
 		void plr_import_hud();
 		void plr_import_detail();

--- a/code/pilotfile/plr_convert.cpp
+++ b/code/pilotfile/plr_convert.cpp
@@ -126,7 +126,7 @@ plr_data::~plr_data()
 void pilotfile_convert::plr_import_controls()
 {
 	int idx;
-	config_item con;
+	CCI con;
 
 	unsigned char num_controls = cfread_ubyte(cfp);
 
@@ -134,8 +134,8 @@ void pilotfile_convert::plr_import_controls()
 		return;
 	}
 
-	// it may be less than 118, but it shouldn't be more than 118
-	if (num_controls > 118) {
+	// TODO: Currently only checks for hardcoded control bindings. Scripted controls will be sliced out in the pilot file
+	if (num_controls > CCFG_MAX) {
 		throw "Data check failure in controls!";
 	}
 

--- a/code/pilotfile/plr_convert.cpp
+++ b/code/pilotfile/plr_convert.cpp
@@ -134,8 +134,9 @@ void pilotfile_convert::plr_import_controls()
 		return;
 	}
 
-	// TODO: Currently only checks for hardcoded control bindings. Scripted controls will be sliced out in the pilot file
-	if (num_controls > CCFG_MAX) {
+	// it may be less than 118, but it shouldn't be more than 118
+	// Don't touch this magic number! This is for old playerfiles. See banner at top of this file.
+	if (num_controls > 118) {
 		throw "Data check failure in controls!";
 	}
 

--- a/code/scripting/scripting.cpp
+++ b/code/scripting/scripting.cpp
@@ -509,7 +509,7 @@ bool ConditionedHook::ConditionsValid(int action, object *objp, int more_data)
 
 					int action_index = more_data;
 
-					if (action_index <= 0 || stricmp(scp->condition_string.c_str(), Control_config[action_index].text) != 0)
+					if (action_index <= 0 || stricmp(scp->condition_string.c_str(), Control_config[action_index].text.c_str()) != 0)
 						return false;
 					break;
 				}

--- a/code/source_groups.cmake
+++ b/code/source_groups.cmake
@@ -318,6 +318,8 @@ add_file_folder("GlobalIncs"
 	globalincs/systemvars.cpp
 	globalincs/systemvars.h
 	globalincs/toolchain.h
+	globalincs/undosys.cpp
+	globalincs/undosys.h
 	globalincs/version.cpp
 	globalincs/version.h
 	globalincs/vmallocator.h

--- a/test/src/pilotfile/plr.cpp
+++ b/test/src/pilotfile/plr.cpp
@@ -250,6 +250,9 @@ std::ostream& operator<<(std::ostream& out, const player& plr) {
 }
 
 TEST_F(PilotPlayerFileTest, binaryToJSONConversion) {
+	// Init control_config stuff
+	control_config_common_init();
+
 	// Call the conversion function
 	convert_pilot_files();
 
@@ -272,4 +275,7 @@ TEST_F(PilotPlayerFileTest, binaryToJSONConversion) {
 	ASSERT_TRUE(loader.load_player("asdf", &json_plr, false));
 
 	ASSERT_EQ(binary_plr, json_plr);
+
+	// Close control_config stuff
+	control_config_common_close();
 }


### PR DESCRIPTION
This PR combines branches `feature/controls`, `feature/controls1`, and `feature.controls2`. This was done because`feature/controls` breaks two features which are fixed in `feature/controls1` and `feature/controls2`, and the three should not be merged in individually.

<hr>

PR #2868 Controls0 - `feature/controls`

This changes the Controls_config array into an SCP_vector to allow scripting to add more controls as they wish, enabling mod devs to create new controls with scripting and not needing hardcode support in the future.  (Custom controls are still a ways off, however)

- [x] Bind mode behaves as it should
- [x] Search mode behaves as it should
- [x] Browse mode behaves as it should
- [x] Loading controlconfigdefaults with retail data behaves as it should
- [x] Loading controlconfigdefaults with mod data behaves as it should

<hr>

PR #2884 Controls 1 - `feature/controls1`

This re-factors control presets and adds a bunch of features.

* Hardcoded defaults are now a preset.
* Mod devs may override the hardcoded defaults with the controlconfigdefaults.tbl by naming a `#ControlConfigOverride` section as "default"
* Mod devs may add as many presets as they like with `#ControlConfigPreset` sections.  These have the same syntax and structure as `#ControlConfigOverride` but only add bindings, and start off as a blank slate.
* Added ability to change the name of controls as they show up in the menu using `$Text:`
* Added possibility of resumption, should a `$Bind Name:` not be found within the controls.

- [x] Reset to defaults should behave as it should
- [x] Repeat hitting of "Reset" button should cycle through all presets
- [x] controlconfigdefaults.tbl is able to override the default preset
- [x] controlconfigdefaults.tbl is able to make new presets with the #ControlConfigOverride section
- [x] controlconfigdefaults.tbl is able to make new presets with the #ControlConfigPreset section
- [x] controlconfigdefaults.tbl is able to relabel controls

<hr>

PR #2907 Controls 2 - `feature/controls2`

Introduces and improves the undo system from PR #1243 and uses it for the controls config menu to re-enable the undo feature.
- [x] Should be able to undo single buttons
- [x] Should be able to undo single axis bindings
- [x] Should be able to undo preset cycling
- [x] Should be able to undo multiple button/control changes (such as an entire wipe of the controls)
- [x] Should be able to do all vanilla functions normally