### PR TITLE
handle nebula poofs dynamically in FRED

### DIFF
--- a/fred2/bgbitmapdlg.cpp
+++ b/fred2/bgbitmapdlg.cpp
@@ -33,6 +33,9 @@ static char THIS_FILE[] = __FILE__;
 /////////////////////////////////////////////////////////////////////////////
 // bg_bitmap_dlg dialog
 
+// FRED has a fixed number of checkboxes and supports only up to this number of nebula poofs
+#define MAX_NEB2_POOF_CHECKBOXES	6
+
 bg_bitmap_dlg::bg_bitmap_dlg(CWnd* pParent) : CDialog(bg_bitmap_dlg::IDD, pParent)
 {
 	//{{AFX_DATA_INIT(bg_bitmap_dlg)		
@@ -47,12 +50,10 @@ bg_bitmap_dlg::bg_bitmap_dlg(CWnd* pParent) : CDialog(bg_bitmap_dlg::IDD, pParen
 	m_subspace = FALSE;
 	m_fullneb = FALSE;
 	m_toggle_trails = FALSE;
-	m_poof_0 = Neb2_poof_flags & (1<<0) ? 1 : 0;
-	m_poof_1 = Neb2_poof_flags & (1<<1) ? 1 : 0;
-	m_poof_2 = Neb2_poof_flags & (1<<2) ? 1 : 0;
-	m_poof_3 = Neb2_poof_flags & (1<<3) ? 1 : 0;
-	m_poof_4 = Neb2_poof_flags & (1<<4) ? 1 : 0;
-	m_poof_5 = Neb2_poof_flags & (1<<5) ? 1 : 0;
+
+	for (int i = 0; i < MAX_NEB2_POOFS; ++i)
+		m_poofs[i] = Neb2_poof_flags & (1 << i) ? 1 : 0;
+
 	s_pitch = 0;
 	s_bank = 0;
 	s_heading = 0;
@@ -95,12 +96,10 @@ void bg_bitmap_dlg::DoDataExchange(CDataExchange* pDX)
 	DDX_CBIndex(pDX, IDC_NEB2_TEXTURE, m_neb2_texture);
 	DDX_Check(pDX, IDC_SUBSPACE, m_subspace);
 	DDX_Check(pDX, IDC_FULLNEB, m_fullneb);
-	DDX_Check(pDX, IDC_POOF0, m_poof_0);
-	DDX_Check(pDX, IDC_POOF1, m_poof_1);
-	DDX_Check(pDX, IDC_POOF2, m_poof_2);
-	DDX_Check(pDX, IDC_POOF3, m_poof_3);
-	DDX_Check(pDX, IDC_POOF4, m_poof_4);
-	DDX_Check(pDX, IDC_POOF5, m_poof_5);
+
+	for (int i = 0; i < MAX_NEB2_POOF_CHECKBOXES; ++i)
+		DDX_Check(pDX, IDC_POOF0 + i, m_poofs[i]);
+
 	DDX_Check(pDX, IDC_NEB_TOGGLE_TRAILS, m_toggle_trails);
 	DDX_Text(pDX, IDC_SUN1, s_name);
 	DDX_Text(pDX, IDC_SUN1_P, s_pitch);
@@ -219,12 +218,8 @@ void bg_bitmap_dlg::create()
 	build_nebfile_list();	
 
 	// setup neb poof names
-	GetDlgItem(IDC_POOF0)->SetWindowText(Poof_info[0].name);	
-	GetDlgItem(IDC_POOF1)->SetWindowText(Poof_info[1].name);
-	GetDlgItem(IDC_POOF2)->SetWindowText(Poof_info[2].name);
-	GetDlgItem(IDC_POOF3)->SetWindowText(Poof_info[3].name);
-	GetDlgItem(IDC_POOF4)->SetWindowText(Poof_info[4].name);
-	GetDlgItem(IDC_POOF5)->SetWindowText(Poof_info[5].name);
+	for (i = 0; i < MAX_NEB2_POOF_CHECKBOXES; ++i)
+		GetDlgItem(IDC_POOF0 + i)->SetWindowText(Poof_info[i].name);
 
 	m_skybox_model = _T(The_mission.skybox_model);
 	m_envmap = _T(The_mission.envmap_name);
@@ -372,32 +367,11 @@ void bg_bitmap_dlg::OnClose()
 		}
 
 		// store poof flags
-
-		//This will clear the first six poof flags to then be set by the checkboxes, and keep higher bits as is, for example when manuall set for custom poofs by editing the mission file
-		Neb2_poof_flags &= ~(0b111111);
-		if(m_poof_0)
+		Neb2_poof_flags = 0;
+		for (int i = 0; i < MAX_NEB2_POOFS; ++i)
 		{
-			Neb2_poof_flags |= (1<<0);
-		}
-		if(m_poof_1)
-		{
-			Neb2_poof_flags |= (1<<1);
-		}
-		if(m_poof_2)
-		{
-			Neb2_poof_flags |= (1<<2);
-		}
-		if(m_poof_3)
-		{
-			Neb2_poof_flags |= (1<<3);
-		}
-		if(m_poof_4)
-		{
-			Neb2_poof_flags |= (1<<4);
-		}
-		if(m_poof_5)
-		{
-			Neb2_poof_flags |= (1<<5);
+			if (m_poofs[i])
+				Neb2_poof_flags |= (1 << i);
 		}
 		
 		// get the bitmap name
@@ -553,12 +527,10 @@ void bg_bitmap_dlg::OnFullNeb()
 		GetDlgItem(IDC_NEB2_INTENSITY)->EnableWindow(TRUE);
 		GetDlgItem(IDC_NEB2_TEXTURE)->EnableWindow(TRUE);
 		GetDlgItem(IDC_NEB2_LIGHTNING)->EnableWindow(TRUE);
-		GetDlgItem(IDC_POOF0)->EnableWindow(TRUE);
-		GetDlgItem(IDC_POOF1)->EnableWindow(TRUE);
-		GetDlgItem(IDC_POOF2)->EnableWindow(TRUE);
-		GetDlgItem(IDC_POOF3)->EnableWindow(TRUE);
-		GetDlgItem(IDC_POOF4)->EnableWindow(TRUE);
-		GetDlgItem(IDC_POOF5)->EnableWindow(TRUE);
+
+		for (int i = 0; i < MAX_NEB2_POOF_CHECKBOXES; ++i)
+			GetDlgItem(IDC_POOF0 + i)->EnableWindow(TRUE);
+
 		GetDlgItem(IDC_NEB_TOGGLE_TRAILS)->EnableWindow(TRUE);
 
 		// disable non-fullneb controls
@@ -568,30 +540,12 @@ void bg_bitmap_dlg::OnFullNeb()
 		GetDlgItem(IDC_BANK)->EnableWindow(FALSE);
 		GetDlgItem(IDC_HEADING)->EnableWindow(FALSE);
 
-		// check all relevant poofs		
-		((CButton*)GetDlgItem(IDC_POOF0))->SetCheck(FALSE);
-		if(m_poof_0){
-			((CButton*)GetDlgItem(IDC_POOF0))->SetCheck(TRUE);
-		}
-		((CButton*)GetDlgItem(IDC_POOF1))->SetCheck(FALSE);
-		if(m_poof_1){
-			((CButton*)GetDlgItem(IDC_POOF1))->SetCheck(TRUE);
-		}
-		((CButton*)GetDlgItem(IDC_POOF2))->SetCheck(FALSE);
-		if(m_poof_2){
-			((CButton*)GetDlgItem(IDC_POOF2))->SetCheck(TRUE);
-		}
-		((CButton*)GetDlgItem(IDC_POOF3))->SetCheck(FALSE);
-		if(m_poof_3){
-			((CButton*)GetDlgItem(IDC_POOF3))->SetCheck(TRUE);
-		}
-		((CButton*)GetDlgItem(IDC_POOF4))->SetCheck(FALSE);
-		if(m_poof_4){
-			((CButton*)GetDlgItem(IDC_POOF4))->SetCheck(TRUE);
-		}
-		((CButton*)GetDlgItem(IDC_POOF5))->SetCheck(FALSE);
-		if(m_poof_5){
-			((CButton*)GetDlgItem(IDC_POOF5))->SetCheck(TRUE);
+		// check all relevant poofs
+		for (int i = 0; i < MAX_NEB2_POOF_CHECKBOXES; ++i)
+		{
+			((CButton*)GetDlgItem(IDC_POOF0 + i))->SetCheck(FALSE);
+			if (m_poofs[i])
+				((CButton*)GetDlgItem(IDC_POOF0 + i))->SetCheck(TRUE);
 		}
 	} else {
 		// enable all non-fullneb controls
@@ -605,12 +559,10 @@ void bg_bitmap_dlg::OnFullNeb()
 		GetDlgItem(IDC_NEB2_INTENSITY)->EnableWindow(FALSE);
 		GetDlgItem(IDC_NEB2_TEXTURE)->EnableWindow(FALSE);
 		GetDlgItem(IDC_NEB2_LIGHTNING)->EnableWindow(FALSE);
-		GetDlgItem(IDC_POOF0)->EnableWindow(FALSE);
-		GetDlgItem(IDC_POOF1)->EnableWindow(FALSE);
-		GetDlgItem(IDC_POOF2)->EnableWindow(FALSE);
-		GetDlgItem(IDC_POOF3)->EnableWindow(FALSE);
-		GetDlgItem(IDC_POOF4)->EnableWindow(FALSE);
-		GetDlgItem(IDC_POOF5)->EnableWindow(FALSE);
+
+		for (int i = 0; i < MAX_NEB2_POOF_CHECKBOXES; ++i)
+			GetDlgItem(IDC_POOF0 + i)->EnableWindow(FALSE);
+
 		GetDlgItem(IDC_NEB_TOGGLE_TRAILS)->EnableWindow(FALSE);
 	}		
 }

--- a/fred2/bgbitmapdlg.h
+++ b/fred2/bgbitmapdlg.h
@@ -11,6 +11,8 @@
 
 #include "resource.h"
 
+#include "../code/nebula/neb.h"
+
 /////////////////////////////////////////////////////////////////////////////
 // bg_bitmap_dlg dialog
 
@@ -55,12 +57,7 @@ public:
 	int		m_neb2_texture;
 	BOOL		m_subspace;
 	BOOL		m_fullneb;
-	int		m_poof_0;
-	int		m_poof_1;
-	int		m_poof_2;
-	int		m_poof_3;
-	int		m_poof_4;
-	int		m_poof_5;
+	int		m_poofs[MAX_NEB2_POOFS];
 	BOOL	m_toggle_trails;
 	CString	m_storm_name;
 	CString s_name;

--- a/fred2/sexp_tree.cpp
+++ b/fred2/sexp_tree.cpp
@@ -6137,7 +6137,7 @@ sexp_list_item *sexp_tree::get_listing_opf_nebula_poof()
 {
 	sexp_list_item head;
 
-	for (poof_info pf : Poof_info)
+	for (poof_info &pf : Poof_info)
 	{
 		head.add_data(pf.name);
 	}

--- a/qtfred/src/ui/widgets/sexp_tree.cpp
+++ b/qtfred/src/ui/widgets/sexp_tree.cpp
@@ -4422,7 +4422,7 @@ sexp_list_item* sexp_tree::get_listing_opf_nebula_storm_type() {
 sexp_list_item* sexp_tree::get_listing_opf_nebula_poof() {
 	sexp_list_item head;
 
-	for (poof_info pf : Poof_info) {
+	for (poof_info &pf : Poof_info) {
 		head.add_data(pf.name);
 	}
 


### PR DESCRIPTION
Inspired by #3584, this properly saves and restores any number of nebula poofs handled by the game.  FRED will only display checkboxes for the first six, since it still uses the static UI, but everything else is handled behind the scenes.