### PR TITLE
Add AI to Fix Negative Turret Ammo

### DIFF
--- a/code/ai/ai_flags.h
+++ b/code/ai/ai_flags.h
@@ -142,6 +142,7 @@ namespace AI {
 		Reset_last_hit_target_time_for_player_hits,
 		Fighterbay_arrivals_use_carrier_orient, 
 		Fighterbay_departures_use_carrier_orient,
+		Prevent_negative_turret_ammo,
 
 		NUM_VALUES
 	};

--- a/code/ai/ai_profiles.cpp
+++ b/code/ai/ai_profiles.cpp
@@ -594,6 +594,8 @@ void parse_ai_profiles_tbl(const char *filename)
 					}
 				}
 
+				set_flag(profile, "$prevent negative turret ammo:", AI::Profile_Flags::Prevent_negative_turret_ammo);
+
 
 				// if we've been through once already and are at the same place, force a move
 				if (saved_Mp && (saved_Mp == Mp))

--- a/code/ai/ai_profiles.cpp
+++ b/code/ai/ai_profiles.cpp
@@ -761,5 +761,6 @@ void ai_profile_t::reset()
 	}
 	if (mod_supports_version(22, 0, 0)) {
 		flags.set(AI::Profile_Flags::Fighterbay_arrivals_use_carrier_orient);
+		flags.set(AI::Profile_Flags::Prevent_negative_turret_ammo);
 	}
 }

--- a/code/ai/aiturret.cpp
+++ b/code/ai/aiturret.cpp
@@ -1907,6 +1907,7 @@ bool turret_fire_weapon(int weapon_num, ship_subsys *turret, int parent_objnum, 
 						if (swp->primary_bank_ammo[bank_to_fire] >= points) {
 							swp->primary_bank_ammo[bank_to_fire] -= points;
 						} else if ((swp->primary_bank_ammo[bank_to_fire] >= 0) && !(The_mission.ai_profile->flags[AI::Profile_Flags::Prevent_negative_turret_ammo])) {
+							// default behavior allowed ammo to be negative
 							swp->primary_bank_ammo[bank_to_fire] -= points;
 						} else if (!(turret->system_info->flags[Model::Subsystem_Flags::Use_multiple_guns]) && (swp->primary_bank_ammo[bank_to_fire] < 0)) {
 							swp->current_primary_bank++;
@@ -1948,6 +1949,7 @@ bool turret_fire_weapon(int weapon_num, ship_subsys *turret, int parent_objnum, 
 							if (swp->secondary_bank_ammo[bank_to_fire] > 0) {
 								swp->secondary_bank_ammo[bank_to_fire]--;
 							} else if ((swp->secondary_bank_ammo[bank_to_fire] == 0) && !(The_mission.ai_profile->flags[AI::Profile_Flags::Prevent_negative_turret_ammo])) {
+								// default behavior allowed ammo to be negative
 								swp->secondary_bank_ammo[bank_to_fire]--;
 							} else if (!(turret->system_info->flags[Model::Subsystem_Flags::Use_multiple_guns]) && (swp->secondary_bank_ammo[bank_to_fire] < 0)) {
 								swp->current_secondary_bank++;

--- a/code/ai/aiturret.cpp
+++ b/code/ai/aiturret.cpp
@@ -1904,7 +1904,9 @@ bool turret_fire_weapon(int weapon_num, ship_subsys *turret, int parent_objnum, 
 							points = 1;
 						}
 
-						if (swp->primary_bank_ammo[bank_to_fire] >= 0) {
+						if (swp->primary_bank_ammo[bank_to_fire] > 0) {
+							swp->primary_bank_ammo[bank_to_fire] -= points;
+						} else if ((swp->primary_bank_ammo[bank_to_fire] == 0) && !(The_mission.ai_profile->flags[AI::Profile_Flags::Prevent_negative_turret_ammo])) {
 							swp->primary_bank_ammo[bank_to_fire] -= points;
 						} else if (!(turret->system_info->flags[Model::Subsystem_Flags::Use_multiple_guns]) && (swp->primary_bank_ammo[bank_to_fire] < 0)) {
 							swp->current_primary_bank++;
@@ -1943,7 +1945,9 @@ bool turret_fire_weapon(int weapon_num, ship_subsys *turret, int parent_objnum, 
 								swp->secondary_next_slot[bank_to_fire] = 0;
 							}
 
-							if (swp->secondary_bank_ammo[bank_to_fire] >= 0) {
+							if (swp->secondary_bank_ammo[bank_to_fire] > 0) {
+								swp->secondary_bank_ammo[bank_to_fire]--;
+							} else if ((swp->secondary_bank_ammo[bank_to_fire] == 0) && !(The_mission.ai_profile->flags[AI::Profile_Flags::Prevent_negative_turret_ammo])) {
 								swp->secondary_bank_ammo[bank_to_fire]--;
 							} else if (!(turret->system_info->flags[Model::Subsystem_Flags::Use_multiple_guns]) && (swp->secondary_bank_ammo[bank_to_fire] < 0)) {
 								swp->current_secondary_bank++;

--- a/code/ai/aiturret.cpp
+++ b/code/ai/aiturret.cpp
@@ -1904,9 +1904,9 @@ bool turret_fire_weapon(int weapon_num, ship_subsys *turret, int parent_objnum, 
 							points = 1;
 						}
 
-						if (swp->primary_bank_ammo[bank_to_fire] > 0) {
+						if (swp->primary_bank_ammo[bank_to_fire] >= points) {
 							swp->primary_bank_ammo[bank_to_fire] -= points;
-						} else if ((swp->primary_bank_ammo[bank_to_fire] == 0) && !(The_mission.ai_profile->flags[AI::Profile_Flags::Prevent_negative_turret_ammo])) {
+						} else if ((swp->primary_bank_ammo[bank_to_fire] >= 0) && !(The_mission.ai_profile->flags[AI::Profile_Flags::Prevent_negative_turret_ammo])) {
 							swp->primary_bank_ammo[bank_to_fire] -= points;
 						} else if (!(turret->system_info->flags[Model::Subsystem_Flags::Use_multiple_guns]) && (swp->primary_bank_ammo[bank_to_fire] < 0)) {
 							swp->current_primary_bank++;


### PR DESCRIPTION
Previously, turrets with ammo would end up firing one extra shot, resulting in a -1 ammo.

This was because of the check `ammo[bank_to_fire] >= 0`, in `aiturret.cpp`. This PR adds an AI flag to have the turret only fire if the ammo is greater than 0 (`ammo[bank_to_fire] > 0`), as opposed to greater than or equal to 0.

Tested and the flag fix works as expected.