### PR TITLE
Allow Fred to Edit and Allow Command briefs in FRED

### DIFF
--- a/fred2/fredview.cpp
+++ b/fred2/fredview.cpp
@@ -4369,7 +4369,7 @@ void CFREDView::OnUpdateDisableUndo(CCmdUI* pCmdUI)
 
 void CFREDView::OnUpdateCmdBrief(CCmdUI* pCmdUI) 
 {
-	pCmdUI->Enable(!(The_mission.game_type & MISSION_TYPE_MULTI));
+	pCmdUI->Enable(true);
 }
 
 int get_visible_sub_system_count(ship *shipp)

--- a/fred2/missionsave.cpp
+++ b/fred2/missionsave.cpp
@@ -1371,9 +1371,6 @@ int CFred_mission_save::save_cmd_brief()
 	required_string_fred("#Command Briefing");
 	parse_comments(2);
 
-	if (The_mission.game_type & MISSION_TYPE_MULTI)
-		return err;  // no command briefings allowed in multiplayer missions.
-
 	save_custom_bitmap("$Background 640:", "$Background 1024:", Cur_cmd_brief->background[GR_640], Cur_cmd_brief->background[GR_1024], 1);
 
 	for (stage = 0; stage < Cur_cmd_brief->num_stages; stage++) {

--- a/qtfred/src/mission/missionsave.cpp
+++ b/qtfred/src/mission/missionsave.cpp
@@ -1134,10 +1134,6 @@ int CFred_mission_save::save_cmd_brief()
 	required_string_fred("#Command Briefing");
 	parse_comments(2);
 
-	if (The_mission.game_type & MISSION_TYPE_MULTI) {
-		return err;
-	}  // no command briefings allowed in multiplayer missions.
-
 	save_custom_bitmap("$Background 640:",
 					   "$Background 1024:",
 					   Cur_cmd_brief->background[GR_640],


### PR DESCRIPTION
They are currently allowed in the game, but not being allowed in Fred was an oversight of mine.

Tested and it works as expected.  A TVT mission will also load if it has a command brief defined, even though TVT will not show the command brief in-game.

As it's already allowed in-game, this should probably get into stable.