### PR TITLE
Fix a rare but eventual crash in the interpolation code.

### DIFF
--- a/code/network/multi_obj.cpp
+++ b/code/network/multi_obj.cpp
@@ -3387,7 +3387,7 @@ void multi_oo_calc_interp_splines(int player_id, object* objp, matrix *new_orien
 	float delta = multi_oo_calc_pos_time_difference(player_id, net_sig_idx);
 	// if an error or invalid value, use the local timestamps instead of those received. Should be rare.
 	if (delta <= 0.0f) {
-		delta = (float)(timestamp() - Oo_info.received_frametimes[player_id].at(Oo_info.interp[net_sig_idx].pos_timestamp)) / TIMESTAMP_FREQUENCY;
+		delta = (float)(timestamp() - Oo_info.interp[net_sig_idx].pos_timestamp) / TIMESTAMP_FREQUENCY;
 	}
 
 	Oo_info.interp[net_sig_idx].pos_time_delta = delta;


### PR DESCRIPTION
I don't know when this was introduced but the bug is extremely obvious once someone hit the crash.  It should just be using the timestamp that the packet was received, not trying to put that timestamp into a vector whose index is server frame numbers.