### PR TITLE
Disengage the sound limiters

### DIFF
--- a/code/gamesnd/gamesnd.cpp
+++ b/code/gamesnd/gamesnd.cpp
@@ -823,7 +823,7 @@ void parse_gamesnd_soundset(game_snd* gs, bool no_create) {
 		int temp_limit;
 		stuff_int(&temp_limit);
 
-		if ((temp_limit > 0) && (static_cast<uint>(temp_limit) <= SND_ENHANCED_MAX_LIMIT))
+		if (temp_limit > 0)
 		{
 			gs->enhanced_sound_data.limit = (unsigned int)temp_limit;
 		}
@@ -927,7 +927,7 @@ void parse_gamesnd_new(game_snd* gs, bool no_create)
 		int temp_limit;
 		stuff_int(&temp_limit);
 
-		if ((temp_limit > 0) && (static_cast<uint>(temp_limit) <= SND_ENHANCED_MAX_LIMIT))
+		if (temp_limit > 0)
 		{
 			gs->enhanced_sound_data.limit = (unsigned int)temp_limit;
 		}

--- a/code/sound/ds.cpp
+++ b/code/sound/ds.cpp
@@ -306,12 +306,27 @@ int ds_load_buffer(int *sid, int  /*flags*/, sound::IAudioFile* file)
 }
 
 /**
- * Initialise the ::Channels[] array
+ * Initialise the ::Channels[] array dynamically based on system resources.
  */
 void ds_init_channels()
 {
-	MAX_CHANNELS = Cmdline_no_enhanced_sound ? 32 : 128;
+	// Legacy assumed safe value if for some reason dynamicly setting it does not work
+	MAX_CHANNELS = 128;
 
+	if (Cmdline_no_enhanced_sound)
+		MAX_CHANNELS = 32; // Old sound code limts
+	else {
+		ALCint size;
+		alcGetIntegerv(ds_sound_device, ALC_ATTRIBUTES_SIZE, 1, &size);
+		std::vector<ALCint> attrs(size);
+		alcGetIntegerv(ds_sound_device, ALC_ALL_ATTRIBUTES, size, &attrs[0]);
+		for (size_t i = 0; i < attrs.size(); ++i) {
+			if (attrs[i] == ALC_MONO_SOURCES) {
+				MAX_CHANNELS = attrs[i + 1];
+				mprintf(("  ALC reported %i available sources", attrs[i + 1]));
+			}
+		}
+	}
 	try {
 		Channels = new channel[MAX_CHANNELS];
 	} catch (const std::bad_alloc&) {

--- a/code/sound/ds.cpp
+++ b/code/sound/ds.cpp
@@ -321,9 +321,11 @@ void ds_init_channels()
 		std::vector<ALCint> attrs(size);
 		alcGetIntegerv(ds_sound_device, ALC_ALL_ATTRIBUTES, size, &attrs[0]);
 		for (size_t i = 0; i < attrs.size(); ++i) {
-			if (attrs[i] == ALC_MONO_SOURCES) {
-				MAX_CHANNELS = attrs[i + 1];
-				mprintf(("  ALC reported %i available sources", attrs[i + 1]));
+			//We reserve a portion of the reported channels to avoid colliding with other types of sound
+			//Using the 32 channels of the no_enhanced_sound as a floor.
+			if (attrs[i] == ALC_MONO_SOURCES && attrs[i+1] - DS_RESERVED_CHANNELS > 32) {
+				MAX_CHANNELS = attrs[i + 1] - DS_RESERVED_CHANNELS;
+				mprintf(("  ALC reported %i available sources, setting max to use at %i ", attrs[i + 1],MAX_CHANNELS));
 			}
 		}
 	}

--- a/code/sound/ds.h
+++ b/code/sound/ds.h
@@ -39,6 +39,8 @@ struct EnhancedSoundData;
 
 #define DS_3D		(1<<0)
 
+#define DS_RESERVED_CHANNELS 32
+
 typedef struct sound_info {
 	uint size;
 	int sample_rate;

--- a/code/sound/rtvoice.cpp
+++ b/code/sound/rtvoice.cpp
@@ -28,7 +28,7 @@ typedef struct rtv_format
 	int frequency;
 } rtv_format;
 
-
+#define MAX_RTV_CHANNELS 15
 #define MAX_RTV_FORMATS	5
 static rtv_format Rtv_formats[MAX_RTV_FORMATS] = 
 {
@@ -455,7 +455,7 @@ sound_handle rtvoice_play(int index, unsigned char* data, int size)
 	}
 
 	// play the voice
-	EnhancedSoundData enhanced_sound_data(SND_ENHANCED_PRIORITY_MUST_PLAY, SND_ENHANCED_MAX_LIMIT);
+	EnhancedSoundData enhanced_sound_data(SND_ENHANCED_PRIORITY_MUST_PLAY, MAX_RTV_CHANNELS);
 	return ds_play(ds_handle, -100, DS_MUST_PLAY, &enhanced_sound_data, Master_voice_volume, 0, 0);
 }
 

--- a/code/sound/sound.cpp
+++ b/code/sound/sound.cpp
@@ -33,8 +33,6 @@
 
 #include <climits>
 
-const unsigned int SND_ENHANCED_MAX_LIMIT = 15; // seems like a good max limit
-
 #define SND_F_USED			(1<<0)		// Sounds[] element is used
 
 struct loaded_sound {

--- a/code/sound/sound.h
+++ b/code/sound/sound.h
@@ -53,8 +53,6 @@ struct EnhancedSoundData
 	EnhancedSoundData(const int new_priority, const unsigned int new_limit);
 };
 
-extern const unsigned int SND_ENHANCED_MAX_LIMIT;
-
 //For the adjust-audio-volume sexp
 #define AAV_MUSIC		0
 #define AAV_VOICE		1


### PR DESCRIPTION
Investigation and personal use cases have shown the limit cap of 15 to be unneeded and a hindrance at times, and the 128 channel cap is also at times a bit too low. This removes the first and makes the second dynamic based on system reported capabilities. 