### PR TITLE
work around MSVC 2015 and 2017 compiler bug

### DIFF
--- a/qtfred/src/mission/dialogs/MissionSpecDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/MissionSpecDialogModel.cpp
@@ -1,6 +1,10 @@
 //
 //
 
+// work around MSVC 2015 and 2017 compiler bug
+// https://bugreports.qt.io/browse/QTBUG-72073
+#define QT_NO_FLOAT16_OPERATORS
+
 #include "MissionSpecDialogModel.h"
 #include "ui/dialogs/MissionSpecDialog.h"
 

--- a/qtfred/src/mission/dialogs/ShipEditorDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/ShipEditorDialogModel.cpp
@@ -1,3 +1,10 @@
+//
+//
+
+// work around MSVC 2015 and 2017 compiler bug
+// https://bugreports.qt.io/browse/QTBUG-72073
+#define QT_NO_FLOAT16_OPERATORS
+
 #include "ShipEditorDialogModel.h"
 
 #include "iff_defs/iff_defs.h"

--- a/qtfred/src/ui/QtGraphicsOperations.cpp
+++ b/qtfred/src/ui/QtGraphicsOperations.cpp
@@ -1,6 +1,10 @@
 //
 //
 
+// work around MSVC 2015 and 2017 compiler bug
+// https://bugreports.qt.io/browse/QTBUG-72073
+#define QT_NO_FLOAT16_OPERATORS
+
 #include "QtGraphicsOperations.h"
 
 #include "widgets/renderwidget.h"

--- a/qtfred/src/ui/widgets/ColorComboBox.cpp
+++ b/qtfred/src/ui/widgets/ColorComboBox.cpp
@@ -1,6 +1,10 @@
 //
 //
 
+// work around MSVC 2015 and 2017 compiler bug
+// https://bugreports.qt.io/browse/QTBUG-72073
+#define QT_NO_FLOAT16_OPERATORS
+
 #include "ColorComboBox.h"
 
 #include <ship/ship.h>

--- a/qtfred/src/ui/widgets/renderwidget.cpp
+++ b/qtfred/src/ui/widgets/renderwidget.cpp
@@ -1,3 +1,9 @@
+//
+//
+
+// work around MSVC 2015 and 2017 compiler bug
+// https://bugreports.qt.io/browse/QTBUG-72073
+#define QT_NO_FLOAT16_OPERATORS
 
 #include "renderwidget.h"
 


### PR DESCRIPTION
This macro bypasses a compiler bug where MSVC can't distinguish the division symbol.  See https://bugreports.qt.io/browse/QTBUG-72073