### PR TITLE
Fix floating point error on subsys hits during ship class changing

### DIFF
--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -2317,7 +2317,7 @@ int parse_create_object_sub(p_object *p_objp)
 		{
 			ptr->max_hits = ptr->system_info->max_subsys_strength * (shipp->ship_max_hull_strength / sip->max_hull_strength);
 
-			float new_hits = ptr->max_hits * (100.0f - sssp->percent) / 100.f;
+			float new_hits = ptr->max_hits * ((100.0f - sssp->percent) / 100.f);
 			if (!(ptr->flags[Ship::Subsystem_Flags::No_aggregate])) {
 				shipp->subsys_info[ptr->system_info->type].aggregate_current_hits -= (ptr->max_hits - new_hits);
 			}


### PR DESCRIPTION
Although this change my seem trivial on the surface, this prevents 'damaging' operations being repeatedly applied to `max_hits` directly. Without this the `current_hits` of the subsystem can end up slightly higher than its max hits, and trip https://github.com/scp-fs2open/fs2open.github.com/blob/master/code/ship/ship.cpp#L10448 this assert when changing ship class.