### PR TITLE
Removing dead code paths

### DIFF
--- a/code/graphics/light.cpp
+++ b/code/graphics/light.cpp
@@ -294,10 +294,7 @@ void gr_light_init() {
 	gr_lights.reserve(1024);
 }
 
-void gr_set_lighting(bool  /*set*/, bool state) {
-	if (!state) {
-		return;
-	}
+void gr_set_lighting() {
 
 	//Valathil: Sort lights by priority
 	extern bool Deferred_lighting;

--- a/code/graphics/light.h
+++ b/code/graphics/light.h
@@ -17,7 +17,7 @@ extern float gr_user_ambient;
 //Functions
 void gr_set_light(light *fs_light);
 void gr_reset_lighting();
-void gr_set_lighting(bool set, bool state);
+void gr_set_lighting();
 void gr_set_center_alpha(int type);
 void gr_set_ambient_light(int red, int green, int blue);
 

--- a/code/graphics/opengl/gropengltnl.cpp
+++ b/code/graphics/opengl/gropengltnl.cpp
@@ -694,8 +694,6 @@ void gr_opengl_shadow_map_start(matrix4 *shadow_view_matrix, const matrix *light
 	glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
 	glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 
-	gr_set_lighting(false,false);
-
 	Rendering_to_shadow_map = true;
 	Glowpoint_override_save = Glowpoint_override;
 	Glowpoint_override = true;

--- a/code/lighting/lighting.cpp
+++ b/code/lighting/lighting.cpp
@@ -649,7 +649,7 @@ bool scene_lights::setLights(const light_indexing_info *info)
 
 	extern bool Deferred_lighting;
 	if ( Deferred_lighting ) {
-		gr_set_lighting(true, true);
+		gr_set_lighting();
 		return false;
 	}
 
@@ -658,7 +658,7 @@ bool scene_lights::setLights(const light_indexing_info *info)
 
 	// check if there are any lights to actually set
 	if ( num_lights <= 0 ) {
-		gr_set_lighting(true, true);
+		gr_set_lighting();
 		return false;
 	}
 
@@ -672,7 +672,7 @@ bool scene_lights::setLights(const light_indexing_info *info)
 		gr_set_light(&AllLights[light_index]);
 	}
 
-	gr_set_lighting(true, true);
+	gr_set_lighting();
 
 	return true;
 }

--- a/code/model/modelrender.cpp
+++ b/code/model/modelrender.cpp
@@ -814,7 +814,6 @@ void model_draw_list::build_uniform_buffer() {
 		if ( queued_draw.render_material.is_lit() ) {
 			Scene_light_handler.setLights(&queued_draw.lights);
 		} else {
-			gr_set_lighting(false, false);
 
 			Scene_light_handler.resetLightState();
 		}
@@ -1506,7 +1505,6 @@ void submodel_render_immediate(model_render_params *render_info, polymodel *pm, 
 	gr_clear_states();
 
 	gr_reset_lighting();
-	gr_set_lighting(false, false);
 }
 
 void submodel_render_queue(model_render_params *render_info, model_draw_list *scene, polymodel *pm, polymodel_instance *pmi, int submodel_num, matrix *orient, vec3d * pos)
@@ -2571,7 +2569,6 @@ void model_render_immediate(model_render_params* render_info, int model_num, int
 	gr_clear_states();
 
 	gr_reset_lighting();
-	gr_set_lighting(false, false);
 
 	if ( render_info->get_debug_flags() ) {
 		model_render_debug(model_num, orient, pos, render_info->get_model_flags(), render_info->get_debug_flags(), render_info->get_object_number(), render_info->get_detail_level_lock());

--- a/code/object/object.cpp
+++ b/code/object/object.cpp
@@ -1655,7 +1655,6 @@ void obj_render(object *obj)
 	gr_clear_states();
 
 	gr_reset_lighting();
-	gr_set_lighting(false, false);
 }
 
 void obj_queue_render(object* obj, model_draw_list* scene)

--- a/code/object/objectsort.cpp
+++ b/code/object/objectsort.cpp
@@ -356,7 +356,6 @@ void obj_render_queue_all()
 	gr_zbuffer_set(ZBUFFER_TYPE_READ);
 
 	gr_reset_lighting();
-	gr_set_lighting(false, false);
 
 	// now render transparent meshes
 	scene.render_all(ZBUFFER_TYPE_READ);
@@ -375,7 +374,6 @@ void obj_render_queue_all()
 	gr_clear_states();
 
 	gr_reset_lighting();
-	gr_set_lighting(false, false);
 
 	batching_render_all();
 
@@ -387,5 +385,4 @@ void obj_render_queue_all()
 	gr_clear_states();
 
 	gr_reset_lighting();
-	gr_set_lighting(false, false);
 }

--- a/fred2/fredrender.cpp
+++ b/fred2/fredrender.cpp
@@ -1822,7 +1822,6 @@ void render_one_model_htl(object *objp) {
 
 		if (!Lighting_on) {
 			j |= MR_NO_LIGHTING;
-			gr_set_lighting(false, false);
 		}
 
 		if (FullDetail) {

--- a/qtfred/src/mission/FredRenderer.cpp
+++ b/qtfred/src/mission/FredRenderer.cpp
@@ -840,7 +840,6 @@ void FredRenderer::render_one_model_htl(object* objp,
 
 		if (!view().Lighting_on) {
 			j |= MR_NO_LIGHTING;
-			gr_set_lighting(false, false);
 		}
 
 		if (view().FullDetail) {


### PR DESCRIPTION
gr_set_lighting is only ever called with literals, either `(true,true)` or `(false,false)`. the first argument isn't and can't ever be used, and the second only exists to trigger an immediate early exit from the function without doing anything if false. Removing the arguments and deleting the calls with `(false,false)` improves the readability of the code and shouldn't be able to affect anything. I've done a little bit of mission play to see that it doesn't look like it does have any changes. I'm not currently set up to build fred so if someone else could make sure it behaves that'd be grand.