### PR TITLE
maintain a copy of the default translations to check against untranslated strings

### DIFF
--- a/code/localization/localize.cpp
+++ b/code/localization/localize.cpp
@@ -462,8 +462,8 @@ void parse_tstringstbl(const char *filename)
 // initialize the xstr table
 void lcl_xstr_init()
 {
-	for (int i = 0; i < XSTR_SIZE; i++)
-		Xstr_table[i].str = nullptr;
+	for (auto &xstr_entry : Xstr_table)
+		xstr_entry.str = nullptr;
 
 	Assertion(Lcl_ext_str.empty() && Lcl_ext_str_explicit_default.empty(), "Localize system was not shut down properly!");
 	Lcl_ext_str.clear();
@@ -534,10 +534,10 @@ void lcl_xstr_init()
 // free Xstr table
 void lcl_xstr_close()
 {
-	for (int i = 0; i < XSTR_SIZE; i++) {
-		if (Xstr_table[i].str != nullptr) {
-			vm_free((void *)Xstr_table[i].str);
-			Xstr_table[i].str = nullptr;
+	for (auto &xstr_entry : Xstr_table) {
+		if (xstr_entry.str != nullptr) {
+			vm_free((void *)xstr_entry.str);
+			xstr_entry.str = nullptr;
 		}
 	}
 
@@ -792,7 +792,7 @@ bool lcl_ext_localize_sub(const char *in, char *text_str, char *out, size_t max_
 	}
 	
 	// if the localization file is not open, or there's no entry, or we're not translating, return the original string
-	if ( !Xstr_inited || (str_id < 0) || (Lcl_current_lang == LCL_UNTRANSLATED) || (Lcl_current_lang == LCL_RETAIL_HYBRID) ) {
+	if ( !Xstr_inited || (str_id < 0) || (!use_default_translation && ((Lcl_current_lang == LCL_UNTRANSLATED) || (Lcl_current_lang == LCL_RETAIL_HYBRID))) ) {
 		if ( strlen(text_str) > max_len && !Lcl_unexpected_tstring_check )
 			error_display(0, "Token too long: [%s].  Length = " SIZE_T_ARG ".  Max is " SIZE_T_ARG ".\n", text_str, strlen(text_str), max_len);
 
@@ -886,7 +886,7 @@ bool lcl_ext_localize_sub(const SCP_string &in, SCP_string &text_str, SCP_string
 	}
 	
 	// if the localization file is not open, or there's no entry, or we're not translating, return the original string
-	if ( !Xstr_inited || (str_id < 0) || (Lcl_current_lang == LCL_UNTRANSLATED) || (Lcl_current_lang == LCL_RETAIL_HYBRID) ) {
+	if ( !Xstr_inited || (str_id < 0) || (!use_default_translation && ((Lcl_current_lang == LCL_UNTRANSLATED) || (Lcl_current_lang == LCL_RETAIL_HYBRID))) ) {
 		out = text_str;
 
 		if (id != NULL)

--- a/code/localization/localize.cpp
+++ b/code/localization/localize.cpp
@@ -70,7 +70,7 @@ typedef struct {
 } lcl_xstr;
 
 lcl_xstr Xstr_table[XSTR_SIZE];
-int Xstr_inited = 0;
+bool Xstr_inited = false;
 
 
 // table/mission externalization stuff --------------------
@@ -78,6 +78,11 @@ int Xstr_inited = 0;
 #define PARSE_ID_BUF_SIZE			8	// 7 digits and a \0
 
 SCP_unordered_map<int, char*> Lcl_ext_str;
+
+// Lcl_ext_str will only keep translations for the active language, so if we're not running in English,
+// keep the English strings so that we can compare untranslated to English-translated.  But to save space,
+// we only need to keep the NAME_LENGTH strings, since we only need to test mission names.
+SCP_unordered_map<int, char*> Lcl_ext_str_explicit_default;
 
 
 // ------------------------------------------------------------------------------------------------------------
@@ -457,14 +462,13 @@ void parse_tstringstbl(const char *filename)
 // initialize the xstr table
 void lcl_xstr_init()
 {
-	int i;
+	for (int i = 0; i < XSTR_SIZE; i++)
+		Xstr_table[i].str = nullptr;
 
-
-	for (i = 0; i < XSTR_SIZE; i++)
-		Xstr_table[i].str = NULL;
-
-	Assertion(Lcl_ext_str.size() == 0, "Localize system was not shut down properly!");
+	Assertion(Lcl_ext_str.empty() && Lcl_ext_str_explicit_default.empty(), "Localize system was not shut down properly!");
 	Lcl_ext_str.clear();
+	Lcl_ext_str_explicit_default.clear();
+
 
 	try
 	{
@@ -474,8 +478,42 @@ void lcl_xstr_init()
 	{
 		mprintf(("TABLES: Unable to parse '%s'!  Error message = %s.\n", "strings.tbl", e.what()));
 	}
-
 	parse_modular_table(NOX("*-lcl.tbm"), parse_stringstbl);
+
+
+	// If this is a non-English language, parse English and keep a copy of the table that's just the NAME_LENGTH strings
+	if (lcl_get_current_lang_index() != LCL_DEFAULT)
+	{
+		auto saved_language = Lcl_current_lang;
+		Lcl_current_lang = LCL_DEFAULT;
+
+		// same parsing as below
+		try
+		{
+			parse_tstringstbl("tstrings.tbl");
+		}
+		catch (const parse::ParseException& e)
+		{
+			mprintf(("TABLES: Unable to parse '%s'!  Error message = %s.\n", "tstrings.tbl", e.what()));
+		}
+		parse_modular_table(NOX("*-tlc.tbm"), parse_tstringstbl);
+
+		// copy entries containing short strings and free the rest
+		for (const auto& entry : Lcl_ext_str)
+		{
+			if (entry.second != nullptr)
+			{
+				if (strlen(entry.second) < NAME_LENGTH)
+					Lcl_ext_str_explicit_default.insert(entry);
+				else
+					vm_free(entry.second);
+			}
+		}
+
+		// reset things so that we can parse the language properly
+		Lcl_ext_str.clear();
+		Lcl_current_lang = saved_language;
+	}
 
 
 	try
@@ -486,23 +524,20 @@ void lcl_xstr_init()
 	{
 		mprintf(("TABLES: Unable to parse '%s'!  Error message = %s.\n", "tstrings.tbl", e.what()));
 	}
-
 	parse_modular_table(NOX("*-tlc.tbm"), parse_tstringstbl);
 
 
-	Xstr_inited = 1;
+	Xstr_inited = true;
 }
 
 
 // free Xstr table
 void lcl_xstr_close()
 {
-	int i;
-
-	for (i=0; i<XSTR_SIZE; i++){
-		if (Xstr_table[i].str != NULL) {
-			vm_free((void *) Xstr_table[i].str);
-			Xstr_table[i].str = NULL;
+	for (int i = 0; i < XSTR_SIZE; i++) {
+		if (Xstr_table[i].str != nullptr) {
+			vm_free((void *)Xstr_table[i].str);
+			Xstr_table[i].str = nullptr;
 		}
 	}
 
@@ -512,6 +547,13 @@ void lcl_xstr_close()
 		}
 	}
 	Lcl_ext_str.clear();
+
+	for (const auto& entry : Lcl_ext_str_explicit_default) {
+		if (entry.second != nullptr) {
+			vm_free(entry.second);
+		}
+	}
+	Lcl_ext_str_explicit_default.clear();
 }
 
 
@@ -680,7 +722,7 @@ void lcl_fred_replace_stuff(SCP_string &text)
 // and these should cover all the externalized string cases
 // fills in id if non-NULL. a value of -2 indicates it is not an external string
 // returns true if we were able to extract the XSTR elements (text_str and maybe id are populated)
-bool lcl_ext_localize_sub(const char *in, char *text_str, char *out, size_t max_len, int *id)
+bool lcl_ext_localize_sub(const char *in, char *text_str, char *out, size_t max_len, int *id, bool use_default_translation = false)
 {
 	int str_id;
 	size_t str_len;
@@ -762,13 +804,21 @@ bool lcl_ext_localize_sub(const char *in, char *text_str, char *out, size_t max_
 		return true;
 	}
 
-	// get the string if it exists
-	if (Lcl_ext_str.find(str_id) != Lcl_ext_str.end()) {
-		// copy to the outgoing string
-		if ( strlen(Lcl_ext_str[str_id]) > max_len && !Lcl_unexpected_tstring_check )
-			error_display(0, "Token too long: [%s].  Length = " SIZE_T_ARG ".  Max is " SIZE_T_ARG ".\n", Lcl_ext_str[str_id], strlen(Lcl_ext_str[str_id]), max_len);
+	auto lookup_map = &Lcl_ext_str;
+	if (use_default_translation && lcl_get_current_lang_index() != LCL_DEFAULT) {
+		// if we're not already using the default, then switch to our explicit default
+		lookup_map = &Lcl_ext_str_explicit_default;
+	}
 
-		strncpy(out, Lcl_ext_str[str_id], max_len);
+	// get the string if it exists
+	if (lookup_map->find(str_id) != lookup_map->end()) {
+		auto lookup_result = (*lookup_map)[str_id];
+
+		// copy to the outgoing string
+		if ( strlen(lookup_result) > max_len && !Lcl_unexpected_tstring_check )
+			error_display(0, "Token too long: [%s].  Length = " SIZE_T_ARG ".  Max is " SIZE_T_ARG ".\n", lookup_result, strlen(lookup_result), max_len);
+
+		strncpy(out, lookup_result, max_len);
 	}
 	// otherwise use what we have - probably should Int3() or assert here
 	else {
@@ -787,7 +837,7 @@ bool lcl_ext_localize_sub(const char *in, char *text_str, char *out, size_t max_
 }
 
 // ditto for SCP_string
-bool lcl_ext_localize_sub(const SCP_string &in, SCP_string &text_str, SCP_string &out, int *id)
+bool lcl_ext_localize_sub(const SCP_string &in, SCP_string &text_str, SCP_string &out, int *id, bool use_default_translation = false)
 {
 	int str_id;
 
@@ -845,10 +895,16 @@ bool lcl_ext_localize_sub(const SCP_string &in, SCP_string &text_str, SCP_string
 		return true;
 	}
 
+	auto lookup_map = &Lcl_ext_str;
+	if (use_default_translation && lcl_get_current_lang_index() != LCL_DEFAULT) {
+		// if we're not already using the default, then switch to our explicit default
+		lookup_map = &Lcl_ext_str_explicit_default;
+	}
+
 	// get the string if it exists
-	if (Lcl_ext_str.find(str_id) != Lcl_ext_str.end()) {
+	if (lookup_map->find(str_id) != lookup_map->end()) {
 		// copy to the outgoing string
-		out = Lcl_ext_str[str_id];
+		out = (*lookup_map)[str_id];
 	}
 	// otherwise use what we have - probably should Int3() or assert here
 	else {
@@ -875,20 +931,20 @@ void lcl_ext_localize(const char *in, char *out, size_t max_len, int *id)
 	// if we're doing this extra check, then we have to compare the untranslated string with the default language string and see if they're different
 	if (Lcl_unexpected_tstring_check)
 	{
-		int saved_language = Lcl_current_lang;
-		Lcl_current_lang = LCL_DEFAULT;
-		bool extracted = lcl_ext_localize_sub(in, text_str, out, max_len, id);
+		// explicitly use the default table for the translation lookup
+		bool extracted = lcl_ext_localize_sub(in, text_str, out, max_len, id, true);
 
-		// the untranslated and default-translated strings should always be identical, so if they're different, it might mean we have some data from a different mod
-		if (extracted && strcmp(text_str, out) != 0)
-			*Lcl_unexpected_tstring_check = true;
-
-		// at this point, we go back to our usual language and do the translation for real
-		if (saved_language != Lcl_current_lang)
+		// only check short strings, since those are the only ones we keep in the explicit default table
+		if (strlen(text_str) < NAME_LENGTH)
 		{
-			Lcl_current_lang = saved_language;
-			lcl_ext_localize_sub(in, text_str, out, max_len, id);
+			// the untranslated and default-translated strings should always be identical, so if they're different, it might mean we have some data from a different mod
+			if (extracted && strcmp(text_str, out) != 0)
+				*Lcl_unexpected_tstring_check = true;
 		}
+
+		// at this point, we can go back to our usual language and do the translation for real
+		if (lcl_get_current_lang_index() != LCL_DEFAULT)
+			lcl_ext_localize_sub(in, text_str, out, max_len, id);
 	}
 	// most of the time we're not going to do the check, so localize as normal
 	else
@@ -910,20 +966,20 @@ void lcl_ext_localize(const SCP_string &in, SCP_string &out, int *id)
 	// if we're doing this extra check, then we have to compare the untranslated string with the default language string and see if they're different
 	if (Lcl_unexpected_tstring_check)
 	{
-		int saved_language = Lcl_current_lang;
-		Lcl_current_lang = LCL_DEFAULT;
-		bool extracted = lcl_ext_localize_sub(in, text_str, out, id);
+		// explicitly use the default table for the translation lookup
+		bool extracted = lcl_ext_localize_sub(in, text_str, out, id, true);
 
-		// the untranslated and default-translated strings should always be identical, so if they're different, it might mean we have some data from a different mod
-		if (extracted && text_str != out)
-			*Lcl_unexpected_tstring_check = true;
-
-		// at this point, we go back to our usual language and do the translation for real
-		if (saved_language != Lcl_current_lang)
+		// only check short strings, since those are the only ones we keep in the explicit default table
+		if (text_str.length() < NAME_LENGTH)
 		{
-			Lcl_current_lang = saved_language;
-			lcl_ext_localize_sub(in, text_str, out, id);
+			// the untranslated and default-translated strings should always be identical, so if they're different, it might mean we have some data from a different mod
+			if (extracted && text_str != out)
+				*Lcl_unexpected_tstring_check = true;
 		}
+
+		// at this point, we can go back to our usual language and do the translation for real
+		if (lcl_get_current_lang_index() != LCL_DEFAULT)
+			lcl_ext_localize_sub(in, text_str, out, id);
 	}
 	// most of the time we're not going to do the check, so localize as normal
 	else

--- a/fred2/management.cpp
+++ b/fred2/management.cpp
@@ -341,8 +341,8 @@ bool fred_init(std::unique_ptr<os::GraphicsOperations>&& graphicsOps)
 	lcl_init(LCL_UNTRANSLATED);
 
 	// Goober5000 - force init XSTRs (so they work, but only work untranslated, based on above comment)
-	extern int Xstr_inited;
-	Xstr_inited = 1;
+	extern bool Xstr_inited;
+	Xstr_inited = true;
 
 #ifndef NDEBUG
 	load_filter_info();

--- a/qtfred/src/mission/management.cpp
+++ b/qtfred/src/mission/management.cpp
@@ -30,7 +30,7 @@
 
 #include <clocale>
 
-extern int Xstr_inited;
+extern bool Xstr_inited;
 
 extern void allocate_parse_text(size_t size);
 
@@ -103,7 +103,7 @@ initialize(const std::string& cfilepath, int argc, char* argv[], Editor* editor,
 	lcl_init(LCL_UNTRANSLATED);
 
 	// Goober5000 - force init XSTRs (so they work, but only work untranslated, based on above comment)
-	Xstr_inited = 1;
+	Xstr_inited = true;
 
 #ifndef NDEBUG
 	load_filter_info();


### PR DESCRIPTION
Bug #3471 occurs because the game only keeps a translation table for the current language.  Since the mission list needs to compare untranslated strings against English strings, this adds a duplicate table for English.  However, it only keeps strings that are NAME_LENGTH or less, because the comparison only needs to be run against mission names.

Fixes #3471.