### PR TITLE
reset object colliders after each mission

### DIFF
--- a/code/object/objcollide.cpp
+++ b/code/object/objcollide.cpp
@@ -44,7 +44,7 @@ public:
 	{}
 };
 
-SCP_unordered_map<uint, collider_pair> Collision_cached_pairs;
+static SCP_unordered_map<uint, collider_pair> Collision_cached_pairs;
 
 class checkobject;
 extern checkobject CheckObjects[MAX_OBJECTS];

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -856,6 +856,7 @@ void game_level_close()
 
 		// De-Initialize the game subsystems
 		obj_delete_all();
+		obj_reset_colliders();
 		sexp_music_close();	// Goober5000
 		event_music_level_close();
 		game_stop_looped_sounds();
@@ -6676,7 +6677,6 @@ void game_shutdown(void)
 	// Free SEXP resources
 	sexp_shutdown();
 
-	obj_reset_colliders();
 	stars_close();			// clean out anything used by stars code
 
 	// the menu close functions will unload the bitmaps if they were displayed during the game


### PR DESCRIPTION
Some object collision info can grow significantly between missions but was only cleared at shutdown. This moves it to level close instead to keep things from getting out of hand.