### PR TITLE
replicate submodels that aren't associated with subsystems

### DIFF
--- a/code/model/model.h
+++ b/code/model/model.h
@@ -303,6 +303,8 @@ public:
 
 	flagset<Model::Submodel_flags> flags;
 
+	int subsys_num = -1;			// subsystem number; index to ship_info->subsystems; the counterpart of model_subsystem->subobj_num
+
 	vec3d	offset;					// 3d offset from parent object
 	matrix	frame_of_reference;		// used to be called 'orientation' - this is just used for setting the rotation axis and the animation angles
 
@@ -781,6 +783,29 @@ public:
 	
 	vertex_buffer detail_buffers[MAX_MODEL_DETAIL_LEVELS];
 };
+
+// Iterate over a submodel tree, starting at the given submodel root node, and running the given function for each node.  The function's signature should be:
+//
+// void func(int submodel, int level, bool isLeaf);
+//
+// The "level" parameter indicates how deep the nesting level is, and the "isLeaf" parameter indicates whether the submodel is a leaf node.
+// To find the model's detail0 root node, use pm->submodel[pm->detail[0]].
+template <typename Func>
+void model_iterate_submodel_tree(polymodel* pm, int submodel, Func func, int level = 0)
+{
+	Assertion(pm != nullptr, "pm must not be null!");
+	Assertion(submodel >= 0 && submodel < pm->n_models, "submodel must be in range!");
+
+	auto child = pm->submodel[submodel].first_child;
+
+	func(submodel, level, child < 0);
+
+	while (child >= 0)
+	{
+		model_iterate_submodel_tree(pm, child, func, level + 1);
+		child = pm->submodel[child].next_sibling;
+	}
+}
 
 // Call once to initialize the model system
 void model_init();

--- a/code/model/modelread.cpp
+++ b/code/model/modelread.cpp
@@ -947,7 +947,7 @@ void print_family_tree(polymodel *obj)
 	mprintf(("PRINTING POLYMODEL TREE\n"));
 	mprintf(("%s\n", obj->filename));
 
-	model_iterate_submodel_tree(obj, obj->detail[0], [&](int submodel, int level, bool isLeaf)
+	model_iterate_submodel_tree(obj, obj->detail[0], [&](int submodel, int level, bool /*isLeaf*/)
 		{
 			mprintf(("  "));
 			for (int i = 0; i < level; i++)
@@ -4340,7 +4340,7 @@ void model_get_rotating_submodel_list(SCP_vector<int> *submodel_vector, object *
 		// Don't check it or its children if it is destroyed or it is a replacement (non-moving)
 		if ( !child_submodel_instance->blown_off && (child_submodel->i_replace == -1) && !child_submodel->flags[Model::Submodel_flags::No_collisions, Model::Submodel_flags::Nocollide_this_only])	{
 
-			// Only look for submodels that rotate or intrinsic-rotate
+			// Look for submodels that rotate or intrinsic-rotate
 			if (child_submodel->movement_type == MOVEMENT_TYPE_ROT || child_submodel->movement_type == MOVEMENT_TYPE_INTRINSIC) {
 
 				// check submodel rotation is less than max allowed.
@@ -4348,6 +4348,10 @@ void model_get_rotating_submodel_list(SCP_vector<int> *submodel_vector, object *
 				if (delta_angle < MAX_SUBMODEL_COLLISION_ROT_ANGLE) {
 					submodel_vector->push_back(i);
 				}
+			}
+			// Also look for submodels that aren't subsystems but still move
+			else if (child_submodel->subsys_num < 0 && child_submodel->flags[Model::Submodel_flags::Can_move]) {
+				submodel_vector->push_back(i);
 			}
 		}
 		i = child_submodel->next_sibling;
@@ -4451,7 +4455,7 @@ void model_set_up_techroom_instance(ship_info *sip, int model_instance_num)
 	sip->animations.clearShipData(pmi);
 	sip->animations.startAll(pmi, animation::ModelAnimationTriggerType::Initial, animation::ModelAnimationDirection::FWD, true, true);
 
-	model_iterate_submodel_tree(pm, pm->detail[0], [&](int submodel, int level, bool isLeaf)
+	model_iterate_submodel_tree(pm, pm->detail[0], [&](int submodel, int /*level*/, bool /*isLeaf*/)
 		{
 			auto sm = &pm->submodel[submodel];
 

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -13531,7 +13531,6 @@ void ship_model_replicate_submodels(object *objp)
 {
 	model_subsystem	*psub;
 	ship		*shipp;
-	ship_info	*sip;
 	ship_subsys	*pss;
 
 	flagset<Ship::Subsystem_Flags> empty;
@@ -13541,7 +13540,6 @@ void ship_model_replicate_submodels(object *objp)
 	Assert(objp->type == OBJ_SHIP);
 
 	shipp = &Ships[objp->instance];
-	sip = &Ship_info[shipp->ship_info_index];
 
 	polymodel_instance *pmi = model_get_instance(shipp->model_instance_num);
 	polymodel *pm = model_get(pmi->model_num);
@@ -13561,7 +13559,7 @@ void ship_model_replicate_submodels(object *objp)
 	}
 
 	// Keep other movable submodels in sync
-	model_iterate_submodel_tree(pm, pm->detail[0], [&](int submodel, int level, bool isLeaf)
+	model_iterate_submodel_tree(pm, pm->detail[0], [&](int submodel, int /*level*/, bool /*isLeaf*/)
 		{
 			auto sm = &pm->submodel[submodel];
 

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -6968,7 +6968,7 @@ static int subsys_set(int objnum, int ignore_subsys_info)
 			ship_system->submodel_instance_2 = &pmi->submodel[model_system->turret_gun_sobj];
 		}
 
-		// if the table has set an name copy it
+		// if the table has set an alt name copy it
 		if (ship_system->system_info->alt_sub_name[0] != '\0') {
 			strcpy_s(ship_system->sub_name, ship_system->system_info->alt_sub_name);
 		}
@@ -13531,16 +13531,23 @@ void ship_model_replicate_submodels(object *objp)
 {
 	model_subsystem	*psub;
 	ship		*shipp;
+	ship_info	*sip;
 	ship_subsys	*pss;
+
+	flagset<Ship::Subsystem_Flags> empty;
 
 	Assert(objp != NULL);
 	Assert(objp->instance >= 0);
 	Assert(objp->type == OBJ_SHIP);
 
 	shipp = &Ships[objp->instance];
+	sip = &Ship_info[shipp->ship_info_index];
+
 	polymodel_instance *pmi = model_get_instance(shipp->model_instance_num);
 	polymodel *pm = model_get(pmi->model_num);
 
+	// Keep submodels belonging to subsystems in sync
+	// (This needs to be done from the subsystem perspective because subsystem flags may affect things)
 	for ( pss = GET_FIRST(&shipp->subsys_list); pss != END_OF_LIST(&shipp->subsys_list); pss = GET_NEXT(pss) ) {
 		psub = pss->system_info;
 
@@ -13552,6 +13559,24 @@ void ship_model_replicate_submodels(object *objp)
 			model_replicate_submodel_instance(pm, pmi, psub->turret_gun_sobj, pss->flags );
 		}
 	}
+
+	// Keep other movable submodels in sync
+	model_iterate_submodel_tree(pm, pm->detail[0], [&](int submodel, int level, bool isLeaf)
+		{
+			auto sm = &pm->submodel[submodel];
+
+			// skip submodels that belong to subsystems since we already updated them above
+			// (Turrets are tricky because they have two submodels per subsystem, but because the subsystem index is copied
+			// when the model is read, both submodels are correctly skipped here.)
+			if (sm->subsys_num >= 0)
+				return;
+
+			// the only non-subsystem submodels that need to be updated are the ones that can move
+			if (!sm->flags[Model::Submodel_flags::Can_move])
+				return;
+
+			model_replicate_submodel_instance(pm, pmi, submodel, empty);
+		});
 }
 
 /**


### PR DESCRIPTION
There are a few related improvements here:

1) Add a new function for iterating over the submodel hierarchy
2) Add a counterpart to the `subobj_num` field so that a submodel can refer to its ship_info subsystem
3) Update `ship_model_replicate_submodels` to replicate all movable submodels, even the ones that aren't associated with subsystems

Fixes #3967