### PR TITLE
Don't search for empty sound names

### DIFF
--- a/code/gamesnd/gamesnd.cpp
+++ b/code/gamesnd/gamesnd.cpp
@@ -303,6 +303,10 @@ gamesnd_id gamesnd_get_by_name(const char* name)
 {
 	Assert( Snds.size() <= INT_MAX );
 
+	// empty name is not valid!
+	if (name == nullptr || name[0] == '\0')
+		return gamesnd_id(-1);
+
 	int index = gamesnd_lookup_name(name, Snds);
 
 	if (index < 0)
@@ -315,12 +319,6 @@ gamesnd_id gamesnd_get_by_name(const char* name)
 			}
 
 			auto& entry = Snd.sound_entries.front();
-
-			if (entry.filename[0] == '\0') {
-				// Ignore empty sounds
-				continue;
-			}
-
 			char *p = strrchr( entry.filename, '.' );
 			if(p == NULL)
 			{

--- a/code/gamesnd/gamesnd.cpp
+++ b/code/gamesnd/gamesnd.cpp
@@ -315,6 +315,12 @@ gamesnd_id gamesnd_get_by_name(const char* name)
 			}
 
 			auto& entry = Snd.sound_entries.front();
+
+			if (entry.filename[0] == '\0') {
+				// Ignore empty sounds
+				continue;
+			}
+
 			char *p = strrchr( entry.filename, '.' );
 			if(p == NULL)
 			{


### PR DESCRIPTION
If a sound entry is left completely blank, literally just
```
	+WarmupSound:
```
It will match the first index with an empty sound definition! This is bad.