### PR TITLE
Exclude dead subsys from targeting

### DIFF
--- a/code/hud/hudlock.cpp
+++ b/code/hud/hudlock.cpp
@@ -1485,7 +1485,7 @@ void hud_do_lock_indicators(float frametime)
 			continue;
 		}
 
-		if ( wip->wi_flags[Weapon::Info_Flags::Multilock_ignore_dead_subsys] && lock_slot->subsys != nullptr && lock_slot->subsys->current_hits <= 0.0f) {
+		if ( !wip->wi_flags[Weapon::Info_Flags::Multilock_target_dead_subsys] && lock_slot->subsys != nullptr && lock_slot->subsys->current_hits <= 0.0f) {
 			ship_clear_lock(lock_slot);
 			continue;
 		}

--- a/code/hud/hudlock.cpp
+++ b/code/hud/hudlock.cpp
@@ -1485,6 +1485,11 @@ void hud_do_lock_indicators(float frametime)
 			continue;
 		}
 
+		if ( wip->wi_flags[Weapon::Info_Flags::Multilock_ignore_dead_subsys] && lock_slot->subsys != nullptr && lock_slot->subsys->current_hits <= 0.0f) {
+			ship_clear_lock(lock_slot);
+			continue;
+		}
+
 		hud_lock_determine_lock_point(lock_slot);
 
 		hud_lock_check_if_target_in_lock_cone(lock_slot, wip);

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -529,7 +529,7 @@ flag_def_list_new<Weapon::Info_Flags> ai_tgt_weapon_flags[] = {
     { "die on lost lock",			Weapon::Info_Flags::Die_on_lost_lock,					true, false },
 	{ "no impact spew",				Weapon::Info_Flags::No_impact_spew,						true, false },
 	{ "require exact los",			Weapon::Info_Flags::Require_exact_los,					true, false },
-	{ "multilock ignore dead subsys", Weapon::Info_Flags::Multilock_ignore_dead_subsys,		true, false },
+	{ "multilock target dead subsys", Weapon::Info_Flags::Multilock_target_dead_subsys,		true, false },
 };
 
 const int num_ai_tgt_weapon_info_flags = sizeof(ai_tgt_weapon_flags) / sizeof(flag_def_list_new<Weapon::Info_Flags>);

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -529,6 +529,7 @@ flag_def_list_new<Weapon::Info_Flags> ai_tgt_weapon_flags[] = {
     { "die on lost lock",			Weapon::Info_Flags::Die_on_lost_lock,					true, false },
 	{ "no impact spew",				Weapon::Info_Flags::No_impact_spew,						true, false },
 	{ "require exact los",			Weapon::Info_Flags::Require_exact_los,					true, false },
+	{ "multilock ignore dead subsys", Weapon::Info_Flags::Multilock_ignore_dead_subsys,		true, false },
 };
 
 const int num_ai_tgt_weapon_info_flags = sizeof(ai_tgt_weapon_flags) / sizeof(flag_def_list_new<Weapon::Info_Flags>);

--- a/code/weapon/weapon_flags.h
+++ b/code/weapon/weapon_flags.h
@@ -88,6 +88,7 @@ namespace Weapon {
 		Can_damage_shooter,					// this weapon and any of its descendants can damage its shooter - Asteroth
 		Heals,								// 'damage' heals instead of actually damaging - Asteroth
 		No_collide,
+		Multilock_ignore_dead_subsys,
 
         NUM_VALUES
 	};

--- a/code/weapon/weapon_flags.h
+++ b/code/weapon/weapon_flags.h
@@ -88,7 +88,7 @@ namespace Weapon {
 		Can_damage_shooter,					// this weapon and any of its descendants can damage its shooter - Asteroth
 		Heals,								// 'damage' heals instead of actually damaging - Asteroth
 		No_collide,
-		Multilock_ignore_dead_subsys,
+		Multilock_target_dead_subsys,
 
         NUM_VALUES
 	};

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -187,6 +187,7 @@ flag_def_list_new<Weapon::Info_Flags> Weapon_Info_Flags[] = {
 	{ "can damage shooter",				Weapon::Info_Flags::Can_damage_shooter,					true, false },
 	{ "heals",							Weapon::Info_Flags::Heals,						        true, false },
 	{ "no collide",						Weapon::Info_Flags::No_collide,						    true, false },
+	{ "multilock ignore dead subsys",   Weapon::Info_Flags::Multilock_ignore_dead_subsys,		true, false },
 };
 
 const size_t num_weapon_info_flags = sizeof(Weapon_Info_Flags) / sizeof(flag_def_list_new<Weapon::Info_Flags>);
@@ -9183,7 +9184,7 @@ bool weapon_multilock_can_lock_on_subsys(object* shooter, object* target, ship_s
 		return false;
 
 	//by not checking for max_hits > 0 here, subsys' with disabled hitpoints are also excluded.
-	if (target_subsys->current_hits <= 0.0f)
+	if (wip->wi_flags[Weapon::Info_Flags::Multilock_ignore_dead_subsys] && target_subsys->current_hits <= 0.0f)
 		return false;
 
 	vec3d ss_pos;

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -187,7 +187,7 @@ flag_def_list_new<Weapon::Info_Flags> Weapon_Info_Flags[] = {
 	{ "can damage shooter",				Weapon::Info_Flags::Can_damage_shooter,					true, false },
 	{ "heals",							Weapon::Info_Flags::Heals,						        true, false },
 	{ "no collide",						Weapon::Info_Flags::No_collide,						    true, false },
-	{ "multilock ignore dead subsys",   Weapon::Info_Flags::Multilock_ignore_dead_subsys,		true, false },
+	{ "multilock target dead subsys",   Weapon::Info_Flags::Multilock_target_dead_subsys,		true, false },
 };
 
 const size_t num_weapon_info_flags = sizeof(Weapon_Info_Flags) / sizeof(flag_def_list_new<Weapon::Info_Flags>);
@@ -9184,7 +9184,7 @@ bool weapon_multilock_can_lock_on_subsys(object* shooter, object* target, ship_s
 		return false;
 
 	//by not checking for max_hits > 0 here, subsys' with disabled hitpoints are also excluded.
-	if (wip->wi_flags[Weapon::Info_Flags::Multilock_ignore_dead_subsys] && target_subsys->current_hits <= 0.0f)
+	if (!wip->wi_flags[Weapon::Info_Flags::Multilock_target_dead_subsys] && target_subsys->current_hits <= 0.0f)
 		return false;
 
 	vec3d ss_pos;

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -9182,6 +9182,10 @@ bool weapon_multilock_can_lock_on_subsys(object* shooter, object* target, ship_s
 	if (target_subsys->flags[Ship::Subsystem_Flags::Untargetable])
 		return false;
 
+	//by not checking for max_hits > 0 here, subsys' with disabled hitpoints are also excluded.
+	if (target_subsys->current_hits <= 0.0f)
+		return false;
+
 	vec3d ss_pos;
 	get_subsystem_world_pos(target, target_subsys, &ss_pos);
 


### PR DESCRIPTION
Fixes #3613.
Turns out ``weapon_multilock_can_lock_on_subsys`` just never checked for HP...