### PR TITLE
Fix collisions with turrets causing physics bugs

### DIFF
--- a/code/model/modelread.cpp
+++ b/code/model/modelread.cpp
@@ -3696,6 +3696,8 @@ void model_get_rotating_submodel_axis(vec3d *model_axis, vec3d *world_axis, cons
 // Normalize the submodel angle and convert float angle to angles struct
 void submodel_canonicalize(bsp_info *sm, submodel_instance *smi, bool clamp)
 {
+	smi->canonical_prev_orient = smi->canonical_orient;
+
 	if (clamp)
 	{
 		// normalize the angle so that we are within a valid range:
@@ -3767,7 +3769,6 @@ void submodel_stepped_rotate(model_subsystem *psub, submodel_instance *smi)
 
 	// save last angles
 	smi->prev_angle = smi->cur_angle;
-	smi->canonical_prev_orient = smi->canonical_orient;
 
 	// angular displacement of one step
 	float step_size = (PI2 / psub->stepped_rotation->num_steps);
@@ -3903,7 +3904,6 @@ void submodel_rotate(bsp_info *sm, submodel_instance *smi)
 {
 	// save last angles
 	smi->prev_angle = smi->cur_angle;
-	smi->canonical_prev_orient = smi->canonical_orient;
 
 	float delta;
 

--- a/code/object/collideshipship.cpp
+++ b/code/object/collideshipship.cpp
@@ -565,7 +565,8 @@ void calculate_ship_ship_collision_physics(collision_info_struct *ship_ship_hit_
 			pm = NULL;
 		}
 		
-		if ( pmi != nullptr ) { 
+		//Previously, a side effect of moving submodel collision excluded turrets from imparting momentum to colliders
+		if ( pmi != nullptr && pm->submodel[ship_ship_hit_info->submodel_num].rotation_type != MOVEMENT_TYPE_TURRET) {
 			//Find the global movement of the position that hit the ship
 			vec3d last_frame_col_pos, col_pos;
 			model_instance_local_to_global_point(&last_frame_col_pos, &ship_ship_hit_info->hit_pos, pm, pmi, ship_ship_hit_info->submodel_num, &heavy->orient, &heavy->pos, true);


### PR DESCRIPTION
#4067 introduced an issue in which collisions with already rotated turrets would fling about the ships.
This happens because the turrets (and certain other types of dumb rotations) did not properly update canonical_prev_orientation, which would cause their calculated momentum to assume that they rotated to their current position within one frame, making them much faster than they actually were.
In addition to fixing this by making submodel_canonicalize take care of updating canonical_prev_orient, turrets are also explicitly excluded from imparting momentum onto colliders. The reason for this is twofold:
1. Stemming from how momentum was calculated before, turrets were included with an implicit velocity of 0, thus previously not imparting momentum as well. Thus, to keep the same behaviour, the new method has to exclude them explicitly.
2. Turrets can sometimes very suddenly start to rotate. Sometimes this does not happen in a smooth motion, but in a quick change of orientation for the turret. This can cause the turret to have very high velocities for a single frame, and if any ship is within the turning arc of the turret for that one frame, it'll fling the collider much faster than sensible.

If, in the long run, momentum impartion from rotating turrets is intended, it should likely be locked behind an aip flag in a future PR.