### PR TITLE
run Lua garbage collector on mission start

### DIFF
--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -188,6 +188,13 @@
 #include "weapon/shockwave.h"
 #include "weapon/weapon.h"
 
+// for the Lua garbage collector
+extern "C"
+{
+	#include "lgc.h"
+}
+
+
 #include <SDL.h>
 #include <SDL_main.h>
 
@@ -1360,7 +1367,13 @@ bool game_start_mission()
 
 	game_busy( NOX("** starting mission_load() **") );
 	load_mission_load = (uint) time(nullptr);
-	if ( !mission_load(Game_current_mission_filename) ) {
+	bool load_success = mission_load(Game_current_mission_filename);
+	load_mission_load = (uint)(time(nullptr) - load_mission_load);
+
+	// free up memory from parsing the mission
+	stop_parse();
+
+	if ( !load_success ) {
 		if ( !(Game_mode & GM_MULTIPLAYER) ) {
 			popup(PF_BODY_BIG | PF_USE_AFFIRMATIVE_ICON, 1, POPUP_OK, XSTR( "Attempt to load the mission failed", 169));
 			gameseq_post_event(GS_EVENT_MAIN_MENU);
@@ -1376,11 +1389,15 @@ bool game_start_mission()
 
 		return false;
 	}
-	load_mission_load = (uint) (time(nullptr) - load_mission_load);
 
-	// free up memory from parsing the mission
-	extern void stop_parse();
-	stop_parse();
+	// Since we just freed up memory, now is probably a good time to run the Lua garbage collector.
+	// This is also after the preliminary checks are complete but before things start getting paged in.
+	auto L = Script_system.GetLuaSession();
+	if (L != nullptr)
+	{
+		game_busy(NOX("** cleaning up Lua objects **"));
+		luaC_fullgc(L);
+	}
 
 	game_busy( NOX("** starting game_post_level_init() **") );
 	load_post_level_init = (uint) time(nullptr);


### PR DESCRIPTION
This might fix #2961.  By explicitly running the garbage collector before a mission starts, this will ensure each mission begins with a clean slate.