### PR TITLE
another model to model_instance refactor

### DIFF
--- a/code/debris/debris.h
+++ b/code/debris/debris.h
@@ -42,6 +42,7 @@ typedef struct debris {
 	float		lifeleft;			// When 0 or less object dies
 	int		must_survive_until;		//WMC - timestamp of earliest point that it can be murthered.
 	int		model_num;				// What model this uses
+	int		model_instance_num;		// What model instance this uses - needed for arcs
 	int		submodel_num;			// What submodel this uses
 	int		next_fireball;			// When to start a fireball
 	int		is_hull;				// indicates a large hull chunk of debris
@@ -54,6 +55,7 @@ typedef struct debris {
 	vec3d	arc_pts[MAX_DEBRIS_ARCS][2];	// The endpoints of each arc
 	int		arc_timestamp[MAX_DEBRIS_ARCS];	// When this times out, the spark goes away.  -1 is not used
 	int		arc_frequency;					// Starts at 1000, gets bigger
+
 	int		parent_alt_name;
 	float	damage_mult;
 

--- a/code/graphics/shadows.cpp
+++ b/code/graphics/shadows.cpp
@@ -482,13 +482,16 @@ void shadows_render_all(float fov, matrix *eye_orient, vec3d *eye_pos)
 					continue;
 				}
 								
+				auto pmi = model_get_instance(db->model_instance_num);
+				auto pm = model_get(pmi->model_num);
+
 				objp = &Objects[db->objnum];
 
 				model_render_params render_info;
 
 				render_info.set_flags(MR_NO_TEXTURING | MR_NO_LIGHTING);
 
-				submodel_render_queue(&render_info, &scene, db->model_num, db->submodel_num, &objp->orient, &objp->pos);
+				submodel_render_queue(&render_info, &scene, pm, pmi, db->submodel_num, &objp->orient, &objp->pos);
 			}
 			break; 
 		}

--- a/code/hud/hudtargetbox.cpp
+++ b/code/hud/hudtargetbox.cpp
@@ -774,8 +774,11 @@ void HudGaugeTargetBox::renderTargetDebris(object *target_objp)
 
 		render_info.set_flags(flags | MR_NO_FOGGING);
 
+		auto pmi = model_get_instance(debrisp->model_instance_num);
+		auto pm = model_get(pmi->model_num);
+
 		// This calls the colour that doesn't get reset
-		submodel_render_immediate( &render_info, debrisp->model_num, debrisp->submodel_num, &target_objp->orient, &obj_pos);
+		submodel_render_immediate( &render_info, pm, pmi, debrisp->submodel_num, &target_objp->orient, &obj_pos);
 
 		if ( Monitor_mask >= 0 ) {
 			gr_stencil_set(GR_STENCIL_NONE);

--- a/code/model/modelrender.h
+++ b/code/model/modelrender.h
@@ -300,8 +300,8 @@ void model_render_immediate(model_render_params* render_info, int model_num, mat
                             int render = MODEL_RENDER_ALL, bool sort = true);
 void model_render_queue(model_render_params* render_info, model_draw_list* scene, int model_num, matrix* orient,
                         vec3d* pos);
-void submodel_render_immediate(model_render_params *render_info, int model_num, int submodel_num, matrix *orient, vec3d * pos);
-void submodel_render_queue(model_render_params *render_info, model_draw_list *scene, int model_num, int submodel_num, matrix *orient, vec3d * pos);
+void submodel_render_immediate(model_render_params *render_info, polymodel *pm, polymodel_instance *pmi, int submodel_num, matrix *orient, vec3d * pos);
+void submodel_render_queue(model_render_params *render_info, model_draw_list *scene, polymodel *pm, polymodel_instance *pmi, int submodel_num, matrix *orient, vec3d * pos);
 void model_render_buffers(model_draw_list* scene, model_material *rendering_material, model_render_params* interp, vertex_buffer *buffer, polymodel *pm, int mn, int detail_level, uint tmap_flags);
 fix model_render_determine_base_frametime(int objnum, uint flags);
 bool model_render_check_detail_box(vec3d *view_pos, polymodel *pm, int submodel_num, uint flags);

--- a/code/object/object.cpp
+++ b/code/object/object.cpp
@@ -2036,6 +2036,44 @@ int object_get_model(const object *objp)
 
 	return -1;
 }
+
+int object_get_model_instance(const object *objp)
+{
+	switch (objp->type)
+	{
+		case OBJ_ASTEROID:
+		{
+			asteroid *asp = &Asteroids[objp->instance];
+			return asp->model_instance_num;
+		}
+		case OBJ_DEBRIS:
+		{
+			debris *debrisp = &Debris[objp->instance];
+			return debrisp->model_instance_num;
+		}
+		case OBJ_SHIP:
+		{
+			ship *shipp = &Ships[objp->instance];
+			return shipp->model_instance_num;
+		}
+		case OBJ_WEAPON:
+		{
+			weapon *wp = &Weapons[objp->instance];
+			return wp->model_instance_num;
+		}
+		case OBJ_JUMP_NODE:
+		{
+			CJumpNode* jnp = jumpnode_get_by_objnum(OBJ_INDEX(objp));
+			Assertion(jnp != nullptr, "Could not find jump node!");
+			return jnp->GetPolymodelInstanceNum();
+		}
+		default:
+			break;
+	}
+
+	return -1;
+}
+
 bool obj_compare(object* left, object* right) {
 	if (left == right) {
 		// Same pointer

--- a/code/object/object.h
+++ b/code/object/object.h
@@ -344,6 +344,7 @@ bool object_get_gliding(object *objp);
 bool object_glide_forced(object* objp);
 int obj_get_by_signature(int sig);
 int object_get_model(const object *objp);
+int object_get_model_instance(const object *objp);
 
 void obj_render_queue_all();
 

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -19381,13 +19381,17 @@ void ship_render(object* obj, model_draw_list* scene)
 		}
 	}
 
+	auto pmi = model_get_instance(shipp->model_instance_num);
+	auto pm = model_get(pmi->model_num);
+
 	model_clear_instance(sip->model_num);
+	model_instance_clear_arcs(pm, pmi);
 
 	// Only render electrical arcs if within 500m of the eye (for a 10m piece)
 	if ( vm_vec_dist_quick( &obj->pos, &Eye_position ) < obj->radius*50.0f && !Rendering_to_shadow_map ) {
 		for ( int i = 0; i < MAX_SHIP_ARCS; i++ )	{
 			if ( timestamp_valid(shipp->arc_timestamp[i]) ) {
-				model_add_arc(sip->model_num, -1, &shipp->arc_pts[i][0], &shipp->arc_pts[i][1], shipp->arc_type[i]);
+				model_instance_add_arc(pm, pmi, -1, &shipp->arc_pts[i][0], &shipp->arc_pts[i][1], shipp->arc_type[i]);
 			}
 		}
 	}

--- a/code/ship/shipfx.cpp
+++ b/code/ship/shipfx.cpp
@@ -1538,7 +1538,8 @@ static void split_ship_init( ship* shipp, split_ship* split_shipp )
 
 void shipfx_queue_render_ship_halves_and_debris(model_draw_list *scene, clip_ship* half_ship, ship *shipp)
 {
-	polymodel *pm = model_get(Ship_info[shipp->ship_info_index].model_num);
+	polymodel_instance *pmi = model_get_instance(shipp->model_instance_num);
+	polymodel *pm = model_get(pmi->model_num);
 
 	// get rotated clip plane normal and world coord of original ship center
 	vec3d orig_ship_world_center, clip_plane_norm, model_clip_plane_pt, debris_clip_plane_pt;
@@ -1594,7 +1595,7 @@ void shipfx_queue_render_ship_halves_and_debris(model_draw_list *scene, clip_shi
 				render_info.set_replacement_textures(shipp->ship_replacement_textures);
 				render_info.set_flags(render_flags);
 
-				submodel_render_queue(&render_info, scene, pm->id, pm->debris_objects[i], &half_ship->orient, &tmp);
+				submodel_render_queue(&render_info, scene, pm, pmi, pm->debris_objects[i], &half_ship->orient, &tmp);
 			}
 
 			// make free piece of debris


### PR DESCRIPTION
A small follow-up to #2992.  This removes arc information from bsp_info and moves it to submodel_instance.  It also adds a model instance to each debris chunk to keep track of it.