### PR TITLE
Switched light shader attenuation math to something that looks more real

### DIFF
--- a/code/def_files/data/effects/deferred-f.sdr
+++ b/code/def_files/data/effects/deferred-f.sdr
@@ -98,7 +98,7 @@ void GetLightInfo(vec3 position, out vec3 lightDir, out float attenuation)
 				}
 			}
 		}
-		attenuation*=attenuation;
+		attenuation *= attenuation;
 		lightDir = normalize(lightDir);
 	}
 }

--- a/code/def_files/data/effects/deferred-f.sdr
+++ b/code/def_files/data/effects/deferred-f.sdr
@@ -56,7 +56,7 @@ void GetLightInfo(vec3 position, out vec3 lightDir, out float attenuation)
 		// Positional light source
 		lightDir = lightPosition - position.xyz;
 		float dist = length(lightDir);
-		attenuation = 1.0 - clamp(dist / lightRadius, 0.0, 1.0);
+		attenuation = 1.0 - clamp(sqrt(dist / lightRadius), 0.0, 1.0);
 
 		if(dist > lightRadius && lightType != LT_TUBE) {
 			discard;
@@ -81,7 +81,7 @@ void GetLightInfo(vec3 position, out vec3 lightDir, out float attenuation)
 			if(dist > lightRadius) {
 				discard;
 			}
-			attenuation = 1.0 - clamp(dist / lightRadius, 0.0, 1.0);
+			attenuation = 1.0 - clamp(sqrt(dist / lightRadius), 0.0, 1.0);
 		} else if (lightType == LT_CONE) {
 			float coneDot = dot(normalize(-lightDir), coneDir);
 			if(dualCone) {
@@ -98,7 +98,7 @@ void GetLightInfo(vec3 position, out vec3 lightDir, out float attenuation)
 				}
 			}
 		}
-
+		attenuation*=attenuation;
 		lightDir = normalize(lightDir);
 	}
 }


### PR DESCRIPTION
This is a change I've been playing with on my personal lighting experiments builds a lot and think is a big step up. I think it may make sense to have the 22.2 default weapon light sizes or brightness be different under this, as the result otherwise is generally dimmer lighting, but followup PRs will add controls for those defaults to lighting profiles. We could potentially have defaults tied to mod target version then, or something. 