### PR TITLE
Hud gauge parameter type

### DIFF
--- a/code/hud/hudgauges.h
+++ b/code/hud/hudgauges.h
@@ -55,7 +55,13 @@
 #define HUD_SUPPORT_GAUGE						37
 #define HUD_LAG_GAUGE							38
 
-extern const char *HUD_gauge_text[NUM_HUD_GAUGES];					// defined in sexp.cpp!!!!
+struct Legacy_HUD_gauge_pair
+{
+	const char *hud_gauge_text;
+	int hud_gauge_type;
+};
+
+extern Legacy_HUD_gauge_pair Legacy_HUD_gauges[NUM_HUD_GAUGES];					// defined in hudparse.cpp!!!!
 
 
 #endif	/* __HUD_COMMON_H__ */

--- a/code/hud/hudparse.cpp
+++ b/code/hud/hudparse.cpp
@@ -564,7 +564,6 @@ void hud_positions_init()
 
 	// load missing retail gauges for the default and ship-specific HUDs
 	load_missing_retail_gauges();
-	
 }
 
 void load_missing_retail_gauges()

--- a/code/hud/hudparse.cpp
+++ b/code/hud/hudparse.cpp
@@ -53,9 +53,9 @@ int Hud_font = -1;
 
 bool Chase_view_only_ex = false;
 
-//WARNING: If you add gauges to this array, make sure to bump Num_default_gauges!
-const int Num_retail_gauges = 42;
-static int Retail_gauges[Num_retail_gauges] = {
+//WARNING: If you add gauges to this array, make sure to bump Num_builtin_gauges!
+const int Num_builtin_gauges = 42;
+static int Builtin_gauges[Num_builtin_gauges] = {
 	HUD_OBJECT_MESSAGES,
 	HUD_OBJECT_TRAINING_MESSAGES,
 	HUD_OBJECT_SUPPORT,
@@ -574,11 +574,11 @@ void load_missing_retail_gauges()
 	if(Hud_retail) {
 		int num_loaded_gauges = (int)default_hud_gauges.size();
 
-		for(int i = 0; i < Num_retail_gauges; i++) {
+		for(int i = 0; i < Num_builtin_gauges; i++) {
 			retail_gauge_loaded = false;
 
 			for(int j = 0; j < num_loaded_gauges; j++) {
-				if(Retail_gauges[i] == default_hud_gauges[j]->getObjectType()) {
+				if(Builtin_gauges[i] == default_hud_gauges[j]->getObjectType()) {
 					retail_gauge_loaded = true;
 					break;
 				}
@@ -586,7 +586,7 @@ void load_missing_retail_gauges()
 
 			if(!retail_gauge_loaded) {
 				gauge_settings settings;
-				load_gauge(Retail_gauges[i], &settings);
+				load_gauge(Builtin_gauges[i], &settings);
 			}
 		}
 
@@ -630,9 +630,9 @@ void load_missing_retail_gauges()
 		if(it->hud_enabled && it->hud_retail) {
 			int num_loaded_gauges = (int)it->hud_gauges.size();
 
-			for(int i = 0; i < Num_retail_gauges; i++) {
+			for(int i = 0; i < Num_builtin_gauges; i++) {
 				for(int j = 0; j < num_loaded_gauges; j++) {
-					if(Retail_gauges[i] == it->hud_gauges[j]->getObjectType()) {
+					if(Builtin_gauges[i] == it->hud_gauges[j]->getObjectType()) {
 						retail_gauge_loaded = true;
 					}
 				}
@@ -640,7 +640,7 @@ void load_missing_retail_gauges()
 				if(!retail_gauge_loaded) {
 					gauge_settings settings;
 					settings.ship_idx = &sindex;
-					load_gauge(Retail_gauges[i], &settings);
+					load_gauge(Builtin_gauges[i], &settings);
 				}
 			}
 

--- a/code/hud/hudparse.cpp
+++ b/code/hud/hudparse.cpp
@@ -53,9 +53,9 @@ int Hud_font = -1;
 
 bool Chase_view_only_ex = false;
 
-//WARNING: If you add gauges to this array, make sure to bump num_default_gauges!
-int num_default_gauges = 42;
-static int retail_gauges[] = {
+//WARNING: If you add gauges to this array, make sure to bump Num_default_gauges!
+const int Num_retail_gauges = 42;
+static int Retail_gauges[Num_retail_gauges] = {
 	HUD_OBJECT_MESSAGES,
 	HUD_OBJECT_TRAINING_MESSAGES,
 	HUD_OBJECT_SUPPORT,
@@ -100,9 +100,52 @@ static int retail_gauges[] = {
 	HUD_OBJECT_ETS_RETAIL
 };
 
+Legacy_HUD_gauge_pair Legacy_HUD_gauges[NUM_HUD_GAUGES] =
+{
+	{ "LEAD_INDICATOR", HUD_OBJECT_LEAD },
+	{ "ORIENTATION_TEE", HUD_OBJECT_ORIENTATION_TEE },
+	{ "HOSTILE_TRIANGLE", HUD_OBJECT_HOSTILE_TRI },
+	{ "TARGET_TRIANGLE", HUD_OBJECT_TARGET_TRI },
+	{ "MISSION_TIME", HUD_OBJECT_MISSION_TIME },
+	{ "RETICLE_CIRCLE", -1 },
+	{ "THROTTLE_GAUGE", HUD_OBJECT_THROTTLE },
+	{ "RADAR", HUD_OBJECT_RADAR_STD },
+	{ "TARGET_MONITOR", HUD_OBJECT_TARGET_MONITOR },
+	{ "CENTER_RETICLE", HUD_OBJECT_CENTER_RETICLE },
+	{ "TARGET_MONITOR_EXTRA_DATA", HUD_OBJECT_EXTRA_TARGET_DATA },
+	{ "TARGET_SHIELD_ICON", HUD_OBJECT_TARGET_SHIELD },
+	{ "PLAYER_SHIELD_ICON", HUD_OBJECT_PLAYER_SHIELD },
+	{ "ETS_GAUGE", HUD_OBJECT_ETS_RETAIL },
+	{ "AUTO_TARGET", HUD_OBJECT_AUTO_TARGET },
+	{ "AUTO_SPEED", HUD_OBJECT_AUTO_SPEED },
+	{ "WEAPONS_GAUGE", HUD_OBJECT_WEAPONS },
+	{ "ESCORT_VIEW", HUD_OBJECT_ESCORT },
+	{ "DIRECTIVES_VIEW", HUD_OBJECT_DIRECTIVES },
+	{ "THREAT_GAUGE", HUD_OBJECT_THREAT },
+	{ "AFTERBURNER_ENERGY", HUD_OBJECT_AFTERBURNER },
+	{ "WEAPONS_ENERGY", HUD_OBJECT_WEAPON_ENERGY },
+	{ "WEAPON_LINKING_GAUGE", HUD_OBJECT_WEAPON_LINKING },
+	{ "TARGER_MINI_ICON", HUD_OBJECT_MINI_SHIELD },
+	{ "OFFSCREEN_INDICATOR", HUD_OBJECT_OFFSCREEN },
+	{ "TALKING_HEAD", HUD_OBJECT_TALKING_HEAD },
+	{ "DAMAGE_GAUGE", HUD_OBJECT_DAMAGE },
+	{ "MESSAGE_LINES", HUD_OBJECT_MESSAGES },
+	{ "MISSILE_WARNING_ARROW", HUD_OBJECT_MISSILE_TRI },
+	{ "CMEASURE_GAUGE", HUD_OBJECT_CMEASURES },
+	{ "OBJECTIVES_NOTIFY_GAUGE", HUD_OBJECT_OBJ_NOTIFY },
+	{ "WINGMEN_STATUS", HUD_OBJECT_WINGMAN_STATUS },
+	{ "OFFSCREEN RANGE", -1 },
+	{ "KILLS GAUGE", HUD_OBJECT_KILLS },
+	{ "ATTACKING TARGET COUNT", -1 },
+	{ "TEXT FLASH", HUD_OBJECT_TEXT_WARNINGS },
+	{ "MESSAGE BOX", HUD_OBJECT_SQUAD_MSG },
+	{ "SUPPORT GUAGE", HUD_OBJECT_SUPPORT },
+	{ "LAG GUAGE", HUD_OBJECT_LAG },
+};
+
 flag_def_list Hud_gauge_types[] = {
 	{ "Messages",			HUD_OBJECT_MESSAGES,			0},
-	{ "Training messages",	HUD_OBJECT_TRAINING_MESSAGES,	0},
+	{ "Training messages",	HUD_OBJECT_TRAINING_MESSAGES,	0},		// Not in legacy list
 	{ "Support",			HUD_OBJECT_SUPPORT,				0},
 	{ "Damage",				HUD_OBJECT_DAMAGE,				0},
 	{ "Wingman status",		HUD_OBJECT_WINGMAN_STATUS,		0},
@@ -120,14 +163,14 @@ flag_def_list Hud_gauge_types[] = {
 	{ "Target shield",		HUD_OBJECT_TARGET_SHIELD,		0},
 	{ "Escort list",		HUD_OBJECT_ESCORT,				0},
 	{ "Mission time",		HUD_OBJECT_MISSION_TIME,		0},
-	{ "Ets weapons",		HUD_OBJECT_ETS_WEAPONS,			0},
-	{ "Ets shields",		HUD_OBJECT_ETS_SHIELDS,			0},
-	{ "Ets engines",		HUD_OBJECT_ETS_ENGINES,			0},
+	{ "Ets weapons",		HUD_OBJECT_ETS_WEAPONS,			0},		// Not in legacy list
+	{ "Ets shields",		HUD_OBJECT_ETS_SHIELDS,			0},		// Not in legacy list
+	{ "Ets engines",		HUD_OBJECT_ETS_ENGINES,			0},		// Not in legacy list
 	{ "Target monitor",		HUD_OBJECT_TARGET_MONITOR,		0},
 	{ "Extra target data",	HUD_OBJECT_EXTRA_TARGET_DATA,	0},
 	{ "Radar",				HUD_OBJECT_RADAR_STD,			0},
-	{ "Radar orb",			HUD_OBJECT_RADAR_ORB,			0},
-	{ "Radar BSG",			HUD_OBJECT_RADAR_BSG,			0},
+	{ "Radar orb",			HUD_OBJECT_RADAR_ORB,			0},		// Not in legacy list
+	{ "Radar BSG",			HUD_OBJECT_RADAR_BSG,			0},		// Not in legacy list
 	{ "Afterburner energy",	HUD_OBJECT_AFTERBURNER,			0},
 	{ "Weapon energy",		HUD_OBJECT_WEAPON_ENERGY,		0},
 	{ "Text warnings",		HUD_OBJECT_TEXT_WARNINGS,		0},
@@ -136,12 +179,12 @@ flag_def_list Hud_gauge_types[] = {
 	{ "Threat indicator",	HUD_OBJECT_THREAT,				0},
 	{ "Lead indicator",		HUD_OBJECT_LEAD,				0},
 	{ "Lead sight",			HUD_OBJECT_LEAD_SIGHT,			0},
-	{ "Lock indicator",		HUD_OBJECT_LOCK,				0},
+	{ "Lock indicator",		HUD_OBJECT_LOCK,				0},		// Not in legacy list
 	{ "Weapon linking",		HUD_OBJECT_WEAPON_LINKING,		0},
-	{ "Multiplayer messages",	HUD_OBJECT_MULTI_MSG,			0},
-	{ "Voice status",		HUD_OBJECT_VOICE_STATUS,		0},
-	{ "Ping",				HUD_OBJECT_PING,				0},
-	{ "Supernova",			HUD_OBJECT_SUPERNOVA,			0},
+	{ "Multiplayer messages",	HUD_OBJECT_MULTI_MSG,			0},	// Not in legacy list
+	{ "Voice status",		HUD_OBJECT_VOICE_STATUS,		0},		// Not in legacy list
+	{ "Ping",				HUD_OBJECT_PING,				0},		// Not in legacy list
+	{ "Supernova",			HUD_OBJECT_SUPERNOVA,			0},		// Not in legacy list
 	{ "Offscreen indicator",	HUD_OBJECT_OFFSCREEN,			0},
 	{ "Targeting brackets",	HUD_OBJECT_BRACKETS,			0},
 	{ "Orientation",		HUD_OBJECT_ORIENTATION_TEE,		0},
@@ -149,10 +192,9 @@ flag_def_list Hud_gauge_types[] = {
 	{ "Target direction",	HUD_OBJECT_TARGET_TRI,			0},
 	{ "Missile indicator",	HUD_OBJECT_MISSILE_TRI,			0},
 	{ "Kills",				HUD_OBJECT_KILLS,				0},
-	{ "Fixed messages",		HUD_OBJECT_FIXED_MESSAGES,		0},
+	{ "Fixed messages",		HUD_OBJECT_FIXED_MESSAGES,		0},		// Not in legacy list
 	{ "Ets retail",			HUD_OBJECT_ETS_RETAIL,			0}
 };
-
 int Num_hud_gauge_types = sizeof(Hud_gauge_types)/sizeof(flag_def_list);
 
 int parse_ship_start()
@@ -533,11 +575,11 @@ void load_missing_retail_gauges()
 	if(Hud_retail) {
 		int num_loaded_gauges = (int)default_hud_gauges.size();
 
-		for(int i = 0; i < num_default_gauges; i++) {
+		for(int i = 0; i < Num_retail_gauges; i++) {
 			retail_gauge_loaded = false;
 
 			for(int j = 0; j < num_loaded_gauges; j++) {
-				if(retail_gauges[i] == default_hud_gauges[j]->getObjectType()) {
+				if(Retail_gauges[i] == default_hud_gauges[j]->getObjectType()) {
 					retail_gauge_loaded = true;
 					break;
 				}
@@ -545,7 +587,7 @@ void load_missing_retail_gauges()
 
 			if(!retail_gauge_loaded) {
 				gauge_settings settings;
-				load_gauge(retail_gauges[i], &settings);
+				load_gauge(Retail_gauges[i], &settings);
 			}
 		}
 
@@ -589,9 +631,9 @@ void load_missing_retail_gauges()
 		if(it->hud_enabled && it->hud_retail) {
 			int num_loaded_gauges = (int)it->hud_gauges.size();
 
-			for(int i = 0; i < num_default_gauges; i++) {
+			for(int i = 0; i < Num_retail_gauges; i++) {
 				for(int j = 0; j < num_loaded_gauges; j++) {
-					if(retail_gauges[i] == it->hud_gauges[j]->getObjectType()) {
+					if(Retail_gauges[i] == it->hud_gauges[j]->getObjectType()) {
 						retail_gauge_loaded = true;
 					}
 				}
@@ -599,7 +641,7 @@ void load_missing_retail_gauges()
 				if(!retail_gauge_loaded) {
 					gauge_settings settings;
 					settings.ship_idx = &sindex;
-					load_gauge(retail_gauges[i], &settings);
+					load_gauge(Retail_gauges[i], &settings);
 				}
 			}
 
@@ -1452,7 +1494,7 @@ void load_gauge_custom(gauge_settings* settings)
 		stuff_string(gauge_string, F_NAME, MAX_FILENAME_LEN);
 		
 		for(i = 0; i < NUM_HUD_GAUGES; i++) {
-			if(!strcmp(HUD_gauge_text[i], gauge_string)) {
+			if(!strcmp(Legacy_HUD_gauges[i].hud_gauge_text, gauge_string)) {
 				gauge_type = i;
 				break;
 			}

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -607,7 +607,7 @@ SCP_vector<sexp_oper> Operators = {
 	{ "hud-disable",					OP_HUD_DISABLE,							1,	1,			SEXP_ACTION_OPERATOR,	},	// Goober5000
 	{ "hud-disable-except-messages",	OP_HUD_DISABLE_EXCEPT_MESSAGES,			1,	1,			SEXP_ACTION_OPERATOR,	},	// Goober5000
 	{ "hud-set-custom-gauge-active",	OP_HUD_SET_CUSTOM_GAUGE_ACTIVE,			2, 	INT_MAX, 	SEXP_ACTION_OPERATOR,	},
-	{ "hud-set-retail-gauge-active",	OP_HUD_SET_RETAIL_GAUGE_ACTIVE,			2, 	INT_MAX,	SEXP_ACTION_OPERATOR,	},
+	{ "hud-set-builtin-gauge-active",	OP_HUD_SET_BUILTIN_GAUGE_ACTIVE,		2, 	INT_MAX,	SEXP_ACTION_OPERATOR,	},
 	{ "hud-set-text",					OP_HUD_SET_TEXT,						2,	2,			SEXP_ACTION_OPERATOR,	},	//WMCoolmon
 	{ "hud-set-text-num",				OP_HUD_SET_TEXT_NUM,					2,	2,			SEXP_ACTION_OPERATOR,	},	//WMCoolmon
 	{ "hud-set-message",				OP_HUD_SET_MESSAGE,						2,	2,			SEXP_ACTION_OPERATOR,	},	//The E
@@ -2938,7 +2938,7 @@ int check_sexp_syntax(int node, int return_type, int recursive, int *bad_node, i
 					return SEXP_CHECK_INVALID_AUDIO_VOLUME_OPTION;
 				break;
 
-			case OPF_RETAIL_HUD_GAUGE:
+			case OPF_BUILTIN_HUD_GAUGE:
 			{
 				if (type2 != SEXP_ATOM_STRING) {
 					return SEXP_CHECK_TYPE_MISMATCH;
@@ -2960,7 +2960,7 @@ int check_sexp_syntax(int node, int return_type, int recursive, int *bad_node, i
 				}
 
 				if (hud_gauge_type_lookup(gauge_name) == -1)
-					return SEXP_CHECK_INVALID_RETAIL_HUD_GAUGE;
+					return SEXP_CHECK_INVALID_BUILTIN_HUD_GAUGE;
 
 				break;
 			}
@@ -3590,6 +3590,8 @@ int get_sexp()
 				strcpy_s(token, "distance-center-to-subsystem");
 			else if (!stricmp(token, "remove-weapons"))
 				strcpy_s(token, "clear-weapons");
+			else if (!stricmp(token, "hud-set-retail-gauge-active"))
+				strcpy_s(token, "hud-set-builtin-gauge-active");
 
 			op = get_operator_index(token);
 			if (op >= 0) {
@@ -11376,7 +11378,7 @@ void sexp_hud_activate_gauge_type(int n)
 	}
 }
 
-void sexp_hud_set_retail_gauge_active(int node)
+void sexp_hud_set_builtin_gauge_active(int node)
 {
 	bool activate = is_sexp_true(node);
 	node = CDR(node);
@@ -25676,9 +25678,9 @@ int eval_sexp(int cur_node, int referenced_node)
 				sexp_hud_activate_gauge_type(node);
 				break;
 
-			case OP_HUD_SET_RETAIL_GAUGE_ACTIVE:
+			case OP_HUD_SET_BUILTIN_GAUGE_ACTIVE:
 				sexp_val = SEXP_TRUE;
-				sexp_hud_set_retail_gauge_active(node);
+				sexp_hud_set_builtin_gauge_active(node);
 				break;
 
 			case OP_ADD_TO_COLGROUP:
@@ -26827,7 +26829,7 @@ int query_operator_return_type(int op)
 		case OP_SET_PLAYER_THROTTLE_SPEED:
 		case OP_DEBUG:
 		case OP_HUD_SET_CUSTOM_GAUGE_ACTIVE:
-		case OP_HUD_SET_RETAIL_GAUGE_ACTIVE:
+		case OP_HUD_SET_BUILTIN_GAUGE_ACTIVE:
 		case OP_ALTER_SHIP_FLAG:
 		case OP_CHANGE_TEAM_COLOR:
 		case OP_NEBULA_CHANGE_PATTERN:
@@ -28206,7 +28208,7 @@ int query_operator_argument_type(int op, int argnum)
 				return OPF_SHIP;
 
 		case OP_FLASH_HUD_GAUGE:
-			return OPF_RETAIL_HUD_GAUGE;
+			return OPF_BUILTIN_HUD_GAUGE;
 
 		case OP_GOOD_SECONDARY_TIME:
 			if ( argnum == 0 )
@@ -29192,7 +29194,7 @@ int query_operator_argument_type(int op, int argnum)
 
 		case OP_HUD_ACTIVATE_GAUGE_TYPE:
 			if (argnum == 0)
-				return OPF_RETAIL_HUD_GAUGE;
+				return OPF_BUILTIN_HUD_GAUGE;
 			else
 				return OPF_BOOL;
 
@@ -29202,11 +29204,11 @@ int query_operator_argument_type(int op, int argnum)
 			else
 				return OPF_CUSTOM_HUD_GAUGE;
 
-		case OP_HUD_SET_RETAIL_GAUGE_ACTIVE:
+		case OP_HUD_SET_BUILTIN_GAUGE_ACTIVE:
 			if (argnum == 0)
 				return OPF_BOOL;
 			else
-				return OPF_RETAIL_HUD_GAUGE;
+				return OPF_BUILTIN_HUD_GAUGE;
 
 		case OP_GET_COLGROUP_ID:
 			return OPF_SHIP;
@@ -29709,8 +29711,8 @@ const char *sexp_error_message(int num)
 		case SEXP_CHECK_INVALID_DAMAGE_TYPE:
 			return "Invalid damage type";
 
-		case SEXP_CHECK_INVALID_RETAIL_HUD_GAUGE:
-			return "Invalid retail HUD gauge";
+		case SEXP_CHECK_INVALID_BUILTIN_HUD_GAUGE:
+			return "Invalid builtin HUD gauge";
 
 		case SEXP_CHECK_INVALID_CUSTOM_HUD_GAUGE:
 			return "Invalid custom HUD gauge";
@@ -30802,7 +30804,7 @@ int get_subcategory(int sexp_id)
 		case OP_HUD_DISABLE:
 		case OP_HUD_DISABLE_EXCEPT_MESSAGES:
 		case OP_HUD_SET_CUSTOM_GAUGE_ACTIVE:
-		case OP_HUD_SET_RETAIL_GAUGE_ACTIVE:
+		case OP_HUD_SET_BUILTIN_GAUGE_ACTIVE:
 		case OP_HUD_SET_TEXT:
 		case OP_HUD_SET_TEXT_NUM:
 		case OP_HUD_SET_MESSAGE:
@@ -34981,8 +34983,8 @@ SCP_vector<sexp_help_struct> Sexp_help = {
 		"\tRest:\tHUD Gauge name\r\n"
 	},
 
-	{OP_HUD_SET_RETAIL_GAUGE_ACTIVE, "hud-set-custom-gauge-active\r\n"
-		"\tActivates or deactivates a retail hud gauge grouping."
+	{OP_HUD_SET_BUILTIN_GAUGE_ACTIVE, "hud-set-builtin-gauge-active\r\n"
+		"\tActivates or deactivates a builtin hud gauge grouping."
 		"Takes 2 Arguments...\r\n"
 		"\t1:\tBoolean, whether or not to display this gauge\r\n"
 		"\tRest:\tHUD Gauge Group name\r\n"

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -2965,6 +2965,16 @@ int check_sexp_syntax(int node, int return_type, int recursive, int *bad_node, i
 				break;
 			}
 
+			case OPF_CUSTOM_HUD_GAUGE:
+				if (type2 != SEXP_ATOM_STRING) {
+					return SEXP_CHECK_TYPE_MISMATCH;
+				}
+
+				if (hud_get_gauge(CTEXT(node)) == nullptr)
+					return SEXP_CHECK_INVALID_CUSTOM_HUD_GAUGE;
+
+				break;
+
 			case OPF_SOUND_ENVIRONMENT_OPTION:
 				if (type2 != SEXP_ATOM_STRING) {
 					return SEXP_CHECK_TYPE_MISMATCH;
@@ -27835,11 +27845,14 @@ int query_operator_argument_type(int op, int argnum)
 			return OPF_POSITIVE;
 
 		case OP_HUD_SET_TEXT:
-			return OPF_STRING;
+			if (argnum == 0)
+				return OPF_CUSTOM_HUD_GAUGE;
+			else
+				return OPF_STRING;
 
 		case OP_HUD_SET_MESSAGE:
 			if(argnum == 0)
-				return OPF_STRING;
+				return OPF_CUSTOM_HUD_GAUGE;
 			else
 				return OPF_MESSAGE;
 
@@ -27848,7 +27861,7 @@ int query_operator_argument_type(int op, int argnum)
 		case OP_HUD_SET_FRAME:
 		case OP_HUD_SET_COLOR:
 			if(argnum == 0)
-				return OPF_STRING;
+				return OPF_CUSTOM_HUD_GAUGE;
 			else
 				return OPF_POSITIVE;
 
@@ -29166,11 +29179,14 @@ int query_operator_argument_type(int op, int argnum)
 				return OPF_BOOL;
 
 		case OP_HUD_SET_DIRECTIVE:
-			return OPF_STRING;
+			if (argnum == 0)
+				return OPF_CUSTOM_HUD_GAUGE;
+			else
+				return OPF_STRING;
 
 		case OP_HUD_GAUGE_SET_ACTIVE:
 			if (argnum == 0)
-				return OPF_STRING;
+				return OPF_CUSTOM_HUD_GAUGE;
 			else
 				return OPF_BOOL;
 
@@ -29184,7 +29200,7 @@ int query_operator_argument_type(int op, int argnum)
 			if (argnum == 0)
 				return OPF_BOOL;
 			else
-				return OPF_STRING;
+				return OPF_CUSTOM_HUD_GAUGE;
 
 		case OP_HUD_SET_RETAIL_GAUGE_ACTIVE:
 			if (argnum == 0)

--- a/code/parse/sexp.h
+++ b/code/parse/sexp.h
@@ -58,7 +58,7 @@ class waypoint_list;
 #define	OPF_MEDAL_NAME			31		// name of medals
 #define	OPF_WEAPON_NAME			32		// name of a weapon
 #define	OPF_SHIP_CLASS_NAME		33		// name of a ship class
-#define	OPF_HUD_GAUGE_NAME		34		// name of HUD gauge
+#define	OPF_CUSTOM_HUD_GAUGE	34		// name of custom HUD gauge
 #define	OPF_HUGE_WEAPON			35		// name of a secondary bomb type weapon
 #define	OPF_SHIP_NOT_PLAYER		36		// a ship, but not a player ship
 #define	OPF_JUMP_NODE_NAME		37		// name of a jump node
@@ -103,7 +103,7 @@ class waypoint_list;
 #define OPF_AUDIO_VOLUME_OPTION 76		// The E
 #define OPF_WEAPON_BANK_NUMBER	77		// Karajorma - The number of a primary/secondary/tertiary weapon bank or all of them
 #define OPF_MESSAGE_OR_STRING	78		// Goober5000 - provides a list of messages like OPF_MESSAGE, but also allows entering arbitrary strings
-#define OPF_HUD_GAUGE			79		// The E
+#define OPF_RETAIL_HUD_GAUGE	79		// The E
 #define OPF_DAMAGE_TYPE			80		// FUBAR - Damage type or <none>
 #define OPF_SHIP_EFFECT			81		// The E - per-ship effects, as defined in post-processing.tbl
 #define OPF_ANIMATION_TYPE		82		// Goober5000 - as defined in modelanim.h
@@ -1024,7 +1024,7 @@ const char *CTEXT(int n);
 #define SEXP_CHECK_INVALID_MEDAL_NAME			-123
 #define SEXP_CHECK_INVALID_WEAPON_NAME			-124
 #define SEXP_CHECK_INVALID_SHIP_CLASS_NAME	-125
-#define SEXP_CHECK_INVALID_GAUGE_NAME			-126
+#define SEXP_CHECK_INVALID_CUSTOM_HUD_GAUGE		-126
 #define SEXP_CHECK_INVALID_JUMP_NODE			-127
 #define SEXP_CHECK_INVALID_VARIABLE				-128
 #define SEXP_CHECK_INVALID_AI_CLASS				-129
@@ -1051,7 +1051,7 @@ const char *CTEXT(int n);
 #define SEXP_CHECK_INVALID_DAMAGE_TYPE			-150
 #define SEXP_CHECK_INVALID_TARGET_PRIORITIES	-151
 #define SEXP_CHECK_INVALID_AUDIO_VOLUME_OPTION	-152
-#define SEXP_CHECK_INVALID_HUD_GAUGE			-153
+#define SEXP_CHECK_INVALID_RETAIL_HUD_GAUGE		-153
 #define SEXP_CHECK_INVALID_ANIMATION_TYPE		-154
 #define SEXP_CHECK_INVALID_MISSION_MOOD			-155
 #define SEXP_CHECK_INVALID_SHIP_FLAG			-156

--- a/code/parse/sexp.h
+++ b/code/parse/sexp.h
@@ -103,7 +103,7 @@ class waypoint_list;
 #define OPF_AUDIO_VOLUME_OPTION 76		// The E
 #define OPF_WEAPON_BANK_NUMBER	77		// Karajorma - The number of a primary/secondary/tertiary weapon bank or all of them
 #define OPF_MESSAGE_OR_STRING	78		// Goober5000 - provides a list of messages like OPF_MESSAGE, but also allows entering arbitrary strings
-#define OPF_RETAIL_HUD_GAUGE	79		// The E
+#define OPF_BUILTIN_HUD_GAUGE	79		// The E
 #define OPF_DAMAGE_TYPE			80		// FUBAR - Damage type or <none>
 #define OPF_SHIP_EFFECT			81		// The E - per-ship effects, as defined in post-processing.tbl
 #define OPF_ANIMATION_TYPE		82		// Goober5000 - as defined in modelanim.h
@@ -745,7 +745,7 @@ class waypoint_list;
 #define OP_CALL_SSM_STRIKE					(0x0024 | OP_CATEGORY_CHANGE2 | OP_NONCAMPAIGN_FLAG) // X3N0-Life-Form
 #define OP_SET_MOTION_DEBRIS				(0x0025 | OP_CATEGORY_CHANGE2 | OP_NONCAMPAIGN_FLAG)    // The E
 #define OP_HUD_SET_CUSTOM_GAUGE_ACTIVE		(0x0026 | OP_CATEGORY_CHANGE2 | OP_NONCAMPAIGN_FLAG) 	// The E, just revamped a bit by Axem
-#define OP_HUD_SET_RETAIL_GAUGE_ACTIVE		(0x0027 | OP_CATEGORY_CHANGE2 | OP_NONCAMPAIGN_FLAG) 	// The E, just revamped a bit by Axem
+#define OP_HUD_SET_BUILTIN_GAUGE_ACTIVE		(0x0027 | OP_CATEGORY_CHANGE2 | OP_NONCAMPAIGN_FLAG) 	// The E, just revamped a bit by Axem
 #define OP_SCRIPT_EVAL_MULTI				(0x0028 | OP_CATEGORY_CHANGE2 | OP_NONCAMPAIGN_FLAG)	// Karajorma
 #define OP_PAUSE_SOUND_FROM_FILE			(0x0029 | OP_CATEGORY_CHANGE2 | OP_NONCAMPAIGN_FLAG)	// Goober5000
 #define OP_SCRIPT_EVAL_BLOCK				(0x002a | OP_CATEGORY_CHANGE2 | OP_NONCAMPAIGN_FLAG) // niffiwan
@@ -1051,7 +1051,7 @@ const char *CTEXT(int n);
 #define SEXP_CHECK_INVALID_DAMAGE_TYPE			-150
 #define SEXP_CHECK_INVALID_TARGET_PRIORITIES	-151
 #define SEXP_CHECK_INVALID_AUDIO_VOLUME_OPTION	-152
-#define SEXP_CHECK_INVALID_RETAIL_HUD_GAUGE		-153
+#define SEXP_CHECK_INVALID_BUILTIN_HUD_GAUGE	-153
 #define SEXP_CHECK_INVALID_ANIMATION_TYPE		-154
 #define SEXP_CHECK_INVALID_MISSION_MOOD			-155
 #define SEXP_CHECK_INVALID_SHIP_FLAG			-156

--- a/fred2/management.cpp
+++ b/fred2/management.cpp
@@ -417,6 +417,7 @@ bool fred_init(std::unique_ptr<os::GraphicsOperations>&& graphicsOps)
 	ship_init();
 	parse_init();
 	techroom_intel_init();
+	hud_positions_init();
 	asteroid_init();
 
 	// get fireball IDs for sexpression usage

--- a/fred2/sexp_tree.cpp
+++ b/fred2/sexp_tree.cpp
@@ -2730,8 +2730,8 @@ int sexp_tree::get_default_value(sexp_list_item *item, char *text_buf, int op, i
 			str = "<Effect Name>";
 			break;
 
-		case OPF_RETAIL_HUD_GAUGE:
-			str = "Messages";
+		case OPF_CUSTOM_HUD_GAUGE:
+			str = "<Custom hud gauge>";
 			break;
 
 		default:
@@ -2823,6 +2823,7 @@ int sexp_tree::query_default_argument_available(int op, int i)
 		case OPF_WEAPON_BANK_NUMBER:
 		case OPF_MESSAGE_OR_STRING:
 		case OPF_RETAIL_HUD_GAUGE:
+		case OPF_CUSTOM_HUD_GAUGE:
 		case OPF_SHIP_EFFECT:
 		case OPF_ANIMATION_TYPE:
 		case OPF_SHIP_FLAG:
@@ -4614,6 +4615,10 @@ sexp_list_item *sexp_tree::get_listing_opf(int opf, int parent_node, int arg_ind
 			list = get_listing_opf_retail_hud_gauge();
 			break;
 
+		case OPF_CUSTOM_HUD_GAUGE:
+			list = get_listing_opf_custom_hud_gauge();
+			break;
+
 		case OPF_SHIP_EFFECT:
 			list = get_listing_opf_ship_effect();
 			break;
@@ -5594,7 +5599,34 @@ sexp_list_item *sexp_tree::get_listing_opf_retail_hud_gauge()
 	return head.next;
 }
 
-sexp_list_item *sexp_tree::get_listing_opf_ship_effect() 
+sexp_list_item *sexp_tree::get_listing_opf_custom_hud_gauge()
+{
+	sexp_list_item head;
+	SCP_unordered_set<SCP_string> all_gauges;
+
+	for (auto &gauge : default_hud_gauges)
+	{
+		all_gauges.insert(gauge->getCustomGaugeName());
+		head.add_data(gauge->getCustomGaugeName());
+	}
+
+	for (auto &si : Ship_info)
+	{
+		for (auto &gauge : si.hud_gauges)
+		{
+			// avoid duplicating any HUD gauges
+			if (all_gauges.count(gauge->getCustomGaugeName()) == 0)
+			{
+				all_gauges.insert(gauge->getCustomGaugeName());
+				head.add_data(gauge->getCustomGaugeName());
+			}
+		}
+	}
+
+	return head.next;
+}
+
+sexp_list_item *sexp_tree::get_listing_opf_ship_effect()
 {
 	sexp_list_item head;
 	

--- a/fred2/sexp_tree.cpp
+++ b/fred2/sexp_tree.cpp
@@ -2730,7 +2730,7 @@ int sexp_tree::get_default_value(sexp_list_item *item, char *text_buf, int op, i
 			str = "<Effect Name>";
 			break;
 
-		case OPF_HUD_GAUGE:
+		case OPF_RETAIL_HUD_GAUGE:
 			str = "Messages";
 			break;
 
@@ -2786,7 +2786,6 @@ int sexp_tree::query_default_argument_available(int op, int i)
 		case OPF_WEAPON_NAME:
 		case OPF_INTEL_NAME:
 		case OPF_SHIP_CLASS_NAME:
-		case OPF_HUD_GAUGE_NAME:
 		case OPF_HUGE_WEAPON:
 		case OPF_JUMP_NODE_NAME:
 		case OPF_AMBIGUOUS:
@@ -2823,7 +2822,7 @@ int sexp_tree::query_default_argument_available(int op, int i)
 		case OPF_AUDIO_VOLUME_OPTION:
 		case OPF_WEAPON_BANK_NUMBER:
 		case OPF_MESSAGE_OR_STRING:
-		case OPF_HUD_GAUGE:
+		case OPF_RETAIL_HUD_GAUGE:
 		case OPF_SHIP_EFFECT:
 		case OPF_ANIMATION_TYPE:
 		case OPF_SHIP_FLAG:
@@ -4491,10 +4490,6 @@ sexp_list_item *sexp_tree::get_listing_opf(int opf, int parent_node, int arg_ind
 			list = get_listing_opf_ship_class_name();
 			break;
 
-		case OPF_HUD_GAUGE_NAME:
-			list = get_listing_opf_hud_gauge_name();
-			break;
-
 		case OPF_HUGE_WEAPON:
 			list = get_listing_opf_huge_weapon();
 			break;
@@ -4615,8 +4610,8 @@ sexp_list_item *sexp_tree::get_listing_opf(int opf, int parent_node, int arg_ind
 			list = get_listing_opf_message();
 			break;
 
-		case OPF_HUD_GAUGE:
-			list = get_listing_opf_hud_gauge();
+		case OPF_RETAIL_HUD_GAUGE:
+			list = get_listing_opf_retail_hud_gauge();
 			break;
 
 		case OPF_SHIP_EFFECT:
@@ -5589,7 +5584,7 @@ sexp_list_item *sexp_tree::get_listing_opf_adjust_audio_volume()
 	return head.next;
 }
 
-sexp_list_item *sexp_tree::get_listing_opf_hud_gauge() 
+sexp_list_item *sexp_tree::get_listing_opf_retail_hud_gauge() 
 {
 	sexp_list_item head;
 
@@ -5910,17 +5905,6 @@ sexp_list_item *sexp_tree::get_listing_opf_ship_class_name()
 
 	for (auto &si : Ship_info)
 		head.add_data(si.name);
-
-	return head.next;
-}
-
-sexp_list_item *sexp_tree::get_listing_opf_hud_gauge_name()
-{
-	int i;
-	sexp_list_item head;
-
-	for (i=0; i<NUM_HUD_GAUGES; i++)
-		head.add_data(HUD_gauge_text[i]);
 
 	return head.next;
 }

--- a/fred2/sexp_tree.cpp
+++ b/fred2/sexp_tree.cpp
@@ -2822,7 +2822,7 @@ int sexp_tree::query_default_argument_available(int op, int i)
 		case OPF_AUDIO_VOLUME_OPTION:
 		case OPF_WEAPON_BANK_NUMBER:
 		case OPF_MESSAGE_OR_STRING:
-		case OPF_RETAIL_HUD_GAUGE:
+		case OPF_BUILTIN_HUD_GAUGE:
 		case OPF_CUSTOM_HUD_GAUGE:
 		case OPF_SHIP_EFFECT:
 		case OPF_ANIMATION_TYPE:
@@ -4611,8 +4611,8 @@ sexp_list_item *sexp_tree::get_listing_opf(int opf, int parent_node, int arg_ind
 			list = get_listing_opf_message();
 			break;
 
-		case OPF_RETAIL_HUD_GAUGE:
-			list = get_listing_opf_retail_hud_gauge();
+		case OPF_BUILTIN_HUD_GAUGE:
+			list = get_listing_opf_builtin_hud_gauge();
 			break;
 
 		case OPF_CUSTOM_HUD_GAUGE:
@@ -5589,7 +5589,7 @@ sexp_list_item *sexp_tree::get_listing_opf_adjust_audio_volume()
 	return head.next;
 }
 
-sexp_list_item *sexp_tree::get_listing_opf_retail_hud_gauge() 
+sexp_list_item *sexp_tree::get_listing_opf_builtin_hud_gauge() 
 {
 	sexp_list_item head;
 

--- a/fred2/sexp_tree.h
+++ b/fred2/sexp_tree.h
@@ -270,6 +270,7 @@ public:
 	sexp_list_item *get_listing_opf_adjust_audio_volume();
 	sexp_list_item *get_listing_opf_weapon_banks();
 	sexp_list_item *get_listing_opf_retail_hud_gauge();
+	sexp_list_item *get_listing_opf_custom_hud_gauge();
 	sexp_list_item *get_listing_opf_ship_effect();
 	sexp_list_item *get_listing_opf_animation_type();
 	sexp_list_item *get_listing_opf_mission_moods();

--- a/fred2/sexp_tree.h
+++ b/fred2/sexp_tree.h
@@ -230,7 +230,6 @@ public:
 	sexp_list_item *get_listing_opf_medal_name();
 	sexp_list_item *get_listing_opf_weapon_name();
 	sexp_list_item *get_listing_opf_ship_class_name();
-	sexp_list_item *get_listing_opf_hud_gauge_name();
 	sexp_list_item *get_listing_opf_huge_weapon();
 	sexp_list_item *get_listing_opf_ship_not_player();
 	sexp_list_item *get_listing_opf_jump_nodes();

--- a/fred2/sexp_tree.h
+++ b/fred2/sexp_tree.h
@@ -268,7 +268,7 @@ public:
 	sexp_list_item *get_listing_opf_explosion_option();
 	sexp_list_item *get_listing_opf_adjust_audio_volume();
 	sexp_list_item *get_listing_opf_weapon_banks();
-	sexp_list_item *get_listing_opf_retail_hud_gauge();
+	sexp_list_item *get_listing_opf_builtin_hud_gauge();
 	sexp_list_item *get_listing_opf_custom_hud_gauge();
 	sexp_list_item *get_listing_opf_ship_effect();
 	sexp_list_item *get_listing_opf_animation_type();

--- a/fred2/sexp_tree.h
+++ b/fred2/sexp_tree.h
@@ -269,7 +269,7 @@ public:
 	sexp_list_item *get_listing_opf_explosion_option();
 	sexp_list_item *get_listing_opf_adjust_audio_volume();
 	sexp_list_item *get_listing_opf_weapon_banks();
-	sexp_list_item *get_listing_opf_hud_gauge();
+	sexp_list_item *get_listing_opf_retail_hud_gauge();
 	sexp_list_item *get_listing_opf_ship_effect();
 	sexp_list_item *get_listing_opf_animation_type();
 	sexp_list_item *get_listing_opf_mission_moods();

--- a/qtfred/src/ui/widgets/sexp_tree.cpp
+++ b/qtfred/src/ui/widgets/sexp_tree.cpp
@@ -1365,8 +1365,8 @@ int sexp_tree::get_default_value(sexp_list_item* item, char* text_buf, int op, i
 		str = "<Effect Name>";
 		break;
 
-	case OPF_HUD_GAUGE:
-		str = "Messages";
+	case OPF_CUSTOM_HUD_GAUGE:
+		str = "<Custom hud gauge>";
 		break;
 
 	default:
@@ -1421,7 +1421,6 @@ int sexp_tree::query_default_argument_available(int op, int i) {
 	case OPF_WEAPON_NAME:
 	case OPF_INTEL_NAME:
 	case OPF_SHIP_CLASS_NAME:
-	case OPF_HUD_GAUGE_NAME:
 	case OPF_HUGE_WEAPON:
 	case OPF_JUMP_NODE_NAME:
 	case OPF_AMBIGUOUS:
@@ -1458,7 +1457,8 @@ int sexp_tree::query_default_argument_available(int op, int i) {
 	case OPF_AUDIO_VOLUME_OPTION:
 	case OPF_WEAPON_BANK_NUMBER:
 	case OPF_MESSAGE_OR_STRING:
-	case OPF_HUD_GAUGE:
+	case OPF_RETAIL_HUD_GAUGE:
+	case OPF_CUSTOM_HUD_GAUGE:
 	case OPF_SHIP_EFFECT:
 	case OPF_ANIMATION_TYPE:
 	case OPF_SHIP_FLAG:
@@ -2868,10 +2868,6 @@ sexp_list_item* sexp_tree::get_listing_opf(int opf, int parent_node, int arg_ind
 		list = get_listing_opf_ship_class_name();
 		break;
 
-	case OPF_HUD_GAUGE_NAME:
-		list = get_listing_opf_hud_gauge_name();
-		break;
-
 	case OPF_HUGE_WEAPON:
 		list = get_listing_opf_huge_weapon();
 		break;
@@ -2992,8 +2988,12 @@ sexp_list_item* sexp_tree::get_listing_opf(int opf, int parent_node, int arg_ind
 		list = get_listing_opf_message();
 		break;
 
-	case OPF_HUD_GAUGE:
-		list = get_listing_opf_hud_gauge();
+	case OPF_RETAIL_HUD_GAUGE:
+		list = get_listing_opf_retail_hud_gauge();
+		break;
+
+	case OPF_CUSTOM_HUD_GAUGE:
+		list = get_listing_opf_custom_hud_gauge();
 		break;
 
 	case OPF_SHIP_EFFECT:
@@ -3912,11 +3912,38 @@ sexp_list_item* sexp_tree::get_listing_opf_adjust_audio_volume() {
 	return head.next;
 }
 
-sexp_list_item* sexp_tree::get_listing_opf_hud_gauge() {
+sexp_list_item* sexp_tree::get_listing_opf_retail_hud_gauge() {
 	sexp_list_item head;
 
 	for (int i = 0; i < Num_hud_gauge_types; i++) {
 		head.add_data(Hud_gauge_types[i].name);
+	}
+
+	return head.next;
+}
+
+sexp_list_item *sexp_tree::get_listing_opf_custom_hud_gauge()
+{
+	sexp_list_item head;
+	SCP_unordered_set<SCP_string> all_gauges;
+
+	for (auto &gauge : default_hud_gauges)
+	{
+		all_gauges.insert(gauge->getCustomGaugeName());
+		head.add_data(gauge->getCustomGaugeName());
+	}
+
+	for (auto &si : Ship_info)
+	{
+		for (auto &gauge : si.hud_gauges)
+		{
+			// avoid duplicating any HUD gauges
+			if (all_gauges.count(gauge->getCustomGaugeName()) == 0)
+			{
+				all_gauges.insert(gauge->getCustomGaugeName());
+				head.add_data(gauge->getCustomGaugeName());
+			}
+		}
 	}
 
 	return head.next;
@@ -4249,17 +4276,6 @@ sexp_list_item* sexp_tree::get_listing_opf_ship_class_name() {
 
 	for (auto &si : Ship_info) {
 		head.add_data(si.name);
-	}
-
-	return head.next;
-}
-
-sexp_list_item* sexp_tree::get_listing_opf_hud_gauge_name() {
-	int i;
-	sexp_list_item head;
-
-	for (i = 0; i < NUM_HUD_GAUGES; i++) {
-		head.add_data(HUD_gauge_text[i]);
 	}
 
 	return head.next;

--- a/qtfred/src/ui/widgets/sexp_tree.cpp
+++ b/qtfred/src/ui/widgets/sexp_tree.cpp
@@ -1457,7 +1457,7 @@ int sexp_tree::query_default_argument_available(int op, int i) {
 	case OPF_AUDIO_VOLUME_OPTION:
 	case OPF_WEAPON_BANK_NUMBER:
 	case OPF_MESSAGE_OR_STRING:
-	case OPF_RETAIL_HUD_GAUGE:
+	case OPF_BUILTIN_HUD_GAUGE:
 	case OPF_CUSTOM_HUD_GAUGE:
 	case OPF_SHIP_EFFECT:
 	case OPF_ANIMATION_TYPE:
@@ -2988,8 +2988,8 @@ sexp_list_item* sexp_tree::get_listing_opf(int opf, int parent_node, int arg_ind
 		list = get_listing_opf_message();
 		break;
 
-	case OPF_RETAIL_HUD_GAUGE:
-		list = get_listing_opf_retail_hud_gauge();
+	case OPF_BUILTIN_HUD_GAUGE:
+		list = get_listing_opf_builtin_hud_gauge();
 		break;
 
 	case OPF_CUSTOM_HUD_GAUGE:
@@ -3912,7 +3912,7 @@ sexp_list_item* sexp_tree::get_listing_opf_adjust_audio_volume() {
 	return head.next;
 }
 
-sexp_list_item* sexp_tree::get_listing_opf_retail_hud_gauge() {
+sexp_list_item* sexp_tree::get_listing_opf_builtin_hud_gauge() {
 	sexp_list_item head;
 
 	for (int i = 0; i < Num_hud_gauge_types; i++) {

--- a/qtfred/src/ui/widgets/sexp_tree.h
+++ b/qtfred/src/ui/widgets/sexp_tree.h
@@ -319,7 +319,7 @@ class sexp_tree: public QTreeWidget {
 	sexp_list_item* get_listing_opf_explosion_option();
 	sexp_list_item* get_listing_opf_adjust_audio_volume();
 	sexp_list_item* get_listing_opf_weapon_banks();
-	sexp_list_item* get_listing_opf_retail_hud_gauge();
+	sexp_list_item* get_listing_opf_builtin_hud_gauge();
 	sexp_list_item* get_listing_opf_custom_hud_gauge();
 	sexp_list_item* get_listing_opf_ship_effect();
 	sexp_list_item* get_listing_opf_animation_type();

--- a/qtfred/src/ui/widgets/sexp_tree.h
+++ b/qtfred/src/ui/widgets/sexp_tree.h
@@ -281,7 +281,6 @@ class sexp_tree: public QTreeWidget {
 	sexp_list_item* get_listing_opf_medal_name();
 	sexp_list_item* get_listing_opf_weapon_name();
 	sexp_list_item* get_listing_opf_ship_class_name();
-	sexp_list_item* get_listing_opf_hud_gauge_name();
 	sexp_list_item* get_listing_opf_huge_weapon();
 	sexp_list_item* get_listing_opf_ship_not_player();
 	sexp_list_item* get_listing_opf_jump_nodes();
@@ -320,7 +319,8 @@ class sexp_tree: public QTreeWidget {
 	sexp_list_item* get_listing_opf_explosion_option();
 	sexp_list_item* get_listing_opf_adjust_audio_volume();
 	sexp_list_item* get_listing_opf_weapon_banks();
-	sexp_list_item* get_listing_opf_hud_gauge();
+	sexp_list_item* get_listing_opf_retail_hud_gauge();
+	sexp_list_item* get_listing_opf_custom_hud_gauge();
 	sexp_list_item* get_listing_opf_ship_effect();
 	sexp_list_item* get_listing_opf_animation_type();
 	sexp_list_item* get_listing_opf_mission_moods();


### PR DESCRIPTION
This upgrades the HUD gauge parameters in two ways:
1) Removes the ugly legacy capitalized HUD gauge names, only used in `flash-hud-gauge`, from the SEXP context menu.  They will still work, but the default going forward will be the more readable retail gauge names.  The parameter type has also been renamed to `OPF_BUILTIN_HUD_GAUGE` to be more specific.
2) Adds a new `OPF_CUSTOM_HUD_GAUGE` to implement the feature requested in #3364.