### PR TITLE
Exclude certain recent error types from the fatal exit on mission parse.

### DIFF
--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -6150,7 +6150,8 @@ bool post_process_mission()
 				Warning(LOCATION, "%s", error_msg.c_str());
 
 				// syntax errors are recoverable in Fred but not FS
-				if (!Fred_running) {
+				// save for some non-fatal error types.
+				if (!Fred_running &&!(result == SEXP_CHECK_AMBIGUOUS_EVENT_NAME || result == SEXP_CHECK_AMBIGUOUS_GOAL_NAME)) {
 					return false;
 				}
 			}


### PR DESCRIPTION
Following the changes in #3774 many old missions which have been perfectly functional as far as anyone could tell now error on load. This makes an exception to the parse error logic to allow those missions to continue loading, while still firing the new warnings.