### PR TITLE
Fix Fov_edge_checks

### DIFF
--- a/code/ai/aiturret.cpp
+++ b/code/ai/aiturret.cpp
@@ -1123,9 +1123,8 @@ int find_turret_enemy(ship_subsys *turret_subsys, int objnum, vec3d *tpos, vec3d
 						if ( tagged_only_flag && ship_is_tagged(&Objects[aip->target_objnum]) ) {
 							// select new target if aip->target_objnum is out of field of view
 							vec3d v2e;
-							float dist;
 							bool in_fov;
-							dist = vm_vec_normalized_dir(&v2e, &Objects[aip->target_objnum].pos, tpos);
+							vm_vec_normalized_dir(&v2e, &Objects[aip->target_objnum].pos, tpos);
 
 							in_fov = turret_fov_test(turret_subsys, tvec, &v2e);
 

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -1765,7 +1765,7 @@ void ship_get_global_turret_info(const object *objp, const model_subsystem *tp, 
 
 // return 1 if objp is in fov of the specified turret, tp.  Otherwise return 0.
 //	dist = distance from turret to center point of object
-int object_in_turret_fov(object *objp, ship_subsys *ss, vec3d *tvec, vec3d *tpos, float dist);
+bool object_in_turret_fov(object *objp, ship_subsys *ss, vec3d *tvec, vec3d *tpos, float dist);
 
 // functions for testing fov.. returns true if fov test is passed.
 bool turret_std_fov_test(ship_subsys *ss, vec3d *gvec, vec3d *v2e, float size_mod = 0);


### PR DESCRIPTION
This flag is useless, it attempts to hold on to targets that have gone out of fov by getting the gun as close as possible and firing in that direction, but that's not a great idea since that point could very well not be aiming at the ship at all, and furthermore the turret is constantly re-targeting either new subsystems on it's target or new targets in its fov, which this edge checks system doesn't touch anyway, so that work will get clobbered in moments after losing fov in the 'standard' way. 

Rather rolling a new function that isn't called in the right places, this flag will have another branch in `object_in_turret_fov`, the real function that determines whether to acquire a new target, and that's the function that is too conservative with regards to the target's size and proximity, while the normal method *does* take them into account, it will still often ignore ships which have portions which are comfortably in fov. The new method simply checks each of the bbox points (with a small fov penalty, don't want to be too greedy if it can only see a tiny portion). 

The changes look confusing, but what happened was that `is_object_radius_in_turret_fov` was removed and an extra branch was added to `object_in_turret_fov`.

Edit: also fixes the crashes that will happen if you attempt to use this flag due to a minor oversight in #3277, the fix is pretty trivial but I figured I would kill two birds with one stone.