### PR TITLE
Remove string comparisons and switch to vector in script conditions

### DIFF
--- a/code/scripting/api/libs/engine.cpp
+++ b/code/scripting/api/libs/engine.cpp
@@ -75,6 +75,7 @@ ADE_FUNC(addHook,
 			script_condition cond;
 			cond.condition_type   = scripting_string_to_condition(key.getValue<SCP_string>().c_str());
 			cond.condition_string = value.getValue<SCP_string>();
+			cond.condition_reference_index = -1;
 
 			cond_hook.AddCondition(&cond);
 		}

--- a/code/scripting/api/libs/engine.cpp
+++ b/code/scripting/api/libs/engine.cpp
@@ -75,7 +75,7 @@ ADE_FUNC(addHook,
 			script_condition cond;
 			cond.condition_type   = scripting_string_to_condition(key.getValue<SCP_string>().c_str());
 			cond.condition_string = value.getValue<SCP_string>();
-			cond.condition_reference_index = -1;
+			cond.condition_cached_value = -1;
 
 			cond_hook.AddCondition(&cond);
 		}

--- a/code/scripting/scripting.h
+++ b/code/scripting/scripting.h
@@ -134,7 +134,14 @@ struct script_condition
 {
 	ConditionalType condition_type = CHC_NONE;
 	SCP_string condition_string;
-	int condition_reference_index;
+	// stores values evaluated at hook load to optimize later condition checking.
+	// currently mostly olg done for the highest impact condition types, according to performance profiling
+	// the exact type of information stored varries between hook types.
+	// CHC_STATE, CHC_OBJECTTYPE - stores the value of enum matching the name requested by the condition string.
+	// CHC_SHIPCLASS, CHC_WEAPONCLASS - stores the index of the info object requested by the condition
+	// CHC_VERSION, CHC_APPLICATION - stores validity of the check in 1 for true or 0 for false, as the condition will not change after load.
+	// see ConditionedHook::AddCondition for exact implimentation
+	int condition_cached_value = -1;
 };
 
 struct script_action

--- a/code/scripting/scripting.h
+++ b/code/scripting/scripting.h
@@ -134,6 +134,7 @@ struct script_condition
 {
 	ConditionalType condition_type = CHC_NONE;
 	SCP_string condition_string;
+	int condition_reference_index;
 };
 
 struct script_action
@@ -146,7 +147,7 @@ class ConditionedHook
 {
 private:
 	SCP_vector<script_action> Actions;
-	script_condition Conditions[MAX_HOOK_CONDITIONS];
+	SCP_vector<script_condition> Conditions;
 public:
 	bool AddCondition(script_condition *sc);
 	bool AddAction(script_action *sa);


### PR DESCRIPTION
String comparisons in lua hook evaluation take up a significant amount of runtime in FSO. This PR shifts those comparisons to hook creation instead of evaluation. Currently only covers the three most frequently evaluated hooks, which in profiling cleans up the vast majority of evaluation's footprint.

~~In draft because it's still pretty messy and slapdash in places, but I wanted to let people review the approach at the least.~~
Now prepared for final review.