### PR TITLE
log when missions are skipped due to XSTR mismatch

### DIFF
--- a/code/menuui/readyroom.cpp
+++ b/code/menuui/readyroom.cpp
@@ -477,8 +477,12 @@ int build_standalone_mission_list_do_frame()
 			// activate tstrings check
 			Lcl_unexpected_tstring_check = &lcl_weirdness;
 
-			// check if we can list the mission, if loading basic info didn't return an error code, and if we didn't find an unexpected XSTR mismatch
+			// check if we can list the mission, if loading basic info didn't return an error code, and if we didn't find an XSTR mismatch
 			bool condition = !mission_is_ignored(filename) && !get_mission_info(filename) && !lcl_weirdness;
+
+			// maybe log
+			if (lcl_weirdness)
+				mprintf(("Skipping %s due to XSTR mismatch\n", filename));
 
 			// deactivate tstrings check
 			Lcl_unexpected_tstring_check = nullptr;

--- a/code/network/multiui.cpp
+++ b/code/network/multiui.cpp
@@ -4513,6 +4513,10 @@ void multi_create_list_load_missions()
 
 		flags = mission_parse_is_multi(filename, mission_name);
 
+		// maybe log
+		if (lcl_weirdness)
+			mprintf(("Skipping %s due to XSTR mismatch\n", filename));
+
 		// deactivate tstrings check
 		Lcl_unexpected_tstring_check = nullptr;
 


### PR DESCRIPTION
As a follow-up to #2343, users might wonder why their mission isn't showing up in the tech room, so log a friendly message.