### PR TITLE
Fix unfocused multi interpolation inaccuracies

### DIFF
--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -4358,6 +4358,7 @@ int game_poll()
 	if (!Cmdline_no_unfocus_pause)
 	{
 		// If we're in a single player game, pause it.  
+		// Cyborg17 - Multiplayer *must not* have its time affected by being in the background.
 		// otherwise, ship interpolation will become inaccurate.
 		if (!os_foreground() && !(Game_mode & GM_MULTIPLAYER)) {
 			game_stop_time();

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -4357,16 +4357,15 @@ int game_poll()
 {
 	if (!Cmdline_no_unfocus_pause)
 	{
-		if (!os_foreground()) {
+		// If we're in a single player game, pause it.  
+		// otherwise, ship interpolation will become inaccurate.
+		if (!os_foreground() && !(Game_mode & GM_MULTIPLAYER)) {
 			game_stop_time();
 			os_sleep(1);
 			game_start_time();
+			if ((gameseq_get_state() == GS_STATE_GAME_PLAY) && (!popup_active()) && (!popupdead_is_active())) {
+				game_process_pause_key();
 
-			// If we're in a single player game, pause it.
-			if (!(Game_mode & GM_MULTIPLAYER)){
-				if ((gameseq_get_state() == GS_STATE_GAME_PLAY) && (!popup_active()) && (!popupdead_is_active()))	{
-					game_process_pause_key();
-				}
 			}
 		}
 	}


### PR DESCRIPTION
Multiplayer *must not* have its time affected by being in the background, because their clocks will come out of sync and ships from an out of focus multiplayer instance will appear to move in slow motion. This fixes the timing discrepancy by only doing `os_sleep ` for unfocused screens when in single player.

I don't think this is necessary for 21.0, but it could be helpful.