### PR TITLE
Qtfred menu update

### DIFF
--- a/qtfred/src/mission/Editor.h
+++ b/qtfred/src/mission/Editor.h
@@ -159,7 +159,6 @@ class Editor : public QObject {
 	 */
 	void remove_wing(int wing_num);
 
-	void duplicate_marked();
 	void delete_marked();
 
 	int delete_wing(int wing_num, int bypass = 0);

--- a/qtfred/src/mission/Editor.h
+++ b/qtfred/src/mission/Editor.h
@@ -159,6 +159,7 @@ class Editor : public QObject {
 	 */
 	void remove_wing(int wing_num);
 
+	void duplicate_marked();
 	void delete_marked();
 
 	int delete_wing(int wing_num, int bypass = 0);

--- a/qtfred/src/mission/EditorViewport.h
+++ b/qtfred/src/mission/EditorViewport.h
@@ -32,7 +32,6 @@ struct ViewSettings {
 	bool FullDetail = false;
 	bool Show_waypoints = true;
 	bool Show_compass = true;
-	bool Move_ships_when_undocking = true;
 	bool Highlight_selectable_subsys = false;
 
 	ViewSettings();
@@ -161,6 +160,7 @@ class EditorViewport {
 
 	bool Group_rotate = true;
 	bool Lookat_mode = false;
+	bool Move_ships_when_undocking = true;
 
 	Editor* editor = nullptr;
 	FredRenderer* renderer = nullptr;

--- a/qtfred/src/ui/FredView.cpp
+++ b/qtfred/src/ui/FredView.cpp
@@ -951,6 +951,11 @@ void FredView::on_actionTool_Bar_triggered(bool enabled) {
 void FredView::on_actionStatus_Bar_triggered(bool enabled) {
 	statusBar()->setVisible(enabled);
 }
+void FredView::on_actionClone_Marked_Objects_triggered(bool) {
+	if (fred->getNumMarked() > 0) {
+		_viewport->duplicate_marked_objects();
+	}
+}
 void FredView::on_actionDelete_triggered(bool) {
 	if (fred->getNumMarked() > 0) {
 		fred->delete_marked();

--- a/qtfred/src/ui/FredView.cpp
+++ b/qtfred/src/ui/FredView.cpp
@@ -277,6 +277,7 @@ void FredView::syncViewOptions() {
 	connectActionToViewSetting(ui->actionShow_Distances, &_viewport->view.Show_distances);
 	connectActionToViewSetting(ui->actionShow_Model_Paths, &_viewport->view.Show_paths_fred);
 	connectActionToViewSetting(ui->actionShow_Model_Dock_Points, &_viewport->view.Show_dock_points);
+	connectActionToViewSetting(ui->actionHighlight_Selectable_Subsystems, &_viewport->view.Highlight_selectable_subsys);
 
 	connectActionToViewSetting(ui->actionShow_Grid, &_viewport->view.Show_grid);
 	connectActionToViewSetting(ui->actionShow_Horizon, &_viewport->view.Show_horizon);

--- a/qtfred/src/ui/FredView.cpp
+++ b/qtfred/src/ui/FredView.cpp
@@ -63,7 +63,6 @@ FredView::FredView(QWidget* parent) : QMainWindow(parent), ui(new Ui::FredView()
 	ui->actionNew->setShortcuts(QKeySequence::New);
 	ui->actionOpen->setShortcuts(QKeySequence::Open);
 	ui->actionSave->setShortcuts(QKeySequence::Save);
-	ui->actionSave_As->setShortcuts(QKeySequence::SaveAs);
 	ui->actionExit->setShortcuts(QKeySequence::Quit);
 	ui->actionUndo->setShortcuts(QKeySequence::Undo);
 	ui->actionDelete->setShortcuts(QKeySequence::Delete);

--- a/qtfred/src/ui/FredView.cpp
+++ b/qtfred/src/ui/FredView.cpp
@@ -129,6 +129,8 @@ void FredView::setEditor(Editor* editor, EditorViewport* viewport) {
 			&FredView::viewIdle,
 			this,
 			[this]() { ui->actionRestore_Camera_Pos->setEnabled(!IS_VEC_NULL(&_viewport->saved_cam_orient.vec.fvec)); });
+
+	connect(this, &FredView::viewIdle, this, [this]() { ui->actionMove_Ships_When_Undocking->setChecked(_viewport->Move_ships_when_undocking); });
 }
 
 void FredView::loadMissionFile(const QString& pathName) {
@@ -1028,14 +1030,14 @@ void FredView::onSetGroup(int group) {
 
 	fred->updateAllViewports();
 }
+void FredView::on_actionControl_Object_triggered(bool) {
+	_viewport->Control_mode = (_viewport->Control_mode + 1) % 2;
+}
 void FredView::on_actionLevel_Object_triggered(bool) {
 	_viewport->level_controlled();
 }
 void FredView::on_actionAlign_Object_triggered(bool) {
 	_viewport->verticalize_controlled();
-}
-void FredView::on_actionControl_Object_triggered(bool) {
-	_viewport->Control_mode = (_viewport->Control_mode + 1) % 2;
 }
 void FredView::on_actionNext_Subsystem_triggered(bool) {
 	fred->select_next_subsystem();
@@ -1045,6 +1047,9 @@ void FredView::on_actionPrev_Subsystem_triggered(bool) {
 }
 void FredView::on_actionCancel_Subsystem_triggered(bool) {
 	fred->cancel_select_subsystem();
+}
+void FredView::on_actionMove_Ships_When_Undocking_triggered(bool) {
+	_viewport->Move_ships_when_undocking = !_viewport->Move_ships_when_undocking;
 }
 void FredView::on_actionError_Checker_triggered(bool) {
 	fred->global_error_check();

--- a/qtfred/src/ui/FredView.cpp
+++ b/qtfred/src/ui/FredView.cpp
@@ -129,18 +129,6 @@ void FredView::setEditor(Editor* editor, EditorViewport* viewport) {
 			&FredView::viewIdle,
 			this,
 			[this]() { ui->actionRestore_Camera_Pos->setEnabled(!IS_VEC_NULL(&_viewport->saved_cam_orient.vec.fvec)); });
-
-	// The Show teams actions need to be initialized after everything has been set up since the IFFs may not have been
-	// initialized yet
-	fredApp->runAfterInit([this]() {
-		for (auto i = 0; i < Num_iffs; ++i) {
-			auto action = new QAction(QString::fromUtf8(Iff_info[i].iff_name), ui->menuDisplay_Filter);
-			action->setCheckable(true);
-			connectActionToViewSetting(action, &_viewport->view.Show_iff[i]);
-
-			ui->menuDisplay_Filter->addAction(action);
-		}
-	});
 }
 
 void FredView::loadMissionFile(const QString& pathName) {
@@ -266,7 +254,17 @@ void FredView::syncViewOptions() {
 	connectActionToViewSetting(ui->actionShow_Player_Starts, &_viewport->view.Show_starts);
 	connectActionToViewSetting(ui->actionShow_Waypoints, &_viewport->view.Show_waypoints);
 
-	// TODO: Dynamically handle the Show teams option
+	// The Show teams actions need to be initialized after everything has been set up since the IFFs may not have been
+	// initialized yet
+	fredApp->runAfterInit([this]() {
+		for (auto i = 0; i < Num_iffs; ++i) {
+			auto action = new QAction(QString::fromUtf8(Iff_info[i].iff_name), ui->menuDisplay_Filter);
+			action->setCheckable(true);
+			connectActionToViewSetting(action, &_viewport->view.Show_iff[i]);
+
+			ui->menuDisplay_Filter->addAction(action);
+		}
+	});
 
 	connectActionToViewSetting(ui->actionShow_Ship_Models, &_viewport->view.Show_ship_models);
 	connectActionToViewSetting(ui->actionShow_Outlines, &_viewport->view.Show_outlines);

--- a/qtfred/src/ui/FredView.h
+++ b/qtfred/src/ui/FredView.h
@@ -111,13 +111,16 @@ class FredView: public QMainWindow, public IDialogProvider {
 	void on_actionDelete_triggered(bool);
 	void on_actionDelete_Wing_triggered(bool);
 
+	void on_actionControl_Object_triggered(bool);
 	void on_actionLevel_Object_triggered(bool);
 	void on_actionAlign_Object_triggered(bool);
-	void on_actionControl_Object_triggered(bool);
 
 	void on_actionNext_Subsystem_triggered(bool);
 	void on_actionPrev_Subsystem_triggered(bool);
 	void on_actionCancel_Subsystem_triggered(bool);
+
+	void on_actionMove_Ships_When_Undocking_triggered(bool);
+
 	void on_actionError_Checker_triggered(bool);
 
 	void on_actionAbout_triggered(bool);

--- a/qtfred/src/ui/FredView.h
+++ b/qtfred/src/ui/FredView.h
@@ -107,6 +107,7 @@ class FredView: public QMainWindow, public IDialogProvider {
 	void on_actionTool_Bar_triggered(bool enabled);
 	void on_actionStatus_Bar_triggered(bool enabled);
 
+	void on_actionClone_Marked_Objects_triggered(bool);
 	void on_actionDelete_triggered(bool);
 	void on_actionDelete_Wing_triggered(bool);
 

--- a/qtfred/ui/FredView.ui
+++ b/qtfred/ui/FredView.ui
@@ -333,7 +333,7 @@
     <string>SelectRotate</string>
    </property>
    <property name="toolTip">
-    <string>Select and Rotate</string>
+    <string>Select and Rotate (R)</string>
    </property>
    <property name="shortcut">
     <string>R</string>
@@ -369,7 +369,7 @@
     <string>ConstraintX</string>
    </property>
    <property name="toolTip">
-    <string>X Constraint (`)</string>
+    <string>X Constraint</string>
    </property>
   </action>
   <action name="actionConstrainY">
@@ -384,7 +384,7 @@
     <string>ConstraintY</string>
    </property>
    <property name="toolTip">
-    <string>Y Constraint (`)</string>
+    <string>Y Constraint</string>
    </property>
   </action>
   <action name="actionConstrainZ">
@@ -399,7 +399,7 @@
     <string>ConstraintZ</string>
    </property>
    <property name="toolTip">
-    <string>Z Constraint (`)</string>
+    <string>Z Constraint</string>
    </property>
   </action>
   <action name="actionConstrainXZ">
@@ -414,7 +414,7 @@
     <string>ConstraintXZ</string>
    </property>
    <property name="toolTip">
-    <string>XZ Constraint (`)</string>
+    <string>XZ Constraint</string>
    </property>
   </action>
   <action name="actionConstrainYZ">
@@ -444,7 +444,7 @@
     <string>ConstraintXY</string>
    </property>
    <property name="toolTip">
-    <string>XY Constaint (`)</string>
+    <string>XY Constaint</string>
    </property>
   </action>
   <action name="actionSelectionList">
@@ -474,10 +474,10 @@
     <string>SelectionLock</string>
    </property>
    <property name="toolTip">
-    <string>Selection Lock (L)</string>
+    <string>Selection Lock (Spacebar)</string>
    </property>
    <property name="shortcut">
-    <string>L</string>
+    <string>Space</string>
    </property>
   </action>
   <action name="actionWingForm">
@@ -489,7 +489,7 @@
     <string>WingForm</string>
    </property>
    <property name="toolTip">
-    <string>Form Wing (Ctrl + W)</string>
+    <string>Form Wing (Ctrl+W)</string>
    </property>
    <property name="shortcut">
     <string>Ctrl+W</string>
@@ -504,7 +504,7 @@
     <string>WingDisband</string>
    </property>
    <property name="toolTip">
-    <string>Disband Wing (Ctrl + D)</string>
+    <string>Disband Wing (Ctrl+D)</string>
    </property>
    <property name="shortcut">
     <string>Ctrl+D</string>
@@ -519,7 +519,10 @@
     <string>ZoomSelected</string>
    </property>
    <property name="toolTip">
-    <string>Zoom on Selected (Alt + Z)</string>
+    <string>Zoom on Selected (Alt+Z)</string>
+   </property>
+   <property name="shortcut">
+    <string>Alt+Z</string>
    </property>
   </action>
   <action name="actionZoomExtents">
@@ -531,7 +534,7 @@
     <string>ZoomExtents</string>
    </property>
    <property name="toolTip">
-    <string>Zoom Extents (Shift + Z)</string>
+    <string>Zoom Extents (Shift+Z)</string>
    </property>
    <property name="shortcut">
     <string>Shift+Z</string>
@@ -567,10 +570,10 @@
     <string>OrbitSelected</string>
    </property>
    <property name="toolTip">
-    <string>Rotate about Selected (Ctrl + V)</string>
+    <string>Rotate about Selected (Alt+R)</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+V</string>
+    <string>Alt+R</string>
    </property>
   </action>
   <action name="actionNew">
@@ -594,6 +597,9 @@
   <action name="actionSave_As">
    <property name="text">
     <string>Sa&amp;ve As...</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+Shift+S</string>
    </property>
   </action>
   <action name="actionRevert">
@@ -915,7 +921,7 @@
     <string>&amp;x1</string>
    </property>
    <property name="shortcut">
-    <string>Alt+Shift+1</string>
+    <string>1</string>
    </property>
   </action>
   <action name="actionx2">
@@ -926,7 +932,7 @@
     <string>x&amp;2</string>
    </property>
    <property name="shortcut">
-    <string>Alt+Shift+2</string>
+    <string>2</string>
    </property>
   </action>
   <action name="actionx3">
@@ -937,7 +943,7 @@
     <string>x&amp;3</string>
    </property>
    <property name="shortcut">
-    <string>Alt+Shift+3</string>
+    <string>3</string>
    </property>
   </action>
   <action name="actionx5">
@@ -948,7 +954,7 @@
     <string>x&amp;5</string>
    </property>
    <property name="shortcut">
-    <string>Alt+Shift+4</string>
+    <string>4</string>
    </property>
   </action>
   <action name="actionx8">
@@ -959,7 +965,7 @@
     <string>x&amp;8</string>
    </property>
    <property name="shortcut">
-    <string>Alt+Shift+5</string>
+    <string>5</string>
    </property>
   </action>
   <action name="actionx10">
@@ -970,7 +976,7 @@
     <string>x&amp;10</string>
    </property>
    <property name="shortcut">
-    <string>Alt+Shift+6</string>
+    <string>6</string>
    </property>
   </action>
   <action name="actionx50">
@@ -981,7 +987,7 @@
     <string>x5&amp;0</string>
    </property>
    <property name="shortcut">
-    <string>Alt+Shift+7</string>
+    <string>7</string>
    </property>
   </action>
   <action name="actionx100">
@@ -992,7 +998,7 @@
     <string>x100</string>
    </property>
    <property name="shortcut">
-    <string>Alt+Shift+8</string>
+    <string>8</string>
    </property>
   </action>
   <action name="actionRotx1">
@@ -1054,10 +1060,16 @@
    <property name="text">
     <string>&amp;Ships</string>
    </property>
+   <property name="shortcut">
+    <string>Shift+S</string>
+   </property>
   </action>
   <action name="actionWings">
    <property name="text">
     <string>&amp;Wings</string>
+   </property>
+   <property name="shortcut">
+    <string>Shift+W</string>
    </property>
   </action>
   <action name="actionObjects">
@@ -1088,6 +1100,9 @@
    <property name="text">
     <string>&amp;Team Loadout</string>
    </property>
+   <property name="shortcut">
+    <string>Shift+P</string>
+   </property>
   </action>
   <action name="actionBackground">
    <property name="text">
@@ -1100,6 +1115,9 @@
   <action name="actionReinforcements">
    <property name="text">
     <string>&amp;Reinforcements</string>
+   </property>
+   <property name="shortcut">
+    <string>Shift+R</string>
    </property>
   </action>
   <action name="actionAsteroid_Field">
@@ -1131,12 +1149,15 @@
     <string>&amp;Debriefing</string>
    </property>
    <property name="shortcut">
-    <string/>
+    <string>Shift+D</string>
    </property>
   </action>
   <action name="actionCommand_Briefing">
    <property name="text">
     <string>&amp;Command Briefing</string>
+   </property>
+   <property name="shortcut">
+    <string>Shift+C</string>
    </property>
   </action>
   <action name="actionFiction_Viewer">
@@ -1379,7 +1400,7 @@
     <string>&amp;Error Checker</string>
    </property>
    <property name="shortcut">
-    <string/>
+    <string>Shift+H</string>
    </property>
   </action>
   <action name="actionHelp_Topics">
@@ -1390,6 +1411,9 @@
   <action name="actionShow_SEXP_Help">
    <property name="text">
     <string>&amp;Show SEXP Help</string>
+   </property>
+   <property name="checkable">
+    <bool>true</bool>
    </property>
   </action>
   <action name="actionAbout">

--- a/qtfred/ui/FredView.ui
+++ b/qtfred/ui/FredView.ui
@@ -225,6 +225,7 @@
     <addaction name="separator"/>
     <addaction name="actionMark_Wing"/>
     <addaction name="actionAdjust_Grid"/>
+    <addaction name="actionMove_Ships_When_Undocking"/>
     <addaction name="actionMission_Statistics"/>
     <addaction name="separator"/>
     <addaction name="actionError_Checker"/>
@@ -1387,6 +1388,14 @@
   <action name="actionAdjust_Grid">
    <property name="text">
     <string>Adjust &amp;Grid</string>
+   </property>
+  </action>
+  <action name="actionMove_Ships_When_Undocking">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Move Ships When Undocking</string>
    </property>
   </action>
   <action name="actionMission_Statistics">

--- a/qtfred/ui/FredView.ui
+++ b/qtfred/ui/FredView.ui
@@ -109,6 +109,7 @@
     <addaction name="actionShow_Distances"/>
     <addaction name="actionShow_Model_Paths"/>
     <addaction name="actionShow_Model_Dock_Points"/>
+    <addaction name="actionHighlight_Selectable_Subsystems"/>
     <addaction name="separator"/>
     <addaction name="actionShow_Grid"/>
     <addaction name="actionShow_Horizon"/>
@@ -796,6 +797,14 @@
    </property>
    <property name="text">
     <string>Show Model Doc&amp;k Points</string>
+   </property>
+  </action>
+  <action name="actionHighlight_Selectable_Subsystems">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Highlight Selectable Subsystems</string>
    </property>
   </action>
   <action name="actionShow_Grid">

--- a/qtfred/ui/FredView.ui
+++ b/qtfred/ui/FredView.ui
@@ -67,6 +67,7 @@
      <string>E&amp;dit</string>
     </property>
     <addaction name="actionUndo"/>
+    <addaction name="actionClone_Marked_Objects"/>
     <addaction name="actionDelete"/>
     <addaction name="actionDelete_Wing"/>
     <addaction name="separator"/>
@@ -635,6 +636,11 @@
   <action name="actionUndo">
    <property name="text">
     <string>&amp;Undo</string>
+   </property>
+  </action>
+  <action name="actionClone_Marked_Objects">
+   <property name="text">
+    <string>&amp;Clone Marked Objects</string>
    </property>
   </action>
   <action name="actionDelete">

--- a/qtfred/ui/FredView.ui
+++ b/qtfred/ui/FredView.ui
@@ -213,16 +213,18 @@
     <property name="title">
      <string>&amp;Misc</string>
     </property>
-    <addaction name="actionLevel_Object"/>
-    <addaction name="actionAlign_Object"/>
-    <addaction name="actionMark_Wing"/>
-    <addaction name="actionControl_Object"/>
     <addaction name="actionNext_Object"/>
     <addaction name="actionPrev_Object"/>
-    <addaction name="actionAdjust_Grid"/>
+    <addaction name="actionControl_Object"/>
+    <addaction name="actionLevel_Object"/>
+    <addaction name="actionAlign_Object"/>
+    <addaction name="separator"/>
     <addaction name="actionNext_Subsystem"/>
     <addaction name="actionPrev_Subsystem"/>
     <addaction name="actionCancel_Subsystem"/>
+    <addaction name="separator"/>
+    <addaction name="actionMark_Wing"/>
+    <addaction name="actionAdjust_Grid"/>
     <addaction name="actionMission_Statistics"/>
     <addaction name="separator"/>
     <addaction name="actionError_Checker"/>
@@ -570,7 +572,7 @@
     <string>OrbitSelected</string>
    </property>
    <property name="toolTip">
-    <string>Rotate about Selected (Alt+R)</string>
+    <string>Rotate Around Object (Alt+R)</string>
    </property>
    <property name="shortcut">
     <string>Alt+R</string>
@@ -894,7 +896,7 @@
     <bool>true</bool>
    </property>
    <property name="text">
-    <string>&amp;Lighting from Suns...</string>
+    <string>&amp;Lighting from Suns</string>
    </property>
   </action>
   <action name="actionCamera">
@@ -1310,38 +1312,6 @@
     <string>Group &amp;9</string>
    </property>
   </action>
-  <action name="actionLevel_Object">
-   <property name="text">
-    <string>&amp;Level Object</string>
-   </property>
-   <property name="shortcut">
-    <string>L</string>
-   </property>
-  </action>
-  <action name="actionAlign_Object">
-   <property name="text">
-    <string>&amp;Align Object</string>
-   </property>
-   <property name="shortcut">
-    <string>Ctrl+L</string>
-   </property>
-  </action>
-  <action name="actionMark_Wing">
-   <property name="text">
-    <string>&amp;Mark Wing</string>
-   </property>
-   <property name="shortcut">
-    <string>W</string>
-   </property>
-  </action>
-  <action name="actionControl_Object">
-   <property name="text">
-    <string>&amp;Control Object</string>
-   </property>
-   <property name="shortcut">
-    <string>T</string>
-   </property>
-  </action>
   <action name="actionNext_Object">
    <property name="text">
     <string>&amp;Next Object</string>
@@ -1358,9 +1328,28 @@
     <string>Ctrl+Tab</string>
    </property>
   </action>
-  <action name="actionAdjust_Grid">
+  <action name="actionControl_Object">
    <property name="text">
-    <string>Adjust &amp;Grid</string>
+    <string>&amp;Control Object</string>
+   </property>
+   <property name="shortcut">
+    <string>T</string>
+   </property>
+  </action>
+  <action name="actionLevel_Object">
+   <property name="text">
+    <string>&amp;Level Object</string>
+   </property>
+   <property name="shortcut">
+    <string>L</string>
+   </property>
+  </action>
+  <action name="actionAlign_Object">
+   <property name="text">
+    <string>&amp;Align Object</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+L</string>
    </property>
   </action>
   <action name="actionNext_Subsystem">
@@ -1385,6 +1374,19 @@
    </property>
    <property name="shortcut">
     <string>Alt+K</string>
+   </property>
+  </action>
+  <action name="actionMark_Wing">
+   <property name="text">
+    <string>&amp;Mark Wing</string>
+   </property>
+   <property name="shortcut">
+    <string>W</string>
+   </property>
+  </action>
+  <action name="actionAdjust_Grid">
+   <property name="text">
+    <string>Adjust &amp;Grid</string>
    </property>
   </action>
   <action name="actionMission_Statistics">


### PR DESCRIPTION
There are several updates to the menu in FRED that hadn't yet been ported over to qtFRED.  This PR ports over the changes to the menu and toolbars, viz. a few added menu options, a menu reorganization, some caption changes, and some shortcut key changes.

This partially addresses #3341.