### PR TITLE
Fix collision retiming to never be in the future

### DIFF
--- a/code/object/objcollide.cpp
+++ b/code/object/objcollide.cpp
@@ -604,10 +604,10 @@ void obj_reset_colliders()
 	Collision_cached_pairs.clear();
 }
 
-void obj_collide_retime_cached_pairs(int checkdly)
+void obj_collide_retime_cached_pairs()
 {
 	for ( auto& pair : Collision_cached_pairs ) {
-		pair.second.next_check_time = timestamp(checkdly);
+		pair.second.next_check_time = timestamp(0);
 	}
 }
 

--- a/code/object/objcollide.h
+++ b/code/object/objcollide.h
@@ -70,8 +70,8 @@ void obj_remove_collider(int obj_index);
 void obj_reset_colliders();
 void obj_sort_and_collide(SCP_vector<int>* Collision_list = nullptr);
 
-// retimes all collision pairs to be checked (in 25ms by default)
-void obj_collide_retime_cached_pairs(int checkdly=25);
+// retimes all collision pairs to be checked immediately
+void obj_collide_retime_cached_pairs();
 
 // Returns TRUE if the weapon will never hit the other object.
 // If it can it predicts how long until these two objects need


### PR DESCRIPTION
A few times in the code, notably by usages of `set-object-position`, collision pairs `next_check_time`'s must be recalculated due to being invalidated for some reason (like an object teleporting). By default, it will set all pairs to be rechecked in 25ms. This is a very bad idea, and should never be set into the future by any amount. A pair which is validly imminently to be checked could end up getting deferred into the future past when it should be colliding. If that SEXP is used every frame and your framerate is better than 40, *all collisions are in effect disabled* as they get indefinitely deferred into the future.

They should always be set to time out on the very next check, and since nothing uses this optional parameter and I see very little reason to actually allow this, it has been removed as well.