### PR TITLE
Use phys_info for max AB speed display instead of ship_info

### DIFF
--- a/code/hud/hudreticle.cpp
+++ b/code/hud/hudreticle.cpp
@@ -544,7 +544,7 @@ void HudGaugeThrottle::render(float  /*frametime*/)
 	percent_aburn_max = 0.0f;
 	if ( percent_max > 1 ) {
 		percent_max = 1.0f;
-		percent_aburn_max = (current_speed - max_speed) / (sip->afterburner_max_vel.xyz.z - max_speed);
+		percent_aburn_max = (current_speed - max_speed) / (Player_obj->phys_info.afterburner_max_vel.xyz.z - max_speed);
 		if ( percent_aburn_max > 1.0f ) {
 			percent_aburn_max = 1.0f;
 		}


### PR DESCRIPTION
I'm not going to pretend like whoever wrote this "should've" known this, because this is pretty esoteric, but since phys_info is subject to runtime change through scripting, the HUD should display based on that, rather than the static info from the table.