### PR TITLE
Set Default Detail Levels to be Consistent at Ultra Settings

### DIFF
--- a/code/globalincs/systemvars.cpp
+++ b/code/globalincs/systemvars.cpp
@@ -243,8 +243,8 @@ detail_levels Detail_defaults[NUM_DEFAULT_DETAIL_LEVELS] = {
 	{				// Highest level
 		3,			// setting
 					// ===== Analogs (0-MAX_DETAIL_LEVEL) ====
-		3,			// nebula_detail;				// 0=lowest detail, MAX_DETAIL_LEVEL=highest detail
-		3,			// detail_distance;			// 0=lowest MAX_DETAIL_LEVEL=highest		
+		4,			// nebula_detail;				// 0=lowest detail, MAX_DETAIL_LEVEL=highest detail
+		4,			// detail_distance;			// 0=lowest MAX_DETAIL_LEVEL=highest		
 		4,			//	hardware_textures;			// 0=max culling, MAX_DETAIL_LEVEL=no culling
 		4,			//	num_small_debris;			// 0=min number, MAX_DETAIL_LEVEL=max number
 		4,			//	num_particles;				// 0=min number, MAX_DETAIL_LEVEL=max number


### PR DESCRIPTION
By default, new pilots have `Model` and `Nebula` detail only set to 4/5 (all others are on 5/5). Furthermore, clicking `Very High` on the model presets options still does not increase the `Model` or `Nebula` detail, as they remain at 4/5. This occurs with making a new pilot in retail, along with making new pilots in mods with a game settings default detail level of `Ultra`.

Simply changing the default values in the code for `Model` and `Nebula` detail to match the other detail levels is the easiest and cleanest solution IMO. I would be happy to alter this though to use a game settings table flag instead, if that is preferred.

Tested and works as expected.