### PR TITLE
In windows, attach to the console we're being evoked from and reopen STDIO streams.

### DIFF
--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -7535,6 +7535,15 @@ int main(int argc, char *argv[])
 	::CoInitialize(nullptr);
 
 	SCP_mspdbcs_Initialise();
+
+	// If we're being evoked from a console, attach the STDIO streams to it and reopen the streams
+	// This is needed because Windows assumes SUBSYSTEM:WINDOWS programs won't need console IO.  Additionally, SDL
+	// seems to close or otherwise grab the streams for somthing else.
+	if (AttachConsole(ATTACH_PARENT_PROCESS)) {
+		freopen("CONIN$", "r", stdin);
+		freopen("CONOUT$", "w", stdout);
+		freopen("CONOUT$", "w", stderr);
+	}
 #else
 #ifdef APPLE_APP
     char pathbuf[PROC_PIDPATHINFO_MAXSIZE];


### PR DESCRIPTION
Fixes #2966 

This needs some avid testing from other folks to ensure there's no side effects.  I'm not sure how SDL handles its error and debug outputs, so its possible this change may affect them.

Based on: [https://stackoverflow.com/questions/34539135/how-do-i-print-to-the-console-while-an-sdl-2-program-is-running](url)