### PR TITLE
Allow submodels to rotate around an arbitrary axis

### DIFF
--- a/code/asteroid/asteroid.cpp
+++ b/code/asteroid/asteroid.cpp
@@ -1045,13 +1045,13 @@ int asteroid_check_collision(object *pasteroid, object *other_obj, vec3d *hitpos
 					smi->collision_checked = false;
 
 					// set angles for last frame (need to set to prev to get p0)
-					angles copy_angles = smi->angs;
+					matrix copy_matrix = smi->canonical_orient;
 
 					// find the start and end positions of the sphere in submodel RF
-					smi->angs = smi->prev_angs;
+					smi->canonical_orient = smi->canonical_prev_orient;
 					world_find_model_instance_point(&p0, &light_obj->last_pos, pm, pmi, submodel, &heavy_obj->last_orient, &heavy_obj->last_pos);
 
-					smi->angs = copy_angles;
+					smi->canonical_orient = copy_matrix;
 					world_find_model_instance_point(&p1, &light_obj->pos, pm, pmi, submodel, &heavy_obj->orient, &heavy_obj->pos);
 
 					mc.p0 = &p0;

--- a/code/asteroid/asteroid.cpp
+++ b/code/asteroid/asteroid.cpp
@@ -1069,7 +1069,7 @@ int asteroid_check_collision(object *pasteroid, object *other_obj, vec3d *hitpos
 
 							// set up asteroid_hit_info for rotating submodel
 							if (asteroid_hit_info->edge_hit == 0) {
-								model_instance_find_obj_dir(&asteroid_hit_info->collision_normal, &mc.hit_normal, pm, pmi, mc.hit_submodel, &heavy_obj->orient);
+								model_instance_find_world_dir(&asteroid_hit_info->collision_normal, &mc.hit_normal, pm, pmi, mc.hit_submodel, &heavy_obj->orient);
 							}
 
 							// find position in submodel RF of light object at collison
@@ -1101,7 +1101,7 @@ int asteroid_check_collision(object *pasteroid, object *other_obj, vec3d *hitpos
 
 					// get collision normal if not edge hit
 					if (asteroid_hit_info->edge_hit == 0) {
-						model_instance_find_obj_dir(&asteroid_hit_info->collision_normal, &mc.hit_normal, pm, pmi, mc.hit_submodel, &heavy_obj->orient);
+						model_instance_find_world_dir(&asteroid_hit_info->collision_normal, &mc.hit_normal, pm, pmi, mc.hit_submodel, &heavy_obj->orient);
 					}
 
 					// find position in submodel RF of light object at collison

--- a/code/debris/debris.cpp
+++ b/code/debris/debris.cpp
@@ -899,13 +899,13 @@ int debris_check_collision(object *pdebris, object *other_obj, vec3d *hitpos, co
 					smi->collision_checked = false;
 
 					// set angles for last frame (need to set to prev to get p0)
-					angles copy_angles = smi->angs;
+					matrix copy_matrix = smi->canonical_orient;
 
 					// find the start and end positions of the sphere in submodel RF
-					smi->angs = smi->prev_angs;
+					smi->canonical_orient = smi->canonical_prev_orient;
 					world_find_model_instance_point(&p0, &light_obj->last_pos, pm, pmi, submodel, &heavy_obj->last_orient, &heavy_obj->last_pos);
 
-					smi->angs = copy_angles;
+					smi->canonical_orient = copy_matrix;
 					world_find_model_instance_point(&p1, &light_obj->pos, pm, pmi, submodel, &heavy_obj->orient, &heavy_obj->pos);
 
 					mc.p0 = &p0;

--- a/code/debris/debris.cpp
+++ b/code/debris/debris.cpp
@@ -924,7 +924,7 @@ int debris_check_collision(object *pdebris, object *other_obj, vec3d *hitpos, co
 
 							// set up debris_hit_info for rotating submodel
 							if (debris_hit_info->edge_hit == 0) {
-								model_instance_find_obj_dir(&debris_hit_info->collision_normal, &mc.hit_normal, pm, pmi, mc.hit_submodel, &heavy_obj->orient);
+								model_instance_find_world_dir(&debris_hit_info->collision_normal, &mc.hit_normal, pm, pmi, mc.hit_submodel, &heavy_obj->orient);
 							}
 
 							// find position in submodel RF of light object at collison
@@ -956,7 +956,7 @@ int debris_check_collision(object *pdebris, object *other_obj, vec3d *hitpos, co
 
 					// get collision normal if not edge hit
 					if (debris_hit_info->edge_hit == 0) {
-						model_instance_find_obj_dir(&debris_hit_info->collision_normal, &mc.hit_normal, pm, pmi, mc.hit_submodel, &heavy_obj->orient);
+						model_instance_find_world_dir(&debris_hit_info->collision_normal, &mc.hit_normal, pm, pmi, mc.hit_submodel, &heavy_obj->orient);
 					}
 
 					// find position in submodel RF of light object at collison

--- a/code/model/model.h
+++ b/code/model/model.h
@@ -95,9 +95,6 @@ struct submodel_instance
 
 	// These fields are the true standard reference for submodel rotation.  They should seldom be read directly
 	// and should almost never be written directly.  In most cases, coders should prefer cur_angle and prev_angle.
-	// NOTE: IF THE ANGLES ARE MODIFIED, THE ORIENT SHOULD BE MODIFIED TOO!
-
-	angles	canonical_angs = vmd_zero_angles;
 	matrix	canonical_orient = vmd_identity_matrix;
 	matrix	canonical_prev_orient = vmd_identity_matrix;
 

--- a/code/model/modelanim.cpp
+++ b/code/model/modelanim.cpp
@@ -434,7 +434,7 @@ void model_anim_submodel_trigger_rotate(model_subsystem *psub, ship_subsys *ss)
 		return;
 
 	// save last angles
-	smi->prev_angs = smi->angs;
+	smi->canonical_prev_orient = smi->canonical_orient;
 
 	// process velocity and position
 	// first you accelerate, then you maintain a speed, then you slow down, then you stay put
@@ -517,24 +517,28 @@ void model_anim_submodel_trigger_rotate(model_subsystem *psub, ship_subsys *ss)
 	smi->turn_accel = vm_vec_mag(&trigger->rot_accel);
 
 	// the extra math here is/was useless, it just returns the exact same value (or really just 0 in the old code)
-	smi->angs.p = trigger->current_ang.xyz.x; //- (2.0f * PI2 * (trigger->current_ang.xyz.x / (2.0f * PI2)));
-	smi->angs.h = trigger->current_ang.xyz.y; //- (2.0f * PI2 * (trigger->current_ang.xyz.y / (2.0f * PI2)));
-	smi->angs.b = trigger->current_ang.xyz.z; //- (2.0f * PI2 * (trigger->current_ang.xyz.z / (2.0f * PI2)));
+	angles angs;
+	angs.p = trigger->current_ang.xyz.x; //- (2.0f * PI2 * (trigger->current_ang.xyz.x / (2.0f * PI2)));
+	angs.h = trigger->current_ang.xyz.y; //- (2.0f * PI2 * (trigger->current_ang.xyz.y / (2.0f * PI2)));
+	angs.b = trigger->current_ang.xyz.z; //- (2.0f * PI2 * (trigger->current_ang.xyz.z / (2.0f * PI2)));
 
-	if (smi->angs.p >= PI2)
-		smi->angs.p -= PI2;
-	else if (smi->angs.p < 0.0f)
-		smi->angs.p += PI2;
+	if (angs.p >= PI2)
+		angs.p -= PI2;
+	else if (angs.p < 0.0f)
+		angs.p += PI2;
 
-	if (smi->angs.h >= PI2)
-		smi->angs.h -= PI2;
-	else if (smi->angs.h < 0.0f)
-		smi->angs.h += PI2;
+	if (angs.h >= PI2)
+		angs.h -= PI2;
+	else if (angs.h < 0.0f)
+		angs.h += PI2;
 
-	if (smi->angs.b >= PI2)
-		smi->angs.b -= PI2;
-	else if (smi->angs.b < 0.0f)
-		smi->angs.b += PI2;
+	if (angs.b >= PI2)
+		angs.b -= PI2;
+	else if (angs.b < 0.0f)
+		angs.b += PI2;
+
+	smi->canonical_angs = angs;
+	vm_angles_2_matrix(&smi->canonical_orient, &angs);
 }
 
 //************************************//
@@ -595,7 +599,8 @@ bool model_anim_start_type(ship_subsys *pss, AnimationTriggerType animation_type
 			// rotate instantly; don't use the queue
 			if (instant) {
 				trigger->set_to_final(&psub->triggers[i]);
-				trigger->apply_trigger_angles(&pss->submodel_instance_1->angs);
+				trigger->apply_trigger_angles(&pss->submodel_instance_1->canonical_angs);
+				vm_angles_2_matrix(&pss->submodel_instance_1->canonical_orient, &pss->submodel_instance_1->canonical_angs);
 
 				retval = true;
 			}
@@ -861,6 +866,9 @@ void model_anim_set_initial_states(ship *shipp)
 	ship_primary_changed(shipp);
 	ship_secondary_changed(shipp);
 
+	auto pmi = model_get_instance(shipp->model_instance_num);
+	auto pm = model_get(pmi->model_num);
+
 	for ( pss = GET_FIRST(&shipp->subsys_list); pss != END_OF_LIST(&shipp->subsys_list); pss = GET_NEXT(pss) ) {
 		psub = pss->system_info;
 
@@ -868,10 +876,14 @@ void model_anim_set_initial_states(ship *shipp)
 			if (psub->triggers[i].type == AnimationTriggerType::Initial) {
 				if (psub->type == SUBSYSTEM_TURRET) {
 					// special case for turrets
-					if (pss->submodel_instance_2 != nullptr)
-						pss->submodel_instance_2->angs.p = psub->triggers[i].angle.xyz.x;
-					if (pss->submodel_instance_1 != nullptr)
-						pss->submodel_instance_1->angs.h = psub->triggers[i].angle.xyz.y;
+					if (pss->submodel_instance_1 != nullptr) {
+						pss->submodel_instance_1->cur_angle = psub->triggers[i].angle.xyz.y;
+						submodel_canonicalize(&pm->submodel[psub->subobj_num], pss->submodel_instance_1, true);
+					}
+					if (pss->submodel_instance_2 != nullptr) {
+						pss->submodel_instance_2->cur_angle = psub->triggers[i].angle.xyz.x;
+						submodel_canonicalize(&pm->submodel[psub->turret_gun_sobj], pss->submodel_instance_2, true);
+					}
 				} else {
 					if (pss->triggered_rotation_index < 0) {
 						mprintf(("Invalid rotation index for triggered rotation in subsystem %s in model %s!\n", psub->name, model_get(Ship_info[shipp->ship_info_index].model_num)->filename));
@@ -880,7 +892,8 @@ void model_anim_set_initial_states(ship *shipp)
 					triggered_rotation *tr = &Triggered_rotations[pss->triggered_rotation_index];
 
 					tr->set_to_initial(&psub->triggers[i]);
-					tr->apply_trigger_angles(&pss->submodel_instance_1->angs);
+					tr->apply_trigger_angles(&pss->submodel_instance_1->canonical_angs);
+					vm_angles_2_matrix(&pss->submodel_instance_1->canonical_orient, &pss->submodel_instance_1->canonical_angs);
 				}
 			}
 		}

--- a/code/model/modelanim.cpp
+++ b/code/model/modelanim.cpp
@@ -537,7 +537,6 @@ void model_anim_submodel_trigger_rotate(model_subsystem *psub, ship_subsys *ss)
 	else if (angs.b < 0.0f)
 		angs.b += PI2;
 
-	smi->canonical_angs = angs;
 	vm_angles_2_matrix(&smi->canonical_orient, &angs);
 }
 
@@ -599,8 +598,10 @@ bool model_anim_start_type(ship_subsys *pss, AnimationTriggerType animation_type
 			// rotate instantly; don't use the queue
 			if (instant) {
 				trigger->set_to_final(&psub->triggers[i]);
-				trigger->apply_trigger_angles(&pss->submodel_instance_1->canonical_angs);
-				vm_angles_2_matrix(&pss->submodel_instance_1->canonical_orient, &pss->submodel_instance_1->canonical_angs);
+
+				angles angs;
+				trigger->apply_trigger_angles(&angs);
+				vm_angles_2_matrix(&pss->submodel_instance_1->canonical_orient, &angs);
 
 				retval = true;
 			}
@@ -892,8 +893,10 @@ void model_anim_set_initial_states(ship *shipp)
 					triggered_rotation *tr = &Triggered_rotations[pss->triggered_rotation_index];
 
 					tr->set_to_initial(&psub->triggers[i]);
-					tr->apply_trigger_angles(&pss->submodel_instance_1->canonical_angs);
-					vm_angles_2_matrix(&pss->submodel_instance_1->canonical_orient, &pss->submodel_instance_1->canonical_angs);
+
+					angles angs;
+					tr->apply_trigger_angles(&angs);
+					vm_angles_2_matrix(&pss->submodel_instance_1->canonical_orient, &angs);
 				}
 			}
 		}

--- a/code/model/modelcollide.cpp
+++ b/code/model/modelcollide.cpp
@@ -1188,32 +1188,12 @@ NoHit:
 		// Don't check it or its children if it is destroyed
 		// or if it's set to no collision
 		if ( !blown_off && !collision_checked && !csm->no_collisions )	{
-			if ( Mc_pmi ) {
-				Mc_orient = Mc_pmi->submodel[i].mc_orient;
-				Mc_base = Mc_pmi->submodel[i].mc_base;
-				vm_vec_add2(&Mc_base, Mc->pos);
-			} else {
-				//instance for this subobject
-				matrix tm = IDENTITY_MATRIX;
+			vm_vec_unrotate(&Mc_base, &csm->offset, &saved_orient);
+			vm_vec_add2(&Mc_base, &saved_base);
 
-				vm_vec_unrotate(&Mc_base, &csm->offset, &saved_orient );
-				vm_vec_add2(&Mc_base, &saved_base );
-
-				if( vm_matrix_same(&tm, &csm->orientation)) {
-					// if submodel orientation matrix is identity matrix then don't bother with matrix ops
-					vm_angles_2_matrix(&tm, &angs);
-				} else {
-					matrix rotation_matrix = csm->orientation;
-					vm_rotate_matrix_by_angles(&rotation_matrix, &angs);
-
-					matrix inv_orientation;
-					vm_copy_transpose(&inv_orientation, &csm->orientation);
-
-					vm_matrix_x_matrix(&tm, &rotation_matrix, &inv_orientation);
-				}
-
-				vm_matrix_x_matrix(&Mc_orient, &saved_orient, &tm);
-			}
+			matrix tm;
+			vm_angles_2_matrix(&tm, &angs);
+			vm_matrix_x_matrix(&Mc_orient, &saved_orient, &tm);
 
 			mc_check_subobj( i );
 		}
@@ -1350,60 +1330,5 @@ int model_collide(mc_info *mc_info_obj)
 		}
 	}
 
-
 	return Mc->num_hits;
-
-}
-
-void model_collide_preprocess_subobj(vec3d *pos, matrix *orient, polymodel *pm, polymodel_instance *pmi, int subobj_num)
-{
-	Assert(pm->id == pmi->model_num);
-	submodel_instance *smi = &pmi->submodel[subobj_num];
-
-	smi->mc_base = *pos;
-	smi->mc_orient = *orient;
-
-	int i = pm->submodel[subobj_num].first_child;
-
-	while ( i >= 0 ) {
-		angles angs = pmi->submodel[i].angs;
-		bsp_info * csm = &pm->submodel[i];
-
-		matrix tm = IDENTITY_MATRIX;
-
-		vm_vec_unrotate(pos, &csm->offset, &smi->mc_orient );
-		vm_vec_add2(pos, &smi->mc_base);
-
-		if( vm_matrix_same(&tm, &csm->orientation)) {
-			// if submodel orientation matrix is identity matrix then don't bother with matrix ops
-			vm_angles_2_matrix(&tm, &angs);
-		} else {
-			matrix rotation_matrix = csm->orientation;
-			vm_rotate_matrix_by_angles(&rotation_matrix, &angs);
-
-			matrix inv_orientation;
-			vm_copy_transpose(&inv_orientation, &csm->orientation);
-
-			vm_matrix_x_matrix(&tm, &rotation_matrix, &inv_orientation);
-		}
-
-		vm_matrix_x_matrix(orient, &smi->mc_orient, &tm);
-
-		model_collide_preprocess_subobj(pos, orient, pm, pmi, i);
-
-		i = csm->next_sibling;
-	}
-}
-
-void model_collide_preprocess(matrix *orient, polymodel *pm, polymodel_instance *pmi, int detail_num)
-{
-	matrix current_orient;
-	vec3d current_pos;
-	Assert(pm->id == pmi->model_num);
-
-	current_orient = *orient;
-
-	vm_vec_zero(&current_pos);
-
-	model_collide_preprocess_subobj(&current_pos, &current_orient, pm, pmi, pm->detail[detail_num]);
 }

--- a/code/model/modelcollide.cpp
+++ b/code/model/modelcollide.cpp
@@ -1170,17 +1170,17 @@ NoHit:
 	// Check all of this subobject's children
 	i = sm->first_child;
 	while ( i >= 0 )	{
-		angles angs;
+		matrix instance_orient;
 		bool blown_off;
 		bool collision_checked;
 		bsp_info * csm = &Mc_pm->submodel[i];
 		
 		if ( Mc_pmi ) {
-			angs = Mc_pmi->submodel[i].angs;
+			instance_orient = Mc_pmi->submodel[i].canonical_orient;
 			blown_off = Mc_pmi->submodel[i].blown_off;
 			collision_checked = Mc_pmi->submodel[i].collision_checked;
 		} else {
-			angs = vmd_zero_angles;
+			instance_orient = vmd_identity_matrix;
 			blown_off = false;
 			collision_checked = false;
 		}
@@ -1191,9 +1191,7 @@ NoHit:
 			vm_vec_unrotate(&Mc_base, &csm->offset, &saved_orient);
 			vm_vec_add2(&Mc_base, &saved_base);
 
-			matrix tm;
-			vm_angles_2_matrix(&tm, &angs);
-			vm_matrix_x_matrix(&Mc_orient, &saved_orient, &tm);
+			vm_matrix_x_matrix(&Mc_orient, &saved_orient, &instance_orient);
 
 			mc_check_subobj( i );
 		}

--- a/code/model/modelrender.cpp
+++ b/code/model/modelrender.cpp
@@ -1262,21 +1262,10 @@ void model_render_children_buffers(model_draw_list* scene, model_material *rende
 		ang = smi->angs;
 	}
 
-	// Compute final submodel orientation by using the orientation matrix
-	// and the rotation angles.
-	// By using this kind of computation, the rotational angles can always
-	// be computed relative to the submodel itself, instead of relative
-	// to the parent
-	matrix rotation_matrix = sm->orientation;
-	vm_rotate_matrix_by_angles(&rotation_matrix, &ang);
+	matrix submodel_orient;
+	vm_angles_2_matrix(&submodel_orient, &ang);
 
-	matrix inv_orientation;
-	vm_copy_transpose(&inv_orientation, &sm->orientation);
-
-	matrix submodel_matrix;
-	vm_matrix_x_matrix(&submodel_matrix, &rotation_matrix, &inv_orientation);
-
-	scene->push_transform(&sm->offset, &submodel_matrix);
+	scene->push_transform(&sm->offset, &submodel_orient);
 	
 	if ( (model_flags & MR_SHOW_OUTLINE || model_flags & MR_SHOW_OUTLINE_HTL || model_flags & MR_SHOW_OUTLINE_PRESET) && 
 		sm->outline_buffer != nullptr ) {
@@ -2389,23 +2378,9 @@ void model_render_debug_children(polymodel *pm, int mn, int detail_level, uint d
 	// to put together a matrix describing the final orientation of
 	// the submodel relative to its parent
 	// (Not needed here because we're not using model instances)
-	angles ang = vmd_zero_angles;
+	matrix submodel_orient = vmd_identity_matrix;
 
-	// Compute final submodel orientation by using the orientation matrix
-	// and the rotation angles.
-	// By using this kind of computation, the rotational angles can always
-	// be computed relative to the submodel itself, instead of relative
-	// to the parent
-	matrix rotation_matrix = model->orientation;
-	vm_rotate_matrix_by_angles(&rotation_matrix, &ang);
-
-	matrix inv_orientation;
-	vm_copy_transpose(&inv_orientation, &model->orientation);
-
-	matrix submodel_matrix;
-	vm_matrix_x_matrix(&submodel_matrix, &rotation_matrix, &inv_orientation);
-
-	g3_start_instance_matrix(&model->offset, &submodel_matrix, true);
+	g3_start_instance_matrix(&model->offset, &submodel_orient, true);
 
 	if ( debug_flags & MR_DEBUG_PIVOTS ) {
 		model_draw_debug_points( pm, &pm->submodel[mn], debug_flags );

--- a/code/model/modelrender.cpp
+++ b/code/model/modelrender.cpp
@@ -1256,14 +1256,11 @@ void model_render_children_buffers(model_draw_list* scene, model_material *rende
 	// Get submodel rotation data and use submodel orientation matrix
 	// to put together a matrix describing the final orientation of
 	// the submodel relative to its parent
-	angles ang = vmd_zero_angles;
+	matrix submodel_orient = vmd_identity_matrix;
 
 	if ( smi != nullptr ) {
-		ang = smi->angs;
+		submodel_orient = smi->canonical_orient;
 	}
-
-	matrix submodel_orient;
-	vm_angles_2_matrix(&submodel_orient, &ang);
 
 	scene->push_transform(&sm->offset, &submodel_orient);
 	

--- a/code/network/multi_obj.cpp
+++ b/code/network/multi_obj.cpp
@@ -1315,9 +1315,9 @@ int multi_oo_pack_data(net_player *pl, object *objp, ushort oo_flags, ubyte *dat
 				angles *angs_1 = nullptr;
 				angles *angs_2 = nullptr;
 				if (subsystem->submodel_instance_1)
-					angs_1 = &subsystem->submodel_instance_1->angs;
+					angs_1 = &subsystem->submodel_instance_1->canonical_angs;
 				if (subsystem->submodel_instance_2)
-					angs_2 = &subsystem->submodel_instance_2->angs;
+					angs_2 = &subsystem->submodel_instance_2->canonical_angs;
 
 				// here we're checking to see if the subsystems rotated enough to send.
 				if (angs_1 != nullptr && angs_1->b != Oo_info.player_frame_info[pl->player_id].last_sent[objp->net_signature].subsystem_1b[i]) {
@@ -1924,12 +1924,12 @@ int multi_oo_unpack_data(net_player* pl, ubyte* data, int seq_num)
 				angles *angs_1 = nullptr;
 				angles *angs_2 = nullptr;
 				if (subsysp->submodel_instance_1) {
-					prev_angs_1 = &subsysp->submodel_instance_1->prev_angs;
-					angs_1 = &subsysp->submodel_instance_1->angs;
+					prev_angs_1 = new angles;
+					angs_1 = &subsysp->submodel_instance_1->canonical_angs;
 				}
 				if (subsysp->submodel_instance_2) {
-					prev_angs_2 = &subsysp->submodel_instance_2->prev_angs;
-					angs_2 = &subsysp->submodel_instance_2->angs;
+					prev_angs_2 = new angles;
+					angs_2 = &subsysp->submodel_instance_2->canonical_angs;
 				}
 
 				if (flags[i] & OO_SUBSYS_ROTATION_1b) {
@@ -1967,6 +1967,19 @@ int multi_oo_unpack_data(net_player* pl, ubyte* data, int seq_num)
 					angs_2->p = (subsys_data[data_idx] * PI2);
 					data_idx++;
 				}
+
+				// fix up the matrixes
+				if (flags[i] & OO_SUBSYS_ROTATION_1) {
+					vm_angles_2_matrix(&subsysp->submodel_instance_1->canonical_prev_orient, prev_angs_1);
+					vm_angles_2_matrix(&subsysp->submodel_instance_1->canonical_orient, angs_1);
+					delete prev_angs_1;
+				}
+				if (flags[i] & OO_SUBSYS_ROTATION_2) {
+					vm_angles_2_matrix(&subsysp->submodel_instance_2->canonical_prev_orient, prev_angs_2);
+					vm_angles_2_matrix(&subsysp->submodel_instance_2->canonical_orient, angs_2);
+					delete prev_angs_2;
+				}
+
 				subsysp = GET_NEXT(subsysp);
 
 			}

--- a/code/network/multimsgs.cpp
+++ b/code/network/multimsgs.cpp
@@ -3306,14 +3306,14 @@ void send_turret_fired_packet( int ship_objnum, int subsys_index, int weapon_obj
 	constexpr float ZERO_VALUE = 0.0f;
 
 	if (ssp->submodel_instance_1 != nullptr) {
-		ADD_FLOAT( ssp->submodel_instance_1->angs.h );
+		ADD_FLOAT( ssp->submodel_instance_1->cur_angle );
 	}
 	else {
 		ADD_FLOAT( ZERO_VALUE );
 	}
 
 	if (ssp->submodel_instance_2 != nullptr) {
-		ADD_FLOAT( ssp->submodel_instance_2->angs.p );
+		ADD_FLOAT( ssp->submodel_instance_2->cur_angle );
 	}
 	else {
 		ADD_FLOAT(ZERO_VALUE);
@@ -3337,7 +3337,7 @@ void process_turret_fired_packet( ubyte *data, header *hinfo )
 	ship_subsys *ssp;
 	ubyte has_sig = 0;
 	ship *shipp;
-	float pitch, heading;
+	float angle1, angle2;
 
 	// get the data for the turret fired packet
 	offset = HEADER_LENGTH;	
@@ -3351,8 +3351,8 @@ void process_turret_fired_packet( ubyte *data, header *hinfo )
 	}
 	GET_SHORT( wid );
 	GET_SHORT( turret_index );
-	GET_FLOAT( heading );
-	GET_FLOAT( pitch );
+	GET_FLOAT( angle1 );
+	GET_FLOAT( angle2 );
 	PACKET_SET_SIZE();				// move our counter forward the number of bytes we have read
 
 	// if we don't have a valid weapon index then bail
@@ -3386,11 +3386,11 @@ void process_turret_fired_packet( ubyte *data, header *hinfo )
 	// bash the position and orientation of the turret
 	// but only if the submodels are not null
 	if (ssp->submodel_instance_1 != nullptr) {
-		ssp->submodel_instance_1->angs.h = heading;
+		ssp->submodel_instance_1->cur_angle = angle1;
 	}
 	
 	if (ssp->submodel_instance_2 != nullptr) {
-		ssp->submodel_instance_2->angs.p = pitch;
+		ssp->submodel_instance_2->cur_angle = angle2;
 	}
 
 	// get the world position of the weapon
@@ -8457,14 +8457,14 @@ void send_flak_fired_packet(int ship_objnum, int subsys_index, int weapon_objnum
 
 	// ensure a nullptr is not dereferenced for the next two values.
 	if (ssp->submodel_instance_1 != nullptr) {
-		ADD_FLOAT( ssp->submodel_instance_1->angs.h );
+		ADD_FLOAT( ssp->submodel_instance_1->cur_angle );
 	}
 	else {
 		ADD_FLOAT( ZERO_VALUE );
 	}
 	
 	if (ssp->submodel_instance_2 != nullptr) {
-		ADD_FLOAT( ssp->submodel_instance_2->angs.p );
+		ADD_FLOAT( ssp->submodel_instance_2->cur_angle );
 	}
 	else {
 		ADD_FLOAT(ZERO_VALUE);
@@ -8487,7 +8487,7 @@ void process_flak_fired_packet(ubyte *data, header *hinfo)
 	object *objp;
 	ship_subsys *ssp;	
 	ship *shipp;
-	float pitch, heading;
+	float angle1, angle2;
 	float flak_range;
 
 	// get the data for the turret fired packet
@@ -8496,8 +8496,8 @@ void process_flak_fired_packet(ubyte *data, header *hinfo)
 	GET_USHORT( pnet_signature );
 	GET_SHORT( wid );
 	GET_SHORT( turret_index );
-	GET_FLOAT( heading );
-	GET_FLOAT( pitch );
+	GET_FLOAT( angle1 );
+	GET_FLOAT( angle2 );
 	GET_FLOAT( flak_range );
 	PACKET_SET_SIZE();				// move our counter forward the number of bytes we have read
 
@@ -8531,11 +8531,11 @@ void process_flak_fired_packet(ubyte *data, header *hinfo)
 
 	// bash the position and orientation of the turret, if it's not a nulltpr
 	if (ssp->submodel_instance_1 != nullptr) {
-		ssp->submodel_instance_1->angs.h = heading;
+		ssp->submodel_instance_1->cur_angle = angle1;
 	}
 
 	if (ssp->submodel_instance_2 != nullptr) {
-		ssp->submodel_instance_2->angs.p = pitch;
+		ssp->submodel_instance_2->cur_angle = angle2;
 	}
 
 	// get the world position of the weapon

--- a/code/object/collideshipship.cpp
+++ b/code/object/collideshipship.cpp
@@ -310,7 +310,7 @@ int ship_ship_check_collision(collision_info_struct *ship_ship_hit_info)
 
 						// set up ship_ship_hit_info for rotating submodel
 						if (ship_ship_hit_info->edge_hit == 0) {
-							model_instance_find_obj_dir(&ship_ship_hit_info->collision_normal, &mc.hit_normal, pm, pmi, mc.hit_submodel, &heavy_obj->orient);
+							model_instance_find_world_dir(&ship_ship_hit_info->collision_normal, &mc.hit_normal, pm, pmi, mc.hit_submodel, &heavy_obj->orient);
 						}
 
 						// find position in submodel RF of light object at collison
@@ -340,7 +340,7 @@ int ship_ship_check_collision(collision_info_struct *ship_ship_hit_info)
 
 				// get collision normal if not edge hit
 				if (ship_ship_hit_info->edge_hit == 0) {
-					model_instance_find_obj_dir(&ship_ship_hit_info->collision_normal, &mc.hit_normal, pm, pmi, mc.hit_submodel, &heavy_obj->orient);
+					model_instance_find_world_dir(&ship_ship_hit_info->collision_normal, &mc.hit_normal, pm, pmi, mc.hit_submodel, &heavy_obj->orient);
 				}
 
 				// find position in submodel RF of light object at collison
@@ -591,7 +591,7 @@ void calculate_ship_ship_collision_physics(collision_info_struct *ship_ship_hit_
 			}
 
 			// get world rotational velocity of rotating submodel
-			model_instance_find_obj_dir(&omega, &axis, pm, pmi, ship_ship_hit_info->submodel_num, &heavy->orient);
+			model_instance_find_world_dir(&omega, &axis, pm, pmi, ship_ship_hit_info->submodel_num, &heavy->orient);
 
 			vm_vec_scale(&omega, smi->current_turn_rate);
 

--- a/code/object/collideshipship.cpp
+++ b/code/object/collideshipship.cpp
@@ -285,13 +285,13 @@ int ship_ship_check_collision(collision_info_struct *ship_ship_hit_info)
 				}
 
 				// set angles for last frame
-				angles copy_angles = smi->angs;
+				matrix copy_matrix = smi->canonical_orient;
 
 				// find the start and end positions of the sphere in submodel RF
-				smi->angs = smi->prev_angs;
+				smi->canonical_orient = smi->canonical_prev_orient;
 				world_find_model_instance_point(&p0, &light_obj->last_pos, pm, pmi, submodel, &heavy_obj->last_orient, &heavy_obj->last_pos);
 
-				smi->angs = copy_angles;
+				smi->canonical_orient = copy_matrix;
 				world_find_model_instance_point(&p1, &light_obj->pos, pm, pmi, submodel, &heavy_obj->orient, &heavy_obj->pos);
 
 				mc.p0 = &p0;
@@ -578,20 +578,10 @@ void calculate_ship_ship_collision_physics(collision_info_struct *ship_ship_hit_
 				model_init_submodel_axis_pt(pm, pmi, ship_ship_hit_info->submodel_num);
 			}
 
-			vec3d omega, axis, r_rot;
-			if ( pm->submodel[ship_ship_hit_info->submodel_num].movement_axis == MOVEMENT_AXIS_X ) {
-				axis = vmd_x_vector;
-			} else if ( pm->submodel[ship_ship_hit_info->submodel_num].movement_axis == MOVEMENT_AXIS_Y ) {
-				axis = vmd_y_vector;
-			} else if ( pm->submodel[ship_ship_hit_info->submodel_num].movement_axis == MOVEMENT_AXIS_Z ) {
-				axis = vmd_z_vector;
-			} else {
-				// must be one of these axes or submodel_rot_hit is incorrectly set
-				Int3();
-			}
+			vec3d omega, r_rot;
 
 			// get world rotational velocity of rotating submodel
-			model_instance_find_world_dir(&omega, &axis, pm, pmi, ship_ship_hit_info->submodel_num, &heavy->orient);
+			model_instance_find_world_dir(&omega, &pm->submodel[ship_ship_hit_info->submodel_num].movement_axis, pm, pmi, ship_ship_hit_info->submodel_num, &heavy->orient);
 
 			vm_vec_scale(&omega, smi->current_turn_rate);
 

--- a/code/scripting/api/objs/subsystem.cpp
+++ b/code/scripting/api/objs/subsystem.cpp
@@ -119,7 +119,6 @@ ADE_VIRTVAR(Orientation, l_Subsystem, "orientation", "Orientation of subobject o
 	{
 		smi->canonical_prev_orient = smi->canonical_orient;
 		smi->canonical_orient = *mh->GetMatrix();
-		smi->canonical_angs = *mh->GetAngles();
 	}
 
 	return ade_set_args(L, "o", l_Matrix.Set(matrix_h(&smi->canonical_orient)));
@@ -143,7 +142,6 @@ ADE_VIRTVAR(GunOrientation, l_Subsystem, "orientation", "Orientation of turret g
 	{
 		smi->canonical_prev_orient = smi->canonical_orient;
 		smi->canonical_orient = *mh->GetMatrix();
-		smi->canonical_angs = *mh->GetAngles();
 	}
 
 	return ade_set_args(L, "o", l_Matrix.Set(matrix_h(&smi->canonical_orient)));

--- a/code/scripting/api/objs/subsystem.cpp
+++ b/code/scripting/api/objs/subsystem.cpp
@@ -111,15 +111,18 @@ ADE_VIRTVAR(Orientation, l_Subsystem, "orientation", "Orientation of subobject o
 	if (!sso->isSubsystemValid())
 		return ade_set_error(L, "o", l_Matrix.Set(matrix_h()));
 
-	if (sso->ss->submodel_instance_1 == nullptr)
+	auto smi = sso->ss->submodel_instance_1;
+	if (smi == nullptr)
 		return ade_set_error(L, "o", l_Matrix.Set(matrix_h()));
 
 	if(ADE_SETTING_VAR && mh)
 	{
-		sso->ss->submodel_instance_1->angs = *mh->GetAngles();
+		smi->canonical_prev_orient = smi->canonical_orient;
+		smi->canonical_orient = *mh->GetMatrix();
+		smi->canonical_angs = *mh->GetAngles();
 	}
 
-	return ade_set_args(L, "o", l_Matrix.Set(matrix_h(&sso->ss->submodel_instance_1->angs)));
+	return ade_set_args(L, "o", l_Matrix.Set(matrix_h(&smi->canonical_orient)));
 }
 
 ADE_VIRTVAR(GunOrientation, l_Subsystem, "orientation", "Orientation of turret gun", "orientation", "Gun orientation, or null orientation if handle is invalid")
@@ -132,15 +135,18 @@ ADE_VIRTVAR(GunOrientation, l_Subsystem, "orientation", "Orientation of turret g
 	if (!sso->isSubsystemValid())
 		return ade_set_error(L, "o", l_Matrix.Set(matrix_h()));
 
-	if (sso->ss->submodel_instance_2 == nullptr)
+	auto smi = sso->ss->submodel_instance_2;
+	if (smi == nullptr)
 		return ade_set_error(L, "o", l_Matrix.Set(matrix_h()));
 
 	if(ADE_SETTING_VAR && mh)
 	{
-		sso->ss->submodel_instance_2->angs = *mh->GetAngles();
+		smi->canonical_prev_orient = smi->canonical_orient;
+		smi->canonical_orient = *mh->GetMatrix();
+		smi->canonical_angs = *mh->GetAngles();
 	}
 
-	return ade_set_args(L, "o", l_Matrix.Set(matrix_h(&sso->ss->submodel_instance_2->angs)));
+	return ade_set_args(L, "o", l_Matrix.Set(matrix_h(&smi->canonical_orient)));
 }
 
 ADE_VIRTVAR(HitpointsLeft, l_Subsystem, "number", "Subsystem hitpoints left", "number", "Hitpoints left, or 0 if handle is invalid. Setting a value of 0 will disable it - set a value of -1 or lower to actually blow it up.")

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -19251,7 +19251,10 @@ void ship_render_weapon_models(model_render_params *ship_render_info, model_draw
 			for (int mn = 0; mn < pm->n_models; ++mn)
 			{
 				if (pm->submodel[mn].gun_rotation)
-					pmi->submodel[mn].angs.b = shipp->primary_rotate_ang[i];
+				{
+					pmi->submodel[mn].canonical_angs.b = shipp->primary_rotate_ang[i];
+					vm_angles_2_matrix(&pmi->submodel[mn].canonical_orient, &pmi->submodel[mn].canonical_angs);
+				}
 			}
 		}
 

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -13402,9 +13402,6 @@ void ship_model_update_instance(object *objp)
 
 	// Handle intrinsic rotations for this ship
 	model_do_intrinsic_rotations(shipp->model_instance_num);
-
-	// preprocess subobject orientations for collision detection
-	model_collide_preprocess(&objp->orient, pm, pmi);
 }
 
 /**

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -19252,8 +19252,9 @@ void ship_render_weapon_models(model_render_params *ship_render_info, model_draw
 			{
 				if (pm->submodel[mn].gun_rotation)
 				{
-					pmi->submodel[mn].canonical_angs.b = shipp->primary_rotate_ang[i];
-					vm_angles_2_matrix(&pmi->submodel[mn].canonical_orient, &pmi->submodel[mn].canonical_angs);
+					angles angs = vmd_zero_angles;
+					angs.b = shipp->primary_rotate_ang[i];
+					vm_angles_2_matrix(&pmi->submodel[mn].canonical_orient, &angs);
 				}
 			}
 		}

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -396,7 +396,7 @@ public:
 	flagset<Ship::Subsys_Sound_Flags> subsys_snd_flags;
 
 	int      rotation_timestamp;
-	matrix   world_to_turret_matrix;
+	matrix   world_to_turret_matrix;			// This is now only used for Turret_alt_math
 
 	// target priority setting for turrets
 	int      target_priority[32];

--- a/code/ship/shipfx.cpp
+++ b/code/ship/shipfx.cpp
@@ -119,7 +119,7 @@ static void shipfx_subsystem_maybe_create_live_debris(object *ship_objp, ship *s
 
 		model_instance_find_world_point(&world_axis_pt, &smi->point_on_axis, pm, pmi, submodel_num, &ship_objp->orient, &ship_objp->pos);
 
-		vm_quaternion_rotate(&m_rot, vm_vec_mag((vec3d*)&smi->angs), &model_axis);
+		vm_quaternion_rotate(&m_rot, smi->cur_angle, &model_axis);
 	} else {
 		//fix to allow non rotating submodels to use live debris
 		vm_vec_zero(&rotvel);


### PR DESCRIPTION
This is a rather substantial rewrite/refactor of the submodel rotation code.  Submodel rotation is now tracked via an axis-angle representation, which is used to calculate a matrix to represent the submodel orientation in the model instance.  The axis can be any unit vector, not limited to the standard X, Y, and Z vectors.

The submodel orientation is now used for position calculation in almost every place the submodel angles were previously used.  In conjunction with the simplification of KeldorKatarn's code, this saves a significant number of calculations for every movable submodel in every frame.  Hopefully this should lead to a measurable speedup in both rendering and collision detection.