### PR TITLE
Add nullptr check for obj_create priority

### DIFF
--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -5770,7 +5770,7 @@ int weapon_create( vec3d * pos, matrix * porient, int weapon_type, int parent_ob
 
 	// mark this object creation as essential, if it is created by a player.  
 	// You don't want players mysteriously wondering why they aren't firing.
-		objnum = obj_create( OBJ_WEAPON, parent_objnum, n, orient, pos, 2.0f, default_flags, parent_objp->flags[Object::Object_Flags::Player_ship]);
+	objnum = obj_create( OBJ_WEAPON, parent_objnum, n, orient, pos, 2.0f, default_flags, (parent_objp != nullptr && parent_objp->flags[Object::Object_Flags::Player_ship]));
 
 	if (objnum < 0) {
 		mprintf(("A weapon failed to be created because FSO is running out of object slots!\n"));


### PR DESCRIPTION
Check for nullptr first, otherwise weapons without parents will crash on creation.