### PR TITLE
Fix APNG Animation Framecounter

### DIFF
--- a/code/graphics/generic.cpp
+++ b/code/graphics/generic.cpp
@@ -676,6 +676,12 @@ void generic_anim_render_variable_frame_delay(generic_anim* ga, float frametime,
 		// I'm not even sure that the existing ani/eff code would allow non-streaming generic anims
 		generic_render_png_stream(ga);
 
+		//generic_render_png_stream can, in some cases, like displaying the first image of the start
+		//of an ANPG that plays backwards, decide to advance the stream in a different direction than
+		//the current_frame counter in/decrementation of this method. Said change of the frame counter
+		//is still necessary for correct handling of not rendering the same frame twice, hence why
+		//the current_frame counter needs to be synchronized to the actual apng frame counter
+		//after the the apng stream rendering is complete
 		ga->current_frame = ga->png.anim->current_frame;
 
 		gr_set_bitmap(ga->bitmap_id, GR_ALPHABLEND_FILTER, GR_BITBLT_MODE_NORMAL, alpha);

--- a/code/graphics/generic.cpp
+++ b/code/graphics/generic.cpp
@@ -675,6 +675,9 @@ void generic_anim_render_variable_frame_delay(generic_anim* ga, float frametime,
 		// note: generic anims are not currently ever non-streaming in FSO
 		// I'm not even sure that the existing ani/eff code would allow non-streaming generic anims
 		generic_render_png_stream(ga);
+
+		ga->current_frame = ga->png.anim->current_frame;
+
 		gr_set_bitmap(ga->bitmap_id, GR_ALPHABLEND_FILTER, GR_BITBLT_MODE_NORMAL, alpha);
 	}
 }


### PR DESCRIPTION
This fixes #3399.
The problem is, that due to the exception for playing direction in APNG's made for first frames of backwards-playing doors ([code/graphics/generic.cpp#L493](https://github.com/BMagnu/fs2open.github.com/blob/79f5eda0d62343b823544a6cc5b13dd023708717/code/graphics/generic.cpp#L493)), the ``ga->current_frame`` got desynchronized from the actual ``framecount ga->png.anim->current_frame``.
This also allowed it to sometimes sink to -1 (which caused the sound crash, as that calculated a volume of over 100% with that), as well as caused it to never reach the end in a way that the animation system would count it as finished to start a new item from the same group.
Due to the early exit in the actual render function (that doesn't render the frame when the current frame and the previous frame are the same), changing the ``ga->current_frame`` _before_ the ``generic_render_png_stream(ga)`` didn't work.
I know this solution is not the prettiest, so any better ideas are very welcome. The proper solution would probably be to completely remove the separate apng framecounter, but that's probably a lot of work.