### PR TITLE
Changed require exact los to track from the exact firing point instead of center

### DIFF
--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -5775,6 +5775,15 @@ int ai_fire_primary_weapon(object *objp)
 		aip->primary_select_timestamp = timestamp(5 * 1000);	//	Maybe change primary weapon five seconds from now.
 	}
 
+	//We can only check LoS if we have a target defined
+	weapon_info* wip = &Weapon_info[swp->primary_bank_weapons[swp->current_primary_bank]];
+	if (aip->target_objnum != -1 && (The_mission.ai_profile->flags[AI::Profile_Flags::Require_exact_los] || wip->wi_flags[Weapon::Info_Flags::Require_exact_los])) {
+		//Check if th AI has Line of Sight and is allowed to fire
+		if (!check_los(OBJ_INDEX(objp), aip->target_objnum, 10.0f, swp->current_primary_bank, -1, nullptr)) {
+			return 0;
+		}
+	}
+
 	//	If pointing nearly at predicted collision point of target, bash orientation to be perfectly pointing.
 	float	dot;
 	vec3d	v2t;
@@ -6123,7 +6132,7 @@ int check_ok_to_fire(int objnum, int target_objnum, weapon_info *wip, int second
 
 		if (The_mission.ai_profile->flags[AI::Profile_Flags::Require_exact_los] || wip->wi_flags[Weapon::Info_Flags::Require_exact_los]) {
 			//Check if th AI has Line of Sight and is allowed to fire
-			if (!check_los(objnum, target_objnum, 10.0f, secondary_bank, turret)) {
+			if (!check_los(objnum, target_objnum, 10.0f, -1, secondary_bank, turret)) {
 				return 0;
 			}
 		}
@@ -6170,28 +6179,30 @@ int check_ok_to_fire(int objnum, int target_objnum, weapon_info *wip, int second
 //	--------------------------------------------------------------------------
 //  Returns true if *aip has a line of sight to its current target.
 //	threshold defines the minimum radius for an object to be considered relevant for LoS
-bool check_los(int objnum, int target_objnum, float threshold, int secondary_bank, ship_subsys* turret) {
+bool check_los(int objnum, int target_objnum, float threshold, int primary_bank, int secondary_bank, ship_subsys* turret) {
 
 	//Do both checks over an XOR-Check for more detailed messages
-	Assertion(secondary_bank != -1 || turret != nullptr, "Cannot check line of sight from a model with neither a secondary bank nor a turret set as a source.");
-	Assertion(!(secondary_bank != -1 && turret != nullptr), "Cannot check line of sight from a model with both a secondary bank and a turret set as source.");
+	int sources = (primary_bank != -1 ? 1 : 0) + (secondary_bank != -1 ? 1 : 0) + (turret != nullptr ? 1 : 0);
+	Assertion(sources >= 1, "Cannot check line of sight from a model with neither a primar bank, nor secondary bank nor a turret set as a source.");
+	Assertion(sources <= 1, "Cannot check line of sight from a model with more than one source set.");
 
 	vec3d start;
 
 	object* firing_ship = &Objects[objnum];
 
-	if (secondary_bank == -1) {
+	if (turret != nullptr) {
 		vec3d turret_fvec;
 		//It doesn't like not having an fvec output vector, so give it a dummy vector
 		ship_get_global_turret_gun_info(firing_ship, turret, &start, &turret_fvec, 1, nullptr);
 	} else {
+		bool is_primary = secondary_bank == -1;
 		ship *shipp = &Ships[firing_ship->instance];
 		ship_weapon *swp = &shipp->weapons;
-		weapon_info *wip = &Weapon_info[swp->secondary_bank_weapons[secondary_bank]];
+		weapon_info *wip = &Weapon_info[is_primary ? swp->primary_bank_weapons[primary_bank] : swp->secondary_bank_weapons[secondary_bank]];
 		polymodel* pm = model_get(Ship_info[shipp->ship_info_index].model_num);
 		
-		vec3d pnt = pm->missile_banks[secondary_bank].pnt[swp->secondary_next_slot[secondary_bank]];
-		vec3d missile_point;
+		vec3d pnt = is_primary ? pm->gun_banks[primary_bank].pnt[swp->primary_next_slot[primary_bank]] : pm->missile_banks[secondary_bank].pnt[swp->secondary_next_slot[secondary_bank]];
+		vec3d firing_point;
 
 		//Following Section taken from ship.cpp ship_fire_secondary()
 		polymodel* weapon_model = nullptr;
@@ -6200,7 +6211,7 @@ bool check_los(int objnum, int target_objnum, float threshold, int secondary_ban
 		}
 
 		if (weapon_model && weapon_model->n_guns) {
-			int external_bank = secondary_bank + MAX_SHIP_PRIMARY_BANKS;
+			int external_bank = is_primary ? primary_bank : secondary_bank + MAX_SHIP_PRIMARY_BANKS;
 			if (wip->wi_flags[Weapon::Info_Flags::External_weapon_fp]) {
 				if ((weapon_model->n_guns <= swp->external_model_fp_counter[external_bank]) || (swp->external_model_fp_counter[external_bank] < 0))
 					swp->external_model_fp_counter[external_bank] = 0;
@@ -6212,8 +6223,8 @@ bool check_los(int objnum, int target_objnum, float threshold, int secondary_ban
 				vm_vec_add2(&pnt, &weapon_model->gun_banks[0].pnt[0]);
 			}
 		}
-		vm_vec_unrotate(&missile_point, &pnt, &firing_ship->orient);
-		vm_vec_add(&start, &missile_point, &firing_ship->pos);
+		vm_vec_unrotate(&firing_point, &pnt, &firing_ship->orient);
+		vm_vec_add(&start, &firing_point, &firing_ship->pos);
 	}
 
 	vec3d& end = Objects[target_objnum].pos;

--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -6107,7 +6107,7 @@ float compute_incoming_payload(object *target_objp)
 //			OR: secondary los flag is set but no line of sight is availabe
 //	Note: If player is attacking a ship, that ship is allowed to fire at player.  Otherwise, we get in a situation in which
 //	player is attacking a large ship, but that large ship is not defending itself with missiles.
-int check_ok_to_fire(int objnum, int target_objnum, weapon_info *wip)
+int check_ok_to_fire(int objnum, int target_objnum, weapon_info *wip, int secondary_bank, ship_subsys* turret)
 {
 	int	num_homers = 0;
 
@@ -6123,7 +6123,7 @@ int check_ok_to_fire(int objnum, int target_objnum, weapon_info *wip)
 
 		if (The_mission.ai_profile->flags[AI::Profile_Flags::Require_exact_los] || wip->wi_flags[Weapon::Info_Flags::Require_exact_los]) {
 			//Check if th AI has Line of Sight and is allowed to fire
-			if (!check_los(objnum, target_objnum, 10.0f)) {
+			if (!check_los(objnum, target_objnum, 10.0f, secondary_bank, turret)) {
 				return 0;
 			}
 		}
@@ -6170,9 +6170,53 @@ int check_ok_to_fire(int objnum, int target_objnum, weapon_info *wip)
 //	--------------------------------------------------------------------------
 //  Returns true if *aip has a line of sight to its current target.
 //	threshold defines the minimum radius for an object to be considered relevant for LoS
-bool check_los(int objnum, int target_objnum, float threshold) {
+bool check_los(int objnum, int target_objnum, float threshold, int secondary_bank, ship_subsys* turret) {
+
+	//Do both checks over an XOR-Check for more detailed messages
+	Assertion(secondary_bank != -1 || turret != nullptr, "Cannot check line of sight from a model with neither a secondary bank nor a turret set as a source.");
+	Assertion(secondary_bank != -1 && turret != nullptr, "Cannot check line of sight from a model with both a secondary bank and a turret set.");
+
+	vec3d start;
+
+	object* firing_ship = &Objects[objnum];
+
+	if (secondary_bank == -1) {
+		vec3d turret_fvec;
+		//It doesn't like not having an fvec output vector, so give it a dummy vector
+		ship_get_global_turret_gun_info(firing_ship, turret, &start, &turret_fvec, 1, nullptr);
+	} else {
+		ship *shipp = &Ships[firing_ship->instance];
+		ship_weapon *swp = &shipp->weapons;
+		weapon_info *wip = &Weapon_info[swp->secondary_bank_weapons[secondary_bank]];
+		polymodel* pm = model_get(Ship_info[shipp->ship_info_index].model_num);
+		
+		vec3d pnt = pm->missile_banks[secondary_bank].pnt[swp->secondary_next_slot[secondary_bank]];
+		vec3d missile_point;
+
+		//Following Section taken from ship.cpp ship_fire_secondary()
+		polymodel* weapon_model = nullptr;
+		if (wip->external_model_num >= 0) {
+			weapon_model = model_get(wip->external_model_num);
+		}
+
+		if (weapon_model && weapon_model->n_guns) {
+			int external_bank = secondary_bank + MAX_SHIP_PRIMARY_BANKS;
+			if (wip->wi_flags[Weapon::Info_Flags::External_weapon_fp]) {
+				if ((weapon_model->n_guns <= swp->external_model_fp_counter[external_bank]) || (swp->external_model_fp_counter[external_bank] < 0))
+					swp->external_model_fp_counter[external_bank] = 0;
+				vm_vec_add2(&pnt, &weapon_model->gun_banks[0].pnt[swp->external_model_fp_counter[external_bank]]);
+				swp->external_model_fp_counter[external_bank]++;
+			}
+			else {
+				// make it use the 0 index slot
+				vm_vec_add2(&pnt, &weapon_model->gun_banks[0].pnt[0]);
+			}
+		}
+		vm_vec_unrotate(&missile_point, &pnt, &firing_ship->orient);
+		vm_vec_add(&start, &missile_point, &firing_ship->pos);
+	}
+
 	vec3d& end = Objects[target_objnum].pos;
-	vec3d& start = Objects[objnum].pos;
 
 	object* objp;
 
@@ -6310,7 +6354,7 @@ int ai_fire_secondary_weapon(object *objp)
 		
 		//	Note, maybe don't fire if firing at player and any homers yet fired.
 		//	Decreasing chance to fire the more homers are incoming on player.
-		if (check_ok_to_fire(OBJ_INDEX(objp), aip->target_objnum, wip)) {
+		if (check_ok_to_fire(OBJ_INDEX(objp), aip->target_objnum, wip, current_bank, nullptr)) {
 			if (ship_fire_secondary(objp)) {
 				rval = 1;
 				swp->next_secondary_fire_stamp[current_bank] = timestamp(500);

--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -6174,7 +6174,7 @@ bool check_los(int objnum, int target_objnum, float threshold, int secondary_ban
 
 	//Do both checks over an XOR-Check for more detailed messages
 	Assertion(secondary_bank != -1 || turret != nullptr, "Cannot check line of sight from a model with neither a secondary bank nor a turret set as a source.");
-	Assertion(secondary_bank != -1 && turret != nullptr, "Cannot check line of sight from a model with both a secondary bank and a turret set.");
+	Assertion(!(secondary_bank != -1 && turret != nullptr), "Cannot check line of sight from a model with both a secondary bank and a turret set as source.");
 
 	vec3d start;
 

--- a/code/ai/aiinternal.h
+++ b/code/ai/aiinternal.h
@@ -26,10 +26,10 @@ int object_is_targetable(object *target, ship *viewer);
 int num_nearby_fighters(int enemy_team_mask, vec3d *pos, float threshold);
 
 //Returns true if OK for *aip to fire its current weapon at its current target.
-int check_ok_to_fire(int objnum, int target_objnum, weapon_info *wip);
+int check_ok_to_fire(int objnum, int target_objnum, weapon_info *wip, int secondary_bank, ship_subsys* turret);
 
 //Returns true if *aip has a line of sight to its current target.
-bool check_los(int objnum, int target_objnum, float threshold);
+bool check_los(int objnum, int target_objnum, float threshold, int secondary_bank, ship_subsys* turret);
 
 //Does all the stuff needed to aim and fire a turret.
 void ai_fire_from_turret(ship *shipp, ship_subsys *ss, int parent_objnum);

--- a/code/ai/aiinternal.h
+++ b/code/ai/aiinternal.h
@@ -29,7 +29,7 @@ int num_nearby_fighters(int enemy_team_mask, vec3d *pos, float threshold);
 int check_ok_to_fire(int objnum, int target_objnum, weapon_info *wip, int secondary_bank, ship_subsys* turret);
 
 //Returns true if *aip has a line of sight to its current target.
-bool check_los(int objnum, int target_objnum, float threshold, int secondary_bank, ship_subsys* turret);
+bool check_los(int objnum, int target_objnum, float threshold, int primary_bank, int secondary_bank, ship_subsys* turret);
 
 //Does all the stuff needed to aim and fire a turret.
 void ai_fire_from_turret(ship *shipp, ship_subsys *ss, int parent_objnum);

--- a/code/ai/aiturret.cpp
+++ b/code/ai/aiturret.cpp
@@ -1839,7 +1839,7 @@ bool turret_fire_weapon(int weapon_num, ship_subsys *turret, int parent_objnum, 
 	}
 #endif
 
-	if (check_ok_to_fire(parent_objnum, turret->turret_enemy_objnum, wip)) {
+	if (check_ok_to_fire(parent_objnum, turret->turret_enemy_objnum, wip, -1, turret)) {
 		vm_vector_2_matrix(&turret_orient, turret_fvec, NULL, NULL);
 		turret->turret_last_fire_direction = *turret_fvec;
 


### PR DESCRIPTION
As this feature is very new, it's probably fine to change it instead of adding a new flag.
This change make the actual firing point of the turret / secondary bank matter and not just raycast center to center, which should help for large capital ships using this flag.
While it seems to work for me, I'd like some help with testing. Pinging @EatThePath, as he requested this change for a specific mission it seems.