### PR TITLE
Death roll for big ships and a death roll multiplier

### DIFF
--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -14304,7 +14304,7 @@ void ai_process( object * obj, int ai_index, float frametime )
 	auto sip = &Ship_info[shipp->ship_info_index];
 
 	// return if ship is dead, unless it's a big ship...then its turrets still fire, like I was quoted in a magazine.  -- MK, 5/15/98.
-	if ((shipp->flags[Ship::Ship_Flags::Dying] ) && !(Ship_info[shipp->ship_info_index].is_big_or_huge())) {
+	if ((shipp->flags[Ship::Ship_Flags::Dying] ) && !(sip->is_big_or_huge())) {
 		return;
 	}
 
@@ -14344,6 +14344,10 @@ void ai_process( object * obj, int ai_index, float frametime )
 	default:
 		break;
 	}
+
+	// this is sufficient because non-big ships were already weeded out by dying above
+	if (shipp->flags[Ship::Ship_Flags::Dying] && sip->flags[Ship::Info_Flags::Large_ship_deathroll])
+		rfc = false;
 
 	if (rfc) {
 		// Wanderer - sexp based override goes here - only if rfc is valid though

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -904,6 +904,7 @@ void ship_info::clone(const ship_info& other)
 	death_roll_r_mult = other.death_roll_r_mult;
 	death_fx_r_mult = other.death_fx_r_mult;
 	death_roll_time_mult = other.death_roll_time_mult;
+	death_roll_rotation_mult = other.death_roll_rotation_mult;
 	death_roll_xrotation_cap = other.death_roll_xrotation_cap;
 	death_roll_yrotation_cap = other.death_roll_yrotation_cap;
 	death_roll_zrotation_cap = other.death_roll_zrotation_cap;
@@ -1226,6 +1227,7 @@ void ship_info::move(ship_info&& other)
 	death_roll_r_mult = other.death_roll_r_mult;
 	death_fx_r_mult = other.death_fx_r_mult;
 	death_roll_time_mult = other.death_roll_time_mult;
+	death_roll_rotation_mult = other.death_roll_rotation_mult;
 	death_roll_xrotation_cap = other.death_roll_xrotation_cap;
 	death_roll_yrotation_cap = other.death_roll_yrotation_cap;
 	death_roll_zrotation_cap = other.death_roll_zrotation_cap;

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -349,6 +349,7 @@ flag_def_list_new<Info_Flags> Ship_flags[] = {
 	{ "don't bank when turning",	Info_Flags::Dont_bank_when_turning,		true, false },
 	{ "don't clamp max velocity",	Info_Flags::Dont_clamp_max_velocity,	true, false },
 	{ "instantaneous acceleration",	Info_Flags::Instantaneous_acceleration,	true, false },
+	{ "large ship deathroll",		Info_Flags::Large_ship_deathroll,	true, false },
     // to keep things clean, obsolete options go last
     { "ballistic primaries",		Info_Flags::Ballistic_primaries,	false, false }
 };
@@ -1563,6 +1564,7 @@ ship_info::ship_info()
 	death_roll_r_mult = 1.0f;
 	death_fx_r_mult = 1.0f;
 	death_roll_time_mult = 1.0f;
+	death_roll_rotation_mult = 1.0f;
 	death_roll_xrotation_cap = 0.75f*DEATHROLL_ROTVEL_CAP;
 	death_roll_yrotation_cap = 0.75f*DEATHROLL_ROTVEL_CAP;
 	death_roll_zrotation_cap = 0.75f*DEATHROLL_ROTVEL_CAP;
@@ -3318,6 +3320,10 @@ static void parse_ship_values(ship_info* sip, const bool is_template, const bool
 		stuff_int(&sip->death_fx_count);
 		if (sip->death_fx_count < 0)
 			sip->death_fx_count = 0;
+	}
+
+	if (optional_string("$Death Roll Rotation Multiplier:")) {
+		stuff_float(&sip->death_roll_rotation_mult);
 	}
 
 	if(optional_string("$Death Roll X rotation Cap:")){

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -1084,6 +1084,7 @@ public:
 	float death_roll_r_mult;
 	float death_fx_r_mult;
 	float death_roll_time_mult;
+	float death_roll_rotation_mult;
 	float death_roll_xrotation_cap;         // max rotation around x-axis in radians-per-sec (aka pitch)
 	float death_roll_yrotation_cap;         // max rotation around y-axis in radians-per-sec (aka yaw)
 	float death_roll_zrotation_cap;         // max rotation around z-axis in radians-per-sec (aka roll)

--- a/code/ship/ship_flags.h
+++ b/code/ship/ship_flags.h
@@ -195,6 +195,7 @@ namespace Ship {
 		Dont_clamp_max_velocity,		// Goober5000
 		Instantaneous_acceleration,		// Goober5000
 		Has_display_name,				// Goober5000
+		Large_ship_deathroll,			// Asteroth - big ships dont normally deathroll, this makes them do it!
 
 		NUM_VALUES
 	};

--- a/code/ship/shiphit.cpp
+++ b/code/ship/shiphit.cpp
@@ -1535,6 +1535,8 @@ void ship_generic_kill_stuff( object *objp, float percent_killed )
 		rotvel_mag = 150.0f / objp->radius;
 	}
 
+	rotvel_mag *= sip->death_roll_rotation_mult;
+
 	if (object_is_dead_docked(objp)) {
 		// don't change current rotvel
 		sp->deathroll_rotvel = objp->phys_info.rotvel;


### PR DESCRIPTION
Two simple additions, a flags that makes big|huge ships do a deathroll (running AI on them despite being dying clobbers their `desired_rotvel` normally), and a multiplier for the intensity of the death roll rotation.