### PR TITLE
refactoring in preparation for model translation

### DIFF
--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -2751,7 +2751,7 @@ void copy_xlate_model_path_points(object *objp, model_path *mp, int dir, int cou
 	int		pp_index;		//	index in Path_points at which to store point, if this is a modify-in-place (pnp ! NULL)
 	int		start_index, finish_index;
 	vec3d submodel_offset, local_vert;
-	bool rotating_submodel;
+	bool moving_submodel;
 	
 	//	Initialize pp_index.
 	//	If pnp == NULL, that means we're creating new points.  If not NULL, then modify in place.
@@ -2772,24 +2772,24 @@ void copy_xlate_model_path_points(object *objp, model_path *mp, int dir, int cou
 	auto pmi = model_get_instance(Ships[objp->instance].model_instance_num);
 	auto pm = model_get(pmi->model_num);
 
-	// Goober5000 - check for rotating submodels
-	if ((mp->parent_submodel >= 0) && (pm->submodel[mp->parent_submodel].movement_type >= 0))
+	// Goober5000 - check for moving submodels
+	if ((mp->parent_submodel >= 0) && (pm->submodel[mp->parent_submodel].rotation_type >= 0))
 	{
-		rotating_submodel = true;
+		moving_submodel = true;
 
 		model_find_submodel_offset(&submodel_offset, pm, mp->parent_submodel);
 	}
 	else
 	{
-		rotating_submodel = false;
+		moving_submodel = false;
 	}
 
 	int offset = 0;
 	for (i=start_index; i != finish_index; i += dir)
 	{
 		//	Globalize the point.
-		// Goober5000 - handle rotating submodels
-		if (rotating_submodel)
+		// Goober5000 - handle moving submodels
+		if (moving_submodel)
 		{
 			// movement... find location of point like with docking code and spark generation
 			vm_vec_sub(&local_vert, &mp->verts[i].pos, &submodel_offset);
@@ -9473,8 +9473,8 @@ void set_goal_dock_orient(matrix *dom, matrix *docker_dock_orient, matrix *docke
 }
 
 // Goober5000
-// Return the rotating submodel on which is mounted the specified dockpoint, or -1 for none.
-int find_parent_rotating_submodel(polymodel *pm, int dock_index)
+// Return the moving submodel on which is mounted the specified dockpoint, or -1 for none.
+int find_parent_moving_submodel(polymodel *pm, int dock_index)
 {
 	Assertion(pm != nullptr, "pm cannot be null!");
 	Assertion(dock_index >= 0 && dock_index < pm->n_docks, "for model %s, dock_index %d must be >= 0 and < %d!", pm->filename, dock_index, pm->n_docks);
@@ -9504,7 +9504,7 @@ int find_parent_rotating_submodel(polymodel *pm, int dock_index)
 		submodel = pm->paths[path_num].parent_submodel;
 
 		// submodel must exist and must move
-		if ((submodel >= 0) && (submodel < pm->n_models) && (pm->submodel[submodel].movement_type >= 0))
+		if ((submodel >= 0) && (submodel < pm->n_models) && (pm->submodel[submodel].rotation_type >= 0))
 		{
 			return submodel;
 		}
@@ -9522,7 +9522,7 @@ void find_adjusted_dockpoint_info(vec3d *global_dock_point, matrix *global_dock_
 
 	vec3d fvec, uvec;
 
-	// are we basing this off a rotating submodel?
+	// are we basing this off a moving submodel?
 	if (submodel >= 0)
 	{
 		vec3d submodel_offset;
@@ -9532,7 +9532,7 @@ void find_adjusted_dockpoint_info(vec3d *global_dock_point, matrix *global_dock_
 		auto pmi = model_get_instance(shipp->model_instance_num);
 		Assert(pmi->model_num == pm->id);
 
-		// calculate the dockpoint locations relative to the unrotated submodel
+		// calculate the dockpoint locations relative to the submodel in its original position
 		model_find_submodel_offset(&submodel_offset, pm, submodel);
 		vm_vec_sub(&local_p0, &pm->docking_bays[dock_index].pnt[0], &submodel_offset);
 		vm_vec_sub(&local_p1, &pm->docking_bays[dock_index].pnt[1], &submodel_offset);
@@ -9611,30 +9611,30 @@ float dock_orient_and_approach(object *docker_objp, int docker_index, object *do
 	Assert(pm1->docking_bays[dockee_index].num_slots == 2);
 
 
-	// Goober5000 - check if we're attached to a rotating submodel
-	int dockee_rotating_submodel = find_parent_rotating_submodel(pm1, dockee_index);
+	// Goober5000 - check if we're attached to a moving submodel
+	int dockee_moving_submodel = find_parent_moving_submodel(pm1, dockee_index);
 
 	matrix docker_dock_orient, dockee_dock_orient;
 	// Goober5000 - move docking points with submodels if necessary, for both docker and dockee
 	find_adjusted_dockpoint_info(&docker_point, &docker_dock_orient, docker_objp, pm0, -1, docker_index);
-	find_adjusted_dockpoint_info(&dockee_point, &dockee_dock_orient, dockee_objp, pm1, dockee_rotating_submodel, dockee_index);
+	find_adjusted_dockpoint_info(&dockee_point, &dockee_dock_orient, dockee_objp, pm1, dockee_moving_submodel, dockee_index);
 
 	// Goober5000
 	vec3d submodel_pos = ZERO_VECTOR;
 	float submodel_radius = 0.0f;
 	float submodel_omega = 0.0f;
-	if ((dockee_rotating_submodel >= 0) && (dock_mode != DOA_DOCK_STAY))
+	if ((dockee_moving_submodel >= 0) && (dock_mode != DOA_DOCK_STAY))
 	{
 		vec3d submodel_offset;
 
 		// get submodel center
-		model_find_submodel_offset(&submodel_offset, pm1, dockee_rotating_submodel);
+		model_find_submodel_offset(&submodel_offset, pm1, dockee_moving_submodel);
 		vm_vec_add(&submodel_pos, &dockee_objp->pos, &submodel_offset);
 
 		polymodel_instance *pmi1 = model_get_instance(Ships[dockee_objp->instance].model_instance_num);
 
 		// get angular velocity of dockpoint
-		submodel_omega = pmi1->submodel[dockee_rotating_submodel].current_turn_rate;
+		submodel_omega = pmi1->submodel[dockee_moving_submodel].current_turn_rate;
 
 		// get radius to dockpoint
 		submodel_radius = vm_vec_dist(&submodel_pos, &dockee_point);
@@ -9648,7 +9648,7 @@ float dock_orient_and_approach(object *docker_objp, int docker_index, object *do
 	rdinfo->docker_point = docker_point;
 	rdinfo->dockee_point = dockee_point;
 	rdinfo->dock_mode = dock_mode;
-	rdinfo->submodel = dockee_rotating_submodel;
+	rdinfo->submodel = dockee_moving_submodel;
 	rdinfo->submodel_pos = submodel_pos;
 	rdinfo->submodel_r = submodel_radius;
 	rdinfo->submodel_w = submodel_omega;
@@ -9708,8 +9708,8 @@ float dock_orient_and_approach(object *docker_objp, int docker_index, object *do
 		} else
 			ss1 = 2.0f;
 
-		// if we're docking to a rotating submodel, speed up translation
-		if (dockee_rotating_submodel >= 0)
+		// if we're docking to a moving submodel, speed up translation
+		if (dockee_moving_submodel >= 0)
 			ss1 = 2.0f;
 
 		speed_scale *= 1.0f + ss1;

--- a/code/model/model.h
+++ b/code/model/model.h
@@ -36,12 +36,11 @@ extern int model_render_flags_size;
 #define MAX_NAME_LEN			32
 #define MAX_ARC_EFFECTS		8
 
-#define MOVEMENT_TYPE_NONE				-1
-#define MOVEMENT_TYPE_POS				0
-#define MOVEMENT_TYPE_ROT				1
-#define MOVEMENT_TYPE_ROT_SPECIAL		2	// for turrets only
-#define MOVEMENT_TYPE_TRIGGERED			3	// triggered rotation
-#define MOVEMENT_TYPE_INTRINSIC			4	// intrinsic (non-subsystem-based) motion
+#define MOVEMENT_TYPE_NONE			-1
+#define MOVEMENT_TYPE_REGULAR		0
+#define MOVEMENT_TYPE_TURRET		1	// for turrets only
+#define MOVEMENT_TYPE_TRIGGERED		2
+#define MOVEMENT_TYPE_INTRINSIC		3	// intrinsic (non-subsystem-based)
 
 
 // DA 11/13/98 Reordered to account for difference between max and game
@@ -87,13 +86,13 @@ struct submodel_instance
 	float	current_turn_rate = 0.0f;
 	float	desired_turn_rate = 0.0f;
 	float	turn_accel = 0.0f;
-	int		step_zero_timestamp = timestamp();		// timestamp determines when next step is to begin (for stepped rotation)
+	int		turn_step_zero_timestamp = timestamp();		// timestamp determines when next step is to begin (for stepped rotation)
 
-	vec3d	point_on_axis;							// in ship RF
+	vec3d	point_on_axis = vmd_zero_vector;		// in ship RF
 	bool	axis_set = false;
-	bool	blown_off = false;						// If set, this subobject is blown off
 
-	bool collision_checked = false;
+	bool	blown_off = false;						// If set, this subobject is blown off
+	bool	collision_checked = false;
 
 	// These fields are the true standard reference for submodel rotation.  They should seldom be read directly
 	// and should almost never be written directly.  In most cases, coders should prefer cur_angle and prev_angle.
@@ -294,9 +293,10 @@ public:
 	}
 
 	char	name[MAX_NAME_LEN];						// name of the subsystem.  Probably displayed on HUD
-	int		movement_type = -1;						// -1 if no movement, otherwise rotational or positional movement -- subobjects only
-	vec3d	movement_axis = vmd_zero_vector;		// which axis this subobject moves or rotates on.
-	int		movement_axis_id = -1;					// for optimization
+
+	int		rotation_type = MOVEMENT_TYPE_NONE;
+	vec3d	rotation_axis = vmd_zero_vector;		// which axis this subobject rotates on.
+	int		rotation_axis_id = MOVEMENT_AXIS_NONE;	// for optimization
 
 	float	default_turn_rate = 0.0f;
 	float	default_turn_accel = 0.0f;
@@ -971,11 +971,11 @@ extern void find_submodel_instance_point_normal(vec3d *outpnt, vec3d *outnorm, c
 extern void find_submodel_instance_point_orient(vec3d *outpnt, matrix *outorient, const polymodel *pm, const polymodel_instance *pmi, int submodel_num, const vec3d *submodel_pnt, const matrix *submodel_orient);
 extern void find_submodel_instance_world_point(vec3d *outpnt, const polymodel *pm, const polymodel_instance *pmi, int submodel_num, const matrix *objorient, const vec3d *objpos);
 
-// Given a polygon model index, find a list of rotating submodels to be used for collision
-void model_get_rotating_submodel_list(SCP_vector<int> *submodel_vector, object *objp);
+// Given a polygon model index, find a list of moving submodels to be used for collision
+void model_get_moving_submodel_list(SCP_vector<int> &submodel_vector, const object *objp);
 
 // Given a polygon model index, get a list of a model tree starting from that index
-void model_get_submodel_tree_list(SCP_vector<int> &submodel_vector, polymodel* pm, int mn);
+void model_get_submodel_tree_list(SCP_vector<int> &submodel_vector, const polymodel *pm, int mn);
 
 // For a rotating submodel, find a point on the axis
 void model_init_submodel_axis_pt(polymodel *pm, polymodel_instance *pmi, int submodel_num);
@@ -1063,7 +1063,7 @@ typedef struct mc_info {
 	float		hit_u, hit_v;		// Where on hit_bitmap the ray hit.  Invalid if hit_bitmap < 0
 	int		shield_hit_tri;	// Which triangle on the shield got hit or -1 if none
 	vec3d	hit_normal;			//	Vector normal of polygon of collision.  (This is in submodel RF)
-	int		edge_hit;			// Set if an edge got hit.  Only valid if MC_CHECK_THICK is set.	
+	bool		edge_hit;			// Set if an edge got hit.  Only valid if MC_CHECK_THICK is set.	
 	ubyte		*f_poly;				// pointer to flat poly where we intersected
 	ubyte		*t_poly;				// pointer to tmap poly where we intersected
 	bsp_collision_leaf *bsp_leaf;
@@ -1092,7 +1092,7 @@ inline void mc_info_init(mc_info *mc)
 	mc->hit_u = 0; mc->hit_v = 0;
 	mc->shield_hit_tri = -1;
 	mc->hit_normal = vmd_zero_vector;
-	mc->edge_hit = 0;
+	mc->edge_hit = false;
 	mc->f_poly = nullptr;
 	mc->t_poly = nullptr;
 	mc->bsp_leaf = nullptr;

--- a/code/model/model_flags.h
+++ b/code/model/model_flags.h
@@ -24,7 +24,7 @@ namespace Model {
 	};
 
 	FLAG_LIST(Subsystem_Flags) {
-		Rotates,			// This means the object rotates automatically with "turn_rate"
+		Rotates,			// This means the object rotates automatically
 		Stepped_rotate,		// This means that the rotation occurs in steps
 		Ai_rotate,			// This means that the rotation is controlled by ai
 		Crewpoint,			// If set, this is a crew point.

--- a/code/model/modelanimation.cpp
+++ b/code/model/modelanimation.cpp
@@ -435,7 +435,7 @@ namespace animation {
 		submodel->canonical_orient = data.orientation;
 
 		float angle = 0.0f;
-		vm_closest_angle_to_matrix(&submodel->canonical_orient, &sm->movement_axis, &angle);
+		vm_closest_angle_to_matrix(&submodel->canonical_orient, &sm->rotation_axis, &angle);
 
 		submodel->cur_angle = angle;
 		submodel->turret_idle_angle = angle;

--- a/code/model/modelanimation_segments.cpp
+++ b/code/model/modelanimation_segments.cpp
@@ -262,7 +262,7 @@ namespace animation {
 			return;
 		}
 
-		switch (submodel_info->movement_axis_id)
+		switch (submodel_info->rotation_axis_id)
 		{
 			case MOVEMENT_AXIS_X:
 			angs.p = m_angle;
@@ -280,7 +280,7 @@ namespace animation {
 			break;
 
 		default:
-			vm_quaternion_rotate(&m_rot, m_angle, &submodel_info->movement_axis);
+			vm_quaternion_rotate(&m_rot, m_angle, &submodel_info->rotation_axis);
 			break;
 		}
 

--- a/code/model/modelcollide.cpp
+++ b/code/model/modelcollide.cpp
@@ -247,7 +247,7 @@ static void mc_check_sphereline_face( int nv, vec3d ** verts, vec3d * plane_pnt,
 			Mc->hit_point = hit_point;
 			Mc->hit_normal = *plane_norm;
 			Mc->hit_submodel = Mc_submodel;			
-			Mc->edge_hit = 0;
+			Mc->edge_hit = false;
 
 			if ( uvl_list )	{
 				Mc->hit_u = u;
@@ -315,7 +315,7 @@ static void mc_check_sphereline_face( int nv, vec3d ** verts, vec3d * plane_pnt,
 				Mc->hit_dist = sphere_time;
 				Mc->hit_point = hit_point;
 				Mc->hit_submodel = Mc_submodel;
-				Mc->edge_hit = 1;
+				Mc->edge_hit = true;
 				if ( ntmap < 0 ) {
 					Mc->hit_bitmap = -1;
 				} else {
@@ -1217,7 +1217,7 @@ int model_collide(mc_info *mc_info_obj)
 	Mc->num_hits = 0;				// How many collisions were found
 	Mc->shield_hit_tri = -1;	// Assume we won't hit any shield polygons
 	Mc->hit_bitmap = -1;
-	Mc->edge_hit = 0;
+	Mc->edge_hit = false;
 
 	if ( (Mc->flags & MC_CHECK_SHIELD) && (Mc->flags & MC_CHECK_MODEL) )	{
 		Error( LOCATION, "Checking both shield and model!\n" );

--- a/code/model/modelread.cpp
+++ b/code/model/modelread.cpp
@@ -53,7 +53,7 @@ flag_def_list model_render_flags[] =
   	 
 int model_render_flags_size = sizeof(model_render_flags)/sizeof(flag_def_list);
 
-#define MAX_SUBMODEL_COLLISION_ROT_ANGLE (PI / 6.0f)	// max 30 degrees per frame
+#define MAX_SUBMODEL_COLLISION_ANGLE	(PI / 6.0f)		// max 30 degrees per frame
 
 // info for special polygon lists
 
@@ -478,7 +478,7 @@ void get_user_prop_value(char *buf, char *value)
 }
 
 // routine to parse out a vec3d from a user property field of an object
-bool get_user_vec3d_value(char *buf, vec3d *value, bool require_brackets, char* submodel_name, char* filename)
+bool get_user_vec3d_value(char *buf, vec3d *value, bool require_brackets, const char *submodel_name, const char *filename)
 {
 	float f1, f2, f3;
 	char closing_bracket = '\0';
@@ -616,7 +616,7 @@ bool in(char *&p, char *str, const char *substr)
 }
 
 const Model::Subsystem_Flags carry_flags[] = { Model::Subsystem_Flags::Crewpoint, Model::Subsystem_Flags::Rotates, Model::Subsystem_Flags::Triggered, Model::Subsystem_Flags::Artillery, Model::Subsystem_Flags::Stepped_rotate };
-// funciton to copy model data from one subsystem set to another subsystem set.  This function
+// Function to copy model data from one subsystem set to another subsystem set.  This function
 // is called when two ships use the same model data, but since the model only gets read in one time,
 // the subsystem data is only present in one location.  The ship code will call this routine to fix
 // this situation by copying stuff from the source subsystem set to the dest subsystem set.
@@ -729,8 +729,8 @@ static void set_subsystem_info(int model_num, model_subsystem *subsystemp, char 
 	}
 
 	if (in(props, "$triggered")) {
-        subsystemp->flags.set(Model::Subsystem_Flags::Rotates);
-        subsystemp->flags.set(Model::Subsystem_Flags::Triggered);
+		subsystemp->flags.set(Model::Subsystem_Flags::Rotates);
+		subsystemp->flags.set(Model::Subsystem_Flags::Triggered);
 	}
 
 	// Dumb-Rotating subsystem
@@ -769,8 +769,8 @@ static void set_subsystem_info(int model_num, model_subsystem *subsystemp, char 
 		}
 
 		// CASE OF WEAPON ROTATION (primary only)
-		if (in(p, props, "$pbank"))	{
-            subsystemp->flags.set(Model::Subsystem_Flags::Artillery);
+		if (in(p, props, "$pbank")) {
+			subsystemp->flags.set(Model::Subsystem_Flags::Artillery);
 
 			// get which pbank should trigger rotation
 			get_user_prop_value(p+6, buf);
@@ -1138,15 +1138,245 @@ void model_calc_bound_box( vec3d *box, vec3d *big_mn, vec3d *big_mx)
 	box[7].xyz.x = big_mn->xyz.x; box[7].xyz.y = big_mx->xyz.y; box[7].xyz.z = big_mx->xyz.z;
 }
 
-void maybe_adjust_movement_axis(bsp_info *sm)
+void determine_submodel_movement(bool is_rotation, const char *filename, bsp_info *sm, char *props, SCP_vector<SCP_string> &look_at_submodel_names)
 {
-	// if we have a FOR, we need to transform the movement axis and make it a non-standard one
-	if (!vm_matrix_equal(sm->frame_of_reference, vmd_identity_matrix) && (sm->movement_type != MOVEMENT_TYPE_NONE) && (sm->movement_axis_id != MOVEMENT_AXIS_NONE)) {
-		vec3d new_axis;
-		vm_vec_unrotate(&new_axis, &sm->movement_axis, &sm->frame_of_reference);
-		sm->movement_axis = new_axis;
-		sm->movement_axis_id = MOVEMENT_AXIS_OTHER;
+	const char *axis_string;
+	int *movement_axis_id, *movement_type;
+	vec3d *movement_axis;
+	char *p;
+
+	if (is_rotation)
+	{
+		axis_string = "$rotation_axis";
+		movement_axis_id = &sm->rotation_axis_id;
+		movement_axis = &sm->rotation_axis;
+		movement_type = &sm->rotation_type;
 	}
+	else
+	{
+		UNREACHABLE("Not yet implemented");
+		axis_string = nullptr;
+		movement_axis_id = nullptr;
+		movement_axis = nullptr;
+		movement_type = nullptr;
+	}
+
+	// determine movement axis
+	// (the axis is a vector from 0,0,0 to the point specified)
+	// note: the standard axis point definitions are copied from Volition code originally in model_init_submodel_axis_pt
+	if (*movement_axis_id == MOVEMENT_AXIS_X)
+		*movement_axis = vmd_x_vector;
+	else if (*movement_axis_id == MOVEMENT_AXIS_Y)
+		*movement_axis = vmd_y_vector;
+	else if (*movement_axis_id == MOVEMENT_AXIS_Z)
+		*movement_axis = vmd_z_vector;
+	else if (*movement_axis_id == MOVEMENT_AXIS_OTHER)
+	{
+		if (in(p, props, axis_string))
+		{
+			if (get_user_vec3d_value(p + 20, movement_axis, true, sm->name, filename))
+				vm_vec_normalize(movement_axis);
+			else
+			{
+				Warning(LOCATION, "Failed to parse %s on subsystem '%s' on ship %s!", axis_string, sm->name, filename);
+				*movement_type = MOVEMENT_TYPE_NONE;
+			}
+		}
+		else
+		{
+			Warning(LOCATION, "A %s was not specified for subsystem '%s' on ship %s!", axis_string, sm->name, filename);
+			*movement_type = MOVEMENT_TYPE_NONE;
+		}
+	}
+
+	if (is_rotation)
+	{
+		// note, this should come BEFORE do_new_subsystem() for proper error handling (to avoid both rotating and look-at submodel)
+		if (in(p, props, "$look_at"))
+		{
+			sm->rotation_type = MOVEMENT_TYPE_INTRINSIC;
+
+			// we need to work out the correct subobject number later, after all subobjects have been processed
+			sm->look_at_submodel = static_cast<int>(look_at_submodel_names.size());
+
+			char submodel_name[MAX_NAME_LEN];
+			get_user_prop_value(p + 9, submodel_name);
+			look_at_submodel_names.push_back(submodel_name);
+		}
+		else
+			sm->look_at_submodel = -1; // No look_at
+
+		// optional extra property for look_at
+		if (in(p, props, "$look_at_offset"))
+		{
+			auto offset = (float)atof(p + 16);
+
+			// model property is specified in degrees, so convert it
+			offset = fl_radians(offset);
+
+			// check range (the angle is now in radians)
+			if (offset < -PI2 || offset > PI2)
+			{
+				Warning(LOCATION, "Submodel '%s' of model '%s' has a look_at_offset that is outside the range of -360 to 360!", sm->name, filename);
+				offset = -1.0f;
+			}
+			// make the angle positive, since negative angles will be set at first look_at call
+			else if (offset < 0.0f)
+				offset += PI2;
+
+			sm->look_at_offset = offset;
+		}
+		else
+			sm->look_at_offset = -1.0f;
+	}
+
+	if (is_rotation)
+	{
+		// note, this should come BEFORE do_new_subsystem() for proper error handling (to avoid both rotating and dumb-rotating submodel)
+		int idx = prop_string(props, &p, "$dumb_rotate_time", "$dumb_rotate_rate", "$dumb_rotate");
+		if (idx >= 0)
+		{
+			sm->rotation_type = MOVEMENT_TYPE_INTRINSIC;
+
+			// do this the same way as regular $rotate
+			char buf[64];
+			get_user_prop_value(p, buf);
+
+			// for past SCP compatibility, $dumb_rotate means $dumb_rotate_rate
+			float turn_rate;
+			if (idx == 0)
+			{
+				auto turn_time = static_cast<float>(atof(buf));
+				if (turn_time == 0.0f)
+				{
+					Warning(LOCATION, "Dumb-Rotation has a turn time of 0 for subsystem '%s' on ship %s!", sm->name, filename);
+					turn_rate = 1.0f;
+				}
+				else
+					turn_rate = PI2 / turn_time;
+			}
+			else
+				turn_rate = static_cast<float>(atof(buf));
+
+			sm->default_turn_rate = turn_rate;
+			sm->flags.set(Model::Submodel_flags::Instant_rotate_accel);
+		}
+	}
+}
+
+void maybe_adjust_movement_axis(bool is_rotation, bsp_info *sm)
+{
+	int *movement_axis_id, *movement_type;
+	vec3d *movement_axis;
+
+	if (is_rotation)
+	{
+		movement_axis_id = &sm->rotation_axis_id;
+		movement_axis = &sm->rotation_axis;
+		movement_type = &sm->rotation_type;
+	}
+	else
+	{
+		UNREACHABLE("Not yet implemented");
+		movement_axis_id = nullptr;
+		movement_axis = nullptr;
+		movement_type = nullptr;
+	}
+
+	// if we have a frame of reference, we need to transform the movement axis and make it a non-standard one
+	if (!vm_matrix_equal(sm->frame_of_reference, vmd_identity_matrix) && (*movement_type != MOVEMENT_TYPE_NONE) && (*movement_axis_id != MOVEMENT_AXIS_NONE))
+	{
+		vec3d new_axis;
+		vm_vec_unrotate(&new_axis, movement_axis, &sm->frame_of_reference);
+		*movement_axis = new_axis;
+		*movement_axis_id = MOVEMENT_AXIS_OTHER;
+	}
+}
+
+void do_movement_sanity_checks(bool is_rotation, bsp_info *sm, bsp_info *parent_sm, const char *filename)
+{
+	int *movement_axis_id, *movement_type;
+	vec3d *movement_axis;
+
+	if (is_rotation)
+	{
+		movement_axis_id = &sm->rotation_axis_id;
+		movement_axis = &sm->rotation_axis;
+		movement_type = &sm->rotation_type;
+	}
+	else
+	{
+		UNREACHABLE("Not yet implemented");
+		movement_axis_id = nullptr;
+		movement_axis = nullptr;
+		movement_type = nullptr;
+	}
+
+	// make sure this is a validly normalized axis
+	if (vm_vec_mag(movement_axis) < 0.999f || vm_vec_mag(movement_axis) > 1.001f)
+		*movement_type = MOVEMENT_TYPE_NONE;
+
+	// maybe use the FOR to manipulate the axes
+	// (do this before the compatibility check below to prevent doing it twice)
+	maybe_adjust_movement_axis(is_rotation, sm);
+
+	if (is_rotation)
+	{
+		// important compatibility check: if there are multipart turrets without rotation axes defined, define them
+		// also, some of the retail models got the axes wrong, so fix those :-/
+		// what this boils down to is that we must force turret axes for submodels with frame_of_reference defined
+		//     and also for turrets which don't have their axes set to "other"
+		if (parent_sm && in(parent_sm->name, "turret"))
+		{
+			auto base = parent_sm;
+			auto gun = sm;
+
+			if (!vm_matrix_equal(base->frame_of_reference, vmd_identity_matrix)
+				|| (base->rotation_axis_id != MOVEMENT_AXIS_OTHER))
+			{
+				base->rotation_axis_id = MOVEMENT_AXIS_Y;
+				base->rotation_axis = vmd_y_vector;
+				base->rotation_type = MOVEMENT_TYPE_TURRET;
+				maybe_adjust_movement_axis(true, base);
+			}
+
+			if (!vm_matrix_equal(gun->frame_of_reference, vmd_identity_matrix)
+				|| (gun->rotation_axis_id != MOVEMENT_AXIS_OTHER))
+			{
+				gun->rotation_axis_id = MOVEMENT_AXIS_X;
+				gun->rotation_axis = vmd_x_vector;
+				gun->rotation_type = MOVEMENT_TYPE_TURRET;
+				maybe_adjust_movement_axis(true, gun);
+			}
+		}
+	}
+
+	// add a warning if movement is specified without movement axis.
+	if (*movement_axis_id == MOVEMENT_AXIS_NONE)
+	{
+		auto str = is_rotation ? "rotation" : "translation";
+
+		if (*movement_type == MOVEMENT_TYPE_REGULAR)
+			Warning(LOCATION, "%s without %s axis defined on submodel '%s' of model '%s'!", str, str, sm->name, filename);
+		else if (*movement_type == MOVEMENT_TYPE_INTRINSIC)
+			Warning(LOCATION, "Intrinsic %s (e.g. dumb-rotate or look-at) without %s axis defined on submodel '%s' of model '%s'!", str, str, sm->name, filename);
+
+		*movement_type = MOVEMENT_TYPE_NONE;
+	}
+
+	// clear the axis if the submodel doesn't move
+	// (don't clear can_move because of gun_rotation)
+	if (*movement_type == MOVEMENT_TYPE_NONE)
+	{
+		*movement_axis_id = MOVEMENT_AXIS_NONE;
+		*movement_axis = vmd_zero_vector;
+	}
+
+	// Set the can_move field on submodels which are of a moving type or which have such a parent somewhere down the hierarchy
+	if (*movement_type != MOVEMENT_TYPE_NONE)
+		sm->flags.set(Model::Submodel_flags::Can_move);
+	else if (parent_sm && parent_sm->flags[Model::Submodel_flags::Can_move])
+		sm->flags.set(Model::Submodel_flags::Can_move);
 }
 
 void resolve_submodel_index(const polymodel *pm, const char *requester, const char *field, int &submodel_index, const SCP_vector<SCP_string> &submodel_list)
@@ -1481,108 +1711,21 @@ int read_model_file(polymodel * pm, const char *filename, int n_subsystems, mode
 
 				// ---------- submodel movement ----------
 
-				sm->movement_type = cfread_int(fp);
-				sm->movement_axis_id = cfread_int(fp);
+				sm->rotation_type = cfread_int(fp);
+				sm->rotation_axis_id = cfread_int(fp);
 
-				// change turret movement type to MOVEMENT_TYPE_ROT_SPECIAL
-				if ( stristr(sm->name, "turret") || (parent_sm && (parent_sm->movement_type == MOVEMENT_TYPE_ROT_SPECIAL)) ) {
-					sm->movement_type = MOVEMENT_TYPE_ROT_SPECIAL;
-				} else if (sm->movement_type == MOVEMENT_TYPE_ROT) {
-					if (stristr(sm->name, "thruster")) {
-						sm->movement_type = MOVEMENT_TYPE_NONE;
-					} else if(strstr(props, "$triggered")) {
-						sm->movement_type = MOVEMENT_TYPE_TRIGGERED;
+				// change turret rotation type to MOVEMENT_TYPE_TURRET
+				if ( in(sm->name, "turret") || (parent_sm && (parent_sm->rotation_type == MOVEMENT_TYPE_TURRET)) ) {
+					sm->rotation_type = MOVEMENT_TYPE_TURRET;
+				} else if (sm->rotation_type == MOVEMENT_TYPE_REGULAR) {
+					if (in(sm->name, "thruster")) {
+						sm->rotation_type = MOVEMENT_TYPE_NONE;
+					} else if (in(props, "$triggered")) {
+						sm->rotation_type = MOVEMENT_TYPE_TRIGGERED;
 					}
 				}
 
-				// determine rotation axis
-				// (the axis is a vector from 0,0,0 to the point specified)
-				// note: the standard axis point definitions are copied from Volition code originally in model_init_submodel_axis_pt
-				if (sm->movement_axis_id == MOVEMENT_AXIS_X) {
-					sm->movement_axis = vmd_x_vector;
-				}
-				else if (sm->movement_axis_id == MOVEMENT_AXIS_Y) {
-					sm->movement_axis = vmd_y_vector;
-				}
-				else if (sm->movement_axis_id == MOVEMENT_AXIS_Z) {
-					sm->movement_axis = vmd_z_vector;
-				}
-				else if (sm->movement_axis_id == MOVEMENT_AXIS_OTHER) {
-					if (in(p, props, "$rotation_axis")) {
-						if (get_user_vec3d_value(p + 20, &sm->movement_axis, true, sm->name, pm->filename)) {
-							vm_vec_normalize(&sm->movement_axis);
-						} else {
-							Warning(LOCATION, "Failed to parse $rotation_axis on subsystem '%s' on ship %s!", sm->name, pm->filename);
-							sm->movement_type = MOVEMENT_TYPE_NONE;
-						}
-					} else {
-						Warning(LOCATION, "A $rotation_axis was not specified for subsystem '%s' on ship %s!", sm->name, pm->filename);
-						sm->movement_type = MOVEMENT_TYPE_NONE;
-					}
-				}
-
-				// note, this should come BEFORE do_new_subsystem() for proper error handling (to avoid both rotating and look-at submodel)
-				if (in(p, props, "$look_at")) {
-					sm->movement_type = MOVEMENT_TYPE_INTRINSIC;
-
-					// we need to work out the correct subobject number later, after all subobjects have been processed
-					sm->look_at_submodel = static_cast<int>(look_at_submodel_names.size());
-
-					char submodel_name[MAX_NAME_LEN];
-					get_user_prop_value(p + 9, submodel_name);
-					look_at_submodel_names.push_back(submodel_name);
-				} else {
-					sm->look_at_submodel = -1; // No look_at
-				}
-
-				// optional extra property for look_at
-				if (in(p, props, "$look_at_offset")) {
-					auto offset = (float)atof(p + 16);
-
-					// model property is specified in degrees, so convert it
-					offset = fl_radians(offset);
-
-					// check range (the angle is now in radians)
-					if (offset < -PI2 || offset > PI2) {
-						Warning(LOCATION, "Submodel '%s' of model '%s' has a look_at_offset that is outside the range of -360 to 360!", sm->name, pm->filename);
-						offset = -1.0f;
-					}
-					// make the angle positive, since negative angles will be set at first look_at call
-					else if (offset < 0.0f) {
-						offset += PI2;
-					}
-
-					sm->look_at_offset = offset;
-				} else {
-					sm->look_at_offset = -1.0f;
-				}
-
-				// note, this should come BEFORE do_new_subsystem() for proper error handling (to avoid both rotating and dumb-rotating submodel)
-				int idx = prop_string(props, &p, "$dumb_rotate_time", "$dumb_rotate_rate", "$dumb_rotate");
-				if (idx >= 0) {
-					sm->movement_type = MOVEMENT_TYPE_INTRINSIC;
-
-					// do this the same way as regular $rotate
-					char buf[64];
-					get_user_prop_value(p, buf);
-
-					// for past SCP compatibility, $dumb_rotate means $dumb_rotate_rate
-					float turn_rate;
-					if (idx == 0) {
-						float turn_time = static_cast<float>(atof(buf));
-						if (turn_time == 0.0f) {
-							Warning(LOCATION, "Dumb-Rotation has a turn time of 0 for subsystem '%s' on ship %s!", sm->name, pm->filename);
-							turn_rate = 1.0f;
-						} else {
-							turn_rate = PI2 / turn_time;
-						}
-					} else {
-						turn_rate = static_cast<float>(atof(buf));
-					}
-
-					sm->default_turn_rate = turn_rate;
-					sm->flags.set(Model::Submodel_flags::Instant_rotate_accel);
-				}
+				determine_submodel_movement(true, pm->filename, sm, props, look_at_submodel_names);
 
 				if ( sm->name[0] == '\0' ) {
 					strcpy_s(sm->name, "unknown object name");
@@ -1596,10 +1739,10 @@ int read_model_file(polymodel * pm, const char *filename, int n_subsystems, mode
 						do_new_subsystem( n_subsystems, subsystems, n, sm->rad, &sm->offset, props, sm->name, pm->id );
 					} else if ( !stricmp(type, "no_rotate") ) {
 						// mark those submodels which should not rotate - ie, those with no subsystem
-						sm->movement_type = MOVEMENT_TYPE_NONE;
+						sm->rotation_type = MOVEMENT_TYPE_NONE;
 					} else {
 						// if submodel rotates (via bspgen), then there is either a subsys or special=no_rotate
-						Assert( sm->movement_type != MOVEMENT_TYPE_ROT );
+						Assert( sm->rotation_type != MOVEMENT_TYPE_REGULAR );
 					}
 				}
 
@@ -1743,72 +1886,11 @@ int read_model_file(polymodel * pm, const char *filename, int n_subsystems, mode
 					sm->frame_of_reference = parent_sm ? parent_sm->frame_of_reference : vmd_identity_matrix;
 				}
 
-				// ---------- submodel rotation sanity checks ----------
+				// ---------- submodel movement sanity checks ----------
 
-				// make sure this is a validly normalized axis
-				if (vm_vec_mag(&sm->movement_axis) < 0.999f || vm_vec_mag(&sm->movement_axis) > 1.001f) {
-					sm->movement_type = MOVEMENT_TYPE_NONE;
-				}
+				do_movement_sanity_checks(true, sm, parent_sm, pm->filename);
 
-				// maybe use the FOR to manipulate the rotation axis
-				// (do this before the compatibility check below to prevent doing it twice)
-				maybe_adjust_movement_axis(sm);
-
-				// important compatibility check: if there are multipart turrets without rotation axes defined, define them
-				// also, some of the retail models got the axes wrong, so fix those :-/
-				// what this boils down to is that we must force turret axes for submodels with frame_of_reference defined
-				//		and also for turrets which don't have their axes set to "other"
-				if (parent_sm && stristr(parent_sm->name, "turret"))
-				{
-					auto base = parent_sm;
-					auto gun = sm;
-
-					if (!vm_matrix_equal(base->frame_of_reference, vmd_identity_matrix)
-						|| (base->movement_axis_id != MOVEMENT_AXIS_OTHER))
-					{
-						base->movement_axis_id = MOVEMENT_AXIS_Y;
-						base->movement_axis = vmd_y_vector;
-						base->movement_type = MOVEMENT_TYPE_ROT_SPECIAL;
-						maybe_adjust_movement_axis(base);
-					}
-
-					if (!vm_matrix_equal(gun->frame_of_reference, vmd_identity_matrix)
-						|| (gun->movement_axis_id != MOVEMENT_AXIS_OTHER))
-					{
-						gun->movement_axis_id = MOVEMENT_AXIS_X;
-						gun->movement_axis = vmd_x_vector;
-						gun->movement_type = MOVEMENT_TYPE_ROT_SPECIAL;
-						maybe_adjust_movement_axis(gun);
-					}
-				}
-
-				// adding a warning if rotation is specified without movement axis.
-				if (sm->movement_axis_id == MOVEMENT_AXIS_NONE) {
-					if (sm->movement_type == MOVEMENT_TYPE_ROT) {
-						Warning(LOCATION, "Rotation without rotation axis defined on submodel '%s' of model '%s'!", sm->name, pm->filename);
-					}
-					else if (sm->movement_type == MOVEMENT_TYPE_INTRINSIC) {
-						Warning(LOCATION, "Intrinsic motion (e.g. dumb-rotate or look-at) without rotation axis defined on submodel '%s' of model '%s'!", sm->name, pm->filename);
-					}
-					sm->movement_type = MOVEMENT_TYPE_NONE;
-				}
-
-				// clear the axis if the submodel doesn't move
-				// (don't clear can_move because of gun_rotation)
-				if (sm->movement_type == MOVEMENT_TYPE_NONE) {
-					sm->movement_axis_id = MOVEMENT_AXIS_NONE;
-					sm->movement_axis = vmd_zero_vector;
-				}
-
-				// Set the can_move field on submodels which are of a rotating type or which have such a parent somewhere down the hierarchy
-				if (sm->movement_type != MOVEMENT_TYPE_NONE) {
-					sm->flags.set(Model::Submodel_flags::Can_move);
-				} else if (parent_sm && parent_sm->flags[Model::Submodel_flags::Can_move]) {
-					sm->flags.set(Model::Submodel_flags::Can_move);
-				}
-
-				// ---------- done submodel rotation sanity checks ----------
-
+				// ---------- done submodel movement sanity checks ----------
 
 				{
 					int nchunks = cfread_int( fp );		// Throw away nchunks
@@ -2633,13 +2715,13 @@ int read_model_file(polymodel * pm, const char *filename, int n_subsystems, mode
 
 			// if we couldn't find it, we shouldn't move
 			if (sm->look_at_submodel < 0) {
-				sm->movement_type = MOVEMENT_TYPE_NONE;
+				sm->rotation_type = MOVEMENT_TYPE_NONE;
 			}
 			// are we navel-gazing?
 			else if (sm->look_at_submodel == i) {
 				Warning(LOCATION, "Matched %s %s $look_at: target with its own submodel!  Submodel cannot look at itself!\n", pm->filename, sm->name);
 				sm->look_at_submodel = -1;
-				sm->movement_type = MOVEMENT_TYPE_NONE;
+				sm->rotation_type = MOVEMENT_TYPE_NONE;
 			}
 		}
 	}
@@ -2655,7 +2737,7 @@ int read_model_file(polymodel * pm, const char *filename, int n_subsystems, mode
 
 	// And now look through all the submodels and set the model flag if any are intrinsic-moving
 	for (i = 0; i < pm->n_models; i++) {
-		if (pm->submodel[i].movement_type == MOVEMENT_TYPE_INTRINSIC) {
+		if (pm->submodel[i].rotation_type == MOVEMENT_TYPE_INTRINSIC) {
 			pm->flags |= PM_FLAG_HAS_INTRINSIC_MOTION;
 			break;
 		}
@@ -3168,7 +3250,7 @@ int model_create_instance(int objnum, int model_num)
 		intrinsic_motion motion(objnum >= 0, open_slot);
 
 		for (int i = 0; i < pm->n_models; i++) {
-			if (pm->submodel[i].movement_type == MOVEMENT_TYPE_INTRINSIC) {
+			if (pm->submodel[i].rotation_type == MOVEMENT_TYPE_INTRINSIC) {
 				// note: dumb_turn_rate will be 0.0f for look_at
 				motion.add_submodel(i, &pmi->submodel[i], pm->submodel[i].default_turn_rate);
 			}
@@ -3626,9 +3708,9 @@ void model_get_rotating_submodel_axis(vec3d *model_axis, vec3d *world_axis, cons
 {
 	Assert(pm->id == pmi->model_num);
 	bsp_info *sm = &pm->submodel[submodel_num];
-	Assert(sm->movement_type == MOVEMENT_TYPE_ROT || sm->movement_type == MOVEMENT_TYPE_INTRINSIC);
+	Assert(sm->rotation_type == MOVEMENT_TYPE_REGULAR || sm->rotation_type == MOVEMENT_TYPE_INTRINSIC);
 
-	*model_axis = sm->movement_axis;
+	*model_axis = sm->rotation_axis;
 	model_instance_find_world_dir(world_axis, model_axis, pm, pmi, submodel_num, objorient);
 }
 
@@ -3647,7 +3729,7 @@ void submodel_canonicalize(bsp_info *sm, submodel_instance *smi, bool clamp)
 	}
 
 	// get the matrix and the angles
-	switch (sm->movement_axis_id)
+	switch (sm->rotation_axis_id)
 	{
 		case MOVEMENT_AXIS_X:
 		{
@@ -3674,7 +3756,7 @@ void submodel_canonicalize(bsp_info *sm, submodel_instance *smi, bool clamp)
 		}
 
 		default:
-			vm_quaternion_rotate(&smi->canonical_orient, smi->cur_angle, &sm->movement_axis);
+			vm_quaternion_rotate(&smi->canonical_orient, smi->cur_angle, &sm->rotation_axis);
 			break;
 	}
 }
@@ -3689,18 +3771,18 @@ void submodel_stepped_rotate(model_subsystem *psub, submodel_instance *smi)
 	polymodel *pm = model_get(psub->model_num);
 	bsp_info *sm = &pm->submodel[psub->subobj_num];
 
-	if ( sm->movement_type != MOVEMENT_TYPE_ROT ) return;
+	if ( sm->rotation_type != MOVEMENT_TYPE_REGULAR ) return;
 
 	// get active rotation time this frame
 	int end_stamp = timestamp();
 	// just to make sure this issue wont pop up again... might cause odd jerking in some extremely odd situations
 	// but given that those issues would require the timer to be reseted in any case it probably wont hurt
 	float rotation_time;
-	if ((end_stamp - smi->step_zero_timestamp) < 0) {
-		smi->step_zero_timestamp = end_stamp;
+	if ((end_stamp - smi->turn_step_zero_timestamp) < 0) {
+		smi->turn_step_zero_timestamp = end_stamp;
 		rotation_time = 0.0f;
 	} else {
-		rotation_time = 0.001f * (end_stamp - smi->step_zero_timestamp);
+		rotation_time = 0.001f * (end_stamp - smi->turn_step_zero_timestamp);
 	}
 	//Assert(rotation_time >= 0);
 
@@ -3724,7 +3806,7 @@ void submodel_stepped_rotate(model_subsystem *psub, submodel_instance *smi)
 
 	if (cur_step >= psub->stepped_rotation->num_steps) {
 		// I don;t know why, but removing this line makes it all good.
-		// sii->step_zero_timestamp += int(1000.0f * (psub->stepped_rotation->num_steps * step_time) + 0.5f);
+		// sii->turn_step_zero_timestamp += int(1000.0f * (psub->stepped_rotation->num_steps * step_time) + 0.5f);
 
 		// reset cur_step (use mod to handle physics/ai pause)
 		cur_step = cur_step % psub->stepped_rotation->num_steps;
@@ -3773,7 +3855,7 @@ void submodel_look_at(polymodel *pm, polymodel_instance *pmi, int submodel_num)
 	auto sm = &pm->submodel[submodel_num];
 	auto smi = &pmi->submodel[submodel_num];
 
-	Assert(sm->movement_type == MOVEMENT_TYPE_INTRINSIC);
+	Assert(sm->rotation_type == MOVEMENT_TYPE_INTRINSIC);
 	Assert(sm->look_at_submodel >= 0);
 
 	// save last angles
@@ -3786,7 +3868,7 @@ void submodel_look_at(polymodel *pm, polymodel_instance *pmi, int submodel_num)
 
 	//------------
 	// Project the destination point onto the submodel base plane
-	model_instance_find_world_dir(&world_axis, &sm->movement_axis, pm, pmi, sm->parent, &vmd_identity_matrix);
+	model_instance_find_world_dir(&world_axis, &sm->rotation_axis, pm, pmi, sm->parent, &vmd_identity_matrix);
 	model_instance_find_world_point(&world_pos, &vmd_zero_vector, pm, pmi, submodel_num, &vmd_identity_matrix, &vmd_zero_vector);
 
 	vm_project_point_onto_plane(&planar_dst, &dst, &world_axis, &world_pos);
@@ -3831,7 +3913,7 @@ void submodel_rotate(model_subsystem *psub, submodel_instance *smi)
 	polymodel *pm = model_get(psub->model_num);
 	sm = &pm->submodel[psub->subobj_num];
 
-	if ( sm->movement_type != MOVEMENT_TYPE_ROT ) return;
+	if ( sm->rotation_type != MOVEMENT_TYPE_REGULAR ) return;
 
 	submodel_rotate(sm, smi);
 }
@@ -3914,7 +3996,7 @@ int model_rotate_gun(object *objp, polymodel *pm, polymodel_instance *pmi, ship_
 
 		//------------
 		// Project the destination point onto the turret base plane
-		model_instance_find_world_dir(&world_axis, &base_sm->movement_axis, pm, pmi, base_sm->parent, &objp->orient);
+		model_instance_find_world_dir(&world_axis, &base_sm->rotation_axis, pm, pmi, base_sm->parent, &objp->orient);
 		model_instance_find_world_point(&world_pos, &vmd_zero_vector, pm, pmi, turret->subobj_num, &objp->orient, &objp->pos);
 
 		vm_project_point_onto_plane(&planar_dst, dst, &world_axis, &world_pos);
@@ -3929,12 +4011,12 @@ int model_rotate_gun(object *objp, polymodel *pm, polymodel_instance *pmi, ship_
 		//------------
 		// Pretend the base is pointing directly at the target
 		save_base_orient = base_smi->canonical_orient;
-		vm_quaternion_rotate(&base_smi->canonical_orient, desired_base_angle, &base_sm->movement_axis);
+		vm_quaternion_rotate(&base_smi->canonical_orient, desired_base_angle, &base_sm->rotation_axis);
 
 		//------------
 		// Project the destination point onto the turret gun plane with the base in the desired orientation
 		// NOTE: the rotation axis is given in the model's reference frame, so it needs to be rotated when the base is rotated
-		model_instance_find_world_dir(&world_axis, &gun_sm->movement_axis, pm, pmi, gun_sm->parent, &objp->orient);
+		model_instance_find_world_dir(&world_axis, &gun_sm->rotation_axis, pm, pmi, gun_sm->parent, &objp->orient);
 		model_instance_find_world_point(&world_pos, &vmd_zero_vector, pm, pmi, turret->turret_gun_sobj, &objp->orient, &objp->pos);
 
 		vm_project_point_onto_plane(&planar_dst, dst, &world_axis, &world_pos);
@@ -4292,9 +4374,9 @@ int rotating_submodel_has_ship_subsys(int submodel, ship *shipp)
  * Get all submodel indexes that satisfy the following:
  * 1) Have the rotating or intrinsic-rotating movement type
  * 2) Are currently rotating (i.e. actually moving and not part of the superstructure due to being destroyed or replaced)
- * 3) Are not rotating too far for collision detection (c.f. MAX_SUBMODEL_COLLISION_ROT_ANGLE)
+ * 3) Are not rotating too far for collision detection (c.f. MAX_SUBMODEL_COLLISION_ANGLE)
  */
-void model_get_rotating_submodel_list(SCP_vector<int> *submodel_vector, object *objp)
+void model_get_moving_submodel_list(SCP_vector<int> &submodel_vector, const object *objp)
 {
 	Assert(objp->type == OBJ_SHIP || objp->type == OBJ_WEAPON || objp->type == OBJ_ASTEROID);
 	
@@ -4341,24 +4423,24 @@ void model_get_rotating_submodel_list(SCP_vector<int> *submodel_vector, object *
 		if ( !child_submodel_instance->blown_off && (child_submodel->i_replace == -1) && !child_submodel->flags[Model::Submodel_flags::No_collisions, Model::Submodel_flags::Nocollide_this_only])	{
 
 			// Look for submodels that rotate or intrinsic-rotate
-			if (child_submodel->movement_type == MOVEMENT_TYPE_ROT || child_submodel->movement_type == MOVEMENT_TYPE_INTRINSIC) {
+			if (child_submodel->rotation_type == MOVEMENT_TYPE_REGULAR || child_submodel->rotation_type == MOVEMENT_TYPE_INTRINSIC) {
 
 				// check submodel rotation is less than max allowed.
 				float delta_angle = get_submodel_delta_angle(child_submodel_instance);
-				if (delta_angle < MAX_SUBMODEL_COLLISION_ROT_ANGLE) {
-					submodel_vector->push_back(i);
+				if (delta_angle < MAX_SUBMODEL_COLLISION_ANGLE) {
+					submodel_vector.push_back(i);
 				}
 			}
 			// Also look for submodels that aren't subsystems but still move
 			else if (child_submodel->subsys_num < 0 && child_submodel->flags[Model::Submodel_flags::Can_move]) {
-				submodel_vector->push_back(i);
+				submodel_vector.push_back(i);
 			}
 		}
 		i = child_submodel->next_sibling;
 	}
 }
 
-void model_get_submodel_tree_list(SCP_vector<int> &submodel_vector, polymodel* pm, int mn)
+void model_get_submodel_tree_list(SCP_vector<int> &submodel_vector, const polymodel *pm, int mn)
 {
 	if ( pm->submodel[mn].buffer.model_list != NULL ) {
 		submodel_vector.push_back(mn);
@@ -4550,7 +4632,7 @@ void model_do_intrinsic_motions_sub(intrinsic_motion *im)
 
 // Handle the intrinsic motions for either a) a single object model; or b) all non-object models.
 //
-// This function called as part of object movement.  All types of object movement, including intrinsic motions,
+// This function called as part of object movement.  All types of object movement, including intrinsic rotations and translations,
 // should be handled at the same time - unless you want inconsistent collisions or damage sparks that aren't attached to models.
 //
 // -- Goober5000
@@ -4567,7 +4649,7 @@ void model_do_intrinsic_motions(object *objp)
 			{
 				Assertion(obj_it->second.is_object, "Inconsistent intrinsic motion: an object's motion is not flagged as belonging to an object!");
 
-				// update the angles in the submodels
+				// update the submodels
 				model_do_intrinsic_motions_sub(&obj_it->second);
 			}
 		}
@@ -4579,7 +4661,7 @@ void model_do_intrinsic_motions(object *objp)
 		{
 			if (!pair.second.is_object)
 			{
-				// update the angles in the submodels
+				// update the submodels
 				model_do_intrinsic_motions_sub(&pair.second);
 			}
 		}
@@ -4593,16 +4675,16 @@ void model_init_submodel_axis_pt(polymodel *pm, polymodel_instance *pmi, int sub
 	vec3d p1, v1, p2, v2, int1;
 	Assert(pm->id == pmi->model_num);
 
-	Assert(pm->submodel[submodel_num].movement_type == MOVEMENT_TYPE_ROT || pm->submodel[submodel_num].movement_type == MOVEMENT_TYPE_INTRINSIC);
+	Assert(pm->submodel[submodel_num].rotation_type == MOVEMENT_TYPE_REGULAR || pm->submodel[submodel_num].rotation_type == MOVEMENT_TYPE_INTRINSIC);
 	submodel_instance *smi = &pmi->submodel[submodel_num];
 	
-	auto axis = &pm->submodel[submodel_num].movement_axis;
+	auto axis = &pm->submodel[submodel_num].rotation_axis;
 
 	// find 2 fixed points in submodel RF
 	// these will be rotated to about the axis an angle of 0 and PI and we'll find the intersection of the
 	// two lines to find a point on the axis
 
-	// since the movement axis is now arbitrary, we can't simply pick points on the other two axes;
+	// since the rotation axis is now arbitrary, we can't simply pick points on the other two axes;
 	// we need to generate some suitably orthogonal points
 
 	// first find the standard vector that's the most orthongonal-ish

--- a/code/model/modelread.cpp
+++ b/code/model/modelread.cpp
@@ -1138,7 +1138,7 @@ void model_calc_bound_box( vec3d *box, vec3d *big_mn, vec3d *big_mx)
 	box[7].xyz.x = big_mn->xyz.x; box[7].xyz.y = big_mx->xyz.y; box[7].xyz.z = big_mx->xyz.z;
 }
 
-void extract_movement_info(const bsp_info *sm, bool is_rotation, int *&movement_axis_id, vec3d *&movement_axis, int *&movement_type)
+void extract_movement_info(bsp_info *sm, bool is_rotation, int *&movement_axis_id, vec3d *&movement_axis, int *&movement_type)
 {
 	if (is_rotation)
 	{

--- a/code/object/collideshipship.cpp
+++ b/code/object/collideshipship.cpp
@@ -189,11 +189,11 @@ int ship_ship_check_collision(collision_info_struct *ship_ship_hit_info)
 	// find the light object's position in the heavy object's reference frame at last frame and also in this frame.
 	vec3d p0_temp, p0_rotated;
 	
-	// Collision detection from rotation enabled if at max rotaional velocity and 5fps, rotation is less than PI/2
+	// Collision detection from rotation enabled if at max rotational velocity and 5fps, rotation is less than PI/2
 	// This should account for all ships
 	if ( (vm_vec_mag_squared( &heavy_obj->phys_info.max_rotvel ) * .04) < (PI*PI/4) ) {
 		// collide_rotate calculate (1) start position and (2) relative velocity
-		ship_ship_hit_info->collide_rotate = 1;
+		ship_ship_hit_info->collide_rotate = true;
 		vm_vec_rotate(&p0_temp, &p0, &heavy_obj->last_orient);
 		vm_vec_unrotate(&p0_rotated, &p0_temp, &heavy_obj->orient);
 		mc.p0 = &p0_rotated;				// Point 1 of ray to check
@@ -209,7 +209,7 @@ int ship_ship_check_collision(collision_info_struct *ship_ship_hit_info)
 			Warned_about_fast_rotational_collisions = true;
 		}
 #endif
-		ship_ship_hit_info->collide_rotate = 0;
+		ship_ship_hit_info->collide_rotate = false;
 		mc.p0 = &p0;							// Point 1 of ray to check
 		vm_vec_sub(&ship_ship_hit_info->light_rel_vel, &light_obj->phys_info.vel, &heavy_obj->phys_info.vel);
 	}
@@ -255,12 +255,12 @@ int ship_ship_check_collision(collision_info_struct *ship_ship_hit_info)
 
 		// Do collision the cool new way
 		if ( ship_ship_hit_info->collide_rotate ) {
-			// We collide with the sphere, find the list of rotating submodels and test one at a time
+			// We collide with the sphere, find the list of moving submodels and test one at a time
 			SCP_vector<int> submodel_vector;
-			model_get_rotating_submodel_list(&submodel_vector, heavy_obj);
+			model_get_moving_submodel_list(submodel_vector, heavy_obj);
 
-			// turn off all rotating submodels, collide against only 1 at a time.
-			// turn off collision detection for all rotating submodels
+			// turn off all moving submodels, collide against only 1 at a time.
+			// turn off collision detection for all moving submodels
 			for (auto submodel : submodel_vector) {
 				pmi->submodel[submodel].collision_checked = true;
 			}
@@ -306,11 +306,11 @@ int ship_ship_check_collision(collision_info_struct *ship_ship_hit_info)
 						valid_hit_occured = 1;
 
 						// set up ship_ship_hit_info common
-						set_hit_struct_info(ship_ship_hit_info, &mc, SUBMODEL_ROT_HIT);
+						set_hit_struct_info(ship_ship_hit_info, &mc, true);
 						model_instance_find_world_point(&ship_ship_hit_info->hit_pos, &mc.hit_point, pm, pmi, mc.hit_submodel, &heavy_obj->orient, &zero);
 
 						// set up ship_ship_hit_info for rotating submodel
-						if (ship_ship_hit_info->edge_hit == 0) {
+						if (!ship_ship_hit_info->edge_hit) {
 							model_instance_find_world_dir(&ship_ship_hit_info->collision_normal, &mc.hit_normal, pm, pmi, mc.hit_submodel, &heavy_obj->orient);
 						}
 
@@ -337,10 +337,10 @@ int ship_ship_check_collision(collision_info_struct *ship_ship_hit_info)
 			if (mc.hit_dist < ship_ship_hit_info->hit_time) {
 				valid_hit_occured = 1;
 
-				set_hit_struct_info(ship_ship_hit_info, &mc, SUBMODEL_NO_ROT_HIT);
+				set_hit_struct_info(ship_ship_hit_info, &mc, false);
 
 				// get collision normal if not edge hit
-				if (ship_ship_hit_info->edge_hit == 0) {
+				if (!ship_ship_hit_info->edge_hit) {
 					model_instance_find_world_dir(&ship_ship_hit_info->collision_normal, &mc.hit_normal, pm, pmi, mc.hit_submodel, &heavy_obj->orient);
 				}
 
@@ -550,7 +550,7 @@ void calculate_ship_ship_collision_physics(collision_info_struct *ship_ship_hit_
 	// if collision from rotating submodel of heavy obj, add in vel from rotvel of submodel
 	vec3d local_vel_from_submodel;
 
-	if (ship_ship_hit_info->submodel_rot_hit == 1) {
+	if (ship_ship_hit_info->submodel_move_hit) {
 		polymodel *pm;
 		polymodel_instance *pmi = NULL;
 		int model_instance_num = -1;
@@ -582,7 +582,7 @@ void calculate_ship_ship_collision_physics(collision_info_struct *ship_ship_hit_
 			vec3d omega, r_rot;
 
 			// get world rotational velocity of rotating submodel
-			model_instance_find_world_dir(&omega, &pm->submodel[ship_ship_hit_info->submodel_num].movement_axis, pm, pmi, ship_ship_hit_info->submodel_num, &heavy->orient);
+			model_instance_find_world_dir(&omega, &pm->submodel[ship_ship_hit_info->submodel_num].rotation_axis, pm, pmi, ship_ship_hit_info->submodel_num, &heavy->orient);
 
 			vm_vec_scale(&omega, smi->current_turn_rate);
 

--- a/code/object/objcollide.cpp
+++ b/code/object/objcollide.cpp
@@ -541,14 +541,14 @@ int collide_remove_weapons( )
 
 }
 
-void set_hit_struct_info(collision_info_struct *hit, mc_info *mc, int submodel_rot_hit)
+void set_hit_struct_info(collision_info_struct *hit, mc_info *mc, bool submodel_move_hit)
 {
 	hit->edge_hit = mc->edge_hit;
 	hit->hit_pos = mc->hit_point_world;
 	hit->hit_time = mc->hit_dist;
 	hit->submodel_num = mc->hit_submodel;
 
-	hit->submodel_rot_hit = submodel_rot_hit;
+	hit->submodel_move_hit = submodel_move_hit;
 }
 
 //Previously, this was done with 

--- a/code/object/objcollide.h
+++ b/code/object/objcollide.h
@@ -30,10 +30,10 @@ struct collision_info_struct {
 	float		hit_time;				// time normalized [0,1] when sphere hits model
 	float		impulse;					// damage scales according to impulse
 	vec3d	light_rel_vel;			// velocity of light relative to heavy before collison
-	int		collide_rotate;		// if collision is detected purely from rotation
+	bool	collide_rotate;		// if collision is being detected purely from rotation (or submodel movement)
 	int		submodel_num;			// submodel of heavy object that is hit
-	int		edge_hit;				// if edge is hit, need to change collision normal
-	int		submodel_rot_hit;		// if collision is against rotating submodel
+	bool	edge_hit;				// if edge is hit, need to change collision normal
+	bool	submodel_move_hit;		// if collision is against a moving submodel
 	bool	is_landing;			//SUSHI: Maybe treat current collision as a landing
 };
 
@@ -61,9 +61,7 @@ extern SCP_vector<int> Collision_sort_list;
 
 #define COLLISION_OF(a,b) (((a)<<8)|(b))
 
-#define SUBMODEL_NO_ROT_HIT	0
-#define SUBMODEL_ROT_HIT		1
-void set_hit_struct_info(collision_info_struct *hit, mc_info *mc, int submodel_rot_hit);
+void set_hit_struct_info(collision_info_struct *hit, mc_info *mc, bool submodel_move_hit);
 
 void obj_add_collider(int obj_index);
 void obj_remove_collider(int obj_index);

--- a/code/object/object.cpp
+++ b/code/object/object.cpp
@@ -1548,7 +1548,7 @@ void obj_move_all(float frametime)
 		}
 	}
 
-	// Now apply intrinsic movement to things that aren't objects (like skyboxes).  This technically doesn't belong in the object code,
+	// Now apply intrinsic motion to things that aren't objects (like skyboxes).  This technically doesn't belong in the object code,
 	// but there isn't really a good place to put this, it doesn't hurt to have this here, and it's conceptually related to what's here.
 	model_do_intrinsic_motions(nullptr);
 

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -6743,7 +6743,7 @@ void ship_recalc_subsys_strength( ship *shipp )
                     ship_system->subsys_snd_flags.set(Ship::Subsys_Sound_Flags::Turret_rotation);
                 }
             }
-            if ((ship_system->flags[Subsystem_Flags::Rotates]) && (ship_system->system_info->rotation_snd.isValid()) && !(ship_system->subsys_snd_flags[Ship::Subsys_Sound_Flags::Rotate]))
+            if ((ship_system->flags[Ship::Subsystem_Flags::Rotates]) && (ship_system->system_info->rotation_snd.isValid()) && !(ship_system->subsys_snd_flags[Ship::Subsys_Sound_Flags::Rotate]))
             {
                 obj_snd_assign(shipp->objnum, ship_system->system_info->rotation_snd, &ship_system->system_info->pnt, OS_SUBSYS_ROTATION, ship_system);
                 ship_system->subsys_snd_flags.set(Ship::Subsys_Sound_Flags::Rotate);
@@ -17530,15 +17530,15 @@ void object_jettison_cargo(object *objp, object *cargo_objp, float jettison_spee
 	if (jettison_new)
 	{
 		// new method uses dockpoint normals and user-specified force
-		extern void find_adjusted_dockpoint_info(vec3d * global_dock_point, matrix * dock_orient, object * objp, polymodel * pm, int submodel, int dock_index);
-		extern int find_parent_rotating_submodel(polymodel *pm, int dock_index);
+		extern void find_adjusted_dockpoint_info(vec3d *global_dock_point, matrix *dock_orient, object *objp, polymodel *pm, int submodel, int dock_index);
+		extern int find_parent_moving_submodel(polymodel *pm, int dock_index);
 
 		int model_num = Ship_info[shipp->ship_info_index].model_num;
 		polymodel *pm = model_get(model_num);
-		int docker_rotating_submodel = find_parent_rotating_submodel(pm, docker_index);
+		int docker_moving_submodel = find_parent_moving_submodel(pm, docker_index);
 		matrix dock_orient;
 
-		find_adjusted_dockpoint_info(&pos, &dock_orient, objp, pm, docker_rotating_submodel, docker_index);
+		find_adjusted_dockpoint_info(&pos, &dock_orient, objp, pm, docker_moving_submodel, docker_index);
 
 		// set for relative separation speed (see also do_dying_undock_physics)
 		vm_vec_copy_scale(&impulse, &dock_orient.vec.fvec, jettison_speed * cargo_objp->phys_info.mass);

--- a/code/ship/shipfx.cpp
+++ b/code/ship/shipfx.cpp
@@ -109,7 +109,7 @@ static void shipfx_subsystem_maybe_create_live_debris(object *ship_objp, ship *s
 	vec3d model_axis, world_axis, rotvel, world_axis_pt;
 	matrix m_rot;	// rotation for debris orient about axis
 
-	if (pm->submodel[submodel_num].movement_type == MOVEMENT_TYPE_ROT || pm->submodel[submodel_num].movement_type == MOVEMENT_TYPE_INTRINSIC) {
+	if (pm->submodel[submodel_num].rotation_type == MOVEMENT_TYPE_REGULAR || pm->submodel[submodel_num].rotation_type == MOVEMENT_TYPE_INTRINSIC) {
 		if ( !smi->axis_set ) {
 			model_init_submodel_axis_pt(pm, pmi, submodel_num);
 		}


### PR DESCRIPTION
Mostly renaming of fields and functions, and moving some modelread sections into functions.  This reorganization will put the code on a better footing for the model translation feature.  No model translation code is included yet, and there should be no change in functionality.