### PR TITLE
Remove _dup() functions from sexp_list_item in FRED and QtFRED

### DIFF
--- a/fred2/sexp_tree.cpp
+++ b/fred2/sexp_tree.cpp
@@ -2228,17 +2228,6 @@ void sexp_list_item::set_data(const char *str, int t)
 	type = t;
 }
 
-// initialize node, type data, allocating memory for the text
-// Defaults: t = SEXPT_STRING
-//
-void sexp_list_item::set_data_dup(const char *str, int t)
-{
-	op = -1;
-	text = str;
-	flags |= SEXP_ITEM_F_DUP;
-	type = t;
-}
-
 // add a node to end of list
 //
 void sexp_list_item::add_op(int op_num)
@@ -2268,23 +2257,6 @@ void sexp_list_item::add_data(const char *str, int t)
 
 	ptr->next = item;
 	item->set_data(str, t);
-}
-
-// add a node to end of list, allocating memory for the text
-// Defaults: t = SEXPT_STRING
-//
-void sexp_list_item::add_data_dup(const char *str, int t)
-{
-	sexp_list_item *item, *ptr;
-
-	item = new sexp_list_item;
-	ptr = this;
-	while (ptr->next)
-		ptr = ptr->next;
-
-	ptr->next = item;
-	item->set_data(str, t);
-	item->flags |= SEXP_ITEM_F_DUP;
 }
 
 // add an sexp list to end of another list (join lists)
@@ -2468,9 +2440,8 @@ int sexp_tree::get_default_value(sexp_list_item *item, char *text_buf, int op, i
 						break;
 				}
 
-				// Goober5000 - set_data_dup is required if we're passing a variable
 				sprintf(sexp_str_token, "%d", temp);
-				item->set_data_dup(sexp_str_token, (SEXPT_NUMBER | SEXPT_VALID));
+				item->set_data(sexp_str_token, (SEXPT_NUMBER | SEXPT_VALID));
 			}
 			else if (Operators[op].value == OP_WARP_EFFECT)
 			{
@@ -2490,9 +2461,8 @@ int sexp_tree::get_default_value(sexp_list_item *item, char *text_buf, int op, i
 						break;
 				}
 
-				// Goober5000 - set_data_dup is required if we're passing a variable
 				sprintf(sexp_str_token, "%d", temp);
-				item->set_data_dup(sexp_str_token, (SEXPT_NUMBER | SEXPT_VALID));
+				item->set_data(sexp_str_token, (SEXPT_NUMBER | SEXPT_VALID));
 			}
 			else if (Operators[op].value == OP_CHANGE_BACKGROUND)
 			{
@@ -2517,7 +2487,7 @@ int sexp_tree::get_default_value(sexp_list_item *item, char *text_buf, int op, i
 				}
 
 				sprintf(sexp_str_token, "%d", temp);
-				item->set_data_dup(sexp_str_token, (SEXPT_NUMBER | SEXPT_VALID));
+				item->set_data(sexp_str_token, (SEXPT_NUMBER | SEXPT_VALID));
 			}
 			else if (Operators[op].value == OP_ADD_SUN_BITMAP)
 			{
@@ -2528,7 +2498,7 @@ int sexp_tree::get_default_value(sexp_list_item *item, char *text_buf, int op, i
 					temp = 100;
 
 				sprintf(sexp_str_token, "%d", temp);
-				item->set_data_dup(sexp_str_token, (SEXPT_NUMBER | SEXPT_VALID));
+				item->set_data(sexp_str_token, (SEXPT_NUMBER | SEXPT_VALID));
 			}
 			else if (Operators[op].value == OP_MISSION_SET_NEBULA)
 			{
@@ -5279,7 +5249,7 @@ sexp_list_item *sexp_tree::get_listing_opf_point()
 		for (j = 0; (uint) j < ii->get_waypoints().size(); ++j)
 		{
 			sprintf(buf, "%s:%d", ii->get_name(), j + 1);
-			head.add_data_dup(buf);
+			head.add_data(buf);
 		}
 	}
 
@@ -5409,7 +5379,7 @@ sexp_list_item *sexp_tree::get_listing_opf_arrival_anchor_all()
 			char tmp[NAME_LENGTH + 15];
 			stuff_special_arrival_anchor_name(tmp, i, restrict_to_players, 0);
 
-			head.add_data_dup(tmp);
+			head.add_data(tmp);
 		}
 	}
 
@@ -5623,7 +5593,7 @@ sexp_list_item *sexp_tree::get_listing_opf_sound_environment()
 
 	head.add_data(SEXP_NONE_STRING);
 	for (int i = 0; i  < (int)EFX_presets.size(); i++) {
-		head.add_data_dup(EFX_presets[i].name.c_str());
+		head.add_data(EFX_presets[i].name.c_str());
 	}
 
 	return head.next;
@@ -5691,7 +5661,7 @@ sexp_list_item *sexp_tree::get_listing_opf_ship_effect()
 	sexp_list_item head;
 	
 	for (SCP_vector<ship_effect>::iterator sei = Ship_effects.begin(); sei != Ship_effects.end(); ++sei) {
-		head.add_data_dup(sei->name);
+		head.add_data(sei->name);
 	}
 
 	return head.next;
@@ -5751,7 +5721,7 @@ sexp_list_item *sexp_tree::get_listing_opf_ship_wing_shiponteam_point()
 		char tmp[NAME_LENGTH + 7];
 		sprintf(tmp, "<any %s>", Iff_info[i].iff_name);
 		strlwr(tmp);
-		head.add_data_dup(tmp);
+		head.add_data(tmp);
 	}
 
 	head.add_list(get_listing_opf_ship_wing_point());
@@ -5870,7 +5840,7 @@ sexp_list_item *sexp_tree::get_listing_opf_keypress()
 		auto btn = Default_config[i].get_btn(CID_KEYBOARD);
 
 		if ((btn >= 0) && !Control_config[i].disabled) {
-			head.add_data_dup(textify_scancode(btn));
+			head.add_data(textify_scancode(btn));
 		}
 	}
 
@@ -6178,9 +6148,9 @@ sexp_list_item *sexp_tree::get_listing_opf_post_effect()
 	SCP_vector<SCP_string> ppe_names;
 	gr_get_post_process_effect_names(ppe_names);
 	for (i=0; i < ppe_names.size(); i++) {
-		head.add_data_dup(ppe_names[i].c_str());
+		head.add_data(ppe_names[i].c_str());
 	}
-	head.add_data_dup("lightshafts");
+	head.add_data("lightshafts");
 
 	return head.next;
 }
@@ -6250,7 +6220,7 @@ sexp_list_item *sexp_tree::get_listing_opf_mission_moods()
 {
 	sexp_list_item head;
 	for (SCP_vector<SCP_string>::iterator iter = Builtin_moods.begin(); iter != Builtin_moods.end(); ++iter) {
-		head.add_data_dup(iter->c_str());
+		head.add_data(iter->c_str());
 	}
 
 	return head.next;
@@ -6262,15 +6232,15 @@ sexp_list_item *sexp_tree::get_listing_opf_ship_flags()
 	sexp_list_item head;
 	// object flags
 	for ( i = 0; i < MAX_OBJECT_FLAG_NAMES; i++) {
-		head.add_data_dup(Object_flag_names[i].flag_name);
+		head.add_data(Object_flag_names[i].flag_name);
 	}
 	// ship flags
 	for ( i = 0; i < MAX_SHIP_FLAG_NAMES; i++) {
-		head.add_data_dup(Ship_flag_names[i].flag_name);
+		head.add_data(Ship_flag_names[i].flag_name);
 	}
 	// ai flags
 	for ( i = 0; i < MAX_AI_FLAG_NAMES; i++) {
-		head.add_data_dup(Ai_flag_names[i].flag_name);
+		head.add_data(Ai_flag_names[i].flag_name);
 	}
 
 	return head.next;
@@ -6281,7 +6251,7 @@ sexp_list_item *sexp_tree::get_listing_opf_team_colors()
 	sexp_list_item head;
 	head.add_data("None");
 	for (SCP_map<SCP_string, team_color>::iterator tcolor = Team_Colors.begin(); tcolor != Team_Colors.end(); ++tcolor) {
-		head.add_data_dup(tcolor->first.c_str());
+		head.add_data(tcolor->first.c_str());
 	}
 
 	return head.next;

--- a/fred2/sexp_tree.h
+++ b/fred2/sexp_tree.h
@@ -100,7 +100,7 @@ public:
 	SCP_string text;
 	sexp_list_item *next;
 
-	sexp_list_item() : next(NULL) {}
+	sexp_list_item() : next(nullptr) {}
 
 	void set_op(int op_num);
 	void set_data(const char *str, int t = (SEXPT_STRING | SEXPT_VALID));

--- a/fred2/sexp_tree.h
+++ b/fred2/sexp_tree.h
@@ -73,8 +73,6 @@
 #define ROOT_DELETED	1
 #define ROOT_RENAMED	2
 
-#define SEXP_ITEM_F_DUP	(1<<0)
-
 /*
  * Notes: An sexp_tree_item is basically a node in a tree.  The sexp_tree is an array of
  * these node items.
@@ -107,11 +105,9 @@ public:
 
 	void set_op(int op_num);
 	void set_data(const char *str, int t = (SEXPT_STRING | SEXPT_VALID));
-	void set_data_dup(const char *str, int t = (SEXPT_STRING | SEXPT_VALID));
 
 	void add_op(int op_num);
 	void add_data(const char *str, int t = (SEXPT_STRING | SEXPT_VALID));
-	void add_data_dup(const char *str, int t = (SEXPT_STRING | SEXPT_VALID));
 	void add_list(sexp_list_item *list);
 
 	void shallow_copy(const sexp_list_item *src);

--- a/fred2/sexp_tree.h
+++ b/fred2/sexp_tree.h
@@ -98,10 +98,9 @@ public:
 	int type;
 	int op;
 	SCP_string text;
-	int flags;
 	sexp_list_item *next;
 
-	sexp_list_item() : flags(0), next(NULL) {}
+	sexp_list_item() : next(NULL) {}
 
 	void set_op(int op_num);
 	void set_data(const char *str, int t = (SEXPT_STRING | SEXPT_VALID));

--- a/qtfred/src/ui/widgets/sexp_tree.cpp
+++ b/qtfred/src/ui/widgets/sexp_tree.cpp
@@ -861,16 +861,6 @@ void sexp_list_item::set_data(const char* str, int t) {
 	type = t;
 }
 
-// initialize node, type data, allocating memory for the text
-// Defaults: t = SEXPT_STRING
-//
-void sexp_list_item::set_data_dup(const char* str, int t) {
-	op = -1;
-	text = str;
-	flags |= SEXP_ITEM_F_DUP;
-	type = t;
-}
-
 // add a node to end of list
 //
 void sexp_list_item::add_op(int op_num) {
@@ -900,23 +890,6 @@ void sexp_list_item::add_data(const char* str, int t) {
 
 	ptr->next = item;
 	item->set_data(str, t);
-}
-
-// add a node to end of list, allocating memory for the text
-// Defaults: t = SEXPT_STRING
-//
-void sexp_list_item::add_data_dup(const char* str, int t) {
-	sexp_list_item* item, * ptr;
-
-	item = new sexp_list_item;
-	ptr = this;
-	while (ptr->next) {
-		ptr = ptr->next;
-	}
-
-	ptr->next = item;
-	item->set_data(str, t);
-	item->flags |= SEXP_ITEM_F_DUP;
 }
 
 // add an sexp list to end of another list (join lists)
@@ -1081,9 +1054,8 @@ int sexp_tree::get_default_value(sexp_list_item* item, char* text_buf, int op, i
 				break;
 			}
 
-			// Goober5000 - set_data_dup is required if we're passing a variable
 			sprintf(sexp_str_token, "%d", temp);
-			item->set_data_dup(sexp_str_token, (SEXPT_NUMBER | SEXPT_VALID));
+			item->set_data(sexp_str_token, (SEXPT_NUMBER | SEXPT_VALID));
 		} else if (Operators[op].value == OP_WARP_EFFECT) {
 			int temp;
 			char sexp_str_token[TOKEN_LENGTH];
@@ -1100,9 +1072,8 @@ int sexp_tree::get_default_value(sexp_list_item* item, char* text_buf, int op, i
 				break;
 			}
 
-			// Goober5000 - set_data_dup is required if we're passing a variable
 			sprintf(sexp_str_token, "%d", temp);
-			item->set_data_dup(sexp_str_token, (SEXPT_NUMBER | SEXPT_VALID));
+			item->set_data(sexp_str_token, (SEXPT_NUMBER | SEXPT_VALID));
 		} else if (Operators[op].value == OP_CHANGE_BACKGROUND) {
 			item->set_data("1", (SEXPT_NUMBER | SEXPT_VALID));
 		} else if (Operators[op].value == OP_ADD_BACKGROUND_BITMAP) {
@@ -1122,7 +1093,7 @@ int sexp_tree::get_default_value(sexp_list_item* item, char* text_buf, int op, i
 			}
 
 			sprintf(sexp_str_token, "%d", temp);
-			item->set_data_dup(sexp_str_token, (SEXPT_NUMBER | SEXPT_VALID));
+			item->set_data(sexp_str_token, (SEXPT_NUMBER | SEXPT_VALID));
 		} else if (Operators[op].value == OP_ADD_SUN_BITMAP) {
 			int temp = 0;
 			char sexp_str_token[TOKEN_LENGTH];
@@ -1132,7 +1103,7 @@ int sexp_tree::get_default_value(sexp_list_item* item, char* text_buf, int op, i
 			}
 
 			sprintf(sexp_str_token, "%d", temp);
-			item->set_data_dup(sexp_str_token, (SEXPT_NUMBER | SEXPT_VALID));
+			item->set_data(sexp_str_token, (SEXPT_NUMBER | SEXPT_VALID));
 		} else if (Operators[op].value == OP_MISSION_SET_NEBULA) {
 			if (i == 0) {
 				item->set_data("1", (SEXPT_NUMBER | SEXPT_VALID));
@@ -3592,7 +3563,7 @@ sexp_list_item* sexp_tree::get_listing_opf_point() {
 	for (ii = Waypoint_lists.begin(); ii != Waypoint_lists.end(); ++ii) {
 		for (j = 0; (uint) j < ii->get_waypoints().size(); ++j) {
 			sprintf(buf, "%s:%d", ii->get_name(), j + 1);
-			head.add_data_dup(buf);
+			head.add_data(buf);
 		}
 	}
 
@@ -3708,7 +3679,7 @@ sexp_list_item* sexp_tree::get_listing_opf_arrival_anchor_all() {
 			char tmp[NAME_LENGTH + 15];
 			stuff_special_arrival_anchor_name(tmp, i, restrict_to_players, 0);
 
-			head.add_data_dup(tmp);
+			head.add_data(tmp);
 		}
 	}
 
@@ -3902,7 +3873,7 @@ sexp_list_item* sexp_tree::get_listing_opf_sound_environment() {
 
 	head.add_data(SEXP_NONE_STRING);
 	for (int i = 0; i < (int) EFX_presets.size(); i++) {
-		head.add_data_dup(EFX_presets[i].name.c_str());
+		head.add_data(EFX_presets[i].name.c_str());
 	}
 
 	return head.next;
@@ -3969,7 +3940,7 @@ sexp_list_item* sexp_tree::get_listing_opf_ship_effect() {
 	sexp_list_item head;
 
 	for (SCP_vector<ship_effect>::iterator sei = Ship_effects.begin(); sei != Ship_effects.end(); ++sei) {
-		head.add_data_dup(sei->name);
+		head.add_data(sei->name);
 	}
 
 	return head.next;
@@ -4026,7 +3997,7 @@ sexp_list_item* sexp_tree::get_listing_opf_ship_wing_shiponteam_point() {
 		SCP_string tmp;
 		sprintf(tmp, "<any %s>", Iff_info[i].iff_name);
 		std::transform(begin(tmp), end(tmp), begin(tmp), [](char c) { return (char)::tolower(c); });
-		head.add_data_dup(tmp.c_str());
+		head.add_data(tmp.c_str());
 	}
 
 	head.add_list(get_listing_opf_ship_wing_point());
@@ -4159,7 +4130,7 @@ sexp_list_item* sexp_tree::get_listing_opf_keypress() {
 		auto btn = Default_config[i].get_btn(CID_KEYBOARD);
 
 		if ((btn >= -1) && !Control_config[i].disabled) {
-			head.add_data_dup(textify_scancode(btn));
+			head.add_data(textify_scancode(btn));
 		}
 	}
 
@@ -4458,9 +4429,9 @@ sexp_list_item* sexp_tree::get_listing_opf_post_effect() {
 	SCP_vector<SCP_string> ppe_names;
 	gr_get_post_process_effect_names(ppe_names);
 	for (i = 0; i < ppe_names.size(); i++) {
-		head.add_data_dup(ppe_names[i].c_str());
+		head.add_data(ppe_names[i].c_str());
 	}
-	head.add_data_dup("lightshafts");
+	head.add_data("lightshafts");
 
 	return head.next;
 }
@@ -4525,7 +4496,7 @@ sexp_list_item* sexp_tree::get_listing_opf_weapon_banks() {
 sexp_list_item* sexp_tree::get_listing_opf_mission_moods() {
 	sexp_list_item head;
 	for (SCP_vector<SCP_string>::iterator iter = Builtin_moods.begin(); iter != Builtin_moods.end(); ++iter) {
-		head.add_data_dup(iter->c_str());
+		head.add_data(iter->c_str());
 	}
 
 	return head.next;
@@ -4536,15 +4507,15 @@ sexp_list_item* sexp_tree::get_listing_opf_ship_flags() {
 	sexp_list_item head;
 	// object flags
 	for (i = 0; i < MAX_OBJECT_FLAG_NAMES; i++) {
-		head.add_data_dup(Object_flag_names[i].flag_name);
+		head.add_data(Object_flag_names[i].flag_name);
 	}
 	// ship flags
 	for (i = 0; i < MAX_SHIP_FLAG_NAMES; i++) {
-		head.add_data_dup(Ship_flag_names[i].flag_name);
+		head.add_data(Ship_flag_names[i].flag_name);
 	}
 	// ai flags
 	for (i = 0; i < MAX_AI_FLAG_NAMES; i++) {
-		head.add_data_dup(Ai_flag_names[i].flag_name);
+		head.add_data(Ai_flag_names[i].flag_name);
 	}
 
 	return head.next;
@@ -4555,7 +4526,7 @@ sexp_list_item* sexp_tree::get_listing_opf_team_colors() {
 	head.add_data("None");
 	for (SCP_map<SCP_string, team_color>::iterator tcolor = Team_Colors.begin(); tcolor != Team_Colors.end();
 		 ++tcolor) {
-		head.add_data_dup(tcolor->first.c_str());
+		head.add_data(tcolor->first.c_str());
 	}
 
 	return head.next;

--- a/qtfred/src/ui/widgets/sexp_tree.h
+++ b/qtfred/src/ui/widgets/sexp_tree.h
@@ -144,10 +144,9 @@ class sexp_list_item {
 	int type;
 	int op;
 	SCP_string text;
-	int flags;
 	sexp_list_item* next;
 
-	sexp_list_item() : flags(0), next(NULL) {
+	sexp_list_item() : next(NULL) {
 	}
 
 	void set_op(int op_num);

--- a/qtfred/src/ui/widgets/sexp_tree.h
+++ b/qtfred/src/ui/widgets/sexp_tree.h
@@ -49,8 +49,6 @@ namespace fred {
 #define ROOT_DELETED    1
 #define ROOT_RENAMED    2
 
-#define SEXP_ITEM_F_DUP    (1<<0)
-
 // tree behavior modes (or tree subtype)
 FLAG_LIST(TreeFlags) {
 	LabeledRoot = 0,
@@ -154,11 +152,9 @@ class sexp_list_item {
 
 	void set_op(int op_num);
 	void set_data(const char* str, int t = (SEXPT_STRING | SEXPT_VALID));
-	void set_data_dup(const char* str, int t = (SEXPT_STRING | SEXPT_VALID));
 
 	void add_op(int op_num);
 	void add_data(const char* str, int t = (SEXPT_STRING | SEXPT_VALID));
-	void add_data_dup(const char* str, int t = (SEXPT_STRING | SEXPT_VALID));
 	void add_list(sexp_list_item* list);
 
 	void destroy();

--- a/qtfred/src/ui/widgets/sexp_tree.h
+++ b/qtfred/src/ui/widgets/sexp_tree.h
@@ -146,7 +146,7 @@ class sexp_list_item {
 	SCP_string text;
 	sexp_list_item* next;
 
-	sexp_list_item() : next(NULL) {
+	sexp_list_item() : next(nullptr) {
 	}
 
 	void set_op(int op_num);


### PR DESCRIPTION
Follow-up to PR #3940 to remove `sexp_list_item` functions `add_data_dup()` and `set_data_dup()`, which are no longer needed.