### PR TITLE
Some fixes to shockwave rotation

### DIFF
--- a/code/weapon/shockwave.cpp
+++ b/code/weapon/shockwave.cpp
@@ -136,7 +136,13 @@ int shockwave_create(int parent_objnum, vec3d* pos, shockwave_create_info* sci, 
 	sw->time_elapsed=0.0f;
 	sw->delay_stamp = delay;
 
-	sw->rot_angles = sci->rot_angles;
+	if (!sci->rot_defined) {
+		sw->rot_angles.p = frand_range(0.0f, PI2);
+		sw->rot_angles.b = frand_range(0.0f, PI2);
+		sw->rot_angles.h = frand_range(0.0f, PI2);
+	} else 
+		sw->rot_angles = sci->rot_angles; // should just be 0,0,0
+
 	sw->damage_type_idx = sci->damage_type_idx;
 
 	sw->total_time = sw->outer_radius / sw->speed;
@@ -425,10 +431,10 @@ void shockwave_render(object *objp, model_draw_list *scene)
 
 		if ( Gr_framebuffer_effects[FramebufferEffects::Shockwaves] ) {
 			float intensity = ((sw->time_elapsed / sw->total_time) > 0.9f) ? (1.0f - (sw->time_elapsed / sw->total_time)) * 10.0f : 1.0f;
-			batching_add_distortion_bitmap_rotated(sw->current_bitmap, &p, fl_radians(sw->rot_angles.p), sw->radius, intensity);
+			batching_add_distortion_bitmap_rotated(sw->current_bitmap, &p, sw->rot_angles.p, sw->radius, intensity);
 		}
 
-		batching_add_volume_bitmap_rotated(sw->current_bitmap, &p, fl_radians(sw->rot_angles.p), sw->radius, alpha);
+		batching_add_volume_bitmap_rotated(sw->current_bitmap, &p, sw->rot_angles.p, sw->radius, alpha);
 	}
 }
 

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -754,7 +754,7 @@ void parse_shockwave_info(shockwave_create_info *sci, const char *pre_char)
 		stuff_float_list(angs, 3);
 		for(int i = 0; i < 3; i++)
 		{
-			angs[i] = angs[i] * (PI2/180.0f);
+			angs[i] = fl_radians(angs[i]);
 			while(angs[i] < 0)
 			{
 				angs[i] += PI2;
@@ -7088,11 +7088,6 @@ void weapon_hit( object * weapon_obj, object * other_obj, vec3d * hitpos, int qu
 	if (sci->inner_rad != 0.0f || sci->outer_rad != 0.0f)
 	{
 		if(sci->speed > 0.0f) {
-			if (!sci->rot_defined) {
-				sci->rot_angles.p = frand_range(0.0f, PI2);
-				sci->rot_angles.b = frand_range(0.0f, PI2);
-				sci->rot_angles.h = frand_range(0.0f, PI2);
-			}
 			shockwave_create(OBJ_INDEX(weapon_obj), hitpos, sci, sw_flag, -1);
 		}
 		else {


### PR DESCRIPTION
Converting from degrees to radians is *not* 2PI / 180 it's PI /180, so use the macro that has this figured out already. Yes, this will break the rotations of all currently defined shockwave rotations, but at least you can actually rotate into all orientations instead of just half of them now...

Additionally remove a redundant radian conversion when rendering 2D shockwaves, as this effectively prevents any usage of the rotation beyond a few degrees.

Also move `rot_angles` into the shockwave code, it should be modifying the new shockwave, not the `shockwave_create_info`.

Fixes #3603