### PR TITLE
fix event editor closing on key press

### DIFF
--- a/fred2/eventeditor.cpp
+++ b/fred2/eventeditor.cpp
@@ -141,7 +141,7 @@ BEGIN_MESSAGE_MAP(event_editor, CDialog)
 	ON_NOTIFY(TVN_ENDLABELEDIT, IDC_EVENT_TREE, OnEndlabeleditEventTree)
 	ON_BN_CLICKED(IDC_BUTTON_NEW_EVENT, OnButtonNewEvent)
 	ON_BN_CLICKED(IDC_DELETE, OnDelete)
-	ON_BN_CLICKED(ID_OK, OnOk)
+	ON_BN_CLICKED(ID_OK, OnButtonOk)
 	ON_WM_CLOSE()
 	ON_NOTIFY(TVN_SELCHANGED, IDC_EVENT_TREE, OnSelchangedEventTree)
 	ON_EN_UPDATE(IDC_REPEAT_COUNT, OnUpdateRepeatCount)
@@ -156,7 +156,7 @@ BEGIN_MESSAGE_MAP(event_editor, CDialog)
 	ON_CBN_SELCHANGE(IDC_WAVE_FILENAME, OnSelchangeWaveFilename)
 	ON_BN_CLICKED(IDC_PLAY, OnPlay)
 	ON_BN_CLICKED(IDC_UPDATE, OnUpdate)
-	ON_BN_CLICKED(ID_CANCEL, OnCancel)
+	ON_BN_CLICKED(ID_CANCEL, OnButtonCancel)
 	ON_CBN_SELCHANGE(IDC_EVENT_TEAM, OnSelchangeTeam)
 	ON_CBN_SELCHANGE(IDC_MESSAGE_TEAM, OnSelchangeMessageTeam)
 	ON_LBN_DBLCLK(IDC_MESSAGE_LIST, OnDblclkMessageList)
@@ -425,6 +425,24 @@ void event_editor::OnEndlabeleditEventTree(NMHDR* pNMHDR, LRESULT* pResult)
 	*pResult = m_event_tree.end_label_edit(pTVDispInfo->item);
 }
 
+// This is needed as a HACK around default MFC standard
+// It is not required, but overrides default MFC and links no errors without.
+// (Specifically, this overrides the MFC behavior so that pressing Enter doesn't close the dialog)
+void event_editor::OnOK()
+{
+	HWND h;
+	CWnd *w;
+
+	save();
+	w = GetFocus();
+	if (w) {
+		h = w->m_hWnd;
+		GetDlgItem(IDC_EVENT_TREE)->SetFocus();
+		::SetFocus(h);
+	}
+	((CListBox *)GetDlgItem(IDC_MESSAGE_LIST))->SetCurSel(m_cur_msg);
+}
+
 int event_editor::query_modified()
 {
 	int i;
@@ -500,7 +518,7 @@ int event_editor::query_modified()
 	return 0;
 }
 
-void event_editor::OnOk()
+void event_editor::OnButtonOk()
 {
 	char buf[256], names[2][MAX_MISSION_EVENTS][NAME_LENGTH];
 	int i, count;
@@ -829,8 +847,13 @@ void event_editor::OnDelete()
 	}
 }
 
-// this is called the clicking the ID_CANCEL button
+// this is called when you hit the escape key..
 void event_editor::OnCancel()
+{
+}
+
+// this is called the clicking the ID_CANCEL button
+void event_editor::OnButtonCancel()
 {
 	audiostream_close_file(m_wave_id, 0);
 	m_wave_id = -1;
@@ -856,7 +879,7 @@ void event_editor::OnClose()
 		}
 
 		if (z == IDYES) {
-			OnOk();
+			OnButtonOk();
 			return;
 		}
 	}

--- a/fred2/eventeditor.h
+++ b/fred2/eventeditor.h
@@ -62,6 +62,8 @@ public:
 	void swap_handler(int node1, int node2);
 	void insert_handler(int old, int node);
 	int query_modified();
+	void OnOK();		// default MFC OK behavior
+	void OnCancel();	// default MFC Cancel behavior
 	int handler(int code, int node, const char *str = nullptr);
 	void create_tree();
 	void load_tree();
@@ -126,7 +128,8 @@ protected:
 	afx_msg void OnEndlabeleditEventTree(NMHDR* pNMHDR, LRESULT* pResult);
 	afx_msg void OnButtonNewEvent();
 	afx_msg void OnDelete();
-	afx_msg void OnOk();
+	afx_msg void OnButtonOk();
+	afx_msg void OnButtonCancel();
 	afx_msg void OnClose();
 	afx_msg void OnSelchangedEventTree(NMHDR* pNMHDR, LRESULT* pResult);
 	afx_msg void OnUpdateRepeatCount();
@@ -141,7 +144,6 @@ protected:
 	afx_msg void OnSelchangeWaveFilename();
 	afx_msg void OnPlay();
 	afx_msg void OnUpdate();
-	afx_msg void OnCancel();
 	afx_msg void OnSelchangeTeam();
 	afx_msg void OnSelchangeMessageTeam();
 	afx_msg void OnDblclkMessageList();


### PR DESCRIPTION
Restores the MFC functions that were taken out in #3073.  These functions appeared redundant, but they were actually necessary to intercept the MFC handling of Enter and Escape.  In addition to fixing that behavior, this PR also adds some clarifying comments and renames some functions to prevent confusion.