### PR TITLE
Improve particle alpha handling for small particles

### DIFF
--- a/code/particle/particle.cpp
+++ b/code/particle/particle.cpp
@@ -47,8 +47,8 @@ namespace
 		float dist;
 		float alpha = 0.99999f;
 
-		const float inner_radius = 30.0f;
-		const float magic_num = 2.75f;
+		const float inner_radius = MIN(30.0f, rad);
+		const float magic_num = MIN(2.75f, rad / 10.0f);
 
 		// determine what alpha to draw this bitmap with
 		// higher alpha the closer the bitmap gets to the eye


### PR DESCRIPTION
Particles start to fade out based on proximity at a hardcoded 30 meters, which can look very odd for particles smaller than 30 meters, so take the min of the two before starting to fade. 

This improves, but does not completely solve #3356. For reasons I'm unable to determine those pure white effects will still be noticeably shy of actually pure white even when the call to `batching_add_volume_bitmap` is passed 100% alpha (and that value survives all the way to the vertices being directly pushed to the batch), regardless of the view distance. Beyond that point, my confidence in being able to debug it drops rapidly.