### PR TITLE
fix multi awacs crash due to code init order

### DIFF
--- a/code/ship/awacs.cpp
+++ b/code/ship/awacs.cpp
@@ -459,5 +459,10 @@ int ship_is_visible_by_team(object *target, ship *viewer)
 	int ship_num = target->instance;
 	int team = viewer->team;
 
+	// this can happen in multi, where networking is processed before first frame sim
+	if (Awacs_stamp == -1) {
+		awacs_process();
+	}
+
 	return Ship_visibility_by_team[team][ship_num] ? 1 : 0;
 }


### PR DESCRIPTION
Fix crash related to PR #3634 changes due to when the awacs info is setup. Awacs is setup/updated on each game frame. However this happens after multi packets are processed that frame, so a client can send related info to the server before the server has had the chance to init awacs causing a crash due to the vector being empty. This should provide a safety catch for when such an out of order issue occurs.