### PR TITLE
Create commandline option for logging data packets

### DIFF
--- a/code/cmdline/cmdline.cpp
+++ b/code/cmdline/cmdline.cpp
@@ -222,6 +222,7 @@ Flag exe_params[] =
 	{ "-noshadercache",		"Disables the shader cache",				true,	0,									EASY_DEFAULT,					"Troubleshoot", "http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-noshadercache", },
 	{ "-prefer_ipv4",		"Prefer IPv4 DNS lookups",					true,	0,									EASY_DEFAULT,					"Troubleshoot", "http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-prefer_ipv4", },
 	{ "-prefer_ipv6",		"Prefer IPv6 DNS lookups",					true,	0,									EASY_DEFAULT,					"Troubleshoot", "http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-prefer_ipv6", },
+	{ "-log_multi_packet",	"Log multi packet types ",					true,	0,									EASY_DEFAULT,					"Troubleshoot", "http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-log_multi_packet",},
 #ifdef WIN32
 	{ "-fix_registry",	"Use a different registry path",				true,	0,									EASY_DEFAULT,					"Troubleshoot", "http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-fix_registry", },
 #endif
@@ -444,6 +445,7 @@ cmdline_parm nograb_arg("-nograb", NULL, AT_NONE);
 cmdline_parm noshadercache_arg("-noshadercache", NULL, AT_NONE);
 cmdline_parm prefer_ipv4_arg("-prefer_ipv4", nullptr, AT_NONE);
 cmdline_parm prefer_ipv6_arg("-prefer_ipv6", nullptr, AT_NONE);
+cmdline_parm log_multi_packet_arg("-log_multi_packet", nullptr, AT_NONE);
 #ifdef WIN32
 cmdline_parm fix_registry("-fix_registry", NULL, AT_NONE);
 #endif
@@ -464,6 +466,7 @@ bool Cmdline_nograb = false;
 bool Cmdline_noshadercache = false;
 bool Cmdline_prefer_ipv4 = false;
 bool Cmdline_prefer_ipv6 = false;
+bool Cmdline_dump_packet_type = false;
 #ifdef WIN32
 bool Cmdline_alternate_registry_path = false;
 #endif
@@ -2280,6 +2283,10 @@ bool SetCmdlineParams()
 		}
 	}
  
+	if (log_multi_packet_arg.found()) {
+		Cmdline_dump_packet_type = true;
+	}
+
 	return true; 
 }
 

--- a/code/cmdline/cmdline.h
+++ b/code/cmdline/cmdline.h
@@ -125,6 +125,7 @@ extern bool Cmdline_nograb;
 extern bool Cmdline_noshadercache;
 extern bool Cmdline_prefer_ipv4;
 extern bool Cmdline_prefer_ipv6;
+extern bool Cmdline_dump_packet_type;
 #ifdef WIN32
 extern bool Cmdline_alternate_registry_path;
 #endif

--- a/code/network/multi.cpp
+++ b/code/network/multi.cpp
@@ -53,6 +53,7 @@
 #include "debugconsole/console.h"
 #include "network/psnet2.h"
 #include "network/multi_mdns.h"
+#include "cmdline/cmdline.h"
 
 // Stupid windows workaround...
 #ifdef MessageBox
@@ -492,6 +493,12 @@ void multi_client_check_server()
 void process_packet_normal(ubyte* data, header *header_info)
 {
 	switch ( data[0] ) {
+
+		// this is for helping to diagnose misaligned packets.  The last sensible packet 
+		// is usually the culprit that needs to be analyzed.
+		if (Cmdline_dump_packet_type) {
+			mprintf(("Packet type of %d received.\n", data[0]));
+		}
 
 		case JOIN:
 			process_join_packet(data, header_info);

--- a/code/network/multi.cpp
+++ b/code/network/multi.cpp
@@ -492,13 +492,15 @@ void multi_client_check_server()
 
 void process_packet_normal(ubyte* data, header *header_info)
 {
-	switch ( data[0] ) {
+	// this is for helping to diagnose misaligned packets.  The last sensible packet 
+	// is usually the culprit that needs to be analyzed.
+	if (Cmdline_dump_packet_type) {
+		mprintf(("Packet type of %d received.\n", data[0]));
+	}
 
-		// this is for helping to diagnose misaligned packets.  The last sensible packet 
-		// is usually the culprit that needs to be analyzed.
-		if (Cmdline_dump_packet_type) {
-			mprintf(("Packet type of %d received.\n", data[0]));
-		}
+
+
+	switch ( data[0] ) {
 
 		case JOIN:
 			process_join_packet(data, header_info);


### PR DESCRIPTION
Creates a mechanism for adding packet types to the debug log.  This is for debugging misaligned packets.  The last "good" packet is usually the culprit.