### PR TITLE
LUA: Add iterator over ships in mission

### DIFF
--- a/code/scripting/api/libs/mission.cpp
+++ b/code/scripting/api/libs/mission.cpp
@@ -1520,6 +1520,8 @@ ADE_FUNC(getShipList,
 	ship_obj* so = &Ship_obj_list;
 
 	return ade_set_args(L, "u", luacpp::LuaFunction::createFromStdFunction(L, [so](lua_State* LInner, const luacpp::LuaValueList& /*params*/) mutable -> luacpp::LuaValueList {
+		//Since the first element of a list is the next element from the head, and we start this function with the the captured "so" object being the head, this GET_NEXT will return the first element on first call of this lambda.
+		//Similarly, an empty list is defined by the head's next element being itself, hence an empty list will immediately return nil just fine
 		so = GET_NEXT(so);
 
 		if (so == END_OF_LIST(&Ship_obj_list)) {

--- a/code/scripting/api/libs/mission.cpp
+++ b/code/scripting/api/libs/mission.cpp
@@ -1510,6 +1510,26 @@ ADE_FUNC(getArrivalList,
 	                    l_ParseObject.Set(parse_object_h(&Ship_arrival_list)));
 }
 
+ADE_FUNC(getShipList,
+	l_Mission,
+	nullptr,
+	"Get an iterator to the list of ships in this mission",
+	"iterator<ship>",
+	"An iterator across all ships in the mission. Can be used in a for .. in loop")
+{
+	ship_obj* so = &Ship_obj_list;
+
+	return ade_set_args(L, "u", luacpp::LuaFunction::createFromStdFunction(L, [so](lua_State* LInner, const luacpp::LuaValueList& /*params*/) mutable -> luacpp::LuaValueList {
+		so = GET_NEXT(so);
+
+		if (so == END_OF_LIST(&Ship_obj_list)) {
+			return luacpp::LuaValueList{ luacpp::LuaValue::createNil(LInner) };
+		}
+
+		return luacpp::LuaValueList{ luacpp::LuaValue::createValue(LInner, l_Ship.Set(object_h(&Objects[so->objnum]))) };
+	}));
+}
+
 ADE_FUNC(waitAsync,
 	l_Mission,
 	"number seconds",

--- a/code/scripting/api/libs/mission.cpp
+++ b/code/scripting/api/libs/mission.cpp
@@ -1492,7 +1492,7 @@ static int arrivalListIter(lua_State* L)
 
 	const auto next = GET_NEXT(poh->getObject());
 
-	if (next == END_OF_LIST(&Ship_arrival_list)) {
+	if (next == END_OF_LIST(&Ship_arrival_list) || next == nullptr) {
 		return ADE_RETURN_NIL;
 	}
 
@@ -1504,7 +1504,7 @@ ADE_FUNC(getArrivalList,
 	nullptr,
 	"Get the list of yet to arrive ships for this mission",
 	"iterator<parse_object>",
-	"An iterator across all the yet to arrive ships. Can be used in a for .. in loop")
+	"An iterator across all the yet to arrive ships. Can be used in a for .. in loop. Is not valid for more than one frame.")
 {
 	return ade_set_args(L, "u*o", luacpp::LuaFunction::createFromCFunction(L, arrivalListIter),
 	                    l_ParseObject.Set(parse_object_h(&Ship_arrival_list)));
@@ -1515,7 +1515,7 @@ ADE_FUNC(getShipList,
 	nullptr,
 	"Get an iterator to the list of ships in this mission",
 	"iterator<ship>",
-	"An iterator across all ships in the mission. Can be used in a for .. in loop")
+	"An iterator across all ships in the mission. Can be used in a for .. in loop. Is not valid for more than one frame.")
 {
 	ship_obj* so = &Ship_obj_list;
 
@@ -1524,7 +1524,7 @@ ADE_FUNC(getShipList,
 		//Similarly, an empty list is defined by the head's next element being itself, hence an empty list will immediately return nil just fine
 		so = GET_NEXT(so);
 
-		if (so == END_OF_LIST(&Ship_obj_list)) {
+		if (so == END_OF_LIST(&Ship_obj_list) || so == nullptr) {
 			return luacpp::LuaValueList{ luacpp::LuaValue::createNil(LInner) };
 		}
 


### PR DESCRIPTION
This makes a loop over all ships much faster in lua, as before, each access to mn.Ships[i] in lua required iterating the Objects array, while the iterator will provide the next element of the ship_objects list in constant time.