### PR TITLE
Increase POF vertex limit

### DIFF
--- a/code/model/model.h
+++ b/code/model/model.h
@@ -235,12 +235,27 @@ typedef struct model_special {
 
 #define MAX_LIVE_DEBRIS	7
 
+/**
+* @struct model_tmap_vert
+* @brief Struct to hold vertex information for a polygon
+* 
+*/
 typedef struct model_tmap_vert {
-	uint vertnum;
-	uint normnum;
-	float u,v;
+	uint vertnum;	//!< Vertex index into a subobject vertex buffer.
+	uint normnum;	//!< Normal index into a subobject normal buffer.
+	float u;        //!< Horizontal texture coordinate for the vertex.
+	float v;		//!< Vertical texture coordinate for the vertex.
 } model_tmap_vert;
 
+/*
+ * @brief Helper function to correctly convert the chunk data from TMAPPOLY to 
+ *		  model_tmap_vert.
+ * 
+ * @param[in] vs Vertex data for the parsed TMAP
+ * @param[out] verts Converted vertex data
+ * @param n_vert Number of vertices in the chunk
+ * 
+**/
 void unpack_tmap_verts(const ubyte* vs, model_tmap_vert* verts, uint n_vert);
 
 struct bsp_collision_node {

--- a/code/model/model.h
+++ b/code/model/model.h
@@ -254,9 +254,7 @@ struct bsp_collision_node {
 };
 
 struct bsp_collision_leaf {
-	vec3d plane_pnt;
 	vec3d plane_norm;
-	float face_rad;
 	int vert_start;
 	ubyte num_verts;
 	ubyte tmap_num;

--- a/code/model/model.h
+++ b/code/model/model.h
@@ -236,10 +236,12 @@ typedef struct model_special {
 #define MAX_LIVE_DEBRIS	7
 
 typedef struct model_tmap_vert {
-	ushort vertnum;
-	ushort normnum;
+	uint vertnum;
+	uint normnum;
 	float u,v;
 } model_tmap_vert;
+
+void unpack_tmap_verts(const ubyte* vs, model_tmap_vert* verts, uint n_vert);
 
 struct bsp_collision_node {
 	vec3d min;
@@ -1322,7 +1324,7 @@ void model_draw_bay_paths_htl(int model_num);
 bool model_interp_config_buffer(indexed_vertex_source *vert_src, vertex_buffer *vb, bool update_ibuffer_only);
 bool model_interp_pack_buffer(indexed_vertex_source *vert_src, vertex_buffer *vb);
 void model_interp_submit_buffers(indexed_vertex_source *vert_src, size_t vertex_stride);
-void model_allocate_interp_data(int n_verts = 0, int n_norms = 0);
+void model_allocate_interp_data(uint n_verts = 0, uint n_norms = 0);
 
 void glowpoint_init();
 SCP_vector<glow_point_bank_override>::iterator get_glowpoint_bank_override_by_name(const char* name);

--- a/code/model/modelcollide.cpp
+++ b/code/model/modelcollide.cpp
@@ -501,11 +501,15 @@ void model_collide_tmappoly(ubyte * p)
 void model_collide_tmap2poly(ubyte* p) {
 	uint i;
 	uint nv;
+	int tmap_num; 
 	uv_pair uvlist[TMAP_MAX_VERTS];
 	vec3d* points[TMAP_MAX_VERTS];
 	model_tmap_vert* verts;
 
-	Assert(Mc_pm->version >= 2300);
+	if (Mc_pm->version < 2300) {
+		Error(LOCATION, "Model contains TMAP2 chunk but version is less than minimum supported!");
+		return;
+	}
 
 	nv = uw(p + 20);
 
@@ -517,7 +521,7 @@ void model_collide_tmap2poly(ubyte* p) {
 		return;
 	}
 
-	int tmap_num = w(p + 24);
+	tmap_num = w(p + 24);
 	if (tmap_num < 0 || tmap_num >= MAX_MODEL_TEXTURES) { // Goober5000
 		Error(LOCATION, "Model contains TMAP2 chunk with invalid texture id (%d)!", tmap_num);
 		return;
@@ -617,8 +621,7 @@ int model_collide_sub(void *model_ptr )
 			break;
 		case OP_TMAP2POLY:		model_collide_tmap2poly(p); break;
 		default:
-			mprintf(( "Bad chunk type %d, len=%d in model_collide_sub\n", chunk_type, chunk_size ));
-			Int3();		// Bad chunk type!
+			UNREACHABLE("Bad chunk type %d, len=%d in model_collide_sub\n", chunk_type, chunk_size);
 			return 0;
 		}
 		p += chunk_size;
@@ -748,6 +751,8 @@ void model_collide_parse_bsp_tmap2poly(bsp_collision_leaf* leaf, SCP_vector<mode
 
 	uint i;
 	uint nv;
+	int tmap_num;
+	vec3d* plane_norm;
 	model_tmap_vert* verts;
 
 	nv = uw(p + 20);
@@ -757,7 +762,7 @@ void model_collide_parse_bsp_tmap2poly(bsp_collision_leaf* leaf, SCP_vector<mode
 		return;
 	}
 
-	int tmap_num = w(p + 24);
+	tmap_num = w(p + 24);
 
 	if (tmap_num < 0 || tmap_num >= MAX_MODEL_TEXTURES) {
 		Error(LOCATION, "Model contains TMAP2 chunk with invalid texture id (%d)!", tmap_num);
@@ -770,7 +775,7 @@ void model_collide_parse_bsp_tmap2poly(bsp_collision_leaf* leaf, SCP_vector<mode
 	leaf->num_verts = (ubyte)nv;
 	leaf->vert_start = (int)vert_buffer->size();
 
-	vec3d* plane_norm = vp(p + 8);
+	plane_norm = vp(p + 8);
 
 	leaf->plane_norm = *plane_norm;
 

--- a/code/model/modelcollide.cpp
+++ b/code/model/modelcollide.cpp
@@ -513,12 +513,15 @@ void model_collide_tmap2poly(ubyte* p) {
 		return;
 
 	if (nv > TMAP_MAX_VERTS) {
-		Int3();
+		Error(LOCATION, "Model contains TMAP2 chunk with more than %d vertices!", TMAP_MAX_VERTS);
 		return;
 	}
 
 	int tmap_num = w(p + 24);
-	Assert(tmap_num >= 0 && tmap_num < MAX_MODEL_TEXTURES); // Goober5000
+	if (tmap_num < 0 || tmap_num >= MAX_MODEL_TEXTURES) { // Goober5000
+		Error(LOCATION, "Model contains TMAP2 chunk with invalid texture id (%d)!", tmap_num);
+		return;
+	}
 
 	if ((!(Mc->flags & MC_CHECK_INVISIBLE_FACES)) && (Mc_pm->maps[tmap_num].textures[TM_BASE_TYPE].GetTexture() < 0)) {
 		// Don't check invisible polygons.
@@ -750,13 +753,16 @@ void model_collide_parse_bsp_tmap2poly(bsp_collision_leaf* leaf, SCP_vector<mode
 	nv = uw(p + 20);
 
 	if (nv > TMAP_MAX_VERTS) {
-		Int3();
+		Error(LOCATION,"Model contains TMAP2 chunk with more than %d vertices!", TMAP_MAX_VERTS);
 		return;
 	}
 
 	int tmap_num = w(p + 24);
 
-	Assert(tmap_num >= 0 && tmap_num < MAX_MODEL_TEXTURES);
+	if (tmap_num < 0 || tmap_num >= MAX_MODEL_TEXTURES) {
+		Error(LOCATION, "Model contains TMAP2 chunk with invalid texture id (%d)!", tmap_num);
+		return;
+	}
 
 	verts = (model_tmap_vert*)(p + 28);
 

--- a/code/model/modelcollide.cpp
+++ b/code/model/modelcollide.cpp
@@ -536,9 +536,9 @@ void model_collide_tmap2poly(ubyte* p) {
 	}
 
 	if (Mc->flags & MC_CHECK_SPHERELINE) {
-		mc_check_sphereline_face(nv, points, points[0], vp(p + 8), uvlist, tmap_num, p, NULL);
+		mc_check_sphereline_face(nv, points, points[0], vp(p + 8), uvlist, tmap_num, p, nullptr);
 	} else {
-		mc_check_face(nv, points, points[0], vp(p + 8), uvlist, tmap_num, p, NULL);
+		mc_check_face(nv, points, points[0], vp(p + 8), uvlist, tmap_num, p, nullptr);
 	}
 }
 
@@ -661,15 +661,15 @@ void model_collide_bsp_poly(bsp_collision_tree *tree, int leaf_index)
 
 		if ( flat_poly ) {
 			if ( Mc->flags & MC_CHECK_SPHERELINE ) {
-				mc_check_sphereline_face(nv, points, points[0], &leaf->plane_norm, NULL, -1, NULL, leaf);
+				mc_check_sphereline_face(nv, points, points[0], &leaf->plane_norm, nullptr, -1, nullptr, leaf);
 			} else {
-				mc_check_face(nv, points, points[0], &leaf->plane_norm, NULL, -1, NULL, leaf);
+				mc_check_face(nv, points, points[0], &leaf->plane_norm, nullptr, -1, nullptr, leaf);
 			}
 		} else {
 			if ( Mc->flags & MC_CHECK_SPHERELINE ) {
-				mc_check_sphereline_face(nv, points, points[0], &leaf->plane_norm, uvlist, leaf->tmap_num, NULL, leaf);
+				mc_check_sphereline_face(nv, points, points[0], &leaf->plane_norm, uvlist, leaf->tmap_num, nullptr, leaf);
 			} else {
-				mc_check_face(nv, points, points[0], &leaf->plane_norm, uvlist, leaf->tmap_num, NULL, leaf);
+				mc_check_face(nv, points, points[0], &leaf->plane_norm, uvlist, leaf->tmap_num, nullptr, leaf);
 			}
 		}
 
@@ -741,7 +741,7 @@ void model_collide_parse_bsp_tmappoly(bsp_collision_leaf *leaf, SCP_vector<model
 
 void model_collide_parse_bsp_tmap2poly(bsp_collision_leaf* leaf, SCP_vector<model_tmap_vert>* vert_buffer, void* model_ptr)
 {
-	ubyte* p = (ubyte*)model_ptr;
+	auto p = (ubyte*)model_ptr;
 
 	uint i;
 	uint nv;

--- a/code/model/modelcollide.cpp
+++ b/code/model/modelcollide.cpp
@@ -513,11 +513,8 @@ void model_collide_tmap2poly(ubyte* p) {
 
 	nv = uw(p + 20);
 
-	if (nv <= 0)
-		return;
-
-	if (nv > TMAP_MAX_VERTS) {
-		Error(LOCATION, "Model contains TMAP2 chunk with more than %d vertices!", TMAP_MAX_VERTS);
+	if (nv == 0 || nv > TMAP_MAX_VERTS) {
+		Error(LOCATION, "Model contains TMAP2 chunk with invalid number of vertices (n_vert=%d)!", nv);
 		return;
 	}
 
@@ -534,7 +531,7 @@ void model_collide_tmap2poly(ubyte* p) {
 			return;
 	}
 
-	verts = (model_tmap_vert*)(p + 28);
+	verts = reinterpret_cast<model_tmap_vert*>(&p[28]);
 
 	for (i = 0; i < nv; i++) {
 		points[i] = Mc_point_list[verts[i].vertnum];
@@ -745,6 +742,13 @@ void model_collide_parse_bsp_tmappoly(bsp_collision_leaf *leaf, SCP_vector<model
 	}
 }
 
+/**
+* @brief Generates BSP leaf and vertex buffer to check against a bsp collision for a TMAP2 chunk.
+* 
+* @param[out] leaf Generated BSP leaf.
+* @param[out] vert_buffer Vertex buffer forming the polygon being checked against.
+* @param[in] model_ptr Buffer of BSP data from model buffer.
+*/
 void model_collide_parse_bsp_tmap2poly(bsp_collision_leaf* leaf, SCP_vector<model_tmap_vert>* vert_buffer, void* model_ptr)
 {
 	auto p = (ubyte*)model_ptr;

--- a/code/model/modelcollide.cpp
+++ b/code/model/modelcollide.cpp
@@ -406,12 +406,12 @@ int model_collide_parse_bsp_defpoints(ubyte * p)
 // +44     nverts*int  vertlist
 void model_collide_flatpoly(ubyte * p)
 {
-	int i;
-	int nv;
+	uint i;
+	uint nv;
 	vec3d *points[TMAP_MAX_VERTS];
 	short *verts;
 
-	nv = w(p+36);
+	nv = uw(p+36);
 
 	if ( nv <= 0 )
 		return;

--- a/code/model/modelcollide.cpp
+++ b/code/model/modelcollide.cpp
@@ -712,8 +712,6 @@ void model_collide_parse_bsp_tmappoly(bsp_collision_leaf *leaf, SCP_vector<model
 
 	nv = uw(p+36);
 
-	if ( nv < 0 ) return;
-
 	if ( nv > TMAP_MAX_VERTS ) {
 		Int3();
 		return;
@@ -749,12 +747,7 @@ void model_collide_parse_bsp_tmap2poly(bsp_collision_leaf* leaf, SCP_vector<mode
 	uint nv;
 	model_tmap_vert* verts;
 
-	//Assert(Mc_pm->version >= 2300);
-
 	nv = uw(p + 20);
-
-	if (nv < 0)
-		return;
 
 	if (nv > TMAP_MAX_VERTS) {
 		Int3();
@@ -789,8 +782,6 @@ void model_collide_parse_bsp_flatpoly(bsp_collision_leaf *leaf, SCP_vector<model
 	short *verts;
 
 	nv = uw(p+36);
-
-	if ( nv < 0 ) return;
 
 	if ( nv > TMAP_MAX_VERTS ) {
 		Int3();

--- a/code/model/modelinterp.cpp
+++ b/code/model/modelinterp.cpp
@@ -131,12 +131,12 @@ struct interp_vertex {
 // Local variables
 //
 
-static int Num_interp_verts_allocated = 0;
+static uint Num_interp_verts_allocated = 0;
 vec3d **Interp_verts = NULL;
 static vertex *Interp_points = NULL;
 static vertex *Interp_splode_points = NULL;
 vec3d *Interp_splode_verts = NULL;
-static int Interp_num_verts = 0;
+static uint Interp_num_verts = 0;
 
 static float Interp_box_scale = 1.0f; // this is used to scale both detail boxes and spheres
 
@@ -153,10 +153,10 @@ int Interp_saved_lighting_full = 0;
 // -------------------------------------------------------------------
 
 
-static int Num_interp_norms_allocated = 0;
+static uint Num_interp_norms_allocated = 0;
 static vec3d **Interp_norms = NULL;
 static ubyte *Interp_light_applied = NULL;
-static int Interp_num_norms = 0;
+static uint Interp_num_norms = 0;
 static ubyte *Interp_lights;
 
 // Stuff to control rendering parameters
@@ -260,7 +260,6 @@ void model_allocate_interp_data(uint n_verts, uint n_norms)
 		dealloc = 1;
 	}
 
-	Assert( (n_verts >= 0) && (n_norms >= 0) );
 	Assert( (n_verts || Num_interp_verts_allocated) && (n_norms || Num_interp_norms_allocated) );
 
 	if (n_verts > Num_interp_verts_allocated) {
@@ -1927,7 +1926,7 @@ void find_tmap(int offset, ubyte *bsp_data, int id)
 
 void find_defpoint(int off, ubyte *bsp_data)
 {
-	int n;
+	uint n;
 	uint nverts = uw(off+bsp_data+8);	
 
 	ubyte * normcount = off+bsp_data+20;

--- a/code/model/modelinterp.cpp
+++ b/code/model/modelinterp.cpp
@@ -1780,6 +1780,12 @@ void parse_tmap(int offset, ubyte *bsp_data)
 	Parse_normal_problem_count += problem_count;
 }
 
+/**
+* @brief Parses a TMAP2POLY chunk into a list of polygons.
+* 
+* @param offset The byte offset to the current TMAP2POLY chunk within bsp_data.
+* @param[in] bsp_data The byte buffer containing the BSP information for the current model.
+*/
 void parse_tmap2(int offset, ubyte* bsp_data)
 {
 	int pof_tex = w(bsp_data + offset + 24);
@@ -1788,25 +1794,25 @@ void parse_tmap2(int offset, ubyte* bsp_data)
 	ubyte* p = &bsp_data[offset + 8];
 	model_tmap_vert* tverts;
 
-	tverts = (model_tmap_vert*)&bsp_data[offset + 28];
-
 	vertex* V;
 	vec3d* v;
 	vec3d* N;
 
 	int problem_count = 0;
 
+	tverts = (model_tmap_vert*)&bsp_data[offset + 28];
+
 	for (uint i = 1; i < (n_vert - 1); i++) {
 		V = &polygon_list[pof_tex].vert[(polygon_list[pof_tex].n_verts)];
 		N = &polygon_list[pof_tex].norm[(polygon_list[pof_tex].n_verts)];
-		v = Interp_verts[(int)tverts[0].vertnum];
+		v = Interp_verts[tverts[0].vertnum];
 		V->world.xyz.x = v->xyz.x;
 		V->world.xyz.y = v->xyz.y;
 		V->world.xyz.z = v->xyz.z;
 		V->texture_position.u = tverts[0].u;
 		V->texture_position.v = tverts[0].v;
 
-		*N = *Interp_norms[(int)tverts[0].normnum];
+		*N = *Interp_norms[tverts[0].normnum];
 
 		if (IS_VEC_NULL(N))
 			*N = *vp(p);
@@ -1816,14 +1822,14 @@ void parse_tmap2(int offset, ubyte* bsp_data)
 
 		V = &polygon_list[pof_tex].vert[(polygon_list[pof_tex].n_verts) + 1];
 		N = &polygon_list[pof_tex].norm[(polygon_list[pof_tex].n_verts) + 1];
-		v = Interp_verts[(int)tverts[i].vertnum];
+		v = Interp_verts[tverts[i].vertnum];
 		V->world.xyz.x = v->xyz.x;
 		V->world.xyz.y = v->xyz.y;
 		V->world.xyz.z = v->xyz.z;
 		V->texture_position.u = tverts[i].u;
 		V->texture_position.v = tverts[i].v;
 
-		*N = *Interp_norms[(int)tverts[i].normnum];
+		*N = *Interp_norms[tverts[i].normnum];
 
 		if (IS_VEC_NULL(N))
 			*N = *vp(p);
@@ -1833,14 +1839,14 @@ void parse_tmap2(int offset, ubyte* bsp_data)
 
 		V = &polygon_list[pof_tex].vert[(polygon_list[pof_tex].n_verts) + 2];
 		N = &polygon_list[pof_tex].norm[(polygon_list[pof_tex].n_verts) + 2];
-		v = Interp_verts[(int)tverts[i + 1].vertnum];
+		v = Interp_verts[tverts[i + 1].vertnum];
 		V->world.xyz.x = v->xyz.x;
 		V->world.xyz.y = v->xyz.y;
 		V->world.xyz.z = v->xyz.z;
 		V->texture_position.u = tverts[i + 1].u;
 		V->texture_position.v = tverts[i + 1].v;
 
-		*N = *Interp_norms[(int)tverts[i + 1].normnum];
+		*N = *Interp_norms[tverts[i + 1].normnum];
 
 		if (IS_VEC_NULL(N))
 			*N = *vp(p);
@@ -3112,26 +3118,29 @@ void bsp_polygon_data::process_tmap(int offset, ubyte* bsp_data)
 	Parse_normal_problem_count += problem_count;
 }
 
+/**
+* @brief Converts a TMAP2POLY chunk into a list of BSP_polygon.
+* 
+* @param offset The byte offset into bsp_data.
+* @param[in] The buffer containing the chunk data.
+*/
 void bsp_polygon_data::process_tmap2(int offset, ubyte* bsp_data)
 {
 	int pof_tex = w(bsp_data + offset + 24);
 	uint n_vert = uw(bsp_data + offset + 20);
+	ubyte* p = &bsp_data[offset + 8];
+	model_tmap_vert* tverts;
+	int problem_count = 0;
+	bsp_polygon polygon;
 
 	if (n_vert < 3) {
 		Error(LOCATION, "Model contains TMAP2 chunk with less than 3 vertices!");
 		return;
 	}
 
-	ubyte* p = &bsp_data[offset + 8];
-	model_tmap_vert* tverts;
-
 	tverts = (model_tmap_vert*)&bsp_data[offset + 28];
 
-	int problem_count = 0;
-
 	// make a polygon
-	bsp_polygon polygon;
-
 	polygon.Start_index = (uint)Polygon_vertices.size();
 	polygon.Num_verts = n_vert;
 	polygon.texture = pof_tex;

--- a/code/model/modelinterp.cpp
+++ b/code/model/modelinterp.cpp
@@ -1711,7 +1711,7 @@ void parse_tmap(int offset, ubyte *bsp_data)
 	uint n_vert = uw(bsp_data+offset+36);
 	
 	ubyte *p = &bsp_data[offset+8];
-	model_tmap_vert* tverts = new model_tmap_vert[n_vert];
+	auto tverts = new model_tmap_vert[n_vert];
 
 	// Copy the verts manually since they aren't aligned with the struct
 	unpack_tmap_verts(&bsp_data[offset + 44], tverts, n_vert);
@@ -1916,7 +1916,7 @@ void parse_sortnorm(int offset, ubyte *bsp_data)
 	if (postlist) parse_bsp(offset+postlist, bsp_data);
 }
 
-void find_tmap(int offset, ubyte *bsp_data, int id)
+void find_tmap(int offset, const ubyte *bsp_data, int id)
 {
 	int pof_tex = w(bsp_data+offset+(id == OP_TMAP2POLY ? 24 : 40));
 	uint n_vert = uw(bsp_data+offset+ (id == OP_TMAP2POLY ? 20 : 36));
@@ -3067,7 +3067,7 @@ void bsp_polygon_data::process_tmap(int offset, ubyte* bsp_data)
 	}
 
 	ubyte *p = &bsp_data[offset + 8];
-	model_tmap_vert* tverts = new model_tmap_vert[n_vert];
+	auto tverts = new model_tmap_vert[n_vert];
 
 	// Copy the verts manually since they aren't aligned with the struct
 	unpack_tmap_verts(&bsp_data[offset + 44], tverts, n_vert);

--- a/code/model/modelinterp.cpp
+++ b/code/model/modelinterp.cpp
@@ -1783,13 +1783,13 @@ void parse_tmap(int offset, ubyte *bsp_data)
 
 void parse_tmap2(int offset, ubyte* bsp_data)
 {
-	int pof_tex = w(bsp_data + offset + 40);
-	uint n_vert = uw(bsp_data + offset + 36);
+	int pof_tex = w(bsp_data + offset + 24);
+	uint n_vert = uw(bsp_data + offset + 20);
 
 	ubyte* p = &bsp_data[offset + 8];
 	model_tmap_vert* tverts;
 
-	tverts = (model_tmap_vert*)&bsp_data[offset + 44];
+	tverts = (model_tmap_vert*)&bsp_data[offset + 28];
 
 	vertex* V;
 	vec3d* v;
@@ -1917,10 +1917,10 @@ void parse_sortnorm(int offset, ubyte *bsp_data)
 	if (postlist) parse_bsp(offset+postlist, bsp_data);
 }
 
-void find_tmap(int offset, ubyte *bsp_data)
+void find_tmap(int offset, ubyte *bsp_data, int id)
 {
-	int pof_tex = w(bsp_data+offset+40);
-	uint n_vert = uw(bsp_data+offset+36);
+	int pof_tex = w(bsp_data+offset+(id == OP_TMAP2POLY ? 24 : 40));
+	uint n_vert = uw(bsp_data+offset+ (id == OP_TMAP2POLY ? 20 : 36));
 
 	tri_count[pof_tex] += n_vert-2;	
 }
@@ -1973,7 +1973,7 @@ void find_tri_counts(int offset, ubyte *bsp_data)
 
 			case OP_TMAPPOLY:
 			case OP_TMAP2POLY:
-				find_tmap(offset, bsp_data);
+				find_tmap(offset, bsp_data, id);
 				break;
 
 			case OP_BOUNDBOX:
@@ -3115,8 +3115,8 @@ void bsp_polygon_data::process_tmap(int offset, ubyte* bsp_data)
 
 void bsp_polygon_data::process_tmap2(int offset, ubyte* bsp_data)
 {
-	int pof_tex = w(bsp_data + offset + 40);
-	uint n_vert = uw(bsp_data + offset + 36);
+	int pof_tex = w(bsp_data + offset + 24);
+	uint n_vert = uw(bsp_data + offset + 20);
 
 	if (n_vert < 3) {
 		// don't parse degenerate polygons
@@ -3126,7 +3126,7 @@ void bsp_polygon_data::process_tmap2(int offset, ubyte* bsp_data)
 	ubyte* p = &bsp_data[offset + 8];
 	model_tmap_vert* tverts;
 
-	tverts = (model_tmap_vert*)&bsp_data[offset + 44];
+	tverts = (model_tmap_vert*)&bsp_data[offset + 28];
 
 	int problem_count = 0;
 

--- a/code/model/modelinterp.cpp
+++ b/code/model/modelinterp.cpp
@@ -3118,7 +3118,7 @@ void bsp_polygon_data::process_tmap2(int offset, ubyte* bsp_data)
 	uint n_vert = uw(bsp_data + offset + 20);
 
 	if (n_vert < 3) {
-		// don't parse degenerate polygons
+		Error(LOCATION, "Model contains TMAP2 chunk with less than 3 vertices!");
 		return;
 	}
 

--- a/code/model/modeloctant.cpp
+++ b/code/model/modeloctant.cpp
@@ -90,10 +90,10 @@ void model_octant_find_shields( polymodel * pm, model_octant * oct )
     
 void moff_defpoints(ubyte * p, int just_count)
 {
-	int n;
-	int nverts = w(p+8);	
-	int offset = w(p+16);
-	int nnorms = 0;
+	uint n;
+	uint nverts = uw(p+8);	
+	uint offset = uw(p+16);
+	uint nnorms = 0;
 
 	// if we are just counting then we don't need to be here
 	if (just_count)
@@ -128,16 +128,19 @@ void moff_defpoints(ubyte * p, int just_count)
 // +32     float      radius
 // +36     int         nverts
 // +40     int         tmap_num
-// +44     nverts*(model_tmap_vert) vertlist (n,u,v)
+// +44     nverts*(model_tmap_vert-4) vertlist (n,u,v)
 void moff_tmappoly(ubyte * p, polymodel * pm, model_octant * oct, int just_count )
 {
-	int i, nv;
+	uint i, nv;
 	model_tmap_vert *verts;
 
-	nv = w(p+36);
+	nv = uw(p+36);
 	if ( nv < 0 ) return;
 
-	verts = (model_tmap_vert *)(p+44);
+	verts = new model_tmap_vert[nv];
+
+	// Copy the verts manually since they aren't aligned with the struct
+	unpack_tmap_verts(&p[44], verts, nv);
 
 	if ( (pm->version < 2003) && !just_count )	{
 		// Set the "normal_point" part of field to be the center of the polygon
@@ -178,6 +181,39 @@ void moff_tmappoly(ubyte * p, polymodel * pm, model_octant * oct, int just_count
 }
 
 
+// Textured Poly
+// +0      int         id
+// +4      int         size
+// +8      vec3d      normal
+// +20     vec3d      center
+// +32     float      radius
+// +36     int         nverts
+// +40     int         tmap_num
+// +44     nverts*(model_tmap_vert) vertlist (n,u,v)
+void moff_tmap2poly(ubyte* p, polymodel* pm, model_octant* oct, int just_count)
+{
+	Assert(pm->version >= 2300);
+
+	uint i, nv;
+	model_tmap_vert* verts;
+
+	nv = uw(p + 36);
+	if (nv < 0)
+		return;
+
+	verts = (model_tmap_vert*)(p + 44);
+
+	// Put each face into a particular octant
+	if (point_in_octant(pm, oct, vp(p + 20))) {
+		if (just_count)
+			oct->nverts++;
+		else
+			oct->verts[oct->nverts++] = vp(p + 20);
+		return;
+	}
+}
+
+
 // Flat Poly
 // +0      int         id
 // +4      int         size 
@@ -192,10 +228,10 @@ void moff_tmappoly(ubyte * p, polymodel * pm, model_octant * oct, int just_count
 // +44     nverts*int  vertlist
 void moff_flatpoly(ubyte * p, polymodel * pm, model_octant * oct, int just_count )
 {
-	int i, nv;
+	uint i, nv;
 	short *verts;
 
-	nv = w(p+36);
+	nv = uw(p+36);
 	if ( nv < 0 ) return;
 
 	verts = (short *)(p+44);
@@ -270,6 +306,7 @@ int model_octant_find_faces_sub(polymodel * pm, model_octant * oct, void *model_
 			}
 			break;
 		case OP_BOUNDBOX:		break;
+		case OP_TMAP2POLY:		moff_tmap2poly(p, pm, oct, just_count); break;
 		default:
 			mprintf(( "Bad chunk type %d, len=%d in model_octant_find_faces_sub\n", chunk_type, chunk_size ));
 			Int3();		// Bad chunk type!

--- a/code/model/modeloctant.cpp
+++ b/code/model/modeloctant.cpp
@@ -146,7 +146,7 @@ void moff_tmappoly(ubyte * p, polymodel * pm, model_octant * oct, int just_count
 		vec3d center_point;
 		vm_vec_zero( &center_point );
 
-		Assert( Interp_verts != NULL );
+		Assert( Interp_verts != nullptr );
 
 		for (i=0;i<nv;i++)	{
 			vm_vec_add2( &center_point, Interp_verts[verts[i].vertnum] );
@@ -201,7 +201,7 @@ void moff_tmap2poly(ubyte* p, polymodel* pm, model_octant* oct, int just_count)
 	vec3d center_point;
 	vm_vec_zero(&center_point);
 
-	Assert(Interp_verts != NULL);
+	Assert(Interp_verts != nullptr);
 
 	for (i = 0; i < nv; i++) {
 		vm_vec_add2(&center_point, Interp_verts[verts[i].vertnum]);

--- a/code/model/modeloctant.cpp
+++ b/code/model/modeloctant.cpp
@@ -135,7 +135,6 @@ void moff_tmappoly(ubyte * p, polymodel * pm, model_octant * oct, int just_count
 	model_tmap_vert *verts;
 
 	nv = uw(p+36);
-	if ( nv < 0 ) return;
 
 	verts = new model_tmap_vert[nv];
 
@@ -196,8 +195,6 @@ void moff_tmap2poly(ubyte* p, polymodel* pm, model_octant* oct, int just_count)
 	model_tmap_vert* verts;
 
 	nv = uw(p + 20);
-	if (nv < 0)
-		return;
 
 	verts = (model_tmap_vert*)(p + 28);
 
@@ -243,7 +240,6 @@ void moff_flatpoly(ubyte * p, polymodel * pm, model_octant * oct, int just_count
 	short *verts;
 
 	nv = uw(p+36);
-	if ( nv < 0 ) return;
 
 	verts = (short *)(p+44);
 

--- a/code/model/modelread.cpp
+++ b/code/model/modelread.cpp
@@ -82,6 +82,8 @@ static uint Global_checksum = 0;
 // compatible.  
 #define PM_OBJFILE_MAJOR_VERSION 30
 
+// 23.00 adds support for increased subobject vertex limit via TMAP2POLY
+// 
 // 22.01 adds support for external weapon model angle offsets
 // 22.00 fixes the POF byte alignment and introduces the SLC2 chunk
 //
@@ -90,7 +92,7 @@ static uint Global_checksum = 0;
 // FreeSpace 2 shipped at POF version 21.17
 // Descent: FreeSpace shipped at POF version 20.14
 // See also https://wiki.hard-light.net/index.php/POF_data_structure
-#define PM_LATEST_ALIGNED_VERSION	2201
+#define PM_LATEST_ALIGNED_VERSION	2300
 #define PM_LATEST_LEGACY_VERSION	2118
 #define PM_FIRST_ALIGNED_VERSION	2200
 

--- a/code/model/modelread.cpp
+++ b/code/model/modelread.cpp
@@ -95,6 +95,7 @@ static uint Global_checksum = 0;
 #define PM_LATEST_ALIGNED_VERSION	2300
 #define PM_LATEST_LEGACY_VERSION	2118
 #define PM_FIRST_ALIGNED_VERSION	2200
+#define PM_FIRST_VERTLIM_VERSION	2300
 
 static int Model_signature = 0;
 
@@ -4993,9 +4994,6 @@ void swap_bsp_tmap2poly(polymodel* pm, ubyte* p)
 	int tmap_num = INTEL_INT(w(p + 40)); // tigital
 	w(p + 40) = tmap_num;
 
-	if (nv < 0)
-		return;
-
 	verts = (model_tmap_vert*)(p + 44);
 	for (i = 0; i < nv; i++) {
 		verts[i].vertnum = INTEL_SHORT(verts[i].vertnum);
@@ -5169,6 +5167,9 @@ void swap_bsp_data( polymodel * pm, void * model_ptr )
 				max->xyz.x = INTEL_FLOAT( &max->xyz.x );
 				max->xyz.y = INTEL_FLOAT( &max->xyz.y );
 				max->xyz.z = INTEL_FLOAT( &max->xyz.z );
+				break;
+			case OP_TMAPPOLY:
+				swap_bsp_tmap2poly(pm, p);
 				break;
 			default:
 				mprintf(( "Bad chunk type %d, len=%d in modelread:swap_bsp_data\n", chunk_type, chunk_size ));

--- a/code/model/modelsinc.h
+++ b/code/model/modelsinc.h
@@ -10,6 +10,7 @@
 #ifndef _MODELSINC_H
 #define _MODELSINC_H
 
+#include "globalincs/pstypes.h"
 
 class polymodel;
 

--- a/code/model/modelsinc.h
+++ b/code/model/modelsinc.h
@@ -73,7 +73,7 @@ class polymodel;
 #define vp(p)	((vec3d *) (p))
 #define fl(p)	(*((float *) (p)))
 
-extern int model_interp(matrix * orient, ubyte * data, polymodel * pm );
+//extern int model_interp(matrix * orient, ubyte * data, polymodel * pm );
 
 // Creates the octants for a given polygon model
 void model_octant_create( polymodel * pm );

--- a/code/model/modelsinc.h
+++ b/code/model/modelsinc.h
@@ -74,8 +74,6 @@ class polymodel;
 #define vp(p)	((vec3d *) (p))
 #define fl(p)	(*((float *) (p)))
 
-//extern int model_interp(matrix * orient, ubyte * data, polymodel * pm );
-
 // Creates the octants for a given polygon model
 void model_octant_create( polymodel * pm );
 

--- a/code/model/modelsinc.h
+++ b/code/model/modelsinc.h
@@ -23,6 +23,7 @@ class polymodel;
 #define OP_TMAPPOLY		3
 #define OP_SORTNORM		4
 #define OP_BOUNDBOX		5
+#define OP_TMAP2POLY	6
 
 // change header for freespace2
 //#define FREESPACE1_FORMAT
@@ -65,6 +66,7 @@ class polymodel;
 #define ID_SLDC 0x43444c53				// CDLS (SLDC): Shield Collision Tree
 #define ID_SLC2 0x32434c53				// 2CLS (SLC2): Shield Collision Tree with ints instead of char - ShivanSpS
 
+#define us(p)	(*((ushort *) (p)))
 #define uw(p)	(*((uint *) (p)))
 #define w(p)	(*((int *) (p)))
 #define wp(p)	((int *) (p))

--- a/code/render/3d.h
+++ b/code/render/3d.h
@@ -256,7 +256,7 @@ struct flash_beam{
 class flash_ball{
 	flash_beam *ray;
 	vec3d center;
-	int n_rays;
+	uint n_rays;
 	void parse_bsp(int offset, ubyte *bsp_data);
 	void defpoint(int off, ubyte *bsp_data);
 

--- a/code/render/3d.h
+++ b/code/render/3d.h
@@ -273,7 +273,7 @@ public:
 			vm_free(ray);
 	}
 
-	void initialize(int number, float min_ray_width, float max_ray_width = 0, const vec3d* dir = &vmd_zero_vector, const vec3d* pcenter = &vmd_zero_vector, float outer = PI2, float inner = 0.0f, ubyte max_r = 255, ubyte max_g = 255, ubyte max_b = 255, ubyte min_r = 255, ubyte min_g = 255, ubyte min_b = 255);
+	void initialize(uint number, float min_ray_width, float max_ray_width = 0, const vec3d* dir = &vmd_zero_vector, const vec3d* pcenter = &vmd_zero_vector, float outer = PI2, float inner = 0.0f, ubyte max_r = 255, ubyte max_g = 255, ubyte max_b = 255, ubyte min_r = 255, ubyte min_g = 255, ubyte min_b = 255);
 	void initialize(ubyte *bsp_data, float min_ray_width, float max_ray_width = 0, const vec3d* dir = &vmd_zero_vector, const vec3d* pcenter = &vmd_zero_vector, float outer = PI2, float inner = 0.0f, ubyte max_r = 255, ubyte max_g = 255, ubyte max_b = 255, ubyte min_r = 255, ubyte min_g = 255, ubyte min_b = 255);
 	void render(int texture, float rad, float intinsity, float life);
 };

--- a/code/render/3ddraw.cpp
+++ b/code/render/3ddraw.cpp
@@ -1244,7 +1244,7 @@ void flash_ball::initialize(int number, float min_ray_width, float max_ray_width
 
 void flash_ball::defpoint(int off, ubyte *bsp_data)
 {
-	int n;
+	uint n;
 	uint nverts = uw(off+bsp_data+8);	
 	uint offset = uw(off+bsp_data+16);
 	ubyte * normcount = off+bsp_data+20;

--- a/code/render/3ddraw.cpp
+++ b/code/render/3ddraw.cpp
@@ -1245,8 +1245,8 @@ void flash_ball::initialize(int number, float min_ray_width, float max_ray_width
 void flash_ball::defpoint(int off, ubyte *bsp_data)
 {
 	int n;
-	int nverts = w(off+bsp_data+8);	
-	int offset = w(off+bsp_data+16);
+	uint nverts = uw(off+bsp_data+8);	
+	uint offset = uw(off+bsp_data+16);
 	ubyte * normcount = off+bsp_data+20;
 	vec3d *src = vp(off+bsp_data+offset);
 
@@ -1278,6 +1278,7 @@ void flash_ball::defpoint(int off, ubyte *bsp_data)
 #define OP_TMAPPOLY		3
 #define OP_SORTNORM		4
 #define OP_BOUNDBOX		5
+#define OP_TMAP2POLY 6
 
 
 void flash_ball::parse_bsp(int offset, ubyte *bsp_data){
@@ -1300,6 +1301,8 @@ void flash_ball::parse_bsp(int offset, ubyte *bsp_data){
 		case OP_TMAPPOLY:
 			break;
 		case OP_BOUNDBOX:
+			break;
+		case OP_TMAP2POLY:
 			break;
 		default:
 			return;

--- a/code/render/3ddraw.cpp
+++ b/code/render/3ddraw.cpp
@@ -1177,7 +1177,7 @@ void g3_render_sphere(vec3d* position, float radius)
 //++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++//
 //flash ball stuff
 
-void flash_ball::initialize(int number, float min_ray_width, float max_ray_width, const vec3d* dir, const vec3d* pcenter, float outer, float inner, ubyte max_r, ubyte max_g, ubyte max_b, ubyte min_r, ubyte min_g, ubyte min_b)
+void flash_ball::initialize(uint number, float min_ray_width, float max_ray_width, const vec3d* dir, const vec3d* pcenter, float outer, float inner, ubyte max_r, ubyte max_g, ubyte max_b, ubyte min_r, ubyte min_g, ubyte min_b)
 {
 	if(number < 1)
 		return;
@@ -1190,7 +1190,7 @@ void flash_ball::initialize(int number, float min_ray_width, float max_ray_width
 		n_rays = number;
 	}
 
-	int i;
+	uint i;
 	for(i = 0; i<n_rays; i++){
 	//colors
 		if(min_r != 255){
@@ -1323,7 +1323,7 @@ void flash_ball::initialize(ubyte *bsp_data, float min_ray_width, float max_ray_
 	parse_bsp(0,bsp_data);
 	center = vmd_zero_vector;
 
-	int i;
+	uint i;
 	for(i = 0; i<n_rays; i++){
 	//colors
 		if(min_r != 255){
@@ -1367,7 +1367,7 @@ void flash_ball::initialize(ubyte *bsp_data, float min_ray_width, float max_ray_
 //intinsity	how visable it should be
 //life		how far along from start to end should it be
 void flash_ball::render(int texture, float rad, float intinsity, float life){
-	for(int i = 0; i < n_rays; i++){
+	for(uint i = 0; i < n_rays; i++){
 		vec3d end;
 		vm_vec_interp_constant(&end, &ray[i].start.world, &ray[i].end.world, life);
 		vm_vec_scale(&end, rad);


### PR DESCRIPTION
These changes add a new chunk to the BSP data structure. TMAP2POLY uses unsigned integer instead of unsigned short to store vertex and normal indices, allowing up to `2^32 - 1` vertices to be used by a single sub-object. 

Also removes vestigal data `center` and `radius` that were unused or superfluous, resulting in a net profit in file-size savings.