### PR TITLE
Allow non-unique sexp subcategories

### DIFF
--- a/code/parse/sexp/LuaSEXP.cpp
+++ b/code/parse/sexp/LuaSEXP.cpp
@@ -77,9 +77,9 @@ int get_category(const SCP_string& name) {
 	return -1;
 }
 
-int get_subcategory(const SCP_string& name) {
+int get_subcategory(const SCP_string& name, int category) {
 	for (auto& subcat : op_submenu) {
-		if (subcat.name == name) {
+		if (subcat.name == name && (subcat.id & OP_CATEGORY_MASK) == category) {
 			return subcat.id;
 		}
 	}
@@ -359,7 +359,7 @@ void LuaSEXP::parseTable() {
 	SCP_string subcategory;
 	stuff_string(subcategory, F_NAME);
 
-	_subcategory = get_subcategory(subcategory);
+	_subcategory = get_subcategory(subcategory, _category);
 	if (_subcategory < 0) {
 		// Unknown subcategory so we need to add this one
 		_subcategory = sexp::add_subcategory(_category, subcategory);
@@ -373,14 +373,7 @@ void LuaSEXP::parseTable() {
 			// Default to the first subcategory in our category, hopefully it will exist...
 			_subcategory = 0x0000 | _category;
 		}
-	} else if ((_subcategory & OP_CATEGORY_MASK) != _category) {
-		error_display(0,
-					  "Subcategory '%s' is in a different category than the specified category! Subcategory names must be unique.",
-					  subcategory.c_str());
-
-		// Default to the first subcategory in our category, hopefully it will exist...
-		_subcategory = 0x0000 | _category;
-	}
+	} 
 
 	required_string("$Minimum Arguments:");
 


### PR DESCRIPTION
Previously, luasexps could not be placed into subcategories that were not unique.
Not only did this include custom categories, but also built-in ones, so sexps couldn't be placed into categories like "Weapons, Shields, and Engines", as that exists both in status and in change.
This does away with this requirement (tbh, I am not sure why it was there in the first place).
If you specify a built in subcategory but it only exists in a different main category, this will now create a new subcategory in the main category specified, as I would expect from the luasexps