### PR TITLE
Animation Rework Phase 3, Turret fix

### DIFF
--- a/code/math/vecmat.cpp
+++ b/code/math/vecmat.cpp
@@ -1603,7 +1603,8 @@ float vm_closest_angle_to_matrix(const matrix* mat, const vec3d* rot_axis, float
 	const auto& a = rot_axis->a1d;
 
 	const float w = m[0]+m[4]+m[8];
-	const float y = -2 * ( m[0]*(a[1]*a[1]+a[2]*a[2]) + m[4]*(a[0]*a[0]+a[2]*a[2]) + m[8]*(a[0]*a[0]+a[1]*a[1]) - a[0]*a[1]*(m[1]+m[3]) - a[0]*a[2]*(m[2]+m[6]) - a[1]*a[2]*(m[5]+m[7]));
+	const float y = -2 * ( m[0]*(a[1]*a[1]+a[2]*a[2]) + m[4]*(a[0]*a[0]+a[2]*a[2]) + m[8]*(a[0]*a[0]+a[1]*a[1]) -
+			      a[0]*a[1]*(m[1]+m[3]) - a[0]*a[2]*(m[2]+m[6]) - a[1]*a[2]*(m[5]+m[7]));
 	const float z = (a[0]*(m[5]-m[7]) + a[1]*(-m[2]+m[6]) + a[2]*(m[1]-m[3]));
 
 	// If both y and z are close to 0, then the rotation axis points in the same direction as the matrix, thus any orientation r would be perpendicular to m

--- a/code/math/vecmat.cpp
+++ b/code/math/vecmat.cpp
@@ -1585,6 +1585,67 @@ void vm_matrix_to_rot_axis_and_angle(const matrix *m, float *theta, vec3d *rot_a
 	}
 }
 
+// Given a rotation axis, calculates the angle that results in the rotation closest to the given matrix m.
+// If the axis is equal or very close to the orientation of the matrix, returns false and an angle of 0
+bool vm_closest_angle_to_matrix(const matrix* mat, const vec3d* rot_axis, float* angle){
+	// The relative rotation between m and the target rotation r (made from axis a and angle x) is m^T.r
+	// The resulting angle between those, as shown by http://www.boris-belousov.net/2016/12/01/quat-dist/ is arccos((tr(m^T.r)-1) / 2)
+
+	// tr(m^T.r) simplifies to the following:
+	// tr = m[0]+m[4]+m[8] - 2( m[0]*(a[1]^2+a[2]^2) + m[4]*(a[0]^2+a[2]^2) + m[8]*(a[0]^2+a[1]^2) -
+	//                          a[0]*a[1]*(m[1]+m[3]) - a[0]*a[2]*(m[2]+m[6]) - a[1]*a[2]*(m[5]+m[7])) * sin(1/2 * x)^2
+	//					   + (a[0]*(m[5]-m[7]) + a[1]*(-m[2]+m[6]) + a[2]*(m[1]-m[3])) * sin(x)
+
+	// The factor before the sine squared will be calculated as y, the factor before the sine as z, the summand as w:
+
+	const auto& m = mat->a1d;
+	const auto& a = rot_axis->a1d;
+
+	const float w = m[0]+m[4]+m[8];
+	const float y = 2 * ( m[0]*(a[1]*a[1]+a[2]*a[2]) + m[4]*(a[0]*a[0]+a[2]*a[2]) + m[8]*(a[0]*a[0]+a[1]*a[1]) - a[0]*a[1]*(m[1]+m[3]) - a[0]*a[2]*(m[2]+m[6]) - a[1]*a[2]*(m[5]+m[7]));
+	const float z = (a[0]*(m[5]-m[7]) + a[1]*(-m[2]+m[6]) + a[2]*(m[1]-m[3]));
+
+	// If both y and z are close to 0, then the rotation axis points in the same direction as the matrix, thus any orientation r would be perpendicular to m
+	if(fabs(y) < 0.01f && fabs(z) < 0.01f){
+		*angle = 0.0f;
+		return false;
+	}
+
+	// arccos((x-1)/2) is then minimal, when x between -1 and 3 approaches 3
+	// Thus we are looking for the maximum of a term in the form of f(x)=w+y*sin(x/2)^2+z*sin(x)
+	// This maximum can be on one of the four solutions of f'(x)=0, not counting periodic repetitions
+
+	const float sr = sqrtf(y*y*y*y+4*y*y*z*z);
+	const float sr_pos = sqrtf(1-(sr/(y*y+4*z*z)));
+	const float sr_neg = sqrtf(1+(sr/(y*y+4*z*z)));
+
+	const float solutions[] = {2 * atan2_safe(-2 * sr_neg, -sr_neg*(y*y+sr)/(y*z)),
+							   2 * atan2_safe(2 * sr_neg, sr_neg*(y*y+sr)/(y*z)),
+							   2 * atan2_safe(-2 * sr_pos, -sr_pos*(y*y-sr)/(y*z)),
+							   2 * atan2_safe(2 * sr_pos, sr_pos*(y*y-sr)/(y*z))};
+
+	float value = -2.0f;
+	float correct = 0;
+	//For whichever of these, w+y*sin(x/2)^2+z*sin(x) is closest to 3 / larger (since the result is between -1 and 3) is our target angle
+	for(float solution : solutions){
+		float currentVal = w + y * sinf(solution * 0.5f) * sinf(solution * 0.5f) + z * sinf(solution);
+		if(currentVal > value){
+			value = currentVal;
+			correct = solution;
+		}
+	}
+
+	Assertion(value > -1.5f, "Did not find solution for closest angle & axis to matrix.");
+
+	// Since atanf can yield -pi/2 to pi/2, we could get negative results here. Convert to 0 to 2Pi
+	while (correct < 0.0f)
+		correct += PI2;
+
+	*angle = correct;
+	return true;
+}
+
+
 // --------------------------------------------------------------------------------------
 
 

--- a/code/math/vecmat.cpp
+++ b/code/math/vecmat.cpp
@@ -1587,7 +1587,7 @@ void vm_matrix_to_rot_axis_and_angle(const matrix *m, float *theta, vec3d *rot_a
 
 // Given a rotation axis, calculates the angle that results in the rotation closest to the given matrix m.
 // If the axis is equal or very close to the orientation of the matrix, returns false and an angle of 0
-bool vm_closest_angle_to_matrix(const matrix* mat, const vec3d* rot_axis, float* angle){
+float vm_closest_angle_to_matrix(const matrix* mat, const vec3d* rot_axis, float* angle){
 	// The relative rotation between m and the target rotation r (made from axis a and angle x) is m^T.r
 	// The resulting angle between those, as shown by http://www.boris-belousov.net/2016/12/01/quat-dist/ is arccos((tr(m^T.r)-1) / 2)
 
@@ -1602,13 +1602,13 @@ bool vm_closest_angle_to_matrix(const matrix* mat, const vec3d* rot_axis, float*
 	const auto& a = rot_axis->a1d;
 
 	const float w = m[0]+m[4]+m[8];
-	const float y = 2 * ( m[0]*(a[1]*a[1]+a[2]*a[2]) + m[4]*(a[0]*a[0]+a[2]*a[2]) + m[8]*(a[0]*a[0]+a[1]*a[1]) - a[0]*a[1]*(m[1]+m[3]) - a[0]*a[2]*(m[2]+m[6]) - a[1]*a[2]*(m[5]+m[7]));
+	const float y = -2 * ( m[0]*(a[1]*a[1]+a[2]*a[2]) + m[4]*(a[0]*a[0]+a[2]*a[2]) + m[8]*(a[0]*a[0]+a[1]*a[1]) - a[0]*a[1]*(m[1]+m[3]) - a[0]*a[2]*(m[2]+m[6]) - a[1]*a[2]*(m[5]+m[7]));
 	const float z = (a[0]*(m[5]-m[7]) + a[1]*(-m[2]+m[6]) + a[2]*(m[1]-m[3]));
 
 	// If both y and z are close to 0, then the rotation axis points in the same direction as the matrix, thus any orientation r would be perpendicular to m
 	if(fabs(y) < 0.01f && fabs(z) < 0.01f){
 		*angle = 0.0f;
-		return false;
+		return PI_2;
 	}
 
 	// arccos((x-1)/2) is then minimal, when x between -1 and 3 approaches 3
@@ -1642,7 +1642,7 @@ bool vm_closest_angle_to_matrix(const matrix* mat, const vec3d* rot_axis, float*
 		correct += PI2;
 
 	*angle = correct;
-	return true;
+	return acosf_safe((value - 1.0f) * 0.5f);
 }
 
 

--- a/code/math/vecmat.h
+++ b/code/math/vecmat.h
@@ -474,6 +474,10 @@ void vm_quaternion_rotate(matrix *m, float theta, const vec3d *u);
 // Takes a rotation matrix and returns the axis and angle needed to generate it
 void vm_matrix_to_rot_axis_and_angle(const matrix *m, float *theta, vec3d *rot_axis);
 
+// Given a rotation axis, calculates the angle that results in the rotation closest to the given matrix m.
+// If the axis is equal or very close to the orientation of the matrix, returns false and an angle of 0
+bool vm_closest_angle_to_matrix(const matrix* mat, const vec3d* rot_axis, float* angle);
+
 // interpolate between 2 vectors. t goes from 0.0 to 1.0. at
 void vm_vec_interp_constant(vec3d *out, const vec3d *v1, const vec3d *v2, float t);
 

--- a/code/math/vecmat.h
+++ b/code/math/vecmat.h
@@ -474,9 +474,9 @@ void vm_quaternion_rotate(matrix *m, float theta, const vec3d *u);
 // Takes a rotation matrix and returns the axis and angle needed to generate it
 void vm_matrix_to_rot_axis_and_angle(const matrix *m, float *theta, vec3d *rot_axis);
 
-// Given a rotation axis, calculates the angle that results in the rotation closest to the given matrix m.
-// If the axis is equal or very close to the orientation of the matrix, returns false and an angle of 0
-bool vm_closest_angle_to_matrix(const matrix* mat, const vec3d* rot_axis, float* angle);
+// Given a rotation axis, calculates the angle that results in the rotation closest to the given matrix m. Returns the angle between the matrix orientation and the closest axis angle orientation
+// If the axis is equal or very close to the orientation of the matrix, returns a distance of Pi/2 and an angle of 0
+float vm_closest_angle_to_matrix(const matrix* mat, const vec3d* rot_axis, float* angle);
 
 // interpolate between 2 vectors. t goes from 0.0 to 1.0. at
 void vm_vec_interp_constant(vec3d *out, const vec3d *v1, const vec3d *v2, float t);

--- a/code/model/modelanimation.cpp
+++ b/code/model/modelanimation.cpp
@@ -444,20 +444,18 @@ namespace animation {
 
 	//To handle Multipart-turrets properly, they need a modified version that sets the actual angle, not just the orientation matrix.
 	void ModelAnimationSubmodelTurret::copyToSubmodel(const ModelAnimationData<>& data, polymodel_instance* pmi) {
-		submodel_instance* submodel = findSubmodel(pmi).first;
+		const auto& submodels = findSubmodel(pmi);
+		submodel_instance* submodel = submodels.first;
+		bsp_info* sm = submodels.second;
 
 		if (!submodel)
 			return;
 
 		submodel->canonical_orient = data.orientation;
 
-		float angle;
-		vec3d axis;
-		vm_matrix_to_rot_axis_and_angle(&submodel->canonical_orient, &angle, &axis);
-		while (angle > PI2)
-			angle -= PI2;
-		while (angle < 0.0f)
-			angle += PI2;
+		float angle = 0.0f;
+
+		vm_closest_angle_to_matrix(&submodel->canonical_orient, &sm->movement_axis, &angle);
 
 		submodel->cur_angle = angle;
 		submodel->turret_idle_angle = angle;


### PR DESCRIPTION
Turrets will now correctly calculate their default position based on POF'd rotation axis. Previously, this could cause problems.
This now also properly supports the case if a turret has been rotated off-axis by an animation, and will set the turret angle for AI and stuff to the closest possible angle on the rotation axis.

Should fix #3876 