### PR TITLE
make HUD target distance consistent

### DIFF
--- a/code/hud/hud.cpp
+++ b/code/hud/hud.cpp
@@ -1377,7 +1377,6 @@ void hud_maybe_popup_weapons_gauge()
 void hud_update_frame(float  /*frametime*/)
 {
 	object	*targetp;
-	vec3d target_pos;
 	int		can_target;
 
 	update_throttle_sound();
@@ -1463,8 +1462,6 @@ void hud_update_frame(float  /*frametime*/)
 		hud_update_closest_turret();
 	}
 
-	hud_target_change_check();
-
 	// check to see if we are in messaging mode.  If so, send the key to the code
 	// to deal with the message.  hud_sqaudmsg_do_frame will return 0 if the key
 	// wasn't used in messaging mode, otherwise 1.  In the event the key was used,
@@ -1474,15 +1471,14 @@ void hud_update_frame(float  /*frametime*/)
 	}
 
 	if (Player_ai->target_objnum == -1) {
-		if (Target_static_looping.isValid()) {
-			snd_stop(Target_static_looping);
-		}
+		hud_target_change_check();
 		return;
 	}
 
 	targetp = &Objects[Player_ai->target_objnum];
 
 	if ( Player_ai->targeted_subsys != NULL ) {
+		vec3d target_pos;
 		get_subsystem_world_pos(targetp, Player_ai->targeted_subsys, &target_pos);
 
 		// get new distance of current target
@@ -1509,10 +1505,11 @@ void hud_update_frame(float  /*frametime*/)
 			}
 		}
 	} else {
-		target_pos = targetp->pos;
-
 		Player_ai->current_target_distance = hud_find_target_distance(targetp,Player_obj);
 	}
+
+	// moved past the if() block so that the target tracker has the current frame's target distance
+	hud_target_change_check();
 
 	bool stop_targeting_this_thing = false;
 

--- a/code/hud/hudbrackets.cpp
+++ b/code/hud/hudbrackets.cpp
@@ -475,7 +475,7 @@ void HudGaugeBrackets::renderObjectBrackets(object *targetp, color *clr, int w_c
 			int target_objnum = -1;
 
 			if(flags & TARGET_DISPLAY_DIST) {
-				distance = hud_find_target_distance(targetp, Player_obj);
+				distance = Player_ai->current_target_distance;
 			}
 
 			if(flags & TARGET_DISPLAY_DOTS) {


### PR DESCRIPTION
Several careful tweaks to improve handling of distance as measured on the HUD.

1) Use `Player_ai->current_target_distance` for rendered HUD gauges which display the distance, because the distance is calculated in `hud_update_frame` (which is called from `game_simulation_frame`) and is used for a couple of these gauges already.  This change makes it all consistent.
1b) Some gauges which depend on distance but do not actually display it (e.g. the lead indicator) still calculate their distance immediately before using it.  I didn't change these because a) the calculation is still correct, even if redundant, and b) there is a small possibility of `hud_update_frame` changing the target after the distance is calculated, so these gauges are guaranteed to have the correct calculation.

2) On discovering that the `evaluate_ship_as_closest_target` specifically switched from bbox-distance to center-distance, I changed all "target closest X" functions to consistently evaluate center-distance.  I believe Volition did this to prioritize small fighters when dogfighting next to large ships.

3) Moved `hud_target_change_check` below the computation of `Player_ai->current_target_distance` because it uses the computed distance to determine the acceleration trend.  This way it will use the distance of the current frame, not the previous one.

4) Minor move of a `Target_static_looping` check into `hud_target_change_check` because it made sense.


Addresses #4120.