### PR TITLE
Add 'landmark' logging

### DIFF
--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -2457,23 +2457,20 @@ int parse_create_object_sub(p_object *p_objp)
 
 	// If the ship is in a wing, this will be done in mission_set_wing_arrival_location() instead
 	// If the ship is in a wing, but the wing is docked then addition of bool brought_in_docked_wing accounts for that status --wookieejedi
-	if (Game_mode & GM_IN_MISSION) {
+	if (Game_mode & GM_IN_MISSION && ((shipp->wingnum == -1) || (brought_in_docked_wing))) {
+		object *anchor_objp = (anchor_objnum >= 0) ? &Objects[anchor_objnum] : nullptr;
 
-		if (Ship_info[shipp->ship_info_index].is_big_or_huge()) {
-			float mission_time = f2fl(Missiontime);
-			int minutes = (int)(mission_time / 60);
-			int seconds = (int)mission_time % 60;
+		Script_system.SetHookObjects(2, "Ship", &Objects[objnum], "Parent", anchor_objp);
+		Script_system.RunCondition(CHA_ONSHIPARRIVE, &Objects[objnum]);
+		Script_system.RemHookVars({"Ship", "Parent"});
+	}
 
-			mprintf(("%s arrived at %02d:%02d\n", shipp->ship_name, minutes, seconds));
-		}
+	if (Game_mode & GM_IN_MISSION && Ship_info[shipp->ship_info_index].is_big_or_huge()) {
+		float mission_time = f2fl(Missiontime);
+		int minutes = (int)(mission_time / 60);
+		int seconds = (int)mission_time % 60;
 
-		if ((shipp->wingnum == -1) || (brought_in_docked_wing)) {
-			object* anchor_objp = (anchor_objnum >= 0) ? &Objects[anchor_objnum] : nullptr;
-
-			Script_system.SetHookObjects(2, "Ship", &Objects[objnum], "Parent", anchor_objp);
-			Script_system.RunCondition(CHA_ONSHIPARRIVE, &Objects[objnum]);
-			Script_system.RemHookVars({"Ship", "Parent"});
-		}
+		mprintf(("%s arrived at %02d:%02d\n", shipp->ship_name, minutes, seconds));
 	}
 
 	return objnum;

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -2463,14 +2463,14 @@ int parse_create_object_sub(p_object *p_objp)
 		Script_system.SetHookObjects(2, "Ship", &Objects[objnum], "Parent", anchor_objp);
 		Script_system.RunCondition(CHA_ONSHIPARRIVE, &Objects[objnum]);
 		Script_system.RemHookVars({"Ship", "Parent"});
-	}
 
-	if (Game_mode & GM_IN_MISSION && Ship_info[shipp->ship_info_index].is_big_or_huge()) {
-		float mission_time = f2fl(Missiontime);
-		int minutes = (int)(mission_time / 60);
-		int seconds = (int)mission_time % 60;
+		if (Ship_info[shipp->ship_info_index].is_big_or_huge() && !brought_in_docked_wing) {
+			float mission_time = f2fl(Missiontime);
+			int minutes = (int)(mission_time / 60);
+			int seconds = (int)mission_time % 60;
 
-		mprintf(("%s arrived at %02d:%02d\n", shipp->ship_name, minutes, seconds));
+			mprintf(("%s arrived at %02d:%02d\n", shipp->ship_name, minutes, seconds));
+		}
 	}
 
 	return objnum;

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -2457,12 +2457,23 @@ int parse_create_object_sub(p_object *p_objp)
 
 	// If the ship is in a wing, this will be done in mission_set_wing_arrival_location() instead
 	// If the ship is in a wing, but the wing is docked then addition of bool brought_in_docked_wing accounts for that status --wookieejedi
-	if (Game_mode & GM_IN_MISSION && ((shipp->wingnum == -1) || (brought_in_docked_wing))) {
-		object *anchor_objp = (anchor_objnum >= 0) ? &Objects[anchor_objnum] : nullptr;
+	if (Game_mode & GM_IN_MISSION) {
 
-		Script_system.SetHookObjects(2, "Ship", &Objects[objnum], "Parent", anchor_objp);
-		Script_system.RunCondition(CHA_ONSHIPARRIVE, &Objects[objnum]);
-		Script_system.RemHookVars({"Ship", "Parent"});
+		if (Ship_info[shipp->ship_info_index].is_big_or_huge()) {
+			float mission_time = f2fl(Missiontime);
+			int minutes = (int)(mission_time / 60);
+			int seconds = (int)mission_time % 60;
+
+			mprintf(("%s arrived at %02d:%02d\n", shipp->ship_name, minutes, seconds));
+		}
+
+		if ((shipp->wingnum == -1) || (brought_in_docked_wing)) {
+			object* anchor_objp = (anchor_objnum >= 0) ? &Objects[anchor_objnum] : nullptr;
+
+			Script_system.SetHookObjects(2, "Ship", &Objects[objnum], "Parent", anchor_objp);
+			Script_system.RunCondition(CHA_ONSHIPARRIVE, &Objects[objnum]);
+			Script_system.RemHookVars({"Ship", "Parent"});
+		}
 	}
 
 	return objnum;

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -15898,6 +15898,14 @@ void sexp_ship_create(int n)
 	Script_system.SetHookObjects(2, "Ship", &Objects[objnum], "Parent", nullptr);
 	Script_system.RunCondition(CHA_ONSHIPARRIVE, &Objects[objnum]);
 	Script_system.RemHookVars({"Ship", "Parent"});
+
+	if (Game_mode & GM_IN_MISSION && sip->is_big_or_huge()) {
+		float mission_time = f2fl(Missiontime);
+		int minutes = (int)(mission_time / 60);
+		int seconds = (int)mission_time % 60;
+
+		mprintf(("%s created at %02d:%02d\n", shipp->ship_name, minutes, seconds));
+	}
 }
 
 // Goober5000

--- a/code/scripting/api/libs/mission.cpp
+++ b/code/scripting/api/libs/mission.cpp
@@ -913,7 +913,9 @@ ADE_FUNC(createShip,
 			shipp->team = team;
 		}
 
-		model_page_in_textures(Ship_info[sclass].model_num, sclass);
+		ship_info* sip = &Ship_info[sclass];
+
+		model_page_in_textures(sip->model_num, sclass);
 
 		ship_set_warp_effects(&Objects[obj_idx]);
 
@@ -924,7 +926,7 @@ ADE_FUNC(createShip,
 			shipp->flags.set(Ship::Ship_Flags::Has_display_name);
 		}
 
-		if (Ship_info[sclass].flags[Ship::Info_Flags::Intrinsic_no_shields]) {
+		if (sip->flags[Ship::Info_Flags::Intrinsic_no_shields]) {
 			Objects[obj_idx].flags.set(Object::Object_Flags::No_shields);
 		}
 
@@ -933,6 +935,14 @@ ADE_FUNC(createShip,
 		Script_system.SetHookObjects(2, "Ship", &Objects[obj_idx], "Parent", NULL);
 		Script_system.RunCondition(CHA_ONSHIPARRIVE, &Objects[obj_idx]);
 		Script_system.RemHookVars({"Ship", "Parent"});
+
+		if (Game_mode & GM_IN_MISSION && sip->is_big_or_huge()) {
+			float mission_time = f2fl(Missiontime);
+			int minutes = (int)(mission_time / 60);
+			int seconds = (int)mission_time % 60;
+
+			mprintf(("%s created at %02d:%02d\n", shipp->ship_name, minutes, seconds));
+		}
 
 		return ade_set_args(L, "o", l_Ship.Set(object_h(&Objects[obj_idx])));
 	} else

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -7910,31 +7910,27 @@ void ship_cleanup(int shipnum, int cleanup_mode)
 		Script_system.RemHookVars({"Ship", "Method", "JumpNode"});
 	}
 
-#ifndef NDEBUG
-	switch (cleanup_mode) {
-	case SHIP_DESTROYED:
-		nprintf(("Alan", "SHIP DESTROYED: %s'\n'", shipp->ship_name));
-		break;
-	case SHIP_DEPARTED:
-	case SHIP_DEPARTED_WARP:
-	case SHIP_DEPARTED_BAY:
-		nprintf(("Alan", "SHIP DEPARTED: %s'\n'", shipp->ship_name));
-		break;
-	case SHIP_DESTROYED_REDALERT:
-		nprintf(("Alan", "SHIP REDALERT DESTROYED: %s'\n'", shipp->ship_name));
-		break;
-	case SHIP_DEPARTED_REDALERT:
-		nprintf(("Alan", "SHIP REDALERT DEPARTED: %s'\n'", shipp->ship_name));
-		break;
-	case SHIP_VANISHED:
-		nprintf(("Alan", "SHIP VANISHED: %s'\n'", shipp->ship_name));
-		break;
-	default:
-		// Can't Happen, but we should've already caught this
-		UNREACHABLE("Unknown cleanup_mode '%i' passed to ship_cleanup!", cleanup_mode);
-		break;
+	if (Ship_info[shipp->ship_info_index].is_big_or_huge()) {
+		float mission_time = f2fl(Missiontime);  
+		int minutes = (int)(mission_time / 60);
+		int seconds = (int)mission_time % 60;
+
+		switch (cleanup_mode) {
+		case SHIP_DESTROYED:
+			mprintf(("%s destroyed at %02d:%02d\n", shipp->ship_name, minutes, seconds));
+			break;
+		case SHIP_DEPARTED:
+		case SHIP_DEPARTED_WARP:
+		case SHIP_DEPARTED_BAY:
+			mprintf(("%s departed at %02d:%02d\n", shipp->ship_name, minutes, seconds));
+			break;
+		case SHIP_VANISHED:
+			mprintf(("%s vanished at %02d:%02d\n", shipp->ship_name, minutes, seconds));
+			break;
+		default:
+			break;
+		}
 	}
-#endif
 
 	// update wingman status gauge
 	if ( (shipp->wing_status_wing_index >= 0) && (shipp->wing_status_wing_pos >= 0) ) {


### PR DESCRIPTION
When looking at a debug log for more than just the particular error/warning, and attempting to narrow down a particular time frame for perhaps when an error may have occurred, there are very few landmarks to help get an idea of where in a mission something happens just through the log. Shader compilations, ani warnings, assorted minor errors, frames "too long" all are pretty useless to determine what the heck is going on in the mission at the time, even if you know what all these are.

This adds what I like to call 'landmark' logging. Merely prints when big|huge ships arrive, depart, or are destroyed providing 'landmarks' for orienting oneself temporally. Shouldn't be too spammy either, even in the worst scenarios several dozen prints will hardly put a dent in it.

For the non-arriving situation, some existing code was repurposed that was being filtered out, being `nprintf`'s.