### PR TITLE
point camera correctly when using set-camera-facing

### DIFF
--- a/code/camera/camera.cpp
+++ b/code/camera/camera.cpp
@@ -378,32 +378,32 @@ void camera::get_info(vec3d *position, matrix *orientation)
 		{
 			if(object_target.IsValid())
 			{
-				object *objp = object_target.objp;
-				int model_num = object_get_model(objp);
-				polymodel *pm = nullptr;
-				polymodel_instance *pmi = nullptr;
+				object *target_objp = object_target.objp;
+				int model_num = object_get_model(target_objp);
+				polymodel *target_pm = nullptr;
+				polymodel_instance *target_pmi = nullptr;
 				vec3d target_pos = vmd_zero_vector;
 				
 				//See if we can get the model
 				if(model_num >= 0)
 				{
-					pm = model_get(model_num);
-					if (objp->type == OBJ_SHIP)
-						pmi = model_get_instance(Ships[objp->instance].model_instance_num);
+					target_pm = model_get(model_num);
+					if (target_objp->type == OBJ_SHIP)
+						target_pmi = model_get_instance(Ships[target_objp->instance].model_instance_num);
 				}
 
 				//If we don't have a submodel or don't have the model use object pos
 				//Otherwise, find the submodel pos as it is rotated
-				if(object_target_submodel < 0 || pm == NULL)
+				if(object_target_submodel < 0 || target_pm == NULL)
 				{
-					target_pos = objp->pos;
+					target_pos = target_objp->pos;
 				}
 				else
 				{
-					if (pmi != nullptr)
-						model_instance_find_world_point(&target_pos, &vmd_zero_vector, pm, pmi, object_target_submodel, &objp->orient, &objp->pos);
+					if (target_pmi != nullptr)
+						model_instance_find_world_point(&target_pos, &vmd_zero_vector, target_pm, target_pmi, object_target_submodel, &target_objp->orient, &target_objp->pos);
 					else
-						model_find_world_point( &target_pos, &vmd_zero_vector, pm, object_target_submodel, &objp->orient, &objp->pos );
+						model_find_world_point( &target_pos, &vmd_zero_vector, target_pm, object_target_submodel, &target_objp->orient, &target_objp->pos );
 				}
 
 				vec3d targetvec;

--- a/code/camera/camera.h
+++ b/code/camera/camera.h
@@ -75,7 +75,7 @@ public:
 	object *get_object_target();
 	int get_object_target_submodel();
 	float get_fov();
-	void get_info(vec3d *position, matrix *orientation);
+	void get_info(vec3d *position, matrix *orientation, bool apply_camera_orientation = true);
 
 	//Is
 	bool is_empty(){return sig < 0;}

--- a/code/math/vecmat.cpp
+++ b/code/math/vecmat.cpp
@@ -863,29 +863,6 @@ matrix *vm_copy_transpose(matrix *dest, const matrix *src)
 	return dest;
 }
 
-inline vec3d operator*(const matrix& A, const vec3d& v) {
-	vec3d out;
-
-	out.xyz.x = vm_vec_dot(&A.vec.rvec, &v);
-	out.xyz.y = vm_vec_dot(&A.vec.uvec, &v);
-	out.xyz.z = vm_vec_dot(&A.vec.fvec, &v);
-
-	return out;
-}
-
-inline matrix operator*(const matrix& A, const matrix& B) {
-	matrix BT, out;
-
-	// we transpose B here for concision and also potential vectorisation opportunities
-	vm_copy_transpose(&BT, &B);
-
-	out.vec.rvec = BT * A.vec.rvec;
-	out.vec.uvec = BT * A.vec.uvec;
-	out.vec.fvec = BT * A.vec.fvec;
-
-	return out;
-}
-
 // Old matrix multiplication routine. Note that the order of multiplication is inverted
 // compared to the mathematical standard: formally, this calculates src1 * src0
 matrix *vm_matrix_x_matrix(matrix *dest, const matrix *src0, const matrix *src1)

--- a/code/math/vecmat.h
+++ b/code/math/vecmat.h
@@ -652,13 +652,41 @@ inline matrix& operator-=(matrix& left, const matrix& right)
 }
 
 /**
- * @brief Implements matrix multiplication on both 3x3 matrices and 3D vectors
+ * @brief Implements matrix multiplication on 3D vectors
  * @param left The matrix
- * @param right The vector/matrix
+ * @param right The vector
  * @return The multiplied result
  */
-inline vec3d operator*(const matrix& A, const vec3d& v);
-inline matrix operator*(const matrix& A, const matrix& B);
+inline vec3d operator*(const matrix& A, const vec3d& v)
+{
+	vec3d out;
+
+	out.xyz.x = vm_vec_dot(&A.vec.rvec, &v);
+	out.xyz.y = vm_vec_dot(&A.vec.uvec, &v);
+	out.xyz.z = vm_vec_dot(&A.vec.fvec, &v);
+
+	return out;
+}
+
+/**
+ * @brief Implements matrix multiplication on 3x3 matrices
+ * @param left The matrix
+ * @param right The matrix
+ * @return The multiplied result
+ */
+inline matrix operator*(const matrix& A, const matrix& B)
+{
+	matrix BT, out;
+
+	// we transpose B here for concision and also potential vectorisation opportunities
+	vm_copy_transpose(&BT, &B);
+
+	out.vec.rvec = BT * A.vec.rvec;
+	out.vec.uvec = BT * A.vec.uvec;
+	out.vec.fvec = BT * A.vec.fvec;
+
+	return out;
+}
 
 std::ostream& operator<<(std::ostream& os, const vec3d& vec);
 

--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -86,6 +86,8 @@ float Min_pizel_size_muzzleflash;
 float Min_pixel_size_trail;
 float Min_pixel_size_laser;
 
+void mod_table_set_version_flags();
+
 SCP_vector<std::pair<SCP_string, gr_capability>> req_render_ext_pairs = {
 	std::make_pair("BPTC Texture Compression", CAPABILITY_BPTC)
 };
@@ -116,6 +118,9 @@ void parse_mod_table(const char *filename)
 					gameversion::format_version(Targeted_version).c_str(),
 					gameversion::format_version(gameversion::get_executable_version()).c_str());
 			}
+
+			// whenever we specify a version, set the flags for that version
+			mod_table_set_version_flags();
 		}
 
 		if (optional_string("$Window title:")) {
@@ -790,7 +795,7 @@ void mod_table_reset()
 	Default_weapon_select_effect = 2;
 	Default_fiction_viewer_ui = -1;
 	Enable_external_shaders = false;
-	Enable_external_default_scripts             = false;
+	Enable_external_default_scripts = false;
 	Default_detail_level = 3; // "very high" seems a reasonable default in 2012 -zookeeper
 	Full_color_head_anis = false;
 	Dont_automatically_select_turret_when_targeting_ship = false;
@@ -843,4 +848,14 @@ void mod_table_reset()
 	Min_pizel_size_muzzleflash = 0.0f;
 	Min_pixel_size_trail = 0.0f;
 	Min_pixel_size_laser = 0.0f;
+}
+
+void mod_table_set_version_flags()
+{
+	if (mod_supports_version(22, 0, 0)) {
+		Fixed_turret_collisions = true;
+		Shockwaves_damage_all_obj_types_once = true;
+		Framerate_independent_turning = true;					// this is already true, but let's re-emphasize it
+		Use_host_orientation_for_set_camera_facing = true;		// this is essentially a bugfix
+	}
 }

--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -27,6 +27,7 @@ bool Fixed_turret_collisions;
 bool Damage_impacted_subsystem_first;
 bool Cutscene_camera_displays_hud;
 bool Alternate_chaining_behavior;
+bool Use_host_orientation_for_set_camera_facing;
 int Default_ship_select_effect;
 int Default_weapon_select_effect;
 int Default_fiction_viewer_ui;
@@ -266,6 +267,16 @@ void parse_mod_table(const char *filename)
 			}
 			else {
 				mprintf(("Game Settings Table: Using standard event chaining behavior\n"));
+			}
+		}
+
+		if (optional_string("$Use host orientation for set-camera-facing:")) {
+			stuff_boolean(&Use_host_orientation_for_set_camera_facing);
+			if (Use_host_orientation_for_set_camera_facing) {
+				mprintf(("Game Settings Table: Using host orientation for set-camera-facing\n"));
+			}
+			else {
+				mprintf(("Game Settings Table: Using identity orientation for set-camera-facing\n"));
 			}
 		}
 
@@ -774,6 +785,7 @@ void mod_table_reset()
 	Damage_impacted_subsystem_first = false;
 	Cutscene_camera_displays_hud = false;
 	Alternate_chaining_behavior = false;
+	Use_host_orientation_for_set_camera_facing = false;
 	Default_ship_select_effect = 2;
 	Default_weapon_select_effect = 2;
 	Default_fiction_viewer_ui = -1;

--- a/code/mod_table/mod_table.h
+++ b/code/mod_table/mod_table.h
@@ -18,6 +18,7 @@ extern bool Fixed_turret_collisions;
 extern bool Damage_impacted_subsystem_first;
 extern bool Cutscene_camera_displays_hud;
 extern bool Alternate_chaining_behavior;
+extern bool Use_host_orientation_for_set_camera_facing;
 extern int Default_ship_select_effect;
 extern int Default_weapon_select_effect;
 extern int Default_fiction_viewer_ui;


### PR DESCRIPTION
A few fixes for the camera code...

1) When pointing the camera toward a target, take into account the host's orientation.  Use a game_settings.tbl flag to control this.
2) When using a submodel to host the camera, correctly calculate the submodel orientation.

Fixes #3889