### PR TITLE
Expose OSWPT to Lua and allow for LuaSEXP argument

### DIFF
--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -5455,86 +5455,61 @@ int sexp_string_compare(int n, int op)
 	return SEXP_TRUE;
 }
 
-#define OSWPT_TYPE_NONE				0
-#define OSWPT_TYPE_SHIP				1
-#define OSWPT_TYPE_WING				2
-#define OSWPT_TYPE_WAYPOINT			3
-#define OSWPT_TYPE_SHIP_ON_TEAM		4	// e.g. <any friendly>
-#define OSWPT_TYPE_WHOLE_TEAM		5	// e.g. Friendly
-#define OSWPT_TYPE_PARSE_OBJECT		6	// a "ship" that hasn't arrived yet
-#define OSWPT_TYPE_EXITED			7
-#define OSWPT_TYPE_WING_NOT_PRESENT	8	// a wing that hasn't arrived yet or is between waves
-
-// Goober5000
-struct object_ship_wing_point_team
+object_ship_wing_point_team::object_ship_wing_point_team(ship* sp)
+: object_name(sp->ship_name), type(OSWPT_TYPE_SHIP), objp(&Objects[sp->objnum])
 {
-	const char *object_name = nullptr;
-	int type = OSWPT_TYPE_NONE;
-
-	const ship_registry_entry *ship_entry = nullptr;
-	object *objp = nullptr;
-	wing *wingp = nullptr;
-	waypoint *waypointp = nullptr;
-	int team = -1;
-
-	object_ship_wing_point_team() = default;
-
-	object_ship_wing_point_team(ship *sp)
-		: object_name(sp->ship_name), type(OSWPT_TYPE_SHIP), objp(&Objects[sp->objnum])
+	ship_entry = ship_registry_get(sp->ship_name);
+	if (ship_entry->status == EXITED)
 	{
-		ship_entry = ship_registry_get(sp->ship_name);
-		if (ship_entry->status == EXITED) 
-		{
-			type = OSWPT_TYPE_EXITED;
-		}
+		type = OSWPT_TYPE_EXITED;
 	}
+}
 
-	object_ship_wing_point_team(p_object *pop)
-		: object_name(pop->name), type(OSWPT_TYPE_PARSE_OBJECT)
+object_ship_wing_point_team::object_ship_wing_point_team(p_object* pop)
+: object_name(pop->name), type(OSWPT_TYPE_PARSE_OBJECT)
+{
+	ship_entry = ship_registry_get(pop->name);
+}
+
+object_ship_wing_point_team::object_ship_wing_point_team(ship_obj* sop)
+	: object_ship_wing_point_team(&Ships[Objects[sop->objnum].instance])
+{}
+
+object_ship_wing_point_team::object_ship_wing_point_team(wing* wp)
+	: object_name(wp->name), wingp(wp)
+{
+	if (wingp->current_count > 0)
+		type = OSWPT_TYPE_WING;
+	else
+		type = OSWPT_TYPE_WING_NOT_PRESENT;
+
+	// point to wing leader if he is valid
+	if ((wingp->special_ship >= 0) && (wingp->ship_index[wingp->special_ship] >= 0))
 	{
-		ship_entry = ship_registry_get(pop->name);
+		objp = &Objects[Ships[wingp->ship_index[wingp->special_ship]].objnum];
 	}
-
-	object_ship_wing_point_team(ship_obj *sop)
-		: object_ship_wing_point_team(&Ships[Objects[sop->objnum].instance])
-	{}
-
-	object_ship_wing_point_team(wing *wp)
-		: object_name(wp->name), wingp(wp)
+	// boo... well, just point to ship at index 0
+	else
 	{
-		if (wingp->current_count > 0)
-			type = OSWPT_TYPE_WING;
-		else
-			type = OSWPT_TYPE_WING_NOT_PRESENT;
-
-		// point to wing leader if he is valid
-		if ((wingp->special_ship >= 0) && (wingp->ship_index[wingp->special_ship] >= 0))
-		{
-			objp = &Objects[Ships[wingp->ship_index[wingp->special_ship]].objnum];
-		}
-		// boo... well, just point to ship at index 0
-		else
-		{
-			objp = &Objects[Ships[wingp->ship_index[0]].objnum];
-			Warning(LOCATION, "Substituting ship '%s' at index 0 for nonexistent wing leader at index %d!", Ships[objp->instance].ship_name, wingp->special_ship);
-		}
+		objp = &Objects[Ships[wingp->ship_index[0]].objnum];
+		Warning(LOCATION, "Substituting ship '%s' at index 0 for nonexistent wing leader at index %d!", Ships[objp->instance].ship_name, wingp->special_ship);
 	}
+}
 
-	void clear()
-	{
-		object_name = nullptr;
-		type = OSWPT_TYPE_NONE;
+void object_ship_wing_point_team::clear()
+{
+	object_name = nullptr;
+	type = OSWPT_TYPE_NONE;
 
-		ship_entry = nullptr;
-		objp = nullptr;
-		wingp = nullptr;
-		waypointp = nullptr;
-		team = -1;
-	}
-};
+	ship_entry = nullptr;
+	objp = nullptr;
+	wingp = nullptr;
+	waypointp = nullptr;
+	team = -1;
+}
 
 // Goober5000
-void eval_object_ship_wing_point_team(object_ship_wing_point_team *oswpt, int node, const char *ctext_override = nullptr)
+void eval_object_ship_wing_point_team(object_ship_wing_point_team *oswpt, int node, const char *ctext_override)
 {
 	const ship_registry_entry *ship_entry = nullptr;
 	wing *wingp = nullptr;

--- a/code/parse/sexp.h
+++ b/code/parse/sexp.h
@@ -16,6 +16,10 @@
 class ship_subsys;
 class ship;
 class waypoint_list;
+class object;
+class waypoint;
+class p_object;
+struct ship_obj;
 
 // bumped to 30 by Goober5000
 #define	OPERATOR_LENGTH	30  // if this ever exceeds TOKEN_LENGTH, let JasonH know!
@@ -1338,5 +1342,40 @@ extern int Sexp_hud_display_warpout;
 int get_effect_from_name(const char* name);
 
 void maybe_write_to_event_log(int result);
+
+//OSWPT Stuff
+
+#define OSWPT_TYPE_NONE				0
+#define OSWPT_TYPE_SHIP				1
+#define OSWPT_TYPE_WING				2
+#define OSWPT_TYPE_WAYPOINT			3
+#define OSWPT_TYPE_SHIP_ON_TEAM		4	// e.g. <any friendly>
+#define OSWPT_TYPE_WHOLE_TEAM		5	// e.g. Friendly
+#define OSWPT_TYPE_PARSE_OBJECT		6	// a "ship" that hasn't arrived yet
+#define OSWPT_TYPE_EXITED			7
+#define OSWPT_TYPE_WING_NOT_PRESENT	8	// a wing that hasn't arrived yet or is between waves
+
+// Goober5000
+struct object_ship_wing_point_team
+{
+	const char* object_name = nullptr;
+	int type = OSWPT_TYPE_NONE;
+
+	const ship_registry_entry* ship_entry = nullptr;
+	object* objp = nullptr;
+	wing* wingp = nullptr;
+	waypoint* waypointp = nullptr;
+	int team = -1;
+
+	object_ship_wing_point_team() = default;
+	object_ship_wing_point_team(ship* sp);
+	object_ship_wing_point_team(p_object* pop);
+	object_ship_wing_point_team(ship_obj* sop);
+	object_ship_wing_point_team(wing* wp);
+
+	void clear();
+};
+
+void eval_object_ship_wing_point_team(object_ship_wing_point_team* oswpt, int node, const char* ctext_override = nullptr);
 
 #endif

--- a/code/parse/sexp/LuaSEXP.cpp
+++ b/code/parse/sexp/LuaSEXP.cpp
@@ -10,6 +10,7 @@
 #include "parse/sexp.h"
 #include "parse/sexp/sexp_lookup.h"
 #include "scripting/api/objs/message.h"
+#include "scripting/api/objs/oswpt.h"
 #include "scripting/api/objs/sexpvar.h"
 #include "scripting/api/objs/ship.h"
 #include "scripting/api/objs/shipclass.h"
@@ -38,7 +39,14 @@ SCP_unordered_map<SCP_string, int> parameter_type_mapping{{ "boolean",      OPF_
 														  { "wing",         OPF_WING },
 														  { "shipclass",    OPF_SHIP_CLASS_NAME },
 														  { "weaponclass",  OPF_WEAPON_NAME },
-														  { "soundentry",   OPF_GAME_SND }, };
+														  { "soundentry",   OPF_GAME_SND }, 
+														  { "oswpt-ship+waypoint",   OPF_SHIP_POINT },
+														  { "oswpt-ship+wing",   OPF_SHIP_WING },
+														  { "oswpt-ship+wing+team",   OPF_SHIP_WING_WHOLETEAM },
+														  { "oswpt-ship+wing+team+waypoint",   OPF_SHIP_WING_SHIPONTEAM_POINT },
+														  { "oswpt-ship+wing+waypoint",   OPF_SHIP_WING_POINT },
+														  { "oswpt-ship+wing+waypoint+none",   OPF_SHIP_WING_POINT_OR_NONE }, };
+
 std::pair<SCP_string, int> get_parameter_type(const SCP_string& name)
 {
 	SCP_string copy = name;
@@ -228,6 +236,16 @@ luacpp::LuaValue LuaSEXP::sexpToLua(int node, int argnum) const {
 	case OPF_STRING: {
 		auto text = CTEXT(node);
 		return LuaValue::createValue(_action.getLuaState(), text);
+	}
+	case OPF_SHIP_POINT:
+	case OPF_SHIP_WING:
+	case OPF_SHIP_WING_WHOLETEAM:
+	case OPF_SHIP_WING_SHIPONTEAM_POINT:
+	case OPF_SHIP_WING_POINT:
+	case OPF_SHIP_WING_POINT_OR_NONE: {
+		object_ship_wing_point_team oswpt;
+		eval_object_ship_wing_point_team(&oswpt, node);
+		return LuaValue::createValue(_action.getLuaState(), l_OSWPT.Set(oswpt));
 	}
 	default:
 		UNREACHABLE("Unhandled argument type! Someone added an argument type but didn't add handling code to execute().");

--- a/code/parse/sexp/LuaSEXP.cpp
+++ b/code/parse/sexp/LuaSEXP.cpp
@@ -40,12 +40,12 @@ SCP_unordered_map<SCP_string, int> parameter_type_mapping{{ "boolean",      OPF_
 														  { "shipclass",    OPF_SHIP_CLASS_NAME },
 														  { "weaponclass",  OPF_WEAPON_NAME },
 														  { "soundentry",   OPF_GAME_SND }, 
-														  { "oswpt-ship+waypoint",   OPF_SHIP_POINT },
-														  { "oswpt-ship+wing",   OPF_SHIP_WING },
-														  { "oswpt-ship+wing+team",   OPF_SHIP_WING_WHOLETEAM },
-														  { "oswpt-ship+wing+team+waypoint",   OPF_SHIP_WING_SHIPONTEAM_POINT },
-														  { "oswpt-ship+wing+waypoint",   OPF_SHIP_WING_POINT },
-														  { "oswpt-ship+wing+waypoint+none",   OPF_SHIP_WING_POINT_OR_NONE }, };
+														  { "ship+waypoint",   OPF_SHIP_POINT },
+														  { "ship+wing",   OPF_SHIP_WING },
+														  { "ship+wing+team",   OPF_SHIP_WING_WHOLETEAM },
+														  { "ship+wing+ship_on_team+waypoint",   OPF_SHIP_WING_SHIPONTEAM_POINT },
+														  { "ship+wing+waypoint",   OPF_SHIP_WING_POINT },
+														  { "ship+wing+waypoint+none",   OPF_SHIP_WING_POINT_OR_NONE }, };
 
 std::pair<SCP_string, int> get_parameter_type(const SCP_string& name)
 {

--- a/code/scripting/api/objs/oswpt.cpp
+++ b/code/scripting/api/objs/oswpt.cpp
@@ -13,7 +13,7 @@ namespace scripting {
 namespace api {
 
 //**********HANDLE: Wing
-ADE_OBJ(l_OSWPT, object_ship_wing_point_team, "oswpt", "OSWPT handle");
+ADE_OBJ(l_OSWPT, object_ship_wing_point_team, "oswpt", "Handle for LuaSEXP arguments that can hold different types (Object/Ship/Wing/Waypoint/Team)");
 
 ADE_FUNC(getType, l_OSWPT, nullptr, "The data-type this OSWPT yields on the get method.", "string", "The name of the data type. Either 'ship', 'parseobject' (a yet-to-spawn ship), 'wing' (can include yet-to-arrive wings with 0 current ships), 'team' (both explicit and ship-on-team), 'waypoint',  or 'none' (either explicitly specified, a ship that doesn't exist anymore, or invalid OSWPT object).")
 {

--- a/code/scripting/api/objs/oswpt.cpp
+++ b/code/scripting/api/objs/oswpt.cpp
@@ -1,0 +1,183 @@
+//
+//
+
+#include "oswpt.h"
+#include "parse_object.h"
+#include "ship.h"
+#include "team.h"
+#include "waypoint.h"
+#include "wing.h"
+#include "ship/ship.h"
+
+namespace scripting {
+namespace api {
+
+//**********HANDLE: Wing
+ADE_OBJ(l_OSWPT, object_ship_wing_point_team, "oswpt", "OSWPT handle");
+
+ADE_FUNC(getType, l_OSWPT, nullptr, "The data-type this OSWPT yields on the get method.", "string", "The name of the data type. Either 'ship', 'parseobject' (a yet-to-spawn ship), 'wing' (can include yet-to-arrive wings with 0 current ships), 'team' (both explicit and ship-on-team), 'waypoint',  or 'none' (either explicitly specified, a ship that doesn't exist anymore, or invalid OSWPT object).")
+{
+	object_ship_wing_point_team oswpt;
+	if (!ade_get_args(L, "o", l_OSWPT.Get(&oswpt)))
+		return ade_set_error(L, "s", "none");
+
+	switch (oswpt.type) {
+	case OSWPT_TYPE_SHIP:
+		return ade_set_args(L, "s", "ship");
+	case OSWPT_TYPE_PARSE_OBJECT:
+		return ade_set_args(L, "s", "parseobject");
+	case OSWPT_TYPE_WING:
+	case OSWPT_TYPE_WING_NOT_PRESENT:
+		return ade_set_args(L, "s", "wing");
+	case OSWPT_TYPE_SHIP_ON_TEAM:
+	case OSWPT_TYPE_WHOLE_TEAM:
+		return ade_set_args(L, "s", "team");
+	case OSWPT_TYPE_WAYPOINT:
+		return ade_set_args(L, "s", "waypoint");
+	case OSWPT_TYPE_NONE:
+	case OSWPT_TYPE_EXITED:
+	default:
+		return ade_set_args(L, "s", "none");
+	}
+}
+
+ADE_FUNC(get, l_OSWPT, nullptr, "Returns the data held by this OSWPT.", "ship | parse_object | wing | team | waypoint | nil", "Returns the data held by this OSWPT, nil if type is 'none'.")
+{
+	object_ship_wing_point_team oswpt;
+	if (!ade_get_args(L, "o", l_OSWPT.Get(&oswpt)))
+		return ADE_RETURN_NIL;
+
+	switch (oswpt.type) {
+	case OSWPT_TYPE_SHIP:
+		return ade_set_args(L, "o", l_Ship.Set(object_h(oswpt.objp)));
+	case OSWPT_TYPE_PARSE_OBJECT:
+		return ade_set_args(L, "o", l_ParseObject.Set(parse_object_h(oswpt.ship_entry->p_objp)));
+	case OSWPT_TYPE_WING:
+	case OSWPT_TYPE_WING_NOT_PRESENT:
+		return ade_set_args(L, "o", l_Wing.Set(WING_INDEX(oswpt.wingp)));
+	case OSWPT_TYPE_SHIP_ON_TEAM:
+	case OSWPT_TYPE_WHOLE_TEAM:
+		return ade_set_args(L, "o", l_Team.Set(oswpt.team));
+	case OSWPT_TYPE_WAYPOINT:
+		return ade_set_args(L, "o", l_Waypoint.Set(object_h(oswpt.objp)));
+	case OSWPT_TYPE_NONE:
+	case OSWPT_TYPE_EXITED:
+	default:
+		return ADE_RETURN_NIL;
+	}
+}
+
+ADE_FUNC(forAllShips, l_OSWPT, "function(ship ship) => void body", "Applies this function to each (present) ship this OSWPT applies to.", nullptr, nullptr)
+{
+	object_ship_wing_point_team oswpt;
+	luacpp::LuaFunction body;
+	if (!ade_get_args(L, "ou", l_OSWPT.Get(&oswpt), &body))
+		return ADE_RETURN_NIL;
+
+	switch (oswpt.type) {
+	case OSWPT_TYPE_SHIP:
+	{
+		luacpp::LuaValueList args;
+		args.push_back(luacpp::LuaValue::createValue(L, l_Ship.Set(object_h(oswpt.objp))));
+
+		body.call(L, args);
+		break;
+	}
+	case OSWPT_TYPE_WING:
+	{
+		auto wp = oswpt.wingp;
+		for (int i = 0; i < wp->current_count; ++i)
+		{
+			luacpp::LuaValueList args;
+			args.push_back(luacpp::LuaValue::createValue(L, l_Ship.Set(object_h(&Objects[Ships[wp->ship_index[i]].objnum]))));
+
+			body.call(L, args);
+		}
+		break;
+	}
+	case OSWPT_TYPE_SHIP_ON_TEAM:
+	case OSWPT_TYPE_WHOLE_TEAM:
+		for (auto so = GET_FIRST(&Ship_obj_list); so != END_OF_LIST(&Ship_obj_list); so = GET_NEXT(so))
+		{
+			if (Ships[Objects[so->objnum].instance].team == oswpt.team)
+			{
+				luacpp::LuaValueList args;
+				args.push_back(luacpp::LuaValue::createValue(L, l_Ship.Set(object_h(&Objects[so->objnum]))));
+
+				body.call(L, args);
+			}
+		}
+		break;
+	case OSWPT_TYPE_PARSE_OBJECT:
+	case OSWPT_TYPE_WING_NOT_PRESENT:
+	case OSWPT_TYPE_WAYPOINT:
+	case OSWPT_TYPE_NONE:
+	case OSWPT_TYPE_EXITED:
+	default:
+		break;
+	}
+	
+	return ADE_RETURN_NIL;
+}
+
+
+ADE_FUNC(forAllParseObjects, l_OSWPT, "function(parse_object po) => void body", "Applies this function to each not-yet-present ship (includes not-yet-present wings and not-yet-present ships of a specified team!) this OSWPT applies to.", nullptr, nullptr)
+{
+	object_ship_wing_point_team oswpt;
+	luacpp::LuaFunction body;
+	if (!ade_get_args(L, "ou", l_OSWPT.Get(&oswpt), &body))
+		return ADE_RETURN_NIL;
+
+	switch (oswpt.type) {
+	case OSWPT_TYPE_PARSE_OBJECT:
+	{
+		luacpp::LuaValueList args;
+		args.push_back(luacpp::LuaValue::createValue(L, l_ParseObject.Set(parse_object_h(oswpt.ship_entry->p_objp))));
+
+		body.call(L, args);
+		break;
+	}
+	case OSWPT_TYPE_WING_NOT_PRESENT:
+	{
+		for (p_object* p_objp = GET_FIRST(&Ship_arrival_list); p_objp != END_OF_LIST(&Ship_arrival_list); p_objp = GET_NEXT(p_objp))
+		{
+			if (p_objp->wingnum == WING_INDEX(oswpt.wingp))
+			{
+				luacpp::LuaValueList args;
+				args.push_back(luacpp::LuaValue::createValue(L, l_ParseObject.Set(parse_object_h(p_objp))));
+
+				body.call(L, args);
+			}
+		}
+		break;
+	}
+	case OSWPT_TYPE_SHIP_ON_TEAM:
+	case OSWPT_TYPE_WHOLE_TEAM:
+	{
+		for (p_object* p_objp = GET_FIRST(&Ship_arrival_list); p_objp != END_OF_LIST(&Ship_arrival_list); p_objp = GET_NEXT(p_objp))
+		{
+			if (p_objp->team == oswpt.team)
+			{
+				luacpp::LuaValueList args;
+				args.push_back(luacpp::LuaValue::createValue(L, l_ParseObject.Set(parse_object_h(p_objp))));
+
+				body.call(L, args);
+			}
+		}
+		break;
+	}
+	case OSWPT_TYPE_SHIP:
+	case OSWPT_TYPE_WING:
+	case OSWPT_TYPE_WAYPOINT:
+	case OSWPT_TYPE_NONE:
+	case OSWPT_TYPE_EXITED:
+	default:
+		break;
+	}
+
+	return ADE_RETURN_NIL;
+}
+
+
+}
+}

--- a/code/scripting/api/objs/oswpt.h
+++ b/code/scripting/api/objs/oswpt.h
@@ -1,0 +1,16 @@
+#pragma once
+//
+//
+
+#include "parse/sexp.h"
+#include "scripting/ade_api.h"
+
+namespace scripting {
+namespace api {
+
+//**********HANDLE: OSWPT
+DECLARE_ADE_OBJ(l_OSWPT, object_ship_wing_point_team);
+
+}
+}
+

--- a/code/source_groups.cmake
+++ b/code/source_groups.cmake
@@ -1325,6 +1325,8 @@ add_file_folder("Scripting\\\\Api\\\\Objs"
 	scripting/api/objs/option.h
 	scripting/api/objs/order.cpp
 	scripting/api/objs/order.h
+	scripting/api/objs/oswpt.cpp
+	scripting/api/objs/oswpt.h
 	scripting/api/objs/parse_object.cpp
 	scripting/api/objs/parse_object.h
 	scripting/api/objs/particle.cpp


### PR DESCRIPTION
This finally remedies my biggest annoyance with LuaSEXPs: It is now possible to specify OSWPT-types as arguments, allowing for custom sexps to work for much broader situations.
As convenience functions, it's not only possible to access OSWPT data directly, but rather supply a function that should then be applied to every ship (or parse object) this OSWPT applies to, allowing for the creation of easy "do n for all Ships/Wings/Teams" SEXPs with little effort.
The newly added argument types are called the following (they include the oswpt prefix to signify that all of these return an OSWPT object, and just differ in how they can be populated in FRED), and are generally equivalent to their built-in SEXP counterparts:
```
ship+waypoint
ship+wing
ship+wing+team
ship+wing+ship_on_team+waypoint
ship+wing+waypoint
ship+wing+waypoint+none
```