### PR TITLE
fix mn.evaluateNumericSEXP

### DIFF
--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -25912,6 +25912,10 @@ int run_sexp(const char* sexpression, bool run_eval_num, bool *is_nan_or_nan_for
 	{
 		if (run_eval_num)
 		{
+			// if this sexp node is an operator, put it in another node so that CAR(node) will find it
+			if (get_operator_index(n) >= 0)
+				n = alloc_sexp("", 1, -1, n, -1);
+
 			bool is_nan, is_nan_forever;
 			sexp_val = eval_num(n, is_nan, is_nan_forever);
 			if (is_nan_or_nan_forever != nullptr)


### PR DESCRIPTION
This is a follow-up to #2687.  The final implementation of evaluateNumericSEXP different from the testing implementation in a small but crucial way that prevented it from actually working.  Since it used `eval_num`, it didn't evaluate the specified SEXP node but rather the CAR (first element) of the node list.  This fixes that by putting the node in a temporary SEXP list so that `eval_num` will look in the right place.