### PR TITLE
karajorma's SEXP containers, Part 1: Definition, parsing, and saving

### DIFF
--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -60,6 +60,7 @@
 #include "object/waypoint.h"
 #include "parse/generic_log.h"
 #include "parse/parselo.h"
+#include "parse/sexp_container.h"
 #include "scripting/hook_api.h"
 #include "scripting/scripting.h"
 #include "playerman/player.h"

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -5785,6 +5785,23 @@ void parse_variables()
 	}
 }
 
+void parse_sexp_containers()
+{
+	if (!optional_string("#Sexp_containers")) {
+		return;
+	}
+
+	if (optional_string("$Lists")) {
+		stuff_sexp_list_containers();
+		required_string("$End Lists");
+	}
+
+	if (optional_string("$Maps")) {
+		stuff_sexp_map_containers();
+		required_string("$End Maps");
+	}
+}
+
 bool parse_mission(mission *pm, int flags)
 {
 	int saved_warning_count = Global_warning_count;
@@ -5830,6 +5847,7 @@ bool parse_mission(mission *pm, int flags)
 
 	parse_plot_info(pm);
 	parse_variables();
+	parse_sexp_containers();
 	parse_briefing_info(pm);	// TODO: obsolete code, keeping so we don't obsolete existing mission files
 	parse_cutscenes(pm);
 	parse_fiction(pm);

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -960,7 +960,6 @@ void multi_sexp_modify_variable();
 SCP_vector<SCP_string> *Current_event_log_buffer;
 SCP_vector<SCP_string> *Current_event_log_variable_buffer;
 SCP_vector<SCP_string> *Current_event_log_argument_buffer;
-SCP_vector<SCP_string> *Current_event_log_container_buffer;
 
 // Goober5000 - arg_item class stuff, borrowed from sexp_list_item class stuff -------------
 void arg_item::add_data(char *str, int n)
@@ -23492,8 +23491,7 @@ void add_to_event_log_buffer(int op_num, int result)
 {
 	Assertion ((Current_event_log_buffer != nullptr) &&
 				(Current_event_log_variable_buffer != nullptr)&& 
-				(Current_event_log_argument_buffer != nullptr) &&
-				(Current_event_log_container_buffer != nullptr), "Attempting to write to a non-existent log buffer");
+				(Current_event_log_argument_buffer != nullptr), "Attempting to write to a non-existent log buffer");
 
 	if (op_num == -1) {
 		nprintf(("SEXP", "ERROR: add_to_event_log_buffer() function called with op_num of %i; this should not happen. Contact a coder.\n", op_num));
@@ -23536,14 +23534,6 @@ void add_to_event_log_buffer(int op_num, int result)
 			tmp.append(Current_event_log_variable_buffer->back());
 			Current_event_log_variable_buffer->pop_back();
 			tmp.append("]");
-		}
-	}
-
-	if (!Current_event_log_container_buffer->empty()) {
-		tmp.append("\nContainers:\n");
-		while (!Current_event_log_container_buffer->empty()) {
-			tmp.append(Current_event_log_container_buffer->back().c_str()); 
-			Current_event_log_container_buffer->pop_back();
 		}
 	}
 

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -14,10 +14,6 @@
 //	It uses a very baggy format, allocating 16 characters per token, regardless
 //	of how many are used.
 
-#include <algorithm>
-#include <functional>
-#include <iterator>
-
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
@@ -86,6 +82,7 @@
 #include "parse/parselo.h"
 #include "scripting/scripting.h"
 #include "parse/sexp.h"
+#include "parse/sexp_container.h"
 #include "playerman/player.h"
 #include "render/3d.h"
 #include "ship/afterburner.h"
@@ -851,12 +848,6 @@ sexp_node *Sexp_nodes = nullptr;
 sexp_variable Sexp_variables[MAX_SEXP_VARIABLES];
 sexp_variable Block_variables[MAX_SEXP_VARIABLES];			// used for compatibility with retail. 
 
-SCP_vector<sexp_container> Sexp_containers;
-// non-extern vars
-// we can't use full name (SCP_string) as the key, because get_sexp_container_index() takes const char*
-// so every call to get_sexp_container_index() would construct a string before lookup (ugh)
-static SCP_unordered_map<char, SCP_vector<int>> Container_indices_by_initial;
-
 int Num_special_expl_blocks;
 
 SCP_vector<int> Current_sexp_operator;
@@ -906,7 +897,6 @@ void build_extended_sexp_string(SCP_string &accumulator, int cur_node, int level
 void update_sexp_references(const char *old_name, const char *new_name, int format, int node);
 int sexp_determine_team(const char *subj);
 void init_sexp_vars();
-void init_sexp_containers();
 
 // for handling variables
 void add_block_variable(const char *text, const char *var_name, int type, int index);
@@ -3771,164 +3761,6 @@ int get_sexp()
 	return start;
 }
 
-void register_new_container_index(const SCP_string &container_name, int container_index = -1)
-{
-	if (container_index == -1) {
-		container_index = (int)Sexp_containers.size() - 1;
-	}
-	Assert(container_index >= 0);
-	Assert(container_index < (int)Sexp_containers.size());
-	Container_indices_by_initial[SCP_tolower(container_name[0])].emplace_back(container_index);
-}
-
-bool stuff_one_generic_sexp_container(SCP_string& name, int& type, int& opf_type, SCP_vector<SCP_string>& data)
-{
-	bool valid = true; // try to skip past bad containers by not returning until end of function
-	SCP_string temp_type_string;
-
-	data.clear();
-
-	required_string("$Name:");
-	stuff_string(name, F_NAME);
-
-	if (name.empty()) {
-		Warning(LOCATION, "SEXP Container with empty name found");
-		log_printf(LOGFILE_EVENT_LOG, "SEXP Container with empty name found");
-		valid = false;
-	} else if (name.length() > sexp_container::NAME_MAX_LENGTH) {
-		Warning(LOCATION,
-			"SEXP Container name %s is longer than limit %u",
-			name.c_str(),
-			sexp_container::NAME_MAX_LENGTH);
-		log_printf(LOGFILE_EVENT_LOG, "SEXP Container name %s is longer than limit %u",
-			name.c_str(),
-			sexp_container::NAME_MAX_LENGTH);
-		valid = false;
-	}
-
-	required_string("$Data Type:");
-	stuff_string(temp_type_string, F_NAME);
-	if (!strcmp(temp_type_string.c_str(), "Number")) {
-		type |= SEXP_CONTAINER_NUMBER_DATA;
-		opf_type = OPF_NUMBER;
-	} else if (!strcmp(temp_type_string.c_str(), "String")) {
-		type |= SEXP_CONTAINER_STRING_DATA;
-		opf_type = OPF_ANYTHING;
-	} else {
-		Warning(LOCATION, "Unknown SEXP Container type %s found", temp_type_string.c_str()); 
-		log_printf(LOGFILE_EVENT_LOG, "Unknown SEXP Container type %s found", temp_type_string.c_str());
-		valid = false;
-	}
-
-	if (optional_string("$Key Type:")) {
-		Assertion ((type & SEXP_CONTAINER_MAP), "$Key Type: found for container which doesn't use keys!");
-
-		stuff_string(temp_type_string, F_NAME);
-		if (!strcmp(temp_type_string.c_str(), "Number")) {
-			type |= SEXP_CONTAINER_NUMBER_KEYS;
-		} else if (!strcmp(temp_type_string.c_str(), "String")) {
-			type |= SEXP_CONTAINER_STRING_KEYS;
-		} else {
-			Warning(LOCATION, "Unknown SEXP Container type %s found", temp_type_string.c_str());
-			log_printf(LOGFILE_EVENT_LOG, "Unknown SEXP Container type %s found", temp_type_string.c_str());
-			valid = false;
-		}
-	}
-
-	if (optional_string("+Strictly Typed Keys")) {
-		Assertion ((type & SEXP_CONTAINER_MAP), "+Strictly Typed Keys found for container which doesn't use keys!");  
-		Warning(LOCATION, "Container %s is marked for strictly typed keys, which are not yet supported.", name.c_str());
-		type |= SEXP_CONTAINER_STRICTLY_TYPED_KEYS;
-	}
-
-	if (optional_string("+Strictly Typed Data")) {
-		Warning(LOCATION, "Container %s is marked for strictly typed data, which are not yet supported.", name.c_str());
-		type |= SEXP_CONTAINER_STRICTLY_TYPED_DATA;
-	}
-
-	required_string("$Data:");
-	stuff_string_list(data);
-
-	if (optional_string("+Network Container")) {
-		Warning(LOCATION, "Container %s is marked as a network container, which is not yet supported.", name.c_str());
-		type |= SEXP_CONTAINER_NETWORK;
-	}
-
-	if (optional_string("+Eternal")) {
-		type |= SEXP_CONTAINER_SAVE_TO_PLAYER_FILE;
-	}
-
-	// campaign-persistent
-	if (optional_string("+Save On Mission Progress")) {
-		type |= SEXP_CONTAINER_SAVE_ON_MISSION_PROGRESS;
-	}
-
-	// player-persistent
-	if (optional_string("+Save On Mission Close")) {
-		Assert(!(type & SEXP_CONTAINER_SAVE_ON_MISSION_PROGRESS));
-		type |= SEXP_CONTAINER_SAVE_ON_MISSION_CLOSE;
-	}
-
-	Assert(!(type & SEXP_CONTAINER_SAVE_TO_PLAYER_FILE) ||
-		   ((type & SEXP_CONTAINER_SAVE_ON_MISSION_PROGRESS) ^ (type & SEXP_CONTAINER_SAVE_ON_MISSION_CLOSE)));
-
-	return valid;
-}
-
-/**
- * Stuffs sexp list type containers
- */
-
-void stuff_sexp_list_containers()
-{
-	SCP_vector<SCP_string>	parsed_data;
-
-	while (required_string_either("$End Lists", "$Name:")) {
-		Sexp_containers.emplace_back();
-		auto& new_list = Sexp_containers.back();
-
-		new_list.type = SEXP_CONTAINER_LIST;
-		if (stuff_one_generic_sexp_container(new_list.container_name, new_list.type, new_list.opf_type, parsed_data)) {
-			std::copy(parsed_data.begin(), parsed_data.end(), back_inserter(new_list.list_data));
-			register_new_container_index(new_list.container_name);
-		} else {
-			Sexp_containers.pop_back();
-		}
-	}
-}
-
-/**
- * Stuffs sexp map type containers
- */
-void stuff_sexp_map_containers()
-{
-	SCP_vector<SCP_string>	parsed_data;
-
-	while (required_string_either("$End Maps", "$Name:")) {
-		Sexp_containers.emplace_back();
-		auto& new_map = Sexp_containers.back();
-
-		new_map.type = SEXP_CONTAINER_MAP;
-		if (stuff_one_generic_sexp_container(new_map.container_name, new_map.type, new_map.opf_type, parsed_data)){
-			if (parsed_data.size() % 2 != 0) {
-				Warning(LOCATION,
-					"Data in the SEXP Map container is corrupt. Must be an even number of entries. Instead have %d",
-					(int)parsed_data.size());
-				log_printf(LOGFILE_EVENT_LOG,
-					"Data in the SEXP Map container is corrupt. Must be an even number of entries. Instead have %d",
-					(int)parsed_data.size());
-				Sexp_containers.pop_back();
-			} else {
-				for (int i = 0; i < (int)parsed_data.size(); i += 2) {
-					new_map.map_data.emplace(parsed_data[i], parsed_data[i + 1]);
-				}
-				register_new_container_index(new_map.container_name);
-			}
-		} else {
-			Sexp_containers.pop_back();
-		}
-	}
-}
 
 /**
  * Stuffs a list of sexp variables
@@ -23460,61 +23292,6 @@ void sexp_set_motion_debris(int node)
 	Motion_debris_override = is_sexp_true(node);
 }
 
-int get_sexp_container_index_generic(const char *name,
-	const std::function<bool(const char*, const char*)>& match_func)
-{
-	const char initial_lower = SCP_tolower(name[0]);
-
-	if (Container_indices_by_initial.count(initial_lower) == 0) {
-		return -1;
-	}
-
-	const SCP_vector<int>& indices = Container_indices_by_initial.at(initial_lower);
-	for (const int& i : indices) {
-		if (match_func(Sexp_containers[i].container_name.c_str(), name)) {
-			return i;
-		}
-	}
-
-	// not found
-	return -1;
-}
-
-static bool str_match(const char* str1, const char* str2)
-{
-	return !stricmp(str1, str2);
-}
-
-/**
- * Return index of a sexp_container by its name, or -1 if not found
- */
-int get_sexp_container_index(const char* name) {
-	return get_sexp_container_index_generic(name, str_match);
-}
-
-static bool str_prefix(const char* prefix, const char* str)
-{
-	for (; *prefix; ++prefix, ++str) {
-		if (SCP_tolower(*str) != SCP_tolower(*prefix)) {
-			return false;
-		}
-	}
-
-	return true;
-}
-
-/**
-* Tests whether this position in a character array is the start of a container name
-* return index in Sexp_containers or -1 if not found
-**/
-int get_sexp_container_index_special(const SCP_string &text, size_t start_pos)
-{
-	Assert(!text.empty());
-	Assert(start_pos < text.length());
-
-	return get_sexp_container_index_generic(text.c_str() + start_pos, str_prefix);
-}
-
 /**
  * Returns the subsystem type if the name of a subsystem is actually a generic type (e.g \<all engines\> or \<all turrets\>
  */
@@ -30035,17 +29812,6 @@ int check_text_for_variable_name(const char *text)
 	return sexp_variable_index;
 }
 
- const container_modifier Container_modifiers[MAX_CONTAINER_MODIFIERS] = {
-	{ "Get_First",			SNF_CONTAINER_GET_FIRST,		},
-	{ "Get_Last",			SNF_CONTAINER_GET_LAST,			},
-	{ "Remove_First",		SNF_CONTAINER_REMOVE_FIRST,		},
-	{ "Remove_Last",		SNF_CONTAINER_REMOVE_LAST,		},
-	{ "Get_Random",			SNF_CONTAINER_GET_RANDOM,		},
-	{ "Remove_Random",		SNF_CONTAINER_REMOVE_RANDOM,	},
-	{ "At",					SNF_CONTAINER_AT_INDEX,			},
-};
-// Remember to update MAX_CONTAINER_MODIFIERS if adding to the above array
-
 /**
  * Wrapper around Sexp_node[xx].text for normal and variable
  */
@@ -30143,26 +29909,6 @@ void init_sexp_vars()
 	for (int i=0; i<MAX_SEXP_VARIABLES; i++) {
 		Sexp_variables[i].type = SEXP_VARIABLE_NOT_USED;
 		Block_variables[i].type = SEXP_VARIABLE_NOT_USED;
-	}
-}
-
-/**
- * Clear the SEXP Containers and related data
- */
-void init_sexp_containers()
-{
-	Sexp_containers.clear();
-	Container_indices_by_initial.clear();
-}
-
-void update_sexp_containers(SCP_vector<sexp_container>& containers)
-{
-	Sexp_containers = std::move(containers);
-
-	// reset index
-	Container_indices_by_initial.clear();
-	for (int i = 0; i < (int)Sexp_containers.size(); ++i) {
-		register_new_container_index(Sexp_containers[i].container_name, i);
 	}
 }
 

--- a/code/parse/sexp.h
+++ b/code/parse/sexp.h
@@ -1184,7 +1184,6 @@ extern SCP_vector<int> Current_sexp_operator;
 extern SCP_vector<SCP_string> *Current_event_log_buffer;
 extern SCP_vector<SCP_string> *Current_event_log_variable_buffer;
 extern SCP_vector<SCP_string> *Current_event_log_argument_buffer;
-extern SCP_vector<SCP_string> *Current_event_log_container_buffer;
 
 extern void init_sexp();
 extern void sexp_shutdown();

--- a/code/parse/sexp.h
+++ b/code/parse/sexp.h
@@ -925,8 +925,6 @@ const char *CTEXT(int n);
 // flags for sexpressions -- masked onto the end of the type field
 #define SEXP_FLAG_PERSISTENT				(1<<31)		// should this sexp node be persistant across missions
 #define SEXP_FLAG_VARIABLE					(1<<30)
-// bit flags 27-29 are used by SEXP variable persistence flags below
-#define SEXP_FLAG_CONTAINER_MODIFIER		(1<<26)
 
 // sexp variable definitions
 #define SEXP_VARIABLE_CHAR					('@')

--- a/code/parse/sexp.h
+++ b/code/parse/sexp.h
@@ -949,44 +949,6 @@ const char *CTEXT(int n);
 
 #define SEXP_VARIABLE_IS_PERSISTENT (SEXP_VARIABLE_SAVE_ON_MISSION_PROGRESS|SEXP_VARIABLE_SAVE_ON_MISSION_CLOSE)
 
-// sexp container definitions
-#define SEXP_CONTAINER_LIST							(1<<0)
-#define SEXP_CONTAINER_MAP							(1<<1)
-#define SEXP_CONTAINER_STRICTLY_TYPED_KEYS			(1<<2)
-#define SEXP_CONTAINER_STRICTLY_TYPED_DATA			(1<<3)
-#define SEXP_CONTAINER_NUMBER_DATA					(1<<4)
-#define SEXP_CONTAINER_STRING_DATA					(1<<5)
-#define SEXP_CONTAINER_NUMBER_KEYS					(1<<6)
-#define SEXP_CONTAINER_STRING_KEYS					(1<<7)
-
-#define SEXP_CONTAINER_ALL			(SEXP_CONTAINER_LIST | SEXP_CONTAINER_MAP)
-
-// jg18 - container persistence, applied to sexp_container.type field
-// adapting values from their variable counterparts
-#define SEXP_CONTAINER_SAVE_ON_MISSION_CLOSE		(1<<30)	//	(0x40000000)
-#define SEXP_CONTAINER_SAVE_ON_MISSION_PROGRESS		(1<<29)	//	(0x20000000)
-#define SEXP_CONTAINER_NETWORK						(1<<28)	//	(0x10000000)
-#define SEXP_CONTAINER_SAVE_TO_PLAYER_FILE			(1<<27)	//	(0x08000000)
-#define SEXP_CONTAINER_IS_PERSISTENT				(SEXP_CONTAINER_SAVE_ON_MISSION_PROGRESS|SEXP_CONTAINER_SAVE_ON_MISSION_CLOSE)
-
-
-// container modifiers - these are the "functions" you can carry out on a SEXP container
-#define SNF_CONTAINER_GET_FIRST				0
-#define SNF_CONTAINER_GET_LAST				1
-#define SNF_CONTAINER_REMOVE_FIRST			2
-#define SNF_CONTAINER_REMOVE_LAST			3
-#define SNF_CONTAINER_GET_RANDOM			4
-#define SNF_CONTAINER_REMOVE_RANDOM			5
-#define SNF_CONTAINER_AT_INDEX				6
-
-// Bump this if you add a container modifier on the line above!
-#define NUM_CONTAINER_MODIFIERS					7
-
-struct container_modifier {
-	const char *name;
-	const int def;
-};
-
 #define BLOCK_EXP_SIZE					6
 #define INNER_RAD							0
 #define OUTER_RAD							1
@@ -1181,59 +1143,6 @@ typedef struct sexp_variable {
 	char	variable_name[TOKEN_LENGTH];
 } sexp_variable;
 
-struct sexp_container
-{
-	// meta-character for containers in text replacement, etc.
-	static constexpr char DELIM = '&';
-	// applies to list data, map keys, and map data
-	static constexpr int VALUE_MAX_LENGTH = NAME_LENGTH - 1; // leave space for null char
-	// leave space for leading/trailing '&' for container multidimensionality
-	static constexpr int NAME_MAX_LENGTH = VALUE_MAX_LENGTH - 2;
-
-	SCP_string container_name;
-	int type = SEXP_CONTAINER_LIST | SEXP_CONTAINER_STRING_DATA;
-	int opf_type = OPF_ANYTHING;
-	SCP_list<SCP_string> list_data;
-	SCP_unordered_map<SCP_string, SCP_string> map_data;
-
-	inline bool is_list() const
-	{
-		return type & SEXP_CONTAINER_LIST;
-	}
-
-	inline bool is_map() const
-	{
-		return type & SEXP_CONTAINER_MAP;
-	}
-
-	inline bool is_eternal() const
-	{
-		return type & SEXP_CONTAINER_SAVE_TO_PLAYER_FILE;
-	}
-
-	inline bool is_persistent() const
-	{
-		return type & SEXP_CONTAINER_IS_PERSISTENT;
-	}
-
-	bool empty() const
-	{
-		return (is_list() && list_data.empty()) || (is_map() && map_data.empty());
-	}
-
-	int size() const
-	{
-		if (is_list()) {
-			return (int)list_data.size();
-		} else if (is_map()) {
-			return (int)map_data.size();
-		} else {
-			Assert(false);
-			return 0;
-		}
-	}
-};
-
 // next define used to eventually mark a directive as satisfied even though there may be more
 // waves for a wing.  bascially a hack for the directives display.
 #define DIRECTIVE_WING_ZERO		-999
@@ -1248,10 +1157,6 @@ extern sexp_variable Sexp_variables[MAX_SEXP_VARIABLES];
 extern sexp_variable Block_variables[MAX_SEXP_VARIABLES];
 
 extern SCP_vector<sexp_oper> Operators;
-extern SCP_vector<sexp_container> Sexp_containers;
-
-#define MAX_CONTAINER_MODIFIERS		7
-extern const container_modifier Container_modifiers[MAX_CONTAINER_MODIFIERS];
 
 extern int Locked_sexp_true, Locked_sexp_false;
 extern int Directive_count;
@@ -1304,8 +1209,6 @@ extern int check_sexp_syntax(int node, int return_type = OPR_BOOL, int recursive
 extern int get_sexp_main(void);	//	Returns start node
 extern int run_sexp(const char* sexpression, bool run_eval_num = false, bool *is_nan_or_nan_forever = nullptr); // debug and lua sexps
 extern int stuff_sexp_variable_list();
-extern void stuff_sexp_list_containers();
-extern void stuff_sexp_map_containers();
 extern int eval_sexp(int cur_node, int referenced_node = -1);
 extern int eval_num(int n, bool &is_nan, bool &is_nan_forever);
 extern bool is_sexp_true(int cur_node, int referenced_node = -1);
@@ -1362,10 +1265,6 @@ int sexp_add_variable(const char *text, const char *var_name, int type, int inde
 bool generate_special_explosion_block_variables();
 int num_block_variables();
 bool has_special_explosion_block_index(ship *shipp, int *index);
-
-// sexp containers
-int get_sexp_container_index(const char* name);
-void update_sexp_containers(SCP_vector<sexp_container> &containers);
 
 // Karajorma
 void set_primary_ammo (int ship_index, int requested_bank, int requested_ammo, int rearm_limit=-1);

--- a/code/parse/sexp_container.cpp
+++ b/code/parse/sexp_container.cpp
@@ -1,0 +1,264 @@
+/*
+ * Created by Hassan "Karajorma" Kazmi and Josh "jg18" Glatt for The FreeSpace 2 Source Code Project.
+ * You may not sell or otherwise commercially exploit the source or things you
+ * create based on the source.
+ */
+
+#include <algorithm>
+#include <functional>
+#include <iterator>
+
+#include "parse/generic_log.h"
+#include "parse/parselo.h"
+#include "parse/sexp_container.h"
+
+static SCP_vector<sexp_container> Sexp_containers;
+
+const SCP_vector<sexp_container> &get_all_sexp_containers()
+{
+	return Sexp_containers;
+}
+
+static const SCP_vector<list_modifier> List_modifiers = {
+	{ "Get_First",			ListModifier::GET_FIRST     },
+	{ "Get_Last",			ListModifier::GET_LAST      },
+	{ "Remove_First",		ListModifier::REMOVE_FIRST  },
+	{ "Remove_Last",		ListModifier::REMOVE_LAST   },
+	{ "Get_Random",			ListModifier::GET_RANDOM    },
+	{ "Remove_Random",		ListModifier::REMOVE_RANDOM },
+	{ "At",					ListModifier::AT_INDEX      }
+};
+
+const SCP_vector<list_modifier>& get_all_list_modifiers()
+{
+	return List_modifiers;
+}
+
+// sexp_container struct functions
+
+bool sexp_container::empty() const
+{
+	return size() == 0;
+}
+
+int sexp_container::size() const
+{
+	if (is_list()) {
+		return (int)list_data.size();
+	} else if (is_map()) {
+		return (int)map_data.size();
+	} else {
+		Assert(false);
+		return 0;
+	}
+}
+
+// sexp_container.h functions
+
+/**
+ * Clear the SEXP Containers and related data
+ */
+void init_sexp_containers()
+{
+	Sexp_containers.clear();
+}
+
+void update_sexp_containers(SCP_vector<sexp_container> &containers)
+{
+	Sexp_containers = std::move(containers);
+}
+
+bool stuff_one_generic_sexp_container(SCP_string &name, ContainerType &type, int &opf_type, SCP_vector<SCP_string> &data)
+{
+	bool valid = true; // try to skip past bad containers by not returning until end of function
+	SCP_string temp_type_string;
+
+	data.clear();
+
+	required_string("$Name:");
+	stuff_string(name, F_NAME);
+
+	if (name.empty()) {
+		Warning(LOCATION, "SEXP Container with empty name found");
+		log_printf(LOGFILE_EVENT_LOG, "SEXP Container with empty name found");
+		valid = false;
+	} else if (name.length() > sexp_container::NAME_MAX_LENGTH) {
+		Warning(LOCATION,
+			"SEXP Container name %s is longer than limit %u",
+			name.c_str(),
+			sexp_container::NAME_MAX_LENGTH);
+		log_printf(LOGFILE_EVENT_LOG, "SEXP Container name %s is longer than limit %i",
+			name.c_str(),
+			sexp_container::NAME_MAX_LENGTH);
+		valid = false;
+	}
+
+	required_string("$Data Type:");
+	stuff_string(temp_type_string, F_NAME);
+	if (!strcmp(temp_type_string.c_str(), "Number")) {
+		type |= NUMBER_DATA;
+		opf_type = OPF_NUMBER;
+	} else if (!strcmp(temp_type_string.c_str(), "String")) {
+		type |= STRING_DATA;
+		opf_type = OPF_ANYTHING;
+	} else {
+		Warning(LOCATION, "Unknown SEXP Container type %s found", temp_type_string.c_str());
+		log_printf(LOGFILE_EVENT_LOG, "Unknown SEXP Container type %s found", temp_type_string.c_str());
+		valid = false;
+	}
+
+	if (optional_string("$Key Type:")) {
+		Assertion((type & MAP), "$Key Type: found for container which doesn't use keys!");
+
+		stuff_string(temp_type_string, F_NAME);
+		if (!strcmp(temp_type_string.c_str(), "Number")) {
+			type |= NUMBER_KEYS;
+		} else if (!strcmp(temp_type_string.c_str(), "String")) {
+			type |= STRING_KEYS;
+		} else {
+			Warning(LOCATION, "Unknown SEXP Container type %s found", temp_type_string.c_str());
+			log_printf(LOGFILE_EVENT_LOG, "Unknown SEXP Container type %s found", temp_type_string.c_str());
+			valid = false;
+		}
+	}
+
+	if (optional_string("+Strictly Typed Keys")) {
+		Assertion((type & MAP), "+Strictly Typed Keys found for container which doesn't use keys!");
+		Warning(LOCATION, "Container %s is marked for strictly typed keys, which are not yet supported.", name.c_str());
+		type |= STRICTLY_TYPED_KEYS;
+	}
+
+	if (optional_string("+Strictly Typed Data")) {
+		Warning(LOCATION, "Container %s is marked for strictly typed data, which are not yet supported.", name.c_str());
+		type |= STRICTLY_TYPED_DATA;
+	}
+
+	required_string("$Data:");
+	stuff_string_list(data);
+
+	if (optional_string("+Network Container")) {
+		Warning(LOCATION, "Container %s is marked as a network container, which is not yet supported.", name.c_str());
+		type |= NETWORK;
+	}
+
+	if (optional_string("+Eternal")) {
+		type |= SAVE_TO_PLAYER_FILE;
+	}
+
+	// campaign-persistent
+	if (optional_string("+Save On Mission Progress")) {
+		type |= SAVE_ON_MISSION_PROGRESS;
+	}
+
+	// player-persistent
+	if (optional_string("+Save On Mission Close")) {
+		Assert(!(type & SAVE_ON_MISSION_PROGRESS));
+		type |= SAVE_ON_MISSION_CLOSE;
+	}
+
+	Assert(!(type & SAVE_TO_PLAYER_FILE) ||
+		((type & SAVE_ON_MISSION_PROGRESS) ^ (type & SAVE_ON_MISSION_CLOSE)));
+
+	return valid;
+}
+
+/**
+ * Stuffs sexp list type containers
+ */
+
+void stuff_sexp_list_containers()
+{
+	SCP_vector<SCP_string>	parsed_data;
+
+	while (required_string_either("$End Lists", "$Name:")) {
+		Sexp_containers.emplace_back();
+		auto &new_list = Sexp_containers.back();
+
+		new_list.type = LIST;
+		if (stuff_one_generic_sexp_container(new_list.container_name, new_list.type, new_list.opf_type, parsed_data)) {
+			std::copy(parsed_data.begin(), parsed_data.end(), back_inserter(new_list.list_data));
+		} else {
+			Sexp_containers.pop_back();
+		}
+	}
+}
+
+/**
+ * Stuffs sexp map type containers
+ */
+void stuff_sexp_map_containers()
+{
+	SCP_vector<SCP_string>	parsed_data;
+
+	while (required_string_either("$End Maps", "$Name:")) {
+		Sexp_containers.emplace_back();
+		auto& new_map = Sexp_containers.back();
+
+		new_map.type = MAP;
+		if (stuff_one_generic_sexp_container(new_map.container_name, new_map.type, new_map.opf_type, parsed_data)) {
+			if (parsed_data.size() % 2 != 0) {
+				Warning(LOCATION,
+					"Data in the SEXP Map container is corrupt. Must be an even number of entries. Instead have %d",
+					(int)parsed_data.size());
+				log_printf(LOGFILE_EVENT_LOG,
+					"Data in the SEXP Map container is corrupt. Must be an even number of entries. Instead have %d",
+					(int)parsed_data.size());
+				Sexp_containers.pop_back();
+			} else {
+				for (int i = 0; i < (int)parsed_data.size(); i += 2) {
+					new_map.map_data.emplace(parsed_data[i], parsed_data[i + 1]);
+				}
+			}
+		} else {
+			Sexp_containers.pop_back();
+		}
+	}
+}
+
+int get_sexp_container_index_generic(const char* name,
+	const std::function<bool(const char*, const char*)>& match_func)
+{
+	for (int i = 0; i < (int)Sexp_containers.size(); ++i) {
+		if (match_func(Sexp_containers[i].container_name.c_str(), name)) {
+			return i;
+		}
+	}
+
+	// not found
+	return -1;
+}
+
+static bool str_match(const char* str1, const char* str2)
+{
+	return !stricmp(str1, str2);
+}
+
+/**
+ * Return index of a sexp_container by its name, or -1 if not found
+ */
+int get_sexp_container_index(const char* name) {
+	return get_sexp_container_index_generic(name, str_match);
+}
+
+static bool str_prefix(const char* prefix, const char* str)
+{
+	for (; *prefix; ++prefix, ++str) {
+		if (SCP_tolower(*str) != SCP_tolower(*prefix)) {
+			return false;
+		}
+	}
+
+	return true;
+}
+
+/**
+* Tests whether this position in a character array is the start of a container name
+* return index in Sexp_containers or -1 if not found
+**/
+int get_sexp_container_index_special(const SCP_string& text, size_t start_pos)
+{
+	Assert(!text.empty());
+	Assert(start_pos < text.length());
+
+	return get_sexp_container_index_generic(text.c_str() + start_pos, str_prefix);
+}

--- a/code/parse/sexp_container.cpp
+++ b/code/parse/sexp_container.cpp
@@ -93,10 +93,11 @@ bool stuff_one_generic_sexp_container(SCP_string &name, ContainerType &type, int
 		valid = false;
 	} else if (name.length() > sexp_container::NAME_MAX_LENGTH) {
 		Warning(LOCATION,
-			"SEXP Container name %s is longer than limit %u",
+			"SEXP Container name %s is longer than limit %d",
 			name.c_str(),
 			sexp_container::NAME_MAX_LENGTH);
-		log_printf(LOGFILE_EVENT_LOG, "SEXP Container name %s is longer than limit %i",
+		log_printf(LOGFILE_EVENT_LOG,
+			"SEXP Container name %s is longer than limit %d",
 			name.c_str(),
 			sexp_container::NAME_MAX_LENGTH);
 		valid = false;

--- a/code/parse/sexp_container.cpp
+++ b/code/parse/sexp_container.cpp
@@ -110,10 +110,10 @@ bool stuff_one_generic_sexp_container(SCP_string &name, ContainerType &type, int
 	required_string("$Data Type:");
 	stuff_string(temp_type_string, F_NAME);
 	if (!stricmp(temp_type_string.c_str(), "Number")) {
-		type |= NUMBER_DATA;
+		type |= ContainerType::NUMBER_DATA;
 		opf_type = OPF_NUMBER;
 	} else if (!stricmp(temp_type_string.c_str(), "String")) {
-		type |= STRING_DATA;
+		type |= ContainerType::STRING_DATA;
 		opf_type = OPF_ANYTHING;
 	} else {
 		Warning(LOCATION, "Unknown SEXP Container type %s found", temp_type_string.c_str());
@@ -122,13 +122,13 @@ bool stuff_one_generic_sexp_container(SCP_string &name, ContainerType &type, int
 	}
 
 	if (optional_string("$Key Type:")) {
-		Assertion((type & MAP), "$Key Type: found for container which doesn't use keys!");
+		Assertion((type & ContainerType::MAP), "$Key Type: found for container which doesn't use keys!");
 
 		stuff_string(temp_type_string, F_NAME);
 		if (!stricmp(temp_type_string.c_str(), "Number")) {
-			type |= NUMBER_KEYS;
+			type |= ContainerType::NUMBER_KEYS;
 		} else if (!stricmp(temp_type_string.c_str(), "String")) {
-			type |= STRING_KEYS;
+			type |= ContainerType::STRING_KEYS;
 		} else {
 			Warning(LOCATION, "Unknown SEXP Container type %s found", temp_type_string.c_str());
 			log_printf(LOGFILE_EVENT_LOG, "Unknown SEXP Container type %s found", temp_type_string.c_str());
@@ -137,14 +137,14 @@ bool stuff_one_generic_sexp_container(SCP_string &name, ContainerType &type, int
 	}
 
 	if (optional_string("+Strictly Typed Keys")) {
-		Assertion((type & MAP), "+Strictly Typed Keys found for container which doesn't use keys!");
+		Assertion((type & ContainerType::MAP), "+Strictly Typed Keys found for container which doesn't use keys!");
 		Warning(LOCATION, "Container %s is marked for strictly typed keys, which are not yet supported.", name.c_str());
-		type |= STRICTLY_TYPED_KEYS;
+		type |= ContainerType::STRICTLY_TYPED_KEYS;
 	}
 
 	if (optional_string("+Strictly Typed Data")) {
 		Warning(LOCATION, "Container %s is marked for strictly typed data, which are not yet supported.", name.c_str());
-		type |= STRICTLY_TYPED_DATA;
+		type |= ContainerType::STRICTLY_TYPED_DATA;
 	}
 
 	required_string("$Data:");
@@ -152,26 +152,26 @@ bool stuff_one_generic_sexp_container(SCP_string &name, ContainerType &type, int
 
 	if (optional_string("+Network Container")) {
 		Warning(LOCATION, "Container %s is marked as a network container, which is not yet supported.", name.c_str());
-		type |= NETWORK;
+		type |= ContainerType::NETWORK;
 	}
 
 	if (optional_string("+Eternal")) {
-		type |= SAVE_TO_PLAYER_FILE;
+		type |= ContainerType::SAVE_TO_PLAYER_FILE;
 	}
 
 	// campaign-persistent
 	if (optional_string("+Save On Mission Progress")) {
-		type |= SAVE_ON_MISSION_PROGRESS;
+		type |= ContainerType::SAVE_ON_MISSION_PROGRESS;
 	}
 
 	// player-persistent
 	if (optional_string("+Save On Mission Close")) {
-		Assert(!(type & SAVE_ON_MISSION_PROGRESS));
-		type |= SAVE_ON_MISSION_CLOSE;
+		Assert(!(type & ContainerType::SAVE_ON_MISSION_PROGRESS));
+		type |= ContainerType::SAVE_ON_MISSION_CLOSE;
 	}
 
-	Assert(!(type & SAVE_TO_PLAYER_FILE) ||
-		((type & SAVE_ON_MISSION_PROGRESS) ^ (type & SAVE_ON_MISSION_CLOSE)));
+	Assert(!(type & ContainerType::SAVE_TO_PLAYER_FILE) ||
+		   ((type & ContainerType::SAVE_ON_MISSION_PROGRESS) ^ (type & ContainerType::SAVE_ON_MISSION_CLOSE)));
 
 	return valid;
 }
@@ -184,7 +184,7 @@ void stuff_sexp_list_containers()
 		Sexp_containers.emplace_back();
 		auto &new_list = Sexp_containers.back();
 
-		new_list.type = LIST;
+		new_list.type = ContainerType::LIST;
 		if (stuff_one_generic_sexp_container(new_list.container_name, new_list.type, new_list.opf_type, parsed_data)) {
 			std::copy(parsed_data.begin(), parsed_data.end(), back_inserter(new_list.list_data));
 			Containers_by_name_map.emplace(new_list.container_name, &new_list);
@@ -202,7 +202,7 @@ void stuff_sexp_map_containers()
 		Sexp_containers.emplace_back();
 		auto& new_map = Sexp_containers.back();
 
-		new_map.type = MAP;
+		new_map.type = ContainerType::MAP;
 		if (stuff_one_generic_sexp_container(new_map.container_name, new_map.type, new_map.opf_type, parsed_data)) {
 			if (parsed_data.size() % 2 != 0) {
 				Warning(LOCATION,

--- a/code/parse/sexp_container.cpp
+++ b/code/parse/sexp_container.cpp
@@ -109,10 +109,10 @@ bool stuff_one_generic_sexp_container(SCP_string &name, ContainerType &type, int
 
 	required_string("$Data Type:");
 	stuff_string(temp_type_string, F_NAME);
-	if (!strcmp(temp_type_string.c_str(), "Number")) {
+	if (!stricmp(temp_type_string.c_str(), "Number")) {
 		type |= NUMBER_DATA;
 		opf_type = OPF_NUMBER;
-	} else if (!strcmp(temp_type_string.c_str(), "String")) {
+	} else if (!stricmp(temp_type_string.c_str(), "String")) {
 		type |= STRING_DATA;
 		opf_type = OPF_ANYTHING;
 	} else {
@@ -125,9 +125,9 @@ bool stuff_one_generic_sexp_container(SCP_string &name, ContainerType &type, int
 		Assertion((type & MAP), "$Key Type: found for container which doesn't use keys!");
 
 		stuff_string(temp_type_string, F_NAME);
-		if (!strcmp(temp_type_string.c_str(), "Number")) {
+		if (!stricmp(temp_type_string.c_str(), "Number")) {
 			type |= NUMBER_KEYS;
-		} else if (!strcmp(temp_type_string.c_str(), "String")) {
+		} else if (!stricmp(temp_type_string.c_str(), "String")) {
 			type |= STRING_KEYS;
 		} else {
 			Warning(LOCATION, "Unknown SEXP Container type %s found", temp_type_string.c_str());

--- a/code/parse/sexp_container.h
+++ b/code/parse/sexp_container.h
@@ -109,6 +109,10 @@ void stuff_sexp_list_containers();
 void stuff_sexp_map_containers();
 
 // retrieval functions
-const SCP_vector<sexp_container>& get_all_sexp_containers();
+const SCP_vector<sexp_container> &get_all_sexp_containers();
 const SCP_vector<list_modifier> &get_all_list_modifiers();
-int get_sexp_container_index(const char *name);
+
+/**
+ * Return pointer to a sexp_container by its name, or nullptr if not found
+ */
+sexp_container *get_sexp_container(const char *name);

--- a/code/parse/sexp_container.h
+++ b/code/parse/sexp_container.h
@@ -1,0 +1,114 @@
+/*
+ * Created by Hassan "Karajorma" Kazmi and Josh "jg18" Glatt for The FreeSpace 2 Source Code Project.
+ * You may not sell or otherwise commercially exploit the source or things you
+ * create based on the source.
+ */
+
+#pragma once
+
+#include "globalincs/globals.h"
+#include "globalincs/pstypes.h"
+#include "parse/sexp.h"
+
+// must inherit from int because of persistence (e.g., csg_write_int())
+enum ContainerType : int {
+	LIST = 0x01,
+	MAP = 0x02,
+	STRICTLY_TYPED_KEYS = 0x04,
+	STRICTLY_TYPED_DATA = 0x08,
+	NUMBER_DATA = 0x10,
+	STRING_DATA = 0x20,
+	NUMBER_KEYS = 0x40,
+	STRING_KEYS = 0x80,
+
+	// persistence
+	SAVE_ON_MISSION_CLOSE = 0x08000000,
+	SAVE_ON_MISSION_PROGRESS = 0x10000000,
+	NETWORK = 0x20000000,
+	SAVE_TO_PLAYER_FILE = 0x40000000,
+};
+
+inline constexpr bool operator&(ContainerType lhs, ContainerType rhs) {
+	using ContainerTypeInt = std::underlying_type<ContainerType>::type;
+	return static_cast<ContainerTypeInt>(lhs) & static_cast<ContainerTypeInt>(rhs);
+}
+
+inline constexpr ContainerType operator|(ContainerType lhs, ContainerType rhs) {
+	using ContainerTypeInt = std::underlying_type<ContainerType>::type;
+	return static_cast<ContainerType>(static_cast<ContainerTypeInt>(lhs) |
+		static_cast<ContainerTypeInt>(rhs));
+}
+
+inline void operator|=(ContainerType lhs, ContainerType rhs) { lhs = lhs | rhs; }
+
+struct sexp_container
+{
+	// meta-character for containers in text replacement, etc.
+	static constexpr char DELIM = '&';
+	// applies to list data, map keys, and map data
+	static constexpr int VALUE_MAX_LENGTH = NAME_LENGTH - 1; // leave space for null char
+	// leave space for leading/trailing '&' for container multidimensionality
+	static constexpr int NAME_MAX_LENGTH = VALUE_MAX_LENGTH - 2;
+
+	SCP_string container_name;
+	ContainerType type = LIST | STRING_DATA;
+	int opf_type = OPF_ANYTHING;
+
+	SCP_list<SCP_string> list_data;
+	SCP_unordered_map<SCP_string, SCP_string> map_data;
+
+	inline bool is_list() const
+	{
+		return type & LIST;
+	}
+
+	inline bool is_map() const
+	{
+		return type & MAP;
+	}
+
+	inline bool is_eternal() const
+	{
+		return type & SAVE_TO_PLAYER_FILE;
+	}
+
+	inline bool is_persistent() const
+	{
+		return type & (SAVE_ON_MISSION_PROGRESS | SAVE_ON_MISSION_CLOSE);
+	}
+
+	bool empty() const;
+	int size() const;
+};
+
+struct list_modifier {
+	enum class Modifier
+	{
+		GET_FIRST,
+		GET_LAST,
+		REMOVE_FIRST,
+		REMOVE_LAST,
+		GET_RANDOM,
+		REMOVE_RANDOM,
+		AT_INDEX,
+		INVALID
+	};
+
+	const char *name;
+	const Modifier modifier;
+};
+
+using ListModifier = list_modifier::Modifier;
+
+// management functions
+void init_sexp_containers();
+void update_sexp_containers(SCP_vector<sexp_container>& containers);
+
+// parsing functions
+void stuff_sexp_list_containers();
+void stuff_sexp_map_containers();
+
+// retrieval functions
+const SCP_vector<sexp_container>& get_all_sexp_containers();
+const SCP_vector<list_modifier> &get_all_list_modifiers();
+int get_sexp_container_index(const char *name);

--- a/code/parse/sexp_container.h
+++ b/code/parse/sexp_container.h
@@ -11,7 +11,7 @@
 #include "parse/sexp.h"
 
 // must inherit from int because of persistence (e.g., csg_write_int())
-enum ContainerType : int {
+enum class ContainerType : int {
 	LIST = 0x01,
 	MAP = 0x02,
 	STRICTLY_TYPED_KEYS = 0x04,
@@ -51,7 +51,7 @@ struct sexp_container
 	static constexpr int NAME_MAX_LENGTH = VALUE_MAX_LENGTH - 2;
 
 	SCP_string container_name;
-	ContainerType type = LIST | STRING_DATA;
+	ContainerType type = ContainerType::LIST | ContainerType::STRING_DATA;
 	int opf_type = OPF_ANYTHING;
 
 	SCP_list<SCP_string> list_data;
@@ -59,22 +59,22 @@ struct sexp_container
 
 	inline bool is_list() const
 	{
-		return type & LIST;
+		return type & ContainerType::LIST;
 	}
 
 	inline bool is_map() const
 	{
-		return type & MAP;
+		return type & ContainerType::MAP;
 	}
 
 	inline bool is_eternal() const
 	{
-		return type & SAVE_TO_PLAYER_FILE;
+		return type & ContainerType::SAVE_TO_PLAYER_FILE;
 	}
 
 	inline bool is_persistent() const
 	{
-		return type & (SAVE_ON_MISSION_PROGRESS | SAVE_ON_MISSION_CLOSE);
+		return type & (ContainerType::SAVE_ON_MISSION_PROGRESS | ContainerType::SAVE_ON_MISSION_CLOSE);
 	}
 
 	bool empty() const;

--- a/code/source_groups.cmake
+++ b/code/source_groups.cmake
@@ -1021,6 +1021,8 @@ add_file_folder("Parse"
 	parse/parselo.h
 	parse/sexp.cpp
 	parse/sexp.h
+	parse/sexp_container.cpp
+	parse/sexp_container.h
 )
 
 add_file_folder("Parse\\\\SEXP"

--- a/fred2/missionsave.cpp
+++ b/fred2/missionsave.cpp
@@ -1675,13 +1675,13 @@ int CFred_mission_save::save_containers()
 		for (const auto &container : containers) {
 			if (container.is_list()) {
 				fout("\n$Name: %s", container.container_name.c_str());
-				if (container.type & STRING_DATA) {
+				if (container.type & ContainerType::STRING_DATA) {
 					fout("\n$Data Type: String");
-				} else if (container.type & NUMBER_DATA) {
+				} else if (container.type & ContainerType::NUMBER_DATA) {
 					fout("\n$Data Type: Number");
 				}
 
-				if (container.type & STRICTLY_TYPED_DATA) {
+				if (container.type & ContainerType::STRICTLY_TYPED_DATA) {
 					fout("\n+Strictly Typed Data");
 				}
 
@@ -1707,23 +1707,23 @@ int CFred_mission_save::save_containers()
 		for (const auto &container : containers) {
 			if (container.is_map()) {
 				fout("\n$Name: %s", container.container_name.c_str());
-				if (container.type & STRING_DATA) {
+				if (container.type & ContainerType::STRING_DATA) {
 					fout("\n$Data Type: String");
-				} else if (container.type & NUMBER_DATA) {
+				} else if (container.type & ContainerType::NUMBER_DATA) {
 					fout("\n$Data Type: Number");
 				}
 
-				if (container.type & NUMBER_KEYS) {
+				if (container.type & ContainerType::NUMBER_KEYS) {
 					fout("\n$Key Type: Number");
 				} else {
 					fout("\n$Key Type: String");
 				}
 
-				if (container.type & STRICTLY_TYPED_KEYS) {
+				if (container.type & ContainerType::STRICTLY_TYPED_KEYS) {
 					fout("\n+Strictly Typed Keys");
 				}
 
-				if (container.type & STRICTLY_TYPED_DATA) {
+				if (container.type & ContainerType::STRICTLY_TYPED_DATA) {
 					fout("\n+Strictly Typed Data");
 				}
 
@@ -1747,7 +1747,7 @@ int CFred_mission_save::save_containers()
 
 void CFred_mission_save::save_container_options(const sexp_container &container)
 {
-	if (container.type & NETWORK) {
+	if (container.type & ContainerType::NETWORK) {
 		fout("+Network Container\n");
 	}
 
@@ -1755,9 +1755,9 @@ void CFred_mission_save::save_container_options(const sexp_container &container)
 		fout("+Eternal\n");
 	}
 
-	if (container.type & SAVE_ON_MISSION_CLOSE) {
+	if (container.type & ContainerType::SAVE_ON_MISSION_CLOSE) {
 		fout("+Save On Mission Close\n");
-	} else if (container.type & SAVE_ON_MISSION_PROGRESS) {
+	} else if (container.type & ContainerType::SAVE_ON_MISSION_PROGRESS) {
 		fout("+Save On Mission Progress\n");
 	}
 

--- a/fred2/missionsave.cpp
+++ b/fred2/missionsave.cpp
@@ -1635,6 +1635,128 @@ int CFred_mission_save::save_common_object_data(object *objp, ship *shipp)
 	return err;
 }
 
+int CFred_mission_save::save_containers()
+{
+	if (Mission_save_format == FSO_FORMAT_RETAIL) {
+		return 0;
+	}
+
+	if (Sexp_containers.empty()) {
+		fso_comment_pop(true);
+		return 0;
+	}
+
+	required_string_fred("#Sexp_containers");
+	parse_comments(2);
+
+	bool list_found = false;
+	bool map_found = false;
+
+	// What types of container do we have?
+	for (int i = 0; i < (int)Sexp_containers.size() && !(list_found && map_found); i++) {
+		if (Sexp_containers[i].is_list()) {
+			list_found = true;
+		} else if (Sexp_containers[i].is_map()) {
+			map_found = true;
+		}
+	}
+
+	if (list_found) {
+		required_string_fred("$Lists");
+		parse_comments(2);
+
+		for (int i = 0; i < (int)Sexp_containers.size(); i++) {
+			if (Sexp_containers[i].is_list()) {
+				fout("\n$Name: %s", Sexp_containers[i].container_name.c_str());
+				if (Sexp_containers[i].type & SEXP_CONTAINER_STRING_DATA) {
+					fout("\n$Data Type: String");
+				} else if (Sexp_containers[i].type & SEXP_CONTAINER_NUMBER_DATA) {
+					fout("\n$Data Type: Number");
+				}
+
+				if (Sexp_containers[i].type & SEXP_CONTAINER_STRICTLY_TYPED_DATA) {
+					fout("\n+Strictly Typed Data");
+				}
+
+				fout("\n$Data: ( ");
+				for (const auto &list_entry : Sexp_containers[i].list_data) {
+					fout("\"%s\" ", list_entry.c_str());
+				}
+
+				fout(")\n");
+
+				save_container_options(Sexp_containers[i]);
+			}
+		}
+
+		required_string_fred("$End Lists");
+		parse_comments(1);
+	}
+
+	if (map_found) {
+		required_string_fred("$Maps");
+		parse_comments(2);
+
+		for (int i = 0; i < (int)Sexp_containers.size(); i++) {
+			if (Sexp_containers[i].is_map()) {
+				fout("\n$Name: %s", Sexp_containers[i].container_name.c_str());
+				if (Sexp_containers[i].type & SEXP_CONTAINER_STRING_DATA) {
+					fout("\n$Data Type: String");
+				} else if (Sexp_containers[i].type & SEXP_CONTAINER_NUMBER_DATA) {
+					fout("\n$Data Type: Number");
+				}
+
+				if (Sexp_containers[i].type & SEXP_CONTAINER_NUMBER_KEYS) {
+					fout("\n$Key Type: Number");
+				} else {
+					fout("\n$Key Type: String");
+				}
+
+				if (Sexp_containers[i].type & SEXP_CONTAINER_STRICTLY_TYPED_KEYS) {
+					fout("\n+Strictly Typed Keys");
+				}
+
+				if (Sexp_containers[i].type & SEXP_CONTAINER_STRICTLY_TYPED_DATA) {
+					fout("\n+Strictly Typed Data");
+				}
+
+				fout("\n$Data: ( ");
+				for (const auto &map_entry : Sexp_containers[i].map_data) {
+					fout("\"%s\" \"%s\" ", map_entry.first.c_str(), map_entry.second.c_str());
+				}
+
+				fout(")\n");
+
+				save_container_options(Sexp_containers[i]);
+			}
+		}
+
+		required_string_fred("$End Maps");
+		parse_comments(1);
+	}
+
+	return err;
+}
+
+void CFred_mission_save::save_container_options(const sexp_container &container)
+{
+	if (container.type & SEXP_CONTAINER_NETWORK) {
+		fout("+Network Container\n");
+	}
+
+	if (container.is_eternal()) {
+		fout("+Eternal\n");
+	}
+
+	if (container.type & SEXP_CONTAINER_SAVE_ON_MISSION_CLOSE) {
+		fout("+Save On Mission Close\n");
+	} else if (container.type & SEXP_CONTAINER_SAVE_ON_MISSION_PROGRESS) {
+		fout("+Save On Mission Progress\n");
+	}
+
+	fout("\n");
+}
+
 void CFred_mission_save::save_custom_bitmap(const char *expected_string_640, const char *expected_string_1024, const char *string_field_640, const char *string_field_1024, int blank_lines)
 {
 	if (Mission_save_format != FSO_FORMAT_RETAIL) {
@@ -2653,6 +2775,8 @@ void CFred_mission_save::save_mission_internal(const char *pathname)
 	else if (save_plot_info())
 		err = -3;
 	else if (save_variables())
+		err = -3;
+	else if (save_containers())
 		err = -3;
 	//	else if (save_briefing_info())
 	//		err = -4;

--- a/fred2/missionsave.h
+++ b/fred2/missionsave.h
@@ -440,6 +440,18 @@ private:
 	int save_variables();
 
 	/**
+	* @brief Saves sexp containers to a file
+	*
+	* @details Returns the value of CFred_mission_save::err, which is:
+	*
+	* @returns 0 for no error, or
+	* @returns A negative value if an error occurred
+	*/
+	int save_containers();
+	// helper function for non-type options, called only by save_containers()
+	void save_container_options(const sexp_container &container);
+
+	/**
 	 * @brief Saves the given vector to file
 	 *
 	 * @param[in] v Vector to save

--- a/fred2/missionsave.h
+++ b/fred2/missionsave.h
@@ -22,6 +22,8 @@
 #include <string>
 #include <stdio.h>
 
+struct sexp_container;
+
 #define BACKUP_DEPTH	9
 
 /**

--- a/qtfred/src/mission/missionsave.cpp
+++ b/qtfred/src/mission/missionsave.cpp
@@ -4030,7 +4030,7 @@ int CFred_mission_save::save_variables()
 
 int CFred_mission_save::save_containers()
 {
-	if (Mission_save_format == FSO_FORMAT_RETAIL) {
+	if (save_format == MissionFormat::RETAIL) {
 		return 0;
 	}
 

--- a/qtfred/src/mission/missionsave.cpp
+++ b/qtfred/src/mission/missionsave.cpp
@@ -4067,13 +4067,13 @@ int CFred_mission_save::save_containers()
 		for (const auto &container : containers) {
 			if (container.is_list()) {
 				fout("\n$Name: %s", container.container_name.c_str());
-				if (container.type & STRING_DATA) {
+				if (container.type & ContainerType::STRING_DATA) {
 					fout("\n$Data Type: String");
-				} else if (container.type & NUMBER_DATA) {
+				} else if (container.type & ContainerType::NUMBER_DATA) {
 					fout("\n$Data Type: Number");
 				}
 
-				if (container.type & STRICTLY_TYPED_DATA) {
+				if (container.type & ContainerType::STRICTLY_TYPED_DATA) {
 					fout("\n+Strictly Typed Data");
 				}
 
@@ -4099,23 +4099,23 @@ int CFred_mission_save::save_containers()
 		for (const auto &container : containers) {
 			if (container.is_map()) {
 				fout("\n$Name: %s", container.container_name.c_str());
-				if (container.type & STRING_DATA) {
+				if (container.type & ContainerType::STRING_DATA) {
 					fout("\n$Data Type: String");
-				} else if (container.type & NUMBER_DATA) {
+				} else if (container.type & ContainerType::NUMBER_DATA) {
 					fout("\n$Data Type: Number");
 				}
 
-				if (container.type & NUMBER_KEYS) {
+				if (container.type & ContainerType::NUMBER_KEYS) {
 					fout("\n$Key Type: Number");
 				} else {
 					fout("\n$Key Type: String");
 				}
 
-				if (container.type & STRICTLY_TYPED_KEYS) {
+				if (container.type & ContainerType::STRICTLY_TYPED_KEYS) {
 					fout("\n+Strictly Typed Keys");
 				}
 
-				if (container.type & STRICTLY_TYPED_DATA) {
+				if (container.type & ContainerType::STRICTLY_TYPED_DATA) {
 					fout("\n+Strictly Typed Data");
 				}
 
@@ -4139,7 +4139,7 @@ int CFred_mission_save::save_containers()
 
 void CFred_mission_save::save_container_options(const sexp_container &container)
 {
-	if (container.type & NETWORK) {
+	if (container.type & ContainerType::NETWORK) {
 		fout("+Network Container\n");
 	}
 
@@ -4147,9 +4147,9 @@ void CFred_mission_save::save_container_options(const sexp_container &container)
 		fout("+Eternal\n");
 	}
 
-	if (container.type & SAVE_ON_MISSION_CLOSE) {
+	if (container.type & ContainerType::SAVE_ON_MISSION_CLOSE) {
 		fout("+Save On Mission Close\n");
-	} else if (container.type & SAVE_ON_MISSION_PROGRESS) {
+	} else if (container.type & ContainerType::SAVE_ON_MISSION_PROGRESS) {
 		fout("+Save On Mission Progress\n");
 	}
 

--- a/qtfred/src/mission/missionsave.h
+++ b/qtfred/src/mission/missionsave.h
@@ -438,6 +438,18 @@ class CFred_mission_save {
 	int save_variables();
 
 	/**
+	 * @brief Saves sexp containers to a file
+	 *
+	 * @details Returns the value of CFred_mission_save::err, which is:
+	 *
+	 * @returns 0 for no error, or
+	 * @returns A negative value if an error occurred
+	 */
+	int save_containers();
+	// helper function for non-type options, called only by save_containers()
+	void save_container_options(const sexp_container &container);
+
+	/**
 	 * @brief Saves the given vector to file
 	 *
 	 * @param[in] v Vector to save

--- a/qtfred/src/mission/missionsave.h
+++ b/qtfred/src/mission/missionsave.h
@@ -22,6 +22,8 @@
 #include <string>
 #include <cstdio>
 
+struct sexp_container;
+
 namespace fso {
 namespace fred {
 


### PR DESCRIPTION
First in a series of PRs to add SEXP containers, based on PR #3398 .

This PR adds
- definition (`struct sexp_container`) and basic bit flags
- parsing containers from mission (`.fs2`) files
- saving containers to mission files