### PR TITLE
make double-character consolidation reusable, and reuse it

### DIFF
--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -8174,20 +8174,8 @@ void mission_process_alt_types()
 		// truncate at a single hash
 		end_string_at_first_hash_symbol(Mission_alt_types[i], true);
 
-		// consolidate double hashes
-		auto src = Mission_alt_types[i];
-		auto dest = src;
-		while (*src)
-		{
-			if (*src == '#' && *(src + 1) == '#')
-				dest--;
-
-			++src;
-			++dest;
-
-			if (src != dest)
-				*dest = *src;
-		}
+		// ## -> #
+		consolidate_double_characters(Mission_alt_types[i], '#');
 	}
 }
 

--- a/code/parse/parselo.cpp
+++ b/code/parse/parselo.cpp
@@ -3861,6 +3861,24 @@ int get_index_of_first_hash_symbol(SCP_string &src, bool ignore_doubled_hash)
 }
 
 // Goober5000
+// Used for escape sequences: ## to #, !! to !, etc.
+void consolidate_double_characters(char *src, char ch)
+{
+	auto dest = src;
+	while (*src)
+	{
+		if (*src == ch && *(src + 1) == ch)
+			dest--;
+
+		++src;
+		++dest;
+
+		if (src != dest)
+			*dest = *src;
+	}
+}
+
+// Goober5000
 ptrdiff_t replace_one(char *str, const char *oldstr, const char *newstr, size_t max_len, ptrdiff_t range)
 {
 	Assert(str && oldstr && newstr);

--- a/code/parse/parselo.h
+++ b/code/parse/parselo.h
@@ -74,6 +74,8 @@ extern char *get_pointer_to_first_hash_symbol(char *src, bool ignore_doubled_has
 extern const char *get_pointer_to_first_hash_symbol(const char *src, bool ignore_doubled_hash = false);
 extern int get_index_of_first_hash_symbol(SCP_string &src, bool ignore_doubled_hash = false);
 
+extern void consolidate_double_characters(char *str, char ch);
+
 // white space
 extern int is_white_space(char ch);
 extern int is_white_space(unicode::codepoint_t cp);

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -26208,15 +26208,26 @@ int get_sexp_main()
 int run_sexp(const char* sexpression, bool run_eval_num, bool *is_nan_or_nan_forever)
 {
 	char* oldMp = Mp;
-	int n, i, sexp_val = UNINITIALIZED;
+	int n, sexp_val = UNINITIALIZED;
 	char buf[8192];
 
 	strcpy_s(buf, sexpression);
 
 	// HACK: ! -> "
-	for (i = 0; i < (int)strlen(buf); i++)
-		if (buf[i] == '!')
-			buf[i]='\"';
+	for (auto ch = buf; *ch; ++ch)
+	{
+		// convert single ! to ", but don't convert !!
+		if (*ch == '!')
+		{
+			if (*(ch + 1) == '!')
+				++ch;
+			else
+				*ch = '\"';
+		}
+	}
+
+	// !! -> !
+	consolidate_double_characters(buf, '!');
 
 	Mp = buf;
 


### PR DESCRIPTION
This moves the ## to # escape sequence logic from `mission_process_alt_types` to its own function where it can be used elsewhere (such as for ship class and weapon class display names that need to do the same thing).  Also, this introduces a !! escape sequence for exclamation points that is needed for exclamation points to be used in scripts, as @naomimyselfandi pointed out.