### PR TITLE
allow subtitles to use different line spacing

### DIFF
--- a/code/camera/camera.cpp
+++ b/code/camera/camera.cpp
@@ -560,9 +560,9 @@ void warp_camera::get_info(vec3d *position, matrix *orientation)
 #define MAX_SUBTITLE_LINES		64
 subtitle::subtitle(int in_x_pos, int in_y_pos, const char* in_text, const char* in_imageanim, float in_display_time,
 	float in_fade_time, const color *in_text_color, int in_text_fontnum, bool center_x, bool center_y, int in_width,
-	int in_height, bool in_post_shaded)
+	int in_height, bool in_post_shaded, float line_height_factor)
 	:display_time(-1.0f), fade_time(-1.0f), text_fontnum(-1), time_displayed(-1.0f), time_displayed_end(-1.0f),
-	post_shaded(false)
+	post_shaded(false), line_height_factor(line_height_factor)
 {
 	// Initialize color
 	gr_init_color(&text_color, 0, 0, 0);
@@ -646,7 +646,7 @@ subtitle::subtitle(int in_x_pos, int in_y_pos, const char* in_text, const char* 
 			if(w > tw)
 				tw = w;
 
-			th += h;
+			th += fl2i(line_height_factor * h);
 		}
 
 		// restore old font
@@ -744,7 +744,7 @@ void subtitle::do_frame(float frametime)
 	for(SCP_vector<SCP_string>::iterator line = text_lines.begin(); line != text_lines.end(); ++line)
 	{
 		gr_string(x, y, (char*)line->c_str(), GR_RESIZE_NONE);
-		y += font_height;
+		y += fl2i(line_height_factor * font_height);
 	}
 
 	// restore old font
@@ -793,9 +793,9 @@ subtitle::~subtitle()
 
 void subtitle::clone(const subtitle &sub)
 {
-
 	text_lines = sub.text_lines;
 	text_fontnum = sub.text_fontnum;
+	line_height_factor = sub.line_height_factor;
 
 	// copy the structs
 	text_pos = sub.text_pos;

--- a/code/camera/camera.cpp
+++ b/code/camera/camera.cpp
@@ -560,9 +560,9 @@ void warp_camera::get_info(vec3d *position, matrix *orientation)
 #define MAX_SUBTITLE_LINES		64
 subtitle::subtitle(int in_x_pos, int in_y_pos, const char* in_text, const char* in_imageanim, float in_display_time,
 	float in_fade_time, const color *in_text_color, int in_text_fontnum, bool center_x, bool center_y, int in_width,
-	int in_height, bool in_post_shaded, float line_height_factor)
-	:display_time(-1.0f), fade_time(-1.0f), text_fontnum(-1), time_displayed(-1.0f), time_displayed_end(-1.0f),
-	post_shaded(false), line_height_factor(line_height_factor)
+	int in_height, bool in_post_shaded, float in_line_height_factor)
+	: display_time(-1.0f), fade_time(-1.0f), text_fontnum(-1), line_height_factor(1.0f),
+	image_id(-1), time_displayed(-1.0f), time_displayed_end(-1.0f), post_shaded(false)
 {
 	// Initialize color
 	gr_init_color(&text_color, 0, 0, 0);
@@ -573,7 +573,6 @@ subtitle::subtitle(int in_x_pos, int in_y_pos, const char* in_text, const char* 
 	memset( imageanim, 0, sizeof(imageanim) );
 	memset( &text_pos, 0, 2*sizeof(int) );
 	memset( &image_pos, 0, 4*sizeof(int) );
-	image_id = -1;
 
 	if ( ((in_text != NULL) && (strlen(in_text) <= 0)) && ((in_imageanim != NULL) && (strlen(in_imageanim) <= 0)) )
 		return;
@@ -584,7 +583,6 @@ subtitle::subtitle(int in_x_pos, int in_y_pos, const char* in_text, const char* 
 		sexp_replace_variable_names_with_values(text_buf);
 		in_text = text_buf.c_str();
 	}
-
 
 	int num_text_lines = 0;
 	const char *text_line_ptrs[MAX_SUBTITLE_LINES];
@@ -608,6 +606,7 @@ subtitle::subtitle(int in_x_pos, int in_y_pos, const char* in_text, const char* 
 	else
 		gr_init_alphacolor(&text_color, 255, 255, 255, 255);
 	text_fontnum = in_text_fontnum;
+	line_height_factor = in_line_height_factor;
 
 	//Setup display and fade time
 	display_time = fl_abs(in_display_time);

--- a/code/camera/camera.h
+++ b/code/camera/camera.h
@@ -141,7 +141,7 @@ public:
 	subtitle(int in_x_pos, int in_y_pos, const char* in_text = NULL, const char* in_imageanim = NULL,
 			 float in_display_time = 0, float in_fade_time = 0.0f, const color *in_text_color = NULL, int in_text_fontnum = -1,
 			 bool center_x = false, bool center_y = false, int in_width = 0, int in_height = 0, bool post_shaded = false,
-			 float line_height_factor = 1.0f);
+			 float in_line_height_factor = 1.0f);
 	~subtitle();
 
     subtitle(const subtitle &sub) { clone(sub); }

--- a/code/camera/camera.h
+++ b/code/camera/camera.h
@@ -123,6 +123,7 @@ private:
 	float fade_time;
 	color text_color;
 	int text_fontnum;
+	float line_height_factor;
 
 	//Done with set
 	char imageanim[MAX_FILENAME_LEN];
@@ -139,7 +140,8 @@ private:
 public:
 	subtitle(int in_x_pos, int in_y_pos, const char* in_text = NULL, const char* in_imageanim = NULL,
 			 float in_display_time = 0, float in_fade_time = 0.0f, const color *in_text_color = NULL, int in_text_fontnum = -1,
-			 bool center_x = false, bool center_y = false, int in_width = 0, int in_height = 0, bool post_shaded=false);
+			 bool center_x = false, bool center_y = false, int in_width = 0, int in_height = 0, bool post_shaded = false,
+			 float line_height_factor = 1.0f);
 	~subtitle();
 
     subtitle(const subtitle &sub) { clone(sub); }

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -22479,7 +22479,7 @@ void sexp_show_subtitle(int node)
 
 						if (n != -1)
 						{
-							auto percent = eval_num(n, is_nan, is_nan_forever);
+							int percent = eval_num(n, is_nan, is_nan_forever);
 							if (is_nan || is_nan_forever)
 								return;
 							line_height_factor = percent / 100.0f;
@@ -22587,7 +22587,7 @@ void sexp_show_subtitle_text(int node)
 	float line_height_factor = 1.0f;
 	if (n >= 0)
 	{
-		auto percent = eval_num(n, is_nan, is_nan_forever);
+		int percent = eval_num(n, is_nan, is_nan_forever);
 		if (is_nan || is_nan_forever)
 			return;
 		line_height_factor = percent / 100.0f;
@@ -22623,7 +22623,8 @@ void sexp_show_subtitle_text(int node)
 	Current_sexp_network_packet.send_bool(center_y);
 	Current_sexp_network_packet.send_int(width_pct);
 	Current_sexp_network_packet.send_bool(post_shaded);
-	Current_sexp_network_packet.send_float(line_height_factor);
+ 	// TODO: uncomment when Github ticket #3773 is implemented
+	//Current_sexp_network_packet.send_float(line_height_factor);
 	Current_sexp_network_packet.end_callback();
 }
 
@@ -22657,7 +22658,8 @@ void multi_sexp_show_subtitle_text()
 	Current_sexp_network_packet.get_bool(center_y);
 	Current_sexp_network_packet.get_int(width_pct);
 	Current_sexp_network_packet.get_bool(post_shaded);
-	Current_sexp_network_packet.get_float(line_height_factor);
+	// TODO: uncomment when Github ticket #3773 is implemented
+	//Current_sexp_network_packet.get_float(line_height_factor);
 
 	gr_init_alphacolor(&new_color, red, green, blue, 255);
 
@@ -35151,7 +35153,7 @@ SCP_vector<sexp_help_struct> Sexp_help = {
 		"\t11:\tText green component (0-255) (optional)\r\n"
 		"\t12:\tText blue component (0-255) (optional)\r\n"
 		"\t13:\tDrawn after shading? (optional; defaults to false)\r\n"
-		"\t14:\tLine vertical spacing, as a percentage, for displaying multi-line subtitles (optional; defaults to 100%)\r\n"
+		"\t14:\tLine vertical spacing, as a percentage, for displaying multi-line subtitles (optional; defaults to 100)\r\n"
 	},
 
 	{ OP_CUTSCENES_SHOW_SUBTITLE_TEXT, "show-subtitle-text\r\n"
@@ -35170,7 +35172,7 @@ SCP_vector<sexp_help_struct> Sexp_help = {
 		"\t11:\tText blue component (0-255) (optional)\r\n"
 		"\t12:\tText font (optional)\r\n"
 		"\t13:\tDrawn after shading? (optional; defaults to false)\r\n"
-		"\t14:\tLine vertical spacing, as a percentage, for displaying multi-line subtitles (optional; defaults to 100%)\r\n"
+		"\t14:\tLine vertical spacing, as a percentage, for displaying multi-line subtitles (optional; defaults to 100)\r\n"
 	},
 
 	{ OP_CUTSCENES_SHOW_SUBTITLE_IMAGE, "show-subtitle-image\r\n"


### PR DESCRIPTION
This adds an optional extra factor to `show-subtitle` and `show-subtitle-text` to adjust the line height.  Useful for double-spacing, 1.5-spacing, etc.