### PR TITLE
Scale distant combat related effects so they stay visible

### DIFF
--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -74,6 +74,11 @@ bool Neb_affects_fireballs;
 std::tuple<float, float, float, float> Shadow_distances;
 std::tuple<float, float, float, float> Shadow_distances_cockpit;
 bool Custom_briefing_icons_always_override_standard_icons;
+float Min_pixel_size_thruster;
+float Min_pixel_size_beam;
+float Min_pizel_size_muzzleflash;
+float Min_pixel_size_trail;
+float Min_pixel_size_laser;
 
 SCP_vector<std::pair<SCP_string, gr_capability>> req_render_ext_pairs = {
 	std::make_pair("BPTC Texture Compression", CAPABILITY_BPTC)
@@ -430,6 +435,22 @@ void parse_mod_table(const char *filename)
 			}
 		}
 
+		if (optional_string("$Minimum Pixel Size Thrusters:")) {
+			stuff_float(&Min_pixel_size_thruster);
+		}
+		if (optional_string("$Minimum Pixel Size Beams:")) {
+			stuff_float(&Min_pixel_size_beam);
+		}
+		if (optional_string("$Minimum Pixel Size Muzzle Flashes:")) {
+			stuff_float(&Min_pizel_size_muzzleflash);
+		}
+		if (optional_string("$Minimum Pixel Size Trails:")) {
+			stuff_float(&Min_pixel_size_trail);
+		}
+		if (optional_string("$Minimum Pixel Size Lasers:")) {
+			stuff_float(&Min_pixel_size_laser);
+		}
+
 		optional_string("#NETWORK SETTINGS");
 
 		if (optional_string("$FS2NetD port:")) {
@@ -729,4 +750,9 @@ void mod_table_reset()
 	Shadow_distances = std::make_tuple(200.0f, 600.0f, 2500.0f, 8000.0f); // Default values tuned by Swifty and added here by wookieejedi
 	Shadow_distances_cockpit = std::make_tuple(0.25f, 0.75f, 1.5f, 3.0f); // Default values tuned by wookieejedi and added here by Lafiel
 	Custom_briefing_icons_always_override_standard_icons = false;
+	Min_pixel_size_thruster = 0.0f;
+	Min_pixel_size_beam = 0.0f;
+	Min_pizel_size_muzzleflash = 0.0f;
+	Min_pixel_size_trail = 0.0f;
+	Min_pixel_size_laser = 0.0f;
 }

--- a/code/mod_table/mod_table.h
+++ b/code/mod_table/mod_table.h
@@ -66,6 +66,11 @@ extern bool Neb_affects_fireballs;
 extern std::tuple<float, float, float, float> Shadow_distances;
 extern std::tuple<float, float, float, float> Shadow_distances_cockpit;
 extern bool Custom_briefing_icons_always_override_standard_icons;
+extern float Min_pixel_size_thruster;
+extern float Min_pixel_size_beam;
+extern float Min_pizel_size_muzzleflash;
+extern float Min_pixel_size_trail;
+extern float Min_pixel_size_laser;
 
 void mod_table_init();
 

--- a/code/model/modelrender.h
+++ b/code/model/modelrender.h
@@ -309,6 +309,8 @@ void model_render_arc(vec3d *v1, vec3d *v2, color *primary, color *secondary, fl
 void model_render_insignias(insignia_draw_data *insignia);
 void model_render_set_wireframe_color(color* clr);
 
+float model_render_get_diameter_clamped_to_min_pixel_size(const vec3d* pos, float diameter, float min_pixel_size);
+
 void model_render_determine_color(color *clr, float alpha, gr_alpha_blend blend_mode, bool no_texturing, bool desaturate);
 gr_alpha_blend model_render_determine_blend_mode(int base_bitmap, bool blending);
 

--- a/code/weapon/beam.cpp
+++ b/code/weapon/beam.cpp
@@ -1799,14 +1799,16 @@ void beam_calc_facing_pts( vec3d *top, vec3d *bot, vec3d *fvec, vec3d *pos, floa
 	temp = *pos;
 
 	vm_vec_sub( &rvec, &Eye_position, &temp );
-	vm_vec_normalize( &rvec );	
+	vm_vec_normalize( &rvec );
 
 	vm_vec_cross(&uvec,fvec,&rvec);
 	// VECMAT-ERROR: NULL VEC3D (value of, fvec == rvec)
 	vm_vec_normalize_safe(&uvec);
 
-	vm_vec_scale_add( top, &temp, &uvec, w * 0.5f );
-	vm_vec_scale_add( bot, &temp, &uvec, -w * 0.5f );	
+	float scaled_w = model_render_get_diameter_clamped_to_min_pixel_size(pos, w, Min_pixel_size_beam);
+
+	vm_vec_scale_add( top, &temp, &uvec, scaled_w * 0.5f );
+	vm_vec_scale_add( bot, &temp, &uvec, -scaled_w * 0.5f );
 }
 
 // light scale factor

--- a/code/weapon/muzzleflash.cpp
+++ b/code/weapon/muzzleflash.cpp
@@ -14,6 +14,7 @@
 #include "parse/parselo.h"
 #include "particle/particle.h"
 #include "weapon/muzzleflash.h"
+#include "model/modelrender.h"
 
 
 // ---------------------------------------------------------------------------------------------------------------------
@@ -260,6 +261,13 @@ void mflash_create(vec3d *gun_pos, vec3d *gun_dir, physics_info *pip, int mflash
 	mi = &Mflash_info[mflash_type];
 
 	if (local != NULL) {
+		int attached_objnum = OBJ_INDEX(local);
+
+		// This muzzle flash is in local space, so its world position must be derived to apply scaling.
+		vec3d gun_world_pos;
+		vm_vec_unrotate(&gun_world_pos, gun_pos, &Objects[attached_objnum].orient);
+		vm_vec_add2(&gun_world_pos, &Objects[attached_objnum].pos);
+
 		for (idx = 0; idx < mi->blobs.size(); idx++) {
 			mbi = &mi->blobs[idx];
 
@@ -272,10 +280,10 @@ void mflash_create(vec3d *gun_pos, vec3d *gun_dir, physics_info *pip, int mflash
 			vm_vec_scale_add(&p.pos, gun_pos, gun_dir, mbi->offset);
 			vm_vec_zero(&p.vel);
 			//vm_vec_scale_add(&p.vel, &pip->rotvel, &pip->vel, 1.0f);
-			p.rad = mbi->radius;
+			p.rad = model_render_get_diameter_clamped_to_min_pixel_size(&gun_world_pos, mbi->radius * 2.0f, Min_pizel_size_muzzleflash) / 2.0f;
 			p.type = particle::PARTICLE_BITMAP;
 			p.optional_data = mbi->anim_id;
-			p.attached_objnum = OBJ_INDEX(local);
+			p.attached_objnum = attached_objnum;
 			p.attached_sig = local->signature;
 			particle::create(&p);
 		}
@@ -291,7 +299,7 @@ void mflash_create(vec3d *gun_pos, vec3d *gun_dir, physics_info *pip, int mflash
 			particle::particle_info p;
 			vm_vec_scale_add(&p.pos, gun_pos, gun_dir, mbi->offset);
 			vm_vec_scale_add(&p.vel, &pip->rotvel, &pip->vel, 1.0f);
-			p.rad = mbi->radius;
+			p.rad = model_render_get_diameter_clamped_to_min_pixel_size(&p.pos, mbi->radius * 2.0f, Min_pizel_size_muzzleflash) / 2.0f;
 			p.type = particle::PARTICLE_BITMAP;
 			p.optional_data = mbi->anim_id;
 			p.attached_objnum = -1;

--- a/code/weapon/trails.cpp
+++ b/code/weapon/trails.cpp
@@ -92,6 +92,8 @@ void trail_calc_facing_pts( vec3d *top, vec3d *bot, vec3d *fvec, vec3d *pos, flo
 	if (!IS_VEC_NULL(&uvec))
 		vm_vec_normalize(&uvec);
 
+	w = model_render_get_diameter_clamped_to_min_pixel_size(pos, w, Min_pixel_size_trail);
+
 	vm_vec_scale_add( top, pos, &uvec, w * 0.5f );
 	vm_vec_scale_add( bot, pos, &uvec, -w * 0.5f );
 }
@@ -151,7 +153,6 @@ void trail_render( trail * trailp )
 	float w_size = (ti->w_end - ti->w_start);
 	float a_size = (ti->a_end - ti->a_start);
 	int num_faded_sections = ti->n_fade_out_sections;
-
 
 	vec3d prev_top, prev_bot; vm_vec_zero(&prev_top); vm_vec_zero(&prev_bot);
 	float prev_U = 0;

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -8231,11 +8231,19 @@ void weapon_render(object* obj, model_draw_list *scene)
 					alpha = (int)(alpha * neb2_get_fog_visibility(&obj->pos, NEB_FOG_VISIBILITY_MULT_WEAPON));
 
 				vec3d headp;
-
 				vm_vec_scale_add(&headp, &obj->pos, &obj->orient.vec.fvec, wip->laser_length);
 
-				batching_add_laser(wip->laser_bitmap.first_frame + framenum, &headp, wip->laser_head_radius, &obj->pos, wip->laser_tail_radius, alpha, alpha, alpha);
-			}			
+				float scaled_head_radius = model_render_get_diameter_clamped_to_min_pixel_size(&headp, wip->laser_head_radius, Min_pixel_size_laser);
+				float scaled_tail_radius = model_render_get_diameter_clamped_to_min_pixel_size(&obj->pos, wip->laser_tail_radius, Min_pixel_size_laser);
+
+				batching_add_laser(
+					wip->laser_bitmap.first_frame + framenum,
+					&headp,
+					scaled_head_radius,
+					&obj->pos,
+					scaled_tail_radius,
+					alpha, alpha, alpha);
+			}
 
 			// maybe draw laser glow bitmap
 			if (wip->laser_glow_bitmap.first_frame >= 0) {
@@ -8281,7 +8289,16 @@ void weapon_render(object* obj, model_draw_list *scene)
 				if (The_mission.flags[Mission::Mission_Flags::Fullneb] && Neb_affects_weapons)
 					alpha = (int)(alpha * neb2_get_fog_visibility(&obj->pos, NEB_FOG_VISIBILITY_MULT_WEAPON));
 
-				batching_add_laser(wip->laser_glow_bitmap.first_frame + framenum, &headp2, wip->laser_head_radius * weapon_glow_scale_f, &tailp, wip->laser_tail_radius * weapon_glow_scale_r, (c.red*alpha)/255, (c.green*alpha)/255, (c.blue*alpha)/255);
+				float scaled_head_radius = model_render_get_diameter_clamped_to_min_pixel_size(&headp2, wip->laser_head_radius, Min_pixel_size_laser);
+				float scaled_tail_radius = model_render_get_diameter_clamped_to_min_pixel_size(&tailp, wip->laser_tail_radius, Min_pixel_size_laser);
+
+				batching_add_laser(
+					wip->laser_glow_bitmap.first_frame + framenum,
+					&headp2,
+					scaled_head_radius * weapon_glow_scale_f,
+					&tailp,
+					scaled_tail_radius * weapon_glow_scale_r,
+					(c.red*alpha)/255, (c.green*alpha)/255, (c.blue*alpha)/255);
 			}
 
 			break;


### PR DESCRIPTION
![](https://i.imgur.com/Hl0mM7u.gif)![](https://i.imgur.com/OBGhmxw.gif)
Left is with these changes enabled, right is current behavior.

While playing through Freespace 1, I noticed that distant lasers remained visible despite being very far away. The below battle is taking place ~7km away from the player. This far enough that the none of the individual ships can be seen, but it's still obvious a battle is happening due to the visible fire.

![](https://i.imgur.com/I1qi6C6.gif)

In Freespace 2, this does not happen anymore. It's been a pet peeve of mine for a long while. This implementation scales the following to ensure they are always visible in the case of point objects, and visible enough for lines to prevent stair-stepping.
- **Thrusters**: When ships are flying away from you, thrusters are visible as bright points in the distance. When facing you, they are no longer visible. This is exactly the same behavior thrusters currently have, it's only visible from a distance now.
- **Lasers**: Self-explanatory. Lasers are scaled such that if they become smaller than a few pixels, they maintain their size and remain visible and do not flicker from subpixels not rasterizing nicely.
- **Muzzle flashes**: Similar behavior to lasers.
- **Trails**: This applies to *all* trails. This primarily affects missiles, but can also affect ship contrails and thruster trails as are used in the Freespace Upgrade Media VPs. Trails are scaled enough to prevent stair-stepping.
- **Beams**: Similar to trails, they are scaled enough to prevent stair-stepping.

Exactly how much scaling can be adjusted using the `game_settings.tbl` or a `***-mod.tbm`. [Attached are example values that I think are ideal for FS2 retail assets](https://github.com/scp-fs2open/fs2open.github.com/files/7165600/tables.zip). Big enough to prevent flickering and stair stepping of beams, but only just so.

```
#GRAPHICS SETTINGS

$Minimum Pixel Size Thrusters: 1.5
$Minimum Pixel Size Beams: 5.0
$Minimum Pixel Size Muzzle Flashes: 4.0
$Minimum Pixel Size Trails: 3.0
$Minimum Pixel Size Lasers: 2.0

#END
```
