### PR TITLE
Expose Outer and Inner Radii to the Lua API in the weaponclass type

### DIFF
--- a/code/scripting/api/objs/weaponclass.cpp
+++ b/code/scripting/api/objs/weaponclass.cpp
@@ -399,6 +399,43 @@ ADE_VIRTVAR(Speed, l_Weaponclass, "number", "Weapon max speed, aka $Velocity in 
 	return ade_set_args(L, "f", Weapon_info[idx].max_speed);
 }
 
+
+ADE_VIRTVAR(InnerRadius, l_Weaponclass, "number", "Radius at which the full explosion damage is done. Marks the line where damage attenuation begins. Same as $Inner Radius in weapons.tbl", "number", "Inner Radius, or 0 if handle is invalid")
+{
+	int idx;
+	float irad = 0.0f;
+	if(!ade_get_args(L, "o|f", l_Weaponclass.Get(&idx), &irad))
+		return ade_set_error(L, "f", 0.0f);
+
+	if(idx < 0 || idx >= weapon_info_size())
+		return ade_set_error(L, "f", 0.0f);
+
+	if(ADE_SETTING_VAR) {
+		Weapon_info[idx].shockwave.inner_rad = irad;
+	}
+
+	return ade_set_args(L, "f", Weapon_info[idx].shockwave.inner_rad);
+}
+
+
+ADE_VIRTVAR(OuterRadius, l_Weaponclass, "number", "Maximum Radius at which any damage is done with this weapon. Same as $Outer Radius in weapons.tbl", "number", "Outer Radius, or 0 if handle is invalid")
+{
+	int idx;
+	float orad = 0.0f;
+	if(!ade_get_args(L, "o|f", l_Weaponclass.Get(&idx), &orad))
+		return ade_set_error(L, "f", 0.0f);
+
+	if(idx < 0 || idx >= weapon_info_size())
+		return ade_set_error(L, "f", 0.0f);
+
+	if(ADE_SETTING_VAR) {
+		Weapon_info[idx].shockwave.outer_rad = orad;
+	}
+
+	return ade_set_args(L, "f", Weapon_info[idx].shockwave.outer_rad);
+}
+
+
 ADE_VIRTVAR(Bomb, l_Weaponclass, "boolean", "Is weapon class flagged as bomb", "boolean", "New flag")
 {
 	int idx;


### PR DESCRIPTION
This allows scripters to have a little more data to work with. I used it to predict which ships are in range of an Infyrno missile, as a proof of concept for 0rp3u5's [request on HLP](https://www.hard-light.net/forums/index.php?topic=96194.0). 