### PR TITLE
PPC tonemapper values followup

### DIFF
--- a/code/def_files/data/effects/tonemapping-f.sdr
+++ b/code/def_files/data/effects/tonemapping-f.sdr
@@ -8,11 +8,17 @@ uniform sampler2D tex;
 layout (std140) uniform genericData {
 	float exposure;
 	int tonemapper;
-	float toeS;
-	float toeL;
-	float shoulderS;
-	float shoulderL;
-	float shoulderA;
+	float x0; //from here on these are for the PPC tonemappers
+	float y0;
+
+	float x1;
+	float toe_B;
+	float toe_lnA;
+	float sh_B;
+
+	float sh_lnA;
+	float sh_offsetX;
+	float sh_offsetY;
 };
 //Tonemapping options, aside from the previous standard UC2, pulled from wookiejedi and qazwsxal's
 //work on testing them for FSO, which itself was based on these references:
@@ -109,29 +115,7 @@ vec3 linearToneMapping(vec3 hdr_color)
 	hdr_color = linear_to_srgb(hdr_color); // return from linear color space to SRGB color space
 	return hdr_color;
 }
-/*
- float toeStrength = toeS; // [0-1]
- float toeLength = toeL; // [0-1]
- float shoulderStrength = shoulderS; // in F stops
- float shoulderLength = shoulderL; // [0-1]
- float shoulderAngle = shoulderA; // [0-1]
-*/
-// LEAVE ALONE
-float x0 = toeL * 0.5f;
-float y0 = (1.0f - toeS) * x0;
-float remainingY = 1.0f - y0;
-float initialW = x0 + remainingY;
-float y1_offset = (1.0f - shoulderL) * remainingY;
-float x1 = x0 + y1_offset;
-float y1 = y0 + y1_offset;
-float extraW = exp2(shoulderS) - 1.0f;
-float W = initialW + extraW;
-float overshootX = (W * 2.0f) * shoulderS + (x0-y0);
-float overshootY = 0.5f * shoulderA;
 
-// Assume slope (m) is always 1.0
-float	toe_B = x0/y0;
-float toe_lnA = log(y0) - toe_B*log(x0);
 float toe( float x ) {
 	return exp(toe_lnA + toe_B * log(x));
 }
@@ -140,14 +124,6 @@ float linear( float x ) {
 	// Slope is 1 by definition
 	return y0 + (x - x0);
 }
-
-float sh_x0 = (1.0 + overshootX) - x1;
-float sh_y0 = (1.0 + overshootY) - y1;
-
-float sh_B = sh_x0/sh_y0;
-float sh_lnA = log(sh_y0) - sh_B*log(sh_x0);
-float sh_offsetX = 1.0 + overshootX;
-float sh_offsetY = 1.0 + overshootY;
 
 float shoulder ( float x ) {
 	// Scale is -1 so reverse subtraction to save a mult

--- a/code/graphics/opengl/gropenglpostprocessing.cpp
+++ b/code/graphics/opengl/gropenglpostprocessing.cpp
@@ -69,14 +69,18 @@ void opengl_post_pass_tonemap()
 	
 	opengl_set_generic_uniform_data<graphics::generic_data::tonemapping_data>(
 		[](graphics::generic_data::tonemapping_data* data) {
-		auto ppc = lighting_profile::current_piecewise_values();
+		auto ppc = lighting_profile::current_piecewise_intermediates();
 		auto tn = lighting_profile::current_tonemapper();
 		data->tonemapper = tn;
-		data->toeS = ppc.toe_strength;
-		data->toeL = ppc.toe_length;
-		data->shoulderS = ppc.shoulder_strength;
-		data->shoulderL = ppc.shoulder_length;
-		data->shoulderA = ppc.shoulder_angle;
+		data->sh_B = ppc.sh_B;
+		data->sh_lnA = ppc.sh_lnA;
+		data->sh_offsetX =ppc.sh_offsetX;
+		data->sh_offsetY = ppc.sh_offsetY;
+		data->toe_B = ppc.toe_B;
+		data->toe_lnA = ppc.toe_lnA;
+		data->x0 = ppc.x0;
+		data->x1 = ppc.x1;
+		data->y0 = ppc.y0; 
 		data->exposure = lighting_profile::current_exposure(); });
 
 	glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, Scene_ldr_texture, 0);

--- a/code/graphics/util/uniform_structs.h
+++ b/code/graphics/util/uniform_structs.h
@@ -228,12 +228,17 @@ struct passthrough_data {
 struct tonemapping_data {
 	float exposure;
 	int tonemapper;
-	float toeS;
-	float toeL;
-	
-	float shoulderS;
-	float shoulderL;
-	float shoulderA;
+	float x0; //from here on these are for the PPC tonemappers
+	float y0;
+
+	float x1;
+	float toe_B;
+	float toe_lnA;
+	float sh_B;
+
+	float sh_lnA;
+	float sh_offsetX;
+	float sh_offsetY;
 	float pad[1];
 };
 

--- a/code/lighting/lighting_profiles.h
+++ b/code/lighting/lighting_profiles.h
@@ -30,12 +30,26 @@ struct piecewise_power_curve_values{
 	float shoulder_angle;
 };
 
+struct piecewise_power_curve_intermediates{
+	float x0;
+	float y0;
+	float x1;
+	float toe_B;
+	float toe_lnA;
+	float sh_B;
+	float sh_lnA;
+	float sh_offsetX;
+	float sh_offsetY;
+};
+
 class lighting_profile{
 public:
 	static enum TonemapperAlgorithm name_to_tonemapper(SCP_string &name);
 	static void load_profiles();
 	static TonemapperAlgorithm current_tonemapper();
 	static const piecewise_power_curve_values & current_piecewise_values();
+	static piecewise_power_curve_intermediates current_piecewise_intermediates();
+	static piecewise_power_curve_intermediates calc_intermediates(piecewise_power_curve_values input);
 	static float current_exposure();
 
 	SCP_string name;


### PR DESCRIPTION
Moved the PPC tonemapper intermediate calculations to C-side to clean up shader compatibility with older versions of opengl. Followup to #3838