### PR TITLE
Set correct time stamp for already-locked indicators.

### DIFF
--- a/code/hud/hudlock.cpp
+++ b/code/hud/hudlock.cpp
@@ -337,6 +337,8 @@ void HudGaugeLock::render(float frametime)
 		Lock_gauge.sx = sx - Lock_gauge_half_w;
 		Lock_gauge.sy = sy - Lock_gauge_half_h;
 		if( current_lock->locked ){
+			current_lock->lock_gauge_time_elapsed = 0.0f;
+			Lock_gauge.time_elapsed = current_lock->lock_gauge_time_elapsed;
 			hud_anim_render(&Lock_gauge, 0.0f, 1);
 		} else {
 			// manually track the animation time, since we may have more than one lock


### PR DESCRIPTION
This should handle #2952 by setting a consistent timestamp for locked indicators instead of accidentally inheriting them from indicators that are still locking.  Tested with normal and multilock missiles.

Took entirely too long to track down.