### PR TITLE
Fix Animation edge case for turret lookup with template and display name

### DIFF
--- a/code/model/modelanimation.cpp
+++ b/code/model/modelanimation.cpp
@@ -391,10 +391,9 @@ namespace animation {
 		//Do we know if we were told to find the barrel submodel or not? This implies we have a subsystem name, not a submodel name
 		else {
 
-			int sip_index = ship_info_lookup(m_SIPname.c_str());
-			if (sip_index < 0)
+			if (pmi->objnum < 0)
 				return { nullptr, nullptr };
-			ship_info* sip = &Ship_info[sip_index];
+			ship_info* sip = &Ship_info[Ships[Objects[pmi->objnum].instance].ship_info_index];
 
 			for (int i = 0; i < sip->n_subsystems; i++) {
 				if (!subsystem_stricmp(sip->subsystems[i].subobj_name, m_name.c_str())) {
@@ -463,10 +462,14 @@ namespace animation {
 
 		for (const auto& animationTypes : m_animationSet) {
 			for (const auto& animations : animationTypes.second) {
-				for(const auto& animation : animations.second)
+				for (const auto& animation : animations.second) {
+					animation->m_animation->exchangeSubmodelPointers(*this);
 					animation->m_set = this;
+				}
 			}
 		}
+
+
 
 		return *this;
 	}

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -2103,12 +2103,14 @@ static void parse_ship(const char *filename, bool replace)
 		}
 	}
 
-	if (new_name && !sip->flags[Ship::Info_Flags::Has_display_name]) {
-		// if this name has a hash, create a default display name
-		if (get_pointer_to_first_hash_symbol(sip->name)) {
-			strcpy_s(sip->display_name, sip->name);
-			end_string_at_first_hash_symbol(sip->display_name);
-			sip->flags.set(Ship::Info_Flags::Has_display_name);
+	if (new_name) {
+		if (!sip->flags[Ship::Info_Flags::Has_display_name]) {
+			// if this name has a hash, create a default display name
+			if (get_pointer_to_first_hash_symbol(sip->name)) {
+				strcpy_s(sip->display_name, sip->name);
+				end_string_at_first_hash_symbol(sip->display_name);
+				sip->flags.set(Ship::Info_Flags::Has_display_name);
+			}
 		}
 
 		sip->animations.changeShipName(sip->name);


### PR DESCRIPTION
When a ship is initialized from a template _and_ has a display name, previously the ship class name was not properly copied to the animation system for multi-hashing, turret lookup, and so far.
This remedies this _and_ adds robustness and performance by using the new pmi objnum to find the shipclass for turret lookup instead of a string search