### PR TITLE
Remove erroneous call to CDR.

### DIFF
--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -11272,7 +11272,6 @@ void sexp_player_use_ai(int flag)
 // Karajorma
 void sexp_allow_treason (int n) 
 {
-	n = CDR(n);
 	if (n != -1) {
 		The_mission.flags.set(Mission::Mission_Flags::No_traitor, is_sexp_true(n));
 	}


### PR DESCRIPTION
The apparent intention of this call to CDR is already fulfilled in eval_sexp on line 23113, which passes this value into child functions including sexp_allow_treason. As a result the latter function will end up CDR'ing into a one-element list, producing (), which evaluates to false, and the allow-treason sexp consequently fails to work.