### PR TITLE
Set default volume on audiostream creation

### DIFF
--- a/code/scripting/api/objs/audio_stream.cpp
+++ b/code/scripting/api/objs/audio_stream.cpp
@@ -11,8 +11,8 @@ ADE_OBJ(l_AudioStream, int, "audio_stream", "An audio stream handle");
 
 ADE_FUNC(play,
 	l_AudioStream,
-	"[number volume = -1.0 /* By default uses preset volume of the stream type */, boolean loop = false]",
-	"Starts playing the audio stream",
+   "[number volume = -1.0 /* By default sets the last used volume of this stream, if applicable. Otherwise, uses preset volume of the stream type */, boolean loop = false]",
+    "Starts playing the audio stream",
 	"boolean",
 	"true on success, false otherwise")
 {

--- a/code/sound/audiostr.cpp
+++ b/code/sound/audiostr.cpp
@@ -959,8 +959,6 @@ static int audiostream_use_next_free( int type )
             return -1;
     }
 
-    Audio_streams[i].Set_Default_Volume(type == ASF_VOICE ? Master_voice_volume * aav_voice_volume : Master_sound_volume);
-
     return i;
 }
 

--- a/code/sound/audiostr.cpp
+++ b/code/sound/audiostr.cpp
@@ -18,6 +18,7 @@
 #include "sound/IAudioFile.h"
 #include "sound/sound.h"
 #include "sound/openal.h"
+#include "gamesnd/eventmusic.h"
 
 #ifdef WITH_FFMPEG
 #include "sound/ffmpeg/FFmpegWaveFile.h"
@@ -939,6 +940,26 @@ static int audiostream_use_next_free( int type )
 
     Audio_streams[i].status = ASF_USED;
     Audio_streams[i].type = type;
+
+    switch (type) {
+        case ASF_SOUNDFX: // As in: sound.cpp:590
+            Audio_streams[i].Set_Default_Volume(Master_sound_volume * aav_effect_volume);
+            break;
+        case ASF_EVENTMUSIC: // As in: sexp.cpp:11562
+            Audio_streams[i].Set_Default_Volume(Master_event_music_volume * aav_music_volume);
+            break;
+        case ASF_MENUMUSIC: // As in: mainhallmenu.cpp:1170
+            Audio_streams[i].Set_Default_Volume(Master_event_music_volume);
+            break;
+        case ASF_VOICE: // As in: sound.cpp:590
+            Audio_streams[i].Set_Default_Volume(Master_voice_volume * aav_voice_volume);
+            break;
+        default:
+            Audio_streams[i].status = ASF_FREE;
+            return -1;
+    }
+
+    Audio_streams[i].Set_Default_Volume(type == ASF_VOICE ? Master_voice_volume * aav_voice_volume : Master_sound_volume);
 
     return i;
 }

--- a/code/sound/audiostr.cpp
+++ b/code/sound/audiostr.cpp
@@ -82,16 +82,16 @@ int Audiostream_inited = 0;
 class Timer
 {
 public:
-    void constructor();
-    void destructor();
-    bool Create (uint nPeriod, uint nRes, ptr_u dwUser, TIMERCALLBACK pfnCallback);
+	void constructor();
+	void destructor();
+	bool Create (uint nPeriod, uint nRes, ptr_u dwUser, TIMERCALLBACK pfnCallback);
 protected:
-    static uint TimeProc(uint interval, void *param);
-    TIMERCALLBACK m_pfnCallback;
-    ptr_u m_dwUser;
-    uint m_nPeriod;
-    uint m_nRes;
-    SDL_TimerID m_nIDTimer;
+	static uint TimeProc(uint interval, void *param);
+	TIMERCALLBACK m_pfnCallback;
+	ptr_u m_dwUser;
+	uint m_nPeriod;
+	uint m_nRes;
+	SDL_TimerID m_nIDTimer;
 };
 
 class AudioStream
@@ -123,7 +123,7 @@ public:
 	bool paused_via_sexp_or_script;
 
 protected:
-    bool prepareOpened(const char *filename);
+	bool prepareOpened(const char *filename);
 	void Cue ();
 	bool WriteWaveData (uint cbSize, uint *num_bytes_written, int service = 1);
 	uint GetMaxWriteSize ();
@@ -187,7 +187,7 @@ void Timer::destructor(void)
 // Create
 bool Timer::Create (uint nPeriod, uint nRes, ptr_u dwUser, TIMERCALLBACK pfnCallback)
 {
-	bool bRtn = true;    // assume success
+	bool bRtn = true;	// assume success
 
 	Assert(pfnCallback);
 	Assert(nPeriod > 10);
@@ -213,19 +213,19 @@ bool Timer::Create (uint nPeriod, uint nRes, ptr_u dwUser, TIMERCALLBACK pfnCall
 // 
 uint Timer::TimeProc(uint interval, void *dwUser)
 {
-    // dwUser contains ptr to Timer object
+	// dwUser contains ptr to Timer object
 	Timer * ptimer = (Timer *) dwUser;
 
-    // Call user-specified callback and pass back user specified data
-    (ptimer->m_pfnCallback) (ptimer->m_dwUser);
+	// Call user-specified callback and pass back user specified data
+	(ptimer->m_pfnCallback) (ptimer->m_dwUser);
 
-    if (ptimer->m_nPeriod) {
+	if (ptimer->m_nPeriod) {
 		return interval;
-    } else {
+	} else {
 		SDL_RemoveTimer(ptimer->m_nIDTimer);
 		ptimer->m_nIDTimer = 0;
 		return 0;
-    }
+	}
 }
 
 //
@@ -279,51 +279,51 @@ void AudioStream::Init_Data ()
 
 bool AudioStream::prepareOpened(const char *filename)
 {
-    bool fRtn = true;
+	bool fRtn = true;
 
-    m_fileProps = m_pwavefile->getFileProperties();
+	m_fileProps = m_pwavefile->getFileProperties();
 
-    m_cbBufSize = (m_fileProps.sample_rate * m_fileProps.bytes_per_sample * m_fileProps.num_channels) >> 2;
-    // make sure that we are a multiple of the frame size
-    m_cbBufSize -= (m_cbBufSize % (m_fileProps.bytes_per_sample * m_fileProps.num_channels));
-    m_cbBufSize += (m_cbBufSize % 12) << 1;
-    // if the requested buffer size is too big then cap it
-    m_cbBufSize = (m_cbBufSize > BIGBUF_SIZE) ? BIGBUF_SIZE : m_cbBufSize;
+	m_cbBufSize = (m_fileProps.sample_rate * m_fileProps.bytes_per_sample * m_fileProps.num_channels) >> 2;
+	// make sure that we are a multiple of the frame size
+	m_cbBufSize -= (m_cbBufSize % (m_fileProps.bytes_per_sample * m_fileProps.num_channels));
+	m_cbBufSize += (m_cbBufSize % 12) << 1;
+	// if the requested buffer size is too big then cap it
+	m_cbBufSize = (m_cbBufSize > BIGBUF_SIZE) ? BIGBUF_SIZE : m_cbBufSize;
 
-//				nprintf(("SOUND", "SOUND => Stream buffer created using %d bytes\n", m_cbBufSize));
+	//				nprintf(("SOUND", "SOUND => Stream buffer created using %d bytes\n", m_cbBufSize));
 
-    OpenAL_ErrorCheck( alGenSources(1, &m_source_id), { fRtn = false; goto ErrorExit; } );
+	OpenAL_ErrorCheck( alGenSources(1, &m_source_id), { fRtn = false; goto ErrorExit; } );
 
-    OpenAL_ErrorCheck( alGenBuffers(MAX_STREAM_BUFFERS, m_buffer_ids), { fRtn = false; goto ErrorExit; } );
+	OpenAL_ErrorCheck( alGenBuffers(MAX_STREAM_BUFFERS, m_buffer_ids), { fRtn = false; goto ErrorExit; } );
 
-    OpenAL_ErrorPrint( alSourcef(m_source_id, AL_ROLLOFF_FACTOR, 1.0f) );
-    OpenAL_ErrorPrint( alSourcei(m_source_id, AL_SOURCE_RELATIVE, AL_TRUE) );
+	OpenAL_ErrorPrint( alSourcef(m_source_id, AL_ROLLOFF_FACTOR, 1.0f) );
+	OpenAL_ErrorPrint( alSourcei(m_source_id, AL_SOURCE_RELATIVE, AL_TRUE) );
 
-    OpenAL_ErrorPrint( alSource3f(m_source_id, AL_POSITION, 0.0f, 0.0f, 0.0f) );
-    OpenAL_ErrorPrint( alSource3f(m_source_id, AL_VELOCITY, 0.0f, 0.0f, 0.0f) );
+	OpenAL_ErrorPrint( alSource3f(m_source_id, AL_POSITION, 0.0f, 0.0f, 0.0f) );
+	OpenAL_ErrorPrint( alSource3f(m_source_id, AL_VELOCITY, 0.0f, 0.0f, 0.0f) );
 
-    OpenAL_ErrorPrint( alSourcef(m_source_id, AL_GAIN, 1.0f) );
-    OpenAL_ErrorPrint( alSourcef(m_source_id, AL_PITCH, 1.0f) );
+	OpenAL_ErrorPrint( alSourcef(m_source_id, AL_GAIN, 1.0f) );
+	OpenAL_ErrorPrint( alSourcef(m_source_id, AL_PITCH, 1.0f) );
 
-    // maybe set EFX
-    if ( (type == ASF_SOUNDFX) && ds_eax_is_inited() ) {
-        extern ALuint AL_EFX_aux_id;
-        OpenAL_ErrorPrint( alSource3i(m_source_id, AL_AUXILIARY_SEND_FILTER, AL_EFX_aux_id, 0, AL_FILTER_NULL) );
-    }
+	// maybe set EFX
+	if ( (type == ASF_SOUNDFX) && ds_eax_is_inited() ) {
+		extern ALuint AL_EFX_aux_id;
+		OpenAL_ErrorPrint( alSource3i(m_source_id, AL_AUXILIARY_SEND_FILTER, AL_EFX_aux_id, 0, AL_FILTER_NULL) );
+	}
 
-    Snd_sram += (m_cbBufSize * MAX_STREAM_BUFFERS);
+	Snd_sram += (m_cbBufSize * MAX_STREAM_BUFFERS);
 
 ErrorExit:
-    if ( (fRtn == false) && (m_pwavefile) ) {
-        mprintf(("AUDIOSTR => ErrorExit for ::prepareOpened() on wave file: %s\n", filename));
+	if ( (fRtn == false) && (m_pwavefile) ) {
+		mprintf(("AUDIOSTR => ErrorExit for ::prepareOpened() on wave file: %s\n", filename));
 
-        if (m_source_id)
-            OpenAL_ErrorPrint( alDeleteSources(1, &m_source_id) );
+		if (m_source_id)
+			OpenAL_ErrorPrint( alDeleteSources(1, &m_source_id) );
 
-        m_pwavefile = nullptr;
-    }
+		m_pwavefile = nullptr;
+	}
 
-    return fRtn;
+	return fRtn;
 }
 
 // Create
@@ -333,22 +333,22 @@ bool AudioStream::Create (char *pszFilename)
 
 	Init_Data();
 
-    if ( ! pszFilename )
-        return false;
-    // make 100% sure we got a good filename
-    if ( !strlen(pszFilename) )
-        return false;
+	if ( ! pszFilename )
+		return false;
+	// make 100% sure we got a good filename
+	if ( !strlen(pszFilename) )
+		return false;
 
-    // Create a new WaveFile object and open it
-    m_pwavefile = openAudioFile(pszFilename, (type == ASF_EVENTMUSIC));
-    if (m_pwavefile) {
-        return prepareOpened(pszFilename);
-    }
-    else {
-        // Error, unable to create WaveFile object
-        nprintf(("Sound", "SOUND => Failed to open wave file %s\n", pszFilename));
-        return false;
-    }
+	// Create a new WaveFile object and open it
+	m_pwavefile = openAudioFile(pszFilename, (type == ASF_EVENTMUSIC));
+	if (m_pwavefile) {
+		return prepareOpened(pszFilename);
+	}
+	else {
+		// Error, unable to create WaveFile object
+		nprintf(("Sound", "SOUND => Failed to open wave file %s\n", pszFilename));
+		return false;
+	}
 
 }
 
@@ -359,12 +359,12 @@ bool AudioStream::CreateMem (const uint8_t* snddata, size_t snd_len)
 	// Create a new WaveFile object and open it
 	m_pwavefile = openAudioMem(snddata, snd_len);
 	if (m_pwavefile) {
-        return prepareOpened("in-memory");
+		return prepareOpened("in-memory");
 	}
 	else {
 		// Error, unable to create WaveFile object
-        nprintf(("Sound", "SOUND => Failed to open in-memory wave file \n"));
-        return false;
+		nprintf(("Sound", "SOUND => Failed to open in-memory wave file \n"));
+		return false;
 	}
 }
 
@@ -425,7 +425,7 @@ bool AudioStream::WriteWaveData (uint size, uint *num_bytes_written, int service
 	if ( service ) {
 		SDL_LockMutex(Global_service_lock);
 	}
-		    
+
 	if ( service ) {
 		uncompressed_wave_data = Wavedata_service_buffer;
 	} else {
@@ -493,7 +493,7 @@ ErrorExit:
 	if ( service ) {
 		SDL_UnlockMutex(Global_service_lock);
 	}
-    
+
 	return (fRtn);
 }
 
@@ -709,10 +709,10 @@ void AudioStream::Play (float volume, int looping)
 // Timer callback for Timer object created by ::Play method.
 bool AudioStream::TimerCallback (ptr_u dwUser)
 {
-    // dwUser contains ptr to AudioStream object
-    AudioStream * pas = (AudioStream *) dwUser;
+	// dwUser contains ptr to AudioStream object
+	AudioStream * pas = (AudioStream *) dwUser;
 
-    return (pas->ServiceBuffer ());
+	return (pas->ServiceBuffer ());
 }
 
 void AudioStream::Set_Sample_Cutoff(unsigned int sample_cutoff)
@@ -925,41 +925,41 @@ void audiostream_close()
 
 static int audiostream_use_next_free( int type )
 {
-    if ( !Audiostream_inited || !snd_is_inited() )
-        return -1;
+	if ( !Audiostream_inited || !snd_is_inited() )
+		return -1;
 
-    int i;
-    for (i = 0; i < MAX_AUDIO_STREAMS; i++)
-        if (Audio_streams[i].status == ASF_FREE)
-            break;
+	int i;
+	for (i = 0; i < MAX_AUDIO_STREAMS; i++)
+		if (Audio_streams[i].status == ASF_FREE)
+			break;
 
-    if (i == MAX_AUDIO_STREAMS) {
-        nprintf(("Sound", "SOUND => No more audio streams available!\n"));
-        return -1;
-    }
+	if (i == MAX_AUDIO_STREAMS) {
+		nprintf(("Sound", "SOUND => No more audio streams available!\n"));
+		return -1;
+	}
 
-    Audio_streams[i].status = ASF_USED;
-    Audio_streams[i].type = type;
+	Audio_streams[i].status = ASF_USED;
+	Audio_streams[i].type = type;
 
-    switch (type) {
-        case ASF_SOUNDFX: // As in: sound.cpp:590
-            Audio_streams[i].Set_Default_Volume(Master_sound_volume * aav_effect_volume);
-            break;
-        case ASF_EVENTMUSIC: // As in: sexp.cpp:11562
-            Audio_streams[i].Set_Default_Volume(Master_event_music_volume * aav_music_volume);
-            break;
-        case ASF_MENUMUSIC: // As in: mainhallmenu.cpp:1170
-            Audio_streams[i].Set_Default_Volume(Master_event_music_volume);
-            break;
-        case ASF_VOICE: // As in: sound.cpp:590
-            Audio_streams[i].Set_Default_Volume(Master_voice_volume * aav_voice_volume);
-            break;
-        default:
-            Audio_streams[i].status = ASF_FREE;
-            return -1;
-    }
+	switch (type) {
+		case ASF_SOUNDFX: // As in: sound.cpp:590
+			Audio_streams[i].Set_Default_Volume(Master_sound_volume * aav_effect_volume);
+			break;
+		case ASF_EVENTMUSIC: // As in: sexp.cpp:11562
+			Audio_streams[i].Set_Default_Volume(Master_event_music_volume * aav_music_volume);
+			break;
+		case ASF_MENUMUSIC: // As in: mainhallmenu.cpp:1170
+			Audio_streams[i].Set_Default_Volume(Master_event_music_volume);
+			break;
+		case ASF_VOICE: // As in: sound.cpp:590
+			Audio_streams[i].Set_Default_Volume(Master_voice_volume * aav_voice_volume);
+			break;
+		default:
+			Audio_streams[i].status = ASF_FREE;
+			return -1;
+	}
 
-    return i;
+	return i;
 }
 
 // Open a digital sound file for streaming
@@ -975,11 +975,11 @@ static int audiostream_use_next_free( int type )
 //				failure => -1
 int audiostream_open( const char *filename, int type )
 {
-    int i = audiostream_use_next_free(type);
-    if ( i == -1 )
-        return -1;
+	int i = audiostream_use_next_free(type);
+	if ( i == -1 )
+		return -1;
 
-    char fname[MAX_FILENAME_LEN];
+	char fname[MAX_FILENAME_LEN];
 	// copy filename, since we might modify it
 	strcpy_s(fname, filename);
 
@@ -1001,11 +1001,11 @@ int audiostream_open( const char *filename, int type )
 			break;
 
 		default:
-            Audio_streams[i].status = ASF_FREE;
+			Audio_streams[i].status = ASF_FREE;
 			return -1;
 	}
 
-    int rc = Audio_streams[i].Create(fname);
+	int rc = Audio_streams[i].Create(fname);
 
 	if ( rc == 0 ) {
 		Audio_streams[i].status = ASF_FREE;
@@ -1017,23 +1017,23 @@ int audiostream_open( const char *filename, int type )
 
 // Open wave file contents previously loaded into memory for streaming
 //
-// input:    snddata    =>	reference of an in-memory file
-//           snd_len    =>  length of loaded file
-//				type	=>	what type of audio stream do we want to open:
-//								ASF_SOUNDFX
-//								ASF_EVENTMUSIC
-//								ASF_MENUMUSIC
-//								ASF_VOICE
+//input:	snddata	=>	reference of an in-memory file
+//			snd_len	=>	length of loaded file
+//			type	=>	what type of audio stream do we want to open:
+//							ASF_SOUNDFX
+//							ASF_EVENTMUSIC
+//							ASF_MENUMUSIC
+//							ASF_VOICE
 //	
 // returns:	success => handle to identify streaming sound
 //				failure => -1
 int audiostream_open_mem( const uint8_t* snddata, size_t snd_len, int type )
 {
-    int i = audiostream_use_next_free(type);
-    if ( i == -1 )
-        return -1;
+	int i = audiostream_use_next_free(type);
+	if ( i == -1 )
+		return -1;
 
-    int rc = Audio_streams[i].CreateMem(snddata, snd_len);
+	int rc = Audio_streams[i].CreateMem(snddata, snd_len);
 
 	if ( rc == 0 ) {
 		Audio_streams[i].status = ASF_FREE;

--- a/code/sound/audiostr.cpp
+++ b/code/sound/audiostr.cpp
@@ -975,7 +975,7 @@ int audiostream_open( const char *filename, int type )
 			break;
 
 		default:
-			Int3();
+            Audio_streams[i].status = ASF_FREE;
 			return -1;
 	}
 


### PR DESCRIPTION
Addressing my issue #3225, I'm setting sane values found in other
parts of the sound system at stream creation, to be used or overwritten later.

Also fixed a potential leak of stream slots and deduplicated some code.