### PR TITLE
Safety for lock restriction handling

### DIFF
--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -9065,7 +9065,7 @@ void ai_chase()
 								}
 							}
 
-							if (timestamp_elapsed(swp->next_secondary_fire_stamp[current_bank]) && weapon_can_lock_on_ship(swip, En_objp->instance)) {
+							if (timestamp_elapsed(swp->next_secondary_fire_stamp[current_bank]) && weapon_allowed_lock_restriction_object(swip, En_objp)) {
 								if (current_bank >= 0) {
 									float firing_range;
 									

--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -9065,7 +9065,7 @@ void ai_chase()
 								}
 							}
 
-							if (timestamp_elapsed(swp->next_secondary_fire_stamp[current_bank]) && weapon_allowed_lock_restriction_object(swip, En_objp)) {
+							if (timestamp_elapsed(swp->next_secondary_fire_stamp[current_bank]) && weapon_target_satisfies_lock_restrictions(swip, En_objp)) {
 								if (current_bank >= 0) {
 									float firing_range;
 									

--- a/code/hud/hudlock.cpp
+++ b/code/hud/hudlock.cpp
@@ -924,7 +924,7 @@ void hud_lock_acquire_uncaged_target(lock_info *current_lock, weapon_info *wip)
 			continue;
 		}*/
 
-		if (!weapon_can_lock_on_ship(wip, A->instance)) {
+		if (!weapon_allowed_lock_restriction_object(wip, A)) {
 			continue;
 		}
 
@@ -1042,7 +1042,7 @@ void hud_lock_determine_lock_target(lock_info *lock_slot, weapon_info *wip)
 			return;
 		}
 
-		if ( !weapon_can_lock_on_ship(wip, lock_slot->obj->instance) ) {
+		if ( !weapon_allowed_lock_restriction_object(wip, lock_slot->obj) ) {
 			ship_clear_lock(lock_slot);
 			return;
 		}
@@ -1110,7 +1110,7 @@ void hud_lock_determine_lock_target(lock_info *lock_slot, weapon_info *wip)
 			return;
 		}
 
-		if ( !weapon_can_lock_on_ship(wip, lock_slot->obj->instance) ) {
+		if ( !weapon_allowed_lock_restriction_object(wip, lock_slot->obj) ) {
 			ship_clear_lock(lock_slot);
 			return;
 		}

--- a/code/hud/hudlock.cpp
+++ b/code/hud/hudlock.cpp
@@ -924,7 +924,7 @@ void hud_lock_acquire_uncaged_target(lock_info *current_lock, weapon_info *wip)
 			continue;
 		}*/
 
-		if (!weapon_allowed_lock_restriction_object(wip, A)) {
+		if (!weapon_target_satisfies_lock_restrictions(wip, A)) {
 			continue;
 		}
 
@@ -1042,7 +1042,7 @@ void hud_lock_determine_lock_target(lock_info *lock_slot, weapon_info *wip)
 			return;
 		}
 
-		if ( !weapon_allowed_lock_restriction_object(wip, lock_slot->obj) ) {
+		if ( !weapon_target_satisfies_lock_restrictions(wip, lock_slot->obj) ) {
 			ship_clear_lock(lock_slot);
 			return;
 		}
@@ -1110,7 +1110,7 @@ void hud_lock_determine_lock_target(lock_info *lock_slot, weapon_info *wip)
 			return;
 		}
 
-		if ( !weapon_allowed_lock_restriction_object(wip, lock_slot->obj) ) {
+		if ( !weapon_target_satisfies_lock_restrictions(wip, lock_slot->obj) ) {
 			ship_clear_lock(lock_slot);
 			return;
 		}

--- a/code/weapon/weapon.h
+++ b/code/weapon/weapon.h
@@ -676,8 +676,8 @@ void shield_impact_explosion(vec3d *hitpos, object *objp, float radius, int idx)
 // Swifty - return number of max simultaneous locks 
 int weapon_get_max_missile_seekers(weapon_info *wip);
 
-// return if this weapon can lock on this ship, based on its type, class, species or iff
-bool weapon_can_lock_on_ship(weapon_info *wip, int ship_num);
+// return if this weapon can lock on this target, based on its type, class, species or iff
+bool weapon_allowed_lock_restriction_object(weapon_info *wip, object* target);
 
 // return if this weapon has iff restrictions, and should ignore normal iff targeting restrictions
 bool weapon_has_iff_restrictions(weapon_info* wip);

--- a/code/weapon/weapon.h
+++ b/code/weapon/weapon.h
@@ -677,7 +677,7 @@ void shield_impact_explosion(vec3d *hitpos, object *objp, float radius, int idx)
 int weapon_get_max_missile_seekers(weapon_info *wip);
 
 // return if this weapon can lock on this target, based on its type, class, species or iff
-bool weapon_allowed_lock_restriction_object(weapon_info *wip, object* target);
+bool weapon_target_satisfies_lock_restrictions(weapon_info *wip, object* target);
 
 // return if this weapon has iff restrictions, and should ignore normal iff targeting restrictions
 bool weapon_has_iff_restrictions(weapon_info* wip);

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -5353,12 +5353,8 @@ void weapon_set_tracking_info(int weapon_objnum, int parent_objnum, int target_o
 
 	if ( parent_objp == NULL || Ships[parent_objp->instance].ai_index >= 0 ) {
 		int target_team = -1;
-		int target_ship_num = -1;
 		if ( target_objnum >= 0 ) {
 			int obj_type = Objects[target_objnum].type;
-
-			if (obj_type == OBJ_SHIP)
-				target_ship_num = Objects[target_objnum].instance;
 
 			if ( (obj_type == OBJ_SHIP) || (obj_type == OBJ_WEAPON) ) {
 				target_team = obj_team(&Objects[target_objnum]);

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -4093,9 +4093,8 @@ void find_homing_object(object *weapon_objp, int num)
 				continue; 
 
 			homing_object_team = obj_team(objp);
-			bool can_lock_on_ship = objp->type != OBJ_SHIP || weapon_allowed_lock_restriction_object(wip, objp);
 			bool can_attack = weapon_has_iff_restrictions(wip) || iff_x_attacks_y(wp->team, homing_object_team);
-			if (can_lock_on_ship && can_attack)
+			if (weapon_allowed_lock_restriction_object(wip, objp) && can_attack)
 			{
 				if ( objp->type == OBJ_SHIP )
                 {

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -4094,7 +4094,7 @@ void find_homing_object(object *weapon_objp, int num)
 
 			homing_object_team = obj_team(objp);
 			bool can_attack = weapon_has_iff_restrictions(wip) || iff_x_attacks_y(wp->team, homing_object_team);
-			if (weapon_allowed_lock_restriction_object(wip, objp) && can_attack)
+			if (weapon_target_satisfies_lock_restrictions(wip, objp) && can_attack)
 			{
 				if ( objp->type == OBJ_SHIP )
                 {
@@ -5376,7 +5376,7 @@ void weapon_set_tracking_info(int weapon_objnum, int parent_objnum, int target_o
 			targeting_same = 0;
 		}
 
-		bool can_lock = (weapon_has_iff_restrictions(wip) && target_objnum >= 0) ? weapon_allowed_lock_restriction_object(wip, &Objects[target_objnum]) :
+		bool can_lock = (weapon_has_iff_restrictions(wip) && target_objnum >= 0) ? weapon_target_satisfies_lock_restrictions(wip, &Objects[target_objnum]) :
 			(!targeting_same || (MULTI_DOGFIGHT && (target_team == Iff_traitor)));
 
 		// Cyborg17 - exclude all invalid object numbers here since in multi, the lock slots can get out of sync.
@@ -8686,7 +8686,7 @@ int weapon_get_max_missile_seekers(weapon_info *wip)
 }
 
 // returns whether a homing weapon can home on a particular ship
-bool weapon_allowed_lock_restriction_object(weapon_info* wip, object* target)
+bool weapon_target_satisfies_lock_restrictions(weapon_info* wip, object* target)
 {
 	if (target->type != OBJ_SHIP)
 		return true;


### PR DESCRIPTION
The previous method only handled ships, even though the target could be a non-ship. This handles all targets properly now, and I also changed its name because "can lock on ship" is pretty vague so I thought it better to be explicit that this is about lock restrictions