### PR TITLE
Various Animation Fixes

### DIFF
--- a/code/math/vecmat.cpp
+++ b/code/math/vecmat.cpp
@@ -1608,34 +1608,41 @@ float vm_closest_angle_to_matrix(const matrix* mat, const vec3d* rot_axis, float
 	const float z = (a[0]*(m[5]-m[7]) + a[1]*(-m[2]+m[6]) + a[2]*(m[1]-m[3]));
 
 	// If both y and z are close to 0, then the rotation axis points in the same direction as the matrix, thus any orientation r would be perpendicular to m
-	// If y is 0, the rest of the math simplifies, and we always find the angle at pi/2 or -pi/2
-	if(fabs(y) < 0.001f) {
-		if (fabs(z) < 0.001f) {
-			*angle = 0.0f;
-			return PI_2;
-		}
-
+	// If y or z is 0, the rest of the math simplifies
+	const float ay = fabs(y);
+	const float az = fabs(z);
+	if(ay < 0.001f && az < 0.001f){
+		*angle = 0.0f;
+		return PI_2;
+	}
+	else if(ay < 0.001f) {
 		*angle = copysignf(PI_2, z);
 		
-		return acosf_safe((w + abs(z) - 1.0f) * 0.5f);
+		return acosf_safe((w + az - 1.0f) * 0.5f);
 	}
-
+	
 	// arccos((x-1)/2) is then minimal, when x between -1 and 3 approaches 3
 	// Thus we are looking for the maximum of a term in the form of f(x)=w+y*sin(x/2)^2+z*sin(x)
 	// This maximum can be on one of the four solutions of f'(x)=0, not counting periodic repetitions
 
-	const float sr = sqrtf(y*y*y*y+4*y*y*z*z);
-	const float sr_pos = sqrtf(1-(sr/(y*y+4*z*z)));
-	const float sr_neg = sqrtf(1+(sr/(y*y+4*z*z)));
+	std::array<float,4> solutions;
 
-	//If we support IEEE float handling, we don't need this, the div by 0 will be handled correctly with the INF. If not, do this:
-	const float yz_recip = (!std::numeric_limits<float>::is_iec559 && y*z < 0.001f) ? FLT_MAX : 1.0f / (y * z);
+	if(az < 0.001f) {
+		solutions = {PI, PI2, PI + PI2, 2.0f * PI2};
+	}
+	else {
+		const float sr = sqrtf(y * y * y * y + 4 * y * y * z * z);
+		const float sr_neg = sqrtf(1 - (sr / (y * y + 4 * z * z)));
+		const float sr_pos = sqrtf(1 + (sr / (y * y + 4 * z * z)));
 
-	const float solutions[] = {2 * atan2_safe(-2 * sr_neg, -sr_neg*(y*y+sr) * yz_recip),
-							   2 * atan2_safe(2 * sr_neg, sr_neg*(y*y+sr) * yz_recip),
-							   2 * atan2_safe(-2 * sr_pos, -sr_pos*(y*y-sr) * yz_recip),
-							   2 * atan2_safe(2 * sr_pos, sr_pos*(y*y-sr) * yz_recip)};
+		//If we support IEEE float handling, we don't need this, the div by 0 will be handled correctly with the INF. If not, do this:
+		const float yz_recip = (!std::numeric_limits<float>::is_iec559 && y * z < 0.001f) ? FLT_MAX : 1.0f / (y * z);
 
+		solutions = { 2 * atan2_safe(-sr_neg * (y * y + sr) * yz_recip, -2 * sr_neg),
+					  2 * atan2_safe(sr_neg * (y * y + sr) * yz_recip, 2 * sr_neg),
+					  2 * atan2_safe(-sr_pos * (y * y - sr) * yz_recip, -2 * sr_pos),
+					  2 * atan2_safe(sr_pos * (y * y - sr) * yz_recip, 2 * sr_pos) };
+	}
 	float value = -2.0f;
 	float correct = 0;
 	//For whichever of these, w+y*sin(x/2)^2+z*sin(x) is closest to 3 / larger (since the result is between -1 and 3) is our target angle
@@ -1649,9 +1656,12 @@ float vm_closest_angle_to_matrix(const matrix* mat, const vec3d* rot_axis, float
 
 	Assertion(value > -1.5f, "Did not find solution for closest angle & axis to matrix.");
 
-	// Since atanf can yield -pi/2 to pi/2, we could get negative results here. Convert to 0 to 2Pi
+	// Convert to 0 to 2Pi
 	while (correct < 0.0f)
 		correct += PI2;
+
+	while (correct > PI2)
+		correct -= PI2;
 
 	*angle = correct;
 	return acosf_safe((value - 1.0f) * 0.5f);

--- a/code/model/modelanimation.cpp
+++ b/code/model/modelanimation.cpp
@@ -321,7 +321,10 @@ namespace animation {
 		if (!submodel.first || !submodel.second) 
 			return;
 
-		submodel.second->flags.set(Model::Submodel_flags::Can_move);
+		if(!submodel.second->flags[Model::Submodel_flags::Can_move]){
+			mprintf(("Submodel %s of model %s is animated and has movement enabled.\n", submodel.second->name, model_get(pmi->model_num)->filename));
+			submodel.second->flags.set(Model::Submodel_flags::Can_move);
+		}
 		
 		data.orientation = submodel.first->canonical_orient;
 		//TODO: Once translation is a thing

--- a/code/model/modelanimation.cpp
+++ b/code/model/modelanimation.cpp
@@ -321,6 +321,8 @@ namespace animation {
 		if (!submodel.first || !submodel.second) 
 			return;
 
+		submodel.second->flags.set(Model::Submodel_flags::Can_move);
+		
 		data.orientation = submodel.first->canonical_orient;
 		//TODO: Once translation is a thing
 		//data.position = m_subsys->submodel_instance_1->offset;
@@ -429,6 +431,9 @@ namespace animation {
 
 		float angle = 0.0f;
 
+		angles test;
+		vm_extract_angles_matrix_alternate(&test, &submodel->canonical_orient);
+		
 		vm_closest_angle_to_matrix(&submodel->canonical_orient, &sm->movement_axis, &angle);
 
 		submodel->cur_angle = angle;

--- a/code/model/modelanimation.cpp
+++ b/code/model/modelanimation.cpp
@@ -430,10 +430,6 @@ namespace animation {
 		submodel->canonical_orient = data.orientation;
 
 		float angle = 0.0f;
-
-		angles test;
-		vm_extract_angles_matrix_alternate(&test, &submodel->canonical_orient);
-		
 		vm_closest_angle_to_matrix(&submodel->canonical_orient, &sm->movement_axis, &angle);
 
 		submodel->cur_angle = angle;

--- a/code/model/modelanimation.cpp
+++ b/code/model/modelanimation.cpp
@@ -308,6 +308,7 @@ namespace animation {
 		if (!submodel)
 			return;
 
+		submodel->canonical_prev_orient = submodel->canonical_orient;
 		submodel->canonical_orient = data.orientation;
 
 		//TODO: Once translation is a thing
@@ -430,6 +431,7 @@ namespace animation {
 		if (!submodel)
 			return;
 
+		submodel->canonical_prev_orient = submodel->canonical_orient;
 		submodel->canonical_orient = data.orientation;
 
 		float angle = 0.0f;

--- a/code/model/modelanimation_moveables.cpp
+++ b/code/model/modelanimation_moveables.cpp
@@ -21,6 +21,8 @@ namespace animation {
 
 			auto& setOrientation = *std::static_pointer_cast<ModelAnimationSegmentSetOrientation>(anim->m_animation);
 			setOrientation.m_targetAngle = angles{fl_radians((float)p), fl_radians((float)b), fl_radians((float)h)};
+			
+			anim->start(pmi, ModelAnimationDirection::FWD);
 		}
 		catch(const linb::bad_any_cast& e){
 			Error(LOCATION, "Argument error trying to update orientation moveable: %s", e.what());
@@ -83,6 +85,8 @@ namespace animation {
 			setOrientation.m_targetOrientation = newOrient;
 			
 			rotation.m_targetAngle = angles{fl_radians((float)p), fl_radians((float)b), fl_radians((float)h)};
+
+			anim->start(pmi, ModelAnimationDirection::FWD);
 		}
 		catch(const linb::bad_any_cast& e){
 			Error(LOCATION, "Argument error trying to update rotation moveable: %s", e.what());
@@ -164,6 +168,8 @@ namespace animation {
 			setOrientation.m_targetOrientation = newOrient;
 
 			rotation.m_targetAngle = fl_radians((float)ang);
+
+			anim->start(pmi, ModelAnimationDirection::FWD);
 		}
 		catch(const linb::bad_any_cast& e){
 			Error(LOCATION, "Argument error trying to update rotation moveable: %s", e.what());
@@ -261,6 +267,8 @@ namespace animation {
 
 			ik.m_targetRotation = orient;
 			ik.m_targetPosition = vec3d{{{x * 0.01f, y * 0.01f, z * 0.01f}}};
+
+			anim->start(pmi, ModelAnimationDirection::FWD);
 		}
 		catch(const linb::bad_any_cast& e){
 			Error(LOCATION, "Argument error trying to update rotation moveable: %s", e.what());


### PR DESCRIPTION
1. Some turrets had wrong initial orientations in mission only. This is fixed by removing the errors from ``vm_closest_angle_to_matrix``.
2. Now sets the Can_move flag for all submodels that might be animated by an animation
3. Properly set canonical_prev_orientation for collisions and others
4. Fix moveables flickering when updating