### PR TITLE
Add Scripting API isNebula and isSubspace

### DIFF
--- a/code/scripting/api/libs/mission.cpp
+++ b/code/scripting/api/libs/mission.cpp
@@ -1271,24 +1271,12 @@ ADE_FUNC(isInCampaign, l_Mission, NULL, "Get whether or not the current mission 
 
 ADE_FUNC(isNebula, l_Mission, nullptr, "Get whether or not the current mission being played is set in a nebula", "boolean", "true if in nebula, false if not")
 {
-	bool b = false;
-
-	if (The_mission.flags[Mission::Mission_Flags::Fullneb]) {
-		b = true;
-	}
-
-	return ade_set_args(L, "b", b);
+	return ade_set_args(L, "b", The_mission.flags[Mission::Mission_Flags::Fullneb]);
 }
 
 ADE_FUNC(isSubspace, l_Mission, nullptr, "Get whether or not the current mission being played is set in subspace", "boolean", "true if in subspace, false if not")
 {
-	bool b = false;
-
-	if (The_mission.flags[Mission::Mission_Flags::Subspace]) {
-		b = true;
-	}
-
-	return ade_set_args(L, "b", b);
+	return ade_set_args(L, "b", The_mission.flags[Mission::Mission_Flags::Subspace);
 }
 
 ADE_FUNC(getMissionTitle, l_Mission, NULL, "Get the title of the current mission", "string", "The mission title or an empty string if currently not in mission") {

--- a/code/scripting/api/libs/mission.cpp
+++ b/code/scripting/api/libs/mission.cpp
@@ -1276,7 +1276,7 @@ ADE_FUNC(isNebula, l_Mission, nullptr, "Get whether or not the current mission b
 
 ADE_FUNC(isSubspace, l_Mission, nullptr, "Get whether or not the current mission being played is set in subspace", "boolean", "true if in subspace, false if not")
 {
-	return ade_set_args(L, "b", The_mission.flags[Mission::Mission_Flags::Subspace);
+	return ade_set_args(L, "b", The_mission.flags[Mission::Mission_Flags::Subspace]);
 }
 
 ADE_FUNC(getMissionTitle, l_Mission, NULL, "Get the title of the current mission", "string", "The mission title or an empty string if currently not in mission") {

--- a/code/scripting/api/libs/mission.cpp
+++ b/code/scripting/api/libs/mission.cpp
@@ -1269,6 +1269,28 @@ ADE_FUNC(isInCampaign, l_Mission, NULL, "Get whether or not the current mission 
 	return ade_set_args(L, "b", b);
 }
 
+ADE_FUNC(isNebula, l_Mission, NULL, "Get whether or not the current mission being played is set in a nebula", "boolean", "true if in nebula, false if not")
+{
+	bool b = false;
+
+	if (The_mission.flags[Mission::Mission_Flags::Fullneb]) {
+		b = true;
+	}
+
+	return ade_set_args(L, "b", b);
+}
+
+ADE_FUNC(isSubspace, l_Mission, NULL, "Get whether or not the current mission being played is set in subspace", "boolean", "true if in subspace, false if not")
+{
+	bool b = false;
+
+	if (The_mission.flags[Mission::Mission_Flags::Subspace]) {
+		b = true;
+	}
+
+	return ade_set_args(L, "b", b);
+}
+
 ADE_FUNC(getMissionTitle, l_Mission, NULL, "Get the title of the current mission", "string", "The mission title or an empty string if currently not in mission") {
 	return ade_set_args(L, "s", The_mission.name);
 }

--- a/code/scripting/api/libs/mission.cpp
+++ b/code/scripting/api/libs/mission.cpp
@@ -1269,7 +1269,7 @@ ADE_FUNC(isInCampaign, l_Mission, NULL, "Get whether or not the current mission 
 	return ade_set_args(L, "b", b);
 }
 
-ADE_FUNC(isNebula, l_Mission, NULL, "Get whether or not the current mission being played is set in a nebula", "boolean", "true if in nebula, false if not")
+ADE_FUNC(isNebula, l_Mission, nullptr, "Get whether or not the current mission being played is set in a nebula", "boolean", "true if in nebula, false if not")
 {
 	bool b = false;
 
@@ -1280,7 +1280,7 @@ ADE_FUNC(isNebula, l_Mission, NULL, "Get whether or not the current mission bein
 	return ade_set_args(L, "b", b);
 }
 
-ADE_FUNC(isSubspace, l_Mission, NULL, "Get whether or not the current mission being played is set in subspace", "boolean", "true if in subspace, false if not")
+ADE_FUNC(isSubspace, l_Mission, nullptr, "Get whether or not the current mission being played is set in subspace", "boolean", "true if in subspace, false if not")
 {
 	bool b = false;
 


### PR DESCRIPTION
This adds a functionality so that scripts can check whether the current mission is a nebula mission and if it is a subspace mission.