### PR TITLE
Expose Additional Countermeasure Options to Modders

### DIFF
--- a/code/ai/ai_flags.h
+++ b/code/ai/ai_flags.h
@@ -135,6 +135,7 @@ namespace AI {
 		Better_collision_avoidance,
 		Require_exact_los,
 		Improved_missile_avoidance,
+		Friendlies_use_countermeasure_firechance,
 
 		NUM_VALUES
 	};

--- a/code/ai/ai_profiles.cpp
+++ b/code/ai/ai_profiles.cpp
@@ -540,6 +540,8 @@ void parse_ai_profiles_tbl(const char *filename)
 
 				set_flag(profile, "$improved missile avoidance for fightercraft:", AI::Profile_Flags::Improved_missile_avoidance);
 
+				set_flag(profile, "$friendly ships use AI profile countermeasure chance:", AI::Profile_Flags::Friendlies_use_countermeasure_firechance);
+
 				// if we've been through once already and are at the same place, force a move
 				if (saved_Mp && (saved_Mp == Mp))
 				{

--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -12412,16 +12412,8 @@ void ai_maybe_launch_cmeasure(object *objp, ai_info *aip)
 
 			//	For ships on player's team, check if modder wants default constant chance to fire or value from specific AI class profile.
 			//	For enemies, use value from specific AI class profile (usually increasing chance with higher skill level).
-			if (shipp->team == Player_ship->team) {
-				// check if modder wants friendly AI to use AI profile or main profile
-				ai_info* aip = &Ai_info[Ships[objp->instance].ai_index];
-				if (aip->ai_profile_flags[AI::Profile_Flags::Friendlies_use_countermeasure_firechance]) {
-					// use AI profile chance
-					fire_chance = aip->ai_cmeasure_fire_chance;
-				} else {
-					// use default constant chance
-					fire_chance = The_mission.ai_profile->cmeasure_fire_chance[NUM_SKILL_LEVELS/2];
-				}
+			if ( (shipp->team == Player_ship->team) && !(aip->ai_profile_flags[AI::Profile_Flags::Friendlies_use_countermeasure_firechance]) ) {
+				fire_chance = The_mission.ai_profile->cmeasure_fire_chance[NUM_SKILL_LEVELS/2];
 			} else {
 				fire_chance = aip->ai_cmeasure_fire_chance;
 			}

--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -12425,10 +12425,10 @@ void ai_maybe_launch_cmeasure(object *objp, ai_info *aip)
 			float r = frand();
 			if (fire_chance < r) {
 				int fail_delay;
-				// check if modder wants to use firewait for fail delay, or default
-				if (cmeasure->cmeasure_faildelay_equals_firewait) {
+				// check if modder wants to use custom fail delay, or default
+				if (cmeasure->cmeasure_failure_delay_multiplier_ai >= 0) {
 					// use firewait as delay
-					fail_delay = cmeasure->cmeasure_firewait;
+					fail_delay = cmeasure->cmeasure_firewait * cmeasure->cmeasure_failure_delay_multiplier_ai;
 				} else {
 					//	use default to wait firwait + additional delay to decrease chance of firing very soon.
 					fail_delay = cmeasure->cmeasure_firewait + (int) (fire_chance*2000);
@@ -12440,7 +12440,7 @@ void ai_maybe_launch_cmeasure(object *objp, ai_info *aip)
 			if (weapon_objp->type == OBJ_WEAPON) {
 				if (weapon_objp->instance >= 0) {
 					ship_launch_countermeasure(objp);
-					shipp->cmeasure_fire_stamp = timestamp(cmeasure->cmeasure_firewait*cmeasure->cmeasure_sucess_delay_multiplier);
+					shipp->cmeasure_fire_stamp = timestamp(cmeasure->cmeasure_firewait * cmeasure->cmeasure_sucess_delay_multiplier_ai);
 					return;
 				}
 			}

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -10765,7 +10765,7 @@ int ship_launch_countermeasure(object *objp, int rand_val)
 		return 0;
 	}
 
-	shipp->cmeasure_fire_stamp = timestamp(CMEASURE_WAIT);	//	Can launch every half second.
+	shipp->cmeasure_fire_stamp = timestamp(Weapon_info[shipp->current_cmeasure].cmeasure_firewait);	//	Can launch every cmeasure wait
 #ifndef NDEBUG
 	if (Weapon_energy_cheat) {
 		shipp->cmeasure_count++;

--- a/code/weapon/weapon.h
+++ b/code/weapon/weapon.h
@@ -471,6 +471,10 @@ struct weapon_info
 	float cm_detonation_rad;
 	bool  cm_kill_single;       // should the countermeasure kill just the single decoyed missile within CMEASURE_DETONATE_DISTANCE?
 	int   cmeasure_timer_interval;	// how many milliseconds between pulses
+	int cmeasure_firewait;					// delay in milliseconds between countermeasure firing --wookieejedi
+	int cmeasure_sucess_delay_multiplier;		// multiplier for firewait between successful countermeasure launches, next launch = this value * firewait  --wookieejedi
+	bool cmeasure_use_firewait;					// if set to true, then countermeasure will use specified firewait instead of default --wookieejedi
+	bool cmeasure_faildelay_equals_firewait;	// if set to true, then countermeasure will use firewait as delay between failed launches --wookieejedi
 
 	float weapon_submodel_rotate_accell;
 	float weapon_submodel_rotate_vel;

--- a/code/weapon/weapon.h
+++ b/code/weapon/weapon.h
@@ -471,10 +471,10 @@ struct weapon_info
 	float cm_detonation_rad;
 	bool  cm_kill_single;       // should the countermeasure kill just the single decoyed missile within CMEASURE_DETONATE_DISTANCE?
 	int   cmeasure_timer_interval;	// how many milliseconds between pulses
-	int cmeasure_firewait;					// delay in milliseconds between countermeasure firing --wookieejedi
-	int cmeasure_sucess_delay_multiplier;		// multiplier for firewait between successful countermeasure launches, next launch = this value * firewait  --wookieejedi
+	int cmeasure_firewait;						// delay in milliseconds between countermeasure firing --wookieejedi
 	bool cmeasure_use_firewait;					// if set to true, then countermeasure will use specified firewait instead of default --wookieejedi
-	bool cmeasure_faildelay_equals_firewait;	// if set to true, then countermeasure will use firewait as delay between failed launches --wookieejedi
+	int cmeasure_failure_delay_multiplier_ai;	// multiplier for firewait between failed countermeasure launches, next launch try = this value * firewait  --wookieejedi
+	int cmeasure_sucess_delay_multiplier_ai;	// multiplier for firewait between successful countermeasure launches, next launch try = this value * firewait  --wookieejedi
 
 	float weapon_submodel_rotate_accell;
 	float weapon_submodel_rotate_vel;

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -2344,12 +2344,24 @@ int parse_weapon(int subtype, bool replace, const char *filename)
 			wip->cmeasure_firewait = (int) (wip->fire_wait*1000.0f);
 		}
 
-		if (optional_string("+Fail Delay Equals Fire Wait:")) {
-			stuff_boolean(&wip->cmeasure_faildelay_equals_firewait);
+		if (optional_string("+Failure Launch Delay Multiplier for AI:")) {
+			int delay_multiplier;
+			stuff_int(&delay_multiplier);
+			if (delay_multiplier > 0) {
+				wip->cmeasure_failure_delay_multiplier_ai = delay_multiplier;
+			} else {
+				mprintf(("Warning: \"+Failure Launch Delay Multiplier for AI:\" should be >= 0 (read %i). Value will not be used. ", delay_multiplier));
+			}
 		}
 
-		if (optional_string("+Successful Launch Delay Multiplier:")) {
-			stuff_int(&wip->cmeasure_sucess_delay_multiplier);
+		if (optional_string("+Successful Launch Delay Multiplier for AI:")) {
+			int delay_multiplier;
+			stuff_int(&delay_multiplier);
+			if (delay_multiplier > 0) {
+				wip->cmeasure_sucess_delay_multiplier_ai = delay_multiplier;
+			} else {
+				mprintf(("Warning: \"+Successful Launch Delay Multiplier for AI:\" should be >= 0 (read %i). Value will not be used. ", delay_multiplier));
+			}
 		}
 
 	}
@@ -8369,9 +8381,9 @@ void weapon_info::reset()
 	this->cm_kill_single = false;
 	this->cmeasure_timer_interval = 0;
 	this->cmeasure_firewait = CMEASURE_WAIT;
-	this->cmeasure_sucess_delay_multiplier = 2;
 	this->cmeasure_use_firewait = false;
-	this->cmeasure_faildelay_equals_firewait = false;
+	this->cmeasure_failure_delay_multiplier_ai = -1;
+	this->cmeasure_sucess_delay_multiplier_ai = 2;
 
 	this->weapon_submodel_rotate_accell = 10.0f;
 	this->weapon_submodel_rotate_vel = 0.0f;

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -2350,7 +2350,7 @@ int parse_weapon(int subtype, bool replace, const char *filename)
 			if (delay_multiplier > 0) {
 				wip->cmeasure_failure_delay_multiplier_ai = delay_multiplier;
 			} else {
-				mprintf(("Warning: \"+Failure Launch Delay Multiplier for AI:\" should be >= 0 (read %i). Value will not be used. ", delay_multiplier));
+				Warning(LOCATION,"\"+Failure Launch Delay Multiplier for AI:\" should be >= 0 (read %i). Value will not be used. ", delay_multiplier);
 			}
 		}
 
@@ -2360,7 +2360,7 @@ int parse_weapon(int subtype, bool replace, const char *filename)
 			if (delay_multiplier > 0) {
 				wip->cmeasure_sucess_delay_multiplier_ai = delay_multiplier;
 			} else {
-				mprintf(("Warning: \"+Successful Launch Delay Multiplier for AI:\" should be >= 0 (read %i). Value will not be used. ", delay_multiplier));
+				Warning(LOCATION, "\"+Successful Launch Delay Multiplier for AI:\" should be >= 0 (read %i). Value will not be used. ", delay_multiplier);
 			}
 		}
 

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -2339,6 +2339,19 @@ int parse_weapon(int subtype, bool replace, const char *filename)
 		if (optional_string("+Pulse Interval:")) {
 			stuff_int(&wip->cmeasure_timer_interval);
 		}
+
+		if (optional_string("+Use Fire Wait:")) {
+			wip->cmeasure_firewait = (int) (wip->fire_wait*1000.0f);
+		}
+
+		if (optional_string("+Fail Delay Equals Fire Wait:")) {
+			stuff_boolean(&wip->cmeasure_faildelay_equals_firewait);
+		}
+
+		if (optional_string("+Successful Launch Delay Multiplier:")) {
+			stuff_int(&wip->cmeasure_sucess_delay_multiplier);
+		}
+
 	}
 
 	// beam weapon optional stuff
@@ -8355,6 +8368,10 @@ void weapon_info::reset()
 	this->cm_detonation_rad = CMEASURE_DETONATE_DISTANCE;
 	this->cm_kill_single = false;
 	this->cmeasure_timer_interval = 0;
+	this->cmeasure_firewait = CMEASURE_WAIT;
+	this->cmeasure_sucess_delay_multiplier = 2;
+	this->cmeasure_use_firewait = false;
+	this->cmeasure_faildelay_equals_firewait = false;
 
 	this->weapon_submodel_rotate_accell = 10.0f;
 	this->weapon_submodel_rotate_vel = 0.0f;


### PR DESCRIPTION
This PR provides modders with additional options to alter countermeasure values. Previously, countermeasures had a fixed, hardcoded fire wait time of 333 milliseconds, regardless of what `$Fire Wait:` was specified. Also, the AI would wait a fixed delay between firing of failed countermeasure launches and successful countermeasure launches. For successful launches the AI would double the fire wait. Also, Friendly ships would only use a fixed constant value for countermeasure firing chance, and not the value based on their class specific AI profile.

This PR exposes those values with the following options:

- Add main AI table flag: `$friendly ships use AI profile countermeasure chance:`. This will allow Friendly ships to use their AI class profile countermeasure firing chance instead of the default fixed value from main AI table.

- Add value in CM section of weapons table: Countermeasures use fire wait time `+Use Fire Wait`. This is a boolean that allows the countermeasure’s fire wait to actually use what is specified in the `$Fire Wait:` section of that weapon.

- Add value in CM section weapons table: `+Fail Delay Equals Fire Wait`. The delay between failed countermeasure launches is set to use the fire wait value.

- Add value in CM section weapons table: `+Successful Launch Delay Multiplier`. This allows modders to set the value that is multiplied to fire wait for successful countermeasure launches.

Everything is tested and works as expected.