### PR TITLE
Fix/issue 3902

### DIFF
--- a/code/pilotfile/plr.cpp
+++ b/code/pilotfile/plr.cpp
@@ -770,6 +770,9 @@ void pilotfile::plr_write_controls()
 
 		} else if (mouse >= 0) {
 			handler->writeInt("axis_map", mouse);
+
+		} else {
+			handler->writeInt("axis_map", -1);
 		}
 		
 		handler->writeInt("invert_axis", item.is_inverted() ? 1 : 0);

--- a/code/pilotfile/plr.cpp
+++ b/code/pilotfile/plr.cpp
@@ -701,14 +701,11 @@ void pilotfile::plr_read_controls()
 				os::dialogs::Information(LOCATION, "Successfully converted playerfile to v4.  Please rebind your mouse controls within the Options -> Controls Config menu.");
 				
 				SCP_string infostring;
-				infostring += "  Due to technical difficulties, playerfiles versions v4 and up are incompatible with FSO versions older than FSO 22.0.\n\n";
-				infostring += "  Your bindings are now saved in a preset file within /data/players/presets, and are used by FSO versions 22.0 and newer.\n\n";
-				infostring += "  However, when trying to play in older FSO versions, your bindings will revert to the defaults while playing in that older version.\n\n";
-				infostring += "  This is done in order to address several issues:\n";
-				infostring += "  1) To prevent older FSO versions from crashing when attempting to load the new playerfile\n";
-				infostring += "  2) To prevent auto-conversions of bindings that you already have a preset for\n\n";
-				infostring += "  You will see this infobox every time the bindings in your playerfile are different from the defaults, including the invert flag of any axis.\n\n";
-				infostring += "  Thus, it is *highly* recommended that you should create another pilot if you still wish to play in FSO versions older than 22.0";
+				infostring += "Due to technical difficulties, playerfiles versions v4 and up are incompatible with FSO versions older than FSO 22.0.\n\n";
+
+				infostring += "Should you try to use this pilot on a pre - 22.0 version of FSO, your control bindings will revert to the defaults.\n\n";
+
+				infostring += "Please visit https://wiki.hard-light.net/index.php/Frequently_Asked_Questions for more information.";
 
 				os::dialogs::Information(LOCATION, "%s", infostring.c_str());
 			} else {

--- a/code/pilotfile/plr.cpp
+++ b/code/pilotfile/plr.cpp
@@ -710,7 +710,7 @@ void pilotfile::plr_read_controls()
 				infostring += "  You will see this infobox every time the bindings in your playerfile are different from the defaults, including the invert flag of any axis.\n\n";
 				infostring += "  Thus, it is *highly* recommended that you should create another pilot if you still wish to play in FSO versions older than 22.0";
 
-				os::dialogs::Information(LOCATION, infostring.c_str());
+				os::dialogs::Information(LOCATION, "%s", infostring.c_str());
 			} else {
 				Warning(LOCATION, "Could not save controls preset file (%s) when converting playerfile to v3.", preset.name.c_str());
 			}


### PR DESCRIPTION
Addresses issues discussed in issue #3902 

* Writes default controls in pre-Controls5 format for the .json to prevent a CTD in non-Controls5 versions when trying to load Controls5 pilot
* Displays a second nag screen with a wall of text to explain that the controls will be defaulted when attempting to use a Controls5 pilot in a non-Controls5 build