### PR TITLE
Feature/texture replacement dialog

### DIFF
--- a/qtfred/source_groups.cmake
+++ b/qtfred/source_groups.cmake
@@ -74,6 +74,8 @@ add_file_folder("Source/Mission/Dialogs"
 	src/mission/dialogs/PlayerOrdersDialogModel.cpp
 	src/mission/dialogs/ShipSpecialStatsDialogModel.h
 	src/mission/dialogs/ShipSpecialStatsDialogModel.cpp
+	src/mission/dialogs/ShipTextureReplacementDialogModel.h
+	src/mission/dialogs/ShipTextureReplacementDialogModel.cpp
 )
 
 add_file_folder("Source/UI"
@@ -130,6 +132,8 @@ add_file_folder("Source/UI/Dialogs"
 	src/ui/dialogs/PlayerOrdersDialog.cpp
 	src/ui/dialogs/ShipSpecialStatsDialog.cpp
 	src/ui/dialogs/ShipSpecialStatsDialog.h
+	src/ui/dialogs/ShipTextureReplacementDialog.h
+	src/ui/dialogs/ShipTextureReplacementDialog.cpp
 )
 
 add_file_folder("Source/UI/Util"
@@ -175,6 +179,7 @@ add_file_folder("UI"
 	ui/ShipSpecialStatsDialog.ui
 	ui/ShipFlagsDialog.ui
 	ui/PlayerOrdersDialog.ui
+	ui/ShipTextureReplacementDialog.ui
 )
 
 add_file_folder("Resources"

--- a/qtfred/src/mission/dialogs/ShipEditorDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/ShipEditorDialogModel.cpp
@@ -51,6 +51,7 @@ namespace fso {
 				int type, wing = -1;
 				int cargo = 0, base_ship, base_player, pship = -1;
 				int escort_count;
+				texenable = true;
 				std::set<size_t> current_orders;
 				pship_count = 0;  // a total count of the player ships not marked
 				player_count = 0;
@@ -149,7 +150,10 @@ namespace fso {
 									base_player = -1;
 								}
 								else {
-									if (Ships[i].ship_info_index != _m_ship_class) { _m_ship_class = -1; }
+									if (Ships[i].ship_info_index != _m_ship_class) { 
+										_m_ship_class = -1; 
+										texenable = false; 
+									}
 									if (Ships[i].team != _m_team) { _m_team = -1; }
 									pship = tristate_set(Objects[Ships[i].objnum].type == OBJ_START, pship);
 								}

--- a/qtfred/src/mission/dialogs/ShipEditorDialogModel.h
+++ b/qtfred/src/mission/dialogs/ShipEditorDialogModel.h
@@ -58,6 +58,7 @@ class ShipEditorDialogModel : public AbstractDialogModel {
 
 	static int make_ship_list(int* arr);
 
+
   public:
 	ShipEditorDialogModel(QObject* parent, EditorViewport* viewport);
 
@@ -165,6 +166,8 @@ class ShipEditorDialogModel : public AbstractDialogModel {
 	int player_ship;
 	std::set<size_t> ship_orders;
 	static int tristate_set(int val, int cur_state);
+
+	bool texenable = true;
 
 	//int pship, current_orders;
 };

--- a/qtfred/src/mission/dialogs/ShipTextureReplacementDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/ShipTextureReplacementDialogModel.cpp
@@ -451,7 +451,9 @@ namespace fso {
 							}
 						}
 						else {
-							error_display(0, "You told us to replace the -misc map with inherited data but didnt change the main texture name. Ignoring -misc map change");
+							SCP_string buf;
+							sprintf(buf, "Cannot use inherited data without changing the main texture name. Ignoring %s map change.", type.c_str());
+							error_display(0, buf.c_str());
 						}
 					}
 					else {

--- a/qtfred/src/mission/dialogs/ShipTextureReplacementDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/ShipTextureReplacementDialogModel.cpp
@@ -569,7 +569,7 @@ namespace fso {
 
 			int ShipTextureReplacementDialogModel::getSize() const
 			{
-				return defaultTextures.size();
+				return (int)defaultTextures.size();
 			}
 			SCP_string ShipTextureReplacementDialogModel::getDefaultName(const int index) const
 			{

--- a/qtfred/src/mission/dialogs/ShipTextureReplacementDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/ShipTextureReplacementDialogModel.cpp
@@ -451,9 +451,7 @@ namespace fso {
 							}
 						}
 						else {
-							SCP_string buf;
-							sprintf(buf, "Cannot use inherited data without changing the main texture name. Ignoring %s map change.", type.c_str());
-							error_display(0, buf.c_str());
+							error_display(0, "Cannot use inherited data without changing the main texture name. Ignoring %s map change.", type.c_str());
 						}
 					}
 					else {

--- a/qtfred/src/mission/dialogs/ShipTextureReplacementDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/ShipTextureReplacementDialogModel.cpp
@@ -381,6 +381,21 @@ namespace fso {
 												texture_set(&(*ii), &(*end));
 											}
 										}
+
+										if (end != Fred_texture_replacements.end())
+											Fred_texture_replacements.erase(end, Fred_texture_replacements.end());
+
+										// now put the new entries on the end of the list
+										texture_replace tr;
+										strcpy_s(tr.old_texture, defaultTextures[index].c_str());
+										strcpy_s(tr.new_texture, fullName.c_str());
+										strcpy_s(tr.ship_name, Ships[_editor->cur_ship].ship_name);
+										tr.new_texture_id = -1;
+										tr.from_table = false;
+
+										// assign to global FRED array
+										Fred_texture_replacements.push_back(tr);
+										_editor->missionChanged();
 									}
 									else {
 										object* objp = nullptr;
@@ -403,6 +418,21 @@ namespace fso {
 														texture_set(&(*ii), &(*end));
 													}
 												}
+
+												if (end != Fred_texture_replacements.end())
+													Fred_texture_replacements.erase(end, Fred_texture_replacements.end());
+
+												// now put the new entries on the end of the list
+												texture_replace tr;
+												strcpy_s(tr.old_texture, defaultTextures[index].c_str());
+												strcpy_s(tr.new_texture, fullName.c_str());
+												strcpy_s(tr.ship_name, shipp->ship_name);
+												tr.new_texture_id = -1;
+												tr.from_table = false;
+
+												// assign to global FRED array
+												Fred_texture_replacements.push_back(tr);
+												_editor->missionChanged();
 											}
 
 											objp = GET_NEXT(objp);
@@ -448,6 +478,21 @@ namespace fso {
 											texture_set(&(*ii), &(*end));
 										}
 									}
+
+									if (end != Fred_texture_replacements.end())
+										Fred_texture_replacements.erase(end, Fred_texture_replacements.end());
+
+									// now put the new entries on the end of the list
+									texture_replace tr;
+									strcpy_s(tr.old_texture, defaultTextures[index].c_str());
+									strcpy_s(tr.new_texture, fullName.c_str());
+									strcpy_s(tr.ship_name, Ships[_editor->cur_ship].ship_name);
+									tr.new_texture_id = -1;
+									tr.from_table = false;
+
+									// assign to global FRED array
+									Fred_texture_replacements.push_back(tr);
+									_editor->missionChanged();
 								}
 								else {
 									object* objp = nullptr;
@@ -470,6 +515,21 @@ namespace fso {
 													texture_set(&(*ii), &(*end));
 												}
 											}
+
+											if (end != Fred_texture_replacements.end())
+												Fred_texture_replacements.erase(end, Fred_texture_replacements.end());
+
+											// now put the new entries on the end of the list
+											texture_replace tr;
+											strcpy_s(tr.old_texture, defaultTextures[index].c_str());
+											strcpy_s(tr.new_texture, fullName.c_str());
+											strcpy_s(tr.ship_name, shipp->ship_name);
+											tr.new_texture_id = -1;
+											tr.from_table = false;
+
+											// assign to global FRED array
+											Fred_texture_replacements.push_back(tr);
+											_editor->missionChanged();
 										}
 
 										objp = GET_NEXT(objp);

--- a/qtfred/src/mission/dialogs/ShipTextureReplacementDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/ShipTextureReplacementDialogModel.cpp
@@ -1,0 +1,578 @@
+#include "ShipTextureReplacementDialogModel.h"
+
+#include "mission/object.h"
+
+namespace fso {
+	namespace fred {
+		namespace dialogs {
+			ShipTextureReplacementDialogModel::ShipTextureReplacementDialogModel(QObject* parent, EditorViewport* viewport, bool multi) :
+				AbstractDialogModel(parent, viewport)
+			{
+				m_multi = multi;
+				initialiseData();
+			}
+
+			void ShipTextureReplacementDialogModel::initialiseData()
+			{
+				char texture_file[MAX_FILENAME_LEN];
+				char* p = nullptr;
+				int duplicate;
+				polymodel* pm = model_get(Ship_info[Ships[_editor->cur_ship].ship_info_index].model_num);
+				defaultTextures.clear();
+				defaultTextures.resize(pm->n_textures);
+				currentTextures.clear();
+				currentTextures.resize(pm->n_textures);
+				subTypesAvailable.clear();
+				subTypesAvailable.resize(pm->n_textures);
+				replaceMap.clear();
+				replaceMap.resize(pm->n_textures);
+				inheritMap.clear();
+				inheritMap.resize(pm->n_textures);
+
+				// look for textures to populate the list
+				for (int i = 0; i < pm->n_textures; i++) {
+					// get texture file name
+					bm_get_filename(pm->maps[i].textures[0].GetOriginalTexture(), texture_file);
+
+					// skip blank textures
+					if (!strlen(texture_file))
+						continue;
+
+					// get rid of file extension
+					p = strchr(texture_file, '.');
+					if (p)
+					{
+						//mprintf(( "ignoring extension on file '%s'\n", texture_file ));
+						*p = 0;
+					}
+
+					// check for duplicate textures in list
+					duplicate = -1;
+					for (int k = 0; k < defaultTextures.size(); k++)
+					{
+						if (!stricmp(defaultTextures[k].c_str(), texture_file))
+						{
+							duplicate = k;
+							break;
+						}
+					}
+
+					if (duplicate >= 0)
+						continue;
+
+					// make old texture lowercase
+					strlwr(texture_file);
+
+					// add it to the field
+					defaultTextures[i] = texture_file;
+					currentTextures[i].insert(std::pair<SCP_string, SCP_string>("main", ""));
+					//Get all Available SubTypes
+					initSubTypes(pm, i);
+
+				}
+
+				if (!m_multi) {
+					for (SCP_vector<texture_replace>::iterator ii = Fred_texture_replacements.begin(); ii != Fred_texture_replacements.end(); ++ii)
+					{
+						if (!stricmp(Ships[_editor->cur_ship].ship_name, ii->ship_name) && !(ii->from_table))
+						{
+							SCP_string pureName = strlwr(ii->old_texture);
+							auto npos = pureName.find_last_of('-');
+							if (npos != SCP_string::npos) {
+								pureName = pureName.substr(0, pureName.find_last_of('-'));
+							}
+
+							// look for corresponding old texture
+							for (int i = 0; i < defaultTextures.size(); i++)
+							{
+								// if match
+								if (!stricmp(defaultTextures[i].c_str(), pureName.c_str()))
+								{
+									SCP_string newText = strlwr(ii->new_texture);
+									npos = newText.find_last_of('-');
+									SCP_string type;
+									if (npos != SCP_string::npos) {
+										type = newText.substr(npos + 1);
+										newText = newText.substr(0, newText.find_last_of('-'));
+									}
+									if (!type.empty()) {
+										if (type == "misc") {
+											currentTextures[i]["misc"] = newText;
+											replaceMap[i]["misc"] = true;
+											inheritMap[i]["misc"] = (newText == pureName);
+										}
+										if (type == "shine") {
+											currentTextures[i]["shine"] = newText;
+											replaceMap[i]["shine"] = true;
+											inheritMap[i]["shine"] = (newText == pureName);
+
+										}
+										if (type == "glow") {
+											currentTextures[i]["glow"] = newText;
+											replaceMap[i]["glow"] = true;
+											inheritMap[i]["glow"] = (newText == pureName);
+
+										}
+										if (type == "normal") {
+											currentTextures[i]["normal"] = newText;
+											replaceMap[i]["normal"] = true;
+											inheritMap[i]["normal"] = (newText == pureName);
+
+										}
+										if (type == "height") {
+											currentTextures[i]["height"] = newText;
+											replaceMap[i]["height"] = true;
+											inheritMap[i]["height"] = (newText == pureName);
+
+										}
+										if (type == "ao") {
+											currentTextures[i]["ao"] = newText;
+											replaceMap[i]["ao"] = true;
+											inheritMap[i]["ao"] = (newText == pureName);
+
+										}
+										if (type == "reflect") {
+											currentTextures[i]["reflect"] = newText;
+											replaceMap[i]["reflect"] = true;
+											inheritMap[i]["reflect"] = (newText == pureName);
+
+										}
+									}
+									else {
+										currentTextures[i]["main"] = newText;
+									}
+
+									// we found one, so no more to check
+									break;
+								}
+							}
+						}
+					}
+				}
+			}
+			void ShipTextureReplacementDialogModel::initSubTypes(polymodel* model, int MapNum)
+			{
+				subTypesAvailable[MapNum].insert(std::pair<SCP_string, bool>("misc", false));
+				subTypesAvailable[MapNum].insert(std::pair<SCP_string, bool>("shine", false));
+				subTypesAvailable[MapNum].insert(std::pair<SCP_string, bool>("glow", false));
+				subTypesAvailable[MapNum].insert(std::pair<SCP_string, bool>("normal", false));
+				subTypesAvailable[MapNum].insert(std::pair<SCP_string, bool>("height", false));
+				subTypesAvailable[MapNum].insert(std::pair<SCP_string, bool>("ao", false));
+				subTypesAvailable[MapNum].insert(std::pair<SCP_string, bool>("reflect", false));
+
+				currentTextures[MapNum].insert(std::pair<SCP_string, SCP_string>("misc", ""));
+				currentTextures[MapNum].insert(std::pair<SCP_string, SCP_string>("shine", ""));
+				currentTextures[MapNum].insert(std::pair<SCP_string, SCP_string>("glow", ""));
+				currentTextures[MapNum].insert(std::pair<SCP_string, SCP_string>("normal", ""));
+				currentTextures[MapNum].insert(std::pair<SCP_string, SCP_string>("height", ""));
+				currentTextures[MapNum].insert(std::pair<SCP_string, SCP_string>("ao", ""));
+				currentTextures[MapNum].insert(std::pair<SCP_string, SCP_string>("reflect", ""));
+
+				replaceMap[MapNum].insert(std::pair<SCP_string, bool>("misc", false));
+				replaceMap[MapNum].insert(std::pair<SCP_string, bool>("shine", false));
+				replaceMap[MapNum].insert(std::pair<SCP_string, bool>("glow", false));
+				replaceMap[MapNum].insert(std::pair<SCP_string, bool>("normal", false));
+				replaceMap[MapNum].insert(std::pair<SCP_string, bool>("height", false));
+				replaceMap[MapNum].insert(std::pair<SCP_string, bool>("ao", false));
+				replaceMap[MapNum].insert(std::pair<SCP_string, bool>("reflect", false));
+
+				inheritMap[MapNum].insert(std::pair<SCP_string, bool>("misc", true));
+				inheritMap[MapNum].insert(std::pair<SCP_string, bool>("shine", true));
+				inheritMap[MapNum].insert(std::pair<SCP_string, bool>("glow", true));
+				inheritMap[MapNum].insert(std::pair<SCP_string, bool>("normal", true));
+				inheritMap[MapNum].insert(std::pair<SCP_string, bool>("height", true));
+				inheritMap[MapNum].insert(std::pair<SCP_string, bool>("ao", true));
+				inheritMap[MapNum].insert(std::pair<SCP_string, bool>("reflect", true));
+				char subMap[MAX_FILENAME_LEN];
+				//init saftly, probly not necessary
+				for (int j = 1; j < TM_NUM_TYPES; j++) {
+					bm_get_filename(model->maps[MapNum].textures[j].GetOriginalTexture(), subMap);
+					char* p = strchr(subMap, '.');
+					if (p)
+					{
+						//mprintf(( "ignoring extension on file '%s'\n", texture_file ));
+						*p = 0;
+					}
+					SCP_string subMapClean = strlwr(subMap);
+					SCP_string type;
+					auto npos = subMapClean.find_last_of('-');
+					if (npos != SCP_string::npos) {
+						type = subMapClean.substr(npos + 1);
+					}
+					else {
+						continue;
+					}
+					if (!type.empty()) {
+						if (type == "trans") {
+						}
+						else if (type == "misc") {
+							subTypesAvailable[MapNum]["misc"] = true;
+						}
+						else if (type == "shine") {
+							subTypesAvailable[MapNum]["shine"] = true;
+						}
+						else if (type == "glow") {
+							subTypesAvailable[MapNum]["glow"] = true;
+						}
+						else if (type == "normal") {
+							subTypesAvailable[MapNum]["normal"] = true;
+						}
+						else if (type == "height") {
+							subTypesAvailable[MapNum]["height"] = true;
+						}
+						else if (type == "ao") {
+							subTypesAvailable[MapNum]["ao"] = true;
+						}
+						else if (type == "reflect") {
+							subTypesAvailable[MapNum]["reflect"] = true;
+						}
+						else {
+							error_display(1, "Invalid Map type %s. Check your model's texture names or get a programmer", type.c_str());
+						}
+					}
+				}
+			}
+
+			bool ShipTextureReplacementDialogModel::apply()
+			{
+				if (query_modified()) {
+					for (int i = 0; i < getSize(); i++) {
+						if ((!currentTextures[i]["main"].empty()) && (currentTextures[i]["main"] != defaultTextures[i])) {
+							mainChanged = true;
+							SCP_string name = currentTextures[i]["main"];
+							if (testTexture(name)) {
+								SCP_vector<texture_replace>::iterator ii, end;
+								end = Fred_texture_replacements.end();
+								if (!m_multi) {
+									end = Fred_texture_replacements.end();
+									for (ii = Fred_texture_replacements.begin(); ii != end; ++ii)
+									{
+										if (!stricmp(ii->ship_name, Ships[_editor->cur_ship].ship_name))
+										{
+											do {
+												end--;
+											} while (end != ii && !stricmp(end->ship_name, Ships[_editor->cur_ship].ship_name));
+											if (end == ii)
+												break;
+											texture_set(&(*ii), &(*end));
+										}
+									}
+
+									if (end != Fred_texture_replacements.end())
+										Fred_texture_replacements.erase(end, Fred_texture_replacements.end());
+
+									// now put the new entries on the end of the list
+									texture_replace tr;
+									strcpy_s(tr.old_texture, defaultTextures[i].c_str());
+									strcpy_s(tr.new_texture, name.c_str());
+									strcpy_s(tr.ship_name, Ships[_editor->cur_ship].ship_name);
+									tr.new_texture_id = -1;
+									tr.from_table = false;
+
+									// assign to global FRED array
+									Fred_texture_replacements.push_back(tr);
+									_editor->missionChanged();
+								}
+								else {
+									object* objp = nullptr;
+									objp = GET_FIRST(&obj_used_list);
+									while (objp != END_OF_LIST(&obj_used_list)) {
+										if (((objp->type == OBJ_SHIP) || (objp->type == OBJ_START)) &&
+											(objp->flags[Object::Object_Flags::Marked])) {
+											Assert((objp->type == OBJ_SHIP) || (objp->type == OBJ_START));
+											auto shipp = &Ships[get_ship_from_obj(objp)];
+											end = Fred_texture_replacements.end();
+											for (ii = Fred_texture_replacements.begin(); ii != end; ++ii)
+											{
+												if (!stricmp(ii->ship_name, shipp->ship_name))
+												{
+													do {
+														end--;
+													} while (end != ii && !stricmp(end->ship_name, shipp->ship_name));
+													if (end == ii)
+														break;
+													texture_set(&(*ii), &(*end));
+												}
+											}
+											if (end != Fred_texture_replacements.end())
+												Fred_texture_replacements.erase(end, Fred_texture_replacements.end());
+
+											// now put the new entries on the end of the list
+											texture_replace tr;
+											strcpy_s(tr.old_texture, defaultTextures[i].c_str());
+											strcpy_s(tr.new_texture, name.c_str());
+											strcpy_s(tr.ship_name, shipp->ship_name);
+											tr.new_texture_id = -1;
+											tr.from_table = false;
+
+											// assign to global FRED array
+											Fred_texture_replacements.push_back(tr);
+											_editor->missionChanged();
+										}
+
+										objp = GET_NEXT(objp);
+									}
+								}
+							}
+							else {
+								auto button = _viewport->dialogProvider->showButtonDialog(DialogType::Error, "Missing Texture", "FRED was unable to find Main Texture %s \n Aborting at this point",
+									{ DialogButton::Ok });
+								if (button == DialogButton::Ok) {
+									return false;
+								}
+							}
+						}
+						saveSubMap(i, "misc");
+						saveSubMap(i, "shine");
+						saveSubMap(i, "glow");
+						saveSubMap(i, "normal");
+						saveSubMap(i, "height");
+						saveSubMap(i, "ao");
+						saveSubMap(i, "reflect");	
+						_editor->missionChanged();
+					}
+					_editor->missionChanged();
+					return true;
+				}
+				else {
+					return true;
+				}
+			}
+			void ShipTextureReplacementDialogModel::reject()
+			{
+			}
+			texture_replace* ShipTextureReplacementDialogModel::texture_set(texture_replace* dest, const texture_replace* src)
+			{
+				dest->new_texture_id = src->new_texture_id;
+				strcpy_s(dest->ship_name, src->ship_name);
+				strcpy_s(dest->old_texture, src->old_texture);
+				strcpy_s(dest->new_texture, src->new_texture);
+				dest->from_table = src->from_table;
+
+				return dest;
+			}
+
+			void ShipTextureReplacementDialogModel::saveSubMap(int index, SCP_string type) {
+				SCP_string fullName;
+				if (replaceMap[index][type]) {
+					if (inheritMap[index][type]) {
+						if (mainChanged) {
+							if (!currentTextures[index]["main"].empty()) {
+								if (currentTextures[index]["main"] != "invisible") {
+									fullName = currentTextures[index]["main"] + "-" + type;
+								}
+								else {
+									fullName = currentTextures[index]["main"];
+								}
+								if (testTexture(fullName)) {
+									SCP_vector<texture_replace>::iterator ii, end;
+									end = Fred_texture_replacements.end();
+									if (!m_multi) {
+										end = Fred_texture_replacements.end();
+										for (ii = Fred_texture_replacements.begin(); ii != end; ++ii)
+										{
+											if (!stricmp(ii->ship_name, Ships[_editor->cur_ship].ship_name))
+											{
+												do {
+													end--;
+												} while (end != ii && !stricmp(end->ship_name, Ships[_editor->cur_ship].ship_name));
+												if (end == ii)
+													break;
+												texture_set(&(*ii), &(*end));
+											}
+										}
+									}
+									else {
+										object* objp = nullptr;
+										objp = GET_FIRST(&obj_used_list);
+										while (objp != END_OF_LIST(&obj_used_list)) {
+											if (((objp->type == OBJ_SHIP) || (objp->type == OBJ_START)) &&
+												(objp->flags[Object::Object_Flags::Marked])) {
+												Assert((objp->type == OBJ_SHIP) || (objp->type == OBJ_START));
+												auto shipp = &Ships[get_ship_from_obj(objp)];
+												end = Fred_texture_replacements.end();
+												for (ii = Fred_texture_replacements.begin(); ii != end; ++ii)
+												{
+													if (!stricmp(ii->ship_name, shipp->ship_name))
+													{
+														do {
+															end--;
+														} while (end != ii && !stricmp(end->ship_name, shipp->ship_name));
+														if (end == ii)
+															break;
+														texture_set(&(*ii), &(*end));
+													}
+												}
+											}
+
+											objp = GET_NEXT(objp);
+										}
+									}
+								}
+								else {
+									auto button = _viewport->dialogProvider->showButtonDialog(DialogType::Error, "Missing Texture", "FRED was unable to find %s \n Skipping",
+										{ DialogButton::Ok });
+									if (button == DialogButton::Ok) {
+										return;
+									}
+								}
+
+							}
+						}
+						else {
+							error_display(0, "You told us to replace the -misc map with inherited data but didnt change the main texture name. Ignoring -misc map change");
+						}
+					}
+					else {
+						if (!currentTextures[index][type].empty()) {
+							if (currentTextures[index][type] != "invisible") {
+								fullName = currentTextures[index][type] + "-" + type;
+							}
+							else {
+								fullName = currentTextures[index][type];
+							}
+							if (testTexture(fullName)) {
+								SCP_vector<texture_replace>::iterator ii, end;
+								end = Fred_texture_replacements.end();
+								if (!m_multi) {
+									end = Fred_texture_replacements.end();
+									for (ii = Fred_texture_replacements.begin(); ii != end; ++ii)
+									{
+										if (!stricmp(ii->ship_name, Ships[_editor->cur_ship].ship_name))
+										{
+											do {
+												end--;
+											} while (end != ii && !stricmp(end->ship_name, Ships[_editor->cur_ship].ship_name));
+											if (end == ii)
+												break;
+											texture_set(&(*ii), &(*end));
+										}
+									}
+								}
+								else {
+									object* objp = nullptr;
+									objp = GET_FIRST(&obj_used_list);
+									while (objp != END_OF_LIST(&obj_used_list)) {
+										if (((objp->type == OBJ_SHIP) || (objp->type == OBJ_START)) &&
+											(objp->flags[Object::Object_Flags::Marked])) {
+											Assert((objp->type == OBJ_SHIP) || (objp->type == OBJ_START));
+											auto shipp = &Ships[get_ship_from_obj(objp)];
+											end = Fred_texture_replacements.end();
+											for (ii = Fred_texture_replacements.begin(); ii != end; ++ii)
+											{
+												if (!stricmp(ii->ship_name, shipp->ship_name))
+												{
+													do {
+														end--;
+													} while (end != ii && !stricmp(end->ship_name, shipp->ship_name));
+													if (end == ii)
+														break;
+													texture_set(&(*ii), &(*end));
+												}
+											}
+										}
+
+										objp = GET_NEXT(objp);
+									}
+								}
+							}
+							else {
+								auto button = _viewport->dialogProvider->showButtonDialog(DialogType::Error, "Missing Texture", "FRED was unable to find %s \n Skipping",
+									{ DialogButton::Ok });
+								if (button == DialogButton::Ok) {
+									return;
+								}
+							}
+
+						}
+					}
+				}
+			}
+
+			bool ShipTextureReplacementDialogModel::testTexture(SCP_string fullName)
+			{
+				int temp_bmp, temp_frames, temp_fps;
+				if (fullName == "invisible") {
+					return true;
+				}
+				else {
+					// try loading the texture (bmpman should take care of eventually unloading it)
+					temp_bmp = bm_load(fullName);
+					if (temp_bmp < 0)
+					{
+						temp_bmp = bm_load_animation(fullName.c_str(), &temp_frames, &temp_fps, nullptr, nullptr, nullptr, true);
+					}
+					if (temp_bmp < 0)
+					{
+						return false;
+					}
+					return true;
+				}
+			}
+
+			int ShipTextureReplacementDialogModel::getSize() const
+			{
+				return defaultTextures.size();
+			}
+			SCP_string ShipTextureReplacementDialogModel::getDefaultName(const int index) const
+			{
+				Assert(index <= defaultTextures.size());
+				return defaultTextures[index];
+			}
+			void ShipTextureReplacementDialogModel::setMap(const int index, const SCP_string& type, const SCP_string& newName)
+			{
+				Assert(index <= currentTextures.size());
+				SCP_map<SCP_string, SCP_string>::const_iterator pos = currentTextures[index].find(type);
+				if (pos == currentTextures[index].end()) {
+					//handle the error
+				}
+				else {
+					modify(currentTextures[index][type], newName);
+				}
+
+			}
+			SCP_string ShipTextureReplacementDialogModel::getMap(const int index, const SCP_string& type) const {
+				Assert(index <= currentTextures.size());
+				SCP_map<SCP_string, SCP_string>::const_iterator pos = currentTextures[index].find(type);
+				if (pos == currentTextures[index].end()) {
+					//handle the error
+				}
+				else {
+					return pos->second;
+				}
+			}
+			SCP_map<SCP_string, bool> ShipTextureReplacementDialogModel::getSubtypesForMap(int index) const
+			{
+				return subTypesAvailable[index];
+			}
+			SCP_map<SCP_string, bool> ShipTextureReplacementDialogModel::getReplace(int index) const
+			{
+				return replaceMap[index];
+			}
+			SCP_map<SCP_string, bool> ShipTextureReplacementDialogModel::getInherit(int index) const
+			{
+				return inheritMap[index];
+			}
+
+			void ShipTextureReplacementDialogModel::setReplace(const int index, const SCP_string& type, const bool state)
+			{
+				modify(replaceMap[index][type], state);
+			}
+			void ShipTextureReplacementDialogModel::setInherit(const int index, const SCP_string& type, const bool state)
+			{
+				modify(inheritMap[index][type], state);
+			}
+			void ShipTextureReplacementDialogModel::set_modified()
+			{
+				if (!_modified) {
+					_modified = true;
+				}
+			}
+
+			bool ShipTextureReplacementDialogModel::query_modified() const
+			{
+				return  _modified;;
+			}
+		}
+	}
+}

--- a/qtfred/src/mission/dialogs/ShipTextureReplacementDialogModel.h
+++ b/qtfred/src/mission/dialogs/ShipTextureReplacementDialogModel.h
@@ -29,9 +29,9 @@ namespace fso {
 				SCP_vector<SCP_string> defaultTextures;
 				SCP_vector<SCP_map<SCP_string, SCP_string>> currentTextures;
 				bool mainChanged = false;
-				void saveSubMap(int index, SCP_string type);
-				bool testTexture(SCP_string);
-				texture_replace* texture_set(texture_replace* dest, const texture_replace* src);
+				void saveSubMap(const int index, const SCP_string& type);
+				static bool testTexture(const SCP_string&);
+				static texture_replace* texture_set(texture_replace* dest, const texture_replace* src);
 			public:
 				ShipTextureReplacementDialogModel(QObject* parent, EditorViewport* viewport, bool multi);
 

--- a/qtfred/src/mission/dialogs/ShipTextureReplacementDialogModel.h
+++ b/qtfred/src/mission/dialogs/ShipTextureReplacementDialogModel.h
@@ -1,0 +1,67 @@
+#pragma once
+
+#include "AbstractDialogModel.h"
+
+namespace fso {
+	namespace fred {
+		namespace dialogs {
+			constexpr auto NUM__SUBTEXTURE_TYPES = 7;
+			class ShipTextureReplacementDialogModel : public AbstractDialogModel {
+			private:
+				void initialiseData();
+				void initSubTypes(polymodel* model, int);
+
+				template<typename T>
+				void modify(T& a, const T& b);
+				bool _modified = false;
+				void set_modified();
+
+				bool m_multi;
+				//Used to dermeine what type of texutre a map has.
+				SCP_vector<SCP_map<SCP_string, bool>> subTypesAvailable;
+
+				//Wether to replace textures.
+				SCP_vector<SCP_map<SCP_string, bool>> replaceMap;
+				//Wether to inherit name from base texture.
+				SCP_vector<SCP_map<SCP_string, bool>> inheritMap;
+
+
+				SCP_vector<SCP_string> defaultTextures;
+				SCP_vector<SCP_map<SCP_string, SCP_string>> currentTextures;
+				bool mainChanged = false;
+				void saveSubMap(int index, SCP_string type);
+				bool testTexture(SCP_string);
+				texture_replace* texture_set(texture_replace* dest, const texture_replace* src);
+			public:
+				ShipTextureReplacementDialogModel(QObject* parent, EditorViewport* viewport, bool multi);
+
+				bool apply() override;
+				void reject() override;
+
+				int getSize() const;
+				SCP_string getDefaultName(const int) const;
+
+				void setMap(const int index, const SCP_string& type, const SCP_string& newName);
+				SCP_string getMap(const int index, const SCP_string& type) const;
+
+				SCP_map<SCP_string, bool> getSubtypesForMap(int index) const;
+				SCP_map<SCP_string, bool> getReplace(int index) const;
+				SCP_map<SCP_string, bool> getInherit(int index) const;
+				void setReplace(const int index, const SCP_string& type, const bool state);
+				void setInherit(const int index, const SCP_string& type, const bool state);
+
+				bool query_modified() const;
+
+			};
+			template<typename T>
+			inline void ShipTextureReplacementDialogModel::modify(T& a, const T& b)
+			{
+				if (a != b) {
+					a = b;
+					set_modified();
+					modelChanged();
+				}
+			}
+		}
+	}
+}

--- a/qtfred/src/ui/dialogs/ShipEditorDialog.cpp
+++ b/qtfred/src/ui/dialogs/ShipEditorDialog.cpp
@@ -687,7 +687,8 @@ void ShipEditorDialog::DepartureCueChanged(bool value) { _model->setDepartureCue
 
 void ShipEditorDialog::on_textureReplacementButton_clicked()
 {
-	// TODO:: Texture Replacement Dialog
+	auto ShipTextureReplacementDialog = new dialogs::ShipTextureReplacementDialog(this, _viewport, _model->multi_edit);
+	ShipTextureReplacementDialog->show();
 }
 
 void ShipEditorDialog::on_playerShipButton_clicked() { _model->setPlayer(true); }

--- a/qtfred/src/ui/dialogs/ShipEditorDialog.cpp
+++ b/qtfred/src/ui/dialogs/ShipEditorDialog.cpp
@@ -523,9 +523,7 @@ void ShipEditorDialog::enableDisable()
 	}
 
 	// disable textures for multiple ships
-	if (_model->multi_edit) {
-		ui->textureReplacementButton->setEnabled(false);
-	}
+		ui->textureReplacementButton->setEnabled(_model->texenable);
 
 	ui->AIClassCombo->setEnabled(_model->enable);
 	ui->cargoCombo->setEnabled(_model->enable);

--- a/qtfred/src/ui/dialogs/ShipEditorDialog.h
+++ b/qtfred/src/ui/dialogs/ShipEditorDialog.h
@@ -9,6 +9,7 @@
 #include "ShipFlagsDialog.h"
 #include "PlayerOrdersDialog.h"
 #include "ShipSpecialStatsDialog.h"
+#include "ShipTextureReplacementDialog.h"
 
 #include <QAbstractButton>
 #include <QtWidgets/QDialog>

--- a/qtfred/src/ui/dialogs/ShipTextureReplacementDialog.cpp
+++ b/qtfred/src/ui/dialogs/ShipTextureReplacementDialog.cpp
@@ -255,7 +255,7 @@ namespace fso {
 			}
 			void ShipTextureReplacementDialog::setMain()
 			{
-				SCP_string newText = "";
+				SCP_string newText;
 				if (!ui->newTextureLineEdit->text().isEmpty()) {
 					newText = ui->newTextureLineEdit->text().toStdString();
 				}
@@ -263,7 +263,7 @@ namespace fso {
 			}
 			void ShipTextureReplacementDialog::setMisc()
 			{
-				SCP_string newText = "";
+				SCP_string newText;
 				if (!ui->MiscTextureLineEdit->text().isEmpty()) {
 					 newText = ui->MiscTextureLineEdit->text().toStdString();
 					_model->setMap(row, "misc", newText);
@@ -271,7 +271,7 @@ namespace fso {
 			}
 			void ShipTextureReplacementDialog::setGlow()
 			{
-				SCP_string newText = "";
+				SCP_string newText;
 				if (!ui->GlowTextureLineEdit->text().isEmpty()) {
 					 newText = ui->GlowTextureLineEdit->text().toStdString();
 					_model->setMap(row, "glow", newText);
@@ -279,15 +279,15 @@ namespace fso {
 			}
 			void ShipTextureReplacementDialog::setShine()
 			{
-				SCP_string newText = "";
+				SCP_string newText;
 				if (!ui->ShineTextureLineEdit->text().isEmpty()) {
-					const SCP_string newText = ui->ShineTextureLineEdit->text().toStdString();
+					newText = ui->ShineTextureLineEdit->text().toStdString();
 					_model->setMap(row, "shine", newText);
 				}
 			}
 			void ShipTextureReplacementDialog::setNormal()
 			{
-				SCP_string newText = "";
+				SCP_string newText;
 				if (!ui->NormalTextureLineEdit->text().isEmpty()) {
 					 newText = ui->NormalTextureLineEdit->text().toStdString();
 					_model->setMap(row, "normal", newText);
@@ -295,25 +295,25 @@ namespace fso {
 			}
 			void ShipTextureReplacementDialog::setHeight()
 			{
-				SCP_string newText = "";
+				SCP_string newText;
 				if (!ui->HeightTextureLineEdit->text().isEmpty()) {
-					 SCP_string newText = ui->HeightTextureLineEdit->text().toStdString();
+					 newText = ui->HeightTextureLineEdit->text().toStdString();
 					_model->setMap(row, "height", newText);
 				}
 			}
 			void ShipTextureReplacementDialog::setAo()
 			{
-				SCP_string newText = "";
+				SCP_string newText;
 				if (!ui->AmbiantTextureLineEdit->text().isEmpty()) {
-					SCP_string newText = ui->AmbiantTextureLineEdit->text().toStdString();
+					newText = ui->AmbiantTextureLineEdit->text().toStdString();
 					_model->setMap(row, "ao", newText);
 				}
 			}
 			void ShipTextureReplacementDialog::setReflect()
 			{
-				SCP_string newText = "";
+				SCP_string newText;
 				if (!ui->ReflectTextureLineEdit->text().isEmpty()) {
-					SCP_string newText = ui->ReflectTextureLineEdit->text().toStdString();
+					newText = ui->ReflectTextureLineEdit->text().toStdString();
 					_model->setMap(row, "reflect", newText);
 				}
 			}

--- a/qtfred/src/ui/dialogs/ShipTextureReplacementDialog.cpp
+++ b/qtfred/src/ui/dialogs/ShipTextureReplacementDialog.cpp
@@ -264,7 +264,7 @@ namespace fso {
 			void ShipTextureReplacementDialog::setMisc()
 			{
 				SCP_string newText = "";
-				if (!ui->newTextureLineEdit->text().isEmpty()) {
+				if (!ui->MiscTextureLineEdit->text().isEmpty()) {
 					 newText = ui->MiscTextureLineEdit->text().toStdString();
 					_model->setMap(row, "misc", newText);
 				}
@@ -272,7 +272,7 @@ namespace fso {
 			void ShipTextureReplacementDialog::setGlow()
 			{
 				SCP_string newText = "";
-				if (!ui->newTextureLineEdit->text().isEmpty()) {
+				if (!ui->GlowTextureLineEdit->text().isEmpty()) {
 					 newText = ui->GlowTextureLineEdit->text().toStdString();
 					_model->setMap(row, "glow", newText);
 				}
@@ -280,7 +280,7 @@ namespace fso {
 			void ShipTextureReplacementDialog::setShine()
 			{
 				SCP_string newText = "";
-				if (!ui->newTextureLineEdit->text().isEmpty()) {
+				if (!ui->ShineTextureLineEdit->text().isEmpty()) {
 					const SCP_string newText = ui->ShineTextureLineEdit->text().toStdString();
 					_model->setMap(row, "shine", newText);
 				}
@@ -288,7 +288,7 @@ namespace fso {
 			void ShipTextureReplacementDialog::setNormal()
 			{
 				SCP_string newText = "";
-				if (!ui->newTextureLineEdit->text().isEmpty()) {
+				if (!ui->NormalTextureLineEdit->text().isEmpty()) {
 					 newText = ui->NormalTextureLineEdit->text().toStdString();
 					_model->setMap(row, "normal", newText);
 				}
@@ -296,7 +296,7 @@ namespace fso {
 			void ShipTextureReplacementDialog::setHeight()
 			{
 				SCP_string newText = "";
-				if (!ui->newTextureLineEdit->text().isEmpty()) {
+				if (!ui->HeightTextureLineEdit->text().isEmpty()) {
 					 SCP_string newText = ui->HeightTextureLineEdit->text().toStdString();
 					_model->setMap(row, "height", newText);
 				}
@@ -304,7 +304,7 @@ namespace fso {
 			void ShipTextureReplacementDialog::setAo()
 			{
 				SCP_string newText = "";
-				if (!ui->newTextureLineEdit->text().isEmpty()) {
+				if (!ui->AmbiantTextureLineEdit->text().isEmpty()) {
 					SCP_string newText = ui->AmbiantTextureLineEdit->text().toStdString();
 					_model->setMap(row, "ao", newText);
 				}
@@ -312,7 +312,7 @@ namespace fso {
 			void ShipTextureReplacementDialog::setReflect()
 			{
 				SCP_string newText = "";
-				if (!ui->newTextureLineEdit->text().isEmpty()) {
+				if (!ui->ReflectTextureLineEdit->text().isEmpty()) {
 					SCP_string newText = ui->ReflectTextureLineEdit->text().toStdString();
 					_model->setMap(row, "reflect", newText);
 				}

--- a/qtfred/src/ui/dialogs/ShipTextureReplacementDialog.cpp
+++ b/qtfred/src/ui/dialogs/ShipTextureReplacementDialog.cpp
@@ -1,0 +1,381 @@
+#include "ShipTextureReplacementDialog.h"
+
+#include "ui_ShipTextureReplacementDialog.h"
+#include <ui/util/SignalBlockers.h>
+
+#include <QCloseEvent>
+namespace fso {
+	namespace fred {
+		namespace dialogs {
+
+			//Model for list view, Should really have its own file but its not big enught for me to bother.
+			MapModel::MapModel(ShipTextureReplacementDialogModel* data, QObject* parent)
+				: QAbstractListModel(parent), _model(data)
+			{
+			}
+
+			int MapModel::rowCount(const QModelIndex& /*parent*/) const
+			{
+				return _model->getSize();
+			}
+
+			QVariant MapModel::data(const QModelIndex& index, int role) const
+			{
+				if (role == Qt::DisplayRole) {
+					QString out = _model->getDefaultName(index.row()).c_str();
+					return out;
+				}
+				if (role == Qt::SizeHintRole) {
+					QString out = _model->getDefaultName(index.row()).c_str();
+					if (out.isEmpty()) {
+						return (QSize(0, 0));
+					}
+				}
+				return QVariant();
+			}
+
+
+			ShipTextureReplacementDialog::ShipTextureReplacementDialog(QDialog* parent, EditorViewport* viewport, bool multi)
+				: QDialog(parent), ui(new Ui::ShipTextureReplacementDialog()), _model(new ShipTextureReplacementDialogModel(this, viewport, multi)),
+				_viewport(viewport)
+			{
+				ui->setupUi(this);
+				connect(this, &QDialog::accepted, _model.get(), &ShipTextureReplacementDialogModel::apply);
+				connect(this, &QDialog::rejected, _model.get(), &ShipTextureReplacementDialogModel::reject);
+				listmodel = new MapModel(_model.get(), this);
+				ui->TexturesList->setModel(listmodel);
+				QItemSelectionModel* selectionModel = ui->TexturesList->selectionModel();
+				connect(selectionModel, &QItemSelectionModel::selectionChanged,
+					this, &ShipTextureReplacementDialog::updateUIFull);
+				QModelIndex index = listmodel->index(0);
+				ui->TexturesList->setCurrentIndex(index);
+
+				connect(ui->newTextureLineEdit, &QLineEdit::editingFinished, this, &ShipTextureReplacementDialog::setMain);
+				connect(ui->MiscTextureLineEdit, &QLineEdit::editingFinished, this, &ShipTextureReplacementDialog::setMisc);
+				connect(ui->GlowTextureLineEdit, &QLineEdit::editingFinished, this, &ShipTextureReplacementDialog::setGlow);
+				connect(ui->ShineTextureLineEdit, &QLineEdit::editingFinished, this, &ShipTextureReplacementDialog::setShine);
+				connect(ui->NormalTextureLineEdit, &QLineEdit::editingFinished, this, &ShipTextureReplacementDialog::setNormal);
+				connect(ui->HeightTextureLineEdit, &QLineEdit::editingFinished, this, &ShipTextureReplacementDialog::setHeight);
+				connect(ui->AmbiantTextureLineEdit, &QLineEdit::editingFinished, this, &ShipTextureReplacementDialog::setAo);
+				connect(ui->ReflectTextureLineEdit, &QLineEdit::editingFinished, this, &ShipTextureReplacementDialog::setReflect);
+
+
+				connect(ui->useMiscTexturecheckbox, &QCheckBox::toggled, this, &ShipTextureReplacementDialog::setMiscReplace);
+				connect(ui->useGlowTexturecheckbox, &QCheckBox::toggled, this, &ShipTextureReplacementDialog::setGlowReplace);
+				connect(ui->useShineTexturecheckbox, &QCheckBox::toggled, this, &ShipTextureReplacementDialog::setShineReplace);
+				connect(ui->useNormalTexturecheckbox, &QCheckBox::toggled, this, &ShipTextureReplacementDialog::setNormalReplace);
+				connect(ui->useHeightTexturecheckbox, &QCheckBox::toggled, this, &ShipTextureReplacementDialog::setHeightReplace);
+				connect(ui->useAmbiantTexturecheckbox, &QCheckBox::toggled, this, &ShipTextureReplacementDialog::setAoReplace);
+				connect(ui->useReflectTexturecheckbox, &QCheckBox::toggled, this, &ShipTextureReplacementDialog::setReflectReplace);
+
+				connect(ui->inheritMiscTextureCheckbox, &QCheckBox::toggled, this, &ShipTextureReplacementDialog::setMiscInherit);
+				connect(ui->inheritGlowTextureCheckbox, &QCheckBox::toggled, this, &ShipTextureReplacementDialog::setGlowInherit);
+				connect(ui->inheritShineTextureCheckbox, &QCheckBox::toggled, this, &ShipTextureReplacementDialog::setShineInherit);
+				connect(ui->inheritNormalTextureCheckbox, &QCheckBox::toggled, this, &ShipTextureReplacementDialog::setNormalInherit);
+				connect(ui->inheritHeightTextureCheckbox, &QCheckBox::toggled, this, &ShipTextureReplacementDialog::setHeightInherit);
+				connect(ui->inheritAmbiantTextureCheckbox, &QCheckBox::toggled, this, &ShipTextureReplacementDialog::setAoInherit);
+				connect(ui->inheritReflectTextureCheckbox, &QCheckBox::toggled, this, &ShipTextureReplacementDialog::setReflectInherit);
+
+				connect(_model.get(), &AbstractDialogModel::modelChanged, this, &ShipTextureReplacementDialog::updateUI);
+
+				// Resize the dialog to the minimum size
+				resize(QDialog::sizeHint());
+			}
+			ShipTextureReplacementDialog::~ShipTextureReplacementDialog() = default;
+
+			void ShipTextureReplacementDialog::closeEvent(QCloseEvent* event)
+			{
+				if (_model->query_modified()) {
+					auto button = _viewport->dialogProvider->showButtonDialog(DialogType::Question, "Changes detected", "Do you want to keep your changes?",
+						{ DialogButton::Yes, DialogButton::No, DialogButton::Cancel });
+
+					if (button == DialogButton::Cancel) {
+						event->ignore();
+						return;
+					}
+
+					if (button == DialogButton::Yes) {
+						accept();
+						return;
+					}
+				}
+
+				QDialog::closeEvent(event);
+			}
+
+			void ShipTextureReplacementDialog::updateUI()
+			{
+				util::SignalBlockers blockers(this);
+				ui->newTextureLineEdit->setText(_model->getMap(row, "main").c_str());
+				bool replace;
+				bool inherit;
+				ui->useMiscTexturecheckbox->setChecked(replace = _model->getReplace(row)["misc"]);
+				if (replace) {
+					ui->inheritMiscTextureCheckbox->setChecked(inherit = _model->getInherit(row)["misc"]);
+					ui->inheritMiscTextureCheckbox->setEnabled(replace);
+					ui->MiscTextureLineEdit->setEnabled(!inherit);
+					if (!inherit) {
+						ui->MiscTextureLineEdit->setText(_model->getMap(row, "misc").c_str());
+					}
+				}
+				else {
+					ui->inheritMiscTextureCheckbox->setDisabled(true);
+					ui->MiscTextureLineEdit->setDisabled(true);
+				}
+
+				ui->useShineTexturecheckbox->setChecked(replace = _model->getReplace(row)["shine"]);
+				if (replace) {
+					ui->inheritShineTextureCheckbox->setChecked(inherit = _model->getInherit(row)["shine"]);
+					ui->inheritShineTextureCheckbox->setEnabled(replace);
+
+					ui->ShineTextureLineEdit->setEnabled(!inherit);
+					if (!inherit) {
+						ui->ShineTextureLineEdit->setText(_model->getMap(row, "shine").c_str());
+					}
+				}
+				else {
+					ui->inheritShineTextureCheckbox->setDisabled(true);
+					ui->ShineTextureLineEdit->setDisabled(true);
+				}
+
+				ui->useGlowTexturecheckbox->setChecked(replace = _model->getReplace(row)["glow"]);
+				if (replace) {
+					ui->inheritGlowTextureCheckbox->setEnabled(replace);
+					ui->inheritGlowTextureCheckbox->setChecked(inherit = _model->getInherit(row)["glow"]);
+					ui->GlowTextureLineEdit->setEnabled(!inherit);
+					if (!inherit) {
+						ui->GlowTextureLineEdit->setText(_model->getMap(row, "glow").c_str());
+					}
+				}
+				else {
+					ui->inheritGlowTextureCheckbox->setDisabled(true);
+					ui->GlowTextureLineEdit->setDisabled(true);
+				}
+
+				ui->useNormalTexturecheckbox->setChecked(replace = _model->getReplace(row)["normal"]);
+				if (replace) {
+					ui->inheritNormalTextureCheckbox->setChecked(inherit = _model->getInherit(row)["normal"]);
+					ui->inheritNormalTextureCheckbox->setEnabled(replace);
+					ui->NormalTextureLineEdit->setEnabled(!inherit);
+					if (!inherit) {
+						ui->NormalTextureLineEdit->setText(_model->getMap(row, "normal").c_str());
+					}
+				}
+				else {
+					ui->inheritNormalTextureCheckbox->setDisabled(true);
+					ui->NormalTextureLineEdit->setDisabled(true);
+				}
+
+				ui->useHeightTexturecheckbox->setChecked(replace = _model->getReplace(row)["height"]);
+				if (replace) {
+					ui->inheritHeightTextureCheckbox->setChecked(inherit = _model->getInherit(row)["height"]);
+					ui->inheritHeightTextureCheckbox->setEnabled(replace);
+					ui->HeightTextureLineEdit->setEnabled(!inherit);
+					if (!inherit) {
+						ui->HeightTextureLineEdit->setText(_model->getMap(row, "height").c_str());
+					}
+				}
+				else {
+					ui->inheritHeightTextureCheckbox->setDisabled(true);
+					ui->HeightTextureLineEdit->setDisabled(true);
+				}
+
+				ui->useAmbiantTexturecheckbox->setChecked(replace = _model->getReplace(row)["ao"]);
+				if (replace) {
+					ui->inheritAmbiantTextureCheckbox->setChecked(inherit = _model->getInherit(row)["ao"]);
+					ui->AmbiantTextureLineEdit->setEnabled(!inherit);
+					ui->inheritAmbiantTextureCheckbox->setEnabled(replace);
+					if (!inherit) {
+						ui->AmbiantTextureLineEdit->setText(_model->getMap(row, "ao").c_str());
+					}
+				}
+				else {
+					ui->inheritAmbiantTextureCheckbox->setDisabled(true);
+					ui->AmbiantTextureLineEdit->setDisabled(true);
+				}
+
+				ui->useReflectTexturecheckbox->setChecked(replace = _model->getReplace(row)["reflect"]);
+				if (replace) {
+					ui->inheritReflectTextureCheckbox->setChecked(inherit = _model->getInherit(row)["reflect"]);
+					ui->ReflectTextureLineEdit->setEnabled(!inherit);
+					ui->inheritReflectTextureCheckbox->setEnabled(replace);
+					if (!inherit) {
+						ui->ReflectTextureLineEdit->setText(_model->getMap(row, "reflect").c_str());
+					}
+				}
+				else {
+					ui->inheritReflectTextureCheckbox->setDisabled(true);
+					ui->ReflectTextureLineEdit->setDisabled(true);
+				}
+
+			}
+			void ShipTextureReplacementDialog::updateUIFull()
+			{
+				util::SignalBlockers blockers(this);
+				const QModelIndex index = ui->TexturesList->selectionModel()->currentIndex();
+				row = index.row();
+				SCP_map<SCP_string, bool> subtypes = _model->getSubtypesForMap(row);
+				bool hide = !(subtypes)["misc"];
+				ui->inheritMiscTextureCheckbox->setHidden(hide);
+				ui->MiscTextureLabel->setHidden(hide);
+				ui->MiscTextureLineEdit->setHidden(hide);
+				ui->useMiscTexturecheckbox->setHidden(hide);
+				hide = !(subtypes)["shine"];
+				ui->inheritShineTextureCheckbox->setHidden(hide);
+				ui->ShineTextureLabel->setHidden(hide);
+				ui->ShineTextureLineEdit->setHidden(hide);
+				ui->useShineTexturecheckbox->setHidden(hide);
+				hide = !(subtypes)["glow"];
+				ui->inheritGlowTextureCheckbox->setHidden(hide);
+				ui->GlowTextureLabel->setHidden(hide);
+				ui->GlowTextureLineEdit->setHidden(hide);
+				ui->useGlowTexturecheckbox->setHidden(hide);
+				hide = !(subtypes)["normal"];
+				ui->inheritNormalTextureCheckbox->setHidden(hide);
+				ui->NormalTextureLabel->setHidden(hide);
+				ui->NormalTextureLineEdit->setHidden(hide);
+				ui->useNormalTexturecheckbox->setHidden(hide);
+				hide = !(subtypes)["height"];
+				ui->inheritHeightTextureCheckbox->setHidden(hide);
+				ui->HeightTextureLabel->setHidden(hide);
+				ui->HeightTextureLineEdit->setHidden(hide);
+				ui->useHeightTexturecheckbox->setHidden(hide);
+				hide = !(subtypes)["ao"];
+				ui->inheritAmbiantTextureCheckbox->setHidden(hide);
+				ui->AmbiantTextureLabel->setHidden(hide);
+				ui->AmbiantTextureLineEdit->setHidden(hide);
+				ui->useAmbiantTexturecheckbox->setHidden(hide);
+				hide = !(subtypes)["reflect"];
+				ui->inheritReflectTextureCheckbox->setHidden(hide);
+				ui->ReflectTextureLabel->setHidden(hide);
+				ui->ReflectTextureLineEdit->setHidden(hide);
+				ui->useReflectTexturecheckbox->setHidden(hide);
+				resize(QDialog::sizeHint());
+				updateUI();
+			}
+			void ShipTextureReplacementDialog::setMain()
+			{
+				SCP_string newText = "";
+				if (!ui->newTextureLineEdit->text().isEmpty()) {
+					newText = ui->newTextureLineEdit->text().toStdString();
+				}
+				_model->setMap(row, "main", newText);
+			}
+			void ShipTextureReplacementDialog::setMisc()
+			{
+				SCP_string newText = "";
+				if (!ui->newTextureLineEdit->text().isEmpty()) {
+					 newText = ui->MiscTextureLineEdit->text().toStdString();
+					_model->setMap(row, "misc", newText);
+				}
+			}
+			void ShipTextureReplacementDialog::setGlow()
+			{
+				SCP_string newText = "";
+				if (!ui->newTextureLineEdit->text().isEmpty()) {
+					 newText = ui->GlowTextureLineEdit->text().toStdString();
+					_model->setMap(row, "glow", newText);
+				}
+			}
+			void ShipTextureReplacementDialog::setShine()
+			{
+				SCP_string newText = "";
+				if (!ui->newTextureLineEdit->text().isEmpty()) {
+					const SCP_string newText = ui->ShineTextureLineEdit->text().toStdString();
+					_model->setMap(row, "shine", newText);
+				}
+			}
+			void ShipTextureReplacementDialog::setNormal()
+			{
+				SCP_string newText = "";
+				if (!ui->newTextureLineEdit->text().isEmpty()) {
+					 newText = ui->NormalTextureLineEdit->text().toStdString();
+					_model->setMap(row, "normal", newText);
+				}
+			}
+			void ShipTextureReplacementDialog::setHeight()
+			{
+				SCP_string newText = "";
+				if (!ui->newTextureLineEdit->text().isEmpty()) {
+					 SCP_string newText = ui->HeightTextureLineEdit->text().toStdString();
+					_model->setMap(row, "height", newText);
+				}
+			}
+			void ShipTextureReplacementDialog::setAo()
+			{
+				SCP_string newText = "";
+				if (!ui->newTextureLineEdit->text().isEmpty()) {
+					SCP_string newText = ui->AmbiantTextureLineEdit->text().toStdString();
+					_model->setMap(row, "ao", newText);
+				}
+			}
+			void ShipTextureReplacementDialog::setReflect()
+			{
+				SCP_string newText = "";
+				if (!ui->newTextureLineEdit->text().isEmpty()) {
+					SCP_string newText = ui->ReflectTextureLineEdit->text().toStdString();
+					_model->setMap(row, "reflect", newText);
+				}
+			}
+
+			void ShipTextureReplacementDialog::setMiscInherit(const bool state)
+			{
+				_model->setInherit(row, "misc", state);
+			}
+			void ShipTextureReplacementDialog::setGlowInherit(const bool state)
+			{
+				_model->setInherit(row, "glow", state);
+			}
+			void ShipTextureReplacementDialog::setShineInherit(const bool state)
+			{
+				_model->setInherit(row, "shine", state);
+			}
+			void ShipTextureReplacementDialog::setNormalInherit(const bool state)
+			{
+				_model->setInherit(row, "normal", state);
+			}
+			void ShipTextureReplacementDialog::setHeightInherit(const bool state)
+			{
+				_model->setInherit(row, "height", state);
+			}
+			void ShipTextureReplacementDialog::setAoInherit(const bool state)
+			{
+				_model->setInherit(row, "ao", state);
+			}
+			void ShipTextureReplacementDialog::setReflectInherit(const bool state)
+			{
+				_model->setInherit(row, "reflect", state);
+			}
+
+
+			void ShipTextureReplacementDialog::setMiscReplace(const bool state)
+			{
+				_model->setReplace(row, "misc", state);
+			}
+			void ShipTextureReplacementDialog::setGlowReplace(const bool state)
+			{
+				_model->setReplace(row, "glow", state);
+			}
+			void ShipTextureReplacementDialog::setShineReplace(const bool state)
+			{
+				_model->setReplace(row, "shine", state);
+			}
+			void ShipTextureReplacementDialog::setNormalReplace(const bool state)
+			{
+				_model->setReplace(row, "normal", state);
+			}
+			void ShipTextureReplacementDialog::setHeightReplace(const bool state)
+			{
+				_model->setReplace(row, "height", state);
+			}
+			void ShipTextureReplacementDialog::setAoReplace(const bool state)
+			{
+				_model->setReplace(row, "ao", state);
+			}
+			void ShipTextureReplacementDialog::setReflectReplace(const bool state)
+			{
+				_model->setReplace(row, "reflect", state);
+			}
+		}
+	}
+}

--- a/qtfred/src/ui/dialogs/ShipTextureReplacementDialog.h
+++ b/qtfred/src/ui/dialogs/ShipTextureReplacementDialog.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <QtWidgets/QDialog>
+#include <QAbstractListModel>
+#include <QItemSelectionModel>
 
 #include <mission/dialogs/ShipTextureReplacementDialogModel.h>
 
@@ -11,14 +13,60 @@ namespace fso {
 			namespace Ui {
 				class ShipTextureReplacementDialog;
 			}
+			//Model for mapping data to listview in Texture Replace dialog
+			class MapModel : public QAbstractListModel
+			{
+				Q_OBJECT
+			public:
+				MapModel(ShipTextureReplacementDialogModel*, QObject* parent);
+				int rowCount(const QModelIndex& parent = QModelIndex()) const override;
+				QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const override;
+				ShipTextureReplacementDialogModel* _model;
+			};
 
 			class ShipTextureReplacementDialog : public QDialog {
-				
+
 				Q_OBJECT
 
 			public:
 				explicit ShipTextureReplacementDialog(QDialog* parent, EditorViewport* viewport, bool);
 				~ShipTextureReplacementDialog() override;
+			protected:
+				void closeEvent(QCloseEvent*) override;
+			private:
+				std::unique_ptr<Ui::ShipTextureReplacementDialog> ui;
+				std::unique_ptr<ShipTextureReplacementDialogModel> _model;
+				EditorViewport* _viewport;
+
+				int row = 0;
+				MapModel* listmodel;
+				void updateUI();
+				void updateUIFull();
+
+				void setMain();
+				void setMisc();
+				void setGlow();
+				void setShine();
+				void setNormal();
+				void setHeight();
+				void setAo();
+				void setReflect();
+
+				void setMiscInherit(const bool state);
+				void setGlowInherit(const bool state);
+				void setShineInherit(const bool state);
+				void setNormalInherit(const bool state);
+				void setHeightInherit(const bool state);
+				void setAoInherit(const bool state);
+				void setReflectInherit(const bool state);
+
+				void setMiscReplace(const bool state);
+				void setGlowReplace(const bool state);
+				void setShineReplace(const bool state);
+				void setNormalReplace(const bool state);
+				void setHeightReplace(const bool state);
+				void setAoReplace(const bool state);
+				void setReflectReplace(const bool state);
 			};
 		}
 	}

--- a/qtfred/src/ui/dialogs/ShipTextureReplacementDialog.h
+++ b/qtfred/src/ui/dialogs/ShipTextureReplacementDialog.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <QtWidgets/QDialog>
+
+#include <mission/dialogs/ShipTextureReplacementDialogModel.h>
+
+namespace fso {
+	namespace fred {
+		namespace dialogs {
+
+			namespace Ui {
+				class ShipTextureReplacementDialog;
+			}
+
+			class ShipTextureReplacementDialog : public QDialog {
+				
+				Q_OBJECT
+
+			public:
+				explicit ShipTextureReplacementDialog(QDialog* parent, EditorViewport* viewport, bool);
+				~ShipTextureReplacementDialog() override;
+			};
+		}
+	}
+}

--- a/qtfred/ui/ShipTextureReplacementDialog.ui
+++ b/qtfred/ui/ShipTextureReplacementDialog.ui
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>fso::fred::dialogs::ShipTextureReplacementDialog</class>
+ <widget class="QDialog" name="fso::fred::dialogs::ShipTextureReplacementDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>399</width>
+    <height>194</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Texture Replacement</string>
+  </property>
+  <property name="modal">
+   <bool>true</bool>
+  </property>
+  <layout class="QHBoxLayout" name="horizontalLayout">
+   <item>
+    <widget class="QGroupBox" name="currentTextureGroupBox">
+     <property name="title">
+      <string>Current Textures</string>
+     </property>
+     <layout class="QHBoxLayout" name="horizontalLayout_2">
+      <item>
+       <widget class="QListView" name="currentTexturesListView"/>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <layout class="QVBoxLayout" name="newTexturesLayout">
+     <item>
+      <layout class="QGridLayout" name="mainTextureLayout">
+       <item row="1" column="2">
+        <widget class="QLineEdit" name="newTextureLineEdit"/>
+       </item>
+       <item row="1" column="0">
+        <widget class="QLabel" name="newTextureLabel">
+         <property name="text">
+          <string>New Texture</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+     <item>
+      <widget class="QGroupBox" name="subTextureBox">
+       <property name="title">
+        <string>Other Maps</string>
+       </property>
+       <layout class="QGridLayout" name="gridLayout_2">
+        <item row="0" column="3">
+         <widget class="QLineEdit" name="SubTextureLineEdit"/>
+        </item>
+        <item row="0" column="0">
+         <widget class="QLabel" name="SubTextureLabel">
+          <property name="text">
+           <string>Template</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="1">
+         <widget class="QCheckBox" name="useSubTexturecheckbox">
+          <property name="text">
+           <string>Use</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="2">
+         <widget class="QCheckBox" name="inheritSubTextureCheckbox">
+          <property name="text">
+           <string>Inherit</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources>
+  <include location="../resources/resources.qrc"/>
+ </resources>
+ <connections/>
+</ui>

--- a/qtfred/ui/ShipTextureReplacementDialog.ui
+++ b/qtfred/ui/ShipTextureReplacementDialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>399</width>
-    <height>194</height>
+    <width>371</width>
+    <height>273</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -24,7 +24,7 @@
      </property>
      <layout class="QHBoxLayout" name="horizontalLayout_2">
       <item>
-       <widget class="QListView" name="currentTexturesListView"/>
+       <widget class="QListView" name="TexturesList"/>
       </item>
      </layout>
     </widget>
@@ -51,31 +51,182 @@
         <string>Other Maps</string>
        </property>
        <layout class="QGridLayout" name="gridLayout_2">
-        <item row="0" column="3">
-         <widget class="QLineEdit" name="SubTextureLineEdit"/>
-        </item>
-        <item row="0" column="0">
-         <widget class="QLabel" name="SubTextureLabel">
-          <property name="text">
-           <string>Template</string>
-          </property>
-         </widget>
-        </item>
         <item row="0" column="1">
-         <widget class="QCheckBox" name="useSubTexturecheckbox">
+         <widget class="QCheckBox" name="useMiscTexturecheckbox">
           <property name="text">
-           <string>Use</string>
+           <string>Replace</string>
           </property>
          </widget>
         </item>
-        <item row="0" column="2">
-         <widget class="QCheckBox" name="inheritSubTextureCheckbox">
+        <item row="5" column="3">
+         <widget class="QLineEdit" name="AmbiantTextureLineEdit"/>
+        </item>
+        <item row="0" column="3">
+         <widget class="QLineEdit" name="MiscTextureLineEdit"/>
+        </item>
+        <item row="1" column="3">
+         <widget class="QLineEdit" name="ShineTextureLineEdit"/>
+        </item>
+        <item row="4" column="3">
+         <widget class="QLineEdit" name="HeightTextureLineEdit"/>
+        </item>
+        <item row="3" column="2">
+         <widget class="QCheckBox" name="inheritNormalTextureCheckbox">
           <property name="text">
            <string>Inherit</string>
           </property>
          </widget>
         </item>
+        <item row="2" column="3">
+         <widget class="QLineEdit" name="GlowTextureLineEdit"/>
+        </item>
+        <item row="1" column="0">
+         <widget class="QLabel" name="ShineTextureLabel">
+          <property name="text">
+           <string>Shine</string>
+          </property>
+         </widget>
+        </item>
+        <item row="4" column="0">
+         <widget class="QLabel" name="HeightTextureLabel">
+          <property name="text">
+           <string>Height</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="0">
+         <widget class="QLabel" name="MiscTextureLabel">
+          <property name="text">
+           <string>Misc</string>
+          </property>
+         </widget>
+        </item>
+        <item row="5" column="1">
+         <widget class="QCheckBox" name="useAmbiantTexturecheckbox">
+          <property name="text">
+           <string>Replace</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="1">
+         <widget class="QCheckBox" name="useGlowTexturecheckbox">
+          <property name="text">
+           <string>Replace</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="0">
+         <widget class="QLabel" name="GlowTextureLabel">
+          <property name="text">
+           <string>Glow</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="2">
+         <widget class="QCheckBox" name="inheritGlowTextureCheckbox">
+          <property name="text">
+           <string>Inherit</string>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="1">
+         <widget class="QCheckBox" name="useNormalTexturecheckbox">
+          <property name="text">
+           <string>Replace</string>
+          </property>
+         </widget>
+        </item>
+        <item row="5" column="2">
+         <widget class="QCheckBox" name="inheritAmbiantTextureCheckbox">
+          <property name="text">
+           <string>Inherit</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="2">
+         <widget class="QCheckBox" name="inheritMiscTextureCheckbox">
+          <property name="text">
+           <string>Inherit</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="2">
+         <widget class="QCheckBox" name="inheritShineTextureCheckbox">
+          <property name="text">
+           <string>Inherit</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="1">
+         <widget class="QCheckBox" name="useShineTexturecheckbox">
+          <property name="text">
+           <string>Replace</string>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="0">
+         <widget class="QLabel" name="NormalTextureLabel">
+          <property name="text">
+           <string>Normal</string>
+          </property>
+         </widget>
+        </item>
+        <item row="4" column="2">
+         <widget class="QCheckBox" name="inheritHeightTextureCheckbox">
+          <property name="text">
+           <string>Inherit</string>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="3">
+         <widget class="QLineEdit" name="NormalTextureLineEdit"/>
+        </item>
+        <item row="4" column="1">
+         <widget class="QCheckBox" name="useHeightTexturecheckbox">
+          <property name="text">
+           <string>Replace</string>
+          </property>
+         </widget>
+        </item>
+        <item row="5" column="0">
+         <widget class="QLabel" name="AmbiantTextureLabel">
+          <property name="text">
+           <string>AO</string>
+          </property>
+         </widget>
+        </item>
+        <item row="6" column="0">
+         <widget class="QLabel" name="ReflectTextureLabel">
+          <property name="text">
+           <string>Reflect</string>
+          </property>
+         </widget>
+        </item>
+        <item row="6" column="1">
+         <widget class="QCheckBox" name="useReflectTexturecheckbox">
+          <property name="text">
+           <string>Replace</string>
+          </property>
+         </widget>
+        </item>
+        <item row="6" column="2">
+         <widget class="QCheckBox" name="inheritReflectTextureCheckbox">
+          <property name="text">
+           <string>Inherit</string>
+          </property>
+         </widget>
+        </item>
+        <item row="6" column="3">
+         <widget class="QLineEdit" name="ReflectTextureLineEdit"/>
+        </item>
        </layout>
+      </widget>
+     </item>
+     <item>
+      <widget class="QDialogButtonBox" name="buttonBox">
+       <property name="standardButtons">
+        <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+       </property>
       </widget>
      </item>
     </layout>
@@ -85,5 +236,38 @@
  <resources>
   <include location="../resources/resources.qrc"/>
  </resources>
- <connections/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>fso::fred::dialogs::ShipTextureReplacementDialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>296</x>
+     <y>179</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>200</x>
+     <y>100</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>fso::fred::dialogs::ShipTextureReplacementDialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>296</x>
+     <y>179</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>200</x>
+     <y>100</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
 </ui>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/2040992/155399424-4f65d1b2-b2c7-44e7-8d57-92836341d7f8.png)
New texture replacement dialog. Made with bulk editing in mind. Available map types dynamically changes based on what subtypes the default map has.
![image](https://user-images.githubusercontent.com/2040992/155399716-5b46533e-8fab-4575-ae4a-b3972a714e24.png)
It also no longer requires the user to type out the subtype names i.e. -misc -shine. that's handled automatically. and they can inherit their name from the main texture if all the submaps are named the same.