### PR TITLE
add an additional check to the convert-to-Command logic

### DIFF
--- a/code/mission/missionmessage.cpp
+++ b/code/mission/missionmessage.cpp
@@ -1718,7 +1718,9 @@ void message_queue_message( int message_num, int priority, int timing, const cha
 		// SPECIAL HACK -- if the who_from is terran command, and there is a wingman persona attached
 		// to this message, then set a bit to tell the wave/anim playing code to play the command version
 		// of the wave and head
-		if ( !stricmp(who_from, The_mission.command_sender) ) {
+		// ADDENDUM -- Since the special hack is specifically for mission-unique messages, don't
+		// convert built-in messages to Command
+		if ( builtin_type < 0 && !stricmp(who_from, The_mission.command_sender) ) {
 			MessageQ[i].flags |= MQF_CONVERT_TO_COMMAND;
 			MessageQ[i].source = HUD_SOURCE_TERRAN_CMD;
 		} else {


### PR DESCRIPTION
The FS1 behavior for converting wingmen messages to Command messages specifically applies to in-mission messages with multiple files corresponding to the possible senders.  There is no situation where a built-in message needs to be converted, and in fact built-in messages can't usually be substituted because most built-in messages are distinct.  This commit adds an extra check for that case.  It has the effect of "fixing" #4149 even though that isn't really a bug.