### PR TITLE
some bitwise operation enhancements

### DIFF
--- a/code/scripting/api/libs/bitops.cpp
+++ b/code/scripting/api/libs/bitops.cpp
@@ -8,25 +8,30 @@ namespace api {
 //**********LIBRARY: Bitwise Ops
 ADE_LIB(l_BitOps, "BitOps", "bit", "Bitwise Operations library");
 
-ADE_FUNC(AND, l_BitOps, "number, number", "Values for which bitwise boolean AND operation is performed", "number", "Result of the AND operation")
+ADE_FUNC(AND, l_BitOps, "number, number, [number, number, number, number, number, number, number, number]", "Values for which bitwise boolean AND operation is performed", "number", "Result of the AND operation")
 {
-
-	int a, b, c;
-	if(!ade_get_args(L, "ii", &a,&b))
+	int a[10], c;
+	int n = ade_get_args(L, "ii|iiiiiiii", &a[0], &a[1], &a[2], &a[3], &a[4], &a[5], &a[6], &a[7], &a[8], &a[9]);
+	if (n < 2)
 		return ade_set_error(L, "i", 0);
 
-	c = (a & b);
+	c = a[0];
+	for (int i = 1; i < n; ++i)
+		c &= a[i];
 
 	return ade_set_args(L, "i", c);
 }
 
-ADE_FUNC(OR, l_BitOps, "number, number", "Values for which bitwise boolean OR operation is performed", "number", "Result of the OR operation")
+ADE_FUNC(OR, l_BitOps, "number, number, [number, number, number, number, number, number, number, number]", "Values for which bitwise boolean OR operation is performed", "number", "Result of the OR operation")
 {
-	int a, b, c;
-	if(!ade_get_args(L, "ii", &a,&b))
+	int a[10], c;
+	int n = ade_get_args(L, "ii|iiiiiiii", &a[0], &a[1], &a[2], &a[3], &a[4], &a[5], &a[6], &a[7], &a[8], &a[9]);
+	if (n < 2)
 		return ade_set_error(L, "i", 0);
 
-	c = (a | b);
+	c = a[0];
+	for (int i = 1; i < n; ++i)
+		c |= a[i];
 
 	return ade_set_args(L, "i", c);
 }
@@ -71,7 +76,14 @@ ADE_FUNC(checkBit, l_BitOps, "number baseNumber, number bit", "Checks the value 
 		return ADE_RETURN_FALSE;
 }
 
-ADE_FUNC(addBit, l_BitOps, "number baseNumber, number bit", "Performs inclusive or (OR) operation on the set bit of the value", "number", "Result of the operation")
+ADE_FUNC_DEPRECATED(addBit,
+	l_BitOps,
+	"number baseNumber, number bit",
+	"Performs inclusive or (OR) operation on the set bit of the value",
+	"number",
+	"Result of the operation",
+	gameversion::version(21, 4),
+	"BitOps.addBit has been replaced by BitOps.setBit")
 {
 	int a, b, c;
 	if(!ade_get_args(L, "ii", &a,&b))
@@ -81,6 +93,34 @@ ADE_FUNC(addBit, l_BitOps, "number baseNumber, number bit", "Performs inclusive 
 		return ade_set_error(L, "i", 0);
 
 	c = (a | (1<<b));
+
+	return ade_set_args(L, "i", c);
+}
+
+ADE_FUNC(setBit, l_BitOps, "number baseNumber, number bit", "Turns on the specified bit of baseNumber (sets it to 1)", "number", "Result of the operation")
+{
+	int a, b, c;
+	if (!ade_get_args(L, "ii", &a, &b))
+		return ade_set_error(L, "i", 0);
+
+	if (!((b >= 0) && (b < 32)))
+		return ade_set_error(L, "i", 0);
+
+	c = (a | (1 << b));
+
+	return ade_set_args(L, "i", c);
+}
+
+ADE_FUNC(unsetBit, l_BitOps, "number baseNumber, number bit", "Turns off the specified bit of baseNumber (sets it to 0)", "number", "Result of the operation")
+{
+	int a, b, c;
+	if (!ade_get_args(L, "ii", &a, &b))
+		return ade_set_error(L, "i", 0);
+
+	if (!((b >= 0) && (b < 32)))
+		return ade_set_error(L, "i", 0);
+
+	c = (a & ~(1 << b));
 
 	return ade_set_args(L, "i", c);
 }

--- a/test/src/scripting/api/bitops.cpp
+++ b/test/src/scripting/api/bitops.cpp
@@ -28,6 +28,10 @@ TEST_F(BitOpsTest, checkBit) {
 	this->EvalTestScript();
 }
 
-TEST_F(BitOpsTest, addBit) {
+TEST_F(BitOpsTest, setBit) {
+	this->EvalTestScript();
+}
+
+TEST_F(BitOpsTest, unsetBit) {
 	this->EvalTestScript();
 }

--- a/test/test_data/scripting/bitops/addBit/data/scripts/test.lua
+++ b/test/test_data/scripting/bitops/addBit/data/scripts/test.lua
@@ -1,4 +1,0 @@
-
-assert(bit.addBit(0xE, 0) == 0xF)
-assert(bit.addBit(0, 0) == 1)
-assert(bit.addBit(1, 0) == 1)

--- a/test/test_data/scripting/bitops/setBit/data/scripts/test.lua
+++ b/test/test_data/scripting/bitops/setBit/data/scripts/test.lua
@@ -1,0 +1,4 @@
+
+assert(bit.setBit(0xE, 0) == 0xF)
+assert(bit.setBit(0, 0) == 1)
+assert(bit.setBit(1, 0) == 1)

--- a/test/test_data/scripting/bitops/unsetBit/data/scripts/test.lua
+++ b/test/test_data/scripting/bitops/unsetBit/data/scripts/test.lua
@@ -1,0 +1,4 @@
+
+assert(bit.unsetBit(0xF, 0) == 0xE)
+assert(bit.unsetBit(0, 0) == 0)
+assert(bit.unsetBit(1, 0) == 0)


### PR DESCRIPTION
Allow AND and OR to take up to 10 arguments.  Deprecate addBit and replace with setBit, and add unsetBit.