### PR TITLE
de-parent live debris

### DIFF
--- a/code/model/model.h
+++ b/code/model/model.h
@@ -803,7 +803,7 @@ polymodel *model_get(int model_num);
 
 polymodel_instance* model_get_instance(int model_instance_num);
 
-// routine to copy susbsystems.  Must be called when subsystems sets are the same -- see ship.cpp
+// routine to copy subsystems.  Must be called when subsystems sets are the same -- see ship.cpp
 void model_copy_subsystems(int n_subsystems, model_subsystem *d_sp, model_subsystem *s_sp);
 
 // If MR_FLAG_OUTLINE bit set this color will be used for outlines.

--- a/code/model/modelread.cpp
+++ b/code/model/modelread.cpp
@@ -2722,6 +2722,9 @@ int model_load(const  char *filename, int n_subsystems, model_subsystem *subsyst
 				Assert(pm->submodel[i].num_live_debris < MAX_LIVE_DEBRIS);
 				pm->submodel[i].live_debris[pm->submodel[i].num_live_debris++] = j;
 				pm->submodel[j].is_live_debris = 1;
+
+				// make sure live debris doesn't have a parent
+				pm->submodel[j].parent = -1;
 			}
 		}
 

--- a/code/ship/shipfx.cpp
+++ b/code/ship/shipfx.cpp
@@ -285,7 +285,7 @@ void shipfx_blow_off_subsystem(object *ship_objp, ship *ship_p, ship_subsys *sub
 		shipfx_blow_up_model(ship_objp, psub->subobj_num, 50, &subobj_pos );
 
 		// create live debris objects, if any
-		// TODO:  some MULITPLAYER implcations here!!
+		// TODO:  some MULTIPLAYER implcations here!!
 		shipfx_subsystem_maybe_create_live_debris(ship_objp, ship_p, subsys, exp_center, 1.0f);
 		
 		int fireball_type = fireball_ship_explosion_type(&Ship_info[ship_p->ship_info_index]);


### PR DESCRIPTION
It appears that live debris is not supposed to have a parent submodel; see the retail NTF Boadicea.  This removes the parent from any live debris that might have it.

This should fix #3078.