### PR TITLE
Fix event parsing by setting flags to zero before loading.

### DIFF
--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -5065,6 +5065,9 @@ void parse_event(mission * /*pm*/)
 		}
 	}
 
+	// Need to set this to zero so that we don't accidentally reuse old data.
+	event->flags = 0;
+
 	if (optional_string("+Event Flags:")) {
 		parse_string_flag_list(&event->flags, Mission_event_flags, Num_mission_event_flags);
 	}

--- a/code/parse/parselo.cpp
+++ b/code/parse/parselo.cpp
@@ -2790,6 +2790,9 @@ size_t stuff_token_list(T *listp, size_t list_max, F stuff_one_token, const char
 	return i;
 }
 
+// If this data is going to be parsed multiple times (like for mission load), then the dest variable 
+// needs to be set to zero in between parses, otherwise we keep bad data.
+// For tbm files, it must not be reset.
 void parse_string_flag_list(int *dest, flag_def_list defs[], size_t defs_size)
 {
 	Assert(dest!=NULL);	//wtf?


### PR DESCRIPTION
We need to set bit flags to zero before stuffing.

fixes #3355 