### PR TITLE
Turn framerate-independent turning on by default

### DIFF
--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -654,7 +654,7 @@ void mod_table_reset()
 	Arc_color_emp_p2 = std::make_tuple(static_cast<ubyte>(128), static_cast<ubyte>(128), static_cast<ubyte>(10));
 	Arc_color_emp_s1 = std::make_tuple(static_cast<ubyte>(255), static_cast<ubyte>(255), static_cast<ubyte>(10));
 	Use_engine_wash_intensity = false;
-	Framerate_independent_turning = false;
+	Framerate_independent_turning = true;
 	Ai_respect_tabled_turntime_rotdamp = false;
 	Swarmers_lead_targets = false;
 	Required_render_ext.clear();


### PR DESCRIPTION
Asteroth's framerate-independent turning feature put a huge amount of work into remaining backwards-compatible with retail behaviour at 60FPS, and at this stage I've been playing with it turned on for everything for months and I've yet to find an identifiable bug due to it in any mod. I think it's definitely time to switch it on by default (leaving the table flags in place so that mods still have the option to disable it). The only thing it needs now is more thorough testing for full compatibility, and the best way to get that is to have it incorporated into the release candidate builds.