### PR TITLE
FFmpeg deprecations fix for FFmpeg >= 5

### DIFF
--- a/code/libs/ffmpeg/FFmpegHeaders.h
+++ b/code/libs/ffmpeg/FFmpegHeaders.h
@@ -6,6 +6,7 @@
 #pragma warning(disable: 4244) // conversion from 'int' to '*'
 
 extern "C" {
+#include <libavcodec/avcodec.h>
 #include <libavcodec/version.h>
 #include <libavformat/avformat.h>
 #include <libswscale/swscale.h>


### PR DESCRIPTION
```
FFmpeg commit e67e02d15672 [1] dropped avcodec.h from avformat.h includes hence
add an include for it to fix build after that commit.

[1]: https://github.com/FFmpeg/FFmpeg/commit/e67e02d15672a87da1b0566e197a1e19dc7e1e33
```