### PR TITLE
allow dockpoints to be anchored to submodels explicitly

### DIFF
--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -9480,6 +9480,14 @@ int find_parent_rotating_submodel(polymodel *pm, int dock_index)
 	Assertion(dock_index >= 0 && dock_index < pm->n_docks, "for model %s, dock_index %d must be >= 0 and < %d!", pm->filename, dock_index, pm->n_docks);
 	int path_num, submodel;
 
+	// if this is explicitly defined, then we're done
+	if (pm->docking_bays[dock_index].parent_submodel >= 0)
+	{
+		return pm->docking_bays[dock_index].parent_submodel;
+	}
+
+	// otherwise infer the submodel using the path...
+
 	// make sure we have a spline path to check against before going any further
 	if (pm->docking_bays[dock_index].num_spline_paths <= 0)
 	{

--- a/code/model/model.h
+++ b/code/model/model.h
@@ -486,6 +486,7 @@ typedef struct dock_bay {
 	int		type_flags;					// indicates what this docking bay can be used for (i.e. cargo/rearm, etc)
 	int		num_spline_paths;			// number of spline paths which lead to this docking bay
 	int		*splines;					// array of indices into the Spline_path array
+	int		parent_submodel;			// if this dockpoint should be relative to a submodel instead of the main model
 	char		name[MAX_NAME_LEN];		// name of this docking location
 	vec3d	pnt[MAX_DOCK_SLOTS];
 	vec3d	norm[MAX_DOCK_SLOTS];


### PR DESCRIPTION
By anchoring a dockpoint to a submodel, the dockpoint will move when the submodel moves.  Historically this has been done by inspecting the path associated with a dockpoint, but this method will not work if there is no path or no rotation mode specified.  Here is an alternate method that allows the submodel to be specified explicitly through a dockpoint property.