### PR TITLE
another timestamp upgrade

### DIFF
--- a/code/controlconfig/controlsconfig.cpp
+++ b/code/controlconfig/controlsconfig.cpp
@@ -127,7 +127,7 @@ int Conflict_warning_coords[GR_NUM_RESOLUTIONS][2] = {
 
 // for flashing the conflict text
 #define CONFLICT_FLASH_TIME	250
-int Conflict_stamp = -1;
+UI_TIMESTAMP Conflict_stamp;
 int Conflict_bright = 0;
 
 #define LIST_BUTTONS_MAX	42
@@ -1462,7 +1462,7 @@ void control_config_init()
 	help_overlay_set_state(Control_config_overlay_id,gr_screen.res,0);
 
 	// reset conflict flashing
-	Conflict_stamp = -1;
+	Conflict_stamp = UI_TIMESTAMP::invalid();
 
 	for (i=0; i<NUM_BUTTONS; i++) {
 		b = &CC_Buttons[gr_screen.res][i];
@@ -1801,7 +1801,7 @@ void control_config_do_frame(float frametime)
 	int font_height = gr_get_font_height();
 	int select_tease_line = -1;  // line mouse is down on, but won't be selected until button released
 	static float timer = 0.0f;
-	static int bound_timestamp = 0;
+	static UI_TIMESTAMP bound_timestamp = UI_TIMESTAMP::invalid();
 	static char bound_string[40];
 	
 	timer += frametime;
@@ -1859,7 +1859,7 @@ void control_config_do_frame(float frametime)
 		if (k == KEY_ESC) {
 			// Cancel bind if ESC is pressed
 			strcpy_s(bound_string, XSTR("Canceled", 206));
-			bound_timestamp = timestamp(2500);
+			bound_timestamp = ui_timestamp(2500);
 			control_config_do_cancel();
 
 		} else if (Control_config[z].is_axis()) {
@@ -1960,7 +1960,7 @@ void control_config_do_frame(float frametime)
 		if (done) {
 			// done with binding mode, clean up and prepare for display
 			font::force_fit_string(bound_string, 39, Conflict_wnd_coords[gr_screen.res][CONTROL_W_COORD]);
-			bound_timestamp = timestamp(2500);
+			bound_timestamp = ui_timestamp(2500);
 			control_config_conflict_check();
 			control_config_list_prepare();
 			control_config_do_cancel();
@@ -2271,10 +2271,10 @@ void control_config_do_frame(float frametime)
 
 	if (z) {
 		// maybe switch from bright to normal
-		if((Conflict_stamp == -1) || timestamp_elapsed(Conflict_stamp)){
+		if (!Conflict_stamp.isValid() || ui_timestamp_elapsed(Conflict_stamp)){
 			Conflict_bright = !Conflict_bright;
 
-			Conflict_stamp = timestamp(CONFLICT_FLASH_TIME);
+			Conflict_stamp = ui_timestamp(CONFLICT_FLASH_TIME);
 		}
 
 		// set color and font
@@ -2298,7 +2298,7 @@ void control_config_do_frame(float frametime)
 		font::set_font(font::FONT1);
 	} else {
 		// might as well always reset the conflict stamp
-		Conflict_stamp = -1;
+		Conflict_stamp = UI_TIMESTAMP::invalid();
 	}
 
 	// Find if a tab button was pressed
@@ -2397,7 +2397,7 @@ void control_config_do_frame(float frametime)
 		gr_set_color_fast(&Color_text_normal);
 		gr_get_string_size(&w, NULL, bound_string);
 		gr_printf_menu(x - w / 2, y - font_height / 2, "%s", bound_string);
-		if (timestamp_elapsed(bound_timestamp)) {
+		if (ui_timestamp_elapsed(bound_timestamp)) {
 			*bound_string = 0;
 		}
 	}

--- a/code/controlconfig/controlsconfig.cpp
+++ b/code/controlconfig/controlsconfig.cpp
@@ -1801,7 +1801,7 @@ void control_config_do_frame(float frametime)
 	int font_height = gr_get_font_height();
 	int select_tease_line = -1;  // line mouse is down on, but won't be selected until button released
 	static float timer = 0.0f;
-	static UI_TIMESTAMP bound_timestamp = UI_TIMESTAMP::invalid();
+	static UI_TIMESTAMP bound_timestamp;
 	static char bound_string[40];
 	
 	timer += frametime;

--- a/code/cutscene/movie.cpp
+++ b/code/cutscene/movie.cpp
@@ -205,14 +205,14 @@ void movie_display_loop(Player* player, PlaybackState* state) {
 	auto fpsCapSave = Cmdline_NoFPSCap;
 	Cmdline_NoFPSCap = 1;
 
-	auto lastDisplayTimestamp = timer_get_microseconds();
+	auto lastDisplayTime = timer_get_microseconds();
 	while (state->playing) {
 		TRACE_SCOPE(tracing::CutsceneStep);
 
-		auto timestamp = timer_get_microseconds();
+		auto now = timer_get_microseconds();
 
-		auto passed = timestamp - lastDisplayTimestamp;
-		lastDisplayTimestamp = timestamp;
+		auto passed = now - lastDisplayTime;
+		lastDisplayTime = now;
 
 		if (player->isPlaybackReady()) {
 			// Play as long as the player reports that there is more to display

--- a/code/io/cursor.cpp
+++ b/code/io/cursor.cpp
@@ -80,7 +80,7 @@ namespace io
 			this->mLastFrame = other.mLastFrame;
 			
 			other.mBitmapHandle = -1;
-			other.mBeginTimeStamp= -1;
+			other.mBeginTimeStamp = UI_TIMESTAMP::invalid();
 			other.mLastFrame = static_cast<size_t>(-1);
 			
 			return *this;
@@ -112,7 +112,7 @@ namespace io
 			if (mAnimationFrames.size() > 1)
 			{
 				// Animated, set the begin and do everything else in setCurrentFrame()
-				mBeginTimeStamp = timestamp();
+				mBeginTimeStamp = ui_timestamp();
 				mLastFrame = static_cast<size_t>(-1);
 			}
 			else
@@ -127,7 +127,7 @@ namespace io
 			if (mAnimationFrames.size() > 1)
 			{
 				// We are animated, compute the current frame
-				float diffSeconds = i2fl(timestamp() - mBeginTimeStamp) / TIMESTAMP_FREQUENCY;
+				float diffSeconds = i2fl(ui_timestamp().value() - mBeginTimeStamp.value()) / TIMESTAMP_FREQUENCY;
 
 				// Use the bmpman function for this. That also ensures that APNG cursors work correctly 
 				auto frameIndex = static_cast<size_t>(bm_get_anim_frame(mBitmapHandle, diffSeconds, 0.0f, true));

--- a/code/io/cursor.cpp
+++ b/code/io/cursor.cpp
@@ -127,7 +127,7 @@ namespace io
 			if (mAnimationFrames.size() > 1)
 			{
 				// We are animated, compute the current frame
-				float diffSeconds = i2fl(ui_timestamp().value() - mBeginTimeStamp.value()) / TIMESTAMP_FREQUENCY;
+				float diffSeconds = i2fl(-ui_timestamp_until(mBeginTimeStamp)) / TIMESTAMP_FREQUENCY;
 
 				// Use the bmpman function for this. That also ensures that APNG cursors work correctly 
 				auto frameIndex = static_cast<size_t>(bm_get_anim_frame(mBitmapHandle, diffSeconds, 0.0f, true));

--- a/code/io/cursor.h
+++ b/code/io/cursor.h
@@ -7,6 +7,7 @@
 
 #include "globalincs/pstypes.h"
 #include "cmdline/cmdline.h"
+#include "io/timer.h"
 
 #include <memory>
 
@@ -26,7 +27,7 @@ namespace io
 
 			int mBitmapHandle; //!< The bitmap of this cursor
 
-			int mBeginTimeStamp; //!< The timestamp when the animation was started, unused when not animated
+			UI_TIMESTAMP mBeginTimeStamp; //!< The UI timestamp when the animation was started, unused when not animated
 			size_t mLastFrame; //!< The last frame which was set
 			
 			Cursor(const Cursor&); // Not implemented
@@ -36,7 +37,7 @@ namespace io
 			 * @brief Default constructor
 			 * @param bitmap The bitmap handle of the cursor. The cursor takes ownership over this handle
 			 */
-			explicit Cursor(int bitmap) : mBitmapHandle(bitmap), mBeginTimeStamp(-1), mLastFrame(static_cast<size_t>(-1)) {}
+			explicit Cursor(int bitmap) : mBitmapHandle(bitmap), mBeginTimeStamp(), mLastFrame(static_cast<size_t>(-1)) {}
 
 			/**
 			 * @brief Move constructor

--- a/code/io/cursor.h
+++ b/code/io/cursor.h
@@ -37,7 +37,7 @@ namespace io
 			 * @brief Default constructor
 			 * @param bitmap The bitmap handle of the cursor. The cursor takes ownership over this handle
 			 */
-			explicit Cursor(int bitmap) : mBitmapHandle(bitmap), mBeginTimeStamp(), mLastFrame(static_cast<size_t>(-1)) {}
+			explicit Cursor(int bitmap) : mBitmapHandle(bitmap), mLastFrame(static_cast<size_t>(-1)) {}
 
 			/**
 			 * @brief Move constructor

--- a/code/io/timer.cpp
+++ b/code/io/timer.cpp
@@ -379,12 +379,6 @@ void timestamp_start_mission()
 	Timestamp_microseconds_at_mission_start = timestamp_get_microseconds();
 }
 
-void timestamp_revert_to_mission_start()
-{
-	auto delta_microseconds = (timestamp_get_microseconds() - Timestamp_microseconds_at_mission_start);
-	timestamp_adjust_microseconds(delta_microseconds, TIMER_DIRECTION::BACKWARD);
-}
-
 fix timestamp_get_mission_time()
 {
 	// convert timestamp to mission time

--- a/code/io/timer.cpp
+++ b/code/io/timer.cpp
@@ -158,15 +158,20 @@ int timestamp() {
 	return timestamp_ms();
 }
 
+UI_TIMESTAMP ui_timestamp() {
+	return UI_TIMESTAMP(timer_get_milliseconds());
+}
+
 // ======================================== checking timestamps ========================================
 
 // Restrict all time values between 0 and MAX_TIME
 // so we don't have to use UINTs to calculate rollover.
 // For debugging & testing, you could set this to
 // something like 1 minute (60000).
+// Although this is around 12.4 days (1073741823 milliseconds).
 extern const std::uint32_t MAX_TIME = INT_MAX / 2;
 
-int timestamp(int delta_ms ) {
+int timestamp(int delta_ms) {
 	int t2;
 	if (delta_ms < 0 ) return 0;
 	if (delta_ms == 0 ) return 1;
@@ -177,6 +182,19 @@ int timestamp(int delta_ms ) {
 	}
 	if (t2 < 2 ) t2 = 2;	// hack??
 	return t2;
+}
+
+UI_TIMESTAMP ui_timestamp(int delta_ms) {
+	int t2;
+	if (delta_ms < 0 ) return UI_TIMESTAMP(0);
+	if (delta_ms == 0 ) return UI_TIMESTAMP(1);
+	t2 = timer_get_milliseconds() + delta_ms;
+	if ( t2 > (int)MAX_TIME )	{
+		// wrap!!!
+		t2 = delta_ms - (MAX_TIME-timer_get_milliseconds());
+	}
+	if (t2 < 2 ) t2 = 2;	// hack??
+	return UI_TIMESTAMP(t2);
 }
 
 //	Returns milliseconds until timestamp will elapse.
@@ -222,6 +240,19 @@ bool timestamp_elapsed(int stamp) {
 	}
 
 	return timestamp_ms() >= stamp;
+}
+
+bool ui_timestamp_elapsed(UI_TIMESTAMP ui_stamp) {
+	if (!ui_stamp.isValid()) {
+		return false;
+	}
+
+	int stamp = ui_stamp.value();
+	if (stamp == 0) {
+		return false;
+	}
+
+	return timer_get_milliseconds() >= stamp;
 }
 
 bool timestamp_elapsed_safe(int a, int b) {

--- a/code/io/timer.cpp
+++ b/code/io/timer.cpp
@@ -186,8 +186,8 @@ int timestamp(int delta_ms) {
 
 UI_TIMESTAMP ui_timestamp(int delta_ms) {
 	int t2;
-	if (delta_ms < 0 ) return UI_TIMESTAMP(0);
-	if (delta_ms == 0 ) return UI_TIMESTAMP(1);
+	if (delta_ms < 0 ) return UI_TIMESTAMP::never();
+	if (delta_ms == 0 ) return UI_TIMESTAMP::immediate();
 	t2 = timer_get_milliseconds() + delta_ms;
 	if ( t2 > (int)MAX_TIME )	{
 		// wrap!!!
@@ -199,7 +199,8 @@ UI_TIMESTAMP ui_timestamp(int delta_ms) {
 
 //	Returns milliseconds until timestamp will elapse.
 //	Negative value gives milliseconds ago that timestamp elapsed.
-int timestamp_until(int stamp) {
+int timestamp_until(int stamp)
+{
 	// JAS: FIX
 	// HACK!! This doesn't handle rollover!
 	// (Will it ever happen?)
@@ -219,6 +220,16 @@ int timestamp_until(int stamp) {
 
 	return delta;
 */
+}
+
+int ui_timestamp_until(UI_TIMESTAMP stamp)
+{
+	if (!stamp.isValid() || stamp.isNever())
+		return INT_MAX;
+	if (stamp.isImmediate())
+		return 0;
+
+	return stamp.value() - timer_get_milliseconds();
 }
 
 int timestamp_has_time_elapsed(int stamp, int time) {
@@ -243,16 +254,14 @@ bool timestamp_elapsed(int stamp) {
 }
 
 bool ui_timestamp_elapsed(UI_TIMESTAMP ui_stamp) {
-	if (!ui_stamp.isValid()) {
+	if (!ui_stamp.isValid() || ui_stamp.isNever()) {
 		return false;
 	}
-
-	int stamp = ui_stamp.value();
-	if (stamp == 0) {
-		return false;
+	if (ui_stamp.isImmediate()) {
+		return true;
 	}
 
-	return timer_get_milliseconds() >= stamp;
+	return timer_get_milliseconds() >= ui_stamp.value();
 }
 
 bool timestamp_elapsed_safe(int a, int b) {

--- a/code/io/timer.h
+++ b/code/io/timer.h
@@ -168,9 +168,6 @@ void timestamp_update_time_compression();
 // Save the timestamp corresponding to the beginning of the mission
 void timestamp_start_mission();
 
-// Restore the timestamp corresponding to the beginning of the mission, since we essentially start time twice
-void timestamp_revert_to_mission_start();
-
 // Calculate the current mission time using the timestamps
 fix timestamp_get_mission_time();
 

--- a/code/io/timer.h
+++ b/code/io/timer.h
@@ -14,11 +14,15 @@
 
 #include "globalincs/pstypes.h"
 
+#include "utils/ID.h"
 #include "utils/Random.h"
 
 #include <cstdint>
 
 using Random = util::Random;
+
+struct ui_timestamp_tag {};
+typedef util::ID<ui_timestamp_tag, int, -1> UI_TIMESTAMP;
 
 //==========================================================================
 // This installs the timer services and interrupts at the rate specified by
@@ -68,6 +72,9 @@ extern int timer_get_seconds();				// seconds since program started... not accur
 // but the count that is right now.
 int timestamp();
 
+// same, but for use in the UI, so not subject to time compression or pauses
+UI_TIMESTAMP ui_timestamp();
+
 inline bool timestamp_valid(int stamp) {
 	return stamp != 0;
 }
@@ -83,7 +90,8 @@ inline bool timestamp_valid(int stamp) {
 // pass -1 for an invalid timestamp that will never time out
 // pass 0 for a timestamp that is instantly timed out
 // pass n > 0 for timestamp n milliseconds in the future.
-int timestamp(int delta_ms );
+int timestamp(int delta_ms);
+UI_TIMESTAMP ui_timestamp(int delta_ms);
 
 // gets a timestamp randomly between a and b milliseconds in
 // the future.
@@ -107,6 +115,7 @@ int timestamp_has_time_elapsed(int stamp, int time);
 //   fire_laser();
 
 bool timestamp_elapsed( int stamp );
+bool ui_timestamp_elapsed( UI_TIMESTAMP stamp );
 
 // safer version of timestamp
 bool timestamp_elapsed_safe(int a, int b);

--- a/code/io/timer.h
+++ b/code/io/timer.h
@@ -14,15 +14,29 @@
 
 #include "globalincs/pstypes.h"
 
-#include "utils/ID.h"
+#include "utils/id.h"
 #include "utils/Random.h"
 
 #include <cstdint>
 
 using Random = util::Random;
 
+// "strong typedef", based on similar usage in gamesnd
 struct ui_timestamp_tag {};
-typedef util::ID<ui_timestamp_tag, int, -1> UI_TIMESTAMP;
+class UI_TIMESTAMP : public util::ID<ui_timestamp_tag, int, -1>
+{
+public:
+	static UI_TIMESTAMP invalid() { return {}; }
+	static UI_TIMESTAMP never() { return UI_TIMESTAMP(0); }
+	static UI_TIMESTAMP immediate() { return UI_TIMESTAMP(1); }
+
+	UI_TIMESTAMP() = default;
+	explicit UI_TIMESTAMP(int val) : ID(val) { }
+
+	inline bool isNever() const { return m_val == 0; }
+	inline bool isImmediate() const { return m_val == 1; }
+};
+
 
 //==========================================================================
 // This installs the timer services and interrupts at the rate specified by
@@ -101,6 +115,7 @@ inline int timestamp_rand(int a, int b) {
 
 //	Returns milliseconds until timestamp will elapse.
 int timestamp_until(int stamp);
+int ui_timestamp_until(UI_TIMESTAMP stamp);
 
 // checks if a specified time (in milliseconds) has elapsed past the given timestamp (which
 // should be obtained from timestamp() or timestamp(x) with a positive x)

--- a/code/menuui/credits.cpp
+++ b/code/menuui/credits.cpp
@@ -200,7 +200,7 @@ static credits_screen_buttons Buttons[NUM_BUTTONS][GR_NUM_RESOLUTIONS] = {
 
 static char Credits_music_name[NAME_LENGTH];
 static int	Credits_music_handle = -1;
-static int	Credits_music_begin_timestamp;
+static UI_TIMESTAMP	Credits_music_begin_timestamp;
 
 static int	Credits_frametime;		// frametime of credits_do_frame() loop in ms
 static int	Credits_last_time;		// timestamp used to calc frametime (in ms)
@@ -458,7 +458,7 @@ void credits_init()
 	}
 
 	// Use this id to trigger the start of music playing on the briefing screen
-	Credits_music_begin_timestamp = timestamp(Credits_music_delay);
+	Credits_music_begin_timestamp = ui_timestamp(Credits_music_delay);
 
 	Credits_frametime = 0;
 	Credits_last_time = timer_get_milliseconds();
@@ -684,8 +684,8 @@ void credits_do_frame(float  /*frametime*/)
 	int bx2, by2, bw2, bh2;
 
 	// Use this id to trigger the start of music playing on the credits screen
-	if ( timestamp_elapsed(Credits_music_begin_timestamp) ) {
-		Credits_music_begin_timestamp = 0;
+	if ( ui_timestamp_elapsed(Credits_music_begin_timestamp) ) {
+		Credits_music_begin_timestamp = UI_TIMESTAMP::invalid();
 		credits_start_music();
 	}
 

--- a/code/menuui/mainhallmenu.cpp
+++ b/code/menuui/mainhallmenu.cpp
@@ -258,7 +258,7 @@ static int Main_hall_paused = 0;
 #define MAIN_HALL_NOTIFY_TIME	3500
 
 // timestamp for the notification messages
-int Main_hall_notify_stamp = -1;
+UI_TIMESTAMP Main_hall_notify_stamp;
 
 // text to display as the current notification message
 char Main_hall_notify_text[300]="";
@@ -626,7 +626,7 @@ void main_hall_init(const SCP_string &main_hall_name)
 	main_hall_start_music();
 
 	// initialize the main hall notify text
-	Main_hall_notify_stamp = 1;
+	Main_hall_notify_stamp = UI_TIMESTAMP(1);
 
 	// initialize the random intercom sound stuff
 	Main_hall_next_intercom_sound = 0;
@@ -1616,7 +1616,7 @@ void main_hall_handle_random_intercom_sounds()
 void main_hall_set_notify_string(const char *str)
 {
 	strcpy_s(Main_hall_notify_text,str);
-	Main_hall_notify_stamp = timestamp(MAIN_HALL_NOTIFY_TIME);
+	Main_hall_notify_stamp = ui_timestamp(MAIN_HALL_NOTIFY_TIME);
 }
 
 /**
@@ -1625,11 +1625,11 @@ void main_hall_set_notify_string(const char *str)
 void main_hall_notify_do()
 {
 	// check to see if we should try and do something
-	if (Main_hall_notify_stamp != -1) {
+	if (Main_hall_notify_stamp.isValid()) {
 		// if the text time has expired
-		if (timestamp_elapsed(Main_hall_notify_stamp)) {
+		if (ui_timestamp_elapsed(Main_hall_notify_stamp)) {
 			strcpy_s(Main_hall_notify_text,"");
-			Main_hall_notify_stamp = -1;
+			Main_hall_notify_stamp = UI_TIMESTAMP::invalid();
 		} else {
 			int w,h;
 

--- a/code/menuui/mainhallmenu.cpp
+++ b/code/menuui/mainhallmenu.cpp
@@ -626,7 +626,7 @@ void main_hall_init(const SCP_string &main_hall_name)
 	main_hall_start_music();
 
 	// initialize the main hall notify text
-	Main_hall_notify_stamp = UI_TIMESTAMP(1);
+	Main_hall_notify_stamp = UI_TIMESTAMP::immediate();
 
 	// initialize the random intercom sound stuff
 	Main_hall_next_intercom_sound = 0;
@@ -1628,7 +1628,7 @@ void main_hall_notify_do()
 	if (Main_hall_notify_stamp.isValid()) {
 		// if the text time has expired
 		if (ui_timestamp_elapsed(Main_hall_notify_stamp)) {
-			strcpy_s(Main_hall_notify_text,"");
+			strcpy_s(Main_hall_notify_text, "");
 			Main_hall_notify_stamp = UI_TIMESTAMP::invalid();
 		} else {
 			int w,h;

--- a/code/menuui/optionsmenu.cpp
+++ b/code/menuui/optionsmenu.cpp
@@ -243,7 +243,7 @@ static int Music_volume_int;
 static int Voice_volume_int;
 
 static sound_handle Voice_vol_handle = sound_handle::invalid();
-int Options_notify_stamp = -1;
+UI_TIMESTAMP Options_notify_stamp;
 char Options_notify_string[200];
 
 // called whenever accept is hit
@@ -478,16 +478,16 @@ void options_play_voice_clip()
 void options_add_notify(const char *str)
 {
 	strcpy_s(Options_notify_string, str);
-	Options_notify_stamp = timestamp(OPTIONS_NOTIFY_TIME);
+	Options_notify_stamp = ui_timestamp(OPTIONS_NOTIFY_TIME);
 }
 
 void options_notify_do_frame()
 {
 	int w,h;
 
-	if (Options_notify_stamp != -1) {
-		if (timestamp_elapsed(Options_notify_stamp)) {
-			Options_notify_stamp = -1;
+	if (Options_notify_stamp.isValid()) {
+		if (ui_timestamp_elapsed(Options_notify_stamp)) {
+			Options_notify_stamp = UI_TIMESTAMP::invalid();
 
 		} else {
 			gr_get_string_size(&w, &h, Options_notify_string);

--- a/code/menuui/optionsmenumulti.cpp
+++ b/code/menuui/optionsmenumulti.cpp
@@ -70,7 +70,7 @@ int Om_mode = OM_MODE_NONE;
 #define OM_NOTIFY_TIME								8000
 #define OM_NOTIFY_Y									430
 #define OM_NOTIFY_Y2									440
-int Om_notify_stamp = -1;
+UI_TIMESTAMP Om_notify_stamp;
 char Om_notify_string[255];
 
 // load all background bitmaps
@@ -630,7 +630,7 @@ void options_multi_add_notify(const char *str)
 	} 		
 
 	// set the timestamp
-	Om_notify_stamp = timestamp(OM_NOTIFY_TIME);
+	Om_notify_stamp = ui_timestamp(OM_NOTIFY_TIME);
 }
 
 // process and blit any notification messages
@@ -646,13 +646,13 @@ void options_multi_notify_process()
 	int line_height;
 	
 	// if there is no timestamp, do nothing
-	if(Om_notify_stamp == -1){
+	if (!Om_notify_stamp.isValid()){
 		return;
 	}
 
 	// otherwise, if it has elapsed, unset it
-	if(timestamp_elapsed(Om_notify_stamp)){
-		Om_notify_stamp = -1;
+	if (ui_timestamp_elapsed(Om_notify_stamp)){
+		Om_notify_stamp = UI_TIMESTAMP::invalid();
 		return;
 	}
 
@@ -2291,7 +2291,7 @@ void options_multi_select()
 	Om_mode = OM_MODE_GENERAL;
 
 	// clear any notification messages
-	Om_notify_stamp = -1;	
+	Om_notify_stamp = UI_TIMESTAMP::invalid();
 
 	// enable all the protocol controls
 	options_multi_enable_protocol_controls();	

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -3844,7 +3844,7 @@ void process_loadout_objects()
 	}
 }
 
-extern int Multi_ping_timestamp;
+extern UI_TIMESTAMP Multi_ping_timestamp;
 void parse_objects(mission *pm, int flag)
 {	
 	Assert(pm != NULL);
@@ -3872,10 +3872,10 @@ void parse_objects(mission *pm, int flag)
 		//      during this loading process
 		if (Game_mode & GM_MULTIPLAYER)
 		{
-			if ((Multi_ping_timestamp == -1) || (Multi_ping_timestamp <= timer_get_milliseconds()))
+			if (!Multi_ping_timestamp.isValid() || ui_timestamp_elapsed(Multi_ping_timestamp))
 			{
 				multi_ping_send_all();
-				Multi_ping_timestamp = timer_get_milliseconds() + 10000; // timeout is 10 seconds between pings
+				Multi_ping_timestamp = ui_timestamp(10000); // timeout is 10 seconds between pings
 			}
 		}
 	}

--- a/code/missionui/missionbrief.cpp
+++ b/code/missionui/missionbrief.cpp
@@ -74,7 +74,7 @@ static int	Brief_playing_fade_sound;
 hud_anim		Fade_anim;
 
 int	Briefing_music_handle = -1;
-int	Briefing_music_begin_timestamp = 0;
+UI_TIMESTAMP Briefing_music_begin_timestamp;
 
 int Briefing_overlay_id = -1;
 

--- a/code/missionui/missionbrief.h
+++ b/code/missionui/missionbrief.h
@@ -41,7 +41,7 @@ extern UI_INPUTBOX	Common_multi_text_inputbox[3];
 // Sounds
 #define		BRIEFING_MUSIC_DELAY	2500		// 650 ms delay before briefing music starts
 extern int	Briefing_music_handle;
-extern int	Briefing_music_begin_timestamp;
+extern UI_TIMESTAMP	Briefing_music_begin_timestamp;
 
 extern int Briefing_overlay_id;
 

--- a/code/missionui/missionscreencommon.cpp
+++ b/code/missionui/missionscreencommon.cpp
@@ -63,8 +63,8 @@ int Mouse_down_last_frame = 0;
 // Timers used to flash buttons after timeouts
 #define MSC_FLASH_AFTER_TIME	60000		//	time before flashing a button
 #define MSC_FLASH_INTERVAL		200		// time between flashes
-int Flash_timer;								//	timestamp used to start flashing
-int Flash_toggle;								// timestamp used to toggle flashing
+UI_TIMESTAMP Flash_timer;						// timestamp used to start flashing
+UI_TIMESTAMP Flash_toggle;						// timestamp used to toggle flashing
 int Flash_bright;								// state of button to flash
 
 //////////////////////////////////////////////////////////////////
@@ -345,7 +345,7 @@ void common_music_init(int score_index)
 
 	briefing_load_music(file_name.c_str());
 	// Use this id to trigger the start of music playing on the briefing screen
-	Briefing_music_begin_timestamp = timestamp(BRIEFING_MUSIC_DELAY);
+	Briefing_music_begin_timestamp = ui_timestamp(BRIEFING_MUSIC_DELAY);
 }
 
 void common_music_do()
@@ -355,8 +355,8 @@ void common_music_do()
 	}
 
 	// Use this id to trigger the start of music playing on the briefing screen
-	if ( timestamp_elapsed( Briefing_music_begin_timestamp) ) {
-		Briefing_music_begin_timestamp = 0;
+	if ( ui_timestamp_elapsed(Briefing_music_begin_timestamp) ) {
+		Briefing_music_begin_timestamp = UI_TIMESTAMP::invalid();
 		briefing_start_music();
 	}
 }
@@ -457,17 +457,17 @@ void common_free_interface_palette()
 // Init timers used for flashing buttons
 void common_flash_button_init()
 {
-	Flash_timer = timestamp(MSC_FLASH_AFTER_TIME);
-	Flash_toggle = 1;
+	Flash_timer = ui_timestamp(MSC_FLASH_AFTER_TIME);
+	Flash_toggle = UI_TIMESTAMP(1);
 	Flash_bright = 0;
 }
 
 // determine if we should draw a button as bright
 int common_flash_bright()
 {
-	if ( timestamp_elapsed(Flash_timer) ) {
-		if ( timestamp_elapsed(Flash_toggle) ) {
-			Flash_toggle = timestamp(MSC_FLASH_INTERVAL);
+	if ( ui_timestamp_elapsed(Flash_timer) ) {
+		if ( ui_timestamp_elapsed(Flash_toggle) ) {
+			Flash_toggle = ui_timestamp(MSC_FLASH_INTERVAL);
 			Flash_bright ^= 1;
 		}
 	}

--- a/code/missionui/missionscreencommon.cpp
+++ b/code/missionui/missionscreencommon.cpp
@@ -458,7 +458,7 @@ void common_free_interface_palette()
 void common_flash_button_init()
 {
 	Flash_timer = ui_timestamp(MSC_FLASH_AFTER_TIME);
-	Flash_toggle = UI_TIMESTAMP(1);
+	Flash_toggle = UI_TIMESTAMP::immediate();
 	Flash_bright = 0;
 }
 

--- a/code/missionui/missionscreencommon.h
+++ b/code/missionui/missionscreencommon.h
@@ -64,8 +64,8 @@ extern int Mouse_down_last_frame;
 extern int Wing_slot_empty_bitmap;
 extern int Wing_slot_disabled_bitmap;
 
-extern int Flash_timer;				//	timestamp used to start flashing
-extern int Flash_toggle;			// timestamp used to toggle flashing
+extern UI_TIMESTAMP Flash_timer;	// timestamp used to start flashing
+extern UI_TIMESTAMP Flash_toggle;	// timestamp used to toggle flashing
 extern int Flash_bright;			// state of button to flash
 
 void common_button_do(int i);

--- a/code/missionui/missionweaponchoice.cpp
+++ b/code/missionui/missionweaponchoice.cpp
@@ -50,8 +50,6 @@
 #define IS_LIST_PRIMARY(x)			(Weapon_info[x].subtype != WP_MISSILE)
 #define IS_LIST_SECONDARY(x)		(Weapon_info[x].subtype == WP_MISSILE)
 
-extern int Multi_ping_timestamp;
-
 //////////////////////////////////////////////////////////////////
 // Game-wide globals
 //////////////////////////////////////////////////////////////////

--- a/code/missionui/redalert.cpp
+++ b/code/missionui/redalert.cpp
@@ -126,7 +126,7 @@ UI_XSTR Red_alert_text[GR_NUM_RESOLUTIONS][RED_ALERT_NUM_TEXT] = {
 #define RA_H_COORD 3
 
 
-static int Text_delay;
+static UI_TIMESTAMP Text_delay;
 
 int Ra_brief_text_wnd_coords[GR_NUM_RESOLUTIONS][4] = {
 	{
@@ -353,7 +353,7 @@ void red_alert_init()
 
 	red_alert_voice_load();
 
-	Text_delay = timestamp(200);
+	Text_delay = ui_timestamp(200);
 
 	Red_alert_voice_started = 0;
 	Red_alert_inited = 1;
@@ -434,7 +434,7 @@ void red_alert_do_frame(float frametime)
 
 	font::set_font(font::FONT1);
 
-	if ( timestamp_elapsed(Text_delay) ) {
+	if ( ui_timestamp_elapsed(Text_delay) ) {
 		int finished_wipe = 0;
 		if ( Briefing->num_stages > 0 ) {
 			finished_wipe = brief_render_text(0, Ra_brief_text_wnd_coords[gr_screen.res][RA_X_COORD], Ra_brief_text_wnd_coords[gr_screen.res][RA_Y_COORD], Ra_brief_text_wnd_coords[gr_screen.res][RA_H_COORD], frametime, 0);

--- a/code/network/multi_pxo.cpp
+++ b/code/network/multi_pxo.cpp
@@ -912,7 +912,7 @@ void multi_pxo_run_medals();
 #define MULTI_PXO_NOTIFY_Y					435
 
 char Multi_pxo_notify_text[MAX_PXO_TEXT_LEN];
-int Multi_pxo_notify_stamp = -1;
+UI_TIMESTAMP Multi_pxo_notify_stamp;
 
 // add a notification string
 void multi_pxo_notify_add(const char *txt);
@@ -4873,7 +4873,7 @@ void multi_pxo_notify_add(const char *txt)
 	strcpy_s(Multi_pxo_notify_text, txt);
 
 	// set the timestamp
-	Multi_pxo_notify_stamp = timestamp(MULTI_PXO_NOTIFY_TIME);
+	Multi_pxo_notify_stamp = ui_timestamp(MULTI_PXO_NOTIFY_TIME);
 }
 
 /**
@@ -4884,13 +4884,13 @@ void multi_pxo_notify_blit()
 	int w;
 
 	// if the timestamp is -1, do nothing
-	if(Multi_pxo_notify_stamp == -1){
+	if (!Multi_pxo_notify_stamp.isValid()){
 		return;
 	}
 
 	// if it has expired, do nothing
-	if(timestamp_elapsed(Multi_pxo_notify_stamp)){
-		Multi_pxo_notify_stamp = -1;
+	if (ui_timestamp_elapsed(Multi_pxo_notify_stamp)){
+		Multi_pxo_notify_stamp = UI_TIMESTAMP::invalid();
 	}
 
 	// otherwise blit the text

--- a/code/network/multiui.cpp
+++ b/code/network/multiui.cpp
@@ -292,12 +292,12 @@ int Multi_common_msg_y[GR_NUM_RESOLUTIONS] = {
 };
 
 char Multi_common_notify_text[200];
-int Multi_common_notify_stamp;
+UI_TIMESTAMP Multi_common_notify_stamp;
 
 void multi_common_notify_init()
 {
 	strcpy_s(Multi_common_notify_text,"");
-	Multi_common_notify_stamp = -1;
+	Multi_common_notify_stamp = UI_TIMESTAMP::invalid();
 }
 
 // add a notification string, drawing appropriately depending on the state/screen we're in
@@ -305,16 +305,16 @@ void multi_common_add_notify(const char *str)
 {
 	if(str){
 		strcpy_s(Multi_common_notify_text,str);
-		Multi_common_notify_stamp = timestamp(MULTI_COMMON_NOTIFY_TIME);
+		Multi_common_notify_stamp = ui_timestamp(MULTI_COMMON_NOTIFY_TIME);
 	}
 }
 
 // process/display notification messages
 void multi_common_notify_do()
 {
-	if(Multi_common_notify_stamp != -1){
-		if(timestamp_elapsed(Multi_common_notify_stamp)){
-			Multi_common_notify_stamp = -1;
+	if (Multi_common_notify_stamp.isValid()){
+		if (ui_timestamp_elapsed(Multi_common_notify_stamp)){
+			Multi_common_notify_stamp = UI_TIMESTAMP::invalid();
 		} else {
 			int w,h,y;
 			gr_get_string_size(&w,&h,Multi_common_notify_text);

--- a/code/network/multiutil.cpp
+++ b/code/network/multiutil.cpp
@@ -82,7 +82,7 @@
 extern int ascii_table[];
 extern int shifted_ascii_table[];
 
-extern int Multi_ping_timestamp;
+extern UI_TIMESTAMP Multi_ping_timestamp;
 
 // network object management
 ushort Next_ship_signature;										// next permanent network signature to assign to an object
@@ -4009,9 +4009,9 @@ void send_debrief_event() {
 void multi_send_anti_timeout_ping()
 {
 	if (Game_mode & GM_MULTIPLAYER) {
-		if ( (Multi_ping_timestamp == -1) || (Multi_ping_timestamp <= timer_get_milliseconds()) ) {
+		if (!Multi_ping_timestamp.isValid() || ui_timestamp_elapsed(Multi_ping_timestamp)) {
 			multi_ping_send_all();
-			Multi_ping_timestamp = timer_get_milliseconds() + 10000; // timeout is 10 seconds between pings
+			Multi_ping_timestamp = ui_timestamp(10000); // timeout is 10 seconds between pings
 		}
 	}
 }

--- a/code/network/stand_gui.cpp
+++ b/code/network/stand_gui.cpp
@@ -92,10 +92,10 @@ static PROPSHEETHEADER Sheet;
 static int Active_standalone_page;
 
 // timestamp for updating currently selected player stats on the player info page
-int Standalone_stats_stamp;
+UI_TIMESTAMP Standalone_stats_stamp;
 
 // timestamp for updating the netgame information are text controls
-int Standalone_ng_stamp;
+UI_TIMESTAMP Standalone_ng_stamp;
 
 // banned player callsigns
 #define STANDALONE_MAX_BAN			50
@@ -1730,10 +1730,10 @@ void std_reset_standalone_gui()
 	std_multi_set_standalone_missiontime((float)0);	
 
 	// reset the stats update timestamp
-	Standalone_stats_stamp = -1;
+	Standalone_stats_stamp = UI_TIMESTAMP::invalid();
 
 	// reset the netgame info timestamp
-	Standalone_ng_stamp = -1;	
+	Standalone_ng_stamp = UI_TIMESTAMP::invalid();
 }
 
 // do any gui related issues on the standalone (like periodically updating player stats, etc...)
@@ -1743,9 +1743,9 @@ void std_do_gui_frame()
 	int idx;
 	
 	// check to see if the timestamp for updating player selected stats has popped
-	if((Standalone_stats_stamp == -1) || timestamp_elapsed(Standalone_stats_stamp)){
+	if (!Standalone_stats_stamp.isValid() || ui_timestamp_elapsed(Standalone_stats_stamp)){
 		// reset the timestamp
-		Standalone_stats_stamp = timestamp(STD_STATS_UPDATE_TIME);
+		Standalone_stats_stamp = ui_timestamp(STD_STATS_UPDATE_TIME);
 
 		// update any player currently selected
 		// there's probably a nicer way to do this, but...
@@ -1759,9 +1759,9 @@ void std_do_gui_frame()
 	}
 
 	// check to see if the timestamp for updating the netgame information controls has popped
-	if((Standalone_ng_stamp == -1) || timestamp_elapsed(Standalone_ng_stamp)){
+	if (!Standalone_ng_stamp.isValid() || ui_timestamp_elapsed(Standalone_ng_stamp)){
 		// reset the timestamp
-		Standalone_ng_stamp = timestamp(STD_NG_UPDATE_TIME);
+		Standalone_ng_stamp = ui_timestamp(STD_NG_UPDATE_TIME);
 
 		// update the controls
 		std_multi_update_netgame_info_controls();
@@ -1794,10 +1794,10 @@ void std_tracker_login()
 void std_reset_timestamps()
 {
 	// reset the stats update stamp
-	Standalone_stats_stamp = timestamp(STD_STATS_UPDATE_TIME);
+	Standalone_stats_stamp = ui_timestamp(STD_STATS_UPDATE_TIME);
 
 	// reset the netgame controls update timestamp
-	Standalone_ng_stamp = timestamp(STD_NG_UPDATE_TIME);
+	Standalone_ng_stamp = ui_timestamp(STD_NG_UPDATE_TIME);
 }
 
 // add a line of text chat to the standalone

--- a/code/popup/popupdead.cpp
+++ b/code/popup/popupdead.cpp
@@ -123,7 +123,7 @@ int Popupdead_multi_type;			// what kind of popup is active for muliplayer
 int Popupdead_skip_active = 0;	// The skip-misison popup is active
 int Popupdead_skip_already_shown = 0;
 
-int Popupdead_timer;
+UI_TIMESTAMP Popupdead_timer;
 
 extern int Cmdline_mpnoreturn;
 // Initialize the dead popup data
@@ -148,7 +148,7 @@ void popupdead_start()
 	Popupdead_multi_type = -1;
 
 	if ((The_mission.max_respawn_delay >= 0) && ( Game_mode & GM_MULTIPLAYER )) {
-		Popupdead_timer = timestamp(The_mission.max_respawn_delay * 1000); 
+		Popupdead_timer = ui_timestamp(The_mission.max_respawn_delay * 1000); 
 		if (Game_mode & GM_MULTIPLAYER) {
 			if(!(Net_player->flags & NETINFO_FLAG_LIMBO)){
 				if (The_mission.max_respawn_delay) {
@@ -490,7 +490,7 @@ int popupdead_do_frame(float  /*frametime*/)
 	popupdead_draw_button_text();
 
 	// maybe force the player to respawn if they've taken too long to choose
-	if (( Game_mode & GM_MULTIPLAYER ) && (The_mission.max_respawn_delay >= 0) && (timestamp_elapsed(Popupdead_timer)) && (choice < 0)) {
+	if (( Game_mode & GM_MULTIPLAYER ) && (The_mission.max_respawn_delay >= 0) && (ui_timestamp_elapsed(Popupdead_timer)) && (choice < 0)) {
 		if (( Popupdead_multi_type == POPUPDEAD_RESPAWN_ONLY) || ( Popupdead_multi_type == POPUPDEAD_RESPAWN_QUIT)) {
 			Popupdead_choice = POPUPDEAD_DO_RESPAWN; 
 		}

--- a/code/ui/button.cpp
+++ b/code/ui/button.cpp
@@ -38,15 +38,15 @@ void UI_BUTTON::create(UI_WINDOW *wnd, const char *_text, int _x, int _y, int _w
 
 	// initialize variables
 	m_flags = 0;
-	next_repeat = 0;
+	next_repeat = UI_TIMESTAMP::invalid();
 	m_just_highlighted_function = NULL;		// assume there is no callback
 	m_disabled_function = NULL;				// ditto
 	if (do_repeat) {
 		m_flags |= BF_REPEATS;
-		next_repeat = 1;
+		next_repeat = UI_TIMESTAMP(1);
 	}
 
-	m_press_linger = 1;
+	m_press_linger = UI_TIMESTAMP(1);
 	first_callback = 1;
 
 	hotkey_if_focus = KEY_SPACEBAR;
@@ -232,7 +232,7 @@ void UI_BUTTON::process(int focus)
 	maybe_show_custom_cursor();
 
 	if ( !mouse_on_me ) {
-		next_repeat = 0;
+		next_repeat = UI_TIMESTAMP::invalid();
 	} else {
 		m_flags |= BF_HIGHLIGHTED;
 		if ( !(old_flags & BF_HIGHLIGHTED) ) {
@@ -280,7 +280,7 @@ void UI_BUTTON::process(int focus)
 
 	// handler for button not down
 	if ( !(m_flags & BF_DOWN) ) {
-		next_repeat = 0;
+		next_repeat = UI_TIMESTAMP::invalid();
 		if ( (old_flags & BF_DOWN) && !(old_flags & BF_CLICKED) )  // check for release of mouse, not hotkey
 			m_flags |= BF_JUST_RELEASED;
 
@@ -296,27 +296,27 @@ void UI_BUTTON::process(int focus)
 	// check if button just went down this frame
 	if ( !(old_flags & BF_DOWN) ) {
 		m_flags |= BF_JUST_PRESSED;
-		m_press_linger = timestamp(100);
+		m_press_linger = ui_timestamp(100);
 		if (user_function)
 			user_function();
 
 		if (m_flags & BF_REPEATS) {
-			next_repeat = timestamp(B_REPEAT_TIME * 3);
+			next_repeat = ui_timestamp(B_REPEAT_TIME * 3);
 			m_flags |= BF_CLICKED;
 		}
 	}
 
 	// check if a repeat event should occur
-	if ( timestamp_elapsed(next_repeat) && (m_flags & BF_REPEATS) ) {
-		next_repeat = timestamp(B_REPEAT_TIME);
+	if ( ui_timestamp_elapsed(next_repeat) && (m_flags & BF_REPEATS) ) {
+		next_repeat = ui_timestamp(B_REPEAT_TIME);
 		m_flags |= BF_CLICKED;
-		m_press_linger = timestamp(100);
+		m_press_linger = ui_timestamp(100);
 	}
 
 	// check for double click occurance
 	if (B1_DOUBLE_CLICKED && mouse_on_me) {
 		m_flags |= BF_DOUBLE_CLICKED;
-		m_press_linger = timestamp(100);
+		m_press_linger = ui_timestamp(100);
 	}
 }
 
@@ -362,7 +362,7 @@ int UI_BUTTON::just_highlighted()
 // how the button is being drawn, if you want to think of it that way.
 int UI_BUTTON::button_down()
 {
-	if ( (m_flags & BF_DOWN) || !timestamp_elapsed(m_press_linger) )
+	if ( (m_flags & BF_DOWN) || !ui_timestamp_elapsed(m_press_linger) )
 		return TRUE;
 	else
  		return FALSE;
@@ -407,8 +407,8 @@ void UI_BUTTON::press_button()
 // reset the "pressed" timestamps
 void UI_BUTTON::reset_timestamps()
 {
-	m_press_linger = 1;
-	next_repeat = 0;
+	m_press_linger = UI_TIMESTAMP(1);
+	next_repeat = UI_TIMESTAMP::invalid();
 }
 
 void UI_BUTTON::skip_first_highlight_callback()
@@ -421,10 +421,10 @@ void UI_BUTTON::repeatable(int yes)
 {
 	if(yes){
 		m_flags |= BF_REPEATS;
-		next_repeat = 1;
+		next_repeat = UI_TIMESTAMP(1);
 	} else {
 		m_flags &= ~(BF_REPEATS);
-		next_repeat = 0;
+		next_repeat = UI_TIMESTAMP::invalid();
 	}
 }
 

--- a/code/ui/button.cpp
+++ b/code/ui/button.cpp
@@ -38,15 +38,15 @@ void UI_BUTTON::create(UI_WINDOW *wnd, const char *_text, int _x, int _y, int _w
 
 	// initialize variables
 	m_flags = 0;
-	next_repeat = UI_TIMESTAMP::invalid();
+	next_repeat = UI_TIMESTAMP::never();
 	m_just_highlighted_function = NULL;		// assume there is no callback
 	m_disabled_function = NULL;				// ditto
 	if (do_repeat) {
 		m_flags |= BF_REPEATS;
-		next_repeat = UI_TIMESTAMP(1);
+		next_repeat = UI_TIMESTAMP::immediate();
 	}
 
-	m_press_linger = UI_TIMESTAMP(1);
+	m_press_linger = UI_TIMESTAMP::immediate();
 	first_callback = 1;
 
 	hotkey_if_focus = KEY_SPACEBAR;
@@ -232,7 +232,7 @@ void UI_BUTTON::process(int focus)
 	maybe_show_custom_cursor();
 
 	if ( !mouse_on_me ) {
-		next_repeat = UI_TIMESTAMP::invalid();
+		next_repeat = UI_TIMESTAMP::never();
 	} else {
 		m_flags |= BF_HIGHLIGHTED;
 		if ( !(old_flags & BF_HIGHLIGHTED) ) {
@@ -280,7 +280,7 @@ void UI_BUTTON::process(int focus)
 
 	// handler for button not down
 	if ( !(m_flags & BF_DOWN) ) {
-		next_repeat = UI_TIMESTAMP::invalid();
+		next_repeat = UI_TIMESTAMP::never();
 		if ( (old_flags & BF_DOWN) && !(old_flags & BF_CLICKED) )  // check for release of mouse, not hotkey
 			m_flags |= BF_JUST_RELEASED;
 
@@ -407,8 +407,8 @@ void UI_BUTTON::press_button()
 // reset the "pressed" timestamps
 void UI_BUTTON::reset_timestamps()
 {
-	m_press_linger = UI_TIMESTAMP(1);
-	next_repeat = UI_TIMESTAMP::invalid();
+	m_press_linger = UI_TIMESTAMP::immediate();
+	next_repeat = UI_TIMESTAMP::never();
 }
 
 void UI_BUTTON::skip_first_highlight_callback()
@@ -421,10 +421,10 @@ void UI_BUTTON::repeatable(int yes)
 {
 	if(yes){
 		m_flags |= BF_REPEATS;
-		next_repeat = UI_TIMESTAMP(1);
+		next_repeat = UI_TIMESTAMP::immediate();
 	} else {
 		m_flags &= ~(BF_REPEATS);
-		next_repeat = UI_TIMESTAMP::invalid();
+		next_repeat = UI_TIMESTAMP::never();
 	}
 }
 

--- a/code/ui/ui.h
+++ b/code/ui/ui.h
@@ -203,8 +203,8 @@ class UI_BUTTON : public UI_GADGET
 
 		char *text;
 		int position;			// indicates position of button (0 - up, 1 - down by mouse click 2 - down by keypress
-		int next_repeat;		// timestamp for next repeat if held down
-		int m_press_linger;	// timestamp for hold a pressed state animation
+		UI_TIMESTAMP next_repeat;		// timestamp for next repeat if held down
+		UI_TIMESTAMP m_press_linger;	// timestamp for hold a pressed state animation
 		int hotkey_if_focus;	// hotkey for button that only works if it has focus
 		int force_draw_frame;	// frame number to draw next time (override default)
 		int first_callback;		// true until first time callback function is called for button highlight

--- a/code/utils/id.h
+++ b/code/utils/id.h
@@ -48,7 +48,7 @@ public:
 
 	inline bool isValid() const { return m_val != default_value; }
 
-private:
+protected:
 	Impl m_val;
 };
 

--- a/fred2/fredstubs.cpp
+++ b/fred2/fredstubs.cpp
@@ -27,7 +27,7 @@ char Game_current_mission_filename[MAX_FILENAME_LEN];
 CFILE *Working_demo;
 struct beam_info;
 bool Env_cubemap_drawn = false;
-int Multi_ping_timestamp = -1;
+UI_TIMESTAMP Multi_ping_timestamp;
 int Sun_drew = 0;
 
 bool running_unittests = false;

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -346,9 +346,9 @@ extern void ssm_process();
 
 // amount of time to wait after the player has died before we display the death died popup
 #define PLAYER_DIED_POPUP_WAIT		2500
-int Player_died_popup_wait = -1;
+UI_TIMESTAMP Player_died_popup_wait;
 
-int Multi_ping_timestamp = -1;
+UI_TIMESTAMP Multi_ping_timestamp;
 
 
 const auto OnMissionAboutToEndHook = scripting::Hook::Factory(
@@ -966,7 +966,7 @@ void game_level_init()
 	// Initialize the game subsystems
 	game_time_level_init();
 
-	Multi_ping_timestamp = -1;
+	Multi_ping_timestamp = UI_TIMESTAMP::invalid();
 
 	obj_init();						// Must be inited before the other systems
 
@@ -4068,13 +4068,13 @@ void game_frame(bool paused)
 					if(Net_player->flags & NETINFO_FLAG_WARPING_OUT){
 						multi_handle_sudden_mission_end();
 						send_debrief_event();
-					} else if((Player_died_popup_wait != -1) && (timestamp_elapsed(Player_died_popup_wait))){
-						Player_died_popup_wait = -1;
+					} else if (Player_died_popup_wait.isValid() && ui_timestamp_elapsed(Player_died_popup_wait)) {
+						Player_died_popup_wait = UI_TIMESTAMP::invalid();
 						popupdead_start();
 					}
 				} else {
-					if((Player_died_popup_wait != -1) && (timestamp_elapsed(Player_died_popup_wait))){
-						Player_died_popup_wait = -1;
+					if (Player_died_popup_wait.isValid() && ui_timestamp_elapsed(Player_died_popup_wait)) {
+						Player_died_popup_wait = UI_TIMESTAMP::invalid();
 						popupdead_start();
 					}
 				}
@@ -5942,7 +5942,7 @@ void mouse_force_pos(int x, int y);
 
 			// timestamp how long we should wait before displaying the died popup
 			if ( !popupdead_is_active() ) {
-				Player_died_popup_wait = timestamp(PLAYER_DIED_POPUP_WAIT);
+				Player_died_popup_wait = ui_timestamp(PLAYER_DIED_POPUP_WAIT);
 			}
 			break;
 

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -1357,9 +1357,6 @@ void game_post_level_init()
 
 	mission_process_alt_types();
 
-	// Now that loading is complete, resume time so that timestamps used in the briefing screens will work
-	game_start_time();
-
 	// m!m Make hv.Player available in "On Mission Start" hook
 	if(Player_obj)
 		Script_system.SetHookObject("Player", Player_obj);
@@ -4352,11 +4349,6 @@ void game_update_missiontime()
 
 void game_do_frame(bool set_frametime)
 {
-	if (Missiontime == 0) {
-		// reset the timestamps to the beginning, since they were running in the briefing screens
-		timestamp_revert_to_mission_start();
-	}
-
 	if (set_frametime) {
 		game_set_frametime(GS_STATE_GAME_PLAY);
 	}

--- a/qtfred/src/fredstubs.cpp
+++ b/qtfred/src/fredstubs.cpp
@@ -31,7 +31,7 @@ char Game_current_mission_filename[MAX_FILENAME_LEN];
 CFILE *Working_demo;
 struct beam_info;
 bool Env_cubemap_drawn = false;
-int Multi_ping_timestamp = -1;
+UI_TIMESTAMP Multi_ping_timestamp;
 int Sun_drew = 0;
 float Sun_spot = 0.0f;
 bool running_unittests = false;

--- a/test/src/test_stubs.cpp
+++ b/test/src/test_stubs.cpp
@@ -29,7 +29,7 @@ char Game_current_mission_filename[MAX_FILENAME_LEN];
 CFILE *Working_demo;
 struct beam_info;
 bool Env_cubemap_drawn = false;
-int Multi_ping_timestamp = -1;
+UI_TIMESTAMP Multi_ping_timestamp;
 int Sun_drew = 0;
 
 int Fred_running = 0;


### PR DESCRIPTION
This adds `UI_TIMESTAMP` which is a real-time timestamp not subject to time compression or pauses.  It is meant to be used in the UI and in other situations where the code needs the actual elapsed time.  It also uses the "strong typedef" pattern pioneered by `gamesnd_id` so that they cannot be mixed up with integers nor interchanged with standard timestamps.  (Doing the same thing with standard timestamps would be a good future upgrade.)

Various UI-related timing functions, including briefing, debriefing, and credits delays, as well as button and cursor delays, have been switched over to `UI_TIMESTAMP`.  This fixes #3955.

Additionally, now that timestamps no longer need to run during briefings, the standard timestamp can be kept paused from initialization until mission start.  This fixes #4016.