### PR TITLE
event logging tweaks

### DIFF
--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -24061,7 +24061,7 @@ const char *sexp_get_result_as_text(int result)
 /**
 * Checks the mission logs flags for this event and writes to the log if this has been asked for
 */
-void add_to_event_log_buffer(int op_num, int result)
+void add_to_event_log_buffer(int node, int op_num, int result)
 {
 	Assertion ((Current_event_log_buffer != nullptr) &&
 				(Current_event_log_variable_buffer != nullptr)&& 
@@ -24075,6 +24075,14 @@ void add_to_event_log_buffer(int op_num, int result)
 
 	char buffer[TOKEN_LENGTH];
 	SCP_string tmp; 
+
+	// indent the operators according to their depth
+	int n = node;
+	while (n >= 0) {
+		tmp.append("  ");
+		n = find_parent_operator(n);
+	}
+
 	tmp.append(Operators[op_num].text);
 	tmp.append(" returned ");
 
@@ -24101,8 +24109,9 @@ void add_to_event_log_buffer(int op_num, int result)
 	}
 
 	if (!Current_event_log_variable_buffer->empty()) {
-		tmp.append("\nVariables:\n");
+		tmp.append("\nVariables:");
 		while (!Current_event_log_variable_buffer->empty()) {
+			tmp.append("\n");
 			tmp.append(Current_event_log_variable_buffer->back());
 			Current_event_log_variable_buffer->pop_back();
 			tmp.append("[");
@@ -24113,8 +24122,9 @@ void add_to_event_log_buffer(int op_num, int result)
 	}
 
 	if (!Current_event_log_container_buffer->empty()) {
-		tmp.append("\nContainers:\n");
+		tmp.append("\nContainers:");
 		while (!Current_event_log_container_buffer->empty()) {
+			tmp.append("\n");
 			tmp.append(Current_event_log_container_buffer->back());
 			Current_event_log_container_buffer->pop_back();
 		}
@@ -24151,7 +24161,7 @@ int eval_sexp(int cur_node, int referenced_node)
 				op_index = get_operator_index(CAR(cur_node));
 
 			// log the known value
-			add_to_event_log_buffer(op_index, Sexp_nodes[cur_node].value);
+			add_to_event_log_buffer(cur_node, op_index, Sexp_nodes[cur_node].value);
 		}
 
 		// now do a quick return whether or not we log, per the comment above about trapping known sexpressions
@@ -26381,7 +26391,7 @@ int eval_sexp(int cur_node, int referenced_node)
 		}
 
 		if (Log_event) {
-			add_to_event_log_buffer(get_operator_index(cur_node), sexp_val);
+			add_to_event_log_buffer(cur_node, get_operator_index(cur_node), sexp_val);
 		}
 
 		Assert(!Current_sexp_operator.empty()); 


### PR DESCRIPTION
A couple quality-of-life improvements for event logging:
1) Indent the SEXP operators according to their depth in the node tree
2) Add newlines between variables and containers