### PR TITLE
Bugfix for beam attenuation damage

### DIFF
--- a/code/weapon/beam.cpp
+++ b/code/weapon/beam.cpp
@@ -229,9 +229,6 @@ void beam_recalc_sounds(beam *b);
 // apply a whack to a ship
 void beam_apply_whack(beam *b, object *objp, vec3d *hit_point);
 
-// return the amount of damage which should be applied to a ship. basically, filters friendly fire damage 
-float beam_get_ship_damage(beam *b, object *objp, vec3d* hitpos);
-
 // if the beam is likely to tool a given target before its lifetime expires
 int beam_will_tool_target(beam *b, object *objp);
 

--- a/code/weapon/beam.h
+++ b/code/weapon/beam.h
@@ -270,7 +270,7 @@ void beam_unpause_sounds();
 void beam_calc_facing_pts(vec3d *top, vec3d *bot, vec3d *fvec, vec3d *pos, float w, float z_add);
 
 // return the amount of damage which should be applied to a ship. basically, filters friendly fire damage 
-float beam_get_ship_damage(beam *b, object *objp);
+float beam_get_ship_damage(beam *b, object *objp, vec3d* hitpos = nullptr);
 
 
 


### PR DESCRIPTION
Another day, another completely dysfunctional feature...

```
+Attenuation:
    Defines the point where the damage caused by the beam starts to attenuate. At maximum range damage is zero.
    Syntax: Float, from 0 - firing point to 1 - no effect 
```
Just so we're clear how this *should* work.

Using `last_shot` to get the hit distance is wrong, because it is only updated to be the world hit position *after* the collision and damage has been handled. And if the ship doesn't stop the beam, that won't happen at all, `last_shot` will still be off in the distance. It should be directly using the collision info's world hit pos (this way different targets of the same beam also have differing amounts of damage depending on attenuation).

Also the calculation was backwards, it was instantly bringing the damage down to 0 at the attenuation start distance, and increasing until it reached the end of the beam, should be inverted so it goes *from* 1, down to 0 at the end.