### PR TITLE
fix a CTD with the no-pain-flash flag

### DIFF
--- a/code/debris/debris.cpp
+++ b/code/debris/debris.cpp
@@ -203,7 +203,7 @@ void maybe_delete_debris(debris *db)
 {
 	object	*objp;
 
-	if (timestamp_elapsed(db->next_distance_check) && timestamp_elapsed(db->must_survive_until)) {
+	if (Player_obj != nullptr && timestamp_elapsed(db->next_distance_check) && timestamp_elapsed(db->must_survive_until)) {
 		if (!(Game_mode & GM_MULTIPLAYER)) {		//	In single player game, just check against player.
 			if (vm_vec_dist_quick(&Player_obj->pos, &Objects[db->objnum].pos) > MAX_DEBRIS_DIST)
 				db->lifeleft = 0.1f;

--- a/code/ship/shipfx.cpp
+++ b/code/ship/shipfx.cpp
@@ -1990,7 +1990,7 @@ int shipfx_large_blowup_do_frame(ship *shipp, float frametime)
 		if ( !the_split_ship->explosion_flash_started ) {
 			object* objp = &Objects[shipp->objnum];
 			if (objp->flags[Object::Object_Flags::Was_rendered]) {
-				float excess_dist = vm_vec_dist(&Player_obj->pos, &objp->pos) - 2.0f*objp->radius - Player_obj->radius;
+				float excess_dist = (Player_obj == nullptr) ? 0.0f : vm_vec_dist(&Player_obj->pos, &objp->pos) - 2.0f*objp->radius - Player_obj->radius;
 				float intensity = 1.0f - 0.1f*excess_dist / objp->radius;
 
 				if (intensity > 1) {

--- a/code/ship/shiphit.cpp
+++ b/code/ship/shiphit.cpp
@@ -2067,8 +2067,8 @@ static void ship_do_damage(object *ship_objp, object *other_obj, vec3d *hitpos, 
 	// if this is not a laser, or i'm not a multiplayer client
 	// apply pain to me
 
-	// Goober5000: make sure other_obj doesn't cause a read violation!
-	if (other_obj && !(Ship_info[Ships[Player_obj->instance].ship_info_index].flags[Ship::Info_Flags::No_pain_flash]))
+	// check for nulls, check that the player is the one being hit, and check that we're actually doing the pain flash
+	if ((other_obj != nullptr) && (ship_objp == Player_obj) && !(Ship_info[Ships[Player_obj->instance].ship_info_index].flags[Ship::Info_Flags::No_pain_flash]))
 	{
 		// For the record, ship_hit_pain seems to simply be the red flash that appears
 		// on the screen when you're hit.
@@ -2078,7 +2078,7 @@ static void ship_do_damage(object *ship_objp, object *other_obj, vec3d *hitpos, 
 		if (other_obj->type == OBJ_BEAM)
 		{
 			Assert((beam_get_weapon_info_index(other_obj) >= 0) && (beam_get_weapon_info_index(other_obj) < weapon_info_size()));
-			if (((Weapon_info[beam_get_weapon_info_index(other_obj)].subtype != WP_LASER) || special_check) && (Player_obj != NULL) && (ship_objp == Player_obj))
+			if (((Weapon_info[beam_get_weapon_info_index(other_obj)].subtype != WP_LASER) || special_check))
 			{
 				ship_hit_pain(damage * difficulty_scale_factor, quadrant);
 			}	
@@ -2086,12 +2086,12 @@ static void ship_do_damage(object *ship_objp, object *other_obj, vec3d *hitpos, 
 		if (other_obj_is_weapon)
 		{
 			Assert((Weapons[other_obj->instance].weapon_info_index > -1) && (Weapons[other_obj->instance].weapon_info_index < weapon_info_size()));
-			if (((Weapon_info[Weapons[other_obj->instance].weapon_info_index].subtype != WP_LASER) || special_check) && (Player_obj != NULL) && (ship_objp == Player_obj))
+			if (((Weapon_info[Weapons[other_obj->instance].weapon_info_index].subtype != WP_LASER) || special_check))
 			{
 				ship_hit_pain(damage * difficulty_scale_factor, quadrant);
 			}
 		}
-	}	// read violation sanity check
+	}
 
 
 	// If the ship is invulnerable, do nothing


### PR DESCRIPTION
There were null checks for `Player_obj`, but whoever added the `No_pain_flash` flag bypassed them by dereferencing `Player_obj` in the top-level if() block.  This caused a crash when self-destructing ships in the F3 lab.

This PR moves the `Player_obj` check to the top-level block (which is also an implicit null check because `ship_objp` is not null by this point) which fixes the crash and also is more efficient.

EDIT: Added two more null checks for the same reason.