### PR TITLE
Fix Crash On second opening of select box cause by #3634

### DIFF
--- a/fred2/ship_select.cpp
+++ b/fred2/ship_select.cpp
@@ -50,6 +50,7 @@ ship_select::ship_select(CWnd* pParent /*=NULL*/)
 	//}}AFX_DATA_INIT
 
 	// this is stupid
+	IDC_FILTER_SHIPS_IFF.clear();
 	IDC_FILTER_SHIPS_IFF.push_back(IDC_FILTER_SHIPS_IFF_0);
 	IDC_FILTER_SHIPS_IFF.push_back(IDC_FILTER_SHIPS_IFF_1);
 	IDC_FILTER_SHIPS_IFF.push_back(IDC_FILTER_SHIPS_IFF_2);


### PR DESCRIPTION
The IDC_FILTER_SHIPS_IFF is not properly cleared resulting in the dialog crashing on second opening due to the data being duplicated and and pushing filter_iff out of range.