### PR TITLE
Add pierce ship weapon flag

### DIFF
--- a/code/weapon/weapon.h
+++ b/code/weapon/weapon.h
@@ -345,7 +345,7 @@ struct weapon_info
 	float WeaponMinRange;           // *Minimum weapon range, default is 0 -Et1
 
 	bool pierce_objects;
-	bool spawn_childs_on_pierce;
+	bool spawn_children_on_pierce;
 
     // spawn weapons
     int num_spawn_weapons_defined;

--- a/code/weapon/weapon.h
+++ b/code/weapon/weapon.h
@@ -344,6 +344,9 @@ struct weapon_info
 	float	weapon_range;						// max range weapon can be effectively fired.  (May be less than life * speed)
 	float WeaponMinRange;           // *Minimum weapon range, default is 0 -Et1
 
+	bool pierce_objects;
+	bool spawn_childs_on_pierce;
+
     // spawn weapons
     int num_spawn_weapons_defined;
     int maximum_children_spawned;		// An upper bound for the total number of spawned children, used by multi

--- a/code/weapon/weapon_flags.h
+++ b/code/weapon/weapon_flags.h
@@ -86,7 +86,6 @@ namespace Weapon {
 		No_impact_spew,						// Goober5000
 		Require_exact_los,					// If secondary or in turret, will only fire if ship has line of sight to target
 		Can_damage_shooter,					// this weapon and any of its descendants can damage its shooter - Asteroth
-		Pierce_ships,						// This flag will allow Weapons to pierce throug ship. They'll still do damage but won't despawn
 
         NUM_VALUES
 	};

--- a/code/weapon/weapon_flags.h
+++ b/code/weapon/weapon_flags.h
@@ -86,6 +86,7 @@ namespace Weapon {
 		No_impact_spew,						// Goober5000
 		Require_exact_los,					// If secondary or in turret, will only fire if ship has line of sight to target
 		Can_damage_shooter,					// this weapon and any of its descendants can damage its shooter - Asteroth
+		Pierce_ships,						// This flag will allow Weapons to pierce throug ship. They'll still do damage but won't despawn
 
         NUM_VALUES
 	};

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -1757,8 +1757,8 @@ int parse_weapon(int subtype, bool replace, const char *filename)
 	if (optional_string("$Pierce Objects:")) {
 		stuff_boolean(&wip->pierce_objects);
 
-		if (optional_string("+Spawn Childs On Hit:")) {
-			stuff_boolean(&wip->spawn_childs_on_pierce);
+		if (optional_string("+Spawn Children On Pierce:")) {
+			stuff_boolean(&wip->spawn_children_on_pierce);
 		}
 	}
 
@@ -6866,7 +6866,7 @@ void weapon_hit( object * weapon_obj, object * other_obj, vec3d * hitpos, int qu
 		}
 	}
 
-	if (!wip->pierce_objects || wip->spawn_childs_on_pierce || other_obj) {
+	if (!wip->pierce_objects || wip->spawn_children_on_pierce || !other_obj) {
 		// spawn weapons - note the change from FS 1 multiplayer.
 		if (wip->wi_flags[Weapon::Info_Flags::Spawn]) {
 			if (!((wip->wi_flags[Weapon::Info_Flags::Dont_spawn_if_shot]) && (Weapons[num].weapon_flags[Weapon::Weapon_Flags::Destroyed_by_weapon]))) {			// prevent spawning of children if shot down and the dont spawn if shot flag is set (DahBlount)
@@ -8274,7 +8274,7 @@ void weapon_info::reset()
 	this->WeaponMinRange = 0.0f;
 
 	this->pierce_objects = false;
-	this->spawn_childs_on_pierce = false;
+	this->spawn_children_on_pierce = false;
 
 	this->num_spawn_weapons_defined = 0;
 	this->maximum_children_spawned = 0;


### PR DESCRIPTION
Adds "pierce ship" as a weapon info flag, which will not remove a weapon on collision with an object, and rather allow it to penetrate and continue flying until it's lifetime is 0, detonated by a player, or shot down.
Regarding possible particle spew upon leaving a pierced ship:
It seems insufficient to just flip the weapon direction for the collision checks to deal with backface collisions as soon as the weapon entered a ship. Larger changes would be necessary to properly check for backface collisions which are, for now, out of scope.