### PR TITLE
Fix CTD on death while support is trying to dock

### DIFF
--- a/code/object/objectdock.cpp
+++ b/code/object/objectdock.cpp
@@ -105,8 +105,8 @@ bool dock_check_find_direct_docked_object(object *objp, object *other_objp)
 
 bool dock_check_find_docked_object(object *objp, object *other_objp)
 {
-	Assert(objp != NULL);
-	Assert(other_objp != NULL);
+	Assert(objp != nullptr && objp->signature > 0);
+	Assert(other_objp != nullptr && other_objp->signature > 0);
 
 	if (!(objp != nullptr && objp->signature > 0))
 		return false;

--- a/code/object/objectdock.cpp
+++ b/code/object/objectdock.cpp
@@ -105,8 +105,11 @@ bool dock_check_find_direct_docked_object(object *objp, object *other_objp)
 
 bool dock_check_find_docked_object(object *objp, object *other_objp)
 {
-	Assert(objp != nullptr && objp->signature > 0);
-	Assert(other_objp != nullptr && other_objp->signature > 0);
+	Assert(objp != nullptr);
+	Assert(objp->signature > 0);
+	Assert(other_objp != nullptr);
+	Assert(other_objp->signature > 0);
+
 
 	if (!(objp != nullptr && objp->signature > 0))
 		return false;

--- a/code/object/objectdock.cpp
+++ b/code/object/objectdock.cpp
@@ -108,6 +108,11 @@ bool dock_check_find_docked_object(object *objp, object *other_objp)
 	Assert(objp != NULL);
 	Assert(other_objp != NULL);
 
+	if (!(objp != NULL && objp->signature > 0))
+		return false;
+	if (!(other_objp != NULL && other_objp->signature > 0))
+		return false;
+
 	dock_function_info dfi;
 	dfi.parameter_variables.objp_value = other_objp;
 

--- a/code/object/objectdock.cpp
+++ b/code/object/objectdock.cpp
@@ -108,9 +108,9 @@ bool dock_check_find_docked_object(object *objp, object *other_objp)
 	Assert(objp != NULL);
 	Assert(other_objp != NULL);
 
-	if (!(objp != NULL && objp->signature > 0))
+	if (!(objp != nullptr && objp->signature > 0))
 		return false;
-	if (!(other_objp != NULL && other_objp->signature > 0))
+	if (!(other_objp != nullptr && other_objp->signature > 0))
 		return false;
 
 	dock_function_info dfi;


### PR DESCRIPTION
This is an issue that only occurs on release builds. I suspect debug builds silently filter bad ID's earlier when evaluating collisions.
The issue is not directly the object (presumably the player) being null, rather it's id being invalid. This filters this, but obviously doesn't really solve the underlying issue, of the player's ship being target for docking even after dying.
For more context, the stack was:

ship_ship_check_collision
->check_for_docking_collision (the aip2->mode == AIM_DOCK branch)
-> dock_check_find_docked_object
bad read on (now) line 119, the function call to dock_evaluate_all_docked_objects