### PR TITLE
Remove extra AI Profiles call

### DIFF
--- a/fred2/management.cpp
+++ b/fred2/management.cpp
@@ -850,7 +850,6 @@ void clear_mission()
 	obj_init();
 	model_free_all();				// Free all existing models
 	ai_init();
-	ai_profiles_init();
 	ship_init();
 	jumpnode_level_close();
 	waypoint_level_close();

--- a/qtfred/src/mission/Editor.cpp
+++ b/qtfred/src/mission/Editor.cpp
@@ -394,7 +394,6 @@ void Editor::clearMission() {
 	obj_init();
 	model_free_all();                // Free all existing models
 	ai_init();
-	ai_profiles_init();
 	ship_init();
 	jumpnode_level_close();
 	waypoint_level_close();


### PR DESCRIPTION
This function has to be called on game/FRED/qtFRED start, and returns immediately every time after that.  So there is no reason for it to be hear on mission close.