### PR TITLE
Fix collision culling for accelerating weapons... again

### DIFF
--- a/code/object/objcollide.cpp
+++ b/code/object/objcollide.cpp
@@ -267,10 +267,10 @@ int weapon_will_never_hit( object *obj_weapon, object *other, obj_pair * current
 		}
 
 		// check weapon that does not turn against sphere expanding at ship maxvel
-		// compare (weeapon) ray with expanding sphere (ship) to find earliest possible collision time
+		// compare (weapon) ray with expanding sphere (ship) to find earliest possible collision time
 		// look for two time solutions to Xw = Xs, where Xw = Xw0 + Vwt*t  Xs = Xs + Vs*(t+dt), where Vs*dt = radius of ship 
 		// Since direction of Vs is unknown, solve for (Vs*t) and find norm of both sides
-		if ( !(wip->wi_flags[Weapon::Info_Flags::Turns]) ) {
+		if ( !(wip->wi_flags[Weapon::Info_Flags::Turns]) && (obj_weapon->phys_info.flags & PF_CONST_VEL) ) {
 			vec3d delta_x, weapon_vel;
 			float a,b,c, delta_x_dot_vl, delta_t;
 			float root1, root2, root, earliest_time;


### PR DESCRIPTION
The collision system will predict how far into the future to defer its next collision check which does this based on the weapon's speed. If the weapon is accelerating however these predictions will be much too far in the future, as the prediction was made with its previous slower velocity in mind. While it's possible to have a secondary quadratic solution for the weapon's minimum speed in addition to its maximum speed it's much simpler to just exclude accelerating weapons from this and treat them more conservatively like missiles.

Note that once the weapon finishes accelerating it gets `CONST_VEL` and can benefit from this calculation again.