### PR TITLE
$AI ignores aspect lock for leading: AIP flag implemented

### DIFF
--- a/code/ai/ai_flags.h
+++ b/code/ai/ai_flags.h
@@ -144,6 +144,7 @@ namespace AI {
 		Fighterbay_departures_use_carrier_orient,
 		Prevent_negative_turret_ammo,
 		Fix_keep_safe_distance,
+		Ignore_aspect_when_leading,
 
 		NUM_VALUES
 	};

--- a/code/ai/ai_profiles.cpp
+++ b/code/ai/ai_profiles.cpp
@@ -598,6 +598,8 @@ void parse_ai_profiles_tbl(const char *filename)
 
 				set_flag(profile, "$fix keep-safe-distance:", AI::Profile_Flags::Fix_keep_safe_distance);
 
+				set_flag(profile, "$AI ignores aspect lock for leading:", AI::Profile_Flags::Ignore_aspect_when_leading);
+
 
 				// if we've been through once already and are at the same place, force a move
 				if (saved_Mp && (saved_Mp == Mp))

--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -8730,7 +8730,7 @@ void ai_chase()
 	//	If just acquired target, or target is not in reasonable cone, don't refine believed enemy position.
 	if ((real_dot_to_enemy < 0.25f) || (aip->target_time < 1.0f)) {
 		predicted_enemy_pos = enemy_pos;
-	} else if (aip->ai_flags[AI::AI_Flags::Seek_lock]) {
+	} else if (aip->ai_flags[AI::AI_Flags::Seek_lock] && !(The_mission.ai_profile->flags[AI::Profile_Flags::Ignore_aspect_when_leading]) ) {
 		if (The_mission.ai_profile->flags[AI::Profile_Flags::Fix_ramming_stationary_targets_bug]) {
 			// fixed by Mantis 3147 - Bash orientation if aspect seekers are equipped.
 			set_predicted_enemy_pos(&predicted_enemy_pos, Pl_objp, &aip->last_aim_enemy_pos, &aip->last_aim_enemy_vel, aip);	// Set G_fire_pos


### PR DESCRIPTION
Retail behavior is to aim directly at a target when gaining aspect locks, often making primaries ineffective in combat. If this flag is set then the AI ignores that case. 