### PR TITLE
Fix calling split_str() with a maximum line length of 0.

### DIFF
--- a/code/missionui/missionshipchoice.cpp
+++ b/code/missionui/missionshipchoice.cpp
@@ -1222,7 +1222,7 @@ void ship_select_blit_ship_info()
 	if(Ship_select_ship_info_text[0] != '\0'){
 		// split the string into multiple lines
 		// MageKing17: Changed to use the widths determined by Yarn here: http://scp.indiegames.us/mantis/view.php?id=3144#c16516
-		n_lines = split_str(Ship_select_ship_info_text, gr_screen.res == GR_640 ? 204 : 328, n_chars, p_str, MAX_NUM_SHIP_DESC_LINES, 0, SHIP_SELECT_SHIP_INFO_MAX_LINE_LEN);
+		n_lines = split_str(Ship_select_ship_info_text, gr_screen.res == GR_640 ? 204 : 328, n_chars, p_str, MAX_NUM_SHIP_DESC_LINES, SHIP_SELECT_SHIP_INFO_MAX_LINE_LEN);
 
 		// copy the split up lines into the text lines array
 		for (int idx = 0;idx<n_lines;idx++ ) {

--- a/code/parse/parselo.cpp
+++ b/code/parse/parselo.cpp
@@ -3337,6 +3337,8 @@ int split_str(const char *src, int max_pixel_w, int *n_chars, const char **p_str
 	Assert(max_lines > 0);
 	Assert(max_pixel_w > 0);
 
+	Assertion(max_line_length > 0, "Max line length should be >0, not %d; get a coder!\n", max_line_length);
+
 	memset(buffer, 0, sizeof(buffer));
 	buf_index = 0;
 	ignore_until_whitespace = 0;
@@ -3464,6 +3466,8 @@ int split_str(const char *src, int max_pixel_w, SCP_vector<int> &n_chars, SCP_ve
 	// check our assumptions..
 	Assert(src != NULL);
 	Assert(max_pixel_w > 0);
+
+	Assertion(max_line_length > 0, "Max line length should be >0, not %d; get a coder!\n", max_line_length);
 
 	memset(buffer, 0, sizeof(buffer));
 


### PR DESCRIPTION
Commit 6c2ebab01c2ab51c1fd1876370667d6f4400be7c (#3439) added a `max_line_length` argument to `split_str()`, but one call had the extra argument added in the wrong spot, and so a previously-pointless-but-harmless `ignored_char` of 0 became a `max_line_length` of 0, resulting (ultimately) in an exception in the unicode code when the iterator tried to decrement at the beginning of a ship's description. This gets rid of the argument entirely, rather than reordering them, because ignoring null characters doesn't really do anything anyway.

I've also added `Assertion`s to check `max_line_length` that should prevent this specific problem from occurring again in the future.