### PR TITLE
Fix fov_edge_checks

### DIFF
--- a/code/ai/aiturret.cpp
+++ b/code/ai/aiturret.cpp
@@ -146,13 +146,15 @@ bool object_in_turret_fov(object *objp, ship_subsys *ss, vec3d *tvec, vec3d *tpo
 			if (in_fov)
 				return true;
 		}
+	} 
+	// if the bbox points method didn't work (or fov_edge_checks isn't on)
+	// try the normal method
 
-	} else {
-		vm_vec_normalized_dir(&v2e, &objp->pos, tpos);
-		size_mod = objp->radius / (dist + objp->radius);
+	vm_vec_normalized_dir(&v2e, &objp->pos, tpos);
+	size_mod = objp->radius / (dist + objp->radius);
 
-		in_fov = turret_fov_test(ss, tvec, &v2e, size_mod);
-	}
+	in_fov = turret_fov_test(ss, tvec, &v2e, size_mod);
+
 
 	return in_fov;
 }


### PR DESCRIPTION
fov_edge_checks allows turrets to more 'greedily' acquire targets as long as it can see some of the ship's geometry by comparing vs the target's bbox points. Since it should be the more 'greedy' method, this shouldn't fail where the normal method would succeed, which can happen with looking directly at the center of the target with a small fov, all the bbox points may still be out of fov. So instead of an 'else' always do the normal method as a fallback to catch these cases.

I'm... not sure if this warrants being in the stable, but I admit due in no small part because we're so close already. It _has_ caused noticeable issues in Solaris already.