### PR TITLE
some bugfixes from the submodel rotation branch

### DIFF
--- a/code/math/vecmat.cpp
+++ b/code/math/vecmat.cpp
@@ -579,6 +579,28 @@ float vm_vec_delta_ang_norm(const vec3d *v0, const vec3d *v1, const vec3d *fvec)
 	return a;
 }
 
+float vm_vec_delta_ang_norm_safe(const vec3d *v0, const vec3d *v1, const vec3d *fvec)
+{
+	float a, dot;
+	vec3d t;
+
+	// to avoid round-off errors...
+	// testing produced a dot of 1.00000012 which evaluates to an angle of -nan(ind)
+	dot = vm_vec_dot(v0, v1);
+	CLAMP(dot, -1.0f, 1.0f);
+
+	a = acosf(dot);
+
+	if (fvec) {
+		vm_vec_cross(&t,v0,v1);
+		if ( vm_vec_dot(&t,fvec) < 0.0 ) {
+			a = -a;
+		}
+	}
+
+	return a;
+}
+
 // helper function that fills in matrix m based on provided sine and cosine values. 
 static matrix *sincos_2_matrix(matrix *m, float sinp, float cosp, float sinb, float cosb, float sinh, float cosh)
 {

--- a/code/math/vecmat.h
+++ b/code/math/vecmat.h
@@ -231,6 +231,7 @@ float vm_vec_delta_ang(const vec3d *v0, const vec3d *v1, const vec3d *fvec);
 
 //computes the delta angle between two normalized vectors.
 float vm_vec_delta_ang_norm(const vec3d *v0, const vec3d *v1,const vec3d *fvec);
+float vm_vec_delta_ang_norm_safe(const vec3d *v0, const vec3d *v1, const vec3d *fvec);
 
 //computes a matrix from a set of three angles.  returns ptr to matrix
 matrix *vm_angles_2_matrix(matrix *m, const angles *a);

--- a/code/model/modelread.cpp
+++ b/code/model/modelread.cpp
@@ -478,8 +478,8 @@ bool get_user_vec3d_value(char *buf, vec3d *value, bool require_brackets)
 	// statements allows the code to jump to the end.  Alternatively,
 	// goto could have been used.
 	do {
-		// skip white space and equal sign
-		while (isspace(*Mp) || (*Mp == '='))
+		// skip white space and equal sign or colon
+		while (isspace(*Mp) || (*Mp == '=') || (*Mp == ':'))
 			Mp++;
 
 		if (require_brackets)
@@ -1392,9 +1392,7 @@ int read_model_file(polymodel * pm, const char *filename, int n_subsystems, mode
 				if ( strstr(pm->submodel[n].name, "turret") || strstr(pm->submodel[n].name, "gun") || strstr(pm->submodel[n].name, "cannon")) {
 					pm->submodel[n].movement_type = MOVEMENT_TYPE_ROT_SPECIAL;
 					pm->submodel[n].can_move = true;
-				} else
-
-				if (pm->submodel[n].movement_type == MOVEMENT_TYPE_ROT) {
+				} else if (pm->submodel[n].movement_type == MOVEMENT_TYPE_ROT) {
 					if (strstr(pm->submodel[n].name, "thruster")) {
 						pm->submodel[n].movement_type = MOVEMENT_TYPE_NONE;
 						pm->submodel[n].movement_axis = MOVEMENT_AXIS_NONE;
@@ -1602,14 +1600,14 @@ int read_model_file(polymodel * pm, const char *filename, int n_subsystems, mode
 				}
 
 				// KeldorKatarn, with modifications
-				if ( (p = strstr(props, "$uvec:")) != nullptr ) {
+				if ( (p = strstr(props, "$uvec")) != nullptr ) {
 					matrix submodel_orient;
 
-					if (get_user_vec3d_value(p + 6, &submodel_orient.vec.uvec, false)) {
+					if (get_user_vec3d_value(p + 5, &submodel_orient.vec.uvec, false)) {
 
-						if ((p = strstr(props, "$fvec:")) != nullptr) {
+						if ((p = strstr(props, "$fvec")) != nullptr) {
 
-							if (get_user_vec3d_value(p + 6, &submodel_orient.vec.fvec, false)) {
+							if (get_user_vec3d_value(p + 5, &submodel_orient.vec.fvec, false)) {
 
 								vm_vec_normalize(&submodel_orient.vec.uvec);
 								vm_vec_normalize(&submodel_orient.vec.fvec);
@@ -1627,8 +1625,8 @@ int read_model_file(polymodel * pm, const char *filename, int n_subsystems, mode
 
 							} else {
 								Warning(LOCATION,
-									"Submodel '%s' of model '%s' has an improperly formatted $fvec: declaration in its properties."
-									"\n\n$fvec: should be followed by 3 numbers separated with commas.",
+									"Submodel '%s' of model '%s' has an improperly formatted $fvec declaration in its properties."
+									"\n\n$fvec should be followed by 3 numbers separated with commas.",
 									pm->submodel[n].name, filename);
 							}
 						} else {
@@ -1636,8 +1634,8 @@ int read_model_file(polymodel * pm, const char *filename, int n_subsystems, mode
 						}
 					} else {
 						Warning(LOCATION,
-							"Submodel '%s' of model '%s' has an improperly formatted $uvec: declaration in its properties."
-							"\n\n$uvec: should be followed by 3 numbers separated with commas.",
+							"Submodel '%s' of model '%s' has an improperly formatted $uvec declaration in its properties."
+							"\n\n$uvec should be followed by 3 numbers separated with commas.",
 							pm->submodel[n].name, filename);
 					}
 				} else {

--- a/code/network/multi_obj.h
+++ b/code/network/multi_obj.h
@@ -53,8 +53,8 @@ struct weapon;
 #define OO_SUBSYS_TRANSLATION		(1<<7)		// Only for backwards compatibility of future builds.
 
 // combo values
-#define OO_SUBSYS_ROTATION_1	(OO_SUBSYS_ROTATION_1b | OO_SUBSYS_ROTATION_1h || OO_SUBSYS_ROTATION_1p)
-#define OO_SUBSYS_ROTATION_2	(OO_SUBSYS_ROTATION_2b | OO_SUBSYS_ROTATION_2h || OO_SUBSYS_ROTATION_2p)
+#define OO_SUBSYS_ROTATION_1	(OO_SUBSYS_ROTATION_1b | OO_SUBSYS_ROTATION_1h | OO_SUBSYS_ROTATION_1p)
+#define OO_SUBSYS_ROTATION_2	(OO_SUBSYS_ROTATION_2b | OO_SUBSYS_ROTATION_2h | OO_SUBSYS_ROTATION_2p)
 
 
 // ---------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Some things that clang noticed, plus a small usability improvement to the parsing of vectors in submodel properties.

Also add the `vm_vec_delta_ang_norm_safe` function.