### PR TITLE
Validate user-provided values passed to Random::next()

### DIFF
--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -5096,7 +5096,8 @@ int rand_sexp(int node, bool multiple)
 
 	if (low > high) {
 		Warning(LOCATION, "rand%s was passed an invalid range (%d ... %d)!", multiple ? "-multiple" : "", low, high);
-		return SEXP_KNOWN_FALSE;
+		// preserve old behavior from before Random class was introduced
+		return low;
 	}
 
 	// get the random number

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -5094,6 +5094,11 @@ int rand_sexp(int node, bool multiple)
 	if (is_nan_forever)
 		return SEXP_NAN_FOREVER;
 
+	if (low > high) {
+		Warning(LOCATION, "rand%s was passed an invalid range (%d ... %d)!", multiple ? "-multiple" : "", low, high);
+		return SEXP_KNOWN_FALSE;
+	}
+
 	// get the random number
 	rand_num = rand_internal(low, high, seed);
 
@@ -9853,6 +9858,7 @@ int eval_random_of(int arg_handler_node, int condition_node, bool multiple)
 
 	// get the number of valid arguments
 	num_valid_args = query_sexp_args_count(arg_handler_node, true);
+	Assert(num_valid_args >= 0);
 
 	if (num_valid_args == 0)
 	{

--- a/code/scripting/api/libs/base.cpp
+++ b/code/scripting/api/libs/base.cpp
@@ -66,14 +66,14 @@ ADE_FUNC(rand32,
 		if (a <= b) {
 			result = Random::next(a, b);
 		} else {
-			Warning(LOCATION, "rand32() script function was passed an invalid range (%d ... %d)!", a, b);
+			LuaError(L, "rand32() script function was passed an invalid range (%d ... %d)!", a, b);
 			result = a; // match behavior of rand_sexp()
 		}
 	} else if (numargs == 1) {
 		if (a > 0) {
 			result = Random::next(a);
 		} else {
-			Warning(LOCATION, "rand32() script function was passed an invalid modulus (%d)!", a);
+			LuaError(L, "rand32() script function was passed an invalid modulus (%d)!", a);
 			result = 0;
 		}
 	} else {

--- a/code/scripting/api/libs/base.cpp
+++ b/code/scripting/api/libs/base.cpp
@@ -67,7 +67,7 @@ ADE_FUNC(rand32,
 			result = Random::next(a, b);
 		} else {
 			Warning(LOCATION, "rand32() script function was passed an invalid range (%d ... %d)!", a, b);
-			result = 0;
+			result = a; // match behavior of rand_sexp()
 		}
 	} else if (numargs == 1) {
 		if (a > 0) {

--- a/code/scripting/api/libs/base.cpp
+++ b/code/scripting/api/libs/base.cpp
@@ -62,12 +62,23 @@ ADE_FUNC(rand32,
 	int numargs = ade_get_args(L, "|ii", &a, &b);
 
 	int result;
-	if (numargs == 2)
-		result = Random::next(a, b);
-	else if (numargs == 1)
-		result = Random::next(a);
-	else
+	if (numargs == 2) {
+		if (a <= b) {
+			result = Random::next(a, b);
+		} else {
+			Warning(LOCATION, "rand32() script function was passed an invalid range (%d ... %d)!", a, b);
+			result = 0;
+		}
+	} else if (numargs == 1) {
+		if (a > 0) {
+			result = Random::next(a);
+		} else {
+			Warning(LOCATION, "rand32() script function was passed an invalid modulus (%d)!", a);
+			result = 0;
+		}
+	} else {
 		result = Random::next();
+	}
 
 	return ade_set_error(L, "i", result);
 }


### PR DESCRIPTION
Validate values supplied to `rand` and `rand-multiple` SEXPs and also to `rand32()` scripting function before calling `Random::next()`, and issue a warning if the provided values are invalid.

Fixes issue #3459.