### PR TITLE
remove Object.parent_type

### DIFF
--- a/code/object/objcollide.cpp
+++ b/code/object/objcollide.cpp
@@ -569,7 +569,6 @@ void obj_add_collider(int obj_index)
 	CheckObjects[obj_index].signature = objp->signature;
     CheckObjects[obj_index].flags = objp->flags - Object::Object_Flags::Not_in_coll;
 	CheckObjects[obj_index].parent_sig = objp->parent_sig;
-	CheckObjects[obj_index].parent_type = objp->parent_type;
 #endif
 
 	if(!(objp->flags[Object::Object_Flags::Not_in_coll])){

--- a/code/object/object.cpp
+++ b/code/object/object.cpp
@@ -111,7 +111,7 @@ obj_flag_name Object_flag_names[] = {
 
 #ifdef OBJECT_CHECK
 checkobject::checkobject() 
-    : type(0), signature(0), parent_sig(0), parent_type(0) 
+    : type(0), signature(0), parent_sig(0) 
 {
     flags.reset();
 }
@@ -138,7 +138,7 @@ void object::clear()
 {
 	signature = num_pairs = collision_group_id = 0;
 	parent = parent_sig = instance = -1;
-	type = parent_type = OBJ_NONE;
+	type = OBJ_NONE;
     flags.reset();
 	pos = last_pos = vmd_zero_vector;
 	orient = last_orient = vmd_identity_matrix;
@@ -505,10 +505,8 @@ int obj_create(ubyte type,int parent_obj,int instance, matrix * orient,
 	obj->parent					= parent_obj;
 	if (obj->parent != -1)	{
 		obj->parent_sig		= Objects[parent_obj].signature;
-		obj->parent_type		= Objects[parent_obj].type;
 	} else {
 		obj->parent_sig = obj->signature;
-		obj->parent_type = obj->type;
 	}
 
 	obj->flags 					= flags;
@@ -1008,10 +1006,6 @@ void obj_check_object( object *obj )
 	}
 	if ( CheckObjects[objnum].parent_sig != obj->parent_sig ) {
 		mprintf(( "Object parent sig changed!\n" ));
-		Int3();
-	}
-	if ( CheckObjects[objnum].parent_type != obj->parent_type ) {
-		mprintf(( "Object's parent type changed!\n" ));
 		Int3();
 	}
 }

--- a/code/object/object.h
+++ b/code/object/object.h
@@ -123,7 +123,6 @@ public:
 	char			type;				// what type of object this is... robot, weapon, hostage, powerup, fireball
 	int				parent;			// This object's parent.
 	int				parent_sig;		// This object's parent's signature
-	char			parent_type;	// This object's parent's type
 	int				instance;		// which instance.  ie.. if type is Robot, then this indexes into the Robots array
 	flagset<Object::Object_Flags> flags;			// misc flags.  Call obj_set_flags to change this.
 	vec3d			pos;				// absolute x,y,z coordinate of center of object
@@ -181,7 +180,6 @@ public:
 	int	signature;
 	flagset<Object::Object_Flags>	flags;
 	int	parent_sig;
-	int	parent_type;
 
     checkobject();
 };

--- a/code/scripting/api/objs/object.cpp
+++ b/code/scripting/api/objs/object.cpp
@@ -84,13 +84,11 @@ ADE_VIRTVAR(Parent, l_Object, "object", "Parent of the object. Value may also be
 		{
 			objh->objp->parent = OBJ_INDEX(newparenth->objp);
 			objh->objp->parent_sig = newparenth->sig;
-			objh->objp->parent_type = newparenth->objp->type;
 		}
 		else
 		{
 			objh->objp->parent = -1;
 			objh->objp->parent_sig = 0;
-			objh->objp->parent_type = OBJ_NONE;
 		}
 	}
 

--- a/code/ship/shiphit.cpp
+++ b/code/ship/shiphit.cpp
@@ -1928,11 +1928,10 @@ void ship_hit_kill(object *ship_objp, object *other_obj, vec3d *hitpos, float pe
 		}
 
 		// maybe praise the player for this kill
-		if ( (killer_damage_percent > 10) && (other_obj != NULL) ) {
+		if ( (killer_damage_percent > 10) && (other_obj != nullptr) && (other_obj->parent >= 0) ) {
 			if (other_obj->parent_sig == Player_obj->signature) {
 				ship_maybe_praise_player(sp);
-			}
-			else if ((other_obj->parent_type == OBJ_SHIP) || (other_obj->parent_type == OBJ_START))  {
+			} else if (Objects[other_obj->parent].type == OBJ_SHIP) {
 				ship_maybe_praise_self(sp, &Ships[Objects[other_obj->parent].instance]);
 			}
 		}

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -6455,7 +6455,7 @@ void spawn_child_weapons(object *objp, int spawn_index_override)
 	parent_num = objp->parent;
 
 	if (parent_num >= 0) {
-		if ((Objects[parent_num].type != objp->parent_type) || (Objects[parent_num].signature != objp->parent_sig)) {
+		if (Objects[parent_num].signature != objp->parent_sig) {
 			mprintf(("Warning: Parent of spawn weapon does not exist.  Not spawning.\n"));
 			return;
 		}

--- a/fred2/freddoc.cpp
+++ b/fred2/freddoc.cpp
@@ -725,7 +725,6 @@ SerializeInt(fp, mode, objp->signature);
 SerializeInt(fp, mode, objp->type);
 SerializeInt(fp, mode, objp->parent);
 SerializeInt(fp, mode, objp->parent_sig);
-SerializeInt(fp, mode, objp->parent_type);
 SerializeInt(fp, mode, objp->instance);
 SerializeInt(fp, mode, objp->flags);
 SerializeInt(fp, mode, objp->flags2);	// Goober5000 - code is obsolete, but I added this just in case


### PR DESCRIPTION
It's theoretically possible for `parent_type` to get out of sync with the parent's type, particularly if the parent is destroyed.  Since the field is almost never used, it can be removed.

Should fix #4105.