### PR TITLE
Expand scripting string functions

### DIFF
--- a/code/scripting/api/libs/base.cpp
+++ b/code/scripting/api/libs/base.cpp
@@ -484,10 +484,11 @@ ADE_FUNC(XSTR,
 }
 
 ADE_FUNC(translateTokens, 
-	l_Base, "string to translate", 
+	l_Base, 
+	"string to translate", 
 	"Returns a string that translates any default control binding to current binding (same as Directive Text). Default binding must be encapsulated by '$$' to be translated.",
 	"string",
-	"string")
+	"string or nil if invalid")
 {
 	const char* untranslated_str;
 	if (!ade_get_args(L, "s", &untranslated_str)) {
@@ -504,7 +505,7 @@ ADE_FUNC(replaceVariableValue,
 	"string to translate",
 	"Returns a string that translates any variable name to the variable value (same as text in Briefings, Debriefings, or Messages). Variable name must be preceeded by '$' to be translated.",
 	"string",
-	"string")
+	"string or nil if invalid")
 {
 	const char* untranslated_str;
 	if (!ade_get_args(L, "s", &untranslated_str)) {

--- a/code/scripting/api/libs/base.cpp
+++ b/code/scripting/api/libs/base.cpp
@@ -485,10 +485,10 @@ ADE_FUNC(XSTR,
 
 ADE_FUNC(translateTokens, 
 	l_Base, 
-	"string to translate", 
+	"string text", 
 	"Returns a string that translates any default control binding to current binding (same as Directive Text). Default binding must be encapsulated by '$$' to be translated.",
 	"string",
-	"string or nil if invalid")
+	"Translated string or nil if invalid")
 {
 	const char* untranslated_str;
 	if (!ade_get_args(L, "s", &untranslated_str)) {
@@ -502,10 +502,10 @@ ADE_FUNC(translateTokens,
 
 ADE_FUNC(replaceVariableValue,
 	l_Base,
-	"string to translate",
+	"string text",
 	"Returns a string that translates any variable name to the variable value (same as text in Briefings, Debriefings, or Messages). Variable name must be preceeded by '$' to be translated.",
 	"string",
-	"string or nil if invalid")
+	"Translated string or nil if invalid")
 {
 	const char* untranslated_str;
 	if (!ade_get_args(L, "s", &untranslated_str)) {

--- a/code/scripting/api/libs/base.cpp
+++ b/code/scripting/api/libs/base.cpp
@@ -8,8 +8,10 @@
 #include "freespace.h"
 
 #include "gamesequence/gamesequence.h"
+#include "mission/missiontraining.h"
 #include "network/multi.h"
 #include "parse/parselo.h"
+#include "parse/sexp.h"
 #include "pilotfile/pilotfile.h"
 #include "playerman/player.h"
 #include "scripting/api/objs/bytearray.h"
@@ -479,6 +481,40 @@ ADE_FUNC(XSTR,
 	lcl_ext_localize(xstr, translated);
 
 	return ade_set_args(L, "s", translated.c_str());
+}
+
+ADE_FUNC(translateTokens, 
+	l_Base, "string to translate", 
+	"Returns a string that translates any default control binding to current binding (same as Directive Text). Default binding must be encapsulated by '$$' to be translated.",
+	"string",
+	"string")
+{
+	const char* untranslated_str;
+	if (!ade_get_args(L, "s", &untranslated_str)) {
+		return ADE_RETURN_NIL;
+	}
+
+	SCP_string translated_str = message_translate_tokens(untranslated_str);
+
+	return ade_set_args(L, "s", translated_str.c_str());
+}
+
+ADE_FUNC(replaceVariableValue,
+	l_Base,
+	"string to translate",
+	"Returns a string that translates any variable name to the variable value (same as text in Briefings, Debriefings, or Messages). Variable name must be preceeded by '$' to be translated.",
+	"string",
+	"string")
+{
+	const char* untranslated_str;
+	if (!ade_get_args(L, "s", &untranslated_str)) {
+		return ADE_RETURN_NIL;
+	}
+
+	SCP_string translated_str = untranslated_str;
+	sexp_replace_variable_names_with_values(translated_str);
+
+	return ade_set_args(L, "s", translated_str.c_str());
 }
 
 ADE_FUNC(inMissionEditor, l_Base, nullptr, "Determine if the current script is running in the mission editor (e.g. FRED2). This should be used to control which code paths will be executed even if running in the editor.", "boolean", "true when we are in the mission editor, false otherwise") {

--- a/code/scripting/api/libs/base.cpp
+++ b/code/scripting/api/libs/base.cpp
@@ -483,12 +483,12 @@ ADE_FUNC(XSTR,
 	return ade_set_args(L, "s", translated.c_str());
 }
 
-ADE_FUNC(translateTokens, 
+ADE_FUNC(replaceTokens, 
 	l_Base, 
 	"string text", 
-	"Returns a string that translates any default control binding to current binding (same as Directive Text). Default binding must be encapsulated by '$$' to be translated.",
+	"Returns a string that replaces any default control binding to current binding (same as Directive Text). Default binding must be encapsulated by '$$' for replacement to work.",
 	"string",
-	"Translated string or nil if invalid")
+	"Updated string or nil if invalid")
 {
 	const char* untranslated_str;
 	if (!ade_get_args(L, "s", &untranslated_str)) {
@@ -500,12 +500,12 @@ ADE_FUNC(translateTokens,
 	return ade_set_args(L, "s", translated_str.c_str());
 }
 
-ADE_FUNC(replaceVariableValue,
+ADE_FUNC(replaceVariables,
 	l_Base,
 	"string text",
-	"Returns a string that translates any variable name to the variable value (same as text in Briefings, Debriefings, or Messages). Variable name must be preceeded by '$' to be translated.",
+	"Returns a string that replaces any variable name with the variable value (same as text in Briefings, Debriefings, or Messages). Variable name must be preceeded by '$' for replacement to work.",
 	"string",
-	"Translated string or nil if invalid")
+	"Updated string or nil if invalid")
 {
 	const char* untranslated_str;
 	if (!ade_get_args(L, "s", &untranslated_str)) {


### PR DESCRIPTION
Allows scripters to use the functions `message_translate_tokens` and `sexp_replace_variable_names_with_values`. This is very useful with scripted HUD gauges and scripted messages. Also, fixes #4034.