### PR TITLE
Remove unneeded search of whole sexp node array from free_sexp

### DIFF
--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -1372,8 +1372,9 @@ int free_one_sexp(int num)
  *
  * Should only be called on an atom or a list, and not an operator.  If on a list, the 
  * list and everything in it will be freed (including the operator).
+ * calling_node defaults to -1
  */
-int free_sexp(int num)
+int free_sexp(int num, int calling_node)
 {
 	int i, rest, count = 0;
 
@@ -1393,20 +1394,20 @@ int free_sexp(int num)
 	count++;
 
 	i = Sexp_nodes[num].first;
-	while (i != -1)
+	while (i != -1) 
 	{
-		count += free_sexp(i);
+		count += free_sexp(i, num);
 		i = Sexp_nodes[i].rest;
 	}
 
 	rest = Sexp_nodes[num].rest;
-	for (i = 0; i < Num_sexp_nodes; i++)
+	if (calling_node >= 0) 
 	{
-		if (Sexp_nodes[i].first == num)
-			Sexp_nodes[i].first = rest;
+		if (Sexp_nodes[calling_node].first == num)
+			Sexp_nodes[calling_node].first = rest;
 
-		if (Sexp_nodes[i].rest == num)
-			Sexp_nodes[i].rest = rest;
+		if (Sexp_nodes[calling_node].rest == num)
+			Sexp_nodes[calling_node].rest = rest;
 	}
 
 	return count;  // total elements freed up.

--- a/code/parse/sexp.h
+++ b/code/parse/sexp.h
@@ -1243,7 +1243,7 @@ extern void sexp_shutdown();
 extern int alloc_sexp(const char *text, int type, int subtype, int first, int rest);
 extern int find_free_sexp();
 extern int free_one_sexp(int num);
-extern int free_sexp(int num);
+extern int free_sexp(int num, int calling_node = -1);
 extern int free_sexp2(int num);
 extern int dup_sexp_chain(int node);
 extern int cmp_sexp_chains(int node1, int node2);


### PR DESCRIPTION
Profiling shows that free_sexp contributes to significant runtime consumption in mods with heavy use of sexps in scripts, especially in missions with lots of sexp nodes. This change removes the need for that looping, cutting about half of the runtime from those sexps from scripts. Given some testing in Blighted and Warmachine with no evident breakage of either scripts or conventional mission logic.