### PR TITLE
TBP warp fix

### DIFF
--- a/code/cmdline/cmdline.cpp
+++ b/code/cmdline/cmdline.cpp
@@ -375,7 +375,7 @@ int Cmdline_rearm_timer = 0;
 int Cmdline_targetinfo = 0;
 
 // Gameplay related
-cmdline_parm use_3dwarp("-3dwarp", NULL, AT_NONE);			// Cmdline_3dwarp
+cmdline_parm use_3dwarp("-3dwarp", NULL, AT_NONE);			// Is now Fireball_use_3d_warp
 cmdline_parm ship_choice_3d_arg("-ship_choice_3d", NULL, AT_NONE);	// Cmdline_ship_choice_3d
 cmdline_parm weapon_choice_3d_arg("-weapon_choice_3d", NULL, AT_NONE);	// Cmdline_weapon_choice_3d
 cmdline_parm use_warp_flash("-warp_flash", NULL, AT_NONE);	// Cmdline_warp_flash
@@ -383,7 +383,6 @@ cmdline_parm allow_autpilot_interrupt("-no_ap_interrupt", NULL, AT_NONE);
 cmdline_parm stretch_menu("-stretch_menu", NULL, AT_NONE);	// Cmdline_stretch_menu
 cmdline_parm no_screenshake("-no_screenshake", nullptr, AT_NONE); // Cmdline_no_screenshake
 
-int Cmdline_3dwarp = 0;
 int Cmdline_ship_choice_3d = 0;
 int Cmdline_weapon_choice_3d = 0;
 int Cmdline_warp_flash = 0;

--- a/code/cmdline/cmdline.cpp
+++ b/code/cmdline/cmdline.cpp
@@ -375,12 +375,12 @@ int Cmdline_rearm_timer = 0;
 int Cmdline_targetinfo = 0;
 
 // Gameplay related
-cmdline_parm use_3dwarp("-3dwarp", NULL, AT_NONE);			// Is now Fireball_use_3d_warp
-cmdline_parm ship_choice_3d_arg("-ship_choice_3d", NULL, AT_NONE);	// Cmdline_ship_choice_3d
-cmdline_parm weapon_choice_3d_arg("-weapon_choice_3d", NULL, AT_NONE);	// Cmdline_weapon_choice_3d
-cmdline_parm use_warp_flash("-warp_flash", NULL, AT_NONE);	// Cmdline_warp_flash
-cmdline_parm allow_autpilot_interrupt("-no_ap_interrupt", NULL, AT_NONE);
-cmdline_parm stretch_menu("-stretch_menu", NULL, AT_NONE);	// Cmdline_stretch_menu
+cmdline_parm use_3dwarp("-3dwarp", nullptr, AT_NONE);			// Is now Fireball_use_3d_warp
+cmdline_parm ship_choice_3d_arg("-ship_choice_3d", nullptr, AT_NONE);	// Cmdline_ship_choice_3d
+cmdline_parm weapon_choice_3d_arg("-weapon_choice_3d", nullptr, AT_NONE);	// Cmdline_weapon_choice_3d
+cmdline_parm use_warp_flash("-warp_flash", nullptr, AT_NONE);	// Cmdline_warp_flash
+cmdline_parm allow_autpilot_interrupt("-no_ap_interrupt", nullptr, AT_NONE);
+cmdline_parm stretch_menu("-stretch_menu", nullptr, AT_NONE);	// Cmdline_stretch_menu
 cmdline_parm no_screenshake("-no_screenshake", nullptr, AT_NONE); // Cmdline_no_screenshake
 
 int Cmdline_ship_choice_3d = 0;

--- a/code/cmdline/cmdline.h
+++ b/code/cmdline/cmdline.h
@@ -83,7 +83,6 @@ extern int Cmdline_rearm_timer;
 extern int Cmdline_targetinfo;
 
 // Gameplay related
-extern int Cmdline_3dwarp;
 extern int Cmdline_ship_choice_3d;
 extern int Cmdline_weapon_choice_3d;
 extern int Cmdline_warp_flash;

--- a/code/fireball/fireballs.cpp
+++ b/code/fireball/fireballs.cpp
@@ -203,6 +203,10 @@ static void fireball_set_default_warp_attributes(int idx)
 			strcpy_s(Fireball_info[idx].warp_glow, "warpglow01");
 			strcpy_s(Fireball_info[idx].warp_ball, "warpball01");
 			strcpy_s(Fireball_info[idx].warp_model, "warp.pof");
+
+			if (Fireball_use_3d_warp)
+				Fireball_info[idx].use_3d_warp = true;
+
 			break;
 	}
 }
@@ -366,7 +370,13 @@ static void parse_fireball_tbl(const char *table_filename)
 
 			// check for custom warp model
 			if (optional_string("$Warp model:"))
+			{
 				stuff_string(fi->warp_model, F_NAME, NAME_LENGTH);
+
+				// if we are explicitly specifying a model, then we'll want to use it,
+				// rather than just having the default model that might or might not be used
+				fi->use_3d_warp = true;
+			}
 		}
 
 		required_string("#End");
@@ -1072,7 +1082,7 @@ void fireball_render(object* obj, model_draw_list *scene)
 			float rad = obj->radius * fireball_wormhole_intensity(fb);
 
 			fireball_info *fi = &Fireball_info[fb->fireball_info_index];
-			warpin_queue_render(scene, obj, &obj->orient, &obj->pos, fb->current_bitmap, rad, percent_life, obj->radius, (fb->flags & FBF_WARP_3D) != 0, fi->warp_glow_bitmap, fi->warp_ball_bitmap, fi->warp_model_id);
+			warpin_queue_render(scene, obj, &obj->orient, &obj->pos, fb->current_bitmap, rad, percent_life, obj->radius, fi->use_3d_warp || (fb->flags & FBF_WARP_3D) != 0, fi->warp_glow_bitmap, fi->warp_ball_bitmap, fi->warp_model_id);
 		}
 		break;
 

--- a/code/fireball/fireballs.cpp
+++ b/code/fireball/fireballs.cpp
@@ -26,7 +26,7 @@
 #include <cstdlib>
 
 
-int Knossos_warp_ani_used;
+bool Knossos_warp_ani_used;
 
 #define WARPHOLE_GROW_TIME		(2.35f)	// time for warphole to reach max size (also time to shrink to nothing once it begins to shrink)
 
@@ -470,7 +470,7 @@ void fireball_init()
 	Unused_fireball_indices.reserve(INTITIAL_FIREBALL_CONTAINTER_SIZE);
 
 	// Goober5000 - reset Knossos warp flag
-	Knossos_warp_ani_used = 0;
+	Knossos_warp_ani_used = false;
 }
 
 MONITOR( NumFireballsRend )

--- a/code/fireball/fireballs.h
+++ b/code/fireball/fireballs.h
@@ -143,7 +143,7 @@ int fireball_asteroid_explosion_type(asteroid_info *aip);
 float fireball_wormhole_intensity( fireball *fb );
 
 // Goober5000
-extern int Knossos_warp_ani_used;
+extern bool Knossos_warp_ani_used;
 
 extern bool Fireball_use_3d_warp;
 

--- a/code/fireball/fireballs.h
+++ b/code/fireball/fireballs.h
@@ -58,6 +58,8 @@ typedef struct fireball_info {
 	fireball_lod		lod[MAX_FIREBALL_LOD];
 	float				exp_color[3];	// red, green, blue
 
+	bool	use_3d_warp;
+
 	char	warp_glow[NAME_LENGTH];
 	int		warp_glow_bitmap;
 	char	warp_ball[NAME_LENGTH];

--- a/code/fireball/warpineffect.cpp
+++ b/code/fireball/warpineffect.cpp
@@ -98,7 +98,7 @@ void warpin_queue_render(model_draw_list *scene, object *obj, matrix *orient, ve
 		}
 	}
 
-	if ( (warp_model_id >= 0) && (warp_3d || Fireball_use_3d_warp) ) {
+	if ( (warp_model_id >= 0) && (warp_3d) ) {
 		model_render_params render_info;
 
 		float scale = radius / 25.0f;

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -2089,7 +2089,7 @@ int parse_create_object_sub(p_object *p_objp)
 	if (p_objp->flags[Mission::Parse_Object_Flags::Knossos_warp_in])
 	{
         Objects[objnum].flags.set(Object::Object_Flags::Special_warpin);
-		Knossos_warp_ani_used = 1;
+		Knossos_warp_ani_used = true;
 	}
 
 	// set the orders that this ship will accept.  It will have already been set to default from the
@@ -3456,7 +3456,7 @@ int parse_object(mission *pm, int  /*flag*/, p_object *p_objp)
 	// Goober5000 - preload stuff for certain object flags
 	// (done after parsing object, but before creating it)
 	if (p_objp->flags[Mission::Parse_Object_Flags::Knossos_warp_in])
-		Knossos_warp_ani_used = 1;
+		Knossos_warp_ani_used = true;
 
 	// this is a valid/legal ship to create
 	return 1;

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -3458,6 +3458,12 @@ int parse_object(mission *pm, int  /*flag*/, p_object *p_objp)
 	if (p_objp->flags[Mission::Parse_Object_Flags::Knossos_warp_in])
 		Knossos_warp_ani_used = true;
 
+	// check the warp parameters too
+	if (p_objp->warpin_params_index >= 0 && (Warp_params[p_objp->warpin_params_index].warp_type == WT_KNOSSOS || Warp_params[p_objp->warpin_params_index].warp_type == WT_DEFAULT_THEN_KNOSSOS))
+		Knossos_warp_ani_used = true;
+	if (p_objp->warpout_params_index >= 0 && (Warp_params[p_objp->warpout_params_index].warp_type == WT_KNOSSOS || Warp_params[p_objp->warpout_params_index].warp_type == WT_DEFAULT_THEN_KNOSSOS))
+		Knossos_warp_ani_used = true;
+
 	// this is a valid/legal ship to create
 	return 1;
 }

--- a/code/mission/missionparse.h
+++ b/code/mission/missionparse.h
@@ -550,9 +550,6 @@ int get_mission_info(const char *filename, mission *missionp = NULL, bool basic 
 // Goober5000
 void parse_dock_one_docked_object(p_object *pobjp, p_object *parent_pobjp);
 
-// Goober5000
-extern bool Knossos_warp_ani_used;
-
 // Karajorma
 void swap_parse_object(p_object *p_obj, int ship_class);
 void clear_texture_replacements();

--- a/code/mission/missionparse.h
+++ b/code/mission/missionparse.h
@@ -551,7 +551,7 @@ int get_mission_info(const char *filename, mission *missionp = NULL, bool basic 
 void parse_dock_one_docked_object(p_object *pobjp, p_object *parent_pobjp);
 
 // Goober5000
-extern int Knossos_warp_ani_used;
+extern bool Knossos_warp_ani_used;
 
 // Karajorma
 void swap_parse_object(p_object *p_obj, int ship_class);

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -3818,7 +3818,7 @@ int get_sexp()
 
 			case OP_SET_SPECIAL_WARPOUT_NAME:
 				// set flag for taylor
-				Knossos_warp_ani_used = 1;
+				Knossos_warp_ani_used = true;
 				break;
 
 			case OP_MISSION_SET_NEBULA:
@@ -3834,9 +3834,9 @@ int get_sexp()
 
 				// set flag for taylor
 				if (CAR(n) != -1 || Sexp_nodes[n].flags & SNF_SPECIAL_ARG_IN_NODE)		// if it's evaluating a sexp or a special argument
-					Knossos_warp_ani_used = 1;												// set flag just in case
+					Knossos_warp_ani_used = true;											// set flag just in case
 				else if (atoi(CTEXT(n)) != 0)											// if it's not the default 0
-					Knossos_warp_ani_used = 1;												// set flag just in case
+					Knossos_warp_ani_used = true;											// set flag just in case
 				break;
 
 			case OP_SET_SKYBOX_MODEL:

--- a/code/parse/sexp.h
+++ b/code/parse/sexp.h
@@ -1332,9 +1332,6 @@ extern int get_subcategory(int sexp_id);
 // Goober5000
 extern void sexp_music_close();
 
-// Goober5000
-extern bool Knossos_warp_ani_used;
-
 //WMC - moved here from FRED
 typedef struct sexp_help_struct {
 	int id;

--- a/code/parse/sexp.h
+++ b/code/parse/sexp.h
@@ -1333,7 +1333,7 @@ extern int get_subcategory(int sexp_id);
 extern void sexp_music_close();
 
 // Goober5000
-extern int Knossos_warp_ani_used;
+extern bool Knossos_warp_ani_used;
 
 //WMC - moved here from FRED
 typedef struct sexp_help_struct {

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -16909,10 +16909,6 @@ void ship_page_in()
 		nprintf(( "Paging","Found ship '%s'\n", Ships[i].ship_name ));
 		ship_class_used[Ships[i].ship_info_index]++;
 
-		// check if we are going to use a Knossos device and make sure the special warp ani gets pre-loaded
-		if ( Ship_info[Ships[i].ship_info_index].flags[Ship::Info_Flags::Knossos_device] )
-			Knossos_warp_ani_used = true;
-
 		// mark any weapons as being used, saves memory and time if we don't load them all
 		ship_weapon *swp = &Ships[i].weapons;
 

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -16911,7 +16911,7 @@ void ship_page_in()
 
 		// check if we are going to use a Knossos device and make sure the special warp ani gets pre-loaded
 		if ( Ship_info[Ships[i].ship_info_index].flags[Ship::Info_Flags::Knossos_device] )
-			Knossos_warp_ani_used = 1;
+			Knossos_warp_ani_used = true;
 
 		// mark any weapons as being used, saves memory and time if we don't load them all
 		ship_weapon *swp = &Ships[i].weapons;


### PR DESCRIPTION
Set the flag for the Knossos warp effect being used when the effect is part of the normal warpin/warpout without involving the Knossos device.

Change the flag from `int` to `bool` and tweak a few things.

Also make sure the warp model is used if it is explicitly specified in the fireball tbl.

Fixes #3917.