### PR TITLE
Fixes a typo in controlconfig that causes an issue with std::move.

### DIFF
--- a/code/controlconfig/controlsconfig.cpp
+++ b/code/controlconfig/controlsconfig.cpp
@@ -1288,7 +1288,7 @@ void control_config_cancel_exit()
 {
 	// Restore all bindings with the backup
 	std::move(Control_config_backup.begin(), Control_config_backup.end(), Control_config.begin());
-	std::move(Axis_map_to_backup, Axis_map_to_backup + JOY_NUM_AXES, Axis_map_to);
+	std::move(Axis_map_to_backup, Axis_map_to_backup + NUM_JOY_AXIS_ACTIONS, Axis_map_to);
 	std::move(Invert_axis_backup, Invert_axis_backup + JOY_NUM_AXES, Invert_axis);
 
 	gameseq_post_event(GS_EVENT_PREVIOUS_STATE);


### PR DESCRIPTION
Essentially, the wrong constant was used in the call to std::move which happened to be 1 element too long fo both Axis_map_to[] and Axis_map_to_defaults[].  Some compilers would complain about this, but apparently mine didn't catch it when I made the code changes.