### PR TITLE
FRED: Don't clear poof flags for poof 7 and after

### DIFF
--- a/fred2/bgbitmapdlg.cpp
+++ b/fred2/bgbitmapdlg.cpp
@@ -372,7 +372,9 @@ void bg_bitmap_dlg::OnClose()
 		}
 
 		// store poof flags
-		Neb2_poof_flags = 0;
+
+		//This will clear the first six poof flags to then be set by the checkboxes, and keep higher bits as is, for example when manuall set for custom poofs by editing the mission file
+		Neb2_poof_flags &= ~(0b111111);
 		if(m_poof_0)
 		{
 			Neb2_poof_flags |= (1<<0);


### PR DESCRIPTION
Previously, on closing the background editing dialog, FRED would clear all poof bits, not just the ones set by the checkboxes.
Since, if someone edited the mission file to add new custom poofs, they probably don't want them reset every time they edit the background.
This changes this, so only the bits that can actually be set again through the checkboxes are cleared. Eventually, and in qtFred, we'd ideally want a dynamic number of checkboxes here.
For now just a quick fix that enables modders to still edit backgrounds when using many custom poofs