### PR TITLE
fix a major bug in ba.rand32f

### DIFF
--- a/code/scripting/api/libs/base.cpp
+++ b/code/scripting/api/libs/base.cpp
@@ -93,7 +93,12 @@ ADE_FUNC(rand32f,
 	float _max;
 	int numargs = ade_get_args(L, "|f", &_max);
 
-	float result = (float)Random::next() * Random::INV_F_MAX_VALUE;
+	// see also frand()
+	int num;
+	do {
+		num = Random::next();
+	} while (num == Random::MAX_VALUE);
+	float result = i2fl(num) * Random::INV_F_MAX_VALUE;
 
 	if (numargs > 0)
 		result *= _max;

--- a/code/scripting/api/libs/base.cpp
+++ b/code/scripting/api/libs/base.cpp
@@ -80,7 +80,7 @@ ADE_FUNC(rand32,
 		result = Random::next();
 	}
 
-	return ade_set_error(L, "i", result);
+	return ade_set_args(L, "i", result);
 }
 
 ADE_FUNC(rand32f,
@@ -98,7 +98,7 @@ ADE_FUNC(rand32f,
 	if (numargs > 0)
 		result *= _max;
 
-	return ade_set_error(L, "f", _max);
+	return ade_set_args(L, "f", result);
 }
 
 ADE_FUNC(createOrientation,


### PR DESCRIPTION
The function should return the random result, not the maximum value.

Also use `ade_set_args` for consistency.