### PR TITLE
Animation Rework Phase 3 - Fixes for Multi

### DIFF
--- a/code/model/modelanimation.cpp
+++ b/code/model/modelanimation.cpp
@@ -2,6 +2,7 @@
 #include "model/modelanimation_segments.h"
 #include "network/multi.h"
 #include "network/multimsgs.h"
+#include "parse/encrypt.h"
 #include "ship/ship.h"
 #include "utils/Random.h"
 
@@ -20,7 +21,7 @@ namespace animation {
 	const size_t Num_animation_flags = sizeof(Animation_flags) / sizeof(flag_def_list_new<animation::Animation_Flags>);
 
 	std::map<int, ModelAnimationSet::RunningAnimationList> ModelAnimationSet::s_runningAnimations;
-	std::vector<std::shared_ptr<ModelAnimation>> ModelAnimation::s_animationById;
+	std::map<unsigned int, std::shared_ptr<ModelAnimation>> ModelAnimationSet::s_animationById;
 
 	ModelAnimation::ModelAnimation(bool isInitialType) : m_set(nullptr), m_isInitialType(isInitialType) { }
 
@@ -139,7 +140,7 @@ namespace animation {
 			//We are in multiplayer. Send animation to server to start. Server starts animation online, and sends start request back (which'll have multiOverride == true).
 			//If we _are_ the server, also just start the animation
 
-			object* objp = nullptr;
+			object* objp = pmi->objnum > -1 ? &Objects[pmi->objnum] : nullptr;
 
 			if(objp != nullptr)
 				send_animation_triggered_packet(id, objp, 0, direction, force, instant, pause);
@@ -515,18 +516,31 @@ namespace animation {
 		return *this;
 	}
 
-	void ModelAnimationSet::emplace(const std::shared_ptr<ModelAnimation>& animation, const SCP_string& name, ModelAnimationTriggerType type, int subtype) {
+	void ModelAnimationSet::emplace(const std::shared_ptr<ModelAnimation>& animation, const SCP_string& name, ModelAnimationTriggerType type, int subtype, unsigned int uniqueId) {
 		auto newAnim = std::shared_ptr<ModelAnimation>(new ModelAnimation(*animation));
 		newAnim->m_set = this;
 		newAnim->m_animation = std::shared_ptr<ModelAnimationSegment>(animation->m_animation->copy());
 		newAnim->m_animation->exchangeSubmodelPointers(*this);
+		newAnim->id = uniqueId;
+		ModelAnimationSet::s_animationById[uniqueId] = newAnim;
 		m_animationSet[{type, subtype}][name].push_back(newAnim);
 	}
 
 	void ModelAnimationSet::changeShipName(const SCP_string& name) {
+		unsigned int hash_change = hash_fnv1a(m_SIPname) ^ hash_fnv1a(name);
+
 		m_SIPname = name;
 		for (const auto& submodel : m_submodels) {
 			submodel->renameSIP(name);
+		}
+
+		for (const auto& animationTypes : m_animationSet) {
+			for (const auto& animations : animationTypes.second) {
+				for (const auto& animation : animations.second) {
+					animation->id ^= hash_change;
+					ModelAnimationSet::s_animationById[animation->id] = animation;
+				}
+			}
 		}
 	}
 
@@ -1198,16 +1212,16 @@ namespace animation {
 
 	}
 
-
 	void ModelAnimationParseHelper::parseTables() {
 		s_animationsById.clear();
 		parse_modular_table("*-anim.tbm", parseTableFile, CF_TYPE_TABLES);
 	}
+
+	unsigned int ModelAnimationParseHelper::getUniqueAnimationID(const SCP_string& animName, char uniquePrefix, const SCP_string& parentName) {
+		return hash_fnv1a(animName + uniquePrefix) ^ hash_fnv1a(parentName);
+	}
 	
-	void ModelAnimationParseHelper::parseAnimsetInfo(ModelAnimationSet& set, ship_info* sip) {
-		if(sip != nullptr)
-			set.changeShipName(sip->name);
-		
+	void ModelAnimationParseHelper::parseAnimsetInfo(ModelAnimationSet& set, char uniqueTypePrefix, const SCP_string& uniqueParentName) {
 		SCP_vector<SCP_string> requestedAnimations;
 		stuff_string_list(requestedAnimations);
 
@@ -1215,12 +1229,20 @@ namespace animation {
 			auto animIt = s_animationsById.find(request);
 			if (animIt != s_animationsById.end()) {
 				const ParsedModelAnimation& foundAnim = animIt->second;
-				set.emplace(foundAnim.anim, foundAnim.name, foundAnim.type, foundAnim.subtype);
+				set.emplace(foundAnim.anim, foundAnim.name, foundAnim.type, foundAnim.subtype, ModelAnimationParseHelper::getUniqueAnimationID(animIt->first, uniqueTypePrefix, uniqueParentName));
 			}
 			else {
 				error_display(0, "Animation with name %s not found!", request.c_str());
 			}
 		}
+	}
+
+	void ModelAnimationParseHelper::parseAnimsetInfo(ModelAnimationSet& set, ship_info* sip) {
+		Assert(sip != nullptr);
+		
+		set.changeShipName(sip->name);
+		
+		ModelAnimationParseHelper::parseAnimsetInfo(set, 's', sip->name);
 	}
 
 
@@ -1324,7 +1346,7 @@ namespace animation {
 
 			//Initial Animations in legacy style will continue to be fully supported and allowed, given the frequency of these (especially for turrets) and the fact that these are more intuitive to be directly in the subsystem section of the ship table, as these are closer to representing a property of the subsystem rather than an animation.
 			//Hence, there will not be any warning displayed if the legacy table is used for these. -Lafiel 
-			sip->animations.emplace(anim, name, animation::ModelAnimationTriggerType::Initial);
+			sip->animations.emplace(anim, name, ModelAnimationTriggerType::Initial, ModelAnimationSet::SUBTYPE_DEFAULT, ModelAnimationParseHelper::getUniqueAnimationID(name + Animation_types.at(ModelAnimationTriggerType::Initial).first + std::to_string(subtype), 'b', sip->name));
 		}
 		else {
 			auto anim = std::shared_ptr<ModelAnimation>(new ModelAnimation());
@@ -1419,7 +1441,7 @@ namespace animation {
 			anim->setAnimation(mainSegment);
 
 			//TODO maybe handle sub_name? Not documented in Wiki, maybe no one actually uses it...
-			sip->animations.emplace(anim, name, type, subtype);
+			sip->animations.emplace(anim, name, type, subtype, ModelAnimationParseHelper::getUniqueAnimationID(name + Animation_types.at(type).first + std::to_string(subtype), 'b', sip->name));
 
 			mprintf(("Specified deprecated non-initial type animation on subsystem %s of ship class %s. Consider using *-anim.tbm's instead.\n", sp->subobj_name, sip->name));
 		}

--- a/code/model/modelanimation.cpp
+++ b/code/model/modelanimation.cpp
@@ -134,6 +134,9 @@ namespace animation {
 	}
 	
 	void ModelAnimation::start(polymodel_instance* pmi, ModelAnimationDirection direction, bool force, bool instant, bool pause, const float* multiOverrideTime) {
+		if (pmi == nullptr)
+			return;
+
 		instance_data& instanceData = m_instances[pmi->id];
 
 		if (multiOverrideTime == nullptr && (Game_mode & GM_MULTIPLAYER) && id != 0) {

--- a/code/model/modelanimation.h
+++ b/code/model/modelanimation.h
@@ -247,13 +247,12 @@ namespace animation {
 
 		ModelAnimationState play(float frametime, polymodel_instance* pmi, ModelAnimationSubmodelBuffer& applyBuffer, bool applyOnly = false);
 
-		ModelAnimation(bool isInitialType);
 
 		friend class ModelAnimationSet;
 		friend class ModelAnimationParseHelper;
 	public:
 		//Initial type animations must complete within a single frame, and then never modifiy the submodel again. If this is the case, we do not need to remember them being active for massive performance gains with lots of turrets
-		static std::shared_ptr<ModelAnimation> createAnimation(bool isInitialType = false);
+		ModelAnimation(bool isInitialType = false);
 
 		void setAnimation(std::shared_ptr<ModelAnimationSegment> animation);
 
@@ -265,7 +264,7 @@ namespace animation {
 		static void stepAnimations(float frametime, polymodel_instance* pmi);
 
 		static std::vector<std::shared_ptr<ModelAnimation>> s_animationById;
-		const size_t id;
+		unsigned int id = 0;
 	};
 
 

--- a/code/model/modelanimation.h
+++ b/code/model/modelanimation.h
@@ -263,7 +263,6 @@ namespace animation {
 
 		static void stepAnimations(float frametime, polymodel_instance* pmi);
 
-		static std::vector<std::shared_ptr<ModelAnimation>> s_animationById;
 		unsigned int id = 0;
 	};
 
@@ -271,6 +270,7 @@ namespace animation {
 	class ModelAnimationSet {
 	public:
 		static int SUBTYPE_DEFAULT;
+		static std::map<unsigned int, std::shared_ptr<ModelAnimation>> s_animationById;
 
 	private:
 		struct RunningAnimationList { const ModelAnimationSet* parentSet; std::list<std::shared_ptr<ModelAnimation>> animationList; };
@@ -305,7 +305,7 @@ namespace animation {
 		ModelAnimationSet& operator=(const ModelAnimationSet& other);
 
 		//Helper function to shorten animation emplaces
-		void emplace(const std::shared_ptr<ModelAnimation>& animation, const SCP_string& name, ModelAnimationTriggerType type = ModelAnimationTriggerType::Scripted, int subtype = SUBTYPE_DEFAULT);
+		void emplace(const std::shared_ptr<ModelAnimation>& animation, const SCP_string& name, ModelAnimationTriggerType type, int subtype, unsigned int uniqueId);
 
 		void changeShipName(const SCP_string& name);
 
@@ -347,6 +347,8 @@ namespace animation {
 		};
 		static std::map<SCP_string, ParsedModelAnimation> s_animationsById;
 
+		static unsigned int getUniqueAnimationID(const SCP_string& animName, char uniquePrefix, const SCP_string& parentName);
+
 		//Internal Parsing Methods
 		static void parseSingleAnimation();
 		static void parseTableFile(const char* filename);
@@ -366,7 +368,8 @@ namespace animation {
 		static std::shared_ptr<ModelAnimationSubmodel> parseSubmodel();
 
 		static void parseTables();
-		static void parseAnimsetInfo(ModelAnimationSet& set, ship_info* sip = nullptr);
+		static void parseAnimsetInfo(ModelAnimationSet& set, ship_info* sip);
+		static void parseAnimsetInfo(ModelAnimationSet& set, char uniqueTypePrefix, const SCP_string& uniqueParentName);
 		//Parses the legacy animation table in ships.tbl of a single subsystem. Currently initial animations only
 		static void parseLegacyAnimationTable(model_subsystem* sp, ship_info* sip);
 	};

--- a/code/network/multi.h
+++ b/code/network/multi.h
@@ -68,9 +68,10 @@ class player;
 // version 53 - 12/2/2020 big set of packet fixes/upgrades
 // version 54 - 3/20/2021 - Fixes for FSO 21_2 especially better net_sig calc, better missile intercept
 // version 55 - 8/28/2021 Adding multi-compatible animations
+// version 56 - 8/28/2021 Fix animations for 22_0 release
 // STANDALONE_ONLY
 
-#define MULTI_FS_SERVER_VERSION							55
+#define MULTI_FS_SERVER_VERSION							56
 
 #define MULTI_FS_SERVER_COMPATIBLE_VERSION			MULTI_FS_SERVER_VERSION
 

--- a/code/network/multimsgs.cpp
+++ b/code/network/multimsgs.cpp
@@ -8011,14 +8011,16 @@ static constexpr size_t animation_forced_bit = 1 << 1;
 static constexpr size_t animation_instant_bit = 1 << 2;
 static constexpr size_t animation_pause_bit = 1 << 3;
 
-void send_animation_triggered_packet(int animationId, int pmi, const animation::ModelAnimationDirection& direction, bool force, bool instant, bool pause, const int* /*time*/) {
+void send_animation_triggered_packet(unsigned int animationId, object* parent_object, ushort special_mode, const animation::ModelAnimationDirection& direction, bool force, bool instant, bool pause, const int* /*time*/) {
 	int packet_size;
+	ushort netsig_to_send = special_mode == 0 && parent_object != nullptr ? parent_object->net_signature : (ushort)0;
 	ubyte data[MAX_PACKET_SIZE];
 
 	BUILD_HEADER(ANIMATION_TRIGGERED);
 
 	ADD_INT(animationId);
-	ADD_INT(pmi);
+	ADD_SHORT(netsig_to_send);
+	ADD_SHORT(special_mode); // Currently empty. Reserved to find special pmi's for non-object animations
 	
 	ubyte metadata = (direction == animation::ModelAnimationDirection::RWD ? animation_direction_bit : 0)
 		| (force ? animation_forced_bit : 0)
@@ -8039,14 +8041,16 @@ void send_animation_triggered_packet(int animationId, int pmi, const animation::
 
 void process_animation_triggered_packet(ubyte* data, header* hinfo) {
 	int offset; // linked;	
-	int animationId, pmi;
+	int animationId;
+	ushort netsig, special_mode;
 	ubyte metadata;
 	int time;
 
 	// read all packet info
 	offset = HEADER_LENGTH;
 	GET_INT(animationId);
-	GET_INT(pmi);
+	GET_SHORT(netsig);
+	GET_SHORT(special_mode);
 	GET_DATA(metadata);
 	GET_INT(time);
 
@@ -8061,11 +8065,17 @@ void process_animation_triggered_packet(ubyte* data, header* hinfo) {
 
 	float delay = time * 0.001f;
 
-	animation::ModelAnimation::s_animationById[animationId]->start(model_get_instance(pmi), direction, forced, instant, pause, &delay);
+	object* objp = multi_get_network_object(netsig);
+	if (special_mode == 0 && objp != nullptr) {
+		animation::ModelAnimation::s_animationById[animationId]->start(model_get_instance(object_get_model_instance(objp)), direction, forced, instant, pause, &delay);
+	}
+	else {
+		//Currently empty. Reserved to find special pmi's for non-object animations
+	}
 
 	//Need to broadcast back to other clients
 	if (Net_player->flags & NETINFO_FLAG_AM_MASTER) {
-		send_animation_triggered_packet(animationId, pmi, direction, forced, instant, pause, &time);
+		send_animation_triggered_packet(animationId, objp, special_mode, direction, forced, instant, pause, &time);
 	}
 }
 

--- a/code/network/multimsgs.cpp
+++ b/code/network/multimsgs.cpp
@@ -8066,11 +8066,15 @@ void process_animation_triggered_packet(ubyte* data, header* hinfo) {
 	float delay = time * 0.001f;
 
 	object* objp = multi_get_network_object(netsig);
-	if (special_mode == 0 && objp != nullptr) {
-		animation::ModelAnimation::s_animationById[animationId]->start(model_get_instance(object_get_model_instance(objp)), direction, forced, instant, pause, &delay);
-	}
-	else {
-		//Currently empty. Reserved to find special pmi's for non-object animations
+
+	auto animation = animation::ModelAnimationSet::s_animationById.find(animationId);
+	if (animation != animation::ModelAnimationSet::s_animationById.end()) {
+		if (special_mode == 0 && objp != nullptr) {
+			animation->second->start(model_get_instance(object_get_model_instance(objp)), direction, forced, instant, pause, &delay);
+		}
+		else {
+			//Currently empty. Reserved to find special pmi's for non-object animations
+		}
 	}
 
 	//Need to broadcast back to other clients

--- a/code/network/multimsgs.h
+++ b/code/network/multimsgs.h
@@ -499,7 +499,7 @@ void send_non_homing_fired_packet(ship *shipp, int banks_fired, bool secondary =
 void process_non_homing_fired_packet(ubyte *data, header *hinfo);
 
 // animation triggered info
-void send_animation_triggered_packet(int animationId, int pmi, const animation::ModelAnimationDirection& direction, bool force, bool instant, bool pause, const int* /*time*/ = nullptr);
+void send_animation_triggered_packet(unsigned int animationId, object* parent_object, ushort special_mode, const animation::ModelAnimationDirection& direction, bool force, bool instant, bool pause, const int* /*time*/ = nullptr);
 void process_animation_triggered_packet(ubyte* data, header* hinfo);
 
 // new countermeasure fired info

--- a/code/object/object.cpp
+++ b/code/object/object.cpp
@@ -2045,6 +2045,9 @@ int object_get_model(const object *objp)
 
 int object_get_model_instance(const object *objp)
 {
+	if (objp == nullptr)
+		return -1;
+
 	switch (objp->type)
 	{
 		case OBJ_ASTEROID:

--- a/code/parse/encrypt.cpp
+++ b/code/parse/encrypt.cpp
@@ -466,3 +466,20 @@ void encrypt_init()
 
 	Encrypt_inited = 1;
 }
+
+uint32_t hash_fnv1a(const SCP_string& string) {
+	return hash_fnv1a(string.c_str(), string.length() * sizeof(SCP_string::value_type));
+}
+
+uint32_t hash_fnv1a(const void* data, size_t length) {
+	const uint32_t fnv1a_magic_prime = 16777619;
+	uint32_t hash = 2166136261;
+
+	const uint8_t* bytes = reinterpret_cast<const uint8_t*>(data);
+
+	for (size_t cnt = 0; cnt < length; cnt++) {
+		hash = (hash ^ bytes[cnt]) * fnv1a_magic_prime;
+	}
+
+	return hash;
+}

--- a/code/parse/encrypt.cpp
+++ b/code/parse/encrypt.cpp
@@ -475,7 +475,7 @@ uint32_t hash_fnv1a(const void* data, size_t length) {
 	const uint32_t fnv1a_magic_prime = 16777619;
 	uint32_t hash = 2166136261;
 
-	const uint8_t* bytes = reinterpret_cast<const uint8_t*>(data);
+	auto bytes = reinterpret_cast<const uint8_t*>(data);
 
 	for (size_t cnt = 0; cnt < length; cnt++) {
 		hash = (hash ^ bytes[cnt]) * fnv1a_magic_prime;

--- a/code/parse/encrypt.h
+++ b/code/parse/encrypt.h
@@ -7,7 +7,8 @@
  *
 */
 
-#include <stdint.h>
+#include <cstdint>
+#include "globalincs/vmallocator.h"
 
 #ifndef __ENCRYPT_H__
 #define __ENCRYPT_H__

--- a/code/parse/encrypt.h
+++ b/code/parse/encrypt.h
@@ -7,7 +7,7 @@
  *
 */
 
-
+#include <stdint.h>
 
 #ifndef __ENCRYPT_H__
 #define __ENCRYPT_H__
@@ -29,6 +29,10 @@ void encrypt(char *text, int text_len, char *scrambled_text, int *scrambled_len,
 
 // Decrypt scrambled_text
 void unencrypt(char *scrambled_text, int scrambled_len, char *text, int *text_len);
+
+//A fast platform/std-implementation stable hashing algorithm. Implements the FNV-1a hash algorithm
+uint32_t hash_fnv1a(const SCP_string& string);
+uint32_t hash_fnv1a(const void* data, size_t length);
 
 #endif
 

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -3382,7 +3382,7 @@ int parse_weapon(int subtype, bool replace, const char *filename)
 	}
 
 	if (optional_string("$Animations:")) {
-		animation::ModelAnimationParseHelper::parseAnimsetInfo(wip->animations);
+		animation::ModelAnimationParseHelper::parseAnimsetInfo(wip->animations, 'w', wip->name);
 	}
 
 	/* Generate a substitution pattern for this weapon.


### PR DESCRIPTION
This PR changes the multi message for the Animations to use netcode signatures instead of PMI ID's.
At the same time, protection against nonexistant animations or objects was added.
Furthermore, animation ID's are now only a function of a unique animation name and a name of whatever class this animation is defined for. This means, that for an animation that has the same name and is used in the same ship or weapon class, the id will be the same as well, making it usably stable for multi.
Closes #3836 
Small logging fixes to close #3842 as well.