### PR TITLE
patch up scripted kills

### DIFF
--- a/code/network/multimsgs.cpp
+++ b/code/network/multimsgs.cpp
@@ -2692,7 +2692,7 @@ void process_ship_kill_packet( ubyte *data, header *hinfo )
 
 	// do the normal thing when not ingame joining.  When ingame joining, simply kill off the ship.
 	if ( !(Net_player->flags & NETINFO_FLAG_INGAME_JOIN) ) {
-		ship_hit_kill( sobjp, oobjp, nullptr, percent_killed, sd );
+		ship_hit_kill( sobjp, oobjp, nullptr, percent_killed, sd != 0 );
 	} else {
         sobjp->flags.set(Object::Object_Flags::Should_be_dead);
 		ship_cleanup(sobjp->instance, SHIP_DESTROYED);

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -8981,7 +8981,7 @@ static void ship_auto_repair_frame(int shipnum, float frametime)
 		if (objp->hull_strength > sp->ship_max_hull_strength)
 			objp->hull_strength = sp->ship_max_hull_strength;
 		else if (objp->hull_strength < 0)
-			ship_hit_kill(objp, nullptr, nullptr, 0, 1);
+			ship_hit_kill(objp, nullptr, nullptr, 0, true);
 	}
 
 	// only allow for the auto-repair of subsystems on small ships

--- a/code/ship/shiphit.h
+++ b/code/ship/shiphit.h
@@ -55,7 +55,7 @@ void ship_apply_global_damage(object *ship_obj, object *other_obj, vec3d *force_
 void ship_apply_wash_damage(object *ship_obj, object *other_obj, float damage);
 
 // next routine needed for multiplayer
-void ship_hit_kill( object *ship_obj, object *other_obj, vec3d *hitpos, float percent_killed, int self_destruct);
+void ship_hit_kill( object *ship_obj, object *other_obj, vec3d *hitpos, float percent_killed, bool self_destruct = false, bool always_log_other_obj = false);
 
 void ship_self_destruct( object *objp );
 


### PR DESCRIPTION
When a ship is killed via scripting, the killer should be credited for the kill in the mission log and the correct hull percentage should be used.  Also, the script should work with either the ship or its weapon passed as the killer parameter.