### PR TITLE
fix main hall sounds/music not getting stopped on multi clients

### DIFF
--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -5327,6 +5327,7 @@ void game_leave_state( int old_state, int new_state )
 
 			Assert( Game_mode & GM_MULTIPLAYER );
 			multi_sync_close();
+
 			if ( new_state == GS_STATE_GAME_PLAY ){
 				// palette_restore_palette();
 
@@ -5337,14 +5338,13 @@ void game_leave_state( int old_state, int new_state )
 				// set the game mode
 				Game_mode |= GM_IN_MISSION;
 
-				main_hall_stop_music(true);
-				main_hall_stop_ambient();		
-
 				// any other state needs to close out the mission, because we're not going in to gameplay.
 			} else if (new_state == GS_STATE_PXO || new_state == GS_STATE_MULTI_JOIN_GAME) {
 				freespace_stop_mission();
 			}
 
+			main_hall_stop_music(true);
+			main_hall_stop_ambient();
 			break;		
    
 		case GS_STATE_VIEW_CUTSCENES:


### PR DESCRIPTION
Fixes a bug recently introduced where the main hall ambient sounds and music aren't stopped after pre-briefing multi sync.