### PR TITLE
add missing #include

### DIFF
--- a/code/globalincs/vmallocator.h
+++ b/code/globalincs/vmallocator.h
@@ -2,6 +2,7 @@
 #define _VMALLOCATOR_H_INCLUDED_
 
 #include <deque>
+#include <iterator>
 #include <list>
 #include <locale>
 #include <map>


### PR DESCRIPTION
On some setups the hierarchy of #include files doesn't catch an `<iterator>`, so #include it explicitly.

(This fixes the "`std::back_inserter` not found" error on MSVC 2015.)