### PR TITLE
Fix Axis Rotation Moveable

### DIFF
--- a/code/model/modelanimation_moveables.cpp
+++ b/code/model/modelanimation_moveables.cpp
@@ -167,7 +167,10 @@ namespace animation {
 			vm_matrix_x_matrix(&newOrient, &startOrient, &buffer[rotation.m_submodel].data.orientation);
 			setOrientation.m_targetOrientation = newOrient;
 
-			rotation.m_targetAngle = fl_radians((float)ang);
+			float currentAngle;
+			vm_closest_angle_to_matrix(&newOrient, &m_axis, &currentAngle);
+			
+			rotation.m_targetAngle = fl_radians((float)ang) - currentAngle;
 
 			anim->start(pmi, ModelAnimationDirection::FWD);
 		}


### PR DESCRIPTION
This moveable was previously working in relative space, which is incorrect.
Moveables must operate in absolute space to be predictable when the movement gets interrupted before the old movement finishes.