### PR TITLE
fix support ships breaking in in-mission jumps

### DIFF
--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -10843,7 +10843,7 @@ void ai_do_objects_repairing_stuff( object *repaired_objp, object *repair_objp, 
 		Int3();			// bogus type of repair info
 	}
 
-	// repair_objp might be NULL is we are cleaning up this mode because of the support ship
+	// repair_objp might be NULL if we are cleaning up this mode because of the support ship
 	// getting killed.
 	if ( repair_objp ) {
         Ai_info[Ships[repair_objp->instance].ai_index].warp_out_timestamp = stamp;

--- a/code/ai/aigoals.cpp
+++ b/code/ai/aigoals.cpp
@@ -266,13 +266,19 @@ void ai_remove_ship_goal( ai_info *aip, int index )
 	// ai goal code look
 	Assert ( index >= 0 );			// must have a valid goal
 
+	if (index == aip->active_goal)
+	{
+		// rearm/repair needs a bit of extra cleanup
+		if (aip->goals[index].ai_mode == AI_GOAL_REARM_REPAIR)
+			ai_abort_rearm_request(&Objects[Ships[aip->shipnum].objnum]);
+
+		aip->active_goal = AI_GOAL_NONE;
+	}
+
 	aip->goals[index].ai_mode = AI_GOAL_NONE;
 	aip->goals[index].signature = -1;
 	aip->goals[index].priority = -1;
 	aip->goals[index].flags.reset(); // must reset the flags since not doing so will screw up goal sorting.
-
-	if ( index == aip->active_goal )
-		aip->active_goal = AI_GOAL_NONE;
 
 	// mwa -- removed this line 8/5/97.  Just because we remove a goal doesn't mean to do the default
 	// behavior.  We will make the call commented out below in a more reasonable location


### PR DESCRIPTION
If a support ship's repair goal is removed, abort the rearm.  There is extra cleanup that needs to be done for this goal only.