### PR TITLE
ships, wings, etc. can share names with teams

### DIFF
--- a/fred2/createwingdlg.cpp
+++ b/fred2/createwingdlg.cpp
@@ -103,13 +103,7 @@ void create_wing_dlg::OnOK()
 		ptr = GET_NEXT(ptr);
 	}
 
-	for (i=0; i<Num_iffs; i++) {
-		if (!stricmp(m_name, Iff_info[i].iff_name)) {
-			msg.Format("The name \"%s\" is already being used by a team", static_cast<LPCTSTR>(m_name));
-			MessageBox(msg);
-			return;
-		}
-	}
+	// We don't need to check teams.  "Unknown" is a valid name and also an IFF.
 
 	for ( i=0; i < (int)Ai_tp_list.size(); i++) {
 		if (!stricmp(m_name, Ai_tp_list[i].name)) {

--- a/fred2/shipeditordlg.cpp
+++ b/fred2/shipeditordlg.cpp
@@ -1086,22 +1086,7 @@ int CShipEditorDlg::update_data(int redraw)
 			}
 		}
 
-		for (i=0; i<Num_iffs; i++) {
-			if (!stricmp(m_ship_name, Iff_info[i].iff_name)) {
-				if (bypass_errors)
-					return 1;
-
-				bypass_errors = 1;
-				z = MessageBox("This ship name is already being used by a team.\n"
-					"Press OK to restore old name", "Error", MB_ICONEXCLAMATION | MB_OKCANCEL);
-
-				if (z == IDCANCEL)
-					return -1;
-
-				m_ship_name = _T(Ships[single_ship].ship_name);
-				UpdateData(FALSE);
-			}
-		}
+		// We don't need to check teams.  "Unknown" is a valid name and also an IFF.
 
 		for ( i=0; i < (int)Ai_tp_list.size(); i++) {
 			if (!stricmp(m_ship_name, Ai_tp_list[i].name)) 

--- a/fred2/waypointpathdlg.cpp
+++ b/fred2/waypointpathdlg.cpp
@@ -215,22 +215,7 @@ int waypoint_path_dlg::update_data(int redraw)
 			ptr = GET_NEXT(ptr);
 		}
 
-		for (i=0; i<Num_iffs; i++) {
-			if (!stricmp(m_name, Iff_info[i].iff_name)) {
-				if (bypass_errors)
-					return 1;
-
-				bypass_errors = 1;
-				z = MessageBox("This waypoint path name is already being used by a team.\n"
-					"Press OK to restore old name", "Error", MB_ICONEXCLAMATION | MB_OKCANCEL);
-
-				if (z == IDCANCEL)
-					return -1;
-
-				m_name = _T(cur_waypoint_list->get_name());
-				UpdateData(FALSE);
-			}
-		}
+		// We don't need to check teams.  "Unknown" is a valid name and also an IFF.
 
 		for ( i=0; i < (int)Ai_tp_list.size(); i++) {
 			if (!stricmp(m_name, Ai_tp_list[i].name)) {
@@ -356,22 +341,7 @@ int waypoint_path_dlg::update_data(int redraw)
 			ptr = GET_NEXT(ptr);
 		}
 
-		for (i=0; i<Num_iffs; i++) {
-			if (!stricmp(m_name, Iff_info[i].iff_name)) {
-				if (bypass_errors)
-					return 1;
-
-				bypass_errors = 1;
-				z = MessageBox("This jump node name is already being used by a team.\n"
-					"Press OK to restore old name", "Error", MB_ICONEXCLAMATION | MB_OKCANCEL);
-
-				if (z == IDCANCEL)
-					return -1;
-
-				m_name = _T(jnp->GetName());
-				UpdateData(FALSE);
-			}
-		}
+		// We don't need to check teams.  "Unknown" is a valid name and also an IFF.
 
 		for ( i=0; i < (int)Ai_tp_list.size(); i++) {
 			if (!stricmp(m_name, Ai_tp_list[i].name)) {

--- a/fred2/wing_editor.cpp
+++ b/fred2/wing_editor.cpp
@@ -606,23 +606,7 @@ int wing_editor::update_data(int redraw)
 			ptr = GET_NEXT(ptr);
 		}
 
-		for (i=0; i<Num_iffs; i++) {
-			if (!stricmp(m_wing_name, Iff_info[i].iff_name)) 
-			{
-				if (bypass_errors)
-					return 1;
-
-				bypass_errors = 1;
-				z = MessageBox("This wing name is already being used by a team.\n"
-					"Press OK to restore old name", "Error", MB_ICONEXCLAMATION | MB_OKCANCEL);
-
-				if (z == IDCANCEL)
-					return -1;
-
-				m_wing_name = _T(Wings[cur_wing].name);
-				UpdateData(FALSE);
-			}
-		}
+		// We don't need to check teams.  "Unknown" is a valid name and also an IFF.
 
 		for ( i=0; i < (int)Ai_tp_list.size(); i++) {
 			if (!stricmp(m_wing_name, Ai_tp_list[i].name)) 

--- a/qtfred/src/mission/dialogs/FormWingDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/FormWingDialogModel.cpp
@@ -70,18 +70,7 @@ bool FormWingDialogModel::apply() {
 		ptr = GET_NEXT(ptr);
 	}
 
-	for (auto i = 0; i < Num_iffs; i++) {
-		if (!stricmp(_name.c_str(), Iff_info[i].iff_name)) {
-			SCP_string msg;
-			sprintf(msg, "The name \"%s\" is already being used by a team", _name.c_str());
-
-			_viewport->dialogProvider->showButtonDialog(DialogType::Error,
-														"Error",
-														msg,
-														{ DialogButton::Ok });
-			return false;
-		}
-	}
+	// We don't need to check teams.  "Unknown" is a valid name and also an IFF.
 
 	for (auto i = 0; i < (int) Ai_tp_list.size(); i++) {
 		if (!stricmp(_name.c_str(), Ai_tp_list[i].name)) {

--- a/qtfred/src/mission/dialogs/ShipEditorDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/ShipEditorDialogModel.cpp
@@ -408,20 +408,7 @@ bool ShipEditorDialogModel::update_data()
 			}
 		}
 
-		for (i = 0; i < Num_iffs; i++) {
-			if (!stricmp(_m_ship_name.c_str(), Iff_info[i].iff_name)) {
-				auto button = _viewport->dialogProvider->showButtonDialog(DialogType::Error,
-					"Ship Name Error",
-					"This ship name is already being used by a team.\n Press OK to restore old name",
-					{DialogButton::Ok, DialogButton::Cancel});
-				if (button == DialogButton::Cancel) {
-					return false;
-				} else {
-					_m_ship_name = Ships[single_ship].ship_name;
-					modelChanged();
-				}
-			}
-		}
+		// We don't need to check teams.  "Unknown" is a valid name and also an IFF.
 
 		for (i = 0; i < (int)Ai_tp_list.size(); i++) {
 			if (!stricmp(_m_ship_name.c_str(), Ai_tp_list[i].name)) {

--- a/qtfred/src/mission/dialogs/WaypointEditorDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/WaypointEditorDialogModel.cpp
@@ -82,17 +82,7 @@ bool WaypointEditorDialogModel::apply() {
 			ptr = GET_NEXT(ptr);
 		}
 
-		for (i = 0; i < Num_iffs; i++) {
-			if (!stricmp(_currentName.c_str(), Iff_info[i].iff_name)) {
-				if (showErrorDialog("This waypoint path name is already being used by a team.\n"
-										"Press OK to restore old name", "Error")) {
-					return false;
-				}
-
-				_currentName = _editor->cur_waypoint_list->get_name();
-				modelChanged();
-			}
-		}
+		// We don't need to check teams.  "Unknown" is a valid name and also an IFF.
 
 		for (i = 0; i < (int) Ai_tp_list.size(); i++) {
 			if (!stricmp(_currentName.c_str(), Ai_tp_list[i].name)) {
@@ -187,17 +177,7 @@ bool WaypointEditorDialogModel::apply() {
 			ptr = GET_NEXT(ptr);
 		}
 
-		for (i = 0; i < Num_iffs; i++) {
-			if (!stricmp(_currentName.c_str(), Iff_info[i].iff_name)) {
-				if (showErrorDialog("This jump node name is already being used by a team.\n"
-										"Press OK to restore old name", "Error")) {
-					return false;
-				}
-
-				_currentName = jnp->GetName();
-				modelChanged();
-			}
-		}
+		// We don't need to check teams.  "Unknown" is a valid name and also an IFF.
 
 		for (i = 0; i < (int) Ai_tp_list.size(); i++) {
 			if (!stricmp(_currentName.c_str(), Ai_tp_list[i].name)) {


### PR DESCRIPTION
Partial revert of Mantis 2053, added in 7d4f9f0fb5:
http://scp.indiegames.us/mantis/view.php?id=2053

The patch was speculative and there was never a confirmed bug.  By contrast, there are plenty of existing missions that use Unknown as a ship, wing, or jump node name and work just fine.