### PR TITLE
fix a bit of improper referencing in rotateTurret

### DIFF
--- a/code/scripting/api/objs/subsystem.cpp
+++ b/code/scripting/api/objs/subsystem.cpp
@@ -630,17 +630,18 @@ ADE_FUNC(rotateTurret, l_Subsystem, "vector Pos, boolean reset=false", "Rotates 
 	vec3d gpos, gvec;
 	model_subsystem *tp = sso->ss->system_info;
 	object *objp = sso->objp;
+	ship *shipp = &Ships[objp->instance];
 
 	//Rotate turret position with ship
-	vm_vec_unrotate(&gpos, &tp->pnt, &sso->objp->orient);
+	vm_vec_unrotate(&gpos, &tp->pnt, &objp->orient);
 
 	//Add turret position to appropriate world space
-	vm_vec_add2(&gpos, &sso->objp->pos);
+	vm_vec_add2(&gpos, &objp->pos);
 
 	// Find direction of turret
-	model_instance_find_world_dir(&gvec, &tp->turret_norm, Ships[objp->instance].model_instance_num, tp->turret_gun_sobj, &objp->orient);
+	model_instance_find_world_dir(&gvec, &tp->turret_norm, shipp->model_instance_num, tp->turret_gun_sobj, &objp->orient);
 
-	int ret_val = model_rotate_gun(Ship_info[(&Ships[sso->objp->instance])->ship_info_index].model_num, tp, &Objects[sso->objp->instance].orient, &sso->ss->submodel_info_1.angs, &sso->ss->submodel_info_2.angs, &Objects[sso->objp->instance].pos, &pos, (&Ships[sso->objp->instance])->objnum, reset);
+	int ret_val = model_rotate_gun(Ship_info[shipp->ship_info_index].model_num, tp, &objp->orient, &sso->ss->submodel_info_1.angs, &sso->ss->submodel_info_2.angs, &objp->pos, &pos, shipp->objnum, reset);
 
 	if (ret_val)
 		return ADE_RETURN_TRUE;
@@ -663,7 +664,7 @@ ADE_FUNC(getTurretHeading, l_Subsystem, NULL, "Returns the turrets forward vecto
 	model_instance_find_world_dir(&gvec, &sso->ss->system_info->turret_norm, Ships[objp->instance].model_instance_num, sso->ss->system_info->turret_gun_sobj, &objp->orient);
 
 	vec3d out;
-	vm_vec_rotate(&out, &gvec, &sso->objp->orient);
+	vm_vec_rotate(&out, &gvec, &objp->orient);
 
 	return ade_set_args(L, "o", l_Vector.Set(out));
 }


### PR DESCRIPTION
The object `instance` field is the index into Ships, not Objects.  In any case, position and orientation can be referenced directly.