### PR TITLE
Animation Rework Phase 1 Fixes 4 / Performance Issues

### DIFF
--- a/code/model/modelanimation.cpp
+++ b/code/model/modelanimation.cpp
@@ -8,6 +8,8 @@ namespace animation {
 
 	std::multimap<int, std::shared_ptr<ModelAnimation>> ModelAnimation::s_runningAnimations;
 
+	ModelAnimation::ModelAnimation(bool isInitialType) : m_isInitialType(isInitialType) { }
+
 	ModelAnimationState ModelAnimation::play(float frametime, polymodel_instance* pmi) {
 
 		float& timeCurrentAnim = m_time[pmi->id];
@@ -15,7 +17,9 @@ namespace animation {
 		switch (m_state[pmi->id]) {
 		case ModelAnimationState::UNTRIGGERED:
 			//We have a new animation starting up in this phase. Put it in the list of running animations to track and step it later
-			s_runningAnimations.emplace(pmi->id, shared_from_this());
+			if(!m_isInitialType)
+				s_runningAnimations.emplace(pmi->id, shared_from_this());
+
 			m_duration = 0.0f;
 			//Stop other running animations on subsystems we care about. Store subsystems initial values as well.
 			for (const auto& animation : m_submodelAnimation) {
@@ -250,7 +254,7 @@ namespace animation {
 		if (optional_string("+time:"))
 			skip_token();
 
-		std::shared_ptr<ModelAnimation> anim = std::shared_ptr<ModelAnimation>(new ModelAnimation());
+		std::shared_ptr<ModelAnimation> anim = std::shared_ptr<ModelAnimation>(new ModelAnimation(true));
 
 		char namelower[MAX_NAME_LEN];
 		strncpy(namelower, sp->subobj_name, MAX_NAME_LEN);
@@ -474,7 +478,7 @@ namespace animation {
 		for (const auto& animationTypes : animationSet) {
 			auto& newAnimations = newAnimationSet[animationTypes.first];
 			for (const auto& oldAnimation : animationTypes.second) {
-				std::shared_ptr<ModelAnimation> newAnimation = std::shared_ptr<ModelAnimation>(new ModelAnimation());
+				std::shared_ptr<ModelAnimation> newAnimation = std::shared_ptr<ModelAnimation>(new ModelAnimation(oldAnimation.second->m_isInitialType));
 				for (const auto& submodelAnims : oldAnimation.second->m_submodelAnimation) {
 					std::shared_ptr<ModelAnimationSubmodel> animSubmodel = std::shared_ptr<ModelAnimationSubmodel>(submodelAnims->copy(name));
 					newAnimation->addSubmodelAnimation(std::move(animSubmodel));

--- a/code/model/modelanimation.h
+++ b/code/model/modelanimation.h
@@ -190,12 +190,18 @@ namespace animation {
 		std::map<int, ModelAnimationState> m_state;
 		//Polymodel Instance ID -> ModelAnimation Time
 		std::map<int, float> m_time;
+
+		bool m_isInitialType;
+
 		ModelAnimationState play(float frametime, polymodel_instance* pmi);
 
 		static void cleanRunning();
 
 		friend struct ModelAnimationSet;
 	public:
+		//Initial type animations must complete within a single frame, and then never modifiy the submodel again. If this is the case, we do not need to remember them being active for massive performance gains with lots of turrets
+		ModelAnimation(bool isInitialType = false);
+
 		void addSubmodelAnimation(std::shared_ptr<ModelAnimationSubmodel> animation);
 
 		//Start playing the animation. Will stop other animations that have components running on the same submodels

--- a/code/object/object.cpp
+++ b/code/object/object.cpp
@@ -1520,8 +1520,6 @@ void obj_move_all(float frametime)
 		// move post
 		obj_move_all_post(objp, frametime);
 
-		animation::ModelAnimation::stepAnimations(frametime);
-
 		// Equipment script processing
 		if (objp->type == OBJ_SHIP) {
 			ship* shipp = &Ships[objp->instance];
@@ -1541,6 +1539,8 @@ void obj_move_all(float frametime)
 			}
 		}
 	}
+
+	animation::ModelAnimation::stepAnimations(frametime);
 
 	// Now that we've moved all the objects, move all the models that use intrinsic rotations.  We do that here because we already handled the
 	// ship models in obj_move_all_post, and this is more or less conceptually close enough to move the rest.  (Originally all models


### PR DESCRIPTION
This fixes one critical issue with the animation rework:
The stepAnimation call was done once per frame _per ship_, which is obviously wrong. For initial animations (that don't require stepping), this has no visual impact, but a massive performance issue. The call is moved to the correct place, once per frame, with this PR.
Additionally, since the (due to turrets) very common initial animations don't require stepping at all, they now have special handling to save on unnecessary performance waste. With this, the new animation system should again be not noticeable in performance.