### PR TITLE
Adding "Start missions in Chase View by default" flag in game_settings.tbl

### DIFF
--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -62,7 +62,7 @@ bool Use_engine_wash_intensity;
 bool Framerate_independent_turning; // an in-depth explanation how this flag is supposed to work can be found in #2740 PR description
 bool Ai_respect_tabled_turntime_rotdamp;
 bool Swarmers_lead_targets;
-bool Third_Person_is_Default;
+bool Chase_view_default;
 SCP_vector<gr_capability> Required_render_ext;
 float Weapon_SS_Threshold_Turret_Inaccuracy;
 bool Render_player_mflash;

--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -659,7 +659,7 @@ void mod_table_reset()
 	Use_engine_wash_intensity = false;
 	Framerate_independent_turning = true;
 	Ai_respect_tabled_turntime_rotdamp = false;
-	Third_Person_is_Default = false;
+	Chase_view_default = false;
 	Swarmers_lead_targets = false;
 	Required_render_ext.clear();
 	Weapon_SS_Threshold_Turret_Inaccuracy = 0.7f; // Defaults to retail value of 0.7 --wookieejedi

--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -62,6 +62,7 @@ bool Use_engine_wash_intensity;
 bool Framerate_independent_turning; // an in-depth explanation how this flag is supposed to work can be found in #2740 PR description
 bool Ai_respect_tabled_turntime_rotdamp;
 bool Swarmers_lead_targets;
+bool Third_Person_is_Default;
 SCP_vector<gr_capability> Required_render_ext;
 float Weapon_SS_Threshold_Turret_Inaccuracy;
 bool Render_player_mflash;
@@ -658,6 +659,7 @@ void mod_table_reset()
 	Use_engine_wash_intensity = false;
 	Framerate_independent_turning = true;
 	Ai_respect_tabled_turntime_rotdamp = false;
+	Third_Person_is_Default = false;
 	Swarmers_lead_targets = false;
 	Required_render_ext.clear();
 	Weapon_SS_Threshold_Turret_Inaccuracy = 0.7f; // Defaults to retail value of 0.7 --wookieejedi

--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -577,7 +577,11 @@ void parse_mod_table(const char *filename)
 				Warning(LOCATION, "\'AI respect tabled turn time and rotdamp\' requires \'AI use framerate independent turning\' in order to function.\n");
 			}
 		}
-
+		
+		if (optional_string("$Player starts in third person/chase view by default:")) {
+			stuff_boolean(&Chase_view_default);
+		}
+		
 		required_string("#END");
 	}
 	catch (const parse::ParseException& e)

--- a/code/mod_table/mod_table.h
+++ b/code/mod_table/mod_table.h
@@ -56,6 +56,7 @@ extern SCP_vector<gr_capability> Required_render_ext;
 extern float Weapon_SS_Threshold_Turret_Inaccuracy;
 extern bool Framerate_independent_turning;
 extern bool Ai_respect_tabled_turntime_rotdamp;
+extern bool Chase_view_default;
 extern bool Render_player_mflash;
 
 void mod_table_init();

--- a/code/playerman/playercontrol.cpp
+++ b/code/playerman/playercontrol.cpp
@@ -1380,7 +1380,7 @@ void player_level_init()
 	Viewer_external_info.current_distance = 0.0f;
 
 	
-	if (Chase_view_default == true)
+	if (Chase_view_default)
 	{
 		Viewer_mode = VM_CHASE;
 	}

--- a/code/playerman/playercontrol.cpp
+++ b/code/playerman/playercontrol.cpp
@@ -1379,7 +1379,15 @@ void player_level_init()
 	Viewer_external_info.preferred_distance = 0.0f;
 	Viewer_external_info.current_distance = 0.0f;
 
-	Viewer_mode = 0;
+	
+	if (Chase_view_default == true)
+	{
+		Viewer_mode = VM_CHASE;
+	}
+	else
+	{
+		Viewer_mode = 0;
+	}
  
 	Player_obj = NULL;
 	Player_ship = NULL;


### PR DESCRIPTION
If the mod has "$Player starts in Third Person View by Default: TRUE" in their game_settings.tbl or any such .tbm, missions will automatically put the player in the third person chase view. This was requested as a FR by Darius on January 17th.

This will NOT stop the player from going back into first person by pressing the key for it.

closes #3152