### PR TITLE
fix a rare crash in the tech room

### DIFF
--- a/code/menuui/techmenu.cpp
+++ b/code/menuui/techmenu.cpp
@@ -43,7 +43,7 @@
 
 #define NUM_BUTTONS	16
 #define NUM_TABS		3
-#define LIST_BUTTONS_MAX	42
+#define LIST_BUTTONS_MAX	50
 
 #define SHIPS_DATA_MODE		(1<<0)
 #define WEAPONS_DATA_MODE	(1<<1)
@@ -430,7 +430,7 @@ void tech_common_render()
 	y = 0;
 	z = List_offset;
 	while (y + font_height <= Tech_list_coords[gr_screen.res][SHIP_H_COORD]) {
-		if (z >= static_cast<int>(Current_list->size())) {
+		if ((z - List_offset) >= LIST_BUTTONS_MAX || z >= static_cast<int>(Current_list->size())) {
 			break;
 		}
 


### PR DESCRIPTION
The tech room loop checked that all the lines could fit in the available screen real estate, but it didn't check to see that the number of lines was less than the array capacity.  Normally this never happened, but certain mods which use smaller fonts will overflow the limit.  This adds a proper bounds check and also increases the bounds so that more of the smaller lines can be used.