### PR TITLE
No chase cam 'slewing' during hyperspace

### DIFF
--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -3141,7 +3141,8 @@ camid game_render_frame_setup()
 
 				vec3d old_pos;
 				main_cam->get_info(&old_pos, nullptr);
-				if (camera_cut)
+				bool hyperspace = (Player_ship->flags[Ship::Ship_Flags::Depart_warp] && Warp_params[Player_ship->warpout_params_index].warp_type == WT_HYPERSPACE);
+				if (camera_cut || hyperspace)
 					old_pos = eye_pos;
 
 				// "push" the camera backwards in the direction of its old position based on acceleration to to make it 


### PR DESCRIPTION
#3571 includes a sort of 'sway' to the camera as the ship moves, which is literally calculated based on the old position of the camera trying to keep up with its proper position. Due to this, if the ship moves in significant or unexpected ways, this camera 'catch-up' makes it quite obvious. Since FotG has requested it, and since as far as I'm concerned they should probably be the authority on how it should work, it is disabled during the extreme acceleration of hyperspace, so it doesn't leave the camera in the dust.

This is also an issue for `set-object-position` or its derivatives, but the solution will be more complicated there.