### PR TITLE
Self-Shadow on 3D-Cockpits

### DIFF
--- a/code/graphics/2d.h
+++ b/code/graphics/2d.h
@@ -808,7 +808,7 @@ typedef struct screen {
 	std::function<void(int bitmap_handle, int bpp, const ubyte* data, int width, int height)> gf_update_texture;
 	std::function<void(void* data_out, int bitmap_num)> gf_get_bitmap_from_texture;
 
-	std::function<void(matrix4* shadow_view_matrix, const matrix* light_matrix, bool relative)> gf_shadow_map_start;
+	std::function<void(matrix4* shadow_view_matrix, const matrix* light_matrix, vec3d* eye_pos)> gf_shadow_map_start;
 	std::function<void()> gf_shadow_map_end;
 
 	std::function<void()> gf_start_decal_pass;

--- a/code/graphics/2d.h
+++ b/code/graphics/2d.h
@@ -808,7 +808,7 @@ typedef struct screen {
 	std::function<void(int bitmap_handle, int bpp, const ubyte* data, int width, int height)> gf_update_texture;
 	std::function<void(void* data_out, int bitmap_num)> gf_get_bitmap_from_texture;
 
-	std::function<void(matrix4* shadow_view_matrix, const matrix* light_matrix)> gf_shadow_map_start;
+	std::function<void(matrix4* shadow_view_matrix, const matrix* light_matrix, bool clear)> gf_shadow_map_start;
 	std::function<void()> gf_shadow_map_end;
 
 	std::function<void()> gf_start_decal_pass;

--- a/code/graphics/2d.h
+++ b/code/graphics/2d.h
@@ -808,7 +808,7 @@ typedef struct screen {
 	std::function<void(int bitmap_handle, int bpp, const ubyte* data, int width, int height)> gf_update_texture;
 	std::function<void(void* data_out, int bitmap_num)> gf_get_bitmap_from_texture;
 
-	std::function<void(matrix4* shadow_view_matrix, const matrix* light_matrix, bool clear)> gf_shadow_map_start;
+	std::function<void(matrix4* shadow_view_matrix, const matrix* light_matrix, bool relative)> gf_shadow_map_start;
 	std::function<void()> gf_shadow_map_end;
 
 	std::function<void()> gf_start_decal_pass;

--- a/code/graphics/grstub.cpp
+++ b/code/graphics/grstub.cpp
@@ -285,7 +285,7 @@ int gr_stub_maybe_create_shader(shader_type  /*shader_t*/, unsigned int  /*flags
 	return -1;
 }
 
-void gr_stub_shadow_map_start(matrix4 * /*shadow_view_matrix*/, const matrix*  /*light_matrix*/, vec3d* eye_pos)
+void gr_stub_shadow_map_start(matrix4 * /*shadow_view_matrix*/, const matrix*  /*light_matrix*/, vec3d* /*eye_pos*/)
 {
 }
 

--- a/code/graphics/grstub.cpp
+++ b/code/graphics/grstub.cpp
@@ -285,7 +285,7 @@ int gr_stub_maybe_create_shader(shader_type  /*shader_t*/, unsigned int  /*flags
 	return -1;
 }
 
-void gr_stub_shadow_map_start(matrix4 * /*shadow_view_matrix*/, const matrix*  /*light_matrix*/, bool relative)
+void gr_stub_shadow_map_start(matrix4 * /*shadow_view_matrix*/, const matrix*  /*light_matrix*/, vec3d* eye_pos)
 {
 }
 

--- a/code/graphics/grstub.cpp
+++ b/code/graphics/grstub.cpp
@@ -285,7 +285,7 @@ int gr_stub_maybe_create_shader(shader_type  /*shader_t*/, unsigned int  /*flags
 	return -1;
 }
 
-void gr_stub_shadow_map_start(matrix4 * /*shadow_view_matrix*/, const matrix*  /*light_matrix*/)
+void gr_stub_shadow_map_start(matrix4 * /*shadow_view_matrix*/, const matrix*  /*light_matrix*/, bool relative)
 {
 }
 

--- a/code/graphics/opengl/gropengldraw.h
+++ b/code/graphics/opengl/gropengldraw.h
@@ -34,7 +34,7 @@ void gr_opengl_update_distortion();
 
 void gr_opengl_sphere(material *material_def, float rad);
 
-void gr_opengl_shadow_map_start(matrix4 *shadow_view_matrix, const matrix *light_orient);
+void gr_opengl_shadow_map_start(matrix4 *shadow_view_matrix, const matrix *light_orient, bool relative = false);
 void gr_opengl_shadow_map_end();
 
 void gr_opengl_render_shield_impact(shield_material* material_info,

--- a/code/graphics/opengl/gropengldraw.h
+++ b/code/graphics/opengl/gropengldraw.h
@@ -34,7 +34,7 @@ void gr_opengl_update_distortion();
 
 void gr_opengl_sphere(material *material_def, float rad);
 
-void gr_opengl_shadow_map_start(matrix4 *shadow_view_matrix, const matrix *light_orient, bool relative = false);
+void gr_opengl_shadow_map_start(matrix4 *shadow_view_matrix, const matrix *light_orient, vec3d* eye_pos);
 void gr_opengl_shadow_map_end();
 
 void gr_opengl_render_shield_impact(shield_material* material_info,

--- a/code/graphics/opengl/gropengltnl.cpp
+++ b/code/graphics/opengl/gropengltnl.cpp
@@ -679,7 +679,7 @@ bool Glowpoint_override_save;
 
 extern bool gr_htl_projection_matrix_set;
 
-void gr_opengl_shadow_map_start(matrix4 *shadow_view_matrix, const matrix *light_orient, bool relative)
+void gr_opengl_shadow_map_start(matrix4 *shadow_view_matrix, const matrix *light_orient, vec3d* eye_pos)
 {
 	if (Shadow_quality == ShadowQuality::Disabled)
 		return;
@@ -702,11 +702,7 @@ void gr_opengl_shadow_map_start(matrix4 *shadow_view_matrix, const matrix *light
 
 	gr_htl_projection_matrix_set = true;
 
-	vec3d pos = Eye_position;
-	if (relative) {
-		pos = { 0.0f, 0.0f, 0.0f };
-	}
-	gr_set_view_matrix(&pos, light_orient);
+	gr_set_view_matrix(eye_pos, light_orient);
 
 	*shadow_view_matrix = gr_view_matrix;
 

--- a/code/graphics/opengl/gropengltnl.cpp
+++ b/code/graphics/opengl/gropengltnl.cpp
@@ -679,7 +679,7 @@ bool Glowpoint_override_save;
 
 extern bool gr_htl_projection_matrix_set;
 
-void gr_opengl_shadow_map_start(matrix4 *shadow_view_matrix, const matrix *light_orient)
+void gr_opengl_shadow_map_start(matrix4 *shadow_view_matrix, const matrix *light_orient, bool relative)
 {
 	if (Shadow_quality == ShadowQuality::Disabled)
 		return;
@@ -701,7 +701,12 @@ void gr_opengl_shadow_map_start(matrix4 *shadow_view_matrix, const matrix *light
 	Glowpoint_override = true;
 
 	gr_htl_projection_matrix_set = true;
-	gr_set_view_matrix(&Eye_position, light_orient);
+
+	vec3d pos = Eye_position;
+	if (relative) {
+		pos = { 0.0f, 0.0f, 0.0f };
+	}
+	gr_set_view_matrix(&pos, light_orient);
 
 	*shadow_view_matrix = gr_view_matrix;
 

--- a/code/graphics/shadows.cpp
+++ b/code/graphics/shadows.cpp
@@ -378,7 +378,7 @@ void shadows_construct_light_frustum(light_frustum_info *shadow_data, matrix *li
 	shadows_construct_light_proj(shadow_data);
 }
 
-matrix shadows_start_render(matrix *eye_orient, vec3d *eye_pos, float fov, float aspect, float veryneardist, float neardist, float middist, float fardist, bool relative)
+matrix shadows_start_render(matrix *eye_orient, vec3d *eye_pos, float fov, float aspect, float veryneardist, float neardist, float middist, float fardist)
 {	
 	if(Static_light.empty())
 		return vmd_identity_matrix; 
@@ -406,7 +406,7 @@ matrix shadows_start_render(matrix *eye_orient, vec3d *eye_pos, float fov, float
 	Shadow_proj_matrix[2] = Shadow_frustums[2].proj_matrix;
 	Shadow_proj_matrix[3] = Shadow_frustums[3].proj_matrix;
 
-	gr_shadow_map_start(&Shadow_view_matrix, &light_matrix, relative);
+	gr_shadow_map_start(&Shadow_view_matrix, &light_matrix, eye_pos);
 
 	return light_matrix;
 }

--- a/code/graphics/shadows.cpp
+++ b/code/graphics/shadows.cpp
@@ -378,7 +378,7 @@ void shadows_construct_light_frustum(light_frustum_info *shadow_data, matrix *li
 	shadows_construct_light_proj(shadow_data);
 }
 
-matrix shadows_start_render(matrix *eye_orient, vec3d *eye_pos, float fov, float aspect, float veryneardist, float neardist, float middist, float fardist)
+matrix shadows_start_render(matrix *eye_orient, vec3d *eye_pos, float fov, float aspect, float veryneardist, float neardist, float middist, float fardist, bool relative)
 {	
 	if(Static_light.empty())
 		return vmd_identity_matrix; 
@@ -406,7 +406,7 @@ matrix shadows_start_render(matrix *eye_orient, vec3d *eye_pos, float fov, float
 	Shadow_proj_matrix[2] = Shadow_frustums[2].proj_matrix;
 	Shadow_proj_matrix[3] = Shadow_frustums[3].proj_matrix;
 
-	gr_shadow_map_start(&Shadow_view_matrix, &light_matrix);
+	gr_shadow_map_start(&Shadow_view_matrix, &light_matrix, relative);
 
 	return light_matrix;
 }

--- a/code/graphics/shadows.h
+++ b/code/graphics/shadows.h
@@ -37,7 +37,7 @@ void shadows_construct_light_frustum(vec3d *min_out, vec3d *max_out, vec3d light
 bool shadows_obj_in_frustum(object *objp, vec3d *min, vec3d *max, matrix *light_orient);
 void shadows_render_all(float fov, matrix *eye_orient, vec3d *eye_pos);
 
-matrix shadows_start_render(matrix *eye_orient, vec3d *eye_pos, float fov, float aspect, float veryneardist, float neardist, float middist, float fardist, bool relative = false);
+matrix shadows_start_render(matrix *eye_orient, vec3d *eye_pos, float fov, float aspect, float veryneardist, float neardist, float middist, float fardist);
 void shadows_end_render();
 
 #endif

--- a/code/graphics/shadows.h
+++ b/code/graphics/shadows.h
@@ -37,7 +37,7 @@ void shadows_construct_light_frustum(vec3d *min_out, vec3d *max_out, vec3d light
 bool shadows_obj_in_frustum(object *objp, vec3d *min, vec3d *max, matrix *light_orient);
 void shadows_render_all(float fov, matrix *eye_orient, vec3d *eye_pos);
 
-matrix shadows_start_render(matrix *eye_orient, vec3d *eye_pos, float fov, float aspect, float veryneardist, float neardist, float middist, float fardist);
+matrix shadows_start_render(matrix *eye_orient, vec3d *eye_pos, float fov, float aspect, float veryneardist, float neardist, float middist, float fardist, bool relative = false);
 void shadows_end_render();
 
 #endif

--- a/code/graphics/vulkan/vulkan_stubs.cpp
+++ b/code/graphics/vulkan/vulkan_stubs.cpp
@@ -121,7 +121,7 @@ bool stub_bm_data(int /*n*/, bitmap* /*bm*/) { return true; }
 
 int stub_maybe_create_shader(shader_type /*shader_t*/, unsigned int /*flags*/) { return -1; }
 
-void stub_shadow_map_start(matrix4* /*shadow_view_matrix*/, const matrix* /*light_matrix*/, vec3d* eye_pos) {}
+void stub_shadow_map_start(matrix4* /*shadow_view_matrix*/, const matrix* /*light_matrix*/, vec3d* /*eye_pos*/) {}
 
 void stub_shadow_map_end() {}
 

--- a/code/graphics/vulkan/vulkan_stubs.cpp
+++ b/code/graphics/vulkan/vulkan_stubs.cpp
@@ -121,7 +121,7 @@ bool stub_bm_data(int /*n*/, bitmap* /*bm*/) { return true; }
 
 int stub_maybe_create_shader(shader_type /*shader_t*/, unsigned int /*flags*/) { return -1; }
 
-void stub_shadow_map_start(matrix4* /*shadow_view_matrix*/, const matrix* /*light_matrix*/) {}
+void stub_shadow_map_start(matrix4* /*shadow_view_matrix*/, const matrix* /*light_matrix*/, bool relative) {}
 
 void stub_shadow_map_end() {}
 

--- a/code/graphics/vulkan/vulkan_stubs.cpp
+++ b/code/graphics/vulkan/vulkan_stubs.cpp
@@ -121,7 +121,7 @@ bool stub_bm_data(int /*n*/, bitmap* /*bm*/) { return true; }
 
 int stub_maybe_create_shader(shader_type /*shader_t*/, unsigned int /*flags*/) { return -1; }
 
-void stub_shadow_map_start(matrix4* /*shadow_view_matrix*/, const matrix* /*light_matrix*/, bool relative) {}
+void stub_shadow_map_start(matrix4* /*shadow_view_matrix*/, const matrix* /*light_matrix*/, vec3d* eye_pos) {}
 
 void stub_shadow_map_end() {}
 

--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -71,6 +71,7 @@ bool Neb_affects_weapons;
 bool Neb_affects_particles;
 bool Neb_affects_fireballs;
 std::tuple<float, float, float, float> Shadow_distances;
+std::tuple<float, float, float, float> Shadow_distances_cockpit;
 
 SCP_vector<std::pair<SCP_string, gr_capability>> req_render_ext_pairs = {
 	std::make_pair("BPTC Texture Compression", CAPABILITY_BPTC)
@@ -408,6 +409,17 @@ void parse_mod_table(const char *filename)
 			}
 		}
 
+		if (optional_string("$Shadow Cascade Distances Cockpit:")) {
+			float dis[4];
+			stuff_float_list(dis, 4);
+			if ((dis[0] >= 0) && (dis[1] > dis[0]) && (dis[2] > dis[1]) && (dis[3] > dis[2])) {
+				Shadow_distances_cockpit = std::make_tuple((dis[0]), (dis[1]), (dis[2]), (dis[3]));
+			}
+			else {
+				error_display(0, "$Shadow Cascade Distances Cockpit are %f, %f, %f, %f. One or more are < 0, and/or values are not increasing. Assuming default distances.", dis[0], dis[1], dis[2], dis[3]);
+			}
+		}
+
 		optional_string("#NETWORK SETTINGS");
 
 		if (optional_string("$FS2NetD port:")) {
@@ -700,4 +712,5 @@ void mod_table_reset()
 	Neb_affects_particles = false;
 	Neb_affects_fireballs = false;
 	Shadow_distances = std::make_tuple(200.0f, 600.0f, 2500.0f, 8000.0f); // Default values tuned by Swifty and added here by wookieejedi
+	Shadow_distances_cockpit = std::make_tuple(0.25f, 0.75f, 1.5f, 3.0f); // Default values tuned by wookieejedi and added here by Lafiel
 }

--- a/code/mod_table/mod_table.h
+++ b/code/mod_table/mod_table.h
@@ -63,6 +63,7 @@ extern bool Neb_affects_weapons;
 extern bool Neb_affects_particles;
 extern bool Neb_affects_fireballs;
 extern std::tuple<float, float, float, float> Shadow_distances;
+extern std::tuple<float, float, float, float> Shadow_distances_cockpit;
 
 void mod_table_init();
 

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -7371,7 +7371,7 @@ void ship_render_cockpit(object *objp)
 
 	vm_vec_unrotate(&pos, &sip->cockpit_offset, &eye_ori);
 
-	bool Shadow_override_backup = Shadow_override;
+	bool shadow_override_backup = Shadow_override;
 
 	//Deal with the model
 	model_clear_instance(sip->cockpit_model_num);
@@ -7414,7 +7414,7 @@ void ship_render_cockpit(object *objp)
 
 	//Restore the Shadow_override
 	if (Shadow_quality != ShadowQuality::Disabled)
-		Shadow_override = Shadow_override_backup;
+		Shadow_override = shadow_override_backup;
 }
 
 void ship_render_show_ship_cockpit(object *objp)

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -7371,13 +7371,15 @@ void ship_render_cockpit(object *objp)
 
 	vm_vec_unrotate(&pos, &sip->cockpit_offset, &eye_ori);
 
+	bool Shadow_override_backup = Shadow_override;
+
+	//Deal with the model
+	model_clear_instance(sip->cockpit_model_num);
 	if (Shadow_quality != ShadowQuality::Disabled) {
 		gr_reset_clip();
 		Shadow_override = false;
 
-		shadows_start_render(&Eye_matrix, &leaning_position, Proj_fov, gr_screen.clip_aspect, 0.25f, 0.75f, 1.5f, 3.0f);
-
-		model_clear_instance(sip->cockpit_model_num);
+		shadows_start_render(&Eye_matrix, &leaning_position, Proj_fov, gr_screen.clip_aspect, std::get<0>(Shadow_distances_cockpit), std::get<1>(Shadow_distances_cockpit), std::get<2>(Shadow_distances_cockpit), std::get<3>(Shadow_distances_cockpit));
 
 		model_render_params shadow_render_info;
 		shadow_render_info.set_detail_level_lock(0);
@@ -7390,9 +7392,6 @@ void ship_render_cockpit(object *objp)
 
 	gr_set_proj_matrix(Proj_fov, gr_screen.clip_aspect, 0.02f, 10.0f * pm->rad);
 	gr_set_view_matrix(&leaning_position, &Eye_matrix);
-
-	//Deal with the model
-	model_clear_instance(sip->cockpit_model_num);
 
 	uint render_flags = MR_NORMAL;
 	render_flags |= MR_NO_FOGGING;
@@ -7415,7 +7414,7 @@ void ship_render_cockpit(object *objp)
 
 	//Restore the Shadow_override
 	if (Shadow_quality != ShadowQuality::Disabled)
-		Shadow_override = true;
+		Shadow_override = Shadow_override_backup;
 }
 
 void ship_render_show_ship_cockpit(object *objp)

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -7375,7 +7375,7 @@ void ship_render_cockpit(object *objp)
 		gr_reset_clip();
 		Shadow_override = false;
 
-		shadows_start_render(&Eye_matrix, &leaning_position, Proj_fov, gr_screen.clip_aspect, 0.25f, 0.75f, 1.5f, 3.0f, true);
+		shadows_start_render(&Eye_matrix, &leaning_position, Proj_fov, gr_screen.clip_aspect, 0.25f, 0.75f, 1.5f, 3.0f);
 
 		model_clear_instance(sip->cockpit_model_num);
 

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -26,6 +26,7 @@
 #include "gamesnd/gamesnd.h"
 #include "globalincs/alphacolors.h"
 #include "graphics/matrix.h"
+#include "graphics/shadows.h"
 #include "def_files/def_files.h"
 #include "globalincs/linklist.h"
 #include "hud/hud.h"
@@ -7369,7 +7370,25 @@ void ship_render_cockpit(object *objp)
 	vec3d pos = vmd_zero_vector;
 
 	vm_vec_unrotate(&pos, &sip->cockpit_offset, &eye_ori);
-	gr_set_proj_matrix(Proj_fov, gr_screen.clip_aspect, 0.02f, 10.0f*pm->rad);
+
+	if (Shadow_quality != ShadowQuality::Disabled) {
+		gr_reset_clip();
+		Shadow_override = false;
+
+		shadows_start_render(&Eye_matrix, &leaning_position, Proj_fov, gr_screen.clip_aspect, 0.25f, 0.75f, 1.5f, 3.0f, true);
+
+		model_clear_instance(sip->cockpit_model_num);
+
+		model_render_params shadow_render_info;
+		shadow_render_info.set_detail_level_lock(0);
+		shadow_render_info.set_flags(MR_NO_TEXTURING | MR_NO_LIGHTING);
+		model_render_immediate(&shadow_render_info, sip->cockpit_model_num, &eye_ori, &pos);
+
+		shadows_end_render();
+		gr_clear_states();
+	}
+
+	gr_set_proj_matrix(Proj_fov, gr_screen.clip_aspect, 0.02f, 10.0f * pm->rad);
 	gr_set_view_matrix(&leaning_position, &Eye_matrix);
 
 	//Deal with the model
@@ -7393,6 +7412,10 @@ void ship_render_cockpit(object *objp)
 	gr_end_proj_matrix();
 
 	hud_save_restore_camera_data(0);
+
+	//Restore the Shadow_override
+	if (Shadow_quality != ShadowQuality::Disabled)
+		Shadow_override = true;
 }
 
 void ship_render_show_ship_cockpit(object *objp)


### PR DESCRIPTION
This finishes @wookieejedi's work on cockpit self-shadow. With this, when shadows are enabled, cockpits will now self-shade automatically. Note, that due to the implementation (and different shadow parameters), cockpits will not get shaded by any other objects (including the rest of their parent craft). Still looks quite good in most situations, and like this there is little performance cost (unlike if we had to re-render the whole scene's shadowmap).
Closes #2023