### PR TITLE
Make sure lock indicators are done even if hud is disabled

### DIFF
--- a/code/hud/hud.cpp
+++ b/code/hud/hud.cpp
@@ -1613,6 +1613,8 @@ void hud_render_preprocess(float frametime)
 	}
 
 	if ( hud_disabled() ) {
+		// if the hud is disabled, we still need to make sure that the indicators are properly handled
+		hud_do_lock_indicators(flFrametime);
 		return;
 	}
 


### PR DESCRIPTION
Someone apparently already did the work of separating the render code from the lock tracking code, now we just make sure that this function always runs even if the hud is disabled. (it just makes sense for it to)  

I tried this out and it works as expected with hud disabled: turning away from your target breaks lock, turning towards your target allows you to acquire lock, and lock is maintained if it was already present and you are facing the target.

For issue #1821 

EDIT: Btw, the locking sounds still run with the HUD disabled, should I add logic that disables it if the hud is disabled?