### PR TITLE
Fix 3980

### DIFF
--- a/code/localization/localize.cpp
+++ b/code/localization/localize.cpp
@@ -60,7 +60,7 @@ bool *Lcl_unexpected_tstring_check = nullptr;
 // add a new string to the code, you must assign it a new index.  Use the number below for
 // that index and increase the number below by one.
 // retail XSTR_SIZE = 1570
-#define XSTR_SIZE	1662
+#define XSTR_SIZE	1665
 
 
 // struct to allow for strings.tbl-determined x offset

--- a/code/menuui/barracks.cpp
+++ b/code/menuui/barracks.cpp
@@ -662,12 +662,8 @@ int barracks_pilot_accepted()
 		return -1;
 	}
 
-	// check that pilot language is OK
-	if (!valid_pilot_lang(Cur_pilot->callsign)) {
-		popup(PF_USE_AFFIRMATIVE_ICON,1,POPUP_OK,XSTR(
-			"Selected pilot was created with a different language\n"
-			"to the currently active language.\n\n"
-			"Please select a different pilot or change the language", 1637));
+	// check that pilot is OK
+	if (!valid_pilot(Cur_pilot->callsign)) {
 		return -1;
 	}
 

--- a/code/menuui/barracks.cpp
+++ b/code/menuui/barracks.cpp
@@ -554,14 +554,23 @@ int barracks_new_pilot_selected()
 		return -1;
 	}
 
+	// check if the pilot is valid
+	// Also prompt if pilot has version mismatch
+	if (!valid_pilot(Pilots[Selected_line])) {
+		// pilot not valid or user opted not to select
+		Cur_pilot->callsign[0] = 0;
+		return -1;
+	}
+
 	if ( !Pilot.load_player(Pilots[Selected_line], Cur_pilot) ) {
+		// could not load, bail
 		Cur_pilot->callsign[0] = 0;  // this indicates no pilot active
 		return -1;
-	} else {
-		if (!Pilot.load_savefile(Cur_pilot, Cur_pilot->current_campaign)) {
-			// set single player squad image to multi if campaign can't be loaded
-			strcpy_s(Cur_pilot->s_squad_filename, Cur_pilot->m_squad_filename);
-		}
+	}
+
+	if (!Pilot.load_savefile(Cur_pilot, Cur_pilot->current_campaign)) {
+		// set single player squad image to multi if campaign can't be loaded
+		strcpy_s(Cur_pilot->s_squad_filename, Cur_pilot->m_squad_filename);
 	}
 
 	// init stuff to reflect new pilot

--- a/code/menuui/mainhallmenu.cpp
+++ b/code/menuui/mainhallmenu.cpp
@@ -1035,15 +1035,7 @@ void main_hall_do(float frametime)
 	}
 
 	// Display a popup if playermenu loaded a player file with a different version than expected
-	if (Player->flags & PLAYER_FLAGS_PLR_VER_CONTROLS) {
-		// Special case. Since the Controls5 PR is significantly different from retail, users must be informed
-		// of changes regarding their bindings
-
-		Player->flags &= ~PLAYER_FLAGS_PLR_VER_CONTROLS;	// Clear the flag, since we're notifying the user right now
-
-		popup(0, 1, POPUP_OK, "The currently selected pilot was from a version older than FSO 22.0.\n"
-			"It is strongly recommended that you verify your control bindings within the Options -> Control Config menu.\n\n");
-	}
+	player_tips_controls();
 
 	// maybe run the player tips popup
 	player_tips_popup();

--- a/code/menuui/mainhallmenu.cpp
+++ b/code/menuui/mainhallmenu.cpp
@@ -1034,19 +1034,19 @@ void main_hall_do(float frametime)
 		}
 	}
 
-	// maybe run the player tips popup
-	player_tips_popup();
-
 	// Display a popup if playermenu loaded a player file with a different version than expected
 	if (Player->flags & PLAYER_FLAGS_PLR_VER_CONTROLS) {
 		// Special case. Since the Controls5 PR is significantly different from retail, users must be informed
 		// of changes regarding their bindings
 
-		Player->flags &= PLAYER_FLAGS_PLR_VER_CONTROLS;	// Clear the flag, since we're notifying the user right now
+		Player->flags &= ~PLAYER_FLAGS_PLR_VER_CONTROLS;	// Clear the flag, since we're notifying the user right now
 
 		popup(0, 1, POPUP_OK, "The currently selected pilot was from a version older than FSO 22.0.\n"
 			"It is strongly recommended that you verify your control bindings within the Options -> Control Config menu.\n\n");
 	}
+
+	// maybe run the player tips popup
+	player_tips_popup();
 
 	// if we were supposed to skip a frame, then stop doing it after 1 frame
 	if (Main_hall_frame_skip) {

--- a/code/menuui/mainhallmenu.cpp
+++ b/code/menuui/mainhallmenu.cpp
@@ -1037,6 +1037,17 @@ void main_hall_do(float frametime)
 	// maybe run the player tips popup
 	player_tips_popup();
 
+	// Display a popup if playermenu loaded a player file with a different version than expected
+	if (Player->flags & PLAYER_FLAGS_PLR_VER_CONTROLS) {
+		// Special case. Since the Controls5 PR is significantly different from retail, users must be informed
+		// of changes regarding their bindings
+
+		Player->flags &= PLAYER_FLAGS_PLR_VER_CONTROLS;	// Clear the flag, since we're notifying the user right now
+
+		popup(0, 1, POPUP_OK, "The currently selected pilot was from a version older than FSO 22.0.\n"
+			"It is strongly recommended that you verify your control bindings within the Options -> Control Config menu.\n\n");
+	}
+
 	// if we were supposed to skip a frame, then stop doing it after 1 frame
 	if (Main_hall_frame_skip) {
 		Main_hall_frame_skip = 0;

--- a/code/menuui/playermenu.cpp
+++ b/code/menuui/playermenu.cpp
@@ -229,24 +229,21 @@ bool valid_pilot(const char* callsign, bool no_popup) {
 			popup(PF_USE_AFFIRMATIVE_ICON, 1, POPUP_OK, XSTR(
 				"Selected pilot was created with a different language\n"
 				"to the currently active language.\n\n"
-				"Please select a different pilot or change the language", 1637));
+				"Please select a different pilot or change the language.", 1637));
 		}
 		return false;
 	}
 
 	// verify pilot flags raised by Pilot::verify()
 	// if no_popup == true, assume sel = 0
-	if ((player_flags & (PLAYER_FLAGS_PLR_VER_LOWER | PLAYER_FLAGS_PLR_VER_HIGHER)) && (!no_popup)) {
+	if ((player_flags & (PLAYER_FLAGS_PLR_VER_IS_LOWER | PLAYER_FLAGS_PLR_VER_IS_HIGHER)) && (!no_popup)) {
 		// warning: Selected player version is different than the expected version
 		int sel = popup(PF_TITLE_BIG | PF_TITLE_RED, 2, POPUP_YES, POPUP_NO, XSTR(
-						"Warning!\n\n"
-						"Selected pilot was created with a different version of Freespace.\n\n"
-						"Should you continue with this pilot, it will be converted to version %i.\n\n"
-						"This update is irreversible and may make the pilot incompatible with other versions.\n\n"
-						"It is highly recommended that you clone this pilot and then use the clone instead.\n\n"
-						"Please visit https://wiki.hard-light.net/index.php/Frequently_Asked_Questions for more information.\n\n"
-						"Do you wish to continue?", 1663),
-						PLR_VERSION);
+			"Warning!\n\n"
+			"This pilot was created with a different version of FreeSpace.  If you continue, it will be converted to version %i.\n\n"
+			"Please consider cloning the pilot instead, so that the original pilot will remain compatible with the other version.  Visit https://wiki.hard-light.net/index.php/Frequently_Asked_Questions for more information.\n\n"
+			"Do you wish to continue?", 1663),
+			PLR_VERSION);
 
 		if (sel != 0) {
 			// Player either hit No or the popup was aborted, so bail
@@ -1459,16 +1456,16 @@ void player_tips_popup()
 }
 
 void player_tips_controls() {
-	if (Player->save_flags & PLAYER_FLAGS_PLR_VER_CONTROLS) {
+	if (Player->save_flags & PLAYER_FLAGS_PLR_VER_PRE_CONTROLS5) {
 		// Special case. Since the Controls5 PR is significantly different from retail, users must be informed
 		// of changes regarding their bindings
 
-		Player->save_flags &= ~PLAYER_FLAGS_PLR_VER_CONTROLS;	// Clear the flag, since we're notifying the user right now
+		Player->save_flags &= ~PLAYER_FLAGS_PLR_VER_PRE_CONTROLS5;	// Clear the flag, since we're notifying the user right now
 
 		int sel = popup(PF_NO_SPECIAL_BUTTONS | PF_TITLE_BIG | PF_TITLE_GREEN, 2, POPUP_OK, XSTR("Don't show me this again", 1443),
-						XSTR("Notice!\n\n"
-						"The currently selected pilot was from a version older than FSO 22.0.\n\n"
-						"It is strongly recommended that you verify your control bindings within the Options -> Control Config menu.\n", 1664));
+			XSTR("Notice!\n\n"
+			"The currently selected pilot was converted from a version older than FSO 22.0.\n\n"
+			"It is strongly recommended that you verify your control bindings within the Options -> Control Config menu.", 1664));
 
 		if (sel == 1) {
 			// Don't show me this again!

--- a/code/menuui/playermenu.cpp
+++ b/code/menuui/playermenu.cpp
@@ -211,7 +211,7 @@ bool valid_pilot(const char* callsign, bool no_popup) {
 	int player_flags = 0;
 
 	SCP_string filename = callsign;
-	filename == ".json";
+	filename += ".json";
 	
 	if (!Pilot.verify(filename.c_str(), NULL, pilot_lang, &player_flags)) {
 		if (!no_popup) {
@@ -554,19 +554,27 @@ void player_select_close()
 	if ( !Pilot.load_player(Pilots[Player_select_pilot], Player) ) {
 		Error(LOCATION,"Couldn't load pilot file, bailing");
 		Player = NULL;
-	} else {
-		// NOTE: this may fail if there is no current campaign, it's not fatal
-		Pilot.load_savefile(Player, Player->current_campaign);
+		return;
 	}
+	
+	// read in the current campaign
+	// NOTE: this may fail if there is no current campaign, it's not fatal
+	Pilot.load_savefile(Player, Player->current_campaign);
 
+	// Set singleplayer/multiplayer mode in Player
 	if (Player_select_mode == PLAYER_SELECT_MODE_MULTI) {
 		Player->player_was_multi = 1;
 	} else {
 		Player->player_was_multi = 0;
 	}
 
+	// save the pilot file to a version that we work with
+	Pilot.save_player(Player);
+
+	// Update the LastPlayer key in the registry
 	os_config_write_string(nullptr, "LastPlayer", Player->callsign);
 
+	// Maybe use a different main hall (debug console)
 	if (Player_select_force_main_hall != "") {
 		main_hall_init(Player_select_force_main_hall);
 	}

--- a/code/menuui/playermenu.cpp
+++ b/code/menuui/playermenu.cpp
@@ -574,17 +574,39 @@ void player_select_button_pressed(int n)
 	case ACCEPT_BUTTON:
 		// make sure he has a valid pilot selected
 		if (Player_select_pilot < 0) {
+			// error: invalid selection
 			popup(PF_USE_AFFIRMATIVE_ICON,1,POPUP_OK,XSTR( "You must select a valid pilot first", 378));
-		} else {
-			if (valid_pilot_lang(Pilots[Player_select_pilot])) {
-				player_select_commit();
-			} else {
-				popup(PF_USE_AFFIRMATIVE_ICON,1,POPUP_OK,XSTR(
-					"Selected pilot was created with a different language\n"
-					"to the currently active language.\n\n"
-					"Please select a different pilot or change the language", 1637));
+			goto player_select_nocommit;
+		}
+		
+		if (!valid_pilot_lang(Pilots[Player_select_pilot])) {
+			// error: Different language
+			popup(PF_USE_AFFIRMATIVE_ICON,1,POPUP_OK,XSTR(
+				"Selected pilot was created with a different language\n"
+				"to the currently active language.\n\n"
+				"Please select a different pilot or change the language", 1637));
+			goto player_select_nocommit;
+		}
+		
+		if (Player->flags & PLAYER_FLAGS_PLR_VER_LOWER) {
+			// warning: Selected player is older than the expected version
+			int sel = popup(PF_BODY_RED, 2, POPUP_YES, POPUP_NO, "Selected pilot was created with an older version of Freespace.\n"
+				"Should you continue with this pilot, it will be updated to version %i.\n"
+				"This update is irreversible and may make the pilot incompatible with older versions.\n"
+				"Please visit https://wiki.hard-light.net/index.php/Frequently_Asked_Questions for more information.\n\n"
+
+				"Do you wish to continue?", PLR_VERSION);
+
+			if (sel != 0) {
+				// Player either hit No or the popup was aborted, so bail
+				goto player_select_nocommit;
 			}
 		}
+		
+		// If we got here, then everything checks out!
+		player_select_commit();
+
+player_select_nocommit:		// ...unless we skipped to here
 		break;
 
 	case CLONE_BUTTON:

--- a/code/menuui/playermenu.cpp
+++ b/code/menuui/playermenu.cpp
@@ -213,7 +213,7 @@ bool valid_pilot(const char* callsign, bool no_popup) {
 	SCP_string filename = callsign;
 	filename += ".json";
 	
-	if (!Pilot.verify(filename.c_str(), NULL, pilot_lang, &player_flags)) {
+	if (!Pilot.verify(filename.c_str(), nullptr, pilot_lang, &player_flags)) {
 		if (!no_popup) {
 			popup(PF_USE_AFFIRMATIVE_ICON, 1, POPUP_OK, "Unable to open pilot!");
 		}

--- a/code/menuui/playermenu.cpp
+++ b/code/menuui/playermenu.cpp
@@ -236,13 +236,14 @@ bool valid_pilot(const char* callsign, bool no_popup) {
 
 	// verify pilot flags raised by Pilot::verify()
 	// if no_popup == true, assume sel = 0
-	if ((player_flags & PLAYER_FLAGS_PLR_VER_LOWER) && (!no_popup)) {
-		// warning: Selected player is older than the expected version
-		int sel = popup(PF_BODY_RED, 2, POPUP_YES, POPUP_NO, "Selected pilot was created with an older version of Freespace.\n"
-						"Should you continue with this pilot, it will be updated to version %i.\n"
-						"This update is irreversible and may make the pilot incompatible with older versions.\n"
+	if ((player_flags & (PLAYER_FLAGS_PLR_VER_LOWER | PLAYER_FLAGS_PLR_VER_HIGHER)) && (!no_popup)) {
+		// warning: Selected player version is different than the expected version
+		int sel = popup(PF_TITLE_BIG | PF_TITLE_RED, 2, POPUP_YES, POPUP_NO, "Warning!\n\n"
+						"Selected pilot was created with a different version of Freespace.\n\n"
+						"Should you continue with this pilot, it will be converted to version %i.\n\n"
+						"This update is irreversible and may make the pilot incompatible with other versions.\n\n"
+						"It is highly recommended that you clone this pilot and then use the clone instead.\n\n"
 						"Please visit https://wiki.hard-light.net/index.php/Frequently_Asked_Questions for more information.\n\n"
-
 						"Do you wish to continue?", PLR_VERSION);
 
 		if (sel != 0) {
@@ -1453,6 +1454,26 @@ void player_tips_popup()
 			break;
 		}
 	} while(ret > 0);
+}
+
+void player_tips_controls() {
+	if (Player->save_flags & PLAYER_FLAGS_PLR_VER_CONTROLS) {
+		// Special case. Since the Controls5 PR is significantly different from retail, users must be informed
+		// of changes regarding their bindings
+
+		Player->save_flags &= ~PLAYER_FLAGS_PLR_VER_CONTROLS;	// Clear the flag, since we're notifying the user right now
+
+		int sel = popup(PF_NO_SPECIAL_BUTTONS | PF_TITLE_BIG | PF_TITLE_GREEN, 2, POPUP_OK, XSTR("Don't show me this again", 1443),
+						"Notice!\n\n"
+						"The currently selected pilot was from a version older than FSO 22.0.\n\n"
+						"It is strongly recommended that you verify your control bindings within the Options -> Control Config menu.\n");
+
+		if (sel == 1) {
+			// Don't show me this again!
+			Pilot.save_player(Player);
+			Pilot.save_savefile();
+		}
+	}
 }
 
 SCP_vector<SCP_string> player_select_enumerate_pilots() {

--- a/code/menuui/playermenu.cpp
+++ b/code/menuui/playermenu.cpp
@@ -215,7 +215,7 @@ bool valid_pilot(const char* callsign, bool no_popup) {
 	
 	if (!Pilot.verify(filename.c_str(), nullptr, pilot_lang, &player_flags)) {
 		if (!no_popup) {
-			popup(PF_USE_AFFIRMATIVE_ICON, 1, POPUP_OK, "Unable to open pilot!");
+			popup(PF_USE_AFFIRMATIVE_ICON, 1, POPUP_OK, XSTR("Unable to open pilot file %s!", 1662), filename.c_str());
 		}
 
 		return false;
@@ -238,13 +238,15 @@ bool valid_pilot(const char* callsign, bool no_popup) {
 	// if no_popup == true, assume sel = 0
 	if ((player_flags & (PLAYER_FLAGS_PLR_VER_LOWER | PLAYER_FLAGS_PLR_VER_HIGHER)) && (!no_popup)) {
 		// warning: Selected player version is different than the expected version
-		int sel = popup(PF_TITLE_BIG | PF_TITLE_RED, 2, POPUP_YES, POPUP_NO, "Warning!\n\n"
+		int sel = popup(PF_TITLE_BIG | PF_TITLE_RED, 2, POPUP_YES, POPUP_NO, XSTR(
+						"Warning!\n\n"
 						"Selected pilot was created with a different version of Freespace.\n\n"
 						"Should you continue with this pilot, it will be converted to version %i.\n\n"
 						"This update is irreversible and may make the pilot incompatible with other versions.\n\n"
 						"It is highly recommended that you clone this pilot and then use the clone instead.\n\n"
 						"Please visit https://wiki.hard-light.net/index.php/Frequently_Asked_Questions for more information.\n\n"
-						"Do you wish to continue?", PLR_VERSION);
+						"Do you wish to continue?", 1663),
+						PLR_VERSION);
 
 		if (sel != 0) {
 			// Player either hit No or the popup was aborted, so bail
@@ -1464,9 +1466,9 @@ void player_tips_controls() {
 		Player->save_flags &= ~PLAYER_FLAGS_PLR_VER_CONTROLS;	// Clear the flag, since we're notifying the user right now
 
 		int sel = popup(PF_NO_SPECIAL_BUTTONS | PF_TITLE_BIG | PF_TITLE_GREEN, 2, POPUP_OK, XSTR("Don't show me this again", 1443),
-						"Notice!\n\n"
+						XSTR("Notice!\n\n"
 						"The currently selected pilot was from a version older than FSO 22.0.\n\n"
-						"It is strongly recommended that you verify your control bindings within the Options -> Control Config menu.\n");
+						"It is strongly recommended that you verify your control bindings within the Options -> Control Config menu.\n", 1664));
 
 		if (sel == 1) {
 			// Don't show me this again!

--- a/code/menuui/playermenu.h
+++ b/code/menuui/playermenu.h
@@ -41,7 +41,7 @@ int player_select_get_last_pilot();
 void player_tips_init();
 void player_tips_close();
 void player_tips_popup();
-void player_tips_close();
+void player_tips_controls();
 
 // quick check to make sure we always load default campaign savefile values when loading from the pilot
 // select screen but let us not overwrite current values with defaults when we aren't - taylor

--- a/code/menuui/playermenu.h
+++ b/code/menuui/playermenu.h
@@ -68,6 +68,18 @@ SCP_string player_get_last_player();
 
 void player_finish_select(const char* callsign, bool is_multi);
 
+/**
+ * Creates a new pilot
+ * 
+ * @param[in] callsign	Name of the new pilot
+ * @param[in] is_multi	True if this is a multiplayer pilot, False otherwise
+ * @param[in] copy_from_callsign	If not null, copy the pilot with the given name
+ * 
+ * @returns true if successful or
+ * @returns false otherwise
+ * 
+ * @note Used by scripting
+ */
 bool player_create_new_pilot(const char* callsign, bool is_multi, const char* copy_from_callsign = nullptr);
 
 #endif

--- a/code/menuui/playermenu.h
+++ b/code/menuui/playermenu.h
@@ -25,6 +25,13 @@ extern int Player_select_very_first_pilot;
 // functions for selecting single/multiplayer pilots at the very beginning of FreeSpace
 void player_select_init();
 void player_select_do();
+
+/**
+ * Playermenu closing handler
+ * 
+ * @details Called by game_leave_state when leaving GS_STATE_INITIAL_PLAYER_SELECT, finalizes player selection and
+ * prepares to enter the mainhall.
+ */
 void player_select_close();
 
 // function to check whether we found a "last pilot". loads this pilot in if possible and returns true, or false otherwise

--- a/code/menuui/playermenu.h
+++ b/code/menuui/playermenu.h
@@ -47,8 +47,20 @@ void player_tips_close();
 // select screen but let us not overwrite current values with defaults when we aren't - taylor
 extern int Player_select_screen_active;
 
-// check the pilots language
-bool valid_pilot_lang(const char *callsign);
+/**
+ * @brief Validates the pilot with the given callsign
+ * 
+ * @param[in] callsign The pilot's name/callsign
+ * @param[in] no_popup If true, supress any popups from being shown
+ * 
+ * @return FALSE If pilot language is NOT the same as the current language,or
+ * @return FALSE If the player selected NO on any popup warnings, or
+ * 
+ * @return TRUE otherwise
+ * 
+ * @note This function calls blocking popup dialogs and should only be used within menus
+ */
+bool valid_pilot(const char *callsign, bool no_popup = false);
 
 SCP_vector<SCP_string> player_select_enumerate_pilots();
 

--- a/code/pilotfile/csg.cpp
+++ b/code/pilotfile/csg.cpp
@@ -1534,6 +1534,8 @@ void pilotfile::csg_close()
 
 	m_have_flags = false;
 	m_have_info = false;
+
+	csg_ver = PLR_VERSION_INVALID;
 }
 
 bool pilotfile::load_savefile(player *_p, const char *campaign)

--- a/code/pilotfile/pilotfile.cpp
+++ b/code/pilotfile/pilotfile.cpp
@@ -18,6 +18,9 @@ pilotfile::pilotfile()
 
 	cfp = NULL;
 	p = NULL;
+
+	plr_ver = PLR_VERSION_INVALID;
+	csg_ver = PLR_VERSION_INVALID;
 }
 
 pilotfile::~pilotfile()

--- a/code/pilotfile/plr.cpp
+++ b/code/pilotfile/plr.cpp
@@ -1105,14 +1105,14 @@ bool pilotfile::load_player(const char* callsign, player* _p, bool force_binary)
 	// Flags to signal the main UI the state of the loaded player file
 	// Do these here after player_read_flags() so they don't get trashed!
 	if (plr_ver < 4) {
-		p->save_flags |= PLAYER_FLAGS_PLR_VER_CONTROLS;
+		p->save_flags |= PLAYER_FLAGS_PLR_VER_PRE_CONTROLS5;
 	}
 
 	if (plr_ver < PLR_VERSION) {
-		p->flags |= PLAYER_FLAGS_PLR_VER_LOWER;
+		p->flags |= PLAYER_FLAGS_PLR_VER_IS_LOWER;
 
 	} else if (plr_ver > PLR_VERSION) {
-		p->flags |= PLAYER_FLAGS_PLR_VER_HIGHER;
+		p->flags |= PLAYER_FLAGS_PLR_VER_IS_HIGHER;
 	}
 
 	mprintf(("PLR => Loading complete!\n"));
@@ -1300,14 +1300,14 @@ bool pilotfile::verify(const char *fname, int *rank, char *valid_language, int* 
 	// Flags to signal the main UI the state of the loaded player file
 	// Do these here after player_read_flags() so they don't get trashed!
 	if (plr_ver < 4) {
-		p->save_flags |= PLAYER_FLAGS_PLR_VER_CONTROLS;
+		p->save_flags |= PLAYER_FLAGS_PLR_VER_PRE_CONTROLS5;
 	}
 
 	if (plr_ver < PLR_VERSION) {
-		p->flags |= PLAYER_FLAGS_PLR_VER_LOWER;
+		p->flags |= PLAYER_FLAGS_PLR_VER_IS_LOWER;
 
 	} else if (plr_ver > PLR_VERSION) {
-		p->flags |= PLAYER_FLAGS_PLR_VER_HIGHER;
+		p->flags |= PLAYER_FLAGS_PLR_VER_IS_HIGHER;
 	}
 
 	if (valid_language) {

--- a/code/pilotfile/plr.cpp
+++ b/code/pilotfile/plr.cpp
@@ -93,16 +93,14 @@ void pilotfile::plr_read_flags()
 	// if there's a valid CSG, this will be overwritten
 	p->stats.rank = handler->readInt("multi_rank");
 
-	if (version > 0) 
-	{
+	if (plr_ver > 0) {
 		p->player_was_multi = handler->readInt("was_multi");
-	} else 
-	{
+	} else {
 		p->player_was_multi = 0; // Default to single player
 	}
 
 	// which language was this pilot created with
-	if (version > 1) {
+	if (plr_ver > 1) {
 		handler->readString("language", p->language, sizeof(p->language));
 	} else {
 		// if we don't know, default to the current language setting
@@ -648,7 +646,7 @@ void pilotfile::plr_write_stats_multi()
 
 void pilotfile::plr_read_controls()
 {
-	if (version < 4) {
+	if (plr_ver < 4) {
 		// PLR < 4
 		short id1, id2;
 		int axi, inv;
@@ -698,19 +696,8 @@ void pilotfile::plr_read_controls()
 			Control_config_presets.push_back(preset);
 
 			// Try to save the preset file
-			if (save_preset_file(preset, false)) {
-				os::dialogs::Information(LOCATION, "Successfully converted playerfile to v4.  Please rebind your mouse controls within the Options -> Controls Config menu.");
-				
-				SCP_string infostring;
-				infostring += "Due to technical difficulties, playerfiles versions v4 and up are incompatible with FSO versions older than FSO 22.0.\n\n";
-
-				infostring += "Should you try to use this pilot on a pre - 22.0 version of FSO, your control bindings will revert to the defaults.\n\n";
-
-				infostring += "Please visit https://wiki.hard-light.net/index.php/Frequently_Asked_Questions for more information.";
-
-				os::dialogs::Information(LOCATION, "%s", infostring.c_str());
-			} else {
-				Warning(LOCATION, "Could not save controls preset file (%s) when converting playerfile to v3.", preset.name.c_str());
+			if (!save_preset_file(preset, false)) {
+				Warning(LOCATION, "Could not save controls preset file (%s)", preset.name.c_str());
 			}
 		}
 		return;
@@ -947,6 +934,9 @@ void pilotfile::plr_close()
 		handler.reset();
 	}
 
+	// clear any special flags first
+	p->flags &= ~(PLAYER_FLAGS_PLR_VER_CONTROLS | PLAYER_FLAGS_PLR_VER_LOWER);
+
 	p = NULL;
 	filename = "";
 
@@ -957,6 +947,8 @@ void pilotfile::plr_close()
 
 	m_have_flags = false;
 	m_have_info = false;
+
+	plr_ver = PLR_VERSION_INVALID;
 }
 
 bool pilotfile::load_player(const char* callsign, player* _p, bool force_binary)
@@ -1020,9 +1012,18 @@ bool pilotfile::load_player(const char* callsign, player* _p, bool force_binary)
 	}
 
 	// version, now used
-	version = handler->readUByte("version");
+	plr_ver = handler->readUByte("version");
 
-	mprintf(("PLR => Loading '%s' with version %d...\n", filename.c_str(), version));
+	// Flags to signal the main UI the state of the loaded player file
+	if (plr_ver < 4) {
+		p->flags |= PLAYER_FLAGS_PLR_VER_CONTROLS;
+	}
+
+	if (plr_ver < PLR_VERSION) {
+		p->flags |= PLAYER_FLAGS_PLR_VER_LOWER;
+	}
+
+	mprintf(("PLR => Loading '%s' with version %d...\n", filename.c_str(), plr_ver));
 
 	//true resets everything, false sets up file verify.
 	plr_reset_data(true);
@@ -1209,7 +1210,7 @@ bool pilotfile::save_player(player *_p)
 	return true;
 }
 
-bool pilotfile::verify(const char *fname, int *rank, char *valid_language)
+bool pilotfile::verify(const char *fname, int *rank, char *valid_language, int* flags)
 {
 	player t_plr;
 
@@ -1247,9 +1248,18 @@ bool pilotfile::verify(const char *fname, int *rank, char *valid_language)
 	}
 
 	// version, now used
-	version = handler->readUByte("version");
+	plr_ver = handler->readUByte("version");
 
-	mprintf(("PLR => Verifying '%s' with version %d...\n", filename.c_str(), version));
+	// Flags to signal the main UI the state of the loaded player file
+	if (plr_ver < 4) {
+		p->flags |= PLAYER_FLAGS_PLR_VER_CONTROLS;
+	}
+
+	if (plr_ver < PLR_VERSION) {
+		p->flags |= PLAYER_FLAGS_PLR_VER_LOWER;
+	}
+
+	mprintf(("PLR => Verifying '%s' with version %d...\n", filename.c_str(), plr_ver));
 
 	// true resets everything, false sets up file verify.
 	plr_reset_data(false);
@@ -1301,6 +1311,12 @@ bool pilotfile::verify(const char *fname, int *rank, char *valid_language)
 
 	// need to cleanup early to ensure everything is OK for use in the CSG next
 	// also means we can't use *p from now on, use t_plr instead for a few vars
+
+	// Save any player flags, if caller wants them
+	if (flags != nullptr) {
+		*flags = p->flags;
+	}
+
 	plr_close();
 
 	if (rank) {

--- a/code/pilotfile/plr.cpp
+++ b/code/pilotfile/plr.cpp
@@ -934,9 +934,6 @@ void pilotfile::plr_close()
 		handler.reset();
 	}
 
-	// clear any special flags first
-	p->flags &= ~(PLAYER_FLAGS_PLR_VER_CONTROLS | PLAYER_FLAGS_PLR_VER_LOWER);
-
 	p = NULL;
 	filename = "";
 

--- a/code/pilotfile/plr.cpp
+++ b/code/pilotfile/plr.cpp
@@ -1011,15 +1011,6 @@ bool pilotfile::load_player(const char* callsign, player* _p, bool force_binary)
 	// version, now used
 	plr_ver = handler->readUByte("version");
 
-	// Flags to signal the main UI the state of the loaded player file
-	if (plr_ver < 4) {
-		p->flags |= PLAYER_FLAGS_PLR_VER_CONTROLS;
-	}
-
-	if (plr_ver < PLR_VERSION) {
-		p->flags |= PLAYER_FLAGS_PLR_VER_LOWER;
-	}
-
 	mprintf(("PLR => Loading '%s' with version %d...\n", filename.c_str(), plr_ver));
 
 	//true resets everything, false sets up file verify.
@@ -1110,6 +1101,19 @@ bool pilotfile::load_player(const char* callsign, player* _p, bool force_binary)
 	player_set_squad_bitmap(p, p->m_squad_filename, true);
 
 	hud_squadmsg_save_keys();
+
+	// Flags to signal the main UI the state of the loaded player file
+	// Do these here after player_read_flags() so they don't get trashed!
+	if (plr_ver < 4) {
+		p->save_flags |= PLAYER_FLAGS_PLR_VER_CONTROLS;
+	}
+
+	if (plr_ver < PLR_VERSION) {
+		p->flags |= PLAYER_FLAGS_PLR_VER_LOWER;
+
+	} else if (plr_ver > PLR_VERSION) {
+		p->flags |= PLAYER_FLAGS_PLR_VER_HIGHER;
+	}
 
 	mprintf(("PLR => Loading complete!\n"));
 
@@ -1247,15 +1251,6 @@ bool pilotfile::verify(const char *fname, int *rank, char *valid_language, int* 
 	// version, now used
 	plr_ver = handler->readUByte("version");
 
-	// Flags to signal the main UI the state of the loaded player file
-	if (plr_ver < 4) {
-		p->flags |= PLAYER_FLAGS_PLR_VER_CONTROLS;
-	}
-
-	if (plr_ver < PLR_VERSION) {
-		p->flags |= PLAYER_FLAGS_PLR_VER_LOWER;
-	}
-
 	mprintf(("PLR => Verifying '%s' with version %d...\n", filename.c_str(), plr_ver));
 
 	// true resets everything, false sets up file verify.
@@ -1301,6 +1296,19 @@ bool pilotfile::verify(const char *fname, int *rank, char *valid_language, int* 
 		}
 	}
 	handler->endSectionRead();
+
+	// Flags to signal the main UI the state of the loaded player file
+	// Do these here after player_read_flags() so they don't get trashed!
+	if (plr_ver < 4) {
+		p->save_flags |= PLAYER_FLAGS_PLR_VER_CONTROLS;
+	}
+
+	if (plr_ver < PLR_VERSION) {
+		p->flags |= PLAYER_FLAGS_PLR_VER_LOWER;
+
+	} else if (plr_ver > PLR_VERSION) {
+		p->flags |= PLAYER_FLAGS_PLR_VER_HIGHER;
+	}
 
 	if (valid_language) {
 		strcpy(valid_language, p->language);

--- a/code/playerman/managepilot.h
+++ b/code/playerman/managepilot.h
@@ -29,6 +29,14 @@ extern char Pilot_squad_images_arr[MAX_PILOT_IMAGES][MAX_FILENAME_LEN];
 extern char *Pilot_squad_image_names[MAX_PILOT_IMAGES];
 extern int Num_pilot_squad_images;
 
+/**
+ * Initilizes the given player
+ * 
+ * @param[in] p The player to initialize
+ * @param[in] reset If 0, don't touch the player settings, only reset scoring and campaign progress
+ * 
+ * @note Is used for creating new pilots as well as cloning
+ */
 void init_new_pilot(player *p, int reset = 1);
 
 // load up the list of pilot image filenames (do this at game startup as well as barracks startup)

--- a/code/playerman/player.h
+++ b/code/playerman/player.h
@@ -52,9 +52,9 @@
 #define PLAYER_FLAGS_KILLED_SELF_UNKNOWN			(1<<16)		// player died by his own hand
 #define PLAYER_FLAGS_KILLED_SELF_MISSILES			(1<<17)		// player died by his own missile
 #define PLAYER_FLAGS_KILLED_SELF_SHOCKWAVE		(1<<18)		// player died by his own shockwave
-#define PLAYER_FLAGS_PLR_VER_CONTROLS		(1<<19)		// loaded PLR file's plr_ver is a pre-controls5 version
-#define PLAYER_FLAGS_PLR_VER_LOWER			(1<<20)		// loaded PLR file's plr_ver is lower than PLR_VERSION
-#define PLAYER_FLAGS_PLR_VER_HIGHER			(1<<21)		// loaded PLR file's plr_ver is higher than PLR_VERSION
+#define PLAYER_FLAGS_PLR_VER_PRE_CONTROLS5		(1<<19)		// loaded PLR file's plr_ver is a pre-controls5 version
+#define PLAYER_FLAGS_PLR_VER_IS_LOWER			(1<<20)		// loaded PLR file's plr_ver is lower than PLR_VERSION
+#define PLAYER_FLAGS_PLR_VER_IS_HIGHER			(1<<21)		// loaded PLR file's plr_ver is higher than PLR_VERSION
 
 #define PLAYER_KILLED_SELF						( PLAYER_FLAGS_KILLED_SELF_UNKNOWN | PLAYER_FLAGS_KILLED_SELF_MISSILES | PLAYER_FLAGS_KILLED_SELF_SHOCKWAVE )
 

--- a/code/playerman/player.h
+++ b/code/playerman/player.h
@@ -52,6 +52,8 @@
 #define PLAYER_FLAGS_KILLED_SELF_UNKNOWN			(1<<16)		// player died by his own hand
 #define PLAYER_FLAGS_KILLED_SELF_MISSILES			(1<<17)		// player died by his own missile
 #define PLAYER_FLAGS_KILLED_SELF_SHOCKWAVE		(1<<18)		// player died by his own shockwave
+#define PLAYER_FLAGS_PLR_VER_CONTROLS		(1<<19)		// loaded PLR file's plr_ver is a pre-controls5 version
+#define PLAYER_FLAGS_PLR_VER_LOWER			(1<<20)		// loaded PLR file's plr_ver is lower than PLR_VERSION
 
 #define PLAYER_KILLED_SELF						( PLAYER_FLAGS_KILLED_SELF_UNKNOWN | PLAYER_FLAGS_KILLED_SELF_MISSILES | PLAYER_FLAGS_KILLED_SELF_SHOCKWAVE )
 

--- a/code/playerman/player.h
+++ b/code/playerman/player.h
@@ -54,6 +54,7 @@
 #define PLAYER_FLAGS_KILLED_SELF_SHOCKWAVE		(1<<18)		// player died by his own shockwave
 #define PLAYER_FLAGS_PLR_VER_CONTROLS		(1<<19)		// loaded PLR file's plr_ver is a pre-controls5 version
 #define PLAYER_FLAGS_PLR_VER_LOWER			(1<<20)		// loaded PLR file's plr_ver is lower than PLR_VERSION
+#define PLAYER_FLAGS_PLR_VER_HIGHER			(1<<21)		// loaded PLR file's plr_ver is higher than PLR_VERSION
 
 #define PLAYER_KILLED_SELF						( PLAYER_FLAGS_KILLED_SELF_UNKNOWN | PLAYER_FLAGS_KILLED_SELF_MISSILES | PLAYER_FLAGS_KILLED_SELF_SHOCKWAVE )
 

--- a/code/scripting/api/libs/ui.cpp
+++ b/code/scripting/api/libs/ui.cpp
@@ -187,7 +187,7 @@ ADE_FUNC(checkPilotLanguage, l_UserInterface_PilotSelect, "string callsign",
 		return ADE_RETURN_FALSE;
 	}
 
-	return ade_set_args(L, "b", valid_pilot_lang(callsign));
+	return ade_set_args(L, "b", valid_pilot(callsign, true));
 }
 
 ADE_FUNC(selectPilot, l_UserInterface_PilotSelect, "string callsign, boolean is_multi",

--- a/test/src/pilotfile/plr.cpp
+++ b/test/src/pilotfile/plr.cpp
@@ -270,6 +270,16 @@ TEST_F(PilotPlayerFileTest, binaryToJSONConversion) {
 	// Then read the json file
 	ASSERT_TRUE(loader.load_player("asdf", &json_plr, false));
 
+	// Ignore version flags since the .plr -> .json conversion is not a pure clone
+	#define IGNORE_FLAGS PLAYER_FLAGS_PLR_VER_LOWER | PLAYER_FLAGS_PLR_VER_HIGHER
+	#define IGNORE_SAVE_FLAGS PLAYER_FLAGS_PLR_VER_CONTROLS
+
+	binary_plr.flags |= IGNORE_FLAGS;
+	binary_plr.save_flags |= IGNORE_SAVE_FLAGS;
+
+	json_plr.flags |= IGNORE_FLAGS;
+	json_plr.save_flags |= IGNORE_SAVE_FLAGS;
+
 	ASSERT_EQ(binary_plr, json_plr);
 
 	// Close control_config stuff

--- a/test/src/pilotfile/plr.cpp
+++ b/test/src/pilotfile/plr.cpp
@@ -271,8 +271,8 @@ TEST_F(PilotPlayerFileTest, binaryToJSONConversion) {
 	ASSERT_TRUE(loader.load_player("asdf", &json_plr, false));
 
 	// Ignore version flags since the .plr -> .json conversion is not a pure clone
-	#define IGNORE_FLAGS PLAYER_FLAGS_PLR_VER_LOWER | PLAYER_FLAGS_PLR_VER_HIGHER
-	#define IGNORE_SAVE_FLAGS PLAYER_FLAGS_PLR_VER_CONTROLS
+	#define IGNORE_FLAGS PLAYER_FLAGS_PLR_VER_IS_LOWER | PLAYER_FLAGS_PLR_VER_IS_HIGHER
+	#define IGNORE_SAVE_FLAGS PLAYER_FLAGS_PLR_VER_PRE_CONTROLS5
 
 	binary_plr.flags |= IGNORE_FLAGS;
 	binary_plr.save_flags |= IGNORE_SAVE_FLAGS;


### PR DESCRIPTION
Should fix #3980 

Alright, This PR adds a number of QoL features and logic flow of selecting a pilot from the player menu, which is the first screen that player see right after the intro movie.

* When players try to a accept a selected pilot, the pilot is checked to see if it is valid. They will be notified with a popup to alert them that the selected file is an older version and prompt them if they want to continue and convert the pilot.
  * Since we can now intercept players before committing to the pilot, we can safely convert the pilot to the version FSO wants to work with.  This is done after the players have committed to using the pilot.  This is to ensure expected behavior of "convert pilot on commit."
* When players enter the mainhall and the verification process detected the pilot was a pre Controls5 save, a popup will be displayed to tell them to check their control bindings

- [x] Investigate option to clone pilot from the version mismatch popup
- [x] XSTR() support in popups.

Adds the following XSTR's:
1662: "Unable to open pilot file %s!"
1663: "Warning!\n\nSelected pilot was created with a different version of Freespace.\n\n"...
1664: "Notice!\n\nThe currently selected pilot was from a version older than FSO 22.0.\n\n"...

![image](https://user-images.githubusercontent.com/5084344/152667234-47e4ad73-14a4-4d4c-963c-62f36608e584.png)

![image](https://user-images.githubusercontent.com/5084344/152667205-3c4e85b7-876d-437e-a3a5-81074d81c168.png)


