### PR TITLE
Remove unecessary ship_get_subsys in model_rotate_gun

### DIFF
--- a/code/ai/aiturret.cpp
+++ b/code/ai/aiturret.cpp
@@ -1382,12 +1382,12 @@ int aifft_rotate_turret(object *objp, ship *shipp, ship_subsys *ss, object *lep,
 		in_fov = turret_fov_test(ss, gvec, &v2e);
 
 		if (in_fov) {
-			ret_val = model_rotate_gun(objp, pm, pmi, tp, predicted_enemy_pos);
+			ret_val = model_rotate_gun(objp, pm, pmi, ss, predicted_enemy_pos);
 		} else if ((tp->flags[Model::Subsystem_Flags::Turret_reset_idle]) &&(timestamp_elapsed(ss->rotation_timestamp))) {
-			ret_val = model_rotate_gun(objp, pm, pmi, tp, predicted_enemy_pos, true);
+			ret_val = model_rotate_gun(objp, pm, pmi, ss, predicted_enemy_pos, true);
 		}
 	} else if ((ss->system_info->flags[Model::Subsystem_Flags::Turret_reset_idle]) && (timestamp_elapsed(ss->rotation_timestamp))) {
-		ret_val = model_rotate_gun(objp, pm, pmi, ss->system_info, predicted_enemy_pos, true);
+		ret_val = model_rotate_gun(objp, pm, pmi, ss, predicted_enemy_pos, true);
 	}
 
 	// by default "ret_val" should be set to 1 for multi-part turrets, and 0 for single-part turrets

--- a/code/model/model.h
+++ b/code/model/model.h
@@ -914,7 +914,7 @@ extern int modelstats_num_sortnorms;
 #endif
 
 // Tries to move joints so that the turret points to the point dst.
-extern int model_rotate_gun(object *objp, polymodel *pm, polymodel_instance *pmi, model_subsystem *turret, vec3d *dst, bool reset = false);
+extern int model_rotate_gun(object *objp, polymodel *pm, polymodel_instance *pmi, ship_subsys *ss, vec3d *dst, bool reset = false);
 
 // Rotates the angle of a submodel.  Use this so the right unlocked axis
 // gets stuffed.

--- a/code/model/modelread.cpp
+++ b/code/model/modelread.cpp
@@ -3727,10 +3727,9 @@ void submodel_rotate(bsp_info *sm, submodel_instance *smi)
 // Tries to move joints so that the turret points to the point dst.
 // turret1 is the angles of the turret, turret2 is the angles of the gun from turret
 //	Returns 1 if rotated gun, 0 if no gun to rotate (rotation handled by AI)
-int model_rotate_gun(object *objp, polymodel *pm, polymodel_instance *pmi, model_subsystem *turret, vec3d *dst, bool reset)
+int model_rotate_gun(object *objp, polymodel *pm, polymodel_instance *pmi, ship_subsys *ss, vec3d *dst, bool reset)
 {
-	ship *shipp = &Ships[objp->instance];
-	ship_subsys *ss = ship_get_subsys(shipp, turret->subobj_name);
+	model_subsystem *turret = ss->system_info;
 
 	// This should not happen
 	if ( turret->turret_gun_sobj < 0 || turret->subobj_num == turret->turret_gun_sobj ) {

--- a/code/scripting/api/objs/subsystem.cpp
+++ b/code/scripting/api/objs/subsystem.cpp
@@ -643,15 +643,12 @@ ADE_FUNC(rotateTurret, l_Subsystem, "vector Pos, boolean reset=false", "Rotates 
 		return ADE_RETURN_NIL;
 
 	//Get default turret info
-	vec3d gpos;
-	model_subsystem *tp = sso->ss->system_info;
 	object *objp = sso->objp;
-	ship_get_global_turret_info(objp, tp, &gpos, nullptr);
 
 	auto pmi = model_get_instance(Ships[objp->instance].model_instance_num);
 	auto pm = model_get(pmi->model_num);
 
-	int ret_val = model_rotate_gun(objp, pm, pmi, tp, &pos, reset);
+	int ret_val = model_rotate_gun(objp, pm, pmi, sso->ss, &pos, reset);
 
 	if (ret_val)
 		return ADE_RETURN_TRUE;


### PR DESCRIPTION
According to some profiling done by @EatThePath this `ship_get_subsys` in `model_rotate_gun` is a surprisingly large expense. Among its users `model_rotate_gun` is definitely the odd man out, all the others are dealing with external user-provided strings, while the callers of `model_rotate_gun` in all cases already have the `ship_subsys` handy anyway, so the function is modified to take it as its argument instead of the `model_subsystem`.