### PR TITLE
Add `no impact debris` for whole ship

### DIFF
--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -351,6 +351,7 @@ flag_def_list_new<Info_Flags> Ship_flags[] = {
 	{ "don't clamp max velocity",	Info_Flags::Dont_clamp_max_velocity,	true, false },
 	{ "instantaneous acceleration",	Info_Flags::Instantaneous_acceleration,	true, false },
 	{ "large ship deathroll",		Info_Flags::Large_ship_deathroll,	true, false },
+	{ "no impact debris",			Info_Flags::No_impact_debris,		true, false },
     // to keep things clean, obsolete options go last
     { "ballistic primaries",		Info_Flags::Ballistic_primaries,	false, false }
 };

--- a/code/ship/ship_flags.h
+++ b/code/ship/ship_flags.h
@@ -198,6 +198,7 @@ namespace Ship {
 		Instantaneous_acceleration,		// Goober5000
 		Has_display_name,				// Goober5000
 		Large_ship_deathroll,			// Asteroth - big ships dont normally deathroll, this makes them do it!
+		No_impact_debris,				// wookieejedi - Don't spawn the small debris on impact
 
 		NUM_VALUES
 	};

--- a/code/ship/shiphit.cpp
+++ b/code/ship/shiphit.cpp
@@ -517,8 +517,8 @@ float do_subobj_hit_stuff(object *ship_objp, object *other_obj, vec3d *hitpos, i
 	if (!global_damage) {
 		auto subsys = ship_get_subsys_for_submodel(ship_p, submodel_num);
 
-		if (subsys == nullptr || !subsys->system_info->flags[Model::Subsystem_Flags::No_impact_debris] ||
-			!Ship_info[ship_p->ship_info_index].flags[Ship::Info_Flags::No_impact_debris]) {
+		if (subsys == nullptr || 
+			!(subsys->system_info->flags[Model::Subsystem_Flags::No_impact_debris] || Ship_info[ship_p->ship_info_index].flags[Ship::Info_Flags::No_impact_debris]) ) {
 			create_generic_debris(ship_objp, hitpos, 1.0f, 5.0f, 1.0f, false);
 		}
 	}

--- a/code/ship/shiphit.cpp
+++ b/code/ship/shiphit.cpp
@@ -517,7 +517,8 @@ float do_subobj_hit_stuff(object *ship_objp, object *other_obj, vec3d *hitpos, i
 	if (!global_damage) {
 		auto subsys = ship_get_subsys_for_submodel(ship_p, submodel_num);
 
-		if (subsys == nullptr || !subsys->system_info->flags[Model::Subsystem_Flags::No_impact_debris]) {
+		if (subsys == nullptr || !subsys->system_info->flags[Model::Subsystem_Flags::No_impact_debris] ||
+			!Ship_info[ship_p->ship_info_index].flags[Ship::Info_Flags::No_impact_debris]) {
 			create_generic_debris(ship_objp, hitpos, 1.0f, 5.0f, 1.0f, false);
 		}
 	}
@@ -1556,8 +1557,9 @@ static void ship_vaporize(ship *shipp)
 	ship_objp = &Objects[shipp->objnum];
 	ship_info* sip = &Ship_info[shipp->ship_info_index];
 
-	// create debris shards
-	create_generic_debris(ship_objp, &ship_objp->pos, (float)sip->generic_debris_spew_num, sip->generic_debris_spew_num * 2.0f, 1.4f, true);
+	// create debris shards if allowed
+	if (!sip->flags[Ship::Info_Flags::No_impact_debris])
+		create_generic_debris(ship_objp, &ship_objp->pos, (float)sip->generic_debris_spew_num, sip->generic_debris_spew_num * 2.0f, 1.4f, true);
 }
 
 //	*ship_objp was hit and we've determined he's been killed!  By *other_obj!

--- a/code/ship/shiphit.cpp
+++ b/code/ship/shiphit.cpp
@@ -1557,7 +1557,7 @@ static void ship_vaporize(ship *shipp)
 	ship_objp = &Objects[shipp->objnum];
 	ship_info* sip = &Ship_info[shipp->ship_info_index];
 
-	// create debris shards if allowed
+	// create debris shards
 	create_generic_debris(ship_objp, &ship_objp->pos, (float)sip->generic_debris_spew_num, sip->generic_debris_spew_num * 2.0f, 1.4f, true);
 }
 

--- a/code/ship/shiphit.cpp
+++ b/code/ship/shiphit.cpp
@@ -1557,9 +1557,7 @@ static void ship_vaporize(ship *shipp)
 	ship_objp = &Objects[shipp->objnum];
 	ship_info* sip = &Ship_info[shipp->ship_info_index];
 
-	// create debris shards if allowed
-	if (!sip->flags[Ship::Info_Flags::No_impact_debris])
-		create_generic_debris(ship_objp, &ship_objp->pos, (float)sip->generic_debris_spew_num, sip->generic_debris_spew_num * 2.0f, 1.4f, true);
+	create_generic_debris(ship_objp, &ship_objp->pos, (float)sip->generic_debris_spew_num, sip->generic_debris_spew_num * 2.0f, 1.4f, true);
 }
 
 //	*ship_objp was hit and we've determined he's been killed!  By *other_obj!

--- a/code/ship/shiphit.cpp
+++ b/code/ship/shiphit.cpp
@@ -1557,6 +1557,7 @@ static void ship_vaporize(ship *shipp)
 	ship_objp = &Objects[shipp->objnum];
 	ship_info* sip = &Ship_info[shipp->ship_info_index];
 
+	// create debris shards if allowed
 	create_generic_debris(ship_objp, &ship_objp->pos, (float)sip->generic_debris_spew_num, sip->generic_debris_spew_num * 2.0f, 1.4f, true);
 }
 

--- a/code/ship/shiphit.cpp
+++ b/code/ship/shiphit.cpp
@@ -517,8 +517,8 @@ float do_subobj_hit_stuff(object *ship_objp, object *other_obj, vec3d *hitpos, i
 	if (!global_damage) {
 		auto subsys = ship_get_subsys_for_submodel(ship_p, submodel_num);
 
-		if (subsys == nullptr || 
-			!(subsys->system_info->flags[Model::Subsystem_Flags::No_impact_debris] || Ship_info[ship_p->ship_info_index].flags[Ship::Info_Flags::No_impact_debris]) ) {
+		if ( !(Ship_info[ship_p->ship_info_index].flags[Ship::Info_Flags::No_impact_debris]) && 
+			( subsys == nullptr || !(subsys->system_info->flags[Model::Subsystem_Flags::No_impact_debris]) ) ) {
 			create_generic_debris(ship_objp, hitpos, 1.0f, 5.0f, 1.0f, false);
 		}
 	}


### PR DESCRIPTION
Previously, the `no impact debris` flag was only utilized for subsystems. This PR adds that flag for the whole ship. It also will disable debris spew for subsystems when the ship flag is enabled. 