### PR TITLE
add preload ability for mission-set-subspace

### DIFF
--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -3918,6 +3918,11 @@ int get_sexp()
 				Nebula_sexp_used = true;
 				break;
 
+			case OP_MISSION_SET_SUBSPACE:
+				// set flag for Goober5000
+				Subspace_sexp_used = true;
+				break;
+
 			case OP_WARP_EFFECT:
 				// type of warp is argument #11
 				n = CDDDDDR(start);

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -14051,10 +14051,17 @@ void sexp_mission_set_subspace(int n)
 	if (is_nan || is_nan_forever)
 		return;
 
-	if (set_it > 0) {
+	if (set_it > 0)
+	{
+		if (Game_subspace_effect)
+			return;
 		Game_subspace_effect = 1;
 		game_start_subspace_ambient_sound();
-	} else {
+	}
+	else
+	{
+		if (!Game_subspace_effect)
+			return;
 		Game_subspace_effect = 0;
 		game_stop_subspace_ambient_sound();
 	}

--- a/code/starfield/starfield.cpp
+++ b/code/starfield/starfield.cpp
@@ -178,8 +178,10 @@ int Num_debris_normal = 0;
 int Num_debris_nebula = 0;
 
 bool Dynamic_environment = false;
-bool Motion_debris_override = false;
 
+bool Subspace_sexp_used = false;
+
+bool Motion_debris_override = false;
 bool Motion_debris_enabled = true;
 
 auto MotionDebrisOption = options::OptionBuilder<bool>("Graphics.MotionDebris", "Motion Debris",
@@ -794,6 +796,8 @@ void stars_pre_level_init(bool clear_backgrounds)
 
 	// also clear the preload indexes
 	Preload_background_indexes.clear();
+
+	Subspace_sexp_used = false;
 
 	Dynamic_environment = false;
 	Motion_debris_override = false;
@@ -1493,17 +1497,17 @@ void subspace_render()
 {
 	int framenum = 0;
 
-	if ( Subspace_model_inner == -1 )	{
-		Subspace_model_inner = model_load( "subspace_small.pof", 0, NULL );
+	if ( Subspace_model_inner < 0 )	{
+		Subspace_model_inner = model_load( "subspace_small.pof", 0, nullptr );
 		Assert(Subspace_model_inner >= 0);
 	}
 
-	if ( Subspace_model_outer == -1 )	{
-		Subspace_model_outer = model_load( "subspace_big.pof", 0, NULL );
+	if ( Subspace_model_outer < 0 )	{
+		Subspace_model_outer = model_load( "subspace_big.pof", 0, nullptr );
 		Assert(Subspace_model_outer >= 0);
 	}
 
-	if ( Subspace_glow_bitmap == -1 )	{
+	if ( Subspace_glow_bitmap < 0 )	{
 		Subspace_glow_bitmap = bm_load( NOX("SunGlow01"));
 		Assert(Subspace_glow_bitmap >= 0);
 	}
@@ -1914,17 +1918,18 @@ void stars_page_in()
 
 	// Initialize the subspace stuff
 
-	if ( Game_subspace_effect )	{
-		Subspace_model_inner = model_load( "subspace_small.pof", 0, NULL );
+	if ( Game_subspace_effect || Subspace_sexp_used ) {
+		Subspace_model_inner = model_load("subspace_small.pof", 0, nullptr);
 		Assert(Subspace_model_inner >= 0);
-		Subspace_model_outer = model_load( "subspace_big.pof", 0, NULL );
+
+		Subspace_model_outer = model_load("subspace_big.pof", 0, nullptr);
 		Assert(Subspace_model_outer >= 0);
 
 		polymodel *pm;
 		
 		pm = model_get(Subspace_model_inner);
 		
-		nprintf(( "Paging", "Paging in textures for subspace effect.\n" ));
+		nprintf(( "Paging", "Paging in textures for inner subspace effect.\n" ));
 
 		for (idx = 0; idx < pm->n_textures; idx++) {
 			pm->maps[idx].PageIn();
@@ -1932,7 +1937,7 @@ void stars_page_in()
 
 		pm = model_get(Subspace_model_outer);
 		
-		nprintf(( "Paging", "Paging in textures for subspace effect.\n" ));
+		nprintf(( "Paging", "Paging in textures for outer subspace effect.\n" ));
 
 		for (idx = 0; idx < pm->n_textures; idx++) {
 			pm->maps[idx].PageIn();

--- a/code/starfield/starfield.h
+++ b/code/starfield/starfield.h
@@ -50,8 +50,9 @@ extern matrix Nmodel_orient;
 extern int Nmodel_flags;
 extern int Nmodel_bitmap;
 
-extern bool Motion_debris_override;
+extern bool Subspace_sexp_used;
 
+extern bool Motion_debris_override;
 extern bool Motion_debris_enabled;
 
 void stars_swap_backgrounds(int idx1, int idx2);


### PR DESCRIPTION
Page in the subspace stuff if the mission-set-subspace sexp is used.

Implements #4166.  Note that this will only preload the tunnel for sexps, not scripts.  If using scripts, just add a `(when (true) (mission-set-subspace 0))` as a mission event and it will trigger the preloader.  The preloader only checks for the use of the sexp operator, not whether it actually sets subspace or not.