### PR TITLE
fix language indexing for custom languages

### DIFF
--- a/code/localization/localize.cpp
+++ b/code/localization/localize.cpp
@@ -103,7 +103,7 @@ int lcl_get_current_lang_index()
 {
 	Assertion(Lcl_current_lang >= 0, "Lcl_current_lang should never be negative!");
 
-	if (Lcl_current_lang < NUM_BUILTIN_LANGUAGES)
+	if (Lcl_current_lang < (int)Lcl_languages.size())
 		return Lcl_current_lang;
 
 	return LCL_DEFAULT;
@@ -257,6 +257,10 @@ void parse_stringstbl_quick(const char *filename)
 				// if we have a new language, add it.
 				if (lang_idx == -1) {
 					Lcl_languages.push_back(language);
+
+					if (Lcl_languages.size() > LCL_UNTRANSLATED) {
+						Warning(LOCATION, "Too many custom languages; this will conflict with certain special-case language definitions and cause unexpected behavior");
+					}
 				}
 			}
 		}

--- a/code/localization/localize.h
+++ b/code/localization/localize.h
@@ -25,8 +25,8 @@
 #define LCL_FRENCH						2
 #define LCL_POLISH						3
 
-#define LCL_UNTRANSLATED				10	// this should be higher than the highest builtin language
-#define LCL_RETAIL_HYBRID				11	// ditto; this is the weird retail behavior where internal is translated but external isn't
+#define LCL_UNTRANSLATED				100		// this should be higher than the highest builtin or custom language index
+#define LCL_RETAIL_HYBRID				101		// ditto; this is the weird retail behavior where internal is translated but external isn't
 #define	LCL_DEFAULT						0
 
 // for language name strings


### PR DESCRIPTION
One of my XSTR and localization fixes from last year did not account for the presence of custom languages.  This PR uses the correct threshold and also adds a warning in case some mod really wants to define more than 6 additional languages.