### PR TITLE
Add comment on why event_editor::OnCancel() is blank

### DIFF
--- a/fred2/eventeditor.cpp
+++ b/fred2/eventeditor.cpp
@@ -855,7 +855,9 @@ void event_editor::OnDelete()
 // this is called when you hit the escape key..
 void event_editor::OnCancel()
 {
-	OnButtonCancel();
+	// override MFC default behavior and do nothing
+	// the Esc key is used for certain actions inside the events editor
+	// so presseing Esc shouldn't close the window
 }
 
 // this is called when you click the ID_CANCEL button

--- a/fred2/eventeditor.cpp
+++ b/fred2/eventeditor.cpp
@@ -855,6 +855,7 @@ void event_editor::OnDelete()
 // this is called when you hit the escape key..
 void event_editor::OnCancel()
 {
+	OnButtonCancel();
 }
 
 // this is called when you click the ID_CANCEL button

--- a/fred2/eventeditor.cpp
+++ b/fred2/eventeditor.cpp
@@ -857,7 +857,7 @@ void event_editor::OnCancel()
 {
 	// override MFC default behavior and do nothing
 	// the Esc key is used for certain actions inside the events editor
-	// so presseing Esc shouldn't close the window
+	// so pressing Esc shouldn't close the window
 }
 
 // this is called when you click the ID_CANCEL button


### PR DESCRIPTION
~~This PR also establishes the semantics that after the Events Editor is closed for any reason, `Event_editor_dlg` is always deleted.~~

~~Note that the behavior being added to `OnCancel()` already exists in `OnClose()`.~~

Clarify why the function `event_editor::OnCancel()` is empty.