### PR TITLE
Translateable Asteroid Name in Asteroid Fields

### DIFF
--- a/code/hud/hudbrackets.cpp
+++ b/code/hud/hudbrackets.cpp
@@ -643,7 +643,7 @@ void HudGaugeBrackets::renderBoundingBrackets(int x1, int y1, int x2, int y2, in
 				break;
 
 			case OBJ_DEBRIS:
-				tinfo_name = XSTR("Debris", 348);
+				tinfo_name = XSTR("debris", 348);
 				break;
 			case OBJ_WEAPON:
 				tinfo_name = Weapon_info[Weapons[t_objp->instance].weapon_info_index].get_display_name();
@@ -653,10 +653,10 @@ void HudGaugeBrackets::renderBoundingBrackets(int x1, int y1, int x2, int y2, in
 					case ASTEROID_TYPE_SMALL:
 					case ASTEROID_TYPE_MEDIUM:
 					case ASTEROID_TYPE_LARGE:
-						tinfo_name = XSTR("Asteroid", 431);
+						tinfo_name = XSTR("asteroid", 431);
 						break;
 					default:
-						tinfo_name = XSTR("Debris", 348);
+						tinfo_name = XSTR("debris", 348);
 				}
 				break;
 			case OBJ_JUMP_NODE:

--- a/code/hud/hudbrackets.cpp
+++ b/code/hud/hudbrackets.cpp
@@ -653,7 +653,7 @@ void HudGaugeBrackets::renderBoundingBrackets(int x1, int y1, int x2, int y2, in
 					case ASTEROID_TYPE_SMALL:
 					case ASTEROID_TYPE_MEDIUM:
 					case ASTEROID_TYPE_LARGE:
-						tinfo_name = NOX("Asteroid");
+						tinfo_name = XSTR("Asteroid", 431);
 						break;
 					default:
 						tinfo_name = XSTR("Debris", 348);

--- a/code/hud/hudtargetbox.cpp
+++ b/code/hud/hudtargetbox.cpp
@@ -1160,7 +1160,7 @@ void HudGaugeTargetBox::renderTargetAsteroid(object *target_objp)
 		case ASTEROID_TYPE_SMALL:
 		case ASTEROID_TYPE_MEDIUM:
 		case ASTEROID_TYPE_LARGE:
-			strcpy_s(hud_name, NOX("asteroid"));
+			strcpy_s(hud_name, XSTR("Asteroid", 431));
 			break;
 
 		default:

--- a/code/hud/hudtargetbox.cpp
+++ b/code/hud/hudtargetbox.cpp
@@ -797,7 +797,7 @@ void HudGaugeTargetBox::renderTargetDebris(object *target_objp)
 		printable_ship_class = Ship_info[debrisp->ship_info_index].get_display_name();
 	
 	renderString(position[0] + Class_offsets[0], position[1] + Class_offsets[1], EG_TBOX_CLASS, printable_ship_class);	
-	renderString(position[0] + Name_offsets[0], position[1] + Name_offsets[1], EG_TBOX_NAME, XSTR("Debris", 348));	
+	renderString(position[0] + Name_offsets[0], position[1] + Name_offsets[1], EG_TBOX_NAME, XSTR("debris", 348));	
 }
 
 /**
@@ -1160,7 +1160,7 @@ void HudGaugeTargetBox::renderTargetAsteroid(object *target_objp)
 		case ASTEROID_TYPE_SMALL:
 		case ASTEROID_TYPE_MEDIUM:
 		case ASTEROID_TYPE_LARGE:
-			strcpy_s(hud_name, XSTR("Asteroid", 431));
+			strcpy_s(hud_name, XSTR("asteroid", 431));
 			break;
 
 		default:


### PR DESCRIPTION
Never noticed this, as Asteroid translates to Asteroid in German 😆.
However after i switched to another language i found out, that the English name is used in the target monitor aswell in the target brackets.
This applies to the generated Asteroids you can target in Asteroid Fields, which is widely used in any kind of Escort Missions through them.
So this is actually a follow up to #3272.

This PR change the Asteroid's name to a translateable one by the strings.tbl.
I decided to use the already established ID 431, as that one is used for the displayed name after you clicked on the Asteroid Field icon image in mission briefings.
I can not think of a scenario, where this name should be any different.