### PR TITLE
Fix FRED accessibility of new flag `ai-attackable-if-no-collide` V2

### DIFF
--- a/code/object/object.h
+++ b/code/object/object.h
@@ -109,7 +109,7 @@ typedef struct obj_flag_name {
 	int flag_list;
 } obj_flag_name;
 
-#define MAX_OBJECT_FLAG_NAMES			10
+#define MAX_OBJECT_FLAG_NAMES			11
 extern obj_flag_name Object_flag_names[];
 
 struct dock_instance;


### PR DESCRIPTION
Turns out the `MAX_OBJECT_FLAG_NAMES` was not increased originally, so this PR increases it to match the new amount now that `ai-attackable-if-no-collide` flag was added.