### PR TITLE
Fix the Tonemapper strings

### DIFF
--- a/code/lighting/lighting_profiles.cpp
+++ b/code/lighting/lighting_profiles.cpp
@@ -55,10 +55,10 @@ TonemapperAlgorithm lighting_profile::name_to_tonemapper(SCP_string &name)
 	if(name == "reinhard extended"){
 		r = tnm_Reinhard_Extended;
 	}
-	if(name == "PPC"){
+	if(name == "ppc"){
 		r = tnm_PPC;
 	}
-	if(name == "PPC RGB"){
+	if(name == "ppc rgb"){
 		r = tnm_PPC_RGB;
 	}
 	return r;


### PR DESCRIPTION
since the content of the name these are matched against is converted to lowercase, the builtin names also need to be lowercase to be able to match.