### PR TITLE
Restore deprecated drawMonochromeImage

### DIFF
--- a/code/scripting/api/libs/graphics.cpp
+++ b/code/scripting/api/libs/graphics.cpp
@@ -1388,7 +1388,7 @@ ADE_FUNC(drawImage,
 	return ADE_RETURN_TRUE;
 }
 
-ADE_FUNC_DEPRECATED(drawMonochromeImage,
+ADE_FUNC(drawMonochromeImage,
 	l_Graphics,
 	"string|texture fileNameOrTexture, number X1, number Y1, [number X2, number Y2, number alpha=1.0]",
 	"Draws a monochrome image from a texture or file using the current color",


### PR DESCRIPTION
this is a quick fix to #3027, which simply undoes the marking of the function as deprecated. This is a bandaid, I assume it would be preferable to have the function still deprecated with a log message/warning rather than an error/CTD, but given the severity of the issue caused I thought a quick fix may be appropriate.