### PR TITLE
Properly cull generic debris

### DIFF
--- a/code/debris/debris.cpp
+++ b/code/debris/debris.cpp
@@ -424,18 +424,6 @@ object *debris_create(object *source_obj, int model_num, int submodel_num, vec3d
 	sip = &Ship_info[shipp->ship_info_index];
 	vaporize = (shipp->flags[Ship::Ship_Flags::Vaporize]);
 
-	// cull the builtin generic debris if its too far away
-	if ( model_num == -1 )	{
-		// Make vaporize debris seen from farther away
-		float dist = vm_vec_dist_quick( pos, &Eye_position );
-		if (vaporize) {
-			dist /= 2.0f;
-		}
-		if ( dist > 200.0f ) {
-			return NULL;
-		}
-	}
-
 	// try to maintain our soft limit
 	if (hull_flag && (Num_hull_pieces >= SOFT_LIMIT_DEBRIS_PIECES)) {
 		// cause oldest hull debris chunk to blow up
@@ -483,10 +471,13 @@ object *debris_create(object *source_obj, int model_num, int submodel_num, vec3d
 
 	// if its generic, maybe cull it if its too small and far
 	if (!hull_flag) {
-		// Make vaporize debris seen from farther away
 		float dist = vm_vec_dist_quick(pos, &Eye_position);
+		// Make vaporize debris seen from farther away
+		if (vaporize) {
+			dist /= 2.0f;
+		}
 		if (dist > radius * 200.0f) {
-			return NULL;
+			return nullptr;
 		}
 	}
 
@@ -570,7 +561,7 @@ object *debris_create(object *source_obj, int model_num, int submodel_num, vec3d
 
 	db->next_fireball = timestamp_rand(500,2000);	//start one 1/2 - 2 secs later
 
-	if ( pos == NULL )
+	if ( pos == nullptr )
 		pos = &source_obj->pos;
 
     flagset<Object::Object_Flags> default_flags;
@@ -589,7 +580,7 @@ object *debris_create(object *source_obj, int model_num, int submodel_num, vec3d
     objnum = obj_create( OBJ_DEBRIS, parent_objnum, n, &orient, pos, radius, default_flags);
 	if ( objnum == -1 ) {
 		mprintf(("Couldn't create debris object -- out of object slots\n"));
-		return NULL;
+		return nullptr;
 	}
 
 	db->objnum = objnum;

--- a/code/debris/debris.cpp
+++ b/code/debris/debris.cpp
@@ -424,13 +424,14 @@ object *debris_create(object *source_obj, int model_num, int submodel_num, vec3d
 	sip = &Ship_info[shipp->ship_info_index];
 	vaporize = (shipp->flags[Ship::Ship_Flags::Vaporize]);
 
-	if ( !hull_flag )	{
+	// cull the builtin generic debris if its too far away
+	if ( model_num == -1 )	{
 		// Make vaporize debris seen from farther away
 		float dist = vm_vec_dist_quick( pos, &Eye_position );
 		if (vaporize) {
 			dist /= 2.0f;
 		}
-		if ( dist > source_obj->radius * 20.0f ) {
+		if ( dist > 200.0f ) {
 			return NULL;
 		}
 	}
@@ -479,6 +480,15 @@ object *debris_create(object *source_obj, int model_num, int submodel_num, vec3d
 	db->model_instance_num = model_create_instance(false, db->model_num);
 
 	float radius = submodel_get_radius(db->model_num, db->submodel_num);
+
+	// if its generic, maybe cull it if its too small and far
+	if (!hull_flag) {
+		// Make vaporize debris seen from farther away
+		float dist = vm_vec_dist_quick(pos, &Eye_position);
+		if (dist > radius * 200.0f) {
+			return NULL;
+		}
+	}
 
 	//WMC - We must survive until now, at least.
 	db->must_survive_until = timestamp();


### PR DESCRIPTION
Generic debris used to be culled only based on a factor of the source ship's size, but I was only considering explosion debris which would be presumably sized appropriately to the ship in question. Regular impact debris is still always small so failing to cull it on a destroyer adds up extremely quickly.

This checks first for the builtin debris which is always small with the original 200m check, and then later does an actual debris size proportional cull once its radius is known. Doing two culls based on distance is kind awkward but i figured doing the first quick cull was better since that was the vastly more common scenario.

Closes #3368