### PR TITLE
Add a CMake platform check for proper non-copyable type support

### DIFF
--- a/code/actions/ActionDefinitionManager.cpp
+++ b/code/actions/ActionDefinitionManager.cpp
@@ -47,24 +47,7 @@ void parseActionParameters(const SCP_vector<ActionParameter>& params,
 
 const ActionDefinitionManager& ActionDefinitionManager::instance()
 {
-	static const ActionDefinitionManager manager = []() {
-		ActionDefinitionManager newManager;
-
-		newManager.addDefinition(
-			std::unique_ptr<ActionDefinition>(new BuiltinActionDefinition<types::MoveToSubmodel>("Move To Subobject")));
-		newManager.addDefinition(std::unique_ptr<ActionDefinition>(
-			new BuiltinActionDefinition<types::ParticleEffectAction>("Start Particle Effect")));
-		newManager.addDefinition(
-			std::unique_ptr<ActionDefinition>(new BuiltinActionDefinition<types::PlaySoundAction>("Play 3D Sound")));
-		newManager.addDefinition(
-			std::unique_ptr<ActionDefinition>(new BuiltinActionDefinition<types::SetDirectionAction>("Set Direction")));
-		newManager.addDefinition(
-			std::unique_ptr<ActionDefinition>(new BuiltinActionDefinition<types::SetPositionAction>("Set Position")));
-		newManager.addDefinition(
-			std::unique_ptr<ActionDefinition>(new BuiltinActionDefinition<types::WaitAction>("Wait")));
-
-		return newManager;
-	}();
+	static const ActionDefinitionManager manager;
 	return manager;
 }
 void ActionDefinitionManager::addDefinition(std::unique_ptr<ActionDefinition> def)
@@ -143,6 +126,20 @@ std::unique_ptr<Action> ActionDefinitionManager::parseAction(const flagset<Progr
 	}
 
 	return std::unique_ptr<Action>();
+}
+ActionDefinitionManager::ActionDefinitionManager()
+{
+	addDefinition(
+		std::unique_ptr<ActionDefinition>(new BuiltinActionDefinition<types::MoveToSubmodel>("Move To Subobject")));
+	addDefinition(std::unique_ptr<ActionDefinition>(
+		new BuiltinActionDefinition<types::ParticleEffectAction>("Start Particle Effect")));
+	addDefinition(
+		std::unique_ptr<ActionDefinition>(new BuiltinActionDefinition<types::PlaySoundAction>("Play 3D Sound")));
+	addDefinition(
+		std::unique_ptr<ActionDefinition>(new BuiltinActionDefinition<types::SetDirectionAction>("Set Direction")));
+	addDefinition(
+		std::unique_ptr<ActionDefinition>(new BuiltinActionDefinition<types::SetPositionAction>("Set Position")));
+	addDefinition(std::unique_ptr<ActionDefinition>(new BuiltinActionDefinition<types::WaitAction>("Wait")));
 }
 
 } // namespace actions

--- a/code/actions/ActionDefinitionManager.h
+++ b/code/actions/ActionDefinitionManager.h
@@ -19,7 +19,7 @@ class ActionDefinitionManager {
 	static const ActionDefinitionManager& instance();
 
   private:
-	ActionDefinitionManager() = default;
+	ActionDefinitionManager();
 
 	void addDefinition(std::unique_ptr<ActionDefinition> def);
 

--- a/code/actions/expression/FunctionManager.cpp
+++ b/code/actions/expression/FunctionManager.cpp
@@ -22,19 +22,7 @@ Value value_minus(const SCP_vector<Value>& parameters)
 
 const FunctionManager& FunctionManager::instance()
 {
-	static const FunctionManager manager = []() {
-		FunctionManager newManager;
-
-		newManager.addOperator("+", {ValueType::Integer, ValueType::Integer}, ValueType::Integer, value_plus<int>);
-		newManager.addOperator("+", {ValueType::Float, ValueType::Float}, ValueType::Float, value_plus<float>);
-		newManager.addOperator("+", {ValueType::Vector, ValueType::Vector}, ValueType::Vector, value_plus<vec3d>);
-
-		newManager.addOperator("-", {ValueType::Integer, ValueType::Integer}, ValueType::Integer, value_minus<int>);
-		newManager.addOperator("-", {ValueType::Float, ValueType::Float}, ValueType::Float, value_minus<float>);
-		newManager.addOperator("-", {ValueType::Vector, ValueType::Vector}, ValueType::Vector, value_minus<vec3d>);
-
-		return newManager;
-	}();
+	static const FunctionManager manager;
 	return manager;
 }
 void FunctionManager::addOperator(const SCP_string& name,
@@ -87,7 +75,16 @@ const FunctionDefinition* FunctionManager::findOperator(const SCP_string& name,
 	return nullptr;
 }
 
-FunctionManager::FunctionManager() = default;
+FunctionManager::FunctionManager()
+{
+	addOperator("+", {ValueType::Integer, ValueType::Integer}, ValueType::Integer, value_plus<int>);
+	addOperator("+", {ValueType::Float, ValueType::Float}, ValueType::Float, value_plus<float>);
+	addOperator("+", {ValueType::Vector, ValueType::Vector}, ValueType::Vector, value_plus<vec3d>);
+
+	addOperator("-", {ValueType::Integer, ValueType::Integer}, ValueType::Integer, value_minus<int>);
+	addOperator("-", {ValueType::Float, ValueType::Float}, ValueType::Float, value_minus<float>);
+	addOperator("-", {ValueType::Vector, ValueType::Vector}, ValueType::Vector, value_minus<vec3d>);
+}
 
 } // namespace expression
 } // namespace actions


### PR DESCRIPTION
Visual Studio has issues in earlier versions where it does not properly
support returning a type that has a deleted copy operator/constructor.

This works around that by checking for that error with CMake and
applying a workaround if that check fails.