### PR TITLE
Explicitly check that the type is a ship.

### DIFF
--- a/code/network/multi_obj.cpp
+++ b/code/network/multi_obj.cpp
@@ -639,7 +639,7 @@ void multi_ship_record_do_rollback()
 		}
 
 		objp = &Objects[cur_ship.objnum];
-		if (objp == nullptr) {
+		if (objp == nullptr || objp->type != OBJ_SHIP) {
 			continue;
 		}
 


### PR DESCRIPTION
Not all ships in the ships array are ships (if they were turned into observers), so we need to explicitly check that they are ships.  This fixes a crash where a player that has become an observer because of number of deaths does not crash the server when the server attempts rollback, because a weapon has taken the object slot that the player's ship used to have.