### PR TITLE
Anti-glint shader trick to reduce glimmer on distant objects

### DIFF
--- a/code/def_files/data/effects/main-f.sdr
+++ b/code/def_files/data/effects/main-f.sdr
@@ -429,7 +429,15 @@ void main()
 	fragOut0 = baseColor;
 #ifdef FLAG_DEFERRED
 	fragOut1 = vec4(vertIn.position.xyz, 1.0);
-	fragOut2 = vec4(normal, glossData);
+
+	// Anti-glint "trick" based on Valve's "Advanced VR Rendering" talk at GDC2015:
+	// http://media.steampowered.com/apps/valve/2015/Alex_Vlachos_Advanced_VR_Rendering_GDC2015.pdf Page 43
+	// basically make surfaces rougher if local normals change too fast in screenspace 
+	vec2 normDx = dFdx(normal.xy);
+	vec2 normDy = dFdy(normal.xy);
+	float glossGeo = 1.0f - pow(clamp(max(dot(normDx,normDx), dot(normDy,normDy)),0.0,1.0),0.33);
+	fragOut2 = vec4(normal, min(glossData, glossGeo));
+
 	fragOut3 = vec4(specColor.rgb, fresnelFactor);
 	fragOut4 = emissiveColor;
 #endif


### PR DESCRIPTION
This is based off a GDC talk given by valve in 2015: http://media.steampowered.com/apps/valve/2015/Alex_Vlachos_Advanced_VR_Rendering_GDC2015.pdf (Page 43)
This decreases the glossiness of surfaces if the derivatives of the normal buffer change too quickly in respect to screen space.

Example of tweak in use:
https://www.youtube.com/watch?v=YjyqpeVCY9I
Default settings, no AA.
