### PR TITLE
Add 'pause on reverse' Animation Flag

### DIFF
--- a/code/model/modelanimation.cpp
+++ b/code/model/modelanimation.cpp
@@ -17,6 +17,7 @@ namespace animation {
 		{ "reset at completion",		animation::Animation_Flags::Reset_at_completion,		        true, false },
 		{ "loop",						animation::Animation_Flags::Loop,						        true, false },
 		{ "random starting phase",		animation::Animation_Flags::Random_starting_phase,				true, false },
+		{ "pause on reverse",			animation::Animation_Flags::Pause_on_reverse,					true, false },
 	};
 
 	const size_t Num_animation_flags = sizeof(Animation_flags) / sizeof(flag_def_list_new<animation::Animation_Flags>);
@@ -173,7 +174,7 @@ namespace animation {
 				return;
 		}
 
-		if (pause) {
+		if (pause || (direction == ModelAnimationDirection::RWD && m_flags[Animation_Flags::Pause_on_reverse])) {
 			if(instanceData.state != ModelAnimationState::UNTRIGGERED && instanceData.state != ModelAnimationState::NEED_RECALC && instanceData.state != ModelAnimationState::COMPLETED)
 				instanceData.state = ModelAnimationState::PAUSED;
 			return;

--- a/code/model/modelanimation.h
+++ b/code/model/modelanimation.h
@@ -113,6 +113,7 @@ namespace animation {
 		Reset_at_completion,	//Will cause the animation to reset once it completes. This usually only makes sense when the state at the end of the animation is identical to the state at the start of the animation. Incompatible with Auto_reverse
 		Loop,					//Will automatically loop the animation once it completes. Is compatible with Reset_at_completion to loop back from the start instead of reversing. Incompatible with Auto_reverse
 		Random_starting_phase,  //When an animation is started from an untriggered state, will randomize its time to any possible time of the animation + possibly on the reverse, if the animation would automatically enter that
+		Pause_on_reverse,		//Will cause any start in RWD direction to behave as a call to pause the animation. Required (and also only really useful) when a looping animation is supposed to be triggered by an internal engine trigger
 		NUM_VALUES
 	};
 


### PR DESCRIPTION
This flag allows to use looping animations that are supposed to loop forwards and then pause instead of the typical "trigger, wait, reverse"-animation in engine-internal triggers such as afterburners.