### PR TITLE
Make sure obj_udpate packet

### DIFF
--- a/code/model/model.h
+++ b/code/model/model.h
@@ -90,6 +90,9 @@ struct submodel_instance
 	float	turn_accel = 0.0f;
 	int		turn_step_zero_timestamp = timestamp();		// timestamp determines when next step is to begin (for stepped rotation)
 
+	vec3d	point_on_axis = vmd_zero_vector;		// in ship RF
+	bool	axis_set = false;
+
 	bool	blown_off = false;						// If set, this subobject is blown off
 	bool	collision_checked = false;
 
@@ -105,9 +108,6 @@ struct submodel_instance
 	int		num_arcs = 0;											// See model_add_arc for more info	
 	vec3d	arc_pts[MAX_ARC_EFFECTS][2];
 	ubyte		arc_type[MAX_ARC_EFFECTS];							// see MARC_TYPE_* defines
-
-	//SMI-Specific movement axis. Only valid in MOVEMENT_TYPE_TRIGGERED.
-	vec3d	rotation_axis;
 
 	submodel_instance()
 	{
@@ -189,8 +189,6 @@ public:
 	// AWACS specific information
 	float		awacs_intensity;						// awacs intensity of this subsystem
 	float		awacs_radius;							// radius of effect of the AWACS
-
-	int		scan_time;							// overrides ship class scan time if >0
 
 	int		primary_banks[MAX_SHIP_PRIMARY_BANKS];					// default primary weapons -hoffoss
 	int		primary_bank_capacity[MAX_SHIP_PRIMARY_BANKS];		// capacity of a bank - Goober5000
@@ -336,7 +334,6 @@ public:
 	int		num_children;			// How many children this model has
 	int		first_child;			// The first_child of this model, -1 if none
 	int		next_sibling;			// This submodel's next sibling, -1 if none
-	int		depth;					// How many levels deep this subobject sits
 
 	int		num_details;			// How many submodels are lower detail "mirrors" of this submodel
 	int		details[MAX_MODEL_DETAIL_LEVELS];		// A list of all the lower detail "mirrors" of this submodel
@@ -795,28 +792,21 @@ public:
 //
 // The "level" parameter indicates how deep the nesting level is, and the "isLeaf" parameter indicates whether the submodel is a leaf node.
 // To find the model's detail0 root node, use pm->submodel[pm->detail[0]].
-template <typename Func, typename... AdditionalParams>
-void model_iterate_submodel_tree(polymodel* pm, int submodel, Func func, int level, AdditionalParams... params)
+template <typename Func>
+void model_iterate_submodel_tree(polymodel* pm, int submodel, Func func, int level = 0)
 {
 	Assertion(pm != nullptr, "pm must not be null!");
 	Assertion(submodel >= 0 && submodel < pm->n_models, "submodel must be in range!");
 
 	auto child = pm->submodel[submodel].first_child;
 
-	func(submodel, level, child < 0, params...);
+	func(submodel, level, child < 0);
 
 	while (child >= 0)
 	{
-		model_iterate_submodel_tree(pm, child, func, level + 1, params...);
+		model_iterate_submodel_tree(pm, child, func, level + 1);
 		child = pm->submodel[child].next_sibling;
 	}
-}
-
-//This wrapper function is needed due to a bug in clang versions before 11 which breaks default parameters before parameter packs
-template <typename Func>
-inline void model_iterate_submodel_tree(polymodel* pm, int submodel, Func func)
-{
-	model_iterate_submodel_tree(pm, submodel, func, 0);
 }
 
 // Call once to initialize the model system
@@ -961,68 +951,44 @@ extern void submodel_rotate(bsp_info *sm, submodel_instance *smi);
 // gets stuffed.  Does this for stepped rotations
 void submodel_stepped_rotate(model_subsystem *psub, submodel_instance *smi);
 
-// ------- submodel transformations -------
-
 // Goober5000
 // For a submodel, return its overall offset from the main model.
 extern void model_find_submodel_offset(vec3d *outpnt, const polymodel *pm, int sub_model_num);
 
-// Given a point in a submodel's local frame of reference, transform it to a global frame of reference.
-// If objorient and objpos are supplied, this will be world space; otherwise it will be the model's space.
-extern void model_local_to_global_point(vec3d *outpnt, const vec3d *mpnt, int model_num, int submodel_num, const matrix *objorient = nullptr, const vec3d *objpos = nullptr);
-// Given a point in a submodel's local frame of reference, transform it to a global frame of reference.
-// If objorient and objpos are supplied, this will be world space; otherwise it will be the model's space.
-extern void model_local_to_global_point(vec3d *outpnt, const vec3d *mpnt, const polymodel *pm, int submodel_num, const matrix *objorient = nullptr, const vec3d *objpos = nullptr);
+// Given a point (pnt) that is in sub_model_num's frame of
+// reference, and given the object's orient and position, 
+// return the point in 3-space in outpnt.
+extern void model_find_world_point(vec3d *outpnt, vec3d *mpnt, int model_num, int submodel_num, const matrix *objorient, const vec3d *objpos);
+extern void model_instance_find_world_point(vec3d *outpnt, vec3d *mpnt, int model_instance_num, int submodel_num, const matrix *objorient, const vec3d *objpos);
+extern void model_find_world_point(vec3d *outpnt, vec3d *mpnt, const polymodel *pm, int submodel_num, const matrix *objorient, const vec3d *objpos);
+extern void model_instance_find_world_point(vec3d *outpnt, vec3d *mpnt, const polymodel *pm, const polymodel_instance *pmi, int submodel_num, const matrix *objorient, const vec3d *objpos);
 
-// Given a point in a submodel's local frame of reference, transform it to a global frame of reference, taking into account submodel rotations.
-// If objorient and objpos are supplied, this will be world space; otherwise it will be the model's space.
-extern void model_instance_local_to_global_point(vec3d *outpnt, const vec3d *mpnt, int model_instance_num, int submodel_num, const matrix *objorient = nullptr, const vec3d *objpos = nullptr, bool use_last_frame = false);
-// Given a point in a submodel's local frame of reference, transform it to a global frame of reference, taking into account submodel rotations.
-// If objorient and objpos are supplied, this will be world space; otherwise it will be the model's space.
-extern void model_instance_local_to_global_point(vec3d *outpnt, const vec3d *mpnt, const polymodel *pm, const polymodel_instance *pmi, int submodel_num, const matrix *objorient = nullptr, const vec3d *objpos = nullptr, bool use_last_frame = false);
+// Given a point in the world RF, find the corresponding point in the model RF.
+// This is special purpose code, specific for model collision.
+// NOTE - this code ASSUMES submodel is 1 level down from hull (detail[0])
+void world_find_model_instance_point(vec3d *out, vec3d *world_pt, const polymodel *pm, const polymodel_instance *pmi, int submodel_num, const matrix *orient, const vec3d *pos);
 
-// Given a direction (or normal) in a submodel's local frame of reference, transform it to a global frame of reference.
-// If objorient and objpos are supplied, this will be world space; otherwise it will be the model's space.
-extern void model_local_to_global_dir(vec3d *out_dir, const vec3d *in_dir, int model_num, int submodel_num, const matrix *objorient = nullptr);
-// Given a direction (or normal) in a submodel's local frame of reference, transform it to a global frame of reference.
-// If objorient and objpos are supplied, this will be world space; otherwise it will be the model's space.
-extern void model_local_to_global_dir(vec3d *out_dir, const vec3d *in_dir, const polymodel *pm, int submodel_num, const matrix *objorient = nullptr);
-
-// Given a direction (or normal) in a submodel's local frame of reference, transform it to a global frame of reference, taking into account submodel rotations.
-// If objorient and objpos are supplied, this will be world space; otherwise it will be the model's space.
-extern void model_instance_local_to_global_dir(vec3d *out_dir, const vec3d *in_dir, int model_instance_num, int submodel_num, const matrix *objorient = nullptr, bool use_submodel_parent = false);
-// Given a direction (or normal) in a submodel's local frame of reference, transform it to a global frame of reference, taking into account submodel rotations.
-// If objorient and objpos are supplied, this will be world space; otherwise it will be the model's space.
-extern void model_instance_local_to_global_dir(vec3d *out_dir, const vec3d *in_dir, const polymodel *pm, const polymodel_instance *pmi, int submodel_num, const matrix *objorient = nullptr);
-
-// Combines model_instance_local_to_global_point and model_instance_local_to_global_dir into one function.
-extern void model_instance_local_to_global_point_dir(vec3d *outpnt, vec3d *outnorm, const vec3d *submodel_pnt, const vec3d *submodel_norm, const polymodel *pm, const polymodel_instance *pmi, int submodel_num, const matrix *objorient = nullptr, const vec3d *objpos = nullptr);
-
-// Combines model_instance_local_to_global_point and the matrix equivalent of model_instance_local_to_global_dir into one function.
-extern void model_instance_local_to_global_point_orient(vec3d *outpnt, matrix *outorient, const vec3d *submodel_pnt, const matrix *submodel_orient, const polymodel *pm, const polymodel_instance *pmi, int submodel_num, const matrix *objorient = nullptr, const vec3d *objpos = nullptr);
-
-
-// Given a point in a global frame of reference, transform it to a submodel's local frame of reference, taking into account submodel rotations.
-// If objorient and objpos are supplied, the global frame will be world space; otherwise it will be the model's space.
-extern void model_instance_global_to_local_point(vec3d *outpnt, const vec3d *mpnt, int model_instance_num, int submodel_num, const matrix *objorient = nullptr, const vec3d *objpos = nullptr, bool use_last_frame = false);
-// Given a point in a global frame of reference, transform it to a submodel's local frame of reference, taking into account submodel rotations.
-// If objorient and objpos are supplied, the global frame will be world space; otherwise it will be the model's space.
-extern void model_instance_global_to_local_point(vec3d *outpnt, const vec3d *mpnt, const polymodel *pm, const polymodel_instance *pmi, int submodel_num, const matrix *objorient = nullptr, const vec3d *objpos = nullptr, bool use_last_frame = false);
-
-// Given a direction (or normal) in a global frame of reference, transform it to a submodel's local frame of reference, taking into account submodel rotations.
-// If objorient is supplied, the global frame will be world space; otherwise it will be the model's space.
-extern void model_instance_global_to_local_dir(vec3d *out_dir, const vec3d *in_dir, int model_instance_num, int submodel_num, const matrix *objorient = nullptr, bool use_submodel_parent = false, bool use_last_frame = false);
-// Given a direction (or normal) in a global frame of reference, transform it to a submodel's local frame of reference, taking into account submodel rotations.
-// If objorient is supplied, the global frame will be world space; otherwise it will be the model's space.
-extern void model_instance_global_to_local_dir(vec3d *out_dir, const vec3d *in_dir, const polymodel *pm, const polymodel_instance *pmi, int submodel_num, const matrix *objorient = nullptr, bool use_last_frame = false);
-
-// ------- end of submodel transformations -------
+extern void find_submodel_instance_point(vec3d *outpnt, const polymodel *pm, const polymodel_instance *pmi, int submodel_num);
+extern void find_submodel_instance_point_normal(vec3d *outpnt, vec3d *outnorm, const polymodel *pm, const polymodel_instance *pmi, int submodel_num, const vec3d *submodel_pnt, const vec3d *submodel_norm);
+extern void find_submodel_instance_point_orient(vec3d *outpnt, matrix *outorient, const polymodel *pm, const polymodel_instance *pmi, int submodel_num, const vec3d *submodel_pnt, const matrix *submodel_orient);
+extern void find_submodel_instance_world_point(vec3d *outpnt, const polymodel *pm, const polymodel_instance *pmi, int submodel_num, const matrix *objorient, const vec3d *objpos);
 
 // Given a polygon model index, find a list of moving submodels to be used for collision
 void model_get_moving_submodel_list(SCP_vector<int> &submodel_vector, const object *objp);
 
 // Given a polygon model index, get a list of a model tree starting from that index
 void model_get_submodel_tree_list(SCP_vector<int> &submodel_vector, const polymodel *pm, int mn);
+
+// For a rotating submodel, find a point on the axis
+void model_init_submodel_axis_pt(polymodel *pm, polymodel_instance *pmi, int submodel_num);
+
+// Given a direction (pnt) that is in sub_model_num's frame of
+// reference, and given the object's orient and position, 
+// return the point in 3-space in outpnt.
+extern void model_find_world_dir(vec3d *out_dir, const vec3d *in_dir, int model_num, int submodel_num, const matrix *objorient);
+extern void model_find_world_dir(vec3d *out_dir, const vec3d *in_dir, const polymodel *pm, int submodel_num, const matrix *objorient);
+extern void model_instance_find_world_dir(vec3d *out_dir, const vec3d *in_dir, int model_instance_num, int submodel_num, const matrix *objorient, bool use_submodel_parent = false);
+extern void model_instance_find_world_dir(vec3d *out_dir, const vec3d *in_dir, const polymodel *pm, const polymodel_instance *pmi, int submodel_num, const matrix *objorient);
 
 // Clears all the submodel instances stored in a model to their defaults.
 extern void model_clear_instance(int model_num);
@@ -1049,8 +1015,6 @@ void submodel_get_cross_sectional_avg_pos(int model_num, int submodel_num, float
 // generates a random position more or less inside-ish a mesh at a particular z slice
 void submodel_get_cross_sectional_random_pos(int model_num, int submodel_num, float z_slice_pos, vec3d* pos);
   
-extern int model_find_submodel_index(int modelnum, const char *name);
-
 // gets the index into the docking_bays array of the specified type of docking point
 // Returns the index.  second functions returns the index of the docking bay with
 // the specified name
@@ -1100,7 +1064,7 @@ typedef struct mc_info {
 	int		hit_bitmap;			// Which texture got hit.  -1 if not a textured poly
 	float		hit_u, hit_v;		// Where on hit_bitmap the ray hit.  Invalid if hit_bitmap < 0
 	int		shield_hit_tri;	// Which triangle on the shield got hit or -1 if none
-	vec3d	hit_normal;			//	Vector normal of polygon of collision (This is in submodel RF). CAN BE ZERO, if edge_hit is true
+	vec3d	hit_normal;			//	Vector normal of polygon of collision.  (This is in submodel RF)
 	bool		edge_hit;			// Set if an edge got hit.  Only valid if MC_CHECK_THICK is set.	
 	ubyte		*f_poly;				// pointer to flat poly where we intersected
 	ubyte		*t_poly;				// pointer to tmap poly where we intersected

--- a/code/network/multi.h
+++ b/code/network/multi.h
@@ -69,9 +69,10 @@ class player;
 // version 54 - 3/20/2021 - Fixes for FSO 21_2 especially better net_sig calc, better missile intercept
 // version 55 - 8/28/2021 Adding multi-compatible animations
 // version 56 - 8/28/2021 Fix animations for 22_0 release
+// version 57 - 3/26/2022 Adjust object update to use missiontime instead of timestamp to fix bugs
 // STANDALONE_ONLY
 
-#define MULTI_FS_SERVER_VERSION							56
+#define MULTI_FS_SERVER_VERSION							57
 
 #define MULTI_FS_SERVER_COMPATIBLE_VERSION			MULTI_FS_SERVER_VERSION
 

--- a/code/network/multi_obj.h
+++ b/code/network/multi_obj.h
@@ -72,7 +72,7 @@ void multi_ship_record_update_all();
 void multi_ship_record_increment_frame();
 
 // find the right frame to start our weapon simulation
-int multi_ship_record_find_frame(int client_frame, int time_elapsed);
+fix multi_ship_record_find_frame(int client_frame, fix time_elapsed);
 
 // a quick lookups for position and orientation
 vec3d multi_ship_record_lookup_position(object* objp, int frame);
@@ -81,10 +81,10 @@ vec3d multi_ship_record_lookup_position(object* objp, int frame);
 matrix multi_ship_record_lookup_orientation(object* objp, int frame);
 
 // figures out how much time has passed bwetween the two frames.
-int multi_ship_record_find_time_after_frame(int client_frame, int frame, int time_elapsed);
+fix multi_ship_record_find_time_after_frame(int client_frame, int frame, fix time_elapsed);
 
 // This stores the information we got from the client to create later.
-void multi_ship_record_add_rollback_shot(object* pobjp, vec3d* pos, matrix* orient, int frame, bool secondary);
+void multi_ship_record_add_rollback_shot(object* pobjp, vec3d* pos, matrix* orient, int frame, fix time_after, bool secondary);
 
 // Lookup whether rollback mode is on
 bool multi_ship_record_get_rollback_wep_mode();

--- a/code/network/multi_obj.h
+++ b/code/network/multi_obj.h
@@ -106,7 +106,7 @@ ushort multi_client_lookup_ref_obj_net_sig();
 int multi_client_lookup_frame_idx();
 
 // Quick lookup for the most recently received timestamp.
-int multi_client_lookup_frame_timestamp();
+fix multi_client_lookup_frame_missiontime();
 
 // reset all the necessary info for respawning player.
 void multi_oo_respawn_reset_info(ushort net_sig);

--- a/code/network/multimsgs.cpp
+++ b/code/network/multimsgs.cpp
@@ -7842,10 +7842,10 @@ void send_non_homing_fired_packet(ship* shipp, int banks_or_number_of_missiles_f
 
 	// We need the time elpased, so send the last frame we got from the server and how much time has happened since then.
 	int last_received_frame = multi_client_lookup_frame_idx();
-	auto time_elapsed = (ushort)(timestamp() - multi_client_lookup_frame_timestamp());
+	fix time_elapsed = Missiontime - multi_client_lookup_frame_missiontime();
 
 	ADD_INT(last_received_frame);
-	ADD_USHORT(time_elapsed);
+	ADD_INT(time_elapsed);
 
 	// Save the transposed matrix so that we can optimize and use it twice.
 	matrix ref_ori;

--- a/code/network/multimsgs.cpp
+++ b/code/network/multimsgs.cpp
@@ -7899,7 +7899,7 @@ void process_non_homing_fired_packet(ubyte* data, header* hinfo)
 		secondary = true;
 	}
 
-	ushort time_elapsed;
+	fix time_elapsed;
 	ushort target_ref;
 	int client_frame;
 	angles adjustment_angles, player_ship_angles;
@@ -7909,7 +7909,7 @@ void process_non_homing_fired_packet(ubyte* data, header* hinfo)
 	//finish processing the packet 
 	GET_USHORT(target_ref);
 	GET_INT(client_frame);
-	GET_USHORT(time_elapsed);
+	GET_INT(time_elapsed);
 	GET_FLOAT(distance);
 	GET_VECTOR(ref_to_ship_vec);
 	GET_FLOAT(adjustment_angles.b);
@@ -7950,12 +7950,11 @@ void process_non_homing_fired_packet(ubyte* data, header* hinfo)
 	}
 
 	// figure out correct start frame
-	int frame = multi_ship_record_find_frame(client_frame, (int)time_elapsed);
+	int frame = multi_ship_record_find_frame(client_frame, time_elapsed);
 
 	if (frame > -1) {
 		// adjust time so that we can interpolate the position and orientation that was seen on the client.
-		int time_after_frame = multi_ship_record_find_time_after_frame(client_frame, frame, (int)time_elapsed);
-		Assertion(time_after_frame >= 0, "Primary fire packet processor found an invalid time_after_frame of %d", time_after_frame);
+		fix time_after = multi_ship_record_find_time_after_frame(client_frame, frame, time_elapsed);
 
 		vec3d new_tar_pos = multi_ship_record_lookup_position(objp_ref, frame);
 		matrix new_tar_ori = multi_ship_record_lookup_orientation(objp_ref, frame);
@@ -7988,7 +7987,7 @@ void process_non_homing_fired_packet(ubyte* data, header* hinfo)
 		// Now multiply the two matrices to find the orientation of the firing ship.
 		matrix new_player_ori;
 		vm_matrix_x_matrix(&new_player_ori, &old_player_ori, &temp_ori);
-		multi_ship_record_add_rollback_shot(objp, &new_player_pos, &new_player_ori, frame, secondary);
+		multi_ship_record_add_rollback_shot(objp, &new_player_pos, &new_player_ori, frame, secondary, time_after);
 
 	}	// if the new way fails for some reason, use the old way.
 	else {

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -346,9 +346,9 @@ extern void ssm_process();
 
 // amount of time to wait after the player has died before we display the death died popup
 #define PLAYER_DIED_POPUP_WAIT		2500
-UI_TIMESTAMP Player_died_popup_wait;
+int Player_died_popup_wait = -1;
 
-UI_TIMESTAMP Multi_ping_timestamp;
+int Multi_ping_timestamp = -1;
 
 
 const auto OnMissionAboutToEndHook = scripting::Hook::Factory(
@@ -966,7 +966,7 @@ void game_level_init()
 	// Initialize the game subsystems
 	game_time_level_init();
 
-	Multi_ping_timestamp = UI_TIMESTAMP::invalid();
+	Multi_ping_timestamp = -1;
 
 	obj_init();						// Must be inited before the other systems
 
@@ -1356,6 +1356,9 @@ void game_post_level_init()
 	freespace_mission_load_stuff();
 
 	mission_process_alt_types();
+
+	// Now that loading is complete, resume time so that timestamps used in the briefing screens will work
+	game_start_time();
 
 	// m!m Make hv.Player available in "On Mission Start" hook
 	if(Player_obj)
@@ -2722,7 +2725,7 @@ void do_timing_test(float frame_time)
 	}
 }
 
-DCF(fov, "Change the field of view of the main camera")
+DCF(dcf_fov, "Change the field of view of the main camera")
 {
 	camera *cam = Main_camera.getCamera();
 	bool process = true;
@@ -2765,6 +2768,7 @@ DCF(fov, "Change the field of view of the main camera")
 		cam->set_fov(value);
 	}
 }
+
 
 DCF(framerate_cap, "Sets the framerate cap")
 {
@@ -3733,7 +3737,7 @@ void game_maybe_do_dead_popup(float frametime)
 		}
 
 		if ( leave_popup ) {
-			popupdead_close(true);
+			popupdead_close();
 		}
 	}
 }
@@ -4064,13 +4068,13 @@ void game_frame(bool paused)
 					if(Net_player->flags & NETINFO_FLAG_WARPING_OUT){
 						multi_handle_sudden_mission_end();
 						send_debrief_event();
-					} else if (Player_died_popup_wait.isValid() && ui_timestamp_elapsed(Player_died_popup_wait)) {
-						Player_died_popup_wait = UI_TIMESTAMP::invalid();
+					} else if((Player_died_popup_wait != -1) && (timestamp_elapsed(Player_died_popup_wait))){
+						Player_died_popup_wait = -1;
 						popupdead_start();
 					}
 				} else {
-					if (Player_died_popup_wait.isValid() && ui_timestamp_elapsed(Player_died_popup_wait)) {
-						Player_died_popup_wait = UI_TIMESTAMP::invalid();
+					if((Player_died_popup_wait != -1) && (timestamp_elapsed(Player_died_popup_wait))){
+						Player_died_popup_wait = -1;
 						popupdead_start();
 					}
 				}
@@ -4174,11 +4178,6 @@ void game_stop_time(bool by_os_focus)
 	// Stop the timer_tick stuff...
 	// We always want to 'sudo' the change, unless this is caused by the focus, because we want the game to have priority in that case
 	timestamp_pause(!by_os_focus);
-}
-
-bool game_time_is_stopped()
-{
-	return Time_paused;
 }
 
 void game_start_time(bool by_os_focus)
@@ -4353,6 +4352,11 @@ void game_update_missiontime()
 
 void game_do_frame(bool set_frametime)
 {
+	if (Missiontime == 0) {
+		// reset the timestamps to the beginning, since they were running in the briefing screens
+		timestamp_revert_to_mission_start();
+	}
+
 	if (set_frametime) {
 		game_set_frametime(GS_STATE_GAME_PLAY);
 	}
@@ -5340,31 +5344,43 @@ void game_leave_state( int old_state, int new_state )
 			break;
 
 		case GS_STATE_DEATH_DIED:
+			if (end_mission) {
+				Game_mode &= ~GM_DEAD_DIED;
+
+				if ( !(Game_mode & GM_MULTIPLAYER) ) {
+					if (new_state == GS_STATE_DEBRIEF) {
+						freespace_stop_mission();
+					}
+				} else {
+					// early end while respawning or blowing up in a multiplayer game
+					if ( (new_state == GS_STATE_DEBRIEF) || (new_state == GS_STATE_MULTI_DOGFIGHT_DEBRIEF) ) {
+						game_stop_time();
+						freespace_stop_mission();
+					}
+				}
+			}
+
+			break;
+
 		case GS_STATE_DEATH_BLEW_UP:
 			if (end_mission) {
-				if (old_state == GS_STATE_DEATH_DIED) {
-					Game_mode &= ~GM_DEAD_DIED;
-				} else if (old_state == GS_STATE_DEATH_BLEW_UP) {
-					Game_mode &= ~GM_DEAD_BLEW_UP;
-				}
+				Game_mode &= ~GM_DEAD_BLEW_UP;
 
-				if (new_state != GS_STATE_DEATH_BLEW_UP) {
-					if ( !(Game_mode & GM_MULTIPLAYER) ) {
-						popupdead_close();			// it's usually closed by this point, but not always (e.g. if end-mission is called)
+				// for single player, we might reload mission, etc.  For multiplayer, look at my new state
+				// to determine if I should do anything.
+				if ( !(Game_mode & GM_MULTIPLAYER) ) {
+					freespace_stop_mission();
+				} else {
+					// if we are not respawing as an observer or as a player, our new state will not
+					// be gameplay state.
+					if ( (new_state != GS_STATE_GAME_PLAY) && (new_state != GS_STATE_MULTI_PAUSED) ) {
+						game_stop_time();									// hasn't been called yet!!
 						freespace_stop_mission();
-					} else {
-						// early end while respawning or blowing up in a multiplayer game
-						// if we are not respawing as an observer or as a player, our new state will not
-						// be gameplay state.
-						if ( (new_state != GS_STATE_GAME_PLAY) && (new_state != GS_STATE_MULTI_PAUSED) ) {
-							game_stop_time();
-							popupdead_close();
-							freespace_stop_mission();
-						}
 					}
 				}
 			}
 			break;
+
 
 		case GS_STATE_CREDITS:
 			credits_close();
@@ -5926,7 +5942,7 @@ void mouse_force_pos(int x, int y);
 
 			// timestamp how long we should wait before displaying the died popup
 			if ( !popupdead_is_active() ) {
-				Player_died_popup_wait = ui_timestamp(PLAYER_DIED_POPUP_WAIT);
+				Player_died_popup_wait = timestamp(PLAYER_DIED_POPUP_WAIT);
 			}
 			break;
 


### PR DESCRIPTION
This allows the object update and rollback packets to use Missiontime instead of timestamp(), since the local timestamp() is not updated when option menus are added.  This should also begin the upgrade to the interpolation code that should get shuddering out of multiplayer missions. 

Needs testing.