### PR TITLE
add a version guard for MSVC compiler bug fix

### DIFF
--- a/qtfred/src/mission/dialogs/MissionSpecDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/MissionSpecDialogModel.cpp
@@ -1,9 +1,11 @@
 //
 //
 
-// work around MSVC 2015 and 2017 compiler bug
-// https://bugreports.qt.io/browse/QTBUG-72073
-#define QT_NO_FLOAT16_OPERATORS
+#if defined(_MSC_VER) && _MSC_VER <= 1920
+	// work around MSVC 2015 and 2017 compiler bug
+	// https://bugreports.qt.io/browse/QTBUG-72073
+	#define QT_NO_FLOAT16_OPERATORS
+#endif
 
 #include "MissionSpecDialogModel.h"
 #include "ui/dialogs/MissionSpecDialog.h"

--- a/qtfred/src/mission/dialogs/ShipEditorDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/ShipEditorDialogModel.cpp
@@ -1,9 +1,11 @@
 //
 //
 
-// work around MSVC 2015 and 2017 compiler bug
-// https://bugreports.qt.io/browse/QTBUG-72073
-#define QT_NO_FLOAT16_OPERATORS
+#if defined(_MSC_VER) && _MSC_VER <= 1920
+	// work around MSVC 2015 and 2017 compiler bug
+	// https://bugreports.qt.io/browse/QTBUG-72073
+	#define QT_NO_FLOAT16_OPERATORS
+#endif
 
 #include "ShipEditorDialogModel.h"
 

--- a/qtfred/src/ui/QtGraphicsOperations.cpp
+++ b/qtfred/src/ui/QtGraphicsOperations.cpp
@@ -1,9 +1,11 @@
 //
 //
 
-// work around MSVC 2015 and 2017 compiler bug
-// https://bugreports.qt.io/browse/QTBUG-72073
-#define QT_NO_FLOAT16_OPERATORS
+#if defined(_MSC_VER) && _MSC_VER <= 1920
+	// work around MSVC 2015 and 2017 compiler bug
+	// https://bugreports.qt.io/browse/QTBUG-72073
+	#define QT_NO_FLOAT16_OPERATORS
+#endif
 
 #include "QtGraphicsOperations.h"
 

--- a/qtfred/src/ui/widgets/ColorComboBox.cpp
+++ b/qtfred/src/ui/widgets/ColorComboBox.cpp
@@ -1,9 +1,11 @@
 //
 //
 
-// work around MSVC 2015 and 2017 compiler bug
-// https://bugreports.qt.io/browse/QTBUG-72073
-#define QT_NO_FLOAT16_OPERATORS
+#if defined(_MSC_VER) && _MSC_VER <= 1920
+	// work around MSVC 2015 and 2017 compiler bug
+	// https://bugreports.qt.io/browse/QTBUG-72073
+	#define QT_NO_FLOAT16_OPERATORS
+#endif
 
 #include "ColorComboBox.h"
 

--- a/qtfred/src/ui/widgets/renderwidget.cpp
+++ b/qtfred/src/ui/widgets/renderwidget.cpp
@@ -1,9 +1,11 @@
 //
 //
 
-// work around MSVC 2015 and 2017 compiler bug
-// https://bugreports.qt.io/browse/QTBUG-72073
-#define QT_NO_FLOAT16_OPERATORS
+#if defined(_MSC_VER) && _MSC_VER <= 1920
+	// work around MSVC 2015 and 2017 compiler bug
+	// https://bugreports.qt.io/browse/QTBUG-72073
+	#define QT_NO_FLOAT16_OPERATORS
+#endif
 
 #include "renderwidget.h"
 


### PR DESCRIPTION
Per ngld's suggestion, this adds a version check around the disabling of the qfloat16 overloads.

Follow-up to #3557.