### PR TITLE
Fix assert with combining flak and non-flak using substitute

### DIFF
--- a/code/ai/aiturret.cpp
+++ b/code/ai/aiturret.cpp
@@ -2027,9 +2027,7 @@ bool turret_fire_weapon(int weapon_num, ship_subsys *turret, int parent_objnum, 
 					Script_system.RemHookVars({"Ship", "Weapon", "Beam", "Target"});
 
 					// if the gun is a flak gun
-					if (wip->wi_flags[Weapon::Info_Flags::Flak]) {			
-						// show a muzzle flash
-						flak_muzzle_flash(turret_pos, firing_vec, &Objects[parent_ship->objnum].phys_info, turret_weapon_class);
+					if (wip->wi_flags[Weapon::Info_Flags::Flak]) {
 
 						if(predicted_pos != NULL)
 						{
@@ -2044,8 +2042,9 @@ bool turret_fire_weapon(int weapon_num, ship_subsys *turret, int parent_objnum, 
 							flak_set_range(objp, flak_range_override);
 						}
 					}
-					// otherwise just do mflash if the weapon has it
-					else if (wip->muzzle_flash >= 0) {
+
+					// do mflash if the weapon has it
+					if (wip->muzzle_flash >= 0) {
 						mflash_create(turret_pos, firing_vec, &Objects[parent_ship->objnum].phys_info, wip->muzzle_flash);
 					}
 

--- a/code/network/multimsgs.cpp
+++ b/code/network/multimsgs.cpp
@@ -57,6 +57,7 @@
 #include "missionui/missiondebrief.h"
 #include "network/multi_log.h"
 #include "weapon/emp.h"
+#include "weapon/muzzleflash.h"
 #include "network/multi_kick.h"
 #include "cmdline/cmdline.h"
 #include "weapon/flak.h"
@@ -8551,7 +8552,7 @@ void process_flak_fired_packet(ubyte *data, header *hinfo)
 		}
 
 		// create a muzzle flash from a flak gun based upon firing position and weapon type
-		flak_muzzle_flash(&pos, &dir, &objp->phys_info, wid);
+		mflash_create(&pos, &dir, &objp->phys_info, Weapon_info[wid].muzzle_flash);
 
 		// set its range explicitly - make it long enough so that it's guaranteed to still exist when the server tells us it blew up
 		flak_set_range(&Objects[weapon_objnum], (float)flak_range);

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -11892,11 +11892,6 @@ int ship_fire_primary(object * obj, int stream_weapons, int force, bool rollback
 								{
 									flak_set_range(&Objects[weapon_objnum], flak_range - winfo_p->untargeted_flak_range_penalty);
 								}
-
-								if ((winfo_p->muzzle_flash>=0) && (((shipp==Player_ship) && (vm_vec_mag(&Player_obj->phys_info.vel)>=45)) || (shipp!=Player_ship)))
-								{
-									flak_muzzle_flash(&firing_pos,&obj->orient.vec.fvec, &obj->phys_info, swp->primary_bank_weapons[bank_to_fire]);
-								}
 							}
 							// create the muzzle flash effect
 							shipfx_flash_create( obj, sip->model_num, &pnt, &obj->orient.vec.fvec, 1, weapon_idx );

--- a/code/weapon/flak.cpp
+++ b/code/weapon/flak.cpp
@@ -115,28 +115,6 @@ void flak_jitter_aim(vec3d *dir, float dist_to_target, float weapon_subsys_stren
 }
 
 /**
- * Create a muzzle flash from a flak gun based upon firing position and weapon type
- */
-void flak_muzzle_flash(vec3d *pos, vec3d *dir, physics_info *pip, int turret_weapon_class)
-{
-	// sanity
-	Assert((turret_weapon_class >= 0) && (turret_weapon_class < weapon_info_size()));
-	if((turret_weapon_class < 0) || (turret_weapon_class >= weapon_info_size())){
-		return;
-	}
-	Assert(Weapon_info[turret_weapon_class].wi_flags[Weapon::Info_Flags::Flak]);
-	if(!(Weapon_info[turret_weapon_class].wi_flags[Weapon::Info_Flags::Flak])){
-		return;
-	}
-
-	if(Weapon_info[turret_weapon_class].muzzle_flash < 0){
-		return;
-	}
-
-	mflash_create(pos, dir, pip, Weapon_info[turret_weapon_class].muzzle_flash);
-}
-
-/**
  * Given a just fired flak shell, pick a detonating distance for it
  */
 void flak_set_range(object *objp, float range)


### PR DESCRIPTION
This should be a perfectly fine thing to do, and only complains because flak muzzle flashes have a pointless wrapper function for the normal muzzle flash function that exists solely to complain about weapons being not flak. 

Closes #2415