### PR TITLE
Remove glowpoint 'depth'

### DIFF
--- a/code/model/modelrender.cpp
+++ b/code/model/modelrender.cpp
@@ -1703,9 +1703,9 @@ void model_render_glowpoint(int point_num, vec3d *pos, matrix *orient, glow_poin
 					int bitmap_id = (gpo && gpo->glow_bitmap_override) ? gpo->glow_bitmap : bank->glow_bitmap;
 
 					if ( use_depth_buffer ) {
-						batching_add_volume_bitmap(bitmap_id, &p, 0, (w * 0.5f), d * pulse, w);
+						batching_add_volume_bitmap(bitmap_id, &p, 0, (w * 0.5f), d * pulse);
 					} else {
-						batching_add_bitmap(bitmap_id, &p, 0, (w * 0.5f), d * pulse, w);
+						batching_add_bitmap(bitmap_id, &p, 0, (w * 0.5f), d * pulse);
 					}
 				}
 			} //d>0.0f


### PR DESCRIPTION
Glowpoint rendering uses `batching_add_bitmap`'s 'depth' parameter, which instead of rendering the bitmap at the "regular" position in space directly moves the bitmap towards the camera by the 'depth' amount (for glowpoints, this is always the radius of the glowpoint). Despite knowing exactly how it is works, I have absolutely no idea what sort of effect this is meant to achieve, or what purpose it was intended for. While it might sound reasonable, in practice it simply looks terrible. It is immediately obvious that the glowpoint's bitmap is being 'detached' from its surface and magically floating towards you. Worse still, if you're closer than its radius the glow point is rendered _behind you_ looking even more absurd.

https://user-images.githubusercontent.com/17305613/120088919-8a841600-c0c3-11eb-9734-9492b35fc11d.mp4

(this glowpoint is positioned _directly on the hull_)

I have noticed this jarring effect on many occasions and unless anyone can give some very good reasons to maintain this ugly behavior it should simply be disabled for glowpoints altogether. I'm pretty dubious about the usefulness of this parameter at all, but other things use it, so for now I'm just concerned about glowpoints.