### PR TITLE
Initialize team visibility before using it

### DIFF
--- a/code/ai/aigoals.cpp
+++ b/code/ai/aigoals.cpp
@@ -23,6 +23,7 @@
 #include "playerman/player.h"
 #include "scripting/scripting.h"
 #include "ship/ship.h"
+#include "ship/awacs.h"
 #include "weapon/weapon.h"
 
 // Just a reference to this struct being for looking up a ship's team in TVT
@@ -186,6 +187,9 @@ void ai_post_process_mission()
 {
 	object *objp;
 	int i;
+
+	// make sure team visibility is updated first
+	awacs_process();
 
 	// Check ships in player starting wings.  Those ships should follow these rules:
 	// (1) if they have no orders, they should get a form on my wing order


### PR DESCRIPTION
TIL global arrays in C++ are automatically initialized to 0, so when `Ship_visibility_by_team` is accessed by `ai_post_process_mission()` to set up everybody's initial orders despite not having been touched yet, this is "ok". But since being changed to a vector in #3634, it will instead be an empty vector where access is out of bounds. So initialize it with `awacs_process()` first, this time with the actual visibilities, instead of just 0, too.