### PR TITLE
Scripting Bugfix: previous HUD set/get gauge color referred to config instead of ingame gauge

### DIFF
--- a/code/hud/hud.cpp
+++ b/code/hud/hud.cpp
@@ -538,6 +538,11 @@ void HudGauge::updateColor(int r, int g, int b, int a)
 	gr_init_alphacolor(&gauge_color, r, g, b, a);
 }
 
+ const color& HudGauge::getColor()
+{
+	return gauge_color;
+}
+
 void HudGauge::updateActive(bool show)
 {
 	active = show;

--- a/code/hud/hud.h
+++ b/code/hud/hud.h
@@ -275,6 +275,7 @@ public:
 	bool isActive();
 	
 	void updateColor(int r, int g, int b, int a = 255);
+	const color& getColor();
 	void lockConfigColor(bool lock);
 	void sexpLockConfigColor(bool lock);
 	void updateActive(bool show);

--- a/code/scripting/api/libs/hud.cpp
+++ b/code/scripting/api/libs/hud.cpp
@@ -53,6 +53,24 @@ ADE_VIRTVAR(HUDDisabledExceptMessages, l_HUD, "boolean", "Specifies if only the 
 		return ADE_RETURN_FALSE;
 }
 
+ADE_VIRTVAR(HUDDefaultGaugeCount, l_HUD, "number", "Specifies the amount of HUD gauges defined by FSO", "number", "The number of FSO HUD gauges")
+{
+	int amount = default_hud_gauges.size();
+
+	if (!ade_get_args(L, "*|i", &amount))
+		return ADE_RETURN_NIL;
+
+	if (ADE_SETTING_VAR)
+	{
+		hud_disable_except_messages(amount);
+	}
+
+	if (hud_disabled_except_messages())
+		return ADE_RETURN_TRUE;
+	else
+		return ADE_RETURN_FALSE;
+}
+
 ADE_FUNC(setHUDGaugeColor, l_HUD,
          "number gaugeIndex, [number red, number green, number blue, number alpha]",
          "Color used to draw the gauge", "boolean", "If the operation was successful")
@@ -61,15 +79,15 @@ ADE_FUNC(setHUDGaugeColor, l_HUD,
 	int r = 0;
 	int g = 0;
 	int b = 0;
-	int a = 0;
+	int a = 255;
 
 	if(!ade_get_args(L, "i|iiii", &idx, &r, &g, &b, &a))
 		return ADE_RETURN_FALSE;
 
-	if ((idx < 0) || (idx >= NUM_HUD_GAUGES))
+	if ((idx < 0) || (idx >= default_hud_gauges.size()))
 		return ADE_RETURN_FALSE;
 
-	gr_init_alphacolor(&HUD_config.clr[idx], r, g, b, a);
+	default_hud_gauges[idx]->updateColor(r, g, b, a);
 
 	return ADE_RETURN_TRUE;
 }
@@ -82,10 +100,10 @@ ADE_FUNC(getHUDGaugeColor, l_HUD, "number gaugeIndex", "Color used to draw the g
 	if(!ade_get_args(L, "i", &idx))
 		return ADE_RETURN_NIL;
 
-	if ((idx < 0) || (idx >= NUM_HUD_GAUGES))
+	if ((idx < 0) || (idx >= default_hud_gauges.size()))
 		return ADE_RETURN_NIL;
 
-	color c = HUD_config.clr[idx];
+	color c = default_hud_gauges[idx]->getColor();
 
 	return ade_set_args(L, "iiii", (int) c.red, (int) c.green, (int) c.blue, (int) c.alpha);
 }

--- a/code/scripting/api/libs/hud.cpp
+++ b/code/scripting/api/libs/hud.cpp
@@ -73,7 +73,7 @@ ADE_VIRTVAR(HUDDefaultGaugeCount, l_HUD, "number", "Specifies the amount of HUD 
 
 ADE_FUNC(setHUDGaugeColor, l_HUD,
          "number gaugeIndex, [number red, number green, number blue, number alpha]",
-         "Color used to draw the gauge", "boolean", "If the operation was successful")
+         "Modifies color used to draw the gauge in the pilot config", "boolean", "If the operation was successful")
 {
 	int idx = -1;
 	int r = 0;
@@ -92,7 +92,7 @@ ADE_FUNC(setHUDGaugeColor, l_HUD,
 	return ADE_RETURN_TRUE;
 }
 
-ADE_FUNC(getHUDGaugeColor, l_HUD, "number gaugeIndex", "Color used to draw the gauge",
+ADE_FUNC(getHUDGaugeColor, l_HUD, "number gaugeIndex", "Color specified in the config to draw the gauge",
          ade_type_info({"number", "number", "number", "number"}), "Red, green, blue, and alpha of the gauge")
 {
 	int idx = -1;

--- a/code/scripting/api/libs/hud.cpp
+++ b/code/scripting/api/libs/hud.cpp
@@ -110,7 +110,7 @@ ADE_FUNC(getHUDGaugeColor, l_HUD, "number gaugeIndex", "Color specified in the c
 
 ADE_FUNC(setHUDGaugeColorInMission, l_HUD,
          "number gaugeIndex, [number red, number green, number blue, number alpha]",
-         "Color used to draw the gauge", "boolean", "If the operation was successful")
+         "Set color currently used to draw the gauge", "boolean", "If the operation was successful")
 {
 	int idx = -1;
 	int r = 0;
@@ -129,7 +129,7 @@ ADE_FUNC(setHUDGaugeColorInMission, l_HUD,
 	return ADE_RETURN_TRUE;
 }
 
-ADE_FUNC(getHUDGaugeColorInMission, l_HUD, "number gaugeIndex", "Color used to draw the gauge",
+ADE_FUNC(getHUDGaugeColorInMission, l_HUD, "number gaugeIndex", "Color currently used to draw the gauge",
          ade_type_info({"number", "number", "number", "number"}), "Red, green, blue, and alpha of the gauge")
 {
 	int idx = -1;

--- a/code/scripting/api/libs/hud.cpp
+++ b/code/scripting/api/libs/hud.cpp
@@ -55,7 +55,7 @@ ADE_VIRTVAR(HUDDisabledExceptMessages, l_HUD, "boolean", "Specifies if only the 
 
 ADE_VIRTVAR(HUDDefaultGaugeCount, l_HUD, "number", "Specifies the amount of HUD gauges defined by FSO", "number", "The number of FSO HUD gauges")
 {
-	int amount = default_hud_gauges.size();
+	int amount = (int)default_hud_gauges.size();
 
 	if (!ade_get_args(L, "*|i", &amount))
 		return ADE_RETURN_NIL;
@@ -79,6 +79,43 @@ ADE_FUNC(setHUDGaugeColor, l_HUD,
 	int r = 0;
 	int g = 0;
 	int b = 0;
+	int a = 0;
+
+	if(!ade_get_args(L, "i|iiii", &idx, &r, &g, &b, &a))
+		return ADE_RETURN_FALSE;
+
+	if ((idx < 0) || (idx >= NUM_HUD_GAUGES))
+		return ADE_RETURN_FALSE;
+
+	gr_init_alphacolor(&HUD_config.clr[idx], r, g, b, a);
+
+	return ADE_RETURN_TRUE;
+}
+
+ADE_FUNC(getHUDGaugeColor, l_HUD, "number gaugeIndex", "Color used to draw the gauge",
+         ade_type_info({"number", "number", "number", "number"}), "Red, green, blue, and alpha of the gauge")
+{
+	int idx = -1;
+
+	if(!ade_get_args(L, "i", &idx))
+		return ADE_RETURN_NIL;
+
+	if ((idx < 0) || (idx >= NUM_HUD_GAUGES))
+		return ADE_RETURN_NIL;
+
+	color c = HUD_config.clr[idx];
+
+	return ade_set_args(L, "iiii", (int) c.red, (int) c.green, (int) c.blue, (int) c.alpha);
+}
+
+ADE_FUNC(setHUDGaugeColorInMission, l_HUD,
+         "number gaugeIndex, [number red, number green, number blue, number alpha]",
+         "Color used to draw the gauge", "boolean", "If the operation was successful")
+{
+	int idx = -1;
+	int r = 0;
+	int g = 0;
+	int b = 0;
 	int a = 255;
 
 	if(!ade_get_args(L, "i|iiii", &idx, &r, &g, &b, &a))
@@ -92,7 +129,7 @@ ADE_FUNC(setHUDGaugeColor, l_HUD,
 	return ADE_RETURN_TRUE;
 }
 
-ADE_FUNC(getHUDGaugeColor, l_HUD, "number gaugeIndex", "Color used to draw the gauge",
+ADE_FUNC(getHUDGaugeColorInMission, l_HUD, "number gaugeIndex", "Color used to draw the gauge",
          ade_type_info({"number", "number", "number", "number"}), "Red, green, blue, and alpha of the gauge")
 {
 	int idx = -1;

--- a/code/scripting/api/libs/hud.cpp
+++ b/code/scripting/api/libs/hud.cpp
@@ -121,7 +121,7 @@ ADE_FUNC(setHUDGaugeColorInMission, l_HUD,
 	if(!ade_get_args(L, "i|iiii", &idx, &r, &g, &b, &a))
 		return ADE_RETURN_FALSE;
 
-	if ((idx < 0) || (idx >= default_hud_gauges.size()))
+	if ((idx < 0) || (idx >= (int)default_hud_gauges.size()))
 		return ADE_RETURN_FALSE;
 
 	default_hud_gauges[idx]->updateColor(r, g, b, a);
@@ -137,7 +137,7 @@ ADE_FUNC(getHUDGaugeColorInMission, l_HUD, "number gaugeIndex", "Color currently
 	if(!ade_get_args(L, "i", &idx))
 		return ADE_RETURN_NIL;
 
-	if ((idx < 0) || (idx >= default_hud_gauges.size()))
+	if ((idx < 0) || (idx >= (int)default_hud_gauges.size()))
 		return ADE_RETURN_NIL;
 
 	color c = default_hud_gauges[idx]->getColor();

--- a/code/scripting/api/libs/hud.cpp
+++ b/code/scripting/api/libs/hud.cpp
@@ -57,18 +57,7 @@ ADE_VIRTVAR(HUDDefaultGaugeCount, l_HUD, "number", "Specifies the amount of HUD 
 {
 	int amount = (int)default_hud_gauges.size();
 
-	if (!ade_get_args(L, "*|i", &amount))
-		return ADE_RETURN_NIL;
-
-	if (ADE_SETTING_VAR)
-	{
-		hud_disable_except_messages(amount);
-	}
-
-	if (hud_disabled_except_messages())
-		return ADE_RETURN_TRUE;
-	else
-		return ADE_RETURN_FALSE;
+	return ade_set_args(L, "i", amount);
 }
 
 ADE_FUNC(setHUDGaugeColor, l_HUD,


### PR DESCRIPTION
Previously, the Scripting API functions setHUDGaugeColor and getHUDGaugeColor referred to HUD_config, which stores the configuration of the gauges by the user. However, modifying the configuration this way does not modify the gauge color in mission.
After this change, it does by accessing not the configuration but rather the currently loaded gauges.
In addition, a new virtvar is added to the HUD environment to allow scripts to query the number of existing gauges (so that this does not need to be hardcoded and subsequently be in danger of failing with an update of the gauges)