### PR TITLE
Fix Ai_aims_from_center flag

### DIFF
--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -7554,7 +7554,7 @@ void ai_chase_attack(ai_info *aip, ship_info *sip, vec3d *predicted_enemy_pos, f
 	vec3d	new_pos;
 
 	start_bank = Ships[aip->shipnum].weapons.current_primary_bank;
-	if (po->n_guns && start_bank != -1 ) {
+	if (po->n_guns && start_bank != -1 && !(The_mission.ai_profile->flags[AI::Profile_Flags::Ai_aims_from_ship_center])) {
 		rel_pos = &po->gun_banks[start_bank].pnt[0];
 	} else
 		rel_pos = NULL;


### PR DESCRIPTION
God _dang_ it, Sushi! Test your shit!! A single test with a seraphim or nephilim would tell you immediately that no, just because you put the flag in `set_predicted_enemy_pos` which, yes, is *one* of the places where it arbitrarily grabs the first firepoint does *not* mean the ship will start shooting from its center! Look at what the effect your code is. It's using that data to calculate *collision time* (from the fire point or center), which going to be negligibly affected by whether its counting from the firepoint or center anyway. At no point in that function does it actually *point the ship at something*. That's handled by `ai_turn_towards_vector`'s `rel_pos` parameter, so *that's* what you should be trying to affect.

I don't expect people to know all that, I know that because I've worked with that code before. But I do expect you to _test your code and see if your thing is even working at all_. And before anyone asks, yes, I checked the blame, all the elements which caused it to not work now also existed at the time it was implemented.

/rant