### PR TITLE
small XSTR qol improvement

### DIFF
--- a/code/localization/localize.cpp
+++ b/code/localization/localize.cpp
@@ -744,13 +744,14 @@ bool lcl_ext_localize_sub(const char *in, char *text_str, char *out, size_t max_
 			break;
 		ch += 4;
 
-		attempted_xstr = true;
-
 		// the next non-whitespace char should be a (
 		ignore_white_space(&ch);
 		if (*ch != '(')
 			break;
 		ch++;
+
+		// by not setting the flag until after the parenthesis, XSTR by itself can be plain text, but XSTR( starts a tag
+		attempted_xstr = true;
 
 		// the next should be a quote
 		ignore_white_space(&ch);
@@ -913,13 +914,14 @@ bool lcl_ext_localize_sub(const SCP_string &in, SCP_string &text_str, SCP_string
 			break;
 		ch += 4;
 
-		attempted_xstr = true;
-
 		// the next non-whitespace char should be a (
 		ignore_white_space(&ch);
 		if (*ch != '(')
 			break;
 		ch++;
+
+		// by not setting the flag until after the parenthesis, XSTR by itself can be plain text, but XSTR( starts a tag
+		attempted_xstr = true;
 
 		// the next should be a quote
 		ignore_white_space(&ch);


### PR DESCRIPTION
Allow `XSTR` to be used by itself, without implying an `XSTR()` tag.