### PR TITLE
probably fix #4187

### DIFF
--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -15916,7 +15916,7 @@ void ai_ship_destroy(int shipnum)
 			aip->hitter_objnum = -1;
 	}
 
-	if (dead_aip->ai_flags[AI::AI_Flags::Formation_object])
+	if (dead_aip->ai_flags[AI::AI_Flags::Formation_object] && dead_aip->goal_objnum >= 0)
 		ai_formation_object_recalculate_slotnums(dead_aip->goal_objnum, objnum);
 
 }

--- a/code/ai/aigoals.cpp
+++ b/code/ai/aigoals.cpp
@@ -2398,7 +2398,7 @@ void ai_process_mission_orders( int objnum, ai_info *aip )
 		break;
 	}
 
-	if (old_form_objnum != -1)
+	if (old_form_objnum >= 0)
 		ai_formation_object_recalculate_slotnums(old_form_objnum);
 }
 


### PR DESCRIPTION
My guess is that, in `ai_ship_destroy`, if the dead ship's goal object has already died in the same frame, the `goal_objnum` will be -1 when `ai_formation_object_recalculate_slotnums` is about to be called.