### PR TITLE
fix out of range error when AI targeting weapons

### DIFF
--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -9065,7 +9065,7 @@ void ai_chase()
 								}
 							}
 
-							if (timestamp_elapsed(swp->next_secondary_fire_stamp[current_bank]) && weapon_can_lock_on_ship(swip, En_objp->instance)) {
+							if (En_objp->type == OBJ_SHIP && timestamp_elapsed(swp->next_secondary_fire_stamp[current_bank]) && weapon_can_lock_on_ship(swip, En_objp->instance)) {
 								if (current_bank >= 0) {
 									float firing_range;
 									


### PR DESCRIPTION
assert on debugs, weapon_can_lock_on_ship() trying to index into the ships array with invalid index because it was called for ships targeting weapons.

Lock-on behavior when targeting weapons would be nice, but seems like it's not an intended feature at this time so just avoiding this logic rather than making new logic seemed to me to be the preferable path especially for the RC phase.