### PR TITLE
Improve graphics API to reduce return values

### DIFF
--- a/code/bmpman/bmpman.cpp
+++ b/code/bmpman/bmpman.cpp
@@ -1912,14 +1912,6 @@ bitmap * bm_lock(int handle, int bpp, ushort flags, bool nodebug) {
 
 		return NULL;
 	}
-	
-	if (!gr_bm_data(handle, bmp)) {
-		// graphics subsystem failed, reset and return NULL
-		bm_unlock( handle );
-		bm_unload( handle );
-
-		return NULL;
-	}
 
 	MONITOR_INC(NumBitmapPage, 1);
 	MONITOR_INC(SizeBitmapPage, bmp->w*bmp->h);
@@ -2973,68 +2965,66 @@ bool bm_set_render_target(int handle, int face) {
 		}
 	}
 
-	if (gr_bm_set_render_target(handle, face)) {
-		if (gr_screen.rendering_to_texture == -1) {
-			//if we are moving from the back buffer to a texture save whatever the current settings are
-			gr_screen.save_max_w = gr_screen.max_w;
-			gr_screen.save_max_h = gr_screen.max_h;
+	gr_bm_set_render_target(handle, face);
 
-			gr_screen.save_max_w_unscaled = gr_screen.max_w_unscaled;
-			gr_screen.save_max_h_unscaled = gr_screen.max_h_unscaled;
+	if (gr_screen.rendering_to_texture == -1) {
+		//if we are moving from the back buffer to a texture save whatever the current settings are
+		gr_screen.save_max_w = gr_screen.max_w;
+		gr_screen.save_max_h = gr_screen.max_h;
 
-			gr_screen.save_max_w_unscaled_zoomed = gr_screen.max_w_unscaled_zoomed;
-			gr_screen.save_max_h_unscaled_zoomed = gr_screen.max_h_unscaled_zoomed;
+		gr_screen.save_max_w_unscaled = gr_screen.max_w_unscaled;
+		gr_screen.save_max_h_unscaled = gr_screen.max_h_unscaled;
 
-			gr_screen.save_center_w = gr_screen.center_w;
-			gr_screen.save_center_h = gr_screen.center_h;
+		gr_screen.save_max_w_unscaled_zoomed = gr_screen.max_w_unscaled_zoomed;
+		gr_screen.save_max_h_unscaled_zoomed = gr_screen.max_h_unscaled_zoomed;
 
-			gr_screen.save_center_offset_x = gr_screen.center_offset_x;
-			gr_screen.save_center_offset_y = gr_screen.center_offset_y;
-		}
+		gr_screen.save_center_w = gr_screen.center_w;
+		gr_screen.save_center_h = gr_screen.center_h;
 
-		if (handle < 0) {
-			gr_screen.max_w = gr_screen.save_max_w;
-			gr_screen.max_h = gr_screen.save_max_h;
-
-			gr_screen.max_w_unscaled = gr_screen.save_max_w_unscaled;
-			gr_screen.max_h_unscaled = gr_screen.save_max_h_unscaled;
-
-			gr_screen.max_w_unscaled_zoomed = gr_screen.save_max_w_unscaled_zoomed;
-			gr_screen.max_h_unscaled_zoomed = gr_screen.save_max_h_unscaled_zoomed;
-
-			gr_screen.center_w = gr_screen.save_center_w;
-			gr_screen.center_h = gr_screen.save_center_h;
-
-			gr_screen.center_offset_x = gr_screen.save_center_offset_x;
-			gr_screen.center_offset_y = gr_screen.save_center_offset_y;
-		} else {
-			gr_screen.max_w = entry->bm.w;
-			gr_screen.max_h = entry->bm.h;
-
-			gr_screen.max_w_unscaled = entry->bm.w;
-			gr_screen.max_h_unscaled = entry->bm.h;
-
-			gr_screen.max_w_unscaled_zoomed = entry->bm.w;
-			gr_screen.max_h_unscaled_zoomed = entry->bm.h;
-
-			gr_screen.center_w = entry->bm.w;
-			gr_screen.center_h = entry->bm.h;
-
-			gr_screen.center_offset_x = 0;
-			gr_screen.center_offset_y = 0;
-		}
-
-		gr_screen.rendering_to_face = face;
-		gr_screen.rendering_to_texture = handle;
-
-		gr_reset_clip();
-
-		gr_setup_viewport();
-
-		return true;
+		gr_screen.save_center_offset_x = gr_screen.center_offset_x;
+		gr_screen.save_center_offset_y = gr_screen.center_offset_y;
 	}
 
-	return false;
+	if (handle < 0) {
+		gr_screen.max_w = gr_screen.save_max_w;
+		gr_screen.max_h = gr_screen.save_max_h;
+
+		gr_screen.max_w_unscaled = gr_screen.save_max_w_unscaled;
+		gr_screen.max_h_unscaled = gr_screen.save_max_h_unscaled;
+
+		gr_screen.max_w_unscaled_zoomed = gr_screen.save_max_w_unscaled_zoomed;
+		gr_screen.max_h_unscaled_zoomed = gr_screen.save_max_h_unscaled_zoomed;
+
+		gr_screen.center_w = gr_screen.save_center_w;
+		gr_screen.center_h = gr_screen.save_center_h;
+
+		gr_screen.center_offset_x = gr_screen.save_center_offset_x;
+		gr_screen.center_offset_y = gr_screen.save_center_offset_y;
+	} else {
+		gr_screen.max_w = entry->bm.w;
+		gr_screen.max_h = entry->bm.h;
+
+		gr_screen.max_w_unscaled = entry->bm.w;
+		gr_screen.max_h_unscaled = entry->bm.h;
+
+		gr_screen.max_w_unscaled_zoomed = entry->bm.w;
+		gr_screen.max_h_unscaled_zoomed = entry->bm.h;
+
+		gr_screen.center_w = entry->bm.w;
+		gr_screen.center_h = entry->bm.h;
+
+		gr_screen.center_offset_x = 0;
+		gr_screen.center_offset_y = 0;
+	}
+
+	gr_screen.rendering_to_face = face;
+	gr_screen.rendering_to_texture = handle;
+
+	gr_reset_clip();
+
+	gr_setup_viewport();
+
+	return true;
 }
 
 int bm_unload(int handle, int clear_render_targets, bool nodebug) {

--- a/code/cmdline/cmdline.cpp
+++ b/code/cmdline/cmdline.cpp
@@ -209,11 +209,8 @@ Flag exe_params[] =
 	{ "-nomovies",			"Disable video playback",					true,	0,									EASY_DEFAULT,					"Troubleshoot",	"http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-nomovies", },
 	{ "-noparseerrors",		"Disable parsing errors",					true,	0,									EASY_DEFAULT,					"Troubleshoot",	"http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-noparseerrors", },
 	{ "-loadallweps",		"Load all weapons, even those not used",	true,	0,									EASY_DEFAULT,					"Troubleshoot",	"http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-loadallweps", },
-	{ "-disable_fbo",		"Disable OpenGL RenderTargets",				true,	0,									EASY_DEFAULT,					"Troubleshoot",	"http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-disable_fbo", },
-	{ "-disable_pbo",		"Disable OpenGL Pixel Buffer Objects",		true,	0,									EASY_DEFAULT,					"Troubleshoot",	"http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-disable_pbo", },
 	{ "-ati_swap",			"Fix colour issues on some ATI cards",		true,	0,									EASY_DEFAULT,					"Troubleshoot",	"http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-ati_swap", },
 	{ "-no_3d_sound",		"Use only 2D/stereo for sound effects",		true,	0,									EASY_DEFAULT,					"Troubleshoot",	"http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-no_3d_sound", },
-	{ "-mipmap",			"Enable mipmapping",						true,	0,									EASY_DEFAULT | EASY_HI_MEM_OFF,	"Troubleshoot",	"http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-mipmap", },
 	{ "-use_gldrawelements","Don't use glDrawRangeElements",			true,	0,									EASY_DEFAULT,					"Troubleshoot",	"http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-use_gldrawelements", },
 	{ "-gl_finish",			"Fix input lag on some ATI+Linux systems",	true,	0,									EASY_DEFAULT,					"Troubleshoot", "http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-gl_finish", },
 	{ "-no_geo_effects",	"Disable geometry shader for effects",		true,	0,									EASY_DEFAULT,					"Troubleshoot", "http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-no_geo_effects", },
@@ -340,7 +337,6 @@ cmdline_parm anisotropy_level_arg("-anisotropic_filter", NULL, AT_INT);
 float Cmdline_clip_dist = Default_min_draw_distance;
 int Cmdline_ambient_factor = 128;
 int Cmdline_env = 1;
-int Cmdline_mipmap = 0;
 int Cmdline_glow = 1;
 int Cmdline_noscalevid = 0;
 int Cmdline_spec = 1;
@@ -424,9 +420,6 @@ bool Cmdline_portable_mode = false;
 cmdline_parm loadallweapons_arg("-loadallweps", NULL, AT_NONE);	// Cmdline_load_all_weapons
 cmdline_parm nomovies_arg("-nomovies", NULL, AT_NONE);		// Cmdline_nomovies  -- Allows video streaming
 cmdline_parm no_set_gamma_arg("-no_set_gamma", NULL, AT_NONE);	// Cmdline_no_set_gamma
-cmdline_parm no_fbo_arg("-disable_fbo", NULL, AT_NONE);		// Cmdline_no_fbo
-cmdline_parm no_pbo_arg("-disable_pbo", NULL, AT_NONE);		// Cmdline_no_pbo
-cmdline_parm mipmap_arg("-mipmap", NULL, AT_NONE);			// Cmdline_mipmap
 cmdline_parm atiswap_arg("-ati_swap", NULL, AT_NONE);        // Cmdline_atiswap - Fix ATI color swap issue for screenshots.
 cmdline_parm no3dsound_arg("-no_3d_sound", NULL, AT_NONE);		// Cmdline_no_3d_sound - Disable use of full 3D sounds
 cmdline_parm no_drawrangeelements("-use_gldrawelements", NULL, AT_NONE); // Cmdline_drawelements -- Uses glDrawElements instead of glDrawRangeElements
@@ -443,8 +436,6 @@ cmdline_parm fix_registry("-fix_registry", NULL, AT_NONE);
 int Cmdline_load_all_weapons = 0;
 int Cmdline_nomovies = 0;
 int Cmdline_no_set_gamma = 0;
-int Cmdline_no_fbo = 0;
-int Cmdline_no_pbo = 0;
 int Cmdline_ati_color_swap = 0;
 int Cmdline_no_3d_sound = 0;
 int Cmdline_drawelements = 0;
@@ -538,6 +529,9 @@ cmdline_parm deprecated_missile_lighting_arg("-missile_lighting", "Deprecated", 
 cmdline_parm deprecated_cache_bitmaps_arg("-cache_bitmaps", "Deprecated", AT_NONE);
 cmdline_parm deprecated_no_emissive_arg("-no_emissive_light", "Deprecated", AT_NONE);
 cmdline_parm deprecated_postprocess_arg("-post_process", "Deprecated", AT_NONE);
+cmdline_parm deprecated_no_fbo_arg("-disable_fbo", NULL, AT_NONE);
+cmdline_parm deprecated_no_pbo_arg("-disable_pbo", NULL, AT_NONE);
+cmdline_parm deprecated_mipmap_arg("-mipmap", NULL, AT_NONE);
 
 int Cmdline_deprecated_spec = 0;
 int Cmdline_deprecated_glow = 0;
@@ -550,6 +544,9 @@ bool Cmdline_deprecated_brief_lighting = 0;
 bool Cmdline_deprecated_missile_lighting = false;
 bool Cmdline_deprecated_cache_bitmaps = false;
 bool Cmdline_deprecated_postprocess = false;
+bool Cmdline_deprecated_no_fbo = false;
+bool Cmdline_deprecated_no_pbo = false;
+bool Cmdline_deprecated_mipmap = false;
 
 #ifndef NDEBUG
 // NOTE: this assumes that os_init() has already been called but isn't a fatal error if it hasn't
@@ -627,6 +624,18 @@ void cmdline_debug_print_cmdline()
 
 	if (Cmdline_deprecated_postprocess) {
 		mprintf(("Deprecated flag '-post_process' found. Please remove from your cmdline.\n"));
+	}
+
+	if (Cmdline_deprecated_no_fbo) {
+		mprintf(("Deprecated flag '-disable_fpo' found. Please remove from your cmdline.\n"));
+	}
+
+	if (Cmdline_deprecated_no_pbo) {
+		mprintf(("Deprecated flag '-disable_pbo' found. Please remove from your cmdline.\n"));
+	}
+
+	if (Cmdline_deprecated_mipmap) {
+		mprintf(("Deprecated flag '-mipmap' found. Please remove from your cmdline.\n"));
 	}
 }
 #endif
@@ -1797,10 +1806,6 @@ bool SetCmdlineParams()
 		Motion_debris_enabled = false;
 	}
 
-	if( mipmap_arg.found() ) {
-		Cmdline_mipmap = 1;
-	}
-
 	if( stats_arg.found() ) {
 		Cmdline_show_stats = 1;
 	}
@@ -1938,11 +1943,6 @@ bool SetCmdlineParams()
 		Cmdline_output_sexp_info = true;
 	}
 
-	if ( no_pbo_arg.found() )
-	{
-		Cmdline_no_pbo = 1;
-	}
-
 	if ( no_drawrangeelements.found() )
 	{
 		Cmdline_drawelements = 1;
@@ -2002,10 +2002,6 @@ bool SetCmdlineParams()
 
 	if(dis_weapons.found())
 		Cmdline_dis_weapons = 1;
-
-	if ( no_fbo_arg.found() ) {
-		Cmdline_no_fbo = 1;
-	}
 
 	if ( emissive_arg.found() ) {
 		Cmdline_emissive = 1;
@@ -2251,7 +2247,17 @@ bool SetCmdlineParams()
 			}
 		}
 	}
- 
+
+	if (deprecated_no_pbo_arg.found()) {
+		Cmdline_deprecated_no_pbo = 1;
+	}
+	if (deprecated_no_fbo_arg.found()) {
+		Cmdline_deprecated_no_fbo = 1;
+	}
+	if (deprecated_mipmap_arg.found()) {
+		Cmdline_deprecated_mipmap = 1;
+	}
+
 	return true; 
 }
 

--- a/code/cmdline/cmdline.h
+++ b/code/cmdline/cmdline.h
@@ -111,9 +111,6 @@ extern bool Cmdline_portable_mode;
 extern int Cmdline_load_all_weapons;
 extern int Cmdline_nomovies;	// WMC Toggles movie playing support
 extern int Cmdline_no_set_gamma;
-extern int Cmdline_no_fbo;
-extern int Cmdline_no_pbo;
-extern int Cmdline_mipmap;
 extern int Cmdline_ati_color_swap;
 extern int Cmdline_no_3d_sound;
 extern int Cmdline_drawelements;

--- a/code/graphics/2d.h
+++ b/code/graphics/2d.h
@@ -712,9 +712,6 @@ typedef struct screen {
 	// dumps the current screen to a file
 	std::function<void(const char* filename)> gf_print_screen;
 
-	// Retrieves the zbuffer mode.
-	std::function<int()> gf_zbuffer_get;
-
 	// Sets mode.  Returns previous mode.
 	std::function<int(int mode)> gf_zbuffer_set;
 
@@ -722,12 +719,12 @@ typedef struct screen {
 	std::function<void(int use_zbuffer)> gf_zbuffer_clear;
 
 	// Set the stencil buffer mode. Returns previous mode
-	std::function<int(int mode)> gf_stencil_set;
+	std::function<void(int mode)> gf_stencil_set;
 
 	// Clears the stencil buffer.
 	std::function<void()> gf_stencil_clear;
 
-	std::function<int(int mode, float alpha)> gf_alpha_mask_set;
+	std::function<void(int mode, float alpha)> gf_alpha_mask_set;
 
 	// Saves screen. Returns an id you pass to restore and free.
 	std::function<int()> gf_save_screen;
@@ -742,7 +739,7 @@ typedef struct screen {
 	std::function<void(int front, int w, int h, ubyte* data)> gf_get_region;
 
 	// poly culling
-	std::function<int(int cull)> gf_set_cull;
+	std::function<void(int cull)> gf_set_cull;
 
 	// color buffer writes
 	std::function<int(int mode)> gf_set_color_buffer;
@@ -758,10 +755,9 @@ typedef struct screen {
 	std::function<void(bitmap_slot* slot)> gf_bm_create;
 	std::function<void(bitmap_slot* slot)> gf_bm_init;
 	std::function<void()> gf_bm_page_in_start;
-	std::function<bool(int handle, bitmap* bm)> gf_bm_data;
 
 	std::function<int(int handle, int* width, int* height, int* bpp, int* mm_lvl, int flags)> gf_bm_make_render_target;
-	std::function<int(int handle, int face)> gf_bm_set_render_target;
+	std::function<void(int handle, int face)> gf_bm_set_render_target;
 
 	std::function<void(int)> gf_set_texture_addressing;
 
@@ -1008,7 +1004,6 @@ void gr_set_bitmap(int bitmap_num, int alphablend = GR_ALPHABLEND_NONE, int bitb
 
 #define gr_clear				GR_CALL(gr_screen.gf_clear)
 
-#define gr_zbuffer_get		GR_CALL(gr_screen.gf_zbuffer_get)
 #define gr_zbuffer_set		GR_CALL(gr_screen.gf_zbuffer_set)
 #define gr_zbuffer_clear	GR_CALL(gr_screen.gf_zbuffer_clear)
 
@@ -1036,13 +1031,12 @@ void gr_set_bitmap(int bitmap_num, int alphablend = GR_ALPHABLEND_NONE, int bitb
 #define gr_bm_create				GR_CALL(gr_screen.gf_bm_create)
 #define gr_bm_init					GR_CALL(gr_screen.gf_bm_init)
 #define gr_bm_page_in_start			GR_CALL(gr_screen.gf_bm_page_in_start)
-#define gr_bm_data					GR_CALL(gr_screen.gf_bm_data)
 
 #define gr_bm_make_render_target					GR_CALL(gr_screen.gf_bm_make_render_target)
 
-inline int gr_bm_set_render_target(int n, int face = -1)
+inline void gr_bm_set_render_target(int n, int face = -1)
 {
-	return gr_screen.gf_bm_set_render_target(n, face);
+	gr_screen.gf_bm_set_render_target(n, face);
 }
 
 #define gr_set_texture_addressing GR_CALL(gr_screen.gf_set_texture_addressing)

--- a/code/graphics/grstub.cpp
+++ b/code/graphics/grstub.cpp
@@ -134,9 +134,8 @@ int gr_stub_set_cull(int  /*cull*/)
 	return 0;
 }
 
-int gr_stub_set_color_buffer(int  /*mode*/)
+void gr_stub_set_color_buffer(int  /*mode*/)
 {
-	return 0;
 }
 
 void gr_stub_set_tex_env_scale(float  /*scale*/)
@@ -172,9 +171,8 @@ void gr_stub_stencil_clear()
 {
 }
 
-int gr_stub_alpha_mask_set(int  /*mode*/, float  /*alpha*/)
+void gr_stub_alpha_mask_set(float  /*alpha*/)
 {
-	return 0;
 }
 
 /*void gr_stub_shade(int x,int y,int w,int h)
@@ -274,11 +272,6 @@ void gr_stub_bm_init(bitmap_slot* /*slot*/)
 
 void gr_stub_bm_page_in_start()
 {
-}
-
-bool gr_stub_bm_data(int  /*n*/, bitmap*  /*bm*/)
-{
-	return true;
 }
 
 int gr_stub_maybe_create_shader(shader_type  /*shader_t*/, unsigned int  /*flags*/) {
@@ -471,7 +464,6 @@ bool gr_stub_init()
 	gr_screen.gf_bm_create				= gr_stub_bm_create;
 	gr_screen.gf_bm_init				= gr_stub_bm_init;
 	gr_screen.gf_bm_page_in_start		= gr_stub_bm_page_in_start;
-	gr_screen.gf_bm_data				= gr_stub_bm_data;
 	gr_screen.gf_bm_make_render_target	= gr_stub_bm_make_render_target;
 	gr_screen.gf_bm_set_render_target	= gr_stub_bm_set_render_target;
 

--- a/code/graphics/opengl/gropengl.cpp
+++ b/code/graphics/opengl/gropengl.cpp
@@ -356,7 +356,7 @@ void gr_opengl_set_clear_color(int r, int g, int b)
 	gr_init_color(&gr_screen.current_clear_color, r, g, b);
 }
 
-int gr_opengl_set_color_buffer(int mode)
+void gr_opengl_set_color_buffer(int mode)
 {
 	bvec4 enabled;
 
@@ -367,9 +367,6 @@ int gr_opengl_set_color_buffer(int mode)
 	}
 
 	GL_state.SetAlphaBlendMode(ALPHA_BLEND_ALPHA_BLEND_ALPHA);
-
-	// Check if all channels are active
-	return enabled.x && enabled.y && enabled.z && enabled.w;
 }
 
 int gr_opengl_zbuffer_get()
@@ -449,16 +446,9 @@ void gr_opengl_stencil_clear()
 	glClear(GL_STENCIL_BUFFER_BIT);
 }
 
-int gr_opengl_alpha_mask_set(int mode, float alpha)
+void gr_opengl_alpha_mask_set(float alpha)
 {
-	if ( mode ) {
-		GL_alpha_threshold = alpha;
-	} else {
-		GL_alpha_threshold = 0.0f;
-	}
-
-	// alpha masking is deprecated
-	return mode;
+	GL_alpha_threshold = alpha;
 }
 
 void gr_opengl_get_region(int  /*front*/, int w, int h, ubyte *data)
@@ -829,7 +819,6 @@ void opengl_setup_function_pointers()
 	gr_screen.gf_bm_create				= gr_opengl_bm_create;
 	gr_screen.gf_bm_init				= gr_opengl_bm_init;
 	gr_screen.gf_bm_page_in_start		= gr_opengl_bm_page_in_start;
-	gr_screen.gf_bm_data				= gr_opengl_bm_data;
 	gr_screen.gf_bm_make_render_target	= gr_opengl_bm_make_render_target;
 	gr_screen.gf_bm_set_render_target	= gr_opengl_bm_set_render_target;
 

--- a/code/graphics/opengl/gropenglbmpman.cpp
+++ b/code/graphics/opengl/gropenglbmpman.cpp
@@ -116,30 +116,16 @@ int gr_opengl_bm_make_render_target(int handle, int *width, int *height, int *bp
 	return 0;
 }
 
-int gr_opengl_bm_set_render_target(int n, int face)
+void gr_opengl_bm_set_render_target(int n, int face)
 {
-	if ( Cmdline_no_fbo ) {
-		return 0;
-	}
-
 	if (n == -1) {
 		opengl_set_render_target(-1);
-		return 1;
+		return;
 	}
 
 	auto entry = bm_get_entry(n);
 
 	int is_static = (entry->type == BM_TYPE_RENDER_TARGET_STATIC);
 
-	if ( opengl_set_render_target(n, face, is_static) ) {
-		return 1;
-	}
-
-	return 0;
-}
-
-bool gr_opengl_bm_data(int  /*n*/, bitmap*  /*bm*/)
-{
-	// Do nothing here
-	return true;
+	opengl_set_render_target(n, face, is_static);
 }

--- a/code/graphics/opengl/gropenglbmpman.h
+++ b/code/graphics/opengl/gropenglbmpman.h
@@ -29,10 +29,8 @@ void gr_opengl_bm_init(bitmap_slot* entry);
 // specific instructions for setting up the start of a page-in session
 void gr_opengl_bm_page_in_start();
 
-bool gr_opengl_bm_data(int handle, bitmap* bm);
-
 void gr_opengl_bm_save_render_target(int slot);
 int gr_opengl_bm_make_render_target(int n, int *width, int *height, int *bpp, int *mm_lvl, int flags);
-int gr_opengl_bm_set_render_target(int n, int face);
+void gr_opengl_bm_set_render_target(int n, int face);
 
 #endif // _OGL_BMPMAN_H

--- a/code/graphics/opengl/gropengltexture.h
+++ b/code/graphics/opengl/gropengltexture.h
@@ -82,7 +82,7 @@ void opengl_set_modulate_tex_env();
 void opengl_preload_init();
 void opengl_kill_render_target(bitmap_slot* slot);
 int opengl_make_render_target(int handle, int *w, int *h, int *bpp, int *mm_lvl, int flags);
-int opengl_set_render_target(int slot, int face = -1, int is_static = 0);
+void opengl_set_render_target(int slot, int face = -1, int is_static = 0);
 void gr_opengl_get_bitmap_from_texture(void* data_out, int bitmap_num);
 size_t opengl_export_render_target( int slot, int width, int height, int alpha, int num_mipmaps, ubyte *image_data );
 void opengl_set_texture_target(GLenum target = GL_TEXTURE_2D);

--- a/code/hud/hudtargetbox.cpp
+++ b/code/hud/hudtargetbox.cpp
@@ -374,7 +374,7 @@ void HudGaugeTargetBox::render(float frametime)
 
 	if ( Monitor_mask >= 0 ) {
 		// render the alpha mask
-		gr_alpha_mask_set(1, 0.5f);
+		gr_alpha_mask_set(0.5f);
 		gr_stencil_clear();
 		gr_stencil_set(GR_STENCIL_WRITE);
 		gr_set_color_buffer(0);
@@ -383,7 +383,7 @@ void HudGaugeTargetBox::render(float frametime)
 
 		gr_set_color_buffer(1);
 		gr_stencil_set(GR_STENCIL_NONE);
-		gr_alpha_mask_set(0, 1.0f);
+		gr_alpha_mask_set(0.0f);
 	}
 
 	switch ( target_objp->type ) {

--- a/code/lab/wmcgui.cpp
+++ b/code/lab/wmcgui.cpp
@@ -522,10 +522,6 @@ int GUIScreen::OnFrame(float frametime, bool doevents)
 		DeletionCache.pop_back();
 	}
 
-	// save zbuffer so that we can reset it after drawing (FIXME: this could probably be done better)
-	int saved_zbuf = gr_zbuffer_get();
-	gr_zbuffer_set(GR_ZBUFF_NONE);
-
 	//Draw now. This prevents problems from an object deleting itself or moving around in the list
 	cgp = (GUIObject*)GET_FIRST(&Guiobjects);
 
@@ -538,9 +534,6 @@ int GUIScreen::OnFrame(float frametime, bool doevents)
 
 		cgp = (GUIObject*)GET_NEXT(cgp);
 	}
-
-	// reset zbuffer to saved value
-	gr_zbuffer_set(saved_zbuf);
 
 	if(SomethingPressed) {
 		return GSOF_SOMETHINGPRESSED;

--- a/code/model/modelinterp.cpp
+++ b/code/model/modelinterp.cpp
@@ -690,7 +690,7 @@ void model_draw_paths_htl( int model_num, uint flags )
 
 	if (pm->n_paths<1){
 		return;
-	}	
+	}
 
 	int cull = gr_set_cull(0);
 	for (i=0; i<pm->n_paths; i++ )	{

--- a/code/model/modelrender.cpp
+++ b/code/model/modelrender.cpp
@@ -627,8 +627,6 @@ void model_draw_list::render_all(gr_zbuffer_type depth_mode)
 			render_buffer(Render_elements[render_index]);
 		}
 	}
-
-	gr_alpha_mask_set(0, 1.0f);
 }
 
 void model_draw_list::render_arc(arc_effect &arc)
@@ -1922,8 +1920,6 @@ void model_render_glow_points(polymodel *pm, polymodel_instance *pmi, ship *ship
 
 	int i, j;
 
-	int cull = gr_set_cull(0);
-
 	glow_point_bank_override *gpo = NULL;
 	bool override_all = false;
 	SCP_unordered_map<int, void*>::iterator gpoi;
@@ -1982,8 +1978,6 @@ void model_render_glow_points(polymodel *pm, polymodel_instance *pmi, ship *ship
 			} // for slot
 		} // bank is on
 	} // for bank
-
-	gr_set_cull(cull);
 }
 
 void model_queue_render_thrusters(model_render_params *interp, polymodel *pm, int objnum, ship *shipp, matrix *orient, vec3d *pos)

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -7479,8 +7479,6 @@ int ship_start_render_cockpit_display(size_t cockpit_display_num)
 		return -1;
 	}
 	gr_push_debug_group("Render cockpit display");
-	
-	int cull = gr_set_cull(0);
 
 	gr_clear();
 	
@@ -7493,8 +7491,6 @@ int ship_start_render_cockpit_display(size_t cockpit_display_num)
 		gr_set_bitmap(display->background);
 		gr_bitmap_ex(display->offset[0], display->offset[1], display->size[0], display->size[1], 0, 0, GR_RESIZE_NONE);
 	}
-
-	gr_set_cull(cull);
 
 	return display->target;
 }
@@ -7517,14 +7513,12 @@ void ship_end_render_cockpit_display(size_t cockpit_display_num)
 
 	cockpit_display* display = &Player_displays[cockpit_display_num];
 
-	int cull = gr_set_cull(0);
 	if ( display->foreground >= 0 ) {
 		gr_reset_clip();
 		gr_set_bitmap(display->foreground);
 		gr_bitmap_ex(display->offset[0], display->offset[1], display->size[0], display->size[1], 0, 0, GR_RESIZE_NONE);
 	}
 
-	gr_set_cull(cull);
 	bm_set_render_target(-1);
 
 	gr_pop_debug_group();

--- a/code/starfield/starfield.cpp
+++ b/code/starfield/starfield.cpp
@@ -1556,11 +1556,7 @@ void subspace_render()
 
 	vm_angles_2_matrix(&tmp,&angs);
 
-	int saved_gr_zbuffering = gr_zbuffer_get();
-
-	gr_zbuffer_set(GR_ZBUFF_NONE);
-
-	int render_flags = MR_NO_LIGHTING | MR_ALL_XPARENT;
+	int render_flags = MR_NO_LIGHTING | MR_ALL_XPARENT | MR_NO_ZBUFFER;
 
 	Interp_subspace = 1;
 	Interp_subspace_offset_u = 1.0f - subspace_offset_u;
@@ -1617,7 +1613,6 @@ void subspace_render()
 	g3_render_rect_screen_aligned_2d(&mat_params, &glow_vex, 0, 17.0f + 0.5f * Noise[framenum]);
 
 	Interp_subspace = 0;
-	gr_zbuffer_set(saved_gr_zbuffering);
 }
 
 void stars_draw_stars()
@@ -1812,9 +1807,6 @@ void stars_draw(int show_stars, int show_suns, int  /*show_nebulas*/, int show_s
 	GR_DEBUG_SCOPE("Draw Stars");
 	TRACE_SCOPE(tracing::DrawStars);
 
-	int gr_zbuffering_save = gr_zbuffer_get();
-	gr_zbuffer_set(GR_ZBUFF_NONE);
-
 	Rendering_to_env = env;
 
 	if (show_subspace)
@@ -1862,7 +1854,6 @@ void stars_draw(int show_stars, int show_suns, int  /*show_nebulas*/, int show_s
 		stars_draw_bitmaps( show_suns );
 	}
 
-	gr_zbuffer_set( gr_zbuffering_save );
 	Rendering_to_env = 0;
 }
 
@@ -2193,7 +2184,7 @@ void stars_draw_background()
 
 	// draw the model at the player's eye with no z-buffering
 	render_info.set_alpha(1.0f);
-	render_info.set_flags(Nmodel_flags | MR_SKYBOX);
+	render_info.set_flags(Nmodel_flags | MR_SKYBOX | MR_NO_ZBUFFER);
 
 	model_render_immediate(&render_info, Nmodel_num, &Nmodel_orient, &Eye_position, MODEL_RENDER_ALL, false);
 }


### PR DESCRIPTION
This is an effort to clean up the graphics API a bit and reduce return
values that are not really needed.

The reason behind this is to reduce the amount of synchronization points
necessary when implementing a threaded rendering backend. The easy way
to do threading is to just dispatch graphics calls to a separate thread.
However, if there are return values involved, there needs to be
synchronizations which defeats the point of multi-threading.