### PR TITLE
Remove the Unused Just_updated Flag

### DIFF
--- a/code/object/object.cpp
+++ b/code/object/object.cpp
@@ -933,13 +933,8 @@ void obj_move_call_physics(object *objp, float frametime)
 				}
 			}			
 
-			// in multiplayer, if this object was just updatd (i.e. clients send their own positions),
-			// then reset the flag and don't move the object.
-            if (MULTIPLAYER_MASTER && (objp->flags[Object::Object_Flags::Just_updated])) {
-				objp->flags.remove(Object::Object_Flags::Just_updated);
-			} else {
-				physics_sim(&objp->pos, &objp->orient, &objp->phys_info, frametime);		// simulate the physics
-			}
+			// simulate the physics
+			physics_sim(&objp->pos, &objp->orient, &objp->phys_info, frametime);		
 
 			// if the object is the player object, do things that need to be done after the ship
 			// is moved (like firing weapons, etc).  This routine will get called either single
@@ -1580,10 +1575,6 @@ void obj_move_all(float frametime)
 				Physics_viewer_bank -= 2.0f * PI; 	 
 			}
 		}
-
-		// unflag all objects as being updates
-        objp->flags.remove(Object::Object_Flags::Just_updated);
-
 		objp = GET_NEXT(objp);
 	}
 
@@ -1809,7 +1800,6 @@ void obj_observer_move(float frame_time)
 	ft = flFrametime;
 	obj_move_call_physics( objp, ft );
 	obj_move_all_post(objp, frame_time);
-	objp->flags.remove(Object::Object_Flags::Just_updated);
 }
 
 /**

--- a/code/object/object_flags.h
+++ b/code/object/object_flags.h
@@ -13,7 +13,6 @@ namespace Object {
 		Protected,				// Don't kill this object, probably mission-critical.
 		Player_ship,			// this object under control of some player -- don't do ai stuff on it!!!
 		No_shields,				// object has no shield generator system (i.e. no shields)
-		Just_updated,			// for multiplayer -- indicates that we received object update this frame
 		Could_be_player,		// for multiplayer -- indicates that it is selectable ingame joiners as their ship
 		Was_rendered,			// Set if this object was rendered this frame.  Only gets set if OF_RENDERS set.  Gets cleared or set in obj_render_all().
 		Not_in_coll,			// object has not been added to collision list


### PR DESCRIPTION
This flag is vestigal.  It was likely used in the FS1 codebase and then was not removed by the rushed FS2 multi team.  Whether or not an object uses physics_sim is determined earlier in `multi_oo_is_interp_object()`, and so this flag is never set.  There are only calls for it to be removed.