### PR TITLE
Add profiling trace for scripting hooks

### DIFF
--- a/code/scripting/scripting.cpp
+++ b/code/scripting/scripting.cpp
@@ -19,6 +19,7 @@
 #include "scripting/doc_json.h"
 #include "scripting/scripting_doc.h"
 #include "ship/ship.h"
+#include "tracing/tracing.h"
 #include "weapon/beam.h"
 #include "weapon/weapon.h"
 
@@ -672,6 +673,7 @@ void script_state::UnloadImages()
 
 int script_state::RunCondition(int action, object* objp, int more_data)
 {
+	TRACE_SCOPE(tracing::LuaHooks);
 	int num = 0;
 
 	if (LuaState == nullptr) {

--- a/code/tracing/categories.cpp
+++ b/code/tracing/categories.cpp
@@ -13,6 +13,7 @@ bool Category::usesGPUCounter() const {
 }
 
 Category LuaOnFrame("LUA On Frame", true);
+Category LuaHooks("LUA hooks", true);
 
 Category DrawSceneTexture("Draw scene texture", true);
 Category UpdateDistortion("Update distortion", true);

--- a/code/tracing/categories.h
+++ b/code/tracing/categories.h
@@ -26,6 +26,7 @@ class Category {
 };
 
 extern Category LuaOnFrame;
+extern Category LuaHooks;
 
 extern Category DrawSceneTexture;
 extern Category UpdateDistortion;


### PR DESCRIPTION
This will separate out Lua scripting hooks from the rest of our performance traces, allowing us to separate time spent in engine code and in modder-supplied scripts.