### PR TITLE
hoist model_get and model_get_instance out of a bunch of functions

### DIFF
--- a/code/ai/aibig.cpp
+++ b/code/ai/aibig.cpp
@@ -370,7 +370,8 @@ int ai_big_maybe_follow_subsys_path(int do_dot_check)
 	float		dot = 1.0f, min_dot;
 	object	*target_objp;
 
-	aip = &Ai_info[Ships[Pl_objp->instance].ai_index];
+	auto shipp = &Ships[Pl_objp->instance];
+	aip = &Ai_info[shipp->ai_index];
     
 	if ( aip->target_objnum < 0 )
 		return 0;
@@ -382,7 +383,7 @@ int ai_big_maybe_follow_subsys_path(int do_dot_check)
 		float			dist;
 
 		// Get models of both source and target
-		polymodel *pm = model_get( Ship_info[Ships[Pl_objp->instance].ship_info_index].model_num );
+		polymodel *pm = model_get( Ship_info[shipp->ship_info_index].model_num );
 		polymodel *pm_t = model_get( Ship_info[Ships[target_objp->instance].ship_info_index].model_num );
 
 		// Necessary sanity check
@@ -403,8 +404,8 @@ int ai_big_maybe_follow_subsys_path(int do_dot_check)
 			aip->path_subsystem_next_check = timestamp(1500);
 
 			// get world pos of eye (stored in geye)
-			ep = &(pm->view_positions[Ships[Pl_objp->instance].current_viewpoint]);
-			model_find_world_point( &geye, &ep->pnt, pm->id, 0, &Pl_objp->orient, &Pl_objp->pos );
+			ep = &(pm->view_positions[shipp->current_viewpoint]);
+			model_find_world_point( &geye, &ep->pnt, pm, 0, &Pl_objp->orient, &Pl_objp->pos );
 			
 			// get world pos of subsystem
 			vm_vec_unrotate(&gsubpos, &aip->targeted_subsys->system_info->pnt, &En_objp->orient);

--- a/code/camera/camera.cpp
+++ b/code/camera/camera.cpp
@@ -319,11 +319,14 @@ void camera::get_info(vec3d *position, matrix *orientation)
 		{
 			object *objp = object_host.objp;
 			int model_num = object_get_model(objp);
-			polymodel *pm = NULL;
+			polymodel *pm = nullptr;
+			polymodel_instance *pmi = nullptr;
 			
-			if(model_num > -1)
+			if(model_num >= 0)
 			{
 				pm = model_get(model_num);
+				if (objp->type == OBJ_SHIP)
+					pmi = model_get_instance(Ships[objp->instance].model_instance_num);
 			}
 
 			if(object_host_submodel < 0 || pm == NULL)
@@ -339,13 +342,16 @@ void camera::get_info(vec3d *position, matrix *orientation)
 					Assertion(objp->type == OBJ_SHIP, "This part of the code expects the object to be a ship");
 
 					vec3d c_pos_in;
-					find_submodel_instance_point_normal(&c_pos_in, &host_normal, Ships[objp->instance].model_instance_num, eyep->parent, &eyep->pnt, &eyep->norm);
+					find_submodel_instance_point_normal(&c_pos_in, &host_normal, pm, pmi, eyep->parent, &eyep->pnt, &eyep->norm);
 					vm_vec_unrotate(&c_pos, &c_pos_in, &objp->orient);
 					vm_vec_add2(&c_pos, &objp->pos);
 				}
 				else
 				{
-					model_find_world_point( &c_pos, &pt, pm->id, object_host_submodel, &objp->orient, &objp->pos );
+					if (pmi != nullptr)
+						model_instance_find_world_point(&c_pos, &pt, pm, pmi, object_host_submodel, &objp->orient, &objp->pos);
+					else
+						model_find_world_point( &c_pos, &pt, pm, object_host_submodel, &objp->orient, &objp->pos );
 				}
 			}
 		}
@@ -374,13 +380,16 @@ void camera::get_info(vec3d *position, matrix *orientation)
 			{
 				object *objp = object_target.objp;
 				int model_num = object_get_model(objp);
-				polymodel *pm = NULL;
+				polymodel *pm = nullptr;
+				polymodel_instance *pmi = nullptr;
 				vec3d target_pos = vmd_zero_vector;
 				
 				//See if we can get the model
-				if(model_num > -1)
+				if(model_num >= 0)
 				{
 					pm = model_get(model_num);
+					if (objp->type == OBJ_SHIP)
+						pmi = model_get_instance(Ships[objp->instance].model_instance_num);
 				}
 
 				//If we don't have a submodel or don't have the model use object pos
@@ -391,7 +400,10 @@ void camera::get_info(vec3d *position, matrix *orientation)
 				}
 				else
 				{
-					model_find_world_point( &target_pos, &vmd_zero_vector, pm->id, object_target_submodel, &objp->orient, &objp->pos );
+					if (pmi != nullptr)
+						model_instance_find_world_point(&target_pos, &vmd_zero_vector, pm, pmi, object_target_submodel, &objp->orient, &objp->pos);
+					else
+						model_find_world_point( &target_pos, &vmd_zero_vector, pm, object_target_submodel, &objp->orient, &objp->pos );
 				}
 
 				vec3d targetvec;

--- a/code/debris/debris.cpp
+++ b/code/debris/debris.cpp
@@ -856,27 +856,24 @@ int debris_check_collision(object *pdebris, object *other_obj, vec3d *hitpos, co
 		// first test against the sphere - if this fails then don't do any submodel tests
 		mc.flags = MC_ONLY_SPHERE | MC_CHECK_SPHERELINE;
 
-		SCP_vector<int> submodel_vector;
-		polymodel_instance *pmi;
-
 		if (model_collide(&mc)) {
 
 			// Set earliest hit time
 			debris_hit_info->hit_time = FLT_MAX;
 
+			auto pmi = model_get_instance(Ships[heavy_obj->instance].model_instance_num);
+			auto pm = model_get(pmi->model_num);
+
 			// Do collision the cool new way
 			if ( debris_hit_info->collide_rotate ) {
-				SCP_vector<int>::iterator smv;
-
 				// We collide with the sphere, find the list of rotating submodels and test one at a time
+				SCP_vector<int> submodel_vector;
 				model_get_rotating_submodel_list(&submodel_vector, heavy_obj);
 
-				// Get polymodel and turn off all rotating submodels, collide against only 1 at a time.
-				pmi = model_get_instance(Ships[heavy_obj->instance].model_instance_num);
-
-				// turn off all rotating submodels and test for collision
-				for (smv = submodel_vector.begin(); smv != submodel_vector.end(); ++smv) {
-					pmi->submodel[*smv].collision_checked = true;
+				// turn off all rotating submodels, collide against only 1 at a time.
+				// turn off collision detection for all rotating submodels
+				for (auto submodel : submodel_vector) {
+					pmi->submodel[submodel].collision_checked = true;
 				}
 
 				// reset flags to check MC_CHECK_MODEL | MC_CHECK_SPHERELINE and maybe MC_CHECK_INVISIBLE_FACES and MC_SUBMODEL_INSTANCE
@@ -887,25 +884,27 @@ int debris_check_collision(object *pdebris, object *other_obj, vec3d *hitpos, co
 				}
 
 				// check each submodel in turn
-				for (smv = submodel_vector.begin(); smv != submodel_vector.end(); ++smv) {
-					// turn on submodel for collision test
-					pmi->submodel[*smv].collision_checked = false;
+				for (auto submodel: submodel_vector) {
+					auto smi = &pmi->submodel[submodel];
+
+					// turn on just one submodel for collision test
+					smi->collision_checked = false;
 
 					// set angles for last frame (need to set to prev to get p0)
-					angles copy_angles = pmi->submodel[*smv].angs;
+					angles copy_angles = smi->angs;
 
 					// find the start and end positions of the sphere in submodel RF
-					pmi->submodel[*smv].angs = pmi->submodel[*smv].prev_angs;
-					world_find_model_instance_point(&p0, &light_obj->last_pos, pmi, *smv, &heavy_obj->last_orient, &heavy_obj->last_pos);
+					smi->angs = smi->prev_angs;
+					world_find_model_instance_point(&p0, &light_obj->last_pos, pm, pmi, submodel, &heavy_obj->last_orient, &heavy_obj->last_pos);
 
-					pmi->submodel[*smv].angs = copy_angles;
-					world_find_model_instance_point(&p1, &light_obj->pos, pmi, *smv, &heavy_obj->orient, &heavy_obj->pos);
+					smi->angs = copy_angles;
+					world_find_model_instance_point(&p1, &light_obj->pos, pm, pmi, submodel, &heavy_obj->orient, &heavy_obj->pos);
 
 					mc.p0 = &p0;
 					mc.p1 = &p1;
 
 					mc.orient = &vmd_identity_matrix;
-					mc.submodel_num = *smv;
+					mc.submodel_num = submodel;
 
 					if ( model_collide(&mc) ) {
 						if ( mc.hit_dist < debris_hit_info->hit_time ) {
@@ -913,22 +912,23 @@ int debris_check_collision(object *pdebris, object *other_obj, vec3d *hitpos, co
 
 							// set up debris_hit_info common
 							set_hit_struct_info(debris_hit_info, &mc, SUBMODEL_ROT_HIT);
-							model_instance_find_world_point(&debris_hit_info->hit_pos, &mc.hit_point, mc.model_instance_num, mc.hit_submodel, &heavy_obj->orient, &zero);
+							model_instance_find_world_point(&debris_hit_info->hit_pos, &mc.hit_point, pm, pmi, mc.hit_submodel, &heavy_obj->orient, &zero);
 
 							// set up debris_hit_info for rotating submodel
 							if (debris_hit_info->edge_hit == 0) {
-								model_instance_find_obj_dir(&debris_hit_info->collision_normal, &mc.hit_normal, mc.model_instance_num, mc.hit_submodel, &heavy_obj->orient);
+								model_instance_find_obj_dir(&debris_hit_info->collision_normal, &mc.hit_normal, pm, pmi, mc.hit_submodel, &heavy_obj->orient);
 							}
 
 							// find position in submodel RF of light object at collison
 							vec3d int_light_pos, diff;
 							vm_vec_sub(&diff, mc.p1, mc.p0);
 							vm_vec_scale_add(&int_light_pos, mc.p0, &diff, mc.hit_dist);
-							model_instance_find_world_point(&debris_hit_info->light_collision_cm_pos, &int_light_pos, mc.model_instance_num, mc.hit_submodel, &heavy_obj->orient, &zero);
+							model_instance_find_world_point(&debris_hit_info->light_collision_cm_pos, &int_light_pos, pm, pmi, mc.hit_submodel, &heavy_obj->orient, &zero);
 						}
 					}
+
 					// Don't look at this submodel again
-					pmi->submodel[*smv].collision_checked = true;
+					smi->collision_checked = true;
 				}
 			}
 
@@ -948,7 +948,7 @@ int debris_check_collision(object *pdebris, object *other_obj, vec3d *hitpos, co
 
 					// get collision normal if not edge hit
 					if (debris_hit_info->edge_hit == 0) {
-						model_instance_find_obj_dir(&debris_hit_info->collision_normal, &mc.hit_normal, Ships[heavy_obj->instance].model_instance_num, mc.hit_submodel, &heavy_obj->orient);
+						model_instance_find_obj_dir(&debris_hit_info->collision_normal, &mc.hit_normal, pm, pmi, mc.hit_submodel, &heavy_obj->orient);
 					}
 
 					// find position in submodel RF of light object at collison

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -3538,12 +3538,11 @@ void mission_parse_maybe_create_parse_object(p_object *pobjp)
 			// FreeSpace
 			if (!Fred_running)
 			{
-				shipfx_blow_up_model(objp, Ship_info[Ships[objp->instance].ship_info_index].model_num, 0, 0, &objp->pos);
+				shipfx_blow_up_model(objp, 0, 0, &objp->pos);
 				objp->flags.set(Object::Object_Flags::Should_be_dead);
 
 				// Make sure that the ship is marked as destroyed so the AI doesn't freak out later
-				auto sip = &Ships[objp->instance];
-				ship_add_exited_ship(sip, Ship::Exit_Flags::Destroyed);
+				ship_add_exited_ship(&Ships[objp->instance], Ship::Exit_Flags::Destroyed);
 
 				// once the ship is exploded, find the debris pieces belonging to this object, mark them
 				// as not to expire, and move them forward in time N seconds

--- a/code/model/model.h
+++ b/code/model/model.h
@@ -103,6 +103,7 @@ typedef struct submodel_instance {
 
 // Data specific to a particular instance of a model.
 typedef struct polymodel_instance {
+	int id;
 	int model_num;					// global model num index, same as polymodel->id
 	submodel_instance *submodel;	// array of submodel instances; mirrors the polymodel->submodel array
 } polymodel_instance;
@@ -917,10 +918,10 @@ extern int modelstats_num_sortnorms;
 
 // Tries to move joints so that the turret points to the point dst.
 // turret1 is the angles of the turret, turret2 is the angles of the gun from turret
-extern int model_rotate_gun(int model_num, model_subsystem *turret, matrix *orient, angles *base_angles, angles *gun_angles, vec3d *pos, vec3d *dst, int obj_idx, bool reset = false);
+extern int model_rotate_gun(polymodel *pm, model_subsystem *turret, matrix *orient, angles *base_angles, angles *gun_angles, vec3d *pos, vec3d *dst, int obj_idx, bool reset = false);
 
 // Gets and sets turret rotation matrix
-extern void model_make_turret_matrix(int model_num, model_subsystem * turret );
+extern void model_make_turret_matrix(polymodel *pm, model_subsystem *turret);
 
 // Rotates the angle of a submodel.  Use this so the right unlocked axis
 // gets stuffed.
@@ -933,23 +934,25 @@ void submodel_stepped_rotate(model_subsystem *psub, submodel_instance_info *sii)
 
 // Goober5000
 // For a submodel, return its overall offset from the main model.
-extern void model_find_submodel_offset(vec3d *outpnt, int model_num, int sub_model_num);
+extern void model_find_submodel_offset(vec3d *outpnt, const polymodel *pm, int sub_model_num);
 
 // Given a point (pnt) that is in sub_model_num's frame of
 // reference, and given the object's orient and position, 
 // return the point in 3-space in outpnt.
 extern void model_find_world_point(vec3d *outpnt, vec3d *mpnt, int model_num, int submodel_num, const matrix *objorient, const vec3d *objpos);
 extern void model_instance_find_world_point(vec3d *outpnt, vec3d *mpnt, int model_instance_num, int submodel_num, const matrix *objorient, const vec3d *objpos);
+extern void model_find_world_point(vec3d *outpnt, vec3d *mpnt, const polymodel *pm, int submodel_num, const matrix *objorient, const vec3d *objpos);
+extern void model_instance_find_world_point(vec3d *outpnt, vec3d *mpnt, const polymodel *pm, const polymodel_instance *pmi, int submodel_num, const matrix *objorient, const vec3d *objpos);
 
 // Given a point in the world RF, find the corresponding point in the model RF.
 // This is special purpose code, specific for model collision.
 // NOTE - this code ASSUMES submodel is 1 level down from hull (detail[0])
-void world_find_model_instance_point(vec3d *out, vec3d *world_pt, const polymodel_instance *pmi, int submodel_num, const matrix *orient, const vec3d *pos);
+void world_find_model_instance_point(vec3d *out, vec3d *world_pt, const polymodel *pm, const polymodel_instance *pmi, int submodel_num, const matrix *orient, const vec3d *pos);
 
-extern void find_submodel_instance_point(vec3d *outpnt, int model_instance_num, int submodel_num);
-extern void find_submodel_instance_point_normal(vec3d *outpnt, vec3d *outnorm, int model_instance_num, int submodel_num, const vec3d *submodel_pnt, const vec3d *submodel_norm);
-extern void find_submodel_instance_point_orient(vec3d *outpnt, matrix *outorient, int model_instance_num, int submodel_num, const vec3d *submodel_pnt, const matrix *submodel_orient);
-extern void find_submodel_instance_world_point(vec3d *outpnt, int model_instance_num, int submodel_num, const matrix *objorient, const vec3d *objpos);
+extern void find_submodel_instance_point(vec3d *outpnt, const polymodel *pm, const polymodel_instance *pmi, int submodel_num);
+extern void find_submodel_instance_point_normal(vec3d *outpnt, vec3d *outnorm, const polymodel *pm, const polymodel_instance *pmi, int submodel_num, const vec3d *submodel_pnt, const vec3d *submodel_norm);
+extern void find_submodel_instance_point_orient(vec3d *outpnt, matrix *outorient, const polymodel *pm, const polymodel_instance *pmi, int submodel_num, const vec3d *submodel_pnt, const matrix *submodel_orient);
+extern void find_submodel_instance_world_point(vec3d *outpnt, const polymodel *pm, const polymodel_instance *pmi, int submodel_num, const matrix *objorient, const vec3d *objpos);
 
 // Given a polygon model index, find a list of rotating submodels to be used for collision
 void model_get_rotating_submodel_list(SCP_vector<int> *submodel_vector, object *objp);
@@ -958,13 +961,15 @@ void model_get_rotating_submodel_list(SCP_vector<int> *submodel_vector, object *
 void model_get_submodel_tree_list(SCP_vector<int> &submodel_vector, polymodel* pm, int mn);
 
 // For a rotating submodel, find a point on the axis
-void model_init_submodel_axis_pt(submodel_instance_info *sii, int model_num, int submodel_num);
+void model_init_submodel_axis_pt(submodel_instance_info *sii, polymodel *pm, int submodel_num);
 
 // Given a direction (pnt) that is in sub_model_num's frame of
 // reference, and given the object's orient and position, 
 // return the point in 3-space in outpnt.
-extern void model_find_world_dir(vec3d *out_dir, vec3d *in_dir, int model_num, int submodel_num, const matrix *objorient);
-extern void model_instance_find_world_dir(vec3d *out_dir, vec3d *in_dir, int model_instance_num, int submodel_num, const matrix *objorient);
+extern void model_find_world_dir(vec3d *out_dir, const vec3d *in_dir, int model_num, int submodel_num, const matrix *objorient);
+extern void model_find_world_dir(vec3d *out_dir, const vec3d *in_dir, const polymodel *pm, int submodel_num, const matrix *objorient);
+extern void model_instance_find_world_dir(vec3d *out_dir, const vec3d *in_dir, int model_instance_num, int submodel_num, const matrix *objorient);
+extern void model_instance_find_world_dir(vec3d *out_dir, const vec3d *in_dir, const polymodel *pm, const polymodel_instance *pmi, int submodel_num, const matrix *objorient);
 
 // Clears all the submodel instances stored in a model to their defaults.
 extern void model_clear_instance(int model_num);
@@ -980,7 +985,8 @@ extern void model_clear_instance_info(submodel_instance_info *sii, float turn_ra
 extern void model_set_instance(int model_num, int sub_model_num, submodel_instance_info *sii, flagset<Ship::Subsystem_Flags>* flags = NULL);
 extern void model_set_instance_techroom(int model_num, int sub_model_num, float angle_1, float angle_2);
 
-void model_update_instance(int model_instance_num, int sub_model_num, submodel_instance_info *sii, flagset<Ship::Subsystem_Flags>& flags);
+void model_update_instance(int model_instance_num, int submodel_num, submodel_instance_info *sii, flagset<Ship::Subsystem_Flags>& flags);
+void model_update_instance(polymodel *pm, polymodel_instance *pmi, int submodel_num, submodel_instance_info *sii, flagset<Ship::Subsystem_Flags>& flags);
 
 // Adds an electrical arcing effect to a submodel
 void model_add_arc(int model_num, int sub_model_num, vec3d *v1, vec3d *v2, int arc_type);
@@ -1014,7 +1020,7 @@ int submodel_get_num_polys(int model_num, int submodel_num);
 // Given a vector that is in sub_model_num's frame of
 // reference, and given the object's orient and position,
 // return the vector in the model's frame of reference.
-void model_instance_find_obj_dir(vec3d *w_vec, vec3d *m_vec, int model_instance_num, int submodel_num, matrix *objorient);
+void model_instance_find_obj_dir(vec3d *w_vec, vec3d *m_vec, const polymodel *pm, const polymodel_instance *pmi, int submodel_num, matrix *objorient);
 
 
 // This is the interface to model_check_collision.  Rather than passing all these

--- a/code/model/modelcollide.cpp
+++ b/code/model/modelcollide.cpp
@@ -1345,9 +1345,9 @@ int model_collide(mc_info *mc_info_obj)
 			vm_vec_add2(&Mc->hit_point_world, Mc->pos);
 		} else {
 			if ( Mc_pmi ) {
-				model_instance_find_world_point(&Mc->hit_point_world, &Mc->hit_point, Mc->model_instance_num, Mc->hit_submodel, Mc->orient, Mc->pos);
+				model_instance_find_world_point(&Mc->hit_point_world, &Mc->hit_point, Mc_pm, Mc_pmi, Mc->hit_submodel, Mc->orient, Mc->pos);
 			} else {
-				model_find_world_point(&Mc->hit_point_world, &Mc->hit_point, Mc->model_num, Mc->hit_submodel, Mc->orient, Mc->pos);
+				model_find_world_point(&Mc->hit_point_world, &Mc->hit_point, Mc_pm, Mc->hit_submodel, Mc->orient, Mc->pos);
 			}
 		}
 	}
@@ -1357,8 +1357,9 @@ int model_collide(mc_info *mc_info_obj)
 
 }
 
-void model_collide_preprocess_subobj(vec3d *pos, matrix *orient, polymodel *pm,  polymodel_instance *pmi, int subobj_num)
+void model_collide_preprocess_subobj(vec3d *pos, matrix *orient, polymodel *pm, polymodel_instance *pmi, int subobj_num)
 {
+	Assert(pm->id == pmi->model_num);
 	submodel_instance *smi = &pmi->submodel[subobj_num];
 
 	smi->mc_base = *pos;
@@ -1398,14 +1399,10 @@ void model_collide_preprocess_subobj(vec3d *pos, matrix *orient, polymodel *pm, 
 
 void model_collide_preprocess(matrix *orient, int model_instance_num, int detail_num)
 {
-	polymodel_instance	*pmi;
-	polymodel *pm;
-
-	pmi = model_get_instance(model_instance_num);
-	pm = model_get(pmi->model_num);
-
 	matrix current_orient;
 	vec3d current_pos;
+	auto pmi = model_get_instance(model_instance_num);
+	auto pm = model_get(pmi->model_num);
 
 	current_orient = *orient;
 

--- a/code/network/multi_obj.cpp
+++ b/code/network/multi_obj.cpp
@@ -1312,38 +1312,39 @@ int multi_oo_pack_data(net_player *pl, object *objp, ushort oo_flags, ubyte *dat
 
 			// retrieve the submodel for rotation info.
 			if (subsystem->system_info->flags[Model::Subsystem_Flags::Rotates, Model::Subsystem_Flags::Dum_rotates]) {
+				angles *angs_1 = &subsystem->submodel_info_1.angs;
+				angles *angs_2 = &subsystem->submodel_info_2.angs;
 
 				// here we're checking to see if the subsystems rotated enough to send.
-				if (subsystem->submodel_info_1.angs.b != Oo_info.player_frame_info[pl->player_id].last_sent[objp->net_signature].subsystem_1b[i]) {
+				if (angs_1 != nullptr && angs_1->b != Oo_info.player_frame_info[pl->player_id].last_sent[objp->net_signature].subsystem_1b[i]) {
 					flags[i] |= OO_SUBSYS_ROTATION_1b;
-					subsys_data.push_back(subsystem->submodel_info_1.angs.b / PI2);
+					subsys_data.push_back(angs_1->b / PI2);
 				}
 
-				if (subsystem->submodel_info_1.angs.h != Oo_info.player_frame_info[pl->player_id].last_sent[objp->net_signature].subsystem_1h[i]) {
+				if (angs_1 != nullptr && angs_1->h != Oo_info.player_frame_info[pl->player_id].last_sent[objp->net_signature].subsystem_1h[i]) {
 					flags[i] |= OO_SUBSYS_ROTATION_1h;
-					subsys_data.push_back(subsystem->submodel_info_1.angs.h / PI2);
+					subsys_data.push_back(angs_1->h / PI2);
 				}
 
-				if (subsystem->submodel_info_1.angs.p != Oo_info.player_frame_info[pl->player_id].last_sent[objp->net_signature].subsystem_1p[i]) {
+				if (angs_1 != nullptr && angs_1->p != Oo_info.player_frame_info[pl->player_id].last_sent[objp->net_signature].subsystem_1p[i]) {
 					flags[i] |= OO_SUBSYS_ROTATION_1p;
-					subsys_data.push_back(subsystem->submodel_info_1.angs.p / PI2);
+					subsys_data.push_back(angs_1->p / PI2);
 				}
 
-				if (subsystem->submodel_info_2.angs.b != Oo_info.player_frame_info[pl->player_id].last_sent[objp->net_signature].subsystem_2b[i]) {
+				if (angs_2 != nullptr && angs_2->b != Oo_info.player_frame_info[pl->player_id].last_sent[objp->net_signature].subsystem_2b[i]) {
 					flags[i] |= OO_SUBSYS_ROTATION_2b;
-					subsys_data.push_back(subsystem->submodel_info_2.angs.b / PI2);
+					subsys_data.push_back(angs_2->b / PI2);
 				}
 
-				if (subsystem->submodel_info_2.angs.h != Oo_info.player_frame_info[pl->player_id].last_sent[objp->net_signature].subsystem_2h[i]) {
+				if (angs_2 != nullptr && angs_2->h != Oo_info.player_frame_info[pl->player_id].last_sent[objp->net_signature].subsystem_2h[i]) {
 					flags[i] |= OO_SUBSYS_ROTATION_2h;
-					subsys_data.push_back(subsystem->submodel_info_2.angs.h / PI2);
+					subsys_data.push_back(angs_2->h / PI2);
 				}
 
-				if (subsystem->submodel_info_2.angs.p != Oo_info.player_frame_info[pl->player_id].last_sent[objp->net_signature].subsystem_2p[i]) {
+				if (angs_2 != nullptr && angs_2->p != Oo_info.player_frame_info[pl->player_id].last_sent[objp->net_signature].subsystem_2p[i]) {
 					flags[i] |= OO_SUBSYS_ROTATION_2p;
-					subsys_data.push_back(subsystem->submodel_info_2.angs.p / PI2);
+					subsys_data.push_back(angs_2->p / PI2);
 				}
-
 			}
 			i++;
 		}
@@ -1914,39 +1915,44 @@ int multi_oo_unpack_data(net_player* pl, ubyte* data, int seq_num)
 					data_idx++;
 				}
 
+				angles *prev_angs_1 = &subsysp->submodel_info_1.prev_angs;
+				angles *prev_angs_2 = &subsysp->submodel_info_2.prev_angs;
+				angles *angs_1 = &subsysp->submodel_info_1.angs;
+				angles *angs_2 = &subsysp->submodel_info_2.angs;
+
 				if (flags[i] & OO_SUBSYS_ROTATION_1b) {
-					subsysp->submodel_info_1.prev_angs.b = subsysp->submodel_info_1.angs.b;
-					subsysp->submodel_info_1.angs.b = (subsys_data[data_idx] * PI2);
+					prev_angs_1->b = angs_1->b;
+					angs_1->b = (subsys_data[data_idx] * PI2);
 					data_idx++;
 				}
 
 				if (flags[i] & OO_SUBSYS_ROTATION_1h) {
-					subsysp->submodel_info_1.prev_angs.h = subsysp->submodel_info_1.angs.h;
-					subsysp->submodel_info_1.angs.h = (subsys_data[data_idx] * PI2);
+					prev_angs_1->h = angs_1->h;
+					angs_1->h = (subsys_data[data_idx] * PI2);
 					data_idx++;
 				}
 
 				if (flags[i] & OO_SUBSYS_ROTATION_1p) {
-					subsysp->submodel_info_1.prev_angs.p = subsysp->submodel_info_1.angs.p;
-					subsysp->submodel_info_1.angs.p = (subsys_data[data_idx] * PI2);
+					prev_angs_1->p = angs_1->p;
+					angs_1->p = (subsys_data[data_idx] * PI2);
 					data_idx++;
 				}
 
 				if (flags[i] & OO_SUBSYS_ROTATION_2b) {
-					subsysp->submodel_info_2.prev_angs.b = subsysp->submodel_info_2.angs.b;
-					subsysp->submodel_info_2.angs.b = (subsys_data[data_idx] * PI2);
+					prev_angs_2->b = angs_2->b;
+					angs_2->b = (subsys_data[data_idx] * PI2);
 					data_idx++;
 				}
 
 				if (flags[i] & OO_SUBSYS_ROTATION_2h) {
-					subsysp->submodel_info_2.prev_angs.h = subsysp->submodel_info_2.angs.h;
-					subsysp->submodel_info_2.angs.h = (subsys_data[data_idx] * PI2);
+					prev_angs_2->h = angs_2->h;
+					angs_2->h = (subsys_data[data_idx] * PI2);
 					data_idx++;
 				}
 
 				if (flags[i] & OO_SUBSYS_ROTATION_2p) {
-					subsysp->submodel_info_2.prev_angs.p = subsysp->submodel_info_2.angs.p;
-					subsysp->submodel_info_2.angs.p = (subsys_data[data_idx] * PI2);
+					prev_angs_2->p = angs_2->p;
+					angs_2->p = (subsys_data[data_idx] * PI2);
 					data_idx++;
 				}
 				subsysp = GET_NEXT(subsysp);

--- a/code/object/collideshipship.cpp
+++ b/code/object/collideshipship.cpp
@@ -237,10 +237,8 @@ int ship_ship_check_collision(collision_info_struct *ship_ship_hit_info)
 	// first test against the sphere - if this fails then don't do any submodel tests
 	mc.flags = MC_ONLY_SPHERE | MC_CHECK_SPHERELINE;
 
-	SCP_vector<int> submodel_vector;
 	int valid_hit_occured = 0;
 	polymodel *pm_light;
-	polymodel_instance *pmi;
 		
 	pm_light = model_get(Ship_info[light_shipp->ship_info_index].model_num);
 
@@ -253,17 +251,19 @@ int ship_ship_check_collision(collision_info_struct *ship_ship_hit_info)
 		// Set earliest hit time
 		ship_ship_hit_info->hit_time = FLT_MAX;
 
+		auto pmi = model_get_instance(heavy_shipp->model_instance_num);
+		auto pm = model_get(pmi->model_num);
+
 		// Do collision the cool new way
 		if ( ship_ship_hit_info->collide_rotate ) {
-			SCP_vector<int>::iterator smv;
-
+			// We collide with the sphere, find the list of rotating submodels and test one at a time
+			SCP_vector<int> submodel_vector;
 			model_get_rotating_submodel_list(&submodel_vector, heavy_obj);
 
-			pmi = model_get_instance(heavy_shipp->model_instance_num);
-
-			// turn off all rotating submodels and test for collision
-			for (smv = submodel_vector.begin(); smv != submodel_vector.end(); ++smv) {
-				pmi->submodel[*smv].collision_checked = true;
+			// turn off all rotating submodels, collide against only 1 at a time.
+			// turn off collision detection for all rotating submodels
+			for (auto submodel : submodel_vector) {
+				pmi->submodel[submodel].collision_checked = true;
 			}
 
 			// reset flags to check MC_CHECK_MODEL | MC_CHECK_SPHERELINE and maybe MC_CHECK_INVISIBLE_FACES and MC_SUBMODEL_INSTANCE
@@ -274,31 +274,33 @@ int ship_ship_check_collision(collision_info_struct *ship_ship_hit_info)
 			}
 
 			// check each submodel in turn
-			for (smv = submodel_vector.begin(); smv != submodel_vector.end(); ++smv) {
-				// turn on submodel for collision test
-				pmi->submodel[*smv].collision_checked = false;
+			for (auto submodel : submodel_vector) {
+				auto smi = &pmi->submodel[submodel];
 
-				if (pmi->submodel[*smv].blown_off)
+				// turn on just one submodel for collision test
+				smi->collision_checked = false;
+
+				if (smi->blown_off)
 				{
-					pmi->submodel[*smv].collision_checked = true;
+					smi->collision_checked = true;
 					continue;
 				}
 
 				// set angles for last frame
-				angles copy_angles = pmi->submodel[*smv].angs;
+				angles copy_angles = smi->angs;
 
 				// find the start and end positions of the sphere in submodel RF
-				pmi->submodel[*smv].angs = pmi->submodel[*smv].prev_angs;
-				world_find_model_instance_point(&p0, &light_obj->last_pos, pmi, *smv, &heavy_obj->last_orient, &heavy_obj->last_pos);
+				smi->angs = smi->prev_angs;
+				world_find_model_instance_point(&p0, &light_obj->last_pos, pm, pmi, submodel, &heavy_obj->last_orient, &heavy_obj->last_pos);
 
-				pmi->submodel[*smv].angs = copy_angles;
-				world_find_model_instance_point(&p1, &light_obj->pos, pmi, *smv, &heavy_obj->orient, &heavy_obj->pos);
+				smi->angs = copy_angles;
+				world_find_model_instance_point(&p1, &light_obj->pos, pm, pmi, submodel, &heavy_obj->orient, &heavy_obj->pos);
 
 				mc.p0 = &p0;
 				mc.p1 = &p1;
 
 				mc.orient = &vmd_identity_matrix;
-				mc.submodel_num = *smv;
+				mc.submodel_num = submodel;
 
 				if ( model_collide(&mc) ) {
 					if (mc.hit_dist < ship_ship_hit_info->hit_time ) {
@@ -306,18 +308,18 @@ int ship_ship_check_collision(collision_info_struct *ship_ship_hit_info)
 
 						// set up ship_ship_hit_info common
 						set_hit_struct_info(ship_ship_hit_info, &mc, SUBMODEL_ROT_HIT);
-						model_instance_find_world_point(&ship_ship_hit_info->hit_pos, &mc.hit_point, mc.model_instance_num, mc.hit_submodel, &heavy_obj->orient, &zero);
+						model_instance_find_world_point(&ship_ship_hit_info->hit_pos, &mc.hit_point, pm, pmi, mc.hit_submodel, &heavy_obj->orient, &zero);
 
 						// set up ship_ship_hit_info for rotating submodel
 						if (ship_ship_hit_info->edge_hit == 0) {
-							model_instance_find_obj_dir(&ship_ship_hit_info->collision_normal, &mc.hit_normal, mc.model_instance_num, mc.hit_submodel, &heavy_obj->orient);
+							model_instance_find_obj_dir(&ship_ship_hit_info->collision_normal, &mc.hit_normal, pm, pmi, mc.hit_submodel, &heavy_obj->orient);
 						}
 
 						// find position in submodel RF of light object at collison
 						vec3d int_light_pos, diff;
 						vm_vec_sub(&diff, mc.p1, mc.p0);
 						vm_vec_scale_add(&int_light_pos, mc.p0, &diff, mc.hit_dist);
-						model_instance_find_world_point(&ship_ship_hit_info->light_collision_cm_pos, &int_light_pos, mc.model_instance_num, mc.hit_submodel, &heavy_obj->orient, &zero);
+						model_instance_find_world_point(&ship_ship_hit_info->light_collision_cm_pos, &int_light_pos, pm, pmi, mc.hit_submodel, &heavy_obj->orient, &zero);
 					}
 				}
 			}
@@ -340,7 +342,7 @@ int ship_ship_check_collision(collision_info_struct *ship_ship_hit_info)
 
 				// get collision normal if not edge hit
 				if (ship_ship_hit_info->edge_hit == 0) {
-					model_instance_find_obj_dir(&ship_ship_hit_info->collision_normal, &mc.hit_normal, mc.model_instance_num, mc.hit_submodel, &heavy_obj->orient);
+					model_instance_find_obj_dir(&ship_ship_hit_info->collision_normal, &mc.hit_normal, pm, pmi, mc.hit_submodel, &heavy_obj->orient);
 				}
 
 				// find position in submodel RF of light object at collison
@@ -571,9 +573,11 @@ void calculate_ship_ship_collision_physics(collision_info_struct *ship_ship_hit_
 		}
 		
 		if ( pmi != NULL && pmi->submodel[ship_ship_hit_info->submodel_num].sii != NULL ) {
+			auto smi = &pmi->submodel[ship_ship_hit_info->submodel_num];
+
 			// set point on axis of rotating submodel if not already set.
-			if ( !pmi->submodel[ship_ship_hit_info->submodel_num].sii->axis_set ) {
-				model_init_submodel_axis_pt(pmi->submodel[ship_ship_hit_info->submodel_num].sii, pm->id, ship_ship_hit_info->submodel_num);
+			if ( !smi->sii->axis_set ) {
+				model_init_submodel_axis_pt(smi->sii, pm, ship_ship_hit_info->submodel_num);
 			}
 
 			vec3d omega, axis, r_rot;
@@ -589,13 +593,13 @@ void calculate_ship_ship_collision_physics(collision_info_struct *ship_ship_hit_
 			}
 
 			// get world rotational velocity of rotating submodel
-			model_instance_find_obj_dir(&omega, &axis, model_instance_num, ship_ship_hit_info->submodel_num, &heavy->orient);
+			model_instance_find_obj_dir(&omega, &axis, pm, pmi, ship_ship_hit_info->submodel_num, &heavy->orient);
 
-			vm_vec_scale(&omega, pmi->submodel[ship_ship_hit_info->submodel_num].sii->current_turn_rate);
+			vm_vec_scale(&omega, smi->sii->current_turn_rate);
 
 			// world coords for r_rot
 			vec3d temp;
-			vm_vec_unrotate(&temp, &pmi->submodel[ship_ship_hit_info->submodel_num].sii->point_on_axis, &heavy->orient);
+			vm_vec_unrotate(&temp, &smi->sii->point_on_axis, &heavy->orient);
 			vm_vec_sub(&r_rot, &ship_ship_hit_info->hit_pos, &temp);
 
 			vm_vec_cross(&local_vel_from_submodel, &omega, &r_rot);

--- a/code/object/collideshipweapon.cpp
+++ b/code/object/collideshipweapon.cpp
@@ -68,11 +68,13 @@ static void ship_weapon_do_hit_stuff(object *pship_obj, object *weapon_obj, vec3
 	weapon	*wp = &Weapons[weapon_obj->instance];
 	weapon_info *wip = &Weapon_info[wp->weapon_info_index];
 	ship *shipp = &Ships[pship_obj->instance];
+	auto pmi = model_get_instance(shipp->model_instance_num);
+	auto pm = model_get(pmi->model_num);
 	float damage;
 	vec3d force;
 
 	vec3d worldNormal;
-	model_instance_find_world_dir(&worldNormal, &hit_dir, shipp->model_instance_num, submodel_num, &pship_obj->orient);
+	model_instance_find_world_dir(&worldNormal, &hit_dir, pm, pmi, submodel_num, &pship_obj->orient);
 
 	// Apply hit & damage & stuff to weapon
 	weapon_hit(weapon_obj, pship_obj,  world_hitpos, quadrant_num, &worldNormal);

--- a/code/particle/ParticleSource.cpp
+++ b/code/particle/ParticleSource.cpp
@@ -310,7 +310,7 @@ void ParticleSource::initializeThrusterOffset(weapon*  /*wp*/, weapon_info* wip)
 	// Only use the first point in the bank
 	auto point = &thruster->points[0];
 
-	model_find_world_point(&this->m_origin.m_offset, &point->pnt, wip->model_num, thruster->submodel_num,
+	model_find_world_point(&this->m_origin.m_offset, &point->pnt, pm, thruster->submodel_num,
 						   &vmd_identity_matrix, &vmd_zero_vector);
 }
 

--- a/code/scripting/api/objs/model_path.cpp
+++ b/code/scripting/api/objs/model_path.cpp
@@ -50,8 +50,11 @@ ADE_VIRTVAR(Position, l_ModelPathPoint, "vector", "The current, global position 
 	auto objp  = p->parent->subsys.objp;
 	auto shipp = &Ships[objp->instance];
 
+	auto pmi = model_get_instance(shipp->model_instance_num);
+	auto pm = model_get(pmi->model_num);
+
 	vec3d world_pos;
-	model_instance_find_world_point(&world_pos, &p->point, shipp->model_instance_num, 0, &objp->orient, &objp->pos);
+	model_instance_find_world_point(&world_pos, &p->point, pm, pmi, 0, &objp->orient, &objp->pos);
 
 	return ade_set_error(L, "o", l_Vector.Set(world_pos));
 }

--- a/code/scripting/api/objs/subsystem.cpp
+++ b/code/scripting/api/objs/subsystem.cpp
@@ -638,10 +638,13 @@ ADE_FUNC(rotateTurret, l_Subsystem, "vector Pos, boolean reset=false", "Rotates 
 	//Add turret position to appropriate world space
 	vm_vec_add2(&gpos, &objp->pos);
 
-	// Find direction of turret
-	model_instance_find_world_dir(&gvec, &tp->turret_norm, shipp->model_instance_num, tp->turret_gun_sobj, &objp->orient);
+	auto pmi = model_get_instance(Ships[objp->instance].model_instance_num);
+	auto pm = model_get(pmi->model_num);
 
-	int ret_val = model_rotate_gun(Ship_info[shipp->ship_info_index].model_num, tp, &objp->orient, &sso->ss->submodel_info_1.angs, &sso->ss->submodel_info_2.angs, &objp->pos, &pos, shipp->objnum, reset);
+	// Find direction of turret
+	model_instance_find_world_dir(&gvec, &tp->turret_norm, pm, pmi, tp->turret_gun_sobj, &objp->orient);
+
+	int ret_val = model_rotate_gun(pm, tp, &objp->orient, &sso->ss->submodel_info_1.angs, &sso->ss->submodel_info_2.angs, &objp->pos, &pos, shipp->objnum, reset);
 
 	if (ret_val)
 		return ADE_RETURN_TRUE;
@@ -661,7 +664,10 @@ ADE_FUNC(getTurretHeading, l_Subsystem, NULL, "Returns the turrets forward vecto
 	vec3d gvec;
 	object *objp = sso->objp;
 
-	model_instance_find_world_dir(&gvec, &sso->ss->system_info->turret_norm, Ships[objp->instance].model_instance_num, sso->ss->system_info->turret_gun_sobj, &objp->orient);
+	auto pmi = model_get_instance(Ships[objp->instance].model_instance_num);
+	auto pm = model_get(pmi->model_num);
+
+	model_instance_find_world_dir(&gvec, &sso->ss->system_info->turret_norm, pm, pmi, sso->ss->system_info->turret_gun_sobj, &objp->orient);
 
 	vec3d out;
 	vm_vec_rotate(&out, &gvec, &objp->orient);

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -1607,12 +1607,6 @@ extern void shield_hit_close();
 int ship_is_shield_up( object *obj, int quadrant );
 
 //=================================================
-// These two functions transfer instance specific angle
-// data into and out of the model structure, which contains
-// angles, but not for each instance of model being used. See
-// the actual functions in ship.cpp for more details.
-extern void ship_model_start(object *objp);
-extern void ship_model_stop(object *objp);
 void ship_model_update_instance(object *objp);
 
 //============================================

--- a/code/ship/shipfx.h
+++ b/code/ship/shipfx.h
@@ -32,11 +32,11 @@ struct matrix;
 void shipfx_emit_spark( int n, int sn );
 
 // Does the special effects to blow a subsystem off a ship
-extern void shipfx_blow_off_subsystem(object *ship_obj,ship *ship_p,ship_subsys *subsys, vec3d *exp_center, bool no_explosion = false);
+extern void shipfx_blow_off_subsystem(object *ship_obj, ship *ship_p, ship_subsys *subsys, vec3d *exp_center, bool no_explosion = false);
 
-// Creates "ndebris" pieces of debris on random verts of the the "submodel" in the 
+// Creates "ndebris" pieces of debris on random verts of the "submodel" in the 
 // ship's model.
-extern void shipfx_blow_up_model(object *obj,int model, int submodel, int ndebris, vec3d *exp_center);
+extern void shipfx_blow_up_model(object *obj, int submodel, int ndebris, vec3d *exp_center);
 
 
 // =================================================

--- a/code/ship/shiphit.cpp
+++ b/code/ship/shiphit.cpp
@@ -562,6 +562,9 @@ float do_subobj_hit_stuff(object *ship_objp, object *other_obj, vec3d *hitpos, i
 		}
 	}
 
+	polymodel_instance *pmi = nullptr;
+	polymodel *pm = nullptr;
+
 	//	First, create a list of the N subsystems within range.
 	//	Then, one at a time, process them in order.
 	int	count = 0;
@@ -597,7 +600,11 @@ float do_subobj_hit_stuff(object *ship_objp, object *other_obj, vec3d *hitpos, i
 				// Special case:
 				// if the subsystem is a turret and the hit submodel is its barrel,
 				// get the distance between the hit and the turret barrel center
-				find_submodel_instance_world_point(&g_subobj_pos, ship_p->model_instance_num, submodel_num, &ship_objp->orient, &ship_objp->pos);
+				if (pmi == nullptr) {
+					pmi = model_get_instance(ship_p->model_instance_num);
+					pm = model_get(pmi->model_num);
+				}
+				find_submodel_instance_world_point(&g_subobj_pos, pm, pmi, submodel_num, &ship_objp->orient, &ship_objp->pos);
 				dist = vm_vec_dist_quick(&hitpos2, &g_subobj_pos);
 
 				// Damage attenuation range of barrel radius * 2 makes full damage
@@ -1150,6 +1157,8 @@ static int choose_next_spark(object *ship_objp, vec3d *hitpos)
 	vec3d world_hitpos[MAX_SHIP_HITS];
 	spark_pair spark_pairs[MAX_SPARK_PAIRS];
 	ship *shipp = &Ships[ship_objp->instance];
+	auto pmi = model_get_instance(shipp->model_instance_num);
+	auto pm = model_get(pmi->model_num);
 
 	// only choose next spark when all slots are full
 	Assert(get_max_sparks(ship_objp) == Ships[ship_objp->instance].num_hits);
@@ -1164,7 +1173,7 @@ static int choose_next_spark(object *ship_objp, vec3d *hitpos)
 	// get the world hitpos for all sparks
 	for (spark_num=0; spark_num<num_sparks; spark_num++) {
 		if (shipp->sparks[spark_num].submodel_num != -1) {
-			model_instance_find_world_point(&world_hitpos[spark_num], &shipp->sparks[spark_num].pos, shipp->model_instance_num, shipp->sparks[spark_num].submodel_num, &ship_objp->orient, &ship_objp->pos);
+			model_instance_find_world_point(&world_hitpos[spark_num], &shipp->sparks[spark_num].pos, pm, pmi, shipp->sparks[spark_num].submodel_num, &ship_objp->orient, &ship_objp->pos);
 		} else {
 			// rotate sparks correctly with current ship orient
 			vm_vec_unrotate(&world_hitpos[spark_num], &shipp->sparks[spark_num].pos, &ship_objp->orient);
@@ -1243,6 +1252,8 @@ static void ship_hit_create_sparks(object *ship_objp, vec3d *hitpos, int submode
 	vec3d	tempv;
 	ship	*shipp = &Ships[ship_objp->instance];
 	ship_info	*sip = &Ship_info[shipp->ship_info_index];
+	polymodel *pm = nullptr;
+	polymodel_instance *pmi = nullptr;
 
 	int n, max_sparks;
 
@@ -1264,21 +1275,22 @@ static void ship_hit_create_sparks(object *ship_objp, vec3d *hitpos, int submode
 	bool instancing = false;
 	// decide whether to do instancing
 	if (submodel_num != -1) {
-		polymodel *pm = model_get(sip->model_num);
+		pm = model_get(sip->model_num);
 		if (pm->detail[0] != submodel_num) {
 			// submodel is not hull
 			// OPTIMIZE ... check if submodel can not rotate
 			instancing = true;
+			pmi = model_get_instance(shipp->model_instance_num);
 		}
 	}
 
 	if (instancing) {
 		// get the hit position in the subobject RF
 		vec3d temp_zero, temp_x, temp_y, temp_z;
-		model_instance_find_world_point(&temp_zero, &vmd_zero_vector, shipp->model_instance_num, submodel_num, &ship_objp->orient, &ship_objp->pos);
-		model_instance_find_world_point(&temp_x, &vmd_x_vector, shipp->model_instance_num, submodel_num, &ship_objp->orient, &ship_objp->pos);
-		model_instance_find_world_point(&temp_y, &vmd_y_vector, shipp->model_instance_num, submodel_num, &ship_objp->orient, &ship_objp->pos);
-		model_instance_find_world_point(&temp_z, &vmd_z_vector, shipp->model_instance_num, submodel_num, &ship_objp->orient, &ship_objp->pos);
+		model_instance_find_world_point(&temp_zero, &vmd_zero_vector, pm, pmi, submodel_num, &ship_objp->orient, &ship_objp->pos);
+		model_instance_find_world_point(&temp_x, &vmd_x_vector, pm, pmi, submodel_num, &ship_objp->orient, &ship_objp->pos);
+		model_instance_find_world_point(&temp_y, &vmd_y_vector, pm, pmi, submodel_num, &ship_objp->orient, &ship_objp->pos);
+		model_instance_find_world_point(&temp_z, &vmd_z_vector, pm, pmi, submodel_num, &ship_objp->orient, &ship_objp->pos);
 
 		// find submodel x,y,z axes
 		vm_vec_sub2(&temp_x, &temp_zero);


### PR DESCRIPTION
More housekeeping changes to the model code, similar to PR #2971, prior to the submodel rotation upgrade.  This reduces the number of model lookups when iterating over submodels and subsystems, which makes collision and rendering code ever so slightly more efficient.  But it's mostly useful for type safety and organization.

This is now ready to review.