### PR TITLE
Moved script initialization to take place after all table loads

### DIFF
--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -1750,7 +1750,6 @@ void game_init()
 	}
 
 #endif
-	script_init();			//WMC
 
 	font::init();					// loads up all fonts
 	
@@ -1902,6 +1901,7 @@ void game_init()
 		main_hall_table_init();
 	}
 
+	script_init();			//WMC
 	// Initialize dynamic SEXPs
 	sexp::dynamic_sexp_init();
 


### PR DESCRIPTION
#3360 actually broke a number of things because scripts were loaded before weapons and ships, so caching those conditions didn't actually work. I failed to realize that none of my test cases actually covered the use of those conditions. 

Changing the scripting init to only take place after everything else makes sense to me since as far as I can tell there are no hooks for 'on load' type actions, so scripts only should be acting on the final state anyway. I have done some testing on script heavy parts of FOTG and this seems to work, ~~but I'm putting this in draft until I can test or get test reports from a few more mods to make sure this doesn't do anything weird.~~ After more testing I'm confident enough to submit this fully.

@asarium I also beg your eyes since I think you're the most familiar with the script code and might know some wrinkle I'm overlooking here.