### PR TITLE
Improve costly RTT sanity check

### DIFF
--- a/code/graphics/opengl/gropengltexture.cpp
+++ b/code/graphics/opengl/gropengltexture.cpp
@@ -1702,7 +1702,8 @@ int opengl_set_render_target( int slot, int face, int is_static )
 	}
 
 	// Since framebuffer_id is only ever 0 or assigned by glGenFramebuffer, it must be valid if not 0
-	if ( fbo->framebuffer_id == 0 /*!glIsFramebuffer(fbo->framebuffer_id)*/ /*|| !glIsRenderbufferEXT(fbo->renderbuffer_id)*/ ) {
+	// This check previously queried !glIsFramebuffer(fbo->framebuffer_id) for the same effect but at significantly higher performance costs.
+	if ( fbo->framebuffer_id == 0 ) {
 		Int3();
 		return 0;
 	}

--- a/code/graphics/opengl/gropengltexture.cpp
+++ b/code/graphics/opengl/gropengltexture.cpp
@@ -1701,7 +1701,8 @@ int opengl_set_render_target( int slot, int face, int is_static )
 		return 0;
 	}
 
-	if ( !glIsFramebuffer(fbo->framebuffer_id) /*|| !glIsRenderbufferEXT(fbo->renderbuffer_id)*/ ) {
+	// Since framebuffer_id is only ever 0 or assigned by glGenFramebuffer, it must be valid if not 0
+	if ( fbo->framebuffer_id == 0 /*!glIsFramebuffer(fbo->framebuffer_id)*/ /*|| !glIsRenderbufferEXT(fbo->renderbuffer_id)*/ ) {
 		Int3();
 		return 0;
 	}


### PR DESCRIPTION
When switching to a texture as a render target, the code previously performed a check with the driver if the ID for the target texture was a valid framebuffer. This is sometimes a _very_ costly check, causing measureable and occasionally visible microstutter. The way this ID is found however, guarantees us one of two things: It's an ID returned directly from the driver from creating the frambuffer, in which case it's valid anyways, or it's 0 because the framebuffer has been cleared.

We can make use of this by changing the check to only check for the 0 case, since any non-zero number must have come from the driver and is valid, thus allowing us to omit the check to the driver, drastically reducing microstutter in cases where RTT is often used (like RTT HUD gauges, or other special drawing effects)