### PR TITLE
make certain SEXP errors nonfatal

### DIFF
--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -6150,7 +6150,7 @@ bool post_process_mission()
 				Warning(LOCATION, "%s", error_msg.c_str());
 
 				// syntax errors are recoverable in Fred but not FS
-				if (!Fred_running) {
+				if (!Fred_running && !sexp_recoverable_error(result)) {
 					return false;
 				}
 			}

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -3040,9 +3040,7 @@ int check_sexp_syntax(int node, int return_type, int recursive, int *bad_node, i
 					return SEXP_CHECK_TYPE_MISMATCH;
 				}
 
-				// Only report invalid gauges in FRED.  Having an invalid gauge in FSO won't hurt,
-				// as all places which use this function check for NULL.
-				if (Fred_running && hud_get_gauge(CTEXT(node), true) == nullptr) {
+				if (hud_get_gauge(CTEXT(node), true) == nullptr) {
 					return SEXP_CHECK_INVALID_CUSTOM_HUD_GAUGE;
 				}
 
@@ -30092,6 +30090,28 @@ int sexp_query_type_match(int opf, int opr)
 	}
 
 	return 0;
+}
+
+bool sexp_recoverable_error(int num)
+{
+	switch (num)
+	{
+		// These two errors may cause mysterious bugs in FSO,
+		// but the mission will run without crashing.
+		case SEXP_CHECK_AMBIGUOUS_EVENT_NAME:
+		case SEXP_CHECK_AMBIGUOUS_GOAL_NAME:
+
+		// Having an invalid gauge in FSO won't hurt,
+		// as all places which call hud_get_gauge() check its return value for NULL.
+		case SEXP_CHECK_INVALID_CUSTOM_HUD_GAUGE:
+
+			return true;
+
+
+		// most errors will halt mission loading
+		default:
+			return false;
+	}
 }
 
 const char *sexp_error_message(int num)

--- a/code/parse/sexp.h
+++ b/code/parse/sexp.h
@@ -1268,6 +1268,7 @@ extern void update_sexp_references(const char *old_name, const char *new_name, i
 extern int query_referenced_in_sexp(int mode, const char *name, int *node);
 extern int build_sexp_string(SCP_string &accumulator, int cur_node, int level, int mode);
 extern int sexp_query_type_match(int opf, int opr);
+extern bool sexp_recoverable_error(int num);
 extern const char *sexp_error_message(int num);
 extern int count_free_sexp_nodes();
 


### PR DESCRIPTION
Some SEXP errors, although they indicate real problems, will not prevent the mission from running.  Add these as exceptions.  Implemented per requests from users of Blue Planet and Solaris.

Supersedes #3870.