### PR TITLE
Animation Rework Phase 1 Fixes #3

### DIFF
--- a/code/model/modelanimation.cpp
+++ b/code/model/modelanimation.cpp
@@ -169,7 +169,7 @@ namespace animation {
 			cleanRunning();
 	}
 
-	void ModelAnimation::addSubsystemAnimation(std::unique_ptr<ModelAnimationSubmodel> animation) {
+	void ModelAnimation::addSubmodelAnimation(std::shared_ptr<ModelAnimationSubmodel> animation) {
 		m_submodelAnimation.push_back(std::move(animation));
 	}
 
@@ -258,21 +258,21 @@ namespace animation {
 		//since sp->type is not set without reading the pof, we need to infer it by subsystem name (which works, since the same name is used to match the submodels name, which is used to match the type in pof parsing)
 		//sadly, we also need to check for engine and radar, since these take precedent (as in, an engineturret is an engine before a turret type)
 		if (!strstr(namelower, "engine") && !strstr(namelower, "radar") && strstr(namelower, "turret")) {
-			auto rotBase = std::unique_ptr<ModelAnimationSegmentSetAngle>(new ModelAnimationSegmentSetAngle(angle.h));
-			auto subsysBase = std::unique_ptr<ModelAnimationSubmodelTurret>(new ModelAnimationSubmodelTurret(sp->subobj_name, false, sip, std::move(rotBase)));
-			anim->addSubsystemAnimation(std::move(subsysBase));
+			auto rotBase = std::shared_ptr<ModelAnimationSegmentSetAngle>(new ModelAnimationSegmentSetAngle(angle.h));
+			auto subsysBase = std::shared_ptr<ModelAnimationSubmodelTurret>(new ModelAnimationSubmodelTurret(sp->subobj_name, false, sip->name, std::move(rotBase)));
+			anim->addSubmodelAnimation(std::move(subsysBase));
 
-			auto rotBarrel = std::unique_ptr<ModelAnimationSegmentSetAngle>(new ModelAnimationSegmentSetAngle(angle.p));
-			auto subsysBarrel = std::unique_ptr<ModelAnimationSubmodelTurret>(new ModelAnimationSubmodelTurret(sp->subobj_name, true, sip, std::move(rotBarrel)));
-			anim->addSubsystemAnimation(std::move(subsysBarrel));
+			auto rotBarrel = std::shared_ptr<ModelAnimationSegmentSetAngle>(new ModelAnimationSegmentSetAngle(angle.p));
+			auto subsysBarrel = std::shared_ptr<ModelAnimationSubmodelTurret>(new ModelAnimationSubmodelTurret(sp->subobj_name, true, sip->name, std::move(rotBarrel)));
+			anim->addSubmodelAnimation(std::move(subsysBarrel));
 		}
 		else {
-			auto rot = std::unique_ptr<ModelAnimationSegmentSetPHB>(new ModelAnimationSegmentSetPHB(angle, isRelative));
-			auto subsys = std::unique_ptr<ModelAnimationSubmodel>(new ModelAnimationSubmodel(sp->subobj_name, std::move(rot)));
-			anim->addSubsystemAnimation(std::move(subsys));
+			auto rot = std::shared_ptr<ModelAnimationSegmentSetPHB>(new ModelAnimationSegmentSetPHB(angle, isRelative));
+			auto subsys = std::shared_ptr<ModelAnimationSubmodel>(new ModelAnimationSubmodel(sp->subobj_name, std::move(rot)));
+			anim->addSubmodelAnimation(std::move(subsys));
 		}
 
-		sip->animations.emplace(anim, "", animation::ModelAnimationTriggerType::Initial);
+		sip->animations.emplace(anim, sp->subobj_name, animation::ModelAnimationTriggerType::Initial);
 	}
 
 	/*std::shared_ptr<ModelAnimation> ModelAnimation::parseAnimationTable() {
@@ -282,7 +282,11 @@ namespace animation {
 	}*/
 
 
-	ModelAnimationSubmodel::ModelAnimationSubmodel(SCP_string submodelName, std::unique_ptr<ModelAnimationSegment> mainSegment) : m_name(std::move(submodelName)), m_mainSegment(std::move(mainSegment)) { }
+	ModelAnimationSubmodel::ModelAnimationSubmodel(SCP_string submodelName, std::shared_ptr<ModelAnimationSegment> mainSegment) : m_name(std::move(submodelName)), m_mainSegment(std::move(mainSegment)) { }
+
+	ModelAnimationSubmodel* ModelAnimationSubmodel::copy(SCP_string newSIPname) {
+		return new ModelAnimationSubmodel(*this);
+	}
 
 	void ModelAnimationSubmodel::play(float frametime, polymodel_instance* pmi) {
 		auto dataIt = m_initialData.find(pmi->id);
@@ -377,7 +381,13 @@ namespace animation {
 		return { &pmi->submodel[submodelNumber], &pm->submodel[submodelNumber] };
 	}
 
-	ModelAnimationSubmodelTurret::ModelAnimationSubmodelTurret(SCP_string subsystemName, bool findBarrel, ship_info* sip, std::unique_ptr<ModelAnimationSegment> mainSegment) : ModelAnimationSubmodel(std::move(subsystemName), std::move(mainSegment)), m_sipIndex((int) (sip - &Ship_info[0])), m_findBarrel(findBarrel) { }
+	ModelAnimationSubmodelTurret::ModelAnimationSubmodelTurret(SCP_string subsystemName, bool findBarrel, SCP_string SIPname, std::shared_ptr<ModelAnimationSegment> mainSegment) : ModelAnimationSubmodel(std::move(subsystemName), std::move(mainSegment)), m_SIPname(std::move(SIPname)), m_findBarrel(findBarrel) { }
+
+	ModelAnimationSubmodel* ModelAnimationSubmodelTurret::copy(SCP_string newSIPname) {
+		ModelAnimationSubmodelTurret* anim = new ModelAnimationSubmodelTurret(*this);
+		anim->m_SIPname = newSIPname;
+		return anim;
+	}
 
 	std::pair<submodel_instance*, bsp_info*> ModelAnimationSubmodelTurret::findSubmodel(polymodel_instance* pmi) {
 		//Ship was deleted
@@ -394,16 +404,16 @@ namespace animation {
 		//Do we know if we were told to find the barrel submodel or not? This implies we have a subsystem name, not a submodel name
 		else {
 
-			if (m_sipIndex < 0 || m_sipIndex >= ship_info_size())
+			int sip_index = ship_info_lookup(m_SIPname.c_str());
+			ship_info* sip = &Ship_info[sip_index];
+			if (sip->subsystems == nullptr)
 				return { nullptr, nullptr };
-
-			ship_info* sip = &Ship_info[m_sipIndex];
 
 			for (int i = 0; i < sip->n_subsystems; i++) {
 				if (!subsystem_stricmp(sip->subsystems[i].subobj_name, m_name.c_str())) {
 					if ((bool)m_findBarrel) {
 						//Check if the barrel subobj is a dedicated existing subobj or just the base turret.
-						if (sip->subsystems[i].turret_gun_sobj != sip->subsystems[i].subobj_num) 
+						if (sip->subsystems[i].turret_gun_sobj != sip->subsystems[i].subobj_num)
 							submodelNumber = sip->subsystems[i].turret_gun_sobj;
 						else
 							submodelNumber = -1;
@@ -456,6 +466,24 @@ namespace animation {
 
 	void ModelAnimationSet::emplace(const std::shared_ptr<ModelAnimation>& animation, const SCP_string& name, ModelAnimationTriggerType type, int subtype) {
 		animationSet[{type, subtype}].emplace(name, animation);
+	}
+
+	void ModelAnimationSet::changeShipName(SCP_string name) {
+		decltype(animationSet) newAnimationSet;
+
+		for (const auto& animationTypes : animationSet) {
+			auto& newAnimations = newAnimationSet[animationTypes.first];
+			for (const auto& oldAnimation : animationTypes.second) {
+				std::shared_ptr<ModelAnimation> newAnimation = std::shared_ptr<ModelAnimation>(new ModelAnimation());
+				for (const auto& submodelAnims : oldAnimation.second->m_submodelAnimation) {
+					std::shared_ptr<ModelAnimationSubmodel> animSubmodel = std::shared_ptr<ModelAnimationSubmodel>(submodelAnims->copy(name));
+					newAnimation->addSubmodelAnimation(std::move(animSubmodel));
+				}
+				newAnimations.emplace(oldAnimation.first, newAnimation);
+			}
+		}
+
+		animationSet = newAnimationSet;
 	}
 
 

--- a/code/model/modelanimation.cpp
+++ b/code/model/modelanimation.cpp
@@ -284,7 +284,7 @@ namespace animation {
 
 	ModelAnimationSubmodel::ModelAnimationSubmodel(SCP_string submodelName, std::shared_ptr<ModelAnimationSegment> mainSegment) : m_name(std::move(submodelName)), m_mainSegment(std::move(mainSegment)) { }
 
-	ModelAnimationSubmodel* ModelAnimationSubmodel::copy(SCP_string newSIPname) {
+	ModelAnimationSubmodel* ModelAnimationSubmodel::copy(const SCP_string& /*newSIPname*/) {
 		return new ModelAnimationSubmodel(*this);
 	}
 
@@ -383,8 +383,8 @@ namespace animation {
 
 	ModelAnimationSubmodelTurret::ModelAnimationSubmodelTurret(SCP_string subsystemName, bool findBarrel, SCP_string SIPname, std::shared_ptr<ModelAnimationSegment> mainSegment) : ModelAnimationSubmodel(std::move(subsystemName), std::move(mainSegment)), m_SIPname(std::move(SIPname)), m_findBarrel(findBarrel) { }
 
-	ModelAnimationSubmodel* ModelAnimationSubmodelTurret::copy(SCP_string newSIPname) {
-		ModelAnimationSubmodelTurret* anim = new ModelAnimationSubmodelTurret(*this);
+	ModelAnimationSubmodel* ModelAnimationSubmodelTurret::copy(const SCP_string& newSIPname) {
+		auto anim = new ModelAnimationSubmodelTurret(*this);
 		anim->m_SIPname = newSIPname;
 		return anim;
 	}
@@ -405,9 +405,9 @@ namespace animation {
 		else {
 
 			int sip_index = ship_info_lookup(m_SIPname.c_str());
-			ship_info* sip = &Ship_info[sip_index];
-			if (sip->subsystems == nullptr)
+			if (sip_index < 0)
 				return { nullptr, nullptr };
+			ship_info* sip = &Ship_info[sip_index];
 
 			for (int i = 0; i < sip->n_subsystems; i++) {
 				if (!subsystem_stricmp(sip->subsystems[i].subobj_name, m_name.c_str())) {
@@ -468,7 +468,7 @@ namespace animation {
 		animationSet[{type, subtype}].emplace(name, animation);
 	}
 
-	void ModelAnimationSet::changeShipName(SCP_string name) {
+	void ModelAnimationSet::changeShipName(const SCP_string& name) {
 		decltype(animationSet) newAnimationSet;
 
 		for (const auto& animationTypes : animationSet) {

--- a/code/model/modelanimation.h
+++ b/code/model/modelanimation.h
@@ -153,8 +153,8 @@ namespace animation {
 
 		void reset(polymodel_instance* pmi);
 
-		//Hack needed for potential cloning of a animations due to templates, while still allowing changing the subsystem data for turret retrieval later on.
-		virtual ModelAnimationSubmodel* copy(SCP_string newSIPname);
+		//Hack needed for potential cloning of animations due to templates, while still allowing changing the subsystem data for turret retrieval later on.
+		virtual ModelAnimationSubmodel* copy(const SCP_string& /*newSIPname*/);
 
 	private:
 		//Set the submodels current state as the base for the animation, recalculate the animation data (e.g. take this as the base for absolutely defined angles)
@@ -175,7 +175,7 @@ namespace animation {
 		*/
 		ModelAnimationSubmodelTurret(SCP_string subsystemName, bool findBarrel, SCP_string SIPname, std::shared_ptr<ModelAnimationSegment> mainSegment);
 
-		ModelAnimationSubmodel* copy(SCP_string newSIPname) override;
+		ModelAnimationSubmodel* copy(const SCP_string& newSIPname) override;
 	};
 
 
@@ -223,7 +223,7 @@ namespace animation {
 		//Helper function to shorten animation emplaces
 		void emplace(const std::shared_ptr<ModelAnimation>& animation, const SCP_string& name, ModelAnimationTriggerType type = ModelAnimationTriggerType::Scripted, int subtype = SUBTYPE_DEFAULT);
 
-		void changeShipName(SCP_string name);
+		void changeShipName(const SCP_string& name);
 	};
 
 

--- a/code/model/modelanimation.h
+++ b/code/model/modelanimation.h
@@ -135,7 +135,7 @@ namespace animation {
 		optional<int> m_submodel;
 		
 	private:
-		std::unique_ptr<ModelAnimationSegment> m_mainSegment;
+		std::shared_ptr<ModelAnimationSegment> m_mainSegment;
 		//Polymodel Instance ID -> ModelAnimationData
 		std::map<int, ModelAnimationData<>> m_initialData;
 		//Polymodel Instance ID -> ModelAnimationData
@@ -144,7 +144,7 @@ namespace animation {
 		friend class ModelAnimation;
 	public:
 		//Create a submodel animation based on the name of the submodel
-		ModelAnimationSubmodel(SCP_string submodelName, std::unique_ptr<ModelAnimationSegment> mainSegment);
+		ModelAnimationSubmodel(SCP_string submodelName, std::shared_ptr<ModelAnimationSegment> mainSegment);
 
 		virtual ~ModelAnimationSubmodel() = default;
 
@@ -152,6 +152,9 @@ namespace animation {
 		void play(float time, polymodel_instance* pmi);
 
 		void reset(polymodel_instance* pmi);
+
+		//Hack needed for potential cloning of a animations due to templates, while still allowing changing the subsystem data for turret retrieval later on.
+		virtual ModelAnimationSubmodel* copy(SCP_string newSIPname);
 
 	private:
 		//Set the submodels current state as the base for the animation, recalculate the animation data (e.g. take this as the base for absolutely defined angles)
@@ -162,16 +165,17 @@ namespace animation {
 	};
 
 	class ModelAnimationSubmodelTurret : public ModelAnimationSubmodel {
-		int m_sipIndex = -1;
+		SCP_string m_SIPname;
 		bool m_findBarrel;
 		void copyToSubmodel(const ModelAnimationData<>& data, polymodel_instance* pmi) override;
 		std::pair<submodel_instance*, bsp_info*> findSubmodel(polymodel_instance* pmi) override;
-
 	public:
 		/*Create a submodel animation by taking the submodel assigned to a subsystem with a given name, or, if requested, the submodel of the turret barrel.
 		Due to how turrets work in FSO, this should never be given a segment that does anything but rotate the turret around its axis
 		*/
-		ModelAnimationSubmodelTurret(SCP_string subsystemName, bool findBarrel, ship_info* sip, std::unique_ptr<ModelAnimationSegment> mainSegment);
+		ModelAnimationSubmodelTurret(SCP_string subsystemName, bool findBarrel, SCP_string SIPname, std::shared_ptr<ModelAnimationSegment> mainSegment);
+
+		ModelAnimationSubmodel* copy(SCP_string newSIPname) override;
 	};
 
 
@@ -179,7 +183,7 @@ namespace animation {
 		//Polymodel Instance ID -> ModelAnimation*
 		static std::multimap<int, std::shared_ptr<ModelAnimation>> s_runningAnimations;
 
-		std::vector<std::unique_ptr<ModelAnimationSubmodel>> m_submodelAnimation;
+		std::vector<std::shared_ptr<ModelAnimationSubmodel>> m_submodelAnimation;
 		float m_duration = 0.0f;
 
 		//Polymodel Instance ID -> ModelAnimationState
@@ -189,8 +193,10 @@ namespace animation {
 		ModelAnimationState play(float frametime, polymodel_instance* pmi);
 
 		static void cleanRunning();
+
+		friend struct ModelAnimationSet;
 	public:
-		void addSubsystemAnimation(std::unique_ptr<ModelAnimationSubmodel> animation);
+		void addSubmodelAnimation(std::shared_ptr<ModelAnimationSubmodel> animation);
 
 		//Start playing the animation. Will stop other animations that have components running on the same submodels
 		void start(polymodel_instance* pmi, bool reverse, bool force = false);
@@ -212,10 +218,12 @@ namespace animation {
 	struct ModelAnimationSet {
 		static int SUBTYPE_DEFAULT;
 
-		std::map <std::pair<ModelAnimationTriggerType, int>, std::multimap <SCP_string, std::shared_ptr<ModelAnimation>>> animationSet;
+		std::map <std::pair<ModelAnimationTriggerType, int>, std::map <SCP_string, std::shared_ptr<ModelAnimation>>> animationSet;
 
 		//Helper function to shorten animation emplaces
 		void emplace(const std::shared_ptr<ModelAnimation>& animation, const SCP_string& name, ModelAnimationTriggerType type = ModelAnimationTriggerType::Scripted, int subtype = SUBTYPE_DEFAULT);
+
+		void changeShipName(SCP_string name);
 	};
 
 

--- a/code/model/modelanimation_segments.cpp
+++ b/code/model/modelanimation_segments.cpp
@@ -43,7 +43,7 @@ namespace animation {
 		}
 	}
 
-	void ModelAnimationSegmentSerial::addSegment(std::unique_ptr<ModelAnimationSegment> segment) {
+	void ModelAnimationSegmentSerial::addSegment(std::shared_ptr<ModelAnimationSegment> segment) {
 		m_duration += segment->getDuration();
 		m_segments.push_back(std::move(segment));
 	}
@@ -78,7 +78,7 @@ namespace animation {
 		}
 	}
 
-	void ModelAnimationSegmentParallel::addSegment(std::unique_ptr<ModelAnimationSegment> segment) {
+	void ModelAnimationSegmentParallel::addSegment(std::shared_ptr<ModelAnimationSegment> segment) {
 		float newDur = segment->getDuration();
 		//recalculate total duration if necessary
 		m_duration = newDur > m_duration ? newDur : m_duration;

--- a/code/model/modelanimation_segments.h
+++ b/code/model/modelanimation_segments.h
@@ -6,27 +6,27 @@ namespace animation {
 
 	//This segment handles multiple generic segments chained after one another
 	class ModelAnimationSegmentSerial : public ModelAnimationSegment {
-		std::vector<std::unique_ptr<ModelAnimationSegment>> m_segments;
+		std::vector<std::shared_ptr<ModelAnimationSegment>> m_segments;
 
 		void recalculate(const submodel_instance* submodel_instance, const bsp_info* submodel, const ModelAnimationData<>& base) override;
 		ModelAnimationData<true> calculateAnimation(const ModelAnimationData<>& base, const ModelAnimationData<>& lastState, float time) const override;
 		void executeAnimation(const ModelAnimationData<>& state, float time) const override;
 
 	public:
-		void addSegment(std::unique_ptr<ModelAnimationSegment> segment);
+		void addSegment(std::shared_ptr<ModelAnimationSegment> segment);
 
 	};
 
 	//This segment handles multiple generic segments executing in parallel
 	class ModelAnimationSegmentParallel : public ModelAnimationSegment {
-		std::vector<std::unique_ptr<ModelAnimationSegment>> m_segments;
+		std::vector<std::shared_ptr<ModelAnimationSegment>> m_segments;
 
 		void recalculate(const submodel_instance* submodel_instance, const bsp_info* submodel, const ModelAnimationData<>& base) override;
 		ModelAnimationData<true> calculateAnimation(const ModelAnimationData<>& base, const ModelAnimationData<>& lastState, float time) const override;
 		void executeAnimation(const ModelAnimationData<>& state, float time) const override;
 
 	public:
-		void addSegment(std::unique_ptr<ModelAnimationSegment> segment);
+		void addSegment(std::shared_ptr<ModelAnimationSegment> segment);
 
 	};
 

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -981,6 +981,8 @@ void ship_info::clone(const ship_info& other)
 	}
 	n_subsystems = other.n_subsystems;
 
+	animations = other.animations;
+
 	power_output = other.power_output;
 	max_overclocked_speed = other.max_overclocked_speed;
 	max_weapon_reserve = other.max_weapon_reserve;
@@ -2145,6 +2147,8 @@ static void parse_ship(const char *filename, bool replace)
 			end_string_at_first_hash_symbol(sip->display_name);
 			sip->flags.set(Ship::Info_Flags::Has_display_name);
 		}
+
+		sip->animations.changeShipName(sip->name);
 	}
 
 	parse_ship_values(sip, false, first_time, replace);
@@ -2195,6 +2199,7 @@ static void parse_ship_template()
 				first_time = false;
 				sip->clone(Ship_templates[template_id]);
 				strcpy_s(sip->name, buf);
+				sip->animations.changeShipName(sip->name);
 			}
 			else {
 				Warning(LOCATION, "Unable to find ship template '%s' requested by ship template '%s', ignoring template request...", template_name, buf);


### PR DESCRIPTION
Another round of fixes.
This time, templates caused three problems:
When defining animations for templates, the ship_info_index is yet undefined. For simplicities sake, ship_info information required to find turret model numbers are looked up using ship_info names. This is stable, even for templates.
When copying ship_infos for instantiating templates, animationsegments are not unique anymore. Hence, all the unique pointer actually need to be shared pointers, since the same pointer data is accessed by multiple ship_infos.
To be able to override a ship template's animation data, animations are now all named, with the names being unique. For the old tables, this name is the subobject name. This means that overriding a submodel will then also override the corresponding animation instead of adding to it.