### PR TITLE
Fix for nebula fogging distance

### DIFF
--- a/code/def_files/data/effects/fog-f.sdr
+++ b/code/def_files/data/effects/fog-f.sdr
@@ -23,8 +23,8 @@ void main()
 
 	// If the scene is in fog then we change the color we operate on based on the depth of the pixel
 	float depth_val = texture(depth_tex, fragTexCoord.xy).x;
-	// Transform depth value from [-1, 1] to [0, 1]
-	float depth_normalized = fma(depth_val, 0.5, 0.5);
+	// Transform depth value from [0, 1] to [-1, 1]
+	float depth_normalized = 2 * depth_val - 1;
 	// Now we compute the depth value in projection space using the clipping plane information
 	float view_depth = 2.0 * zNear * zFar / (zFar + zNear - depth_normalized * (zFar - zNear));
 


### PR DESCRIPTION
Reverts #2222 and fixes the comment, it was in fact the *comment* that was in error, not the code. `depth_normalized` needs to be [-1, 1] that's what makes `view_depth` right below it accurately map to ingame meters.