### PR TITLE
Adjust event flag reseting position

### DIFF
--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -4983,6 +4983,8 @@ void parse_event(mission * /*pm*/)
 	mission_event *event;
 
 	event = &Mission_events[Num_mission_events];
+	// Need to set this to zero so that we don't accidentally reuse old data.
+	event->flags = 0;
 
 	required_string( "$Formula:" );
 	event->formula = get_sexp_main();
@@ -5067,9 +5069,6 @@ void parse_event(mission * /*pm*/)
 			event->team = -1;
 		}
 	}
-
-	// Need to set this to zero so that we don't accidentally reuse old data.
-	event->flags = 0;
 
 	if (optional_string("+Event Flags:")) {
 		parse_string_flag_list(&event->flags, Mission_event_flags, Num_mission_event_flags);


### PR DESCRIPTION
https://github.com/scp-fs2open/fs2open.github.com/pull/3363/commits/2a9178318c5137dd7fcfdd1fb2e465b3c937d8cc #3363 put the event flag resetting a little bit too late, where it could end up wiping `MEF_USING_TRIGGER_COUNT`. It should be right at the top, before anything is done.
