### PR TITLE
fix nebula range in mission-set-nebula

### DIFF
--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -13794,7 +13794,10 @@ void sexp_mission_set_nebula(int n)
 	bool is_nan, is_nan_forever;
 	int set_it, range;
 
-	// range is optional, so if it isn't found, it will be set to 0
+	// range is optional, so if it isn't found, it will be set to 0,
+	// which will in turn be set to a default in the next function
+	// (this means the sexp cannot set the nebula range to 0,
+	// but the same is true in the background editor)
 	eval_nums(n, is_nan, is_nan_forever, set_it, range);
 	if (is_nan || is_nan_forever)
 		return;

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -673,7 +673,7 @@ SCP_vector<sexp_oper> Operators = {
 	{ "set-motion-debris-override",		OP_SET_MOTION_DEBRIS,					1,  1,			SEXP_ACTION_OPERATOR,	},	// The E
 
 	//Background and Nebula Sub-Category
-	{ "mission-set-nebula",				OP_MISSION_SET_NEBULA,					1,	1,			SEXP_ACTION_OPERATOR,	},	// Sesquipedalian
+	{ "mission-set-nebula",				OP_MISSION_SET_NEBULA,					1,	2,			SEXP_ACTION_OPERATOR,	},	// Sesquipedalian
 	{ "mission-set-subspace",			OP_MISSION_SET_SUBSPACE,				1,	1,			SEXP_ACTION_OPERATOR,	},
 	{ "change-background",				OP_CHANGE_BACKGROUND,					1,	1,			SEXP_ACTION_OPERATOR,	},	// Goober5000
 	{ "add-background-bitmap",			OP_ADD_BACKGROUND_BITMAP,				8,	9,			SEXP_ACTION_OPERATOR,	},	// phreak
@@ -13792,11 +13792,14 @@ void sexp_force_jump()
 void sexp_mission_set_nebula(int n)
 {
 	bool is_nan, is_nan_forever;
-	int set_it = eval_num(n, is_nan, is_nan_forever);
+	int set_it, range;
+
+	// range is optional, so if it isn't found, it will be set to 0
+	eval_nums(n, is_nan, is_nan_forever, set_it, range);
 	if (is_nan || is_nan_forever)
 		return;
 
-	stars_set_nebula(set_it > 0);
+	stars_set_nebula(set_it > 0, range);
 }
 
 /* freespace.cpp does not have these availiable externally, and we must call
@@ -33444,8 +33447,9 @@ SCP_vector<sexp_help_struct> Sexp_help = {
 
 	{ OP_MISSION_SET_NEBULA, "mission-set-nebula\r\n" 
 		"\tTurns nebula on/off\r\n"
-		"\tTakes1 argument...\r\n"
-		"\t1:\t0 for nebula off, 1 for nebula on" },
+		"\tTakes 1 or 2 arguments...\r\n"
+		"\t1:\t0 for nebula off, 1 for nebula on\r\n"
+		"\t2:\tNebula range (optional; defaults to 3000)\r\n" },
 
 	{ OP_MISSION_SET_SUBSPACE, "mission-set-subspace\r\n"
 		"\tTurns subspace on/off\r\n"

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -13799,7 +13799,7 @@ void sexp_mission_set_nebula(int n)
 	if (is_nan || is_nan_forever)
 		return;
 
-	stars_set_nebula(set_it > 0, range);
+	stars_set_nebula(set_it > 0, static_cast<float>(range));
 }
 
 /* freespace.cpp does not have these availiable externally, and we must call

--- a/code/starfield/starfield.cpp
+++ b/code/starfield/starfield.cpp
@@ -2530,6 +2530,14 @@ void stars_set_nebula(bool activate, float range)
 		Neb2_awacs = range;
 		if (Neb2_awacs < 0.1f)
 			Neb2_awacs = 3000.0f;	// this is also the default in the background editor
+
+		// this function is not currently called in FRED, but this would be needed for FRED support
+		if (Fred_running)
+		{
+			Neb2_render_mode = NEB2_RENDER_POF;
+			stars_set_background_model(BACKGROUND_MODEL_FILENAME, Neb2_texture_name);
+			stars_set_background_orientation();
+		}
 	}
 	else
 	{

--- a/code/starfield/starfield.cpp
+++ b/code/starfield/starfield.cpp
@@ -2517,7 +2517,7 @@ const char *stars_get_name_from_instance(int index, bool is_a_sun)
 }
 
 // WMC/Goober5000
-void stars_set_nebula(bool activate)
+void stars_set_nebula(bool activate, float range)
 {
     The_mission.flags.set(Mission::Mission_Flags::Fullneb, activate);
 	
@@ -2525,19 +2525,19 @@ void stars_set_nebula(bool activate)
 	{
 		Toggle_text_alpha = TOGGLE_TEXT_NEBULA_ALPHA;
 		HUD_contrast = 1;
-		if(Fred_running) {
-			Neb2_render_mode = NEB2_RENDER_POF;
-			stars_set_background_model(BACKGROUND_MODEL_FILENAME, Neb2_texture_name);
-			stars_set_background_orientation();
-		} else {
-			Neb2_render_mode = NEB2_RENDER_HTL;
-		}
+
+		Neb2_render_mode = NEB2_RENDER_HTL;
+		Neb2_awacs = range;
+		if (Neb2_awacs < 0.1f)
+			Neb2_awacs = 3000.0f;
 	}
 	else
 	{
 		Toggle_text_alpha = TOGGLE_TEXT_NORMAL_ALPHA;
-		Neb2_render_mode = NEB2_RENDER_NONE;
 		HUD_contrast = 0;
+
+		Neb2_render_mode = NEB2_RENDER_NONE;
+		Neb2_awacs = -1.0f;
 	}
 
 	// (DahBlount)

--- a/code/starfield/starfield.cpp
+++ b/code/starfield/starfield.cpp
@@ -2529,7 +2529,7 @@ void stars_set_nebula(bool activate, float range)
 		Neb2_render_mode = NEB2_RENDER_HTL;
 		Neb2_awacs = range;
 		if (Neb2_awacs < 0.1f)
-			Neb2_awacs = 3000.0f;
+			Neb2_awacs = 3000.0f;	// this is also the default in the background editor
 	}
 	else
 	{

--- a/code/starfield/starfield.h
+++ b/code/starfield/starfield.h
@@ -130,7 +130,7 @@ void stars_preload_background(const char *token);
 void stars_preload_sun_bitmap(const char *fname);
 void stars_preload_background_bitmap(const char *fname);
 
-void stars_set_nebula(bool activate);
+void stars_set_nebula(bool activate, float range);
 
 void stars_load_debris(int fullneb = 0);
 

--- a/fred2/sexp_tree.cpp
+++ b/fred2/sexp_tree.cpp
@@ -2528,6 +2528,13 @@ int sexp_tree::get_default_value(sexp_list_item *item, char *text_buf, int op, i
 				sprintf(sexp_str_token, "%d", temp);
 				item->set_data_dup(sexp_str_token, (SEXPT_NUMBER | SEXPT_VALID));
 			}
+			else if (Operators[op].value == OP_MISSION_SET_NEBULA)
+			{
+				if (i == 0)
+					item->set_data("1", (SEXPT_NUMBER | SEXPT_VALID));
+				else
+					item->set_data("3000", (SEXPT_NUMBER | SEXPT_VALID));
+			}
 			else if (Operators[op].value == OP_MODIFY_VARIABLE)
 			{
 				if (get_modify_variable_type(index) == OPF_NUMBER)

--- a/qtfred/src/ui/widgets/sexp_tree.cpp
+++ b/qtfred/src/ui/widgets/sexp_tree.cpp
@@ -1133,6 +1133,12 @@ int sexp_tree::get_default_value(sexp_list_item* item, char* text_buf, int op, i
 
 			sprintf(sexp_str_token, "%d", temp);
 			item->set_data_dup(sexp_str_token, (SEXPT_NUMBER | SEXPT_VALID));
+		} else if (Operators[op].value == OP_MISSION_SET_NEBULA) {
+			if (i == 0) {
+				item->set_data("1", (SEXPT_NUMBER | SEXPT_VALID));
+			} else {
+				item->set_data("3000", (SEXPT_NUMBER | SEXPT_VALID));
+			}
 		} else if (Operators[op].value == OP_MODIFY_VARIABLE) {
 			if (get_modify_variable_type(index) == OPF_NUMBER) {
 				item->set_data("0", (SEXPT_NUMBER | SEXPT_VALID));


### PR DESCRIPTION
The mission-set-nebula sexp never initialized the nebula range, which is usually done in the background editor.  This PR allows the range to be specified, and sets it to 3000 (the same default as in the background editor) if not specified.

Fixes #3619.