### PR TITLE
Fix probability distribution of vm_vec_random_in_circle/sphere

### DIFF
--- a/code/math/vecmat.cpp
+++ b/code/math/vecmat.cpp
@@ -2261,7 +2261,7 @@ void vm_vec_random_in_circle(vec3d *out, const vec3d *in, const matrix *orient, 
 	vec3d temp;
 	float scalar = frand();
 
-	// sqrt because scaling inward increases the probability desnity by the square of its distance towards the center
+	// sqrt because scaling inward increases the probability density by the square of its proximity towards the center
 	if (!bias_towards_center)
 		scalar = sqrtf(scalar);
 
@@ -2274,7 +2274,7 @@ void vm_vec_random_in_circle(vec3d *out, const vec3d *in, const matrix *orient, 
 
 // given a start vector and a radius, generate a point in a spherical volume
 // if on_surface is true, the point will be on the surface of the sphere
-void vm_vec_random_in_sphere(vec3d *out, const vec3d *in, float radius, bool on_surface)
+void vm_vec_random_in_sphere(vec3d *out, const vec3d *in, float radius, bool on_surface, bool bias_towards_center)
 {
 	vec3d temp;
 
@@ -2282,8 +2282,13 @@ void vm_vec_random_in_sphere(vec3d *out, const vec3d *in, float radius, bool on_
 	float phi = util::UniformFloatRange(0.0f, PI2).next();
 	vm_vec_make(&temp, sqrtf(1.0f - z * z) * cosf(phi), sqrtf(1.0f - z * z) * sinf(phi), z); // Using the z-vec as the starting point
 
-	// cube root because scaling inward increases the probability desnity by the cube of its distance towards the center
-	vm_vec_scale_add(out, in, &temp, on_surface ? radius : powf(util::UniformFloatRange(0.0f, 1.0f).next(), 0.333f) * radius);
+	float scalar = util::UniformFloatRange(0.0f, 1.0f).next();
+
+	// cube root because scaling inward increases the probability density by the cube of its proximity towards the center
+	if (!bias_towards_center)
+		scalar = powf(scalar, 0.333f);
+
+	vm_vec_scale_add(out, in, &temp, on_surface ? radius : scalar * radius);
 }
 
 // find the nearest point on the line to p. if dist is non-NULL, it is filled in

--- a/code/math/vecmat.h
+++ b/code/math/vecmat.h
@@ -491,7 +491,8 @@ void vm_vec_random_in_circle(vec3d *out, const vec3d *in, const matrix *orient, 
 
 // given a start vector and a radius, generate a point in a spherical volume
 // if on_surface is true, the point will be on the surface of the sphere
-void vm_vec_random_in_sphere(vec3d *out, const vec3d *in, float radius, bool on_surface);
+// if bias_towards_center is true, the probability will be higher towards the center
+void vm_vec_random_in_sphere(vec3d *out, const vec3d *in, float radius, bool on_surface, bool bias_towards_center = false);
 
 // find the nearest point on the line to p. if dist is non-NULL, it is filled in
 // returns 0 if the point is inside the line segment, -1 if "before" the line segment and 1 ir "after" the line segment

--- a/code/math/vecmat.h
+++ b/code/math/vecmat.h
@@ -486,7 +486,8 @@ void vm_vec_random_cone(vec3d *out, const vec3d *in, float min_angle, float max_
 
 // given a start vector, an orientation, and a radius, generate a point on the plane of the circle
 // if on_edge is true, the point will be on the edge of the circle
-void vm_vec_random_in_circle(vec3d *out, const vec3d *in, const matrix *orient, float radius, bool on_edge);
+// if bias_towards_center is true, the probability will be higher towards the center
+void vm_vec_random_in_circle(vec3d *out, const vec3d *in, const matrix *orient, float radius, bool on_edge, bool bias_towards_center = false);
 
 // given a start vector and a radius, generate a point in a spherical volume
 // if on_surface is true, the point will be on the surface of the sphere

--- a/code/scripting/api/objs/vecmath.cpp
+++ b/code/scripting/api/objs/vecmath.cpp
@@ -702,8 +702,8 @@ ADE_FUNC(perturb,
 
 ADE_FUNC(randomInCircle,
 	l_Vector,
-	"orientation orient, number radius, boolean on_edge",
-	"Given this vector (the origin point), an orientation, and a radius, generate a point on the plane of the circle.  If on_edge is true, the point will be on the edge of the circle.",
+	"orientation orient, number radius, boolean on_edge, [boolean bias_towards_center = true]",
+	"Given this vector (the origin point), an orientation, and a radius, generate a point on the plane of the circle.  If on_edge is true, the point will be on the edge of the circle. If bias_towards_center is true, the probability will be higher towards the center.",
 	"vector",
 	"A point within the plane of the circle")
 {
@@ -711,30 +711,32 @@ ADE_FUNC(randomInCircle,
 	matrix_h* mh = nullptr;
 	float radius;
 	bool on_edge;
+	bool bias_towards_center = true;
 
-	if (!ade_get_args(L, "oofb", l_Vector.GetPtr(&in), l_Matrix.GetPtr(&mh), &radius, &on_edge))
+	if (!ade_get_args(L, "oofb|b", l_Vector.GetPtr(&in), l_Matrix.GetPtr(&mh), &radius, &on_edge, &bias_towards_center))
 		return ADE_RETURN_NIL;
 
-	vm_vec_random_in_circle(&out, in, mh->GetMatrix(), radius, on_edge);
+	vm_vec_random_in_circle(&out, in, mh->GetMatrix(), radius, on_edge, bias_towards_center);
 
 	return ade_set_args(L, "o", l_Vector.Set(out));
 }
 
 ADE_FUNC(randomInSphere,
 	l_Vector,
-	"number radius, boolean on_surface",
-	"Given this vector (the origin point) and a radius, generate a point in the volume of the sphere.  If on_surface is true, the point will be on the surface of the sphere.",
+	"number radius, boolean on_surface, [boolean bias_towards_center = true]",
+	"Given this vector (the origin point) and a radius, generate a point in the volume of the sphere.  If on_surface is true, the point will be on the surface of the sphere. If bias_towards_center is true, the probability will be higher towards the center",
 	"vector",
 	"A point within the plane of the circle")
 {
 	vec3d *in, out;
 	float radius;
 	bool on_surface;
+	bool bias_towards_center = true;
 
-	if (!ade_get_args(L, "ofb", l_Vector.GetPtr(&in), &radius, &on_surface))
+	if (!ade_get_args(L, "ofb|b", l_Vector.GetPtr(&in), &radius, &on_surface, &bias_towards_center))
 		return ADE_RETURN_NIL;
 
-	vm_vec_random_in_sphere(&out, in, radius, on_surface);
+	vm_vec_random_in_sphere(&out, in, radius, on_surface, bias_towards_center);
 
 	return ade_set_args(L, "o", l_Vector.Set(out));
 }

--- a/code/weapon/beam.cpp
+++ b/code/weapon/beam.cpp
@@ -2437,7 +2437,7 @@ void beam_jitter_aim(beam *b, float aim)
 	vm_vector_2_matrix(&m, &forward, NULL, NULL);
 
 	// get a vector on the circle - this should appear to be pretty random
-	vm_vec_random_in_circle(&circle, &b->last_shot, &m, aim * b->target->radius, false);
+	vm_vec_random_in_circle(&circle, &b->last_shot, &m, aim * b->target->radius, false, true);
 	
 	// get the vector pointing to the circle point
 	vm_vec_sub(&forward, &circle, &b->last_start);	

--- a/code/weapon/beam.cpp
+++ b/code/weapon/beam.cpp
@@ -2436,7 +2436,7 @@ void beam_jitter_aim(beam *b, float aim)
 	// vector
 	vm_vector_2_matrix(&m, &forward, NULL, NULL);
 
-	// get a vector on the circle - this should appear to be pretty random
+	// get a random vector on the circle, but somewhat biased towards the center
 	vm_vec_random_in_circle(&circle, &b->last_shot, &m, aim * b->target->radius, false, true);
 	
 	// get the vector pointing to the circle point

--- a/code/weapon/trails.cpp
+++ b/code/weapon/trails.cpp
@@ -332,7 +332,7 @@ void trail_add_segment( trail *trailp, vec3d *pos , const matrix* orient)
 	trailp->val[next] = 0.0f;
 
 	if (orient != nullptr && trailp->info.spread > 0.0f) {
-		vm_vec_random_in_circle(&trailp->vel[next], &vmd_zero_vector, orient, trailp->info.spread, false);
+		vm_vec_random_in_circle(&trailp->vel[next], &vmd_zero_vector, orient, trailp->info.spread, false, true);
 	} else 
 		vm_vec_zero(&trailp->vel[next]);
 }		


### PR DESCRIPTION
Randomly getting a point on a circle/sphere edge and scaling inward by `frand()` is *not* a uniform distribution, as the comments say, this will bias the distribution towards the center, so introduce a factor to combat this. The only thing that should be noticeably affected that isn't just visual is beam aim 'jitter', since this is retail an optional parameter is added to to maintain this 'bias' (and also for trails because they look better that way)

As an aside, randomizing a vector's coordinates and normalizing is *also* not a uniform distribution over a spherical surface (ironically that method was introduced in the same PR that introduced the proper method for random_cone, which has been used for circle and sphere now).

![screen0138](https://user-images.githubusercontent.com/17305613/110755862-709b0b80-8217-11eb-9692-f1e45c6caf9a.png)

![screen0139](https://user-images.githubusercontent.com/17305613/110755899-7a247380-8217-11eb-8cc5-1a874914d38f.png)
