### PR TITLE
Build Windows nightlies with GitHub actions

### DIFF
--- a/.github/workflows/build-dist.yaml
+++ b/.github/workflows/build-dist.yaml
@@ -103,7 +103,7 @@ jobs:
     name: Build Linux distribution zip
     needs: build_linux
     runs-on: ubuntu-latest
-    container: ghcr.io/scp-fs2open/sftp_upload:latest
+    container: ghcr.io/scp-fs2open/sftp_upload:sha-dd9d8cf
     steps:
       - uses: actions/checkout@v1
         name: Checkout
@@ -127,6 +127,132 @@ jobs:
           . $GITHUB_WORKSPACE/ci/github/dist_functions.sh
           ls -alR
           tar -cvzf "$(get_package_name)-builds-Linux.tar.gz" *
+          ls -alR
+      - name: Upload result package
+        working-directory: ./builds
+        shell: bash
+        env:
+          INDIEGAMES_SSHPASS: ${{ secrets.INDIEGAMES_PASSWORD }}
+          DATACORDER_SSHPASS: ${{ secrets.DATACORDER_PASSWORD }}
+        run: |
+          . $GITHUB_WORKSPACE/ci/github/dist_functions.sh
+
+          SSHPASS=$INDIEGAMES_SSHPASS upload_files_to_sftp "${{ secrets.INDIEGAMES_USER }}@scp.indiegames.us" "public_html/builds/nightly"
+
+          SSHPASS=$DATACORDER_SSHPASS upload_files_to_sftp "${{ secrets.DATACORDER_USER }}@porphyrion.feralhosting.com" "/www/datacorder.porphyrion.feralhosting.com/public_html/builds/nightly"
+
+  build_windows:
+    strategy:
+      matrix:
+        configuration: [FastDebug, Release]
+        arch: [Win32, x64]
+        simd: [SSE2]
+    name: Windows
+    runs-on: windows-2019
+    steps:
+      - uses: actions/checkout@v1
+        name: Checkout
+        with:
+          submodules: true
+      - name: Cache Qt
+        id: cache-qt-win
+        uses: actions/cache@v1
+        with:
+          path: ${{ github.workspace }}/../Qt
+          key: ${{ runner.os }}-${{ matrix.arch }}-QtCache-${{ env.QT_VERSION }}
+      - name: Install Qt (32 bit)
+        uses: jurplel/install-qt-action@v2
+        if: ${{ matrix.arch == 'Win32' }}
+        with:
+          version: ${{ env.QT_VERSION }}
+          dir: ${{ github.workspace }}/..
+          arch: win32_msvc2017
+          cached: ${{ steps.cache-qt-win.outputs.cache-hit }}
+          aqtversion: ==0.8
+      - name: Install Qt (64 bit)
+        uses: jurplel/install-qt-action@v2
+        if: ${{ matrix.arch == 'x64' }}
+        with:
+          version: ${{ env.QT_VERSION }}
+          dir: ${{ github.workspace }}/..
+          arch: win64_msvc2017_64
+          cached: ${{ steps.cache-qt-win.outputs.cache-hit }}
+          aqtversion: ==0.8
+
+      - name: Configure CMake
+        env:
+          CONFIGURATION: ${{ matrix.configuration }}
+          ARCHITECTURE: ${{ matrix.arch }}
+          SIMD: ${{ matrix.simd }}
+        shell: bash
+        run: |
+          mkdir build
+          cd build
+
+          cmake -DCMAKE_INSTALL_PREFIX="$(pwd)/install" -DFSO_USE_SPEECH="ON" \
+            -DFSO_USE_VOICEREC="ON" -DMSVC_SIMD_INSTRUCTIONS="$SIMD" \
+            -DFSO_BUILD_QTFRED=ON -DFSO_BUILD_TESTS=ON \
+            -DFSO_INSTALL_DEBUG_FILES="ON" -A "$ARCHITECTURE" \
+            -G "Visual Studio 16 2019" -T "v142" ..
+      - name: Compile
+        working-directory: ./build
+        env:
+          CONFIGURATION: ${{ matrix.configuration }}
+          COMPILER: ${{ matrix.compiler }}
+        shell: bash
+        run: |
+          cmake --build . --config "$CONFIGURATION" --target INSTALL -- /verbosity:minimal
+          ls -alR "$(pwd)/install"
+      - name: Run Tests
+        working-directory: ./build
+        env:
+          CONFIGURATION: ${{ matrix.configuration }}
+        shell: bash
+        run: ./bin/$CONFIGURATION/unittests --gtest_shuffle
+      - name: Upload build result
+        uses: actions/upload-artifact@v2
+        with:
+          name: windows-${{ matrix.configuration }}-${{ matrix.arch }}-${{ matrix.simd }}
+          path: ${{ github.workspace }}/build/install/*
+  windows_zip:
+    name: Build Windows distribution zip
+    needs: build_windows
+    runs-on: ubuntu-latest
+    container: ghcr.io/scp-fs2open/sftp_upload:sha-dd9d8cf
+    strategy:
+      matrix:
+        arch: [Win32, x64]
+        simd: [SSE2]
+    steps:
+      - uses: actions/checkout@v1
+        name: Checkout
+        with:
+          submodules: true
+          fetch-depth: '0'
+      - name: Download Release builds
+        uses: actions/download-artifact@v1
+        with:
+          name: windows-Release-${{ matrix.arch }}-${{ matrix.simd }}
+          path: builds
+      - name: Download FastDebug builds
+        uses: actions/download-artifact@v2
+        with:
+          name: windows-FastDebug-${{ matrix.arch }}-${{ matrix.simd }}
+          path: builds
+      - name: Create Distribution package
+        working-directory: ./builds
+        shell: bash
+        env:
+          ARCH: ${{ matrix.arch }}
+          SIMD: ${{ matrix.simd }}
+        run: |
+          . $GITHUB_WORKSPACE/ci/github/dist_functions.sh
+          ls -alR
+
+          7z a -xr'!*.pdb' "$(get_package_name)-builds-$ARCH-$SIMD.zip" "*"
+
+          7z a "$(get_package_name)-debug-$ARCH-$SIMD.7z" "*.pdb"
+
           ls -alR
       - name: Upload result package
         working-directory: ./builds

--- a/ci/appveyor/build.ps1
+++ b/ci/appveyor/build.ps1
@@ -9,22 +9,22 @@ class BuildConfig {
 }
 
 $NightlyConfigurations = @(
-	[BuildConfig]@{ 
-		Generator="Visual Studio 14 2015 Win64";
-		PackageType="Win64";
-		Toolset="v140";
-		SimdType="SSE2";
-		QtDir="C:\Qt\5.9\msvc2015_64";
-		SourcePackage=$false;
-	},
-	[BuildConfig]@{ 
-		Generator="Visual Studio 14 2015";
-		PackageType="Win32";
-		Toolset="v140";
-		SimdType="SSE2";
-		QtDir="C:\Qt\5.9\msvc2015";
-		SourcePackage=$false;
-	}
+#	[BuildConfig]@{
+#		Generator="Visual Studio 14 2015 Win64";
+#		PackageType="Win64";
+#		Toolset="v140";
+#		SimdType="SSE2";
+#		QtDir="C:\Qt\5.9\msvc2015_64";
+#		SourcePackage=$false;
+#	},
+#	[BuildConfig]@{
+#		Generator="Visual Studio 14 2015";
+#		PackageType="Win32";
+#		Toolset="v140";
+#		SimdType="SSE2";
+#		QtDir="C:\Qt\5.9\msvc2015";
+#		SourcePackage=$false;
+#	}
 )
 $ReleaseConfigurations = @(
 	[BuildConfig]@{

--- a/ci/github/dist_functions.sh
+++ b/ci/github/dist_functions.sh
@@ -28,7 +28,7 @@ function upload_files_to_sftp() {
   sshpass -e sftp -oBatchMode=no -o "StrictHostKeyChecking no" -b sftp_batch $1 || true
 
   echo "cd $2/$(get_version_name)/" > sftp_batch
-  for file in *.tar.gz; do
+  for file in {*.tar.gz, *.7z}; do
     echo "put $file" >> sftp_batch
   done
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -3,6 +3,8 @@ set(gtest_force_shared_crt "${MSVC_USE_RUNTIME_DLL}" CACHE BOOL "Always use msvc
 
 add_subdirectory(gtest)
 
+target_compile_definitions(gtest PUBLIC "$<$<CONFIG:FastDebug>:_ITERATOR_DEBUG_LEVEL=0>")
+
 set_target_properties(gtest PROPERTIES FOLDER "3rdparty")
 
 add_subdirectory(src)


### PR DESCRIPTION
This is much faster since all build variations can be compiled at the
same time. Only applies to nightly builds for now.