### PR TITLE
Add shadow map generation for briefing

### DIFF
--- a/code/missionui/missionbrief.cpp
+++ b/code/missionui/missionbrief.cpp
@@ -21,6 +21,7 @@
 #include "globalincs/linklist.h"
 #include "graphics/font.h"
 #include "graphics/matrix.h"
+#include "graphics/shadows.h"
 #include "hud/hud.h"
 #include "io/key.h"
 #include "io/mouse.h"
@@ -1045,10 +1046,6 @@ void brief_render_closeup(int ship_class, float frametime)
 
 	g3_start_frame(1);
 	g3_set_view_matrix(&Closeup_cam_pos, &view_orient, Closeup_zoom);
-
-
-	gr_set_proj_matrix(Proj_fov, gr_screen.clip_aspect, Min_draw_distance, Max_draw_distance);
-	gr_set_view_matrix(&Eye_position, &Eye_matrix);
 	
 	// the following is copied from menuui/techmenu.cpp ... it works heehee :D  - delt.
 	// lighting for techroom
@@ -1070,12 +1067,28 @@ void brief_render_closeup(int ship_class, float frametime)
 	model_render_params render_info;
 	render_info.set_detail_level_lock(0);
 
+	if (Shadow_quality != ShadowQuality::Disabled)
+	{
+		auto pm = model_get(Closeup_icon->modelnum);
+
+		gr_reset_clip();
+		shadows_start_render(&Eye_matrix, &Eye_position, Proj_fov, gr_screen.clip_aspect, -Closeup_cam_pos.xyz.z + pm->rad, -Closeup_cam_pos.xyz.z + pm->rad + 200.0f, -Closeup_cam_pos.xyz.z + pm->rad + 2000.0f, -Closeup_cam_pos.xyz.z + pm->rad + 10000.0f);
+		render_info.set_flags(MR_NO_TEXTURING | MR_NO_LIGHTING | MR_AUTOCENTER);
+
+		model_render_immediate(&render_info, Closeup_icon->modelnum, Closeup_icon->model_instance_num, &Closeup_orient, &Closeup_pos);
+		shadows_end_render();
+		gr_set_clip(Closeup_region[gr_screen.res][0], Closeup_region[gr_screen.res][1], w, h, GR_RESIZE_MENU);
+	}
+
 	if ( Closeup_icon->type == ICON_JUMP_NODE) {
 		render_info.set_color(HUD_color_red, HUD_color_green, HUD_color_blue);
 		render_info.set_flags(MR_NO_LIGHTING | MR_AUTOCENTER | MR_NO_POLYS | MR_SHOW_OUTLINE_HTL | MR_NO_TEXTURING);
 	} else {
 		render_info.set_flags(MR_AUTOCENTER);
 	}
+
+	gr_set_proj_matrix(Proj_fov, gr_screen.clip_aspect, Min_draw_distance, Max_draw_distance);
+	gr_set_view_matrix(&Eye_position, &Eye_matrix);
 
 	model_render_immediate( &render_info, Closeup_icon->modelnum, Closeup_icon->model_instance_num, &Closeup_orient, &Closeup_pos );
 


### PR DESCRIPTION
Currently, the model previews during the briefing did not calculate a shadow map. This means that the actual render stage used the last used shadowmap to render (in case of a mission play through the techroom, this is most likely the shadow of the ship shown by default in the ship viewer of the techroom). This is obviously just wrong and will lead to shadows completely unpredictable and wrong in the mission briefing.
This adds proper shadow calculation.

Code is essentially copied from the techroom