### PR TITLE
reorganize submodel rotation

### DIFF
--- a/code/ai/ai.h
+++ b/code/ai/ai.h
@@ -659,7 +659,7 @@ void ai_start_fly_to_ship(object *objp, int shipnum);
 void ai_fly_to_ship();
 
 //Moved declaration here for player ship -WMC
-void process_subobjects(int objnum);
+void ai_process_subobjects(int objnum);
 
 //SUSHI: Setting ai_info stuff from both ai class and ai profile
 void init_aip_from_class_and_profile(ai_info *aip, ai_class *aicp, ai_profile_t *profile);

--- a/code/asteroid/asteroid.cpp
+++ b/code/asteroid/asteroid.cpp
@@ -335,7 +335,7 @@ object *asteroid_create(asteroid_field *asfieldp, int asteroid_type, int asteroi
 	asp->model_instance_num = -1;
 
 	if (model_get(asip->model_num[asteroid_subtype])->flags & PM_FLAG_HAS_INTRINSIC_ROTATE) {
-		asp->model_instance_num = model_create_instance(false, asip->model_num[asteroid_subtype]);
+		asp->model_instance_num = model_create_instance(true, asip->model_num[asteroid_subtype]);
 	}
 
 	// Add to Asteroid_used_list

--- a/code/debris/debris.cpp
+++ b/code/debris/debris.cpp
@@ -433,7 +433,7 @@ object *debris_create(object *source_obj, int model_num, int submodel_num, vec3d
 		db->submodel_num = submodel_num;
 	}
 
-	db->model_instance_num = model_create_instance(false, db->model_num);
+	db->model_instance_num = model_create_instance(true, db->model_num);
 
 	float radius = submodel_get_radius(db->model_num, db->submodel_num);
 

--- a/code/jumpnode/jumpnode.cpp
+++ b/code/jumpnode/jumpnode.cpp
@@ -52,7 +52,7 @@ CJumpNode::CJumpNode(const vec3d* position)
 		polymodel* pm = model_get(m_modelnum);
 
 		if (pm->flags & PM_FLAG_HAS_INTRINSIC_ROTATE) {
-			m_polymodel_instance_num = model_create_instance(false, m_modelnum);
+			m_polymodel_instance_num = model_create_instance(true, m_modelnum);
 		}
 	}
 	

--- a/code/lab/renderer/lab_renderer.cpp
+++ b/code/lab/renderer/lab_renderer.cpp
@@ -73,8 +73,6 @@ void LabRenderer::renderModel(float frametime) {
 		Ships[obj->instance].flags.set(Ship::Ship_Flags::Render_without_weapons, !renderFlags[LabRenderFlag::ShowWeapons]);
 		Ships[obj->instance].flags.set(Ship::Ship_Flags::Render_without_ambientmap, renderFlags[LabRenderFlag::NoAOMap]);
 
-		ship_model_update_instance(obj);
-
 		Ships[obj->instance].team_name = currentTeamColor;
 
 		if (renderFlags[LabRenderFlag::ShowDamageLightning]) {
@@ -109,10 +107,6 @@ void LabRenderer::renderModel(float frametime) {
 	}
 
 	obj_move_all(frametime);
-	if (getLabManager()->CurrentMode == LabMode::Ship)
-		process_subobjects(getLabManager()->CurrentObject);
-
-	animation::ModelAnimation::stepAnimations(frametime);
 
 	particle::move_all(frametime);
 	particle::ParticleManager::get()->doFrame(frametime);

--- a/code/menuui/techmenu.cpp
+++ b/code/menuui/techmenu.cpp
@@ -335,7 +335,7 @@ void techroom_select_new_entry()
 		if (Techroom_ship_model_instance >= 0) {
 			model_delete_instance(Techroom_ship_model_instance);
 		}
-		Techroom_ship_model_instance = model_create_instance(true, Techroom_ship_modelnum);
+		Techroom_ship_model_instance = model_create_instance(false, Techroom_ship_modelnum);
 
 		model_set_up_techroom_instance(sip, Techroom_ship_model_instance);
 

--- a/code/missionui/missionbrief.cpp
+++ b/code/missionui/missionbrief.cpp
@@ -1281,7 +1281,7 @@ int brief_setup_closeup(brief_icon *bi)
 			Closeup_icon->modelnum = model_load(pof_filename, 0, NULL);
 		} else {
 			Closeup_icon->modelnum = model_load(sip->pof_file, sip->n_subsystems, &sip->subsystems[0]);
-			Closeup_icon->model_instance_num = model_create_instance(true, Closeup_icon->modelnum);
+			Closeup_icon->model_instance_num = model_create_instance(false, Closeup_icon->modelnum);
 			model_set_up_techroom_instance(sip, Closeup_icon->model_instance_num);
 		}
 	}

--- a/code/model/model.h
+++ b/code/model/model.h
@@ -802,7 +802,7 @@ void model_instance_free_all();
 // Loads a model from disk and returns the model number it loaded into.
 int model_load(const char *filename, int n_subsystems, model_subsystem *subsystems, int ferror = 1, int duplicate = 0);
 
-int model_create_instance(bool is_ship, int model_num);
+int model_create_instance(bool is_object, int model_num);
 void model_delete_instance(int model_instance_num);
 
 // Goober5000
@@ -979,8 +979,7 @@ extern void model_set_submodel_turn_info(submodel_instance *smi, float turn_rate
 // Sets the submodel instance data in a submodel
 extern void model_set_up_techroom_instance(ship_info *sip, int model_instance_num);
 
-void model_update_instance(int model_instance_num, int submodel_num, flagset<Ship::Subsystem_Flags>& flags);
-void model_update_instance(polymodel *pm, polymodel_instance *pmi, int submodel_num, flagset<Ship::Subsystem_Flags>& flags);
+void model_replicate_submodel_instance(polymodel *pm, polymodel_instance *pmi, int submodel_num, flagset<Ship::Subsystem_Flags>& flags);
 
 // Adds an electrical arcing effect to a submodel
 void model_instance_clear_arcs(polymodel *pm, polymodel_instance *pmi);
@@ -1248,15 +1247,13 @@ void model_page_in_textures(int modelnum, int ship_info_index = -1);
 // given a model, unload all of its textures
 void model_page_out_textures(int model_num, bool release = false);
 
-void model_do_intrinsic_rotations(int model_instance_num = -1);
+void model_do_intrinsic_rotations(object *objp);
 
 int model_should_render_engine_glow(int objnum, int bank_obj);
 
 bool model_get_team_color(team_color *clr, const SCP_string &team, const SCP_string &secondaryteam, fix timestamp, int fadetime);
 
 void moldel_calc_facing_pts( vec3d *top, vec3d *bot, vec3d *fvec, vec3d *pos, float w, float z_add, vec3d *Eyeposition );
-
-void model_render_insignias(polymodel *pm, int detail_level, int bitmap_num);
 
 void model_draw_debug_points( polymodel *pm, bsp_info * submodel, uint flags );
 

--- a/code/model/modelread.cpp
+++ b/code/model/modelread.cpp
@@ -147,12 +147,12 @@ SCP_vector<glow_point_bank_override> glowpoint_bank_overrides;
 class intrinsic_rotation
 {
 public:
-	bool is_ship;
+	bool is_object;
 	int model_instance_num;
 	SCP_vector<int> submodel_list;
 
-	intrinsic_rotation(bool _is_ship, int _model_instance_num)
-		: is_ship(_is_ship), model_instance_num(_model_instance_num)
+	intrinsic_rotation(bool _is_object, int _model_instance_num)
+		: is_object(_is_object), model_instance_num(_model_instance_num)
 	{}
 
 	void add_submodel(int _submodel_num, submodel_instance *_submodel_instance_1, float _turn_rate)
@@ -163,7 +163,7 @@ public:
 	}
 };
 
-SCP_vector<intrinsic_rotation> Intrinsic_rotations;
+SCP_unordered_map<int, intrinsic_rotation> Intrinsic_rotations;
 
 
 // Free up a model, getting rid of all its memory
@@ -3091,7 +3091,7 @@ int model_load(const  char *filename, int n_subsystems, model_subsystem *subsyst
 	return pm->id;
 }
 
-int model_create_instance(bool is_ship, int model_num)
+int model_create_instance(bool is_object, int model_num)
 {
 	int i = 0;
 	int open_slot = -1;
@@ -3123,7 +3123,7 @@ int model_create_instance(bool is_ship, int model_num)
 
 	// add intrinsic_rotation instances if this model is intrinsic-rotating
 	if (pm->flags & PM_FLAG_HAS_INTRINSIC_ROTATE) {
-		intrinsic_rotation intrinsic_rotate(is_ship, open_slot);
+		intrinsic_rotation intrinsic_rotate(is_object, open_slot);
 
 		for (i = 0; i < pm->n_models; i++) {
 			if (pm->submodel[i].movement_type == MOVEMENT_TYPE_INTRINSIC_ROTATE) {
@@ -3135,7 +3135,7 @@ int model_create_instance(bool is_ship, int model_num)
 		if (intrinsic_rotate.submodel_list.empty()) {
 			Assertion(!intrinsic_rotate.submodel_list.empty(), "This model has the PM_FLAG_HAS_INTRINSIC_ROTATE flag; why doesn't it have an intrinsic-rotating submodel?");
 		} else {
-			Intrinsic_rotations.push_back(intrinsic_rotate);
+			Intrinsic_rotations.insert(std::make_pair(pmi->id, std::move(intrinsic_rotate)));
 		}
 	}
 
@@ -3160,12 +3160,7 @@ void model_delete_instance(int model_instance_num)
 	Polygon_model_instances[model_instance_num] = nullptr;
 
 	// delete intrinsic rotations associated with this instance
-	for (auto intrinsic_it = Intrinsic_rotations.begin(); intrinsic_it != Intrinsic_rotations.end(); ++intrinsic_it) {
-		if (intrinsic_it->model_instance_num == model_instance_num) {
-			Intrinsic_rotations.erase(intrinsic_it);
-			break;
-		}
-	}
+	Intrinsic_rotations.erase(model_instance_num);
 }
 
 // ensure that the subsys path is at least SUBSYS_PATH_DIST from the 
@@ -4413,25 +4408,18 @@ void model_set_up_techroom_instance(ship_info *sip, int model_instance_num)
 		}
 
 		if (msp->subobj_num >= 0)
-			model_update_instance(pm, pmi, msp->subobj_num, empty);
+			model_replicate_submodel_instance(pm, pmi, msp->subobj_num, empty);
 
-		if (msp->turret_gun_sobj >= 0)
-			model_update_instance(pm, pmi, msp->turret_gun_sobj, empty);
+		if ((msp->subobj_num != msp->turret_gun_sobj) && (msp->turret_gun_sobj >= 0))
+			model_replicate_submodel_instance(pm, pmi, msp->turret_gun_sobj, empty);
 	}
-}
-
-void model_update_instance(int model_instance_num, int submodel_num, flagset<Ship::Subsystem_Flags>& flags)
-{
-	auto pmi = model_get_instance(model_instance_num);
-	auto pm = model_get(pmi->model_num);
-	model_update_instance(pm, pmi, submodel_num, flags);
 }
 
 /*
  * This function handles copying submodel instance information to other submodel instances as appropriate.  The copy_from parameter is used for
- * copying data to other LODs, and is only specified from within model_update_instance itself.  The "public" function header omits this parameter.
+ * copying data to other LODs, and is only specified from within this function itself.  The "public" function header omits this parameter.
  */
-void model_update_instance(polymodel *pm, polymodel_instance *pmi, const submodel_instance *copy_from, int submodel_num, flagset<Ship::Subsystem_Flags>& flags)
+void model_replicate_submodel_instance_sub(polymodel *pm, polymodel_instance *pmi, const submodel_instance *copy_from, int submodel_num, flagset<Ship::Subsystem_Flags>& flags)
 {
 	Assert(pm->id == pmi->model_num);
 	
@@ -4484,13 +4472,13 @@ void model_update_instance(polymodel *pm, polymodel_instance *pmi, const submode
 
 	// For all the detail levels of this submodel, set them also.
 	for ( int i=0; i<sm->num_details; i++ )	{
-		model_update_instance( pm, pmi, smi, sm->details[i], flags );
+		model_replicate_submodel_instance_sub( pm, pmi, smi, sm->details[i], flags );
 	}
 }
 
-void model_update_instance(polymodel *pm, polymodel_instance *pmi, int submodel_num, flagset<Ship::Subsystem_Flags>& flags)
+void model_replicate_submodel_instance(polymodel *pm, polymodel_instance *pmi, int submodel_num, flagset<Ship::Subsystem_Flags>& flags)
 {
-	model_update_instance(pm, pmi, nullptr, submodel_num, flags);
+	model_replicate_submodel_instance_sub(pm, pmi, nullptr, submodel_num, flags);
 }
 
 void model_do_intrinsic_rotations_sub(intrinsic_rotation *ir)
@@ -4504,58 +4492,46 @@ void model_do_intrinsic_rotations_sub(intrinsic_rotation *ir)
 	// Handle all submodels which have intrinsic rotation
 	for (auto submodel_num: ir->submodel_list)
 	{
-		// First, calculate the angles for the rotation
 		if (pm->submodel[submodel_num].look_at_submodel >= 0)
 			submodel_look_at(pm, pmi, submodel_num);
 		else
 			submodel_rotate(&pm->submodel[submodel_num], &pmi->submodel[submodel_num]);
-
-		// Now actually rotate the submodel instance
-		// (Since this is an intrinsic rotation, we have no associated subsystem, so pass 0 for subsystem flags.)
-		model_update_instance(pm, pmi, submodel_num, empty);
 	}
 }
 
-// Handle the intrinsic rotations for either a) a single ship model; or b) all non-ship models.  The reason for the two cases is that ship_model_update_instance will
-// be called for each ship via obj_move_all_post, but we also need to handle non-ship models once obj_move_all_post exits.  Since the two processes are almost identical,
-// they are both handled here.
+// Handle the intrinsic rotations for either a) a single object model; or b) all non-object models.
 //
-// This function is quite a bit different than Bobboau's old model_do_dumb_rotation function.  Whereas Bobboau used the brute-force technique of navigating through
-// each model hierarchy as it was rendered, this function should be seen as a version of obj_move_all_post, but for models rather than objects.  In fact, the only reason
-// for the special ship case is that the ship intrinsic rotations kind of need to be handled where all the other ship rotations are.  (Unless you want inconsistent collisions
-// or damage sparks that aren't attached to models.)
+// This function called as part of object movement.  All types of object movement, including intrinsic rotations,
+// should be handled at the same time - unless you want inconsistent collisions or damage sparks that aren't attached to models.
 //
 // -- Goober5000
-void model_do_intrinsic_rotations(int model_instance_num)
+void model_do_intrinsic_rotations(object *objp)
 {
-	// we are handling a specific ship
-	if (model_instance_num >= 0)
+	// we are handling a specific object
+	if (objp)
 	{
-		for (auto intrinsic_it = Intrinsic_rotations.begin(); intrinsic_it != Intrinsic_rotations.end(); ++intrinsic_it)
+		int model_instance_num = object_get_model_instance(objp);
+		if (model_instance_num >= 0)
 		{
-			if (intrinsic_it->model_instance_num == model_instance_num)
+			auto obj_it = Intrinsic_rotations.find(model_instance_num);
+			if (obj_it != Intrinsic_rotations.end())
 			{
-				Assertion(intrinsic_it->is_ship, "This code path is only for ship rotations!  See the comments associated with the model_do_intrinsic_rotations function!");
+				Assertion(obj_it->second.is_object, "Inconsistent intrinsic rotation: an object's rotation is not flagged as belonging to an object!");
 
-				// we're just doing one ship, and in ship_model_update_instance, that ship's angles were already set to zero
-
-				// Now update the angles in the submodels
-				model_do_intrinsic_rotations_sub(&(*intrinsic_it));
-
-				// once we've handled this one ship, we're done
-				break;
+				// update the angles in the submodels
+				model_do_intrinsic_rotations_sub(&obj_it->second);
 			}
 		}
 	}
-	// we are handling all non-ships
+	// we are handling all non-objects (so basically just skyboxes)
 	else
 	{
-		for (auto intrinsic_it = Intrinsic_rotations.begin(); intrinsic_it != Intrinsic_rotations.end(); ++intrinsic_it)
+		for (auto &pair: Intrinsic_rotations)
 		{
-			if (!intrinsic_it->is_ship)
+			if (!pair.second.is_object)
 			{
 				// update the angles in the submodels
-				model_do_intrinsic_rotations_sub(&(*intrinsic_it));
+				model_do_intrinsic_rotations_sub(&pair.second);
 			}
 		}
 	}

--- a/code/object/object.cpp
+++ b/code/object/object.cpp
@@ -1260,7 +1260,6 @@ void obj_move_all_post(object *objp, float frametime)
 
 			if ( !physics_paused || (objp==Player_obj) ) {
 				ship_process_post( objp, frametime );
-				ship_model_update_instance(objp);
 			}
 
 			// Make any electrical arcs on ships cast light
@@ -1517,6 +1516,28 @@ void obj_move_all(float frametime)
 			}
 		}
 
+		// Submodel movement now happens here, right after physics movement.
+		// It's not excluded by the "immobile" flag, but it *is* excluded by the Rotators_locked flag.
+		if (objp->type != OBJ_SHIP || !Ships[objp->instance].flags[Ship::Ship_Flags::Rotators_locked]) {
+			// do subsystem movement on this object
+			if (objp->type == OBJ_SHIP) {
+				ship_move_subsystems(objp);
+			}
+
+			// do animation on this object
+			// TODO: change stepAnimations to operate on a per-object basis
+			//animation::ModelAnimation::stepAnimations(objp, frametime);
+
+			// finally, do intrinsic rotation on this object
+			// (this happens last because look_at is a type of intrinsic rotation,
+			// and look_at needs to happen last or the angle may be off by a frame)
+			model_do_intrinsic_rotations(objp);
+		}
+
+		// For ships, we now have to make sure that all the submodel detail levels remain consistent.
+		if (objp->type == OBJ_SHIP)
+			ship_model_replicate_submodels(objp);
+
 		// move post
 		obj_move_all_post(objp, frametime);
 
@@ -1540,12 +1561,12 @@ void obj_move_all(float frametime)
 		}
 	}
 
+	// TODO: remove; see stepAnimations comment above
 	animation::ModelAnimation::stepAnimations(frametime);
 
-	// Now that we've moved all the objects, move all the models that use intrinsic rotations.  We do that here because we already handled the
-	// ship models in obj_move_all_post, and this is more or less conceptually close enough to move the rest.  (Originally all models
-	// were intrinsic-rotated here, but for sequencing reasons, intrinsic ship rotations must happen along with regular ship rotations.)
-	model_do_intrinsic_rotations();
+	// Now apply intrinsic movement to things that aren't objects (like skyboxes).  This technically doesn't belong in the object code,
+	// but there isn't really a good place to put this, it doesn't hurt to have this here, and it's conceptually related to what's here.
+	model_do_intrinsic_rotations(nullptr);
 
 	//	After all objects have been moved, move all docked objects.
 	objp = GET_FIRST(&obj_used_list);

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -9210,45 +9210,31 @@ void ship_evaluate_ai(object* obj, float frametime) {
 	int num = obj->instance;
 	Assertion(obj->type == OBJ_SHIP, "Non-ship object passed to ship_evaluate_ai");
 	Assertion(num >= 0 && num < MAX_SHIPS, "Invalid ship instance num in ship_evaluate_ai");
-	Assertion(Ships[num].objnum == OBJ_INDEX(obj), "Ship objnum does not match its num in OBJ_INDEX in ship_evaluate_ai");
-
 	ship* shipp = &Ships[num];
+	Assertion(shipp->objnum == OBJ_INDEX(obj), "Ship objnum does not match its num in OBJ_INDEX in ship_evaluate_ai");
 
-	//rotate player subobjects since its processed by the ai functions
-	// AL 2-19-98: Fire turret for player if it exists
-	//WMC - changed this to call process_subobjects
-	if ((obj->flags[Object::Object_Flags::Player_ship]) && !Player_use_ai)
-	{
-		ai_info* aip = &Ai_info[Ships[obj->instance].ai_index];
-		if (aip->ai_flags[AI::AI_Flags::Being_repaired, AI::AI_Flags::Awaiting_repair])
-		{
-			if (aip->support_ship_objnum >= 0)
-			{
-				if (vm_vec_dist_quick(&obj->pos, &Objects[aip->support_ship_objnum].pos) < (obj->radius + Objects[aip->support_ship_objnum].radius) * 1.25f)
-					return;
-			}
-		}
-		if (!shipp->flags[Ship::Ship_Flags::Rotators_locked])
-			process_subobjects(OBJ_INDEX(obj));
-	}
+	// seems important
+	if (shipp->ai_index < 0)
+		return;
+
+	// this prevents AI stuff, according to original Volition code
+	if (physics_paused || ai_paused)
+		return;
 
 	// update ship lethality
-	if (Ships[num].ai_index >= 0 ){
-		if (!physics_paused && !ai_paused) {
-			lethality_decay(&Ai_info[Ships[num].ai_index]);
-		}
-	}
+	lethality_decay(&Ai_info[shipp->ai_index]);
 
-	// if the ship is an observer ship don't need to do AI
-	if ( obj->type == OBJ_OBSERVER)  {
-		return;
+	// if we are a player ship and not under AI control, all we do is process our subobjects
+	if ((obj->flags[Object::Object_Flags::Player_ship]) && !Player_use_ai)
+	{
+		// AL 2-19-98: Fire turret for player if it exists
+		//WMC - changed this to call ai_process_subobjects
+		ai_process_subobjects(OBJ_INDEX(obj));
 	}
-
-	// Goober5000 - player may want to use AI
-	if ( (Ships[num].ai_index >= 0) && (!(obj->flags[Object::Object_Flags::Player_ship]) || Player_use_ai) ){
-		if (!physics_paused && !ai_paused){
-			ai_process( obj, Ships[num].ai_index, frametime );
-		}
+	// otherwise we run the full AI pipeline
+	else
+	{
+		ai_process( obj, shipp->ai_index, frametime );
 	}
 }
 
@@ -13500,9 +13486,9 @@ int get_subsystem_pos(vec3d* pos, object* objp, ship_subsys* subsysp)
 }
 
 /**
- * Like ship_model_start but fills submodel instances instead of the submodels themselves
+ * Makes sure all submodel instances for this ship are kept in sync
  */
-void ship_model_update_instance(object *objp)
+void ship_model_replicate_submodels(object *objp)
 {
 	model_subsystem	*psub;
 	ship		*shipp;
@@ -13516,37 +13502,17 @@ void ship_model_update_instance(object *objp)
 	polymodel_instance *pmi = model_get_instance(shipp->model_instance_num);
 	polymodel *pm = model_get(pmi->model_num);
 
-	// Handle subsystem rotations for this ship
 	for ( pss = GET_FIRST(&shipp->subsys_list); pss != END_OF_LIST(&shipp->subsys_list); pss = GET_NEXT(pss) ) {
 		psub = pss->system_info;
-		switch (psub->type) {
-			case SUBSYSTEM_RADAR:
-			case SUBSYSTEM_NAVIGATION:
-			case SUBSYSTEM_COMMUNICATION:
-			case SUBSYSTEM_UNKNOWN:
-			case SUBSYSTEM_ENGINE:
-			case SUBSYSTEM_SENSORS:
-			case SUBSYSTEM_WEAPONS:
-			case SUBSYSTEM_SOLAR:
-			case SUBSYSTEM_GAS_COLLECT:
-			case SUBSYSTEM_ACTIVATION:
-			case SUBSYSTEM_TURRET:
-				break;
-			default:
-				Error(LOCATION, "Illegal subsystem type.\n");
-		}
 
 		if ( psub->subobj_num >= 0 )	{
-			model_update_instance(pm, pmi, psub->subobj_num, pss->flags );
+			model_replicate_submodel_instance(pm, pmi, psub->subobj_num, pss->flags );
 		}
 
 		if ( (psub->subobj_num != psub->turret_gun_sobj) && (psub->turret_gun_sobj >= 0) )		{
-			model_update_instance(pm, pmi, psub->turret_gun_sobj, pss->flags );
+			model_replicate_submodel_instance(pm, pmi, psub->turret_gun_sobj, pss->flags );
 		}
 	}
-
-	// Handle intrinsic rotations for this ship
-	model_do_intrinsic_rotations(shipp->model_instance_num);
 }
 
 /**
@@ -18187,6 +18153,24 @@ void ship_do_submodel_rotation(ship *shipp, model_subsystem *psub, ship_subsys *
 		submodel_stepped_rotate(psub, pss->submodel_instance_1);
 	} else {
 		submodel_rotate(psub, pss->submodel_instance_1 );
+	}
+}
+
+void ship_move_subsystems(object *objp)
+{
+	Assertion(objp->type == OBJ_SHIP, "ship_move_subsystems should only be called for ships!  objp type = %d", objp->type);
+	auto shipp = &Ships[objp->instance];
+
+	for (auto pss = GET_FIRST(&shipp->subsys_list); pss != END_OF_LIST(&shipp->subsys_list); pss = GET_NEXT(pss))
+	{
+		auto psub = pss->system_info;
+
+		// Don't process destroyed objects (but allow subobjects with hitpoints disabled -nuke) (but also process subobjects that are allowed to rotate)
+		if (pss->max_hits > 0 && pss->current_hits <= 0.0f && !(psub->flags[Model::Subsystem_Flags::Destroyed_rotation]))
+			continue;
+
+		// do solar/radar/gas/activator rotation here
+		ship_do_submodel_rotation(shipp, psub, pss);
 	}
 }
 

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -1677,7 +1677,7 @@ extern void shield_hit_close();
 int ship_is_shield_up( object *obj, int quadrant );
 
 //=================================================
-void ship_model_update_instance(object *objp);
+void ship_model_replicate_submodels(object *objp);
 
 //============================================
 extern int ship_find_num_crewpoints(object *objp);
@@ -1909,8 +1909,8 @@ extern bool ship_fighterbays_all_destroyed(ship *shipp);
 // Goober5000
 extern bool ship_subsys_takes_damage(ship_subsys *ss);
 
-// Goober5000 - handles submodel rotation, incorporating conditions such as gun barrels when firing
-extern void ship_do_submodel_rotation(ship *shipp, model_subsystem *psub, ship_subsys *pss);
+// Goober5000 - handles submodel rotation for subsystems, excluding turrets
+extern void ship_move_subsystems(object *objp);
 
 // Goober5000 - shortcut hud stuff
 extern int ship_has_energy_weapons(ship *shipp);

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -6091,7 +6091,7 @@ int weapon_create( vec3d * pos, matrix * porient, int weapon_type, int parent_ob
 
 		// Always create an instance in case we need them
 		if (model_get(wip->model_num)->flags & PM_FLAG_HAS_INTRINSIC_ROTATE || !wip->on_create_program.isEmpty()) {
-			wp->model_instance_num = model_create_instance(false, wip->model_num);
+			wp->model_instance_num = model_create_instance(true, wip->model_num);
 		}
 	} else if ( wip->render_type == WRT_LASER ) {
 		objp->radius = wip->laser_head_radius;


### PR DESCRIPTION
This moves submodel rotation out of the AI pipeline and into object movement.  With the exception of turret rotation (which remains in the AI code) this now allows all types of submodel rotation to happen in the same place.  Many associated functions have also been cleaned up.

In addition to making the code cleaner and clearer, this will make it much easier for intrinsic rotations and new animations to be applied to non-ship objects, such as weapons.