### PR TITLE
Add More Options to Scripted Persistent Sounds

### DIFF
--- a/code/object/objectsnd.cpp
+++ b/code/object/objectsnd.cpp
@@ -611,7 +611,7 @@ void obj_snd_do_frame()
 
 				if ( go_ahead_flag ) {
 					int is_looping = (osp->flags & OS_LOOPING_DISABLED) ? 0 : 1;
-					osp->instance = snd_play_3d(gs, &source_pos, &View_position, add_distance, &objp->phys_info.vel, is_looping, 1.0f, SND_PRIORITY_TRIPLE_INSTANCE, NULL, 1.0f, 0, true);
+					osp->instance = snd_play_3d(gs, &source_pos, &View_position, add_distance, &objp->phys_info.vel, is_looping, 1.0f, SND_PRIORITY_TRIPLE_INSTANCE, nullptr, 1.0f, 0, true);
 					if (osp->instance.isValid()) {
 						Num_obj_sounds_playing++;
 						osp->flags |= OS_STARTED_PLAYING;

--- a/code/object/objectsnd.cpp
+++ b/code/object/objectsnd.cpp
@@ -86,7 +86,7 @@ void obj_snd_source_pos(vec3d *sound_pos, obj_snd *osp)
 int obj_snd_find(object *objp, obj_snd *osp)
 {
 	int idx = 0;
-	for (SCP_vector<int>::iterator iter = objp->objsnd_num.begin(); iter != objp->objsnd_num.end(); ++iter, ++idx) {
+	for (auto iter = objp->objsnd_num.begin(); iter != objp->objsnd_num.end(); ++iter, ++idx) {
 		if (*iter == (osp - Objsnds)) {
 			return idx;
 		}

--- a/code/object/objectsnd.h
+++ b/code/object/objectsnd.h
@@ -26,6 +26,7 @@
 #define OS_LOOPING_DISABLED		(1<<9)
 
 struct vec3d;
+class object;
 class ship_subsys;
 
 extern int Obj_snd_enabled;

--- a/code/object/objectsnd.h
+++ b/code/object/objectsnd.h
@@ -23,6 +23,9 @@
 #define OS_SUBSYS_DEAD			(1<<6)
 #define OS_SUBSYS_DAMAGED		(1<<7)
 #define OS_SUBSYS_ROTATION		(1<<8)
+#define OS_PLAY_ON_PLAYER		(1<<9)
+#define OS_LOOPING_DISABLED		(1<<7)
+#define OS_STARTED_PLAYING		(1<<11)
 
 struct vec3d;
 class ship_subsys;

--- a/code/object/objectsnd.h
+++ b/code/object/objectsnd.h
@@ -15,17 +15,16 @@
 #include "gamesnd/gamesnd.h"
 
 #define	OS_USED					(1<<0)
-#define	OS_DS3D					(1<<1)
-#define OS_MAIN					(1<<2)		// "main" sound. attentuation does not apply until outside the radius of the object
-#define OS_TURRET_BASE_ROTATION	(1<<3)
-#define OS_TURRET_GUN_ROTATION	(1<<4)
-#define OS_SUBSYS_ALIVE			(1<<5)
-#define OS_SUBSYS_DEAD			(1<<6)
-#define OS_SUBSYS_DAMAGED		(1<<7)
-#define OS_SUBSYS_ROTATION		(1<<8)
-#define OS_PLAY_ON_PLAYER		(1<<9)
-#define OS_LOOPING_DISABLED		(1<<10)
-#define OS_STARTED_PLAYING		(1<<11)
+#define OS_MAIN					(1<<1)		// "main" sound. attentuation does not apply until outside the radius of the object
+#define OS_TURRET_BASE_ROTATION	(1<<2)
+#define OS_TURRET_GUN_ROTATION	(1<<3)
+#define OS_SUBSYS_ALIVE			(1<<4)
+#define OS_SUBSYS_DEAD			(1<<5)
+#define OS_SUBSYS_DAMAGED		(1<<6)
+#define OS_SUBSYS_ROTATION		(1<<7)
+#define OS_PLAY_ON_PLAYER		(1<<8)
+#define OS_LOOPING_DISABLED		(1<<9)
+#define OS_STARTED_PLAYING		(1<<10)
 
 struct vec3d;
 class ship_subsys;

--- a/code/object/objectsnd.h
+++ b/code/object/objectsnd.h
@@ -24,7 +24,7 @@
 #define OS_SUBSYS_DAMAGED		(1<<7)
 #define OS_SUBSYS_ROTATION		(1<<8)
 #define OS_PLAY_ON_PLAYER		(1<<9)
-#define OS_LOOPING_DISABLED		(1<<7)
+#define OS_LOOPING_DISABLED		(1<<10)
 #define OS_STARTED_PLAYING		(1<<11)
 
 struct vec3d;

--- a/code/object/objectsnd.h
+++ b/code/object/objectsnd.h
@@ -24,7 +24,6 @@
 #define OS_SUBSYS_ROTATION		(1<<7)
 #define OS_PLAY_ON_PLAYER		(1<<8)
 #define OS_LOOPING_DISABLED		(1<<9)
-#define OS_STARTED_PLAYING		(1<<10)
 
 struct vec3d;
 class ship_subsys;
@@ -43,7 +42,7 @@ void	obj_snd_do_frame();
 int	obj_snd_assign(int objnum, gamesnd_id sndnum, const vec3d *pos, int flags = 0, const ship_subsys *associated_sub = nullptr);
 
 //Delete specific persistent sound on object
-void obj_snd_delete(int objnum, int index);
+void obj_snd_delete(object *objp, int index, bool stop_sound = true);
 
 // if sndnum is not -1, deletes all instances of the given sound within the object
 void	obj_snd_delete_type(int objnum, gamesnd_id sndnum = gamesnd_id(), ship_subsys *ss = NULL);

--- a/code/scripting/api/objs/enums.cpp
+++ b/code/scripting/api/objs/enums.cpp
@@ -116,6 +116,9 @@ flag_def_list Enumerations[] = {
 	{"OS_SUBSYS_DEAD", OS_SUBSYS_DEAD, 0},
 	{"OS_SUBSYS_DAMAGED", OS_SUBSYS_DAMAGED, 0},
 	{"OS_SUBSYS_ROTATION", OS_SUBSYS_ROTATION, 0},
+	{"OS_PLAY_ON_PLAYER", OS_PLAY_ON_PLAYER, 0},
+	{"OS_LOOPING_DISABLED", OS_LOOPING_DISABLED, 0},
+	{"OS_STARTED_PLAYING", OS_STARTED_PLAYING, 0},
 	// end of OS_ definitions
 	// these also use values that aren't in enums.h
 	{ "MOVIE_PRE_FICTION", MOVIE_PRE_FICTION, 0 },

--- a/code/scripting/api/objs/enums.cpp
+++ b/code/scripting/api/objs/enums.cpp
@@ -107,8 +107,6 @@ flag_def_list Enumerations[] = {
 	{"FIREBALL_WARP_EFFECT", LE_FIREBALL_WARP_EFFECT, 0},
 	// the following OS_ definitions use bitfield values, not the indexes in enums.h
 	{"OS_NONE", 0, 0},
-	{"OS_USED", OS_USED, 0},
-	{"OS_DS3D", OS_DS3D, 0},
 	{"OS_MAIN", OS_MAIN, 0},
 	{"OS_TURRET_BASE_ROTATION", OS_TURRET_BASE_ROTATION, 0},
 	{"OS_TURRET_GUN_ROTATION", OS_TURRET_GUN_ROTATION, 0},
@@ -118,7 +116,6 @@ flag_def_list Enumerations[] = {
 	{"OS_SUBSYS_ROTATION", OS_SUBSYS_ROTATION, 0},
 	{"OS_PLAY_ON_PLAYER", OS_PLAY_ON_PLAYER, 0},
 	{"OS_LOOPING_DISABLED", OS_LOOPING_DISABLED, 0},
-	{"OS_STARTED_PLAYING", OS_STARTED_PLAYING, 0},
 	// end of OS_ definitions
 	// these also use values that aren't in enums.h
 	{ "MOVIE_PRE_FICTION", MOVIE_PRE_FICTION, 0 },

--- a/code/scripting/api/objs/object.cpp
+++ b/code/scripting/api/objs/object.cpp
@@ -565,7 +565,7 @@ ADE_FUNC(removeSoundByIndex, l_Object, "number index", "Removes an assigned soun
 		return ADE_RETURN_NIL;
 	}
 
-	obj_snd_delete(OBJ_INDEX(objp), snd_idx);
+	obj_snd_delete(objp, snd_idx);
 
 	return ADE_RETURN_NIL;
 }

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -19424,7 +19424,7 @@ void ship_render_batch_thrusters(object *obj)
 			shipp->thrusters_start[i] = 0;
 			if(shipp->thrusters_sounds[i] >= 0)
 			{
-				obj_snd_delete(OBJ_INDEX(obj), shipp->thrusters_sounds[i]);
+				obj_snd_delete(obj, shipp->thrusters_sounds[i]);
 				shipp->thrusters_sounds[i] = -1;
 			}
 


### PR DESCRIPTION
This adds two new enums to persistent sounds which can be utilized by scripts.
1. OS_PLAY_ON_PLAYER, which allows persistent sounds to play on the player's ship.
2. OS_LOOPING_DISABLED, which allows the scripter to set the sound to play once and not have to then call `removeSound` later. Very handy for playing an assigned sound once with one line.

Tested and everything works as expected.