### PR TITLE
make gamesnd a little more robust

### DIFF
--- a/code/gamesnd/gamesnd.cpp
+++ b/code/gamesnd/gamesnd.cpp
@@ -861,9 +861,10 @@ void parse_gamesnd_new(game_snd* gs, bool no_create)
 	// Default pitch is 1.0. This is set here in case we don't have a valid file name
 	gs->pitch_range = util::UniformFloatRange(1.0f);
 
-	if (!stricmp(name, NOX("empty")))
+	if (!stricmp(name, NOX("empty")) || !stricmp(name, NOX("none")))
 	{
 		entry->filename[0] = 0;
+		gs->flags |= GAME_SND_NOT_VALID;
 		return;
 	}
 
@@ -1344,7 +1345,7 @@ bool gamesnd_interface_sound_valid(interface_snd_id sound) {
 	return sound.isValid() && sound.value() < (int) Snds_iface.size();
 }
 
-bool gamesnd_game_sound_exists(gamesnd_id sound)
+bool gamesnd_game_sound_try_load(gamesnd_id sound)
 {
 	if (!gamesnd_game_sound_valid(sound)) {
 		return false;

--- a/code/gamesnd/gamesnd.cpp
+++ b/code/gamesnd/gamesnd.cpp
@@ -642,10 +642,11 @@ void parse_gamesnd_old(game_snd* gs)
 
 	stuff_string(entry.filename, F_NAME, MAX_FILENAME_LEN, ",");
 
-	if (!stricmp(entry.filename, NOX("empty")))
+	if (!stricmp(entry.filename, NOX("empty")) || !stricmp(entry.filename, NOX("none")))
 	{
 		entry.filename[0] = 0;
-		advance_to_eoln(NULL);
+		advance_to_eoln(nullptr);
+		gs->flags |= GAME_SND_NOT_VALID;
 		return;
 	}
 	Mp++;
@@ -1341,6 +1342,24 @@ bool gamesnd_game_sound_valid(gamesnd_id sound) {
 }
 bool gamesnd_interface_sound_valid(interface_snd_id sound) {
 	return sound.isValid() && sound.value() < (int) Snds_iface.size();
+}
+
+bool gamesnd_game_sound_exists(gamesnd_id sound)
+{
+	if (!gamesnd_game_sound_valid(sound)) {
+		return false;
+	}
+	auto gs = gamesnd_get_game_sound(sound);
+
+	for (auto& entry : gs->sound_entries) {
+		if (!entry.id.isValid()) {
+			// Lazily load unloaded sound entries when required
+			entry.id = snd_load(&entry, &gs->flags);
+		}
+	}
+
+	// check flag
+	return (gs->flags & GAME_SND_NOT_VALID) == 0;
 }
 
 float gamesnd_get_max_duration(game_snd* gs) {

--- a/code/gamesnd/gamesnd.h
+++ b/code/gamesnd/gamesnd.h
@@ -404,7 +404,7 @@ bool gamesnd_game_sound_valid(gamesnd_id sound);
 /**
 * @brief Checks if the given sound handle can be loaded
 */
-bool gamesnd_game_sound_exists(gamesnd_id sound);
+bool gamesnd_game_sound_try_load(gamesnd_id sound);
 
 /**
  * @brief Checks if the given sound handle is a valid interface sound handle

--- a/code/gamesnd/gamesnd.h
+++ b/code/gamesnd/gamesnd.h
@@ -402,6 +402,11 @@ game_snd* gamesnd_get_interface_sound(interface_snd_id handle);
 bool gamesnd_game_sound_valid(gamesnd_id sound);
 
 /**
+* @brief Checks if the given sound handle can be loaded
+*/
+bool gamesnd_game_sound_exists(gamesnd_id sound);
+
+/**
  * @brief Checks if the given sound handle is a valid interface sound handle
  * @param sound The handle to check
  * @return @c true if the handle is valid

--- a/code/scripting/api/objs/sound.cpp
+++ b/code/scripting/api/objs/sound.cpp
@@ -124,13 +124,13 @@ ADE_FUNC(isValid, l_SoundEntry, nullptr, "Detects whether handle is valid", "boo
 	return ade_set_args(L, "b", seh->IsValid());
 }
 
-ADE_FUNC(exists, l_SoundEntry, nullptr, "Detects whether handle references a sound that can be loaded", "boolean", "true if exists, false if not, nil if a syntax/type error occurs")
+ADE_FUNC(tryLoad, l_SoundEntry, nullptr, "Detects whether handle references a sound that can be loaded", "boolean", "true if a load succeeded, false if not, nil if a syntax/type error occurs")
 {
 	sound_entry_h *seh;
 	if (!ade_get_args(L, "o", l_SoundEntry.GetPtr(&seh)))
 		return ADE_RETURN_NIL;
 
-	return ade_set_args(L, "b", gamesnd_game_sound_exists(seh->idx));
+	return ade_set_args(L, "b", gamesnd_game_sound_try_load(seh->idx));
 }
 
 sound_h::sound_h() : sound_entry_h() { sig = sound_handle::invalid(); }

--- a/code/scripting/api/objs/sound.cpp
+++ b/code/scripting/api/objs/sound.cpp
@@ -115,13 +115,22 @@ ADE_FUNC(get3DValues,
 	}
 }
 
-ADE_FUNC(isValid, l_SoundEntry, NULL, "Detects whether handle is valid", "boolean", "true if valid, false if handle is invalid, nil if a syntax/type error occurs")
+ADE_FUNC(isValid, l_SoundEntry, nullptr, "Detects whether handle is valid", "boolean", "true if valid, false if handle is invalid, nil if a syntax/type error occurs")
 {
 	sound_entry_h *seh;
 	if(!ade_get_args(L, "o", l_SoundEntry.GetPtr(&seh)))
 		return ADE_RETURN_NIL;
 
 	return ade_set_args(L, "b", seh->IsValid());
+}
+
+ADE_FUNC(exists, l_SoundEntry, nullptr, "Detects whether handle references a sound that can be loaded", "boolean", "true if exists, false if not, nil if a syntax/type error occurs")
+{
+	sound_entry_h *seh;
+	if (!ade_get_args(L, "o", l_SoundEntry.GetPtr(&seh)))
+		return ADE_RETURN_NIL;
+
+	return ade_set_args(L, "b", gamesnd_game_sound_exists(seh->idx));
 }
 
 sound_h::sound_h() : sound_entry_h() { sig = sound_handle::invalid(); }

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -14299,7 +14299,7 @@ int ship_do_rearm_frame( object *objp, float frametime )
 				{
 					// Goober5000
 					gamesnd_id sound_index;
-					if (gamesnd_game_sound_exists(GameSounds::BALLISTIC_START_LOAD))
+					if (gamesnd_game_sound_try_load(GameSounds::BALLISTIC_START_LOAD))
 						sound_index = GameSounds::BALLISTIC_START_LOAD;
 					else
 						sound_index = GameSounds::MISSILE_START_LOAD;
@@ -14326,7 +14326,7 @@ int ship_do_rearm_frame( object *objp, float frametime )
 	
 						// Goober5000
 						gamesnd_id sound_index;
-						if (gamesnd_game_sound_exists(GameSounds::BALLISTIC_LOAD))
+						if (gamesnd_game_sound_try_load(GameSounds::BALLISTIC_LOAD))
 							sound_index = GameSounds::BALLISTIC_LOAD;
 						else
 							sound_index = GameSounds::MISSILE_LOAD;
@@ -14358,7 +14358,7 @@ int ship_do_rearm_frame( object *objp, float frametime )
 				{
 					// Goober5000
 					gamesnd_id sound_index;
-					if (gamesnd_game_sound_exists(GameSounds::BALLISTIC_START_LOAD))
+					if (gamesnd_game_sound_try_load(GameSounds::BALLISTIC_START_LOAD))
 						sound_index = GameSounds::BALLISTIC_START_LOAD;
 					else
 						sound_index = GameSounds::MISSILE_START_LOAD;

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -14299,7 +14299,7 @@ int ship_do_rearm_frame( object *objp, float frametime )
 				{
 					// Goober5000
 					gamesnd_id sound_index;
-					if (gamesnd_game_sound_valid(GameSounds::BALLISTIC_START_LOAD))
+					if (gamesnd_game_sound_exists(GameSounds::BALLISTIC_START_LOAD))
 						sound_index = GameSounds::BALLISTIC_START_LOAD;
 					else
 						sound_index = GameSounds::MISSILE_START_LOAD;
@@ -14326,7 +14326,7 @@ int ship_do_rearm_frame( object *objp, float frametime )
 	
 						// Goober5000
 						gamesnd_id sound_index;
-						if (gamesnd_game_sound_valid(GameSounds::BALLISTIC_LOAD))
+						if (gamesnd_game_sound_exists(GameSounds::BALLISTIC_LOAD))
 							sound_index = GameSounds::BALLISTIC_LOAD;
 						else
 							sound_index = GameSounds::MISSILE_LOAD;
@@ -14358,7 +14358,7 @@ int ship_do_rearm_frame( object *objp, float frametime )
 				{
 					// Goober5000
 					gamesnd_id sound_index;
-					if (gamesnd_game_sound_valid(GameSounds::BALLISTIC_START_LOAD))
+					if (gamesnd_game_sound_exists(GameSounds::BALLISTIC_START_LOAD))
 						sound_index = GameSounds::BALLISTIC_START_LOAD;
 					else
 						sound_index = GameSounds::MISSILE_START_LOAD;


### PR DESCRIPTION
a) add a new method `gamesnd_game_sound_exists`
b) add script support for this new method
c) use this method when checking for existence of ballistic rearming sounds
d) prevent "empty" and "none" sounds from triggering warnings