### PR TITLE
rename and adjust scope of Rotators_locked flag

### DIFF
--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -11728,7 +11728,7 @@ void ai_process_subobjects(int objnum)
 		switch (psub->type) {
 		case SUBSYSTEM_TURRET:
 			// Don't process multipart turrets if we can't rotate.
-			if ((psub->subobj_num != psub->turret_gun_sobj) && (psub->turret_gun_sobj >= 0) && shipp->flags[Ship::Ship_Flags::Rotators_locked])
+			if ((psub->subobj_num != psub->turret_gun_sobj) && (psub->turret_gun_sobj >= 0) && shipp->flags[Ship::Ship_Flags::Subsystem_movement_locked])
 				break;
 
 			// Don't process a turret for a ship being repaired, if the support ship is close

--- a/code/lab/renderer/lab_renderer.cpp
+++ b/code/lab/renderer/lab_renderer.cpp
@@ -59,7 +59,7 @@ void LabRenderer::renderModel(float frametime) {
 	PostProcessing_override = renderFlags[LabRenderFlag::HidePostProcessing];
 
 	if (obj->type == OBJ_SHIP) {
-		Ships[obj->instance].flags.set(Ship::Ship_Flags::Rotators_locked, !renderFlags[LabRenderFlag::RotateSubsystems]);
+		Ships[obj->instance].flags.set(Ship::Ship_Flags::Subsystem_movement_locked, !renderFlags[LabRenderFlag::RotateSubsystems]);
 		Ships[obj->instance].flags.set(Ship::Ship_Flags::Draw_as_wireframe, renderFlags[LabRenderFlag::ShowWireframe]);
 		Ships[obj->instance].flags.set(Ship::Ship_Flags::Render_full_detail, renderFlags[LabRenderFlag::ShowFullDetail]);
 		Ships[obj->instance].flags.set(Ship::Ship_Flags::Render_without_light, renderFlags[LabRenderFlag::NoLighting] || currentMissionBackground == "None");

--- a/code/object/object.cpp
+++ b/code/object/object.cpp
@@ -1516,23 +1516,20 @@ void obj_move_all(float frametime)
 			}
 		}
 
-		// Submodel movement now happens here, right after physics movement.
-		// It's not excluded by the "immobile" flag, but it *is* excluded by the Rotators_locked flag.
-		if (objp->type != OBJ_SHIP || !Ships[objp->instance].flags[Ship::Ship_Flags::Rotators_locked]) {
-			// do subsystem movement on this object
-			if (objp->type == OBJ_SHIP) {
-				ship_move_subsystems(objp);
-			}
+		// Submodel movement now happens here, right after physics movement.  It's not excluded by the "immobile" flag.
+		
+		// this flag only affects ship subsystems, not any other type of submodel movement
+		if (objp->type == OBJ_SHIP && !Ships[objp->instance].flags[Ship::Ship_Flags::Subsystem_movement_locked])
+			ship_move_subsystems(objp);
 
-			// do animation on this object
-			// TODO: change stepAnimations to operate on a per-object basis
-			//animation::ModelAnimation::stepAnimations(objp, frametime);
+		// do animation on this object
+		// TODO: change stepAnimations to operate on a per-object basis
+		//animation::ModelAnimation::stepAnimations(objp, frametime);
 
-			// finally, do intrinsic rotation on this object
-			// (this happens last because look_at is a type of intrinsic rotation,
-			// and look_at needs to happen last or the angle may be off by a frame)
-			model_do_intrinsic_rotations(objp);
-		}
+		// finally, do intrinsic rotation on this object
+		// (this happens last because look_at is a type of intrinsic rotation,
+		// and look_at needs to happen last or the angle may be off by a frame)
+		model_do_intrinsic_rotations(objp);
 
 		// For ships, we now have to make sure that all the submodel detail levels remain consistent.
 		if (objp->type == OBJ_SHIP)

--- a/code/ship/ship_flags.h
+++ b/code/ship/ship_flags.h
@@ -110,7 +110,7 @@ namespace Ship {
 		Scramble_messages,			// Goober5000 - all messages sent from this ship appear scrambled
         No_secondary_lockon,        // zookeeper - secondary lock-on disabled
         No_disabled_self_destruct,  // Goober5000 - ship will not self-destruct after 90 seconds if engines or weapons destroyed (c.f. ai_maybe_self_destruct)
-		Rotators_locked,			// The_E -- Rotating subobjects are locked in place
+		Subsystem_movement_locked,	// The_E -- Rotating subsystems are locked in place.
 		Draw_as_wireframe,			// The_E -- Ship will be rendered in wireframe mode
 		Render_without_diffuse,		// The_E -- Ship will be rendered without diffuse map (needed for the lab)
 		Render_without_glowmap,


### PR DESCRIPTION
The Rotators_locked flag was created specifically as a lab option that didn't affect animations or intrinsic rotations, so return it to that scope.  Also rename it to clarify that it applies to subsystems and to be future-proof for submodel translation.

This is a follow-up to #3713.