### PR TITLE
convert the FSO timestamp system to use SDL time

### DIFF
--- a/code/gamesnd/eventmusic.cpp
+++ b/code/gamesnd/eventmusic.cpp
@@ -659,7 +659,7 @@ void event_music_first_pattern()
 			audiostream_stop( Patterns[Current_pattern].handle );
 	}
 
-	Pattern_timer_id = 2000;	// start music delay
+	Pattern_timer_id = timestamp(-1);	// don't let this start quite yet; see event_music_set_start_delay()
 	
 	Event_music_begun = FALSE;
 	if ( Event_Music_battle_started == TRUE ) {
@@ -668,6 +668,13 @@ void event_music_first_pattern()
 	else {
 		Current_pattern = SONG_NRML_1;
 	}
+}
+
+// Event music was originally hard-coded to start at 2 seconds, regardless of the timestamp.  Since the default player entry delay is 1 second,
+// this yields a relative start time of 1 second.  Mission start will now use relative rather than absolute delay.
+void event_music_set_start_delay()
+{
+	Pattern_timer_id = timestamp(1000);
 }
 
 // -------------------------------------------------------------------------------------------------

--- a/code/gamesnd/eventmusic.h
+++ b/code/gamesnd/eventmusic.h
@@ -107,6 +107,7 @@ void	event_music_parse_musictbl(const char *filename);
 void	event_music_change_pattern(int new_pattern);
 int	event_music_return_current_pattern();
 void	event_music_first_pattern();
+void event_music_set_start_delay();
 int	event_music_battle_start();
 int	event_music_enemy_arrival();
 int	event_music_friendly_arrival();

--- a/code/io/timer.cpp
+++ b/code/io/timer.cpp
@@ -157,6 +157,21 @@ void timer_unpause_timestamp(bool sudo)
 	}
 }
 
+void timer_adjust(float delta)
+{
+	Assertion(Timer_inited, "Timer should be initialized at this point!");
+	Assertion(Timer_timestamp_offset_from_counter != 0 && Timer_timestamp_paused_at_counter != 0 && Timestamp_microseconds_at_mission_start != 0,
+		"Warranty void if these variables have not been set!");
+
+	auto microseconds = (long double) delta * MICROSECONDS_PER_SECOND;
+	auto timer_delta = (uint64_t) (microseconds / Timer_to_microseconds);
+
+	// adjust all the internal variables so it is as if the timer jumped forward
+	Timestamp_microseconds_at_mission_start -= (uint64_t) microseconds;
+	Timer_timestamp_offset_from_counter -= timer_delta;
+	Timer_timestamp_paused_at_counter -= timer_delta;
+}
+
 void timer_start_mission()
 {
 	Timestamp_microseconds_at_mission_start = timestamp_get_microseconds();

--- a/code/io/timer.cpp
+++ b/code/io/timer.cpp
@@ -250,6 +250,8 @@ void timer_unpause_timestamp(bool sudo)
 		return;
 	if (sudo)
 		Timer_sudo_paused = false;
+	if (!Timer_is_paused)
+		return;
 	Timer_is_paused = false;
 
 	auto counter = get_performance_counter();

--- a/code/io/timer.cpp
+++ b/code/io/timer.cpp
@@ -157,13 +157,13 @@ void timer_unpause_timestamp(bool sudo)
 	}
 }
 
-void timer_adjust(float delta)
+void timer_adjust(float delta_seconds)
 {
 	Assertion(Timer_inited, "Timer should be initialized at this point!");
 	Assertion(Timer_timestamp_offset_from_counter != 0 && Timer_timestamp_paused_at_counter != 0 && Timestamp_microseconds_at_mission_start != 0,
 		"Warranty void if these variables have not been set!");
 
-	auto microseconds = (long double) delta * MICROSECONDS_PER_SECOND;
+	auto microseconds = (long double) delta_seconds * MICROSECONDS_PER_SECOND;
 	auto timer_delta = (uint64_t) (microseconds / Timer_to_microseconds);
 
 	// adjust all the internal variables so it is as if the timer jumped forward

--- a/code/io/timer.cpp
+++ b/code/io/timer.cpp
@@ -66,8 +66,8 @@ void timer_init()
 
 		// set up the config so that timestamps are usable
 		// (timestamps are used in the UI and in some init functions, not just within the mission)
-		timer_pause_timestamp();
-		timer_unpause_timestamp();
+		timer_pause_timestamp(true);
+		timer_unpause_timestamp(true);
 
 		atexit(timer_close);
 	}

--- a/code/io/timer.h
+++ b/code/io/timer.h
@@ -72,6 +72,10 @@ void timer_pause_timestamp(bool sudo);
 // See above re: the sudo parameter
 void timer_unpause_timestamp(bool sudo);
 
+// This should only be called before the player has entered the mission!
+// Calling this function will render inaccurate any timestamps that have been saved.
+void timer_adjust(float delta);
+
 // Save the timestamp corresponding to the beginning of the mission
 void timer_start_mission();
 

--- a/code/io/timer.h
+++ b/code/io/timer.h
@@ -66,11 +66,11 @@ extern int timer_get_seconds();				// seconds since program started... not accur
 // This should be called when the timestamp should stop ticking, e.g when the game is paused.
 // The "sudo" is for cases where we want the time to remain paused, e.g. during level loading,
 //     even if the game loses focus (which would normally unpause when focus is regained)
-void timer_pause_timestamp(bool sudo = false);
+void timer_pause_timestamp(bool sudo);
 
 // This should be called when the timestamp should resume ticking, e.g. when the player is in-mission.
 // See above re: the sudo parameter
-void timer_unpause_timestamp(bool sudo = false);
+void timer_unpause_timestamp(bool sudo);
 
 // Save the timestamp corresponding to the beginning of the mission
 void timer_start_mission();

--- a/code/io/timer.h
+++ b/code/io/timer.h
@@ -63,21 +63,20 @@ extern int timer_get_seconds();				// seconds since program started... not accur
 // scale it correctly.
 #define TIMESTAMP_FREQUENCY 1000
 
-// Call this at least every 600 hours, I would
-// say at the start of each level should do it.
-extern void timestamp_reset();
+// This should be called when the timestamp should stop ticking, e.g when the game is paused.
+// The "sudo" is for cases where we want the time to remain paused, e.g. during level loading,
+//     even if the game loses focus (which would normally unpause when focus is regained)
+void timer_pause_timestamp(bool sudo = false);
 
-// Call this once every frame with the frametime.
-extern void timestamp_inc(fix frametime);
+// This should be called when the timestamp should resume ticking, e.g. when the player is in-mission.
+// See above re: the sudo parameter
+void timer_unpause_timestamp(bool sudo = false);
 
-/**
- * @brief Sets the value of the internal timestamp ticker
- *
- * @warning This function may only be used in special cases! Only use if you are absolutely certain that you need it.
- *
- * @param value The new value of the ticker
- */
-void timestamp_set_value(int value);
+// Save the timestamp corresponding to the beginning of the mission
+void timer_start_mission();
+
+// Calculate the current mission time using the timestamps
+fix timer_get_mission_time();
 
 // To do timing, call this with the interval you
 // want to check.  Then, pass this to timestamp_elapsed

--- a/code/io/timer.h
+++ b/code/io/timer.h
@@ -72,9 +72,8 @@ void timer_pause_timestamp(bool sudo);
 // See above re: the sudo parameter
 void timer_unpause_timestamp(bool sudo);
 
-// This should only be called before the player has entered the mission!
-// Calling this function will render inaccurate any timestamps that have been saved.
-void timer_adjust(float delta);
+// Use with caution!
+void timer_adjust(float delta_seconds);
 
 // Save the timestamp corresponding to the beginning of the mission
 void timer_start_mission();

--- a/code/io/timer.h
+++ b/code/io/timer.h
@@ -72,11 +72,16 @@ void timer_pause_timestamp(bool sudo);
 // See above re: the sudo parameter
 void timer_unpause_timestamp(bool sudo);
 
+enum class TIMER_DIRECTION { FORWARD, BACKWARD };
 // Use with caution!
-void timer_adjust(float delta_seconds);
+void timer_adjust(float delta_seconds, TIMER_DIRECTION dir);
+void timer_adjust_microseconds(uint64_t delta_microseconds, TIMER_DIRECTION dir);
 
 // Save the timestamp corresponding to the beginning of the mission
 void timer_start_mission();
+
+// Restore the timestamp corresponding to the beginning of the mission, since we essentially start time twice
+void timer_revert_to_mission_start();
 
 // Calculate the current mission time using the timestamps
 fix timer_get_mission_time();

--- a/code/io/timer.h
+++ b/code/io/timer.h
@@ -63,28 +63,14 @@ extern int timer_get_seconds();				// seconds since program started... not accur
 // scale it correctly.
 #define TIMESTAMP_FREQUENCY 1000
 
-// This should be called when the timestamp should stop ticking, e.g when the game is paused.
-// The "sudo" is for cases where we want the time to remain paused, e.g. during level loading,
-//     even if the game loses focus (which would normally unpause when focus is regained)
-void timer_pause_timestamp(bool sudo);
+// use this call to get the current counter value (which represents the time at the time
+// this function is called).  I.e. it doesn't return a count that would be in the future,
+// but the count that is right now.
+int timestamp();
 
-// This should be called when the timestamp should resume ticking, e.g. when the player is in-mission.
-// See above re: the sudo parameter
-void timer_unpause_timestamp(bool sudo);
-
-enum class TIMER_DIRECTION { FORWARD, BACKWARD };
-// Use with caution!
-void timer_adjust(float delta_seconds, TIMER_DIRECTION dir);
-void timer_adjust_microseconds(uint64_t delta_microseconds, TIMER_DIRECTION dir);
-
-// Save the timestamp corresponding to the beginning of the mission
-void timer_start_mission();
-
-// Restore the timestamp corresponding to the beginning of the mission, since we essentially start time twice
-void timer_revert_to_mission_start();
-
-// Calculate the current mission time using the timestamps
-fix timer_get_mission_time();
+inline bool timestamp_valid(int stamp) {
+	return stamp != 0;
+}
 
 // To do timing, call this with the interval you
 // want to check.  Then, pass this to timestamp_elapsed
@@ -99,16 +85,18 @@ fix timer_get_mission_time();
 // pass n > 0 for timestamp n milliseconds in the future.
 int timestamp(int delta_ms );
 
-// use this call to get the current counter value (which represents the time at the time
-// this function is called).  I.e. it doesn't return a count that would be in the future,
-// but the count that is right now.
-int timestamp();
-
 // gets a timestamp randomly between a and b milliseconds in
 // the future.
 inline int timestamp_rand(int a, int b) {
 	return timestamp(Random::next(a, b));
 }
+
+//	Returns milliseconds until timestamp will elapse.
+int timestamp_until(int stamp);
+
+// checks if a specified time (in milliseconds) has elapsed past the given timestamp (which
+// should be obtained from timestamp() or timestamp(x) with a positive x)
+int timestamp_has_time_elapsed(int stamp, int time);
 
 // Example that makes a ship fire in 1/2 second
 
@@ -120,19 +108,38 @@ inline int timestamp_rand(int a, int b) {
 
 bool timestamp_elapsed( int stamp );
 
-inline bool timestamp_valid(int stamp) {
-	return stamp != 0;
-}
-
-//	Returns millliseconds until timestamp will elapse.
-int timestamp_until(int stamp);
-
-// checks if a specified time (in milliseconds) has elapsed past the given timestamp (which
-// should be obtained from timestamp() or timestamp(x) with a positive x)
-int timestamp_has_time_elapsed(int stamp, int time);
-
 // safer version of timestamp
 bool timestamp_elapsed_safe(int a, int b);
 
+//=================================================================
+//               T I M E S T A M P   A D J U S T M E N T
+//=================================================================
+
+// This should be called when the timestamp should stop ticking, e.g when the game is paused.
+// The "sudo" is for cases where we want the time to remain paused, e.g. during level loading,
+//     even if the game loses focus (which would normally unpause when focus is regained)
+void timer_pause_timestamp(bool sudo);
+
+// This should be called when the timestamp should resume ticking, e.g. when the player is in-mission.
+// See above re: the sudo parameter
+void timer_unpause_timestamp(bool sudo);
+
+enum class TIMER_DIRECTION { FORWARD, BACKWARD };
+// Use with caution!
+void timer_adjust(float delta_seconds, TIMER_DIRECTION dir);
+void timer_adjust_microseconds(uint64_t delta_microseconds, TIMER_DIRECTION dir);
+
+//=================================================================
+//               M I S S I O N   T I M E
+//=================================================================
+
+// Save the timestamp corresponding to the beginning of the mission
+void timer_start_mission();
+
+// Restore the timestamp corresponding to the beginning of the mission, since we essentially start time twice
+void timer_revert_to_mission_start();
+
+// Calculate the current mission time using the timestamps
+fix timer_get_mission_time();
 
 #endif

--- a/code/io/timer.h
+++ b/code/io/timer.h
@@ -129,6 +129,8 @@ enum class TIMER_DIRECTION { FORWARD, BACKWARD };
 void timer_adjust(float delta_seconds, TIMER_DIRECTION dir);
 void timer_adjust_microseconds(uint64_t delta_microseconds, TIMER_DIRECTION dir);
 
+void timer_update_time_compression();
+
 //=================================================================
 //               M I S S I O N   T I M E
 //=================================================================

--- a/code/io/timer.h
+++ b/code/io/timer.h
@@ -118,30 +118,32 @@ bool timestamp_elapsed_safe(int a, int b);
 // This should be called when the timestamp should stop ticking, e.g when the game is paused.
 // The "sudo" is for cases where we want the time to remain paused, e.g. during level loading,
 //     even if the game loses focus (which would normally unpause when focus is regained)
-void timer_pause_timestamp(bool sudo);
+void timestamp_pause(bool sudo);
 
 // This should be called when the timestamp should resume ticking, e.g. when the player is in-mission.
 // See above re: the sudo parameter
-void timer_unpause_timestamp(bool sudo);
+void timestamp_unpause(bool sudo);
 
 enum class TIMER_DIRECTION { FORWARD, BACKWARD };
-// Use with caution!
-void timer_adjust(float delta_seconds, TIMER_DIRECTION dir);
-void timer_adjust_microseconds(uint64_t delta_microseconds, TIMER_DIRECTION dir);
+// Alters the timestamp time forward or backward.  Use with caution!
+void timestamp_adjust_seconds(float delta_seconds, TIMER_DIRECTION dir);
+void timestamp_adjust_microseconds(uint64_t delta_microseconds, TIMER_DIRECTION dir);
 
-void timer_update_time_compression();
+// This should be called when the game time compression is changed in any way, so that
+// the timestamp will be consistent with the faster or slower time.
+void timestamp_update_time_compression();
 
 //=================================================================
 //               M I S S I O N   T I M E
 //=================================================================
 
 // Save the timestamp corresponding to the beginning of the mission
-void timer_start_mission();
+void timestamp_start_mission();
 
 // Restore the timestamp corresponding to the beginning of the mission, since we essentially start time twice
-void timer_revert_to_mission_start();
+void timestamp_revert_to_mission_start();
 
 // Calculate the current mission time using the timestamps
-fix timer_get_mission_time();
+fix timestamp_get_mission_time();
 
 #endif

--- a/code/menuui/credits.cpp
+++ b/code/menuui/credits.cpp
@@ -457,6 +457,8 @@ void credits_init()
 		}
 	}
 
+	game_start_time();
+
 	// Use this id to trigger the start of music playing on the briefing screen
 	Credits_music_begin_timestamp = timestamp(Credits_music_delay);
 
@@ -661,8 +663,6 @@ void credits_close()
 	}	
 	Credits_bmps.clear();
 
-	credits_stop_music(true);
-
 	Credit_text_parts.clear();
 
 	if (Background_bitmap){
@@ -671,6 +671,11 @@ void credits_close()
 
 	Ui_window.destroy();
 	common_free_interface_palette();		// restore game palette
+
+
+	// non-UI stuff
+	game_stop_time();
+	credits_stop_music(true);
 }
 
 void credits_do_frame(float  /*frametime*/)
@@ -837,7 +842,6 @@ void credits_do_frame(float  /*frametime*/)
 
 	Credits_frametime = temp_time - Credits_last_time;
 	Credits_last_time = temp_time;
-	timestamp_inc(i2f(Credits_frametime) / TIMESTAMP_FREQUENCY);
 
 	float fl_frametime = i2fl(Credits_frametime) / 1000.f;
 	if (keyd_pressed[KEY_LSHIFT]) {

--- a/code/menuui/credits.cpp
+++ b/code/menuui/credits.cpp
@@ -457,8 +457,6 @@ void credits_init()
 		}
 	}
 
-	game_start_time();
-
 	// Use this id to trigger the start of music playing on the briefing screen
 	Credits_music_begin_timestamp = timestamp(Credits_music_delay);
 
@@ -674,7 +672,6 @@ void credits_close()
 
 
 	// non-UI stuff
-	game_stop_time();
 	credits_stop_music(true);
 }
 

--- a/code/network/multi.cpp
+++ b/code/network/multi.cpp
@@ -1493,9 +1493,6 @@ void standalone_main_init()
 	multi_xfer_reset();
 	multi_xfer_force_dir(CF_TYPE_MULTI_CACHE);
 
-	// reset timer
-	timestamp_reset();
-
 	// setup a blank pilot (this is a standalone usage only!)
 	Pilot.load_player(NULL);
 

--- a/code/popup/popup.cpp
+++ b/code/popup/popup.cpp
@@ -575,7 +575,7 @@ void popup_close(popup_info *pi, int screen_id)
 	Popup_is_active = 0;
 	Popup_running_state = 0;
 
-	// anytime in single player, and multiplayer, not in mission, go ahead and stop time
+	// anytime in single player, and multiplayer, not in mission, go ahead and resume time
 	if ( (Game_mode & GM_NORMAL) || ((Game_mode & GM_MULTIPLAYER) && !(Game_mode & GM_IN_MISSION)) )
 		game_start_time();
 }

--- a/code/scripting/api/libs/mission.cpp
+++ b/code/scripting/api/libs/mission.cpp
@@ -1208,7 +1208,6 @@ ADE_FUNC(loadMission, l_Mission, "string missionName", "Loads a mission", "boole
 	gr_post_process_set_defaults();
 
 	//NOW do the loading stuff
-	game_stop_time();
 	get_mission_info(s, &The_mission, false);
 	game_level_init();
 

--- a/fred2/fredstubs.cpp
+++ b/fred2/fredstubs.cpp
@@ -183,7 +183,7 @@ int Test_begin;
 int Debug_octant;
 int Framerate_delay;
 void game_start_time(bool){}
-void game_stop_time(){}
+void game_stop_time(bool){}
 int game_get_default_skill_level(){return 0;}
 int find_freespace_cd(char*){return 0;}
 void game_do_state_common(int, int){}

--- a/fred2/fredstubs.cpp
+++ b/fred2/fredstubs.cpp
@@ -182,7 +182,7 @@ void game_leave_state(int, int){}
 int Test_begin;
 int Debug_octant;
 int Framerate_delay;
-void game_start_time(){}
+void game_start_time(bool){}
 void game_stop_time(){}
 int game_get_default_skill_level(){return 0;}
 int find_freespace_cd(char*){return 0;}

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -4207,6 +4207,7 @@ void game_set_frametime(int state)
 {
 	fix thistime;
 	float frame_cap_diff;
+	bool do_pre_player_skip = false;
 
 	thistime = timer_get_fixed_seconds();
 
@@ -4220,8 +4221,10 @@ void game_set_frametime(int state)
 #endif
 
 	//	If player hasn't entered mission yet, make frame take 1/4 second.
-	if ((Pre_player_entry) && (state == GS_STATE_GAME_PLAY))
+	if ((Pre_player_entry) && (state == GS_STATE_GAME_PLAY)) {
 		Frametime = F1_0/4;
+		do_pre_player_skip = true;
+	}
 #ifndef NDEBUG
 	else if ((Debug_dump_frames) && (state == GS_STATE_GAME_PLAY)) {				// note link to above if!!!!!
 	
@@ -4300,6 +4303,10 @@ void game_set_frametime(int state)
 	Last_frame_timestamp = timestamp();
 
 	flFrametime = f2fl(Frametime);
+
+	// before the player enters the mission, we blitz through time
+	if (do_pre_player_skip)
+		timer_adjust(flFrametime);
 
 	// wrap overall frametime if needed
 	if ( FrametimeOverall > (INT_MAX - F1_0) )

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -3944,8 +3944,10 @@ void game_frame(bool paused)
 			}
 		}
 	
-		if (Missiontime > Entry_delay_time)
+		if (Pre_player_entry && Missiontime > Entry_delay_time) {
 			Pre_player_entry = 0;
+			event_music_set_start_delay();
+		}
 
 		//	Note: These are done even before the player enters, else buffers can overflow.
 		if (! (Game_mode & GM_STANDALONE_SERVER)){

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -4185,6 +4185,8 @@ void change_time_compression(float multiplier)
 
 	Desired_time_compression = Game_time_compression = modified;
 	Time_compression_change_rate = 0;
+
+	timer_update_time_compression();
 }
 
 void set_time_compression(float multiplier, float change_time)
@@ -4193,6 +4195,8 @@ void set_time_compression(float multiplier, float change_time)
 	{
 		Game_time_compression = Desired_time_compression = fl2f(multiplier);
 		Time_compression_change_rate = 0;
+
+		timer_update_time_compression();
 		return;
 	}
 
@@ -4265,10 +4269,16 @@ void game_set_frametime(int state)
 	{
 		bool ascending = Desired_time_compression > Game_time_compression;
 		if(Time_compression_change_rate)
+		{
 			Game_time_compression += fixmul(Time_compression_change_rate, Frametime);
+			timer_update_time_compression();
+		}
 		if((ascending && Game_time_compression > Desired_time_compression)
 			|| (!ascending && Game_time_compression < Desired_time_compression))
+		{
 			Game_time_compression = Desired_time_compression;
+			timer_update_time_compression();
+		}
 	}
 
 	Frametime = fixmul(Frametime, Game_time_compression);

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -4127,7 +4127,7 @@ void game_time_level_init()
 	game_stop_time();
 
 	Missiontime = 0;
-	timer_start_mission();
+	timestamp_start_mission();
 }
 
 void game_time_level_close()
@@ -4153,7 +4153,7 @@ void game_stop_time(bool by_os_focus)
 
 	// Stop the timer_tick stuff...
 	// We always want to 'sudo' the change, unless this is caused by the focus, because we want the game to have priority in that case
-	timer_pause_timestamp(!by_os_focus);
+	timestamp_pause(!by_os_focus);
 }
 
 void game_start_time(bool by_os_focus)
@@ -4171,7 +4171,7 @@ void game_start_time(bool by_os_focus)
 
 	// Restore the timer_tick stuff...
 	// We always want to 'sudo' the change, unless this is caused by the focus, because we want the game to have priority in that case
-	timer_unpause_timestamp(!by_os_focus);
+	timestamp_unpause(!by_os_focus);
 }
 
 void lock_time_compression(bool is_locked)
@@ -4186,7 +4186,7 @@ void change_time_compression(float multiplier)
 	Desired_time_compression = Game_time_compression = modified;
 	Time_compression_change_rate = 0;
 
-	timer_update_time_compression();
+	timestamp_update_time_compression();
 }
 
 void set_time_compression(float multiplier, float change_time)
@@ -4196,7 +4196,7 @@ void set_time_compression(float multiplier, float change_time)
 		Game_time_compression = Desired_time_compression = fl2f(multiplier);
 		Time_compression_change_rate = 0;
 
-		timer_update_time_compression();
+		timestamp_update_time_compression();
 		return;
 	}
 
@@ -4271,13 +4271,13 @@ void game_set_frametime(int state)
 		if(Time_compression_change_rate)
 		{
 			Game_time_compression += fixmul(Time_compression_change_rate, Frametime);
-			timer_update_time_compression();
+			timestamp_update_time_compression();
 		}
 		if((ascending && Game_time_compression > Desired_time_compression)
 			|| (!ascending && Game_time_compression < Desired_time_compression))
 		{
 			Game_time_compression = Desired_time_compression;
-			timer_update_time_compression();
+			timestamp_update_time_compression();
 		}
 	}
 
@@ -4297,7 +4297,7 @@ void game_set_frametime(int state)
 
 	// before the player enters the mission, we blitz through time
 	if (do_pre_player_skip)
-		timer_adjust(flFrametime, TIMER_DIRECTION::FORWARD);
+		timestamp_adjust_seconds(flFrametime, TIMER_DIRECTION::FORWARD);
 
 	// wrap overall frametime if needed
 	if ( FrametimeOverall > (INT_MAX - F1_0) )
@@ -4313,14 +4313,14 @@ fix game_get_overall_frametime()
 
 void game_update_missiontime()
 {
-	Missiontime = timer_get_mission_time();
+	Missiontime = timestamp_get_mission_time();
 }
 
 void game_do_frame(bool set_frametime)
 {
 	if (Missiontime == 0) {
 		// reset the timestamps to the beginning, since they were running in the briefing screens
-		timer_revert_to_mission_start();
+		timestamp_revert_to_mission_start();
 	}
 
 	if (set_frametime) {

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -345,11 +345,6 @@ extern void ssm_process();
 // I figure out how to get the username into the file
 //LOCAL char freespace_build_time[] = "Compiled on:"__DATE__" "__TIME__" by "__USER__;
 
-// defines and variables used for dumping frame for making trailers.
-#ifndef NDEBUG
-int Debug_dump_frames = 0;			// Set to 0 to not dump frames, else equal hz to dump. (15 or 30 probably)
-#endif
-
 // amount of time to wait after the player has died before we display the death died popup
 #define PLAYER_DIED_POPUP_WAIT		2500
 int Player_died_popup_wait = -1;
@@ -2101,11 +2096,6 @@ void game_show_framerate()
 			gr_printf_no_resize( gr_screen.center_offset_x + 20, gr_screen.center_offset_y + 100 - line_height, "BMPMAN: %d/%d", bmpman_count_bitmaps(), bmpman_count_available_slots() );
 		}
 	}
-
-#ifndef NDEBUG
-	if ( Debug_dump_frames )
-		return;
-#endif	
 
 	// possibly show control checking info
 	control_check_indicate();
@@ -4227,22 +4217,6 @@ void game_set_frametime(int state)
 		Frametime = F1_0/4;
 		do_pre_player_skip = true;
 	}
-#ifndef NDEBUG
-	else if ((Debug_dump_frames) && (state == GS_STATE_GAME_PLAY)) {				// note link to above if!!!!!
-	
-		fix frame_speed = F1_0 / Debug_dump_frames;
-
-		if (Frametime > frame_speed ){
-			nprintf(("warning","slow frame: %x\n",(int)Frametime));
-		} else {			
-			do {
-				thistime = timer_get_fixed_seconds();
-				Frametime = thistime - Last_time;
-			} while (Frametime < frame_speed );			
-		}
-		Frametime = frame_speed;
-	}
-#endif
 
 	Assertion( Framerate_cap > 0, "Framerate cap %d is too low. Needs to be a positive, non-zero number", Framerate_cap );
 
@@ -4934,7 +4908,7 @@ void game_process_event( int current_state, int event )
 			break;
 
 		case GS_EVENT_GAME_INIT:
-			// see if the command line option has been set to use the last pilot, and act acoordingly
+			// see if the command line option has been set to use the last pilot, and act accordingly
 			if( player_select_get_last_pilot() ) {	
 				// always enter the main menu -- do the automatic network startup stuff elsewhere
 				// so that we still have valid checks for networking modes, etc.

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -4148,12 +4148,12 @@ void game_stop_time(bool by_os_focus)
 		if (Last_delta_time < 0) {
 			Last_delta_time = 0;
 		}
-
-		// Stop the timer_tick stuff...
-		// We always want to 'sudo' the change, unless this is caused by the focus, because we want the game to have priority in that case
-		timer_pause_timestamp(!by_os_focus);
 	}
 	Time_paused = true;
+
+	// Stop the timer_tick stuff...
+	// We always want to 'sudo' the change, unless this is caused by the focus, because we want the game to have priority in that case
+	timer_pause_timestamp(!by_os_focus);
 }
 
 void game_start_time(bool by_os_focus)
@@ -4166,12 +4166,12 @@ void game_start_time(bool by_os_focus)
 		// will be correct when it goes to calculate the frametime next
 		// frame.
 		Last_time = time - Last_delta_time;		
-
-		// Restore the timer_tick stuff...
-		// We always want to 'sudo' the change, unless this is caused by the focus, because we want the game to have priority in that case
-		timer_unpause_timestamp(!by_os_focus);
 	}
 	Time_paused = false;
+
+	// Restore the timer_tick stuff...
+	// We always want to 'sudo' the change, unless this is caused by the focus, because we want the game to have priority in that case
+	timer_unpause_timestamp(!by_os_focus);
 }
 
 void lock_time_compression(bool is_locked)

--- a/freespace2/freespace.h
+++ b/freespace2/freespace.h
@@ -98,7 +98,7 @@ void game_level_close();
 void game_stop_time();
 
 // start the game (mission) timer
-void game_start_time();
+void game_start_time(bool lazy_start = false);
 
 // call whenever in a loop or if you need to get a keypress
 int game_check_key();

--- a/freespace2/freespace.h
+++ b/freespace2/freespace.h
@@ -95,10 +95,10 @@ void game_level_close();
 // gameplay stuff -----------------------------------------------------
 
 // stop the game (mission) timer
-void game_stop_time();
+void game_stop_time(bool by_os_focus = false);
 
 // start the game (mission) timer
-void game_start_time(bool lazy_start = false);
+void game_start_time(bool by_os_focus = false);
 
 // call whenever in a loop or if you need to get a keypress
 int game_check_key();

--- a/qtfred/src/fredstubs.cpp
+++ b/qtfred/src/fredstubs.cpp
@@ -186,8 +186,8 @@ void game_leave_state(int, int){}
 int Test_begin;
 int Debug_octant;
 int Framerate_delay;
-void game_start_time(){}
-void game_stop_time(){}
+void game_start_time(bool){}
+void game_stop_time(bool){}
 int game_get_default_skill_level(){return 0;}
 int find_freespace_cd(char*){return 0;}
 void game_do_state_common(int, int){}

--- a/test/src/test_stubs.cpp
+++ b/test/src/test_stubs.cpp
@@ -191,7 +191,7 @@ int Test_begin;
 int Debug_octant;
 int Framerate_delay;
 void game_start_time(bool){}
-void game_stop_time(){}
+void game_stop_time(bool){}
 int game_get_default_skill_level(){return 0;}
 int find_freespace_cd(char*){return 0;}
 void game_do_state_common(int, int){}

--- a/test/src/test_stubs.cpp
+++ b/test/src/test_stubs.cpp
@@ -190,7 +190,7 @@ void game_leave_state(int, int){}
 int Test_begin;
 int Debug_octant;
 int Framerate_delay;
-void game_start_time(){}
+void game_start_time(bool){}
 void game_stop_time(){}
 int game_get_default_skill_level(){return 0;}
 int find_freespace_cd(char*){return 0;}


### PR DESCRIPTION
Previously, the game used a dead-reckoning system for measuring time, where several time counters were incremented as long as time was running.  This unfortunately has no way to synchronize time in the long term, and therefore in-game time will tend to run faster or slower than real time by a few percent, depending on various factors.

This PR redesigns the timestamp system to use the SDL time counter which will always keep it in sync with real time.  However this necessarily involves a bit of clever handling when the game is paused and unpaused.  It also revealed several minor bugs in several places in the code where timestamps were handled.

~~This PR is currently in draft status until the design can be updated to handle time compression.  In all other respects it should be working.~~  ~~The PR will be rebased after #3878 is merged.~~

Fixes #3854.

EDIT:

This should have several benefits:
1) Music and mission events will now be consistently synchronized across computers
2) Mission message timestamps will now match the mission time counter
3) Timestamps will no longer lose accuracy at high time compressions