### PR TITLE
Keep fred from adding extra texture replacements to mission file

### DIFF
--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -3366,6 +3366,8 @@ int parse_object(mission *pm, int  /*flag*/, p_object *p_objp)
 		texture_replace tr;
 		char *p;
 
+		tr.from_table = false;
+
 		while (optional_string("+old:"))
 		{
 			strcpy_s(tr.ship_name, p_objp->name);
@@ -3400,6 +3402,7 @@ int parse_object(mission *pm, int  /*flag*/, p_object *p_objp)
 	// now load the textures (do this outside the parse loop because we may have ship class replacements too)
 	for (SCP_vector<texture_replace>::iterator tr = p_objp->replacement_textures.begin(); tr != p_objp->replacement_textures.end(); ++tr)
 	{
+
 		// load the texture
 		if (!stricmp(tr->new_texture, "invisible"))
 		{

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -3402,7 +3402,6 @@ int parse_object(mission *pm, int  /*flag*/, p_object *p_objp)
 	// now load the textures (do this outside the parse loop because we may have ship class replacements too)
 	for (SCP_vector<texture_replace>::iterator tr = p_objp->replacement_textures.begin(); tr != p_objp->replacement_textures.end(); ++tr)
 	{
-
 		// load the texture
 		if (!stricmp(tr->new_texture, "invisible"))
 		{

--- a/code/mission/missionparse.h
+++ b/code/mission/missionparse.h
@@ -310,6 +310,7 @@ typedef struct texture_replace {
 	char old_texture[MAX_FILENAME_LEN];
 	char new_texture[MAX_FILENAME_LEN];
 	int new_texture_id;
+	bool from_table;
 } texture_replace;
 
 extern SCP_vector<texture_replace> Fred_texture_replacements;

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -2838,6 +2838,8 @@ static void parse_ship_values(ship_info* sip, const bool is_template, const bool
 		texture_replace tr;
 		char *p;
 
+		tr.from_table = true;
+
 		while (optional_string("+old:"))
 		{
 			strcpy_s(tr.ship_name, sip->name);

--- a/fred2/missionsave.cpp
+++ b/fred2/missionsave.cpp
@@ -3474,7 +3474,7 @@ int CFred_mission_save::save_objects()
 			fso_comment_push(";;FSO 3.6.8;;");
 
 			for (SCP_vector<texture_replace>::iterator ii = Fred_texture_replacements.begin(); ii != Fred_texture_replacements.end(); ++ii) {
-				if (!stricmp(shipp->ship_name, ii->ship_name)) {
+				if (!stricmp(shipp->ship_name, ii->ship_name) && !(ii->from_table)) {
 					if (needs_header) {
 						if (optional_string_fred("$Texture Replace:")) {
 							parse_comments(1);

--- a/fred2/shiptexturesdlg.cpp
+++ b/fred2/shiptexturesdlg.cpp
@@ -150,6 +150,7 @@ void CShipTexturesDlg::OnOK()
 				strcpy_s(tr.new_texture, new_texture_name[i]);
 				strcpy_s(tr.ship_name, Ships[self_ship].ship_name);
 				tr.new_texture_id = -1;
+				tr.from_table = false;
 
 				// assign to global FRED array
 				Fred_texture_replacements.push_back(tr);
@@ -238,7 +239,7 @@ BOOL CShipTexturesDlg::OnInitDialog()
 	// now look for new textures
 	for (SCP_vector<texture_replace>::iterator ii = Fred_texture_replacements.begin(); ii != Fred_texture_replacements.end(); ++ii)
 	{
-		if (!stricmp(Ships[self_ship].ship_name, ii->ship_name))
+		if (!stricmp(Ships[self_ship].ship_name, ii->ship_name) && !(ii->from_table))
 		{
 			// look for corresponding old texture
 			for (i=0; i<texture_count; i++)
@@ -390,6 +391,7 @@ texture_replace *CShipTexturesDlg::texture_set(texture_replace *dest, const text
 	strcpy_s(dest->ship_name, src->ship_name);
 	strcpy_s(dest->old_texture, src->old_texture);
 	strcpy_s(dest->new_texture, src->new_texture);
+	dest->from_table = src->from_table;
 
 	return dest;
 }

--- a/qtfred/src/mission/missionsave.cpp
+++ b/qtfred/src/mission/missionsave.cpp
@@ -3396,7 +3396,7 @@ int CFred_mission_save::save_objects()
 			for (SCP_vector<texture_replace>::iterator ii = Fred_texture_replacements.begin();
 				 ii != Fred_texture_replacements.end(); ++ii) {
 				// Only look at this entry if it's not from the table. Table entries will just be read by FSO.
-				if (!stricmp(shipp->ship_name, ii->ship_name) && (!ii->from_table)) {
+				if (!stricmp(shipp->ship_name, ii->ship_name) && !(ii->from_table)) {
 					if (needs_header) {
 						if (optional_string_fred("$Texture Replace:")) {
 							parse_comments(1);

--- a/qtfred/src/mission/missionsave.cpp
+++ b/qtfred/src/mission/missionsave.cpp
@@ -3395,7 +3395,8 @@ int CFred_mission_save::save_objects()
 
 			for (SCP_vector<texture_replace>::iterator ii = Fred_texture_replacements.begin();
 				 ii != Fred_texture_replacements.end(); ++ii) {
-				if (!stricmp(shipp->ship_name, ii->ship_name)) {
+				// Only look at this entry if it's not from the table. Table entries will just be read by FSO.
+				if (!stricmp(shipp->ship_name, ii->ship_name) && (!ii->from_table)) {
 					if (needs_header) {
 						if (optional_string_fred("$Texture Replace:")) {
 							parse_comments(1);


### PR DESCRIPTION
Adds a way for fred to distinguish whether texture replacements are from the table or from the mission file/ship texture dialog, by adding a bool to the struct.

Fixes #3069 