### PR TITLE
fix to #3476

### DIFF
--- a/code/object/objectsnd.cpp
+++ b/code/object/objectsnd.cpp
@@ -44,7 +44,7 @@ typedef struct _obj_snd {
 	int		freq;				// valid range: 100 -> 100000 Hz
 	int		flags;			
 	vec3d	offset;			// offset from the center of the object where the sound lives
-	ship_subsys *ss;		//Associated subsystem
+	const ship_subsys *ss;		//Associated subsystem
 } obj_snd;
 
 #define SPEED_SOUND				600.0f				// speed of sound in FreeSpace
@@ -684,8 +684,10 @@ void obj_snd_do_frame()
 //										sound can be assigned per object).  
 //               >= 0			=> sound was successfully assigned
 //
-int obj_snd_assign(int objnum, gamesnd_id sndnum, vec3d *pos, int flags, ship_subsys *associated_sub)
+int obj_snd_assign(int objnum, gamesnd_id sndnum, const vec3d *pos, int flags, const ship_subsys *associated_sub)
 {
+	Assertion(pos != nullptr, "Sound position must not be null!");
+
 	if(objnum < 0 || objnum > MAX_OBJECTS)
 		return -1;
 

--- a/code/object/objectsnd.h
+++ b/code/object/objectsnd.h
@@ -38,7 +38,7 @@ void	obj_snd_do_frame();
 // model coords of the location of the engine
 // by passing vmd_zero_vector here, you get a sound centered directly on the object
 // This function used to have a "main" argument, but that is equivalent to including OS_MAIN as one of the flags
-int	obj_snd_assign(int objnum, gamesnd_id sndnum, vec3d *pos, int flags=0, ship_subsys *associated_sub=NULL);
+int	obj_snd_assign(int objnum, gamesnd_id sndnum, const vec3d *pos, int flags = 0, const ship_subsys *associated_sub = nullptr);
 
 //Delete specific persistent sound on object
 void obj_snd_delete(int objnum, int index);

--- a/code/scripting/api/objs/object.cpp
+++ b/code/scripting/api/objs/object.cpp
@@ -539,6 +539,8 @@ ADE_FUNC(assignSound, l_Object, "soundentry GameSnd, [vector Offset=nil, enumera
 	auto objp = objh->objp;
 	auto gs_id = seh->idx;
 	auto subsys = tgsh ? tgsh->ss : nullptr;
+	if (!offset)
+		offset = &vmd_zero_vector;
 	if (enum_flags.IsValid())
 	{
 		flags = enum_flags.index;


### PR DESCRIPTION
The default sound position should be the zero-vector, not nullptr.  Also, this adds a bit of extra type safety.