### PR TITLE
fix training mission stats bug

### DIFF
--- a/code/missionui/missiondebrief.cpp
+++ b/code/missionui/missiondebrief.cpp
@@ -2037,13 +2037,13 @@ void debrief_close()
 						scoring_backout_accept(sc);
 
 						if (Net_player == &Net_players[i]) {
-							Pilot.update_stats_backout( sc );
+							Pilot.update_stats_backout( sc, (The_mission.game_type == MISSION_TYPE_TRAINING) );
 						}
 					}
 				}
 			} else {
 				scoring_backout_accept( &Player->stats );
-				Pilot.update_stats_backout( &Player->stats );
+				Pilot.update_stats_backout( &Player->stats, (The_mission.game_type == MISSION_TYPE_TRAINING) );
 			}
 		}
 	} else {
@@ -2054,7 +2054,7 @@ void debrief_close()
 				Campaign.next_mission = Campaign.current_mission;
 			}
 			scoring_backout_accept( &Player->stats );
-			Pilot.update_stats_backout( &Player->stats );
+			Pilot.update_stats_backout( &Player->stats, (The_mission.game_type == MISSION_TYPE_TRAINING) );
 		}
 	}
 


### PR DESCRIPTION
Training missions don't save kills so make sure that we don't try to back out kills by mistake when replaying a training mission.

Fixes #3916