### PR TITLE
some small timestamp fixes

### DIFF
--- a/code/gamesnd/eventmusic.cpp
+++ b/code/gamesnd/eventmusic.cpp
@@ -659,7 +659,12 @@ void event_music_first_pattern()
 			audiostream_stop( Patterns[Current_pattern].handle );
 	}
 
-	Pattern_timer_id = timestamp(-1);	// don't let this start quite yet; see event_music_set_start_delay()
+	// if we really are initializing the level
+	if (Missiontime == 0) {
+		Pattern_timer_id = timestamp(-1);	// don't let this start quite yet; see event_music_set_start_delay()
+	} else {
+		Pattern_timer_id = timestamp(0);	// start immediately
+	}
 	
 	Event_music_begun = FALSE;
 	if ( Event_Music_battle_started == TRUE ) {

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -4286,8 +4286,11 @@ void game_set_frametime(int state)
 		// If the frame took more than 5 seconds, assume we're tracing through a debugger.  If timestamps are running, correct the elapsed time.
 		if (!Cmdline_slow_frames_ok && !timestamp_is_paused() && (Last_frame_timestamp != 0) && (f2fl(Frametime) > 5.0f)) {
 			auto delta_timestamp = timestamp() - Last_frame_timestamp;
-			mprintf(("Adjusting timestamp by %2i milliseconds to compensate\n", delta_timestamp));
-			timestamp_adjust_pause_offset(delta_timestamp);
+			// could be 0 if we have time compression slowed to a crawl
+			if (delta_timestamp > 0) {
+				mprintf(("Adjusting timestamp by %2i milliseconds to compensate\n", delta_timestamp));
+				timestamp_adjust_pause_offset(delta_timestamp);
+			}
 		}
 #endif
 		Frametime = MAX_FRAMETIME;
@@ -4328,7 +4331,7 @@ void game_set_frametime(int state)
 
 	// before the player enters the mission, we blitz through time
 	if (do_pre_player_skip)
-		timestamp_adjust_seconds(flFrametime, TIMER_DIRECTION::FORWARD);
+		timestamp_adjust_seconds(flRealframetime, TIMER_DIRECTION::FORWARD);
 
 	// wrap overall frametime if needed
 	if ( FrametimeOverall > (INT_MAX - F1_0) )


### PR DESCRIPTION
A few assorted fixes for timestamps:

1) The pre-player delay should be fast-forwarded by 1/4 second per frame regardless of time compression
2) If time compression is very slow, there could be a 0-millisecond change in timestamps, so don't adjust this
3) Properly handle a change in soundtrack that occurs during a mission, not just when the mission is parsed