### PR TITLE
Overhaul briefing icon parsing

### DIFF
--- a/code/mission/missionbriefcommon.cpp
+++ b/code/mission/missionbriefcommon.cpp
@@ -303,7 +303,7 @@ int add_briefing_icons() {
 
 	Briefing_icon_info.push_back(bii);
 
-	return Briefing_icon_info.size() - 1;
+	return (int)Briefing_icon_info.size() - 1;
 }
 
 void brief_icon_parse_cleanup() {
@@ -316,7 +316,7 @@ void brief_icon_parse_cleanup() {
 		int lender_species = spinfo.borrows_bii_index_species;
 
 		for (int i = 0; i < MIN_BRIEF_ICONS; i++) {
-			spinfo.bii_index[i] = Species_info[lender_species].bii_index[i];
+			spinfo.bii_indices[i] = Species_info[lender_species].bii_indices[i];
 		}
 	}
 
@@ -326,7 +326,7 @@ void brief_icon_parse_cleanup() {
 	for (species_info spinfo : Species_info) {
 		bool missing_icon_species = false;
 		for (int i = 0; i < MIN_BRIEF_ICONS; i++) {
-			if (spinfo.bii_index[i] < 0) {
+			if (spinfo.bii_indices[i] < 0) {
 				mprintf(("Species %s missing %s icon\n", spinfo.species_name, Icon_names[i]));
 				missing_icons = missing_icon_species = true;
 			}
@@ -398,7 +398,7 @@ void brief_parse_icon_tbl(const char* filename)
 						Warning(LOCATION, "Icon Type %s is invalid, in icons.tbl.", name);
 					}
 
-					int &existing_bii_index = Species_info[spinfo_index].bii_index[icon_type];
+					int &existing_bii_index = Species_info[spinfo_index].bii_indices[icon_type];
 
 					if (existing_bii_index >= 0) { // overwriting
 						briefing_icon_info bii = parse_briefing_icons();
@@ -414,11 +414,11 @@ void brief_parse_icon_tbl(const char* filename)
 			}
 		}
 		else { // old style
-			for (int icon_type = 0; icon_type < (int)MIN_BRIEF_ICONS; icon_type++) {
+			for (int icon_type = 0; icon_type < MIN_BRIEF_ICONS; icon_type++) { // NOLINT(modernize-loop-convert)
 				for (species = 0; species < unique_icons_species.size(); species++) {
 					// if this check isn't true we're missing entries and will complain about it later in brief_icon_parse_cleanup()
 					if (check_for_string("$Name:"))
-						Species_info[unique_icons_species[species]].bii_index[icon_type] = add_briefing_icons();
+						Species_info[unique_icons_species[species]].bii_indices[icon_type] = add_briefing_icons();
 				}
 			}
 
@@ -683,7 +683,7 @@ briefing_icon_info *brief_get_icon_info(brief_icon *bi)
 	if (sip->species < 0)
 		return NULL;
 
-	int bii_index = Species_info[sip->species].bii_index[bi->type];
+	int bii_index = Species_info[sip->species].bii_indices[bi->type];
 	if (bii_index < 0)
 		return NULL;
 

--- a/code/mission/missionbriefcommon.cpp
+++ b/code/mission/missionbriefcommon.cpp
@@ -332,22 +332,17 @@ void brief_icon_parse_cleanup() {
 			}
 		}
 		
-		if (missing_icon_species)
+		if (missing_icon_species) {
 			errormsg += spinfo.species_name;
+			errormsg += "\n";
+		}
+			
 	}
 
 	if (missing_icons) {
-		errormsg += "\nAn exact list of the missing entries has been logged.";
+		errormsg += "An exact list of the missing entries has been logged.";
 		Warning(LOCATION, "%s", errormsg.c_str());
 	}
-	/*
-	const size_t max_icons = Species_info.size() * MIN_BRIEF_ICONS;
-
-	if (!optional_string("#End")) {
-		Warning(LOCATION, "Too many icons in icons.tbl; only the first " SIZE_T_ARG " will be used", max_icons);
-		skip_to_start_of_string("#End");
-		required_string("#End");
-	}*/
 }
 
 // --------------------------------------------------------------------------------------
@@ -356,7 +351,6 @@ void brief_icon_parse_cleanup() {
 //
 void brief_parse_icon_tbl(const char* filename)
 {
-	int icon;
 	size_t species;
 	char name[MAX_FILENAME_LEN];
 
@@ -422,7 +416,9 @@ void brief_parse_icon_tbl(const char* filename)
 		else { // old style
 			for (int icon_type = 0; icon_type < (int)MIN_BRIEF_ICONS; icon_type++) {
 				for (species = 0; species < unique_icons_species.size(); species++) {
-					Species_info[unique_icons_species[species]].bii_index[icon_type] = add_briefing_icons();
+					// if this check isn't true we're missing entries and will complain about it later in brief_icon_parse_cleanup()
+					if (check_for_string("$Name:"))
+						Species_info[unique_icons_species[species]].bii_index[icon_type] = add_briefing_icons();
 				}
 			}
 

--- a/code/mission/missionbriefcommon.cpp
+++ b/code/mission/missionbriefcommon.cpp
@@ -274,85 +274,177 @@ void	brief_set_text_color(char color_tag);
 extern void get_camera_limits(const matrix *start_camera, const matrix *end_camera, float time, vec3d *acc_max, vec3d *w_max);
 int brief_text_wipe_finished();
 
+// parses, fills and returns a briefing_icon_info struct
+briefing_icon_info parse_briefing_icons() {
+	char name[MAX_FILENAME_LEN];
+	briefing_icon_info bii;
+
+	// parse regular frames
+	required_string("$Name:");
+	stuff_string(name, F_NAME, MAX_FILENAME_LEN);
+	generic_anim_init(&bii.regular, name);
+
+	// parse fade frames
+	required_string("$Name:");
+	stuff_string(name, F_NAME, MAX_FILENAME_LEN);
+	hud_anim_init(&bii.fade, 0, 0, name);
+
+	// parse highlighting frames
+	required_string("$Name:");
+	stuff_string(name, F_NAME, MAX_FILENAME_LEN);
+	hud_anim_init(&bii.highlight, 0, 0, name);
+
+	return bii;
+}
+
+// parses and adds a briefing_icon_info into the global vector
+int add_briefing_icons() {
+	briefing_icon_info bii = parse_briefing_icons();
+
+	Briefing_icon_info.push_back(bii);
+
+	return Briefing_icon_info.size() - 1;
+}
+
+void brief_icon_parse_cleanup() {
+
+	// assign "borrows" icons
+	for (species_info &spinfo : Species_info) {
+		if (spinfo.borrows_bii_index_species < 0)
+			continue;
+
+		int lender_species = spinfo.borrows_bii_index_species;
+
+		for (int i = 0; i < MIN_BRIEF_ICONS; i++) {
+			spinfo.bii_index[i] = Species_info[lender_species].bii_index[i];
+		}
+	}
+
+	SCP_string errormsg = "The following species are missing briefing icons:\n";
+	bool missing_icons = false;
+
+	for (species_info spinfo : Species_info) {
+		bool missing_icon_species = false;
+		for (int i = 0; i < MIN_BRIEF_ICONS; i++) {
+			if (spinfo.bii_index[i] < 0) {
+				mprintf(("Species %s missing %s icon\n", spinfo.species_name, Icon_names[i]));
+				missing_icons = missing_icon_species = true;
+			}
+		}
+		
+		if (missing_icon_species)
+			errormsg += spinfo.species_name;
+	}
+
+	if (missing_icons) {
+		errormsg += "\nAn exact list of the missing entries has been logged.";
+		Warning(LOCATION, "%s", errormsg.c_str());
+	}
+	/*
+	const size_t max_icons = Species_info.size() * MIN_BRIEF_ICONS;
+
+	if (!optional_string("#End")) {
+		Warning(LOCATION, "Too many icons in icons.tbl; only the first " SIZE_T_ARG " will be used", max_icons);
+		skip_to_start_of_string("#End");
+		required_string("#End");
+	}*/
+}
+
 // --------------------------------------------------------------------------------------
 //	brief_parse_icon_tbl()
 //
 //
-void brief_parse_icon_tbl()
+void brief_parse_icon_tbl(const char* filename)
 {
 	int icon;
 	size_t species;
 	char name[MAX_FILENAME_LEN];
 
 	Assert(!Species_info.empty());
-	const size_t max_icons = Species_info.size() * MIN_BRIEF_ICONS;
 
 	try
 	{
-		read_file_text("icons.tbl", CF_TYPE_TABLES);
+		read_file_text(filename, CF_TYPE_TABLES);
 		reset_parse();
 
 		required_string("#Start");
 
-		Briefing_icon_info.clear();
-		while (required_string_either("#End", "$Name:"))
-		{
-			if (Briefing_icon_info.size() >= max_icons) {
+		// get all the species who are using unique icons (i.e. not borrowing from another species)
+		SCP_vector<int> unique_icons_species;
+		for (int i = 0; i < (int)Species_info.size(); i++) {
+			if (Species_info[i].borrows_bii_index_species == -1)
+				unique_icons_species.push_back(i);
+		}
+
+		bool new_style_parsing = false;
+		if (check_for_string("$Species:"))
+			new_style_parsing = true;
+
+		if (new_style_parsing) {
+			while (optional_string("$Species:")) {
+				stuff_string(name, F_NAME, MAX_FILENAME_LEN);
+				int spinfo_index = species_info_lookup(name);
+
+				if (spinfo_index < 0) {
+					Warning(LOCATION, "Unable to find species %s, in icons.tbl.", name);
+				}
+
+				while (optional_string("$Icon Type:")) {
+					stuff_string(name, F_NAME, MAX_FILENAME_LEN);
+					int icon_type = [&]() {
+						for (int i = 0; i < MIN_BRIEF_ICONS; i++) {
+							if (strcmp(Icon_names[i], name) == 0) {
+								return i;
+							}
+						}
+						return -1;
+					}();
+
+					if (icon_type < 0) {
+						Warning(LOCATION, "Icon Type %s is invalid, in icons.tbl.", name);
+					}
+
+					int &existing_bii_index = Species_info[spinfo_index].bii_index[icon_type];
+
+					if (existing_bii_index >= 0) { // overwriting
+						briefing_icon_info bii = parse_briefing_icons();
+						if (icon_type >= 0 && spinfo_index >= 0)
+							Briefing_icon_info[existing_bii_index] = bii;
+					} else { // adding a new one
+						int new_bii_index = add_briefing_icons();
+						if (icon_type >= 0 && spinfo_index >= 0)
+							existing_bii_index = new_bii_index;
+					}
+
+				}
+			}
+		}
+		else { // old style
+			for (int icon_type = 0; icon_type < (int)MIN_BRIEF_ICONS; icon_type++) {
+				for (species = 0; species < unique_icons_species.size(); species++) {
+					Species_info[unique_icons_species[species]].bii_index[icon_type] = add_briefing_icons();
+				}
+			}
+
+			const size_t max_icons = unique_icons_species.size() * MIN_BRIEF_ICONS;
+			if (!check_for_string("#End"))
 				Warning(LOCATION, "Too many icons in icons.tbl; only the first " SIZE_T_ARG " will be used", max_icons);
-				skip_to_start_of_string("#End");
-				break;
-			}
-
-			briefing_icon_info bii;
-
-			// parse regular frames
-			required_string("$Name:");
-			stuff_string(name, F_NAME, MAX_FILENAME_LEN);
-			generic_anim_init(&bii.regular, name);
-
-			// parse fade frames
-			required_string("$Name:");
-			stuff_string(name, F_NAME, MAX_FILENAME_LEN);
-			hud_anim_init(&bii.fade, 0, 0, name);
-
-			// parse highlighting frames
-			required_string("$Name:");
-			stuff_string(name, F_NAME, MAX_FILENAME_LEN);
-			hud_anim_init(&bii.highlight, 0, 0, name);
-
-			// add it to the collection
-			Briefing_icon_info.push_back(bii);
-		}
-		required_string("#End");
-
-
-		// now assign the icons to their species
-		const size_t num_species_covered = Briefing_icon_info.size() / MIN_BRIEF_ICONS;
-		size_t bii_index = 0;
-		for (icon = 0; icon < MIN_BRIEF_ICONS; icon++)
-		{
-			for (species = 0; species < num_species_covered; species++)
-				Species_info[species].bii_index[icon] = (int)(bii_index++);
-		}
-
-		// error check
-		if (num_species_covered < Species_info.size())
-		{
-			SCP_string errormsg = "The following species are missing icon info in icons.tbl:\n";
-
-			for (species = num_species_covered; species < Species_info.size(); species++)
-			{
-				errormsg += Species_info[species].species_name;
-				errormsg += "\n";
-			}
-
-			Error(LOCATION, "%s", errormsg.c_str());
 		}
 	}
 	catch (const parse::ParseException& e)
 	{
 		mprintf(("TABLES: Unable to parse '%s'!  Error message = %s.\n", "icons.tbl", e.what()));
 	}
+}
+
+void brief_icons_init() {
+	Briefing_icon_info.clear();
+
+	brief_parse_icon_tbl("icons.tbl");
+
+	parse_modular_table(NOX("*-ico.tbm"), brief_parse_icon_tbl);
+
+	brief_icon_parse_cleanup();
 }
 
 void brief_set_icon_color(int team)

--- a/code/mission/missionbriefcommon.cpp
+++ b/code/mission/missionbriefcommon.cpp
@@ -385,12 +385,15 @@ void brief_parse_icon_tbl(const char* filename)
 
 				while (optional_string("$Icon Type:")) {
 					stuff_string(name, F_NAME, MAX_FILENAME_LEN);
+					// find the matching icon type
 					int icon_type = [&]() {
 						for (int i = 0; i < MIN_BRIEF_ICONS; i++) {
 							if (strcmp(Icon_names[i], name) == 0) {
+								// found it
 								return i;
 							}
 						}
+						// couldnt find it...
 						return -1;
 					}();
 

--- a/code/mission/missionbriefcommon.h
+++ b/code/mission/missionbriefcommon.h
@@ -297,7 +297,7 @@ void brief_camera_move(float frametime, int stage_num);
 void brief_render_icon(int stage_num, int icon_num, float frametime, int selected = 0, float w_scale_factor = 1.0f, float h_scale_factor = 1.0f);
 void brief_render_icon_line(int stage_num, int line_num);
 void brief_init_map();
-void brief_parse_icon_tbl();
+void brief_icons_init();
 void brief_common_close();
 void brief_reset_icons(int stage_num);
 void brief_restart_text_wipe();

--- a/code/species_defs/species_defs.cpp
+++ b/code/species_defs/species_defs.cpp
@@ -328,6 +328,14 @@ void parse_species_tbl(const char *filename)
 			if (optional_string("$Countermeasure type:"))
 				stuff_string(species->cmeasure_name, F_NAME, NAME_LENGTH);
 
+			if (optional_string("$Borrows Briefing Icons from:")) {
+				char temp_name[NAME_LENGTH];
+				stuff_string(temp_name, F_NAME, NAME_LENGTH);
+				int idx = species_info_lookup(temp_name);
+				if (idx >= 0)
+					species->borrows_bii_index_species = idx;
+			}
+
 
 			// don't add new entry if this is just a modified one
 			if (!no_create)

--- a/code/species_defs/species_defs.cpp
+++ b/code/species_defs/species_defs.cpp
@@ -334,6 +334,10 @@ void parse_species_tbl(const char *filename)
 				int idx = species_info_lookup(temp_name);
 				if (idx >= 0)
 					species->borrows_bii_index_species = idx;
+				else {
+					Warning(LOCATION, "Species %s for '$Borrows Briefing Icons from' in Species %s is either invalid or not yet parsed."
+									  "The Species doing the borrowing must be defined after the Species it is borrowing from\n", temp_name, species->species_name);
+				}
 			}
 
 

--- a/code/species_defs/species_defs.h
+++ b/code/species_defs/species_defs.h
@@ -70,6 +70,7 @@ public:
 	game_snd snd_flyby_bomber;
 
 	int bii_index[MIN_BRIEF_ICONS];
+	int borrows_bii_index_species;   // species that this species borrows all of its briefing icons from, -1 if none
 
 	// countermeasures by species
 	char cmeasure_name[NAME_LENGTH];
@@ -82,6 +83,7 @@ public:
 
 		cmeasure_name[0] = '\0';
 		cmeasure_index = -1;
+		borrows_bii_index_species = -1;
 	}
 };
 

--- a/code/species_defs/species_defs.h
+++ b/code/species_defs/species_defs.h
@@ -69,7 +69,7 @@ public:
 	game_snd snd_flyby_fighter;
 	game_snd snd_flyby_bomber;
 
-	int bii_index[MIN_BRIEF_ICONS];
+	int bii_indices[MIN_BRIEF_ICONS];
 	int borrows_bii_index_species;   // species that this species borrows all of its briefing icons from, -1 if none
 
 	// countermeasures by species
@@ -79,7 +79,7 @@ public:
 	species_info()
 	{
 		for (int i = 0; i < MIN_BRIEF_ICONS; i++)
-			bii_index[i] = -1;
+			bii_indices[i] = -1;
 
 		cmeasure_name[0] = '\0';
 		cmeasure_index = -1;

--- a/fred2/management.cpp
+++ b/fred2/management.cpp
@@ -380,7 +380,7 @@ bool fred_init(std::unique_ptr<os::GraphicsOperations>&& graphicsOps)
 	iff_init();			// Goober5000
 	species_init();		// Kazan
 
-	brief_parse_icon_tbl();
+	brief_icons_init();
 
 	// for fred specific replacement texture stuff
 	Fred_texture_replacements.clear();

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -1808,7 +1808,7 @@ void game_init()
 	iff_init();						// Goober5000 - this must be done even before species_defs :p
 	species_init();					// Load up the species defs - this needs to be done FIRST -- Kazan
 
-	brief_parse_icon_tbl();
+	brief_icons_init();
 
 	hud_init_comm_orders();	// Goober5000
 

--- a/qtfred/src/mission/management.cpp
+++ b/qtfred/src/mission/management.cpp
@@ -150,7 +150,7 @@ initialize(const std::string& cfilepath, int argc, char* argv[], Editor* editor,
 	species_init();        // Kazan
 
 	listener(SubSystem::BriefingIcons);
-	brief_parse_icon_tbl();
+	brief_icons_init();
 
 	// for fred specific replacement texture stuff
 	Fred_texture_replacements.clear();


### PR DESCRIPTION
Adds modular table support for icons.tbl, with xxx-ico.tbm. icons.tbl can use either the 'old style' or 'new style' (explicit $species and $icon type) definitions, but .tbms must be done in the new style.

Additionally adds '$Borrows Briefing Icons from:' to species, to simply copy another species' icons. Unfortunately, because this is done *after* modular table parsing, this will override modular tables and thus any species icons that were coped from another cannot be modified through modular tables. This is unideal, but if this copying is done before modular tables, not all icons may even be defined yet, and also changes made to a 'lender' species icons will not propagate to its associated 'borrower' species (although this may be desirable).

A more complex form of parsing would need to be done to resolve this in general, so I decided to pick the option I thought was more generally useful.