### PR TITLE
Add functions to draw rectangles and images by passing the center position 

### DIFF
--- a/code/scripting/api/libs/graphics.cpp
+++ b/code/scripting/api/libs/graphics.cpp
@@ -664,30 +664,19 @@ ADE_FUNC(drawPolygon,
 	return ADE_RETURN_TRUE;
 }
 
-ADE_FUNC(drawRectangle, l_Graphics, "number X1, number Y1, number X2, number Y2, [boolean Filled=true, number angle=0.0]", "Draws a rectangle with CurrentColor. May be rotated by passing the angle parameter in radians.", nullptr, nullptr)
+void drawRectInternal(int x1, int x2, int y1, int y2, bool f = true, float a = 0.f) 
 {
-	if(!Gr_inited)
-		return ADE_RETURN_NIL;
-
-	int x1,y1,x2,y2;
-	bool f=true;
-	float a = 0;
-
-	if(!ade_get_args(L, "iiii|bf", &x1, &y1, &x2, &y2, &f, &a))
-		return ADE_RETURN_NIL;
-
 	if(f)
 	{
 		gr_set_bitmap(0);  // gr_rect will use the last bitmaps info, so set to zero to flush any previous alpha state
 		gr_rect(x1, y1, x2-x1, y2-y1, GR_RESIZE_NONE, a);
+						   //gr_rect(x1, y1, x2-x1, y2-y1, GR_RESIZE_NONE, a);
 	}
 	else
 	{
 		if (a != 0) {
 			float centerX = (x1 + x2) / 2.0f;
 			float centerY = (y1 + y2) / 2.0f;
-
-			
 
 			//We need to calculate each point individually due to the rotation, as they won't always align horizontally and vertically. 
 			
@@ -717,6 +706,46 @@ ADE_FUNC(drawRectangle, l_Graphics, "number X1, number Y1, number X2, number Y2,
 			gr_line(x2, y1, x2, y2, GR_RESIZE_NONE);	//Right
 		}
 	}
+
+}
+
+ADE_FUNC(drawRectangle, l_Graphics, "number X1, number Y1, number X2, number Y2, [boolean Filled=true, number angle=0.0]", "Draws a rectangle with CurrentColor. May be rotated by passing the angle parameter in radians.", nullptr, nullptr)
+{
+	if(!Gr_inited)
+		return ADE_RETURN_NIL;
+
+	int x1,y1,x2,y2;
+	bool f=true;
+	float a = 0;
+
+	if(!ade_get_args(L, "iiii|bf", &x1, &y1, &x2, &y2, &f, &a))
+		return ADE_RETURN_NIL;
+	
+	drawRectInternal(x1, x2, y1, y2, f, a);
+
+	return ADE_RETURN_NIL;
+}
+
+ADE_FUNC(drawRectangleCentered, l_Graphics, 
+	"number X, number Y, number Width, number Height, [boolean Filled=true, number angle=0.0]", 
+	"Draws a rectangle centered at X,Y with CurrentColor. May be rotated by passing the angle parameter in radians.", nullptr, nullptr) 
+{
+		if(!Gr_inited)
+		return ADE_RETURN_NIL;
+
+	int x,y,w,h;
+	bool f=true;
+	float a = 0;
+
+	if(!ade_get_args(L, "iiii|bf", &x, &y, &w, &h, &f, &a))
+		return ADE_RETURN_NIL;
+	
+	int x1 = x - (w / 2);
+	int x2 = x + (w / 2);
+	int y1 = y - (h / 2);
+	int y2 = y + (h / 2);
+
+	drawRectInternal(x1, x2, y1, y2, f, a);
 
 	return ADE_RETURN_NIL;
 }
@@ -1348,6 +1377,17 @@ ADE_FUNC(loadTexture, l_Graphics, "string Filename, [boolean LoadIfAnimation, bo
 	return ade_set_args(L, "o", l_Texture.Set(texture_h(idx)));
 }
 
+void drawImageInternal(int x1, int y1, int w, int h, float uv_x1, float uv_y1, float uv_x2, float uv_y2, bool aabitmap, float angle) {
+	
+	bitmap_rect_list brl = bitmap_rect_list(x1, y1, w, h, uv_x1, uv_y1, uv_x2, uv_y2);
+
+	if (aabitmap) {
+		gr_aabitmap_list(&brl, 1, GR_RESIZE_NONE, angle);
+	} else {
+		gr_bitmap_list(&brl, 1, GR_RESIZE_NONE, angle);
+	}
+}
+
 ADE_FUNC(drawImage,
 	l_Graphics,
 	"string|texture fileNameOrTexture, [number X1=0, number Y1=0, number X2, number Y2, number UVX1 = 0.0, number UVY1 "
@@ -1427,6 +1467,7 @@ ADE_FUNC(drawImage,
 		h = y2-y1;
 
 	gr_set_bitmap(idx, lua_Opacity_type, GR_BITBLT_MODE_NORMAL, alpha);
+
 	bitmap_rect_list brl = bitmap_rect_list(x1, y1, w, h, uv_x1, uv_y1, uv_x2, uv_y2);
 
 	if (aabitmap) {
@@ -1437,6 +1478,99 @@ ADE_FUNC(drawImage,
 
 	return ADE_RETURN_TRUE;
 }
+
+ADE_FUNC(drawImageCentered,
+	l_Graphics,
+	"string|texture fileNameOrTexture, [number X=0, number Y=0, number W, number H, number UVX1 = 0.0, number UVY1 "
+	"= 0.0, number UVX2=1.0, number UVY2=1.0, number alpha=1.0, boolean aaImage = false, number angle = 0.0]",
+	"Draws an image file or texture. Any image extension passed will be ignored."
+	"The UV variables specify the UV value for each corner of the image. "
+	"In UV coordinates, (0,0) is the top left of the image; (1,1) is the lower right. If aaImage is true, image needs "
+	"to be monochrome and will be drawn tinted with the currently active color."
+	"The angle variable can be used to rotate the image in radians.",
+	"boolean",
+	"Whether image was drawn") {
+	if(!Gr_inited)
+		return ade_set_error(L, "b", false);
+
+	int idx;
+	int x = 0;
+	int y = 0;
+	int w=INT_MAX;
+	int h=INT_MAX;
+	float uv_x1=0.0f;
+	float uv_y1=0.0f;
+	float uv_x2=1.0f;
+	float uv_y2=1.0f;
+	float alpha=1.0f;
+	bool aabitmap = false;
+	float angle = 0.f;
+
+	if(lua_isstring(L, 1))
+	{
+		const char* s = nullptr;
+		if (!ade_get_args(L, "s|iiiifffffbf", &s, &x, &y, &w, &h, &uv_x1, &uv_y1, &uv_x2, &uv_y2, &alpha, &aabitmap, &angle))
+			return ade_set_error(L, "b", false);
+
+		idx = Script_system.LoadBm(s);
+
+		if(idx < 0)
+			return ADE_RETURN_FALSE;
+	}
+	else
+	{
+		texture_h* th = nullptr;
+		if (!ade_get_args(L,
+				"o|iiiifffffbf",
+				l_Texture.GetPtr(&th),
+				&x,
+				&y,
+				&h,
+				&w,
+				&uv_x1,
+				&uv_y1,
+				&uv_x2,
+				&uv_y2,
+				&alpha,
+				&aabitmap,
+				&angle))
+			return ade_set_error(L, "b", false);
+
+		if (!th->isValid()) {
+			return ade_set_error(L, "b", false);
+		}
+
+		idx = th->handle;
+	}
+
+	if(!bm_is_valid(idx))
+		return ade_set_error(L, "b", false);
+
+	int original_w, original_h;
+	if(bm_get_info(idx, &original_w, &original_h) < 0)
+		return ADE_RETURN_FALSE;
+
+	if(w==INT_MAX)
+		w = original_w;
+
+	if(h==INT_MAX)
+		h = original_h;
+
+	gr_set_bitmap(idx, lua_Opacity_type, GR_BITBLT_MODE_NORMAL, alpha);
+
+	bitmap_rect_list brl = bitmap_rect_list(x-(w/2), y-(h/2), w, h, uv_x1, uv_y1, uv_x2, uv_y2);
+
+	if (aabitmap) {
+		gr_aabitmap_list(&brl, 1, GR_RESIZE_NONE, angle);
+	} else {
+		gr_bitmap_list(&brl, 1, GR_RESIZE_NONE, angle);
+	}
+
+	return ADE_RETURN_TRUE;
+
+}
+
+
 
 ADE_FUNC_DEPRECATED(drawMonochromeImage,
 	l_Graphics,

--- a/code/scripting/api/libs/graphics.cpp
+++ b/code/scripting/api/libs/graphics.cpp
@@ -670,7 +670,6 @@ void drawRectInternal(int x1, int x2, int y1, int y2, bool f = true, float a = 0
 	{
 		gr_set_bitmap(0);  // gr_rect will use the last bitmaps info, so set to zero to flush any previous alpha state
 		gr_rect(x1, y1, x2-x1, y2-y1, GR_RESIZE_NONE, a);
-						   //gr_rect(x1, y1, x2-x1, y2-y1, GR_RESIZE_NONE, a);
 	}
 	else
 	{
@@ -1377,17 +1376,6 @@ ADE_FUNC(loadTexture, l_Graphics, "string Filename, [boolean LoadIfAnimation, bo
 	return ade_set_args(L, "o", l_Texture.Set(texture_h(idx)));
 }
 
-void drawImageInternal(int x1, int y1, int w, int h, float uv_x1, float uv_y1, float uv_x2, float uv_y2, bool aabitmap, float angle) {
-	
-	bitmap_rect_list brl = bitmap_rect_list(x1, y1, w, h, uv_x1, uv_y1, uv_x2, uv_y2);
-
-	if (aabitmap) {
-		gr_aabitmap_list(&brl, 1, GR_RESIZE_NONE, angle);
-	} else {
-		gr_bitmap_list(&brl, 1, GR_RESIZE_NONE, angle);
-	}
-}
-
 ADE_FUNC(drawImage,
 	l_Graphics,
 	"string|texture fileNameOrTexture, [number X1=0, number Y1=0, number X2, number Y2, number UVX1 = 0.0, number UVY1 "
@@ -1483,7 +1471,7 @@ ADE_FUNC(drawImageCentered,
 	l_Graphics,
 	"string|texture fileNameOrTexture, [number X=0, number Y=0, number W, number H, number UVX1 = 0.0, number UVY1 "
 	"= 0.0, number UVX2=1.0, number UVY2=1.0, number alpha=1.0, boolean aaImage = false, number angle = 0.0]",
-	"Draws an image file or texture. Any image extension passed will be ignored."
+	"Draws an image file or texture centered on the X,Y position. Any image extension passed will be ignored."
 	"The UV variables specify the UV value for each corner of the image. "
 	"In UV coordinates, (0,0) is the top left of the image; (1,1) is the lower right. If aaImage is true, image needs "
 	"to be monochrome and will be drawn tinted with the currently active color."


### PR DESCRIPTION
This was a request I got recently. The reason they are new functions rather than some boolean flag in the original ones is just that it'd make the original function too unwieldy.  
This is especially useful with the recent feature that allows drawing rotated images, since the rotation axis is the image's center. 

I couldn't find a good way to avoid duplication in the `drawImage` functions. 