### PR TITLE
Fix weapons with submodel rotation firing

### DIFF
--- a/code/object/object.cpp
+++ b/code/object/object.cpp
@@ -829,8 +829,6 @@ void obj_move_call_physics(object *objp, float frametime)
 {
 	TRACE_SCOPE(tracing::Physics);
 
-	int has_fired = -1;	//stop fireing stuff-Bobboau
-
 	//	Do physics for objects with OF_PHYSICS flag set and with some engine strength remaining.
 	if ( objp->flags[Object::Object_Flags::Physics] ) {
 		// only set phys info if ship is not dead

--- a/code/object/object.cpp
+++ b/code/object/object.cpp
@@ -946,10 +946,6 @@ void obj_move_call_physics(object *objp, float frametime)
 			}
 		}
 	}
-	
-	if(has_fired == -1){
-		ship_stop_fire_primary(objp);	//if it hasn't fired do the "has just stoped fireing" stuff
-	}
 
 	//2D MODE
 	//THIS IS A FREAKIN' HACK


### PR DESCRIPTION
In #3720 there was some code which fired stream weapons for all ships, and then set `has_fired` to 1 (regardless if it even had any stream weapons), thus preventing the code removed in this PR from ever triggering and stopping primary fire. After it was removed  this would trigger every time, thus stopping weapons with submodel rotation rate requirements from ever reaching them. The code can be safely removed as both players and AI handle stopping their own primary fire on their own.

Fixes #3848 