### PR TITLE
Add filename-hash-mapped CFile cache

### DIFF
--- a/code/cfile/cfile.cpp
+++ b/code/cfile/cfile.cpp
@@ -107,10 +107,15 @@ static const char *Cfile_cdrom_dir = NULL;
 
 CFileLocation::CFileLocation(const cf_file& file) {
 	found = true;
-	if(file.name_ext)
-		name_ext = file.name_ext;
+	name_ext = file.name_ext;
 	if (file.real_name)
 		full_name = file.real_name;
+	else {
+		//In Memory files need their full name generated
+		full_name = Pathtypes[file.pathtype_index].path;
+		full_name += DIR_SEPARATOR_STR;
+		full_name += name_ext;
+	}
 	size = file.size;
 	offset = file.pack_offset;
 	data_ptr = file.data;

--- a/code/cfile/cfile.cpp
+++ b/code/cfile/cfile.cpp
@@ -105,6 +105,17 @@ std::array<CFILE, MAX_CFILE_BLOCKS> Cfile_block_list;
 
 static const char *Cfile_cdrom_dir = NULL;
 
+CFileLocation::CFileLocation(const cf_file& file) {
+	found = true;
+	if(file.name_ext)
+		name_ext = file.name_ext;
+	if (file.real_name)
+		full_name = file.real_name;
+	size = file.size;
+	offset = file.pack_offset;
+	data_ptr = file.data;
+}
+
 //
 // Function prototypes for internally-called functions
 //

--- a/code/cfile/cfile.h
+++ b/code/cfile/cfile.h
@@ -372,6 +372,8 @@ int cf_get_file_list_preallocated(int max, char arr[][MAX_FILENAME_LEN], char** 
 void cf_sort_filenames( int n, char **list, int sort, file_list_info *info = NULL );
 void cf_sort_filenames( SCP_vector<SCP_string> &list, int sort, SCP_vector<file_list_info> *info = NULL );
 
+struct cf_file;
+
 struct CFileLocation {
 	bool found = false;
 	SCP_string name_ext;
@@ -381,6 +383,7 @@ struct CFileLocation {
 	const void* data_ptr = nullptr;
 
 	explicit CFileLocation(bool found_in = false) : found(found_in) {}
+	explicit CFileLocation(const cf_file& file);
 };
 
 // Searches for a file.   Follows all rules and precedence and searches

--- a/code/cfile/cfilesystem.cpp
+++ b/code/cfile/cfilesystem.cpp
@@ -940,6 +940,7 @@ void cf_build_file_list()
 	int i;
 
 	Num_files = 0;
+	File_mapped_access.clear();
 
 	// For each root, find all files...
 	for (i=0; i<Num_roots; i++ )	{
@@ -1078,14 +1079,16 @@ CFileLocation cf_find_file_location(const char* filespec, int pathtype, bool loc
 		}
 	}
 
-	//Try a cache lookup first
-	for (ui = 0; ui < num_search_dirs; ui++) {
-		const auto& file_map = File_mapped_access[search_order[ui]];
-		auto file_it = file_map.find(filespec);
+	//Try a cache lookup first unless we need to localize
+	if (!localize) {
+		for (ui = 0; ui < num_search_dirs; ui++) {
+			const auto& file_map = File_mapped_access[search_order[ui]];
+			auto file_it = file_map.find(filespec);
 
-		if (file_it != file_map.end()) {
-			//Found file location in cache, return it
-			return CFileLocation(*file_it->second);
+			if (file_it != file_map.end()) {
+				//Found file location in cache, return it
+				return CFileLocation(*file_it->second);
+			}
 		}
 	}
 

--- a/code/cfile/cfilesystem.cpp
+++ b/code/cfile/cfilesystem.cpp
@@ -751,7 +751,7 @@ void cf_search_root_path(int root_index)
 
 							file->real_name = vm_strdup(fn.c_str());
 
-							cf_emplace_file_in_lookup_map(i, file);
+							cf_emplace_file_in_lookup_map(file);
 
 							num_files++;
 							//mprintf(( "Found file '%s'\n", file->name_ext ));

--- a/code/cfile/cfilesystem.h
+++ b/code/cfile/cfilesystem.h
@@ -26,6 +26,17 @@ typedef struct cf_pathtype {
 	int			parent_index;			// Index of this directory's parent.  Used for creating directories when writing.
 } cf_pathtype;
 
+typedef struct cf_file {
+	char		name_ext[CF_MAX_FILENAME_LENGTH];	// Filename and extension
+	int			root_index;							// Where in Roots this is located
+	int			pathtype_index;						// Where in Paths this is located
+	time_t		write_time;							// When it was last written
+	int			size;								// How big it is in bytes
+	int			pack_offset;						// For pack files, where it is at.   0 if not in a pack file.  This can be used to tell if in a pack file.
+	char* real_name;							// For real files, the full path
+	const void* data;								// For in-memory files, the data pointer
+} cf_file;
+
 // During cfile_init, verify that Pathtypes[n].index == n for each item
 extern cf_pathtype Pathtypes[CF_MAX_PATH_TYPES];
 


### PR DESCRIPTION
This utilizes the already existing (but seemingly unused) cfile index to provide a mapping of CF Pathtypes and filenames to cf_file objects to massively speed up file discovery.

Previously, at least on windows, the repeated calls of ``_findfirst(longname, &findstruct);`` were a major slowdown for file loading, which is now taken over by a single map lookup. In subjective tests, this reduces microstutters ingame, for example when particles are loaded in-mission.