### PR TITLE
add new popup type to handle mission/table validation

### DIFF
--- a/code/network/multi_fstracker.cpp
+++ b/code/network/multi_fstracker.cpp
@@ -1308,7 +1308,7 @@ int multi_fs_tracker_validate_game_data()
 
 		// now check with tracker
 
-		if ( !Is_standalone ) {
+		if ( !(Game_mode & GM_STANDALONE_SERVER) ) {
 			popup_conditional_create(0, XSTR("&Cancel", 667), XSTR("Validating tables ...", -1));
 		}
 
@@ -1330,7 +1330,7 @@ int multi_fs_tracker_validate_game_data()
 			}
 		}
 
-		if ( !Is_standalone) {
+		if ( !(Game_mode & GM_STANDALONE_SERVER) ) {
 			popup_conditional_close();
 		}
 

--- a/code/network/multi_fstracker.cpp
+++ b/code/network/multi_fstracker.cpp
@@ -1323,6 +1323,11 @@ int multi_fs_tracker_validate_game_data()
 			else if (rval == TVALID_STATUS_INVALID) {
 				game_data_status = TVALID_STATUS_INVALID;
 			}
+			// if the popup was canceled then force a recheck on next attempt
+			else if (rval == -2) {
+				game_data_status = TVALID_STATUS_UNKNOWN;
+				break;
+			}
 		}
 
 		if ( !Is_standalone) {

--- a/code/network/multi_fstracker.cpp
+++ b/code/network/multi_fstracker.cpp
@@ -1126,7 +1126,7 @@ int multi_fs_tracker_validate_mission(char *filename)
 		SDL_snprintf(popup_string, SDL_arraysize(popup_string), XSTR("Validating mission %s", 1074), filename);
 
 		// run a popup
-		switch(popup_till_condition(multi_fs_tracker_validate_mission_normal, XSTR("&Cancel", 667), popup_string)){
+		switch ( popup_conditional_do(multi_fs_tracker_validate_mission_normal, popup_string) ) {
 		// cancel 
 		case 0: 
 			// bash some API values here so that next time we try and verify, everything works
@@ -1242,7 +1242,7 @@ int multi_fs_tracker_validate_table(const char *filename)
 		SDL_snprintf(popup_string, SDL_arraysize(popup_string), XSTR("Validating table %s", -1), filename);
 
 		// run a popup
-		switch ( popup_till_condition(multi_fs_tracker_validate_table_normal, XSTR("&Cancel", 667), popup_string) ) {
+		switch ( popup_conditional_do(multi_fs_tracker_validate_table_normal, popup_string) ) {
 			// cancel
 			case 0:
 				TableValidState = VALID_STATE_IDLE;
@@ -1308,7 +1308,11 @@ int multi_fs_tracker_validate_game_data()
 
 		// now check with tracker
 
-		for (auto tbl : table_list) {
+		if ( !Is_standalone ) {
+			popup_conditional_create(0, XSTR("&Cancel", 667), XSTR("Validating tables ...", -1));
+		}
+
+		for (auto &tbl : table_list) {
 			rval = multi_fs_tracker_validate_table( tbl.c_str() );
 
 			// if anything is valid then update our default
@@ -1319,6 +1323,10 @@ int multi_fs_tracker_validate_game_data()
 			else if (rval == TVALID_STATUS_INVALID) {
 				game_data_status = TVALID_STATUS_INVALID;
 			}
+		}
+
+		if ( !Is_standalone) {
+			popup_conditional_close();
 		}
 
 		// we should hopefully have a mod id now, so log it

--- a/code/network/multiutil.cpp
+++ b/code/network/multiutil.cpp
@@ -3074,6 +3074,10 @@ void multi_update_valid_missions()
 	// now poll for all unknown missions
 	was_cancelled = false;
 
+	if ( !Is_standalone ) {
+		popup_conditional_create(0, XSTR("&Cancel", 667), XSTR("Validating missions ...", -1));
+	}
+
 	for (idx = 0; idx < Multi_create_mission_list.size(); idx++) {
 		if (Multi_create_mission_list[idx].valid_status != MVALID_STATUS_UNKNOWN) {
 			continue;
@@ -3087,6 +3091,10 @@ void multi_update_valid_missions()
 		}
 
 		Multi_create_mission_list[idx].valid_status = (char)rval;
+	}
+
+	if ( !Is_standalone) {
+		popup_conditional_close();
 	}
 
 	// if the operation was cancelled, don't write anything new

--- a/code/network/multiutil.cpp
+++ b/code/network/multiutil.cpp
@@ -3074,7 +3074,7 @@ void multi_update_valid_missions()
 	// now poll for all unknown missions
 	was_cancelled = false;
 
-	if ( !Is_standalone ) {
+	if ( !(Game_mode & GM_STANDALONE_SERVER) ) {
 		popup_conditional_create(0, XSTR("&Cancel", 667), XSTR("Validating missions ...", -1));
 	}
 
@@ -3093,7 +3093,7 @@ void multi_update_valid_missions()
 		Multi_create_mission_list[idx].valid_status = (char)rval;
 	}
 
-	if ( !Is_standalone) {
+	if ( !(Game_mode & GM_STANDALONE_SERVER) ) {
 		popup_conditional_close();
 	}
 

--- a/code/popup/popup.cpp
+++ b/code/popup/popup.cpp
@@ -1183,7 +1183,7 @@ bool popup_conditional_create(int flags, ...)
 	va_list args;
 
 	if (Popup_is_active) {
-		Int3();
+		UNREACHABLE("Can't create a conditional popup while another popup is open!");
 		return false;
 	}
 
@@ -1225,7 +1225,8 @@ bool popup_conditional_create(int flags, ...)
 
 int popup_conditional_do(int (*condition)(), const char *text)
 {
-	int choice = -1, done = 0;
+	int choice = -1;
+	bool done = false;
 	int k, test;
 	bool self_popup = false;
 
@@ -1264,21 +1265,21 @@ int popup_conditional_do(int (*condition)(), const char *text)
 
 		// test the condition function or process for the window
 		if ((test = condition()) > 0) {
-			done = 1;
+			done = true;
 			choice = test;
 		} else {
 			k = Popup_window.process();						// poll for input, handle mouse
 			choice = popup_process_keys(&Popup_info, k, Popup_flags);
 
 			if (choice != POPUP_NOCHANGE) {
-				done = 1;
+				done = true;
 			}
 
 			if ( !done ) {
 				choice = popup_check_buttons(&Popup_info);
 
 				if (choice != POPUP_NOCHANGE) {
-					done = 1;
+					done = true;
 				}
 			}
 		}

--- a/code/popup/popup.cpp
+++ b/code/popup/popup.cpp
@@ -1293,7 +1293,7 @@ int popup_conditional_do(int (*condition)(), const char *text)
 
 	switch (choice) {
 		case POPUP_ABORT:
-			return -1;
+			return 0;
 
 		default:
 			return choice;

--- a/code/popup/popup.cpp
+++ b/code/popup/popup.cpp
@@ -125,6 +125,7 @@ static int Popup_should_die=0;			// popup should quit during the next iteration 
 
 static popup_info Popup_info;
 static int Popup_flags;
+static int Popup_screen_id = -1;
 
 static int Title_coords[GR_NUM_RESOLUTIONS][5] =
 {
@@ -1172,4 +1173,140 @@ void popup_change_text(const char *new_text)
 void popup_game_feature_not_in_demo()
 {
 	popup(PF_USE_AFFIRMATIVE_ICON|PF_BODY_BIG, 1, POPUP_OK, XSTR( "Sorry, this feature is available only in the retail version", 200));
+}
+
+// the same as popup_till_condition(), but split into separate parts such that
+// it can run multiple conditions with a single popup
+bool popup_conditional_create(int flags, ...)
+{
+	char *format, *s;
+	va_list args;
+
+	if (Popup_is_active) {
+		Int3();
+		return false;
+	}
+
+	flags = 0;	// no flags supported at this time
+
+	Popup_info.nchoices = 1;
+
+	Popup_flags = flags;
+
+	va_start(args, flags);
+
+	// get button text
+	s = va_arg(args, char *);
+	Popup_info.button_text[0] = nullptr;
+	popup_maybe_assign_keypress(&Popup_info, 0, s);
+
+	// get msg text
+	format = va_arg( args, char * );
+	vsnprintf(Popup_info.raw_text, sizeof(Popup_info.raw_text)-1, format, args);
+	Popup_info.raw_text[sizeof(Popup_info.raw_text)-1] = '\0';
+
+	va_end(args);
+
+	gamesnd_play_iface(InterfaceSounds::POPUP_APPEAR); 	// play sound when popup appears
+
+	io::mouse::CursorManager::get()->pushStatus();
+	io::mouse::CursorManager::get()->showCursor(true);
+	Popup_is_active = 1;
+
+	Popup_screen_id = gr_save_screen();
+
+	if ( popup_init(&Popup_info, flags) == -1 ) {
+		popup_conditional_close();
+		return false;
+	}
+
+	return true;
+}
+
+int popup_conditional_do(int (*condition)(), const char *text)
+{
+	int choice = -1, done = 0;
+	int k, test;
+	bool self_popup = false;
+
+	// if no popup, create a default
+	if ( !Popup_is_active ) {
+		if ( !popup_conditional_create(0, XSTR("&Cancel", 667), text ? text : "") ) {
+			return -1;
+		}
+
+		self_popup = true;
+	} else if (text) {
+		popup_change_text(text);
+	}
+
+	int old_max_w_unscaled = gr_screen.max_w_unscaled;
+	int old_max_h_unscaled = gr_screen.max_h_unscaled;
+	int old_max_w_unscaled_zoomed = gr_screen.max_w_unscaled_zoomed;
+	int old_max_h_unscaled_zoomed = gr_screen.max_h_unscaled_zoomed;
+
+	gr_reset_screen_scale();
+
+
+	while ( !done ) {
+		os_poll();
+
+		game_set_frametime(-1);
+		game_do_state_common(gameseq_get_state());	// do stuff common to all states
+		gr_restore_screen(Popup_screen_id);
+
+		// draw one frame first
+		Popup_window.draw();
+		popup_force_draw_buttons(&Popup_info);
+		popup_draw_msg_text(&Popup_info, Popup_flags);
+		popup_draw_button_text(&Popup_info, Popup_flags);
+		gr_flip();
+
+		// test the condition function or process for the window
+		if ((test = condition()) > 0) {
+			done = 1;
+			choice = test;
+		} else {
+			k = Popup_window.process();						// poll for input, handle mouse
+			choice = popup_process_keys(&Popup_info, k, Popup_flags);
+
+			if (choice != POPUP_NOCHANGE) {
+				done = 1;
+			}
+
+			if ( !done ) {
+				choice = popup_check_buttons(&Popup_info);
+
+				if (choice != POPUP_NOCHANGE) {
+					done = 1;
+				}
+			}
+		}
+	}
+
+	gr_set_screen_scale(old_max_w_unscaled, old_max_h_unscaled, old_max_w_unscaled_zoomed, old_max_h_unscaled_zoomed);
+
+	// close popup if we created it here
+	if (self_popup) {
+		popup_conditional_close();
+	}
+
+	switch (choice) {
+		case POPUP_ABORT:
+			return -1;
+
+		default:
+			return choice;
+	}
+}
+
+void popup_conditional_close()
+{
+	if ( !Popup_is_active ) {
+		return;
+	}
+
+	popup_close(&Popup_info, Popup_screen_id);
+
+	io::mouse::CursorManager::get()->popStatus();
 }

--- a/code/popup/popup.h
+++ b/code/popup/popup.h
@@ -110,4 +110,9 @@ void popup_change_text(const char *new_text);
 // Used if certain data is missing (e.g. running demo data).
 void popup_game_feature_not_in_demo();
 
+// create a popup which can test multiple conditions in a row
+bool popup_conditional_create(int flags, ...);
+void popup_conditional_close();
+int popup_conditional_do(int (*condition)(), const char *text);
+
 #endif


### PR DESCRIPTION
A new type of conditional popup which can be created, run multiple test conditions, then close. This provides an alternative to `popup_till_condition()` which simply creates a popup, runs a single test condition, then closes.

Fixes the dreaded popup sounds during mission and table validation in multi.