### PR TITLE
Make sure objects and ships get cleared if leaving mission sync

### DIFF
--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -5323,10 +5323,15 @@ void game_leave_state( int old_state, int new_state )
 
 				// set the game mode
 				Game_mode |= GM_IN_MISSION;
+
+				main_hall_stop_music(true);
+				main_hall_stop_ambient();		
+
+				// any other state needs to close out the mission, because we're not going in to gameplay.
+			} else {
+				freespace_stop_mission();
 			}
 
-			main_hall_stop_music(true);
-			main_hall_stop_ambient();		
 			break;		
    
 		case GS_STATE_VIEW_CUTSCENES:


### PR DESCRIPTION
This properly clears ships if you are leaving the sync state for any other state besides the gameplay state.

Previously, if the player left this state and then started another game, the old ships would still be present and could causes nan crashes.