### PR TITLE
Clarify naming of vm_vec_rotate and vm_vec_unrotate

### DIFF
--- a/code/math/vecmat.cpp
+++ b/code/math/vecmat.cpp
@@ -835,7 +835,7 @@ matrix *vm_vector_2_matrix_norm(matrix *m, const vec3d *fvec, const vec3d *uvec,
 //
 // Goober5000: FYI, the result of rotating a normalized vector through a rotation matrix will
 // also be a normalized vector.  It took me awhile to verify online that this was true. ;)
-vec3d *vm_vec_rotate(vec3d *dest, const vec3d *src, const matrix *m)
+vec3d *vm_matrix_x_vector(vec3d *dest, const matrix *m, const vec3d* src)
 {
 	Assert(dest != src);
 
@@ -861,7 +861,7 @@ vec3d *vm_vec_rotate(vec3d *dest, const vec3d *src, const matrix *m)
 //
 // Goober5000: FYI, the result of rotating a normalized vector through a rotation matrix will
 // also be a normalized vector.  It took me awhile to verify online that this was true. ;)
-vec3d *vm_vec_unrotate(vec3d *dest, const vec3d *src, const matrix *m)
+vec3d *vm_vector_x_matrix(vec3d *dest, const vec3d *src, const matrix *m)
 {
 	Assert(dest != src);
 
@@ -1141,7 +1141,7 @@ float find_nearest_point_on_line(vec3d *nearest_point, const vec3d *p0, const ve
 
 	vm_vec_outer_product(&mat, &norm);
 
-	vm_vec_rotate(&projected_point, &xlated_int_pnt, &mat);
+	vm_matrix_x_vector(&projected_point, &mat, &xlated_int_pnt);
 	vm_vec_add(nearest_point, &projected_point, p0);
 
 	dot = vm_vec_dot(&norm, &projected_point);

--- a/code/math/vecmat.h
+++ b/code/math/vecmat.h
@@ -284,23 +284,21 @@ matrix *vm_vector_2_matrix(matrix *m, const vec3d *fvec, const vec3d *uvec = nul
  */
 matrix *vm_vector_2_matrix_norm(matrix *m, const vec3d *fvec, const vec3d *uvec = NULL, const vec3d *rvec = NULL);
 
-//rotates a vector through a matrix. returns ptr to dest vector
-//dest CANNOT equal either source
-vec3d *vm_vec_rotate(vec3d *dest, const vec3d *src, const matrix *m);
+// rotates a vector through a matrix (equivalent to left multiplying the vector by the matrix). 
+// returns ptr to dest vector. dest CANNOT equal either source
+#define vm_vec_rotate(dest, vec, mat) vm_matrix_x_vector(dest, mat, vec)
 
-//rotates a vector through the transpose of the given matrix. 
-//returns ptr to dest vector
-//dest CANNOT equal source
-// This is a faster replacement for this common code sequence:
-//    vm_copy_transpose(&tempm,src_matrix);
-//    vm_vec_rotate(dst_vec,src_vect,&tempm);
-// Replace with:
-//    vm_vec_unrotate(dst_vec,src_vect, src_matrix)
-//
-// THIS DOES NOT ACTUALLY TRANSPOSE THE SOURCE MATRIX!!! So if
-// you need it transposed later on, you should use the 
-// vm_vec_transpose() / vm_vec_rotate() technique.
-vec3d *vm_vec_unrotate(vec3d *dest, const vec3d *src, const matrix *m);
+// rotates a vector through the transpose of the given matrix (equivalent to right multiplying the vector by the matrix). 
+// returns ptr to dest vector. dest CANNOT equal either source
+#define vm_vec_unrotate(dest, vec, mat) vm_vector_x_matrix(dest, vec, mat)
+
+// left multiplies a vector by a matrix
+// dest CANNOT equal either source
+vec3d* vm_matrix_x_vector(vec3d* dest, const matrix* m, const vec3d* src);
+
+// right multiplies a vector by a matrix
+// dest CANNOT equal either source
+vec3d* vm_vector_x_matrix(vec3d* dest, const vec3d* src, const matrix* m);
 
 //transpose a matrix in place. returns ptr to matrix
 matrix *vm_transpose(matrix *m);
@@ -639,18 +637,15 @@ inline matrix& operator-=(matrix& left, const matrix& right)
 	return left;
 }
 
-/**
- * @brief Rotates a vector into the orientation specified by the matrix
- * @param left The matrix
- * @param right The vector
- * @return The rotated vector
- *
- * @note This actually follows the definition of the * operator in linear algebra. The standard vm_vec_rotate actually
- * implements a multiplication with the transpose of the matrix.
- */
 inline vec3d operator*(const matrix& left, const vec3d& right) {
 	vec3d out;
-	vm_vec_unrotate(&out, &right, &left);
+	vm_matrix_x_vector(&out, &left, &right);
+	return out;
+}
+
+inline vec3d operator*(const vec3d& left, const matrix& right) {
+	vec3d out;
+	vm_vector_x_matrix(&out, &left, &right);
 	return out;
 }
 

--- a/code/object/collideshipship.cpp
+++ b/code/object/collideshipship.cpp
@@ -681,7 +681,7 @@ void calculate_ship_ship_collision_physics(collision_info_struct *ship_ship_hit_
 	} else {
 		vm_vec_cross(&rotational_impulse_heavy, &ship_ship_hit_info->r_heavy, &impulse);
 		get_I_inv(&heavy_I_inv, &heavy->phys_info.I_body_inv, &heavy->orient);
-		vm_vec_rotate(&delta_rotvel_heavy, &rotational_impulse_heavy, &heavy_I_inv);
+		vm_matrix_x_vector(&delta_rotvel_heavy, &heavy_I_inv, &rotational_impulse_heavy);
 		float rotation_factor = (heavy->type == OBJ_SHIP) ? heavy_sip->collision_physics.rotation_factor : COLLISION_ROTATION_FACTOR;
 		vm_vec_scale(&delta_rotvel_heavy, rotation_factor);		// hack decrease rotation (delta_rotvel)
 		vm_vec_cross(&delta_vel_from_delta_rotvel_heavy, &delta_rotvel_heavy , &ship_ship_hit_info->r_heavy);
@@ -705,7 +705,7 @@ void calculate_ship_ship_collision_physics(collision_info_struct *ship_ship_hit_
 	} else {
 		vm_vec_cross(&rotational_impulse_light, &ship_ship_hit_info->r_light, &impulse);
 		get_I_inv(&light_I_inv, &lighter->phys_info.I_body_inv, &lighter->orient);
-		vm_vec_rotate(&delta_rotvel_light, &rotational_impulse_light, &light_I_inv);
+		vm_matrix_x_vector(&delta_rotvel_light, &light_I_inv, &rotational_impulse_light);
 		float rotation_factor = (lighter->type == OBJ_SHIP) ? light_sip->collision_physics.rotation_factor : COLLISION_ROTATION_FACTOR;
 		vm_vec_scale(&delta_rotvel_light, rotation_factor);		// hack decrease rotation (delta_rotvel)
 		vm_vec_cross(&delta_vel_from_delta_rotvel_light, &delta_rotvel_light, &ship_ship_hit_info->r_light);

--- a/code/object/objectdock.cpp
+++ b/code/object/objectdock.cpp
@@ -423,7 +423,7 @@ void dock_calculate_and_apply_whack_docked_object(vec3d* impulse, const vec3d* w
 
 	// calculate the change in rotvel caused by the whack in world coords
 	vec3d delta_rotvel;
-	vm_vec_rotate(&delta_rotvel, &angular_impulse, &inv_moi);
+	vm_matrix_x_vector(&delta_rotvel, &inv_moi, &angular_impulse);
 
 	// get the total change in vel for the entire docked assembly
 	vec3d center_mass_delta_vel = *impulse * (1.0f / total_mass);

--- a/code/physics/physics.cpp
+++ b/code/physics/physics.cpp
@@ -775,7 +775,7 @@ void physics_calculate_and_apply_whack(vec3d *impulse, vec3d *pos, physics_info 
 	vm_vec_rotate ( &local_angular_impulse, &angular_impulse, orient );
 
 	vec3d delta_rotvel;
-	vm_vec_rotate(&delta_rotvel, &local_angular_impulse, inv_moi);
+	vm_matrix_x_vector(&delta_rotvel, inv_moi, &local_angular_impulse);
 
 	vec3d delta_vel = *impulse * (1.0f / pi->mass);
 


### PR DESCRIPTION
This can wait until after the stable, if desired, but it's just a small renaming change.

While working on something unrelated I realized that I would need to "`vm_vec_rotate`" a vector through a matrix when the situation was not at all in fact rotation, and indeed this situation situations happens several times throughout the code, so I think it's less confusing to have the more mathematically general names `vm_matrix_x_vector` and `vm_vector_x_matrix`, so the image of "rotation" can be avoided when necessary and rotate and unrotate can be macros of these functions when "rotation" *should* be evoked.

Now, which you want to call which is down to convention but it needs to be consistent with regards to associativity, but the convention used matches `vm_matrix_x_matrix`. i.e. (MatrixA x MatrixB) x VectorA (matrix_x_matrix followed by rotate) = MatrixA x (MatrixB x VectorA) (two rotates).

The already existing operator* overload (which had yet to be used) for matrix * vector, would *not* have followed this convention which is why it was changed.