### PR TITLE
properly restore turret angles after calculating matrix

### DIFF
--- a/code/model/modelread.cpp
+++ b/code/model/modelread.cpp
@@ -3756,6 +3756,8 @@ void model_make_turret_matrix(polymodel *pm, polymodel_instance *pmi, model_subs
 	if (pm_base->force_turret_normal)
 		turret->turret_norm = pm_base->orientation.vec.uvec;
 
+	auto save_base_angs = base->angs;
+	auto save_gun_angs = gun->angs;
 	base->angs = gun->angs = vmd_zero_angles;
 
 	base->angs.h = offset_base_h;
@@ -3792,6 +3794,10 @@ void model_make_turret_matrix(polymodel *pm, polymodel_instance *pmi, model_subs
 	// apart, so this should be close enough.  I think this will start 
 	// causing weird errors when we view from turrets. -John
     turret->flags.set(Model::Subsystem_Flags::Turret_matrix);
+
+	// restore the position of the turret before we entered this function
+	base->angs = save_base_angs;
+	gun->angs = save_gun_angs;
 }
 
 // Tries to move joints so that the turret points to the point dst.


### PR DESCRIPTION
Since angles are no longer written in three redundant places, the temporary hijacking of the turret angles in `model_make_turret_matrix` was overwriting the turret's proper position.  So this PR just saves the angles and restores them when the calculation is done.

Fixes #3013.