### PR TITLE
Fix/issue 3427

### DIFF
--- a/code/controlconfig/controlsconfig.cpp
+++ b/code/controlconfig/controlsconfig.cpp
@@ -115,10 +115,10 @@ int Conflict_wnd_coords[GR_NUM_RESOLUTIONS][4] = {
 // conflict warning anim coords
 int Conflict_warning_coords[GR_NUM_RESOLUTIONS][2] = {
 	{
-		-1, 420			// GR_640
+		320, 420			// GR_640
 	},
 	{
-		-1, 669			// GR_1024
+		512, 669			// GR_1024
 	}
 };
 
@@ -2295,7 +2295,7 @@ void control_config_do_frame(float frametime)
 		int sw, sh;
 		gr_get_string_size(&sw, &sh, conflict_str);
 
-		gr_string((gr_screen.max_w / 2) - (sw / 2), Conflict_warning_coords[gr_screen.res][1], conflict_str, GR_RESIZE_MENU);
+		gr_printf_menu(Conflict_warning_coords[gr_screen.res][CONTROL_X_COORD] - (sw / 2), Conflict_warning_coords[gr_screen.res][CONTROL_Y_COORD], conflict_str);
 
 		font::set_font(font::FONT1);
 	} else {

--- a/code/controlconfig/controlsconfig.cpp
+++ b/code/controlconfig/controlsconfig.cpp
@@ -2295,7 +2295,9 @@ void control_config_do_frame(float frametime)
 		int sw, sh;
 		gr_get_string_size(&sw, &sh, conflict_str);
 
-		gr_printf_menu(Conflict_warning_coords[gr_screen.res][CONTROL_X_COORD] - (sw / 2), Conflict_warning_coords[gr_screen.res][CONTROL_Y_COORD], conflict_str);
+		x = Conflict_warning_coords[gr_screen.res][CONTROL_X_COORD] - (sw / 2);
+		y = Conflict_warning_coords[gr_screen.res][CONTROL_Y_COORD];
+		gr_printf_menu(x, y, "%s", conflict_str);
 
 		font::set_font(font::FONT1);
 	} else {

--- a/code/controlconfig/controlsconfigcommon.cpp
+++ b/code/controlconfig/controlsconfigcommon.cpp
@@ -1516,9 +1516,9 @@ void control_config_common_read_section(int s, bool first_override) {
 
 		// Assign the various attributes to this control
 		int iTemp;
-		short key = 0;
 		auto  item = &Control_config[item_id];
 		auto& new_binding = new_preset.bindings[item_id];
+		short key = new_binding.get_btn(CID_KEYBOARD);
 
 		// Key assignment and modifiers
 		if (optional_string("$Key Default:")) {


### PR DESCRIPTION
Fixes two issues that led to #3427 :

Fixes logic of controlsconfigdefault.tbl so that legacy .tbl's can modify the default key bindings with Shift+ and/or Alt+ without corrupting the keybind.

Fixes draw anchor of the "Conflict!" warning text to use the menu's resolution instead of the screen width.  (The text anchor is effectively in the bottom center of the text)