### PR TITLE
Add weapon ambient sound

### DIFF
--- a/code/object/objectsnd.cpp
+++ b/code/object/objectsnd.cpp
@@ -247,6 +247,7 @@ void obj_snd_stop(object *objp, int index)
 					case OBJ_GHOST:
 					case OBJ_DEBRIS:
 					case OBJ_ASTEROID:
+					case OBJ_WEAPON:
 						Num_obj_sounds_playing--;
 						Assert(Num_obj_sounds_playing >= 0);					
 						break;
@@ -272,6 +273,7 @@ void obj_snd_stop(object *objp, int index)
 			case OBJ_GHOST:
 			case OBJ_DEBRIS:
 			case OBJ_ASTEROID:
+			case OBJ_WEAPON:
 				Num_obj_sounds_playing--;
 				Assert(Num_obj_sounds_playing >= 0);					
 				break;
@@ -594,6 +596,7 @@ void obj_snd_do_frame()
 					case OBJ_SHIP:
 					case OBJ_DEBRIS:
 					case OBJ_ASTEROID:
+					case OBJ_WEAPON:
 						if ( Num_obj_sounds_playing >= MAX_OBJ_SOUNDS_PLAYING ) {
 							go_ahead_flag = obj_snd_stop_lowest_vol(new_vol);
 						}

--- a/code/weapon/weapon.h
+++ b/code/weapon/weapon.h
@@ -387,10 +387,11 @@ struct weapon_info
 	gamesnd_id	impact_snd;
 	gamesnd_id disarmed_impact_snd;
 	gamesnd_id	flyby_snd;							//	whizz-by sound, transmitted through weapon's portable atmosphere.
+	gamesnd_id	ambient_snd;
 	
-	gamesnd_id hud_tracking_snd; // Sound played when this weapon tracks a target
-	gamesnd_id hud_locked_snd; // Sound played when this weapon locked onto a target
-	gamesnd_id hud_in_flight_snd; // Sound played while the weapon is in flight
+	gamesnd_id hud_tracking_snd; // Sound played when the player is tracking a target with this weapon
+	gamesnd_id hud_locked_snd; // Sound played when the player is locked onto a target with this weapon
+	gamesnd_id hud_in_flight_snd; // Sound played while the player has this weapon in flight
 	InFlightSoundType in_flight_play_type; // The status when the sound should be played
 
 	// Specific to weapons with TRAILS:

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -34,6 +34,7 @@
 #include "network/multiutil.h"
 #include "object/objcollide.h"
 #include "object/objectdock.h"
+#include "object/objectsnd.h"
 #include "scripting/scripting.h"
 #include "particle/particle.h"
 #include "playerman/player.h"
@@ -1655,6 +1656,8 @@ int parse_weapon(int subtype, bool replace, const char *filename)
 	parse_game_sound("$Disarmed ImpactSnd:", &wip->disarmed_impact_snd);
 
 	parse_game_sound("$FlyBySnd:", &wip->flyby_snd);
+
+	parse_game_sound("$AmbientSnd:", &wip->ambient_snd);
 
 	parse_game_sound("$TrackingSnd:", &wip->hud_tracking_snd);
 	
@@ -6111,6 +6114,10 @@ int weapon_create( vec3d * pos, matrix * porient, int weapon_type, int parent_ob
 			&vmd_zero_vector,
 			&vmd_identity_matrix,
 			model_get(wip->model_num)->detail[0]);
+	}
+
+	if (wip->ambient_snd.isValid()) {
+		obj_snd_assign(objnum, wip->ambient_snd, &vmd_zero_vector , 1);
 	}
 
 	Script_system.SetHookObject("Weapon", &Objects[objnum]);


### PR DESCRIPTION
Very confusingly $InFlightSnd is _not_ a 3d sound that the weapon emits, like EngineSnd for ships. It is a HUD sound that constantly plays while the player has one of these weapons in flight. This adds 'AmbientSnd' for weapons, as a counterpart to EngineSnd, any instance of this weapon passively emits this 3d sound as it moves.