### PR TITLE
additional case functions and checks

### DIFF
--- a/code/cfile/cfile.cpp
+++ b/code/cfile/cfile.cpp
@@ -287,7 +287,7 @@ static int _cfile_chdir(const char *new_dir, const char *cur_dir __UNUSED)
 	const char *colon = strchr(new_dir, ':');
 
 	if (colon) {
-		if (!cfile_chdrive(tolower(*(colon - 1)) - 'a' + 1, 1))
+		if (!cfile_chdrive(SCP_tolower(*(colon - 1)) - 'a' + 1, 1))
 			return 1;
 
 		path = colon + 1;
@@ -305,7 +305,7 @@ static int _cfile_chdir(const char *new_dir, const char *cur_dir __UNUSED)
 	status = _chdir(path);
 	if (status != 0) {
 #ifdef _WIN32
-		cfile_chdrive(tolower(cur_dir[0]) - 'a' + 1, 1);
+		cfile_chdrive(SCP_tolower(cur_dir[0]) - 'a' + 1, 1);
 #endif /* _WIN32 */
 		return 2;
 	}

--- a/code/cutscene/ffmpeg/FFMPEGDecoder.cpp
+++ b/code/cutscene/ffmpeg/FFMPEGDecoder.cpp
@@ -453,7 +453,7 @@ bool FFMPEGDecoder::initialize(const SCP_string& fileName, const PlaybackPropert
 {
 	SCP_string movieName = fileName;
 	// First make the file name lower case
-	std::transform(movieName.begin(), movieName.end(), movieName.begin(), [](char c) { return (char)::tolower(c); });
+	SCP_tolower(movieName);
 
 	// Then remove the extension
 	size_t dotPos = movieName.find('.');

--- a/code/globalincs/systemvars.cpp
+++ b/code/globalincs/systemvars.cpp
@@ -511,3 +511,19 @@ void insertion_sort(void *array_base, size_t array_size, size_t element_size, in
 	// free the allocated space
 	free(current);
 }
+
+// Stuff that can't be included in vmallocator.h
+
+std::locale SCP_default_locale("");
+
+void SCP_tolower(char *str)
+{
+	for (; *str != '\0'; ++str)
+		*str = SCP_tolower(*str);
+}
+
+void SCP_toupper(char *str)
+{
+	for (; *str != '\0'; ++str)
+		*str = SCP_toupper(*str);
+}

--- a/code/globalincs/vmallocator.h
+++ b/code/globalincs/vmallocator.h
@@ -1,10 +1,9 @@
 #ifndef _VMALLOCATOR_H_INCLUDED_
 #define _VMALLOCATOR_H_INCLUDED_
 
-/* SCP_vm_allocator - maintained by portej05 (i.e. please don't patch this one yourself!) */
-
 #include <deque>
 #include <list>
+#include <locale>
 #include <map>
 #include <queue>
 #include <sstream>
@@ -25,9 +24,30 @@ bool SCP_vector_contains(SCP_vector<T>& vector, T item) {
 template< typename T >
 using SCP_list = std::list< T, std::allocator< T > >;
 
+
+extern std::locale SCP_default_locale;
+
+template< class charT >
+charT SCP_toupper(charT ch) { return std::toupper(ch, SCP_default_locale); }
+
+template< class charT >
+charT SCP_tolower(charT ch) { return std::tolower(ch, SCP_default_locale); }
+
 typedef std::basic_string<char, std::char_traits<char>, std::allocator<char> > SCP_string;
 
 typedef std::basic_stringstream<char, std::char_traits<char>, std::allocator<char> > SCP_stringstream;
+
+inline void SCP_tolower(SCP_string &str) {
+	std::transform(str.begin(), str.end(), str.begin(), [](char c) { return SCP_tolower(c); });
+}
+
+inline void SCP_toupper(SCP_string &str) {
+	std::transform(str.begin(), str.end(), str.begin(), [](char c) { return SCP_toupper(c); });
+}
+
+extern void SCP_tolower(char *str);
+extern void SCP_toupper(char *str);
+
 
 template< typename T, typename U >
 using SCP_map = std::map<T, U, std::less<T>, std::allocator<std::pair<const T, U> > >;
@@ -79,8 +99,8 @@ struct SCP_string_lcase_hash {
 	size_t operator()(const SCP_string& elem) const {
 		SCP_string lcase_copy;
 		std::transform(elem.begin(), elem.end(), std::back_inserter(lcase_copy),
-			[](unsigned char c) {
-				return static_cast<unsigned char>(::tolower(c));
+			[](char c) {
+				return SCP_tolower(c);
 			});
 		return SCP_hash<SCP_string>()(lcase_copy);
 	}
@@ -94,7 +114,31 @@ struct SCP_string_lcase_equal_to {
 		auto l_it = _Left.cbegin();
 		auto r_it = _Right.cbegin();
 		while (l_it != _Left.cend()) {
-			if (::tolower(*l_it) != ::tolower(*r_it)) {
+			if (SCP_tolower(*l_it) != SCP_tolower(*r_it)) {
+				return false;
+			}
+			++l_it;
+			++r_it;
+		}
+		return true;
+	}
+};
+
+struct SCP_string_lcase_less_than {
+	bool operator()(const SCP_string& _Left, const SCP_string& _Right) const {
+		auto l_it = _Left.cbegin();
+		auto r_it = _Right.cbegin();
+		while (true) {
+			if (l_it == _Left.cend()) {
+				return (r_it != _Right.cend());
+			} else if (r_it == _Right.cend()) {
+				return false;
+			}
+			auto lch = SCP_tolower(*l_it);
+			auto rch = SCP_tolower(*r_it);
+			if (lch < rch) {
+				return true;
+			} else if (lch > rch) {
 				return false;
 			}
 			++l_it;

--- a/code/hud/hudwingmanstatus.cpp
+++ b/code/hud/hudwingmanstatus.cpp
@@ -9,9 +9,6 @@
 
 
 
-#include <cctype> // for 'tolower'
-
-
 #include "globalincs/alphacolors.h"
 #include "globalincs/linklist.h"
 #include "hud/hudtargetbox.h"
@@ -457,9 +454,9 @@ void HudGaugeWingmanStatus::renderDots(int wing_index, int screen_index, int num
 
 	// Goober5000 - get the lowercase abbreviation
 	char abbrev[4];
-	abbrev[0] = (char) tolower(Squadron_wing_names[wing_index][0]);
-	abbrev[1] = (char) tolower(Squadron_wing_names[wing_index][1]);
-	abbrev[2] = (char) tolower(Squadron_wing_names[wing_index][2]);
+	abbrev[0] = SCP_tolower(Squadron_wing_names[wing_index][0]);
+	abbrev[1] = SCP_tolower(Squadron_wing_names[wing_index][1]);
+	abbrev[2] = SCP_tolower(Squadron_wing_names[wing_index][2]);
 	abbrev[3] = '\0';
 
 	// Goober5000 - center it (round the offset rather than truncate it)

--- a/code/io/joy-sdl.cpp
+++ b/code/io/joy-sdl.cpp
@@ -78,8 +78,7 @@ SCP_string getJoystickGUID(SDL_Joystick* stick)
 	joystickGUID.resize(GUID_STR_SIZE - 1);
 
 	// Make sure the GUID is upper case
-	std::transform(begin(joystickGUID), end(joystickGUID), begin(joystickGUID),
-	               [](char c) { return (char)::toupper(c); });
+	SCP_toupper(joystickGUID);
 
 	return joystickGUID;
 }
@@ -92,7 +91,7 @@ bool joystickMatchesGuid(Joystick* testStick, const SCP_string& guid, int id)
 	}
 
 	SCP_string guidStr(guid);
-	std::transform(begin(guidStr), end(guidStr), begin(guidStr), [](char c) { return (char)::toupper(c); });
+	SCP_toupper(guidStr);
 
 	if (testStick->getGUID() != guidStr) {
 		return false; // GUID doesn't match

--- a/code/menuui/readyroom.cpp
+++ b/code/menuui/readyroom.cpp
@@ -275,7 +275,7 @@ int hash_filename(const char *filename) {
 	
 	// Don't hash .fsm extension, convert all to upper case
 	for (int i=0; i < ((signed int)(strlen(filename)) - 4); i++) {
-		hash_val = (hash_val << 4) + toupper(*ptr++);
+		hash_val = (hash_val << 4) + SCP_toupper(*ptr++);
 	}
 
 	return int(hash_val % CAMPAIGN_MISSION_HASH_SIZE);

--- a/code/mission/missioncampaign.cpp
+++ b/code/mission/missioncampaign.cpp
@@ -1588,8 +1588,7 @@ bool campaign_is_ignored(const char *filename)
 {
 	SCP_string filename_no_ext = filename;
 	drop_extension(filename_no_ext);
-	std::transform(filename_no_ext.begin(), filename_no_ext.end(), filename_no_ext.begin(),
-	               [](char c) { return (char)::tolower(c); });
+	SCP_tolower(filename_no_ext);
 
 	for (auto &ii: Ignored_campaigns) {
 		if (ii == filename_no_ext) {

--- a/code/mission/missionload.cpp
+++ b/code/mission/missionload.cpp
@@ -82,8 +82,7 @@ bool mission_is_ignored(const char *filename)
 {
 	SCP_string filename_no_ext = filename;
 	drop_extension(filename_no_ext);
-	std::transform(filename_no_ext.begin(), filename_no_ext.end(), filename_no_ext.begin(),
-	               [](char c) { return (char)::tolower(c); });
+	SCP_tolower(filename_no_ext);
 
 	for (auto &ii: Ignored_missions) {
 		if (ii == filename_no_ext) {

--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -152,8 +152,7 @@ void parse_mod_table(const char *filename)
 				}
 
 				// we want case-insensitive matching, so make this lowercase
-				std::transform(campaign_name.begin(), campaign_name.end(), campaign_name.begin(),
-				               [](char c) { return (char)::tolower(c); });
+				SCP_tolower(campaign_name);
 
 				Ignored_campaigns.push_back(campaign_name);
 			}
@@ -172,8 +171,7 @@ void parse_mod_table(const char *filename)
 				}
 
 				// we want case-insensitive matching, so make this lowercase
-				std::transform(mission_name.begin(), mission_name.end(), mission_name.begin(),
-				               [](char c) { return (char)::tolower(c); });
+				SCP_tolower(mission_name);
 
 				Ignored_missions.push_back(mission_name);
 			}

--- a/code/model/modelread.cpp
+++ b/code/model/modelread.cpp
@@ -2912,13 +2912,13 @@ int model_load(const  char *filename, int n_subsystems, model_subsystem *subsyst
 				int dl1, dl2;
 				// If a backward compatibility LOD name is declared use it
 				if (sm1->lod_name[0] != '\0') {
-					dl1 = tolower(sm1->lod_name[first_diff]) - 'a';
+					dl1 = SCP_tolower(sm1->lod_name[first_diff]) - 'a';
 				}
 				// otherwise do the standard LOD comparision
 				else {
-					dl1 = tolower(sm1->name[first_diff]) - 'a';
+					dl1 = SCP_tolower(sm1->name[first_diff]) - 'a';
 				}
-				dl2 = tolower(sm2->name[first_diff]) - 'a';
+				dl2 = SCP_tolower(sm2->name[first_diff]) - 'a';
 
 				// Handle LODs named "detail0/1/2/etc" too (as opposed to "detaila/b/c/etc")
 				if (sm1->parent == -1 && sm2->parent == -1 && !sm1->is_damaged && !sm2->is_damaged && !sm1->is_live_debris && !sm2->is_live_debris) {

--- a/code/network/multi_data.cpp
+++ b/code/network/multi_data.cpp
@@ -336,9 +336,7 @@ void multi_data_send_my_junk()
 
 // is the give file xfer handle for a "multi data" file (pcx, wav, etc)
 int multi_data_is_data(char *filename)
-{		
-	size_t len,idx;
-
+{
 	Assert(filename != NULL);
 
 	// some kind of error
@@ -347,10 +345,7 @@ int multi_data_is_data(char *filename)
 	}
 
 	// convert to lowercase
-	len = strlen(filename);
-	for(idx=0;idx<len;idx++){
-		filename[idx] = (char)tolower(filename[idx]);
-	}
+	SCP_tolower(filename);
 
 	// check to see if the extension is .pcx
 	if(strstr(filename, NOX(".pcx"))){

--- a/code/network/multiutil.cpp
+++ b/code/network/multiutil.cpp
@@ -2297,7 +2297,6 @@ void multi_handle_state_special()
 void multi_file_xfer_notify(int handle)
 {
 	char *filename = nullptr;
-	size_t len,idx;
 	int cf_type;
 	int is_mission = 0;	
 
@@ -2310,10 +2309,7 @@ void multi_file_xfer_notify(int handle)
 	}
 
 	// convert the filename to all lowercase
-	len = strlen(filename);
-	for(idx=0;idx<len;idx++){
-		filename[idx] = (char)tolower(filename[idx]);
-	}		
+	SCP_tolower(filename);
 
 	// if this is a mission file
 	is_mission = (strstr(filename, FS_MISSION_FILE_EXT) != nullptr);

--- a/code/parse/parselo.cpp
+++ b/code/parse/parselo.cpp
@@ -3859,11 +3859,11 @@ int subsystem_stricmp(const char *str1, const char *str2)
 	auto len2 = (int)strlen(str2);
 
 	// get rid of trailing s on s1?
-	if (tolower(*(str1+len1-1) == 's'))
+	if (SCP_tolower(*(str1+len1-1)) == 's')
 		len1--;
 
 	// get rid of trailing s on s2?
-	if (tolower(*(str2+len2-1) == 's'))
+	if (SCP_tolower(*(str2+len2-1)) == 's')
 		len2--;
 
 	// once we remove the trailing s on both names, they should be the same length
@@ -3887,8 +3887,8 @@ const char *stristr(const char *str, const char *substr)
 		return NULL;
 
 	// save both a lowercase and an uppercase version of the first character of substr
-	char substr_ch_lower = (char)tolower(*substr);
-	char substr_ch_upper = (char)toupper(*substr);
+	char substr_ch_lower = SCP_tolower(*substr);
+	char substr_ch_upper = SCP_toupper(*substr);
 
 	// find the maximum distance to search
 	const char *upper_bound = str + strlen(str) - strlen(substr);
@@ -3907,7 +3907,7 @@ const char *stristr(const char *str, const char *substr)
 					continue;
 
 				// converted character match?
-				if (tolower(*str_ch) == tolower(*substr_ch))
+				if (SCP_tolower(*str_ch) == SCP_tolower(*substr_ch))
 					continue;
 
 				// mismatch
@@ -3936,8 +3936,8 @@ char *stristr(char *str, const char *substr)
 		return NULL;
 
 	// save both a lowercase and an uppercase version of the first character of substr
-	char substr_ch_lower = (char)tolower(*substr);
-	char substr_ch_upper = (char)toupper(*substr);
+	char substr_ch_lower = SCP_tolower(*substr);
+	char substr_ch_upper = SCP_toupper(*substr);
 
 	// find the maximum distance to search
 	const char *upper_bound = str + strlen(str) - strlen(substr);
@@ -3956,7 +3956,7 @@ char *stristr(char *str, const char *substr)
 					continue;
 
 				// converted character match?
-				if (tolower(*str_ch) == tolower(*substr_ch))
+				if (SCP_tolower(*str_ch) == SCP_tolower(*substr_ch))
 					continue;
 
 				// mismatch

--- a/code/parse/sexp/LuaSEXP.cpp
+++ b/code/parse/sexp/LuaSEXP.cpp
@@ -38,9 +38,10 @@ SCP_unordered_map<SCP_string, int> parameter_type_mapping{{ "boolean",      OPF_
 														  { "shipclass",    OPF_SHIP_CLASS_NAME },
 														  { "weaponclass",  OPF_WEAPON_NAME },
 														  { "soundentry",   OPF_GAME_SND }, };
-std::pair<SCP_string, int> get_parameter_type(const SCP_string& name) {
+std::pair<SCP_string, int> get_parameter_type(const SCP_string& name)
+{
 	SCP_string copy = name;
-	std::transform(copy.begin(), copy.end(), copy.begin(), [](char c) { return (char)::tolower(c); });
+	SCP_tolower(copy);
 
 	auto iter = parameter_type_mapping.find(copy);
 	if (iter == parameter_type_mapping.end()) {
@@ -53,9 +54,10 @@ std::pair<SCP_string, int> get_parameter_type(const SCP_string& name) {
 SCP_unordered_map<SCP_string, int> return_type_mapping{{ "number",  OPR_NUMBER },
 													   { "boolean", OPR_BOOL },
 													   { "nothing", OPR_NULL }, };
-int get_return_type(const SCP_string& name) {
+int get_return_type(const SCP_string& name)
+{
 	SCP_string copy = name;
-	std::transform(copy.begin(), copy.end(), copy.begin(), [](char c) { return (char)::tolower(c); });
+	SCP_tolower(copy);
 
 	auto iter = return_type_mapping.find(copy);
 	if (iter == return_type_mapping.end()) {

--- a/code/scripting/lua.cpp
+++ b/code/scripting/lua.cpp
@@ -193,15 +193,8 @@ static bool sort_table_entries(const ade_table_entry* left, const ade_table_entr
 		return false;
 	}
 
-	SCP_string leftStr(leftCmp);
-	std::transform(std::begin(leftStr), std::end(leftStr), std::begin(leftStr),
-	               [](char c) { return (char)::tolower(c); });
-
-	SCP_string rightStr(rightCmp);
-	std::transform(std::begin(rightStr), std::end(rightStr), std::begin(rightStr),
-	               [](char c) { return (char)::tolower(c); });
-
-	return leftStr < rightStr;
+	SCP_string_lcase_less_than lt;
+	return lt(leftCmp, rightCmp);
 }
 
 static bool sort_doc_entries(const ade_table_entry* left, const ade_table_entry* right) {

--- a/code/utils/strings.h
+++ b/code/utils/strings.h
@@ -50,7 +50,7 @@ inline void strlwr(char *s) {
 		return;
 
 	while (*s) {
-		*s = (char) tolower(*s);
+		*s = (char) tolower((unsigned char) *s);
 		s++;
 	}
 }

--- a/fred2/voiceactingmanager.cpp
+++ b/fred2/voiceactingmanager.cpp
@@ -280,7 +280,7 @@ CString VoiceActingManager::generate_filename(CString section, int number, int d
 		size_t j;
 		for( j = 0; sender[j] != '\0'; j++ ) {
 			// lower case letter
-			sender[j] = (char)tolower(sender[j]);
+			sender[j] = SCP_tolower(sender[j]);
 
 			// replace any non alpha numeric with a underscore
 			if ( !isalnum( sender[j] ) )

--- a/tools/embedfile/embedfile.cpp
+++ b/tools/embedfile/embedfile.cpp
@@ -22,7 +22,7 @@ bool casecmp(const char* strA, const char* strB) {
 	}
 
 	for (size_t i = 0; i < lenA; i++) {
-		if (toupper(strA[i]) != toupper(strB[i])) {
+		if (toupper(static_cast<unsigned char>(strA[i])) != toupper(static_cast<unsigned char>(strB[i]))) {
 			return false;
 		}
 	}
@@ -171,7 +171,8 @@ void do_text_content(std::ifstream& file_in, std::ofstream& file_out,
 void write_header(std::ostream& out, const std::string& fieldName, bool text_content, bool wxWidgets_image) {
 	std::string headerDefine(fieldName);
 
-	std::transform(fieldName.begin(), fieldName.end(), headerDefine.begin(), [](char c) { return (char)::toupper(c); });
+	std::transform(fieldName.begin(), fieldName.end(), headerDefine.begin(),
+	               [](char c) { return static_cast<char>(::toupper(static_cast<unsigned char>(c))); });
 
 	headerDefine = "SCP_" + headerDefine + "_H";
 


### PR DESCRIPTION
This refactors the tolower/toupper code to use standards-conformant logic, and also adds some helpful utility functions.  Regular tolower/toupper must be supplied a value that can be represented as `unsigned char`, but the std:: functions are a bit more robust.

~~This is in draft status until #3223 is merged, as it depends on that.~~