### PR TITLE
Translateable Asteroid Impact Time

### DIFF
--- a/code/hud/hudtargetbox.cpp
+++ b/code/hud/hudtargetbox.cpp
@@ -1172,7 +1172,7 @@ void HudGaugeTargetBox::renderTargetAsteroid(object *target_objp)
 	
 
 	if ( time_to_impact >= 0.0f ) {
-		renderPrintf(position[0] + Class_offsets[0], position[1] + Class_offsets[1], EG_TBOX_CLASS, NOX("impact: %.1f sec"), time_to_impact);	
+		renderPrintf(position[0] + Class_offsets[0], position[1] + Class_offsets[1], EG_TBOX_CLASS, XSTR("impact: %.1f sec", 1596), time_to_impact);	
 	}
 }
 


### PR DESCRIPTION
The english "Impact:" is translateable for targetable bombs, but not for Asteroids in escort missions through asteroid fields. This PR fixes that. Both "Impact:" entries are now translateable through the same string in strings.tbl.