### PR TITLE
Changed File not closed error to a warning and automatic file close

### DIFF
--- a/code/scripting/api/objs/file.cpp
+++ b/code/scripting/api/objs/file.cpp
@@ -14,7 +14,6 @@ cfile_h::~cfile_h()
 {
 	if (_cfp && cf_is_valid(_cfp.get())) {
 		Warning(LOCATION, "Lua cfile handle of file %s has been left open!\nYou should close the file with the object's close() method explicitly.\n", cf_get_filename(_cfp.get()));
-		close();
 	}
 }
 bool cfile_h::isValid() const { return _cfp != nullptr; }

--- a/code/scripting/api/objs/file.cpp
+++ b/code/scripting/api/objs/file.cpp
@@ -13,7 +13,8 @@ cfile_h::cfile_h(CFILE* cfp) : _cfp(cfp) {}
 cfile_h::~cfile_h()
 {
 	if (_cfp && cf_is_valid(_cfp.get())) {
-		Error(LOCATION, "Lua file handle has been left open!\n\nSorry, I can't say anything more than that...");
+		Warning(LOCATION, "Lua cfile handle of file %s has been left open!\nYou should close the file with the object's close() method explicitly.\n", cf_get_filename(_cfp.get()));
+		close();
 	}
 }
 bool cfile_h::isValid() const { return _cfp != nullptr; }


### PR DESCRIPTION
Previous message was cryptic, and since we are sure that the handle is invalid when it get's destructed (as it's out of scope in lua), we can just close the file then.
Still warn the user for the sake of best practices.