### PR TITLE
Bugfix for FIT with set-object-facing

### DIFF
--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -1343,8 +1343,10 @@ void ai_turn_towards_vector(vec3d* dest, object* objp, vec3d* slide_vec, vec3d* 
 	}
 	
 	if (Framerate_independent_turning) {
-		pip->ai_desired_orient = out_orient;
-		pip->desired_rotvel = vel_out;
+		if (IS_MAT_NULL(&pip->ai_desired_orient)) {
+			pip->ai_desired_orient = out_orient;
+			pip->desired_rotvel = vel_out;
+		} // if ai_desired_orient is NOT null, that means a SEXP is trying to move the ship right now, and the AI should defer to it
 	}
 	else {
 		objp->orient = out_orient;

--- a/code/physics/physics.cpp
+++ b/code/physics/physics.cpp
@@ -183,13 +183,8 @@ void physics_sim_rot(matrix * orient, physics_info * pi, float sim_time )
 
 	// "frit" here meaning Framerate_independent_turning
 	bool frit_ai_wants_to_move = Framerate_independent_turning && !IS_MAT_NULL(&pi->ai_desired_orient);
-	bool spinning_too_fast = vm_vec_mag(&pi->max_rotvel) > 0.001f &&
-		(pi->rotvel.xyz.x > pi->max_rotvel.xyz.x * 1.5f ||
-		pi->rotvel.xyz.y > pi->max_rotvel.xyz.y * 1.5f ||
-		pi->rotvel.xyz.z > pi->max_rotvel.xyz.z * 1.5f);
 	// In the case an ai entity used angular_move, we should use those calculations instead
-	// Unless it's spinning too fast, in which case let the exponential damping handle it
-	if (frit_ai_wants_to_move && !(spinning_too_fast)){
+	if (frit_ai_wants_to_move){
 		Assert(is_valid_matrix(&pi->ai_desired_orient));
 
 		// AI simply get the rotvel they ask for, calculations were already done
@@ -203,11 +198,6 @@ void physics_sim_rot(matrix * orient, physics_info * pi, float sim_time )
 		vm_mat_zero(&pi->ai_desired_orient);
 
 	} else { // players and no framerate_independent_turning go here
-
-		if (frit_ai_wants_to_move) {
-			// Make sure its slowing down as much as possible by desiring 0 velocity
-			vm_vec_zero(&pi->desired_rotvel);
-		}
 
 		// Do rotational physics with given damping
 		apply_physics(rotdamp, pi->desired_rotvel.xyz.x, pi->rotvel.xyz.x, sim_time, &new_vel.xyz.x, nullptr);


### PR DESCRIPTION
AI will erroneously overwrite turns from `set-object-facing`, so it should see if `ai_desired_orient` is already set (physics will wipe it out when it acts on it) and if so, don't overwrite it, the SEXP takes priority.

Sadly this means physics can't really tell if something is 'spinning too fast', the SEXP could be telling it to go way faster than normal. This isn't a huge loss, that spinning too fast stuff was mostly just some defense against physics bugs or degenerate cases to try and slow it down in a reasonable time, but this should be very rare.