### PR TITLE
Fix scripted setting of weapon targets

### DIFF
--- a/code/hud/hudtargetbox.cpp
+++ b/code/hud/hudtargetbox.cpp
@@ -826,7 +826,7 @@ void HudGaugeTargetBox::renderTargetWeapon(object *target_objp)
 		return;
 
 	is_homing = FALSE;
-	if ( target_wip->is_homing() && wp->homing_object != &obj_used_list )
+	if ( target_wip->is_homing() && weapon_has_homing_object(wp) )
 		is_homing = TRUE;
 
 	is_player_missile = FALSE;

--- a/code/scripting/api/objs/weapon.cpp
+++ b/code/scripting/api/objs/weapon.cpp
@@ -116,7 +116,7 @@ ADE_VIRTVAR(Target, l_Weapon, "object", "Target of weapon. Value may also be a d
 	{
 		if(newh && newh->IsValid())
 		{
-			if(wp->target_sig != newh->sig)
+			if(wp->target_sig != newh->sig || !weapon_has_homing_object(wp))
 			{
 				weapon_set_tracking_info(OBJ_INDEX(objh->objp), objh->objp->parent, OBJ_INDEX(newh->objp), 1);
 			}
@@ -198,7 +198,7 @@ ADE_VIRTVAR(HomingObject, l_Weapon, "object", "Object that weapon will home in o
 		}
 	}
 
-	if(wp->homing_object == &obj_used_list)
+	if(!weapon_has_homing_object(wp))
 		return ade_set_args(L, "o", l_Object.Set(object_h()));
 	else
 		return ade_set_object_with_breed(L, OBJ_INDEX(wp->homing_object));

--- a/code/weapon/weapon.h
+++ b/code/weapon/weapon.h
@@ -783,5 +783,8 @@ bool weapon_multilock_can_lock_on_subsys(object* shooter, object* target, ship_s
 // While single target missiles will check these properties as well separately, this function is ONLY used by multilock
 bool weapon_multilock_can_lock_on_target(object* shooter, object* target_objp, weapon_info* wip, float* out_dot = nullptr, bool checkWeapons = false);
 
+// Return whether the weapon has a target it is currently homing on
+bool weapon_has_homing_object(weapon* wp);
+
 
 #endif


### PR DESCRIPTION
A weapon fired without a lock has a proper `target_sig` but no `homing_object` and will not home, so when setting the target of a weapon through scripting check for that case as well, to prevent edge cases where a weapon might not allow one to set the target manually through scripting.

All the rest is adding a clarity function for how 'no homing object' is represented, which has always confused me because it looks weird. Some odd pointer shenanigans, but it works.