### PR TITLE
Single target multilock missiles should use `targeted_subsys`

### DIFF
--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -5789,10 +5789,9 @@ bool ai_do_multilock(ai_info* aip, weapon_info* wip) {
 	// First we accrue all available targets into this vector which we will later sort by dot 
 	SCP_vector<multilock_target> multilock_targets;
 
-	if (wip->target_restrict == LR_CURRENT_TARGET) {
-
+	if (wip->target_restrict == LR_CURRENT_TARGET)
 		multilock_targets.push_back(multilock_target{ primary_target, aip->targeted_subsys, 1.0f });
-	} else if (wip->target_restrict == LR_CURRENT_TARGET_SUBSYS) {
+	else if (wip->target_restrict == LR_CURRENT_TARGET_SUBSYS) {
 
 		if (primary_target->type != OBJ_SHIP)
 			multilock_targets.push_back(multilock_target{ primary_target,  nullptr, 1.0f });

--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -5789,9 +5789,10 @@ bool ai_do_multilock(ai_info* aip, weapon_info* wip) {
 	// First we accrue all available targets into this vector which we will later sort by dot 
 	SCP_vector<multilock_target> multilock_targets;
 
-	if (wip->target_restrict == LR_CURRENT_TARGET)
-		multilock_targets.push_back(multilock_target{ primary_target,  nullptr, 1.0f });
-	else if (wip->target_restrict == LR_CURRENT_TARGET_SUBSYS) {
+	if (wip->target_restrict == LR_CURRENT_TARGET) {
+
+		multilock_targets.push_back(multilock_target{ primary_target, aip->targeted_subsys, 1.0f });
+	} else if (wip->target_restrict == LR_CURRENT_TARGET_SUBSYS) {
 
 		if (primary_target->type != OBJ_SHIP)
 			multilock_targets.push_back(multilock_target{ primary_target,  nullptr, 1.0f });


### PR DESCRIPTION
...if available, it's simply nullptr otherwise. That they got this far that means the ship is attempting to fire a missile at its target, and if it has a `targeted_subsys` then in all other scenarios this means necessarily it is attempting to fire it locked on that subsystem. (the other cases already handle this properly)

Fixes #3611