### PR TITLE
a few turret fixes

### DIFF
--- a/code/ai/aiturret.cpp
+++ b/code/ai/aiturret.cpp
@@ -1246,11 +1246,13 @@ int find_turret_enemy(ship_subsys *turret_subsys, int objnum, vec3d *tpos, vec3d
  * in global space.
  * @note2 Because of this, both single-part and multi-part turrets are treated the same way; no need to find the multi-part's gun submodel.
  */
-void ship_get_global_turret_info(object *objp, model_subsystem *tp, vec3d *gpos, vec3d *gvec)
+void ship_get_global_turret_info(const object *objp, const model_subsystem *tp, vec3d *gpos, vec3d *gvec)
 {
 	auto model_instance_num = Ships[objp->instance].model_instance_num;
-	model_instance_find_world_point(gpos, &tp->pnt, model_instance_num, tp->subobj_num, &objp->orient, &objp->pos);
-	model_instance_find_world_dir(gvec, &tp->turret_norm, model_instance_num, tp->subobj_num, &objp->orient);
+	if (gpos)
+		model_instance_find_world_point(gpos, &vmd_zero_vector, model_instance_num, tp->subobj_num, &objp->orient, &objp->pos);
+	if (gvec)
+		model_instance_find_world_dir(gvec, &tp->turret_norm, model_instance_num, tp->subobj_num, &objp->orient);
 }
 
 void turret_ai_update_aim(ai_info *aip, object *En_Objp, ship_subsys *ss);
@@ -1555,8 +1557,7 @@ ship_subsys *aifft_find_turret_subsys(object *objp, ship_subsys *ssp, object *en
 
 	//	Compute absolute gun position.
 	vec3d	abs_gun_pos;
-	vm_vec_unrotate(&abs_gun_pos, &ssp->system_info->pnt, &objp->orient);
-	vm_vec_add2(&abs_gun_pos, &objp->pos);
+	ship_get_global_turret_info(objp, ssp->system_info, &abs_gun_pos, nullptr);
 
 	//	Only pick a turret to attack on large ships.
 	if (!esip->is_big_or_huge())

--- a/code/asteroid/asteroid.cpp
+++ b/code/asteroid/asteroid.cpp
@@ -1878,7 +1878,7 @@ void maybe_change_asteroid_name(asteroid_info* asip) {
 		return;
 
 	if (num.empty() || std::find_if(num.begin(),
-		num.end(), [](unsigned char c) { return !std::isdigit(c); }) != num.end())
+		num.end(), [](unsigned char c) { return !std::isdigit(c, SCP_default_locale); }) != num.end())
 		return;
 
 	// make sure this asteroid would correspond the 'species section' of the old style retail asteroids

--- a/code/scripting/api/objs/subsystem.cpp
+++ b/code/scripting/api/objs/subsystem.cpp
@@ -646,12 +646,7 @@ ADE_FUNC(rotateTurret, l_Subsystem, "vector Pos, boolean reset=false", "Rotates 
 	vec3d gpos;
 	model_subsystem *tp = sso->ss->system_info;
 	object *objp = sso->objp;
-
-	//Rotate turret position with ship
-	vm_vec_unrotate(&gpos, &tp->pnt, &objp->orient);
-
-	//Add turret position to appropriate world space
-	vm_vec_add2(&gpos, &objp->pos);
+	ship_get_global_turret_info(objp, tp, &gpos, nullptr);
 
 	auto pmi = model_get_instance(Ships[objp->instance].model_instance_num);
 	auto pm = model_get(pmi->model_num);

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -1761,7 +1761,7 @@ void ship_get_global_turret_gun_info(object *objp, ship_subsys *ssp, vec3d *gpos
 //	of the turret.   The gun normal is the unrotated gun normal, (the center of the FOV cone), not
 // the actual gun normal given using the current turret heading.  But it _is_ rotated into the model's orientation
 //	in global space.
-void ship_get_global_turret_info(object *objp, model_subsystem *tp, vec3d *gpos, vec3d *gvec);
+void ship_get_global_turret_info(const object *objp, const model_subsystem *tp, vec3d *gpos, vec3d *gvec);
 
 // return 1 if objp is in fov of the specified turret, tp.  Otherwise return 0.
 //	dist = distance from turret to center point of object


### PR DESCRIPTION
This correctly calculates the turret position from the center (zero position) of its submodel instead of using the offset from the main model.

This patches a few more parts of the code and also adds a missing locale argument.

Bugfix and follow-up to #3277.