### PR TITLE
Fix the support ship refilling ships to the wrong secondary capacity

### DIFF
--- a/code/missionui/missionweaponchoice.cpp
+++ b/code/missionui/missionweaponchoice.cpp
@@ -3426,6 +3426,7 @@ void wl_bash_ship_weapons(ship_weapon *swp, wss_unit *slot)
 		if ( (slot->wep_count[sidx] > 0) && (slot->wep[sidx] >= 0) ) {
 			swp->secondary_bank_weapons[j] = slot->wep[sidx];
 			swp->secondary_bank_ammo[j] = slot->wep_count[sidx];
+			swp->secondary_bank_start_ammo[j] = (int)std::lround(Ship_info[slot->ship_class].secondary_bank_ammo_capacity[i] / Weapon_info[swp->secondary_bank_weapons[j]].cargo_size);
 			j++;
 		}
 	}

--- a/code/network/multimsgs.cpp
+++ b/code/network/multimsgs.cpp
@@ -6159,6 +6159,7 @@ void process_post_sync_data_packet(ubyte *data, header *hinfo)
 		for (j = 0; j < shipp->weapons.num_primary_banks; j++) {
 			GET_SHORT(val_short);
 			shipp->weapons.primary_bank_weapons[j] = static_cast<int>(val_short);
+			shipp->weapons.primary_bank_start_ammo[j] = (int)std::lround(Ship_info[shipp->ship_info_index].primary_bank_ammo_capacity[j] / Weapon_info[shipp->weapons.primary_bank_weapons[j]].cargo_size);
 		}
 
 		// secondary weapon info
@@ -6167,6 +6168,7 @@ void process_post_sync_data_packet(ubyte *data, header *hinfo)
 			shipp->weapons.secondary_bank_weapons[j] = static_cast<int>(val_short);
 			GET_SHORT(val_short);
 			shipp->weapons.secondary_bank_ammo[j] = static_cast<int>(val_short);
+			shipp->weapons.secondary_bank_start_ammo[j] = (int)std::lround(Ship_info[shipp->ship_info_index].secondary_bank_ammo_capacity[j] / Weapon_info[shipp->weapons.secondary_bank_weapons[j]].cargo_size);
 		}
 
 		// other flags

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -134,7 +134,7 @@ public:
 	// end dynamic weapon linking
 
 	int secondary_bank_ammo[MAX_SHIP_SECONDARY_BANKS];			// Number of missiles left in secondary bank
-	int secondary_bank_start_ammo[MAX_SHIP_SECONDARY_BANKS];	// Number of missiles starting in secondary bank
+	int secondary_bank_start_ammo[MAX_SHIP_SECONDARY_BANKS];	// Number of missiles starting in secondary bank -- Every time the secondary bank changes, this must change too!
 	int secondary_bank_capacity[MAX_SHIP_SECONDARY_BANKS];		// Max number of missiles in bank
 	int secondary_next_slot[MAX_SHIP_SECONDARY_BANKS];			// Next slot to fire in the bank
 	int secondary_bank_rearm_time[MAX_SHIP_SECONDARY_BANKS];	// timestamp which indicates when bank can get new missile


### PR DESCRIPTION
This is a bug that periodically appears on discord, most often when players see they've been given 60 trebs by the support ship.  Basically what happens is that there was a place in the code that was changing which weapon was used, but not the starting ammo.

I check all the places where the secondary weapon is changed, and there is also another instance of it in the multi-code.

Btw, there is one place in the scripting code where the weapon can be changed, but I am unsure if that one should also change the starting ammo, because there is another scripting function for changing starting ammo.