### PR TITLE
Fix shadow check on lightshafts

### DIFF
--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -722,7 +722,7 @@ void game_sunspot_process(float frametime)
 			for(idx=0; idx<n_lights; idx++)	{
 				bool in_shadow = shipfx_eye_in_shadow(&Eye_position, Viewer_obj, idx);
 
-				if (gr_lightshafts_enabled() || !in_shadow) {
+				if (gr_lightshafts_enabled() && !in_shadow) {
 					vec3d light_dir;				
 					light_get_global_dir(&light_dir, idx);
 


### PR DESCRIPTION
This appears to be a bug present since the initial lightshafts code was added, while a check is made to see if the sun is occluded, the `||` conditional short circuits, and causes lightshafts to always be rendered:

![image](https://user-images.githubusercontent.com/2259858/147971006-109c5329-6907-4aa3-886c-31ec7298068a.png)

Had a quick discussion with @TRBlount and @EatThePath and we all agreed that the original intention was probably to block lightshaft rendering when the sun was occluded, so `&&` would make more sense.