### PR TITLE
Fix struct_has_member test in libpcp

### DIFF
--- a/lib/libpcp/CMakeLists.txt
+++ b/lib/libpcp/CMakeLists.txt
@@ -1,7 +1,7 @@
 include(CheckStructHasMember)
 
 check_struct_has_member("struct sockaddr" sa_len
-        "sys/types.h sys/socket.h"
+        "sys/socket.h"
         HAVE_SOCKADDR_SA_LEN)
 
 set(LIBPCP_INCLUDE_DIRECTORIES


### PR DESCRIPTION
check_struct_has_member was trying to include 2 headers, which is not allowed, as the generated C code ends up with this invalid line:

    #include <sys/types.h sys/socket.h>

This fixes the test so it actually checks for sa_len. Alternatively, libpcp could be updated to match the current release, which appears to have removed the test entirely.