### PR TITLE
Inline matrix multiplication ops for performance improvements

### DIFF
--- a/code/math/vecmat.cpp
+++ b/code/math/vecmat.cpp
@@ -862,7 +862,7 @@ matrix *vm_copy_transpose(matrix *dest, const matrix *src)
 	return dest;
 }
 
-vec3d operator*(const matrix& A, const vec3d& v) {
+inline vec3d operator*(const matrix& A, const vec3d& v) {
 	vec3d out;
 
 	out.xyz.x = vm_vec_dot(&A.vec.rvec, &v);
@@ -872,7 +872,7 @@ vec3d operator*(const matrix& A, const vec3d& v) {
 	return out;
 }
 
-matrix operator*(const matrix& A, const matrix& B) {
+inline matrix operator*(const matrix& A, const matrix& B) {
 	matrix BT, out;
 
 	// we transpose B here for concision and also potential vectorisation opportunities

--- a/code/math/vecmat.h
+++ b/code/math/vecmat.h
@@ -645,8 +645,8 @@ inline matrix& operator-=(matrix& left, const matrix& right)
  * @param right The vector/matrix
  * @return The multiplied result
  */
-vec3d operator*(const matrix& A, const vec3d& v);
-matrix operator*(const matrix& A, const matrix& B);
+inline vec3d operator*(const matrix& A, const vec3d& v);
+inline matrix operator*(const matrix& A, const matrix& B);
 
 std::ostream& operator<<(std::ostream& os, const vec3d& vec);
 


### PR DESCRIPTION
Asteroth suggested I use the unit tests to profile the new matrix ops. Multiplication was slow as hell. I added inlining. The artificial unit test benchmark became fast! The total binary size seems the same. What could possibly go wrong?