### PR TITLE
Add flag for AI to only fire Turrets / Secondaries when having clear Line of Sight

### DIFF
--- a/code/ai/ai_flags.h
+++ b/code/ai/ai_flags.h
@@ -132,6 +132,7 @@ namespace AI {
 		Use_axial_turnrate_differences,
 		nonshielded_ships_can_manage_ets,
 		Better_collision_avoidance,
+		Require_exact_los,
 
 		NUM_VALUES
 	};

--- a/code/ai/ai_profiles.cpp
+++ b/code/ai/ai_profiles.cpp
@@ -446,6 +446,8 @@ void parse_ai_profiles_tbl(const char *filename)
 
 				set_flag(profile, "$support don't add primaries:", AI::Profile_Flags::Support_dont_add_primaries);
 
+				set_flag(profile, "$firing requires exact los:", AI::Profile_Flags::Require_exact_los);
+
 				profile->ai_path_mode = AI_PATH_MODE_NORMAL;
 				if (optional_string("$ai path mode:"))
 				{

--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -6171,31 +6171,33 @@ int check_ok_to_fire(int objnum, int target_objnum, weapon_info *wip)
 //	--------------------------------------------------------------------------
 //  Returns true if *aip has a line of sight to its current target.
 //	This is a computationally expensive operation, so use sparingly
-int check_los(int objnum, int target_objnum) {
+bool check_los(int objnum, int target_objnum) {
 	vec3d& end = Objects[target_objnum].pos;
 	vec3d& start = Objects[objnum].pos;
 
-	for (int i = 0; i < Highest_object_index; i++) {
+	object* objp;
+
+	for (objp = GET_FIRST(&obj_used_list); objp != END_OF_LIST(&obj_used_list); objp = GET_NEXT(objp)) {
 		//Don't collision check against ourselves or our target
-		if (i == objnum || i == target_objnum)
+		if (OBJ_INDEX(objp) == objnum || OBJ_INDEX(objp) == target_objnum)
 			continue;
 
 		int model_num = 0;
 		int model_instance_num = 0;
 
 		//Only collision check against other pieces of Debris, Asteroids or Ships
-		char type = Objects[i].type;
+		char type = objp->type;
 		if (type == OBJ_DEBRIS) {
-			model_num = Debris[Objects[i].instance].model_num;
+			model_num = Debris[objp->instance].model_num;
 			model_instance_num = -1;
 		}
 		else if (type == OBJ_ASTEROID) {
-			model_num = Asteroid_info[Asteroids[Objects[i].instance].asteroid_type].model_num[Asteroids[Objects[i].instance].asteroid_subtype];
-			model_instance_num = Asteroids[Objects[i].instance].model_instance_num;
+			model_num = Asteroid_info[Asteroids[objp->instance].asteroid_type].model_num[Asteroids[objp->instance].asteroid_subtype];
+			model_instance_num = Asteroids[objp->instance].model_instance_num;
 		}
 		else if (type == OBJ_SHIP) {
-			model_num = Ship_info[Ships[Objects[i].instance].ship_info_index].model_num;
-			model_instance_num = Ships[Objects[i].instance].model_instance_num;
+			model_num = Ship_info[Ships[objp->instance].ship_info_index].model_num;
+			model_instance_num = Ships[objp->instance].model_instance_num;
 		}
 		else
 			continue;
@@ -6205,18 +6207,18 @@ int check_los(int objnum, int target_objnum) {
 
 		hull_check.model_instance_num = model_instance_num;
 		hull_check.model_num = model_num;
-		hull_check.orient = &Objects[i].orient;
-		hull_check.pos = &Objects[i].pos;
+		hull_check.orient = &objp->orient;
+		hull_check.pos = &objp->pos;
 		hull_check.p0 = &start;
 		hull_check.p1 = &end;
 		hull_check.flags = MC_CHECK_MODEL;
 
 		if (model_collide(&hull_check)) {
-			return 0;
+			return false;
 		}
 	}
 
-	return 1;
+	return true;
 }
 
 //	--------------------------------------------------------------------------

--- a/code/ai/aiinternal.h
+++ b/code/ai/aiinternal.h
@@ -28,6 +28,9 @@ int num_nearby_fighters(int enemy_team_mask, vec3d *pos, float threshold);
 //Returns true if OK for *aip to fire its current weapon at its current target.
 int check_ok_to_fire(int objnum, int target_objnum, weapon_info *wip);
 
+//Returns true if *aip has a line of sight to its current target.
+int check_los(int objnum, int target_objnum);
+
 //Does all the stuff needed to aim and fire a turret.
 void ai_fire_from_turret(ship *shipp, ship_subsys *ss, int parent_objnum);
 

--- a/code/ai/aiinternal.h
+++ b/code/ai/aiinternal.h
@@ -29,7 +29,7 @@ int num_nearby_fighters(int enemy_team_mask, vec3d *pos, float threshold);
 int check_ok_to_fire(int objnum, int target_objnum, weapon_info *wip);
 
 //Returns true if *aip has a line of sight to its current target.
-int check_los(int objnum, int target_objnum);
+bool check_los(int objnum, int target_objnum);
 
 //Does all the stuff needed to aim and fire a turret.
 void ai_fire_from_turret(ship *shipp, ship_subsys *ss, int parent_objnum);

--- a/code/ai/aiinternal.h
+++ b/code/ai/aiinternal.h
@@ -29,7 +29,7 @@ int num_nearby_fighters(int enemy_team_mask, vec3d *pos, float threshold);
 int check_ok_to_fire(int objnum, int target_objnum, weapon_info *wip);
 
 //Returns true if *aip has a line of sight to its current target.
-bool check_los(int objnum, int target_objnum);
+bool check_los(int objnum, int target_objnum, float threshold);
 
 //Does all the stuff needed to aim and fire a turret.
 void ai_fire_from_turret(ship *shipp, ship_subsys *ss, int parent_objnum);

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -524,6 +524,7 @@ flag_def_list_new<Weapon::Info_Flags> ai_tgt_weapon_flags[] = {
     { "don't spawn if shot",		Weapon::Info_Flags::Dont_spawn_if_shot,				    true, false },
     { "die on lost lock",			Weapon::Info_Flags::Die_on_lost_lock,					true, false },
 	{ "no impact spew",				Weapon::Info_Flags::No_impact_spew,						true, false },
+	{ "require exact los",			Weapon::Info_Flags::Require_exact_los,					true, false },
 };
 
 const int num_ai_tgt_weapon_info_flags = sizeof(ai_tgt_weapon_flags) / sizeof(flag_def_list_new<Weapon::Info_Flags>);

--- a/code/weapon/weapon_flags.h
+++ b/code/weapon/weapon_flags.h
@@ -84,6 +84,7 @@ namespace Weapon {
         Die_on_lost_lock,                   // WIF_LOCKED_HOMING missiles will die if they lose their lock
 		Has_display_name,					// Goober5000
 		No_impact_spew,						// Goober5000
+		Require_exact_los,					// If secondary or in turret, will only fire if ship has line of sight to target
 
         NUM_VALUES
 	};

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -173,6 +173,7 @@ flag_def_list_new<Weapon::Info_Flags> Weapon_Info_Flags[] = {
     { "don't spawn if shot",            Weapon::Info_Flags::Dont_spawn_if_shot,                 true, false },
     { "die on lost lock",               Weapon::Info_Flags::Die_on_lost_lock,                   true, true  }, //special case
 	{ "no impact spew",					Weapon::Info_Flags::No_impact_spew,						true, false },
+	{ "require exact los",				Weapon::Info_Flags::Require_exact_los,					true, false },
 };
 
 const size_t num_weapon_info_flags = sizeof(Weapon_Info_Flags) / sizeof(flag_def_list_new<Weapon::Info_Flags>);


### PR DESCRIPTION
This added the Weapon Flag "require exact los", which will prevent AI form firing it from a turret or as a secondary weapon if there is no clear line of sight from the AI's ship (center) to it's targeted ship (center)
In addition, this added the AI Profile Flag "$firing requires exact los:", which has the same effect, but applied to all turrets and AI controlled secondaries regardless of weapon or weapon flags