### PR TITLE
some fixes to aiturret code

### DIFF
--- a/code/ai/ai_flags.h
+++ b/code/ai/ai_flags.h
@@ -120,7 +120,7 @@ namespace AI {
         Smart_secondary_weapon_selection,
         Smart_shield_management,
         Smart_subsystem_targeting_for_turrets,
-        Strict_turred_tagged_only_targeting,
+        Strict_turret_tagged_only_targeting,
 		Support_dont_add_primaries, //Prevents support ship from equipping new primary as requested in http://scp.indiegames.us/mantis/view.php?id=3198
         Turrets_ignore_target_radius,
         Use_actual_primary_range,

--- a/code/ai/ai_profiles.cpp
+++ b/code/ai/ai_profiles.cpp
@@ -463,7 +463,7 @@ void parse_ai_profiles_tbl(const char *filename)
 
 				set_flag(profile, "$fix ai path order bug:", AI::Profile_Flags::Fix_ai_path_order_bug);
 
-				set_flag(profile, "$strict turret-tagged-only targeting:", AI::Profile_Flags::Strict_turred_tagged_only_targeting);
+				set_flag(profile, "$strict turret-tagged-only targeting:", AI::Profile_Flags::Strict_turret_tagged_only_targeting);
 
 				set_flag(profile, "$aspect bomb invulnerability fix:", AI::Profile_Flags::Aspect_invulnerability_fix);
 

--- a/code/ai/aiturret.cpp
+++ b/code/ai/aiturret.cpp
@@ -2734,6 +2734,7 @@ void ai_fire_from_turret(ship *shipp, ship_subsys *ss, int parent_objnum)
 			}
 
 			// we are done firing, so fire the next weapon from the next firing point
+			// (This was originally done under the "We're ready to fire..." comment)
 			ss->turret_next_fire_pos++;
 		}
 

--- a/code/ai/aiturret.cpp
+++ b/code/ai/aiturret.cpp
@@ -2140,7 +2140,7 @@ void turret_swarm_fire_from_turret(turret_swarm_info *tsi)
 		// maybe sound
 		if ( Weapon_info[tsi->weapon_class].launch_snd.isValid() ) {
 			// Don't play turret firing sound if turret sits on player ship... it gets annoying.
-			if ( tsi->parent_objnum != OBJ_INDEX(Player_obj) ) {
+			if ( tsi->parent_objnum != OBJ_INDEX(Player_obj) || (tsi->turret->flags[Ship::Subsystem_Flags::Play_sound_for_player]) ) {
 				snd_play_3d( gamesnd_get_game_sound(Weapon_info[tsi->weapon_class].launch_snd), &turret_pos, &View_position );
 			}
 		}
@@ -2541,9 +2541,6 @@ void ai_fire_from_turret(ship *shipp, ship_subsys *ss, int parent_objnum)
 	//Assert(ss->turret_enemy_objnum != -1);
 
 	bool in_fov = turret_fov_test(ss, &gvec, &v2e);
-
-	// Ok, the turret is lined up... now line up a particular gun.
-	bool ok_to_fire = false;
 	bool something_was_ok_to_fire = false;
 
 	if (in_fov) {
@@ -2582,8 +2579,8 @@ void ai_fire_from_turret(ship *shipp, ship_subsys *ss, int parent_objnum)
 					ss->turret_next_fire_pos = ffp_bank - MAX_SHIP_PRIMARY_BANKS + ss->weapons.num_primary_banks;
 			}
 
-			// make sure to reset this for current weapon
-			ok_to_fire = false;
+			// Ok, the turret is lined up... now line up a particular gun.
+			bool ok_to_fire = false;
 
 			// We're ready to fire... now get down to specifics, like where is the
 			// actual gun point and normal, not just the one for whole turret.

--- a/code/ai/aiturret.cpp
+++ b/code/ai/aiturret.cpp
@@ -2391,11 +2391,7 @@ void ai_fire_from_turret(ship *shipp, ship_subsys *ss, int parent_objnum)
 
 		// Similar check for small weapons
 		if ( wip->wi_flags[Weapon::Info_Flags::Small_only] ) {
-			if ( lep->type != OBJ_SHIP) {
-				tentative_return = true;
-				continue;
-			}
-			if ( Ship_info[Ships[lep->instance].ship_info_index].is_big_or_huge() ) {
+			if ( (lep->type == OBJ_SHIP) && Ship_info[Ships[lep->instance].ship_info_index].is_big_or_huge() ) {
 				tentative_return = true;
 				continue;
 			}

--- a/code/ai/aiturret.cpp
+++ b/code/ai/aiturret.cpp
@@ -793,29 +793,6 @@ void evaluate_obj_as_target(object *objp, eval_enemy_obj_struct *eeo)
 }
 
 /**
- * Is target beam valid?
- *
- * @return 0 only if objnum is beam protected and turret is beam turret
- */
-int is_target_beam_valid(ship_weapon *swp, object *objp)
-{
-	// check if turret has beam weapon
-	if (all_turret_weapons_have_flags(swp, Weapon::Info_Flags::Beam)) {
-		if (objp->flags[Object::Object_Flags::Beam_protected]) {
-			return 0;
-		}
-
-		if (all_turret_weapons_have_flags(swp, Weapon::Info_Flags::Huge)) {
-			if (objp->type == OBJ_SHIP && !(Ship_info[Ships[objp->instance].ship_info_index].is_big_or_huge()) ) {
-				return 0;
-			}
-		}
-	}
-
-	return 1;
-}
-
-/**
  * Given an object and an enemy team, return the index of the nearest enemy object.
  *
  * @param turret_parent_objnum	Parent objnum for the turret
@@ -1090,8 +1067,7 @@ int get_nearest_turret_objnum(int turret_parent_objnum, ship_subsys *turret_subs
 						evaluate_obj_as_target(objp, &eeo);
 					}
 
-					Assert(eeo.nearest_attacker_objnum < 0 || is_target_beam_valid(swp, &Objects[eeo.nearest_attacker_objnum]));
-						// next highest priority is attacking ship
+					// next highest priority is attacking ship
 					if ( eeo.nearest_attacker_objnum != -1 ) {			// next highest priority is an attacking ship
 						return eeo.nearest_attacker_objnum;
 					}
@@ -2496,9 +2472,8 @@ void ai_fire_from_turret(ship *shipp, ship_subsys *ss, int parent_objnum)
 	if ( turret_should_pick_new_target(ss) && !ss->scripting_target_override ) {
 		Num_find_turret_enemy++;
 		int objnum = find_turret_enemy(ss, parent_objnum, &gpos, &gvec, ss->turret_enemy_objnum);
-		//Assert(objnum < 0 || is_target_beam_valid(tp, objnum));
 
-		if (objnum >= 0 && is_target_beam_valid(&ss->weapons, &Objects[objnum])) {
+		if (objnum >= 0) {
 			if (ss->turret_enemy_objnum == -1) {
 				ss->turret_enemy_objnum = objnum;
 				ss->targeted_subsys = NULL;		// Turret has retargeted; reset subsystem - Valathil for Mantis #2652

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -2333,7 +2333,6 @@ int parse_create_object_sub(p_object *p_objp)
 		if (sssp->ai_class != SUBSYS_STATUS_NO_CHANGE)
 			ptr->weapons.ai_class = sssp->ai_class;
 
-		ptr->turret_best_weapon = -1;
 		ptr->turret_animation_position = MA_POS_NOT_SET;	// model animation position is not set
 		ptr->turret_animation_done_time = 0;
 	}

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -6772,7 +6772,6 @@ void ship_subsys::clear()
 	subsys_guardian_threshold = 0;
 	armor_type_idx = -1;
 
-	turret_best_weapon = -1;
 	turret_last_fire_direction = vmd_zero_vector;
 	turret_next_enemy_check_stamp = timestamp(0);
 	turret_next_fire_stamp = timestamp(0);

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -340,7 +340,6 @@ public:
 	//or higher, an index into the turret weapons is considered to be an index into the secondary weapons
 	//for much of the code. See turret_next_weap_fire_stamp.
 
-	int		turret_best_weapon;				// best weapon for current target; index into prim/secondary banks
 	vec3d	turret_last_fire_direction;		//	direction pointing last time this turret fired
 	int		turret_next_enemy_check_stamp;	//	time at which to next look for a new enemy.
 	int		turret_next_fire_stamp;				// next time this turret can fire


### PR DESCRIPTION
I did a careful review of all the functions in aiturret.cpp.  This cleans up the code a bit to more closely follow the original code flow from the public code release (for ease of comparison) and fixes several bugs.

1) fixed other weapons on a turret being handicapped by spawning weapon fire rate

2) fixed beam-free flag on a turret with multiple weapons

3) fixed turret accuracy penalty never being applied

4) fixed weapon timestamp being overridden

5) fixed player sound not being played, if specified, with swarm turret weapons

6) fixed flak not jittering if it had the fire-down-normals flag

This finally resolves Mantis 804.
http://scp.indiegames.us/mantis/view.php?id=804