### PR TITLE
Fix for 'anemic' poofs

### DIFF
--- a/code/globalincs/systemvars.cpp
+++ b/code/globalincs/systemvars.cpp
@@ -328,9 +328,6 @@ void detail_level_set(int level)
 	Assert( level < NUM_DEFAULT_DETAIL_LEVELS );
 
 	Detail = Detail_defaults[level];
-
-	// reset nebula stuff
-	neb2_set_detail_level(level);
 }
 
 // Returns the current detail level or -1 if custom.

--- a/code/menuui/optionsmenu.cpp
+++ b/code/menuui/optionsmenu.cpp
@@ -1353,7 +1353,6 @@ void options_detail_sliders_update()
 
 	// modify nebula stuff
 	Detail.nebula_detail = Detail_sliders[gr_screen.res][NEBULA_DETAIL_SLIDER].slider.pos;
-	neb2_set_detail_level(Detail.nebula_detail);
 
 	Detail.hardware_textures = Detail_sliders[gr_screen.res][HARDWARE_TEXTURES_SLIDER].slider.pos;
 	Detail.num_small_debris = Detail_sliders[gr_screen.res][SHARD_CULLING_SLIDER].slider.pos;

--- a/code/nebula/neb.cpp
+++ b/code/nebula/neb.cpp
@@ -119,8 +119,6 @@ const float NEB_FOG_FAR_PCT = 0.1f;
 
 SCP_vector<poof> Neb2_poofs;
 
-int Neb2_detail = 2;
-
 int Neb2_background_color[3] = {0, 0, 255};			// rgb background color (used for lame rendering)
 
 const SCP_vector<std::pair<int, SCP_string>> DetailLevelValues = {{ 0, "Minimum" },
@@ -134,10 +132,6 @@ const auto ModelDetailOption = options::OptionBuilder<int>("Graphics.NebulaDetai
                                                            "Detail level of nebulas").category("Graphics").values(
 	DetailLevelValues).default_val(MAX_DETAIL_LEVEL).importance(7).change_listener([](int val, bool initial) {
 	Detail.nebula_detail = val;
-	if (!initial) {
-		// This is only needed for changes after the game startup
-		neb2_set_detail_level(Detail.nebula_detail);
-	}
 	return true;
 }).finish();
 
@@ -261,22 +255,6 @@ bool poof_is_used(size_t idx) {
 	return (Neb2_poof_flags & (1 << idx)) != 0;
 }
 
-// set detail level
-void neb2_set_detail_level(int level)
-{
-	// sanity
-	if (level < 0) {
-		Neb2_detail = 0;
-		return;
-	}
-	if (level > MAX_DETAIL_LEVEL) {
-		Neb2_detail = MAX_DETAIL_LEVEL;
-		return;
-	}
-
-	Neb2_detail = level;
-}
-
 void neb2_get_fog_color(ubyte *r, ubyte *g, ubyte *b)
 {
 	if (r) *r = Neb2_fog_color[0];
@@ -313,7 +291,7 @@ void neb2_poof_setup() {
 		}
 	}
 	Poof_density_multiplier = Poof_density_sum_square / (Poof_density_sum * Poof_density_sum);
-	Poof_density_multiplier *= (Neb2_detail + 0.5f) / (MAX_DETAIL_LEVEL + 0.5f); // scale the poofs down based on detail level
+	Poof_density_multiplier *= (Detail.nebula_detail + 0.5f) / (MAX_DETAIL_LEVEL + 0.5f); // scale the poofs down based on detail level
 }
 
 // initialize nebula stuff - call from game_post_level_init(), so the mission has been loaded

--- a/code/nebula/neb.cpp
+++ b/code/nebula/neb.cpp
@@ -130,7 +130,7 @@ const SCP_vector<std::pair<int, SCP_string>> DetailLevelValues = {{ 0, "Minimum"
 const auto ModelDetailOption = options::OptionBuilder<int>("Graphics.NebulaDetail",
                                                            "Nebula Detail",
                                                            "Detail level of nebulas").category("Graphics").values(
-	DetailLevelValues).default_val(MAX_DETAIL_LEVEL).importance(7).change_listener([](int val, bool initial) {
+	DetailLevelValues).default_val(MAX_DETAIL_LEVEL).importance(7).change_listener([](int val, bool) {
 	Detail.nebula_detail = val;
 	return true;
 }).finish();

--- a/code/nebula/neb.h
+++ b/code/nebula/neb.h
@@ -76,11 +76,11 @@ typedef struct poof_info {
 	poof_info() {
 		bitmap_filename[0] = '\0';
 		bitmap = -1;
-		scale = ::util::UniformFloatRange(150.0f, 150.0f);
-		density = 1 / (150.f * 150.f * 150.f);
+		scale = ::util::UniformFloatRange(175.0f, 175.0f);
+		density = 1 / (110.f * 110.f * 110.f);
 		rotation = ::util::UniformFloatRange(-3.7f, 3.7f);
-		view_dist = 360.f;
-		alpha = ::util::UniformFloatRange(0.5f, 0.5f);
+		view_dist = 250.f;
+		alpha = ::util::UniformFloatRange(0.8f, 0.8f);
 	}
 } poof_info;
 
@@ -124,9 +124,6 @@ typedef struct neb2_detail {
 
 // initialize neb2 stuff at game startup
 void neb2_init();
-
-// set detail level
-void neb2_set_detail_level(int level);
 
 //init neb stuff  - WMC
 void neb2_level_init();

--- a/code/render/3ddraw.cpp
+++ b/code/render/3ddraw.cpp
@@ -501,7 +501,9 @@ void g3_render_rect_oriented(material* mat_info, vec3d *pos, vec3d *norm, float 
 //void render_rotated_bitmap(int texture, float alpha, vertex *pnt, float angle, float rad)
 void g3_render_rect_screen_aligned_rotated(material *mat_params, vertex *pnt, float angle, float rad)
 {
-	rad *= 1.41421356f;//1/0.707, becase these are the points of a square or width and hieght rad
+	// holdover mistake from retail causes these bitmaps to be rendered 41% bigger than rad
+	// this turns radius into the diagonal distance, but the methods below presume manhattan distance (unadjusted radius)
+	rad *= 1.41421356f;
 
 	angle -= Physics_viewer_bank;
 	if ( angle < 0.0f ) {
@@ -739,7 +741,9 @@ void g3_render_rect_screen_aligned_2d(material *mat_params, vertex *pnt, int ori
 // adapted from g3_draw_bitmap_3d
 void g3_render_rect_screen_aligned(material *mat_params, vertex *pnt, int orient, float rad, float depth)
 {
-	rad *= 1.41421356f;//1/0.707, becase these are the points of a square or width and hieght rad
+	// holdover mistake from retail causes these bitmaps to be rendered 41% bigger than rad
+	// this turns radius into the diagonal distance, but the methods below presume manhattan distance (unadjusted radius)
+	rad *= 1.41421356f;
 
 	vec3d PNT(pnt->world);
 	vec3d p[4];


### PR DESCRIPTION
Follow up to #3507. Due to the confluence of 3 old bugs, the nebula poofs people were getting had significantly more 'oomph' (density, opacity *and* size) than a straightforward analysis of the code would suggest, all of which are compensated for in this PR.

1. Despite literally handing ~0.5 alpha to the renderer, for reasons I can't determine, the actual results were significantly more opaque. Since the new rendering actually displays the proper amount of alpha, I've basically just guess and checked comparisons to adjust; the apparent alpha is actually more like 0.8

2. Unlike all other `Detail` settings, nebula detail has an extra level of indirection for no reason; any changes to nebula detail must update  `neb2_set_detail_level()` rather than just using the value directly. Likely because of this inconsistency, an oversight when retrieving detail settings from the player file means this function is not called, and effectively nebula detail is never updated and always set to the medium initialized value for all players, unless they specifically go to the detail options screen.
All the values chosen for defaults were based on the highest detail, but this means pretty much everyone has been seeing the medium detail, which has smaller and closer poofs, and so the defaults have also been adjusted to those values instead and this pointless indrection has been removed.

3. Due to a math error in g3_render_rect_rotated()` all bitmaps drawn in that way were augmented in size by 41%. I've commented all the functions which used this math to make this behavior more clear and again compensated for this size difference for the new rendering (which renders at the proper size)

Poofs with test bitmaps

Retail:
https://user-images.githubusercontent.com/17305613/128966683-10429d78-ea78-4b28-bcc0-6876dce72241.mp4

#3507 
https://user-images.githubusercontent.com/17305613/128966692-7947e300-7be8-46b4-87f6-819bd6a4545d.mp4

This PR
https://user-images.githubusercontent.com/17305613/128966707-7b1acf29-7241-42f5-853b-56a95cf0d001.mp4

(the changes to the pattern of poofs is intentional, of note here is the density, opacity, and size of poofs)





