### PR TITLE
enhance help text for Lua sexps

### DIFF
--- a/code/parse/parselo.cpp
+++ b/code/parse/parselo.cpp
@@ -353,6 +353,19 @@ void advance_to_next_white()
 	}
 }
 
+// If the parser is at an eoln, move past it
+bool skip_eoln()
+{
+	auto old_Mp = Mp;
+
+	if (*Mp == '\r')
+		Mp++;
+	if (*Mp == '\n')
+		Mp++;
+
+	return old_Mp != Mp;
+}
+
 // Search for specified string, skipping everything up to that point.  Returns 1 if found,
 // 0 if string wasn't found (and hit end of file), or -1 if not found, but end of checking
 // block was reached.

--- a/code/parse/parselo.h
+++ b/code/parse/parselo.h
@@ -107,6 +107,7 @@ extern int skip_to_string(const char *pstr, const char *end = NULL);
 extern int skip_to_start_of_string(const char *pstr, const char *end = NULL);
 extern int skip_to_start_of_string_either(const char *pstr1, const char *pstr2, const char *end = NULL);
 extern void advance_to_eoln(const char *terminators);
+extern bool skip_eoln();
 extern void skip_token();
 
 // optional

--- a/code/parse/sexp/LuaSEXP.h
+++ b/code/parse/sexp/LuaSEXP.h
@@ -26,6 +26,9 @@ class LuaSEXP : public DynamicSEXP {
 	std::pair<SCP_string, int> getArgumentInternalType(int argnum) const;
 	luacpp::LuaValue sexpToLua(int node, int argnum) const;
 
+	// just a helper for parseTable
+	static bool parseCheckEndOfDescription();
+
  public:
 	explicit LuaSEXP(const SCP_string& name);
 


### PR DESCRIPTION
Two enhancements:
1) Allow the SEXP help description to take up multiple lines.  Since the parser did not originally use `stuff_string` with `F_MULTITEXT`, this required some creative parsing.
2) Generate the text for minimum and maximum number of arguments.