### PR TITLE
Make nebula poof detail settings partially dynamic

### DIFF
--- a/code/io/keycontrol.cpp
+++ b/code/io/keycontrol.cpp
@@ -692,15 +692,6 @@ void process_debug_keys(int k)
 		case KEY_DEBUGGED + KEY_H:
 			hud_target_toggle_hidden_from_sensors();
 			break;
-
-		case KEY_DEBUGGED + KEY_F: 
-			extern int wacky_scheme;
-			if(wacky_scheme == 3){
-				wacky_scheme = 0;
-			} else {
-				wacky_scheme++;
-			}
-			break;
 		
 		case KEY_DEBUGGED + KEY_ALTED + KEY_F:
 			Framerate_delay += 10;

--- a/code/nebula/neb.cpp
+++ b/code/nebula/neb.cpp
@@ -426,7 +426,7 @@ void neb2_post_level_init()
 	for (auto poof : Neb2_poofs) {
 		int bm_height;
 		bm_get_info(poof, nullptr, &bm_height);
-		height = MAX(height, static_cast<float>(bm_height));
+		height = MAX(height, static_cast<float>(bm_height * 2));
 	}
 
 	for (auto& detail : Neb2_detail) {

--- a/code/nebula/neb.cpp
+++ b/code/nebula/neb.cpp
@@ -170,7 +170,7 @@ neb2_detail	Neb2_detail[MAX_DETAIL_LEVEL] = {
 	{ // lowest detail level
 		0.575f,							// max alpha for this detail level in Glide
 		0.71f,							// max alpha for this detail level in D3d
-		0.13f,							// break alpha (below which, poofs don't draw). this affects the speed and visual quality a lot
+		0.013f,							// break alpha (below which, poofs don't draw). this affects the speed and visual quality a lot
 		150.0f, 150.0f / 1.3333f,		// x and y alpha fade/break values. adjust alpha on the polys as they move offscreen 
 		510.0f,							// total dimension of player poof cube
 		50.0f,							// inner radius of the player poof cube
@@ -181,7 +181,7 @@ neb2_detail	Neb2_detail[MAX_DETAIL_LEVEL] = {
 	{ // 2nd lowest detail level
 		0.575f,							// max alpha for this detail level in Glide
 		0.71f,							// max alpha for this detail level in D3d
-		0.125f,							// break alpha (below which, poofs don't draw). this affects the speed and visual quality a lot
+		0.0125f,							// break alpha (below which, poofs don't draw). this affects the speed and visual quality a lot
 		300.0f, 300.0f / 1.3333f,		// x and y alpha fade/break values. adjust alpha on the polys as they move offscreen 
 		550.0f,							// total dimension of player poof cube
 		100.0f,							// inner radius of the player poof cube
@@ -192,7 +192,7 @@ neb2_detail	Neb2_detail[MAX_DETAIL_LEVEL] = {
 	{ // 2nd highest detail level
 		0.575f,							// max alpha for this detail level in Glide
 		0.71f,							// max alpha for this detail level in D3d
-		0.1f,							// break alpha (below which, poofs don't draw). this affects the speed and visual quality a lot
+		0.01f,							// break alpha (below which, poofs don't draw). this affects the speed and visual quality a lot
 		300.0f, 300.0f / 1.3333f,		// x and y alpha fade/break values. adjust alpha on the polys as they move offscreen 
 		550.0f,							// total dimension of player poof cube
 		150.0f,							// inner radius of the player poof cube
@@ -203,7 +203,7 @@ neb2_detail	Neb2_detail[MAX_DETAIL_LEVEL] = {
 	{ // higest detail level
 		0.475f,							// max alpha for this detail level in Glide
 		0.575f,							// max alpha for this detail level in D3d
-		0.05f,							// break alpha (below which, poofs don't draw). this affects the speed and visual quality a lot
+		0.005f,							// break alpha (below which, poofs don't draw). this affects the speed and visual quality a lot
 		200.0f, 200.0f / 1.3333f,		// x and y alpha fade/break values. adjust alpha on the polys as they move offscreen 
 		750.0f,							// total dimension of player poof cube
 		200.0f,							// inner radius of the player poof cube
@@ -420,6 +420,18 @@ void neb2_post_level_init()
 		if (Neb2_poofs[idx] < 0) {
 			Neb2_poofs[idx] = bm_load(Neb2_poof_filenames[idx]);
 		}
+	}
+
+	float height = Neb2_detail[MAX_DETAIL_LEVEL-1].break_y;
+	for (auto poof : Neb2_poofs) {
+		int bm_height;
+		bm_get_info(poof, nullptr, &bm_height);
+		height = MAX(height, static_cast<float>(bm_height));
+	}
+
+	for (auto& detail : Neb2_detail) {
+		detail.break_y = height;
+		detail.break_x = height * gr_screen.aspect;
 	}
 
 	pneb_tried = 0;

--- a/code/nebula/neb.cpp
+++ b/code/nebula/neb.cpp
@@ -1284,9 +1284,6 @@ void neb2_pre_render(camid cid)
 	}
 }
 
-// wacky scheme for smoothing colors
-int wacky_scheme = 3;
-
 // fill in the position of the eye for this frame
 void neb2_get_eye_pos(vec3d *eye_vector)
 {
@@ -1395,17 +1392,6 @@ DCF(neb2_max_alpha, "max alpha value (0.0 to 1.0) for cloud poofs.")
 DCF(neb2_break_alpha, "alpha value (0.0 to 1.0) at which faded polygons are not drawn.")
 {
 	dc_stuff_float(&Nd->break_alpha);
-}
-
-DCF(neb2_smooth, "magic fog smoothing modes (0 - 3)")
-{
-	int index;
-	dc_stuff_int(&index);
-	if ( (index >= 0) && (index <= 3) ) {
-		wacky_scheme = index;
-	} else {
-		dc_printf("Invalid smooth mode %i", index);
-	}
 }
 
 DCF(neb2_select, "Enables/disables a poof bitmap")

--- a/code/nebula/neb.cpp
+++ b/code/nebula/neb.cpp
@@ -422,16 +422,9 @@ void neb2_post_level_init()
 		}
 	}
 
-	float height = Neb2_detail[MAX_DETAIL_LEVEL-1].break_y;
-	for (auto poof : Neb2_poofs) {
-		int bm_height;
-		bm_get_info(poof, nullptr, &bm_height);
-		height = MAX(height, static_cast<float>(bm_height * 2));
-	}
-
 	for (auto& detail : Neb2_detail) {
-		detail.break_y = height;
-		detail.break_x = height * gr_screen.aspect;
+		detail.break_y = gr_screen.max_h;
+		detail.break_x = gr_screen.max_w;
 	}
 
 	pneb_tried = 0;

--- a/code/nebula/neb.cpp
+++ b/code/nebula/neb.cpp
@@ -171,7 +171,6 @@ neb2_detail	Neb2_detail[MAX_DETAIL_LEVEL] = {
 		0.575f,							// max alpha for this detail level in Glide
 		0.71f,							// max alpha for this detail level in D3d
 		0.013f,							// break alpha (below which, poofs don't draw). this affects the speed and visual quality a lot
-		150.0f, 150.0f / 1.3333f,		// x and y alpha fade/break values. adjust alpha on the polys as they move offscreen 
 		510.0f,							// total dimension of player poof cube
 		50.0f,							// inner radius of the player poof cube
 		250.0f,							// outer radius of the player pood cube
@@ -182,7 +181,6 @@ neb2_detail	Neb2_detail[MAX_DETAIL_LEVEL] = {
 		0.575f,							// max alpha for this detail level in Glide
 		0.71f,							// max alpha for this detail level in D3d
 		0.0125f,							// break alpha (below which, poofs don't draw). this affects the speed and visual quality a lot
-		300.0f, 300.0f / 1.3333f,		// x and y alpha fade/break values. adjust alpha on the polys as they move offscreen 
 		550.0f,							// total dimension of player poof cube
 		100.0f,							// inner radius of the player poof cube
 		250.0f,							// outer radius of the player pood cube
@@ -193,7 +191,6 @@ neb2_detail	Neb2_detail[MAX_DETAIL_LEVEL] = {
 		0.575f,							// max alpha for this detail level in Glide
 		0.71f,							// max alpha for this detail level in D3d
 		0.01f,							// break alpha (below which, poofs don't draw). this affects the speed and visual quality a lot
-		300.0f, 300.0f / 1.3333f,		// x and y alpha fade/break values. adjust alpha on the polys as they move offscreen 
 		550.0f,							// total dimension of player poof cube
 		150.0f,							// inner radius of the player poof cube
 		250.0f,							// outer radius of the player pood cube
@@ -204,7 +201,6 @@ neb2_detail	Neb2_detail[MAX_DETAIL_LEVEL] = {
 		0.475f,							// max alpha for this detail level in Glide
 		0.575f,							// max alpha for this detail level in D3d
 		0.005f,							// break alpha (below which, poofs don't draw). this affects the speed and visual quality a lot
-		200.0f, 200.0f / 1.3333f,		// x and y alpha fade/break values. adjust alpha on the polys as they move offscreen 
 		750.0f,							// total dimension of player poof cube
 		200.0f,							// inner radius of the player poof cube
 		360.0f,							// outer radius of the player pood cube
@@ -420,11 +416,6 @@ void neb2_post_level_init()
 		if (Neb2_poofs[idx] < 0) {
 			Neb2_poofs[idx] = bm_load(Neb2_poof_filenames[idx]);
 		}
-	}
-
-	for (auto& detail : Neb2_detail) {
-		detail.break_y = gr_screen.max_h;
-		detail.break_x = gr_screen.max_w;
 	}
 
 	pneb_tried = 0;
@@ -697,8 +688,8 @@ float neb2_get_alpha_2shell(float inner_radius, float outer_radius, float magic_
 float neb2_get_alpha_offscreen(float sx, float sy, float incoming_alpha)
 {
 	float alpha = 0.0f;
-	float per_pixel_x = incoming_alpha / (float)Nd->break_x;
-	float per_pixel_y = incoming_alpha / (float)Nd->break_y;
+	float per_pixel_x = incoming_alpha / (float)gr_screen.max_w;
+	float per_pixel_y = incoming_alpha / (float)gr_screen.max_h;
 	int off_x = ((sx < 0.0f) || (sx > (float)gr_screen.max_w));
 	int off_y = ((sy < 0.0f) || (sy > (float)gr_screen.max_h));
 	float off_x_amount = 0.0f;
@@ -1404,14 +1395,6 @@ DCF(neb2_max_alpha, "max alpha value (0.0 to 1.0) for cloud poofs.")
 DCF(neb2_break_alpha, "alpha value (0.0 to 1.0) at which faded polygons are not drawn.")
 {
 	dc_stuff_float(&Nd->break_alpha);
-}
-
-DCF(neb2_break_off, "how many pixels offscreen (left, right, top, bottom) when a cloud poof becomes fully transparent.")
-{
-	int value;
-	dc_stuff_int(&value);
-	Nd->break_y = (float)value;
-	Nd->break_x = Nd->break_y * gr_screen.aspect;
 }
 
 DCF(neb2_smooth, "magic fog smoothing modes (0 - 3)")

--- a/code/nebula/neb.h
+++ b/code/nebula/neb.h
@@ -87,7 +87,6 @@ typedef struct neb2_detail {
 	float max_alpha_glide;		// max alpha for this detail level in Glide
 	float max_alpha_d3d;		// max alpha for this detail level in D3d
 	float break_alpha;			// break alpha (below which, poofs don't draw). this affects the speed and visual quality a lot
-	float break_x, break_y;		// x and y alpha fade/break values. adjust alpha on the polys as they move offscreen
 	float cube_dim;				// total dimension of player poof cube
 	float cube_inner;			// inner radius of the player poof cube
 	float cube_outer;			// outer radius of the player pood cube


### PR DESCRIPTION
After loading the nebula poofs, resize the break_x and break_y values so they are equal to the largest poof bitmap in use.

Also reduce the break alpha value by 90% for all detail levels.

This closes #3250 