### PR TITLE
properly use model instances for tech room and briefing popups

### DIFF
--- a/code/menuui/techmenu.cpp
+++ b/code/menuui/techmenu.cpp
@@ -337,6 +337,8 @@ void techroom_select_new_entry()
 		}
 		Techroom_ship_model_instance = model_create_instance(true, Techroom_ship_modelnum);
 
+		model_set_up_techroom_instance(sip, Techroom_ship_model_instance);
+
 		Current_list->at(Cur_entry).model_num = Techroom_ship_modelnum;
 
 		// page in ship textures properly (takes care of nondimming pixels)
@@ -463,8 +465,6 @@ void tech_common_render()
 	}
 }
 
-void light_set_all_relevent();
-
 void techroom_ships_render(float frametime)
 {
 	// render all the common stuff
@@ -476,7 +476,6 @@ void techroom_ships_render(float frametime)
 	// now render the trackball ship, which is unique to the ships tab
 	float rev_rate = REVOLUTION_RATE;
 	angles rot_angles, view_angles;
-	int i, j;
 	ship_info *sip = &Ship_info[Cur_entry_index];
 	model_render_params render_info;
 
@@ -547,31 +546,6 @@ void techroom_ships_render(float frametime)
 	model_clear_instance(Techroom_ship_modelnum);
 	render_info.set_detail_level_lock(0);
 
-	polymodel *pm = model_get(Techroom_ship_modelnum);
-	polymodel_instance *pmi = model_get_instance(Techroom_ship_model_instance);
-	
-	for (i = 0; i < sip->n_subsystems; i++) {
-		model_subsystem *msp = &sip->subsystems[i];
-		if (msp->type == SUBSYSTEM_TURRET) {
-
-			float p = 0.0f;
-			float h = 0.0f;
-
-			for (j = 0; j < msp->n_triggers; j++) {
-
-				// special case for turrets
-				p = msp->triggers[j].angle.xyz.x;
-				h = msp->triggers[j].angle.xyz.y;
-			}
-			if ( msp->subobj_num >= 0 )	{
-				model_set_instance_techroom(pm, pmi, msp->subobj_num, 0.0f, h );
-			}
-			if ( (msp->subobj_num != msp->turret_gun_sobj) && (msp->turret_gun_sobj >= 0) )		{
-				model_set_instance_techroom(pm, pmi, msp->turret_gun_sobj, p, 0.0f );
-			}
-		}
-	}
-
 	if (sip->replacement_textures.size() > 0)
 	{
 		render_info.set_replacement_textures(Techroom_ship_modelnum, sip->replacement_textures);
@@ -581,10 +555,12 @@ void techroom_ships_render(float frametime)
     {
         gr_reset_clip();
 
+		auto pm = model_get(Techroom_ship_modelnum);
+
 		shadows_start_render(&Eye_matrix, &Eye_position, Proj_fov, gr_screen.clip_aspect, -sip->closeup_pos.xyz.z + pm->rad, -sip->closeup_pos.xyz.z + pm->rad + 200.0f, -sip->closeup_pos.xyz.z + pm->rad + 2000.0f, -sip->closeup_pos.xyz.z + pm->rad + 10000.0f);
         render_info.set_flags(MR_NO_TEXTURING | MR_NO_LIGHTING | MR_AUTOCENTER);
 		
-		model_render_immediate(&render_info, Techroom_ship_modelnum, &Techroom_ship_orient, &vmd_zero_vector);
+		model_render_immediate(&render_info, Techroom_ship_modelnum, Techroom_ship_model_instance, &Techroom_ship_orient, &vmd_zero_vector);
         shadows_end_render();
 
 		gr_set_clip(Tech_ship_display_coords[gr_screen.res][SHIP_X_COORD], Tech_ship_display_coords[gr_screen.res][SHIP_Y_COORD], Tech_ship_display_coords[gr_screen.res][SHIP_W_COORD], Tech_ship_display_coords[gr_screen.res][SHIP_H_COORD], GR_RESIZE_MENU);
@@ -600,7 +576,7 @@ void techroom_ships_render(float frametime)
 
 	render_info.set_flags(render_flags);
 
-	model_render_immediate(&render_info, Techroom_ship_modelnum, &Techroom_ship_orient, &vmd_zero_vector);
+	model_render_immediate(&render_info, Techroom_ship_modelnum, Techroom_ship_model_instance, &Techroom_ship_orient, &vmd_zero_vector);
 
 	Glowpoint_use_depth_buffer = true;
 

--- a/code/mission/missionbriefcommon.cpp
+++ b/code/mission/missionbriefcommon.cpp
@@ -463,6 +463,7 @@ void mission_brief_common_reset()
 					memset( Briefings[i].stages[j].icons, 0, sizeof(brief_icon) * MAX_STAGE_ICONS );
 					Briefings[i].stages[j].icons->ship_class = -1;
 					Briefings[i].stages[j].icons->modelnum = -1;
+					Briefings[i].stages[j].icons->model_instance_num = -1;
 					Briefings[i].stages[j].icons->bitmap_id = -1;
 				}
 

--- a/code/mission/missionbriefcommon.h
+++ b/code/mission/missionbriefcommon.h
@@ -114,6 +114,7 @@ typedef struct brief_icon {
 	int		hold_x, hold_y;	// 2D screen position of icon, used to place animations
 	int		ship_class;
 	int		modelnum;
+	int		model_instance_num;
 	float		radius;
 	int		type;					// ICON_* defines from MissionBriefCommon.h
 	int		bitmap_id;

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -1509,6 +1509,8 @@ void parse_briefing(mission * /*pm*/, int flags)
 				find_and_stuff("$team:", &bi->team, F_NAME, temp_team_names, Num_iffs, "team name");
 
 				find_and_stuff("$class:", &bi->ship_class, F_NAME, Ship_class_names, Ship_info.size(), "ship class");
+				bi->modelnum = -1;
+				bi->model_instance_num = -1;
 
 				// Goober5000 - import
 				if (flags & MPF_IMPORT_FSM)

--- a/code/missionui/missionbrief.cpp
+++ b/code/missionui/missionbrief.cpp
@@ -704,8 +704,13 @@ brief_icon *brief_get_closeup_icon()
 // stop showing the closeup view of an icon
 void brief_turn_off_closeup_icon()
 {
-	// turn off closup
+	// turn off closeup
 	if ( Closeup_icon != NULL ) {
+		if (Closeup_icon->model_instance_num >= 0) {
+			model_delete_instance(Closeup_icon->model_instance_num);
+			Closeup_icon->model_instance_num = -1;
+		}
+
 		gamesnd_play_iface(InterfaceSounds::BRIEF_ICON_SELECT);
 		Closeup_icon = NULL;
 		Closeup_close_button.disable();
@@ -1075,7 +1080,7 @@ void brief_render_closeup(int ship_class, float frametime)
 		render_info.set_flags(MR_AUTOCENTER);
 	}
 
-	model_render_immediate( &render_info, Closeup_icon->modelnum, &Closeup_orient, &Closeup_pos );
+	model_render_immediate( &render_info, Closeup_icon->modelnum, Closeup_icon->model_instance_num, &Closeup_orient, &Closeup_pos );
 
     The_mission.flags.set(Mission::Mission_Flags::Fullneb, neb_restore);
 
@@ -1198,28 +1203,6 @@ void brief_set_closeup_pos(brief_icon * /*bi*/)
 	Closeup_x1 = (int)std::lround(320 - Closeup_coords[gr_screen.res][BRIEF_W_COORD]/2.0f);
 }
 
-void brief_get_closeup_ship_modelnum(brief_icon *ci)
-{
-	object	*objp;
-	ship		*sp;
-
-	// find the model number for the ship to display
-	for ( objp = GET_FIRST(&obj_used_list); objp !=END_OF_LIST(&obj_used_list); objp = GET_NEXT(objp) ) {
-
-		if ( objp == &obj_used_list || objp->type != OBJ_SHIP ) {
-			continue;
-		}
-		
-		sp = &Ships[objp->instance];
-		if ( sp->ship_info_index == ci->ship_class ) {
-			ci->ship_class = sp->ship_info_index;
-			ci->modelnum = Ship_info[sp->ship_info_index].model_num;
-			ci->radius = objp->radius;
-			break;
-		}
-	}
-}
-
 // -------------------------------------------------------------------------------------
 // brief_setup_closeup()
 //
@@ -1234,6 +1217,7 @@ int brief_setup_closeup(brief_icon *bi)
 	Closeup_icon = bi;
 	Closeup_icon->ship_class = bi->ship_class;
 	Closeup_icon->modelnum = -1;
+	Closeup_icon->model_instance_num = -1;
 
 	Closeup_one_revolution_time = ONE_REV_TIME;
 
@@ -1270,7 +1254,6 @@ int brief_setup_closeup(brief_icon *bi)
 		Closeup_zoom = 0.5f;
 		break;
 	default:
-		brief_get_closeup_ship_modelnum(Closeup_icon);
 		Assert( Closeup_icon->ship_class != -1 );
 		sip = &Ship_info[Closeup_icon->ship_class];
 
@@ -1284,12 +1267,17 @@ int brief_setup_closeup(brief_icon *bi)
 		break;
 	}
 	
-	if ( Closeup_icon->modelnum == -1 ) {
+	if ( Closeup_icon->modelnum < 0 ) {
 		if ( sip == NULL ) {
 			Closeup_icon->modelnum = model_load(pof_filename, 0, NULL);
 		} else {
 			Closeup_icon->modelnum = model_load(sip->pof_file, sip->n_subsystems, &sip->subsystems[0]);
+			Closeup_icon->model_instance_num = model_create_instance(true, Closeup_icon->modelnum);
+			model_set_up_techroom_instance(sip, Closeup_icon->model_instance_num);
 		}
+	}
+
+	if ( Closeup_icon->modelnum >= 0 ) {
 		Closeup_icon->radius = model_get_radius(Closeup_icon->modelnum);
 	}
 

--- a/code/model/model.h
+++ b/code/model/model.h
@@ -22,6 +22,7 @@
 #include "model/model_flags.h"
 
 class object;
+class ship_info;
 class model_render_params;
 
 extern flag_def_list model_render_flags[];
@@ -968,7 +969,7 @@ extern void model_clear_instance(int model_num);
 extern void model_set_submodel_turn_info(submodel_instance *smi, float turn_rate, float turn_accel);
 
 // Sets the submodel instance data in a submodel
-extern void model_set_instance_techroom(polymodel *pm, polymodel_instance *pmi, int submodel_num, float angle_1, float angle_2);
+extern void model_set_up_techroom_instance(ship_info *sip, int model_instance_num);
 
 void model_update_instance(int model_instance_num, int submodel_num, flagset<Ship::Subsystem_Flags>& flags);
 void model_update_instance(polymodel *pm, polymodel_instance *pmi, int submodel_num, flagset<Ship::Subsystem_Flags>& flags);

--- a/fred2/briefingeditordlg.cpp
+++ b/fred2/briefingeditordlg.cpp
@@ -1044,6 +1044,10 @@ void briefing_editor_dlg::OnMakeIcon()
 	biconp->pos = pos;
 	biconp->flags = 0;
 	biconp->id = Cur_brief_id++;
+
+	biconp->modelnum = -1;
+	biconp->model_instance_num = -1;
+
 	if (ship >= 0) {
 		biconp->ship_class = Ships[ship].ship_info_index;
         ship_info* sip = &Ship_info[Ships[ship].ship_info_index];


### PR DESCRIPTION
These two situations mostly relied on the obsolete model code which didn't include model instances.  Data for submodel positions and for whether a submodel is blown off are now stored exclusively in model instances, not the model itself.

This fixes #3124.