### PR TITLE
Give swarm missile handling a well-deserved makeover

### DIFF
--- a/code/math/floating.cpp
+++ b/code/math/floating.cpp
@@ -11,6 +11,7 @@
 
 #include "io/timer.h"
 #include "math/floating.h"
+#include "math/staticrand.h"
 
 
 /**
@@ -77,7 +78,10 @@ static float accum_golden_ratio_rand_seed = 0.0f;
 // generates a quasirandom, low discrepancy number sequence
 // acts very much like a random number generator, but has the property of being very well distributed
 // use if you need quasirandom numbers, but don't want ugly 'runs' or 'clumps' of similar numbers 
-float golden_ratio_rand() {
+float golden_ratio_rand(int seed) {
+	if (seed >= 0) 
+		accum_golden_ratio_rand_seed = static_randf(seed);
+
 	accum_golden_ratio_rand_seed += GOLDEN_RATIO;
 	if (accum_golden_ratio_rand_seed >= 1.0f)
 		accum_golden_ratio_rand_seed -= 1.0f;

--- a/code/math/floating.cpp
+++ b/code/math/floating.cpp
@@ -71,3 +71,15 @@ int rand_chance(float frametime, float chance)
 
 	return frand() < (frametime * (chance + 1.0f));
 }
+
+static float accum_golden_ratio_rand_seed = 0.0f;
+
+// generates a quasirandom, low discrepancy number sequence
+// acts very much like a random number generator, but has the property of being very well distributed
+// use if you need quasirandom numbers, but don't want ugly 'runs' or 'clumps' of similar numbers 
+float golden_ratio_rand() {
+	accum_golden_ratio_rand_seed += GOLDEN_RATIO;
+	if (accum_golden_ratio_rand_seed >= 1.0f)
+		accum_golden_ratio_rand_seed -= 1.0f;
+	return accum_golden_ratio_rand_seed;
+}

--- a/code/math/floating.cpp
+++ b/code/math/floating.cpp
@@ -78,10 +78,7 @@ static float accum_golden_ratio_rand_seed = 0.0f;
 // generates a quasirandom, low discrepancy number sequence
 // acts very much like a random number generator, but has the property of being very well distributed
 // use if you need quasirandom numbers, but don't want ugly 'runs' or 'clumps' of similar numbers 
-float golden_ratio_rand(int seed) {
-	if (seed >= 0) 
-		accum_golden_ratio_rand_seed = static_randf(seed);
-
+float golden_ratio_rand() {
 	accum_golden_ratio_rand_seed += GOLDEN_RATIO;
 	if (accum_golden_ratio_rand_seed >= 1.0f)
 		accum_golden_ratio_rand_seed -= 1.0f;

--- a/code/math/floating.h
+++ b/code/math/floating.h
@@ -115,6 +115,6 @@ extern float fl_roundoff(float x, int multiple);
 
 const float GOLDEN_RATIO = 0.618033989f;
 
-float golden_ratio_rand(int seed = -1);
+float golden_ratio_rand();
 
 #endif

--- a/code/math/floating.h
+++ b/code/math/floating.h
@@ -115,6 +115,6 @@ extern float fl_roundoff(float x, int multiple);
 
 const float GOLDEN_RATIO = 0.618033989f;
 
-float golden_ratio_rand();
+float golden_ratio_rand(int seed = -1);
 
 #endif

--- a/code/math/floating.h
+++ b/code/math/floating.h
@@ -113,4 +113,8 @@ extern float fl_roundoff(float x, int multiple);
  */
 #define IS_NEAR_ZERO(x, e) (fl_abs(x) < (float)(e))
 
+const float GOLDEN_RATIO = 0.618033989f;
+
+float golden_ratio_rand();
+
 #endif

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -6210,7 +6210,6 @@ void ship::clear()
 
 	num_swarm_missiles_to_fire = 0;
 	next_swarm_fire = timestamp(0);
-	next_swarm_path = 0;
 	num_turret_swarm_info = 0;
 	swarm_missile_bank = -1;
 

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -597,7 +597,6 @@ public:
 
 	int	num_swarm_missiles_to_fire;	// number of swarm missiles that need to be launched
 	int	next_swarm_fire;					// timestamp of next swarm missile to fire
-	int	next_swarm_path;					// next path number for swarm missile to take
 	int	num_turret_swarm_info;			// number of turrets in process of launching swarm
 	int swarm_missile_bank;				// The missilebank the swarm was originally launched from
 

--- a/code/weapon/swarm.cpp
+++ b/code/weapon/swarm.cpp
@@ -131,9 +131,7 @@ void swarm_create(object* objp, swarm_info* swarmp)
 {
 	swarmp->change_timestamp = 1;
 	swarmp->homing_objnum = -1;
-
-	int sig = (Game_mode & GM_MULTIPLAYER ? objp->net_signature : objp->signature);
-	swarmp->zig_direction = golden_ratio_rand(sig) * PI2;
+	swarmp->zig_direction = golden_ratio_rand() * PI2;
 
 	vm_vec_zero(&swarmp->offset);
 
@@ -241,7 +239,7 @@ void swarm_update_direction(object *objp, swarm_info* swarmp)
 			// depending on the signature, switch every 3, 4, or 5 zig zags
 			if (zigs_zagged % (mod_signature + 3)) { 
 				// angle change!
-				swarmp->zig_direction = golden_ratio_rand((Game_mode & GM_MULTIPLAYER ? objp->net_signature : objp->signature) + zigs_zagged) * PI2;
+				swarmp->zig_direction = golden_ratio_rand() * PI2;
 			} else // otherwise go 180 degrees off of what you were before
 				swarmp->zig_direction += PI;
 

--- a/code/weapon/swarm.cpp
+++ b/code/weapon/swarm.cpp
@@ -235,7 +235,7 @@ void swarm_update_direction(object *objp, swarm_info* swarmp)
 
 			// maybe zig zag to a different angle
 			int zigs_zagged = (int)(missile_age * (1 / (SWARM_CHANGE_DIR_TIME / 1000.0f)));
-			int mod_signature = (Game_mode && GM_MULTIPLAYER ? objp->net_signature : objp->signature) % 3;
+			int mod_signature = (Game_mode & GM_MULTIPLAYER ? objp->net_signature : objp->signature) % 3;
 			// depending on the signature, switch every 3, 4, or 5 zig zags
 			if (zigs_zagged % (mod_signature + 3)) { 
 				// angle change!

--- a/code/weapon/swarm.cpp
+++ b/code/weapon/swarm.cpp
@@ -35,10 +35,7 @@
 #define TURRET_SWARM_VALIDITY_CHECKTIME	5000	// number of ms between checks on turret_swam_info checks
 
 #define SWARM_USED						(1<<0)
-#define SWARM_POSITIVE_PATH			(1<<1)
 
-
-swarm_info	Swarm_missiles[MAX_SWARM_MISSILES];
 
 turret_swarm_info Turret_swarm_info[MAX_TURRET_SWARM_INFO];
 
@@ -52,15 +49,7 @@ int Turret_swarm_validity_next_check_time;
 void swarm_level_init()
 {
 	int					i;
-	swarm_info			*swarmp;
 	turret_swarm_info	*tswarmp;
-
-	for ( i = 0; i < MAX_SWARM_MISSILES; i++ ) {
-		swarmp = &Swarm_missiles[i];
-		swarmp->flags = 0;
-		swarmp->change_timestamp = 1;
-		swarmp->path_num = -1;
-	}
 
 	for (i=0; i<MAX_TURRET_SWARM_INFO; i++) {
 		tswarmp = &Turret_swarm_info[i];
@@ -128,52 +117,24 @@ void swarm_maybe_fire_missile(int shipnum)
 	}
 }
 
-// ------------------------------------------------------------------
-// swarm_create()
-//
-//	Get a free swarm missile entry, and initialize the struct members
-//
-int swarm_create()
-{
-	int			i;
-	swarm_info	*swarmp = NULL;
-
-	for ( i = 0; i < MAX_SWARM_MISSILES; i++ ) {
-		swarmp = &Swarm_missiles[i];
-		if ( !(swarmp->flags & SWARM_USED) ) 
-			break;		
-	}
-
-	if ( i >= MAX_SWARM_MISSILES ) {
-		nprintf(("Warning","No more swarm missiles are available\n"));
-		return -1;
-	}
-
-	swarmp->flags = 0;
-	swarmp->change_timestamp = 1;
-	swarmp->path_num = -1;
-	swarmp->homing_objnum = -1;
-
-	swarmp->flags |= SWARM_USED;
-	return i;
+// if it can't home on something, just set target dead ahead
+void swarm_set_defaut_target_pos(object* objp, swarm_info* swarmp) {
+	vm_vec_scale_add(&swarmp->current_target, &objp->pos, &objp->orient.vec.fvec, SWARM_CONE_LENGTH);
 }
 
 // ------------------------------------------------------------------
-// swarm_delete()
+// swarm_create()
 //
+//	Set up all the basic info for a swarm missile
 //
-void swarm_delete(int i)
+void swarm_create(object* objp, swarm_info* swarmp)
 {
-	swarm_info	*swarmp;
+	swarmp->change_timestamp = 1;
+	swarmp->homing_objnum = -1;
+	swarmp->zig_direction = golden_ratio_rand() * PI2;
+	vm_vec_zero(&swarmp->offset);
 
-	Assert(i >= 0 && i < MAX_SWARM_MISSILES);
-	swarmp = &Swarm_missiles[i];
-
-	if ( !(swarmp->flags & SWARM_USED) ) {
-		Int3();	// tried to delete a swarm missile that didn't exist, get Alan
-	}
-
-	swarmp->flags = 0;
+	swarm_set_defaut_target_pos(objp, swarmp);
 }
 
 // ------------------------------------------------------------------
@@ -181,12 +142,11 @@ void swarm_delete(int i)
 //
 //	Check if we want to update the direction of a swarm missile.
 //
-void swarm_update_direction(object *objp)
+void swarm_update_direction(object *objp, swarm_info* swarmp)
 {
 	weapon_info	*wip;
 	weapon		*wp;
 	object		*hobjp;
-	swarm_info	*swarmp;
 	vec3d		obj_to_target;	// Vector pointing from the swarm missile to its target
 	float			vel, target_dist, radius;
 	physics_info	*pi;
@@ -195,20 +155,15 @@ void swarm_update_direction(object *objp)
 
 	wp = &Weapons[objp->instance];
 
-	if (wp->swarm_index == -1) {
-		return;
-	}
-
 	wip = &Weapon_info[wp->weapon_info_index];
 	hobjp = wp->homing_object;
 	pi = &Objects[wp->objnum].phys_info;
-	swarmp = &Swarm_missiles[wp->swarm_index];
 
-	// check if homing is lost.. if it is then get a new path to move swarm missile along
+	// check if homing is lost.. if it is then set the target point dead ahead
 	if ( swarmp->homing_objnum != -1 && hobjp == &obj_used_list ) {
 		swarmp->change_timestamp = 1;
-		swarmp->path_num = -1;
 		swarmp->homing_objnum = -1;
+		swarm_set_defaut_target_pos(objp, swarmp);
 	}
 
 	if ( hobjp != &obj_used_list ) {
@@ -216,44 +171,18 @@ void swarm_update_direction(object *objp)
 	}
 
 	if ( timestamp_elapsed(swarmp->change_timestamp) ) {
+		
 		// Time to (maybe) zig-zag!
-		swarmp->change_timestamp = timestamp(swarmp->change_time);
+		int zig_zag_time = fl2i(SWARM_CHANGE_DIR_TIME + SWARM_TIME_VARIANCE * (frand() - 0.5f) * 2);
+		swarmp->change_timestamp = timestamp(zig_zag_time);
 
-		if (swarmp->path_num == -1) {
-			// Swarm missile was just created, or just lost homing
-			if (Objects[objp->parent].type != OBJ_SHIP) {
-				//AL: parent ship died... so just pick some random paths
-				swarmp->path_num = myrand() % 4;
-
-			} else {
-				// Parent ship is alive, try to get a new path from them
-				ship *parent_shipp;
-				parent_shipp = &Ships[Objects[objp->parent].instance];
-				swarmp->path_num = (parent_shipp->next_swarm_path++) % 4;
-
-				if (parent_shipp->next_swarm_path % 4 == 0) {
-					swarmp->flags ^= SWARM_POSITIVE_PATH;
-				}
-			}
-
-			// Set the change time. This is here because it's common to both swarm_create() and turret_swarm_create()
-			swarmp->change_time = fl2i(SWARM_CHANGE_DIR_TIME + SWARM_TIME_VARIANCE*(frand() - 0.5f) * 2);
-
-			// Set target to straight ahead
-			vm_vec_scale_add(&swarmp->original_target, &objp->pos, &objp->orient.vec.fvec, SWARM_CONE_LENGTH);
-
-			// Reset zigzag index
-			swarmp->change_count = 1;
-
-			vm_vec_zero(&swarmp->last_offset);
-
-		} else if (hobjp != &obj_used_list &&
-				   f2fl(Missiontime - wp->creation_time) > 0.5f &&
-				   f2fl(Missiontime - wp->creation_time) > wip->free_flight_time) 
+		if (hobjp != &obj_used_list &&
+			f2fl(Missiontime - wp->creation_time) > 0.5f &&
+			f2fl(Missiontime - wp->creation_time) > wip->free_flight_time)
 		{
 			// This is a copy of the relevant bits near the end of weapon_home() to make missiles lead their targets
 			// note that if the swarm missile has a target_lead_scaler of 0 this is equivalent to retail behavior (no leading)
-			if (Swarmers_lead_targets) { 
+			if (Swarmers_lead_targets) {
 				vec3d target_pos = wp->homing_pos;
 				vec3d vec_to_goal;
 				float dist_to_target = vm_vec_normalized_dir(&vec_to_goal, &target_pos, &objp->pos);
@@ -267,134 +196,56 @@ void swarm_update_direction(object *objp)
 
 				if ((old_dot > 0.1f) && (time_to_target > 0.1f)) {
 					if (wip->wi_flags[Weapon::Info_Flags::Variable_lead_homing]) {
-						vm_vec_scale_add2(&target_pos, &hobjp->phys_info.vel, (0.33f * wip->target_lead_scaler * MIN(time_to_target, 6.0f)));
+						target_pos += hobjp->phys_info.vel * (0.33f * wip->target_lead_scaler * MIN(time_to_target, 6.0f));
 					}
 					else if (wip->is_locked_homing()) {
-						vm_vec_scale_add2(&target_pos, &hobjp->phys_info.vel, MIN(time_to_target, 2.0f));
+						target_pos += hobjp->phys_info.vel * MIN(time_to_target, 2.0f);
 					}
 				}
-				swarmp->original_target = target_pos;
-			}
-			else { // Else, retail behavior (usually simply the target's position)
-				swarmp->original_target = wp->homing_pos;
+				swarmp->current_target = target_pos;
+			} else { // Else, retail behavior (usually simply the target's position)
+				swarmp->current_target = wp->homing_pos;
 			}
 		}
 
-		// Calculate a rvec and uvec that will determine the displacement from the
-		// intended target.  Use crossprod to generate a right vector, from the missile
-		// up vector and the vector connecting missile to the homing object.
-		// Faster missiles have a tighter grouping than slower missiles, They should expand at sharp turns
-		{
+		obj_to_target = swarmp->current_target - objp->pos;
+		target_dist = vm_vec_mag_quick(&obj_to_target);
+
+		// If homing swarm missile is close to target, let missile home in on original target
+		if ((target_dist / pi->speed) <= ((zig_zag_time / 1000.0f) * SWARM_FRAME_STOP_SWARMING)) {
+			vm_vec_zero(&swarmp->offset);
+		} else {
+			
+			// calculate a radius around our target such that it would be the same angular offset
+			// as SWARM_DIST_OFFSET (2 meters) at our next zig distance
+			
 			float missile_dist;     // straight-line distance the missile will travel between now and next check
 			float missile_speed;    // current speed of the missile
 
-			swarmp->circle_uvec = objp->orient.vec.uvec;
-			swarmp->circle_rvec = objp->orient.vec.rvec;
-
 			missile_speed = pi->speed;
-			missile_dist = missile_speed * swarmp->change_time / 1000.0f;
-			if (missile_dist < SWARM_DIST_OFFSET) {
+			missile_dist = missile_speed * zig_zag_time / 1000.0f;
+			if (missile_dist < SWARM_DIST_OFFSET)
 				missile_dist = SWARM_DIST_OFFSET;
-			}
-			swarmp->angle_offset = asinf(SWARM_DIST_OFFSET / missile_dist);
-			Assert(!fl_is_nan(swarmp->angle_offset));
+			float angle_offset = asinf(SWARM_DIST_OFFSET / missile_dist);
+			Assert(!fl_is_nan(angle_offset));
+
+			// Radius around the target pos. Shortens as the missiles get closer to the target.
+			radius = tanf(angle_offset) * target_dist;
+
+			// calculate the angle around our target
+			if (frand() < 0.3f) // maybe go to a different angle
+				swarmp->zig_direction = golden_ratio_rand() * PI2;
+			else // otherwise go 180 degrees off of what you were before
+				swarmp->zig_direction += PI;
+
+			// then rotate by it 
+			swarmp->offset = objp->orient.vec.uvec * radius;
+			vm_rot_point_around_line(&swarmp->offset, &swarmp->offset, swarmp->zig_direction, &vmd_zero_vector, &objp->orient.vec.fvec);
 		}
-
-		vm_vec_sub(&obj_to_target, &swarmp->original_target, &objp->pos);
-		target_dist = vm_vec_mag_quick(&obj_to_target);
-		swarmp->last_dist = target_dist;
-
-		// Radius around the target pos. Shortens as the missiles get closer to the target.
-		radius = tanf(swarmp->angle_offset) * target_dist;
-
-		// If homing swarm missile is close to target, let missile home in on original target
-		if ((target_dist / pi->speed) <= ((swarmp->change_time / 1000.0f) * SWARM_FRAME_STOP_SWARMING)) {
-			swarmp->new_target = swarmp->original_target;
-			vm_vec_zero(&swarmp->last_offset);
-			goto swarm_new_target_calced;
-		}
-
-		vec3d rvec_component, uvec_component;
-		vm_vec_zero(&rvec_component);
-		vm_vec_zero(&uvec_component);
-
-		swarmp->change_count++;
-		if ( swarmp->change_count > 2 ) {
-			swarmp->flags ^= SWARM_POSITIVE_PATH;
-			swarmp->change_count = 0;
-		}
-
-		// pick a new path number to follow once at center
-		if ( swarmp->change_count == 1 ) {
-			swarmp->path_num = swarmp->path_num + myrand()%3;
-			if ( swarmp->path_num > 3 ) {
-				swarmp->path_num = 0;
-			}
-		}
-
-		switch ( swarmp->path_num ) {
-			case 0:	// straight up and down
-				if ( swarmp->flags & SWARM_POSITIVE_PATH )
-					vm_vec_copy_scale( &uvec_component, &swarmp->circle_uvec, radius);
-				else
-					vm_vec_copy_scale( &uvec_component, &swarmp->circle_uvec, -radius);
-				break;
-
-			case 1:	// left/right
-				if ( swarmp->flags & SWARM_POSITIVE_PATH )
-					vm_vec_copy_scale( &rvec_component, &swarmp->circle_rvec, radius);
-				else
-					vm_vec_copy_scale( &rvec_component, &swarmp->circle_rvec, -radius);
-				break;
-
-			case 2:	// top/right - bottom/left
-				if ( swarmp->flags & SWARM_POSITIVE_PATH ) {
-					vm_vec_copy_scale( &rvec_component, &swarmp->circle_rvec, radius);
-					vm_vec_copy_scale( &uvec_component, &swarmp->circle_uvec, radius);
-				}
-				else {
-					vm_vec_copy_scale( &rvec_component, &swarmp->circle_rvec, -radius);
-					vm_vec_copy_scale( &uvec_component, &swarmp->circle_uvec, -radius);
-				}
-				break;
-
-			case 3:	// top-left - bottom/right
-				if ( swarmp->flags & SWARM_POSITIVE_PATH ) {
-					vm_vec_copy_scale( &rvec_component, &swarmp->circle_rvec, -radius);
-					vm_vec_copy_scale( &uvec_component, &swarmp->circle_uvec, radius);
-				}
-				else {
-					vm_vec_copy_scale( &rvec_component, &swarmp->circle_rvec, radius);
-					vm_vec_copy_scale( &uvec_component, &swarmp->circle_uvec, -radius);
-				}
-				break;
-
-			default:
-				Int3();
-				break;
-		}
-
-		swarmp->new_target = swarmp->original_target;
-		vm_vec_zero(&swarmp->last_offset);
-		vm_vec_add(&swarmp->last_offset, &uvec_component, &rvec_component);
-		vm_vec_add2(&swarmp->new_target, &swarmp->last_offset);
-
-	} else {
-		// Not time to zig-zag.
-		if (hobjp != &obj_used_list &&
-			f2fl(Missiontime - wp->creation_time) > 0.5f &&
-			f2fl(Missiontime - wp->creation_time) > wip->free_flight_time) {
-			// Still homing
-			swarmp->new_target = swarmp->original_target;
-
-			// Continue homing in on our last offset around the target
-			vm_vec_add2(&swarmp->new_target, &swarmp->last_offset);
-		}	// Else, lost homing, maintain current trajectory
 	}
 
-	swarm_new_target_calced:
-
-	ai_turn_towards_vector(&swarmp->new_target, objp, nullptr, nullptr, 0.0f, 0);
+	vec3d actual_target = swarmp->current_target + swarmp->offset;
+	ai_turn_towards_vector(&actual_target, objp, nullptr, nullptr, 0.0f, 0);
 	vel = vm_vec_mag(&objp->phys_info.desired_vel);
 	vm_vec_copy_scale(&objp->phys_info.desired_vel, &objp->orient.vec.fvec, vel);
 }

--- a/code/weapon/swarm.h
+++ b/code/weapon/swarm.h
@@ -32,33 +32,22 @@ typedef struct turret_swarm_info {
 	int				weapon_num;
 } turret_swarm_info;
 
-typedef struct swarm_info {
-	int		flags;
+struct swarm_info {
 	int		change_timestamp;
-	vec3d	original_target;
-	vec3d	new_target;
-	vec3d	circle_rvec, circle_uvec;
-	vec3d	last_offset;
-	uint		change_count;		
-	int		path_num;			// which path swarm missile is currently following
+	vec3d	current_target;
+	vec3d	offset;
 	int		homing_objnum;		// object number that swarm missile is homing on, -1 if not homing
-	int		change_time;		// when swarm missile should next update direction, based on missile speed
-	float		angle_offset;
-	float		last_dist;			// last distance to target
-} swarm_info;
+	float	zig_direction;
+};
 
 #define SWARM_DEFAULT_NUM_MISSILES_FIRED					4		// number of swarm missiles that launch when fired
-
-#define MAX_SWARM_MISSILES	100
-extern swarm_info	Swarm_missiles[MAX_SWARM_MISSILES];
 
 #define MAX_TURRET_SWARM_INFO	100
 extern turret_swarm_info Turret_swarm_info[MAX_TURRET_SWARM_INFO];
 
 void	swarm_level_init();
-void	swarm_delete(int index);
-int	swarm_create();
-void	swarm_update_direction(object *objp);
+void	swarm_create(object* objp, swarm_info* swarmp);
+void	swarm_update_direction(object *objp, swarm_info* swarmp);
 void	swarm_maybe_fire_missile(int shipnum);
 
 int	turret_swarm_create();

--- a/code/weapon/weapon.h
+++ b/code/weapon/weapon.h
@@ -19,6 +19,7 @@
 #include "gamesnd/gamesnd.h"
 #include "model/model.h"
 #include "weapon/shockwave.h"
+#include "weapon/swarm.h"
 #include "weapon/trails.h"
 #include "particle/ParticleManager.h"
 #include "weapon/weapon_flags.h"
@@ -101,7 +102,7 @@ typedef struct weapon {
 	object*	homing_object;					//	object this weapon is homing on.
 	ship_subsys*	homing_subsys;			// subsystem this weapon is homing on
 	vec3d	homing_pos;						// world position missile is homing on
-	short		swarm_index;					// index into swarm missile info, -1 if not WIF_SWARM
+	std::unique_ptr<swarm_info>		swarm_info_ptr;					// index into swarm missile info, -1 if not WIF_SWARM
 	int		missile_list_index;			// index for missiles into Missile_obj_list, -1 weapon not missile
 	trail		*trail_ptr;						// NULL if no trail, otherwise a pointer to its trail
 	ship_subsys *turret_subsys;			// points to turret that fired weapon, otherwise NULL

--- a/code/weapon/weapon.h
+++ b/code/weapon/weapon.h
@@ -102,7 +102,7 @@ typedef struct weapon {
 	object*	homing_object;					//	object this weapon is homing on.
 	ship_subsys*	homing_subsys;			// subsystem this weapon is homing on
 	vec3d	homing_pos;						// world position missile is homing on
-	std::unique_ptr<swarm_info>		swarm_info_ptr;					// index into swarm missile info, -1 if not WIF_SWARM
+	std::unique_ptr<swarm_info>		swarm_info_ptr;	// index into swarm missile info, -1 if not WIF_SWARM
 	int		missile_list_index;			// index for missiles into Missile_obj_list, -1 weapon not missile
 	trail		*trail_ptr;						// NULL if no trail, otherwise a pointer to its trail
 	ship_subsys *turret_subsys;			// points to turret that fired weapon, otherwise NULL

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -6076,7 +6076,7 @@ void spawn_child_weapons(object *objp, int spawn_index_override)
 				// fire the beam
 				beam_fire(&fire_info);
 			} else {
-				vm_vector_2_matrix(&orient, &tvec, NULL, NULL);
+				vm_vector_2_matrix(&orient, &tvec, nullptr, nullptr);
 				weapon_objnum = weapon_create(&pos, &orient, child_id, parent_num, -1, wp->weapon_flags[Weapon::Weapon_Flags::Locked_when_fired], 1);
 
 				//if the child inherits parent target, do it only if the parent weapon was locked to begin with

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -6084,9 +6084,7 @@ void spawn_child_weapons(object *objp, int spawn_index_override)
 				{
 					//Deal with swarm weapons
 					if (wp->swarm_info_ptr != nullptr) {
-						swarm_info* swarmp = wp->swarm_info_ptr.get();
-
-						weapon_set_tracking_info(weapon_objnum, parent_num, swarmp->homing_objnum, 1, wp->homing_subsys);
+						weapon_set_tracking_info(weapon_objnum, parent_num, wp->swarm_info_ptr->homing_objnum, 1, wp->homing_subsys);
 					} else {
 						weapon_set_tracking_info(weapon_objnum, parent_num, wp->target_num, 1, wp->homing_subsys);
 					}


### PR DESCRIPTION
It was getting a bit old and crusty in swarm.cpp

Swarm missiles were doing *a lot* of bending over backwards and complicated overhead, fucking around with these 'paths' for the swarm missile (even going so far as to store state on the ship that fired it?? `next_swarm_path`) the whole purpose of which is to ensure that the swarm missiles choose different direction to 'zig' in, so they don't all follow the same perfect path which would look weird. What they did was massively overengineered for something that can be easily solved with the right RNG function.

`golden_ratio_rand()`, as the comment describes, has all the benefits of rng while avoiding runs and clumps, subsequent calls to the function will evenly spread themselves around the 0 - 1 range, and is perfectly suited for this purpose. Getting rid of these dumb paths was most of the fat cutting here.

This is a comparison, and I'll give you dollar if you can tell the difference.

https://user-images.githubusercontent.com/17305613/106226914-484ed480-61b6-11eb-8322-b36ed07052fd.mp4

https://user-images.githubusercontent.com/17305613/106226923-4d138880-61b6-11eb-89c8-35cc2c9ad22a.mp4

(mp4 support now woot!)

Additionally, weapons now have a unique pointer to their `swarm_info`, instead of an index into the arbitrarily sized `Swarm_missiles` array allowing for indefinite numbers of them simultaneously. Only a single element was plucked from the array each time anyway so this should have a negligible effect on speed.

Turret swarm handling is even worse in terms of ugly overhead tbh, but one step at a time.