### PR TITLE
Training message preservation

### DIFF
--- a/code/mission/missiontraining.cpp
+++ b/code/mission/missiontraining.cpp
@@ -922,6 +922,15 @@ void message_training_queue_check()
 	if (Training_failure)
 		return;
 
+	// don't pre-empt any voice files that are playing
+	for (int i = 0; i < Num_messages_playing; ++i)
+	{
+		if ((Playing_messages[i].wave.isValid()) && (snd_time_remaining(Playing_messages[i].wave) > 250))
+			return;
+	}
+	if (fsspeech_playing())
+		return;
+
 	for (i=0; i<Training_message_queue_count; i++) {
 		if (timestamp_elapsed(Training_message_queue[i].timestamp)) {
 			message_training_setup(Training_message_queue[i].num, Training_message_queue[i].length, Training_message_queue[i].special_message);

--- a/code/mission/missiontraining.cpp
+++ b/code/mission/missiontraining.cpp
@@ -27,6 +27,7 @@
 #include "popup/popup.h"
 #include "ship/ship.h"
 #include "sound/audiostr.h"
+#include "sound/fsspeech.h"
 #include "sound/sound.h"
 #include "weapon/emp.h"
 
@@ -922,14 +923,16 @@ void message_training_queue_check()
 	if (Training_failure)
 		return;
 
-	// don't pre-empt any voice files that are playing
-	for (int i = 0; i < Num_messages_playing; ++i)
-	{
-		if ((Playing_messages[i].wave.isValid()) && (snd_time_remaining(Playing_messages[i].wave) > 250))
+	if (Dont_preempt_training_voice) {
+		// don't pre-empt any voice files that are playing
+		if (Training_voice >= 0) {
+			auto z = (Training_voice_type) ? audiostream_is_playing(Training_voice_soundstream) : snd_is_playing(Training_voice_snd_handle);
+			if (z)
+				return;
+		}
+		if (fsspeech_playing())
 			return;
 	}
-	if (fsspeech_playing())
-		return;
 
 	for (i=0; i<Training_message_queue_count; i++) {
 		if (timestamp_elapsed(Training_message_queue[i].timestamp)) {

--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -43,6 +43,7 @@ gameversion::version Targetted_version; // Defaults to retail
 SCP_string Window_title;
 bool Unicode_text_mode;
 bool Use_tabled_strings_for_default_language;
+bool Dont_preempt_training_voice;
 SCP_string Movie_subtitle_font;
 bool Enable_scripts_in_fred; // By default FRED does not initialize the scripting system
 SCP_string Window_icon_path;
@@ -116,13 +117,21 @@ void parse_mod_table(const char *filename)
 		if (optional_string("$Unicode mode:")) {
 			stuff_boolean(&Unicode_text_mode);
 
-			mprintf(("Game settings table: Unicode mode: %s\n", Unicode_text_mode ? "yes" : "no"));
+			mprintf(("Game Settings Table: Unicode mode: %s\n", Unicode_text_mode ? "yes" : "no"));
 		}
+
+		optional_string("#LOCALIZATION SETTINGS");
 
 		if (optional_string("$Use tabled strings for the default language:")) {
 			stuff_boolean(&Use_tabled_strings_for_default_language);
 
-			mprintf(("Game settings table: Use tabled strings (translations) for the default language: %s\n", Use_tabled_strings_for_default_language ? "yes" : "no"));
+			mprintf(("Game Settings Table: Use tabled strings (translations) for the default language: %s\n", Use_tabled_strings_for_default_language ? "yes" : "no"));
+		}
+
+		if (optional_string("$Don't pre-empt training message voice:")) {
+			stuff_boolean(&Dont_preempt_training_voice);
+
+			mprintf(("Game Settings Table: %sre-empting training message voice\n", Dont_preempt_training_voice ? "Not p" : "P"));
 		}
 
 		optional_string("#CAMPAIGN SETTINGS");

--- a/code/mod_table/mod_table.h
+++ b/code/mod_table/mod_table.h
@@ -35,6 +35,7 @@ extern float Shield_pain_flash_factor;
 extern SCP_string Window_title;
 extern bool Unicode_text_mode;
 extern bool Use_tabled_strings_for_default_language;
+extern bool Dont_preempt_training_voice;
 extern SCP_string Movie_subtitle_font;
 extern bool Enable_scripts_in_fred;
 extern SCP_string Window_icon_path;


### PR DESCRIPTION
This adds a setting to game_settings.tbl to allow training messages to play to their full duration.  This avoids them getting pre-empted by other messages as noted in #3202.

To use, add this to game_settings.tbl:
```
#LOCALIZATION SETTINGS

$Don't pre-empt training message voice: true
```

Fixes #3202.