### PR TITLE
fix missile detonation for computers with high FPS

### DIFF
--- a/code/io/keycontrol.cpp
+++ b/code/io/keycontrol.cpp
@@ -784,7 +784,8 @@ void process_debug_keys(int k)
 					ship_apply_local_damage( objp, Player_obj, &objp->pos, 1.0f, -1, MISS_SHIELDS, CREATE_SPARKS);
 					break;
 				case OBJ_WEAPON:
-					Weapons[objp->instance].lifeleft = 0.01f;
+					Weapons[objp->instance].lifeleft = 0.001f;
+					Weapons[objp->instance].weapon_flags.set(Weapon::Weapon_Flags::Begun_detonation);
 					break;
 				}
 			}

--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -24,6 +24,7 @@
 int Directive_wait_time;
 bool True_loop_argument_sexps;
 bool Fixed_turret_collisions;
+bool Fixed_missile_detonation;
 bool Damage_impacted_subsystem_first;
 bool Cutscene_camera_displays_hud;
 bool Alternate_chaining_behavior;
@@ -593,6 +594,10 @@ void parse_mod_table(const char *filename)
 			stuff_boolean(&Fixed_turret_collisions);
 		}
 
+		if (optional_string("$Fixed Missile Detonation:")) {
+			stuff_boolean(&Fixed_missile_detonation);
+		}
+
 		if (optional_string("$Damage Impacted Subsystem First:")) {
 			stuff_boolean(&Damage_impacted_subsystem_first);
 		}
@@ -787,6 +792,7 @@ void mod_table_reset()
 	Directive_wait_time = 3000;
 	True_loop_argument_sexps = false;
 	Fixed_turret_collisions = false;
+	Fixed_missile_detonation = false;
 	Damage_impacted_subsystem_first = false;
 	Cutscene_camera_displays_hud = false;
 	Alternate_chaining_behavior = false;
@@ -854,6 +860,7 @@ void mod_table_set_version_flags()
 {
 	if (mod_supports_version(22, 0, 0)) {
 		Fixed_turret_collisions = true;
+		Fixed_missile_detonation = true;
 		Shockwaves_damage_all_obj_types_once = true;
 		Framerate_independent_turning = true;					// this is already true, but let's re-emphasize it
 		Use_host_orientation_for_set_camera_facing = true;		// this is essentially a bugfix

--- a/code/mod_table/mod_table.h
+++ b/code/mod_table/mod_table.h
@@ -15,6 +15,7 @@
 extern int Directive_wait_time;
 extern bool True_loop_argument_sexps;
 extern bool Fixed_turret_collisions;
+extern bool Fixed_missile_detonation;
 extern bool Damage_impacted_subsystem_first;
 extern bool Cutscene_camera_displays_hud;
 extern bool Alternate_chaining_behavior;

--- a/code/network/multimsgs.cpp
+++ b/code/network/multimsgs.cpp
@@ -2761,8 +2761,6 @@ void process_weapon_kill_packet(ubyte *data, header *hinfo )
 	}
 
 	weapon_detonate(missile);
-	missile->flags.set(Object::Object_Flags::Should_be_dead);
-	Weapons[missile->instance].lifeleft = -1.0f;
 }
 
 // send a packet indicating a ship should be created

--- a/code/object/collideshipweapon.cpp
+++ b/code/object/collideshipweapon.cpp
@@ -497,6 +497,8 @@ static int ship_weapon_check_collision(object *ship_objp, object *weapon_objp, f
 				// check if we're colliding against "invisible" ship
 				if (!(shipp->flags[Ship::Ship_Flags::Dont_collide_invis])) {
 					wp->lifeleft = 0.001f;
+					wp->weapon_flags.set(Weapon::Weapon_Flags::Begun_detonation);
+
 					if (ship_objp == Player_obj)
 						nprintf(("Jim", "Frame %i: Weapon %d set to detonate, dist = %7.3f.\n", Framecount, OBJ_INDEX(weapon_objp), dist));
 					valid_hit_occurred = 1;

--- a/code/object/collideweaponweapon.cpp
+++ b/code/object/collideweaponweapon.cpp
@@ -112,9 +112,11 @@ int collide_weapon_weapon( obj_pair * pair )
 			if (wipA->weapon_hitpoints > 0) {
 				if (wipB->weapon_hitpoints > 0) {		//	Two bombs collide, detonate both.
 					if ((wipA->wi_flags[Weapon::Info_Flags::Bomb]) && (wipB->wi_flags[Weapon::Info_Flags::Bomb])) {
-						wpA->lifeleft = 0.01f;
-						wpB->lifeleft = 0.01f;
+						wpA->lifeleft = 0.001f;
+						wpA->weapon_flags.set(Weapon::Weapon_Flags::Begun_detonation);
 						wpA->weapon_flags.set(Weapon::Weapon_Flags::Destroyed_by_weapon);
+						wpB->lifeleft = 0.001f;
+						wpB->weapon_flags.set(Weapon::Weapon_Flags::Begun_detonation);
 						wpB->weapon_flags.set(Weapon::Weapon_Flags::Destroyed_by_weapon);
 					} else {
 						A->hull_strength -= bDamage;
@@ -130,29 +132,35 @@ int collide_weapon_weapon( obj_pair * pair )
 						}
 						
 						if (A->hull_strength < 0.0f) {
-							wpA->lifeleft = 0.01f;
+							wpA->lifeleft = 0.001f;
+							wpA->weapon_flags.set(Weapon::Weapon_Flags::Begun_detonation);
 							wpA->weapon_flags.set(Weapon::Weapon_Flags::Destroyed_by_weapon);
 						}
 						if (B->hull_strength < 0.0f) {
-							wpB->lifeleft = 0.01f;
+							wpB->lifeleft = 0.001f;
+							wpB->weapon_flags.set(Weapon::Weapon_Flags::Begun_detonation);
 							wpB->weapon_flags.set(Weapon::Weapon_Flags::Destroyed_by_weapon);
 						}
 					}
 				} else {
 					A->hull_strength -= bDamage;
-					wpB->lifeleft = 0.01f;
+					wpB->lifeleft = 0.001f;
+					wpB->weapon_flags.set(Weapon::Weapon_Flags::Begun_detonation);
 					wpB->weapon_flags.set(Weapon::Weapon_Flags::Destroyed_by_weapon);
 					if (A->hull_strength < 0.0f) {
-						wpA->lifeleft = 0.01f;
+						wpA->lifeleft = 0.001f;
+						wpA->weapon_flags.set(Weapon::Weapon_Flags::Begun_detonation);
 						wpA->weapon_flags.set(Weapon::Weapon_Flags::Destroyed_by_weapon);
 					}
 				}
 			} else if (wipB->weapon_hitpoints > 0) {
 				B->hull_strength -= aDamage;
-				wpA->lifeleft = 0.01f;
+				wpA->lifeleft = 0.001f;
+				wpA->weapon_flags.set(Weapon::Weapon_Flags::Begun_detonation);
 				wpA->weapon_flags.set(Weapon::Weapon_Flags::Destroyed_by_weapon);
 				if (B->hull_strength < 0.0f) {
-					wpB->lifeleft = 0.01f;
+					wpB->lifeleft = 0.001f;
+					wpB->weapon_flags.set(Weapon::Weapon_Flags::Begun_detonation);
 					wpB->weapon_flags.set(Weapon::Weapon_Flags::Destroyed_by_weapon);
 				}
 			}

--- a/code/weapon/shockwave.cpp
+++ b/code/weapon/shockwave.cpp
@@ -348,7 +348,8 @@ void shockwave_move(object *shockwave_objp, float frametime)
 
 			objp->hull_strength -= damage;
 			if (objp->hull_strength < 0.0f) {
-				Weapons[objp->instance].lifeleft = 0.01f;
+				Weapons[objp->instance].lifeleft = 0.001f;
+				Weapons[objp->instance].weapon_flags.set(Weapon::Weapon_Flags::Begun_detonation);
 				Weapons[objp->instance].weapon_flags.set(Weapon::Weapon_Flags::Destroyed_by_weapon);
 			}
 			break;

--- a/code/weapon/weapon_flags.h
+++ b/code/weapon/weapon_flags.h
@@ -107,6 +107,7 @@ namespace Weapon {
 		Overridden_homing,          // Homing is overridden by an external source (probably scripting)
 		Multi_homing_update_needed, // this is a newly spawned homing weapon which needs to update client machines
 		Multi_Update_Sent,			// Marks this missile as already being updated once by the server
+		Begun_detonation,			// The engine has set this weapon to detonate momentarily
 
 		NUM_VALUES
 	};


### PR DESCRIPTION
There is a bit of code that detonates a missile if it misses impacting on a subsystem.  On Nyctaeus's Arachnas model, missiles could reach the center point of the main beam turret submodel without actually hitting any part of the submodel.  The fail-safe code would set the missile to detonate in that case, but on low-FPS systems the weapon would be able to actually hit the turret before it detonated.  On high-FPS systems, there is a clean miss.

This reworks the code to delay the missile detonation until it reaches the other side of the submodel, so it has time to hit some other part of it.  It also reduces the detonation time from 1/100 of a second (which is more than one frame on 120 FPS systems) to 1/1000 of a second (which is always less than one frame).