### PR TITLE
Fix Bay Door Animations for Multi and Lone Player Ship

### DIFF
--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -13251,7 +13251,7 @@ int ai_acquire_emerge_path(object *pl_objp, int parent_objnum, int allowed_path_
 
 	//This is kind of hacky, but allows for hangarbay animations to trigger even if the player is not accompanied by AI.
 	//Since it doesn't really keep track of this, it won't ever tell the bay door that the player has fully left for it to close again.
-	if (Player_obj == pl_objp)
+	if (pl_objp->flags[Object::Object_Flags::Player_ship])
 		ai_manage_bay_doors(pl_objp, aip, false);
 
 	//due to the door animations the ship has to remain still until the doors are open


### PR DESCRIPTION
For a long time, bay door animations would not trigger if the player was arriving from the bay as the the only ship in the wing. This was fixed by adding a check for the player. This check uses the `Player_obj` to check if the ship is as player, which does not work on standalones since the `Player_obj` is always the Standalone Ship.

This PR changes the check to check if the flag `Player_ship` is set, which is a common strategy used to make these kinds of checks work on standalones.

Tests show the old behavior still works as expected (including sole-player arrivals, player with other ships, and only AI ships).