### PR TITLE
Remove light filtering data

### DIFF
--- a/code/lighting/lighting.cpp
+++ b/code/lighting/lighting.cpp
@@ -221,42 +221,6 @@ void light_add_point(const vec3d *pos, float r1, float r2, float intensity, floa
 	Lights.push_back(l);
 }
 
-void light_add_point_unique(const vec3d *pos, float r1, float r2, float intensity, float r, float g, float b, float spec_r, float spec_g, float spec_b, bool specular)
-{
-	Assertion(r1 > 0.0f, "Invalid radius r1 specified for light: %f. Radius must be > 0.0f. Examine stack trace to determine culprit.\n", r1);
-	Assertion(r2 > 0.0f, "Invalid radius r2 specified for light: %f. Radius must be > 0.0f. Examine stack trace to determine culprit.\n", r2);
-
-	if (Lighting_off) return;
-
-	if (!Lighting_flag) return;
-
-	if(!specular){
-		spec_r = r;
-		spec_g = g;
-		spec_b = b;
-	}
-	light l;
-
-	Num_lights++;
-
-	l.type = Light_Type::Point;
-	l.vec = *pos;
-	l.r = r;
-	l.g = g;
-	l.b = b;
-	l.spec_r = spec_r;
-	l.spec_g = spec_g;
-	l.spec_b = spec_b;
-	l.intensity = intensity;
-	l.rada = r1;
-	l.radb = r2;
-	l.rada_squared = l.rada*l.rada;
-	l.radb_squared = l.radb*l.radb;
-	l.instance = Num_lights-1;
-
-	Lights.push_back(l);
-}
-
 // beams affect every ship except the firing ship
 void light_add_tube(const vec3d *p0, const vec3d *p1, float r1, float r2, float intensity, float r, float g, float b, float spec_r, float spec_g, float spec_b, bool specular)
 {

--- a/code/lighting/lighting.cpp
+++ b/code/lighting/lighting.cpp
@@ -177,16 +177,14 @@ void light_add_directional(const vec3d *dir, float intensity, float r, float g, 
 	l.radb = 0.0f;
 	l.rada_squared = l.rada*l.rada;
 	l.radb_squared = l.radb*l.radb;
-	l.light_ignore_objnum = -1;
-	l.affected_objnum = -1;
 	l.instance = Num_lights-1;
-		
+
 	Lights.push_back(l);
 	Static_light.push_back(l);
 }
 
 
-void light_add_point(const vec3d *pos, float r1, float r2, float intensity, float r, float g, float b, int light_ignore_objnum, float spec_r, float spec_g, float spec_b, bool specular)
+void light_add_point(const vec3d *pos, float r1, float r2, float intensity, float r, float g, float b, float spec_r, float spec_g, float spec_b, bool specular)
 {
 	Assertion( r1 > 0.0f, "Invalid radius r1 specified for light: %f. Radius must be > 0.0f. Examine stack trace to determine culprit.\n", r1 );
 	Assertion( r2 > 0.0f, "Invalid radius r2 specified for light: %f. Radius must be > 0.0f. Examine stack trace to determine culprit.\n", r2 );
@@ -218,14 +216,12 @@ void light_add_point(const vec3d *pos, float r1, float r2, float intensity, floa
 	l.radb = r2;
 	l.rada_squared = l.rada*l.rada;
 	l.radb_squared = l.radb*l.radb;
-	l.light_ignore_objnum = light_ignore_objnum;
-	l.affected_objnum = -1;
 	l.instance = Num_lights-1;
 
 	Lights.push_back(l);
 }
 
-void light_add_point_unique(const vec3d *pos, float r1, float r2, float intensity, float r, float g, float b, int affected_objnum, float spec_r, float spec_g, float spec_b, bool specular)
+void light_add_point_unique(const vec3d *pos, float r1, float r2, float intensity, float r, float g, float b, float spec_r, float spec_g, float spec_b, bool specular)
 {
 	Assertion(r1 > 0.0f, "Invalid radius r1 specified for light: %f. Radius must be > 0.0f. Examine stack trace to determine culprit.\n", r1);
 	Assertion(r2 > 0.0f, "Invalid radius r2 specified for light: %f. Radius must be > 0.0f. Examine stack trace to determine culprit.\n", r2);
@@ -256,15 +252,13 @@ void light_add_point_unique(const vec3d *pos, float r1, float r2, float intensit
 	l.radb = r2;
 	l.rada_squared = l.rada*l.rada;
 	l.radb_squared = l.radb*l.radb;
-	l.light_ignore_objnum = -1;
-	l.affected_objnum = affected_objnum;
 	l.instance = Num_lights-1;
 
 	Lights.push_back(l);
 }
 
 // beams affect every ship except the firing ship
-void light_add_tube(const vec3d *p0, const vec3d *p1, float r1, float r2, float intensity, float r, float g, float b, int affected_objnum, float spec_r, float spec_g, float spec_b, bool specular)
+void light_add_tube(const vec3d *p0, const vec3d *p1, float r1, float r2, float intensity, float r, float g, float b, float spec_r, float spec_g, float spec_b, bool specular)
 {
 	Assertion(r1 > 0.0f, "Invalid radius r1 specified for light: %f. Radius must be > 0.0f. Examine stack trace to determine culprit.\n", r1);
 	Assertion(r2 > 0.0f, "Invalid radius r2 specified for light: %f. Radius must be > 0.0f. Examine stack trace to determine culprit.\n", r2);
@@ -297,8 +291,6 @@ void light_add_tube(const vec3d *p0, const vec3d *p1, float r1, float r2, float 
 	l.radb = r2;
 	l.rada_squared = l.rada*l.rada;
 	l.radb_squared = l.radb*l.radb;
-	l.light_ignore_objnum = affected_objnum;
-	l.affected_objnum = -1;
 	l.instance = Num_lights-1;
 
 	Lights.push_back(l);
@@ -471,7 +463,7 @@ void light_apply_rgb( ubyte *param_r, ubyte *param_g, ubyte *param_b, const vec3
 	*param_b = ubyte(fl2i(bval*255.0f));
 }
 
-void light_add_cone(const vec3d *pos, const vec3d *dir, float angle, float inner_angle, bool dual_cone, float r1, float r2, float intensity, float r, float g, float b, int light_ignore_objnum, float spec_r, float spec_g, float spec_b, bool specular)
+void light_add_cone(const vec3d *pos, const vec3d *dir, float angle, float inner_angle, bool dual_cone, float r1, float r2, float intensity, float r, float g, float b, float spec_r, float spec_g, float spec_b, bool specular)
 {
 	Assertion( r1 > 0.0f, "Invalid radius r1 specified for light: %f. Radius must be > 0.0f. Examine stack trace to determine culprit.\n", r1 );
 	Assertion( r2 > 0.0f, "Invalid radius r2 specified for light: %f. Radius must be > 0.0f. Examine stack trace to determine culprit.\n", r2 );
@@ -507,8 +499,6 @@ void light_add_cone(const vec3d *pos, const vec3d *dir, float angle, float inner
 	l.radb = r2;
 	l.rada_squared = l.rada*l.rada;
 	l.radb_squared = l.radb*l.radb;
-	l.light_ignore_objnum = light_ignore_objnum;
-	l.affected_objnum = -1;
 	l.instance = Num_lights-1;
 
 	Lights.push_back(l);
@@ -542,48 +532,29 @@ void scene_lights::setLightFilter(int objnum, const vec3d *pos, float rad)
 				++i;
 				continue;
 			case Light_Type::Point: {
-				// if this is a "unique" light source, it only affects one guy
-				if ( l.affected_objnum >= 0 ) {
-					if ( objnum == l.affected_objnum ) {
-						vec3d to_light;
-						float dist_squared, max_dist_squared;
-						vm_vec_sub( &to_light, &l.vec, pos );
-						dist_squared = vm_vec_mag_squared(&to_light);
+				vec3d to_light;
+				float dist_squared, max_dist_squared;
+				vm_vec_sub( &to_light, &l.vec, pos );
+				dist_squared = vm_vec_mag_squared(&to_light);
 
-						max_dist_squared = l.radb+rad;
-						max_dist_squared *= max_dist_squared;
+				max_dist_squared = l.radb+rad;
+				max_dist_squared *= max_dist_squared;
 
-						if ( dist_squared < max_dist_squared )	{
-							FilteredLights.push_back(i);
-						}
-					}
-				} else { // otherwise check all relevant objects
-					vec3d to_light;
-					float dist_squared, max_dist_squared;
-					vm_vec_sub( &to_light, &l.vec, pos );
-					dist_squared = vm_vec_mag_squared(&to_light);
-
-					max_dist_squared = l.radb+rad;
-					max_dist_squared *= max_dist_squared;
-
-					if ( dist_squared < max_dist_squared )	{
-						FilteredLights.push_back(i);
-					}
+				if ( dist_squared < max_dist_squared )	{
+					FilteredLights.push_back(i);
 				}
 			}
 			break;
 			case Light_Type::Tube: {
-				if ( l.light_ignore_objnum != objnum ) {
-					vec3d nearest;
-					float dist_squared, max_dist_squared;
-					vm_vec_dist_squared_to_line(pos,&l.vec,&l.vec2,&nearest,&dist_squared);
+				vec3d nearest;
+				float dist_squared, max_dist_squared;
+				vm_vec_dist_squared_to_line(pos,&l.vec,&l.vec2,&nearest,&dist_squared);
 
-					max_dist_squared = l.radb+rad;
-					max_dist_squared *= max_dist_squared;
+				max_dist_squared = l.radb+rad;
+				max_dist_squared *= max_dist_squared;
 
-					if ( dist_squared < max_dist_squared ) {
-						FilteredLights.push_back(i);
-					}
+				if ( dist_squared < max_dist_squared ) {
+					FilteredLights.push_back(i);
 				}
 			}
 			break;

--- a/code/lighting/lighting.cpp
+++ b/code/lighting/lighting.cpp
@@ -484,7 +484,7 @@ void scene_lights::addLight(const light *light_ptr)
 	}
 }
 
-void scene_lights::setLightFilter(int objnum, const vec3d *pos, float rad)
+void scene_lights::setLightFilter(const vec3d *pos, float rad)
 {
 	size_t i = 0;
 	// clear out current filtered lights

--- a/code/lighting/lighting.h
+++ b/code/lighting/lighting.h
@@ -88,7 +88,7 @@ extern void light_reset();
 // Intensity - how strong the light is.  1.0 will cast light around 5meters or so.
 // r,g,b - only used for colored lighting. Ignored currently.
 extern void light_add_directional(const vec3d *dir, float intensity, float r, float g, float b, float spec_r = 0.0f, float spec_g = 0.0f, float spec_b = 0.0f, bool specular = false);
-extern void light_add_point(const vec3d * pos, float r1, float r2, float intensity, float r, float g, float b,float spec_r = 0.0f, float spec_g = 0.0f, float spec_b = 0.0f, bool specular = false);
+extern void light_add_point(const vec3d * pos, float r1, float r2, float intensity, float r, float g, float b, float spec_r = 0.0f, float spec_g = 0.0f, float spec_b = 0.0f, bool specular = false);
 extern void light_add_tube(const vec3d *p0, const vec3d *p1, float r1, float r2, float intensity, float r, float g, float b, float spec_r = 0.0f, float spec_g = 0.0f, float spec_b = 0.0f, bool specular = false);
 extern void light_add_cone(const vec3d * pos, const vec3d * dir, float angle, float inner_angle, bool dual_cone, float r1, float r2, float intensity, float r, float g, float b, float spec_r = 0.0f, float spec_g = 0.0f, float spec_b = 0.0f, bool specular = false);
 extern void light_rotate_all();

--- a/code/lighting/lighting.h
+++ b/code/lighting/lighting.h
@@ -45,8 +45,6 @@ typedef struct light {
 	float	radb, radb_squared;				// How big of an area a point light affect.  Is equal to l->intensity / MIN_LIGHT;
 	float	r,g,b;							// The color components of the light
 	float	spec_r,spec_g,spec_b;			// The specular color components of the light
-	int		light_ignore_objnum;			// Don't light this object.  Used to optimize weapons casting light on parents.
-	int		affected_objnum;				// for "unique lights". ie, lights which only affect one object (trust me, its useful)
 	float	cone_angle;						// angle for cone lights
 	float	cone_inner_angle;				// the inner angle for calculating falloff
 	bool	dual_cone;						// should the cone be shining in both directions?
@@ -90,10 +88,10 @@ extern void light_reset();
 // Intensity - how strong the light is.  1.0 will cast light around 5meters or so.
 // r,g,b - only used for colored lighting. Ignored currently.
 extern void light_add_directional(const vec3d *dir, float intensity, float r, float g, float b, float spec_r = 0.0f, float spec_g = 0.0f, float spec_b = 0.0f, bool specular = false);
-extern void light_add_point(const vec3d * pos, float r1, float r2, float intensity, float r, float g, float b, int light_ignore_objnum, float spec_r = 0.0f, float spec_g = 0.0f, float spec_b = 0.0f, bool specular = false);
-extern void light_add_point_unique(const vec3d * pos, float r1, float r2, float intensity, float r, float g, float b, int affected_objnum, float spec_r = 0.0f, float spec_g = 0.0f, float spec_b = 0.0f, bool specular = false);
-extern void light_add_tube(const vec3d *p0, const vec3d *p1, float r1, float r2, float intensity, float r, float g, float b, int affected_objnum, float spec_r = 0.0f, float spec_g = 0.0f, float spec_b = 0.0f, bool specular = false);
-extern void light_add_cone(const vec3d * pos, const vec3d * dir, float angle, float inner_angle, bool dual_cone, float r1, float r2, float intensity, float r, float g, float b, int light_ignore_objnum, float spec_r = 0.0f, float spec_g = 0.0f, float spec_b = 0.0f, bool specular = false);
+extern void light_add_point(const vec3d * pos, float r1, float r2, float intensity, float r, float g, float b,float spec_r = 0.0f, float spec_g = 0.0f, float spec_b = 0.0f, bool specular = false);
+extern void light_add_point_unique(const vec3d * pos, float r1, float r2, float intensity, float r, float g, float b,float spec_r = 0.0f, float spec_g = 0.0f, float spec_b = 0.0f, bool specular = false);
+extern void light_add_tube(const vec3d *p0, const vec3d *p1, float r1, float r2, float intensity, float r, float g, float b, float spec_r = 0.0f, float spec_g = 0.0f, float spec_b = 0.0f, bool specular = false);
+extern void light_add_cone(const vec3d * pos, const vec3d * dir, float angle, float inner_angle, bool dual_cone, float r1, float r2, float intensity, float r, float g, float b, float spec_r = 0.0f, float spec_g = 0.0f, float spec_b = 0.0f, bool specular = false);
 extern void light_rotate_all();
 
 // Same as above only does RGB.

--- a/code/lighting/lighting.h
+++ b/code/lighting/lighting.h
@@ -89,7 +89,6 @@ extern void light_reset();
 // r,g,b - only used for colored lighting. Ignored currently.
 extern void light_add_directional(const vec3d *dir, float intensity, float r, float g, float b, float spec_r = 0.0f, float spec_g = 0.0f, float spec_b = 0.0f, bool specular = false);
 extern void light_add_point(const vec3d * pos, float r1, float r2, float intensity, float r, float g, float b,float spec_r = 0.0f, float spec_g = 0.0f, float spec_b = 0.0f, bool specular = false);
-extern void light_add_point_unique(const vec3d * pos, float r1, float r2, float intensity, float r, float g, float b,float spec_r = 0.0f, float spec_g = 0.0f, float spec_b = 0.0f, bool specular = false);
 extern void light_add_tube(const vec3d *p0, const vec3d *p1, float r1, float r2, float intensity, float r, float g, float b, float spec_r = 0.0f, float spec_g = 0.0f, float spec_b = 0.0f, bool specular = false);
 extern void light_add_cone(const vec3d * pos, const vec3d * dir, float angle, float inner_angle, bool dual_cone, float r1, float r2, float intensity, float r, float g, float b, float spec_r = 0.0f, float spec_g = 0.0f, float spec_b = 0.0f, bool specular = false);
 extern void light_rotate_all();

--- a/code/lighting/lighting.h
+++ b/code/lighting/lighting.h
@@ -77,7 +77,7 @@ public:
 		resetLightState();
 	}
 	void addLight(const light *light_ptr);
-	void setLightFilter(int objnum, const vec3d *pos, float rad);
+	void setLightFilter(const vec3d *pos, float rad);
 	bool setLights(const light_indexing_info *info);
 	void resetLightState();
 	light_indexing_info bufferLights();

--- a/code/lighting/lighting.h
+++ b/code/lighting/lighting.h
@@ -7,10 +7,10 @@
  *
 */ 
 
-
-
 #ifndef _LIGHTING_H
 #define _LIGHTING_H
+
+#include "globalincs/pstypes.h"
 
 // Light stuff works like this:
 // At the start of the frame, call light_reset.

--- a/code/model/modelrender.cpp
+++ b/code/model/modelrender.cpp
@@ -489,9 +489,9 @@ void model_draw_list::add_arc(vec3d *v1, vec3d *v2, color *primary, color *secon
 	Arcs.push_back(new_arc);
 }
 
-void model_draw_list::set_light_filter(int objnum, vec3d *pos, float rad)
+void model_draw_list::set_light_filter(vec3d *pos, float rad)
 {
-	Scene_light_handler.setLightFilter(objnum, pos, rad);
+	Scene_light_handler.setLightFilter(pos, rad);
 
 	Current_lights_set = Scene_light_handler.bufferLights();
 }
@@ -1582,7 +1582,7 @@ void submodel_render_queue(model_render_params *render_info, model_draw_list *sc
 	rendering_material.set_light_factor(1.0f);
 	
 	if ( !( flags & MR_NO_LIGHTING ) ) {
-		scene->set_light_filter(-1, pos, pm->submodel[submodel_num].rad);
+		scene->set_light_filter(pos, pm->submodel[submodel_num].rad);
 		rendering_material.set_lighting(true);
 	} else {
 		rendering_material.set_lighting(false);
@@ -2712,7 +2712,7 @@ void model_render_queue(model_render_params* interp, model_draw_list* scene, int
 	model_render_set_glow_points(pm, objnum);
 
 	if ( !(model_flags & MR_NO_LIGHTING) ) {
-		scene->set_light_filter(objnum, pos, pm->rad);
+		scene->set_light_filter(pos, pm->rad);
 	}
 
 	ship *shipp = NULL;

--- a/code/model/modelrender.h
+++ b/code/model/modelrender.h
@@ -295,7 +295,7 @@ public:
 	void add_outline(vertex* vert_array, int n_verts, color *clr);
 	void render_outlines();
 
-	void set_light_filter(int objnum, vec3d *pos, float rad);
+	void set_light_filter(vec3d *pos, float rad);
 
 	void init_render(bool sort = true);
 	void render_all(gr_zbuffer_type depth_mode = ZBUFFER_TYPE_DEFAULT);

--- a/code/object/object.cpp
+++ b/code/object/object.cpp
@@ -1224,10 +1224,9 @@ void obj_move_all_post(object *objp, float frametime)
 						g = i2fl(c.green)/255.0f;
 						b = i2fl(c.blue)/255.0f;
 
-						//light_add_point( &objp->pos, 10.0f, 20.0f, 1.0f, r, g, b, objp->parent );
-						light_add_point( &objp->pos, 10.0f, 100.0f, 1.0f, r, g, b, objp->parent );
+						light_add_point( &objp->pos, 10.0f, 100.0f, 1.0f, r, g, b);
 					} else {
-						light_add_point( &objp->pos, 10.0f, 20.0f, 1.0f, 1.0f, 1.0f, 1.0f, objp->parent );
+						light_add_point( &objp->pos, 10.0f, 20.0f, 1.0f, 1.0f, 1.0f, 1.0f);
 					} 
 				}
 			}
@@ -1260,8 +1259,8 @@ void obj_move_all_post(object *objp, float frametime)
 							vm_vec_unrotate(&tmp2,&shipp->arc_pts[i][1],&objp->orient);
 							vm_vec_add2(&tmp2,&objp->pos);
 
-							light_add_point( &tmp1, 10.0f, 20.0f, frand(), 1.0f, 1.0f, 1.0f, -1 );
-							light_add_point( &tmp2, 10.0f, 20.0f, frand(), 1.0f, 1.0f, 1.0f, -1 );
+							light_add_point( &tmp1, 10.0f, 20.0f, frand(), 1.0f, 1.0f, 1.0f);
+							light_add_point( &tmp2, 10.0f, 20.0f, frand(), 1.0f, 1.0f, 1.0f);
 						}
 					}
 				}
@@ -1321,7 +1320,7 @@ void obj_move_all_post(object *objp, float frametime)
 					// P goes from 0 to 1 to 0 over the life of the explosion
 					// Only do this if rad is > 0.0000001f
 					if (rad > 0.0001f)
-						light_add_point( &objp->pos, rad * 2.0f, rad * 5.0f, intensity, r, g, b, -1 );
+						light_add_point( &objp->pos, rad * 2.0f, rad * 5.0f, intensity, r, g, b);
 				}
 			}
 
@@ -1357,8 +1356,8 @@ void obj_move_all_post(object *objp, float frametime)
 								vm_vec_unrotate(&tmp2,&db->arc_pts[i][1],&objp->orient);
 								vm_vec_add2(&tmp2,&objp->pos);
 
-								light_add_point( &tmp1, 10.0f, 20.0f, frand(), 1.0f, 1.0f, 1.0f, -1 );
-								light_add_point( &tmp2, 10.0f, 20.0f, frand(), 1.0f, 1.0f, 1.0f, -1 );
+								light_add_point( &tmp1, 10.0f, 20.0f, frand(), 1.0f, 1.0f, 1.0f );
+								light_add_point( &tmp2, 10.0f, 20.0f, frand(), 1.0f, 1.0f, 1.0f );
 							}
 						}
 					}

--- a/code/weapon/beam.cpp
+++ b/code/weapon/beam.cpp
@@ -1877,12 +1877,12 @@ void beam_add_light_small(beam *bm, object *objp, vec3d *pt_override = NULL)
 	if (bm->warmup_stamp != -1) {	// calculate muzzle light intensity
 		// get warmup pct
 		pct = BEAM_WARMUP_PCT(bm)*0.5f;
-	} else
+	}
 	// if the beam is warming down
-	if (bm->warmdown_stamp != -1) {
+	else if (bm->warmdown_stamp != -1) {
 		// get warmup pct
 		pct = MAX(1.0f - BEAM_WARMDOWN_PCT(bm)*1.3f,0.0f)*0.5f;
-	} 
+	}
 	// otherwise the beam is really firing
 	else {
 		pct = 1.0f;

--- a/code/weapon/beam.cpp
+++ b/code/weapon/beam.cpp
@@ -1877,10 +1877,8 @@ void beam_add_light_small(beam *bm, object *objp, vec3d *pt_override = NULL)
 	if (bm->warmup_stamp != -1) {	// calculate muzzle light intensity
 		// get warmup pct
 		pct = BEAM_WARMUP_PCT(bm)*0.5f;
-	}
-	// if the beam is warming down
-	else if (bm->warmdown_stamp != -1) {
-		// get warmup pct
+	} else if (bm->warmdown_stamp != -1) {
+	// if the beam is warming down get warmdown pct
 		pct = MAX(1.0f - BEAM_WARMDOWN_PCT(bm)*1.3f,0.0f)*0.5f;
 	}
 	// otherwise the beam is really firing

--- a/code/weapon/beam.cpp
+++ b/code/weapon/beam.cpp
@@ -1887,8 +1887,8 @@ void beam_add_light_small(beam *bm, object *objp, vec3d *pt_override = NULL)
 	else {
 		pct = 1.0f;
 	}
-	// add a unique light
-	light_add_point_unique(&near_pt, light_rad * 0.0001f, light_rad, pct, fr, fg, fb);
+	// add a light
+	light_add_point(&near_pt, light_rad * 0.0001f, light_rad, pct, fr, fg, fb);
 }
 
 // call to add a light source to a large object

--- a/code/weapon/beam.cpp
+++ b/code/weapon/beam.cpp
@@ -1888,7 +1888,7 @@ void beam_add_light_small(beam *bm, object *objp, vec3d *pt_override = NULL)
 		pct = 1.0f;
 	}
 	// add a unique light
-	light_add_point_unique(&near_pt, light_rad * 0.0001f, light_rad, pct, fr, fg, fb, OBJ_INDEX(objp));
+	light_add_point_unique(&near_pt, light_rad * 0.0001f, light_rad, pct, fr, fg, fb);
 }
 
 // call to add a light source to a large object
@@ -1927,7 +1927,7 @@ void beam_add_light_large(beam *bm, object *objp, vec3d *pt0, vec3d *pt1)
 	float fg = (float)wip->laser_color_1.green / 255.0f;
 	float fb = (float)wip->laser_color_1.blue / 255.0f;
 
-	light_add_tube(pt0, pt1, 1.0f, light_rad, 1.0f * noise, fr, fg, fb, OBJ_INDEX(objp));
+	light_add_tube(pt0, pt1, 1.0f, light_rad, 1.0f * noise, fr, fg, fb);
 }
 
 // mark an object as being lit


### PR DESCRIPTION
`light_ignore_objnum` and `affected_objnum` support features that, as far as I can determine, can't work in deferred and don't even work in non-deferred lighting. Their continued presence in the code is a distraction.

Submitted in draft at the moment because my ability to actually test these changes has been very limited.