### PR TITLE
Remove unnecessary/leaky strdup() calls in sexp_list_item in FRED/QtFRED

### DIFF
--- a/fred2/sexp_tree.cpp
+++ b/fred2/sexp_tree.cpp
@@ -2234,7 +2234,7 @@ void sexp_list_item::set_data(const char *str, int t)
 void sexp_list_item::set_data_dup(const char *str, int t)
 {
 	op = -1;
-	text = strdup(str);
+	text = str;
 	flags |= SEXP_ITEM_F_DUP;
 	type = t;
 }
@@ -2283,7 +2283,7 @@ void sexp_list_item::add_data_dup(const char *str, int t)
 		ptr = ptr->next;
 
 	ptr->next = item;
-	item->set_data(strdup(str), t);
+	item->set_data(str, t);
 	item->flags |= SEXP_ITEM_F_DUP;
 }
 

--- a/qtfred/src/ui/widgets/sexp_tree.cpp
+++ b/qtfred/src/ui/widgets/sexp_tree.cpp
@@ -866,7 +866,7 @@ void sexp_list_item::set_data(const char* str, int t) {
 //
 void sexp_list_item::set_data_dup(const char* str, int t) {
 	op = -1;
-	text = strdup(str);
+	text = str;
 	flags |= SEXP_ITEM_F_DUP;
 	type = t;
 }
@@ -915,7 +915,7 @@ void sexp_list_item::add_data_dup(const char* str, int t) {
 	}
 
 	ptr->next = item;
-	item->set_data(strdup(str), t);
+	item->set_data(str, t);
 	item->flags |= SEXP_ITEM_F_DUP;
 }
 


### PR DESCRIPTION
Since `sexp_list_item::text` is an `SCP_string`, these `strdup()` calls are unnecessary and are leaking memory.

For context, these objects are used to populate the right-click menu options for, e.g., Replace Data.