### PR TITLE
accommodate elapsed time during debugging

### DIFF
--- a/code/cmdline/cmdline.cpp
+++ b/code/cmdline/cmdline.cpp
@@ -251,6 +251,8 @@ Flag exe_params[] =
 	{ "-json_profiling",	"Generate JSON profiling output",			true,	0,									EASY_DEFAULT,					"Dev Tool",		"http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-json_profiling", },
 	{ "-debug_window",		"Enable the debug window",					true,	0,									EASY_DEFAULT,					"Dev Tool",		"http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-debug_window", },
 	{ "-gr_debug",		"Output graphics debug information",			true,	0,									EASY_DEFAULT,					"Dev Tool",		"http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-gr_debug", },
+	{ "-stdout_log",		"Output log file to stdout",				true,	0,									EASY_DEFAULT,					"Dev Tool",		"http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-stdout_log", },
+	{ "-slow_frames_ok",	"Don't adjust timestamps for slow frames",	true,	0,									EASY_DEFAULT,					"Dev Tool",		"http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-slow_frames_ok", },
 };
 // clang-format on
 
@@ -486,6 +488,7 @@ cmdline_parm frame_profile_arg("-profile_frame_time", NULL, AT_NONE); //Cmdline_
 cmdline_parm debug_window_arg("-debug_window", NULL, AT_NONE);	// Cmdline_debug_window
 cmdline_parm graphics_debug_output_arg("-gr_debug", nullptr, AT_NONE); // Cmdline_graphics_debug_output
 cmdline_parm log_to_stdout_arg("-stdout_log", nullptr, AT_NONE); // Cmdline_log_to_stdout
+cmdline_parm slow_frames_ok_arg("-slow_frames_ok", nullptr, AT_NONE);	// Cmdline_slow_frames_ok
 
 
 char *Cmdline_start_mission = NULL;
@@ -518,6 +521,7 @@ bool Cmdline_show_video_info = false;
 bool Cmdline_debug_window = false;
 bool Cmdline_graphics_debug_output = false;
 bool Cmdline_log_to_stdout = false;
+bool Cmdline_slow_frames_ok = false;
 
 // Other
 cmdline_parm get_flags_arg(GET_FLAGS_STRING, "Output the launcher flags file", AT_STRING);
@@ -2139,6 +2143,10 @@ bool SetCmdlineParams()
 
 	if (log_to_stdout_arg.found()) {
 		Cmdline_log_to_stdout = true;
+	}
+
+	if (slow_frames_ok_arg.found()) {
+		Cmdline_slow_frames_ok = true;
 	}
 
 	if (show_video_info.found())

--- a/code/cmdline/cmdline.h
+++ b/code/cmdline/cmdline.h
@@ -150,6 +150,7 @@ extern bool Cmdline_show_video_info;
 extern bool Cmdline_debug_window;
 extern bool Cmdline_graphics_debug_output;
 extern bool Cmdline_log_to_stdout;
+extern bool Cmdline_slow_frames_ok;
 
 enum class WeaponSpewType { NONE = 0, STANDARD, ALL };
 extern WeaponSpewType Cmdline_spew_weapon_stats;

--- a/code/controlconfig/controlsconfig.cpp
+++ b/code/controlconfig/controlsconfig.cpp
@@ -14,7 +14,7 @@
 #include "controlconfig/controlsconfig.h"
 #include "controlconfig/presets.h"
 #include "debugconsole/console.h"
-#include "freespace.h"
+#include "../freespace2/freespace.h"
 #include "gamehelp/contexthelp.h"
 #include "gamesequence/gamesequence.h"
 #include "gamesnd/gamesnd.h"
@@ -2720,7 +2720,6 @@ void control_get_axes_readings(int *axis_v, float frame_time)
 	}
 }
 
-int Last_frame_timestamp;
 void control_used(int id)
 {
 	// if we have set this key to be ignored, ignore it

--- a/code/io/timer.cpp
+++ b/code/io/timer.cpp
@@ -276,7 +276,11 @@ void timestamp_adjust_pause_offset(int delta_milliseconds)
 	Assertion(delta_milliseconds > 0, "Pausing for a negative amount of time doesn't make sense.  Also, negative numbers won't work with uint64_t.");
 
 	// act like we were paused for a certain period of time, even though we weren't
-	Timestamp_offset_from_counter += static_cast<uint64_t>(static_cast<uint64_t>(delta_milliseconds) * 1000 / Timer_to_microseconds);
+	if (Timestamp_offset_from_counter == 0) {
+		Timestamp_offset_from_counter = get_performance_counter();
+	} else {
+		Timestamp_offset_from_counter += static_cast<uint64_t>(static_cast<uint64_t>(delta_milliseconds) * 1000 / Timer_to_microseconds);
+	}
 }
 
 void timestamp_adjust_seconds(float delta_seconds, TIMER_DIRECTION dir)

--- a/code/io/timer.cpp
+++ b/code/io/timer.cpp
@@ -265,6 +265,20 @@ void timestamp_unpause(bool sudo)
 	}
 }
 
+bool timestamp_is_paused()
+{
+	return Timestamp_is_paused;
+}
+
+void timestamp_adjust_pause_offset(int delta_milliseconds)
+{
+	Assertion(!Timestamp_is_paused, "This function is not needed if the game is actually paused.");
+	Assertion(delta_milliseconds > 0, "Pausing for a negative amount of time doesn't make sense.  Also, negative numbers won't work with uint64_t.");
+
+	// act like we were paused for a certain period of time, even though we weren't
+	Timestamp_offset_from_counter += static_cast<uint64_t>(static_cast<uint64_t>(delta_milliseconds) * 1000 / Timer_to_microseconds);
+}
+
 void timestamp_adjust_seconds(float delta_seconds, TIMER_DIRECTION dir)
 {
 	Assertion(Timer_inited, "Timer should be initialized at this point!");

--- a/code/io/timer.h
+++ b/code/io/timer.h
@@ -124,6 +124,10 @@ void timestamp_pause(bool sudo);
 // See above re: the sudo parameter
 void timestamp_unpause(bool sudo);
 
+// for timestamp handling during debugging
+bool timestamp_is_paused();
+void timestamp_adjust_pause_offset(int delta_milliseconds);
+
 enum class TIMER_DIRECTION { FORWARD, BACKWARD };
 // Alters the timestamp time forward or backward.  Use with caution!
 void timestamp_adjust_seconds(float delta_seconds, TIMER_DIRECTION dir);

--- a/fred2/fredstubs.cpp
+++ b/fred2/fredstubs.cpp
@@ -216,6 +216,7 @@ void game_unpause() {}
 //Time stuff
 bool Time_compression_locked;
 float flRealframetime;
+int Last_frame_timestamp = 0;
 void lock_time_compression(bool is_locked){}
 void change_time_compression(float multiplier){}
 void set_time_compression(float multiplier, float change_time){}

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -4284,7 +4284,7 @@ void game_set_frametime(int state)
 		mprintf(("Frame %2i too long!!: frametime = %.3f (%.3f)\n", Framecount, f2fl(Frametime), f2fl(debug_frametime)));
 
 		// If the frame took more than 5 seconds, assume we're tracing through a debugger.  If timestamps are running, correct the elapsed time.
-		if (!timestamp_is_paused() && (Last_frame_timestamp != 0) && (f2fl(Frametime) > 5.0f)) {
+		if (!Cmdline_slow_frames_ok && !timestamp_is_paused() && (Last_frame_timestamp != 0) && (f2fl(Frametime) > 5.0f)) {
 			auto delta_timestamp = timestamp() - Last_frame_timestamp;
 			mprintf(("Adjusting timestamp by %2i milliseconds to compensate\n", delta_timestamp));
 			timestamp_adjust_pause_offset(delta_timestamp);

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -4142,7 +4142,8 @@ void game_frame(bool paused)
 
 fix Last_time = 0;						// The absolute time of game at end of last frame (beginning of this frame)
 fix Last_delta_time = 0;				// While game is paused, this keeps track of how much elapsed in the frame before paused.
-static bool Time_paused=false;
+int Last_frame_timestamp = 0;
+static bool Time_paused = false;
 
 void game_time_level_init()
 {
@@ -4283,7 +4284,7 @@ void game_set_frametime(int state)
 		mprintf(("Frame %2i too long!!: frametime = %.3f (%.3f)\n", Framecount, f2fl(Frametime), f2fl(debug_frametime)));
 
 		// If the frame took more than 5 seconds, assume we're tracing through a debugger.  If timestamps are running, correct the elapsed time.
-		if (!timestamp_is_paused() && f2fl(Frametime) > 5.0f) {
+		if (!timestamp_is_paused() && (Last_frame_timestamp != 0) && (f2fl(Frametime) > 5.0f)) {
 			auto delta_timestamp = timestamp() - Last_frame_timestamp;
 			mprintf(("Adjusting timestamp by %2i milliseconds to compensate\n", delta_timestamp));
 			timestamp_adjust_pause_offset(delta_timestamp);

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -4281,6 +4281,13 @@ void game_set_frametime(int state)
 	if (Frametime > MAX_FRAMETIME)	{
 #ifndef NDEBUG
 		mprintf(("Frame %2i too long!!: frametime = %.3f (%.3f)\n", Framecount, f2fl(Frametime), f2fl(debug_frametime)));
+
+		// If the frame took more than 5 seconds, assume we're tracing through a debugger.  If timestamps are running, correct the elapsed time.
+		if (!timestamp_is_paused() && f2fl(Frametime) > 5.0f) {
+			auto delta_timestamp = timestamp() - Last_frame_timestamp;
+			mprintf(("Adjusting timestamp by %2i milliseconds to compensate\n", delta_timestamp));
+			timestamp_adjust_pause_offset(delta_timestamp);
+		}
 #endif
 		Frametime = MAX_FRAMETIME;
 	}

--- a/qtfred/src/fredstubs.cpp
+++ b/qtfred/src/fredstubs.cpp
@@ -220,6 +220,7 @@ void game_unpause() {}
 //Time stuff
 bool Time_compression_locked;
 float flRealframetime;
+int Last_frame_timestamp = 0;
 void lock_time_compression(bool  /*is_locked*/){}
 void change_time_compression(float  /*multiplier*/){}
 void set_time_compression(float  /*multiplier*/, float  /*change_time*/){}

--- a/test/src/test_stubs.cpp
+++ b/test/src/test_stubs.cpp
@@ -224,6 +224,7 @@ void game_unpause() {}
 //Time stuff
 bool Time_compression_locked;
 float flRealframetime;
+int Last_frame_timestamp = 0;
 void lock_time_compression(bool  /*is_locked*/){}
 void change_time_compression(float  /*multiplier*/){}
 void set_time_compression(float  /*multiplier*/, float  /*change_time*/){}


### PR DESCRIPTION
If a breakpoint is hit in the code, the SDL time will keep running even though FSO doesn't realize things are effectively, if not actually, paused.  Detect this situation and adjust the timestamp offset to compensate.