### PR TITLE
prototype for fading from lightshafts to glares

### DIFF
--- a/code/graphics/opengl/gropenglpostprocessing.cpp
+++ b/code/graphics/opengl/gropenglpostprocessing.cpp
@@ -21,6 +21,7 @@
 #include "nebula/neb.h"
 #include "parse/parselo.h"
 #include "ship/ship.h"
+#include "starfield/supernova.h"
 #include "tracing/tracing.h"
 
 extern bool PostProcessing_override;
@@ -441,6 +442,10 @@ void opengl_post_lightshafts()
 	// should we even be here?
 	if ( !Game_subspace_effect && gr_lightshafts_enabled() ) {
 		int n_lights = light_get_global_count();
+		auto intensity_scale = Sun_spot;
+		if (supernova_active()) {
+			intensity_scale *= (1.0f - supernova_lightshaft_to_glare_pct());
+		}
 
 		for ( int idx = 0; idx<n_lights; idx++ ) {
 			vec3d light_dir;
@@ -468,8 +473,8 @@ void opengl_post_lightshafts()
 						data->density      = ls_params.density;
 						data->falloff      = ls_params.falloff;
 						data->weight       = ls_params.weight;
-						data->intensity    = Sun_spot * ls_params.intensity;
-						data->cp_intensity = Sun_spot * ls_params.cpintensity;
+						data->intensity    = intensity_scale * ls_params.intensity;
+						data->cp_intensity = intensity_scale * ls_params.cpintensity;
 					});
 
 				Current_shader->program->Uniforms.setTextureUniform("scene", 0);

--- a/code/starfield/supernova.cpp
+++ b/code/starfield/supernova.cpp
@@ -256,6 +256,16 @@ float supernova_sunspot_pct()
 	return 1.0f - (Supernova_time / SUPERNOVA_HIT_TIME);
 }
 
+float supernova_lightshaft_to_glare_pct()
+{
+	if (Supernova_status < SUPERNOVA_STAGE::CLOSE)
+		return 0.0f;
+	else if (Supernova_time > (SUPERNOVA_CLOSE_TIME - SUPERNOVA_SWITCH_TO_GLARE_DURATION))
+		return (SUPERNOVA_CLOSE_TIME - Supernova_time) / SUPERNOVA_SWITCH_TO_GLARE_DURATION;
+	else
+		return 1.0f;
+}
+
 // if the camera should cut to the "you-are-toast" cam
 bool supernova_camera_cut()
 {

--- a/code/starfield/supernova.h
+++ b/code/starfield/supernova.h
@@ -24,6 +24,7 @@ constexpr float SUPERNOVA_CLOSE_TIME = 15.0f;							// must be at least 15 secon
 constexpr float SUPERNOVA_HIT_TIME = 5.0f;								// note this is also the minimum time for the supernova sexpression
 constexpr float SUPERNOVA_CAMERA_MOVE_DURATION = 2.0f;					// this is the amount of time the camera will cut from the sun to the player
 constexpr float SUPERNOVA_FADE_TO_WHITE_DURATION = 1.0f;				// fade to white over this amount of time
+constexpr float SUPERNOVA_SWITCH_TO_GLARE_DURATION = 1.0f;				// switch from lightshaft to glare over this amount of time
 
 // how much bigger the sun will be when the effect hits
 constexpr float SUPERNOVA_SUN_SCALE = 3.0f;
@@ -69,6 +70,9 @@ float supernova_pct_complete();
 
 // special sunspot percent calculation (0.0 to 1.0)
 float supernova_sunspot_pct();
+
+// for smoothly switching from one to the other
+float supernova_lightshaft_to_glare_pct();
 
 // if the camera should cut to the "you-are-toast" cam
 bool supernova_camera_cut();

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -820,10 +820,11 @@ static void game_flash_diminish(float frametime)
 		g = fl2i( Game_flash_green*128.0f );   
 		b = fl2i( Game_flash_blue*128.0f );  
 
-		if ( Sun_spot > 0.0f && !gr_lightshafts_enabled()) {
-			r += fl2i(Sun_spot*128.0f);
-			g += fl2i(Sun_spot*128.0f);
-			b += fl2i(Sun_spot*128.0f);
+		if ( (Sun_spot > 0.0f) && (!gr_lightshafts_enabled() || supernova_active()) ) {
+			auto inc = fl2i(Sun_spot * 128.0f * supernova_lightshaft_to_glare_pct());
+			r += inc;
+			g += inc;
+			b += inc;
 		}
 
 		if ( Big_expl_flash.cur_flash_intensity  > 0.0f ) {


### PR DESCRIPTION
A possible method for fading lightshafts out at the same time glares fade in.  Based on ~~(and includes the commit from)~~ #4153.

Still in draft form because more work is needed: scaling the intensity is not enough to disable the lightshaft effect.