### PR TITLE
fix the keep-safe-distance AI mode

### DIFF
--- a/code/ai/ai_flags.h
+++ b/code/ai/ai_flags.h
@@ -143,6 +143,7 @@ namespace AI {
 		Fighterbay_arrivals_use_carrier_orient, 
 		Fighterbay_departures_use_carrier_orient,
 		Prevent_negative_turret_ammo,
+		Fix_keep_safe_distance,
 
 		NUM_VALUES
 	};

--- a/code/ai/ai_profiles.cpp
+++ b/code/ai/ai_profiles.cpp
@@ -596,6 +596,8 @@ void parse_ai_profiles_tbl(const char *filename)
 
 				set_flag(profile, "$prevent negative turret ammo:", AI::Profile_Flags::Prevent_negative_turret_ammo);
 
+				set_flag(profile, "$fix keep-safe-distance:", AI::Profile_Flags::Fix_keep_safe_distance);
+
 
 				// if we've been through once already and are at the same place, force a move
 				if (saved_Mp && (saved_Mp == Mp))
@@ -762,5 +764,6 @@ void ai_profile_t::reset()
 	if (mod_supports_version(22, 0, 0)) {
 		flags.set(AI::Profile_Flags::Fighterbay_arrivals_use_carrier_orient);
 		flags.set(AI::Profile_Flags::Prevent_negative_turret_ammo);
+		flags.set(AI::Profile_Flags::Fix_keep_safe_distance);
 	}
 }


### PR DESCRIPTION
There were two bugs that kept this from working until now:

1) The destination goal point was calculated to take the ship right through the center of danger.  Flipping the vector now takes the ship away from danger as intended.
2) The original AI code did not turn the ship at all.  The new code turns the ship toward its goal point.

The fixed behavior is tied to the new `$fix keep-safe-distance:` flag.