### PR TITLE
Only close common_select when we should

### DIFF
--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -4954,6 +4954,40 @@ void game_process_event( int current_state, int event )
 	}
 }
 
+static bool going_to_briefing_state(int new_state)
+{
+	switch (new_state) {
+		case GS_STATE_TEAM_SELECT:
+		case GS_STATE_SHIP_SELECT:
+		case GS_STATE_WEAPON_SELECT:
+		case GS_STATE_OPTIONS_MENU:
+		case GS_STATE_GAMEPLAY_HELP:
+		case GS_STATE_HOTKEY_SCREEN:
+		case GS_STATE_MULTI_MISSION_SYNC:
+		case GS_STATE_BRIEFING:
+		case GS_STATE_CMD_BRIEF:
+		case GS_STATE_RED_ALERT:
+		case GS_STATE_FICTION_VIEWER:
+			return true;
+	}
+
+	return false;
+}
+
+static bool going_to_menu_state(int new_state)
+{
+	switch (new_state) {
+		case GS_STATE_MAIN_MENU:
+		case GS_STATE_PXO:
+		case GS_STATE_MULTI_JOIN_GAME:
+		case GS_STATE_STANDALONE_MAIN:
+		case GS_STATE_QUIT_GAME:
+			return true;
+	}
+
+	return false;
+}
+
 // Called when a state is being left.
 // The current state is still at old_state, but as soon as
 // this function leaves, then the current state will become
@@ -5002,17 +5036,15 @@ void game_leave_state( int old_state, int new_state )
 	switch (old_state) {
 		case GS_STATE_BRIEFING:
 			brief_stop_voices();
-			if ( (new_state != GS_STATE_OPTIONS_MENU) && (new_state != GS_STATE_WEAPON_SELECT)
-				  && (new_state != GS_STATE_SHIP_SELECT) && (new_state != GS_STATE_HOTKEY_SCREEN)
-				  && (new_state != GS_STATE_TEAM_SELECT) && (new_state != GS_STATE_MULTI_MISSION_SYNC)){
+
+			if ( !going_to_briefing_state(new_state) ) {
 				common_select_close();
-				if ( (new_state == GS_STATE_MAIN_MENU) || (new_state == GS_STATE_PXO)
-					 || (new_state == GS_STATE_MULTI_JOIN_GAME) )
-				{
-					freespace_stop_mission();	
+
+				if ( going_to_menu_state(new_state) ) {
+					freespace_stop_mission();
 				}
 			}
-			
+
 			// COMMAND LINE OPTION
 			if (Cmdline_multi_stream_chat_to_file){
 				cfwrite_string(NOX("-------------------------------------------\n"),Multi_chat_stream);
@@ -5048,67 +5080,57 @@ void game_leave_state( int old_state, int new_state )
 				cmd_brief_hold();
 			} else {
 				cmd_brief_close();
-				common_select_close();
 
-				if (new_state != GS_STATE_BRIEFING) {
-					common_music_close();
-				}
+				if ( !going_to_briefing_state(new_state) ) {
+					common_select_close();
 
-				if ( (new_state == GS_STATE_MAIN_MENU) || (new_state == GS_STATE_PXO)
-					 || (new_state == GS_STATE_MULTI_JOIN_GAME) )
-				{
-					freespace_stop_mission();	
+					if ( going_to_menu_state(new_state) ) {
+						freespace_stop_mission();
+					}
 				}
 			}
 			break;
 
 		case GS_STATE_RED_ALERT:
 			red_alert_close();
-			common_select_close();
-			if ( (new_state == GS_STATE_MAIN_MENU) || (new_state == GS_STATE_PXO)
-				 || (new_state == GS_STATE_MULTI_JOIN_GAME) )
-			{
-				freespace_stop_mission();
+
+			if ( !going_to_briefing_state(new_state) ) {
+				common_select_close();
+
+				if ( going_to_menu_state(new_state) ) {
+					freespace_stop_mission();
+				}
 			}
 			break;
 
 		case GS_STATE_SHIP_SELECT:
-			if ( new_state != GS_STATE_OPTIONS_MENU && new_state != GS_STATE_WEAPON_SELECT &&
-				  new_state != GS_STATE_HOTKEY_SCREEN &&
-				  new_state != GS_STATE_BRIEFING && new_state != GS_STATE_TEAM_SELECT  && (new_state != GS_STATE_MULTI_MISSION_SYNC)) {
+			if ( !going_to_briefing_state(new_state) ) {
 				common_select_close();
-				if ( (new_state == GS_STATE_MAIN_MENU) || (new_state == GS_STATE_PXO)
-					 || (new_state == GS_STATE_MULTI_JOIN_GAME) )
-				{
-					freespace_stop_mission();	
+
+				if ( going_to_menu_state(new_state) ) {
+					freespace_stop_mission();
 				}
 			}
 			break;
 
 		case GS_STATE_WEAPON_SELECT:
-			if ( new_state != GS_STATE_OPTIONS_MENU && new_state != GS_STATE_SHIP_SELECT &&
-				  new_state != GS_STATE_HOTKEY_SCREEN &&
-				  new_state != GS_STATE_BRIEFING && new_state != GS_STATE_TEAM_SELECT && (new_state != GS_STATE_MULTI_MISSION_SYNC)) {
+			if ( !going_to_briefing_state(new_state) ) {
 				common_select_close();
-				if ( (new_state == GS_STATE_MAIN_MENU) || (new_state == GS_STATE_PXO)
-					 || (new_state == GS_STATE_MULTI_JOIN_GAME) )
-				{
-					freespace_stop_mission();	
+
+				if ( going_to_menu_state(new_state) ) {
+					freespace_stop_mission();
 				}
 			}
 			break;
 
 		case GS_STATE_TEAM_SELECT:
-			if ( new_state != GS_STATE_OPTIONS_MENU && new_state != GS_STATE_SHIP_SELECT &&
-				  new_state != GS_STATE_HOTKEY_SCREEN &&
-				  new_state != GS_STATE_BRIEFING && new_state != GS_STATE_WEAPON_SELECT && (new_state != GS_STATE_MULTI_MISSION_SYNC)) {
+			if ( !going_to_briefing_state(new_state) ) {
 				common_select_close();
-				if ( (new_state == GS_STATE_MAIN_MENU) || (new_state == GS_STATE_PXO)
-					 || (new_state == GS_STATE_MULTI_JOIN_GAME) )
-				{
-					freespace_stop_mission();	
+
+				if ( going_to_menu_state(new_state) ) {
+					freespace_stop_mission();
 				}
-			}					
+			}
 			break;
 
 		case GS_STATE_MAIN_MENU:
@@ -5121,6 +5143,12 @@ void game_leave_state( int old_state, int new_state )
 			}
 
 			options_menu_close();
+
+			// can't use going_to_briefing_state() here since it doesn't catch sub-optionmenu states
+			// it's basically just to catch the exit game button
+			if ( going_to_menu_state(new_state) ) {
+				common_select_close();
+			}
 
 			if (new_state != GS_STATE_CONTROL_CONFIG && new_state != GS_STATE_HUD_CONFIG) {
 				// unpause all sounds, since we could be headed back to the game
@@ -5318,7 +5346,9 @@ void game_leave_state( int old_state, int new_state )
 			break;
 
 		case GS_STATE_MULTI_MISSION_SYNC:
-			common_select_close();
+			if ( !going_to_briefing_state(new_state) ) {
+				common_select_close();
+			}
 
 			// if we're moving into the options menu we don't need to do anything else
 			if(new_state == GS_STATE_OPTIONS_MENU){	
@@ -5341,7 +5371,7 @@ void game_leave_state( int old_state, int new_state )
 				main_hall_stop_ambient();		
 
 				// any other state needs to close out the mission, because we're not going in to gameplay.
-			} else if (new_state == GS_STATE_PXO || new_state == GS_STATE_MULTI_JOIN_GAME) {
+			} else if ( going_to_menu_state(new_state) ) {
 				freespace_stop_mission();
 			}
 
@@ -5396,16 +5426,13 @@ void game_leave_state( int old_state, int new_state )
 
 		case GS_STATE_FICTION_VIEWER:
 			fiction_viewer_close();
-			common_select_close();
 
-			if ( (new_state != GS_STATE_BRIEFING) && (new_state != GS_STATE_CMD_BRIEF) ) {
-				common_music_close();
-			}
+			if ( !going_to_briefing_state(new_state) ) {
+				common_select_close();
 
-			if ( (new_state == GS_STATE_MAIN_MENU) || (new_state == GS_STATE_PXO)
-				 || (new_state == GS_STATE_MULTI_JOIN_GAME) )
-			{
-				freespace_stop_mission();
+				if ( going_to_menu_state(new_state) ) {
+					freespace_stop_mission();
+				}
 			}
 			break;
 


### PR DESCRIPTION
Address various issues that cropped up when the various pre-briefing states were fixed for multi. This should fix the various places where `common_select_close()` was getting called when it shouldn't, or not getting called at all.