### PR TITLE
Bugfix for waypoint turnrate

### DIFF
--- a/code/ai/ai_flags.h
+++ b/code/ai/ai_flags.h
@@ -5,7 +5,7 @@
 
 namespace AI {
 	FLAG_LIST(AI_Flags) {
-		Formation_wing,				//	Fly in formation as part of wing.
+		Formation_wing,				//	Fly in formation as part of wing. Also used when flying waypoints.
 		Awaiting_repair,			//	Awaiting a repair ship.
 		Being_repaired,				//	Currently docked with repair ship.
 		Repairing,					//	Repairing a ship (or going to repair a ship)

--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -4420,6 +4420,13 @@ void ai_fly_to_target_position(vec3d* target_pos, bool* pl_done_p=NULL, bool* pl
 	bool carry_flag = ((shipp->flags[Ship::Ship_Flags::Navpoint_carry]) || ((shipp->wingnum >= 0) && (Wings[shipp->wingnum].flags[Ship::Wing_Flags::Nav_carry])));
 
 	float waypoint_turnrate = 1 / (3.0f * scale);
+
+	// for retail compatability reasons, have to take into account rotdamp so that ships with less than 1 rotdamp have increased waypoint turnrate
+	// please see PR #2740 and #3494 for more information
+	if (Pl_objp->phys_info.rotdamp < 1.0f )
+		// start increasing the turnrate to 2x at 0.5 rotdamp and 3x at 0
+		waypoint_turnrate *= (3 - 2 * Pl_objp->phys_info.rotdamp);
+
 	vec3d turnrate_mod;
 	vm_vec_make(&turnrate_mod, waypoint_turnrate, waypoint_turnrate, waypoint_turnrate);
 


### PR DESCRIPTION
In #2673 a chunk of code was removed https://github.com/scp-fs2open/fs2open.github.com/pull/2673/files#diff-5bc93e562f5e539d8b3dc382d359e76b27125c5607bab24aaeb6c8c2471e5a7aL14227

This code allowed ships in `Formation_object` or `Formation_wing` mode to turn much faster than normal (by actually setting `desired_rotvel` to non-zero, unlike the rest of the code, which means the physics damping no longer works against the ship). However, it really mucked up how the system should've worked, and ships don't really need any extra help while simply flying in formation. Later, @Goober5000 would report a bug to me, where I discovered that, very counter-intuitively, `Formation_wing` also applies to waypoint flying. Ships which before barely made their waypoint turns, were now unable without this boost and had to make potentially costly detours.

Luckily, the hardcoded arbitrary 1/3rd waypoint flying turnrate can be adjusted to account for this, at least approximately. The result is that ships with less than 1 rotdamp (ships above that, which includes most capitals, were unaffected by this problem) gain an up to 3x boost to their waypoint turnrate, depending on their rotdamp. This is most obvious for freighters and transports, which can have slow turn rates and thus most strongly affected by the boost. Fighters and the like are affected as well, but can turn so fast anyway that it would rarely cause issues.

For those interested in the details: Removing the physics damping doesn't actually make a big deal for ships above 1 rotdamp because the physics damping is so weak it can make its "cap" of the doubled turnrate (discussed in more detail in #2740) either way, it is below 1 where the damping becomes strong enough that the maximum effective rotvel is less than 2x. While running waypoints this damping is in effect removed, giving it the 2x effective rotvel again and causing the discrepancy. Since 0.5 rotdamp is the break even point where the damping and the AI acceleration happen to exactly meet, 0.5 rotdamp is where it should have exactly doubled turnrate, hence 3 - 2 * rotdamp, for no effect at 1 rotdamp and double at 0.5. Although it continues to 3x at 0 rotdamp, technically it would be asymptotic, and the multiplier should increase to infinity as rotdamp reaches 0, but to avoid this degenerate scenario and since fighters turn so quickly that this is hardly relevant anyway, I kept it to the simpler linear formula.

And finally a table of some example ships and 180 turn times:

| Ship  | Before 2673 | After 2673 | This PR |
| ------------- | ------------- | ------------- | ------------- |
| Triton (rotdamp 0.7) | 12s | 16s  | 11.5s  |
| Aeolus (rotdamp 2.0) | 78s  | 78s  | 78s  | 
| Anuket (rotdamp 1.0) | 78s  | 76s  | 76s  |
| Azrael (rotdamp 0.6) | 4.5s | 7.5s | 4.5s |
| Dis (rotdamp 0.7) | 19s  | 27s  | 18s  |
| Argo (rotdamp 0.6) | 4.5s  | 7.5s  | 4.5s  |