### PR TITLE
Revert timestamp change for event music

### DIFF
--- a/code/gamesnd/eventmusic.cpp
+++ b/code/gamesnd/eventmusic.cpp
@@ -659,7 +659,7 @@ void event_music_first_pattern()
 			audiostream_stop( Patterns[Current_pattern].handle );
 	}
 
-	Pattern_timer_id = timestamp(2000);	// start music delay
+	Pattern_timer_id = 2000;	// start music delay
 	
 	Event_music_begun = FALSE;
 	if ( Event_Music_battle_started == TRUE ) {


### PR DESCRIPTION
The timestamp fix/cleanup in #3878 revealed a longstanding bug with music timestamps--the timestamps were never set to something valid later.

This is a widespread issue in the code, fortunately Goober is modifying the timestamp code to accommodate invalid timestamps.

Fixes #3929.