### PR TITLE
Qtfred runtime fixes

### DIFF
--- a/qtfred/src/FredApplication.cpp
+++ b/qtfred/src/FredApplication.cpp
@@ -3,6 +3,7 @@
 #include <QDebug>
 #include <QTimer>
 #include <QtGui/QtEvents>
+#include <QApplication>
 
 #include <mission/Editor.h>
 #include <mission/management.h>
@@ -25,8 +26,8 @@ FredApplication::FredApplication() {
 
 	connect(this, &FredApplication::initializeComplete, [this]() { _initializeEmitted = true; });
 
-	// Put our shutdown code into a slot connected to the quit signal. That's the recommended way of doing cleanup
-	connect(qGuiApp, &QCoreApplication::aboutToQuit, this, &FredApplication::shutdown);
+	// Run our shutdown code after closing last window, but before application quits.
+	connect(qApp, &QApplication::lastWindowClosed, this, &FredApplication::shutdown);
 
 	// This will call our function in regular increments which allows us to do mission simulation stuff
 	auto idleTimer = new QTimer(this);

--- a/qtfred/src/main.cpp
+++ b/qtfred/src/main.cpp
@@ -183,7 +183,7 @@ int main(int argc, char* argv[]) {
 	game_busy_callback(game_busy_callback);
 
 	// Show all top level windows that are our window
-	FredView* fredview;
+	FredView* fredview(nullptr);
 	for (auto& window : qApp->topLevelWidgets()) {
 		fredview = qobject_cast<FredView*>(window);
 		if (fredview != nullptr) break;

--- a/qtfred/src/main.cpp
+++ b/qtfred/src/main.cpp
@@ -14,6 +14,8 @@
 
 #include "mission/Editor.h"
 #include "mission/management.h"
+#include "ui/widgets/renderwidget.h"
+#include "globalincs/pstypes.h"
 
 #include "ui/FredView.h"
 #include "FredApplication.h"
@@ -180,12 +182,14 @@ int main(int argc, char* argv[]) {
 	// Use this to keep the app responsive
 	game_busy_callback(game_busy_callback);
 
+	// Show all top level windows that are our window
+	FredView* fredview;
 	for (auto& window : qApp->topLevelWidgets()) {
-		// Show all top level windows that are our window
-		if (qobject_cast<FredView*>(window) != nullptr) {
-			window->showMaximized();
-		}
+		fredview = qobject_cast<FredView*>(window);
+		if (fredview != nullptr) break;
 	}
+	Assert(fredview != nullptr);
+	fredview->showMaximized();
 
 	// Allow other parts of the code to execute code that needs to run after everything has been set up
 	fredApp->initializeComplete();
@@ -196,6 +200,12 @@ int main(int argc, char* argv[]) {
 			fred->loadMission(Cmdline_start_mission);
 		});
 	}
+
+	// Render first correct frame
+	QTimer::singleShot(50, [=]{
+		Assert(fredview != nullptr);
+		fredview->getRenderWidget()->renderFrame();
+	});
 
 	return QGuiApplication::exec();
 }

--- a/qtfred/src/main.cpp
+++ b/qtfred/src/main.cpp
@@ -182,7 +182,7 @@ int main(int argc, char* argv[]) {
 	// Use this to keep the app responsive
 	game_busy_callback(game_busy_callback);
 
-	// Show all top level windows that are our window
+	// Find and show our window from the top level windows
 	FredView* fredview(nullptr);
 	for (auto& window : qApp->topLevelWidgets()) {
 		fredview = qobject_cast<FredView*>(window);

--- a/qtfred/src/ui/QtGraphicsOperations.cpp
+++ b/qtfred/src/ui/QtGraphicsOperations.cpp
@@ -129,8 +129,9 @@ std::pair<uint32_t, uint32_t> QtViewport::getSize() {
 	return std::make_pair((uint32_t) size.width(), (uint32_t) size.height());
 }
 void QtViewport::swapBuffers() {
-	if (_viewportWindow->getRenderWidget()->isVisible()) {
-		QOpenGLContext::currentContext()->swapBuffers(_viewportWindow->getRenderSurface());
+	auto qSurf = dynamic_cast<QWindow*>(_viewportWindow->getRenderSurface());
+	if (qSurf && qSurf->isExposed()) {
+		QOpenGLContext::currentContext()->swapBuffers(qSurf);
 	}
 }
 void QtViewport::setState(os::ViewportState  /*state*/) {


### PR DESCRIPTION
Fixes blurry background image / stars and related Qt warning on startup, as well as a crash on quit, caused by deallocating a glsync too late.