### PR TITLE
Standalone fixes/optimizations

### DIFF
--- a/code/graphics/2d.cpp
+++ b/code/graphics/2d.cpp
@@ -1605,8 +1605,6 @@ bool gr_init(std::unique_ptr<os::GraphicsOperations>&& graphicsOps, int d_mode, 
 		return false;
 	}
 
-	gr_light_init();
-
 	gr_set_palette_internal(Gr_current_palette_name, NULL, 0);
 
 	bm_init();
@@ -1615,13 +1613,17 @@ bool gr_init(std::unique_ptr<os::GraphicsOperations>&& graphicsOps, int d_mode, 
 
 	io::mouse::CursorManager::init();
 
-	mprintf(("Initializing path renderer...\n"));
-	graphics::paths::PathRenderer::init();
+	if ( !Is_standalone ) {
+		gr_light_init();
 
-	// Initialize uniform buffer managers
-	uniform_buffer_managers_init();
+		mprintf(("Initializing path renderer...\n"));
+		graphics::paths::PathRenderer::init();
 
-	gpu_heap_init();
+		// Initialize uniform buffer managers
+		uniform_buffer_managers_init();
+
+		gpu_heap_init();
+	}
 
 	mprintf(("Checking graphics capabilities:\n"));
 	mprintf(("  Persistent buffer mapping: %s\n",

--- a/code/graphics/2d.cpp
+++ b/code/graphics/2d.cpp
@@ -1613,11 +1613,11 @@ bool gr_init(std::unique_ptr<os::GraphicsOperations>&& graphicsOps, int d_mode, 
 
 	io::mouse::CursorManager::init();
 
+	mprintf(("Initializing path renderer...\n"));
+	graphics::paths::PathRenderer::init();
+
 	if ( !Is_standalone ) {
 		gr_light_init();
-
-		mprintf(("Initializing path renderer...\n"));
-		graphics::paths::PathRenderer::init();
 
 		// Initialize uniform buffer managers
 		uniform_buffer_managers_init();

--- a/code/model/modelinterp.cpp
+++ b/code/model/modelinterp.cpp
@@ -207,26 +207,40 @@ int model_interp_get_texture(texture_info *tinfo, fix base_frametime);
 
 void model_deallocate_interp_data()
 {
-	if (Interp_verts != NULL)
+	if (Interp_verts != nullptr) {
 		vm_free(Interp_verts);
+		Interp_verts = nullptr;
+	}
 
-	if (Interp_points != NULL)
+	if (Interp_points != nullptr) {
 		vm_free(Interp_points);
+		Interp_points = nullptr;
+	}
 
-	if (Interp_splode_points != NULL)
+	if (Interp_splode_points != nullptr) {
 		vm_free(Interp_splode_points);
+		Interp_splode_points = nullptr;
+	}
 
-	if (Interp_splode_verts != NULL)
+	if (Interp_splode_verts != nullptr) {
 		vm_free(Interp_splode_verts);
+		Interp_splode_verts = nullptr;
+	}
 
-	if (Interp_norms != NULL)
+	if (Interp_norms != nullptr) {
 		vm_free(Interp_norms);
+		Interp_norms = nullptr;
+	}
 
-	if (Interp_light_applied != NULL)
+	if (Interp_light_applied != nullptr) {
 		vm_free(Interp_light_applied);
+		Interp_light_applied = nullptr;
+	}
 
-	if (Interp_lighting_temp.lights != NULL)
+	if (Interp_lighting_temp.lights != nullptr) {
 		vm_free(Interp_lighting_temp.lights);
+		Interp_lighting_temp.lights = nullptr;
+	}
 
 	Num_interp_verts_allocated = 0;
 	Num_interp_norms_allocated = 0;

--- a/code/network/multi_fstracker.cpp
+++ b/code/network/multi_fstracker.cpp
@@ -274,7 +274,10 @@ int multi_fs_tracker_validate(int show_error)
 void multi_fs_tracker_login_freespace()
 {	
 	if(!Multi_fs_tracker_inited){
-		popup(PF_USE_AFFIRMATIVE_ICON,1,POPUP_OK,XSTR("Warning, Parallax Online startup failed. Will not be able to play tracker games!",666));
+		if ( !(Game_mode & GM_STANDALONE_SERVER) ) {
+			popup(PF_USE_AFFIRMATIVE_ICON,1,POPUP_OK,XSTR("Warning, Parallax Online startup failed. Will not be able to play tracker games!",666));
+		}
+
 		return;
 	}
 

--- a/code/network/multi_obj.cpp
+++ b/code/network/multi_obj.cpp
@@ -2689,6 +2689,52 @@ void multi_init_oo_and_ship_tracker()
 	}
 }
 
+// release and reset object update info
+void multi_close_oo_and_ship_tracker()
+{
+	if ( !(Game_mode & GM_MULTIPLAYER) ) {
+		return;
+	}
+
+	// Part 1: Get the non-repeating parts of the struct set.
+	Oo_info.ref_timestamp = -1;
+	Oo_info.most_recent_updated_net_signature = 0;
+	Oo_info.most_recent_frame = 0;
+
+	for (int i = 0; i < MAX_PLAYERS; i++) { // NOLINT
+		Oo_info.received_frametimes[i].clear();
+		Oo_info.received_frametimes[i].shrink_to_fit();
+	}
+
+	Oo_info.number_of_frames = 0;
+	Oo_info.cur_frame_index = 0;
+
+	for (int i = 0; i < MAX_FRAMES_RECORDED; i++) { // NOLINT
+		Oo_info.timestamps[i] = MAX_TIME; // This needs to be Max time (or at least some absurdly high number) for rollback to work correctly
+	}
+
+	Oo_info.rollback_mode = false;
+	Oo_info.rollback_weapon_object_number.clear();
+	Oo_info.rollback_weapon_object_number.shrink_to_fit();
+	Oo_info.rollback_collide_list.clear();
+	Oo_info.rollback_collide_list.shrink_to_fit();
+	Oo_info.rollback_ships.clear();
+	Oo_info.rollback_ships.shrink_to_fit();
+
+	for (int i = 0; i < MAX_FRAMES_RECORDED; i++) { // NOLINT
+		Oo_info.rollback_shots_to_be_fired[i].clear();
+		Oo_info.rollback_shots_to_be_fired[i].shrink_to_fit();
+	}
+
+	// Part 2: Init/Reset the repeating parts of the struct.
+	Oo_info.frame_info.clear();
+	Oo_info.frame_info.shrink_to_fit();
+	Oo_info.player_frame_info.clear();
+	Oo_info.player_frame_info.shrink_to_fit();
+	Oo_info.interp.clear();
+	Oo_info.interp.shrink_to_fit();
+}
+
 
 // send control info for a client (which is basically a "reverse" object update)
 void multi_oo_send_control_info()

--- a/code/network/multi_obj.h
+++ b/code/network/multi_obj.h
@@ -123,6 +123,8 @@ void multi_oo_process_update(ubyte *data, header *hinfo);
 
 // initialize all object update timestamps (call whenever entering gameplay state)
 void multi_init_oo_and_ship_tracker();
+// release memory allocated for object update
+void multi_close_oo_and_ship_tracker();
 
 // send control info for a client (which is basically a "reverse" object update)
 void multi_oo_send_control_info();

--- a/code/network/multi_portfwd.cpp
+++ b/code/network/multi_portfwd.cpp
@@ -164,6 +164,8 @@ void multi_port_forward_close()
 		ml_string("Port forward => Shutdown");
 	}
 
+	free(PF_pcp_ctx);	// system call, allocated in lib  ** don't change! **
+
 	PF_pcp_ctx = nullptr;
 	PF_pcp_flow = nullptr;
 

--- a/code/particle/ParticleManager.cpp
+++ b/code/particle/ParticleManager.cpp
@@ -222,7 +222,7 @@ ParticleEffectHandle ParticleManager::addEffect(ParticleEffectPtr effect)
 	if (Is_standalone) {
 		delete effect;
 
-		return ParticleEffectHandle();
+		return ParticleEffectHandle::invalid();
 	}
 
 	Assertion(effect, "Invalid effect pointer passed!");

--- a/code/particle/ParticleManager.cpp
+++ b/code/particle/ParticleManager.cpp
@@ -183,43 +183,48 @@ ParticleEffectHandle ParticleManager::getEffectByName(const SCP_string& name)
 
 void ParticleManager::doFrame(float) {
 	if (Is_standalone) {
-		// Don't process sources for standalone server
-		m_sources.clear(); // Always clear the vector to free memory
+		return;
 	}
-	else {
-		TRACE_SCOPE(tracing::ProcessParticleEffects);
 
-		m_processingSources = true;
+	TRACE_SCOPE(tracing::ProcessParticleEffects);
 
-		for (auto source = std::begin(m_sources); source != std::end(m_sources);) {
-			if (!source->isValid() || !source->process()) {
-				// if we're sitting on the very last source, popping-back will invalidate the iterator!
-				if (std::next(source) == m_sources.end()) {
-					m_sources.pop_back();
-					break;
-				}
+	m_processingSources = true;
 
-				*source = std::move(m_sources.back());
+	for (auto source = std::begin(m_sources); source != std::end(m_sources);) {
+		if (!source->isValid() || !source->process()) {
+			// if we're sitting on the very last source, popping-back will invalidate the iterator!
+			if (std::next(source) == m_sources.end()) {
 				m_sources.pop_back();
-				continue;
+				break;
 			}
 
-			// source is only incremented here as elements would be skipped in
-			// the case that a source needs to be removed
-			++source;
+			*source = std::move(m_sources.back());
+			m_sources.pop_back();
+			continue;
 		}
 
-		m_processingSources = false;
-
-		for (auto& source : m_deferredSourceAdding) {
-			m_sources.push_back(source);
-		}
-		m_deferredSourceAdding.clear();
+		// source is only incremented here as elements would be skipped in
+		// the case that a source needs to be removed
+		++source;
 	}
+
+	m_processingSources = false;
+
+	for (auto& source : m_deferredSourceAdding) {
+		m_sources.push_back(source);
+	}
+	m_deferredSourceAdding.clear();
 }
 
 ParticleEffectHandle ParticleManager::addEffect(ParticleEffectPtr effect)
 {
+	// we don't need this on standalone so remove the effect and return something invalid
+	if (Is_standalone) {
+		delete effect;
+
+		return ParticleEffectHandle();
+	}
+
 	Assertion(effect, "Invalid effect pointer passed!");
 
 #ifndef NDEBUG
@@ -289,6 +294,7 @@ ParticleSourceWrapper ParticleManager::createSource(ParticleEffectHandle index)
 
 void ParticleManager::clearSources() {
 	m_sources.clear();
+	m_deferredSourceAdding.clear();
 }
 
 namespace util {

--- a/code/particle/effects/SingleParticleEffect.cpp
+++ b/code/particle/effects/SingleParticleEffect.cpp
@@ -62,6 +62,10 @@ SingleParticleEffect* SingleParticleEffect::createInstance(int effectID, float m
 	Assertion(minSize <= maxSize, "Maximum size %f is more than minimum size %f!", maxSize, minSize);
 	Assertion(minSize >= 0.0f, "Minimum size may not be less than zero, got %f!", minSize);
 
+	if (Is_standalone) {
+		return nullptr;
+	}
+
 	auto effectPtr = new SingleParticleEffect("");
 	effectPtr->m_particleProperties.m_bitmap_list.push_back(effectID);
 	effectPtr->m_particleProperties.m_bitmap_range = ::util::UniformRange<size_t>(0, effectPtr->m_particleProperties.m_bitmap_list.size() - 1);

--- a/code/particle/particle.cpp
+++ b/code/particle/particle.cpp
@@ -91,6 +91,12 @@ namespace particle
 	// Reset everything between levels
 	void init()
 	{
+		if (Is_standalone)
+		{
+			Particles_enabled = 0;
+			return;
+		}
+
 		// FIRE!!!
 		if (Anim_bitmap_id_fire == -1)
 		{
@@ -119,6 +125,11 @@ namespace particle
 
 	void page_in()
 	{
+		if (!Particles_enabled)
+		{
+			return;
+		}
+
 		bm_page_in_texture(Anim_bitmap_id_fire);
 		bm_page_in_texture(Anim_bitmap_id_smoke);
 		bm_page_in_texture(Anim_bitmap_id_smoke2);

--- a/code/weapon/trails.cpp
+++ b/code/weapon/trails.cpp
@@ -21,8 +21,8 @@
 #include "weapon/trails.h"
 #include "render/batching.h"
 
-int Num_trails;
-trail Trails;
+static int Num_trails = 0;
+static trail Trails;
 
 // Reset everything between levels
 void trail_level_init()
@@ -33,6 +33,10 @@ void trail_level_init()
 
 void trail_level_close()
 {
+	if ( !Num_trails ) {
+		return;
+	}
+
 	trail *nextp;
 	for(trail *trailp = Trails.next; trailp != &Trails; trailp = nextp)
 	{

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -5349,7 +5349,7 @@ static void weapon_set_state(weapon_info* wip, weapon* wp, WeaponState state)
 
 	auto map_entry = wip->state_effects.find(wp->weapon_state);
 
-	if (map_entry != wip->state_effects.end())
+	if ((map_entry != wip->state_effects.end()) && map_entry->second.isValid())
 	{
 		auto source = particle::ParticleManager::get()->createSource(map_entry->second);
 

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -902,6 +902,10 @@ void game_level_close()
 		Weapon_energy_cheat = false;
 
 		game_time_level_close();
+
+		if (Game_mode & GM_STANDALONE_SERVER) {
+			model_free_all();			// Free all existing models if standalone server
+		}
 	}
 	else
 	{

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -1705,8 +1705,15 @@ void game_init()
 		Cmdline_spec = 0;
 		Cmdline_glow = 0;
 		Cmdline_env = 0;
-		Fireball_use_3d_warp = false;
+		Cmdline_height = 0;
 		Cmdline_normal = 0;
+		Cmdline_voice_recognition = 0;
+		Cmdline_freespace_no_sound = 1;
+		Cmdline_freespace_no_music = 1;
+		Cmdline_NoFPSCap = 0;
+		Cmdline_load_all_weapons = 0;
+		Cmdline_enable_3d_shockwave = 0;
+		Fireball_use_3d_warp = false;
 
 		// now init the standalone server code
 		std_init_standalone();

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -907,6 +907,14 @@ void game_level_close()
 
 		if (Game_mode & GM_STANDALONE_SERVER) {
 			model_free_all();			// Free all existing models if standalone server
+
+			// clean out interp data as it's better to allocate as needed here instead
+			// of letting it use a bunch of memory
+			extern void model_deallocate_interp_data();
+			model_deallocate_interp_data();
+
+			extern void model_collide_free_point_list();
+			model_collide_free_point_list();
 		}
 	}
 	else

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -895,6 +895,8 @@ void game_level_close()
 
 		stars_level_close();
 
+		multi_close_oo_and_ship_tracker();
+
 		Pilot.save_savefile();
 
 		// Cybor17 - also, undo cheats.

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -1966,11 +1966,13 @@ void game_init()
 	// convert old pilot files (if they need it)
 	convert_pilot_files();
 
+	if ( !Is_standalone ) {
 #ifdef WITH_FFMPEG
-	libs::ffmpeg::initialize();
+		libs::ffmpeg::initialize();
 #endif
 
-	libs::discord::init();
+		libs::discord::init();
+	}
 
 	nprintf(("General", "Ships.tbl is : %s\n", Game_ships_tbl_valid ? "VALID" : "INVALID!!!!"));
 	nprintf(("General", "Weapons.tbl is : %s\n", Game_weapons_tbl_valid ? "VALID" : "INVALID!!!!"));
@@ -6552,7 +6554,7 @@ int game_main(int argc, char *argv[])
 		return 1;
 	}
 
-	if (!headtracking::init())
+	if (!Is_standalone && !headtracking::init())
 	{
 		mprintf(("Headtracking is not enabled...\n"));
 	}


### PR DESCRIPTION
Various fixes and optimizations for standalone servers, plus minor general fixes.

- reduces memory usage for standalones 35-40 MB by not initializing unneeded stuff
- fix crash on standalone reset if level has never loaded
- fix small portfwd memory leak