### PR TITLE
Update deprecation version of drawMonochromeImage

### DIFF
--- a/code/scripting/api/libs/graphics.cpp
+++ b/code/scripting/api/libs/graphics.cpp
@@ -1394,7 +1394,7 @@ ADE_FUNC_DEPRECATED(drawMonochromeImage,
 	"Draws a monochrome image from a texture or file using the current color",
 	"boolean",
 	"Whether image was drawn",
-	gameversion::version(20, 1),
+	gameversion::version(21, 0),
 	"gr.drawImage now has support for drawing monochrome images with full UV scaling support")
 {
 	if(!Gr_inited)


### PR DESCRIPTION
This was 20.1 since I erronously thought that the "current" nightly
version was lower than that. This updates the version to a release that
has not been built yet.

Fixes #3027.