### PR TITLE
Improve Performance of Global to Local functions

### DIFF
--- a/code/model/model.h
+++ b/code/model/model.h
@@ -336,6 +336,7 @@ public:
 	int		num_children;			// How many children this model has
 	int		first_child;			// The first_child of this model, -1 if none
 	int		next_sibling;			// This submodel's next sibling, -1 if none
+	int		depth;					// How many levels deep this subobject sits
 
 	int		num_details;			// How many submodels are lower detail "mirrors" of this submodel
 	int		details[MAX_MODEL_DETAIL_LEVELS];		// A list of all the lower detail "mirrors" of this submodel

--- a/code/model/modelread.cpp
+++ b/code/model/modelread.cpp
@@ -1654,6 +1654,16 @@ int read_model_file(polymodel * pm, const char *filename, int n_subsystems, mode
 				parent = cfread_int(fp);
 				sm->parent = parent;
 				auto parent_sm = parent < 0 ? nullptr : &pm->submodel[parent];
+				sm->depth = 1;
+				{
+					int parent_sm_id = parent;
+					while (parent_sm_id >= 0) {
+						sm->depth++;
+						parent_sm_id = pm->submodel[parent_sm_id].parent;
+					}
+				}
+
+
 
 //				cfread_vector(&sm->norm,fp);
 //				d = cfread_float(fp);				
@@ -4231,34 +4241,43 @@ void model_instance_global_to_local_point(vec3d* outpnt, const vec3d* mpnt, int 
 void model_instance_global_to_local_point(vec3d* outpnt, const vec3d* mpnt, const polymodel* pm, const polymodel_instance* pmi, int submodel_num, const matrix* objorient, const vec3d* objpos, bool use_last_frame) {
 	Assert(pm->id == pmi->model_num);
 
-	std::stack<std::pair<const matrix*, const vec3d*>> submodelStack;
+	constexpr int preallocatedStackDepth = 5;
+	std::pair<const matrix*, const vec3d*> preallocatedStack[preallocatedStackDepth];
+
+	auto submodelStack = pm->submodel[submodel_num].depth <= preallocatedStackDepth ? preallocatedStack : new std::pair<const matrix*, const vec3d*>[pm->submodel[submodel_num].depth];
+	int stackCounter = 0;
 
 	int mn = submodel_num;
 
 	//Go up the chain of parents to build a stack of transformations from parent -> child
 	while ((mn >= 0) && (pm->submodel[mn].parent >= 0)) {
 		if(use_last_frame)
-			submodelStack.emplace(&pmi->submodel[mn].canonical_prev_orient, &pm->submodel[mn].offset);
+			submodelStack[stackCounter].first = &pmi->submodel[mn].canonical_prev_orient;
 		else
-			submodelStack.emplace(&pmi->submodel[mn].canonical_orient, &pm->submodel[mn].offset);
+			submodelStack[stackCounter].first = &pmi->submodel[mn].canonical_orient;
+		submodelStack[stackCounter++].second = &pm->submodel[mn].offset;
 		mn = pm->submodel[mn].parent;
 	}
 
-	if(objorient != nullptr && objpos != nullptr)
-		submodelStack.emplace(objorient, objpos);
-	
+	if (objorient != nullptr && objpos != nullptr) {
+		submodelStack[stackCounter].first = objorient;
+		submodelStack[stackCounter++].second = objpos;
+	}
+	stackCounter--;
+		
 	vec3d resultPnt = *mpnt;
 
-	while (!submodelStack.empty()) {
-		const auto& transform = submodelStack.top();
+	while (stackCounter >= 0) {
+		const auto& transform = submodelStack[stackCounter--];
 
 		vm_vec_sub2(&resultPnt, transform.second);
 		vm_vec_rotate(&resultPnt, &resultPnt, transform.first);
-
-		submodelStack.pop();
 	}
 
 	*outpnt = resultPnt;
+
+	if (pm->submodel[submodel_num].depth > preallocatedStackDepth)
+		delete[] submodelStack;
 }
 
 void model_instance_global_to_local_dir(vec3d* out_dir, const vec3d* in_dir, int model_instance_num, int submodel_num, const matrix* objorient, bool use_submodel_parent, bool use_last_frame) {

--- a/test/src/model/test_modelread.cpp
+++ b/test/src/model/test_modelread.cpp
@@ -36,6 +36,10 @@ protected:
 		pm->submodel[1].offset = vec3d{ {{0, 1, 0}} };
 		pm->submodel[2].offset = vec3d{ {{0, 1, 0}} };
 
+		pm->submodel[0].depth = 1;
+		pm->submodel[1].depth = 2;
+		pm->submodel[2].depth = 3;
+
 		pmi->submodel[0].canonical_orient = vmd_identity_matrix;
 		angles ang{ PI_2, 0.0f, 0.0f };
 		vm_angles_2_matrix(&pmi->submodel[1].canonical_orient, &ang);


### PR DESCRIPTION
Fixes #4079.

The whole thing is still somewhat expensive, currently taking 2% of frametime for checking turret collision using these functions in very large missions. This is already a magnitude better than the previous version, and should fix most of the noticeable performance hiccups