### PR TITLE
Fix variable replacement in text in briefings and debriefings

### DIFF
--- a/code/missionui/missionbrief.cpp
+++ b/code/missionui/missionbrief.cpp
@@ -789,14 +789,17 @@ void brief_set_default_closeup()
  */
 void brief_compact_stages()
 {
-	int num, before, result, i;
+	int num, before, i;
 
 	before = Briefing->num_stages;
 
 	num = 0;
 	while ( num < Briefing->num_stages ) {
-		result = eval_sexp( Briefing->stages[num].formula );
-		if ( !result ) {
+		if ( eval_sexp(Briefing->stages[num].formula) ) {
+			// Goober5000 - replace any variables (probably persistent variables) with their values
+			sexp_replace_variable_names_with_values(Briefing->stages[num].text);
+		} else {
+			// clean up unused briefing stage
 			Briefing->stages[num].text = "";
 
 			if ( Briefing->stages[num].icons != NULL ) {
@@ -856,10 +859,6 @@ void brief_init()
 	} else {
 		Briefing = &Briefings[0];			
 	}
-
-	// Goober5000 - replace any variables (probably persistent variables) with their values
-	for (i = 0; i < Briefing->num_stages; i++)
-		sexp_replace_variable_names_with_values(Briefing->stages[i].text);
 
 	Brief_last_auto_advance = 0;
 

--- a/code/missionui/missionbrief.cpp
+++ b/code/missionui/missionbrief.cpp
@@ -838,8 +838,6 @@ void brief_compact_stages()
 //
 void brief_init()
 {
-	int i;
-
 	// for multiplayer, change the state in my netplayer structure
 	// and initialize the briefing chat area thingy
 	if ( Game_mode & GM_MULTIPLAYER ){

--- a/code/missionui/missiondebrief.cpp
+++ b/code/missionui/missiondebrief.cpp
@@ -1890,8 +1890,6 @@ static void debrief_init_music()
 
 void debrief_init()
 {
-	int i;
-
 	Assert(!Debrief_inited);
 //	Campaign.loop_enabled = 0;
 	Campaign.loop_mission = CAMPAIGN_LOOP_MISSION_UNINITIALIZED;

--- a/code/missionui/missiondebrief.cpp
+++ b/code/missionui/missiondebrief.cpp
@@ -699,6 +699,9 @@ void debrief_set_multi_clients( int stage_count, int active_stages[] )
 	// set the pointers to the debriefings for this client
 	for (i = 0; i < stage_count; i++) {
 		Debrief_stages[Num_debrief_stages++] = &Debriefing->stages[active_stages[i]];
+		// in multi, debriefing text replacement must occur client-side
+		// update most recently added stage only, in case replacement has side effects
+		debrief_replace_stage_text(*Debrief_stages[Num_debrief_stages - 1]);
 	}
 
 	Debrief_multi_stages_loaded = 1;

--- a/code/missionui/missiondebrief.cpp
+++ b/code/missionui/missiondebrief.cpp
@@ -460,6 +460,7 @@ int Debrief_award_text_num_lines = 0;
 // prototypes, you know you love 'em
 void debrief_add_award_text(const char *str);
 void debrief_award_text_clear();
+void debrief_replace_stage_text(debrief_stage &stage);
 
 
 
@@ -720,6 +721,8 @@ void debrief_multi_server_stuff()
 		stages[i] = stage_active[i];
 		for (j=0; j<debriefp->num_stages; j++) {
 			if ( eval_sexp(debriefp->stages[j].formula) ) {
+				// DISCUSSME: how to handle repeatedly evaluating SEXPs that have side effects?
+				// DISCUSSME: at what point should we replace text?
 				stage_active[i][num_stages] = j;
 				num_stages++;
 			}
@@ -780,7 +783,9 @@ int debrief_set_stages_and_multi_stuff()
 	}
 
 	for (i=0; i<debriefp->num_stages; i++) {
+		// DISCUSSME: is SEXP_TRUE the only acceptable value? What about SEXP_KNOWN_TRUE?
 		if (eval_sexp(debriefp->stages[i].formula) == 1) {
+			debrief_replace_stage_text(debriefp->stages[i]);
 			Debrief_stages[Num_debrief_stages++] = &debriefp->stages[i];
 		}
 	}
@@ -1901,12 +1906,6 @@ void debrief_init()
 		Debriefing = &Debriefings[0];			
 	}
 
-	// Goober5000 - replace any variables with their values
-	for (i = 0; i < Debriefing->num_stages; i++) {
-		sexp_replace_variable_names_with_values(Debriefing->stages[i].text);
-		sexp_replace_variable_names_with_values(Debriefing->stages[i].recommendation_text);
-	}
-
 	// no longer is mission
 	Game_mode &= ~(GM_IN_MISSION);	
 
@@ -2558,4 +2557,11 @@ void debrief_handle_player_drop()
 
 void debrief_disable_accept()
 {
+}
+
+// Goober5000 - replace any variables with their values
+void debrief_replace_stage_text(debrief_stage &stage)
+{
+	sexp_replace_variable_names_with_values(stage.text);
+	sexp_replace_variable_names_with_values(stage.recommendation_text);
 }

--- a/code/missionui/missiondebrief.cpp
+++ b/code/missionui/missiondebrief.cpp
@@ -721,8 +721,6 @@ void debrief_multi_server_stuff()
 		stages[i] = stage_active[i];
 		for (j=0; j<debriefp->num_stages; j++) {
 			if ( eval_sexp(debriefp->stages[j].formula) ) {
-				// DISCUSSME: how to handle repeatedly evaluating SEXPs that have side effects?
-				// DISCUSSME: at what point should we replace text?
 				stage_active[i][num_stages] = j;
 				num_stages++;
 			}
@@ -783,8 +781,8 @@ int debrief_set_stages_and_multi_stuff()
 	}
 
 	for (i=0; i<debriefp->num_stages; i++) {
-		// DISCUSSME: is SEXP_TRUE the only acceptable value? What about SEXP_KNOWN_TRUE?
-		if (eval_sexp(debriefp->stages[i].formula) == 1) {
+		if (eval_sexp(debriefp->stages[i].formula) == SEXP_TRUE) {
+			// replacement in single-player and for host/server in multi
 			debrief_replace_stage_text(debriefp->stages[i]);
 			Debrief_stages[Num_debrief_stages++] = &debriefp->stages[i];
 		}


### PR DESCRIPTION
As reported by @Karajorma in https://www.hard-light.net/forums/index.php?topic=97412.msg1909252#msg1909252 text replacement for variables in briefings/debriefings doesn't take into account the effects of evaluating SEXPs used to determine whether to include the  briefing/debriefing stage.

This PR moves text replacement for variables so that it's applied on a per-stage basis and only if the stage is selected for inclusion (i.e., if its SEXP formula evaluates to true).

**Gotchas**:
1. Text replacement in multi assumes that variables and variable operations (e.g., modify) are replicated on all clients. The same will apply to SEXP containers, once those are added.
2. Debriefing SEXPs are unavoidably evaluated server-side multiple times: once for *every* team in `debrief_multi_server_stuff()`, and then, if the server is not a standalone, *again* in `debrief_set_stages_and_multi_stuff()`. Therefore, **debriefing SEXPs in multi missions *should not* have side effects.**
3. Text replacement in debriefings, however, *can* have side effects in multi missions, because replacement occurs only once in both server and clients.