### PR TITLE
fix file name getting trimmed in cf_get_file_list()

### DIFF
--- a/code/cfile/cfilesystem.cpp
+++ b/code/cfile/cfilesystem.cpp
@@ -1705,7 +1705,7 @@ int cf_get_file_list(int max, char** list, int pathtype, const char* filter, int
 			}
 
 			list[num_files] = reinterpret_cast<char *>(vm_malloc(l + 1));
-			SDL_strlcpy(list[num_files], file.name.c_str(), l);
+			SDL_strlcpy(list[num_files], file.name.c_str(), l+1);
 
 			if (info) {
 				info[num_files].write_time = file.m_time;


### PR DESCRIPTION
Fixes bug in the old dynamic cf_get_file_list() introduced by the
3734 PR. That PR used SDL_strlcpy() to copy the filename which
always null terminates the string, but was only given the length
of the string itself as the available space, so the last character
was removed.