### PR TITLE
Minor improvement for generic debris on subsystems

### DIFF
--- a/code/ship/shipfx.cpp
+++ b/code/ship/shipfx.cpp
@@ -359,8 +359,10 @@ void shipfx_blow_up_model(object *obj, int submodel, int ndebris, vec3d *exp_cen
 
 	// made a change to allow anyone but multiplayer client to blow up hull.  Clients will do it when
 	// they get the create packet
+	bool use_ship_debris = false;
 	if ( submodel == 0 ) {
 		shipfx_blow_up_hull(obj, pm, pmi, exp_center);
+		use_ship_debris = true;
 	}
 
 	for (i=0; i<ndebris; i++ )	{
@@ -374,7 +376,7 @@ void shipfx_blow_up_model(object *obj, int submodel, int ndebris, vec3d *exp_cen
 		vm_vec_avg( &tmp, &pnt1, &pnt2 );
 		model_instance_find_world_point(&outpnt, &tmp, pm, pmi, submodel, &obj->orient, &obj->pos );
 
-		debris_create( obj, Ship_info[Ships[obj->instance].ship_info_index].generic_debris_model_num, -1, &outpnt, exp_center, 0, 1.0f );
+		debris_create( obj, use_ship_debris ? Ship_info[Ships[obj->instance].ship_info_index].generic_debris_model_num : -1, -1, &outpnt, exp_center, 0, 1.0f );
 	}
 }
 


### PR DESCRIPTION
If the ship has a specially defined generic debris model, don't use it for subsystem destruction. The entire ship and and its subsystems are usually quite different in size, and so look very silly if they spew generic debris sized for an 'entire ship' explosion. Possibly different kinds of generic debris for subsystem destruction and weapon impacts is on the table, but I'll uh, defer that until asked for. For now, it is only meant for when the ship explodes.