### PR TITLE
Fix reverse instant trigger edge case

### DIFF
--- a/code/model/modelanimation.cpp
+++ b/code/model/modelanimation.cpp
@@ -137,7 +137,6 @@ namespace animation {
 				}
 				else
 					stop(pmi, false);
-				break;
 			}
 
 			m_animation->calculateAnimation(applyBuffer, instanceData.time, pmi->id);

--- a/code/model/modelanimation_segments.cpp
+++ b/code/model/modelanimation_segments.cpp
@@ -25,9 +25,8 @@ namespace animation {
 	}
 
 	void ModelAnimationSegmentSerial::calculateAnimation(ModelAnimationSubmodelBuffer& base, float time, int pmi_id) const {
-
 		size_t animationCnt = 0;
-		while (time > 0.0f && animationCnt < m_segments.size()) {
+		while (time >= 0.0f && animationCnt < m_segments.size()) {
 			float timeLocal = time;
 			//Make sure that each segment actually stops at its end
 			if (timeLocal > m_segments[animationCnt]->getDuration(pmi_id))


### PR DESCRIPTION
As discovered by MjnMixael, triggering an animation in instant mode in reverse can cause problems, notably with a serial segment as well. The fix is simple enough.