### PR TITLE
Stop including tube lights between anti-fighter beam pulses

### DIFF
--- a/code/weapon/beam.cpp
+++ b/code/weapon/beam.cpp
@@ -168,6 +168,8 @@ void beam_type_c_move(beam *b);
 
 // type D functions
 void beam_type_d_move(beam *b);
+// stuffs the index of the current pulse in shot_index
+// stuffs 0 in fire_wait if the beam is active, 1 if it is between pulses
 void beam_type_d_get_status(beam *b, int *shot_index, int *fire_wait);
 
 // type e functions
@@ -1037,6 +1039,7 @@ void beam_move_all_post()
 	beam *next_one;	
 	int bf_status;	
 	beam_weapon_info *bwi;
+	int type_d_index, type_d_wait = 0;
 
 	// traverse through all active beams
 	moveup = GET_FIRST(&Beam_used_list);
@@ -1136,8 +1139,15 @@ void beam_move_all_post()
 		}
 
 		// add tube light for the beam
-		if(moveup->objp != NULL)
-			beam_add_light(moveup, OBJ_INDEX(moveup->objp), 1, NULL);
+		if (moveup->objp != NULL)
+			//assume we are in the waiting phases of a type D beam
+			type_d_wait = 0;
+			//test that assumption
+			if(moveup->type == BEAM_TYPE_D)
+				beam_type_d_get_status(moveup, &type_d_index, &type_d_wait);
+			//if it remains true, create a tube light.
+			if(type_d_wait==0)
+				beam_add_light(moveup, OBJ_INDEX(moveup->objp), 1, NULL);
 
 		// stop shooting?
 		if(bf_status <= 0){

--- a/code/weapon/beam.cpp
+++ b/code/weapon/beam.cpp
@@ -1139,15 +1139,16 @@ void beam_move_all_post()
 		}
 
 		// add tube light for the beam
-		if (moveup->objp != NULL)
+		if (moveup->objp != NULL) {
 			//assume we are in the waiting phases of a type D beam
 			type_d_wait = 0;
 			//test that assumption
-			if(moveup->type == BEAM_TYPE_D)
+			if (moveup->type == BEAM_TYPE_D)
 				beam_type_d_get_status(moveup, &type_d_index, &type_d_wait);
 			//if it remains true, create a tube light.
-			if(type_d_wait==0)
+			if (type_d_wait == 0)
 				beam_add_light(moveup, OBJ_INDEX(moveup->objp), 1, NULL);
+		}
 
 		// stop shooting?
 		if(bf_status <= 0){

--- a/code/weapon/beam.cpp
+++ b/code/weapon/beam.cpp
@@ -1039,7 +1039,6 @@ void beam_move_all_post()
 	beam *next_one;	
 	int bf_status;	
 	beam_weapon_info *bwi;
-	int type_d_index, type_d_wait = 0;
 
 	// traverse through all active beams
 	moveup = GET_FIRST(&Beam_used_list);
@@ -1139,15 +1138,23 @@ void beam_move_all_post()
 		}
 
 		// add tube light for the beam
-		if (moveup->objp != NULL) {
-			//assume we are in the waiting phases of a type D beam
-			type_d_wait = 0;
-			//test that assumption
-			if (moveup->type == BEAM_TYPE_D)
-				beam_type_d_get_status(moveup, &type_d_index, &type_d_wait);
-			//if it remains true, create a tube light.
-			if (type_d_wait == 0)
-				beam_add_light(moveup, OBJ_INDEX(moveup->objp), 1, NULL);
+		if (moveup->objp != nullptr) {
+			if (moveup->type == BEAM_TYPE_D) {
+
+				//we only use the second variable but we need two pointers to pass.
+				int type_d_index, type_d_waiting = 0;
+
+				beam_type_d_get_status(moveup, &type_d_index, &type_d_waiting);
+
+				//create a tube light only if we are not waiting between shots
+				if (type_d_waiting == 0) {
+					beam_add_light(moveup, OBJ_INDEX(moveup->objp), 1, nullptr);
+				}
+			}
+			else
+			{
+				beam_add_light(moveup, OBJ_INDEX(moveup->objp), 1, nullptr);
+			}
 		}
 
 		// stop shooting?


### PR DESCRIPTION
Fixing tube lighting revealed a bug were the light remained on between the pulses of a anti-fighter beam cycle. This adds a check in  `beam_move_all_post()` to avoid that.

also adds a comment to `beam_type_d_get_status()` about the returns of that function, because I used that here and that comment would have saved me some time had it been there already.