### PR TITLE
lua ship.checkVisibility mimicing sexp ship-is-visible

### DIFF
--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -7038,8 +7038,7 @@ int sexp_hits_left(int node, bool sim_hull)
  */
 int sexp_is_ship_visible(int node)
 {
-	ship *viewer_shipp = nullptr;
-	int n = node, ship_is_visible = 0;
+	int n = node;
 
 	// get the ship
 	auto ship_entry = eval_ship(n);
@@ -7053,52 +7052,12 @@ int sexp_is_ship_visible(int node)
 	if (n >= 0)
 	{
 		auto viewer_entry = eval_ship(n);
-		if (viewer_entry)
-			viewer_shipp = viewer_entry->shipp;
+		return ship_check_visibility(ship_entry->shipp, viewer_entry->shipp);
 	}
 	else
 	{
-		// if the second argument is not supplied, default to the player, per retail
-		if (Game_mode & GM_MULTIPLAYER)
-		{
-			mprintf(("In multiplayer, is-ship-visible must have two arguments!  Defaulting to the first player.\n"));
-
-			// to make allowances for buggy missions (such as retail), just pick the first player
-			// if we actually have no valid players, viewer_shipp will be NULL, but that's ok
-			for (int i = 0; i < MAX_PLAYERS; ++i)
-			{
-				int shipnum = multi_get_player_ship(i);
-				if (shipnum >= 0)
-				{
-					viewer_shipp = &Ships[shipnum];
-					break;
-				}
-			}
-		}
-		else
-			viewer_shipp = Player_ship;
+		return ship_check_visibility(ship_entry->shipp, nullptr);
 	}
-
-	// get ship's *radar* visiblity
-	if (viewer_shipp)
-	{
-		if (ship_is_visible_by_team(ship_entry->objp, viewer_shipp))
-		{
-			ship_is_visible = 2;
-		}
-	}
-
-	// only check awacs level if ship is not visible by team
-	if (viewer_shipp && !ship_is_visible) {
-		float awacs_level = awacs_get_level(ship_entry->objp, viewer_shipp);
-		if (awacs_level >= 1.0f) {
-			ship_is_visible = 2;
-		} else if (awacs_level > 0) {
-			ship_is_visible = 1;
-		}
-	}
-
-	return ship_is_visible;
 }
 
 /**

--- a/code/scripting/api/objs/ship.cpp
+++ b/code/scripting/api/objs/ship.cpp
@@ -1005,6 +1005,26 @@ ADE_FUNC(kill, l_Ship, "[object Killer, vector Hitpos]", "Kills the ship. Set \"
 	return ADE_RETURN_TRUE;
 }
 
+ADE_FUNC(checkVisibility,
+	l_Ship,
+	"[ship viewer]",
+	"checks if a ship can appear on the viewer's radar. If a viewer is not provided it assumes the viewer is the "
+	"player.\n",
+	"number",
+	"Returns 0 - not visible, 1 - partially visible, 2 - fully visible")
+{
+	object_h* v1 = nullptr;
+	object_h* v2 = nullptr;
+	if (!ade_get_args(L, "o|o", l_Ship.GetPtr(&v1), l_Ship.GetPtr(&v2)))
+		return ade_set_error(L, "o", "");
+	ship* viewer_shipp = nullptr;
+	ship* viewed_shipp = nullptr;
+	viewed_shipp = &Ships[v1->objp->instance];
+	if (v2)
+		viewer_shipp = &Ships[v2->objp->instance];
+	return ade_set_args(L, "i", ship_check_visibility(viewed_shipp, viewer_shipp));
+}
+
 ADE_FUNC(addShipEffect, l_Ship, "string name, number durationMillis", "Activates an effect for this ship. Effect names are defined in Post_processing.tbl, and need to be implemented in the main shader. This functions analogous to the ship-effect sexp. NOTE: only one effect can be active at any time, adding new effects will override effects already in progress.\n", "boolean", "Returns true if the effect was successfully added, false otherwise") {
 	object_h *shiph;
 	const char* effect = nullptr;

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -20171,7 +20171,7 @@ int ship_check_visibility(const ship* viewed, ship* viewer)
 			viewer = Player_ship;
 	}
 
-	object* viewed_obj = &Objects[viewer->objnum];
+	object* viewed_obj = &Objects[viewed->objnum];
 	int ship_is_visible = 0;
 	//There are cases where the player is not a ship, so the above logic could result in still not having any valid ship pointer.
 	if(!viewer)

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -2024,4 +2024,7 @@ bool ship_lock_present(ship *shipp);
 
 bool ship_secondary_has_ammo(ship_weapon* swp, int bank_index);
 
+// Used to check if one ship can see the other on radar
+int ship_check_visibility(const ship* viewed, ship* viewer);
+
 #endif


### PR DESCRIPTION
the ship-is-visibile sexp is used heavily from inside lua in the popular radaricons script, and evaluating those sexps is unavoidably a heavy performance cost. This function can replace those sexp calls.