### PR TITLE
Fix ammo safety regressions.

### DIFF
--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -17322,7 +17322,7 @@ void sexp_set_ammo_sub(ship_weapon *swp, int requested_bank, int requested_ammo,
 	}
 	else if (ammo[requested_bank] > maximum_allowed)
 	{
-		// Make sure the current ammo doesn't exceed the maximum
+		// Make sure the current ammo doesn't exceed the maximum (this can otherwise happen with the set-*-weapon SEXPs)
 		ammo[requested_bank] = maximum_allowed;
 	}
 
@@ -17335,7 +17335,7 @@ void sexp_set_ammo_sub(ship_weapon *swp, int requested_bank, int requested_ammo,
 
 		start_ammo[requested_bank] = rearm_limit;
 	}
-	else	// Cyborg17 - No matter what
+	else	// Even if no rearm limit is explicitly set, don't allow more weapons than the bank can actually hold (this can otherwise happen with the set-*-weapon SEXPs).
 	{
 		start_ammo[requested_bank] = maximum_allowed;
 	}

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -17320,15 +17320,24 @@ void sexp_set_ammo_sub(ship_weapon *swp, int requested_bank, int requested_ammo,
 		// Set the number of weapons
 		ammo[requested_bank] = requested_ammo;
 	}
+	else if (ammo[requested_bank] > maximum_allowed)
+	{
+		// Make sure the current ammo doesn't exceed the maximum
+		ammo[requested_bank] = maximum_allowed;
+	}
 
 	// Check rearm validity
 	if (rearm_limit >= 0)
 	{
-		// Don't allow more weapons than the bank can actually hold. -- Cyborg17 - No matter what
+		// Don't allow more weapons than the bank can actually hold.
 		if (rearm_limit > maximum_allowed)
 			rearm_limit = maximum_allowed;
 
 		start_ammo[requested_bank] = rearm_limit;
+	}
+	else	// Cyborg17 - No matter what
+	{
+		start_ammo[requested_bank] = maximum_allowed;
 	}
 }
 


### PR DESCRIPTION
When various SEXP functions related to ammo were consolidated back in June (in commit 54409ec92887d2e6db92450a2ccf78d8fc90ff2d, PR #2480), certain safety catches meant to avoid having too much ammo or the wrong ammo capacity after changing weapons were lost. This commit adds code that should be functionally equivalent.