### PR TITLE
Fixed incoherent case sensitivity for animation submodels

### DIFF
--- a/code/model/modelanimation.cpp
+++ b/code/model/modelanimation.cpp
@@ -274,7 +274,10 @@ namespace animation {
 		ModelAnimationSet::cleanRunning();
 	}
 
-	ModelAnimationSubmodel::ModelAnimationSubmodel(SCP_string submodelName) : m_name(std::move(submodelName)) { }
+	ModelAnimationSubmodel::ModelAnimationSubmodel(SCP_string submodelName) {
+		SCP_tolower(submodelName);
+		m_name = std::move(submodelName);
+	}
 
 	ModelAnimationSubmodel* ModelAnimationSubmodel::copy() const {
 		return new ModelAnimationSubmodel(*this);

--- a/code/model/modelanimation.cpp
+++ b/code/model/modelanimation.cpp
@@ -208,10 +208,8 @@ namespace animation {
 
 			//Save the things modified by initial animations as actual baseline
 			for (const auto& initialModified : applyBuffer) {
-				if (!initialModified.second.modified)
-					continue;
-
-				initialModified.first->saveCurrentAsBase(pmi);
+				if (initialModified.second.modified)
+					initialModified.first->saveCurrentAsBase(pmi);
 			}
 		}
 	}
@@ -852,7 +850,9 @@ namespace animation {
 		return true;
 	};
 
-	std::shared_ptr<ModelAnimationSubmodel> ModelAnimationSet::getSubmodel(const SCP_string& submodelName) {
+	std::shared_ptr<ModelAnimationSubmodel> ModelAnimationSet::getSubmodel(SCP_string submodelName) {
+		SCP_tolower(submodelName);
+
 		for (const auto& submodel : m_submodels) {
 			if (!submodel->is_turret && submodel->m_name == submodelName)
 				return submodel;
@@ -863,7 +863,9 @@ namespace animation {
 		return submodel;
 	}
 
-	std::shared_ptr<ModelAnimationSubmodel> ModelAnimationSet::getSubmodel(const SCP_string& submodelName, const SCP_string& SIP_name, bool findBarrel) {
+	std::shared_ptr<ModelAnimationSubmodel> ModelAnimationSet::getSubmodel(SCP_string submodelName, const SCP_string& SIP_name, bool findBarrel) {
+		SCP_tolower(submodelName);
+
 		for (const auto& submodel : m_submodels) {
 			if (submodel->is_turret && submodel->m_name == submodelName) {
 				auto submodelTurret = ((ModelAnimationSubmodelTurret*)submodel.get());

--- a/code/model/modelanimation.h
+++ b/code/model/modelanimation.h
@@ -360,8 +360,8 @@ namespace animation {
 
 		bool isEmpty() const;
 
-		std::shared_ptr<ModelAnimationSubmodel> getSubmodel(const SCP_string& submodelName);
-		std::shared_ptr<ModelAnimationSubmodel> getSubmodel(const SCP_string& submodelName, const SCP_string& SIP_name, bool findBarrel);
+		std::shared_ptr<ModelAnimationSubmodel> getSubmodel(SCP_string submodelName);
+		std::shared_ptr<ModelAnimationSubmodel> getSubmodel(SCP_string submodelName, const SCP_string& SIP_name, bool findBarrel);
 		std::shared_ptr<ModelAnimationSubmodel> getSubmodel(const std::shared_ptr<ModelAnimationSubmodel>& other);
 	};
 


### PR DESCRIPTION
Previously, using different capitalization for the same submodel in animation definition would cause unpredictable behaviour due to the animation system considering these to be separate submodels, while the rest of FSO would regard them as the same.
This change gets the animation system to also be case agnostic for coherent behaviour even with different capitalizations of submodel names.