### PR TITLE
clean up model point/dir/normal/orient functions

### DIFF
--- a/code/actions/types/ParticleEffectAction.cpp
+++ b/code/actions/types/ParticleEffectAction.cpp
@@ -43,13 +43,13 @@ ActionResult ParticleEffectAction::execute(ProgramLocals& locals) const
 		auto pmi = model_get_instance(instance);
 		auto pm = model_get(pmi->model_num);
 
-		find_submodel_instance_point_orient(&local_pos,
+		model_instance_find_world_point_orient(&local_pos,
 			&local_orient,
+			&locals.localPosition,
+			&locals.localOrient,
 			pm,
 			pmi,
-			locals.hostSubobject,
-			&locals.localPosition,
-			&locals.localOrient);
+			locals.hostSubobject);
 	} else {
 		local_pos = locals.localPosition;
 		local_orient = locals.localOrient;

--- a/code/actions/types/PlaySoundAction.cpp
+++ b/code/actions/types/PlaySoundAction.cpp
@@ -32,13 +32,13 @@ ActionResult PlaySoundAction::execute(ProgramLocals& locals) const
 		auto pmi = model_get_instance(instance);
 		auto pm = model_get(pmi->model_num);
 
-		find_submodel_instance_point_orient(&local_pos,
+		model_instance_find_world_point_orient(&local_pos,
 			&local_orient,
+			&locals.localPosition,
+			&locals.localOrient,
 			pm,
 			pmi,
-			locals.hostSubobject,
-			&locals.localPosition,
-			&locals.localOrient);
+			locals.hostSubobject);
 	} else {
 		local_pos = locals.localPosition;
 		local_orient = locals.localOrient;

--- a/code/camera/camera.cpp
+++ b/code/camera/camera.cpp
@@ -366,7 +366,7 @@ void camera::get_info(vec3d *position, matrix *orientation, bool apply_camera_or
 					Assertion(objp->type == OBJ_SHIP, "This part of the code expects the object to be a ship");
 
 					vec3d c_pos_in;
-					find_submodel_instance_point_normal(&c_pos_in, &host_normal, pm, pmi, eyep->parent, &eyep->pnt, &eyep->norm);
+					model_instance_find_world_point_normal(&c_pos_in, &host_normal, &eyep->pnt, &eyep->norm, pm, pmi, eyep->parent);
 					vm_vec_unrotate(&c_pos, &c_pos_in, &objp->orient);
 					vm_vec_add2(&c_pos, &objp->pos);
 				}
@@ -374,14 +374,8 @@ void camera::get_info(vec3d *position, matrix *orientation, bool apply_camera_or
 				{
 					if (pmi != nullptr)
 					{
-						vec3d c_pos_in;
-						find_submodel_instance_point_orient(&c_pos_in, &host_orient, pm, pmi, object_host_submodel, &pt, &vmd_identity_matrix);
-
-						host_orient = host_orient * objp->orient;
+						model_instance_find_world_point_orient(&c_pos, &host_orient, &pt, &vmd_identity_matrix, pm, pmi, object_host_submodel, &objp->orient, &objp->pos);
 						use_host_orient = true;
-
-						vm_vec_unrotate(&c_pos, &c_pos_in, &objp->orient);
-						vm_vec_add2(&c_pos, &objp->pos);
 					}
 					else
 						model_find_world_point( &c_pos, &pt, pm, object_host_submodel, &objp->orient, &objp->pos );

--- a/code/model/model.h
+++ b/code/model/model.h
@@ -958,20 +958,30 @@ extern void model_find_submodel_offset(vec3d *outpnt, const polymodel *pm, int s
 // Given a point (pnt) that is in sub_model_num's frame of
 // reference, and given the object's orient and position, 
 // return the point in 3-space in outpnt.
-extern void model_find_world_point(vec3d *outpnt, vec3d *mpnt, int model_num, int submodel_num, const matrix *objorient, const vec3d *objpos);
-extern void model_instance_find_world_point(vec3d *outpnt, vec3d *mpnt, int model_instance_num, int submodel_num, const matrix *objorient, const vec3d *objpos);
-extern void model_find_world_point(vec3d *outpnt, vec3d *mpnt, const polymodel *pm, int submodel_num, const matrix *objorient, const vec3d *objpos);
-extern void model_instance_find_world_point(vec3d *outpnt, vec3d *mpnt, const polymodel *pm, const polymodel_instance *pmi, int submodel_num, const matrix *objorient, const vec3d *objpos);
+// Or, if the orient or position is nullptr,
+// return the point in the model's reference frame.
+extern void model_find_world_point(vec3d *outpnt, const vec3d *mpnt, int model_num, int submodel_num, const matrix *objorient = nullptr, const vec3d *objpos = nullptr);
+extern void model_find_world_point(vec3d *outpnt, const vec3d *mpnt, const polymodel *pm, int submodel_num, const matrix *objorient = nullptr, const vec3d *objpos = nullptr);
+extern void model_instance_find_world_point(vec3d *outpnt, const vec3d *mpnt, int model_instance_num, int submodel_num, const matrix *objorient = nullptr, const vec3d *objpos = nullptr);
+extern void model_instance_find_world_point(vec3d *outpnt, const vec3d *mpnt, const polymodel *pm, const polymodel_instance *pmi, int submodel_num, const matrix *objorient = nullptr, const vec3d *objpos = nullptr);
+
+// Given a direction (pnt) that is in sub_model_num's frame of
+// reference, and given the object's orient and position, 
+// return the direction in 3-space in outpnt.
+// Or, if the orient or position is nullptr,
+// return the direction in the model's reference frame.
+extern void model_find_world_dir(vec3d *out_dir, const vec3d *in_dir, int model_num, int submodel_num, const matrix *objorient = nullptr);
+extern void model_find_world_dir(vec3d *out_dir, const vec3d *in_dir, const polymodel *pm, int submodel_num, const matrix *objorient = nullptr);
+extern void model_instance_find_world_dir(vec3d *out_dir, const vec3d *in_dir, int model_instance_num, int submodel_num, const matrix *objorient = nullptr, bool use_submodel_parent = false);
+extern void model_instance_find_world_dir(vec3d *out_dir, const vec3d *in_dir, const polymodel *pm, const polymodel_instance *pmi, int submodel_num, const matrix *objorient = nullptr);
 
 // Given a point in the world RF, find the corresponding point in the model RF.
 // This is special purpose code, specific for model collision.
 // NOTE - this code ASSUMES submodel is 1 level down from hull (detail[0])
 void world_find_model_instance_point(vec3d *out, vec3d *world_pt, const polymodel *pm, const polymodel_instance *pmi, int submodel_num, const matrix *orient, const vec3d *pos);
 
-extern void find_submodel_instance_point(vec3d *outpnt, const polymodel *pm, const polymodel_instance *pmi, int submodel_num);
-extern void find_submodel_instance_point_normal(vec3d *outpnt, vec3d *outnorm, const polymodel *pm, const polymodel_instance *pmi, int submodel_num, const vec3d *submodel_pnt, const vec3d *submodel_norm);
-extern void find_submodel_instance_point_orient(vec3d *outpnt, matrix *outorient, const polymodel *pm, const polymodel_instance *pmi, int submodel_num, const vec3d *submodel_pnt, const matrix *submodel_orient);
-extern void find_submodel_instance_world_point(vec3d *outpnt, const polymodel *pm, const polymodel_instance *pmi, int submodel_num, const matrix *objorient, const vec3d *objpos);
+extern void model_instance_find_world_point_normal(vec3d *outpnt, vec3d *outnorm, const vec3d *submodel_pnt, const vec3d *submodel_norm, const polymodel *pm, const polymodel_instance *pmi, int submodel_num, const matrix *objorient = nullptr, const vec3d *objpos = nullptr);
+extern void model_instance_find_world_point_orient(vec3d *outpnt, matrix *outorient, const vec3d *submodel_pnt, const matrix *submodel_orient, const polymodel *pm, const polymodel_instance *pmi, int submodel_num, const matrix *objorient = nullptr, const vec3d *objpos = nullptr);
 
 // Given a polygon model index, find a list of moving submodels to be used for collision
 void model_get_moving_submodel_list(SCP_vector<int> &submodel_vector, const object *objp);
@@ -981,14 +991,6 @@ void model_get_submodel_tree_list(SCP_vector<int> &submodel_vector, const polymo
 
 // For a rotating submodel, find a point on the axis
 void model_init_submodel_axis_pt(polymodel *pm, polymodel_instance *pmi, int submodel_num);
-
-// Given a direction (pnt) that is in sub_model_num's frame of
-// reference, and given the object's orient and position, 
-// return the point in 3-space in outpnt.
-extern void model_find_world_dir(vec3d *out_dir, const vec3d *in_dir, int model_num, int submodel_num, const matrix *objorient);
-extern void model_find_world_dir(vec3d *out_dir, const vec3d *in_dir, const polymodel *pm, int submodel_num, const matrix *objorient);
-extern void model_instance_find_world_dir(vec3d *out_dir, const vec3d *in_dir, int model_instance_num, int submodel_num, const matrix *objorient, bool use_submodel_parent = false);
-extern void model_instance_find_world_dir(vec3d *out_dir, const vec3d *in_dir, const polymodel *pm, const polymodel_instance *pmi, int submodel_num, const matrix *objorient);
 
 // Clears all the submodel instances stored in a model to their defaults.
 extern void model_clear_instance(int model_num);

--- a/code/model/modelrender.cpp
+++ b/code/model/modelrender.cpp
@@ -1657,7 +1657,7 @@ void model_render_glowpoint_bitmap(int point_num, vec3d *pos, matrix *orient, gl
 		vm_vec_sub(&loc_offset, &gpt->pnt, &submodel_static_offset);
 
 		tempv = loc_offset;
-		find_submodel_instance_point_normal(&loc_offset, &loc_norm, pm, pmi, bank->submodel_parent, &tempv, &loc_norm);
+		model_instance_find_world_point_normal(&loc_offset, &loc_norm, &tempv, &loc_norm, pm, pmi, bank->submodel_parent);
 	}
 
 	vm_vec_unrotate(&world_pnt, &loc_offset, orient);
@@ -1812,7 +1812,7 @@ void model_render_glowpoint_add_light(int point_num, vec3d *pos, matrix *orient,
 		vm_vec_sub(&loc_offset, &gpt->pnt, &submodel_static_offset);
 
 		tempv = loc_offset;
-		find_submodel_instance_point_normal(&loc_offset, &loc_norm, pm, pmi, bank->submodel_parent, &tempv, &loc_norm);
+		model_instance_find_world_point_normal(&loc_offset, &loc_norm, &tempv, &loc_norm, pm, pmi, bank->submodel_parent);
 	}
 
 	vm_vec_unrotate(&world_pnt, &loc_offset, orient);
@@ -1849,7 +1849,6 @@ void model_render_glowpoint_add_light(int point_num, vec3d *pos, matrix *orient,
 			vec3d cone_dir_model;
 			vec3d cone_dir_world;
 			vec3d cone_dir_screen;
-			vec3d unused;
 
 			if ( gpo->rotating ) {
 				vm_rot_point_around_line(&cone_dir_rot, &gpo->cone_direction, PI * timestamp() * 0.000033333f * gpo->rotation_speed, &vmd_zero_vector, &gpo->rotation_axis);
@@ -1857,7 +1856,7 @@ void model_render_glowpoint_add_light(int point_num, vec3d *pos, matrix *orient,
 				cone_dir_rot = gpo->cone_direction;
 			}
 
-			find_submodel_instance_point_normal(&unused, &cone_dir_model, pm, pmi, bank->submodel_parent, &unused, &cone_dir_rot);
+			model_instance_find_world_dir(&cone_dir_model, &cone_dir_rot, pm, pmi, bank->submodel_parent);
 			vm_vec_unrotate(&cone_dir_world, &cone_dir_model, orient);
 			vm_vec_rotate(&cone_dir_screen, &cone_dir_world, &Eye_matrix);
 			cone_dir_screen.xyz.z = -cone_dir_screen.xyz.z;
@@ -2222,7 +2221,7 @@ void model_queue_render_thrusters(model_render_params *interp, polymodel *pm, in
 				if (pmi == nullptr)
 					pmi = model_get_instance(shipp->model_instance_num);
 
-				find_submodel_instance_point_normal(&loc_offset, &loc_norm, pm, pmi, bank->submodel_num, &tempv, &loc_norm);
+				model_instance_find_world_point_normal(&loc_offset, &loc_norm, &tempv, &loc_norm, pm, pmi, bank->submodel_num);
 			}
 
 			vm_vec_unrotate(&world_pnt, &loc_offset, orient);

--- a/code/scripting/api/objs/mc_info.cpp
+++ b/code/scripting/api/objs/mc_info.cpp
@@ -114,8 +114,10 @@ ADE_FUNC(getCollisionNormal, l_ColInfo, "[boolean local]", "The collision normal
 		if (!local)
 		{
 			vec3d normal;
+			auto pmi = model_get_instance(collide->model_instance_num);
+			auto pm = model_get(pmi->model_num);
 
-			vm_vec_unrotate(&normal, &collide->hit_normal, collide->orient);
+			model_instance_find_world_dir(&normal, &collide->hit_normal, pm, pmi, collide->hit_submodel, collide->orient);
 
 			return ade_set_args(L, "o", l_Vector.Set(normal));
 		}

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -13520,7 +13520,7 @@ int get_subsystem_pos(vec3d* pos, object* objp, ship_subsys* subsysp)
 
 		auto pmi = model_get_instance(Ships[objp->instance].model_instance_num);
 		auto pm = model_get(pmi->model_num);
-		find_submodel_instance_world_point(pos, pm, pmi, mss->subobj_num, &objp->orient, &objp->pos);
+		model_instance_find_world_point(pos, &vmd_zero_vector, pm, pmi, mss->subobj_num, &objp->orient, &objp->pos);
 	}
 
 	return 1;
@@ -13701,7 +13701,7 @@ void ship_get_eye( vec3d *eye_pos, matrix *eye_orient, object *obj, bool do_slew
 	eye *ep = &(pm->view_positions[shipp->current_viewpoint]);
 
 	if (ep->parent >= 0 && pm->submodel[ep->parent].flags[Model::Submodel_flags::Can_move]) {
-		find_submodel_instance_point_orient(eye_pos, eye_orient, pm, pmi, ep->parent, &ep->pnt, &vmd_identity_matrix);
+		model_instance_find_world_point_orient(eye_pos, eye_orient, &ep->pnt, &vmd_identity_matrix, pm, pmi, ep->parent);
 		vec3d tvec = *eye_pos;
 		vm_vec_unrotate(eye_pos, &tvec, &obj->orient);
 		vm_vec_add2(eye_pos, &obj->pos);

--- a/code/ship/shipfx.cpp
+++ b/code/ship/shipfx.cpp
@@ -2702,7 +2702,7 @@ void engine_wash_ship_process(ship *shipp)
 
 					// Gets the final offset and normal in the ship's frame of reference
 					temp = loc_pos;
-					find_submodel_instance_point_normal(&loc_pos, &loc_norm, pm, pmi, bank->submodel_num, &temp, &loc_norm);
+					model_instance_find_world_point_normal(&loc_pos, &loc_norm, &temp, &loc_norm, pm, pmi, bank->submodel_num);
 				}
 
 				// get world pos of thruster

--- a/code/ship/shiphit.cpp
+++ b/code/ship/shiphit.cpp
@@ -469,7 +469,8 @@ void do_subobj_heal_stuff(object* ship_objp, object* other_obj, vec3d* hitpos, i
 				// if the subsystem is a turret and the hit submodel is its barrel,
 				// get the distance between the hit and the turret barrel center
 				auto pmi = model_get_instance(ship_p->model_instance_num);
-				find_submodel_instance_world_point(&g_subobj_pos, model_get(pmi->model_num), pmi, submodel_num, &ship_objp->orient, &ship_objp->pos);
+				auto pm = model_get(pmi->model_num);
+				model_instance_find_world_point(&g_subobj_pos, &vmd_zero_vector, pm, pmi, submodel_num, &ship_objp->orient, &ship_objp->pos);
 				dist = vm_vec_dist_quick(&hitpos2, &g_subobj_pos);
 
 				// Healing attenuation range of barrel radius * 2 makes full healing
@@ -788,7 +789,7 @@ float do_subobj_hit_stuff(object *ship_objp, object *other_obj, vec3d *hitpos, i
 					pmi = model_get_instance(ship_p->model_instance_num);
 					pm = model_get(pmi->model_num);
 				}
-				find_submodel_instance_world_point(&g_subobj_pos, pm, pmi, submodel_num, &ship_objp->orient, &ship_objp->pos);
+				model_instance_find_world_point(&g_subobj_pos, &vmd_zero_vector, pm, pmi, submodel_num, &ship_objp->orient, &ship_objp->pos);
 				dist = vm_vec_dist_quick(&hitpos2, &g_subobj_pos);
 
 				// Damage attenuation range of barrel radius * 2 makes full damage


### PR DESCRIPTION
Consolidated these functions and replaced the `find_submodel_point_*` functions with their closest `world_find_` counterparts.  (One of those functions may not have actually worked correctly.)  Also use the correct coordinate logic when returning normals from collision info in scripting.

Related to #3985 although not yet a fix for it.