### PR TITLE
Fix Particle `PageIn()` (V2)

### DIFF
--- a/code/particle/util/ParticleProperties.cpp
+++ b/code/particle/util/ParticleProperties.cpp
@@ -73,11 +73,8 @@ WeakParticlePtr ParticleProperties::createPersistentParticle(particle_info& info
 
 void ParticleProperties::pageIn() {
 
-	int nframes = 1;
-
 	for (int bitmap : m_bitmap_list) {
-		bm_get_info(bitmap, nullptr, nullptr, nullptr, &nframes);
-		bm_page_in_aabitmap(bitmap, nframes);
+		bm_page_in_texture(bitmap);
 	}
 
 }


### PR DESCRIPTION
It turns out the particle preloading fix revealed a long standing bug in the particle `pageIn()` function--it should be calling `bm_page_in_texture()` instead of `bm_page_in_aabitmap()`. It's been wrong the entire time and we didn't notice because of the frame bug, which was fixed in #3884. Without this fix, when it's preloaded it locks the image as 8-bit, when it force loads it's 24-bit. 

Tested and works as expected. Fixes #3890. It also has the added benefit of making the code cleaner because the `bm_page_in_texture()` loads the frames if none are specified. 

Massive thanks to taylor for spotting this!