### PR TITLE
consolidate model instance code

### DIFF
--- a/code/ai/aibig.cpp
+++ b/code/ai/aibig.cpp
@@ -384,6 +384,7 @@ int ai_big_maybe_follow_subsys_path(int do_dot_check)
 
 		// Get models of both source and target
 		polymodel *pm = model_get( Ship_info[shipp->ship_info_index].model_num );
+		polymodel_instance *pmi = model_get_instance( shipp->model_instance_num );
 		polymodel *pm_t = model_get( Ship_info[Ships[target_objp->instance].ship_info_index].model_num );
 
 		// Necessary sanity check
@@ -405,7 +406,7 @@ int ai_big_maybe_follow_subsys_path(int do_dot_check)
 
 			// get world pos of eye (stored in geye)
 			ep = &(pm->view_positions[shipp->current_viewpoint]);
-			model_find_world_point( &geye, &ep->pnt, pm, 0, &Pl_objp->orient, &Pl_objp->pos );
+			model_instance_find_world_point( &geye, &ep->pnt, pm, pmi, 0, &Pl_objp->orient, &Pl_objp->pos );
 			
 			// get world pos of subsystem
 			vm_vec_unrotate(&gsubpos, &aip->targeted_subsys->system_info->pnt, &En_objp->orient);

--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -9354,10 +9354,7 @@ float dock_orient_and_approach(object *docker_objp, int docker_index, object *do
 		polymodel_instance *pmi1 = model_get_instance(Ships[dockee_objp->instance].model_instance_num);
 
 		// get angular velocity of dockpoint
-		//WMC - hack(?) to fix bug where sii might not exist
-		if ( pmi1->submodel[dockee_rotating_submodel].sii != NULL ) {
-			submodel_omega = pmi1->submodel[dockee_rotating_submodel].sii->current_turn_rate;
-		}
+		submodel_omega = pmi1->submodel[dockee_rotating_submodel].current_turn_rate;
 
 		// get radius to dockpoint
 		submodel_radius = vm_vec_dist(&submodel_pos, &dockee_point);

--- a/code/ai/aiturret.cpp
+++ b/code/ai/aiturret.cpp
@@ -1438,8 +1438,8 @@ int aifft_rotate_turret(ship *shipp, int parent_objnum, ship_subsys *ss, object 
 				in_fov = is_object_radius_in_turret_fov(&Objects[ss->turret_enemy_objnum], ss, gvec, &gun_pos, &v2e, predicted_enemy_pos, 0.0f);
 		}
 
-		auto base_angles = &ss->submodel_info_1.angs;
-		auto gun_angles = &ss->submodel_info_2.angs;
+		auto base_angles = &ss->submodel_instance_1->angs;
+		auto gun_angles = &ss->submodel_instance_2->angs;
 		if (in_fov) {
 			ret_val = model_rotate_gun(pm,
 										tp, &Objects[parent_objnum].orient, 
@@ -1449,8 +1449,8 @@ int aifft_rotate_turret(ship *shipp, int parent_objnum, ship_subsys *ss, object 
 			ret_val = model_rotate_gun(pm, tp, &Objects[parent_objnum].orient, base_angles, gun_angles, &Objects[parent_objnum].pos, predicted_enemy_pos, shipp->objnum, true);
 		}
 	} else if ((ss->system_info->flags[Model::Subsystem_Flags::Turret_reset_idle]) && (timestamp_elapsed(ss->rotation_timestamp))) {
-		auto base_angles = &ss->submodel_info_1.angs;
-		auto gun_angles = &ss->submodel_info_2.angs;
+		auto base_angles = &ss->submodel_instance_1->angs;
+		auto gun_angles = &ss->submodel_instance_2->angs;
 		ret_val = model_rotate_gun(pm, ss->system_info, &Objects[parent_objnum].orient, base_angles, gun_angles, &Objects[parent_objnum].pos, predicted_enemy_pos, shipp->objnum, true);
 	}
 
@@ -2253,8 +2253,9 @@ void ai_fire_from_turret(ship *shipp, ship_subsys *ss, int parent_objnum)
 	{
 		if (!(tp->turret_gun_sobj == tp->subobj_num))
 		{
-			auto pm = model_get(Ship_info[shipp->ship_info_index].model_num);
-			model_make_turret_matrix(pm, tp);
+			auto pmi = model_get_instance(shipp->model_instance_num);
+			auto pm = model_get(pmi->model_num);
+			model_make_turret_matrix(pm, pmi, tp);
 		}
 	}
 

--- a/code/asteroid/asteroid.cpp
+++ b/code/asteroid/asteroid.cpp
@@ -929,7 +929,6 @@ int asteroid_check_collision(object *pasteroid, object *other_obj, vec3d *hitpos
 		Assert( other_obj->type == OBJ_WEAPON );
 		mc.model_instance_num = Asteroids[num].model_instance_num;
 		mc.model_num = Asteroid_info[Asteroids[num].asteroid_type].model_num[asteroid_subtype];	// Fill in the model to check
-		model_clear_instance( mc.model_num );
 		mc.orient = &pasteroid->orient;					// The object's orient
 		mc.pos = &pasteroid->pos;							// The object's position
 		mc.p0 = &other_obj->last_pos;				// Point 1 of ray to check
@@ -943,7 +942,11 @@ int asteroid_check_collision(object *pasteroid, object *other_obj, vec3d *hitpos
 			if (hitnormal)
 			{
 				vec3d normal;
-				model_find_world_dir(&normal, &mc.hit_normal, mc.model_num, mc.hit_submodel, mc.orient);
+
+				if (mc.model_instance_num >= 0)
+					model_instance_find_world_dir(&normal, &mc.hit_normal, mc.model_instance_num, mc.hit_submodel, mc.orient);
+				else
+					model_find_world_dir(&normal, &mc.hit_normal, mc.model_num, mc.hit_submodel, mc.orient);
 
 				*hitnormal = normal;
 			}
@@ -1114,7 +1117,6 @@ int asteroid_check_collision(object *pasteroid, object *other_obj, vec3d *hitpos
 		// Asteroid is heavier obj
 		mc.model_instance_num = Asteroids[num].model_instance_num;
 		mc.model_num = Asteroid_info[Asteroids[num].asteroid_type].model_num[asteroid_subtype];		// Fill in the model to check
-		model_clear_instance( mc.model_num );
 		mc.orient = &pasteroid->orient;				// The object's orient
 		mc.radius = model_get_core_radius(Ship_info[Ships[pship_obj->instance].ship_info_index].model_num);
 

--- a/code/debris/debris.cpp
+++ b/code/debris/debris.cpp
@@ -776,7 +776,6 @@ int debris_check_collision(object *pdebris, object *other_obj, vec3d *hitpos, co
 		mc.model_instance_num = -1;
 		mc.model_num = Debris[num].model_num;	// Fill in the model to check
 		mc.submodel_num = Debris[num].submodel_num;
-		model_clear_instance( mc.model_num );
 		mc.orient = &pdebris->orient;					// The object's orient
 		mc.pos = &pdebris->pos;							// The object's position
 		mc.p0 = &other_obj->last_pos;				// Point 1 of ray to check
@@ -789,7 +788,11 @@ int debris_check_collision(object *pdebris, object *other_obj, vec3d *hitpos, co
 			if (hitNormal)
 			{
 				vec3d normal;
-				model_find_world_dir(&normal, &mc.hit_normal, mc.model_num, mc.hit_submodel, mc.orient);
+
+				if (mc.model_instance_num >= 0)
+					model_instance_find_world_dir(&normal, &mc.hit_normal, mc.model_instance_num, mc.hit_submodel, mc.orient);
+				else
+					model_find_world_dir(&normal, &mc.hit_normal, mc.model_num, mc.hit_submodel, mc.orient);
 
 				*hitNormal = normal;
 			}
@@ -965,7 +968,6 @@ int debris_check_collision(object *pdebris, object *other_obj, vec3d *hitpos, co
 		mc.model_instance_num = -1;
 		mc.model_num = Debris[num].model_num;		// Fill in the model to check
 		mc.submodel_num = Debris[num].submodel_num;
-		model_clear_instance( mc.model_num );
 		mc.orient = &pdebris->orient;				// The object's orient
 		mc.radius = model_get_core_radius(Ship_info[Ships[pship_obj->instance].ship_info_index].model_num);
 

--- a/code/decals/decals.cpp
+++ b/code/decals/decals.cpp
@@ -401,11 +401,14 @@ matrix4 getDecalTransform(Decal& decal) {
 
 	auto objp = decal.object.objp;
 	auto ship = &Ships[objp->instance];
+	auto pmi = model_get_instance(ship->model_instance_num);
+	auto pm = model_get(pmi->model_num);
 
 	vec3d worldPos;
 	model_instance_find_world_point(&worldPos,
 									&decal.position,
-									ship->model_instance_num,
+									pm,
+									pmi,
 									decal.submodel,
 									&objp->orient,
 									&objp->pos);
@@ -413,14 +416,16 @@ matrix4 getDecalTransform(Decal& decal) {
 	vec3d worldDir;
 	model_instance_find_world_dir(&worldDir,
 								  &decal.orientation.vec.fvec,
-								  ship->model_instance_num,
+								  pm,
+								  pmi,
 								  decal.submodel,
 								  &objp->orient);
 
 	vec3d worldUp;
 	model_instance_find_world_dir(&worldUp,
 								  &decal.orientation.vec.fvec,
-								  ship->model_instance_num,
+								  pm,
+								  pmi,
 								  decal.submodel,
 								  &objp->orient);
 

--- a/code/hud/hudtarget.cpp
+++ b/code/hud/hudtarget.cpp
@@ -2513,8 +2513,6 @@ void hud_target_in_reticle_new()
 			}
 
 		} else {
-
-			model_clear_instance( mc.model_num );
 			mc.orient = &A->orient;										// The object's orient
 			mc.pos = &A->pos;												// The object's position
 			mc.p0 = &Eye_position;										// Point 1 of ray to check

--- a/code/hud/hudtarget.cpp
+++ b/code/hud/hudtarget.cpp
@@ -7271,7 +7271,6 @@ void HudGaugeHardpoints::render(float  /*frametime*/)
 				} else {
 					polymodel* pm = model_get(Weapon_info[swp->primary_bank_weapons[i]].external_model_num);
 
-
 					model_render_params weapon_render_info;
 					weapon_render_info.set_detail_level_lock(detail_level_lock);
 					weapon_render_info.set_flags(render_flags);

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -2320,7 +2320,7 @@ int parse_create_object_sub(p_object *p_objp)
 			if ((100.0f - sssp->percent) < 0.5)
 			{
 				ptr->current_hits = 0.0f;
-				ptr->submodel_info_1.blown_off = true;
+				ptr->submodel_instance_1->blown_off = true;
 			}
 			else
 			{

--- a/code/missionui/redalert.cpp
+++ b/code/missionui/redalert.cpp
@@ -624,7 +624,7 @@ void red_alert_bash_subsys_status(red_alert_ship_status *ras, ship *shipp)
 		}
 
 		if (ss->current_hits <= 0) {
-			ss->submodel_info_1.blown_off = true;
+			ss->submodel_instance_1->blown_off = true;
 		}
 
 		ss = GET_NEXT( ss );

--- a/code/model/modelanim.cpp
+++ b/code/model/modelanim.cpp
@@ -417,7 +417,7 @@ void model_anim_submodel_trigger_rotate(model_subsystem *psub, ship_subsys *ss)
 	}
 
 	triggered_rotation *trigger = &Triggered_rotations[ss->triggered_rotation_index];
-	submodel_instance_info *sii = &ss->submodel_info_1;	
+	submodel_instance *smi = ss->submodel_instance_1;	
 	int not_moving_count = 0;
 
 	if ( psub->model_num < 0 ) {
@@ -434,7 +434,7 @@ void model_anim_submodel_trigger_rotate(model_subsystem *psub, ship_subsys *ss)
 		return;
 
 	// save last angles
-	sii->prev_angs = sii->angs;
+	smi->prev_angs = smi->angs;
 
 	// process velocity and position
 	// first you accelerate, then you maintain a speed, then you slow down, then you stay put
@@ -512,29 +512,29 @@ void model_anim_submodel_trigger_rotate(model_subsystem *psub, ship_subsys *ss)
 
 	// objects can be animated along several axes at the same time
 	// I'm prety sure using the magnitude of the vectors is at least pretty close for any code that might be using it
-	sii->current_turn_rate = vm_vec_mag(&trigger->current_vel);
-	sii->desired_turn_rate = vm_vec_mag(&trigger->rot_vel);
-	sii->turn_accel = vm_vec_mag(&trigger->rot_accel);
+	smi->current_turn_rate = vm_vec_mag(&trigger->current_vel);
+	smi->desired_turn_rate = vm_vec_mag(&trigger->rot_vel);
+	smi->turn_accel = vm_vec_mag(&trigger->rot_accel);
 
 	// the extra math here is/was useless, it just returns the exact same value (or really just 0 in the old code)
-	sii->angs.p = trigger->current_ang.xyz.x; //- (2.0f * PI2 * (trigger->current_ang.xyz.x / (2.0f * PI2)));
-	sii->angs.h = trigger->current_ang.xyz.y; //- (2.0f * PI2 * (trigger->current_ang.xyz.y / (2.0f * PI2)));
-	sii->angs.b = trigger->current_ang.xyz.z; //- (2.0f * PI2 * (trigger->current_ang.xyz.z / (2.0f * PI2)));
+	smi->angs.p = trigger->current_ang.xyz.x; //- (2.0f * PI2 * (trigger->current_ang.xyz.x / (2.0f * PI2)));
+	smi->angs.h = trigger->current_ang.xyz.y; //- (2.0f * PI2 * (trigger->current_ang.xyz.y / (2.0f * PI2)));
+	smi->angs.b = trigger->current_ang.xyz.z; //- (2.0f * PI2 * (trigger->current_ang.xyz.z / (2.0f * PI2)));
 
-	if (sii->angs.p >= PI2)
-		sii->angs.p -= PI2;
-	else if (sii->angs.p < 0.0f)
-		sii->angs.p += PI2;
+	if (smi->angs.p >= PI2)
+		smi->angs.p -= PI2;
+	else if (smi->angs.p < 0.0f)
+		smi->angs.p += PI2;
 
-	if (sii->angs.h >= PI2)
-		sii->angs.h -= PI2;
-	else if (sii->angs.h < 0.0f)
-		sii->angs.h += PI2;
+	if (smi->angs.h >= PI2)
+		smi->angs.h -= PI2;
+	else if (smi->angs.h < 0.0f)
+		smi->angs.h += PI2;
 
-	if (sii->angs.b >= PI2)
-		sii->angs.b -= PI2;
-	else if (sii->angs.b < 0.0f)
-		sii->angs.b += PI2;
+	if (smi->angs.b >= PI2)
+		smi->angs.b -= PI2;
+	else if (smi->angs.b < 0.0f)
+		smi->angs.b += PI2;
 }
 
 //************************************//
@@ -595,7 +595,7 @@ bool model_anim_start_type(ship_subsys *pss, AnimationTriggerType animation_type
 			// rotate instantly; don't use the queue
 			if (instant) {
 				trigger->set_to_final(&psub->triggers[i]);
-				trigger->apply_trigger_angles(&pss->submodel_info_1.angs);
+				trigger->apply_trigger_angles(&pss->submodel_instance_1->angs);
 
 				retval = true;
 			}
@@ -868,8 +868,8 @@ void model_anim_set_initial_states(ship *shipp)
 			if (psub->triggers[i].type == AnimationTriggerType::Initial) {
 				if (psub->type == SUBSYSTEM_TURRET) {
 					// special case for turrets
-					pss->submodel_info_2.angs.p = psub->triggers[i].angle.xyz.x;
-					pss->submodel_info_1.angs.h = psub->triggers[i].angle.xyz.y;
+					pss->submodel_instance_2->angs.p = psub->triggers[i].angle.xyz.x;
+					pss->submodel_instance_1->angs.h = psub->triggers[i].angle.xyz.y;
 				} else {
 					if (pss->triggered_rotation_index < 0) {
 						mprintf(("Invalid rotation index for triggered rotation in subsystem %s in model %s!\n", psub->name, model_get(Ship_info[shipp->ship_info_index].model_num)->filename));
@@ -878,7 +878,7 @@ void model_anim_set_initial_states(ship *shipp)
 					triggered_rotation *tr = &Triggered_rotations[pss->triggered_rotation_index];
 
 					tr->set_to_initial(&psub->triggers[i]);
-					tr->apply_trigger_angles(&pss->submodel_info_1.angs);
+					tr->apply_trigger_angles(&pss->submodel_instance_1->angs);
 				}
 			}
 		}

--- a/code/model/modelcollide.cpp
+++ b/code/model/modelcollide.cpp
@@ -1180,8 +1180,8 @@ NoHit:
 			blown_off = Mc_pmi->submodel[i].blown_off;
 			collision_checked = Mc_pmi->submodel[i].collision_checked;
 		} else {
-			angs = csm->angs;
-			blown_off = csm->blown_off;
+			angs = vmd_zero_angles;
+			blown_off = false;
 			collision_checked = false;
 		}
 
@@ -1330,9 +1330,7 @@ int model_collide(mc_info *mc_info_obj)
 				mc_check_subobj(Mc_pm->detail[0]);
 			}
 		} else {
-			if ( !Mc_pm->submodel[Mc_pm->detail[0]].blown_off ) {
-				mc_check_subobj(Mc_pm->detail[0]);
-			}
+			mc_check_subobj(Mc_pm->detail[0]);
 		}
 	}
 
@@ -1397,12 +1395,11 @@ void model_collide_preprocess_subobj(vec3d *pos, matrix *orient, polymodel *pm, 
 	}
 }
 
-void model_collide_preprocess(matrix *orient, int model_instance_num, int detail_num)
+void model_collide_preprocess(matrix *orient, polymodel *pm, polymodel_instance *pmi, int detail_num)
 {
 	matrix current_orient;
 	vec3d current_pos;
-	auto pmi = model_get_instance(model_instance_num);
-	auto pm = model_get(pmi->model_num);
+	Assert(pm->id == pmi->model_num);
 
 	current_orient = *orient;
 

--- a/code/model/modelread.cpp
+++ b/code/model/modelread.cpp
@@ -4454,6 +4454,7 @@ void model_instance_find_world_dir(vec3d *out_dir, const vec3d *in_dir, const po
 // Clears all the submodel instances stored in a model to their defaults.
 void model_clear_instance(int model_num)
 {
+	// ---- stuff that should be moved into model instances at some point
 	int i;
 	auto pm = model_get(model_num);
 
@@ -4467,6 +4468,7 @@ void model_clear_instance(int model_num)
 	for (i=0; i<pm->n_models; i++ )	{
 		pm->submodel[i].num_arcs = 0;		// Turn off any electric arcing effects
 	}
+	// ---- end of stuff that should be moved into model instances at some point
 
 	interp_clear_instance();
 }

--- a/code/network/multi_obj.cpp
+++ b/code/network/multi_obj.cpp
@@ -1312,8 +1312,12 @@ int multi_oo_pack_data(net_player *pl, object *objp, ushort oo_flags, ubyte *dat
 
 			// retrieve the submodel for rotation info.
 			if (subsystem->system_info->flags[Model::Subsystem_Flags::Rotates, Model::Subsystem_Flags::Dum_rotates]) {
-				angles *angs_1 = &subsystem->submodel_info_1.angs;
-				angles *angs_2 = &subsystem->submodel_info_2.angs;
+				angles *angs_1 = nullptr;
+				angles *angs_2 = nullptr;
+				if (subsystem->submodel_instance_1)
+					angs_1 = &subsystem->submodel_instance_1->angs;
+				if (subsystem->submodel_instance_2)
+					angs_2 = &subsystem->submodel_instance_2->angs;
 
 				// here we're checking to see if the subsystems rotated enough to send.
 				if (angs_1 != nullptr && angs_1->b != Oo_info.player_frame_info[pl->player_id].last_sent[objp->net_signature].subsystem_1b[i]) {
@@ -1915,10 +1919,18 @@ int multi_oo_unpack_data(net_player* pl, ubyte* data, int seq_num)
 					data_idx++;
 				}
 
-				angles *prev_angs_1 = &subsysp->submodel_info_1.prev_angs;
-				angles *prev_angs_2 = &subsysp->submodel_info_2.prev_angs;
-				angles *angs_1 = &subsysp->submodel_info_1.angs;
-				angles *angs_2 = &subsysp->submodel_info_2.angs;
+				angles *prev_angs_1 = nullptr;
+				angles *prev_angs_2 = nullptr;
+				angles *angs_1 = nullptr;
+				angles *angs_2 = nullptr;
+				if (subsysp->submodel_instance_1) {
+					prev_angs_1 = &subsysp->submodel_instance_1->prev_angs;
+					angs_1 = &subsysp->submodel_instance_1->angs;
+				}
+				if (subsysp->submodel_instance_2) {
+					prev_angs_2 = &subsysp->submodel_instance_2->prev_angs;
+					angs_2 = &subsysp->submodel_instance_2->angs;
+				}
 
 				if (flags[i] & OO_SUBSYS_ROTATION_1b) {
 					prev_angs_1->b = angs_1->b;

--- a/code/network/multimsgs.cpp
+++ b/code/network/multimsgs.cpp
@@ -3261,9 +3261,9 @@ void send_turret_fired_packet( int ship_objnum, int subsys_index, int weapon_obj
 		ADD_USHORT( objp->net_signature );
 	}
 	ADD_DATA( cindex );
-	val = (short)ssp->submodel_info_1.angs.h;
+	val = (short)ssp->submodel_instance_1->angs.h;
 	ADD_SHORT( val );
-	val = (short)ssp->submodel_info_2.angs.p;
+	val = (short)ssp->submodel_instance_2->angs.p;
 	ADD_SHORT( val );	
 	
 	multi_io_send_to_all(data, packet_size);
@@ -3334,8 +3334,8 @@ void process_turret_fired_packet( ubyte *data, header *hinfo )
 		return;
 
 	// bash the position and orientation of the turret
-	ssp->submodel_info_1.angs.h = (float)heading;
-	ssp->submodel_info_2.angs.p = (float)pitch;
+	ssp->submodel_instance_1->angs.h = (float)heading;
+	ssp->submodel_instance_2->angs.p = (float)pitch;
 
 	// get the world position of the weapon
 	ship_get_global_turret_info(objp, ssp->system_info, &pos, &temp);
@@ -8293,9 +8293,9 @@ void send_flak_fired_packet(int ship_objnum, int subsys_index, int weapon_objnum
 	packet_size += multi_pack_unpack_position(1, data + packet_size, &objp->orient.vec.fvec);	
 	ADD_USHORT( pnet_signature );		
 	ADD_DATA( cindex );
-	val = (short)ssp->submodel_info_1.angs.h;
+	val = (short)ssp->submodel_instance_1->angs.h;
 	ADD_SHORT( val );
-	val = (short)ssp->submodel_info_2.angs.p;
+	val = (short)ssp->submodel_instance_2->angs.p;
 	ADD_SHORT( val );	
 	ADD_FLOAT( flak_range );
 	
@@ -8362,8 +8362,8 @@ void process_flak_fired_packet(ubyte *data, header *hinfo)
 	}
 
 	// bash the position and orientation of the turret
-	ssp->submodel_info_1.angs.h = (float)heading;
-	ssp->submodel_info_2.angs.p = (float)pitch;
+	ssp->submodel_instance_1->angs.h = (float)heading;
+	ssp->submodel_instance_2->angs.p = (float)pitch;
 
 	// get the world position of the weapon
 	ship_get_global_turret_info(objp, ssp->system_info, &pos, &dir);

--- a/code/object/collideshipship.cpp
+++ b/code/object/collideshipship.cpp
@@ -572,12 +572,12 @@ void calculate_ship_ship_collision_physics(collision_info_struct *ship_ship_hit_
 			pm = NULL;
 		}
 		
-		if ( pmi != NULL && pmi->submodel[ship_ship_hit_info->submodel_num].sii != NULL ) {
+		if ( pmi != nullptr ) {
 			auto smi = &pmi->submodel[ship_ship_hit_info->submodel_num];
 
 			// set point on axis of rotating submodel if not already set.
-			if ( !smi->sii->axis_set ) {
-				model_init_submodel_axis_pt(smi->sii, pm, ship_ship_hit_info->submodel_num);
+			if ( !smi->axis_set ) {
+				model_init_submodel_axis_pt(pm, pmi, ship_ship_hit_info->submodel_num);
 			}
 
 			vec3d omega, axis, r_rot;
@@ -595,11 +595,11 @@ void calculate_ship_ship_collision_physics(collision_info_struct *ship_ship_hit_
 			// get world rotational velocity of rotating submodel
 			model_instance_find_obj_dir(&omega, &axis, pm, pmi, ship_ship_hit_info->submodel_num, &heavy->orient);
 
-			vm_vec_scale(&omega, smi->sii->current_turn_rate);
+			vm_vec_scale(&omega, smi->current_turn_rate);
 
 			// world coords for r_rot
 			vec3d temp;
-			vm_vec_unrotate(&temp, &smi->sii->point_on_axis, &heavy->orient);
+			vm_vec_unrotate(&temp, &smi->point_on_axis, &heavy->orient);
 			vm_vec_sub(&r_rot, &ship_ship_hit_info->hit_pos, &temp);
 
 			vm_vec_cross(&local_vel_from_submodel, &omega, &r_rot);

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -12685,7 +12685,11 @@ void set_subsys_strength_and_maybe_ancestors(ship *shipp, ship_subsys *ss, polym
 	Assertion(shipp != nullptr && ss != nullptr, "Ship and subsys must not be null!");
 	Assertion(assign_percent != nullptr || repair_percent != nullptr || sabotage_percent != nullptr, "Either assign_percent or repair_percent or sabotage_percent must not be null!");
 
-	bool originally_zero = (ss->current_hits <= 0 || ss->submodel_info_1.blown_off || ss->submodel_info_2.blown_off);
+	bool originally_zero = (ss->current_hits <= 0);
+	if (ss->submodel_instance_1 && ss->submodel_instance_1->blown_off)
+		originally_zero = true;
+	if (ss->submodel_instance_2 && ss->submodel_instance_2->blown_off)
+		originally_zero = true;
 
 	if (assign_percent != nullptr)
 	{
@@ -12731,8 +12735,10 @@ void set_subsys_strength_and_maybe_ancestors(ship *shipp, ship_subsys *ss, polym
 	// and now see if we are repairing from zero
 	if (originally_zero && ss->current_hits > 0 && do_submodel_repair)
 	{
-		ss->submodel_info_1.blown_off = false;
-		ss->submodel_info_2.blown_off = false;
+		if (ss->submodel_instance_1)
+			ss->submodel_instance_1->blown_off = false;
+		if (ss->submodel_instance_2)
+			ss->submodel_instance_2->blown_off = false;
 
 		// see if we are handling ancestors and if this subsystem has a submodel
 		int subobj = ss->system_info->subobj_num;
@@ -12751,8 +12757,14 @@ void set_subsys_strength_and_maybe_ancestors(ship *shipp, ship_subsys *ss, polym
 					// found parent?
 					if (parent_ss->system_info->subobj_num == parent_subobj)
 					{
+						bool parent_destroyed = (parent_ss->current_hits <= 0);
+						if (parent_ss->submodel_instance_1 && parent_ss->submodel_instance_1->blown_off)
+							parent_destroyed = true;
+						if (parent_ss->submodel_instance_2 && parent_ss->submodel_instance_2->blown_off)
+							parent_destroyed = true;
+
 						// if the parent subobject was destroyed...
-						if (parent_ss->current_hits <= 0 || parent_ss->submodel_info_1.blown_off || parent_ss->submodel_info_2.blown_off)
+						if (parent_destroyed)
 						{
 							// ...repair the parent in the same way
 							set_subsys_strength_and_maybe_ancestors(shipp, parent_ss, pm, assign_percent, repair_percent, sabotage_percent, do_submodel_repair, repair_ancestors);
@@ -17626,8 +17638,10 @@ void ship_copy_damage(ship *target_shipp, ship *source_shipp)
 		// copy
 		target_ss->max_hits = source_ss->max_hits;
 		target_ss->current_hits = source_ss->current_hits;
-		target_ss->submodel_info_1.blown_off = source_ss->submodel_info_1.blown_off;
-		target_ss->submodel_info_2.blown_off = source_ss->submodel_info_2.blown_off;
+		if (target_ss->submodel_instance_1 && source_ss->submodel_instance_1)
+			target_ss->submodel_instance_1->blown_off = source_ss->submodel_instance_1->blown_off;
+		if (target_ss->submodel_instance_2 && source_ss->submodel_instance_2)
+			target_ss->submodel_instance_2->blown_off = source_ss->submodel_instance_2->blown_off;
 	}
 }
 
@@ -18947,13 +18961,13 @@ void sexp_reverse_rotating_subsystem(int node)
 	{
 		// get the rotating subsystem
 		auto rotate = ship_get_subsys(ship_entry->shipp, CTEXT(node));
-		if (rotate == nullptr)
+		if (rotate == nullptr || rotate->submodel_instance_1 == nullptr)
 			continue;
 
 		// switch direction of rotation
 		rotate->turn_rate *= -1.0f;
-		rotate->submodel_info_1.current_turn_rate *= -1.0f;
-		rotate->submodel_info_1.desired_turn_rate *= -1.0f;
+		rotate->submodel_instance_1->current_turn_rate *= -1.0f;
+		rotate->submodel_instance_1->desired_turn_rate *= -1.0f;
 	}
 }
 
@@ -18972,7 +18986,7 @@ void sexp_rotating_subsys_set_turn_time(int node)
 
 	// get the rotating subsystem
 	auto rotate = ship_get_subsys(ship_entry->shipp, CTEXT(n));
-	if (rotate == nullptr)
+	if (rotate == nullptr || rotate->submodel_instance_1 == nullptr)
 		return;
 	n = CDR(n);
 
@@ -18980,7 +18994,7 @@ void sexp_rotating_subsys_set_turn_time(int node)
 	turn_time = eval_num(n, is_nan, is_nan_forever) / 1000.0f;
 	if (is_nan || is_nan_forever)
 		return;
-	rotate->submodel_info_1.desired_turn_rate = PI2 / turn_time;
+	rotate->submodel_instance_1->desired_turn_rate = PI2 / turn_time;
 	n = CDR(n);
 
 	// maybe get and set the turn accel
@@ -18989,10 +19003,10 @@ void sexp_rotating_subsys_set_turn_time(int node)
 		turn_accel = eval_num(n, is_nan, is_nan_forever) / 1000.0f;
 		if (is_nan || is_nan_forever)
 			return;
-		rotate->submodel_info_1.turn_accel = PI2 / turn_accel;
+		rotate->submodel_instance_1->turn_accel = PI2 / turn_accel;
 	}
 	else
-		rotate->submodel_info_1.current_turn_rate = PI2 / turn_time;
+		rotate->submodel_instance_1->current_turn_rate = PI2 / turn_time;
 }
 
 void sexp_trigger_submodel_animation(int node)

--- a/code/scripting/api/objs/subsystem.cpp
+++ b/code/scripting/api/objs/subsystem.cpp
@@ -113,10 +113,10 @@ ADE_VIRTVAR(Orientation, l_Subsystem, "orientation", "Orientation of subobject o
 
 	if(ADE_SETTING_VAR && mh)
 	{
-		sso->ss->submodel_info_1.angs = *mh->GetAngles();
+		sso->ss->submodel_instance_1->angs = *mh->GetAngles();
 	}
 
-	return ade_set_args(L, "o", l_Matrix.Set(matrix_h(&sso->ss->submodel_info_1.angs)));
+	return ade_set_args(L, "o", l_Matrix.Set(matrix_h(&sso->ss->submodel_instance_1->angs)));
 }
 
 ADE_VIRTVAR(GunOrientation, l_Subsystem, "orientation", "Orientation of turret gun", "orientation", "Gun orientation, or null orientation if handle is invalid")
@@ -131,10 +131,10 @@ ADE_VIRTVAR(GunOrientation, l_Subsystem, "orientation", "Orientation of turret g
 
 	if(ADE_SETTING_VAR && mh)
 	{
-		sso->ss->submodel_info_2.angs = *mh->GetAngles();
+		sso->ss->submodel_instance_2->angs = *mh->GetAngles();
 	}
 
-	return ade_set_args(L, "o", l_Matrix.Set(matrix_h(&sso->ss->submodel_info_2.angs)));
+	return ade_set_args(L, "o", l_Matrix.Set(matrix_h(&sso->ss->submodel_instance_2->angs)));
 }
 
 ADE_VIRTVAR(HitpointsLeft, l_Subsystem, "number", "Subsystem hitpoints left", "number", "Hitpoints left, or 0 if handle is invalid. Setting a value of 0 will disable it - set a value of -1 or lower to actually blow it up.")
@@ -644,7 +644,7 @@ ADE_FUNC(rotateTurret, l_Subsystem, "vector Pos, boolean reset=false", "Rotates 
 	// Find direction of turret
 	model_instance_find_world_dir(&gvec, &tp->turret_norm, pm, pmi, tp->turret_gun_sobj, &objp->orient);
 
-	int ret_val = model_rotate_gun(pm, tp, &objp->orient, &sso->ss->submodel_info_1.angs, &sso->ss->submodel_info_2.angs, &objp->pos, &pos, shipp->objnum, reset);
+	int ret_val = model_rotate_gun(pm, tp, &objp->orient, &sso->ss->submodel_instance_1->angs, &sso->ss->submodel_instance_2->angs, &objp->pos, &pos, shipp->objnum, reset);
 
 	if (ret_val)
 		return ADE_RETURN_TRUE;

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -374,8 +374,8 @@ public:
 	// angles and if it is blown off or not.
 	// There are 2 of these because turrets need one for the turret and one for the barrel.
 	// Things like radar dishes would only use one.
-	submodel_instance_info	submodel_info_1;		// Instance data for main turret or main object
-	submodel_instance_info	submodel_info_2;		// Instance data for turret guns, if there is one
+	submodel_instance *submodel_instance_1;		// Instance data for main turret or main object
+	submodel_instance *submodel_instance_2;		// Instance data for turret guns, if there is one
 
 	int disruption_timestamp;							// time at which subsystem isn't disrupted
 

--- a/code/ship/shipfx.cpp
+++ b/code/ship/shipfx.cpp
@@ -788,7 +788,6 @@ bool shipfx_eye_in_shadow( vec3d *eye_pos, object * src_obj, int sun_n )
 		mc.model_instance_num = -1;
 		mc.model_num = db.model_num;	// Fill in the model to check
 		mc.submodel_num = db.submodel_num;
-		model_clear_instance( mc.model_num );
 		mc.orient = &objp->orient;					// The object's orient
 		mc.pos = &objp->pos;							// The object's position
 		mc.p0 = &rp0;				// Point 1 of ray to check
@@ -928,7 +927,6 @@ bool shipfx_eye_in_shadow( vec3d *eye_pos, object * src_obj, int sun_n )
 		mc.model_instance_num = -1;
 		mc.model_num = Asteroid_info[ast->asteroid_type].model_num[ast->asteroid_subtype];	// Fill in the model to check
 		mc.submodel_num = -1;
-		model_clear_instance( mc.model_num );
 		mc.orient = &objp->orient;					// The object's orient
 		mc.pos = &objp->pos;							// The object's position
 		mc.p0 = &rp0;				// Point 1 of ray to check

--- a/code/ship/shiphit.cpp
+++ b/code/ship/shiphit.cpp
@@ -145,7 +145,7 @@ void do_subobj_destroyed_stuff( ship *ship_p, ship_subsys *subsys, vec3d* hitpos
 				// is this other submodel a child of the one being destroyed?
 				if (pm->submodel[ssp->system_info->subobj_num].parent == psub->subobj_num) {
 					// is it not yet destroyed?  (this is a valid check because we already know there is a submodel)
-					if (!ssp->submodel_info_1.blown_off) {
+					if (!ssp->submodel_instance_1->blown_off) {
 						// then destroy it first
 						ssp->current_hits = 0;
 						do_subobj_destroyed_stuff(ship_p, ssp, nullptr, no_explosion);
@@ -308,11 +308,11 @@ void do_subobj_destroyed_stuff( ship *ship_p, ship_subsys *subsys, vec3d* hitpos
 	if (!(subsys->flags[Ship::Subsystem_Flags::No_disappear])) {
 		if (psub->subobj_num > -1) {
 			shipfx_blow_off_subsystem(ship_objp, ship_p, subsys, &g_subobj_pos, no_explosion);
-			subsys->submodel_info_1.blown_off = true;
+			subsys->submodel_instance_1->blown_off = true;
 		}
 
 		if ((psub->subobj_num != psub->turret_gun_sobj) && (psub->turret_gun_sobj >= 0)) {
-			subsys->submodel_info_2.blown_off = true;
+			subsys->submodel_instance_2->blown_off = true;
 		}
 	}
 


### PR DESCRIPTION
Swifty's earlier model instance refactoring feature got 90% of the way to the goal, but there was still some parts of code that kept stuffing angles into the model for every game frame, rather than keeping the angles properly separate in the model instances.  This PR properly consolidates and compartmentalizes the angles to just the model instances.

(Gun submodel rotation, electrical arcing, and texture management are still stuffed into the model instead of handled in model instances, but those are probably best handled in a separate PR.)

This is a prerequisite to the upcoming animation system upgrade because the animation is a lot simpler if it is only handled in one data structure rather than three redundant data structures.