### PR TITLE
Fix strings.tbl in unicode mode

### DIFF
--- a/code/parse/parselo.cpp
+++ b/code/parse/parselo.cpp
@@ -2293,7 +2293,7 @@ void coerce_to_utf8(SCP_string &buffer, const char *str)
 	Warning(LOCATION, "Truncating non-UTF-8 string '%s' to '%s'!\n", str, buffer.c_str());
 }
 
-const char* const get_encoding_string(int encoding) {
+const char* get_encoding_string(int encoding) {
 	switch (encoding) {
 	case ENCODING_ISO8859_1:
 		return "ISO-8859-1";

--- a/code/parse/parselo.cpp
+++ b/code/parse/parselo.cpp
@@ -2297,13 +2297,13 @@ void coerce_to_utf8(SCP_string &buffer, const char *str)
 void process_raw_file_text(char* processed_text, char* raw_text)
 {
 	SCP_string parse_exception_1402;
-	convert_encoding(parse_exception_1402, "1402, \"Sie haben IPX-Protokoll als Protokoll ausgew\xE4hlt, aber dieses Protokoll ist auf Ihrer Maschine nicht installiert.\".\"\n", ENCODING_ISO8859_1, ENCODING_CURRENT);
+	unicode::convert_encoding(parse_exception_1402, "1402, \"Sie haben IPX-Protokoll als Protokoll ausgew\xE4hlt, aber dieses Protokoll ist auf Ihrer Maschine nicht installiert.\".\"\n", unicode::Encoding_iso8859_1);
 	SCP_string parse_exception_1117;
-	convert_encoding(parse_exception_1117, "1117, \"\\r\\n\"Aucun web browser trouva. Del\xE0 isn't on emm\xE9nagea ou if \\r\\non est emm\xE9nagea, ca isn't set pour soient la default browser.\\r\\n\\r\\n\"\n", ENCODING_ISO8859_1, ENCODING_CURRENT);
+	unicode::convert_encoding(parse_exception_1117, "1117, \"\\r\\n\"Aucun web browser trouva. Del\xE0 isn't on emm\xE9nagea ou if \\r\\non est emm\xE9nagea, ca isn't set pour soient la default browser.\\r\\n\\r\\n\"\n", unicode::Encoding_iso8859_1);
 	SCP_string parse_exception_1337;
-	convert_encoding(parse_exception_1337, "1337, \"(fr)Loading\"\n", ENCODING_ISO8859_1, ENCODING_CURRENT);
+	unicode::convert_encoding(parse_exception_1337, "1337, \"(fr)Loading\"\n", unicode::Encoding_iso8859_1);
 	SCP_string parse_exception_3966;
-	convert_encoding(parse_exception_3966, "3966, \"Es sieht so aus, als habe Staffel Kappa Zugriff auf die GTVA-Zugangscodes f\xFCr das System gehabt. Das ist ein ernstes Sicherheitsleck. Ihre IFF-Kennung erschien als \"verb\xFCndet\", so da\xDF sie sich dem Konvoi ungehindert n\xE4hern konnten. Zum Gl\xFC\x63k flogen Sie und  Alpha 2 Geleitschutz und lie\xDF\x65n den Schwindel auffliegen, bevor Kappa ihren Befehl ausf\xFChren konnte.\"\n", ENCODING_ISO8859_1, ENCODING_CURRENT);
+	unicode::convert_encoding(parse_exception_3966, "3966, \"Es sieht so aus, als habe Staffel Kappa Zugriff auf die GTVA-Zugangscodes f\xFCr das System gehabt. Das ist ein ernstes Sicherheitsleck. Ihre IFF-Kennung erschien als \"verb\xFCndet\", so da\xDF sie sich dem Konvoi ungehindert n\xE4hern konnten. Zum Gl\xFC\x63k flogen Sie und  Alpha 2 Geleitschutz und lie\xDF\x65n den Schwindel auffliegen, bevor Kappa ihren Befehl ausf\xFChren konnte.\"\n", unicode::Encoding_iso8859_1);
 
 	char* mp;
 	char* mp_raw;

--- a/code/parse/parselo.cpp
+++ b/code/parse/parselo.cpp
@@ -2285,7 +2285,7 @@ void coerce_to_utf8(SCP_string &buffer, const char *str)
 	// we can convert it
 	if (isLatin1)
 	{
-		unicode::convert_encoding(buffer, str, unicode::Encoding_iso8859_1, unicode::Encoding_utf8);
+		unicode::convert_encoding(buffer, str, unicode::Encoding::Encoding_iso8859_1, unicode::Encoding::Encoding_utf8);
 	}
 
 	// unknown encoding, so just truncate
@@ -2297,13 +2297,13 @@ void coerce_to_utf8(SCP_string &buffer, const char *str)
 void process_raw_file_text(char* processed_text, char* raw_text)
 {
 	SCP_string parse_exception_1402;
-	unicode::convert_encoding(parse_exception_1402, "1402, \"Sie haben IPX-Protokoll als Protokoll ausgew\xE4hlt, aber dieses Protokoll ist auf Ihrer Maschine nicht installiert.\".\"\n", unicode::Encoding_iso8859_1);
+	unicode::convert_encoding(parse_exception_1402, "1402, \"Sie haben IPX-Protokoll als Protokoll ausgew\xE4hlt, aber dieses Protokoll ist auf Ihrer Maschine nicht installiert.\".\"\n", unicode::Encoding::Encoding_iso8859_1);
 	SCP_string parse_exception_1117;
-	unicode::convert_encoding(parse_exception_1117, "1117, \"\\r\\n\"Aucun web browser trouva. Del\xE0 isn't on emm\xE9nagea ou if \\r\\non est emm\xE9nagea, ca isn't set pour soient la default browser.\\r\\n\\r\\n\"\n", unicode::Encoding_iso8859_1);
+	unicode::convert_encoding(parse_exception_1117, "1117, \"\\r\\n\"Aucun web browser trouva. Del\xE0 isn't on emm\xE9nagea ou if \\r\\non est emm\xE9nagea, ca isn't set pour soient la default browser.\\r\\n\\r\\n\"\n", unicode::Encoding::Encoding_iso8859_1);
 	SCP_string parse_exception_1337;
-	unicode::convert_encoding(parse_exception_1337, "1337, \"(fr)Loading\"\n", unicode::Encoding_iso8859_1);
+	unicode::convert_encoding(parse_exception_1337, "1337, \"(fr)Loading\"\n", unicode::Encoding::Encoding_iso8859_1);
 	SCP_string parse_exception_3966;
-	unicode::convert_encoding(parse_exception_3966, "3966, \"Es sieht so aus, als habe Staffel Kappa Zugriff auf die GTVA-Zugangscodes f\xFCr das System gehabt. Das ist ein ernstes Sicherheitsleck. Ihre IFF-Kennung erschien als \"verb\xFCndet\", so da\xDF sie sich dem Konvoi ungehindert n\xE4hern konnten. Zum Gl\xFC\x63k flogen Sie und  Alpha 2 Geleitschutz und lie\xDF\x65n den Schwindel auffliegen, bevor Kappa ihren Befehl ausf\xFChren konnte.\"\n", unicode::Encoding_iso8859_1);
+	unicode::convert_encoding(parse_exception_3966, "3966, \"Es sieht so aus, als habe Staffel Kappa Zugriff auf die GTVA-Zugangscodes f\xFCr das System gehabt. Das ist ein ernstes Sicherheitsleck. Ihre IFF-Kennung erschien als \"verb\xFCndet\", so da\xDF sie sich dem Konvoi ungehindert n\xE4hern konnten. Zum Gl\xFC\x63k flogen Sie und  Alpha 2 Geleitschutz und lie\xDF\x65n den Schwindel auffliegen, bevor Kappa ihren Befehl ausf\xFChren konnte.\"\n", unicode::Encoding::Encoding_iso8859_1);
 
 	char* mp;
 	char* mp_raw;

--- a/code/parse/parselo.h
+++ b/code/parse/parselo.h
@@ -66,6 +66,10 @@ extern int Token_found_flag;
 #define SEXP_SAVE_MODE				1
 #define SEXP_ERROR_CHECK_MODE		2
 
+#define ENCODING_CURRENT	0
+#define ENCODING_UTF8		1
+#define ENCODING_ISO8859_1	2
+
 // Goober5000 - this seems to be a pretty universal function
 extern bool end_string_at_first_hash_symbol(char *src, bool ignore_doubled_hash = false);
 extern bool end_string_at_first_hash_symbol(SCP_string &src, bool ignore_doubled_hash = false);
@@ -256,8 +260,8 @@ extern void read_file_text_from_default(const default_file& file, char *processe
 extern void read_raw_file_text(const char *filename, int mode = CF_TYPE_ANY, char *raw_text = NULL);
 extern void process_raw_file_text(char *processed_text = NULL, char *raw_text = NULL);
 extern void coerce_to_utf8(SCP_string &buffer, const char *src);
-extern SCP_string iso8859_1_to_current(const char* src);
-extern SCP_string utf8_to_current(const char* src);
+extern const char* const get_encoding_string(int encoding);
+extern void convert_encoding(SCP_string& buffer, const char* src, int encoding_src, int encoding_dest = ENCODING_CURRENT);
 extern void debug_show_mission_text();
 extern void convert_sexp_to_string(SCP_string &dest, int cur_node, int mode);
 extern size_t maybe_convert_foreign_characters(const char *in, char *out, bool add_null = true);

--- a/code/parse/parselo.h
+++ b/code/parse/parselo.h
@@ -260,7 +260,7 @@ extern void read_file_text_from_default(const default_file& file, char *processe
 extern void read_raw_file_text(const char *filename, int mode = CF_TYPE_ANY, char *raw_text = NULL);
 extern void process_raw_file_text(char *processed_text = NULL, char *raw_text = NULL);
 extern void coerce_to_utf8(SCP_string &buffer, const char *src);
-extern const char* const get_encoding_string(int encoding);
+extern const char* get_encoding_string(int encoding);
 extern void convert_encoding(SCP_string& buffer, const char* src, int encoding_src, int encoding_dest = ENCODING_CURRENT);
 extern void debug_show_mission_text();
 extern void convert_sexp_to_string(SCP_string &dest, int cur_node, int mode);

--- a/code/parse/parselo.h
+++ b/code/parse/parselo.h
@@ -256,6 +256,8 @@ extern void read_file_text_from_default(const default_file& file, char *processe
 extern void read_raw_file_text(const char *filename, int mode = CF_TYPE_ANY, char *raw_text = NULL);
 extern void process_raw_file_text(char *processed_text = NULL, char *raw_text = NULL);
 extern void coerce_to_utf8(SCP_string &buffer, const char *src);
+extern SCP_string iso8859_1_to_current(const char* src);
+extern SCP_string utf8_to_current(const char* src);
 extern void debug_show_mission_text();
 extern void convert_sexp_to_string(SCP_string &dest, int cur_node, int mode);
 extern size_t maybe_convert_foreign_characters(const char *in, char *out, bool add_null = true);

--- a/code/parse/parselo.h
+++ b/code/parse/parselo.h
@@ -66,10 +66,6 @@ extern int Token_found_flag;
 #define SEXP_SAVE_MODE				1
 #define SEXP_ERROR_CHECK_MODE		2
 
-#define ENCODING_CURRENT	0
-#define ENCODING_UTF8		1
-#define ENCODING_ISO8859_1	2
-
 // Goober5000 - this seems to be a pretty universal function
 extern bool end_string_at_first_hash_symbol(char *src, bool ignore_doubled_hash = false);
 extern bool end_string_at_first_hash_symbol(SCP_string &src, bool ignore_doubled_hash = false);
@@ -260,8 +256,6 @@ extern void read_file_text_from_default(const default_file& file, char *processe
 extern void read_raw_file_text(const char *filename, int mode = CF_TYPE_ANY, char *raw_text = NULL);
 extern void process_raw_file_text(char *processed_text = NULL, char *raw_text = NULL);
 extern void coerce_to_utf8(SCP_string &buffer, const char *src);
-extern const char* get_encoding_string(int encoding);
-extern void convert_encoding(SCP_string& buffer, const char* src, int encoding_src, int encoding_dest = ENCODING_CURRENT);
 extern void debug_show_mission_text();
 extern void convert_sexp_to_string(SCP_string &dest, int cur_node, int mode);
 extern size_t maybe_convert_foreign_characters(const char *in, char *out, bool add_null = true);

--- a/code/utils/unicode.cpp
+++ b/code/utils/unicode.cpp
@@ -156,4 +156,87 @@ size_t encoded_size(codepoint_t cp) {
 		return 1;
 	}
 }
+
+
+const char* get_encoding_string(Encoding encoding) {
+	switch (encoding) {
+	case Encoding_iso8859_1:
+		return "ISO-8859-1";
+	case Encoding_utf8:
+		return "UTF-8";
+	case Encoding_current:
+	default:
+		UNREACHABLE("Unknown encoding type was passed: %d\n", encoding);
+		return "";
+	}
+}
+
+void convert_encoding(SCP_string& buffer, const char* src, Encoding encoding_src, Encoding encoding_dest) {
+
+	if (encoding_src == Encoding_current)
+		encoding_src = Unicode_text_mode ? Encoding_utf8 : Encoding_iso8859_1;
+
+	if (encoding_dest == Encoding_current)
+		encoding_dest = Unicode_text_mode ? Encoding_utf8 : Encoding_iso8859_1;
+
+	//We are already in the correct encoding, the string is correct
+	if (encoding_src == encoding_dest) {
+		buffer.assign(src);
+		return;
+	}
+
+	//If not, convert
+	auto len = strlen(src);
+
+	// Validate if no change needs to be done
+	bool valid = true;
+
+	for (size_t i = 0; i < len; i++) {
+		if (src[i] > 0x79 || src[i] < 0) {
+			valid = false;
+			break;
+		}
+	}
+
+	if (valid)
+	{
+		// turns out this is valid anyways
+		buffer.assign(src);
+		return;
+	}
+
+	size_t newlen = len;
+	std::unique_ptr<char[]> newstr(new char[newlen]);
+
+	do {
+		auto in_str = src;
+		auto in_size = len;
+		auto out_str = newstr.get();
+		auto out_size = newlen;
+
+		auto iconv = SDL_iconv_open(get_encoding_string(encoding_dest), get_encoding_string(encoding_src));
+		auto err = SDL_iconv(iconv, &in_str, &in_size, &out_str, &out_size);
+		SDL_iconv_close(iconv);
+
+		// SDL returns the number of processed character on success;
+		// error codes are (size_t)-1 through -4
+		if (err < (size_t)-100)
+		{
+			// successful re-encoding
+			buffer.assign(newstr.get(), newlen - out_size);
+			return;
+		}
+		else if (err == SDL_ICONV_E2BIG)
+		{
+			// buffer is not big enough, try again with a bigger buffer. Use a rather conservative size
+			// increment since the additional size required is probably pretty small
+			newlen += 10;
+			newstr.reset(new char[newlen]);
+		}
+		else
+		{
+			break;
+		}
+	} while (true);
+}
 }

--- a/code/utils/unicode.cpp
+++ b/code/utils/unicode.cpp
@@ -160,11 +160,11 @@ size_t encoded_size(codepoint_t cp) {
 
 const char* get_encoding_string(Encoding encoding) {
 	switch (encoding) {
-	case Encoding_iso8859_1:
+	case Encoding::Encoding_iso8859_1:
 		return "ISO-8859-1";
-	case Encoding_utf8:
+	case Encoding::Encoding_utf8:
 		return "UTF-8";
-	case Encoding_current:
+	case Encoding::Encoding_current:
 	default:
 		UNREACHABLE("Unknown encoding type was passed: %d\n", encoding);
 		return "";
@@ -173,11 +173,11 @@ const char* get_encoding_string(Encoding encoding) {
 
 void convert_encoding(SCP_string& buffer, const char* src, Encoding encoding_src, Encoding encoding_dest) {
 
-	if (encoding_src == Encoding_current)
-		encoding_src = Unicode_text_mode ? Encoding_utf8 : Encoding_iso8859_1;
+	if (encoding_src == Encoding::Encoding_current)
+		encoding_src = Unicode_text_mode ? Encoding::Encoding_utf8 : Encoding::Encoding_iso8859_1;
 
-	if (encoding_dest == Encoding_current)
-		encoding_dest = Unicode_text_mode ? Encoding_utf8 : Encoding_iso8859_1;
+	if (encoding_dest == Encoding::Encoding_current)
+		encoding_dest = Unicode_text_mode ? Encoding::Encoding_utf8 : Encoding::Encoding_iso8859_1;
 
 	//We are already in the correct encoding, the string is correct
 	if (encoding_src == encoding_dest) {

--- a/code/utils/unicode.cpp
+++ b/code/utils/unicode.cpp
@@ -166,7 +166,7 @@ const char* get_encoding_string(Encoding encoding) {
 		return "UTF-8";
 	case Encoding::Encoding_current:
 	default:
-		UNREACHABLE("Unknown encoding type was passed: %d\n", encoding);
+		UNREACHABLE("Unknown encoding type was passed.\n");
 		return "";
 	}
 }

--- a/code/utils/unicode.cpp
+++ b/code/utils/unicode.cpp
@@ -157,6 +157,14 @@ size_t encoded_size(codepoint_t cp) {
 	}
 }
 
+bool string_is_ascii_only(const char* str, size_t len) {
+	for (size_t i = 0; i < len; i++) {
+		if (str[i] > 0x79 || str[i] < 0)
+			return false;
+	}
+
+	return true;
+}
 
 const char* get_encoding_string(Encoding encoding) {
 	switch (encoding) {
@@ -189,16 +197,7 @@ void convert_encoding(SCP_string& buffer, const char* src, Encoding encoding_src
 	auto len = strlen(src);
 
 	// Validate if no change needs to be done
-	bool valid = true;
-
-	for (size_t i = 0; i < len; i++) {
-		if (src[i] > 0x79 || src[i] < 0) {
-			valid = false;
-			break;
-		}
-	}
-
-	if (valid)
+	if (string_is_ascii_only(src, len))
 	{
 		// turns out this is valid anyways
 		buffer.assign(src);

--- a/code/utils/unicode.cpp
+++ b/code/utils/unicode.cpp
@@ -179,7 +179,7 @@ const char* get_encoding_string(Encoding encoding) {
 	}
 }
 
-void convert_encoding(SCP_string& buffer, const char* src, Encoding encoding_src, Encoding encoding_dest) {
+bool convert_encoding(SCP_string& buffer, const char* src, Encoding encoding_src, Encoding encoding_dest) {
 
 	if (encoding_src == Encoding::Encoding_current)
 		encoding_src = Unicode_text_mode ? Encoding::Encoding_utf8 : Encoding::Encoding_iso8859_1;
@@ -190,7 +190,7 @@ void convert_encoding(SCP_string& buffer, const char* src, Encoding encoding_src
 	//We are already in the correct encoding, the string is correct
 	if (encoding_src == encoding_dest) {
 		buffer.assign(src);
-		return;
+		return true;
 	}
 
 	//If not, convert
@@ -201,7 +201,7 @@ void convert_encoding(SCP_string& buffer, const char* src, Encoding encoding_src
 	{
 		// turns out this is valid anyways
 		buffer.assign(src);
-		return;
+		return true;
 	}
 
 	size_t newlen = len;
@@ -223,7 +223,7 @@ void convert_encoding(SCP_string& buffer, const char* src, Encoding encoding_src
 		{
 			// successful re-encoding
 			buffer.assign(newstr.get(), newlen - out_size);
-			return;
+			return true;
 		}
 		else if (err == SDL_ICONV_E2BIG)
 		{
@@ -237,5 +237,7 @@ void convert_encoding(SCP_string& buffer, const char* src, Encoding encoding_src
 			break;
 		}
 	} while (true);
+
+	return false;
 }
 }

--- a/code/utils/unicode.h
+++ b/code/utils/unicode.h
@@ -167,5 +167,5 @@ enum class Encoding { Encoding_current, Encoding_utf8, Encoding_iso8859_1 };
 
 bool string_is_ascii_only(const char* str, size_t len);
 const char* get_encoding_string(Encoding encoding);
-void convert_encoding(SCP_string& buffer, const char* src, Encoding encoding_src, Encoding encoding_dest = Encoding::Encoding_current);
+bool convert_encoding(SCP_string& buffer, const char* src, Encoding encoding_src, Encoding encoding_dest = Encoding::Encoding_current);
 }

--- a/code/utils/unicode.h
+++ b/code/utils/unicode.h
@@ -165,6 +165,7 @@ void advance(octet_iterator& start, size_t n, octet_iterator end) {
 
 enum class Encoding { Encoding_current, Encoding_utf8, Encoding_iso8859_1 };
 
+bool string_is_ascii_only(const char* str, size_t len);
 const char* get_encoding_string(Encoding encoding);
 void convert_encoding(SCP_string& buffer, const char* src, Encoding encoding_src, Encoding encoding_dest = Encoding::Encoding_current);
 }

--- a/code/utils/unicode.h
+++ b/code/utils/unicode.h
@@ -163,4 +163,8 @@ void advance(octet_iterator& start, size_t n, octet_iterator end) {
 	}
 }
 
+enum Encoding { Encoding_current, Encoding_utf8, Encoding_iso8859_1	};
+
+const char* get_encoding_string(Encoding encoding);
+void convert_encoding(SCP_string& buffer, const char* src, Encoding encoding_src, Encoding encoding_dest = Encoding_current);
 }

--- a/code/utils/unicode.h
+++ b/code/utils/unicode.h
@@ -163,8 +163,8 @@ void advance(octet_iterator& start, size_t n, octet_iterator end) {
 	}
 }
 
-enum Encoding { Encoding_current, Encoding_utf8, Encoding_iso8859_1	};
+enum class Encoding { Encoding_current, Encoding_utf8, Encoding_iso8859_1 };
 
 const char* get_encoding_string(Encoding encoding);
-void convert_encoding(SCP_string& buffer, const char* src, Encoding encoding_src, Encoding encoding_dest = Encoding_current);
+void convert_encoding(SCP_string& buffer, const char* src, Encoding encoding_src, Encoding encoding_dest = Encoding::Encoding_current);
 }


### PR DESCRIPTION
This will fix #2994.
It consist of two parts, one two helper functions to convert strings of a known encoding into the encoding currently used by FSO. Even if we wanted to hardcode the alterative unicode match strings as opposed as determining them at runtime, we _will_ need these functions anyway for the controls6, as there the local-specific keynames by SDL are always in UTF-8 and need to be converted, which is why I would advocate for adding these functions anyways.
Part two is the actual matching. This is... kinda ugly here. Especially with the offset where the changes need to be made changing depending on the game being in unicode mode or not. At least it works, and will now start both in normal mode and unicode mode when not set to english. Though I am open to suggestions, in case you don't like this solution.