### PR TITLE
Add a safety check to the $On Frame: Hook

### DIFF
--- a/code/graphics/2d.cpp
+++ b/code/graphics/2d.cpp
@@ -41,6 +41,7 @@
 #include "scripting/scripting.h"
 #include "tracing/tracing.h"
 #include "utils/boost/hash_combine.h"
+#include "gamesequence/gamesequence.h"
 
 #ifdef WITH_OPENGL
 #include "graphics/opengl/gropengl.h"
@@ -2547,7 +2548,8 @@ void gr_flip(bool execute_scripting)
 	executor::OnFrameExecutor->process();
 
 	// m!m avoid running CHA_ONFRAME when the "Quit mission" popup is shown. See mantis 2446 for reference
-	if (execute_scripting && !popup_active()) {
+	// Cyborg - A similar bug will occur when a mission is restarted so check for that, too.
+	if (execute_scripting && !popup_active() && GameState_Stack_Valid() && !((gameseq_get_state() == GS_STATE_GAME_PLAY) && !(Game_mode & GM_IN_MISSION))) {
 		TRACE_SCOPE(tracing::LuaOnFrame);
 
 		// WMC - Do conditional hooks. Yippee!


### PR DESCRIPTION
So #3007 is a larger bug than just trying to access the player's target.  It happens when using a combination of the use of `$State: GS_STATE_GAME_PLAY` and `$On frame:` 

The real problem is that the game state is not changed from `GS_STATE_GAME_PLAY` during the mission load when restarting the mission.  So the script thinks it's in the mission, tries to access the target and then crashes.  But this won't be the only bug.  Any script that tries to access data on Frame will run into possible problems on mission restart.

This change checks that if we are currently in `GS_STATE_GAME_PLAY` that `Game_Mode` is set to `GM_IN_MISSION`.

It might be a slightly complicated way to do it, but it may be the only way possible without making a new game state for mission reload and dealing with all the headaches that would come with that.

Closes #3007 