### PR TITLE
additional null checks

### DIFF
--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -2320,7 +2320,8 @@ int parse_create_object_sub(p_object *p_objp)
 			if ((100.0f - sssp->percent) < 0.5)
 			{
 				ptr->current_hits = 0.0f;
-				ptr->submodel_instance_1->blown_off = true;
+				if (ptr->submodel_instance_1 != nullptr)
+					ptr->submodel_instance_1->blown_off = true;
 			}
 			else
 			{

--- a/code/missionui/redalert.cpp
+++ b/code/missionui/redalert.cpp
@@ -623,7 +623,7 @@ void red_alert_bash_subsys_status(red_alert_ship_status *ras, ship *shipp)
 			break;
 		}
 
-		if (ss->current_hits <= 0) {
+		if (ss->current_hits <= 0 && ss->submodel_instance_1 != nullptr) {
 			ss->submodel_instance_1->blown_off = true;
 		}
 


### PR DESCRIPTION
Some subsystem code was being run for submodels when the subsystem didn't necessarily have a submodel attached.