### PR TITLE
Restore original error handling of stuff_int_list

### DIFF
--- a/code/parse/parselo.cpp
+++ b/code/parse/parselo.cpp
@@ -2901,44 +2901,40 @@ size_t stuff_int_list(int *ilp, size_t max_ints, int lookup_type)
 				case SHIP_TYPE:
 					num = ship_name_lookup(str.c_str());	// returns index of Ship[] entry with name
 					if (num < 0)
-						error_display(1, "Unable to find ship %s in stuff_int_list!", str.c_str());
-
-					*buf = num;
+						error_display(0, "Unable to find ship %s in stuff_int_list!", str.c_str());
 					break;
 
 				case SHIP_INFO_TYPE:
 					num = ship_info_lookup(str.c_str());	// returns index of Ship_info[] entry with name
 					if (num < 0)
 						error_display(0, "Unable to find ship class %s in stuff_int_list!", str.c_str());
-					else
-						*buf = num;
 					break;
 
 				case WEAPON_POOL_TYPE:
 					num = weapon_info_lookup(str.c_str());
 					if (num < 0)
 						error_display(0, "Unable to find weapon class %s in stuff_int_list!", str.c_str());
-					else
-						*buf = num;
 					break;
 
 				case WEAPON_LIST_TYPE:
 					num = weapon_info_lookup(str.c_str());
 					if (num < 0 && !str.empty())
 						error_display(0, "Unable to find weapon class %s in stuff_int_list!", str.c_str());
-
-					*buf = num;
 					break;
 
 				case RAW_INTEGER_TYPE:
 					num = atoi(str.c_str());
-					*buf = num;
 					break;
 
 				default:
 					error_display(1, "Unknown lookup_type %d in stuff_int_list", lookup_type);
 					break;
 			}
+
+			if (num < 0)
+				return false;
+
+			*buf = num;			
 		} else {
 			stuff_int(buf);
 		}

--- a/code/parse/parselo.cpp
+++ b/code/parse/parselo.cpp
@@ -2902,36 +2902,43 @@ size_t stuff_int_list(int *ilp, size_t max_ints, int lookup_type)
 					num = ship_name_lookup(str.c_str());	// returns index of Ship[] entry with name
 					if (num < 0)
 						error_display(1, "Unable to find ship %s in stuff_int_list!", str.c_str());
+
+					*buf = num;
 					break;
 
 				case SHIP_INFO_TYPE:
 					num = ship_info_lookup(str.c_str());	// returns index of Ship_info[] entry with name
 					if (num < 0)
-						error_display(1, "Unable to find ship class %s in stuff_int_list!", str.c_str());
+						error_display(0, "Unable to find ship class %s in stuff_int_list!", str.c_str());
+					else
+						*buf = num;
 					break;
 
 				case WEAPON_POOL_TYPE:
 					num = weapon_info_lookup(str.c_str());
 					if (num < 0)
-						error_display(1, "Unable to find weapon class %s in stuff_int_list!", str.c_str());
+						error_display(0, "Unable to find weapon class %s in stuff_int_list!", str.c_str());
+					else
+						*buf = num;
 					break;
 
 				case WEAPON_LIST_TYPE:
 					num = weapon_info_lookup(str.c_str());
 					if (num < 0 && !str.empty())
-						error_display(1, "Unable to find weapon class %s in stuff_int_list!", str.c_str());
+						error_display(0, "Unable to find weapon class %s in stuff_int_list!", str.c_str());
+
+					*buf = num;
 					break;
 
 				case RAW_INTEGER_TYPE:
 					num = atoi(str.c_str());
+					*buf = num;
 					break;
 
 				default:
 					error_display(1, "Unknown lookup_type %d in stuff_int_list", lookup_type);
 					break;
 			}
-
-			*buf = num;
 		} else {
 			stuff_int(buf);
 		}


### PR DESCRIPTION
https://github.com/scp-fs2open/fs2open.github.com/blame/ed2cc47093f2a1b2f8bd89c54784ad5a2de49179/code/parse/parselo.cpp#L3014

Attempts to restore the original error handling of `stuff_int_list` for `WEAPON_LIST_TYPE`, `WEAPON_POOL_TYPE`, and `SHIP_INFO_TYPE`. Where `WEAPON_LIST_TYPE` would merely warn and stuff -1, and the other two would stuff nothing and produce no warning or error. This changes it to warnings in all cases but only stuffing as it did before. Erroring instead of warning is a very harsh backwards compatibility break which people have been running into, and I would like to ease if possible.
