### PR TITLE
Turrets on movable submodels

### DIFF
--- a/code/ai/aiturret.cpp
+++ b/code/ai/aiturret.cpp
@@ -2251,24 +2251,9 @@ void ai_fire_from_turret(ship *shipp, ship_subsys *ss)
 	objp = &Objects[shipp->objnum];
 	Assert(objp->type == OBJ_SHIP);
 
-	// Wanderer - make sure turrets already have all the data
-	if ( !(tp->flags[Model::Subsystem_Flags::Turret_matrix]) )
-	{
-		if (!(tp->turret_gun_sobj == tp->subobj_num))
-		{
-			auto pmi = model_get_instance(shipp->model_instance_num);
-			auto pm = model_get(pmi->model_num);
-			model_make_turret_matrix(pm, pmi, tp);
-		}
-	}
-
 	// Use the turret info for all guns, not one gun in particular.
 	vec3d	 gvec, gpos;
 	ship_get_global_turret_info(objp, tp, &gpos, &gvec);
-
-	if (tp->flags[Model::Subsystem_Flags::Turret_alt_math]) {
-		vm_matrix_x_matrix( &ss->world_to_turret_matrix, &objp->orient, &tp->turret_matrix );
-	}
 
 	// Rotate the turret even if time hasn't elapsed, since it needs to turn to face its target.
 	int use_angles = aifft_rotate_turret(objp, shipp, ss, lep, &predicted_enemy_pos, &gvec);

--- a/code/ai/aiturret.cpp
+++ b/code/ai/aiturret.cpp
@@ -162,7 +162,7 @@ bool is_object_radius_in_turret_fov(object *objp, ship_subsys *ss, vec3d *tvec, 
 			// Since we no longer maintain world_to_turret_matrix, regenerate it here.
 			vec3d turret_norm;
 			matrix turret_matrix, world_to_turret_matrix;
-			model_instance_find_world_dir(&turret_norm, &tp->turret_norm, object_get_model_instance(objp), tp->subobj_num, &vmd_identity_matrix);
+			model_instance_find_world_dir(&turret_norm, &tp->turret_norm, Ships[objp->instance].model_instance_num, tp->subobj_num, &vmd_identity_matrix);
 			vm_vector_2_matrix(&turret_matrix, &turret_norm, nullptr, nullptr);
 			vm_matrix_x_matrix(&world_to_turret_matrix, &objp->orient, &turret_matrix);
 
@@ -1485,7 +1485,7 @@ float	aifft_compute_turret_dot(object *objp, object *enemy_objp, vec3d *abs_gunp
 	if (ship_subsystem_in_sight(enemy_objp, enemy_subsysp, abs_gunposp, &subobj_pos, 1, &dot_out, &vector_out)) {
 		vec3d	turret_norm;
 
-		model_instance_find_world_dir(&turret_norm, &turret_subsysp->system_info->turret_norm, object_get_model_instance(objp), turret_subsysp->system_info->subobj_num, &objp->orient);
+		model_instance_find_world_dir(&turret_norm, &turret_subsysp->system_info->turret_norm, Ships[objp->instance].model_instance_num, turret_subsysp->system_info->subobj_num, &objp->orient);
 		float dot_return = vm_vec_dot(&turret_norm, &vector_out);
 
 		if (Ai_info[Ships[objp->instance].ai_index].ai_profile_flags[AI::Profile_Flags::Smart_subsystem_targeting_for_turrets]) {
@@ -2810,7 +2810,7 @@ bool turret_adv_fov_test(ship_subsys *ss, vec3d *gvec, vec3d *v2e, float size_mo
 		object *objp = &Objects[ss->parent_objnum];
 		vec3d turret_norm;
 		matrix turret_matrix, world_to_turret_matrix;
-		model_instance_find_world_dir(&turret_norm, &tp->turret_norm, object_get_model_instance(objp), tp->subobj_num, &vmd_identity_matrix);
+		model_instance_find_world_dir(&turret_norm, &tp->turret_norm, Ships[objp->instance].model_instance_num, tp->subobj_num, &vmd_identity_matrix);
 		vm_vector_2_matrix(&turret_matrix, &turret_norm, nullptr, nullptr);
 		vm_matrix_x_matrix(&world_to_turret_matrix, &objp->orient, &turret_matrix);
 

--- a/code/ai/aiturret.cpp
+++ b/code/ai/aiturret.cpp
@@ -1230,20 +1230,20 @@ int find_turret_enemy(ship_subsys *turret_subsys, int objnum, vec3d *tpos, vec3d
  * of the turret.
  *
  * @param objp  Pointer to object
- * @param tp    Turrent model system on that object
+ * @param tp    Turret model system on that object
  * @param gpos  [Output] Global absolute position of gun firing point
  * @param gvec  [Output] Global vector
  *
  * @note The gun normal is the unrotated gun normal, (the center of the FOV cone), not
  * the actual gun normal given using the current turret heading.  But it _is_ rotated into the model's orientation
  * in global space.
+ * @note2 Because of this, both single-part and multi-part turrets are treated the same way; no need to find the multi-part's gun submodel.
  */
 void ship_get_global_turret_info(object *objp, model_subsystem *tp, vec3d *gpos, vec3d *gvec)
 {
-//	vm_vec_unrotate(gpos, &tp->turret_avg_firing_point, &objp->orient);
-	vm_vec_unrotate(gpos, &tp->pnt, &objp->orient);
-	vm_vec_add2(gpos, &objp->pos);
-	vm_vec_unrotate(gvec, &tp->turret_norm, &objp->orient);	
+	auto model_instance_num = Ships[objp->instance].model_instance_num;
+	model_instance_find_world_point(gpos, &tp->pnt, model_instance_num, tp->subobj_num, &objp->orient, &objp->pos);
+	model_instance_find_world_dir(gvec, &tp->turret_norm, model_instance_num, tp->subobj_num, &objp->orient);
 }
 
 void turret_ai_update_aim(ai_info *aip, object *En_Objp, ship_subsys *ss);
@@ -1303,7 +1303,8 @@ void ship_get_global_turret_gun_info(object *objp, ship_subsys *ssp, vec3d *gpos
 				vm_vec_add2(&enemy_point, &ssp->last_aim_enemy_pos);
 			} else {
 				if ((lep->type == OBJ_SHIP) && (Ship_info[Ships[lep->instance].ship_info_index].is_big_or_huge())) {
-                    vm_vec_unrotate(&turret_norm, &tp->turret_norm, &objp->orient);
+                    // the turret norm here is from the perspective of the base submodel, not the gun submodel
+					model_instance_find_world_dir(&turret_norm, &tp->turret_norm, pm, pmi, tp->subobj_num, &objp->orient);
 					ai_big_pick_attack_point_turret(lep, ssp, &tmp_pos, &turret_norm, &enemy_point, MIN(wip->max_speed * wip->lifetime, wip->weapon_range), tp->turret_fov);
 				}
 				else {
@@ -1477,7 +1478,7 @@ float	aifft_compute_turret_dot(object *objp, object *enemy_objp, vec3d *abs_gunp
 	if (ship_subsystem_in_sight(enemy_objp, enemy_subsysp, abs_gunposp, &subobj_pos, 1, &dot_out, &vector_out)) {
 		vec3d	turret_norm;
 
-		vm_vec_unrotate(&turret_norm, &turret_subsysp->system_info->turret_norm, &objp->orient);
+		model_instance_find_world_dir(&turret_norm, &turret_subsysp->system_info->turret_norm, object_get_model_instance(objp), turret_subsysp->system_info->subobj_num, &objp->orient);
 		float dot_return = vm_vec_dot(&turret_norm, &vector_out);
 
 		if (Ai_info[Ships[objp->instance].ai_index].ai_profile_flags[AI::Profile_Flags::Smart_subsystem_targeting_for_turrets]) {

--- a/code/model/model.h
+++ b/code/model/model.h
@@ -157,7 +157,6 @@ public:
 	//	a separate struct so they don't take up space for all subsystem types.
     char	crewspot[MAX_NAME_LEN];	    		// unique identifying name for this turret -- used to assign AI class and multiplayer people
 	vec3d	turret_norm;						//	direction this turret faces (i.e. the normal to the turret base, or the center of the field of view)
-	matrix	turret_matrix;						// turret_norm converted to a matrix.  This is now only used for Turret_alt_math
 	float	turret_fov;							//	dot of turret_norm:vec_to_enemy > this means can see
 	float	turret_max_fov;						//  dot of turret_norm:vec_to_enemy <= this means barrels can elevate up to the target
 	float	turret_y_fov;						//  turret's base's fov
@@ -916,9 +915,6 @@ extern int modelstats_num_sortnorms;
 
 // Tries to move joints so that the turret points to the point dst.
 extern int model_rotate_gun(object *objp, polymodel *pm, polymodel_instance *pmi, model_subsystem *turret, vec3d *dst, bool reset = false);
-
-// Gets and sets turret rotation matrix
-extern void model_make_turret_matrix(polymodel *pm, polymodel_instance *pmi, model_subsystem *turret);
 
 // Rotates the angle of a submodel.  Use this so the right unlocked axis
 // gets stuffed.

--- a/code/model/model.h
+++ b/code/model/model.h
@@ -156,7 +156,7 @@ public:
 	//	The following items are specific to turrets and will probably be moved to
 	//	a separate struct so they don't take up space for all subsystem types.
     char	crewspot[MAX_NAME_LEN];	    		// unique identifying name for this turret -- used to assign AI class and multiplayer people
-	vec3d	turret_norm;						//	direction this turret faces
+	vec3d	turret_norm;						//	direction this turret faces (i.e. the normal to the turret base, or the center of the field of view)
 	matrix	turret_matrix;						// turret_norm converted to a matrix.  This is now only used for Turret_alt_math
 	float	turret_fov;							//	dot of turret_norm:vec_to_enemy > this means can see
 	float	turret_max_fov;						//  dot of turret_norm:vec_to_enemy <= this means barrels can elevate up to the target

--- a/code/model/model_flags.h
+++ b/code/model/model_flags.h
@@ -10,7 +10,6 @@ namespace Model {
 		Stepped_rotate,		// This means that the rotation occurs in steps
 		Ai_rotate,			// This means that the rotation is controlled by ai
 		Crewpoint,			// If set, this is a crew point.
-		Turret_matrix,		// If set, this has it's turret matrix created correctly.
 		Awacs,				// If set, this subsystem has AWACS capability
 		Artillery,			// if this rotates when weapons are fired - Goober5000
 		Triggered,			// rotates when triggered by something

--- a/code/model/modelread.cpp
+++ b/code/model/modelread.cpp
@@ -607,7 +607,6 @@ void model_copy_subsystems( int n_subsystems, model_subsystem *d_sp, model_subsy
 					dest->turret_fov = source->turret_fov;
 					dest->turret_num_firing_points = source->turret_num_firing_points;
 					dest->turret_norm = source->turret_norm;
-					dest->turret_matrix = source->turret_matrix;
 
 					for (nfp = 0; nfp < dest->turret_num_firing_points; nfp++ )
 						dest->turret_firing_point[nfp] = source->turret_firing_point[nfp];
@@ -2185,7 +2184,6 @@ int read_model_file(polymodel * pm, const char *filename, int n_subsystems, mode
 								cfread_vector( &temp_vec, fp );
 								vm_vec_normalize_safe(&temp_vec);
 								subsystemp->turret_norm = temp_vec;
-								vm_vector_2_matrix(&subsystemp->turret_matrix,&subsystemp->turret_norm,NULL,NULL);
 
 								n_slots = cfread_int( fp );
 								subsystemp->turret_gun_sobj = physical_parent;
@@ -3726,78 +3724,6 @@ void submodel_rotate(bsp_info *sm, submodel_instance *smi)
 	submodel_canonicalize(sm, smi, true);
 }
 
-
-//=========================================================================
-// Make a turret's correct orientation matrix.   This should be done when 
-// the model is read, but I wasn't sure at what point all the data that I
-// needed was read, so I just check a flag and call this routine when
-// I determine I need the correct matrix.   In this code, you can't use
-// vm_vec_2_matrix or anything, since these turrets could be either 
-// right handed or left handed.
-// Addendum: Since we no longer stuff angles into the model, we need a
-// model instance to do angle calculation.  We can just piggy back on
-// the active ship's model instance because all invocations of this
-// function are done from somewhere with a valid ship.
-void model_make_turret_matrix(polymodel *pm, polymodel_instance *pmi, model_subsystem *turret)
-{
-	vec3d fvec, uvec, rvec;
-	Assert(pm->id == pmi->model_num);
-
-	auto base = &pmi->submodel[turret->subobj_num];
-	auto gun = &pmi->submodel[turret->turret_gun_sobj];
-
-	auto pm_base = &pm->submodel[turret->subobj_num];
-	auto pm_gun = &pm->submodel[turret->turret_gun_sobj];
-
-	auto save_base_angle = base->cur_angle;
-	auto save_gun_angle = gun->cur_angle;
-	auto save_base_orient = base->canonical_orient;
-	auto save_gun_orient = gun->canonical_orient;
-
-	base->cur_angle = 0.0f;
-	submodel_canonicalize(pm_base, base, false);
-	gun->cur_angle = 0.0f;
-	submodel_canonicalize(pm_gun, gun, false);
-	model_instance_find_world_dir(&fvec, &turret->turret_norm, pm, pmi, turret->turret_gun_sobj, &vmd_identity_matrix);
-
-	base->cur_angle = -PI_2;
-	submodel_canonicalize(pm_base, base, false);
-	gun->cur_angle = -PI_2;
-	submodel_canonicalize(pm_gun, gun, false);
-	model_instance_find_world_dir(&rvec, &turret->turret_norm, pm, pmi, turret->turret_gun_sobj, &vmd_identity_matrix);
-
-	base->cur_angle = 0.0f;
-	submodel_canonicalize(pm_base, base, false);
-	model_instance_find_world_dir(&uvec, &turret->turret_norm, pm, pmi, turret->turret_gun_sobj, &vmd_identity_matrix);
-									
-	vm_vec_normalize(&fvec);
-	vm_vec_normalize(&rvec);
-	vm_vec_normalize(&uvec);
-
-	turret->turret_matrix.vec.fvec = fvec;
-	turret->turret_matrix.vec.rvec = rvec;
-	turret->turret_matrix.vec.uvec = uvec;
-
-//	vm_vector_2_matrix(&turret->turret_matrix,&turret->turret_norm,NULL,NULL);
-
-	// HACK!! WARNING!!!
-	// I'm doing nothing to verify that this matrix is orthogonal!!
-	// In other words, there's no guarantee that the vectors are 90 degrees
-	// from each other.
-	// I'm not doing this because I don't know how to do it without ruining
-	// the handedness of the matrix... however, I'm not too worried about	
-	// this because I am creating these 3 vectors by making them 90 degrees
-	// apart, so this should be close enough.  I think this will start 
-	// causing weird errors when we view from turrets. -John
-    turret->flags.set(Model::Subsystem_Flags::Turret_matrix);
-
-	// restore the position of the turret before we entered this function
-	base->cur_angle = save_base_angle;
-	gun->cur_angle = save_gun_angle;
-	base->canonical_orient = save_base_orient;
-	gun->canonical_orient = save_gun_orient;
-}
-
 // Tries to move joints so that the turret points to the point dst.
 // turret1 is the angles of the turret, turret2 is the angles of the gun from turret
 //	Returns 1 if rotated gun, 0 if no gun to rotate (rotation handled by AI)
@@ -3823,12 +3749,6 @@ int model_rotate_gun(object *objp, polymodel *pm, polymodel_instance *pmi, model
 	Assert( turret->turret_num_firing_points > 0 );
 	// Check for a valid subsystem
 	Assert( ss != NULL );
-
-	// Build the correct turret matrix if there isn't already one
-	if ( !(turret->flags[Model::Subsystem_Flags::Turret_matrix]) ) {
-		model_make_turret_matrix(pm, pmi, turret);
-	}
-	Assert( turret->flags[Model::Subsystem_Flags::Turret_matrix]);
 
 	// Find the heading and pitch that the gun needs to turn to
 	float desired_base_angle, desired_gun_angle;
@@ -5448,9 +5368,6 @@ void model_subsystem::reset()
     memset(crewspot, 0, sizeof(crewspot));
     turret_norm.xyz.x = turret_norm.xyz.y = turret_norm.xyz.z = 0.0f;
     
-    for (auto it = std::begin(turret_matrix.a1d); it != std::end(turret_matrix.a1d); ++it)
-        *it = 0.0f;
-
     turret_fov = 0;
     turret_max_fov = 0;
     turret_y_fov = 0;

--- a/code/scripting/api/objs/subsystem.cpp
+++ b/code/scripting/api/objs/subsystem.cpp
@@ -643,7 +643,7 @@ ADE_FUNC(rotateTurret, l_Subsystem, "vector Pos, boolean reset=false", "Rotates 
 		return ADE_RETURN_NIL;
 
 	//Get default turret info
-	vec3d gpos, gvec;
+	vec3d gpos;
 	model_subsystem *tp = sso->ss->system_info;
 	object *objp = sso->objp;
 
@@ -655,9 +655,6 @@ ADE_FUNC(rotateTurret, l_Subsystem, "vector Pos, boolean reset=false", "Rotates 
 
 	auto pmi = model_get_instance(Ships[objp->instance].model_instance_num);
 	auto pm = model_get(pmi->model_num);
-
-	// Find direction of turret
-	model_instance_find_world_dir(&gvec, &tp->turret_norm, pm, pmi, tp->turret_gun_sobj, &objp->orient);
 
 	int ret_val = model_rotate_gun(objp, pm, pmi, tp, &pos, reset);
 

--- a/code/scripting/api/objs/subsystem.cpp
+++ b/code/scripting/api/objs/subsystem.cpp
@@ -741,7 +741,8 @@ ADE_FUNC(getTurretMatrix, l_Subsystem, nullptr, "Returns current subsystems turr
 
 	model_subsystem *tp = sso->ss->system_info;
 
-	m = tp->turret_matrix;
+	// we have to fake a turret matrix because that field is no longer part of model_subsystem
+	vm_vector_2_matrix(&m, &tp->turret_norm, nullptr, nullptr);
 
 	return ade_set_args(L, "o", l_Matrix.Set(matrix_h(&m)));
 }

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -6885,8 +6885,6 @@ void ship_subsys::clear()
 
 	rotation_timestamp = timestamp(0);
 
-	world_to_turret_matrix = vmd_identity_matrix;
-
 	for (i = 0; i < 32; i++)
 		target_priority[i] = -1;
 	num_target_priorities = 0;
@@ -7176,9 +7174,6 @@ static int subsys_set(int objnum, int ignore_subsys_info)
 		float turn_accel = 0.5f;
 		if (ship_system->submodel_instance_1 != nullptr)
 			model_set_submodel_turn_info(ship_system->submodel_instance_1, model_system->turn_rate, turn_accel);
-
-		// Clear this flag here so we correctly rebuild the turret matrix on mission load
-        model_system->flags.remove(Model::Subsystem_Flags::Turret_matrix);
 
 		// Allocate a triggered rotation instance if we need it
 		if (model_system->flags[Model::Subsystem_Flags::Triggered]) {

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -399,7 +399,6 @@ public:
 	flagset<Ship::Subsys_Sound_Flags> subsys_snd_flags;
 
 	int      rotation_timestamp;
-	matrix   world_to_turret_matrix;			// This is now only used for Turret_alt_math
 
 	// target priority setting for turrets
 	int      target_priority[32];

--- a/code/weapon/beam.cpp
+++ b/code/weapon/beam.cpp
@@ -783,9 +783,12 @@ void beam_unpause_sounds()
 	}
 }
 
-void beam_get_global_turret_gun_info(object *objp, ship_subsys *ssp, vec3d *gpos, vec3d *gvec, int use_angles, vec3d *targetp, bool fighter_beam){
-		ship_get_global_turret_gun_info(objp, ssp, gpos, gvec, use_angles, targetp);
-	if(fighter_beam)*gvec = objp->orient.vec.fvec;
+void beam_get_global_turret_gun_info(object *objp, ship_subsys *ssp, vec3d *gpos, vec3d *gvec, int use_angles, vec3d *targetp, bool fighter_beam)
+{
+	ship_get_global_turret_gun_info(objp, ssp, gpos, gvec, use_angles, targetp);
+
+	if (fighter_beam)
+		*gvec = objp->orient.vec.fvec;
 }
 
 // -----------------------------===========================------------------------------
@@ -3559,7 +3562,7 @@ int beam_ok_to_fire(beam *b)
 				turret_normal = b->objp->orient.vec.fvec;
                 b->subsys->system_info->flags.remove(Model::Subsystem_Flags::Turret_alt_math);
 			} else {
-				model_instance_find_world_dir(&turret_normal, &b->subsys->system_info->turret_norm, object_get_model_instance(b->objp), b->subsys->system_info->subobj_num, &b->objp->orient);
+				model_instance_find_world_dir(&turret_normal, &b->subsys->system_info->turret_norm, Ships[b->objp->instance].model_instance_num, b->subsys->system_info->subobj_num, &b->objp->orient);
 			}
 
 			if (!(turret_fov_test(b->subsys, &turret_normal, &aim_dir))) {

--- a/code/weapon/beam.cpp
+++ b/code/weapon/beam.cpp
@@ -3559,7 +3559,7 @@ int beam_ok_to_fire(beam *b)
 				turret_normal = b->objp->orient.vec.fvec;
                 b->subsys->system_info->flags.remove(Model::Subsystem_Flags::Turret_alt_math);
 			} else {
-				vm_vec_unrotate(&turret_normal, &b->subsys->system_info->turret_norm, &b->objp->orient);
+				model_instance_find_world_dir(&turret_normal, &b->subsys->system_info->turret_norm, object_get_model_instance(b->objp), b->subsys->system_info->subobj_num, &b->objp->orient);
 			}
 
 			if (!(turret_fov_test(b->subsys, &turret_normal, &aim_dir))) {


### PR DESCRIPTION
The code always assumed that turrets were part of a fixed reference frame with respect to the main model.  This updates the relevant turret calculation code (mainly FOV and turret normals) so that turrets now use the appropriate submodel functions.  As a result, turrets now work on movable submodels.

Note that most of the `turret_matrix` code has been ripped out because it assumes a fixed reference frame.  This isn't a problem because most of the code can be easily converted to use `turret_norm` via the submodel functions.  The only exception is the `Turret_alt_math` flag, whose code is rather inscrutable.  For those cases, I just regenerated a new turret matrix on the fly.  In the future, someone who is more familiar with that code should rewrite it to use `turret_norm`.