### PR TITLE
Make secondaries use $energy consumed

### DIFF
--- a/code/hud/hudtarget.cpp
+++ b/code/hud/hudtarget.cpp
@@ -431,6 +431,7 @@ typedef struct weapon_flash
 {
 	int flash_duration[MAX_WEAPON_FLASH_LINES];
 	int flash_next[MAX_WEAPON_FLASH_LINES];
+	bool flash_energy[MAX_WEAPON_FLASH_LINES];
 	int is_bright;
 } weapon_flash;
 weapon_flash Weapon_flash_info;
@@ -1001,6 +1002,7 @@ void hud_weapons_init()
 	for ( int i = 0; i < MAX_WEAPON_FLASH_LINES; i++ ) {
 		Weapon_flash_info.flash_duration[i] = 1;
 		Weapon_flash_info.flash_next[i] = 1;
+		Weapon_flash_info.flash_energy[i] = false;
 	}
 
 	// The E: There used to be a number of checks here. They are no longer needed, as the new HUD code handles it on its own.
@@ -4521,7 +4523,7 @@ void HudGaugeTargetTriangle::render(float  /*frametime*/)
 }
 
 // start the weapon line (on the HUD) flashing
-void hud_start_flash_weapon(int index)
+void hud_start_flash_weapon(int index, bool flash_energy)
 {
 	if ( index >= MAX_WEAPON_FLASH_LINES ) {
 		Int3();	// Get Alan
@@ -4534,6 +4536,7 @@ void hud_start_flash_weapon(int index)
 	}
 
 	Weapon_flash_info.flash_duration[index] = timestamp(TBOX_FLASH_DURATION);
+	Weapon_flash_info.flash_energy[index] = flash_energy;
 }
 
 // maybe change the text color for the weapon line indicated by index
@@ -5776,9 +5779,10 @@ void HudGaugeWeaponEnergy::render(float  /*frametime*/)
 			}
 		}
 
-		for ( i = 0; i < sw->num_primary_banks; i++ )
+		// maybe flash the energy bar
+		for ( i = 0; i < MAX_SHIP_WEAPONS; i++ )
 		{
-			if ( !timestamp_elapsed(Weapon_flash_info.flash_duration[i]) )
+			if ( !timestamp_elapsed(Weapon_flash_info.flash_duration[i]) && Weapon_flash_info.flash_energy[i])
 			{
 				if ( Weapon_flash_info.is_bright & (1<<i) )
 				{

--- a/code/hud/hudtarget.cpp
+++ b/code/hud/hudtarget.cpp
@@ -5780,7 +5780,7 @@ void HudGaugeWeaponEnergy::render(float  /*frametime*/)
 		}
 
 		// maybe flash the energy bar
-		for ( i = 0; i < MAX_SHIP_WEAPONS; i++ )
+		for ( i = 0; i < sw->num_primary_banks + sw->num_secondary_banks; i++ )
 		{
 			if ( !timestamp_elapsed(Weapon_flash_info.flash_duration[i]) && Weapon_flash_info.flash_energy[i])
 			{

--- a/code/hud/hudtarget.h
+++ b/code/hud/hudtarget.h
@@ -133,7 +133,7 @@ vec3d* get_subsystem_world_pos(object* parent_obj, ship_subsys* subsys, vec3d* w
 void	hud_target_change_check();
 
 void hud_show_hostile_triangle();
-void hud_start_flash_weapon(int index);
+void hud_start_flash_weapon(int index, bool flash_energy);
 void hud_update_weapon_flash();
 void hud_process_homing_missiles(void);
 

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -11585,7 +11585,7 @@ int ship_fire_primary(object * obj, int force, bool rollback_shot)
 					points = num_slots;
 				}
 
-				bool no_energy = shipp->weapon_energy < points* winfo_p->energy_consumed* flFrametime;
+				bool no_energy = shipp->weapon_energy < points * winfo_p->energy_consumed * flFrametime;
 				if (no_energy || (winfo_p->wi_flags[Weapon::Info_Flags::Ballistic] && shipp->weapons.primary_bank_ammo[bank_to_fire] <= 0))
 				{
 					swp->next_primary_fire_stamp[bank_to_fire] = timestamp((int)(next_fire_delay));
@@ -11669,7 +11669,7 @@ int ship_fire_primary(object * obj, int force, bool rollback_shot)
 				// the weapon's energy_consumed to 0 and it'll work just fine. - Goober5000
 
 				// fail unless we're forcing (energy based primaries)
-				bool no_energy = shipp->weapon_energy < points* numtimes* winfo_p->energy_consumed; //was num_slots
+				bool no_energy = shipp->weapon_energy < points * numtimes * winfo_p->energy_consumed; //was num_slots
 				if ( no_energy && !force ) {
 
 					swp->next_primary_fire_stamp[bank_to_fire] = timestamp((int)(next_fire_delay));

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -10948,12 +10948,12 @@ int ship_launch_countermeasure(object *objp, int rand_val)
 /**
  * See if enough time has elapsed to play fail sound again
  */
-void ship_maybe_play_primary_fail_sound()
+void ship_maybe_do_primary_fail_sound_hud(bool depleted_energy)
 {
 	ship_weapon *swp = &Player_ship->weapons;
 	int stampval;
 
-	hud_start_flash_weapon(swp->current_primary_bank);
+	hud_start_flash_weapon(swp->current_primary_bank, depleted_energy);
 
 	if ( timestamp_elapsed(Laser_energy_out_snd_timer) )
 	{
@@ -10974,9 +10974,9 @@ void ship_maybe_play_primary_fail_sound()
 /**
  * See if enough time has elapsed to play secondary fail sound again
  */
-static int ship_maybe_play_secondary_fail_sound(weapon_info *wip)
+static int ship_maybe_do_secondary_fail_sound_hud(weapon_info *wip, bool depleted_energy)
 {
-	hud_start_flash_weapon(Player_ship->weapons.num_primary_banks + Player_ship->weapons.current_secondary_bank);
+	hud_start_flash_weapon(Player_ship->weapons.num_primary_banks + Player_ship->weapons.current_secondary_bank, depleted_energy);
 
 	if ( timestamp_elapsed(Missile_out_snd_timer) ) {
 		
@@ -11518,7 +11518,7 @@ int ship_fire_primary(object * obj, int force, bool rollback_shot)
 		// functional, which should be cool.  		
 		if ( ship_weapon_maybe_fail(shipp) && !force) {
 			if ( obj == Player_obj ) {
-				ship_maybe_play_primary_fail_sound();
+				ship_maybe_do_primary_fail_sound_hud(false);
 			}
 			ship_stop_fire_primary_bank(obj, bank_to_fire);
 			continue;
@@ -11585,13 +11585,13 @@ int ship_fire_primary(object * obj, int force, bool rollback_shot)
 					points = num_slots;
 				}
 
-				if ( shipp->weapon_energy < points*winfo_p->energy_consumed*flFrametime || 
-					(winfo_p->wi_flags[Weapon::Info_Flags::Ballistic] && shipp->weapons.primary_bank_ammo[bank_to_fire] <= 0))
+				bool no_energy = shipp->weapon_energy < points* winfo_p->energy_consumed* flFrametime;
+				if (no_energy || (winfo_p->wi_flags[Weapon::Info_Flags::Ballistic] && shipp->weapons.primary_bank_ammo[bank_to_fire] <= 0))
 				{
 					swp->next_primary_fire_stamp[bank_to_fire] = timestamp((int)(next_fire_delay));
 					if ( obj == Player_obj )
 					{
-						ship_maybe_play_primary_fail_sound();
+						ship_maybe_do_primary_fail_sound_hud(no_energy);
 					}
 					ship_stop_fire_primary_bank(obj, bank_to_fire);
 					continue;
@@ -11669,13 +11669,13 @@ int ship_fire_primary(object * obj, int force, bool rollback_shot)
 				// the weapon's energy_consumed to 0 and it'll work just fine. - Goober5000
 
 				// fail unless we're forcing (energy based primaries)
-				if ( (shipp->weapon_energy < points*numtimes * winfo_p->energy_consumed)			//was num_slots
-				 && !force ) {
+				bool no_energy = shipp->weapon_energy < points* numtimes* winfo_p->energy_consumed; //was num_slots
+				if ( no_energy && !force ) {
 
 					swp->next_primary_fire_stamp[bank_to_fire] = timestamp((int)(next_fire_delay));
 					if ( obj == Player_obj )
 					{
-						ship_maybe_play_primary_fail_sound();
+						ship_maybe_do_primary_fail_sound_hud(no_energy);
 					}
 					ship_stop_fire_primary_bank(obj, bank_to_fire);
 					continue;
@@ -11707,7 +11707,7 @@ int ship_fire_primary(object * obj, int force, bool rollback_shot)
 					{
 						if ( obj == Player_obj )
 						{
-							ship_maybe_play_primary_fail_sound();
+							ship_maybe_do_primary_fail_sound_hud(false);
 						}
 						else
 						{
@@ -11862,7 +11862,7 @@ int ship_fire_primary(object * obj, int force, bool rollback_shot)
 							if (weapon_objnum == -1) {
 								// Weapon most likely failed to fire
 								if (obj == Player_obj) {
-									ship_maybe_play_primary_fail_sound();
+									ship_maybe_do_primary_fail_sound_hud(false);
 								}
 								continue;
 							}
@@ -12436,7 +12436,7 @@ int ship_fire_secondary( object *obj, int allow_swarm, bool rollback_shot )
 	if ( !(Game_mode & GM_MULTIPLAYER) || MULTIPLAYER_MASTER ) {
 		if ( ship_weapon_maybe_fail(shipp) ) {
 			if ( obj == Player_obj ) 
-				if ( ship_maybe_play_secondary_fail_sound(wip) ) {
+				if ( ship_maybe_do_secondary_fail_sound_hud(wip, false) ) {
 					HUD_sourced_printf(HUD_SOURCE_HIDDEN, XSTR( "Cannot fire %s due to weapons system damage", 489), Weapon_info[weapon_idx].get_display_name());
 				}
 			goto done_secondary;
@@ -12506,13 +12506,11 @@ int ship_fire_secondary( object *obj, int allow_swarm, bool rollback_shot )
 			check_ammo = 0;
 		}
 
-		if (Weapon_info[swp->secondary_bank_weapons[bank]].wi_flags[Weapon::Info_Flags::SecondaryNoAmmo]) {
-			check_ammo = 0;
-		}
-
-		if ( check_ammo && ( swp->secondary_bank_ammo[bank] <= 0) ) {
+		bool no_ammo_needed = Weapon_info[swp->secondary_bank_weapons[bank]].wi_flags[Weapon::Info_Flags::SecondaryNoAmmo];
+		bool no_energy = shipp->weapon_energy < wip->energy_consumed;
+		if ( check_ammo && ((swp->secondary_bank_ammo[bank] <= 0 && !no_ammo_needed) || no_energy)) {
 			if ( shipp->objnum == OBJ_INDEX(Player_obj) ) {
-				if ( ship_maybe_play_secondary_fail_sound(wip) ) {
+				if (ship_maybe_do_secondary_fail_sound_hud(wip, no_energy) ) {
 //					HUD_sourced_printf(HUD_SOURCE_HIDDEN, "No %s missiles left in bank", Weapon_info[swp->secondary_bank_weapons[bank]].name);
 				}
 			}
@@ -12538,11 +12536,12 @@ int ship_fire_secondary( object *obj, int allow_swarm, bool rollback_shot )
 		}
 
 		int start_slot, end_slot;
+		no_energy = shipp->weapon_energy < 2 * wip->energy_consumed; // whether there's enough energy for at least 1 shot was checked above
 
 		if ( shipp->flags[Ship_Flags::Secondary_dual_fire] && num_slots > 1) {
 			start_slot = swp->secondary_next_slot[bank];
 			// AL 11-19-97: Ensure enough ammo remains when firing linked secondary weapons
-			if ( check_ammo && (swp->secondary_bank_ammo[bank] < 2) ) {
+			if ( check_ammo && ((swp->secondary_bank_ammo[bank] < 2 && !no_ammo_needed) || no_energy) ) {
 				end_slot = start_slot;
 			} else {
 				end_slot = start_slot+1;
@@ -12614,7 +12613,7 @@ int ship_fire_secondary( object *obj, int allow_swarm, bool rollback_shot )
 			if (weapon_num == -1) {
 				// Weapon most likely failed to fire
 				if (obj == Player_obj) {
-					ship_maybe_play_secondary_fail_sound(wip);
+					ship_maybe_do_secondary_fail_sound_hud(wip, false);
 				}
 				continue;
 			}
@@ -12647,6 +12646,8 @@ int ship_fire_secondary( object *obj, int allow_swarm, bool rollback_shot )
 				if ( !Weapon_energy_cheat ){
 					if(!Weapon_info[swp->secondary_bank_weapons[bank]].wi_flags[Weapon::Info_Flags::SecondaryNoAmmo])
 						swp->secondary_bank_ammo[bank]--;
+
+					shipp->weapon_energy -= wip->energy_consumed;
 				}
 			}
 		}
@@ -12711,7 +12712,7 @@ done_secondary:
 
 	// if we are out of ammo in this bank then don't carry over firing swarm/corkscrew
 	// missiles to a new bank
-	if (!ship_secondary_has_ammo(swp, bank)) {
+	if (!ship_secondary_has_ammo(swp, bank) || shipp->weapon_energy < (shipp->flags[Ship_Flags::Secondary_dual_fire] ? 2 : 1 * wip->energy_consumed)) {
 		// NOTE: these are set to 1 since they will get reduced by 1 in the
 		//       swarm/corkscrew code once this function returns
 

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -12712,7 +12712,7 @@ done_secondary:
 
 	// if we are out of ammo in this bank then don't carry over firing swarm/corkscrew
 	// missiles to a new bank
-	if (!ship_secondary_has_ammo(swp, bank) || shipp->weapon_energy < (shipp->flags[Ship_Flags::Secondary_dual_fire] ? 2 : 1 * wip->energy_consumed)) {
+	if (!ship_secondary_has_ammo(swp, bank) || shipp->weapon_energy < wip->energy_consumed) {
 		// NOTE: these are set to 1 since they will get reduced by 1 in the
 		//       swarm/corkscrew code once this function returns
 

--- a/code/weapon/beam.cpp
+++ b/code/weapon/beam.cpp
@@ -3948,8 +3948,8 @@ int beam_ok_to_fire(beam *b)
 		if (shipp->weapon_energy <= 0.0f ) {
 
 			if ( OBJ_INDEX(Player_obj) == shipp->objnum && !(b->life_left>0.0f)) {
-				extern void ship_maybe_play_primary_fail_sound();
-				ship_maybe_play_primary_fail_sound();
+				extern void ship_maybe_do_primary_fail_sound_hud(bool depleted_energy);
+				ship_maybe_do_primary_fail_sound_hud(true);
 			}
 
 			return 0;


### PR DESCRIPTION
It was completely ignored before. Just to be sure, I checked retail and no secondary had any energy consumption listed, nor did any of the high-profile mods I checked, which makes sense, since usually people will use retail weapons as a base.

Additionally, the weapon energy bar will now only flash if the weapon in question is actually starved of energy. Being out of missiles, or ballistics with no ammo will not flash the energy bar (ballistics used to do so even if they were merely out of ammo).