### PR TITLE
handle invalid gamesnds

### DIFF
--- a/code/gamesnd/gamesnd.cpp
+++ b/code/gamesnd/gamesnd.cpp
@@ -544,12 +544,12 @@ void gamesnd_preload_common_sounds()
 		return;
 
 	Assert( Snds.size() <= INT_MAX );
-	for (SCP_vector<game_snd>::iterator gs = Snds.begin(); gs != Snds.end(); ++gs) {
-		if ( gs->preload ) {
-			for (auto& entry : gs->sound_entries) {
+	for (auto& gs: Snds) {
+		if ( gs.preload ) {
+			for (auto& entry : gs.sound_entries) {
 				if ( entry.filename[0] != 0 && strnicmp(entry.filename, NOX("none.wav"), 4) != 0 ) {
 					game_busy( NOX("** preloading common game sounds **") );	// Animate loading cursor... does nothing if loading screen not active.
-					entry.id = snd_load(&entry, gs->flags);
+					entry.id = snd_load(&entry, &gs.flags);
 				}
 			}
 		}
@@ -565,12 +565,12 @@ void gamesnd_load_gameplay_sounds()
 		return;
 
 	Assert( Snds.size() <= INT_MAX );
-	for (SCP_vector<game_snd>::iterator gs = Snds.begin(); gs != Snds.end(); ++gs) {
-		if ( !gs->preload ) { // don't try to load anything that's already preloaded
-			for (auto& entry : gs->sound_entries) {
+	for (auto& gs: Snds) {
+		if ( !gs.preload ) { // don't try to load anything that's already preloaded
+			for (auto& entry : gs.sound_entries) {
 				if (entry.filename[0] != 0 && strnicmp(entry.filename, NOX("none.wav"), 4) != 0) {
 					game_busy(NOX("** preloading gameplay sounds **"));        // Animate loading cursor... does nothing if loading screen not active.
-					entry.id = snd_load(&entry, gs->flags);
+					entry.id = snd_load(&entry, &gs.flags);
 				}
 			}
 		}
@@ -583,8 +583,8 @@ void gamesnd_load_gameplay_sounds()
 void gamesnd_unload_gameplay_sounds()
 {
 	Assert( Snds.size() <= INT_MAX );
-	for (SCP_vector<game_snd>::iterator gs = Snds.begin(); gs != Snds.end(); ++gs) {
-		for (auto& entry : gs->sound_entries) {
+	for (auto& gs: Snds) {
+		for (auto& entry : gs.sound_entries) {
 			if (entry.id.isValid()) {
 				snd_unload(entry.id);
 				entry.id = sound_load_id::invalid();
@@ -602,10 +602,10 @@ void gamesnd_load_interface_sounds()
 		return;
 
 	Assert( Snds_iface.size() < INT_MAX );
-	for (SCP_vector<game_snd>::iterator si = Snds_iface.begin(); si != Snds_iface.end(); ++si) {
-		for (auto& entry : si->sound_entries) {
+	for (auto& gs: Snds) {
+		for (auto& entry : gs.sound_entries) {
 			if ( entry.filename[0] != 0 && strnicmp(entry.filename, NOX("none.wav"), 4) != 0 ) {
-				entry.id = snd_load(&entry, si->flags);
+				entry.id = snd_load(&entry, &gs.flags);
 			}
 		}
 	}
@@ -1349,7 +1349,7 @@ float gamesnd_get_max_duration(game_snd* gs) {
 	for (auto& entry : gs->sound_entries) {
 		if (!entry.id.isValid()) {
 			// Lazily load unloaded sound entries when required
-			entry.id = snd_load(&entry, gs->flags);
+			entry.id = snd_load(&entry, &gs->flags);
 		}
 
 		max_length = std::max(max_length, snd_get_duration(entry.id));

--- a/code/menuui/optionsmenu.cpp
+++ b/code/menuui/optionsmenu.cpp
@@ -470,7 +470,7 @@ void options_play_voice_clip()
 	auto gs = gamesnd_get_interface_sound(InterfaceSounds::VOICE_SLIDER_CLIP);
 	auto entry = gamesnd_choose_entry(gs);
 
-	auto snd_id = snd_load(entry, gs->flags, 0);
+	auto snd_id = snd_load(entry, &gs->flags, 0);
 
 	Voice_vol_handle = snd_play_raw( snd_id, 0.0f, 1.0f, SND_PRIORITY_SINGLE_INSTANCE );
 }

--- a/code/mission/missionmessage.cpp
+++ b/code/mission/missionmessage.cpp
@@ -1008,9 +1008,9 @@ void message_load_wave(int index, const char *filename)
 		return;
 	}
 
-	game_snd_entry tmp_gs;
-	strcpy_s( tmp_gs.filename, filename );
-	Message_waves[index].num = snd_load( &tmp_gs, 0, 0 );
+	game_snd_entry tmp_gse;
+	strcpy_s(tmp_gse.filename, filename);
+	Message_waves[index].num = snd_load(&tmp_gse, nullptr, 0);
 
 	if (!Message_waves[index].num.isValid())
 		nprintf(("messaging", "Cannot load message wave: %s.  Will not play\n", Message_waves[index].name));

--- a/code/mission/missiontraining.cpp
+++ b/code/mission/missiontraining.cpp
@@ -773,9 +773,9 @@ int message_play_training_voice(int index)
 			return Training_voice;
 
 		} else {
-			game_snd_entry tmp_gs;
-			strcpy_s(tmp_gs.filename, Message_waves[index].name);
-			Message_waves[index].num = snd_load(&tmp_gs, 0, 0);
+			game_snd_entry tmp_gse;
+			strcpy_s(tmp_gse.filename, Message_waves[index].name);
+			Message_waves[index].num = snd_load(&tmp_gse, nullptr, 0);
 			if (!Message_waves[index].num.isValid()) {
 				nprintf(("Warning", "Cannot load message wave: %s.  Will not play\n", Message_waves[index].name));
 				return -1;

--- a/code/network/multi_voice.cpp
+++ b/code/network/multi_voice.cpp
@@ -319,7 +319,7 @@ void multi_voice_init()
 
 		// attempt to copy in the "pre" voice sound
 		auto gs = gamesnd_get_game_sound(MULTI_VOICE_PRE_SOUND);
-		auto pre_sound = snd_load(gamesnd_choose_entry(gs), gs->flags, 0);
+		auto pre_sound = snd_load(gamesnd_choose_entry(gs), &gs->flags, 0);
 		if (pre_sound.isValid()) {
 			// get the pre-sound size
 			if((snd_size(pre_sound,&pre_size) != -1) && (pre_size < MULTI_VOICE_MAX_BUFFER_SIZE)){
@@ -1418,7 +1418,7 @@ int multi_voice_mix(gamesnd_id post_sound,char *data,int cur_size,int max_size)
 	
 	// post sound
 	auto gs = gamesnd_get_game_sound(post_sound);
-	auto post_sound_handle = snd_load(gamesnd_choose_entry(gs), gs->flags, 0);
+	auto post_sound_handle = snd_load(gamesnd_choose_entry(gs), &gs->flags, 0);
 	if (post_sound_handle.isValid()) {
 		if(snd_size(post_sound_handle, &post_size) == -1){
 			post_size = 0;

--- a/code/object/objectsnd.cpp
+++ b/code/object/objectsnd.cpp
@@ -483,6 +483,9 @@ void obj_snd_do_frame()
 		}
 
 		gs = gamesnd_get_game_sound(osp->id);
+		if (gs->flags & GAME_SND_NOT_VALID) {
+			continue;
+		}
 
 		obj_snd_source_pos(&source_pos, osp);
 		distance = vm_vec_dist_quick( &source_pos, &View_position );

--- a/code/scripting/api/libs/audio.cpp
+++ b/code/scripting/api/libs/audio.cpp
@@ -89,9 +89,9 @@ ADE_FUNC(loadSoundfile, l_Audio, "string filename", "Loads the specified sound f
 	if (!ade_get_args(L, "s", &fileName))
 		return ade_set_error(L, "o", l_Soundfile.Set(soundfile_h(sound_load_id::invalid())));
 
-	game_snd_entry tmp_gs;
-	strcpy_s( tmp_gs.filename, fileName );
-	auto n = snd_load(&tmp_gs, 0, 0);
+	game_snd_entry tmp_gse;
+	strcpy_s(tmp_gse.filename, fileName);
+	auto n = snd_load(&tmp_gse, nullptr, 0);
 
 	return ade_set_error(L, "o", l_Soundfile.Set(soundfile_h(n)));
 }

--- a/code/sound/sound.cpp
+++ b/code/sound/sound.cpp
@@ -301,8 +301,9 @@ static std::unique_ptr<sound::IAudioFile> openAudioFile(const char* fileName)
 // DirectSound, only 1 copy of the sound is used.
 //
 // parameters:		entry							=> entry of sound to load
-// parameters:		flags							=> flags of sound to load
-//						allow_hardware_load	=> whether to try to allocate in hardware
+// parameters:		flags							=> pointer to flags of sound to load, so they
+//													   can be modified if necessary; can be nullptr
+//					allow_hardware_load				=> whether to try to allocate in hardware
 //
 // returns:			success => index of sound in Sounds[] array
 //						failure => -1

--- a/code/sound/sound.cpp
+++ b/code/sound/sound.cpp
@@ -655,6 +655,9 @@ sound_handle snd_play_3d(game_snd* gs, vec3d* source_pos, vec3d* listen_pos, flo
 		Int3();
 		return sound_handle::invalid();
 	}
+	if (gs->flags & GAME_SND_NOT_VALID) {
+		return sound_handle::invalid();
+	}
 
 	MONITOR_INC( Num3DSoundsStarted, 1 );
 	
@@ -662,13 +665,16 @@ sound_handle snd_play_3d(game_snd* gs, vec3d* source_pos, vec3d* listen_pos, flo
 
 	if (!entry->id.isValid()) {
 		entry->id = snd_load(entry, gs->flags);
-		MONITOR_INC( Num3DSoundsLoaded, 1 );
+		MONITOR_INC(Num3DSoundsLoaded, 1);
 	} else if (entry->id_sig != Sounds[entry->id.value()].sig) {
 		entry->id = snd_load(entry, gs->flags);
 	}
 
-	if (!entry->id.isValid())
+	if (!entry->id.isValid()) {
+		Warning(LOCATION, "Failed to load one or more sounds for gamesnd %s!", gs->name.c_str());
+		gs->flags |= GAME_SND_NOT_VALID;
 		return sound_handle::invalid();
+	}
 
 	snd = &Sounds[entry->id.value()];
 

--- a/code/sound/sound.h
+++ b/code/sound/sound.h
@@ -21,8 +21,9 @@
 #define SOUND_LIB_DIRECTSOUND		0
 #define SOUND_LIB_RSX				1
 
-#define GAME_SND_USE_DS3D			(1<<1)
-#define GAME_SND_VOICE				(1<<2)
+#define GAME_SND_USE_DS3D			(1<<0)
+#define GAME_SND_VOICE				(1<<1)
+#define GAME_SND_NOT_VALID			(1<<2)
 
 // Priorities that can be passed to snd_play() functions to limit how many concurrent sounds of a 
 // given type are played.

--- a/code/sound/sound.h
+++ b/code/sound/sound.h
@@ -127,7 +127,7 @@ void snd_set_effects_volume(float volume);
 void snd_set_voice_volume(float volume);
 
 //int	snd_load( char *filename, int hardware=0, int three_d=0, int *sig=NULL );
-sound_load_id snd_load(game_snd_entry* entry, int flags, int allow_hardware_load = 0);
+sound_load_id snd_load(game_snd_entry* entry, int* flags, int allow_hardware_load = 0);
 
 int snd_unload(sound_load_id sndnum);
 void	snd_unload_all();


### PR DESCRIPTION
If an entry in a game sound fails to load, mark the sound as invalid and don't try to load it afterwards.  This is the "permanent fail" fix for #3388.