### PR TITLE
Fix for #3629

### DIFF
--- a/code/lab/renderer/lab_renderer.cpp
+++ b/code/lab/renderer/lab_renderer.cpp
@@ -439,7 +439,10 @@ void LabRenderer::useBackground(const SCP_string& mission_name) {
 			if (strlen(envmap_name)) {
 				// Load the mission map so we can use it later
 				ENVMAP = bm_load(The_mission.envmap_name);
-				return;
+				// Load may fail, if so, don't exit early. Proceed to make render target.
+				if (ENVMAP > 1) {
+					return;
+				}
 			}
 
 			gr_screen.envmap_render_target = bm_make_render_target(size, size, gen_flags);

--- a/code/lab/renderer/lab_renderer.cpp
+++ b/code/lab/renderer/lab_renderer.cpp
@@ -247,7 +247,7 @@ void LabRenderer::useBackground(const SCP_string& mission_name) {
 	int ambient_light_level;
 	extern const char* Neb2_filenames[];
 
-	char envmap_name[MAX_FILENAME_LEN];
+	char envmap_name[MAX_FILENAME_LEN] = {0};
 
 	currentMissionBackground = mission_name;
 


### PR DESCRIPTION
Couple of minor fixes here,

Firstly, envmap_name wasn't zero initialised, so strlen() would return =>1 even if no filename had been found, leading to an erroneous call to bm_load.

Secondly, I added a guard to check that bm_load returned a valid handle, so that environment maps are still generated if precalculated ones are missing.