### PR TITLE
Fix limitations of GetColor script function

### DIFF
--- a/code/hud/hud.cpp
+++ b/code/hud/hud.cpp
@@ -3049,7 +3049,19 @@ void hud_set_dim_color()
  * @param objp			Object to test for team color to base on
  * @param is_bright		Default parameter (value 0) which uses bright version of IFF color
  */
-void hud_set_iff_color(object *objp, int is_bright)
+void hud_set_iff_color(object* objp, int is_bright) {
+
+	gr_set_color_fast(hud_get_iff_color(objp, is_bright));
+
+}
+
+/**
+ * @brief Will get the color to the IFF color based on the team
+ *
+ * @param objp			Object to test for team color to base on
+ * @param is_bright		Default parameter (value 0) which uses bright version of IFF color
+ */
+color* hud_get_iff_color(object* objp, int is_bright)
 {
 	color *use_color;
 
@@ -3076,7 +3088,7 @@ void hud_set_iff_color(object *objp, int is_bright)
 		}
 	}
 
-	gr_set_color_fast(use_color);
+	return use_color;
 }
 
 /**

--- a/code/hud/hud.cpp
+++ b/code/hud/hud.cpp
@@ -3046,7 +3046,7 @@ void hud_set_dim_color()
 /**
  * @brief Will set the color to the IFF color based on the team
  *
- * @param objp			Object to test for team color to base on
+ * @param objp			Pointer to object whose team will be queried to set HUD gauge color
  * @param is_bright		Default parameter (value 0) which uses bright version of IFF color
  */
 void hud_set_iff_color(object* objp, int is_bright) {
@@ -3058,7 +3058,7 @@ void hud_set_iff_color(object* objp, int is_bright) {
 /**
  * @brief Will get the color to the IFF color based on the team
  *
- * @param objp			Object to test for team color to base on
+ * @param objp			Pointer to object whose team will be queried to get HUD gauge color
  * @param is_bright		Default parameter (value 0) which uses bright version of IFF color
  */
 color* hud_get_iff_color(object* objp, int is_bright)

--- a/code/scripting/api/objs/object.cpp
+++ b/code/scripting/api/objs/object.cpp
@@ -603,10 +603,10 @@ ADE_FUNC(getIFFColor, l_Object, "number, number, number",
 	object_h* objh;
 
 	if (!ade_get_args(L, "o", l_Object.GetPtr(&objh)))
-		return ade_set_error(L, "iii", ADE_RETURN_NIL, ADE_RETURN_NIL, ADE_RETURN_NIL);
+		return ADE_RETURN_NIL;
 
 	if (!objh->IsValid())
-		return ade_set_error(L, "iii", ADE_RETURN_NIL, ADE_RETURN_NIL, ADE_RETURN_NIL);
+		return ADE_RETURN_NIL;
 
 	auto objp = objh->objp;
 	color* col = hud_get_iff_color(objp);

--- a/code/scripting/api/objs/object.cpp
+++ b/code/scripting/api/objs/object.cpp
@@ -594,5 +594,29 @@ ADE_FUNC(removeSound, l_Object, "soundentry GameSnd, [subsystem Subsys=nil]",
 	return ADE_RETURN_NIL;
 }
 
+
+ADE_FUNC(getIFFColor, l_Object, "number, number, number", 
+	"Gets the IFF color of the object",
+	"number, number, number", 
+	"IFF rgb color of the object or nil if object invalid")
+{
+	object_h* objh;
+
+	if (!ade_get_args(L, "o", l_Object.GetPtr(&objh)))
+		return ade_set_error(L, "iii", ADE_RETURN_NIL, ADE_RETURN_NIL, ADE_RETURN_NIL);
+
+	if (!objh->IsValid())
+		return ade_set_error(L, "iii", ADE_RETURN_NIL, ADE_RETURN_NIL, ADE_RETURN_NIL);
+
+	auto objp = objh->objp;
+	color* col = hud_get_iff_color(objp);
+
+	int r = col->red;
+	int g = col->green;
+	int b = col->blue;
+
+	return ade_set_args(L, "iii", r, g, b);
+}
+
 } // namespace api
 } // namespace scripting


### PR DESCRIPTION
It is very valuable for custom HUD gauges to be able to show/use the IFF color of any given object. Previous scripting solutions were limited and did not account for traitor status, varying team combinations (i.e. TvT multiplayer), and other cases.

This PR allows scripters to get the IFF color of a given object properly, as it uses the same method that retail HUD gauges use. It also allows HUD scripts to be updated to properly work in the aforementioned cases. For example, this will fix FotG's custom HUD gauges in multiplayer in TvT and Dogfight missions. 

Also, it turns out there was already a function `hud_get_iff_color` defined in `hud.h`. It was never used though, as `hud_set_iff_color` both got the color then set it. I've added the color getting to the `get` function and the setting to the `set` function, that way the script function can easily just call the `hud_get_iff_color` function. If this is undesirable, I can instead copy the entire logic of the function `hud_set_iff_color` into the script section.

Tested and works as expected.