### PR TITLE
add mission flag for starting missions in chase view

### DIFF
--- a/code/mission/mission_flags.h
+++ b/code/mission/mission_flags.h
@@ -25,13 +25,14 @@ namespace Mission {
 		Red_alert,					// a red-alert mission - Goober5000
 		Scramble,					// a scramble mission - Goober5000
 		No_builtin_command,			// turns off Command without turning off pilots - Karajorma
-		Player_start_ai,			// Player Starts mission under AI Control (NOT MULTI COMPATABLE) - Kazan
+		Player_start_ai,			// Player starts mission under AI Control (NOT MULTI COMPATABLE) - Kazan
 		All_attack,					// all teams at war - Goober5000
 		Use_ap_cinematics,			// use autopilot cinematics - Kazan
 		Deactivate_ap,				// deactivate autopilot - KeldorKatarn (patch approved by Kazan)
 		Always_show_goals,			// Show the mission goals, even for training missions - Karajorma
 		End_to_mainhall,			// Return to the mainhall after debrief - niffiwan
 		Override_hashcommand,		// Override #Command with the Command info in Mission Specs - Goober5000
+		Player_start_chase_view,	// Player starts mission in chase view - Goober5000
 		
 		NUM_VALUES
 	};

--- a/code/playerman/playercontrol.cpp
+++ b/code/playerman/playercontrol.cpp
@@ -1380,7 +1380,7 @@ void player_level_init()
 	Viewer_external_info.current_distance = 0.0f;
 
 	
-	if (Chase_view_default)
+	if (Chase_view_default || The_mission.flags[Mission::Mission_Flags::Player_start_chase_view])
 	{
 		Viewer_mode = VM_CHASE;
 	}

--- a/fred2/fred.rc
+++ b/fred2/fred.rc
@@ -902,7 +902,9 @@ BEGIN
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,326,151,123,10
     CONTROL         "Player Starts under AI Control (NO MULTI)",IDC_PLAYER_START_AI,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,326,161,146,10
-    CONTROL         "2D Mission",IDC_2D_MISSION,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,326,171,123,10
+    CONTROL         "Player Starts in Chase View",IDC_PLAYER_START_CHASE,
+                    "Button",BS_AUTOCHECKBOX | WS_TABSTOP,326,171,146,10
+    CONTROL         "2D Mission",IDC_2D_MISSION,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,326,181,123,10
     LTEXT           "AI Profile",IDC_STATIC,320,229,32,8
     COMBOBOX        IDC_AI_PROFILE,378,226,93,140,CBS_DROPDOWNLIST | WS_VSCROLL | WS_TABSTOP
     LTEXT           "Mission Description",IDC_STATIC,4,260,62,8
@@ -916,8 +918,8 @@ BEGIN
     CONTROL         "",IDC_MAX_RESPAWN_DELAY_SPIN,"msctls_updown32",UDS_SETBUDDYINT | UDS_ALIGNRIGHT | UDS_AUTOBUDDY | UDS_ARROWKEYS,136,112,11,14
     PUSHBUTTON      "Sound Environment",IDC_SOUND_ENVIRONMENT_BUTTON,158,244,140,15
     CONTROL         "Always Show Mission Goals In Briefing",IDC_ALWAYS_SHOW_GOALS,
-                    "Button",BS_AUTOCHECKBOX | WS_TABSTOP,326,180,142,10
-    CONTROL         "Mission End to Mainhall",IDC_END_TO_MAINHALL,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,326,190,142,10
+                    "Button",BS_AUTOCHECKBOX | WS_TABSTOP,326,191,142,10
+    CONTROL         "Mission End to Mainhall",IDC_END_TO_MAINHALL,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,326,201,142,10
     CONTROL         "Override #Command in event messages",IDC_OVERRIDE_HASHCOMMAND,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,166,172,142,10
 END

--- a/fred2/missionnotesdlg.cpp
+++ b/fred2/missionnotesdlg.cpp
@@ -67,6 +67,7 @@ CMissionNotesDlg::CMissionNotesDlg(CWnd* pParent /*=NULL*/) : CDialog(CMissionNo
 	m_support_repairs_hull = FALSE;
 	m_beam_free_all_by_default = FALSE;
 	m_player_start_using_ai = FALSE;
+	m_player_start_chase_view = FALSE;
 	m_no_briefing = FALSE;
 	m_no_debriefing = FALSE;
 	m_autpilot_cinematics = FALSE;
@@ -120,6 +121,7 @@ void CMissionNotesDlg::DoDataExchange(CDataExchange* pDX)
 	DDX_Check(pDX, IDC_SUPPORT_REPAIRS_HULL, m_support_repairs_hull);
 	DDX_Check(pDX, IDC_BEAM_FREE_ALL_BY_DEFAULT, m_beam_free_all_by_default);
 	DDX_Check(pDX, IDC_PLAYER_START_AI, m_player_start_using_ai);
+	DDX_Check(pDX, IDC_PLAYER_START_CHASE, m_player_start_chase_view);
 	DDX_Check(pDX, IDC_NO_BRIEFING, m_no_briefing);
 	DDX_Check(pDX, IDC_NO_DEBRIEFING, m_no_debriefing);
 	DDX_Check(pDX, IDC_USE_AUTOPILOT_CINEMATICS, m_autpilot_cinematics);
@@ -273,6 +275,9 @@ void CMissionNotesDlg::OnOK()
 	// set player AI by default
     The_mission.flags.set(Mission::Mission_Flags::Player_start_ai, m_player_start_using_ai != 0);
 
+	// set player chase view
+    The_mission.flags.set(Mission::Mission_Flags::Player_start_chase_view, m_player_start_chase_view != 0);
+
 	// set briefing
     The_mission.flags.set(Mission::Mission_Flags::No_briefing, m_no_briefing != 0);
 
@@ -394,6 +399,7 @@ BOOL CMissionNotesDlg::OnInitDialog()
 	m_support_repairs_hull = (The_mission.flags[Mission::Mission_Flags::Support_repairs_hull]) ? 1 : 0;
 	m_beam_free_all_by_default = (The_mission.flags[Mission::Mission_Flags::Beam_free_all_by_default]) ? 1 : 0;
 	m_player_start_using_ai = (The_mission.flags[Mission::Mission_Flags::Player_start_ai]) ? 1 : 0;
+	m_player_start_chase_view = (The_mission.flags[Mission::Mission_Flags::Player_start_chase_view]) ? 1 : 0;
 	m_no_briefing = (The_mission.flags[Mission::Mission_Flags::No_briefing]) ? 1 : 0;
 	m_no_debriefing = (The_mission.flags[Mission::Mission_Flags::Toggle_debriefing]) ? 1 : 0;
 	m_autpilot_cinematics = (The_mission.flags[Mission::Mission_Flags::Use_ap_cinematics]) ? 1 : 0;

--- a/fred2/missionnotesdlg.h
+++ b/fred2/missionnotesdlg.h
@@ -58,6 +58,7 @@ public:
 	BOOL		m_support_repairs_hull;
 	BOOL		m_beam_free_all_by_default;
 	BOOL		m_player_start_using_ai;
+	BOOL		m_player_start_chase_view;
 	BOOL		m_no_briefing;
 	BOOL		m_no_debriefing;
 	BOOL		m_autpilot_cinematics;

--- a/fred2/resource.h
+++ b/fred2/resource.h
@@ -1054,6 +1054,7 @@
 #define IDC_EXPORT                      1581
 #define IDC_SECONDARIES_LOCKED          1582
 #define IDC_SUBSTITUTE_BRIEFING_MUSIC   1582
+#define IDC_PLAYER_START_CHASE          1583
 #define IDC_RESTRICT_PATHS_LABEL        1584
 #define IDC_PATH_LIST                   1585
 #define IDC_BACKGROUND                  1586

--- a/qtfred/src/ui/dialogs/MissionSpecDialog.cpp
+++ b/qtfred/src/ui/dialogs/MissionSpecDialog.cpp
@@ -79,6 +79,7 @@ MissionSpecDialog::MissionSpecDialog(FredView* parent, EditorViewport* viewport)
 	connect(ui->toggleAutopilotCinematics, &QCheckBox::toggled, this, [this](bool param) {flagToggled(param, Mission::Mission_Flags::Use_ap_cinematics); });
 	connect(ui->toggleHardcodedAutopilot, &QCheckBox::toggled, this, [this](bool param) {flagToggled(param, Mission::Mission_Flags::Deactivate_ap); });
 	connect(ui->toggleAIControlStart, &QCheckBox::toggled, this, [this](bool param) {flagToggled(param, Mission::Mission_Flags::Player_start_ai); });
+	connect(ui->toggleChaseViewStart, &QCheckBox::toggled, this, [this](bool param) {flagToggled(param, Mission::Mission_Flags::Player_start_chase_view); });
 	connect(ui->toggle2DMission, &QCheckBox::toggled, this, [this](bool param) {flagToggled(param, Mission::Mission_Flags::Mission_2d); });
 	connect(ui->toggleGoalsInBriefing, &QCheckBox::toggled, this, [this](bool param) {flagToggled(param, Mission::Mission_Flags::Always_show_goals); });
 	connect(ui->toggleMissionEndToMainhall, &QCheckBox::toggled, this, [this](bool param) {flagToggled(param, Mission::Mission_Flags::End_to_mainhall); });
@@ -236,6 +237,7 @@ void MissionSpecDialog::updateFlags() {
 	auto flags = _model->getMissionFlags();
 	ui->toggle2DMission->setChecked(flags[Mission::Mission_Flags::Mission_2d]);
 	ui->toggleAIControlStart->setChecked(flags[Mission::Mission_Flags::Player_start_ai]);
+	ui->toggleChaseViewStart->setChecked(flags[Mission::Mission_Flags::Player_start_chase_view]);
 	ui->toggleAllTeamsAtWar->setChecked(flags[Mission::Mission_Flags::All_attack]);
 	ui->toggleAutopilotCinematics->setChecked(flags[Mission::Mission_Flags::Use_ap_cinematics]);
 	ui->toggleBeamFreeDefault->setChecked(flags[Mission::Mission_Flags::Beam_free_all_by_default]);

--- a/qtfred/ui/MissionSpecDialog.ui
+++ b/qtfred/ui/MissionSpecDialog.ui
@@ -888,6 +888,16 @@
          </widget>
         </item>
         <item>
+         <widget class="QCheckBox" name="toggleChaseViewStart">
+          <property name="text">
+           <string>Player Starts in Chase View</string>
+          </property>
+          <attribute name="buttonGroup">
+           <string notr="true">m_flagGroup</string>
+          </attribute>
+         </widget>
+        </item>
+        <item>
          <widget class="QCheckBox" name="toggle2DMission">
           <property name="text">
            <string>2D Mission</string>


### PR DESCRIPTION
Follow-up to #3305.  Some mods may want one or two missions to start in chase view without having every single mission default to chase view.  So this adds a mission flag (with FRED and qtFRED support) that will enable this on a per-mission basis.