### PR TITLE
Remove superfluous warning about missing "child" flag.

### DIFF
--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -692,11 +692,6 @@ void parse_wi_flags(weapon_info *weaponp, flagset<Weapon::Info_Flags> preset_wi_
         Warning(LOCATION, "\"smart spawn\" flag used without \"spawn\" flag in %s\n", weaponp->name);
     }
 
-    if (weaponp->wi_flags[Weapon::Info_Flags::Inherit_parent_target] && (!weaponp->wi_flags[Weapon::Info_Flags::Child]))
-    {
-        Warning(LOCATION, "Weapon %s has the \"inherit parent target\" flag, but not the \"child\" flag.  No changes in behavior will occur.", weaponp->name);
-    }
-
     if (!weaponp->wi_flags[Weapon::Info_Flags::Homing_heat] && weaponp->wi_flags[Weapon::Info_Flags::Untargeted_heat_seeker])
     {
         Warning(LOCATION, "Weapon '%s' has the \"untargeted heat seeker\" flag, but Homing Type is not set to \"HEAT\".", weaponp->name);


### PR DESCRIPTION
If a weapon has "inherit parent target" but not "child", a Warning will be generated. However, there is no dependency between the two flags; the weapon will function as the modder presumably expects. The Warning even seems to indicate this, by saying "No changes in behavior will occur" (as opposed to other similar warnings, which generally indicate that a flag will be ignored). Since the situation being warned about does not actually cause any issues, the Warning is entirely superfluous. As such, I've removed it outright.

Reported by @MatthTheGeek on Discord.