### PR TITLE
fix Time To: Unknown on the HUD

### DIFF
--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -15867,9 +15867,13 @@ char *ship_return_time_to_goal(char *outbuf, ship *sp)
 			seconds = 99;
 		}
 		sprintf(outbuf, NOX("%02d:%02d"), minutes, seconds);
-	
-	} else {
+
+	} else if ( time == -1 ) {
 		strcpy( outbuf, XSTR( "Unknown", 497) );
+
+	} else {
+		// we don't want to display anything on the HUD
+		return nullptr;
 	}
 
 	return outbuf;


### PR DESCRIPTION
PR #3064 inadvertently caused all goals to display Time To: Unknown, even though time was only supplied for docking and waypoints.  This restores the original behavior where the Time To: line simply wasn't displayed.