### PR TITLE
Anim Rework Phase 1 Fixes

### DIFF
--- a/code/model/modelanimation.cpp
+++ b/code/model/modelanimation.cpp
@@ -103,12 +103,20 @@ namespace animation {
 		}
 	}
 	
-	void ModelAnimation::start(polymodel_instance* pmi, bool reverse) {
+	void ModelAnimation::start(polymodel_instance* pmi, bool reverse, bool force) {
 		if (reverse) {
 			switch (m_state[pmi->id]) {
 			case ModelAnimationState::RUNNING_RWD:
 			case ModelAnimationState::UNTRIGGERED:
 				//Cannot reverse-start if it's already running rwd or fully untriggered
+
+				//If forced, reset and play anyways
+				if (force) {
+					m_time[pmi->id] = m_duration;
+					m_state[pmi->id] = ModelAnimationState::RUNNING_RWD;
+					break;
+				}
+
 				return;
 			case ModelAnimationState::RUNNING_FWD:
 				//Just pretend we were going in the right direction
@@ -124,6 +132,14 @@ namespace animation {
 			case ModelAnimationState::RUNNING_FWD:
 			case ModelAnimationState::COMPLETED:
 				//Cannot start if it's already running fwd or fully triggered
+
+				//If forced, reset and play anyways
+				if (force) {
+					m_time[pmi->id] = 0;
+					m_state[pmi->id] = ModelAnimationState::RUNNING_FWD;
+					break;
+				}
+
 				return;
 			case ModelAnimationState::RUNNING_RWD:
 				//Just pretend we were going in the right direction
@@ -404,7 +420,7 @@ namespace animation {
 		const auto& initialAnims = sip->animations.animationSet[{animation::ModelAnimationTriggerType::Initial, animation::ModelAnimationSet::SUBTYPE_DEFAULT}];
 
 		for (const auto& anim : initialAnims) {
-			anim.second->start(model_get_instance(shipp->model_instance_num), false);
+			anim.second->start(model_get_instance(shipp->model_instance_num), false, true);
 		}
 	}
 }

--- a/code/model/modelanimation.cpp
+++ b/code/model/modelanimation.cpp
@@ -242,11 +242,11 @@ namespace animation {
 		//since sp->type is not set without reading the pof, we need to infer it by subsystem name (which works, since the same name is used to match the submodels name, which is used to match the type in pof parsing)
 		//sadly, we also need to check for engine and radar, since these take precedent (as in, an engineturret is an engine before a turret type)
 		if (!strstr(namelower, "engine") && !strstr(namelower, "radar") && strstr(namelower, "turret")) {
-			auto rotBase = std::unique_ptr<ModelAnimationSegmentSetAngle>(new ModelAnimationSegmentSetAngle(angle.p));
+			auto rotBase = std::unique_ptr<ModelAnimationSegmentSetAngle>(new ModelAnimationSegmentSetAngle(angle.h));
 			auto subsysBase = std::unique_ptr<ModelAnimationSubmodel>(new ModelAnimationSubmodel(sp->subobj_name, false, sip, std::move(rotBase)));
 			anim->addSubsystemAnimation(std::move(subsysBase));
 
-			auto rotBarrel = std::unique_ptr<ModelAnimationSegmentSetAngle>(new ModelAnimationSegmentSetAngle(angle.h));
+			auto rotBarrel = std::unique_ptr<ModelAnimationSegmentSetAngle>(new ModelAnimationSegmentSetAngle(angle.p));
 			auto subsysBarrel = std::unique_ptr<ModelAnimationSubmodel>(new ModelAnimationSubmodel(sp->subobj_name, true, sip, std::move(rotBarrel)));
 			anim->addSubsystemAnimation(std::move(subsysBarrel));
 		}

--- a/code/model/modelanimation.h
+++ b/code/model/modelanimation.h
@@ -179,7 +179,7 @@ namespace animation {
 		void addSubsystemAnimation(std::unique_ptr<ModelAnimationSubmodel> animation);
 
 		//Start playing the animation. Will stop other animations that have components running on the same submodels
-		void start(polymodel_instance* pmi, bool reverse);
+		void start(polymodel_instance* pmi, bool reverse, bool force = false);
 		//Stops the animation. If cleanup is set, it will remove the animation from the list of running animations. Don't call without cleanup unless you know what you are doing
 		void stop(polymodel_instance* pmi, bool cleanup = true);
 

--- a/code/model/modelread.cpp
+++ b/code/model/modelread.cpp
@@ -4398,7 +4398,7 @@ void model_set_up_techroom_instance(ship_info *sip, int model_instance_num)
 		const auto& initialAnims = sip->animations.animationSet[{animation::ModelAnimationTriggerType::Initial, animation::ModelAnimationSet::SUBTYPE_DEFAULT}];
 
 		for (const auto& initialAnim : initialAnims) {
-			initialAnim.second->start(pmi, false);
+			initialAnim.second->start(pmi, false, true);
 		}
 
 		if (msp->subobj_num >= 0)


### PR DESCRIPTION
Fixes two issues identified with the Animation Rework first Phase:
1. Multipart turrets had base and turret angles switched.
2. Initial Type Animations, when called again (due to something like FRED saving and reloading), have already been "completed" and will not start again. This introduces a "forced reset and start" mode for animations, to handle cases like these initial type animations restarting instead of not continuing. Might also be useful for other types of animations in the F3 lab later.