### PR TITLE
fix off-by-one error in text splitting logic

### DIFF
--- a/code/graphics/software/VFNTFont.cpp
+++ b/code/graphics/software/VFNTFont.cpp
@@ -49,7 +49,7 @@ namespace font
 
 		bool checkLength = textLen >= 0;
 
-		if (text != NULL) {
+		if (text != nullptr && textLen != 0) {
 			h += fl2i(this->getHeight());
 			while (*text)
 			{

--- a/code/graphics/software/font.cpp
+++ b/code/graphics/software/font.cpp
@@ -688,7 +688,8 @@ void gr_get_string_size(int *w1, int *h1, const char *text, int len)
 	float w = 0.0f;
 	float h = 0.0f;
 
-	FontManager::getCurrentFont()->getStringSize(text, static_cast<size_t>(len), -1, &w, &h);
+	if (len != 0)
+		FontManager::getCurrentFont()->getStringSize(text, static_cast<size_t>(len), -1, &w, &h);
 
 	if (w1)
 	{

--- a/code/mission/missionlog.cpp
+++ b/code/mission/missionlog.cpp
@@ -672,6 +672,7 @@ void message_log_add_segs(const char *source_string, int msg_color, int flags = 
 			break;
 		}
 
+		Assertion(Num_log_lines < MAX_LOG_LINES, "Too many log lines!  There might have been a text split failure.");
 		Num_log_lines++;
 		X = ACTION_X;
 		str = split;

--- a/code/parse/parselo.cpp
+++ b/code/parse/parselo.cpp
@@ -3283,7 +3283,7 @@ char *split_str_once(char *src, int max_pixel_w)
 
 	len = (int)strlen(src);
 	for (i=0; i<len; i++) {
-		gr_get_string_size(&w, nullptr, src, i);
+		gr_get_string_size(&w, nullptr, src, i + 1);
 
 		if (w <= max_pixel_w) {
 			if (src[i] == '\n') {  // reached natural end of line


### PR DESCRIPTION
`gr_get_string_size` takes a length parameter, but `split_str_once` was calling it with the position instead.  This led to incorrect results occasionally.  If the incorrect pixel width had the bad luck to be exactly equal to the remaining space, this would cause an infinite loop.  This fixes the bug and adds a bunch of safeguards to prevent a similar situation in the future.