### PR TITLE
Make sure the Hud_config_inited is reset when the screen is exited.

### DIFF
--- a/code/hud/hudconfig.cpp
+++ b/code/hud/hudconfig.cpp
@@ -1509,6 +1509,8 @@ void hud_config_close()
 	if (HC_background_bitmap_mask != -1) {
 		bm_release(HC_background_bitmap_mask);
 	}
+
+	HUD_config_inited = 0;
 }
 
 // hud_set_default_hud_config() will set the hud configuration to default values
@@ -1557,7 +1559,7 @@ void hud_config_backup()
 
 void hud_config_as_observer(ship *shipp,ai_info *aif)
 {
-	// store the current hus
+	// store the current hud
 	hud_config_backup();
 
 	// bash these values so the HUD is not offset incorrectly


### PR DESCRIPTION
In trying to look for the real cause for #3136 , the only other thing we could find besides shoring up the struct and the player file loads is making sure that `HUD_config_inited` is set back to zero when the screen is closed.  The crash is so rare, and the work around in the player file and campaign file load are good enough that we can wait until @z64555's undo system is merged, and we can put that struct under that, in hopes that that fully fixes the issue.