### PR TITLE
Force portable if unicode

### DIFF
--- a/code/osapi/osapi.cpp
+++ b/code/osapi/osapi.cpp
@@ -54,7 +54,8 @@ namespace
 						"Report at www.hard-light.net or the hard-light discord.", SDL_GetError());
 					sdl_is_borked_warning = true;
 				}
-				// No preferences path, try current directory.  
+				// No preferences path, try current directory.
+				Cmdline_portable_mode = true;
 				return "." DIR_SEPARATOR_STR;
 		    }
 #ifdef WIN32
@@ -64,15 +65,21 @@ namespace
 			    while (current != prefPathEnd) {
 				    const auto cp = utf8::next(current, prefPathEnd);
 				    if (cp > 127) {
-					    // On Windows, we currently do not support Unicode paths so catch this early and let the user
+					    // On Windows, we currently do not support Unicode paths so force portable mode let the user
 					    // know
 					    const auto invalid_end = current;
-					    utf8::prior(current, preferencesPath);
-					    Error(LOCATION,
-					          "Determined the preferences path as \"%s\". That path is not supported since it "
-					          "contains a Unicode character (%s). If possible, choose a different user name or "
-					          "use portable mode.",
-					          preferencesPath, std::string(current, invalid_end).c_str());
+						static bool force_portable_warning = false;
+						if (!force_portable_warning) {
+							utf8::prior(current, preferencesPath);
+							ReleaseWarning(LOCATION,
+								"Determined the preferences path as \"%s\". That path is not supported since it "
+								"contains a Unicode character (%s). Using portable mode. Set -portable_mode in "
+								"the commandline to avoid this message in the future.",
+								preferencesPath, std::string(current, invalid_end).c_str());
+							force_portable_warning = true;
+						}
+						Cmdline_portable_mode = true;
+						return "." DIR_SEPARATOR_STR;
 				    }
 			    }
 		    } catch (const std::exception& e) {


### PR DESCRIPTION
This allows FSO to assume that it's in portable mode if it detects Unicode characters in the path provided by SDL.  I tested this by creating a local account with Unicode characters.  It not only runs as expected, but also keeps Knossos from getting stuck on the executable when trying to parse the command line.  

Fixes #3173 