### PR TITLE
Add flag for beams to track uoffset individually

### DIFF
--- a/code/weapon/beam.cpp
+++ b/code/weapon/beam.cpp
@@ -1276,6 +1276,12 @@ void beam_render(beam *b, float u_offset)
 
 	bwi = &Weapon_info[b->weapon_info_index].b_info;
 
+	// if this beam tracks it's own u_offset, increment
+	if (bwi->flags[Weapon::Beam_Info_Flags::Track_own_texture_tiling]) {
+		b->u_offset_local += flFrametime;
+		u_offset = b->u_offset_local;
+	}
+
 	// draw all sections	
 	for (s_idx = 0; s_idx < bwi->beam_num_sections; s_idx++) {
 		bwsi = &bwi->sections[s_idx];
@@ -1634,6 +1640,7 @@ void beam_render_all()
 		if ( (moveup->warmup_stamp == -1) && (moveup->warmdown_stamp == -1) && !(moveup->flags & BF_SAFETY) ) {
 			// HACK -  if this is the first frame the beam is firing, don't render it
             if (moveup->framecount <= 0) {
+				moveup->u_offset_local = 0;
 				moveup = GET_NEXT(moveup);
 				continue;
 			}			

--- a/code/weapon/beam.h
+++ b/code/weapon/beam.h
@@ -187,6 +187,8 @@ typedef struct beam {
 
 	float		beam_collide_width;
 	float		beam_light_width;
+
+	float u_offset_local;
 } beam;
 
 extern std::array<beam, MAX_BEAMS> Beams;				// all beams

--- a/code/weapon/weapon_flags.h
+++ b/code/weapon/weapon_flags.h
@@ -115,6 +115,7 @@ namespace Weapon {
 
 	FLAG_LIST(Beam_Info_Flags) {
 		Burst_share_random,
+		Track_own_texture_tiling,
 
 		NUM_VALUES
 	};

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -104,7 +104,8 @@ flag_def_list_new<Weapon::Burst_Flags> Burst_fire_flags[] = {
 const size_t Num_burst_fire_flags = sizeof(Burst_fire_flags)/sizeof(flag_def_list_new<Weapon::Burst_Flags>);
 
 flag_def_list_new<Weapon::Beam_Info_Flags> Beam_info_flags[] = {
-	{ "burst shares random target",		Weapon::Beam_Info_Flags::Burst_share_random,		        true, false }
+	{ "burst shares random target",		Weapon::Beam_Info_Flags::Burst_share_random,		        true, false },
+	{ "track own texture tiling",       Weapon::Beam_Info_Flags::Track_own_texture_tiling,          true, false }
 };
 
 const size_t Num_beam_info_flags = sizeof(Beam_info_flags) / sizeof(flag_def_list_new<Weapon::Beam_Info_Flags>);


### PR DESCRIPTION
To explain what this does:
A beam has sections that are translated over time according to the +Translation property of the sections of a beam.
This translation happens globally for all beams, and independently of if they are active or not.
This means, that the beam, when started, does not always look the same as the translation may be at a different point.
The new flag allows to make this more consistent, by tracking a beams translation offset (and resetting it to 0 before it gets rendered again). This allows for consistent beam appearances.
Usually, this is not a problem with continuous beams, but when using beams with projectile-like appearance like Talhydras did, then this flag allows for consistency in the moment you start up the beam.