### PR TITLE
Add getColor to lua gr library, which returns the active color

### DIFF
--- a/code/scripting/api/libs/graphics.cpp
+++ b/code/scripting/api/libs/graphics.cpp
@@ -493,6 +493,16 @@ ADE_FUNC(setColor, l_Graphics, "number Red, number Green, number Blue, [number A
 	return ADE_RETURN_NIL;
 }
 
+ADE_FUNC(getColor, l_Graphics, nullptr, "Gets the active 2D drawing color", "number, number, number, number" , "rgba color which is currently in use for 2D drawing")
+{
+	
+	if(!Gr_inited)
+		return ADE_RETURN_NIL;
+
+	color cur = gr_screen.current_color;
+	return ade_set_args(L, "iiii", (int)cur.red, (int)cur.green, (int)cur.blue, (int)cur.alpha);
+}
+
 ADE_FUNC(setLineWidth, l_Graphics, "[number width=1.0]", "Sets the line width for lines. This call might fail if the specified width is not supported by the graphics implementation. Then the width will be the nearest supported value.", "boolean", "true if succeeded, false otherwise")
 {
 	if(!Gr_inited)


### PR DESCRIPTION
This function returns the current active color (as set in `gr.setColor`). 
An example use-case for this is when debugging a script that uses 2D drawing, you can save the active color in a variable, change it to draw some visual aid at a different color, then reset the color to the one you saved. 