### PR TITLE
Increase max nebula poofs to 32

### DIFF
--- a/code/nebula/neb.cpp
+++ b/code/nebula/neb.cpp
@@ -964,10 +964,6 @@ void neb2_render_poofs()
 	if (!(The_mission.flags[Mission::Mission_Flags::Fullneb])) {
 		return;
 	}
-	
-	// no poofs, bail
-	if (!Neb2_poof_flags)
-		return;
 
 	if (Neb2_regen) {
 		neb2_regen();
@@ -1324,9 +1320,12 @@ void neb2_get_eye_orient(matrix *eye_matrix)
 // get a (semi) random bitmap to use for a poof
 int neb2_get_bitmap()
 {
-	Assertion(Neb2_poof_flags, "Cannot get a random poof without any poofs!");
+	if (Neb2_poof_flags == 0)
+		return -1;
+
 	int neb2_choose = 0;
 	int mission_num_poofs = 0;
+
 
 	// count up poofs in use
 	for (int i = 0; i < MAX_NEB2_POOFS; i++) {
@@ -1348,10 +1347,6 @@ int neb2_get_bitmap()
 		}
 	}
 
-	// bitmap 0
-	if (Neb2_poofs[neb2_choose] < 0) {
-		return Neb2_poofs[0];
-	}
 	return Neb2_poofs[neb2_choose];
 }
 

--- a/code/nebula/neb.cpp
+++ b/code/nebula/neb.cpp
@@ -59,11 +59,9 @@ AccelStar II
 int Neb2_render_mode = NEB2_RENDER_NONE;
 
 // array of neb2 poofs
-char Neb2_poof_filenames[MAX_NEB2_POOFS][MAX_FILENAME_LEN] = {
-	"", "", "", "", "", ""
-};
-int Neb2_poofs[MAX_NEB2_POOFS] = { -1, -1, -1, -1, -1, -1 };
-int Neb2_poof_flags = ( (1<<0) | (1<<1) | (1<<2) | (1<<3) | (1<<4) | (1<<5) );
+char Neb2_poof_filenames[MAX_NEB2_POOFS][MAX_FILENAME_LEN];
+int Neb2_poofs[MAX_NEB2_POOFS];
+int Neb2_poof_flags = 0;
 int Neb2_poof_count = 0;
 
 // array of neb2 bitmaps
@@ -271,6 +269,12 @@ void neb2_init()
 {
 	char name[MAX_FILENAME_LEN];
 
+	for (int& bitmap : Neb2_poofs)
+		bitmap = -1;
+
+	for (auto& filename : Neb2_poof_filenames)
+		filename[0] = '\0';
+
 	try
 	{
 		// read in the nebula.tbl
@@ -306,9 +310,6 @@ void neb2_init()
 				WarningEx(LOCATION, "nebula.tbl\nExceeded maximum number of nebula poofs (%d)!\nSkipping %s.", MAX_NEB2_POOFS, name);
 			}
 		}
-
-		// should always have 6 neb poofs
-		Assert(Neb2_poof_count == 6);
 	}
 	catch (const parse::ParseException& e)
 	{
@@ -439,6 +440,18 @@ void neb2_post_level_init()
 		Neb2_render_mode = NEB2_RENDER_NONE;
 		Neb2_awacs = -1.0f;
 	}
+
+	// truncate the poof flags down to the poofs we have
+	if (Neb2_poof_count < MAX_NEB2_POOFS) {
+		int available_poofs_mask = (1 << Neb2_poof_count) - 1;
+
+		// check for negative here too, because if we're not at max, 32, then we're gauranteed not to have the sign bit
+		if (Neb2_poof_flags > available_poofs_mask || Neb2_poof_flags < 0)
+			Warning(LOCATION, "One or more invalid nebula poofs detected!");
+
+		Neb2_poof_flags = Neb2_poof_flags & available_poofs_mask;
+	}
+
 }
 
 // shutdown nebula stuff
@@ -931,7 +944,7 @@ DCF(max_area, "")
 int frames_total = 0;
 int frame_count = 0;
 float frame_avg;
-void neb2_render_player()
+void neb2_render_poofs()
 {
 	GR_DEBUG_SCOPE("Nebula render player");
 
@@ -951,6 +964,10 @@ void neb2_render_player()
 	if (!(The_mission.flags[Mission::Mission_Flags::Fullneb])) {
 		return;
 	}
+	
+	// no poofs, bail
+	if (!Neb2_poof_flags)
+		return;
 
 	if (Neb2_regen) {
 		neb2_regen();
@@ -1307,28 +1324,28 @@ void neb2_get_eye_orient(matrix *eye_matrix)
 // get a (semi) random bitmap to use for a poof
 int neb2_get_bitmap()
 {
-	int count = 0;
-	int huh;
-	static int neb2_choose = 0;
+	Assertion(Neb2_poof_flags, "Cannot get a random poof without any poofs!");
+	int neb2_choose = 0;
+	int mission_num_poofs = 0;
 
-	// get a random count
-	count = (int)frand_range(1.0f, 5.0f);
+	// count up poofs in use
+	for (int i = 0; i < MAX_NEB2_POOFS; i++) {
+		if (Neb2_poof_flags & (1 << i))
+			mission_num_poofs++;
+	}
 
-	// very ad-hoc
-	while(count > 0) {
-		// don't cycle too many times
-		huh = 0;
-		do {
-			if(neb2_choose == MAX_NEB2_POOFS - 1){
-				neb2_choose = 0;
-			} else {
-				neb2_choose++;
-			}
+	// a pick a random one of the available number
+	neb2_choose = (int)(golden_ratio_rand() * mission_num_poofs);
 
-			huh++;
+	// grab that one from our poofs
+	for (int i = 0; i < MAX_NEB2_POOFS; i++) {
+		if (Neb2_poof_flags & (1 << i)) {
+			if (neb2_choose == 0) {
+				neb2_choose = i;
+				break;
+			} else
+				neb2_choose--;
 		}
-		while(!(Neb2_poof_flags & (1<<neb2_choose)) && (huh < 10));
-		count--;
 	}
 
 	// bitmap 0

--- a/code/nebula/neb.cpp
+++ b/code/nebula/neb.cpp
@@ -61,7 +61,7 @@ int Neb2_render_mode = NEB2_RENDER_NONE;
 // array of neb2 poofs
 char Neb2_poof_filenames[MAX_NEB2_POOFS][MAX_FILENAME_LEN];
 int Neb2_poofs[MAX_NEB2_POOFS];
-int Neb2_poof_flags = 0;
+int32_t Neb2_poof_flags = 0;
 int Neb2_poof_count = 0;
 
 // array of neb2 bitmaps

--- a/code/nebula/neb.h
+++ b/code/nebula/neb.h
@@ -40,7 +40,7 @@ extern float Neb2_awacs;
 extern float Neb2_fog_near_mult;
 extern float Neb2_fog_far_mult;
 
-#define MAX_NEB2_POOFS				6
+#define MAX_NEB2_POOFS				32
 
 // poof names and flags (for fred)
 extern char Neb2_poof_filenames[MAX_NEB2_POOFS][MAX_FILENAME_LEN];	
@@ -107,7 +107,7 @@ void neb2_level_close();
 void neb2_render_setup(camid cid);
 
 // render the player nebula
-void neb2_render_player();
+void neb2_render_poofs();
 
 // call this when the player's viewpoint has changed, this will cause the code to properly reset
 // the eye's local poofs

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -3329,7 +3329,7 @@ void game_render_frame( camid cid )
 	nebl_render_all();
 
 	// render local player nebula
-	neb2_render_player();
+	neb2_render_poofs();
 
 	batching_render_all(false);
 


### PR DESCRIPTION
As part of a collab with @Goober5000 this is just the engine side of the changes, FRED will need to be updated at some point to allow setting of more than the first 6 without manually editing the mission file. The currently used methods for poof assignment uses a bitfield stored in an `int`, so we have 26 bits lying around that can be used without any significant data structure changes. 

Also comes with support for 0 (or not max) poofs, previously not possible, and a less confusing random poof picker (the assertion added should always be true because `neb2_render_poofs()` is the only thing that calls `neb2_get_bitmap()`.