### PR TITLE
actually use GS_STATE_INVALID

### DIFF
--- a/code/gamesequence/gamesequence.cpp
+++ b/code/gamesequence/gamesequence.cpp
@@ -239,7 +239,10 @@ bool GameState_Stack_Valid()
 
 // returns one of the GS_STATE_ macros
 int gameseq_get_state(int depth)
-{	
+{
+	if (!GameState_Stack_Valid())
+		return GS_STATE_INVALID;
+
 	Assert(depth <= gs_current_stack);
 			
 	return gs[gs_current_stack - depth].current_state;

--- a/code/graphics/2d.cpp
+++ b/code/graphics/2d.cpp
@@ -2549,7 +2549,7 @@ void gr_flip(bool execute_scripting)
 
 	// m!m avoid running CHA_ONFRAME when the "Quit mission" popup is shown. See mantis 2446 for reference
 	// Cyborg - A similar bug will occur when a mission is restarted so check for that, too.
-	if (execute_scripting && !popup_active() && GameState_Stack_Valid() && !((gameseq_get_state() == GS_STATE_GAME_PLAY) && !(Game_mode & GM_IN_MISSION))) {
+	if (execute_scripting && !popup_active() && !((gameseq_get_state() == GS_STATE_GAME_PLAY) && !(Game_mode & GM_IN_MISSION))) {
 		TRACE_SCOPE(tracing::LuaOnFrame);
 
 		// WMC - Do conditional hooks. Yippee!


### PR DESCRIPTION
Make `gameseq_get_state` return GS_STATE_INVALID if the stack is invalid.

With this change, the check for stack validity can be removed in `gr_flip`.

Follow-up to #3346.