### PR TITLE
Use special GitHub action for clang-tidy

### DIFF
--- a/.github/workflows/pr-workflow.yaml
+++ b/.github/workflows/pr-workflow.yaml
@@ -22,7 +22,7 @@ jobs:
             cmake_options: -DFSO_BUILD_WITH_OPENGL=OFF -DFSO_BUILD_WITH_VULKAN=OFF
     name: Linux
     runs-on: ubuntu-latest
-    container: ghcr.io/scp-fs2open/linux_build:sha-a8ca321
+    container: ghcr.io/scp-fs2open/linux_build:sha-e977d36
     steps:
       - name: Cache Qt
         id: cache-qt-lin
@@ -36,6 +36,7 @@ jobs:
           version: ${{ env.QT_VERSION }}
           dir: ${{ github.workspace }}/..
           cached: ${{ steps.cache-qt-lin.outputs.cache-hit }}
+          setup-python: 'false'
 
       - uses: actions/checkout@v1
         name: Checkout
@@ -98,6 +99,11 @@ jobs:
         # Clang-tidy reuses the precompiled headers so this only makes sense for the clang compilers
         if: startsWith(matrix.compiler, 'clang-')
         run: $GITHUB_WORKSPACE/ci/linux/clang_tidy.sh ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }}
+      - name: Process clang-tidy warnings
+        if: startsWith(matrix.compiler, 'clang-')
+        uses: asarium/clang-tidy-action@v1
+        with:
+          fixesFile: clang-fixes.yaml
   build_windows:
     strategy:
       matrix:

--- a/ci/linux/clang-tidy-diff.py
+++ b/ci/linux/clang-tidy-diff.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #===- clang-tidy-diff.py - ClangTidy Diff Checker ------------*- python -*--===#
 #

--- a/ci/linux/clang_tidy.sh
+++ b/ci/linux/clang_tidy.sh
@@ -7,7 +7,7 @@ HERE=$(dirname "$SCRIPT")
 
 COMMIT_RANGE=$1..$2
 
-if ! git rev-list $COMMIT_RANGE 2>1 >/dev/null; then
+if ! git rev-list $COMMIT_RANGE 2>&1 >/dev/null; then
     echo "\$COMMIT_RANGE ($COMMIT_RANGE) is not valid for this build (probably caused by a rebase)."
     exit 0
 fi
@@ -16,12 +16,4 @@ echo "Running clang-tidy on changed files"
 git diff -U0 --no-color $COMMIT_RANGE | \
     $HERE/clang-tidy-diff.py -path "$(pwd)/build" -p1 \
     -regex '(code(?!\/graphics\/shaders\/compiled)|freespace2|qtfred|test|build|tools)\/.*\.(cpp|h)' \
-    -clang-tidy-binary /usr/bin/clang-tidy-9 -j$(nproc) -quiet | \
-    tee /tmp/clang-tidy-output.txt
-
-if [[ -n $(grep "warning: " /tmp/clang-tidy-output.txt) ]] || [[ -n $(grep "error: " /tmp/clang-tidy-output.txt) ]]; then
-    echo "Errors or warnings were detected in the clang-tidy output!"
-    exit 1
-else
-    echo -e "\033[1;32m\xE2\x9C\x93 passed:\033[0m clang-tidy test succeeded";
-fi
+    -clang-tidy-binary /usr/bin/clang-tidy-9 -j$(nproc) -export-fixes "$(pwd)/clang-fixes.yaml"


### PR DESCRIPTION
This action should bring the clang-tidy issues in a better format by
displaying them inline in the diff.