### PR TITLE
bump tracker packet sizes to match server

### DIFF
--- a/code/network/gtrack.cpp
+++ b/code/network/gtrack.cpp
@@ -29,7 +29,7 @@
 
 
 // check structs for size compatibility
-SDL_COMPILE_TIME_ASSERT(game_packet_header, sizeof(game_packet_header) == 529);
+SDL_COMPILE_TIME_ASSERT(game_packet_header, sizeof(game_packet_header) == 1529);
 SDL_COMPILE_TIME_ASSERT(freespace2_net_game_data, sizeof(freespace2_net_game_data) == 120);
 SDL_COMPILE_TIME_ASSERT(game_list_ip4, sizeof(game_list_ip4) == 384);
 SDL_COMPILE_TIME_ASSERT(game_list_ip6, sizeof(game_list_ip6) == 504);
@@ -146,6 +146,7 @@ static int SerializeGamePacket(const game_packet_header *gph, ubyte *data)
 
 	Assert(packet_size >= GAME_HEADER_ONLY_SIZE);
 	Assert(packet_size == gph->len);
+	Assert(packet_size <= MAX_PACKET_SIZE);
 
 	return static_cast<int>(packet_size);
 }

--- a/code/network/gtrack.h
+++ b/code/network/gtrack.h
@@ -24,7 +24,8 @@
 #define NET_ACK_TIMEOUT 2500
 #define NET_GAME_TIMEOUT 300			//time in seconds
 
-#define MAX_GAME_DATA_SIZE	500
+#define MAX_GAME_DATA_SIZE	1500		// NOTE: this is larger than MAX_PACKET_SIZE but
+										//       is set here to match server code
 
 #define MAX_GENERIC_GAME_NAME_LEN	32
 

--- a/code/network/ptrack.cpp
+++ b/code/network/ptrack.cpp
@@ -29,7 +29,7 @@
 
 
 // check structs for size compatibility
-SDL_COMPILE_TIME_ASSERT(udp_packet_header, sizeof(udp_packet_header) == 497);
+SDL_COMPILE_TIME_ASSERT(udp_packet_header, sizeof(udp_packet_header) == 517);
 SDL_COMPILE_TIME_ASSERT(vmt_fs2open_struct, sizeof(vmt_fs2open_struct) == 480);
 SDL_COMPILE_TIME_ASSERT(validate_id_request, sizeof(validate_id_request) == 60);
 SDL_COMPILE_TIME_ASSERT(squad_war_request, sizeof(squad_war_request) == 104);
@@ -163,6 +163,7 @@ static int SerializePilotPacket(const udp_packet_header *uph, ubyte *data)
 
 	Assert(packet_size >= PACKED_HEADER_ONLY_SIZE);
 	Assert(packet_size == uph->len);
+	Assert(packet_size <= MAX_PACKET_SIZE);
 
 	return static_cast<int>(packet_size);
 }

--- a/code/network/ptrack.h
+++ b/code/network/ptrack.h
@@ -88,7 +88,7 @@
 #define REG_NAK_UPDATE_LOG			7								// update failed because login not found
 #define REG_ACK_NEW_ID				8								// New id created, just used for return code, not net packets.
 
-#define MAX_UDP_DATA_LENGH			480
+#define MAX_UDP_DATA_LENGH			500
 #define PACKED_HEADER_ONLY_SIZE	(sizeof(udp_packet_header)-MAX_UDP_DATA_LENGH)
 //sizeof(update_id_request)	//The largest packet
 

--- a/code/network/valid.cpp
+++ b/code/network/valid.cpp
@@ -138,6 +138,7 @@ static int SerializeValidatePacket(const udp_packet_header *uph, ubyte *data)
 
 	Assert(packet_size >= PACKED_HEADER_ONLY_SIZE);
 	Assert(packet_size == uph->len);
+	Assert(packet_size <= MAX_PACKET_SIZE);
 
 	return static_cast<int>(packet_size);
 }


### PR DESCRIPTION
 - allow for size of IPv6 game list packet (fixes #3543)

These larger packet sizes aren't required for
FS2/FS2_Open, but just keeps the code in sync.