### PR TITLE
More Pof space optimizations

### DIFF
--- a/code/model/modelcollide.cpp
+++ b/code/model/modelcollide.cpp
@@ -619,7 +619,7 @@ void model_collide_parse_bsp(bsp_collision_tree *tree, void *model_ptr, int vers
 
 		chunk_type = w(p);
 		chunk_size = w(p+4);
-
+		int front_offset, back_offset;
 		switch ( chunk_type ) {
 		case OP_SORTNORM:
 			if ( version >= 2000 ) {
@@ -634,7 +634,7 @@ void model_collide_parse_bsp(bsp_collision_tree *tree, void *model_ptr, int vers
 			node_buffer[i].front = -1;
 			node_buffer[i].back = -1;
 
-			int front_offset = w(p + 36);
+			front_offset = w(p + 36);
 			if (front_offset) {
 				next_chunk_type = w(p + front_offset);
 
@@ -645,7 +645,7 @@ void model_collide_parse_bsp(bsp_collision_tree *tree, void *model_ptr, int vers
 				}
 			}
 
-			int back_offset = w(p + 40);
+			back_offset = w(p + 40);
 			if (back_offset) {
 				next_chunk_type = w(p + back_offset);
 				
@@ -674,7 +674,7 @@ void model_collide_parse_bsp(bsp_collision_tree *tree, void *model_ptr, int vers
 			node_buffer[i].front = -1;
 			node_buffer[i].back = -1;
 
-			int front_offset = w(p + 8);
+			front_offset = w(p + 8);
 			if (front_offset) {
 				next_chunk_type = w(p + front_offset);
 
@@ -685,7 +685,7 @@ void model_collide_parse_bsp(bsp_collision_tree *tree, void *model_ptr, int vers
 				}
 			}
 
-			int back_offset = w(p + 12);
+			back_offset = w(p + 12);
 			if (back_offset) {
 				next_chunk_type = w(p + back_offset);
 
@@ -760,14 +760,14 @@ void model_collide_parse_bsp(bsp_collision_tree *tree, void *model_ptr, int vers
 			node_buffer[i].max = *max;
 
 			node_buffer[i].front = -1;
-			node_buffer[i].back = -1;
-			node_buffer[i].leaf = -1;
+			node_buffer[i].back = -1; 
+			node_buffer[i].leaf = (int)leaf_buffer.size();
 
-			model_collide_parse_bsp_tmap2poly(&new_leaf, &vert_buffer, next_p);
+			model_collide_parse_bsp_tmap2poly(&new_leaf, &vert_buffer, p);
 
 			leaf_buffer.push_back(new_leaf);
 
-			leaf_buffer.back().next = (int)leaf_buffer.size();
+			leaf_buffer.back().next = -1;
 
 			++i;
 			break;

--- a/code/model/modelinterp.cpp
+++ b/code/model/modelinterp.cpp
@@ -1798,10 +1798,10 @@ void parse_tmap(int offset, ubyte *bsp_data)
 */
 void parse_tmap2(int offset, ubyte* bsp_data)
 {
-	int pof_tex = w(bsp_data + offset + 24);
-	uint n_vert = uw(bsp_data + offset + 20);
+	int pof_tex = w(bsp_data + offset + 44);
+	uint n_vert = uw(bsp_data + offset + 48);
 
-	ubyte* p = &bsp_data[offset + 8];
+	ubyte* p = &bsp_data[offset + 32];
 	model_tmap_vert* tverts;
 
 	vertex* V;
@@ -1810,7 +1810,7 @@ void parse_tmap2(int offset, ubyte* bsp_data)
 
 	int problem_count = 0;
 
-	tverts = (model_tmap_vert*)&bsp_data[offset + 28];
+	tverts = (model_tmap_vert*)&bsp_data[offset + 52];
 
 	for (uint i = 1; i < (n_vert - 1); i++) {
 		V = &polygon_list[pof_tex].vert[(polygon_list[pof_tex].n_verts)];
@@ -1947,8 +1947,8 @@ void parse_bsp(int offset, ubyte *bsp_data)
 
 void find_tmap(int offset, const ubyte *bsp_data, int id)
 {
-	int pof_tex = w(bsp_data+offset+(id == OP_TMAP2POLY ? 48 : 40));
-	uint n_vert = uw(bsp_data+offset+ (id == OP_TMAP2POLY ? 44 : 36));
+	int pof_tex = w(bsp_data+offset+(id == OP_TMAP2POLY ? 44 : 40));
+	uint n_vert = uw(bsp_data+offset+ (id == OP_TMAP2POLY ? 48 : 36));
 
 	tri_count[pof_tex] += n_vert-2;	
 }

--- a/code/model/modelinterp.cpp
+++ b/code/model/modelinterp.cpp
@@ -3114,6 +3114,12 @@ void bsp_polygon_data::process_defpoints(int off, ubyte* bsp_data)
 	}
 }
 
+/**
+* @brief Parses a SORTNORM2 by recursively parsing into the two pointers it contains.
+*
+* @param offset The byte offset to the current SORT2NORM chunk within bsp_data.
+* @param bsp_data The byte buffer containing the BSP information for the current model.
+*/
 void bsp_polygon_data::process_sortnorm2(int offset, ubyte* bsp_data)
 {
 	int frontlist, backlist;

--- a/code/model/modeloctant.cpp
+++ b/code/model/modeloctant.cpp
@@ -312,6 +312,14 @@ int model_octant_find_faces_sub(polymodel * pm, model_octant * oct, void *model_
 				if (postlist) model_octant_find_faces_sub(pm,oct,p+postlist,just_count);
 			}
 			break;
+		case OP_SORTNORM2: {
+			int frontlist = w(p + 8);
+			int backlist = w(p + 12);
+
+			if (backlist) model_octant_find_faces_sub(pm, oct, p + backlist, just_count);
+			if (frontlist) model_octant_find_faces_sub(pm, oct, p + frontlist, just_count);
+			}	
+			break;
 		case OP_BOUNDBOX:		break;
 		case OP_TMAP2POLY:		moff_tmap2poly(p, pm, oct, just_count); break;
 		default:

--- a/code/model/modeloctant.cpp
+++ b/code/model/modeloctant.cpp
@@ -194,9 +194,9 @@ void moff_tmap2poly(ubyte* p, polymodel* pm, model_octant* oct, int just_count)
 	uint i, nv;
 	model_tmap_vert* verts;
 
-	nv = uw(p + 20);
+	nv = uw(p + 48);
 
-	verts = (model_tmap_vert*)(p + 28);
+	verts = (model_tmap_vert*)(p + 52);
 
 	vec3d center_point;
 	vm_vec_zero(&center_point);

--- a/code/model/modeloctant.cpp
+++ b/code/model/modeloctant.cpp
@@ -181,12 +181,14 @@ void moff_tmappoly(ubyte * p, polymodel * pm, model_octant * oct, int just_count
 
 
 // Textured Poly version 2
-// +0      int         id
-// +4      int         size
-// +8      vec3d      normal
-// +20     int         nverts
-// +24     int         tmap_num
-// +28     nverts*(model_tmap2_vert) vertlist (n,u,v)
+// +0 int id = 6
+// + 4 int size
+// + 8 vector min_bounding_box_point
+// + 20 vector max_bounding_box_point
+// + 32 vector normal
+// + 44 int tmap_num
+// + 48 int nverts
+// + 52 nverts*(model_tmap2_vert) vertlist (n,u,v)
 void moff_tmap2poly(ubyte* p, polymodel* pm, model_octant* oct, int just_count)
 {
 	Assert(pm->version >= 2300);
@@ -289,8 +291,9 @@ int model_octant_find_faces_sub(polymodel * pm, model_octant * oct, void *model_
 
 	chunk_type = w(p);
 	chunk_size = w(p+4);
-	
-	while (chunk_type != OP_EOF)	{
+
+	bool end = chunk_type == OP_EOF;
+	while (!end)	{
 
 		switch (chunk_type) {
 		case OP_DEFPOINTS:	
@@ -313,15 +316,19 @@ int model_octant_find_faces_sub(polymodel * pm, model_octant * oct, void *model_
 			}
 			break;
 		case OP_SORTNORM2: {
-			int frontlist = w(p + 8);
-			int backlist = w(p + 12);
+				int frontlist = w(p + 8);
+				int backlist = w(p + 12);
 
-			if (backlist) model_octant_find_faces_sub(pm, oct, p + backlist, just_count);
-			if (frontlist) model_octant_find_faces_sub(pm, oct, p + frontlist, just_count);
-			}	
+				if (backlist) model_octant_find_faces_sub(pm, oct, p + backlist, just_count);
+				if (frontlist) model_octant_find_faces_sub(pm, oct, p + frontlist, just_count);
+				end = true; // should not continue after this chunk
+			}
 			break;
 		case OP_BOUNDBOX:		break;
-		case OP_TMAP2POLY:		moff_tmap2poly(p, pm, oct, just_count); break;
+		case OP_TMAP2POLY:		
+			moff_tmap2poly(p, pm, oct, just_count);
+			end = true; // should not continue after this chunk
+			break;
 		default:
 			mprintf(( "Bad chunk type %d, len=%d in model_octant_find_faces_sub\n", chunk_type, chunk_size ));
 			Int3();		// Bad chunk type!
@@ -330,6 +337,9 @@ int model_octant_find_faces_sub(polymodel * pm, model_octant * oct, void *model_
 		p += chunk_size;
 		chunk_type = w(p);
 		chunk_size = w(p+4);
+
+		if (chunk_type == OP_EOF)
+			end = true;
 	}
 	return 1;
 }

--- a/code/model/modelread.cpp
+++ b/code/model/modelread.cpp
@@ -5126,7 +5126,8 @@ void swap_bsp_data( polymodel * pm, void * model_ptr )
 	w(p) = chunk_type;
 	w(p+4) = chunk_size;
 
-	while (chunk_type != OP_EOF) {
+	bool end = chunk_type == OP_EOF;
+	while (!end) {
 		switch (chunk_type) {
 			case OP_EOF:
 				return;
@@ -5144,6 +5145,7 @@ void swap_bsp_data( polymodel * pm, void * model_ptr )
 				break;
 			case OP_SORTNORM2:
 				swap_bsp_sortnorm2(pm, p);
+				end = true; // should not continue after this chunk
 				break;
 			case OP_BOUNDBOX:
 				min = vp(p+8);
@@ -5157,6 +5159,7 @@ void swap_bsp_data( polymodel * pm, void * model_ptr )
 				break;
 			case OP_TMAP2POLY:
 				swap_bsp_tmap2poly(pm, p);
+				end = true; // should not continue after this chunk
 				break;
 			default:
 				mprintf(( "Bad chunk type %d, len=%d in modelread:swap_bsp_data\n", chunk_type, chunk_size ));
@@ -5169,6 +5172,9 @@ void swap_bsp_data( polymodel * pm, void * model_ptr )
 		chunk_size = INTEL_INT( w(p+4) );
 		w(p) = chunk_type;
 		w(p+4) = chunk_size;
+
+		if (chunk_type == OP_EOF)
+			end = true;
 	}
 
 	return;

--- a/code/model/modelread.cpp
+++ b/code/model/modelread.cpp
@@ -4975,57 +4975,19 @@ void swap_bsp_tmap2poly(polymodel* pm, ubyte* p)
 {
 	uint i, nv;
 	model_tmap_vert* verts;
-	vec3d* normal = vp(p + 8); // tigital
-	vec3d* center = vp(p + 20);
-	float radius = INTEL_FLOAT(&fl(p + 32));
 
-	fl(p + 32) = radius;
+	nv = INTEL_INT(uw(p + 48)); // tigital
+	uw(p + 48) = nv;
 
-	normal->xyz.x = INTEL_FLOAT(&normal->xyz.x);
-	normal->xyz.y = INTEL_FLOAT(&normal->xyz.y);
-	normal->xyz.z = INTEL_FLOAT(&normal->xyz.z);
-	center->xyz.x = INTEL_FLOAT(&center->xyz.x);
-	center->xyz.y = INTEL_FLOAT(&center->xyz.y);
-	center->xyz.z = INTEL_FLOAT(&center->xyz.z);
+	int tmap_num = INTEL_INT(w(p + 44)); // tigital
+	w(p + 44) = tmap_num;
 
-	nv = INTEL_INT(uw(p + 36)); // tigital
-	uw(p + 36) = nv;
-
-	int tmap_num = INTEL_INT(w(p + 40)); // tigital
-	w(p + 40) = tmap_num;
-
-	verts = (model_tmap_vert*)(p + 44);
+	verts = (model_tmap_vert*)(p + 52);
 	for (i = 0; i < nv; i++) {
 		verts[i].vertnum = INTEL_SHORT(verts[i].vertnum);
 		verts[i].normnum = INTEL_SHORT(verts[i].normnum);
 		verts[i].u = INTEL_FLOAT(&verts[i].u);
 		verts[i].v = INTEL_FLOAT(&verts[i].v);
-	}
-
-	if (pm->version < 2003) {
-		// Set the "normal_point" part of field to be the center of the polygon
-		vec3d center_point;
-		vm_vec_zero(&center_point);
-
-		for (i = 0; i < nv; i++) {
-			vm_vec_add2(&center_point, Interp_verts[verts[i].vertnum]);
-		}
-
-		center_point.xyz.x /= nv;
-		center_point.xyz.y /= nv;
-		center_point.xyz.z /= nv;
-
-		*vp(p + 20) = center_point;
-
-		float rad = 0.0f;
-
-		for (i = 0; i < nv; i++) {
-			float dist = vm_vec_dist(&center_point, Interp_verts[verts[i].vertnum]);
-			if (dist > rad) {
-				rad = dist;
-			}
-		}
-		fl(p + 32) = rad;
 	}
 }
 

--- a/code/model/modelread.cpp
+++ b/code/model/modelread.cpp
@@ -5084,7 +5084,29 @@ void swap_bsp_flatpoly( polymodel * pm, ubyte * p )
 	}
 }
 
-void swap_bsp_sortnorms( polymodel * pm, ubyte * p )
+void swap_bsp_sortnorm2(polymodel* pm, ubyte* p)
+{
+	int frontlist = INTEL_INT(w(p + 8));	//tigital
+	int backlist = INTEL_INT(w(p + 12));
+
+	w(p + 8) = frontlist;
+	w(p + 12) = backlist;
+
+	vec3d* bmin = vp(p + 8);	//tigital
+	vec3d* bmax = vp(p + 20);
+
+	bmin->xyz.x = INTEL_FLOAT(&bmin->xyz.x);
+	bmin->xyz.y = INTEL_FLOAT(&bmin->xyz.y);
+	bmin->xyz.z = INTEL_FLOAT(&bmin->xyz.z);
+	bmax->xyz.x = INTEL_FLOAT(&bmax->xyz.x);
+	bmax->xyz.y = INTEL_FLOAT(&bmax->xyz.y);
+	bmax->xyz.z = INTEL_FLOAT(&bmax->xyz.z);
+
+	if (backlist) swap_bsp_data(pm, p + backlist);
+	if (frontlist) swap_bsp_data(pm, p + frontlist);
+}
+
+void swap_bsp_sortnorm( polymodel * pm, ubyte * p )
 {
 	int frontlist = INTEL_INT( w(p+36) );	//tigital
 	int backlist = INTEL_INT( w(p+40) );
@@ -5156,7 +5178,10 @@ void swap_bsp_data( polymodel * pm, void * model_ptr )
 				swap_bsp_tmappoly(pm, p);
 				break;
 			case OP_SORTNORM:	
-				swap_bsp_sortnorms(pm, p);
+				swap_bsp_sortnorm(pm, p);
+				break;
+			case OP_SORTNORM2:
+				swap_bsp_sortnorm2(pm, p);
 				break;
 			case OP_BOUNDBOX:
 				min = vp(p+8);
@@ -5168,7 +5193,7 @@ void swap_bsp_data( polymodel * pm, void * model_ptr )
 				max->xyz.y = INTEL_FLOAT( &max->xyz.y );
 				max->xyz.z = INTEL_FLOAT( &max->xyz.z );
 				break;
-			case OP_TMAPPOLY:
+			case OP_TMAP2POLY:
 				swap_bsp_tmap2poly(pm, p);
 				break;
 			default:

--- a/code/model/modelsinc.h
+++ b/code/model/modelsinc.h
@@ -25,6 +25,7 @@ class polymodel;
 #define OP_SORTNORM		4
 #define OP_BOUNDBOX		5
 #define OP_TMAP2POLY	6
+#define OP_SORTNORM2	7
 
 // change header for freespace2
 //#define FREESPACE1_FORMAT

--- a/code/render/3ddraw.cpp
+++ b/code/render/3ddraw.cpp
@@ -1278,7 +1278,8 @@ void flash_ball::defpoint(int off, ubyte *bsp_data)
 #define OP_TMAPPOLY		3
 #define OP_SORTNORM		4
 #define OP_BOUNDBOX		5
-#define OP_TMAP2POLY 6
+#define OP_TMAP2POLY    6
+#define OP_SORTNORM2	7
 
 
 void flash_ball::parse_bsp(int offset, ubyte *bsp_data){
@@ -1295,6 +1296,8 @@ void flash_ball::parse_bsp(int offset, ubyte *bsp_data){
 		case OP_DEFPOINTS:	defpoint(offset, bsp_data);
 			break;
 		case OP_SORTNORM:
+			break;
+		case OP_SORTNORM2:
 			break;
 		case OP_FLATPOLY:
 			break;


### PR DESCRIPTION
Adds the `SORTNORM2` chunk and merges the `BOUNDBOX` chunk into `TMAP2POLY` as part of version 2300 (more details [here](https://github.com/Baezon/pof-tools/issues/36#issuecomment-1101733254)). Technically, a 'breaking' change, but since it just introduced and there's no pofs in the wild with this version yet it should be ok.

Also removes several dead bsp parsing functions.