### PR TITLE
Fix qtFRED crash when using Edit Data

### DIFF
--- a/qtfred/src/ui/widgets/sexp_tree.cpp
+++ b/qtfred/src/ui/widgets/sexp_tree.cpp
@@ -5736,7 +5736,7 @@ void sexp_tree::handleItemChange(QTreeWidgetItem* item, int  /*column*/) {
 
 	if (update_node) {
 		modified();
-		strncpy(tree_nodes[node].text, str.toStdString().c_str(), len);
+		strncpy(tree_nodes[node].text, str.toUtf8().constData(), len);
 		tree_nodes[node].text[len] = 0;
 
 		// let's make sure we aren't introducing any invalid characters, per Mantis #2893

--- a/qtfred/src/ui/widgets/sexp_tree.cpp
+++ b/qtfred/src/ui/widgets/sexp_tree.cpp
@@ -5736,7 +5736,8 @@ void sexp_tree::handleItemChange(QTreeWidgetItem* item, int  /*column*/) {
 
 	if (update_node) {
 		modified();
-		strncpy(tree_nodes[node].text, str.toUtf8().constData(), len);
+		auto strBytes = str.toUtf8(); // avoid using dangling ptr
+		strncpy(tree_nodes[node].text, strBytes.constData(), len);
 		tree_nodes[node].text[len] = 0;
 
 		// let's make sure we aren't introducing any invalid characters, per Mantis #2893


### PR DESCRIPTION
On Windows, there's currently a debug heap assertion failure when trying to use Edit Data.

This change seems to fix it.

I originally thought the issue was with Add Data >> Number/String (hence the branch name) but realized it was actually Edit Data.

I wonder if the issue is `QString`'s implementation of `toStdString()` itself.

Unrelated known issue: when Add Data >> Number is used and the text is left as "number" and the Events Editor is closed with OK, qtFRED doesn't automatically change the value to 0, but if you save/reload the mission, it's set to 0.