### PR TITLE
Add 'Dont_override_old_maneuvers' flag to maneuvers

### DIFF
--- a/code/ai/ai.h
+++ b/code/ai/ai.h
@@ -487,7 +487,8 @@ typedef struct ai_info {
 
 	flagset<AI::Maneuver_Override_Flags>	ai_override_flags;			// flags for marking ai overrides from sexp or lua systems
 	control_info	ai_override_ci;		// ai override control info
-	int		ai_override_timestamp;		// mark for when to end the current override
+	int		ai_override_lat_timestamp;		// mark for when to end the current lateral maneuver override
+	int		ai_override_rot_timestamp;		// mark for when to end the current rotational maneuver override
 
 	int form_obj_slotnum;               // for flying in formation object mode, the position in the formation
 } ai_info;

--- a/code/ai/ai_flags.h
+++ b/code/ai/ai_flags.h
@@ -63,7 +63,8 @@ namespace AI {
 		Dont_bank_when_turning,		// maps to CIF_DONT_BANK_WHEN_TURNING
 		Dont_clamp_max_velocity,	// maps to CIF_DONT_CLAMP_MAX_VELOCITY
 		Instantaneous_acceleration,	// maps to CIF_INSTANTANEOUS_ACCELERATION
-		Never_expire,				// don't clear the maneuver when the timestamp is up
+		Lateral_never_expire,       // don't clear the lateral maneuver when the timestamp is up
+		Rotational_never_expire,    // don't clear the rotational maneuver when the timestamp is up
 		Dont_override_old_maneuvers,// doesn't clear any previous maneuvers
 
 		NUM_VALUES

--- a/code/ai/ai_flags.h
+++ b/code/ai/ai_flags.h
@@ -64,6 +64,7 @@ namespace AI {
 		Dont_clamp_max_velocity,	// maps to CIF_DONT_CLAMP_MAX_VELOCITY
 		Instantaneous_acceleration,	// maps to CIF_INSTANTANEOUS_ACCELERATION
 		Never_expire,				// don't clear the maneuver when the timestamp is up
+		Dont_override_old_maneuvers,// doesn't clear any previous maneuvers
 
 		NUM_VALUES
 	};

--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -14227,8 +14227,28 @@ static void ai_control_info_check(ai_info *aip, ship_info *sip, physics_info *pi
 	if (aip->ai_override_flags.none_set())
 		return;
 
-	if (!aip->ai_override_flags[AI::Maneuver_Override_Flags::Never_expire] && timestamp_elapsed(aip->ai_override_timestamp))
+	bool no_lat = false;
+	bool no_rot = false;
+
+	if (!aip->ai_override_flags[AI::Maneuver_Override_Flags::Lateral_never_expire] && timestamp_elapsed(aip->ai_override_lat_timestamp))
 	{
+		aip->ai_override_flags.remove(AI::Maneuver_Override_Flags::Sideways);
+		aip->ai_override_flags.remove(AI::Maneuver_Override_Flags::Up);
+		aip->ai_override_flags.remove(AI::Maneuver_Override_Flags::Forward);
+		aip->ai_override_flags.remove(AI::Maneuver_Override_Flags::Full_lat);
+		no_lat = true;
+	}
+
+	if (!aip->ai_override_flags[AI::Maneuver_Override_Flags::Rotational_never_expire] && timestamp_elapsed(aip->ai_override_rot_timestamp))
+	{
+		aip->ai_override_flags.remove(AI::Maneuver_Override_Flags::Heading);
+		aip->ai_override_flags.remove(AI::Maneuver_Override_Flags::Roll);
+		aip->ai_override_flags.remove(AI::Maneuver_Override_Flags::Pitch);
+		aip->ai_override_flags.remove(AI::Maneuver_Override_Flags::Full_rot);
+		no_rot = true;
+	}
+
+	if (no_rot && no_lat) {
 		aip->ai_override_flags.reset();
 	}
 	else

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -8114,7 +8114,9 @@ void sexp_set_ship_man(ship *shipp, int duration, int heading, int pitch, int ba
 {
 	ai_info	*aip = &Ai_info[shipp->ai_index];
 	
-	aip->ai_override_flags.reset();
+	if (!(maneuver_flags & CIF_DONT_OVERRIDE_OLD_MANEUVERS)) {
+		aip->ai_override_flags.reset();
+	}
 
 	// handle infinite timestamps
 	if (duration >= 2) {
@@ -31817,6 +31819,7 @@ SCP_vector<sexp_help_struct> Sexp_help = {
 		"\t\t1 or 2^0: don't bank when changing heading\r\n"
 		"\t\t2 or 2^1: allow maneuvers exceeding tabled maximums (outside the -100 to 100 range)\r\n"
 		"\t\t4 or 2^2: instantaneously jump to the goal velocity\r\n"
+		"\t\t8 or 2^3: keeps old, but still active, maneuver values that were not overwritten. This will refresh the old maneuver's duration\r\n"
 	},
 
 	// Wanderer
@@ -31834,6 +31837,7 @@ SCP_vector<sexp_help_struct> Sexp_help = {
 		"\t\t1 or 2^0: don't bank when changing heading\r\n"
 		"\t\t2 or 2^1: allow maneuvers exceeding tabled maximums (outside the -100 to 100 range)\r\n"
 		"\t\t4 or 2^2: instantaneously jump to the goal velocity\r\n"
+		"\t\t8 or 2^3: keeps old, but still active, maneuver values that were not overwritten. This will refresh the old maneuver's duration\r\n"
 	},
 	
 	// Wanderer
@@ -31851,6 +31855,7 @@ SCP_vector<sexp_help_struct> Sexp_help = {
 		"\t\t1 or 2^0: don't bank when changing heading (which won't have any affect for lat-maneuver)\r\n"
 		"\t\t2 or 2^1: allow maneuvers exceeding tabled maximums (outside the -100 to 100 range)\r\n"
 		"\t\t4 or 2^2: instantaneously jump to the goal velocity\r\n"
+		"\t\t8 or 2^3: keeps old, but still active, maneuver values that were not overwritten. This will refresh the old maneuver's duration\r\n"
 	},
 
 	// Goober5000

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -8117,51 +8117,72 @@ void sexp_set_ship_man(ship *shipp, int duration, int heading, int pitch, int ba
 	if (!(maneuver_flags & CIF_DONT_OVERRIDE_OLD_MANEUVERS)) {
 		aip->ai_override_flags.reset();
 	}
-
-	// handle infinite timestamps
-	if (duration >= 2) {
-		aip->ai_override_timestamp = timestamp(duration);
-	} else {
-		aip->ai_override_timestamp = timestamp(10);
-		aip->ai_override_flags.set(AI::Maneuver_Override_Flags::Never_expire);
-	}
+	bool applied_rot, applied_lat;
+	applied_rot = applied_lat = false;
 
 	if (apply_all_rotate) {
 		aip->ai_override_flags.set(AI::Maneuver_Override_Flags::Full_rot);
 		aip->ai_override_ci.bank = bank / 100.0f;
 		aip->ai_override_ci.pitch = pitch / 100.0f;
 		aip->ai_override_ci.heading = heading / 100.0f;
+		applied_rot = true;
 	} else {
 		if (bank != 0) {
 			aip->ai_override_flags.set(AI::Maneuver_Override_Flags::Roll);
 			aip->ai_override_ci.bank = bank / 100.0f;
+			applied_rot = true;
 		}
 		if (pitch != 0) {
 			aip->ai_override_flags.set(AI::Maneuver_Override_Flags::Pitch);
 			aip->ai_override_ci.pitch = pitch / 100.0f;
+			applied_rot = true;
 		}
 		if (heading != 0) {
 			aip->ai_override_flags.set(AI::Maneuver_Override_Flags::Heading);
 			aip->ai_override_ci.heading = heading / 100.0f;
+			applied_rot = true;
 		}
 	}
+
 	if (apply_all_lat) {
 		aip->ai_override_flags.set(AI::Maneuver_Override_Flags::Full_lat);
 		aip->ai_override_ci.vertical = up / 100.0f;
 		aip->ai_override_ci.sideways = sideways / 100.0f;
 		aip->ai_override_ci.forward = forward / 100.0f;
+		applied_lat = true;
 	} else {
 		if (up != 0) {
 			aip->ai_override_flags.set(AI::Maneuver_Override_Flags::Up);
 			aip->ai_override_ci.vertical = up / 100.0f;
+			applied_lat = true;
 		}
 		if (sideways != 0) {
 			aip->ai_override_flags.set(AI::Maneuver_Override_Flags::Sideways);
 			aip->ai_override_ci.sideways = sideways / 100.0f;
+			applied_lat = true;
 		}
 		if (forward != 0) {
 			aip->ai_override_flags.set(AI::Maneuver_Override_Flags::Forward);
 			aip->ai_override_ci.forward = forward / 100.0f;
+			applied_lat = true;
+		}
+	}
+
+	// handle infinite timestamps
+	if (duration >= 2) {
+		if (applied_rot)
+			aip->ai_override_rot_timestamp = timestamp(duration);
+		if (applied_lat)
+			aip->ai_override_lat_timestamp = timestamp(duration);
+	}
+	else {
+		if (applied_rot) {
+			aip->ai_override_rot_timestamp = timestamp(10);
+			aip->ai_override_flags.set(AI::Maneuver_Override_Flags::Rotational_never_expire);
+		}
+		if (applied_lat) {
+			aip->ai_override_lat_timestamp = timestamp(10);
+			aip->ai_override_flags.set(AI::Maneuver_Override_Flags::Lateral_never_expire);
 		}
 	}
 
@@ -31819,7 +31840,7 @@ SCP_vector<sexp_help_struct> Sexp_help = {
 		"\t\t1 or 2^0: don't bank when changing heading\r\n"
 		"\t\t2 or 2^1: allow maneuvers exceeding tabled maximums (outside the -100 to 100 range)\r\n"
 		"\t\t4 or 2^2: instantaneously jump to the goal velocity\r\n"
-		"\t\t8 or 2^3: keeps old, but still active, maneuver values that were not overwritten. This will refresh the old maneuver's duration\r\n"
+		"\t\t8 or 2^3: keeps old, but still active, maneuver values that were not overwritten\r\n"
 	},
 
 	// Wanderer
@@ -31837,7 +31858,7 @@ SCP_vector<sexp_help_struct> Sexp_help = {
 		"\t\t1 or 2^0: don't bank when changing heading\r\n"
 		"\t\t2 or 2^1: allow maneuvers exceeding tabled maximums (outside the -100 to 100 range)\r\n"
 		"\t\t4 or 2^2: instantaneously jump to the goal velocity\r\n"
-		"\t\t8 or 2^3: keeps old, but still active, maneuver values that were not overwritten. This will refresh the old maneuver's duration\r\n"
+		"\t\t8 or 2^3: keeps old, but still active, maneuver values that were not overwritten\r\n"
 	},
 	
 	// Wanderer
@@ -31855,7 +31876,7 @@ SCP_vector<sexp_help_struct> Sexp_help = {
 		"\t\t1 or 2^0: don't bank when changing heading (which won't have any affect for lat-maneuver)\r\n"
 		"\t\t2 or 2^1: allow maneuvers exceeding tabled maximums (outside the -100 to 100 range)\r\n"
 		"\t\t4 or 2^2: instantaneously jump to the goal velocity\r\n"
-		"\t\t8 or 2^3: keeps old, but still active, maneuver values that were not overwritten. This will refresh the old maneuver's duration\r\n"
+		"\t\t8 or 2^3: keeps old, but still active, maneuver values that were not overwritten\r\n"
 	},
 
 	// Goober5000

--- a/code/physics/physics.h
+++ b/code/physics/physics.h
@@ -102,10 +102,11 @@ typedef struct physics_info {
 								// only by the AI after calls to angular_move. It is read and then zeroed out for the rest of the frame by physics_sim_rot
 } physics_info;
 
-
+// control info override flags
 #define CIF_DONT_BANK_WHEN_TURNING		(1 << 0)	// Goober5000 - changing heading does not change bank
 #define CIF_DONT_CLAMP_MAX_VELOCITY		(1 << 1)	// Goober5000 - maneuvers can exceed tabled max velocity
 #define CIF_INSTANTANEOUS_ACCELERATION	(1 << 2)	// Goober5000 - instantaneously jump to the goal velocity
+#define CIF_DONT_OVERRIDE_OLD_MANEUVERS	(1 << 3)	// Asteroth - will attempt to maintain any old maneuvers still in progress
 
 #define	SW_ROT_FACTOR			5		// increase in rotational time constant in shockwave
 #define	SW_BLAST_DURATION		2000	// maximum duration of shockwave

--- a/code/scripting/api/objs/ship.cpp
+++ b/code/scripting/api/objs/ship.cpp
@@ -1462,7 +1462,9 @@ ADE_FUNC(doManeuver,
 	ai_info *aip = &Ai_info[shipp->ai_index];
 	control_info *cip = &aip->ai_override_ci;
 
-	aip->ai_override_flags.reset();
+	if (!(maneuver_flags & CIF_DONT_OVERRIDE_OLD_MANEUVERS)) {
+		aip->ai_override_flags.reset();
+	}
 
 	// handle infinite timestamps
 	if (duration >= 2) {

--- a/code/scripting/api/objs/ship.cpp
+++ b/code/scripting/api/objs/ship.cpp
@@ -1465,32 +1465,30 @@ ADE_FUNC(doManeuver,
 	if (!(maneuver_flags & CIF_DONT_OVERRIDE_OLD_MANEUVERS)) {
 		aip->ai_override_flags.reset();
 	}
-
-	// handle infinite timestamps
-	if (duration >= 2) {
-		aip->ai_override_timestamp = timestamp(duration);
-	} else {
-		aip->ai_override_timestamp = timestamp(10);
-		aip->ai_override_flags.set(AI::Maneuver_Override_Flags::Never_expire);
-	}
-
+	
+	bool applied_rot = false;
+	bool applied_lat = false;
 	if (apply_all_rotate) {
 		aip->ai_override_flags.set(AI::Maneuver_Override_Flags::Full_rot);
 		cip->heading = heading;
 		cip->pitch = pitch;
 		cip->bank = bank;
+		applied_rot = true;
 	} else {
 		if (heading != 0) {
 			cip->heading = heading;
 			aip->ai_override_flags.set(AI::Maneuver_Override_Flags::Heading);
+			applied_rot = true;
 		}
 		if (pitch != 0) {
 			cip->pitch = pitch;
 			aip->ai_override_flags.set(AI::Maneuver_Override_Flags::Pitch);
+			applied_rot = true;
 		}
 		if (bank != 0) {
 			cip->bank = bank;
 			aip->ai_override_flags.set(AI::Maneuver_Override_Flags::Roll);
+			applied_rot = true;
 		}
 	}
 	if (apply_all_move) {
@@ -1498,18 +1496,40 @@ ADE_FUNC(doManeuver,
 		cip->vertical = up;
 		cip->sideways = sideways;
 		cip->forward = forward;
+		applied_lat = true;
 	} else {
 		if (up != 0) {
 			cip->vertical = up;
 			aip->ai_override_flags.set(AI::Maneuver_Override_Flags::Up);
+			applied_lat = true;
 		}
 		if (sideways != 0) {
 			cip->sideways = sideways;
 			aip->ai_override_flags.set(AI::Maneuver_Override_Flags::Sideways);
+			applied_lat = true;
 		}
 		if (forward != 0) {
 			cip->forward = forward;
 			aip->ai_override_flags.set(AI::Maneuver_Override_Flags::Forward);
+			applied_lat = true;
+		}
+	}
+
+	// handle infinite timestamps
+	if (duration >= 2) {
+		if (applied_rot)
+			aip->ai_override_rot_timestamp = timestamp(duration);
+		if (applied_lat)
+			aip->ai_override_lat_timestamp = timestamp(duration);
+	}
+	else {
+		if (applied_rot) {
+			aip->ai_override_rot_timestamp = timestamp(10);
+			aip->ai_override_flags.set(AI::Maneuver_Override_Flags::Rotational_never_expire);
+		}
+		if (applied_lat) {
+			aip->ai_override_lat_timestamp = timestamp(10);
+			aip->ai_override_flags.set(AI::Maneuver_Override_Flags::Lateral_never_expire);
 		}
 	}
 


### PR DESCRIPTION
Maneuvers normally clear any existing maneuvers before taking effect, with this flag it will not do that. Though it does refresh the duration of the old maneuver, which is unideal, this allows for independent sexp/scripting control over lateral and rotational maneuvers at the same time, which is incredibly useful.