### PR TITLE
add campaign start hook

### DIFF
--- a/code/menuui/readyroom.cpp
+++ b/code/menuui/readyroom.cpp
@@ -266,6 +266,13 @@ void sim_room_load_mission_icons();
 void sim_room_unload_mission_icons();
 void sim_room_blit_icons(int line_index, int y_start, fs_builtin_mission *fb = NULL, int is_md = 0);
 
+const std::shared_ptr<scripting::Hook> OnCampaignBeginHook = scripting::Hook::Factory(
+	"On Campaign Begin", "Called when a campaign is started from the beginning or is reset",
+	{
+		{ "Campaign", "string", "The campaign filename (without the extension)" },
+	});
+
+
 // Finds a hash value for mission filename
 //
 // returns hash value
@@ -1553,6 +1560,8 @@ void campaign_reset(const SCP_string& campaign_file) {
 		// reset tech database to what's in the tables
 		tech_reset_to_default();
 	}
+
+	OnCampaignBeginHook->run(scripting::hook_param_list(scripting::hook_param("Campaign", 's', Campaign.filename)));
 }
 
 // returns: 0 = success, !0 = aborted or failed
@@ -1664,7 +1673,10 @@ void campaign_select_campaign(const SCP_string& campaign_file)
 				// reset tech database to what's in the tables
 				tech_reset_to_default();
 			}
+
+			OnCampaignBeginHook->run(scripting::hook_param_list(scripting::hook_param("Campaign", 's', Campaign.filename)));
 		}
+
 		// that's all we need to do for now; the campaign loading status will be checked again when we try to load the
 		// campaign in the ready room
 	}

--- a/code/menuui/readyroom.h
+++ b/code/menuui/readyroom.h
@@ -12,6 +12,7 @@
 #define _READYROOM_H
 
 #include "globalincs/pstypes.h"
+#include "scripting/hook_api.h"
 
 extern int Sim_room_overlay_id;
 extern int Campaign_room_overlay_id;
@@ -30,5 +31,7 @@ void campaign_room_do_frame(float frametime);
 bool campaign_build_campaign_list();
 void campaign_select_campaign(const SCP_string& campaign_file);
 void campaign_reset(const SCP_string& campaign_file);
+
+extern const std::shared_ptr<scripting::Hook> OnCampaignBeginHook;
 
 #endif

--- a/code/playerman/managepilot.cpp
+++ b/code/playerman/managepilot.cpp
@@ -17,6 +17,7 @@
 #include "io/joy.h"
 #include "io/mouse.h"
 #include "menuui/playermenu.h"
+#include "menuui/readyroom.h"
 #include "menuui/techmenu.h"
 #include "mission/missionbriefcommon.h"
 #include "mission/missioncampaign.h"
@@ -163,6 +164,8 @@ void init_new_pilot(player *p, int reset)
 	}
 
 	pilot_set_start_campaign(p);
+
+	OnCampaignBeginHook->run(scripting::hook_param_list(scripting::hook_param("Campaign", 's', p->current_campaign)));
 }
 
 int local_num_campaigns = 0;

--- a/code/scripting/api/objs/player.cpp
+++ b/code/scripting/api/objs/player.cpp
@@ -5,6 +5,7 @@
 
 #include "gamesequence/gamesequence.h"
 #include "menuui/mainhallmenu.h"
+#include "menuui/readyroom.h"
 #include "menuui/techmenu.h"
 #include "mission/missioncampaign.h"
 #include "pilotfile/pilotfile.h"
@@ -322,7 +323,10 @@ ADE_FUNC(loadCampaign, l_Player, "string campaign", "Loads the specified campaig
 			// reset tech database to what's in the tables
 			tech_reset_to_default();
 		}
+
+		OnCampaignBeginHook->run(scripting::hook_param_list(scripting::hook_param("Campaign", 's', Campaign.filename)));
 	}
+
 	// that's all we need to do for now; the campaign loading status will be checked again when we try to load the
 	// campaign in the ready room
 


### PR DESCRIPTION
This hook will be called when a campaign is started for the first time (whether in Player Select or in the campaign room), or is reset.