### PR TITLE
Safety for replace-texture

### DIFF
--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -17408,7 +17408,7 @@ void ship_replace_active_texture(int ship_index, const char* old_name, const cha
 	if (final_index >= 0) {
 		int texture = bm_load(new_name);
 
-		if (shipp->ship_replacement_textures == NULL) {
+		if (shipp->ship_replacement_textures == nullptr) {
 			shipp->ship_replacement_textures = (int*)vm_malloc(MAX_REPLACEMENT_TEXTURES * sizeof(int));
 
 			for (int i = 0; i < MAX_REPLACEMENT_TEXTURES; i++)

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -17405,16 +17405,19 @@ void ship_replace_active_texture(int ship_index, const char* old_name, const cha
 		}
 	}
 
-	int texture = bm_load(new_name);
+	if (final_index >= 0) {
+		int texture = bm_load(new_name);
 
-	if (shipp->ship_replacement_textures == NULL) {
-		shipp->ship_replacement_textures = (int*)vm_malloc(MAX_REPLACEMENT_TEXTURES * sizeof(int));
+		if (shipp->ship_replacement_textures == NULL) {
+			shipp->ship_replacement_textures = (int*)vm_malloc(MAX_REPLACEMENT_TEXTURES * sizeof(int));
 
-		for (int i = 0; i < MAX_REPLACEMENT_TEXTURES; i++)
-			shipp->ship_replacement_textures[i] = -1;
-	}
+			for (int i = 0; i < MAX_REPLACEMENT_TEXTURES; i++)
+				shipp->ship_replacement_textures[i] = -1;
+		}
 
-	shipp->ship_replacement_textures[final_index] = texture;
+		shipp->ship_replacement_textures[final_index] = texture;
+	} else
+		Warning(LOCATION, "Invalid texture '%s' used for replacement texture", old_name);
 }
 
 // function to return true if support ships are allowed in the mission for the given object.


### PR DESCRIPTION
If the original texture due to be replaced cannot be found, `final_index` is not changed from its original -1 and will write whatever its result from the new texture is into that position for the `ship_replacement_textures` array, corrupting the heap! So, uh, don't do anything if you can't find the old texture.