### PR TITLE
fix time resuming when popups are closed

### DIFF
--- a/code/popup/popup.cpp
+++ b/code/popup/popup.cpp
@@ -129,6 +129,8 @@ static popup_info Popup_info;
 static int Popup_flags;
 static int Popup_screen_id = -1;
 
+static bool Popup_time_was_stopped = false;
+
 static int Title_coords[GR_NUM_RESOLUTIONS][5] =
 {
 	{ // GR_640
@@ -477,8 +479,12 @@ int popup_init(popup_info *pi, int flags)
 	}
 
 	// anytime in single player, and multiplayer, not in mission, go ahead and stop time
+	Popup_time_was_stopped = false;
 	if ( (Game_mode & GM_NORMAL) || ((Game_mode & GM_MULTIPLAYER) && !(Game_mode & GM_IN_MISSION)) ){
-		game_stop_time();
+		if (!game_time_is_stopped()) {
+			game_stop_time();
+			Popup_time_was_stopped = true;
+		}
 	}
 
 	// create base window
@@ -578,8 +584,8 @@ void popup_close(popup_info *pi, int screen_id)
 	Popup_is_active = 0;
 	Popup_running_state = 0;
 
-	// anytime in single player, and multiplayer, not in mission, go ahead and resume time
-	if ( (Game_mode & GM_NORMAL) || ((Game_mode & GM_MULTIPLAYER) && !(Game_mode & GM_IN_MISSION)) )
+	// if we had previously stopped time, go ahead and resume time
+	if ( Popup_time_was_stopped )
 		game_start_time();
 }
 

--- a/code/popup/popup.cpp
+++ b/code/popup/popup.cpp
@@ -129,7 +129,7 @@ static popup_info Popup_info;
 static int Popup_flags;
 static int Popup_screen_id = -1;
 
-static bool Popup_time_was_stopped = false;
+static bool Popup_time_was_stopped_in_init = false;
 
 static int Title_coords[GR_NUM_RESOLUTIONS][5] =
 {
@@ -479,11 +479,11 @@ int popup_init(popup_info *pi, int flags)
 	}
 
 	// anytime in single player, and multiplayer, not in mission, go ahead and stop time
-	Popup_time_was_stopped = false;
+	Popup_time_was_stopped_in_init = false;
 	if ( (Game_mode & GM_NORMAL) || ((Game_mode & GM_MULTIPLAYER) && !(Game_mode & GM_IN_MISSION)) ){
 		if (!game_time_is_stopped()) {
 			game_stop_time();
-			Popup_time_was_stopped = true;
+			Popup_time_was_stopped_in_init = true;
 		}
 	}
 
@@ -585,7 +585,7 @@ void popup_close(popup_info *pi, int screen_id)
 	Popup_running_state = 0;
 
 	// if we had previously stopped time, go ahead and resume time
-	if ( Popup_time_was_stopped )
+	if ( Popup_time_was_stopped_in_init )
 		game_start_time();
 }
 

--- a/fred2/fredstubs.cpp
+++ b/fred2/fredstubs.cpp
@@ -183,6 +183,7 @@ int Test_begin;
 int Debug_octant;
 int Framerate_delay;
 void game_start_time(bool){}
+bool game_time_is_stopped(){return false;}
 void game_stop_time(bool){}
 int game_get_default_skill_level(){return 0;}
 int find_freespace_cd(char*){return 0;}

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -4177,6 +4177,11 @@ void game_stop_time(bool by_os_focus)
 	timestamp_pause(!by_os_focus);
 }
 
+bool game_time_is_stopped()
+{
+	return Time_paused;
+}
+
 void game_start_time(bool by_os_focus)
 {
 	if (Time_paused) {

--- a/freespace2/freespace.h
+++ b/freespace2/freespace.h
@@ -97,6 +97,8 @@ void game_level_close();
 // stop the game (mission) timer
 void game_stop_time(bool by_os_focus = false);
 
+bool game_time_is_stopped();
+
 // start the game (mission) timer
 void game_start_time(bool by_os_focus = false);
 

--- a/qtfred/src/fredstubs.cpp
+++ b/qtfred/src/fredstubs.cpp
@@ -187,6 +187,7 @@ int Test_begin;
 int Debug_octant;
 int Framerate_delay;
 void game_start_time(bool){}
+bool game_time_is_stopped(){return false;}
 void game_stop_time(bool){}
 int game_get_default_skill_level(){return 0;}
 int find_freespace_cd(char*){return 0;}

--- a/test/src/test_stubs.cpp
+++ b/test/src/test_stubs.cpp
@@ -191,6 +191,7 @@ int Test_begin;
 int Debug_octant;
 int Framerate_delay;
 void game_start_time(bool){}
+bool game_time_is_stopped(){return false;}
 void game_stop_time(bool){}
 int game_get_default_skill_level(){return 0;}
 int find_freespace_cd(char*){return 0;}


### PR DESCRIPTION
If time is already stopped when a popup is displayed, it should remain stopped when the popup is closed.