### PR TITLE
More safety checks for the HUD_config struct

### DIFF
--- a/code/hud/hudconfig.cpp
+++ b/code/hud/hudconfig.cpp
@@ -566,7 +566,7 @@ typedef struct hc_col {
 	ubyte	r, g, b;
 } hc_col;
 
-hc_col HC_colors[3] =
+hc_col HC_colors[HUD_COLOR_SIZE] =
 {
 	{0, 255, 0},		// Green - get RGB from Adam so it matches palette?-??.pcx
 	{67, 123, 203},	// Blue - get RGB from Adam so it matches palette?-??.pcx

--- a/code/hud/hudconfig.h
+++ b/code/hud/hudconfig.h
@@ -21,6 +21,7 @@ struct ai_info;
 #define HUD_COLOR_GREEN		0
 #define HUD_COLOR_BLUE		1
 #define HUD_COLOR_AMBER		2
+#define HUD_COLOR_SIZE		3	// Number of default colors.  Keep this up to date.
 
 // specify the max distance that the radar should detect objects
 // Index in Radar_ranges[] array to get values
@@ -45,19 +46,22 @@ extern int HUD_default_popup_mask2;
 extern int HUD_config_default_flags;
 extern int HUD_config_default_flags2;
 
+/**
+ * @brief Contains core HUD configuration data
+ * @note Is not default init'd.  Assumes new player, PLR, or CSG reads will correctly set data.
+ */
 typedef struct HUD_CONFIG_TYPE {		
-	int show_flags;				// whether to show gauge
-	int show_flags2;				// whether to show gauge
-	int popup_flags;				// whether gauge is popup 	
-	int popup_flags2;				// whether gauge is popup 		
-	int rp_flags;					// see RP_ flags above
-	int rp_dist;					// one of RR_ #defines above
-	int is_observer;				// 1 or 0, observer mode or not, respectively
-	int main_color;				// the main color
-	ubyte num_msg_window_lines;	
+	int show_flags;				//!< bitfield, whether to show gauge (0 ~ 31)
+	int show_flags2;			//!< bitfield, whether to show gauge (32 ~ 63)
+	int popup_flags;			//!< bitfield, whether gauge is popup (0 ~ 31)
+	int popup_flags2;			//!< bitfield, whether gauge is popup (32 ~ 63)
+	int rp_flags;				//!< one of RP_ #defines in hudconfig.h;  Chiefly shows/hides non-ship objects
+	int rp_dist;				//!< one of RR_ #defines above; Is the maxium radar view distance setting
+	int is_observer;			//!< 1 or 0, observer mode or not, respectively
+	int main_color;				//!< the default HUD_COLOR selection for all gauges; each gauge may override this with a custom RGB
+	ubyte num_msg_window_lines;	//!< Number of message lines. (Deprecated by HudGaugeMessages::Max_lines)
 
-	// colors for all the gauges
-	color clr[NUM_HUD_GAUGES];
+	color clr[NUM_HUD_GAUGES];	//!< colors for all the gauges
 } HUD_CONFIG_TYPE;
 
 extern HUD_CONFIG_TYPE HUD_config;

--- a/code/pilotfile/csg.cpp
+++ b/code/pilotfile/csg.cpp
@@ -966,6 +966,7 @@ void pilotfile::csg_write_redalert()
 void pilotfile::csg_read_hud()
 {
 	int idx;
+	int strikes = 0;
 
 	// flags
 	HUD_config.show_flags = cfread_int(cfp);
@@ -986,10 +987,19 @@ void pilotfile::csg_read_hud()
 
 	// basic colors
 	HUD_config.main_color = cfread_int(cfp);
-	HUD_color_alpha = cfread_int(cfp);
+	if (HUD_config.main_color < 0 || HUD_config.main_color > HUD_COLOR_SIZE) {
+		Warning(LOCATION, "Campaign file has invalid main color selection %i, setting to default.\n", HUD_config.main_color);
+		HUD_config.main_color = HUD_COLOR_GREEN;
+	}
 
-	if (HUD_color_alpha < HUD_COLOR_ALPHA_USER_MIN) {
+	HUD_color_alpha = cfread_int(cfp);
+	if (HUD_color_alpha < HUD_COLOR_ALPHA_USER_MIN || HUD_color_alpha > HUD_COLOR_ALPHA_USER_MAX) {
+		Warning(LOCATION, "Campaign file has invalid alpha color %i, setting to default.\n", HUD_color_alpha);
 		HUD_color_alpha = HUD_COLOR_ALPHA_DEFAULT;
+	}
+
+	if (strikes == 3) {
+		Warning(LOCATION, "Campaign file has too many hud config errors, and is likely corrupted. Please verify and save your settings in the hud config menu.");
 	}
 
 	hud_config_record_color(HUD_config.main_color);

--- a/code/pilotfile/csg.cpp
+++ b/code/pilotfile/csg.cpp
@@ -981,25 +981,28 @@ void pilotfile::csg_read_hud()
 	HUD_config.rp_flags = cfread_int(cfp);
 	HUD_config.rp_dist = cfread_int(cfp);
 	if (HUD_config.rp_dist < 0 || HUD_config.rp_dist >= RR_MAX_RANGES) {
-		Warning(LOCATION, "Campaign file has invalid radar range %d, setting to default.\n", HUD_config.rp_dist);
+		ReleaseWarning(LOCATION, "Campaign file has invalid radar range %d, setting to default.\n", HUD_config.rp_dist);
 		HUD_config.rp_dist = RR_INFINITY;
+		strikes++;
 	}
 
 	// basic colors
 	HUD_config.main_color = cfread_int(cfp);
-	if (HUD_config.main_color < 0 || HUD_config.main_color > HUD_COLOR_SIZE) {
-		Warning(LOCATION, "Campaign file has invalid main color selection %i, setting to default.\n", HUD_config.main_color);
+	if (HUD_config.main_color < 0 || HUD_config.main_color >= HUD_COLOR_SIZE) {
+		ReleaseWarning(LOCATION, "Campaign file has invalid main color selection %i, setting to default.\n", HUD_config.main_color);
 		HUD_config.main_color = HUD_COLOR_GREEN;
+		strikes++;
 	}
 
 	HUD_color_alpha = cfread_int(cfp);
 	if (HUD_color_alpha < HUD_COLOR_ALPHA_USER_MIN || HUD_color_alpha > HUD_COLOR_ALPHA_USER_MAX) {
-		Warning(LOCATION, "Campaign file has invalid alpha color %i, setting to default.\n", HUD_color_alpha);
+		ReleaseWarning(LOCATION, "Campaign file has invalid alpha color %i, setting to default.\n", HUD_color_alpha);
 		HUD_color_alpha = HUD_COLOR_ALPHA_DEFAULT;
+		strikes++;
 	}
 
 	if (strikes == 3) {
-		Warning(LOCATION, "Campaign file has too many hud config errors, and is likely corrupted. Please verify and save your settings in the hud config menu.");
+		ReleaseWarning(LOCATION, "Campaign file has too many hud config errors, and is likely corrupted. Please verify and save your settings in the hud config menu.");
 	}
 
 	hud_config_record_color(HUD_config.main_color);

--- a/code/pilotfile/plr.cpp
+++ b/code/pilotfile/plr.cpp
@@ -186,28 +186,28 @@ void pilotfile::plr_read_hud()
 	HUD_config.rp_flags = handler->readInt("rp_flags");
 	HUD_config.rp_dist = handler->readInt("rp_dist");
 	if (HUD_config.rp_dist < 0 || HUD_config.rp_dist >= RR_MAX_RANGES) {
-		Warning(LOCATION, "Player file has invalid radar range %d, setting to default.\n", HUD_config.rp_dist);
+		ReleaseWarning(LOCATION, "Player file has invalid radar range %d, setting to default.\n", HUD_config.rp_dist);
 		HUD_config.rp_dist = RR_INFINITY;
 		strikes++;
 	}
 
 	// basic colors
 	HUD_config.main_color = handler->readInt("main_color");
-	if (HUD_config.main_color < 0 || HUD_config.main_color > HUD_COLOR_SIZE) {
-		Warning(LOCATION, "Player file has invalid main color selection %i, setting to default.\n", HUD_config.main_color);
+	if (HUD_config.main_color < 0 || HUD_config.main_color >= HUD_COLOR_SIZE) {
+		ReleaseWarning(LOCATION, "Player file has invalid main color selection %i, setting to default.\n", HUD_config.main_color);
 		HUD_config.main_color = HUD_COLOR_GREEN;
 		strikes++;
 	}
 
 	HUD_color_alpha = handler->readInt("color_alpha");
 	if (HUD_color_alpha < HUD_COLOR_ALPHA_USER_MIN || HUD_color_alpha > HUD_COLOR_ALPHA_USER_MAX) {
-		Warning(LOCATION, "Player file has invalid alpha color %i, setting to default.\n", HUD_color_alpha);
+		ReleaseWarning(LOCATION, "Player file has invalid alpha color %i, setting to default.\n", HUD_color_alpha);
 		HUD_color_alpha = HUD_COLOR_ALPHA_DEFAULT;
 		strikes++;
 	}
 
 	if (strikes == 3) {
-		Warning(LOCATION, "Player file has too many hud config errors, and is likely corrupted. Please verify and save your settings in the hud config menu.");
+		ReleaseWarning(LOCATION, "Player file has too many hud config errors, and is likely corrupted. Please verify and save your settings in the hud config menu.");
 	}
 
 	hud_config_set_color(HUD_config.main_color);

--- a/code/pilotfile/plr.cpp
+++ b/code/pilotfile/plr.cpp
@@ -172,6 +172,7 @@ void pilotfile::plr_write_info()
 
 void pilotfile::plr_read_hud()
 {
+	int strikes = 0;
 	// flags
 	HUD_config.show_flags = handler->readInt("show_flags");
 	HUD_config.show_flags2 = handler->readInt("show_flags2");
@@ -187,13 +188,26 @@ void pilotfile::plr_read_hud()
 	if (HUD_config.rp_dist < 0 || HUD_config.rp_dist >= RR_MAX_RANGES) {
 		Warning(LOCATION, "Player file has invalid radar range %d, setting to default.\n", HUD_config.rp_dist);
 		HUD_config.rp_dist = RR_INFINITY;
+		strikes++;
 	}
+
 	// basic colors
 	HUD_config.main_color = handler->readInt("main_color");
-	HUD_color_alpha = handler->readInt("color_alpha");
+	if (HUD_config.main_color < 0 || HUD_config.main_color > HUD_COLOR_SIZE) {
+		Warning(LOCATION, "Player file has invalid main color selection %i, setting to default.\n", HUD_config.main_color);
+		HUD_config.main_color = HUD_COLOR_GREEN;
+		strikes++;
+	}
 
-	if (HUD_color_alpha < HUD_COLOR_ALPHA_USER_MIN) {
+	HUD_color_alpha = handler->readInt("color_alpha");
+	if (HUD_color_alpha < HUD_COLOR_ALPHA_USER_MIN || HUD_color_alpha > HUD_COLOR_ALPHA_USER_MAX) {
+		Warning(LOCATION, "Player file has invalid alpha color %i, setting to default.\n", HUD_color_alpha);
 		HUD_color_alpha = HUD_COLOR_ALPHA_DEFAULT;
+		strikes++;
+	}
+
+	if (strikes == 3) {
+		Warning(LOCATION, "Player file has too many hud config errors, and is likely corrupted. Please verify and save your settings in the hud config menu.");
 	}
 
 	hud_config_set_color(HUD_config.main_color);


### PR DESCRIPTION
* Adds more safety checks for PLR and CSG reading for the HUD_config structure.
* Adds a #define for the HC_color array size
* Doxy's the HUD_config struct

Looking into causes of #3136 revealed the HUD_config struct is somewhat haphazard in initialization.  It makes the assumption that the struct will be properly initialized by a PLR or CSG read, or by creation of a new player.  No where else is the singleton struct init'd, making it a potential issue for data races should anything try to operate on non-init'd data.

@JohnAFernandez Is still looking into the cause of the data corruption due to a bad exit of the HUD Config menu.  This PR doesn't completely fix #3136 but it should at least prevent crashes due to bad data.