### PR TITLE
Keep Fred from freezing

### DIFF
--- a/fred2/fredrender.cpp
+++ b/fred2/fredrender.cpp
@@ -1125,6 +1125,8 @@ void inc_mission_time() {
 
 	if (Frametime > MAX_FRAMETIME) {
 		Frametime = MAX_FRAMETIME;
+	} else if (Frametime < 0) {
+		Frametime = thistime = MIN_FRAMETIME;
 	} else if (Frametime < MIN_FRAMETIME) {
 		if (!Cmdline_NoFPSCap) {
 			thistime = MIN_FRAMETIME - Frametime;


### PR DESCRIPTION
Could be because of variable overflows or from `thistime` somehow being much smaller than `lasttime`.

Hard to find the root cause, but manually setting the memory to bad values will no longer cause the freezing with this patch since we are explicitly checking for a negative value that is far too negative. 

Closes #3155