### PR TITLE
Build Linux nightlies with GitHub actions

### DIFF
--- a/.github/workflows/build-dist.yaml
+++ b/.github/workflows/build-dist.yaml
@@ -1,0 +1,171 @@
+name: Build distribution package
+
+on:
+  push:
+    tags:
+      - 'nightly_*'
+      - 'release_*'
+
+env:
+  QT_VERSION: 5.12.9
+
+jobs:
+  build_linux:
+    strategy:
+      matrix:
+        configuration: [FastDebug, Release]
+    name: Linux
+    runs-on: ubuntu-16.04
+    steps:
+      - name: Prepare Environment
+        working-directory: /tmp
+        env:
+          DEBIAN_FRONTEND: noninteractive
+        run: |
+          sudo add-apt-repository ppa:ubuntu-toolchain-r/test
+          sudo add-apt-repository ppa:msulikowski/valgrind # For fixing a bug with valgrind 3.11 which does not recognize the rdrand instruction
+          sudo apt-get -yq update
+          sudo apt-get -yq install cmake ninja-build libopenal-dev libreadline6-dev libpng12-dev libjpeg62-dev liblua5.1-0-dev libjansson-dev libsdl2-dev libfreetype6-dev valgrind g++-5 g++-9 clang-4.0 clang-tidy-4.0 libc++-dev libc++abi-dev
+          # Fix a header bug present in ubuntu...
+          sudo ln -s /usr/include/libcxxabi/__cxxabi_config.h /usr/include/c++/v1/__cxxabi_config.h
+
+          wget https://apt.llvm.org/llvm.sh
+          chmod +x llvm.sh
+          sudo ./llvm.sh 9
+          sudo apt-get -yq install libc++-9-dev libc++abi-9-dev
+
+          wget -O appimagetool -c "https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage" # (64-bit)
+          chmod a+x ./appimagetool
+      - name: Cache Qt
+        id: cache-qt-lin
+        uses: actions/cache@v1
+        with:
+          path: ${{ github.workspace }}/../Qt
+          key: ${{ runner.os }}-QtCache-${{ env.QT_VERSION }}
+      - name: Install Qt
+        uses: jurplel/install-qt-action@v2
+        with:
+          version: ${{ env.QT_VERSION }}
+          dir: ${{ github.workspace }}/..
+          cached: ${{ steps.cache-qt-lin.outputs.cache-hit }}
+
+      - uses: actions/checkout@v1
+        name: Checkout
+        with:
+          submodules: true
+      - name: Configure CMake
+        env:
+          CONFIGURATION: ${{ matrix.configuration }}
+          COMPILER: gcc-5
+        run: |
+          if [ "$COMPILER" = "gcc-5" ]; then
+            export CC=gcc-5
+            export CXX=g++-5
+          fi
+          if [ "$COMPILER" = "gcc-9" ]; then
+            export CC=gcc-9
+            export CXX=g++-9
+          fi
+          if [ "$COMPILER" = "clang-4.0" ]; then
+            export CC=clang-4.0
+            export CXX=clang++-4.0
+          fi
+
+          LD_LIBRARY_PATH=$Qt5_DIR/lib:$LD_LIBRARY_PATH
+          CXXFLAGS="-m64 -mtune=generic -mfpmath=sse -msse -msse2 -pipe -Wno-unknown-pragmas"
+          CFLAGS="-m64 -mtune=generic -mfpmath=sse -msse -msse2 -pipe -Wno-unknown-pragmas"
+
+          if [[ "$CC" =~ ^clang.*$ ]]; then
+              CXXFLAGS="$CXXFLAGS -stdlib=libc++"
+          fi
+
+          mkdir build
+          cd build
+
+          export CXXFLAGS
+          export CFLAGS
+          export LD_LIBRARY_PATH
+          CMAKE="cmake -G Ninja -DFSO_FATAL_WARNINGS=ON $CMAKE_OPTIONS"
+          eval $CMAKE -DFSO_INSTALL_DEBUG_FILES=ON -DCMAKE_BUILD_TYPE=$CONFIGURATION -DCMAKE_INSTALL_PREFIX="$GITHUB_WORKSPACE/build/install" \
+            -DFSO_BUILD_APPIMAGE=ON -DFSO_BUILD_INCLUDED_LIBS=ON -DFFMPEG_USE_PRECOMPILED=ON -DFSO_BUILD_QTFRED=OFF -DFSO_BUILD_TESTS=ON ..
+      - name: Compile
+        working-directory: ./build
+        env:
+          CONFIGURATION: ${{ matrix.configuration }}
+        run: |
+          LD_LIBRARY_PATH=$Qt5_DIR/lib:$LD_LIBRARY_PATH ninja -k 20 all
+      - name: Run Tests
+        working-directory: ./build/bin
+        run: |
+          LD_LIBRARY_PATH=./lib:$LD_LIBRARY_PATH ./unittests --gtest_shuffle
+      - name: Generate AppImage
+        working-directory: ./build
+        env:
+          CONFIGURATION: ${{ matrix.configuration }}
+        run: |
+          # Install Freespace2 targets
+          cmake -DCMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/build/install -DCOMPONENT=Unspecified -P cmake_install.cmake
+          cmake -DCMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/build/install -DCOMPONENT=Freespace2 -P cmake_install.cmake
+
+          # We need to be a bit creative for determining the AppImage name since we don't want to hard-code the name
+          FILENAME="$(find $GITHUB_WORKSPACE/build/install/bin -name 'fs2_open_*' -type f -printf "%f\n").AppImage"
+          /tmp/appimagetool -n $GITHUB_WORKSPACE/build/install "$GITHUB_WORKSPACE/build/install/$FILENAME"
+          ls -al $GITHUB_WORKSPACE/build/install
+      - name: Upload build result
+        uses: actions/upload-artifact@v2
+        with:
+          name: linux-${{ matrix.configuration }}
+          path: ${{ github.workspace }}/build/install/*.AppImage
+  linux_zip:
+    name: Build Linux distribution zip
+    needs: build_linux
+    runs-on: ubuntu-latest
+    container: ghcr.io/scp-fs2open/sftp_upload:latest
+    steps:
+      - uses: actions/checkout@v1
+        name: Checkout
+        with:
+          submodules: true
+          fetch-depth: '0'
+      - name: Download Release builds
+        uses: actions/download-artifact@v1
+        with:
+          name: linux-Release
+          path: builds
+      - name: Download FastDebug builds
+        uses: actions/download-artifact@v2
+        with:
+          name: linux-FastDebug
+          path: builds
+      - name: Create Distribution package
+        working-directory: ./builds
+        shell: bash
+        run: |
+          . $GITHUB_WORKSPACE/ci/github/dist_functions.sh
+          ls -alR
+          tar -cvzf "$(get_package_name)-builds-Linux.tar.gz" *
+          ls -alR
+      - name: Upload result package
+        working-directory: ./builds
+        shell: bash
+        env:
+          SSHPASS: ${{ secrets.INDIEGAMES_PASSWORD }}
+        run: |
+          . $GITHUB_WORKSPACE/ci/github/dist_functions.sh
+
+          echo "cd public_html/builds/nightly/" > sftp_batch
+          echo "mkdir $(get_version_name)" >> sftp_batch
+          # Create directory but do not cause an error if it already exists
+          sshpass -e sftp -oBatchMode=no -o "StrictHostKeyChecking no" -b sftp_batch ${{ secrets.INDIEGAMES_USER }}@scp.indiegames.us || true
+
+          echo "cd public_html/builds/nightly/$(get_version_name)/" > sftp_batch
+          for file in *.tar.gz; do
+            echo "put $file" >> sftp_batch
+          done
+
+          echo "bye" >> sftp_batch
+
+          sshpass -e sftp -oBatchMode=no -o "StrictHostKeyChecking no" -b sftp_batch ${{ secrets.INDIEGAMES_USER }}@scp.indiegames.us
+
+#          # Upload to datacorder
+#          curl -k "sftp://porphyrion.feralhosting.com/www/datacorder.porphyrion.feralhosting.com/public_html/builds/nightly/$(get_version_name)/" --user "${{ secrets.DATACORDER_USER }}:${{ secrets.DATACORDER_PASSWORD }}" -T "$file" --ftp-create-dirs

--- a/ci/github/dist_functions.sh
+++ b/ci/github/dist_functions.sh
@@ -1,0 +1,22 @@
+function get_package_name() {
+  if git describe --match 'nightly_*' --exact-match >/dev/null; then
+    echo -n "$(git describe --match "nightly_*" --exact-match)"
+    return
+  fi
+
+  echo "unknown_config"
+}
+
+function get_version_name() {
+  if git describe --match 'nightly_*' --exact-match >/dev/null; then
+    local tag_name=$(git describe --match "nightly_*" --exact-match)
+
+    # Use the bash regex matching for getting the relevant part of the tag name
+    [[ $tag_name =~ ^nightly_(.*)$ ]]
+
+    echo -n "${BASH_REMATCH[1]}"
+    return
+  fi
+
+  echo "unknown_config"
+}


### PR DESCRIPTION
This creates a new workflow which will build linux binaries for
FastDebug and Release, combine them in a second step, and then upload
them.