### PR TITLE
some ai_profiles fixes

### DIFF
--- a/code/ai/ai_flags.h
+++ b/code/ai/ai_flags.h
@@ -139,6 +139,7 @@ namespace AI {
 		Improved_subsystem_attack_pathing,
 		Fixed_ship_weapon_collision,
 		No_shield_damage_from_ship_collisions,
+		Reset_last_hit_target_time_for_player_hits,
 
 		NUM_VALUES
 	};

--- a/code/ai/ai_profiles.cpp
+++ b/code/ai/ai_profiles.cpp
@@ -468,7 +468,6 @@ void parse_ai_profiles_tbl(const char *filename)
 
 				set_flag(profile, "$firing requires exact los:", AI::Profile_Flags::Require_exact_los);
 
-				profile->ai_path_mode = AI_PATH_MODE_NORMAL;
 				if (optional_string("$ai path mode:"))
 				{
 					stuff_string(buf, F_NAME, NAME_LENGTH);
@@ -507,8 +506,6 @@ void parse_ai_profiles_tbl(const char *filename)
 
 				set_flag(profile, "$use POF radius for subsystem path points:", AI::Profile_Flags::Use_subsystem_path_point_radii);
 
-				profile->bay_arrive_speed_mult = 1.0f;
-				profile->bay_depart_speed_mult = 1.0f;
 				if (optional_string("$bay arrive speed multiplier:")) {
 					stuff_float(&profile->bay_arrive_speed_mult);
 				}
@@ -568,7 +565,6 @@ void parse_ai_profiles_tbl(const char *filename)
 
 				//Intention is to expand this feature to include a preference for close or long range weapons
 				//hence using something besides a simple flag.
-				profile->ai_range_aware_secondary_select_mode = AI_RANGE_AWARE_SEC_SEL_MODE_RETAIL;
 				if (optional_string("$AI secondary range awareness:"))
 				{
 					stuff_string(buf, F_NAME, NAME_LENGTH);
@@ -582,6 +578,8 @@ void parse_ai_profiles_tbl(const char *filename)
 				}
 
 				set_flag(profile, "$no shield damage from ship collisions:", AI::Profile_Flags::No_shield_damage_from_ship_collisions);
+
+				set_flag(profile, "$reset last_hit_target_time for player hits:", AI::Profile_Flags::Reset_last_hit_target_time_for_player_hits);
 
 				// if we've been through once already and are at the same place, force a move
 				if (saved_Mp && (saved_Mp == Mp))
@@ -654,10 +652,10 @@ void ai_profile_t::reset()
 
     flags.reset();
 
-    ai_path_mode = 0;
+    ai_path_mode = AI_PATH_MODE_NORMAL;
 	subsystem_path_radii = 0;
-    bay_arrive_speed_mult = 0;
-    bay_depart_speed_mult = 0;
+    bay_arrive_speed_mult = 1.0f;
+    bay_depart_speed_mult = 1.0f;
 	second_order_lead_predict_factor = 0;
 	ai_range_aware_secondary_select_mode = AI_RANGE_AWARE_SEC_SEL_MODE_RETAIL;
 
@@ -736,6 +734,10 @@ void ai_profile_t::reset()
 	// this flag has been enabled ever since 3.7.2
 	if (mod_supports_version(3, 7, 2)) {
 		flags.set(AI::Profile_Flags::Fix_ramming_stationary_targets_bug);
+	}
+	// and this flag has been enabled ever since 3.6.10
+	if (mod_supports_version(3, 6, 10)) {
+		flags.set(AI::Profile_Flags::Reset_last_hit_target_time_for_player_hits);
 	}
 	if (mod_supports_version(21, 4, 0)) {
 		flags.set(AI::Profile_Flags::Fixed_ship_weapon_collision);

--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -15426,27 +15426,29 @@ void ai_ship_hit(object *objp_ship, object *hit_objp, vec3d *hit_normal)
 	aip = &Ai_info[shipp->ai_index];
 
 	if (objp_ship->flags[Object::Object_Flags::Player_ship]) {
-		//SUSHI: So that hitting a player ship actually resets the last_hit_target_time counter for whoever hit the player.
-		//This is all copypasted from code below
-		// Added OBJ_BEAM for traitor detection - FUBAR
-		if ((hit_objp->type == OBJ_WEAPON) || (hit_objp->type == OBJ_BEAM)) {
-			hitter_objnum = hit_objp->parent;
-			Assert((hitter_objnum < MAX_OBJECTS));
-			if (hitter_objnum == -1) {
-				return; // Possible SSM, bail while we still can.
+		if (The_mission.ai_profile->flags[AI::Profile_Flags::Reset_last_hit_target_time_for_player_hits]) {
+			//SUSHI: So that hitting a player ship actually resets the last_hit_target_time counter for whoever hit the player.
+			//This is all copypasted from code below
+			// Added OBJ_BEAM for traitor detection - FUBAR
+			if ((hit_objp->type == OBJ_WEAPON) || (hit_objp->type == OBJ_BEAM)) {
+				hitter_objnum = hit_objp->parent;
+				Assert((hitter_objnum < MAX_OBJECTS));
+				if (hitter_objnum == -1) {
+					return; // Possible SSM, bail while we still can.
+				}
+				objp_hitter = &Objects[hitter_objnum];
+			} else if (hit_objp->type == OBJ_SHIP) {
+				objp_hitter = hit_objp;
+			} else {
+				Int3();	// Should never happen.
+				return;
 			}
-			objp_hitter = &Objects[hitter_objnum];
-		} else if (hit_objp->type == OBJ_SHIP) {
-			objp_hitter = hit_objp;
-		} else {
-			Int3();	// Should never happen.
-			return;
-		}
-		Assert(objp_hitter != NULL);
-		hitter_aip = &Ai_info[Ships[objp_hitter->instance].ai_index];
-		hitter_aip->last_hit_target_time = Missiontime;
+			Assert(objp_hitter != NULL);
+			hitter_aip = &Ai_info[Ships[objp_hitter->instance].ai_index];
+			hitter_aip->last_hit_target_time = Missiontime;
 
-		aip->last_hit_time = Missiontime;
+			aip->last_hit_time = Missiontime;
+		}
 		return;
 	}
 

--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -15418,7 +15418,7 @@ void ai_update_lethality(object *pship_obj, object *other_obj, float damage)
 void ai_ship_hit(object *objp_ship, object *hit_objp, vec3d *hit_normal)
 {
 	int		hitter_objnum = -2;
-	object	*objp_hitter = NULL;
+	object	*objp_hitter = nullptr;
 	ship		*shipp;
 	ai_info	*aip, *hitter_aip;
 
@@ -15440,10 +15440,10 @@ void ai_ship_hit(object *objp_ship, object *hit_objp, vec3d *hit_normal)
 			} else if (hit_objp->type == OBJ_SHIP) {
 				objp_hitter = hit_objp;
 			} else {
-				Int3();	// Should never happen.
+				UNREACHABLE("Should never happen.");
 				return;
 			}
-			Assert(objp_hitter != NULL);
+			Assert(objp_hitter != nullptr);
 			hitter_aip = &Ai_info[Ships[objp_hitter->instance].ai_index];
 			hitter_aip->last_hit_target_time = Missiontime;
 
@@ -15534,7 +15534,7 @@ void ai_ship_hit(object *objp_ship, object *hit_objp, vec3d *hit_normal)
 	if (hit_objp->flags[Object::Object_Flags::Protected])
 		return;
 
-	Assert(objp_hitter != NULL);
+	Assert(objp_hitter != nullptr);
 	hitter_aip = &Ai_info[Ships[objp_hitter->instance].ai_index];
 	hitter_aip->last_hit_target_time = Missiontime;
 	


### PR DESCRIPTION
1) Several AI profiles options were getting reset on every iteration through the loop.  They should only be reset when the profile is initially created.
2) Keeping track of AI hits on the player ship was added by Sushi in 9246a2f74d and needs to be guarded by a flag.  This flag has been enabled for mods that set the required FSO version.