### PR TITLE
handle primary and secondary inversion explicitly and independently

### DIFF
--- a/code/controlconfig/controlsconfig.cpp
+++ b/code/controlconfig/controlsconfig.cpp
@@ -1096,7 +1096,8 @@ void control_config_toggle_invert()
 	switch (Selected_item) {
 	case selItem::None:
 		// both
-		item.invert_toggle();
+		item.first.invert_toggle();
+		item.second.invert_toggle();
 		break;
 	case selItem::Primary:
 		// first

--- a/code/controlconfig/controlsconfig.h
+++ b/code/controlconfig/controlsconfig.h
@@ -499,21 +499,6 @@ public:
 	 * Returns a pointer to first, or second, whichever has *all* flags in the given mask
 	 */
 	CC_bind* find_flags(const char);
-
-	/*!
-	 * Sets the inversion state of both bindings
-	 */
-	void invert(bool);
-
-	/*!
-	 * Toggles the inversion state of Primary and copies it to Secondary
-	 */
-	void invert_toggle();
-
-	/*!
-	 * Is true if both bindings are inverted, false otherwise
-	 */
-	bool is_inverted() const;
 };
 
 /*!

--- a/code/controlconfig/controlsconfigcommon.cpp
+++ b/code/controlconfig/controlsconfigcommon.cpp
@@ -2601,20 +2601,6 @@ CC_bind* CCB::find_flags(const char mask) {
 	return nullptr;
 }
 
-void CCB::invert(bool inv) {
-	first.invert(inv);
-	second.invert(inv);
-}
-
-void CCB::invert_toggle() {
-	first.invert_toggle();
-	second.invert_toggle();
-}
-
-bool CCB::is_inverted() const {
-	return first.is_inverted() && second.is_inverted();
-}
-
 bool CCI::is_axis() {
 	switch (type) {
 	case CC_TYPE_AXIS_ABS:

--- a/code/pilotfile/plr.cpp
+++ b/code/pilotfile/plr.cpp
@@ -685,7 +685,8 @@ void pilotfile::plr_read_controls()
 
 			if (idx < NUM_JOY_AXIS_ACTIONS) {
 				Control_config[idx + JOY_AXIS_BEGIN].take(CC_bind(CID_JOY0, static_cast<short>(axi), CCF_AXIS), 0);
-				Control_config[idx + JOY_AXIS_BEGIN].invert(inv != 0);
+				Control_config[idx + JOY_AXIS_BEGIN].first.invert(inv != 0);
+				Control_config[idx + JOY_AXIS_BEGIN].second.invert(inv != 0);
 			}
 		}
 		handler->endArrayRead();
@@ -772,7 +773,7 @@ void pilotfile::plr_write_controls()
 			handler->writeInt("axis_map", -1);
 		}
 		
-		handler->writeInt("invert_axis", item.is_inverted() ? 1 : 0);
+		handler->writeInt("invert_axis", (item.first.is_inverted() || item.second.is_inverted()) ? 1 : 0);
 
 		handler->endSectionWrite();
 	}

--- a/code/scripting/api/objs/controls.cpp
+++ b/code/scripting/api/objs/controls.cpp
@@ -80,13 +80,8 @@ ADE_FUNC(isMouseButtonDown,
 	return ade_set_args(L, "b", rtn);
 }
 
-static int AxisActionInverted_sub(int AxisAction, lua_State* L)
+static int AxisActionInverted_sub(int AxisAction, int ordinal, lua_State* L)
 {
-	// z64: If so desired, it may be possible to have two inversion states, one set by the player in the config menu,
-	//   and one set by scripting.  Essentially, the CCI will have its own inversion flag in addition to the inversion
-	//   flags to both bindings.  Thus, its possible for the player to invert one binding while keeping the other
-	//   binding normal instead of having the script try to set each bind's inversion state individually.
-
 	bool b;
 	if (!ade_get_args(L, "*|b", &b))
 		return ade_set_error(L, "b", false);
@@ -94,55 +89,89 @@ static int AxisActionInverted_sub(int AxisAction, lua_State* L)
 	if ((AxisAction < JOY_HEADING_AXIS) || (AxisAction > JOY_REL_THROTTLE_AXIS))
 		return ade_set_error(L, "b", false);	// invalid IoActionId
 
-	auto& item = Control_config[AxisAction];
+	CC_bind *bind;
+	if (ordinal == 0)
+		bind = &Control_config[AxisAction].first;
+	else if (ordinal == 1)
+		bind = &Control_config[AxisAction].second;
+	else
+	{
+		UNREACHABLE("Currently only primary and secondary bindings are supported!");
+		return ADE_RETURN_NIL;
+	}
 
 	if (ADE_SETTING_VAR)
-		item.invert(b);
+		bind->invert(b);
 
-	if (item.is_inverted())
+	if (bind->is_inverted())
 		return ADE_RETURN_TRUE;
 	else
 		return ADE_RETURN_FALSE;
 }
 
-ADE_VIRTVAR_DEPRECATED(XAxisInverted, l_Mouse, "boolean inverted", "Gets or sets whether the X-axis action is inverted", "boolean", "True/false", gameversion::version(21, 6), "Deprecated in favor of HeadingAxisInverted")
+ADE_VIRTVAR_DEPRECATED(XAxisInverted, l_Mouse, "boolean inverted", "Gets or sets whether the heading axis action's primary binding is inverted", "boolean", "True/false", gameversion::version(21, 6), "Deprecated in favor of HeadingAxisInverted")
 {
-	return AxisActionInverted_sub(JOY_HEADING_AXIS, L);
+	return AxisActionInverted_sub(JOY_HEADING_AXIS, 0, L);
 }
 
-ADE_VIRTVAR_DEPRECATED(YAxisInverted, l_Mouse, "boolean inverted", "Gets or sets whether the Y-axis action is inverted", "boolean", "True/false", gameversion::version(21, 6), "Deprecated in favor of PitchAxisInverted")
+ADE_VIRTVAR_DEPRECATED(YAxisInverted, l_Mouse, "boolean inverted", "Gets or sets whether the pitch axis action's primary binding is inverted", "boolean", "True/false", gameversion::version(21, 6), "Deprecated in favor of PitchAxisInverted")
 {
-	return AxisActionInverted_sub(JOY_PITCH_AXIS, L);
+	return AxisActionInverted_sub(JOY_PITCH_AXIS, 0, L);
 }
 
-ADE_VIRTVAR_DEPRECATED(ZAxisInverted, l_Mouse, "boolean inverted", "Gets or sets whether the Z-axis action is inverted", "boolean", "True/false", gameversion::version(21, 6), "Deprecated in favor of BankAxisInverted")
+ADE_VIRTVAR_DEPRECATED(ZAxisInverted, l_Mouse, "boolean inverted", "Gets or sets whether the bank axis action's primary binding is inverted", "boolean", "True/false", gameversion::version(21, 6), "Deprecated in favor of BankAxisInverted")
 {
-	return AxisActionInverted_sub(JOY_BANK_AXIS, L);
+	return AxisActionInverted_sub(JOY_BANK_AXIS, 0, L);
 }
 
-ADE_VIRTVAR(HeadingAxisInverted, l_Mouse, "boolean inverted", "Gets or sets whether the heading axis action is inverted", "boolean", "True/false")
+ADE_VIRTVAR(HeadingAxisPrimaryInverted, l_Mouse, "boolean inverted", "Gets or sets whether the heading axis action's primary binding is inverted", "boolean", "True/false")
 {
-	return AxisActionInverted_sub(JOY_HEADING_AXIS, L);
+	return AxisActionInverted_sub(JOY_HEADING_AXIS, 0, L);
 }
 
-ADE_VIRTVAR(PitchAxisInverted, l_Mouse, "boolean inverted", "Gets or sets whether the pitch axis action is inverted", "boolean", "True/false")
+ADE_VIRTVAR(HeadingAxisSecondaryInverted, l_Mouse, "boolean inverted", "Gets or sets whether the heading axis action's secondary binding is inverted", "boolean", "True/false")
 {
-	return AxisActionInverted_sub(JOY_PITCH_AXIS, L);
+	return AxisActionInverted_sub(JOY_HEADING_AXIS, 1, L);
 }
 
-ADE_VIRTVAR(BankAxisInverted, l_Mouse, "boolean inverted", "Gets or sets whether the bank axis action is inverted", "boolean", "True/false")
+ADE_VIRTVAR(PitchAxisPrimaryInverted, l_Mouse, "boolean inverted", "Gets or sets whether the pitch axis action's primary binding is inverted", "boolean", "True/false")
 {
-	return AxisActionInverted_sub(JOY_BANK_AXIS, L);
+	return AxisActionInverted_sub(JOY_PITCH_AXIS, 0, L);
 }
 
-ADE_VIRTVAR(AbsoluteThrottleAxisInverted, l_Mouse, "boolean inverted", "Gets or sets whether the absolute throttle axis action is inverted", "boolean", "True/false")
+ADE_VIRTVAR(PitchAxisSecondaryInverted, l_Mouse, "boolean inverted", "Gets or sets whether the pitch axis action's secondary binding is inverted", "boolean", "True/false")
 {
-	return AxisActionInverted_sub(JOY_ABS_THROTTLE_AXIS, L);
+	return AxisActionInverted_sub(JOY_PITCH_AXIS, 1, L);
 }
 
-ADE_VIRTVAR(RelativeThrottleAxisInverted, l_Mouse, "boolean inverted", "Gets or sets whether the relative throttle axis action is inverted", "boolean", "True/false")
+ADE_VIRTVAR(BankAxisPrimaryInverted, l_Mouse, "boolean inverted", "Gets or sets whether the bank axis action's primary binding is inverted", "boolean", "True/false")
 {
-	return AxisActionInverted_sub(JOY_REL_THROTTLE_AXIS, L);
+	return AxisActionInverted_sub(JOY_BANK_AXIS, 0, L);
+}
+
+ADE_VIRTVAR(BankAxisSecondaryInverted, l_Mouse, "boolean inverted", "Gets or sets whether the bank axis action's secondary binding is inverted", "boolean", "True/false")
+{
+	return AxisActionInverted_sub(JOY_BANK_AXIS, 1, L);
+}
+
+ADE_VIRTVAR(AbsoluteThrottleAxisPrimaryInverted, l_Mouse, "boolean inverted", "Gets or sets whether the absolute throttle axis action's primary binding is inverted", "boolean", "True/false")
+{
+	return AxisActionInverted_sub(JOY_ABS_THROTTLE_AXIS, 0, L);
+}
+
+ADE_VIRTVAR(AbsoluteThrottleAxisSecondaryInverted, l_Mouse, "boolean inverted", "Gets or sets whether the absolute throttle axis action's secondary binding is inverted", "boolean", "True/false")
+{
+	return AxisActionInverted_sub(JOY_ABS_THROTTLE_AXIS, 1, L);
+}
+
+ADE_VIRTVAR(RelativeThrottleAxisPrimaryInverted, l_Mouse, "boolean inverted", "Gets or sets whether the relative throttle axis action's primary binding is inverted", "boolean", "True/false")
+{
+	return AxisActionInverted_sub(JOY_REL_THROTTLE_AXIS, 0, L);
+}
+
+ADE_VIRTVAR(RelativeThrottleAxisSecondaryInverted, l_Mouse, "boolean inverted", "Gets or sets whether the relative throttle axis action's secondary binding is inverted", "boolean", "True/false")
+{
+	return AxisActionInverted_sub(JOY_REL_THROTTLE_AXIS, 1, L);
 }
 
 ADE_FUNC(AxisInverted, l_Mouse, "number cid, number axis, boolean inverted", "Gets or sets the given Joystick or Mouse axis inversion state.  Mouse cid = -1, Joystick cid = [0, 3]", "boolean", "True/false")


### PR DESCRIPTION
Treating both bindings together will fail when a player has one binding inverted but the other uninverted.  This was complicated by the dual-binding method mysteriously delegating to the single-binding method in certain cases.  This change removes the dual-binding methods altogether and explicitly handles the bindings individually.  It also adds additional scripting VIRTVARs for all current use cases.