### PR TITLE
fix a bunch of FRED dialog problems

### DIFF
--- a/fred2/eventeditor.cpp
+++ b/fred2/eventeditor.cpp
@@ -181,7 +181,7 @@ void maybe_add_head(CComboBox *box, char* name)
 
 BOOL event_editor::OnInitDialog() 
 {
-	int i, adjust = 0;
+	int i;
 	BOOL r = TRUE;
 	CListBox *list;
 	CComboBox *box;
@@ -191,10 +191,7 @@ BOOL event_editor::OnInitDialog()
 	m_play_bm.LoadBitmap(IDB_PLAY);
 	((CButton *) GetDlgItem(IDC_PLAY)) -> SetBitmap(m_play_bm);
 
-	if (!Show_sexp_help)
-		adjust = -SEXP_HELP_BOX_SIZE;
-
-	theApp.init_window(&Events_wnd_data, this, adjust);
+	theApp.init_window(&Events_wnd_data, this, 0);
 	m_event_tree.setup((CEdit *) GetDlgItem(IDC_HELP_BOX));
 	load_tree();
 	create_tree();

--- a/fred2/fred.cpp
+++ b/fred2/fred.cpp
@@ -372,22 +372,31 @@ void CFREDApp::OnAppAbout() {
 }
 
 BOOL CFREDApp::OnIdle(LONG lCount) {
-	int adjust = 0;
 	CWnd *top, *wnd;
-
-	if (!Show_sexp_help)
-		adjust = -SEXP_HELP_BOX_SIZE;
 
 	if (!app_init) {
 		app_init = 1;
-		theApp.init_window(&Ship_wnd_data, &Ship_editor_dialog, adjust, 1);
-		theApp.init_window(&Wing_wnd_data, &Wing_editor_dialog, adjust, 1);
+		theApp.init_window(&Ship_wnd_data, &Ship_editor_dialog, 0, 1);
+		theApp.init_window(&Wing_wnd_data, &Wing_editor_dialog, 0, 1);
 		theApp.init_window(&Waypoint_wnd_data, &Waypoint_editor_dialog, 0, 1);
 		init_window(&Main_wnd_data, Fred_main_wnd);
 		Fred_main_wnd->SetWindowPos(&CWnd::wndTop, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE);
 
 		Ship_editor_dialog.calc_cue_height();
+		Ship_editor_dialog.calc_help_height();
+		// on initial setup, these must be called in this order
+		if (!Show_sexp_help)
+			Ship_editor_dialog.show_hide_sexp_help();
+		if (Hide_ship_cues)
+			Ship_editor_dialog.show_hide_cues();
+
 		Wing_editor_dialog.calc_cue_height();
+		Wing_editor_dialog.calc_help_height();
+		// on initial setup, these must be called in this order
+		if (!Show_sexp_help)
+			Wing_editor_dialog.show_hide_sexp_help();
+		if (Hide_wing_cues)
+			Wing_editor_dialog.show_hide_cues();
 	}
 
 	CWinApp::OnIdle(lCount);

--- a/fred2/fredview.cpp
+++ b/fred2/fredview.cpp
@@ -1150,13 +1150,9 @@ LRESULT CFREDView::OnGoodbye(WPARAM wParam, LPARAM lParam)
 
 void CFREDView::OnEditorsShips() 
 {
-	int adjust = 0;
-
 	Assert(Ship_editor_dialog.GetSafeHwnd());
-	if (!Show_sexp_help)
-		adjust = -SEXP_HELP_BOX_SIZE;
 
-	if (!theApp.init_window(&Ship_wnd_data, &Ship_editor_dialog, adjust))
+	if (!theApp.init_window(&Ship_wnd_data, &Ship_editor_dialog, 0))
 		return;
 
 	Ship_editor_dialog.SetWindowPos(&wndTop, 0, 0, 0, 0,
@@ -2329,13 +2325,9 @@ void CFREDView::OnUpdateShowHorizon(CCmdUI* pCmdUI)
 
 void CFREDView::OnEditorsWing() 
 {
-	int adjust = 0;
-
 	Assert(Wing_editor_dialog.GetSafeHwnd());
-	if (!Show_sexp_help)
-		adjust = -SEXP_HELP_BOX_SIZE;
 
-	if (!theApp.init_window(&Wing_wnd_data, &Wing_editor_dialog, adjust))
+	if (!theApp.init_window(&Wing_wnd_data, &Wing_editor_dialog, 0))
 		return;
 
 	Wing_editor_dialog.SetWindowPos(&wndTop, 0, 0, 0, 0,
@@ -3403,11 +3395,7 @@ int CFREDView::fred_check_sexp(int sexp, int type, const char *msg, ...)
 
 void CFREDView::OnEditorsWaypoint() 
 {
-	int adjust = 0;
-
 	Assert(Waypoint_editor_dialog.GetSafeHwnd());
-	if (!Show_sexp_help)
-		adjust = -SEXP_HELP_BOX_SIZE;
 
 	if (!theApp.init_window(&Waypoint_wnd_data, &Waypoint_editor_dialog))
 		return;
@@ -4073,16 +4061,6 @@ void CFREDView::OnShowSexpHelp()
 	Show_sexp_help = !Show_sexp_help;
 	Ship_editor_dialog.show_hide_sexp_help();
 	Wing_editor_dialog.show_hide_sexp_help();
-
-	if (Event_editor_dlg) {
-		Event_editor_dlg->GetWindowRect(rect);
-		if (Show_sexp_help)
-			rect.bottom += SEXP_HELP_BOX_SIZE;
-		else
-			rect.bottom -= SEXP_HELP_BOX_SIZE;
-
-		Event_editor_dlg->MoveWindow(rect);
-	}
 }
 
 void CFREDView::OnUpdateShowSexpHelp(CCmdUI* pCmdUI) 

--- a/fred2/fredview.h
+++ b/fred2/fredview.h
@@ -15,7 +15,6 @@
 
 #define WM_MENU_POPUP_SHIPS	(WM_USER+6)
 #define WM_MENU_POPUP_EDIT		(WM_USER+7)
-#define SEXP_HELP_BOX_SIZE 170
 
 typedef struct Marking_box {
 	int x1, y1, x2, y2;

--- a/fred2/missiongoalsdlg.cpp
+++ b/fred2/missiongoalsdlg.cpp
@@ -62,8 +62,13 @@ BOOL CMissionGoalsDlg::OnInitDialog()
 	int i, adjust = 0;
 
 	CDialog::OnInitDialog();  // let the base class do the default work
+
 	if (!Show_sexp_help)
-		adjust = -SEXP_HELP_BOX_SIZE;
+	{
+		CRect rect;
+		GetDlgItem(IDC_HELP_BOX)->GetWindowRect(rect);
+		adjust = rect.top - rect.bottom - 20;
+	}
 
 	theApp.init_window(&Mission_goals_wnd_data, this, adjust);
 	m_goals_tree.setup((CEdit *) GetDlgItem(IDC_HELP_BOX));

--- a/fred2/sexp_tree.cpp
+++ b/fred2/sexp_tree.cpp
@@ -4063,7 +4063,7 @@ void sexp_tree::update_help(HTREEITEM h)
 		return;
 
 	mini_help_box = (CEdit *) GetParent()->GetDlgItem(IDC_MINI_HELP_BOX);
-	if (!mini_help_box || !::IsWindow(mini_help_box->m_hWnd))
+	if (mini_help_box && !::IsWindow(mini_help_box->m_hWnd))
 		return;
 
 	for (i=0; i<(int)tree_nodes.size(); i++)
@@ -4072,13 +4072,15 @@ void sexp_tree::update_help(HTREEITEM h)
 
 	if ((i >= (int)tree_nodes.size()) || !tree_nodes[i].type) {
 		help_box->SetWindowText("");
-		mini_help_box->SetWindowText("");
+		if (mini_help_box)
+			mini_help_box->SetWindowText("");
 		return;
 	}
 
 	if (SEXPT_TYPE(tree_nodes[i].type) == SEXPT_OPERATOR)
 	{
-		mini_help_box->SetWindowText("");
+		if (mini_help_box)
+			mini_help_box->SetWindowText("");
 	}
 	else
 	{
@@ -4168,7 +4170,8 @@ void sexp_tree::update_help(HTREEITEM h)
 				sprintf(buffer, "%d:", sibling_place);
 			}
 
-			mini_help_box->SetWindowText(buffer);
+			if (mini_help_box)
+				mini_help_box->SetWindowText(buffer);
 		}
 
 		if (index >= 0) {

--- a/fred2/shipeditordlg.cpp
+++ b/fred2/shipeditordlg.cpp
@@ -1832,48 +1832,44 @@ void CShipEditorDlg::OnSelchangedDepartureTree(NMHDR* pNMHDR, LRESULT* pResult)
 	*pResult = 0;
 }
 
+void CShipEditorDlg::calc_help_height()
+{
+	CRect minihelp, help;
+
+	GetDlgItem(IDC_MINI_HELP_BOX)->GetWindowRect(minihelp);
+	GetDlgItem(IDC_HELP_BOX)->GetWindowRect(help);
+	help_height = (help.bottom - minihelp.top) + 10;
+}
+
 void CShipEditorDlg::calc_cue_height()
 {
-	CRect cue, help;
+	CRect cue;
 
 	GetDlgItem(IDC_CUE_FRAME)->GetWindowRect(cue);
-	cue_height = (cue.bottom - cue.top)+20;
-	if (Show_sexp_help){
-		GetDlgItem(IDC_HELP_BOX)->GetWindowRect(help);
-		cue_height += (help.bottom - help.top);
-	}
-
-	if (Hide_ship_cues) {
-		((CButton *) GetDlgItem(IDC_HIDE_CUES)) -> SetCheck(1);
-		OnHideCues();
-	}
+	cue_height = (cue.bottom - cue.top) + 10;
 }
 
 void CShipEditorDlg::show_hide_sexp_help()
 {
-	CRect rect, help;
-	GetDlgItem(IDC_HELP_BOX)->GetWindowRect(help);
-	float box_size = (float)(help.bottom - help.top);
+	CRect rect;
 
-	if (Show_sexp_help){
-		cue_height += (int)box_size;
-	} else {
-		cue_height -= (int)box_size;
-	}
-
-	if (((CButton *) GetDlgItem(IDC_HIDE_CUES)) -> GetCheck()){
+	if (((CButton *) GetDlgItem(IDC_HIDE_CUES)) -> GetCheck())
 		return;
-	}
 
 	GetWindowRect(rect);
 
-	if (Show_sexp_help){
-		rect.bottom += (LONG)box_size;
-	} else {
-		rect.bottom -= (LONG)box_size;
-	}
+	if (Show_sexp_help)
+		rect.bottom += help_height;
+	else
+		rect.bottom -= help_height;
 
 	MoveWindow(rect);
+}
+
+void CShipEditorDlg::show_hide_cues()
+{
+	((CButton*)GetDlgItem(IDC_HIDE_CUES))->SetCheck(Hide_ship_cues ? TRUE : FALSE);
+	OnHideCues();
 }
 
 void CShipEditorDlg::OnHideCues() 
@@ -1881,12 +1877,18 @@ void CShipEditorDlg::OnHideCues()
 	CRect rect;
 
 	GetWindowRect(rect);
+
 	if (((CButton *) GetDlgItem(IDC_HIDE_CUES)) -> GetCheck()) {
 		rect.bottom -= cue_height;
-		Hide_ship_cues = 1;
+		if (Show_sexp_help)
+			rect.bottom -= help_height;
 
+		Hide_ship_cues = 1;
 	} else {
 		rect.bottom += cue_height;
+		if (Show_sexp_help)
+			rect.bottom += help_height;
+
 		Hide_ship_cues = 0;
 	}
 

--- a/fred2/shipeditordlg.h
+++ b/fred2/shipeditordlg.h
@@ -47,6 +47,7 @@ private:
 	int initialized;
 	int multi_edit;
 	int always_on_top;
+	int help_height;
 	int cue_height;
 	int mission_type;  // indicates if single player(1) or multiplayer(0)
 	CView*	m_pSEView;
@@ -65,8 +66,10 @@ public:
 	int p_enable;  // used to enable(1)/disable(0) controls based on if a player ship
 
 	int tristate_set(int val, int cur_state);
-	void show_hide_sexp_help();
+	void calc_help_height();
 	void calc_cue_height();
+	void show_hide_sexp_help();
+	void show_hide_cues();
 	int verify();
 	void OnInitMenu(CMenu *m);
 	void OnOK();

--- a/fred2/wing_editor.cpp
+++ b/fred2/wing_editor.cpp
@@ -1117,53 +1117,63 @@ void wing_editor::OnSelchangedDepartureTree(NMHDR* pNMHDR, LRESULT* pResult)
 	*pResult = 0;
 }
 
+void wing_editor::calc_help_height()
+{
+	CRect minihelp, help;
+
+	GetDlgItem(IDC_MINI_HELP_BOX)->GetWindowRect(minihelp);
+	GetDlgItem(IDC_HELP_BOX)->GetWindowRect(help);
+	help_height = (help.bottom - minihelp.top) + 10;
+}
+
 void wing_editor::calc_cue_height()
 {
 	CRect cue;
 
 	GetDlgItem(IDC_CUE_FRAME)->GetWindowRect(cue);
-	cue_height = cue.bottom - cue.top + 10;
-	if (Show_sexp_help)
-		cue_height += SEXP_HELP_BOX_SIZE;
-
-	if (Hide_wing_cues) {
-		((CButton *) GetDlgItem(IDC_HIDE_CUES)) -> SetCheck(1);
-		OnHideCues();
-	}
+	cue_height = (cue.bottom - cue.top) + 10;
 }
 
 void wing_editor::show_hide_sexp_help()
 {
 	CRect rect;
 
-	if (Show_sexp_help)
-		cue_height += SEXP_HELP_BOX_SIZE;
-	else
-		cue_height -= SEXP_HELP_BOX_SIZE;
-
 	if (((CButton *) GetDlgItem(IDC_HIDE_CUES)) -> GetCheck())
 		return;
 
 	GetWindowRect(rect);
+
 	if (Show_sexp_help)
-		rect.bottom += SEXP_HELP_BOX_SIZE;
+		rect.bottom += help_height;
 	else
-		rect.bottom -= SEXP_HELP_BOX_SIZE;
+		rect.bottom -= help_height;
 
 	MoveWindow(rect);
 }
 
-void wing_editor::OnHideCues() 
+void wing_editor::show_hide_cues()
+{
+	((CButton*)GetDlgItem(IDC_HIDE_CUES))->SetCheck(Hide_wing_cues ? TRUE : FALSE);
+	OnHideCues();
+}
+
+void wing_editor::OnHideCues()
 {
 	CRect rect;
 
 	GetWindowRect(rect);
+
 	if (((CButton *) GetDlgItem(IDC_HIDE_CUES)) -> GetCheck()) {
 		rect.bottom -= cue_height;
-		Hide_wing_cues = 1;
+		if (Show_sexp_help)
+			rect.bottom -= help_height;
 
+		Hide_wing_cues = 1;
 	} else {
 		rect.bottom += cue_height;
+		if (Show_sexp_help)
+			rect.bottom += help_height;
+
 		Hide_wing_cues = 0;
 	}
 

--- a/fred2/wing_editor.h
+++ b/fred2/wing_editor.h
@@ -18,6 +18,7 @@ class wing_editor : public CDialog
 {
 // Construction
 public:
+	int help_height;
 	int cue_height;
 	int bypass_errors;
 	int modified;
@@ -25,8 +26,10 @@ public:
 
 	void initialize_data_safe(int full_update);
 	void update_data_safe();
-	void show_hide_sexp_help();
+	void calc_help_height();
 	void calc_cue_height();
+	void show_hide_sexp_help();
+	void show_hide_cues();
 	int verify();
 	wing_editor(CWnd* pParent = NULL);   // standard constructor
 	BOOL Create();


### PR DESCRIPTION
1) Fixes the ship and wing dialog resizing for both sexp help and arrival/departure cues
2) Restores the sexp help in the Mission Goals dialog, which had been broken since the mini-help-box was added