### PR TITLE
Cylinder only tube lights

### DIFF
--- a/code/def_files/data/effects/deferred-f.sdr
+++ b/code/def_files/data/effects/deferred-f.sdr
@@ -65,10 +65,17 @@ void GetLightInfo(vec3 position, out vec3 lightDir, out float attenuation)
 		if (lightType == LT_TUBE) {  // Tube light
 			float beamLength = length(beamVec);
 			vec3 beamDir = beamVec / beamLength;
+			//The actual 'lighting element' is shorter than the light volume cylinder
+			//To compensate the light is moved forward along the beam one radius and the length shortened
+			//this allows room for clean falloff of the light past the ends of beams.
+			vec3 adjustedLightPos = lightPosition - (beamDir * lightRadius);
+			beamLength = beamLength - (lightRadius * 2.0);
+			//adjustments having been made, lightdir needs recalculating
+			lightDir = adjustedLightPos - position.xyz;
 			// Get nearest point on line
 			float neardist = clamp(dot(lightDir, beamDir), 0.0, beamLength);
 			// Move back from the endpoint of the beam along the beam by the distance we calculated
-			vec3 nearest = lightPosition - beamDir * neardist;
+			vec3 nearest = adjustedLightPos - beamDir * neardist;
 			lightDir = nearest - position.xyz;
 			dist = length(lightDir);
 			if(dist > lightRadius) {

--- a/code/graphics/opengl/gropengldeferred.cpp
+++ b/code/graphics/opengl/gropengldeferred.cpp
@@ -271,7 +271,7 @@ void gr_opengl_deferred_lighting_finish()
 				vec3d dir, newPos;
 				matrix orient;
 				vm_vec_sub(&dir, &l.vec, &l.vec2);
-				vm_vector_2_matrix(&orient, &dir, NULL, NULL);
+				vm_vector_2_matrix(&orient, &dir, nullptr, nullptr);
 				//Tube light volumes must be extended past the length of their requested light vector
 				//to allow smooth fall-off from all angles. Since the light volume starts at the mesh
 				//origin we must extend it, which has been done above, and then move it backwards one radius.

--- a/code/graphics/opengl/gropengldeferred.cpp
+++ b/code/graphics/opengl/gropengldeferred.cpp
@@ -130,10 +130,7 @@ void gr_opengl_deferred_lighting_finish()
 	using namespace graphics;
 
 	// We need to precompute how many elements we are going to need
-	size_t num_data_elements = 0;
-	for (auto& l : Lights) {
-		++num_data_elements;
-	}
+	size_t num_data_elements = Lights.size();
 
 	// Get a uniform buffer for our data
 	auto buffer          = gr_get_uniform_buffer(uniform_block_type::Lights, num_data_elements);

--- a/code/graphics/opengl/gropengldeferred.cpp
+++ b/code/graphics/opengl/gropengldeferred.cpp
@@ -133,9 +133,6 @@ void gr_opengl_deferred_lighting_finish()
 	size_t num_data_elements = 0;
 	for (auto& l : Lights) {
 		++num_data_elements;
-		if (l.type == Light_Type::Tube) {
-			++num_data_elements;
-		}
 	}
 
 	// Get a uniform buffer for our data
@@ -235,20 +232,6 @@ void gr_opengl_deferred_lighting_finish()
 				light_data->scale.xyz.z = length;
 
 				vm_vec_scale(&light_data->specLightColor, static_tube_factor);
-
-				// Tube lights consist of two different types of lights with almost the same properties
-				light_data = uniformAligner.addTypedElement<deferred_light_data>();
-				light_data->diffuseLightColor = diffuse;
-				light_data->specLightColor = spec;
-
-				vm_vec_scale(&light_data->specLightColor, static_tube_factor);
-
-				light_data->lightRadius = l.radb * 1.5f;
-				light_data->lightType = LT_POINT;
-
-				light_data->scale.xyz.x = l.radb * 1.53f;
-				light_data->scale.xyz.y = l.radb * 1.53f;
-				light_data->scale.xyz.z = l.radb * 1.53f;
 				break;
 			}
 			}
@@ -290,14 +273,6 @@ void gr_opengl_deferred_lighting_finish()
 				vm_vector_2_matrix(&orient, &a, NULL, NULL);
 
 				gr_opengl_draw_deferred_light_cylinder(&l.vec2, &orient);
-				++element_index;
-
-				// The next two draws use the same uniform block element
-				gr_bind_uniform_buffer(uniform_block_type::Lights, buffer.getAlignerElementOffset(element_index),
-				                       sizeof(graphics::deferred_light_data), buffer.bufferHandle());
-
-				gr_opengl_draw_deferred_light_sphere(&l.vec);
-				gr_opengl_draw_deferred_light_sphere(&l.vec2);
 				++element_index;
 				break;
 			default:


### PR DESCRIPTION
Implements #3161 / fixes #3146. Extends tube light cylinder volumes to cover the end cap sphere volumes and removes those spheres. Before and after test videos available at https://www.youtube.com/watch?v=G5pXm7Jv8Us and https://www.youtube.com/watch?v=gC84qUBXJq8, but leaving in draft till I get some more general play time on the modified build to make sure no weird edge cases crop up