### PR TITLE
Add GitHub actions test build support

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -1,9 +1,9 @@
-name: Build Nightly package
+name: Build Test package
 
 on:
   push:
-    tags:
-      - 'nightly_*'
+    branches:
+      - 'test/*'
 
 env:
   QT_VERSION: 5.12.9
@@ -34,6 +34,12 @@ jobs:
         name: Checkout
         with:
           submodules: true
+      - name: Set up test version
+        shell: bash
+        run: |
+          [[ "${{ github.ref }}" =~ ^refs\/heads\/test\/(.*)$ ]]
+          # Override the revision string so that the builds are named correctly
+          echo "set(FSO_VERSION_REVISION_STR ${BASH_REMATCH[1]})" > "version_override.cmake"
       - name: Configure CMake
         env:
           CONFIGURATION: ${{ matrix.configuration }}
@@ -67,11 +73,12 @@ jobs:
     runs-on: ubuntu-latest
     container: ghcr.io/scp-fs2open/sftp_upload:sha-dd9d8cf
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
         name: Checkout
         with:
           submodules: true
           fetch-depth: '0'
+          ref: '${{ github.ref }}'
       - name: Download Release builds
         uses: actions/download-artifact@v1
         with:
@@ -92,7 +99,7 @@ jobs:
           INDIEGAMES_SSHPASS: ${{ secrets.INDIEGAMES_PASSWORD }}
           DATACORDER_USER: ${{ secrets.DATACORDER_USER }}
           DATACORDER_SSHPASS: ${{ secrets.DATACORDER_PASSWORD }}
-        run: $GITHUB_WORKSPACE/ci/linux/upload_dist_package.sh nightly
+        run: $GITHUB_WORKSPACE/ci/linux/upload_dist_package.sh test
 
   build_windows:
     strategy:
@@ -107,6 +114,12 @@ jobs:
         name: Checkout
         with:
           submodules: true
+      - name: Set up test version
+        shell: bash
+        run: |
+          [[ "${{ github.ref }}" =~ ^refs\/heads\/test\/(.*)$ ]]
+          # Override the revision string so that the builds are named correctly
+          echo "set(FSO_VERSION_REVISION_STR ${BASH_REMATCH[1]})" > "version_override.cmake"
       - name: Cache Qt
         id: cache-qt-win
         uses: actions/cache@v1
@@ -177,11 +190,12 @@ jobs:
         arch: [Win32, x64]
         simd: [SSE2]
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
         name: Checkout
         with:
           submodules: true
           fetch-depth: '0'
+          ref: '${{ github.ref }}'
       - name: Download Release builds
         uses: actions/download-artifact@v1
         with:
@@ -207,4 +221,4 @@ jobs:
           INDIEGAMES_SSHPASS: ${{ secrets.INDIEGAMES_PASSWORD }}
           DATACORDER_USER: ${{ secrets.DATACORDER_USER }}
           DATACORDER_SSHPASS: ${{ secrets.DATACORDER_PASSWORD }}
-        run: $GITHUB_WORKSPACE/ci/linux/upload_dist_package.sh nightly
+        run: $GITHUB_WORKSPACE/ci/linux/upload_dist_package.sh test

--- a/ci/linux/dist_functions.sh
+++ b/ci/linux/dist_functions.sh
@@ -1,11 +1,16 @@
 function get_package_name() {
-  if git describe --match 'nightly_*' --exact-match >/dev/null; then
+  if git describe --match 'nightly_*' --exact-match 2>/dev/null >/dev/null; then
     echo -n "$(git describe --match "nightly_*" --exact-match)"
     return
   fi
 
-  if git describe --match 'release_*' --exact-match >/dev/null; then
+  if git describe --match 'release_*' --exact-match 2>/dev/null >/dev/null; then
     echo -n "$(git describe --match "release_*" --exact-match | sed 's/release_/fs2_open_/i')"
+    return
+  fi
+
+  if [[ "$(git branch --show-current)" =~ ^test\/(.*)$ ]]; then
+    echo -n "test_${BASH_REMATCH[1]}"
     return
   fi
 
@@ -13,7 +18,7 @@ function get_package_name() {
 }
 
 function get_version_name() {
-  if git describe --match 'nightly_*' --exact-match >/dev/null; then
+  if git describe --match 'nightly_*' --exact-match 2>/dev/null >/dev/null; then
     local tag_name=$(git describe --match "nightly_*" --exact-match)
 
     # Use the bash regex matching for getting the relevant part of the tag name
@@ -23,12 +28,17 @@ function get_version_name() {
     return
   fi
 
-  if git describe --match 'release_*' --exact-match >/dev/null; then
+  if git describe --match 'release_*' --exact-match 2>/dev/null >/dev/null; then
     local tag_name=$(git describe --match "release_*" --exact-match)
 
     # Use the bash regex matching for getting the relevant part of the tag name
     [[ $tag_name =~ ^release_(.*)$ ]]
 
+    echo -n "${BASH_REMATCH[1]}"
+    return
+  fi
+
+  if [[ "$(git branch --show-current)" =~ ^test\/(.*)$ ]]; then
     echo -n "${BASH_REMATCH[1]}"
     return
   fi

--- a/ci/linux/upload_dist_package.sh
+++ b/ci/linux/upload_dist_package.sh
@@ -2,11 +2,20 @@
 
 set -e
 
+UPLOAD_TYPE=$1
+
 SCRIPT=$(readlink -f "$0")
 HERE=$(dirname "$SCRIPT")
 
 source $HERE/dist_functions.sh
 
-SSHPASS=$INDIEGAMES_SSHPASS upload_files_to_sftp "$INDIEGAMES_USER@scp.indiegames.us" "public_html/builds/nightly"
+if [ "$UPLOAD_TYPE" = "nightly" ]; then
+    SSHPASS=$INDIEGAMES_SSHPASS upload_files_to_sftp "$INDIEGAMES_USER@scp.indiegames.us" "public_html/builds/nightly"
 
-SSHPASS=$DATACORDER_SSHPASS upload_files_to_sftp "$DATACORDER_USER@porphyrion.feralhosting.com" "www/datacorder.porphyrion.feralhosting.com/public_html/builds/nightly"
+    SSHPASS=$DATACORDER_SSHPASS upload_files_to_sftp "$DATACORDER_USER@porphyrion.feralhosting.com" "www/datacorder.porphyrion.feralhosting.com/public_html/builds/nightly"
+elif [ "$UPLOAD_TYPE" = "test" ]; then
+    SSHPASS=$DATACORDER_SSHPASS upload_files_to_sftp "$DATACORDER_USER@porphyrion.feralhosting.com" "www/datacorder.porphyrion.feralhosting.com/public_html/builds/test"
+else
+    echo "Unknown upload type $UPLOAD_TYPE"
+    exit 1
+fi


### PR DESCRIPTION
This was previously a feature of Travis and Appveyor and is very useful for producing all necessary builds for testing purposes.