### PR TITLE
Log data packets2

### DIFF
--- a/code/network/multi.cpp
+++ b/code/network/multi.cpp
@@ -951,7 +951,7 @@ void process_packet_normal(ubyte* data, header *header_info)
 // process_tracker_packet() as defined in MultiTracker.[h,cpp]
 void multi_process_bigdata(ubyte *data, int len, net_addr *from_addr, int reliable)
 {
-	int type, bytes_processed;
+	int bytes_processed;
 	int player_num;
 	header header_info;
 	ubyte *buf;	
@@ -986,16 +986,13 @@ void multi_process_bigdata(ubyte *data, int len, net_addr *from_addr, int reliab
 
       buf = &(data[bytes_processed]);
 
-      type = buf[0];
+      const ubyte type = buf[0];
 
 		// if its coming from an unknown source, there are only certain packets we will actually process
 		if((player_num == -1) && !multi_is_valid_unknown_packet((ubyte)type)){
+			// So let's log it, because we should probably at least be vaguely aware of the buggy behavior.
+			mprintf(("Receiving unknown source packet of type %d that should have a source, aborting packet processing!\n", type));
 			return ;
-		}		
-
-		if ( (type<0) || (type > MAX_TYPE_ID )) {
-			nprintf( ("Network", "multi_process_bigdata: Invalid packet type %d!\n", type ));
-			return;
 		}		
 
 		// perform any special processing checks here		

--- a/code/network/multi.cpp
+++ b/code/network/multi.cpp
@@ -930,7 +930,7 @@ void process_packet_normal(ubyte* data, header *header_info)
 			break; 
 
 		default:
-			nprintf(("Network", "Received packet with unknown type %d\n", data[0] ));
+			mprintf(("Received packet with unknown type %d\n", data[0] ));
 			header_info->bytes_processed = 10000;
 			break;
 

--- a/code/network/multi.cpp
+++ b/code/network/multi.cpp
@@ -495,10 +495,8 @@ void process_packet_normal(ubyte* data, header *header_info)
 	// this is for helping to diagnose misaligned packets.  The last sensible packet 
 	// is usually the culprit that needs to be analyzed.
 	if (Cmdline_dump_packet_type) {
-		mprintf(("Packet type of %d received.\n", data[0]));
+		mprintf(("Game packet type of %d received.\n", data[0]));
 	}
-
-
 
 	switch ( data[0] ) {
 
@@ -937,6 +935,11 @@ void process_packet_normal(ubyte* data, header *header_info)
 			break;
 
 	} // end switch
+
+	// Let's also dump the amount of data that we've processed so far.
+	if (Cmdline_dump_packet_type) {
+		mprintf(("Game packet ended.  Total amount of data processed from packet is %d.\n", header_info->bytes_processed));
+	}
 }
 
 
@@ -973,6 +976,12 @@ void multi_process_bigdata(ubyte *data, int len, net_addr *from_addr, int reliab
 	}   
 
 	bytes_processed = 0;
+
+	// start off logging of packets by writing how many bytes of data we should get through.
+	if (Cmdline_dump_packet_type) {
+		mprintf(("Network packet with %d bytes of data received. ", len));
+	}
+
 	while( (bytes_processed >= 0) && (bytes_processed < len) )  {
 
       buf = &(data[bytes_processed]);


### PR DESCRIPTION
Upgrade packet dumping command line option to include the amount of data that has been processed from the packet so far.  Also, upgrade the `nprintf` that dumps unknown packet types to an `mprintf` because even power users very rarely use the debug filter.