### PR TITLE
fix 3539

### DIFF
--- a/code/parse/parselo.cpp
+++ b/code/parse/parselo.cpp
@@ -2824,6 +2824,8 @@ void stuff_string_list(SCP_vector<SCP_string> &slp)
 	stuff_token_list(slp, [](SCP_string *buf)->bool {
 		if (*Mp != '\"') {
 			error_display(0, "Missing quotation marks in string list.");
+			// Since this is a bad token, skip characters until we find a comma, parenthesis, or EOLN
+			advance_to_eoln(",)");
 			return false;
 		}
 


### PR DESCRIPTION
If a bad token is found in a string list, just advance the parser until the next token or EOLN.

Should fix #3539.