### PR TITLE
two small but important warp fixes

### DIFF
--- a/code/playerman/playercontrol.cpp
+++ b/code/playerman/playercontrol.cpp
@@ -999,7 +999,8 @@ void read_player_controls(object *objp, float frametime)
 				target_warpout_speed = ship_get_warpout_speed(objp);
 
 				// check if warp ability has been disabled
-				if (!(Warpout_forced) && !(ship_can_warp_full_check(&Ships[objp->instance]))) {
+				// but only in the first stage
+				if (!(Warpout_forced) && !(ship_can_warp_full_check(&Ships[objp->instance])) && (Player->control_mode == PCM_WARPOUT_STAGE1)) {
 					HUD_sourced_printf(HUD_SOURCE_HIDDEN, "%s", XSTR( "Cannot warp out at this time.", 81));
 					snd_play(gamesnd_get_game_sound(GameSounds::PLAYER_WARP_FAIL));
 					gameseq_post_event( GS_EVENT_PLAYER_WARPOUT_STOP );

--- a/code/ship/shipfx.cpp
+++ b/code/ship/shipfx.cpp
@@ -3429,14 +3429,7 @@ int WE_Default::warpStart()
 
 	// determine the warping speed
 	if (direction == WarpDirection::WARP_OUT)
-	{
 		warping_speed = ship_get_warpout_speed(objp, sip, half_length, warping_dist);
-
-		// this is Volition behavior; we probably will want an AI profiles flag for this so that the ship could use its tabled speed
-		if (objp == Player_obj) {
-			warping_speed = 0.8f*objp->phys_info.max_vel.xyz.z;
-		}
-	}
 	else
 		warping_speed = warping_dist / warping_time;
 


### PR DESCRIPTION
1) Don't knock the player out of the warp if the sequence has already moved to stage two.  It breaks the sequence and the game will still end the mission anyway.
2) Remove the Volition code for calculating player speed.  It did not actually affect the speed, but it *did* affect the calculation of warp distance which often caused the player's ship to miss the portal.