### PR TITLE
Allow normal weapons to use 'fire down normals'

### DIFF
--- a/code/ai/aiturret.cpp
+++ b/code/ai/aiturret.cpp
@@ -2718,11 +2718,16 @@ void ai_fire_from_turret(ship *shipp, ship_subsys *ss, int parent_objnum)
 				something_was_ok_to_fire = true;
 				Num_turrets_fired++;
 
+				vec3d shoot_vector = v2e;
+				if (tp->flags[Model::Subsystem_Flags::Fire_on_normal])
+					shoot_vector = gvec;
+
 				//Pass along which gun we are using
+				int wep_to_fire = i;
 				if (tp->flags[Model::Subsystem_Flags::Turret_salvo])
-					turret_fire_weapon(valid_weapons[0], ss, parent_objnum, &gpos, &v2e, &predicted_enemy_pos);
-				else
-					turret_fire_weapon(valid_weapons[i], ss, parent_objnum, &gpos, &v2e, &predicted_enemy_pos);
+					wep_to_fire = 0;
+
+				turret_fire_weapon(valid_weapons[wep_to_fire], ss, parent_objnum, &gpos, &shoot_vector, &predicted_enemy_pos);
 			} else {
 				// make sure salvo fire mode does not turn into autofire
 				if ((tp->flags[Model::Subsystem_Flags::Turret_salvo]) && ((i + 1) == number_of_firings)) {

--- a/code/ai/aiturret.cpp
+++ b/code/ai/aiturret.cpp
@@ -2718,16 +2718,16 @@ void ai_fire_from_turret(ship *shipp, ship_subsys *ss, int parent_objnum)
 				something_was_ok_to_fire = true;
 				Num_turrets_fired++;
 
-				vec3d shoot_vector = v2e;
+				vec3d* shoot_vector = &v2e;
 				if (tp->flags[Model::Subsystem_Flags::Fire_on_normal])
-					shoot_vector = gvec;
+					shoot_vector = &gvec;
 
 				//Pass along which gun we are using
 				int wep_to_fire = i;
 				if (tp->flags[Model::Subsystem_Flags::Turret_salvo])
 					wep_to_fire = 0;
 
-				turret_fire_weapon(valid_weapons[wep_to_fire], ss, parent_objnum, &gpos, &shoot_vector, &predicted_enemy_pos);
+				turret_fire_weapon(valid_weapons[wep_to_fire], ss, parent_objnum, &gpos, shoot_vector, &predicted_enemy_pos);
 			} else {
 				// make sure salvo fire mode does not turn into autofire
 				if ((tp->flags[Model::Subsystem_Flags::Turret_salvo]) && ((i + 1) == number_of_firings)) {


### PR DESCRIPTION
With `fire_down_normals` `ship_get_global_turret_info()` properly sets up `gvec` to be actually pointing in the direction the turret is, which is used by the turret firing code prior to this to determine things like being in fov, but when it comes to actually firing it doesn't bother and just fires straight at its target. This is fine normally, but given we have a specific flag to force firing down `gvec` its quite unintuitive that this won't be the case for normal weapons (it is only used by beams AFAICT).

Also a little readability change right next to it because it was bothering me. I dunno about you guys but if a big function call might need several different arguments, I prefer setting up the arguments beforehand, and calling the function once rather than a bunch of conditional calls to the function.