### PR TITLE
remove daisy-chained mission flag

### DIFF
--- a/code/mission/mission_flags.h
+++ b/code/mission/mission_flags.h
@@ -19,9 +19,9 @@ namespace Mission {
 		No_briefing,				// no briefing, jump right into mission - Goober5000
 		Toggle_debriefing,			// Turn on debriefing for dogfight. Off for everything else - Goober5000
 		Unused_3,					// Necessary to not break parsing
-		Allow_dock_trees,			// toggle between hub and tree model for ship docking (see objectdock.cpp) - Gooober5000
-		Mission_2d,					// Mission is meant to be played top-down style; 2D physics and movement.
 		Unused_4,					// Necessary to not break parsing
+		Mission_2d,					// Mission is meant to be played top-down style; 2D physics and movement.
+		Unused_5,					// Necessary to not break parsing
 		Red_alert,					// a red-alert mission - Goober5000
 		Scramble,					// a scramble mission - Goober5000
 		No_builtin_command,			// turns off Command without turning off pilots - Karajorma

--- a/code/object/objectdock.cpp
+++ b/code/object/objectdock.cpp
@@ -941,8 +941,9 @@ bool dock_check_assume_hub()
 	// is not needed.  So this function is provided to allow the code to optimize itself for level 2, should level 1
 	// evaluation fail.
 
-	// Assume level 2 optimization unless the mission specifies level 3.
-	return !(The_mission.flags[Mission::Mission_Flags::Allow_dock_trees]);
+	// Determining this with a mission flag is a rather brittle design, and in any case this is not likely to be a large
+	// resource sink.  Until a general-purpose tree detection routine is written, this function will always return false.
+	return false;
 }
 
 object *dock_get_hub(object *objp)

--- a/fred2/fred.rc
+++ b/fred2/fred.rc
@@ -898,19 +898,17 @@ BEGIN
     CONTROL         "No Traitor",IDC_NO_TRAITOR,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,326,91,123,10
     CONTROL         "All Ships Beam-Freed By Default",IDC_BEAM_FREE_ALL_BY_DEFAULT,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,326,101,123,10
-    CONTROL         "Allow Daisy-Chained Docking",IDC_ALLOW_DOCK_TREES,
-                    "Button",BS_AUTOCHECKBOX | WS_TABSTOP,326,111,123,10
-    CONTROL         "No Briefing",IDC_NO_BRIEFING,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,326,121,72,10
-    CONTROL         "Toggle Debriefing (On/Off)",IDC_NO_DEBRIEFING,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,326,131,102,10
+    CONTROL         "No Briefing",IDC_NO_BRIEFING,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,326,111,72,10
+    CONTROL         "Toggle Debriefing (On/Off)",IDC_NO_DEBRIEFING,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,326,121,102,10
     CONTROL         "Use Autopilot Cinematics",IDC_USE_AUTOPILOT_CINEMATICS,
-                    "Button",BS_AUTOCHECKBOX | WS_TABSTOP,326,141,123,10
+                    "Button",BS_AUTOCHECKBOX | WS_TABSTOP,326,131,123,10
     CONTROL         "Deactivate Hardcoded Autopilot",IDC_DEACTIVATE_AUTOPILOT,
-                    "Button",BS_AUTOCHECKBOX | WS_TABSTOP,326,151,123,10
+                    "Button",BS_AUTOCHECKBOX | WS_TABSTOP,326,141,123,10
     CONTROL         "Player Starts under AI Control (NO MULTI)",IDC_PLAYER_START_AI,
-                    "Button",BS_AUTOCHECKBOX | WS_TABSTOP,326,161,146,10
+                    "Button",BS_AUTOCHECKBOX | WS_TABSTOP,326,151,146,10
     CONTROL         "Player Starts in Chase View",IDC_PLAYER_START_CHASE,
-                    "Button",BS_AUTOCHECKBOX | WS_TABSTOP,326,171,146,10
-    CONTROL         "2D Mission",IDC_2D_MISSION,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,326,181,123,10
+                    "Button",BS_AUTOCHECKBOX | WS_TABSTOP,326,161,146,10
+    CONTROL         "2D Mission",IDC_2D_MISSION,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,326,171,123,10
     LTEXT           "AI Profile",IDC_STATIC,320,229,32,8
     COMBOBOX        IDC_AI_PROFILE,378,226,93,140,CBS_DROPDOWNLIST | WS_VSCROLL | WS_TABSTOP
     LTEXT           "Mission Description",IDC_STATIC,4,260,62,8
@@ -924,8 +922,8 @@ BEGIN
     CONTROL         "",IDC_MAX_RESPAWN_DELAY_SPIN,"msctls_updown32",UDS_SETBUDDYINT | UDS_ALIGNRIGHT | UDS_AUTOBUDDY | UDS_ARROWKEYS,136,112,11,14
     PUSHBUTTON      "Sound Environment",IDC_SOUND_ENVIRONMENT_BUTTON,158,244,140,15
     CONTROL         "Always Show Mission Goals In Briefing",IDC_ALWAYS_SHOW_GOALS,
-                    "Button",BS_AUTOCHECKBOX | WS_TABSTOP,326,191,142,10
-    CONTROL         "Mission End to Mainhall",IDC_END_TO_MAINHALL,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,326,201,142,10
+                    "Button",BS_AUTOCHECKBOX | WS_TABSTOP,326,181,142,10
+    CONTROL         "Mission End to Mainhall",IDC_END_TO_MAINHALL,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,326,191,142,10
     CONTROL         "Override #Command in event messages",IDC_OVERRIDE_HASHCOMMAND,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,166,172,142,10
 END

--- a/fred2/missionnotesdlg.cpp
+++ b/fred2/missionnotesdlg.cpp
@@ -55,7 +55,6 @@ CMissionNotesDlg::CMissionNotesDlg(CWnd* pParent /*=NULL*/) : CDialog(CMissionNo
 	m_full_war = FALSE;
 	m_red_alert = FALSE;
 	m_scramble = FALSE;
-	m_daisy_chained_docking = FALSE;
 	m_num_respawns = 0;
 	m_max_respawn_delay = -1;
 	m_disallow_support = 0;
@@ -107,7 +106,6 @@ void CMissionNotesDlg::DoDataExchange(CDataExchange* pDX)
 	DDX_Check(pDX, IDC_FULL_WAR, m_full_war);
 	DDX_Check(pDX, IDC_RED_ALERT, m_red_alert);
 	DDX_Check(pDX, IDC_SCRAMBLE, m_scramble);
-	DDX_Check(pDX, IDC_ALLOW_DOCK_TREES, m_daisy_chained_docking);
 	DDX_Text(pDX, IDC_RESPAWNS, m_num_respawns);
 	DDX_Text(pDX, IDC_MAX_RESPAWN_DELAY, m_max_respawn_delay);
 	DDV_MinMaxUInt(pDX, m_num_respawns, 0, 99);
@@ -240,9 +238,6 @@ void CMissionNotesDlg::OnOK()
 
 	// set flags for scramble
     The_mission.flags.set(Mission::Mission_Flags::Scramble, m_scramble != 0);
-
-	// set flags for dock trees
-    The_mission.flags.set(Mission::Mission_Flags::Allow_dock_trees, m_daisy_chained_docking != 0);
 
 	// set the flags for no promotion
     The_mission.flags.set(Mission::Mission_Flags::No_promotion, m_no_promotion != 0);
@@ -389,7 +384,6 @@ BOOL CMissionNotesDlg::OnInitDialog()
 	m_red_alert = (The_mission.flags[Mission::Mission_Flags::Red_alert]) ? 1 : 0;
 	m_scramble = (The_mission.flags[Mission::Mission_Flags::Scramble]) ? 1 : 0;
 	m_full_war = Mission_all_attack;
-	m_daisy_chained_docking = (The_mission.flags[Mission::Mission_Flags::Allow_dock_trees]) ? 1 : 0;
 	m_disallow_support = (The_mission.support_ships.max_support_ships == 0) ? 1 : 0;
 	m_no_promotion = (The_mission.flags[Mission::Mission_Flags::No_promotion]) ? 1 : 0;
 	m_no_builtin_msgs = (The_mission.flags[Mission::Mission_Flags::No_builtin_msgs]) ? 1 : 0;

--- a/fred2/missionnotesdlg.h
+++ b/fred2/missionnotesdlg.h
@@ -46,7 +46,6 @@ public:
 	BOOL		m_full_war;
 	BOOL		m_red_alert;
 	BOOL		m_scramble;
-	BOOL		m_daisy_chained_docking;
 	UINT		m_num_respawns;
 	int			m_max_respawn_delay;
 	int			m_disallow_support;

--- a/fred2/resource.h
+++ b/fred2/resource.h
@@ -986,7 +986,6 @@
 #define IDC_ST_OVERRIDE_NEB             1545
 #define IDC_MAINHALL_LABEL              1545
 #define IDC_3D_WARP_EFFECT              1545
-#define IDC_ALLOW_DOCK_TREES            1545
 #define IDC_NEB2_FOG_R                  1545
 #define IDC_MISSION_OPTIONS             1546
 #define IDC_PLAYER_START_AI             1546

--- a/qtfred/src/ui/dialogs/MissionSpecDialog.cpp
+++ b/qtfred/src/ui/dialogs/MissionSpecDialog.cpp
@@ -73,7 +73,6 @@ MissionSpecDialog::MissionSpecDialog(FredView* parent, EditorViewport* viewport)
 	connect(ui->toggleBuiltinCmdMsg, &QCheckBox::toggled, this, [this](bool param) {flagToggled(param, Mission::Mission_Flags::No_builtin_command); });
 	connect(ui->toggleNoTraitor, &QCheckBox::toggled, this, [this](bool param) {flagToggled(param, Mission::Mission_Flags::No_traitor); });
 	connect(ui->toggleBeamFreeDefault, &QCheckBox::toggled, [this](bool param) {flagToggled(param, Mission::Mission_Flags::Beam_free_all_by_default); });
-	connect(ui->toggleDaisyChainedDocking, &QCheckBox::toggled, this, [this](bool param) {flagToggled(param, Mission::Mission_Flags::Allow_dock_trees); });
 	connect(ui->toggleNoBriefing, &QCheckBox::toggled, this, [this](bool param) {flagToggled(param, Mission::Mission_Flags::No_briefing); });
 	connect(ui->toggleDebriefing, &QCheckBox::toggled, this, [this](bool param) {flagToggled(param, Mission::Mission_Flags::Toggle_debriefing); });
 	connect(ui->toggleAutopilotCinematics, &QCheckBox::toggled, this, [this](bool param) {flagToggled(param, Mission::Mission_Flags::Use_ap_cinematics); });
@@ -243,7 +242,6 @@ void MissionSpecDialog::updateFlags() {
 	ui->toggleBeamFreeDefault->setChecked(flags[Mission::Mission_Flags::Beam_free_all_by_default]);
 	ui->toggleBuiltinCmdMsg->setChecked(flags[Mission::Mission_Flags::No_builtin_command]);
 	ui->toggleBuiltinMsg->setChecked(flags[Mission::Mission_Flags::No_builtin_msgs]);
-	ui->toggleDaisyChainedDocking->setChecked(flags[Mission::Mission_Flags::Allow_dock_trees]);
 	ui->toggleDebriefing->setChecked(flags[Mission::Mission_Flags::Toggle_debriefing]);
 	ui->toggleGoalsInBriefing->setChecked(flags[Mission::Mission_Flags::Always_show_goals]);
 	ui->toggleHardcodedAutopilot->setChecked(flags[Mission::Mission_Flags::Deactivate_ap]);

--- a/qtfred/ui/MissionSpecDialog.ui
+++ b/qtfred/ui/MissionSpecDialog.ui
@@ -828,16 +828,6 @@
          </widget>
         </item>
         <item>
-         <widget class="QCheckBox" name="toggleDaisyChainedDocking">
-          <property name="text">
-           <string>Allow Daisy-Chained Docking</string>
-          </property>
-          <attribute name="buttonGroup">
-           <string notr="true">m_flagGroup</string>
-          </attribute>
-         </widget>
-        </item>
-        <item>
          <widget class="QCheckBox" name="toggleNoBriefing">
           <property name="text">
            <string>No Briefing</string>


### PR DESCRIPTION
This flag is not the sort of thing that should depend on the FREDder, and in any case it probably isn't needed.  So this removes it.