### PR TITLE
Protected against trying to animate non-existant submodels 

### DIFF
--- a/code/model/modelanimation.cpp
+++ b/code/model/modelanimation.cpp
@@ -112,13 +112,16 @@ namespace animation {
 			}
 
 			for (const auto& animation : m_submodelAnimation) {
-				ModelAnimationData<> base = animation->s_initialData.at({ pmi->id, animation->m_submodel });
-				ModelAnimationData<true>& previousDelta = (*applyBuffer)[animation->m_submodel].second;
-				(*applyBuffer)[animation->m_submodel].first = animation.get();
+				auto b = animation->s_initialData.find({ pmi->id, animation->m_submodel });
+				if(b != animation->s_initialData.end()){
+					ModelAnimationData<> base = animation->s_initialData.at({ pmi->id, animation->m_submodel });
+					ModelAnimationData<true>& previousDelta = (*applyBuffer)[animation->m_submodel].second;
+					(*applyBuffer)[animation->m_submodel].first = animation.get();
 
-				base.applyDelta(previousDelta);
-				ModelAnimationData<true> delta = animation->play(instanceData.time, prevTime, ModelAnimationDirection::FWD, pmi, base);
-				previousDelta.applyDelta(delta);
+					base.applyDelta(previousDelta);
+					ModelAnimationData<true> delta = animation->play(instanceData.time, prevTime, ModelAnimationDirection::FWD, pmi, base);
+					previousDelta.applyDelta(delta);
+				}
 			}
 			break;
 


### PR DESCRIPTION
This is crude and blunt, but in my testing it does resolve #3721. Even if it's going to be wiped out by animation 3 soon, I'm in favor of having this bandaid