### PR TITLE
when we're finished parsing a main hall, the next main hall should be a new one

### DIFF
--- a/code/menuui/mainhallmenu.cpp
+++ b/code/menuui/mainhallmenu.cpp
@@ -2576,7 +2576,7 @@ void parse_one_main_hall(bool replace, int num_resolutions, int &hall_idx, int &
 	if (res_idx >= num_resolutions)
 	{
 		res_idx = 0;
-		hall_idx++;
+		hall_idx = (int)Main_hall_defines.size();	// assume the next main hall is going to be a new one
 	}
 }
 


### PR DESCRIPTION
With modular tables, we might have modified an entry in the middle of the vector, in which case the next index would be an existing main hall.  If the next modular table then created a brand new main hall, it would overwrite that entry.  This makes sure the code always assumes the next main hall will come at the end of the list.