### PR TITLE
Some fixes to nebula fog set up

### DIFF
--- a/code/fireball/warpineffect.cpp
+++ b/code/fireball/warpineffect.cpp
@@ -91,7 +91,7 @@ void warpin_queue_render(model_draw_list *scene, object *obj, matrix *orient, ve
 
 			g3_transfer_vertex( &verts[4], &vecs[4] );
 
-			float alpha = (The_mission.flags[Mission::Mission_Flags::Fullneb]) ? neb2_get_fog_visibility(obj) : 1.0f;
+			float alpha = (The_mission.flags[Mission::Mission_Flags::Fullneb]) ? neb2_get_fog_visibility(&obj->pos, 1.0f) : 1.0f;
 
 			//batch_add_bitmap(warp_glow_bitmap, TMAP_FLAG_TEXTURED | TMAP_HTL_3D_UNLIT, &verts[4], 0, r, alpha);
 			batching_add_bitmap(warp_glow_bitmap, &verts[4], 0, r, alpha);

--- a/code/nebula/neb.cpp
+++ b/code/nebula/neb.cpp
@@ -347,6 +347,7 @@ void neb2_level_init()
 	Nebula_sexp_used = false;
 }
 
+float nNf_near, nNf_density;
 // initialize nebula stuff - call from game_post_level_init(), so the mission has been loaded
 void neb2_post_level_init()
 {
@@ -449,6 +450,10 @@ void neb2_post_level_init()
 
 		Neb2_poof_flags = Neb2_poof_flags & available_poofs_mask;
 	}
+
+	// set the mission fog near dist and density
+	float fog_far;
+	neb2_get_adjusted_fog_values(&nNf_near, &fog_far, &nNf_density, nullptr);
 
 }
 
@@ -1180,25 +1185,8 @@ void neb2_get_adjusted_fog_values(float *fnear, float *ffar, float *fdensity, ob
 		*fdensity = powf(NEB_FOG_FAR_PCT, 1 / (*ffar - *fnear));
 }
 
-float nNf_near, nNf_density;
-// given a position in space, return a value from 0.0 to 1.0 representing the fog level 
-float neb2_get_fog_visibility(object *obj)
-{
-	float fog_far;
-
-	// get near and far fog values based upon object type and rendering mode
-	neb2_get_adjusted_fog_values(&nNf_near, &fog_far, &nNf_density, obj);
-
-	// get the fog pct
-	float pct = pow(nNf_density, vm_vec_dist(&Eye_position, &obj->pos) - nNf_near);
-
-	CLAMP(pct, 0.0f, 1.0f);
-
-	return pct;
-}
-
-//this only gets called after the one above has been called as it assumes you have set the near and far planes properly
-//don't use this outside of ship rendering
+// given a position, returns 0 - 1 the fog visibility of that position, 0 = completely obscured
+// distance_mult will multiply the result, use for things that can be obscured but can 'shine through' the nebula more than normal
 float neb2_get_fog_visibility(vec3d *pos, float distance_mult)
 {
 	float pct;

--- a/code/nebula/neb.h
+++ b/code/nebula/neb.h
@@ -132,9 +132,6 @@ void neb2_get_fog_values(float *fnear, float *ffar, object *obj = NULL);
 // get adjusted near and far fog values (allows mission-specific fog adjustments)
 void neb2_get_adjusted_fog_values(float *fnear, float *ffar, float *fdensity = nullptr, object *obj = nullptr);
 
-// given an object, returns 0 - 1 the fog visibility of its center, 0 = completely obscured
-float neb2_get_fog_visibility(object *obj);
-
 // given a position, returns 0 - 1 the fog visibility of that position, 0 = completely obscured
 // distance_mult will multiply the result, use for things that can be obscured but can 'shine through' the nebula more than normal
 float neb2_get_fog_visibility (vec3d* pos, float distance_mult);

--- a/code/object/objectsort.cpp
+++ b/code/object/objectsort.cpp
@@ -278,15 +278,9 @@ void obj_render_all(const std::function<void(object*)>& render_function, bool *d
 		if ( obj_render_is_model(obj) )
 			continue;
 
-		// if we're fullneb, fire up the fog - this also generates a fog table
-		if(full_neb){
-			// get the fog values
-			neb2_get_adjusted_fog_values(&fog_near, &fog_far, &fog_density, obj);
-
-			// maybe skip rendering an object because its obscured by the nebula
-			if(neb2_skip_render(obj, os->z)){
-				continue;
-			}
+		// maybe skip rendering an object because its obscured by the nebula
+		if(full_neb && neb2_skip_render(obj, os->z)){
+			continue;
 		}
 
 		render_function(obj);

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -19702,7 +19702,7 @@ void ship_render(object* obj, model_draw_list* scene)
 	if ( !( shipp->flags[Ship_Flags::Cloaked] ) ) {
 		if ( ( The_mission.flags[Mission::Mission_Flags::Fullneb] ) && ( sip->is_small_ship() ) ) {			
 			// force detail levels
-			float fog_val = neb2_get_fog_visibility(obj);
+			float fog_val = neb2_get_fog_visibility(&obj->pos, 1.0f);
 			if ( fog_val <= 0.15f ) {
 				render_info.set_detail_level_lock(2);
 			}

--- a/code/weapon/trails.cpp
+++ b/code/weapon/trails.cpp
@@ -226,7 +226,7 @@ void trail_render( trail * trailp )
 			l = (ubyte)fl2i((fade * a_size + ti->a_start) * 255.0f);
 		}
 
-		if (The_mission.flags[Mission::Mission_Flags::Fullneb])
+		if (The_mission.flags[Mission::Mission_Flags::Fullneb] && Neb_affects_weapons)
 			l = (ubyte)(l * neb2_get_fog_visibility(&trailp->pos[n], NEB_FOG_VISIBILITY_MULT_TRAIL));
 
 		if ( i == 0 )	{


### PR DESCRIPTION
The mission-specific fog near/far/density values need to set before being used, but this is only done by the `neb2_get_fog_visibility(object *obj)` function so the other overload (that only takes a position) may not have this information when necessary. Although this is unlikely (as it is common for both functions to be called several times a frame), it should really be part of `neb2_post_level_init`. 

Pulling that out was basically the only real difference between the two so it can just be removed. Also puts a flag check on trail fading since it is new.