### PR TITLE
Fix leaking of game objects and memory in F3 lab

### DIFF
--- a/code/lab/dialogs/actions.cpp
+++ b/code/lab/dialogs/actions.cpp
@@ -2,6 +2,8 @@
 #include "lab/labv2_internal.h"
 #include "ship/shiphit.h"
 
+#include <array>
+
 /**********************Click event handlers********************************************/
 
 void destroy_subsystem(Tree* caller) {
@@ -62,8 +64,8 @@ void destroy_ship(Button* /*caller*/) {
 std::map<AnimationTriggerType, std::map<int, bool>> manual_animation_triggers = {};
 std::map<AnimationTriggerType, bool> manual_animations = {};
 
-bool triggered_primary_banks[MAX_SHIP_PRIMARY_BANKS];
-bool triggered_secondary_banks[MAX_SHIP_SECONDARY_BANKS];
+std::array<bool, MAX_SHIP_PRIMARY_BANKS> triggered_primary_banks;
+std::array<bool, MAX_SHIP_SECONDARY_BANKS> triggered_secondary_banks;
 
 void reset_animations(Tree*) {
 	if (getLabManager()->isSafeForShips()) {
@@ -176,7 +178,8 @@ void Actions::open(Button* /*caller*/) {
 	getLabManager()->loadWeapons();
 
 	dialogWindow = (DialogWindow*)getLabManager()->Screen->Add(new DialogWindow("Actions", gr_screen.center_offset_x + 250, gr_screen.center_offset_y + 50));
-	dialogWindow->SetOwner(this);
+	Assert(Opener != nullptr);
+	dialogWindow->SetOwner(Opener->getDialog());
 
 	int y = 0;
 
@@ -185,7 +188,8 @@ void Actions::open(Button* /*caller*/) {
 	y += btn->GetHeight();
 
 	for (auto dialog : subDialogs) {
-		auto dgo = new DialogOpener(dialog, 0, y);
+		auto *dgo = new DialogOpener(dialog, 0, y);
+		dialog->setOpener(dgo);
 		dialogWindow->AddChild(dgo);
 		y += dgo->GetHeight();
 	}
@@ -204,7 +208,8 @@ void DestroySubsystems::open(Button* /*caller*/) {
 		return;
 
 	dialogWindow = (DialogWindow*)getLabManager()->Screen->Add(new DialogWindow("Destroy Subsystems", gr_screen.center_offset_x + 400, gr_screen.center_offset_y + 50));
-	dialogWindow->SetOwner(this);
+	Assert(Opener != nullptr);
+	dialogWindow->SetOwner(Opener->getDialog());
 
 	update(getLabManager()->CurrentMode, getLabManager()->CurrentClass);
 }
@@ -234,7 +239,8 @@ void ChangeLoadout::open(Button* /*caller*/) {
 		return;
 
 	dialogWindow = (DialogWindow*)getLabManager()->Screen->Add(new DialogWindow("Change Loadout", gr_screen.center_offset_x + 400, gr_screen.center_offset_y + 50));
-	dialogWindow->SetOwner(this);
+	Assert(Opener != nullptr);
+	dialogWindow->SetOwner(Opener->getDialog());
 
 	update(getLabManager()->CurrentMode, getLabManager()->CurrentClass);
 }
@@ -349,7 +355,8 @@ void WeaponFire::open(Button* /*caller*/) {
 	dialogWindow = (DialogWindow*)getLabManager()->Screen->Add(
 		new DialogWindow("Fire weapons", gr_screen.center_offset_x + 400, gr_screen.center_offset_y + 50)
 	);
-	dialogWindow->SetOwner(this);
+	Assert(Opener != nullptr);
+	dialogWindow->SetOwner(Opener->getDialog());
 
 	update(getLabManager()->CurrentMode, getLabManager()->CurrentClass);
 }
@@ -387,7 +394,8 @@ void AnimationTrigger::open(Button* /*caller*/) {
 	dialogWindow = (DialogWindow*)getLabManager()->Screen->Add(
 		new DialogWindow("Trigger animations", gr_screen.center_offset_x + 400, gr_screen.center_offset_y + 50)
 	);
-	dialogWindow->SetOwner(this);
+	Assert(Opener != nullptr);
+	dialogWindow->SetOwner(Opener->getDialog());
 
 	update(getLabManager()->CurrentMode, getLabManager()->CurrentClass);
 }

--- a/code/lab/dialogs/actions.cpp
+++ b/code/lab/dialogs/actions.cpp
@@ -187,7 +187,7 @@ void Actions::open(Button* /*caller*/) {
 	dialogWindow->AddChild(btn);
 	y += btn->GetHeight();
 
-	for (auto dialog : subDialogs) {
+	for (auto &dialog : subDialogs) {
 		auto *dgo = new DialogOpener(dialog, 0, y);
 		dialog->setOpener(dgo);
 		dialogWindow->AddChild(dgo);
@@ -198,7 +198,7 @@ void Actions::open(Button* /*caller*/) {
 }
 
 void Actions::update(LabMode newLabMode, int classIndex) {
-	for (auto dialog : subDialogs) {
+	for (auto &dialog : subDialogs) {
 		dialog->update(newLabMode, classIndex);
 	}
 }

--- a/code/lab/dialogs/actions.h
+++ b/code/lab/dialogs/actions.h
@@ -105,10 +105,10 @@ private:
 class Actions : public LabDialog {
 public:
 	Actions() {
-		subDialogs.push_back(new DestroySubsystems());
-		subDialogs.push_back(new ChangeLoadout());
-		subDialogs.push_back(new WeaponFire());
-		subDialogs.push_back(new AnimationTrigger());
+		subDialogs.emplace_back(std::make_shared<DestroySubsystems>());
+		subDialogs.emplace_back(std::make_shared<ChangeLoadout>());
+		subDialogs.emplace_back(std::make_shared<WeaponFire>());
+		subDialogs.emplace_back(std::make_shared<AnimationTrigger>());
 	}
 
 	// Called when this dialog is opened via the top toolbar
@@ -133,5 +133,5 @@ public:
 
 private:
 	DialogWindow* dialogWindow = nullptr;
-	SCP_vector<LabDialog*> subDialogs;
+	SCP_vector<std::shared_ptr<LabDialog>> subDialogs;
 };

--- a/code/lab/dialogs/actions.h
+++ b/code/lab/dialogs/actions.h
@@ -5,7 +5,10 @@
 
 
 class DestroySubsystems : public LabDialog {
+public:
+	~DestroySubsystems() override = default;
 
+private:
 	// Called when this dialog is opened via the top toolbar
 	void open(Button* /*caller*/) override;
 
@@ -31,7 +34,10 @@ private:
 };
 
 class ChangeLoadout : public LabDialog {
+public:
+	~ChangeLoadout() override = default;
 
+private:
 	// Called when this dialog is opened via the top toolbar
 	void open(Button* /*caller*/) override;
 
@@ -57,7 +63,10 @@ private:
 };
 
 class WeaponFire : public LabDialog {
+public:
+	~WeaponFire() override = default;
 
+private:
 	// Called when this dialog is opened via the top toolbar
 	void open(Button* /*caller*/) override;
 
@@ -83,6 +92,10 @@ private:
 };
 
 class AnimationTrigger : public LabDialog {
+public:
+	~AnimationTrigger() override = default;
+
+private:
 	// Called when this dialog is opened via the top toolbar
 	void open(Button* /*caller*/) override;
 
@@ -110,6 +123,8 @@ public:
 		subDialogs.emplace_back(std::make_shared<WeaponFire>());
 		subDialogs.emplace_back(std::make_shared<AnimationTrigger>());
 	}
+
+	~Actions() override = default;
 
 	// Called when this dialog is opened via the top toolbar
 	void open(Button* /*caller*/) override;

--- a/code/lab/dialogs/backgrounds.cpp
+++ b/code/lab/dialogs/backgrounds.cpp
@@ -36,7 +36,8 @@ void BackgroundDialog::open(Button* /*caller*/) {
 		return;
 
 	dialogWindow = (DialogWindow*)getLabManager()->Screen->Add(new DialogWindow("Mission Backgrounds", gr_screen.center_offset_x + 250, gr_screen.center_offset_y + 50));
-	dialogWindow->SetOwner(this);
+	Assert(Opener != nullptr);
+	dialogWindow->SetOwner(Opener->getDialog());
 
 	SCP_vector<SCP_string> missions;
 

--- a/code/lab/dialogs/backgrounds.h
+++ b/code/lab/dialogs/backgrounds.h
@@ -4,6 +4,10 @@
 
 
 class BackgroundDialog : public LabDialog {
+public:
+	~BackgroundDialog() override = default;
+
+private:
 	// Called when this dialog is opened via the top toolbar
 	void open(Button* /*caller*/) override;
 

--- a/code/lab/dialogs/class_descriptions.cpp
+++ b/code/lab/dialogs/class_descriptions.cpp
@@ -8,7 +8,8 @@ void Descriptions::open(Button* /*caller*/) {
 				gr_screen.center_offset_y + gr_screen.center_h - gr_screen.center_h / 6 - 50, gr_screen.center_w / 3,
 				gr_screen.center_h / 6)
 		);
-		dialogWindow->SetOwner(this);
+		Assert(Opener != nullptr);
+		dialogWindow->SetOwner(Opener->getDialog());
 	}
 
 	dialogWindow->DeleteChildren();

--- a/code/lab/dialogs/class_descriptions.h
+++ b/code/lab/dialogs/class_descriptions.h
@@ -3,6 +3,10 @@
 #include "lab/dialogs/lab_dialog.h"
 
 class Descriptions : public LabDialog {
+public:
+	~Descriptions() override = default;
+
+private:
 	void open(Button* caller) override;
 
 	void close() override {

--- a/code/lab/dialogs/class_options.cpp
+++ b/code/lab/dialogs/class_options.cpp
@@ -7,7 +7,8 @@ void Options::open(Button* /*caller*/) {
 	if (dialogWindow == nullptr) {
 		dialogWindow = (DialogWindow*)getLabManager()->Screen->Add(new DialogWindow(
 			"Flags Window", gr_screen.center_offset_x + gr_screen.center_w - 205, gr_screen.center_offset_y + 200));
-		dialogWindow->SetOwner(this);
+		Assert(Opener != nullptr);
+		dialogWindow->SetOwner(Opener->getDialog());
 	}
 	update(getLabManager()->CurrentMode, getLabManager()->CurrentClass);
 }

--- a/code/lab/dialogs/class_options.h
+++ b/code/lab/dialogs/class_options.h
@@ -9,6 +9,10 @@ struct lab_flag {
 };
 
 class Options : public LabDialog {
+public:
+	~Options() override = default;
+
+private:
 	// Called when this dialog is opened via the top toolbar
 	void open(Button* /*caller*/) override;
 

--- a/code/lab/dialogs/class_variables.cpp
+++ b/code/lab/dialogs/class_variables.cpp
@@ -8,7 +8,8 @@ void Variables::open(Button* /*caller*/) {
 	if (dialogWindow == nullptr) {
 		dialogWindow = (DialogWindow*)getLabManager()->Screen->Add(new DialogWindow("Class Variables", gr_screen.center_offset_x + gr_screen.center_w - 285,
 			gr_screen.center_offset_y + 200));
-		dialogWindow->SetOwner(this);
+		Assert(Opener != nullptr);
+		dialogWindow->SetOwner(Opener->getDialog());
 	}
 	update(getLabManager()->CurrentMode, getLabManager()->CurrentClass);
 }

--- a/code/lab/dialogs/class_variables.h
+++ b/code/lab/dialogs/class_variables.h
@@ -3,6 +3,10 @@
 #include "lab/dialogs/lab_dialog.h"
 
 class Variables : public LabDialog {
+public:
+	~Variables() override = default;
+
+private:
 	void open(Button* caller) override;
 
 	void close() override {

--- a/code/lab/dialogs/lab_dialog.h
+++ b/code/lab/dialogs/lab_dialog.h
@@ -3,6 +3,8 @@
 #include "lab/wmcgui.h"
 #include "lab/labv2.h"
 
+class DialogOpener;
+
 class LabDialog {
 public:
 	// Called when this dialog is opened via the top toolbar
@@ -19,13 +21,17 @@ public:
 
 	// Returns true if it is safe to open this dialog
 	virtual bool safeToOpen(LabMode labMode) = 0;
+
+	void setOpener(const DialogOpener* opener) { Opener = opener; }
+protected:
+	const DialogOpener *Opener = nullptr;
 };
 
 // This is a base class for Windows opened by the various dialogs. Since dialogs exist even when their Windows are closed,
 // this introduces the concept of an "Owner", who gets notified when the DialogWindow is closed.
 class DialogWindow : public Window {
 public:
-	void SetOwner(LabDialog* owner) { Owner = owner; }
+	void SetOwner(std::shared_ptr<LabDialog> owner) { Owner = owner; }
 	DialogWindow(const SCP_string& in_caption, int x_coord, int y_coord, int x_width = -1, int y_height = -1, int in_style = 0) :
 		Window(in_caption, x_coord, y_coord, x_width, y_height, in_style) {
 	}
@@ -35,5 +41,5 @@ public:
 			Owner->close();
 	}
 private:
-	LabDialog* Owner = nullptr;
+	std::shared_ptr<LabDialog> Owner;
 };

--- a/code/lab/dialogs/lab_dialog.h
+++ b/code/lab/dialogs/lab_dialog.h
@@ -7,6 +7,8 @@ class DialogOpener;
 
 class LabDialog {
 public:
+	virtual ~LabDialog() = default;
+
 	// Called when this dialog is opened via the top toolbar
 	virtual void open(Button* caller) = 0;
 

--- a/code/lab/dialogs/lab_dialog.h
+++ b/code/lab/dialogs/lab_dialog.h
@@ -33,7 +33,6 @@ protected:
 // this introduces the concept of an "Owner", who gets notified when the DialogWindow is closed.
 class DialogWindow : public Window {
 public:
-	void SetOwner(std::shared_ptr<LabDialog> owner) { Owner = owner; }
 	DialogWindow(const SCP_string& in_caption, int x_coord, int y_coord, int x_width = -1, int y_height = -1, int in_style = 0) :
 		Window(in_caption, x_coord, y_coord, x_width, y_height, in_style) {
 	}
@@ -42,6 +41,12 @@ public:
 		if (Owner != nullptr)
 			Owner->close();
 	}
+
+	void SetOwner(std::shared_ptr<LabDialog> owner)
+	{
+		Owner = std::move(owner);
+	}
+
 private:
 	std::shared_ptr<LabDialog> Owner;
 };

--- a/code/lab/dialogs/render_options.cpp
+++ b/code/lab/dialogs/render_options.cpp
@@ -170,7 +170,8 @@ void RenderOptions::open(Button* /*caller*/) {
 		return;
 
 	dialogWindow = (DialogWindow*)getLabManager()->Screen->Add(new DialogWindow("Render Options", gr_screen.center_offset_x + gr_screen.center_w - 300, gr_screen.center_offset_y + 200));
-	dialogWindow->SetOwner(this);
+	Assert(Opener != nullptr);
+	dialogWindow->SetOwner(Opener->getDialog());
 
 	dialogWindow->DeleteChildren();
 

--- a/code/lab/dialogs/render_options.h
+++ b/code/lab/dialogs/render_options.h
@@ -4,6 +4,10 @@
 
 
 class RenderOptions : public LabDialog {
+public:
+	~RenderOptions() override = default;
+
+private:
 	// Called when this dialog is opened via the top toolbar
 	void open(Button* /*caller*/) override;
 

--- a/code/lab/dialogs/ship_classes.cpp
+++ b/code/lab/dialogs/ship_classes.cpp
@@ -56,7 +56,7 @@ void ShipClasses::update(LabMode newLabMode, int classIndex) {
 	Class_toolbar->DeleteChildren();
 
 	auto x = 0;
-	for (auto subdialog : Subdialogs) {
+	for (auto &subdialog : Subdialogs) {
 		auto *dgo = new DialogOpener(subdialog, x, 0);
 		subdialog->setOpener(dgo);
 		auto *cbp = Class_toolbar->AddChild(dgo);

--- a/code/lab/dialogs/ship_classes.cpp
+++ b/code/lab/dialogs/ship_classes.cpp
@@ -12,7 +12,8 @@ void ShipClasses::open(Button* /*caller*/) {
 		return;
 
 	dialogWindow = (DialogWindow*)getLabManager()->Screen->Add(new DialogWindow("Ship Classes", gr_screen.center_offset_x + 50, gr_screen.center_offset_y + 50));
-	dialogWindow->SetOwner(this);
+	Assert(Opener != nullptr);
+	dialogWindow->SetOwner(Opener->getDialog());
 	auto tree = (Tree*)dialogWindow->AddChild(new Tree("Ship Tree", 0, 0));
 
 	/* Ship tree layout
@@ -49,13 +50,16 @@ void ShipClasses::update(LabMode newLabMode, int classIndex) {
 	if (Class_toolbar == nullptr) {
 		Class_toolbar = (DialogWindow*)getLabManager()->Screen->Add(new DialogWindow("Class Toolbar", gr_screen.center_offset_x + 0,
 			gr_screen.center_offset_y + getLabManager()->Toolbar->GetHeight(), -1, -1, WS_NOTITLEBAR | WS_NONMOVEABLE));
-		Class_toolbar->SetOwner(this);
+		Assert(Opener != nullptr);
+		Class_toolbar->SetOwner(Opener->getDialog());
 	}
 	Class_toolbar->DeleteChildren();
 
 	auto x = 0;
 	for (auto subdialog : Subdialogs) {
-		auto cbp = Class_toolbar->AddChild(new DialogOpener(subdialog, x, 0));
+		auto *dgo = new DialogOpener(subdialog, x, 0);
+		subdialog->setOpener(dgo);
+		auto *cbp = Class_toolbar->AddChild(dgo);
 		x += cbp->GetWidth();
 
 		subdialog->update(newLabMode, classIndex);

--- a/code/lab/dialogs/ship_classes.h
+++ b/code/lab/dialogs/ship_classes.h
@@ -12,9 +12,9 @@
 class ShipClasses : public LabDialog {
 public:
 	ShipClasses() {
-		Subdialogs.push_back(new Descriptions());
-		Subdialogs.push_back(new Options());
-		Subdialogs.push_back(new Variables());
+		Subdialogs.emplace_back(std::make_shared<Descriptions>());
+		Subdialogs.emplace_back(std::make_shared<Options>());
+		Subdialogs.emplace_back(std::make_shared<Variables>());
 
 		dialogWindow = nullptr;
 		Class_toolbar = nullptr;
@@ -43,5 +43,5 @@ public:
 private:
 	DialogWindow* dialogWindow = nullptr;
 	DialogWindow* Class_toolbar = nullptr;
-	SCP_vector<LabDialog*> Subdialogs;
+	SCP_vector<std::shared_ptr<LabDialog>> Subdialogs;
 };

--- a/code/lab/dialogs/ship_classes.h
+++ b/code/lab/dialogs/ship_classes.h
@@ -20,6 +20,8 @@ public:
 		Class_toolbar = nullptr;
 	}
 
+	~ShipClasses() override = default;
+
 	SCP_string getTitle() override { return "Ship Classes"; }
 
 	bool safeToOpen(LabMode /*labMode*/) override { return true; }

--- a/code/lab/dialogs/weapon_classes.cpp
+++ b/code/lab/dialogs/weapon_classes.cpp
@@ -59,7 +59,7 @@ void WeaponClasses::update(LabMode newLabMode, int classIndex) {
 	Class_toolbar->DeleteChildren();
 
 	auto x = 0;
-	for (auto subdialog : Subdialogs) {
+	for (auto &subdialog : Subdialogs) {
 		auto *dgo = new DialogOpener(subdialog, x, 0);
 		subdialog->setOpener(dgo);
 		auto *cbp = Class_toolbar->AddChild(dgo);

--- a/code/lab/dialogs/weapon_classes.cpp
+++ b/code/lab/dialogs/weapon_classes.cpp
@@ -13,7 +13,8 @@ void WeaponClasses::open(Button* /*caller*/) {
 		return;
 
 	dialogWindow = (DialogWindow*)getLabManager()->Screen->Add(new DialogWindow("Weapon Classes", gr_screen.center_offset_x + 50, gr_screen.center_offset_y + 50));
-	dialogWindow->SetOwner(this);
+	Assert(Opener != nullptr);
+	dialogWindow->SetOwner(Opener->getDialog());
 	auto tree = (Tree*)dialogWindow->AddChild(new Tree("Weapon Tree", 0, 0));
 
 	SCP_vector<TreeItem*> typeHeaders;
@@ -52,13 +53,16 @@ void WeaponClasses::update(LabMode newLabMode, int classIndex) {
 	if (Class_toolbar == nullptr) {
 		Class_toolbar = (DialogWindow*)getLabManager()->Screen->Add(new DialogWindow("Class Toolbar", gr_screen.center_offset_x + 0,
 			gr_screen.center_offset_y + getLabManager()->Toolbar->GetHeight(), -1, -1, WS_NOTITLEBAR | WS_NONMOVEABLE));
-		Class_toolbar->SetOwner(this);
+		Assert(Opener != nullptr);
+		Class_toolbar->SetOwner(Opener->getDialog());
 	}
 	Class_toolbar->DeleteChildren();
 
 	auto x = 0;
 	for (auto subdialog : Subdialogs) {
-		auto cbp = Class_toolbar->AddChild(new DialogOpener(subdialog, x, 0));
+		auto *dgo = new DialogOpener(subdialog, x, 0);
+		subdialog->setOpener(dgo);
+		auto *cbp = Class_toolbar->AddChild(dgo);
 		x += cbp->GetWidth();
 
 		subdialog->update(newLabMode, classIndex);

--- a/code/lab/dialogs/weapon_classes.h
+++ b/code/lab/dialogs/weapon_classes.h
@@ -8,9 +8,9 @@
 class WeaponClasses : public LabDialog {
 public:
 	WeaponClasses() {
-		Subdialogs.push_back(new Descriptions());
-		Subdialogs.push_back(new Options());
-		Subdialogs.push_back(new Variables());
+		Subdialogs.emplace_back(std::make_shared<Descriptions>());
+		Subdialogs.emplace_back(std::make_shared<Options>());
+		Subdialogs.emplace_back(std::make_shared<Variables>());
 
 		dialogWindow = nullptr;
 		Class_toolbar = nullptr;
@@ -39,5 +39,5 @@ public:
 private:
 	DialogWindow* dialogWindow = nullptr;
 	DialogWindow* Class_toolbar = nullptr;
-	SCP_vector<LabDialog*> Subdialogs;
+	SCP_vector<std::shared_ptr<LabDialog>> Subdialogs;
 };

--- a/code/lab/dialogs/weapon_classes.h
+++ b/code/lab/dialogs/weapon_classes.h
@@ -16,6 +16,8 @@ public:
 		Class_toolbar = nullptr;
 	}
 
+	~WeaponClasses() override = default;
+
 	SCP_string getTitle() override { return "Weapon Classes"; }
 
 	bool safeToOpen(LabMode /*labMode*/) override { return true; }

--- a/code/lab/labv2.cpp
+++ b/code/lab/labv2.cpp
@@ -3,11 +3,11 @@
 #include "lab/manager/lab_manager.h"
 #include "gamesequence/gamesequence.h"
 
-LabManager* LMGR = nullptr;
+static std::unique_ptr<LabManager> LMGR;
 
-LabManager* getLabManager() {
+const std::unique_ptr<LabManager> &getLabManager() {
 	if (LMGR == nullptr) {
-		LMGR = new LabManager();
+		LMGR.reset(new LabManager());
 	}
 
 	return LMGR;
@@ -18,8 +18,7 @@ void lab_init() {
 }
 
 void lab_close() {
-	delete LMGR;
-	LMGR = nullptr; 
+	LMGR.reset();
 	gameseq_post_event(GS_EVENT_PREVIOUS_STATE);
 }
 

--- a/code/lab/labv2_internal.h
+++ b/code/lab/labv2_internal.h
@@ -7,7 +7,7 @@ LabManager* getLabManager();
 
 class DialogOpener : public Button {
 public:
-	DialogOpener(LabDialog* dialog, int x_coord, int y_coord, int x_width = -1, int y_height = -1, int in_style = 0) :
+	DialogOpener(std::shared_ptr<LabDialog> dialog, int x_coord, int y_coord, int x_width = -1, int y_height = -1, int in_style = 0) :
 		Button(dialog->getTitle(), x_coord, y_coord, nullptr, x_width, y_height, in_style) {
 		Dialog = dialog;
 	}
@@ -18,6 +18,8 @@ public:
 
 		return Button::DoMouseUp(frametime);
 	}
+
+	std::shared_ptr<LabDialog> getDialog() const { return Dialog; }
 private:
-	LabDialog* Dialog;
+	std::shared_ptr<LabDialog> Dialog;
 };

--- a/code/lab/labv2_internal.h
+++ b/code/lab/labv2_internal.h
@@ -3,7 +3,7 @@
 #include "lab/manager/lab_manager.h"
 
 
-LabManager* getLabManager();
+const std::unique_ptr<LabManager> &getLabManager();
 
 class DialogOpener : public Button {
 public:

--- a/code/lab/labv2_internal.h
+++ b/code/lab/labv2_internal.h
@@ -9,7 +9,7 @@ class DialogOpener : public Button {
 public:
 	DialogOpener(std::shared_ptr<LabDialog> dialog, int x_coord, int y_coord, int x_width = -1, int y_height = -1, int in_style = 0) :
 		Button(dialog->getTitle(), x_coord, y_coord, nullptr, x_width, y_height, in_style) {
-		Dialog = dialog;
+		Dialog = std::move(dialog);
 	}
 
 	int DoMouseUp(float frametime) override {

--- a/code/lab/manager/lab_manager.cpp
+++ b/code/lab/manager/lab_manager.cpp
@@ -32,7 +32,7 @@ LabManager::LabManager() {
 	Dialogs.emplace_back(std::make_shared<RenderOptions>());
 
 	int x = 0;
-	for (auto dialog : Dialogs) {
+	for (auto &dialog : Dialogs) {
 		auto *dgo = new DialogOpener(dialog, x, 0);
 		dialog->setOpener(dgo);
 		auto *cbp = Toolbar->AddChild(dgo);
@@ -327,7 +327,7 @@ void LabManager::changeDisplayedObject(LabMode mode, int info_index) {
 
 	Assert(CurrentObject != -1);
 
-	for (auto dialog : Dialogs) {
+	for (auto &dialog : Dialogs) {
 		dialog->update(CurrentMode, CurrentClass);
 	}
 

--- a/code/lab/manager/lab_manager.cpp
+++ b/code/lab/manager/lab_manager.cpp
@@ -23,7 +23,7 @@ LabManager::LabManager() {
 	Toolbar = (Window*)Screen->Add(new Window("Toolbar", gr_screen.center_offset_x, gr_screen.center_offset_y,
 		-1, -1, WS_NOTITLEBAR | WS_NONMOVEABLE));
 
-	Renderer = std::make_unique<LabRenderer>();
+	Renderer.reset(new LabRenderer());
 
 	Dialogs.emplace_back(std::make_shared<ShipClasses>());
 	Dialogs.emplace_back(std::make_shared<WeaponClasses>());

--- a/code/lab/manager/lab_manager.cpp
+++ b/code/lab/manager/lab_manager.cpp
@@ -89,6 +89,10 @@ LabManager::LabManager() {
 
 LabManager::~LabManager()
 {
+	for (auto &dialog : Dialogs) {
+		dialog->close();
+	}
+
 	obj_delete_all();
 	Toolbar = nullptr;
 }

--- a/code/lab/manager/lab_manager.h
+++ b/code/lab/manager/lab_manager.h
@@ -18,6 +18,7 @@ FLAG_LIST(ManagerFlags) {
 class LabManager {
 public:
 	LabManager();
+	~LabManager();
 
 	// Do rendering and handle keyboard/mouse events
 	void onFrame(float frametime);
@@ -27,18 +28,11 @@ public:
 	void changeDisplayedObject(LabMode type, int info_index);
 
 	void close() {
-		if (CurrentObject != -1)
-			obj_delete(CurrentObject);
-		CurrentObject = -1;
-
 		for (auto d : Dialogs) {
 			d->close();
 		}
 
 		LabRenderer::close();
-
-		delete Screen;
-		Screen = nullptr;
 
 		Game_mode &= ~GM_LAB;
 
@@ -47,9 +41,10 @@ public:
 		gameseq_post_event(GS_EVENT_PREVIOUS_STATE);
 	}
 
-	GUIScreen* Screen;
+	std::unique_ptr<GUIScreen> Screen;
+	// points to an object inside Screen, so we can't use smart pointer
 	Window* Toolbar;
-	LabRenderer* Renderer;
+	std::unique_ptr<LabRenderer> Renderer;
 
 	LabMode CurrentMode = LabMode::None;
 	int CurrentObject = -1;
@@ -88,7 +83,7 @@ public:
 
 	flagset<ManagerFlags> Flags;
 private:
-	SCP_vector<LabDialog*> Dialogs = {};
+	SCP_vector<std::shared_ptr<LabDialog>> Dialogs;
 
 	float Lab_thrust_len = 0.0f;
 	bool Lab_thrust_afterburn = false;

--- a/code/lab/manager/lab_manager.h
+++ b/code/lab/manager/lab_manager.h
@@ -28,8 +28,8 @@ public:
 	void changeDisplayedObject(LabMode type, int info_index);
 
 	void close() {
-		for (auto d : Dialogs) {
-			d->close();
+		for (auto &dialog : Dialogs) {
+			dialog->close();
 		}
 
 		LabRenderer::close();

--- a/code/lab/manager/lab_manager.h
+++ b/code/lab/manager/lab_manager.h
@@ -28,10 +28,6 @@ public:
 	void changeDisplayedObject(LabMode type, int info_index);
 
 	void close() {
-		for (auto &dialog : Dialogs) {
-			dialog->close();
-		}
-
 		LabRenderer::close();
 
 		Game_mode &= ~GM_LAB;

--- a/code/lab/renderer/lab_renderer.cpp
+++ b/code/lab/renderer/lab_renderer.cpp
@@ -452,11 +452,10 @@ void LabRenderer::useBackground(const SCP_string& mission_name) {
 	}
 }
 
-LabCamera* LabRenderer::getCurrentCamera() {
+std::unique_ptr<LabCamera> &LabRenderer::getCurrentCamera() {
 	return labCamera;
 }
 
-void LabRenderer::setCurrentCamera(LabCamera* newcam) {
-	delete labCamera;
-	labCamera = newcam;
+void LabRenderer::setCurrentCamera(std::unique_ptr<LabCamera> &newcam) {
+	labCamera = std::move(newcam);
 }

--- a/code/lab/renderer/lab_renderer.h
+++ b/code/lab/renderer/lab_renderer.h
@@ -68,7 +68,7 @@ enum class TextureOverride {
 
 class LabRenderer {
 public:
-	LabRenderer(LabCamera* cam) {
+	LabRenderer() {
 		bloomLevel = gr_bloom_intensity();
 		ambientFactor = Cmdline_ambient_factor;
 		directionalFactor = static_light_factor;
@@ -77,7 +77,7 @@ public:
 		currentTeamColor = "<none>";
 		useBackground("None");
 
-		labCamera = cam;
+		labCamera = std::make_unique<OrbitCamera>();
 
 		Viewer_mode |= VM_FREECAMERA;
 
@@ -157,8 +157,8 @@ public:
 
 	void resetTextureOverride() {};
 
-	LabCamera* getCurrentCamera();
-	void setCurrentCamera(LabCamera* newcam);
+	std::unique_ptr<LabCamera> &getCurrentCamera();
+	void setCurrentCamera(std::unique_ptr<LabCamera> &newcam);
 
 private:
 	flagset<LabRenderFlag> renderFlags;
@@ -169,7 +169,7 @@ private:
 	SCP_string currentTeamColor;
 	SCP_string currentMissionBackground;
 
-	LabCamera* labCamera;
+	std::unique_ptr<LabCamera> labCamera;
 
 	float cameraDistance;
 

--- a/code/lab/renderer/lab_renderer.h
+++ b/code/lab/renderer/lab_renderer.h
@@ -77,7 +77,7 @@ public:
 		currentTeamColor = "<none>";
 		useBackground("None");
 
-		labCamera = std::make_unique<OrbitCamera>();
+		labCamera.reset(new OrbitCamera());
 
 		Viewer_mode |= VM_FREECAMERA;
 


### PR DESCRIPTION
Ensure the `LabManager` always cleans up game objects when it's destroyed.  The fact that it *wasn't* cleaning up when players go to the options menu was causing Issue #3127.

Also plug various memory leaks in the lab, specifically with
1.The `LabManager`'s `Renderer`
2. The `LabRenderer`'s `labCamera`
3. The `LabManager`'s `Dialogs` and any `LabDialog`s' `Subdialogs`/`subDialogs`.

The PR fixes (1) and (2) using `unique_ptr`s and (3) by always using `shared_ptr` for `LabDialog` objects.

The PR also makes `LabManager`'s `Screen` a `unique_ptr` to avoid having to manually delete it.

AFAICT, all other lab objects are managed in FSO-style linked lists, and it looks like the code is correctly managing the lists, but I would need to dig extra-deep to be 100% sure.