### PR TITLE
Fix 3892 Amendment

### DIFF
--- a/code/pilotfile/csg.cpp
+++ b/code/pilotfile/csg.cpp
@@ -1211,7 +1211,7 @@ void pilotfile::csg_write_settings()
 
 void pilotfile::csg_read_controls()
 {
-	if (version < 7) {
+	if (csg_ver < 7) {
 		// Pre CSG-7 compatibility
 		int idx, list_size;
 		short id1, id2, id3 __UNUSED;


### PR DESCRIPTION
Use correct version var when inside CSG stuffs.

*LOVE* that action at a distance!