### PR TITLE
refactor submodel flags and add $rotate_accel

### DIFF
--- a/code/missionui/missionscreencommon.cpp
+++ b/code/missionui/missionscreencommon.cpp
@@ -1571,7 +1571,7 @@ void draw_model_icon(int model_id, int flags, float closeup_zoom, int x, int y, 
 		bsp_info *bs = NULL;	//tehe
 		for(int i = 0; i < pm->n_models; i++)
 		{
-			if(!pm->submodel[i].is_thruster)
+			if(!pm->submodel[i].flags[Model::Submodel_flags::Is_thruster])
 			{
 				bs = &pm->submodel[i];
 				break;

--- a/code/model/model.h
+++ b/code/model/model.h
@@ -180,7 +180,6 @@ public:
 	struct engine_wash_info		*engine_wash_pointer;					// index into Engine_wash_info
 
 	// rotation specific info
-	float		turn_rate;							// The turning rate of this subobject, if MSS_FLAG_ROTATES is set.
 	int			weapon_rotation_pbank;				// weapon-controlled rotation - Goober5000
 	stepped_rotation_t	*stepped_rotation;			// turn rotation struct
 
@@ -276,12 +275,10 @@ class bsp_info
 {
 public:
 	bsp_info()
-		: can_move(false), bsp_data_size(0), bsp_data(nullptr), collision_tree_index(-1),
-		rad(0.0f), my_replacement(-1), i_replace(-1), is_live_debris(false), num_live_debris(0),
+		: bsp_data_size(0), bsp_data(nullptr), collision_tree_index(-1),
+		rad(0.0f), my_replacement(-1), i_replace(-1), num_live_debris(0),
 		parent(-1), num_children(0), first_child(-1), next_sibling(-1), num_details(0),
-		outline_buffer(nullptr), n_verts_outline(0), render_sphere_radius(0.0f), use_render_box(0), use_render_box_offset(false),
-		use_render_sphere(0), use_render_sphere_offset(false), gun_rotation(false), no_collisions(false),
-		nocollide_this_only(false), collide_invisible(false), attach_thrusters(false)
+		outline_buffer(nullptr), n_verts_outline(0), render_sphere_radius(0.0f), use_render_box(0),	use_render_sphere(0)
 	{
 		name[0] = 0;
 		lod_name[0] = 0;
@@ -298,7 +295,11 @@ public:
 	int		movement_type = -1;						// -1 if no movement, otherwise rotational or positional movement -- subobjects only
 	vec3d	movement_axis = vmd_zero_vector;		// which axis this subobject moves or rotates on.
 	int		movement_axis_id = -1;					// for optimization
-	bool	can_move;				// If true, the position and/or orientation of this submodel can change due to rotation of itself OR a parent
+
+	float	default_turn_rate = 0.0f;
+	float	default_turn_accel = 0.0f;
+
+	flagset<Model::Submodel_flags> flags;
 
 	vec3d	offset;					// 3d offset from parent object
 	matrix	frame_of_reference;		// used to be called 'orientation' - this is just used for setting the rotation axis and the animation angles
@@ -319,12 +320,8 @@ public:
 	int		my_replacement;		// If not -1 this subobject is what should get rendered instead of this one
 	int		i_replace;				// If this is not -1, then this subobject will replace i_replace when it is damaged
 
-	bool	is_live_debris;		// whether current submodel is a live debris model
 	int		num_live_debris;		// num live debris models assocaiated with a submodel
 	int		live_debris[MAX_LIVE_DEBRIS];	// array of live debris submodels for a submodel
-
-	bool	is_thruster	= false;		// is an engine thruster submodel
-	bool	is_damaged = false;			// is a submodel that represents a damaged submodel (e.g. a -destroyed version of some other submodel)
 
 	// Tree info
 	int		parent;					// what is parent for each submodel, -1 if none
@@ -348,18 +345,10 @@ public:
 	float	render_sphere_radius;
 	vec3d	render_sphere_offset;
 	int		use_render_box;			// 0==do nothing, 1==only render this object if you are inside the box, -1==only if you're outside
-	bool	use_render_box_offset;		// whether an offset has been defined; needed because one can't tell just by looking at render_box_offset
 	int		use_render_sphere;		// 0==do nothing, 1==only render this object if you are inside the sphere, -1==only if you're outside
-	bool 	use_render_sphere_offset;// whether an offset has been defined; needed because one can't tell just by looking at render_sphere_offset
-	bool    do_not_scale_detail_distances{false}; // if set should not scale boxes or spheres based on 'model detail' settings
-	bool	gun_rotation;			// for animated weapon models
-	bool	no_collisions;			// for $no_collisions property - kazan
-	bool	nocollide_this_only;	//SUSHI: Like no_collisions, but not recursive. For the "replacement" collision model scheme.
-	bool	collide_invisible;		//SUSHI: If set, this submodel should allow collisions for invisible textures. For the "replacement" collision model scheme.
-	char	lod_name[MAX_NAME_LEN];	//FUBAR:  Name to be used for LOD naming comparison to preserve compatibility with older tables.  Only used on LOD0 
-	bool	attach_thrusters;		//zookeeper: If set and this submodel or any of its parents rotates, also rotates associated thrusters.
 
-	float	dumb_turn_rate = 0.0f;		//Bobboau
+	char	lod_name[MAX_NAME_LEN];	//FUBAR:  Name to be used for LOD naming comparison to preserve compatibility with older tables.  Only used on LOD0 
+
 	int		look_at_submodel = -1;		//VA - number of the submodel to be looked at by this submodel (-1 if none)
 	float	look_at_offset = -1.0f;		//angle in radians that the submodel should be turned from its initial orientation to be considered "looking at" something (-1 if set on first eval)
 };
@@ -975,7 +964,7 @@ extern void model_instance_find_world_dir(vec3d *out_dir, const vec3d *in_dir, c
 extern void model_clear_instance(int model_num);
 
 // Sets rotating submodel turn info to that stored in model
-extern void model_set_submodel_turn_info(submodel_instance *smi, float turn_rate, float turn_accel);
+extern void model_set_submodel_instance_motion_info(bsp_info *sm, submodel_instance *smi);
 
 // Sets the submodel instance data in a submodel
 extern void model_set_up_techroom_instance(ship_info *sip, int model_instance_num);

--- a/code/model/model_flags.h
+++ b/code/model/model_flags.h
@@ -5,6 +5,24 @@
 
 namespace Model {
 
+	FLAG_LIST(Submodel_flags) {
+		Can_move,						// If true, the position and/or orientation of this submodel can change due to rotation of itself OR a parent
+		Is_live_debris,					// whether current submodel is a live debris model
+		Is_thruster,					// is an engine thruster submodel
+		Is_damaged,						// is a submodel that represents a damaged submodel (e.g. a -destroyed version of some other submodel)
+		Do_not_scale_detail_distances,	// if set should not scale boxes or spheres based on 'model detail' settings
+		Gun_rotation,					// for animated weapon models
+		Instant_rotate_accel,			// rotating submodels instantly reach their desired velocity
+		No_collisions,					// for $no_collisions property - kazan
+		Nocollide_this_only,			//SUSHI: Like no_collisions, but not recursive. For the "replacement" collision model scheme.
+		Collide_invisible,				//SUSHI: If set, this submodel should allow collisions for invisible textures. For the "replacement" collision model scheme.
+		Use_render_box_offset,			// whether an offset has been defined; needed because one can't tell just by looking at render_box_offset
+		Use_render_sphere_offset,		// whether an offset has been defined; needed because one can't tell just by looking at render_sphere_offset
+		Attach_thrusters,				//zookeeper: If set and this submodel or any of its parents rotates, also rotates associated thrusters.
+
+		NUM_VALUES
+	};
+
 	FLAG_LIST(Subsystem_Flags) {
 		Rotates,			// This means the object rotates automatically with "turn_rate"
 		Stepped_rotate,		// This means that the rotation occurs in steps
@@ -24,7 +42,6 @@ namespace Model {
 		No_ss_targeting,	// toggles the subsystem targeting for the turret
 		Turret_reset_idle,	// makes turret reset to their initial position if the target is out of field of view
 		Turret_restricted_fov,	// tells the game to use additional calculations should turret have a limited base fov or elevation
-		Dum_rotates,		// Bobboau
 		Carry_shockwave,	// subsystem - even with 'carry no damage' flag - will carry shockwave damage to the hull
 		Allow_landing,		// This subsystem can be landed on
 		Fov_edge_check,		// Tells the game to use better FOV edge checking with this turret

--- a/code/model/modelcollide.cpp
+++ b/code/model/modelcollide.cpp
@@ -468,7 +468,7 @@ void model_collide_tmappoly(ubyte * p)
 	if ( (!(Mc->flags & MC_CHECK_INVISIBLE_FACES)) && (Mc_pm->maps[tmap_num].textures[TM_BASE_TYPE].GetTexture() < 0) )	{
 		// Don't check invisible polygons.
 		//SUSHI: Unless $collide_invisible is set.
-		if (!(Mc_pm->submodel[Mc_submodel].collide_invisible))
+		if (!(Mc_pm->submodel[Mc_submodel].flags[Model::Submodel_flags::Collide_invisible]))
 			return;
 	}
 
@@ -588,7 +588,7 @@ void model_collide_bsp_poly(bsp_collision_tree *tree, int leaf_index)
 			if ( (!(Mc->flags & MC_CHECK_INVISIBLE_FACES)) && (Mc_pm->maps[leaf->tmap_num].textures[TM_BASE_TYPE].GetTexture() < 0) )	{
 				// Don't check invisible polygons.
 				//SUSHI: Unless $collide_invisible is set.
-				if (!(Mc_pm->submodel[Mc_submodel].collide_invisible))
+				if (!(Mc_pm->submodel[Mc_submodel].flags[Model::Submodel_flags::Collide_invisible]))
 					return;
 			}
 		} else {
@@ -1067,8 +1067,8 @@ void mc_check_subobj( int mn )
 	if ( (mn < 0) || (mn>=Mc_pm->n_models) ) return;
 	
 	sm = &Mc_pm->submodel[mn];
-	if (sm->no_collisions) return; // don't do collisions
-	if (sm->nocollide_this_only) goto NoHit; // Don't collide for this model, but keep checking others
+	if (sm->flags[Model::Submodel_flags::No_collisions]) return; // don't do collisions
+	if (sm->flags[Model::Submodel_flags::Nocollide_this_only]) goto NoHit; // Don't collide for this model, but keep checking others
 
 	// Rotate the world check points into the current subobject's 
 	// frame of reference.
@@ -1189,7 +1189,7 @@ NoHit:
 
 		// Don't check it or its children if it is destroyed
 		// or if it's set to no collision
-		if ( !blown_off && !collision_checked && !csm->no_collisions )	{
+		if ( !blown_off && !collision_checked && !csm->flags[Model::Submodel_flags::No_collisions] )	{
 			vm_vec_unrotate(&Mc_base, &csm->offset, &saved_orient);
 			vm_vec_add2(&Mc_base, &saved_base);
 

--- a/code/model/modelinterp.cpp
+++ b/code/model/modelinterp.cpp
@@ -2319,7 +2319,7 @@ void interp_fill_detail_index_buffer(SCP_vector<int> &submodel_list, polymodel *
 	for ( i = 0; i < (int)submodel_list.size(); ++i ) {
 		model_num = submodel_list[i];
 
-		if ( pm->submodel[model_num].is_thruster ) {
+		if ( pm->submodel[model_num].flags[Model::Submodel_flags::Is_thruster] ) {
 			continue;
 		}
 
@@ -2355,7 +2355,7 @@ void interp_fill_detail_index_buffer(SCP_vector<int> &submodel_list, polymodel *
 	for ( i = 0; i < (int)submodel_list.size(); ++i ) {
 		model_num = submodel_list[i];
 
-		if (pm->submodel[model_num].is_thruster) {
+		if (pm->submodel[model_num].flags[Model::Submodel_flags::Is_thruster]) {
 			continue;
 		}
 

--- a/code/network/multi_obj.cpp
+++ b/code/network/multi_obj.cpp
@@ -1312,7 +1312,7 @@ int multi_oo_pack_data(net_player *pl, object *objp, ushort oo_flags, ubyte *dat
 			
 
 			// retrieve the submodel for rotation info.
-			if (subsystem->system_info->flags[Model::Subsystem_Flags::Rotates, Model::Subsystem_Flags::Dum_rotates]) {
+			if (subsystem->system_info->flags[Model::Subsystem_Flags::Rotates]) {
 				angles *angs_1 = nullptr;
 				angles *angs_2 = nullptr;
 				if (subsystem->submodel_instance_1) {

--- a/code/object/collideshipship.cpp
+++ b/code/object/collideshipship.cpp
@@ -241,7 +241,7 @@ int ship_ship_check_collision(collision_info_struct *ship_ship_hit_info)
 		
 	pm_light = model_get(Ship_info[light_shipp->ship_info_index].model_num);
 
-	if(pm_light->submodel[pm_light->detail[0]].no_collisions) {
+	if(pm_light->submodel[pm_light->detail[0]].flags[Model::Submodel_flags::No_collisions]) {
 		return 0;
 	}
 

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -19618,7 +19618,6 @@ void sexp_reverse_rotating_subsystem(int node)
 			continue;
 
 		// switch direction of rotation
-		rotate->turn_rate *= -1.0f;
 		rotate->submodel_instance_1->current_turn_rate *= -1.0f;
 		rotate->submodel_instance_1->desired_turn_rate *= -1.0f;
 	}

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -420,7 +420,6 @@ public:
 
 	//scaler for setting adjusted turret rof
 	float	rof_scaler;
-	float	turn_rate;
 
 	//Per-turret ownage settings - SUSHI
 	int turret_max_bomb_ownage; 

--- a/code/ship/shipfx.cpp
+++ b/code/ship/shipfx.cpp
@@ -232,7 +232,7 @@ static void shipfx_maybe_create_live_debris_at_ship_death( object *ship_objp )
 
 	int live_debris_submodel = -1;
 	for (int idx=0; idx<pm->num_debris_objects; idx++) {
-		if (pm->submodel[pm->debris_objects[idx]].is_live_debris) {
+		if (pm->submodel[pm->debris_objects[idx]].flags[Model::Submodel_flags::Is_live_debris]) {
 			live_debris_submodel = pm->debris_objects[idx];
 
 			// get submodel that produces live debris
@@ -316,7 +316,7 @@ static void shipfx_blow_up_hull(object *obj, polymodel *pm, polymodel_instance *
 
 	bool try_live_debris = true;
 	for (i=0; i<pm->num_debris_objects; i++ )	{
-		if (! pm->submodel[pm->debris_objects[i]].is_live_debris) {
+		if (! pm->submodel[pm->debris_objects[i]].flags[Model::Submodel_flags::Is_live_debris]) {
 			vec3d tmp = ZERO_VECTOR;
 			model_instance_find_world_point(&tmp, &pm->submodel[pm->debris_objects[i]].offset, pm, pmi, 0, &obj->orient, &obj->pos );
 			debris_create( obj, pm->id, pm->debris_objects[i], &tmp, exp_center, 1, 3.0f );
@@ -1574,7 +1574,7 @@ void shipfx_queue_render_ship_halves_and_debris(model_draw_list *scene, clip_shi
 
 			// determine if explosion front has past debris piece
 			// 67 ~ dist expl moves in 2 frames -- maybe fraction works better
-			int is_live_debris = pm->submodel[pm->debris_objects[i]].is_live_debris;
+			bool is_live_debris = pm->submodel[pm->debris_objects[i]].flags[Model::Submodel_flags::Is_live_debris];
 			int create_debris = 0;
 			// front ship
 			if (half_ship->explosion_vel > 0) {
@@ -2673,7 +2673,7 @@ void engine_wash_ship_process(ship *shipp)
 			// set the the necessary submodel instance info needed here. The second
 			// condition is thus a hack to disable the feature while in the lab, and
 			// can be removed if the lab is re-structured accordingly. -zookeeper
-			if ( bank->submodel_num > -1 && pm->submodel[bank->submodel_num].can_move && (gameseq_get_state_idx(GS_STATE_LAB) == -1) ) {
+			if ( bank->submodel_num >= 0 && pm->submodel[bank->submodel_num].flags[Model::Submodel_flags::Can_move] && (gameseq_get_state_idx(GS_STATE_LAB) == -1) ) {
 				model_find_submodel_offset(&submodel_static_offset, pm, bank->submodel_num);
 
 				submodel_rotation = true;


### PR DESCRIPTION
1) Changes the submodel flags to use a flagset instead of several booleans
2) Adds `rotate_accel` to allow submodel rotation acceleration to be specified

Submodel acceleration can now be instant; dumb-rotating submodels always instantly accelerate (and have always done so)