### PR TITLE
Rewrite of CheckedDataListModel

### DIFF
--- a/qtfred/src/CheckedDataListModel.h
+++ b/qtfred/src/CheckedDataListModel.h
@@ -81,7 +81,7 @@ public:
 		if (parent.isValid())
 			return 0;
 
-		return items.size();
+		return static_cast<int>(items.size());
 	}
 
 	QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override {

--- a/qtfred/src/CheckedDataListModel.h
+++ b/qtfred/src/CheckedDataListModel.h
@@ -17,8 +17,8 @@ class CheckedDataListModel : public QAbstractListModel
 		bool _checked;
 		Qt::GlobalColor _color;
 
-		BaseRowData(const QString &text, bool checked, Qt::GlobalColor bgColor) :
-			_text(text),
+		BaseRowData(QString text, bool checked, Qt::GlobalColor bgColor) :
+			_text(std::move(text)),
 			_checked(checked),
 			_color(bgColor)
 		{}
@@ -32,7 +32,7 @@ class CheckedDataListModel : public QAbstractListModel
 			_internalData(internalData)
 		{}
 
-		explicit RowData(RowData&& move) = default;
+		explicit RowData(RowData&& move) noexcept = default;
 		RowData& operator=(RowData&& move) = delete;
 
 		inline U& internalData() {return _internalData;}
@@ -47,15 +47,15 @@ class CheckedDataListModel : public QAbstractListModel
 			_internalData(std::move(internalData))
 		{}
 
-		explicit RowData(RowData&& move) = default;
+		explicit RowData(RowData&& move) noexcept = default;
 		RowData& operator=(RowData&& move) = delete;
 
 		inline U& internalData() {return *_internalData;}
 	};
 
+public:
 	CheckedDataListModel(QObject *parent) = delete;
 
-public:
 	template<typename Container>
 	CheckedDataListModel(const Container &c,
 						 void (*emplacerFn)(const typename Container::const_iterator &it, CheckedDataListModel<T> &model),
@@ -145,7 +145,7 @@ public:
 		return checkeds;
 	}
 
-	inline const SCP_unordered_set<const T*> getCheckedDataConst() const {
+	inline const SCP_unordered_set<const T*>& getCheckedDataConst() const {
 		return checkedsConst;
 	}
 


### PR DESCRIPTION
My CheckedDataListModel wasn't flexible enough for use in the CampaignEditor's mission list so I rewrote it. It now stores simple types directly or takes ownership of a pointer to class types.