### PR TITLE
Restrict allowable characters for preset names

### DIFF
--- a/code/popup/popup.cpp
+++ b/code/popup/popup.cpp
@@ -33,6 +33,7 @@
 #define POPUP_MAX_LINES				30					// max lines of text allowed
 #define POPUP_MAX_CHARS				2048				// total max chars 
 #define POPUP_INPUT_MAX_CHARS		255				// max length of input string
+#define POPUP_MAX_VALID_CHARS		32				// maximum number of unique non-alphanumeric characters in the input whitelist
 
 #define POPUP_NOCHANGE				100
 #define POPUP_ABORT					101
@@ -77,6 +78,7 @@ typedef struct popup_info
 	char	input_text[POPUP_INPUT_MAX_CHARS];						// input box text (if this is an inputbox popup)
 	int	max_input_text_len;
 	int	web_cursor_flag[POPUP_MAX_CHOICES];						// flag for using web cursor over button
+	char valid_chars[POPUP_MAX_VALID_CHARS];					// whitelist of non-alphanumeric characters used for popup_input
 } popup_info;
 
 ////////////////////////////////////////////////////////////////
@@ -531,6 +533,7 @@ int popup_init(popup_info *pi, int flags)
 	if(flags & PF_INPUT){
 		Popup_input.create(&Popup_window, Popup_text_coords[gr_screen.res][0], pbg->coords[1] + Popup_input_y_offset[gr_screen.res], Popup_text_coords[gr_screen.res][2], pi->max_input_text_len, pi->input_text, UI_INPUTBOX_FLAG_INVIS | UI_INPUTBOX_FLAG_ESC_CLR | UI_INPUTBOX_FLAG_ESC_FOC | UI_INPUTBOX_FLAG_KEYTHRU | UI_INPUTBOX_FLAG_TEXT_CEN);
 		Popup_input.set_focus();
+		Popup_input.set_valid_chars(pi->valid_chars);
 	}	
 	
 	Popup_default_choice=0;
@@ -1102,7 +1105,7 @@ int popup_till_condition(int (*condition)(), ...)
 }
 
 // popup to return the value from an input box
-char *popup_input(int flags, const char *caption, int max_output_len, const char *default_input)
+char *popup_input(int flags, const char *caption, int max_output_len, const char *default_input, const char *vchar)
 {
 	if ( Popup_is_active ) {
 		Int3();		// should never happen
@@ -1132,6 +1135,13 @@ char *popup_input(int flags, const char *caption, int max_output_len, const char
 	// zero the popup input text and set default, if provided
 	memset(Popup_info.input_text, 0, POPUP_INPUT_MAX_CHARS);
 	strcpy_s(Popup_info.input_text, default_input);
+
+	// Set the character whitelist for non-alphanumerics
+	if (vchar != nullptr) {
+		strcpy_s(Popup_info.valid_chars, vchar);
+	} else {
+		memset(Popup_info.valid_chars, 0, POPUP_MAX_VALID_CHARS);
+	}
 	
 	gamesnd_play_iface(InterfaceSounds::POPUP_APPEAR); 	// play sound when popup appears
 

--- a/code/popup/popup.h
+++ b/code/popup/popup.h
@@ -19,6 +19,8 @@
 #define POPUP_YES						XSTR("&Yes", 505)
 #define POPUP_NO						XSTR("&No", 506)
 
+#define POPUP_DEFAULT_VALID_CHARS "_.-"	// Default string of valid non-alphanumeric characters that popup_input may accept
+
 ///////////////////////////////////////////////////
 // flags
 ///////////////////////////////////////////////////
@@ -100,8 +102,9 @@ int popup_till_condition( int(*condition)() , ...);
  * @param[in] caption           Caption text of the prompt
  * @param[in] max_output_len    (Optional) Maximum string length of the input text
  * @param[in] default_input     (Optional) Default input text
+ * @param[in] vchar             (Optional) Valid character whitelist for non-alphanumeric characters. If nullptr, no non-alphanumeric characters are accepted
  */
-char *popup_input(int flags, const char *caption, int max_output_len = -1, const char *default_input = "");
+char *popup_input(int flags, const char *caption, int max_output_len = -1, const char *default_input = "", const char *vchar = POPUP_DEFAULT_VALID_CHARS);
 
 int popup_active();
 

--- a/code/ui/ui.h
+++ b/code/ui/ui.h
@@ -301,21 +301,111 @@ class UI_INPUTBOX : public UI_GADGET
 		int cursor_current_frame;
 		int cursor_elapsed_time;
 
-		int	validate_input(int chr);
-		void	init_cursor();
+		/**
+		 * @brief Checks if the given chr is a valid character
+		 * 
+		 * @param[in] chr The character to validate
+		 * 
+		 * @return 0   If an invalid character was passed, or
+		 * @return chr If the character is valid
+		 * 
+		 * @details Rejects control characters and characters that are in the invalid_chars blacklist string, Accepts
+		 *   alphanumeric characters and characters that are in the valid_chars whitelist string
+		*/
+		int validate_input(int chr);
+		
+		/**
+		 * @brief Inits the cursor for the input box
+		*/
+		void init_cursor();
 
+		/**
+		 * @brief Draws the input box according to its mode and settings.
+		*/
 		void draw() override;
+
+		/**
+		 * @brief Processes mouse and keyboard input
+		 * 
+		 * @param[in] focus Focus state of this widget
+		 * 
+		 * @details If focus is not 0, or the widget is selected, the mouse and keyboard input is processed.
+		*/
 		void process(int focus = 0) override;
+
+		/**
+		 * @brief De-inits the widget, vm_free'ing relevant strings and other relevant heap elements
+		*/
 		void destroy() override;
 
 	public:
+		/**
+		 * @brief Creates an input box gadget
+		 * @param[in] wnd Pointer to parent window
+		 * @param[in] _x        horizontal anchor position (pixels)
+		 * @param[in] _y        vertical anchor position (pixels)
+		 * @param[in] _w        width (pixels)
+		 * @param[in] _textlen  maximum number of characters acceptable in a line
+		 * @param[in] _text     initial text value
+		 * @param[in] _flags    any of UI_INPUTBOX_FLAG* flags
+		 * @param[in] pixel_lim     width, in pixels, to limit the input string. Set this to -1 to ignore.
+		 * @param[in] clr       color of the input text as defined in uidefs.h
+		 * 
+		 * @note _h is not a specified param and is instead automatically determined by the font size of the input text
+		*/
 		void create(UI_WINDOW *wnd, int _x, int _y, int _w, int _textlen, const char *_text, int _flags = 0, int pixel_lim = -1, color *clr = NULL);
+		
+		/**
+		 * @brief Sets the whitelist of all characters allowed for input
+		 * 
+		 * @param[in] vchars String of all characters that are whitelisted.  May be nullptr.
+		 * 
+		 * @note Alpha [a-z, A-Z] and Numeric [0-9] characters are implicity whitelisted. May be affected by locale.
+		*/
 		void set_valid_chars(const char *vchars);
+		
+		/**
+		 * @brief Sets the blacklist of all characters not allowed for input
+		 * 
+		 * @param[in] ichars String of al lcharacters that are blacklisted.  May be nullptr.
+		 * 
+		 * @note Non-printable and control characters are implicitly blacklisted
+		*/
 		void set_invalid_chars(const char *ichars);
+		
+		/**
+		 * @brief Returns 1 if the input text has changed
+		 * 
+		 * @return changed_flag, 0 for no change, 1 for change occured
+		 * 
+		 * @note Does not clear changed_flag on use
+		*/
 		int changed();
+		
+		/**
+		 * @brief Returns 1 if the Enter key was pressed
+		*/
 		int pressed();
-		void get_text(char *out);
+
+		/**
+		 * @brief Retrieves the string currently in the inputbox
+		 * @param[out] out Destination char[] to copy the string to
+		*/
+		void get_text(char* out);
+		
+		/**
+		 * @brief Sets the string in the inputbox
+		 * @param[in] in Source char[] to copy the string from
+		*/
 		void set_text(const char *in);
+		
+		/**
+		 * @brief Appends the given string to the input string
+		 * 
+		 * @param in String to append
+		 * 
+		 * @note Takes in as much of the input string as possible, truncating once textlen is exceeded
+		*/
 		void append_text(const char *in);
 };
 


### PR DESCRIPTION
This PR extends the popup_input() function to allow users to set an arbitrary whitelist of non-alphanumeric characters (anything that isn't a-z or 0-9, and isn't a control character), and sets the default whitelist to include period ( . ), underscore( _ ), and minus( - ).

Affects the input boxes used for squadwars matchmaking code, controls preset naming, and the mainhall mission jump-to-mission  cheat.

Fixes #4005 