### PR TITLE
Fix warnings concerning ballistic weapons

### DIFF
--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -5611,7 +5611,7 @@ DCF_BOOL( show_velocity_dot, ship_show_velocity_dot )
 static bool ballistic_possible_for_this_ship(const ship_info *sip)
 {
 	// has no weapons!
-	if (sip->allowed_bank_restricted_weapons.empty() && sip->num_primary_banks < 1)
+	if (sip->num_primary_banks < 1)
 		return false;
 
 	for (int i = 0; i < MAX_SHIP_PRIMARY_BANKS; i++)

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -5610,20 +5610,15 @@ DCF_BOOL( show_velocity_dot, ship_show_velocity_dot )
 
 static bool ballistic_possible_for_this_ship(const ship_info *sip)
 {
-	if (sip->allowed_bank_restricted_weapons.empty() && sip->num_primary_banks < 1)
+	if (sip->allowed_bank_restricted_weapons.empty())
 		return false;
 
 	for (int i = 0; i < MAX_SHIP_PRIMARY_BANKS; i++)
 	{
-		if (sip->primary_bank_weapons[i] >= 0 && Weapon_info[sip->primary_bank_weapons[i]].wi_flags[Weapon::Info_Flags::Ballistic])
-			return true;
-
-		if (!sip->allowed_bank_restricted_weapons.empty()) {
-			for (int j = 0; j < weapon_info_size(); ++j)
-			{
-				if (sip->allowed_bank_restricted_weapons[i][j] && (Weapon_info[j].wi_flags[Weapon::Info_Flags::Ballistic]))
-					return true;
-			}
+		for (int j = 0; j < weapon_info_size(); ++j)
+		{
+			if (sip->allowed_bank_restricted_weapons[i][j] && (Weapon_info[j].wi_flags[Weapon::Info_Flags::Ballistic]))
+				return true;
 		}
 	}
 
@@ -5653,7 +5648,15 @@ static void ship_parse_post_cleanup()
 			}
 
 			// be friendly; ensure ballistic flags check out
-			if (!pbank_capacity_specified) {
+			if (pbank_capacity_specified) {
+				if ( !ballistic_possible_for_this_ship(&(*sip)) ) {
+					Warning(LOCATION, "Pbank capacity specified for non-ballistic-primary-enabled ship %s.\nResetting capacities to 0.\nTo fix this, add a ballistic primary to the list of allowed primaries.\n", sip->name);
+
+					for (j = 0; j < MAX_SHIP_PRIMARY_BANKS; j++) {
+						sip->primary_bank_ammo_capacity[j] = 0;
+					}
+				}
+			} else {
 				if ( ballistic_possible_for_this_ship(&(*sip)) ) {
 					Warning(LOCATION, "Pbank capacity not specified for ballistic-primary-enabled ship %s.\nDefaulting to capacity of 1 per bank.\n", sip->name);
 
@@ -7436,8 +7439,7 @@ void ship_render_show_ship_cockpit(object *objp)
 	gr_set_proj_matrix(Proj_fov, gr_screen.clip_aspect, 0.05f, Max_draw_distance);
 	gr_set_view_matrix(&cockpit_eye_pos, &Eye_matrix); // Set Camera to cockpit eye position
 	
-	//Glowpoint_override = true; // Turn off glowpoints so they dont get rendered fixed at origin
-	Deferred_lighting = true;
+	Glowpoint_override = true; // Turn off glowpoints so they dont get rendered fixed at origin
 
 	model_render_params render_info;
 
@@ -7448,8 +7450,7 @@ void ship_render_show_ship_cockpit(object *objp)
 	model_render_immediate(&render_info, Ship_info[Ships[objp->instance].ship_info_index].model_num, &objp->orient,
 	                       &objp->pos); // Render ship model with fixed detail level 0 so its not switching LOD when
 	                                    // moving away from origin
-	//Glowpoint_override = false;
-	Deferred_lighting = false;
+	Glowpoint_override = false;
 
 	gr_end_view_matrix();
 	gr_end_proj_matrix();

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -5610,15 +5610,23 @@ DCF_BOOL( show_velocity_dot, ship_show_velocity_dot )
 
 static bool ballistic_possible_for_this_ship(const ship_info *sip)
 {
-	if (sip->allowed_bank_restricted_weapons.empty())
+	// has no weapons!
+	if (sip->allowed_bank_restricted_weapons.empty() && sip->num_primary_banks < 1)
 		return false;
 
 	for (int i = 0; i < MAX_SHIP_PRIMARY_BANKS; i++)
 	{
-		for (int j = 0; j < weapon_info_size(); ++j)
-		{
-			if (sip->allowed_bank_restricted_weapons[i][j] && (Weapon_info[j].wi_flags[Weapon::Info_Flags::Ballistic]))
-				return true;
+		// check default weapons
+		if (sip->primary_bank_weapons[i] >= 0 && Weapon_info[sip->primary_bank_weapons[i]].wi_flags[Weapon::Info_Flags::Ballistic])
+			return true;
+
+		// check allowed weapons
+		if (!sip->allowed_bank_restricted_weapons.empty()) {
+			for (int j = 0; j < weapon_info_size(); ++j)
+			{
+				if (sip->allowed_bank_restricted_weapons[i][j] && (Weapon_info[j].wi_flags[Weapon::Info_Flags::Ballistic]))
+					return true;
+			}
 		}
 	}
 
@@ -5648,15 +5656,7 @@ static void ship_parse_post_cleanup()
 			}
 
 			// be friendly; ensure ballistic flags check out
-			if (pbank_capacity_specified) {
-				if ( !ballistic_possible_for_this_ship(&(*sip)) ) {
-					Warning(LOCATION, "Pbank capacity specified for non-ballistic-primary-enabled ship %s.\nResetting capacities to 0.\nTo fix this, add a ballistic primary to the list of allowed primaries.\n", sip->name);
-
-					for (j = 0; j < MAX_SHIP_PRIMARY_BANKS; j++) {
-						sip->primary_bank_ammo_capacity[j] = 0;
-					}
-				}
-			} else {
+			if (!pbank_capacity_specified) {
 				if ( ballistic_possible_for_this_ship(&(*sip)) ) {
 					Warning(LOCATION, "Pbank capacity not specified for ballistic-primary-enabled ship %s.\nDefaulting to capacity of 1 per bank.\n", sip->name);
 

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -8161,9 +8161,6 @@ void weapon_render(object* obj, model_draw_list *scene)
 	{
 	case WRT_LASER:
 		{
-			if(wip->laser_length < 0.0001f)
-				return;
-
 			int alpha = 255;
 			int framenum = 0;
 
@@ -8182,11 +8179,17 @@ void weapon_render(object* obj, model_draw_list *scene)
 				if (The_mission.flags[Mission::Mission_Flags::Fullneb] && Neb_affects_weapons)
 					alpha = (int)(alpha * neb2_get_fog_visibility(&obj->pos, NEB_FOG_VISIBILITY_MULT_WEAPON));
 
-				vec3d headp;
+				if (wip->laser_length > 0.0f) {
+					vec3d headp;
 
-				vm_vec_scale_add(&headp, &obj->pos, &obj->orient.vec.fvec, wip->laser_length);
+					vm_vec_scale_add(&headp, &obj->pos, &obj->orient.vec.fvec, wip->laser_length);
 
-				batching_add_laser(wip->laser_bitmap.first_frame + framenum, &headp, wip->laser_head_radius, &obj->pos, wip->laser_tail_radius, alpha, alpha, alpha);
+					batching_add_laser(wip->laser_bitmap.first_frame + framenum, &headp, wip->laser_head_radius, &obj->pos, wip->laser_tail_radius, alpha, alpha, alpha);
+				} else {
+					vertex vert;
+					g3_rotate_vertex(&vert, &obj->pos);
+					batching_add_bitmap(wip->laser_bitmap.first_frame + framenum, &vert, 0, wip->laser_head_radius, alpha);
+				}
 			}			
 
 			// maybe draw laser glow bitmap
@@ -8233,7 +8236,13 @@ void weapon_render(object* obj, model_draw_list *scene)
 				if (The_mission.flags[Mission::Mission_Flags::Fullneb] && Neb_affects_weapons)
 					alpha = (int)(alpha * neb2_get_fog_visibility(&obj->pos, NEB_FOG_VISIBILITY_MULT_WEAPON));
 
-				batching_add_laser(wip->laser_glow_bitmap.first_frame + framenum, &headp2, wip->laser_head_radius * weapon_glow_scale_f, &tailp, wip->laser_tail_radius * weapon_glow_scale_r, (c.red*alpha)/255, (c.green*alpha)/255, (c.blue*alpha)/255);
+				if (wip->laser_length > 0.0f) {
+					batching_add_laser(wip->laser_glow_bitmap.first_frame + framenum, &headp2, wip->laser_head_radius * weapon_glow_scale_f, &tailp, wip->laser_tail_radius * weapon_glow_scale_r, (c.red * alpha) / 255, (c.green * alpha) / 255, (c.blue * alpha) / 255);
+				} else {
+					vertex vert;
+					g3_rotate_vertex(&vert, &obj->pos);
+					batching_add_bitmap(wip->laser_bitmap.first_frame + framenum, &vert, 0, wip->laser_head_radius * weapon_glow_scale_f, alpha);
+				}
 			}
 
 			break;

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -8161,6 +8161,9 @@ void weapon_render(object* obj, model_draw_list *scene)
 	{
 	case WRT_LASER:
 		{
+			if(wip->laser_length < 0.0001f)
+				return;
+
 			int alpha = 255;
 			int framenum = 0;
 
@@ -8179,17 +8182,11 @@ void weapon_render(object* obj, model_draw_list *scene)
 				if (The_mission.flags[Mission::Mission_Flags::Fullneb] && Neb_affects_weapons)
 					alpha = (int)(alpha * neb2_get_fog_visibility(&obj->pos, NEB_FOG_VISIBILITY_MULT_WEAPON));
 
-				if (wip->laser_length > 0.0f) {
-					vec3d headp;
+				vec3d headp;
 
-					vm_vec_scale_add(&headp, &obj->pos, &obj->orient.vec.fvec, wip->laser_length);
+				vm_vec_scale_add(&headp, &obj->pos, &obj->orient.vec.fvec, wip->laser_length);
 
-					batching_add_laser(wip->laser_bitmap.first_frame + framenum, &headp, wip->laser_head_radius, &obj->pos, wip->laser_tail_radius, alpha, alpha, alpha);
-				} else {
-					vertex vert;
-					g3_rotate_vertex(&vert, &obj->pos);
-					batching_add_bitmap(wip->laser_bitmap.first_frame + framenum, &vert, 0, wip->laser_head_radius, alpha);
-				}
+				batching_add_laser(wip->laser_bitmap.first_frame + framenum, &headp, wip->laser_head_radius, &obj->pos, wip->laser_tail_radius, alpha, alpha, alpha);
 			}			
 
 			// maybe draw laser glow bitmap
@@ -8236,13 +8233,7 @@ void weapon_render(object* obj, model_draw_list *scene)
 				if (The_mission.flags[Mission::Mission_Flags::Fullneb] && Neb_affects_weapons)
 					alpha = (int)(alpha * neb2_get_fog_visibility(&obj->pos, NEB_FOG_VISIBILITY_MULT_WEAPON));
 
-				if (wip->laser_length > 0.0f) {
-					batching_add_laser(wip->laser_glow_bitmap.first_frame + framenum, &headp2, wip->laser_head_radius * weapon_glow_scale_f, &tailp, wip->laser_tail_radius * weapon_glow_scale_r, (c.red * alpha) / 255, (c.green * alpha) / 255, (c.blue * alpha) / 255);
-				} else {
-					vertex vert;
-					g3_rotate_vertex(&vert, &obj->pos);
-					batching_add_bitmap(wip->laser_bitmap.first_frame + framenum, &vert, 0, wip->laser_head_radius * weapon_glow_scale_f, alpha);
-				}
+				batching_add_laser(wip->laser_glow_bitmap.first_frame + framenum, &headp2, wip->laser_head_radius * weapon_glow_scale_f, &tailp, wip->laser_tail_radius * weapon_glow_scale_r, (c.red*alpha)/255, (c.green*alpha)/255, (c.blue*alpha)/255);
 			}
 
 			break;


### PR DESCRIPTION
A ship which has primary bank capacities defined, but has no ballistic weapons should *not* be warned for. There absolutely no harm in providing those capacities anyway, and there many ways that weapons be arbitrarily swapped in, regardless of what its defaults or 'allowed' banks are, and so it is *only safer* to allow the specifications of capacities anyway.

Additionally, `ballistic_possible_for_this_ship` should also check the default weapons in addition to the allowed weapons. Allowed weapons are optional, but you should *definitely* be warned if a ship has default ballistic weapons but no capacities.