### PR TITLE
Non-linear Trail decay and Texture stretch

### DIFF
--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -3878,6 +3878,10 @@ static void parse_ship_values(ship_info* sip, const bool is_template, const bool
 		if (optional_string("+Alpha Decay Exponent:")) {
 			trails_warning = false;
 			stuff_float(&sip->afterburner_trail_alpha_decay_exponent);
+			if (sip->afterburner_trail_alpha_decay_exponent < 0.0f) {
+				Warning(LOCATION, "Trail Alpha Decay Exponent of ship %s cannot be negative. Reseting to 1.\n", sip->name);
+				sip->afterburner_trail_alpha_decay_exponent = 1.0f;
+			}
 		}
 			
 		if ( optional_string("+Life:") ) {
@@ -4297,8 +4301,13 @@ static void parse_ship_values(ship_info* sip, const bool is_template, const bool
 		required_string("+End Alpha:");
 		stuff_float(&ci->a_end);
 
-		if (optional_string("+Alpha Decay Exponent:"))
+		if (optional_string("+Alpha Decay Exponent:")) {
 			stuff_float(&ci->a_decay_exponent);
+			if (ci->a_decay_exponent < 0.0f) {
+				Warning(LOCATION, "Trail Alpha Decay Exponent of ship %s cannot be negative. Reseting to 1.\n", sip->name);
+				ci->a_decay_exponent = 1.0f;
+			}
+		}
 
 		required_string("+Max Life:");
 		stuff_float(&ci->max_life);

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -3879,7 +3879,7 @@ static void parse_ship_values(ship_info* sip, const bool is_template, const bool
 			trails_warning = false;
 			stuff_float(&sip->afterburner_trail_alpha_decay_exponent);
 			if (sip->afterburner_trail_alpha_decay_exponent < 0.0f) {
-				Warning(LOCATION, "Trail Alpha Decay Exponent of ship %s cannot be negative. Reseting to 1.\n", sip->name);
+				Warning(LOCATION, "Trail Alpha Decay Exponent of ship %s cannot be negative. Resetting to 1.\n", sip->name);
 				sip->afterburner_trail_alpha_decay_exponent = 1.0f;
 			}
 		}
@@ -4304,7 +4304,7 @@ static void parse_ship_values(ship_info* sip, const bool is_template, const bool
 		if (optional_string("+Alpha Decay Exponent:")) {
 			stuff_float(&ci->a_decay_exponent);
 			if (ci->a_decay_exponent < 0.0f) {
-				Warning(LOCATION, "Trail Alpha Decay Exponent of ship %s cannot be negative. Reseting to 1.\n", sip->name);
+				Warning(LOCATION, "Trail Alpha Decay Exponent of ship %s cannot be negative. Resetting to 1.\n", sip->name);
 				ci->a_decay_exponent = 1.0f;
 			}
 		}

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -1069,9 +1069,11 @@ void ship_info::clone(const ship_info& other)
 	uses_team_colors = other.uses_team_colors;
 	default_team_name = other.default_team_name;
 
-	afterburner_trail = other.afterburner_trail;
+	afterburner_trail = other.afterburner_trail; 
+	afterburner_trail_tex_stretch = other.afterburner_trail_tex_stretch;
 	afterburner_trail_width_factor = other.afterburner_trail_width_factor;
 	afterburner_trail_alpha_factor = other.afterburner_trail_alpha_factor;
+	afterburner_trail_alpha_end_factor = other.afterburner_trail_alpha_end_factor;
 	afterburner_trail_life = other.afterburner_trail_life;
 	afterburner_trail_faded_out_sections = other.afterburner_trail_faded_out_sections;
 	afterburner_trail_spread = other.afterburner_trail_spread;
@@ -1373,8 +1375,10 @@ void ship_info::move(ship_info&& other)
 	std::swap(default_team_name, other.default_team_name);
 
 	std::swap(afterburner_trail, other.afterburner_trail);
+	afterburner_trail_tex_stretch = other.afterburner_trail_tex_stretch;
 	afterburner_trail_width_factor = other.afterburner_trail_width_factor;
 	afterburner_trail_alpha_factor = other.afterburner_trail_alpha_factor;
+	afterburner_trail_alpha_end_factor = other.afterburner_trail_alpha_end_factor;
 	afterburner_trail_life = other.afterburner_trail_life;
 	afterburner_trail_faded_out_sections = other.afterburner_trail_faded_out_sections;
 	afterburner_trail_spread = other.afterburner_trail_spread;
@@ -1783,8 +1787,10 @@ ship_info::ship_info()
 	default_team_name = "";
 
 	generic_bitmap_init(&afterburner_trail, NULL);
+	afterburner_trail_tex_stretch = 1.0f;
 	afterburner_trail_width_factor = 1.0f;
 	afterburner_trail_alpha_factor = 1.0f;
+	afterburner_trail_alpha_end_factor = 0.0f;
 	afterburner_trail_life = 5.0f;
 	afterburner_trail_spread = 0.0f;
 	afterburner_trail_faded_out_sections = 0;
@@ -3844,6 +3850,15 @@ static void parse_ship_values(ship_info* sip, const bool is_template, const bool
 			generic_bitmap_init(&sip->afterburner_trail, NULL);
 			stuff_string(sip->afterburner_trail.filename, F_NAME, MAX_FILENAME_LEN);
 		}
+
+		if (optional_string("+Bitmap Stretch:")) {
+			trails_warning = false;
+			stuff_float(&sip->afterburner_trail_tex_stretch);
+			if (sip->afterburner_trail_tex_stretch == 0.0f) {
+				Warning(LOCATION, "Trail bitmap stretch of ship %s cannot be 0.  Setting to 1.\n", sip->name);
+				sip->afterburner_trail_tex_stretch = 1.0f;
+			}
+		}
 		
 		if ( optional_string("+Width:") ) {
 			trails_warning = false;
@@ -3853,6 +3868,16 @@ static void parse_ship_values(ship_info* sip, const bool is_template, const bool
 		if ( optional_string("+Alpha:") ) {
 			trails_warning = false;
 			stuff_float(&sip->afterburner_trail_alpha_factor);
+		}
+
+		if (optional_string("+Alpha End:")) {
+			trails_warning = false;
+			stuff_float(&sip->afterburner_trail_alpha_end_factor);
+		}
+
+		if (optional_string("+Alpha Decay Exponent:")) {
+			trails_warning = false;
+			stuff_float(&sip->afterburner_trail_alpha_decay_exponent);
 		}
 			
 		if ( optional_string("+Life:") ) {
@@ -4272,6 +4297,9 @@ static void parse_ship_values(ship_info* sip, const bool is_template, const bool
 		required_string("+End Alpha:");
 		stuff_float(&ci->a_end);
 
+		if (optional_string("+Alpha Decay Exponent:"))
+			stuff_float(&ci->a_decay_exponent);
+
 		required_string("+Max Life:");
 		stuff_float(&ci->max_life);
 
@@ -4285,6 +4313,14 @@ static void parse_ship_values(ship_info* sip, const bool is_template, const bool
 		stuff_string(name_tmp, F_NAME, NAME_LENGTH);
 		generic_bitmap_init(&ci->texture, name_tmp);
 		generic_bitmap_load(&ci->texture);
+
+		if (optional_string("+Bitmap Stretch:")) {
+			stuff_float(&ci->texture_stretch);
+			if (ci->texture_stretch == 0.0f) {
+				Warning(LOCATION, "Trail bitmap stretch of ship %s cannot be 0.  Setting to 1.\n", sip->name);
+				ci->texture_stretch = 1.0f;
+			}
+		}
 
 		if (optional_string("+Faded Out Sections:") ) {
 			stuff_int(&ci->n_fade_out_sections);
@@ -9738,8 +9774,8 @@ static void ship_init_afterburners(ship *shipp)
 			ci->w_start = bank->points[j].radius * sip->afterburner_trail_width_factor;	// width * table loaded width factor
 			ci->w_end = 0.05f; //end width
 
-			ci->a_start = 1.0f * sip->afterburner_trail_alpha_factor; // start alpha  * table loaded alpha factor
-			ci->a_end = 0.0f; //end alpha
+			ci->a_start = sip->afterburner_trail_alpha_factor; // start alpha  * table loaded alpha factor
+			ci->a_end = sip->afterburner_trail_alpha_end_factor; //end alpha
 
 			ci->max_life = sip->afterburner_trail_life;	// table loaded max life
 			ci->stamp = 60;	//spew time???	
@@ -9748,6 +9784,7 @@ static void ship_init_afterburners(ship *shipp)
 			ci->n_fade_out_sections = sip->afterburner_trail_faded_out_sections; // initial fade out
 
 			ci->texture.bitmap_id = sip->afterburner_trail.bitmap_id; // table loaded bitmap used on this ships burner trails
+			ci->texture_stretch = sip->afterburner_trail_tex_stretch;
 
 			nprintf(("AB TRAIL", "AB trail point #%d made for '%s'\n", shipp->ab_count, shipp->ship_name));
 
@@ -10587,9 +10624,11 @@ void change_ship_type(int n, int ship_type, int by_sexp)
 	
 				ci->w_end = 0.05f;//end width
 	
-				ci->a_start = 1.0f * sip->afterburner_trail_alpha_factor;	// start alpha  * table loaded alpha factor
+				ci->a_start = sip->afterburner_trail_alpha_factor;	// start alpha  * table loaded alpha factor
 	
-				ci->a_end = 0.0f;//end alpha
+				ci->a_end = sip->afterburner_trail_alpha_end_factor;//end alpha
+
+				ci->a_decay_exponent = sip->afterburner_trail_alpha_decay_exponent;
 	
 				ci->max_life = sip->afterburner_trail_life;	// table loaded max life
 
@@ -10600,6 +10639,8 @@ void change_ship_type(int n, int ship_type, int by_sexp)
 				ci->n_fade_out_sections = sip->afterburner_trail_faded_out_sections; // table loaded n sections to be faded out
 
 				ci->texture.bitmap_id = sip->afterburner_trail.bitmap_id; // table loaded bitmap used on this ships burner trails
+
+				ci->texture_stretch = sip->afterburner_trail_tex_stretch;
 				nprintf(("AB TRAIL", "AB trail point #%d made for '%s'\n", sp->ab_count, sp->ship_name));
 				sp->ab_count++;
 				Assert(MAX_SHIP_CONTRAILS > sp->ab_count);

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -1239,8 +1239,11 @@ public:
 
 	// optional afterburner trail values
 	generic_bitmap afterburner_trail;
+	float afterburner_trail_tex_stretch;
 	float afterburner_trail_width_factor;
 	float afterburner_trail_alpha_factor;
+	float afterburner_trail_alpha_end_factor;
+	float afterburner_trail_alpha_decay_exponent;
 	float afterburner_trail_life;
 	float afterburner_trail_spread;
 	int afterburner_trail_faded_out_sections;

--- a/code/weapon/trails.cpp
+++ b/code/weapon/trails.cpp
@@ -249,7 +249,7 @@ void trail_render( trail * trailp )
 		top.a = bot.a = l;	
 
 		if (i > 0) {
-			float U = i2fl(i);
+			float U = i2fl(n) / trailp->info.texture_stretch;
 
 			if (i == num_sections-1) {
 				// Last one...

--- a/code/weapon/trails.cpp
+++ b/code/weapon/trails.cpp
@@ -212,10 +212,16 @@ void trail_render( trail * trailp )
 		}
 
 		w = trailp->val[n] * w_size + ti->w_start;
+
+		float fade = trailp->val[n];
+		
+		if (trailp->info.a_decay_exponent != 1.0f)
+			fade = powf(trailp->val[n], trailp->info.a_decay_exponent);
+
 		if (init_fade_out != 1.0f) {
-			l = (ubyte)fl2i((trailp->val[n] * a_size + ti->a_start) * 255.0f * init_fade_out * init_fade_out);
+			l = (ubyte)fl2i((fade * a_size + ti->a_start) * 255.0f * init_fade_out * init_fade_out);
 		} else {
-			l = (ubyte)fl2i((trailp->val[n] * a_size + ti->a_start) * 255.0f);
+			l = (ubyte)fl2i((fade * a_size + ti->a_start) * 255.0f);
 		}
 
 		if ( i == 0 )	{

--- a/code/weapon/trails.h
+++ b/code/weapon/trails.h
@@ -29,6 +29,7 @@ typedef struct trail_info {
 	float max_life;		// max_life for a section
 	int stamp;				// spew timestamp
 	generic_bitmap texture;	// texture to use for trail
+	float texture_stretch;  // stretches ... the texture
 	int n_fade_out_sections;// number of initial sections used for fading out start 'edge' of the effect
 	float spread;           // casues the trail points to spread and drift away over its lifetime
 	                        // trail points move away sideways randomly between 0 - spread m/s

--- a/code/weapon/trails.h
+++ b/code/weapon/trails.h
@@ -25,6 +25,7 @@ typedef struct trail_info {
 	float w_end;			// ending width
 	float a_start;			// starting alpha
 	float a_end;			// ending alpha
+	float a_decay_exponent; // applied to val to determine final alpha
 	float max_life;		// max_life for a section
 	int stamp;				// spew timestamp
 	generic_bitmap texture;	// texture to use for trail

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -1366,7 +1366,7 @@ int parse_weapon(int subtype, bool replace, const char *filename)
 				}
 				else
 				{
-					Warning(LOCATION,"Seeker Strength for missile \'%s\' must be greater than zero\nReseting value to default.", wip->name);
+					Warning(LOCATION,"Seeker Strength for missile \'%s\' must be greater than zero\nResetting value to default.", wip->name);
 					wip->seeker_strength = 3.0f;
 				}
 			}

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -1797,8 +1797,13 @@ int parse_weapon(int subtype, bool replace, const char *filename)
 		if ( optional_string("+End Alpha:") )
 			stuff_float(&ti->a_end);
 
-		if (optional_string("+Alpha Decay Exponent:"))
+		if (optional_string("+Alpha Decay Exponent:")) {
 			stuff_float(&ti->a_decay_exponent);
+			if (ti->a_decay_exponent < 0.0f) {
+				Warning(LOCATION, "Trail Alpha Decay Exponent of weapon %s cannot be negative. Reseting to 1.\n", wip->name);
+				ti->a_decay_exponent = 1.0f;
+			}
+		}
 
 		if ( optional_string("+Max Life:") ) {
 			stuff_float(&ti->max_life);

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -1813,6 +1813,14 @@ int parse_weapon(int subtype, bool replace, const char *filename)
 			generic_bitmap_init(&ti->texture, fname);
 		}
 
+		if (optional_string("+Bitmap Stretch:")) {
+			stuff_float(&ti->texture_stretch);
+			if (ti->texture_stretch == 0.0f) {
+				Warning(LOCATION, "Trail bitmap stretch of weapon %s cannot be 0.  Setting to 1.\n", wip->name);
+				ti->texture_stretch = 1.0f;
+			}
+		}
+
 		if ( optional_string("+Faded Out Sections:") ) {
 			stuff_int(&ti->n_fade_out_sections);
 		}

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -1797,6 +1797,9 @@ int parse_weapon(int subtype, bool replace, const char *filename)
 		if ( optional_string("+End Alpha:") )
 			stuff_float(&ti->a_end);
 
+		if (optional_string("+Alpha Decay Exponent:"))
+			stuff_float(&ti->a_decay_exponent);
+
 		if ( optional_string("+Max Life:") ) {
 			stuff_float(&ti->max_life);
 			ti->stamp = fl2i(1000.0f*ti->max_life)/(NUM_TRAIL_SECTIONS+1);
@@ -8185,6 +8188,7 @@ void weapon_info::reset()
 	this->tr_info.a_end = 1.0f;
 	this->tr_info.max_life = 1.0f;
 	this->tr_info.spread = 0.0f;
+	this->tr_info.a_decay_exponent = 1.0f;
 	this->tr_info.stamp = 0;
 	generic_bitmap_init(&this->tr_info.texture, NULL);
 	this->tr_info.n_fade_out_sections = 0;


### PR DESCRIPTION
Adds a field for an exponent to apply to the 0 - 1 alpha progress for non-linear decay.

Also allows texture to stretch by a specified amount rather than 1 full texture per trail segment. Switching `i` for `n` was necessary because `i` is measured from the tip to the tail, and thus the points move along with the trail, `n` are the points that are stable in space which is why they are needed. Before it was 1 texture per segment anyway so it didn't matter which it was.