### PR TITLE
add a class encapsulation for Volition's linked list

### DIFF
--- a/code/globalincs/linklist.h
+++ b/code/globalincs/linklist.h
@@ -7,7 +7,7 @@
  *
 */ 
 
-
+#include <utility>	// for std::move
 
 #ifndef _LINKLIST_H
 #define _LINKLIST_H
@@ -82,5 +82,88 @@ do {												\
 #define END_OF_LIST(head)	(head)
 #define NOT_EMPTY(head)		((head)->next != (head))
 #define EMPTY(head)			((head) == nullptr || (head)->next == (head))
+
+template <class T>
+class volition_linked_list
+{
+	T* head;
+
+public:
+	class iterator
+	{
+		T* ptr;
+
+	public:
+		iterator(T* x)
+			: ptr(x)
+		{}
+
+		iterator(const iterator& it)
+			: ptr(it.ptr)
+		{}
+
+		iterator& operator++()
+		{
+			ptr = GET_NEXT(ptr);
+			return *this;
+		}
+
+		iterator operator++(int)
+		{
+			iterator tmp(*this);
+			operator++();
+			return tmp;
+		}
+
+		iterator& operator--()
+		{
+			ptr = GET_PREV(ptr);
+			return *this;
+		}
+
+		iterator operator--(int)
+		{
+			iterator tmp(*this);
+			operator--();
+			return tmp;
+		}
+
+		bool operator==(const iterator& rhs) const
+		{
+			return ptr == rhs.ptr;
+
+		}
+
+		bool operator!=(const iterator& rhs) const
+		{
+			return ptr != rhs.ptr;
+		}
+
+		T&& operator*()
+		{
+			return std::move(*ptr);
+		}
+	};
+
+	iterator begin() const
+	{
+		return iterator(GET_FIRST(head));
+	}
+
+	iterator end() const
+	{
+		return iterator(END_OF_LIST(head));
+	}
+
+	volition_linked_list(T* ptr)
+		: head(ptr)
+	{}
+};
+
+template <class T>
+volition_linked_list<T> list_range(T* head)
+{
+	return volition_linked_list<T>(head);
+}
 
 #endif

--- a/code/globalincs/linklist.h
+++ b/code/globalincs/linklist.h
@@ -83,6 +83,7 @@ do {												\
 #define NOT_EMPTY(head)		((head)->next != (head))
 #define EMPTY(head)			((head) == nullptr || (head)->next == (head))
 
+// Note that since these iterators operate on pointer collections, the dereference of an iterator using operator* returns a pointer.
 template <class T>
 class volition_linked_list
 {
@@ -139,9 +140,14 @@ public:
 			return ptr != rhs.ptr;
 		}
 
-		T& operator*()
+		T*& operator*()
 		{
-			return *ptr;
+			return ptr;
+		}
+
+		T* operator->()
+		{
+			return ptr;
 		}
 	};
 
@@ -195,9 +201,14 @@ public:
 			return ptr != rhs.ptr;
 		}
 
-		const T& operator*()
+		const T*& operator*()
 		{
-			return *ptr;
+			return ptr;
+		}
+
+		const T* operator->()
+		{
+			return ptr;
 		}
 	};
 

--- a/code/globalincs/linklist.h
+++ b/code/globalincs/linklist.h
@@ -139,9 +139,65 @@ public:
 			return ptr != rhs.ptr;
 		}
 
-		T&& operator*()
+		T& operator*()
 		{
-			return std::move(*ptr);
+			return *ptr;
+		}
+	};
+
+	class const_iterator
+	{
+		const T* ptr;
+
+	public:
+		const_iterator(const T* x)
+			: ptr(x)
+		{}
+
+		const_iterator(const const_iterator& it)
+			: ptr(it.ptr)
+		{}
+
+		const_iterator& operator++()
+		{
+			ptr = GET_NEXT(ptr);
+			return *this;
+		}
+
+		const_iterator operator++(int)
+		{
+			const_iterator tmp(*this);
+			operator++();
+			return tmp;
+		}
+
+		const_iterator& operator--()
+		{
+			ptr = GET_PREV(ptr);
+			return *this;
+		}
+
+		const_iterator operator--(int)
+		{
+			const_iterator tmp(*this);
+			operator--();
+			return tmp;
+		}
+
+		bool operator==(const const_iterator& rhs) const
+		{
+			return ptr == rhs.ptr;
+
+		}
+
+		bool operator!=(const const_iterator& rhs) const
+		{
+			return ptr != rhs.ptr;
+		}
+
+		const T& operator*()
+		{
+			return *ptr;
 		}
 	};
 
@@ -153,6 +209,16 @@ public:
 	iterator end() const
 	{
 		return iterator(END_OF_LIST(head));
+	}
+
+	const_iterator cbegin() const
+	{
+		return const_iterator(GET_FIRST(head));
+	}
+
+	const_iterator cend() const
+	{
+		return const_iterator(END_OF_LIST(head));
 	}
 
 	volition_linked_list(T* ptr)


### PR DESCRIPTION
This should allow collections which use the Volition linked list (for example `obj_used_list`) to be iterated using range-based `for` loops.