### PR TITLE
Fix Weapon-Loadout-Specific Models

### DIFF
--- a/code/missionui/missionweaponchoice.cpp
+++ b/code/missionui/missionweaponchoice.cpp
@@ -416,7 +416,6 @@ UI_XSTR Weapon_select_text[GR_NUM_RESOLUTIONS][WEAPON_SELECT_NUM_TEXT] = {
 	}
 };
 
-
 ///////////////////////////////////////////////////////////////////////
 // Carried Icon
 ///////////////////////////////////////////////////////////////////////
@@ -757,7 +756,8 @@ void wl_render_overhead_view(float frametime)
 			if (wl_ship->model_num < 0)
 			{
 				if (sip->pof_file_tech[0] != '\0') {
-					wl_ship->model_num = model_load(sip->pof_file_tech, sip->n_subsystems, &sip->subsystems[0]);
+					//This cannot load into sip->subsystems, as this will overwrite the subsystems model_num to the techroom model, which is decidedly wrong for the mission itself.
+					wl_ship->model_num = model_load(sip->pof_file_tech, 0, nullptr);
 				}
 				else {
 					wl_ship->model_num = model_load(sip->pof_file, sip->n_subsystems, &sip->subsystems[0]);
@@ -830,7 +830,8 @@ void wl_render_overhead_view(float frametime)
 		if (wl_ship->model_num < 0)
 		{
 			if (sip->pof_file_tech[0] != '\0') {
-				wl_ship->model_num = model_load(sip->pof_file_tech, sip->n_subsystems, &sip->subsystems[0]);
+				//This cannot load into sip->subsystems, as this will overwrite the subsystems model_num to the techroom model, which is decidedly wrong for the mission itself.
+				wl_ship->model_num = model_load(sip->pof_file_tech, 0, nullptr);
 			}
 			else {
 				wl_ship->model_num = model_load(sip->pof_file, sip->n_subsystems, &sip->subsystems[0]);


### PR DESCRIPTION
By specifying a different techroom model, the weapon loadout screen can display a different model than used ingame.
However, when loaded it would also reinitialize the model_subsystems of the ship_info, and thus change the model_num of the subsystems. This causes a bunch of problems down the line. Since the recent change to subsystem rotation handling, a corrupt model_num can just cause straight CTD's on mission start.

This addresses this by not loading the ship_info's subsystems with the techmodel, but a seperate submodel buffer, thus not erroniously overwriting the subsystem data. 