### PR TITLE
Add fancy lua error message additions

### DIFF
--- a/code/osapi/dialogs.cpp
+++ b/code/osapi/dialogs.cpp
@@ -5,6 +5,7 @@
 #include "cmdline/cmdline.h"
 #include "graphics/2d.h"
 #include "scripting/ade.h"
+#include "scripting/scripting.h"
 
 #include <SDL_messagebox.h>
 #include <SDL_clipboard.h>
@@ -152,6 +153,10 @@ namespace os
 		{
 			SCP_stringstream msgStream;
 			
+			if (!Custom_lua_error_message.empty()) {
+				msgStream << Custom_lua_error_message << '\n';
+			}
+
 			//WMC - if format is set to NULL, assume this is acting as an
 			//error handler for Lua.
 			if (format == NULL)

--- a/code/scripting/api/libs/base.cpp
+++ b/code/scripting/api/libs/base.cpp
@@ -21,6 +21,7 @@
 #include "scripting/api/objs/vecmath.h"
 #include "scripting/util/LuaValueDeserializer.h"
 #include "scripting/util/LuaValueSerializer.h"
+#include "scripting/scripting.h"
 #include "utils/Random.h"
 
 namespace scripting {
@@ -47,6 +48,19 @@ ADE_FUNC(warning, l_Base, "string Message", "Displays a FreeSpace warning (debug
 ADE_FUNC(error, l_Base, "string Message", "Displays a FreeSpace error message with the string provided", NULL, NULL)
 {
 	Error(LOCATION, "%s", lua_tostring(L, -1));
+
+	return ADE_RETURN_NIL;
+}
+
+ADE_FUNC(setOnErrorString, l_Base, "string Message", "Sets a string that will be displayed on the next lua error", nullptr, nullptr)
+{
+	const char* message;
+	if (!ade_get_args(L, "s", &message)) {
+		Custom_lua_error_message = "";
+	}
+	else {
+		Custom_lua_error_message = message;
+	}
 
 	return ADE_RETURN_NIL;
 }

--- a/code/scripting/scripting.cpp
+++ b/code/scripting/scripting.cpp
@@ -30,6 +30,8 @@ script_state Script_system("FS2_Open Scripting");
 bool Output_scripting_meta = false;
 bool Output_scripting_json = false;
 
+SCP_string Custom_lua_error_message = "";
+
 flag_def_list Script_conditions[] = 
 {
 	{"State",		CHC_STATE,			0},

--- a/code/scripting/scripting.h
+++ b/code/scripting/scripting.h
@@ -388,6 +388,7 @@ void script_init();
 extern class script_state Script_system;
 extern bool Output_scripting_meta;
 extern bool Output_scripting_json;
+extern SCP_string Custom_lua_error_message;
 
 //*************************Conditional scripting*************************
 


### PR DESCRIPTION
Adds capability to add custom text to lua errors, allowing to inform a user / programmer what went wrong instead of just showing a trace (or possibly printing variable contents as well).
Requested by @EatThePath in discord.