### PR TITLE
Fix Turrets in Lab

### DIFF
--- a/code/lab/manager/lab_manager.cpp
+++ b/code/lab/manager/lab_manager.cpp
@@ -7,6 +7,7 @@
 #include "lab/dialogs/backgrounds.h"
 #include "lab/dialogs/actions.h"
 #include "io/key.h"
+#include "asteroid/asteroid.h"
 #include "missionui/missionscreencommon.h"
 #include "debris/debris.h"
 #include "ship/shipfx.h"
@@ -50,6 +51,7 @@ LabManager::LabManager() {
 	debris_init();
 	extern void debris_page_in();
 	debris_page_in();
+	asteroid_level_init();
 	shockwave_level_init();
 	shipfx_flash_init();
 	mflash_page_in(true);


### PR DESCRIPTION
Fixes a regression introduced by #3636.
Due to the turrets now doing actual submodel processing, they'll try to acquire targets, which CTD's due to the asteroid list being uninitialized (and not just empty).