### PR TITLE
Increase test engine version to fix 21.0 tests

### DIFF
--- a/test/test_data/mod/future_targetted_version/data/tables/test-mod.tbm
+++ b/test/test_data/mod/future_targetted_version/data/tables/test-mod.tbm
@@ -1,7 +1,7 @@
 #GAME SETTINGS
 
 $Target Version:
-    +Major: 20
+    +Major: 999
     +Minor: 5
     +Build: 10
 


### PR DESCRIPTION
I just tried building 21.0 which is a higher version than the one used
in the test data which broke this test.

This should be a high enough version to not break any time soon...