### PR TITLE
Limit instances of Client Collisions to Avoid Instant Death

### DIFF
--- a/code/network/multi.cpp
+++ b/code/network/multi.cpp
@@ -1798,6 +1798,7 @@ void multi_reset_timestamps()
 		Players[i].update_lock_time = timestamp(0);
 
 		Net_players[i].s_info.voice_token_timestamp = -1;
+		Net_players[i].s_info.player_collision_timestamp = timestamp(0);
 	}
 
 	// reset standalone gui timestamps (these are not game critical, so there is not much danger)

--- a/code/network/multi.h
+++ b/code/network/multi.h
@@ -366,6 +366,9 @@ class player;
 #define STATS_MISSION_CLASS_KILLS	4			// kills for the mission, for one player
 #define STATS_ALLTIME_KILLS			5			// alltime kills, for one player
 
+// minor hack
+constexpr int PLAYER_COLLISION_TIMESTAMP = 200; // how often the server should allow a client to go through ship-ship collisions
+
 // ----------------------------------------------------------------------------------------
 
 
@@ -418,6 +421,9 @@ typedef struct net_player_server_info {
 
 	// common targeting information
 	int				target_objnum;
+
+	// for collision hack -- to fix, enough bandwidth would be needed for full physics info to be transmitted uncompressed
+	int				player_collision_timestamp;		// gets around limitations on oo update packets by having collisions only occur so often								
 
 	// rate limiting information
 	int				rate_stamp;							// rate limiting timestamp

--- a/code/network/multi_obj.cpp
+++ b/code/network/multi_obj.cpp
@@ -88,6 +88,7 @@ struct oo_packet_and_interp_tracking {
 	int prev_pack_pos_frame;			// the prev position packet arrival frame
 
 	bool client_simulation_mode;		// if the packets come in too late, a toggle to sim things like normal
+										// now also triggered after a ship-ship collision
 
 	bool prev_packet_positionless;		// a flag that marks if the last packet as having no new position or orientation info.
 
@@ -3212,7 +3213,7 @@ void multi_oo_interp(object* objp)
 			objp->orient = interp_data->new_orientation;
 			objp->phys_info.vel = vmd_zero_vector;
 		} // Overshoting in this frame or some edge case bug. Just sim the ship from the known values.
-		else if (time_factor > 4.0f || time_factor < 1.0f) {
+		else if (time_factor > 4.0f || time_factor < 1.0f || interp_data->client_simulation_mode) {
 			// if transitioning to uninterpolated movement, we need to jump to the end of the simulated points 
 			// and then simulate forward some if there's extra time. 
 			float regular_sim_delta;
@@ -3227,6 +3228,7 @@ void multi_oo_interp(object* objp)
 				regular_sim_delta = flFrametime;
 			}
 			// Continue simulating if we have time that we need to simulate and exclude fake values.
+			// Note, whenever client_simulation_mode is on the following will be true.
 			if (regular_sim_delta > 0.001f && regular_sim_delta < 0.500f) {
 				// make sure to bash desired velocity and rotational velocity in this case.
 				objp->phys_info.desired_vel = interp_data->cur_pack_des_vel;
@@ -3420,6 +3422,9 @@ void multi_oo_calc_interp_splines(int player_id, object* objp, matrix *new_orien
 
 	// Set the points to the bezier
 	Oo_info.interp[net_sig_idx].pos_spline.bez_set_points(3, pts);
+
+	// unset client mode, now that we have brand new data!
+	Oo_info.interp[net_sig_idx].client_simulation_mode = false;
 }
 
 // Calculates how much time has gone by between the two most recent frames 
@@ -3457,6 +3462,16 @@ float multi_oo_calc_pos_time_difference(int player_id, int net_sig_idx)
 	temp_sum /= TIMESTAMP_FREQUENCY; // convert from timestamp to float frame time
 
 	return temp_sum;
+}
+
+// temporarily sets this as a client interpolated ship 
+void multi_oo_set_client_simulation_mode(ushort netsig) 
+{
+	if (netsig == 0 || netsig >= Oo_info.interp.size()) {
+		return;
+	}
+
+	Oo_info.interp[netsig].client_simulation_mode = true;
 }
 
 bool display_oo_bez = false;

--- a/code/network/multi_obj.h
+++ b/code/network/multi_obj.h
@@ -168,6 +168,9 @@ int multi_oo_rate_exceeded(net_player *pl);
 // if it is ok for me to send a control info (will be ~N times a second)
 int multi_oo_cirate_can_send();
 
+// temporarily sets this as a client interpolated ship 
+void multi_oo_set_client_simulation_mode(ushort netsig);
+
 // display any oo info on the hud
 void multi_oo_display();
 

--- a/code/network/multi_observer.cpp
+++ b/code/network/multi_observer.cpp
@@ -60,6 +60,7 @@ void multi_obs_create_player(int player_num,char *name,net_addr *addr,player *pl
 	Net_players[player_num].reliable_socket = PSNET_INVALID_SOCKET;
 	Net_players[player_num].s_info.kick_timestamp = -1;
 	Net_players[player_num].s_info.voice_token_timestamp = -1;
+	Net_players[player_num].s_info.player_collision_timestamp = -1;
 	Net_players[player_num].s_info.tracker_security_last = -1;
 	Net_players[player_num].s_info.target_objnum = -1;
 	Net_players[player_num].s_info.accum_buttons = 0;

--- a/code/network/multi_observer.cpp
+++ b/code/network/multi_observer.cpp
@@ -60,7 +60,7 @@ void multi_obs_create_player(int player_num,char *name,net_addr *addr,player *pl
 	Net_players[player_num].reliable_socket = PSNET_INVALID_SOCKET;
 	Net_players[player_num].s_info.kick_timestamp = -1;
 	Net_players[player_num].s_info.voice_token_timestamp = -1;
-	Net_players[player_num].s_info.player_collision_timestamp = -1;
+	Net_players[player_num].s_info.player_collision_timestamp = timestamp(0);
 	Net_players[player_num].s_info.tracker_security_last = -1;
 	Net_players[player_num].s_info.target_objnum = -1;
 	Net_players[player_num].s_info.accum_buttons = 0;

--- a/code/network/multiui.cpp
+++ b/code/network/multiui.cpp
@@ -2799,6 +2799,7 @@ void multi_sg_init_gamenet()
 	// assign my player struct and other data	
 	Net_player->flags |= (NETINFO_FLAG_CONNECTED | NETINFO_FLAG_DO_NETWORKING);
 	Net_player->s_info.voice_token_timestamp = -1;	
+	Net_player->s_info.player_collision_timestamp = -1;
 
 	// if we're supposed to flush our cache directory, do so now
 	if(Net_player->p_info.options.flags & MLO_FLAG_FLUSH_CACHE){

--- a/code/network/multiui.cpp
+++ b/code/network/multiui.cpp
@@ -2799,7 +2799,7 @@ void multi_sg_init_gamenet()
 	// assign my player struct and other data	
 	Net_player->flags |= (NETINFO_FLAG_CONNECTED | NETINFO_FLAG_DO_NETWORKING);
 	Net_player->s_info.voice_token_timestamp = -1;	
-	Net_player->s_info.player_collision_timestamp = -1;
+	Net_player->s_info.player_collision_timestamp = timestamp(0);
 
 	// if we're supposed to flush our cache directory, do so now
 	if(Net_player->p_info.options.flags & MLO_FLAG_FLUSH_CACHE){

--- a/code/network/multiutil.cpp
+++ b/code/network/multiutil.cpp
@@ -800,7 +800,7 @@ void multi_create_player( int net_player_num, player *pl, const char* name, net_
 	Net_players[net_player_num].reliable_socket = PSNET_INVALID_SOCKET;
 	Net_players[net_player_num].s_info.kick_timestamp = -1;
 	Net_players[net_player_num].s_info.voice_token_timestamp = -1;
-	Net_players[net_player_num].s_info.player_collision_timestamp = -1;
+	Net_players[net_player_num].s_info.player_collision_timestamp = timestamp(0);
 	Net_players[net_player_num].s_info.tracker_security_last = -1;
 	Net_players[net_player_num].s_info.target_objnum = -1;
 	Net_players[net_player_num].s_info.accum_buttons = 0;

--- a/code/network/multiutil.cpp
+++ b/code/network/multiutil.cpp
@@ -800,6 +800,7 @@ void multi_create_player( int net_player_num, player *pl, const char* name, net_
 	Net_players[net_player_num].reliable_socket = PSNET_INVALID_SOCKET;
 	Net_players[net_player_num].s_info.kick_timestamp = -1;
 	Net_players[net_player_num].s_info.voice_token_timestamp = -1;
+	Net_players[net_player_num].s_info.player_collision_timestamp = -1;
 	Net_players[net_player_num].s_info.tracker_security_last = -1;
 	Net_players[net_player_num].s_info.target_objnum = -1;
 	Net_players[net_player_num].s_info.accum_buttons = 0;

--- a/code/object/collideshipship.cpp
+++ b/code/object/collideshipship.cpp
@@ -1337,7 +1337,7 @@ int collide_ship_ship( obj_pair * pair )
 							// iterate through each player
 							for (net_player & current_player : Net_players) {
 								// check that this player's ship is valid, and that it's not the server ship.
-								if ((current_player.m_player != nullptr) && (&current_player != Netgame.server) && (current_player.m_player->objnum > 0) && current_player.m_player->objnum < MAX_OBJECTS) {
+								if ((current_player.m_player != nullptr) && !(current_player.flags & NETINFO_FLAG_AM_MASTER) && (current_player.m_player->objnum > 0) && current_player.m_player->objnum < MAX_OBJECTS) {
 									// check that one of the colliding ships is this player's ship
 									if (LightOne == &Objects[current_player.m_player->objnum]) {
 										// set this as not an interpolated ship

--- a/code/object/collideshipship.cpp
+++ b/code/object/collideshipship.cpp
@@ -1334,40 +1334,44 @@ int collide_ship_ship( obj_pair * pair )
 						// happen to multiplayer clients, because otherwise the server can kill clients far too quickly.
 						// So here it goes, first only do this on the master (has an intrinsic multiplayer check) 
 						if (MULTIPLAYER_MASTER) {
+							// check to see if both colliding ships are player ships
+							bool second_player_check = false;
+							if ((LightOne->flags[Object::Object_Flags::Player_ship]) && (HeavyOne->flags[Object::Object_Flags::Player_ship]))
+								second_player_check = true;
+
 							// iterate through each player
 							for (net_player & current_player : Net_players) {
 								// check that this player's ship is valid, and that it's not the server ship.
 								if ((current_player.m_player != nullptr) && !(current_player.flags & NETINFO_FLAG_AM_MASTER) && (current_player.m_player->objnum > 0) && current_player.m_player->objnum < MAX_OBJECTS) {
 									// check that one of the colliding ships is this player's ship
-									if (LightOne == &Objects[current_player.m_player->objnum]) {
-										// set this as not an interpolated ship
-										multi_oo_set_client_simulation_mode(LightOne->net_signature);
+									if ((LightOne == &Objects[current_player.m_player->objnum]) || (HeavyOne == &Objects[current_player.m_player->objnum])) {
+										// finally if the host is also a player, ignore making these adjustments for him because he is in a pure simulation.
+										if (&Ships[Objects[current_player.m_player->objnum].instance] != Player_ship) {
+											// temp set this as an uninterpolated ship, to make the collision look more natural until the next update comes in.
+											multi_oo_set_client_simulation_mode(Objects[current_player.m_player->objnum].net_signature);
 
-										// check to see if it has been long enough since the last collision, if not negate the damage
-										if (!timestamp_elapsed(current_player.s_info.player_collision_timestamp)) {
-											damage = 0.0f;
-										} else {
-											// make the usual adjustments
-											damage *= (float) (Game_skill_level*Game_skill_level+1)/(NUM_SKILL_LEVELS+1);
-											// if everything is good to go, set the timestamp for the next collision
-											current_player.s_info.player_collision_timestamp = timestamp(PLAYER_COLLISION_TIMESTAMP);
+											// check to see if it has been long enough since the last collision, if not negate the damage
+											if (!timestamp_elapsed(current_player.s_info.player_collision_timestamp)) {
+												damage = 0.0f;
+											} else {
+												// make the usual adjustments
+												damage *= (float)(Game_skill_level * Game_skill_level + 1) / (NUM_SKILL_LEVELS + 1);
+												// if everything is good to go, set the timestamp for the next collision
+												current_player.s_info.player_collision_timestamp = timestamp(PLAYER_COLLISION_TIMESTAMP);
+											}
 										}
-									} else if (HeavyOne == &Objects[current_player.m_player->objnum]) {
-										// set this as not an interpolated ship
-										multi_oo_set_client_simulation_mode(HeavyOne->net_signature);
 
-										// check to see if it has been long enough since the last collision
-										if (!timestamp_elapsed(current_player.s_info.player_collision_timestamp)) {
-											damage = 0.0f;
-										} else if (!(&Ships[LightOne->instance] != Player_ship)) {
-											// make the usual adjustments
-											damage *= (float) (Game_skill_level*Game_skill_level+1)/(NUM_SKILL_LEVELS+1);
-											// if everything is good to go, set the timestamp for the next collision
-											current_player.s_info.player_collision_timestamp = timestamp(PLAYER_COLLISION_TIMESTAMP);
+										// did we find the player we were looking for?
+										if (!second_player_check) {
+											break;
+										// if we found one of the players we were looking for, set this to false so that the next one breaks the loop
+										} else {
+											second_player_check = false;
 										}
 									}
 								}
 							}
+						// if not in multiplayer, just do the damage adjustment.
 						} else {
 							damage *= (float) (Game_skill_level*Game_skill_level+1)/(NUM_SKILL_LEVELS+1);
 						}

--- a/code/object/collideshipship.cpp
+++ b/code/object/collideshipship.cpp
@@ -19,6 +19,7 @@
 #include "hud/hudshield.h"
 #include "io/joy_ff.h"
 #include "io/timer.h"
+#include "network/multi.h"
 #include "object/objcollide.h"
 #include "object/object.h"
 #include "object/objectdock.h"
@@ -1328,7 +1329,48 @@ int collide_ship_ship( obj_pair * pair )
 				if (!ship_ship_hit_info.is_landing) {
 					//	Scale damage based on skill level for player.
 					if ((LightOne->flags[Object::Object_Flags::Player_ship]) || (HeavyOne->flags[Object::Object_Flags::Player_ship])) {
-						damage *= (float) (Game_skill_level*Game_skill_level+1)/(NUM_SKILL_LEVELS+1);
+
+						// Cyborg17 - Pretty hackish, but it's our best option, limit the amount of times a collision can
+						// happen to multiplayer clients, because otherwise the server can kill clients far too quickly.
+						// So here it goes, first only do this on the master (has an intrinsic multiplayer check) 
+						if (MULTIPLAYER_MASTER) {
+							// iterate through each player
+							for (net_player & current_player : Net_players) {
+								// check that this player's ship is valid, and that it's not the server ship.
+								if ((current_player.m_player != nullptr) && (&current_player != Netgame.server) && (current_player.m_player->objnum > 0) && current_player.m_player->objnum < MAX_OBJECTS) {
+									// check that one of the colliding ships is this player's ship
+									if (LightOne == &Objects[current_player.m_player->objnum]) {
+										// set this as not an interpolated ship
+										multi_oo_set_client_simulation_mode(LightOne->net_signature);
+
+										// check to see if it has been long enough since the last collision, if not negate the damage
+										if (!timestamp_elapsed(current_player.s_info.player_collision_timestamp)) {
+											damage = 0.0f;
+										} else {
+											// make the usual adjustments
+											damage *= (float) (Game_skill_level*Game_skill_level+1)/(NUM_SKILL_LEVELS+1);
+											// if everything is good to go, set the timestamp for the next collision
+											current_player.s_info.player_collision_timestamp = timestamp(PLAYER_COLLISION_TIMESTAMP);
+										}
+									} else if (HeavyOne == &Objects[current_player.m_player->objnum]) {
+										// set this as not an interpolated ship
+										multi_oo_set_client_simulation_mode(HeavyOne->net_signature);
+
+										// check to see if it has been long enough since the last collision
+										if (!timestamp_elapsed(current_player.s_info.player_collision_timestamp)) {
+											damage = 0.0f;
+										} else if (!(&Ships[LightOne->instance] != Player_ship)) {
+											// make the usual adjustments
+											damage *= (float) (Game_skill_level*Game_skill_level+1)/(NUM_SKILL_LEVELS+1);
+											// if everything is good to go, set the timestamp for the next collision
+											current_player.s_info.player_collision_timestamp = timestamp(PLAYER_COLLISION_TIMESTAMP);
+										}
+									}
+								}
+							}
+						} else {
+							damage *= (float) (Game_skill_level*Game_skill_level+1)/(NUM_SKILL_LEVELS+1);
+						}
 					} else if (Ships[LightOne->instance].team == Ships[HeavyOne->instance].team) {
 						//	Decrease damage if non-player ships and not large.
 						//	Looks dumb when fighters are taking damage from bumping into each other.


### PR DESCRIPTION
Often in Multi, a client colliding with another ship, especially a capship, will result in instant death.  By limiting the maximum frequency of damage to client ships from ship-ship collisions to once every .2 seconds, instant death can be avoided in most cases.

Before
https://youtu.be/bUfe_dEUSeE

After
https://youtu.be/tFzUu3WlXxc

