### PR TITLE
Fix turrets not resetting sometimes

### DIFF
--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -11648,9 +11648,6 @@ void process_subobjects(int objnum)
 	ai_info	*aip = &Ai_info[shipp->ai_index];
 	ship_info	*sip = &Ship_info[shipp->ship_info_index];
 
-	//Look for enemies. If none are present, we don't have to move turrets
-	int enemies_present = -1;
-
 	model_subsystem	*psub;
 	for ( pss = GET_FIRST(&shipp->subsys_list); pss !=END_OF_LIST(&shipp->subsys_list); pss = GET_NEXT(pss) ) {
 		psub = pss->system_info;

--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -11670,34 +11670,7 @@ void process_subobjects(int objnum)
 
 			if ( psub->turret_num_firing_points > 0 )
 			{
-				if(enemies_present == -1)
-				{
-					enemies_present = 0;
-					for(unsigned int i = 0; i < MAX_OBJECTS; i++)
-					{
-						objp = &Objects[i];
-						switch(objp->type)
-						{
-							case OBJ_SHIP:
-							case OBJ_DEBRIS:
-							case OBJ_WEAPON:
-								if(obj_team(objp) != shipp->team)
-									enemies_present = 1;
-								break;
-							case OBJ_ASTEROID:
-								enemies_present = 1;
-								break;
-						}
-
-						if(enemies_present==1)
-							break;
-					}
-					//Reset objp
-					objp = &Objects[objnum];
-				}
-				//Only move turrets if enemies are present
-				if(enemies_present == 1 || pss->turret_enemy_objnum >= 0)
-					ai_fire_from_turret(shipp, pss);
+				ai_turret_execute_behavior(shipp, pss);
 			} else {
 				Warning( LOCATION, "Turret %s on ship %s has no firing points assigned to it.\nThis needs to be fixed in the model.\n", psub->name, shipp->ship_name );
 			}

--- a/code/ai/aiinternal.h
+++ b/code/ai/aiinternal.h
@@ -32,6 +32,6 @@ int check_ok_to_fire(int objnum, int target_objnum, weapon_info *wip, int second
 bool check_los(int objnum, int target_objnum, float threshold, int primary_bank, int secondary_bank, ship_subsys* turret);
 
 //Does all the stuff needed to aim and fire a turret.
-void ai_fire_from_turret(ship *shipp, ship_subsys *ss);
+void ai_turret_execute_behavior(ship *shipp, ship_subsys *ss);
 
 #endif

--- a/code/ai/aiturret.cpp
+++ b/code/ai/aiturret.cpp
@@ -2130,7 +2130,7 @@ int Num_turrets_fired = 0;
  * Given a turret tp and its parent parent_objnum, fire from the turret at its enemy.
  */
 extern int Nebula_sec_range;
-void ai_fire_from_turret(ship *shipp, ship_subsys *ss)
+void ai_turret_execute_behavior(ship *shipp, ship_subsys *ss)
 {
 	float		weapon_firing_range;
     float		weapon_min_range;			// *Weapon minimum firing range -Et1

--- a/code/ai/aiturret.cpp
+++ b/code/ai/aiturret.cpp
@@ -2127,7 +2127,9 @@ int Num_find_turret_enemy = 0;
 int Num_turrets_fired = 0;
 
 /**
- * Given a turret tp and its parent parent_objnum, fire from the turret at its enemy.
+ * Previously called ai_fire_from_turret()
+ * Given a ship and a turret subsystem, handle all its behavior, mostly targeting and shooting but also 
+ * all turret movement and resetting when idle
  */
 extern int Nebula_sec_range;
 void ai_turret_execute_behavior(ship *shipp, ship_subsys *ss)


### PR DESCRIPTION
`ai_fire_from_turret()` has been renamed to something more appropriate `ai_turret_execute_behavior()` to make it clear that it's more general than literally just shooting at things. The function needs to be evaluated regardless of whether there are enemies on the field or the turret has a target because that is where resetting is done. The function is perfectly capable of determining on its own that there are no valid targets and not to do anything other than possibly reset.