### PR TITLE
Add delay into ai_new_maybe_reposition_attack_subsys for performance 

### DIFF
--- a/code/ai/ai.h
+++ b/code/ai/ai.h
@@ -267,6 +267,8 @@ extern pnode	*Ppfp;			//	Free pointer in path points.
 // Goober5000 (based on the "you can only remember 7 things in short-term memory" assumption)
 #define MAX_IGNORE_NEW_OBJECTS	7
 
+#define AI_DYNAMIC_PATH_RECHECK_DELAY 1*1000
+
 typedef struct ai_info {
 	flagset<AI::AI_Flags> ai_flags;				//	Special flags for AI behavior.
 	int		shipnum;					// Ship using this slot, -1 means none.
@@ -342,6 +344,9 @@ typedef struct ai_info {
 	int		submode_parm0;			//	parameter specific to current submode
 	int		submode_parm1;			//	SUSHI: Another optional parameter
 	fix		next_predict_pos_time;			//	Next time to predict position.
+
+	int		next_dynamic_path_check_time;	//ETP: Time of next path check in ai_new_maybe_reposition_attack_subsys
+	vec3d	last_dynamic_path_goal;			//ETP: Remebers last target location in ai_new_maybe_reposition_attack_subsys
 
 	//SUSHI: like last_predicted_enemy_pos, but for aiming (which currently ignores predicted position)
 	//Unlike the predicted position stuff, also takes into account velocity

--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -15031,6 +15031,9 @@ void init_ai_object(int objnum)
 	aip->next_predict_pos_time = 0;
 	aip->next_aim_pos_time = 0;
 
+	aip->next_dynamic_path_check_time = timestamp(0);
+	vm_vec_zero(&aip->last_dynamic_path_goal);
+
 	aip->afterburner_stop_time = 0;
 	aip->last_objsig_hit = -1;				// object signature of the ship most recently hit by aip
 


### PR DESCRIPTION
Profiling found ai_new_maybe_reposition_attack_subsys accounting for around 13% of runtime in crowded missions. This adds a 1 second delay between checking new points, which takes it to 0% of runtime in those same missions. I have not been able to discern a visible change in ship behavior.