### PR TITLE
Apply adjust-audio-volume SEXP for effects to looping 3D sounds

### DIFF
--- a/code/sound/sound.cpp
+++ b/code/sound/sound.cpp
@@ -111,16 +111,6 @@ struct LoopingSoundInfo {
     }
 };
 
-bool does_ls_info_match_sig(const LoopingSoundInfo &ls_info, sound_handle sig)
-{
-	return ls_info.m_dsHandle == sig;
-}
-
-std::function<bool(const LoopingSoundInfo&)> create_ls_info_match_pred(sound_handle sig)
-{
-	return std::bind(does_ls_info_match_sig, std::placeholders::_1, sig);
-}
-
 SCP_list<LoopingSoundInfo> currentlyLoopingSoundInfos;
 SCP_list<LoopingSoundInfo> currentlyLooping3dSoundInfos;
 
@@ -922,7 +912,9 @@ sound_handle snd_play_looping(game_snd* gs, float pan, int /*start_loop*/, int /
 void remove_looping_sound(SCP_list<LoopingSoundInfo> &looping_sounds, sound_handle sig)
 {
 	// the cast to void avoids warnings about unused return value
-	(void)std::remove_if(looping_sounds.begin(), looping_sounds.end(), create_ls_info_match_pred(sig));
+	(void)std::remove_if(looping_sounds.begin(), looping_sounds.end(), [sig](const LoopingSoundInfo &ls_info) -> bool {
+		return ls_info.m_dsHandle == sig;
+	});
 }
 
 /**
@@ -966,7 +958,9 @@ void snd_stop_all()
 
 SCP_list<LoopingSoundInfo>::iterator find_looping_sound(SCP_list<LoopingSoundInfo> &looping_sounds, sound_handle sig)
 {
-	return std::find_if(looping_sounds.begin(), looping_sounds.end(), create_ls_info_match_pred(sig));
+	return std::find_if(looping_sounds.begin(), looping_sounds.end(), [sig](const LoopingSoundInfo &ls_info) -> bool {
+		return ls_info.m_dsHandle == sig;
+	});
 }
 
 /**

--- a/code/sound/sound.cpp
+++ b/code/sound/sound.cpp
@@ -111,7 +111,13 @@ struct LoopingSoundInfo {
     }
 };
 
+bool does_ls_info_match_sig(const LoopingSoundInfo &ls_info, sound_handle sig)
+{
+	return ls_info.m_dsHandle == sig;
+}
+
 SCP_list<LoopingSoundInfo> currentlyLoopingSoundInfos;
+SCP_list<LoopingSoundInfo> currentlyLooping3dSoundInfos;
 
 //For the adjust-audio-volume sexp
 float aav_voice_volume = 1.0f;
@@ -737,6 +743,10 @@ sound_handle snd_play_3d(game_snd* gs, vec3d* source_pos, vec3d* listen_pos, flo
 	}
 
 	if (handle.isValid()) {
+		if (looping) {
+			currentlyLooping3dSoundInfos.emplace_back(handle, default_volume, vol_scale);
+		}
+
 		snd_set_pitch(handle, gs->pitch_range.next());
 	}
 
@@ -894,7 +904,7 @@ sound_handle snd_play_looping(game_snd* gs, float pan, int /*start_loop*/, int /
 
 		if (handle.isValid()) {
 			if (scriptingUpdateVolume) {
-				currentlyLoopingSoundInfos.push_back(LoopingSoundInfo(handle, default_volume, vol_scale));
+				currentlyLoopingSoundInfos.emplace_back(handle, default_volume, vol_scale);
 			}
 
 			snd_set_pitch(handle, gs->pitch_range.next());
@@ -902,6 +912,13 @@ sound_handle snd_play_looping(game_snd* gs, float pan, int /*start_loop*/, int /
 	}
 
 	return handle;
+}
+
+void remove_looping_sound(SCP_list<LoopingSoundInfo> &looping_sounds, sound_handle sig)
+{
+	std::remove_if(looping_sounds.begin(),
+		looping_sounds.end(),
+		std::bind(does_ls_info_match_sig, std::placeholders::_1, sig));
 }
 
 /**
@@ -921,15 +938,8 @@ void snd_stop(sound_handle sig)
 	if ( channel == -1 )
 		return;
 	
-	SCP_list<LoopingSoundInfo>::iterator iter = currentlyLoopingSoundInfos.begin();
-	while (iter != currentlyLoopingSoundInfos.end())
-	{
-		if(iter->m_dsHandle == sig) {
-			iter = currentlyLoopingSoundInfos.erase(iter);
-		} else {
-			++iter;
-		}
-	}
+	remove_looping_sound(currentlyLoopingSoundInfos, sig);
+	remove_looping_sound(currentlyLooping3dSoundInfos, sig);
 
 	ds_stop_channel(channel);
 }
@@ -946,7 +956,15 @@ void snd_stop_all()
 		return;
 
 	currentlyLoopingSoundInfos.clear();
+	currentlyLooping3dSoundInfos.clear();
 	ds_stop_channel_all();
+}
+
+SCP_list<LoopingSoundInfo>::iterator find_looping_sound(SCP_list<LoopingSoundInfo>& looping_sounds, sound_handle sig)
+{
+	return std::find_if(looping_sounds.begin(),
+		looping_sounds.end(),
+		std::bind(does_ls_info_match_sig, std::placeholders::_1, sig));
 }
 
 /**
@@ -974,13 +992,16 @@ void snd_set_volume(sound_handle sig, float volume)
 
 	bool isLoopingSound = false;
 
-	SCP_list<LoopingSoundInfo>::iterator iter;
-	for (iter = currentlyLoopingSoundInfos.begin(); iter != currentlyLoopingSoundInfos.end(); ++iter) {
-		if(iter->m_dsHandle == sig) {
-			iter->m_dynamicVolume = volume;
 
+	auto iter = find_looping_sound(currentlyLoopingSoundInfos, sig);
+	if (iter != currentlyLoopingSoundInfos.end()) {
+		iter->m_dynamicVolume = volume;
+		isLoopingSound = true;
+	} else {
+		iter = find_looping_sound(currentlyLooping3dSoundInfos, sig);
+		if (iter != currentlyLooping3dSoundInfos.end()) {
+			iter->m_dynamicVolume = volume;
 			isLoopingSound = true;
-			break;
 		}
 	}
 
@@ -1429,20 +1450,26 @@ int sound_env_supported()
 //
 
 void adjust_volume_on_frame(float* volume_now, aav* data);
+void update_looping_sound_volumes(SCP_list<LoopingSoundInfo>& looping_sounds);
 void snd_do_frame()
 {
 	adjust_volume_on_frame(&aav_music_volume, &aav_data[AAV_MUSIC]);
 	adjust_volume_on_frame(&aav_voice_volume, &aav_data[AAV_VOICE]);
 	adjust_volume_on_frame(&aav_effect_volume, &aav_data[AAV_EFFECTS]);
 
-	SCP_list<LoopingSoundInfo>::iterator iter;
-	for (iter = currentlyLoopingSoundInfos.begin(); iter != currentlyLoopingSoundInfos.end(); ++iter) {
-
-		float new_volume = iter->m_defaultVolume * iter->m_dynamicVolume * (Master_sound_volume * aav_effect_volume);
-		ds_set_volume(ds_get_channel(iter->m_dsHandle), new_volume);
-	}
+	update_looping_sound_volumes(currentlyLoopingSoundInfos);
+	update_looping_sound_volumes(currentlyLooping3dSoundInfos);
 
 	ds_do_frame();
+}
+
+void update_looping_sound_volumes(SCP_list<LoopingSoundInfo> &looping_sounds)
+{
+	for (auto &looping_sound : looping_sounds) {
+		const float new_volume =
+			looping_sound.m_defaultVolume * looping_sound.m_dynamicVolume * (Master_sound_volume * aav_effect_volume);
+		ds_set_volume(ds_get_channel(looping_sound.m_dsHandle), new_volume);
+	}
 }
 
 void snd_adjust_audio_volume(int type, float percent, int time)

--- a/code/sound/sound.cpp
+++ b/code/sound/sound.cpp
@@ -116,6 +116,11 @@ bool does_ls_info_match_sig(const LoopingSoundInfo &ls_info, sound_handle sig)
 	return ls_info.m_dsHandle == sig;
 }
 
+std::function<bool(const LoopingSoundInfo&)> create_ls_info_match_pred(sound_handle sig)
+{
+	return std::bind(does_ls_info_match_sig, std::placeholders::_1, sig);
+}
+
 SCP_list<LoopingSoundInfo> currentlyLoopingSoundInfos;
 SCP_list<LoopingSoundInfo> currentlyLooping3dSoundInfos;
 
@@ -917,9 +922,7 @@ sound_handle snd_play_looping(game_snd* gs, float pan, int /*start_loop*/, int /
 void remove_looping_sound(SCP_list<LoopingSoundInfo> &looping_sounds, sound_handle sig)
 {
 	// the cast to void avoids warnings about unused return value
-	(void)std::remove_if(looping_sounds.begin(),
-		looping_sounds.end(),
-		std::bind(does_ls_info_match_sig, std::placeholders::_1, sig));
+	(void)std::remove_if(looping_sounds.begin(), looping_sounds.end(), create_ls_info_match_pred(sig));
 }
 
 /**
@@ -961,11 +964,9 @@ void snd_stop_all()
 	ds_stop_channel_all();
 }
 
-SCP_list<LoopingSoundInfo>::iterator find_looping_sound(SCP_list<LoopingSoundInfo>& looping_sounds, sound_handle sig)
+SCP_list<LoopingSoundInfo>::iterator find_looping_sound(SCP_list<LoopingSoundInfo> &looping_sounds, sound_handle sig)
 {
-	return std::find_if(looping_sounds.begin(),
-		looping_sounds.end(),
-		std::bind(does_ls_info_match_sig, std::placeholders::_1, sig));
+	return std::find_if(looping_sounds.begin(), looping_sounds.end(), create_ls_info_match_pred(sig));
 }
 
 /**

--- a/code/sound/sound.cpp
+++ b/code/sound/sound.cpp
@@ -916,7 +916,8 @@ sound_handle snd_play_looping(game_snd* gs, float pan, int /*start_loop*/, int /
 
 void remove_looping_sound(SCP_list<LoopingSoundInfo> &looping_sounds, sound_handle sig)
 {
-	std::remove_if(looping_sounds.begin(),
+	// the cast to void avoids warnings about unused return value
+	(void)std::remove_if(looping_sounds.begin(),
 		looping_sounds.end(),
 		std::bind(does_ls_info_match_sig, std::placeholders::_1, sig));
 }


### PR DESCRIPTION
Looping 3D sounds are defined as sounds played using `snd_play_3d()` with the `looping` argument set to `1`. These include beam fire and object-persistent sounds (see objectsnd.cpp), which include the engine and subsystem operation sounds of other ships.

Intended to fix Issue #3414.