### PR TITLE
Fix APNG misc mainhall animations.

### DIFF
--- a/code/graphics/generic.cpp
+++ b/code/graphics/generic.cpp
@@ -630,7 +630,7 @@ void generic_anim_render_variable_frame_delay(generic_anim* ga, float frametime,
 		else {
 			// playing forwards
 			ga->anim_time += frametime;
-			if(ga->anim_time >= ga->total_time && ga->png.anim->current_frame >= ga->png.anim->nframes-1) {
+			if(ga->anim_time >= ga->total_time && ga->png.anim->current_frame >= ga->png.anim->nframes) {
 				if(ga->direction & GENERIC_ANIM_DIRECTION_NOLOOP) {
 					ga->anim_time = ga->total_time;  // stop on last frame when playing
 				}
@@ -660,7 +660,7 @@ void generic_anim_render_variable_frame_delay(generic_anim* ga, float frametime,
 		}
 		else {
 			if (ga->anim_time >= ga->png.previous_frame_time + ga->png.anim->frame.delay &&
-					ga->png.anim->current_frame < ga->png.anim->nframes-1) {
+					ga->png.anim->current_frame < ga->png.anim->nframes) {
 				ga->png.previous_frame_time += ga->png.anim->frame.delay;
 				ga->current_frame++;
 			}
@@ -723,5 +723,19 @@ void generic_anim_render(generic_anim *ga, float frametime, int x, int y, bool m
 				gr_bitmap_uv(x, y, ge->width, ge->height, ge->u0, ge->v0, ge->u1, ge->v1, GR_RESIZE_NONE);
 			}
 		}
+	}
+}
+
+/*
+ * @brief reset an animation back to the start
+ *
+ * @param [in] *ga  animation data
+ */
+void generic_anim_reset(generic_anim *ga) {
+	ga->anim_time = 0.0f;
+	ga->current_frame = 0;
+	if (ga->type == BM_TYPE_PNG) {
+		ga->png.previous_frame_time = 0.0f;
+		ga->png.anim->goto_start();
 	}
 }

--- a/code/graphics/generic.h
+++ b/code/graphics/generic.h
@@ -89,5 +89,5 @@ int generic_anim_stream(generic_anim *ga, const bool cache = true);
 int generic_bitmap_load(generic_bitmap *gb);
 void generic_anim_unload(generic_anim *ga);
 void generic_anim_render(generic_anim *ga, float frametime, int x, int y, bool menu = false, const generic_extras *ge = nullptr);
-
+void generic_anim_reset(generic_anim *ga);
 #endif

--- a/code/menuui/mainhallmenu.cpp
+++ b/code/menuui/mainhallmenu.cpp
@@ -736,6 +736,7 @@ void main_hall_do(float frametime)
 								Main_hall_misc_anim.at(idx).direction |= GENERIC_ANIM_DIRECTION_NOLOOP;
 						}
 
+						// TODO: generic_anim_skip_to(cur_frame, anim_time);
 						Main_hall_misc_anim.at(idx).current_frame = cur_frame;
 						Main_hall_misc_anim.at(idx).anim_time = anim_time;
 
@@ -764,6 +765,7 @@ void main_hall_do(float frametime)
 								Main_hall_door_anim.at(idx).direction = GENERIC_ANIM_DIRECTION_BACKWARDS | GENERIC_ANIM_DIRECTION_NOLOOP;
 							}
 
+							// TODO: generic_anim_skip_to(cur_frame, anim_time);
 							Main_hall_door_anim.at(idx).current_frame = cur_frame;
 							Main_hall_door_anim.at(idx).anim_time = anim_time;
 
@@ -1251,8 +1253,7 @@ void main_hall_render_misc_anims(float frametime, bool over_doors)
 				// if the timestamp is not -1 and has popped, play the anim and make the timestamp -1
 				} else if (timestamp_elapsed(Main_hall->misc_anim_delay.at(idx).at(0))) {
 					Main_hall->misc_anim_paused.at(idx) = false;
-					Main_hall_misc_anim.at(idx).current_frame = 0;
-					Main_hall_misc_anim.at(idx).anim_time = 0.0;
+					generic_anim_reset(Main_hall_misc_anim.at(idx));
 
 					// kill the timestamp
 					Main_hall->misc_anim_delay.at(idx).at(0) = -1;

--- a/code/menuui/mainhallmenu.cpp
+++ b/code/menuui/mainhallmenu.cpp
@@ -1418,12 +1418,14 @@ void main_hall_mouse_release_region(int region)
 			sound_pair->second = snd_play(sound_pair->first, Main_hall->door_sound_pan.at(region));
 		}
 
-		// TODO: track current frame
-		snd_set_pos(sound_pair->second,
-					(float) ((Main_hall_door_anim.at(region).keyframe) ? Main_hall_door_anim.at(region).keyframe :
-							 Main_hall_door_anim.at(region).num_frames - Main_hall_door_anim.at(region).current_frame)
-						/ (float) Main_hall_door_anim.at(region).num_frames,
-					1);
+		// start the sound playing at the right spot relative to the completion of the animation
+		if ( Main_hall_door_anim.at(region).current_frame != -1 ) {
+			snd_set_pos(sound_pair->second,
+						(float) ((Main_hall_door_anim.at(region).keyframe) ? Main_hall_door_anim.at(region).keyframe :
+								 Main_hall_door_anim.at(region).num_frames - Main_hall_door_anim.at(region).current_frame)
+							/ (float) Main_hall_door_anim.at(region).num_frames,
+						1);
+		}
 	}
 }
 

--- a/code/menuui/mainhallmenu.cpp
+++ b/code/menuui/mainhallmenu.cpp
@@ -1253,7 +1253,7 @@ void main_hall_render_misc_anims(float frametime, bool over_doors)
 				// if the timestamp is not -1 and has popped, play the anim and make the timestamp -1
 				} else if (timestamp_elapsed(Main_hall->misc_anim_delay.at(idx).at(0))) {
 					Main_hall->misc_anim_paused.at(idx) = false;
-					generic_anim_reset(Main_hall_misc_anim.at(idx));
+					generic_anim_reset(&Main_hall_misc_anim.at(idx));
 
 					// kill the timestamp
 					Main_hall->misc_anim_delay.at(idx).at(0) = -1;


### PR DESCRIPTION
This is a partial fix of issues related to APNG animations in mainhalls; specifically, issue #3399 (plus a safety check to avoid the related assertion from https://github.com/scp-fs2open/fs2open.github.com/issues/3399#issuecomment-826017373). I'm marking this as a draft for now, because it should be tested thoroughly before being merged (and also because I hope to fix some related issues before 21.4, like cheat animations, but that will require going deeper into the APNG code itself rather than just the generic animation code). However, if this gets tested and seems to work well enough by itself (it should at least be an improvement over the status quo), we can remove draft status and I can make another PR later for the other stuff (hence why I'm not tagging this as unfinished).

Fixes #3399.