### PR TITLE
allow two SEXPs to be used in multiplayer that previously couldn't be

### DIFF
--- a/code/scripting/api/objs/ship.cpp
+++ b/code/scripting/api/objs/ship.cpp
@@ -1864,10 +1864,6 @@ ADE_FUNC(vanish, l_Ship, nullptr, "Vanishes this ship from the mission. Works in
 	if (!objh->IsValid())
 		return ade_set_error(L, "b", false);
 
-	// if MULTIPLAYER bail
-	if (Game_mode & GM_MULTIPLAYER)
-		return ade_set_error(L, "b", false);
-
 	ship_actually_depart(objh->objp->instance, SHIP_VANISHED);
 
 	return ade_set_args(L, "b", true);


### PR DESCRIPTION
1) The ship-vanish SEXP (and script function) was already multiplayer-ready
2) The is-ship-visible SEXP was enhanced to add a second argument, which defaults to the player's ship in single-player mode

And this adds a few useful Asserts to the caching functions as well.