### PR TITLE
fix character type for isdigit

### DIFF
--- a/code/asteroid/asteroid.cpp
+++ b/code/asteroid/asteroid.cpp
@@ -1877,8 +1877,9 @@ void maybe_change_asteroid_name(asteroid_info* asip) {
 	if (stricmp(debris.c_str(), "Debris") != 0)
 		return;
 
-	if (num.empty() || std::find_if(num.begin(),
-		num.end(), [](unsigned char c) { return !std::isdigit(c, SCP_default_locale); }) != num.end())
+	if (num.empty() || std::find_if(num.begin(), num.end(), [](char c) {
+	                       return !std::isdigit(c, SCP_default_locale);
+	                   }) != num.end())
 		return;
 
 	// make sure this asteroid would correspond the 'species section' of the old style retail asteroids


### PR DESCRIPTION
Just like the `std::toupper` and `std::tolower` functions (see PR #3226), `std::isdigit` is designed to work with regular `char`, not `unsigned char`.

This fixes #3282.