### PR TITLE
preprocess alt names before mission start

### DIFF
--- a/code/hud/hudtarget.cpp
+++ b/code/hud/hudtarget.cpp
@@ -5323,15 +5323,16 @@ SCP_string hud_get_ship_class(const ship *shipp)
 	// try to get alt name
 	if (Fred_running) {
 		ship_class_text = Fred_alt_names[shipp-Ships];
+
+		if (ship_class_text.empty()) {
+			ship_class_text = Ship_info[shipp->ship_info_index].get_display_name();
+		}
 	} else {
 		if (shipp->alt_type_index >= 0) {
 			ship_class_text = mission_parse_lookup_alt_index(shipp->alt_type_index);
+		} else {
+			ship_class_text = Ship_info[shipp->ship_info_index].get_display_name();
 		}
-	}
-
-	// maybe get ship class
-	if (ship_class_text.empty()) {
-		ship_class_text = Ship_info[shipp->ship_info_index].get_display_name();
 	}
 
 	if (!Disable_built_in_translations) {

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -8085,6 +8085,33 @@ void mission_parse_reset_alt()
 	Mission_alt_type_count = 0;
 }
 
+// For compatibility purposes some mods want alt names to truncate at the hash symbol.  But we can't actually do that at mission load,
+// since we have to save them again in FRED.  So this function processes the names just before the mission starts.
+// To further complicate things, some mods actually want the hash to be displayed.  So this function uses the double-hash as an escape sequence for a single hash.
+void mission_process_alt_types()
+{
+	for (int i = 0; i < Mission_alt_type_count; ++i)
+	{
+		// truncate at a single hash
+		end_string_at_first_hash_symbol(Mission_alt_types[i], true);
+
+		// consolidate double hashes
+		auto src = Mission_alt_types[i];
+		auto dest = src;
+		while (*src)
+		{
+			if (*src == '#' && *(src + 1) == '#')
+				dest--;
+
+			++src;
+			++dest;
+
+			if (src != dest)
+				*dest = *src;
+		}
+	}
+}
+
 /**
  * Callsign stuff
  */

--- a/code/mission/missionparse.h
+++ b/code/mission/missionparse.h
@@ -518,9 +518,6 @@ int get_parse_name_index(const char *name);
 // called from freespace game level loop
 void mission_parse_eval_stuff();
 
-// function to set the ramaing time left in the mission
-void mission_parse_set_end_time( int seconds );
-
 // code to bring in a repair ship.
 void mission_bring_in_support_ship( object *requester_objp );
 int mission_is_support_ship_arriving( void );
@@ -535,6 +532,7 @@ const char *mission_parse_lookup_alt_index(int index);
 int mission_parse_add_alt(const char *name);
 void mission_parse_remove_alt(const char *name);
 void mission_parse_reset_alt();
+void mission_process_alt_types();
 
 // callsign stuff
 int mission_parse_lookup_callsign(const char *name);

--- a/code/parse/parselo.cpp
+++ b/code/parse/parselo.cpp
@@ -4004,12 +4004,12 @@ void sprintf(SCP_string &dest, const char *format, ...)
 }
 
 // Goober5000
-bool end_string_at_first_hash_symbol(char *src)
+bool end_string_at_first_hash_symbol(char *src, bool ignore_doubled_hash)
 {
 	char *p;
 	Assert(src);
 
-	p = get_pointer_to_first_hash_symbol(src);
+	p = get_pointer_to_first_hash_symbol(src, ignore_doubled_hash);
 	if (p)
 	{
 		while ((p != src) && (*(p-1) == ' '))
@@ -4023,9 +4023,9 @@ bool end_string_at_first_hash_symbol(char *src)
 }
 
 // Goober5000
-bool end_string_at_first_hash_symbol(SCP_string &src)
+bool end_string_at_first_hash_symbol(SCP_string &src, bool ignore_doubled_hash)
 {
-	int index = get_index_of_first_hash_symbol(src);
+	int index = get_index_of_first_hash_symbol(src, ignore_doubled_hash);
 	if (index >= 0)
 	{
 		while (index > 0 && src[index-1] == ' ')
@@ -4039,24 +4039,73 @@ bool end_string_at_first_hash_symbol(SCP_string &src)
 }
 
 // Goober5000
-char *get_pointer_to_first_hash_symbol(char *src)
+char *get_pointer_to_first_hash_symbol(char *src, bool ignore_doubled_hash)
 {
 	Assert(src);
-	return strchr(src, '#');
+
+	if (ignore_doubled_hash)
+	{
+		for (auto ch = src; *ch; ++ch)
+		{
+			if (*ch == '#')
+			{
+				if (*(ch + 1) == '#')
+					++ch;
+				else
+					return ch;
+			}
+		}
+		return nullptr;
+	}
+	else
+		return strchr(src, '#');
 }
 
 // Goober5000
-const char *get_pointer_to_first_hash_symbol(const char *src)
+const char *get_pointer_to_first_hash_symbol(const char *src, bool ignore_doubled_hash)
 {
 	Assert(src);
-	return strchr(src, '#');
+
+	if (ignore_doubled_hash)
+	{
+		for (auto ch = src; *ch; ++ch)
+		{
+			if (*ch == '#')
+			{
+				if (*(ch + 1) == '#')
+					++ch;
+				else
+					return ch;
+			}
+		}
+		return nullptr;
+	}
+	else
+		return strchr(src, '#');
 }
 
 // Goober5000
-int get_index_of_first_hash_symbol(SCP_string &src)
+int get_index_of_first_hash_symbol(SCP_string &src, bool ignore_doubled_hash)
 {
-	size_t pos = src.find('#');
-	return (pos == SCP_string::npos) ? -1 : (int)pos;
+	if (ignore_doubled_hash)
+	{
+		for (auto ch = src.begin(); ch != src.end(); ++ch)
+		{
+			if (*ch == '#')
+			{
+				if ((ch + 1) != src.end() && *(ch + 1) == '#')
+					++ch;
+				else
+					return (int)std::distance(src.begin(), ch);
+			}
+		}
+		return -1;
+	}
+	else
+	{
+		size_t pos = src.find('#');
+		return (pos == SCP_string::npos) ? -1 : (int)pos;
+	}
 }
 
 // Goober5000

--- a/code/parse/parselo.h
+++ b/code/parse/parselo.h
@@ -67,11 +67,11 @@ extern int Token_found_flag;
 #define SEXP_ERROR_CHECK_MODE		2
 
 // Goober5000 - this seems to be a pretty universal function
-extern bool end_string_at_first_hash_symbol(char *src);
-extern bool end_string_at_first_hash_symbol(SCP_string &src);
-extern char *get_pointer_to_first_hash_symbol(char *src);
-extern const char *get_pointer_to_first_hash_symbol(const char *src);
-extern int get_index_of_first_hash_symbol(SCP_string &src);
+extern bool end_string_at_first_hash_symbol(char *src, bool ignore_doubled_hash = false);
+extern bool end_string_at_first_hash_symbol(SCP_string &src, bool ignore_doubled_hash = false);
+extern char *get_pointer_to_first_hash_symbol(char *src, bool ignore_doubled_hash = false);
+extern const char *get_pointer_to_first_hash_symbol(const char *src, bool ignore_doubled_hash = false);
+extern int get_index_of_first_hash_symbol(SCP_string &src, bool ignore_doubled_hash = false);
 
 // white space
 extern int is_white_space(char ch);

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -1314,6 +1314,8 @@ void game_post_level_init()
 
 	freespace_mission_load_stuff();
 
+	mission_process_alt_types();
+
 	// m!m Make hv.Player available in "On Mission Start" hook
 	if(Player_obj)
 		Script_system.SetHookObject("Player", Player_obj);


### PR DESCRIPTION
For compatibility purposes some mods want alt names to truncate at the hash symbol.  But we can't actually do that at mission load,
since we have to save them again in FRED.  So this PR processes the names just before the mission starts.

To further complicate things, some mods actually want the hash to be displayed.  So this PR introduces the double-hash as an escape sequence for a single hash.