### PR TITLE
Add external weapon model angle offset

### DIFF
--- a/code/hud/hudtarget.cpp
+++ b/code/hud/hudtarget.cpp
@@ -7214,7 +7214,7 @@ void HudGaugeHardpoints::render(float  /*frametime*/)
 					if (num_secondaries_rendered >= sp->weapons.secondary_bank_ammo[i])
 						break;
 
-					if(sp->secondary_point_reload_pct[i][k] <= 0.0)
+					if(sp->secondary_point_reload_pct.get(i, k) <= 0.0)
 						continue;
 
 					model_render_params weapon_render_info;
@@ -7227,7 +7227,7 @@ void HudGaugeHardpoints::render(float  /*frametime*/)
 
 					num_secondaries_rendered++;
 
-					vm_vec_scale_add2(&secondary_weapon_pos, &vmd_z_vector, -(1.0f-sp->secondary_point_reload_pct[i][k]) * model_get(Weapon_info[swp->secondary_bank_weapons[i]].external_model_num)->rad);
+					vm_vec_scale_add2(&secondary_weapon_pos, &vmd_z_vector, -(1.0f-sp->secondary_point_reload_pct.get(i, k)) * model_get(Weapon_info[swp->secondary_bank_weapons[i]].external_model_num)->rad);
 
 					weapon_render_info.set_detail_level_lock(detail_level_lock);
 					weapon_render_info.set_flags(render_flags);

--- a/code/hud/hudtarget.cpp
+++ b/code/hud/hudtarget.cpp
@@ -7185,13 +7185,17 @@ void HudGaugeHardpoints::render(float  /*frametime*/)
 	//secondary weapons
 	int num_secondaries_rendered = 0;
 	if ( draw_secondary_models ) {
+		auto ship_pm = model_get(sip->model_num);
+
 		for (i = 0; i < swp->num_secondary_banks; i++) {
-			if (Weapon_info[swp->secondary_bank_weapons[i]].external_model_num == -1 || !sip->draw_secondary_models[i])
+			auto wip = &Weapon_info[swp->secondary_bank_weapons[i]];
+
+			if (wip->external_model_num == -1 || !sip->draw_secondary_models[i])
 				continue;
 
-			auto bank = &(model_get(sip->model_num))->missile_banks[i];
+			auto bank = &ship_pm->missile_banks[i];
 
-			if (Weapon_info[swp->secondary_bank_weapons[i]].wi_flags[Weapon::Info_Flags::External_weapon_lnch]) {
+			if (wip->wi_flags[Weapon::Info_Flags::External_weapon_lnch]) {
 				for(k = 0; k < bank->num_slots; k++) {
 					model_render_params weapon_render_info;
 
@@ -7202,7 +7206,12 @@ void HudGaugeHardpoints::render(float  /*frametime*/)
 					vec3d world_position;
 					vm_vec_unrotate(&world_position, &bank->pnt[k], &object_orient);
 
-					model_render_immediate(&weapon_render_info, Weapon_info[swp->secondary_bank_weapons[i]].external_model_num, &object_orient, &bank->pnt[k]);
+					// "Bank" the external model by the angle offset
+					angles angs = { 0.0f, bank->external_model_angle_offset[k], 0.0f };
+					matrix model_orient = object_orient;
+					vm_rotate_matrix_by_angles(&model_orient, &angs);
+
+					model_render_immediate(&weapon_render_info, wip->external_model_num, &model_orient, &bank->pnt[k]);
 				}
 			} else {
 				num_secondaries_rendered = 0;
@@ -7227,7 +7236,7 @@ void HudGaugeHardpoints::render(float  /*frametime*/)
 
 					num_secondaries_rendered++;
 
-					vm_vec_scale_add2(&secondary_weapon_pos, &vmd_z_vector, -(1.0f-sp->secondary_point_reload_pct.get(i, k)) * model_get(Weapon_info[swp->secondary_bank_weapons[i]].external_model_num)->rad);
+					vm_vec_scale_add2(&secondary_weapon_pos, &vmd_z_vector, -(1.0f-sp->secondary_point_reload_pct.get(i, k)) * model_get(wip->external_model_num)->rad);
 
 					weapon_render_info.set_detail_level_lock(detail_level_lock);
 					weapon_render_info.set_flags(render_flags);
@@ -7236,7 +7245,12 @@ void HudGaugeHardpoints::render(float  /*frametime*/)
 					vec3d world_position;
 					vm_vec_unrotate(&world_position, &secondary_weapon_pos, &object_orient);
 
-					model_render_immediate(&weapon_render_info, Weapon_info[swp->secondary_bank_weapons[i]].external_model_num, &object_orient, &world_position);
+					// "Bank" the external model by the angle offset
+					angles angs = { 0.0f, bank->external_model_angle_offset[k], 0.0f };
+					matrix model_orient = object_orient;
+					vm_rotate_matrix_by_angles(&model_orient, &angs);
+
+					model_render_immediate(&weapon_render_info, wip->external_model_num, &model_orient, &world_position);
 				}
 			}
 		}
@@ -7248,9 +7262,11 @@ void HudGaugeHardpoints::render(float  /*frametime*/)
 
 	//primary weapons
 	if ( draw_primary_models ) {
+		auto ship_pm = model_get(sip->model_num);
+
 		for ( i = 0; i < swp->num_primary_banks; i++ ) {
 			auto wip = &Weapon_info[swp->primary_bank_weapons[i]];
-			auto bank = &model_get(sip->model_num)->gun_banks[i];
+			auto bank = &ship_pm->gun_banks[i];
 
 			for ( k = 0; k < bank->num_slots; k++ ) {
 				if ( wip->external_model_num < 0 || !sip->draw_primary_models[i] ) {
@@ -7278,7 +7294,12 @@ void HudGaugeHardpoints::render(float  /*frametime*/)
 					vec3d world_position;
 					vm_vec_unrotate(&world_position, &bank->pnt[k], &object_orient);
 
-					model_render_immediate(&weapon_render_info, wip->external_model_num, swp->primary_bank_external_model_instance[i], &object_orient, &world_position);
+					// "Bank" the external model by the angle offset
+					angles angs = { 0.0f, bank->external_model_angle_offset[k], 0.0f };
+					matrix model_orient = object_orient;
+					vm_rotate_matrix_by_angles(&model_orient, &angs);
+
+					model_render_immediate(&weapon_render_info, wip->external_model_num, swp->primary_bank_external_model_instance[i], &model_orient, &world_position);
 				}
 			}
 		}

--- a/code/model/model.h
+++ b/code/model/model.h
@@ -391,14 +391,23 @@ typedef struct model_path {
 // info for gun and missile banks.  Also used for docking points.  There should always
 // only be two slots for each docking bay
 
-#define MAX_SLOTS		25
+struct w_bank
+{
+	int		num_slots = 0;
+	vec3d	*pnt = nullptr;
+	vec3d	*norm = nullptr;
+	float   *external_model_angle_offset = nullptr;
 
-typedef struct w_bank {
-	int		num_slots;
-	vec3d	pnt[MAX_SLOTS];
-	vec3d	norm[MAX_SLOTS];
-	float		radius[MAX_SLOTS];
-} w_bank;
+	~w_bank()
+	{
+		if (pnt)
+			delete[] pnt;
+		if (norm)
+			delete[] norm;
+		if (external_model_angle_offset)
+			delete[] external_model_angle_offset;
+	}
+};
 
 struct glow_point{
 	vec3d	pnt;

--- a/code/model/model.h
+++ b/code/model/model.h
@@ -400,12 +400,9 @@ struct w_bank
 
 	~w_bank()
 	{
-		if (pnt)
-			delete[] pnt;
-		if (norm)
-			delete[] norm;
-		if (external_model_angle_offset)
-			delete[] external_model_angle_offset;
+		delete[] pnt;
+		delete[] norm;
+		delete[] external_model_angle_offset;
 	}
 };
 

--- a/code/model/modelread.cpp
+++ b/code/model/modelread.cpp
@@ -226,11 +226,11 @@ void model_unload(int modelnum, int force)
 		vm_free(pm->shield.tris);
 	}
 
-	if (pm->gun_banks) {
+	if (pm->gun_banks) {	// NOLINT
 		delete[] pm->gun_banks;
 	}
 
-	if (pm->missile_banks) {
+	if (pm->missile_banks) {	// NOLINT
 		delete[] pm->missile_banks;
 	}
 

--- a/code/object/object.cpp
+++ b/code/object/object.cpp
@@ -873,7 +873,7 @@ void obj_move_call_physics(object *objp, float frametime)
 					if (points > missles_left) {
 						//there are more slots than missles left, so not all of the slots will have missles drawn on them
 						for (int k = next_point; k < next_point+missles_left; k ++) {
-							float &s_pct = shipp->secondary_point_reload_pct[i][k % points];
+							float &s_pct = shipp->secondary_point_reload_pct.get(i, k % points);
 							if (s_pct < 1.0)
 								s_pct += reload_time * frametime;
 							if (s_pct > 1.0)
@@ -882,7 +882,7 @@ void obj_move_call_physics(object *objp, float frametime)
 					} else {
 						//we don't have to worry about such things
 						for (int k = 0; k < points; k++) {
-							float &s_pct = shipp->secondary_point_reload_pct[i][k];
+							float &s_pct = shipp->secondary_point_reload_pct.get(i, k);
 							if (s_pct < 1.0)
 								s_pct += reload_time * frametime;
 							if (s_pct > 1.0)

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -6323,11 +6323,7 @@ void ship::clear()
 		was_firing_last_frame[i] = 0;
 	}
 
-	for (i = 0; i < MAX_SHIP_SECONDARY_BANKS; i++)
-	{
-		for (j = 0; j < MAX_SLOTS; j++)
-			secondary_point_reload_pct[i][j] = 1.0f;
-	}
+	secondary_point_reload_pct.init(0, 0, 0.0f);
 	// ---------- done with weapons init
 
 	shield_hits = 0;
@@ -6715,6 +6711,16 @@ static void ship_set(int ship_index, int objnum, int ship_type)
 		else
 			swp->secondary_bank_ammo[i] = (int)std::lround(sip->secondary_bank_ammo_capacity[i] / weapon_size);
 	}
+
+	// set initial reload percentages... used to be done in ship::clear()
+	int max_points_per_bank = 0;
+	for (i = 0; i < sip->num_secondary_banks; ++i)
+	{
+		int slots = pm->missile_banks[i].num_slots;
+		if (slots > max_points_per_bank)
+			max_points_per_bank = slots;
+	}
+	shipp->secondary_point_reload_pct.init(sip->num_secondary_banks, max_points_per_bank, 1.0f);
 
 	shipp->armor_type_idx = sip->armor_type_idx;
 	shipp->shield_armor_type_idx = sip->shield_armor_type_idx;
@@ -12602,7 +12608,7 @@ int ship_fire_secondary( object *obj, int allow_swarm, bool rollback_shot )
 			if ( pnt_index >= num_slots ){
 				pnt_index = 0;
 			}
-			shipp->secondary_point_reload_pct[bank][pnt_index] = 0.0f;
+			shipp->secondary_point_reload_pct.set(bank, pnt_index, 0.0f);
 			pnt = pm->missile_banks[bank].pnt[pnt_index++];
 
 			polymodel *weapon_model = NULL;
@@ -19537,13 +19543,13 @@ void ship_render_weapon_models(model_render_params *ship_render_info, model_draw
 					break;
 				}
 
-				if ( shipp->secondary_point_reload_pct[i][k] <= 0.0 ) {
+				if ( shipp->secondary_point_reload_pct.get(i, k) <= 0.0 ) {
 					continue;
 				}
 
 				num_secondaries_rendered++;
 
-				vm_vec_scale_add2(&secondary_weapon_pos, &vmd_z_vector, -(1.0f-shipp->secondary_point_reload_pct[i][k]) * model_get(Weapon_info[swp->secondary_bank_weapons[i]].external_model_num)->rad);
+				vm_vec_scale_add2(&secondary_weapon_pos, &vmd_z_vector, -(1.0f-shipp->secondary_point_reload_pct.get(i, k)) * model_get(Weapon_info[swp->secondary_bank_weapons[i]].external_model_num)->rad);
 
 				model_render_queue(ship_render_info, scene, Weapon_info[swp->secondary_bank_weapons[i]].external_model_num, &vmd_identity_matrix, &secondary_weapon_pos);
 			}

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -469,22 +469,34 @@ struct reload_pct
 		_points_per_bank = points_per_bank;
 		_buffer.clear();
 		_buffer.resize(num_banks * points_per_bank, value);
+		_value = value;
 	}
 
 	T& get(int bank, int point)
 	{
 		int pos = bank * _points_per_bank + point;
+
+		// this can happen with mismatched ships.tbl and models
+		if (pos >= (int)_buffer.size())
+			return _value;
+
 		return _buffer[pos];
 	}
 
 	void set(int bank, int point, T value)
 	{
 		int pos = bank * _points_per_bank + point;
+
+		// this can happen with mismatched ships.tbl and models
+		if (pos >= (int)_buffer.size())
+			return;
+
 		_buffer[pos] = value;
 	}
 
 private:
 	int _points_per_bank = 0;
+	T _value;
 	SCP_vector<T> _buffer;
 };
 

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -461,6 +461,33 @@ typedef struct ship_spark {
 	int end_time;
 } ship_spark;
 
+template <class T>
+struct reload_pct
+{
+	void init(int num_banks, int points_per_bank, T value)
+	{
+		_points_per_bank = points_per_bank;
+		_buffer.clear();
+		_buffer.resize(num_banks * points_per_bank, value);
+	}
+
+	T& get(int bank, int point)
+	{
+		int pos = bank * _points_per_bank + point;
+		return _buffer[pos];
+	}
+
+	void set(int bank, int point, T value)
+	{
+		int pos = bank * _points_per_bank + point;
+		_buffer[pos] = value;
+	}
+
+private:
+	int _points_per_bank = 0;
+	SCP_vector<T> _buffer;
+};
+
 // NOTE: Can't be treated as a struct anymore, since it has STL data structures in its object tree!
 class ship
 {
@@ -715,7 +742,7 @@ public:
 	bool bay_doors_need_open;		// keep track of whether I need the door open or not
 	int bay_doors_parent_shipnum;	// our parent ship, what we are entering/leaving
 	
-	float secondary_point_reload_pct[MAX_SHIP_SECONDARY_BANKS][MAX_SLOTS];	//after fireing a secondary it takes some time for that secondary weapon to reload, this is how far along in that proces it is (from 0 to 1)
+	reload_pct<float> secondary_point_reload_pct;	//after fireing a secondary it takes some time for that secondary weapon to reload, this is how far along in that proces it is (from 0 to 1)
 	float primary_rotate_rate[MAX_SHIP_PRIMARY_BANKS];
 	float primary_rotate_ang[MAX_SHIP_PRIMARY_BANKS];
 


### PR DESCRIPTION
@EatThePath pointed out that external weapon models are always rendered in the same orientation as the parent ship, and many models would benefit from being rotated to different orientations.  This adds an angle offset as a property of gun and missile points.  It requires a bump in the POF version, which consequently requires the extra information to be added via a hex editor, at least until PCS2 is upgraded.

Gun and missile points are also cleaned up a bit, mostly by being dynamically allocated so that they don't waste so much memory (about 4kb for every model in the game).

Implements #3143.  ~~This is in draft status until tested.~~