### PR TITLE
Fix techroom turret lookup and make animations more robust

### DIFF
--- a/code/model/modelanimation.cpp
+++ b/code/model/modelanimation.cpp
@@ -274,6 +274,8 @@ namespace animation {
 		ModelAnimationSet::cleanRunning();
 	}
 
+	ModelAnimationData<> ModelAnimationSubmodel::identity(ZERO_VECTOR, IDENTITY_MATRIX);
+
 	ModelAnimationSubmodel::ModelAnimationSubmodel(SCP_string submodelName) {
 		SCP_tolower(submodelName);
 		m_name = std::move(submodelName);
@@ -286,7 +288,9 @@ namespace animation {
 	const ModelAnimationData<>& ModelAnimationSubmodel::getInitialData(polymodel_instance* pmi) {
 		auto dataIt = m_initialData.find({ pmi->id });
 		if (dataIt == m_initialData.end()) {
-			saveCurrentAsBase(pmi);
+			if (!saveCurrentAsBase(pmi)) {
+				return identity;
+			}
 		}
 
 		return m_initialData.at(pmi->id);
@@ -333,12 +337,13 @@ namespace animation {
 		submodel->current_turn_rate = 0.0f;
 	}
 
-	void ModelAnimationSubmodel::saveCurrentAsBase(polymodel_instance* pmi, bool isInitialType) {
+	bool ModelAnimationSubmodel::saveCurrentAsBase(polymodel_instance* pmi, bool isInitialType) {
 		auto submodel = findSubmodel(pmi);
-		ModelAnimationData<>& data = m_initialData[{ pmi->id }];
 
 		if (!submodel.first || !submodel.second) 
-			return;
+			return false;
+
+		ModelAnimationData<>& data = m_initialData[{ pmi->id }];
 
 		if(!submodel.second->flags[Model::Submodel_flags::Can_move]){
 			mprintf(("Submodel %s of model %s is animated and has movement enabled.\n", submodel.second->name, model_get(pmi->model_num)->filename));
@@ -356,6 +361,8 @@ namespace animation {
 		//In this case, we just initial-type initialized the submodel. Properly set its last frame data as well
 		if(isInitialType)
 			submodel.first->canonical_prev_orient = submodel.first->canonical_orient;
+
+		return true;
 	}
 
 	std::pair<submodel_instance*, bsp_info*> ModelAnimationSubmodel::findSubmodel(polymodel_instance* pmi) {
@@ -416,10 +423,19 @@ namespace animation {
 			submodelNumber = m_submodel;
 		//Do we know if we were told to find the barrel submodel or not? This implies we have a subsystem name, not a submodel name
 		else {
+			ship_info* sip = nullptr;
+			if (pmi->objnum >= 0) {
+				sip = &Ship_info[Ships[Objects[pmi->objnum].instance].ship_info_index];
+			}
+			else {
+				//No objnum present. Check by SIP name we have saved (slow, so don't do if not absolutely necessary)
+				int sip_index = ship_info_lookup(m_SIPname.c_str());
 
-			if (pmi->objnum < 0)
-				return { nullptr, nullptr };
-			ship_info* sip = &Ship_info[Ships[Objects[pmi->objnum].instance].ship_info_index];
+				if(sip_index < 0) //Give up
+					return { nullptr, nullptr };
+
+				sip = &Ship_info[sip_index];
+			} 
 
 			for (int i = 0; i < sip->n_subsystems; i++) {
 				if (!subsystem_stricmp(sip->subsystems[i].subobj_name, m_name.c_str())) {
@@ -599,6 +615,13 @@ namespace animation {
 	void ModelAnimationSet::clearShipData(polymodel_instance* pmi) {
 		for (const auto& submodel : m_submodels) {
 			submodel->m_initialData.erase(pmi->id);
+		}
+		for (const auto& animations : m_animationSet) {
+			for (const auto& namedAnimations : animations.second) {
+				for (const auto& namedAnimation : namedAnimations.second) {
+					namedAnimation->m_instances.erase(pmi->id);
+				}
+			}
 		}
 	}
 

--- a/code/model/modelanimation.h
+++ b/code/model/modelanimation.h
@@ -127,6 +127,9 @@ namespace animation {
 		ModelAnimationData(const ModelAnimationData<!is_optional>& other) :
 			position(other.position),
 			orientation(other.orientation) {};
+		ModelAnimationData(const vec3d& copy_position, const matrix& copy_orientation) :
+			position(copy_position),
+			orientation(copy_orientation) {};
 
 		maybe_optional<vec3d> position;
 		maybe_optional<matrix> orientation;
@@ -166,6 +169,7 @@ namespace animation {
 	private:
 		//Polymodel Instance ID -> ModelAnimationData
 		std::map<int, ModelAnimationData<>> m_initialData;
+		static ModelAnimationData<> identity;
 
 	public:
 		ModelAnimationSubmodel(SCP_string submodelName);
@@ -173,7 +177,7 @@ namespace animation {
 
 		void reset(polymodel_instance* pmi);
 
-		void saveCurrentAsBase(polymodel_instance* pmi, bool isInitialType = false);
+		bool saveCurrentAsBase(polymodel_instance* pmi, bool isInitialType = false);
 		const ModelAnimationData<>& getInitialData(polymodel_instance* pmi);
 
 		virtual std::pair<submodel_instance*, bsp_info*> findSubmodel(polymodel_instance* pmi);


### PR DESCRIPTION
Fixes #4137.
The animations cache submodel numbers from the model file the first time any ship class animates their submodels. When this first animation was the techroom, where no objnum was present, the lookup would fail and cache an empty matrix, thus breaking the following animations. This PR adds safety to not cache bad values when no subsystem was found, and re-enables submodel lookup by ship_info name as fallback.