### PR TITLE
restore retail behavior of XSTR

### DIFF
--- a/code/cutscene/ffmpeg/FFMPEGDecoder.cpp
+++ b/code/cutscene/ffmpeg/FFMPEGDecoder.cpp
@@ -286,7 +286,7 @@ std::unique_ptr<DecoderStatus> initializeStatus(std::unique_ptr<InputStream>& st
 
 	if (status->subtitleStream == nullptr) {
 		// We don't have an external subtitle stream or loading from that file has failed
-		auto& current_language = Lcl_languages[Lcl_current_lang == LCL_UNTRANSLATED ? LCL_DEFAULT : Lcl_current_lang];
+		auto& current_language = Lcl_languages[lcl_get_current_lang_index()];
 		for (uint32_t i = 0; i < ctx->nb_streams; ++i) {
 			auto test_stream = ctx->streams[i];
 
@@ -428,7 +428,7 @@ std::unique_ptr<InputStream> openInputStream(const SCP_string& name) {
 
 std::unique_ptr<InputStream> openSubtitleStream(const SCP_string& name)
 {
-	auto& current_language = Lcl_languages[Lcl_current_lang == LCL_UNTRANSLATED ? LCL_DEFAULT : Lcl_current_lang];
+	auto& current_language = Lcl_languages[lcl_get_current_lang_index()];
 
 	for (auto ext : CHECKED_SUBT_EXTENSIONS) {
 		SCP_string fileName;

--- a/code/localization/localize.h
+++ b/code/localization/localize.h
@@ -26,6 +26,7 @@
 #define LCL_POLISH						3
 
 #define LCL_UNTRANSLATED				10	// this should be higher than the highest builtin language
+#define LCL_RETAIL_HYBRID				11	// ditto; this is the weird retail behavior where internal is translated but external isn't
 #define	LCL_DEFAULT						0
 
 // for language name strings
@@ -69,6 +70,10 @@ extern bool *Lcl_unexpected_tstring_check;
 // ------------------------------------------------------------------------------------------------------------
 // LOCALIZE FUNCTIONS
 //
+
+// get an index we can use to look into the array, since we now have three different ways of using English
+// (translated, untranslated, and hybrid: internal translated, external untranslated)
+int lcl_get_current_lang_index();
 
 // initialize localization, if no language is passed - use the language specified in the registry
 void lcl_init(int lang = -1);

--- a/code/scripting/api/libs/base.cpp
+++ b/code/scripting/api/libs/base.cpp
@@ -492,8 +492,16 @@ ADE_FUNC(getCurrentLanguage,
 		 nullptr,
 		 "Determines the language that is being used by the engine. This returns the full name of the language (e.g. \"English\").",
 		 "string",
-		 "The current game language") {
-	auto lang_name = (Lcl_current_lang == LCL_UNTRANSLATED) ? "UNTRANSLATED" : Lcl_languages[Lcl_current_lang].lang_name;
+		 "The current game language")
+{
+	const char *lang_name;
+	if (Lcl_current_lang == LCL_UNTRANSLATED)
+		lang_name = "UNTRANSLATED";
+	else if (Lcl_current_lang == LCL_RETAIL_HYBRID)
+		lang_name = "RETAIL HYBRID";
+	else
+		lang_name = Lcl_languages[lcl_get_current_lang_index()].lang_name;
+
 	return ade_set_args(L, "s", lang_name);
 }
 
@@ -504,8 +512,9 @@ ADE_FUNC(getCurrentLanguageExtension,
 			 "This returns a short code for the current language that can be used for creating language specific file names (e.g. \"gr\" when the current language is German). "
 			 "This will return an empty string for the default language.",
 		 "string",
-		 "The current game language") {
-	int lang = (Lcl_current_lang == LCL_UNTRANSLATED) ? LCL_DEFAULT : Lcl_current_lang;
+		 "The current game language")
+{
+	int lang = lcl_get_current_lang_index();
 	return ade_set_args(L, "s", Lcl_languages[lang].lang_ext);
 }
 


### PR DESCRIPTION
This is a follow-up to #2390.  Retail used a weird hybrid approach where internal strings were translated but external strings were not.  This restores that behavior by adding another language, LCL_RETAIL_HYBRID, which is the default.  The game can still be run in completely untranslated or completely translated mode.

All three modes have been tested and translate strings, or not, as expected.  The `$Use tabled strings for the default language:` flag has also been tested and still works.