### PR TITLE
Prevent almost immediate crash and Warn User about corrupt/unreachable SDL.dll

### DIFF
--- a/code/osapi/osapi.cpp
+++ b/code/osapi/osapi.cpp
@@ -42,8 +42,20 @@ namespace
 		// Lazily initialize the preferences path
 		if (!preferencesPath) {
 		    preferencesPath = SDL_GetPrefPath(ORGANIZATION_NAME, APPLICATION_NAME);
-		    if (!preferencesPath) {
-			    mprintf(("Failed to get preferences path from SDL: %s\n", SDL_GetError()));
+			
+			// this section will at least tell the user if something is seriously wrong instead of just crashing without a message or debug log.
+			// It may crash later, especially when trying to load sound. But let's let it *try* to run in the current directory at least.
+		    if (preferencesPath == nullptr) {
+				static bool sdl_is_borked_warning = false;
+				if (!sdl_is_borked_warning) {
+					ReleaseWarning(LOCATION, "%s\n\nSDL and Windows are unable to get the preferred path for the reason above. "
+						"Installing FSO, its executables and DLLs in another non-protected folder may fix the issue.\n\n"
+						"You may experience issues if you continue playing, and FSO may crash. Please report this error if it persists.\n\n"
+						"Report at www.hard-light.net or the hard-light discord.", SDL_GetError());
+					sdl_is_borked_warning = true;
+				}
+				// No preferences path, try current directory.  
+				return "." DIR_SEPARATOR_STR;
 		    }
 #ifdef WIN32
 		    try {


### PR DESCRIPTION
This may not be the correct approach for this, but the code here crashes without a window open or debug log created if SDL cannot get the preferred path.  I started encountering this crash without any noticeable cause except for the fact that my builds were being created in a sub-directory of documents (which I've been doing for 18 months without issue).  

I went with the option of having a pretty verbose warning message, telling the user FSO will attempt to use the current directory, but will probably crash without a warning message.

This avoids the immediate crash, and warns the user, but it cannot prevent the other things that will occur, like a possible crash when trying to load OpenAL.  

I don't mind switching to an Error instead of a warning if requested.