### PR TITLE
Added comment to clarify that the mod_table is about game_settings.tbl

### DIFF
--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -2,6 +2,9 @@
  * Created by Hassan "Karajorma" Kazmi for the FreeSpace2 Source Code Project.
  * You may not sell or otherwise commercially exploit the source or things you
  * create based on the source.
+ *
+ * This file is in charge of the "game_settings.tbl", colloquially referred to
+ * as the "mod table", and contains many misc FSO specific settings.
  */
 
 #include "gamesnd/eventmusic.h"

--- a/code/mod_table/mod_table.h
+++ b/code/mod_table/mod_table.h
@@ -2,8 +2,10 @@
  * Created by Hassan "Karajorma" Kazmi for the FreeSpace2 Source Code Project.
  * You may not sell or otherwise commercially exploit the source or things you
  * create based on the source.
+ *
+ * This file is in charge of the "game_settings.tbl", colloquially referred to
+ * as the "mod table", and contains many misc FSO specific settings.
  */
-
 
 #include "globalincs/globals.h"
 #include "globalincs/pstypes.h"


### PR DESCRIPTION
As somebody who is not experienced with the history of FS modding or its tables, `mod_table.cpp` not being related to modular tables, and instead actually being the file in charge of `game_settings.tbl` was a major source of confusion for me.