### PR TITLE
Fix a nullptr bug with change_ship_type

### DIFF
--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -10880,9 +10880,10 @@ void change_ship_type(int n, int ship_type, int by_sexp)
 		for (i = 0; i < MAX_REPLACEMENT_TEXTURES; i++)
 			sp->ship_replacement_textures[i] = -1;
 
-		if (p_objp != nullptr) {
+		if (p_objp != nullptr) 
+		{
 			// now fill them in according to texture name
-			for (SCP_vector<texture_replace>::iterator tr = p_objp->replacement_textures.begin(); tr != p_objp->replacement_textures.end(); ++tr)
+			for (const auto &tr : p_objp->replacement_textures)
 			{
 				int j;
 				polymodel* pm = model_get(sip->model_num);
@@ -10892,9 +10893,9 @@ void change_ship_type(int n, int ship_type, int by_sexp)
 				{
 					texture_map* tmap = &pm->maps[j];
 
-					int tnum = tmap->FindTexture(tr->old_texture);
+					int tnum = tmap->FindTexture(tr.old_texture);
 					if (tnum > -1)
-						sp->ship_replacement_textures[j * TM_NUM_TYPES + tnum] = tr->new_texture_id;
+						sp->ship_replacement_textures[j * TM_NUM_TYPES + tnum] = tr.new_texture_id;
 				}
 			}
 		}

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -10540,10 +10540,10 @@ void change_ship_type(int n, int ship_type, int by_sexp)
 	// Mantis 2763: moved down to have access to the right ship_max_shield_strength value
 	// make sure that shields are disabled/enabled if they need to be - Chief1983
 	if (!Fred_running) {
-		if ((p_objp->flags[Mission::Parse_Object_Flags::OF_Force_shields_on]) && (sp->ship_max_shield_strength > 0.0f)) {
+		if ((p_objp != nullptr && p_objp->flags[Mission::Parse_Object_Flags::OF_Force_shields_on]) && (sp->ship_max_shield_strength > 0.0f)) {
 			objp->flags.remove(Object::Object_Flags::No_shields);
 		}
-		else if ((p_objp->flags[Mission::Parse_Object_Flags::OF_No_shields]) || (sp->ship_max_shield_strength == 0.0f)) {
+		else if ((p_objp != nullptr && p_objp->flags[Mission::Parse_Object_Flags::OF_No_shields]) || (sp->ship_max_shield_strength == 0.0f)) {
 			objp->flags.set(Object::Object_Flags::No_shields);
 			// Since there's not a mission flag set to be adjusting this, see if there was a change from a ship that normally has shields to one that doesn't, and vice versa
 		}
@@ -10874,26 +10874,28 @@ void change_ship_type(int n, int ship_type, int by_sexp)
 	}
 
 	// Goober5000 - deal with texture replacement by re-applying the same code we used during parsing
-	if (sp->ship_replacement_textures != NULL)
+	if (sp->ship_replacement_textures != nullptr)
 	{
 		// clear them out because the new positions may be different
 		for (i = 0; i < MAX_REPLACEMENT_TEXTURES; i++)
 			sp->ship_replacement_textures[i] = -1;
 
-		// now fill them in according to texture name
-		for (SCP_vector<texture_replace>::iterator tr = p_objp->replacement_textures.begin(); tr != p_objp->replacement_textures.end(); ++tr)
-		{
-			int j;
-			polymodel *pm = model_get(sip->model_num);
-
-			// look for textures
-			for (j = 0; j < pm->n_textures; j++)
+		if (p_objp != nullptr) {
+			// now fill them in according to texture name
+			for (SCP_vector<texture_replace>::iterator tr = p_objp->replacement_textures.begin(); tr != p_objp->replacement_textures.end(); ++tr)
 			{
-				texture_map *tmap = &pm->maps[j];
+				int j;
+				polymodel* pm = model_get(sip->model_num);
 
-				int tnum = tmap->FindTexture(tr->old_texture);
-				if(tnum > -1)
-					sp->ship_replacement_textures[j * TM_NUM_TYPES + tnum] = tr->new_texture_id;
+				// look for textures
+				for (j = 0; j < pm->n_textures; j++)
+				{
+					texture_map* tmap = &pm->maps[j];
+
+					int tnum = tmap->FindTexture(tr->old_texture);
+					if (tnum > -1)
+						sp->ship_replacement_textures[j * TM_NUM_TYPES + tnum] = tr->new_texture_id;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Always ensure that `p_objp` is not null before accessing it, SEXP or script created ships will have no parse object. There is only one other place where `p_objp` is accessed https://github.com/scp-fs2open/fs2open.github.com/blob/master/code/ship/ship.cpp#L10855, but this apparently will only happen in the loadout screen so it should be safe.

As for texture replacements, (as always the diff is confusing but I just wrapped it in p_objp != nullptr) as the comment states, the new positions may be different so we can't import the old ones and if this ship also doesn't have a parse object then it's out of luck and will need to have texture-replace reran on it.