### PR TITLE
Store standalone image on GitHub

### DIFF
--- a/.github/workflows/standalone-image-workflow.yaml
+++ b/.github/workflows/standalone-image-workflow.yaml
@@ -3,7 +3,8 @@ name: Publish Standalone docker image
 on:
   push:
     tags:
-    - '*'
+    - 'nightly_*'
+    - 'release_*'
 
 jobs:
   build_images:
@@ -12,13 +13,9 @@ jobs:
         configuration: [FastDebug, Release]
         include:
         - configuration: FastDebug
-          latest_tag: latest_debug
-          nightly_tag: nightly_debug
-          release_tag: release_debug
+          tag_suffix: -debug
         - configuration: Release
-          latest_tag: latest
-          nightly_tag: nightly
-          release_tag: release
+          tag_suffix: ""
       fail-fast: false
     runs-on: ubuntu-latest
     steps:
@@ -26,23 +23,30 @@ jobs:
       name: Checkout
       with:
         submodules: true
-    - name: Docker login
-      run: echo ${{ secrets.DOCKER_ACCESSTOKEN }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
-    - name: Docker build
-      run: docker build --build-arg build_type=${{ matrix.configuration }} -f docker/standalone/Dockerfile -t ${{ secrets.DOCKER_REPOSITORY }}:${{ matrix.latest_tag }} .
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
 
-    - name: Push latest tag
-      run: |
-        docker push ${{ secrets.DOCKER_REPOSITORY }}:${{ matrix.latest_tag }}
+    - name: Docker meta
+      id: docker_meta
+      uses: crazy-max/ghaction-docker-meta@v1
+      with:
+        images: ghcr.io/scp-fs2open/standalone_server
+        tag-latest: false
 
-    - name: Push nightly tag
-      if: contains(github.ref, 'refs/tags/nightly_')
-      run: |
-        docker tag ${{ secrets.DOCKER_REPOSITORY }}:${{ matrix.latest_tag }} ${{ secrets.DOCKER_REPOSITORY }}:${{ matrix.nightly_tag }}
-        docker push ${{ secrets.DOCKER_REPOSITORY }}:${{ matrix.nightly_tag }}
-
-    - name: Push release tag
-      if: contains(github.ref, 'refs/tags/release_')
-      run: |
-        docker tag ${{ secrets.DOCKER_REPOSITORY }}:${{ matrix.latest_tag }} ${{ secrets.DOCKER_REPOSITORY }}:${{ matrix.release_tag }}
-        docker push ${{ secrets.DOCKER_REPOSITORY }}:${{ matrix.release_tag }}
+    - name: Login to GitHub Docker Registry
+      uses: docker/login-action@v1
+      with:
+        registry: ghcr.io
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.CR_PAT }}
+    - name: Build and push
+      id: docker_build
+      uses: docker/build-push-action@v2
+      with:
+        context: .
+        file: ./docker/standalone/Dockerfile
+        push: true
+        tags: ${{ steps.docker_meta.outputs.tags }}${{ matrix.tag_suffix }}
+        labels: ${{ steps.docker_meta.outputs.labels }}
+        build-args: |
+          build_type=${{ matrix.configuration }}


### PR DESCRIPTION
Docker Hub is going into a weird direction with their rate limits and
the GitHub Container Registry is better in that regard.

Old images will stay in Docker Hub for the time being though.