### PR TITLE
add model instance support to FRED rendering

### DIFF
--- a/fred2/fredrender.cpp
+++ b/fred2/fredrender.cpp
@@ -1799,14 +1799,14 @@ void render_one_model_htl(object *objp) {
 		if (Fred_outline) {
 			render_info.set_color(Fred_outline >> 16, (Fred_outline >> 8) & 0xff, Fred_outline & 0xff);
 			render_info.set_flags(j | MR_SHOW_OUTLINE_HTL | MR_NO_LIGHTING | MR_NO_POLYS | MR_NO_TEXTURING);
-			model_render_immediate(&render_info, Ship_info[Ships[z].ship_info_index].model_num, &objp->orient, &objp->pos);
+			model_render_immediate(&render_info, Ship_info[Ships[z].ship_info_index].model_num, Ships[z].model_instance_num, &objp->orient, &objp->pos);
 		}
 
 		g3_done_instance(0);
 
 		if (Show_ship_models) {
 			render_info.set_flags(j);
-			model_render_immediate(&render_info, Ship_info[Ships[z].ship_info_index].model_num, &objp->orient, &objp->pos);
+			model_render_immediate(&render_info, Ship_info[Ships[z].ship_info_index].model_num, Ships[z].model_instance_num, &objp->orient, &objp->pos);
 		}
 	} else {
 		int r = 0, g = 0, b = 0;

--- a/fred2/management.cpp
+++ b/fred2/management.cpp
@@ -521,18 +521,16 @@ void fix_ship_name(int ship)
 
 int create_ship(matrix *orient, vec3d *pos, int ship_type)
 {
-	// Save the Current Working dir to restore in a minute - fred is being stupid
-	char pwd[MAX_PATH_LEN];
-	getcwd(pwd, MAX_PATH_LEN); // get the present working dir - probably <fs2path>[/modpapth]/data/missions/
-	
-
 	int obj, z1, z2;
 	float temp_max_hull_strength;
 	ship_info *sip;
 
-	// "pop" and cfile_chdirs off the sta
-	chdir(Fred_base_dir);
+	// Save the Current Working dir to restore in a minute - fred is being stupid
+	char pwd[MAX_PATH_LEN];
+	getcwd(pwd, MAX_PATH_LEN); // get the present working dir - probably <fs2path>[/modpath]/data/missions/
 
+	// "pop" and cfile_chdirs off the stack
+	chdir(Fred_base_dir);
 
 	obj = ship_create(orient, pos, ship_type);
 	if (obj == -1)
@@ -548,6 +546,9 @@ int create_ship(matrix *orient, vec3d *pos, int ship_type)
 
 	if (query_ship_name_duplicate(Objects[obj].instance))
 		fix_ship_name(Objects[obj].instance);
+
+	// set up model stuff - only needs to be done once, not every frame
+	model_set_up_techroom_instance(sip, shipp->model_instance_num);
 
 	// default stuff according to species and IFF
 	shipp->team = Species_info[Ship_info[shipp->ship_info_index].species].default_iff;


### PR DESCRIPTION
This changes FRED to properly initialize a model instance on ship creation and also use that instance when rendering the ship.  This prevents destroyed submodels from appearing.  Fixes #3212.