### PR TITLE
Fix #3901: Inverted Controls Don't Save

### DIFF
--- a/code/controlconfig/controlsconfig.cpp
+++ b/code/controlconfig/controlsconfig.cpp
@@ -1584,7 +1584,7 @@ void control_config_close()
 	Undo_controls.clear();
 }
 
-SCP_vector<CC_preset>::iterator control_config_get_current_preset() {
+SCP_vector<CC_preset>::iterator control_config_get_current_preset(bool invert_agnostic) {
 	// Find the matching preset.
 	// We do this instead of relying on Defaults_cycle_pos because the player may end up duplicating a preset
 	auto it = Control_config_presets.begin();
@@ -1600,19 +1600,39 @@ SCP_vector<CC_preset>::iterator control_config_get_current_preset() {
 				continue;
 			}
 
-			// Check Primary
-			if (!Control_config[i].first.invert_agnostic_equals(it->bindings[i].first)) {
-				// Isn't a match, stop checking this preset
-				is_match = false;
-				break;
-			}
+			if (invert_agnostic) {
+				// Check for binding equality, ignoring invert flag
+				// Check Primary
+				if (!Control_config[i].first.invert_agnostic_equals(it->bindings[i].first)) {
+					// Isn't a match, stop checking this preset
+					is_match = false;
+					break;
+				}
 
-			// Check Secondary
-			if (!Control_config[i].second.invert_agnostic_equals(it->bindings[i].second)) {
-				// Isn't a match, stop checking this preset
-				is_match = false;
-				break;
+				// Check Secondary
+				if (!Control_config[i].second.invert_agnostic_equals(it->bindings[i].second)) {
+					// Isn't a match, stop checking this preset
+					is_match = false;
+					break;
+				}
+
+			} else {
+				// Check for binding exact equality
+				// Check Primary
+				if (Control_config[i].first != it->bindings[i].first) {
+					// Isn't a match, stop checking this preset
+					is_match = false;
+					break;
+				}
+
+				// Check Secondary
+				if (Control_config[i].second != it->bindings[i].second) {
+					// Isn't a match, stop checking this preset
+					is_match = false;
+					break;
+				}
 			}
+			
 		}
 
 		if (is_match) {

--- a/code/controlconfig/controlsconfig.h
+++ b/code/controlconfig/controlsconfig.h
@@ -701,10 +701,12 @@ bool control_config_use_preset_by_name(const SCP_string &name);
 /**
  * @brief Gets the currently used preset
  *
+ * @param[in] invert_agnostic  If true, check the bindings in Control_config against the preset, ignoring inversion flags
+ * 
  * @returns an iterator to the current preset, or
  * @returns ::iterator Control_config_presets.end() if current bindings are not in a preset
  */
-SCP_vector<CC_preset>::iterator control_config_get_current_preset();
+SCP_vector<CC_preset>::iterator control_config_get_current_preset(bool invert_agnostic = false);
 
 /*!
  * Returns the IoActionId (index within Control_config[]) of a control bound to the given key

--- a/code/pilotfile/csg.cpp
+++ b/code/pilotfile/csg.cpp
@@ -1230,7 +1230,8 @@ void pilotfile::csg_read_controls()
 		}
 
 		// Check that these bindings are in a preset.
-		auto it = control_config_get_current_preset();
+		// CSG doesn't save invert flags, so use agnostic equals
+		auto it = control_config_get_current_preset(true);
 		if (it == Control_config_presets.end()) {
 			// Not a preset, create one and its file
 			CC_preset preset;


### PR DESCRIPTION
Preset identification should only be invert agnostic when reading a CSG<7 file, for all other uses of control_config_get_current_preset(), it should be exact equality with the preset.

Agnostic equals was added by @Goober5000 to address an issue with LUA scripts that attempted to invert axes controls.  In addition, there was a bug where a tester was switching back and forth between pre-Controls5 test builds only to have the conversion process continously trigger, because the CSG files did not save the invert flag and its generated preset was not exactly equal with the preset generated by his player file or current bindings.  PLR files did have the invert flag in them, however.

!!Notice!! I don't have time right now to do a full build test nor a run test, so please test this before merging.

Switching back and forth between pre and post builds may work, but another bug (Issue #3902 ) may cause a crash if you try to do so, should the "controls" key in the PLR.json get deleted (or rather not written) if you have a new pilot created in Controls5.  The workaround to this currently is to have an old pilotfile from before Controls5 be converted, or manually edit in an empty "controls: []" section in the .json.

