### PR TITLE
add is-language

### DIFF
--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -233,6 +233,7 @@ SCP_vector<sexp_oper> Operators = {
 	{ "ship_score",						OP_SHIP_SCORE,							1,	1,			SEXP_INTEGER_OPERATOR,	},
 	{ "time-elapsed-last-order",		OP_LAST_ORDER_TIME,						2,	2,			SEXP_INTEGER_OPERATOR,	},
 	{ "player-is-cheating",				OP_PLAYER_IS_CHEATING_BASTARD,			0,  0,			SEXP_BOOLEAN_OPERATOR,  },
+	{ "is-language",					OP_IS_LANGUAGE,							1,	1,			SEXP_BOOLEAN_OPERATOR, }, // Goober5000
 
 	//Multiplayer Sub-Category
 	{ "num-players",					OP_NUM_PLAYERS,							0,	0,			SEXP_INTEGER_OPERATOR,	},
@@ -3317,6 +3318,14 @@ int check_sexp_syntax(int node, int return_type, int recursive, int *bad_node, i
 				if (species_info_lookup(CTEXT(node)) < 0 ) {
 					return SEXP_CHECK_INVALID_SPECIES;
 				}
+				break;
+
+			case OPF_LANGUAGE:
+				if (type2 != SEXP_ATOM_STRING) {
+					return SEXP_CHECK_TYPE_MISMATCH;
+				}
+
+				// that's all we do, since there may be a language the game doesn't know about
 				break;
 
 			default:
@@ -23295,6 +23304,21 @@ int sexp_player_is_cheating_bastard()
 	return SEXP_FALSE;
 }
 
+int sexp_is_language(int node)
+{
+	// we don't check the language for validity because it could be a language the engine doesn't know about
+	auto lang = CTEXT(node);
+
+	// easy lookup
+	auto li = &Lcl_languages[lcl_get_current_lang_index()];
+
+	// easy comparison
+	if (stricmp(li->lang_name, lang) == 0)
+		return SEXP_KNOWN_TRUE;
+	else
+		return SEXP_KNOWN_FALSE;
+}
+
 void sexp_set_motion_debris(int node)
 {
 	Motion_debris_override = is_sexp_true(node);
@@ -25755,6 +25779,10 @@ int eval_sexp(int cur_node, int referenced_node)
 				sexp_val = sexp_player_is_cheating_bastard();
 				break;
 
+			case OP_IS_LANGUAGE:
+				sexp_val = sexp_is_language(node);
+				break;
+
 			case OP_IS_IN_TURRET_FOV:
 				sexp_val = sexp_is_in_turret_fov(node);
 				break;
@@ -26432,6 +26460,7 @@ int query_operator_return_type(int op)
 		case OP_PLAYER_IS_CHEATING_BASTARD:
 		case OP_ARE_SHIP_FLAGS_SET:
 		case OP_IS_IN_TURRET_FOV:
+		case OP_IS_LANGUAGE:
 			return OPR_BOOL;
 
 		case OP_PLUS:
@@ -29280,6 +29309,9 @@ int query_operator_argument_type(int op, int argnum)
 			else
 				return OPF_SHIP_WING;
 
+		case OP_IS_LANGUAGE:
+			return OPF_LANGUAGE;
+
 		default: {
 			auto dynamicSEXP = sexp::get_dynamic_sexp(op);
 			if (dynamicSEXP != nullptr) {
@@ -30971,6 +31003,7 @@ int get_subcategory(int sexp_id)
 		case OP_SHIP_SCORE:
 		case OP_LAST_ORDER_TIME:
 		case OP_PLAYER_IS_CHEATING_BASTARD:
+		case OP_IS_LANGUAGE:
 			return STATUS_SUBCATEGORY_PLAYER;
 
 		case OP_NUM_PLAYERS:
@@ -35106,6 +35139,12 @@ SCP_vector<sexp_help_struct> Sexp_help = {
 
 	{OP_PLAYER_IS_CHEATING_BASTARD, "player-is-cheating\r\n"
 		"\tReturns true if the player is or has been cheating in this mission.\r\n"
+	},
+
+	{ OP_IS_LANGUAGE, "is-language\r\n"
+		"\tReturns whether the game is running in the specified language.  Takes 1 argument...\r\n"
+		"\t1:\tA language.  This can be any string; the SEXP will return true if and only if the string matches the current language.  "
+		"Builtin languages are English, German, French, and Polish, and others can be defined in strings.tbl.\r\n"
 	},
 
 	{ OP_SET_MOTION_DEBRIS, "set-motion-debris-override\r\n"

--- a/code/parse/sexp.h
+++ b/code/parse/sexp.h
@@ -115,6 +115,7 @@ class waypoint_list;
 #define OPF_GAME_SND			88		// m!m - A game sound
 #define OPF_FIREBALL			89		// Goober5000 - an entry in fireball.tbl
 #define OPF_SPECIES				90		// Goober5000
+#define OPF_LANGUAGE			91		// Goober5000
 
 // Operand return types
 #define	OPR_NUMBER				1	// returns number
@@ -397,6 +398,7 @@ class waypoint_list;
 #define OP_DISTANCE_CENTER					(0x0054 | OP_CATEGORY_STATUS | OP_NONCAMPAIGN_FLAG) // Goober5000
 #define OP_DISTANCE_BBOX					(0x0055 | OP_CATEGORY_STATUS | OP_NONCAMPAIGN_FLAG) // Goober5000
 #define OP_DISTANCE_BBOX_SUBSYSTEM			(0x0056 | OP_CATEGORY_STATUS | OP_NONCAMPAIGN_FLAG) // Goober5000
+#define OP_IS_LANGUAGE						(0x0057 | OP_CATEGORY_STATUS)						// Goober5000
 
 // conditional sexpressions
 #define OP_WHEN								(0x0000 | OP_CATEGORY_CONDITIONAL)

--- a/fred2/sexp_tree.cpp
+++ b/fred2/sexp_tree.cpp
@@ -2874,6 +2874,7 @@ int sexp_tree::query_default_argument_available(int op, int i)
 		case OPF_GAME_SND:
 		case OPF_FIREBALL:
 		case OPF_SPECIES:
+		case OPF_LANGUAGE:
 			return 1;
 
 		case OPF_SHIP:
@@ -4692,6 +4693,10 @@ sexp_list_item *sexp_tree::get_listing_opf(int opf, int parent_node, int arg_ind
 			list = get_listing_opf_species();
 			break;
 
+		case OPF_LANGUAGE:
+			list = get_listing_opf_language();
+			break;
+
 		default:
 			Int3();  // unknown OPF code
 			list = NULL;
@@ -6322,6 +6327,16 @@ sexp_list_item *sexp_tree::get_listing_opf_species()	// NOLINT
 
 	for (auto &species : Species_info)
 		head.add_data(species.species_name);
+
+	return head.next;
+}
+
+sexp_list_item *sexp_tree::get_listing_opf_language()	// NOLINT
+{
+	sexp_list_item head;
+
+	for (auto &lang: Lcl_languages)
+		head.add_data(lang.lang_name);
 
 	return head.next;
 }

--- a/fred2/sexp_tree.h
+++ b/fred2/sexp_tree.h
@@ -282,6 +282,7 @@ public:
 	sexp_list_item *get_listing_opf_game_snds();
 	sexp_list_item *get_listing_opf_fireball();
 	sexp_list_item *get_listing_opf_species();
+	sexp_list_item *get_listing_opf_language();
 
 	int m_mode;
 	int item_index;

--- a/qtfred/src/ui/widgets/sexp_tree.cpp
+++ b/qtfred/src/ui/widgets/sexp_tree.cpp
@@ -1468,6 +1468,7 @@ int sexp_tree::query_default_argument_available(int op, int i) {
 	case OPF_GAME_SND:
 	case OPF_FIREBALL:
 	case OPF_SPECIES:
+	case OPF_LANGUAGE:
 		return 1;
 
 	case OPF_SHIP:
@@ -3026,6 +3027,10 @@ sexp_list_item* sexp_tree::get_listing_opf(int opf, int parent_node, int arg_ind
 
 	case OPF_SPECIES:
 		list = get_listing_opf_species();
+		break;
+
+	case OPF_LANGUAGE:
+		list = get_listing_opf_language();
 		break;
 
 	default:
@@ -4595,6 +4600,16 @@ sexp_list_item *sexp_tree::get_listing_opf_species()	// NOLINT
 
 	for (auto &species : Species_info)
 		head.add_data(species.species_name);
+
+	return head.next;
+}
+
+sexp_list_item *sexp_tree::get_listing_opf_language()	// NOLINT
+{
+	sexp_list_item head;
+
+	for (auto &lang: Lcl_languages)
+		head.add_data(lang.lang_name);
 
 	return head.next;
 }

--- a/qtfred/src/ui/widgets/sexp_tree.h
+++ b/qtfred/src/ui/widgets/sexp_tree.h
@@ -330,6 +330,7 @@ class sexp_tree: public QTreeWidget {
 	sexp_list_item* get_listing_opf_game_snds();
 	sexp_list_item* get_listing_opf_fireball();
 	sexp_list_item *get_listing_opf_species();
+	sexp_list_item *get_listing_opf_language();
 
 
 	int getCurrentItemIndex() const;


### PR DESCRIPTION
Checks whether the game is running in the specified language.  Since the fiction viewer doesn't use XSTR-style localization, this SEXP can be used to display different stages for different languages.