### PR TITLE
patch some holes in the mission cleanup

### DIFF
--- a/code/popup/popupdead.cpp
+++ b/code/popup/popupdead.cpp
@@ -500,13 +500,16 @@ int popupdead_do_frame(float  /*frametime*/)
 }
 
 // Close down the dead popup
-void popupdead_close()
+void popupdead_close(bool play_sound)
 {
 	if ( !Popupdead_active ) {
 		return;
 	}
 
-	gamesnd_play_iface(InterfaceSounds::POPUP_DISAPPEAR);
+	if (play_sound) {
+		gamesnd_play_iface(InterfaceSounds::POPUP_DISAPPEAR);
+	}
+
 	Popupdead_window.destroy();
 	game_flush();
 	

--- a/code/popup/popupdead.h
+++ b/code/popup/popupdead.h
@@ -18,7 +18,7 @@
 #define POPUPDEAD_DO_MAIN_HALL	2
 
 void	popupdead_start();
-void	popupdead_close();
+void	popupdead_close(bool play_sound = false);
 int	popupdead_do_frame(float frametime);
 int	popupdead_is_active();
 


### PR DESCRIPTION
Bug #3672 was caused by the dead popup not being cleaned up properly when the player-dead state was left.  Closer examination revealed some possible holes in the cleanup logic - e.g. the game assumed that the mission would proceed to the debriefing but neglected the possibility that it would exit to the main hall.  This consolidates the two dead states and attempts to make the cleanup more robust.

Fixes #3672.