### PR TITLE
Capture SDL logs to our standard logging output

### DIFF
--- a/code/osapi/osapi.cpp
+++ b/code/osapi/osapi.cpp
@@ -129,6 +129,61 @@ namespace
 		gameseq_post_event(GS_EVENT_QUIT_GAME);
 		return true;
 	}
+
+	const char* mapCategory(int category) {
+		switch (category) {
+			case SDL_LOG_CATEGORY_APPLICATION:
+				return "APPLICATION";
+			case SDL_LOG_CATEGORY_ERROR:
+				return "ERROR";
+			case SDL_LOG_CATEGORY_ASSERT:
+				return "ASSERT";
+			case SDL_LOG_CATEGORY_SYSTEM:
+				return "SYSTEM";
+			case SDL_LOG_CATEGORY_AUDIO:
+				return "AUDIO";
+			case SDL_LOG_CATEGORY_VIDEO:
+				return "VIDEO";
+			case SDL_LOG_CATEGORY_RENDER:
+				return "RENDER";
+			case SDL_LOG_CATEGORY_INPUT:
+				return "INPUT";
+			case SDL_LOG_CATEGORY_TEST:
+				return "TEST";
+
+			default:
+				return "UNKNOWN";
+		}
+	}
+
+	const char* mapPriority(SDL_LogPriority prio)
+	{
+		switch (prio) {
+		case SDL_LOG_PRIORITY_VERBOSE:
+			return "VRB";
+		case SDL_LOG_PRIORITY_DEBUG:
+			return "DBG";
+		case SDL_LOG_PRIORITY_INFO:
+			return "INF";
+		case SDL_LOG_PRIORITY_WARN:
+			return "WRN";
+		case SDL_LOG_PRIORITY_ERROR:
+			return "ERR";
+		case SDL_LOG_PRIORITY_CRITICAL:
+			return "CRI";
+
+		default:
+			return "UNK";
+		}
+	}
+
+	void SDLCALL logHandler(void*, int category, SDL_LogPriority priority, const char* message) {
+		if (priority >= SDL_LOG_PRIORITY_INFO) {
+			mprintf(("SDL [%s][%s]: %s\n", mapPriority(priority), mapCategory(category), message));
+		} else {
+			nprintf(("SDL", "SDL [%s][%s]: %s\n", mapPriority(priority), mapCategory(category), message));
+		}
+	}
 }
 
 
@@ -282,6 +337,11 @@ void os_init(const char * wclass, const char * title, const char * app_name)
 
 	mprintf(("  Initializing SDL %d.%d.%d (compiled with %d.%d.%d)...\n", linked.major, linked.minor, linked.patch,
 	         compiled.major, compiled.minor, compiled.patch));
+
+	if (LoggingEnabled) {
+		SDL_LogSetAllPriority(SDL_LOG_PRIORITY_VERBOSE);
+		SDL_LogSetOutputFunction(&logHandler, nullptr);
+	}
 
 	if (SDL_Init(SDL_INIT_EVENTS) < 0)
 	{


### PR DESCRIPTION
This can be useful when SDL produces log output that helps with
debugging an issue.