### PR TITLE
Properly recalculate tube light attenuation

### DIFF
--- a/code/def_files/data/effects/deferred-f.sdr
+++ b/code/def_files/data/effects/deferred-f.sdr
@@ -74,6 +74,7 @@ void GetLightInfo(vec3 position, out vec3 lightDir, out float attenuation)
 			if(dist > lightRadius) {
 				discard;
 			}
+			attenuation = 1.0 - clamp(dist / lightRadius, 0.0, 1.0);
 		} else if (lightType == LT_CONE) {
 			float coneDot = dot(normalize(-lightDir), coneDir);
 			if(dualCone) {


### PR DESCRIPTION
Before the fragment shader was calculating attenuation from one end of the beam as a point light, then doing the proper tube lighting distance calculation for culling but using the original attenuation calc for all other lighting. This just recalculates the attenuation after the proper distance is found, which fixes #2920 as well as slash beam lighting issues found while investigating that issue.