### PR TITLE
Adding basic Vampirism Capabilities to weapons

### DIFF
--- a/code/ship/shiphit.cpp
+++ b/code/ship/shiphit.cpp
@@ -2387,6 +2387,27 @@ static void ship_do_damage(object *ship_objp, object *other_obj, vec3d *hitpos, 
 				apply_diff_scale = false;
 			}
 		}
+			// if weapon is vampiric, slap healing on shooter instead of target
+		if (Weapons[other_obj->instance].weapon_info_index >= 0){
+			weapon_info *wip = &Weapon_info[Weapons[other_obj->instance].weapon_info_index];
+			if (wip->wi_flags[Weapon::Info_Flags::Vampiric]){
+				if (other_obj->parent > 0){
+					object* parent = &Objects[other_obj->parent];
+					if (parent->type == OBJ_SHIP) {
+						if (parent->signature == other_obj->parent_sig){
+							ship* shipparent = &Ships[parent->instance];
+							if (!parent->flags[Object::Object_Flags::Should_be_dead]) {
+								parent->hull_strength += damage * wip->succ_factor;
+								if (parent->hull_strength > shipparent->ship_max_hull_strength){
+									parent->hull_strength = shipparent->ship_max_hull_strength;
+								}
+							}
+						}
+					}
+				}
+			}
+		
+		}
 		// Nuke: this is done incase difficulty scaling is not applied into damage by getDamage() above
 		if (apply_diff_scale) {
 			damage *= difficulty_scale_factor; // Nuke: we can finally stop doing this now

--- a/code/weapon/weapon.h
+++ b/code/weapon/weapon.h
@@ -473,7 +473,10 @@ struct weapon_info
 	// Energy suck effect
 	float weapon_reduce;					// how much energy removed from weapons systems
 	float afterburner_reduce;			// how much energy removed from weapons systems
-
+	
+	// Vampirism Effect -Strygon 7/23/2021
+	float succ_factor;					// Factor by which a vampiric weapon will multiply the healing done to the shooter
+	
 	// tag stuff
 	float	tag_time;						// how long the tag lasts		
 	int tag_level;							// tag level (1 - 3)

--- a/code/weapon/weapon_flags.h
+++ b/code/weapon/weapon_flags.h
@@ -87,6 +87,7 @@ namespace Weapon {
 		Require_exact_los,					// If secondary or in turret, will only fire if ship has line of sight to target
 		Can_damage_shooter,					// this weapon and any of its descendants can damage its shooter - Asteroth
 		Heals,								// 'damage' heals instead of actually damaging - Asteroth
+		Vampiric,							// damage applied also brings back health to the shooter - Strygon
 		No_collide,
 
         NUM_VALUES

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -186,6 +186,7 @@ flag_def_list_new<Weapon::Info_Flags> Weapon_Info_Flags[] = {
 	{ "require exact los",				Weapon::Info_Flags::Require_exact_los,					true, false },
 	{ "can damage shooter",				Weapon::Info_Flags::Can_damage_shooter,					true, false },
 	{ "heals",							Weapon::Info_Flags::Heals,						        true, false },
+	{ "vampiric",						Weapon::Info_Flags::Vampiric,					        true, false },
 	{ "no collide",						Weapon::Info_Flags::No_collide,						    true, false },
 };
 

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -2174,6 +2174,11 @@ int parse_weapon(int subtype, bool replace, const char *filename)
 	if( optional_string("$Leech Afterburner:") ){
 		stuff_float(&wip->afterburner_reduce);
 	}
+	
+	// Multiplier for the healing done to the shooter of the weapon.
+	if( optional_string("$Vampiric Healing Factor:") ){
+		stuff_float(&wip->succ_factor);
+	}
 
 	if (optional_string("$Corkscrew:"))
 	{


### PR DESCRIPTION
By giving a weapon the "Vampirism" flag and specifying a "$Vampiric Healing Factor" (taking suggestions for better names) in the tables allows a weapon to heal the shooter by the amount of raw damage dealt by the weapon, multiplied by the healing factor. 

This is currently a fairly basic framework and I'm open to suggestions/ideas on how to further expand this, if desired.

As of now, this does NOT work with beams or shockwaves due to a problem with weapon_info_index registering as -1 and causing crashes. So both types of damage currently do not deal any healing (but they also won't crash the game anymore).

It does however, work with primaries and secondaries.