### PR TITLE
Peoperly initialize alpha decay exponent for contrails

### DIFF
--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -4352,6 +4352,8 @@ static void parse_ship_values(ship_info* sip, const bool is_template, const bool
 				ci->a_decay_exponent = 1.0f;
 			}
 		}
+		else if (first_time)
+			ci->a_decay_exponent = 1.0f;
 
 		required_string("+Max Life:");
 		stuff_float(&ci->max_life);


### PR DESCRIPTION
Basically the same problem as #3255. I've run out of excuses, but I ran through weapons, afterburner trails and contrails with and without the new fields and everything seems to be set properly.