### PR TITLE
Fixes the version string in main.py

### DIFF
--- a/.github/workflows/post-build-release.yaml
+++ b/.github/workflows/post-build-release.yaml
@@ -38,18 +38,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
         with:
           fetch-depth: '0'
+
       - name: Install Python dependencies
         run: pip install -r ci/post/requirements.txt
+
       - name: Post Builds (Auto trigger)
         if: ${{ github.event_name == 'workflow_call' }}
         env:
           LINUX_RESULT: ${{ github.event.inputs.linux_result }}
           WINDOWS_RESULT: ${{ github.event.inputs.windows_result }}
         run: python ci/post/main.py release
-      
+
       - name: Post Builds (Manual trigger)
         if: ${{ github.event_name == 'workflow_dispatch' }}
         # assume user knows what they're doing...

--- a/ci/post/main.py
+++ b/ci/post/main.py
@@ -62,22 +62,41 @@ def _match_version_number(text, regex):
 	return int(match.group(1))
 	
 
-def get_source_version(date_version):
+def get_source_version(date_version: datetime, tag_name: str) -> semantic_version.Version:
 	"""! Retrieves the build's version from `version.cmake`, forms it as a string, and appends the date
 
 	@param[in] `date_version` Date this build is published for release
+	@param[in] 'tag_name'     Tag of this release, used to determine if release, rc, or nightly
 
-	@return String of the form `MAJOR_VERSION.MINOR_VERSION.BUILD_VERSION-date`
+	@return String of the form `MAJOR_VERSION.MINOR_VERSION.BUILD_VERSION-date`, ' MAJOR_VERS
 	"""
-	
+	major = minor = build = version = 0
 	with open(os.path.join("..", "..", "cmake", "version.cmake"), "r") as f:
 		filetext = f.read()
-
 		major = _match_version_number(filetext, MAJOR_VERSION_PATTERN)
 		minor = _match_version_number(filetext, MINOR_VERSION_PATTERN)
 		build = _match_version_number(filetext, BUILD_VERSION_PATTERN)
 
-		return semantic_version.Version("{}.{}.{}-{}".format(major, minor, build, date_version))
+	if "release" in tag_name.lower():
+		version = semantic_version.Version("{}.{}.{}".format(major, minor, build))
+
+	elif "nightly" in tag_name.lower():
+		version = semantic_version.Version("{}.{}.{}-{}".format(major, minor, build, date_version))
+	
+	elif "rc" in tag_name.lower():
+		# Release canidates retain an internal version unstable, but external version is the tagname
+		# tag_name format is release_<year>_<major>_<minor>_RC<build>
+		x = tag_name.upper().split("_")
+		# "release" = x[0], year = x[1], major = x[2], minor = x[3], build = x[4], 
+		version = semantic_version.Version("{}.{}.{}-{}".format(x[1], x[2], x[3], x[4]))
+		version.prerelease = True
+
+	else:	
+		print("ERROR: malformed tag_name %s" % tag_name)
+		sys.exit(1)
+
+	print("version: {}".format(version))
+	return version
 
 
 def main():
@@ -125,7 +144,7 @@ def main():
 
 	tag_name = os.environ["RELEASE_TAG"]	##!< commit tag string
 	date = datetime.now()	##!< current date
-	version = get_source_version(date.strftime(DATEFORMAT_VERSION))	##!< form full version string
+	version = get_source_version(date.strftime(DATEFORMAT_VERSION), tag_name)	##!< form full version string
 	success = os.environ["LINUX_RESULT"] == "success" and os.environ["WINDOWS_RESULT"] == "success"	##!< true if both linux and windows builds successful
 
 	# check that tag_name is actually in the git repo and find the previous tag release
@@ -189,7 +208,7 @@ def main():
 				print("ERROR: No x64-AVX builds were detected!")
 				sys.exit(1)
 		else:
-			print("ERROR: Now x64 builds were detected!")
+			print("ERROR: No x64 builds were detected!")
 			sys.exit(1)
 		
 		if "Linux" not in groups.keys():

--- a/ci/post/main.py
+++ b/ci/post/main.py
@@ -83,7 +83,6 @@ def get_source_version(date_version: datetime, tag_name: str) -> semantic_versio
 		x = tag_name.upper().split("_")
 		# "release" = x[0], year = x[1], major = x[2], minor = x[3], build = x[4], 
 		version = semantic_version.Version("{}.{}.{}-{}".format(x[1], x[2], x[3], x[4]))
-		version.prerelease = True
 
 	elif "release" in tag_name.lower():
 		version = semantic_version.Version("{}.{}.{}".format(major, minor, build))
@@ -96,6 +95,7 @@ def get_source_version(date_version: datetime, tag_name: str) -> semantic_versio
 		sys.exit(1)
 
 	print("version: {}".format(version))
+	print("version.prerelease: {}".format(version.prerelease))
 	return version
 
 

--- a/ci/post/main.py
+++ b/ci/post/main.py
@@ -66,9 +66,11 @@ def get_source_version(date_version: datetime, tag_name: str) -> semantic_versio
 	"""! Retrieves the build's version from `version.cmake`, forms it as a string, and appends the date
 
 	@param[in] `date_version` Date this build is published for release
-	@param[in] 'tag_name'     Tag of this release, used to determine if release, rc, or nightly
+	@param[in] `tag_name`     Tag of this release, used to determine if release, rc, or nightly
 
-	@return String of the form `MAJOR_VERSION.MINOR_VERSION.BUILD_VERSION-date`, ' MAJOR_VERS
+	@return If release: `MAJOR_VERSION.MINOR_VERSION.BUILD_VERSION` from version.cmake, or
+	@return If rc:      `MAJOR_VERSION.MINOR_VERSION.BUILD_VERSION` from tag_name, or
+	@return If nightly: `MAJOR_VERSION.MINOR_VERSION.BUILD_VERSION-date` from version.cmake
 	"""
 	major = minor = build = version = 0
 	with open(os.path.join("..", "..", "cmake", "version.cmake"), "r") as f:
@@ -78,8 +80,9 @@ def get_source_version(date_version: datetime, tag_name: str) -> semantic_versio
 		build = _match_version_number(filetext, BUILD_VERSION_PATTERN)
 
 	if "rc" in tag_name.lower():
-		# Release canidates retain an internal version unstable, but external version is the tagname
-		# tag_name format is release_<year>_<major>_<minor>_RC<build>
+		# Release candidates idenfity with their unstable version (ex: 21.5.0-03052022) within the game and the logs, but
+		# the builds are named with the target release version (ex: 22.0.0).  Since this script works on the builds we
+		# need to grab the target release version from tag_name
 		x = tag_name.upper().split("_")
 		# "release" = x[0], year = x[1], major = x[2], minor = x[3], build = x[4], 
 		version = semantic_version.Version("{}.{}.{}-{}".format(x[1], x[2], x[3], x[4]))

--- a/ci/post/main.py
+++ b/ci/post/main.py
@@ -77,13 +77,7 @@ def get_source_version(date_version: datetime, tag_name: str) -> semantic_versio
 		minor = _match_version_number(filetext, MINOR_VERSION_PATTERN)
 		build = _match_version_number(filetext, BUILD_VERSION_PATTERN)
 
-	if "release" in tag_name.lower():
-		version = semantic_version.Version("{}.{}.{}".format(major, minor, build))
-
-	elif "nightly" in tag_name.lower():
-		version = semantic_version.Version("{}.{}.{}-{}".format(major, minor, build, date_version))
-	
-	elif "rc" in tag_name.lower():
+	if "rc" in tag_name.lower():
 		# Release canidates retain an internal version unstable, but external version is the tagname
 		# tag_name format is release_<year>_<major>_<minor>_RC<build>
 		x = tag_name.upper().split("_")
@@ -91,6 +85,12 @@ def get_source_version(date_version: datetime, tag_name: str) -> semantic_versio
 		version = semantic_version.Version("{}.{}.{}-{}".format(x[1], x[2], x[3], x[4]))
 		version.prerelease = True
 
+	elif "release" in tag_name.lower():
+		version = semantic_version.Version("{}.{}.{}".format(major, minor, build))
+
+	elif "nightly" in tag_name.lower():
+		version = semantic_version.Version("{}.{}.{}-{}".format(major, minor, build, date_version))
+	
 	else:	
 		print("ERROR: malformed tag_name %s" % tag_name)
 		sys.exit(1)


### PR DESCRIPTION
This should now use the correct version string for both rc and release builds, which affects both Nebula publishing and the forum post title