### PR TITLE
Make an invalid variable name throw an error.

### DIFF
--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -3391,7 +3391,9 @@ void get_sexp_text_for_variable(char *text, const char *token)
 	if ( !Fred_running ) {
 		// freespace - get index into Sexp_variables array
 		sexp_var_index = get_index_sexp_variable_name(text);
-		Assert(sexp_var_index != -1);
+		if (sexp_var_index == -1) {
+			Error(LOCATION, "Invalid variable name [%s]!", text);
+		}
 		sprintf(text, "%d", sexp_var_index);
 	}
 }


### PR DESCRIPTION
There were a few assertions in the SEXP code that would trip if an invalid variable name were specified in a SEXP, but nothing that actually stopped a Release build from performing an out-of-bounds array access if someone made a typo in notepad. Since, as far as I could tell, everything should go through `get_sexp_text_for_variable()` first, I changed its `Assert()` into an `Error()` that should hopefully ensure that we avoid ever doing anything with `Sexp_variables[-1]`.