### PR TITLE
Do not add check_alive flag on msg with #Command as source if it has a wingman type persona attached

### DIFF
--- a/code/mission/missionmessage.cpp
+++ b/code/mission/missionmessage.cpp
@@ -1714,7 +1714,7 @@ void message_queue_message( int message_num, int priority, int timing, const cha
 		MessageQ[i].source = HUD_SOURCE_TERRAN_CMD;
 	}
 
-	if ( (m_persona != -1) && (Personas[m_persona].flags & PERSONA_FLAG_WINGMAN) ) {
+	if ( MessageQ[i].source != HUD_SOURCE_TERRAN_CMD && (m_persona != -1) && (Personas[m_persona].flags & PERSONA_FLAG_WINGMAN) ) {
 		if ( !strstr(who_from, ".wav") ) {
 			MessageQ[i].flags |= MQF_CHECK_ALIVE;
 		}


### PR DESCRIPTION
The problem:
Using SendMessage sexp, if you set the source to "#Command" and use a message that has a wingman type persona assigned to it, the message will never be sent.

At first this may seem to make sense, but, this is the only exception, sendmessage does not stop any other kind of conflicting personas, you can send a message with persona type command on a ship with persona wingman, or with non-matching personas.

This only happens with "#Command", using any other kind of special source is fine. Using "#Command" and any other than wingman type is also fine.

The problem is this if that sets the check_alive flag on all messages that has a wingman persona set. 

Right abvode this if there is the following hack:
// SPECIAL HACK -- if the who_from is terran command, and there is a wingman persona attached
// to this message, then set a bit to tell the wave/anim playing code to play the command version
// of the wave and head
MessageQ[i].flags = 0;
if ( !stricmp(who_from, The_mission.command_sender) && (m_persona != -1) && (Personas[m_persona].flags & PERSONA_FLAG_WINGMAN) ) {
    MessageQ[i].flags |= MQF_CONVERT_TO_COMMAND;
    MessageQ[i].source = HUD_SOURCE_TERRAN_CMD;
}

It considers that a wingman persona on a message coming from command as a mistake so it changes the ani. (this works btw). But more importanly, it means that this is allowed, it just that it is very likely that it never worked.

The fix:
Since the "hack" changes the source to "HUD_SOURCE_TERRAN_CMD" ill just use that to not enter in the if. This fixes the issue for this special case and makes the hack to start working again too. But it may not be the correct fix. 


**An alternative fix, that i belive it is a better choice but it may have a retail behaviour change, is to just comment out the "special hack" code, because thats is what is causing the problem, whiout that "hack" the messages are sended as they should, even with the check alive flag set.  That i belive it is a better route as correct anim/persona settings should be up to the mission designer, and the hack should not work in any case as it is now anyway.


Test mission it should play 3 messages:
[commandPersonaTest.zip](https://github.com/scp-fs2open/fs2open.github.com/files/7447690/commandPersonaTest.zip)