### PR TITLE
polish sexp syntax checking 

### DIFF
--- a/code/mission/missioncampaign.cpp
+++ b/code/mission/missioncampaign.cpp
@@ -1413,6 +1413,7 @@ void read_mission_goal_list(int num)
 	char events[MAX_MISSION_EVENTS][NAME_LENGTH];
 	int i, z, event_count, count = 0;
 
+	Assertion(num >= 0 && num < Campaign.num_missions, "mission number out of range!");
 	filename = Campaign.missions[num].name;
 	
 	try

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -2230,7 +2230,12 @@ int check_sexp_syntax(int node, int return_type, int recursive, int *bad_node, i
 						if (type == OPF_SUBSYSTEM_OR_NONE)
 							break;
 						else
+						{
+							if (bad_node)
+								*bad_node = ship_node;
+
 							return SEXP_CHECK_INVALID_SHIP;
+						}
 					}
 
 					ship_class = p_objp->ship_class;
@@ -2717,8 +2722,12 @@ int check_sexp_syntax(int node, int return_type, int recursive, int *bad_node, i
 						if (!stricmp(CTEXT(z), Campaign.missions[i].name))
 							break;
 
-					if (i >= Campaign.num_missions)
+					if (i >= Campaign.num_missions) {
+						if (bad_node)
+							*bad_node = z;
+
 						return SEXP_CHECK_INVALID_MISSION_NAME;
+					}
 
 					// read the goal/event list from the mission file if both num_goals and num_events
 					// are < 0


### PR DESCRIPTION
Some instances of the ship syntax checker will check other nodes in the sexp tree.  In those cases, make sure to accommodate special-arg nodes.

This also merges syntax checking for goal/event names and docker/dockee points since they are highly similar.

Fixes #3758.