### PR TITLE
Split beam width for collision purposes and lighting purposes

### DIFF
--- a/code/weapon/beam.cpp
+++ b/code/weapon/beam.cpp
@@ -433,7 +433,7 @@ int beam_fire(beam_fire_info *fire_info)
 		vm_vec_zero(&new_item->target_pos2);
 	}
 
-	for (int i = 0; i < MAX_BEAM_SECTIONS; i++)
+	for (int i : new_item->beam_section_frame)
 		new_item->beam_section_frame[i] = 0.0f;
 
 	// beam collision and light width

--- a/code/weapon/beam.cpp
+++ b/code/weapon/beam.cpp
@@ -433,8 +433,8 @@ int beam_fire(beam_fire_info *fire_info)
 		vm_vec_zero(&new_item->target_pos2);
 	}
 
-	for (int i : new_item->beam_section_frame)
-		new_item->beam_section_frame[i] = 0.0f;
+	for (float &frame : new_item->beam_section_frame)
+		frame = 0.0f;
 
 	// beam collision and light width
 	if (wip->b_info.beam_width > 0.0f) {
@@ -1683,12 +1683,12 @@ void beam_add_light_small(beam *bm, object *objp, vec3d *pt_override = NULL)
 	}
 
 	// sanity
-	Assert(bm != NULL);
-	if(bm == NULL){
+	Assert(bm != nullptr);
+	if(bm == nullptr){
 		return;
 	}
-	Assert(objp != NULL);
-	if(objp == NULL){
+	Assert(objp != nullptr);
+	if(objp == nullptr){
 		return;
 	}
 	Assert(bm->weapon_info_index >= 0);

--- a/code/weapon/beam.h
+++ b/code/weapon/beam.h
@@ -184,7 +184,8 @@ typedef struct beam {
 	int Beam_muzzle_stamp;
 	int firingpoint;
 
-	float		beam_width;
+	float		beam_collide_width;
+	float		beam_light_width;
 } beam;
 
 extern std::array<beam, MAX_BEAMS> Beams;				// all beams


### PR DESCRIPTION
This way `$Collision Radius Override:` can also be used for beam width if `+BeamWidth:` is not specified. For compatibility purposes `+BeamWidth:` is used for *both* if specified, the widest section is the fallback for both.