### PR TITLE
Move some flag setting to subsys_set()

### DIFF
--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -2300,7 +2300,7 @@ int parse_create_object_sub(p_object *p_objp)
 			}
 		}
 
-		if (shipp->flags[Ship::Ship_Flags::Lock_all_turrets_initially] || ptr->system_info->flags[Model::Subsystem_Flags::Turret_locked])
+		if (shipp->flags[Ship::Ship_Flags::Lock_all_turrets_initially])
 		{
 			// mark all turrets as locked
 			if(ptr->system_info->type == SUBSYSTEM_TURRET)

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -2289,17 +2289,6 @@ int parse_create_object_sub(p_object *p_objp)
 		if (!ptr)
 			continue;
 
-		// check the mission flag to possibly free all beam weapons - Goober5000, taken from SEXP.CPP
-		if (The_mission.flags[Mission::Mission_Flags::Beam_free_all_by_default])
-		{
-			// mark all turrets as beam free
-			if(ptr->system_info->type == SUBSYSTEM_TURRET)
-			{
-				ptr->weapons.flags.set(Ship::Weapon_Flags::Beam_Free);
-				ptr->turret_next_fire_stamp = timestamp((int) frand_range(50.0f, 4000.0f));
-			}
-		}
-
 		if (shipp->flags[Ship::Ship_Flags::Lock_all_turrets_initially])
 		{
 			// mark all turrets as locked

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -7099,6 +7099,7 @@ static int subsys_set(int objnum, int ignore_subsys_info)
 			ship_system->flags.set(Ship::Subsystem_Flags::No_autorepair_if_disabled);
 		if (model_system->flags[Model::Subsystem_Flags::Turret_locked])
 			ship_system->weapons.flags.set(Ship::Weapon_Flags::Turret_Lock);
+		// check the mission flag to possibly free all beam weapons - Goober5000, taken from SEXP.CPP, and moved to subsys_set() by Asteroth
 		if (The_mission.flags[Mission::Mission_Flags::Beam_free_all_by_default]) 
 			ship_system->weapons.flags.set(Ship::Weapon_Flags::Beam_Free);
 

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -7097,6 +7097,10 @@ static int subsys_set(int objnum, int ignore_subsys_info)
 			ship_system->flags.set(Ship::Subsystem_Flags::Autorepair_if_disabled);
 		if (model_system->flags[Model::Subsystem_Flags::No_autorepair_if_disabled])
 			ship_system->flags.set(Ship::Subsystem_Flags::No_autorepair_if_disabled);
+		if (model_system->flags[Model::Subsystem_Flags::Turret_locked])
+			ship_system->weapons.flags.set(Ship::Weapon_Flags::Turret_Lock);
+		if (The_mission.flags[Mission::Mission_Flags::Beam_free_all_by_default]) 
+			ship_system->weapons.flags.set(Ship::Weapon_Flags::Beam_Free);
 
 		ship_system->turn_rate = model_system->turn_rate;
 


### PR DESCRIPTION
Some more bugs from assumptions of ships having parse objects. Beam free by default and turrets that are supposed to start locked should be handled in `subsys_set()` instead of just `parse_create_object_sub()`. I would've liked to remove `Beam_free_all_by_default` handling from `parse_create_object_sub()` entirely, in addition to starting locked, since it should be redundant now, but turrets freed in this way have their initial fire timestamp set to a different value for some reason. 