### PR TITLE
add collision group checks to debris

### DIFF
--- a/code/object/collidedebrisship.cpp
+++ b/code/object/collidedebrisship.cpp
@@ -44,6 +44,9 @@ int collide_debris_ship( obj_pair * pair )
 	Assert( pdebris->type == OBJ_DEBRIS );
 	Assert( pship->type == OBJ_SHIP );
 
+	if (reject_due_collision_groups(pdebris, pship))
+		return 0;
+
 	// don't check collision if it's our own debris and we are dying
 	if ( (pdebris->parent == OBJ_INDEX(pship)) && (Ships[pship->instance].flags[Ship::Ship_Flags::Dying]) )
 		return 0;

--- a/code/object/collidedebrisweapon.cpp
+++ b/code/object/collidedebrisweapon.cpp
@@ -34,6 +34,9 @@ int collide_debris_weapon( obj_pair * pair )
 	Assert( pdebris->type == OBJ_DEBRIS );
 	Assert( weapon_obj->type == OBJ_WEAPON );
 
+	if (reject_due_collision_groups(pdebris, weapon_obj))
+		return 0;
+
 	// first check the bounding spheres of the two objects.
 	int hit = fvi_segment_sphere(&hitpos, &weapon_obj->last_pos, &weapon_obj->pos, &pdebris->pos, pdebris->radius);
 	if (hit) {

--- a/code/weapon/beam.cpp
+++ b/code/weapon/beam.cpp
@@ -2413,6 +2413,9 @@ int beam_collide_ship(obj_pair *pair)
 		return 0;
 	}
 
+	if (reject_due_collision_groups(pair->a, pair->b))
+		return 0;
+
 	// get the beam
 	Assert(pair->a->instance >= 0);
 	Assert(pair->a->type == OBJ_BEAM);
@@ -2460,9 +2463,6 @@ int beam_collide_ship(obj_pair *pair)
 		return 1;
 	ship_objp = pair->b;
 	shipp = &Ships[ship_objp->instance];
-
-	if (reject_due_collision_groups(weapon_objp, ship_objp))
-		return 0;
 
 	if (shipp->flags[Ship::Ship_Flags::Arriving_stage_1])
 		return 0;
@@ -2882,6 +2882,9 @@ int beam_collide_debris(obj_pair *pair)
 	if(pair == NULL){
 		return 0;
 	}
+
+	if (reject_due_collision_groups(pair->a, pair->b))
+		return 0;
 
 	// get the beam
 	Assert(pair->a->instance >= 0);


### PR DESCRIPTION
Collision groups were checked between ships, weapons, and beams, but not debris.  This adds debris.

Also the check for beams vs. ships was a little too far down the function, so I moved it up.