### PR TITLE
Fix turret-change-weapon comparing sec_slot to max primary banks.

### DIFF
--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -18313,7 +18313,7 @@ void sexp_turret_change_weapon(int node)
 	}
 	else if (sec_slot)
 	{
-		if (sec_slot > MAX_SHIP_PRIMARY_BANKS) {
+		if (sec_slot > MAX_SHIP_SECONDARY_BANKS) {
 			return;
 		}
 


### PR DESCRIPTION
We should compare `sec_slot` to `MAX_SHIP_SECONDARY_BANKS`, not `MAX_SHIP_PRIMARY_BANKS`.