### PR TITLE
Remove new assert in `model_instance_local_to_global_dir`

### DIFF
--- a/code/model/model.h
+++ b/code/model/model.h
@@ -1099,7 +1099,7 @@ typedef struct mc_info {
 	int		hit_bitmap;			// Which texture got hit.  -1 if not a textured poly
 	float		hit_u, hit_v;		// Where on hit_bitmap the ray hit.  Invalid if hit_bitmap < 0
 	int		shield_hit_tri;	// Which triangle on the shield got hit or -1 if none
-	vec3d	hit_normal;			//	Vector normal of polygon of collision.  (This is in submodel RF)
+	vec3d	hit_normal;			//	Vector normal of polygon of collision (This is in submodel RF). CAN BE ZERO, if edge_hit is true
 	bool		edge_hit;			// Set if an edge got hit.  Only valid if MC_CHECK_THICK is set.	
 	ubyte		*f_poly;				// pointer to flat poly where we intersected
 	ubyte		*t_poly;				// pointer to tmap poly where we intersected

--- a/code/model/modelread.cpp
+++ b/code/model/modelread.cpp
@@ -4434,7 +4434,6 @@ void model_instance_local_to_global_dir(vec3d *out_dir, const vec3d *in_dir, con
 	vec3d tpnt;
 	int mn;
 	Assert(pm->id == pmi->model_num);
-	Assertion(vm_vec_is_normalized(in_dir), "Input vector must be normalized!");
 
 	pnt = *in_dir;
 	mn = submodel_num;

--- a/code/model/modelread.cpp
+++ b/code/model/modelread.cpp
@@ -4161,7 +4161,6 @@ void model_instance_local_to_global_point_dir(vec3d *out_pnt, vec3d *out_dir, co
 	vec3d pnt, tpnt, dir, tdir;
 	int mn;
 	Assert(pm->id == pmi->model_num);
-	Assertion(vm_vec_is_normalized(in_dir), "Input vector must be normalized!");
 
 	pnt = *in_pnt;
 	dir = *in_dir;
@@ -4270,7 +4269,6 @@ void model_instance_global_to_local_dir(vec3d* out_dir, const vec3d* in_dir, int
 
 void model_instance_global_to_local_dir(vec3d* out_dir, const vec3d* in_dir, const polymodel* pm, const polymodel_instance* pmi, int submodel_num, const matrix* objorient, bool use_last_frame) {
 	Assert(pm->id == pmi->model_num);
-	Assertion(vm_vec_is_normalized(in_dir), "Input vector must be normalized!");
 
 	std::stack<const matrix*> submodelStack;
 
@@ -4411,7 +4409,6 @@ void model_local_to_global_dir(vec3d *out_dir, const vec3d *in_dir, const polymo
 {
 	SCP_UNUSED(pm);
 	SCP_UNUSED(submodel_num);
-	Assertion(vm_vec_is_normalized(in_dir), "Input vector must be normalized!");
 
 	//now instance for the entire object
 	if (objorient) {


### PR DESCRIPTION
Consider this approach tentative, but *apparently* model collide info does not necessarily fill `hit_normal` even when hits are registered. This happens in the case of a sphere hitting the 'edge' of a polygon (although I'm not convinced a hit normal cant be generated in this case, but this would require a deeper dive), which, at least in my tests, seems to happen a lot with maras and beams for whatever reason. 

Other parts of the code even explicitly check for edge hits and don't check normals.
https://github.com/scp-fs2open/fs2open.github.com/blob/master/code/object/collideshipship.cpp#L336

And, at least for beams, this hit normal is passed directly to the relevant function.
https://github.com/scp-fs2open/fs2open.github.com/blob/master/code/weapon/beam.cpp#L3689

Apparently before, it would simply operate on a null vector, which for this math is at least safe, it simply remains null. Whether perhaps the function itself or its calls should be changed to something else more reasonable, I'll leave to discussion, but this is the simplest approach.
