### PR TITLE
Various annotation fixes

### DIFF
--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -5082,7 +5082,7 @@ void parse_event(mission * /*pm*/)
 	if (optional_string("$Annotations Start")) {
 		// annotations are only used in FRED
 		if (Fred_running) {
-			while (check_for_string("+Comment:") || check_for_string("+Background Color:")) {
+			while (check_for_string("+Comment:") || check_for_string("+Background Color:") || check_for_string("+Path:")) {
 				event_annotation ea;
 				ea.path.push_back(Num_mission_events);
 

--- a/code/parse/parselo.cpp
+++ b/code/parse/parselo.cpp
@@ -2478,7 +2478,13 @@ int stuff_int(int *i, bool optional)
 	// this is a bit cumbersome
 	size_t span;
 	if (*Mp == '+' || *Mp == '-')
-		span = strspn(Mp + 1, "0123456789") + 1;
+	{
+		span = strspn(Mp + 1, "0123456789");
+
+		// account for the sign symbol, but not if it's the only valid character
+		if (span > 0)
+			++span;
+	}
 	else
 		span = strspn(Mp, "0123456789");
 
@@ -2511,13 +2517,15 @@ int stuff_int(int *i, bool optional)
 		Mp = str_start;
 
 	if (success)
+	{
 		retval = 2;
+		diag_printf("Stuffed int: %d\n", *i);
+	}
 	else if (optional)
 		retval = comma ? 1 : 0;
 	else
 		skip_token();
 
-	diag_printf("Stuffed int: %d\n", *i);
 	return retval;
 }
 
@@ -2533,7 +2541,13 @@ int stuff_long(long *l, bool optional)
 	// this is a bit cumbersome
 	size_t span;
 	if (*Mp == '+' || *Mp == '-')
-		span = strspn(Mp + 1, "0123456789") + 1;
+	{
+		span = strspn(Mp + 1, "0123456789");
+
+		// account for the sign symbol, but not if it's the only valid character
+		if (span > 0)
+			++span;
+	}
 	else
 		span = strspn(Mp, "0123456789");
 
@@ -2566,13 +2580,15 @@ int stuff_long(long *l, bool optional)
 		Mp = str_start;
 
 	if (success)
+	{
 		retval = 2;
+		diag_printf("Stuffed long: %ld\n", *l);
+	}
 	else if (optional)
 		retval = comma ? 1 : 0;
 	else
 		skip_token();
 
-	diag_printf("Stuffed long: %ld\n", *l);
 	return retval;
 }
 

--- a/code/parse/parselo.cpp
+++ b/code/parse/parselo.cpp
@@ -214,7 +214,7 @@ void diag_printf(const char *format, ...)
 
 //	Grab and return (a pointer to) a bunch of tokens, terminating at
 // ERROR_LENGTH chars, or end of line.
-char *next_tokens()
+char *next_tokens(bool terminate_before_parenthesis_or_comma)
 {
 	int	count = 0;
 	char	*pstr = Mp;
@@ -222,6 +222,9 @@ char *next_tokens()
 
 	while (((ch = *pstr++) != EOLN) && (ch != '\0') && (count < ERROR_LENGTH-1))
 		Error_str[count++] = ch;
+
+	if (terminate_before_parenthesis_or_comma && (Error_str[count-1] == ',' || Error_str[count - 1] == ')'))
+		--count;
 
 	Error_str[count] = 0;
 	return Error_str;
@@ -2417,6 +2420,11 @@ void debug_show_mission_text()
 		printf("%c", ch);
 }
 
+bool unexpected_numeric_char(char ch)
+{
+	return (ch != '\0') && (ch != ',') && (ch != ')') && !is_white_space(ch);
+}
+
 //	Stuff a floating point value pointed at by Mp.
 //	Advances past float characters.
 int stuff_float(float *f, bool optional)
@@ -2435,7 +2443,7 @@ int stuff_float(float *f, bool optional)
 	if (result == 0.0f && str_end == Mp)
 	{
 		if (!optional)
-			error_display(1, "Expecting float, found [%.32s].\n", next_tokens());
+			error_display(1, "Expected float, found [%.32s].\n", next_tokens());
 	}
 	else
 	{
@@ -2445,6 +2453,14 @@ int stuff_float(float *f, bool optional)
 
 	if (success)
 		Mp = str_end;
+
+	// if an unexpected character is part of the number, the number parsing should fail
+	if (success && unexpected_numeric_char(*Mp))
+	{
+		Mp = str_start;
+		success = false;
+		error_display(1, "Expected float, found [%.32s].\n", next_tokens(true));
+	}
 
 	if (*Mp == ',')
 	{
@@ -2496,7 +2512,7 @@ int stuff_int(int *i, bool optional)
 	if (result == 0 && span == 0)
 	{
 		if (!optional)
-			error_display(1, "Expecting int, found [%.32s].\n", next_tokens());
+			error_display(1, "Expected int, found [%.32s].\n", next_tokens());
 	}
 	else
 	{
@@ -2506,6 +2522,14 @@ int stuff_int(int *i, bool optional)
 
 	if (success)
 		Mp += span;
+
+	// if an unexpected character is part of the number, the number parsing should fail
+	if (success && unexpected_numeric_char(*Mp))
+	{
+		Mp = str_start;
+		success = false;
+		error_display(1, "Expected int, found [%.32s].\n", next_tokens(true));
+	}
 
 	if (*Mp == ',')
 	{
@@ -2559,7 +2583,7 @@ int stuff_long(long *l, bool optional)
 	if (result == 0 && span == 0)
 	{
 		if (!optional)
-			error_display(1, "Expecting long, found [%.32s].\n", next_tokens());
+			error_display(1, "Expected long, found [%.32s].\n", next_tokens());
 	}
 	else
 	{
@@ -2569,6 +2593,14 @@ int stuff_long(long *l, bool optional)
 
 	if (success)
 		Mp += span;
+
+	// if an unexpected character is part of the number, the number parsing should fail
+	if (success && unexpected_numeric_char(*Mp))
+	{
+		Mp = str_start;
+		success = false;
+		error_display(1, "Expected long, found [%.32s].\n", next_tokens(true));
+	}
 
 	if (*Mp == ',')
 	{

--- a/code/parse/parselo.h
+++ b/code/parse/parselo.h
@@ -93,7 +93,7 @@ extern void ignore_gray_space();
 
 // error
 extern int get_line_num();
-extern char *next_tokens();
+extern char *next_tokens(bool terminate_before_parenthesis_or_comma = false);
 extern void diag_printf(SCP_FORMAT_STRING const char *format, ...) SCP_FORMAT_STRING_ARGS(1, 2);
 extern void error_display(int error_level, SCP_FORMAT_STRING const char *format, ...) SCP_FORMAT_STRING_ARGS(2, 3);
 


### PR DESCRIPTION
Make some improvements to the annotation code and the parsing code:

1) A single plus sign or single minus sign is not a number, and this is what was causing the parser to treat the + on the following line as another number in the Path list.  This is the major fix for #3267.
2) If there is an unexpected character after a number, the number should be considered a bad token, versus just reading as much of the number as we can and considering the result valid.  This is a partial fix for #3265.
3) If the annotation contains unmodified information for a certain value (such as background color), don't render the unmodified values.
4) There are also a few minor fixes here, such as checking for all three possible annotation strings and slightly cleaning up the reporting of parse errors.