### PR TITLE
Clarify logging when loading thruster textures as static images

### DIFF
--- a/code/bmpman/bmpman.cpp
+++ b/code/bmpman/bmpman.cpp
@@ -1424,7 +1424,7 @@ static int bm_load_image_data(int handle, int bpp, ushort flags, bool nodebug)
 	return 0;
 }
 
-int bm_load_animation(const char *real_filename, int *nframes, int *fps, int *keyframe, float *total_time, bool can_drop_frames, int dir_type) {
+int bm_load_animation(const char *real_filename, int *nframes, int *fps, int *keyframe, float *total_time, bool can_drop_frames, int dir_type, bool rethrow_exceptions) {
 	int	i, n;
 	anim	the_anim;
 	CFILE	*img_cfp = nullptr;
@@ -1594,10 +1594,15 @@ int bm_load_animation(const char *real_filename, int *nframes, int *fps, int *ke
 			img_size = the_apng.imgsize();
 		}
 		catch (const apng::ApngException& e) {
-			mprintf(("Failed to load apng: %s\n", e.what() ));
 			if (img_cfp != nullptr)
 				cfclose(img_cfp);
-			return -1;
+			if (rethrow_exceptions) {
+				throw e;
+			}
+			else {
+				mprintf(("Failed to load apng: %s\n", e.what()));
+				return -1;
+			}
 		}
 	}
 	else {

--- a/code/bmpman/bmpman.h
+++ b/code/bmpman/bmpman.h
@@ -289,7 +289,14 @@ bool bm_release_rendertarget(int handle);
  * @returns The bm number of the first bitmap in the sequence if successful, or
  * @returns A negative value if unsuccessful
  */
-int bm_load_animation(const char *filename, int *nframes = nullptr, int *fps = nullptr, int *keyframe = nullptr, float *total_time = nullptr, bool can_drop_frames = 0, int dir_type = CF_TYPE_ANY);
+int bm_load_animation(const char *filename,
+	int *nframes = nullptr,
+	int *fps = nullptr,
+	int *keyframe = nullptr,
+	float *total_time = nullptr,
+	bool can_drop_frames = 0,
+	int dir_type = CF_TYPE_ANY,
+	bool rethrow_exceptions = false);
 
 /**
  * @brief Loads either animation (bm_load_animation) or still image (bm_load)

--- a/code/bmpman/bmpman.h
+++ b/code/bmpman/bmpman.h
@@ -294,7 +294,7 @@ int bm_load_animation(const char *filename,
 	int *fps = nullptr,
 	int *keyframe = nullptr,
 	float *total_time = nullptr,
-	bool can_drop_frames = 0,
+	bool can_drop_frames = false,
 	int dir_type = CF_TYPE_ANY,
 	bool rethrow_exceptions = false);
 

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -4478,7 +4478,10 @@ static void parse_ship_values(ship_info* sip, const bool is_template, const bool
 			int tex_fps=0, tex_nframes=0, tex_id=-1;;
 			tex_id = bm_load_animation(name_tmp, &tex_nframes, &tex_fps, nullptr, nullptr, true);
 			if(tex_id < 0)
+			{
+				mprintf(("Could not load thruster texture %s as animation. Attempting to load as static image.\n", name_tmp));
 				tex_id = bm_load(name_tmp);
+			}
 			if(tex_id >= 0)
 			{
 				if(mtp->tex_id >= 0) {
@@ -4488,6 +4491,8 @@ static void parse_ship_values(ship_info* sip, const bool is_template, const bool
 				mtp->tex_id = tex_id;
 				mtp->tex_fps = tex_fps;
 				mtp->tex_nframes = tex_nframes;
+			} else {
+				mprintf(("Failed to load thruster texture %s\n", name_tmp));
 			}
 		}
 

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -4476,12 +4476,17 @@ static void parse_ship_values(ship_info* sip, const bool is_template, const bool
 		{
 			stuff_string(name_tmp, F_NAME, sizeof(name_tmp));
 			int tex_fps=0, tex_nframes=0, tex_id=-1;;
-			tex_id = bm_load_animation(name_tmp, &tex_nframes, &tex_fps, nullptr, nullptr, true);
-			if(tex_id < 0)
-			{
-				mprintf(("Could not load thruster texture %s as animation. Attempting to load as static image.\n", name_tmp));
-				tex_id = bm_load(name_tmp);
+			try {
+				tex_id = bm_load_animation(name_tmp, &tex_nframes, &tex_fps, nullptr, nullptr, true, CF_TYPE_ANY, true);
+			} catch (const std::exception& e) {
+				mprintf(("Could not load thruster texture %s as animation (%s). Attempting to load as static image.\n",
+					name_tmp,
+					e.what()));
+				tex_id = -1;
 			}
+
+			if(tex_id < 0)
+				tex_id = bm_load(name_tmp);
 			if(tex_id >= 0)
 			{
 				if(mtp->tex_id >= 0) {


### PR DESCRIPTION
Log when falling back to loading a thruster texture as a static image instead of animated, and log when loading the texture fails entirely.

Fixes issue #3644.