### PR TITLE
allow characters in SEXP help

### DIFF
--- a/code/parse/sexp/LuaSEXP.cpp
+++ b/code/parse/sexp/LuaSEXP.cpp
@@ -3,6 +3,7 @@
 #include "LuaSEXP.h"
 
 #include "iff_defs/iff_defs.h"
+#include "localization/localize.h"
 #include "mission/missionmessage.h"
 #include "object/waypoint.h"
 #include "parse/parselo.h"
@@ -470,6 +471,7 @@ void LuaSEXP::parseTable() {
 	}
 
 	_help_text = help_text.str();
+	lcl_replace_stuff(_help_text, true);
 }
 void LuaSEXP::setAction(const luacpp::LuaFunction& action) {
 	Assertion(action.isValid(), "Invalid function handle supplied!");


### PR DESCRIPTION
Certain characters (especially the semicolon) couldn't be used in SEXP help.  By using the same character replacement as in briefings and messages, now they can.