### PR TITLE
add scripting support for submodels

### DIFF
--- a/code/model/model.h
+++ b/code/model/model.h
@@ -1033,6 +1033,8 @@ void submodel_get_cross_sectional_avg_pos(int model_num, int submodel_num, float
 // generates a random position more or less inside-ish a mesh at a particular z slice
 void submodel_get_cross_sectional_random_pos(int model_num, int submodel_num, float z_slice_pos, vec3d* pos);
   
+extern int model_find_submodel_index(int modelnum, const char *name);
+
 // gets the index into the docking_bays array of the specified type of docking point
 // Returns the index.  second functions returns the index of the docking bay with
 // the specified name

--- a/code/model/modelread.cpp
+++ b/code/model/modelread.cpp
@@ -4683,6 +4683,19 @@ void model_instance_add_arc(polymodel *pm, polymodel_instance *pmi, int sub_mode
 	}
 }
 
+int model_find_submodel_index(int modelnum, const char *name)
+{
+	auto pm = model_get(modelnum);
+
+	for (int i = 0; i < pm->n_models; i++)
+	{
+		if (!stricmp(pm->submodel[i].name, name))
+			return i;
+	}
+
+	return -1;
+}
+
 // function to return an index into the docking_bays array which matches the criteria passed
 // to this function.  dock_type is one of the DOCK_TYPE_XXX defines in model.h
 // Goober5000 - now finds more than one dockpoint of this type

--- a/code/scripting/api/objs/mc_info.cpp
+++ b/code/scripting/api/objs/mc_info.cpp
@@ -18,7 +18,7 @@ bool mc_info_h::IsValid() { return valid; }
 //**********HANDLE: Collision info
 ADE_OBJ(l_ColInfo, mc_info_h, "collision_info", "Information about a collision");
 
-ADE_VIRTVAR(Model, l_ColInfo, "model", "The model this collision info is about", "model", "The model")
+ADE_VIRTVAR(Model, l_ColInfo, "model", "The model this collision info is about", "model", "The model, or an invalid model if the handle is not valid")
 {
 	mc_info_h* info;
 	model_h * mh = nullptr;
@@ -44,16 +44,16 @@ ADE_VIRTVAR(Model, l_ColInfo, "model", "The model this collision info is about",
 	return ade_set_args(L, "o", l_Model.Set(model_h(modelNum)));
 }
 
-ADE_FUNC(getCollisionSubmodel, l_ColInfo, nullptr, "The submodel where the collision occurred, if applicable", "submodel", "The submodel, or nil if none")
+ADE_FUNC(getCollisionSubmodel, l_ColInfo, nullptr, "The submodel where the collision occurred, if applicable", "submodel", "The submodel, or nil if none or if the handle is not valid")
 {
 	mc_info_h *info;
 	submodel_h *sh = nullptr;
 
 	if (!ade_get_args(L, "o|o", l_ColInfo.GetPtr(&info), l_Submodel.GetPtr(&sh)))
-		return ade_set_error(L, "o", l_Submodel.Set(submodel_h()));
+		return ADE_RETURN_NIL;
 
 	if (!info->IsValid())
-		return ade_set_error(L, "o", l_Submodel.Set(submodel_h()));
+		return ADE_RETURN_NIL;
 
 	mc_info *collide = info->Get();
 
@@ -85,7 +85,7 @@ ADE_FUNC(getCollisionDistance, l_ColInfo, NULL, "The distance to the closest col
 	}
 }
 
-ADE_FUNC(getCollisionPoint, l_ColInfo, "[boolean local]", "The collision point of this information (local to the object if boolean is set to <i>true</i>)", "vector", "The collision point or nil of none")
+ADE_FUNC(getCollisionPoint, l_ColInfo, "[boolean local]", "The collision point of this information (local to the object if boolean is set to <i>true</i>)", "vector", "The collision point, or nil if none or if the handle is not valid")
 {
 	mc_info_h* info;
 	bool local = false;
@@ -111,7 +111,7 @@ ADE_FUNC(getCollisionPoint, l_ColInfo, "[boolean local]", "The collision point o
 	}
 }
 
-ADE_FUNC(getCollisionNormal, l_ColInfo, "[boolean local]", "The collision normal of this information (local to object if boolean is set to <i>true</i>)", "vector", "The collision normal or nil of none")
+ADE_FUNC(getCollisionNormal, l_ColInfo, "[boolean local]", "The collision normal of this information (local to object if boolean is set to <i>true</i>)", "vector", "The collision normal, or nil if none or if the handle is not valid")
 {
 	mc_info_h* info;
 	bool local = false;
@@ -152,7 +152,7 @@ ADE_FUNC(isValid, l_ColInfo, NULL, "Detects if this handle is valid", "boolean",
 	mc_info_h* info;
 
 	if(!ade_get_args(L, "o", l_ColInfo.GetPtr(&info)))
-		return ADE_RETURN_NIL;
+		return ADE_RETURN_FALSE;
 
 	if (info->IsValid())
 		return ADE_RETURN_TRUE;

--- a/code/scripting/api/objs/mc_info.cpp
+++ b/code/scripting/api/objs/mc_info.cpp
@@ -44,6 +44,25 @@ ADE_VIRTVAR(Model, l_ColInfo, "model", "The model this collision info is about",
 	return ade_set_args(L, "o", l_Model.Set(model_h(modelNum)));
 }
 
+ADE_FUNC(getCollisionSubmodel, l_ColInfo, nullptr, "The submodel where the collision occurred, if applicable", "submodel", "The submodel, or nil if none")
+{
+	mc_info_h *info;
+	submodel_h *sh = nullptr;
+
+	if (!ade_get_args(L, "o|o", l_ColInfo.GetPtr(&info), l_Submodel.GetPtr(&sh)))
+		return ade_set_error(L, "o", l_Submodel.Set(submodel_h()));
+
+	if (!info->IsValid())
+		return ade_set_error(L, "o", l_Submodel.Set(submodel_h()));
+
+	mc_info *collide = info->Get();
+
+	if (collide->hit_submodel < 0)
+		return ADE_RETURN_NIL;
+
+	return ade_set_args(L, "o", l_Submodel.Set(submodel_h(collide->model_num, collide->hit_submodel)));
+}
+
 ADE_FUNC(getCollisionDistance, l_ColInfo, NULL, "The distance to the closest collision point", "number", "distance or -1 on error")
 {
 	mc_info_h* info;

--- a/code/scripting/api/objs/model.cpp
+++ b/code/scripting/api/objs/model.cpp
@@ -66,7 +66,7 @@ bool submodel_h::IsValid()
 }
 
 
-ADE_VIRTVAR(Submodels, l_Model, "modelsubmodels_h", "Model submodels", "modelsubmodels_h", "Model submodels, or an invalid modelsubmodels handle if the model handle is invalid")
+ADE_VIRTVAR(Submodels, l_Model, "Submodels", "Submodels", "Submodels", "Model submodels, or an invalid modelsubmodels handle if the model handle is invalid")
 {
 	model_h *mdl = nullptr;
 	if (!ade_get_args(L, "o", l_Model.GetPtr(&mdl)))
@@ -155,7 +155,7 @@ ADE_VIRTVAR(Dockingbays, l_Model, "dockingbays", "Docking bays handle of model",
 	return ade_set_args(L, "o", l_Dockingbays.Set(dockingbays_h(pm)));
 }
 
-ADE_VIRTVAR(BoundingBoxMax, l_Model, "vector", "Model bounding box maximum", "vector", "Model bounding box, or an empty vector if the handle is invalid")
+ADE_VIRTVAR(BoundingBoxMax, l_Model, "vector", "Model bounding box maximum", "vector", "Model bounding box, or an empty vector if the handle is not valid")
 {
 	model_h *mdl = NULL;
 	vec3d *v = NULL;
@@ -177,7 +177,7 @@ ADE_VIRTVAR(BoundingBoxMax, l_Model, "vector", "Model bounding box maximum", "ve
 	return ade_set_args(L, "o", l_Vector.Set(pm->maxs));
 }
 
-ADE_VIRTVAR(BoundingBoxMin, l_Model, "vector", "Model bounding box minimum", "vector", "Model bounding box, or an empty vector if the handle is invalid")
+ADE_VIRTVAR(BoundingBoxMin, l_Model, "vector", "Model bounding box minimum", "vector", "Model bounding box, or an empty vector if the handle is not valid")
 {
 	model_h *mdl = NULL;
 	vec3d *v = NULL;
@@ -199,7 +199,7 @@ ADE_VIRTVAR(BoundingBoxMin, l_Model, "vector", "Model bounding box minimum", "ve
 	return ade_set_args(L, "o", l_Vector.Set(pm->mins));
 }
 
-ADE_VIRTVAR(Filename, l_Model, "string", "Model filename", "string", "Model filename, or an empty string if the handle is invalid")
+ADE_VIRTVAR(Filename, l_Model, "string", "Model filename", "string", "Model filename, or an empty string if the handle is not valid")
 {
 	model_h *mdl = NULL;
 	const char* s = nullptr;
@@ -278,7 +278,7 @@ ADE_VIRTVAR(Radius, l_Model, "number", "Model radius (Used for collision & culli
 	return ade_set_args(L, "f", pm->rad);
 }
 
-ADE_FUNC(getDetailRoot, l_Model, "[number detailLevel]", "Returns the root submodel of the specified detail level - 0 for detail0, etc.", "submodel", "A submodel")
+ADE_FUNC(getDetailRoot, l_Model, "[number detailLevel]", "Returns the root submodel of the specified detail level - 0 for detail0, etc.", "submodel", "A submodel, or an invalid submodel if handle is not valid")
 {
 	model_h *mdl;
 	int detail = 0;
@@ -299,7 +299,7 @@ ADE_FUNC(isValid, l_Model, nullptr, "True if valid, false or nil if not", "boole
 {
 	model_h *mdl;
 	if (!ade_get_args(L, "o", l_Model.GetPtr(&mdl)))
-		return ADE_RETURN_NIL;
+		return ADE_RETURN_FALSE;
 
 	return ade_set_args(L, "b", mdl->IsValid());
 }
@@ -320,7 +320,7 @@ ADE_VIRTVAR(Name, l_Submodel, nullptr, "Gets the submodel's name", "string", "Th
 	return ade_set_args(L, "s", smh->GetSubmodel()->name);
 }
 
-ADE_VIRTVAR(Offset, l_Submodel, nullptr, "Gets the submodel's offset from its parent submodel", "vector", "The offset vector or a null vector if invalid")
+ADE_VIRTVAR(Offset, l_Submodel, nullptr, "Gets the submodel's offset from its parent submodel", "vector", "The offset vector or a empty vector if invalid")
 {
 	submodel_h *smh = nullptr;
 
@@ -352,7 +352,7 @@ ADE_VIRTVAR(Radius, l_Submodel, nullptr, "Gets the submodel's radius", "number",
 	return ade_set_args(L, "f", smh->GetSubmodel()->rad);
 }
 
-ADE_FUNC(getFirstChild, l_Submodel, nullptr, "Gets the first child submodel of this submodel", "submodel", "A submodel, or nil if there is no child")
+ADE_FUNC(getFirstChild, l_Submodel, nullptr, "Gets the first child submodel of this submodel", "submodel", "A submodel, or nil if there is no child, or an invalid submodel if the handle is not valid")
 {
 	submodel_h *smh = nullptr;
 
@@ -369,7 +369,7 @@ ADE_FUNC(getFirstChild, l_Submodel, nullptr, "Gets the first child submodel of t
 	return ade_set_args(L, "o", l_Submodel.Set(submodel_h(smh->GetModel(), sm->first_child)));
 }
 
-ADE_FUNC(getNextSibling, l_Submodel, nullptr, "Gets the next sibling submodel of this submodel", "submodel", "A submodel, or nil if there are no remaining siblings")
+ADE_FUNC(getNextSibling, l_Submodel, nullptr, "Gets the next sibling submodel of this submodel", "submodel", "A submodel, or nil if there are no remaining siblings, or an invalid submodel if the handle is not valid")
 {
 	submodel_h *smh = nullptr;
 
@@ -390,14 +390,14 @@ ADE_FUNC(isValid, l_Submodel, nullptr, "True if valid, false or nil if not", "bo
 {
 	submodel_h *smh;
 	if (!ade_get_args(L, "o", l_Submodel.GetPtr(&smh)))
-		return ADE_RETURN_NIL;
+		return ADE_RETURN_FALSE;
 
 	return ade_set_args(L, "b", smh->IsValid());
 }
 
 
 //**********HANDLE: modelsubmodels
-ADE_OBJ(l_ModelSubmodels, modelsubmodels_h, "modelsubmodels_h", "Array of submodels");
+ADE_OBJ(l_ModelSubmodels, modelsubmodels_h, "Submodels", "Array of submodels");
 
 modelsubmodels_h::modelsubmodels_h(polymodel* pm) : model_h(pm){}
 modelsubmodels_h::modelsubmodels_h() : model_h(){}
@@ -453,7 +453,7 @@ ADE_FUNC(isValid, l_ModelSubmodels, nullptr, "Detects whether handle is valid", 
 {
 	modelsubmodels_h *msh;
 	if (!ade_get_args(L, "o", l_ModelSubmodels.GetPtr(&msh)))
-		return ADE_RETURN_NIL;
+		return ADE_RETURN_FALSE;
 
 	return ade_set_args(L, "b", msh->IsValid());
 }
@@ -537,7 +537,7 @@ ADE_FUNC(isValid, l_ModelTextures, NULL, "Detects whether handle is valid", "boo
 {
 	modeltextures_h *mth;
 	if(!ade_get_args(L, "o", l_ModelTextures.GetPtr(&mth)))
-		return ADE_RETURN_NIL;
+		return ADE_RETURN_FALSE;
 
 	return ade_set_args(L, "b", mth->IsValid());
 }
@@ -679,7 +679,7 @@ ADE_FUNC(isValid, l_Thrusters, NULL, "Detects whether handle is valid", "boolean
 {
 	thrusters_h *trh;
 	if(!ade_get_args(L, "o", l_Thrusters.GetPtr(&trh)))
-		return ADE_RETURN_NIL;
+		return ADE_RETURN_FALSE;
 
 	return ade_set_args(L, "b", trh->IsValid());
 }
@@ -951,7 +951,7 @@ ADE_FUNC(getName, l_Dockingbay, NULL, "Gets the name of this docking bay", "stri
 	return ade_set_args(L, "s", dbp->name);
 }
 
-ADE_FUNC(getPoint, l_Dockingbay, "number index", "Gets the location of a docking point in this bay", "vector", "The local location or null vector on error")
+ADE_FUNC(getPoint, l_Dockingbay, "number index", "Gets the location of a docking point in this bay", "vector", "The local location or empty vector on error")
 {
 	dockingbay_h* dbh = NULL;
 	int index = -1;
@@ -979,7 +979,7 @@ ADE_FUNC(getPoint, l_Dockingbay, "number index", "Gets the location of a docking
 	return ade_set_args(L, "o", l_Vector.Set(dbp->pnt[index]));
 }
 
-ADE_FUNC(getNormal, l_Dockingbay, "number index", "Gets the normal of a docking point in this bay", "vector", "The normal vector or null vector on error")
+ADE_FUNC(getNormal, l_Dockingbay, "number index", "Gets the normal of a docking point in this bay", "vector", "The normal vector or empty vector on error")
 {
 	dockingbay_h* dbh = NULL;
 	int index = -1;
@@ -1062,7 +1062,7 @@ ADE_FUNC(isValid, l_Dockingbay, NULL, "Detects whether is valid or not", "number
 
 	if (!ade_get_args(L, "o", l_Dockingbay.GetPtr(&dbh)))
 	{
-		return ade_set_error(L, "i", 0);
+		return ADE_RETURN_FALSE;
 	}
 
 	if (dbh == NULL)

--- a/code/scripting/api/objs/model.cpp
+++ b/code/scripting/api/objs/model.cpp
@@ -13,38 +13,73 @@ namespace api {
 
 ADE_OBJ(l_Model, model_h, "model", "3D Model (POF) handle");
 
-polymodel* model_h::Get() {
-	if(!this->IsValid())
-		return NULL;
-
+polymodel *model_h::Get()
+{
 	return model;
 }
-int model_h::GetID() {
-	if(!this->IsValid())
-		return -1;
+int model_h::GetID()
+{
+	return model ? model->id : -1;
+}
+bool model_h::IsValid()
+{
+	return (model != nullptr);
+}
+model_h::model_h(int n_modelnum)
+{
+	if (n_modelnum >= 0)
+		model = model_get(n_modelnum);
+	else
+		model = nullptr;
+}
+model_h::model_h(polymodel *n_model)
+	: model(n_model)
+{
+}
+model_h::model_h()
+	: model(nullptr)
+{
+}
 
-	return mid;
+
+ADE_OBJ(l_Submodel, submodel_h, "submodel", "Handle to a submodel");
+
+submodel_h::submodel_h()
+	: model(nullptr), submodel_num(-1)
+{}
+submodel_h::submodel_h(polymodel *n_model, int n_submodelnum)
+	: model(n_model), submodel_num(n_submodelnum)
+{
 }
-bool model_h::IsValid() {
-	return (model != NULL && mid > -1 && model_get(mid) == model);
+submodel_h::submodel_h(int n_modelnum, int n_submodelnum)
+	: submodel_num(n_submodelnum)
+{
+	model = model_get(n_modelnum);
 }
-model_h::model_h(int n_modelnum) {
-	mid = n_modelnum;
-	if(mid > 0)
-		model = model_get(mid);
-	else
-		model = NULL;
+polymodel *submodel_h::GetModel() { return IsValid() ? model : nullptr; }
+int submodel_h::GetModelID() { return IsValid() ? model->id : -1; }
+bsp_info* submodel_h::GetSubmodel() { return IsValid() ? &model->submodel[submodel_num] : nullptr; }
+int submodel_h::GetSubmodelIndex() { return IsValid() ? submodel_num : -1; }
+bool submodel_h::IsValid()
+{
+	return model != nullptr && submodel_num >= 0 && submodel_num < model->n_models;
 }
-model_h::model_h(polymodel* n_model) {
-	model = n_model;
-	if(n_model != NULL)
-		mid = n_model->id;
-	else
-		mid = -1;
-}
-model_h::model_h() {
-	mid=-1;
-	model = NULL;
+
+
+ADE_VIRTVAR(Submodels, l_Model, "modelsubmodels_h", "Model submodels", "modelsubmodels_h", "Model submodels, or an invalid modelsubmodels handle if the model handle is invalid")
+{
+	model_h *mdl = nullptr;
+	if (!ade_get_args(L, "o", l_Model.GetPtr(&mdl)))
+		return ade_set_error(L, "o", l_ModelSubmodels.Set(modelsubmodels_h()));
+
+	polymodel *pm = mdl->Get();
+	if (!pm)
+		return ade_set_error(L, "o", l_ModelSubmodels.Set(modelsubmodels_h()));
+
+	if (ADE_SETTING_VAR)
+		LuaError(L, "Attempt to use Incomplete Feature: Modelsubmodels copy");
+
+	return ade_set_args(L, "o", l_ModelSubmodels.Set(modelsubmodels_h(pm)));
 }
 
 ADE_VIRTVAR(Textures, l_Model, "modeltextures_h", "Model textures", "modeltextures_h", "Model textures, or an invalid modeltextures handle if the model handle is invalid")
@@ -243,13 +278,184 @@ ADE_VIRTVAR(Radius, l_Model, "number", "Model radius (Used for collision & culli
 	return ade_set_args(L, "f", pm->rad);
 }
 
+ADE_FUNC(getDetailRoot, l_Model, "[number detailLevel]", "Returns the root submodel of the specified detail level - 0 for detail0, etc.", "submodel", "A submodel")
+{
+	model_h *mdl;
+	int detail = 0;
+	if (!ade_get_args(L, "o|i", l_Model.GetPtr(&mdl), &detail))
+		return ade_set_error(L, "o", l_Submodel.Set(submodel_h()));
+
+	auto pm = mdl->Get();
+	if (!pm)
+		return ade_set_error(L, "o", l_Submodel.Set(submodel_h()));
+
+	if (detail < 0 || detail >= pm->n_detail_levels)
+		return ade_set_error(L, "o", l_Submodel.Set(submodel_h()));
+
+	return ade_set_args(L, "o", l_Submodel.Set(submodel_h(pm, pm->detail[detail])));
+}
+
 ADE_FUNC(isValid, l_Model, nullptr, "True if valid, false or nil if not", "boolean", "Detects whether handle is valid")
 {
 	model_h *mdl;
-	if(!ade_get_args(L, "o", l_Model.GetPtr(&mdl)))
+	if (!ade_get_args(L, "o", l_Model.GetPtr(&mdl)))
 		return ADE_RETURN_NIL;
 
 	return ade_set_args(L, "b", mdl->IsValid());
+}
+
+ADE_VIRTVAR(Name, l_Submodel, nullptr, "Gets the submodel's name", "string", "The name or an empty string if invalid")
+{
+	submodel_h *smh = nullptr;
+
+	if (!ade_get_args(L, "o", l_Submodel.GetPtr(&smh)))
+		return ade_set_error(L, "s", "");
+
+	if (!smh->IsValid())
+		return ade_set_error(L, "s", "");
+
+	if (ADE_SETTING_VAR)
+		LuaError(L, "Setting the submodel offset is not implemented");
+
+	return ade_set_args(L, "s", smh->GetSubmodel()->name);
+}
+
+ADE_VIRTVAR(Offset, l_Submodel, nullptr, "Gets the submodel's offset from its parent submodel", "vector", "The offset vector or a null vector if invalid")
+{
+	submodel_h *smh = nullptr;
+
+	if (!ade_get_args(L, "o", l_Submodel.GetPtr(&smh)))
+		return ade_set_error(L, "o", l_Vector.Set(vmd_zero_vector));
+
+	if (!smh->IsValid())
+		return ade_set_error(L, "o", l_Vector.Set(vmd_zero_vector));
+
+	if (ADE_SETTING_VAR)
+		LuaError(L, "Setting the submodel offset is not implemented");
+
+	return ade_set_args(L, "o", l_Vector.Set(smh->GetSubmodel()->offset));
+}
+
+ADE_VIRTVAR(Radius, l_Submodel, nullptr, "Gets the submodel's radius", "number", "The radius of the submodel or -1 if invalid")
+{
+	submodel_h *smh = nullptr;
+
+	if (!ade_get_args(L, "o", l_Submodel.GetPtr(&smh)))
+		return ade_set_error(L, "f", -1.0f);
+
+	if (!smh->IsValid())
+		return ade_set_error(L, "f", -1.0f);
+
+	if (ADE_SETTING_VAR)
+		LuaError(L, "Setting the submodel radius is not implemented");
+
+	return ade_set_args(L, "f", smh->GetSubmodel()->rad);
+}
+
+ADE_FUNC(getFirstChild, l_Submodel, nullptr, "Gets the first child submodel of this submodel", "submodel", "A submodel, or nil if there is no child")
+{
+	submodel_h *smh = nullptr;
+
+	if (!ade_get_args(L, "o", l_Submodel.GetPtr(&smh)))
+		return ade_set_error(L, "o", l_Submodel.Set(submodel_h()));
+
+	if (!smh->IsValid())
+		return ade_set_error(L, "o", l_Submodel.Set(submodel_h()));
+
+	auto sm = smh->GetSubmodel();
+	if (sm->first_child < 0)
+		return ADE_RETURN_NIL;
+
+	return ade_set_args(L, "o", l_Submodel.Set(submodel_h(smh->GetModel(), sm->first_child)));
+}
+
+ADE_FUNC(getNextSibling, l_Submodel, nullptr, "Gets the next sibling submodel of this submodel", "submodel", "A submodel, or nil if there are no remaining siblings")
+{
+	submodel_h *smh = nullptr;
+
+	if (!ade_get_args(L, "o", l_Submodel.GetPtr(&smh)))
+		return ade_set_error(L, "o", l_Submodel.Set(submodel_h()));
+
+	if (!smh->IsValid())
+		return ade_set_error(L, "o", l_Submodel.Set(submodel_h()));
+
+	auto sm = smh->GetSubmodel();
+	if (sm->next_sibling < 0)
+		return ADE_RETURN_NIL;
+
+	return ade_set_args(L, "o", l_Submodel.Set(submodel_h(smh->GetModel(), sm->next_sibling)));
+}
+
+ADE_FUNC(isValid, l_Submodel, nullptr, "True if valid, false or nil if not", "boolean", "Detects whether handle is valid")
+{
+	submodel_h *smh;
+	if (!ade_get_args(L, "o", l_Submodel.GetPtr(&smh)))
+		return ADE_RETURN_NIL;
+
+	return ade_set_args(L, "b", smh->IsValid());
+}
+
+
+//**********HANDLE: modelsubmodels
+ADE_OBJ(l_ModelSubmodels, modelsubmodels_h, "modelsubmodels_h", "Array of submodels");
+
+modelsubmodels_h::modelsubmodels_h(polymodel* pm) : model_h(pm){}
+modelsubmodels_h::modelsubmodels_h() : model_h(){}
+
+ADE_FUNC(__len, l_ModelSubmodels, nullptr, "Number of submodels on model", "number", "Number of model submodels")
+{
+	modelsubmodels_h *msh;
+	if (!ade_get_args(L, "o", l_ModelSubmodels.GetPtr(&msh)))
+		return ade_set_error(L, "i", 0);
+
+	if (!msh->IsValid())
+		return ade_set_error(L, "i", 0);
+
+	polymodel *pm = msh->Get();
+
+	if (!pm)
+		return ade_set_error(L, "i", 0);
+
+	return ade_set_args(L, "i", pm->n_models);
+}
+
+ADE_INDEXER(l_ModelSubmodels, "submodel", "number|string IndexOrName", "submodel", "Model submodels, or invalid modelsubmodels handle if model handle is invalid")
+{
+	modelsubmodels_h *msh = nullptr;
+	int index = -1;
+
+	if (lua_isnumber(L, 2))
+	{
+		if (!ade_get_args(L, "oi", l_ModelSubmodels.GetPtr(&msh), &index))
+			return ade_set_error(L, "o", l_Submodel.Set(submodel_h()));
+
+		index--; // Lua --> C/C++
+	}
+	else
+	{
+		const char *name = nullptr;
+
+		if (!ade_get_args(L, "os", l_ModelSubmodels.GetPtr(&msh), &name))
+			return ade_set_error(L, "o", l_Submodel.Set(submodel_h()));
+
+		index = model_find_submodel_index(msh->GetID(), name);
+	}
+
+	polymodel *pm = msh->Get();
+
+	if (index < 0 || index >= pm->n_models)
+		return ade_set_error(L, "o", l_Submodel.Set(submodel_h()));
+
+	return ade_set_args(L, "o", l_Submodel.Set(submodel_h(pm, index)));
+}
+
+ADE_FUNC(isValid, l_ModelSubmodels, nullptr, "Detects whether handle is valid", "boolean", "true if valid, false if invalid, nil if a syntax/type error occurs")
+{
+	modelsubmodels_h *msh;
+	if (!ade_get_args(L, "o", l_ModelSubmodels.GetPtr(&msh)))
+		return ADE_RETURN_NIL;
+
+	return ade_set_args(L, "b", msh->IsValid());
 }
 
 
@@ -574,7 +780,7 @@ bool glowpoint_h::isValid() {
 	return point != NULL;
 }
 
-ADE_VIRTVAR(Position, l_Glowpoint, NULL, "The (local) vector to the position of the glowpoint", "vector", "The local vector to the glowpoint or nil invalid")
+ADE_VIRTVAR(Position, l_Glowpoint, nullptr, "The (local) vector to the position of the glowpoint", "vector", "The local vector to the glowpoint or nil if invalid")
 {
 	glowpoint_h *glh = NULL;
 	vec3d newVec;
@@ -595,7 +801,7 @@ ADE_VIRTVAR(Position, l_Glowpoint, NULL, "The (local) vector to the position of 
 	return ade_set_args(L, "o", l_Vector.Set(vec));
 }
 
-ADE_VIRTVAR(Radius, l_Glowpoint, NULL, "The radius of the glowpoint", "number", "The radius of the glowpoint or -1 of invalid")
+ADE_VIRTVAR(Radius, l_Glowpoint, nullptr, "The radius of the glowpoint", "number", "The radius of the glowpoint or -1 if invalid")
 {
 	glowpoint_h* glh = NULL;
 	float newVal;

--- a/code/scripting/api/objs/model.cpp
+++ b/code/scripting/api/objs/model.cpp
@@ -66,7 +66,7 @@ bool submodel_h::IsValid()
 }
 
 
-ADE_VIRTVAR(Submodels, l_Model, "Submodels", "Submodels", "Submodels", "Model submodels, or an invalid modelsubmodels handle if the model handle is invalid")
+ADE_VIRTVAR(Submodels, l_Model, nullptr, "Model submodels", "submodels", "Model submodels, or an invalid submodels handle if the model handle is invalid")
 {
 	model_h *mdl = nullptr;
 	if (!ade_get_args(L, "o", l_Model.GetPtr(&mdl)))
@@ -82,7 +82,7 @@ ADE_VIRTVAR(Submodels, l_Model, "Submodels", "Submodels", "Submodels", "Model su
 	return ade_set_args(L, "o", l_ModelSubmodels.Set(modelsubmodels_h(pm)));
 }
 
-ADE_VIRTVAR(Textures, l_Model, "modeltextures_h", "Model textures", "modeltextures_h", "Model textures, or an invalid modeltextures handle if the model handle is invalid")
+ADE_VIRTVAR(Textures, l_Model, nullptr, "Model textures", "textures", "Model textures, or an invalid textures handle if the model handle is invalid")
 {
 	model_h *mdl = NULL;
 	modeltextures_h *oth = NULL;
@@ -101,7 +101,7 @@ ADE_VIRTVAR(Textures, l_Model, "modeltextures_h", "Model textures", "modeltextur
 	return ade_set_args(L, "o", l_ModelTextures.Set(modeltextures_h(pm)));
 }
 
-ADE_VIRTVAR(Thrusters, l_Model, "thrusters", "Model thrusters", "thrusters", "Thrusters of the model or invalid handle")
+ADE_VIRTVAR(Thrusters, l_Model, nullptr, "Model thrusters", "thrusters", "Model thrusters, or an invalid thrusters handle if the model handle is invalid")
 {
 	model_h *mdl = NULL;
 	thrusters_h *oth = NULL;
@@ -119,7 +119,7 @@ ADE_VIRTVAR(Thrusters, l_Model, "thrusters", "Model thrusters", "thrusters", "Th
 	return ade_set_args(L, "o", l_Thrusters.Set(thrusters_h(pm)));
 }
 
-ADE_VIRTVAR(Eyepoints, l_Model, "eyepoints", "Model eyepoints", "eyepoints", "Array of eyepoints or invalid handle on error")
+ADE_VIRTVAR(Eyepoints, l_Model, nullptr, "Model eyepoints", "eyepoints", "Array of eyepoints, or an invalid eyepoints handle if the model handle is invalid")
 {
 	model_h *mdl = NULL;
 	eyepoints_h *eph = NULL;
@@ -137,7 +137,7 @@ ADE_VIRTVAR(Eyepoints, l_Model, "eyepoints", "Model eyepoints", "eyepoints", "Ar
 	return ade_set_args(L, "o", l_Eyepoints.Set(eyepoints_h(pm)));
 }
 
-ADE_VIRTVAR(Dockingbays, l_Model, "dockingbays", "Docking bays handle of model", "dockingbays", "Array of docking bays on this model, or invalid handle on error")
+ADE_VIRTVAR(Dockingbays, l_Model, nullptr, "Model docking bays", "dockingbays", "Array of docking bays, or an invalid dockingbays handle if the model handle is invalid")
 {
 	model_h *mdl = NULL;
 	dockingbays_h *dbh = NULL;
@@ -397,7 +397,7 @@ ADE_FUNC(isValid, l_Submodel, nullptr, "True if valid, false or nil if not", "bo
 
 
 //**********HANDLE: modelsubmodels
-ADE_OBJ(l_ModelSubmodels, modelsubmodels_h, "Submodels", "Array of submodels");
+ADE_OBJ(l_ModelSubmodels, modelsubmodels_h, "submodels", "Array of submodels");
 
 modelsubmodels_h::modelsubmodels_h(polymodel* pm) : model_h(pm){}
 modelsubmodels_h::modelsubmodels_h() : model_h(){}
@@ -460,7 +460,7 @@ ADE_FUNC(isValid, l_ModelSubmodels, nullptr, "Detects whether handle is valid", 
 
 
 //**********HANDLE: modeltextures
-ADE_OBJ(l_ModelTextures, modeltextures_h, "modeltextures_h", "Array of materials");
+ADE_OBJ(l_ModelTextures, modeltextures_h, "textures", "Array of textures");
 
 modeltextures_h::modeltextures_h(polymodel* pm) : model_h(pm){}
 modeltextures_h::modeltextures_h() : model_h(){}

--- a/code/scripting/api/objs/model.h
+++ b/code/scripting/api/objs/model.h
@@ -11,7 +11,6 @@ namespace api {
 class model_h
 {
  protected:
-	int mid;
 	polymodel *model;
 
  public:
@@ -26,6 +25,35 @@ class model_h
 	bool IsValid();
 };
 DECLARE_ADE_OBJ(l_Model, model_h);
+
+class submodel_h
+{
+protected:
+	polymodel *model;
+	int submodel_num;
+
+public:
+	explicit submodel_h(int n_modelnum, int n_submodelnum);
+	explicit submodel_h(polymodel *n_model, int n_submodelnum);
+	submodel_h();
+
+	polymodel *GetModel();
+	int GetModelID();
+
+	bsp_info *GetSubmodel();
+	int GetSubmodelIndex();
+
+	bool IsValid();
+};
+DECLARE_ADE_OBJ(l_Submodel, submodel_h);
+
+class modelsubmodels_h : public model_h
+{
+ public:
+	 modelsubmodels_h(polymodel *pm);
+	 modelsubmodels_h();
+};
+DECLARE_ADE_OBJ(l_ModelSubmodels, modelsubmodels_h);
 
 class modeltextures_h : public model_h
 {

--- a/code/scripting/api/objs/modelinstance.cpp
+++ b/code/scripting/api/objs/modelinstance.cpp
@@ -94,7 +94,7 @@ ADE_FUNC(getObject, l_ModelInstance, nullptr, "Returns the object that this inst
 	return ade_set_object_with_breed(L, mih->Get()->objnum);
 }
 
-ADE_VIRTVAR(SubmodelInstances, l_ModelInstance, "SubmodelInstances", "Submodel instances", "SubmodelInstances", "Model submodel instances, or an invalid modelsubmodelinstances handle if the model instance handle is invalid")
+ADE_VIRTVAR(SubmodelInstances, l_ModelInstance, nullptr, "Submodel instances", "submodel_instances", "Model submodel instances, or an invalid modelsubmodelinstances handle if the model instance handle is invalid")
 {
 	modelinstance_h *mih = nullptr;
 	if (!ade_get_args(L, "o", l_ModelInstance.GetPtr(&mih)))
@@ -237,7 +237,7 @@ ADE_FUNC(isValid, l_SubmodelInstance, nullptr, "True if valid, false or nil if n
 }
 
 
-ADE_OBJ(l_ModelSubmodelInstances, modelsubmodelinstances_h, "modelsubmodelinstances_h", "Array of submodel instances");
+ADE_OBJ(l_ModelSubmodelInstances, modelsubmodelinstances_h, "submodel_instances", "Array of submodel instances");
 
 modelsubmodelinstances_h::modelsubmodelinstances_h(polymodel_instance *pmi) : modelinstance_h(pmi){}
 modelsubmodelinstances_h::modelsubmodelinstances_h() : modelinstance_h(){}

--- a/code/scripting/api/objs/modelinstance.cpp
+++ b/code/scripting/api/objs/modelinstance.cpp
@@ -1,0 +1,323 @@
+//
+//
+
+#include "model.h"
+#include "modelinstance.h"
+#include "object.h"
+#include "vecmath.h"
+
+namespace scripting {
+namespace api {
+
+ADE_OBJ(l_ModelInstance, modelinstance_h, "modelinstance", "Model instance handle");
+
+modelinstance_h::modelinstance_h(int pmi_id)
+{
+	_pmi = model_get_instance(pmi_id);
+}
+modelinstance_h::modelinstance_h(polymodel_instance *pmi)
+	: _pmi(pmi)
+{}
+modelinstance_h::modelinstance_h()
+	: _pmi(nullptr)
+{}
+polymodel_instance *modelinstance_h::Get()
+{
+	return _pmi;
+}
+bool modelinstance_h::IsValid()
+{
+	return (_pmi != nullptr);
+}
+
+
+ADE_OBJ(l_SubmodelInstance, submodelinstance_h, "submodelinstance", "Submodel instance handle");
+
+submodelinstance_h::submodelinstance_h(int pmi_id, int submodel_num)
+	: _submodel_num(submodel_num)
+{
+	_pmi = model_get_instance(pmi_id);
+	_pm = _pmi ? model_get(_pmi->model_num) : nullptr;
+}
+submodelinstance_h::submodelinstance_h(polymodel_instance *pmi, int submodel_num)
+	: _pmi(pmi), _submodel_num(submodel_num)
+{
+	_pm = pmi ? model_get(pmi->model_num) : nullptr;
+}
+submodelinstance_h::submodelinstance_h()
+	: _pmi(nullptr), _pm(nullptr), _submodel_num(-1)
+{}
+polymodel_instance *submodelinstance_h::GetModelInstance()
+{
+	return IsValid() ? _pmi : nullptr;
+}
+submodel_instance *submodelinstance_h::Get()
+{
+	return IsValid() ? &_pmi->submodel[_submodel_num] : nullptr;
+}
+polymodel *submodelinstance_h::GetModel()
+{
+	return IsValid() ? _pm : nullptr;
+}
+bsp_info *submodelinstance_h::GetSubmodel()
+{
+	return IsValid() ? &_pm->submodel[_submodel_num] : nullptr;
+}
+int submodelinstance_h::GetSubmodelIndex()
+{
+	return IsValid() ? _submodel_num : -1;
+}
+bool submodelinstance_h::IsValid()
+{
+	return _pmi != nullptr && _pm != nullptr && _submodel_num >= 0 && _submodel_num < _pm->n_models;
+}
+
+
+ADE_FUNC(getModel, l_ModelInstance, nullptr, "Returns the model used by this instance", "model", "A model")
+{
+	modelinstance_h *mih;
+	if (!ade_get_args(L, "o", l_ModelInstance.GetPtr(&mih)))
+		return ade_set_error(L, "o", l_Model.Set(model_h()));
+
+	return ade_set_args(L, "o", l_Model.Set(model_h(mih->Get()->model_num)));
+}
+
+ADE_FUNC(getObject, l_ModelInstance, nullptr, "Returns the object that this instance refers to", "object", "An object")
+{
+	modelinstance_h *mih;
+	if (!ade_get_args(L, "o", l_ModelInstance.GetPtr(&mih)))
+		return ade_set_error(L, "o", l_Object.Set(object_h()));
+
+	if (mih->Get()->objnum < 0)
+		return ade_set_error(L, "o", l_Object.Set(object_h()));
+
+	return ade_set_object_with_breed(L, mih->Get()->objnum);
+}
+
+ADE_VIRTVAR(SubmodelInstances, l_ModelInstance, "modelsubmodelinstances_h", "Model submodel instances", "modelsubmodelinstances_h", "Model submodel instances, or an invalid modelsubmodelinstances handle if the model instance handle is invalid")
+{
+	modelinstance_h *mih = nullptr;
+	if (!ade_get_args(L, "o", l_ModelInstance.GetPtr(&mih)))
+		return ade_set_error(L, "o", l_ModelSubmodelInstances.Set(modelsubmodelinstances_h()));
+
+	auto pmi = mih->Get();
+	if (!pmi)
+		return ade_set_error(L, "o", l_ModelSubmodelInstances.Set(modelsubmodelinstances_h()));
+
+	if (ADE_SETTING_VAR)
+		LuaError(L, "Attempt to use Incomplete Feature: submodel instance copy");
+
+	return ade_set_args(L, "o", l_ModelSubmodelInstances.Set(modelsubmodelinstances_h(pmi)));
+}
+
+ADE_FUNC(isValid, l_ModelInstance, nullptr, "True if valid, false or nil if not", "boolean", "Detects whether handle is valid")
+{
+	modelinstance_h *mih;
+	if (!ade_get_args(L, "o", l_ModelInstance.GetPtr(&mih)))
+		return ADE_RETURN_NIL;
+
+	return ade_set_args(L, "b", mih->IsValid());
+}
+
+ADE_VIRTVAR(Orientation, l_SubmodelInstance, "orientation", "Gets or sets the submodel instance orientation (world orientation)", "orientation", "Orientation, or null orientation if handle is invalid")
+{
+	submodelinstance_h *smih;
+	matrix_h *mh = nullptr;
+	if (!ade_get_args(L, "o|o", l_SubmodelInstance.GetPtr(&smih), l_Matrix.GetPtr(&mh)))
+		return ade_set_error(L, "o", l_Matrix.Set(matrix_h(&vmd_identity_matrix)));
+
+	if (!smih->IsValid())
+		return ade_set_error(L, "o", l_Matrix.Set(matrix_h(&vmd_identity_matrix)));
+
+	if (ADE_SETTING_VAR && mh != nullptr)
+	{
+		auto sm = smih->GetSubmodel();
+		auto smi = smih->Get();
+
+		smi->canonical_prev_orient = smi->canonical_orient;
+		smi->canonical_orient = *mh->GetMatrix();
+
+		float angle = 0.0f;
+		vm_closest_angle_to_matrix(&smi->canonical_orient, &sm->rotation_axis, &angle);
+
+		smi->cur_angle = angle;
+		smi->turret_idle_angle = angle;
+	}
+
+	return ade_set_args(L, "o", l_Matrix.Set(matrix_h(&smih->Get()->canonical_orient)));
+}
+
+ADE_FUNC(findWorldPoint, l_SubmodelInstance, "vector", "Calculates the world coordinates of a point in a submodel's frame of reference", "vector", "Point, or null vector if handle is invalid")
+{
+	submodelinstance_h *smih;
+	vec3d pnt, outpnt;
+	if (!ade_get_args(L, "oo", l_SubmodelInstance.GetPtr(&smih), l_Vector.Get(&pnt)))
+		return ade_set_error(L, "o", l_Vector.Set(vmd_zero_vector));
+
+	if (!smih->IsValid())
+		return ade_set_error(L, "o", l_Vector.Set(vmd_zero_vector));
+
+	auto pmi = smih->GetModelInstance();
+	if (pmi->objnum < 0)
+		return ade_set_error(L, "o", l_Vector.Set(vmd_zero_vector));
+	auto objp = &Objects[pmi->objnum];
+
+	model_instance_find_world_point(&outpnt, &pnt, pmi->id, smih->GetSubmodelIndex(), &objp->orient, &objp->pos);
+	return ade_set_args(L, "o", l_Vector.Set(outpnt));
+}
+
+ADE_FUNC(findWorldDir, l_SubmodelInstance, "vector", "Calculates the world direction of a vector in a submodel's frame of reference", "vector", "Vector, or null vector if handle is invalid")
+{
+	submodelinstance_h *smih;
+	vec3d dir, outdir;
+	if (!ade_get_args(L, "oo", l_SubmodelInstance.GetPtr(&smih), l_Vector.Get(&dir)))
+		return ade_set_error(L, "o", l_Vector.Set(vmd_zero_vector));
+
+	if (!smih->IsValid())
+		return ade_set_error(L, "o", l_Vector.Set(vmd_zero_vector));
+
+	auto pmi = smih->GetModelInstance();
+	if (pmi->objnum < 0)
+		return ade_set_error(L, "o", l_Vector.Set(vmd_zero_vector));
+	auto objp = &Objects[pmi->objnum];
+
+	model_instance_find_world_dir(&outdir, &dir, smih->GetModel(), pmi, smih->GetSubmodelIndex(), &objp->orient);
+	return ade_set_args(L, "o", l_Vector.Set(outdir));
+}
+
+bool findObjectPointAndOrientationSub(lua_State *L, bool use_object, vec3d *outpnt, matrix *outorient)
+{
+	submodelinstance_h *smih;
+	vec3d local_pnt;
+	matrix_h *local_orient;
+	if (!ade_get_args(L, "ooo", l_SubmodelInstance.GetPtr(&smih), l_Vector.Get(&local_pnt), l_Matrix.GetPtr(&local_orient)))
+		return false;
+
+	if (!smih->IsValid())
+		return false;
+
+	auto pmi = smih->GetModelInstance();
+	if (pmi->objnum < 0)
+		return false;
+	auto objp = &Objects[pmi->objnum];
+
+	model_instance_find_world_point_orient(outpnt, outorient, &local_pnt, local_orient->GetMatrix(), smih->GetModel(), pmi, smih->GetSubmodelIndex(), use_object ? &objp->orient : nullptr, use_object ? &objp->pos : nullptr);
+	return true;
+}
+
+ADE_FUNC(findObjectPointAndOrientation, l_SubmodelInstance, "vector, orientation", "Calculates the coordinates and orientation, in an object's frame of reference, of a point and orientation in a submodel's frame of reference", "vector, orientation", "Vector and orientation, or null values if a handle is invalid")
+{
+	vec3d pnt;
+	matrix orient;
+
+	if (!findObjectPointAndOrientationSub(L, false, &pnt, &orient))
+		return ade_set_error(L, "oo", l_Vector.Set(vmd_zero_vector), l_Matrix.Set(matrix_h(&vmd_zero_matrix)));
+
+	return ade_set_args(L, "oo", l_Vector.Set(pnt), l_Matrix.Set(matrix_h(&orient)));
+}
+
+ADE_FUNC(findWorldPointAndOrientation, l_SubmodelInstance, "vector, orientation", "Calculates the world coordinates and orientation of a point and orientation in a submodel's frame of reference", "vector, orientation", "Vector and orientation, or null values if a handle is invalid")
+{
+	vec3d pnt;
+	matrix orient;
+
+	if (!findObjectPointAndOrientationSub(L, true, &pnt, &orient))
+		return ade_set_error(L, "oo", l_Vector.Set(vmd_zero_vector), l_Matrix.Set(matrix_h(&vmd_zero_matrix)));
+
+	return ade_set_args(L, "oo", l_Vector.Set(pnt), l_Matrix.Set(matrix_h(&orient)));
+}
+
+ADE_FUNC(isValid, l_SubmodelInstance, nullptr, "True if valid, false or nil if not", "boolean", "Detects whether handle is valid")
+{
+	submodelinstance_h *smih;
+	if (!ade_get_args(L, "o", l_SubmodelInstance.GetPtr(&smih)))
+		return ADE_RETURN_NIL;
+
+	return ade_set_args(L, "b", smih->IsValid());
+}
+
+
+ADE_OBJ(l_ModelSubmodelInstances, modelsubmodelinstances_h, "modelsubmodelinstances_h", "Array of submodel instances");
+
+modelsubmodelinstances_h::modelsubmodelinstances_h(polymodel_instance *pmi) : modelinstance_h(pmi){}
+modelsubmodelinstances_h::modelsubmodelinstances_h() : modelinstance_h(){}
+
+ADE_FUNC(__len, l_ModelSubmodelInstances, nullptr, "Number of submodel instances on model", "number", "Number of model submodel instances")
+{
+	modelsubmodelinstances_h *msih;
+	if (!ade_get_args(L, "o", l_ModelSubmodelInstances.GetPtr(&msih)))
+		return ade_set_error(L, "i", 0);
+
+	if (!msih->IsValid())
+		return ade_set_error(L, "i", 0);
+
+	auto pmi = msih->Get();
+	if (!pmi)
+		return ade_set_error(L, "i", 0);
+	auto pm = model_get(pmi->model_num);
+	if (!pm)
+		return ade_set_error(L, "i", 0);
+
+	return ade_set_args(L, "i", pm->n_models);
+}
+
+ADE_INDEXER(l_ModelSubmodelInstances, "submodelinstance", "number|string IndexOrName", "submodelinstance", "Model submodel instances, or invalid modelsubmodelinstances handle if model instance handle is invalid")
+{
+	modelsubmodelinstances_h *msih = nullptr;
+	int index = -1;
+
+	if (lua_isnumber(L, 2))
+	{
+		if (!ade_get_args(L, "oi", l_ModelSubmodelInstances.GetPtr(&msih), &index))
+			return ade_set_error(L, "o", l_SubmodelInstance.Set(submodelinstance_h()));
+
+		if (!msih->IsValid())
+			return ade_set_error(L, "o", l_SubmodelInstance.Set(submodelinstance_h()));
+
+		index--; // Lua --> C/C++
+	}
+	else if (lua_isstring(L, 2))
+	{
+		const char *name = nullptr;
+
+		if (!ade_get_args(L, "os", l_ModelSubmodelInstances.GetPtr(&msih), &name))
+			return ade_set_error(L, "o", l_SubmodelInstance.Set(submodelinstance_h()));
+
+		if (!msih->IsValid() || name == nullptr)
+			return ade_set_error(L, "o", l_SubmodelInstance.Set(submodelinstance_h()));
+
+		index = model_find_submodel_index(msih->Get()->model_num, name);
+	}
+	else
+	{
+		submodel_h *smh;
+
+		if (!ade_get_args(L, "oo", l_ModelSubmodelInstances.GetPtr(&msih), l_Submodel.GetPtr(&smh)))
+			return ade_set_error(L, "o", l_SubmodelInstance.Set(submodelinstance_h()));
+
+		if (!msih->IsValid() || !smh->IsValid())
+			return ade_set_error(L, "o", l_SubmodelInstance.Set(submodelinstance_h()));
+
+		index = smh->GetSubmodelIndex();
+	}
+
+	auto pmi = msih->Get();
+	auto pm = model_get(pmi->model_num);
+
+	if (index < 0 || index >= pm->n_models)
+		return ade_set_error(L, "o", l_SubmodelInstance.Set(submodelinstance_h()));
+
+	return ade_set_args(L, "o", l_SubmodelInstance.Set(submodelinstance_h(pmi, index)));
+}
+
+ADE_FUNC(isValid, l_ModelSubmodelInstances, nullptr, "Detects whether handle is valid", "boolean", "true if valid, false if invalid, nil if a syntax/type error occurs")
+{
+	modelsubmodelinstances_h *msih;
+	if (!ade_get_args(L, "o", l_ModelSubmodelInstances.GetPtr(&msih)))
+		return ADE_RETURN_NIL;
+
+	return ade_set_args(L, "b", msih->IsValid());
+}
+
+}
+}

--- a/code/scripting/api/objs/modelinstance.h
+++ b/code/scripting/api/objs/modelinstance.h
@@ -1,0 +1,62 @@
+#pragma once
+
+#include "scripting/ade_api.h"
+
+#include "model/model.h"
+
+namespace scripting {
+namespace api {
+
+class modelinstance_h
+{
+ protected:
+	polymodel_instance *_pmi;
+
+ public:
+	explicit modelinstance_h(int pmi_id);
+	explicit modelinstance_h(polymodel_instance *pmi);
+	modelinstance_h();
+
+	polymodel_instance *Get();
+
+	bool IsValid();
+};
+DECLARE_ADE_OBJ(l_ModelInstance, modelinstance_h);
+
+class submodelinstance_h
+{
+protected:
+	polymodel_instance *_pmi;
+	polymodel *_pm;
+	int _submodel_num;
+
+public:
+	explicit submodelinstance_h(int pmi_id, int submodel_num);
+	explicit submodelinstance_h(polymodel_instance *pmi, int submodel_num);
+	submodelinstance_h();
+
+	polymodel_instance *GetModelInstance();
+	submodel_instance *Get();
+
+	polymodel *GetModel();
+	bsp_info *GetSubmodel();
+	int GetSubmodelIndex();
+
+	bool IsValid();
+};
+DECLARE_ADE_OBJ(l_SubmodelInstance, submodelinstance_h);
+
+class modelsubmodelinstances_h : public modelinstance_h
+{
+ public:
+	 modelsubmodelinstances_h(polymodel_instance *pmi);
+	 modelsubmodelinstances_h();
+};
+DECLARE_ADE_OBJ(l_ModelSubmodelInstances, modelsubmodelinstances_h);
+
+}
+}
+
+
+
+

--- a/code/scripting/api/objs/object.cpp
+++ b/code/scripting/api/objs/object.cpp
@@ -3,6 +3,7 @@
 
 #include "enums.h"
 #include "mc_info.h"
+#include "modelinstance.h"
 #include "object.h"
 #include "physics_info.h"
 #include "shields.h"
@@ -169,6 +170,25 @@ ADE_VIRTVAR(LastOrientation, l_Object, "orientation", "Object world orientation 
 	}
 
 	return ade_set_args(L, "o", l_Matrix.Set(matrix_h(&objh->objp->last_orient)));
+}
+
+ADE_VIRTVAR(ModelInstance, l_Object, "modelinstance", "model instance used by this object", "modelinstance", "Model instance, nil if this object does not have one, or invalid model instance handle if object handle is invalid")
+{
+	object_h* objh;
+	if (!ade_get_args(L, "o", l_Object.GetPtr(&objh)))
+		return ade_set_error(L, "o", l_ModelInstance.Set(modelinstance_h()));
+
+	if (!objh->IsValid())
+		return ade_set_error(L, "o", l_ModelInstance.Set(modelinstance_h()));
+
+	if (ADE_SETTING_VAR)
+		LuaError(L, "Assigning model instances is not implemented");
+
+	int id = object_get_model_instance(objh->objp);
+	if (id < 0)
+		return ADE_RETURN_NIL;
+
+	return ade_set_args(L, "o", l_ModelInstance.Set(modelinstance_h(id)));
 }
 
 ADE_VIRTVAR(Physics, l_Object, "physics", "Physics data used to move ship between frames", "physics", "Physics data, or invalid physics handle if object handle is invalid")

--- a/code/scripting/api/objs/object.cpp
+++ b/code/scripting/api/objs/object.cpp
@@ -172,7 +172,7 @@ ADE_VIRTVAR(LastOrientation, l_Object, "orientation", "Object world orientation 
 	return ade_set_args(L, "o", l_Matrix.Set(matrix_h(&objh->objp->last_orient)));
 }
 
-ADE_VIRTVAR(ModelInstance, l_Object, "modelinstance", "model instance used by this object", "modelinstance", "Model instance, nil if this object does not have one, or invalid model instance handle if object handle is invalid")
+ADE_VIRTVAR(ModelInstance, l_Object, nullptr, "model instance used by this object", "modelinstance", "Model instance, nil if this object does not have one, or invalid model instance handle if object handle is invalid")
 {
 	object_h* objh;
 	if (!ade_get_args(L, "o", l_Object.GetPtr(&objh)))

--- a/code/scripting/api/objs/object.cpp
+++ b/code/scripting/api/objs/object.cpp
@@ -172,7 +172,7 @@ ADE_VIRTVAR(LastOrientation, l_Object, "orientation", "Object world orientation 
 	return ade_set_args(L, "o", l_Matrix.Set(matrix_h(&objh->objp->last_orient)));
 }
 
-ADE_VIRTVAR(ModelInstance, l_Object, nullptr, "model instance used by this object", "modelinstance", "Model instance, nil if this object does not have one, or invalid model instance handle if object handle is invalid")
+ADE_VIRTVAR(ModelInstance, l_Object, nullptr, "model instance used by this object", "model_instance", "Model instance, nil if this object does not have one, or invalid model instance handle if object handle is invalid")
 {
 	object_h* objh;
 	if (!ade_get_args(L, "o", l_Object.GetPtr(&objh)))

--- a/code/source_groups.cmake
+++ b/code/source_groups.cmake
@@ -1321,6 +1321,8 @@ add_file_folder("Scripting\\\\Api\\\\Objs"
 	scripting/api/objs/message.h
 	scripting/api/objs/model.cpp
 	scripting/api/objs/model.h
+	scripting/api/objs/modelinstance.cpp
+	scripting/api/objs/modelinstance.h
 	scripting/api/objs/model_path.cpp
 	scripting/api/objs/model_path.h
 	scripting/api/objs/movie_player.cpp


### PR DESCRIPTION
Allow scripts to reference submodels, submodel instances, and model instances.  Currently just a few properties (like Orientation and Radius) can be accessed, but this can be easily expanded in the future.

Also add relevant functions to calculate real-world positions and orientations of rotated submodels.