### PR TITLE
Inverse Kinematics for Animations

### DIFF
--- a/code/math/ik_solver.cpp
+++ b/code/math/ik_solver.cpp
@@ -153,13 +153,17 @@ void ik_node::calculateGlobalRotation(const ik_node& child) {
 	vec3d rotax;
 	vec3d n_off;
 	vec3d n_diff = child.calculatedPos - calculatedPos;
-
 	vm_vec_copy_normalize(&n_off, &child.submodel->offset);
+	vm_vec_normalize(&n_diff);
+	
+	vec3d checkSafeTransform = n_diff - n_off;
+	if(vm_vec_mag(&checkSafeTransform) <= 0.001){
+		calculatedRot = IDENTITY_MATRIX;
+		return;
+	}
 	
 	vm_vec_cross(&rotax, &n_off, &n_diff);
 	vm_vec_normalize(&rotax);
-
-	vm_vec_normalize(&n_diff);
 
 	vm_quaternion_rotate(&calculatedRot, acosf(vm_vec_dot(&n_diff, &n_off)), &rotax);
 }

--- a/code/math/ik_solver.cpp
+++ b/code/math/ik_solver.cpp
@@ -1,0 +1,180 @@
+#include "math/ik_solver.h"
+
+ik_solver_fabrik::ik_solver_fabrik(unsigned int maxIterations, float targetDistance, float minProgress)
+	: m_maxIterations(maxIterations), m_targetDistance(targetDistance), m_minProgress(minProgress) { }
+
+void ik_solver_fabrik::solve(const vec3d& targetPos, const matrix* targetOrient) {
+
+	Assertion(m_nodes.size() > 1, "Node-list for IK does not contain at least two nodes.");
+	
+	//Calculate distances and set up nodes
+	for(size_t i = 1; i < m_nodes.size(); ++i){
+		//This assumes that m_nodes[n] is _always_ a direct child of m_nodes[n-1]
+		m_nodes[i - 1].distance = vm_vec_mag(&m_nodes[i].submodel->offset);
+		m_nodes[i].calculatedPos = m_nodes[i - 1].calculatedPos + m_nodes[i].submodel->offset;
+	}
+	
+	//Abort condition counter
+	unsigned int iterationCounter = 0;
+	float endEffectorDistance = FLT_MAX;
+	float endEffectorDistanceDelta = FLT_MAX;
+	
+	while(iterationCounter++ < m_maxIterations && endEffectorDistance > m_targetDistance && endEffectorDistanceDelta > m_minProgress) {
+		endEffectorDistanceDelta = endEffectorDistance;
+
+		m_nodes.back().calculatedPos = targetPos;
+		
+		//Backwards pass
+		for(size_t i = m_nodes.size() - 2; i != static_cast<size_t>(-1); --i) {
+			auto& child = m_nodes[i + 1];
+			auto& parent = m_nodes[i];
+			
+			// Find new position for parent
+			float localDistance = vm_vec_dist(&parent.calculatedPos, &child.calculatedPos);
+			float lambda = parent.distance / localDistance;
+
+			parent.calculatedPos *= lambda;
+			parent.calculatedPos += child.calculatedPos * (1.0f - lambda);
+
+			// Find the parent's global rotation based on parent-child combination
+			parent.calculateGlobalRotation(child);
+			
+			if(i == m_nodes.size() - 2){
+				//Now that we know where the first parent sits, we can update the end effector rotation.
+				//If we have a target rotation, point to it, otherwise take its parent's rotation
+				child.calculatedRot = targetOrient == nullptr ? parent.calculatedRot : *targetOrient;
+			}
+			
+			// Find local rotation of child for constraint
+			matrix localRot;
+			vm_copy_transpose(&localRot, &parent.calculatedRot);
+			vm_matrix_x_matrix(&localRot, &child.calculatedRot, &localRot);
+
+			// Check if constraint requires change of local rotation
+			if(child.constraint->constrain(localRot)){
+				// Reposition parent to fulfill child local rotation constraint by changing parent global rotation
+				
+				// Convert new local rotation of child and global rotation of child to new parent global rotation
+				vm_transpose(&localRot);
+				vm_matrix_x_matrix(&parent.calculatedRot, &localRot, &child.calculatedRot);
+
+				// Find new parent position from new parent global rotation, child offset and child position
+				vm_vec_unrotate(&parent.calculatedPos, &child.submodel->offset, &parent.calculatedRot);
+				parent.calculatedPos *= -1;
+				parent.calculatedPos += child.calculatedPos;
+			}
+		}
+		
+		//Technically the base node would now need to be rotation constrained, but since the parent position is reset anyways for the forwards pass with a fixed base, this has no effect
+		
+		m_nodes.front().calculatedPos = ZERO_VECTOR;
+		m_nodes.front().calculatedRot = IDENTITY_MATRIX;
+
+		//Forwards pass
+		for(size_t i = 0; i < m_nodes.size() - 1; ++i) {
+			auto& child = m_nodes[i + 1];
+			auto& parent = m_nodes[i];
+			
+			// Find new position for child
+			float localDistance = vm_vec_dist(&parent.calculatedPos, &child.calculatedPos);
+			float lambda = parent.distance / localDistance;
+
+			child.calculatedPos *= lambda;
+			child.calculatedPos += parent.calculatedPos * (1.0f - lambda);
+			
+			// Find the parent's global rotation based on parent-child combination
+			parent.calculateGlobalRotation(child);
+			
+			// Find local rotation of parent for constraint
+			const matrix& parentRot = i == 0 ? vmd_identity_matrix : m_nodes[i - 1].calculatedRot;
+			matrix localRot;
+			vm_copy_transpose(&localRot, &parentRot);
+			vm_matrix_x_matrix(&localRot, &parent.calculatedRot, &localRot);
+			
+			// Check if constraint requires change of local rotation
+			if(parent.constraint->constrain(localRot)){
+				// Reposition child to fulfill parent local rotation constraint by changing parent global rotation
+				
+				// Convert new local rotation and global rotation of tha parent's parent to new parent global rotation
+				vm_matrix_x_matrix(&parent.calculatedRot, &localRot, &parentRot);
+				
+				// Find new child position from new parent global rotation, child offset and parent position
+				vm_vec_unrotate(&child.calculatedPos, &child.submodel->offset, &parent.calculatedRot);
+				child.calculatedPos += parent.calculatedPos;
+			}
+		}
+		
+		//After positioning the end effector, it now needs to be oriented correctly. If we have a target orientation use it, otherwise assume it's parents rotation. Then constrain.
+		{
+			const matrix& parentRot = m_nodes[m_nodes.size() - 2].calculatedRot;
+			// Find end effector target
+			m_nodes.back().calculatedRot = targetOrient == nullptr ? parentRot : *targetOrient;
+			
+			// Calculate end effector local rotation
+			matrix localRot;
+			vm_copy_transpose(&localRot, &parentRot);
+			vm_matrix_x_matrix(&localRot, &m_nodes.back().calculatedRot, &localRot);
+			
+			// Constrain
+			if(m_nodes.back().constraint->constrain(localRot)) {
+				// Calculate new global end effector rotation
+				vm_matrix_x_matrix(&localRot, &localRot, &parentRot);
+				m_nodes.back().calculatedRot = localRot;
+			}
+		}
+		
+		// Calculate abort conditions
+		endEffectorDistance = vm_vec_dist(&targetPos, &m_nodes.back().calculatedPos);
+		endEffectorDistanceDelta -= endEffectorDistance;
+	}
+	
+	//Localize rotations
+	for(size_t i = m_nodes.size() - 1; i > 0; --i) {
+		matrix parent = m_nodes[i - 1].calculatedRot;
+		vm_transpose(&parent);
+		vm_matrix_x_matrix(&m_nodes[i].calculatedRot, &m_nodes[i].calculatedRot, &parent);
+	}
+}
+
+void ik_node::calculateGlobalRotation(const ik_node& child) {
+	vec3d rotax;
+	vec3d n_off;
+	vec3d n_diff = child.calculatedPos - calculatedPos;
+
+	vm_vec_copy_normalize(&n_off, &child.submodel->offset);
+	
+	vm_vec_cross(&rotax, &n_off, &n_diff);
+	vm_vec_normalize(&rotax);
+
+	vm_vec_normalize(&n_diff);
+
+	vm_quaternion_rotate(&calculatedRot, acosf(vm_vec_dot(&n_diff, &n_off)), &rotax);
+}
+
+static constexpr float angles::*pbh[] = { &angles::p, &angles::b, &angles::h };
+
+ik_constraint_window::ik_constraint_window(const angles& _absLimit) : absLimit(_absLimit) { }
+
+bool ik_constraint_window::constrain(matrix& localRot) const {
+	//Convert to angles
+	angles currentAngles;
+	vm_extract_angles_matrix_alternate(&currentAngles, &localRot);
+	
+	bool needsClamp = false;
+	
+	//Clamp absolute value of individual angles to window
+	for (float angles::* i : pbh) {
+		const float absAngle = abs(currentAngles.*i);
+		if(absAngle > absLimit.*i){
+			needsClamp = true;
+			currentAngles.*i = copysignf(std::max(absAngle, absLimit.*i), currentAngles.*i);
+		}
+	}
+	
+	//If any axis needed clamping, recalc the local rotation
+	if(needsClamp){
+		vm_angles_2_matrix(&localRot, &currentAngles);
+	}
+	
+	return needsClamp;
+}

--- a/code/math/ik_solver.cpp
+++ b/code/math/ik_solver.cpp
@@ -4,7 +4,9 @@ ik_solver_fabrik::ik_solver_fabrik(unsigned int maxIterations, float targetDista
 	: m_maxIterations(maxIterations), m_targetDistance(targetDistance), m_minProgress(minProgress) { }
 
 void ik_solver_fabrik::solve(const vec3d& targetPos, const matrix* targetOrient) {
-
+	//Implementation of the paper "FABRIK: A fast iterative solver for the Inverse Kinematics problem"
+	//http://andreasaristidou.com/publications/papers/FABRIK.pdf
+	
 	Assertion(m_nodes.size() > 1, "Node-list for IK does not contain at least two nodes.");
 	
 	//Calculate distances and set up nodes
@@ -107,7 +109,7 @@ void ik_solver_fabrik::solve(const vec3d& targetPos, const matrix* targetOrient)
 			}
 		}
 		
-		//After positioning the end effector, it now needs to be oriented correctly. If we have a target orientation use it, otherwise assume it's parents rotation. Then constrain.
+		//After positioning the end effector, it now needs to be oriented correctly. If we have a target orientation use it, otherwise assume its parents rotation. Then constrain.
 		{
 			const matrix& parentRot = m_nodes[m_nodes.size() - 2].calculatedRot;
 			// Find end effector target

--- a/code/math/ik_solver.h
+++ b/code/math/ik_solver.h
@@ -1,0 +1,72 @@
+#pragma once
+
+#include "math/vecmat.h"
+#include "model/model.h"
+
+class ik_constraint;
+
+struct ik_node{
+	const bsp_info* submodel;
+	const ik_constraint* constraint;
+	
+	vec3d calculatedPos = ZERO_VECTOR;
+	matrix calculatedRot = IDENTITY_MATRIX;
+	float distance = 0.0f;
+	
+	ik_node(const bsp_info* _submodel, const ik_constraint* _constraint) : submodel(_submodel), constraint(_constraint) { }
+
+	void calculateGlobalRotation(const ik_node& child);
+};
+
+class ik_solver {
+protected:
+	std::vector<ik_node> m_nodes;
+
+public:
+	template <typename... Args>
+	void addNode(Args&&... args) {
+		m_nodes.emplace_back(std::forward<Args>(args)...);
+	}
+
+	virtual void solve(const vec3d& targetPos, const matrix* targetOrient = nullptr) = 0;
+
+	//Allow const-iterating over created nodes
+	inline decltype(m_nodes)::const_iterator begin() const { return m_nodes.cbegin(); }
+	inline decltype(m_nodes)::const_iterator end() const { return m_nodes.cend(); }
+	
+	virtual ~ik_solver() = default;
+};
+
+class ik_solver_fabrik : public ik_solver {
+	unsigned int m_maxIterations;
+	float m_targetDistance;
+	float m_minProgress;
+	
+public:
+	ik_solver_fabrik(unsigned int maxIterations = 15, float targetDistance = 0.01f, float minProgress = 0.05f);
+	
+	void solve(const vec3d& targetPos, const matrix* targetOrient = nullptr) override;
+};
+
+class ik_constraint{
+public:
+	/* 
+	 * Return true if the local rotation was modified by the constraint
+	 * */
+	virtual bool constrain(matrix& /*localRot*/) const {
+		return false;
+	};
+	
+};
+
+class ik_constraint_hinge : public ik_constraint{
+
+};
+
+class ik_constraint_window : public ik_constraint{
+	angles absLimit;
+public:
+	ik_constraint_window(const angles& _absLimit);
+	
+	bool constrain(matrix& localRot) const override;
+};

--- a/code/math/ik_solver.h
+++ b/code/math/ik_solver.h
@@ -58,6 +58,7 @@ public:
 		return false;
 	};
 	
+	virtual ~ik_constraint() = default;
 };
 
 class ik_constraint_hinge : public ik_constraint{

--- a/code/math/ik_solver.h
+++ b/code/math/ik_solver.h
@@ -10,6 +10,7 @@ struct ik_node{
 	const ik_constraint* constraint;
 	
 	vec3d calculatedPos = ZERO_VECTOR;
+	vec3d lastPos = ZERO_VECTOR;
 	matrix calculatedRot = IDENTITY_MATRIX;
 	float distance = 0.0f;
 	
@@ -53,14 +54,18 @@ public:
 	/* 
 	 * Return true if the local rotation was modified by the constraint
 	 * */
-	virtual bool constrain(matrix& /*localRot*/) const {
+	virtual bool constrain(matrix& /*localRot*/, bool /*backwardsPass*/ = false) const {
 		return false;
 	};
 	
 };
 
 class ik_constraint_hinge : public ik_constraint{
-
+	vec3d axis;
+public:
+	ik_constraint_hinge(const vec3d& _axis);
+	
+	bool constrain(matrix& localRot, bool backwardsPass) const override;
 };
 
 class ik_constraint_window : public ik_constraint{
@@ -68,5 +73,5 @@ class ik_constraint_window : public ik_constraint{
 public:
 	ik_constraint_window(const angles& _absLimit);
 	
-	bool constrain(matrix& localRot) const override;
+	bool constrain(matrix& localRot, bool backwardsPass) const override;
 };

--- a/code/math/vecmat.h
+++ b/code/math/vecmat.h
@@ -601,7 +601,7 @@ inline vec3d& operator-=(vec3d& left, const vec3d& right)
 	return left;
 }
 
-inline vec3d operator*(vec3d& left, float right)
+inline vec3d operator*(const vec3d& left, float right)
 {
 	vec3d out;
 	vm_vec_copy_scale(&out, &left, right);
@@ -613,7 +613,7 @@ inline vec3d& operator*=(vec3d& left, float right)
 	return left;
 }
 
-inline vec3d operator/(vec3d& left, float right)
+inline vec3d operator/(const vec3d& left, float right)
 {
 	vec3d out;
 	vm_vec_copy_scale(&out, &left, 1.0f / right);

--- a/code/model/modelanimation.cpp
+++ b/code/model/modelanimation.cpp
@@ -1569,7 +1569,8 @@ namespace animation {
 	
 	std::map<SCP_string, ModelAnimationParseHelper::ModelAnimationMoveableParser> ModelAnimationParseHelper::s_moveableParsers = {
 		{"Orientation", 			ModelAnimationMoveableOrientation::parser},
-		{"Rotation", 				ModelAnimationMoveableRotation::parser}
+		{"Rotation", 				ModelAnimationMoveableRotation::parser},
+		{"Inverse Kinematics", 	ModelAnimationMoveableIK::parser}
 	};
 
 	

--- a/code/model/modelanimation.cpp
+++ b/code/model/modelanimation.cpp
@@ -1563,7 +1563,8 @@ namespace animation {
 		{"$Set Angle:", 			ModelAnimationSegmentSetAngle::parser},
 		{"$Rotation:",		 	ModelAnimationSegmentRotation::parser},
 	//	{"$Translation:", 		ModelAnimationSegmentTranslation::parser},
-		{"$Sound During:", 		ModelAnimationSegmentSoundDuring::parser}
+		{"$Sound During:", 		ModelAnimationSegmentSoundDuring::parser},
+		{"$Inverse Kinematics:", 	ModelAnimationSegmentIK::parser}
 	};
 	
 	std::map<SCP_string, ModelAnimationParseHelper::ModelAnimationMoveableParser> ModelAnimationParseHelper::s_moveableParsers = {

--- a/code/model/modelanimation.h
+++ b/code/model/modelanimation.h
@@ -37,6 +37,10 @@ public:
 			return T();
 		}
 	}
+	
+	inline const T* operator&() const {
+		return filled ? &data.t : nullptr;
+	}
 
 	inline bool has() const {
 		return filled;

--- a/code/model/modelanimation_moveables.cpp
+++ b/code/model/modelanimation_moveables.cpp
@@ -131,4 +131,148 @@ namespace animation {
 		return std::shared_ptr<ModelAnimationMoveableRotation>(new ModelAnimationMoveableRotation(submodel, angle, velocity, acceleration));
 	}
 
+
+	ModelAnimationMoveableIK::ModelAnimationMoveableIK(std::vector<moveable_chainlink> chain, float time) :
+		m_time(time), m_chain(std::move(chain)) { }
+
+	void ModelAnimationMoveableIK::update(polymodel_instance* pmi, const std::vector<linb::any>& args) {
+		if(args.size() < 3){
+			Error(LOCATION,"Tried updating moveable IK with too few (%d of 3) arguments!", (int) args.size());
+			return;
+		}
+
+		auto& anim = m_instances[pmi->id].animation;
+
+		try {
+			auto x = linb::any_cast<int>(args[0]), y = linb::any_cast<int>(args[1]), z = linb::any_cast<int>(args[2]);
+
+			optional<matrix> orient;
+			if(args.size() >= 6 && args[3].type() == typeid(int)) {
+				auto p = linb::any_cast<int>(args[3]), h = linb::any_cast<int>(args[4]), b = linb::any_cast<int>(args[5]);
+				
+				matrix rot;
+				angles ang{ fl_radians(p), fl_radians(b), fl_radians(h) };
+				vm_angles_2_matrix(&rot, &ang);
+				orient = rot;
+			}
+			
+			auto& sequence = *std::static_pointer_cast<ModelAnimationSegmentSerial>(anim->m_animation);
+			auto& setOrientationParallel = *std::static_pointer_cast<ModelAnimationSegmentParallel>(sequence.m_segments[0]);
+			auto& ik = *std::static_pointer_cast<ModelAnimationSegmentIK>(sequence.m_segments[1]);
+
+			ModelAnimationSubmodelBuffer buffer;
+			for(const auto& segment : setOrientationParallel.m_segments){
+				auto& orientation = *std::static_pointer_cast<ModelAnimationSegmentSetOrientation>(segment);
+				buffer[orientation.m_submodel].data.orientation = IDENTITY_MATRIX;
+			}
+			
+			//Will now only contain the delta of the IK
+			sequence.m_segments[1]->calculateAnimation(buffer, anim->getTime(pmi->id), pmi->id);
+
+			anim->forceRecalculate(pmi);
+
+			for(const auto& segment : setOrientationParallel.m_segments){
+				auto& orientation = *std::static_pointer_cast<ModelAnimationSegmentSetOrientation>(segment);
+				matrix startOrient = orientation.m_targetOrientation;
+				matrix newOrient;
+				//Apply rotation to old default state
+				vm_matrix_x_matrix(&newOrient, &startOrient, &buffer[orientation.m_submodel].data.orientation);
+				orientation.m_targetOrientation = newOrient;
+			}
+
+			ik.m_targetRotation = orient;
+			ik.m_targetPosition = vec3d{{x * 0.01f, y * 0.01f, z * 0.01f}};
+		}
+		catch(const linb::bad_any_cast& e){
+			Error(LOCATION, "Argument error trying to update rotation moveable: %s", e.what());
+		}
+	}
+	
+	void ModelAnimationMoveableIK::initialize(ModelAnimationSet* parentSet, polymodel_instance* pmi) {
+		auto& anim = m_instances[pmi->id].animation;
+
+		anim = std::shared_ptr<ModelAnimation>(new ModelAnimation(false, false, true, parentSet));
+
+		auto sequence = std::shared_ptr<ModelAnimationSegmentSerial>(new ModelAnimationSegmentSerial());
+		auto parallelSetOrient = std::shared_ptr<ModelAnimationSegmentParallel>(new ModelAnimationSegmentParallel());
+		for(const auto& link : m_chain) {
+			auto submodel = parentSet->getSubmodel(link.submodel);
+			parallelSetOrient->addSegment(std::shared_ptr<ModelAnimationSegment>(new ModelAnimationSegmentSetOrientation(submodel, vmd_identity_matrix, true)));
+		}
+		sequence->addSegment(parallelSetOrient);
+		
+		auto parallelIK = std::shared_ptr<ModelAnimationSegmentParallel>(new ModelAnimationSegmentParallel());
+		vec3d startPos = ZERO_VECTOR;
+		
+		for(size_t i = 1; i < m_chain.size(); ++i) {
+			startPos += parentSet->getSubmodel(m_chain[i].submodel)->findSubmodel(pmi).second->offset;
+		}
+		
+		auto segment = std::shared_ptr<ModelAnimationSegmentIK>(new ModelAnimationSegmentIK(startPos, optional<matrix>()));
+		segment->m_segment = parallelIK;
+		
+		for(const auto& link : m_chain) {
+			auto submodel = parentSet->getSubmodel(link.submodel);
+			auto rotation = std::shared_ptr<ModelAnimationSegmentRotation>(new ModelAnimationSegmentRotation(submodel, optional<angles>({0,0,0}), optional<angles>(), m_time, link.acceleration, true));
+			parallelIK->addSegment(rotation);
+			segment->m_chain.push_back({submodel, link.constraint, rotation});
+		}
+		
+		sequence->addSegment(segment);
+		
+		anim->setAnimation(sequence);
+
+		anim->start(pmi,ModelAnimationDirection::FWD);
+	}
+	
+	std::shared_ptr<ModelAnimationMoveable> ModelAnimationMoveableIK::parser() {
+		required_string("+Time:");
+		float time;
+		stuff_float(&time);
+
+		std::vector<moveable_chainlink> chain;
+
+		while (optional_string("$Chain Link:")) {
+			auto submodel = ModelAnimationParseHelper::parseSubmodel();
+
+			optional<angles> acceleration;
+			if (optional_string("+Acceleration:")) {
+				angles accel;
+				stuff_angles_deg_phb(&accel);
+				acceleration = accel;
+			}
+
+			std::shared_ptr<ik_constraint> constraint;
+			if (optional_string("+Constraint:")) {
+				int type = required_string_one_of(2, "Window", "Hinge");
+				switch (type) {
+					case 0: { //Window
+						angles window;
+						required_string("Window");
+						required_string("+Window Size:");
+						stuff_angles_deg_phb(&window);
+						constraint = std::shared_ptr<ik_constraint>(new ik_constraint_window(window));
+						break;
+					}
+					case 1: { //Hinge
+						vec3d axis;
+						required_string("Hinge");
+						required_string("+Axis:");
+						stuff_vec3d(&axis);
+						vm_vec_normalize(&axis);
+						constraint = std::shared_ptr<ik_constraint>(new ik_constraint_hinge(axis));
+						break;
+					}
+					default:
+						UNREACHABLE("IK constraint of unknown type specified!");
+						break;
+				}
+			} else
+				constraint = std::shared_ptr<ik_constraint>(new ik_constraint());
+
+			chain.push_back({submodel, constraint, acceleration});
+		}
+		
+		return std::shared_ptr<ModelAnimationMoveable>(new ModelAnimationMoveableIK(chain, time));
+	}
 }

--- a/code/model/modelanimation_moveables.cpp
+++ b/code/model/modelanimation_moveables.cpp
@@ -181,7 +181,7 @@ namespace animation {
 			}
 
 			ik.m_targetRotation = orient;
-			ik.m_targetPosition = vec3d{{x * 0.01f, y * 0.01f, z * 0.01f}};
+			ik.m_targetPosition = vec3d{{{x * 0.01f, y * 0.01f, z * 0.01f}}};
 		}
 		catch(const linb::bad_any_cast& e){
 			Error(LOCATION, "Argument error trying to update rotation moveable: %s", e.what());

--- a/code/model/modelanimation_moveables.h
+++ b/code/model/modelanimation_moveables.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "math/ik_solver.h"
 #include "model/modelanimation.h"
 
 namespace animation {
@@ -25,6 +26,25 @@ namespace animation {
 	public:
 		static std::shared_ptr<ModelAnimationMoveable> parser();
 		ModelAnimationMoveableRotation(std::shared_ptr<ModelAnimationSubmodel> submodel, const angles& defaultOrient, const angles& velocity, const optional<angles>& acceleration);
+
+		void update(polymodel_instance* pmi, const std::vector<linb::any>& args) override;
+		void initialize(ModelAnimationSet* parentSet, polymodel_instance* pmi) override;
+	};
+
+	class ModelAnimationMoveableIK : public ModelAnimationMoveable {
+		float m_time;
+		
+		struct moveable_chainlink {
+			std::shared_ptr<ModelAnimationSubmodel> submodel;
+			std::shared_ptr<ik_constraint> constraint;
+			optional<angles> acceleration;
+		};
+		
+		std::vector<moveable_chainlink> m_chain;
+		
+	public:
+		static std::shared_ptr<ModelAnimationMoveable> parser();
+		ModelAnimationMoveableIK(std::vector<moveable_chainlink> chain, float time);
 
 		void update(polymodel_instance* pmi, const std::vector<linb::any>& args) override;
 		void initialize(ModelAnimationSet* parentSet, polymodel_instance* pmi) override;

--- a/code/model/modelanimation_segments.cpp
+++ b/code/model/modelanimation_segments.cpp
@@ -1083,6 +1083,12 @@ namespace animation {
 		
 		while(optional_string("$Chain Link:")){
 			auto submodel = ModelAnimationParseHelper::parseSubmodel();
+			if (!submodel) {
+				if (data->parentSubmodel)
+					submodel = data->parentSubmodel;
+				else
+					error_display(1, "IK chain link has no target submodel!");
+			}
 
 			optional<angles> acceleration;
 			if(optional_string("+Acceleration:")){

--- a/code/model/modelanimation_segments.cpp
+++ b/code/model/modelanimation_segments.cpp
@@ -1069,17 +1069,23 @@ namespace animation {
 
 			std::shared_ptr<ik_constraint> constraint;
 			if(optional_string("+Constraint:")){
-				int type = required_string_one_of(1, "Window");
+				int type = required_string_one_of(2, "Window", "Hinge");
 				switch(type){
 					case 0: { //Window
 						angles window;
+						required_string("Window");
 						required_string("+Window Size:");
 						stuff_angles_deg_phb(&window);
 						constraint = std::shared_ptr<ik_constraint>(new ik_constraint_window(window));
 						break;
 					}
 					case 1: { //Hinge
-						constraint = std::shared_ptr<ik_constraint>(new ik_constraint_hinge());
+						vec3d axis;
+						required_string("Hinge");
+						required_string("+Axis:");
+						stuff_vec3d(&axis);
+						vm_vec_normalize(&axis);
+						constraint = std::shared_ptr<ik_constraint>(new ik_constraint_hinge(axis));
 						break;
 					}
 					default:

--- a/code/model/modelanimation_segments.h
+++ b/code/model/modelanimation_segments.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "math/ik_solver.h"
 #include "model/modelanimation.h"
 
 namespace animation {
@@ -11,13 +12,13 @@ namespace animation {
 		std::vector<std::shared_ptr<ModelAnimationSegment>> m_segments;
 
 	private:
-		ModelAnimationSegment* copy() const override;
 		void recalculate(ModelAnimationSubmodelBuffer& base, polymodel_instance* pmi) override;
 		void calculateAnimation(ModelAnimationSubmodelBuffer& base, float time, int pmi_id) const override;
 		void executeAnimation(const ModelAnimationSubmodelBuffer& state, float timeboundLower, float timeboundUpper, ModelAnimationDirection direction, int pmi_id) override;
 		void exchangeSubmodelPointers(ModelAnimationSet& replaceWith) override;
 
 	public:
+		ModelAnimationSegment* copy() const override;
 		static std::shared_ptr<ModelAnimationSegment> parser(ModelAnimationParseHelper* data);
 		void addSegment(std::shared_ptr<ModelAnimationSegment> segment);
 
@@ -30,13 +31,13 @@ namespace animation {
 		std::vector<std::shared_ptr<ModelAnimationSegment>> m_segments;
 
 	private:
-		ModelAnimationSegment* copy() const override;
 		void recalculate(ModelAnimationSubmodelBuffer& base, polymodel_instance* pmi) override;
 		void calculateAnimation(ModelAnimationSubmodelBuffer& base, float time, int pmi_id) const override;
 		void executeAnimation(const ModelAnimationSubmodelBuffer& state, float timeboundLower, float timeboundUpper, ModelAnimationDirection direction, int pmi_id) override;
 		void exchangeSubmodelPointers(ModelAnimationSet& replaceWith) override;
 
 	public:
+		ModelAnimationSegment* copy() const override;
 		static std::shared_ptr<ModelAnimationSegment> parser(ModelAnimationParseHelper* data);
 		void addSegment(std::shared_ptr<ModelAnimationSegment> segment);
 
@@ -169,12 +170,12 @@ namespace animation {
 		enum class CoordinateSystem { COORDS_PARENT, COORDS_LOCAL_AT_START, COORDS_LOCAL_CURRENT } m_coordType;
 
 	private:
+
 		ModelAnimationSegment* copy() const override;
 		void recalculate(ModelAnimationSubmodelBuffer& base, polymodel_instance* pmi) override;
 		void calculateAnimation(ModelAnimationSubmodelBuffer& base, float time, int pmi_id) const override;
 		void executeAnimation(const ModelAnimationSubmodelBuffer& /*state*/, float /*timeboundLower*/, float /*timeboundUpper*/, ModelAnimationDirection /*direction*/, int /*pmi_id*/) override { };
 		void exchangeSubmodelPointers(ModelAnimationSet& replaceWith) override;
-
 	public:
 		static std::shared_ptr<ModelAnimationSegment> parser(ModelAnimationParseHelper* data);
 		ModelAnimationSegmentTranslation(std::shared_ptr<ModelAnimationSubmodel> submodel, optional<vec3d> target, optional<vec3d> velocity, optional<float> time, optional<vec3d> acceleration, CoordinateSystem coordType = CoordinateSystem::COORDS_PARENT);
@@ -211,6 +212,38 @@ namespace animation {
 	public:
 		static std::shared_ptr<ModelAnimationSegment> parser(ModelAnimationParseHelper* data);
 		ModelAnimationSegmentSoundDuring(std::shared_ptr<ModelAnimationSegment> segment, gamesnd_id start, gamesnd_id end, gamesnd_id during, bool flipIfReversed = false);
+
+	};
+	
+	class ModelAnimationSegmentIK : public ModelAnimationSegment {
+		struct instance_data {
+			
+		};
+
+		struct chainlink_data{
+			std::shared_ptr<ModelAnimationSubmodel> submodel;
+			std::shared_ptr<ik_constraint> constraint;
+			std::shared_ptr<ModelAnimationSegmentRotation> animSegment;
+		};
+		
+		//PMI ID -> Instance Data
+		std::map<int, instance_data> m_instances;
+		std::vector<chainlink_data> m_chain;
+		std::shared_ptr<ModelAnimationSegmentParallel> m_segment;
+		
+	public:
+		
+		vec3d m_targetPosition;
+		optional<matrix> m_targetRotation;
+	private:
+		ModelAnimationSegment* copy() const override;
+		void recalculate(ModelAnimationSubmodelBuffer& base, polymodel_instance* pmi) override;
+		void calculateAnimation(ModelAnimationSubmodelBuffer& base, float time, int pmi_id) const override;
+		void executeAnimation(const ModelAnimationSubmodelBuffer& /*state*/, float /*timeboundLower*/, float /*timeboundUpper*/, ModelAnimationDirection /*direction*/, int /*pmi_id*/) override { };
+		void exchangeSubmodelPointers(ModelAnimationSet& replaceWith) override;
+	public:
+		static std::shared_ptr<ModelAnimationSegment> parser(ModelAnimationParseHelper* data);
+		ModelAnimationSegmentIK(const vec3d& targetPosition, const optional<matrix>& targetRotation);
 
 	};
 

--- a/code/model/modelanimation_segments.h
+++ b/code/model/modelanimation_segments.h
@@ -228,11 +228,10 @@ namespace animation {
 		
 		//PMI ID -> Instance Data
 		std::map<int, instance_data> m_instances;
-		std::vector<chainlink_data> m_chain;
-		std::shared_ptr<ModelAnimationSegmentParallel> m_segment;
-		
 	public:
 		
+		std::vector<chainlink_data> m_chain;
+		std::shared_ptr<ModelAnimationSegmentParallel> m_segment;
 		vec3d m_targetPosition;
 		optional<matrix> m_targetRotation;
 	private:

--- a/code/source_groups.cmake
+++ b/code/source_groups.cmake
@@ -753,6 +753,8 @@ add_file_folder("Math"
 	math/floating.h
 	math/fvi.cpp
 	math/fvi.h
+        math/ik_solver.cpp
+        math/ik_solver.h
 	math/spline.cpp
 	math/spline.h
 	math/staticrand.cpp


### PR DESCRIPTION
This PR introduces an animation segment type used to combine multiple submodels into a chain which can be controlled by inverse kinematics.
Allows for each joint to have a specified rotation constraint, as well as to target a specific orientation with the end effector.
Implements the FABRIK algorithm with additions for constraints and end effector rotation.
The hinge constraint _could_ cause certain cases where FABRIK doesn't properly converge, but these'd need to be investigated in the wild when found.

As a side note: Apart from the outstanding translation module by Goober (for which animation support already exists), this is the final thing on my ToDo for animations. So unless someone has more feature requests, the overhaul can be considered basically complete with this PR.