### PR TITLE
Turn all asinf and acosf into safe versions

### DIFF
--- a/code/graphics/opengl/gropenglpostprocessing.cpp
+++ b/code/graphics/opengl/gropenglpostprocessing.cpp
@@ -442,9 +442,9 @@ void opengl_post_lightshafts()
 			float dot;
 			if ( (dot = vm_vec_dot(&light_dir, &Eye_matrix.vec.fvec)) > 0.7f ) {
 
-				x = asinf(vm_vec_dot(&light_dir, &Eye_matrix.vec.rvec)) / PI * 1.5f +
+				x = asinf_safe(vm_vec_dot(&light_dir, &Eye_matrix.vec.rvec)) / PI * 1.5f +
 					0.5f; // cant get the coordinates right but this works for the limited glare fov
-				y = asinf(vm_vec_dot(&light_dir, &Eye_matrix.vec.uvec)) / PI * 1.5f * gr_screen.clip_aspect + 0.5f;
+				y = asinf_safe(vm_vec_dot(&light_dir, &Eye_matrix.vec.uvec)) / PI * 1.5f * gr_screen.clip_aspect + 0.5f;
 
 				opengl_set_generic_uniform_data<graphics::generic_data::lightshaft_data>(
 					[&](graphics::generic_data::lightshaft_data* data) {

--- a/code/math/floating.cpp
+++ b/code/math/floating.cpp
@@ -84,3 +84,13 @@ float golden_ratio_rand() {
 		accum_golden_ratio_rand_seed -= 1.0f;
 	return accum_golden_ratio_rand_seed;
 }
+
+float acosf_safe(float x) {
+	CLAMP(x, -1.f, 1.f);
+	return acosf(x);
+}
+
+float asinf_safe(float x) {
+	CLAMP(x, -1.f, 1.f);
+	return asinf(x);
+}

--- a/code/math/floating.h
+++ b/code/math/floating.h
@@ -117,4 +117,8 @@ const float GOLDEN_RATIO = 0.618033989f;
 
 float golden_ratio_rand();
 
+// clamps the input to -1, 1 to avoid floating point error putting it outside that range
+float acosf_safe(float x);
+float asinf_safe(float x);
+
 #endif

--- a/code/math/vecmat.cpp
+++ b/code/math/vecmat.cpp
@@ -586,33 +586,11 @@ float vm_vec_delta_ang_norm(const vec3d *v0, const vec3d *v1, const vec3d *uvec)
 	float a;
 	vec3d t;
 
-	a = acosf(vm_vec_dot(v0,v1));
+	a = acosf_safe(vm_vec_dot(v0,v1));
 
 	if (uvec) {
 		vm_vec_cross(&t,v0,v1);
 		if ( vm_vec_dot(&t,uvec) < 0.0 )	{
-			a = -a;
-		}
-	}
-
-	return a;
-}
-
-float vm_vec_delta_ang_norm_safe(const vec3d *v0, const vec3d *v1, const vec3d *uvec)
-{
-	float a, dot;
-	vec3d t;
-
-	// to avoid round-off errors...
-	// testing produced a dot of 1.00000012 which evaluates to an angle of -nan(ind)
-	dot = vm_vec_dot(v0, v1);
-	CLAMP(dot, -1.0f, 1.0f);
-
-	a = acosf(dot);
-
-	if (uvec) {
-		vm_vec_cross(&t,v0,v1);
-		if ( vm_vec_dot(&t,uvec) < 0.0 ) {
 			a = -a;
 		}
 	}
@@ -977,21 +955,11 @@ angles *vm_extract_angles_matrix_alternate(angles *a, const matrix *m)
 	Assert(a != NULL);
 	Assert(m != NULL);
 
-	// Extract pitch from m32, being careful for domain errors with
-	// asin().  We could have values slightly out of range due to
-	// floating point arithmetic.
-	float sp = -m->vec.fvec.xyz.y;
-	if (sp <= -1.0f) {
-		a->p = -PI_2;	// -pi/2
-	} else if (sp >= 1.0f) {
-		a->p = PI_2;	// pi/2
-	} else {
-		a->p = asinf(sp);
-	}
+	a->p = asinf_safe(-m->vec.fvec.xyz.y);
 
 	// Check for the Gimbal lock case, giving a slight tolerance
 	// for numerical imprecision
-	if (fabs(sp) > 0.9999f) {
+	if (fabs(m->vec.fvec.xyz.y) > 0.9999f) {
 		// We are looking straight up or down.
 		// Slam bank to zero and just set heading
 		a->b = 0.0f;
@@ -1014,7 +982,7 @@ static angles *vm_extract_angles_vector_normalized(angles *a, const vec3d *v)
 
 	a->b = 0.0f;		//always zero bank
 
-	a->p = asinf(-v->xyz.y);
+	a->p = asinf_safe(-v->xyz.y);
 
 	a->h = atan2_safe(v->xyz.z,v->xyz.x);
 
@@ -1567,7 +1535,7 @@ void vm_matrix_to_rot_axis_and_angle(const matrix *m, float *theta, vec3d *rot_a
 
 		vm_vec_make(rot_axis, 1.0f, 0.0f, 0.0f);
 	} else if (cos_theta > -0.999999875f) { // angle is within limits between 0 and PI
-		*theta = acosf(cos_theta);
+		*theta = acosf_safe(cos_theta);
 		Assert( !fl_is_nan(*theta) );
 
 		rot_axis->xyz.x = (m->vec.uvec.xyz.z - m->vec.fvec.xyz.y);
@@ -1988,7 +1956,7 @@ void vm_angular_move_forward_vec(const vec3d* goal_f, const matrix* orient, cons
 		vm_vec_rotate(&local_rot_axis, &rot_axis, orient);
 
 		// derive theta from sin(theta) for better accuracy
-		vm_vec_copy_scale(&theta_goal, &local_rot_axis, (cos_theta > 0 ? asinf(sin_theta) : PI - asinf(sin_theta)) / sin_theta);
+		vm_vec_copy_scale(&theta_goal, &local_rot_axis, (cos_theta > 0 ? asinf_safe(sin_theta) : PI - asinf_safe(sin_theta)) / sin_theta);
 		
 		// reset z to delta_bank, because it just got cleared
 		theta_goal.xyz.z = delta_bank;
@@ -2196,7 +2164,7 @@ void vm_vec_interp_constant(vec3d *out, const vec3d *v0, const vec3d *v1, float 
 	vm_vec_normalize(&cross);
 
 	// get the total angle between the 2 vectors
-	total_ang = -(acosf(vm_vec_dot(v0, v1)));
+	total_ang = -(acosf_safe(vm_vec_dot(v0, v1)));
 
 	// rotate around the cross product vector by the appropriate angle
 	vm_rot_point_around_line(out, v0, t * total_ang, &vmd_zero_vector, &cross);

--- a/code/math/vecmat.h
+++ b/code/math/vecmat.h
@@ -237,7 +237,6 @@ float vm_vec_delta_ang(const vec3d *v0, const vec3d *v1, const vec3d *uvec);
 
 //computes the delta angle between two normalized vectors.
 float vm_vec_delta_ang_norm(const vec3d *v0, const vec3d *v1,const vec3d *uvec);
-float vm_vec_delta_ang_norm_safe(const vec3d *v0, const vec3d *v1, const vec3d *uvec);
 
 //computes a matrix from a set of three angles.  returns ptr to matrix
 matrix *vm_angles_2_matrix(matrix *m, const angles *a);

--- a/code/model/modelread.cpp
+++ b/code/model/modelread.cpp
@@ -3649,7 +3649,7 @@ void submodel_look_at(polymodel *pm, polymodel_instance *pmi, int submodel_num)
 	model_instance_find_world_dir(&rotated_vec, &sm->frame_of_reference.vec.fvec, pm, pmi, sm->parent, &vmd_identity_matrix);
 	vm_vec_sub(&dir, &planar_dst, &world_pos);
 	vm_vec_normalize(&dir);
-	smi->cur_angle = vm_vec_delta_ang_norm_safe(&rotated_vec, &dir, &world_axis);
+	smi->cur_angle = vm_vec_delta_ang_norm(&rotated_vec, &dir, &world_axis);
 
 	// apply an offset to the angle, since the direction we look at may be different than the default orientation!
 	// if we have not specified an offset in the POF, assume that the very first time we call submodel_look_at, the submodel is pointing in the correct direction
@@ -3770,7 +3770,7 @@ int model_rotate_gun(object *objp, polymodel *pm, polymodel_instance *pmi, ship_
 		model_instance_find_world_dir(&rotated_vec, &base_sm->frame_of_reference.vec.fvec, pm, pmi, base_sm->parent, &objp->orient);
 		vm_vec_sub(&dir, &planar_dst, &world_pos);
 		vm_vec_normalize(&dir);
-		desired_base_angle = vm_vec_delta_ang_norm_safe(&rotated_vec, &dir, &world_axis);
+		desired_base_angle = vm_vec_delta_ang_norm(&rotated_vec, &dir, &world_axis);
 
 		//------------
 		// Pretend the base is pointing directly at the target
@@ -3790,7 +3790,7 @@ int model_rotate_gun(object *objp, polymodel *pm, polymodel_instance *pmi, ship_
 		model_instance_find_world_dir(&rotated_vec, &gun_sm->frame_of_reference.vec.uvec, pm, pmi, gun_sm->parent, &objp->orient);
 		vm_vec_sub(&dir, &planar_dst, &world_pos);
 		vm_vec_normalize(&dir);
-		desired_gun_angle = vm_vec_delta_ang_norm_safe(&rotated_vec, &dir, &world_axis);
+		desired_gun_angle = vm_vec_delta_ang_norm(&rotated_vec, &dir, &world_axis);
 		// for ventral turrets without custom matrixes
 		if (vm_vec_dot(&gun_sm->frame_of_reference.vec.uvec, &turret->turret_norm) < 0.0f) {
 			desired_gun_angle = PI + desired_gun_angle;

--- a/code/radar/radar.cpp
+++ b/code/radar/radar.cpp
@@ -389,7 +389,7 @@ void HudGaugeRadarStd::plotBlip(blip *b, int *x, int *y)
 	if (b->dist < pos->xyz.z) {
 		rscale = 0.0f;
 	} else {
-		rscale = (float) acosf(pos->xyz.z / b->dist) / PI;
+		rscale = (float) acosf_safe(pos->xyz.z / b->dist) / PI;
 	}
 
 	zdist = hypotf(pos->xyz.x, pos->xyz.y);

--- a/code/radar/radarorb.cpp
+++ b/code/radar/radarorb.cpp
@@ -336,7 +336,7 @@ int HudGaugeRadarOrb::calcAlpha(vec3d* pt)
     vm_vec_normalize(&new_pt);
 
     float dot = vm_vec_dot(&fvec, &new_pt);
-    float angle = fabs(acosf(dot));
+    float angle = fabs(acosf_safe(dot));
     int alpha = int(angle*192.0f/PI);
     
     return alpha;

--- a/code/weapon/swarm.cpp
+++ b/code/weapon/swarm.cpp
@@ -227,7 +227,7 @@ void swarm_update_direction(object *objp, swarm_info* swarmp)
 			missile_dist = missile_speed * zig_zag_time / 1000.0f;
 			if (missile_dist < SWARM_DIST_OFFSET)
 				missile_dist = SWARM_DIST_OFFSET;
-			float angle_offset = asinf(SWARM_DIST_OFFSET / missile_dist);
+			float angle_offset = asinf_safe(SWARM_DIST_OFFSET / missile_dist);
 			Assert(!fl_is_nan(angle_offset));
 
 			// Radius around the target pos. Shortens as the missiles get closer to the target.


### PR DESCRIPTION
Goober added `vm_vec_delta_ang_norm_safe` to clamp the input of an `acosf` because floating point inaccuracy can sometimes produce numbers slightly greater than 1 or less than 1. After I ran into the exact same problem in `vm_vec_interp_constant` I think it's clear this is not specific to that particular usage, and instead all the `asinf`s and `acosf`s should be sanitized when used.

This also removes the occasional inconsistent bounds checking a few of their callers already did, so it can be made consistent for all usages.