### PR TITLE
Substitute Ship Label

### DIFF
--- a/code/mission/missionbriefcommon.h
+++ b/code/mission/missionbriefcommon.h
@@ -122,6 +122,7 @@ typedef struct brief_icon {
 	int		team;
 	vec3d	pos;
 	char		label[MAX_LABEL_LEN];
+	char		customClass[MAX_LABEL_LEN];
 	char		closeup_label[MAX_LABEL_LEN];
 //	char		text[MAX_ICON_TEXT_LEN];
 	hud_anim	fadein_anim;

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -1543,6 +1543,10 @@ void parse_briefing(mission * /*pm*/, int flags)
 				bi->label[0] = 0;
 				if (optional_string("$label:"))
 					stuff_string(bi->label, F_MESSAGE, MAX_LABEL_LEN);
+				bi->customClass[0] = 0;
+				if (optional_string("$Closeup label:")) {
+					stuff_string(bi->customClass, F_MESSAGE, MAX_LABEL_LEN);
+				}
 
 				if (optional_string("+id:")) {
 					stuff_int(&bi->id);

--- a/code/missionui/missionbrief.cpp
+++ b/code/missionui/missionbrief.cpp
@@ -1275,6 +1275,9 @@ int brief_setup_closeup(brief_icon *bi)
 
 		break;
 	}
+	if (Closeup_icon->customClass[0] != 0) {
+		strcpy_s(Closeup_icon->closeup_label, Closeup_icon->customClass);
+	}
 	
 	if ( Closeup_icon->modelnum < 0 ) {
 		if ( sip == NULL ) {

--- a/fred2/missionsave.cpp
+++ b/fred2/missionsave.cpp
@@ -1046,6 +1046,15 @@ int CFred_mission_save::save_briefing()
 					fout_ext(" ", "%s", bi->label);
 				}
 
+				if (drop_white_space(bi->customClass)[0]) {
+					if (optional_string_fred("$Closeup label:"))
+						parse_comments();
+					else
+						fout("\n$Closeup label::");
+
+					fout_ext(" ", "%s", bi->customClass);
+				}
+
 				if (optional_string_fred("+id:"))
 					parse_comments();
 				else

--- a/fred2/missionsave.cpp
+++ b/fred2/missionsave.cpp
@@ -1046,13 +1046,15 @@ int CFred_mission_save::save_briefing()
 					fout_ext(" ", "%s", bi->label);
 				}
 
-				if (drop_white_space(bi->customClass)[0]) {
-					if (optional_string_fred("$Closeup label:"))
-						parse_comments();
-					else
-						fout("\n$Closeup label::");
+				if (Mission_save_format != FSO_FORMAT_RETAIL) {
+					if (drop_white_space(bi->customClass)[0]) {
+						if (optional_string_fred("$Closeup label:"))
+							parse_comments();
+						else
+							fout("\n$Closeup label::");
 
-					fout_ext(" ", "%s", bi->customClass);
+						fout_ext(" ", "%s", bi->customClass);
+					}
 				}
 
 				if (optional_string_fred("+id:"))

--- a/qtfred/src/mission/missionsave.cpp
+++ b/qtfred/src/mission/missionsave.cpp
@@ -1071,6 +1071,16 @@ int CFred_mission_save::save_briefing()
 
 					fout_ext(" ", "%s", bi->label);
 				}
+				if (drop_white_space(bi->customClass)[0]) {
+					if (optional_string_fred("$Closeup label:")) {
+						parse_comments();
+					}
+					else {
+						fout("\n$Closeup label:");
+					}
+
+					fout_ext(" ", "%s", bi->customClass);
+				}
 
 				if (optional_string_fred("+id:")) {
 					parse_comments();

--- a/qtfred/src/mission/missionsave.cpp
+++ b/qtfred/src/mission/missionsave.cpp
@@ -1071,15 +1071,17 @@ int CFred_mission_save::save_briefing()
 
 					fout_ext(" ", "%s", bi->label);
 				}
-				if (drop_white_space(bi->customClass)[0]) {
-					if (optional_string_fred("$Closeup label:")) {
-						parse_comments();
-					}
-					else {
-						fout("\n$Closeup label:");
-					}
+				if (save_format != MissionFormat::RETAIL) {
+					if (drop_white_space(bi->customClass)[0]) {
+						if (optional_string_fred("$Closeup label:")) {
+							parse_comments();
+						}
+						else {
+							fout("\n$Closeup label:");
+						}
 
-					fout_ext(" ", "%s", bi->customClass);
+						fout_ext(" ", "%s", bi->customClass);
+					}
 				}
 
 				if (optional_string_fred("+id:")) {

--- a/qtfred/ui/BriefingEditorDialog.ui
+++ b/qtfred/ui/BriefingEditorDialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>620</width>
-    <height>725</height>
+    <width>622</width>
+    <height>732</height>
    </rect>
   </property>
   <property name="minimumSize">
@@ -100,6 +100,13 @@
         </item>
         <item row="1" column="0">
          <layout class="QGridLayout" name="iconInfo">
+          <item row="3" column="0">
+           <widget class="QLabel" name="iconImage">
+            <property name="text">
+             <string>Icon Image</string>
+            </property>
+           </widget>
+          </item>
           <item row="0" column="0">
            <widget class="QLabel" name="iconID">
             <property name="text">
@@ -109,6 +116,23 @@
           </item>
           <item row="0" column="1">
            <widget class="QLineEdit" name="iconIDEdit"/>
+          </item>
+          <item row="5" column="0">
+           <widget class="QLabel" name="iconTeam">
+            <property name="text">
+             <string>Team</string>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="0">
+           <widget class="QLabel" name="iconShipType">
+            <property name="text">
+             <string>Ship Type</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="1">
+           <widget class="QComboBox" name="iconImageCombo"/>
           </item>
           <item row="1" column="0">
            <widget class="QLabel" name="iconLabel">
@@ -120,35 +144,21 @@
           <item row="1" column="1">
            <widget class="QLineEdit" name="iconLabelEdit"/>
           </item>
-          <item row="2" column="0">
-           <widget class="QLabel" name="iconImage">
-            <property name="text">
-             <string>Icon Image</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="1">
-           <widget class="QComboBox" name="iconImageCombo"/>
-          </item>
-          <item row="3" column="0">
-           <widget class="QLabel" name="iconShipType">
-            <property name="text">
-             <string>Ship Type</string>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="1">
-           <widget class="QComboBox" name="iconShipTypeCombo"/>
-          </item>
-          <item row="4" column="0">
-           <widget class="QLabel" name="iconTeam">
-            <property name="text">
-             <string>Team</string>
-            </property>
-           </widget>
+          <item row="5" column="1">
+           <widget class="QComboBox" name="iconTeamCombo"/>
           </item>
           <item row="4" column="1">
-           <widget class="QComboBox" name="iconTeamCombo"/>
+           <widget class="QComboBox" name="iconShipTypeCombo"/>
+          </item>
+          <item row="2" column="1">
+           <widget class="QLineEdit" name="iconcloseupLabel"/>
+          </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="closeup">
+            <property name="text">
+             <string>Closeup Label</string>
+            </property>
+           </widget>
           </item>
          </layout>
         </item>


### PR DESCRIPTION
Implement #3757 Adding a new optional line to the missionfile for a briefing icon $Closeup label after $label. Currently has to be added in text editor though i have added a field in QTFred's briefing editor for when someone completes it.