### PR TITLE
Clean up Player_orders

### DIFF
--- a/code/hud/hudsquadmsg.cpp
+++ b/code/hud/hudsquadmsg.cpp
@@ -157,22 +157,22 @@ int keys_used[] = {	KEY_1, KEY_2, KEY_3, KEY_4, KEY_5, KEY_6, KEY_7, KEY_8, KEY_
 SCP_string  Comm_order_types[NUM_COMM_ORDER_TYPES];
 
 std::vector<player_order> Player_orders = {
-	{"attack ship",   "Destroy my target",  299, ATTACK_TARGET_ITEM},
-	{"disable ship",  "Disable my target",	300, DISABLE_TARGET_ITEM },
-	{"disarm ship",	  "Disarm my target",	301, DISARM_TARGET_ITEM },
-	{"disable subsys","Destroy subsystem",	302, DISABLE_SUBSYSTEM_ITEM },
-	{"guard ship",	  "Protect my target",	303, PROTECT_TARGET_ITEM },
-	{"ignore ship",   "Ignore my target",	304, IGNORE_TARGET_ITEM },
-	{"form on wing","Form on my wing",	305, FORMATION_ITEM },
-	{"cover me",	"Cover me",			306, COVER_ME_ITEM },
-	{"attack any",	"Engage enemy",		307, ENGAGE_ENEMY_ITEM },
-	{"dock", "Capture my target",	308, CAPTURE_TARGET_ITEM},
-	{"rearm me", "Rearm me",			309, REARM_REPAIR_ME_ITEM},
-	{"abort rearm", "Abort rearm",		310, ABORT_REARM_REPAIR_ITEM},
-	{"depart", "Depart",				311, DEPART_ITEM},
-	{"stay near me", "Stay near me",		-1, STAY_NEAR_ME_ITEM},
-	{"stay near ship", "Stay near my target",-1, STAY_NEAR_TARGET_ITEM},
-	{"keep safe dist", "Keep safe distance", -1, KEEP_SAFE_DIST_ITEM}
+	player_order("attack ship",   "Destroy my target",  299, ATTACK_TARGET_ITEM),
+	player_order("disable ship",  "Disable my target",	300, DISABLE_TARGET_ITEM ),
+	player_order("disarm ship",	  "Disarm my target",	301, DISARM_TARGET_ITEM ),
+	player_order("disable subsys","Destroy subsystem",	302, DISABLE_SUBSYSTEM_ITEM ),
+	player_order("guard ship",	  "Protect my target",	303, PROTECT_TARGET_ITEM ),
+	player_order("ignore ship",   "Ignore my target",	304, IGNORE_TARGET_ITEM ),
+	player_order("form on wing","Form on my wing",	305, FORMATION_ITEM ),
+	player_order("cover me",	"Cover me",			306, COVER_ME_ITEM ),
+	player_order("attack any",	"Engage enemy",		307, ENGAGE_ENEMY_ITEM ),
+	player_order("dock", "Capture my target",	308, CAPTURE_TARGET_ITEM),
+	player_order("rearm me", "Rearm me",			309, REARM_REPAIR_ME_ITEM),
+	player_order("abort rearm", "Abort rearm",		310, ABORT_REARM_REPAIR_ITEM),
+	player_order("depart", "Depart",				311, DEPART_ITEM),
+	player_order("stay near me", "Stay near me",		-1, STAY_NEAR_ME_ITEM),
+	player_order("stay near ship", "Stay near my target",-1, STAY_NEAR_TARGET_ITEM),
+	player_order("keep safe dist", "Keep safe distance", -1, KEEP_SAFE_DIST_ITEM)
 };
 
 void hud_init_comm_orders()
@@ -194,17 +194,17 @@ void hud_init_comm_orders()
 		Comm_order_types[i] = temp_comm_order_types[i];
 	}
 
-	for(auto& player_order : Player_orders) {
-		player_order.localized_name = XSTR(player_order.hud_name.c_str(), player_order.hud_xstr);
+	for(auto& order : Player_orders) {
+		order.localized_name = XSTR(order.hud_name.c_str(), order.hud_xstr);
 	}
 }
 
 // Text to display on the messaging menu when using the shortcut keys
 const char *comm_order_get_text(int item)
 {
-	for(const auto& player_order : Player_orders){
-		if(player_order.id == item)
-			return player_order.localized_name.c_str();
+	for(const auto& order : Player_orders){
+		if(order.id == item)
+			return order.localized_name.c_str();
 	}
 	
 	UNREACHABLE("Did not find order with id %d!", item);
@@ -827,7 +827,7 @@ bool hud_squadmsg_is_target_order_valid(int order, int find_order, ai_info *aip 
 	}
 
 	// if order is disable subsystem, and no subsystem targeted or no hits, then order not valid
-	if ( (Player_orders[order].id == DISABLE_SUBSYSTEM_ITEM) && ((aip->targeted_subsys == NULL) || (aip->targeted_subsys->current_hits <= 0.0f)) ){
+	if ( (Player_orders[order].id == DISABLE_SUBSYSTEM_ITEM) && ((aip->targeted_subsys == nullptr) || (aip->targeted_subsys->current_hits <= 0.0f)) ){
 		return false;
 	}
 
@@ -1939,7 +1939,7 @@ void hud_squadmsg_ship_command()
 	Num_menu_items = 0;
 	for(size_t order_id : default_orders) {
 		Assert (Num_menu_items < MAX_MENU_ITEMS);
-		MsgItems[Num_menu_items].text = Player_orders[order_id].localized_name.c_str();
+		MsgItems[Num_menu_items].text = Player_orders[order_id].localized_name;
 		MsgItems[Num_menu_items].instance = Player_orders[order_id].id;
 		MsgItems[Num_menu_items].active = 0;
 		// check the bit to see if the command is active
@@ -2411,7 +2411,7 @@ int hud_query_order_issued(const char *to, const char *order_name, const char *t
 	}
 
 	
-	for (i = 0; i < Player_orders.size(); i++)
+	for (i = 0; i < (int) Player_orders.size(); i++)
 		if (!stricmp(order_name, Player_orders[i].hud_name.c_str()))
 			order = Player_orders[i].id;
 

--- a/code/hud/hudsquadmsg.cpp
+++ b/code/hud/hudsquadmsg.cpp
@@ -155,41 +155,25 @@ int keys_used[] = {	KEY_1, KEY_2, KEY_3, KEY_4, KEY_5, KEY_6, KEY_7, KEY_8, KEY_
 
 
 SCP_string  Comm_order_types[NUM_COMM_ORDER_TYPES];
-comm_order Comm_orders[NUM_COMM_ORDER_ITEMS];
 
-
-// Goober5000
-// this is stupid, but localization won't work otherwise
-// Karajorma 
-// moving the defines to a non-temporary array is no less stupid. But at least now the SEXP system can get at them.
-sexp_com_order Sexp_comm_orders[] =
-	{
-		// common stuff
-		{ "Destroy my target",	299,	ATTACK_TARGET_ITEM },
-		{ "Disable my target",	300,	DISABLE_TARGET_ITEM },
-		{ "Disarm my target",	301,	DISARM_TARGET_ITEM },
-		{ "Destroy subsystem",	302,	DISABLE_SUBSYSTEM_ITEM },
-		{ "Protect my target",	303,	PROTECT_TARGET_ITEM },
-		{ "Ignore my target",	304,	IGNORE_TARGET_ITEM },
-		{ "Form on my wing",	305,	FORMATION_ITEM },
-		{ "Cover me",			306,	COVER_ME_ITEM },
-		{ "Engage enemy",		307,	ENGAGE_ENEMY_ITEM },
-
-		// transports mostly
-		{ "Capture my target",	308,	CAPTURE_TARGET_ITEM },
-
-		// support ships
-		{ "Rearm me",			309,	REARM_REPAIR_ME_ITEM },
-		{ "Abort rearm",		310,	ABORT_REARM_REPAIR_ITEM },
-
-		// all ships
-		{ "Depart",				311,	DEPART_ITEM },
-	
-		// extra stuff for support (maintain original comm menu order)
-		{ "Stay near me",		-1,		STAY_NEAR_ME_ITEM},
-		{ "Stay near my target",-1,		STAY_NEAR_TARGET_ITEM},
-		{ "Keep safe distance", -1,		KEEP_SAFE_DIST_ITEM},
-	};
+std::vector<player_order> Player_orders = {
+	{"attack ship",   "Destroy my target",  299, ATTACK_TARGET_ITEM},
+	{"disable ship",  "Disable my target",	300, DISABLE_TARGET_ITEM },
+	{"disarm ship",	  "Disarm my target",	301, DISARM_TARGET_ITEM },
+	{"disable subsys","Destroy subsystem",	302, DISABLE_SUBSYSTEM_ITEM },
+	{"guard ship",	  "Protect my target",	303, PROTECT_TARGET_ITEM },
+	{"ignore ship",   "Ignore my target",	304, IGNORE_TARGET_ITEM },
+	{"form on wing","Form on my wing",	305, FORMATION_ITEM },
+	{"cover me",	"Cover me",			306, COVER_ME_ITEM },
+	{"attack any",	"Engage enemy",		307, ENGAGE_ENEMY_ITEM },
+	{"dock", "Capture my target",	308, CAPTURE_TARGET_ITEM},
+	{"rearm me", "Rearm me",			309, REARM_REPAIR_ME_ITEM},
+	{"abort rearm", "Abort rearm",		310, ABORT_REARM_REPAIR_ITEM},
+	{"depart", "Depart",				311, DEPART_ITEM},
+	{"stay near me", "Stay near me",		-1, STAY_NEAR_ME_ITEM},
+	{"stay near ship", "Stay near my target",-1, STAY_NEAR_TARGET_ITEM},
+	{"keep safe dist", "Keep safe distance", -1, KEEP_SAFE_DIST_ITEM}
+};
 
 void hud_init_comm_orders()
 {
@@ -210,27 +194,22 @@ void hud_init_comm_orders()
 		Comm_order_types[i] = temp_comm_order_types[i];
 	}
 
-	for (i = 0; i < NUM_COMM_ORDER_ITEMS; i++)
-	{
-		Comm_orders[i].name = XSTR(Sexp_comm_orders[i].name, Sexp_comm_orders[i].xstring);
-		Comm_orders[i].item = Sexp_comm_orders[i].item;
+	for(auto& player_order : Player_orders) {
+		player_order.localized_name = XSTR(player_order.hud_name.c_str(), player_order.hud_xstr);
 	}
 }
 
 // Text to display on the messaging menu when using the shortcut keys
 const char *comm_order_get_text(int item)
 {
-	int i;
-
-	for (i = 0; i < NUM_COMM_ORDER_ITEMS; i++)
-	{
-		if (Comm_orders[i].item == item)
-			return Comm_orders[i].name.c_str();
+	for(const auto& player_order : Player_orders){
+		if(player_order.id == item)
+			return player_order.localized_name.c_str();
 	}
-
-	// not found
-	Int3();
-	return NULL;
+	
+	UNREACHABLE("Did not find order with id %d!", item);
+	
+	return nullptr;
 }
 
 SCP_vector<squadmsg_history> Squadmsg_history; 
@@ -344,7 +323,7 @@ bool hud_squadmsg_ship_valid(ship *shipp, object *objp)
 		return false;
 
 	// ship must be accepting ship type orders
-	if ( shipp->orders_accepted == 0)
+	if ( shipp->orders_accepted.empty())
 		return false;
 
 	// if it is a player ship, we must be in multiplayer
@@ -353,8 +332,12 @@ bool hud_squadmsg_ship_valid(ship *shipp, object *objp)
 
 	// if a messaging shortcut, be sure this ship can process the order
 	if ( Msg_shortcut_command != -1 ) {
-		if ( !(shipp->orders_accepted & Msg_shortcut_command) )
+		bool accepts_any = false;
+		for(size_t order : shipp->orders_accepted)
+			accepts_any |= (bool)(Player_orders[order].id & Msg_shortcut_command);
+		if ( !accepts_any )
 			return false;
+		
 		else if ( !hud_squadmsg_ship_order_valid(objp->instance, Msg_shortcut_command) )
 			return false;
 	}
@@ -764,7 +747,8 @@ bool hud_squadmsg_ship_order_valid( int shipnum, int order )
 // to do this action in some cases since all we know is the actual "value" of the order
 bool hud_squadmsg_is_target_order_valid(int order, int find_order, ai_info *aip )
 {
-	int target_objnum, i;
+	int target_objnum;
+	size_t i;
 	ship *shipp, *ordering_shipp;
 	object *objp;
 
@@ -773,16 +757,16 @@ bool hud_squadmsg_is_target_order_valid(int order, int find_order, ai_info *aip 
 
 	// find the comm_menu item for this command
 	if ( find_order ) {
-		for (i = 0; i < NUM_COMM_ORDER_ITEMS; i++ ) {
-			if ( Comm_orders[i].item == order )
+		for (i = 0; i < Player_orders.size(); i++ ) {
+			if ( Player_orders[i].id == order )
 				break;
 		}
-		Assert( i < NUM_COMM_ORDER_ITEMS );
-		order = i;
+		Assert( i < Player_orders.size() );
+		order = (int)i;
 	}
 
 	// orders which don't operate on targets are always valid
-	if ( !(Comm_orders[order].item & TARGET_MESSAGES) )
+	if ( !(Player_orders[order].id & TARGET_MESSAGES) )
 		return true;
 
 	target_objnum = aip->target_objnum;
@@ -809,7 +793,7 @@ bool hud_squadmsg_is_target_order_valid(int order, int find_order, ai_info *aip 
 			return false;
 		}
 		
-		if ( (Comm_orders[order].item == ATTACK_TARGET_ITEM )
+		if ( (Player_orders[order].id == ATTACK_TARGET_ITEM )
 			&& ((Weapon_info[Weapons[objp->instance].weapon_info_index].wi_flags[Weapon::Info_Flags::Bomb]) || (Weapon_info[Weapons[objp->instance].weapon_info_index].wi_flags[Weapon::Info_Flags::Fighter_Interceptable]))
 			&& (Weapons[objp->instance].team != ordering_shipp->team) ) {
 			return true;
@@ -833,24 +817,24 @@ bool hud_squadmsg_is_target_order_valid(int order, int find_order, ai_info *aip 
 	}
 
 	// if the order is a disable order or depart, and the ship is disabled, order isn't active
-	if ( (Comm_orders[order].item == DISABLE_TARGET_ITEM) && (shipp->flags[Ship::Ship_Flags::Disabled]) ){
+	if ( (Player_orders[order].id == DISABLE_TARGET_ITEM) && (shipp->flags[Ship::Ship_Flags::Disabled]) ){
 		return false;
 	}
 
 	// same as above except for disarmed.
-	if ( (Comm_orders[order].item == DISARM_TARGET_ITEM) && ((shipp->subsys_info[SUBSYSTEM_TURRET].type_count == 0) || (shipp->subsys_info[SUBSYSTEM_TURRET].aggregate_current_hits <= 0.0f)) ){
+	if ( (Player_orders[order].id == DISARM_TARGET_ITEM) && ((shipp->subsys_info[SUBSYSTEM_TURRET].type_count == 0) || (shipp->subsys_info[SUBSYSTEM_TURRET].aggregate_current_hits <= 0.0f)) ){
 		return false;
 	}
 
 	// if order is disable subsystem, and no subsystem targeted or no hits, then order not valid
-	if ( (Comm_orders[order].item == DISABLE_SUBSYSTEM_ITEM) && ((aip->targeted_subsys == NULL) || (aip->targeted_subsys->current_hits <= 0.0f)) ){
+	if ( (Player_orders[order].id == DISABLE_SUBSYSTEM_ITEM) && ((aip->targeted_subsys == NULL) || (aip->targeted_subsys->current_hits <= 0.0f)) ){
 		return false;
 	}
 
 	// check based on target's and player's team
-	if ( (shipp->team == ordering_shipp->team) && (FRIENDLY_TARGET_MESSAGES & Comm_orders[order].item) ){
+	if ( (shipp->team == ordering_shipp->team) && (FRIENDLY_TARGET_MESSAGES & Player_orders[order].id) ){
 		return true;
-	} else if ( (shipp->team != ordering_shipp->team) && (ENEMY_TARGET_MESSAGES & Comm_orders[order].item) ){
+	} else if ( (shipp->team != ordering_shipp->team) && (ENEMY_TARGET_MESSAGES & Player_orders[order].id) ){
 		return true;
 	} else {
 		return false;
@@ -927,7 +911,11 @@ void hud_squadmsg_send_to_all_fighters( int command, int player_num )
 
 		// don't send the command if the "wing" won't accept the command.  We do this by looking at
 		// the set of orders accepted for the wing leader
-		if ( !(command & shipp->orders_accepted) )
+		bool accepts_current = false;
+		for(size_t order : shipp->orders_accepted)
+			accepts_current |= (bool)(Player_orders[order].id & command);
+		
+		if ( !accepts_current )
 			continue;
 
 		// send the command to the wing
@@ -963,7 +951,11 @@ void hud_squadmsg_send_to_all_fighters( int command, int player_num )
 			continue;
 
 		// don't send command if ship won't accept if
-		if ( !(command & shipp->orders_accepted) )
+		bool accepts_current = false;
+		for(size_t order : shipp->orders_accepted)
+			accepts_current |= (bool)(Player_orders[order].id & command);
+
+		if ( !accepts_current )
 			continue;
 
 		if (send_message) {
@@ -1925,7 +1917,7 @@ void hud_squadmsg_reinforcement_select()
 void hud_squadmsg_ship_command()
 {
 	int k;
-	int i, orders, default_orders;
+	std::set<size_t> orders, default_orders;
 
 	// when adding ship commands, we must look at the type of ship, and what messages that
 	// ship allows.  First, place all messages that are possible onto the menu, then 
@@ -1936,70 +1928,72 @@ void hud_squadmsg_ship_command()
 		orders = Ships[Msg_instance].orders_accepted;
 		default_orders = ship_get_default_orders_accepted( &Ship_info[Ships[Msg_instance].ship_info_index] );
 	} else {
-
-		default_orders = DEFAULT_MESSAGES;
+		for(size_t i = 0; i < Player_orders.size(); i++){
+			if(Player_orders[i].id & DEFAULT_MESSAGES)
+				default_orders.insert(i);
+		}
 		orders = default_orders;
 	}
 
 	First_menu_item = 0;
 	Num_menu_items = 0;
-	for ( i = 0; i < NUM_COMM_ORDER_ITEMS; i++ ) {
-		// check to see if the comm order should even be added to the menu -- if so, then add it
-		// the order will be activated if the bit is set for the ship.
-		if ( default_orders & Comm_orders[i].item ) {
-			Assert ( Num_menu_items < MAX_MENU_ITEMS );
-			MsgItems[Num_menu_items].text = Comm_orders[i].name.c_str();
-			MsgItems[Num_menu_items].instance = Comm_orders[i].item;
+	for(size_t order_id : default_orders) {
+		Assert (Num_menu_items < MAX_MENU_ITEMS);
+		MsgItems[Num_menu_items].text = Player_orders[order_id].localized_name.c_str();
+		MsgItems[Num_menu_items].instance = Player_orders[order_id].id;
+		MsgItems[Num_menu_items].active = 0;
+		// check the bit to see if the command is active
+		if (orders.find(order_id) != orders.end())
+			MsgItems[Num_menu_items].active = 1;
+
+		// if the order cannot be carried out by the ship, then item should be inactive
+		if ((Msg_instance != MESSAGE_ALL_FIGHTERS) && !hud_squadmsg_ship_order_valid(Msg_instance, Player_orders[order_id].id))
 			MsgItems[Num_menu_items].active = 0;
-			// check the bit to see if the command is active
-			if ( orders & Comm_orders[i].item )
-				MsgItems[Num_menu_items].active = 1;
 
-			// if the order cannot be carried out by the ship, then item should be inactive
-			if ( (Msg_instance != MESSAGE_ALL_FIGHTERS) && !hud_squadmsg_ship_order_valid( Msg_instance, Comm_orders[i].item ) )
-				MsgItems[Num_menu_items].active = 0;
+		// do some other checks to possibly gray out other items.
+		// if no target, remove any items which are associated with the players target
+		if (!hud_squadmsg_is_target_order_valid((int)order_id, 0))
+			MsgItems[Num_menu_items].active = 0;
 
-			// do some other checks to possibly gray out other items.
-			// if no target, remove any items which are associated with the players target
-			if ( !hud_squadmsg_is_target_order_valid(i, 0) )
-				MsgItems[Num_menu_items].active = 0;
+		// if messaging all fighters, see if we should gray out the order if no one will accept it,
+		// or modify the text if only some of the ships will accept it
+		if (Msg_instance == MESSAGE_ALL_FIGHTERS) {
+			ship_obj* so;
+			ship* shipp;
+			int partial_accept, all_accept;            // value which tells us what to do with menu item
 
-			// if messaging all fighters, see if we should gray out the order if no one will accept it,
-			// or modify the text if only some of the ships will accept it
-			if ( Msg_instance == MESSAGE_ALL_FIGHTERS ) {
-				ship_obj *so;
-				ship *shipp;
-				int partial_accept, all_accept;			// value which tells us what to do with menu item
+			all_accept = Player_orders[order_id].id;
+			partial_accept = 0;
+			for (so = GET_FIRST(&Ship_obj_list); so != END_OF_LIST(&Ship_obj_list); so = GET_NEXT(so)) {
 
-				all_accept = Comm_orders[i].item;
-				partial_accept = 0;
-				for ( so = GET_FIRST(&Ship_obj_list); so != END_OF_LIST(&Ship_obj_list); so = GET_NEXT(so) ) {
+				// don't send messge to ships not on player's team, or that are in a wing.
+				shipp = &Ships[Objects[so->objnum].instance];
+				if (shipp->team != Player_ship->team)
+					continue;
 
-					// don't send messge to ships not on player's team, or that are in a wing.
-					shipp = &Ships[Objects[so->objnum].instance];
-					if ( shipp->team != Player_ship->team )
-						continue;
+				// don't send message to non fighter wings
+				if (!(Ship_info[shipp->ship_info_index].is_fighter_bomber()))
+					continue;
 
-					// don't send message to non fighter wings
-					if ( !(Ship_info[shipp->ship_info_index].is_fighter_bomber()) )
-						continue;
-
-					all_accept &= shipp->orders_accepted;		// 'and'ing will either keep this bit set or zero it properly
-					partial_accept |= (shipp->orders_accepted & Comm_orders[i].item);	// 'or'ing will tell us if at least one accepts
-				}
-
-				if ( !all_accept ) {
-					// either modify the text if a partial accept, or grey it out if no one accepts
-					if ( partial_accept ) {
-						MsgItems[Num_menu_items].text += XSTR("(*)", 320);
-					} else {
-						MsgItems[Num_menu_items].active = 0;
-					}
-				}
+				int local_accepted = 0;
+				for(size_t accepted_order : shipp->orders_accepted)
+					local_accepted |= Player_orders[accepted_order].id;
+				all_accept &= local_accepted;        // 'and'ing will either keep this bit set or zero it properly
+				partial_accept |= (local_accepted & Player_orders[order_id].id);    // 'or'ing will tell us if at least one accepts
 			}
 
-			Num_menu_items++;
+			if (!all_accept) {
+				// either modify the text if a partial accept, or grey it out if no one accepts
+				if (partial_accept) {
+					MsgItems[Num_menu_items].text += XSTR("(*)", 320);
+				} else {
+					MsgItems[Num_menu_items].active = 0;
+				}
+			}
 		}
+
+		Num_menu_items++;
+	
 	}
 
 	strcpy_s( Squad_msg_title, XSTR( "What Command", 321) );
@@ -2025,46 +2019,51 @@ void hud_squadmsg_wing_command()
 {
 	int k;
 	wing *wingp;
-	int default_orders, i, orders, shipnum;
+	int shipnum;
 
+	std::set<size_t> default_orders, orders;
+	
 	// when adding commands for wings, we will look at all of the ships in the wing, and create
 	// the order list from that set of ships.  In the future, we may want to do something else....
 
 	wingp = &Wings[Msg_instance];
 
 	// or together all of the orders for all the ships in the wing
-	default_orders = 0;
-	for ( i = 0; i < wingp->current_count; i++ ) {
-		orders = ship_get_default_orders_accepted( &Ship_info[Ships[wingp->ship_index[i]].ship_info_index] );
-		default_orders |= orders;
+	for (int i = 0; i < wingp->current_count; i++ ) {
+		const auto& setAdd = ship_get_default_orders_accepted( &Ship_info[Ships[wingp->ship_index[i]].ship_info_index] );
+		default_orders.insert(setAdd.begin(), setAdd.end());
 	}
-	default_orders &= ~CAPTURE_TARGET_ITEM;		// we cannot capture any target with a wing.
+	
+	for(size_t i = 0; i < Player_orders.size(); i++){
+		if (Player_orders[i].id & CAPTURE_TARGET_ITEM) // we cannot capture any target with a wing.
+			default_orders.erase(i);
+	}
 
 	Num_menu_items = 0;
 	shipnum = wingp->ship_index[wingp->special_ship];
 	Assertion(shipnum >= 0, "Special ship (%d) for wing '%s' has a negative ship_index (%d). This should not happen; get a coder!\n", wingp->special_ship, wingp->name, shipnum);
 	orders = Ships[shipnum].orders_accepted;		// get the orders that the wing leader will accept
-	for ( i = 0; i < NUM_COMM_ORDER_ITEMS; i++ ) {
+	
+	for ( size_t order_id : default_orders ) {
 		// add the set of default orders to the comm menu.  We will currently allow all messages
 		// to be available in the wing.
-		if ( default_orders & Comm_orders[i].item ) {
-			Assert ( Num_menu_items < MAX_MENU_ITEMS );
-			MsgItems[Num_menu_items].text = Comm_orders[i].name;
-			MsgItems[Num_menu_items].instance = Comm_orders[i].item;
+		Assert ( Num_menu_items < MAX_MENU_ITEMS );
+		MsgItems[Num_menu_items].text = Player_orders[order_id].localized_name;
+		MsgItems[Num_menu_items].instance = Player_orders[order_id].id;
+		MsgItems[Num_menu_items].active = 0;
+
+		// possibly grey out the menu item depending on whether or not the "wing" will accept this order
+		// the "wing" won't accept the order if the first ship in the wing doesn't accept it.
+		if ( orders.find(order_id) != orders.end() )
+			MsgItems[Num_menu_items].active = 1;
+
+		// do some other checks to possibly gray out other items.
+		// if no target, remove any items which are associated with the players target
+		if ( !hud_squadmsg_is_target_order_valid((int)order_id, 0) )
 			MsgItems[Num_menu_items].active = 0;
 
-			// possibly grey out the menu item depending on whether or not the "wing" will accept this order
-			// the "wing" won't accept the order if the first ship in the wing doesn't accept it.
-			if ( orders & Comm_orders[i].item )
-				MsgItems[Num_menu_items].active = 1;
-
-			// do some other checks to possibly gray out other items.
-			// if no target, remove any items which are associated with the players target
-			if ( !hud_squadmsg_is_target_order_valid(i, 0) )
-				MsgItems[Num_menu_items].active = 0;
-
-			Num_menu_items++;
-		}
+		Num_menu_items++;
+	
 	}
 
 	
@@ -2243,7 +2242,11 @@ int hud_squadmsg_hotkey_select( int k )
 			continue;
 
 		// be sure that this ship can accept this command
-		if ( !(Ships[objp->instance].orders_accepted & Msg_shortcut_command) )
+		bool accepts_current = false;
+		for(size_t order : Ships[objp->instance].orders_accepted)
+			accepts_current |= (bool)(Player_orders[order].id & Msg_shortcut_command);
+
+		if ( !accepts_current )
 			continue;
 
 		hud_squadmsg_send_ship_command( objp->instance, Msg_shortcut_command, send_message, SQUADMSG_HISTORY_ADD_ENTRY );
@@ -2408,9 +2411,9 @@ int hud_query_order_issued(const char *to, const char *order_name, const char *t
 	}
 
 	
-	for (i = 0; i < NUM_COMM_ORDER_ITEMS; i++)
-		if (!stricmp(order_name, Comm_orders[i].name.c_str()))
-			order = Comm_orders[i].item;
+	for (i = 0; i < Player_orders.size(); i++)
+		if (!stricmp(order_name, Player_orders[i].hud_name.c_str()))
+			order = Player_orders[i].id;
 
 	// Goober5000 - if not found, check compatibility
 	if (order == -1)
@@ -2418,7 +2421,7 @@ int hud_query_order_issued(const char *to, const char *order_name, const char *t
 		if (!stricmp(order_name, "Attack my target"))
 		{
 			i = 0;	// it maps to option 0, "Destroy my target"
-			order = Comm_orders[i].item;
+			order = Player_orders[i].id;
 		}
 	}
 

--- a/code/hud/hudsquadmsg.h
+++ b/code/hud/hudsquadmsg.h
@@ -33,8 +33,6 @@ class object;
 // defines for messages that can be sent from the player.  Defined at bitfields so that we can enable
 // and disable messages on a message by message basis
 
-#define NUM_COMM_ORDER_ITEMS		16
-
 #define ATTACK_TARGET_ITEM			(1<<0)
 #define DISABLE_TARGET_ITEM			(1<<1)
 #define DISARM_TARGET_ITEM			(1<<2)
@@ -61,20 +59,15 @@ class object;
 // used for Message box gauge
 #define NUM_MBOX_FRAMES		3
 
-// data structure to hold character string of commands for comm menu
-typedef struct comm_order {
-	SCP_string name;
-	int item;
-} comm_order;
+typedef struct player_order {
+	SCP_string parse_name;
+	SCP_string hud_name;
+	int hud_xstr;
+	int id = -1;
+	SCP_string localized_name = "";
+} player_order;
 
-typedef struct sexp_com_order{ 
-	const char *name;
-	int xstring; 
-	int item; 
-}sexp_com_order;
-
-extern comm_order Comm_orders[];
-extern sexp_com_order Sexp_comm_orders[];
+extern std::vector<player_order> Player_orders;
 
 // following defines are the set of possible commands that can be given to a ship.  A mission designer
 // might not allow some messages

--- a/code/hud/hudsquadmsg.h
+++ b/code/hud/hudsquadmsg.h
@@ -63,8 +63,9 @@ typedef struct player_order {
 	SCP_string parse_name;
 	SCP_string hud_name;
 	int hud_xstr;
-	int id = -1;
-	SCP_string localized_name = "";
+	int id;
+	SCP_string localized_name;
+	player_order(SCP_string parsename, SCP_string hudname, int hudxstr, int orderid = 0) : parse_name(std::move(parsename)), hud_name(std::move(hudname)), hud_xstr(hudxstr), id(orderid), localized_name("") { }
 } player_order;
 
 extern std::vector<player_order> Player_orders;

--- a/code/io/keycontrol.cpp
+++ b/code/io/keycontrol.cpp
@@ -1645,7 +1645,8 @@ void game_process_cheats(int k)
 		ship *shipp = &Ships[Objects[objnum].instance];
 		shipp->ship_name[0] = '\0';
 		shipp->display_name.clear();
-		shipp->orders_accepted = (1<<NUM_COMM_ORDER_ITEMS)-1;
+		for(size_t j = 0; j < Player_orders.size(); j++)
+			shipp->orders_accepted.insert(j);
 
 		// Goober5000 - stolen from support ship creation
 		// create a name for the ship.  use "Volition Bravos #".  look for collisions until one isn't found anymore

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -3325,7 +3325,7 @@ int parse_object(mission *pm, int  /*flag*/, p_object *p_objp)
         if (tmp_orders != -1) {
 			p_objp->flags.set(Mission::Parse_Object_Flags::SF_Use_unique_orders);
 
-			for(size_t j = 0; i < Player_orders.size(); j++){
+			for(size_t j = 0; j < Player_orders.size(); j++){
 				if(Player_orders[j].id & tmp_orders)
 					p_objp->orders_accepted.insert(j);
 			}

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -2107,7 +2107,7 @@ int parse_create_object_sub(p_object *p_objp)
 			std::set<size_t> default_orders, remaining_orders;
 			
 			default_orders = ship_get_default_orders_accepted(&Ship_info[shipp->ship_info_index]);
-			std::set_intersection(p_objp->orders_accepted.begin(), p_objp->orders_accepted.end(), default_orders.begin(), default_orders.end(),
+			std::set_difference(p_objp->orders_accepted.begin(), p_objp->orders_accepted.end(), default_orders.begin(), default_orders.end(),
 								  std::inserter(remaining_orders, remaining_orders.begin()));
 			if (!remaining_orders.empty())
 			{

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -28,6 +28,7 @@
 #include "globalincs/linklist.h"
 #include "hud/hudescort.h"
 #include "hud/hudets.h"
+#include "hud/hudsquadmsg.h"
 #include "hud/hudwingmanstatus.h"
 #include "iff_defs/iff_defs.h"
 #include "io/timer.h"
@@ -335,7 +336,6 @@ const char *Mission_event_log_flags[MAX_MISSION_EVENT_LOG_FLAGS] = {
 	"last trigger",
 	"state change",
 };
-
 
 //XSTR:ON
 
@@ -2104,11 +2104,12 @@ int parse_create_object_sub(p_object *p_objp)
 #ifndef NDEBUG
 		if (Fred_running)
 		{
-			int default_orders, remaining_orders;
+			std::set<size_t> default_orders, remaining_orders;
 			
 			default_orders = ship_get_default_orders_accepted(&Ship_info[shipp->ship_info_index]);
-			remaining_orders = p_objp->orders_accepted & ~default_orders;
-			if (remaining_orders)
+			std::set_intersection(p_objp->orders_accepted.begin(), p_objp->orders_accepted.end(), default_orders.begin(), default_orders.end(),
+								  std::inserter(remaining_orders, remaining_orders.begin()));
+			if (!remaining_orders.empty())
 			{
 				Warning(LOCATION, "Ship %s has orders which it will accept that are\nnot part of default orders accepted.\n\nPlease reedit this ship and change the orders again\n", shipp->ship_name);
 			}
@@ -3316,9 +3317,19 @@ int parse_object(mission *pm, int  /*flag*/, p_object *p_objp)
     // set that this ship will actually listen to
     if (optional_string("+Orders Accepted:"))
     {
-        stuff_int(&p_objp->orders_accepted);
-        if (p_objp->orders_accepted != -1)
-            p_objp->flags.set(Mission::Parse_Object_Flags::SF_Use_unique_orders);
+		p_objp->orders_accepted.clear();
+		
+		int tmp_orders;
+        stuff_int(&tmp_orders);
+		
+        if (tmp_orders != -1) {
+			p_objp->flags.set(Mission::Parse_Object_Flags::SF_Use_unique_orders);
+
+			for(size_t j = 0; i < Player_orders.size(); j++){
+				if(Player_orders[j].id & tmp_orders)
+					p_objp->orders_accepted.insert(j);
+			}
+		}
     }
 
 	p_objp->group = 0;
@@ -4382,7 +4393,7 @@ int parse_wing_create_ships( wing *wingp, int num_to_create, int force, int spec
 		// of orders from the leader
 		if ( Fred_running ) {
 			Assert( wingp->ship_index[wingp->special_ship] != -1 );
-			int orders = Ships[wingp->ship_index[0]].orders_accepted;
+			const std::set<size_t>& orders = Ships[wingp->ship_index[0]].orders_accepted;
 			for (it = 0; it < wingp->current_count; it++ ) {
 				if (it == wingp->special_ship)
 					continue;

--- a/code/mission/missionparse.h
+++ b/code/mission/missionparse.h
@@ -11,6 +11,7 @@
 #define _PARSE_H
 
 #include <csetjmp>
+#include <set>
 
 #include "ai/ai.h"
 #include "ai/ai_profiles.h"
@@ -381,7 +382,7 @@ public:
 	int	hotkey;								// hotkey number (between 0 and 9) -1 means no hotkey
 	int	score;
 	float assist_score_pct;					// percentage of the score which players who gain an assist will get when this ship is killed
-	int	orders_accepted;					// which orders this ship will accept from the player
+	std::set<size_t> orders_accepted;					// which orders this ship will accept from the player
 	p_dock_instance	*dock_list;				// Goober5000 - parse objects this parse object is docked to
 	object *created_object;					// Goober5000
 	int	group;								// group object is within or -1 if none.

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -116,8 +116,6 @@ extern bool splodeing;
 extern float splode_level;
 extern int splodeingtexture;
 
-extern std::vector<player_order> Player_orders;
-
 #define SHIP_REPAIR_SUBSYSTEM_RATE	0.01f
 
 // The minimum required fuel to engage afterburners

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -116,6 +116,8 @@ extern bool splodeing;
 extern float splode_level;
 extern int splodeingtexture;
 
+extern std::vector<player_order> Player_orders;
+
 #define SHIP_REPAIR_SUBSYSTEM_RATE	0.01f
 
 // The minimum required fuel to engage afterburners
@@ -229,40 +231,6 @@ flag_def_list_new<Thruster_Flags> Man_types[] = {
 };
 
 const size_t Num_man_types = sizeof(Man_types) / sizeof(flag_def_list_new<Thruster_Flags>);
-
-// Goober5000 - I figured we should keep this separate
-// from Comm_orders, considering how I redid it :p
-// (and also because we may want to change either
-// the order text or the flag text in the future)
-flag_def_list Player_orders[] = {
-	// common stuff
-	{ "attack ship",		ATTACK_TARGET_ITEM,		0 },
-	{ "disable ship",		DISABLE_TARGET_ITEM,	0 },
-	{ "disarm ship",		DISARM_TARGET_ITEM,		0 },
-	{ "disable subsys",		DISABLE_SUBSYSTEM_ITEM,	0 },
-	{ "guard ship",			PROTECT_TARGET_ITEM,	0 },
-	{ "ignore ship",		IGNORE_TARGET_ITEM,		0 },
-	{ "form on wing",		FORMATION_ITEM,			0 },
-	{ "cover me",			COVER_ME_ITEM,			0 },
-	{ "attack any",			ENGAGE_ENEMY_ITEM,		0 },
-
-	// transports mostly
-	{ "dock",				CAPTURE_TARGET_ITEM,	0 },
-
-	// support ships
-	{ "rearm me",			REARM_REPAIR_ME_ITEM,	0 },
-	{ "abort rearm",		ABORT_REARM_REPAIR_ITEM,	0 },
-
-	// all ships
-	{ "depart",				DEPART_ITEM,			0 },
-
-	// extra stuff for support
-	{ "stay near me",		STAY_NEAR_ME_ITEM,		0 },
-	{ "stay near ship",		STAY_NEAR_TARGET_ITEM,	0 },
-	{ "keep safe dist",		KEEP_SAFE_DIST_ITEM,	0 }
-};
-
-const int Num_player_orders = sizeof(Player_orders)/sizeof(flag_def_list);
 
 // Use the last parameter here to tell the parser whether to stuff the flag into flags or flags2
 flag_def_list_new<Model::Subsystem_Flags> Subsystem_flags[] = {
@@ -5344,7 +5312,14 @@ static void parse_ship_type(const char *filename, const bool replace)
 		}
 
 		if(optional_string("+Player Orders:")) {
-			parse_string_flag_list(&stp->ai_player_orders, Player_orders, Num_player_orders);
+			SCP_vector<SCP_string> slp;
+			stuff_string_list(slp);
+			
+			for(size_t i = 0; i < Player_orders.size(); i++){
+				if(std::find(slp.begin(), slp.end(), Player_orders[i].parse_name) != slp.end()){
+					stp->ai_player_orders.insert(i);
+				}
+			}
 		}
 
 		if(optional_string("+Auto attacks:")) {
@@ -6118,12 +6093,13 @@ int ship_get_type(char* output, ship_info *sip)
  *
  * This value might get overridden by a value in the mission file.
  */
-int ship_get_default_orders_accepted( ship_info *sip )
+const std::set<size_t>& ship_get_default_orders_accepted( ship_info *sip )
 {
 	if(sip->class_type >= 0) {
 		return Ship_types[sip->class_type].ai_player_orders;
 	} else {
-		return 0;
+		static std::set<size_t> inv_class_set;
+		return inv_class_set;
 	}
 }
 
@@ -6229,7 +6205,7 @@ void ship::clear()
 	departure_delay = 0;
 
 	wingnum = -1;
-	orders_accepted = 0;
+	orders_accepted.clear();
 
 	subsys_list.clear();
 	// since these aren't cleared by clear()
@@ -10801,8 +10777,8 @@ void change_ship_type(int n, int ship_type, int by_sexp)
 	// (this avoids wiping the orders if we're e.g. changing between fighter classes)
 	if (Fred_running)
 	{
-		int old_defaults = ship_get_default_orders_accepted(sip_orig);
-		int new_defaults = ship_get_default_orders_accepted(sip);
+		const std::set<size_t>& old_defaults = ship_get_default_orders_accepted(sip_orig);
+		const std::set<size_t>& new_defaults = ship_get_default_orders_accepted(sip);
 
 		if (old_defaults != new_defaults)
 			sp->orders_accepted = new_defaults;

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -968,7 +968,7 @@ typedef struct ship_type_info {
 		: debris_max_speed( 0.f ),
 		  ff_multiplier( 0.f ), emp_multiplier( 0.f ),
 		  fog_start_dist( 0.f ), fog_complete_dist( 0.f ),
-		  ai_valid_goals( 0 ), ai_player_orders( ), ai_active_dock( 0 ), ai_passive_dock( 0 ),
+		  ai_valid_goals( 0 ), ai_active_dock( 0 ), ai_passive_dock( 0 ),
 		  vaporize_chance( 0.f )
 
 	{

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -34,6 +34,7 @@
 #include "ai/ai.h"
 
 #include <string>
+#include <set>
 #include <particle/ParticleManager.h>
 
 class object;
@@ -601,7 +602,7 @@ public:
 	int	departure_delay;		// time in seconds after sexp is true that we delay.
 
 	int	wingnum;								// wing number this ship is in.  -1 if in no wing, Wing array index otherwise
-	int	orders_accepted;					// set of orders this ship will accept from the player.
+	std::set<size_t> orders_accepted;					// set of orders this ship will accept from the player.
 
 	// Subsystem fields.  The subsys_list is a list of all subsystems (which might include multiple types
 	// of a particular subsystem, like engines).  The subsys_info struct is information for particular
@@ -947,7 +948,7 @@ typedef struct ship_type_info {
 
 	//AI
 	int	ai_valid_goals;
-	int ai_player_orders;
+	std::set<size_t> ai_player_orders;
 	int ai_active_dock;
 	int ai_passive_dock;
 	SCP_vector<int> ai_actively_pursues;
@@ -967,7 +968,7 @@ typedef struct ship_type_info {
 		: debris_max_speed( 0.f ),
 		  ff_multiplier( 0.f ), emp_multiplier( 0.f ),
 		  fog_start_dist( 0.f ), fog_complete_dist( 0.f ),
-		  ai_valid_goals( 0 ), ai_player_orders( 0 ), ai_active_dock( 0 ), ai_passive_dock( 0 ),
+		  ai_valid_goals( 0 ), ai_player_orders( ), ai_active_dock( 0 ), ai_passive_dock( 0 ),
 		  vaporize_chance( 0.f )
 
 	{
@@ -1733,7 +1734,7 @@ extern void ship_clear_ship_type_counts();
 extern void ship_add_ship_type_count( int ship_info_index, int num );
 
 extern int ship_get_type(char* output, ship_info* sip);
-extern int ship_get_default_orders_accepted( ship_info *sip );
+extern const std::set<size_t>& ship_get_default_orders_accepted( ship_info *sip );
 extern int ship_query_general_type(int ship);
 extern int ship_class_query_general_type(int ship_class);
 extern int ship_query_general_type(ship *shipp);

--- a/fred2/fredview.cpp
+++ b/fred2/fredview.cpp
@@ -2445,7 +2445,6 @@ int CFREDView::global_error_check()
 	int bs, i, j, n, s, t, z, ai, count, ship, wing, obj, team, point, multi;
 	object *ptr;
 	brief_stage *sp;
-	int starting_orders;
 
 	g_err = multi = 0;
 	if ( The_mission.game_type & MISSION_TYPE_MULTI )
@@ -2992,9 +2991,10 @@ int CFREDView::global_error_check()
 
 	// for all wings, be sure that the orders accepted for all ships are the same for all ships
 	// in the wing
-	starting_orders = -1;
+	//std::set<size_t> starting_orders { std::numeric_limits<size_t>::max() };
 	for (i=0; i<MAX_WINGS; i++) {
-		int default_orders, starting_wing;
+		int starting_wing;
+		std::set<size_t> default_orders;
 
 		if ( !Wings[i].wave_count ){
 			continue;
@@ -3009,10 +3009,9 @@ int CFREDView::global_error_check()
 // Goober5000				return 1;
 			}
 		}
-
-		default_orders = 0;
+		
 		for ( j = 0; j < Wings[i].wave_count; j++ ) {
-			int orders;
+			std::set<size_t> orders;
 
 			orders = Ships[Wings[i].ship_index[j]].orders_accepted;
 			if ( j == 0 ) {

--- a/fred2/ignoreordersdlg.cpp
+++ b/fred2/ignoreordersdlg.cpp
@@ -108,7 +108,7 @@ BOOL ignore_orders_dlg::OnInitDialog()
 		// Need to add more checkboxes.
 		if (m_num_checks_active >= MAX_CHECKBOXES)
 		{
-			Warning("Tried to add more orders than FRED2 has checkboxes for them (can be max %d)!", MAX_CHECKBOXES);
+			Warning(LOCATION, "Tried to add more orders than FRED2 has checkboxes for them (can be max %d)!", MAX_CHECKBOXES);
 			break;
 		}
 

--- a/fred2/ignoreordersdlg.cpp
+++ b/fred2/ignoreordersdlg.cpp
@@ -108,7 +108,7 @@ BOOL ignore_orders_dlg::OnInitDialog()
 		// Need to add more checkboxes.
 		if (m_num_checks_active >= MAX_CHECKBOXES)
 		{
-			Int3();
+			Warning("Tried to add more orders than FRED2 has checkboxes for them (can be max %d)!", MAX_CHECKBOXES);
 			break;
 		}
 

--- a/fred2/ignoreordersdlg.cpp
+++ b/fred2/ignoreordersdlg.cpp
@@ -62,7 +62,8 @@ END_MESSAGE_MAP()
 
 BOOL ignore_orders_dlg::OnInitDialog() 
 {
-	int i, default_orders, last_bottom, orders_accepted;
+	int i, last_bottom;
+	std::set<size_t> default_orders, orders_accepted;
 	RECT	window_size;
 	char buf[128];
 	object *objp;
@@ -87,13 +88,11 @@ BOOL ignore_orders_dlg::OnInitDialog()
 	} else {
 		// we are doing multiple edit on ships.  We just need to get default orders for
 		// the first marked ship since they'd better all be the same anyway!!!
-		default_orders = 0;
+		default_orders.clear();
 		for ( objp = GET_FIRST(&obj_used_list); objp != END_OF_LIST(&obj_used_list); objp = GET_NEXT(objp) ) {
 			if (((objp->type == OBJ_SHIP) || (objp->type == OBJ_START)) && (objp->flags[Object::Object_Flags::Marked])) {
-				int these_orders;
-
-				these_orders = ship_get_default_orders_accepted( &Ship_info[Ships[objp->instance].ship_info_index] );
-				if ( default_orders == 0 )
+				const std::set<size_t>& these_orders = ship_get_default_orders_accepted( &Ship_info[Ships[objp->instance].ship_info_index] );
+				if ( default_orders.empty() )
 					default_orders = these_orders;
 				else if ( default_orders != these_orders )
 					Int3();
@@ -104,22 +103,19 @@ BOOL ignore_orders_dlg::OnInitDialog()
 
 	// set the checkboxes for the orders accepted
 	m_num_checks_active = 0;
-	for (i = 0; i < NUM_COMM_ORDER_ITEMS; i++ )
-	{
-		if (default_orders & Comm_orders[i].item)
+	for (size_t order_id : default_orders){
+		// Not enough space to display checkboxes for all comm orders!
+		// Need to add more checkboxes.
+		if (m_num_checks_active >= MAX_CHECKBOXES)
 		{
-			// Not enough space to display checkboxes for all comm orders!
-			// Need to add more checkboxes.
-			if (m_num_checks_active >= MAX_CHECKBOXES)
-			{
-				Int3();
-				break;
-			}
-
-			check_boxes[m_num_checks_active].button->SetWindowText(Comm_orders[i].name.c_str());
-			check_boxes[m_num_checks_active].id = Comm_orders[i].item;
-			m_num_checks_active++;
+			Int3();
+			break;
 		}
+
+		check_boxes[m_num_checks_active].button->SetWindowText(Player_orders[order_id].localized_name.c_str());
+		check_boxes[m_num_checks_active].id = (int)order_id;
+		m_num_checks_active++;
+	
 	}
 
 	// resize the dialog by shrinking the height by the number of checkboxes that
@@ -150,7 +146,7 @@ BOOL ignore_orders_dlg::OnInitDialog()
 	if ( m_ship >= 0 ) {
 		orders_accepted = Ships[m_ship].orders_accepted;
 		for ( i = 0; i < m_num_checks_active; i++ ) {
-			if ( check_boxes[i].id & orders_accepted )
+			if ( orders_accepted.find(check_boxes[i].id) != orders_accepted.end() )
 				check_boxes[i].button->SetCheck(1);
 		}
 	} else {
@@ -164,14 +160,14 @@ BOOL ignore_orders_dlg::OnInitDialog()
 				orders_accepted = Ships[objp->instance].orders_accepted;
 				if ( first_time ) {
 					for ( i = 0; i < m_num_checks_active; i++ ) {
-						if ( check_boxes[i].id & orders_accepted )
+						if ( orders_accepted.find(check_boxes[i].id) != orders_accepted.end() )
 							check_boxes[i].button->SetCheck(1);
 					}
 					first_time = 0;
 				} else {
 					for ( i = 0; i < m_num_checks_active; i++ ) {
 						// see if the order matches the check box order
-						if ( check_boxes[i].id & orders_accepted ) {
+						if ( orders_accepted.find(check_boxes[i].id) != orders_accepted.end() ) {
 							// if it matches, if it is not already set, then it is indeterminate.
 							if ( !check_boxes[i].button->GetCheck() )
 								check_boxes[i].button->SetCheck(2);
@@ -199,21 +195,21 @@ BOOL ignore_orders_dlg::OnInitDialog()
 // variable based on the state of the checkboxes
 void ignore_orders_dlg::OnOK() 
 {
-	int orders_accepted, i;
+	std::set<size_t> orders_accepted;
+	int i;
 	object *objp;
 
 	// clear out the orders, then set the bits according to which check boxes are set
 	if ( m_ship >= 0 ) {
-		orders_accepted = 0;
 		for ( i = 0; i < m_num_checks_active; i++ ) {
 			if ( check_boxes[i].button->GetCheck() )
-				orders_accepted |= check_boxes[i].id;
+				orders_accepted.insert(check_boxes[i].id);
 		}
 		Ships[m_ship].orders_accepted = orders_accepted;
 	} else {
 		for ( objp = GET_FIRST(&obj_used_list); objp != END_OF_LIST(&obj_used_list); objp = GET_NEXT(objp) ) {
 			if (((objp->type == OBJ_SHIP) || (objp->type == OBJ_START)) && (objp->flags[Object::Object_Flags::Marked])) {
-				Ships[objp->instance].orders_accepted = 0;
+				Ships[objp->instance].orders_accepted.clear();
 				for ( i = 0; i < m_num_checks_active; i++ ) {
 					int box_value;
 
@@ -225,9 +221,9 @@ void ignore_orders_dlg::OnOK()
 
 					// if the button is set, then set the bit, otherwise, clear the bit
 					if ( box_value == 1 )
-						Ships[objp->instance].orders_accepted |= check_boxes[i].id;
+						Ships[objp->instance].orders_accepted.insert(check_boxes[i].id);
 					else
-						Ships[objp->instance].orders_accepted &= ~(check_boxes[i].id);
+						Ships[objp->instance].orders_accepted.erase(check_boxes[i].id);
 				}
 			}
 		}

--- a/fred2/management.cpp
+++ b/fred2/management.cpp
@@ -585,12 +585,16 @@ int create_ship(matrix *orient, vec3d *pos, int ship_type)
 			if (!(sip->is_small_ship()))
 			{
 				shipp->orders_accepted = ship_get_default_orders_accepted( sip );
-				shipp->orders_accepted &= ~DEPART_ITEM;
+
+				for(size_t i = 0; i < Player_orders.size(); i++) {
+					if (Player_orders[i].id & DEPART_ITEM)
+						shipp->orders_accepted.erase(i);
+				}
 			}
 		}
 		else
 		{
-			shipp->orders_accepted = 0;
+			shipp->orders_accepted.clear();
 		}
 	}
 	

--- a/fred2/missionsave.cpp
+++ b/fred2/missionsave.cpp
@@ -26,6 +26,7 @@
 #include "gamesnd/eventmusic.h"
 #include "globalincs/linklist.h"
 #include "globalincs/version.h"
+#include "hud/hudsquadmsg.h"
 #include "iff_defs/iff_defs.h"
 #include "jumpnode/jumpnode.h"
 #include "lighting/lighting.h"
@@ -3644,7 +3645,10 @@ int CFred_mission_save::save_objects()
 			else
 				fout("\n+Orders Accepted:");
 
-			fout(" %d\t\t;! note that this is a bitfield!!!", shipp->orders_accepted);
+			int bitfield = 0;
+			for(size_t order : shipp->orders_accepted)
+				bitfield |= Player_orders[order].id;
+			fout(" %d\t\t;! note that this is a bitfield!!!", bitfield);
 		}
 
 		if (shipp->group >= 0) {

--- a/fred2/sexp_tree.cpp
+++ b/fred2/sexp_tree.cpp
@@ -5912,11 +5912,10 @@ sexp_list_item *sexp_tree::get_listing_opf_event_name(int parent_node)
 
 sexp_list_item *sexp_tree::get_listing_opf_ai_order()
 {
-	int i;
 	sexp_list_item head;
 
-	for (i=0; i<NUM_COMM_ORDER_ITEMS; i++)
-		head.add_data(Comm_orders[i].name.c_str());
+	for (const auto& order : Player_orders)
+		head.add_data(order.hud_name.c_str());
 
 	return head.next;
 }

--- a/fred2/shipeditordlg.cpp
+++ b/fred2/shipeditordlg.cpp
@@ -386,7 +386,8 @@ void CShipEditorDlg::initialize_data(int full_update)
 {
 	int type, ship_count, player_count, total_count, wing = -1, pvalid_count;
 	int a_cue, d_cue, cue_init = 0, cargo = 0, base_ship, base_player, pship = -1;
-	int no_arrival_warp = 0, no_departure_warp = 0, escort_count, ship_orders, current_orders;
+	int no_arrival_warp = 0, no_departure_warp = 0, escort_count;
+	std::set<size_t> ship_orders, current_orders;
 	int pship_count;  // a total count of the player ships not marked
 	object *objp;
 	CWnd *w = NULL;
@@ -473,7 +474,7 @@ void CShipEditorDlg::initialize_data(int full_update)
 	player_ship = single_ship = -1;
 	m_arrival_tree.select_sexp_node = m_departure_tree.select_sexp_node = select_sexp_node;
 	select_sexp_node = -1;
-	ship_orders = 0;				// assume they are all the same type
+	ship_orders.clear();				// assume they are all the same type
 	if (ship_count) {
 		box = (CComboBox *) GetDlgItem(IDC_SHIP_CARGO1);
 		box->ResetContent();
@@ -513,10 +514,10 @@ void CShipEditorDlg::initialize_data(int full_update)
 
 					// 'and' in the ship type of this ship to our running bitfield
 					current_orders = ship_get_default_orders_accepted( &Ship_info[Ships[i].ship_info_index] );
-					if (!ship_orders){
+					if (ship_orders.empty()){
 						ship_orders = current_orders;
 					} else if (ship_orders != current_orders){
-						ship_orders = -1;
+						ship_orders = {std::numeric_limits<size_t>::max()};
 					}
 
 					if (Ships[i].flags[Ship::Ship_Flags::Escort]){
@@ -975,7 +976,7 @@ void CShipEditorDlg::initialize_data(int full_update)
 		// ships are the same type.  the ship_type (local) variable holds the ship types
 		// for all ships.  Determine how may bits set and enable/diable window
 		// as appropriate
-		if ( /*(m_team == -1) ||*/ (ship_orders == -1) ){
+		if ( /*(m_team == -1) ||*/ (ship_orders.find(std::numeric_limits<size_t>::max()) != ship_orders.end()) ){
 			GetDlgItem(IDC_IGNORE_ORDERS)->EnableWindow(FALSE);
 		} else {
 			GetDlgItem(IDC_IGNORE_ORDERS)->EnableWindow(TRUE);

--- a/qtfred/src/mission/Editor.cpp
+++ b/qtfred/src/mission/Editor.cpp
@@ -735,10 +735,14 @@ int Editor::create_ship(matrix* orient, vec3d* pos, int ship_type) {
 			// the depart item
 			if (!(sip->is_small_ship())) {
 				shipp->orders_accepted = ship_get_default_orders_accepted(sip);
-				shipp->orders_accepted &= ~DEPART_ITEM;
+
+				for(size_t i = 0; i < Player_orders.size(); i++) {
+					if (Player_orders[i].id & DEPART_ITEM)
+						shipp->orders_accepted.erase(i);
+				}
 			}
 		} else {
-			shipp->orders_accepted = 0;
+			shipp->orders_accepted.clear();
 		}
 	}
 
@@ -2450,7 +2454,7 @@ int Editor::global_error_check_impl() {
 	// for all wings, be sure that the orders accepted for all ships are the same for all ships
 	// in the wing
 	for (i = 0; i < MAX_WINGS; i++) {
-		int default_orders, starting_wing;
+		int starting_wing;
 
 		if (!Wings[i].wave_count) {
 			continue;
@@ -2468,11 +2472,9 @@ int Editor::global_error_check_impl() {
 			}
 		}
 
-		default_orders = 0;
+		std::set<size_t> default_orders;
 		for (j = 0; j < Wings[i].wave_count; j++) {
-			int orders;
-
-			orders = Ships[Wings[i].ship_index[j]].orders_accepted;
+			const std::set<size_t>& orders = Ships[Wings[i].ship_index[j]].orders_accepted;
 			if (j == 0) {
 				default_orders = orders;
 			} else if (default_orders != orders) {

--- a/qtfred/src/mission/dialogs/PlayerOrdersDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/PlayerOrdersDialogModel.cpp
@@ -107,7 +107,7 @@ namespace fso {
 				for (size_t order_id : default_orders)
 				{
 					orderNames[m_num_checks_active] = Player_orders[order_id].localized_name;
-					acceptedOrders[m_num_checks_active] = order_id;
+					acceptedOrders[m_num_checks_active] = (int) order_id;
 					m_num_checks_active++;
 				}
 

--- a/qtfred/src/mission/dialogs/ShipEditorDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/ShipEditorDialogModel.cpp
@@ -50,7 +50,8 @@ namespace fso {
 			void ShipEditorDialogModel::initializeData() {
 				int type, wing = -1;
 				int cargo = 0, base_ship, base_player, pship = -1;
-				int escort_count, current_orders;
+				int escort_count;
+				std::set<size_t> current_orders;
 				pship_count = 0;  // a total count of the player ships not marked
 				player_count = 0;
 				ship_count = 0;
@@ -58,7 +59,7 @@ namespace fso {
 				total_count = 0;
 				pvalid_count = 0;
 				player_ship = 0;
-				ship_orders = 0;
+				ship_orders.clear();
 				object* objp;
 				if (The_mission.game_type & MISSION_TYPE_MULTI) {
 					mission_type = 0;  // multi player mission
@@ -122,7 +123,7 @@ namespace fso {
 
 				player_ship = single_ship = -1;
 
-				ship_orders = 0;				// assume they are all the same type
+				ship_orders.clear();				// assume they are all the same type
 				if (ship_count) {
 					if (!multi_edit) {
 						Assert((ship_count == 1) && (base_ship >= 0));
@@ -154,11 +155,11 @@ namespace fso {
 								}
 								// 'and' in the ship type of this ship to our running bitfield
 								current_orders = ship_get_default_orders_accepted(&Ship_info[Ships[i].ship_info_index]);
-								if (!ship_orders) {
+								if (ship_orders.empty()) {
 									ship_orders = current_orders;
 								}
 								else if (ship_orders != current_orders) {
-									ship_orders = -1;
+									ship_orders = {std::numeric_limits<size_t>::max()};
 								}
 
 								if (Ships[i].flags[Ship::Ship_Flags::Escort]) {

--- a/qtfred/src/mission/dialogs/ShipEditorDialogModel.h
+++ b/qtfred/src/mission/dialogs/ShipEditorDialogModel.h
@@ -163,7 +163,7 @@ class ShipEditorDialogModel : public AbstractDialogModel {
 	int pship_count; // a total count of the player ships not marked
 	int single_ship;
 	int player_ship;
-	int ship_orders;
+	std::set<size_t> ship_orders;
 	static int tristate_set(int val, int cur_state);
 
 	//int pship, current_orders;

--- a/qtfred/src/mission/missionsave.cpp
+++ b/qtfred/src/mission/missionsave.cpp
@@ -11,6 +11,7 @@
 #include <ai/aigoals.h>
 #include <asteroid/asteroid.h>
 #include <cfile/cfile.h>
+#include <hud/hudsquadmsg.h>
 #include <gamesnd/eventmusic.h>
 #include <globalincs/linklist.h>
 #include <globalincs/version.h>
@@ -3433,7 +3434,10 @@ int CFred_mission_save::save_objects()
 				fout("\n+Orders Accepted:");
 			}
 
-			fout(" %d\t\t;! note that this is a bitfield!!!", shipp->orders_accepted);
+			int bitfield = 0;
+			for(size_t order : shipp->orders_accepted)
+				bitfield |= Player_orders[order].id;
+			fout(" %d\t\t;! note that this is a bitfield!!!", bitfield);
 		}
 
 		if (shipp->group >= 0) {

--- a/qtfred/src/ui/dialogs/ShipEditorDialog.cpp
+++ b/qtfred/src/ui/dialogs/ShipEditorDialog.cpp
@@ -583,7 +583,7 @@ void ShipEditorDialog::enableDisable()
 		// ships are the same type.  the ship_type variable holds the ship types
 		// for all ships.  Determine how may bits set and enable/diable window
 		// as appropriate
-		if (_model->ship_orders == -1) {
+		if (_model->ship_orders.find(std::numeric_limits<size_t>::max()) != _model->ship_orders.end()) {
 			ui->playerOrdersButton->setEnabled(false);
 		} else {
 			ui->playerOrdersButton->setEnabled(true);

--- a/qtfred/src/ui/widgets/sexp_tree.cpp
+++ b/qtfred/src/ui/widgets/sexp_tree.cpp
@@ -4210,7 +4210,6 @@ sexp_list_item* sexp_tree::get_listing_opf_event_name(int parent_node) {
 }
 
 sexp_list_item* sexp_tree::get_listing_opf_ai_order() {
-	int i;
 	sexp_list_item head;
 
 	for (const auto& order : Player_orders) {

--- a/qtfred/src/ui/widgets/sexp_tree.cpp
+++ b/qtfred/src/ui/widgets/sexp_tree.cpp
@@ -4213,8 +4213,8 @@ sexp_list_item* sexp_tree::get_listing_opf_ai_order() {
 	int i;
 	sexp_list_item head;
 
-	for (i = 0; i < NUM_COMM_ORDER_ITEMS; i++) {
-		head.add_data(Comm_orders[i].name.c_str());
+	for (const auto& order : Player_orders) {
+		head.add_data(order.hud_name.c_str());
 	}
 
 	return head.next;


### PR DESCRIPTION
Previously, possible player orders were stored redundantly in three separate, fixed-size arrays: ``Comm_orders``, ``Sexp_comm_orders``, and ``Player_orders``.  This PR does away with these and creates a new ``Player_orders`` vector, allowing for a dynamic amount of player orders. In preparation for eventually changing up player orders in such a way that the old ID's are removed and not based on bitfields, thus allowing for more than 32 different ones, ships now store player order acceptance as sets of the index of the order in the Player_orders vector. 

This is needed to eventually facilitate LuaAI, a feature that allows a scripter to add AI logic based on Lua which can be added both by SEXP, as well as made available as a player order.

~Still needs testing in addition to a review:~ Finished testing, it seems like everything still works as it should.
- [x] Player orders work as expected ingame
- [x] The query-order training sexp works as expected
- [x] Player orders properly parse, show and save in FRED
- [x] Player orders properly parse, show and save in QtFRED