### PR TITLE
Make sure the Netgame state is set to prevent a crash

### DIFF
--- a/code/network/multi_respawn.cpp
+++ b/code/network/multi_respawn.cpp
@@ -644,9 +644,14 @@ void multi_respawn_process_packet(ubyte *data, header *hinfo)
 		p_object *pobjp;
 
 		GET_USHORT( net_sig );
-		pobjp = mission_parse_get_arrival_ship( net_sig );
-		Assert( pobjp != NULL );
-		multi_respawn_ai( pobjp );
+
+		// only attempt to respawn if we are in the mission
+		if (!(Net_player->flags & NETINFO_FLAG_WARPING_OUT)) {
+			pobjp = mission_parse_get_arrival_ship(net_sig);
+			Assert(pobjp != NULL);
+			multi_respawn_ai(pobjp);
+		}
+
 		break;		
 
 	case RESPAWN_BROADCAST:
@@ -659,19 +664,23 @@ void multi_respawn_process_packet(ubyte *data, header *hinfo)
 		GET_DATA(cur_link_status);
 		GET_USHORT(ship_ets);
 		GET_STRING(parse_name);
-		player_index = find_player_id(player_id);
-		if(player_index == -1){
-			nprintf(("Network","Couldn't find player to respawn!\n"));
-			break;
-		}
 
-		// create the ship and assign its position, net_signature, and class
-		// respawn the player
-		multi_respawn_player(&Net_players[player_index], cur_primary_bank, cur_secondary_bank, cur_link_status, ship_ets, net_sig, parse_name, &v);
+		if (!(Net_player->flags & NETINFO_FLAG_WARPING_OUT)) {
+			player_index = find_player_id(player_id);
 
-		// if this is for me, I should jump back into gameplay
-		if(&Net_players[player_index] == Net_player){
-			gameseq_post_event(GS_EVENT_ENTER_GAME);
+			if(player_index == -1){
+				nprintf(("Network","Couldn't find player to respawn!\n"));
+				break;
+			}
+
+			// create the ship and assign its position, net_signature, and class
+			// respawn the player
+			multi_respawn_player(&Net_players[player_index], cur_primary_bank, cur_secondary_bank, cur_link_status, ship_ets, net_sig, parse_name, &v);
+
+			// if this is for me, I should jump back into gameplay
+			if(&Net_players[player_index] == Net_player){
+				gameseq_post_event(GS_EVENT_ENTER_GAME);
+			}
 		}
 		break;
 	


### PR DESCRIPTION
If the client tries to respawn a player when the server is trying to end the game it will lead to a crash on the client side.  This sets the client's game to the correct state when an end game packet is received and adds extra checks before respawning.

I am hoping for a little more testing before this is merged.