### PR TITLE
Fix render orientation for decals

### DIFF
--- a/code/decals/decals.cpp
+++ b/code/decals/decals.cpp
@@ -421,9 +421,14 @@ matrix4 getDecalTransform(Decal& decal) {
 								  decal.submodel,
 								  &objp->orient);
 
+	// The decal API sees the "direction" of a decal to be along the normal of the surface it is attached to. However,
+	// this will lead to a situation where we would look at the decal texture "from behind" causing the texture to
+	// appear flipped. We fix that here for the graphics transform.
+	vm_vec_scale(&worldDir, -1.0f);
+
 	vec3d worldUp;
 	model_instance_local_to_global_dir(&worldUp,
-								  &decal.orientation.vec.fvec,
+								  &decal.orientation.vec.uvec,
 								  pm,
 								  pmi,
 								  decal.submodel,

--- a/code/object/collideshipweapon.cpp
+++ b/code/object/collideshipweapon.cpp
@@ -132,8 +132,13 @@ static void ship_weapon_do_hit_stuff(object *pship_obj, object *weapon_obj, vec3
 
 	// Add impact decal
 	if (quadrant_num == -1 && wip->impact_decal.definition_handle >= 0) {
+		// Use the weapon orientation to augment the orientation computation. This is a very basic variant where only
+		// the object itself is taken into account
+		vec3d weapon_up;
+		vm_vec_rotate(&weapon_up, &weapon_obj->orient.vec.uvec, &pship_obj->orient);
+
 		matrix decal_orient;
-		vm_vector_2_matrix_norm(&decal_orient, &hit_dir); // hit_dir is already normalized so we can use the more efficient function
+		vm_vector_2_matrix_norm(&decal_orient, &hit_dir, &weapon_up); // hit_dir is already normalized so we can use the more efficient function
 
 		decals::addDecal(wip->impact_decal, pship_obj, submodel_num, *hitpos, decal_orient);
 	}


### PR DESCRIPTION
The orientation was broken since the engine rendered the decal box in
the direction of the hit normal which meant that the viewer was looking
at a flipped version of the decal texture.

This fixes that by flipping the direction of the decal before passing it
to the GPU.

This also fixes the orientation for weapon decals which previously did
not take the orientation of the weapon that just impacted into account.