### PR TITLE
Allow for arbitrary asteroid targets in missions

### DIFF
--- a/code/asteroid/asteroid.cpp
+++ b/code/asteroid/asteroid.cpp
@@ -544,6 +544,11 @@ void asteroid_create_all()
 		return;
 	}
 
+	if (Asteroid_field.num_used_field_debris_types <= 0) {
+		Warning(LOCATION, "An asteroid field is enabled, but no asteroid types were enabled.");
+		return;
+	}
+
 	int max_asteroids = Asteroid_field.num_initial_asteroids; // * (1.0f - 0.1f*(MAX_DETAIL_LEVEL-Detail.asteroid_density)));
 
 	int num_debris_types = 0;

--- a/code/asteroid/asteroid.cpp
+++ b/code/asteroid/asteroid.cpp
@@ -596,10 +596,16 @@ void asteroid_create_all()
 			// For asteroid, load only large asteroids
 
 			// get a valid subtype
-			int subtype = Random::next(NUM_DEBRIS_POFS);
-			for (int i = 0; i < NUM_DEBRIS_POFS; i++) {
-				if (Asteroid_field.field_debris_type[subtype] == -1)
-					subtype = (subtype + 1) % NUM_DEBRIS_POFS;
+			int counter = Random::next(Asteroid_field.num_used_field_debris_types);
+			int subtype = -1;
+			for (int j = 0; j < NUM_DEBRIS_POFS; j++) {
+				if (Asteroid_field.field_debris_type[j] >= 0) {
+					if (counter == 0) {
+						subtype = j;
+						break;
+					} else
+						counter--;
+				}
 			}
 
 			if (subtype >= 0)
@@ -633,6 +639,7 @@ void asteroid_level_init()
 	SCP_vector<asteroid_info>::iterator ast;
 	for (ast = Asteroid_info.begin(); ast != Asteroid_info.end(); ++ast)
 		ast->damage_type_idx = ast->damage_type_idx_sav;
+	Asteroid_field.num_used_field_debris_types = 0;
 }
 
 /**
@@ -805,10 +812,17 @@ static void maybe_throw_asteroid()
 
 		target.throw_stamp = timestamp(1000 + 1200 * target.incoming_asteroids /(Game_skill_level+1));
 
-		int subtype = Random::next(NUM_DEBRIS_POFS);
+		int counter = Random::next(Asteroid_field.num_used_field_debris_types);
+		int subtype = -1;
 		for (int i = 0; i < NUM_DEBRIS_POFS; i++) {
-			if (Asteroid_field.field_debris_type[subtype] == -1)
-				subtype = (subtype + 1) % NUM_DEBRIS_POFS;
+			if (Asteroid_field.field_debris_type[i] >= 0) {
+				if (counter == 0) {
+					subtype = i;
+					break;
+				}
+				else
+					counter--;
+			}
 		}
 
 		// this really shouldn't happen but just in case...

--- a/code/asteroid/asteroid.cpp
+++ b/code/asteroid/asteroid.cpp
@@ -802,7 +802,7 @@ static void maybe_throw_asteroid()
 			subtype = (subtype + 1) % NUM_DEBRIS_POFS;
 
 		object *objp = asteroid_create(&Asteroid_field, ASTEROID_TYPE_LARGE, subtype);
-		if (objp != NULL) {
+		if (objp != nullptr) {
 			asteroid_aim_at_target(target_objp, objp, ASTEROID_MIN_COLLIDE_TIME + frand() * 20.0f);
 
 			// if asteroid is inside inner bound, kill it

--- a/code/asteroid/asteroid.h
+++ b/code/asteroid/asteroid.h
@@ -36,6 +36,11 @@ class model_draw_list;
 // Goober5000 - currently same as MAX_SHIP_DETAIL_LEVELS (put here to avoid an #include)
 #define MAX_ASTEROID_DETAIL_LEVELS	5
 
+// whether to do retail behavior, just throw at the first big ship in the field
+// must be explicitly opted out of by the mission
+extern bool Default_asteroid_throwing_behavior;
+
+extern SCP_vector<SCP_string> Asteroid_target_ships;
 
 // Data structure to track the active asteroids
 typedef struct asteroid_obj {
@@ -165,6 +170,7 @@ int	asteroid_collide_objnum(object *asteroid_objp);
 float asteroid_time_to_impact(object *asteroid_objp);
 void	asteroid_show_brackets();
 void	asteroid_target_closest_danger();
+void asteroid_add_target(object* objp);
 
 // need to extern for multiplayer
 void asteroid_sub_create(object *parent_objp, int asteroid_type, vec3d *relvec);

--- a/code/asteroid/asteroid.h
+++ b/code/asteroid/asteroid.h
@@ -143,6 +143,7 @@ typedef	struct asteroid_field {
 	field_type_t		field_type;		// active throws and wraps, passive does not
 	debris_genre_t	debris_genre;		// type of debris (ship or asteroid)  [generic type]
 	int				field_debris_type[MAX_ACTIVE_DEBRIS_TYPES];	// one of the debris type defines above
+	int				num_used_field_debris_types;	// how many of the above are used
 } asteroid_field;
 
 extern SCP_vector< asteroid_info > Asteroid_info;

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -5620,12 +5620,15 @@ void parse_asteroid_fields(mission *pm)
 		if (Asteroid_field.debris_genre == DG_SHIP) {
 			if (optional_string("+Field Debris Type:")) {
 				stuff_int(&Asteroid_field.field_debris_type[0]);
+				count++;
 			}
 			if (optional_string("+Field Debris Type:")) {
 				stuff_int(&Asteroid_field.field_debris_type[1]);
+				count++;
 			}
 			if (optional_string("+Field Debris Type:")) {
 				stuff_int(&Asteroid_field.field_debris_type[2]);
+				count++;
 			}
 		} else {
 			// debris asteroid
@@ -5646,6 +5649,8 @@ void parse_asteroid_fields(mission *pm)
 			}
 		}
 
+		Asteroid_field.num_used_field_debris_types = count;
+
 		bool invalid_asteroids = false;
 		for (int& ast_type : Asteroid_field.field_debris_type) {
 			if (ast_type >= (int)Asteroid_info.size()) {
@@ -5658,8 +5663,9 @@ void parse_asteroid_fields(mission *pm)
 			Warning(LOCATION, "The Asteroid field contains invalid entries!");
 
 		// backward compatibility
-		if ( (Asteroid_field.debris_genre == DG_ASTEROID) && (count == 0) ) {
+		if ( (Asteroid_field.debris_genre == DG_ASTEROID) && (Asteroid_field.num_used_field_debris_types == 0) ) {
 			Asteroid_field.field_debris_type[0] = 0;
+			Asteroid_field.num_used_field_debris_types = 1;
 		}
 
 		required_string("$Average Speed:");

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -2446,11 +2446,10 @@ int parse_create_object_sub(p_object *p_objp)
 	}
 
 	// if this is an asteroid target, add it to the list
-	if (!Asteroid_target_ships.empty()) {
-		for (SCP_string& name : Asteroid_target_ships) {
-			if (strcmp(name.c_str(), shipp->ship_name) == 0) {
-				asteroid_add_target(&Objects[objnum]);
-			}
+	for (SCP_string& name : Asteroid_target_ships) {
+		if (stricmp(name.c_str(), shipp->ship_name) == 0) {
+			asteroid_add_target(&Objects[objnum]);
+			break;
 		}
 	}
 

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -2445,6 +2445,15 @@ int parse_create_object_sub(p_object *p_objp)
 		}
 	}
 
+	// if this is an asteroid target, add it to the list
+	if (!Asteroid_target_ships.empty()) {
+		for (SCP_string& name : Asteroid_target_ships) {
+			if (strcmp(name.c_str(), shipp->ship_name) == 0) {
+				asteroid_add_target(&Objects[objnum]);
+			}
+		}
+	}
+
 	return objnum;
 }
 
@@ -5685,6 +5694,11 @@ void parse_asteroid_fields(mission *pm)
 			stuff_vec3d(&Asteroid_field.inner_max_bound);
 		} else {
 			Asteroid_field.has_inner_bound = 0;
+		}
+
+		if (optional_string("$Asteroid Targets:")) {
+			stuff_string_list(Asteroid_target_ships);
+			Default_asteroid_throwing_behavior = false;
 		}
 		i++;
 	}

--- a/fred2/missionsave.cpp
+++ b/fred2/missionsave.cpp
@@ -768,6 +768,21 @@ int CFred_mission_save::save_asteroid_fields()
 			save_vector(Asteroid_field.inner_max_bound);
 		}
 
+		if (!Asteroid_targets.is_empty())
+			if (optional_string_fred("$Asteroid Targets:")) {
+				parse_comments();
+				fout(" (");
+			} else {
+				fout("\n$Asteroid Targets: (");
+			}
+
+			for (SCP_string& name : Asteroid_target_ships) {				
+				fout(" %s", name);
+			}
+
+			fout(" )");
+		}
+
 		fso_comment_pop();
 	}
 

--- a/fred2/missionsave.cpp
+++ b/fred2/missionsave.cpp
@@ -768,7 +768,7 @@ int CFred_mission_save::save_asteroid_fields()
 			save_vector(Asteroid_field.inner_max_bound);
 		}
 
-		if (!Asteroid_targets.is_empty())
+		if (!Asteroid_target_ships.is_empty()) {
 			if (optional_string_fred("$Asteroid Targets:")) {
 				parse_comments();
 				fout(" (");

--- a/fred2/missionsave.cpp
+++ b/fred2/missionsave.cpp
@@ -769,11 +769,12 @@ int CFred_mission_save::save_asteroid_fields()
 		}
 
 		if (!Asteroid_target_ships.empty()) {
+			fso_comment_push(";;FSO 22.0.0;;");
 			if (optional_string_fred("$Asteroid Targets:")) {
 				parse_comments();
 				fout(" (");
 			} else {
-				fout("\n$Asteroid Targets: (");
+				fout_version("\n$Asteroid Targets: (");
 			}
 
 			for (SCP_string& name : Asteroid_target_ships) {				
@@ -781,6 +782,7 @@ int CFred_mission_save::save_asteroid_fields()
 			}
 
 			fout(" )");
+			fso_comment_pop();
 		}
 
 		fso_comment_pop();

--- a/fred2/missionsave.cpp
+++ b/fred2/missionsave.cpp
@@ -777,7 +777,7 @@ int CFred_mission_save::save_asteroid_fields()
 			}
 
 			for (SCP_string& name : Asteroid_target_ships) {				
-				fout(" %s", name);
+				fout(" %s", name.c_str());
 			}
 
 			fout(" )");

--- a/fred2/missionsave.cpp
+++ b/fred2/missionsave.cpp
@@ -768,7 +768,7 @@ int CFred_mission_save::save_asteroid_fields()
 			save_vector(Asteroid_field.inner_max_bound);
 		}
 
-		if (!Asteroid_target_ships.is_empty()) {
+		if (!Asteroid_target_ships.empty()) {
 			if (optional_string_fred("$Asteroid Targets:")) {
 				parse_comments();
 				fout(" (");

--- a/qtfred/src/mission/missionsave.cpp
+++ b/qtfred/src/mission/missionsave.cpp
@@ -784,11 +784,12 @@ int CFred_mission_save::save_asteroid_fields()
 		}
 
 		if (!Asteroid_target_ships.empty()) {
+			fso_comment_push(";;FSO 22.0.0;;");
 			if (optional_string_fred("$Asteroid Targets:")) {
 				parse_comments();
 				fout(" (");
 			} else {
-				fout("\n$Asteroid Targets: (");
+				fout_version("\n$Asteroid Targets: (");
 			}
 
 			for (SCP_string& name : Asteroid_target_ships) {				
@@ -796,6 +797,7 @@ int CFred_mission_save::save_asteroid_fields()
 			}
 
 			fout(" )");
+			fso_comment_pop();
 		}
 
 		fso_comment_pop();

--- a/qtfred/src/mission/missionsave.cpp
+++ b/qtfred/src/mission/missionsave.cpp
@@ -783,6 +783,21 @@ int CFred_mission_save::save_asteroid_fields()
 			save_vector(Asteroid_field.inner_max_bound);
 		}
 
+		if (!Asteroid_targets.is_empty())
+			if (optional_string_fred("$Asteroid Targets:")) {
+				parse_comments();
+				fout(" (");
+			} else {
+				fout("\n$Asteroid Targets: (");
+			}
+
+			for (SCP_string& name : Asteroid_target_ships) {				
+				fout(" %s", name);
+			}
+
+			fout(" )");
+		}
+		
 		fso_comment_pop();
 	}
 

--- a/qtfred/src/mission/missionsave.cpp
+++ b/qtfred/src/mission/missionsave.cpp
@@ -783,7 +783,7 @@ int CFred_mission_save::save_asteroid_fields()
 			save_vector(Asteroid_field.inner_max_bound);
 		}
 
-		if (!Asteroid_target_ships.is_empty()) {
+		if (!Asteroid_target_ships.empty()) {
 			if (optional_string_fred("$Asteroid Targets:")) {
 				parse_comments();
 				fout(" (");

--- a/qtfred/src/mission/missionsave.cpp
+++ b/qtfred/src/mission/missionsave.cpp
@@ -783,7 +783,7 @@ int CFred_mission_save::save_asteroid_fields()
 			save_vector(Asteroid_field.inner_max_bound);
 		}
 
-		if (!Asteroid_targets.is_empty())
+		if (!Asteroid_target_ships.is_empty()) {
 			if (optional_string_fred("$Asteroid Targets:")) {
 				parse_comments();
 				fout(" (");
@@ -797,7 +797,7 @@ int CFred_mission_save::save_asteroid_fields()
 
 			fout(" )");
 		}
-		
+
 		fso_comment_pop();
 	}
 

--- a/qtfred/src/mission/missionsave.cpp
+++ b/qtfred/src/mission/missionsave.cpp
@@ -792,7 +792,7 @@ int CFred_mission_save::save_asteroid_fields()
 			}
 
 			for (SCP_string& name : Asteroid_target_ships) {				
-				fout(" %s", name);
+				fout(" %s", name.c_str());
 			}
 
 			fout(" )");


### PR DESCRIPTION
Instead of throwing asteroids at the first big ship you find in the field, the FREDder can specify an arbitrary list of ships that are the sole targets for asteroids, which disables the retail behavior. Only the engine side changes, as FRED currently no means to populate the requisite "$Asteroid targets" field in the mission file, which hopefully @Goober5000 can help with.