### PR TITLE
Range aware secondary selection

### DIFF
--- a/code/ai/ai_profiles.cpp
+++ b/code/ai/ai_profiles.cpp
@@ -58,6 +58,26 @@ int ai_path_type_match(char *p)
 	return -1;
 }
 
+
+const char* AI_secondary_range_aware_select_modes[] = {
+	"retail",
+	"aware",
+};
+
+int Num_ai_secondary_range_aware_select_modes = sizeof(AI_secondary_range_aware_select_modes) / sizeof(char*);
+
+int ai_secondary_range_select_mode_match(char* p)
+{
+	int i;
+	for (i = 0; i < Num_ai_secondary_range_aware_select_modes; i++)
+	{
+		if (!stricmp(AI_secondary_range_aware_select_modes[i], p))
+			return i;
+	}
+
+	return -1;
+}
+
 void parse_ai_profiles_tbl(const char *filename)
 {
 	int i;
@@ -546,6 +566,20 @@ void parse_ai_profiles_tbl(const char *filename)
 
 				set_flag(profile, "$fixed ship-weapon collisions:", AI::Profile_Flags::Fixed_ship_weapon_collision);
 
+				//Intention is to expand this feature to include a preference for close or long range weapons
+				//hence using something besides a simple flag.
+				profile->ai_range_aware_secondary_select_mode = AI_RANGE_AWARE_SEC_SEL_MODE_RETAIL;
+				if (optional_string("$AI secondary range awareness:"))
+				{
+					stuff_string(buf, F_NAME, NAME_LENGTH);
+					int j = ai_secondary_range_select_mode_match(buf);
+					if (j >= 0) {
+						profile->ai_range_aware_secondary_select_mode = j;
+					}
+					else {
+						Warning(LOCATION, "Invalid ai secondary range awareness mode '%s' specified", buf);
+					}
+				}
 				// if we've been through once already and are at the same place, force a move
 				if (saved_Mp && (saved_Mp == Mp))
 				{
@@ -622,6 +656,7 @@ void ai_profile_t::reset()
     bay_arrive_speed_mult = 0;
     bay_depart_speed_mult = 0;
 	second_order_lead_predict_factor = 0;
+	ai_range_aware_secondary_select_mode = AI_RANGE_AWARE_SEC_SEL_MODE_RETAIL;
 
     for (int i = 0; i < NUM_SKILL_LEVELS; ++i) {
         max_incoming_asteroids[i] = 0;

--- a/code/ai/ai_profiles.h
+++ b/code/ai/ai_profiles.h
@@ -18,8 +18,8 @@
 #define	AI_PATH_MODE_NORMAL 0
 #define	AI_PATH_MODE_ALT1	1
 
-#define	AI_RANGE_SEC_SEL_MODE_RETAIL 0
-#define	AI_RANGE_SEC_SEL_MODE_AWARE 1
+#define	AI_RANGE_AWARE_SEC_SEL_MODE_RETAIL 0
+#define	AI_RANGE_AWARE_SEC_SEL_MODE_AWARE 1
 	
 #define MAX_AI_PROFILES	5
 
@@ -112,7 +112,7 @@ public:
 	float second_order_lead_predict_factor;
 	
 	//Controls if the AI is dumb enough to keep trying to use out-of-range secondaries. 
-	int ai_range_secondary_select_mode;
+	int ai_range_aware_secondary_select_mode;
 
     void reset();
 };

--- a/code/ai/ai_profiles.h
+++ b/code/ai/ai_profiles.h
@@ -17,6 +17,9 @@
 // AI Path types
 #define	AI_PATH_MODE_NORMAL 0
 #define	AI_PATH_MODE_ALT1	1
+
+#define	AI_RANGE_SEC_SEL_MODE_RETAIL 0
+#define	AI_RANGE_SEC_SEL_MODE_AWARE 1
 	
 #define MAX_AI_PROFILES	5
 
@@ -107,6 +110,9 @@ public:
 
 	// How much 0-1 of a second-order lead prediction factor to add to lead indicators. Affects only the HUD indicator, and autoaim.
 	float second_order_lead_predict_factor;
+	
+	//Controls if the AI is dumb enough to keep trying to use out-of-range secondaries. 
+	int ai_range_secondary_select_mode;
 
     void reset();
 };

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -13161,15 +13161,15 @@ int get_available_secondary_weapons(object *objp, int *outlist, int *outbanklist
 	int	i;
 	ship	*shipp;
 	weapon_info *wepp;
-	bool flag = true;
 	Assert(objp->type == OBJ_SHIP);
 	Assert((objp->instance >= 0) && (objp->instance < MAX_SHIPS));
 	shipp = &Ships[objp->instance];
 	ai_info* aip = &Ai_info[shipp->ai_index];
 	
-	float target_range,	weapon_range_max,weapon_range_min;
+	float target_range, weapon_range_max, weapon_range_min;
+	target_range = 0.0f;
 
-	if (flag) {
+	if (The_mission.ai_profile->ai_range_secondary_select_mode!= AI_RANGE_SEC_SEL_MODE_RETAIL) {
 		vec3d our_position = objp->pos;
 		vec3d target_position;
 		object *target = &Objects[Ai_info[shipp->ai_index].target_objnum];
@@ -13191,7 +13191,7 @@ int get_available_secondary_weapons(object *objp, int *outlist, int *outbanklist
 	}
 	for (i=0; i<shipp->weapons.num_secondary_banks; i++)
 		if (shipp->weapons.secondary_bank_ammo[i]) {
-			if (flag) {
+			if (The_mission.ai_profile->ai_range_secondary_select_mode != AI_RANGE_SEC_SEL_MODE_RETAIL) {
 				wepp = &Weapon_info[shipp->weapons.secondary_bank_weapons[i]];
 				weapon_range_min = wepp->WeaponMinRange;
 				weapon_range_max = wepp->weapon_range;

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -13164,6 +13164,7 @@ int get_available_secondary_weapons(object *objp, int *outlist, int *outbanklist
 	Assert(objp->type == OBJ_SHIP);
 	Assert((objp->instance >= 0) && (objp->instance < MAX_SHIPS));
 	shipp = &Ships[objp->instance];
+	Assert(shipp->ai_index >= 0 && shipp->ai_index < MAX_AI_INFO);
 	ai_info* aip = &Ai_info[shipp->ai_index];
 	
 	float target_range, weapon_range_max, weapon_range_min;

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -13169,12 +13169,12 @@ int get_available_secondary_weapons(object *objp, int *outlist, int *outbanklist
 	float target_range, weapon_range_max, weapon_range_min;
 	target_range = 0.0f;
 
-	if (The_mission.ai_profile->ai_range_secondary_select_mode!= AI_RANGE_SEC_SEL_MODE_RETAIL) {
+	if (The_mission.ai_profile->ai_range_aware_secondary_select_mode!= AI_RANGE_AWARE_SEC_SEL_MODE_RETAIL) {
 		vec3d our_position = objp->pos;
 		vec3d target_position;
 		object *target = &Objects[Ai_info[shipp->ai_index].target_objnum];
 		if (target->type == OBJ_SHIP) {
-			if (aip->targeted_subsys != NULL) {
+			if (aip->targeted_subsys != nullptr) {
 				get_subsystem_pos(&target_position, target, aip->targeted_subsys);
 			}
 			else if (Ship_info[shipp->ship_info_index].is_big_or_huge() ){
@@ -13191,12 +13191,12 @@ int get_available_secondary_weapons(object *objp, int *outlist, int *outbanklist
 	}
 	for (i=0; i<shipp->weapons.num_secondary_banks; i++)
 		if (shipp->weapons.secondary_bank_ammo[i]) {
-			if (The_mission.ai_profile->ai_range_secondary_select_mode != AI_RANGE_SEC_SEL_MODE_RETAIL) {
+			if (The_mission.ai_profile->ai_range_aware_secondary_select_mode != AI_RANGE_AWARE_SEC_SEL_MODE_RETAIL) {
 				wepp = &Weapon_info[shipp->weapons.secondary_bank_weapons[i]];
 				weapon_range_min = wepp->WeaponMinRange;
 				weapon_range_max = wepp->weapon_range;
 				//If weapon range is not set in the weapon info, derive it
-				if (weapon_range_max >= 999999999.0f) { 
+				if (weapon_range_max >= WEAPON_DEFAULT_TABLED_MAX_RANGE) {
 					if (wepp->subtype == WP_BEAM) {
 						weapon_range_max = wepp->b_info.range;
 					}

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -1565,7 +1565,6 @@ extern void physics_ship_init(object *objp);
 
 //	Note: This is not a general purpose routine.
 //	It is specifically used for targeting.
-//	It only returns a subsystem position if it has shields.
 //	Return true/false for subsystem found/not found.
 //	Stuff vector *pos with absolute position.
 extern int get_subsystem_pos(vec3d *pos, object *objp, ship_subsys *subsysp);

--- a/code/weapon/weapon.h
+++ b/code/weapon/weapon.h
@@ -66,6 +66,9 @@ extern int Num_weapon_subtypes;
 // default amount of time to wait after firing before a remote detonated missile can be detonated
 #define DEFAULT_REMOTE_DETONATE_TRIGGER_WAIT  0.5f
 
+// default value weapon max range is set to if there's not a tabled range value.
+#define WEAPON_DEFAULT_TABLED_MAX_RANGE 999999999.9f
+
 #define MAX_SPAWN_TYPES_PER_WEAPON 5
 
 enum class WeaponState : uint32_t

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -8304,7 +8304,7 @@ void weapon_info::reset()
 	this->cargo_size = 1.0f;
 	this->rearm_rate = 1.0f;
 	this->reloaded_per_batch = -1;
-	this->weapon_range = 999999999.9f;
+	this->weapon_range = WEAPON_DEFAULT_TABLED_MAX_RANGE;
 	// *Minimum weapon range, default is 0 -Et1
 	this->WeaponMinRange = 0.0f;
 


### PR DESCRIPTION
Makes AIs only select secondary weapons that are in range of the AI's target. This is in addition to the normal selection filtering that AIs do to try to pick appropriate missiles. Controlled by a AIProfiles flag, which is set up for later expansion to multiple modes; I wanted to implement a preference for longer or shorter ranges when multiple weapons are in range, I'm deffering that to later rather than letting this languish on my drives any more.