### PR TITLE
Try to fix linux nightly builds

### DIFF
--- a/.github/workflows/build-nightly.yaml
+++ b/.github/workflows/build-nightly.yaml
@@ -29,6 +29,7 @@ jobs:
           version: ${{ env.QT_VERSION }}
           dir: ${{ github.workspace }}/..
           cached: ${{ steps.cache-qt-lin.outputs.cache-hit }}
+          setup-python: 'false'
 
       - uses: actions/checkout@v1
         name: Checkout

--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -53,6 +53,7 @@ jobs:
           version: ${{ env.QT_VERSION }}
           dir: ${{ github.workspace }}/..
           cached: ${{ steps.cache-qt-lin.outputs.cache-hit }}
+          setup-python: 'false'
 
       - uses: actions/checkout@v1
         name: Checkout

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -29,6 +29,7 @@ jobs:
           version: ${{ env.QT_VERSION }}
           dir: ${{ github.workspace }}/..
           cached: ${{ steps.cache-qt-lin.outputs.cache-hit }}
+          setup-python: 'false'
 
       - uses: actions/checkout@v1
         name: Checkout


### PR DESCRIPTION
The default Python version appears to be too recent so let's try to have
this action use the python package that is installed in our build image.