### PR TITLE
improve SEXP error handling a bit

### DIFF
--- a/code/mission/missiongoals.cpp
+++ b/code/mission/missiongoals.cpp
@@ -1504,3 +1504,19 @@ void mission_goal_exit()
 	snd_play( gamesnd_get_interface_sound(InterfaceSounds::USER_SELECT) );
 	gameseq_post_event(GS_EVENT_PREVIOUS_STATE);
 }
+
+int mission_goal_find_sexp_tree(int root_node)
+{
+	for (int i = 0; i < Num_goals; ++i)
+		if (Mission_goals[i].formula == root_node)
+			return i;
+	return -1;
+}
+
+int mission_event_find_sexp_tree(int root_node)
+{
+	for (int i = 0; i < Num_mission_events; ++i)
+		if (Mission_events[i].formula == root_node)
+			return i;
+	return -1;
+}

--- a/code/mission/missiongoals.h
+++ b/code/mission/missiongoals.h
@@ -190,6 +190,9 @@ void mission_maybe_play_directive_success_sound();
 
 void mission_goal_exit();
 
+int mission_goal_find_sexp_tree(int root_node);
+int mission_event_find_sexp_tree(int root_node);
+
 int ML_objectives_init(int x, int y, int w, int h);
 void ML_objectives_close();
 void ML_objectives_do_frame(int scroll_offset);

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -6131,12 +6131,22 @@ bool post_process_mission()
 			// print out an error based on the return value from check_sexp_syntax()
 			// G5K: now entering this statement simply aborts the mission load
 			if ( result ) {
+				SCP_string location_str;
 				SCP_string sexp_str;
 				SCP_string error_msg;
 
+				// it's helpful to point out the goal/event, so do that if we can
+				int index;
+				if ((index = mission_event_find_sexp_tree(i)) >= 0) {
+					sprintf(location_str, "Error in mission event: \"%s\": ", Mission_events[index].name);
+				} else if ((index = mission_goal_find_sexp_tree(i)) >= 0) {
+					sprintf(location_str, "Error in mission goal: \"%s\": ", Mission_goals[index].name);
+				}
+
 				convert_sexp_to_string(sexp_str, i, SEXP_ERROR_CHECK_MODE);
 				truncate_message_lines(sexp_str, 30);
-				sprintf(error_msg, "%s.\n\nIn sexpression: %s\n(Error appears to be: %s)", sexp_error_message(result), sexp_str.c_str(), Sexp_nodes[bad_node].text);
+				
+				sprintf(error_msg, "%s%s.\n\nIn sexpression: %s\n\n(Bad node appears to be: %s)\n", location_str.c_str(), sexp_error_message(result), sexp_str.c_str(), Sexp_nodes[bad_node].text);
 				Warning(LOCATION, "%s", error_msg.c_str());
 
 				// syntax errors are recoverable in Fred but not FS

--- a/fred2/campaigntreewnd.cpp
+++ b/fred2/campaigntreewnd.cpp
@@ -427,7 +427,7 @@ int campaign_tree_wnd::fred_check_sexp(int sexp, int type, char *msg, ...)
 
 	convert_sexp_to_string(sexp_buf, sexp, SEXP_ERROR_CHECK_MODE);
 	truncate_message_lines(sexp_buf, 30);
-	sprintf(error_buf, "Error in %s: %s\n\nIn sexpression: %s\n\n(Error appears to be: %s)", buf.c_str(), sexp_error_message(z), sexp_buf.c_str(), Sexp_nodes[faulty_node].text);
+	sprintf(error_buf, "Error in %s: %s\n\nIn sexpression: %s\n\n(Bad node appears to be: %s)", buf.c_str(), sexp_error_message(z), sexp_buf.c_str(), Sexp_nodes[faulty_node].text);
 
 	if (z < 0 && z > -100)
 		err = 1;

--- a/fred2/fredview.cpp
+++ b/fred2/fredview.cpp
@@ -3388,7 +3388,7 @@ int CFREDView::fred_check_sexp(int sexp, int type, const char *msg, ...)
 
 	convert_sexp_to_string(sexp_buf, sexp, SEXP_ERROR_CHECK_MODE);
 	truncate_message_lines(sexp_buf, 30);
-	sprintf(error_buf, "Error in %s: %s\n\nIn sexpression: %s\n\n(Error appears to be: %s)", buf.c_str(), sexp_error_message(z), sexp_buf.c_str(), Sexp_nodes[faulty_node].text);
+	sprintf(error_buf, "Error in %s: %s\n\nIn sexpression: %s\n\n(Bad node appears to be: %s)", buf.c_str(), sexp_error_message(z), sexp_buf.c_str(), Sexp_nodes[faulty_node].text);
 
 	if (z < 0 && z > -100)
 		err = 1;

--- a/qtfred/src/mission/Editor.cpp
+++ b/qtfred/src/mission/Editor.cpp
@@ -2581,7 +2581,7 @@ int Editor::fred_check_sexp(int sexp, int type, const char* msg, ...) {
 	convert_sexp_to_string(sexp_buf, sexp, SEXP_ERROR_CHECK_MODE);
 	truncate_message_lines(sexp_buf, 30);
 	sprintf(error_buf,
-			"Error in %s: %s\n\nIn sexpression: %s\n\n(Error appears to be: %s)",
+			"Error in %s: %s\n\nIn sexpression: %s\n\n(Bad node appears to be: %s)",
 			buf.c_str(),
 			sexp_error_message(z),
 			sexp_buf.c_str(),


### PR DESCRIPTION
1) Sync formatting of each place SEXP errors are reported
2) Add error location (event or goal) if possible when mission is loaded

Note that the two FRED error dialogs already indicate the event or goal.