### PR TITLE
Make sure that zero-length strings still get the proper height;  fixes missing whitespace in the credits

### DIFF
--- a/code/graphics/software/VFNTFont.cpp
+++ b/code/graphics/software/VFNTFont.cpp
@@ -41,7 +41,7 @@ namespace font
 		int w, h;
 
 		w = 0;
-		h = 0;
+		h = text == nullptr ? 0 : fl2i(this->getHeight());
 		longest_width = 0;
 
 		// Maintain old behavior where textLen was an int
@@ -49,8 +49,8 @@ namespace font
 
 		bool checkLength = textLen >= 0;
 
-		if (text != nullptr && textLen != 0) {
-			h += fl2i(this->getHeight());
+		if (text != nullptr && textLen != 0)
+		{
 			while (*text)
 			{
 				// Process one or more 

--- a/code/graphics/software/font.cpp
+++ b/code/graphics/software/font.cpp
@@ -688,8 +688,7 @@ void gr_get_string_size(int *w1, int *h1, const char *text, int len)
 	float w = 0.0f;
 	float h = 0.0f;
 
-	if (len != 0)
-		FontManager::getCurrentFont()->getStringSize(text, static_cast<size_t>(len), -1, &w, &h);
+	FontManager::getCurrentFont()->getStringSize(text, static_cast<size_t>(len), -1, &w, &h);
 
 	if (w1)
 	{


### PR DESCRIPTION
Make sure that zero-length strings still get the proper height.

Fixes #4122.  Follow-up to #4071.