### PR TITLE
Improve damage type handling when dealing damage

### DIFF
--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -14116,7 +14116,7 @@ void ai_maybe_self_destruct(object *objp, ai_info *aip)
 		}
 
 		if (timestamp_elapsed(aip->self_destruct_timestamp)) {
-			ship_apply_local_damage( objp, objp, &objp->pos, objp->hull_strength*flFrametime + 1.0f, MISS_SHIELDS);
+			ship_apply_local_damage( objp, objp, &objp->pos, objp->hull_strength*flFrametime + 1.0f, -1, MISS_SHIELDS);
 		}
 	}
 }

--- a/code/asteroid/asteroid.cpp
+++ b/code/asteroid/asteroid.cpp
@@ -1324,7 +1324,7 @@ static void asteroid_do_area_effect(object *asteroid_objp)
 		if ( weapon_area_calc_damage(ship_objp, &asteroid_objp->pos, asip->inner_rad, asip->outer_rad, asip->blast, asip->damage, &blast, &damage, asip->outer_rad) == -1 )
 			continue;
 
-		ship_apply_global_damage(ship_objp, asteroid_objp, &asteroid_objp->pos, damage );
+		ship_apply_global_damage(ship_objp, asteroid_objp, &asteroid_objp->pos, damage, asip->damage_type_idx);
 		weapon_area_apply_blast(NULL, ship_objp, &asteroid_objp->pos, blast, 0);
 	}	// end for
 }

--- a/code/io/keycontrol.cpp
+++ b/code/io/keycontrol.cpp
@@ -776,8 +776,8 @@ void process_debug_keys(int k)
 					// remove guardian flag -- kazan
 					Ships[objp->instance].ship_guardian_threshold = 0;
 					
-					ship_apply_local_damage( objp, Player_obj, &objp->pos, 100000.0f, MISS_SHIELDS, CREATE_SPARKS);
-					ship_apply_local_damage( objp, Player_obj, &objp->pos, 1.0f, MISS_SHIELDS, CREATE_SPARKS);
+					ship_apply_local_damage( objp, Player_obj, &objp->pos, 100000.0f, -1, MISS_SHIELDS, CREATE_SPARKS);
+					ship_apply_local_damage( objp, Player_obj, &objp->pos, 1.0f, -1, MISS_SHIELDS, CREATE_SPARKS);
 					break;
 				case OBJ_WEAPON:
 					Weapons[objp->instance].lifeleft = 0.01f;
@@ -847,7 +847,7 @@ void process_debug_keys(int k)
 				object	*objp = &Objects[Player_ai->target_objnum];
 
 				if (objp->type == OBJ_SHIP) {
-					ship_apply_local_damage( objp, Player_obj, &objp->pos, Ships[objp->instance].ship_max_hull_strength * 0.1f + 10.0f, MISS_SHIELDS, CREATE_SPARKS);
+					ship_apply_local_damage( objp, Player_obj, &objp->pos, Ships[objp->instance].ship_max_hull_strength * 0.1f + 10.0f, -1, MISS_SHIELDS, CREATE_SPARKS);
 				}
 			}
 			break;
@@ -885,7 +885,7 @@ void process_debug_keys(int k)
 
 				vm_vec_rand_vec_quick(&randvec);
 				vm_vec_scale_add(&pos, &Player_obj->pos, &randvec, Player_obj->radius);
-			ship_apply_local_damage(Player_obj, Player_obj, &pos, 25.0f, MISS_SHIELDS, CREATE_SPARKS);
+			ship_apply_local_damage(Player_obj, Player_obj, &pos, 25.0f, -1, MISS_SHIELDS, CREATE_SPARKS);
 			hud_get_target_strength(Player_obj, &shield, &integrity);
 			HUD_sourced_printf(HUD_SOURCE_HIDDEN, XSTR( "You whacked yourself down to %7.3f percent hull.\n", 9), 100.0f * integrity);
 			break;

--- a/code/object/collidedebrisship.cpp
+++ b/code/object/collidedebrisship.cpp
@@ -32,52 +32,53 @@ void calculate_ship_ship_collision_physics(collision_info_struct *ship_ship_hit_
 int collide_debris_ship( obj_pair * pair )
 {
 	float dist;
-	object *pdebris = pair->a;
-	object *pship = pair->b;
+	object *debris_objp = pair->a;
+	object *ship_objp = pair->b;
 
 	// Don't check collisions for warping out player
 	if ( Player->control_mode != PCM_NORMAL )	{
-		if ( pship == Player_obj )
+		if ( ship_objp == Player_obj )
 			return 0;
 	}
 
-	Assert( pdebris->type == OBJ_DEBRIS );
-	Assert( pship->type == OBJ_SHIP );
+	Assert( debris_objp->type == OBJ_DEBRIS );
+	Assert( ship_objp->type == OBJ_SHIP );
 
-	if (reject_due_collision_groups(pdebris, pship))
+	if (reject_due_collision_groups(debris_objp, ship_objp))
 		return 0;
 
+	ship* shipp = &Ships[ship_objp->instance];
 	// don't check collision if it's our own debris and we are dying
-	if ( (pdebris->parent == OBJ_INDEX(pship)) && (Ships[pship->instance].flags[Ship::Ship_Flags::Dying]) )
+	if ( (debris_objp->parent == OBJ_INDEX(ship_objp)) && (shipp->flags[Ship::Ship_Flags::Dying]) )
 		return 0;
 
-	dist = vm_vec_dist( &pdebris->pos, &pship->pos );
-	if ( dist < pdebris->radius + pship->radius )	{
+	dist = vm_vec_dist( &debris_objp->pos, &ship_objp->pos );
+	if ( dist < debris_objp->radius + ship_objp->radius )	{
 		int hit;
 		vec3d	hitpos;
 		// create and initialize ship_ship_hit_info struct
 		collision_info_struct debris_hit_info;
 		init_collision_info_struct(&debris_hit_info);
 
-		if ( pdebris->phys_info.mass > pship->phys_info.mass ) {
-			debris_hit_info.heavy = pdebris;
-			debris_hit_info.light = pship;
+		if ( debris_objp->phys_info.mass > ship_objp->phys_info.mass ) {
+			debris_hit_info.heavy = debris_objp;
+			debris_hit_info.light = ship_objp;
 		} else {
-			debris_hit_info.heavy = pship;
-			debris_hit_info.light = pdebris;
+			debris_hit_info.heavy = ship_objp;
+			debris_hit_info.light = debris_objp;
 		}
 
-		hit = debris_check_collision(pdebris, pship, &hitpos, &debris_hit_info );
+		hit = debris_check_collision(debris_objp, ship_objp, &hitpos, &debris_hit_info );
 		if ( hit )
 		{
-			Script_system.SetHookObjects(4, "Self", pship, "Object", pdebris, "Ship", pship, "Debris", pdebris);
+			Script_system.SetHookObjects(4, "Self", ship_objp, "Object", debris_objp, "Ship", ship_objp, "Debris", debris_objp);
 			Script_system.SetHookVar("Hitpos", 'o', scripting::api::l_Vector.Set(hitpos));
-			bool ship_override = Script_system.IsConditionOverride(CHA_COLLIDEDEBRIS, pship);
+			bool ship_override = Script_system.IsConditionOverride(CHA_COLLIDEDEBRIS, ship_objp);
 			Script_system.RemHookVars({ "Self", "Object", "Ship", "Debris", "Hitpos" });
 
-			Script_system.SetHookObjects(4, "Self", pdebris, "Object", pship, "Ship", pship, "Debris", pdebris);
+			Script_system.SetHookObjects(4, "Self", debris_objp, "Object", ship_objp, "Ship", ship_objp, "Debris", debris_objp);
 			Script_system.SetHookVar("Hitpos", 'o', scripting::api::l_Vector.Set(hitpos));
-			bool debris_override = Script_system.IsConditionOverride(CHA_COLLIDESHIP, pdebris);
+			bool debris_override = Script_system.IsConditionOverride(CHA_COLLIDESHIP, debris_objp);
 			Script_system.RemHookVars({ "Self", "Object", "Ship", "Debris", "Hitpos" });
 
 			if(!ship_override && !debris_override)
@@ -100,61 +101,61 @@ int collide_debris_ship( obj_pair * pair )
 				// calculate debris damage and set debris damage to greater or debris and ship
 				// debris damage is needed since we can really whack some small debris with afterburner and not do
 				// significant damage to ship but the debris goes off faster than afterburner speed.
-				debris_damage = debris_hit_info.impulse/pdebris->phys_info.mass;	// ie, delta velocity of debris
+				debris_damage = debris_hit_info.impulse/debris_objp->phys_info.mass;	// ie, delta velocity of debris
 				debris_damage = (debris_damage > ship_damage) ? debris_damage : ship_damage;
 
 				// modify ship damage by debris damage multiplier
-				ship_damage *= Debris[pdebris->instance].damage_mult;
+				ship_damage *= Debris[debris_objp->instance].damage_mult;
 
 				// supercaps cap damage at 10-20% max hull ship damage
-				if (Ship_info[Ships[pship->instance].ship_info_index].flags[Ship::Info_Flags::Supercap]) {
+				if (Ship_info[shipp->ship_info_index].flags[Ship::Info_Flags::Supercap]) {
 					float cap_percent_damage = frand_range(0.1f, 0.2f);
-					ship_damage = MIN(ship_damage, cap_percent_damage * Ships[pship->instance].ship_max_hull_strength);
+					ship_damage = MIN(ship_damage, cap_percent_damage * shipp->ship_max_hull_strength);
 				}
 
 				// apply damage to debris
-				debris_hit( pdebris, pship, &hitpos, debris_damage);		// speed => damage
+				debris_hit( debris_objp, ship_objp, &hitpos, debris_damage);		// speed => damage
 				int quadrant_num, apply_ship_damage;
 
 				// apply damage to ship unless 1) debris is from ship
-				apply_ship_damage = (pship->signature != pdebris->parent_sig);
+				apply_ship_damage = (ship_objp->signature != debris_objp->parent_sig);
 
-				if ( debris_hit_info.heavy == pship ) {
-					quadrant_num = get_ship_quadrant_from_global(&hitpos, pship);
-					if ((pship->flags[Object::Object_Flags::No_shields]) || !ship_is_shield_up(pship, quadrant_num) ) {
+				if ( debris_hit_info.heavy == ship_objp ) {
+					quadrant_num = get_ship_quadrant_from_global(&hitpos, ship_objp);
+					if ((ship_objp->flags[Object::Object_Flags::No_shields]) || !ship_is_shield_up(ship_objp, quadrant_num) ) {
 						quadrant_num = -1;
 					}
 					if (apply_ship_damage) {
-						ship_apply_local_damage(debris_hit_info.heavy, debris_hit_info.light, &hitpos, ship_damage, quadrant_num, CREATE_SPARKS, debris_hit_info.submodel_num);
+						ship_apply_local_damage(debris_hit_info.heavy, debris_hit_info.light, &hitpos, ship_damage, Debris[debris_objp->instance].damage_type_idx, quadrant_num, CREATE_SPARKS, debris_hit_info.submodel_num);
 					}
 				} else {
 					// don't draw sparks using sphere hit position
 					if (apply_ship_damage) {
-						ship_apply_local_damage(debris_hit_info.light, debris_hit_info.heavy, &hitpos, ship_damage, MISS_SHIELDS, NO_SPARKS);
+						ship_apply_local_damage(debris_hit_info.light, debris_hit_info.heavy, &hitpos, ship_damage, Debris[debris_objp->instance].damage_type_idx, MISS_SHIELDS, NO_SPARKS);
 					}
 				}
 
 				// maybe print Collision on HUD
-				if ( pship == Player_obj ) {					
+				if ( ship_objp == Player_obj ) {					
 					hud_start_text_flash(XSTR("Collision", 1431), 2000);
 				}
 
-				collide_ship_ship_do_sound(&hitpos, pship, pdebris, pship==Player_obj);
+				collide_ship_ship_do_sound(&hitpos, ship_objp, debris_objp, ship_objp==Player_obj);
 			}
 
 			if (!(debris_override && !ship_override))
 			{
-				Script_system.SetHookObjects(4, "Self", pship, "Object", pdebris, "Ship", pship, "Debris", pdebris);
+				Script_system.SetHookObjects(4, "Self", ship_objp, "Object", debris_objp, "Ship", ship_objp, "Debris", debris_objp);
 				Script_system.SetHookVar("Hitpos", 'o', scripting::api::l_Vector.Set(hitpos));
-				Script_system.RunCondition(CHA_COLLIDEDEBRIS, pship);
+				Script_system.RunCondition(CHA_COLLIDEDEBRIS, ship_objp);
 				Script_system.RemHookVars({ "Self", "Object", "Ship", "Debris", "Hitpos" });
 			}
 
 			if ((debris_override && !ship_override) || (!debris_override && !ship_override))
 			{
-				Script_system.SetHookObjects(4, "Self", pdebris, "Object", pship, "Ship", pship, "Debris", pdebris);
+				Script_system.SetHookObjects(4, "Self", debris_objp, "Object", ship_objp, "Ship", ship_objp, "Debris", debris_objp);
 				Script_system.SetHookVar("Hitpos", 'o', scripting::api::l_Vector.Set(hitpos));
-				Script_system.RunCondition(CHA_COLLIDESHIP, pdebris);
+				Script_system.RunCondition(CHA_COLLIDESHIP, debris_objp);
 				Script_system.RemHookVars({ "Self", "Object", "Ship", "Debris", "Hitpos" });
 			}
 
@@ -163,21 +164,18 @@ int collide_debris_ship( obj_pair * pair )
 	} else {	//	Bounding spheres don't intersect, set timestamp for next collision check.
 		float	ship_max_speed, debris_speed;
 		float	time;
-		ship *shipp;
 
-		shipp = &Ships[pship->instance];
-
-		if (ship_is_beginning_warpout_speedup(pship)) {
-			ship_max_speed = MAX(ship_get_max_speed(shipp), ship_get_warpout_speed(pship));
+		if (ship_is_beginning_warpout_speedup(ship_objp)) {
+			ship_max_speed = MAX(ship_get_max_speed(shipp), ship_get_warpout_speed(ship_objp));
 		} else {
 			ship_max_speed = ship_get_max_speed(shipp);
 		}
 		ship_max_speed = MAX(ship_max_speed, 10.0f);
-		ship_max_speed = MAX(ship_max_speed, pship->phys_info.vel.xyz.z);
+		ship_max_speed = MAX(ship_max_speed, ship_objp->phys_info.vel.xyz.z);
 
-		debris_speed = pdebris->phys_info.speed;
+		debris_speed = debris_objp->phys_info.speed;
 
-		time = 1000.0f * (dist - pship->radius - pdebris->radius - 10.0f) / (ship_max_speed + debris_speed);		// 10.0f is a safety factor
+		time = 1000.0f * (dist - ship_objp->radius - debris_objp->radius - 10.0f) / (ship_max_speed + debris_speed);		// 10.0f is a safety factor
 		time -= 200.0f;		// allow one frame slow frame at ~5 fps
 
 		if (time > 100) {
@@ -201,49 +199,51 @@ int collide_asteroid_ship( obj_pair * pair )
 		return 0;
 
 	float		dist;
-	object	*pasteroid = pair->a;
-	object	*pship = pair->b;
+	object	*asteroid_objp = pair->a;
+	object	*ship_objp = pair->b;
 
 	// Don't check collisions for warping out player
 	if ( Player->control_mode != PCM_NORMAL )	{
-		if ( pship == Player_obj ) return 0;
+		if ( ship_objp == Player_obj ) return 0;
 	}
 
-	if (pasteroid->hull_strength < 0.0f)
+	if (asteroid_objp->hull_strength < 0.0f)
 		return 0;
 
-	Assert( pasteroid->type == OBJ_ASTEROID );
-	Assert( pship->type == OBJ_SHIP );
+	Assert( asteroid_objp->type == OBJ_ASTEROID );
+	Assert( ship_objp->type == OBJ_SHIP );
 
-	dist = vm_vec_dist( &pasteroid->pos, &pship->pos );
+	dist = vm_vec_dist( &asteroid_objp->pos, &ship_objp->pos );
 
-	if ( dist < pasteroid->radius + pship->radius )	{
+	ship* shipp = &Ships[ship_objp->instance];
+
+	if ( dist < asteroid_objp->radius + ship_objp->radius )	{
 		int hit;
 		vec3d	hitpos;
 		// create and initialize ship_ship_hit_info struct
 		collision_info_struct asteroid_hit_info;
 		init_collision_info_struct(&asteroid_hit_info);
 
-		if ( pasteroid->phys_info.mass > pship->phys_info.mass ) {
-			asteroid_hit_info.heavy = pasteroid;
-			asteroid_hit_info.light = pship;
+		if ( asteroid_objp->phys_info.mass > ship_objp->phys_info.mass ) {
+			asteroid_hit_info.heavy = asteroid_objp;
+			asteroid_hit_info.light = ship_objp;
 		} else {
-			asteroid_hit_info.heavy = pship;
-			asteroid_hit_info.light = pasteroid;
+			asteroid_hit_info.heavy = ship_objp;
+			asteroid_hit_info.light = asteroid_objp;
 		}
 
-		hit = asteroid_check_collision(pasteroid, pship, &hitpos, &asteroid_hit_info );
+		hit = asteroid_check_collision(asteroid_objp, ship_objp, &hitpos, &asteroid_hit_info );
 		if ( hit )
 		{
 			//Scripting support (WMC)
-			Script_system.SetHookObjects(4, "Self", pship, "Object", pasteroid, "Ship", pship, "Asteroid", pasteroid);
+			Script_system.SetHookObjects(4, "Self", ship_objp, "Object", asteroid_objp, "Ship", ship_objp, "Asteroid", asteroid_objp);
 			Script_system.SetHookVar("Hitpos", 'o', scripting::api::l_Vector.Set(hitpos));
-			bool ship_override = Script_system.IsConditionOverride(CHA_COLLIDEASTEROID, pship);
+			bool ship_override = Script_system.IsConditionOverride(CHA_COLLIDEASTEROID, ship_objp);
 			Script_system.RemHookVars({ "Self", "Object", "Ship", "Asteroid", "Hitpos" });
 
-			Script_system.SetHookObjects(4, "Self", pasteroid, "Object", pship, "Ship", pship, "Asteroid", pasteroid);
+			Script_system.SetHookObjects(4, "Self", asteroid_objp, "Object", ship_objp, "Ship", ship_objp, "Asteroid", asteroid_objp);
 			Script_system.SetHookVar("Hitpos", 'o', scripting::api::l_Vector.Set(hitpos));
-			bool asteroid_override = Script_system.IsConditionOverride(CHA_COLLIDESHIP, pasteroid);
+			bool asteroid_override = Script_system.IsConditionOverride(CHA_COLLIDESHIP, asteroid_objp);
 			Script_system.RemHookVars({ "Self", "Object", "Ship", "Asteroid", "Hitpos" });
 
 			if(!ship_override && !asteroid_override)
@@ -251,7 +251,7 @@ int collide_asteroid_ship( obj_pair * pair )
 				float		ship_damage;	
 				float		asteroid_damage;
 
-				vec3d asteroid_vel = pasteroid->phys_info.vel;
+				vec3d asteroid_vel = asteroid_objp->phys_info.vel;
 
 				// do collision physics
 				calculate_ship_ship_collision_physics( &asteroid_hit_info );
@@ -260,8 +260,8 @@ int collide_asteroid_ship( obj_pair * pair )
 					return 0;
 
 				// limit damage from impulse by making max impulse (for damage) 2*m*v_max_relative
-				float max_ship_impulse = (2.0f*pship->phys_info.max_vel.xyz.z+vm_vec_mag_quick(&asteroid_vel)) * 
-					(pship->phys_info.mass*pasteroid->phys_info.mass) / (pship->phys_info.mass + pasteroid->phys_info.mass);
+				float max_ship_impulse = (2.0f*ship_objp->phys_info.max_vel.xyz.z+vm_vec_mag_quick(&asteroid_vel)) * 
+					(ship_objp->phys_info.mass*asteroid_objp->phys_info.mass) / (ship_objp->phys_info.mass + asteroid_objp->phys_info.mass);
 
 				if (asteroid_hit_info.impulse > max_ship_impulse) {
 					ship_damage = 0.001f * max_ship_impulse;
@@ -273,59 +273,59 @@ int collide_asteroid_ship( obj_pair * pair )
 				if (ship_damage > 5.0f)
 					ship_damage = 5.0f + (ship_damage - 5.0f)/2.0f;
 
-				if ((ship_damage > 500.0f) && (ship_damage > Ships[pship->instance].ship_max_hull_strength/8.0f)) {
-					ship_damage = Ships[pship->instance].ship_max_hull_strength/8.0f;
-					nprintf(("AI", "Pinning damage to %s from asteroid at %7.3f (%7.3f percent)\n", Ships[pship->instance].ship_name, ship_damage, 100.0f * ship_damage/Ships[pship->instance].ship_max_hull_strength));
+				if ((ship_damage > 500.0f) && (ship_damage > shipp->ship_max_hull_strength/8.0f)) {
+					ship_damage = shipp->ship_max_hull_strength/8.0f;
+					nprintf(("AI", "Pinning damage to %s from asteroid at %7.3f (%7.3f percent)\n", shipp->ship_name, ship_damage, 100.0f * ship_damage/ shipp->ship_max_hull_strength));
 				}
 
 				//	Decrease damage during warp out because it's annoying when your escoree dies during warp out.
-				if (Ai_info[Ships[pship->instance].ai_index].mode == AIM_WARP_OUT)
+				if (Ai_info[shipp->ai_index].mode == AIM_WARP_OUT)
 					ship_damage /= 3.0f;
 
 				// calculate asteroid damage and set asteroid damage to greater or asteroid and ship
 				// asteroid damage is needed since we can really whack some small asteroid with afterburner and not do
 				// significant damage to ship but the asteroid goes off faster than afterburner speed.
-				asteroid_damage = asteroid_hit_info.impulse/pasteroid->phys_info.mass;	// ie, delta velocity of asteroid
+				asteroid_damage = asteroid_hit_info.impulse/asteroid_objp->phys_info.mass;	// ie, delta velocity of asteroid
 				asteroid_damage = (asteroid_damage > ship_damage) ? asteroid_damage : ship_damage;
 
 				// apply damage to asteroid
-				asteroid_hit( pasteroid, pship, &hitpos, asteroid_damage);		// speed => damage
+				asteroid_hit( asteroid_objp, ship_objp, &hitpos, asteroid_damage);		// speed => damage
 
-				//extern fix Missiontime;
+				int ast_damage_type = Asteroid_info[Asteroids[asteroid_objp->instance].asteroid_type].damage_type_idx;
 
 				int quadrant_num;
-				if ( asteroid_hit_info.heavy == pship ) {
-					quadrant_num = get_ship_quadrant_from_global(&hitpos, pship);
-					if ((pship->flags[Object::Object_Flags::No_shields]) || !ship_is_shield_up(pship, quadrant_num) ) {
+				if ( asteroid_hit_info.heavy == ship_objp ) {
+					quadrant_num = get_ship_quadrant_from_global(&hitpos, ship_objp);
+					if ((ship_objp->flags[Object::Object_Flags::No_shields]) || !ship_is_shield_up(ship_objp, quadrant_num) ) {
 						quadrant_num = -1;
 					}
-					ship_apply_local_damage(asteroid_hit_info.heavy, asteroid_hit_info.light, &hitpos, ship_damage, quadrant_num, CREATE_SPARKS, asteroid_hit_info.submodel_num);
+					ship_apply_local_damage(asteroid_hit_info.heavy, asteroid_hit_info.light, &hitpos, ship_damage, ast_damage_type, quadrant_num, CREATE_SPARKS, asteroid_hit_info.submodel_num);
 				} else {
 					// don't draw sparks (using sphere hitpos)
-					ship_apply_local_damage(asteroid_hit_info.light, asteroid_hit_info.heavy, &hitpos, ship_damage, MISS_SHIELDS, NO_SPARKS);
+					ship_apply_local_damage(asteroid_hit_info.light, asteroid_hit_info.heavy, &hitpos, ship_damage, ast_damage_type, MISS_SHIELDS, NO_SPARKS);
 				}
 
 				// maybe print Collision on HUD
-				if ( pship == Player_obj ) {					
+				if ( ship_objp == Player_obj ) {					
 					hud_start_text_flash(XSTR("Collision", 1431), 2000);
 				}
 
-				collide_ship_ship_do_sound(&hitpos, pship, pasteroid, pship==Player_obj);
+				collide_ship_ship_do_sound(&hitpos, ship_objp, asteroid_objp, ship_objp==Player_obj);
 			}
 
 			if (!(asteroid_override && !ship_override))
 			{
-				Script_system.SetHookObjects(4, "Self", pship, "Object", pasteroid, "Ship", pship, "Asteroid", pasteroid);
+				Script_system.SetHookObjects(4, "Self", ship_objp, "Object", asteroid_objp, "Ship", ship_objp, "Asteroid", asteroid_objp);
 				Script_system.SetHookVar("Hitpos", 'o', scripting::api::l_Vector.Set(hitpos));
-				Script_system.RunCondition(CHA_COLLIDEASTEROID, pship);
+				Script_system.RunCondition(CHA_COLLIDEASTEROID, ship_objp);
 				Script_system.RemHookVars({ "Self", "Object", "Ship", "Asteroid", "Hitpos" });
 			}
 
 			if ((asteroid_override && !ship_override) || (!asteroid_override && !ship_override))
 			{
-				Script_system.SetHookObjects(4, "Self", pasteroid, "Object", pship, "Ship", pship, "Asteroid", pasteroid);
+				Script_system.SetHookObjects(4, "Self", asteroid_objp, "Object", ship_objp, "Ship", ship_objp, "Asteroid", asteroid_objp);
 				Script_system.SetHookVar("Hitpos", 'o', scripting::api::l_Vector.Set(hitpos));
-				Script_system.RunCondition(CHA_COLLIDESHIP, pasteroid);
+				Script_system.RunCondition(CHA_COLLIDESHIP, asteroid_objp);
 				Script_system.RemHookVars({ "Self", "Object", "Ship", "Asteroid", "Hitpos" });
 			}
 
@@ -336,21 +336,20 @@ int collide_asteroid_ship( obj_pair * pair )
 	} else {
 		// estimate earliest time at which pair can hit
 		float asteroid_max_speed, ship_max_speed, time;
-		ship *shipp = &Ships[pship->instance];
 
-		asteroid_max_speed = vm_vec_mag(&pasteroid->phys_info.vel);		// Asteroid... vel gets reset, not max vel.z
+		asteroid_max_speed = vm_vec_mag(&asteroid_objp->phys_info.vel);		// Asteroid... vel gets reset, not max vel.z
 		asteroid_max_speed = MAX(asteroid_max_speed, 10.0f);
 
-		if (ship_is_beginning_warpout_speedup(pship)) {
-			ship_max_speed = MAX(ship_get_max_speed(shipp), ship_get_warpout_speed(pship));
+		if (ship_is_beginning_warpout_speedup(ship_objp)) {
+			ship_max_speed = MAX(ship_get_max_speed(shipp), ship_get_warpout_speed(ship_objp));
 		} else {
 			ship_max_speed = ship_get_max_speed(shipp);
 		}
 		ship_max_speed = MAX(ship_max_speed, 10.0f);
-		ship_max_speed = MAX(ship_max_speed, pship->phys_info.vel.xyz.z);
+		ship_max_speed = MAX(ship_max_speed, ship_objp->phys_info.vel.xyz.z);
 
 
-		time = 1000.0f * (dist - pship->radius - pasteroid->radius - 10.0f) / (asteroid_max_speed + ship_max_speed);		// 10.0f is a safety factor
+		time = 1000.0f * (dist - ship_objp->radius - asteroid_objp->radius - 10.0f) / (asteroid_max_speed + ship_max_speed);		// 10.0f is a safety factor
 		time -= 200.0f;		// allow one frame slow frame at ~5 fps
 
 		if (time > 100) {

--- a/code/object/collideshipship.cpp
+++ b/code/object/collideshipship.cpp
@@ -841,7 +841,7 @@ static void mcp_1(object *player_objp, object *planet_objp)
 	if (dist > planet_radius*PLANET_DAMAGE_RANGE)
 		return;
 
-	ship_apply_global_damage( player_objp, planet_objp, NULL, PLANET_DAMAGE_SCALE * flFrametime * (float)pow((planet_radius*PLANET_DAMAGE_RANGE)/dist, 3.0f) );
+	ship_apply_global_damage( player_objp, planet_objp, NULL, PLANET_DAMAGE_SCALE * flFrametime * (float)pow((planet_radius*PLANET_DAMAGE_RANGE)/dist, 3.0f), -1 );
 
 	if ((Missiontime - Last_planet_damage_time > F1_0) || (Missiontime < Last_planet_damage_time)) {
 		HUD_sourced_printf(HUD_SOURCE_HIDDEN, "%s", XSTR( "Too close to planet.  Taking damage!", 465));
@@ -1371,20 +1371,24 @@ int collide_ship_ship( obj_pair * pair )
 						if ((LightOne->radius < 50.0f) && (HeavyOne->radius <50.0f)) {
 							damage /= 4.0f;
 						}
-					}
-					
-					float dam2 = (100.0f * damage/LightOne->phys_info.mass);
+					}					
 
 					int	quadrant_num = get_ship_quadrant_from_global(&world_hit_pos, ship_ship_hit_info.heavy);
 					if ((ship_ship_hit_info.heavy->flags[Object::Object_Flags::No_shields]) || !ship_is_shield_up(ship_ship_hit_info.heavy, quadrant_num) ) {
 						quadrant_num = -1;
 					}
 
-					ship_apply_local_damage(ship_ship_hit_info.heavy, ship_ship_hit_info.light, &world_hit_pos, 100.0f * damage/HeavyOne->phys_info.mass, quadrant_num, CREATE_SPARKS, ship_ship_hit_info.submodel_num, &ship_ship_hit_info.collision_normal);
+					float damage_heavy = (100.0f * damage / HeavyOne->phys_info.mass);
+					ship_apply_local_damage(ship_ship_hit_info.heavy, ship_ship_hit_info.light, &world_hit_pos, damage_heavy, light_shipp->collision_damage_type_idx, 
+						quadrant_num, CREATE_SPARKS, ship_ship_hit_info.submodel_num, &ship_ship_hit_info.collision_normal);
+
 					hud_shield_quadrant_hit(ship_ship_hit_info.heavy, quadrant_num);
 
 					// don't draw sparks (using sphere hitpos)
-					ship_apply_local_damage(ship_ship_hit_info.light, ship_ship_hit_info.heavy, &world_hit_pos, dam2, MISS_SHIELDS, NO_SPARKS, -1, &ship_ship_hit_info.collision_normal);
+					float damage_light = (100.0f * damage / LightOne->phys_info.mass);
+					ship_apply_local_damage(ship_ship_hit_info.light, ship_ship_hit_info.heavy, &world_hit_pos, damage_light, heavy_shipp->collision_damage_type_idx, 
+						MISS_SHIELDS, NO_SPARKS, -1, &ship_ship_hit_info.collision_normal);
+
 					hud_shield_quadrant_hit(ship_ship_hit_info.light, -1);
 
 					maybe_push_little_ship_from_fast_big_ship(ship_ship_hit_info.heavy, ship_ship_hit_info.light, ship_ship_hit_info.impulse, &ship_ship_hit_info.collision_normal);

--- a/code/object/collideshipweapon.cpp
+++ b/code/object/collideshipweapon.cpp
@@ -112,7 +112,7 @@ static void ship_weapon_do_hit_stuff(object *pship_obj, object *weapon_obj, vec3
 		}
 	}	
 
-	ship_apply_local_damage(pship_obj, weapon_obj, world_hitpos, damage, quadrant_num, CREATE_SPARKS, submodel_num);
+	ship_apply_local_damage(pship_obj, weapon_obj, world_hitpos, damage, wip->damage_type_idx, quadrant_num, CREATE_SPARKS, submodel_num);
 
 	// let the hud shield gauge know when Player or Player target is hit
 	hud_shield_quadrant_hit(pship_obj, quadrant_num);

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -12374,7 +12374,7 @@ void sexp_explosion_effect(int n)
 				switch ( objp->type )
 				{
 					case OBJ_SHIP:
-						ship_apply_global_damage( objp, nullptr, &origin, t_damage );
+						ship_apply_global_damage( objp, nullptr, &origin, t_damage, -1 );
 						vec3d force, vec_ship_to_impact;
 						vm_vec_sub( &vec_ship_to_impact, &objp->pos, &origin );
 						if (!IS_VEC_NULL_SQ_SAFE( &vec_ship_to_impact )) {

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -8218,7 +8218,7 @@ static void ship_blow_up_area_apply_blast( object *exp_objp)
 
 			switch ( objp->type ) {
 			case OBJ_SHIP:
-				ship_apply_global_damage( objp, exp_objp, &exp_objp->pos, damage );
+				ship_apply_global_damage( objp, exp_objp, &exp_objp->pos, damage, sip->shockwave.damage_type_idx);
 				vec3d force, vec_ship_to_impact;
 				vm_vec_sub( &vec_ship_to_impact, &objp->pos, &exp_objp->pos );
 				vm_vec_copy_normalize( &force, &vec_ship_to_impact );
@@ -8277,7 +8277,7 @@ static void do_dying_undock_physics(object *dying_objp, ship *dying_shipp)
 		float docked_mass = dying_objp->phys_info.mass + docked_objp->phys_info.mass;
 
 		// damage this docked object
-		ship_apply_global_damage(docked_objp, dying_objp, &dying_objp->pos, damage);
+		ship_apply_global_damage(docked_objp, dying_objp, &dying_objp->pos, damage, -1);
 
 		// do physics
 		vm_vec_sub(&impulse_norm, &docked_objp->pos, &dying_objp->pos);
@@ -9090,7 +9090,7 @@ static void ship_check_player_distance_sub(player *p, int multi_target=-1)
 		if ( (p->flags & PLAYER_FLAGS_DIST_TO_BE_KILLED) && (timestamp_until(p->distance_warning_time) < 0) ) {
 			p->flags |= PLAYER_FLAGS_FORCE_MISSION_OVER;
 			float damage = 10.0f * Objects[p->objnum].hull_strength;
-			ship_apply_global_damage(&Objects[p->objnum], &Objects[p->objnum], NULL, damage);
+			ship_apply_global_damage(&Objects[p->objnum], &Objects[p->objnum], NULL, damage, -1);
 		}
 	}
 

--- a/code/ship/shiphit.cpp
+++ b/code/ship/shiphit.cpp
@@ -2185,18 +2185,15 @@ static int maybe_shockwave_damage_adjust(object *ship_objp, object *other_obj, f
 // Goober5000 - sanity checked this whole function in the case that other_obj is NULL, which
 // will happen with the explosion-effect sexp
 void ai_update_lethality(object *ship_objp, object *weapon_obj, float damage);
-static void ship_do_damage(object *ship_objp, object *other_obj, vec3d *hitpos, float damage, int quadrant, int submodel_num, int wash_damage=0)
+static void ship_do_damage(object *ship_objp, object *other_obj, vec3d *hitpos, float damage, int quadrant, int submodel_num, int damage_type_idx = -1, bool wash_damage = false)
 {
 //	mprintf(("doing damage\n"));
 
 	ship *shipp;	
 	float subsystem_damage = damage;			// damage to be applied to subsystems
-	int other_obj_is_weapon;
-	int other_obj_is_beam;
-	int other_obj_is_shockwave;
-	int other_obj_is_asteroid;
-	int other_obj_is_debris;
-	int other_obj_is_ship;
+	bool other_obj_is_weapon;
+	bool other_obj_is_beam;
+	bool other_obj_is_shockwave;
 	float difficulty_scale_factor = 1.0f;
 
 	Assertion(ship_objp, "No ship_objp in ship_do_damage!");
@@ -2214,18 +2211,12 @@ static void ship_do_damage(object *ship_objp, object *other_obj, vec3d *hitpos, 
 		other_obj_is_weapon = ((other_obj->type == OBJ_WEAPON) && (other_obj->instance >= 0) && (other_obj->instance < MAX_WEAPONS));
 		other_obj_is_beam = ((other_obj->type == OBJ_BEAM) && (other_obj->instance >= 0) && (other_obj->instance < MAX_BEAMS));
 		other_obj_is_shockwave = ((other_obj->type == OBJ_SHOCKWAVE) && (other_obj->instance >= 0) && (other_obj->instance < MAX_SHOCKWAVES));
-		other_obj_is_asteroid = ((other_obj->type == OBJ_ASTEROID) && (other_obj->instance >= 0) && (other_obj->instance < MAX_ASTEROIDS));
-		other_obj_is_debris = ((other_obj->type == OBJ_DEBRIS) && (other_obj->instance >= 0) && (other_obj->instance < (int)Debris.size()));
-		other_obj_is_ship = ((other_obj->type == OBJ_SHIP) && (other_obj->instance >= 0) && (other_obj->instance < MAX_SHIPS));
 	}
 	else
 	{
 		other_obj_is_weapon = 0;
 		other_obj_is_beam = 0;
 		other_obj_is_shockwave = 0;
-		other_obj_is_asteroid = 0;
-		other_obj_is_debris = 0;
-		other_obj_is_ship = 0;
 	}
 
 	// update lethality of ship doing damage - modified by Goober5000
@@ -2320,26 +2311,11 @@ static void ship_do_damage(object *ship_objp, object *other_obj, vec3d *hitpos, 
 		if ( damage > 0.0f ) {
 
 			float piercing_pct = 0.0f;
-			int dmg_type_idx = -1;
 
-			//Do armor stuff
-			if(other_obj_is_weapon) {
-				dmg_type_idx = Weapon_info[Weapons[other_obj->instance].weapon_info_index].damage_type_idx;
-			} else if(other_obj_is_beam) {
-				dmg_type_idx = Weapon_info[beam_get_weapon_info_index(other_obj)].damage_type_idx;
-			} else if(other_obj_is_shockwave) {
-				dmg_type_idx = shockwave_get_damage_type_idx(other_obj->instance);
-			} else if(other_obj_is_asteroid) {
-				dmg_type_idx = Asteroid_info[Asteroids[other_obj->instance].asteroid_type].damage_type_idx;
-			} else if(other_obj_is_debris) {
-				dmg_type_idx = Debris[other_obj->instance].damage_type_idx;
-			} else if(other_obj_is_ship) {
-				dmg_type_idx = Ships[other_obj->instance].collision_damage_type_idx;
-			}
-				
+			//Do armor stuff				
 			if(shipp->shield_armor_type_idx != -1)
 			{
-				piercing_pct = Armor_types[shipp->shield_armor_type_idx].GetShieldPiercePCT(dmg_type_idx);
+				piercing_pct = Armor_types[shipp->shield_armor_type_idx].GetShieldPiercePCT(damage_type_idx);
 			}
 			
 			float pre_shield = damage; // Nuke: don't use the difficulty scaling in here, since its also applied in Armor_type.GetDamage. Don't want it to apply twice
@@ -2355,7 +2331,7 @@ static void ship_do_damage(object *ship_objp, object *other_obj, vec3d *hitpos, 
 			if(shipp->shield_armor_type_idx != -1)
 			{
 				// Nuke: this call will decide when to use the damage factor, but it will get used, unless the modder is dumb (like setting +Difficulty Scale Type: to 'manual' and not manually applying it in their calculations)
-				damage = Armor_types[shipp->shield_armor_type_idx].GetDamage(damage, dmg_type_idx, difficulty_scale_factor, other_obj_is_beam);
+				damage = Armor_types[shipp->shield_armor_type_idx].GetDamage(damage, damage_type_idx, difficulty_scale_factor, other_obj_is_beam);
 
 			} else { // Nuke: if that didn't get called, difficulty would not be applied to damage so apply it here
 				damage *= difficulty_scale_factor;
@@ -2400,25 +2376,10 @@ static void ship_do_damage(object *ship_objp, object *other_obj, vec3d *hitpos, 
 
 		//Do armor stuff
 		if (apply_hull_armor)
-		{
-			int dmg_type_idx = -1;
-			if(other_obj_is_weapon) {
-				dmg_type_idx = Weapon_info[Weapons[other_obj->instance].weapon_info_index].damage_type_idx;
-			} else if(other_obj_is_beam) {
-				dmg_type_idx = Weapon_info[beam_get_weapon_info_index(other_obj)].damage_type_idx;
-			} else if(other_obj_is_shockwave) {
-				dmg_type_idx = shockwave_get_damage_type_idx(other_obj->instance);
-			} else if(other_obj_is_asteroid) {
-				dmg_type_idx = Asteroid_info[Asteroids[other_obj->instance].asteroid_type].damage_type_idx;
-			} else if(other_obj_is_debris) {
-				dmg_type_idx = Debris[other_obj->instance].damage_type_idx;
-			} else if(other_obj_is_ship) {
-				dmg_type_idx = Ships[other_obj->instance].collision_damage_type_idx;
-			}
-			
+		{			
 			if(shipp->armor_type_idx != -1)
 			{
-				damage = Armor_types[shipp->armor_type_idx].GetDamage(damage, dmg_type_idx, difficulty_scale_factor, other_obj_is_beam);
+				damage = Armor_types[shipp->armor_type_idx].GetDamage(damage, damage_type_idx, difficulty_scale_factor, other_obj_is_beam);
 				apply_diff_scale = false;
 			}
 		}
@@ -2590,7 +2551,7 @@ static void ship_do_damage(object *ship_objp, object *other_obj, vec3d *hitpos, 
 	}
 }
 
-static void ship_do_healing(object* ship_objp, object* other_obj, vec3d* hitpos, float healing, int submodel_num)
+static void ship_do_healing(object* ship_objp, object* other_obj, vec3d* hitpos, float healing, int submodel_num, int damage_type_idx = -1)
 {
 	// multiplayer clients dont do healing
 	if (MULTIPLAYER_CLIENT)
@@ -2639,17 +2600,8 @@ static void ship_do_healing(object* ship_objp, object* other_obj, vec3d* hitpos,
 		float shield_healing = healing * wip->shield_factor;
 
 		if (shield_healing > 0.0f) {
-
-			int dmg_type_idx = -1;
-
-			//get the "damage" type
-			if (other_obj_is_weapon || other_obj_is_beam) 
-				dmg_type_idx = wip->damage_type_idx;
-			else if (other_obj_is_shockwave) 
-				dmg_type_idx = shockwave_get_damage_type_idx(other_obj->instance);
-
 			if (shipp->shield_armor_type_idx != -1)
-				shield_healing = Armor_types[shipp->shield_armor_type_idx].GetDamage(shield_healing, dmg_type_idx, 1.0f, other_obj_is_beam);
+				shield_healing = Armor_types[shipp->shield_armor_type_idx].GetDamage(shield_healing, damage_type_idx, 1.0f, other_obj_is_beam);
 
 			shield_apply_healing(ship_objp, shield_healing);
 		}
@@ -2661,14 +2613,8 @@ static void ship_do_healing(object* ship_objp, object* other_obj, vec3d* hitpos,
 		do_subobj_heal_stuff(ship_objp, other_obj, hitpos, submodel_num, healing);
 
 		//Do armor stuff
-		int dmg_type_idx = -1;
-		if (other_obj_is_weapon || other_obj_is_beam)
-			dmg_type_idx = wip->damage_type_idx;
-		else if (other_obj_is_shockwave)
-			dmg_type_idx = shockwave_get_damage_type_idx(other_obj->instance);
-
 		if (shipp->armor_type_idx != -1)
-			healing = Armor_types[shipp->armor_type_idx].GetDamage(healing, dmg_type_idx, 1.0f, other_obj_is_beam);
+			healing = Armor_types[shipp->armor_type_idx].GetDamage(healing, damage_type_idx, 1.0f, other_obj_is_beam);
 		
 		if (wip->wi_flags[Weapon::Info_Flags::Puncture])
 			healing /= 4;
@@ -2743,7 +2689,7 @@ void ship_apply_tag(ship *shipp, int tag_level, float tag_time, object *target, 
 // This assumes that whoever called this knows if the shield got hit or not.
 // hitpos is in world coordinates.
 // if quadrant is not -1, then that part of the shield takes damage properly.
-void ship_apply_local_damage(object *ship_objp, object *other_obj, vec3d *hitpos, float damage, int quadrant, bool create_spark, int submodel_num, vec3d *hit_normal)
+void ship_apply_local_damage(object *ship_objp, object *other_obj, vec3d *hitpos, float damage, int damage_type_idx, int quadrant, bool create_spark, int submodel_num, vec3d *hit_normal)
 {
 	Assert(ship_objp);	// Goober5000
 	Assert(other_obj);	// Goober5000
@@ -2834,7 +2780,7 @@ void ship_apply_local_damage(object *ship_objp, object *other_obj, vec3d *hitpos
 		create_sparks = false;
 	}
 	else
-		ship_do_damage(ship_objp, other_obj, hitpos, damage, quadrant, submodel_num );
+		ship_do_damage(ship_objp, other_obj, hitpos, damage, quadrant, submodel_num, damage_type_idx );
 
 	// DA 5/5/98: move ship_hit_create_sparks() after do_damage() since number of sparks depends on hull strength
 	// doesn't hit shield and we want sparks
@@ -2880,7 +2826,7 @@ void ship_apply_local_damage(object *ship_objp, object *other_obj, vec3d *hitpos
 // You can pass force_center==NULL if you the damage doesn't come from anywhere,
 // like for debug keys to damage an object or something.  It will 
 // assume damage is non-directional and will apply it correctly.   
-void ship_apply_global_damage(object *ship_objp, object *other_obj, vec3d *force_center, float damage )
+void ship_apply_global_damage(object *ship_objp, object *other_obj, vec3d *force_center, float damage, int damage_type_idx )
 {
 	Assert(ship_objp);	// Goober5000 (but not other_obj in case of sexp)
 
@@ -2909,10 +2855,10 @@ void ship_apply_global_damage(object *ship_objp, object *other_obj, vec3d *force
 
 		// the healing case should only ever be true for shockwaves
 		if (wip_index >= 0 && Weapon_info[wip_index].wi_flags[Weapon::Info_Flags::Heals])
-			ship_do_healing(ship_objp, other_obj, &world_hitpos, damage, -1);
+			ship_do_healing(ship_objp, other_obj, &world_hitpos, damage, -1, damage_type_idx);
 		else
 			// Do damage on local point		
-			ship_do_damage(ship_objp, other_obj, &world_hitpos, damage, shield_quad, -1 );
+			ship_do_damage(ship_objp, other_obj, &world_hitpos, damage, shield_quad, -1 , damage_type_idx);
 	} else {
 		// Since an force_center wasn't specified, this is probably just a debug key
 		// to kill an object.   So pick a shield quadrant and a point on the
@@ -2920,7 +2866,7 @@ void ship_apply_global_damage(object *ship_objp, object *other_obj, vec3d *force
 		vm_vec_scale_add( &world_hitpos, &ship_objp->pos, &ship_objp->orient.vec.fvec, ship_objp->radius );
 
 		for (int i=0; i<ship_objp->n_quadrants; i++){
-			ship_do_damage(ship_objp, other_obj, &world_hitpos, damage/ship_objp->n_quadrants, i, -1);
+			ship_do_damage(ship_objp, other_obj, &world_hitpos, damage/ship_objp->n_quadrants, i, -1, damage_type_idx );
 		}
 	}
 
@@ -2951,7 +2897,7 @@ void ship_apply_wash_damage(object *ship_objp, object *other_obj, float damage)
 
 	// Do damage to hull and not to shields
 	global_damage = true;
-	ship_do_damage(ship_objp, other_obj, &world_hitpos, damage, -1, -1, 1);
+	ship_do_damage(ship_objp, other_obj, &world_hitpos, damage, -1, -1, -1, true);
 
 	// AL 3-30-98: Show flashing blast icon if player ship has taken blast damage
 	if ( ship_objp == Player_obj ) {

--- a/code/ship/shiphit.h
+++ b/code/ship/shiphit.h
@@ -41,7 +41,7 @@ extern void ship_apply_tag(ship *ship_p, int tag_level, float tag_time, object *
 // This assumes that whoever called this knows if the shield got hit or not.
 // hitpos is in world coordinates.
 // if quadrant is not -1, then that part of the shield takes damage properly.
-void ship_apply_local_damage(object *ship_obj, object *other_obj, vec3d *hitpos, float damage, int quadrant, bool create_spark=true, int submodel_num=-1, vec3d *hit_normal=0 /*NULL*/);
+void ship_apply_local_damage(object *ship_obj, object *other_obj, vec3d *hitpos, float damage, int damage_type_idx, int quadrant, bool create_spark=true, int submodel_num=-1, vec3d *hit_normal=0 /*NULL*/);
 
 // This gets called to apply damage when a damaging force hits a ship, but at no 
 // point in particular.  Like from a shockwave.   This routine will see if the
@@ -49,7 +49,7 @@ void ship_apply_local_damage(object *ship_obj, object *other_obj, vec3d *hitpos,
 // You can pass force_center==NULL if you the damage doesn't come from anywhere,
 // like for debug keys to damage an object or something.  It will 
 // assume damage is non-directional and will apply it correctly.   
-void ship_apply_global_damage(object *ship_obj, object *other_obj, vec3d *force_center, float damage );
+void ship_apply_global_damage(object *ship_obj, object *other_obj, vec3d *force_center, float damage, int damage_type_idx);
 
 // like above, but does not apply damage to shields
 void ship_apply_wash_damage(object *ship_obj, object *other_obj, float damage);

--- a/code/weapon/beam.cpp
+++ b/code/weapon/beam.cpp
@@ -3532,7 +3532,7 @@ void beam_handle_collisions(beam *b)
 				//only apply damage if the collision is not an exit collision.  this prevents twice the damage from being done, although it probably be more realistic since two holes are being punched in the ship instead of one.
 				if (!b->f_collisions[idx].is_exit_collision) {
 					real_damage = beam_get_ship_damage(b, &Objects[target]) * damage_time_mod;
-					ship_apply_local_damage(&Objects[target], &Objects[b->objnum], &b->f_collisions[idx].cinfo.hit_point_world, real_damage, b->f_collisions[idx].quadrant);
+					ship_apply_local_damage(&Objects[target], &Objects[b->objnum], &b->f_collisions[idx].cinfo.hit_point_world, real_damage, wi->damage_type_idx, b->f_collisions[idx].quadrant);
 				}
 				// if this is the first hit on the player ship. whack him
 				if(apply_beam_physics)

--- a/code/weapon/shockwave.cpp
+++ b/code/weapon/shockwave.cpp
@@ -329,7 +329,7 @@ void shockwave_move(object *shockwave_objp, float frametime)
 			if ( (sw->weapon_info_index >= 0) && (Weapon_info[sw->weapon_info_index].wi_flags[Weapon::Info_Flags::Aoe_Electronics]) && !(objp->flags[Object::Object_Flags::Invulnerable]) ) {
 				weapon_do_electronics_effect(objp, &sw->pos, sw->weapon_info_index);
 			}
-			ship_apply_global_damage(objp, shockwave_objp, &sw->pos, damage );
+			ship_apply_global_damage(objp, shockwave_objp, &sw->pos, damage, sw->damage_type_idx );
 			weapon_area_apply_blast(NULL, objp, &sw->pos, blast, 1);
 			break;
 		case OBJ_ASTEROID:

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -6683,7 +6683,7 @@ void weapon_do_area_effect(object *wobjp, shockwave_create_info *sci, vec3d *pos
 			if ( (wip->wi_flags[Weapon::Info_Flags::Aoe_Electronics]) && !((objp->flags[Object::Object_Flags::Invulnerable]) || ((objp == other_obj) && (wip->wi_flags[Weapon::Info_Flags::Electronics]))) ) {
 				weapon_do_electronics_effect(objp, pos, Weapons[wobjp->instance].weapon_info_index);
 			}
-			ship_apply_global_damage(objp, wobjp, pos, damage);
+			ship_apply_global_damage(objp, wobjp, pos, damage, wip->shockwave.damage_type_idx);
 			weapon_area_apply_blast(NULL, objp, pos, blast, 0);
 			break;
 		case OBJ_ASTEROID:
@@ -6692,7 +6692,7 @@ void weapon_do_area_effect(object *wobjp, shockwave_create_info *sci, vec3d *pos
 		case OBJ_WEAPON:
 			target_wip = &Weapon_info[Weapons[objp->instance].weapon_info_index];
 			if (target_wip->armor_type_idx >= 0)
-				damage = Armor_types[target_wip->armor_type_idx].GetDamage(damage, wip->damage_type_idx, 1.0f);
+				damage = Armor_types[target_wip->armor_type_idx].GetDamage(damage, wip->shockwave.damage_type_idx, 1.0f);
 
 			objp->hull_strength -= damage;
 			if (objp->hull_strength < 0.0f) {


### PR DESCRIPTION
I wouldn't have bothered so soon after posting the issue, but I kept running into it so I guess I gotta do something about it.

When dealing damage, damage callers should pass in the appropriate damage type, rather than having `ship_do_damage` make wild guesses based only on the type of the damaging object which cut down on those obnoxious chains of if elses in there. The changes to collidedebrisship.cpp look daunting but I had to do some varaible renaming to avoid awkward stuff like carrying around `pship` and `shipp` or something.

The main behavioral changes of note here are that instant blasts from ship explosions and weapons now deal their associated shockwave damage type. That might sound worrying for weapons, but remember that the shockwave damage type for a weapon is by default the same as the weapon. This will only make it use the shockwave damage type if it was explicitly provided, where before it would've silently ignored it (or used the collision damage type for ship explosions).

Awkward scenarios like cheat codes and even AI self-destruct attempts being possibly averted by the ship's collision damage type are also fixed, and inherit no damage type.

Fixes #3482 