### PR TITLE
Add tonemapping options to lab render settings

### DIFF
--- a/code/lab/dialogs/render_options.cpp
+++ b/code/lab/dialogs/render_options.cpp
@@ -1,5 +1,6 @@
 #include "lab/labv2_internal.h"
 #include "lab/dialogs/render_options.h"
+#include "lighting/lighting_profiles.h"
 
 void set_model_rotation_flag(Checkbox* caller) {
 	auto value = caller->GetChecked();
@@ -153,6 +154,12 @@ void set_bloom(Slider* caller) {
 	getLabManager()->Renderer->setBloomLevel(fl2i(value));
 }
 
+void set_exposure(Slider* caller) {
+	auto value = caller->GetSliderValue();
+
+	getLabManager()->Renderer->setExposureLevel(value);
+}
+
 void change_detail_texture(Tree* caller) {
 	auto detail = (TextureQuality)caller->GetSelectedItem()->GetData();
 
@@ -163,6 +170,12 @@ void change_aa_setting(Tree* caller) {
 	auto setting = (AntiAliasMode)caller->GetSelectedItem()->GetData();
 
 	LabRenderer::setAAMode(setting);
+}
+
+void change_tonemapper_setting(Tree* caller) {
+	auto setting = (TonemapperAlgorithm)caller->GetSelectedItem()->GetData();
+
+	LabRenderer::setTonemapper(setting);
 }
 
 void RenderOptions::open(Button* /*caller*/) {
@@ -257,6 +270,12 @@ void RenderOptions::open(Button* /*caller*/) {
 	dialogWindow->AddChild(bloom_sldr);
 	y += bloom_sldr->GetHeight() + 2;
 
+	auto exposure_sldr= new Slider("Exposure", 0, 80, 0, y + 2, set_exposure, dialogWindow->GetWidth());
+	exposure_sldr->SetSliderValue(lighting_profile::current_exposure());
+	dialogWindow->AddChild(exposure_sldr);
+	y += exposure_sldr->GetHeight() + 2;
+
+
 	// start tree
 	auto cmp = (Tree*)dialogWindow->AddChild(new Tree("Detail Options Tree", 0, y + 2, nullptr, dialogWindow->GetWidth()));
 
@@ -279,5 +298,16 @@ void RenderOptions::open(Button* /*caller*/) {
 	cmp->AddItem(aa_header, "SMAA Medium", (int)AntiAliasMode::SMAA_Medium, false, change_aa_setting);
 	cmp->AddItem(aa_header, "SMAA High",   (int)AntiAliasMode::SMAA_High,   false, change_aa_setting);
 	cmp->AddItem(aa_header, "SMAA Ultra",  (int)AntiAliasMode::SMAA_Ultra,  false, change_aa_setting);
+
+	auto tonemapper = cmp->AddItem(nullptr, "Tonemapper", 0, false);
+	cmp->AddItem(tonemapper, "Linear", (int)TonemapperAlgorithm::tnm_Linear, false, change_tonemapper_setting );
+	cmp->AddItem(tonemapper, "Uncharted", (int)TonemapperAlgorithm::tnm_Uncharted, false, change_tonemapper_setting );
+	cmp->AddItem(tonemapper, "ACES", (int)TonemapperAlgorithm::tnm_Aces, false, change_tonemapper_setting );
+	cmp->AddItem(tonemapper, "ACES Approximate", (int)TonemapperAlgorithm::tnm_Aces_Approx, false, change_tonemapper_setting );
+	cmp->AddItem(tonemapper, "Cineon", (int)TonemapperAlgorithm::tnm_Cineon, false, change_tonemapper_setting );
+	cmp->AddItem(tonemapper, "Piecewise Power Curve", (int)TonemapperAlgorithm::tnm_PPC, false, change_tonemapper_setting );
+	cmp->AddItem(tonemapper, "Piecewise Power Curve(RGB)", (int)TonemapperAlgorithm::tnm_PPC_RGB, false, change_tonemapper_setting );
+	cmp->AddItem(tonemapper, "Reinhard Extended", (int)TonemapperAlgorithm::tnm_Reinhard_Extended, false, change_tonemapper_setting );
+	cmp->AddItem(tonemapper, "Reinhard Jodie", (int)TonemapperAlgorithm::tnm_Reinhard_Jodie, false, change_tonemapper_setting );
 
 }

--- a/code/lab/dialogs/render_options.cpp
+++ b/code/lab/dialogs/render_options.cpp
@@ -270,7 +270,7 @@ void RenderOptions::open(Button* /*caller*/) {
 	dialogWindow->AddChild(bloom_sldr);
 	y += bloom_sldr->GetHeight() + 2;
 
-	auto exposure_sldr= new Slider("Exposure", 0, 80, 0, y + 2, set_exposure, dialogWindow->GetWidth());
+	auto exposure_sldr= new Slider("Exposure", 0, 8, 0, y + 2, set_exposure, dialogWindow->GetWidth());
 	exposure_sldr->SetSliderValue(lighting_profile::current_exposure());
 	dialogWindow->AddChild(exposure_sldr);
 	y += exposure_sldr->GetHeight() + 2;

--- a/code/lab/dialogs/render_options.cpp
+++ b/code/lab/dialogs/render_options.cpp
@@ -308,6 +308,7 @@ void RenderOptions::open(Button* /*caller*/) {
 	exposure_sldr->SetSliderValue(lighting_profile::current_exposure());
 	dialogWindow->AddChild(exposure_sldr);
 	y += exposure_sldr->GetHeight() + 2;
+
 	auto ppcv = lighting_profile::lab_get_ppc();
 
 	auto ppcts_sldr= new Slider("PPC: Toe Strength", 0, 1, 0, y + 2, set_ppc_ts, dialogWindow->GetWidth());
@@ -334,6 +335,7 @@ void RenderOptions::open(Button* /*caller*/) {
 	ppcss_sldr->SetSliderValue(ppcv.shoulder_strength);
 	dialogWindow->AddChild(ppcss_sldr);
 	y += ppcss_sldr->GetHeight() + 2;
+
 	// start tree
 	auto cmp = (Tree*)dialogWindow->AddChild(new Tree("Detail Options Tree", 0, y + 2, nullptr, dialogWindow->GetWidth()));
 
@@ -357,6 +359,7 @@ void RenderOptions::open(Button* /*caller*/) {
 	cmp->AddItem(aa_header, "SMAA High",   (int)AntiAliasMode::SMAA_High,   false, change_aa_setting);
 	cmp->AddItem(aa_header, "SMAA Ultra",  (int)AntiAliasMode::SMAA_Ultra,  false, change_aa_setting);
 
+	//see lighting_profiles.h for documentation and lighting_profiles.cpp for implementation of these options
 	auto tonemapper = cmp->AddItem(nullptr, "Tonemapper", 0, false);
 	cmp->AddItem(tonemapper, "Linear", (int)TonemapperAlgorithm::tnm_Linear, false, change_tonemapper_setting );
 	cmp->AddItem(tonemapper, "Uncharted", (int)TonemapperAlgorithm::tnm_Uncharted, false, change_tonemapper_setting );

--- a/code/lab/dialogs/render_options.cpp
+++ b/code/lab/dialogs/render_options.cpp
@@ -160,6 +160,40 @@ void set_exposure(Slider* caller) {
 	getLabManager()->Renderer->setExposureLevel(value);
 }
 
+void set_ppc_ts(Slider* caller) {
+	auto value = caller->GetSliderValue();
+	auto ppcv = lighting_profile::lab_get_ppc();
+	ppcv.toe_strength = value;
+	getLabManager()->Renderer->setPPCValues(ppcv);
+}
+
+void set_ppc_tl(Slider* caller) {
+	auto value = caller->GetSliderValue();
+	auto ppcv = lighting_profile::lab_get_ppc();
+	ppcv.toe_length = value;
+	getLabManager()->Renderer->setPPCValues(ppcv);
+}
+
+void set_ppc_sa(Slider* caller) {
+	auto value = caller->GetSliderValue();
+	auto ppcv = lighting_profile::lab_get_ppc();
+	ppcv.shoulder_angle = value;
+	getLabManager()->Renderer->setPPCValues(ppcv);
+}
+
+void set_ppc_sl(Slider* caller) {
+	auto value = caller->GetSliderValue();
+	auto ppcv = lighting_profile::lab_get_ppc();
+	ppcv.shoulder_length = value;
+	getLabManager()->Renderer->setPPCValues(ppcv);
+}
+
+void set_ppc_ss(Slider* caller) {
+	auto value = caller->GetSliderValue();
+	auto ppcv = lighting_profile::lab_get_ppc();
+	ppcv.shoulder_strength = value;
+	getLabManager()->Renderer->setPPCValues(ppcv);
+}
 void change_detail_texture(Tree* caller) {
 	auto detail = (TextureQuality)caller->GetSelectedItem()->GetData();
 
@@ -274,8 +308,32 @@ void RenderOptions::open(Button* /*caller*/) {
 	exposure_sldr->SetSliderValue(lighting_profile::current_exposure());
 	dialogWindow->AddChild(exposure_sldr);
 	y += exposure_sldr->GetHeight() + 2;
+	auto ppcv = lighting_profile::lab_get_ppc();
 
+	auto ppcts_sldr= new Slider("PPC: Toe Strength", 0, 1, 0, y + 2, set_ppc_ts, dialogWindow->GetWidth());
+	ppcts_sldr->SetSliderValue(ppcv.toe_strength);
+	dialogWindow->AddChild(ppcts_sldr);
+	y += ppcts_sldr->GetHeight() + 2;
 
+	auto ppctl_sldr= new Slider("PPC: Toe Length", 0, 1, 0, y + 2, set_ppc_tl, dialogWindow->GetWidth());
+	ppcts_sldr->SetSliderValue(ppcv.toe_length);
+	dialogWindow->AddChild(ppctl_sldr);
+	y += ppctl_sldr->GetHeight() + 2;
+
+	auto ppcsa_sldr= new Slider("PPC: Shoudler Angle", 0, 1, 0, y + 2, set_ppc_sa, dialogWindow->GetWidth());
+	ppcsa_sldr->SetSliderValue(ppcv.shoulder_angle);
+	dialogWindow->AddChild(ppcsa_sldr);
+	y += ppcsa_sldr->GetHeight() + 2;
+
+	auto ppcsl_sldr= new Slider("PPC: Shoulder Length", 0, 10, 0, y + 2, set_ppc_sl, dialogWindow->GetWidth());
+	ppcsl_sldr->SetSliderValue(ppcv.shoulder_length);
+	dialogWindow->AddChild(ppcsl_sldr);
+	y += ppcsl_sldr->GetHeight() + 2;
+
+	auto ppcss_sldr= new Slider("PPC: Shoulder Strength", 0, 1, 0, y + 2, set_ppc_ss, dialogWindow->GetWidth());
+	ppcss_sldr->SetSliderValue(ppcv.shoulder_strength);
+	dialogWindow->AddChild(ppcss_sldr);
+	y += ppcss_sldr->GetHeight() + 2;
 	// start tree
 	auto cmp = (Tree*)dialogWindow->AddChild(new Tree("Detail Options Tree", 0, y + 2, nullptr, dialogWindow->GetWidth()));
 

--- a/code/lab/renderer/lab_renderer.cpp
+++ b/code/lab/renderer/lab_renderer.cpp
@@ -3,6 +3,7 @@
 #include "lab/wmcgui.h"
 #include "graphics/2d.h"
 #include "graphics/light.h"
+#include "lighting/lighting_profiles.h"
 #include "starfield/starfield.h"
 #include "starfield/nebula.h"
 #include "nebula/neb.h"

--- a/code/lab/renderer/lab_renderer.h
+++ b/code/lab/renderer/lab_renderer.h
@@ -161,6 +161,10 @@ public:
 		lighting_profile::lab_set_exposure(level);
 		return level;
 	}
+	
+	static void setPPCValues(piecewise_power_curve_values ppcv) {
+		lighting_profile::lab_set_ppc(ppcv);
+	}
 
 	void setTextureQuality(TextureQuality quality) { textureQuality = quality; }
 

--- a/code/lab/renderer/lab_renderer.h
+++ b/code/lab/renderer/lab_renderer.h
@@ -3,6 +3,7 @@
 #include "globalincs/pstypes.h"
 #include "globalincs/flagset.h"
 #include "graphics/2d.h"
+#include "lighting/lighting_profiles.h"
 #include "camera/camera.h"
 #include "cmdline/cmdline.h"
 #include "lab/renderer/lab_cameras.h"
@@ -101,6 +102,10 @@ public:
 		Motion_debris_override = false;
 	}
 
+	static void setTonemapper(TonemapperAlgorithm mode) {
+		lighting_profile::lab_set_tonemapper(mode);
+	}
+
 	void useNextTeamColorPreset() {
 		auto color_itr = Team_Colors.find(currentTeamColor);
 
@@ -151,6 +156,12 @@ public:
 		return level; 
 	}
 
+	float setExposureLevel(float level) {
+		exposureLevel = level;
+		lighting_profile::lab_set_exposure(level);
+		return level;
+	}
+
 	void setTextureQuality(TextureQuality quality) { textureQuality = quality; }
 
 	void setTextureOverride(TextureOverride, bool) {};
@@ -165,6 +176,7 @@ private:
 	int ambientFactor;
 	float directionalFactor;
 	int bloomLevel;
+	float exposureLevel;
 	TextureQuality textureQuality;
 	SCP_string currentTeamColor;
 	SCP_string currentMissionBackground;

--- a/code/lighting/lighting_profiles.cpp
+++ b/code/lighting/lighting_profiles.cpp
@@ -183,9 +183,18 @@ piecewise_power_curve_intermediates lighting_profile::calc_intermediates(piecewi
 }
 void lighting_profile::lab_set_exposure(float exIn){
 	default_profile.exposure = exIn;
-};
+}
 
 
 void lighting_profile::lab_set_tonemapper(TonemapperAlgorithm tnin){
 	default_profile.tonemapper = tnin;
-};
+}
+
+void lighting_profile::lab_set_ppc(piecewise_power_curve_values ppcin ){
+	default_profile.ppc_values = ppcin;
+
+}
+
+piecewise_power_curve_values lighting_profile::lab_get_ppc(){
+	return default_profile.ppc_values;
+}

--- a/code/lighting/lighting_profiles.cpp
+++ b/code/lighting/lighting_profiles.cpp
@@ -1,6 +1,7 @@
 #include "globalincs/pstypes.h"
 #include "globalincs/safe_strings.h"
 #include "globalincs/vmallocator.h"
+#include "def_files/def_files.h"
 #include "lighting/lighting.h"
 #include "lighting/lighting_profiles.h"
 #include "parse/parselo.h"
@@ -180,3 +181,11 @@ piecewise_power_curve_intermediates lighting_profile::calc_intermediates(piecewi
 	return ppci;
 
 }
+void lighting_profile::lab_set_exposure(float exIn){
+	default_profile.exposure = exIn;
+};
+
+
+void lighting_profile::lab_set_tonemapper(TonemapperAlgorithm tnin){
+	default_profile.tonemapper = tnin;
+};

--- a/code/lighting/lighting_profiles.h
+++ b/code/lighting/lighting_profiles.h
@@ -53,6 +53,8 @@ public:
 	static float current_exposure();
 	static void lab_set_exposure(float exIn);
 	static void lab_set_tonemapper(TonemapperAlgorithm tnin);
+	static void lab_set_ppc(piecewise_power_curve_values ppcin );
+	static piecewise_power_curve_values lab_get_ppc();
 
 
 	SCP_string name;

--- a/code/lighting/lighting_profiles.h
+++ b/code/lighting/lighting_profiles.h
@@ -51,6 +51,9 @@ public:
 	static piecewise_power_curve_intermediates current_piecewise_intermediates();
 	static piecewise_power_curve_intermediates calc_intermediates(piecewise_power_curve_values input);
 	static float current_exposure();
+	static void lab_set_exposure(float exIn);
+	static void lab_set_tonemapper(TonemapperAlgorithm tnin);
+
 
 	SCP_string name;
     TonemapperAlgorithm tonemapper;


### PR DESCRIPTION
This punches a bunch of holes in the abstraction of light profiles that I will want to revisit when I get light profiles fully featured, but this is too useful for previewing different settings to sit on until then.