### PR TITLE
add bitwise operations with enums

### DIFF
--- a/code/scripting/api/libs/bitops.cpp
+++ b/code/scripting/api/libs/bitops.cpp
@@ -1,6 +1,7 @@
 
 #include "bitops.h"
 #include "scripting/ade_args.h"
+#include "scripting/api/objs/enums.h"
 
 namespace scripting {
 namespace api {
@@ -34,6 +35,36 @@ ADE_FUNC(OR, l_BitOps, "number, number, [number, number, number, number, number,
 		c |= a[i];
 
 	return ade_set_args(L, "i", c);
+}
+
+ADE_FUNC(EnumAND, l_BitOps, "enumeration, enumeration, [enumeration, enumeration, enumeration, enumeration, enumeration, enumeration, enumeration, enumeration]", "Values for which bitwise boolean AND operation is performed", "number", "Result of the AND operation")
+{
+	enum_h a[10];
+	int c;
+	int n = ade_get_args(L, "oo|oooooooo", l_Enum.Get(&a[0]), l_Enum.Get(&a[1]), l_Enum.Get(&a[2]), l_Enum.Get(&a[3]), l_Enum.Get(&a[4]), l_Enum.Get(&a[5]), l_Enum.Get(&a[6]), l_Enum.Get(&a[7]), l_Enum.Get(&a[8]), l_Enum.Get(&a[9]));
+	if (n < 2)
+		return ade_set_error(L, "o", l_Enum.Set(enum_h()));
+
+	c = a[0].index;
+	for (int i = 1; i < n; ++i)
+		c &= a[i].index;
+
+	return ade_set_args(L, "o", l_Enum.Set(enum_h(c)));
+}
+
+ADE_FUNC(EnumOR, l_BitOps, "enumeration, enumeration, [enumeration, enumeration, enumeration, enumeration, enumeration, enumeration, enumeration, enumeration]", "Values for which bitwise boolean OR operation is performed", "number", "Result of the OR operation")
+{
+	enum_h a[10];
+	int c;
+	int n = ade_get_args(L, "oo|oooooooo", l_Enum.Get(&a[0]), l_Enum.Get(&a[1]), l_Enum.Get(&a[2]), l_Enum.Get(&a[3]), l_Enum.Get(&a[4]), l_Enum.Get(&a[5]), l_Enum.Get(&a[6]), l_Enum.Get(&a[7]), l_Enum.Get(&a[8]), l_Enum.Get(&a[9]));
+	if (n < 2)
+		return ade_set_error(L, "o", l_Enum.Set(enum_h()));
+
+	c = a[0].index;
+	for (int i = 1; i < n; ++i)
+		c |= a[i].index;
+
+	return ade_set_args(L, "o", l_Enum.Set(enum_h(c)));
 }
 
 ADE_FUNC(XOR, l_BitOps, "number, number", "Values for which bitwise boolean XOR operation is performed", "number", "Result of the XOR operation")

--- a/code/scripting/api/objs/enums.cpp
+++ b/code/scripting/api/objs/enums.cpp
@@ -106,6 +106,7 @@ flag_def_list Enumerations[] = {
 	{"FIREBALL_LARGE_EXPLOSION", LE_FIREBALL_LARGE_EXPLOSION, 0},
 	{"FIREBALL_WARP_EFFECT", LE_FIREBALL_WARP_EFFECT, 0},
 	// the following OS_ definitions use bitfield values, not the indexes in enums.h
+	{"OS_NONE", 0, 0},
 	{"OS_USED", OS_USED, 0},
 	{"OS_DS3D", OS_DS3D, 0},
 	{"OS_MAIN", OS_MAIN, 0},
@@ -213,6 +214,21 @@ ADE_FUNC(__eq,
 	}
 
 	return ade_set_args(L, "b", e1->index == e2->index);
+}
+
+ADE_VIRTVAR(IntValue, l_Enum, "enumeration", "Internal value of the enum.  Probably not useful unless this enum is a bitfield or corresponds to a #define somewhere else in the source code.", "number", "Integer (index) value of the enum")
+{
+	enum_h* e = nullptr;
+	if (!ade_get_args(L, "o", l_Enum.GetPtr(&e))) {
+		return ade_set_args(L, "i", -1);
+	}
+
+	if (ADE_SETTING_VAR) {
+		LuaError(L, "IntValue is read only!");
+		return ADE_RETURN_NIL;
+	}
+
+	return ade_set_args(L, "i", e->index);
 }
 
 }

--- a/code/scripting/api/objs/object.cpp
+++ b/code/scripting/api/objs/object.cpp
@@ -541,16 +541,8 @@ ADE_FUNC(assignSound, l_Object, "soundentry GameSnd, [vector Offset=nil, enumera
 	auto subsys = tgsh ? tgsh->ss : nullptr;
 	if (!offset)
 		offset = &vmd_zero_vector;
-	if (enum_flags.IsValid())
-	{
+	if (enum_flags.index >= 0)
 		flags = enum_flags.index;
-
-		if (flags < 0 || flags > OS_SUBSYS_ROTATION)
-		{
-			LuaError(L, "Flags parameter %d is out of range for object %d!", flags, OBJ_INDEX(objp));
-			return ADE_RETURN_NIL;
-		}
-	}
 
 	int snd_idx = obj_snd_assign(OBJ_INDEX(objp), gs_id, offset, flags, subsys);
 


### PR DESCRIPTION
This adds `EnumAND` and `EnumOR` which will return new enums based on the specified operations.  These are handy for enums that correspond to bit fields, such as those used for object persistent sounds.