### PR TITLE
Fix clang tidy commit range

### DIFF
--- a/.github/workflows/build-nightly.yaml
+++ b/.github/workflows/build-nightly.yaml
@@ -1,4 +1,4 @@
-name: Build distribution package
+name: Build Nightly package
 
 on:
   push:

--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -1,4 +1,4 @@
-name: Build distribution package
+name: Build Release package
 
 on:
   push:

--- a/ci/linux/clang_tidy.sh
+++ b/ci/linux/clang_tidy.sh
@@ -14,7 +14,7 @@ fi
 
 # In order to get a proper diff without irrelevant changes, we need to determine where we branched off from the base
 # branch
-$BASE_COMMIT=$(git merge-base $1 $2)
+BASE_COMMIT=$(git merge-base $1 $2)
 
 echo "Running clang-tidy on changed files"
 git diff -U0 --no-color "$BASE_COMMIT..$2" | \

--- a/ci/linux/clang_tidy.sh
+++ b/ci/linux/clang_tidy.sh
@@ -12,8 +12,12 @@ if ! git rev-list $COMMIT_RANGE 2>&1 >/dev/null; then
     exit 0
 fi
 
+# In order to get a proper diff without irrelevant changes, we need to determine where we branched off from the base
+# branch
+$BASE_COMMIT=$(git merge-base $1 $2)
+
 echo "Running clang-tidy on changed files"
-git diff -U0 --no-color $COMMIT_RANGE | \
+git diff -U0 --no-color "$BASE_COMMIT..$2" | \
     $HERE/clang-tidy-diff.py -path "$(pwd)/build" -p1 \
     -regex '(code(?!\/graphics\/shaders\/compiled)|freespace2|qtfred|test|build|tools)\/.*\.(cpp|h)' \
     -clang-tidy-binary /usr/bin/clang-tidy-9 -j$(nproc) -export-fixes "$(pwd)/clang-fixes.yaml"


### PR DESCRIPTION
By only looking at the HEADs of the respective branches, we included
irrelevant changes in the diff passed to clang-tidy-diff so it was
possible to generate irrelevant warnings in a PR.