### PR TITLE
Fix Damage Gauge Display

### DIFF
--- a/code/hud/hud.cpp
+++ b/code/hud/hud.cpp
@@ -2056,7 +2056,14 @@ void HudGaugeDamage::render(float  /*frametime*/)
 		psub = pss->system_info;
 		strength = ship_get_subsystem_strength(Player_ship, psub->type);
 		if ( strength < 1 ) {
-			screen_integrity = fl2i(strength*100);
+			// display the actual health of this specific subsystem --wookieejedi
+			if (pss->max_hits > 0) {
+				// get percentage if this subsystem has hitpoints to begin with
+				screen_integrity = fl2i((pss->current_hits / pss->max_hits) * 100);
+			} else {
+				// subsystems with no starting hitpoints can never be damaged, so they are always full health
+				screen_integrity = 1;
+			}
 			if ( screen_integrity == 0 ) {
 				if ( strength > 0 ) {
 					screen_integrity = 1;


### PR DESCRIPTION
Previously, the damage display gauge only showed the integrity for subsystem types. This was fine if there were a 1:1 match, with each type only having 1 subsystem. If there were more than one subsystem of a given type though, it would not display accurate information to the player.

Fixed Version
![Working](https://user-images.githubusercontent.com/14077810/151711951-bfea8456-e517-4db4-a7c1-386c77aa13e9.png)

This PR sets the displayed subsystem integrity to that actual specific subsystem, not the aggregate. Tested and works as expected (screenshot attached) and fixes #3982.