### PR TITLE
Make model point picking more flexible

### DIFF
--- a/code/model/modelinterp.cpp
+++ b/code/model/modelinterp.cpp
@@ -1233,21 +1233,8 @@ void submodel_get_two_random_points(int model_num, int submodel_num, vec3d *v1, 
 		return;
 	}
 
-#ifndef NDEBUG
-	if (RAND_MAX < nv)
-	{
-		static int submodel_get_two_random_points_warned = false;
-		if (!submodel_get_two_random_points_warned)
-		{
-			polymodel *pm = model_get(model_num);
-			Warning(LOCATION, "RAND_MAX is only %d, but submodel %d for model %s has %d vertices!  Explosions will not propagate through the entire model!\n", RAND_MAX, submodel_num, pm->filename, nv);
-			submodel_get_two_random_points_warned = true;
-		}
-	}
-#endif
-
-	int vn1 = myrand() % nv;
-	int vn2 = myrand() % nv;
+	int vn1 = rand32() % nv;
+	int vn2 = rand32() % nv;
 
 	*v1 = *Interp_verts[vn1];
 	*v2 = *Interp_verts[vn2];
@@ -1292,20 +1279,8 @@ void submodel_get_two_random_points_better(int model_num, int submodel_num, vec3
 			return;
 		}
 
-#ifndef NDEBUG
-		if (RAND_MAX < nv)
-		{
-			static int submodel_get_two_random_points_warned = false;
-			if (!submodel_get_two_random_points_warned)
-			{
-				Warning(LOCATION, "RAND_MAX is only %d, but submodel %d for model %s has %d vertices!  Explosions will not propagate through the entire model!\n", RAND_MAX, submodel_num, pm->filename, nv);
-				submodel_get_two_random_points_warned = true;
-			}
-		}
-#endif
-
-		int vn1 = myrand() % nv;
-		int vn2 = myrand() % nv;
+		int vn1 = rand32() % nv;
+		int vn2 = rand32() % nv;
 
 		*v1 = tree->point_list[vn1];
 		*v2 = tree->point_list[vn2];


### PR DESCRIPTION
This works around the Windows only limitation where the standard random
function only returns up to 2^15 which limits how many vertices in the
model can be picked.

Since we already have a function that handles this properly and returns
values in the entire integer range, using that fixes that low limit.