### PR TITLE
Expose turret re-targeting delay

### DIFF
--- a/code/ai/ai_profiles.cpp
+++ b/code/ai/ai_profiles.cpp
@@ -581,6 +581,16 @@ void parse_ai_profiles_tbl(const char *filename)
 
 				set_flag(profile, "$reset last_hit_target_time for player hits:", AI::Profile_Flags::Reset_last_hit_target_time_for_player_hits);
 
+				if (optional_string("$Turret target recheck time:"))
+				{
+					stuff_float(&profile->turret_target_recheck_time);
+					if (profile->turret_target_recheck_time < 0) {
+						Warning(LOCATION, "Turret target recheck time must be positive.");
+						profile->turret_target_recheck_time = 2000.0f;
+					}
+				}
+
+
 				// if we've been through once already and are at the same place, force a move
 				if (saved_Mp && (saved_Mp == Mp))
 				{
@@ -658,6 +668,7 @@ void ai_profile_t::reset()
     bay_depart_speed_mult = 1.0f;
 	second_order_lead_predict_factor = 0;
 	ai_range_aware_secondary_select_mode = AI_RANGE_AWARE_SEC_SEL_MODE_RETAIL;
+	turret_target_recheck_time = 2000.0f;
 
     for (int i = 0; i < NUM_SKILL_LEVELS; ++i) {
         max_incoming_asteroids[i] = 0;

--- a/code/ai/ai_profiles.h
+++ b/code/ai/ai_profiles.h
@@ -114,6 +114,9 @@ public:
 	//Controls if the AI is dumb enough to keep trying to use out-of-range secondaries. 
 	int ai_range_aware_secondary_select_mode;
 
+	// how often turrets shoulds check for new targets, milliseconds
+	float turret_target_recheck_time;
+
     void reset();
 };
 

--- a/code/ai/aiturret.cpp
+++ b/code/ai/aiturret.cpp
@@ -2470,7 +2470,7 @@ void ai_turret_execute_behavior(ship *shipp, ship_subsys *ss)
 				ss->targeted_subsys = aifft_find_turret_subsys(objp, ss, lep, &dot);				
 			}
 			// recheck in 2-3 seconds
-			ss->turret_next_enemy_check_stamp = timestamp((int)(MAX(dot, 0.5f) * The_mission.ai_profile->turret_target_recheck_time) + (The_mission.ai_profile->turret_target_recheck_time / 2.0f));
+			ss->turret_next_enemy_check_stamp = timestamp((int)((MAX(dot, 0.5f) * The_mission.ai_profile->turret_target_recheck_time) + (The_mission.ai_profile->turret_target_recheck_time / 2.0f)));
 		} else {
 			ss->turret_next_enemy_check_stamp = timestamp((int)(The_mission.ai_profile->turret_target_recheck_time * frand_range(0.9f, 1.1f)));	//	Check every two seconds
 		}

--- a/code/ai/aiturret.cpp
+++ b/code/ai/aiturret.cpp
@@ -2469,9 +2469,10 @@ void ai_turret_execute_behavior(ship *shipp, ship_subsys *ss)
 			if (( lep->type == OBJ_SHIP ) && !(ss->flags[Ship::Subsystem_Flags::No_SS_targeting])) {
 				ss->targeted_subsys = aifft_find_turret_subsys(objp, ss, lep, &dot);				
 			}
-			ss->turret_next_enemy_check_stamp = timestamp();
+			// recheck in 2-3 seconds
+			ss->turret_next_enemy_check_stamp = timestamp((int)(MAX(dot, 0.5f) * The_mission.ai_profile->turret_target_recheck_time) + (The_mission.ai_profile->turret_target_recheck_time / 2));
 		} else {
-			ss->turret_next_enemy_check_stamp = timestamp();	//	Check every two seconds
+			ss->turret_next_enemy_check_stamp = timestamp((int)(The_mission.ai_profile->turret_target_recheck_time * frand_range(0.9f, 1.1f)));	//	Check every two seconds
 		}
 	}
 

--- a/code/ai/aiturret.cpp
+++ b/code/ai/aiturret.cpp
@@ -2470,7 +2470,7 @@ void ai_turret_execute_behavior(ship *shipp, ship_subsys *ss)
 				ss->targeted_subsys = aifft_find_turret_subsys(objp, ss, lep, &dot);				
 			}
 			// recheck in 2-3 seconds
-			ss->turret_next_enemy_check_stamp = timestamp((int)(MAX(dot, 0.5f) * The_mission.ai_profile->turret_target_recheck_time) + (The_mission.ai_profile->turret_target_recheck_time / 2));
+			ss->turret_next_enemy_check_stamp = timestamp((int)(MAX(dot, 0.5f) * The_mission.ai_profile->turret_target_recheck_time) + (The_mission.ai_profile->turret_target_recheck_time / 2.0f));
 		} else {
 			ss->turret_next_enemy_check_stamp = timestamp((int)(The_mission.ai_profile->turret_target_recheck_time * frand_range(0.9f, 1.1f)));	//	Check every two seconds
 		}

--- a/code/ai/aiturret.cpp
+++ b/code/ai/aiturret.cpp
@@ -2469,9 +2469,9 @@ void ai_turret_execute_behavior(ship *shipp, ship_subsys *ss)
 			if (( lep->type == OBJ_SHIP ) && !(ss->flags[Ship::Subsystem_Flags::No_SS_targeting])) {
 				ss->targeted_subsys = aifft_find_turret_subsys(objp, ss, lep, &dot);				
 			}
-			ss->turret_next_enemy_check_stamp = timestamp((int) (MAX(dot, 0.5f)*2000.0f) + 1000);
+			ss->turret_next_enemy_check_stamp = timestamp();
 		} else {
-			ss->turret_next_enemy_check_stamp = timestamp((int) (2000.0f * frand_range(0.9f, 1.1f)));	//	Check every two seconds
+			ss->turret_next_enemy_check_stamp = timestamp();	//	Check every two seconds
 		}
 	}
 


### PR DESCRIPTION
This the time at which a turret will reacquire a target, maybe finding a new one, maybe re-affirming the current one, etc. If you have very fast missiles and very fast CIWS even 2 seconds can be too long a delay, but potentially comes with performance problems, as the check that it triggers has to search all ships and weapons, and is done per turret.