### PR TITLE
a few scripting bugfixes

### DIFF
--- a/code/scripting/api/objs/camera.cpp
+++ b/code/scripting/api/objs/camera.cpp
@@ -123,7 +123,7 @@ ADE_VIRTVAR(Self, l_Camera, "object", "New mount object", "object", "Camera obje
 		cid.getCamera()->set_object_host(oh->objp);
 	}
 
-	return ade_set_args(L, "o", l_Object.Set(object_h(cid.getCamera()->get_object_host())));
+	return ade_set_object_with_breed(L, OBJ_INDEX(cid.getCamera()->get_object_host()));
 }
 
 ADE_VIRTVAR(SelfSubsystem, l_Camera, "subsystem", "New mount object subsystem", "subsystem", "Subsystem that the camera is mounted on")
@@ -178,7 +178,7 @@ ADE_VIRTVAR(Target, l_Camera, "object", "New target object", "object", "Camera t
 		cid.getCamera()->set_object_target(oh->objp);
 	}
 
-	return ade_set_args(L, "o", l_Object.Set(object_h(cid.getCamera()->get_object_target())));
+	return ade_set_object_with_breed(L, OBJ_INDEX(cid.getCamera()->get_object_target()));
 }
 
 ADE_VIRTVAR(TargetSubsystem, l_Camera, "subsystem", "New target subsystem", "subsystem", "Subsystem that the camera is pointed at")

--- a/code/scripting/api/objs/particle.cpp
+++ b/code/scripting/api/objs/particle.cpp
@@ -173,7 +173,7 @@ ADE_VIRTVAR(TracerLength, l_Particle, "number", "The tracer legth of the particl
 	return ade_set_args(L, "f", -1.0f);
 }
 
-ADE_VIRTVAR(AttachedObject, l_Particle, "object", "The object this particle is attached to. If valid the position will be relativ to this object and the velocity will be ignored.", "object", "Attached object or invalid object handle on error")
+ADE_VIRTVAR(AttachedObject, l_Particle, "object", "The object this particle is attached to. If valid the position will be relative to this object and the velocity will be ignored.", "object", "Attached object or invalid object handle on error")
 {
 	particle_h *ph = NULL;
 	object_h *newObj = nullptr;
@@ -192,7 +192,7 @@ ADE_VIRTVAR(AttachedObject, l_Particle, "object", "The object this particle is a
 			ph->Get().lock()->attached_objnum = newObj->objp->signature;
 	}
 
-	return ade_set_args(L, "o", l_Object.Set(object_h(&Objects[ph->Get().lock()->attached_objnum])));
+	return ade_set_object_with_breed(L, ph->Get().lock()->attached_objnum);
 }
 
 ADE_FUNC(isValid, l_Particle, NULL, "Detects whether this handle is valid", "boolean", "true if valid false if not")

--- a/code/scripting/api/objs/streaminganim.cpp
+++ b/code/scripting/api/objs/streaminganim.cpp
@@ -195,13 +195,13 @@ ADE_FUNC(getWidth, l_streaminganim, nullptr, "Get the width of the animation in 
 	return ade_set_args(L, "i", sah->ga.width);
 }
 
-ADE_FUNC(isValid, l_streaminganim, NULL, "Detects whether handle is valid", "boolean", "true if valid, false if handle is invalid, nil if a syntax/type error occurs")
+ADE_FUNC(isValid, l_streaminganim, nullptr, "Detects whether handle is valid", "boolean", "true if valid, false if handle is invalid, nil if a syntax/type error occurs")
 {
 	streaminganim_h* sah;
 	if(!ade_get_args(L, "o", l_streaminganim.GetPtr(&sah)))
 		return ADE_RETURN_NIL;
 
-	return sah->IsValid();
+	return ade_set_args(L, "b", sah->IsValid());
 }
 
 ADE_FUNC(preload, l_streaminganim, NULL, "Load all apng animations into memory, enabling apng frame cache if not already enabled", "boolean", "true if preload was successful, nil if a syntax/type error occurs")

--- a/code/scripting/api/objs/subsystem.cpp
+++ b/code/scripting/api/objs/subsystem.cpp
@@ -746,7 +746,7 @@ ADE_FUNC(getParent, l_Subsystem, NULL, "The object parent of this subsystem, is 
 	if (!sso->isSubsystemValid())
 		return ade_set_error(L, "o", l_Object.Set(object_h()));
 
-	return ade_set_args(L, "o", l_Object.Set(object_h(sso->objp)));
+	return ade_set_object_with_breed(L, OBJ_INDEX(sso->objp));
 }
 
 ADE_FUNC(isInViewFrom, l_Subsystem, "vector from",


### PR DESCRIPTION
When returning objects, be sure to use `ade_set_object_with_breed`, per the documentation on that function.  This ensures that all relevant subclass information can be used (e.g. for ships, the `.Name` virtvar).

Also fix the return value of streaminganim's isValid() function.