### PR TITLE
Basic Implementation for Attackable_if_no_collide

### DIFF
--- a/code/ai/aiturret.cpp
+++ b/code/ai/aiturret.cpp
@@ -434,7 +434,7 @@ int valid_turret_enemy(object *objp, object *turret_parent)
 		}
 
 		// don't shoot at ships without collision check
-		if (!(objp->flags[Object::Object_Flags::Collides])) {
+		if (!(objp->flags[Object::Object_Flags::Collides]) && !(objp->flags[Object::Object_Flags::Attackable_if_no_collide])) {
 			return 0;
 		}
 

--- a/code/mission/mission_flags.h
+++ b/code/mission/mission_flags.h
@@ -102,6 +102,7 @@ namespace Mission {
 		SF_Hide_mission_log,
 		SF_Same_arrival_warp_when_docked,
 		SF_Same_departure_warp_when_docked,
+		OF_Attackable_if_no_collide, // Cyborg - keeps turrets from ignoring ships that have no_collide set
 
 		NUM_VALUES
 	};

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -317,6 +317,7 @@ flag_def_list_new<Mission::Parse_Object_Flags> Parse_object_flags[] = {
     { "hide-in-mission-log",			Mission::Parse_Object_Flags::SF_Hide_mission_log,		true, false },
     { "same-arrival-warp-when-docked",		Mission::Parse_Object_Flags::SF_Same_arrival_warp_when_docked,		true, false },
     { "same-departure-warp-when-docked",	Mission::Parse_Object_Flags::SF_Same_departure_warp_when_docked,	true, false },
+	{ "attackable_if_no_collide"},			Mission::Parse_Object_Flags::OF_Attackable_if_no_collide, true, false },
 };
 
 const size_t num_parse_object_flags = sizeof(Parse_object_flags) / sizeof(flag_def_list_new<Mission::Parse_Object_Flags>);

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -317,7 +317,7 @@ flag_def_list_new<Mission::Parse_Object_Flags> Parse_object_flags[] = {
     { "hide-in-mission-log",			Mission::Parse_Object_Flags::SF_Hide_mission_log,		true, false },
     { "same-arrival-warp-when-docked",		Mission::Parse_Object_Flags::SF_Same_arrival_warp_when_docked,		true, false },
     { "same-departure-warp-when-docked",	Mission::Parse_Object_Flags::SF_Same_departure_warp_when_docked,	true, false },
-	{ "attackable_if_no_collide",			Mission::Parse_Object_Flags::OF_Attackable_if_no_collide, true, false },
+    { "attackable_if_no_collide",			Mission::Parse_Object_Flags::OF_Attackable_if_no_collide, true, false },
 };
 
 const size_t num_parse_object_flags = sizeof(Parse_object_flags) / sizeof(flag_def_list_new<Mission::Parse_Object_Flags>);
@@ -2735,7 +2735,7 @@ void resolve_parse_flags(object *objp, flagset<Mission::Parse_Object_Flags> &par
     if (parse_flags[Mission::Parse_Object_Flags::SF_Same_departure_warp_when_docked])
 		shipp->flags.set(Ship::Ship_Flags::Same_departure_warp_when_docked);
 
-	if (parse_flags[Mission::Parse_Object_Flags::OF_Attackable_if_no_collide])
+    if (parse_flags[Mission::Parse_Object_Flags::OF_Attackable_if_no_collide])
 		objp->flags.set(Object::Object_Flags::Attackable_if_no_collide);
 }
 

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -317,7 +317,7 @@ flag_def_list_new<Mission::Parse_Object_Flags> Parse_object_flags[] = {
     { "hide-in-mission-log",			Mission::Parse_Object_Flags::SF_Hide_mission_log,		true, false },
     { "same-arrival-warp-when-docked",		Mission::Parse_Object_Flags::SF_Same_arrival_warp_when_docked,		true, false },
     { "same-departure-warp-when-docked",	Mission::Parse_Object_Flags::SF_Same_departure_warp_when_docked,	true, false },
-	{ "attackable_if_no_collide"},			Mission::Parse_Object_Flags::OF_Attackable_if_no_collide, true, false },
+	{ "attackable_if_no_collide",			Mission::Parse_Object_Flags::OF_Attackable_if_no_collide, true, false },
 };
 
 const size_t num_parse_object_flags = sizeof(Parse_object_flags) / sizeof(flag_def_list_new<Mission::Parse_Object_Flags>);
@@ -2734,6 +2734,9 @@ void resolve_parse_flags(object *objp, flagset<Mission::Parse_Object_Flags> &par
 
     if (parse_flags[Mission::Parse_Object_Flags::SF_Same_departure_warp_when_docked])
         shipp->flags.set(Ship::Ship_Flags::Same_departure_warp_when_docked);
+
+	if (parse_flags[Mission::Parse_Object_Flags::OF_Attackable_if_no_collide])
+        objp->flags.set(Object::Object_Flags::Attackable_if_no_collide);
 }
 
 void fix_old_special_explosions(p_object *p_objp, int variable_index) 

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -2733,10 +2733,10 @@ void resolve_parse_flags(object *objp, flagset<Mission::Parse_Object_Flags> &par
         shipp->flags.set(Ship::Ship_Flags::Same_arrival_warp_when_docked);
 
     if (parse_flags[Mission::Parse_Object_Flags::SF_Same_departure_warp_when_docked])
-        shipp->flags.set(Ship::Ship_Flags::Same_departure_warp_when_docked);
+		shipp->flags.set(Ship::Ship_Flags::Same_departure_warp_when_docked);
 
 	if (parse_flags[Mission::Parse_Object_Flags::OF_Attackable_if_no_collide])
-        objp->flags.set(Object::Object_Flags::Attackable_if_no_collide);
+		objp->flags.set(Object::Object_Flags::Attackable_if_no_collide);
 }
 
 void fix_old_special_explosions(p_object *p_objp, int variable_index) 

--- a/code/object/object.cpp
+++ b/code/object/object.cpp
@@ -107,7 +107,7 @@ obj_flag_name Object_flag_names[] = {
 	{ Object::Object_Flags::Missile_protected,		"missile-protect-ship",		1,	},
 	{ Object::Object_Flags::Immobile,				"immobile",					1,	},
 	{ Object::Object_Flags::Collides,				"collides",					1,  },
-	{ Object::Object_Flags::Unprotect_from_no_collide, "unprotect_from_no_collide", 1,},
+	{ Object::Object_Flags::Attackable_if_no_collide, "ai_can_attack_if_no_collide", 1,},
 };
 
 #ifdef OBJECT_CHECK

--- a/code/object/object.cpp
+++ b/code/object/object.cpp
@@ -107,6 +107,7 @@ obj_flag_name Object_flag_names[] = {
 	{ Object::Object_Flags::Missile_protected,		"missile-protect-ship",		1,	},
 	{ Object::Object_Flags::Immobile,				"immobile",					1,	},
 	{ Object::Object_Flags::Collides,				"collides",					1,  },
+	{ Object::Object_Flags::Unprotect_from_no_collide, "unprotect_from_no_collide", 1,},
 };
 
 #ifdef OBJECT_CHECK

--- a/code/object/object_flags.h
+++ b/code/object/object_flags.h
@@ -28,7 +28,7 @@ namespace Object {
 		Temp_marked,			// Temporarily marked (Fred).
 		Hidden,					// Object is hidden (not shown) and can't be manipulated
 		Collides_with_parent,	// Asteroth - Only used for weapons with 'Can_damage_shooter'
-		Unprotect_from_no_collide,	// Cyborg - Allows the AI to attack this object, even if no-collide is set (Cue Admiral Ackbar)
+		Attackable_if_no_collide,	// Cyborg - Allows the AI to attack this object, even if no-collide is set (Cue Admiral Ackbar)
 
 		NUM_VALUES
 	};

--- a/code/object/object_flags.h
+++ b/code/object/object_flags.h
@@ -28,6 +28,7 @@ namespace Object {
 		Temp_marked,			// Temporarily marked (Fred).
 		Hidden,					// Object is hidden (not shown) and can't be manipulated
 		Collides_with_parent,	// Asteroth - Only used for weapons with 'Can_damage_shooter'
+		Unprotect_from_no_collide,	// Cyborg - Allows the AI to attack this object, even if no-collide is set (Cue Admiral Ackbar)
 
 		NUM_VALUES
 	};


### PR DESCRIPTION
A work-around for the default behavior where turrets will ignore ships that have no-collide set.  This allows turrets to target such ships.  As requested by @MjnMixael and the bta team.

Needs testing, as I'm not in a position to build and test at the moment.