### PR TITLE
Expose Shadow Cascade Distances

### DIFF
--- a/code/graphics/shadows.cpp
+++ b/code/graphics/shadows.cpp
@@ -14,6 +14,7 @@
 #include "graphics/matrix.h"
 #include "lighting/lighting.h"
 #include "math/vecmat.h"
+#include "mod_table/mod_table.h"
 #include "model/model.h"
 #include "model/modelrender.h"
 #include "options/Option.h"
@@ -433,9 +434,9 @@ void shadows_render_all(float fov, matrix *eye_orient, vec3d *eye_pos)
 	gr_end_proj_matrix();
 	gr_end_view_matrix();
 
-	// these cascade distances are a result of some arbitrary tuning to give a good balance of quality and banding. 
+	// the default cascade distances are a result of some arbitrary tuning to give a good balance of quality and banding. 
 	// maybe we could use a more programmatic algorithim? 
-	matrix light_matrix = shadows_start_render(eye_orient, eye_pos, fov, gr_screen.clip_aspect, 200.0f, 600.0f, 2500.0f, 8000.0f);
+	matrix light_matrix = shadows_start_render(eye_orient, eye_pos, fov, gr_screen.clip_aspect, std::get<0>(Shadow_distances), std::get<1>(Shadow_distances), std::get<2>(Shadow_distances), std::get<3>(Shadow_distances));
 
 	model_draw_list scene;
 	object *objp = Objects;

--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -401,10 +401,10 @@ void parse_mod_table(const char *filename)
 		if (optional_string("$Shadow Cascade Distances:")) {
 			float dis[4];
 			stuff_float_list(dis, 4);
-			if ((dis[0] >= 0) && (dis[1] >= 0) && (dis[2] >= 0) && (dis[3] >= 0)) {
-				Shadow_distances = std::make_tuple(static_cast<float>(dis[0]), static_cast<float>(dis[1]), static_cast<float>(dis[2]), static_cast<float>(dis[3]));
+			if ((dis[0] >= 0) && (dis[1] > dis[0]) && (dis[2] > dis[1]) && (dis[3] > dis[2])) {
+				Shadow_distances = std::make_tuple((dis[0]), (dis[1]), (dis[2]), (dis[3]));
 			} else {
-				error_display(0, "$Shadow Cascade Distances are %f, %f, %f, %f. One or more are < 0. Assuming default distances.", dis[0], dis[1], dis[2], dis[3]);
+				error_display(0, "$Shadow Cascade Distances are %f, %f, %f, %f. One or more are < 0, and/or values are not increasing. Assuming default distances.", dis[0], dis[1], dis[2], dis[3]);
 			}
 		}
 

--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -70,6 +70,7 @@ bool Neb_affects_beams;
 bool Neb_affects_weapons;
 bool Neb_affects_particles;
 bool Neb_affects_fireballs;
+std::tuple<ubyte, ubyte, ubyte, ubyte> Shadow_distances;
 
 SCP_vector<std::pair<SCP_string, gr_capability>> req_render_ext_pairs = {
 	std::make_pair("BPTC Texture Compression", CAPABILITY_BPTC)
@@ -397,6 +398,16 @@ void parse_mod_table(const char *filename)
 			stuff_boolean(&Neb_affects_fireballs);
 		}
 
+		if (optional_string("$Shadow Cascade Distances:")) {
+			float dis[4];
+			stuff_float_list(dis, 4);
+			if ((dis[0] >= 0) && (dis[1] >= 0) && (dis[2] >= 0) && (dis[3] >= 0)) {
+				Shadow_distances = std::make_tuple(static_cast<ubyte>(dis[0]), static_cast<ubyte>(dis[1]), static_cast<ubyte>(dis[2]), static_cast<ubyte>(dis[3]));
+			} else {
+				error_display(0, "$Shadow Cascade Distances are %f, %f, %f, %f. One or more are < 0. Assuming default distances.", dis[0], dis[1], dis[2], dis[3]);
+			}
+		}
+
 		optional_string("#NETWORK SETTINGS");
 
 		if (optional_string("$FS2NetD port:")) {
@@ -688,4 +699,5 @@ void mod_table_reset()
 	Neb_affects_weapons = false;
 	Neb_affects_particles = false;
 	Neb_affects_fireballs = false;
+	Shadow_distances = std::make_tuple(200.0f, 600.0f, 2500.0f, 8000.0f); // Default values tuned by Swifty and added here by wookieejedi
 }

--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -70,7 +70,7 @@ bool Neb_affects_beams;
 bool Neb_affects_weapons;
 bool Neb_affects_particles;
 bool Neb_affects_fireballs;
-std::tuple<ubyte, ubyte, ubyte, ubyte> Shadow_distances;
+std::tuple<float, float, float, float> Shadow_distances;
 
 SCP_vector<std::pair<SCP_string, gr_capability>> req_render_ext_pairs = {
 	std::make_pair("BPTC Texture Compression", CAPABILITY_BPTC)
@@ -402,7 +402,7 @@ void parse_mod_table(const char *filename)
 			float dis[4];
 			stuff_float_list(dis, 4);
 			if ((dis[0] >= 0) && (dis[1] >= 0) && (dis[2] >= 0) && (dis[3] >= 0)) {
-				Shadow_distances = std::make_tuple(static_cast<ubyte>(dis[0]), static_cast<ubyte>(dis[1]), static_cast<ubyte>(dis[2]), static_cast<ubyte>(dis[3]));
+				Shadow_distances = std::make_tuple(static_cast<float>(dis[0]), static_cast<float>(dis[1]), static_cast<float>(dis[2]), static_cast<float>(dis[3]));
 			} else {
 				error_display(0, "$Shadow Cascade Distances are %f, %f, %f, %f. One or more are < 0. Assuming default distances.", dis[0], dis[1], dis[2], dis[3]);
 			}

--- a/code/mod_table/mod_table.h
+++ b/code/mod_table/mod_table.h
@@ -62,7 +62,7 @@ extern bool Neb_affects_beams;
 extern bool Neb_affects_weapons;
 extern bool Neb_affects_particles;
 extern bool Neb_affects_fireballs;
-extern std::tuple<ubyte, ubyte, ubyte, ubyte> Shadow_distances;
+extern std::tuple<float, float, float, float> Shadow_distances;
 
 void mod_table_init();
 

--- a/code/mod_table/mod_table.h
+++ b/code/mod_table/mod_table.h
@@ -62,6 +62,7 @@ extern bool Neb_affects_beams;
 extern bool Neb_affects_weapons;
 extern bool Neb_affects_particles;
 extern bool Neb_affects_fireballs;
+extern std::tuple<ubyte, ubyte, ubyte, ubyte> Shadow_distances;
 
 void mod_table_init();
 


### PR DESCRIPTION
The shadow cascade distances were tuned/added by swifty with the following logic:
`// these cascade distances are a result of some arbitrary tuning to give a good balance of quality and banding.`

Mods, especially TCs, may have very different sized ships compared to FS, and they may desire more precise control over shadow cascade distances.

This PR exposes those values with settings in the `game_settings.tbl`.

PR is tested and works as expected.