### PR TITLE
Apply particle source hack to correct vector

### DIFF
--- a/code/particle/ParticleManager.cpp
+++ b/code/particle/ParticleManager.cpp
@@ -250,7 +250,12 @@ ParticleSourceWrapper ParticleManager::createSource(ParticleEffectHandle index)
 
 		// UGH, HACK! To implement the source wrapper we need constant pointers to all sources.
 		// To ensure this we reserve the number of sources we will need (current sources + sources being created)
-		m_sources.reserve(m_sources.size() + childEffects.size());
+		if (m_processingSources) {
+			// If we are already in our onFrame, we need to apply the hack to the right vector though
+			m_deferredSourceAdding.reserve(m_sources.size() + childEffects.size());
+		} else {
+			m_sources.reserve(m_sources.size() + childEffects.size());
+		}
 
 		for (auto& effect : childEffects) {
 			ParticleSource* source = createSource();


### PR DESCRIPTION
In the particle effect code there is a small hack required for getting
some constant pointers in a vector. However, there is another mechanism
where sources are not added to the sources vector if the sources are
currently being iterated through. That is necessary to avoid
accidentally invalidating the iterators.

The issue here was that the vector resizing hack was not applied to the
correct vector when we were currently iterating. This fixes that.

This fixes #2928.