### PR TITLE
Enable `Use Cargo Icon` for briefing icons

### DIFF
--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -1590,6 +1590,13 @@ void parse_briefing(mission * /*pm*/, int flags)
 					}
 				}
 
+				if (optional_string("$use cargo icon:")) {
+					stuff_int(&val);
+					if (val > 0) {
+						bi->flags |= BI_USE_CARGO_ICON;
+					}
+				}
+
 				required_string("$multi_text");
 				stuff_string(not_used_text, F_MULTITEXT, MAX_ICON_TEXT_LEN);
 				required_string("$end_icon");

--- a/fred2/missionsave.cpp
+++ b/fred2/missionsave.cpp
@@ -1098,6 +1098,12 @@ int CFred_mission_save::save_briefing()
 					fout(" %d", (bi->flags & BI_USE_WING_ICON) ? 1 : 0);
 				}
 
+				if ((Mission_save_format != FSO_FORMAT_RETAIL) && (bi->flags & BI_USE_CARGO_ICON)) {
+					required_string_fred("$use cargo icon:");
+					parse_comments();
+					fout(" %d", (bi->flags & BI_USE_CARGO_ICON) ? 1 : 0);
+				}
+
 				required_string_fred("$multi_text");
 				parse_comments();
 

--- a/qtfred/src/mission/missionsave.cpp
+++ b/qtfred/src/mission/missionsave.cpp
@@ -1126,7 +1126,7 @@ int CFred_mission_save::save_briefing()
 					fout(" %d", (bi->flags & BI_USE_WING_ICON) ? 1 : 0);
 				}
 
-				if ((Mission_save_format != FSO_FORMAT_RETAIL) && (bi->flags & BI_USE_CARGO_ICON)) {
+				if ((save_format != MissionFormat::RETAIL) && (bi->flags & BI_USE_CARGO_ICON)) {
 					required_string_fred("$use cargo icon:");
 					parse_comments();
 					fout(" %d", (bi->flags & BI_USE_CARGO_ICON) ? 1 : 0);

--- a/qtfred/src/mission/missionsave.cpp
+++ b/qtfred/src/mission/missionsave.cpp
@@ -1126,6 +1126,12 @@ int CFred_mission_save::save_briefing()
 					fout(" %d", (bi->flags & BI_USE_WING_ICON) ? 1 : 0);
 				}
 
+				if ((Mission_save_format != FSO_FORMAT_RETAIL) && (bi->flags & BI_USE_CARGO_ICON)) {
+					required_string_fred("$use cargo icon:");
+					parse_comments();
+					fout(" %d", (bi->flags & BI_USE_CARGO_ICON) ? 1 : 0);
+				}
+
 				required_string_fred("$multi_text");
 				parse_comments();
 


### PR DESCRIPTION
#3963 notes that cargo icons do not save/work. I'm not sure why the code was not present to use cargo icons, but this PR adds it back in. If there was a deliberate decision to leave out that code, I'm happy to discuss/close. Tested and works as expected. Fixes #3963 