### PR TITLE
fix briefing icons changing to ships unexpectedly

### DIFF
--- a/code/mission/missionbriefcommon.cpp
+++ b/code/mission/missionbriefcommon.cpp
@@ -649,8 +649,21 @@ briefing_icon_info *brief_get_icon_info(brief_icon *bi)
 		return NULL;
 	ship_info *sip = &Ship_info[bi->ship_class];
 
+	bool allow_override = true;
+	switch (bi->type)
+	{
+		case ICON_PLANET:
+		case ICON_ASTEROID_FIELD:
+		case ICON_WAYPOINT:
+		case ICON_UNKNOWN:
+		case ICON_UNKNOWN_WING:
+		case ICON_JUMP_NODE:
+			allow_override = false;
+			break;
+	}
+
 	// ship info might override the usual briefing icon
-	if (sip->bii_index_ship >= 0)
+	if (allow_override && sip->bii_index_ship >= 0)
 	{
 		if (bi->flags & BI_USE_WING_ICON)
 		{

--- a/code/missionui/missionbrief.cpp
+++ b/code/missionui/missionbrief.cpp
@@ -1225,7 +1225,6 @@ int brief_setup_closeup(brief_icon *bi)
 	vec3d			tvec;
 
 	Closeup_icon = bi;
-	Closeup_icon->ship_class = bi->ship_class;
 	Closeup_icon->modelnum = -1;
 	Closeup_icon->model_instance_num = -1;
 


### PR DESCRIPTION
If the briefing icon doesn't actually show a ship, then don't use the ship icon override.

Also remove a redundant assignment.