### PR TITLE
Fix erroneous collision detection due to invalid canonical_prev_orient on inital-type animated turrets

### DIFF
--- a/code/model/modelanimation.cpp
+++ b/code/model/modelanimation.cpp
@@ -209,7 +209,7 @@ namespace animation {
 			//Save the things modified by initial animations as actual baseline
 			for (const auto& initialModified : applyBuffer) {
 				if (initialModified.second.modified)
-					initialModified.first->saveCurrentAsBase(pmi);
+					initialModified.first->saveCurrentAsBase(pmi, true);
 			}
 		}
 	}
@@ -333,7 +333,7 @@ namespace animation {
 		submodel->current_turn_rate = 0.0f;
 	}
 
-	void ModelAnimationSubmodel::saveCurrentAsBase(polymodel_instance* pmi) {
+	void ModelAnimationSubmodel::saveCurrentAsBase(polymodel_instance* pmi, bool isInitialType) {
 		auto submodel = findSubmodel(pmi);
 		ModelAnimationData<>& data = m_initialData[{ pmi->id }];
 
@@ -352,6 +352,10 @@ namespace animation {
 		data.orientation = submodel.first->canonical_orient;
 		//TODO: Once translation is a thing
 		//data.position = m_subsys->submodel_instance_1->offset;
+
+		//In this case, we just initial-type initialized the submodel. Properly set its last frame data as well
+		if(isInitialType)
+			submodel.first->canonical_prev_orient = submodel.first->canonical_orient;
 	}
 
 	std::pair<submodel_instance*, bsp_info*> ModelAnimationSubmodel::findSubmodel(polymodel_instance* pmi) {

--- a/code/model/modelanimation.h
+++ b/code/model/modelanimation.h
@@ -173,7 +173,7 @@ namespace animation {
 
 		void reset(polymodel_instance* pmi);
 
-		void saveCurrentAsBase(polymodel_instance* pmi);
+		void saveCurrentAsBase(polymodel_instance* pmi, bool isInitialType = false);
 		const ModelAnimationData<>& getInitialData(polymodel_instance* pmi);
 
 		virtual std::pair<submodel_instance*, bsp_info*> findSubmodel(polymodel_instance* pmi);


### PR DESCRIPTION
Fixes #4081.

The problem was that the initial animations did not set prev_orient correctly, which means that for the first frame, the physics of turrets set with initial type animation is very whacky. This caused the unintended behaviour, as #4065 changed the way collision detection on moving submodels worked in such a way that requires prev_orient to be correctly set.