### PR TITLE
convert float parsing to use strtof

### DIFF
--- a/code/gamesnd/gamesnd.cpp
+++ b/code/gamesnd/gamesnd.cpp
@@ -663,11 +663,9 @@ void parse_gamesnd_old(game_snd* gs)
 		{
 			int temp_min, temp_max;
 
-			ignore_gray_space();
-			if (stuff_int_optional(&temp_min, true) == 2)
+			if (stuff_int_optional(&temp_min) == 2)
 			{
-				ignore_gray_space();
-				if (stuff_int_optional(&temp_max, true) == 2)
+				if (stuff_int_optional(&temp_max) == 2)
 				{
 					mprintf(("Dutifully converting retail sound %s, '%s' to a 3D sound...\n", gs->name.c_str(), entry.filename));
 					is_3d = 1;
@@ -681,8 +679,7 @@ void parse_gamesnd_old(game_snd* gs)
 	}
 
 	// check for extra values per Mantis #2408
-	ignore_gray_space();
-	if (stuff_int_optional(&temp, true) == 2)
+	if (stuff_int_optional(&temp) == 2)
 	{
 		Warning(LOCATION, "Unexpected extra value %d found for sound '%s' (filename '%s')!  Check the format of the sounds.tbl (or .tbm) entry.", temp, gs->name.c_str(), entry.filename);
 	}

--- a/code/model/modelread.cpp
+++ b/code/model/modelread.cpp
@@ -462,55 +462,6 @@ void get_user_prop_value(char *buf, char *value)
 	*p1 = c;
 }
 
-//	Stuff a floating point value pointed at by Mp.
-//	Advances past float characters.
-int stuff_float_temp(float *f, bool optional)
-{
-	char *str_start = Mp;
-	char *str_end;
-
-	// since strtof ignores white space anyway, might as well make it explicit
-	ignore_white_space();
-
-	auto result = strtof(Mp, &str_end);
-	bool success = false, comma = false;
-	int retval = 0;
-
-	// no float found?
-	if (result == 0.0f && str_end == Mp)
-	{
-		if (!optional)
-			error_display(1, "Expecting float, found [%.32s].\n", next_tokens());
-	}
-	else
-	{
-		*f = result;
-		success = true;
-	}
-
-	if (success)
-		Mp = str_end;
-
-	if (*Mp == ',')
-	{
-		comma = true;
-		Mp++;
-	}
-
-	if (optional && !success)
-		Mp = str_start;
-
-	if (success)
-		retval = 2;
-	else if (optional)
-		retval = comma ? 1 : 0;
-	else
-		skip_token();
-
-	diag_printf("Stuffed float: %f\n", *f);
-	return retval;
-}
-
 // routine to parse out a vec3d from a user property field of an object
 bool get_user_vec3d_value(char *buf, vec3d *value, bool require_brackets)
 {
@@ -543,11 +494,11 @@ bool get_user_vec3d_value(char *buf, vec3d *value, bool require_brackets)
 		}
 
 		// get comma-separated floats
-		if (stuff_float_temp(&f1, true) != 2)
+		if (stuff_float(&f1, true) != 2)
 			break;
-		if (stuff_float_temp(&f2, true) != 2)
+		if (stuff_float(&f2, true) != 2)
 			break;
-		if (stuff_float_temp(&f3, true) != 2)
+		if (stuff_float(&f3, true) != 2)
 			break;
 
 		if (require_brackets)

--- a/code/parse/parselo.h
+++ b/code/parse/parselo.h
@@ -138,11 +138,12 @@ extern char* alloc_block(const char* startstr, const char* endstr, int extra_cha
 // the default string length if using the F_NAME case.
 extern char *stuff_and_malloc_string(int type, const char *terminators = nullptr);
 extern void stuff_malloc_string(char **dest, int type, const char *terminators = nullptr);
-extern void stuff_float(float *f);
-extern int stuff_float_optional(float *f, bool raw = false);
-extern int stuff_int_optional(int *i, bool raw = false);
-extern void stuff_int(int *i);
+extern int stuff_float(float *f, bool optional = false);
+extern int stuff_int(int *i, bool optional = false);
+extern int stuff_long(long *l, bool optional = false);
 extern void stuff_ubyte(ubyte *i);
+extern int stuff_int_optional(int *i);
+extern int stuff_float_optional(float *f);
 extern int stuff_string_list(SCP_vector<SCP_string>& slp);
 extern int stuff_string_list(char slp[][NAME_LENGTH], int max_strings);
 extern int parse_string_flag_list(int *dest, flag_def_list defs[], int defs_size);
@@ -184,25 +185,16 @@ int parse_string_flag_list(Flagset& dest, flag_def_list_new<T> defs [], size_t n
     return num_strings;
 }
 
-extern bool atol2(long *out);
 template<class T>
 void stuff_flagset(T *dest) {
-    long l;
-    bool success = atol2(&l);
+    long l = 0;
+    stuff_long(&l);
 
 	if (l < 0) {
 		error_display(0, "Expected flagset value but got negative value %lu!\n", l);
 		l = 0;
 	}
     dest->from_u64((std::uint64_t) l);
-
-    if (!success)
-        skip_token();
-    else
-        Mp += strspn(Mp, "+-0123456789");
-
-    if (*Mp == ',')
-        Mp++;
 
     diag_printf("Stuffed flagset: %" PRIu64 "\n", dest->to_u64());
 }


### PR DESCRIPTION
One small detail that was overlooked in PR #3021... KeldorKatarn's old code used `strtod` while the new code used `stuff_float`.  This wouldn't be a problem except that a couple MVP models use annoyingly formatted floats like 8.9e-08.  So I decided to convert `stuff_float` to use `strtof` and do a few other minor improvements at the same time.