### PR TITLE
Fix a bug where shields could occasionally be pierced

### DIFF
--- a/code/ai/ai_flags.h
+++ b/code/ai/ai_flags.h
@@ -137,6 +137,7 @@ namespace AI {
 		Improved_missile_avoidance,
 		Friendlies_use_countermeasure_firechance,
 		Improved_subsystem_attack_pathing,
+		Fixed_ship_weapon_collision,
 
 		NUM_VALUES
 	};

--- a/code/ai/ai_profiles.cpp
+++ b/code/ai/ai_profiles.cpp
@@ -544,6 +544,8 @@ void parse_ai_profiles_tbl(const char *filename)
 
 				set_flag(profile, "$improved subsystem attack pathing:", AI::Profile_Flags::Improved_subsystem_attack_pathing);
 
+				set_flag(profile, "$fixed ship-weapon collisions:", AI::Profile_Flags::Fixed_ship_weapon_collision);
+
 				// if we've been through once already and are at the same place, force a move
 				if (saved_Mp && (saved_Mp == Mp))
 				{
@@ -696,5 +698,8 @@ void ai_profile_t::reset()
 	// this flag has been enabled ever since 3.7.2
 	if (mod_supports_version(3, 7, 2)) {
 		flags.set(AI::Profile_Flags::Fix_ramming_stationary_targets_bug);
+	}
+	if (mod_supports_version(21, 4, 0)) {
+		flags.set(AI::Profile_Flags::Fixed_ship_weapon_collision);
 	}
 }

--- a/code/object/collideshipweapon.cpp
+++ b/code/object/collideshipweapon.cpp
@@ -185,6 +185,12 @@ static int ship_weapon_check_collision(object *ship_objp, object *weapon_objp, f
 	vm_vec_scale_add( &weapon_end_pos, &weapon_objp->pos, &weapon_objp->phys_info.vel, time_limit );
 
 
+	vec3d weapon_start_pos = weapon_objp->last_pos;
+	// Maybe take into account the ship's velocity, so it won't later overstep the weapon's
+	// current position (what will be its last_pos next frame)
+	if (The_mission.ai_profile->flags[AI::Profile_Flags::Fixed_ship_weapon_collision])
+		weapon_start_pos += ship_objp->phys_info.vel * flFrametime;
+
 	// Goober5000 - I tried to make collision code here much saner... here begin the (major) changes
 	mc_info_init(&mc);
 
@@ -194,7 +200,7 @@ static int ship_weapon_check_collision(object *ship_objp, object *weapon_objp, f
 	mc.submodel_num = -1;
 	mc.orient = &ship_objp->orient;
 	mc.pos = &ship_objp->pos;
-	mc.p0 = &weapon_objp->last_pos;
+	mc.p0 = &weapon_start_pos;
 	mc.p1 = &weapon_end_pos;
 	mc.lod = sip->collision_lod;
 	memcpy(&mc_shield, &mc, sizeof(mc_info));


### PR DESCRIPTION
...despite full shields in that quadrant. If the ship moves towards the weapon in the frame, the next collision check for the weapon may start it *inside* the shield where last frame it may have ended just *outside* the shield. By adding in the ship's velocity we essentially take into account the apparent motion of the weapon from the ship's own moving reference frame. This was tested and works with regular and highly adversarial examples, such as very slow moving weapons which are normally very difficult to actually trigger collisions against for this reason.

The bigger issue, however, is backwards compatibility. I think almost everyone has noticed this happen at some point or another, and although I haven't specifically tested for it, I highly suspect this is the reason Seraphim and Nephilim bombers can occasionally be destroyed in a single volley of trebuchets, despite the stats on the paper not allowing for this. This could be behind a flag (possibly enabled by `$Target version`) but I am loathe to do this because of how simple, clearly a bug, and fundamental this is to the collision system.