### PR TITLE
Add volume effects

### DIFF
--- a/code/math/vecmat.cpp
+++ b/code/math/vecmat.cpp
@@ -2863,3 +2863,14 @@ std::ostream& operator<<(std::ostream& os, const vec3d& vec)
 	os << "vec3d<" << vec.xyz.x << ", " << vec.xyz.y << ", " << vec.xyz.z << ">";
 	return os;
 }
+
+matrix vm_stretch_matrix(const vec3d* stretch_dir, float stretch) {
+	matrix outer_prod;
+	vm_vec_outer_product(&outer_prod, stretch_dir);
+
+	for (float& i : outer_prod.a1d)
+		i *= stretch - 1.f;
+
+
+	return vmd_identity_matrix + outer_prod;
+}

--- a/code/math/vecmat.h
+++ b/code/math/vecmat.h
@@ -662,6 +662,13 @@ inline matrix operator*(const matrix& left, const matrix& right) {
 
 std::ostream& operator<<(std::ostream& os, const vec3d& vec);
 
+// Given a direction and a 'stretch amount', computes a matrix which can be used to
+// 'rotate' positional vectors as to stretch them in that direction by that amount
+// Positions in the opposite direction of the stretch_dir are stretched in the opposite direction
+// and position orthogonal to the stretch_dir are not moved at all
+// Essentially turns spheres into ellipsoids
+matrix vm_stretch_matrix(const vec3d* stretch_dir, float stretch);
+
 #endif
 
 

--- a/code/particle/ParticleEffect.h
+++ b/code/particle/ParticleEffect.h
@@ -19,6 +19,7 @@ enum class EffectType: int64_t {
 	Composite,
 	Cone,
 	Sphere,
+	Volume,
 
 	MAX,
 };

--- a/code/particle/ParticleManager.cpp
+++ b/code/particle/ParticleManager.cpp
@@ -5,6 +5,7 @@
 
 #include "particle/effects/SingleParticleEffect.h"
 #include "particle/effects/CompositeEffect.h"
+#include "particle/effects/VolumeEffect.h"
 
 #include "particle/effects/ConeShape.h"
 #include "particle/effects/SphereShape.h"
@@ -25,7 +26,8 @@ const char* effectTypeNames[static_cast<int64_t>(EffectType::MAX)] = {
 	"Single",
 	"Composite",
 	"Cone",
-	"Sphere"
+	"Sphere",
+	"Volume"
 };
 
 const char* getEffectTypeName(EffectType type) {
@@ -59,6 +61,11 @@ ParticleEffectPtr constructEffect(const SCP_string& name, EffectType type) {
 		}
 		case EffectType::Sphere: {
 			effect.reset(new GenericShapeEffect<SphereShape>(name));
+			effect->parseValues(false);
+			break;
+		}
+		case EffectType::Volume: {
+			effect.reset(new VolumeEffect(name));
 			effect->parseValues(false);
 			break;
 		}

--- a/code/particle/effects/VolumeEffect.cpp
+++ b/code/particle/effects/VolumeEffect.cpp
@@ -1,0 +1,122 @@
+#include "particle/particle.h"
+#include "particle/ParticleEffect.h"
+#include "particle/ParticleSource.h"
+#include "particle/effects/VolumeEffect.h"
+
+#include "bmpman/bmpman.h"
+
+/**
+ * @defgroup particleEffects Particle Effects
+ *
+ * @ingroup particleSystems
+ */
+
+namespace particle {
+	namespace effects {
+		VolumeEffect::VolumeEffect(const SCP_string& name)
+			: ParticleEffect(name) {}
+
+		bool VolumeEffect::processSource(ParticleSource* source) {
+			if (!m_timing.continueProcessing(source)) {
+				return false;
+			}
+
+			// This uses the internal features of the timing class for determining if and how many effects should be
+			// triggered this frame
+			util::EffectTiming::TimingState time_state;
+			while (m_timing.shouldCreateEffect(source, time_state)) {
+				auto num = m_particleNum.next();
+
+				vec3d stretch_dir = source->getOrientation()->getDirectionVector(source->getOrigin());
+				matrix stretch_matrix = vm_stretch_matrix(&stretch_dir, m_stretch);
+				for (uint i = 0; i < num; ++i) {
+					vec3d pos;
+					// get an unbiased random point in the sphere
+					vm_vec_random_in_sphere(&pos, &vmd_zero_vector, 1.0f, false);
+
+					// maybe bias it towards the center or edge
+					if (m_bias != 1.0f) {
+						float mag = vm_vec_mag(&pos);
+						vm_vec_normalize(&pos);
+						mag = powf(mag, m_bias);
+						pos *= mag;
+					}
+
+					// maybe stretch it
+					vec3d copy_pos = pos;
+					if (m_stretch != 1.0f)
+						vm_vec_rotate(&pos, &copy_pos, &stretch_matrix);
+
+					particle_info info;
+					source->getOrigin()->applyToParticleInfo(info);
+
+					// make their velocity radial, and based on position, allows for some very cool effects
+					info.vel = pos;
+					pos *= m_radius;
+					info.pos += pos;
+
+					vm_vec_scale(&info.vel, m_velocity.next());
+					m_particleProperties.createParticle(info);
+				}
+			}
+
+			// Continue processing this source
+			return true;
+		}
+
+		void VolumeEffect::parseValues(bool nocreate) {
+			m_particleProperties.parse(nocreate);
+
+			if (internal::required_string_if_new("+Velocity:", nocreate)) {
+				m_velocity = ::util::parseUniformRange<float>();
+			}
+
+			if (internal::required_string_if_new("+Number:", nocreate)) {
+				m_particleNum = ::util::parseUniformRange<uint>();
+			}
+
+			if (internal::required_string_if_new("+Volume radius:", nocreate)) {
+				float radius;
+				stuff_float(&radius);
+
+				if (radius < 0.001f) {
+					Warning(LOCATION, "A volume radius of %f is not valid. Must be greater than 0. Defaulting to 10.", radius);
+					radius = 10.0f;
+				}
+				m_radius = radius;
+			}
+
+			if (optional_string("+Bias:")) {
+				float bias;
+				stuff_float(&bias);
+
+				if (bias < 0.001f) {
+					Warning(LOCATION, "A volume bias value of %f is not valid. Must be greater than 0.", bias);
+					bias = 1.0f;
+				}
+				m_bias = bias;
+			}
+
+			if (optional_string("+Stretch:")) {
+				float stretch;
+				stuff_float(&stretch);
+
+				if (stretch < 0.001f) {
+					Warning(LOCATION, "A volume stretch value of %f is not valid. Must be greater than 0.", stretch);
+					stretch = 1.0f;
+				}
+				m_stretch = stretch;
+			}
+
+			m_timing = util::EffectTiming::parseTiming();
+		}
+
+		void VolumeEffect::pageIn() {
+			m_particleProperties.pageIn();
+		}
+
+		void VolumeEffect::initializeSource(ParticleSource& source) {
+			m_timing.applyToSource(&source);
+		}
+	}
+}

--- a/code/particle/effects/VolumeEffect.h
+++ b/code/particle/effects/VolumeEffect.h
@@ -1,0 +1,46 @@
+#ifndef VOLUME_EFFECT_H
+#define VOLUME_EFFECT_H
+#pragma once
+
+#include "globalincs/pstypes.h"
+#include "particle/ParticleEffect.h"
+#include "particle/ParticleManager.h"
+#include "particle/util/ParticleProperties.h"
+#include "particle/util/EffectTiming.h"
+
+namespace particle {
+	namespace effects {
+		/**
+		 * @ingroup particleEffects
+		 */
+		class VolumeEffect : public ParticleEffect {
+		private:
+			util::ParticleProperties m_particleProperties;
+
+			float m_radius = 10.0f;
+			float m_bias = 1.0f;
+			float m_stretch = 1.0f;
+			util::EffectTiming m_timing;
+			::util::UniformUIntRange m_particleNum;
+
+			::util::UniformFloatRange m_velocity;
+
+		public:
+			explicit VolumeEffect(const SCP_string& name);
+
+			bool processSource(ParticleSource* source) override;
+
+			void parseValues(bool nocreate) override;
+
+			void pageIn() override;
+
+			void initializeSource(ParticleSource& source) override;
+
+			EffectType getType() const override { return EffectType::Volume; }
+
+			util::ParticleProperties& getProperties() { return m_particleProperties; }
+		};
+	}
+}
+
+#endif // VOLUME_EFFECT_H

--- a/code/source_groups.cmake
+++ b/code/source_groups.cmake
@@ -1061,6 +1061,8 @@ add_file_folder("Particle\\\\Effects"
 	particle/effects/SingleParticleEffect.cpp
 	particle/effects/SingleParticleEffect.h
 	particle/effects/SphereShape.h
+	particle/effects/VolumeEffect.cpp
+	particle/effects/VolumeEffect.h
 )
 
 add_file_folder("Particle\\\\Util"


### PR DESCRIPTION
Adds the 'Volume' effect type, which spawns particles in a spherical volume. Options for biasing the particles towards the center or the edge, or 'stretching' it into an ellipsoid are provided as well.

Closes #2935