### PR TITLE
Separate ship splitting explosions from propagating explosions

### DIFF
--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -3284,7 +3284,7 @@ static void parse_ship_values(ship_info* sip, const bool is_template, const bool
 		stuff_boolean(&sip->explosion_splits_ship);
 	}
 	else if (first_time) {
-		sip->explosion_splits_ship = sip->explosion_propagates;
+		sip->explosion_splits_ship = sip->explosion_propagates == 1;
 	}
 
 	if(optional_string("$Propagating Expl Radius Multiplier:")){

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -1079,6 +1079,7 @@ public:
 	// ship explosion info
 	shockwave_create_info shockwave;
 	int	explosion_propagates;				// If true, then the explosion propagates
+	bool explosion_splits_ship;				// If true, then the ship 'splits in two' when it blows up
 	float big_exp_visual_rad;				//SUSHI: The visual size of the main explosion
 	float prop_exp_rad_mult;				// propagating explosions radius multiplier
 	float death_roll_r_mult;


### PR DESCRIPTION
Another small death-related addition: whether a ship splits in two at the end of its death roll can now be set separately from a propagating explosion.