### PR TITLE
refactor supernova code

### DIFF
--- a/code/graphics/post_processing.cpp
+++ b/code/graphics/post_processing.cpp
@@ -5,6 +5,7 @@
 #include "options/Option.h"
 #include "parse/parselo.h"
 #include "ship/ship.h"
+#include "starfield/supernova.h"
 
 namespace graphics {
 namespace {
@@ -208,6 +209,10 @@ void PostProcessingManager::setBloomShadersOk(bool ok)
 
 bool gr_lightshafts_enabled()
 {
+	// supernova glare should disable lightshafts
+	if (supernova_stage() >= SUPERNOVA_STAGE::CLOSE) {
+		return false;
+	}
 
 	if (!graphics::Post_processing_manager->getLightshaftParams().on) {
 		return false;

--- a/code/hud/hud.cpp
+++ b/code/hud/hud.cpp
@@ -1620,7 +1620,7 @@ void hud_render_preprocess(float frametime)
 	Player->subsys_in_view = -1;
 	hud_target_clear_display_list();
 
-	if ( (Game_detail_flags & DETAIL_FLAG_HUD) && (supernova_active() >= 3) ) {
+	if ( (Game_detail_flags & DETAIL_FLAG_HUD) && (supernova_stage() >= SUPERNOVA_STAGE::HIT) ) {
 		return;
 	}
 
@@ -1731,16 +1731,15 @@ void HudGaugeMissionTime::render(float  /*frametime*/)
 }
 
 /**
- * @brief Show supernova warning it there's a supernova coming
+ * @brief Show supernova warning if there's a supernova coming
  */
 void hud_maybe_display_supernova()
 {
-	float time_left;
-
-	time_left = supernova_time_left();
-	if(time_left < 0.0f){
+	if (!supernova_active()) {
 		return;
 	}
+
+	auto time_left = supernova_hud_time_left();
 
 	gr_set_color_fast(&Color_bright_red);
 	if (Lcl_pl) {
@@ -1791,7 +1790,7 @@ void hud_render_gauges(int cockpit_display_num)
 			return;
 		}
 	} else {
-		if( supernova_active() >= 3 ) {
+		if( supernova_stage() >= SUPERNOVA_STAGE::HIT) {
 			return;
 		}
 	}
@@ -4023,13 +4022,11 @@ HudGauge(HUD_OBJECT_SUPERNOVA, HUD_DIRECTIVES_VIEW, false, false, 0, 255, 255, 2
 
 void HudGaugeSupernova::render(float  /*frametime*/)
 {
-	float time_left;
-
-	// if there's a supernova coming
-	time_left = supernova_time_left();
-	if(time_left < 0.0f){
+	if (!supernova_active()) {
 		return;
 	}
+
+	auto time_left = supernova_hud_time_left();
 
 	gr_set_color_fast(&Color_bright_red);
 	if (Lcl_pl) {

--- a/code/mission/missioncampaign.cpp
+++ b/code/mission/missioncampaign.cpp
@@ -1746,7 +1746,7 @@ void mission_campaign_end_do()
 	// this is specific to the FreeSpace 2 single-player campaign
 	if (!stricmp(Campaign.filename, "freespace2")) {
 		// did the supernova blow?
-		if (Supernova_status == SUPERNOVA_HIT) {
+		if (supernova_stage() >= SUPERNOVA_STAGE::HIT) {
 			movie::play_two("endpart1.mve", "endprt2b.mve");			// bad ending
 		} else {
 			movie::play_two("endpart1.mve", "endprt2a.mve");			// good ending

--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -19,6 +19,7 @@
 #include "mod_table/mod_table.h"
 #include "parse/parselo.h"
 #include "sound/sound.h"
+#include "starfield/supernova.h"
 #include "playerman/player.h"
 
 int Directive_wait_time;
@@ -86,6 +87,7 @@ float Min_pixel_size_beam;
 float Min_pizel_size_muzzleflash;
 float Min_pixel_size_trail;
 float Min_pixel_size_laser;
+bool Supernova_hits_at_zero;
 
 void mod_table_set_version_flags();
 
@@ -252,6 +254,15 @@ void parse_mod_table(const char *filename)
 
 		if (optional_string("$Don't automatically select a turret when targeting a ship:")) {
 			stuff_boolean(&Dont_automatically_select_turret_when_targeting_ship);
+		}
+
+		if (optional_string("$Supernova hits at zero:")) {
+			stuff_boolean(&Supernova_hits_at_zero);
+			if (Supernova_hits_at_zero) {
+				mprintf(("Game Settings Table: HUD timer will reach 0 when the supernova shockwave hits the player\n"));
+			} else {
+				mprintf(("Game Settings Table: HUD timer will reach %.2f when the supernova shockwave hits the player\n", SUPERNOVA_HIT_TIME));
+			}
 		}
 
 		optional_string("#SEXP SETTINGS");
@@ -854,6 +865,7 @@ void mod_table_reset()
 	Min_pizel_size_muzzleflash = 0.0f;
 	Min_pixel_size_trail = 0.0f;
 	Min_pixel_size_laser = 0.0f;
+	Supernova_hits_at_zero = false;
 }
 
 void mod_table_set_version_flags()

--- a/code/mod_table/mod_table.h
+++ b/code/mod_table/mod_table.h
@@ -76,6 +76,7 @@ extern float Min_pixel_size_beam;
 extern float Min_pizel_size_muzzleflash;
 extern float Min_pixel_size_trail;
 extern float Min_pixel_size_laser;
+extern bool Supernova_hits_at_zero;
 
 void mod_table_init();
 

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -34730,7 +34730,7 @@ SCP_vector<sexp_help_struct> Sexp_help = {
 		"\t4: List of subsys names not to be randomized\r\n"},
 
 	{ OP_SUPERNOVA_START, "supernova-start\r\n"
-		"\t1: Time in seconds until the supernova shockwave hits the player\r\n"},
+		"\t1: Time in seconds that the supernova lasts.  Note that it will actually hit the player at " STR(SUPERNOVA_CUT_TIME) " seconds.  If you want the HUD gauge to adjust for this, use the '$Supernova hits at zero' game_settings.tbl option.\r\n"},
 
 	{ OP_SUPERNOVA_STOP, "supernova-stop\r\n"
 		"\t Stops a supernova in progress.\r\n"

--- a/code/starfield/starfield.cpp
+++ b/code/starfield/starfield.cpp
@@ -1818,7 +1818,7 @@ void stars_draw(int show_stars, int show_suns, int  /*show_nebulas*/, int show_s
 		stars_draw_background();
 	}
 
-	if ( !env && show_stars && (Nmodel_num < 0) && (Game_detail_flags & DETAIL_FLAG_STARS) && !(The_mission.flags[Mission::Mission_Flags::Fullneb]) && (supernova_active() < 3) ) {
+	if ( !env && show_stars && (Nmodel_num < 0) && (Game_detail_flags & DETAIL_FLAG_STARS) && !(The_mission.flags[Mission::Mission_Flags::Fullneb]) && (supernova_stage() < SUPERNOVA_STAGE::TOOLTIME) ) {
 		stars_draw_stars();
 	}
 
@@ -1829,7 +1829,7 @@ void stars_draw(int show_stars, int show_suns, int  /*show_nebulas*/, int show_s
 	mprintf(( "Stars: %d\n", xt2-xt1 ));
 #endif
 
-	if ( !Rendering_to_env && (Game_detail_flags & DETAIL_FLAG_MOTION) && (!Fred_running) && (supernova_active() < 3) && in_mission)	{
+	if ( !Rendering_to_env && (Game_detail_flags & DETAIL_FLAG_MOTION) && (!Fred_running) && (supernova_stage() < SUPERNOVA_STAGE::TOOLTIME) && in_mission)	{
 		stars_draw_motion_debris();
 	}
 

--- a/code/starfield/supernova.cpp
+++ b/code/starfield/supernova.cpp
@@ -27,47 +27,35 @@
 // SUPERNOVA DEFINES/VARS
 //
 
-// supernova time 1
-#define SUPERNOVA_SOUND_1_TIME		15.0f
-#define SUPERNOVA_SOUND_2_TIME		5.0f
-int Supernova_sound_1_played = 0;
-int Supernova_sound_2_played = 0;
-
 // countdown for supernova
 static float Supernova_time_total = -1.0f;
 static float Supernova_time = -1.0f;
-static int Supernova_finished = 0;
-static int Supernova_popup = 0;
 static float Supernova_fade_to_white = 0.0f;
 static int Supernova_particle_stamp = -1;
 
-int Supernova_status = SUPERNOVA_NONE;
+auto Supernova_status = SUPERNOVA_STAGE::NONE;
 
 // --------------------------------------------------------------------------------------------------------------------------
 // SUPERNOVA FUNCTIONS
 //
 
 // level init
+// (if this function is modified, check that its use in supernova_stop() is still valid)
 void supernova_level_init()
 {
 	Supernova_time_total = -1.0f;
 	Supernova_time = -1.0f;	
-	Supernova_finished = 0;
 	Supernova_fade_to_white = 0.0f;
-	Supernova_popup = 0;
 	Supernova_particle_stamp = -1;
 
-	Supernova_sound_1_played = 0;
-	Supernova_sound_2_played = 0;
-
-	Supernova_status = SUPERNOVA_NONE;
+	Supernova_status = SUPERNOVA_STAGE::NONE;
 }
 
 // start a supernova
 void supernova_start(int seconds)
 {
 	// bogus time
-	if((float)seconds < SUPERNOVA_CUT_TIME) {
+	if((float)seconds < SUPERNOVA_HIT_TIME) {
 		return;
 	}
 
@@ -78,41 +66,25 @@ void supernova_start(int seconds)
 
 	Supernova_time_total = (float)seconds;
 	Supernova_time = (float)seconds;
-	Supernova_finished = 0;
-	Supernova_fade_to_white = 0.0f;
-	Supernova_popup = 0;
-	Supernova_particle_stamp = -1;
 
-	Supernova_status = SUPERNOVA_STARTED;
+	Supernova_status = SUPERNOVA_STAGE::STARTED;
 }
 
 void supernova_stop()
 {
 	// There's no currently active supernova
-	if(Supernova_status != SUPERNOVA_STARTED)
-	{
+	if (Supernova_status == SUPERNOVA_STAGE::NONE)
 		return;
-	}
 	
 	// We're too late.
-	if(supernova_time_left() < SUPERNOVA_CUT_TIME)
-	{
+	if (Supernova_status >= SUPERNOVA_STAGE::HIT)
 		return;
-	}
 
 	// A supernova? In MY multiplayer?
-	if(Game_mode & GM_MULTIPLAYER) {
+	if (Game_mode & GM_MULTIPLAYER)
 		return;
-	}
 
-	Supernova_time_total = -1.0f;
-	Supernova_time = -1.0f;
-	Supernova_finished = 0;
-	Supernova_popup = 0;
-	Supernova_fade_to_white = 0.0f;
-	Supernova_particle_stamp = -1;
-
-	Supernova_status = SUPERNOVA_NONE;
+	supernova_level_init();
 }
 
 
@@ -179,105 +151,96 @@ DCF_FLOAT2(sn_shud, sn_shudder, 0.0, FLT_MAX, "Sets camera shudder rate for bein
 
 void supernova_process()
 {
-	int sn_stage;
-
-	// if the supernova is running
-	sn_stage = supernova_active();
-	if(sn_stage) {
+	if (Supernova_status != SUPERNOVA_STAGE::NONE)
 		Supernova_time -= flFrametime;
 
-		// sound stuff
-		if((Supernova_time <= SUPERNOVA_SOUND_1_TIME) && !Supernova_sound_1_played) {
-			Supernova_sound_1_played = 1;
-			snd_play(gamesnd_get_game_sound(GameSounds::SUPERNOVA_1), 0.0f, 1.0f, SND_PRIORITY_MUST_PLAY);
-		}
-		if((Supernova_time <= SUPERNOVA_SOUND_2_TIME) && !Supernova_sound_2_played) {
-			Supernova_sound_2_played = 1;
-			snd_play(gamesnd_get_game_sound(GameSounds::SUPERNOVA_2), 0.0f, 1.0f, SND_PRIORITY_MUST_PLAY);
-		}
+	if (Supernova_status >= SUPERNOVA_STAGE::DEAD1)
+		Supernova_fade_to_white += flFrametime;
 
-		// if we've crossed from stage 1 to stage 2 kill all particles and stick a bunch on the player ship
-		if((sn_stage == 1) && (supernova_active() == 2)) {
-			// first kill all active particles so we have a bunch of free ones
-			particle::kill_all();
-		}
+	switch (Supernova_status)
+	{
+		case SUPERNOVA_STAGE::NONE:
+			break;
 
-		// if we're in stage 2, emit particles
-		if((sn_stage >= 2) && (sn_stage != 5)) {
-			supernova_do_particles();
-		}
-
-		// if we've got negative. the supernova is done
-		if(Supernova_time < 0.0f) {
-			Supernova_finished = 1;
-			Supernova_fade_to_white += flFrametime;
-
-			// start the dead popup
-			if(Supernova_fade_to_white >= SUPERNOVA_FADE_TO_WHITE_TIME) {
-				if(!Supernova_popup) {
-					// main freespace 2 campaign? if so - end it now
-					//
-					// don't actually check for a specific campaign here since others may want to end this way but we
-					// should test positive here if in campaign mode and sexp_end_campaign() got called - taylor
-					if (Campaign_ending_via_supernova && (Game_mode & GM_CAMPAIGN_MODE) /*&& !stricmp(Campaign.filename, "freespace2")*/) {
-						gameseq_post_event(GS_EVENT_END_CAMPAIGN);
-					} else {
-						popupdead_start();
-					}
-					Supernova_popup = 1;
-				}
-				Supernova_finished = 2;
+		case SUPERNOVA_STAGE::STARTED:
+			if (Supernova_time <= SUPERNOVA_CLOSE_TIME)
+			{
+				snd_play(gamesnd_get_game_sound(GameSounds::SUPERNOVA_1), 0.0f, 1.0f, SND_PRIORITY_MUST_PLAY);
+				Supernova_status = SUPERNOVA_STAGE::CLOSE;
 			}
-		}
+			break;
+
+		case SUPERNOVA_STAGE::CLOSE:
+			if (Supernova_time <= SUPERNOVA_HIT_TIME)
+			{
+				snd_play(gamesnd_get_game_sound(GameSounds::SUPERNOVA_2), 0.0f, 1.0f, SND_PRIORITY_MUST_PLAY);
+				Supernova_status = SUPERNOVA_STAGE::HIT;
+
+				// if we've crossed from stage 1 to stage 2 kill all particles and stick a bunch on the player ship
+				particle::kill_all();	// kill all active particles so we have a bunch of free ones
+			}
+			break;
+
+		case SUPERNOVA_STAGE::HIT:
+			supernova_do_particles();
+			if (Supernova_time <= (SUPERNOVA_HIT_TIME - SUPERNOVA_CAMERA_MOVE_DURATION))
+			{
+				Supernova_status = SUPERNOVA_STAGE::TOOLTIME;
+			}
+			break;
+
+		case SUPERNOVA_STAGE::TOOLTIME:
+			supernova_do_particles();
+			// if we've got negative, the supernova is done
+			if (Supernova_time < 0.0f)
+			{
+				Supernova_status = SUPERNOVA_STAGE::DEAD1;
+			}
+			break;
+
+		case SUPERNOVA_STAGE::DEAD1:
+			supernova_do_particles();
+			// start the dead popup
+			if (Supernova_fade_to_white >= SUPERNOVA_FADE_TO_WHITE_DURATION)
+			{
+				// main freespace 2 campaign? if so - end it now
+				//
+				// don't actually check for a specific campaign here since others may want to end this way but we
+				// should test positive here if in campaign mode and sexp_end_campaign() got called - taylor
+				if (Campaign_ending_via_supernova && (Game_mode & GM_CAMPAIGN_MODE) /*&& !stricmp(Campaign.filename, "freespace2")*/) {
+					gameseq_post_event(GS_EVENT_END_CAMPAIGN);
+				} else {
+					popupdead_start();
+				}
+				Supernova_status = SUPERNOVA_STAGE::DEAD2;
+			}
+			break;
+
+		case SUPERNOVA_STAGE::DEAD2:
+			// popup etc. was already handled when the state switched, so nothing else to do
+			break;
 	}
 }
 
 // is there a supernova active
-int supernova_active()
+bool supernova_active()
 {
-	// if not supernova has been set then just bail now
-	if (Supernova_status == SUPERNOVA_NONE) {
-		return 0;
-	}
-
-	// if the supernova has "finished". fade to white and dead popup
-	if(Supernova_finished == 1) {
-		Supernova_status = SUPERNOVA_HIT;
-		return 4;
-	}
-	if(Supernova_finished == 2) {
-		Supernova_status = SUPERNOVA_HIT;
-		return 5;
-	}
-
-	// no supernova
-	if( (Supernova_time_total <= 0.0f) || (Supernova_time <= 0.0f) ) {
-		return 0;
-	}	
-
-	// final stage,
-	if(Supernova_time < (SUPERNOVA_CUT_TIME - SUPERNOVA_CAMERA_MOVE_TIME)) {
-		Supernova_status = SUPERNOVA_HIT;
-		return 3;
-	}
-
-	// 2nd stage
-	if(Supernova_time < SUPERNOVA_CUT_TIME) {
-		Supernova_status = SUPERNOVA_HIT;
-		return 2;
-	}
-
-	// first stage
-	return 1;
+	return Supernova_status != SUPERNOVA_STAGE::NONE;
 }
 
-// time left before the supernova hits
-float supernova_time_left()
+SUPERNOVA_STAGE supernova_stage()
 {
-	return Supernova_time;
+	return Supernova_status;
 }
 
-// pct complete the supernova (0.0 to 1.0)
+float supernova_hud_time_left()
+{
+	auto time_left = Supernova_time;
+	if (Supernova_hits_at_zero)
+		time_left -= SUPERNOVA_HIT_TIME;
+	return MAX(time_left, 0.0f);
+}
+
 float supernova_pct_complete()
 {
 	// bogus
@@ -288,21 +251,15 @@ float supernova_pct_complete()
 	return (Supernova_time_total - Supernova_time) / Supernova_time_total;
 }
 
-// if the camera should cut to the "you-are-toast" cam
-int supernova_camera_cut()
+float supernova_sunspot_pct()
 {
-	// if we're not in a supernova
-	if(!supernova_active()) {
-		return 0;
-	}
+	return 1.0f - (Supernova_time / SUPERNOVA_HIT_TIME);
+}
 
-	// if we're past the critical time
-	if(Supernova_time <= SUPERNOVA_CUT_TIME) {
-		return 1;
-	}
-
-	// no cut yet
-	return 0;
+// if the camera should cut to the "you-are-toast" cam
+bool supernova_camera_cut()
+{
+	return Supernova_status >= SUPERNOVA_STAGE::HIT;
 }
 
 // get view params from supernova
@@ -339,7 +296,7 @@ void supernova_get_eye(vec3d *eye_pos, matrix *eye_orient)
 	*eye_pos = Supernova_camera_pos;
 
 	// if we're no longer moving the camera
-	if(Supernova_time < (SUPERNOVA_CUT_TIME - SUPERNOVA_CAMERA_MOVE_TIME)) {
+	if (Supernova_status >= SUPERNOVA_STAGE::TOOLTIME) {
 		// *eye_pos = Supernova_camera_pos;
 		//cam->set_rotation(&Supernova_camera_orient);
 		*eye_orient = Supernova_camera_orient;
@@ -353,7 +310,7 @@ void supernova_get_eye(vec3d *eye_pos, matrix *eye_orient)
 		vm_vec_normalize(&move);
 
 		// linearly move towards the player pos
-		float pct = ((SUPERNOVA_CUT_TIME - Supernova_time) / SUPERNOVA_CAMERA_MOVE_TIME);
+		float pct = ((SUPERNOVA_HIT_TIME - Supernova_time) / SUPERNOVA_CAMERA_MOVE_DURATION);
 		vm_vec_scale_add2(&at, &move, sn_distance * pct);
 
 		vm_vec_sub(&view, &at, &Supernova_camera_pos);

--- a/code/starfield/supernova.h
+++ b/code/starfield/supernova.h
@@ -20,19 +20,25 @@ struct vec3d;
 struct matrix;
 
 // supernova timing stuff
-#define SUPERNOVA_MIN_TIME							15.0f				// must be at least 15 seconds out
-#define SUPERNOVA_CUT_TIME							5.0f				// note this is also the minimum time for the supernova sexpression
-#define SUPERNOVA_CAMERA_MOVE_TIME				2.0f				// this is the amount of time the camera will cut from the sun to the player
-#define SUPERNOVA_FADE_TO_WHITE_TIME			1.0f				// fade to white over this amount of time
+constexpr float SUPERNOVA_CLOSE_TIME = 15.0f;							// must be at least 15 seconds out
+constexpr float SUPERNOVA_HIT_TIME = 5.0f;								// note this is also the minimum time for the supernova sexpression
+constexpr float SUPERNOVA_CAMERA_MOVE_DURATION = 2.0f;					// this is the amount of time the camera will cut from the sun to the player
+constexpr float SUPERNOVA_FADE_TO_WHITE_DURATION = 1.0f;				// fade to white over this amount of time
 
 // how much bigger the sun will be when the effect hits
-#define SUPERNOVA_SUN_SCALE						3.0f
+constexpr float SUPERNOVA_SUN_SCALE = 3.0f;
 
-// status for the supernova this mission
-#define SUPERNOVA_NONE								0					// nothing happened in this mission
-#define SUPERNOVA_STARTED							1					// started, but the player never got hit by it
-#define SUPERNOVA_HIT								2					// started and killed the player
-extern int Supernova_status;
+// stages for the supernova this mission
+enum class SUPERNOVA_STAGE
+{
+	NONE,																// not active.
+	STARTED,															// player still in control. shockwave approaching.
+	CLOSE,																// shockwave still approaching, but very close. sound1 has started
+	HIT,																// camera cut. player controls locked. letterbox. sound2 has started. particles start
+	TOOLTIME,															// tooltime. lots of particles. camera stops moving
+	DEAD1,																// player is effectively dead. fade to white. stop simulation
+	DEAD2,																// give dead popup
+};
 
 // --------------------------------------------------------------------------------------------------------------------------
 // SUPERNOVA FUNCTIONS
@@ -51,22 +57,21 @@ void supernova_stop();
 void supernova_process();
 
 // is there a supernova active
-// 0 : not active.
-// 1 : player still in control. shockwave approaching.
-// 2 : camera cut. player controls locked. letterbox
-// 3 : tooltime. lots of particles
-// 4 : player is effectively dead. fade to white. stop simulation
-// 5 : give dead popup
-int supernova_active();
+SUPERNOVA_STAGE supernova_stage();
+bool supernova_active();
 
-// time left before the supernova hits
-float supernova_time_left();
+// time left before the supernova hits - for displaying on HUD
+float supernova_hud_time_left();
 
-// pct complete the supernova (0.0 to 1.0)
+// percent to complete the supernova (0.0 to 1.0)
+// note: this covers total time, not time until the camera cuts
 float supernova_pct_complete();
 
+// special sunspot percent calculation (0.0 to 1.0)
+float supernova_sunspot_pct();
+
 // if the camera should cut to the "you-are-toast" cam
-int supernova_camera_cut();
+bool supernova_camera_cut();
 
 // get view params from supernova
 void supernova_get_eye(vec3d *eye_pos, matrix *eye_orient);


### PR DESCRIPTION
A bit of cleanup, refactoring, and bugfixing...

1) The supernova code now uses enums to represent states, and those state transitions now all happen in `supernova_process` instead of being scattered around.
2) Some state transition bugs were fixed - e.g. the HUD is now disabled when the camera cuts to the external view, instead of when the camera stops moving; and the particles start and the simulation stops when the comments say they do.
3) There is now a game_settings.tbl flag to make the HUD countdown timer reach zero when the supernova hits, instead of reaching 5s.  This only affects the HUD display; actual timing is not changed.
4) Don't apply lightshafts if the supernova glare is in effect - partial fix for #4152.