### PR TITLE
Add guardrails to object cleanup during object creation

### DIFF
--- a/code/asteroid/asteroid.cpp
+++ b/code/asteroid/asteroid.cpp
@@ -324,7 +324,7 @@ object *asteroid_create(asteroid_field *asfieldp, int asteroid_type, int asteroi
     asteroid_default_flagset += Object::Object_Flags::Physics;
     asteroid_default_flagset += Object::Object_Flags::Collides;
     
-    objnum = obj_create(OBJ_ASTEROID, -1, n, &orient, &pos, radius, asteroid_default_flagset);
+    objnum = obj_create(OBJ_ASTEROID, -1, n, &orient, &pos, radius, asteroid_default_flagset, false);
 	
 	if ( (objnum == -1) || (objnum >= MAX_OBJECTS) ) {
 		mprintf(("Couldn't create asteroid -- out of object slots\n"));

--- a/code/debris/debris.cpp
+++ b/code/debris/debris.cpp
@@ -576,7 +576,7 @@ object *debris_create(object *source_obj, int model_num, int submodel_num, vec3d
 		vm_vector_2_matrix(&orient, &rand);
 	}
 
-    objnum = obj_create( OBJ_DEBRIS, parent_objnum, n, &orient, pos, radius, default_flags);
+	objnum = obj_create(OBJ_DEBRIS, parent_objnum, n, &orient, pos, radius, default_flags, false);
 	if ( objnum == -1 ) {
 		mprintf(("Couldn't create debris object -- out of object slots\n"));
 		return NULL;

--- a/code/fireball/fireballs.cpp
+++ b/code/fireball/fireballs.cpp
@@ -838,7 +838,7 @@ int fireball_create(vec3d *pos, int fireball_type, int render_type, int parent_o
 	
     flagset<Object::Object_Flags> default_flags;
     default_flags.set(Object::Object_Flags::Renders);
-	objnum = obj_create(OBJ_FIREBALL, parent_obj, n, &orient, pos, size, default_flags);
+	objnum = obj_create(OBJ_FIREBALL, parent_obj, n, &orient, pos, size, default_flags, false);
 
 	obj = &Objects[objnum];
 

--- a/code/object/objcollide.cpp
+++ b/code/object/objcollide.cpp
@@ -536,38 +536,7 @@ int collide_remove_weapons( )
 		}
 	}
 
-	if ( num_deleted )
-		return num_deleted;
-
-	// if we didn't remove any weapons, try to the N oldest weapons.  first checking for pairs, then
-	// checking for oldest weapons in general.  We will go through the loop a max of 2 times.  first time
-	// through, we check oldest weapons with pairs, next time through, for oldest weapons.
-	int loop_count = 0;
-	do {
-		for (int j = 0; j < CRW_MAX_TO_DELETE; j++ ) {
-			float oldest_time = 1000.0f;
-			int oldest_index = -1;
-			for (int i = 0; i < MAX_WEAPONS; i++ ) {
-				if ( Weapons[i].objnum == -1 )			// shouldn't happen, but this is the safe thing to do.
-					continue;
-				if ( ((loop_count || crw_status[i] == CRW_NO_PAIR)) && (Weapons[i].lifeleft < oldest_time) ) {
-					oldest_time = Weapons[i].lifeleft;
-					oldest_index = i;
-				}
-			}
-			if ( oldest_index != -1 ) {
-				obj_delete(Weapons[oldest_index].objnum);
-				num_deleted++;
-			}
-		}
-
-		// if we deleted some weapons, then we can break
-		if ( num_deleted )
-			break;
-
-		loop_count++;
-	} while ( loop_count < 2);
-
+	// stop here because any other weapon could currently be involved in a collision and can cause crashes
 	return num_deleted;
 
 }

--- a/code/object/object.h
+++ b/code/object/object.h
@@ -231,7 +231,7 @@ void obj_shutdown();
 //object.  Returns 0 if failed, otherwise object index.
 //You can pass 0 for parent if you don't care about that.
 //You can pass null for orient and/or pos if you don't care.
-int obj_create(ubyte type,int parent_obj, int instance, matrix * orient, vec3d * pos, float radius, const flagset<Object::Object_Flags> &flags );
+int obj_create(ubyte type,int parent_obj, int instance, matrix * orient, vec3d * pos, float radius, const flagset<Object::Object_Flags> &flags, bool essential = true );
 
 void obj_render(object* obj);
 

--- a/code/weapon/beam.cpp
+++ b/code/weapon/beam.cpp
@@ -488,8 +488,7 @@ int beam_fire(beam_fire_info *fire_info)
 	objnum = obj_create(OBJ_BEAM, ((fire_info->shooter != NULL) ? OBJ_INDEX(fire_info->shooter) : -1), BEAM_INDEX(new_item), &vmd_identity_matrix, &vmd_zero_vector, 1.0f, default_flags);
 	if(objnum < 0){
 		beam_delete(new_item);
-		nprintf(("General", "obj_create() failed for beam weapon! bah!\n"));
-		Int3();
+		mprintf(("obj_create() failed for a beam weapon because you are running out of object slots!\n"));
 		return -1;
 	}
 	new_item->objnum = objnum;

--- a/code/weapon/shockwave.cpp
+++ b/code/weapon/shockwave.cpp
@@ -151,7 +151,7 @@ int shockwave_create(int parent_objnum, vec3d* pos, shockwave_create_info* sci, 
 	orient = vmd_identity_matrix;
 	vm_angles_2_matrix(&orient, &sw->rot_angles);
     flagset<Object::Object_Flags> tmp_flags;
-	objnum = obj_create( OBJ_SHOCKWAVE, real_parent, i, &orient, &sw->pos, sw->outer_radius, tmp_flags + Object::Object_Flags::Renders);
+	objnum = obj_create( OBJ_SHOCKWAVE, real_parent, i, &orient, &sw->pos, sw->outer_radius, tmp_flags + Object::Object_Flags::Renders, false );
 
 	if ( objnum == -1 ){
 		Int3();

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -5690,13 +5690,9 @@ int weapon_create( vec3d * pos, matrix * porient, int weapon_type, int parent_ob
 	num_deleted = 0;
 	if (Num_weapons >= MAX_WEAPONS-5) {
 
-		//No, do remove for AI ships -- MK, 3/12/98  // don't need to try and delete weapons for ai ships
-		//if ( !(Objects[parent_objnum].flags[Object::Object_Flags::Player_ship]) )
-		//	return -1;
-
 		num_deleted = collide_remove_weapons();
 
-		nprintf(("WARNING", "Deleted %d weapons because of lack of slots\n", num_deleted));
+		mprintf(("Deleted %d weapons because of lack of slots.\n", num_deleted));
 		if (num_deleted == 0){
 			return -1;
 		}
@@ -5775,7 +5771,11 @@ int weapon_create( vec3d * pos, matrix * porient, int weapon_type, int parent_ob
 		objnum = obj_create( OBJ_WEAPON, parent_objnum, n, orient, pos, 2.0f, default_flags, false);
 	}
 
-	Assert(objnum >= 0);
+	if (objnum < 0) {
+		mprintf(("A weapon failed to be created because FSO is running out of object slots!\n"));
+		return -1;
+	}
+
 	objp = &Objects[objnum];
 
 	// Create laser n!

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -5764,12 +5764,7 @@ int weapon_create( vec3d * pos, matrix * porient, int weapon_type, int parent_ob
 
 	// mark this object creation as essential, if it is created by a player.  
 	// You don't want players mysteriously wondering why they aren't firing.
-	if (parent_objp->flags[Object::Object_Flags::Player_ship]) {
-		objnum = obj_create( OBJ_WEAPON, parent_objnum, n, orient, pos, 2.0f, default_flags);
-	}
-	else {
-		objnum = obj_create( OBJ_WEAPON, parent_objnum, n, orient, pos, 2.0f, default_flags, false);
-	}
+		objnum = obj_create( OBJ_WEAPON, parent_objnum, n, orient, pos, 2.0f, default_flags, parent_objp->flags[Object::Object_Flags::Player_ship]);
 
 	if (objnum < 0) {
 		mprintf(("A weapon failed to be created because FSO is running out of object slots!\n"));

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -5766,7 +5766,15 @@ int weapon_create( vec3d * pos, matrix * porient, int weapon_type, int parent_ob
 	if (wip->wi_flags[Weapon::Info_Flags::Can_damage_shooter])
 		default_flags.set(Object::Object_Flags::Collides_with_parent);
 
-	objnum = obj_create( OBJ_WEAPON, parent_objnum, n, orient, pos, 2.0f, default_flags);
+	// mark this object creation as essential, if it is created by a player.  
+	// You don't want players mysteriously wondering why they aren't firing.
+	if (parent_objp->flags[Object::Object_Flags::Player_ship]) {
+		objnum = obj_create( OBJ_WEAPON, parent_objnum, n, orient, pos, 2.0f, default_flags);
+	}
+	else {
+		objnum = obj_create( OBJ_WEAPON, parent_objnum, n, orient, pos, 2.0f, default_flags, false);
+	}
+
 	Assert(objnum >= 0);
 	objp = &Objects[objnum];
 


### PR DESCRIPTION
This does three things.  1) It changes an INT3 and an Assertion that can be triggered if there are not enough object slots to debug log statements. 2) It removes some of the problematic logic that was causing crashes when trying to clear weapons when short on slots.  Previously, if none of the "safe" weapons could be removed, then it would resort to the oldest weapon, which could be colliding!  (this crash started my 4 hour search two nights ago)  3) It allows object creation to fail on purpose for certain types of objects like fireballs and asteroids instead of forcing weapons to be removed for them, if there are only 10 object slots remaining.

These changes are no longer urgent due to @Baezon's changes to how debris is being culled.  But they are still important changes until if/when objects would be made dynamic to stabilize future builds if another bug like that is introduced.

Closes #3361 

PS: I first encountered the removing the colliding weapon bug during BP's Icarus, previous to Asteroth's changes, and hit it very early in the second scene the first time running it. This prevented the collision bug from reappearing after trying Icarus 6 more times.