### PR TITLE
add Draw Outlines on Selected Ships option

### DIFF
--- a/fred2/fred.cpp
+++ b/fred2/fred.cpp
@@ -233,8 +233,9 @@ BOOL CFREDApp::InitInstance() {
 	// Goober5000
 	Mission_save_format = GetProfileInt("Preferences", "FS2 open format", FSO_FORMAT_STANDARD);
 	Mission_save_format = GetProfileInt("Preferences", "Mission save format", Mission_save_format);
-	Move_ships_when_undocking = GetProfileInt("Preferences", "Move ships when undocking", Move_ships_when_undocking);
+	Move_ships_when_undocking = GetProfileInt("Preferences", "Move ships when undocking", 1);
 	Highlight_selectable_subsys = GetProfileInt("Preferences", "Highlight selectable subsys", Highlight_selectable_subsys);
+	Draw_outlines_on_selected_ships = GetProfileInt("Preferences", "Draw outlines on selected ships", 1) != 0;
 
 	read_window("Main window", &Main_wnd_data);
 	read_window("Ship window", &Ship_wnd_data);
@@ -497,6 +498,7 @@ void CFREDApp::write_ini_file(int degree) {
 	WriteProfileInt("Preferences", "Mission save format", Mission_save_format);
 	WriteProfileInt("Preferences", "Move ships when undocking", Move_ships_when_undocking);
 	WriteProfileInt("Preferences", "Highlight selectable subsys", Highlight_selectable_subsys);
+	WriteProfileInt("Preferences", "Draw outlines on selected ships", Draw_outlines_on_selected_ships ? 1 : 0);
 
 	if (!degree) {
 		record_window_data(&Waypoint_wnd_data, &Waypoint_editor_dialog);

--- a/fred2/fred.rc
+++ b/fred2/fred.rc
@@ -254,6 +254,7 @@ BEGIN
         MENUITEM SEPARATOR
         MENUITEM "Show Ship Models\tShift+Alt+M", 32820, CHECKED
         MENUITEM "Show Outlines\tShift+Alt+O",  32980
+        MENUITEM "Draw Outlines on Selected Ships",      32982, CHECKED
         MENUITEM "Show Ship Info\tShift+Alt+I", 32823, CHECKED, HELP
         MENUITEM "Show Coordinates\tShift+Alt+C", 32915
         MENUITEM "Show Grid Positions\tShift+Alt+P", 32914

--- a/fred2/fredrender.cpp
+++ b/fred2/fredrender.cpp
@@ -70,7 +70,7 @@ static char THIS_FILE[] = __FILE__;
 #define CONVERT_DEGREES 57.29578f   // conversion factor from radians to degrees
 
 #define FRED_COLOUR_WHITE	0xffffff
-#define FRED_COLOUR_YELLOW	0x9fff00
+#define FRED_COLOUR_YELLOW	0xffff00
 
 const float FRED_DEFAULT_HTL_FOV = 0.485f;
 const float FRED_BRIEFING_HTL_FOV = 0.325f;
@@ -99,6 +99,7 @@ int Show_grid = 1;
 int Show_grid_positions = 1;
 int Show_horizon = 0;
 int Show_outlines = 0;
+bool Draw_outlines_on_selected_ships = false;
 int Show_stars = 1;
 int Single_axis_constraint = 0;
 int True_rw, True_rh;
@@ -1780,7 +1781,11 @@ void render_one_model_htl(object *objp) {
 
 	rendering_order[render_count] = OBJ_INDEX(objp);
 	Fred_outline = 0;
-	if ((OBJ_INDEX(objp) == cur_object_index) && !Bg_bitmap_dialog)
+
+	if (!Draw_outlines_on_selected_ships && ((OBJ_INDEX(objp) == cur_object_index) || (objp->flags[Object::Object_Flags::Marked])))
+		/* don't draw the outlines we would normally draw */;
+
+	else if ((OBJ_INDEX(objp) == cur_object_index) && !Bg_bitmap_dialog)
 		Fred_outline = FRED_COLOUR_WHITE;
 
 	else if ((objp->flags[Object::Object_Flags::Marked]) && !Bg_bitmap_dialog)  // is it a marked object?
@@ -1931,7 +1936,11 @@ void render_one_model_nohtl(object *objp) {
 
 	rendering_order[render_count] = OBJ_INDEX(objp);
 	Fred_outline = 0;
-	if ((OBJ_INDEX(objp) == cur_object_index) && !Bg_bitmap_dialog)
+
+	if (!Draw_outlines_on_selected_ships && ((OBJ_INDEX(objp) == cur_object_index) || (objp->flags[Object::Object_Flags::Marked])))
+		/* don't draw the outlines we would normally draw */;
+
+	else if ((OBJ_INDEX(objp) == cur_object_index) && !Bg_bitmap_dialog)
 		Fred_outline = FRED_COLOUR_WHITE;
 
 	else if ((objp->flags[Object::Object_Flags::Marked]) && !Bg_bitmap_dialog)  // is it a marked object?

--- a/fred2/fredrender.cpp
+++ b/fred2/fredrender.cpp
@@ -69,8 +69,8 @@ static char THIS_FILE[] = __FILE__;
 #define LOLLIPOP_SIZE   2.5f
 #define CONVERT_DEGREES 57.29578f   // conversion factor from radians to degrees
 
-#define FRED_COLOUR_WHITE	0xffffff
-#define FRED_COLOUR_YELLOW	0xffff00
+#define FRED_COLOUR_WHITE			0xffffff
+#define FRED_COLOUR_YELLOW_GREEN	0xc8ff00
 
 const float FRED_DEFAULT_HTL_FOV = 0.485f;
 const float FRED_BRIEFING_HTL_FOV = 0.325f;
@@ -129,7 +129,7 @@ CWnd info_popup;
 color colour_black;
 color colour_green;
 color colour_white;
-color colour_yellow;
+color colour_yellow_green;
 
 static vec3d Global_light_world = { 0.208758f, -0.688253f, -0.694782f };
 
@@ -493,7 +493,7 @@ void display_ship_info() {
 		if (OBJ_INDEX(objp) == cur_object_index)
 			Fred_outline = FRED_COLOUR_WHITE;
 		else if (objp->flags[Object::Object_Flags::Marked])  // is it a marked object?
-			Fred_outline = FRED_COLOUR_YELLOW;
+			Fred_outline = FRED_COLOUR_YELLOW_GREEN;
 		else
 			Fred_outline = 0;
 
@@ -557,8 +557,8 @@ void display_ship_info() {
 				if (*buf) {
 					if (Fred_outline == FRED_COLOUR_WHITE)
 						gr_set_color_fast(&colour_green);
-					else if (Fred_outline == FRED_COLOUR_YELLOW)
-						gr_set_color_fast(&colour_yellow);
+					else if (Fred_outline == FRED_COLOUR_YELLOW_GREEN)
+						gr_set_color_fast(&colour_yellow_green);
 					else
 						gr_set_color_fast(&colour_white);
 
@@ -916,7 +916,7 @@ void fred_render_init() {
 
 	gr_init_alphacolor(&colour_white, 255, 255, 255, 255);
 	gr_init_alphacolor(&colour_green, 0, 200, 0, 255);
-	gr_init_alphacolor(&colour_yellow, 200, 255, 0, 255);
+	gr_init_alphacolor(&colour_yellow_green, 200, 255, 0, 255);
 	gr_init_alphacolor(&colour_black, 0, 0, 0, 255);
 }
 
@@ -1789,7 +1789,7 @@ void render_one_model_htl(object *objp) {
 		Fred_outline = FRED_COLOUR_WHITE;
 
 	else if ((objp->flags[Object::Object_Flags::Marked]) && !Bg_bitmap_dialog)  // is it a marked object?
-		Fred_outline = FRED_COLOUR_YELLOW;
+		Fred_outline = FRED_COLOUR_YELLOW_GREEN;
 
 	else if ((objp->type == OBJ_SHIP) && Show_outlines) {
 		color *iff_color = iff_get_color_by_team_and_object(Ships[objp->instance].team, -1, 1, objp);
@@ -1944,7 +1944,7 @@ void render_one_model_nohtl(object *objp) {
 		Fred_outline = FRED_COLOUR_WHITE;
 
 	else if ((objp->flags[Object::Object_Flags::Marked]) && !Bg_bitmap_dialog)  // is it a marked object?
-		Fred_outline = FRED_COLOUR_YELLOW;
+		Fred_outline = FRED_COLOUR_YELLOW_GREEN;
 
 	else if ((objp->type == OBJ_SHIP) && Show_outlines) {
 		color *iff_color = iff_get_color_by_team_and_object(Ships[objp->instance].team, -1, 1, objp);

--- a/fred2/fredrender.h
+++ b/fred2/fredrender.h
@@ -21,6 +21,7 @@ extern int Show_grid;       //!< Bool. If nonzero, draw the grid
 extern int Show_grid_positions;     //!< Bool. If nonzero, draw an elevation line from each object to the grid.
 extern int Show_coordinates;        //!< Bool. If nonzero, draw the coordinates of each object on their label
 extern int Show_outlines;           //!< Bool. If nonzero, draw each object's mesh. If models are shown, highlight them in white.
+extern bool Draw_outlines_on_selected_ships;	// If a ship is selected, don't draw the mesh lines that would normally be drawn
 extern int Show_stars;              //!< Bool. If nonzero, draw the starfield, nebulas, and suns. Might also handle skyboxes
 extern int Single_axis_constraint;  //!< Bool. If nonzero, constrain movement to one axis
 extern int Show_distances;          //!< Bool. If nonzero, draw lines between each object and display their distance on the middle of each line

--- a/fred2/fredview.cpp
+++ b/fred2/fredview.cpp
@@ -251,6 +251,8 @@ BEGIN_MESSAGE_MAP(CFREDView, CView)
 	ON_COMMAND(ID_EDITORS_WAYPOINT, OnEditorsWaypoint)
 	ON_COMMAND(ID_VIEW_OUTLINES, OnViewOutlines)
 	ON_UPDATE_COMMAND_UI(ID_VIEW_OUTLINES, OnUpdateViewOutlines)
+	ON_COMMAND(ID_VIEW_OUTLINES_ON_SELECTED, OnViewOutlinesOnSelected)
+	ON_UPDATE_COMMAND_UI(ID_VIEW_OUTLINES_ON_SELECTED, OnUpdateViewOutlinesOnSelected)
 	ON_UPDATE_COMMAND_UI(ID_NEW_SHIP_TYPE, OnUpdateNewShipType)
 	ON_COMMAND(ID_SHOW_STARFIELD, OnShowStarfield)
 	ON_UPDATE_COMMAND_UI(ID_SHOW_STARFIELD, OnUpdateShowStarfield)
@@ -3758,6 +3760,18 @@ void CFREDView::OnViewOutlines()
 void CFREDView::OnUpdateViewOutlines(CCmdUI* pCmdUI) 
 {
 	pCmdUI->SetCheck(Show_outlines);
+}
+
+void CFREDView::OnViewOutlinesOnSelected() 
+{
+	Draw_outlines_on_selected_ships = !Draw_outlines_on_selected_ships;
+	theApp.write_ini_file();
+	Update_window = 1;
+}
+
+void CFREDView::OnUpdateViewOutlinesOnSelected(CCmdUI* pCmdUI) 
+{
+	pCmdUI->SetCheck(Draw_outlines_on_selected_ships);
 }
 
 void CFREDView::OnUpdateNewShipType(CCmdUI* pCmdUI) 

--- a/fred2/fredview.h
+++ b/fred2/fredview.h
@@ -215,6 +215,8 @@ protected:
 	afx_msg void OnEditorsWaypoint();
 	afx_msg void OnViewOutlines();
 	afx_msg void OnUpdateViewOutlines(CCmdUI* pCmdUI);
+	afx_msg void OnViewOutlinesOnSelected();
+	afx_msg void OnUpdateViewOutlinesOnSelected(CCmdUI* pCmdUI);
 	afx_msg void OnUpdateNewShipType(CCmdUI* pCmdUI);
 	afx_msg void OnShowStarfield();
 	afx_msg void OnUpdateShowStarfield(CCmdUI* pCmdUI);

--- a/fred2/resource.h
+++ b/fred2/resource.h
@@ -1334,6 +1334,7 @@
 #define ID_EDITORS_WAYPOINT             32979
 #define ID_VIEW_OUTLINES                32980
 #define ID_NEW_SHIP_TYPE                32981
+#define ID_VIEW_OUTLINES_ON_SELECTED    32982
 #define ID_SHOW_STARFIELD               32983
 #define ID_ASTEROID_EDITOR              32984
 #define ID_RUN_FREESPACE                32985

--- a/qtfred/src/mission/EditorViewport.h
+++ b/qtfred/src/mission/EditorViewport.h
@@ -20,6 +20,7 @@ struct ViewSettings {
 	bool Aa_gridlines = false;
 	bool Show_coordinates = false;
 	bool Show_outlines = false;
+	bool Draw_outlines_on_selected_ships = true;
 	bool Show_grid_positions = true;
 	bool Show_dock_points = false;
 	bool Show_starts = true;

--- a/qtfred/src/mission/FredRenderer.cpp
+++ b/qtfred/src/mission/FredRenderer.cpp
@@ -800,7 +800,10 @@ void FredRenderer::render_one_model_htl(object* objp,
 	}
 
 	Fred_outline = 0;
-	if ((OBJ_INDEX(objp) == cur_object_index) && !Bg_bitmap_dialog) {
+
+	if (!view().Draw_outlines_on_selected_ships && ((OBJ_INDEX(objp) == cur_object_index) || (objp->flags[Object::Object_Flags::Marked]))) {
+		/* don't draw the outlines we would normally draw */;
+	} else if ((OBJ_INDEX(objp) == cur_object_index) && !Bg_bitmap_dialog) {
 		Fred_outline = FRED_COLOUR_WHITE;
 	} else if ((objp->flags[Object::Object_Flags::Marked]) && !Bg_bitmap_dialog) { // is it a marked object?
 		Fred_outline = FRED_COLOUR_YELLOW;

--- a/qtfred/src/mission/FredRenderer.cpp
+++ b/qtfred/src/mission/FredRenderer.cpp
@@ -35,7 +35,7 @@ const float FRED_DEFAULT_HTL_FOV = 0.485f;
 const float FRED_DEAFULT_HTL_DRAW_DIST = 300000.0f;
 
 const int FRED_COLOUR_WHITE = 0xffffff;
-const int FRED_COLOUR_YELLOW = 0x9fff00;
+const int FRED_COLOUR_YELLOW_GREEN = 0xc8ff00;
 
 const int BRIEFING_LOOKAT_POINT_ID = 99999;
 
@@ -57,7 +57,7 @@ bool fred_colors_inited = false;
 color colour_white;
 color colour_green;
 color colour_black;
-color colour_yellow;
+color colour_yellow_green;
 
 void init_fred_colors() {
 	if (fred_colors_inited) {
@@ -68,7 +68,7 @@ void init_fred_colors() {
 
 	gr_init_alphacolor(&colour_white, 255, 255, 255, 255);
 	gr_init_alphacolor(&colour_green, 0, 200, 0, 255);
-	gr_init_alphacolor(&colour_yellow, 200, 255, 0, 255);
+	gr_init_alphacolor(&colour_yellow_green, 200, 255, 0, 255);
 	gr_init_alphacolor(&colour_black, 0, 0, 0, 255);
 }
 
@@ -435,7 +435,7 @@ void FredRenderer::display_ship_info(int cur_object_index) {
 		if (OBJ_INDEX(objp) == cur_object_index) {
 			Fred_outline = FRED_COLOUR_WHITE;
 		} else if (objp->flags[Object::Object_Flags::Marked]) { // is it a marked object?
-			Fred_outline = FRED_COLOUR_YELLOW;
+			Fred_outline = FRED_COLOUR_YELLOW_GREEN;
 		} else {
 			Fred_outline = 0;
 		}
@@ -502,8 +502,8 @@ void FredRenderer::display_ship_info(int cur_object_index) {
 				if (*buf) {
 					if (Fred_outline == FRED_COLOUR_WHITE) {
 						gr_set_color_fast(&colour_green);
-					} else if (Fred_outline == FRED_COLOUR_YELLOW) {
-						gr_set_color_fast(&colour_yellow);
+					} else if (Fred_outline == FRED_COLOUR_YELLOW_GREEN) {
+						gr_set_color_fast(&colour_yellow_green);
 					} else {
 						gr_set_color_fast(&colour_white);
 					}
@@ -806,7 +806,7 @@ void FredRenderer::render_one_model_htl(object* objp,
 	} else if ((OBJ_INDEX(objp) == cur_object_index) && !Bg_bitmap_dialog) {
 		Fred_outline = FRED_COLOUR_WHITE;
 	} else if ((objp->flags[Object::Object_Flags::Marked]) && !Bg_bitmap_dialog) { // is it a marked object?
-		Fred_outline = FRED_COLOUR_YELLOW;
+		Fred_outline = FRED_COLOUR_YELLOW_GREEN;
 	} else if ((objp->type == OBJ_SHIP) && view().Show_outlines) {
 		color* iff_color = iff_get_color_by_team_and_object(Ships[objp->instance].team, -1, 1, objp);
 

--- a/qtfred/src/ui/FredView.cpp
+++ b/qtfred/src/ui/FredView.cpp
@@ -270,6 +270,7 @@ void FredView::syncViewOptions() {
 
 	connectActionToViewSetting(ui->actionShow_Ship_Models, &_viewport->view.Show_ship_models);
 	connectActionToViewSetting(ui->actionShow_Outlines, &_viewport->view.Show_outlines);
+	connectActionToViewSetting(ui->actionDraw_Outlines_On_Selected_Ships, &_viewport->view.Draw_outlines_on_selected_ships);
 	connectActionToViewSetting(ui->actionShow_Ship_Info, &_viewport->view.Show_ship_info);
 	connectActionToViewSetting(ui->actionShow_Coordinates, &_viewport->view.Show_coordinates);
 	connectActionToViewSetting(ui->actionShow_Grid_Positions, &_viewport->view.Show_grid_positions);

--- a/qtfred/ui/FredView.ui
+++ b/qtfred/ui/FredView.ui
@@ -103,6 +103,7 @@
     <addaction name="separator"/>
     <addaction name="actionShow_Ship_Models"/>
     <addaction name="actionShow_Outlines"/>
+    <addaction name="actionDraw_Outlines_On_Selected_Ships"/>
     <addaction name="actionShow_Ship_Info"/>
     <addaction name="actionShow_Coordinates"/>
     <addaction name="actionShow_Grid_Positions"/>
@@ -757,6 +758,14 @@
    </property>
    <property name="shortcut">
     <string>Alt+Shift+O</string>
+   </property>
+  </action>
+  <action name="actionDraw_Outlines_On_Selected_Ships">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Draw Outlines on Selected Ships</string>
    </property>
   </action>
   <action name="actionShow_Coordinates">


### PR DESCRIPTION
This option is helpful because the mesh outlines will often obscure important information like submodel names and turret weapons.