### PR TITLE
Add No_shield_damage_from_ship_collisions flag

### DIFF
--- a/code/ai/ai_flags.h
+++ b/code/ai/ai_flags.h
@@ -138,6 +138,7 @@ namespace AI {
 		Friendlies_use_countermeasure_firechance,
 		Improved_subsystem_attack_pathing,
 		Fixed_ship_weapon_collision,
+		All_ships_take_hull_damage_from_collisions,
 
 		NUM_VALUES
 	};

--- a/code/ai/ai_flags.h
+++ b/code/ai/ai_flags.h
@@ -138,7 +138,7 @@ namespace AI {
 		Friendlies_use_countermeasure_firechance,
 		Improved_subsystem_attack_pathing,
 		Fixed_ship_weapon_collision,
-		All_ships_take_hull_damage_from_collisions,
+		No_shield_damage_from_ship_collisions,
 
 		NUM_VALUES
 	};

--- a/code/ai/ai_profiles.cpp
+++ b/code/ai/ai_profiles.cpp
@@ -580,6 +580,9 @@ void parse_ai_profiles_tbl(const char *filename)
 						Warning(LOCATION, "Invalid ai secondary range awareness mode '%s' specified", buf);
 					}
 				}
+
+				set_flag(profile, "$all ships take hull damage in collisions:", AI::Profile_Flags::All_ships_take_hull_damage_from_collisions);
+
 				// if we've been through once already and are at the same place, force a move
 				if (saved_Mp && (saved_Mp == Mp))
 				{

--- a/code/ai/ai_profiles.cpp
+++ b/code/ai/ai_profiles.cpp
@@ -581,7 +581,7 @@ void parse_ai_profiles_tbl(const char *filename)
 					}
 				}
 
-				set_flag(profile, "$all ships take hull damage in collisions:", AI::Profile_Flags::All_ships_take_hull_damage_from_collisions);
+				set_flag(profile, "$no shield damage from ship collisions:", AI::Profile_Flags::No_shield_damage_from_ship_collisions);
 
 				// if we've been through once already and are at the same place, force a move
 				if (saved_Mp && (saved_Mp == Mp))

--- a/code/object/collidedebrisship.cpp
+++ b/code/object/collidedebrisship.cpp
@@ -121,7 +121,8 @@ int collide_debris_ship( obj_pair * pair )
 
 				if ( debris_hit_info.heavy == pship ) {
 					quadrant_num = get_ship_quadrant_from_global(&hitpos, pship);
-					if ((pship->flags[Object::Object_Flags::No_shields]) || !ship_is_shield_up(pship, quadrant_num) ) {
+					if (The_mission.ai_profile->flags[AI::Profile_Flags::No_shield_damage_from_ship_collisions] || 
+						(pship->flags[Object::Object_Flags::No_shields]) || !ship_is_shield_up(pship, quadrant_num) ) {
 						quadrant_num = -1;
 					}
 					if (apply_ship_damage) {
@@ -296,7 +297,8 @@ int collide_asteroid_ship( obj_pair * pair )
 				int quadrant_num;
 				if ( asteroid_hit_info.heavy == pship ) {
 					quadrant_num = get_ship_quadrant_from_global(&hitpos, pship);
-					if ((pship->flags[Object::Object_Flags::No_shields]) || !ship_is_shield_up(pship, quadrant_num) ) {
+					if (The_mission.ai_profile->flags[AI::Profile_Flags::No_shield_damage_from_ship_collisions] || 
+						(pship->flags[Object::Object_Flags::No_shields]) || !ship_is_shield_up(pship, quadrant_num) ) {
 						quadrant_num = -1;
 					}
 					ship_apply_local_damage(asteroid_hit_info.heavy, asteroid_hit_info.light, &hitpos, ship_damage, quadrant_num, CREATE_SPARKS, asteroid_hit_info.submodel_num);

--- a/code/object/collideshipship.cpp
+++ b/code/object/collideshipship.cpp
@@ -1376,7 +1376,7 @@ int collide_ship_ship( obj_pair * pair )
 					float dam2 = (100.0f * damage/LightOne->phys_info.mass);
 
 					int	quadrant_num = -1;					
-					if (!The_mission.ai_profile->flags[AI::Profile_Flags::All_ships_take_hull_damage_from_collisions] && !(ship_ship_hit_info.heavy->flags[Object::Object_Flags::No_shields])) {
+					if (!The_mission.ai_profile->flags[AI::Profile_Flags::No_shield_damage_from_ship_collisions] && !(ship_ship_hit_info.heavy->flags[Object::Object_Flags::No_shields])) {
 						quadrant_num = get_ship_quadrant_from_global(&world_hit_pos, ship_ship_hit_info.heavy);
 						if (!ship_is_shield_up(ship_ship_hit_info.heavy, quadrant_num))
 							quadrant_num = -1;

--- a/code/object/collideshipship.cpp
+++ b/code/object/collideshipship.cpp
@@ -1375,9 +1375,11 @@ int collide_ship_ship( obj_pair * pair )
 					
 					float dam2 = (100.0f * damage/LightOne->phys_info.mass);
 
-					int	quadrant_num = get_ship_quadrant_from_global(&world_hit_pos, ship_ship_hit_info.heavy);
-					if ((ship_ship_hit_info.heavy->flags[Object::Object_Flags::No_shields]) || !ship_is_shield_up(ship_ship_hit_info.heavy, quadrant_num) ) {
-						quadrant_num = -1;
+					int	quadrant_num = -1;					
+					if (!The_mission.ai_profile->flags[AI::Profile_Flags::All_ships_take_hull_damage_from_collisions] && !(ship_ship_hit_info.heavy->flags[Object::Object_Flags::No_shields])) {
+						quadrant_num = get_ship_quadrant_from_global(&world_hit_pos, ship_ship_hit_info.heavy);
+						if (!ship_is_shield_up(ship_ship_hit_info.heavy, quadrant_num))
+							quadrant_num = -1;
 					}
 
 					ship_apply_local_damage(ship_ship_hit_info.heavy, ship_ship_hit_info.light, &world_hit_pos, 100.0f * damage/HeavyOne->phys_info.mass, quadrant_num, CREATE_SPARKS, ship_ship_hit_info.submodel_num, &ship_ship_hit_info.collision_normal);


### PR DESCRIPTION
For some dumb reason, ship-ship collisions will try to count the damage as a shield hit for the heavier one. This adds a flag to make it hull damage for all involved parties.