### PR TITLE
FRED turret info

### DIFF
--- a/fred2/fred.cpp
+++ b/fred2/fred.cpp
@@ -234,6 +234,7 @@ BOOL CFREDApp::InitInstance() {
 	Mission_save_format = GetProfileInt("Preferences", "FS2 open format", FSO_FORMAT_STANDARD);
 	Mission_save_format = GetProfileInt("Preferences", "Mission save format", Mission_save_format);
 	Move_ships_when_undocking = GetProfileInt("Preferences", "Move ships when undocking", Move_ships_when_undocking);
+	Highlight_selectable_subsys = GetProfileInt("Preferences", "Highlight selectable subsys", Highlight_selectable_subsys);
 
 	read_window("Main window", &Main_wnd_data);
 	read_window("Ship window", &Ship_wnd_data);
@@ -495,6 +496,7 @@ void CFREDApp::write_ini_file(int degree) {
 	// Goober5000
 	WriteProfileInt("Preferences", "Mission save format", Mission_save_format);
 	WriteProfileInt("Preferences", "Move ships when undocking", Move_ships_when_undocking);
+	WriteProfileInt("Preferences", "Highlight selectable subsys", Highlight_selectable_subsys);
 
 	if (!degree) {
 		record_window_data(&Waypoint_wnd_data, &Waypoint_editor_dialog);

--- a/fred2/fred.rc
+++ b/fred2/fred.rc
@@ -260,6 +260,7 @@ BEGIN
         MENUITEM "Show Distances\tD",           32941
         MENUITEM "Show Model Paths",            33066
         MENUITEM "Show Model Dock Points",      33065
+        MENUITEM "Highlight Selectable Subsystems",      33062
         MENUITEM SEPARATOR
         MENUITEM "Show &Grid\tShift+Alt+G",     32808
         MENUITEM "Show Horizon\tShift+Alt+H",   32954

--- a/fred2/fredrender.cpp
+++ b/fred2/fredrender.cpp
@@ -409,22 +409,31 @@ void display_active_ship_subsystem() {
 		if (Objects[cur_object_index].type == OBJ_SHIP) {
 
 			object *objp = &Objects[cur_object_index];
-			char buf[256];
+			
+			// if this option is checked, we want to render info for all subsystems, not just the ones we select with K and Shift-K
+			if (Highlight_selectable_subsys) {
+				auto shipp = &Ships[objp->instance];
 
-			// switching to a new ship, so reset
-			if (objp != Render_subsys.ship_obj) {
-				cancel_display_active_ship_subsystem();
-				return;
+				for (auto ss = GET_FIRST(&shipp->subsys_list); ss != END_OF_LIST(&shipp->subsys_list); ss = GET_NEXT(ss)) {
+					if (ss->system_info->subobj_num != -1) {
+						subsys_to_render s2r = { true, objp, ss };
+						fredhtl_render_subsystem_bounding_box(&s2r);
+					}
+				}
 			}
+			// otherwise select individual subsystems, or not, as normal
+			else {
+				// switching to a new ship, so reset
+				if (objp != Render_subsys.ship_obj) {
+					cancel_display_active_ship_subsystem();
+					return;
+				}
 
-			if (Render_subsys.do_render) {
-
-				// get subsys name
-				strcpy_s(buf, Render_subsys.cur_subsys->system_info->subobj_name);
-
-				fredhtl_render_subsystem_bounding_box(&Render_subsys);
-			} else {
-				cancel_display_active_ship_subsystem();
+				if (Render_subsys.do_render) {
+					fredhtl_render_subsystem_bounding_box(&Render_subsys);
+				} else {
+					cancel_display_active_ship_subsystem();
+				}
 			}
 		}
 	}

--- a/fred2/fredrender.cpp
+++ b/fred2/fredrender.cpp
@@ -786,8 +786,30 @@ void fredhtl_render_subsystem_bounding_box(subsys_to_render * s2r) {
 
 	fred_disable_htl();
 
+	// get text
+	strcpy_s(buf, s2r->cur_subsys->system_info->subobj_name);
+
+	// add weapons if present
+	for (int i = 0; i < s2r->cur_subsys->weapons.num_primary_banks; ++i)
+	{
+		int wi = s2r->cur_subsys->weapons.primary_bank_weapons[i];
+		if (wi >= 0)
+		{
+			strcat_s(buf, "\n");
+			strcat_s(buf, Weapon_info[wi].name);
+		}
+	}
+	for (int i = 0; i < s2r->cur_subsys->weapons.num_secondary_banks; ++i)
+	{
+		int wi = s2r->cur_subsys->weapons.secondary_bank_weapons[i];
+		if (wi >= 0)
+		{
+			strcat_s(buf, "\n");
+			strcat_s(buf, Weapon_info[wi].name);
+		}
+	}
+
 	//draw the text.  rotate the center of the subsystem into place before finding out where to put the text
-	strcpy_s(buf, Render_subsys.cur_subsys->system_info->subobj_name);
 	vec3d center_pt;
 	vm_vec_unrotate(&center_pt, &bsp->offset, &s2r->ship_obj->orient);
 	vm_vec_add2(&center_pt, &s2r->ship_obj->pos);

--- a/fred2/fredview.cpp
+++ b/fred2/fredview.cpp
@@ -102,6 +102,7 @@ int Id_select_type_start = 0;
 int Id_select_type_waypoint = 0;
 int Hide_ship_cues = 0, Hide_wing_cues = 0;
 int Move_ships_when_undocking = 1;			// true by default
+int Highlight_selectable_subsys = 0;
 
 vec3d original_pos, saved_cam_pos;
 matrix bitmap_matrix_backup, saved_cam_orient = { 0.0f };
@@ -333,6 +334,8 @@ BEGIN_MESSAGE_MAP(CFREDView, CView)
 	ON_UPDATE_COMMAND_UI(ID_FORMAT_FS1_RETAIL, OnUpdateFormatFs1Retail)
 	ON_COMMAND(ID_MISC_MOVESHIPSWHENUNDOCKING, OnMoveShipsWhenUndocking)
 	ON_UPDATE_COMMAND_UI(ID_MISC_MOVESHIPSWHENUNDOCKING, OnUpdateMoveShipsWhenUndocking)
+	ON_COMMAND(ID_HIGHLIGHT_SUBSYS, OnHighlightSubsys)
+	ON_UPDATE_COMMAND_UI(ID_HIGHLIGHT_SUBSYS, OnUpdateHighlightSubsys)
 	ON_COMMAND(ID_EDITORS_SET_GLOBAL_SHIP_FLAGS, OnEditorsSetGlobalShipFlags)
 	ON_COMMAND(ID_EDITORS_VOICE, OnEditorsVoiceManager)
 	ON_COMMAND(ID_EDITORS_FICTION, OnEditorsFiction)
@@ -4552,6 +4555,18 @@ void CFREDView::OnMoveShipsWhenUndocking()
 void CFREDView::OnUpdateMoveShipsWhenUndocking(CCmdUI* pCmdUI)
 {
 	pCmdUI->SetCheck(Move_ships_when_undocking);
+}
+
+void CFREDView::OnHighlightSubsys()
+{
+	Highlight_selectable_subsys = !Highlight_selectable_subsys;
+	theApp.write_ini_file();
+	Update_window = 1;
+}
+
+void CFREDView::OnUpdateHighlightSubsys(CCmdUI* pCmdUI)
+{
+	pCmdUI->SetCheck(Highlight_selectable_subsys);
 }
 
 void CFREDView::OnDumpStats()

--- a/fred2/fredview.h
+++ b/fred2/fredview.h
@@ -298,6 +298,8 @@ protected:
 	afx_msg void OnUpdateFormatFs1Retail(CCmdUI* pCmdUI);
 	afx_msg void OnMoveShipsWhenUndocking();
 	afx_msg void OnUpdateMoveShipsWhenUndocking(CCmdUI* pCmdUI);
+	afx_msg void OnHighlightSubsys();
+	afx_msg void OnUpdateHighlightSubsys(CCmdUI* pCmdUI);
 	afx_msg void OnEditorsSetGlobalShipFlags();
 	afx_msg void OnEditorsVoiceManager();
 	afx_msg void OnEditorsFiction();
@@ -359,6 +361,7 @@ extern int Id_select_type_start;
 extern int Id_select_type_waypoint;
 extern int Hide_ship_cues, Hide_wing_cues;
 extern int Move_ships_when_undocking;
+extern int Highlight_selectable_subsys;
 
 extern Marking_box marking_box;
 extern object_orient_pos	rotation_backup[MAX_OBJECTS];

--- a/fred2/resource.h
+++ b/fred2/resource.h
@@ -1408,6 +1408,7 @@
 #define ID_NEXT_SUBSYS                  33059
 #define ID_PREV_SUBSYS                  33060
 #define ID_CANCEL_SUBSYS                33061
+#define ID_HIGHLIGHT_SUBSYS             33062
 #define ID_SHOW_DOCK_POINTS             33065
 #define ID_SHOW_PATHS                   33066
 #define ID_DUMP_STATS                   33067

--- a/qtfred/src/mission/EditorViewport.h
+++ b/qtfred/src/mission/EditorViewport.h
@@ -33,6 +33,7 @@ struct ViewSettings {
 	bool Show_waypoints = true;
 	bool Show_compass = true;
 	bool Move_ships_when_undocking = true;
+	bool Highlight_selectable_subsys = false;
 
 	ViewSettings();
 };

--- a/qtfred/src/mission/FredRenderer.cpp
+++ b/qtfred/src/mission/FredRenderer.cpp
@@ -526,21 +526,31 @@ void FredRenderer::display_active_ship_subsystem(subsys_to_render& Render_subsys
 	if (cur_object_index != -1) {
 		if (Objects[cur_object_index].type == OBJ_SHIP) {
 			object* objp = &Objects[cur_object_index];
-			char buf[256];
 
-			// switching to a new ship, so reset
-			if (objp != Render_subsys.ship_obj) {
-				cancel_display_active_ship_subsystem(Render_subsys);
-				return;
+			// if this option is checked, we want to render info for all subsystems, not just the ones we select with K and Shift-K
+			if (Highlight_selectable_subsys) {
+				auto shipp = &Ships[objp->instance];
+
+				for (auto ss = GET_FIRST(&shipp->subsys_list); ss != END_OF_LIST(&shipp->subsys_list); ss = GET_NEXT(ss)) {
+					if (ss->system_info->subobj_num != -1) {
+						subsys_to_render s2r = { true, objp, ss };
+						fredhtl_render_subsystem_bounding_box(&s2r);
+					}
+				}
 			}
+			// otherwise select individual subsystems, or not, as normal
+			else {
+				// switching to a new ship, so reset
+				if (objp != Render_subsys.ship_obj) {
+					cancel_display_active_ship_subsystem(Render_subsys);
+					return;
+				}
 
-			if (Render_subsys.do_render) {
-				// get subsys name
-				strcpy_s(buf, Render_subsys.cur_subsys->system_info->subobj_name);
-
-				fredhtl_render_subsystem_bounding_box(&Render_subsys);
-			} else {
-				cancel_display_active_ship_subsystem(Render_subsys);
+				if (Render_subsys.do_render) {
+					fredhtl_render_subsystem_bounding_box(&Render_subsys);
+				} else {
+					cancel_display_active_ship_subsystem(Render_subsys);
+				}
 			}
 		}
 	}

--- a/qtfred/src/mission/FredRenderer.cpp
+++ b/qtfred/src/mission/FredRenderer.cpp
@@ -25,6 +25,7 @@
 #include <graphics/light.h>
 
 #include "mission/object.h"
+#include "weapon/weapon.h"
 
 
 namespace {
@@ -528,7 +529,7 @@ void FredRenderer::display_active_ship_subsystem(subsys_to_render& Render_subsys
 			object* objp = &Objects[cur_object_index];
 
 			// if this option is checked, we want to render info for all subsystems, not just the ones we select with K and Shift-K
-			if (Highlight_selectable_subsys) {
+			if (view().Highlight_selectable_subsys) {
 				auto shipp = &Ships[objp->instance];
 
 				for (auto ss = GET_FIRST(&shipp->subsys_list); ss != END_OF_LIST(&shipp->subsys_list); ss = GET_NEXT(ss)) {

--- a/qtfred/src/mission/FredRenderer.cpp
+++ b/qtfred/src/mission/FredRenderer.cpp
@@ -141,7 +141,7 @@ void draw_asteroid_field() {
 	}
 }
 
-void fredhtl_render_subsystem_bounding_box(subsys_to_render* s2r, subsys_to_render& Render_subsys) {
+void fredhtl_render_subsystem_bounding_box(subsys_to_render* s2r) {
 	vertex text_center;
 	polymodel* pm = model_get(Ship_info[Ships[s2r->ship_obj->instance].ship_info_index].model_num);
 	int subobj_num = s2r->cur_subsys->system_info->subobj_num;
@@ -219,8 +219,30 @@ void fredhtl_render_subsystem_bounding_box(subsys_to_render* s2r, subsys_to_rend
 
 	disable_htl();
 
+	// get text
+	strcpy_s(buf, s2r->cur_subsys->system_info->subobj_name);
+
+	// add weapons if present
+	for (int i = 0; i < s2r->cur_subsys->weapons.num_primary_banks; ++i)
+	{
+		int wi = s2r->cur_subsys->weapons.primary_bank_weapons[i];
+		if (wi >= 0)
+		{
+			strcat_s(buf, "\n");
+			strcat_s(buf, Weapon_info[wi].name);
+		}
+	}
+	for (int i = 0; i < s2r->cur_subsys->weapons.num_secondary_banks; ++i)
+	{
+		int wi = s2r->cur_subsys->weapons.secondary_bank_weapons[i];
+		if (wi >= 0)
+		{
+			strcat_s(buf, "\n");
+			strcat_s(buf, Weapon_info[wi].name);
+		}
+	}
+
 	//draw the text.  rotate the center of the subsystem into place before finding out where to put the text
-	strcpy_s(buf, Render_subsys.cur_subsys->system_info->subobj_name);
 	vec3d center_pt;
 	vm_vec_unrotate(&center_pt, &bsp->offset, &s2r->ship_obj->orient);
 	vm_vec_add2(&center_pt, &s2r->ship_obj->pos);
@@ -516,7 +538,7 @@ void FredRenderer::display_active_ship_subsystem(subsys_to_render& Render_subsys
 				// get subsys name
 				strcpy_s(buf, Render_subsys.cur_subsys->system_info->subobj_name);
 
-				fredhtl_render_subsystem_bounding_box(&Render_subsys, Render_subsys);
+				fredhtl_render_subsystem_bounding_box(&Render_subsys);
 			} else {
 				cancel_display_active_ship_subsystem(Render_subsys);
 			}


### PR DESCRIPTION
Add some useful QoL improvements for turrets.
1) Each turret now not only displays its name, but also whatever weapons it is carrying.
2) A new menu option allows displaying info from all turrets at once.

Tested and works as expected.  See screenshot:

![all_turrets](https://user-images.githubusercontent.com/1878523/125186818-7ec75b80-e1fa-11eb-9287-b9212ba44ef2.png)
