### PR TITLE
Fix LUA Steering Control Override

### DIFF
--- a/code/playerman/playercontrol.cpp
+++ b/code/playerman/playercontrol.cpp
@@ -916,31 +916,45 @@ void read_keyboard_controls( control_info * ci, float frame_time, physics_info *
 	}
 }
 
-void copy_control_info(control_info *dest_ci, control_info *src_ci)
+void copy_control_info(control_info *dest_ci, control_info *src_ci, int control_copy_method)
 {
-	if (dest_ci == NULL)
+	if (dest_ci == nullptr)
 		return;
 
-	if (src_ci == NULL) {
-		dest_ci->pitch = 0.0f;
-		dest_ci->vertical = 0.0f;
-		dest_ci->heading = 0.0f;
-		dest_ci->sideways = 0.0f;
-		dest_ci->bank = 0.0f;
-		dest_ci->forward = 0.0f;
-		dest_ci->forward_cruise_percent = 0.0f;
-		dest_ci->fire_countermeasure_count = 0;
-		dest_ci->fire_secondary_count = 0;
-		dest_ci->fire_primary_count = 0;
-	} else {
-		dest_ci->pitch = src_ci->pitch;
-		dest_ci->vertical = src_ci->vertical;
-		dest_ci->heading = src_ci->heading;
-		dest_ci->sideways = src_ci->sideways;
-		dest_ci->bank = src_ci->bank;
-		dest_ci->forward = src_ci->forward;
-		dest_ci->forward_cruise_percent = src_ci->forward_cruise_percent;
+	// check which type of controls are being copied --wookieejedi
+	if (control_copy_method & LGC_STEERING) {
+		if (src_ci == nullptr) {
+			dest_ci->pitch = 0.0f;
+			dest_ci->heading = 0.0f;
+			dest_ci->bank = 0.0f;
+		} else {
+			dest_ci->pitch = src_ci->pitch;
+			dest_ci->heading = src_ci->heading;
+			dest_ci->bank = src_ci->bank;
+		}
+	} else if (control_copy_method & LGC_FULL) {
+		if (src_ci == nullptr) {
+			dest_ci->pitch = 0.0f;
+			dest_ci->vertical = 0.0f;
+			dest_ci->heading = 0.0f;
+			dest_ci->sideways = 0.0f;
+			dest_ci->bank = 0.0f;
+			dest_ci->forward = 0.0f;
+			dest_ci->forward_cruise_percent = 0.0f;
+			dest_ci->fire_countermeasure_count = 0;
+			dest_ci->fire_secondary_count = 0;
+			dest_ci->fire_primary_count = 0;
+		} else {
+			dest_ci->pitch = src_ci->pitch;
+			dest_ci->vertical = src_ci->vertical;
+			dest_ci->heading = src_ci->heading;
+			dest_ci->sideways = src_ci->sideways;
+			dest_ci->bank = src_ci->bank;
+			dest_ci->forward = src_ci->forward;
+			dest_ci->forward_cruise_percent = src_ci->forward_cruise_percent;
+		}	
 	}
+
 }
 
 void read_player_controls(object *objp, float frametime)
@@ -970,15 +984,10 @@ void read_player_controls(object *objp, float frametime)
 					Player->ci.control_flags |= CIF_INSTANTANEOUS_ACCELERATION;
 			}
 
-			if ( lua_game_control & LGC_STEERING ) {
-				// make sure to copy the control before reseting it
-				Player->lua_ci = Player->ci;
-				copy_control_info(&(Player->ci), NULL);
-			} else if ( lua_game_control & LGC_FULL ) {
-				control_info temp;
+			if ((lua_game_control & LGC_STEERING) || (lua_game_control & LGC_FULL)) {
 				// first copy over the new values, then reset
-				temp = Player->ci;
-				copy_control_info(&(Player->ci), &(Player->lua_ci));
+				control_info temp = Player->ci;
+				copy_control_info(&(Player->ci), &(Player->lua_ci), lua_game_control);
 				Player->lua_ci = temp;
 			} else {
 				// just copy the ci should that be needed in scripting

--- a/code/playerman/playercontrol.cpp
+++ b/code/playerman/playercontrol.cpp
@@ -922,17 +922,7 @@ void copy_control_info(control_info *dest_ci, control_info *src_ci, int control_
 		return;
 
 	// check which type of controls are being copied --wookieejedi
-	if (control_copy_method & LGC_STEERING) {
-		if (src_ci == nullptr) {
-			dest_ci->pitch = 0.0f;
-			dest_ci->heading = 0.0f;
-			dest_ci->bank = 0.0f;
-		} else {
-			dest_ci->pitch = src_ci->pitch;
-			dest_ci->heading = src_ci->heading;
-			dest_ci->bank = src_ci->bank;
-		}
-	} else if (control_copy_method & LGC_FULL) {
+	if (control_copy_method & LGC_FULL) {
 		if (src_ci == nullptr) {
 			dest_ci->pitch = 0.0f;
 			dest_ci->vertical = 0.0f;
@@ -952,7 +942,17 @@ void copy_control_info(control_info *dest_ci, control_info *src_ci, int control_
 			dest_ci->bank = src_ci->bank;
 			dest_ci->forward = src_ci->forward;
 			dest_ci->forward_cruise_percent = src_ci->forward_cruise_percent;
-		}	
+		}
+	} else if (control_copy_method & LGC_STEERING) {
+		if (src_ci == nullptr) {
+			dest_ci->pitch = 0.0f;
+			dest_ci->heading = 0.0f;
+			dest_ci->bank = 0.0f;
+		} else {
+			dest_ci->pitch = src_ci->pitch;
+			dest_ci->heading = src_ci->heading;
+			dest_ci->bank = src_ci->bank;
+		}
 	}
 
 }


### PR DESCRIPTION
I've been using `LUA_FULL_CONTROLS` in the updated mouse-as-a-joystick script, and it works well, but there's one last small bug that just was found that I'd like to fix. `LUA_FULL_CONTROLS` affects things that beyond just steering values, which has the unfortunate side-effect of also overriding non-steering controls such as cruise percent. It would be less intrusive to use the `LUA_STEERING_CONTROLS`. Unfortunately, `LUA_STEERING_CONTROLS` just sets everything to 0, which I think is a code issue bug that has been around since the LUA controls were added in 2010 here:
(https://github.com/scp-fs2open/fs2open.github.com/commit/2a69aaa23ba0def3dbfb9f566706e7130a33866f).

This PR fixes usage of `LUA_STEERING_CONTROLS`, and in testing everything works as expected (including fixing the cruise percent issue). Also, I do not think there are any scripts that use `LUA_STEERING_CONTROLS`, but if desired I can make a new version called `LUA_STEERING_CONTROLS_FIXED` or something to that effect.