### PR TITLE
match wing names and aliases on the status gauge

### DIFF
--- a/code/hud/hudwingmanstatus.cpp
+++ b/code/hud/hudwingmanstatus.cpp
@@ -99,24 +99,6 @@ void hud_set_wingman_status_alive( int wing_index, int wing_pos)
 	HUD_wingman_status[wing_index].status[wing_pos] = HUD_WINGMAN_STATUS_ALIVE;
 }
 
-void hud_wingman_status_init_late_wings()
-{
-/*
-	int i, j, wing_index;
-
-	for ( i = 0; i < Num_wings; i++ ) {
-		wing_index = ship_squadron_wing_lookup(Wings[i].name);
-
-		if ( (wing_index >= 0) && (Wings[i].total_arrived_count == 0) ) {
-			HUD_wingman_status[wing_index].used = 1;
-			for (j = 0; j < Wings[i].wave_count; j++) {
-				HUD_wingman_status[wing_index].status[j] = HUD_WINGMAN_STATUS_NOT_HERE;
-			}
-		}
-	}
-*/
-}
-
 // function which marks the other team wing as not used for the wingman status gauge
 void hud_wingman_kill_multi_teams()
 {
@@ -161,7 +143,6 @@ void hud_init_wingman_status_gauge()
 		}
 	}
 
-	hud_wingman_status_init_late_wings();
 	hud_wingman_kill_multi_teams();
 	hud_wingman_status_update();
 }

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -18322,9 +18322,13 @@ int ship_squadron_wing_lookup(const char *wing_name)
 	}
 	else 
 	{
+		// match duplicate wings, such as Epsilon and Epsilon#clone
+		auto ch = get_pointer_to_first_hash_symbol(wing_name);
+		size_t len = (ch != nullptr) ? (ch - wing_name) : strlen(wing_name);
+
 		for (int i = 0; i < MAX_SQUADRON_WINGS; i++)
 		{
-			if (!stricmp(Squadron_wing_names[i], wing_name))
+			if (!strnicmp(Squadron_wing_names[i], wing_name, len))
 				return i;
 		}
 	}


### PR DESCRIPTION
If a wing has a hash symbol, it needs to match the squadron status gauge for the equivalent name without the hash.  This could happen for in-mission jumps or cases where a wing leaves and comes back.

Also remove an obsolete function.