### PR TITLE
Use ccache to speed up some PR builds

### DIFF
--- a/.github/workflows/master-build.yaml
+++ b/.github/workflows/master-build.yaml
@@ -1,0 +1,62 @@
+name: Build caches for master
+
+on:
+  push:
+    branches:
+      - master
+
+env:
+  QT_VERSION: 5.12.9
+
+jobs:
+  build_linux:
+    strategy:
+      matrix:
+        configuration: [Debug, Release]
+        compiler: [gcc-5, gcc-10]
+        cmake_options: [""]
+        include:
+          # Also include configurations that check if the code compiles without the graphics backends
+          - configuration: Debug
+            compiler: gcc-10
+            cmake_options: -DFSO_BUILD_WITH_OPENGL=OFF -DFSO_BUILD_WITH_VULKAN=OFF
+          - configuration: Release
+            compiler: gcc-10
+            cmake_options: -DFSO_BUILD_WITH_OPENGL=OFF -DFSO_BUILD_WITH_VULKAN=OFF
+    name: Linux
+    runs-on: ubuntu-latest
+    container: ghcr.io/scp-fs2open/linux_build:sha-11e553c
+    steps:
+      - name: Cache Qt
+        id: cache-qt-lin
+        uses: actions/cache@v1
+        with:
+          path: ${{ github.workspace }}/../Qt
+          key: ${{ runner.os }}-QtCache-${{ env.QT_VERSION }}
+      - name: Install Qt
+        uses: jurplel/install-qt-action@v2
+        with:
+          version: ${{ env.QT_VERSION }}
+          dir: ${{ github.workspace }}/..
+          cached: ${{ steps.cache-qt-lin.outputs.cache-hit }}
+          setup-python: 'false'
+          aqtversion: ==1.1.3
+
+      - uses: actions/checkout@v1
+        name: Checkout
+        with:
+          submodules: true
+      - name: ccache
+        uses: hendrikmuhs/ccache-action@v1
+        with:
+          key: ${{ runner.os }}-${{ matrix.configuration }}-${{ matrix.compiler }}
+
+      - name: Configure CMake
+        env:
+          CONFIGURATION: ${{ matrix.configuration }}
+          COMPILER: ${{ matrix.compiler }}
+          JOB_CMAKE_OPTIONS: ${{ matrix.cmake_options }}
+        run: $GITHUB_WORKSPACE/ci/linux/configure_cmake.sh
+      - name: Compile
+        working-directory: ./build
+        run: LD_LIBRARY_PATH=$Qt5_DIR/lib:$LD_LIBRARY_PATH ninja -k 20 all

--- a/.github/workflows/pr-workflow.yaml
+++ b/.github/workflows/pr-workflow.yaml
@@ -44,6 +44,11 @@ jobs:
         with:
           submodules: true
           fetch-depth: 0
+      - name: ccache
+        uses: hendrikmuhs/ccache-action@v1
+        with:
+          key: ${{ runner.os }}-${{ matrix.configuration }}-${{ matrix.compiler }}
+
       - name: Configure CMake
         env:
           CONFIGURATION: ${{ matrix.configuration }}


### PR DESCRIPTION
This sets up ccache to speed up some builds. I hope this also works with
forks since I don't know if those are allowed to use the main repo
cache.