### PR TITLE
Fix text overflow on multi-related screen

### DIFF
--- a/code/graphics/2d.h
+++ b/code/graphics/2d.h
@@ -983,6 +983,9 @@ extern void gr_get_string_size( int *w, int *h, const char * text, int len = 999
 // Returns the height of the current font
 extern int gr_get_font_height();
 
+// Returns a scaled amount of lines per the current font --wookieejedi
+extern int gr_get_dyanmic_font_lines(int number_default_lines);
+
 extern io::mouse::Cursor* Web_cursor;
 
 // Called by OS when application gets/looses focus

--- a/code/graphics/2d.h
+++ b/code/graphics/2d.h
@@ -984,7 +984,7 @@ extern void gr_get_string_size( int *w, int *h, const char * text, int len = 999
 extern int gr_get_font_height();
 
 // Returns a scaled amount of lines per the current font --wookieejedi
-extern int gr_get_dyanmic_font_lines(int number_default_lines);
+extern int gr_get_dynamic_font_lines(int number_default_lines);
 
 extern io::mouse::Cursor* Web_cursor;
 

--- a/code/graphics/software/font.cpp
+++ b/code/graphics/software/font.cpp
@@ -667,6 +667,10 @@ int gr_get_font_height()
 	}
 }
 
+int gr_get_dyanmic_font_lines(int number_default_lines) {
+	return fl2i((number_default_lines * 10) / (gr_get_font_height() + 1));
+}
+
 void gr_get_string_size(int *w1, int *h1, const char *text, int len)
 {
 	if (!FontManager::isReady())

--- a/code/graphics/software/font.cpp
+++ b/code/graphics/software/font.cpp
@@ -667,7 +667,7 @@ int gr_get_font_height()
 	}
 }
 
-int gr_get_dyanmic_font_lines(int number_default_lines) {
+int gr_get_dynamic_font_lines(int number_default_lines) {
 	return fl2i((number_default_lines * 10) / (gr_get_font_height() + 1));
 }
 

--- a/code/graphics/software/font.cpp
+++ b/code/graphics/software/font.cpp
@@ -668,6 +668,7 @@ int gr_get_font_height()
 }
 
 int gr_get_dynamic_font_lines(int number_default_lines) {
+	// the default font height (font01) is 9, thus the *10 --wookieejedi
 	return fl2i((number_default_lines * 10) / (gr_get_font_height() + 1));
 }
 

--- a/code/missionui/chatbox.cpp
+++ b/code/missionui/chatbox.cpp
@@ -342,7 +342,7 @@ void chatbox_set_mode(int mode_flags)
 		Chatbox_begin_x = Chatbox_small_display_coords[gr_screen.res][CHATBOX_X_COORD];
 		Chatbox_begin_y = Chatbox_small_display_coords[gr_screen.res][CHATBOX_Y_COORD];
 		Chatbox_disp_w = Chatbox_small_display_coords[gr_screen.res][CHATBOX_W_COORD];
-		Chatbox_max_lines = Chatbox_small_max_lines[gr_screen.res];
+		Chatbox_max_lines = gr_get_dyanmic_font_lines(Chatbox_small_max_lines[gr_screen.res]);
 		Chatbox_inputbox_x = Chatbox_small_input_coords[gr_screen.res][CHATBOX_X_COORD];
 		Chatbox_inputbox_w = Chatbox_small_input_coords[gr_screen.res][CHATBOX_W_COORD];
 		Chatbox_textenter_y = Chatbox_small_input_coords[gr_screen.res][CHATBOX_Y_COORD];		
@@ -358,7 +358,7 @@ void chatbox_set_mode(int mode_flags)
 		Chatbox_begin_x = Chatbox_big_display_coords[gr_screen.res][CHATBOX_X_COORD];
 		Chatbox_begin_y = Chatbox_big_display_coords[gr_screen.res][CHATBOX_Y_COORD];
 		Chatbox_disp_w = Chatbox_big_display_coords[gr_screen.res][CHATBOX_W_COORD];
-		Chatbox_max_lines = Chatbox_big_max_lines[gr_screen.res];
+		Chatbox_max_lines = gr_get_dyanmic_font_lines(Chatbox_big_max_lines[gr_screen.res]);
 		Chatbox_inputbox_x = Chatbox_big_input_coords[gr_screen.res][CHATBOX_X_COORD];
 		Chatbox_inputbox_w = Chatbox_big_input_coords[gr_screen.res][CHATBOX_W_COORD];
 		Chatbox_textenter_y = Chatbox_big_input_coords[gr_screen.res][CHATBOX_Y_COORD];		
@@ -373,7 +373,7 @@ void chatbox_set_mode(int mode_flags)
 		Chatbox_begin_x = Chatbox_p_display_coords[gr_screen.res][CHATBOX_X_COORD];
 		Chatbox_begin_y = Chatbox_p_display_coords[gr_screen.res][CHATBOX_Y_COORD];
 		Chatbox_disp_w = Chatbox_p_display_coords[gr_screen.res][CHATBOX_W_COORD];
-		Chatbox_max_lines = Chatbox_p_max_lines[gr_screen.res];
+		Chatbox_max_lines = gr_get_dyanmic_font_lines(Chatbox_p_max_lines[gr_screen.res]);
 		Chatbox_inputbox_x = Chatbox_p_input_coords[gr_screen.res][CHATBOX_X_COORD];
 		Chatbox_inputbox_w = Chatbox_p_input_coords[gr_screen.res][CHATBOX_W_COORD];
 		Chatbox_textenter_y = Chatbox_p_input_coords[gr_screen.res][CHATBOX_Y_COORD];

--- a/code/missionui/chatbox.cpp
+++ b/code/missionui/chatbox.cpp
@@ -342,7 +342,7 @@ void chatbox_set_mode(int mode_flags)
 		Chatbox_begin_x = Chatbox_small_display_coords[gr_screen.res][CHATBOX_X_COORD];
 		Chatbox_begin_y = Chatbox_small_display_coords[gr_screen.res][CHATBOX_Y_COORD];
 		Chatbox_disp_w = Chatbox_small_display_coords[gr_screen.res][CHATBOX_W_COORD];
-		Chatbox_max_lines = gr_get_dyanmic_font_lines(Chatbox_small_max_lines[gr_screen.res]);
+		Chatbox_max_lines = gr_get_dynamic_font_lines(Chatbox_small_max_lines[gr_screen.res]);
 		Chatbox_inputbox_x = Chatbox_small_input_coords[gr_screen.res][CHATBOX_X_COORD];
 		Chatbox_inputbox_w = Chatbox_small_input_coords[gr_screen.res][CHATBOX_W_COORD];
 		Chatbox_textenter_y = Chatbox_small_input_coords[gr_screen.res][CHATBOX_Y_COORD];		
@@ -358,7 +358,7 @@ void chatbox_set_mode(int mode_flags)
 		Chatbox_begin_x = Chatbox_big_display_coords[gr_screen.res][CHATBOX_X_COORD];
 		Chatbox_begin_y = Chatbox_big_display_coords[gr_screen.res][CHATBOX_Y_COORD];
 		Chatbox_disp_w = Chatbox_big_display_coords[gr_screen.res][CHATBOX_W_COORD];
-		Chatbox_max_lines = gr_get_dyanmic_font_lines(Chatbox_big_max_lines[gr_screen.res]);
+		Chatbox_max_lines = gr_get_dynamic_font_lines(Chatbox_big_max_lines[gr_screen.res]);
 		Chatbox_inputbox_x = Chatbox_big_input_coords[gr_screen.res][CHATBOX_X_COORD];
 		Chatbox_inputbox_w = Chatbox_big_input_coords[gr_screen.res][CHATBOX_W_COORD];
 		Chatbox_textenter_y = Chatbox_big_input_coords[gr_screen.res][CHATBOX_Y_COORD];		
@@ -373,7 +373,7 @@ void chatbox_set_mode(int mode_flags)
 		Chatbox_begin_x = Chatbox_p_display_coords[gr_screen.res][CHATBOX_X_COORD];
 		Chatbox_begin_y = Chatbox_p_display_coords[gr_screen.res][CHATBOX_Y_COORD];
 		Chatbox_disp_w = Chatbox_p_display_coords[gr_screen.res][CHATBOX_W_COORD];
-		Chatbox_max_lines = gr_get_dyanmic_font_lines(Chatbox_p_max_lines[gr_screen.res]);
+		Chatbox_max_lines = gr_get_dynamic_font_lines(Chatbox_p_max_lines[gr_screen.res]);
 		Chatbox_inputbox_x = Chatbox_p_input_coords[gr_screen.res][CHATBOX_X_COORD];
 		Chatbox_inputbox_w = Chatbox_p_input_coords[gr_screen.res][CHATBOX_W_COORD];
 		Chatbox_textenter_y = Chatbox_p_input_coords[gr_screen.res][CHATBOX_Y_COORD];

--- a/code/network/multi_pxo.cpp
+++ b/code/network/multi_pxo.cpp
@@ -2660,7 +2660,7 @@ void multi_pxo_blit_channels()
 
 		// next item
 		moveup = moveup->next;
-	} while((moveup != Multi_pxo_channels) && (disp_count < gr_get_dyanmic_font_lines(Multi_pxo_max_chan_display[gr_screen.res])));
+	} while((moveup != Multi_pxo_channels) && (disp_count < gr_get_dynamic_font_lines(Multi_pxo_max_chan_display[gr_screen.res])));
 }
 
 /**
@@ -2692,7 +2692,7 @@ void multi_pxo_scroll_channels_down()
 	}
 
 	// if we can't scroll further without going past the end of the viewable list, don't
-	if((Multi_pxo_channel_start_index + gr_get_dyanmic_font_lines(Multi_pxo_max_chan_display[gr_screen.res]) >= Multi_pxo_channel_count)){
+	if((Multi_pxo_channel_start_index + gr_get_dynamic_font_lines(Multi_pxo_max_chan_display[gr_screen.res]) >= Multi_pxo_channel_count)){
 		gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 		return;
 	}
@@ -3070,7 +3070,7 @@ void multi_pxo_blit_players()
 
 		// next item
 		moveup = moveup->next;
-	} while((moveup != Multi_pxo_players) && (disp_count < gr_get_dyanmic_font_lines(Multi_pxo_max_player_display[gr_screen.res])));
+	} while((moveup != Multi_pxo_players) && (disp_count < gr_get_dynamic_font_lines(Multi_pxo_max_player_display[gr_screen.res])));
 }
 
 /**
@@ -3111,7 +3111,7 @@ void multi_pxo_scroll_players_down()
 	}
 	
 	// if we can move down
-	if(count >= gr_get_dyanmic_font_lines(Multi_pxo_max_player_display[gr_screen.res])){
+	if(count >= gr_get_dynamic_font_lines(Multi_pxo_max_player_display[gr_screen.res])){
 		Multi_pxo_player_start = Multi_pxo_player_start->next;
 		gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 	} else {
@@ -3254,7 +3254,7 @@ void multi_pxo_chat_add_line(const char *txt, int mode)
 	}
 
 	// set the count
-	Multi_pxo_chat_slider.set_numberItems(Multi_pxo_chat_count > gr_get_dyanmic_font_lines(Multi_pxo_max_chat_display[gr_screen.res]) ? Multi_pxo_chat_count - gr_get_dyanmic_font_lines(Multi_pxo_max_chat_display[gr_screen.res]) : 0, 0);		// the 0 means don't reset
+	Multi_pxo_chat_slider.set_numberItems(Multi_pxo_chat_count > gr_get_dynamic_font_lines(Multi_pxo_max_chat_display[gr_screen.res]) ? Multi_pxo_chat_count - gr_get_dynamic_font_lines(Multi_pxo_max_chat_display[gr_screen.res]) : 0, 0);		// the 0 means don't reset
 
 	multi_pxo_goto_bottom();
 }
@@ -3373,7 +3373,7 @@ void multi_pxo_chat_blit()
 	disp_count = 0;
 	y_start = Multi_pxo_chat_coords[gr_screen.res][1];
 	line_height = gr_get_font_height() + 1;
-	while((moveup != nullptr) && (moveup != Multi_pxo_chat_add) && (disp_count < (gr_get_dyanmic_font_lines(Multi_pxo_max_chat_display[gr_screen.res])))){
+	while((moveup != nullptr) && (moveup != Multi_pxo_chat_add) && (disp_count < (gr_get_dynamic_font_lines(Multi_pxo_max_chat_display[gr_screen.res])))){
 		switch(moveup->mode){
 		// if this is text from the server, display it all "bright"
 		case CHAT_MODE_SERVER:				
@@ -3448,7 +3448,7 @@ void multi_pxo_goto_bottom()
 	}
 	
 	// if we have less than the displayable amount of lines, do nothing
-	if(Multi_pxo_chat_count <= gr_get_dyanmic_font_lines(Multi_pxo_max_chat_display[gr_screen.res])){
+	if(Multi_pxo_chat_count <= gr_get_dynamic_font_lines(Multi_pxo_max_chat_display[gr_screen.res])){
 		Multi_pxo_chat_start = Multi_pxo_chat;						
 		
 		// nothing to do for the slider
@@ -3460,7 +3460,7 @@ void multi_pxo_goto_bottom()
 	{
 		// otherwise move back the right # of items
 		backup = Multi_pxo_chat_add;	
-		for(idx=0; idx<gr_get_dyanmic_font_lines(Multi_pxo_max_chat_display[gr_screen.res]); idx++){
+		for(idx=0; idx<gr_get_dynamic_font_lines(Multi_pxo_max_chat_display[gr_screen.res]); idx++){
 			Assert(backup->prev != NULL);
 			backup = backup->prev;		
 		}
@@ -3511,7 +3511,7 @@ int multi_pxo_can_scroll_down()
 	}
 	
 	// check if we can move down, return accordingly
-	if (count > gr_get_dyanmic_font_lines(Multi_pxo_max_chat_display[gr_screen.res])) {
+	if (count > gr_get_dynamic_font_lines(Multi_pxo_max_chat_display[gr_screen.res])) {
 		return 1;
 	} else {
 		return 0;

--- a/code/network/multi_pxo.cpp
+++ b/code/network/multi_pxo.cpp
@@ -2660,7 +2660,7 @@ void multi_pxo_blit_channels()
 
 		// next item
 		moveup = moveup->next;
-	} while((moveup != Multi_pxo_channels) && (disp_count < Multi_pxo_max_chan_display[gr_screen.res]));
+	} while((moveup != Multi_pxo_channels) && (disp_count < gr_get_dyanmic_font_lines(Multi_pxo_max_chan_display[gr_screen.res])));
 }
 
 /**
@@ -2692,7 +2692,7 @@ void multi_pxo_scroll_channels_down()
 	}
 
 	// if we can't scroll further without going past the end of the viewable list, don't
-	if((Multi_pxo_channel_start_index + Multi_pxo_max_chan_display[gr_screen.res]) >= Multi_pxo_channel_count){
+	if((Multi_pxo_channel_start_index + gr_get_dyanmic_font_lines(Multi_pxo_max_chan_display[gr_screen.res]) >= Multi_pxo_channel_count)){
 		gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 		return;
 	}
@@ -3070,7 +3070,7 @@ void multi_pxo_blit_players()
 
 		// next item
 		moveup = moveup->next;
-	} while((moveup != Multi_pxo_players) && (disp_count < Multi_pxo_max_player_display[gr_screen.res]));
+	} while((moveup != Multi_pxo_players) && (disp_count < gr_get_dyanmic_font_lines(Multi_pxo_max_player_display[gr_screen.res])));
 }
 
 /**
@@ -3111,7 +3111,7 @@ void multi_pxo_scroll_players_down()
 	}
 	
 	// if we can move down
-	if(count >= Multi_pxo_max_player_display[gr_screen.res]){
+	if(count >= gr_get_dyanmic_font_lines(Multi_pxo_max_player_display[gr_screen.res])){
 		Multi_pxo_player_start = Multi_pxo_player_start->next;
 		gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 	} else {
@@ -3254,7 +3254,7 @@ void multi_pxo_chat_add_line(const char *txt, int mode)
 	}
 
 	// set the count
-	Multi_pxo_chat_slider.set_numberItems(Multi_pxo_chat_count > Multi_pxo_max_chat_display[gr_screen.res] ? Multi_pxo_chat_count - Multi_pxo_max_chat_display[gr_screen.res] : 0, 0);		// the 0 means don't reset
+	Multi_pxo_chat_slider.set_numberItems(Multi_pxo_chat_count > gr_get_dyanmic_font_lines(Multi_pxo_max_chat_display[gr_screen.res]) ? Multi_pxo_chat_count - gr_get_dyanmic_font_lines(Multi_pxo_max_chat_display[gr_screen.res]) : 0, 0);		// the 0 means don't reset
 
 	multi_pxo_goto_bottom();
 }
@@ -3373,7 +3373,7 @@ void multi_pxo_chat_blit()
 	disp_count = 0;
 	y_start = Multi_pxo_chat_coords[gr_screen.res][1];
 	line_height = gr_get_font_height() + 1;
-	while((moveup != NULL) && (moveup != Multi_pxo_chat_add) && (disp_count < (Multi_pxo_max_chat_display[gr_screen.res]))){
+	while((moveup != nullptr) && (moveup != Multi_pxo_chat_add) && (disp_count < (gr_get_dyanmic_font_lines(Multi_pxo_max_chat_display[gr_screen.res])))){
 		switch(moveup->mode){
 		// if this is text from the server, display it all "bright"
 		case CHAT_MODE_SERVER:				
@@ -3448,7 +3448,7 @@ void multi_pxo_goto_bottom()
 	}
 	
 	// if we have less than the displayable amount of lines, do nothing
-	if(Multi_pxo_chat_count <= Multi_pxo_max_chat_display[gr_screen.res]){
+	if(Multi_pxo_chat_count <= gr_get_dyanmic_font_lines(Multi_pxo_max_chat_display[gr_screen.res])){
 		Multi_pxo_chat_start = Multi_pxo_chat;						
 		
 		// nothing to do for the slider
@@ -3460,7 +3460,7 @@ void multi_pxo_goto_bottom()
 	{
 		// otherwise move back the right # of items
 		backup = Multi_pxo_chat_add;	
-		for(idx=0; idx<Multi_pxo_max_chat_display[gr_screen.res]; idx++){
+		for(idx=0; idx<gr_get_dyanmic_font_lines(Multi_pxo_max_chat_display[gr_screen.res]); idx++){
 			Assert(backup->prev != NULL);
 			backup = backup->prev;		
 		}
@@ -3511,7 +3511,7 @@ int multi_pxo_can_scroll_down()
 	}
 	
 	// check if we can move down, return accordingly
-	if (count > Multi_pxo_max_chat_display[gr_screen.res]) {
+	if (count > gr_get_dyanmic_font_lines(Multi_pxo_max_chat_display[gr_screen.res])) {
 		return 1;
 	} else {
 		return 0;

--- a/code/network/multiui.cpp
+++ b/code/network/multiui.cpp
@@ -144,7 +144,7 @@ void multi_common_scroll_text_up()
 void multi_common_scroll_text_down()
 {
 	Multi_common_top_text_line++;
-	if ( (Multi_common_num_text_lines - Multi_common_top_text_line) < Multi_common_text_max_display[gr_screen.res] ) {
+	if ( (Multi_common_num_text_lines - Multi_common_top_text_line) < gr_get_dyanmic_font_lines(Multi_common_text_max_display[gr_screen.res]) ) {
 		Multi_common_top_text_line--;
 		if ( !mouse_down(MOUSE_LEFT_BUTTON) ){
 			gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
@@ -157,11 +157,11 @@ void multi_common_scroll_text_down()
 void multi_common_move_to_bottom()
 {
 	// if there's nowhere to scroll down, do nothing
-	if(Multi_common_num_text_lines <= Multi_common_text_max_display[gr_screen.res]){
+	if(Multi_common_num_text_lines <= gr_get_dyanmic_font_lines(Multi_common_text_max_display[gr_screen.res])){
 		return;
 	}
 		
-	Multi_common_top_text_line = Multi_common_num_text_lines - Multi_common_text_max_display[gr_screen.res];
+	Multi_common_top_text_line = Multi_common_num_text_lines - gr_get_dyanmic_font_lines(Multi_common_text_max_display[gr_screen.res]);
 }
 
 void multi_common_set_text(const char *str,int auto_scroll)
@@ -257,14 +257,14 @@ void multi_common_render_text()
 	line_count = 0;
 	gr_set_color_fast(&Color_text_normal);
 	for ( i = Multi_common_top_text_line; i < Multi_common_num_text_lines; i++ ) {
-		if ( line_count >= Multi_common_text_max_display[gr_screen.res] ){
+		if ( line_count >= gr_get_dyanmic_font_lines(Multi_common_text_max_display[gr_screen.res]) ){
 			break;	
 		}
 		gr_string(Multi_common_text_coords[gr_screen.res][0], Multi_common_text_coords[gr_screen.res][1] + (line_count*fh), Multi_common_text[i], GR_RESIZE_MENU);		
 		line_count++;
 	}
 
-	if ( (Multi_common_num_text_lines - Multi_common_top_text_line) > Multi_common_text_max_display[gr_screen.res] ) {
+	if ( (Multi_common_num_text_lines - Multi_common_top_text_line) > gr_get_dyanmic_font_lines(Multi_common_text_max_display[gr_screen.res]) ) {
 		gr_set_color_fast(&Color_more_bright);
 		gr_string(Multi_common_text_coords[gr_screen.res][0], (Multi_common_text_coords[gr_screen.res][1] + Multi_common_text_coords[gr_screen.res][3])-5, XSTR("more",755), GR_RESIZE_MENU);
 	}
@@ -3553,7 +3553,7 @@ void multi_create_setup_list_data(int mode)
 	}
 
 	// reset the slider
-	Multi_create_slider.set_numberItems(Multi_create_list_count > Multi_create_list_max_display[gr_screen.res] ? Multi_create_list_count-Multi_create_list_max_display[gr_screen.res] : 0);
+	Multi_create_slider.set_numberItems(Multi_create_list_count > gr_get_dyanmic_font_lines(Multi_create_list_max_display[gr_screen.res]) ? Multi_create_list_count-gr_get_dyanmic_font_lines(Multi_create_list_max_display[gr_screen.res]) : 0);
 }
 
 void multi_create_game_init()
@@ -4457,7 +4457,7 @@ void multi_create_list_scroll_up()
 
 void multi_create_list_scroll_down()
 {
-	if((Multi_create_list_count - Multi_create_list_start) > Multi_create_list_max_display[gr_screen.res]){
+	if((Multi_create_list_count - Multi_create_list_start) > gr_get_dyanmic_font_lines(Multi_create_list_max_display[gr_screen.res])){
 		Multi_create_list_start++;		
 
 		gamesnd_play_iface(InterfaceSounds::SCROLL);
@@ -4554,7 +4554,7 @@ void multi_create_list_load_missions()
 		file_list = NULL;
 	}
 
-	Multi_create_slider.set_numberItems(int(Multi_create_mission_list.size()) > Multi_create_list_max_display[gr_screen.res] ? int(Multi_create_mission_list.size())-Multi_create_list_max_display[gr_screen.res] : 0);
+	Multi_create_slider.set_numberItems(int(Multi_create_mission_list.size()) > gr_get_dyanmic_font_lines(Multi_create_list_max_display[gr_screen.res]) ? int(Multi_create_mission_list.size())-gr_get_dyanmic_font_lines(Multi_create_list_max_display[gr_screen.res]) : 0);
 
 	// maybe create a standalone dialog
 	if (Game_mode & GM_STANDALONE_SERVER) {
@@ -4705,7 +4705,7 @@ void multi_create_list_do()
 		}
 		
 		// see if we should drop out
-		if(count == Multi_create_list_max_display[gr_screen.res]){
+		if(count == gr_get_dyanmic_font_lines(Multi_create_list_max_display[gr_screen.res])){
 			break;
 		}
 

--- a/code/network/multiui.cpp
+++ b/code/network/multiui.cpp
@@ -144,7 +144,7 @@ void multi_common_scroll_text_up()
 void multi_common_scroll_text_down()
 {
 	Multi_common_top_text_line++;
-	if ( (Multi_common_num_text_lines - Multi_common_top_text_line) < gr_get_dyanmic_font_lines(Multi_common_text_max_display[gr_screen.res]) ) {
+	if ( (Multi_common_num_text_lines - Multi_common_top_text_line) < gr_get_dynamic_font_lines(Multi_common_text_max_display[gr_screen.res]) ) {
 		Multi_common_top_text_line--;
 		if ( !mouse_down(MOUSE_LEFT_BUTTON) ){
 			gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
@@ -157,11 +157,11 @@ void multi_common_scroll_text_down()
 void multi_common_move_to_bottom()
 {
 	// if there's nowhere to scroll down, do nothing
-	if(Multi_common_num_text_lines <= gr_get_dyanmic_font_lines(Multi_common_text_max_display[gr_screen.res])){
+	if(Multi_common_num_text_lines <= gr_get_dynamic_font_lines(Multi_common_text_max_display[gr_screen.res])){
 		return;
 	}
 		
-	Multi_common_top_text_line = Multi_common_num_text_lines - gr_get_dyanmic_font_lines(Multi_common_text_max_display[gr_screen.res]);
+	Multi_common_top_text_line = Multi_common_num_text_lines - gr_get_dynamic_font_lines(Multi_common_text_max_display[gr_screen.res]);
 }
 
 void multi_common_set_text(const char *str,int auto_scroll)
@@ -257,14 +257,14 @@ void multi_common_render_text()
 	line_count = 0;
 	gr_set_color_fast(&Color_text_normal);
 	for ( i = Multi_common_top_text_line; i < Multi_common_num_text_lines; i++ ) {
-		if ( line_count >= gr_get_dyanmic_font_lines(Multi_common_text_max_display[gr_screen.res]) ){
+		if ( line_count >= gr_get_dynamic_font_lines(Multi_common_text_max_display[gr_screen.res]) ){
 			break;	
 		}
 		gr_string(Multi_common_text_coords[gr_screen.res][0], Multi_common_text_coords[gr_screen.res][1] + (line_count*fh), Multi_common_text[i], GR_RESIZE_MENU);		
 		line_count++;
 	}
 
-	if ( (Multi_common_num_text_lines - Multi_common_top_text_line) > gr_get_dyanmic_font_lines(Multi_common_text_max_display[gr_screen.res]) ) {
+	if ( (Multi_common_num_text_lines - Multi_common_top_text_line) > gr_get_dynamic_font_lines(Multi_common_text_max_display[gr_screen.res]) ) {
 		gr_set_color_fast(&Color_more_bright);
 		gr_string(Multi_common_text_coords[gr_screen.res][0], (Multi_common_text_coords[gr_screen.res][1] + Multi_common_text_coords[gr_screen.res][3])-5, XSTR("more",755), GR_RESIZE_MENU);
 	}
@@ -3553,7 +3553,7 @@ void multi_create_setup_list_data(int mode)
 	}
 
 	// reset the slider
-	Multi_create_slider.set_numberItems(Multi_create_list_count > gr_get_dyanmic_font_lines(Multi_create_list_max_display[gr_screen.res]) ? Multi_create_list_count-gr_get_dyanmic_font_lines(Multi_create_list_max_display[gr_screen.res]) : 0);
+	Multi_create_slider.set_numberItems(Multi_create_list_count > gr_get_dynamic_font_lines(Multi_create_list_max_display[gr_screen.res]) ? Multi_create_list_count-gr_get_dynamic_font_lines(Multi_create_list_max_display[gr_screen.res]) : 0);
 }
 
 void multi_create_game_init()
@@ -4457,7 +4457,7 @@ void multi_create_list_scroll_up()
 
 void multi_create_list_scroll_down()
 {
-	if((Multi_create_list_count - Multi_create_list_start) > gr_get_dyanmic_font_lines(Multi_create_list_max_display[gr_screen.res])){
+	if((Multi_create_list_count - Multi_create_list_start) > gr_get_dynamic_font_lines(Multi_create_list_max_display[gr_screen.res])){
 		Multi_create_list_start++;		
 
 		gamesnd_play_iface(InterfaceSounds::SCROLL);
@@ -4554,7 +4554,7 @@ void multi_create_list_load_missions()
 		file_list = NULL;
 	}
 
-	Multi_create_slider.set_numberItems(int(Multi_create_mission_list.size()) > gr_get_dyanmic_font_lines(Multi_create_list_max_display[gr_screen.res]) ? int(Multi_create_mission_list.size())-gr_get_dyanmic_font_lines(Multi_create_list_max_display[gr_screen.res]) : 0);
+	Multi_create_slider.set_numberItems(int(Multi_create_mission_list.size()) > gr_get_dynamic_font_lines(Multi_create_list_max_display[gr_screen.res]) ? int(Multi_create_mission_list.size())-gr_get_dynamic_font_lines(Multi_create_list_max_display[gr_screen.res]) : 0);
 
 	// maybe create a standalone dialog
 	if (Game_mode & GM_STANDALONE_SERVER) {
@@ -4705,7 +4705,7 @@ void multi_create_list_do()
 		}
 		
 		// see if we should drop out
-		if(count == gr_get_dyanmic_font_lines(Multi_create_list_max_display[gr_screen.res])){
+		if(count == gr_get_dynamic_font_lines(Multi_create_list_max_display[gr_screen.res])){
 			break;
 		}
 


### PR DESCRIPTION
Multiplayer screens such as PXO lobby, chat boxes, and multi-game setup screens had hard coded values for the number of lines to display. These would only work correctly with the default .vf font01 from retail. If a mod or user used a TTF or other .vf font than text would spill over. This PR makes these values take into the account the font used.
![TTF_Spill](https://user-images.githubusercontent.com/14077810/148656323-611e0572-a889-4193-95d5-e20c756421cf.png)

Tested and works as expected with TTF fonts and the retail fonts.  Marking as draft to see what others think.