### PR TITLE
Fix a secondary range bug from AI multilock

### DIFF
--- a/code/hud/hudlock.cpp
+++ b/code/hud/hudlock.cpp
@@ -1392,7 +1392,7 @@ int hud_lock_target_in_range(lock_info *lock_slot)
 	}
 	ship_weapon* swp = &Player_ship->weapons;
 
-	return weapon_secondary_world_pos_in_range(Player_obj, &Weapon_info[swp->secondary_bank_weapons[swp->current_secondary_bank]], &lock_slot->obj->pos);
+	return weapon_secondary_world_pos_in_range(Player_obj, &Weapon_info[swp->secondary_bank_weapons[swp->current_secondary_bank]], &target_world_pos);
 }
 
 void hud_do_lock_indicators(float frametime)


### PR DESCRIPTION
A bit of fallout from AI multilock, this was erroneously changed from `target_world_pos` (which had just been calculated for this purpose) to `lock_slot->obj->pos`, preventing locks on subsystems if the player is is out of range of the ship's center.