### PR TITLE
Add shield regen hit delay

### DIFF
--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -15295,6 +15295,8 @@ void ai_ship_hit(object *objp_ship, object *hit_objp, vec3d *hit_normal)
 		Assert(objp_hitter != NULL);
 		hitter_aip = &Ai_info[Ships[objp_hitter->instance].ai_index];
 		hitter_aip->last_hit_target_time = Missiontime;
+
+		aip->last_hit_time = Missiontime;
 		return;
 	}
 

--- a/code/hud/hudets.cpp
+++ b/code/hud/hudets.cpp
@@ -103,6 +103,9 @@ void update_ets(object* objp, float fl_frametime)
 		shield_delta = Energy_levels[ship_p->shield_recharge_index] * max_new_shield_energy;
 	}
 
+	if (Missiontime - Ai_info[ship_p->ai_index].last_hit_time < fl2f(sinfo_p->shield_regen_hit_delay))
+		shield_delta = 0.0f;
+
 	shield_add_strength(objp, shield_delta);
 
 	// if strength now exceeds max, scale back segments proportionally

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -3609,6 +3609,14 @@ static void parse_ship_values(ship_info* sip, const bool is_template, const bool
 	else if (first_time)
 		sip->max_shield_regen_per_second = 0.02f;
 
+	if (optional_string("+Shield Regen Hit Delay:")) {
+		stuff_float(&sip->shield_regen_hit_delay);
+		if (sip->shield_regen_hit_delay < 0.0f) {
+			Warning(LOCATION, "Shield Regen Hit Delay on ship '%s' cannot be less than 0.\n", sip->name);
+			sip->shield_regen_hit_delay = 0.0f;
+		}
+	}
+
 	// Support ship hull shield rate - if allowed
 	if(optional_string("$Support Shield Repair Rate:"))
 	{

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -1179,6 +1179,7 @@ public:
 	float		max_overclocked_speed;			// max speed when 100% power output sent to engines
 	float		max_weapon_reserve;				// maximum energy that can be stored for primary weapon usage
 	float		max_shield_regen_per_second;	// Goober5000 - max percent/100 of shield energy regenerated per second
+	float       shield_regen_hit_delay;			// Asteroth - delay after being hit before shield will start recharging again
 	float		max_weapon_regen_per_second;	// Goober5000 - max percent/100 of weapon energy regenerated per second
 
 	// Fields for tuning the ETS' direct shield<->weapon transfer feature


### PR DESCRIPTION
Adds an optional delay after hitting before shields will start to recharge.

In order for this to work on players `last_hit_time` needs to be properly updated for them too, and wasn't before, which should also make the behavior of player ships under AI control a bit more consistent.