### PR TITLE
Fix auto-trigger for post-release build workflow, Checkout passed release tag, Fix version string

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,8 @@
 
 cmake/ @asarium
 
+ci/ @asarium @z64555
+
 code/executor/ @asarium
 
 code/scpui/ @asarium

--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -34,23 +34,6 @@ jobs:
           release_name: Release ${{ github.ref }}
           draft: false
           prerelease: false
-      - name: Store upload URL
-        run: |
-          echo -n "${{ steps.create_release.outputs.upload_url }}" > upload_url
-      - name: Persist upload URL
-        uses: actions/upload-artifact@v2
-        # Upload the url file for use with other runners
-        # upload-artifact.inputs:
-        #   if-no-files-found=warn  What to do if path fails to find any files.
-        #       warn      Display a warning but do not fail the action
-        #       error     Display an error and fail the action
-        #       ignore    No display, No fail
-        #   retention-days=0    Days to keep the artifact.
-        #       0     Use default retention policy of the repo
-        #       1~90  Min 1, Max 90 days to keep the artifact unless changed by repo settings page
-        with:
-          name: upload_url  # name of artifact
-          path: ${{ github.workspace }}/upload_url  # source location of artifact to upload
 
   build_linux:
     strategy:
@@ -134,6 +117,15 @@ jobs:
         run: $GITHUB_WORKSPACE/ci/linux/generate_appimage.sh $GITHUB_WORKSPACE/build/install
       - name: Upload build result
         uses: actions/upload-artifact@v2
+        # Upload the url file for use with other runners
+        # upload-artifact.inputs:
+        #   if-no-files-found=warn  What to do if path fails to find any files.
+        #       warn      Display a warning but do not fail the action
+        #       error     Display an error and fail the action
+        #       ignore    No display, No fail
+        #   retention-days=0    Days to keep the artifact.
+        #       0     Use default retention policy of the repo
+        #       1~90  Min 1, Max 90 days to keep the artifact unless changed by repo settings page
         with:
           name: linux-${{ matrix.configuration }}
           path: ${{ github.workspace }}/build/install/*.AppImage
@@ -148,21 +140,6 @@ jobs:
         with:
           submodules: true
           fetch-depth: '0'  # value 0 to fetch all history and tags for all branches
-      - name: Download upload URL
-        uses: actions/download-artifact@v1
-        # Downloads and extracts uploaded artifact by name
-        # github_token  default ${{secrets.GITHUB_TOKEN}}
-        # name      name of artifact to download
-        # latest    Download latest artifact (default true)
-        # path      Where to save the artifact, (default extract_here)
-        # repo      Source repo of artifact (default ${{github.repository}})
-        with:
-          name: upload_url
-          path: .
-      - name: Extract upload URL
-        # Extract the URL from file and stuff it into a shell variable
-        id: extractUploadUrl
-        run: echo "::set-output name=upload_url::$(cat upload_url)"
       - name: Download Release builds
         # Grab the release builds
         uses: actions/download-artifact@v2
@@ -290,16 +267,6 @@ jobs:
         with:
           submodules: true
           fetch-depth: '0'
-
-      - name: Download upload URL
-        uses: actions/download-artifact@v1
-        with:
-          name: upload_url
-          path: .
-
-      - name: Extract upload URL
-        id: extractUploadUrl
-        run: echo "::set-output name=upload_url::$(cat upload_url)"
 
       - name: Download Release builds
         uses: actions/download-artifact@v2

--- a/.github/workflows/post-build-release.yaml
+++ b/.github/workflows/post-build-release.yaml
@@ -6,10 +6,10 @@ on:
     inputs:
       linux_result:   # job.result; either success, failure, canceled or skipped
         required: true
-        type: boolean
+        type: string
       windows_result: # job.result
         required: true
-        type: boolean
+        type: string
       releaseTag:
         required: true
         type: string

--- a/.github/workflows/post-build-release.yaml
+++ b/.github/workflows/post-build-release.yaml
@@ -41,6 +41,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: '0'
+          ref: RELEASE_TAG
 
       - name: Install Python dependencies
         run: pip install -r ci/post/requirements.txt

--- a/ci/post/changelog.py
+++ b/ci/post/changelog.py
@@ -1,0 +1,156 @@
+# Retrives a log of commit messages and attempts to pretty them into a human-readbile format
+
+import datetime
+import os
+import re
+import requests
+import sys
+
+from datetime import datetime
+from subprocess import check_output
+
+MAX_PAGES = 100  # maximum number of PR pages to go through
+warnings = 0
+
+def get_last_page(response: requests.Response) -> int:
+    """
+    @brief Extract the last page number from the response header
+
+    @param[in] response The response from a GET call
+
+    @returns The page number of the last page, or MAX_PAGES
+    """
+
+    # The link header is a heckn dictionary in string form, and for that matter the
+    # value is in front of the key.  It is of the form '<<url1>>; rel=<key1>, <url2>, <key2>'
+    link = response.headers['link']
+    link = link.split(',')
+    for x in link:
+        y = x.split(';')        # <url>; rel=<key>
+        if "last" not in y[1]:  # look for rel='last'
+            continue
+        # search in the url for `page=`` and grab the int immediately after
+        # the int may be delimited by '&' or '>'
+        str = y[0][y[0].find('page=') : ]   # slice everything out before 'page='
+        str = str.split('&', 1)[0]          # slice out any possible queries after page=<int>
+        last_page = int( re.sub('\D', "", str) )    # strip out just the page number, as integer
+        if last_page > MAX_PAGES:
+            return MAX_PAGES
+        else:
+            return last_page
+    
+
+def main():
+    os.chdir(os.path.dirname(__file__))	# Change working directory to this file's directory
+    
+    start_date = datetime.strptime(sys.argv[1], "%Y-%m-%d")
+
+    print("start_date: {}".format(start_date))
+
+    # Retrive the git log for master, since start date, order by date, in ascending order, use YYYY-MM-DD date format,
+    #   each line is of the form "<author short date> | <message>", only grab commits from master,
+    #   output to `fsofordigest.txt`,
+    
+    # check_output(("git log master", "--after=2021-09-15", "--date-order", "--reverse", "--date=short",
+    # "--pretty=\"%as | %s\"",  "--first-parent",
+    # "--output fsofordigest.txt"), text=True)
+
+    # The commit messages are either of the form "<body> (#<PR_number>)" or "Merge pull request #<PR_number> from <source_repo>"
+    # For our purposes, we want them be all of the form "<body> (#<PR_number>)"
+    # Typically, the second form does not have a usable body, so we'll have to pull the PR title from github
+
+    # Github's REST API allows us to retrieve PR's, but due to it being HTTP requests it has to page in the data.
+    # We can loop over the GET request and check for a merge date.
+    # The GET request doesn't have sorting by merge date, but does have sorting by the last time it was updated... which is usually
+    # also the merge date but not always.
+
+    # Key attributes within the PR JSON objects:
+    #   "merged_at: <date>"
+    #   "merged: <bool>"
+    #   "html_url: <string>"
+    #   "number: <int>"     # The PR id number
+    #   "title: <string>"   # Title of the PR
+    #   "body: <string>"    # The body paragraph detailing the PR
+    #   "labels: [label_object]"    # All labels attached to this PR
+
+    changelog = {}
+    url = "https://api.github.com/repos/scp-fs2open/fs2open.github.com/pulls"
+    page = 1
+    last_page = MAX_PAGES
+    while (page != (last_page + 1)):
+        # GET <url>?base=master&sort=updated&direction=desc&state=closed&page=1
+        response = requests.get(url, params={
+            "base": "master",
+            "direction": "desc",
+            "page": page,
+            "state": "closed",
+            "sort": "updated"
+        })
+
+        # Check if good response
+        if (response.status_code != 200) :
+            print("Error: ", response.status_code)
+            print(response.json()['message'])
+            sys.exit(1)
+        else:
+            print("Request successful: 200")
+            print("page={}".format(page))
+
+        # Update the last_page index at first iteration and possibly last iteration
+        # This should cover the edge case of a new PR being added to the database before this script is finished
+        if (page == 1) or (page == last_page):
+            last_page = get_last_page(response)
+            print("last_page={}".format(last_page))
+
+        # assume pulls are organized from newest to oldest
+        for pull in response.json():
+            if (pull['state'] != 'closed'):
+                # This pull is not merged, so ignore
+                print("Found irrelevant pull, skipping...")
+                print("state: {}; number: {}".format(pull['state'], pull['number']))
+                continue
+            
+            if (pull['merged_at'] == None):
+                # This pull wasn't merged, skip
+                print("Found closed pull #{} ({}), skipping...".format(pull['number'], pull['closed_at']))
+                continue
+
+            merge_date = datetime.strptime(pull['merged_at'], "%Y-%m-%dT%H:%M:%SZ")
+            updated_date = datetime.strptime(pull['updated_at'], "%Y-%m-%dT%H:%M:%SZ")            
+            if (merge_date < start_date) and (updated_date >= start_date):
+                # This pull is too old, but was updated within our timeframe. skip
+                print("Found old pull #{} ({}), skipping...".format(pull['number'], pull['merged_at']))
+                continue
+
+            if (updated_date < start_date):
+                # This pull is too old
+                print("Found old pull #{} ({}), stopping loop...".format(pull['number'], pull['updated_at']))
+                page = last_page + 1
+                break
+
+            # Add the pull to the changelog, indexed by its pull.number
+            if pull['number'] not in changelog:
+                # only add if the key isn't there already
+                changelog[pull['number']] = {
+                    "title":    pull['title'],
+                    "labels":   pull['labels'],
+                    "url":      pull['html_url']
+                }
+                print("Added pull #{} ({})".format(pull['number'], merge_date))
+            # Else, silently ignore duplicate (for now...)
+
+        page += 1
+
+
+    # Write the changelog to file
+    print("Writing to change.log...")
+    str = ''
+    for key, value in changelog.items():
+        str += "{} ({})\n".format(value['title'], key)
+    
+    with open("change.log", "w") as file:
+        file.write(str)
+
+    print("Done!")
+
+main()

--- a/ci/post/changelog.py
+++ b/ci/post/changelog.py
@@ -77,7 +77,7 @@ def main():
     url = "https://api.github.com/repos/scp-fs2open/fs2open.github.com/pulls"
     page = 1
     last_page = MAX_PAGES
-    while (page != (last_page + 1)):
+    while (page <= last_page):
         # GET <url>?base=master&sort=updated&direction=desc&state=closed&page=1
         response = requests.get(url, params={
             "base": "master",

--- a/ci/post/changelog.py
+++ b/ci/post/changelog.py
@@ -132,6 +132,7 @@ def main():
             if pull['number'] not in changelog:
                 # only add if the key isn't there already
                 changelog[pull['number']] = {
+                    "date":     merge_date,
                     "title":    pull['title'],
                     "labels":   pull['labels'],
                     "url":      pull['html_url']
@@ -143,10 +144,11 @@ def main():
 
 
     # Write the changelog to file
+    # 2021-09-28 | (#3661) Fix homing child weapons in niche circumstances 
     print("Writing to change.log...")
     str = ''
     for key, value in changelog.items():
-        str += "{} ({})\n".format(value['title'], key)
+        str += "{} | (#{}) {} \n".format(value['date'].strftime("%Y-%m-%d"), key, value['title'])
     
     with open("change.log", "w") as file:
         file.write(str)

--- a/ci/post/forum.py
+++ b/ci/post/forum.py
@@ -27,8 +27,6 @@ class ForumAPI:
         @param[in] board    Which board/forum to post to
         """
 
-        print(self.config["hlp"]["api"])
-        print(self.config["hlp"]["key"])
         if (self.config["hlp"]["api"] == "") or (self.config["hlp"]["key"] == ""):
             print("Post failed! No API or API_KEY given!")
             return

--- a/ci/post/forum.py
+++ b/ci/post/forum.py
@@ -25,6 +25,8 @@ class ForumAPI:
         @param[in] title    Title of the post
         @param[in] content  Body of the post
         @param[in] board    Which board/forum to post to
+
+        @returns { "thread_url": <url_of_created_thread> }
         """
 
         if (self.config["hlp"]["api"] == "") or (self.config["hlp"]["key"] == ""):
@@ -40,6 +42,8 @@ class ForumAPI:
 
         if resp.text != "OK":
             print("Post failed! Response: %s" %resp.text)
+        
+        return resp.json()
 
     def post_nightly(self, date, revision, files, log, success):
         """!
@@ -75,6 +79,8 @@ class ForumAPI:
         @param[in] version      The build's version
         @param[in] groups       dict[Any, file_list.FileGroup]; FileGroups of SSE2, AVX, etc.
         @param[in] sources      URL's of builds on github or fs2net
+
+        @returns If Successful, the URL of the created post
         """
 
         print("Posting release thread...")
@@ -93,4 +99,5 @@ class ForumAPI:
 
         print("Creating post...")
 
-        self.create_post(title, rendered, self.config["release"]["hlp_board"])
+        json = self.create_post(title, rendered, self.config["release"]["hlp_board"])
+        return json["thread_url"]

--- a/ci/post/forum.py
+++ b/ci/post/forum.py
@@ -8,10 +8,25 @@ from file_list import ReleaseFile
 
 
 class ForumAPI:
+    POST_SIZE_MAX = 50000
+    """!
+    Maximum number of characters allowed in a post, including BBCode (03/17/2022)
+
+    Check with HLP admins occasionally to verify this limit, they can set it in the forum's admin panel
+    """
+
     def __init__(self, config):
         self.config = config
 
     def create_post(self, title, content, board):
+        """!
+        @brief Create a post on the forums
+
+        @param[in] title    Title of the post
+        @param[in] content  Body of the post
+        @param[in] board    Which board/forum to post to
+        """
+
         print(self.config["hlp"]["api"])
         print(self.config["hlp"]["key"])
         if (self.config["hlp"]["api"] == "") or (self.config["hlp"]["key"] == ""):
@@ -29,6 +44,15 @@ class ForumAPI:
             print("Post failed! Response: %s" %resp.text)
 
     def post_nightly(self, date, revision, files, log, success):
+        """!
+        @brief Post a new Nightly topic on the forums using nightly.mako
+
+        @param[in] date         The date to use
+        @param[in] version      The build's version
+        @param[in] groups       dict[Any, file_list.FileGroup]; FileGroups of SSE2, AVX, etc.
+        @param[in] sources      URL's of builds on github or fs2net
+        """
+
         print("Posting nightly thread...")
 
         title = "Nightly: {} - Revision {}".format(date, revision)
@@ -46,6 +70,15 @@ class ForumAPI:
         self.create_post(title, rendered, self.config["nightly"]["hlp_board"])
 
     def post_release(self, date, version: semantic_version.Version, groups, sources):
+        """!
+        @brief Post a new Release topic on the forums using release.mako.
+
+        @param[in] date         The date to use
+        @param[in] version      The build's version
+        @param[in] groups       dict[Any, file_list.FileGroup]; FileGroups of SSE2, AVX, etc.
+        @param[in] sources      URL's of builds on github or fs2net
+        """
+
         print("Posting release thread...")
 
         title = "Release: {}".format(version)

--- a/ci/post/github.py
+++ b/ci/post/github.py
@@ -1,0 +1,85 @@
+# Class for use with interfacing with github via HTTP requests
+
+import requests
+
+from util import retry_multi, GLOBAL_TIMEOUT
+
+class GithubAPI:
+    headers = {
+        "Accept": "application/vnd.github.v3+json"
+    }
+    url_root = "https://api.github.com"
+
+    def __init__(self, config):
+        self.config = config
+
+    @retry_multi(5)
+    def get(self, path):
+        """!
+        @brief Performs a GET request with the given path. To be used with Github's REST API.
+        @returns If successful, returns a .JSON object
+        """
+        url = self.url_root + path
+
+        # GET https://api.github.com/<path> Accept: "application/vnd.github.v3+json"
+
+        response = requests.get(url, headers=self.headers, timeout=GLOBAL_TIMEOUT)
+
+        response.raise_for_status() # Raise a RequestException if we failed, and trigger retry
+
+        return response.json()
+    
+    def get_release(self, tag_name):
+        """!
+        @brief Retrieves the Github Release metadata as a JSON object
+        @see https://docs.github.com/en/rest/reference/releases#get-a-release-by-tag-name
+        """
+        return self.get("/repos/{}/releases/tags/{}".format(self.config["github"]["repo"], tag_name))
+
+
+    def patch(self, path, data):
+        """!
+        @brief Performs a PATCH request with the given path and body data (as dictionary)
+        @returns If successful, returns a .JSON object
+        """
+        url = self.url_root + path
+
+        response = requests.patch(url, headers=self.headers, timeout=GLOBAL_TIMEOUT, data=data)
+
+        response.raise_for_status()
+
+        return response.json()
+        
+    def update_release(self, release_id, tag_name="", name="", body="", draft=None, prerelease=None):
+        """!
+        @brief Updates a Github Release
+        @param[in] release_id   The id of the release, as obtained by get_release()
+        @param[in] tag_name     (optional) The git tag this release is associated with
+        @param[in] name         (optional) The name of the release
+        @param[in] body         (optional) Body text describing the release
+        @param[in] draft        (optional) If true, the release is marked as a "draft"
+        @param[in] prerelease   (optional) If true, the release is marked as a "prerelease"
+
+        @note If an optional argument is not provided, then its associated data is not changed
+        """
+        path = "/repos/{}/releases/{}".format(self.config["github"]["repo"], release_id)
+
+        # Add to the data JSON if options are specified
+        data = {}
+        if tag_name != "":
+            data["tag_name"] = tag_name
+        
+        if name != "":
+            data["name"] = name
+
+        if body != "":
+            data["body"] = body
+        
+        if draft != None:
+            data["draft"] = data
+
+        if prerelease != None:
+            data["prerelease"] = prerelease
+        
+        self.patch(path, data)
+

--- a/ci/post/main.py
+++ b/ci/post/main.py
@@ -22,7 +22,6 @@
 # LINUX_RESULT: bool, if the linux builds were sucessfully uploaded
 # WINDOWS_RESULT: bool, if the windows builds were successfully uploaded
 
-from curses import window
 import sys
 import os
 import re

--- a/ci/post/main.py
+++ b/ci/post/main.py
@@ -63,7 +63,7 @@ def _match_version_number(text, regex):
 	
 
 def get_source_version(date_version: datetime, tag_name: str) -> semantic_version.Version:
-	"""! Retrieves the build's version from `version.cmake`, forms it as a string, and appends the date
+	"""! Retrieves the build's version from the tag name, forms it as a string, and appends the date
 
 	@param[in] `date_version` Date this build is published for release
 	@param[in] `tag_name`     Tag of this release, used to determine if release, rc, or nightly
@@ -71,34 +71,35 @@ def get_source_version(date_version: datetime, tag_name: str) -> semantic_versio
 	@return If release: `MAJOR_VERSION.MINOR_VERSION.BUILD_VERSION` from version.cmake, or
 	@return If rc:      `MAJOR_VERSION.MINOR_VERSION.BUILD_VERSION` from tag_name, or
 	@return If nightly: `MAJOR_VERSION.MINOR_VERSION.BUILD_VERSION-date` from version.cmake
-	"""
-	major = minor = build = version = 0
-	with open(os.path.join("..", "..", "cmake", "version.cmake"), "r") as f:
-		filetext = f.read()
-		major = _match_version_number(filetext, MAJOR_VERSION_PATTERN)
-		minor = _match_version_number(filetext, MINOR_VERSION_PATTERN)
-		build = _match_version_number(filetext, BUILD_VERSION_PATTERN)
 
+	@note This is the version used to identify in Nebula and the forums.  version_override.cmake is used for the builds
+	  made by CI tools and version.cmake is used for builds made by devs.
+	"""
+
+	print("Parsing version from tag_name...")
 	if "rc" in tag_name.lower():
 		# Release candidates idenfity with their unstable version (ex: 21.5.0-03052022) within the game and the logs, but
 		# the builds are named with the target release version (ex: 22.0.0).  Since this script works on the builds we
 		# need to grab the target release version from tag_name
 		x = tag_name.upper().split("_")
-		# "release" = x[0], year = x[1], major = x[2], minor = x[3], build = x[4], 
+		# "release" = x[0], year = x[1], major = x[2], minor = x[3], candidate = x[4], 
 		version = semantic_version.Version("{}.{}.{}-{}".format(x[1], x[2], x[3], x[4]))
 
 	elif "release" in tag_name.lower():
-		version = semantic_version.Version("{}.{}.{}".format(major, minor, build))
+		x = tag_name.upper().split("_")
+		# "release" = x[0], year = x[1], major = x[2], minor = x[3], candidate = x[4], 
+		version = semantic_version.Version("{}.{}.{}".format(x[1], x[2], x[3]))
 
 	elif "nightly" in tag_name.lower():
-		version = semantic_version.Version("{}.{}.{}-{}".format(major, minor, build, date_version))
+		print("  ERROR: \'nightly\' post-build not implemented yet!")
+		sys.exit(1)
 	
 	else:	
-		print("ERROR: malformed tag_name %s" % tag_name)
+		print("  ERROR: malformed tag_name %s" % tag_name)
 		sys.exit(1)
 
-	print("version: {}".format(version))
-	print("version.prerelease: {}".format(version.prerelease))
+	print("  version: {}".format(version))
+	print("  version.prerelease: {}".format(version.prerelease))
 	return version
 
 


### PR DESCRIPTION
Auto triggers were failing because the `linux_result` and `windows_result` variables were expected by the .yaml to be bools but were in fact strings.  This fixes that assumption to be the correct type.

Changed checkout of current master HEAD to the passed release tag, thus allowing the script to be run on only the intended release data instead of accidentally including new merges after the release tag.

Fixes the Nebula and forum post version strings to correctly pull version string data from `version_override.cmake` and `version.cmake`, instead of trying to fudge it from the tag_name or incorrectly from the `version.cmake` alone.

Also Adds a `changelog.py` script to create a `change.log` file.  This grabs the titles of merged PR's since a given date passed as an argument of the form of `YYYY-MM-DD`.  This can be manually run but be aware there's a limit to the number of HTTP GET requests you can do from Github (This script doesn't authorize yet)

The `changelog.py` is still a WIP, but it can be manually run for now.  In the future it'll be used to auto-generate the change.log for the forum post and the `main.py` script will insert as much of the log into the post.  Since the forums have a character limit per post, a constant was added and the intended use is to truncate the changelog text once the limit is reached.

