### PR TITLE
Fix moving submodel collision speed calculation

### DIFF
--- a/code/model/model.h
+++ b/code/model/model.h
@@ -975,10 +975,10 @@ extern void model_local_to_global_point(vec3d *outpnt, const vec3d *mpnt, const 
 
 // Given a point in a submodel's local frame of reference, transform it to a global frame of reference, taking into account submodel rotations.
 // If objorient and objpos are supplied, this will be world space; otherwise it will be the model's space.
-extern void model_instance_local_to_global_point(vec3d *outpnt, const vec3d *mpnt, int model_instance_num, int submodel_num, const matrix *objorient = nullptr, const vec3d *objpos = nullptr);
+extern void model_instance_local_to_global_point(vec3d *outpnt, const vec3d *mpnt, int model_instance_num, int submodel_num, const matrix *objorient = nullptr, const vec3d *objpos = nullptr, bool use_last_frame = false);
 // Given a point in a submodel's local frame of reference, transform it to a global frame of reference, taking into account submodel rotations.
 // If objorient and objpos are supplied, this will be world space; otherwise it will be the model's space.
-extern void model_instance_local_to_global_point(vec3d *outpnt, const vec3d *mpnt, const polymodel *pm, const polymodel_instance *pmi, int submodel_num, const matrix *objorient = nullptr, const vec3d *objpos = nullptr);
+extern void model_instance_local_to_global_point(vec3d *outpnt, const vec3d *mpnt, const polymodel *pm, const polymodel_instance *pmi, int submodel_num, const matrix *objorient = nullptr, const vec3d *objpos = nullptr, bool use_last_frame = false);
 
 // Given a direction (or normal) in a submodel's local frame of reference, transform it to a global frame of reference.
 // If objorient and objpos are supplied, this will be world space; otherwise it will be the model's space.

--- a/code/model/modelread.cpp
+++ b/code/model/modelread.cpp
@@ -4125,14 +4125,14 @@ void model_local_to_global_point(vec3d *outpnt, const vec3d *mpnt, const polymod
 	}
 }
 
-void model_instance_local_to_global_point(vec3d *outpnt, const vec3d *mpnt, int model_instance_num, int submodel_num, const matrix *objorient, const vec3d *objpos)
+void model_instance_local_to_global_point(vec3d *outpnt, const vec3d *mpnt, int model_instance_num, int submodel_num, const matrix *objorient, const vec3d *objpos, bool use_last_frame)
 {
 	auto pmi = model_get_instance(model_instance_num);
 	auto pm = model_get(pmi->model_num);
-	return model_instance_local_to_global_point(outpnt, mpnt, pm, pmi, submodel_num, objorient, objpos);
+	return model_instance_local_to_global_point(outpnt, mpnt, pm, pmi, submodel_num, objorient, objpos, use_last_frame);
 }
 
-void model_instance_local_to_global_point(vec3d *outpnt, const vec3d *mpnt, const polymodel *pm, const polymodel_instance *pmi, int submodel_num, const matrix *objorient, const vec3d *objpos)
+void model_instance_local_to_global_point(vec3d *outpnt, const vec3d *mpnt, const polymodel *pm, const polymodel_instance *pmi, int submodel_num, const matrix *objorient, const vec3d *objpos, bool use_last_frame)
 {
 	vec3d pnt;
 	vec3d tpnt;
@@ -4144,7 +4144,7 @@ void model_instance_local_to_global_point(vec3d *outpnt, const vec3d *mpnt, cons
 
 	//instance up the tree for this point
 	while ( (mn >= 0) && (pm->submodel[mn].parent >= 0) ) {
-		vm_vec_unrotate(&tpnt, &pnt, &pmi->submodel[mn].canonical_orient);
+		vm_vec_unrotate(&tpnt, &pnt, use_last_frame ? &pmi->submodel[mn].canonical_prev_orient : &pmi->submodel[mn].canonical_orient);
 		vm_vec_add(&pnt, &tpnt, &pm->submodel[mn].offset);
 
 		mn = pm->submodel[mn].parent;


### PR DESCRIPTION
This is the followup for #4065 that redos collision speed and momentum transfer for moving submodels.
It turned out a lot simpler than originally thought, but now properly calculates collision speed for animated submodels, even with moving ancestors or (future) translating submodels. Additionally, steps are taken to drastically reduce the number of accidental tunneling through very fast moving (~100m/s) submodels.