### PR TITLE
Fix Particles `pageIn()` to use actual number of frames

### DIFF
--- a/code/particle/util/ParticleProperties.cpp
+++ b/code/particle/util/ParticleProperties.cpp
@@ -73,8 +73,11 @@ WeakParticlePtr ParticleProperties::createPersistentParticle(particle_info& info
 
 void ParticleProperties::pageIn() {
 
-	for (int bitmap: m_bitmap_list) {
-		bm_page_in_aabitmap(bitmap, -1);
+	int nframes = 1;
+
+	for (int bitmap : m_bitmap_list) {
+		bm_get_info(bitmap, nullptr, nullptr, nullptr, &nframes);
+		bm_page_in_aabitmap(bitmap, nframes);
 	}
 
 }


### PR DESCRIPTION
Previously the `bm_page_in_aabitmap` call in `ParticleProperties::pageIn()` used -1 as the number of frames. It seemed particles with more than 1 frame still worked correctly, but likely prevent preloading of particles. This PR fixes that to use the actual number of frames. Fixes #3706  

Thanks for @notimaginative for catching this. Would be useful to have review by @asarium even though it's just a few lines.  