### PR TITLE
Fix erroneous line break generation for non-ASCII string and high resolutions

### DIFF
--- a/code/cutscene/cutscenes.cpp
+++ b/code/cutscene/cutscenes.cpp
@@ -613,7 +613,7 @@ void cutscenes_screen_do_frame()
 			if (src)
 			{
 				Text_size = split_str(src, Cutscene_desc_coords[gr_screen.res][2], Text_line_size, Text_lines,
-									  Cutscene_max_text_lines[gr_screen.res]);
+									  Cutscene_max_text_lines[gr_screen.res], MAX_TEXT_LINE_LEN);
 				Assert(Text_size >= 0 && Text_size < Cutscene_max_text_lines[gr_screen.res]);
 			}
 		}

--- a/code/menuui/optionsmenumulti.cpp
+++ b/code/menuui/optionsmenumulti.cpp
@@ -656,7 +656,7 @@ void options_multi_notify_process()
 
 	// otherwise display the string
 	line_height = gr_get_font_height() + 1;
-	line_count = split_str(Om_notify_string, 600, n_chars, p_str, 3);	
+	line_count = split_str(Om_notify_string, 600, n_chars, p_str, 3, 255);
 	y_start = OM_NOTIFY_Y;
 	gr_set_color_fast(&Color_bright);
 	for(idx=0;idx<line_count;idx++){

--- a/code/menuui/optionsmenumulti.cpp
+++ b/code/menuui/optionsmenumulti.cpp
@@ -58,6 +58,8 @@ int Om_mask_0		  = -1;
 int Om_background_1 = -1;
 int Om_mask_1       = -1;
 
+#define OM_NOTIFICATION_LINE_LEN 255
+
 // screen modes
 #define OM_MODE_NONE									-1		// no mode (unintialized)
 #define OM_MODE_GENERAL								0		// general tab
@@ -637,7 +639,7 @@ void options_multi_notify_process()
 	int w;
 	const char *p_str[3];
 	int n_chars[3];
-	char line[255];
+	char line[OM_NOTIFICATION_LINE_LEN];
 	int line_count;
 	int y_start;
 	int idx;
@@ -656,11 +658,11 @@ void options_multi_notify_process()
 
 	// otherwise display the string
 	line_height = gr_get_font_height() + 1;
-	line_count = split_str(Om_notify_string, 600, n_chars, p_str, 3, 255);
+	line_count = split_str(Om_notify_string, 600, n_chars, p_str, 3, OM_NOTIFICATION_LINE_LEN);
 	y_start = OM_NOTIFY_Y;
 	gr_set_color_fast(&Color_bright);
 	for(idx=0;idx<line_count;idx++){
-		memset(line, 0, 255);
+		memset(line, 0, OM_NOTIFICATION_LINE_LEN);
 		strncpy(line, p_str[idx], n_chars[idx]);
 				
 		gr_get_string_size(&w,NULL,line);

--- a/code/menuui/readyroom.cpp
+++ b/code/menuui/readyroom.cpp
@@ -1510,7 +1510,7 @@ void set_new_campaign_line(int n)
 	str = Campaign_descs[Selected_campaign_index];
 	Num_info_lines = 0;
 	if (str) {
-		Num_info_lines = split_str(str, Cr_info_coords[gr_screen.res][2], Info_text_line_size, Info_text_ptrs, MAX_INFO_LINES);
+		Num_info_lines = split_str(str, Cr_info_coords[gr_screen.res][2], Info_text_line_size, Info_text_ptrs, MAX_INFO_LINES, MAX_INFO_LINE_LEN);
 		Assert(Num_info_lines >= 0);
 	}
 

--- a/code/menuui/techmenu.cpp
+++ b/code/menuui/techmenu.cpp
@@ -265,7 +265,7 @@ void techroom_init_desc(const char *src, int w)
 		return;
 	}
 
-	Text_size = split_str(src, w, Text_line_size, Text_lines, MAX_TEXT_LINES);
+	Text_size = split_str(src, w, Text_line_size, Text_lines, MAX_TEXT_LINES, MAX_TEXT_LINE_LEN);
 	Assert(Text_size >= 0 && Text_size < MAX_TEXT_LINES);
 }
 

--- a/code/mission/missionbriefcommon.cpp
+++ b/code/mission/missionbriefcommon.cpp
@@ -1681,7 +1681,7 @@ int brief_color_text_init(const char* src, int w, const char default_color, int 
 	}
 
 	Assert(src != NULL);
-	n_lines = split_str(src, w, n_chars, p_str, BRIEF_META_CHAR);
+	n_lines = split_str(src, w, n_chars, p_str, BRIEF_META_CHAR, true, MAX_BRIEF_LINE_LEN);
 	Assert(n_lines >= 0);
 
 	//for compatability reasons truncate text from everything except the fiction viewer

--- a/code/mission/missionbriefcommon.cpp
+++ b/code/mission/missionbriefcommon.cpp
@@ -1681,7 +1681,7 @@ int brief_color_text_init(const char* src, int w, const char default_color, int 
 	}
 
 	Assert(src != NULL);
-	n_lines = split_str(src, w, n_chars, p_str, BRIEF_META_CHAR, true, MAX_BRIEF_LINE_LEN);
+	n_lines = split_str(src, w, n_chars, p_str, MAX_BRIEF_LINE_LEN, BRIEF_META_CHAR, true);
 	Assert(n_lines >= 0);
 
 	//for compatability reasons truncate text from everything except the fiction viewer

--- a/code/mission/missionbriefcommon.cpp
+++ b/code/mission/missionbriefcommon.cpp
@@ -1681,7 +1681,7 @@ int brief_color_text_init(const char* src, int w, const char default_color, int 
 	}
 
 	Assert(src != NULL);
-	n_lines = split_str(src, w, n_chars, p_str, MAX_BRIEF_LINE_LEN, BRIEF_META_CHAR, true);
+	n_lines = split_str(src, w, n_chars, p_str, MAX_BRIEF_LINE_LEN, BRIEF_META_CHAR);
 	Assert(n_lines >= 0);
 
 	//for compatability reasons truncate text from everything except the fiction viewer

--- a/code/mission/missionbriefcommon.h
+++ b/code/mission/missionbriefcommon.h
@@ -84,17 +84,17 @@ extern const float		BRIEF_TEXT_WIPE_TIME;		// time in seconds for wipe to occur
 // ------------------------------------------------------------------------
 
 #define	MAX_BRIEF_LINES		70
-#define	MAX_BRIEF_LINE_LEN	256		// max number of chars in a briefing line
+#define	MAX_BRIEF_LINE_LEN	512		// max number of chars in a briefing line. Increased to allow for multibyte characters to fill a briefing line
 #define	MAX_BRIEF_LINE_W_640		375		// max width of line in pixels in 640x480 mode
 #define	MAX_BRIEF_LINE_W_1024	600		// max width of line in pixels in 1024x768 mode
 
 #define	MAX_DEBRIEF_LINES		60
-#define	MAX_DEBRIEF_LINE_LEN	256		// max number of chars in a debriefing line
+#define	MAX_DEBRIEF_LINE_LEN	512		// max number of chars in a debriefing line
 #define	MAX_DEBRIEF_LINE_W	500		// max width of line in pixels
 
 #define	MAX_ICON_TEXT_LEN			1024		// max number of chars for icon info
 #define	MAX_ICON_TEXT_LINES		30
-#define	MAX_ICON_TEXT_LINE_LEN	256		// max number of chars in icon info line
+#define	MAX_ICON_TEXT_LINE_LEN	512	// max number of chars in icon info line
 #define	MAX_ICON_TEXT_LINE_W		170		// max width of line in pixels
 
 #define	MAX_STAGE_ICONS			20

--- a/code/mission/missiongoals.cpp
+++ b/code/mission/missiongoals.cpp
@@ -324,7 +324,7 @@ int goal_text::add(const char *text)
 		return 1;
 	}
 
-	count = split_str(text, Goal_screen_text_w - Goal_screen_text_coords[gr_screen.res][GOAL_SCREEN_X_COORD] + Goal_screen_icon_xcoord[gr_screen.res], m_line_sizes + m_num_lines, m_lines + m_num_lines, max);
+	count = split_str(text, Goal_screen_text_w - Goal_screen_text_coords[gr_screen.res][GOAL_SCREEN_X_COORD] + Goal_screen_icon_xcoord[gr_screen.res], m_line_sizes + m_num_lines, m_lines + m_num_lines, max, MAX_GOAL_TEXT);
 	m_num_lines += count;
 	return count;
 }

--- a/code/missionui/chatbox.cpp
+++ b/code/missionui/chatbox.cpp
@@ -802,7 +802,7 @@ void chatbox_add_line(const char *msg, int pid, int add_id)
 	Assert(strlen(msg_extra) < (CHATBOX_STRING_LEN - 2));	
 
 	// split the text up into as many lines as necessary
-	n_lines = split_str(msg_extra, Chatbox_disp_w, n_chars, p_str, 3);
+	n_lines = split_str(msg_extra, Chatbox_disp_w, n_chars, p_str, 3, CHATBOX_STRING_LEN);
 	Assert(n_lines != -1);	
 
 	// setup the first line -- be sure to clear out the line
@@ -835,7 +835,7 @@ void chatbox_add_line(const char *msg, int pid, int add_id)
 	// if we have more than 1 line, re-split everything so that the rest are indented
 	if(n_lines > 1){
 		// split up the string after the first break-marker
-		n_lines = split_str(msg_extra + n_chars[0],Chatbox_disp_w - CHAT_LINE_INDENT,n_chars,p_str,3);
+		n_lines = split_str(msg_extra + n_chars[0],Chatbox_disp_w - CHAT_LINE_INDENT,n_chars,p_str,3, CHATBOX_STRING_LEN);
 		Assert(n_lines != -1);		
 
 		// setup these remaining lines

--- a/code/missionui/missionshipchoice.cpp
+++ b/code/missionui/missionshipchoice.cpp
@@ -1222,7 +1222,7 @@ void ship_select_blit_ship_info()
 	if(Ship_select_ship_info_text[0] != '\0'){
 		// split the string into multiple lines
 		// MageKing17: Changed to use the widths determined by Yarn here: http://scp.indiegames.us/mantis/view.php?id=3144#c16516
-		n_lines = split_str(Ship_select_ship_info_text, gr_screen.res == GR_640 ? 204 : 328, n_chars, p_str, MAX_NUM_SHIP_DESC_LINES, 0);
+		n_lines = split_str(Ship_select_ship_info_text, gr_screen.res == GR_640 ? 204 : 328, n_chars, p_str, MAX_NUM_SHIP_DESC_LINES, 0, SHIP_SELECT_SHIP_INFO_MAX_LINE_LEN);
 
 		// copy the split up lines into the text lines array
 		for (int idx = 0;idx<n_lines;idx++ ) {

--- a/code/network/multi_pxo.cpp
+++ b/code/network/multi_pxo.cpp
@@ -511,6 +511,8 @@ int Multi_pxo_max_chat_display[GR_NUM_RESOLUTIONS] = {
 // the "has left" message from the server
 #define MULTI_PXO_HAS_LEFT				"has left"
 
+#define MULTI_PXO_CHAT_LINE_LEN 512
+
 // chat flags
 #define CHAT_MODE_NORMAL				0			// normal chat from someone
 #define CHAT_MODE_SERVER				1			// is from the server, display appropriately
@@ -3203,7 +3205,7 @@ void multi_pxo_chat_add_line(const char *txt, int mode)
  */
 void multi_pxo_chat_process_incoming(const char *txt,int mode)
 {
-	char msg_total[512],line[512];
+	char msg_total[MULTI_PXO_CHAT_LINE_LEN],line[MULTI_PXO_CHAT_LINE_LEN];
 	int	n_lines,idx;
 	int	n_chars[20];
 	const char	*p_str[20];			//  the initial line (unindented)	
@@ -3248,7 +3250,7 @@ void multi_pxo_chat_process_incoming(const char *txt,int mode)
 	}
 
 	// split the text up into as many lines as necessary
-	n_lines = split_str(msg_total, Multi_pxo_chat_coords[gr_screen.res][2] - 5, n_chars, p_str, 3, 512);
+	n_lines = split_str(msg_total, Multi_pxo_chat_coords[gr_screen.res][2] - 5, n_chars, p_str, 3, MULTI_PXO_CHAT_LINE_LEN);
 	Assert((n_lines != -1) && (n_lines <= 20));
 	if((n_lines < 0) || (n_lines > 20)) {
 		return;

--- a/code/network/multi_pxo.cpp
+++ b/code/network/multi_pxo.cpp
@@ -3248,7 +3248,7 @@ void multi_pxo_chat_process_incoming(const char *txt,int mode)
 	}
 
 	// split the text up into as many lines as necessary
-	n_lines = split_str(msg_total, Multi_pxo_chat_coords[gr_screen.res][2] - 5, n_chars, p_str, 3);
+	n_lines = split_str(msg_total, Multi_pxo_chat_coords[gr_screen.res][2] - 5, n_chars, p_str, 3, 512);
 	Assert((n_lines != -1) && (n_lines <= 20));
 	if((n_lines < 0) || (n_lines > 20)) {
 		return;

--- a/code/network/multiteamselect.cpp
+++ b/code/network/multiteamselect.cpp
@@ -2604,7 +2604,7 @@ void multi_ts_select_ship()
 	
 		if(Multi_ts_ship_info_text[0] != '\0'){
 			// split the string into multiple lines
-			n_lines = split_str(Multi_ts_ship_info_text, Multi_ts_ship_info_coords[gr_screen.res][MULTI_TS_W_COORD], n_chars, p_str, MULTI_TS_SHIP_INFO_MAX_LINES, 0);	
+			n_lines = split_str(Multi_ts_ship_info_text, Multi_ts_ship_info_coords[gr_screen.res][MULTI_TS_W_COORD], n_chars, p_str, MULTI_TS_SHIP_INFO_MAX_LINES, MULTI_TS_SHIP_INFO_MAX_LINE_LEN,0);
 
 			// copy the split up lines into the text lines array
 			for (int idx = 0;idx<n_lines;idx++ ) {

--- a/code/network/multiui.cpp
+++ b/code/network/multiui.cpp
@@ -234,13 +234,11 @@ void multi_common_split_text()
 	int	n_chars[MAX_BRIEF_LINES];
 	const char	*p_str[MAX_BRIEF_LINES];
 
-	n_lines = split_str(Multi_common_all_text, Multi_common_text_coords[gr_screen.res][2], n_chars, p_str, MULTI_COMMON_TEXT_MAX_LINES, MULTI_COMMON_TEXT_META_CHAR);
+	n_lines = split_str(Multi_common_all_text, Multi_common_text_coords[gr_screen.res][2], n_chars, p_str, MULTI_COMMON_TEXT_MAX_LINES, MULTI_COMMON_TEXT_MAX_LINE_LENGTH, MULTI_COMMON_TEXT_META_CHAR);
 	Assert(n_lines != -1);
 
 	for ( i = 0; i < n_lines; i++ ) {
-		//The E -- This check is unnecessary, and will break when fonts that aren't bank gothic are used
-		//split_str already ensured that everything will fit in the text window for us already.
-		//Assert(n_chars[i] < MULTI_COMMON_TEXT_MAX_LINE_LENGTH); 
+		Assert(n_chars[i] < MULTI_COMMON_TEXT_MAX_LINE_LENGTH); 
 		strncpy(Multi_common_text[i], p_str[i], n_chars[i]);
 		Multi_common_text[i][n_chars[i]] = 0;
 		drop_leading_white_space(Multi_common_text[i]);		

--- a/code/parse/parselo.cpp
+++ b/code/parse/parselo.cpp
@@ -3323,7 +3323,7 @@ char *split_str_once(char *src, int max_pixel_w)
 //	returns:			number of lines src is broken into
 //						-1 is returned when an error occurs
 //
-int split_str(const char *src, int max_pixel_w, int *n_chars, const char **p_str, int max_lines, unicode::codepoint_t ignore_char, bool strip_leading_whitespace)
+int split_str(const char *src, int max_pixel_w, int *n_chars, const char **p_str, int max_lines, int max_line_length, unicode::codepoint_t ignore_char, bool strip_leading_whitespace)
 {
 	char buffer[SPLIT_STR_BUFFER_SIZE];
 	const char *breakpoint = NULL;
@@ -3419,7 +3419,7 @@ int split_str(const char *src, int max_pixel_w, int *n_chars, const char **p_str
 		buffer[buf_index] = 0;  // null terminate it
 
 		gr_get_string_size(&sw, NULL, buffer);
-		if (sw >= max_pixel_w) {
+		if (sw >= max_pixel_w || buf_index >= max_line_length) {
 			const char *end;
 
 			if (breakpoint) {
@@ -3454,7 +3454,7 @@ int split_str(const char *src, int max_pixel_w, int *n_chars, const char **p_str
 	return line_num;
 }
 
-int split_str(const char *src, int max_pixel_w, SCP_vector<int> &n_chars, SCP_vector<const char*> &p_str, unicode::codepoint_t ignore_char, bool strip_leading_whitespace)
+int split_str(const char *src, int max_pixel_w, SCP_vector<int> &n_chars, SCP_vector<const char*> &p_str, int max_line_length, unicode::codepoint_t ignore_char, bool strip_leading_whitespace)
 {
 	char buffer[SPLIT_STR_BUFFER_SIZE];
 	const char *breakpoint = NULL;
@@ -3542,7 +3542,7 @@ int split_str(const char *src, int max_pixel_w, SCP_vector<int> &n_chars, SCP_ve
 		buffer[buf_index] = 0;  // null terminate it
 
 		gr_get_string_size(&sw, NULL, buffer);
-		if (sw >= max_pixel_w) {
+		if (sw >= max_pixel_w || buf_index >= max_line_length) {
 			const char *end;
 
 			if (breakpoint) {

--- a/code/parse/parselo.h
+++ b/code/parse/parselo.h
@@ -19,6 +19,7 @@
 
 #include <cinttypes>
 #include <exception>
+#include <limits.h>
 
 // NOTE: although the main game doesn't need this anymore, FRED2 still does
 #define	PARSE_TEXT_SIZE	1000000

--- a/code/parse/parselo.h
+++ b/code/parse/parselo.h
@@ -264,12 +264,14 @@ int split_str(const char* src,
 			  int* n_chars,
 			  const char** p_str,
 			  int max_lines,
+			  int max_line_length = INT_MAX,
 			  unicode::codepoint_t ignore_char = (unicode::codepoint_t) -1,
 			  bool strip_leading_whitespace = true);
 int split_str(const char* src,
 			  int max_pixel_w,
 			  SCP_vector<int>& n_chars,
 			  SCP_vector<const char*>& p_str,
+			  int max_line_length = INT_MAX,
 			  unicode::codepoint_t ignore_char = (unicode::codepoint_t) -1,
 			  bool strip_leading_whitespace = true);
 

--- a/code/popup/popup.cpp
+++ b/code/popup/popup.cpp
@@ -361,7 +361,7 @@ void popup_split_lines(popup_info *pi, int flags)
 	font::set_font(font::FONT1);
 	n_chars[0]=0;
 
-	nlines = split_str(pi->raw_text, 1000, n_chars, p_str, POPUP_MAX_LINES);
+	nlines = split_str(pi->raw_text, 1000, n_chars, p_str, POPUP_MAX_LINES, POPUP_MAX_LINE_CHARS);
 	Assert(nlines >= 0 && nlines <= POPUP_MAX_LINES );
 
 	if ( flags & (PF_TITLE | PF_TITLE_BIG) ) {
@@ -375,7 +375,7 @@ void popup_split_lines(popup_info *pi, int flags)
 		font::set_font(font::FONT2);
 	}
 
-	nlines = split_str(pi->raw_text, Popup_text_coords[gr_screen.res][2], n_chars, p_str, POPUP_MAX_LINES);
+	nlines = split_str(pi->raw_text, Popup_text_coords[gr_screen.res][2], n_chars, p_str, POPUP_MAX_LINES, POPUP_MAX_LINE_CHARS);
 	Assert(nlines >= 0 && nlines <= POPUP_MAX_LINES );
 
 	pi->nlines = nlines - body_offset;

--- a/code/scripting/api/libs/graphics.cpp
+++ b/code/scripting/api/libs/graphics.cpp
@@ -1159,7 +1159,7 @@ ADE_FUNC(drawString, l_Graphics, "string Message, [number X1, number Y1, number 
 			y2 = temp;
 		}
 
-		num_lines = split_str(s, x2-x, linelengths, linestarts, (unicode::codepoint_t)-1, false);
+		num_lines = split_str(s, x2-x, linelengths, linestarts, INT_MAX, (unicode::codepoint_t)-1, false);
 
 		//Make sure we don't go over size
 		int line_ht = gr_get_font_height();


### PR DESCRIPTION
FSO's function to automatically linebreak text was previously only looking at the line lengths in pixels, and copying that into fixed length buffers. Hence, if you had characters using a lot of bytes per width (like in the NTP's Japanese translation with Kanjis) or a high resolution resulting in more characters per line being displayable (this is conjecture only, I haven't actually tested that this was an error before, but I am fairly certain it was), many functions using this linebreak functions could trip asserts, or worse, overrun their buffers causing CTD's. Thus, this also fixes #3438.
For the briefing parts specifically I also increased the buffer size, as this is a relatively safe thing to do, and otherwise lines could be broken earlier than the screens end, which is ugly (but not a CTD anymore).
I severely hope to not have missed any uses of this function, that would also need a specific maximum buffer length set.