### PR TITLE
Add GitHub workflow for building releases

### DIFF
--- a/.github/workflows/build-nightly.yaml
+++ b/.github/workflows/build-nightly.yaml
@@ -1,0 +1,210 @@
+name: Build distribution package
+
+on:
+  push:
+    tags:
+      - 'nightly_*'
+
+env:
+  QT_VERSION: 5.12.9
+
+jobs:
+  build_linux:
+    strategy:
+      matrix:
+        configuration: [FastDebug, Release]
+    name: Linux
+    runs-on: ubuntu-latest
+    container: ghcr.io/scp-fs2open/linux_build:sha-a8ca321
+    steps:
+      - name: Cache Qt
+        id: cache-qt-lin
+        uses: actions/cache@v1
+        with:
+          path: ${{ github.workspace }}/../Qt
+          key: ${{ runner.os }}-QtCache-${{ env.QT_VERSION }}
+      - name: Install Qt
+        uses: jurplel/install-qt-action@v2
+        with:
+          version: ${{ env.QT_VERSION }}
+          dir: ${{ github.workspace }}/..
+          cached: ${{ steps.cache-qt-lin.outputs.cache-hit }}
+
+      - uses: actions/checkout@v1
+        name: Checkout
+        with:
+          submodules: true
+      - name: Configure CMake
+        env:
+          CONFIGURATION: ${{ matrix.configuration }}
+          COMPILER: gcc-5
+        run: $GITHUB_WORKSPACE/ci/linux/configure_cmake.sh
+      - name: Compile
+        working-directory: ./build
+        env:
+          CONFIGURATION: ${{ matrix.configuration }}
+        run: |
+          LD_LIBRARY_PATH=$Qt5_DIR/lib:$LD_LIBRARY_PATH ninja -k 20 all
+      - name: Run Tests
+        working-directory: ./build
+        env:
+          CONFIGURATION: ${{ matrix.configuration }}
+          XDG_RUNTIME_DIR: /root
+        run: $GITHUB_WORKSPACE/ci/linux/run_tests.sh
+      - name: Generate AppImage
+        working-directory: ./build
+        env:
+          CONFIGURATION: ${{ matrix.configuration }}
+        run: $GITHUB_WORKSPACE/ci/linux/generate_appimage.sh $GITHUB_WORKSPACE/build/install
+      - name: Upload build result
+        uses: actions/upload-artifact@v2
+        with:
+          name: linux-${{ matrix.configuration }}
+          path: ${{ github.workspace }}/build/install/*.AppImage
+  linux_zip:
+    name: Build Linux distribution zip
+    needs: build_linux
+    runs-on: ubuntu-latest
+    container: ghcr.io/scp-fs2open/sftp_upload:sha-dd9d8cf
+    steps:
+      - uses: actions/checkout@v1
+        name: Checkout
+        with:
+          submodules: true
+          fetch-depth: '0'
+      - name: Download Release builds
+        uses: actions/download-artifact@v1
+        with:
+          name: linux-Release
+          path: builds
+      - name: Download FastDebug builds
+        uses: actions/download-artifact@v2
+        with:
+          name: linux-FastDebug
+          path: builds
+      - name: Create Distribution package
+        working-directory: ./builds
+        run: $GITHUB_WORKSPACE/ci/linux/create_dist_pack.sh Linux
+      - name: Upload result package
+        working-directory: ./builds
+        env:
+          INDIEGAMES_USER: ${{ secrets.INDIEGAMES_USER }}
+          INDIEGAMES_SSHPASS: ${{ secrets.INDIEGAMES_PASSWORD }}
+          DATACORDER_USER: ${{ secrets.DATACORDER_USER }}
+          DATACORDER_SSHPASS: ${{ secrets.DATACORDER_PASSWORD }}
+        run: $GITHUB_WORKSPACE/ci/linux/upload_dist_package.sh
+
+  build_windows:
+    strategy:
+      matrix:
+        configuration: [FastDebug, Release]
+        arch: [Win32, x64]
+        simd: [SSE2]
+    name: Windows
+    runs-on: windows-2019
+    steps:
+      - uses: actions/checkout@v1
+        name: Checkout
+        with:
+          submodules: true
+      - name: Cache Qt
+        id: cache-qt-win
+        uses: actions/cache@v1
+        with:
+          path: ${{ github.workspace }}/../Qt
+          key: ${{ runner.os }}-${{ matrix.arch }}-QtCache-${{ env.QT_VERSION }}
+      - name: Install Qt (32 bit)
+        uses: jurplel/install-qt-action@v2
+        if: ${{ matrix.arch == 'Win32' }}
+        with:
+          version: ${{ env.QT_VERSION }}
+          dir: ${{ github.workspace }}/..
+          arch: win32_msvc2017
+          cached: ${{ steps.cache-qt-win.outputs.cache-hit }}
+          aqtversion: ==0.8
+      - name: Install Qt (64 bit)
+        uses: jurplel/install-qt-action@v2
+        if: ${{ matrix.arch == 'x64' }}
+        with:
+          version: ${{ env.QT_VERSION }}
+          dir: ${{ github.workspace }}/..
+          arch: win64_msvc2017_64
+          cached: ${{ steps.cache-qt-win.outputs.cache-hit }}
+          aqtversion: ==0.8
+
+      - name: Configure CMake
+        env:
+          CONFIGURATION: ${{ matrix.configuration }}
+          ARCHITECTURE: ${{ matrix.arch }}
+          SIMD: ${{ matrix.simd }}
+        shell: bash
+        run: |
+          mkdir build
+          cd build
+
+          cmake -DCMAKE_INSTALL_PREFIX="$(pwd)/install" -DFSO_USE_SPEECH="ON" \
+            -DFSO_USE_VOICEREC="ON" -DMSVC_SIMD_INSTRUCTIONS="$SIMD" \
+            -DFSO_BUILD_QTFRED=ON -DFSO_BUILD_TESTS=ON \
+            -DFSO_INSTALL_DEBUG_FILES="ON" -A "$ARCHITECTURE" \
+            -G "Visual Studio 16 2019" -T "v142" ..
+      - name: Compile
+        working-directory: ./build
+        env:
+          CONFIGURATION: ${{ matrix.configuration }}
+          COMPILER: ${{ matrix.compiler }}
+        shell: bash
+        run: |
+          cmake --build . --config "$CONFIGURATION" --target INSTALL -- /verbosity:minimal
+          ls -alR "$(pwd)/install"
+      - name: Run Tests
+        working-directory: ./build
+        env:
+          CONFIGURATION: ${{ matrix.configuration }}
+        shell: bash
+        run: ./bin/$CONFIGURATION/unittests --gtest_shuffle
+      - name: Upload build result
+        uses: actions/upload-artifact@v2
+        with:
+          name: windows-${{ matrix.configuration }}-${{ matrix.arch }}-${{ matrix.simd }}
+          path: ${{ github.workspace }}/build/install/*
+  windows_zip:
+    name: Build Windows distribution zip
+    needs: build_windows
+    runs-on: ubuntu-latest
+    container: ghcr.io/scp-fs2open/sftp_upload:sha-dd9d8cf
+    strategy:
+      matrix:
+        arch: [Win32, x64]
+        simd: [SSE2]
+    steps:
+      - uses: actions/checkout@v1
+        name: Checkout
+        with:
+          submodules: true
+          fetch-depth: '0'
+      - name: Download Release builds
+        uses: actions/download-artifact@v1
+        with:
+          name: windows-Release-${{ matrix.arch }}-${{ matrix.simd }}
+          path: builds
+      - name: Download FastDebug builds
+        uses: actions/download-artifact@v2
+        with:
+          name: windows-FastDebug-${{ matrix.arch }}-${{ matrix.simd }}
+          path: builds
+      - name: Create Distribution package
+        working-directory: ./builds
+        shell: bash
+        env:
+          ARCH: ${{ matrix.arch }}
+          SIMD: ${{ matrix.simd }}
+        run: $GITHUB_WORKSPACE/ci/linux/create_dist_pack.sh Windows
+      - name: Upload result package
+        working-directory: ./builds
+        shell: bash
+        env:
+          INDIEGAMES_USER: ${{ secrets.INDIEGAMES_USER }}
+          INDIEGAMES_SSHPASS: ${{ secrets.INDIEGAMES_PASSWORD }}
+          DATACORDER_USER: ${{ secrets.DATACORDER_USER }}
+          DATACORDER_SSHPASS: ${{ secrets.DATACORDER_PASSWORD }}
+        run: $GITHUB_WORKSPACE/ci/linux/upload_dist_package.sh

--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -3,18 +3,41 @@ name: Build distribution package
 on:
   push:
     tags:
-      - 'nightly_*'
       - 'release_*'
 
 env:
   QT_VERSION: 5.12.9
 
 jobs:
+  create_release:
+    name: Create GitHub release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          draft: false
+          prerelease: false
+      - name: Store upload URL
+        run: |
+          echo -n "${{ steps.create_release.outputs.upload_url }}" > upload_url
+      - name: Persist upload URL
+        uses: actions/upload-artifact@v2
+        with:
+          name: upload_url
+          path: ${{ github.workspace }}/upload_url
+
   build_linux:
     strategy:
       matrix:
         configuration: [FastDebug, Release]
     name: Linux
+    needs: create_release
     runs-on: ubuntu-latest
     container: ghcr.io/scp-fs2open/linux_build:sha-a8ca321
     steps:
@@ -73,6 +96,14 @@ jobs:
         with:
           submodules: true
           fetch-depth: '0'
+      - name: Download upload URL
+        uses: actions/download-artifact@v1
+        with:
+          name: upload_url
+          path: .
+      - name: Extract upload URL
+        id: extractUploadUrl
+        run: echo "::set-output name=upload_url::$(cat upload_url)"
       - name: Download Release builds
         uses: actions/download-artifact@v1
         with:
@@ -84,23 +115,27 @@ jobs:
           name: linux-FastDebug
           path: builds
       - name: Create Distribution package
+        id: generate_package
         working-directory: ./builds
         run: $GITHUB_WORKSPACE/ci/linux/create_dist_pack.sh Linux
       - name: Upload result package
-        working-directory: ./builds
+        uses: actions/upload-release-asset@v1
         env:
-          INDIEGAMES_USER: ${{ secrets.INDIEGAMES_USER }}
-          INDIEGAMES_SSHPASS: ${{ secrets.INDIEGAMES_PASSWORD }}
-          DATACORDER_USER: ${{ secrets.DATACORDER_USER }}
-          DATACORDER_SSHPASS: ${{ secrets.DATACORDER_PASSWORD }}
-        run: $GITHUB_WORKSPACE/ci/linux/upload_dist_package.sh
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.extractUploadUrl.outputs.upload_url }}
+          asset_path: ${{ steps.generate_package.outputs.package_path }}
+          asset_name: ${{ steps.generate_package.outputs.package_name }}
+          # All builds are zips at the moment so this is fine for now
+          asset_content_type: application/zip
 
   build_windows:
     strategy:
       matrix:
         configuration: [FastDebug, Release]
         arch: [Win32, x64]
-        simd: [SSE2]
+        simd: [SSE2, AVX]
+    needs: create_release
     name: Windows
     runs-on: windows-2019
     steps:
@@ -176,13 +211,21 @@ jobs:
     strategy:
       matrix:
         arch: [Win32, x64]
-        simd: [SSE2]
+        simd: [SSE2, AVX]
     steps:
       - uses: actions/checkout@v1
         name: Checkout
         with:
           submodules: true
           fetch-depth: '0'
+      - name: Download upload URL
+        uses: actions/download-artifact@v1
+        with:
+          name: upload_url
+          path: .
+      - name: Extract upload URL
+        id: extractUploadUrl
+        run: echo "::set-output name=upload_url::$(cat upload_url)"
       - name: Download Release builds
         uses: actions/download-artifact@v1
         with:
@@ -194,6 +237,7 @@ jobs:
           name: windows-FastDebug-${{ matrix.arch }}-${{ matrix.simd }}
           path: builds
       - name: Create Distribution package
+        id: generate_package
         working-directory: ./builds
         shell: bash
         env:
@@ -201,11 +245,12 @@ jobs:
           SIMD: ${{ matrix.simd }}
         run: $GITHUB_WORKSPACE/ci/linux/create_dist_pack.sh Windows
       - name: Upload result package
-        working-directory: ./builds
-        shell: bash
+        uses: actions/upload-release-asset@v1
         env:
-          INDIEGAMES_USER: ${{ secrets.INDIEGAMES_USER }}
-          INDIEGAMES_SSHPASS: ${{ secrets.INDIEGAMES_PASSWORD }}
-          DATACORDER_USER: ${{ secrets.DATACORDER_USER }}
-          DATACORDER_SSHPASS: ${{ secrets.DATACORDER_PASSWORD }}
-        run: $GITHUB_WORKSPACE/ci/linux/upload_dist_package.sh
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.extractUploadUrl.outputs.upload_url }}
+          asset_path: ${{ steps.generate_package.outputs.package_path }}
+          asset_name: ${{ steps.generate_package.outputs.package_name }}
+          # All builds are zips at the moment so this is fine for now
+          asset_content_type: application/zip

--- a/ci/appveyor/build.ps1
+++ b/ci/appveyor/build.ps1
@@ -27,38 +27,38 @@ $NightlyConfigurations = @(
 #	}
 )
 $ReleaseConfigurations = @(
-	[BuildConfig]@{
-		Generator="Visual Studio 14 2015";
-		PackageType="Win32";
-		Toolset="v140";
-		SimdType="SSE2";
-		QtDir="C:\Qt\5.9\msvc2015";
-		SourcePackage=$true;
-	}
-	[BuildConfig]@{
-		Generator="Visual Studio 14 2015";
-		PackageType="Win32-AVX";
-		Toolset="v140";
-		SimdType="AVX";
-		QtDir="C:\Qt\5.9\msvc2015";
-		SourcePackage=$false;
-	}
-	[BuildConfig]@{
-		Generator="Visual Studio 14 2015 Win64";
-		PackageType="Win64";
-		Toolset="v140";
-		SimdType="SSE2";
-		QtDir="C:\Qt\5.9\msvc2015_64";
-		SourcePackage=$false;
-	}
-	[BuildConfig]@{
-		Generator="Visual Studio 14 2015 Win64";
-		PackageType="Win64-AVX";
-		Toolset="v140";
-		SimdType="AVX";
-		QtDir="C:\Qt\5.9\msvc2015_64";
-		SourcePackage=$false;
-	}
+#	[BuildConfig]@{
+#		Generator="Visual Studio 14 2015";
+#		PackageType="Win32";
+#		Toolset="v140";
+#		SimdType="SSE2";
+#		QtDir="C:\Qt\5.9\msvc2015";
+#		SourcePackage=$true;
+#	}
+#	[BuildConfig]@{
+#		Generator="Visual Studio 14 2015";
+#		PackageType="Win32-AVX";
+#		Toolset="v140";
+#		SimdType="AVX";
+#		QtDir="C:\Qt\5.9\msvc2015";
+#		SourcePackage=$false;
+#	}
+#	[BuildConfig]@{
+#		Generator="Visual Studio 14 2015 Win64";
+#		PackageType="Win64";
+#		Toolset="v140";
+#		SimdType="SSE2";
+#		QtDir="C:\Qt\5.9\msvc2015_64";
+#		SourcePackage=$false;
+#	}
+#	[BuildConfig]@{
+#		Generator="Visual Studio 14 2015 Win64";
+#		PackageType="Win64-AVX";
+#		Toolset="v140";
+#		SimdType="AVX";
+#		QtDir="C:\Qt\5.9\msvc2015_64";
+#		SourcePackage=$false;
+#	}
 )
 
 $BuildConfigurations = $null

--- a/ci/linux/create_dist_pack.sh
+++ b/ci/linux/create_dist_pack.sh
@@ -9,8 +9,14 @@ source $HERE/dist_functions.sh
 
 if [ "$OS" = "Linux" ]; then
     tar -cvzf "$(get_package_name)-builds-Linux.tar.gz" *
+
+    echo "::set-output name=package_path::$(pwd)/$(get_package_name)-builds-Linux.tar.gz"
+    echo "::set-output name=package_name::$(get_package_name)-builds-Linux.tar.gz"
 elif [ "$OS" = "Windows" ]; then
     7z a -xr'!*.pdb' "$(get_package_name)-builds-$ARCH-$SIMD.zip" "*"
+
+    echo "::set-output name=package_path::$(pwd)/$(get_package_name)-builds-$ARCH-$SIMD.zip"
+    echo "::set-output name=package_name::$(get_package_name)-builds-$ARCH-$SIMD.zip"
 
     7z a "$(get_package_name)-debug-$ARCH-$SIMD.7z" "*.pdb"
 else

--- a/ci/linux/dist_functions.sh
+++ b/ci/linux/dist_functions.sh
@@ -4,6 +4,11 @@ function get_package_name() {
     return
   fi
 
+  if git describe --match 'release_*' --exact-match >/dev/null; then
+    echo -n "$(git describe --match "release_*" --exact-match | sed 's/release_/fs2_open_/i')"
+    return
+  fi
+
   echo "unknown_config"
 }
 
@@ -13,6 +18,16 @@ function get_version_name() {
 
     # Use the bash regex matching for getting the relevant part of the tag name
     [[ $tag_name =~ ^nightly_(.*)$ ]]
+
+    echo -n "${BASH_REMATCH[1]}"
+    return
+  fi
+
+  if git describe --match 'release_*' --exact-match >/dev/null; then
+    local tag_name=$(git describe --match "release_*" --exact-match)
+
+    # Use the bash regex matching for getting the relevant part of the tag name
+    [[ $tag_name =~ ^release_(.*)$ ]]
 
     echo -n "${BASH_REMATCH[1]}"
     return

--- a/ci/linux/generate_appimage.sh
+++ b/ci/linux/generate_appimage.sh
@@ -9,4 +9,6 @@ cmake -DCMAKE_INSTALL_PREFIX=$INSTALL_FOLDER -DCOMPONENT=Freespace2 -P cmake_ins
 # We need to be a bit creative for determining the AppImage name since we don't want to hard-code the name
 FILENAME="$(find $INSTALL_FOLDER/bin -name 'fs2_open_*' -type f -printf "%f\n").AppImage"
 appimagetool -n $INSTALL_FOLDER "$INSTALL_FOLDER/$FILENAME"
+chmod +x "$INSTALL_FOLDER/$FILENAME"
+
 ls -al $INSTALL_FOLDER


### PR DESCRIPTION
This uses GitHub actions for building Linux and Windows builds for
release tags.

Appveyor is now no longer used for building distribution packages and is
also not used for anything relevant anymore. If this works properly we
can disable that PR check to get better PR scalability.