### PR TITLE
Avoid negative lookup when parsing loadouts.

### DIFF
--- a/code/parse/parselo.cpp
+++ b/code/parse/parselo.cpp
@@ -2992,16 +2992,18 @@ void stuff_loadout_list(SCP_vector<loadout_row> &list, int lookup_type)
 			Warning(LOCATION, "Weapon '%s' has more than 300 possible spawned weapons over its lifetime! This can cause issues for Multiplayer.", Weapon_info[buf->index].name);
 		}
 
-		// similarly, complain if this is a valid ship or weapon class that the player can't use
-		if ((lookup_type == MISSION_LOADOUT_SHIP_LIST) && (!(Ship_info[buf->index].flags[Ship::Info_Flags::Player_ship])) ) {
-			error_display(0, "Ship type \"%s\" found in loadout of mission file. This class is not marked as a player ship...skipping", str.c_str());
-			skip_this_entry = true;
-		}
-		else if ((lookup_type == MISSION_LOADOUT_WEAPON_LIST) && (!(Weapon_info[buf->index].wi_flags[Weapon::Info_Flags::Player_allowed])) ) {
-			nprintf(("Warning",  "Warning: Weapon type %s found in loadout of mission file. This class is not marked as a player allowed weapon...skipping\n", str.c_str()));
-			if ( !Is_standalone )
-				error_display(0, "Weapon type \"%s\" found in loadout of mission file. This class is not marked as a player allowed weapon...skipping", str.c_str());
-			skip_this_entry = true;
+		if (!skip_this_entry) {
+			// similarly, complain if this is a valid ship or weapon class that the player can't use
+			if ((lookup_type == MISSION_LOADOUT_SHIP_LIST) && (!(Ship_info[buf->index].flags[Ship::Info_Flags::Player_ship])) ) {
+				error_display(0, "Ship type \"%s\" found in loadout of mission file. This class is not marked as a player ship...skipping", str.c_str());
+				skip_this_entry = true;
+			}
+			else if ((lookup_type == MISSION_LOADOUT_WEAPON_LIST) && (!(Weapon_info[buf->index].wi_flags[Weapon::Info_Flags::Player_allowed])) ) {
+				nprintf(("Warning",  "Warning: Weapon type %s found in loadout of mission file. This class is not marked as a player allowed weapon...skipping\n", str.c_str()));
+				if ( !Is_standalone )
+					error_display(0, "Weapon type \"%s\" found in loadout of mission file. This class is not marked as a player allowed weapon...skipping", str.c_str());
+				skip_this_entry = true;
+			}
 		}
 
 		// Loadout counts are only needed for missions


### PR DESCRIPTION
#3271 changed the logic of `stuff_token_list()` in such a way that the supplied index being used to access an array was no longer skipped if it was invalid; naturally, this means that this warning was now being inevitably followed up by an out-of-bounds array access. Adding a `!skip_this_entry` check should hopefully fix the problem while still allowing the loadout count parsing code below it to run, which was presumably the reason the `continue` statement was replaced with the `skip_this_entry` variable in the first place. Fixes #3405.