### PR TITLE
Add 'No evasion' weapons

### DIFF
--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -1108,6 +1108,10 @@ void ai_update_danger_weapon(int attacked_objnum, int weapon_objnum)
 		}
 	}
 
+	weapon_info* wip = &Weapon_info[Weapons[weapon_objp->instance].weapon_info_index];
+	if (wip->wi_flags[Weapon::Info_Flags::No_evasion])
+		return;
+
 	if (aip->danger_weapon_objnum != -1) {
 		old_weapon_objp = &Objects[aip->danger_weapon_objnum];
 		if ((old_weapon_objp->type == OBJ_WEAPON) && (old_weapon_objp->signature == aip->danger_weapon_signature)) {

--- a/code/weapon/weapon_flags.h
+++ b/code/weapon/weapon_flags.h
@@ -88,6 +88,7 @@ namespace Weapon {
 		Can_damage_shooter,					// this weapon and any of its descendants can damage its shooter - Asteroth
 		Heals,								// 'damage' heals instead of actually damaging - Asteroth
 		No_collide,
+		No_evasion,							// AI will not attempt to dodge this weapon - Asteroth
 
         NUM_VALUES
 	};

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -187,6 +187,7 @@ flag_def_list_new<Weapon::Info_Flags> Weapon_Info_Flags[] = {
 	{ "can damage shooter",				Weapon::Info_Flags::Can_damage_shooter,					true, false },
 	{ "heals",							Weapon::Info_Flags::Heals,						        true, false },
 	{ "no collide",						Weapon::Info_Flags::No_collide,						    true, false },
+	{ "no evasion",						Weapon::Info_Flags::No_evasion,						    true, false },
 };
 
 const size_t num_weapon_info_flags = sizeof(Weapon_Info_Flags) / sizeof(flag_def_list_new<Weapon::Info_Flags>);
@@ -4848,7 +4849,7 @@ void weapon_home(object *obj, int num, float frame_time)
 
 	//	See if this weapon is the nearest homing object to the object it is homing on.
 	//	If so, update some fields in the target object's ai_info.
-	if (hobjp != &obj_used_list) {
+	if (hobjp != &obj_used_list && !(wip->wi_flags[Weapon::Info_Flags::No_evasion])) {
 
 		if (hobjp->type == OBJ_SHIP) {
 			ai_info	*aip;


### PR DESCRIPTION
Adds a flag that causes AI to ignore certain weapon and never attempt to dodge them. Useful if you're really spamming around weapons or otherwise don't want an AI to get distracted by certain kinds of weapons fire.