### PR TITLE
Fix incorrect net signature for wave ships

### DIFF
--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -4227,7 +4227,7 @@ int parse_wing_create_ships( wing *wingp, int num_to_create, int force, int spec
 		// base + total_arrived_count (before adding 1)
 		// Cyborg -- The original ships in the wave have their net_signature set at mission parse
 		// so only do this if this is a subsequent wave.
-		if (Game_mode & GM_MULTIPLAYER && wingp->num_waves > 1)
+		if (Game_mode & GM_MULTIPLAYER && wingp->current_wave > 1)
 		{
 			// Cyborg -- Also, then we need to subtract the original wave's number of fighters 
 			// and also subtract 1 to use the wing's starting signature


### PR DESCRIPTION
Previously, multiplayer missions with wings with waves would incorrectly set the `net_signature` of ships in the initial wave. The code is supposed to only set the `net_signature` if it was past the initial wave. This is because original ships in the wave have their `net signature` set at mission parse. (Note, the check `wingp->current_wave > 1` is also used in the docking code to check for initial wave or not status).

This PR fixes that and has been confirmed to work via multiplayer tests. 