### PR TITLE
Animation Rework Phase 1 Fixes #2

### DIFF
--- a/code/model/model.h
+++ b/code/model/model.h
@@ -82,6 +82,7 @@ struct submodel_instance
 {
 	float	cur_angle = 0.0f;							// The current angle this thing is turned to.
 	float	prev_angle = 0.0f;
+	float	turret_idle_angle = 0.0f;				// If this is a turret, this is the expected idling angle of the submodel
 
 	float	current_turn_rate = 0.0f;
 	float	desired_turn_rate = 0.0f;

--- a/code/model/modelanimation.cpp
+++ b/code/model/modelanimation.cpp
@@ -259,11 +259,11 @@ namespace animation {
 		//sadly, we also need to check for engine and radar, since these take precedent (as in, an engineturret is an engine before a turret type)
 		if (!strstr(namelower, "engine") && !strstr(namelower, "radar") && strstr(namelower, "turret")) {
 			auto rotBase = std::unique_ptr<ModelAnimationSegmentSetAngle>(new ModelAnimationSegmentSetAngle(angle.h));
-			auto subsysBase = std::unique_ptr<ModelAnimationSubmodel>(new ModelAnimationSubmodel(sp->subobj_name, false, sip, std::move(rotBase)));
+			auto subsysBase = std::unique_ptr<ModelAnimationSubmodel>(new ModelAnimationSubmodelTurret(sp->subobj_name, false, sip, std::move(rotBase)));
 			anim->addSubsystemAnimation(std::move(subsysBase));
 
 			auto rotBarrel = std::unique_ptr<ModelAnimationSegmentSetAngle>(new ModelAnimationSegmentSetAngle(angle.p));
-			auto subsysBarrel = std::unique_ptr<ModelAnimationSubmodel>(new ModelAnimationSubmodel(sp->subobj_name, true, sip, std::move(rotBarrel)));
+			auto subsysBarrel = std::unique_ptr<ModelAnimationSubmodel>(new ModelAnimationSubmodelTurret(sp->subobj_name, true, sip, std::move(rotBarrel)));
 			anim->addSubsystemAnimation(std::move(subsysBarrel));
 		}
 		else {
@@ -283,8 +283,6 @@ namespace animation {
 
 
 	ModelAnimationSubmodel::ModelAnimationSubmodel(SCP_string submodelName, std::unique_ptr<ModelAnimationSegment> mainSegment) : m_name(std::move(submodelName)), m_mainSegment(std::move(mainSegment)) { }
-
-	ModelAnimationSubmodel::ModelAnimationSubmodel(SCP_string subsystemName, bool findBarrel, ship_info* sip, std::unique_ptr<ModelAnimationSegment> mainSegment) : m_name(std::move(subsystemName)), m_findBarrel(findBarrel), m_sip(sip), m_mainSegment(std::move(mainSegment)) { }
 
 	void ModelAnimationSubmodel::play(float frametime, polymodel_instance* pmi) {
 		auto dataIt = m_initialData.find(pmi->id);
@@ -327,6 +325,7 @@ namespace animation {
 			return;
 
 		submodel->canonical_orient = data.orientation;
+
 		//TODO: Once translation is a thing
 		//m_subsys->submodel_instance_1->offset = data.position;
 	}
@@ -358,29 +357,6 @@ namespace animation {
 		//Do we have a submodel number already cached?
 		if (m_submodel.has())
 			submodelNumber = m_submodel;
-		//Do we know if we were told to find the barrel submodel or not? This implies we have a subsystem name, not a submodel name
-		else if (m_findBarrel.has()) {
-
-			if(m_sip == nullptr)
-				return { nullptr, nullptr };
-
-			for (int i = 0; i < m_sip->n_subsystems; i++) {
-				if (!subsystem_stricmp(m_sip->subsystems[i].subobj_name, m_name.c_str())) {
-					if ((bool)m_findBarrel) {
-						//Check if the barrel subobj is a dedicated existing subobj or just the base turret.
-						if (m_sip->subsystems[i].turret_gun_sobj != m_sip->subsystems[i].subobj_num)
-							submodelNumber = m_sip->subsystems[i].turret_gun_sobj;
-						else
-							submodelNumber = -1;
-					}
-					else
-						submodelNumber = m_sip->subsystems[i].subobj_num;
-					break;
-				}
-			}
-
-			m_submodel = submodelNumber;
-		}
 		//We seem to have a submodel name
 		else {
 			for (int i = 0; i < pm->n_models; i++) {
@@ -399,6 +375,75 @@ namespace animation {
 			return { nullptr, nullptr };
 
 		return { &pmi->submodel[submodelNumber], &pm->submodel[submodelNumber] };
+	}
+
+	ModelAnimationSubmodelTurret::ModelAnimationSubmodelTurret(SCP_string subsystemName, bool findBarrel, ship_info* sip, std::unique_ptr<ModelAnimationSegment> mainSegment) : ModelAnimationSubmodel(std::move(subsystemName), std::move(mainSegment)), m_findBarrel(findBarrel), m_sipIndex(sip - &Ship_info[0]) { }
+
+	std::pair<submodel_instance*, bsp_info*> ModelAnimationSubmodelTurret::findSubmodel(polymodel_instance* pmi) {
+		//Ship was deleted
+		if (pmi->id < 0)
+			return { nullptr, nullptr };
+
+		int submodelNumber = -1;
+
+		polymodel* pm = model_get(pmi->model_num);
+
+		//Do we have a submodel number already cached?
+		if (m_submodel.has())
+			submodelNumber = m_submodel;
+		//Do we know if we were told to find the barrel submodel or not? This implies we have a subsystem name, not a submodel name
+		else {
+
+			if (m_sipIndex < 0 || m_sipIndex >= Ship_info.size())
+				return { nullptr, nullptr };
+
+			ship_info* sip = &Ship_info[m_sipIndex];
+
+			for (int i = 0; i < sip->n_subsystems; i++) {
+				if (!subsystem_stricmp(sip->subsystems[i].subobj_name, m_name.c_str())) {
+					if ((bool)m_findBarrel) {
+						//Check if the barrel subobj is a dedicated existing subobj or just the base turret.
+						if (sip->subsystems[i].turret_gun_sobj != sip->subsystems[i].subobj_num) 
+							submodelNumber = sip->subsystems[i].turret_gun_sobj;
+						else
+							submodelNumber = -1;
+					}
+					else 
+						submodelNumber = sip->subsystems[i].subobj_num;
+					break;
+				}
+			}
+
+			m_submodel = submodelNumber;
+		}
+
+		//If the model does not exist, return null. The system is expected to just silently tolerate this,
+		//as this needs to be the case to be able to handle turrets whose barrels may or may not exist, depending on the pof which is not loaded at table parse time
+		if (submodelNumber < 0 || submodelNumber >= pm->n_models)
+			return { nullptr, nullptr };
+
+		return { &pmi->submodel[submodelNumber], &pm->submodel[submodelNumber] };
+	}
+
+	//To handle Multipart-turrets properly, they need a modified version that sets the actual angle, not just the orientation matrix.
+	void ModelAnimationSubmodelTurret::copyToSubmodel(const ModelAnimationData<>& data, polymodel_instance* pmi) {
+		submodel_instance* submodel = findSubmodel(pmi).first;
+
+		if (!submodel)
+			return;
+
+		submodel->canonical_orient = data.orientation;
+
+		float angle;
+		vec3d axis;
+		vm_matrix_to_rot_axis_and_angle(&submodel->canonical_orient, &angle, &axis);
+		while (angle > PI2)
+			angle -= PI2;
+		while (angle < 0.0f)
+			angle += PI2;
+
+		submodel->cur_angle = angle;
+		submodel->turret_idle_angle = angle;
 	}
 
 

--- a/code/model/modelanimation.cpp
+++ b/code/model/modelanimation.cpp
@@ -259,11 +259,11 @@ namespace animation {
 		//sadly, we also need to check for engine and radar, since these take precedent (as in, an engineturret is an engine before a turret type)
 		if (!strstr(namelower, "engine") && !strstr(namelower, "radar") && strstr(namelower, "turret")) {
 			auto rotBase = std::unique_ptr<ModelAnimationSegmentSetAngle>(new ModelAnimationSegmentSetAngle(angle.h));
-			auto subsysBase = std::unique_ptr<ModelAnimationSubmodel>(new ModelAnimationSubmodelTurret(sp->subobj_name, false, sip, std::move(rotBase)));
+			auto subsysBase = std::unique_ptr<ModelAnimationSubmodelTurret>(new ModelAnimationSubmodelTurret(sp->subobj_name, false, sip, std::move(rotBase)));
 			anim->addSubsystemAnimation(std::move(subsysBase));
 
 			auto rotBarrel = std::unique_ptr<ModelAnimationSegmentSetAngle>(new ModelAnimationSegmentSetAngle(angle.p));
-			auto subsysBarrel = std::unique_ptr<ModelAnimationSubmodel>(new ModelAnimationSubmodelTurret(sp->subobj_name, true, sip, std::move(rotBarrel)));
+			auto subsysBarrel = std::unique_ptr<ModelAnimationSubmodelTurret>(new ModelAnimationSubmodelTurret(sp->subobj_name, true, sip, std::move(rotBarrel)));
 			anim->addSubsystemAnimation(std::move(subsysBarrel));
 		}
 		else {
@@ -377,7 +377,7 @@ namespace animation {
 		return { &pmi->submodel[submodelNumber], &pm->submodel[submodelNumber] };
 	}
 
-	ModelAnimationSubmodelTurret::ModelAnimationSubmodelTurret(SCP_string subsystemName, bool findBarrel, ship_info* sip, std::unique_ptr<ModelAnimationSegment> mainSegment) : ModelAnimationSubmodel(std::move(subsystemName), std::move(mainSegment)), m_findBarrel(findBarrel), m_sipIndex(sip - &Ship_info[0]) { }
+	ModelAnimationSubmodelTurret::ModelAnimationSubmodelTurret(SCP_string subsystemName, bool findBarrel, ship_info* sip, std::unique_ptr<ModelAnimationSegment> mainSegment) : ModelAnimationSubmodel(std::move(subsystemName), std::move(mainSegment)), m_sipIndex((int) (sip - &Ship_info[0])), m_findBarrel(findBarrel) { }
 
 	std::pair<submodel_instance*, bsp_info*> ModelAnimationSubmodelTurret::findSubmodel(polymodel_instance* pmi) {
 		//Ship was deleted
@@ -394,7 +394,7 @@ namespace animation {
 		//Do we know if we were told to find the barrel submodel or not? This implies we have a subsystem name, not a submodel name
 		else {
 
-			if (m_sipIndex < 0 || m_sipIndex >= Ship_info.size())
+			if (m_sipIndex < 0 || m_sipIndex >= ship_info_size())
 				return { nullptr, nullptr };
 
 			ship_info* sip = &Ship_info[m_sipIndex];

--- a/code/model/modelanimation.h
+++ b/code/model/modelanimation.h
@@ -146,6 +146,7 @@ namespace animation {
 		//Create a submodel animation based on the name of the submodel
 		ModelAnimationSubmodel(SCP_string submodelName, std::unique_ptr<ModelAnimationSegment> mainSegment);
 
+		virtual ~ModelAnimationSubmodel() = default;
 
 		//Sets the animation to the specified time and applies it to the submodel
 		void play(float time, polymodel_instance* pmi);

--- a/code/model/modelanimation.h
+++ b/code/model/modelanimation.h
@@ -130,10 +130,11 @@ namespace animation {
 	
 
 	class ModelAnimationSubmodel {
+	protected:
 		SCP_string m_name;
 		optional<int> m_submodel;
-		optional<bool> m_findBarrel;
-		ship_info* m_sip = nullptr;
+		
+	private:
 		std::unique_ptr<ModelAnimationSegment> m_mainSegment;
 		//Polymodel Instance ID -> ModelAnimationData
 		std::map<int, ModelAnimationData<>> m_initialData;
@@ -144,8 +145,7 @@ namespace animation {
 	public:
 		//Create a submodel animation based on the name of the submodel
 		ModelAnimationSubmodel(SCP_string submodelName, std::unique_ptr<ModelAnimationSegment> mainSegment);
-		//Create a submodel animation by taking the submodel assigned to a subsystem with a given name, or, if requested, the submodel of the turret barrel
-		ModelAnimationSubmodel(SCP_string subsystemName, bool findBarrel, ship_info* sip, std::unique_ptr<ModelAnimationSegment> mainSegment);
+
 
 		//Sets the animation to the specified time and applies it to the submodel
 		void play(float time, polymodel_instance* pmi);
@@ -156,8 +156,21 @@ namespace animation {
 		//Set the submodels current state as the base for the animation, recalculate the animation data (e.g. take this as the base for absolutely defined angles)
 		float saveCurrentAsBase(polymodel_instance* pmi);
 		//Reapply the calculated animation state to the submodel
-		void copyToSubmodel(const ModelAnimationData<>& data, polymodel_instance* pmi);
-		std::pair<submodel_instance*, bsp_info*> findSubmodel(polymodel_instance* pmi);
+		virtual void copyToSubmodel(const ModelAnimationData<>& data, polymodel_instance* pmi);
+		virtual std::pair<submodel_instance*, bsp_info*> findSubmodel(polymodel_instance* pmi);
+	};
+
+	class ModelAnimationSubmodelTurret : public ModelAnimationSubmodel {
+		int m_sipIndex = -1;
+		bool m_findBarrel;
+		void copyToSubmodel(const ModelAnimationData<>& data, polymodel_instance* pmi) override;
+		std::pair<submodel_instance*, bsp_info*> findSubmodel(polymodel_instance* pmi) override;
+
+	public:
+		/*Create a submodel animation by taking the submodel assigned to a subsystem with a given name, or, if requested, the submodel of the turret barrel.
+		Due to how turrets work in FSO, this should never be given a segment that does anything but rotate the turret around its axis
+		*/
+		ModelAnimationSubmodelTurret(SCP_string subsystemName, bool findBarrel, ship_info* sip, std::unique_ptr<ModelAnimationSegment> mainSegment);
 	};
 
 

--- a/code/model/modelread.cpp
+++ b/code/model/modelread.cpp
@@ -3895,14 +3895,11 @@ int model_rotate_gun(object *objp, polymodel *pm, polymodel_instance *pmi, ship_
 		base_smi->canonical_orient = save_base_orient;
 
 	} else {
-		desired_base_angle = 0.0f;
+		desired_base_angle = base_smi->turret_idle_angle;
 		desired_gun_angle = 0.0f;
-		if (turret->n_triggers > 0) {
-			int i;
-			for (i = 0; i<turret->n_triggers; i++) {
-				desired_gun_angle = turret->triggers[i].angle.xyz.x;
-				desired_base_angle = turret->triggers[i].angle.xyz.y;
-			}
+
+		if ((turret->subobj_num != turret->turret_gun_sobj)) {
+			desired_gun_angle = gun_smi->turret_idle_angle;
 		}
 	}
 

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -1481,6 +1481,8 @@ void ship_info::move(ship_info&& other)
 	std::swap(pathMetadata, other.pathMetadata);
 
 	std::swap(glowpoint_bank_override_map, other.glowpoint_bank_override_map);
+
+	std::swap(animations, other.animations);
 }
 
 #define CHECK_THEN_FREE(attribute) \


### PR DESCRIPTION
Adds a missing copy function in the ship_info class missing so far that was occasionally clearing the animations before,
Additionally, convert turret-based AnimationSubmodels into their own child class to properly modularize that code due to all the required exceptions for turret handling everywhere. Also properly sets cur_angle and desired_base/gun_angle for proper behaviour once the turrets target anything.