### PR TITLE
Add 'spout' type particle effect

### DIFF
--- a/code/particle/ParticleEffect.h
+++ b/code/particle/ParticleEffect.h
@@ -19,9 +19,20 @@ enum class EffectType: int64_t {
 	Composite,
 	Cone,
 	Sphere,
+	Spout,
+	SpoutSphere,
 
 	MAX,
 };
+
+namespace effects {
+	enum class ConeDirection {
+		Incoming,
+		Normal,
+		Reflected,
+		Reverse
+	};
+}
 
 /**
  * @brief Defines a particle effect

--- a/code/particle/ParticleManager.cpp
+++ b/code/particle/ParticleManager.cpp
@@ -9,6 +9,7 @@
 #include "particle/effects/ConeShape.h"
 #include "particle/effects/SphereShape.h"
 #include "particle/effects/GenericShapeEffect.h"
+#include "particle/effects/SpoutEffect.h"
 
 #include "bmpman/bmpman.h"
 #include "globalincs/systemvars.h"
@@ -25,7 +26,9 @@ const char* effectTypeNames[static_cast<int64_t>(EffectType::MAX)] = {
 	"Single",
 	"Composite",
 	"Cone",
-	"Sphere"
+	"Sphere",
+	"Spout",
+	"SpoutSphere"
 };
 
 const char* getEffectTypeName(EffectType type) {
@@ -59,6 +62,16 @@ ParticleEffectPtr constructEffect(const SCP_string& name, EffectType type) {
 		}
 		case EffectType::Sphere: {
 			effect.reset(new GenericShapeEffect<SphereShape>(name));
+			effect->parseValues(false);
+			break;
+		}
+		case EffectType::Spout: {
+			effect.reset(new SpoutEffect<ConeShape>(name));
+			effect->parseValues(false);
+			break;
+		}
+		case EffectType::SpoutSphere: {
+			effect.reset(new SpoutEffect<SphereShape>(name));
 			effect->parseValues(false);
 			break;
 		}

--- a/code/particle/ParticleSource.cpp
+++ b/code/particle/ParticleSource.cpp
@@ -275,7 +275,7 @@ float SourceTiming::getLifeTimeProgress() const {
 bool SourceTiming::nextCreationTimeExpired() const { return timestamp_elapsed(m_nextCreation); }
 void SourceTiming::incrementNextCreationTime(int time_diff) { m_nextCreation += time_diff; }
 
-ParticleSource::ParticleSource() : m_effect(nullptr), m_processingCount(0) {}
+ParticleSource::ParticleSource() : m_effect(nullptr), m_processingCount(0), m_effectData(nullptr) {}
 
 bool ParticleSource::isValid() const {
 	if (m_timing.isFinished()) {

--- a/code/particle/ParticleSource.h
+++ b/code/particle/ParticleSource.h
@@ -263,8 +263,8 @@ class SourceTiming {
  * @brief A particle source
  *
  * A particle source contains the information about where and for how long particles are created. A particle effect uses
- * this information to create new particles. A particle source has not effect-specific information which means that an
- * effect can only use the information contained in this object.
+ * this information to create new particles. m_effectData is only effect-specific information that a 
+ * particle source has.
  *
  * @ingroup particleSystems
  */

--- a/code/particle/ParticleSource.h
+++ b/code/particle/ParticleSource.h
@@ -282,6 +282,9 @@ class ParticleSource {
 
 	void initializeThrusterOffset(weapon* wp, weapon_info* wip);
  public:
+	 
+	std::shared_ptr<void> m_effectData; //!< a pointer to a data record specific to the effect type
+
 	ParticleSource();
 
 	inline const ParticleEffect* getEffect() const { return m_effect; }

--- a/code/particle/effects/ConeShape.h
+++ b/code/particle/effects/ConeShape.h
@@ -31,11 +31,16 @@ class ConeShape {
 		return m;
 	}
 
-	void restoreForce(vec3d* dir, vec3d* walker, float fudge) {
+	// restoreForce keeps the normalized spout vector (in local orientation) within the shape bounds
+	// Cone doesnt do much unless its near the edge of the cone, where it nudges it back
+	void restoreForce(vec3d* spout, float spout_speed) {
 		if (m_normalDeviation.max() == 0.0f)
-			*walker = *dir;
-		else
-			vm_vec_scale_add(walker, walker, dir, fudge / sinf(m_normalDeviation.max()));
+			*spout = vmd_z_vector;
+		else {
+			float deviation = vm_vec_delta_ang(&vmd_z_vector, spout, nullptr);
+			vm_vec_scale_add(spout, spout, &vmd_z_vector, (spout_speed / sinf(m_normalDeviation.max()) * (deviation / m_normalDeviation.max())));
+			vm_vec_normalize(spout);
+		}
 	}
 
 	void parse(bool nocreate) {

--- a/code/particle/effects/ConeShape.h
+++ b/code/particle/effects/ConeShape.h
@@ -31,6 +31,13 @@ class ConeShape {
 		return m;
 	}
 
+	void restoreForce(vec3d* dir, vec3d* walker, float fudge) {
+		if (m_normalDeviation.max() == 0.0f)
+			*walker = *dir;
+		else
+			vm_vec_scale_add(walker, walker, dir, fudge / sinf(m_normalDeviation.max()));
+	}
+
 	void parse(bool nocreate) {
 		if (internal::required_string_if_new("+Deviation:", nocreate)) {
 			float deviation;

--- a/code/particle/effects/SphereShape.h
+++ b/code/particle/effects/SphereShape.h
@@ -38,6 +38,8 @@ class SphereShape {
 		return m;
 	}
 
+	void restoreForce(vec3d* dir, vec3d* walker, float fudge) {	}
+
 	void parse(bool  /*nocreate*/) {
 	}
 

--- a/code/particle/effects/SphereShape.h
+++ b/code/particle/effects/SphereShape.h
@@ -38,7 +38,9 @@ class SphereShape {
 		return m;
 	}
 
-	void restoreForce(vec3d* dir, vec3d* walker, float fudge) {	}
+	// restoreForce keeps the normalized spout vector (in local orientation) within the shape bounds
+	// Sphere doesn't do anything, the spout can go wherever it wants
+	void restoreForce(vec3d* spout, float spout_speed) {	}
 
 	void parse(bool  /*nocreate*/) {
 	}


### PR DESCRIPTION
Instead of randomly making particles in a sphere or cone, this effect makes them in the direction of a randomly walking vector contained within a sphere or cone, the 'spout'. For @asarium's note, or anyone else interested in the structure of the particle effect system, this adds the `m_effectData` pointer to particle sources, to be used by whatever the effect in question wants. Sources did not before have effect-specific data, but its fundamentally required for this type of effect in order to have per-source memory regarding the current position of the spout. And I do think adding this opens up many good doors in the future as far as what can be achieved by particle effects.