### PR TITLE
fix: cmdbrief not saving current stage text by closing the window

### DIFF
--- a/fred2/cmdbrief.cpp
+++ b/fred2/cmdbrief.cpp
@@ -313,6 +313,7 @@ BOOL cmd_brief_dlg::DestroyWindow()
 	audiostream_close_file(m_wave_id, 0);
 	m_wave_id = -1;
 
+	update_data();
 	m_play_bm.DeleteObject();
 	return CDialog::DestroyWindow();
 }


### PR DESCRIPTION
Command Briefing dialog on Fred2 was not saving the current stage text changes if after editing the text you close the window with the X instead of using the OK.

