### PR TITLE
deprecate script-eval

### DIFF
--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -34939,14 +34939,14 @@ SCP_vector<sexp_help_struct> Sexp_help = {
 		"\t2:\tString variable to hold the result\r\n"
 	},
 
-	{OP_SCRIPT_EVAL, "script-eval\r\n"
-		"\tEvaluates the given script\r\n"
+	{OP_SCRIPT_EVAL, "script-eval (deprecated in favor of script-eval-block)\r\n"
+		"\tEvaluates the given scripts, one script per argument\r\n"
 		"Takes at least 1 argument...\r\n"
-		"\t1:\tScript to evaluate\r\n"
+		"\tAll:\tScript to evaluate\r\n"
 	},
 
 	{OP_SCRIPT_EVAL_BLOCK, "script-eval-block\r\n"
-		"\tEvaluates the concatenation of all arguments as a script\r\n"
+		"\tEvaluates the concatenation of all arguments as a single script\r\n"
 		"Takes at least 1 argument...\r\n"
 		"\tAll:\tScript to evaluate\r\n"
 	},

--- a/fred2/sexp_tree.cpp
+++ b/fred2/sexp_tree.cpp
@@ -853,6 +853,7 @@ void sexp_tree::right_clicked(int mode)
 							case OP_SET_OBJECT_SPEED_Y:
 							case OP_SET_OBJECT_SPEED_Z:
 							case OP_DISTANCE:
+							case OP_SCRIPT_EVAL:
 								j = (int)op_menu.size();	// don't allow these operators to be visible
 								break;
 						}
@@ -903,6 +904,7 @@ void sexp_tree::right_clicked(int mode)
 							case OP_SET_OBJECT_SPEED_Y:
 							case OP_SET_OBJECT_SPEED_Z:
 							case OP_DISTANCE:
+							case OP_SCRIPT_EVAL:
 								j = (int)op_submenu.size();	// don't allow these operators to be visible
 								break;
 						}

--- a/qtfred/src/ui/widgets/sexp_tree.cpp
+++ b/qtfred/src/ui/widgets/sexp_tree.cpp
@@ -5022,6 +5022,7 @@ std::unique_ptr<QMenu> sexp_tree::buildContextMenu(QTreeWidgetItem* h) {
 					case OP_SET_OBJECT_SPEED_Y:
 					case OP_SET_OBJECT_SPEED_Z:
 					case OP_DISTANCE:
+					case OP_SCRIPT_EVAL:
 						j = (int) op_menu.size();    // don't allow these operators to be visible
 						break;
 					}
@@ -5089,6 +5090,7 @@ std::unique_ptr<QMenu> sexp_tree::buildContextMenu(QTreeWidgetItem* h) {
 					case OP_SET_OBJECT_SPEED_Y:
 					case OP_SET_OBJECT_SPEED_Z:
 					case OP_DISTANCE:
+					case OP_SCRIPT_EVAL:
 						j = (int) op_submenu.size();    // don't allow these operators to be visible
 						break;
 					}


### PR DESCRIPTION
The script-eval SEXP evaluates all arguments as individual script commands, which is not ideal because most FREDders expect the arguments to be concatenated.  Since the script-eval-block SEXP handles its arguments this way, it makes sense to hide the script-eval SEXP in FRED to prevent confusion.