### PR TITLE
Multi 21 2 bump requiring changes

### DIFF
--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -4236,9 +4236,13 @@ int parse_wing_create_ships( wing *wingp, int num_to_create, int force, int spec
 
 		// also, if multiplayer, set the parse object's net signature to be wing's net signature
 		// base + total_arrived_count (before adding 1)
-		if (Game_mode & GM_MULTIPLAYER)
+		// Cyborg -- The original ships in the wave have their net_signature set at mission parse
+		// so only do this if this is a subsequent wave.
+		if (Game_mode & GM_MULTIPLAYER && wingp->num_waves > 1)
 		{
-			p_objp->net_signature = (ushort) (wingp->net_signature + wingp->total_arrived_count);
+			// Cyborg -- Also, then we need to subtract the original wave's number of fighters 
+			// and also subtract 1 to use the wing's starting signature
+			p_objp->net_signature = (ushort) (wingp->net_signature + wingp->total_arrived_count - (wingp->wave_count + 1));
 		}
 
 
@@ -4683,7 +4687,8 @@ void parse_wing(mission *pm)
 		int next_signature;
 
 		wingp->net_signature = multi_assign_network_signature( MULTI_SIG_SHIP );
-		next_signature = wingp->net_signature + (wingp->wave_count * wingp->num_waves);
+		// Cyborg -- Subtract one because the original wave already has its signatures set.
+		next_signature = wingp->net_signature + (wingp->wave_count * (wingp->num_waves - 1));
 		if ( next_signature > SHIP_SIG_MAX )
 			Error(LOCATION, "Too many total ships in mission (%d) for network signature assignment", SHIP_SIG_MAX);
 		multi_set_network_signature( (ushort)next_signature, MULTI_SIG_SHIP );

--- a/code/network/multi.cpp
+++ b/code/network/multi.cpp
@@ -569,7 +569,7 @@ void process_packet_normal(ubyte* data, header *header_info)
 			process_ship_kill_packet( data, header_info );
 			break;
 
-		case WEAPON_KILL:
+		case MISSILE_KILL:
 			process_weapon_kill_packet(data, header_info);
 			break;
 

--- a/code/network/multi.cpp
+++ b/code/network/multi.cpp
@@ -569,6 +569,10 @@ void process_packet_normal(ubyte* data, header *header_info)
 			process_ship_kill_packet( data, header_info );
 			break;
 
+		case WEAPON_KILL:
+			process_weapon_kill_packet(data, header_info);
+			break;
+
 		case WING_CREATE:
 			process_wing_create_packet( data, header_info );
 			break;

--- a/code/network/multi.h
+++ b/code/network/multi.h
@@ -66,9 +66,10 @@ class player;
 // version 51 - 9/20/2020 Object Update Packet Upgrade: Waypoints, subsystem rotation, bandwidth improvements, bugfixes
 // version 52 - 10/9/2020 Dumbfire Rollback, increases accuracy of high ping, or delayed packet primary fire for clients.
 // version 53 - 12/2/2020 big set of packet fixes/upgrades
+// version 54 - 3/20/2021 - Fixes for FSO 21_2 especially better net_sig calc, better missile intercept
 // STANDALONE_ONLY
 
-#define MULTI_FS_SERVER_VERSION							53
+#define MULTI_FS_SERVER_VERSION							54
 
 #define MULTI_FS_SERVER_COMPATIBLE_VERSION			MULTI_FS_SERVER_VERSION
 

--- a/code/network/multi.h
+++ b/code/network/multi.h
@@ -253,6 +253,7 @@ class player;
 #define REINFORCEMENT_AVAIL		0xDB		// a reinforcement is available
 #define LIGHTNING_PACKET			0xDC		// lightning bolt packet for multiplayer nebula
 #define BYTES_SENT					0xDD		// how much data we've sent/received
+#define WEAPON_KILL					0xDE		// get rid of this weapon on the client.
 
 #define GAME_ACTIVE					0xE1		// info on an active game server
 #define GAME_QUERY					0xE2		// request for a list of active game servers

--- a/code/network/multi.h
+++ b/code/network/multi.h
@@ -253,7 +253,7 @@ class player;
 #define REINFORCEMENT_AVAIL		0xDB		// a reinforcement is available
 #define LIGHTNING_PACKET			0xDC		// lightning bolt packet for multiplayer nebula
 #define BYTES_SENT					0xDD		// how much data we've sent/received
-#define WEAPON_KILL					0xDE		// get rid of this weapon on the client.
+#define MISSILE_KILL					0xDE		// get rid of this weapon on the client.
 
 #define GAME_ACTIVE					0xE1		// info on an active game server
 #define GAME_QUERY					0xE2		// request for a list of active game servers

--- a/code/network/multimsgs.cpp
+++ b/code/network/multimsgs.cpp
@@ -7522,6 +7522,7 @@ void send_homing_weapon_info( int weapon_num )
 	// homing signature.
 	homing_signature = 0;
 	homing_object = wp->homing_object;
+
 	if ( homing_object != &obj_used_list ) {
 		homing_signature = homing_object->net_signature;
 
@@ -7545,7 +7546,7 @@ void send_homing_weapon_info( int weapon_num )
 
 	if (flags & HWIF_BIG_UPDATE) {
 		fix current_lifetime = Missiontime - wp->creation_time;
-		ADD_DATA(current_lifetime);
+		ADD_INT(current_lifetime);
 		ADD_VECTOR(Objects[wp->objnum].pos);
 		ADD_FLOAT(wp->launch_speed);
 		ADD_ORIENT(Objects[wp->objnum].orient);
@@ -7579,7 +7580,7 @@ void process_homing_weapon_info( ubyte *data, header *hinfo )
 	GET_VECTOR( homing_goal );
 
 	if (flags & HWIF_BIG_UPDATE) {
-		GET_DATA(missile_lifetime);
+		GET_INT(missile_lifetime);
 		GET_VECTOR(missile_pos);
 		GET_FLOAT(launch_speed);
 		GET_ORIENT(orient_in);
@@ -7588,15 +7589,18 @@ void process_homing_weapon_info( ubyte *data, header *hinfo )
 
 	// deal with changing this weapons homing information
 	weapon_objp = multi_get_network_object( weapon_signature );
+
 	if ( weapon_objp == nullptr ) {
 		nprintf(("Network", "Couldn't find weapon object for homing update -- skipping update\n"));
 		return;
 	}
+
 	Assert( weapon_objp->type == OBJ_WEAPON );
 	wp = &Weapons[weapon_objp->instance];
 
 	// be sure that we can find these weapons and 
 	homing_object = multi_get_network_object( homing_signature );
+
 	if ( homing_object == nullptr ) {
 		wp->homing_object = &obj_used_list;
 		wp->homing_subsys = nullptr;
@@ -7622,6 +7626,7 @@ void process_homing_weapon_info( ubyte *data, header *hinfo )
 	wp->target_num = OBJ_INDEX(homing_object);
 	wp->target_sig = homing_object->signature;
 	wp->homing_pos = homing_goal;
+
 	if ( h_subsys != -1 ) {
 		Assert( homing_object->type == OBJ_SHIP );
 		wp->homing_subsys = ship_get_indexed_subsys( &Ships[homing_object->instance], h_subsys);

--- a/code/network/multimsgs.cpp
+++ b/code/network/multimsgs.cpp
@@ -7568,7 +7568,7 @@ void process_homing_weapon_info( ubyte *data, header *hinfo )
 	vec3d missile_pos = vmd_zero_vector, homing_goal = vmd_zero_vector;
 	object *homing_object, *weapon_objp;
 	weapon *wp;
-	matrix orient_in;
+	matrix orient_in = vmd_identity_matrix;
 
 	offset = HEADER_LENGTH;
 

--- a/code/network/multimsgs.cpp
+++ b/code/network/multimsgs.cpp
@@ -7561,11 +7561,11 @@ void process_homing_weapon_info( ubyte *data, header *hinfo )
 {
 	ubyte flags;
 	int offset;
-	fix missile_lifetime;
+	fix missile_lifetime = 0;
 	ushort weapon_signature, homing_signature;
 	short h_subsys;
-	float launch_speed;
-	vec3d missile_pos, homing_goal;
+	float launch_speed = 0.0f;
+	vec3d missile_pos = vmd_zero_vector, homing_goal = vmd_zero_vector;
 	object *homing_object, *weapon_objp;
 	weapon *wp;
 	matrix orient_in;

--- a/code/network/multimsgs.h
+++ b/code/network/multimsgs.h
@@ -295,8 +295,8 @@ void send_object_update_packet(int force_all = 0);
 // send a packet indicating a ship has been killed
 void send_ship_kill_packet( object *ship_obj, object *other_objp, float percent_killed, int self_destruct );
 
-// send a packet indicating that a weapon collided
-void send_weapon_kill_packet(object* objp);
+// send a packet indicating that a missile died.
+void send_missile_kill_packet(object* objp);
 
 void process_weapon_kill_packet(ubyte* data, header* hinfo);
 

--- a/code/network/multimsgs.h
+++ b/code/network/multimsgs.h
@@ -295,6 +295,11 @@ void send_object_update_packet(int force_all = 0);
 // send a packet indicating a ship has been killed
 void send_ship_kill_packet( object *ship_obj, object *other_objp, float percent_killed, int self_destruct );
 
+// send a packet indicating that a weapon collided
+void send_weapon_kill_packet(object* objp);
+
+void process_weapon_kill_packet(ubyte* data, header* hinfo);
+
 // send a packet indicating a wing of ships should be created
 void send_wing_create_packet( wing *wingp, int num_to_create, int pre_create_count );
 

--- a/code/network/multiutil.cpp
+++ b/code/network/multiutil.cpp
@@ -3574,7 +3574,6 @@ int multi_pack_unpack_rotvel( int write, ubyte *data, physics_info *pi)
 		bitbuffer_put( &buf, (uint)b, 10 );
 		bitbuffer_put( &buf, (uint)c, 10 );
 
-
 		return bitbuffer_write_flush(&buf);
 
 	} else {
@@ -3637,8 +3636,10 @@ int multi_pack_unpack_desired_vel_and_desired_rotvel( int write, bool full_physi
 		if (pi->max_vel.xyz.y > 0.0f) {
 			e = fl2i(round( (local_desired_vel->xyz.y / pi->max_vel.xyz.y) * 7.0f));
 		}
-		float z_divisor = MAX(pi->afterburner_max_vel.xyz.z, pi->max_vel.xyz.z);
+
 		// for z velocity, take into account afterburner.
+		float z_divisor = MAX(pi->afterburner_max_vel.xyz.z, pi->max_vel.xyz.z);
+
 		if (z_divisor > 0.0f) {
 			f = fl2i(round( (local_desired_vel->xyz.z / z_divisor) * 255.0f));
 		}
@@ -3648,8 +3649,8 @@ int multi_pack_unpack_desired_vel_and_desired_rotvel( int write, bool full_physi
 		CAP(f,-z_capfactor,z_capfactor);
 		bitbuffer_put( &buf, (uint)d,4);
 		bitbuffer_put( &buf, (uint)e,4);
-
 		bitbuffer_put( &buf, (uint)f,z_bitcount); // either 9 or 16 bits.
+
 		return bitbuffer_write_flush(&buf);
 
 	} else {

--- a/code/network/multiutil.cpp
+++ b/code/network/multiutil.cpp
@@ -3522,25 +3522,25 @@ int multi_pack_unpack_vel( int write, ubyte *data, matrix *orient, physics_info 
 		f = vm_vec_dot( &orient->vec.fvec, &pi->vel );
 
 		// Cyborg17 - using round here allows us keep part of the decimal accuracy that would have been dropped with just fl2i
-		a = fl2i(round(r * 2.0f)); 
-		b = fl2i(round(u * 2.0f));
-		c = fl2i(round(f * 4.0f));
-		CAP(a,-512,511);
-		CAP(b,-512,511);
-		CAP(c,-2048,2047);
-		bitbuffer_put( &buf, (uint)a, 10 );
-		bitbuffer_put( &buf, (uint)b, 10 );
-		bitbuffer_put( &buf, (uint)c, 12 );
+		a = fl2i(round(r * 16.0f)); 
+		b = fl2i(round(u * 16.0f));
+		c = fl2i(round(f * 32.0f));
+		CAP(a,-2048,2047);
+		CAP(b,-2048,2047);
+		CAP(c,-4096,4095);
+		bitbuffer_put( &buf, (uint)a, 13 );
+		bitbuffer_put( &buf, (uint)b, 13 );
+		bitbuffer_put( &buf, (uint)c, 14 );
 
 		return bitbuffer_write_flush(&buf);
 	} else {
 		// unpack velocity
-		a = bitbuffer_get_signed(&buf,10);
-		b = bitbuffer_get_signed(&buf,10);
-		c = bitbuffer_get_signed(&buf,12);
-		r = i2fl(a)/2.0f;
-		u = i2fl(b)/2.0f;
-		f = i2fl(c)/4.0f;
+		a = bitbuffer_get_signed(&buf,13);
+		b = bitbuffer_get_signed(&buf,13);
+		c = bitbuffer_get_signed(&buf,14);
+		r = i2fl(a)/16.0f;
+		u = i2fl(b)/16.0f;
+		f = i2fl(c)/32.0f;
 
 		// Convert into world coordinates
 		vm_vec_zero(&pi->vel);

--- a/code/network/multiutil.cpp
+++ b/code/network/multiutil.cpp
@@ -3600,6 +3600,11 @@ int multi_pack_unpack_desired_vel_and_desired_rotvel( int write, bool full_physi
 	int a = 0, b = 0, c = 0;
 	int d = 0, e = 0, f = 0;
 
+	// we could have reduced it to 8 when full physics is false, and saved the byte, 
+	// but this ends up allowing us more accuracy during capship warpin/out
+	const int z_bitcount = (full_physics) ? 9 : 16; 				
+	const int z_capfactor = (full_physics) ? 255 : 32640;
+
 	if ( write )	{
 		if (full_physics) {
 			// output desired rotational velocity
@@ -3632,18 +3637,19 @@ int multi_pack_unpack_desired_vel_and_desired_rotvel( int write, bool full_physi
 		if (pi->max_vel.xyz.y > 0.0f) {
 			e = fl2i(round( (local_desired_vel->xyz.y / pi->max_vel.xyz.y) * 7.0f));
 		}
+		float z_divisor = MAX(pi->afterburner_max_vel.xyz.z, pi->max_vel.xyz.z);
 		// for z velocity, take into account afterburner.
-		if (pi->max_vel.xyz.z > 0.0f) {
-			f = fl2i(round( (local_desired_vel->xyz.z / pi->afterburner_max_vel.xyz.z) * 255.0f));
+		if (z_divisor > 0.0f) {
+			f = fl2i(round( (local_desired_vel->xyz.z / z_divisor) * 255.0f));
 		}
 
 		CAP(d,-7,7);
 		CAP(e,-7,7);
-		CAP(f,-255,255);
+		CAP(f,-z_capfactor,z_capfactor);
 		bitbuffer_put( &buf, (uint)d,4);
 		bitbuffer_put( &buf, (uint)e,4);
-		bitbuffer_put( &buf, (uint)f,9);
 
+		bitbuffer_put( &buf, (uint)f,z_bitcount); // either 9 or 16 bits.
 		return bitbuffer_write_flush(&buf);
 
 	} else {
@@ -3662,10 +3668,13 @@ int multi_pack_unpack_desired_vel_and_desired_rotvel( int write, bool full_physi
 		// unpack desired velocity
 		d = bitbuffer_get_signed(&buf,4);
 		e = bitbuffer_get_signed(&buf,4);
-		f = bitbuffer_get_signed(&buf,9);
+		f = bitbuffer_get_signed(&buf,z_bitcount); // either 9 or 16 bits.
 		local_desired_vel->xyz.x = pi->max_vel.xyz.x * i2fl(d)/7.0f;
 		local_desired_vel->xyz.y = pi->max_vel.xyz.y * i2fl(e)/7.0f;
-		local_desired_vel->xyz.z = pi->afterburner_max_vel.xyz.z * i2fl(f)/255.0f;
+
+		float z_multiplier = MAX(pi->afterburner_max_vel.xyz.z, pi->max_vel.xyz.z);
+
+		local_desired_vel->xyz.z = z_multiplier * i2fl(f)/255.0f;
 
 
 		return bitbuffer_read_flush(&buf);

--- a/code/object/collideweaponweapon.cpp
+++ b/code/object/collideweaponweapon.cpp
@@ -94,7 +94,8 @@ int collide_weapon_weapon( obj_pair * pair )
 		bool b_override = Script_system.IsConditionOverride(CHA_COLLIDEWEAPON, B);
 		Script_system.RemHookVars({ "Self", "Object", "Weapon", "WeaponB", "Hitpos" });
 
-		if(!a_override && !b_override)
+		// damage calculation should not be done on clients, the server will tell the client version of the bomb when to die
+		if(!a_override && !b_override && !MULTIPLAYER_CLIENT)
 		{
 			float aDamage = wipA->damage;
 			if (wipB->armor_type_idx >= 0)

--- a/code/scripting/api/objs/weapon.cpp
+++ b/code/scripting/api/objs/weapon.cpp
@@ -231,6 +231,7 @@ ADE_VIRTVAR(HomingPosition, l_Weapon, "vector", "Position that weapon will home 
 		{
 			wp->homing_pos = vmd_zero_vector;
 		}
+
 		// need to update the position for multiplayer.
 		if (Game_mode & GM_MULTIPLAYER) {
 			wp->weapon_flags.set(Weapon::Weapon_Flags::Multi_homing_update_needed);
@@ -273,6 +274,7 @@ ADE_VIRTVAR(HomingSubsystem, l_Weapon, "subsystem", "Subsystem that weapon will 
 			wp->homing_pos = vmd_zero_vector;
 			wp->homing_subsys = NULL;
 		}
+
 		// need to update the position for multiplayer.
 		if (Game_mode & GM_MULTIPLAYER) {
 			wp->weapon_flags.set(Weapon::Weapon_Flags::Multi_homing_update_needed);

--- a/code/scripting/api/objs/weapon.cpp
+++ b/code/scripting/api/objs/weapon.cpp
@@ -231,6 +231,10 @@ ADE_VIRTVAR(HomingPosition, l_Weapon, "vector", "Position that weapon will home 
 		{
 			wp->homing_pos = vmd_zero_vector;
 		}
+		// need to update the position for multiplayer.
+		if (Game_mode & GM_MULTIPLAYER) {
+			wp->weapon_flags.set(Weapon::Weapon_Flags::Multi_homing_update_needed);
+		}
 	}
 
 	return ade_set_args(L, "o", l_Vector.Set(wp->homing_pos));
@@ -268,6 +272,10 @@ ADE_VIRTVAR(HomingSubsystem, l_Weapon, "subsystem", "Subsystem that weapon will 
 			wp->homing_object = &obj_used_list;
 			wp->homing_pos = vmd_zero_vector;
 			wp->homing_subsys = NULL;
+		}
+		// need to update the position for multiplayer.
+		if (Game_mode & GM_MULTIPLAYER) {
+			wp->weapon_flags.set(Weapon::Weapon_Flags::Multi_homing_update_needed);
 		}
 	}
 

--- a/code/weapon/weapon_flags.h
+++ b/code/weapon/weapon_flags.h
@@ -99,9 +99,10 @@ namespace Weapon {
 		Locked_when_fired,			// fired with a lock
 		Destroyed_by_weapon,		// destroyed by damage from other weapon
 		Spawned,					//Spawned from a spawning type weapon
-		Homing_update_needed,       // this is a newly spawned homing weapon which needs to update client machines
         No_homing,                  // this weapon should ignore any homing behavior it'd usually have
 		Overridden_homing,          // Homing is overridden by an external source (probably scripting)
+		Multi_homing_update_needed, // this is a newly spawned homing weapon which needs to update client machines
+		Multi_Update_Sent,			// Marks this missile as already being updated once by the server
 
 		NUM_VALUES
 	};

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -4493,10 +4493,6 @@ void weapon_home(object *obj, int num, float frame_time)
 				return;
 			}
 		}
-		else if (MULTIPLAYER_MASTER && (wip->is_locked_homing()) && (wp->weapon_flags[Weapon::Weapon_Flags::Homing_update_needed])) {
-            wp->weapon_flags.remove(Weapon::Weapon_Flags::Homing_update_needed);
-			send_homing_weapon_info(num);
-		}
 
 		if (wip->acceleration_time > 0.0f) {
 			if (Missiontime - wp->creation_time < fl2f(wip->acceleration_time)) {
@@ -4712,7 +4708,8 @@ void weapon_home(object *obj, int num, float frame_time)
 				if (hobjp->radius < 40.0f) {
 					target_pos     = hobjp->pos;
 					wp->homing_pos = target_pos;
-				} else if (pick_homing_point || (dist < 500.0f) || (rand_chance(flFrametime, 2.0f))) {
+					// only recalculate a homing point if you are not a client.  You will get the new point from the server.
+				} else if (pick_homing_point || (!MULTIPLAYER_CLIENT && ((dist < 500.0f) || (rand_chance(flFrametime, 2.0f))))) {
 
 					if (hobjp->type == OBJ_SHIP) {
 						if (!pick_homing_point) {
@@ -4880,7 +4877,23 @@ void weapon_update_missiles(object* obj, float  frame_time) {
 
 	// a single player or multiplayer server function -- it affects actual weapon movement.
 	if (wip->is_homing() && !(wp->weapon_flags[Weapon::Weapon_Flags::No_homing])) {
+		vec3d pos_hold = wp->homing_pos;
+		int target_hold = wp->target_sig;
+
 		weapon_home(obj, obj->instance, frame_time);
+
+		// tell the server to send an update of the missile.
+		if (MULTIPLAYER_MASTER && !IS_VEC_NULL(&wp->homing_pos)) {
+			wp->weapon_flags.set(Weapon::Weapon_Flags::Multi_homing_update_needed);
+			// if the first update for a weapon has already been sent, then we do not need to send any others unless the homing_pos
+			// drastically changes.
+			if (wp->weapon_flags[Weapon::Weapon_Flags::Multi_Update_Sent]) {
+				vm_vec_sub2(&pos_hold, &wp->homing_pos);
+				if ((vm_vec_mag(&pos_hold) < 1.0f) && (wp->target_sig == target_hold)) {
+					wp->weapon_flags.remove(Weapon::Weapon_Flags::Multi_homing_update_needed);
+				}
+			}
+		}
 
 		// If this is a swarm type missile,  
 		if (wp->swarm_info_ptr != nullptr) {
@@ -5142,9 +5155,13 @@ void weapon_process_post(object * obj, float frame_time)
 	if ( wp->lifeleft < 0.0f ) {
 		if ( wip->subtype & WP_MISSILE ) {
 			if(Game_mode & GM_MULTIPLAYER){				
-				if ( !MULTIPLAYER_CLIENT || (MULTIPLAYER_CLIENT && (wp->lifeleft < -2.0f)) || (MULTIPLAYER_CLIENT && (wip->wi_flags[Weapon::Info_Flags::Child]))) {					// don't call this function multiplayer client -- host will send this packet to us
+				if ( !MULTIPLAYER_CLIENT || (MULTIPLAYER_CLIENT && (wip->wi_flags[Weapon::Info_Flags::Child]))) {					// don't call this function multiplayer client -- host will send this packet to us
 					weapon_detonate(obj);					
 				}
+				if (MULTIPLAYER_MASTER) {
+					send_weapon_kill_packet(obj);
+				}
+
 			} else {
 				weapon_detonate(obj);									
 			}
@@ -5154,8 +5171,11 @@ void weapon_process_post(object * obj, float frame_time)
 		} else {
             obj->flags.set(Object::Object_Flags::Should_be_dead);
 		}
-
 		return;
+	}
+	else if ((MULTIPLAYER_MASTER) && (wip->is_locked_homing() && wp->weapon_flags[Weapon::Weapon_Flags::Multi_homing_update_needed])) {
+		send_homing_weapon_info(obj->instance);
+		wp->weapon_flags.remove(Weapon::Weapon_Flags::Multi_homing_update_needed);
 	}
 
 	// plot homing missiles on the radar
@@ -5560,9 +5580,6 @@ void weapon_set_tracking_info(int weapon_objnum, int parent_objnum, int target_o
 		//	put a sanity check in the color changing laser code that was broken by this code.
 		if (target_is_locked && (wp->target_num != -1) && (wip->is_locked_homing()) ) {
 			wp->lifeleft *= LOCKED_HOMING_EXTENDED_LIFE_FACTOR;
-			if (MULTIPLAYER_MASTER) {
-                wp->weapon_flags.set(Weapon::Weapon_Flags::Homing_update_needed);
-			}
 		}
 
 		ai_update_danger_weapon(target_objnum, weapon_objnum);		

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -5160,7 +5160,7 @@ void weapon_process_post(object * obj, float frame_time)
 				}
 
 				if (MULTIPLAYER_MASTER) {
-					send_weapon_kill_packet(obj);
+					send_missile_kill_packet(obj);
 				}
 
 			} else {

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -5158,6 +5158,7 @@ void weapon_process_post(object * obj, float frame_time)
 				if ( !MULTIPLAYER_CLIENT || (MULTIPLAYER_CLIENT && (wip->wi_flags[Weapon::Info_Flags::Child]))) {					// don't call this function multiplayer client -- host will send this packet to us
 					weapon_detonate(obj);					
 				}
+
 				if (MULTIPLAYER_MASTER) {
 					send_weapon_kill_packet(obj);
 				}


### PR DESCRIPTION
This PR contains all the changes that require a multi bump for 21_2:

- Upgrade velocity compression in OO packet, which prevents some of the back and forth shaking you will see as a client at the cost of slightly more bandwidth.
- Fixes the support ship bug by properly setting net singatures for ships in wings so that there's no overlap for the support ship and the last ship in the wing.
- Allows the client to shoot down bombs.  Previously bombs would be in wildly different positions on server and client.
- Fix a bug in the packer function for desired velocity and desired rotational velocity that kept the correct speed from displaying.

Closes #3031 
Closes #3170 
Does not work for all of 3042 --- Further testing reveals more interpolation problems even after making this change. 
Closes #3081 
