### PR TITLE
Model preliminary edits

### DIFF
--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -9356,7 +9356,7 @@ float dock_orient_and_approach(object *docker_objp, int docker_index, object *do
 		// get angular velocity of dockpoint
 		//WMC - hack(?) to fix bug where sii might not exist
 		if ( pmi1->submodel[dockee_rotating_submodel].sii != NULL ) {
-			submodel_omega = pmi1->submodel[dockee_rotating_submodel].sii->cur_turn_rate;
+			submodel_omega = pmi1->submodel[dockee_rotating_submodel].sii->current_turn_rate;
 		}
 
 		// get radius to dockpoint

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -2320,7 +2320,7 @@ int parse_create_object_sub(p_object *p_objp)
 			if ((100.0f - sssp->percent) < 0.5)
 			{
 				ptr->current_hits = 0.0f;
-				ptr->submodel_info_1.blown_off = 1;
+				ptr->submodel_info_1.blown_off = true;
 			}
 			else
 			{

--- a/code/missionui/redalert.cpp
+++ b/code/missionui/redalert.cpp
@@ -624,7 +624,7 @@ void red_alert_bash_subsys_status(red_alert_ship_status *ras, ship *shipp)
 		}
 
 		if (ss->current_hits <= 0) {
-			ss->submodel_info_1.blown_off = 1;
+			ss->submodel_info_1.blown_off = true;
 		}
 
 		ss = GET_NEXT( ss );

--- a/code/model/model.h
+++ b/code/model/model.h
@@ -972,11 +972,9 @@ extern void model_clear_instance(int model_num);
 void model_clear_submodel_instance( submodel_instance *sm_instance, bsp_info *sm );
 void model_clear_submodel_instances( int model_instance_num );
 
-// Sets rotating submodel turn info to that stored in model
-void model_set_instance_info(submodel_instance_info *sii, float turn_rate, float turn_accel);
-
 // Clears all the values in a particular instance to their defaults.
-extern void model_clear_instance_info(submodel_instance_info * sii);
+// Sets rotating submodel turn info to that stored in model
+extern void model_clear_instance_info(submodel_instance_info *sii, float turn_rate = 0.0f, float turn_accel = 0.0f);
 
 // Sets the submodel instance data in a submodel
 extern void model_set_instance(int model_num, int sub_model_num, submodel_instance_info *sii, flagset<Ship::Subsystem_Flags>* flags = NULL);

--- a/code/model/model.h
+++ b/code/model/model.h
@@ -80,7 +80,7 @@ typedef struct submodel_instance_info {
 	angles	angs;										// The current angle this thing is turned to.
 	angles	prev_angs;
 	vec3d	pt_on_axis;								// in ship RF
-	float		cur_turn_rate;
+	float		current_turn_rate;
 	float		desired_turn_rate;
 	float		turn_accel;
 	int		axis_set;

--- a/code/model/model.h
+++ b/code/model/model.h
@@ -76,22 +76,26 @@ extern const char *Subsystem_types[SUBSYSTEM_MAX];
 // Data specific to a particular instance of a submodel.  This gets stuffed/unstuffed using
 // the model_clear_instance, model_set_instance, model_get_instance functions.
 typedef struct submodel_instance_info {
-	int		blown_off;								// If set, this subobject is blown off
 	angles	angs;									// The current angle this thing is turned to.
 	angles	prev_angs;
-	vec3d	point_on_axis;							// in ship RF
-	float		current_turn_rate;
-	float		desired_turn_rate;
-	float		turn_accel;
-	int		axis_set;
+
+	float	current_turn_rate;
+	float	desired_turn_rate;
+	float	turn_accel;
 	int		step_zero_timestamp;		// timestamp determines when next step is to begin (for stepped rotation)
+
+	vec3d	point_on_axis;							// in ship RF
+	bool	axis_set;
+	bool	blown_off;								// If set, this subobject is blown off
 } submodel_instance_info;
 
 typedef struct submodel_instance {
 	angles angs;
 	angles prev_angs;
+
 	vec3d mc_base;
 	matrix mc_orient;
+
 	bool collision_checked;
 	bool blown_off;
 	submodel_instance_info *sii;
@@ -259,10 +263,10 @@ class bsp_info
 {
 public:
 	bsp_info()
-		: movement_type(-1), movement_axis(0), can_move(false), bsp_data_size(0), bsp_data(NULL), collision_tree_index(-1),
-		rad(0.0f), blown_off(0), my_replacement(-1), i_replace(-1), is_live_debris(0), num_live_debris(0),
-		is_thruster(0), is_damaged(0), parent(-1), num_children(0), first_child(-1), next_sibling(-1), num_details(0),
-		num_arcs(0), outline_buffer(NULL), n_verts_outline(0), render_sphere_radius(0.0f), use_render_box(0), use_render_box_offset(false),
+		: movement_type(-1), movement_axis(0), can_move(false), bsp_data_size(0), bsp_data(nullptr), collision_tree_index(-1),
+		rad(0.0f), blown_off(false), my_replacement(-1), i_replace(-1), is_live_debris(false), num_live_debris(0),
+		is_thruster(false), is_damaged(false), parent(-1), num_children(0), first_child(-1), next_sibling(-1), num_details(0),
+		num_arcs(0), outline_buffer(nullptr), n_verts_outline(0), render_sphere_radius(0.0f), use_render_box(0), use_render_box_offset(false),
 		use_render_sphere(0), use_render_sphere_offset(false), gun_rotation(false), no_collisions(false),
 		nocollide_this_only(false), collide_invisible(false), force_turret_normal(false), attach_thrusters(false), dumb_turn_rate(0.0f),
 		look_at_num(-1)
@@ -303,17 +307,17 @@ public:
 	vec3d	max;						// The max point of this object's geometry
 	vec3d	bounding_box[8];		// calculated fron min/max
 
-	int		blown_off;				// If set, this subobject is blown off. Stuffed by model_set_instance
+	bool	blown_off;				// If set, this subobject is blown off. Stuffed by model_set_instance
 	int		my_replacement;		// If not -1 this subobject is what should get rendered instead of this one
 	int		i_replace;				// If this is not -1, then this subobject will replace i_replace when it is damaged
 	angles	angs;					// The rotation angles of this subobject (Within its own orientation, NOT relative to parent - KeldorKatarn)
 
-	int		is_live_debris;		// whether current submodel is a live debris model
+	bool	is_live_debris;		// whether current submodel is a live debris model
 	int		num_live_debris;		// num live debris models assocaiated with a submodel
 	int		live_debris[MAX_LIVE_DEBRIS];	// array of live debris submodels for a submodel
 
-	int		is_thruster;
-	int		is_damaged;
+	bool	is_thruster;
+	bool	is_damaged;
 
 	// Tree info
 	int		parent;					// what is parent for each submodel, -1 if none

--- a/code/model/model.h
+++ b/code/model/model.h
@@ -77,9 +77,9 @@ extern const char *Subsystem_types[SUBSYSTEM_MAX];
 // the model_clear_instance, model_set_instance, model_get_instance functions.
 typedef struct submodel_instance_info {
 	int		blown_off;								// If set, this subobject is blown off
-	angles	angs;										// The current angle this thing is turned to.
+	angles	angs;									// The current angle this thing is turned to.
 	angles	prev_angs;
-	vec3d	pt_on_axis;								// in ship RF
+	vec3d	point_on_axis;							// in ship RF
 	float		current_turn_rate;
 	float		desired_turn_rate;
 	float		turn_accel;

--- a/code/model/modelanim.cpp
+++ b/code/model/modelanim.cpp
@@ -512,7 +512,7 @@ void model_anim_submodel_trigger_rotate(model_subsystem *psub, ship_subsys *ss)
 
 	// objects can be animated along several axes at the same time
 	// I'm prety sure using the magnitude of the vectors is at least pretty close for any code that might be using it
-	sii->cur_turn_rate = vm_vec_mag(&trigger->current_vel);
+	sii->current_turn_rate = vm_vec_mag(&trigger->current_vel);
 	sii->desired_turn_rate = vm_vec_mag(&trigger->rot_vel);
 	sii->turn_accel = vm_vec_mag(&trigger->rot_accel);
 

--- a/code/model/modelcollide.cpp
+++ b/code/model/modelcollide.cpp
@@ -1181,7 +1181,7 @@ NoHit:
 			collision_checked = Mc_pmi->submodel[i].collision_checked;
 		} else {
 			angs = csm->angs;
-			blown_off = csm->blown_off ? true : false;
+			blown_off = csm->blown_off;
 			collision_checked = false;
 		}
 

--- a/code/model/modelread.cpp
+++ b/code/model/modelread.cpp
@@ -1710,7 +1710,7 @@ int read_model_file(polymodel * pm, const char *filename, int n_subsystems, mode
 					pm->submodel[n].bsp_data = NULL;
 				}
 
-				pm->submodel[n].is_thruster = strstr(pm->submodel[n].name, "thruster");
+				pm->submodel[n].is_thruster = (strstr(pm->submodel[n].name, "thruster") != nullptr);
 
 				// Genghis: if we have a thruster and none of the collision 
 				// properties were provided, then set "nocollide_this_only".
@@ -1719,7 +1719,7 @@ int read_model_file(polymodel * pm, const char *filename, int n_subsystems, mode
 					pm->submodel[n].nocollide_this_only = true;
 				}
 
-				pm->submodel[n].is_damaged = strstr(pm->submodel[n].name, "-destroyed");
+				pm->submodel[n].is_damaged = (strstr(pm->submodel[n].name, "-destroyed") != nullptr);
 
 				//mprintf(( "Submodel %d, name '%s', parent = %d\n", n, pm->submodel[n].name, pm->submodel[n].parent ));
 				//key_getch();

--- a/code/model/modelread.cpp
+++ b/code/model/modelread.cpp
@@ -3722,7 +3722,7 @@ void submodel_rotate(bsp_info *sm, submodel_instance_info *sii)
 	sii->current_turn_rate = final_turn_rate;
 
 	// Apply rotation in the axis of movement
-	// then normalize the angle angle so that we are within a valid range:
+	// then normalize the angle so that we are within a valid range:
 	//  greater than or equal to 0
 	//  less than PI2
 	switch( sm->movement_axis )	{
@@ -4643,7 +4643,7 @@ void model_clear_submodel_instance( submodel_instance *sm_instance, bsp_info *sm
 	sm_instance->blown_off = sm->is_damaged ? true : false;
 
 	sm_instance->collision_checked = false;
-	sm_instance->sii = NULL;
+	sm_instance->sii = nullptr;
 }
 
 void model_clear_submodel_instances( int model_instance_num )
@@ -4954,7 +4954,7 @@ void model_init_submodel_axis_pt(submodel_instance_info *sii, int model_num, int
 	vm_vec_scale_add(&int1, &p1, &v1, s);
 
 	// set flag to init
-	sii->pt_on_axis = int1;
+	sii->point_on_axis = int1;
 	sii->axis_set = 1;
 }
 

--- a/code/model/modelread.cpp
+++ b/code/model/modelread.cpp
@@ -139,7 +139,7 @@ public:
 		: submodel_num(_submodel_num)
 	{
 		memset(&submodel_info_1, 0, sizeof(submodel_info_1));
-		submodel_info_1.cur_turn_rate = _turn_rate;
+		submodel_info_1.current_turn_rate = _turn_rate;
 		submodel_info_1.desired_turn_rate = _turn_rate;
 	}
 };
@@ -3551,21 +3551,21 @@ void submodel_stepped_rotate(model_subsystem *psub, submodel_instance_info *sii)
 		// do accel
 		float accel_time = step_offset_time;
 		*ang_next += 0.5f * psub->stepped_rotation->max_turn_accel * accel_time * accel_time;
-		sii->cur_turn_rate = psub->stepped_rotation->max_turn_accel * accel_time;
+		sii->current_turn_rate = psub->stepped_rotation->max_turn_accel * accel_time;
 	} else if (step_offset_time < decel_start_time) {
 		// do coast
 		float coast_time = step_offset_time - coast_start_time;
 		*ang_next += start_coast_angle + psub->stepped_rotation->max_turn_rate * coast_time;
-		sii->cur_turn_rate = psub->stepped_rotation->max_turn_rate;
+		sii->current_turn_rate = psub->stepped_rotation->max_turn_rate;
 	} else if (step_offset_time < pause_start_time) {
 		// do decel
 		float time_to_pause = psub->stepped_rotation->t_transit - step_offset_time;
 		*ang_next += (step_size - 0.5f * psub->stepped_rotation->max_turn_accel * time_to_pause * time_to_pause);
-		sii->cur_turn_rate = psub->stepped_rotation->max_turn_rate * time_to_pause;
+		sii->current_turn_rate = psub->stepped_rotation->max_turn_rate * time_to_pause;
 	} else {
 		// do pause
 		*ang_next += step_size;
-		sii->cur_turn_rate = 0.0f;
+		sii->current_turn_rate = 0.0f;
 	}
 }
 
@@ -3701,16 +3701,16 @@ void submodel_rotate(bsp_info *sm, submodel_instance_info *sii)
 	sii->prev_angs = sii->angs;
 
 	// probably send in a calculated desired turn rate
-	float diff = sii->desired_turn_rate - sii->cur_turn_rate;
+	float diff = sii->desired_turn_rate - sii->current_turn_rate;
 
 	float final_turn_rate;
 	if (diff > 0) {
-		final_turn_rate = sii->cur_turn_rate + sii->turn_accel * flFrametime;
+		final_turn_rate = sii->current_turn_rate + sii->turn_accel * flFrametime;
 		if (final_turn_rate > sii->desired_turn_rate) {
 			final_turn_rate = sii->desired_turn_rate;
 		}
 	} else if (diff < 0) {
-		final_turn_rate = sii->cur_turn_rate - sii->turn_accel * flFrametime;
+		final_turn_rate = sii->current_turn_rate - sii->turn_accel * flFrametime;
 		if (final_turn_rate < sii->desired_turn_rate) {
 			final_turn_rate = sii->desired_turn_rate;
 		}
@@ -3718,8 +3718,8 @@ void submodel_rotate(bsp_info *sm, submodel_instance_info *sii)
 		final_turn_rate = sii->desired_turn_rate;
 	}
 
-	float delta = (sii->cur_turn_rate + final_turn_rate) * 0.5f * flFrametime;
-	sii->cur_turn_rate = final_turn_rate;
+	float delta = (sii->current_turn_rate + final_turn_rate) * 0.5f * flFrametime;
+	sii->current_turn_rate = final_turn_rate;
 
 	// Apply rotation in the axis of movement
 	// then normalize the angle angle so that we are within a valid range:
@@ -3773,16 +3773,16 @@ void submodel_ai_rotate(model_subsystem *psub, submodel_instance_info *sii)
 	sii->prev_angs = sii->angs;
 
 	// probably send in a calculated desired turn rate
-	float diff = sii->desired_turn_rate - sii->cur_turn_rate;
+	float diff = sii->desired_turn_rate - sii->current_turn_rate;
 
 	float final_turn_rate;
 	if (diff > 0) {
-		final_turn_rate = sii->cur_turn_rate + sii->turn_accel * flFrametime;
+		final_turn_rate = sii->current_turn_rate + sii->turn_accel * flFrametime;
 		if (final_turn_rate > sii->desired_turn_rate) {
 			final_turn_rate = sii->desired_turn_rate;
 		}
 	} else if (diff < 0) {
-		final_turn_rate = sii->cur_turn_rate - sii->turn_accel * flFrametime;
+		final_turn_rate = sii->current_turn_rate - sii->turn_accel * flFrametime;
 		if (final_turn_rate < sii->desired_turn_rate) {
 			final_turn_rate = sii->desired_turn_rate;
 		}
@@ -3790,8 +3790,8 @@ void submodel_ai_rotate(model_subsystem *psub, submodel_instance_info *sii)
 		final_turn_rate = sii->desired_turn_rate;
 	}
 
-	float delta = (sii->cur_turn_rate + final_turn_rate) * 0.5f * flFrametime;
-	sii->cur_turn_rate = final_turn_rate;
+	float delta = (sii->current_turn_rate + final_turn_rate) * 0.5f * flFrametime;
+	sii->current_turn_rate = final_turn_rate;
 
 	
 	//float delta = psub->turn_rate * flFrametime;
@@ -4629,7 +4629,7 @@ void model_clear_instance_info( submodel_instance_info * sii )
 	sii->prev_angs.b = 0.0f;
 	sii->prev_angs.h = 0.0f;
 
-	sii->cur_turn_rate = 0.0f;
+	sii->current_turn_rate = 0.0f;
 	sii->desired_turn_rate = 0.0f;
 	sii->turn_accel = 0.0f;
 }
@@ -4668,7 +4668,7 @@ void model_set_instance_info(submodel_instance_info *sii, float turn_rate, float
 	sii->prev_angs.b = 0.0f;
 	sii->prev_angs.h = 0.0f;
 
-	sii->cur_turn_rate = turn_rate * 0.0f;
+	sii->current_turn_rate = turn_rate * 0.0f;
 	sii->desired_turn_rate = turn_rate;
 	sii->turn_accel = turn_accel;
 	sii->axis_set = 0;

--- a/code/model/modelread.cpp
+++ b/code/model/modelread.cpp
@@ -4609,9 +4609,10 @@ void model_clear_instance(int model_num)
 }
 
 // initialization during ship set
-void model_clear_instance_info( submodel_instance_info * sii )
+void model_clear_instance_info(submodel_instance_info *sii, float turn_rate, float turn_accel)
 {
 	sii->blown_off = false;
+
 	sii->angs.p = 0.0f;
 	sii->angs.b = 0.0f;
 	sii->angs.h = 0.0f;
@@ -4620,8 +4621,11 @@ void model_clear_instance_info( submodel_instance_info * sii )
 	sii->prev_angs.h = 0.0f;
 
 	sii->current_turn_rate = 0.0f;
-	sii->desired_turn_rate = 0.0f;
-	sii->turn_accel = 0.0f;
+	sii->desired_turn_rate = turn_rate;
+	sii->turn_accel = turn_accel;
+
+	sii->axis_set = false;
+	sii->step_zero_timestamp = timestamp();
 }
 
 void model_clear_submodel_instance( submodel_instance *sm_instance, bsp_info *sm )
@@ -4645,24 +4649,6 @@ void model_clear_submodel_instances( int model_instance_num )
 	for ( i = 0; i < pm->n_models; i++ ) {
 		model_clear_submodel_instance(&pmi->submodel[i], &pm->submodel[i]);
 	}
-}
-
-// initialization during ship set
-void model_set_instance_info(submodel_instance_info *sii, float turn_rate, float turn_accel)
-{
-	sii->blown_off = false;
-	sii->angs.p = 0.0f;
-	sii->angs.b = 0.0f;
-	sii->angs.h = 0.0f;
-	sii->prev_angs.p = 0.0f;
-	sii->prev_angs.b = 0.0f;
-	sii->prev_angs.h = 0.0f;
-
-	sii->current_turn_rate = turn_rate * 0.0f;
-	sii->desired_turn_rate = turn_rate;
-	sii->turn_accel = turn_accel;
-	sii->axis_set = false;
-	sii->step_zero_timestamp = timestamp();
 }
 
 // Sets the submodel instance data in a submodel (for all detail levels)

--- a/code/object/collideshipship.cpp
+++ b/code/object/collideshipship.cpp
@@ -595,7 +595,7 @@ void calculate_ship_ship_collision_physics(collision_info_struct *ship_ship_hit_
 
 			// world coords for r_rot
 			vec3d temp;
-			vm_vec_unrotate(&temp, &pmi->submodel[ship_ship_hit_info->submodel_num].sii->pt_on_axis, &heavy->orient);
+			vm_vec_unrotate(&temp, &pmi->submodel[ship_ship_hit_info->submodel_num].sii->point_on_axis, &heavy->orient);
 			vm_vec_sub(&r_rot, &ship_ship_hit_info->hit_pos, &temp);
 
 			vm_vec_cross(&local_vel_from_submodel, &omega, &r_rot);

--- a/code/object/collideshipship.cpp
+++ b/code/object/collideshipship.cpp
@@ -591,7 +591,7 @@ void calculate_ship_ship_collision_physics(collision_info_struct *ship_ship_hit_
 			// get world rotational velocity of rotating submodel
 			model_instance_find_obj_dir(&omega, &axis, model_instance_num, ship_ship_hit_info->submodel_num, &heavy->orient);
 
-			vm_vec_scale(&omega, pmi->submodel[ship_ship_hit_info->submodel_num].sii->cur_turn_rate);
+			vm_vec_scale(&omega, pmi->submodel[ship_ship_hit_info->submodel_num].sii->current_turn_rate);
 
 			// world coords for r_rot
 			vec3d temp;

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -18952,7 +18952,7 @@ void sexp_reverse_rotating_subsystem(int node)
 
 		// switch direction of rotation
 		rotate->turn_rate *= -1.0f;
-		rotate->submodel_info_1.cur_turn_rate *= -1.0f;
+		rotate->submodel_info_1.current_turn_rate *= -1.0f;
 		rotate->submodel_info_1.desired_turn_rate *= -1.0f;
 	}
 }
@@ -18992,7 +18992,7 @@ void sexp_rotating_subsys_set_turn_time(int node)
 		rotate->submodel_info_1.turn_accel = PI2 / turn_accel;
 	}
 	else
-		rotate->submodel_info_1.cur_turn_rate = PI2 / turn_time;
+		rotate->submodel_info_1.current_turn_rate = PI2 / turn_time;
 }
 
 void sexp_trigger_submodel_animation(int node)

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -12731,8 +12731,8 @@ void set_subsys_strength_and_maybe_ancestors(ship *shipp, ship_subsys *ss, polym
 	// and now see if we are repairing from zero
 	if (originally_zero && ss->current_hits > 0 && do_submodel_repair)
 	{
-		ss->submodel_info_1.blown_off = 0;
-		ss->submodel_info_2.blown_off = 0;
+		ss->submodel_info_1.blown_off = false;
+		ss->submodel_info_2.blown_off = false;
 
 		// see if we are handling ancestors and if this subsystem has a submodel
 		int subobj = ss->system_info->subobj_num;

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -7120,7 +7120,7 @@ static int subsys_set(int objnum, int ignore_subsys_info)
 	// Fix up animation code references
 	for (i = 0; i < sinfo->n_subsystems; i++) {
 		for (j = 0; j < sinfo->subsystems[i].n_triggers; j++) {
-			if (subsystem_stricmp(sinfo->subsystems[i].triggers[j].sub_name, "<none>")) {
+			if (stricmp(sinfo->subsystems[i].triggers[j].sub_name, "<none>")) {
 				int idx = ship_get_subobj_model_num(sinfo, sinfo->subsystems[i].triggers[j].sub_name);
 				if (idx != -1) {
 					sinfo->subsystems[i].triggers[j].subtype = idx;

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -7119,7 +7119,7 @@ static int subsys_set(int objnum, int ignore_subsys_info)
 	// Fix up animation code references
 	for (i = 0; i < sinfo->n_subsystems; i++) {
 		for (j = 0; j < sinfo->subsystems[i].n_triggers; j++) {
-			if (stricmp(sinfo->subsystems[i].triggers[j].sub_name, "<none>")) {
+			if (stricmp(sinfo->subsystems[i].triggers[j].sub_name, "<none>") != 0) {
 				int idx = ship_get_subobj_model_num(sinfo, sinfo->subsystems[i].triggers[j].sub_name);
 				if (idx != -1) {
 					sinfo->subsystems[i].triggers[j].subtype = idx;

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -7098,9 +7098,8 @@ static int subsys_set(int objnum, int ignore_subsys_info)
 
 		// turn_rate, turn_accel
 		float turn_accel = 0.5f;
-		model_set_instance_info(&ship_system->submodel_info_1, model_system->turn_rate, turn_accel);
-
-		model_clear_instance_info( &ship_system->submodel_info_2 );
+		model_clear_instance_info(&ship_system->submodel_info_1, model_system->turn_rate, turn_accel);
+		model_clear_instance_info(&ship_system->submodel_info_2);
 
 		// Clear this flag here so we correctly rebuild the turret matrix on mission load
         model_system->flags.remove(Model::Subsystem_Flags::Turret_matrix);

--- a/code/ship/shipfx.cpp
+++ b/code/ship/shipfx.cpp
@@ -118,7 +118,7 @@ static void shipfx_subsystem_maybe_create_live_debris(object *ship_objp, ship *s
 
 		// get the rotvel
 		model_get_rotating_submodel_axis(&model_axis, &world_axis, shipp->model_instance_num, submodel_num, &ship_objp->orient);
-		vm_vec_copy_scale(&rotvel, &world_axis, sii->cur_turn_rate);
+		vm_vec_copy_scale(&rotvel, &world_axis, sii->current_turn_rate);
 
 		model_instance_find_world_point(&world_axis_pt, &sii->pt_on_axis, shipp->model_instance_num, submodel_num, &ship_objp->orient, &ship_objp->pos);
 

--- a/code/ship/shipfx.cpp
+++ b/code/ship/shipfx.cpp
@@ -269,7 +269,7 @@ static void shipfx_maybe_create_live_debris_at_ship_death( object *ship_objp )
 
 						// now set subsystem as blown off, so we only get one copy
 						pmi->submodel[parent].blown_off = true;
-						pss->submodel_info_1.blown_off = 1;
+						pss->submodel_info_1.blown_off = true;
 					}
 				}
 			}

--- a/code/ship/shipfx.cpp
+++ b/code/ship/shipfx.cpp
@@ -120,7 +120,7 @@ static void shipfx_subsystem_maybe_create_live_debris(object *ship_objp, ship *s
 		model_get_rotating_submodel_axis(&model_axis, &world_axis, shipp->model_instance_num, submodel_num, &ship_objp->orient);
 		vm_vec_copy_scale(&rotvel, &world_axis, sii->current_turn_rate);
 
-		model_instance_find_world_point(&world_axis_pt, &sii->pt_on_axis, shipp->model_instance_num, submodel_num, &ship_objp->orient, &ship_objp->pos);
+		model_instance_find_world_point(&world_axis_pt, &sii->point_on_axis, shipp->model_instance_num, submodel_num, &ship_objp->orient, &ship_objp->pos);
 
 		vm_quaternion_rotate(&m_rot, vm_vec_mag((vec3d*)&sii->angs), &model_axis);
 	} else {

--- a/code/ship/shiphit.cpp
+++ b/code/ship/shiphit.cpp
@@ -308,11 +308,11 @@ void do_subobj_destroyed_stuff( ship *ship_p, ship_subsys *subsys, vec3d* hitpos
 	if (!(subsys->flags[Ship::Subsystem_Flags::No_disappear])) {
 		if (psub->subobj_num > -1) {
 			shipfx_blow_off_subsystem(ship_objp, ship_p, subsys, &g_subobj_pos, no_explosion);
-			subsys->submodel_info_1.blown_off = 1;
+			subsys->submodel_info_1.blown_off = true;
 		}
 
 		if ((psub->subobj_num != psub->turret_gun_sobj) && (psub->turret_gun_sobj >= 0)) {
-			subsys->submodel_info_2.blown_off = 1;
+			subsys->submodel_info_2.blown_off = true;
 		}
 	}
 


### PR DESCRIPTION
Several housekeeping changes in preparation for the submodel rotation upgrade.  These are in a separate PR so as to not clutter up the upcoming main PR.  All changes should be no-ops.