### PR TITLE
fix the camera flicker in the lab

### DIFF
--- a/code/camera/camera.cpp
+++ b/code/camera/camera.cpp
@@ -259,9 +259,13 @@ void camera::set_rotation_facing(vec3d *in_target, float in_rotation_time, float
 			// point along the target vector, but using the host orient's roll
 			vm_vector_2_matrix(&temp_matrix, &targetvec, &orient->vec.uvec, nullptr);
 
-			// we need the difference between the camera's current orient and the orient we want
-			vm_transpose(orient);
-			temp_matrix = temp_matrix * *orient;
+			// if we have a host, we need the difference between the camera's current orient and the orient we want
+			// if not, we will later set the absolute orientation, rather than the orientation relative to the host
+			if (object_host.IsValid())
+			{
+				vm_transpose(orient);
+				temp_matrix = temp_matrix * *orient;
+			}
 		}
 		else
 		{
@@ -485,8 +489,7 @@ void camera::get_info(vec3d *position, matrix *orientation, bool apply_camera_or
 			}
 		}
 
-		if (orientation != nullptr)
-			*orientation = c_ori;
+		*orientation = c_ori;
 	}
 }
 


### PR DESCRIPTION
As @Baezon figured out, when a host exists, `get_info` will return the orientation relative to the host.  When there is no host, `get_info` returns the absolute orientation.  In the latter case, `set_rotation_facing` does not need to do extra calculations to find the delta orientation.

Also remove a redundant `if` check.

Follow-up to #3989.