### PR TITLE
add the ability for subtitles to be scaled correctly to the screen 

### DIFF
--- a/code/camera/camera.cpp
+++ b/code/camera/camera.cpp
@@ -597,11 +597,43 @@ void warp_camera::get_info(vec3d *position, matrix *orientation)
 
 #define MAX_SUBTITLE_LINES		64
 subtitle::subtitle(int in_x_pos, int in_y_pos, const char* in_text, const char* in_imageanim, float in_display_time,
-	float in_fade_time, const color *in_text_color, int in_text_fontnum, bool center_x, bool center_y, int in_width,
+	float in_fade_time, const color* in_text_color, int in_text_fontnum, bool center_x, bool center_y, int in_width,
 	int in_height, bool in_post_shaded, int in_line_height_modifier)
 	: display_time(-1.0f), fade_time(-1.0f), text_fontnum(-1), line_height_modifier(0),
-	image_id(-1), time_displayed(-1.0f), time_displayed_end(-1.0f), post_shaded(false)
+	image_id(-1), time_displayed(-1.0f), time_displayed_end(-1.0f), post_shaded(false), do_screen_scaling(false)
 {
+	if ((in_text == nullptr || *in_text == '\0') && (in_imageanim == nullptr || *in_imageanim == '\0'))
+		return;
+
+	auto screen_w = gr_screen.center_w;
+	auto screen_h = gr_screen.center_h;
+
+	// we might be doing screen scaling
+	if (Show_subtitle_screen_base_res[0] > 0 && Show_subtitle_screen_base_res[1] > 0)
+	{
+		// The way this works is we specify our subtitle coordinates relative to a base resolution, e.g. 1024x768.
+		// The base resolution is adjusted behind the scenes to match the aspect ratio of the current resolution
+		// (and the subtitle coordinates are adjusted as well).  Then the adjusted subtitles are resized by the
+		// graphics code when they are drawn to the screen.
+		do_screen_scaling = true;
+
+		// we might need to adjust the coordinates for aspect ratio
+		if (Show_subtitle_screen_base_res[0] != Show_subtitle_screen_adjusted_res[0])
+		{
+			in_x_pos = in_x_pos * Show_subtitle_screen_adjusted_res[0] / Show_subtitle_screen_base_res[0];
+			in_width = in_width * Show_subtitle_screen_adjusted_res[0] / Show_subtitle_screen_base_res[0];
+		}
+		if (Show_subtitle_screen_base_res[1] != Show_subtitle_screen_adjusted_res[1])
+		{
+			in_y_pos = in_y_pos * Show_subtitle_screen_adjusted_res[1] / Show_subtitle_screen_base_res[1];
+			in_height = in_height * Show_subtitle_screen_adjusted_res[1] / Show_subtitle_screen_base_res[1];
+		}
+
+		// use these because we will be scaling the subtitle when it is displayed
+		screen_w = Show_subtitle_screen_adjusted_res[0];
+		screen_h = Show_subtitle_screen_adjusted_res[1];
+	}
+
 	// Initialize color
 	gr_init_color(&text_color, 0, 0, 0);
 	
@@ -611,9 +643,6 @@ subtitle::subtitle(int in_x_pos, int in_y_pos, const char* in_text, const char* 
 	memset( imageanim, 0, sizeof(imageanim) );
 	memset( &text_pos, 0, 2*sizeof(int) );
 	memset( &image_pos, 0, 4*sizeof(int) );
-
-	if ( ((in_text != NULL) && (strlen(in_text) <= 0)) && ((in_imageanim != NULL) && (strlen(in_imageanim) <= 0)) )
-		return;
 
 	if (in_text != NULL && in_text[0] != '\0')
 	{
@@ -716,20 +745,20 @@ subtitle::subtitle(int in_x_pos, int in_y_pos, const char* in_text, const char* 
 
 		//Center it?
 		if(center_x)
-			image_pos.x = (gr_screen.center_w - tw)/2 + gr_screen.center_offset_x;
+			image_pos.x = (screen_w - tw)/2;
 		if(center_y)
-			image_pos.y = (gr_screen.center_h - th)/2 + gr_screen.center_offset_y;
+			image_pos.y = (screen_h - th)/2;
 	}
 
 	if(in_x_pos < 0 && !center_x)
-		image_pos.x += gr_screen.center_offset_x + gr_screen.center_w + in_x_pos;
+		image_pos.x += screen_w + in_x_pos;
 	else if(!center_x)
-		image_pos.x += gr_screen.center_offset_x + in_x_pos;
+		image_pos.x += in_x_pos;
 
 	if(in_y_pos < 0 && !center_y)
-		image_pos.y += gr_screen.center_offset_y + gr_screen.center_h + in_y_pos;
+		image_pos.y += screen_h + in_y_pos;
 	else if(!center_y)
-		image_pos.y += gr_screen.center_offset_y + in_y_pos;
+		image_pos.y += in_y_pos;
 
 	image_pos.w = in_width;
 	image_pos.h = in_height;
@@ -785,10 +814,15 @@ void subtitle::do_frame(float frametime)
 	int x = text_pos.x;
 	int y = text_pos.y;
 
+	auto sizing_mode = do_screen_scaling ? GR_RESIZE_FULL : GR_RESIZE_NONE;
+	if (do_screen_scaling)
+		gr_set_screen_scale(Show_subtitle_screen_adjusted_res[0], Show_subtitle_screen_adjusted_res[1]);
+
+	// do the actual drawing ---------------------
 
 	for(SCP_vector<SCP_string>::iterator line = text_lines.begin(); line != text_lines.end(); ++line)
 	{
-		gr_string(x, y, (char*)line->c_str(), GR_RESIZE_NONE);
+		gr_string(x, y, (char*)line->c_str(), sizing_mode);
 
 		if (line_height_modifier != 0.0f)
 		{
@@ -801,17 +835,11 @@ void subtitle::do_frame(float frametime)
 		y += font_height;
 	}
 
-	// restore old font
-	if (old_fontnum >= 0)
-	{
-		font::set_font(old_fontnum);
-	}
-
 	if(image_id >= 0)
 	{
 		gr_set_bitmap(image_id, GR_ALPHABLEND_FILTER, GR_BITBLT_MODE_NORMAL, text_color.alpha/255.0f);
 
-		// scaling?
+		// image scaling?
 		if (image_pos.w > 0 || image_pos.h > 0)
 		{
 			int orig_w, orig_h;
@@ -823,15 +851,24 @@ void subtitle::do_frame(float frametime)
 			scale.xyz.z = 1.0f;
 
 			gr_push_scale_matrix(&scale);
-			gr_bitmap(fl2i(image_pos.x / scale.xyz.x), fl2i(image_pos.y / scale.xyz.y), GR_RESIZE_NONE);
+			gr_bitmap(fl2i(image_pos.x / scale.xyz.x), fl2i(image_pos.y / scale.xyz.y), sizing_mode);
 			gr_pop_scale_matrix();
 		}
 		// no scaling
 		else
 		{
-			gr_bitmap(image_pos.x, image_pos.y, GR_RESIZE_NONE);
+			gr_bitmap(image_pos.x, image_pos.y, sizing_mode);
 		}
 	}
+
+	// finished the actual drawing ---------------
+
+	if (do_screen_scaling)
+		gr_reset_screen_scale();
+
+	// restore old font
+	if (old_fontnum >= 0)
+		font::set_font(old_fontnum);
 
 	time_displayed += frametime;
 }
@@ -872,6 +909,7 @@ void subtitle::clone(const subtitle &sub)
 	time_displayed_end = sub.time_displayed_end;
 
 	post_shaded = sub.post_shaded;
+	do_screen_scaling = sub.do_screen_scaling;
 }
 
 subtitle& subtitle::operator=(const subtitle &sub)

--- a/code/camera/camera.h
+++ b/code/camera/camera.h
@@ -137,6 +137,8 @@ private:
 	float time_displayed_end;
 
 	bool post_shaded;
+	bool do_screen_scaling;
+
 public:
 	subtitle(int in_x_pos, int in_y_pos, const char* in_text = NULL, const char* in_imageanim = NULL,
 			 float in_display_time = 0, float in_fade_time = 0.0f, const color *in_text_color = NULL, int in_text_fontnum = -1,

--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -89,6 +89,8 @@ float Min_pixel_size_trail;
 float Min_pixel_size_laser;
 bool Supernova_hits_at_zero;
 bool Show_subtitle_uses_pixels;
+int Show_subtitle_screen_base_res[2];
+int Show_subtitle_screen_adjusted_res[2];
 
 void mod_table_set_version_flags();
 
@@ -304,6 +306,21 @@ void parse_mod_table(const char *filename)
 				mprintf(("Game Settings Table: Show-subtitle uses pixels\n"));
 			} else {
 				mprintf(("Game Settings Table: Show-subtitle uses percentages\n"));
+			}
+		}
+
+		if (optional_string("$Show-subtitle base resolution:")) {
+			int base_res[2];
+			if (stuff_int_list(base_res, 2) == 2) {
+				if (base_res[0] >= 640 && base_res[1] >= 480) {
+					Show_subtitle_screen_base_res[0] = base_res[0];
+					Show_subtitle_screen_base_res[1] = base_res[1];
+					mprintf(("Game Settings Table: Show-subtitle base resolution is (%d, %d)\n", base_res[0], base_res[1]));
+				} else {
+					Warning(LOCATION, "$Show-subtitle base resolution: arguments must be at least 640x480!");
+				}
+			} else {
+				Warning(LOCATION, "$Show-subtitle base resolution: must specify two arguments");
 			}
 		}
 
@@ -803,6 +820,23 @@ void mod_table_init()
 	parse_modular_table("*-mod.tbm", parse_mod_table);
 }
 
+// game_settings.tbl is parsed before graphics are actually initialized, so we can't calculate the resolution at that time
+void mod_table_post_process()
+{
+	// use the same widescreen code as in adjust_base_res()
+	// This calculates an adjusted resolution if the aspect ratio of the base resolution doesn't exactly match that of the current resolution.
+	// The base resolution specified in game_settings.tbl does not need to be 1024x768 or even 4:3.
+	float aspect_quotient = ((float)gr_screen.center_w / (float)gr_screen.center_h) / ((float)Show_subtitle_screen_base_res[0] / (float)Show_subtitle_screen_base_res[1]);
+	if (aspect_quotient >= 1.0) {
+		Show_subtitle_screen_adjusted_res[0] = (int)(Show_subtitle_screen_base_res[0] * aspect_quotient);
+		Show_subtitle_screen_adjusted_res[1] = Show_subtitle_screen_base_res[1];
+	} else {
+		Show_subtitle_screen_adjusted_res[0] = Show_subtitle_screen_base_res[0];
+		Show_subtitle_screen_adjusted_res[1] = (int)(Show_subtitle_screen_base_res[1] / aspect_quotient);
+	}
+	mprintf(("Game Settings Table: Show-subtitle adjusted resolution is (%d, %d)\n", Show_subtitle_screen_adjusted_res[0], Show_subtitle_screen_adjusted_res[1]));
+}
+
 bool mod_supports_version(int major, int minor, int build)
 {
 	return Targeted_version >= gameversion::version(major, minor, build, 0);
@@ -877,6 +911,10 @@ void mod_table_reset()
 	Min_pixel_size_laser = 0.0f;
 	Supernova_hits_at_zero = false;
 	Show_subtitle_uses_pixels = false;
+	Show_subtitle_screen_base_res[0] = -1;
+	Show_subtitle_screen_base_res[1] = -1;
+	Show_subtitle_screen_adjusted_res[0] = -1;
+	Show_subtitle_screen_adjusted_res[1] = -1;
 }
 
 void mod_table_set_version_flags()

--- a/code/mod_table/mod_table.h
+++ b/code/mod_table/mod_table.h
@@ -78,8 +78,11 @@ extern float Min_pixel_size_trail;
 extern float Min_pixel_size_laser;
 extern bool Supernova_hits_at_zero;
 extern bool Show_subtitle_uses_pixels;
+extern int Show_subtitle_screen_base_res[];
+extern int Show_subtitle_screen_adjusted_res[];
 
 void mod_table_init();
+void mod_table_post_process();
 
 /**
  * @brief Resets the mod values back to their default values

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -22747,6 +22747,23 @@ void multi_sexp_clear_subtitles()
 	Subtitles.clear();
 }
 
+void get_subtitle_screen_size(int& w, int& h)
+{
+	// if we are doing screen scaling, then set the size to the base resolution
+	// (it will be adjusted when the subtitle is constructed)
+	if (Show_subtitle_screen_base_res[0] > 0 && Show_subtitle_screen_base_res[1] > 0)
+	{
+		w = Show_subtitle_screen_base_res[0];
+		h = Show_subtitle_screen_base_res[1];
+	}
+	// otherwise use the actual screen size
+	else
+	{
+		w = gr_screen.center_w;
+		h = gr_screen.center_h;
+	}
+}
+
 void sexp_show_subtitle_text(int node)
 {
 	bool is_nan, is_nan_forever;
@@ -22846,9 +22863,12 @@ void sexp_show_subtitle_text(int node)
 	}
 	else
 	{
-		x_pos = fl2i(gr_screen.center_w * (xy_input[0] / 100.0f));
-		y_pos = fl2i(gr_screen.center_h * (xy_input[1] / 100.0f));
-		width = fl2i(gr_screen.center_w * (width_input / 100.0f));
+		int screen_w, screen_h;
+		get_subtitle_screen_size(screen_w, screen_h);
+
+		x_pos = fl2i(screen_w * (xy_input[0] / 100.0f));
+		y_pos = fl2i(screen_h * (xy_input[1] / 100.0f));
+		width = fl2i(screen_w * (width_input / 100.0f));
 	}
 
 	// add the subtitle
@@ -22889,9 +22909,9 @@ void multi_sexp_show_subtitle_text()
 	bool post_shaded = false;
 	color new_color;
 
-	 Current_sexp_network_packet.get_int(xy_input[0]);
-	 Current_sexp_network_packet.get_int(xy_input[1]);
-	 Current_sexp_network_packet.get_int(message_index); 
+	Current_sexp_network_packet.get_int(xy_input[0]);
+	Current_sexp_network_packet.get_int(xy_input[1]);
+	Current_sexp_network_packet.get_int(message_index); 
 	if (message_index == -1) {
 		Current_sexp_network_packet.get_string(text);
 	}
@@ -22924,9 +22944,12 @@ void multi_sexp_show_subtitle_text()
 	}
 	else
 	{
-		x_pos = fl2i(gr_screen.center_w * (xy_input[0] / 100.0f));
-		y_pos = fl2i(gr_screen.center_h * (xy_input[1] / 100.0f));
-		width = fl2i(gr_screen.center_w * (width_input / 100.0f));
+		int screen_w, screen_h;
+		get_subtitle_screen_size(screen_w, screen_h);
+
+		x_pos = fl2i(screen_w * (xy_input[0] / 100.0f));
+		y_pos = fl2i(screen_h * (xy_input[1] / 100.0f));
+		width = fl2i(screen_w * (width_input / 100.0f));
 	}
 
 	// add the subtitle
@@ -22991,10 +23014,13 @@ void sexp_show_subtitle_image(int node)
 	}
 	else
 	{
-		x_pos = fl2i(gr_screen.center_w * (xy_input[0] / 100.0f));
-		y_pos = fl2i(gr_screen.center_h * (xy_input[1] / 100.0f));
-		width = fl2i(gr_screen.center_w * (width_input / 100.0f));
-		height = fl2i(gr_screen.center_h * (height_input / 100.0f));
+		int screen_w, screen_h;
+		get_subtitle_screen_size(screen_w, screen_h);
+
+		x_pos = fl2i(screen_w * (xy_input[0] / 100.0f));
+		y_pos = fl2i(screen_h * (xy_input[1] / 100.0f));
+		width = fl2i(screen_w * (width_input / 100.0f));
+		height = fl2i(screen_h * (height_input / 100.0f));
 	}
 
 	// add the subtitle
@@ -23046,10 +23072,13 @@ void multi_sexp_show_subtitle_image()
 	}
 	else
 	{
-		x_pos = fl2i(gr_screen.center_w * (xy_input[0] / 100.0f));
-		y_pos = fl2i(gr_screen.center_h * (xy_input[1] / 100.0f));
-		width = fl2i(gr_screen.center_w * (width_input / 100.0f));
-		height = fl2i(gr_screen.center_h * (height_input / 100.0f));
+		int screen_w, screen_h;
+		get_subtitle_screen_size(screen_w, screen_h);
+
+		x_pos = fl2i(screen_w * (xy_input[0] / 100.0f));
+		y_pos = fl2i(screen_h * (xy_input[1] / 100.0f));
+		width = fl2i(screen_w * (width_input / 100.0f));
+		height = fl2i(screen_h * (height_input / 100.0f));
 	}
 
 	// add the subtitle
@@ -35603,7 +35632,8 @@ SCP_vector<sexp_help_struct> Sexp_help = {
 
 	{ OP_CUTSCENES_SHOW_SUBTITLE_TEXT, "show-subtitle-text\r\n"
 		"\tDisplays a subtitle in the form of text.  Note that because of the constraints of the subtitle system, textual subtitles are currently limited to 255 characters or fewer.\r\n\r\n"
-		"Certain arguments can be specified in a percentage of the screen or an absolute number of pixels.  This is controlled by the '$Show-subtitle uses pixels' game_settings.tbl option.\r\n\r\n"
+		"Certain arguments can be specified in a percentage of the screen or an absolute number of pixels.  This is controlled by the '$Show-subtitle uses pixels' game_settings.tbl option.  "
+		"Whether percentages or pixels, the subtitle can be configured to scale according to screen resolution via the '$Show-subtitle base resolution' option.\r\n\r\n"
 		"Takes 6 to 14 arguments...\r\n"
 		"\t1:\tText to display, or the name of a message containing text\r\n"
 		"\t2:\tX position (percentage/pixels) - positive measures from the left; negative measures from the right\r\n"
@@ -35623,7 +35653,8 @@ SCP_vector<sexp_help_struct> Sexp_help = {
 
 	{ OP_CUTSCENES_SHOW_SUBTITLE_IMAGE, "show-subtitle-image\r\n"
 		"\tDisplays a subtitle in the form of an image.  Please note that, in images without an alpha channel, black pixels will be treated as transparent.  In images with an alpha channel, black pixels will be drawn as expected.\r\n\r\n"
-		"Certain arguments can be specified in a percentage of the screen or an absolute number of pixels.  This is controlled by the '$Show-subtitle uses pixels' game_settings.tbl option.\r\n\r\n"
+		"Certain arguments can be specified in a percentage of the screen or an absolute number of pixels.  This is controlled by the '$Show-subtitle uses pixels' game_settings.tbl option.  "
+		"Whether percentages or pixels, the subtitle can be configured to scale according to screen resolution via the '$Show-subtitle base resolution' option.\r\n\r\n"
 		"Takes 8 to 10 arguments...\r\n"
 		"\t1:\tImage to display\r\n"
 		"\t2:\tX position (percentage/pixels) - positive measures from the left; negative measures from the right\r\n"

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -1998,6 +1998,8 @@ void game_init()
 		libs::discord::init();
 	}
 
+	mod_table_post_process();
+
 	nprintf(("General", "Ships.tbl is : %s\n", Game_ships_tbl_valid ? "VALID" : "INVALID!!!!"));
 	nprintf(("General", "Weapons.tbl is : %s\n", Game_weapons_tbl_valid ? "VALID" : "INVALID!!!!"));
 


### PR DESCRIPTION
By specifying a base resolution in game_settings.tbl, subtitles can be scaled to the screen in the same way as HUD gauges.  This can be used to prevent subtitles from appearing smaller at larger resolutions.

Depends on and is a follow-up to https://github.com/scp-fs2open/fs2open.github.com/pull/4157.