### PR TITLE
Fix nested and animated submodel collisions

### DIFF
--- a/code/asteroid/asteroid.cpp
+++ b/code/asteroid/asteroid.cpp
@@ -1092,7 +1092,6 @@ int asteroid_check_collision(object *pasteroid, object *other_obj, vec3d *hitpos
 					pmi->submodel[submodel].collision_checked = true;
 				}
 
-				// reset flags to check MC_CHECK_MODEL | MC_CHECK_SPHERELINE and maybe MC_CHECK_INVISIBLE_FACES and MC_SUBMODEL_INSTANCE
 				// Only check single submodel now, since children of moving submodels are handled as moving as well
 				mc.flags = copy_flags | MC_SUBMODEL;
 

--- a/code/asteroid/asteroid.cpp
+++ b/code/asteroid/asteroid.cpp
@@ -1093,7 +1093,8 @@ int asteroid_check_collision(object *pasteroid, object *other_obj, vec3d *hitpos
 				}
 
 				// reset flags to check MC_CHECK_MODEL | MC_CHECK_SPHERELINE and maybe MC_CHECK_INVISIBLE_FACES and MC_SUBMODEL_INSTANCE
-				mc.flags = copy_flags | MC_SUBMODEL_INSTANCE;
+				// Only check single submodel now, since children of moving submodels are handled as moving as well
+				mc.flags = copy_flags | MC_SUBMODEL;
 
 				// check each submodel in turn
 				for (auto submodel: submodel_vector) {
@@ -1102,15 +1103,9 @@ int asteroid_check_collision(object *pasteroid, object *other_obj, vec3d *hitpos
 					// turn on just one submodel for collision test
 					smi->collision_checked = false;
 
-					// set angles for last frame (need to set to prev to get p0)
-					matrix copy_matrix = smi->canonical_orient;
-
 					// find the start and end positions of the sphere in submodel RF
-					smi->canonical_orient = smi->canonical_prev_orient;
-					model_instance_world_to_local_point(&p0, &light_obj->last_pos, pm, pmi, submodel, &heavy_obj->last_orient, &heavy_obj->last_pos);
-
-					smi->canonical_orient = copy_matrix;
-					model_instance_world_to_local_point(&p1, &light_obj->pos, pm, pmi, submodel, &heavy_obj->orient, &heavy_obj->pos);
+					model_instance_global_to_local_point(&p0, &light_obj->last_pos, pm, pmi, submodel, &heavy_obj->last_orient, &heavy_obj->last_pos, true);
+					model_instance_global_to_local_point(&p1, &light_obj->pos, pm, pmi, submodel, &heavy_obj->orient, &heavy_obj->pos);
 
 					mc.p0 = &p0;
 					mc.p1 = &p1;

--- a/code/debris/debris.cpp
+++ b/code/debris/debris.cpp
@@ -865,7 +865,8 @@ int debris_check_collision(object *pdebris, object *other_obj, vec3d *hitpos, co
 				}
 
 				// reset flags to check MC_CHECK_MODEL | MC_CHECK_SPHERELINE and maybe MC_CHECK_INVISIBLE_FACES and MC_SUBMODEL_INSTANCE
-				mc.flags = copy_flags | MC_SUBMODEL_INSTANCE;
+				// Only check single submodel now, since children of moving submodels are handled as moving as well
+				mc.flags = copy_flags | MC_SUBMODEL;
 
 				if (Ship_info[Ships[pship_obj->instance].ship_info_index].collision_lod > -1) {
 					mc.lod = Ship_info[Ships[pship_obj->instance].ship_info_index].collision_lod;
@@ -878,15 +879,9 @@ int debris_check_collision(object *pdebris, object *other_obj, vec3d *hitpos, co
 					// turn on just one submodel for collision test
 					smi->collision_checked = false;
 
-					// set angles for last frame (need to set to prev to get p0)
-					matrix copy_matrix = smi->canonical_orient;
-
 					// find the start and end positions of the sphere in submodel RF
-					smi->canonical_orient = smi->canonical_prev_orient;
-					model_instance_world_to_local_point(&p0, &light_obj->last_pos, pm, pmi, submodel, &heavy_obj->last_orient, &heavy_obj->last_pos);
-
-					smi->canonical_orient = copy_matrix;
-					model_instance_world_to_local_point(&p1, &light_obj->pos, pm, pmi, submodel, &heavy_obj->orient, &heavy_obj->pos);
+					model_instance_global_to_local_point(&p0, &light_obj->last_pos, pm, pmi, submodel, &heavy_obj->last_orient, &heavy_obj->last_pos, true);
+					model_instance_global_to_local_point(&p1, &light_obj->pos, pm, pmi, submodel, &heavy_obj->orient, &heavy_obj->pos);
 
 					mc.p0 = &p0;
 					mc.p1 = &p1;

--- a/code/debris/debris.cpp
+++ b/code/debris/debris.cpp
@@ -864,7 +864,6 @@ int debris_check_collision(object *pdebris, object *other_obj, vec3d *hitpos, co
 					pmi->submodel[submodel].collision_checked = true;
 				}
 
-				// reset flags to check MC_CHECK_MODEL | MC_CHECK_SPHERELINE and maybe MC_CHECK_INVISIBLE_FACES and MC_SUBMODEL_INSTANCE
 				// Only check single submodel now, since children of moving submodels are handled as moving as well
 				mc.flags = copy_flags | MC_SUBMODEL;
 

--- a/code/model/model.h
+++ b/code/model/model.h
@@ -795,7 +795,7 @@ public:
 // The "level" parameter indicates how deep the nesting level is, and the "isLeaf" parameter indicates whether the submodel is a leaf node.
 // To find the model's detail0 root node, use pm->submodel[pm->detail[0]].
 template <typename Func, typename... AdditionalParams>
-void model_iterate_submodel_tree(polymodel* pm, int submodel, Func func, int level = 0, AdditionalParams... params)
+void model_iterate_submodel_tree(polymodel* pm, int submodel, Func func, int level, AdditionalParams... params)
 {
 	Assertion(pm != nullptr, "pm must not be null!");
 	Assertion(submodel >= 0 && submodel < pm->n_models, "submodel must be in range!");
@@ -809,6 +809,13 @@ void model_iterate_submodel_tree(polymodel* pm, int submodel, Func func, int lev
 		model_iterate_submodel_tree(pm, child, func, level + 1, params...);
 		child = pm->submodel[child].next_sibling;
 	}
+}
+
+//This wrapper function is needed due to a bug in clang versions before 11 which breaks default parameters before parameter packs
+template <typename Func>
+inline void model_iterate_submodel_tree(polymodel* pm, int submodel, Func func)
+{
+	model_iterate_submodel_tree(pm, submodel, func, 0);
 }
 
 // Call once to initialize the model system

--- a/code/model/model.h
+++ b/code/model/model.h
@@ -109,6 +109,9 @@ struct submodel_instance
 	vec3d	arc_pts[MAX_ARC_EFFECTS][2];
 	ubyte		arc_type[MAX_ARC_EFFECTS];							// see MARC_TYPE_* defines
 
+	//SMI-Specific movement axis. Only valid in MOVEMENT_TYPE_TRIGGERED.
+	vec3d	rotation_axis;
+
 	submodel_instance()
 	{
 		memset(&arc_pts, 0, MAX_ARC_EFFECTS * 2 * sizeof(vec3d));

--- a/code/model/model.h
+++ b/code/model/model.h
@@ -90,9 +90,6 @@ struct submodel_instance
 	float	turn_accel = 0.0f;
 	int		turn_step_zero_timestamp = timestamp();		// timestamp determines when next step is to begin (for stepped rotation)
 
-	vec3d	point_on_axis = vmd_zero_vector;		// in ship RF
-	bool	axis_set = false;
-
 	bool	blown_off = false;						// If set, this subobject is blown off
 	bool	collision_checked = false;
 
@@ -1027,9 +1024,6 @@ void model_get_moving_submodel_list(SCP_vector<int> &submodel_vector, const obje
 
 // Given a polygon model index, get a list of a model tree starting from that index
 void model_get_submodel_tree_list(SCP_vector<int> &submodel_vector, const polymodel *pm, int mn);
-
-// For a rotating submodel, find a point on the axis
-void model_init_submodel_axis_pt(polymodel *pm, polymodel_instance *pmi, int submodel_num);
 
 // Clears all the submodel instances stored in a model to their defaults.
 extern void model_clear_instance(int model_num);

--- a/code/model/model.h
+++ b/code/model/model.h
@@ -983,24 +983,42 @@ extern void model_local_to_global_dir(vec3d *out_dir, const vec3d *in_dir, int m
 // If objorient and objpos are supplied, this will be world space; otherwise it will be the model's space.
 extern void model_local_to_global_dir(vec3d *out_dir, const vec3d *in_dir, const polymodel *pm, int submodel_num, const matrix *objorient = nullptr);
 
-// Given a direction (or normal) in a submodel's local frame of reference, transform it to a global frame of reference, taking into account submodel rotations..
+// Given a direction (or normal) in a submodel's local frame of reference, transform it to a global frame of reference, taking into account submodel rotations.
 // If objorient and objpos are supplied, this will be world space; otherwise it will be the model's space.
 extern void model_instance_local_to_global_dir(vec3d *out_dir, const vec3d *in_dir, int model_instance_num, int submodel_num, const matrix *objorient = nullptr, bool use_submodel_parent = false);
-// Given a direction (or normal) in a submodel's local frame of reference, transform it to a global frame of reference, taking into account submodel rotations..
+// Given a direction (or normal) in a submodel's local frame of reference, transform it to a global frame of reference, taking into account submodel rotations.
 // If objorient and objpos are supplied, this will be world space; otherwise it will be the model's space.
 extern void model_instance_local_to_global_dir(vec3d *out_dir, const vec3d *in_dir, const polymodel *pm, const polymodel_instance *pmi, int submodel_num, const matrix *objorient = nullptr);
-
-// Given a point in world coordinates, transform it to a submodel's local frame of reference.
-// This is special purpose code, specific for model collision.
-// NOTE - this code ASSUMES submodel is 1 level down from hull (detail[0])
-// TODO - fix this function to work for all submodel levels
-extern void model_instance_world_to_local_point(vec3d *out, vec3d *world_pt, const polymodel *pm, const polymodel_instance *pmi, int submodel_num, const matrix *orient, const vec3d *pos);
 
 // Combines model_instance_local_to_global_point and model_instance_local_to_global_dir into one function.
 extern void model_instance_local_to_global_point_dir(vec3d *outpnt, vec3d *outnorm, const vec3d *submodel_pnt, const vec3d *submodel_norm, const polymodel *pm, const polymodel_instance *pmi, int submodel_num, const matrix *objorient = nullptr, const vec3d *objpos = nullptr);
 
 // Combines model_instance_local_to_global_point and the matrix equivalent of model_instance_local_to_global_dir into one function.
 extern void model_instance_local_to_global_point_orient(vec3d *outpnt, matrix *outorient, const vec3d *submodel_pnt, const matrix *submodel_orient, const polymodel *pm, const polymodel_instance *pmi, int submodel_num, const matrix *objorient = nullptr, const vec3d *objpos = nullptr);
+
+
+// Given a point in a global frame of reference, transform it to a submodel's local frame of reference, taking into account submodel rotations.
+// If objorient and objpos are supplied, the global frame will be world space; otherwise it will be the model's space.
+extern void model_instance_global_to_local_point(vec3d *outpnt, const vec3d *mpnt, int model_instance_num, int submodel_num, const matrix *objorient = nullptr, const vec3d *objpos = nullptr);
+// Given a point in a global frame of reference, transform it to a submodel's local frame of reference, taking into account submodel rotations.
+// If objorient and objpos are supplied, the global frame will be world space; otherwise it will be the model's space.
+extern void model_instance_global_to_local_point(vec3d *outpnt, const vec3d *mpnt, const polymodel *pm, const polymodel_instance *pmi, int submodel_num, const matrix *objorient = nullptr, const vec3d *objpos = nullptr);
+
+// Given a direction (or normal) in a global frame of reference, transform it to a submodel's local frame of reference, taking into account submodel rotations.
+// If objorient is supplied, the global frame will be world space; otherwise it will be the model's space.
+extern void model_instance_global_to_local_dir(vec3d *out_dir, const vec3d *in_dir, int model_instance_num, int submodel_num, const matrix *objorient = nullptr, bool use_submodel_parent = false);
+// Given a direction (or normal) in a global frame of reference, transform it to a submodel's local frame of reference, taking into account submodel rotations.
+// If objorient is supplied, the global frame will be world space; otherwise it will be the model's space.
+extern void model_instance_global_to_local_dir(vec3d *out_dir, const vec3d *in_dir, const polymodel *pm, const polymodel_instance *pmi, int submodel_num, const matrix *objorient = nullptr);
+
+
+// TODO remove --------
+// Given a point in world coordinates, transform it to a submodel's local frame of reference.
+// This is special purpose code, specific for model collision.
+// NOTE - this code ASSUMES submodel is 1 level down from hull (detail[0])
+// TODO - fix this function to work for all submodel levels
+extern void model_instance_world_to_local_point(vec3d* out, vec3d* world_pt, const polymodel* pm, const polymodel_instance* pmi, int submodel_num, const matrix* orient, const vec3d* pos);
+// TODO remove --------
 
 // ------- end of submodel transformations -------
 

--- a/code/model/model.h
+++ b/code/model/model.h
@@ -797,19 +797,19 @@ public:
 //
 // The "level" parameter indicates how deep the nesting level is, and the "isLeaf" parameter indicates whether the submodel is a leaf node.
 // To find the model's detail0 root node, use pm->submodel[pm->detail[0]].
-template <typename Func>
-void model_iterate_submodel_tree(polymodel* pm, int submodel, Func func, int level = 0)
+template <typename Func, typename... AdditionalParams>
+void model_iterate_submodel_tree(polymodel* pm, int submodel, Func func, int level = 0, AdditionalParams... params)
 {
 	Assertion(pm != nullptr, "pm must not be null!");
 	Assertion(submodel >= 0 && submodel < pm->n_models, "submodel must be in range!");
 
 	auto child = pm->submodel[submodel].first_child;
 
-	func(submodel, level, child < 0);
+	func(submodel, level, child < 0, params...);
 
 	while (child >= 0)
 	{
-		model_iterate_submodel_tree(pm, child, func, level + 1);
+		model_iterate_submodel_tree(pm, child, func, level + 1, params...);
 		child = pm->submodel[child].next_sibling;
 	}
 }
@@ -999,17 +999,17 @@ extern void model_instance_local_to_global_point_orient(vec3d *outpnt, matrix *o
 
 // Given a point in a global frame of reference, transform it to a submodel's local frame of reference, taking into account submodel rotations.
 // If objorient and objpos are supplied, the global frame will be world space; otherwise it will be the model's space.
-extern void model_instance_global_to_local_point(vec3d *outpnt, const vec3d *mpnt, int model_instance_num, int submodel_num, const matrix *objorient = nullptr, const vec3d *objpos = nullptr);
+extern void model_instance_global_to_local_point(vec3d *outpnt, const vec3d *mpnt, int model_instance_num, int submodel_num, const matrix *objorient = nullptr, const vec3d *objpos = nullptr, bool use_last_frame = false);
 // Given a point in a global frame of reference, transform it to a submodel's local frame of reference, taking into account submodel rotations.
 // If objorient and objpos are supplied, the global frame will be world space; otherwise it will be the model's space.
-extern void model_instance_global_to_local_point(vec3d *outpnt, const vec3d *mpnt, const polymodel *pm, const polymodel_instance *pmi, int submodel_num, const matrix *objorient = nullptr, const vec3d *objpos = nullptr);
+extern void model_instance_global_to_local_point(vec3d *outpnt, const vec3d *mpnt, const polymodel *pm, const polymodel_instance *pmi, int submodel_num, const matrix *objorient = nullptr, const vec3d *objpos = nullptr, bool use_last_frame = false);
 
 // Given a direction (or normal) in a global frame of reference, transform it to a submodel's local frame of reference, taking into account submodel rotations.
 // If objorient is supplied, the global frame will be world space; otherwise it will be the model's space.
-extern void model_instance_global_to_local_dir(vec3d *out_dir, const vec3d *in_dir, int model_instance_num, int submodel_num, const matrix *objorient = nullptr, bool use_submodel_parent = false);
+extern void model_instance_global_to_local_dir(vec3d *out_dir, const vec3d *in_dir, int model_instance_num, int submodel_num, const matrix *objorient = nullptr, bool use_submodel_parent = false, bool use_last_frame = false);
 // Given a direction (or normal) in a global frame of reference, transform it to a submodel's local frame of reference, taking into account submodel rotations.
 // If objorient is supplied, the global frame will be world space; otherwise it will be the model's space.
-extern void model_instance_global_to_local_dir(vec3d *out_dir, const vec3d *in_dir, const polymodel *pm, const polymodel_instance *pmi, int submodel_num, const matrix *objorient = nullptr);
+extern void model_instance_global_to_local_dir(vec3d *out_dir, const vec3d *in_dir, const polymodel *pm, const polymodel_instance *pmi, int submodel_num, const matrix *objorient = nullptr, bool use_last_frame = false);
 
 
 // TODO remove --------
@@ -1017,7 +1017,7 @@ extern void model_instance_global_to_local_dir(vec3d *out_dir, const vec3d *in_d
 // This is special purpose code, specific for model collision.
 // NOTE - this code ASSUMES submodel is 1 level down from hull (detail[0])
 // TODO - fix this function to work for all submodel levels
-extern void model_instance_world_to_local_point(vec3d* out, vec3d* world_pt, const polymodel* pm, const polymodel_instance* pmi, int submodel_num, const matrix* orient, const vec3d* pos);
+//extern void model_instance_world_to_local_point(vec3d* out, vec3d* world_pt, const polymodel* pm, const polymodel_instance* pmi, int submodel_num, const matrix* orient, const vec3d* pos);
 // TODO remove --------
 
 // ------- end of submodel transformations -------

--- a/code/model/model.h
+++ b/code/model/model.h
@@ -1015,15 +1015,6 @@ extern void model_instance_global_to_local_dir(vec3d *out_dir, const vec3d *in_d
 // If objorient is supplied, the global frame will be world space; otherwise it will be the model's space.
 extern void model_instance_global_to_local_dir(vec3d *out_dir, const vec3d *in_dir, const polymodel *pm, const polymodel_instance *pmi, int submodel_num, const matrix *objorient = nullptr, bool use_last_frame = false);
 
-
-// TODO remove --------
-// Given a point in world coordinates, transform it to a submodel's local frame of reference.
-// This is special purpose code, specific for model collision.
-// NOTE - this code ASSUMES submodel is 1 level down from hull (detail[0])
-// TODO - fix this function to work for all submodel levels
-//extern void model_instance_world_to_local_point(vec3d* out, vec3d* world_pt, const polymodel* pm, const polymodel_instance* pmi, int submodel_num, const matrix* orient, const vec3d* pos);
-// TODO remove --------
-
 // ------- end of submodel transformations -------
 
 // Given a polygon model index, find a list of moving submodels to be used for collision

--- a/code/model/modelanimation.cpp
+++ b/code/model/modelanimation.cpp
@@ -318,7 +318,7 @@ namespace animation {
 
 		float deltaAngle;
 		vm_matrix_to_rot_axis_and_angle(&delta, &deltaAngle, &submodel->rotation_axis);
-		submodel->current_turn_rate = deltaAngle * flFrametime;
+		submodel->current_turn_rate = deltaAngle / flFrametime;
 
 		//TODO: Once translation is a thing
 		//m_subsys->submodel_instance_1->offset = data.position;

--- a/code/model/modelanimation.cpp
+++ b/code/model/modelanimation.cpp
@@ -324,6 +324,15 @@ namespace animation {
 		//m_subsys->submodel_instance_1->offset = data.position;
 	}
 
+	void ModelAnimationSubmodel::resetPhysicsData(polymodel_instance* pmi) {
+		submodel_instance* submodel = findSubmodel(pmi).first;
+		if (!submodel)
+			return;
+
+		submodel->canonical_prev_orient = submodel->canonical_orient;
+		submodel->current_turn_rate = 0.0f;
+	}
+
 	void ModelAnimationSubmodel::saveCurrentAsBase(polymodel_instance* pmi) {
 		auto submodel = findSubmodel(pmi);
 		ModelAnimationData<>& data = m_initialData[{ pmi->id }];
@@ -591,8 +600,10 @@ namespace animation {
 
 	void ModelAnimationSet::apply(polymodel_instance* pmi, const ModelAnimationSubmodelBuffer& applyBuffer) {
 		for (const auto& toApply : applyBuffer) {
-			if(toApply.second.modified)
+			if (toApply.second.modified)
 				toApply.first->copyToSubmodel(toApply.second.data, pmi);
+			else
+				toApply.first->resetPhysicsData(pmi);
 		}
 	}
 

--- a/code/model/modelanimation.cpp
+++ b/code/model/modelanimation.cpp
@@ -318,6 +318,7 @@ namespace animation {
 
 		float deltaAngle;
 		vm_matrix_to_rot_axis_and_angle(&delta, &deltaAngle, &submodel->rotation_axis);
+		submodel->current_turn_rate = deltaAngle * flFrametime;
 
 		//TODO: Once translation is a thing
 		//m_subsys->submodel_instance_1->offset = data.position;

--- a/code/model/modelanimation.cpp
+++ b/code/model/modelanimation.cpp
@@ -312,6 +312,13 @@ namespace animation {
 		submodel->canonical_prev_orient = submodel->canonical_orient;
 		submodel->canonical_orient = data.orientation;
 
+		matrix delta;
+		vm_copy_transpose(&delta, &submodel->canonical_prev_orient);
+		vm_matrix_x_matrix(&delta, &submodel->canonical_orient, &delta);
+
+		float deltaAngle;
+		vm_matrix_to_rot_axis_and_angle(&delta, &deltaAngle, &submodel->rotation_axis);
+
 		//TODO: Once translation is a thing
 		//m_subsys->submodel_instance_1->offset = data.position;
 	}
@@ -326,6 +333,10 @@ namespace animation {
 		if(!submodel.second->flags[Model::Submodel_flags::Can_move]){
 			mprintf(("Submodel %s of model %s is animated and has movement enabled.\n", submodel.second->name, model_get(pmi->model_num)->filename));
 			submodel.second->flags.set(Model::Submodel_flags::Can_move);
+
+			if (submodel.second->rotation_type == MOVEMENT_TYPE_NONE) {
+				submodel.second->rotation_type = MOVEMENT_TYPE_TRIGGERED;
+			}
 		}
 		
 		data.orientation = submodel.first->canonical_orient;
@@ -436,6 +447,7 @@ namespace animation {
 
 		float angle = 0.0f;
 		vm_closest_angle_to_matrix(&submodel->canonical_orient, &sm->rotation_axis, &angle);
+		submodel->rotation_axis = sm->rotation_axis;
 
 		submodel->cur_angle = angle;
 		submodel->turret_idle_angle = angle;

--- a/code/model/modelanimation.h
+++ b/code/model/modelanimation.h
@@ -185,6 +185,8 @@ namespace animation {
 		//Reapply the calculated animation state to the submodel
 		virtual void copyToSubmodel(const ModelAnimationData<>& data, polymodel_instance* pmi);
 
+		void resetPhysicsData(polymodel_instance* pmi);
+
 		friend class ModelAnimationSet;
 	};
 

--- a/code/model/modelread.cpp
+++ b/code/model/modelread.cpp
@@ -4370,6 +4370,7 @@ void model_get_moving_submodel_list(SCP_vector<int> &submodel_vector, const obje
 		const auto& child_submodel = pm->submodel[submodel];
 		const auto& child_submodel_instance = pmi->submodel[submodel];
 
+		// Don't check it or its children if it is destroyed or it is a replacement (non-moving)
 		if (child_submodel.flags[Model::Submodel_flags::No_collisions] || child_submodel_instance.blown_off || child_submodel.i_replace != -1) {
 			skipChildren = true;
 			return;

--- a/code/model/modelread.cpp
+++ b/code/model/modelread.cpp
@@ -4268,7 +4268,7 @@ void model_instance_global_to_local_point(vec3d* outpnt, const vec3d* mpnt, cons
 void model_instance_global_to_local_dir(vec3d* out_dir, const vec3d* in_dir, int model_instance_num, int submodel_num, const matrix* objorient, bool use_submodel_parent, bool use_last_frame) {
 	auto pmi = model_get_instance(model_instance_num);
 	auto pm = model_get(pmi->model_num);
-	model_instance_global_to_local_dir(out_dir, in_dir, pm, pmi, use_submodel_parent ? pm->submodel[submodel_num].parent : submodel_num, objorient);
+	model_instance_global_to_local_dir(out_dir, in_dir, pm, pmi, use_submodel_parent ? pm->submodel[submodel_num].parent : submodel_num, objorient, use_last_frame);
 }
 
 void model_instance_global_to_local_dir(vec3d* out_dir, const vec3d* in_dir, const polymodel* pm, const polymodel_instance* pmi, int submodel_num, const matrix* objorient, bool use_last_frame) {

--- a/code/object/collideshipship.cpp
+++ b/code/object/collideshipship.cpp
@@ -266,7 +266,8 @@ int ship_ship_check_collision(collision_info_struct *ship_ship_hit_info)
 			}
 
 			// reset flags to check MC_CHECK_MODEL | MC_CHECK_SPHERELINE and maybe MC_CHECK_INVISIBLE_FACES and MC_SUBMODEL_INSTANCE
-			mc.flags = copy_flags | MC_SUBMODEL_INSTANCE;
+			// Only check single submodel now, since children of moving submodels are handled as moving as well
+			mc.flags = copy_flags | MC_SUBMODEL;
 
 			if (heavy_sip->collision_lod > -1) {
 				mc.lod = heavy_sip->collision_lod;
@@ -285,15 +286,9 @@ int ship_ship_check_collision(collision_info_struct *ship_ship_hit_info)
 					continue;
 				}
 
-				// set angles for last frame
-				matrix copy_matrix = smi->canonical_orient;
-
 				// find the start and end positions of the sphere in submodel RF
-				smi->canonical_orient = smi->canonical_prev_orient;
-				model_instance_world_to_local_point(&p0, &light_obj->last_pos, pm, pmi, submodel, &heavy_obj->last_orient, &heavy_obj->last_pos);
-
-				smi->canonical_orient = copy_matrix;
-				model_instance_world_to_local_point(&p1, &light_obj->pos, pm, pmi, submodel, &heavy_obj->orient, &heavy_obj->pos);
+				model_instance_global_to_local_point(&p0, &light_obj->last_pos, pm, pmi, submodel, &heavy_obj->last_orient, &heavy_obj->last_pos, true);
+				model_instance_global_to_local_point(&p1, &light_obj->pos, pm, pmi, submodel, &heavy_obj->orient, &heavy_obj->pos);
 
 				mc.p0 = &p0;
 				mc.p1 = &p1;

--- a/code/object/collideshipship.cpp
+++ b/code/object/collideshipship.cpp
@@ -576,7 +576,7 @@ void calculate_ship_ship_collision_physics(collision_info_struct *ship_ship_hit_
 			//This method of doing things is kinda fake for now, _especially_ in this case, as we basically just approximate this submodel rotating like its parent.
 			//A proper rewrite for how this stuff is calculated is in order
 			do {
-				Assertion(pm >= 0, "Couldn't find the submodel that is rotating for a collision with a submodel with rotating parent.");
+				Assertion(rot_sm >= 0, "Couldn't find the submodel that is rotating for a collision with a submodel with rotating parent.");
 				rotation_axis = pm->submodel[rot_sm].rotation_type != MOVEMENT_TYPE_TRIGGERED ? &pm->submodel[rot_sm].rotation_axis : &pmi->submodel[rot_sm].rotation_axis;
 				rotation_speed = pmi->submodel[rot_sm].current_turn_rate;
 				rot_sm = pm->submodel[rot_sm].parent;

--- a/code/object/collideshipship.cpp
+++ b/code/object/collideshipship.cpp
@@ -265,7 +265,6 @@ int ship_ship_check_collision(collision_info_struct *ship_ship_hit_info)
 				pmi->submodel[submodel].collision_checked = true;
 			}
 
-			// reset flags to check MC_CHECK_MODEL | MC_CHECK_SPHERELINE and maybe MC_CHECK_INVISIBLE_FACES and MC_SUBMODEL_INSTANCE
 			// Only check single submodel now, since children of moving submodels are handled as moving as well
 			mc.flags = copy_flags | MC_SUBMODEL;
 

--- a/code/object/collideshipweapon.cpp
+++ b/code/object/collideshipweapon.cpp
@@ -132,10 +132,9 @@ static void ship_weapon_do_hit_stuff(object *pship_obj, object *weapon_obj, vec3
 
 	// Add impact decal
 	if (quadrant_num == -1 && wip->impact_decal.definition_handle >= 0) {
-		// Use the weapon orientation to augment the orientation computation. This is a very basic variant where only
-		// the object itself is taken into account
+		// Use the weapon orientation to augment the orientation computation.
 		vec3d weapon_up;
-		vm_vec_rotate(&weapon_up, &weapon_obj->orient.vec.uvec, &pship_obj->orient);
+		model_instance_global_to_local_dir(&weapon_up, &weapon_obj->orient.vec.uvec, pm, pmi, submodel_num, &pship_obj->orient);
 
 		matrix decal_orient;
 		vm_vector_2_matrix_norm(&decal_orient, &hit_dir, &weapon_up); // hit_dir is already normalized so we can use the more efficient function

--- a/code/ship/shipfx.cpp
+++ b/code/ship/shipfx.cpp
@@ -109,16 +109,13 @@ static void shipfx_subsystem_maybe_create_live_debris(object *ship_objp, ship *s
 	vec3d model_axis, world_axis, rotvel, world_axis_pt;
 	matrix m_rot;	// rotation for debris orient about axis
 
-	if (pm->submodel[submodel_num].rotation_type == MOVEMENT_TYPE_REGULAR || pm->submodel[submodel_num].rotation_type == MOVEMENT_TYPE_INTRINSIC) {
-		if ( !smi->axis_set ) {
-			model_init_submodel_axis_pt(pm, pmi, submodel_num);
-		}
-
+	if (pm->submodel[submodel_num].rotation_type == MOVEMENT_TYPE_REGULAR || pm->submodel[submodel_num].rotation_type == MOVEMENT_TYPE_INTRINSIC || pm->submodel[submodel_num].rotation_type == MOVEMENT_TYPE_TRIGGERED){
 		// get the rotvel
 		model_get_rotating_submodel_axis(&model_axis, &world_axis, pm, pmi, submodel_num, &ship_objp->orient);
 		vm_vec_copy_scale(&rotvel, &world_axis, smi->current_turn_rate);
 
-		model_instance_local_to_global_point(&world_axis_pt, &smi->point_on_axis, pm, pmi, submodel_num, &ship_objp->orient, &ship_objp->pos);
+		//TODO replace zero_vector with translation offset of submodel
+		model_instance_local_to_global_point(&world_axis_pt, &vmd_zero_vector, pm, pmi, submodel_num, &ship_objp->orient, &ship_objp->pos);
 
 		vm_quaternion_rotate(&m_rot, smi->cur_angle, &model_axis);
 	} else {

--- a/code/ship/shipfx.cpp
+++ b/code/ship/shipfx.cpp
@@ -138,7 +138,7 @@ static void shipfx_subsystem_maybe_create_live_debris(object *ship_objp, ship *s
 		model_instance_local_to_global_point(&start_world_pos, &pm->submodel[live_debris_submodel].offset, pm, pmi, live_debris_submodel, &ship_objp->orient, &ship_objp->pos );
 
 		// convert to model coord of underlying submodel
-		model_instance_world_to_local_point(&start_model_pos, &start_world_pos, pm, pmi, submodel_num, &ship_objp->orient, &ship_objp->pos);
+		model_instance_global_to_local_point(&start_model_pos, &start_world_pos, pm, pmi, submodel_num, &ship_objp->orient, &ship_objp->pos);
 
 		// rotate from submodel coord to world coords
 		model_instance_local_to_global_point(&end_world_pos, &start_model_pos, pm, pmi, submodel_num, &ship_objp->orient, &ship_objp->pos);

--- a/test/src/model/test_modelread.cpp
+++ b/test/src/model/test_modelread.cpp
@@ -1,0 +1,86 @@
+#include <gtest/gtest.h>
+#include <model/model.h>
+
+#include "util/FSTestFixture.h"
+
+#define EXPECT_VECTOR_NEAR(global,vector) EXPECT_NEAR(error(&global,vector), 0.0f, 0.001f);
+
+float error(vec3d* val, vec3d target) {
+	float totalError = 0;
+	for (int i = 0; i < 3; i++) {
+		float diff = val->a1d[i] - target.a1d[i];
+		totalError += diff * diff;
+	}
+	return totalError;
+}
+
+class SubmodelLocalizeTest : public test::FSTestFixture {
+public:
+	SubmodelLocalizeTest() : test::FSTestFixture() { pushModDir("model"); }
+
+protected:
+	void SetUp() override {
+		test::FSTestFixture::SetUp();
+		
+		pm = new polymodel();
+		pmi = new polymodel_instance();
+
+		pm->submodel = new bsp_info[3];
+		pmi->submodel = new submodel_instance[3];
+
+		pm->submodel[0].parent = -1;
+		pm->submodel[1].parent = 0;
+		pm->submodel[2].parent = 1;
+
+		pm->submodel[0].offset = vec3d{ {{0, 0, 0}} };
+		pm->submodel[1].offset = vec3d{ {{0, 1, 0}} };
+		pm->submodel[2].offset = vec3d{ {{0, 1, 0}} };
+
+		pmi->submodel[0].canonical_orient = vmd_identity_matrix;
+		angles ang{ PI_2, 0.0f, 0.0f };
+		vm_angles_2_matrix(&pmi->submodel[1].canonical_orient, &ang);
+		ang = angles{ -PI_2, 0.0f, PI_2 };
+		vm_angles_2_matrix(&pmi->submodel[2].canonical_orient, &ang);
+	}
+
+	void TearDown() override {
+		test::FSTestFixture::TearDown();
+
+		delete[] pm->submodel;
+		delete[] pmi->submodel;
+		delete pm;
+		delete pmi;
+	}
+
+	polymodel *pm;
+	polymodel_instance *pmi;
+};
+
+TEST_F(SubmodelLocalizeTest, submodel_instance_localize_roundtrip) {
+
+	vec3d global;
+	vec3d roundtrip;
+	vec3d local{ {{0.0f, 1.0f, 0.0f}} };
+	model_instance_local_to_global_point(&global, &local, pm, pmi, 2);
+	model_instance_global_to_local_point(&roundtrip, &global, pm, pmi, 2);
+
+	EXPECT_VECTOR_NEAR(global, (vec3d{ {{-1.0f, 1.0f, 1.0f}} }));
+	EXPECT_VECTOR_NEAR(roundtrip, local);
+}
+
+TEST_F(SubmodelLocalizeTest, submodel_instance_localize_roundtrip_world) {
+
+	vec3d globalPos{ {{0.0f, 5.0f, 0.0f}} };
+	matrix globalOrient;
+	angles globalRot{ 0.0f, PI_2, 0.0f};
+	vm_angles_2_matrix(&globalOrient, &globalRot);
+
+	vec3d global;
+	vec3d roundtrip;
+	vec3d local{ {{0.0f, 1.0f, 0.0f}} };
+	model_instance_local_to_global_point(&global, &local, pm, pmi, 2, &globalOrient, &globalPos);
+	model_instance_global_to_local_point(&roundtrip, &global, pm, pmi, 2, &globalOrient, &globalPos);
+
+	EXPECT_VECTOR_NEAR(global, (vec3d{ {{-1.0f, 4.0f, 1.0f}} }));
+	EXPECT_VECTOR_NEAR(roundtrip, local);
+}

--- a/test/src/model/test_modelread.cpp
+++ b/test/src/model/test_modelread.cpp
@@ -16,7 +16,7 @@ float error(vec3d* val, vec3d target) {
 
 class SubmodelLocalizeTest : public test::FSTestFixture {
 public:
-	SubmodelLocalizeTest() : test::FSTestFixture() { pushModDir("model"); }
+	SubmodelLocalizeTest() { pushModDir("model"); }
 
 protected:
 	void SetUp() override {

--- a/test/src/source_groups.cmake
+++ b/test/src/source_groups.cmake
@@ -39,6 +39,10 @@ add_file_folder("mod"
     mod/test_mod_table.cpp
 )
 
+add_file_folder("model"
+    model/test_modelread.cpp
+)
+
 add_file_folder("Parse"
     parse/test_parselo.cpp
 )


### PR DESCRIPTION
With the previous animation overhaul, some problems with the collision code came to light.
This PR aims to fix most of the more problematic ones, including:

- Fixes Global -> Local coordinate transformation for nested submodels (prerequisite for latter points)
- Fixes Submodel collisions for nested submodels more than two layers deep
- Fixes Submodel collisions for nested submodels that have moving ancestors
- Fixes Collision physics calculation for submodels with triggered animations (fixes #3985)
- Laid groundwork to follow up to improve the collision physics calculation to more accurately represent submodels with moving ancestors in a future PR