### PR TITLE
Add view show status for HUD gauges in scripting

### DIFF
--- a/code/scripting/api/libs/hud.cpp
+++ b/code/scripting/api/libs/hud.cpp
@@ -60,6 +60,22 @@ ADE_VIRTVAR(HUDDefaultGaugeCount, l_HUD, "number", "Specifies the amount of HUD 
 	return ade_set_args(L, "i", amount);
 }
 
+ADE_FUNC(getHUDConfigShowStatus, l_HUD, "number gaugeIndex", "Gets the HUD configuration show status for the specified default HUD gauge.", "boolean", "Returns show status or nil if gauge invalid")
+{
+	int idx = -1;
+
+	if (!ade_get_args(L, "i", &idx))
+		return ADE_RETURN_NIL;
+
+	if ((idx < 0) || (idx >= default_hud_gauges.size()))
+		return ADE_RETURN_NIL;
+
+	if (hud_config_show_flag_is_set(idx))
+		return ADE_RETURN_TRUE;
+	else
+		return ADE_RETURN_FALSE;
+}
+
 ADE_FUNC(setHUDGaugeColor, l_HUD,
          "number gaugeIndex, [number red, number green, number blue, number alpha]",
          "Modifies color used to draw the gauge in the pilot config", "boolean", "If the operation was successful")


### PR DESCRIPTION
Many FSO mods use scripted HUD gauges, but previously the scripted HUD gauges were always forced to be on for the player, unlike retail gauges that can be toggled in the HUD Config screen. This PR allows scripters to view the show status of a HUD gauge, which is very useful for adding a check in the script to only show the gauge if a certain gauge is active. This is similar behavior to the getColor function, which allowed scripters to get the HUD Config colors of a given default gauge.

Tested and works as expected.