### PR TITLE
Add "no collide" for weapons

### DIFF
--- a/code/weapon/beam.cpp
+++ b/code/weapon/beam.cpp
@@ -483,7 +483,9 @@ int beam_fire(beam_fire_info *fire_info)
 	}	
 
     flagset<Object::Object_Flags> default_flags;
-    default_flags.set(Object::Object_Flags::Collides);
+	if (!wip->wi_flags[Weapon::Info_Flags::No_collide])
+		default_flags.set(Object::Object_Flags::Collides);
+
 	// create the associated object
 	objnum = obj_create(OBJ_BEAM, ((fire_info->shooter != NULL) ? OBJ_INDEX(fire_info->shooter) : -1), BEAM_INDEX(new_item), &vmd_identity_matrix, &vmd_zero_vector, 1.0f, default_flags);
 	if(objnum < 0){
@@ -613,8 +615,12 @@ int beam_fire_targeting(fighter_beam_fire_info *fire_info)
 
 	// type c is a very special weapon type - binfo has no meaning
 
+	flagset<Object::Object_Flags> initial_flags;
+	if (!wip->wi_flags[Weapon::Info_Flags::No_collide])
+		initial_flags.set(Object::Object_Flags::Collides);
+
 	// create the associated object
-	objnum = obj_create(OBJ_BEAM, OBJ_INDEX(fire_info->shooter), BEAM_INDEX(new_item), &vmd_identity_matrix, &vmd_zero_vector, 1.0f, {Object::Object_Flags::Collides});
+	objnum = obj_create(OBJ_BEAM, OBJ_INDEX(fire_info->shooter), BEAM_INDEX(new_item), &vmd_identity_matrix, &vmd_zero_vector, 1.0f, initial_flags);
 
 	if(objnum < 0){
 		beam_delete(new_item);
@@ -2399,8 +2405,9 @@ void beam_aim(beam *b)
 		UNREACHABLE("Impossible beam type (%d); get a coder!\n", b->type);
 	}
 
-	// recalculate object pairs
-	OBJ_RECALC_PAIRS((&Objects[b->objnum]));
+	if (!Weapon_info[b->weapon_info_index].wi_flags[Weapon::Info_Flags::No_collide])
+		// recalculate object pairs
+		OBJ_RECALC_PAIRS((&Objects[b->objnum]));
 }
 
 // given a model #, and an object, stuff 2 good world coord points

--- a/code/weapon/weapon_flags.h
+++ b/code/weapon/weapon_flags.h
@@ -87,6 +87,7 @@ namespace Weapon {
 		Require_exact_los,					// If secondary or in turret, will only fire if ship has line of sight to target
 		Can_damage_shooter,					// this weapon and any of its descendants can damage its shooter - Asteroth
 		Heals,								// 'damage' heals instead of actually damaging - Asteroth
+		No_collide,
 
         NUM_VALUES
 	};

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -185,6 +185,7 @@ flag_def_list_new<Weapon::Info_Flags> Weapon_Info_Flags[] = {
 	{ "require exact los",				Weapon::Info_Flags::Require_exact_los,					true, false },
 	{ "can damage shooter",				Weapon::Info_Flags::Can_damage_shooter,					true, false },
 	{ "heals",							Weapon::Info_Flags::Heals,						        true, false },
+	{ "no collide",						Weapon::Info_Flags::No_collide,						    true, false },
 };
 
 const size_t num_weapon_info_flags = sizeof(Weapon_Info_Flags) / sizeof(flag_def_list_new<Weapon::Info_Flags>);
@@ -5766,8 +5767,10 @@ int weapon_create( vec3d * pos, matrix * porient, int weapon_type, int parent_ob
 	Weapons_created++;
     flagset<Object::Object_Flags> default_flags;
     default_flags.set(Object::Object_Flags::Renders);
-    default_flags.set(Object::Object_Flags::Collides);
     default_flags.set(Object::Object_Flags::Physics);
+
+	if (!wip->wi_flags[Weapon::Info_Flags::No_collide])
+		default_flags.set(Object::Object_Flags::Collides);
 
 	if (wip->wi_flags[Weapon::Info_Flags::Can_damage_shooter])
 		default_flags.set(Object::Object_Flags::Collides_with_parent);


### PR DESCRIPTION
While a silly idea on the surface, modders can (and already do) use weapons for a wide variety of utilitarian purposes, far beyond just things you throw at other things to make them blow up. From triggering visual effects, audio effects, spawning other weapons, or any other thing might want them for, actual collisions might just be getting in the way of what they need.