### PR TITLE
Fix a bug with previous_bank and ship class swapping

### DIFF
--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -10657,10 +10657,12 @@ void change_ship_type(int n, int ship_type, int by_sexp)
 	if ( by_sexp ) {
 		if (sip_orig->num_primary_banks > sip->num_primary_banks) {
 			sp->weapons.current_primary_bank = 0;
+			sp->weapons.previous_primary_bank = 0;
 		}
 
 		if (sip_orig->num_secondary_banks > sip->num_secondary_banks) {
 			sp->weapons.current_secondary_bank = 0;
+			sp->weapons.previous_secondary_bank = 0;
 		}
 
 		// While we're at it, let's copy over the ETS settings too


### PR DESCRIPTION
Previous bank also needs to be reset when swapping or this will cause crashes with scripts using it as a conditional.

As much I would love to PR all my features, I do think this should be in stable as JAD currently will very reliably crash on current builds, and I suspect this is also the cause of another similar bug reported in WoD recently.