### PR TITLE
Fix ai update danger weapon and Add guardrails for other checks

### DIFF
--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -2349,8 +2349,9 @@ void ai_set_goal_abort_support_call(object *objp, ai_info *aip)
 		object	*repair_obj;
 
 		if (aip->support_ship_objnum == -1) {
-			repair_obj = NULL;
+			repair_obj = nullptr;
 		} else {
+			Assertion(aip->support_ship_objnum >= 0, "%s has a nonsense support_ship_objnum of %d, please report!", Ships[aip->shipnum].ship_name, aip->support_ship_objnum);
 			repair_obj = &Objects[aip->support_ship_objnum];
 		}
 		ai_do_objects_repairing_stuff( objp, repair_obj, REPAIR_INFO_ABORT );
@@ -2377,7 +2378,7 @@ void ai_attack_object(object* attacker, object* attacked, int ship_info_index)
 	ai_info* aip;
 
 	Assert(attacker != nullptr);
-	Assert(attacker->instance != -1);
+	Assert(attacker->instance >= 0);
 	Assert(Ships[attacker->instance].ai_index != -1);
 	//	Bogus!  Who tried to get me to attack myself!
 	if (attacker == attacked) {
@@ -6607,6 +6608,7 @@ float ai_get_weapon_dist(ship_weapon *swp)
 		return 1000.0f;
 	}
 
+
 	return MIN((Weapon_info[weapon_num].max_speed * Weapon_info[weapon_num].lifetime), Weapon_info[weapon_num].weapon_range);
 }
 
@@ -6624,6 +6626,8 @@ float ai_get_weapon_speed(ship_weapon *swp)
 		return 100.0f;
 	}
 
+	Assertion(weapon_num >= 0, "A ship's weapon has a nonesense index of %d, but the ship's name is not accessible from this function.  Please report!", weapon_num);
+
 	return Weapon_info[weapon_num].max_speed;
 }
 
@@ -6633,13 +6637,15 @@ weapon_info* ai_get_weapon(ship_weapon *swp)
 
 	bank_num = swp->current_primary_bank;
 	if (bank_num < 0)
-		return NULL;
+		return nullptr;
 
 	weapon_num = swp->primary_bank_weapons[bank_num];
 
 	if (weapon_num == -1) {
-		return NULL;
+		return nullptr;
 	}
+
+	Assertion(weapon_num >= 0, "A ship's weapon has a nonesense index of %d, but the ship's name is not accessible from this function.  Please report!", weapon_num);
 
 	return &Weapon_info[weapon_num];
 }
@@ -6894,6 +6900,8 @@ float ai_endangered_by_weapon(ai_info *aip)
 	if (aip->danger_weapon_objnum == -1) {
 		return -1.0f;
 	}
+
+	Assertion(aip->danger_weapon_objnum >= 0, "%s has a nonsense danger_weapon_objnum of %d. Please report!", Ships[aip->shipnum].ship_name, aip->danger_weapon_objnum);\
 
 	weapon_objp = &Objects[aip->danger_weapon_objnum];
 
@@ -7678,6 +7686,8 @@ int ai_set_attack_subsystem(object *objp, int subnum)
 	if ( aip->target_objnum == -1 )
 		return 0;
 
+	Assertion(aip->target_objnum >= 0, "The target_objnum for %s has become a nonsense value of %d. Please report!",attacker_shipp->ship_name ,aip->target_objnum);
+
 	attacked_objp = &Objects[aip->target_objnum];
 	shipp = &Ships[attacked_objp->instance];		//  need to get our target's ship pointer!!!
 
@@ -7933,6 +7943,8 @@ void ai_chase_fly_away(object *objp, ai_info *aip)
 	} else {
 		vec3d	v2e;
 		float		dot;
+		
+		Assertion(aip->target_objnum >= 0, "This ship's target objnum is nonsense. It is %d instead of a positive number or -1.", aip->target_objnum);
 
 		vm_vec_normalized_dir(&v2e, &Objects[aip->target_objnum].pos, &objp->pos);
 
@@ -12295,6 +12307,8 @@ void ai_do_repair_frame(object *objp, ai_info *aip, float frametime)
 		if (support_objnum == -1)
 			return;
 
+		Assertion(support_objnum >= 0, "The support ship objnum is nonsense. It is %d instead of a positive number or -1.", support_objnum);
+
 		//	Curious -- object numbers match, but signatures do not.
 		//	Must mean original repair ship died and was replaced by current ship.
 		Assert(Objects[support_objnum].signature == aip->support_ship_signature);
@@ -12894,7 +12908,9 @@ int ai_acquire_emerge_path(object *pl_objp, int parent_objnum, int allowed_path_
 	pnode		*pnp;
 	vec3d		*next_point;
 
+	Assertion(pl_objp->instance >= 0, "Arriving ship does not have a valid ship number.  Has %d instead. Please report!", pl_objp->instance);
 	ship *shipp = &Ships[pl_objp->instance];
+	Assertion(shipp->ai_index >= 0, "Arriving ship does not have a valid ai index.  Has %d instead. Please report!", shipp->ai_index);
 	ai_info *aip = &Ai_info[shipp->ai_index];
 
 	if ( parent_objnum == -1 ) {
@@ -12902,6 +12918,7 @@ int ai_acquire_emerge_path(object *pl_objp, int parent_objnum, int allowed_path_
 		return -1;
 	}
 
+	Assertion(parent_objnum >= 0, "Arriving ship does not have a parent object number.  Has %d instead. Please report!", parent_objnum);
 	object *parent_objp = &Objects[parent_objnum];
 	ship *parent_shipp = &Ships[parent_objp->instance];
 

--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -6608,6 +6608,7 @@ float ai_get_weapon_dist(ship_weapon *swp)
 		return 1000.0f;
 	}
 
+	Assertion(weapon_num >= 0, "A ship's weapon has a nonesense index of %d, but the ship's name is not accessible from this function.  Please report!", weapon_num);
 
 	return MIN((Weapon_info[weapon_num].max_speed * Weapon_info[weapon_num].lifetime), Weapon_info[weapon_num].weapon_range);
 }

--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -6608,7 +6608,7 @@ float ai_get_weapon_dist(ship_weapon *swp)
 		return 1000.0f;
 	}
 
-	Assertion(weapon_num >= 0, "A ship's weapon has a nonesense index of %d, but the ship's name is not accessible from this function.  Please report!", weapon_num);
+	Assertion(weapon_num >= 0, "A ship's weapon has a nonsense index of %d, but the ship's name is not accessible from this function.  Please report!", weapon_num);
 
 	return MIN((Weapon_info[weapon_num].max_speed * Weapon_info[weapon_num].lifetime), Weapon_info[weapon_num].weapon_range);
 }
@@ -6627,7 +6627,7 @@ float ai_get_weapon_speed(ship_weapon *swp)
 		return 100.0f;
 	}
 
-	Assertion(weapon_num >= 0, "A ship's weapon has a nonesense index of %d, but the ship's name is not accessible from this function.  Please report!", weapon_num);
+	Assertion(weapon_num >= 0, "A ship's weapon has a nonsense index of %d, but the ship's name is not accessible from this function.  Please report!", weapon_num);
 
 	return Weapon_info[weapon_num].max_speed;
 }
@@ -6646,7 +6646,7 @@ weapon_info* ai_get_weapon(ship_weapon *swp)
 		return nullptr;
 	}
 
-	Assertion(weapon_num >= 0, "A ship's weapon has a nonesense index of %d, but the ship's name is not accessible from this function.  Please report!", weapon_num);
+	Assertion(weapon_num >= 0, "A ship's weapon has a nonsense index of %d, but the ship's name is not accessible from this function.  Please report!", weapon_num);
 
 	return &Weapon_info[weapon_num];
 }

--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -1077,7 +1077,8 @@ void ai_update_danger_weapon(int attacked_objnum, int weapon_objnum)
 	float		old_dot, new_dot;
 	object	*old_weapon_objp = NULL;
 
-	if ((attacked_objnum == -1) || (weapon_objnum == -1)) {
+	// any object number less than 0 is invalid
+	if ((attacked_objnum < 0) || (weapon_objnum < 0)) {
 		return;
 	}
 


### PR DESCRIPTION
The AI code seems to assume that bugs can never happen and that it only has to check to see if an index is -1.  The trouble is, with memory bugs, this is not always the case, and we need to add some asserts to prevent error message-less edge case crashes if they start occurring. 

The first commit in this PR gracefully handles a case in multi where the objnum is nonsense.   The others just add those safety checks to throw an assert so that we don't do a negative array access by accident.

Bug reported here: https://discord.com/channels/223511295431933953/423504150437953537/832038232623022110

The minidumps used to find the break point are here: https://discord.com/channels/223511295431933953/423504150437953537/832062427226963982